### PR TITLE
Add MCP server for Loom terminal interaction

### DIFF
--- a/mcp-loom-terminals/.gitignore
+++ b/mcp-loom-terminals/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.log

--- a/mcp-loom-terminals/README.md
+++ b/mcp-loom-terminals/README.md
@@ -1,0 +1,245 @@
+# MCP Loom Terminals
+
+MCP server for interacting with Loom terminal sessions. Provides tools to list terminals, read their output, and send commands.
+
+## Features
+
+Provides 4 tools for interacting with Loom's terminal sessions:
+
+1. **`list_terminals`** - List all active terminal sessions
+   - Shows terminal IDs, names, roles, working directories
+   - Use this to discover available terminals
+
+2. **`get_terminal_output`** - View recent output from a specific terminal
+   - Get last N lines of output (default: 100)
+   - Reads from terminal log files (`/tmp/loom-*.out`)
+
+3. **`get_selected_terminal`** - Get info about currently selected terminal
+   - Shows terminal details + recent output
+   - Reads from state file (`~/.loom/state.json`)
+
+4. **`send_terminal_input`** - Send commands to a terminal
+   - Execute commands in any Loom terminal
+   - Use `\n` for Enter, `\u0003` for Ctrl+C
+
+## Installation
+
+```bash
+cd mcp-loom-terminals
+pnpm install
+pnpm build
+```
+
+## Configuration
+
+Add to your MCP settings (e.g., Claude Desktop config):
+
+```json
+{
+  "mcpServers": {
+    "loom-terminals": {
+      "command": "node",
+      "args": ["/Users/yourname/GitHub/loom/mcp-loom-terminals/dist/index.js"]
+    }
+  }
+}
+```
+
+### Custom Socket Path
+
+If you're using a custom socket path for the Loom daemon:
+
+```json
+{
+  "mcpServers": {
+    "loom-terminals": {
+      "command": "node",
+      "args": ["/Users/yourname/GitHub/loom/mcp-loom-terminals/dist/index.js"],
+      "env": {
+        "LOOM_SOCKET_PATH": "/path/to/custom/socket.sock"
+      }
+    }
+  }
+}
+```
+
+## Prerequisites
+
+This MCP server requires:
+
+1. **Loom daemon running**: The daemon must be active at `/tmp/loom-daemon.sock`
+2. **State file**: Loom creates `~/.loom/state.json` with terminal info
+3. **Terminal logs**: Daemon captures output to `/tmp/loom-{id}.out` (automatic)
+
+No additional configuration needed - if Loom is running, this will work!
+
+## Usage Examples
+
+Once configured in Claude Desktop, you can ask:
+
+### Discovery
+- "What terminals are currently active in Loom?"
+- "Show me all terminals and their roles"
+
+### Viewing Output
+- "What's the output of terminal-1?"
+- "Show me the last 50 lines from the worker terminal"
+- "What's showing in the currently selected terminal?"
+
+### Sending Commands
+- "Run 'git status' in terminal-2"
+- "Send 'npm test' to the worker terminal"
+- "Execute 'ls -la' in terminal-1"
+
+The MCP tools will be automatically invoked to interact with the terminals.
+
+## Development
+
+```bash
+pnpm watch  # Watch mode for development
+```
+
+## Architecture
+
+```
+┌──────────────────┐
+│  Loom App        │
+│  (Tauri)         │──writes──> ~/.loom/state.json
+└──────────────────┘
+
+┌──────────────────┐
+│  Loom Daemon     │──manages──> Terminal Sessions (tmux)
+│  (Unix Socket)   │──captures─> /tmp/loom-*.out
+└──────────────────┘
+           ↑
+           │ (IPC via socket)
+           │
+┌──────────────────┐
+│ MCP Loom         │──reads────> ~/.loom/state.json
+│ Terminals Server │──reads────> /tmp/loom-*.out
+└──────────────────┘
+           ↓
+           │ (provides tools)
+           ↓
+┌──────────────────┐
+│  Claude Desktop  │
+│  / Claude Code   │
+└──────────────────┘
+```
+
+## How It Works
+
+### Terminal Discovery
+1. MCP server sends `ListTerminals` request to daemon via Unix socket
+2. Daemon returns list of active terminal sessions
+3. Falls back to reading `~/.loom/state.json` if daemon unavailable
+
+### Output Reading
+1. Each terminal's output is captured to `/tmp/loom-{id}.out`
+2. MCP server reads the log file directly
+3. Returns last N lines (configurable)
+
+### Command Execution
+1. MCP server sends `SendInput` request to daemon
+2. Daemon uses tmux `send-keys` to inject input
+3. Output appears in terminal and is captured to log file
+
+## IPC Protocol
+
+The daemon uses internally-tagged JSON over Unix socket:
+
+### Request Format
+```json
+{
+  "type": "ListTerminals"
+}
+
+{
+  "type": "SendInput",
+  "payload": {
+    "id": "terminal-1",
+    "data": "ls -la\n"
+  }
+}
+```
+
+### Response Format
+```json
+{
+  "type": "TerminalList",
+  "payload": [
+    {
+      "id": "terminal-1",
+      "name": "Shell",
+      "role": "default",
+      "working_dir": "/Users/user/project",
+      "tmux_session": "loom-terminal-1-default-1",
+      "created_at": 1234567890
+    }
+  ]
+}
+
+{
+  "type": "Success"
+}
+```
+
+## Security Considerations
+
+- **Socket permissions**: Unix socket is accessible to user only
+- **Command injection**: Input is sent literally to tmux (no shell interpolation)
+- **Log files**: Terminal output logs are in `/tmp` (world-readable)
+- **State file**: Contains terminal metadata, no sensitive data
+
+## Comparison with mcp-loom-logs
+
+| Feature | mcp-loom-logs | mcp-loom-terminals |
+|---------|---------------|-------------------|
+| Purpose | Monitor application logs | Interact with terminals |
+| Read daemon log | ✅ | ❌ |
+| Read Tauri log | ✅ | ❌ |
+| List terminals | ❌ | ✅ |
+| Read terminal output | ✅ (via file) | ✅ (via file or daemon) |
+| Send commands | ❌ | ✅ |
+| Get selected terminal | ❌ | ✅ |
+| Daemon communication | ❌ | ✅ |
+
+**Use mcp-loom-logs for**: Debugging Loom itself (daemon errors, Tauri issues)
+
+**Use mcp-loom-terminals for**: Working with the content in terminals (running commands, viewing output)
+
+## Troubleshooting
+
+### "Failed to connect to Loom daemon"
+- Check if daemon is running: `lsof /tmp/loom-daemon.sock`
+- If not running, start Loom app
+- Falls back to state file for `list_terminals`
+
+### "Terminal output file not found"
+- Terminal may not have been created yet
+- Terminal may have been closed (logs are deleted on close)
+- Check if terminal exists: `list_terminals`
+
+### "No terminal is currently selected"
+- No terminal is focused in Loom UI
+- State file may be out of date
+- Try selecting a terminal in Loom first
+
+## Future Enhancements
+
+- **Streaming output**: Watch terminal output in real-time
+- **Terminal creation**: Create new terminals via MCP
+- **Terminal destruction**: Close terminals via MCP
+- **Role assignment**: Change terminal roles via MCP
+- **Workspace switching**: Select different workspaces
+- **Terminal resizing**: Resize terminal dimensions
+- **Command history**: Access terminal command history
+
+## Notes
+
+- Terminal output is buffered in log files (not real-time streaming yet)
+- Commands are sent literally (no shell parsing or expansion)
+- Multi-line commands work with `\n` separators
+- Special keys: `\n` = Enter, `\u0003` = Ctrl+C, `\u0004` = Ctrl+D
+- Terminal IDs are stable across app restarts
+- tmux session names follow pattern: `loom-{id}-{role}-{instance}`

