### PR TITLE
Fix Workers Missing Curator Enhancements in Comments (#300)

### DIFF
--- a/defaults/roles/critic.md
+++ b/defaults/roles/critic.md
@@ -604,7 +604,7 @@ $ gh issue list --state=open --json number,title,body --jq '.[] | "\(.number): \
 ...
 
 # Review issue #42 about auth refactoring
-$ gh issue view 42
+$ gh issue view 42 --comments
 
 # Notice: Issue mentions supporting OAuth, SAML, and LDAP
 # Check: Are all these actually used?
@@ -658,7 +658,7 @@ gh issue list --state=open --json number,title,labels \
   --jq '.[] | select(([.labels[].name] | inside(["loom:critic-suggestion"])) | not) | "\(.number): \(.title)"'
 
 # View issue details before commenting
-gh issue view <number>
+gh issue view <number> --comments
 
 # Search for issues related to specific topic
 gh issue list --search "authentication" --state=open

--- a/defaults/roles/curator.md
+++ b/defaults/roles/curator.md
@@ -139,6 +139,33 @@ Issue #99: "fix the crash bug"
 - Estimate complexity and effort when helpful
 - Break down large features into phased deliverables
 
+## Where to Add Enhancements
+
+Add your detailed enhancements as **issue comments** (not edits to the body). Workers are instructed to read comments via `gh issue view <number> --comments`, so this is where they'll find your detailed guidance.
+
+**Why comments instead of body edits:**
+- Preserves original issue for context
+- Shows curation as explicit review step
+- Easier to see what was added vs original
+- GitHub UI highlights new comments
+
+**Example workflow:**
+```bash
+# 1. Read issue with comments
+gh issue view 100 --comments
+
+# 2. Add your enhancement as a comment
+gh issue comment 100 --body "$(cat <<'EOF'
+## Implementation Guidance
+
+[Your detailed enhancement here...]
+EOF
+)"
+
+# 3. Mark as ready
+gh issue edit 100 --add-label "loom:ready"
+```
+
 ## Checking Dependencies
 
 Before marking an issue as `loom:ready`, check if it has a **Dependencies** section with a task list.

--- a/defaults/roles/worker.md
+++ b/defaults/roles/worker.md
@@ -103,6 +103,27 @@ pnpm worktree 84
 
 This on-demand approach prevents worktree clutter and reduces resource usage.
 
+## Reading Issues: Always Include Comments
+
+**Curator adds detailed enhancements in comments.** Always use `--comments` flag:
+
+```bash
+# CORRECT - See full context including Curator enhancements
+gh issue view 100 --comments
+
+# WRONG - Only sees original issue body
+gh issue view 100
+```
+
+Curator comments typically include:
+- Root cause analysis
+- Implementation guidance
+- Detailed acceptance criteria
+- Test plans and debugging tips
+- Code examples and specifications
+
+**Read these before starting work** - they contain the detailed requirements.
+
 ## Checking Dependencies Before Claiming
 
 Before claiming a `loom:ready` issue, check if it has a **Dependencies** section.
@@ -146,7 +167,7 @@ If you discover a dependency while working:
 
 ```bash
 # Before claiming issue #100, check it
-gh issue view 100
+gh issue view 100 --comments
 
 # If you see unchecked dependencies, mark as blocked instead
 gh issue edit 100 --remove-label "loom:ready" --add-label "loom:blocked"


### PR DESCRIPTION
Workers now use `gh issue view --comments` to see full issue context including
Curator enhancements added as comments. Updated all role prompts to use the flag
consistently.

Changes:
- Add "Reading Issues: Always Include Comments" section to Worker prompt
- Update Worker example commands to include --comments flag
- Add "Where to Add Enhancements" section to Curator prompt documenting that
  enhancements go in comments and Workers read them
- Update Critic commands to include --comments flag for consistency

This ensures Workers see root cause analysis, implementation guidance, acceptance
criteria, test plans, and code examples that Curators add as comments.

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
