### PR TITLE
Add tarot card reveal effect during terminal drag

### DIFF
--- a/src/lib/tarot-cards.ts
+++ b/src/lib/tarot-cards.ts
@@ -1,0 +1,93 @@
+/**
+ * Tarot Card Mapping for Role-Based Terminal UI
+ *
+ * Maps terminal roles to their corresponding tarot card SVG assets.
+ * Used for visual effects during drag-and-drop operations.
+ */
+
+export type TarotRole =
+  | "worker"
+  | "curator"
+  | "architect"
+  | "reviewer"
+  | "critic"
+  | "fixer"
+  | "default";
+
+/**
+ * Maps a role string to the corresponding tarot card SVG path
+ * @param role - The terminal role (e.g., "claude-code-worker", "curator", etc.)
+ * @returns Path to the tarot card SVG file, or default card if role not recognized
+ */
+export function getTarotCardPath(role: string | undefined): string {
+  // Extract base role from role identifiers like "claude-code-worker"
+  const normalizedRole = normalizeRole(role);
+
+  const roleToCard: Record<TarotRole, string> = {
+    worker: "assets/tarot-cards/worker.svg",
+    curator: "assets/tarot-cards/curator.svg",
+    architect: "assets/tarot-cards/architect.svg",
+    reviewer: "assets/tarot-cards/reviewer.svg",
+    critic: "assets/tarot-cards/critic.svg",
+    fixer: "assets/tarot-cards/fixer.svg",
+    default: "assets/tarot-cards/worker.svg", // Fallback to worker card
+  };
+
+  return roleToCard[normalizedRole] || roleToCard.default;
+}
+
+/**
+ * Normalizes a role identifier to the base tarot role
+ * @param role - Role identifier (e.g., "claude-code-worker", "worker", "curator")
+ * @returns Normalized tarot role
+ */
+function normalizeRole(role: string | undefined): TarotRole {
+  if (!role) {
+    return "default";
+  }
+
+  const lowerRole = role.toLowerCase();
+
+  // Map various role formats to tarot roles
+  if (lowerRole.includes("worker")) {
+    return "worker";
+  }
+  if (lowerRole.includes("curator")) {
+    return "curator";
+  }
+  if (lowerRole.includes("architect")) {
+    return "architect";
+  }
+  if (lowerRole.includes("reviewer")) {
+    return "reviewer";
+  }
+  if (lowerRole.includes("critic")) {
+    return "critic";
+  }
+  if (lowerRole.includes("fixer")) {
+    return "fixer";
+  }
+
+  return "default";
+}
+
+/**
+ * Gets the tarot archetype name for a role
+ * @param role - The terminal role
+ * @returns The tarot archetype name (e.g., "The Magician")
+ */
+export function getTarotArchetype(role: string | undefined): string {
+  const normalizedRole = normalizeRole(role);
+
+  const roleToArchetype: Record<TarotRole, string> = {
+    worker: "The Magician",
+    curator: "The High Priestess",
+    architect: "The Emperor",
+    reviewer: "Justice",
+    critic: "The Hermit",
+    fixer: "The Hanged Man",
+    default: "The Fool",
+  };
+
+  return roleToArchetype[normalizedRole] || roleToArchetype.default;
+}

--- a/src/lib/ui.ts
+++ b/src/lib/ui.ts
@@ -1,4 +1,5 @@
 import { type Terminal, TerminalStatus } from "./state";
