### PR TITLE
Fix terminal ID validation in security tests

### DIFF
--- a/loom-daemon/tests/common/mod.rs
+++ b/loom-daemon/tests/common/mod.rs
@@ -148,8 +148,26 @@ impl TestClient {
     }
 
     /// Helper: Create terminal
+    ///
+    /// For security tests, the first parameter (id) is used as the `config_id`.
+    /// For non-security tests that need unique IDs, use `create_terminal_with_unique_id` instead.
     #[allow(dead_code)]
     pub async fn create_terminal(
+        &mut self,
+        id: impl Into<String>,
+        working_dir: Option<String>,
+    ) -> Result<String> {
+        let id_str: String = id.into();
+        // Use the provided ID as both config_id and name for security testing
+        self.create_terminal_with_config(&id_str, &id_str, working_dir, None, None)
+            .await
+    }
+
+    /// Helper: Create terminal with auto-generated unique ID
+    ///
+    /// Use this for non-security tests that need valid, unique terminal IDs.
+    #[allow(dead_code)]
+    pub async fn create_terminal_with_unique_id(
         &mut self,
         name: impl Into<String>,
         working_dir: Option<String>,


### PR DESCRIPTION
## Summary

- Fixed 8 failing security tests in `integration_security.rs`
- Daemon already had proper terminal ID validation to prevent shell injection
- Test client was bypassing validation by auto-generating valid UUIDs

## Changes

Updated `loom-daemon/tests/common/mod.rs`:
- Modified `create_terminal()` to use first parameter as `config_id` instead of auto-generating UUID
- Added `create_terminal_with_unique_id()` for non-security tests that need valid IDs
- Added proper documentation with backticks for clippy compliance

## Testing

All 9 security tests now pass:
- `test_reject_injection_semicolon` ✅
- `test_reject_injection_command_substitution` ✅
- `test_reject_injection_pipe` ✅
- `test_reject_injection_backticks` ✅
- `test_reject_injection_ampersand` ✅
- `test_reject_injection_newline` ✅
- `test_reject_empty_id` ✅
- `test_reject_various_shell_chars` ✅
- `test_accept_valid_ids` ✅

All 9 basic integration tests also pass (verified no regression).

## Impact

- Unblocks all PRs (issue #311 was blocking CI)
- Fixes high-severity security vulnerability testing
- No changes to daemon validation logic (already correct)
- Only test infrastructure changes

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)