### PR TITLE
Configure git identity per terminal based on role (Issue #40)

### DIFF
--- a/defaults/roles/architect.json
+++ b/defaults/roles/architect.json
@@ -4,5 +4,9 @@
   "defaultInterval": 900000,
   "defaultIntervalPrompt": "Check if there are already 3+ open proposals using `gh issue list --label=\"loom:proposal\"`. If < 3, scan the codebase for improvement opportunities across all domains (features, refactoring, docs, tests, CI, security). Create one comprehensive proposal issue and add the `loom:proposal` label.",
   "autonomousRecommended": true,
-  "suggestedWorkerType": "claude"
+  "suggestedWorkerType": "claude",
+  "gitIdentity": {
+    "name": "Loom Architect",
+    "email": "loom-architect@users.noreply.github.com"
+  }
 }

--- a/defaults/roles/curator.json
+++ b/defaults/roles/curator.json
@@ -4,5 +4,9 @@
   "defaultInterval": 300000,
   "defaultIntervalPrompt": "Find approved issues (without loom:proposal label) that need curation. Enhance one issue with implementation details, test plans, and code references, then mark it as `loom:ready` when complete.",
   "autonomousRecommended": true,
-  "suggestedWorkerType": "claude"
+  "suggestedWorkerType": "claude",
+  "gitIdentity": {
+    "name": "Loom Curator",
+    "email": "loom-curator@users.noreply.github.com"
+  }
 }

--- a/defaults/roles/issues.json
+++ b/defaults/roles/issues.json
@@ -4,5 +4,9 @@
   "defaultInterval": 0,
   "defaultIntervalPrompt": "",
   "autonomousRecommended": false,
-  "suggestedWorkerType": "claude"
+  "suggestedWorkerType": "claude",
+  "gitIdentity": {
+    "name": "Loom Issues",
+    "email": "loom-issues@users.noreply.github.com"
+  }
 }

--- a/defaults/roles/reviewer.json
+++ b/defaults/roles/reviewer.json
@@ -4,5 +4,9 @@
   "defaultInterval": 300000,
   "defaultIntervalPrompt": "Check for PRs requesting review using `gh pr list --label=\"loom:review-requested\" --state=open`. If you find any, claim one by updating its label to `loom:reviewing`, check out the branch, run tests, and provide a thorough code review.",
   "autonomousRecommended": true,
-  "suggestedWorkerType": "claude"
+  "suggestedWorkerType": "claude",
+  "gitIdentity": {
+    "name": "Loom Reviewer",
+    "email": "loom-reviewer@users.noreply.github.com"
+  }
 }

--- a/defaults/roles/worker.json
+++ b/defaults/roles/worker.json
@@ -4,5 +4,9 @@
   "defaultInterval": 0,
   "defaultIntervalPrompt": "Check for issues labeled `loom:ready` using `gh issue list --label=\"loom:ready\" --state=open`. If you find any, claim one by updating its label to `loom:in-progress` and begin implementation.",
   "autonomousRecommended": false,
-  "suggestedWorkerType": "claude"
+  "suggestedWorkerType": "claude",
+  "gitIdentity": {
+    "name": "Loom Worker",
+    "email": "loom-worker@users.noreply.github.com"
+  }
 }

