### PR TITLE
Improve default interval prompts for all role types

### DIFF
--- a/defaults/roles/architect.json
+++ b/defaults/roles/architect.json
@@ -2,7 +2,7 @@
   "name": "System Architect",
   "description": "Identifies improvement opportunities and creates proposals",
   "defaultInterval": 900000,
-  "defaultIntervalPrompt": "Check if there are already 3+ open proposals using `gh issue list --label=\"loom:proposal\"`. If < 3, scan the codebase for improvement opportunities across all domains (features, refactoring, docs, tests, CI, security). Create one comprehensive proposal issue and add the `loom:proposal` label.",
+  "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are a System Architect who scans the codebase for improvement opportunities across ALL domains (features, refactoring, docs, tests, CI, security, performance). Check if there are already 3+ open proposals using `gh issue list --label=\"loom:proposal\"`. If < 3, scan for opportunities and create ONE comprehensive proposal issue with proper categorization (features, refactoring, docs, tests, CI, security). After creating the issue, immediately add `loom:proposal` label and assess if `loom:urgent` is warranted.",
   "autonomousRecommended": true,
   "suggestedWorkerType": "claude",
   "gitIdentity": {

--- a/defaults/roles/curator.json
+++ b/defaults/roles/curator.json
@@ -2,7 +2,7 @@
   "name": "Issue Curator",
   "description": "Enhances approved issues and prepares them for implementation",
   "defaultInterval": 300000,
-  "defaultIntervalPrompt": "Find unlabeled open issues (without loom:proposal, loom:ready, or loom:in-progress). If already well-formed (clear problem, acceptance criteria, test plan), mark as loom:ready immediately. Otherwise, enhance with details first, then mark loom:ready.",
+  "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are an Issue Curator who enhances approved issues. Use `gh issue list --state=open --json number,title,labels --jq '.[] | select(([.labels[].name] | inside([\"loom:proposal\", \"loom:ready\", \"loom:in-progress\", \"loom:blocked\"]) | not)) | \"#\\(.number) \\(.title)\"'` to find unlabeled issues needing curation. For each issue: (1) Check if well-formed (clear problem, acceptance criteria, test plan), (2) If yes, mark `loom:ready` immediately, (3) If no, enhance with missing details then mark `loom:ready`. Always verify dependencies are met before adding `loom:ready` label.",
   "autonomousRecommended": true,
   "suggestedWorkerType": "claude",
   "gitIdentity": {

--- a/defaults/roles/reviewer.json
+++ b/defaults/roles/reviewer.json
@@ -2,7 +2,7 @@
   "name": "Code Review Specialist",
   "description": "Reviews PRs labeled loom:review-requested",
   "defaultInterval": 300000,
-  "defaultIntervalPrompt": "Check for PRs ready for review using `gh pr list --label=\"loom:review-requested\" --state=open`. If you find any, claim one by removing loom:review-requested and adding loom:reviewing, check out the branch, run tests, and provide a thorough code review. When approved, remove loom:reviewing and add loom:approved.",
+  "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are a Code Review Specialist. Monitor open PRs: (1) Check `gh pr list --label=\"loom:review-requested\"` for new PRs needing initial review, (2) Check `gh pr list --label=\"loom:reviewing\"` for PRs you're actively reviewing that may have new commits addressing your feedback. For new reviews: claim PR (remove `loom:review-requested`, add `loom:reviewing`), check out branch, run `pnpm check:ci`, review code thoroughly. When complete: approve with `gh pr review --approve` and update labels (remove `loom:reviewing`, add `loom:approved`), or request changes with `gh pr review --request-changes` (keep `loom:reviewing`).",
   "autonomousRecommended": true,
   "suggestedWorkerType": "claude",
   "gitIdentity": {

--- a/defaults/roles/worker.json
+++ b/defaults/roles/worker.json
@@ -2,7 +2,7 @@
   "name": "Development Worker",
   "description": "Implements issues labeled loom:ready",
   "defaultInterval": 0,
-  "defaultIntervalPrompt": "Check for issues labeled `loom:ready` using `gh issue list --label=\"loom:ready\" --state=open`. If you find any, claim one by updating its label to `loom:in-progress` and begin implementation.",
+  "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are a Development Worker who implements `loom:ready` issues. Priority system: (1) Check urgent: `gh pr list --author=@me --state=open`, if active PR exists, check if it's been merged or has new review comments needing attention. (2) If no active PR, check `gh issue list --label=\"loom:ready\" --label=\"loom:urgent\"` for critical issues. (3) If none urgent, check `gh issue list --label=\"loom:ready\"` (oldest first, FIFO). Workers stick with ONE PR until merged - don't start new issues while you have an open PR.",
   "autonomousRecommended": false,
   "suggestedWorkerType": "claude",
   "gitIdentity": {


### PR DESCRIPTION
## Summary

Enhanced the default interval prompts for all autonomous role types (Architect, Curator, Worker, Reviewer) to be more actionable, include system prompt reminders, and align with the label-based workflow.

## Changes Made

### Architect (`defaults/roles/architect.json:5`)
- Added "REMINDER: Follow your system prompt" prefix to reinforce role identity
- Emphasized scanning **ALL domains** (features, refactoring, docs, tests, CI, security, performance)
- Added instruction to assess if `loom:urgent` label is warranted when creating proposals
- Maintains existing 15-minute interval and proposal limit (< 3 open)

### Curator (`defaults/roles/curator.json:5`)
- Added "REMINDER: Follow your system prompt" with role clarification
- Improved `jq` command to filter out `loom:blocked` issues (in addition to proposal/ready/in-progress)
- Added clear step-by-step workflow: check if well-formed → mark ready or enhance first
- Emphasized verifying dependencies before adding `loom:ready` label

### Worker (`defaults/roles/worker.json:5`)
- Added "REMINDER: Follow your system prompt" with role clarification
- Implemented priority system:
  1. Check active PR first (`gh pr list --author=@me`) for merge status or new comments
  2. If no active PR, check urgent issues (`--label="loom:urgent"`)
  3. If none urgent, check normal priority (FIFO via `gh issue list --label="loom:ready"`)
- Reinforced "stick with ONE PR until merged" principle from issue requirements

### Reviewer (`defaults/roles/reviewer.json:5`)
- Added "REMINDER: Follow your system prompt" with role clarification
- Added monitoring of **both** `loom:review-requested` (new PRs) and `loom:reviewing` (in-progress reviews with new commits)
- Included `pnpm check:ci` command in the review workflow
- Detailed label transition steps for approve vs request-changes scenarios

## Test Plan

- [x] JSON files are valid (biome check passed)
- [x] Changes only affect `defaultIntervalPrompt` field in metadata files
- [x] Build succeeds (frontend compiled successfully)
- [ ] Manual testing: Set up autonomous terminals with each role and verify prompts appear correctly
- [ ] Verify agents follow the improved prompts during autonomous operation

## Impact

- **User Experience**: Agents will have clearer, more actionable prompts during autonomous intervals
- **Consistency**: All roles now start with "REMINDER: Follow your system prompt" to reinforce role identity
- **Workflow Alignment**: Prompts now better match the documented label-based workflow
- **No Breaking Changes**: Only updated default values in metadata; existing terminals unaffected until reconfigured

## Related

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>