### PR TITLE
Add loading state during app startup

### DIFF
--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -60,6 +60,7 @@ export class AppState {
   private displayedWorkspacePath: string = ""; // Path shown in input (may be invalid)
   private nextTerminalNumber: number = 1; // Counter for terminal numbering (always increments)
   private isResettingWorkspace: boolean = false; // Loading state during factory reset
+  private isInitializing: boolean = false; // Loading state during app startup
 
   addTerminal(terminal: Terminal): void {
     this.terminals.set(terminal.id, terminal);
@@ -303,6 +304,15 @@ export class AppState {
 
   isWorkspaceResetting(): boolean {
     return this.isResettingWorkspace;
+  }
+
+  setInitializing(isInitializing: boolean): void {
+    this.isInitializing = isInitializing;
+    this.notify();
+  }
+
+  isAppInitializing(): boolean {
+    return this.isInitializing;
   }
 
   getNextTerminalNumber(): number {


### PR DESCRIPTION
## Summary

Implements a loading spinner with "Initializing Loom..." message during app startup to improve user experience. Previously, users saw a blank screen for several seconds while the app performed initialization tasks like dependency checks, workspace restoration, and config loading.

## Changes

### State Management (`src/lib/state.ts`)
- Added `isInitializing` boolean field to AppState
- Added `setInitializing()` method to control loading state
- Added `isAppInitializing()` getter method
- Follows same pattern as existing `isResettingWorkspace` state

### Main App (`src/main.ts`)
- Updated `render()` to check `isInitializing` and display loading UI
- Set `isInitializing(true)` at start of `initializeApp()`
- Clear `isInitializing(false)` before all exit paths:
  - After successfully loading workspace
  - Before showing workspace picker
  - On dependency check failure

## Benefits

✅ **Better User Experience**: Users see immediate visual feedback instead of a blank screen  
✅ **Clear Communication**: Loading message explains what's happening  
✅ **Consistent Pattern**: Reuses existing `renderLoadingState()` function  
✅ **No Visual Regression**: Same loading UI as factory reset

## Testing

- ✅ TypeScript compilation passes
- ✅ Follows established loading state pattern
- ✅ All initialization paths properly clear loading state

## Screenshots

_Loading state appears immediately on app launch with "Initializing Loom..." message and spinner_

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)