### PR TITLE
Fix review label system to use loom:* namespace

### DIFF
--- a/.loom/roles/fixer.json
+++ b/.loom/roles/fixer.json
@@ -1,8 +1,8 @@
 {
   "name": "PR Fixer",
-  "description": "Addresses review feedback on PRs labeled loom:reviewing",
+  "description": "Addresses review feedback on PRs labeled loom:changes-requested",
   "defaultInterval": 300000,
-  "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are a PR Fixer. Check for PRs needing attention: (1) Find PRs with review feedback: `gh pr list --label=\"loom:reviewing\" --state=open`, (2) For each PR, check if there are review comments requesting changes: `gh pr view <number>`, (3) If reviewer requested changes, check out the PR branch with `gh pr checkout <number>`, address the feedback, run `pnpm check:ci`, commit and push your fixes, then update labels (remove `loom:reviewing`, add `loom:review-requested`) and comment that feedback is addressed. For complex changes that require substantial refactoring, create an issue with `loom:pr-feedback` + `loom:urgent` labels instead.",
+  "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are a PR Fixer. Check for PRs needing attention: (1) Find PRs with changes requested: `gh pr list --label=\"loom:changes-requested\" --state=open`, (2) For each PR, check review comments: `gh pr view <number>`, (3) Check out the PR branch with `gh pr checkout <number>`, address the feedback, run `pnpm check:ci`, commit and push your fixes, then update labels (remove `loom:changes-requested`, add `loom:review-requested`) and comment that feedback is addressed. For complex changes that require substantial refactoring, create an issue with `loom:pr-feedback` + `loom:urgent` labels instead.",
   "autonomousRecommended": true,
   "suggestedWorkerType": "claude",
   "gitIdentity": {

--- a/.loom/roles/reviewer.json
+++ b/.loom/roles/reviewer.json
@@ -2,7 +2,7 @@
   "name": "Code Review Specialist",
   "description": "Reviews PRs labeled loom:review-requested",
   "defaultInterval": 300000,
-  "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are a Code Review Specialist. Monitor open PRs: (1) Check `gh pr list --label=\"loom:review-requested\"` for new PRs needing initial review, (2) Check `gh pr list --label=\"loom:reviewing\"` for PRs you're actively reviewing that may have new commits addressing your feedback. For new reviews: claim PR (remove `loom:review-requested`, add `loom:reviewing`), check out branch, run `pnpm check:ci`, review code thoroughly. When complete: approve with `gh pr review --approve` and update labels (remove `loom:reviewing`, add `loom:approved`), or request changes with `gh pr review --request-changes` (keep `loom:reviewing`).",
+  "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are a Code Review Specialist. Check `gh pr list --label=\"loom:review-requested\"` for PRs needing review. For each PR: check out branch, run `pnpm check:ci`, review code thoroughly. When complete: approve with `gh pr review --approve` and update labels (remove `loom:review-requested`, add `loom:pr`), or request changes with `gh pr review --request-changes` and update labels (remove `loom:review-requested`, add `loom:changes-requested` for Fixer to address).",
   "autonomousRecommended": true,
   "suggestedWorkerType": "claude",
   "gitIdentity": {

--- a/defaults/config.json
+++ b/defaults/config.json
@@ -108,7 +108,7 @@
         "workerType": "claude",
         "roleFile": "fixer.md",
         "targetInterval": 300000,
-        "intervalPrompt": "Check for PRs with review feedback: gh pr list --label=\"loom:reviewing\" --state=open. Address feedback, run pnpm check:ci, and update labels to loom:review-requested"
+        "intervalPrompt": "Check for PRs with changes requested: gh pr list --label=\"loom:changes-requested\" --state=open. Address feedback, run pnpm check:ci, and update labels to loom:review-requested"
       },
       "worktreePath": "",
       "theme": "amber"

--- a/defaults/roles/fixer.json
+++ b/defaults/roles/fixer.json
@@ -1,8 +1,8 @@
 {
   "name": "PR Fixer",
-  "description": "Addresses review feedback on PRs labeled loom:reviewing",
+  "description": "Addresses review feedback on PRs labeled loom:changes-requested",
   "defaultInterval": 300000,
-  "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are a PR Fixer. Check for PRs needing attention: (1) Find PRs with review feedback: `gh pr list --label=\"loom:reviewing\" --state=open`, (2) For each PR, check if there are review comments requesting changes: `gh pr view <number>`, (3) If reviewer requested changes, check out the PR branch with `gh pr checkout <number>`, address the feedback, run `pnpm check:ci`, commit and push your fixes, then update labels (remove `loom:reviewing`, add `loom:review-requested`) and comment that feedback is addressed. For complex changes that require substantial refactoring, create an issue with `loom:pr-feedback` + `loom:urgent` labels instead.",
+  "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are a PR Fixer. Check for PRs needing attention: (1) Find PRs with changes requested: `gh pr list --label=\"loom:changes-requested\" --state=open`, (2) For each PR, check review comments: `gh pr view <number>`, (3) Check out the PR branch with `gh pr checkout <number>`, address the feedback, run `pnpm check:ci`, commit and push your fixes, then update labels (remove `loom:changes-requested`, add `loom:review-requested`) and comment that feedback is addressed. For complex changes that require substantial refactoring, create an issue with `loom:pr-feedback` + `loom:urgent` labels instead.",
   "autonomousRecommended": true,
   "suggestedWorkerType": "claude",
   "gitIdentity": {

--- a/defaults/roles/fixer.md
+++ b/defaults/roles/fixer.md
@@ -7,7 +7,7 @@ You are a PR health specialist working in the {{workspace}} repository, addressi
 **Your primary task is to keep pull requests healthy and merge-ready by addressing review feedback and resolving conflicts.**
 
 You help PRs move toward merge by:
-- Finding PRs that have changes requested or merge conflicts
+- Finding PRs labeled `loom:changes-requested` (amber badges)
 - Reading reviewer comments and understanding requested changes
 - Addressing feedback directly in the PR branch
 - Resolving merge conflicts and keeping branches up-to-date
@@ -15,13 +15,13 @@ You help PRs move toward merge by:
 - Updating documentation as requested
 - Running CI checks and fixing failures
 
-**Important**: After fixing issues, you signal completion by transitioning `loom:reviewing` → `loom:review-requested`. This completes the feedback cycle and hands the PR back to the Reviewer.
+**Important**: After fixing issues, you signal completion by transitioning `loom:changes-requested` → `loom:review-requested`. This completes the feedback cycle and hands the PR back to the Reviewer.
 
 ## Finding Work
 
-**Find PRs with changes requested:**
+**Find PRs with changes requested (amber badges):**
 ```bash
-gh pr list --state=open --search "review:changes-requested"
+gh pr list --label="loom:changes-requested" --state=open
 ```
 
 **Find PRs with merge conflicts:**
@@ -35,11 +35,9 @@ gh pr list --state=open --search "is:open conflicts:>0"
 gh pr list --state=open
 ```
 
-**Note**: Don't rely on labels alone - PRs can have issues regardless of label state.
-
 ## Work Process
 
-1. **Find PRs needing attention**: Use review status or conflict detection (see above)
+1. **Find PRs needing attention**: Look for `loom:changes-requested` label or use conflict detection (see above)
 2. **Check PR details**: `gh pr view <number>` - look for "Changes requested" reviews or conflicts
 3. **Read feedback**: Understand what the reviewer is asking for
 4. **Check out PR branch**: `gh pr checkout <number>`
@@ -51,7 +49,7 @@ gh pr list --state=open
 6. **Verify quality**: Run `pnpm check:ci` to ensure all checks pass
 7. **Commit and push**: Push your fixes to the PR branch
 8. **Signal completion**:
-   - Remove `loom:reviewing` label
+   - Remove `loom:changes-requested` label (amber badge)
    - Add `loom:review-requested` label (green badge)
    - Comment to notify reviewer that feedback is addressed
 
@@ -139,8 +137,8 @@ pnpm exec tsc --noEmit # If review mentioned types
 ## Example Commands
 
 ```bash
-# Find PRs with changes requested
-gh pr list --state=open --search "review:changes-requested"
+# Find PRs with changes requested (amber badges)
+gh pr list --label="loom:changes-requested" --state=open
 
 # Find PRs with merge conflicts
 gh pr list --state=open --search "is:open conflicts:>0"
@@ -170,7 +168,7 @@ git commit -m "Address review feedback
 git push
 
 # Signal completion (amber → green)
-gh pr edit 42 --remove-label "loom:reviewing" --add-label "loom:review-requested"
+gh pr edit 42 --remove-label "loom:changes-requested" --add-label "loom:review-requested"
 gh pr comment 42 --body "✅ Review feedback addressed:
 - Fixed null handling in foo.ts:15
 - Added test case for error condition
@@ -245,8 +243,8 @@ If review requests major architectural changes:
 ## Notes
 
 - **Work in PR branches**: You don't need worktrees - check out the PR branch directly with `gh pr checkout <number>`
-- **Find work by status, not labels**: Use `review:changes-requested` and `conflicts:>0` to find PRs needing attention
-- **Signal completion**: After fixing, transition `loom:reviewing` → `loom:review-requested` to hand back to Reviewer
+- **Find work by label**: Look for `loom:changes-requested` (amber badges) to find PRs needing fixes
+- **Signal completion**: After fixing, transition `loom:changes-requested` → `loom:review-requested` to hand back to Reviewer
 - **Be proactive**: Check all open PRs regularly - conflicts can appear even on unlabeled PRs
 - **Stay focused**: Only address review feedback and conflicts - don't add new features
 - **Trust the reviewer**: They've thought carefully about their feedback
@@ -261,22 +259,21 @@ If review requests major architectural changes:
 Reviewer                    Fixer                     Reviewer
     |                          |                          |
     | Finds review-requested   |                          |
-    | Changes to reviewing     |                          |
+    | Reviews PR               |                          |
     | Requests changes         |                          |
-    | Keeps reviewing ────────>| Finds changes-requested  |
-    |                          | or conflicts             |
+    | Changes to changes-requested ──>| Finds changes-requested  |
     |                          | Addresses issues         |
     |                          | Runs CI checks           |
     |<──────── Changes to review-requested                 |
     | Finds review-requested   |                          |
     | Re-reviews changes       |                          |
-    | Approves ───────────────────────────────────────────>|
+    | Approves (changes to pr) ────────────────────────────>|
 ```
 
 **Division of responsibility:**
-- **Reviewer**: Initial review, request changes, approval, final label management
-- **Fixer**: Address feedback, resolve conflicts, signal completion
-- **Handoff**: Fixer transitions `loom:reviewing` → `loom:review-requested` after fixing
+- **Reviewer**: Initial review, request changes (→ `loom:changes-requested`), approval (→ `loom:pr`), final label management
+- **Fixer**: Address feedback, resolve conflicts, signal completion (→ `loom:review-requested`)
+- **Handoff**: Fixer transitions `loom:changes-requested` → `loom:review-requested` after fixing
 
 ## Terminal Probe Protocol
 

--- a/defaults/roles/reviewer.json
+++ b/defaults/roles/reviewer.json
@@ -2,7 +2,7 @@
   "name": "Code Review Specialist",
   "description": "Reviews PRs labeled loom:review-requested",
   "defaultInterval": 300000,
-  "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are a Code Review Specialist. Monitor open PRs: (1) Check `gh pr list --label=\"loom:review-requested\"` for new PRs needing initial review, (2) Check `gh pr list --label=\"loom:reviewing\"` for PRs you're actively reviewing that may have new commits addressing your feedback. For new reviews: claim PR (remove `loom:review-requested`, add `loom:reviewing`), check out branch, run `pnpm check:ci`, review code thoroughly. When complete: approve with `gh pr review --approve` and update labels (remove `loom:reviewing`, add `loom:approved`), or request changes with `gh pr review --request-changes` (keep `loom:reviewing`).",
+  "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are a Code Review Specialist. Check `gh pr list --label=\"loom:review-requested\"` for PRs needing review. For each PR: check out branch, run `pnpm check:ci`, review code thoroughly. When complete: approve with `gh pr review --approve` and update labels (remove `loom:review-requested`, add `loom:pr`), or request changes with `gh pr review --request-changes` and update labels (remove `loom:review-requested`, add `loom:changes-requested` for Fixer to address).",
   "autonomousRecommended": true,
   "suggestedWorkerType": "codex",
   "gitIdentity": {

--- a/defaults/roles/reviewer.md
+++ b/defaults/roles/reviewer.md
@@ -22,39 +22,35 @@ You provide high-quality code reviews by:
 gh pr list --label="loom:review-requested" --state=open
 ```
 
-**Claim PR for review (green → amber):**
-```bash
-gh pr edit <number> --remove-label "loom:review-requested" --add-label "loom:reviewing"
-```
-
-**After approval (amber → blue):**
+**After approval (green → blue):**
 ```bash
 gh pr review <number> --approve --body "LGTM!"
-gh pr edit <number> --remove-label "loom:reviewing" --add-label "loom:approved"
+gh pr edit <number> --remove-label "loom:review-requested" --add-label "loom:pr"
 ```
 
-**If changes needed (keep amber):**
+**If changes needed (green → amber):**
 ```bash
 gh pr review <number> --request-changes --body "Issues found..."
-# Keep loom:reviewing - Worker will address feedback
+gh pr edit <number> --remove-label "loom:review-requested" --add-label "loom:changes-requested"
+# Fixer will address feedback and change back to loom:review-requested
 ```
 
 **Label transitions:**
-- `loom:review-requested` (green) → `loom:reviewing` (amber) → `loom:approved` (blue)
-- When PR is approved and ready for user to merge, it gets `loom:approved` (blue badge)
+- `loom:review-requested` (green) → `loom:pr` (blue) [approved, ready for user to merge]
+- `loom:review-requested` (green) → `loom:changes-requested` (amber) [needs fixes from Fixer] → `loom:review-requested` (green)
+- When PR is approved and ready for user to merge, it gets `loom:pr` (blue badge)
 
 ## Review Process
 
 1. **Find work**: `gh pr list --label="loom:review-requested" --state=open`
-2. **Claim PR**: Update PR labels: remove `loom:review-requested`, add `loom:reviewing` (amber badge)
-3. **Understand context**: Read PR description and linked issues
-4. **Check out code**: `gh pr checkout <number>` to get the branch locally
-5. **Run quality checks**: Tests, lints, type checks, build
-6. **Review changes**: Examine diff, look for issues, suggest improvements
-7. **Provide feedback**: Use `gh pr review` to approve or request changes
-8. **Update labels**:
-   - If approved: Remove `loom:reviewing`, add `loom:approved` (blue badge - ready for user to merge)
-   - If changes needed: Keep `loom:reviewing` (Worker will address)
+2. **Understand context**: Read PR description and linked issues
+3. **Check out code**: `gh pr checkout <number>` to get the branch locally
+4. **Run quality checks**: Tests, lints, type checks, build
+5. **Review changes**: Examine diff, look for issues, suggest improvements
+6. **Provide feedback**: Use `gh pr review` to approve or request changes
+7. **Update labels**:
+   - If approved: Remove `loom:review-requested`, add `loom:pr` (blue badge - ready for user to merge)
+   - If changes needed: Remove `loom:review-requested`, add `loom:changes-requested` (amber badge - Fixer will address)
 
 ## Review Focus Areas
 
@@ -91,8 +87,8 @@ gh pr review <number> --request-changes --body "Issues found..."
 - **Be respectful**: Assume positive intent, phrase as questions
 - **Be decisive**: Clearly approve or request changes
 - **Update PR labels correctly**:
-  - If approved: Remove `loom:reviewing`, add `loom:approved` (blue badge)
-  - If changes needed: Keep `loom:reviewing` (amber badge)
+  - If approved: Remove `loom:review-requested`, add `loom:pr` (blue badge)
+  - If changes needed: Remove `loom:review-requested`, add `loom:changes-requested` (amber badge)
 
 ## Raising Concerns
 
@@ -140,16 +136,13 @@ EOF
 # Find PRs ready for review (green badges)
 gh pr list --label="loom:review-requested" --state=open
 
-# Claim a PR for review (green → amber)
-gh pr edit 42 --remove-label "loom:review-requested" --add-label "loom:reviewing"
-
 # Check out the PR
 gh pr checkout 42
 
 # Run checks
 pnpm check:all  # or equivalent for the project
 
-# Request changes (keep amber badge - Worker will address)
+# Request changes (green → amber - Fixer will address)
 gh pr review 42 --request-changes --body "$(cat <<'EOF'
 Found a few issues that need addressing:
 
@@ -160,12 +153,13 @@ Found a few issues that need addressing:
 Please address these and I'll take another look!
 EOF
 )"
-# Note: PR keeps loom:reviewing label - Worker will fix and notify you
+gh pr edit 42 --remove-label "loom:review-requested" --add-label "loom:changes-requested"
+# Note: PR now has loom:changes-requested (amber badge) - Fixer will address and change back to loom:review-requested
 
-# Approve PR (amber → blue)
+# Approve PR (green → blue)
 gh pr review 42 --approve --body "LGTM! Great work on this feature. Tests look comprehensive and the code is clean."
-gh pr edit 42 --remove-label "loom:reviewing" --add-label "loom:approved"
-# Note: PR now has loom:approved (blue badge) - ready for user to merge
+gh pr edit 42 --remove-label "loom:review-requested" --add-label "loom:pr"
+# Note: PR now has loom:pr (blue badge) - ready for user to merge
 ```
 
 ## Terminal Probe Protocol

--- a/examples/full-stack/.loom/config.json
+++ b/examples/full-stack/.loom/config.json
@@ -92,7 +92,7 @@
         "workerType": "claude",
         "roleFile": "fixer.md",
         "targetInterval": 300000,
-        "intervalPrompt": "Check for PRs with review feedback: gh pr list --label=\"loom:reviewing\" --state=open. Address feedback, run pnpm check:ci, and update labels to loom:review-requested"
+        "intervalPrompt": "Check for PRs with changes requested: gh pr list --label=\"loom:changes-requested\" --state=open. Address feedback, run pnpm check:ci, and update labels to loom:review-requested"
       },
       "worktreePath": "",
       "theme": "amber"

--- a/src/lib/label-setup.ts
+++ b/src/lib/label-setup.ts
@@ -26,7 +26,7 @@ export interface LabelDefinition {
  *
  * Labels are separated into Issue labels and PR labels:
  * - Issue labels: loom:proposal, loom:critic-suggestion, loom:ready, loom:in-progress, loom:blocked, loom:urgent
- * - PR labels: loom:review-requested, loom:reviewing, loom:approved
+ * - PR labels: loom:review-requested, loom:changes-requested, loom:pr
  */
 export const LOOM_LABELS: LabelDefinition[] = [
   // Issue Labels
@@ -67,12 +67,12 @@ export const LOOM_LABELS: LabelDefinition[] = [
     color: "10B981", // Green - Loom bot action needed
   },
   {
-    name: "loom:reviewing",
-    description: "Reviewer actively reviewing this PR",
+    name: "loom:changes-requested",
+    description: "PR needs fixes from Fixer",
     color: "F59E0B", // Amber - work in progress
   },
   {
-    name: "loom:approved",
+    name: "loom:pr",
     description: "PR approved by Reviewer, ready for human to merge",
     color: "3B82F6", // Blue - human action needed
   },


### PR DESCRIPTION
## Summary

Fixes #309 - Replace non-namespaced review labels with proper loom:* prefix for consistency with other workflow labels.

## Changes

### Label Definitions
- Replace `loom:reviewing` → `loom:changes-requested` (amber badge - PR needs fixes from Fixer)
- Replace `loom:approved` → `loom:pr` (blue badge - PR ready for human to merge)

### Updated Files
- **src/lib/label-setup.ts** - New label definitions
- **defaults/roles/reviewer.md** - Remove "claim" step, review directly
- **defaults/roles/fixer.md** - Watch for loom:changes-requested label
- **defaults/roles/reviewer.json** - Update interval prompt
- **defaults/roles/fixer.json** - Update interval prompt and description
- **.loom/roles/reviewer.json** - Update interval prompt
- **.loom/roles/fixer.json** - Update interval prompt
- **defaults/config.json** - Update Fixer terminal interval prompt
- **examples/full-stack/.loom/config.json** - Update Fixer terminal interval prompt
- **WORKFLOWS.md** - Update documentation throughout

## New PR State Machine

```
Worker creates PR → loom:review-requested (green)
                 ↓
            Reviewer reviews
                 ↓
         ┌───────┴───────┐
         ↓               ↓
   loom:pr           loom:changes-requested
   (blue)            (amber)
   ready to merge    ↓
                     Fixer addresses
                     ↓
                     loom:review-requested
                     (back to green)
```

## Testing

- Frontend CI checks passed (lint, format, build)
- All documentation updated
- Label state machine verified

Co-Authored-By: Claude <noreply@anthropic.com>