### PR TITLE
Add CI check to prevent tmux socket mismatch regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,39 @@ jobs:
           # Create platform-specific symlink for Tauri build script
           ln -sf loom-daemon target/release/loom-daemon-x86_64-unknown-linux-gnu
 
+      - name: Verify tmux socket consistency (Issue #144 regression check)
+        run: |
+          echo "Checking that all tmux commands use -L loom socket..."
+          # Find all tmux command invocations in main.rs
+          TMUX_COMMANDS=$(grep -n 'Command::new("tmux")' src-tauri/src/main.rs || true)
+
+          if [ -z "$TMUX_COMMANDS" ]; then
+            echo "✅ No tmux commands found (expected if tmux usage removed)"
+            exit 0
+          fi
+
+          # Check each tmux command has -L loom flag within next 3 lines
+          MISSING_SOCKET=0
+          while IFS= read -r line; do
+            LINE_NUM=$(echo "$line" | cut -d':' -f1)
+            CONTEXT=$(sed -n "${LINE_NUM},$((LINE_NUM+3))p" src-tauri/src/main.rs)
+
+            if ! echo "$CONTEXT" | grep -q '"-L".*"loom"'; then
+              echo "❌ Missing -L loom flag near line $LINE_NUM:"
+              echo "$CONTEXT"
+              MISSING_SOCKET=$((MISSING_SOCKET+1))
+            fi
+          done <<< "$TMUX_COMMANDS"
+
+          if [ $MISSING_SOCKET -gt 0 ]; then
+            echo ""
+            echo "❌ Found $MISSING_SOCKET tmux command(s) without -L loom flag"
+            echo "All tmux commands MUST use -L loom to avoid socket mismatch (see Issue #144, PR #172)"
+            exit 1
+          fi
+
+          echo "✅ All tmux commands correctly use -L loom socket"
+
       - name: Run Clippy
         run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 


### PR DESCRIPTION
## Purpose

Adds automated CI verification to prevent regression of the critical socket mismatch bug fixed in PR #172.

## Implementation

New CI step in  that:
- Finds all  invocations in 
- Verifies each command includes  flag within next 3 lines
- Fails CI if any tmux command is missing the required flag
- Runs before Clippy and Tests in the Rust Build job

## Example Output

**Pass** ✅:
```
Checking that all tmux commands use -L loom socket...
✅ All tmux commands correctly use -L loom socket
```

**Fail** ❌:
```
❌ Missing -L loom flag near line 1219:
    let output = Command::new("tmux")
        .args(["list-sessions", "-F", "#{session_name}"])
        .output()

❌ Found 1 tmux command(s) without -L loom flag
All tmux commands MUST use -L loom to avoid socket mismatch (see Issue #144, PR #172)
```

## Background

Since Issue #144, the daemon uses a custom tmux socket () to avoid conflicts. Any tmux command without this flag will:
1. Look at the default socket instead of the loom socket
2. Not find the sessions (they're on the loom socket)  
3. Cause socket mismatch, potentially killing the app with SIGTERM

PR #172 fixed 4 locations where this flag was missing. This CI check ensures we never introduce this bug again.

## Testing

✅ Tested locally with current main.rs - check passes
✅ Check logic verified to detect missing flags
✅ Gracefully handles no tmux commands (future-proof)

## Related

- #144 - Custom tmux socket implementation
- #172 - Hotfix for socket mismatch bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>