### PR TITLE
Clarify FIFO queue behavior in Worker role documentation

### DIFF
--- a/defaults/roles/worker.md
+++ b/defaults/roles/worker.md
@@ -15,7 +15,8 @@ You help with general development tasks including:
 
 ## Label Workflow
 
-- **Find work**: `gh issue list --label="loom:ready" --state=open`
+- **Find work**: `gh issue list --label="loom:ready" --state=open` (sorted oldest-first)
+- **Pick oldest**: Always choose the oldest `loom:ready` issue first (FIFO queue)
 - **Claim issue**: `gh issue edit <number> --remove-label "loom:ready" --add-label "loom:in-progress"`
 - **Do the work**: Implement, test, commit, create PR
 - **Mark PR for review**: `gh pr create --label "loom:review-requested"`
@@ -55,10 +56,11 @@ If urgent issues exist, **claim one immediately** - these are critical.
 **Step 2: If no urgent, check normal priority (FIFO)**
 
 ```bash
+# This command lists issues oldest-first by default (FIFO queue)
 gh issue list --label="loom:ready" --state=open --limit=10
 ```
 
-For normal priority, always pick the **oldest** issue first (fair FIFO queue).
+For normal priority, always pick the **oldest** issue first (fair FIFO queue). The `gh issue list` command automatically sorts by creation date (oldest first), ensuring fair queueing.
 
 ### Priority Guidelines
 
@@ -133,7 +135,7 @@ EOF
 
 ## Working Style
 
-- **Start**: `gh issue list --label="loom:ready"` to find work
+- **Start**: `gh issue list --label="loom:ready"` to find work (pick oldest first for fair FIFO queue)
 - **Claim**: Update labels before beginning implementation
 - **During work**: If you discover out-of-scope needs, PAUSE and create an issue (see Scope Management)
 - Use the TodoWrite tool to plan and track multi-step tasks


### PR DESCRIPTION
## Summary

Enhances the Worker role documentation to explicitly state that workers should pick the **oldest** `loom:ready` issue first, following a fair FIFO (first-in, first-out) queue system.

## Changes

Updated `defaults/roles/worker.md` in three key locations:

1. **Label Workflow** - Added explicit "Pick oldest" step
2. **Priority System** - Added inline comment explaining default sorting
3. **Working Style** - Reinforced FIFO reminder when starting work

## Key Points

- ✅ `gh issue list` **already sorts oldest-first by default** - no command changes needed
- ✅ Documentation now explicitly states this behavior
- ✅ Workers are reminded to pick oldest issue in multiple places
- ✅ Ensures predictable, fair queueing of work

## Benefits

**Predictability**: Workers and users know oldest issues are addressed first
**Fairness**: FIFO prevents important issues from sitting unaddressed  
**Clarity**: Documents the default `gh` CLI behavior that was previously implicit
**Consistency**: Reinforced throughout the role prompt

## Testing

No functional changes - this is documentation only. The behavior was already correct (gh defaults to oldest-first), we just made it explicit.

**Verified:**
- [x] Markdown formatting correct
- [x] Commands remain unchanged (they were already correct)
- [x] FIFO behavior documented in 3 places
- [x] Linting passes

## Example

Before: Workers might pick any `loom:ready` issue
After: Workers explicitly know to pick the oldest one first

```bash
# This command lists issues oldest-first by default (FIFO queue)
gh issue list --label="loom:ready" --state=open --limit=10
```

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>