### PR TITLE
Fix defaults directory resolution for Tauri bundled resources

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -425,6 +425,13 @@ fn resolve_defaults_path(defaults_path: &str) -> Result<std::path::PathBuf, Stri
             if let Some(contents_dir) = exe_dir.parent() {
                 let resources_dir = contents_dir.join("Resources");
 
+                // Try with _up_ prefix (Tauri bundles ../defaults as _up_/defaults)
+                let up_path = resources_dir.join("_up_").join(defaults_path);
+                tried_paths.push(up_path.display().to_string());
+                if up_path.exists() {
+                    return Ok(up_path);
+                }
+
                 // Try with subdirectory name (standard Tauri bundling)
                 let resources_path = resources_dir.join(defaults_path);
                 tried_paths.push(resources_path.display().to_string());


### PR DESCRIPTION
## Summary

Fixes the "Defaults directory not found" error that occurs during workspace initialization in production builds.

## Problem

When Tauri bundles resources with relative paths like `../defaults` (as specified in `tauri.conf.json`), it creates a `_up_` directory to represent parent directory traversal. The actual bundle location is:

- **Expected path**: `/Applications/Loom.app/Contents/Resources/defaults`
- **Actual path**: `/Applications/Loom.app/Contents/Resources/_up_/defaults`

PR #291 attempted to fix this by adding better error messages and checking for flattened structures, but it missed checking the `_up_` path where Tauri actually places the bundled defaults directory.

## Solution

Updated `resolve_defaults_path()` in `src-tauri/src/main.rs` to check for the `_up_/defaults` path as the **first priority** when resolving bundled resources:

```rust
// Try with _up_ prefix (Tauri bundles ../defaults as _up_/defaults)
let up_path = resources_dir.join("_up_").join(defaults_path);
tried_paths.push(up_path.display().to_string());
if up_path.exists() {
    return Ok(up_path);
}
```

## Changes

- Added check for `Contents/Resources/_up_/defaults` path (actual Tauri bundle location)
- Prioritized `_up_` path check before other fallback strategies
- Maintains full backward compatibility with all existing path resolution methods

## Testing

- ✅ Built production release with `pnpm app:build`
- ✅ Verified `_up_/defaults` directory structure exists in bundle
- ✅ Installed to `/Applications/Loom.app` 
- ✅ Ready for workspace initialization testing
- ✅ Development mode paths remain unaffected

## Backward Compatibility

The fix maintains compatibility with all existing path resolution strategies:
- Development mode relative paths
- Git worktree resolution
- Flattened resource structures
- Direct resource paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>