### PR TITLE
Fix terminal rename losing focus immediately after double-click

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1566,8 +1566,13 @@ function startRename(terminalId: string, nameElement: HTMLElement) {
   if (!parent) return;
 
   parent.replaceChild(input, nameElement);
-  input.focus();
-  input.select();
+
+  // Defer focus to the next tick to prevent the double-click event from interfering
+  // The double-click bubbles up and can trigger other handlers that might steal focus
+  setTimeout(() => {
+    input.focus();
+    input.select();
+  }, 0);
 
   const commit = () => {
     const newName = input.value.trim();


### PR DESCRIPTION
Fixes #262

## Problem

When double-clicking a terminal name to rename it, the input field appeared but immediately lost focus, making inline renaming completely unusable.

## Root Cause

The `startRename()` function called `input.focus()` and `input.select()` immediately after replacing the DOM element. However, the double-click event was still bubbling up through the event chain, and other event handlers (or browser default behavior) were stealing focus before the input could capture it.

## Solution

Defer the focus operation to the next event loop tick using `setTimeout(..., 0)`. This allows:
1. The double-click event to fully complete and finish bubbling
2. All event handlers to run
3. The browser to process any pending actions
4. Then focus the input field cleanly

## Changes

- Modified `startRename()` in `src/main.ts` (lines 1570-1575)
- Wrapped `input.focus()` and `input.select()` in `setTimeout(..., 0)`
- Added explanatory comment about why deferral is needed

## Testing

- ✅ TypeScript compilation passes
- ✅ Biome linting passes
- ✅ Rust formatting passes
- ✅ Clippy passes
- ✅ Build completes successfully

## Impact

This is a minimal change with no side effects:
- Only affects the terminal rename feature
- No changes to state management, event handlers, or other components
- The 0ms timeout simply defers to the next tick, adding negligible delay (<1ms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>