### PR TITLE
Fix defaults directory bundling for production builds

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -50,7 +50,7 @@
         "providerShortName": null,
         "signingIdentity": null
       },
-      "resources": [],
+      "resources": ["../defaults"],
       "shortDescription": "",
       "targets": "all",
       "windows": {


### PR DESCRIPTION
## Summary

Fixes the "Defaults directory not found: defaults" error when running factory reset in production builds. The defaults directory wasn't being bundled into the .app, causing initialization to fail.

## Problem

When running factory reset in production builds, initialization failed with:
```
Error: Defaults directory not found: defaults
```

Root cause: The `defaults/` directory wasn't being bundled into the .app bundle, and the hardcoded `Path::new("defaults")` didn't exist in the production environment.

## Solution

**Tauri Configuration** (`src-tauri/tauri.conf.json:53`):
- Added `"../defaults"` to resources array for bundling into `.app/Contents/Resources/`

**Path Resolution** (`src-tauri/src/main.rs`):
- Added `resolve_defaults_path()` helper function that:
  - Tries development path first (`defaults/`)
  - Falls back to bundled resource path (`.app/Contents/Resources/defaults/`)
  - Returns specific error if neither path exists
- Updated three functions to use the helper:
  - `initialize_loom_workspace` (line 109)
  - `reset_workspace_to_defaults` (line 174)
  - `init_loom_directory` (line 332)

## Testing

**Before** (production build):
```
Error: Defaults directory not found: defaults
```

**After**:
- ✅ Development mode: Uses `defaults/` directory directly
- ✅ Production mode: Uses bundled `Contents/Resources/defaults/`
- ✅ Factory reset works in both environments

## Related

Discovered while testing file-based IPC implementation from PR #149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)