### PR TITLE
Optimize factory default agent worker types for Claude (#365)

### DIFF
--- a/defaults/config.json
+++ b/defaults/config.json
@@ -25,7 +25,7 @@
       "isPrimary": false,
       "role": "claude-code-worker",
       "roleConfig": {
-        "workerType": "codex",
+        "workerType": "claude",
         "roleFile": "curator.md",
         "targetInterval": 300000,
         "intervalPrompt": "Find unlabeled issues and enhance with implementation details"
@@ -137,7 +137,7 @@
       "isPrimary": false,
       "role": "claude-code-worker",
       "roleConfig": {
-        "workerType": "codex",
+        "workerType": "claude",
         "roleFile": "worker.md",
         "targetInterval": 60000,
         "intervalPrompt": "Find and implement loom:ready issues"


### PR DESCRIPTION
## Summary

Optimizes the factory default configuration to use Claude for most agent roles while keeping Codex for the Reviewer role, based on task complexity analysis.

## Changes

- **Curator**: `codex` → `claude` (requires strategic thinking for issue enhancement)
- **Worker 3**: `codex` → `claude` (implementation work benefits from Claude's reasoning)
- **Reviewer**: remains `codex` (pattern-based high-frequency task)

**Final agent mix**: 8 Claude / 1 Codex (Reviewer only)

## Rationale

1. **Curator needs Claude**: Issue enhancement requires understanding context, cross-referencing code, and strategic thinking - Claude excels here
2. **Worker 3 needs Claude**: Implementation work benefits from Claude's reasoning and code understanding
3. **Reviewer can stay Codex**: Code review is the most pattern-based task (style, tests, CI), runs frequently (5min), and Codex may be faster while maintaining quality

## Files Changed

- `defaults/config.json`: Updated worker types for Curator (terminal-2) and Worker 3 (terminal-9)

## Testing

- ✅ JSON syntax validated with `jq`
- ✅ No code changes required
- ✅ CI will verify configuration on merge

## Test Plan

To verify these changes after merge:

```bash
# Reset workspace and verify new defaults
mcp__loom-ui__trigger_force_factory_reset
mcp__loom-ui__trigger_force_start

# Verify worker types
jq '.agents[] | select(.name == "Curator") | .roleConfig.workerType' .loom/config.json
# Should output: "claude"

jq '.agents[] | select(.name == "Reviewer") | .roleConfig.workerType' .loom/config.json
# Should output: "codex"

jq '.agents[] | select(.name == "Worker 3") | .roleConfig.workerType' .loom/config.json
# Should output: "claude"
```

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)