### PR TITLE
Fix runtime health check causing false missingSession errors

### DIFF
--- a/src/lib/workspace-start.ts
+++ b/src/lib/workspace-start.ts
@@ -13,6 +13,7 @@ export interface WorkspaceStartDependencies {
   setCurrentAttachedTerminalId: (id: string | null) => void;
   launchAgentsForTerminals: (workspacePath: string, terminals: Terminal[]) => Promise<void>;
   render: () => void;
+  markTerminalsHealthChecked: (terminalIds: string[]) => void;
 }
 
 /**
@@ -182,6 +183,14 @@ export async function startWorkspaceEngine(
       const healthMonitor = getHealthMonitor();
       await healthMonitor.performHealthCheck();
       console.log(`[${logPrefix}] Health check complete`);
+
+      // Mark all terminals as health-checked to prevent redundant checks in render loop
+      const terminalIds = state.getTerminals().map((t) => t.id);
+      dependencies.markTerminalsHealthChecked(terminalIds);
+      console.log(
+        `[${logPrefix}] Marked ${terminalIds.length} terminals as health-checked:`,
+        terminalIds
+      );
 
       console.log(`[${logPrefix}] Workspace engine started successfully`);
     } else {

--- a/src/main.ts
+++ b/src/main.ts
@@ -615,6 +615,12 @@ if (!eventListenersRegistered) {
         },
         launchAgentsForTerminals,
         render,
+        markTerminalsHealthChecked: (terminalIds) => {
+          terminalIds.forEach((id) => healthCheckedTerminals.add(id));
+          console.log(
+            `[start-workspace] [Phase 3] Marked ${terminalIds.length} terminals as health-checked, Set size: ${healthCheckedTerminals.size}`
+          );
+        },
       },
       "start-workspace"
     );
@@ -647,6 +653,12 @@ if (!eventListenersRegistered) {
         },
         launchAgentsForTerminals,
         render,
+        markTerminalsHealthChecked: (terminalIds) => {
+          terminalIds.forEach((id) => healthCheckedTerminals.add(id));
+          console.log(
+            `[force-start-workspace] [Phase 3] Marked ${terminalIds.length} terminals as health-checked, Set size: ${healthCheckedTerminals.size}`
+          );
+        },
       },
       "force-start-workspace"
     );


### PR DESCRIPTION
## Problem

Terminals showed `missingSession=true` approximately 2.5 seconds after successful workspace start, even though tmux sessions existed and the immediate health check passed.

Two health check systems were out of sync:
1. **HealthMonitor** runs immediate health check after workspace start (succeeds)
2. **Render loop** in `initializeTerminalDisplay` runs redundant health checks

The `healthCheckedTerminals` Set was being **cleared** during workspace start but **not populated** after the immediate health check. This caused the render loop (~1 second interval) to think no terminals had been checked, so it ran its own health check which failed and set `missingSession=true`.

## Solution

Added callback to populate `healthCheckedTerminals` Set after immediate health check:

**Changes:**
1. `workspace-start.ts`: Added `markTerminalsHealthChecked` to `WorkspaceStartDependencies` interface
2. `workspace-start.ts`: Call callback after health check to mark all terminals as checked
3. `main.ts`: Implement callback in both `start-workspace` and `force-start-workspace` listeners

## Result

- ✅ Immediate health check runs and verifies sessions exist
- ✅ `healthCheckedTerminals` Set is populated with all terminal IDs  
- ✅ Render loop sees terminals already checked, skips redundant checks
- ✅ No false `missingSession=true` errors after startup

## Testing

TypeScript compilation passes. The fix ensures terminals that pass the immediate health check won't be rechecked by the render loop.

## Related

Builds on PR #245 (state persistence fix) - this addresses the runtime health check issue discovered during testing.