### PR TITLE
Fix terminal registry sync issues and MCP improvements

### DIFF
--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -108,7 +108,7 @@ fn handle_request(
         }
 
         Request::ListTerminals => {
-            let tm = terminal_manager
+            let mut tm = terminal_manager
                 .lock()
                 .expect("Terminal manager mutex poisoned");
             Response::TerminalList {

--- a/loom-daemon/src/terminal.rs
+++ b/loom-daemon/src/terminal.rs
@@ -90,7 +90,14 @@ impl TerminalManager {
         Ok(id)
     }
 
-    pub fn list_terminals(&self) -> Vec<TerminalInfo> {
+    pub fn list_terminals(&mut self) -> Vec<TerminalInfo> {
+        // If registry is empty but tmux sessions exist, restore from tmux
+        if self.terminals.is_empty() {
+            log::debug!("Registry empty, attempting to restore from tmux");
+            if let Err(e) = self.restore_from_tmux() {
+                log::warn!("Failed to restore terminals from tmux: {e}");
+            }
+        }
         self.terminals.values().cloned().collect()
     }
 

--- a/mcp-loom-terminals/src/index.ts
+++ b/mcp-loom-terminals/src/index.ts
@@ -8,7 +8,7 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 
-const SOCKET_PATH = process.env.LOOM_SOCKET_PATH || "/tmp/loom-daemon.sock";
+const SOCKET_PATH = process.env.LOOM_SOCKET_PATH || join(homedir(), ".loom", "loom-daemon.sock");
 const LOOM_DIR = join(homedir(), ".loom");
 const STATE_FILE = join(LOOM_DIR, "state.json");
 
@@ -86,10 +86,10 @@ async function listTerminals(): Promise<Terminal[]> {
   try {
     const response = (await sendDaemonRequest({
       type: "ListTerminals",
-    })) as { type: string; payload?: Terminal[] };
+    })) as { type: string; payload?: { terminals: Terminal[] } };
 
-    if (response.type === "TerminalList" && response.payload) {
-      return response.payload;
+    if (response.type === "TerminalList" && response.payload?.terminals) {
+      return response.payload.terminals;
     }
 
     return [];

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "app:build": "pnpm daemon:build && pnpm tauri:build",
     "app:prod": "pnpm daemon:build && pnpm tauri:build && RUST_LOG=info ./target/release/loom-daemon & sleep 2 && ./target/release/bundle/macos/Loom.app/Contents/MacOS/Loom",
     "app:quit": "pkill -9 -f 'loom-daemon|Loom|vite|tauri' || true && rm -f ~/.loom/loom-daemon.sock",
+    "logs:clean": "rm -f /tmp/loom-*.log /tmp/app-*.log /tmp/daemon-*.log /tmp/factory-reset-*.log",
     "check": "cargo check --workspace",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",

--- a/src-tauri/src/mcp_watcher.rs
+++ b/src-tauri/src/mcp_watcher.rs
@@ -58,6 +58,12 @@ pub fn start_mcp_watcher(window: Window) {
                                         );
                                         window.emit("factory-reset-workspace", ())
                                     }
+                                    "trigger_force_factory_reset" => {
+                                        eprintln!(
+                                            "[MCP Watcher] Emitting force-factory-reset-workspace event"
+                                        );
+                                        window.emit("force-factory-reset-workspace", ())
+                                    }
                                     _ => {
                                         eprintln!(
                                             "[MCP Watcher] Unknown command: {}",


### PR DESCRIPTION
## Summary

This PR fixes three critical issues with terminal registry synchronization and MCP communication that were blocking automated testing and factory reset workflows.

## Problems Solved

### 1. Missing MCP Force Factory Reset Trigger

**Problem**: MCP tools couldn't trigger factory resets without confirmation dialogs, blocking test automation.

**Root Cause**: The Rust MCP watcher (`src-tauri/src/mcp_watcher.rs`) was missing the handler for `trigger_force_factory_reset` command.

**Fix**: Added the missing command handler (lines 61-66).

**Impact**: MCP tools can now fully automate factory reset testing.

### 2. Terminal Registry Appears Out of Sync

**Problem**: After factory reset creates terminals, `list_terminals` IPC call returned 0 terminals even though tmux sessions existed and were running.

**Root Cause**: 
- Daemon starts with empty registry (correct - no tmux sessions exist yet)
- Factory reset later creates terminals and adds them to registry
- However, registry wasn't being populated when queried after daemon restart

**Fix**: Implemented lazy population in `list_terminals()` method:
- Automatically calls `restore_from_tmux()` if registry is empty
- Ensures registry is populated on first query after daemon restart

**Verification**: Direct IPC test confirmed 10 terminals in registry after factory reset (previously 0).

**Files Changed**:
- `loom-daemon/src/terminal.rs` (lines 93-102) - Added lazy population logic
- `loom-daemon/src/ipc.rs` (line 111) - Changed to mutable lock for list operation

### 3. MCP Terminals Server Communication Failures

**Problem**: MCP `list_terminals` tool couldn't communicate with daemon properly, always returning "No active terminals found".

**Root Cause**: Two bugs in `mcp-loom-terminals/src/index.ts`:
1. Wrong socket path: `/tmp/loom-daemon.sock` instead of `~/.loom/loom-daemon.sock`
2. Wrong payload structure: Expected `payload: Terminal[]` but actual is `payload: { terminals: Terminal[] }`

**Fix**: Corrected both socket path and payload parsing (lines 11, 85-101).

**Impact**: MCP tools can now properly query terminal information from daemon.

### 4. Log Cleanup Helper

**Problem**: Manual log cleanup during testing was tedious and error-prone.

**Fix**: Added `logs:clean` script to `package.json` for one-command log cleanup.

## Testing

### Direct IPC Test
```bash
echo '{"type":"ListTerminals"}' | nc -U ~/.loom/loom-daemon.sock | jq '.payload.terminals | length'
# Output: 10 (previously 0)
```

### MCP Tool Test
```bash
mcp__loom-terminals__list_terminals
# Now correctly returns all active terminals
```

### Factory Reset Test
```bash
mcp__loom-ui__trigger_force_factory_reset
# Successfully triggers factory reset without confirmation
```

## Files Changed

- `src-tauri/src/mcp_watcher.rs` - Add missing MCP command handler
- `loom-daemon/src/terminal.rs` - Implement lazy registry population
- `loom-daemon/src/ipc.rs` - Use mutable lock for list operation
- `mcp-loom-terminals/src/index.ts` - Fix socket path and payload parsing
- `package.json` - Add logs:clean helper script

## Related Issues

This PR unblocks testing for Issue #84 (factory reset reliability) and improves overall MCP tool reliability for automated testing workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)