### PR TITLE
Include terminal name in close confirmation dialog

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -527,7 +527,7 @@ if (!eventListenersRegistered) {
   listen("close-terminal", async () => {
     const primary = state.getPrimary();
     if (primary) {
-      const confirmed = await ask("Are you sure you want to close this terminal?", {
+      const confirmed = await ask(`Are you sure you want to close "${primary.name}"?`, {
         title: "Close Terminal",
         type: "warning",
       });
@@ -1590,7 +1590,9 @@ function setupEventListeners() {
         e.stopPropagation();
         const id = closeBtn.getAttribute("data-terminal-id");
         if (id) {
-          ask("Are you sure you want to close this terminal?", {
+          const terminal = state.getTerminal(id);
+          const terminalName = terminal ? terminal.name : "this terminal";
+          ask(`Are you sure you want to close "${terminalName}"?`, {
             title: "Close Terminal",
             type: "warning",
           }).then(async (confirmed) => {
@@ -1708,12 +1710,16 @@ function setupEventListeners() {
         const id = target.getAttribute("data-terminal-id");
 
         if (id) {
-          ask("Are you sure you want to close this terminal?", {
+          // Look up the terminal to get its name
+          const terminal = state.getTerminal(id);
+          const terminalName = terminal ? terminal.name : "this terminal";
+
+          ask(`Are you sure you want to close "${terminalName}"?`, {
             title: "Close Terminal",
             type: "warning",
           }).then(async (confirmed) => {
             if (confirmed) {
-              // Look up the terminal
+              // Look up the terminal again for the rest of the logic
               const terminal = state.getTerminal(id);
               if (!terminal) {
                 console.error(`Terminal with id ${id} not found`);


### PR DESCRIPTION
## Summary

Updated the close terminal confirmation message to display the terminal name, making it clear which terminal is being closed. This improves UX by preventing accidental terminal closures.

## Changes

- Modified three confirmation dialogs in `src/main.ts` to include terminal name in the prompt:
  - Menu listener for "close-terminal" event
  - Primary terminal close button handler
  - Mini terminal row close button handler

## Example

Before: "Are you sure you want to close this terminal?"
After: "Are you sure you want to close \"Worker 1\"?"

## Test Plan

- [x] Code changes pass linting checks
- [ ] Manual testing: Open Loom, create multiple terminals, click close button on each
- [ ] Verify terminal name appears in confirmation dialog for all three close methods

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)