### PR TITLE
Add MCP server configuration for Loom monitoring tools

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -6,6 +6,7 @@ This directory contains Claude Code configuration for the Loom project.
 
 - **`settings.json`**: Team-wide permissions and settings (committed to git)
 - **`settings.local.json`**: Personal preferences (gitignored, create if needed)
+- **`../.mcp.json`**: MCP server configuration (at project root, committed to git)
 
 ## Pre-approved Commands
 
@@ -63,6 +64,26 @@ Create `.claude/settings.local.json` for personal preferences:
 ```
 
 Local settings override team settings for that specific configuration key.
+
+## MCP Servers
+
+The project includes two MCP servers configured in `.mcp.json`:
+
+### loom-logs
+Monitor Loom application logs:
+- `tail_daemon_log` - View daemon logs (`~/.loom/daemon.log`)
+- `tail_tauri_log` - View Tauri app logs (`~/.loom/tauri.log`)
+- `list_terminal_logs` - List terminal output files
+- `tail_terminal_log` - View specific terminal output
+
+### loom-terminals
+Interact with Loom terminal sessions:
+- `list_terminals` - List all active terminals
+- `get_terminal_output` - Read terminal output
+- `get_selected_terminal` - Get current terminal info
+- `send_terminal_input` - Execute commands in terminals
+
+**Note**: When you first open the project, Claude Code will prompt you to approve these MCP servers. You can also enable them automatically by setting `"enableAllProjectMcpServers": true` in your `.claude/settings.local.json`.
 
 ## Documentation
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "loom-logs": {
+      "command": "node",
+      "args": ["${workspaceFolder}/mcp-loom-logs/dist/index.js"]
+    },
+    "loom-terminals": {
+      "command": "node",
+      "args": ["${workspaceFolder}/mcp-loom-terminals/dist/index.js"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds project-level MCP server configuration (`.mcp.json`) so that fresh Claude Code instances automatically discover the Loom monitoring tools.

## Changes

**Added Files:**
- `.mcp.json` - Project-level MCP server configuration at root
  - Uses `${workspaceFolder}` variable for portable paths
  - Auto-discovered by Claude Code when opening the project

**Updated Files:**
- `.claude/README.md` - Documented the MCP server setup
  - Explains the two MCP servers and their available tools
  - Notes about approval process and auto-enable option

## MCP Servers Configured

### 1. loom-logs
Monitor Loom application logs:
- `tail_daemon_log` - View daemon activity and errors
- `tail_tauri_log` - View frontend/UI logs
- `list_terminal_logs` - List available terminal outputs
- `tail_terminal_log` - View specific terminal output

### 2. loom-terminals
Interact with Loom terminal sessions:
- `list_terminals` - Discover all active terminals
- `get_terminal_output` - Read terminal output
- `get_selected_terminal` - Get focused terminal info
- `send_terminal_input` - Execute commands in terminals

## Benefits

1. **Automatic Discovery**: Fresh Claude Code instances see MCP servers immediately
2. **AI Capabilities**: Enables Claude to monitor factory reset, debug issues, run commands
3. **Team Consistency**: All team members get the same MCP configuration
4. **Portable**: Uses workspace-relative paths, works on any machine

## Usage

When opening the project, Claude Code will prompt to approve these MCP servers.

**Optional**: Auto-approve all project MCP servers by adding to `.claude/settings.local.json`:
```json
{
  "enableAllProjectMcpServers": true
}
```

## Testing

- ✅ `.mcp.json` created with correct syntax
- ✅ Documentation updated in README
- ✅ Both MCP servers tested and working locally
- ✅ Biome formatting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)