### PR TITLE
Improve workspace (.loom) settings system

### DIFF
--- a/.loom/roles/README.md
+++ b/.loom/roles/README.md
@@ -12,10 +12,30 @@ Each prompt consists of two files:
 
 - **`default.md`** - Plain shell environment, no specialized role
 - **`worker.md`** - General development worker for features, bugs, and refactoring
-- **`issues.md`** - Specialist for creating well-structured GitHub issues
+- **`issues.md`** - Specialist for creating well-structured GitHub issues (manual, user-driven)
 - **`reviewer.md`** - Code review specialist for thorough PR reviews
-- **`architect.md`** - System architecture and technical decision making
+- **`architect.md`** - System architecture and technical decision making (autonomous, proactive)
 - **`curator.md`** - Issue maintenance and quality improvement
+
+### Issues vs Architect: What's the Difference?
+
+These roles serve different purposes and are both valuable:
+
+**Issues Bot** (issues.md):
+- **Trigger**: Manual invocation by user
+- **Purpose**: Helps users format their requests into well-structured GitHub issues
+- **Input**: Takes what the user wants and structures it properly
+- **Scope**: Single issue at a time, user-directed
+- **Use case**: "I want feature X" → Issues Bot creates a proper GitHub issue
+
+**Architect Bot** (architect.md):
+- **Trigger**: Autonomous (runs every 15 minutes)
+- **Purpose**: Proactively scans codebase to identify improvement opportunities
+- **Input**: Analyzes code, docs, tests, CI/CD, security, performance
+- **Scope**: Entire codebase across all domains
+- **Use case**: Discovers problems you didn't know existed and proposes comprehensive solutions
+
+**Think of it this way**: Issues Bot is your secretary formatting memos you dictate, while Architect Bot is your technical advisor who reviews everything and suggests improvements.
 
 ## Usage
 

--- a/defaults/.loom-README.md
+++ b/defaults/.loom-README.md
@@ -1,5 +1,7 @@
 # Loom Workspace Configuration
 
+> **This project uses [Loom](https://github.com/rjwalters/loom)** - A multi-terminal desktop application that orchestrates AI-powered development agents using git worktrees and GitHub as the coordination layer.
+
 This directory contains workspace-specific Loom configuration that should be committed to version control for team sharing.
 
 ## Files in This Directory

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -397,7 +397,10 @@ fn list_role_files(workspace_path: &str) -> Result<Vec<String>, String> {
                 if extension == "md" {
                     if let Some(filename) = path.file_name() {
                         if let Some(name) = filename.to_str() {
-                            role_files.push(name.to_string());
+                            // Filter out README.md - it's documentation, not a role
+                            if name != "README.md" {
+                                role_files.push(name.to_string());
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Implements Issue #78 - improvements to the .loom workspace configuration system including better documentation, role file filtering, and clarification of the Issues vs Architect roles.

## Changes

### 1. Filter README.md from Role Selection

**File**: `src-tauri/src/main.rs:400-402`

Modified the `list_role_files` function to exclude README.md from the list of available roles:

```rust
// Filter out README.md - it's documentation, not a role
if name != "README.md" {
    role_files.push(name.to_string());
}
```

**Why**: README.md files in `.loom/roles/` are documentation, not role definitions. Showing them in the role dropdown was confusing to users.

### 2. Add Loom Marketing Banner to .loom/README.md

**File**: `defaults/.loom-README.md:3`

Added a prominent banner at the top of the .loom/README.md template:

```markdown
> **This project uses [Loom](https://github.com/rjwalters/loom)** - A multi-terminal desktop application that orchestrates AI-powered development agents using git worktrees and GitHub as the coordination layer.
```

**Why**: Open source projects that use Loom will commit `.loom/README.md` to their repositories. This banner serves as natural marketing for Loom while explaining to contributors what the `.loom/` directory is for.

### 3. Clarify Issues vs Architect Role Difference

**File**: `.loom/roles/README.md:20-38`

Added a comprehensive comparison section explaining the difference between Issues Bot and Architect Bot:

**Issues Bot**:
- Manual, user-driven
- Formats user requests into well-structured GitHub issues
- Single issue at a time
- Like a secretary taking dictation

**Architect Bot**:
- Autonomous, runs every 15 minutes
- Proactively scans codebase for improvements
- Analyzes entire codebase across all domains
- Like a technical advisor reviewing everything

**Why**: Users were confused about why both roles existed, thinking they were redundant. This clarifies they serve completely different purposes.

## Benefits

1. **Better UX**: Users no longer see README.md as a selectable "role" in terminal settings
2. **Marketing**: Open source projects using Loom get natural marketing via their `.loom/README.md` on GitHub
3. **Clarity**: Clear explanation prevents confusion about the two issue-creation-related roles
4. **Discoverability**: Improves discoverability of Loom for developers exploring projects that use it

## Testing

- [x] All checks pass (lint, format, clippy, build, tests)
- [x] README.md will not appear in role dropdown
- [x] .loom/README.md template includes Loom attribution with link
- [x] Role difference explanation is clear and actionable

## Related

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)