### PR TITLE
Add MCP server for Loom UI interaction

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -83,6 +83,13 @@ Interact with Loom terminal sessions:
 - `get_selected_terminal` - Get current terminal info
 - `send_terminal_input` - Execute commands in terminals
 
+### loom-ui
+Interact with the Loom application UI and state:
+- `read_console_log` - View browser console output (JavaScript errors, console.log statements)
+- `read_state_file` - Read current application state (.loom/state.json)
+- `read_config_file` - Read terminal configurations (.loom/config.json)
+- `trigger_factory_reset` - Trigger factory reset (placeholder, not yet functional)
+
 **Note**: When you first open the project, Claude Code will prompt you to approve these MCP servers. You can also enable them automatically by setting `"enableAllProjectMcpServers": true` in your `.claude/settings.local.json`.
 
 ## Documentation

--- a/.mcp.json
+++ b/.mcp.json
@@ -7,6 +7,13 @@
     "loom-terminals": {
       "command": "node",
       "args": ["${workspaceFolder}/mcp-loom-terminals/dist/index.js"]
+    },
+    "loom-ui": {
+      "command": "node",
+      "args": ["${workspaceFolder}/mcp-loom-ui/dist/index.js"],
+      "env": {
+        "LOOM_WORKSPACE": "${workspaceFolder}"
+      }
     }
   }
 }

--- a/mcp-loom-ui/package.json
+++ b/mcp-loom-ui/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@loom/mcp-ui",
+  "version": "0.1.0",
+  "description": "MCP server for interacting with Loom UI (console logs, events, actions)",
+  "type": "module",
+  "bin": {
+    "mcp-loom-ui": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc --watch"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.20.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.18.10",
+    "typescript": "^5.9.3"
+  }
+}

--- a/mcp-loom-ui/src/index.ts
+++ b/mcp-loom-ui/src/index.ts
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+
+/**
+ * MCP Server for Loom UI Interaction
+ *
+ * Provides tools for Claude Code to interact with the Loom application:
+ * - Read browser console logs (via Tauri log file)
+ * - Trigger UI events (factory reset, workspace changes, etc.)
+ * - Monitor application state
+ */
+
+import { spawn } from "node:child_process";
+import { access, readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+const LOOM_DIR = join(homedir(), ".loom");
+const CONSOLE_LOG_PATH = join(LOOM_DIR, "console.log");
+
+/**
+ * Read the browser console log file
+ */
+async function readConsoleLog(lines = 100): Promise<string> {
+  try {
+    await access(CONSOLE_LOG_PATH);
+    const content = await readFile(CONSOLE_LOG_PATH, "utf-8");
+    const allLines = content.split("\n");
+    const relevantLines = allLines.slice(-lines).filter(Boolean);
+
+    if (relevantLines.length === 0) {
+      return "(console log is empty)";
+    }
+
+    return relevantLines.join("\n");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return "Console log file not found. The Loom app may need to enable console logging.";
+    }
+    throw error;
+  }
+}
+
+/**
+ * Trigger a Tauri menu event
+ */
+async function triggerMenuEvent(eventName: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    // Use osascript to trigger menu items via macOS accessibility
+    // This requires the Loom app to be running and focused
+
+    const script = `
+      tell application "System Events"
+        tell process "loom"
+          set frontmost to true
+          -- Simulate menu navigation based on event name
+          -- This is a placeholder - actual implementation would need to map
+          -- event names to specific menu paths
+        end tell
+      end tell
+    `;
+
+    // For now, just return a message indicating the limitation
+    resolve(
+      `Menu event triggering not yet implemented. Event: ${eventName}\n\nTo implement this, we need to either:\n1. Add Tauri IPC endpoints for triggering events\n2. Use macOS accessibility API via osascript\n3. Use a Chrome DevTools Protocol connection`
+    );
+  });
+}
+
+/**
+ * Read the Loom state file
+ */
+async function readStateFile(): Promise<string> {
+  try {
+    const workspacePath = process.env.LOOM_WORKSPACE || join(homedir(), "GitHub", "loom");
+    const statePath = join(workspacePath, ".loom", "state.json");
+
+    await access(statePath);
+    const content = await readFile(statePath, "utf-8");
+    return content;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return "State file not found. Workspace may not be initialized.";
+    }
+    throw error;
+  }
+}
+
+/**
+ * Read the Loom config file
+ */
+async function readConfigFile(): Promise<string> {
+  try {
+    const workspacePath = process.env.LOOM_WORKSPACE || join(homedir(), "GitHub", "loom");
+    const configPath = join(workspacePath, ".loom", "config.json");
+
+    await access(configPath);
+    const content = await readFile(configPath, "utf-8");
+    return content;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return "Config file not found. Workspace may not be initialized.";
+    }
+    throw error;
+  }
+}
+
+// Create server instance
+const server = new Server(
+  {
+    name: "loom-ui",
+    version: "0.1.0",
+  },
+  {
+    capabilities: {
+      tools: {},
+    },
+  }
+);
+
+// List available tools
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return {
+    tools: [
+      {
+        name: "read_console_log",
+        description:
+          "Read the Loom browser console log to see JavaScript errors, console.log output, and debugging information",
+        inputSchema: {
+          type: "object",
+          properties: {
+            lines: {
+              type: "number",
+              description: "Number of recent lines to return (default: 100)",
+              default: 100,
+            },
+          },
+        },
+      },
+      {
+        name: "trigger_factory_reset",
+        description:
+          "Trigger a factory reset of the current workspace (WARNING: This is a placeholder and doesn't work yet)",
+        inputSchema: {
+          type: "object",
+          properties: {},
+        },
+      },
+      {
+        name: "read_state_file",
+        description:
+          "Read the current Loom state file (.loom/state.json) to see terminal state, agent numbers, etc.",
+        inputSchema: {
+          type: "object",
+          properties: {},
+        },
+      },
+      {
+        name: "read_config_file",
+        description:
+          "Read the current Loom config file (.loom/config.json) to see terminal configurations and role settings",
+        inputSchema: {
+          type: "object",
+          properties: {},
+        },
+      },
+    ],
+  };
+});
+
+// Handle tool calls
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+
+  try {
+    switch (name) {
+      case "read_console_log": {
+        const lines = (args?.lines as number) || 100;
+        const log = await readConsoleLog(lines);
+        return {
+          content: [
+            {
+              type: "text",
+              text: log,
+            },
+          ],
+        };
+      }
+
+      case "trigger_factory_reset": {
+        const result = await triggerMenuEvent("factory-reset-workspace");
+        return {
+          content: [
+            {
+              type: "text",
+              text: result,
+            },
+          ],
+        };
+      }
+
+      case "read_state_file": {
+        const state = await readStateFile();
+        return {
+          content: [
+            {
+              type: "text",
+              text: state,
+            },
+          ],
+        };
+      }
+
+      case "read_config_file": {
+        const config = await readConfigFile();
+        return {
+          content: [
+            {
+              type: "text",
+              text: config,
+            },
+          ],
+        };
+      }
+
+      default:
+        throw new Error(`Unknown tool: ${name}`);
+    }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Error: ${errorMessage}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+});
+
+// Start server
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error("Loom UI MCP server running on stdio");
+}
+
+main().catch((error) => {
+  console.error("Server error:", error);
+  process.exit(1);
+});

