### PR TITLE
Simplify curator workflow to proactively mark ready issues

### DIFF
--- a/defaults/roles/curator.json
+++ b/defaults/roles/curator.json
@@ -2,7 +2,7 @@
   "name": "Issue Curator",
   "description": "Enhances approved issues and prepares them for implementation",
   "defaultInterval": 300000,
-  "defaultIntervalPrompt": "Find approved issues (without loom:proposal label) that need curation. Enhance one issue with implementation details, test plans, and code references, then mark it as `loom:ready` when complete.",
+  "defaultIntervalPrompt": "Find unlabeled open issues (without loom:proposal, loom:ready, or loom:in-progress). If already well-formed (clear problem, acceptance criteria, test plan), mark as loom:ready immediately. Otherwise, enhance with details first, then mark loom:ready.",
   "autonomousRecommended": true,
   "suggestedWorkerType": "claude",
   "gitIdentity": {

--- a/defaults/roles/curator.md
+++ b/defaults/roles/curator.md
@@ -44,6 +44,67 @@ gh issue list --state=open --limit=20
 # Then manually check which ones need curation
 ```
 
+## Triage: Ready or Needs Enhancement?
+
+When you find an unlabeled issue, **first assess if it's already implementation-ready**:
+
+### Quick Quality Checklist
+
+- ✅ **Clear problem statement** - Explains "why" this matters
+- ✅ **Acceptance criteria** - Testable success metrics or checklist
+- ✅ **Test plan or guidance** - How to verify the solution works
+- ✅ **No obvious blockers** - No unresolved dependencies mentioned
+
+### Decision Tree
+
+**If ALL checkboxes pass:**
+✅ **Mark it `loom:ready` immediately** - the issue is already complete:
+
+```bash
+gh issue edit <number> --add-label "loom:ready"
+```
+
+**If ANY checkboxes fail:**
+⚠️ **Enhance first, then mark ready:**
+
+1. Add missing problem context or acceptance criteria
+2. Include implementation guidance or options
+3. Add test plan checklist
+4. Check/add dependencies section if needed
+5. Then mark `loom:ready`
+
+### Examples
+
+**Already Ready** (mark immediately):
+```markdown
+Issue #84: "Expand frontend unit test coverage"
+- ✅ Detailed problem statement (low coverage creates risk)
+- ✅ Lists specific acceptance criteria (which files to test)
+- ✅ Includes test plan (Phase 1, 2, 3 approach)
+- ✅ No dependencies mentioned
+
+→ Action: `gh issue edit 84 --add-label "loom:ready"`
+→ Result: Worker can start immediately
+```
+
+**Needs Enhancement** (improve first):
+```markdown
+Issue #99: "fix the crash bug"
+- ❌ Vague title and description
+- ❌ No reproduction steps
+- ❌ No acceptance criteria
+
+→ Action: Ask for reproduction steps, add acceptance criteria
+→ Then: Mark `loom:ready` after enhancement complete
+```
+
+### Why This Matters
+
+1. **Faster Workflow**: Well-formed issues move to implementation without delay
+2. **Quality Gate**: Every `loom:ready` issue has been explicitly reviewed
+3. **Prevents Bypass**: Workers can trust `loom:ready` issues are truly ready
+4. **Clear Standards**: Establishes what "ready" means
+
 ## Curation Activities
 
 ### Enhancement


### PR DESCRIPTION
## Summary

Changes the Curator role to immediately mark well-formed issues as `loom:ready` without requiring manual enhancement first. This prevents workflow bypasses where issues go straight to `loom:in-progress`.

## Changes

**Updated `defaults/roles/curator.json`:**
- Updated `defaultIntervalPrompt` to emphasize immediate triage
- New prompt: "Find unlabeled open issues (without loom:proposal, loom:ready, or loom:in-progress). If already well-formed (clear problem, acceptance criteria, test plan), mark as loom:ready immediately. Otherwise, enhance with details first, then mark loom:ready."

**Added to `defaults/roles/curator.md`:**
- New "Triage: Ready or Needs Enhancement?" section (lines 47-107)
- Quick Quality Checklist (problem statement, acceptance criteria, test plan, no blockers)
- Decision Tree (mark ready immediately vs enhance first)
- Examples using Issue #84 as "already ready" case
- "Why This Matters" explanation of workflow benefits

## New Workflow

1. Curator finds unlabeled issue
2. Checks quality checklist
3. If ALL pass → mark loom:ready immediately
4. If ANY fail → enhance first, then mark loom:ready

## Problem Solved

Issue #84 went directly from unlabeled → loom:in-progress, bypassing the loom:ready triage step. This ensures every loom:ready issue has been explicitly reviewed.

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)