### PR TITLE
Fix issue template by removing empty title field

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,6 +1,5 @@
 name: "Development Task"
 description: "Create a development task for Loom"
-title: ""
 labels: ["loom:triage"]
 body:
   - type: markdown

--- a/defaults/.github/ISSUE_TEMPLATE/task.yml
+++ b/defaults/.github/ISSUE_TEMPLATE/task.yml
@@ -1,6 +1,5 @@
 name: "Development Task"
 description: "Create a development task for Loom"
-title: ""
 labels: ["loom:triage"]
 body:
   - type: markdown


### PR DESCRIPTION
## Summary

Fixes the issue where users cannot create new issues and only see a link to GitHub Discussions.

## Problem

After PRs #345 and #357, the repository was in a state where creating issues was broken. Users were seeing only a link to GitHub Discussions instead of the "Development Task" template.

The root cause was the `title: ""` field in the issue template. According to [GitHub's issue form documentation](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms), the title field is optional. When you want users to provide their own title, you should **omit the field entirely** rather than setting it to an empty string.

## Changes

- ✅ Removed `title: ""` from `.github/ISSUE_TEMPLATE/task.yml`
- ✅ Removed `title: ""` from `defaults/.github/ISSUE_TEMPLATE/task.yml`

## Testing

- Verified YAML syntax is valid
- Lint, format, and clippy checks pass
- After merge, users should be able to create issues using the Development Task template

## References

- GitHub Issue Forms Syntax: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms
- Related PRs: #345, #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)