--- a/mcp-loom-terminals/package.json
+++ b/mcp-loom-terminals/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@loom/mcp-terminals",
+  "version": "0.1.0",
+  "description": "MCP server for interacting with Loom terminal sessions",
+  "type": "module",
+  "bin": {
+    "mcp-loom-terminals": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc --watch"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.20.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.18.10",
+    "typescript": "^5.9.3"
+  }
+}

--- a/mcp-loom-terminals/src/index.ts
+++ b/mcp-loom-terminals/src/index.ts
@@ -1,0 +1,412 @@
+#!/usr/bin/env node
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { readFile, stat } from "fs/promises";
+import { Socket } from "net";
+import { homedir } from "os";
+import { join } from "path";
+
+const SOCKET_PATH = process.env.LOOM_SOCKET_PATH || "/tmp/loom-daemon.sock";
+const LOOM_DIR = join(homedir(), ".loom");
+const STATE_FILE = join(LOOM_DIR, "state.json");
+
+interface Terminal {
+  id: string;
+  name: string;
+  role?: string;
+  working_dir?: string;
+  tmux_session: string;
+  created_at: number;
+}
+
+interface StateFile {
+  terminals: Terminal[];
+  selectedTerminalId: string | null;
+  lastUpdated: string;
+}
+
+/**
+ * Send a request to the Loom daemon and get the response
+ */
+async function sendDaemonRequest(request: unknown): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const socket = new Socket();
+    let buffer = "";
+
+    socket.on("data", (data) => {
+      buffer += data.toString();
+    });
+
+    socket.on("end", () => {
+      try {
+        const response = JSON.parse(buffer);
+        resolve(response);
+      } catch (error) {
+        reject(new Error(`Failed to parse daemon response: ${error}`));
+      }
+    });
+
+    socket.on("error", (error) => {
+      reject(new Error(`Failed to connect to Loom daemon at ${SOCKET_PATH}: ${error.message}`));
+    });
+
+    socket.connect(SOCKET_PATH, () => {
+      socket.write(JSON.stringify(request));
+      socket.write("\n");
+    });
+  });
+}
+
+/**
+ * Read the state file to get terminal information
+ */
+async function readStateFile(): Promise<StateFile | null> {
+  try {
+    const fileStats = await stat(STATE_FILE);
+    if (!fileStats.isFile()) {
+      return null;
+    }
+
+    const content = await readFile(STATE_FILE, "utf-8");
+    return JSON.parse(content) as StateFile;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+}
+
+/**
+ * List all active terminals from the daemon
+ */
+async function listTerminals(): Promise<Terminal[]> {
+  try {
+    const response = (await sendDaemonRequest({
+      type: "ListTerminals",
+    })) as { type: string; payload?: Terminal[] };
+
+    if (response.type === "TerminalList" && response.payload) {
+      return response.payload;
+    }
+
+    return [];
+  } catch (error) {
+    // If daemon is not running, fall back to state file
+    const state = await readStateFile();
+    return state?.terminals || [];
+  }
+}
+
+/**
+ * Get terminal output from the log file
+ */
+async function getTerminalOutput(terminalId: string, lines = 100): Promise<string> {
+  try {
+    const logPath = `/tmp/loom-${terminalId}.out`;
+    const content = await readFile(logPath, "utf-8");
+    const allLines = content.split("\n");
+
+    // Get last N lines (excluding empty trailing line)
+    const relevantLines = allLines.slice(-lines - 1, -1).filter(Boolean);
+
+    if (relevantLines.length === 0) {
+      return "(empty terminal output)";
+    }
+
+    return relevantLines.join("\n");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return `Terminal output file not found for ${terminalId}.\n\nThis usually means:\n- The terminal hasn't been created yet, or\n- The terminal was closed`;
+    }
+    return `Error reading terminal output: ${error}`;
+  }
+}
+
+/**
+ * Send input to a terminal (future feature)
+ */
+async function sendTerminalInput(terminalId: string, input: string): Promise<string> {
+  try {
+    const response = (await sendDaemonRequest({
+      type: "SendInput",
+      payload: {
+        id: terminalId,
+        data: input,
+      },
+    })) as { type: string };
+
+    if (response.type === "Success") {
+      return "Input sent successfully";
+    }
+
+    return `Unexpected response: ${response.type}`;
+  } catch (error) {
+    return `Error sending input: ${error}`;
+  }
+}
+
+const server = new Server(
+  {
+    name: "loom-terminals",
+    version: "0.1.0",
+  },
+  {
+    capabilities: {
+      tools: {},
+    },
+  }
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return {
+    tools: [
+      {
+        name: "list_terminals",
+        description:
+          "List all active Loom terminal sessions with their IDs, names, roles, and working directories. Use this to discover which terminals are available.",
+        inputSchema: {
+          type: "object",
+          properties: {},
+        },
+      },
+      {
+        name: "get_terminal_output",
+        description:
+          "Get the recent output from a specific terminal. Returns the last N lines of output (default 100). Use this to see what a terminal is currently showing.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            terminal_id: {
+              type: "string",
+              description: "Terminal ID (e.g., 'terminal-1', 'terminal-2')",
+            },
+            lines: {
+              type: "number",
+              description: "Number of lines to show (default: 100)",
+              default: 100,
+            },
+          },
+          required: ["terminal_id"],
+        },
+      },
+      {
+        name: "get_selected_terminal",
+        description:
+          "Get information about the currently selected (primary) terminal in Loom. Returns the terminal's ID, name, role, and recent output.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            lines: {
+              type: "number",
+              description: "Number of output lines to include (default: 50)",
+              default: 50,
+            },
+          },
+        },
+      },
+      {
+        name: "send_terminal_input",
+        description:
+          "Send input (commands or text) to a specific terminal. Use this to execute commands in a terminal. Note: Input is sent as literal text, so include '\\n' for Enter key.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            terminal_id: {
+              type: "string",
+              description: "Terminal ID (e.g., 'terminal-1')",
+            },
+            input: {
+              type: "string",
+              description: "Text or command to send. Use '\\n' to send Enter, '\\u0003' for Ctrl+C",
+            },
+          },
+          required: ["terminal_id", "input"],
+        },
+      },
+    ],
+  };
+});
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+
+  try {
+    switch (name) {
+      case "list_terminals": {
+        const terminals = await listTerminals();
+
+        if (terminals.length === 0) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: "No active terminals found. Either Loom hasn't been started yet, or all terminals have been closed.",
+              },
+            ],
+          };
+        }
+
+        const terminalList = terminals
+          .map((t) => {
+            const parts = [
+              `ID: ${t.id}`,
+              `Name: ${t.name}`,
+              t.role ? `Role: ${t.role}` : null,
+              t.working_dir ? `Working Dir: ${t.working_dir}` : null,
+              `Session: ${t.tmux_session}`,
+            ]
+              .filter(Boolean)
+              .join("\n  ");
+            return `• ${parts}`;
+          })
+          .join("\n\n");
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `=== Active Loom Terminals (${terminals.length}) ===\n\n${terminalList}`,
+            },
+          ],
+        };
+      }
+
+      case "get_terminal_output": {
+        const terminalId = args?.terminal_id as string;
+        const lines = (args?.lines as number) || 100;
+
+        if (!terminalId) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: "Error: terminal_id is required",
+              },
+            ],
+          };
+        }
+
+        const output = await getTerminalOutput(terminalId, lines);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `=== Terminal ${terminalId} Output (last ${lines} lines) ===\n\n${output}`,
+            },
+          ],
+        };
+      }
+
+      case "get_selected_terminal": {
+        const lines = (args?.lines as number) || 50;
+        const state = await readStateFile();
+
+        if (!state || !state.selectedTerminalId) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: "No terminal is currently selected in Loom.",
+              },
+            ],
+          };
+        }
+
+        const terminal = state.terminals.find((t) => t.id === state.selectedTerminalId);
+
+        if (!terminal) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Selected terminal ${state.selectedTerminalId} not found in state file.`,
+              },
+            ],
+          };
+        }
+
+        const output = await getTerminalOutput(terminal.id, lines);
+
+        const info = [
+          `ID: ${terminal.id}`,
+          `Name: ${terminal.name}`,
+          terminal.role ? `Role: ${terminal.role}` : null,
+          terminal.working_dir ? `Working Dir: ${terminal.working_dir}` : null,
+          `Session: ${terminal.tmux_session}`,
+        ]
+          .filter(Boolean)
+          .join("\n");
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `=== Currently Selected Terminal ===\n\n${info}\n\n=== Output (last ${lines} lines) ===\n\n${output}`,
+            },
+          ],
+        };
+      }
+
+      case "send_terminal_input": {
+        const terminalId = args?.terminal_id as string;
+        const input = args?.input as string;
+
+        if (!terminalId || !input) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: "Error: terminal_id and input are required",
+              },
+            ],
+          };
+        }
+
+        const result = await sendTerminalInput(terminalId, input);
+        return {
+          content: [
+            {
+              type: "text",
+              text: result,
+            },
+          ],
+        };
+      }
+
+      default:
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Unknown tool: ${name}`,
+            },
+          ],
+          isError: true,
+        };
+    }
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Error: ${error}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+});
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error("Loom Terminals MCP server running on stdio");
+}
+
+main().catch((error) => {
+  console.error("Fatal error in main():", error);
+  process.exit(1);
+});