--- a/src/lib/agent-launcher.ts
+++ b/src/lib/agent-launcher.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/tauri";
+import type { GitIdentity } from "./worktree-manager";
 
 /**
  * Launch a Claude agent in a terminal by sending the Claude CLI command
@@ -12,6 +13,7 @@ import { invoke } from "@tauri-apps/api/tauri";
  * @param workspacePath - The workspace path for the agent
  * @param worktreePath - Optional worktree path for isolated work (defaults to workspace)
  * @param useWorktree - Whether to create a worktree for isolation (default: false)
+ * @param gitIdentity - Optional git identity to configure in the worktree
  * @returns Promise that resolves with the working directory path that was used
  */
 export async function launchAgentInTerminal(
@@ -19,13 +21,14 @@ export async function launchAgentInTerminal(
   roleFile: string,
   workspacePath: string,
   worktreePath?: string,
-  useWorktree = false
+  useWorktree = false,
+  gitIdentity?: GitIdentity
 ): Promise<string> {
   // Set up worktree if requested
   let agentWorkingDir = workspacePath;
   if (useWorktree && !worktreePath) {
     const { setupWorktreeForAgent } = await import("./worktree-manager");
-    agentWorkingDir = await setupWorktreeForAgent(terminalId, workspacePath);
+    agentWorkingDir = await setupWorktreeForAgent(terminalId, workspacePath, gitIdentity);
   } else if (worktreePath) {
     agentWorkingDir = worktreePath;
   }

--- a/src/lib/worktree-manager.ts
+++ b/src/lib/worktree-manager.ts
@@ -1,5 +1,10 @@
 import { invoke } from "@tauri-apps/api/tauri";
 
+export interface GitIdentity {
+  name: string;
+  email: string;
+}
+
 /**
  * Set up a git worktree for an agent terminal
  *
@@ -11,11 +16,13 @@ import { invoke } from "@tauri-apps/api/tauri";
  *
  * @param terminalId - The terminal ID to set up the worktree in
  * @param workspacePath - The main workspace path (git repository root)
+ * @param gitIdentity - Optional git identity to configure in the worktree
  * @returns Promise that resolves with the worktree path
  */
 export async function setupWorktreeForAgent(
   terminalId: string,
-  workspacePath: string
+  workspacePath: string,
+  gitIdentity?: GitIdentity
 ): Promise<string> {
   // Worktree path: .loom/worktrees/{terminalId}
   const worktreePath = `${workspacePath}/.loom/worktrees/${terminalId}`;
@@ -29,6 +36,16 @@ export async function setupWorktreeForAgent(
 
   // Change to worktree directory
   await sendCommand(terminalId, `cd "${worktreePath}"`);
+
+  // Configure git identity if provided
+  if (gitIdentity) {
+    await sendCommand(terminalId, `git config user.name "${gitIdentity.name}"`);
+    await sendCommand(terminalId, `git config user.email "${gitIdentity.email}"`);
+    await sendCommand(
+      terminalId,
+      `echo "✓ Git identity configured: ${gitIdentity.name} <${gitIdentity.email}>"`
+    );
+  }
 
   // Log success message
   await sendCommand(terminalId, `echo "✓ Worktree ready at ${worktreePath}"`);


### PR DESCRIPTION
## Summary

Implements role-based git identity configuration so that commits in agent worktrees are properly attributed to the role that created them.

## Changes

**Git Identity Metadata:**
- Added `gitIdentity` field to all role metadata files (worker.json, architect.json, curator.json, reviewer.json, issues.json)
- Each role now has a unique name and noreply email address

**Worktree Setup:**
- Updated `setupWorktreeForAgent()` to accept optional git identity parameter
- Configures `git config user.name` and `user.email` in worktrees when identity is provided
- Displays confirmation message showing configured identity

**Agent Launcher:**
- Modified `launchAgentInTerminal()` to accept git identity parameter
- Passes git identity from role metadata to worktree setup

**Terminal Settings Modal:**
- Loads git identity from role metadata when launching agents
- Automatically configures identity based on selected role

## Git Identity Mappings

| Role | Name | Email |
|------|------|-------|
| Worker | Loom Worker | loom-worker@users.noreply.github.com |
| Architect | Loom Architect | loom-architect@users.noreply.github.com |
| Curator | Loom Curator | loom-curator@users.noreply.github.com |
| Reviewer | Loom Reviewer | loom-reviewer@users.noreply.github.com |
| Issues | Loom Issues | loom-issues@users.noreply.github.com |
| Default | _(no git identity - uses global config)_ | |

## Terminal Initialization Flow

When a role is assigned via the settings modal:
1. Terminal created with `workingDir: workspace` (starts in repo root) ✓
2. Agent launcher called with role file and git identity ✓
3. Worktree created at `.loom/worktrees/{terminalId}` ✓
4. Git identity configured in worktree ✓
5. Claude Code launched with role's system prompt ✓

## Test Plan

- [x] All CI checks pass (lint, format, clippy, build, tests)
- [ ] Factory reset creates terminals with default config
- [ ] Assign role to terminal via settings modal
- [ ] Verify worktree created with correct git identity
- [ ] Verify commits in worktree show role attribution

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)