### PR TITLE
Add frontend unit tests to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,10 +77,19 @@ jobs:
           pnpm run lint &
           pnpm run format &
           pnpm exec tsc --noEmit &
+          pnpm run test:unit &
           wait
 
       - name: Build frontend
         run: pnpm run build
+
+      - name: Upload coverage report
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 7
 
       - name: Upload build artifacts
         if: success()


### PR DESCRIPTION
## Summary

Adds frontend unit tests (Vitest) to the CI pipeline, ensuring tests run automatically on every PR and push to main.

## Changes

**CI Workflow** (`.github/workflows/ci.yml`):
- Added `pnpm run test:unit &` to parallel checks (runs alongside lint, format, TypeScript)
- Added coverage report upload step for future visibility (optional artifact)

## Testing

✅ All 108 tests pass locally (5 test files):
- `state.test.ts` (19 tests)
- `themes.test.ts` (19 tests)
- `config.test.ts` (29 tests)
- `autonomous-manager.test.ts` (27 tests)
- `worktree-manager.test.ts` (14 tests)

✅ Tests run successfully in parallel with other checks (~20s duration)

## Benefits

1. **Catch Frontend Regressions**: Tests run in CI before merge
2. **Prevent Stale Tests**: Enforces tests stay passing
3. **Coverage Tracking**: Coverage artifacts uploaded for future analysis
4. **Matches Local Workflow**: Now aligns with `pnpm check:ci` command

## Impact

- **Files Affected**: 1 file (`.github/workflows/ci.yml`)
- **Breaking Changes**: None
- **Runtime Impact**: Adds ~20 seconds to CI (runs in parallel)

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>