+import { getTarotCardPath } from "./tarot-cards";
 import { getTheme, getThemeStyles, isDarkMode } from "./themes";
 
 /**
@@ -506,42 +507,53 @@ function createMiniTerminalHTML(
     }
   }
 
+  // Get tarot card path for this terminal's role
+  const tarotCardPath = getTarotCardPath(terminal.role);
+
   return `
     <div class="p-1 flex-shrink-0">
       <div class="relative">
         ${needsInputBadge}
         <div
-          class="terminal-card group w-40 h-40 bg-white dark:bg-gray-800 hover:bg-gray-900/5 dark:hover:bg-white/5 rounded-lg cursor-grab transition-all"
+          class="terminal-card group w-40 h-40 bg-white dark:bg-gray-800 hover:bg-gray-900/5 dark:hover:bg-white/5 rounded-lg cursor-grab transition-all relative overflow-hidden"
           style="border: ${borderWidth}px solid ${borderColor}"
           data-terminal-id="${terminal.id}"
           draggable="true"
         >
-        <div class="p-2 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700 group-hover:bg-gray-100 dark:group-hover:bg-gray-600 flex items-center justify-between transition-colors rounded-t-lg" style="background-color: ${styles.backgroundColor}">
-          <div class="flex items-center gap-2 flex-1 min-w-0">
-            <div class="w-2 h-2 rounded-full flex-shrink-0 ${getStatusColor(terminal.status)}"></div>
-            <span class="terminal-name text-xs font-medium truncate" data-tooltip="Double-click to rename, drag to reorder" data-tooltip-position="top">${escapeHtml(terminal.name)}</span>
+          <!-- Regular terminal card content -->
+          <div class="terminal-card-content">
+            <div class="p-2 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700 group-hover:bg-gray-100 dark:group-hover:bg-gray-600 flex items-center justify-between transition-colors rounded-t-lg" style="background-color: ${styles.backgroundColor}">
+              <div class="flex items-center gap-2 flex-1 min-w-0">
+                <div class="w-2 h-2 rounded-full flex-shrink-0 ${getStatusColor(terminal.status)}"></div>
+                <span class="terminal-name text-xs font-medium truncate" data-tooltip="Double-click to rename, drag to reorder" data-tooltip-position="top">${escapeHtml(terminal.name)}</span>
+              </div>
+              <div class="flex items-center gap-0.5 flex-shrink-0">
+                ${createRunNowButtonHTML(terminal, "mini")}
+                <button
+                  class="close-terminal-btn text-gray-400 hover:text-red-500 dark:hover:text-red-400 font-bold transition-colors"
+                  data-terminal-id="${terminal.id}"
+                  data-tooltip="Close terminal"
+                  data-tooltip-position="top"
+                  title="Close terminal"
+                >
+                  ×
+                </button>
+              </div>
+            </div>
+            <div class="p-2 text-xs text-gray-500 dark:text-gray-400 flex flex-col gap-1">
+              <div class="flex items-center justify-between">
+                <span>${terminal.status}</span>
+                <span class="font-mono font-bold text-blue-600 dark:text-blue-400">#${index}</span>
+              </div>
+              ${activityInfo ? `<div class="flex items-center justify-between">${activityInfo}</div>` : ""}
+              ${createTimerDisplayHTML(terminal)}
+            </div>
           </div>
-          <div class="flex items-center gap-0.5 flex-shrink-0">
-            ${createRunNowButtonHTML(terminal, "mini")}
-            <button
-              class="close-terminal-btn text-gray-400 hover:text-red-500 dark:hover:text-red-400 font-bold transition-colors"
-              data-terminal-id="${terminal.id}"
-              data-tooltip="Close terminal"
-              data-tooltip-position="top"
-              title="Close terminal"
-            >
-              ×
-            </button>
+
+          <!-- Tarot card overlay (hidden by default, shown during drag) -->
+          <div class="tarot-card-overlay absolute inset-0 opacity-0 pointer-events-none flex items-center justify-center bg-gray-900 dark:bg-black rounded-lg">
+            <img src="${tarotCardPath}" alt="Tarot card" class="h-full w-full object-contain p-2" />
           </div>
-        </div>
-        <div class="p-2 text-xs text-gray-500 dark:text-gray-400 flex flex-col gap-1">
-          <div class="flex items-center justify-between">
-            <span>${terminal.status}</span>
-            <span class="font-mono font-bold text-blue-600 dark:text-blue-400">#${index}</span>
-          </div>
-          ${activityInfo ? `<div class="flex items-center justify-between">${activityInfo}</div>` : ""}
-          ${createTimerDisplayHTML(terminal)}
-        </div>
         </div>
       </div>
     </div>

--- a/src/style.css
+++ b/src/style.css
@@ -38,6 +38,23 @@
   cursor: grabbing;
 }
 
+/* Tarot card reveal effect during drag */
+.terminal-card-content {
+  transition: opacity 200ms ease-in-out;
+}
+
+.terminal-card.dragging .terminal-card-content {
+  opacity: 0;
+}
+
+.tarot-card-overlay {
+  transition: opacity 200ms ease-in-out;
+}
+
+.terminal-card.dragging .tarot-card-overlay {
+  opacity: 1;
+}
+
 /* Modal animations */
 @keyframes fade-in {
   from {


### PR DESCRIPTION
## Summary

Implements mystical tarot card reveal when dragging terminals in the mini row (#277). Terminal cards transform into their archetypal tarot representation during drag operations.

**Visual behavior**:
- **Default state**: Normal terminal card visible, tarot overlay hidden
- **Dragging state**: Terminal content fades out, tarot card fades in with 200ms transition
- **Smooth reveal**: Creates subtle mystical aesthetic matching archetypal branding

## Implementation

**New file - `src/lib/tarot-cards.ts`**:
- `getTarotCardPath()`: Maps role strings to tarot card SVG paths
- `getTarotArchetype()`: Returns tarot archetype name for role
- `normalizeRole()`: Handles role variations (e.g., "claude-code-worker" → "worker")

**Updated `src/lib/ui.ts`**:
- Modified `createMiniTerminalHTML()` to add tarot card overlay
- Overlay absolutely positioned with `opacity: 0` by default
- Terminal content wrapped in `.terminal-card-content` div

**Updated `src/style.css`**:
- CSS transitions for `.terminal-card-content` and `.tarot-card-overlay`
- `.dragging` class triggers opacity swap (content → 0, overlay → 1)
- 200ms ease-in-out transition timing

## Technical approach

**CSS-driven** (no JavaScript changes):
- Hooks into existing `.dragging` class from HTML5 drag implementation (src/main.ts:1804)
- Pure CSS opacity transitions provide smooth reveal
- No modifications to drag event handlers needed

**Role mapping**:
| Role | Tarot Card | Archetype |
|------|------------|-----------|
| Worker | worker.svg | The Magician |
| Curator | curator.svg | The High Priestess |
| Architect | architect.svg | The Emperor |
| Reviewer | reviewer.svg | Justice |
| Critic | critic.svg | The Hermit |
| Fixer | fixer.svg | The Hanged Man |

**Fallback**: Terminals without specific roles default to worker card (The Magician)

## Screenshots

_Note: This PR provides the integration layer for tarot cards. The actual tarot card SVG assets are in PR #276._

## Dependencies

- ✅ **No dependency on #276** - Can be developed and reviewed independently
- ⚠️ **Visual effect requires #276 merged** - Tarot cards will show placeholder paths until assets are available

## Test plan

1. **Build verification**: ✅ `pnpm build` succeeds
2. **Visual testing** (requires #276 merged):
   - Open workspace with multiple terminals
   - Assign different roles to terminals (worker, curator, architect, etc.)
   - Drag terminal cards and verify tarot card reveals
   - Check smooth 200ms opacity transition
   - Verify cards match assigned roles
3. **Fallback testing**:
   - Create terminal without specific role
   - Verify it shows worker card (The Magician) during drag
4. **Theme compatibility**:
   - Test in both dark and light themes
   - Verify tarot cards visible in both

## Future enhancements

Potential improvements for future PRs:
- Add rotation or scale effect during drag for more dramatic reveal
- Implement card flip animation (front/back transition)
- Add particle effects or glow around dragged cards
- Consider sound effects for drag/drop (optional, configurable)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)