### PR TITLE
Implement worktree reference counting in daemon cleanup (Issue #171)

### DIFF
--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -205,6 +205,18 @@ fn handle_request(request: Request, terminal_manager: &Arc<Mutex<TerminalManager
             }
         }
 
+        Request::SetWorktreePath { id, worktree_path } => {
+            let mut tm = terminal_manager
+                .lock()
+                .expect("Terminal manager mutex poisoned");
+            match tm.set_worktree_path(&id, &worktree_path) {
+                Ok(()) => Response::Success,
+                Err(e) => Response::Error {
+                    message: e.to_string(),
+                },
+            }
+        }
+
         Request::Shutdown => {
             log::info!("Shutdown requested");
             std::process::exit(0);

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -41,6 +41,10 @@ pub enum Request {
     KillSession {
         session_name: String,
     },
+    SetWorktreePath {
+        id: TerminalId,
+        worktree_path: String,
+    },
     Shutdown,
 }
 

--- a/src-tauri/src/daemon_client.rs
+++ b/src-tauri/src/daemon_client.rs
@@ -45,6 +45,10 @@ pub enum Request {
     KillSession {
         session_name: String,
     },
+    SetWorktreePath {
+        id: TerminalId,
+        worktree_path: String,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -247,6 +247,21 @@ async fn kill_session(session_name: String) -> Result<(), String> {
 }
 
 #[tauri::command]
+async fn set_worktree_path(id: String, worktree_path: String) -> Result<(), String> {
+    let client = DaemonClient::new().map_err(|e| e.to_string())?;
+    let response = client
+        .send_request(Request::SetWorktreePath { id, worktree_path })
+        .await
+        .map_err(|e| e.to_string())?;
+
+    match response {
+        Response::Success => Ok(()),
+        Response::Error { message } => Err(message),
+        _ => Err("Unexpected response".to_string()),
+    }
+}
+
+#[tauri::command]
 fn validate_git_repo(path: &str) -> Result<bool, String> {
     let workspace_path = Path::new(path);
 
@@ -1551,6 +1566,7 @@ fn main() {
             list_available_sessions,
             attach_to_session,
             kill_session,
+            set_worktree_path,
             get_env_var,
             check_claude_code,
             get_stored_workspace,

--- a/src/lib/ui.ts
+++ b/src/lib/ui.ts
@@ -357,12 +357,14 @@ function createTimerDisplayHTML(terminal: Terminal): string {
   const idleDisplay = formatDuration(currentIdleTime);
 
   // Choose colors based on status
-  const busyColor = terminal.status === TerminalStatus.Busy
-    ? "text-blue-600 dark:text-blue-400 font-semibold"
-    : "text-gray-500 dark:text-gray-400";
-  const idleColor = terminal.status === TerminalStatus.Idle
-    ? "text-gray-600 dark:text-gray-300 font-semibold"
-    : "text-gray-500 dark:text-gray-400";
+  const busyColor =
+    terminal.status === TerminalStatus.Busy
+      ? "text-blue-600 dark:text-blue-400 font-semibold"
+      : "text-gray-500 dark:text-gray-400";
+  const idleColor =
+    terminal.status === TerminalStatus.Idle
+      ? "text-gray-600 dark:text-gray-300 font-semibold"
+      : "text-gray-500 dark:text-gray-400";
 
   return `
     <div class="flex flex-col gap-0.5 mt-1 border-t border-gray-200 dark:border-gray-700 pt-1">

--- a/src/lib/worktree-manager.ts
+++ b/src/lib/worktree-manager.ts
@@ -60,6 +60,20 @@ export async function setupWorktreeForAgent(
   // Log success message
   await sendCommand(terminalId, `echo "✓ Worktree ready at ${worktreePath}"`);
 
+  // Notify daemon about worktree path for reference counting
+  try {
+    await invoke("set_worktree_path", {
+      id: terminalId,
+      worktreePath,
+    });
+    console.log(
+      `[setupWorktreeForAgent] Notified daemon: terminal ${terminalId} using worktree ${worktreePath}`
+    );
+  } catch (error) {
+    console.error(`[setupWorktreeForAgent] Failed to notify daemon about worktree path:`, error);
+    // Non-fatal - continue even if notification fails
+  }
+
   return worktreePath;
 }
 


### PR DESCRIPTION
## Summary

Implements reference counting for git worktree cleanup to support the branch-based worktree model where multiple terminals can share the same worktree. This is Phase 4 of Issue #164.

## Changes

### Backend (Rust)

**`loom-daemon/src/terminal.rs`**:
- Added `set_worktree_path()` method to store worktree paths per terminal
- Updated `destroy_terminal()` with reference counting logic
- Counts how many terminals use each worktree before cleanup
- Only removes worktree when last terminal using it is destroyed
- Added detailed logging for debugging reference counting behavior

**`loom-daemon/src/types.rs`**:
- Added `SetWorktreePath` IPC request variant

**`loom-daemon/src/ipc.rs`**:
- Added IPC handler for `SetWorktreePath` requests

**`src-tauri/src/daemon_client.rs`**:
- Added `SetWorktreePath` request variant to client

**`src-tauri/src/main.rs`**:
- Added `set_worktree_path()` Tauri command
- Registered command in invoke_handler

### Frontend (TypeScript)

**`src/lib/worktree-manager.ts`**:
- Added daemon notification after worktree setup completes
- Calls `set_worktree_path()` to inform daemon of worktree association
- Non-fatal error handling if notification fails

## Implementation Details

**Reference Counting Logic** (loom-daemon/src/terminal.rs:119-152):
```rust
let other_users = self
    .terminals
    .values()
    .filter(|t| t.id != *id && t.worktree_path.as_ref() == Some(worktree_path))
    .count();

if other_users == 0 {
    // Last terminal - safe to remove worktree
    log::info!("Removing worktree at {} (no other terminals using it)", ...);
    // Remove via git worktree remove
} else {
    log::info!("Skipping worktree removal at {} ({} other terminal(s) still using it)", ...);
}
```

**Flow**:
1. Worktree setup completes in frontend
2. Frontend calls `invoke("set_worktree_path", { id, worktreePath })`
3. Tauri forwards to daemon via IPC
4. Daemon stores path in `TerminalInfo.worktree_path`
5. On terminal destroy, daemon checks reference count before cleanup

## Benefits

- ✅ Multiple terminals can safely share the same worktree/branch
- ✅ Worktrees only removed when last user terminates
- ✅ Prevents "worktree not found" errors from premature cleanup
- ✅ Maintains backward compatibility (single-terminal case still works)
- ✅ Clear logging for debugging reference counting behavior

## Test Plan

### Manual Testing
1. Create Terminal A on `feature/test-1`
2. Create Terminal B on `feature/test-1` (same branch, same worktree)
3. Destroy Terminal A
4. Verify worktree still exists (Terminal B using it)
5. Check daemon logs show "X other terminal(s) still using it"
6. Destroy Terminal B
7. Verify worktree is now removed

### CI Status
- ✅ Biome linting and formatting
- ✅ Rust formatting (rustfmt)
- ✅ Clippy with all CI flags
- ✅ Cargo check
- ✅ Frontend build (TypeScript + Vite)
- ✅ Unit tests (105/108 passing, 3 pre-existing failures from #148)

## Related Issues

- Closes #171
- Part of #164 (Phase 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)