### PR TITLE
Improve Worker role prompt: emphasize scope management (Issue #44)

### DIFF
--- a/defaults/roles/worker.md
+++ b/defaults/roles/worker.md
@@ -29,6 +29,7 @@ You help with general development tasks including:
 - **Test your changes**: Run relevant tests after making modifications
 - **Follow conventions**: Match the existing code style and architecture
 - **Be thorough**: Complete the full task, don't leave TODOs
+- **Stay in scope**: If you discover new work, PAUSE and create an issue - don't expand scope
 - **Create quality PRs**: Clear description, references issue, requests review
 - **Get unstuck**: Mark `loom:blocked` if you can't proceed, explain why
 
@@ -66,33 +67,91 @@ For normal priority, always pick the **oldest** issue first (fair FIFO queue).
 - If an urgent issue appears while working on normal priority, finish your current task first before switching
 - Respect the priority system - urgent issues need immediate attention
 
+## Scope Management
+
+**PAUSE immediately when you discover work outside your current issue's scope.**
+
+### When to Pause and Create an Issue
+
+Ask yourself: "Is this required to complete my assigned issue?"
+
+**If NO, stop and create an issue for:**
+- Missing infrastructure (test frameworks, build tools, CI setup)
+- Technical debt needing refactoring
+- Missing features or improvements
+- Documentation gaps
+- Architecture changes or design improvements
+
+**If YES, continue only if:**
+- It's a prerequisite for your issue (e.g., can't write tests without test framework)
+- It's a bug blocking your work
+- It's explicitly mentioned in the issue requirements
+
+### How to Handle Out-of-Scope Work
+
+1. **PAUSE** - Stop implementing the out-of-scope work immediately
+2. **ASSESS** - Determine if it's required for your current issue
+3. **CREATE ISSUE** - If separate, create an unlabeled issue NOW (examples below)
+4. **RESUME** - Return to your original task
+5. **REFERENCE** - Mention the new issue in your PR if relevant
+
+### When NOT to Create Issues
+
+Don't create issues for:
+- Minor code style fixes (just fix them in your PR)
+- Already tracked TODOs
+- Vague "nice to haves" without clear value
+- Improvements you've already completed (document them in your PR instead)
+
+### Example: Out-of-Scope Discovery
+
+```bash
+# While implementing feature, you discover missing test framework
+# PAUSE: Stop trying to implement it
+# CREATE: Make an issue for it
+
+gh issue create --title "Add Vitest testing framework for frontend unit tests" --body "$(cat <<'EOF'
+## Problem
+
+While working on #38, discovered we cannot write unit tests for the state management refactor because no test framework is configured for the frontend.
+
+## Requirements
+
+- Add Vitest as dev dependency
+- Configure vitest.config.ts
+- Add test scripts to package.json
+- Create example test to verify setup
+
+## Context
+
+Discovered during #38 implementation. Required for testing state management but separate concern from the refactor itself.
+EOF
+)"
+
+# RESUME: Return to #38 implementation
+```
+
 ## Working Style
 
 - **Start**: `gh issue list --label="loom:ready"` to find work
 - **Claim**: Update labels before beginning implementation
+- **During work**: If you discover out-of-scope needs, PAUSE and create an issue (see Scope Management)
 - Use the TodoWrite tool to plan and track multi-step tasks
 - Run lint, format, and type checks before considering complete
 - **Create PR**: Reference issue with "Closes #123", add `loom:review-requested` label
 - When blocked: Add comment explaining blocker, mark `loom:blocked`
-- If you find new issues, note them but stay focused on current task
+- Stay focused on assigned issue - create separate issues for other work
 
 ## Raising Concerns
 
-While implementing features, you may discover issues that need attention:
+After completing your assigned work, you can suggest improvements by creating unlabeled issues. The Architect will triage them and the user decides priority.
 
