### PR TITLE
Implement persistent workspace storage (Issue #14)

### DIFF
--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -130,6 +130,18 @@ fn handle_request(request: Request, terminal_manager: &Arc<Mutex<TerminalManager
             }
         }
 
+        Request::ResizeTerminal { id, cols, rows } => {
+            let tm = terminal_manager
+                .lock()
+                .expect("Terminal manager mutex poisoned");
+            match tm.resize_terminal(&id, cols, rows) {
+                Ok(()) => Response::Success,
+                Err(e) => Response::Error {
+                    message: e.to_string(),
+                },
+            }
+        }
+
         Request::Shutdown => {
             log::info!("Shutdown requested");
             std::process::exit(0);

--- a/loom-daemon/src/terminal.rs
+++ b/loom-daemon/src/terminal.rs
@@ -144,10 +144,10 @@ impl TerminalManager {
             .get(id)
             .ok_or_else(|| anyhow!("Terminal not found"))?;
 
-        // Resize tmux pane
+        // Resize tmux window (which resizes the pane when there's only one pane)
         Command::new("tmux")
             .args([
-                "resize-pane",
+                "resize-window",
                 "-t",
                 &info.tmux_session,
                 "-x",

--- a/loom-daemon/src/terminal.rs
+++ b/loom-daemon/src/terminal.rs
@@ -138,6 +138,29 @@ impl TerminalManager {
         Ok((content, total_lines))
     }
 
+    pub fn resize_terminal(&self, id: &TerminalId, cols: u16, rows: u16) -> Result<()> {
+        let info = self
+            .terminals
+            .get(id)
+            .ok_or_else(|| anyhow!("Terminal not found"))?;
+
+        // Resize tmux pane
+        Command::new("tmux")
+            .args([
+                "resize-pane",
+                "-t",
+                &info.tmux_session,
+                "-x",
+                &cols.to_string(),
+                "-y",
+                &rows.to_string(),
+            ])
+            .spawn()?
+            .wait()?;
+
+        Ok(())
+    }
+
     pub fn restore_from_tmux(&mut self) -> Result<()> {
         let output = Command::new("tmux")
             .args(["list-sessions", "-F", "#{session_name}"])

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -22,6 +22,11 @@ pub enum Request {
         id: TerminalId,
         start_line: Option<i32>,
     },
+    ResizeTerminal {
+        id: TerminalId,
+        cols: u16,
+        rows: u16,
+    },
     Shutdown,
 }
 

--- a/src-tauri/src/daemon_client.rs
+++ b/src-tauri/src/daemon_client.rs
@@ -26,6 +26,11 @@ pub enum Request {
         id: TerminalId,
         start_line: Option<i32>,
     },
+    ResizeTerminal {
+        id: TerminalId,
+        cols: u16,
+        rows: u16,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -103,6 +103,21 @@ async fn get_terminal_output(
 }
 
 #[tauri::command]
+async fn resize_terminal(id: String, cols: u16, rows: u16) -> Result<(), String> {
+    let client = DaemonClient::new().map_err(|e| e.to_string())?;
+    let response = client
+        .send_request(Request::ResizeTerminal { id, cols, rows })
+        .await
+        .map_err(|e| e.to_string())?;
+
+    match response {
+        Response::Success => Ok(()),
+        Response::Error { message } => Err(message),
+        _ => Err("Unexpected response".to_string()),
+    }
+}
+
+#[tauri::command]
 fn validate_git_repo(path: &str) -> Result<bool, String> {
     let workspace_path = Path::new(path);
 
@@ -381,6 +396,7 @@ fn main() {
             destroy_terminal,
             send_terminal_input,
             get_terminal_output,
+            resize_terminal,
             get_env_var,
             check_claude_code,
             get_stored_workspace,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5,6 +5,7 @@ use std::fs;
 use std::io;
 use std::path::Path;
 use std::process::Command;
+use tauri::{CustomMenuItem, Menu, MenuItem, Submenu};
 
 mod daemon_client;
 
@@ -239,11 +240,111 @@ fn check_claude_code() -> Result<bool, String> {
         .map_err(|e| e.to_string())
 }
 
+#[derive(serde::Serialize, serde::Deserialize)]
+struct WorkspaceData {
+    last_workspace_path: String,
+    last_opened_at: i64,
+}
+
+fn get_workspace_file_path(app_handle: &tauri::AppHandle) -> Result<std::path::PathBuf, String> {
+    let app_data_dir = app_handle
+        .path_resolver()
+        .app_data_dir()
+        .ok_or_else(|| "Failed to get app data directory".to_string())?;
+
+    // Ensure app data directory exists
+    if !app_data_dir.exists() {
+        fs::create_dir_all(&app_data_dir)
+            .map_err(|e| format!("Failed to create app data directory: {e}"))?;
+    }
+
+    Ok(app_data_dir.join("workspace.json"))
+}
+
+#[tauri::command]
+#[allow(clippy::needless_pass_by_value)]
+fn get_stored_workspace(app_handle: tauri::AppHandle) -> Result<Option<String>, String> {
+    let workspace_file = get_workspace_file_path(&app_handle)?;
+
+    if !workspace_file.exists() {
+        return Ok(None);
+    }
+
+    let contents = fs::read_to_string(&workspace_file)
+        .map_err(|e| format!("Failed to read workspace file: {e}"))?;
+
+    let workspace_data: WorkspaceData = serde_json::from_str(&contents)
+        .map_err(|e| format!("Failed to parse workspace file: {e}"))?;
+
+    Ok(Some(workspace_data.last_workspace_path))
+}
+
+#[tauri::command]
+#[allow(clippy::needless_pass_by_value)]
+fn set_stored_workspace(app_handle: tauri::AppHandle, path: &str) -> Result<(), String> {
+    // Validate path exists and is a git repo
+    validate_git_repo(path)?;
+
+    let workspace_file = get_workspace_file_path(&app_handle)?;
+
+    let workspace_data = WorkspaceData {
+        last_workspace_path: path.to_string(),
+        #[allow(clippy::cast_possible_truncation)]
+        last_opened_at: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|e| format!("Failed to get current time: {e}"))?
+            .as_millis() as i64,
+    };
+
+    let json = serde_json::to_string_pretty(&workspace_data)
+        .map_err(|e| format!("Failed to serialize workspace data: {e}"))?;
+
+    fs::write(&workspace_file, json).map_err(|e| format!("Failed to write workspace file: {e}"))?;
+
+    Ok(())
+}
+
+#[tauri::command]
+#[allow(clippy::needless_pass_by_value)]
+fn clear_stored_workspace(app_handle: tauri::AppHandle) -> Result<(), String> {
+    let workspace_file = get_workspace_file_path(&app_handle)?;
+
+    if workspace_file.exists() {
+        fs::remove_file(&workspace_file)
+            .map_err(|e| format!("Failed to remove workspace file: {e}"))?;
+    }
+
+    Ok(())
+}
+
 fn main() {
     // Load .env file
     dotenvy::dotenv().ok();
 
+    // Build File menu
+    let close_workspace =
+        CustomMenuItem::new("close_workspace", "Close Workspace").accelerator("CmdOrCtrl+W");
+
+    let file_menu = Submenu::new(
+        "File",
+        Menu::new()
+            .add_item(close_workspace)
+            .add_native_item(MenuItem::Separator)
+            .add_native_item(MenuItem::Quit),
+    );
+
+    let menu = Menu::new().add_submenu(file_menu);
+
     if let Err(e) = tauri::Builder::default()
+        .menu(menu)
+        .on_menu_event(|event| {
+            if event.menu_item_id() == "close_workspace" {
+                // Emit event to frontend
+                if let Err(e) = event.window().emit("close-workspace", ()) {
+                    eprintln!("Failed to emit close-workspace event: {e}");
+                }
+            }
+        })
         .invoke_handler(tauri::generate_handler![
             greet,
             validate_git_repo,
@@ -257,7 +358,10 @@ fn main() {
             send_terminal_input,
             get_terminal_output,
             get_env_var,
-            check_claude_code
+            check_claude_code,
+            get_stored_workspace,
+            set_stored_workspace,
+            clear_stored_workspace
         ])
         .run(tauri::generate_context!())
     {

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -11,6 +11,8 @@ export interface Terminal {
   name: string;
   status: TerminalStatus;
   isPrimary: boolean;
+  role?: string; // Optional: "claude-code-worker", "codex-worker", etc. Undefined = plain shell
+  roleConfig?: Record<string, unknown>; // Role-specific configuration (e.g., system prompt)
 }
 
 export class AppState {
@@ -73,6 +75,19 @@ export class AppState {
     const terminal = this.terminals.get(id);
     if (terminal && newName.trim()) {
       terminal.name = newName.trim();
+      this.notify();
+    }
+  }
+
+  setTerminalRole(
+    id: string,
+    role: string | undefined,
+    roleConfig?: Record<string, unknown>
+  ): void {
+    const terminal = this.terminals.get(id);
+    if (terminal) {
+      terminal.role = role;
+      terminal.roleConfig = roleConfig;
       this.notify();
     }
   }

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -34,19 +34,17 @@ export class AppState {
   }
 
   removeTerminal(id: string): void {
-    // Don't allow removing the last terminal
-    if (this.terminals.size <= 1) {
-      return;
-    }
-
     this.terminals.delete(id);
     this.order = this.order.filter((tid) => tid !== id); // Remove from order
 
-    // If we removed the primary, make the first remaining terminal primary
+    // If we removed the primary, make the first remaining terminal primary (if any)
     if (this.primaryId === id) {
       const firstId = this.order[0];
       if (firstId) {
         this.setPrimary(firstId);
+      } else {
+        // No terminals left - clear primary
+        this.primaryId = null;
       }
     }
 

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -154,6 +154,17 @@ export class AppState {
     });
   }
 
+  clearAll(): void {
+    // Clear all state
+    this.terminals.clear();
+    this.order = [];
+    this.primaryId = null;
+    this.workspacePath = null;
+    this.displayedWorkspacePath = "";
+    // Note: Don't reset nextAgentNumber - it persists across workspace changes
+    this.notify();
+  }
+
   onChange(callback: () => void): () => void {
     this.listeners.add(callback);
     return () => this.listeners.delete(callback);

--- a/src/lib/ui.ts
+++ b/src/lib/ui.ts
@@ -67,13 +67,27 @@ export function renderPrimaryTerminal(
     return;
   }
 
+  const roleLabel = terminal.role ? getRoleLabel(terminal.role) : "Shell";
+
   container.innerHTML = `
     <div class="h-full flex flex-col bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
       <div class="flex items-center justify-between px-4 py-2 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700">
         <div class="flex items-center gap-2">
           <div class="w-2 h-2 rounded-full ${getStatusColor(terminal.status)}"></div>
           <span class="terminal-name font-medium text-sm" data-terminal-id="${terminal.id}">${escapeHtml(terminal.name)}</span>
+          <span class="text-xs text-gray-500 dark:text-gray-400">• ${roleLabel}</span>
         </div>
+        <button
+          id="terminal-settings-btn"
+          data-terminal-id="${terminal.id}"
+          class="p-1.5 hover:bg-gray-200 dark:hover:bg-gray-600 rounded transition-colors"
+          title="Terminal settings"
+        >
+          <svg class="w-4 h-4 text-gray-600 dark:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path>
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
+          </svg>
+        </button>
       </div>
       <div class="flex-1 overflow-hidden" id="terminal-content-${terminal.id}"></div>
     </div>
@@ -151,6 +165,14 @@ export function getStatusColor(status: TerminalStatus): string {
     [TerminalStatus.Stopped]: "bg-gray-400",
   };
   return colors[status];
+}
+
+function getRoleLabel(role: string): string {
+  const labels: Record<string, string> = {
+    "claude-code-worker": "Claude Code Worker",
+    "codex-worker": "Codex Worker",
+  };
+  return labels[role] || role;
 }
 
 function escapeHtml(text: string): string {

--- a/src/lib/ui.ts
+++ b/src/lib/ui.ts
@@ -77,17 +77,29 @@ export function renderPrimaryTerminal(
           <span class="terminal-name font-medium text-sm" data-terminal-id="${terminal.id}">${escapeHtml(terminal.name)}</span>
           <span class="text-xs text-gray-500 dark:text-gray-400">• ${roleLabel}</span>
         </div>
-        <button
-          id="terminal-settings-btn"
-          data-terminal-id="${terminal.id}"
-          class="p-1.5 hover:bg-gray-200 dark:hover:bg-gray-600 rounded transition-colors"
-          title="Terminal settings"
-        >
-          <svg class="w-4 h-4 text-gray-600 dark:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path>
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
-          </svg>
-        </button>
+        <div class="flex items-center gap-1">
+          <button
+            id="terminal-clear-btn"
+            data-terminal-id="${terminal.id}"
+            class="p-1.5 hover:bg-gray-200 dark:hover:bg-gray-600 rounded transition-colors"
+            title="Clear terminal"
+          >
+            <svg class="w-4 h-4 text-gray-600 dark:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
+            </svg>
+          </button>
+          <button
+            id="terminal-settings-btn"
+            data-terminal-id="${terminal.id}"
+            class="p-1.5 hover:bg-gray-200 dark:hover:bg-gray-600 rounded transition-colors"
+            title="Terminal settings"
+          >
+            <svg class="w-4 h-4 text-gray-600 dark:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path>
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
+            </svg>
+          </button>
+        </div>
       </div>
       <div class="flex-1 overflow-hidden" id="terminal-content-${terminal.id}"></div>
     </div>

--- a/src/lib/ui.ts
+++ b/src/lib/ui.ts
@@ -31,10 +31,10 @@ export function renderPrimaryTerminal(
 
   if (!terminal) {
     if (hasWorkspace) {
-      // Workspace set but no agents
+      // Workspace set but no terminals
       container.innerHTML = `
         <div class="h-full flex items-center justify-center text-gray-400">
-          <p class="text-lg">No agents. Click + to add an agent.</p>
+          <p class="text-lg">No terminals. Click + to add a terminal.</p>
         </div>
       `;
     } else {
@@ -105,7 +105,7 @@ export function renderMiniTerminals(terminals: Terminal[], hasWorkspace: boolean
     : "bg-gray-50 dark:bg-gray-800 cursor-not-allowed opacity-50";
 
   const addButtonDisabled = hasWorkspace ? "" : "disabled";
-  const addButtonTitle = hasWorkspace ? "Add agent" : "Select a workspace first";
+  const addButtonTitle = hasWorkspace ? "Add terminal" : "Select a workspace first";
 
   container.innerHTML = `
     <div class="h-full flex items-center gap-2 px-4 py-2 overflow-x-auto overflow-y-visible">
@@ -142,7 +142,7 @@ function createMiniTerminalHTML(terminal: Terminal, index: number): string {
         <button
           class="close-terminal-btn flex-shrink-0 text-gray-400 hover:text-red-500 dark:hover:text-red-400 font-bold transition-colors"
           data-terminal-id="${terminal.id}"
-          title="Close agent"
+          title="Close terminal"
         >
           ×
         </button>

--- a/src/lib/worker-modal.ts
+++ b/src/lib/worker-modal.ts
@@ -77,6 +77,13 @@ export function createWorkerModal(_workspacePath: string): HTMLElement {
 }
 
 export async function showWorkerModal(state: AppState, renderFn: () => void): Promise<void> {
+  // Get workspace path from state
+  const workspacePath = state.getWorkspace();
+  if (!workspacePath) {
+    alert("No workspace selected");
+    return;
+  }
+
   // Check prerequisites (warn but don't block)
   try {
     // Check for API key (warn if missing)
@@ -92,11 +99,6 @@ export async function showWorkerModal(state: AppState, renderFn: () => void): Pr
         "Warning: ANTHROPIC_API_KEY not set in .env file.\n\nWorkers won't function without it. Add the key to your .env file and restart Loom."
       );
     }
-
-    // Get workspace path (needed for prompt template)
-    const workspacePath = await invoke<string>("get_env_var", {
-      key: "WORKSPACE_PATH",
-    });
 
     // Check for Claude Code (warn if missing)
     const hasClaudeCode = await invoke<boolean>("check_claude_code");

--- a/src/lib/worker-modal.ts
+++ b/src/lib/worker-modal.ts
@@ -77,8 +77,9 @@ export function createWorkerModal(_workspacePath: string): HTMLElement {
 }
 
 export async function showWorkerModal(state: AppState, renderFn: () => void): Promise<void> {
-  // Check prerequisites
+  // Check prerequisites (warn but don't block)
   try {
+    // Check for API key (warn if missing)
     const hasApiKey = await invoke<string>("get_env_var", {
       key: "ANTHROPIC_API_KEY",
     })
@@ -86,18 +87,24 @@ export async function showWorkerModal(state: AppState, renderFn: () => void): Pr
       .catch(() => false);
 
     if (!hasApiKey) {
-      alert("ANTHROPIC_API_KEY not set in .env file.\n\nAdd it and restart Loom.");
-      return;
+      console.warn("ANTHROPIC_API_KEY not set in .env file");
+      alert(
+        "Warning: ANTHROPIC_API_KEY not set in .env file.\n\nWorkers won't function without it. Add the key to your .env file and restart Loom."
+      );
     }
 
+    // Get workspace path (needed for prompt template)
     const workspacePath = await invoke<string>("get_env_var", {
       key: "WORKSPACE_PATH",
     });
 
+    // Check for Claude Code (warn if missing)
     const hasClaudeCode = await invoke<boolean>("check_claude_code");
     if (!hasClaudeCode) {
-      alert("Claude Code not found.\n\nInstall with: npm install -g @anthropic-ai/claude-code");
-      return;
+      console.warn("Claude Code not found in PATH");
+      alert(
+        "Warning: Claude Code not found in PATH.\n\nWorkers won't function without it. Install with:\nnpm install -g @anthropic-ai/claude-code"
+      );
     }
 
     // Create modal

--- a/src/main.ts
+++ b/src/main.ts
@@ -591,12 +591,7 @@ function setupEventListeners() {
         const id = target.getAttribute("data-terminal-id");
 
         if (id) {
-          if (state.getTerminals().length <= 1) {
-            alert("Cannot close the last agent");
-            return;
-          }
-
-          if (confirm("Close this agent?")) {
+          if (confirm("Close this terminal?")) {
             // Stop polling and clean up xterm.js instance
             outputPoller.stopPolling(id);
             terminalManager.destroyTerminal(id);

--- a/src/main.ts
+++ b/src/main.ts
@@ -546,9 +546,26 @@ function setupEventListeners() {
     toggleTheme();
   });
 
-  // Primary terminal - double-click to rename
+  // Primary terminal - double-click to rename, click for settings
   const primaryTerminal = document.getElementById("primary-terminal");
   if (primaryTerminal) {
+    // Settings button click
+    primaryTerminal.addEventListener("click", (e) => {
+      const target = e.target as HTMLElement;
+      const settingsBtn = target.closest("#terminal-settings-btn");
+
+      if (settingsBtn) {
+        e.stopPropagation();
+        const id = settingsBtn.getAttribute("data-terminal-id");
+        if (id) {
+          console.log(`[terminal-settings-btn] Opening settings for terminal ${id}`);
+          // TODO: Show terminal settings modal
+          alert("Terminal settings modal coming soon!");
+        }
+      }
+    });
+
+    // Double-click to rename
     primaryTerminal.addEventListener("dblclick", (e) => {
       const target = e.target as HTMLElement;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,7 +54,7 @@ function initializeTerminalDisplay(terminalId: string) {
 
   // Check if terminal already exists
   if (terminalManager.getTerminal(terminalId)) {
-    // Terminal already exists, just ensure polling is active
+    // Terminal already exists, just ensure polling is active and resize to fit
     if (currentAttachedTerminalId !== terminalId) {
       // Stop polling previous terminal
       if (currentAttachedTerminalId) {
@@ -64,6 +64,11 @@ function initializeTerminalDisplay(terminalId: string) {
       outputPoller.startPolling(terminalId);
       currentAttachedTerminalId = terminalId;
     }
+
+    // Resize terminal to fit container after DOM updates
+    setTimeout(() => {
+      terminalManager.fitTerminal(terminalId);
+    }, 0);
     return;
   }
 
@@ -546,14 +551,15 @@ function setupEventListeners() {
     toggleTheme();
   });
 
-  // Primary terminal - double-click to rename, click for settings
+  // Primary terminal - double-click to rename, click for settings/clear
   const primaryTerminal = document.getElementById("primary-terminal");
   if (primaryTerminal) {
-    // Settings button click
+    // Button clicks (settings, clear)
     primaryTerminal.addEventListener("click", (e) => {
       const target = e.target as HTMLElement;
-      const settingsBtn = target.closest("#terminal-settings-btn");
 
+      // Settings button
+      const settingsBtn = target.closest("#terminal-settings-btn");
       if (settingsBtn) {
         e.stopPropagation();
         const id = settingsBtn.getAttribute("data-terminal-id");
@@ -562,6 +568,19 @@ function setupEventListeners() {
           // TODO: Show terminal settings modal
           alert("Terminal settings modal coming soon!");
         }
+        return;
+      }
+
+      // Clear button
+      const clearBtn = target.closest("#terminal-clear-btn");
+      if (clearBtn) {
+        e.stopPropagation();
+        const id = clearBtn.getAttribute("data-terminal-id");
+        if (id) {
+          console.log(`[terminal-clear-btn] Clearing terminal ${id}`);
+          terminalManager.clearTerminal(id);
+        }
+        return;
       }
     });
 


### PR DESCRIPTION
## Summary

Implements workspace persistence to automatically remember and restore the last opened workspace across app restarts.

### Backend (Rust)
- **Workspace Persistence Commands**: Added three new Tauri commands
  - `get_stored_workspace()`: Retrieves stored workspace path from app data
  - `set_stored_workspace()`: Saves workspace path with timestamp
  - `clear_stored_workspace()`: Removes stored workspace
- **File Menu**: Added native File menu with "Close Workspace" item (Cmd+W)
- **Event System**: Menu emits `close-workspace` event to frontend
- **Storage Location**: `~/Library/Application Support/com.loom.dev/workspace.json`

### Frontend (TypeScript)
- **Auto-load on Startup**: `initializeApp()` checks for stored workspace and loads automatically
- **Path Validation**: Validates stored path before auto-loading (handles deleted/moved workspaces)
- **Store on Load**: Saves workspace path after successful load
- **Close Handler**: Listens for close-workspace event and cleans up all state

### State Management
- **Clear All**: New `clearAll()` method resets terminals, workspace, and paths
- **Persistent Counter**: `nextAgentNumber` preserved across workspace changes

### Storage Format
```json
{
  "last_workspace_path": "/path/to/workspace",
  "last_opened_at": 1728694746000
}
```

## Implementation Details

**Path Validation**: Before auto-loading, the stored path is validated using the existing `validate_git_repo` command. If validation fails (workspace deleted/moved), the stored path is cleared and the workspace picker is shown.

**State Cleanup**: When closing a workspace, the system:
1. Clears stored workspace path
2. Stops all output polling
3. Destroys all xterm instances
4. Resets application state
5. Returns to workspace picker

**Menu Integration**: Used Tauri's native Menu API with cross-platform accelerator (CmdOrCtrl+W) for keyboard shortcut support.

## Test Plan

**Manual Testing**:
- [ ] First launch shows workspace picker (no stored workspace)
- [ ] Select workspace - loads successfully
- [ ] Quit and reopen - workspace auto-loads
- [ ] File > Close Workspace returns to picker
- [ ] Re-select workspace loads correctly
- [ ] Edge case: Delete workspace folder while closed, reopen should show picker
- [ ] Edge case: Move workspace folder while closed, reopen should show picker
- [ ] Keyboard shortcut (Cmd+W) closes workspace

**Automated Testing**: Clippy passed, TypeScript compilation passed, Vite build passed.

## Related Issues

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)