### PR TITLE
Fix agent launcher to handle empty worktreePath (Issue #202 follow-up)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -923,55 +923,49 @@ async function launchAgentsForTerminals(workspacePath: string, terminals: Termin
         const { launchGrokAgent } = await import("./lib/agent-launcher");
         await launchGrokAgent(terminal.id);
       } else if (workerType === "codex") {
-        // Codex with worktree support
+        // Codex with worktree support (optional - starts in main workspace if empty)
         console.log(`[launchAgentsForTerminals] Launching Codex for ${terminal.name}...`);
         const { launchCodexAgent } = await import("./lib/agent-launcher");
 
-        // Verify worktreePath exists
-        if (!terminal.worktreePath) {
-          throw new Error(
-            `Terminal ${terminal.name} (${terminal.id}) is missing worktreePath - this should have been created during terminal setup`
-          );
-        }
-
+        // Use worktree path if available, otherwise main workspace
+        const locationDesc = terminal.worktreePath
+          ? `worktree ${terminal.worktreePath}`
+          : "main workspace";
         console.log(
-          `[launchAgentsForTerminals] Launching Codex agent for ${terminal.name} (id=${terminal.id}) in worktree ${terminal.worktreePath}...`
+          `[launchAgentsForTerminals] Launching Codex agent for ${terminal.name} (id=${terminal.id}) in ${locationDesc}...`
         );
 
-        // Launch Codex agent using existing worktree
+        // Launch Codex agent (will use main workspace if worktreePath is empty)
         await launchCodexAgent(
           terminal.id,
           roleConfig.roleFile as string,
           workspacePath,
-          terminal.worktreePath
+          terminal.worktreePath || ""
         );
 
-        console.log(`[launchAgentsForTerminals] Codex agent launched in ${terminal.worktreePath}`);
+        console.log(`[launchAgentsForTerminals] Codex agent launched in ${locationDesc}`);
       } else {
-        // Claude with worktree support
+        // Claude with worktree support (optional - starts in main workspace if empty)
         console.log(`[launchAgentsForTerminals] Importing agent-launcher for ${terminal.name}...`);
         const { launchAgentInTerminal } = await import("./lib/agent-launcher");
 
-        // Verify worktreePath exists (should have been created during terminal creation)
-        if (!terminal.worktreePath) {
-          throw new Error(
-            `Terminal ${terminal.name} (${terminal.id}) is missing worktreePath - this should have been created during terminal setup`
-          );
-        }
-
+        // Use worktree path if available, otherwise main workspace
+        const locationDesc = terminal.worktreePath
+          ? `worktree ${terminal.worktreePath}`
+          : "main workspace";
         console.log(
-          `[launchAgentsForTerminals] Launching agent for ${terminal.name} (id=${terminal.id}) in worktree ${terminal.worktreePath}...`
+          `[launchAgentsForTerminals] Launching agent for ${terminal.name} (id=${terminal.id}) in ${locationDesc}...`
         );
 
-        // Launch agent using existing worktree
+        // Launch agent (will use main workspace if worktreePath is empty)
         await launchAgentInTerminal(
           terminal.id,
           roleConfig.roleFile as string,
           workspacePath,
-          terminal.worktreePath
+          terminal.worktreePath || ""
         );
 
-        console.log(`[launchAgentsForTerminals] Agent launched in ${terminal.worktreePath}`);
+        console.log(`[launchAgentsForTerminals] Agent launched in ${locationDesc}`);
       }
 
       console.log(`[launchAgentsForTerminals] Successfully launched ${terminal.name}`);


### PR DESCRIPTION
## Summary

Fixes factory reset failure caused by validation code that rejected terminals with empty `worktreePath`. After PR #203 merged on-demand worktrees, agents were supposed to start in the main workspace, but the launch code still required worktrees to exist.

## Problem

Factory reset would create terminals with empty worktreePath (correct new behavior), but then `launchAgentsForTerminals()` would throw errors and prevent agents from launching.

## Changes

**src/main.ts (lines 925-967)**:
- Removed validation checks that rejected empty worktreePath
- Added logic to fallback to workspacePath when worktreePath is empty
- Updated log messages to show "main workspace" vs "worktree" location

## Testing

- ✅ Factory reset creates 9 terminals with empty worktreePath
- ✅ No errors about missing worktreePath  
- ✅ Agents launch successfully in main workspace
- ✅ Ready for on-demand worktree creation using `pnpm worktree <issue>`

## Related

- Issue #202
- PR #203 (on-demand worktrees)
- PR #204 (documentation update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)