### PR TITLE
Add loading state during factory reset

### DIFF
--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -59,6 +59,7 @@ export class AppState {
   private workspacePath: string | null = null; // Valid workspace path
   private displayedWorkspacePath: string = ""; // Path shown in input (may be invalid)
   private nextTerminalNumber: number = 1; // Counter for terminal numbering (always increments)
+  private isResettingWorkspace: boolean = false; // Loading state during factory reset
 
   addTerminal(terminal: Terminal): void {
     this.terminals.set(terminal.id, terminal);
@@ -293,6 +294,15 @@ export class AppState {
 
   getDisplayedWorkspace(): string {
     return this.displayedWorkspacePath;
+  }
+
+  setResettingWorkspace(isResetting: boolean): void {
+    this.isResettingWorkspace = isResetting;
+    this.notify();
+  }
+
+  isWorkspaceResetting(): boolean {
+    return this.isResettingWorkspace;
   }
 
   getNextTerminalNumber(): number {

--- a/src/lib/ui.ts
+++ b/src/lib/ui.ts
@@ -58,6 +58,27 @@ function extractRepoName(path: string): string {
   return parts[parts.length - 1] || path;
 }
 
+/**
+ * Render loading state during factory reset
+ */
+export function renderLoadingState(message: string = "Resetting workspace..."): void {
+  const container = document.getElementById("primary-terminal");
+  if (!container) return;
+
+  container.innerHTML = `
+    <div class="h-full flex items-center justify-center bg-gray-50 dark:bg-gray-900">
+      <div class="flex flex-col items-center gap-4">
+        <div class="relative">
+          <div class="w-16 h-16 border-4 border-blue-200 dark:border-blue-900 rounded-full"></div>
+          <div class="absolute top-0 left-0 w-16 h-16 border-4 border-blue-600 dark:border-blue-400 border-t-transparent rounded-full animate-spin"></div>
+        </div>
+        <p class="text-lg font-medium text-gray-700 dark:text-gray-300">${escapeHtml(message)}</p>
+        <p class="text-sm text-gray-500 dark:text-gray-400">This may take a few moments...</p>
+      </div>
+    </div>
+  `;
+}
+
 export function renderPrimaryTerminal(
   terminal: Terminal | null,
   hasWorkspace: boolean,


### PR DESCRIPTION
Fixes #191

## Summary
Prevents confusing "choose a repo" UI from appearing during factory reset by showing a loading spinner instead.

## Changes

**src/lib/state.ts**:
- Added `isResettingWorkspace` boolean state property
- Added `setResettingWorkspace(isResetting)` method
- Added `isWorkspaceResetting()` getter

**src/lib/ui.ts**:
- Added `renderLoadingState(message)` function
- Shows centered spinner with message and "This may take a few moments..."

**src/main.ts**:
- Imported `renderLoadingState` from ui.ts
- Wrapped `resetWorkspaceToDefaults` in try/finally block
- Sets `isResettingWorkspace = true` before reset
- Sets `isResettingWorkspace = false` after reset (even on error)
- Updated `render()` to check loading state and show loading UI

## UX Flow

**Before**: User sees workspace selector during reset (confusing)
**After**: User sees "Resetting workspace..." spinner (clear)

## Testing

- ✅ TypeScript compilation passes
- ✅ Vite build passes  
- ✅ Biome linting passes
- ✅ Rust formatting passes

Manual testing required to verify loading state appears during factory reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>