### PR TITLE
Add visual bell notification for terminals needing input

### DIFF
--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -245,3 +245,17 @@ export class AppState {
     this.listeners.forEach((cb) => cb());
   }
 }
+
+// Singleton instance for accessing state from anywhere
+let appStateInstance: AppState | null = null;
+
+export function getAppState(): AppState {
+  if (!appStateInstance) {
+    appStateInstance = new AppState();
+  }
+  return appStateInstance;
+}
+
+export function setAppState(state: AppState): void {
+  appStateInstance = state;
+}

--- a/src/lib/terminal-manager.ts
+++ b/src/lib/terminal-manager.ts
@@ -96,6 +96,31 @@ export class TerminalManager {
         .catch((e) => {
           console.error(`[terminal-input] Failed to import tauri API:`, e);
         });
+
+      // Clear needs-input state when user types
+      import("./state")
+        .then(({ getAppState, TerminalStatus: Status }) => {
+          const state = getAppState();
+          const terminal = state.getTerminals().find((t) => t.id === terminalId);
+          if (terminal?.status === Status.NeedsInput) {
+            state.updateTerminal(terminalId, { status: Status.Idle });
+          }
+        })
+        .catch((e) => {
+          console.error(`[terminal-input] Failed to clear needs-input state:`, e);
+        });
+    });
+
+    // Hook up bell handler - set needs-input state when terminal beeps
+    terminal.onBell(() => {
+      import("./state")
+        .then(({ getAppState, TerminalStatus: Status }) => {
+          const state = getAppState();
+          state.updateTerminal(terminalId, { status: Status.NeedsInput });
+        })
+        .catch((e) => {
+          console.error(`[terminal-bell] Failed to set needs-input state:`, e);
+        });
     });
 
     // Store managed terminal

