### PR TITLE
Add Tauri IPC commands for programmatic factory reset control

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1045,6 +1045,24 @@ fn append_to_console_log(content: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// Trigger workspace start programmatically (for MCP/testing)
+#[tauri::command]
+#[allow(clippy::needless_pass_by_value)]
+fn trigger_start(window: tauri::Window) -> Result<(), String> {
+    window
+        .emit("start-workspace", ())
+        .map_err(|e| format!("Failed to emit start-workspace event: {e}"))
+}
+
+/// Trigger force start programmatically (for MCP/testing)
+#[tauri::command]
+#[allow(clippy::needless_pass_by_value)]
+fn trigger_force_start(window: tauri::Window) -> Result<(), String> {
+    window
+        .emit("force-start-workspace", ())
+        .map_err(|e| format!("Failed to emit force-start-workspace event: {e}"))
+}
+
 /// Kill all loom tmux sessions
 #[tauri::command]
 fn kill_all_loom_sessions() -> Result<(), String> {
@@ -1364,6 +1382,8 @@ fn main() {
             create_github_repository,
             emit_menu_event,
             append_to_console_log,
+            trigger_start,
+            trigger_force_start,
             kill_all_loom_sessions
         ])
         .run(tauri::generate_context!())


### PR DESCRIPTION
## Summary

Adds reliable Tauri commands for triggering workspace start/reset programmatically, replacing the unreliable accessibility-based approach that was failing in MCP.

## Problem

The existing MCP `trigger_factory_reset` tool used AppleScript to navigate File menu → Start, which was fragile and often failed with "Can't get menu" errors. This blocked automated testing and debugging workflows.

## Solution

Added two new Tauri IPC commands that can be invoked programmatically:

### Tauri Commands (`src-tauri/src/main.rs`)

**`trigger_start(window: Window) -> Result<(), String>`**
- Emits `start-workspace` event 
- Shows confirmation dialog before reset
- For interactive use cases

**`trigger_force_start(window: Window) -> Result<(), String>`**
- Emits `force-start-workspace` event
- Bypasses confirmation dialog  
- For automated testing and debugging

Both commands registered in `invoke_handler`.

### MCP Server Updates (`mcp-loom-ui/src/index.ts`)

**New approach**: Direct Tauri IPC via AppleScript + JavaScript injection

```typescript
async function invokeTauriCommand(command: string, args: Record<string, unknown> = {}) {
  // Uses AppleScript to activate Loom and inject JavaScript
  // Calls window.__TAURI__.invoke(command, args)
  // Much more reliable than menu navigation
}
```

**Two new MCP tools**:
- `trigger_start` - Normal factory reset with confirmation
- `trigger_force_start` - Bypass confirmation for automation

## Benefits

- ✅ **More reliable**: Direct IPC instead of accessibility/menu automation  
- ✅ **Works when UI isn't ready**: Doesn't depend on menu structure
- ✅ **Better separation**: Normal vs force start use cases
- ✅ **Integrated with events**: Uses existing Tauri event handlers
- ✅ **Better error handling**: Clear success/failure responses

## Testing

After merging:

1. **Restart Claude Code** to pick up updated MCP server
2. **Test normal start**:
   ```
   Use mcp__loom-ui__trigger_start
   ```
   Should show confirmation dialog
3. **Test force start**:
   ```
   Use mcp__loom-ui__trigger_force_start  
   ```
   Should trigger immediately without confirmation

## Files Changed

- `src-tauri/src/main.rs` (+28 lines) - Added `trigger_start()` and `trigger_force_start()` commands
- `mcp-loom-ui/src/index.ts` (+107, -25 lines) - Replaced trigger file approach with Tauri IPC

## Related

- Issue #84 - Factory reset testing and debugging
- PR #144 - Fixed tmux socket mismatch (enables testing this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>