### PR TITLE
Add pnpm worktree permission and document Claude Code configuration (#319)

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -2,6 +2,15 @@
 
 This directory contains Claude Code configuration for the Loom project.
 
+## Configuration Philosophy
+
+Loom maintains a minimal `.claude/` configuration focused on:
+- **Permissions**: Pre-approved commands for common workflows
+- **MCP Servers**: Tool integration for testing and debugging
+- **Documentation**: Clear explanation of available capabilities
+
+We intentionally keep the structure simple and avoid over-configuration. Additional directories (`agents/`, `commands/`, `hooks/`) can be added later if specific needs arise.
+
 ## Files
 
 - **`settings.json`**: Team-wide permissions and settings (committed to git)
@@ -31,6 +40,7 @@ The `settings.json` file pre-approves common development commands to streamline 
 - `pnpm daemon:dev` - Run daemon in dev mode
 - `pnpm check:all` - Run all checks
 - `pnpm check:ci` - Run CI checks locally
+- `pnpm worktree` - Create git worktree for issue development
 
 ### Code Quality
 - `pnpm lint` - Biome linting

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -41,6 +41,7 @@
       "Bash(pnpm daemon:test:*)",
       "Bash(pnpm check:all:*)",
       "Bash(pnpm check:ci:*)",
+      "Bash(pnpm worktree:*)",
       "Bash(pnpm exec tsc:*)",
       "Bash(pnpm lint:*)",
       "Bash(pnpm format:*)",


### PR DESCRIPTION
## Summary

Adds `pnpm worktree` permission to Claude Code settings and documents our configuration philosophy. This addresses the permission prompt issue when creating worktrees and provides clarity on our minimal configuration approach.

## Changes

### 1. Add `pnpm worktree` Permission

**File**: `.claude/settings.json`

Added `Bash(pnpm worktree:*)` to the permissions allow list. This pre-approves the worktree creation command so Claude Code doesn't prompt for permission each time.

**Before**: Permission prompt appeared every time `pnpm worktree <issue>` was run
**After**: Command executes immediately without interruption

### 2. Document Configuration Philosophy

**File**: `.claude/README.md`

Added "Configuration Philosophy" section that explains:
- Why we maintain a minimal configuration
- Focus on permissions, MCP servers, and documentation
- Intentional decision to avoid unused directory structures (agents/, commands/, hooks/)
- Note that structure can evolve as needs arise

Also documented the new `pnpm worktree` permission in the README.

## Rationale

The `pnpm worktree` command is core to Loom's development workflow:
- Used every time a Builder claims an issue
- Creates isolated working directory at `.loom/worktrees/issue-{number}`
- Enables multiple agents to work on different issues simultaneously

Without pre-approval, Claude Code prompts for permission on every invocation, disrupting the workflow.

## Configuration Philosophy Decision

After reviewing the reference structure with `agents/`, `commands/`, and `hooks/` directories, we decided to maintain a minimal configuration because:

1. **YAGNI Principle**: Don't add directories until we have specific use cases
2. **Clear Purpose**: Our current structure serves all current needs
3. **Agent Config**: Already handled via `defaults/roles/` in the workspace
4. **Future Flexibility**: Can add directories later if requirements emerge

## Benefits

- **Streamlined workflow**: No permission interruptions for worktree creation
- **Clear documentation**: Explains our configuration decisions
- **Reduced complexity**: Avoids over-engineering the config structure
- **Future-proof**: Documents philosophy for future additions

## Test Plan

- [x] JSON syntax validation passes
- [x] README renders correctly
- [x] Permission format matches existing patterns
- [ ] Manual test: Create worktree without permission prompt

## Related

- Addresses #319
- Follows patterns established in `.claude/settings.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)