### PR TITLE
Rename Factory Reset to Start and add Force Start option

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1096,8 +1096,10 @@ fn build_menu() -> Menu {
         CustomMenuItem::new("close_terminal", "Close Terminal").accelerator("CmdOrCtrl+Shift+W");
     let close_workspace =
         CustomMenuItem::new("close_workspace", "Close Workspace").accelerator("CmdOrCtrl+W");
-    let factory_reset_workspace =
-        CustomMenuItem::new("factory_reset_workspace", "Factory Reset Workspace...");
+    let start_workspace =
+        CustomMenuItem::new("start_workspace", "Start...").accelerator("CmdOrCtrl+Shift+R");
+    let force_start_workspace = CustomMenuItem::new("force_start_workspace", "Force Start")
+        .accelerator("CmdOrCtrl+Shift+Alt+R");
 
     let file_menu = Submenu::new(
         "File",
@@ -1106,7 +1108,8 @@ fn build_menu() -> Menu {
             .add_item(close_terminal)
             .add_native_item(MenuItem::Separator)
             .add_item(close_workspace)
-            .add_item(factory_reset_workspace)
+            .add_item(start_workspace)
+            .add_item(force_start_workspace)
             .add_native_item(MenuItem::Separator)
             .add_native_item(MenuItem::Quit),
     );
@@ -1189,8 +1192,11 @@ fn handle_menu_event(event: &tauri::WindowMenuEvent) {
         "close_workspace" => {
             let _ = event.window().emit("close-workspace", ());
         }
-        "factory_reset_workspace" => {
-            let _ = event.window().emit("factory-reset-workspace", ());
+        "start_workspace" => {
+            let _ = event.window().emit("start-workspace", ());
+        }
+        "force_start_workspace" => {
+            let _ = event.window().emit("force-start-workspace", ());
         }
         "toggle_theme" => {
             let _ = event.window().emit("toggle-theme", ());


### PR DESCRIPTION
## Summary

Improves UX by renaming "Factory Reset Workspace..." to "Start..." and adds a "Force Start" option that skips the confirmation dialog for automation purposes.

## Changes

### Menu Updates (src-tauri/src/main.rs)
- **Renamed**: `factory_reset_workspace` → `start_workspace` ("Factory Reset Workspace..." → "Start...")
- **Added**: `force_start_workspace` ("Force Start") with `Cmd+Shift+Alt+R` shortcut
- **Keyboard shortcuts**: `Cmd+Shift+R` for Start, `Cmd+Shift+Alt+R` for Force Start

### Event Listeners (src/main.ts)
- **Renamed**: `factory-reset-workspace` event → `start-workspace`
- **Added**: `force-start-workspace` event listener (identical workflow, no confirmation dialog)
- **Updated**: All log messages from `[factory-reset-workspace]` to `[start-workspace]` or `[force-start-workspace]`

### MCP Server Automation (mcp-loom-ui/src/index.ts)
- **Updated**: `trigger_factory_reset` now uses Force Start keyboard shortcut (`Cmd+Shift+Alt+R`)
- **Improved**: Changed from AppleScript menu accessibility to keyboard shortcuts (more reliable in dev mode)
- **Updated**: Tool description clarifies it triggers force start WITHOUT confirmation dialog

## Benefits

1. **Better UX**: "Start" is more intuitive than "Factory Reset" for users
2. **Automation-friendly**: Force Start enables automated testing via MCP without user intervention
3. **Reliability**: Keyboard shortcuts are more reliable than AppleScript menu accessibility APIs
4. **Dual options**: Manual workflow with confirmation (Start), automated workflow without (Force Start)

## Workflow

Both options trigger the same reset workflow:
- Stop all polling
- Destroy all terminal sessions
- Kill all tmux sessions
- Reset to defaults (6 terminals with default roles)
- Launch Claude Code agents

**Difference**: Start shows confirmation dialog, Force Start does not.

## Testing

Manual testing:
1. File menu → Start... → Confirm dialog appears → Workspace resets
2. File menu → Force Start → No dialog → Workspace resets immediately
3. `Cmd+Shift+R` → Confirm dialog appears → Workspace resets
4. `Cmd+Shift+Alt+R` → No dialog → Workspace resets immediately

MCP testing:
```bash
# Use MCP tool to trigger force start
mcp__loom-ui__trigger_factory_reset
# Should reset workspace without confirmation
```

## Related Issues

Improves automation capabilities for testing and development workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)