### PR TITLE
Remove dead code for loom:reviewing label cleanup

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -31,11 +31,6 @@ struct GhIssue {
     number: u32,
 }
 
-#[derive(serde::Deserialize)]
-struct GhPr {
-    number: u32,
-}
-
 #[tauri::command]
 fn greet(name: &str) -> String {
     format!("Hello, {name}! Welcome to Loom.")
@@ -955,7 +950,6 @@ fn update_github_label(name: &str, description: &str, color: &str) -> Result<(),
 #[derive(serde::Serialize)]
 struct LabelResetResult {
     issues_cleaned: usize,
-    prs_updated: usize,
     errors: Vec<String>,
 }
 
@@ -964,7 +958,6 @@ struct LabelResetResult {
 fn reset_github_labels() -> Result<LabelResetResult, String> {
     let mut result = LabelResetResult {
         issues_cleaned: 0,
-        prs_updated: 0,
         errors: Vec::new(),
     };
 
@@ -1008,54 +1001,6 @@ fn reset_github_labels() -> Result<LabelResetResult, String> {
                 let error = format!(
                     "Failed to remove loom:in-progress from issue {issue_num}: {}",
                     String::from_utf8_lossy(&remove_output.stderr)
-                );
-                result.errors.push(error);
-            }
-        }
-    }
-
-    // Step 2: Replace loom:reviewing with loom:review-requested on PRs
-    let prs_output = Command::new("gh")
-        .args([
-            "pr",
-            "list",
-            "--label",
-            "loom:reviewing",
-            "--state",
-            "open",
-            "--json",
-            "number",
-        ])
-        .output()
-        .map_err(|e| format!("Failed to list PRs: {e}"))?;
-
-    if prs_output.status.success() {
-        // Parse JSON in Rust instead of using jq to prevent injection
-        let prs: Vec<GhPr> = serde_json::from_slice(&prs_output.stdout)
-            .map_err(|e| format!("Failed to parse PR JSON: {e}"))?;
-
-        for pr in prs {
-            let pr_num = pr.number.to_string();
-
-            let edit_output = Command::new("gh")
-                .args([
-                    "pr",
-                    "edit",
-                    &pr_num,
-                    "--remove-label",
-                    "loom:reviewing",
-                    "--add-label",
-                    "loom:review-requested",
-                ])
-                .output()
-                .map_err(|e| format!("Failed to update PR labels: {e}"))?;
-
-            if edit_output.status.success() {
-                result.prs_updated += 1;
-            } else {
-                let error = format!(
-                    "Failed to update labels on PR {pr_num}: {}",
-                    String::from_utf8_lossy(&edit_output.stderr)
                 );
                 result.errors.push(error);
             }


### PR DESCRIPTION
## Summary

Removes obsolete cleanup code that references the `loom:reviewing` label, which was intentionally removed in #332.

## Changes

- **Removed `GhPr` struct** - No longer used after removing PR label cleanup
- **Removed `prs_updated` field** from `LabelResetResult` struct
- **Removed entire "Step 2" section** (lines 1017-1063) that handled `loom:reviewing` → `loom:review-requested` label replacement on PRs
- `reset_github_labels()` function now only handles `loom:in-progress` cleanup on issues

## Background

Issue #332 revised the label state machine and explicitly removed the `loom:reviewing` label because:
- PRs don't need a "claiming" mechanism like issues do
- Multiple reviewers can review the same PR (duplicate reviews catch more bugs)
- GitHub already provides assignee and draft review features
- Most setups have 1-2 reviewer terminals, not enough to justify the complexity

See `docs/design/issue-332-label-state-machine.md` line 46 for the design decision.

## Testing

- ✅ All linting, formatting, and clippy checks pass
- ✅ All tests pass (daemon integration tests, security tests, factory reset tests)
- ✅ Code compiles successfully
- ✅ Function still correctly resets issue labels on workspace restart

Fixes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)