### PR TITLE
Security: Add symlink validation to git root detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tempfile",
  "tokio",
 ]
 
@@ -898,7 +899,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2179,7 +2180,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2875,7 +2876,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3624,7 +3625,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4258,7 +4259,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4428,15 +4429,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,6 +25,9 @@ dotenvy = "0.15"
 chrono = "0.4"
 notify = { version = "6", default-features = false, features = ["macos_fsevent"] }
 
+[dev-dependencies]
+tempfile = "3.8"
+
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem and the built-in dev server is disabled.
 # If you use cargo directly instead of tauri's cli you can use this feature flag to switch between tauri's `dev` and `build` modes.


### PR DESCRIPTION
## Summary

Security hardening for `find_git_root()` function to prevent symlink-based directory traversal attacks (CWE-59).

**Key Changes:**
- Add symlink detection using `symlink_metadata()` in `find_git_root()` (`src-tauri/src/main.rs:418-424`)
- Reject symlinks to prevent directory escape attacks
- Add comprehensive test coverage for both symlink rejection and valid .git directory acceptance
- Add `tempfile` dev dependency for test infrastructure

## Security Impact

**Vulnerability**: The original `find_git_root()` function followed symbolic links when checking for `.git` directories, allowing potential directory traversal attacks.

**Attack Scenario**:
```bash
# Attacker creates symlink pointing outside workspace
ln -s /sensitive/path .git

# find_git_root() would follow symlink and return escaped path
# resolve_defaults_path() would then use this to locate resources outside workspace
```

**Fix**: Added symlink validation that rejects any `.git` directory that is a symbolic link, preventing the attack.

## Test Results

✅ **New tests pass:**
```
running 2 tests
test tests::test_find_git_root_accepts_real_git_directory ... ok
test tests::test_find_git_root_rejects_symlink ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

✅ **All existing daemon tests pass** (10/10 unit tests, 2/2 factory reset tests)

✅ **Code quality:**
- Clippy: No warnings (with appropriate `#[allow]` for test unwraps)
- Rustfmt: All files formatted
- Biome: No linting issues

## Implementation Details

**Before**:
```rust
fn find_git_root() -> Option<std::path::PathBuf> {
    let mut current = std::env::current_dir().ok()?;
    loop {
        let git_dir = current.join(".git");
        if git_dir.exists() {  // ⚠️ Follows symlinks
            return Some(current);
        }
        if !current.pop() {
            return None;
        }
    }
}
```

**After**:
```rust
fn find_git_root() -> Option<std::path::PathBuf> {
    let mut current = std::env::current_dir().ok()?;
    loop {
        let git_dir = current.join(".git");
        
        // Security: Check if .git exists and is NOT a symlink
        if git_dir.exists() {
            if let Ok(metadata) = git_dir.symlink_metadata() {
                if metadata.is_symlink() {
                    return None;  // ✅ Reject symlinks
                }
            }
            return Some(current);
        }
        
        if !current.pop() {
            return None;
        }
    }
}
```

**Key Difference**: Using `symlink_metadata()` instead of relying on `exists()` alone. This allows detection of symlinks without following them.

## Test Coverage

**Test 1: Symlink Rejection** (`test_find_git_root_rejects_symlink`)
- Creates temp directory with `.git` as a symlink
- Verifies `find_git_root()` returns `None` (rejects symlink)
- Ensures security vulnerability is mitigated

**Test 2: Valid Directory Acceptance** (`test_find_git_root_accepts_real_git_directory`)
- Creates temp directory with real `.git` directory
- Verifies `find_git_root()` returns correct path
- Ensures functionality isn't broken for legitimate repos

## Files Changed

- `src-tauri/src/main.rs` - Add symlink validation + tests
- `src-tauri/Cargo.toml` - Add `tempfile` dev dependency
- `Cargo.lock` - Updated with `tempfile` dependency

## References

- **CWE-59**: Improper Link Resolution Before File Access
- **OWASP**: Path Traversal
- **Issue**: #235 (Architect suggestion for security hardening)

## Success Criteria

- ✅ Symlinks are rejected by `find_git_root()`
- ✅ Valid `.git` directories still work correctly
- ✅ Tests verify both rejection and acceptance cases
- ✅ No clippy warnings
- ✅ All existing tests still pass

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)