### PR TITLE
Fix health monitor type mismatch causing false 'missing session' errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
       </main>
 
       <!-- Mini Terminal Row -->
-      <footer id="mini-terminal-row" class="h-40 border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
+      <footer id="mini-terminal-row" class="h-40 mb-4 border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
         <!-- Mini terminals here -->
       </footer>
     </div>

--- a/loom-daemon/src/terminal.rs
+++ b/loom-daemon/src/terminal.rs
@@ -407,20 +407,34 @@ impl TerminalManager {
 
     /// Check if a tmux session exists for the given terminal ID
     pub fn has_tmux_session(&self, id: &TerminalId) -> Result<bool> {
+        log::info!("🔍 has_tmux_session called for terminal id: '{}'", id);
+        log::info!(
+            "📋 Registry has {} terminals: {:?}",
+            self.terminals.len(),
+            self.terminals.keys().collect::<Vec<_>>()
+        );
+
         // First check if we have this terminal registered
         if let Some(info) = self.terminals.get(id) {
             // Terminal is registered - check its specific tmux session
+            log::info!(
+                "✅ Terminal '{}' found in registry, checking session: '{}'",
+                id,
+                info.tmux_session
+            );
             let output = Command::new("tmux")
                 .args(["-L", "loom"])
                 .args(["has-session", "-t", &info.tmux_session])
                 .output()?;
 
-            return Ok(output.status.success());
+            let result = output.status.success();
+            log::info!("📊 tmux has-session result for '{}': {}", info.tmux_session, result);
+            return Ok(result);
         }
 
         // Terminal not registered yet - check if ANY loom session with this ID exists
         // This handles the race condition where frontend creates state before daemon registers
-        log::debug!("Terminal {id} not found in registry, checking tmux sessions directly");
+        log::warn!("⚠️  Terminal '{}' NOT found in registry, checking tmux sessions directly", id);
 
         let output = Command::new("tmux")
             .args(["-L", "loom"])

--- a/src/lib/health-monitor.test.ts
+++ b/src/lib/health-monitor.test.ts
@@ -78,7 +78,7 @@ describe("HealthMonitor", () => {
     // Setup mock implementations
     vi.mocked(getAppState).mockReturnValue(mockState as any);
     vi.mocked(getOutputPoller).mockReturnValue(mockPoller as any);
-    vi.mocked(invoke).mockResolvedValue({ has_session: true });
+    vi.mocked(invoke).mockResolvedValue(true);
 
     // Create fresh monitor instance
     monitor = new HealthMonitor();
@@ -219,7 +219,7 @@ describe("HealthMonitor", () => {
     });
 
     it("detects missing session and updates terminal status", async () => {
-      vi.mocked(invoke).mockResolvedValueOnce({ has_session: false });
+      vi.mocked(invoke).mockResolvedValueOnce(false);
 
       monitor.start();
       await vi.advanceTimersByTimeAsync(0);
@@ -235,7 +235,7 @@ describe("HealthMonitor", () => {
       mockTerminals[0].missingSession = true;
       mockTerminals[0].status = TerminalStatus.Error;
 
-      vi.mocked(invoke).mockResolvedValueOnce({ has_session: true });
+      vi.mocked(invoke).mockResolvedValueOnce(true);
 
       monitor.start();
       await vi.advanceTimersByTimeAsync(0);
@@ -318,7 +318,7 @@ describe("HealthMonitor", () => {
         if (cmd === "check_daemon_health") {
           return Promise.reject(new Error("Daemon unreachable"));
         }
-        return Promise.resolve({ has_session: true });
+        return Promise.resolve(true);
       });
 
       monitor.start();
@@ -355,7 +355,7 @@ describe("HealthMonitor", () => {
           }
           return Promise.resolve(true);
         }
-        return Promise.resolve({ has_session: true });
+        return Promise.resolve(true);
       });
 
       monitor.start();
@@ -431,7 +431,7 @@ describe("HealthMonitor", () => {
     });
 
     it("counts error terminals correctly", async () => {
-      vi.mocked(invoke).mockResolvedValueOnce({ has_session: false });
+      vi.mocked(invoke).mockResolvedValueOnce(false);
 
       monitor.start();
       await vi.advanceTimersByTimeAsync(0);
@@ -644,7 +644,7 @@ describe("HealthMonitor", () => {
       // Initial state - session exists
       vi.mocked(invoke).mockImplementation((cmd) => {
         if (cmd === "check_session_health") {
-          return Promise.resolve({ has_session: true });
+          return Promise.resolve(true);
         }
         return Promise.resolve(true); // daemon health
       });
@@ -658,7 +658,7 @@ describe("HealthMonitor", () => {
       // Session lost
       vi.mocked(invoke).mockImplementation((cmd) => {
         if (cmd === "check_session_health") {
-          return Promise.resolve({ has_session: false });
+          return Promise.resolve(false);
         }
         return Promise.resolve(true); // daemon health
       });
@@ -675,7 +675,7 @@ describe("HealthMonitor", () => {
       mockTerminals[0].missingSession = true;
       vi.mocked(invoke).mockImplementation((cmd) => {
         if (cmd === "check_session_health") {
-          return Promise.resolve({ has_session: true });
+          return Promise.resolve(true);
         }
         return Promise.resolve(true); // daemon health
       });
@@ -697,7 +697,7 @@ describe("HealthMonitor", () => {
         if (cmd === "check_daemon_health") {
           return Promise.resolve(true);
         }
-        return Promise.resolve({ has_session: true });
+        return Promise.resolve(true);
       });
 
       await vi.advanceTimersByTimeAsync(0);
@@ -709,7 +709,7 @@ describe("HealthMonitor", () => {
         if (cmd === "check_daemon_health") {
           return Promise.reject(new Error("Connection refused"));
         }
-        return Promise.resolve({ has_session: true });
+        return Promise.resolve(true);
       });
 
       // 3 consecutive failures

--- a/src/lib/health-monitor.ts
+++ b/src/lib/health-monitor.ts
@@ -241,10 +241,11 @@ export class HealthMonitor {
 
       try {
         // Check if tmux session exists
-        const result = await invoke<{ has_session: boolean }>("check_session_health", {
+        console.log(`[HealthMonitor] 🔍 Checking session health for terminal.id="${terminal.id}"`);
+        const hasSession = await invoke<boolean>("check_session_health", {
           id: terminal.id,
         });
-        const hasSession = result.has_session;
+        console.log(`[HealthMonitor] 📊 Result for ${terminal.id}: hasSession=${hasSession}`);
 
         // Get last activity time
         const lastActivity = this.terminalActivity.get(terminal.id) || null;


### PR DESCRIPTION
## Summary
Fixed critical bug where health monitor was reporting "missing tmux session" for all terminals even when sessions existed. The issue was a type mismatch between the Tauri IPC command return type and the TypeScript frontend expectations.

## Root Cause
- Tauri command `check_session_health` returns plain `boolean`
- Frontend was expecting `{ has_session: boolean }` object
- Accessing `result.has_session` returned `undefined`
- All terminals incorrectly showed as missing sessions

## Changes

### Core Fix
- **src/lib/health-monitor.ts:272** - Changed `invoke` type from object to boolean
- **src/lib/health-monitor.test.ts** - Updated all test mocks to return boolean instead of object

### Debug Logging  
- **src/lib/health-monitor.ts:271-275** - Added console logging for session checks
- **loom-daemon/src/terminal.rs:410-432** - Added structured logging for session lookups

### UI Polish
- **index.html:35** - Added `mb-4` bottom margin to mini terminal row

## Testing
- All 315 TypeScript unit tests pass
- All 36 health monitor tests pass
- Tested factory reset with 9 terminals - all correctly show sessions exist

## Before/After
**Before**: All terminals 2-9 showing "missing tmux session" even though `tmux list-sessions` showed all sessions active

**After**: All terminals correctly show healthy status with proper session detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)