### PR TITLE
Add GitHub label reset on workspace restart

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -88,7 +88,13 @@ Interact with the Loom application UI and state:
 - `read_console_log` - View browser console output (JavaScript errors, console.log statements)
 - `read_state_file` - Read current application state (.loom/state.json)
 - `read_config_file` - Read terminal configurations (.loom/config.json)
-- `trigger_factory_reset` - Trigger factory reset (placeholder, not yet functional)
+- `trigger_start` - Trigger workspace start with confirmation dialog (factory reset with 6 terminals)
+- `trigger_force_start` - Trigger force start without confirmation (immediate reset)
+
+**Label State Machine Reset**: When workspace is started (via `trigger_start` or `trigger_force_start`), the `reset_github_labels` Tauri command automatically resets the GitHub label state machine:
+- Removes `loom:in-progress` from all open issues (workers can reclaim them)
+- Replaces `loom:reviewing` with `loom:review-requested` on all open PRs (reviewer can re-review)
+- This ensures a clean state when restarting the workspace with fresh agent terminals
 
 **Note**: When you first open the project, Claude Code will prompt you to approve these MCP servers. You can also enable them automatically by setting `"enableAllProjectMcpServers": true` in your `.claude/settings.local.json`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+The Vite-powered frontend lives in `src/` with feature modules under `src/lib/` and colocated Vitest specs (`*.test.ts`). Tauri glue code and native bindings reside in `src-tauri/`, while the Rust daemon runs from `loom-daemon/`. Runtime defaults and role templates sit in `defaults/` and `.loom/roles/`; automation helpers live in `scripts/`, and production bundles emit to `dist/`.
