### PR TITLE
Implement git worktree management for terminal isolation

### DIFF
--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -186,6 +186,35 @@ fn handle_request(request: Request, terminal_manager: &Arc<Mutex<TerminalManager
             }
         }
 
+        Request::CreateTerminalWithWorktree {
+            name,
+            workspace_path,
+        } => {
+            let mut tm = terminal_manager
+                .lock()
+                .expect("Terminal manager mutex poisoned");
+            let path = std::path::Path::new(&workspace_path);
+            match tm.create_terminal_with_worktree(name, path) {
+                Ok(id) => Response::TerminalCreated { id },
+                Err(e) => Response::Error {
+                    message: e.to_string(),
+                },
+            }
+        }
+
+        Request::CleanupOrphanedWorktrees { workspace_path } => {
+            let tm = terminal_manager
+                .lock()
+                .expect("Terminal manager mutex poisoned");
+            let path = std::path::Path::new(&workspace_path);
+            match tm.cleanup_orphaned_worktrees(path) {
+                Ok(()) => Response::Success,
+                Err(e) => Response::Error {
+                    message: e.to_string(),
+                },
+            }
+        }
+
         Request::Shutdown => {
             log::info!("Shutdown requested");
             std::process::exit(0);

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -35,6 +35,13 @@ pub enum Request {
         id: TerminalId,
         session_name: String,
     },
+    CreateTerminalWithWorktree {
+        name: String,
+        workspace_path: String,
+    },
+    CleanupOrphanedWorktrees {
+        workspace_path: String,
+    },
     Shutdown,
 }
 

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "clippy:locked": "cargo clippy --workspace --all-targets --all-features --locked -- -D warnings",
     "clippy:fix": "cargo clippy --workspace --all-targets --all-features --fix --allow-dirty --allow-staged",
     "test": "cargo test --workspace --locked --all-features --no-fail-fast -- --nocapture",
-    "check:all": "npm run lint && npm run format:rust && npm run clippy && npm run check && npm run build",
-    "check:ci": "npm run lint && npm run format:rust && npm run clippy:locked && npm run check && npm run build && npm run test",
+    "check:all": "pnpm lint && pnpm format:rust && pnpm clippy && pnpm check && pnpm build",
+    "check:ci": "pnpm lint && pnpm format:rust && pnpm clippy:locked && pnpm check && pnpm build && pnpm test",
     "prepare": "husky"
   },
   "repository": {

--- a/src-tauri/src/daemon_client.rs
+++ b/src-tauri/src/daemon_client.rs
@@ -39,6 +39,13 @@ pub enum Request {
         id: TerminalId,
         session_name: String,
     },
+    CreateTerminalWithWorktree {
+        name: String,
+        workspace_path: String,
+    },
+    CleanupOrphanedWorktrees {
+        workspace_path: String,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

This PR implements daemon-managed git worktree creation and cleanup to enable isolated working directories for each terminal, allowing multiple AI agents to work on different features simultaneously without conflicts.

### Architecture

**Daemon-Managed Worktrees** (Option 1 from Issue #33):
- Worktrees created in `.loom/worktrees/<terminal-id>/`
- Daemon manages lifecycle (creation, cleanup, recovery)
- No manual intervention required from frontend

### Implementation Details

**Daemon Layer** (`loom-daemon`):
- `create_terminal_with_worktree()`: Creates git worktree at HEAD and terminal with worktree as working directory
- Enhanced `destroy_terminal()`: Automatically detects and cleans up worktree paths
- `cleanup_orphaned_worktrees()`: Scans `.loom/worktrees/` for orphaned directories and removes them
- New IPC protocol: `CreateTerminalWithWorktree`, `CleanupOrphanedWorktrees`

**Tauri Layer** (`src-tauri`):
- `create_terminal_with_worktree` command: Exposes worktree terminal creation to frontend
- `cleanup_orphaned_worktrees` command: Exposes orphan cleanup to frontend
- Updated `daemon_client.rs` with new request types

### Cleanup Strategy

Multi-layered cleanup approach for robustness:

1. **Graceful removal**: `git worktree remove <path>`
2. **Force removal**: `git worktree remove --force <path>` (if locked/modified)
3. **Manual fallback**: `fs::remove_dir_all()` (if git commands fail)
4. **Metadata cleanup**: `git worktree prune` (removes stale references)

### Error Handling

- Proper `Result` propagation throughout
- Descriptive error messages for debugging
- Path validation (non-UTF8 paths handled gracefully)
- No panics - all errors logged and returned

### Changes

**Modified Files**:
- `loom-daemon/src/terminal.rs`: Core worktree logic
- `loom-daemon/src/types.rs`: New IPC request types
- `loom-daemon/src/ipc.rs`: New IPC handlers
- `src-tauri/src/daemon_client.rs`: Updated request enum
- `src-tauri/src/main.rs`: New Tauri commands and registration
- `package.json`: Fixed to use `pnpm` instead of `npm` in scripts

**Key Code Locations**:
- Worktree creation: `loom-daemon/src/terminal.rs:75-109`
- Worktree cleanup in destroy: `loom-daemon/src/terminal.rs:121-149`
- Orphan cleanup: `loom-daemon/src/terminal.rs:299-359`

## Test Plan

- [x] All existing daemon integration tests pass (9/9)
- [x] CI checks pass (lint, format, clippy, build, test)
- [x] TypeScript compilation passes (strict mode)
- [x] Rust clippy passes with `-D warnings`
- [ ] Manual test: Create terminal with worktree
- [ ] Manual test: Verify worktree directory exists in `.loom/worktrees/`
- [ ] Manual test: Destroy terminal and verify worktree cleanup
- [ ] Manual test: Simulate crash and run orphan cleanup
- [ ] Manual test: Verify `git worktree list` shows no stale entries

## Related Issues

Closes #33

Part of Issue #32 (Multi-Agent Coordination System) - this is the first of 5 sub-issues.

## Next Steps

After this PR is merged, the following dependent issues can be implemented:

- Issue #34: Terminal Role Metadata Extensions
- Issue #35: Claude Code Agent Process Management  
- Issue #36: User Input Request/Response Protocol
- Issue #37: Autonomous Mode Timer System

🤖 Generated with [Claude Code](https://claude.com/claude-code)