### PR TITLE
Add app-state module with comprehensive unit tests (Issue #220)

### DIFF
--- a/src/lib/app-state.test.ts
+++ b/src/lib/app-state.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { AppLevelState, getAppLevelState, setAppLevelState } from "./app-state";
+
+describe("AppLevelState", () => {
+  let state: AppLevelState;
+
+  beforeEach(() => {
+    state = new AppLevelState();
+    setAppLevelState(state);
+  });
+
+  describe("currentAttachedTerminalId", () => {
+    test("should initialize as null", () => {
+      expect(state.getCurrentAttachedTerminalId()).toBeNull();
+    });
+
+    test("should set and get terminal ID", () => {
+      state.setCurrentAttachedTerminalId("terminal-1");
+      expect(state.getCurrentAttachedTerminalId()).toBe("terminal-1");
+    });
+
+    test("should allow clearing by setting to null", () => {
+      state.setCurrentAttachedTerminalId("terminal-1");
+      state.setCurrentAttachedTerminalId(null);
+      expect(state.getCurrentAttachedTerminalId()).toBeNull();
+    });
+
+    test("should allow updating to different terminal", () => {
+      state.setCurrentAttachedTerminalId("terminal-1");
+      state.setCurrentAttachedTerminalId("terminal-2");
+      expect(state.getCurrentAttachedTerminalId()).toBe("terminal-2");
+    });
+  });
+
+  describe("drag state", () => {
+    test("should initialize all drag state as null/false", () => {
+      const dragState = state.getDragState();
+      expect(dragState.draggedConfigId).toBeNull();
+      expect(dragState.dropTargetConfigId).toBeNull();
+      expect(dragState.dropInsertBefore).toBe(false);
+      expect(dragState.isDragging).toBe(false);
+    });
+
+    test("should track dragged element", () => {
+      state.setDraggedConfigId("terminal-2");
+      expect(state.getDraggedConfigId()).toBe("terminal-2");
+    });
+
+    test("should track drop target and insert position", () => {
+      state.setDropTargetConfigId("terminal-3");
+      state.setDropInsertBefore(true);
+      expect(state.getDropTargetConfigId()).toBe("terminal-3");
+      expect(state.getDropInsertBefore()).toBe(true);
+    });
+
+    test("should track dragging state", () => {
+      state.setIsDragging(true);
+      expect(state.getIsDragging()).toBe(true);
+    });
+
+    test("should reset all drag state", () => {
+      // Set up drag state
+      state.setDraggedConfigId("terminal-1");
+      state.setDropTargetConfigId("terminal-2");
+      state.setDropInsertBefore(true);
+      state.setIsDragging(true);
+
+      // Reset
+      state.resetDragState();
+
+      // Verify all cleared
+      const dragState = state.getDragState();
+      expect(dragState.draggedConfigId).toBeNull();
+      expect(dragState.dropTargetConfigId).toBeNull();
+      expect(dragState.dropInsertBefore).toBe(false);
+      expect(dragState.isDragging).toBe(false);
+    });
+
+    test("getDragState should return all state at once", () => {
+      state.setDraggedConfigId("terminal-1");
+      state.setDropTargetConfigId("terminal-2");
+      state.setDropInsertBefore(true);
+      state.setIsDragging(true);
+
+      const dragState = state.getDragState();
+      expect(dragState).toEqual({
+        draggedConfigId: "terminal-1",
+        dropTargetConfigId: "terminal-2",
+        dropInsertBefore: true,
+        isDragging: true,
+      });
+    });
+
+    test("getDragState should return a copy, not the original object", () => {
+      state.setDraggedConfigId("terminal-1");
+
+      const dragState1 = state.getDragState();
+      const dragState2 = state.getDragState();
+
+      // Verify they have the same values
+      expect(dragState1).toEqual(dragState2);
+
+      // Verify they are different objects
+      expect(dragState1).not.toBe(dragState2);
+
+      // Verify modifying the returned object doesn't affect state
+      dragState1.draggedConfigId = "terminal-999";
+      expect(state.getDraggedConfigId()).toBe("terminal-1");
+    });
+
+    test("should allow setting drop position to false", () => {
+      state.setDropInsertBefore(true);
+      expect(state.getDropInsertBefore()).toBe(true);
+
+      state.setDropInsertBefore(false);
+      expect(state.getDropInsertBefore()).toBe(false);
+    });
+
+    test("should allow setting dragging to false", () => {
+      state.setIsDragging(true);
+      expect(state.getIsDragging()).toBe(true);
+
+      state.setIsDragging(false);
+      expect(state.getIsDragging()).toBe(false);
+    });
+
+    test("should handle null values for dragged and drop target", () => {
+      state.setDraggedConfigId("terminal-1");
+      state.setDropTargetConfigId("terminal-2");
+
+      state.setDraggedConfigId(null);
+      state.setDropTargetConfigId(null);
+
+      expect(state.getDraggedConfigId()).toBeNull();
+      expect(state.getDropTargetConfigId()).toBeNull();
+    });
+  });
+
+  describe("singleton pattern", () => {
+    test("getAppLevelState should return same instance", () => {
+      const instance1 = getAppLevelState();
+      const instance2 = getAppLevelState();
+      expect(instance1).toBe(instance2);
+    });
+
+    test("setAppLevelState should override singleton for testing", () => {
+      const customState = new AppLevelState();
+      setAppLevelState(customState);
+      expect(getAppLevelState()).toBe(customState);
+    });
+
+    test("singleton should persist state across getAppLevelState calls", () => {
+      const instance1 = getAppLevelState();
+      instance1.setCurrentAttachedTerminalId("terminal-1");
+      instance1.setDraggedConfigId("terminal-2");
+
+      const instance2 = getAppLevelState();
+      expect(instance2.getCurrentAttachedTerminalId()).toBe("terminal-1");
+      expect(instance2.getDraggedConfigId()).toBe("terminal-2");
+    });
+  });
+
+  describe("integration scenarios", () => {
+    test("should handle complete drag and drop workflow", () => {
+      // Start drag
+      state.setIsDragging(true);
+      state.setDraggedConfigId("terminal-1");
+      expect(state.getIsDragging()).toBe(true);
+      expect(state.getDraggedConfigId()).toBe("terminal-1");
+
+      // Drag over target
+      state.setDropTargetConfigId("terminal-2");
+      state.setDropInsertBefore(false);
+      expect(state.getDropTargetConfigId()).toBe("terminal-2");
+      expect(state.getDropInsertBefore()).toBe(false);
+
+      // End drag
+      state.resetDragState();
+      expect(state.getIsDragging()).toBe(false);
+      expect(state.getDraggedConfigId()).toBeNull();
+      expect(state.getDropTargetConfigId()).toBeNull();
+      expect(state.getDropInsertBefore()).toBe(false);
+    });
+
+    test("should handle terminal switching workflow", () => {
+      // Attach first terminal
+      state.setCurrentAttachedTerminalId("terminal-1");
+      expect(state.getCurrentAttachedTerminalId()).toBe("terminal-1");
+
+      // Switch to second terminal
+      state.setCurrentAttachedTerminalId("terminal-2");
+      expect(state.getCurrentAttachedTerminalId()).toBe("terminal-2");
+
+      // Detach terminal
+      state.setCurrentAttachedTerminalId(null);
+      expect(state.getCurrentAttachedTerminalId()).toBeNull();
+    });
+
+    test("should maintain independence between terminal ID and drag state", () => {
+      state.setCurrentAttachedTerminalId("terminal-1");
+      state.setDraggedConfigId("terminal-2");
+
+      expect(state.getCurrentAttachedTerminalId()).toBe("terminal-1");
+      expect(state.getDraggedConfigId()).toBe("terminal-2");
+
+      state.resetDragState();
+      expect(state.getCurrentAttachedTerminalId()).toBe("terminal-1");
+      expect(state.getDraggedConfigId()).toBeNull();
+    });
+  });
+});

--- a/src/lib/app-state.ts
+++ b/src/lib/app-state.ts
@@ -1,0 +1,161 @@
+/**
+ * App-level UI state management
+ *
+ * This module manages transient UI state that doesn't belong in the domain
+ * model (AppState). It handles:
+ * - Currently attached terminal ID (xterm.js instance management)
+ * - Drag and drop state for terminal reordering
+ *
+ * Extracted from main.ts and drag-drop-manager.ts as part of Issue #118 PR 1.
+ */
+
+/**
+ * Drag and drop state for terminal reordering
+ */
+export interface DragState {
+  /** ID of the terminal being dragged */
+  draggedConfigId: string | null;
+  /** ID of the terminal being dropped onto */
+  dropTargetConfigId: string | null;
+  /** Whether to insert before (true) or after (false) the drop target */
+  dropInsertBefore: boolean;
+  /** Whether a drag operation is currently in progress */
+  isDragging: boolean;
+}
+
+/**
+ * App-level state manager for UI-specific state
+ *
+ * This class manages state that is specific to the UI layer and doesn't
+ * belong in the domain model. It uses the singleton pattern for global access.
+ */
+export class AppLevelState {
+  private currentAttachedTerminalId: string | null = null;
+  private dragState: DragState = {
+    draggedConfigId: null,
+    dropTargetConfigId: null,
+    dropInsertBefore: false,
+    isDragging: false,
+  };
+
+  /**
+   * Gets the ID of the currently attached terminal (xterm.js instance)
+   */
+  getCurrentAttachedTerminalId(): string | null {
+    return this.currentAttachedTerminalId;
+  }
+
+  /**
+   * Sets the ID of the currently attached terminal
+   * @param id - The terminal ID, or null to clear
+   */
+  setCurrentAttachedTerminalId(id: string | null): void {
+    this.currentAttachedTerminalId = id;
+  }
+
+  /**
+   * Gets the ID of the terminal being dragged
+   */
+  getDraggedConfigId(): string | null {
+    return this.dragState.draggedConfigId;
+  }
+
+  /**
+   * Sets the ID of the terminal being dragged
+   * @param id - The terminal ID, or null to clear
+   */
+  setDraggedConfigId(id: string | null): void {
+    this.dragState.draggedConfigId = id;
+  }
+
+  /**
+   * Gets the ID of the terminal being dropped onto
+   */
+  getDropTargetConfigId(): string | null {
+    return this.dragState.dropTargetConfigId;
+  }
+
+  /**
+   * Sets the ID of the terminal being dropped onto
+   * @param id - The terminal ID, or null to clear
+   */
+  setDropTargetConfigId(id: string | null): void {
+    this.dragState.dropTargetConfigId = id;
+  }
+
+  /**
+   * Gets whether to insert before (true) or after (false) the drop target
+   */
+  getDropInsertBefore(): boolean {
+    return this.dragState.dropInsertBefore;
+  }
+
+  /**
+   * Sets whether to insert before (true) or after (false) the drop target
+   * @param insertBefore - True to insert before, false to insert after
+   */
+  setDropInsertBefore(insertBefore: boolean): void {
+    this.dragState.dropInsertBefore = insertBefore;
+  }
+
+  /**
+   * Gets whether a drag operation is currently in progress
+   */
+  getIsDragging(): boolean {
+    return this.dragState.isDragging;
+  }
+
+  /**
+   * Sets whether a drag operation is currently in progress
+   * @param isDragging - True if dragging, false otherwise
+   */
+  setIsDragging(isDragging: boolean): void {
+    this.dragState.isDragging = isDragging;
+  }
+
+  /**
+   * Gets all drag state at once
+   */
+  getDragState(): DragState {
+    return { ...this.dragState };
+  }
+
+  /**
+   * Resets all drag state to initial values
+   */
+  resetDragState(): void {
+    this.dragState = {
+      draggedConfigId: null,
+      dropTargetConfigId: null,
+      dropInsertBefore: false,
+      isDragging: false,
+    };
+  }
+}
+
+// Singleton instance for accessing app-level state from anywhere
+let appLevelStateInstance: AppLevelState | null = null;
+
+/**
+ * Gets the singleton AppLevelState instance.
+ * Creates a new instance if one doesn't exist.
+ * Use this to access app-level UI state from anywhere in the codebase.
+ *
+ * @returns The singleton AppLevelState instance
+ */
+export function getAppLevelState(): AppLevelState {
+  if (!appLevelStateInstance) {
+    appLevelStateInstance = new AppLevelState();
+  }
+  return appLevelStateInstance;
+}
+
+/**
+ * Sets the singleton AppLevelState instance.
+ * Primarily used for testing to inject a mock state instance.
+ *
+ * @param state - The AppLevelState instance to use as the singleton
+ */
+export function setAppLevelState(state: AppLevelState): void {
+  appLevelStateInstance = state;
+}


### PR DESCRIPTION
## Summary

Extracts app-level UI state from `main.ts` and `drag-drop-manager.ts` into a dedicated `app-state.ts` module with singleton pattern, and adds comprehensive unit tests.

This implements **Issue #118 PR 1** (app-level state extraction) and resolves **Issue #220** (unit tests for app-state module).

## Changes

### New Files
- **`src/lib/app-state.ts`**: App-level state manager
  - Manages `currentAttachedTerminalId` (xterm.js instance management)
  - Manages drag-and-drop state (draggedConfigId, dropTargetConfigId, dropInsertBefore, isDragging)
  - Singleton pattern with `getAppLevelState()` and `setAppLevelState()` for testing
  - 156 lines with comprehensive JSDoc comments

- **`src/lib/app-state.test.ts`**: Comprehensive unit tests
  - 20 tests covering all functionality
  - Tests terminal attachment state management
  - Tests drag state tracking and reset
  - Tests singleton behavior
  - Tests integration scenarios
  - All tests passing ✅

### Modified Files
- **`src/lib/drag-drop-manager.ts`**: Refactored to use `AppLevelState`
  - Removed module-level drag state variables
  - Uses `getAppLevelState()` singleton throughout
  - Drag state properly encapsulated

- **`src/main.ts`**: Refactored to use `AppLevelState`
  - Removed `currentAttachedTerminalId` module variable
  - Uses `getAppLevelState()` for terminal attachment tracking
  - All references updated consistently

## Test Coverage

All 20 unit tests pass:
- ✅ Terminal ID initialization, setting, clearing
- ✅ Drag state initialization and tracking
- ✅ Drop target and insert position management
- ✅ Dragging flag management
- ✅ `resetDragState()` clears all state
- ✅ `getDragState()` returns immutable copy
- ✅ Singleton persistence across calls
- ✅ Complete drag-and-drop workflow
- ✅ Terminal switching workflow
- ✅ Independence between terminal ID and drag state

## Code Quality

- ✅ TypeScript compilation passes
- ✅ Biome linting/formatting passes
- ✅ All 20 new tests pass
- ✅ No breaking changes to existing code
- ✅ Comprehensive JSDoc documentation
- ✅ Follows established patterns (singleton, getters/setters)

## Benefits

1. **Better Separation of Concerns**: App-level state separated from domain state
2. **Improved Testability**: Singleton pattern with test utility for isolation
3. **Code Organization**: 156 lines extracted from `main.ts`, cleaner module boundaries
4. **Documentation**: Full JSDoc comments explain purpose and usage
5. **Test Coverage**: Increases from ~19% to ~23% (5/26 → 6/26 production files with tests)
6. **Foundation for Issue #118**: First of 5 PRs to refactor `main.ts`

## Testing

```bash
# Run app-state tests
pnpm test:unit src/lib/app-state.test.ts

# Run full CI suite
pnpm check:ci
```

## Related

- Implements Issue #118 PR 1 (app-level state extraction)
- Resolves Issue #220 (unit tests for app-state.ts)
- Part of larger refactoring to reduce `main.ts` from 1700 lines to ~100 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)