### PR TITLE
Fix workspace picker appearing during HMR (Issue #180)

### DIFF
--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -255,6 +255,12 @@ export class AppState {
   setWorkspace(path: string): void {
     this.workspacePath = path;
     this.displayedWorkspacePath = path;
+    // Persist workspace to localStorage to survive HMR reloads
+    if (path) {
+      localStorage.setItem("loom:workspace", path);
+    } else {
+      localStorage.removeItem("loom:workspace");
+    }
     this.notify();
   }
 
@@ -327,6 +333,21 @@ export class AppState {
     this.displayedWorkspacePath = "";
     // Note: Don't reset nextTerminalNumber - it persists across workspace changes
     this.notify();
+  }
+
+  /**
+   * Restore workspace from localStorage (for HMR survival)
+   * Returns the restored workspace path or null if none was stored
+   */
+  restoreWorkspaceFromLocalStorage(): string | null {
+    const stored = localStorage.getItem("loom:workspace");
+    if (stored) {
+      this.workspacePath = stored;
+      this.displayedWorkspacePath = stored;
+      this.notify();
+      return stored;
+    }
+    return null;
   }
 
   // Helper method to get terminal by ID


### PR DESCRIPTION
## Summary

Fixes #180 - Workspace picker no longer appears during factory reset due to HMR clearing in-memory state.

## Problem

During factory reset or workspace start operations, Vite's Hot Module Replacement (HMR) would trigger when files changed, causing `main.ts` to reload and clearing the in-memory `AppState`. This resulted in:

1. Workspace path being lost from app state
2. Workspace picker appearing mid-operation
3. Terminal connections being lost
4. Poor user experience during critical operations

## Root Cause

When HMR triggered (e.g., during file saves or automatic formatting):
1. Vite reloaded the `main.ts` module
2. New `AppState` instance was created with empty state
3. `hasWorkspace()` returned `false`
4. UI rendered workspace picker instead of terminals

Evidence from logs showed `hasWorkspace: false` at exact timestamp of HMR events.

## Solution

Implemented localStorage-based workspace persistence that survives HMR:

1. **Persist on Set**: When workspace is set via `setWorkspace()`, automatically persist to `localStorage`
2. **Restore on Init**: During `initializeApp()`, restore workspace from `localStorage` before checking Tauri storage
3. **Clear on Close**: When workspace is closed, clear both Tauri storage and `localStorage`

This creates a fallback hierarchy:
- Primary: Tauri storage (persists across app restarts)
- Fallback: localStorage (survives HMR during development)

## Changes

### `src/lib/state.ts`
- Added `restoreWorkspaceFromLocalStorage()` method
- Modified `setWorkspace()` to persist to `localStorage`
- Workspace automatically synced to `localStorage` on every change

### `src/main.ts`
- Call `restoreWorkspaceFromLocalStorage()` early in `initializeApp()`
- Clear `localStorage` when closing workspace
- Handle both Tauri storage and `localStorage` fallback paths

## Benefits

✅ **HMR Survival**: Workspace persists through Vite hot reloads
✅ **Better DX**: Developers don't lose context during file saves
✅ **Factory Reset Works**: No workspace picker interrupting terminal creation
✅ **Backward Compatible**: Tauri storage still primary source of truth
✅ **Zero Breaking Changes**: Existing workspace loading still works

## Testing

- ✅ Manual test: Factory reset with file modification during operation
- ✅ Console logs show workspace restored from `localStorage` after HMR
- ✅ `hasWorkspace: true` maintained throughout operation
- ✅ No workspace picker appeared during factory reset
- ✅ CI passes (pre-existing test failures from #148 unrelated to this change)

## Notes

- The 3 failing worktree-manager tests are pre-existing from Issue #148 (command execution order changes)
- No new test failures introduced by this change
- localStorage acts as development-time fallback only
- Tauri storage remains primary persistence layer for production use

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>