### PR TITLE
Add comprehensive debug logging for agent launch failures

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1004,6 +1004,15 @@ SOFTWARE.
     }
 }
 
+/// Emit a menu event programmatically (for MCP control)
+#[tauri::command]
+#[allow(clippy::needless_pass_by_value)]
+fn emit_menu_event(window: tauri::Window, event_name: &str) -> Result<(), String> {
+    window
+        .emit(event_name, ())
+        .map_err(|e| format!("Failed to emit event: {e}"))
+}
+
 fn build_menu() -> Menu {
     // Build File menu
     let new_terminal =
@@ -1271,7 +1280,8 @@ fn main() {
             create_github_label,
             update_github_label,
             create_local_project,
-            create_github_repository
+            create_github_repository,
+            emit_menu_event
         ])
         .run(tauri::generate_context!())
     {


### PR DESCRIPTION
## Summary

Adds extensive debug logging to diagnose why factory reset creates terminals but doesn't launch Claude Code agents.

## Problem

After factory reset:
- ✅ 6 terminals created successfully
- ✅ tmux sessions exist
- ✅ Output files present
- ❌ Claude Code never launches (bare shells only)
- ❌ Interval prompts sent to bare shells cause "command not found" errors
- ❌ No worktrees created

## Changes

### Debug Logging

**`src/main.ts` - `launchAgentsForTerminals()`:**
- Log workspace path and terminals array
- Log filtered workers to launch
- Log each step: import, worktree setup, command sending
- Added `alert()` calls to surface errors immediately

**`src/lib/agent-launcher.ts` - `launchAgentInTerminal()`:**
- Log START with all parameters
- Log worktree setup progress
- Log role file reading and processing
- Log command construction and sending
- Log COMPLETE with return value

### MCP UI Control (Preparatory)

**`src-tauri/src/main.rs` - `emit_menu_event()`:**
- New Tauri command for programmatic menu event triggering
- Will allow MCP tools to click factory reset and other UI actions
- Not yet functional (needs implementation)

## Testing Plan

1. **Full app restart required** - TypeScript changes won't be picked up by hot reload
2. Trigger factory reset in the app
3. Check browser DevTools console for logs starting with:
   - `[factory-reset-workspace]`
   - `[launchAgentsForTerminals]`
   - `[launchAgentInTerminal]`
4. Look for error messages or alerts
5. Debug logs will reveal exactly where agent launch fails

## Expected Outcome

After this PR, we'll have:
- Detailed visibility into the agent launch process
- Clear error messages if launch fails
- Foundation for MCP-controlled UI automation

## Related

- Issue #84 - Factory reset testing and agent launch issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)