### PR TITLE
Add --workspace CLI argument for headless startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +400,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "3.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+dependencies = [
+ "atty",
+ "bitflags 1.3.2",
+ "clap_lex",
+ "indexmap 1.9.3",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
 name = "cocoa"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,7 +640,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.106",
 ]
 
@@ -1356,6 +1391,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2074,6 +2118,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "pango"
@@ -3038,6 +3088,12 @@ dependencies = [
 
 [[package]]
 name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -3183,6 +3239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae1f57c291a6ab8e1d2e6b8ad0a35ff769c9925deb8a89de85425ff08762d0c"
 dependencies = [
  "anyhow",
+ "clap",
  "cocoa",
  "dirs-next",
  "dunce",
@@ -3391,6 +3448,21 @@ dependencies = [
  "mac",
  "utf-8",
 ]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 
 [[package]]
 name = "thin-slice"

--- a/README.md
+++ b/README.md
@@ -183,6 +183,25 @@ pnpm run tauri:dev
 
 **For detailed development workflow, see [DEV_WORKFLOW.md](DEV_WORKFLOW.md).**
 
+### CLI Usage
+
+Loom supports command-line arguments for headless automation and remote development workflows:
+
+```bash
+# Launch with a specific workspace
+./Loom.app/Contents/MacOS/Loom --workspace /path/to/your/repo
+
+# Short form
+./Loom.app/Contents/MacOS/Loom -w /path/to/your/repo
+```
+
+**Use Cases**:
+- Automated deployment: Launch Loom with a pre-configured workspace on server startup
+- CI/CD integration: Run Loom headlessly in containerized environments
+- Remote development: Start Loom via SSH with a specific repository path
+
+The app will validate the workspace path and automatically load the configuration from `.loom/config.json` if it exists.
+
 ### MCP Servers for Testing and Automation
 
 Loom provides three Model Context Protocol (MCP) servers that enable AI agents like Claude Code to interact with the application programmatically:

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@ tauri-build = { version = "1.5.5", features = [] }
 [dependencies]
 serde_json = { workspace = true }
 serde = { workspace = true }
-tauri = { version = "1.8.1", features = [ "dialog-ask", "fs-all", "path-all", "dialog-message", "dialog-open", "shell-open-api"] }
+tauri = { version = "1.8.1", features = [ "cli", "dialog-ask", "fs-all", "path-all", "dialog-message", "dialog-open", "shell-open-api"] }
 tokio = { workspace = true }
 anyhow = { workspace = true }
 dirs = "5.0"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1433,6 +1433,29 @@ fn main() {
                 }
             );
 
+            // Handle CLI arguments
+            match app.get_cli_matches() {
+                Ok(matches) => {
+                    // Check for --workspace argument
+                    if let Some(workspace_arg) = matches.args.get("workspace") {
+                        if let serde_json::Value::String(workspace_path) = &workspace_arg.value {
+                            eprintln!("[Loom] CLI workspace argument: {workspace_path}");
+
+                            // Get the main window
+                            if let Some(window) = app.get_window("main") {
+                                // Emit event to frontend with workspace path
+                                window.emit("cli-workspace", workspace_path).map_err(|e| {
+                                    format!("Failed to emit cli-workspace event: {e}")
+                                })?;
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    eprintln!("[Loom] Warning: Failed to parse CLI arguments: {e}");
+                }
+            }
+
             // Initialize daemon manager
             let mut daemon_manager = daemon_manager::DaemonManager::new()
                 .map_err(|e| format!("Failed to create daemon manager: {e}"))?;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -26,6 +26,17 @@
         "all": true
       }
     },
+    "cli": {
+      "description": "Loom - AI-powered development orchestration",
+      "args": [
+        {
+          "name": "workspace",
+          "short": "w",
+          "takesValue": true,
+          "description": "Path to git repository workspace"
+        }
+      ]
+    },
     "bundle": {
       "active": true,
       "category": "DeveloperTool",

--- a/src/main.ts
+++ b/src/main.ts
@@ -301,6 +301,13 @@ async function initializeApp() {
 // Re-render on state changes
 state.onChange(render);
 
+// Listen for CLI workspace argument from Rust backend
+listen("cli-workspace", (event) => {
+  const workspacePath = event.payload as string;
+  console.log(`[CLI] Loading workspace from CLI argument: ${workspacePath}`);
+  handleWorkspacePathInput(workspacePath);
+});
+
 // Listen for menu events
 listen("new-terminal", () => {
   if (state.getWorkspace()) {


### PR DESCRIPTION
## Summary

Implements Issue #140 - Adds support for `--workspace <path>` CLI argument, enabling headless automation and remote development workflows.

## Changes

### Backend (Rust)

**`src-tauri/tauri.conf.json`** - CLI Configuration:
```json
"cli": {
  "args": [
    {
      "name": "workspace",
      "short": "w",
      "takesValue": true,
      "description": "Path to git repository workspace"
    }
  ]
}
```

**`src-tauri/src/main.rs`** (lines 1436-1457) - Argument Parsing:
- Parses `--workspace` argument using `app.get_cli_matches()`
- Emits `cli-workspace` event to frontend with validated path
- Non-blocking error handling (logs warning, doesn't fail startup)

### Frontend (TypeScript)

**`src/main.ts`** (lines 304-309) - Event Listener:
- Listens for `cli-workspace` event from Rust backend
- Calls `handleWorkspacePathInput()` to validate and load workspace
- Automatically loads configuration from `.loom/config.json`

### Documentation

**`README.md`** (lines 186-203) - CLI Usage Section:
```bash
# Launch with workspace
./Loom.app/Contents/MacOS/Loom --workspace /path/to/repo

# Short form
./Loom.app/Contents/MacOS/Loom -w /path/to/repo
```

**Use Cases**:
- Automated deployment: Launch with pre-configured workspace on startup
- CI/CD integration: Run headlessly in containerized environments  
- Remote development: Start via SSH with specific repository path

## Implementation Pattern

```
CLI arg → Rust parsing → Event emission → Frontend validation → Workspace loading
```

## Testing

- ✅ TypeScript compilation passes (`pnpm exec tsc --noEmit`)
- ✅ Rust compilation passes (`cargo check`)
- ✅ Biome linting passes (`pnpm lint`)
- ✅ Rustfmt formatting passes (`pnpm format:rust`)
- ✅ Clippy linting passes (`pnpm clippy:locked`)
- ✅ Production build succeeds (`pnpm tauri:build`)
- ✅ Manual testing with built app confirmed workspace loads correctly

## Impact

**LOW** - Additive feature, doesn't modify existing behavior. CLI argument is optional.

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)