### PR TITLE
Improve terminal session naming and add kill functionality

### DIFF
--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -9,6 +9,8 @@ pub enum Request {
     CreateTerminal {
         name: String,
         working_dir: Option<String>,
+        role: Option<String>,
+        instance_number: Option<u32>,
     },
     ListTerminals,
     DestroyTerminal {
@@ -33,6 +35,9 @@ pub enum Request {
     ListAvailableSessions,
     AttachToSession {
         id: TerminalId,
+        session_name: String,
+    },
+    KillSession {
         session_name: String,
     },
     Shutdown,

--- a/src-tauri/src/daemon_client.rs
+++ b/src-tauri/src/daemon_client.rs
@@ -13,6 +13,8 @@ pub enum Request {
     CreateTerminal {
         name: String,
         working_dir: Option<String>,
+        role: Option<String>,
+        instance_number: Option<u32>,
     },
     ListTerminals,
     DestroyTerminal {
@@ -37,6 +39,9 @@ pub enum Request {
     ListAvailableSessions,
     AttachToSession {
         id: TerminalId,
+        session_name: String,
+    },
+    KillSession {
         session_name: String,
     },
 }

--- a/src/lib/ui.ts
+++ b/src/lib/ui.ts
@@ -217,16 +217,27 @@ export function renderAvailableSessionsList(terminalId: string, sessions: string
   const sessionItems = sessions
     .map(
       (session) => `
-      <button
-        class="attach-session-item w-full px-4 py-2 text-left bg-white dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 border border-gray-300 dark:border-gray-600 rounded transition-colors"
-        data-terminal-id="${terminalId}"
-        data-session-name="${escapeHtml(session)}"
-      >
-        <div class="flex items-center justify-between">
-          <span class="text-sm font-mono">${escapeHtml(session)}</span>
-          <span class="text-xs text-gray-500 dark:text-gray-400">Attach</span>
-        </div>
-      </button>
+      <div class="flex items-center gap-2">
+        <button
+          class="attach-session-item flex-1 px-4 py-2 text-left bg-white dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 border border-gray-300 dark:border-gray-600 rounded transition-colors"
+          data-terminal-id="${terminalId}"
+          data-session-name="${escapeHtml(session)}"
+        >
+          <div class="flex items-center justify-between">
+            <span class="text-sm font-mono">${escapeHtml(session)}</span>
+            <span class="text-xs text-gray-500 dark:text-gray-400">Attach</span>
+          </div>
+        </button>
+        <button
+          class="kill-session-btn px-3 py-2 bg-red-600 hover:bg-red-700 text-white rounded transition-colors"
+          data-session-name="${escapeHtml(session)}"
+          title="Kill session"
+        >
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+          </svg>
+        </button>
+      </div>
     `
     )
     .join("");

--- a/src/lib/worker-modal.ts
+++ b/src/lib/worker-modal.ts
@@ -179,10 +179,15 @@ async function launchWorker(
   }
 
   try {
+    // Get instance number
+    const instanceNumber = state.getNextAgentNumber();
+
     // Create terminal in workspace directory
     const terminalId = await invoke<string>("create_terminal", {
       name,
       workingDir: workspacePath,
+      role: "worker",
+      instanceNumber,
     });
 
     // Add to state
@@ -191,6 +196,7 @@ async function launchWorker(
       name,
       status: TerminalStatus.Busy,
       isPrimary: false,
+      role: "worker",
     });
 
     // Save updated state to config


### PR DESCRIPTION
## Summary

Improves terminal session identification by changing naming from `loom-<uuid>` to `loom-<uuid>-<role>-<counter>`, making it easier to identify sessions in tmux. Also adds the ability to kill orphaned sessions from the session recovery UI.

## Changes

### Backend (Daemon)
- Updated `CreateTerminal` request to accept `role` and `instance_number` parameters
- Added `KillSession` request type for killing sessions by name
- Changed terminal session naming format to: `loom-{uuid}-{role}-{instance}`
  - Example: `loom-abc12345-worker-2`, `loom-def67890-reviewer-3`
- Implemented `kill_session()` method in daemon terminal manager
- Updated IPC handler to pass role and instance_number

### Frontend (Tauri)
- Updated `create_terminal` command to accept role and instance_number
- Added `kill_session` command
- Registered new command in invoke_handler

### Frontend (TypeScript)
- Updated all terminal creation call sites to pass role and nextAgentNumber:
  - Plain terminal creation (new terminal button)
  - Factory reset workspace
  - Workspace initialization
  - Session recovery
- Added kill button (red X) next to each session in recovery UI
- Implemented confirmation dialog before killing sessions
- Auto-refresh session list after successful kill

## Naming Format

The new naming format makes it easy to identify sessions:
- **UUID**: First 8 characters for uniqueness (e.g., `abc12345`)
- **Role**: Terminal's role type (e.g., `worker`, `reviewer`, `default`)
- **Counter**: Global instance number from `nextAgentNumber` (e.g., `1`, `2`, `3`)

Examples:
- `loom-abc12345-default-1` - Plain shell terminal
- `loom-def67890-worker-2` - Worker terminal
- `loom-ghi13579-reviewer-3` - Reviewer terminal

## Test Plan

- [x] CI checks pass (lint, format, clippy, build, tests)
- [x] Terminal creation works with new naming format
- [x] Session recovery UI shows session names clearly
- [x] Kill button appears for each session
- [x] Confirmation dialog works correctly
- [x] Sessions are killed successfully
- [x] Session list refreshes after kill
- [x] Factory reset creates terminals with correct names
- [x] Workspace initialization creates terminals with correct names

## Screenshots

N/A - Terminal naming change is visible in tmux session lists

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)