### PR TITLE
Enhance CI summary to explain why jobs were skipped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     needs:
+      - changes
       - frontend
       - rust-format
       - rust-build
@@ -188,6 +189,11 @@ jobs:
         if: always()
         with:
           script: |
+            // Get change detection outputs
+            const frontendChanged = '${{ needs.changes.outputs.frontend }}' === 'true';
+            const rustChanged = '${{ needs.changes.outputs.rust }}' === 'true';
+            const ciChanged = '${{ needs.changes.outputs.ci }}' === 'true';
+
             const jobs = {
               'Frontend': '${{ needs.frontend.result }}',
               'Rust Format': '${{ needs.rust-format.result }}',
@@ -201,6 +207,26 @@ jobs:
               return '❌ Fail';
             };
 
+            const getReason = (jobName, status) => {
+              if (status === 'success') {
+                return 'Files changed';
+              }
+
+              if (status === 'skipped') {
+                if (jobName === 'Frontend') {
+                  return 'No frontend changes detected';
+                } else {
+                  return 'No Rust changes detected';
+                }
+              }
+
+              if (status === 'failure') {
+                return 'Job failed';
+              }
+
+              return '';
+            };
+
             const allPassed = Object.values(jobs).every(
               status => status === 'success' || status === 'skipped'
             );
@@ -209,9 +235,32 @@ jobs:
               .addHeading(allPassed ? '✅ CI Summary - All Passed' : '❌ CI Summary - Some Failed')
               .addHeading('Job Results', 3)
               .addTable([
-                [{ data: 'Job', header: true }, { data: 'Status', header: true }],
-                ...Object.entries(jobs).map(([name, status]) => [name, statusIcon(status)])
+                [
+                  { data: 'Job', header: true },
+                  { data: 'Status', header: true },
+                  { data: 'Reason', header: true }
+                ],
+                ...Object.entries(jobs).map(([name, status]) => [
+                  name,
+                  statusIcon(status),
+                  getReason(name, status)
+                ])
               ]);
+
+            // Add collapsible change detection details
+            const detailsContent = `
+            **Path Filters Evaluated:**
+
+            ${frontendChanged ? '✅' : '❌'} Frontend changes (filters: \`src/**/*.{ts,tsx,js,jsx,json,css,html}\`, \`package*.json\`, \`tsconfig.json\`, \`biome.json\`)
+
+            ${rustChanged ? '✅' : '❌'} Rust changes (filters: \`src-tauri/**/*.rs\`, \`Cargo.{toml,lock}\`)
+
+            ${ciChanged ? '✅' : '❌'} CI workflow changes (filters: \`.github/workflows/**\`)
+
+            **Note:** CI workflow changes force all jobs to run for validation.
+            `;
+
+            summary.addDetails('Change Detection Details', detailsContent);
 
             if (context.eventName === 'pull_request') {
               summary.addRaw(`\n\n🔀 Triggered by: PR #${context.payload.pull_request.number}`);


### PR DESCRIPTION
## Summary

Implements the **hybrid approach (Option 3)** from #46, enhancing the CI summary with:
1. **"Reason" column** in job results table for quick scanning
2. **Collapsible "Change Detection Details"** section for debugging path filters

## Changes

Updated `.github/workflows/ci.yml`:

### 1. Added `changes` job to dependencies
Allows `all-checks` job to access path filter outputs for displaying reasons.

### 2. Added "Reason" column to results table
```
Job           | Status      | Reason
Frontend      | ✅ Pass     | Files changed
Rust Format   | ⏭️ Skipped  | No Rust changes detected
Rust Build    | ⏭️ Skipped  | No Rust changes detected
```

### 3. Added collapsible Change Detection Details
Shows which path filters matched/didn't match with actual glob patterns:

```
[Expandable] Change Detection Details
  ✅ Frontend changes (filters: \`src/**/*.{ts,tsx,js,jsx,json,css,html}\`, ...)
  ❌ No Rust changes (filters: \`src-tauri/**/*.rs\`, \`Cargo.{toml,lock}\`)
  ❌ No CI workflow changes (filters: \`.github/workflows/**\`)
```

## Implementation

**getReason() function:**
- Returns "Files changed" for successful jobs
- Returns specific message for skipped jobs (e.g., "No frontend changes detected")
- Returns "Job failed" for failures

**Collapsible details:**
- Uses \`summary.addDetails()\` for collapsible section
- Shows ✅/❌ for each filter category
- Displays actual glob patterns being evaluated
- Includes note about CI workflow changes

## Benefits

✅ **Quick scanning** - Reason column provides immediate context
✅ **Debugging** - Details section helps troubleshoot filter issues  
✅ **Transparency** - Contributors understand skip decisions
✅ **Maintainability** - Filter patterns self-documented

## Testing

This PR will trigger CI and demonstrate the new summary format:
- Since only \`.github/workflows/ci.yml\` changed, all jobs will run (CI filter matches)
- Summary will show "Files changed" for all jobs
- Details section will show ✅ for CI workflow changes

**Test scenarios covered by this PR:**
- [x] CI workflow changes (all jobs run)
- [ ] Frontend-only changes (Rust jobs skip) - needs separate PR
- [ ] Rust-only changes (Frontend skips) - needs separate PR
- [ ] No relevant changes (all skip) - needs separate PR

## Files Changed

- \`.github/workflows/ci.yml\` - Enhanced summary generation logic

## Related

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>