### PR TITLE
Add comprehensive JSDoc comments to public APIs

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -6,72 +6,116 @@ import { TerminalStatus } from "./state";
 const logger = Logger.forComponent("config");
 
 /**
- * Persistent configuration stored in .loom/config.json (committed to git)
- * Contains team-shareable terminal definitions (roles, themes, intervals)
+ * Persistent configuration stored in .loom/config.json (committed to git).
+ * Contains team-shareable terminal definitions (roles, themes, intervals).
+ * This file should be committed to git so all team members share the same terminal setup.
  */
 export interface TerminalConfig {
-  id: string; // Stable terminal ID (e.g., "terminal-1")
-  name: string; // User-assigned terminal name
-  role?: string; // Role type (worker, reviewer, architect, etc.)
-  roleConfig?: Record<string, unknown>; // Role-specific configuration
-  theme?: string; // Theme ID or "default"
-  customTheme?: ColorTheme; // Custom color theme
+  /** Stable terminal ID (e.g., "terminal-1") - persists across restarts */
+  id: string;
+  /** User-assigned terminal name */
+  name: string;
+  /** Optional role type (worker, reviewer, architect, etc.) */
+  role?: string;
+  /** Role-specific configuration (e.g., system prompt, worker type) */
+  roleConfig?: Record<string, unknown>;
+  /** Theme ID (e.g., "ocean", "forest") or "default" */
+  theme?: string;
+  /** Custom color theme configuration */
+  customTheme?: ColorTheme;
 }
 
+/**
+ * Root configuration structure for Loom workspace.
+ * Stored in .loom/config.json and committed to version control.
+ */
 export interface LoomConfig {
+  /** Array of terminal configurations */
   terminals: TerminalConfig[];
 }
 
 /**
- * Ephemeral runtime state stored in .loom/state.json (gitignored)
- * Contains machine-specific terminal sessions and daemon state
+ * Ephemeral runtime state stored in .loom/state.json (gitignored).
+ * Contains machine-specific terminal sessions and daemon state that should NOT be committed.
+ * This file is regenerated on each machine based on actual running processes.
  */
 export interface TerminalState {
-  id: string; // Stable terminal ID (matches config)
-  status: TerminalStatus; // Current runtime status
-  isPrimary: boolean; // Which terminal is currently focused
-  worktreePath?: string; // Active git worktree path
-  agentPid?: number; // Running agent process ID
-  agentStatus?: AgentStatus; // Agent lifecycle state
-  lastIntervalRun?: number; // Last autonomous interval execution (ms)
+  /** Stable terminal ID (matches corresponding TerminalConfig) */
+  id: string;
+  /** Current runtime status of the terminal */
+  status: TerminalStatus;
+  /** Whether this terminal is currently focused in the UI */
+  isPrimary: boolean;
+  /** Active git worktree path (if terminal is working in a worktree) */
+  worktreePath?: string;
+  /** Running agent process ID (if an AI agent is active) */
+  agentPid?: number;
+  /** Agent lifecycle state */
+  agentStatus?: AgentStatus;
+  /** Unix timestamp (ms) of last autonomous interval execution */
+  lastIntervalRun?: number;
+  /** Queue of pending input requests from the agent */
   pendingInputRequests?: Array<{
+    /** Unique request identifier */
     id: string;
+    /** The question or prompt */
     prompt: string;
+    /** Unix timestamp (ms) when requested */
     timestamp: number;
   }>;
-  // Timer tracking fields
-  busyTime?: number; // Total milliseconds spent in busy state
-  idleTime?: number; // Total milliseconds spent in idle state
-  lastStateChange?: number; // Timestamp (ms) of last status change
+  /** Total milliseconds spent in busy state (for analytics) */
+  busyTime?: number;
+  /** Total milliseconds spent in idle state (for analytics) */
+  idleTime?: number;
+  /** Unix timestamp (ms) of last status change */
+  lastStateChange?: number;
 }
 
