### PR TITLE
Fix unit tests

### DIFF
--- a/src/lib/health-monitor.ts
+++ b/src/lib/health-monitor.ts
@@ -143,12 +143,13 @@ export class HealthMonitor {
     let errorTerminals = 0;
 
     for (const terminal of terminals) {
-      const health = this.terminalHealth.get(terminal.id);
-      if (!health) continue;
-
+      // Count active terminals based on status alone (don't require health record)
       if (terminal.status !== TerminalStatus.Stopped) {
         activeTerminals++;
       }
+
+      const health = this.terminalHealth.get(terminal.id);
+      if (!health) continue;
 
       if (health.hasSession && !health.isStale && health.pollerErrors === 0) {
         healthyTerminals++;


### PR DESCRIPTION
## Summary
Fixed two failing unit tests in `health-monitor.test.ts`:

1. **"counts active terminals correctly"** - Fixed activeTerminals count to include terminals without health records (e.g., Busy terminals that are skipped during health checks)
2. **"detects terminal session loss and recovery"** - Changed mock setup from `mockResolvedValueOnce` to `mockImplementation` to properly differentiate between `check_session_health` and `check_daemon_health` invoke commands

## Changes
- `src/lib/health-monitor.ts:145-149`: Moved active terminal counting before health record check
- `src/lib/health-monitor.test.ts:643-690`: Updated test mock setup to use `mockImplementation` pattern

## Test Plan
- [x] All 36 health monitor unit tests pass
- [x] No new lint errors introduced
- [x] Pre-commit hooks passed

## Notes
There are pre-existing lint warnings in test files (unrelated to this PR) that will need to be addressed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #295