### PR TITLE
Fix new terminals not displaying default/driver role in UI

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -984,13 +984,14 @@ async function createPlainTerminal() {
     const worktreePath = await setupWorktreeForAgent(id, workspacePath);
     logger.info("Created worktree", { name, id, worktreePath });
 
-    // Add to state (no role assigned - plain shell)
+    // Add to state with default role (plain shell / driver)
     state.addTerminal({
       id,
       name,
       worktreePath,
       status: TerminalStatus.Idle,
       isPrimary: false,
+      role: "default",
       theme: "default",
     });
 


### PR DESCRIPTION
## Summary

Fixes issue where new terminals created via the "+" button were not displaying their role in the UI.

## Changes

- Added `role: "default"` property to terminal object when calling `state.addTerminal()` in main.ts:994
- Updated comment to clarify that default role is now properly assigned

## Root Cause

When creating a new terminal via the "+" button:
1. The code correctly passed `role: "default"` to the `create_terminal` IPC command (line 975)
2. But the terminal object added to state was missing the `role` property (lines 988-996)

This caused the UI to show "Terminal N" with no role, even though the terminal config showed "default" because it was stored in the IPC layer.

## Testing

- ✅ TypeScript compilation passes
- ✅ Linting and formatting pass
- ✅ Clippy passes
- ✅ Build succeeds
- ⚠️ Daemon tests show flaky failures (pre-existing race conditions, not related to this change)

## Test Plan

1. Start Loom and select a workspace
2. Click the "+" button to add a new terminal
3. Verify the new terminal displays "Driver" role in the UI
4. Open terminal settings and verify role shows as "default"

Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)