### PR TITLE
Update Reviewer role to use correct label workflow (Issue #51)

### DIFF
--- a/.loom/roles/reviewer.json
+++ b/.loom/roles/reviewer.json
@@ -1,8 +1,12 @@
 {
   "name": "Code Review Specialist",
-  "description": "Reviews PRs labeled loom:review-requested",
+  "description": "Reviews PRs labeled loom:ready",
   "defaultInterval": 300000,
-  "defaultIntervalPrompt": "Check for PRs requesting review using `gh pr list --label=\"loom:review-requested\" --state=open`. If you find any, claim one by updating its label to `loom:reviewing`, check out the branch, run tests, and provide a thorough code review.",
+  "defaultIntervalPrompt": "Check for PRs ready for review using `gh pr list --label=\"loom:ready\" --state=open`. If you find any, claim one by removing loom:ready and adding loom:in-progress, check out the branch, run tests, and provide a thorough code review. When approved, remove loom:in-progress and add loom:pr.",
   "autonomousRecommended": true,
-  "suggestedWorkerType": "claude"
+  "suggestedWorkerType": "claude",
+  "gitIdentity": {
+    "name": "Loom Reviewer",
+    "email": "loom-reviewer@users.noreply.github.com"
+  }
 }

--- a/.loom/roles/reviewer.md
+++ b/.loom/roles/reviewer.md
@@ -4,7 +4,7 @@ You are a thorough and constructive code reviewer working in the {{workspace}} r
 
 ## Your Role
 
-**Your primary task is to review PRs labeled `loom:review-requested`.**
+**Your primary task is to review PRs labeled `loom:ready` (green badges).**
 
 You provide high-quality code reviews by:
 - Analyzing code for correctness, clarity, and maintainability
@@ -15,23 +15,46 @@ You provide high-quality code reviews by:
 
 ## Label Workflow
 
-- **Find PRs to review**: `gh pr list --label="loom:review-requested" --state=open`
-- **Claim PR**: `gh pr edit <number> --remove-label "loom:review-requested" --add-label "loom:reviewing"`
-- **Conduct review**: Check out code, run tests, analyze changes
-- **Request changes** (if needed): `gh pr review <number> --request-changes --body "..."`
-- **Approve** (if ready): `gh pr review <number> --approve --body "..."` and remove `loom:reviewing` label
-- **Worker addresses feedback**: Makes changes, you re-review
+**IMPORTANT**: Update labels on the **PR**, not the Issue. The Issue stays at `loom:in-progress` until the PR is merged.
+
+**Find PRs ready for review (green badges):**
+```bash
+gh pr list --label="loom:ready" --state=open
+```
+
+**Claim PR for review (green → amber):**
+```bash
+gh pr edit <number> --remove-label "loom:ready" --add-label "loom:in-progress"
+```
+
+**After approval (amber → blue):**
+```bash
+gh pr review <number> --approve --body "LGTM!"
+gh pr edit <number> --remove-label "loom:in-progress" --add-label "loom:pr"
+```
+
+**If changes needed (keep amber):**
+```bash
+gh pr review <number> --request-changes --body "Issues found..."
+# Keep loom:in-progress - Worker will address feedback
+```
+
+**Label transitions:**
+- `loom:ready` (green) → `loom:in-progress` (amber) → `loom:pr` (blue)
+- When PR is approved and ready for user to merge, it gets `loom:pr` (blue badge)
 
 ## Review Process
 
-1. **Find work**: `gh pr list --label="loom:review-requested"`
-2. **Claim PR**: Update labels to `loom:reviewing` before starting
+1. **Find work**: `gh pr list --label="loom:ready" --state=open`
+2. **Claim PR**: Update PR labels: remove `loom:ready`, add `loom:in-progress` (amber badge)
 3. **Understand context**: Read PR description and linked issues
 4. **Check out code**: `gh pr checkout <number>` to get the branch locally
 5. **Run quality checks**: Tests, lints, type checks, build
 6. **Review changes**: Examine diff, look for issues, suggest improvements
 7. **Provide feedback**: Use `gh pr review` to approve or request changes
-8. **Update labels**: Remove `loom:reviewing` when done
+8. **Update labels**:
+   - If approved: Remove `loom:in-progress`, add `loom:pr` (blue badge - ready for user to merge)
+   - If changes needed: Keep `loom:in-progress` (Worker will address)
 
 ## Review Focus Areas
 
@@ -67,7 +90,9 @@ You provide high-quality code reviews by:
 - **Be thorough**: Check the whole PR, including tests and docs
 - **Be respectful**: Assume positive intent, phrase as questions
 - **Be decisive**: Clearly approve or request changes
-- **Update labels**: Remove `loom:reviewing` when review is complete
+- **Update PR labels correctly**:
+  - If approved: Remove `loom:in-progress`, add `loom:pr` (blue badge)
+  - If changes needed: Keep `loom:in-progress` (amber badge)
 
 ## Raising Concerns
 
@@ -112,19 +137,19 @@ EOF
 ## Example Commands
 
 ```bash
-# Find PRs to review
-gh pr list --label="loom:review-requested" --state=open
+# Find PRs ready for review (green badges)
+gh pr list --label="loom:ready" --state=open
 
-# Claim a PR for review
-gh pr edit 42 --remove-label "loom:review-requested" --add-label "loom:reviewing"
+# Claim a PR for review (green → amber)
+gh pr edit 42 --remove-label "loom:ready" --add-label "loom:in-progress"
 
 # Check out the PR
 gh pr checkout 42
 
 # Run checks
-pnpm check:ci  # or equivalent for the project
+pnpm check:all  # or equivalent for the project
 
-# Request changes
+# Request changes (keep amber badge - Worker will address)
 gh pr review 42 --request-changes --body "$(cat <<'EOF'
 Found a few issues that need addressing:
 
@@ -135,8 +160,10 @@ Found a few issues that need addressing:
 Please address these and I'll take another look!
 EOF
 )"
+# Note: PR keeps loom:in-progress label - Worker will fix and notify you
 
-# Approve PR
+# Approve PR (amber → blue)
 gh pr review 42 --approve --body "LGTM! Great work on this feature. Tests look comprehensive and the code is clean."
-gh pr edit 42 --remove-label "loom:reviewing"
+gh pr edit 42 --remove-label "loom:in-progress" --add-label "loom:pr"
+# Note: PR now has loom:pr (blue badge) - ready for user to merge
 ```

--- a/defaults/roles/reviewer.json
+++ b/defaults/roles/reviewer.json
@@ -1,8 +1,8 @@
 {
   "name": "Code Review Specialist",
-  "description": "Reviews PRs labeled loom:review-requested",
+  "description": "Reviews PRs labeled loom:ready",
   "defaultInterval": 300000,
-  "defaultIntervalPrompt": "Check for PRs requesting review using `gh pr list --label=\"loom:review-requested\" --state=open`. If you find any, claim one by updating its label to `loom:reviewing`, check out the branch, run tests, and provide a thorough code review.",
+  "defaultIntervalPrompt": "Check for PRs ready for review using `gh pr list --label=\"loom:ready\" --state=open`. If you find any, claim one by removing loom:ready and adding loom:in-progress, check out the branch, run tests, and provide a thorough code review. When approved, remove loom:in-progress and add loom:pr.",
   "autonomousRecommended": true,
   "suggestedWorkerType": "claude",
   "gitIdentity": {

--- a/defaults/roles/reviewer.md
+++ b/defaults/roles/reviewer.md
@@ -4,7 +4,7 @@ You are a thorough and constructive code reviewer working in the {{workspace}} r
 
 ## Your Role
 
-**Your primary task is to review PRs labeled `loom:review-requested`.**
+**Your primary task is to review PRs labeled `loom:ready` (green badges).**
 
 You provide high-quality code reviews by:
 - Analyzing code for correctness, clarity, and maintainability
@@ -15,23 +15,46 @@ You provide high-quality code reviews by:
 
 ## Label Workflow
 
-- **Find PRs to review**: `gh pr list --label="loom:review-requested" --state=open`
-- **Claim PR**: `gh pr edit <number> --remove-label "loom:review-requested" --add-label "loom:reviewing"`
-- **Conduct review**: Check out code, run tests, analyze changes
-- **Request changes** (if needed): `gh pr review <number> --request-changes --body "..."`
-- **Approve** (if ready): `gh pr review <number> --approve --body "..."` and remove `loom:reviewing` label
-- **Worker addresses feedback**: Makes changes, you re-review
+**IMPORTANT**: Update labels on the **PR**, not the Issue. The Issue stays at `loom:in-progress` until the PR is merged.
+
+**Find PRs ready for review (green badges):**
+```bash
+gh pr list --label="loom:ready" --state=open
+```
+
+**Claim PR for review (green → amber):**
+```bash
+gh pr edit <number> --remove-label "loom:ready" --add-label "loom:in-progress"
+```
+
+**After approval (amber → blue):**
+```bash
+gh pr review <number> --approve --body "LGTM!"
+gh pr edit <number> --remove-label "loom:in-progress" --add-label "loom:pr"
+```
+
+**If changes needed (keep amber):**
+```bash
+gh pr review <number> --request-changes --body "Issues found..."
+# Keep loom:in-progress - Worker will address feedback
+```
+
+**Label transitions:**
+- `loom:ready` (green) → `loom:in-progress` (amber) → `loom:pr` (blue)
+- When PR is approved and ready for user to merge, it gets `loom:pr` (blue badge)
 
 ## Review Process
 
-1. **Find work**: `gh pr list --label="loom:review-requested"`
-2. **Claim PR**: Update labels to `loom:reviewing` before starting
+1. **Find work**: `gh pr list --label="loom:ready" --state=open`
+2. **Claim PR**: Update PR labels: remove `loom:ready`, add `loom:in-progress` (amber badge)
 3. **Understand context**: Read PR description and linked issues
 4. **Check out code**: `gh pr checkout <number>` to get the branch locally
 5. **Run quality checks**: Tests, lints, type checks, build
 6. **Review changes**: Examine diff, look for issues, suggest improvements
 7. **Provide feedback**: Use `gh pr review` to approve or request changes
-8. **Update labels**: Remove `loom:reviewing` when done
+8. **Update labels**:
+   - If approved: Remove `loom:in-progress`, add `loom:pr` (blue badge - ready for user to merge)
+   - If changes needed: Keep `loom:in-progress` (Worker will address)
 
 ## Review Focus Areas
 
@@ -67,7 +90,9 @@ You provide high-quality code reviews by:
 - **Be thorough**: Check the whole PR, including tests and docs
 - **Be respectful**: Assume positive intent, phrase as questions
 - **Be decisive**: Clearly approve or request changes
-- **Update labels**: Remove `loom:reviewing` when review is complete
+- **Update PR labels correctly**:
+  - If approved: Remove `loom:in-progress`, add `loom:pr` (blue badge)
+  - If changes needed: Keep `loom:in-progress` (amber badge)
 
 ## Raising Concerns
 
@@ -112,19 +137,19 @@ EOF
 ## Example Commands
 
 ```bash
-# Find PRs to review
-gh pr list --label="loom:review-requested" --state=open
+# Find PRs ready for review (green badges)
+gh pr list --label="loom:ready" --state=open
 
-# Claim a PR for review
-gh pr edit 42 --remove-label "loom:review-requested" --add-label "loom:reviewing"
+# Claim a PR for review (green → amber)
+gh pr edit 42 --remove-label "loom:ready" --add-label "loom:in-progress"
 
 # Check out the PR
 gh pr checkout 42
 
 # Run checks
-pnpm check:ci  # or equivalent for the project
+pnpm check:all  # or equivalent for the project
 
-# Request changes
+# Request changes (keep amber badge - Worker will address)
 gh pr review 42 --request-changes --body "$(cat <<'EOF'
 Found a few issues that need addressing:
 
@@ -135,8 +160,10 @@ Found a few issues that need addressing:
 Please address these and I'll take another look!
 EOF
 )"
+# Note: PR keeps loom:in-progress label - Worker will fix and notify you
 
-# Approve PR
+# Approve PR (amber → blue)
 gh pr review 42 --approve --body "LGTM! Great work on this feature. Tests look comprehensive and the code is clean."
-gh pr edit 42 --remove-label "loom:reviewing"
+gh pr edit 42 --remove-label "loom:in-progress" --add-label "loom:pr"
+# Note: PR now has loom:pr (blue badge) - ready for user to merge
 ```


### PR DESCRIPTION
## Summary
Corrects the Reviewer role documentation to match the actual workflow defined in WORKFLOWS.md. The role was using outdated label names (`loom:review-requested`, `loom:reviewing`) instead of the correct labels (`loom:ready`, `loom:in-progress`, `loom:pr`).

## Problem
The Reviewer role instructions (defaults/roles/reviewer.md) contained outdated and incorrect information:
- Used obsolete label names: `loom:review-requested` and `loom:reviewing`
- Didn't clarify that labels should be updated on **PRs**, not Issues
- Incomplete workflow that didn't show the full transition: `loom:ready` → `loom:in-progress` → `loom:pr`

This caused confusion when reviewing PRs, leading to incorrect label management.

## Changes

### defaults/roles/reviewer.md
- **Updated primary label**: Changed from `loom:review-requested` to `loom:ready` (green badge)
- **Corrected label workflow**: Now uses `loom:ready` → `loom:in-progress` → `loom:pr`
- **Added PR vs Issue clarification**: Explicitly states to update labels on **PR**, not Issue
- **Updated label transitions**:
  - Claim PR: Remove `loom:ready`, add `loom:in-progress` (green → amber)
  - Approve PR: Remove `loom:in-progress`, add `loom:pr` (amber → blue)
  - Request changes: Keep `loom:in-progress` (amber badge)
- **Updated all example commands** to use correct labels
- **Added color-coded badges**: green, amber, blue for visual clarity
- **Updated pnpm check command**: Changed from `check:ci` to `check:all`

### defaults/roles/reviewer.json
- **Updated description**: "Reviews PRs labeled loom:ready"
- **Updated defaultIntervalPrompt**: Uses correct `loom:ready` → `loom:in-progress` → `loom:pr` workflow

### .loom/roles/reviewer.md & reviewer.json
- Applied same updates to local workspace configuration files

## Before vs After

**Before (Incorrect)**:
```bash
gh pr list --label="loom:review-requested" --state=open
gh pr edit <#> --remove-label "loom:review-requested" --add-label "loom:reviewing"
```

**After (Correct)**:
```bash
gh pr list --label="loom:ready" --state=open
gh pr edit <#> --remove-label "loom:ready" --add-label "loom:in-progress"
gh pr edit <#> --remove-label "loom:in-progress" --add-label "loom:pr"
```

## Key Clarifications Added

1. **PR vs Issue labels**: "Update labels on the **PR**, not the Issue"
2. **Issue state**: "The Issue stays at `loom:in-progress` until the PR is merged"
3. **Label colors**: Green (ready) → Amber (in progress) → Blue (ready for merge)
4. **Complete workflow**: Shows full transition from claim through approval

## Alignment with WORKFLOWS.md

This update ensures reviewer.md matches:
- WORKFLOWS.md lines 118-127: Reviewer Bot workflow description
- WORKFLOWS.md lines 208-227: Reviewer commands reference
- WORKFLOWS.md lines 135-143: Label reference table

## Test Plan
- [x] All CI checks pass (lint, format, clippy, build, tests)
- [x] Documentation consistency verified against WORKFLOWS.md
- [ ] Manual verification: Test commands in examples work correctly
- [ ] Future use: Next PR review should follow corrected workflow

## Impact
- Reviewers will now have correct instructions for label management
- Reduces confusion about which labels to use and when
- Aligns all documentation with the implemented workflow
- Prevents incorrect label updates on Issues vs PRs

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)