### PR TITLE
Complete config/state split by updating defaults/config.json

### DIFF
--- a/defaults/config.json
+++ b/defaults/config.json
@@ -1,12 +1,8 @@
 {
-  "nextAgentNumber": 10,
-  "agents": [
+  "terminals": [
     {
-      "configId": "terminal-1",
-      "id": "__needs_session__",
+      "id": "terminal-1",
       "name": "Architect",
-      "status": "idle",
-      "isPrimary": true,
       "role": "claude-code-worker",
       "roleConfig": {
         "workerType": "claude",
@@ -14,15 +10,11 @@
         "targetInterval": 900000,
         "intervalPrompt": "First triage any unlabeled issues. If none exist, scan codebase and create new improvement suggestions across features, docs, quality, CI, and security"
       },
-      "worktreePath": "",
       "theme": "lavender"
     },
     {
-      "configId": "terminal-2",
-      "id": "__needs_session__",
+      "id": "terminal-2",
       "name": "Curator",
-      "status": "idle",
-      "isPrimary": false,
       "role": "claude-code-worker",
       "roleConfig": {
         "workerType": "claude",
@@ -30,15 +22,11 @@
         "targetInterval": 300000,
         "intervalPrompt": "Find unlabeled issues and enhance with implementation details"
       },
-      "worktreePath": "",
       "theme": "ocean"
     },
     {
-      "configId": "terminal-3",
-      "id": "__needs_session__",
+      "id": "terminal-3",
       "name": "Guide",
-      "status": "idle",
-      "isPrimary": false,
       "role": "claude-code-worker",
       "roleConfig": {
         "workerType": "claude",
@@ -46,15 +34,11 @@
         "targetInterval": 900000,
         "intervalPrompt": "Review all loom:ready issues and update loom:urgent labels to reflect current top 3 priorities"
       },
-      "worktreePath": "",
       "theme": "indigo"
     },
     {
-      "configId": "terminal-4",
-      "id": "__needs_session__",
+      "id": "terminal-4",
       "name": "Judge",
-      "status": "idle",
-      "isPrimary": false,
       "role": "claude-code-worker",
       "roleConfig": {
         "workerType": "codex",
@@ -62,15 +46,11 @@
         "targetInterval": 300000,
         "intervalPrompt": "Find and review PRs with loom:review-requested label"
       },
-      "worktreePath": "",
       "theme": "rose"
     },
     {
-      "configId": "terminal-5",
-      "id": "__needs_session__",
+      "id": "terminal-5",
       "name": "Builder 1",
-      "status": "idle",
-      "isPrimary": false,
       "role": "claude-code-worker",
       "roleConfig": {
         "workerType": "claude",
@@ -78,15 +58,11 @@
         "targetInterval": 60000,
         "intervalPrompt": "Find and implement loom:ready issues"
       },
-      "worktreePath": "",
       "theme": "forest"
     },
     {
-      "configId": "terminal-6",
-      "id": "__needs_session__",
+      "id": "terminal-6",
       "name": "Builder 2",
-      "status": "idle",
-      "isPrimary": false,
       "role": "claude-code-worker",
       "roleConfig": {
         "workerType": "claude",
@@ -94,15 +70,11 @@
         "targetInterval": 60000,
         "intervalPrompt": "Find and implement loom:ready issues"
       },
-      "worktreePath": "",
       "theme": "forest"
     },
     {
-      "configId": "terminal-7",
-      "id": "__needs_session__",
+      "id": "terminal-7",
       "name": "Healer",
-      "status": "idle",
-      "isPrimary": false,
       "role": "claude-code-worker",
       "roleConfig": {
         "workerType": "claude",
@@ -110,15 +82,11 @@
         "targetInterval": 300000,
         "intervalPrompt": "Check for PRs with changes requested: gh pr list --label=\"loom:changes-requested\" --state=open. Address feedback, run pnpm check:ci, and update labels to loom:review-requested"
       },
-      "worktreePath": "",
       "theme": "amber"
     },
     {
-      "configId": "terminal-8",
-      "id": "__needs_session__",
+      "id": "terminal-8",
       "name": "Hermit",
-      "status": "idle",
-      "isPrimary": false,
       "role": "claude-code-worker",
       "roleConfig": {
         "workerType": "claude",
@@ -126,15 +94,11 @@
         "targetInterval": 900000,
         "intervalPrompt": "Analyze the codebase for opportunities to simplify, remove bloat, or eliminate unnecessary complexity. Create a GitHub issue with loom:critic-suggestion label if you find something concrete"
       },
-      "worktreePath": "",
       "theme": "gray"
     },
     {
-      "configId": "terminal-9",
-      "id": "__needs_session__",
+      "id": "terminal-9",
       "name": "Builder 3",
-      "status": "idle",
-      "isPrimary": false,
       "role": "claude-code-worker",
       "roleConfig": {
         "workerType": "claude",
@@ -142,7 +106,6 @@
         "targetInterval": 60000,
         "intervalPrompt": "Find and implement loom:ready issues"
       },
-      "worktreePath": "",
       "theme": "crimson"
     }
   ]


### PR DESCRIPTION
## Summary

Completes the config/state split migration (ADR-0003 & Issue #96) by updating `defaults/config.json` to the new format.

## Changes

- ✅ Convert `defaults/config.json` from legacy "agents" to new "terminals" format
- ✅ Remove dual-ID system (`configId` + `id`) in favor of single stable `id` field  
- ✅ Remove all state fields (`status`, `isPrimary`, `worktreePath`) - these belong in `state.json`
- ✅ Remove `nextAgentNumber` from config (belongs in state, defaults to 1)

## Context

Issue #96 identified that terminal IDs were conflated for both configuration identity and runtime session management. The config/state split (ADR-0003) was already implemented in the code, but `defaults/config.json` still used the legacy format.

The daemon already correctly:
- Accepts stable config IDs (e.g., `"terminal-1"`)
- Returns the same stable ID (not the tmux session name)
- Maintains tmux session mapping internally (`"loom-terminal-1-default-0"`)

Migration logic in `config.ts` already handles converting legacy formats, so existing workspaces will automatically upgrade on next load.

## Testing

- ✅ All config-related tests pass
- ✅ Migration logic verified working
- ✅ Config/state split functional

Note: Some unrelated test failures exist due to structured logging format changes (Issue #130), but all config functionality is working correctly.

## Test plan

- [ ] Load existing workspace - should migrate automatically
- [ ] Factory reset - should use new config format
- [ ] Verify terminals created with stable IDs

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)