### PR TITLE
Add Codex configuration and agent launcher

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,23 @@
+# Codex Configuration for Loom Project
+# This configuration provides similar permissions to .claude/settings.json
+
+# Sandbox mode: workspace-write allows modification within the workspace
+# This is safer than danger-full-access but sufficient for our autonomous agents
+sandbox = "workspace-write"
+
+# Approval policy: never - run commands without asking for approval
+# Since we trust the commands in our workflow (git, gh, pnpm, cargo, etc.)
+ask_for_approval = "never"
+
+# Enable web search for agents that need it
+search = true
+
+# Shell environment policy - inherit environment variables
+[shell_environment_policy]
+inherit = "all"
+
+# Sandbox permissions - grant specific access beyond workspace-write
+# These mirror the permissions we've granted in .claude/settings.json
+sandbox_permissions = [
+    "disk-full-read-access",  # Allow reading anywhere (like cat, ls in Claude settings)
+]

--- a/src/main.ts
+++ b/src/main.ts
@@ -758,8 +758,33 @@ async function launchAgentsForTerminals(workspacePath: string, terminals: Termin
       } else if (workerType === "grok") {
         const { launchGrokAgent } = await import("./lib/agent-launcher");
         await launchGrokAgent(terminal.id);
+      } else if (workerType === "codex") {
+        // Codex with worktree support
+        console.log(`[launchAgentsForTerminals] Launching Codex for ${terminal.name}...`);
+        const { launchCodexAgent } = await import("./lib/agent-launcher");
+
+        // Verify worktreePath exists
+        if (!terminal.worktreePath) {
+          throw new Error(
+            `Terminal ${terminal.name} (${terminal.id}) is missing worktreePath - this should have been created during terminal setup`
+          );
+        }
+
+        console.log(
+          `[launchAgentsForTerminals] Launching Codex agent for ${terminal.name} (id=${terminal.id}) in worktree ${terminal.worktreePath}...`
+        );
+
+        // Launch Codex agent using existing worktree
+        await launchCodexAgent(
+          terminal.id,
+          roleConfig.roleFile as string,
+          workspacePath,
+          terminal.worktreePath
+        );
+
+        console.log(`[launchAgentsForTerminals] Codex agent launched in ${terminal.worktreePath}`);
       } else {
-        // Claude or Codex with worktree support
+        // Claude with worktree support
         console.log(`[launchAgentsForTerminals] Importing agent-launcher for ${terminal.name}...`);
         const { launchAgentInTerminal } = await import("./lib/agent-launcher");
 


### PR DESCRIPTION
## Summary

Implements Codex agent support with permissions similar to Claude Code, enabling the Curator and Reviewer agents (now configured as Codex workers) to run autonomously.

## Changes

**New File: `.codex/config.toml`** (`/Users/rwalters/GitHub/loom/.codex/config.toml`)

Project-level Codex configuration with:
- `sandbox = "workspace-write"` - Safe file modifications within workspace
- `ask_for_approval = "never"` - Autonomous operation without prompts
- `search = true` - Enable web search capability
- `sandbox_permissions = ["disk-full-read-access"]` - Read files outside workspace
- Provides similar autonomous operation to `.claude/settings.json`

**New Function: `launchCodexAgent()`** (`src/lib/agent-launcher.ts:289-347`)

Codex agent launcher following the same pattern as Claude:
- Reads role file from workspace
- Processes template variables (`{{workspace}}`)
- Writes system prompt to `CODEX.md` in worktree
- Launches with `codex --full-auto "$(cat CODEX.md)"`
- `--full-auto` combines `workspace-write` sandbox + `on-failure` approval

**Updated: Worker Type Switch** (`src/main.ts:761-786`)

Added Codex case in `launchAgentsForTerminals()`:
- Verifies worktree exists before launching
- Calls `launchCodexAgent()` for `workerType === "codex"`
- Uses same worktree architecture as Claude agents

## Benefits

- ✅ **Codex Support**: Codex agents can now run autonomously in Loom
- ✅ **Permission Parity**: Similar autonomous operation to Claude Code
- ✅ **Curator & Reviewer Ready**: Enables the Codex-configured agents from PR #158
- ✅ **Consistent Pattern**: Follows same architecture as Claude agent launcher
- ✅ **Safe Defaults**: Workspace-write sandbox prevents filesystem escapes

## Testing

- ✅ TypeScript compilation passes (`pnpm exec tsc --noEmit`)
- ✅ Biome linting passes
- ✅ Rust formatting and clippy pass
- ✅ Frontend build succeeds
- ⏳ Manual testing required: Launch Codex agents and verify autonomous operation

## Related

- PR #158 - Configures Curator and Reviewer to use Codex worker type
- Issue #157 - Adds Critic role to default lineup

🤖 Generated with [Claude Code](https://claude.com/claude-code)