### PR TITLE
Add force factory reset option for automated testing

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -547,6 +547,39 @@ listen("factory-reset-workspace", async () => {
   }
 });
 
+// Force Factory Reset - NO confirmation dialog (for MCP automation)
+listen("force-factory-reset-workspace", async () => {
+  if (!state.hasWorkspace()) return;
+  const workspace = state.getWorkspaceOrThrow();
+
+  console.log("[force-factory-reset-workspace] Resetting workspace (no confirmation)");
+
+  // Set loading state before reset
+  state.setResettingWorkspace(true);
+
+  try {
+    // Use the workspace reset module (no confirmation)
+    const { resetWorkspaceToDefaults } = await import("./lib/workspace-reset");
+    await resetWorkspaceToDefaults(
+      workspace,
+      {
+        state,
+        outputPoller,
+        terminalManager,
+        setCurrentAttachedTerminalId: (id) => {
+          currentAttachedTerminalId = id;
+        },
+        launchAgentsForTerminals,
+        render,
+      },
+      "force-factory-reset-workspace"
+    );
+  } finally {
+    // Clear loading state when done (even if error)
+    state.setResettingWorkspace(false);
+  }
+});
+
 listen("toggle-theme", () => {
   toggleTheme();
 });


### PR DESCRIPTION
Fixes #194

## Summary

Adds a "force factory reset" menu option that bypasses the confirmation dialog, enabling fully automated factory reset testing via MCP tools.

## Changes

**src/main.ts**:
- Added `force-factory-reset-workspace` event listener
- Skips `ask()` confirmation dialog
- Uses same loading state management as regular factory reset
- Consistent with existing `force-start-workspace` pattern

**mcp-loom-ui/src/index.ts**:
- Added `triggerForceFactoryReset()` function to write MCP command
- Added `trigger_force_factory_reset` tool to MCP server tools list
- Added handler for `trigger_force_factory_reset` tool calls

## Benefits

- ✅ Enables fully automated factory reset testing via MCP
- ✅ No changes to existing factory reset behavior
- ✅ Clean separation between user-facing and automation workflows
- ✅ Consistent with existing force-start pattern

## Usage

For automated testing and MCP integration:

```bash
# Reset to defaults (no confirmation)
mcp__loom-ui__trigger_force_factory_reset

# Then start engine (also no confirmation)
mcp__loom-ui__trigger_force_start
```

## Testing

- ✅ TypeScript compilation passes
- ✅ Vite build passes
- ✅ Biome linting passes
- ✅ Rust formatting passes
- ✅ Clippy passes
- ✅ MCP server builds successfully

Manual testing required to verify event triggers factory reset without confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>