### PR TITLE
Remove unnecessary wrapper functions from main.ts

### DIFF
--- a/loom-daemon/tests/integration_basic.rs
+++ b/loom-daemon/tests/integration_basic.rs
@@ -130,9 +130,7 @@ async fn test_create_terminal_with_working_dir() {
     // The output should contain the actual directory path from pwd command
     assert!(
         output.contains(&working_dir),
-        "Expected working directory '{}' in output, got: '{}'",
-        working_dir,
-        output
+        "Expected working directory '{working_dir}' in output, got: '{output}'"
     );
 
     // Cleanup
@@ -295,7 +293,7 @@ async fn test_send_input() {
     let output = capture_terminal_output(&session_name).expect("Failed to capture terminal output");
 
     // Verify echoed output appears in terminal
-    assert!(output.contains("hello"), "Expected 'hello' in output, got: {}", output);
+    assert!(output.contains("hello"), "Expected 'hello' in output, got: {output}");
 
     // Cleanup
     cleanup_all_loom_sessions();


### PR DESCRIPTION
## Summary

Removed 4 unnecessary wrapper functions from `src/main.ts` that only passed dependencies without adding value:

- `handleWorkspacePathInput` wrapper
- `verifyTerminalSessions` wrapper  
- `launchAgentsForTerminals` wrapper
- `reconnectTerminals` wrapper

All call sites now use direct dependency injection via arrow function lambdas, making the code simpler and more maintainable.

## Changes

**Modified files:**
- `src/main.ts` - Removed wrappers, updated all call sites to pass dependencies directly
- `loom-daemon/tests/integration_basic.rs` - Fixed clippy warnings for inline format args

**Pattern used:**
```typescript
// Before (wrapper function)
async function reconnectTerminals() {
  await reconnectTerminalsCore({ state, initializeTerminalDisplay, saveCurrentConfig });
}

// After (direct dependency injection)
reconnectTerminals: () => reconnectTerminals({ state, initializeTerminalDisplay, saveCurrentConfig })
```

## Test Plan

- ✅ TypeScript compilation passes (`pnpm exec tsc --noEmit`)
- ✅ Linting and formatting pass (`pnpm lint`, `pnpm format`)
- ✅ Clippy passes with CI flags (`pnpm clippy`)
- ✅ Frontend builds successfully (`pnpm build`)
- ✅ 489 unit tests pass

## Impact

- **Code simplification**: 4 fewer wrapper functions to maintain
- **Better clarity**: Dependencies are now explicit at call sites
- **No functional changes**: Pure refactoring with identical runtime behavior

Closes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)