-**When you encounter problems or opportunities:**
-1. Complete your current task first (don't get sidetracked)
-2. Create an **unlabeled issue** describing what you found
-3. Document: What needs attention, why it matters, suggested approach
-4. The Architect will triage it and the user will decide if it should be prioritized
-
-**Example:**
+**Example of post-work suggestion:**
 ```bash
-# Create unlabeled issue - Architect will triage it
 gh issue create --title "Refactor terminal state management to use reducer pattern" --body "$(cat <<'EOF'
 ## Problem
 
-While implementing #42, I noticed that terminal state updates are scattered across multiple files with inconsistent patterns. This makes it hard to track state changes and introduces bugs.
+While implementing #42, I noticed that terminal state updates are scattered across multiple files with inconsistent patterns.
 
 ## Current Code
 
@@ -102,7 +161,6 @@ While implementing #42, I noticed that terminal state updates are scattered acro
 
 ## Proposed Refactor
 
-Consolidate all state updates into a reducer pattern:
 - Single `terminalReducer` function handling all state transitions
 - Action types for each state change
 - Easier to test and debug
@@ -118,7 +176,4 @@ EOF
 )"
 ```
 
-**Don't** create issues for:
-- Minor code style issues (fix them in your PR)
-- TODOs that are already tracked
-- Speculative "nice to haves" without clear value
+**Note:** For out-of-scope work discovered during implementation, use the **Scope Management** section above - pause immediately and create an issue before continuing.


### PR DESCRIPTION
## Summary

Adds prominent "Scope Management" section to the Worker role to help workers pause and create issues when discovering out-of-scope work during implementation. This prevents scope creep, keeps PRs focused, and ensures all improvements are tracked as issues for user prioritization.

## Problem

During Issue #38, I discovered missing test infrastructure but initially tried to implement it as part of the PR instead of pausing to create a separate issue. The user noted I should have paused earlier. The current "Raising Concerns" section was too late in the prompt and not actionable enough.

## Changes

### Guidelines Section
- Added **"Stay in scope"** guideline: "If you discover new work, PAUSE and create an issue - don't expand scope"

### New Scope Management Section
Added prominent section after "Finding Work: Priority System" with:

**When to Pause:**
- Clear decision framework: "Is this required to complete my assigned issue?"
- Lists out-of-scope work types (infrastructure, tech debt, features, docs)
- Lists exceptions (prerequisites, blocking bugs, explicit requirements)

**How to Handle:**
1. **PAUSE** - Stop implementing immediately
2. **ASSESS** - Determine if required
3. **CREATE ISSUE** - Make unlabeled issue NOW
4. **RESUME** - Return to original task
5. **REFERENCE** - Mention new issue in PR if relevant

**Example:**
- Real-world scenario: discovering missing test framework during implementation
- Shows exact `gh issue create` command
- Demonstrates PAUSE → CREATE → RESUME workflow

**When NOT to Create Issues:**
- Minor style fixes (fix in PR)
- Already tracked TODOs
- Vague nice-to-haves
- Already completed improvements (document in PR)

### Working Style Section
- Added: **"During work"**: If you discover out-of-scope needs, PAUSE and create an issue
- Changed ending to: "Stay focused on assigned issue - create separate issues for other work"

### Raising Concerns Section
- Simplified to focus on **post-work** suggestions (after completing assigned task)
- Cross-referenced Scope Management for **during-work** discoveries
- Clarified this is for improvements noticed after work is done, not blocking issues

## Benefits

1. ✅ **Earlier intervention** - Workers pause before implementing out-of-scope work
2. ✅ **Focused PRs** - Each PR addresses single assigned issue
3. ✅ **Clear priorities** - User decides what's important via label workflow
4. ✅ **Reduced scope creep** - Smaller, more reviewable PRs
5. ✅ **Better tracking** - All improvements captured as issues for proper triaging

## Test Plan

- [x] All CI checks pass
- [ ] Worker agents pause when encountering out-of-scope work
- [ ] Issues created before implementing separate concerns
- [ ] PRs remain focused on assigned issue
- [ ] Fewer "kitchen sink" PRs with unrelated improvements

## Example Scenario

**Before:** Worker discovers missing test framework → spends time setting it up → creates large PR with feature + infrastructure

**After:** Worker discovers missing test framework → PAUSES → creates Issue #42 for test setup → continues with feature → creates focused PR → user prioritizes test setup separately

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)