--- a/src/lib/ui.ts
+++ b/src/lib/ui.ts
@@ -234,31 +234,40 @@ function createMiniTerminalHTML(terminal: Terminal, index: number): string {
   const borderWidth = terminal.isPrimary ? "3" : "2";
   const borderColor = terminal.isPrimary ? styles.activeColor : styles.borderColor;
 
+  // Show notification badge when terminal needs input
+  const needsInputBadge =
+    terminal.status === TerminalStatus.NeedsInput
+      ? `<div class="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full border-2 border-white dark:border-gray-900 animate-pulse"></div>`
+      : "";
+
   return `
     <div class="p-1 flex-shrink-0">
-      <div
-        class="terminal-card group w-40 h-32 bg-white dark:bg-gray-800 hover:bg-gray-900/5 dark:hover:bg-white/5 rounded-lg cursor-grab transition-all"
-        style="border: ${borderWidth}px solid ${borderColor}"
-        data-terminal-id="${terminal.id}"
-        draggable="true"
-      >
-      <div class="p-2 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700 group-hover:bg-gray-100 dark:group-hover:bg-gray-600 flex items-center justify-between transition-colors rounded-t-lg" style="background-color: ${styles.backgroundColor}">
-        <div class="flex items-center gap-2 flex-1 min-w-0">
-          <div class="w-2 h-2 rounded-full flex-shrink-0 ${getStatusColor(terminal.status)}"></div>
-          <span class="terminal-name text-xs font-medium truncate">${escapeHtml(terminal.name)}</span>
-        </div>
-        <button
-          class="close-terminal-btn flex-shrink-0 text-gray-400 hover:text-red-500 dark:hover:text-red-400 font-bold transition-colors"
+      <div class="relative">
+        ${needsInputBadge}
+        <div
+          class="terminal-card group w-40 h-32 bg-white dark:bg-gray-800 hover:bg-gray-900/5 dark:hover:bg-white/5 rounded-lg cursor-grab transition-all"
+          style="border: ${borderWidth}px solid ${borderColor}"
           data-terminal-id="${terminal.id}"
-          title="Close terminal"
+          draggable="true"
         >
-          ×
-        </button>
-      </div>
-      <div class="p-2 text-xs text-gray-500 dark:text-gray-400 flex items-center justify-between">
-        <span>${terminal.status}</span>
-        <span class="font-mono font-bold text-blue-600 dark:text-blue-400">#${index}</span>
-      </div>
+        <div class="p-2 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700 group-hover:bg-gray-100 dark:group-hover:bg-gray-600 flex items-center justify-between transition-colors rounded-t-lg" style="background-color: ${styles.backgroundColor}">
+          <div class="flex items-center gap-2 flex-1 min-w-0">
+            <div class="w-2 h-2 rounded-full flex-shrink-0 ${getStatusColor(terminal.status)}"></div>
+            <span class="terminal-name text-xs font-medium truncate">${escapeHtml(terminal.name)}</span>
+          </div>
+          <button
+            class="close-terminal-btn flex-shrink-0 text-gray-400 hover:text-red-500 dark:hover:text-red-400 font-bold transition-colors"
+            data-terminal-id="${terminal.id}"
+            title="Close terminal"
+          >
+            ×
+          </button>
+        </div>
+        <div class="p-2 text-xs text-gray-500 dark:text-gray-400 flex items-center justify-between">
+          <span>${terminal.status}</span>
+          <span class="font-mono font-bold text-blue-600 dark:text-blue-400">#${index}</span>
+        </div>
+        </div>
       </div>
     </div>
   `;

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import { homeDir } from "@tauri-apps/api/path";
 import { invoke } from "@tauri-apps/api/tauri";
 import { loadConfig, saveConfig, setConfigWorkspace } from "./lib/config";
 import { getOutputPoller } from "./lib/output-poller";
-import { AppState, TerminalStatus } from "./lib/state";
+import { AppState, setAppState, TerminalStatus } from "./lib/state";
 import { getTerminalManager } from "./lib/terminal-manager";
 import { showTerminalSettingsModal } from "./lib/terminal-settings-modal";
 import { initTheme, toggleTheme } from "./lib/theme";
@@ -16,6 +16,7 @@ initTheme();
 
 // Initialize state (no agents until workspace is selected)
 const state = new AppState();
+setAppState(state); // Register singleton so terminal-manager can access it
 
 // Get terminal manager and output poller
 const terminalManager = getTerminalManager();


### PR DESCRIPTION
## Summary

Implements a simple, frontend-only solution for issue #36 using xterm.js's built-in `onBell` callback. When Claude Code (or any process) sends a BEL character (0x07) to indicate it needs user input, a prominent animated red dot appears on the corresponding terminal card.

## Changes

### Frontend
- **Bell Detection**: Wire up xterm.js `onBell` callback to set terminal status to `needs_input`
- **Auto-Clear**: Clear `needs_input` status automatically when user types into the terminal
- **Visual Indicator**: Add animated red dot badge to top-right of mini terminal cards when input needed
- **State Management**: Add singleton pattern for AppState to allow terminal-manager access

### Visual Design
- Red pulsing dot (`animate-pulse`) on top-right corner of mini terminal card
- Automatically clears when user types in that terminal
- Yellow status dot already indicates `needs_input` state in terminal header
- Badge provides additional prominent notification visible at a glance

### Implementation Notes
- ✅ No backend/daemon changes needed
- ✅ BEL character (0x07) already forwarded to xterm
- ✅ Each terminal independently tracks its own bell state
- ✅ Supports 0-20 terminals each with independent notifications
- ✅ Terminal-level state management (not app-level)

## Test Plan

### Manual Testing
- [x] Create multiple terminals
- [ ] Run Claude Code in a terminal
- [ ] Verify red dot appears when Claude prompts for input
- [ ] Verify red dot disappears when typing into terminal
- [ ] Verify multiple terminals can show indicators independently

### Automated Tests
- [x] TypeScript compilation passes
- [x] All linting checks pass
- [x] All existing unit tests pass
- [x] Frontend build successful

## Screenshots

_Will be added after testing with real Claude Code instance_

## Related Issues

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)