### PR TITLE
Add file logging for daemon in production mode

### DIFF
--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -5,13 +5,15 @@ mod types;
 use anyhow::{anyhow, Result};
 use ipc::IpcServer;
 use std::fs;
+use std::io::Write;
 use std::process::Command;
 use std::sync::{Arc, Mutex};
 use terminal::TerminalManager;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    env_logger::init();
+    // Setup logging to ~/.loom/daemon.log
+    setup_logging()?;
 
     // Check tmux
     check_tmux_installed()?;
@@ -52,4 +54,40 @@ fn check_tmux_installed() -> Result<()> {
         .success()
         .then_some(())
         .ok_or_else(|| anyhow!("tmux not installed. Install with: brew install tmux"))
+}
+
+fn setup_logging() -> Result<()> {
+    // Get log file path: ~/.loom/daemon.log
+    let log_path = dirs::home_dir()
+        .ok_or_else(|| anyhow!("No home directory"))?
+        .join(".loom/daemon.log");
+
+    // Create .loom directory if it doesn't exist
+    if let Some(parent) = log_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    // Open log file in append mode
+    let log_file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)?;
+
+    // Configure env_logger to write to file
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .target(env_logger::Target::Pipe(Box::new(log_file)))
+        .format(|buf, record| {
+            writeln!(
+                buf,
+                "[{}] [{}] {}",
+                chrono::Local::now().format("%Y-%m-%dT%H:%M:%S%.3f"),
+                record.level(),
+                record.args()
+            )
+        })
+        .init();
+
+    log::info!("Daemon logging initialized to {}", log_path.display());
+
+    Ok(())
 }


### PR DESCRIPTION
## Summary

Enable daemon logging to `~/.loom/daemon.log` in both development and production modes. Previously, the production daemon (launched from the bundled app) had no logging output, making debugging and troubleshooting difficult.

## Changes

- **Added `setup_logging()` function** in `loom-daemon/src/main.rs`:
  - Configures `env_logger` to write to file instead of stdout
  - Log file location: `~/.loom/daemon.log` (append mode)
  - Timestamp format: ISO 8601 with milliseconds
  - Default log level: `info` (can be overridden with `RUST_LOG` env var)

- **Replaced `env_logger::init()`**:
  - Old: Only logged to stdout when `RUST_LOG` was set
  - New: Always logs to file, works in production

## Example Log Output

```
[2025-10-15T18:31:17.226] [INFO] Daemon logging initialized to /Users/rwalters/.loom/daemon.log
[2025-10-15T18:31:17.235] [INFO] Restored 0 terminals
[2025-10-15T18:31:17.235] [INFO] Loom daemon starting...
[2025-10-15T18:31:17.235] [INFO] IPC server listening at /Users/rwalters/.loom/daemon.sock
```

## Benefits

- **Always On**: Logs written in both dev and production
- **No Configuration**: Works out of the box, no env vars needed
- **Persistent**: Logs survive daemon restarts
- **Debuggable**: Easy to inspect daemon activity for troubleshooting

## Testing

- ✅ Daemon compiles successfully
- ✅ Log file created at correct location
- ✅ Logs contain properly formatted timestamps
- ✅ Tested in development mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)