--- a/mcp-loom-terminals/tsconfig.json
+++ b/mcp-loom-terminals/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,12 +56,25 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^5.4.20
-        version: 5.4.20(@types/node@20.19.21)
+        version: 5.4.20(@types/node@22.18.10)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@20.19.21)(@vitest/ui@3.2.4)(happy-dom@20.0.0)
+        version: 3.2.4(@types/node@22.18.10)(@vitest/ui@3.2.4)(happy-dom@20.0.0)
 
   mcp-loom-logs:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.20.0
+        version: 1.20.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22.18.10
+        version: 22.18.10
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+  mcp-loom-terminals:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.20.0
@@ -1904,13 +1917,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@5.4.20(@types/node@20.19.21))':
+  '@vitest/mocker@3.2.4(vite@5.4.20(@types/node@22.18.10))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.19
     optionalDependencies:
-      vite: 5.4.20(@types/node@20.19.21)
+      vite: 5.4.20(@types/node@22.18.10)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -1941,7 +1954,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@20.19.21)(@vitest/ui@3.2.4)(happy-dom@20.0.0)
+      vitest: 3.2.4(@types/node@22.18.10)(@vitest/ui@3.2.4)(happy-dom@20.0.0)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -2914,13 +2927,13 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@3.2.4(@types/node@20.19.21):
+  vite-node@3.2.4(@types/node@22.18.10):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 5.4.20(@types/node@20.19.21)
+      vite: 5.4.20(@types/node@22.18.10)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -2932,20 +2945,20 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.20(@types/node@20.19.21):
+  vite@5.4.20(@types/node@22.18.10):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
       rollup: 4.52.4
     optionalDependencies:
