### PR TITLE
Hotfix Part 2: Fix frontend socket path regression from PR #217

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "app:preview": "pnpm build && pnpm tauri build --debug --bundles app && RUST_LOG=info pnpm daemon:preview & sleep 2 && ./target/debug/bundle/macos/Loom.app/Contents/MacOS/Loom",
     "app:build": "pnpm daemon:build && pnpm tauri:build",
     "app:prod": "pnpm daemon:build && pnpm tauri:build && RUST_LOG=info ./target/release/loom-daemon & sleep 2 && ./target/release/bundle/macos/Loom.app/Contents/MacOS/Loom",
-    "app:quit": "pkill -9 -f 'loom-daemon|Loom|vite|tauri' || true && rm -f ~/.loom/daemon.sock",
+    "app:quit": "pkill -9 -f 'loom-daemon|Loom|vite|tauri' || true && rm -f ~/.loom/loom-daemon.sock",
     "check": "cargo check --workspace",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",

--- a/src-tauri/src/daemon_client.rs
+++ b/src-tauri/src/daemon_client.rs
@@ -81,7 +81,7 @@ impl DaemonClient {
     pub fn new() -> Result<Self> {
         let socket_path = dirs::home_dir()
             .ok_or_else(|| anyhow!("No home directory"))?
-            .join(".loom/daemon.sock");
+            .join(".loom/loom-daemon.sock");
 
         Ok(Self { socket_path })
     }

--- a/src-tauri/src/daemon_manager.rs
+++ b/src-tauri/src/daemon_manager.rs
@@ -15,7 +15,7 @@ impl DaemonManager {
     pub fn new() -> Result<Self> {
         let socket_path = dirs::home_dir()
             .ok_or_else(|| anyhow!("No home directory"))?
-            .join(".loom/daemon.sock");
+            .join(".loom/loom-daemon.sock");
 
         Ok(Self {
             daemon_process: None,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -172,7 +172,7 @@ struct DaemonStatus {
 #[tauri::command]
 async fn get_daemon_status() -> DaemonStatus {
     let socket_path = dirs::home_dir()
-        .map(|h| h.join(".loom/daemon.sock"))
+        .map(|h| h.join(".loom/loom-daemon.sock"))
         .map_or_else(|| "Unknown".to_string(), |p| p.display().to_string());
 
     match DaemonClient::new() {


### PR DESCRIPTION
## Summary

Critical hotfix completing PR #218. PR #218 fixed the daemon socket path, but
missed the frontend Tauri code that also references the socket path. This
completes the fix by updating all remaining socket path references.

## Problem

PR #217 introduced a regression where the socket filename was changed from
`loom-daemon.sock` to `daemon.sock`. PR #218 fixed the daemon side, but the
frontend Tauri code (daemon client, daemon manager, and main.rs) still
referenced the old `daemon.sock` path.

**Symptoms**:
- App fails to start with error: "Daemon socket not found at ~/.loom/daemon.sock"
- Daemon creates socket at `~/.loom/loom-daemon.sock` (correct from PR #218)
- Frontend looks for socket at `~/.loom/daemon.sock` (incorrect)
- Complete communication failure between app and daemon

## Changes

### 1. `src-tauri/src/daemon_client.rs:84`
```rust
// BEFORE:
.join(".loom/daemon.sock");

// AFTER:
.join(".loom/loom-daemon.sock");
```

### 2. `src-tauri/src/daemon_manager.rs:18`
```rust
// BEFORE:
.join(".loom/daemon.sock");

// AFTER:
.join(".loom/loom-daemon.sock");
```

### 3. `src-tauri/src/main.rs:175`
```rust
// BEFORE:
.map(|h| h.join(".loom/daemon.sock"))

// AFTER:
.map(|h| h.join(".loom/loom-daemon.sock"))
```

### 4. `package.json:22`
```json
// BEFORE:
"app:quit": "... rm -f ~/.loom/daemon.sock"

// AFTER:
"app:quit": "... rm -f ~/.loom/loom-daemon.sock"
```

## Testing

- ✅ Local CI checks passed (`pnpm check:ci`)
- ✅ Daemon creates socket at: `~/.loom/loom-daemon.sock`
- ✅ Frontend connects to correct socket path
- ✅ All linting, formatting, and clippy checks passed
- ✅ TypeScript compilation successful
- ✅ All tests passed (daemon integration + frontend unit tests)

## Impact

🔴 **CRITICAL** - PR #218 is incomplete without this fix. Frontend cannot
communicate with daemon at all due to socket path mismatch. This is the
final piece needed to complete the socket path regression fix.

Related: #217, #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>