### PR TITLE
Replace auto-worktrees with on-demand issue-based worktrees

### DIFF
--- a/src/lib/workspace-reset.ts
+++ b/src/lib/workspace-reset.ts
@@ -156,12 +156,10 @@ export async function resetWorkspaceToDefaults(
           agent.id = terminalId;
           console.log(`[${logPrefix}] ✓ Created terminal ${agent.name} (${terminalId})`);
 
-          // Create worktree for this terminal
-          console.log(`[${logPrefix}] Creating worktree for ${agent.name} (${terminalId})...`);
-          const { setupWorktreeForAgent } = await import("./worktree-manager");
-          const worktreePath = await setupWorktreeForAgent(terminalId, workspacePath);
-          agent.worktreePath = worktreePath;
-          console.log(`[${logPrefix}] ✓ Created worktree at ${worktreePath}`);
+          // NOTE: Worktrees are now created on-demand when claiming issues, not automatically
+          // Agents start in the main workspace directory
+          agent.worktreePath = "";
+          console.log(`[${logPrefix}] ✓ Agent will start in main workspace`);
         } catch (error) {
           console.error(`[${logPrefix}] ✗ Failed to create terminal ${agent.name}:`, error);
           alert(`Failed to create terminal ${agent.name}: ${error}`);

--- a/src/lib/workspace-start.ts
+++ b/src/lib/workspace-start.ts
@@ -117,12 +117,10 @@ export async function startWorkspaceEngine(
           agent.id = terminalId;
           console.log(`[${logPrefix}] ✓ Created terminal ${agent.name} (${terminalId})`);
 
-          // Create worktree for this terminal
-          console.log(`[${logPrefix}] Creating worktree for ${agent.name} (${terminalId})...`);
-          const { setupWorktreeForAgent } = await import("./worktree-manager");
-          const worktreePath = await setupWorktreeForAgent(terminalId, workspacePath);
-          agent.worktreePath = worktreePath;
-          console.log(`[${logPrefix}] ✓ Created worktree at ${worktreePath}`);
+          // NOTE: Worktrees are now created on-demand when claiming issues, not automatically
+          // Agents start in the main workspace directory
+          agent.worktreePath = "";
+          console.log(`[${logPrefix}] ✓ Agent will start in main workspace`);
         } catch (error) {
           console.error(`[${logPrefix}] ✗ Failed to create terminal ${agent.name}:`, error);
           alert(`Failed to create terminal ${agent.name}: ${error}`);


### PR DESCRIPTION
## Summary

Changes agent startup behavior from automatically creating `.loom/worktrees/terminal-{id}` for each terminal to using on-demand `.loom/worktrees/issue-{number}` worktrees created via `pnpm worktree <issue>` when claiming GitHub issues.

## Changes

### Code Changes

**src/lib/workspace-start.ts** (lines 120-123):
- Removed automatic worktree creation during workspace start
- Agents now start in main workspace directory (`worktreePath = ""`)
- Added comment explaining on-demand approach

**src/lib/workspace-reset.ts** (lines 159-162):
- Removed automatic worktree creation during factory reset
- Same changes as workspace-start.ts for consistency

**src/lib/agent-launcher.ts**:
- `launchAgentInTerminal()` (lines 37-39): Use `worktreePath || workspacePath` to support both main workspace and worktrees
- `launchCodexAgent()` (lines 303-306): Same fallback pattern
- Updated comments to clarify new on-demand behavior

### Documentation Updates

**defaults/roles/worker.md** (lines 26-104):
- Replaced "Git Worktree Best Practices" with "On-Demand Git Worktrees"
- Added instructions for `pnpm worktree <issue-number>` helper script
- Documented collision detection and worktree workflow
- Clarified when to create worktrees vs. work in main workspace

**CLAUDE.md**:
- Updated "Context 1" to explain agents start in main workspace
- Replaced "Dogfooding Confusion" with "Workflow for Agents"
- Changed "Benefits of Automatic Worktree System" to "On-Demand"
- Updated "Automatic Worktree Lifecycle" to show helper script usage

## Benefits

✅ **Semantic naming**: `.loom/worktrees/issue-42` instead of `terminal-1`
✅ **Self-documenting**: Worktree path indicates which issue it's for
✅ **No nested worktrees**: Helper script prevents accidental nesting
✅ **Resource efficiency**: Only create worktrees when needed
✅ **Developer-friendly**: Matches manual development workflow

## Test Plan

- [x] Run full CI suite locally (`pnpm check:ci`)
- [x] Biome linting: Clean
- [x] Rust formatting: Clean
- [x] Clippy: No warnings
- [x] Daemon integration tests: 9/9 passed
- [x] Frontend unit tests: 108/108 passed
- [ ] Manual testing: Start workspace and verify agents start in main workspace
- [ ] Manual testing: Use `pnpm worktree 42` to create issue-based worktree
- [ ] Manual testing: Verify collision detection prevents nested worktrees

## Related Issues

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)