+
+## Build, Test, and Development Commands
+- `pnpm app:dev` boots the daemon then Tauri for an end-to-end local session.
+- `pnpm daemon:dev` + `pnpm tauri:dev` mirrors the two-terminal workflow in `DEV_WORKFLOW.md`.
+- `pnpm build`, `pnpm daemon:build`, and `pnpm tauri:build` produce frontend assets, the daemon binary, and the packaged desktop app.
+- Quality gates: `pnpm lint`, `pnpm format:rust`, `pnpm clippy`, and `pnpm check:ci`.
+
+## Coding Style & Naming Conventions
+TypeScript follows Biome defaults (two-space indent, trailing commas, explicit semicolons); prefer `camelCase` for functions and `PascalCase` for exported classes. Keep modules single-purpose and expose public helpers from `src/lib/` index files only when shared. Rust code must pass `cargo fmt` and `cargo clippy -- -D warnings`; keep IPC command enums and structs serde-annotated for stability.
+
+## Testing Guidelines
+Rust suites run through `pnpm test` (aliased to `cargo test --workspace --locked --all-features`). Frontend units reside beside their sources and execute with `pnpm test:unit`; use `pnpm test:unit:coverage` when verifying regressions or new UI states. Mirror test filenames after the subject and include minimal fixtures so daemon logs stay readable.
+
+## Commit & Pull Request Guidelines
+Commits use imperative, title-cased subjects with the related issue in parentheses (e.g., `Fix tmux socket mismatch (#144)`). Group work logically and include generated artifacts or schema updates in the same change. Pull requests should outline intent, list the commands you ran, and link issues or Loom workflow references. Attach screenshots or terminal excerpts for UX-facing updates and call out any skipped checks.
+
+## Daemon & Configuration Notes
+Agent role prompts live under `.loom/roles/`; keep Markdown and any sibling JSON metadata in sync. Workspace overrides persist in `~/.loom/`, so mention reset steps (`Help → Daemon Status → Yes`) when altering stateful behavior. Document new environment variables or defaults under `defaults/` before requesting review.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,6 +246,12 @@ fn validate_git_repo(path: String) -> Result<bool, String> {
   - Checks path exists and is a directory
   - Verifies `.git` directory exists
   - Returns `Result<bool, String>` with specific error messages
+- `reset_github_labels()`: Resets GitHub label state machine during workspace restart
+  - Removes `loom:in-progress` from all open issues
+  - Replaces `loom:reviewing` with `loom:review-requested` on all open PRs
+  - Returns `LabelResetResult` with counts and errors
+  - Called automatically during both start-workspace and force-start-workspace
+  - Non-critical operation - continues on error
 
 **Workspace Validation Pattern**:
 ```typescript

--- a/mcp-loom-ui/src/index.ts
+++ b/mcp-loom-ui/src/index.ts
@@ -71,11 +71,11 @@ async function invokeTauriCommand(
     `;
 
     const proc = spawn("osascript", ["-e", script]);
-    let stdout = "";
+    let _stdout = "";
     let stderr = "";
 
     proc.stdout.on("data", (data) => {
-      stdout += data.toString();
+      _stdout += data.toString();
     });
 
     proc.stderr.on("data", (data) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -394,6 +394,28 @@ listen("start-workspace", async () => {
     return;
   }
 
+  // Reset GitHub labels to clean state
+  console.log("[start-workspace] Resetting GitHub labels...");
+  try {
+    interface LabelResetResult {
+      issues_cleaned: number;
+      prs_updated: number;
+      errors: string[];
+    }
+
+    const labelResult = await invoke<LabelResetResult>("reset_github_labels");
+    console.log(
+      `[start-workspace] Label reset complete: ${labelResult.issues_cleaned} issues cleaned, ${labelResult.prs_updated} PRs updated`
+    );
+
+    if (labelResult.errors.length > 0) {
+      console.warn("[start-workspace] Label reset errors:", labelResult.errors);
+    }
+  } catch (error) {
+    console.warn("[start-workspace] Failed to reset GitHub labels:", error);
+    // Continue anyway - label reset is non-critical
+  }
+
   // Clear state
   state.clearAll();
   currentAttachedTerminalId = null;
@@ -546,6 +568,28 @@ listen("force-start-workspace", async () => {
     console.error("Failed to reset workspace:", error);
     alert(`Failed to reset workspace: ${error}`);
     return;
+  }
+
+  // Reset GitHub labels to clean state
+  console.log("[force-start-workspace] Resetting GitHub labels...");
+  try {
+    interface LabelResetResult {
+      issues_cleaned: number;
+      prs_updated: number;
+      errors: string[];
+    }
+
+    const labelResult = await invoke<LabelResetResult>("reset_github_labels");
+    console.log(
+      `[force-start-workspace] Label reset complete: ${labelResult.issues_cleaned} issues cleaned, ${labelResult.prs_updated} PRs updated`
+    );
+
+    if (labelResult.errors.length > 0) {
+      console.warn("[force-start-workspace] Label reset errors:", labelResult.errors);
+    }
+  } catch (error) {
+    console.warn("[force-start-workspace] Failed to reset GitHub labels:", error);
+    // Continue anyway - label reset is non-critical
   }
 
   // Clear state


### PR DESCRIPTION
## Summary

Implements automatic reset of GitHub label state machine when workspace is started or restarted. This ensures agents can pick up work cleanly after a restart without confusion from stale labels.

## Problem

When restarting the Loom workspace, GitHub labels from previous sessions remain:
- Issues marked `loom:in-progress` may not have active workers anymore
- PRs marked `loom:reviewing` may not have an active reviewer anymore

This causes confusion when agents restart because they can't tell which issues/PRs are truly in progress.

## Solution

Added `reset_github_labels` Tauri command that automatically resets the label state machine during workspace restart:
1. Removes `loom:in-progress` from all open issues (workers can reclaim them)
2. Replaces `loom:reviewing` with `loom:review-requested` on open PRs (reviewer can re-review)

The command is called automatically in both `start-workspace` and `force-start-workspace` event handlers.

## Changes

**1. Added `reset_github_labels` Tauri command** (`src-tauri/src/main.rs` lines 760-847)
   - Uses `gh` CLI to list and update issue/PR labels
   - Returns structured `LabelResetResult` with counts and errors
   - Non-critical operation - logs errors but continues workspace reset

**2. Integrated label reset into workspace start flows** (`src/main.ts`)
   - `start-workspace` handler (lines 397-417)
   - `force-start-workspace` handler (lines 573-593)
   - Called after backend reset, before state clearing
   - Logs results and warnings but doesn't block on errors

**3. Added AGENTS.md repository guidelines**
   - Comprehensive coding guidelines for AI agents
   - Project structure, testing, commit conventions
   - Build commands and quality gates

**4. Updated documentation**
   - `.claude/README.md` - Added label reset explanation
   - `CLAUDE.md` - Documented `reset_github_labels` command

**5. Fixed linting warning** (`mcp-loom-ui/src/index.ts`)
   - Prefixed unused `stdout` variable with underscore per Biome suggestion

## Testing Plan

### Manual Testing
1. Manually add `loom:in-progress` to some issues
2. Manually add `loom:reviewing` to some PRs
3. Trigger workspace restart (start or force start)
4. Verify labels are reset correctly:
   - `loom:in-progress` removed from issues
   - `loom:reviewing` replaced with `loom:review-requested` on PRs
5. Check console logs for reset results

### Automated Testing
- ✅ `pnpm check:ci` passes
- ✅ Biome linting passes
- ✅ Clippy passes
- ✅ Build succeeds
- ✅ Pre-commit hooks pass

## Expected Outcome

After merging:
- ✅ Workspace restart automatically resets label state machine
- ✅ Workers can pick up issues cleanly without label confusion
- ✅ Reviewers can re-review PRs after restart
- ✅ Non-critical operation - doesn't block workspace reset on error
- ✅ Logs provide visibility into reset process

## Dependencies

- Requires `gh` CLI to be installed and authenticated
- Works with GitHub API rate limits (uses `gh` which handles auth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)