--- a/mcp-loom-ui/tsconfig.json
+++ b/mcp-loom-ui/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,19 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  mcp-loom-ui:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.20.0
+        version: 1.20.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22.18.10
+        version: 22.18.10
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
 packages:
 
   '@alloc/quick-lru@5.2.0':


### PR DESCRIPTION
## Summary

Creates a new MCP server (`loom-ui`) that provides tools for Claude Code to interact with the Loom application UI and state.

## New Tools

- **`read_console_log`** - View browser console output (JavaScript errors, console.log)
- **`read_state_file`** - Read current application state (`.loom/state.json`)
- **`read_config_file`** - Read terminal configurations (`.loom/config.json`)
- **`trigger_factory_reset`** - Placeholder for triggering factory reset (not yet functional)

## Implementation

- New package: `mcp-loom-ui/` with TypeScript MCP server
- Updated `.mcp.json` to include the new server with `LOOM_WORKSPACE` env var
- Updated `.claude/README.md` to document the new tools

## Use Case

This allows AI agents (including Claude Code itself) to debug issues by:
1. Reading browser console logs to see errors and debug output
2. Inspecting application state and configuration files
3. (Future) Triggering UI actions programmatically

This is particularly useful for debugging the factory reset agent launch issue (#84), where we need to see console output to understand where the launch process fails.

## Test Plan

- [x] Build MCP server successfully
- [x] Add to `.mcp.json` configuration
- [x] Document in `.claude/README.md`
- [ ] Test `read_state_file` tool
- [ ] Test `read_config_file` tool
- [ ] Test `read_console_log` tool (requires Loom to write console logs to file)

## Future Enhancements

- Implement `trigger_factory_reset` using Tauri IPC or macOS accessibility API
- Add more UI interaction tools (click buttons, select workspace, etc.)
- Add Chrome DevTools Protocol integration for full browser automation

🤖 Generated with [Claude Code](https://claude.com/claude-code)