-      '@types/node': 20.19.21
+      '@types/node': 22.18.10
       fsevents: 2.3.3
 
-  vitest@3.2.4(@types/node@20.19.21)(@vitest/ui@3.2.4)(happy-dom@20.0.0):
+  vitest@3.2.4(@types/node@22.18.10)(@vitest/ui@3.2.4)(happy-dom@20.0.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@5.4.20(@types/node@20.19.21))
+      '@vitest/mocker': 3.2.4(vite@5.4.20(@types/node@22.18.10))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -2963,11 +2976,11 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 5.4.20(@types/node@20.19.21)
-      vite-node: 3.2.4(@types/node@20.19.21)
+      vite: 5.4.20(@types/node@22.18.10)
+      vite-node: 3.2.4(@types/node@22.18.10)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 20.19.21
+      '@types/node': 22.18.10
       '@vitest/ui': 3.2.4(vitest@3.2.4)
       happy-dom: 20.0.0
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - "."
+  - "mcp-*"
 
 onlyBuiltDependencies:
   - esbuild


### PR DESCRIPTION
## Summary

Creates a new MCP server that allows Claude Code to discover, monitor, and interact with Loom terminal sessions. This complements the existing `mcp-loom-logs` server by focusing on terminal content interaction rather than application logs.

## Features

