### PR TITLE
Fix duplicate tmux session bug in factory reset

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -369,6 +369,17 @@ listen("factory-reset-workspace", async () => {
     }
   }
 
+  // Kill ALL loom tmux sessions to ensure clean slate
+  // This is necessary because daemon may restore old sessions on startup
+  console.log("[factory-reset-workspace] Killing all loom tmux sessions...");
+  try {
+    await invoke("kill_all_loom_sessions");
+    console.log("[factory-reset-workspace] All loom sessions killed");
+  } catch (error) {
+    console.warn("[factory-reset-workspace] Failed to kill loom sessions:", error);
+    // Continue anyway - we'll try to create fresh terminals
+  }
+
   // Call backend reset
   try {
     await invoke("reset_workspace_to_defaults", {


### PR DESCRIPTION
## Summary

Fixes the duplicate tmux session bug that prevents factory reset from creating terminals.

## Problem

Factory reset was failing with "duplicate session" errors for all 6 terminals:

```
[2025-10-15T04:29:04Z INFO  loom_daemon] Restored 1 terminals
...
duplicate session: loom-terminal-2-claude-code-worker-8
duplicate session: loom-terminal-3-claude-code-worker-9
duplicate session: loom-terminal-4-claude-code-worker-10
duplicate session: loom-terminal-5-claude-code-worker-11
duplicate session: loom-terminal-6-claude-code-worker-12
```

## Root Cause

When daemon starts, it restores terminals from `state.json`, creating tmux sessions like `loom-terminal-2-claude-code-worker-8`. Then when factory reset tries to create NEW terminals, it attempts to use the same session names, causing "duplicate session" errors.

## Fix

Added `kill_all_loom_sessions` Tauri command that:
- Lists all tmux sessions
- Kills any session starting with "loom-"
- Called during factory reset BEFORE creating new terminals

**Changes:**

1. **`src-tauri/src/main.rs`** (lines 1048-1089):
   - New command `kill_all_loom_sessions()`
   - Uses same logic as app cleanup code (lines 1251-1273)
   - Registered in `invoke_handler`

2. **`src/main.ts`** (lines 372-381):
   - Call `kill_all_loom_sessions()` after destroying terminals via daemon
   - Called BEFORE `reset_workspace_to_defaults`
   - Ensures clean slate for terminal creation

## Testing Plan

After merging:
1. Pull main and rebuild Loom
2. Use MCP `trigger_factory_reset` tool (or manual factory reset)
3. Check console logs for session cleanup messages
4. Verify all 6 terminals created successfully
5. Verify Claude Code launches in each terminal
6. Verify worktrees created at `.loom/worktrees/terminal-{n}`

## Related

- Issue #84 - Factory reset testing and agent launch debugging
- PR #107 - Console logging to file (enables MCP debugging)
- PR #108 - Fixed Claude Code session ID validation
- PR #109 - MCP factory reset trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)