### PR TITLE
Fix command concatenation when launching agents with worktrees

### DIFF
--- a/src/lib/agent-launcher.ts
+++ b/src/lib/agent-launcher.ts
@@ -78,6 +78,11 @@ export async function launchAgentInTerminal(
   const command = "claude --dangerously-skip-permissions";
   console.log(`[launchAgentInTerminal] Sending command to terminal: ${command}`);
 
+  // Wait for any previous commands to fully complete
+  // This prevents command concatenation with worktree setup commands
+  console.log(`[launchAgentInTerminal] Waiting 500ms for previous commands to complete...`);
+  await new Promise((resolve) => setTimeout(resolve, 500));
+
   // Send command to terminal
   await invoke("send_terminal_input", {
     id: terminalId,


### PR DESCRIPTION
## Summary

Fixes command concatenation bug when changing a plain shell terminal to a Codex/Claude worker with worktree enabled.

## Problem

Commands were being concatenated:
```
echo "✓ Worktree ready..."claude --dangerously-skip-permissions
```

This caused:
- Claude command not executing
- Terminal receiving "2" commands instead of accepting bypass prompt
- Error: `zsh: command not found: 2`

## Solution

Added 500ms delay in `src/lib/agent-launcher.ts:81-84` before sending Claude command:

```typescript
// Wait for any previous commands to fully complete
// This prevents command concatenation with worktree setup commands
console.log(`[launchAgentInTerminal] Waiting 500ms for previous commands to complete...`);
await new Promise((resolve) => setTimeout(resolve, 500));
```

## Testing

Test by changing terminal-1 from plain shell to Codex worker:
1. Open terminal settings for terminal-1
2. Change worker type to "codex" and role to "worker.md"
3. Enable autonomous mode
4. Verify commands appear on separate lines
5. Verify Claude Code launches successfully

## Related

Closes #137

Timing issues with terminal input have been a recurring theme:
- #84 - Factory reset testing
- #112 - Bypass permissions acceptance  
- #117 - 100% success rate improvements