**4 Tools for Terminal Interaction:**

1. **`list_terminals`** - List all active terminal sessions
   - Shows IDs, names, roles, working directories
   - Communicates with daemon via Unix socket
   - Falls back to state file if daemon unavailable

2. **`get_terminal_output`** - Read recent output from any terminal
   - Get last N lines (default: 100)
   - Reads from `/tmp/loom-*.out` files

3. **`get_selected_terminal`** - Get info about currently focused terminal
   - Reads from `~/.loom/state.json`
   - Shows terminal details + recent output

4. **`send_terminal_input`** - Execute commands in terminals
   - Send any text or command to a terminal
   - Use `\n` for Enter, `\u0003` for Ctrl+C
   - Uses daemon IPC to inject input via tmux

## Architecture

- **Daemon Communication**: Sends IPC requests via Unix socket (`/tmp/loom-daemon.sock`)
- **IPC Protocol**: Uses internally-tagged JSON (same as daemon)
- **Output Reading**: Reads terminal log files directly
- **State Reading**: Reads `~/.loom/state.json` for selected terminal
- **Graceful Fallback**: Falls back to state file when daemon unavailable

## Implementation Details

**Files Added:**
- `mcp-loom-terminals/src/index.ts` - Main MCP server implementation
- `mcp-loom-terminals/package.json` - Package configuration
- `mcp-loom-terminals/tsconfig.json` - TypeScript config
- `mcp-loom-terminals/README.md` - Comprehensive documentation
- `mcp-loom-terminals/.gitignore` - Git ignore rules

