### PR TITLE
Skip bypass permissions warning prompt on agent launch

### DIFF
--- a/src/lib/agent-launcher.ts
+++ b/src/lib/agent-launcher.ts
@@ -74,7 +74,8 @@ export async function launchAgentInTerminal(
 
   // Build Claude CLI command - CLAUDE.md will be automatically loaded
   // Note: --session-id removed because Claude Code requires UUID format, not our terminal IDs
-  const command = "claude --permission-mode bypassPermissions";
+  // Using --dangerously-skip-permissions to bypass the interactive warning prompt
+  const command = "claude --dangerously-skip-permissions";
   console.log(`[launchAgentInTerminal] Sending command to terminal: ${command}`);
 
   // Send command to terminal


### PR DESCRIPTION
## Summary

Removes the interactive bypass permissions warning prompt that appears when launching Claude Code agents, enabling fully autonomous agent startup during factory reset.

## Problem

When factory reset launches Claude Code agents with `--permission-mode bypassPermissions`, Claude still shows an interactive warning prompt:

```
WARNING: Claude Code running in Bypass Permissions mode

In Bypass Permissions mode, Claude Code will not ask for your approval
before running potentially dangerous commands.

❯ 1. No, exit
  2. Yes, I accept
```

This prevents autonomous agent startup and requires manual intervention for each of the 5 worker terminals, defeating the purpose of factory reset automation.

## Solution

Use `--dangerously-skip-permissions` flag instead of `--permission-mode bypassPermissions`. This flag completely bypasses the interactive warning prompt, allowing agents to start immediately without user intervention.

## Changes

**src/lib/agent-launcher.ts** (line 78):
- **Before**: `claude --permission-mode bypassPermissions`
- **After**: `claude --dangerously-skip-permissions`

## Security Justification

This is safe for Loom's use case because:
1. **Isolated worktrees**: Agents run in isolated git worktrees (`.loom/worktrees/`)
2. **Defined roles**: Each agent has a specific role and limited scope
3. **User configuration**: Users explicitly configure these agents and their roles
4. **Trusted workspace**: The workspace is already trusted (user selected it)

The `--dangerously-skip-permissions` flag is appropriate here because Loom's architecture provides isolation and the user has already made an explicit trust decision by configuring agent roles.

## Testing Plan

After merging:
1. Pull changes and rebuild Loom
2. Trigger factory reset (manually or via MCP)
3. Verify all 5 worker terminals start Claude Code immediately
4. Verify no interactive prompts appear
5. Verify agents begin working autonomously on their assigned tasks
6. Check terminal output files to confirm Claude started cleanly

## Expected Outcome

All agent terminals will launch Claude Code without any interactive prompts, showing output like:

```
Loom Architect
<agent begins working immediately>
```

Instead of getting stuck at the warning prompt.

## Related

- Issue #84 - Factory reset testing and agent launch debugging
- PR #110 - Fixed duplicate tmux session bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)