### PR TITLE
Replace AppleScript with file-based IPC for MCP commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ Thumbs.db
 .loom/daemon.sock
 .loom/worktrees/
 .loom/state.json
+.loom/mcp-command.json
 
 # Loom workspace config (DO commit for team sharing)
 # - config.json: Persistent terminal configurations (roles, themes, intervals)

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "app:preview": "RUST_LOG=info pnpm daemon:preview & sleep 2 && pnpm tauri:preview",
     "app:build": "pnpm daemon:build && pnpm tauri:build",
     "app:prod": "pnpm daemon:build && pnpm tauri:build && RUST_LOG=info ./target/release/loom-daemon & sleep 2 && ./target/release/bundle/macos/Loom.app/Contents/MacOS/Loom",
+    "app:quit": "pkill -f 'loom-daemon|Loom' || true",
     "check": "cargo check --workspace",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -11,6 +11,7 @@ use tauri::{CustomMenuItem, Manager, Menu, MenuItem, Submenu};
 mod daemon_client;
 mod daemon_manager;
 mod dependency_checker;
+mod mcp_watcher;
 
 use daemon_client::{DaemonClient, Request, Response, TerminalInfo};
 
@@ -1407,6 +1408,13 @@ fn main() {
 
             // Store daemon manager in app state for cleanup on quit
             app.manage(std::sync::Mutex::new(daemon_manager));
+
+            // Start MCP command file watcher
+            let window = app
+                .get_window("main")
+                .ok_or_else(|| "Failed to get main window".to_string())?;
+            mcp_watcher::start_mcp_watcher(window);
+            eprintln!("[Loom] MCP command watcher started");
 
             Ok(())
         })

--- a/src-tauri/src/mcp_watcher.rs
+++ b/src-tauri/src/mcp_watcher.rs
@@ -1,0 +1,91 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime};
+use tauri::Window;
+
+#[derive(Debug, Deserialize, Serialize)]
+struct MCPCommand {
+    command: String,
+    timestamp: String,
+}
+
+/// Start watching for MCP commands in ~/.loom/mcp-command.json
+pub fn start_mcp_watcher(window: Window) {
+    // Spawn a background thread to poll for commands
+    std::thread::spawn(move || {
+        let mut last_processed: Option<SystemTime> = None;
+        let command_file = get_command_file_path();
+
+        loop {
+            // Poll every 500ms
+            std::thread::sleep(Duration::from_millis(500));
+
+            // Check if command file exists
+            if !command_file.exists() {
+                continue;
+            }
+
+            // Get file metadata to check modification time
+            match fs::metadata(&command_file) {
+                Ok(metadata) => {
+                    if let Ok(modified) = metadata.modified() {
+                        // If we haven't processed this file yet, or if it's been modified since last check
+                        let should_process = last_processed.map_or(true, |last| last < modified);
+                        if should_process {
+                            // Read and process command
+                            if let Ok(content) = fs::read_to_string(&command_file) {
+                                if let Ok(mcp_cmd) = serde_json::from_str::<MCPCommand>(&content) {
+                                    eprintln!(
+                                        "[MCP Watcher] Received command: {}",
+                                        mcp_cmd.command
+                                    );
+
+                                    // Execute the command
+                                    let result = match mcp_cmd.command.as_str() {
+                                        "trigger_start" => window.emit("start-workspace", ()),
+                                        "trigger_force_start" => {
+                                            window.emit("force-start-workspace", ())
+                                        }
+                                        _ => {
+                                            eprintln!(
+                                                "[MCP Watcher] Unknown command: {}",
+                                                mcp_cmd.command
+                                            );
+                                            Ok(())
+                                        }
+                                    };
+
+                                    if let Err(e) = result {
+                                        eprintln!("[MCP Watcher] Failed to execute command: {e}");
+                                    }
+
+                                    // Update last processed time
+                                    last_processed = Some(modified);
+
+                                    // Delete the command file after processing
+                                    if let Err(e) = fs::remove_file(&command_file) {
+                                        eprintln!(
+                                            "[MCP Watcher] Failed to remove command file: {e}"
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                Err(_) => continue,
+            }
+        }
+    });
+}
+
+#[allow(clippy::expect_used)]
+fn get_command_file_path() -> PathBuf {
+    // Home directory must exist for the app to function
+    // This is only called in background thread, panic is acceptable
+    dirs::home_dir()
+        .expect("Could not get home directory")
+        .join(".loom")
+        .join("mcp-command.json")
+}


### PR DESCRIPTION
## Summary

Fixes the issue where MCP `trigger_force_start` and `trigger_start` functions were launching duplicate Loom app instances using unreliable AppleScript.

## Problem

The MCP server's trigger functions used AppleScript with `tell application "Loom"` which would:
- Launch new Loom instances if none found
- Focus wrong instance if multiple running
- Provide unreliable cross-process communication

This caused repeated issues during testing where multiple Loom windows would appear, requiring manual cleanup.

## Solution

Implemented a simple, reliable file-based IPC mechanism using `~/.loom/mcp-command.json`:

1. **MCP Server**: Writes command with timestamp to JSON file
2. **Tauri App**: Polls file every 500ms in background thread
3. **On Detection**: Parses command, emits appropriate Tauri event
4. **Cleanup**: Automatically deletes file after processing

## Changes

### MCP Server (`mcp-loom-ui/src/index.ts`)

- Created `writeMCPCommand()` function for file-based IPC
- Updated `triggerStart()` and `triggerForceStart()` to use new mechanism
- Removed old `invokeTauriCommand()` with AppleScript

### Tauri App (`src-tauri/src/mcp_watcher.rs` - new file)

- Background file watcher polling `~/.loom/mcp-command.json`
- Parses JSON commands and emits Tauri events:
  - `trigger_start` → `start-workspace`
  - `trigger_force_start` → `force-start-workspace`
- Tracks last processed time to avoid duplicate execution
- Auto-cleanup after command execution

### Integration (`src-tauri/src/main.rs`)

- Added `mcp_watcher` module
- Starts watcher in app setup function
- Watcher runs in background thread throughout app lifecycle

### Additional Improvements

- **`package.json`**: Added `app:quit` script for clean process shutdown
- **`.gitignore`**: Added `.loom/mcp-command.json` to ignore ephemeral IPC files

## Benefits

- ✅ **No more duplicate app instances** - File-based IPC doesn't launch apps
- ✅ **Reliable communication** - Simple file system operations, no AppleScript quirks
- ✅ **Cross-platform ready** - Works on any OS with file system (not macOS-specific)
- ✅ **Development friendly** - Works in both dev and production modes
- ✅ **Automatic cleanup** - Command files deleted after execution
- ✅ **Clean code** - All clippy checks pass

## Testing Plan

1. Restart Loom app to load new MCP watcher
2. Call `mcp__loom-ui__trigger_force_start` via Claude Code
3. Verify only one Loom instance remains active
4. Check console logs for MCP watcher messages
5. Confirm factory reset executes correctly

## Related Issues

This fixes the repeated issue from previous sessions where MCP commands would launch multiple Loom app windows, requiring manual `pnpm app:quit` cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)