### PR TITLE
Implement test output capture for daemon integration tests

### DIFF
--- a/loom-daemon/tests/common/mod.rs
+++ b/loom-daemon/tests/common/mod.rs
@@ -338,10 +338,7 @@ pub fn capture_terminal_output(session_name: &str) -> Result<String> {
         .context("Failed to execute tmux capture-pane")?;
 
     if !output.status.success() {
-        anyhow::bail!(
-            "tmux capture-pane failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
+        anyhow::bail!("tmux capture-pane failed: {}", String::from_utf8_lossy(&output.stderr));
     }
 
     String::from_utf8(output.stdout).context("Invalid UTF-8 in captured output")

--- a/loom-daemon/tests/integration_basic.rs
+++ b/loom-daemon/tests/integration_basic.rs
@@ -5,8 +5,7 @@
 mod common;
 
 use common::{
-    capture_terminal_output, cleanup_all_loom_sessions, tmux_session_exists, TestClient,
-    TestDaemon,
+    capture_terminal_output, cleanup_all_loom_sessions, tmux_session_exists, TestClient, TestDaemon,
 };
 use serial_test::serial;
 
@@ -125,8 +124,7 @@ async fn test_create_terminal_with_working_dir() {
     tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
 
     // Capture terminal output
-    let output = capture_terminal_output(&session_name)
-        .expect("Failed to capture terminal output");
+    let output = capture_terminal_output(&session_name).expect("Failed to capture terminal output");
 
     // Verify working directory appears in output
     // The output should contain the actual directory path from pwd command
@@ -294,15 +292,10 @@ async fn test_send_input() {
 
     // Capture terminal output
     let session_name = format!("loom-{terminal_id}-default-0");
-    let output = capture_terminal_output(&session_name)
-        .expect("Failed to capture terminal output");
+    let output = capture_terminal_output(&session_name).expect("Failed to capture terminal output");
 
     // Verify echoed output appears in terminal
-    assert!(
-        output.contains("hello"),
-        "Expected 'hello' in output, got: {}",
-        output
-    );
+    assert!(output.contains("hello"), "Expected 'hello' in output, got: {}", output);
 
     // Cleanup
     cleanup_all_loom_sessions();


### PR DESCRIPTION
## Summary

Implements test output capture mechanism for daemon integration tests using tmux's built-in `capture-pane` functionality. This resolves two TODO comments in the test suite and enables complete verification of terminal I/O behavior.

## Changes

### New Functionality
- **`capture_terminal_output()` helper** (`loom-daemon/tests/common/mod.rs:323-348`)
  - Uses `tmux capture-pane -t <session> -p` to read terminal content
  - Returns captured output as String with proper error handling
  - No additional dependencies required

### Test Improvements
- **`test_create_terminal_with_working_dir`** (`integration_basic.rs:88-139`)
  - Now sends `pwd` command and captures output
  - Verifies working directory path appears in terminal output
  - Removes TODO at line 112
  
- **`test_send_input`** (`integration_basic.rs:245-305`)
  - Captures output after `echo hello` command
  - Verifies echoed text appears in terminal
  - Removes TODO at line 273

### Technical Details
- Added 500ms initialization delay before sending commands to ensure shell is ready
- Used 1000ms delay after command execution to allow output to appear
- All 9 integration tests in `integration_basic.rs` passing

## Testing

```bash
pnpm daemon:test
# Result: 9/9 tests passing in integration_basic.rs
```

## Implementation Choice

Chose **Option 1 (Tmux Capture-Pane)** from issue proposal because:
- ✅ Minimal changes to existing architecture
- ✅ Leverages tmux's built-in functionality
- ✅ No additional dependencies
- ✅ Matches current daemon design perfectly

## Benefits

- **Complete test coverage** for terminal I/O operations
- **Verify daemon behavior** end-to-end with real output
- **Catch regressions** in terminal output handling
- **Document expected behavior** through executable tests

Closes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>