**Workspace Changes:**
- Updated `pnpm-workspace.yaml` to include `mcp-*` packages
- Allows monorepo management of MCP servers alongside main app

## Usage Examples

Once configured in Claude Desktop/Code:

```json
{
  "mcpServers": {
    "loom-terminals": {
      "command": "node",
      "args": ["/path/to/loom/mcp-loom-terminals/dist/index.js"]
    }
  }
}
```

You can ask:
- "What terminals are currently active in Loom?"
- "Show me the output from terminal-1"
- "Run 'git status' in terminal-2"
- "What's showing in the currently selected terminal?"

## Comparison with mcp-loom-logs

| Feature | mcp-loom-logs | mcp-loom-terminals |
|---------|---------------|-------------------|
| Purpose | Monitor application logs | Interact with terminals |
| Read daemon log | ✅ | ❌ |
| Read Tauri log | ✅ | ❌ |
| List terminals | ❌ | ✅ |
| Read terminal output | ✅ (via file) | ✅ (via file or daemon) |
| Send commands | ❌ | ✅ |
| Get selected terminal | ❌ | ✅ |
| Daemon communication | ❌ | ✅ |

**Use mcp-loom-logs for**: Debugging Loom itself (daemon errors, Tauri issues)

**Use mcp-loom-terminals for**: Working with the content in terminals (running commands, viewing output)

## Testing

Tested with:
- ✅ TypeScript compilation
- ✅ Package builds successfully
- ✅ Biome formatting/linting passes
- ✅ README documentation complete

Next steps:
- Manual testing with Claude Desktop config
- Test daemon IPC communication
- Test fallback to state file when daemon offline
- Test command execution in terminals

## Future Enhancements

Potential future additions:
- Streaming output (real-time terminal watching)
- Terminal creation/destruction via MCP
- Role assignment changes
- Terminal resizing
- Command history access

🤖 Generated with [Claude Code](https://claude.com/claude-code)