### PR TITLE
Refactor main.ts Phase 2: Extract app initialization and terminal creation (#392)

### DIFF
--- a/src/lib/app-initializer.ts
+++ b/src/lib/app-initializer.ts
@@ -1,0 +1,183 @@
+/**
+ * App Initialization
+ *
+ * Handles application startup including dependency checks and workspace loading.
+ * Implements a priority-based workspace loading system:
+ * 1. CLI argument (--workspace flag)
+ * 2. LocalStorage (HMR survival)
+ * 3. Tauri storage (persistent)
+ */
+
+import { invoke } from "@tauri-apps/api/tauri";
+import { Logger } from "./logger";
+import type { AppState } from "./state";
+
+const logger = Logger.forComponent("app-initializer");
+
+/**
+ * Check dependencies on startup
+ *
+ * Verifies all required system dependencies are installed.
+ * Exits the app if dependencies are missing and user declines to retry.
+ *
+ * @returns True if all dependencies are present, false otherwise
+ */
+export async function checkDependenciesOnStartup(): Promise<boolean> {
+  const { checkAndReportDependencies } = await import("./dependency-checker");
+  const hasAllDependencies = await checkAndReportDependencies();
+
+  if (!hasAllDependencies) {
+    // User chose not to retry, close the app gracefully
+    logger.error("Missing dependencies, exiting", new Error("Missing dependencies"));
+    const { exit } = await import("@tauri-apps/api/process");
+    await exit(1);
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Initialize application
+ *
+ * Handles app startup sequence:
+ * 1. Check dependencies
+ * 2. Try CLI workspace argument (highest priority)
+ * 3. Try localStorage workspace (HMR survival)
+ * 4. Try Tauri storage workspace (persistent)
+ * 5. Show workspace picker if no valid workspace found
+ *
+ * @param state - Application state
+ * @param validateWorkspacePath - Function to validate workspace paths
+ * @param handleWorkspacePathInput - Function to handle workspace path input
+ * @param render - Function to render the UI
+ */
+export async function initializeApp(deps: {
+  state: AppState;
+  validateWorkspacePath: (path: string) => Promise<boolean>;
+  handleWorkspacePathInput: (path: string) => Promise<void>;
+  render: () => void;
+}): Promise<void> {
+  const { state, validateWorkspacePath, handleWorkspacePathInput, render } = deps;
+
+  // Set initializing state to show loading UI
+  state.setInitializing(true);
+  logger.info("Starting initialization");
+
+  // Check dependencies first
+  const hasAllDependencies = await checkDependenciesOnStartup();
+  if (!hasAllDependencies) {
+    state.setInitializing(false);
+    return; // Exit early if dependencies are missing
+  }
+
+  // PRIORITY 1: Check for CLI workspace argument (highest priority)
+  try {
+    const cliWorkspace = await invoke<string | null>("get_cli_workspace");
+    if (cliWorkspace) {
+      logger.info("Found CLI workspace argument", {
+        cliWorkspace,
+        priority: "highest",
+      });
+      logger.info("Using CLI workspace (takes precedence over stored workspace)");
+
+      // Validate CLI workspace
+      const isValid = await validateWorkspacePath(cliWorkspace);
+      if (isValid) {
+        logger.info("CLI workspace is valid, loading", { cliWorkspace });
+        await handleWorkspacePathInput(cliWorkspace);
+        state.setInitializing(false);
+        return; // CLI workspace loaded successfully - skip stored workspace
+      }
+
+      logger.warn("CLI workspace is invalid, falling back to stored workspace", {
+        cliWorkspace,
+      });
+    } else {
+      logger.info("No CLI workspace argument provided");
+    }
+  } catch (error) {
+    logger.error("Failed to get CLI workspace", error);
+    // Continue to stored workspace fallback
+  }
+
+  // PRIORITY 2: Try to restore workspace from localStorage (for HMR survival)
+  const localStorageWorkspace = state.restoreWorkspaceFromLocalStorage();
+  if (localStorageWorkspace) {
+    logger.info("Restored workspace from localStorage (HMR survival)", {
+      localStorageWorkspace,
+    });
+    logger.info("This prevents HMR from clearing the workspace during hot reload");
+  }
+
+  try {
+    // PRIORITY 3: Check for stored workspace in Tauri storage (lowest priority)
+    const storedPath = await invoke<string | null>("get_stored_workspace");
+
+    if (storedPath) {
+      logger.info("Found stored workspace", { storedPath, priority: "lowest" });
+
+      // Validate stored workspace is still valid
+      const isValid = await validateWorkspacePath(storedPath);
+
+      if (isValid) {
+        // Load workspace automatically
+        logger.info("Loading stored workspace", { storedPath });
+        await handleWorkspacePathInput(storedPath);
+        state.setInitializing(false);
+        return;
+      }
+
+      // Path no longer valid - clear it and show picker
+      logger.info("Stored workspace invalid, clearing", { storedPath });
+      await invoke("clear_stored_workspace");
+      localStorage.removeItem("loom:workspace"); // Also clear localStorage
+    } else if (localStorageWorkspace) {
+      // No Tauri storage but have localStorage (HMR case)
+      logger.info("Using localStorage workspace after HMR", {
+        localStorageWorkspace,
+      });
+      const isValid = await validateWorkspacePath(localStorageWorkspace);
+
+      if (isValid) {
+        logger.info("localStorage workspace is valid, loading", {
+          localStorageWorkspace,
+        });
+        await handleWorkspacePathInput(localStorageWorkspace);
+        state.setInitializing(false);
+        return;
+      }
+
+      // Invalid - clear it
+      logger.info("localStorage workspace is invalid, clearing", {
+        localStorageWorkspace,
+      });
+      localStorage.removeItem("loom:workspace");
+    }
+  } catch (error) {
+    logger.error("Failed to load stored workspace", error);
+
+    // If Tauri storage failed but we have localStorage, try that
+    if (localStorageWorkspace) {
+      logger.info("Tauri storage failed, trying localStorage workspace", {
+        localStorageWorkspace,
+      });
+      const isValid = await validateWorkspacePath(localStorageWorkspace);
+      if (isValid) {
+        logger.info("localStorage workspace is valid, loading", {
+          localStorageWorkspace,
+        });
+        await handleWorkspacePathInput(localStorageWorkspace);
+        state.setInitializing(false);
+        return;
+      }
+
+      logger.info("localStorage workspace is invalid", { localStorageWorkspace });
+    }
+  }
+
+  // No workspace found or all validation failed - show picker
+  logger.info("No valid workspace found, showing workspace picker");
+  state.setInitializing(false);
+  render();
+}


### PR DESCRIPTION
## Summary

Completes Phase 2 of issue #392 refactoring work, reducing main.ts from 1174 to 997 lines (177 lines removed).

## Changes

### Phase 2.1: Extract app initialization (~136 lines)
- ✅ Created `src/lib/app-initializer.ts` with:
  - `checkDependenciesOnStartup()` - Verify system dependencies
  - `initializeApp()` - Priority-based workspace loading:
    1. CLI argument (`--workspace` flag)
    2. LocalStorage (HMR survival)
    3. Tauri storage (persistent)
- ✅ Dependency injection pattern for state, validators, render
- ✅ Removed inline implementation from main.ts

### Phase 2.2: Extract terminal creation (~56 lines)
- ✅ Moved `createPlainTerminal()` to `src/lib/terminal-actions.ts`
- ✅ Updated call sites to pass dependencies (state, workspacePath, generateNextConfigId, saveCurrentConfig)
- ✅ Consistent with existing terminal action patterns

## Files Changed
- **src/lib/app-initializer.ts** (NEW): 183 lines
- **src/lib/terminal-actions.ts**: +66 lines
- **src/main.ts**: -199 lines (net reduction accounting for dependency passing)

## Testing
- ✅ TypeScript compilation passes
- ✅ Vite build succeeds
- ✅ Biome linting passes
- ✅ Rust formatting passes
- ✅ Clippy passes
- ⚠️ One pre-existing flaky daemon test failure (`test_reject_empty_id` - connection refused, unrelated to changes)

## Metrics
- **Phase 1**: 1343 → 1174 lines (-169 lines)
- **Phase 2**: 1174 → 997 lines (-177 lines)
- **Total**: 1343 → 997 lines **(-346 lines, 25.8% reduction)**

## Next Steps
After this PR merges, Phase 3 will tackle:
- Consolidate event handlers (~285 lines)
- Target: reduce main.ts to ~600-700 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)