+/**
+ * Root state structure for Loom workspace.
+ * Stored in .loom/state.json and gitignored (machine-specific).
+ */
 export interface LoomState {
-  daemonPid?: number; // Running daemon process ID
-  nextAgentNumber: number; // Counter for terminal numbering (legacy name for compatibility)
+  /** Running daemon process ID */
+  daemonPid?: number;
+  /** Counter for terminal numbering (name preserved for compatibility) */
+  nextAgentNumber: number;
+  /** Array of terminal runtime states */
   terminals: TerminalState[];
 }
 
 /**
- * Legacy config format (pre-split)
- * Contained both config and state in one file
+ * Legacy config format (pre-split into config/state).
+ * Contained both config and state in one file.
+ * Automatically migrated to new format on first load.
+ *
+ * @deprecated This format is no longer used but supported for migration
  */
 interface LegacyConfig {
+  /** Terminal number counter */
   nextAgentNumber: number;
+  /** Array of terminals with mixed config and state data */
   agents: Array<Terminal & { configId?: string }>;
 }
 
 let cachedWorkspacePath: string | null = null;
 
 /**
- * Set the current workspace path for config/state operations
+ * Sets the current workspace path for config/state operations.
+ * Must be called before any loadConfig/saveConfig/loadState/saveState operations.
+ *
+ * @param workspacePath - Absolute path to the workspace directory
  */
 export function setConfigWorkspace(workspacePath: string): void {
   cachedWorkspacePath = workspacePath;
 }
 
 /**
- * Assert that workspace is configured before file operations
- * Throws descriptive error if workspace is not set
+ * Asserts that workspace is configured before file operations.
+ * Internal helper to ensure setConfigWorkspace() was called before file I/O.
+ *
+ * @returns The configured workspace path
+ * @throws {Error} If workspace is not set (setConfigWorkspace() not called)
  */
 function assertWorkspace(): string {
   if (!cachedWorkspacePath) {
@@ -83,8 +127,14 @@ function assertWorkspace(): string {
 }
 
 /**
- * Migrate legacy config format to new split format
- * Returns both config and state
+ * Migrates legacy config format to new split format.
+ * Handles three cases of legacy IDs:
+ * 1. Dual-ID system (configId field) - uses existing configId
+ * 2. UUID or placeholder IDs - generates stable "terminal-N" ID
+ * 3. Already stable IDs - uses as-is
+ *
+ * @param legacy - The legacy config object containing mixed config/state data
+ * @returns Object with separated config and state structures
  */
 function migrateLegacyConfig(legacy: LegacyConfig): {
   config: LoomConfig;
@@ -160,8 +210,12 @@ function migrateLegacyConfig(legacy: LegacyConfig): {
 }
 
 /**
- * Load config from .loom/config.json
- * Automatically migrates legacy format if needed
+ * Loads configuration from .loom/config.json.
+ * Automatically migrates legacy format if detected (has "agents" field instead of "terminals").
+ * Returns empty config on error.
+ *
+ * @returns The loaded configuration, or empty config if file doesn't exist or is invalid
+ * @throws Never throws - returns empty config on error and logs the error
  */
 export async function loadConfig(): Promise<LoomConfig> {
   const workspacePath = assertWorkspace();
@@ -194,7 +248,12 @@ export async function loadConfig(): Promise<LoomConfig> {
 }
 
 /**
- * Save config to .loom/config.json
+ * Saves configuration to .loom/config.json.
+ * Creates the .loom directory if it doesn't exist.
+ * Formats JSON with 2-space indentation for readability.
+ *
+ * @param config - The configuration to save
+ * @throws Never throws - logs error and continues on failure
  */
 export async function saveConfig(config: LoomConfig): Promise<void> {
   try {
@@ -211,7 +270,11 @@ export async function saveConfig(config: LoomConfig): Promise<void> {
 }
 
 /**
- * Load state from .loom/state.json
+ * Loads runtime state from .loom/state.json.
+ * Returns default state (nextAgentNumber: 1, empty terminals array) on error.
+ *
+ * @returns The loaded state, or default state if file doesn't exist or is invalid
+ * @throws Never throws - returns default state on error and logs the error
  */
 export async function loadState(): Promise<LoomState> {
   try {
@@ -233,8 +296,13 @@ export async function loadState(): Promise<LoomState> {
 }
 
 /**
- * Save state to .loom/state.json
- * Sanitizes runtime-only flags that shouldn't persist across restarts
+ * Saves runtime state to .loom/state.json.
+ * Sanitizes runtime-only flags that shouldn't persist across restarts:
+ * - Removes missingSession flag (re-evaluated on startup)
+ * - Resets error status to idle if it was only due to missing session
+ *
+ * @param state - The state to save
+ * @throws Never throws - logs error and continues on failure
  */
 export async function saveState(state: LoomState): Promise<void> {
   try {
@@ -270,7 +338,13 @@ export async function saveState(state: LoomState): Promise<void> {
 }
 
 /**
- * Merge config and state into full Terminal objects
+ * Merges configuration and state into full Terminal objects.
+ * Combines persistent config (roles, themes) with ephemeral state (status, PIDs).
+ * Uses default values for any missing state fields.
+ *
+ * @param config - The persistent configuration
+ * @param state - The ephemeral runtime state
+ * @returns Object containing merged terminals array and nextAgentNumber counter
  */
 export function mergeConfigAndState(
   config: LoomConfig,
@@ -308,7 +382,12 @@ export function mergeConfigAndState(
 }
 
 /**
- * Split Terminal objects into config and state
+ * Splits Terminal objects into separate config and state arrays.
+ * Separates persistent configuration (roles, themes) from ephemeral state (status, PIDs).
+ * Resets error status to idle before persisting (health monitor will re-detect issues).
+ *
+ * @param terminals - Array of full Terminal objects to split
+ * @returns Object containing separate config and state arrays
  */
 export function splitTerminals(terminals: Terminal[]): {
   config: TerminalConfig[];
@@ -343,9 +422,18 @@ export function splitTerminals(terminals: Terminal[]): {
 }
 
 /**
- * Load both config and state, merge them, and return in legacy format
- * This provides backward compatibility for existing code that expects
- * { nextAgentNumber, agents } structure
+ * Loads both config and state, merges them, and returns in legacy format.
+ * This provides backward compatibility for existing code that expects the
+ * { nextAgentNumber, agents } structure instead of separate config/state.
+ *
+ * @returns Object containing nextAgentNumber counter and merged terminals array (as "agents")
+ *
+ * @example
+ * ```ts
+ * const { nextAgentNumber, agents } = await loadWorkspaceConfig();
+ * state.setNextAgentNumber(nextAgentNumber);
+ * state.loadAgents(agents);
+ * ```
  */
 export async function loadWorkspaceConfig(): Promise<{
   nextAgentNumber: number;

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -2,59 +2,126 @@ import { Logger } from "./logger";
 
 const logger = Logger.forComponent("state");
 
+/**
+ * Represents the operational status of a terminal.
+ * Used to track the current state of terminal activity.
+ */
 export enum TerminalStatus {
+  /** Terminal is idle and ready for new tasks */
   Idle = "idle",
+  /** Terminal is actively executing a task */
   Busy = "busy",
+  /** Terminal is waiting for user input */
   NeedsInput = "needs_input",
+  /** Terminal has encountered an error */
   Error = "error",
+  /** Terminal has been stopped */
   Stopped = "stopped",
 }
 
+/**
+ * Represents the status of an AI agent running in a terminal.
+ * Tracks the agent's lifecycle from initialization through execution.
+ */
 export enum AgentStatus {
+  /** Agent has not been started yet */
   NotStarted = "not_started",
+  /** Agent is initializing (spawning process, loading context) */
   Initializing = "initializing",
+  /** Agent is ready and waiting for work */
   Ready = "ready",
+  /** Agent is actively working on a task */
   Busy = "busy",
+  /** Agent is waiting for user input */
   WaitingForInput = "waiting_for_input",
+  /** Agent has encountered an error */
   Error = "error",
+  /** Agent has been stopped */
   Stopped = "stopped",
 }
 
+/**
+ * Defines a custom color theme for a terminal.
+ * Used to personalize terminal appearance beyond preset themes.
+ */
 export interface ColorTheme {
+  /** Display name of the theme */
   name: string;
+  /** Primary color (hex or CSS color) */
   primary: string;
+  /** Optional background color (hex or CSS color) */
   background?: string;
+  /** Border color (hex or CSS color) */
   border: string;
 }
 
+/**
+ * Represents a pending input request from an AI agent.
+ * Agents can queue multiple input requests when they need user interaction.
+ */
 export interface InputRequest {
-  id: string; // Unique request ID
-  prompt: string; // Question from Claude
-  timestamp: number; // When requested (ms)
+  /** Unique identifier for this input request */
+  id: string;
+  /** The question or prompt from the agent */
+  prompt: string;
+  /** Unix timestamp (ms) when the request was created */
+  timestamp: number;
 }
 
+/**
+ * Represents a terminal instance in the application.
+ * Terminals can be plain shells or AI agents with specialized roles.
+ */
 export interface Terminal {
-  id: string; // Stable terminal ID (e.g., "terminal-1"), used for both config and runtime
+  /** Stable terminal identifier (e.g., "terminal-1") used for both config and runtime */
+  id: string;
+  /** User-friendly display name */
   name: string;
+  /** Current operational status */
   status: TerminalStatus;
+  /** Whether this terminal is currently selected as the primary view */
   isPrimary: boolean;
-  role?: string; // Optional: "claude-code-worker", "codex-worker", etc. Undefined = plain shell
-  roleConfig?: Record<string, unknown>; // Role-specific configuration (e.g., system prompt)
-  missingSession?: boolean; // Flag for terminals with missing tmux sessions (used in error recovery)
-  theme?: string; // Theme ID (e.g., "ocean", "forest") or "default"
-  customTheme?: ColorTheme; // For custom colors
-  // Agent-specific fields
-  worktreePath?: string; // Path to git worktree (automatically created at .loom/worktrees/{id})
-  agentPid?: number; // Claude process ID
-  agentStatus?: AgentStatus; // Agent state machine
-  lastIntervalRun?: number; // Timestamp (ms)
-  pendingInputRequests?: InputRequest[]; // Queue of input requests
-  // Timer tracking fields
-  busyTime?: number; // Total milliseconds spent in busy state
-  idleTime?: number; // Total milliseconds spent in idle state
-  lastStateChange?: number; // Timestamp (ms) of last status change
+  /** Optional role identifier (e.g., "claude-code-worker"). Undefined = plain shell */
+  role?: string;
+  /** Role-specific configuration data (e.g., system prompt, worker type) */
+  roleConfig?: Record<string, unknown>;
+  /** Flag indicating the tmux session is missing (used in error recovery) */
+  missingSession?: boolean;
+  /** Theme identifier (e.g., "ocean", "forest") or "default" */
+  theme?: string;
+  /** Custom color theme configuration */
+  customTheme?: ColorTheme;
+  /** Path to git worktree (automatically created at .loom/worktrees/{id}) */
+  worktreePath?: string;
+  /** Process ID of the running agent */
+  agentPid?: number;
+  /** Current agent lifecycle status */
+  agentStatus?: AgentStatus;
+  /** Unix timestamp (ms) of the last autonomous interval execution */
+  lastIntervalRun?: number;
+  /** Queue of pending input requests from the agent */
+  pendingInputRequests?: InputRequest[];
+  /** Total milliseconds spent in busy state (for analytics) */
+  busyTime?: number;
+  /** Total milliseconds spent in idle state (for analytics) */
+  idleTime?: number;
+  /** Unix timestamp (ms) of the last status change */
+  lastStateChange?: number;
 }
 
+/**
+ * Central state management for the Loom application.
+ * Implements the Observer pattern to automatically update UI when state changes.
+ *
+ * This class manages:
+ * - Terminal instances and their lifecycle
+ * - Primary terminal selection
+ * - Terminal display order
+ * - Workspace path validation
+ * - Application initialization state
+ *
+ * All state mutations automatically notify registered listeners via the onChange() callback system.
+ */
 export class AppState {
   private terminals: Map<string, Terminal> = new Map(); // Key is terminal id
   private primaryId: string | null = null; // Store primary terminal id
@@ -66,6 +133,13 @@ export class AppState {
   private isResettingWorkspace: boolean = false; // Loading state during factory reset
   private isInitializing: boolean = false; // Loading state during app startup
 
+  /**
+   * Adds a new terminal to the application state.
+   * Automatically assigns it as primary if it's marked as primary in the terminal object.
+   * Adds the terminal to the end of the display order.
+   *
+   * @param terminal - The terminal configuration to add
+   */
   addTerminal(terminal: Terminal): void {
     this.terminals.set(terminal.id, terminal);
     this.order.push(terminal.id); // Add to end of order
@@ -75,6 +149,12 @@ export class AppState {
     this.notify();
   }
 
+  /**
+   * Removes a terminal from the application state.
+   * If the removed terminal was primary, automatically promotes the first remaining terminal.
+   *
+   * @param id - The terminal ID to remove
+   */
   removeTerminal(id: string): void {
     this.terminals.delete(id);
     this.order = this.order.filter((tid) => tid !== id); // Remove from order
@@ -93,6 +173,12 @@ export class AppState {
     this.notify();
   }
 
+  /**
+   * Sets the specified terminal as the primary (selected) terminal.
+   * Automatically clears the primary flag from the previously selected terminal.
+   *
+   * @param id - The terminal ID to make primary
+   */
   setPrimary(id: string): void {
     // Clear old primary
     if (this.primaryId) {
@@ -111,6 +197,13 @@ export class AppState {
     }
   }
 
+  /**
+   * Renames a terminal with validation to ensure non-empty names.
+   * Trims whitespace from the new name.
+   *
+   * @param id - The terminal ID to rename
+   * @param newName - The new name (will be trimmed)
+   */
   renameTerminal(id: string, newName: string): void {
     const terminal = this.terminals.get(id);
     if (terminal && newName.trim()) {
@@ -119,6 +212,13 @@ export class AppState {
     }
   }
 
+  /**
+   * Updates a terminal with partial changes.
+   * Useful for updating multiple properties at once or properties not covered by specific setters.
+   *
+   * @param id - The terminal ID to update
+   * @param updates - Partial terminal object with properties to update
+   */
   updateTerminal(id: string, updates: Partial<Terminal>): void {
     const terminal = this.terminals.get(id);
     if (terminal) {
@@ -127,6 +227,13 @@ export class AppState {
     }
   }
 
+  /**
+   * Updates a terminal's status and tracks time spent in each state.
+   * Automatically calculates elapsed time in previous status and updates busyTime/idleTime counters.
+   *
+   * @param id - The terminal ID to update
+   * @param newStatus - The new status to set
+   */
   updateTerminalStatus(id: string, newStatus: TerminalStatus): void {
     const terminal = this.terminals.get(id);
     if (!terminal) {
@@ -163,6 +270,14 @@ export class AppState {
     this.notify();
   }
 
+  /**
+   * Sets or clears a terminal's role and role configuration.
+   * Roles define specialized behavior for AI agents (e.g., "claude-code-worker", "reviewer").
+   *
+   * @param id - The terminal ID to update
+   * @param role - The role identifier, or undefined to clear the role
+   * @param roleConfig - Optional role-specific configuration object
+   */
   setTerminalRole(
     id: string,
     role: string | undefined,
@@ -176,6 +291,13 @@ export class AppState {
     }
   }
 
+  /**
+   * Sets a terminal's theme to a preset theme by ID.
+   * Clears any custom theme configuration when using a preset.
+   *
+   * @param id - The terminal ID to update
+   * @param themeId - The preset theme identifier (e.g., "ocean", "forest", "default")
+   */
   setTerminalTheme(id: string, themeId: string): void {
     const terminal = this.terminals.get(id);
     if (terminal) {
@@ -185,6 +307,13 @@ export class AppState {
     }
   }
 
+  /**
+   * Sets a terminal's theme to a custom color scheme.
+   * Automatically sets the theme ID to "custom".
+   *
+   * @param id - The terminal ID to update
+   * @param theme - The custom color theme configuration
+   */
   setTerminalCustomTheme(id: string, theme: ColorTheme): void {
     const terminal = this.terminals.get(id);
     if (terminal) {
@@ -194,6 +323,13 @@ export class AppState {
     }
   }
 
+  /**
+   * Updates the worker type for a terminal that has a role configuration.
+   * Used to switch between different AI providers (Claude, Codex, etc.).
+   *
+   * @param id - The terminal ID to update
+   * @param workerType - The AI worker type to use
+   */
   updateTerminalWorkerType(
     id: string,
     workerType: "claude" | "codex" | "github-copilot" | "gemini" | "deepseek" | "grok"
@@ -205,20 +341,30 @@ export class AppState {
     }
   }
 
+  /**
+   * Gets the current primary (selected) terminal.
+   *
+   * @returns The primary terminal, or null if no primary is set
+   */
   getPrimary(): Terminal | null {
     return this.primaryId ? this.terminals.get(this.primaryId) || null : null;
   }
 
   /**
-   * Check if a primary terminal exists
+   * Check if a primary terminal exists.
+   *
+   * @returns True if a valid primary terminal is set, false otherwise
    */
   hasPrimary(): boolean {
     return this.primaryId !== null && this.terminals.has(this.primaryId);
   }
 
   /**
-   * Get primary terminal or throw error if none exists
-   * Use this when you're certain a primary must exist (e.g., after validation)
+   * Get primary terminal or throw error if none exists.
+   * Use this when you're certain a primary must exist (e.g., after validation).
+   *
+   * @returns The primary terminal
+   * @throws {Error} If no primary terminal is available
    */
   getPrimaryOrThrow(): Terminal {
     const primary = this.getPrimary();
@@ -228,6 +374,12 @@ export class AppState {
     return primary;
   }
 
+  /**
+   * Gets all terminals in their current display order.
+   * The order can be modified via drag-and-drop (see reorderTerminal).
+   *
+   * @returns Array of terminals in display order
+   */
   getTerminals(): Terminal[] {
     // Return terminals in display order
     return this.order
@@ -235,6 +387,14 @@ export class AppState {
       .filter((t): t is Terminal => t !== undefined);
   }
 
+  /**
+   * Reorders a terminal in the display sequence via drag-and-drop.
+   * Used to implement drag-and-drop reordering in the mini terminal row.
+   *
+   * @param draggedId - The ID of the terminal being dragged
+   * @param targetId - The ID of the terminal being dropped onto
+   * @param insertBefore - If true, insert before target; if false, insert after target
+   */
   reorderTerminal(draggedId: string, targetId: string, insertBefore: boolean): void {
     const draggedIndex = this.order.indexOf(draggedId);
     const targetIndex = this.order.indexOf(targetId);
@@ -258,6 +418,13 @@ export class AppState {
     this.notify();
   }
 
+  /**
+   * Sets the validated workspace path and persists it to localStorage.
+   * Also updates the displayed workspace path to match.
+   * Workspace path persists across HMR reloads.
+   *
+   * @param path - The validated workspace path, or empty string to clear
+   */
   setWorkspace(path: string): void {
     this.workspacePath = path;
     this.displayedWorkspacePath = path;
@@ -270,25 +437,42 @@ export class AppState {
     this.notify();
   }
 
+  /**
+   * Sets the displayed workspace path without validation.
+   * Used to show user input in the workspace selector even if it's invalid.
+   * This allows showing specific error messages while preserving user typing.
+   *
+   * @param path - The path to display (may be invalid)
+   */
   setDisplayedWorkspace(path: string): void {
     this.displayedWorkspacePath = path;
     this.notify();
   }
 
+  /**
+   * Gets the current validated workspace path.
+   *
+   * @returns The workspace path, or null if no valid workspace is set
+   */
   getWorkspace(): string | null {
     return this.workspacePath;
   }
 
   /**
-   * Check if a valid workspace is set
+   * Check if a valid workspace is set.
+   *
+   * @returns True if a non-empty workspace path is set, false otherwise
    */
   hasWorkspace(): boolean {
     return this.workspacePath !== null && this.workspacePath !== "";
   }
 
   /**
-   * Get workspace path or throw error if none exists
-   * Use this when workspace is required for an operation
+   * Get workspace path or throw error if none exists.
+   * Use this when workspace is required for an operation.
+   *
+   * @returns The workspace path
+   * @throws {Error} If no workspace is selected
    */
   getWorkspaceOrThrow(): string {
     if (!this.workspacePath) {
@@ -297,40 +481,93 @@ export class AppState {
     return this.workspacePath;
   }
 
+  /**
+   * Gets the displayed workspace path (which may be invalid).
+   * This may differ from getWorkspace() when user has entered an invalid path.
+   *
+   * @returns The displayed workspace path
+   */
   getDisplayedWorkspace(): string {
     return this.displayedWorkspacePath;
   }
 
+  /**
+   * Sets the workspace resetting flag.
+   * Used to show loading state during factory reset operations.
+   *
+   * @param isResetting - True if workspace is being reset, false otherwise
+   */
   setResettingWorkspace(isResetting: boolean): void {
     this.isResettingWorkspace = isResetting;
     this.notify();
   }
 
+  /**
+   * Checks if a workspace reset operation is in progress.
+   *
+   * @returns True if workspace is being reset, false otherwise
+   */
   isWorkspaceResetting(): boolean {
     return this.isResettingWorkspace;
   }
 
+  /**
+   * Sets the application initialization flag.
+   * Used to show loading state during app startup.
+   *
+   * @param isInitializing - True if app is initializing, false otherwise
+   */
   setInitializing(isInitializing: boolean): void {
     this.isInitializing = isInitializing;
     this.notify();
   }
 
+  /**
+   * Checks if the application is currently initializing.
+   *
+   * @returns True if app is initializing, false otherwise
+   */
   isAppInitializing(): boolean {
     return this.isInitializing;
   }
 
+  /**
+   * Gets the next available terminal number and increments the counter.
+   * Terminal numbering is monotonic and never reused, even after terminal deletion.
+   *
+   * @returns The next terminal number
+   */
   getNextTerminalNumber(): number {
     return this.nextTerminalNumber++;
   }
 
+  /**
+   * Sets the terminal number counter to a specific value.
+   * Used when loading configuration from disk to restore the counter state.
+   *
+   * @param num - The terminal number to set
+   */
   setNextTerminalNumber(num: number): void {
     this.nextTerminalNumber = num;
   }
 
+  /**
+   * Gets the current terminal number without incrementing.
+   * Useful for displaying the current counter value or saving configuration.
+   *
+   * @returns The current terminal number
+   */
   getCurrentTerminalNumber(): number {
     return this.nextTerminalNumber;
   }
 
+  /**
+   * Loads a complete set of terminals from configuration.
+   * Clears all existing terminals and replaces them with the provided ones.
+   * Automatically sets a primary terminal if none is marked as primary.
+   *
+   * @param agents - Array of terminal configurations to load
+   */
   loadAgents(agents: Terminal[]): void {
     // Clear existing terminals
     this.terminals.clear();
@@ -359,6 +596,11 @@ export class AppState {
     }
   }
 
+  /**
+   * Clears all application state except the terminal number counter.
+   * Removes all terminals, workspace paths, and resets flags.
+   * The terminal number counter persists to maintain monotonic numbering across workspace changes.
+   */
   clearAll(): void {
     // Clear all state
     this.terminals.clear();
@@ -371,8 +613,10 @@ export class AppState {
   }
 
   /**
-   * Restore workspace from localStorage (for HMR survival)
-   * Returns the restored workspace path or null if none was stored
+   * Restore workspace from localStorage (for HMR survival).
+   * Workspace path is automatically persisted to survive hot module replacement during development.
+   *
+   * @returns The restored workspace path, or null if none was stored
    */
   restoreWorkspaceFromLocalStorage(): string | null {
     const stored = localStorage.getItem("loom:workspace");
@@ -385,11 +629,35 @@ export class AppState {
     return null;
   }
 
-  // Helper method to get terminal by ID
+  /**
+   * Gets a terminal by its ID.
+   *
+   * @param id - The terminal ID to look up
+   * @returns The terminal if found, null otherwise
+   */
   getTerminal(id: string): Terminal | null {
     return this.terminals.get(id) || null;
   }
 
+  /**
+   * Registers a callback to be notified of state changes.
+   * The callback will be invoked whenever any state mutation occurs.
+   * This is the core of the Observer pattern implementation.
+   *
+   * @param callback - Function to call when state changes
+   * @returns Cleanup function to unregister the callback
+   *
+   * @example
+   * ```ts
+   * const unsubscribe = appState.onChange(() => {
+   *   console.log('State changed!');
+   *   render();
+   * });
+   *
+   * // Later, to stop listening:
+   * unsubscribe();
+   * ```
+   */
   onChange(callback: () => void): () => void {
     this.listeners.add(callback);
     return () => this.listeners.delete(callback);
@@ -403,6 +671,13 @@ export class AppState {
 // Singleton instance for accessing state from anywhere
 let appStateInstance: AppState | null = null;
 
+/**
+ * Gets the singleton AppState instance.
+ * Creates a new instance if one doesn't exist.
+ * Use this to access application state from anywhere in the codebase.
+ *
+ * @returns The singleton AppState instance
+ */
 export function getAppState(): AppState {
   if (!appStateInstance) {
     appStateInstance = new AppState();
@@ -410,13 +685,29 @@ export function getAppState(): AppState {
   return appStateInstance;
 }
 
+/**
+ * Sets the singleton AppState instance.
+ * Primarily used for testing to inject a mock state instance.
+ *
+ * @param state - The AppState instance to use as the singleton
+ */
 export function setAppState(state: AppState): void {
   appStateInstance = state;
 }
 
 /**
- * Type guard to check if a value is a valid Terminal
- * Useful for filtering and narrowing types
+ * Type guard to check if a value is a valid Terminal.
+ * Useful for filtering and narrowing types in array operations.
+ *
+ * @param t - The value to check
+ * @returns True if the value is a valid Terminal with a non-empty ID
+ *
+ * @example
+ * ```ts
+ * const terminals = [terminal1, null, terminal2, undefined];
+ * const validTerminals = terminals.filter(isValidTerminal);
+ * // validTerminals is now Terminal[] (not (Terminal | null | undefined)[])
+ * ```
  */
 export function isValidTerminal(t: Terminal | null | undefined): t is Terminal {
   return t !== null && t !== undefined && typeof t.id === "string" && t.id.length > 0;

--- a/src/lib/terminal-lifecycle.ts
+++ b/src/lib/terminal-lifecycle.ts
@@ -42,7 +42,7 @@ export async function launchAgentsForTerminals(
 
   logger.info("Launching agents for configured terminals", {
     workspacePath,
-    terminals: terminals.map((t) => `${t.name}=${t.id}, role=${t.role}`)
+    terminals: terminals.map((t) => `${t.name}=${t.id}, role=${t.role}`),
   });
 
   // Filter terminals that have Claude Code worker role
@@ -53,7 +53,7 @@ export async function launchAgentsForTerminals(
   logger.info("Found terminals with role configs", {
     workspacePath,
     workerCount: workersToLaunch.length,
-    workers: workersToLaunch.map((t) => `${t.name}=${t.id}`)
+    workers: workersToLaunch.map((t) => `${t.name}=${t.id}`),
   });
 
   // Track terminals that were successfully launched
@@ -70,7 +70,7 @@ export async function launchAgentsForTerminals(
       logger.info("Launching agent", {
         workspacePath,
         terminalName: terminal.name,
-        terminalId: terminal.id
+        terminalId: terminal.id,
       });
 
       // Set terminal to busy status BEFORE launching agent
@@ -79,7 +79,7 @@ export async function launchAgentsForTerminals(
       logger.info("Set terminal to busy status", {
         workspacePath,
         terminalName: terminal.name,
-        terminalId: terminal.id
+        terminalId: terminal.id,
       });
 
       // Get worker type from config (default to claude)
@@ -110,7 +110,7 @@ export async function launchAgentsForTerminals(
           workspacePath,
           terminalName: terminal.name,
           terminalId: terminal.id,
-          location: locationDesc
+          location: locationDesc,
         });
 
         // Launch Codex agent (will use main workspace if worktreePath is empty)
@@ -124,7 +124,7 @@ export async function launchAgentsForTerminals(
         logger.info("Codex agent launched", {
           workspacePath,
           terminalName: terminal.name,
-          location: locationDesc
+          location: locationDesc,
         });
       } else {
         // Claude with worktree support (optional - starts in main workspace if empty)
@@ -138,7 +138,7 @@ export async function launchAgentsForTerminals(
           workspacePath,
           terminalName: terminal.name,
           terminalId: terminal.id,
-          location: locationDesc
+          location: locationDesc,
         });
 
         // Launch agent (will use main workspace if worktreePath is empty)
@@ -152,14 +152,14 @@ export async function launchAgentsForTerminals(
         logger.info("Claude agent launched", {
           workspacePath,
           terminalName: terminal.name,
-          location: locationDesc
+          location: locationDesc,
         });
       }
 
       logger.info("Successfully launched agent", {
         workspacePath,
         terminalName: terminal.name,
-        terminalId: terminal.id
+        terminalId: terminal.id,
       });
 
       // Track successfully launched terminals (will reset to idle AFTER all launches complete)
@@ -169,7 +169,7 @@ export async function launchAgentsForTerminals(
       logger.error("Failed to launch agent", error as Error, {
         workspacePath,
         terminalName: terminal.name,
-        terminalId: terminal.id
+        terminalId: terminal.id,
       });
 
       // Still track this terminal ID - reset to idle after all launches complete
@@ -188,13 +188,13 @@ export async function launchAgentsForTerminals(
   // state before all agent launches finish (which can take 2+ minutes for 6 terminals)
   logger.info("All agent launches complete, resetting terminals to idle", {
     workspacePath,
-    terminalCount: launchedTerminalIds.length
+    terminalCount: launchedTerminalIds.length,
   });
   for (const terminalId of launchedTerminalIds) {
     state.updateTerminal(terminalId, { status: TerminalStatus.Idle });
     logger.info("Reset terminal to idle status", {
       workspacePath,
-      terminalId
+      terminalId,
     });
   }
 
@@ -217,7 +217,7 @@ export async function verifyTerminalSessions(deps: TerminalLifecycleDependencies
   }
 
   logger.info("Checking terminal session health", {
-    terminalCount: terminals.length
+    terminalCount: terminals.length,
   });
 
   // Batch check all terminals in parallel
@@ -232,7 +232,7 @@ export async function verifyTerminalSessions(deps: TerminalLifecycleDependencies
       return { terminal, hasSession };
     } catch (error) {
       logger.error("Failed to check terminal session health", error as Error, {
-        terminalId: terminal.id
+        terminalId: terminal.id,
       });
       return { terminal, hasSession: false };
     }
@@ -248,7 +248,7 @@ export async function verifyTerminalSessions(deps: TerminalLifecycleDependencies
     if (hasSession && terminal.missingSession) {
       // Clear stale missingSession flag
       logger.info("Clearing stale missingSession flag", {
-        terminalId: terminal.id
+        terminalId: terminal.id,
       });
       state.updateTerminal(terminal.id, {
         status: TerminalStatus.Idle,
@@ -258,7 +258,7 @@ export async function verifyTerminalSessions(deps: TerminalLifecycleDependencies
     } else if (!hasSession && !terminal.missingSession) {
       // Mark as missing if not already marked
       logger.info("Marking terminal as missing session", {
-        terminalId: terminal.id
+        terminalId: terminal.id,
       });
       state.updateTerminal(terminal.id, {
         status: TerminalStatus.Error,
@@ -270,7 +270,7 @@ export async function verifyTerminalSessions(deps: TerminalLifecycleDependencies
 
   logger.info("Terminal session verification complete", {
     clearedCount,
-    markedMissingCount
+    markedMissingCount,
   });
 }
 
@@ -299,7 +299,7 @@ export async function reconnectTerminals(deps: TerminalLifecycleDependencies): P
 
     const daemonTerminals = await invoke<DaemonTerminalInfo[]>("list_terminals");
     logger.info("Found active daemon terminals", {
-      daemonTerminalCount: daemonTerminals.length
+      daemonTerminalCount: daemonTerminals.length,
     });
 
     // Create a set of active terminal IDs for quick lookup
@@ -308,7 +308,7 @@ export async function reconnectTerminals(deps: TerminalLifecycleDependencies): P
     // Get all agents from state
     const agents = state.getTerminals();
     logger.info("Config agents loaded", {
-      agentCount: agents.length
+      agentCount: agents.length,
     });
 
     let reconnectedCount = 0;
@@ -319,7 +319,7 @@ export async function reconnectTerminals(deps: TerminalLifecycleDependencies): P
       // Check if agent has placeholder ID (shouldn't happen after proper initialization)
       if (agent.id === "__unassigned__") {
         logger.info("Agent has placeholder ID, skipping (already in error state)", {
-          terminalName: agent.name
+          terminalName: agent.name,
         });
 
         // Don't call state.updateTerminal() here - it triggers infinite render loop
@@ -331,7 +331,7 @@ export async function reconnectTerminals(deps: TerminalLifecycleDependencies): P
       if (activeTerminalIds.has(agent.id)) {
         logger.info("Reconnecting agent", {
           terminalName: agent.name,
-          terminalId: agent.id
+          terminalId: agent.id,
         });
 
         // Clear any error state from previous connection issues (use configId for state)
@@ -352,7 +352,7 @@ export async function reconnectTerminals(deps: TerminalLifecycleDependencies): P
       } else {
         logger.info("Agent not found in daemon, marking as missing", {
           terminalName: agent.name,
-          terminalId: agent.id
+          terminalId: agent.id,
         });
 
         // Mark terminal as having missing session so user can see it needs recovery (use configId for state)
@@ -367,7 +367,7 @@ export async function reconnectTerminals(deps: TerminalLifecycleDependencies): P
 
     logger.info("Reconnection complete", {
       reconnectedCount,
-      missingCount
+      missingCount,
     });
 
     // If we reconnected at least some terminals, save the updated state

--- a/src/lib/terminal-state-parser.test.ts
+++ b/src/lib/terminal-state-parser.test.ts
@@ -2,7 +2,7 @@
  * terminal-state-parser.test.ts - Tests for passive terminal state detection
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { parseTerminalState } from "./terminal-state-parser";
 
 describe("parseTerminalState", () => {

--- a/src/lib/workspace-lifecycle.ts
+++ b/src/lib/workspace-lifecycle.ts
@@ -124,7 +124,9 @@ export async function handleWorkspacePathInput(
         });
         logger.info("Workspace initialized", { workspacePath: expandedPath });
       } catch (error) {
-        logger.error("Failed to initialize workspace", error as Error, { workspacePath: expandedPath });
+        logger.error("Failed to initialize workspace", error as Error, {
+          workspacePath: expandedPath,
+        });
         alert(`Failed to initialize workspace: ${error}`);
         return;
       }
@@ -137,7 +139,7 @@ export async function handleWorkspacePathInput(
       if (config.agents && config.agents.length > 0) {
         logger.info("Creating terminals for fresh workspace", {
           workspacePath: expandedPath,
-          terminalCount: config.agents.length
+          terminalCount: config.agents.length,
         });
 
         // Create terminal sessions for each agent in the config
@@ -160,12 +162,12 @@ export async function handleWorkspacePathInput(
             logger.info("Created terminal", {
               terminalName: agent.name,
               terminalId,
-              workspacePath: expandedPath
+              workspacePath: expandedPath,
             });
           } catch (error) {
             logger.error("Failed to create terminal", error as Error, {
               terminalName: agent.name,
-              workspacePath: expandedPath
+              workspacePath: expandedPath,
             });
             alert(`Failed to create terminal ${agent.name}: ${error}`);
           }
@@ -197,7 +199,7 @@ export async function handleWorkspacePathInput(
       if (config.agents && config.agents.length > 0) {
         logger.info("Config agents before session creation", {
           workspacePath: expandedPath,
-          agents: config.agents.map((a) => `${a.name}=${a.id}`)
+          agents: config.agents.map((a) => `${a.name}=${a.id}`),
         });
 
         // IMPORTANT: Create sessions for migrated terminals with placeholder IDs
@@ -212,7 +214,7 @@ export async function handleWorkspacePathInput(
               logger.info("Creating session for migrated terminal", {
                 workspacePath: expandedPath,
                 terminalName: agent.name,
-                currentId: agent.id
+                currentId: agent.id,
               });
 
               // Create terminal session in daemon
@@ -231,12 +233,12 @@ export async function handleWorkspacePathInput(
               logger.info("Created session for migrated terminal", {
                 workspacePath: expandedPath,
                 terminalName: agent.name,
-                sessionId
+                sessionId,
               });
             } catch (error) {
               logger.error("Failed to create session for migrated terminal", error as Error, {
                 workspacePath: expandedPath,
-                terminalName: agent.name
+                terminalName: agent.name,
               });
               // Keep placeholder ID - terminal will show as missing session
               // User can use recovery options
@@ -247,19 +249,19 @@ export async function handleWorkspacePathInput(
         if (createdSessionCount > 0) {
           logger.info("Created sessions for migrated terminals", {
             workspacePath: expandedPath,
-            createdCount: createdSessionCount
+            createdCount: createdSessionCount,
           });
         }
 
         // Now load agents into state with their session IDs
         logger.info("Config agents before loadAgents", {
           workspacePath: expandedPath,
-          agents: config.agents.map((a) => `${a.name}=${a.id}`)
+          agents: config.agents.map((a) => `${a.name}=${a.id}`),
         });
         state.loadAgents(config.agents);
         logger.info("State after loadAgents", {
           workspacePath: expandedPath,
-          terminals: state.getTerminals().map((a) => `${a.name}=${a.id}`)
+          terminals: state.getTerminals().map((a) => `${a.name}=${a.id}`),
         });
 
         // If we created sessions, save the updated config with real IDs
@@ -274,7 +276,7 @@ export async function handleWorkspacePathInput(
           });
           logger.info("Saved config with new session IDs", {
             workspacePath: expandedPath,
-            newSessionCount: createdSessionCount
+            newSessionCount: createdSessionCount,
           });
         }
 
@@ -286,10 +288,13 @@ export async function handleWorkspacePathInput(
         const allMissing = terminals.every((t) => t.missingSession === true);
 
         if (allMissing && terminals.length > 0) {
-          logger.info("All terminals missing, auto-creating sessions (clean slate reset recovery)", {
-            workspacePath: expandedPath,
-            terminalCount: terminals.length
-          });
+          logger.info(
+            "All terminals missing, auto-creating sessions (clean slate reset recovery)",
+            {
+              workspacePath: expandedPath,
+              terminalCount: terminals.length,
+            }
+          );
 
           let createdCount = 0;
           for (const terminal of terminals) {
@@ -299,7 +304,7 @@ export async function handleWorkspacePathInput(
               logger.info("Auto-creating session for terminal", {
                 workspacePath: expandedPath,
                 terminalName: terminal.name,
-                terminalId: terminal.id
+                terminalId: terminal.id,
               });
 
               // Create terminal session in daemon
@@ -322,12 +327,12 @@ export async function handleWorkspacePathInput(
               logger.info("Auto-created session for terminal", {
                 workspacePath: expandedPath,
                 terminalName: terminal.name,
-                sessionId
+                sessionId,
               });
             } catch (error) {
               logger.error("Failed to auto-create session for terminal", error as Error, {
                 workspacePath: expandedPath,
-                terminalName: terminal.name
+                terminalName: terminal.name,
               });
               // Keep in error state - user can try manual recovery
             }
@@ -337,7 +342,7 @@ export async function handleWorkspacePathInput(
             logger.info("Auto-created sessions", {
               workspacePath: expandedPath,
               createdCount,
-              totalCount: terminals.length
+              totalCount: terminals.length,
             });
 
             // Save updated config with new session IDs
@@ -352,7 +357,7 @@ export async function handleWorkspacePathInput(
 
             // Launch agents for terminals with role configs
             logger.info("Launching agents for auto-created terminals", {
-              workspacePath: expandedPath
+              workspacePath: expandedPath,
             });
             await launchAgentsForTerminals(expandedPath, state.getTerminals());
           }
@@ -378,7 +383,9 @@ export async function handleWorkspacePathInput(
       await invoke("set_stored_workspace", { path: expandedPath });
       logger.info("Workspace path stored", { workspacePath: expandedPath });
     } catch (error) {
-      logger.error("Failed to store workspace path", error as Error, { workspacePath: expandedPath });
+      logger.error("Failed to store workspace path", error as Error, {
+        workspacePath: expandedPath,
+      });
       // Non-fatal - workspace is still loaded
     }
   } catch (error) {

--- a/src/lib/workspace-reset.ts
+++ b/src/lib/workspace-reset.ts
@@ -59,7 +59,7 @@ export async function resetWorkspaceToDefaults(
 
   logger.info("Resetting workspace to defaults", {
     workspacePath,
-    source: logPrefix
+    source: logPrefix,
   });
 
   // Cleanup existing terminals and sessions
@@ -79,12 +79,12 @@ export async function resetWorkspaceToDefaults(
     });
     logger.info("Backend reset complete", {
       workspacePath,
-      source: logPrefix
+      source: logPrefix,
     });
   } catch (error) {
     logger.error("Failed to reset workspace", error as Error, {
       workspacePath,
-      source: logPrefix
+      source: logPrefix,
     });
     alert(`Failed to reset workspace: ${error}`);
     return;
@@ -93,7 +93,7 @@ export async function resetWorkspaceToDefaults(
   // Reset GitHub labels to clean state
   logger.info("Resetting GitHub labels", {
     workspacePath,
-    source: logPrefix
+    source: logPrefix,
   });
   try {
     interface LabelResetResult {
@@ -107,21 +107,21 @@ export async function resetWorkspaceToDefaults(
       workspacePath,
       issuesCleaned: labelResult.issues_cleaned,
       prsUpdated: labelResult.prs_updated,
-      source: logPrefix
+      source: logPrefix,
     });
 
     if (labelResult.errors.length > 0) {
       logger.warn("Label reset errors", {
         workspacePath,
         errors: labelResult.errors,
-        source: logPrefix
+        source: logPrefix,
       });
     }
   } catch (error) {
     logger.warn("Failed to reset GitHub labels", {
       workspacePath,
       error: String(error),
-      source: logPrefix
+      source: logPrefix,
     });
     // Continue anyway - label reset is non-critical
   }
@@ -138,7 +138,7 @@ export async function resetWorkspaceToDefaults(
       logger.info("Creating terminals", {
         workspacePath,
         terminalCount: config.agents.length,
-        source: logPrefix
+        source: logPrefix,
       });
       for (const agent of config.agents) {
         try {
@@ -150,7 +150,7 @@ export async function resetWorkspaceToDefaults(
             terminalName: agent.name,
             instanceNumber,
             role: agent.role || "default",
-            source: logPrefix
+            source: logPrefix,
           });
 
           // Create terminal in daemon
@@ -168,7 +168,7 @@ export async function resetWorkspaceToDefaults(
             workspacePath,
             terminalName: agent.name,
             terminalId,
-            source: logPrefix
+            source: logPrefix,
           });
 
           // NOTE: Worktrees are now created on-demand when claiming issues, not automatically
@@ -177,13 +177,13 @@ export async function resetWorkspaceToDefaults(
           logger.info("Agent will start in main workspace", {
             workspacePath,
             terminalName: agent.name,
-            source: logPrefix
+            source: logPrefix,
           });
         } catch (error) {
           logger.error("Failed to create terminal", error as Error, {
             workspacePath,
             terminalName: agent.name,
-            source: logPrefix
+            source: logPrefix,
           });
           alert(`Failed to create terminal ${agent.name}: ${error}`);
         }
@@ -192,7 +192,7 @@ export async function resetWorkspaceToDefaults(
       logger.info("All terminals created", {
         workspacePath,
         agents: config.agents.map((a) => `${a.name}=${a.id}`),
-        source: logPrefix
+        source: logPrefix,
       });
 
       // Set workspace as active BEFORE loading agents (needed for proper initialization)
@@ -202,20 +202,20 @@ export async function resetWorkspaceToDefaults(
       logger.info("Loading agents into state", {
         workspacePath,
         agents: config.agents.map((a) => `${a.name}=${a.id}`),
-        source: logPrefix
+        source: logPrefix,
       });
       state.loadAgents(config.agents);
       logger.info("State after loadAgents", {
         workspacePath,
         terminals: state.getTerminals().map((a) => `${a.name}=${a.id}`),
-        source: logPrefix
+        source: logPrefix,
       });
 
       // IMPORTANT: Save config now with real terminal IDs, BEFORE launching agents
       // This ensures that if we get interrupted (e.g., hot reload), the config has real IDs
       logger.info("Saving config with real terminal IDs", {
         workspacePath,
-        source: logPrefix
+        source: logPrefix,
       });
       const terminalsToSave1 = state.getTerminals();
       const { config: terminalConfigs1, state: terminalStates1 } = splitTerminals(terminalsToSave1);
@@ -226,25 +226,25 @@ export async function resetWorkspaceToDefaults(
       });
       logger.info("Config saved", {
         workspacePath,
-        source: logPrefix
+        source: logPrefix,
       });
 
       // Launch agents for terminals with role configs
       logger.info("Launching agents", {
         workspacePath,
-        source: logPrefix
+        source: logPrefix,
       });
       await launchAgentsForTerminals(workspacePath, config.agents);
       logger.info("State after launchAgentsForTerminals", {
         workspacePath,
         terminals: state.getTerminals().map((a) => `${a.name}=${a.id}`),
-        source: logPrefix
+        source: logPrefix,
       });
 
       // Save final state after agent launch
       logger.info("Saving final config", {
         workspacePath,
-        source: logPrefix
+        source: logPrefix,
       });
       const terminalsToSave2 = state.getTerminals();
       const { config: terminalConfigs2, state: terminalStates2 } = splitTerminals(terminalsToSave2);
@@ -256,7 +256,7 @@ export async function resetWorkspaceToDefaults(
 
       logger.info("Workspace reset complete", {
         workspacePath,
-        source: logPrefix
+        source: logPrefix,
       });
     } else {
       // No agents in config - still set workspace as active
@@ -265,7 +265,7 @@ export async function resetWorkspaceToDefaults(
   } catch (error) {
     logger.error("Failed to reload config after reset", error as Error, {
       workspacePath,
-      source: logPrefix
+      source: logPrefix,
     });
     alert(`Failed to reload config: ${error}`);
   }

--- a/src/lib/workspace-start.ts
+++ b/src/lib/workspace-start.ts
@@ -52,7 +52,7 @@ export async function startWorkspaceEngine(
 
   logger.info("Starting Loom engine for workspace", {
     workspacePath,
-    source: logPrefix
+    source: logPrefix,
   });
 
   // Cleanup existing terminals and sessions
@@ -76,7 +76,7 @@ export async function startWorkspaceEngine(
     logger.info("Loaded config", {
       workspacePath,
       terminalCount: config.agents?.length || 0,
-      source: logPrefix
+      source: logPrefix,
     });
 
     // Create terminal sessions for each agent in the config
@@ -84,7 +84,7 @@ export async function startWorkspaceEngine(
       logger.info("Creating terminal sessions", {
         workspacePath,
         terminalCount: config.agents.length,
-        source: logPrefix
+        source: logPrefix,
       });
 
       for (const agent of config.agents) {
@@ -97,7 +97,7 @@ export async function startWorkspaceEngine(
             terminalName: agent.name,
             instanceNumber,
             role: agent.role || "default",
-            source: logPrefix
+            source: logPrefix,
           });
 
           // Create terminal in daemon
@@ -115,7 +115,7 @@ export async function startWorkspaceEngine(
             workspacePath,
             terminalName: agent.name,
             terminalId,
-            source: logPrefix
+            source: logPrefix,
           });
 
           // NOTE: Worktrees are now created on-demand when claiming issues, not automatically
@@ -124,13 +124,13 @@ export async function startWorkspaceEngine(
           logger.info("Agent will start in main workspace", {
             workspacePath,
             terminalName: agent.name,
-            source: logPrefix
+            source: logPrefix,
           });
         } catch (error) {
           logger.error("Failed to create terminal", error as Error, {
             workspacePath,
             terminalName: agent.name,
-            source: logPrefix
+            source: logPrefix,
           });
           alert(`Failed to create terminal ${agent.name}: ${error}`);
         }
@@ -139,7 +139,7 @@ export async function startWorkspaceEngine(
       logger.info("All terminals created", {
         workspacePath,
         agents: config.agents.map((a) => `${a.name}=${a.id}`),
-        source: logPrefix
+        source: logPrefix,
       });
 
       // Set workspace as active BEFORE loading agents
@@ -149,19 +149,19 @@ export async function startWorkspaceEngine(
       logger.info("Loading agents into state", {
         workspacePath,
         agents: config.agents.map((a) => `${a.name}=${a.id}`),
-        source: logPrefix
+        source: logPrefix,
       });
       state.loadAgents(config.agents);
       logger.info("State after loadAgents", {
         workspacePath,
         terminals: state.getTerminals().map((a) => `${a.name}=${a.id}`),
-        source: logPrefix
+        source: logPrefix,
       });
 
       // Save config with real terminal IDs BEFORE launching agents
       logger.info("Saving config with real terminal IDs", {
         workspacePath,
-        source: logPrefix
+        source: logPrefix,
       });
       const terminalsToSave1 = state.getTerminals();
       const { config: terminalConfigs1, state: terminalStates1 } = splitTerminals(terminalsToSave1);
@@ -172,25 +172,25 @@ export async function startWorkspaceEngine(
       });
       logger.info("Config saved", {
         workspacePath,
-        source: logPrefix
+        source: logPrefix,
       });
 
       // Launch agents for terminals with role configs
       logger.info("Launching agents", {
         workspacePath,
-        source: logPrefix
+        source: logPrefix,
       });
       await launchAgentsForTerminals(workspacePath, config.agents);
       logger.info("State after launchAgentsForTerminals", {
         workspacePath,
         terminals: state.getTerminals().map((a) => `${a.name}=${a.id}`),
-        source: logPrefix
+        source: logPrefix,
       });
 
       // Save final state after agent launch
       logger.info("Saving final config", {
         workspacePath,
-        source: logPrefix
+        source: logPrefix,
       });
       const terminalsToSave2 = state.getTerminals();
       const { config: terminalConfigs2, state: terminalStates2 } = splitTerminals(terminalsToSave2);
@@ -204,7 +204,7 @@ export async function startWorkspaceEngine(
       // Without this delay, health checks may run before tmux sessions are fully query-able
       logger.info("Waiting for tmux sessions to stabilize (500ms)", {
         workspacePath,
-        source: logPrefix
+        source: logPrefix,
       });
       await new Promise((resolve) => setTimeout(resolve, 500));
 
@@ -212,14 +212,14 @@ export async function startWorkspaceEngine(
       // This prevents false "missing session" errors on startup
       logger.info("Running immediate health check", {
         workspacePath,
-        source: logPrefix
+        source: logPrefix,
       });
       const { getHealthMonitor } = await import("./health-monitor");
       const healthMonitor = getHealthMonitor();
       await healthMonitor.performHealthCheck();
       logger.info("Health check complete", {
         workspacePath,
-        source: logPrefix
+        source: logPrefix,
       });
 
       // Mark all terminals as health-checked to prevent redundant checks in render loop
@@ -229,25 +229,25 @@ export async function startWorkspaceEngine(
         workspacePath,
         terminalCount: terminalIds.length,
         terminalIds,
-        source: logPrefix
+        source: logPrefix,
       });
 
       logger.info("Workspace engine started successfully", {
         workspacePath,
-        source: logPrefix
+        source: logPrefix,
       });
     } else {
       // No agents in config - still set workspace as active
       state.setWorkspace(workspacePath);
       logger.info("No terminals configured, workspace active with empty state", {
         workspacePath,
-        source: logPrefix
+        source: logPrefix,
       });
     }
   } catch (error) {
     logger.error("Failed to start engine", error as Error, {
       workspacePath,
-      source: logPrefix
+      source: logPrefix,
     });
     alert(`Failed to start Loom engine: ${error}`);
   }


### PR DESCRIPTION
## Summary

This PR adds comprehensive JSDoc comments to public APIs in the TypeScript codebase to improve developer experience with IDE autocomplete and inline documentation.

## Changes

### Documentation Added

- **src/lib/state.ts**: Added JSDoc to all public methods, interfaces, enums, and helper functions
  - `AppState` class with full method documentation
  - `Terminal`, `TerminalConfig`, `ColorTheme`, `InputRequest` interfaces
  - `TerminalStatus` and `AgentStatus` enums
  - Module-level helper functions (`getAppState`, `setAppState`, `isValidTerminal`)

- **src/lib/config.ts**: Added JSDoc to all configuration functions and interfaces
  - `loadConfig`, `saveConfig`, `loadState`, `saveState`
  - `mergeConfigAndState`, `splitTerminals`, `loadWorkspaceConfig`
  - All interfaces with comprehensive property documentation

- **src/lib/agent-launcher.ts**: Already had comprehensive JSDoc (verified)

### Auto-formatting

Biome auto-formatted several files with trailing comma fixes:
- `src/lib/terminal-lifecycle.ts`
- `src/lib/terminal-state-parser.test.ts`
- `src/lib/workspace-lifecycle.ts`
- `src/lib/workspace-reset.ts`
- `src/lib/workspace-start.ts`

## Documentation Format

All JSDoc comments include:
- Clear descriptions of what functions/methods do
- `@param` tags for all parameters with descriptions
- `@returns` tags describing return values
- `@throws` tags for functions that throw errors
- Usage examples where appropriate

## Test Plan

- [x] All files build successfully (`pnpm build`)
- [x] Linting passes with auto-fixes applied (`pnpm lint --write`)
- [x] Pre-commit hooks passed
- [x] No breaking changes - only documentation added

## Related

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)