### PR TITLE
Make app:preview always rebuild before launch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -794,7 +794,23 @@ If this passes, CI should pass too.
 
 **Package Manager Preference**: Always use `pnpm` (not `npm`) as the package manager for this project.
 
-**Development Workflow**: See "Self-Modification Problem" section below for important guidance on which app mode to use.
+**Development Workflow**:
+
+Use the appropriate script based on your scenario:
+
+- **`pnpm app:dev`**: Normal development with hot reload (fastest iteration)
+  - Use when: Making frequent frontend changes
+  - Caveat: Hot reload sometimes misses changes (see "Stale Code Issue" below)
+
+- **`pnpm app:preview`**: Complete rebuild + launch (recommended for testing)
+  - Use when: After pulling new code, switching branches, or hot reload misses changes
+  - Always rebuilds both frontend AND Tauri binary before launching
+  - This is the "safe" option that guarantees fresh code
+
+- **`pnpm app:build`**: Production build
+  - Use when: Creating release builds
+
+**Stale Code Issue**: If you pull new code or switch branches, run `pnpm app:preview` to ensure you're running the latest code. The `tauri dev` command caches the built frontend and hot reload doesn't always catch everything, leading to wasted debugging time.
 
 ### Clippy Configuration Details
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "daemon:build": "cargo build --package loom-daemon --release && rm -f target/release/loom-daemon-aarch64-apple-darwin && cp target/release/loom-daemon target/release/loom-daemon-aarch64-apple-darwin",
     "daemon:test": "cargo test --package loom-daemon",
     "app:dev": "pnpm daemon:dev & sleep 2 && pnpm tauri:dev",
-    "app:preview": "RUST_LOG=info pnpm daemon:preview & sleep 2 && pnpm tauri:preview",
+    "app:preview": "pnpm build && pnpm tauri build --debug && RUST_LOG=info pnpm daemon:preview & sleep 2 && ./target/debug/bundle/macos/Loom.app/Contents/MacOS/Loom",
     "app:build": "pnpm daemon:build && pnpm tauri:build",
     "app:prod": "pnpm daemon:build && pnpm tauri:build && RUST_LOG=info ./target/release/loom-daemon & sleep 2 && ./target/release/bundle/macos/Loom.app/Contents/MacOS/Loom",
     "app:quit": "pkill -9 -f 'loom-daemon|Loom|vite|tauri' || true",


### PR DESCRIPTION
## Summary

Makes `app:preview` a single "rebuild + launch" command that guarantees fresh code.

## Problem

After pulling new code or switching branches, developers were running stale code because:
- `tauri dev` caches the built frontend
- Hot reload doesn't always catch changes
- No clear "safe" workflow to ensure fresh code

This caused wasted debugging time (like after PR #203 when we ran old code).

## Solution

Updated `app:preview` to always rebuild before launching:
```bash
pnpm build && pnpm tauri build --debug && [launch daemon + app]
```

## Changes

**package.json**:
- `app:preview` now rebuilds frontend + Tauri binary before launching
- Simple, predictable workflow

**CLAUDE.md**:
- Clear guidance: two main workflows
  - `app:dev` for fast iteration (may be stale)
  - `app:preview` for safe testing (always fresh)
- Use `app:preview` after pulling code or when hot reload fails

## Benefits

- ✅ Single command guarantees fresh code
- ✅ Clearer mental model (dev vs preview)
- ✅ Prevents stale code debugging sessions
- ✅ Simple rollup command as requested

🤖 Generated with [Claude Code](https://claude.com/claude-code)