### PR TITLE
Extract duplicate workspace cleanup code into shared utility

### DIFF
--- a/src/lib/workspace-cleanup.test.ts
+++ b/src/lib/workspace-cleanup.test.ts
@@ -1,0 +1,446 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorkspaceCleanupOptions } from "./workspace-cleanup";
+
+// Mock Tauri API
+vi.mock("@tauri-apps/api/tauri", () => ({
+  invoke: vi.fn(),
+}));
+
+// Mock Logger
+vi.mock("./logger", () => ({
+  Logger: {
+    forComponent: vi.fn(() => ({
+      info: vi.fn(),
+      error: vi.fn(),
+    })),
+  },
+}));
+
+import { invoke } from "@tauri-apps/api/tauri";
+import { Logger } from "./logger";
+import { cleanupWorkspace } from "./workspace-cleanup";
+
+describe("cleanupWorkspace", () => {
+  let mockState: any;
+  let mockOutputPoller: any;
+  let mockTerminalManager: any;
+  let mockSetCurrentAttachedTerminalId: any;
+  let mockLogger: any;
+  let mockTerminals: any[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Create mock terminals
+    mockTerminals = [
+      { id: "terminal-1", name: "Worker 1" },
+      { id: "terminal-2", name: "Reviewer 1" },
+      { id: "terminal-3", name: "Architect 1" },
+    ];
+
+    // Mock state
+    mockState = {
+      getTerminals: vi.fn(() => mockTerminals),
+      clearAll: vi.fn(),
+    };
+
+    // Mock output poller
+    mockOutputPoller = {
+      stopPolling: vi.fn(),
+    };
+
+    // Mock terminal manager
+    mockTerminalManager = {
+      destroyAll: vi.fn(),
+    };
+
+    // Mock callback
+    mockSetCurrentAttachedTerminalId = vi.fn();
+
+    // Mock logger
+    mockLogger = {
+      info: vi.fn(),
+      error: vi.fn(),
+    };
+
+    vi.mocked(Logger.forComponent).mockReturnValue(mockLogger);
+    vi.mocked(invoke).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("Cleanup Sequence", () => {
+    it("executes cleanup steps in correct order", async () => {
+      const options: WorkspaceCleanupOptions = {
+        component: "test-component",
+        state: mockState,
+        outputPoller: mockOutputPoller,
+        terminalManager: mockTerminalManager,
+        setCurrentAttachedTerminalId: mockSetCurrentAttachedTerminalId,
+      };
+
+      await cleanupWorkspace(options);
+
+      // Verify cleanup sequence
+      expect(mockState.getTerminals).toHaveBeenCalled();
+      expect(mockOutputPoller.stopPolling).toHaveBeenCalledTimes(3);
+      expect(mockTerminalManager.destroyAll).toHaveBeenCalled();
+      expect(invoke).toHaveBeenCalledWith("destroy_terminal", { id: "terminal-1" });
+      expect(invoke).toHaveBeenCalledWith("destroy_terminal", { id: "terminal-2" });
+      expect(invoke).toHaveBeenCalledWith("destroy_terminal", { id: "terminal-3" });
+      expect(invoke).toHaveBeenCalledWith("kill_all_loom_sessions");
+      expect(mockState.clearAll).toHaveBeenCalled();
+      expect(mockSetCurrentAttachedTerminalId).toHaveBeenCalledWith(null);
+    });
+
+    it("stops polling for each terminal", async () => {
+      const options: WorkspaceCleanupOptions = {
+        component: "test-component",
+        state: mockState,
+        outputPoller: mockOutputPoller,
+        terminalManager: mockTerminalManager,
+        setCurrentAttachedTerminalId: mockSetCurrentAttachedTerminalId,
+      };
+
+      await cleanupWorkspace(options);
+
+      expect(mockOutputPoller.stopPolling).toHaveBeenCalledWith("terminal-1");
+      expect(mockOutputPoller.stopPolling).toHaveBeenCalledWith("terminal-2");
+      expect(mockOutputPoller.stopPolling).toHaveBeenCalledWith("terminal-3");
+    });
+
+    it("destroys all xterm instances", async () => {
+      const options: WorkspaceCleanupOptions = {
+        component: "test-component",
+        state: mockState,
+        outputPoller: mockOutputPoller,
+        terminalManager: mockTerminalManager,
+        setCurrentAttachedTerminalId: mockSetCurrentAttachedTerminalId,
+      };
+
+      await cleanupWorkspace(options);
+
+      expect(mockTerminalManager.destroyAll).toHaveBeenCalledTimes(1);
+    });
+
+    it("destroys all terminal sessions", async () => {
+      const options: WorkspaceCleanupOptions = {
+        component: "test-component",
+        state: mockState,
+        outputPoller: mockOutputPoller,
+        terminalManager: mockTerminalManager,
+        setCurrentAttachedTerminalId: mockSetCurrentAttachedTerminalId,
+      };
+
+      await cleanupWorkspace(options);
+
+      expect(invoke).toHaveBeenCalledWith("destroy_terminal", { id: "terminal-1" });
+      expect(invoke).toHaveBeenCalledWith("destroy_terminal", { id: "terminal-2" });
+      expect(invoke).toHaveBeenCalledWith("destroy_terminal", { id: "terminal-3" });
+    });
+
+    it("kills all loom tmux sessions", async () => {
+      const options: WorkspaceCleanupOptions = {
+        component: "test-component",
+        state: mockState,
+        outputPoller: mockOutputPoller,
+        terminalManager: mockTerminalManager,
+        setCurrentAttachedTerminalId: mockSetCurrentAttachedTerminalId,
+      };
+
+      await cleanupWorkspace(options);
+
+      expect(invoke).toHaveBeenCalledWith("kill_all_loom_sessions");
+    });
+
+    it("clears state and resets attached terminal ID", async () => {
+      const options: WorkspaceCleanupOptions = {
+        component: "test-component",
+        state: mockState,
+        outputPoller: mockOutputPoller,
+        terminalManager: mockTerminalManager,
+        setCurrentAttachedTerminalId: mockSetCurrentAttachedTerminalId,
+      };
+
+      await cleanupWorkspace(options);
+
+      expect(mockState.clearAll).toHaveBeenCalled();
+      expect(mockSetCurrentAttachedTerminalId).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe("Error Handling", () => {
+    it("continues cleanup when destroy_terminal fails for one terminal", async () => {
+      vi.mocked(invoke).mockImplementation((cmd: string, args?: any) => {
+        if (cmd === "destroy_terminal" && args?.id === "terminal-2") {
+          return Promise.reject(new Error("Failed to destroy terminal"));
+        }
+        return Promise.resolve(undefined);
+      });
+
+      const options: WorkspaceCleanupOptions = {
+        component: "test-component",
+        state: mockState,
+        outputPoller: mockOutputPoller,
+        terminalManager: mockTerminalManager,
+        setCurrentAttachedTerminalId: mockSetCurrentAttachedTerminalId,
+      };
+
+      await cleanupWorkspace(options);
+
+      // Should still attempt to destroy all terminals
+      expect(invoke).toHaveBeenCalledWith("destroy_terminal", { id: "terminal-1" });
+      expect(invoke).toHaveBeenCalledWith("destroy_terminal", { id: "terminal-2" });
+      expect(invoke).toHaveBeenCalledWith("destroy_terminal", { id: "terminal-3" });
+
+      // Should continue with cleanup
+      expect(invoke).toHaveBeenCalledWith("kill_all_loom_sessions");
+      expect(mockState.clearAll).toHaveBeenCalled();
+
+      // Should log error
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "Failed to destroy terminal",
+        expect.any(Error),
+        { terminalId: "terminal-2" }
+      );
+    });
+
+    it("continues cleanup when kill_all_loom_sessions fails", async () => {
+      vi.mocked(invoke).mockImplementation((cmd: string) => {
+        if (cmd === "kill_all_loom_sessions") {
+          return Promise.reject(new Error("Failed to kill sessions"));
+        }
+        return Promise.resolve(undefined);
+      });
+
+      const options: WorkspaceCleanupOptions = {
+        component: "test-component",
+        state: mockState,
+        outputPoller: mockOutputPoller,
+        terminalManager: mockTerminalManager,
+        setCurrentAttachedTerminalId: mockSetCurrentAttachedTerminalId,
+      };
+
+      await cleanupWorkspace(options);
+
+      // Should still complete state cleanup
+      expect(mockState.clearAll).toHaveBeenCalled();
+      expect(mockSetCurrentAttachedTerminalId).toHaveBeenCalledWith(null);
+
+      // Should log error
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "Failed to kill loom sessions",
+        expect.any(Error)
+      );
+    });
+
+    it("destroys all terminals even when some fail", async () => {
+      let callCount = 0;
+      vi.mocked(invoke).mockImplementation((cmd: string) => {
+        if (cmd === "destroy_terminal") {
+          callCount++;
+          if (callCount % 2 === 0) {
+            return Promise.reject(new Error("Simulated failure"));
+          }
+        }
+        return Promise.resolve(undefined);
+      });
+
+      const options: WorkspaceCleanupOptions = {
+        component: "test-component",
+        state: mockState,
+        outputPoller: mockOutputPoller,
+        terminalManager: mockTerminalManager,
+        setCurrentAttachedTerminalId: mockSetCurrentAttachedTerminalId,
+      };
+
+      await cleanupWorkspace(options);
+
+      // Should attempt all 3 destroys
+      expect(invoke).toHaveBeenCalledWith("destroy_terminal", { id: "terminal-1" });
+      expect(invoke).toHaveBeenCalledWith("destroy_terminal", { id: "terminal-2" });
+      expect(invoke).toHaveBeenCalledWith("destroy_terminal", { id: "terminal-3" });
+    });
+  });
+
+  describe("Logging", () => {
+    it("creates logger with correct component name", async () => {
+      const options: WorkspaceCleanupOptions = {
+        component: "workspace-start",
+        state: mockState,
+        outputPoller: mockOutputPoller,
+        terminalManager: mockTerminalManager,
+        setCurrentAttachedTerminalId: mockSetCurrentAttachedTerminalId,
+      };
+
+      await cleanupWorkspace(options);
+
+      expect(Logger.forComponent).toHaveBeenCalledWith("workspace-start");
+    });
+
+    it("logs cleanup progress with structured logging", async () => {
+      const options: WorkspaceCleanupOptions = {
+        component: "test-component",
+        state: mockState,
+        outputPoller: mockOutputPoller,
+        terminalManager: mockTerminalManager,
+        setCurrentAttachedTerminalId: mockSetCurrentAttachedTerminalId,
+      };
+
+      await cleanupWorkspace(options);
+
+      // Check structured logging calls
+      expect(mockLogger.info).toHaveBeenCalledWith("Stopping output polling for all terminals", {
+        terminalCount: 3,
+      });
+      expect(mockLogger.info).toHaveBeenCalledWith("Destroying xterm instances");
+      expect(mockLogger.info).toHaveBeenCalledWith("Destroying terminal sessions", {
+        terminalCount: 3,
+      });
+      expect(mockLogger.info).toHaveBeenCalledWith("Killing all loom tmux sessions");
+      expect(mockLogger.info).toHaveBeenCalledWith("Clearing terminals from state");
+      expect(mockLogger.info).toHaveBeenCalledWith("Workspace cleanup complete");
+    });
+
+    it("logs successful terminal destruction", async () => {
+      const options: WorkspaceCleanupOptions = {
+        component: "test-component",
+        state: mockState,
+        outputPoller: mockOutputPoller,
+        terminalManager: mockTerminalManager,
+        setCurrentAttachedTerminalId: mockSetCurrentAttachedTerminalId,
+      };
+
+      await cleanupWorkspace(options);
+
+      expect(mockLogger.info).toHaveBeenCalledWith("Destroyed terminal session", {
+        terminalId: "terminal-1",
+        terminalName: "Worker 1",
+      });
+      expect(mockLogger.info).toHaveBeenCalledWith("Destroyed terminal session", {
+        terminalId: "terminal-2",
+        terminalName: "Reviewer 1",
+      });
+      expect(mockLogger.info).toHaveBeenCalledWith("Destroyed terminal session", {
+        terminalId: "terminal-3",
+        terminalName: "Architect 1",
+      });
+    });
+
+    it("logs errors with proper context", async () => {
+      const testError = new Error("Destroy failed");
+      vi.mocked(invoke).mockImplementation((cmd: string, args?: any) => {
+        if (cmd === "destroy_terminal" && args?.id === "terminal-2") {
+          return Promise.reject(testError);
+        }
+        return Promise.resolve(undefined);
+      });
+
+      const options: WorkspaceCleanupOptions = {
+        component: "test-component",
+        state: mockState,
+        outputPoller: mockOutputPoller,
+        terminalManager: mockTerminalManager,
+        setCurrentAttachedTerminalId: mockSetCurrentAttachedTerminalId,
+      };
+
+      await cleanupWorkspace(options);
+
+      expect(mockLogger.error).toHaveBeenCalledWith("Failed to destroy terminal", testError, {
+        terminalId: "terminal-2",
+      });
+    });
+  });
+
+  describe("Edge Cases", () => {
+    it("handles empty terminal list", async () => {
+      mockState.getTerminals.mockReturnValue([]);
+
+      const options: WorkspaceCleanupOptions = {
+        component: "test-component",
+        state: mockState,
+        outputPoller: mockOutputPoller,
+        terminalManager: mockTerminalManager,
+        setCurrentAttachedTerminalId: mockSetCurrentAttachedTerminalId,
+      };
+
+      await cleanupWorkspace(options);
+
+      // Should still complete all steps
+      expect(mockOutputPoller.stopPolling).not.toHaveBeenCalled();
+      expect(mockTerminalManager.destroyAll).toHaveBeenCalled();
+      expect(invoke).toHaveBeenCalledWith("kill_all_loom_sessions");
+      expect(mockState.clearAll).toHaveBeenCalled();
+      expect(mockLogger.info).toHaveBeenCalledWith("Stopping output polling for all terminals", {
+        terminalCount: 0,
+      });
+    });
+
+    it("handles single terminal", async () => {
+      mockState.getTerminals.mockReturnValue([{ id: "terminal-1", name: "Solo" }]);
+
+      const options: WorkspaceCleanupOptions = {
+        component: "test-component",
+        state: mockState,
+        outputPoller: mockOutputPoller,
+        terminalManager: mockTerminalManager,
+        setCurrentAttachedTerminalId: mockSetCurrentAttachedTerminalId,
+      };
+
+      await cleanupWorkspace(options);
+
+      expect(mockOutputPoller.stopPolling).toHaveBeenCalledTimes(1);
+      expect(mockOutputPoller.stopPolling).toHaveBeenCalledWith("terminal-1");
+      expect(invoke).toHaveBeenCalledWith("destroy_terminal", { id: "terminal-1" });
+    });
+  });
+
+  describe("Integration with Different Components", () => {
+    it("works with workspace-start component", async () => {
+      const options: WorkspaceCleanupOptions = {
+        component: "start-workspace",
+        state: mockState,
+        outputPoller: mockOutputPoller,
+        terminalManager: mockTerminalManager,
+        setCurrentAttachedTerminalId: mockSetCurrentAttachedTerminalId,
+      };
+
+      await cleanupWorkspace(options);
+
+      expect(Logger.forComponent).toHaveBeenCalledWith("start-workspace");
+      expect(mockState.clearAll).toHaveBeenCalled();
+    });
+
+    it("works with workspace-reset component", async () => {
+      const options: WorkspaceCleanupOptions = {
+        component: "workspace-reset",
+        state: mockState,
+        outputPoller: mockOutputPoller,
+        terminalManager: mockTerminalManager,
+        setCurrentAttachedTerminalId: mockSetCurrentAttachedTerminalId,
+      };
+
+      await cleanupWorkspace(options);
+
+      expect(Logger.forComponent).toHaveBeenCalledWith("workspace-reset");
+      expect(mockState.clearAll).toHaveBeenCalled();
+    });
+
+    it("works with force-start-workspace component", async () => {
+      const options: WorkspaceCleanupOptions = {
+        component: "force-start-workspace",
+        state: mockState,
+        outputPoller: mockOutputPoller,
+        terminalManager: mockTerminalManager,
+        setCurrentAttachedTerminalId: mockSetCurrentAttachedTerminalId,
+      };
+
+      await cleanupWorkspace(options);
+
+      expect(Logger.forComponent).toHaveBeenCalledWith("force-start-workspace");
+      expect(mockState.clearAll).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/lib/workspace-cleanup.ts
+++ b/src/lib/workspace-cleanup.ts
@@ -1,0 +1,116 @@
+import { invoke } from "@tauri-apps/api/tauri";
+import { Logger } from "./logger";
+import type { OutputPoller } from "./output-poller";
+import type { AppState } from "./state";
+import type { TerminalManager } from "./terminal-manager";
+
+/**
+ * Options for workspace cleanup operations
+ */
+export interface WorkspaceCleanupOptions {
+  /**
+   * Component name for structured logging (e.g., "workspace-start", "workspace-reset")
+   */
+  component: string;
+
+  /**
+   * Application state instance
+   */
+  state: AppState;
+
+  /**
+   * Output poller instance for stopping polling
+   */
+  outputPoller: OutputPoller;
+
+  /**
+   * Terminal manager instance for destroying xterm instances
+   */
+  terminalManager: TerminalManager;
+
+  /**
+   * Callback to clear the currently attached terminal ID
+   */
+  setCurrentAttachedTerminalId: (id: string | null) => void;
+}
+
+/**
+ * Performs complete workspace cleanup before starting or resetting terminals.
+ *
+ * This function executes the following cleanup steps in order:
+ * 1. Stops output polling for all terminals
+ * 2. Destroys all xterm instances
+ * 3. Destroys all terminal sessions in the daemon
+ * 4. Kills all loom tmux sessions to ensure clean slate
+ * 5. Clears terminal state
+ *
+ * This cleanup sequence is used by both workspace-start and workspace-reset
+ * to ensure a clean state before creating new terminals.
+ *
+ * @param options - Cleanup options including component name and dependencies
+ *
+ * @example
+ * ```typescript
+ * await cleanupWorkspace({
+ *   component: "workspace-start",
+ *   state,
+ *   outputPoller,
+ *   terminalManager,
+ *   setCurrentAttachedTerminalId,
+ * });
+ * ```
+ */
+export async function cleanupWorkspace(options: WorkspaceCleanupOptions): Promise<void> {
+  const { component, state, outputPoller, terminalManager, setCurrentAttachedTerminalId } = options;
+
+  const logger = Logger.forComponent(component);
+
+  // Get terminals before cleanup
+  const terminals = state.getTerminals();
+
+  // Stop all polling
+  logger.info("Stopping output polling for all terminals", {
+    terminalCount: terminals.length,
+  });
+  terminals.forEach((t) => outputPoller.stopPolling(t.id));
+
+  // Destroy all xterm instances
+  logger.info("Destroying xterm instances");
+  terminalManager.destroyAll();
+
+  // Destroy all terminal sessions in daemon (clean up old tmux sessions)
+  logger.info("Destroying terminal sessions", {
+    terminalCount: terminals.length,
+  });
+  for (const terminal of terminals) {
+    try {
+      await invoke("destroy_terminal", { id: terminal.id });
+      logger.info("Destroyed terminal session", {
+        terminalId: terminal.id,
+        terminalName: terminal.name,
+      });
+    } catch (error) {
+      logger.error("Failed to destroy terminal", error, {
+        terminalId: terminal.id,
+      });
+      // Continue anyway - we'll create fresh terminals
+    }
+  }
+
+  // Kill ALL loom tmux sessions to ensure clean slate
+  logger.info("Killing all loom tmux sessions");
+  try {
+    await invoke("kill_all_loom_sessions");
+    logger.info("All loom sessions killed");
+  } catch (error) {
+    logger.error("Failed to kill loom sessions", error);
+    // Continue anyway - we'll try to create fresh terminals
+  }
+
+  // Clear state (but don't clear config files)
+  logger.info("Clearing terminals from state");
+  state.clearAll();
+  setCurrentAttachedTerminalId(null);
+
+  logger.info("Workspace cleanup complete");
+}


### PR DESCRIPTION
## Summary

Resolves #228

This PR extracts duplicate workspace cleanup code from `workspace-start.ts` and `workspace-reset.ts` into a shared utility module `workspace-cleanup.ts`.

## Changes

### New Files
- **`src/lib/workspace-cleanup.ts`**: Shared cleanup utility with `cleanupWorkspace()` function
- **`src/lib/workspace-cleanup.test.ts`**: Comprehensive unit tests (18 tests)

### Modified Files
- **`src/lib/workspace-start.ts`**: Replaced ~27 lines of cleanup code with utility call
- **`src/lib/workspace-reset.ts`**: Replaced ~29 lines of cleanup code with utility call

## Benefits

- ✅ Eliminates ~54 lines of duplicated code
- ✅ Single source of truth for cleanup logic
- ✅ Easier to test independently
- ✅ Uses structured logging (aligned with Issue #226)
- ✅ Future improvements only need one update
- ✅ Better error handling with proper context

## Implementation Details

The `cleanupWorkspace()` function executes cleanup in this order:
1. Stops output polling for all terminals
2. Destroys all xterm instances
3. Destroys all terminal sessions
4. Kills all loom tmux sessions  
5. Clears terminal state

Error handling continues on failures to ensure complete cleanup.

## Testing

- **18 new unit tests** covering:
  - Cleanup sequence verification
  - Error handling (continues on failures)
  - Structured logging
  - Edge cases (empty terminal list, single terminal)
  - Integration with different components

- **All existing tests pass** (244 total tests)
- **CI suite passes clean** (lint, format, clippy, build, all tests)

## Review Notes

- No breaking changes - internal refactoring only
- Same cleanup behavior, just extracted into shared module
- Both workspace-start and workspace-reset now use identical cleanup logic
- Structured logging provides better debugging capability

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>