### PR TITLE
Fix false 'missing session' errors on workspace startup

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -314,7 +314,9 @@ export function splitTerminals(terminals: Terminal[]): {
 
   const state: TerminalState[] = terminals.map((t) => ({
     id: t.id,
-    status: t.status,
+    // Don't persist error status - terminals should start as idle
+    // Health monitor will re-detect missing sessions if they actually don't exist
+    status: t.status === TerminalStatus.Error ? TerminalStatus.Idle : t.status,
     isPrimary: t.isPrimary,
     worktreePath: t.worktreePath,
     agentPid: t.agentPid,

--- a/src/lib/health-monitor.ts
+++ b/src/lib/health-monitor.ts
@@ -214,8 +214,9 @@ export class HealthMonitor {
 
   /**
    * Perform health check on all terminals
+   * Public to allow immediate health checks on workspace start
    */
-  private async performHealthCheck(): Promise<void> {
+  public async performHealthCheck(): Promise<void> {
     const state = getAppState();
     const terminals = state.getTerminals();
     const now = Date.now();

--- a/src/lib/workspace-start.ts
+++ b/src/lib/workspace-start.ts
@@ -175,6 +175,14 @@ export async function startWorkspaceEngine(
         terminals: terminalStates2,
       });
 
+      // Trigger immediate health check to verify terminal sessions exist
+      // This prevents false "missing session" errors on startup
+      console.log(`[${logPrefix}] Running immediate health check...`);
+      const { getHealthMonitor } = await import("./health-monitor");
+      const healthMonitor = getHealthMonitor();
+      await healthMonitor.performHealthCheck();
+      console.log(`[${logPrefix}] Health check complete`);
+
       console.log(`[${logPrefix}] Workspace engine started successfully`);
     } else {
       // No agents in config - still set workspace as active


### PR DESCRIPTION
## Problem

Terminals were appearing broken on startup with `missingSession` errors even though they were actually working correctly. The issue persisted for 11-30 seconds until the health monitor ran its periodic check.

## Root Cause

1. Terminals saved with `status="error"` in `state.json` (persisted across restarts)
2. Health monitor started but waited 30 seconds before first check
3. App loaded error states from disk and assumed sessions were missing
4. Health monitor eventually detected sessions and cleared the flag

## Solution

This PR implements a three-part fix:

### Part 1: Don't persist transient error states
- Modified `splitTerminals()` in `config.ts` to convert error status to idle when saving
- Error status is now runtime-only, not persisted across restarts
- Health monitor will re-detect real missing sessions if they occur

### Part 2: Make performHealthCheck public
- Changed method visibility in `health-monitor.ts` from private to public
- Allows immediate health verification from workspace initialization code

### Part 3: Trigger immediate health check
- Added health check call in `workspace-start.ts` after terminal creation
- Runs within 1-2 seconds instead of waiting 30 seconds
- Prevents false negative UI states on startup

## Benefits

- ✅ No false "missing session" errors on startup
- ✅ Fast recovery (1-2s vs 30s)
- ✅ Terminals load as "idle", health check confirms immediately
- ✅ Still detects real missing sessions if they occur

## Files Changed

- `src/lib/config.ts` - splitTerminals error sanitization
- `src/lib/health-monitor.ts` - public performHealthCheck method
- `src/lib/workspace-start.ts` - immediate health check after terminal creation

## Testing

1. Build and run the app with these changes
2. Start workspace with terminals
3. Verify terminals show as "idle" immediately (no 30s delay)
4. Verify console logs show "Running immediate health check..." and "Health check complete"
5. Confirm no false "missing session" error overlays

Related to ongoing stability improvements from #234.