### PR TITLE
Add /loom slash command for random role iteration (#398)

### DIFF
--- a/defaults/.claude/commands/loom.md
+++ b/defaults/.claude/commands/loom.md
@@ -1,0 +1,93 @@
+# Assume Loom Role
+
+Randomly select and assume an archetypal role from the Loom orchestration system, then perform one iteration of work following that role's guidelines.
+
+## Process
+
+1. **List available roles**: Check `defaults/roles/*.md` or `.loom/roles/*.md`
+2. **Select one at random**: Use current timestamp or random selection
+3. **Read the role definition**: Load the markdown file for the selected role
+4. **Follow the role's workflow**: Complete ONE iteration only (one task, one PR review, one issue triage, etc.)
+5. **Report results**: Summarize what you accomplished with links to issues/PRs modified
+
+## Available Roles
+
+- **builder.md** - Claim `loom:ready` issue, implement feature/fix, create PR with `loom:review-requested`
+- **judge.md** - Review PR with `loom:review-requested`, approve or request changes, update labels
+- **curator.md** - Find unlabeled issue, enhance with technical details, mark as `loom:ready`
+- **architect.md** - Create architectural proposal issue with `loom:architect-suggestion` label
+- **hermit.md** - Analyze codebase complexity, create bloat removal issue with `loom:critic-suggestion`
+- **healer.md** - Fix bug or address PR feedback, maintain existing PRs
+- **guide.md** - Triage batch of issues, update priorities and labels for workflow
+- **driver.md** - Execute direct task or command (plain shell, no specific workflow)
+
+## Work Scope
+
+Complete **ONE** meaningful task following the selected role's guidelines, then **stop and report**.
+
+### Task Examples by Role
+
+**Builder**: Claim one `loom:ready` issue → implement → test → commit → create PR
+**Judge**: Review one PR with `loom:review-requested` → provide feedback → approve/request changes
+**Curator**: Find one unlabeled issue → add context → tag as `loom:ready`
+**Architect**: Identify one architectural need → create detailed proposal issue
+**Hermit**: Analyze codebase section → identify bloat → create removal issue
+**Healer**: Fix one bug or address one PR comment → update PR → push changes
+**Guide**: Review issue backlog → update priorities → add/remove labels for batch
+**Driver**: Execute one direct command or task per user instruction
+
+## Report Format
+
+After completing your iteration, report:
+
+```
+✓ Role Assumed: [Role Name]
+✓ Task Completed: [Brief description]
+✓ Changes Made:
+  - [Issue/PR #XXX]: [Description with link]
+  - [Label changes]
+  - [Files modified if applicable]
+✓ Next Steps: [Suggestions for follow-up or ready state]
+```
+
+## Label Workflow
+
+Follow the label-based coordination system (ADR-0006):
+
+- Issues: `loom:ready` → `loom:in-progress` → closed
+- PRs: `loom:review-requested` → `loom:approved` → merged
+- Proposals: `loom:architect-suggestion` → reviewed → implemented or closed
+- Suggestions: `loom:critic-suggestion` → reviewed → implemented or closed
+
+## Notes
+
+- This command simulates one terminal's work in the Loom multi-terminal orchestration system
+- Multiple Claude Code sessions can run `/loom` in parallel for distributed work
+- Each iteration should be atomic and complete (don't leave partial work)
+- Always update labels appropriately to signal state to other roles
+- Check for existing work to avoid conflicts (e.g., don't claim already `in-progress` issues)
+
+## Example Usage
+
+```bash
+# In Claude Code terminal
+/loom
+
+# Claude responds:
+"🎭 Rolling random role... Assuming the Judge role for this iteration.
+
+Looking for PRs with loom:review-requested...
+Found PR #401 - 'Add terminal restart functionality'
+
+[Performs detailed review following judge.md guidelines]
+
+✓ Role Assumed: Judge
+✓ Task Completed: Reviewed PR #401
+✓ Changes Made:
+  - PR #401: Added detailed review comment with 3 suggestions
+  - Label changed: loom:review-requested → loom:approved
+  - Approved PR for merge
+✓ Next Steps: Ready for maintainer to merge
+
+Review complete!"
+```


### PR DESCRIPTION
## Summary

Adds a `/loom` slash command that enables Claude Code agents to randomly assume an archetypal role and perform one iteration of work. This supports manual orchestration experiments and parallel role testing.

**Usage:**
```bash
/loom
```

Claude Code will:
1. Randomly select a role from `defaults/roles/`
2. Load the role definition (builder.md, judge.md, curator.md, etc.)
3. Perform ONE iteration of that role's work
4. Report results with links

## Implementation

Created `defaults/.claude/commands/loom.md` slash command definition with:
- Instructions to list and randomly select roles
- Guidelines for each role's work scope
- Report format for results
- Label-based workflow coordination

## Integration

The existing `setup_repository_scaffolding()` function in `loom-daemon/src/init.rs:225-277` already copies `.claude/` directories recursively when running `loom init <path>`, so this slash command will automatically be available after initialization.

## Example Usage

```bash
# Terminal 1 - Claude Code session 1
/loom
> "🎭 Assuming Builder role, claiming issue #400..."
> "Implemented feature, created PR #401"

# Terminal 2 - Claude Code session 2  
/loom
> "🎭 Assuming Judge role, reviewing PR #398..."
> "Approved PR #398, changed label to loom:approved"

# Terminal 3 - Claude Code session 3
/loom
> "🎭 Assuming Curator role, enhancing issue #399..."
> "Added technical details, marked as loom:ready"
```

## Work Scope per Role

- **Builder**: Claim 1 `loom:ready` issue → implement → create PR with `loom:review-requested`
- **Judge**: Review 1 PR with `loom:review-requested` → approve/request changes
- **Curator**: Find 1 unlabeled issue → enhance → mark `loom:ready`
- **Architect**: Create 1 architectural proposal with `loom:architect-suggestion`
- **Hermit**: Analyze codebase → create bloat removal issue with `loom:critic-suggestion`
- **Healer**: Fix 1 bug or address PR feedback
- **Guide**: Triage batch of issues, update priorities/labels
- **Driver**: Execute 1 direct command/task

## Benefits

✅ **Parallel Testing**: Run multiple Claude Code sessions to test concurrent role execution
✅ **Manual Orchestration**: Experiment with role coordination without the desktop app
✅ **Fast Iteration**: Quick way to test and refine role definitions
✅ **Dogfooding**: Use Loom's orchestration system on the Loom codebase itself

## Test Plan

The slash command works automatically once the `.claude/commands/` directory exists:

1. Run `loom init <workspace>` to copy slash command to workspace
2. Open Claude Code in the workspace
3. Type `/loom` to trigger the command
4. Claude Code reads the markdown and follows the instructions

No code changes needed - pure configuration!

## Notes

- Follows label-based workflow coordination (ADR-0006)
- Each iteration is atomic and complete
- Multiple agents can run `/loom` in parallel safely
- Command is automatically discovered by Claude Code

Closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)