### PR TITLE
Fix worktree-manager tests to match implementation changes (Issue #148)

### DIFF
--- a/src/lib/worktree-manager.test.ts
+++ b/src/lib/worktree-manager.test.ts
@@ -38,10 +38,10 @@ describe("worktree-manager", () => {
 
       await setupWorktreeForAgent("test-terminal-2", "/path/to/workspace");
 
-      // Check git worktree add was called
+      // Check git worktree add was called with -b flag for branch isolation
       expect(invoke).toHaveBeenCalledWith("send_terminal_input", {
         id: "test-terminal-2",
-        data: 'git worktree add "/path/to/workspace/.loom/worktrees/test-terminal-2" HEAD',
+        data: 'git worktree add -b "worktree/test-terminal-2" "/path/to/workspace/.loom/worktrees/test-terminal-2" HEAD',
       });
 
       // Check Enter was sent after git command
@@ -155,7 +155,7 @@ describe("worktree-manager", () => {
       // Expected order of commands
       const expectedCommands = [
         'mkdir -p "/path/to/workspace/.loom/worktrees/test-terminal-7"',
-        'git worktree add "/path/to/workspace/.loom/worktrees/test-terminal-7" HEAD',
+        'git worktree add -b "worktree/test-terminal-7" "/path/to/workspace/.loom/worktrees/test-terminal-7" HEAD',
         'cd "/path/to/workspace/.loom/worktrees/test-terminal-7"',
         'git config user.name "Test User"',
         'git config user.email "test@example.com"',
@@ -179,7 +179,7 @@ describe("worktree-manager", () => {
 
       expect(invoke).toHaveBeenCalledWith("send_terminal_input", {
         id: "test-terminal-8",
-        data: 'git worktree add "/path/with spaces/workspace/.loom/worktrees/test-terminal-8" HEAD',
+        data: 'git worktree add -b "worktree/test-terminal-8" "/path/with spaces/workspace/.loom/worktrees/test-terminal-8" HEAD',
       });
     });
 


### PR DESCRIPTION
## Summary

Fixes 3 failing tests in `worktree-manager.test.ts` by updating test expectations to match the current implementation in `worktree-manager.ts`.

The tests were failing because the implementation was updated to use the `-b` flag when creating git worktrees (for proper branch isolation), but the test expectations still expected the old command format without the flag.

## Changes

**src/lib/worktree-manager.test.ts**:
- Updated "should create git worktree from HEAD" test (line 42-45)
- Updated "should execute commands in correct order" test (line 157-158)
- Updated "should handle workspace paths with spaces" test (line 180-183)

All three tests now expect the new command format:
```typescript
git worktree add -b "worktree/terminal-N" "path" HEAD
```

Instead of the old format:
```typescript
git worktree add "path" HEAD
```

## Testing

✅ All 108 unit tests passing (previously 105/108)
✅ Worktree-manager tests now pass (previously 3 failures)
✅ No changes to implementation code, only test expectations

## Related Implementation Changes

The failing tests were caused by implementation changes in `worktree-manager.ts`:
- Line 45: Added `-b` flag for worktree branch isolation
- Lines 65-75: Added daemon notification via `set_worktree_path`

The tests correctly validate the `-b` flag behavior. The daemon notification is automatically handled by the mock without explicit expectations.

Fixes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)