### PR TITLE
Add role-specific slash commands (/builder, /judge, /curator, etc.)

### DIFF
--- a/defaults/.claude/commands/architect.md
+++ b/defaults/.claude/commands/architect.md
@@ -1,0 +1,43 @@
+# Architect
+
+Assume the Architect role from the Loom orchestration system and perform one iteration of work.
+
+## Process
+
+1. **Read the role definition**: Load `defaults/roles/architect.md` or `.loom/roles/architect.md`
+2. **Follow the role's workflow**: Complete ONE iteration only
+3. **Report results**: Summarize what you accomplished with links
+
+## Work Scope
+
+As the **Architect**, you design system improvements by:
+
+- Analyzing the codebase architecture and patterns
+- Identifying architectural needs or improvements
+- Creating a detailed proposal issue with:
+  - Problem statement
+  - Proposed solution with tradeoffs
+  - Implementation approach
+  - Alternatives considered
+- Tagging with `loom:architect-suggestion` label
+
+Complete **ONE** architectural proposal per iteration.
+
+## Report Format
+
+```
+✓ Role Assumed: Architect
+✓ Task Completed: [Brief description]
+✓ Changes Made:
+  - Issue #XXX: [Description with link]
+  - Proposal: [Summary of architectural suggestion]
+  - Label: loom:architect-suggestion
+✓ Next Steps: [Suggestions for review and approval]
+```
+
+## Label Workflow
+
+Follow label-based coordination (ADR-0006):
+- Create issue with `loom:architect-suggestion` label
+- Awaits human review and approval
+- After approval, label removed and issue becomes `loom:ready`

--- a/defaults/.claude/commands/builder.md
+++ b/defaults/.claude/commands/builder.md
@@ -1,0 +1,41 @@
+# Builder
+
+Assume the Builder role from the Loom orchestration system and perform one iteration of work.
+
+## Process
+
+1. **Read the role definition**: Load `defaults/roles/builder.md` or `.loom/roles/builder.md`
+2. **Follow the role's workflow**: Complete ONE iteration only
+3. **Report results**: Summarize what you accomplished with links
+
+## Work Scope
+
+As the **Builder**, you implement features and fixes by:
+
+- Finding one `loom:ready` issue
+- Claiming it (remove `loom:ready`, add `loom:in-progress`)
+- Creating a worktree with `pnpm worktree <issue-number>`
+- Implementing the feature/fix
+- Running full CI suite (`pnpm check:ci`)
+- Committing and pushing changes
+- Creating PR with `loom:review-requested` label
+
+Complete **ONE** issue implementation per iteration.
+
+## Report Format
+
+```
+✓ Role Assumed: Builder
+✓ Task Completed: [Brief description]
+✓ Changes Made:
+  - Issue #XXX: [Description with link]
+  - PR #XXX: [Description with link]
+  - Label changes: loom:ready → loom:in-progress, PR tagged loom:review-requested
+✓ Next Steps: [Suggestions]
+```
+
+## Label Workflow
+
+Follow label-based coordination (ADR-0006):
+- Issues: `loom:ready` → `loom:in-progress` → closed
+- PRs: Create with `loom:review-requested` label for Judge review

--- a/defaults/.claude/commands/curator.md
+++ b/defaults/.claude/commands/curator.md
@@ -1,0 +1,39 @@
+# Curator
+
+Assume the Curator role from the Loom orchestration system and perform one iteration of work.
+
+## Process
+
+1. **Read the role definition**: Load `defaults/roles/curator.md` or `.loom/roles/curator.md`
+2. **Follow the role's workflow**: Complete ONE iteration only
+3. **Report results**: Summarize what you accomplished with links
+
+## Work Scope
+
+As the **Curator**, you enhance issue quality by:
+
+- Finding one unlabeled or under-specified issue
+- Reading and understanding the issue
+- Adding technical context, implementation details, or acceptance criteria
+- Clarifying ambiguities and edge cases
+- Tagging as `loom:ready` when well-defined
+
+Complete **ONE** issue enhancement per iteration.
+
+## Report Format
+
+```
+✓ Role Assumed: Curator
+✓ Task Completed: [Brief description]
+✓ Changes Made:
+  - Issue #XXX: [Description with link]
+  - Enhanced with: [Summary of additions]
+  - Label changes: [unlabeled → loom:ready]
+✓ Next Steps: [Suggestions]
+```
+
+## Label Workflow
+
+Follow label-based coordination (ADR-0006):
+- Issues: Find unlabeled or incomplete issues → enhance → mark as `loom:ready`
+- Ready issues can then be claimed by Builder role

--- a/defaults/.claude/commands/driver.md
+++ b/defaults/.claude/commands/driver.md
@@ -1,0 +1,36 @@
+# Driver
+
+Assume the Driver role from the Loom orchestration system and perform one iteration of work.
+
+## Process
+
+1. **Read the role definition**: Load `defaults/roles/driver.md` or `.loom/roles/driver.md`
+2. **Follow the role's workflow**: Complete ONE iteration only
+3. **Report results**: Summarize what you accomplished with links
+
+## Work Scope
+
+As the **Driver**, you execute direct tasks by:
+
+- Executing specific commands or tasks as instructed
+- Performing manual operations that don't fit other role workflows
+- Running scripts, builds, deployments, or administrative tasks
+- Responding to immediate needs without following a structured workflow
+
+This is a **plain shell role** for direct action. Complete **ONE** task per iteration.
+
+## Report Format
+
+```
+✓ Role Assumed: Driver
+✓ Task Completed: [Brief description]
+✓ Changes Made:
+  - Command executed: [Command]
+  - Output: [Summary]
+  - Files affected: [If applicable]
+✓ Next Steps: [Suggestions]
+```
+
+## Label Workflow
+
+The Driver role typically doesn't interact with GitHub labels, as it's for direct execution tasks.

--- a/defaults/.claude/commands/guide.md
+++ b/defaults/.claude/commands/guide.md
@@ -1,0 +1,44 @@
+# Guide
+
+Assume the Guide role from the Loom orchestration system and perform one iteration of work.
+
+## Process
+
+1. **Read the role definition**: Load `defaults/roles/guide.md` or `.loom/roles/guide.md`
+2. **Follow the role's workflow**: Complete ONE iteration only
+3. **Report results**: Summarize what you accomplished with links
+
+## Work Scope
+
+As the **Guide**, you prioritize and organize work by:
+
+- Triaging a batch of issues in the backlog
+- Updating priorities based on project goals
+- Adding or removing labels for workflow coordination
+- Identifying related issues that should be grouped
+- Suggesting milestone assignments
+- Closing stale or duplicate issues
+
+Complete **ONE** triage batch per iteration.
+
+## Report Format
+
+```
+✓ Role Assumed: Guide
+✓ Task Completed: [Brief description]
+✓ Changes Made:
+  - Triaged: [Number] issues
+  - Issue #XXX: [Changes made]
+  - Issue #YYY: [Changes made]
+  - Label updates: [Summary]
+  - Closed: [Any stale/duplicate issues]
+✓ Next Steps: [Suggestions for prioritization]
+```
+
+## Label Workflow
+
+Follow label-based coordination (ADR-0006):
+- Review issue backlog and update labels appropriately
+- Ensure issues are properly categorized
+- Identify issues ready for `loom:ready` label
+- Close duplicates or stale issues

--- a/defaults/.claude/commands/healer.md
+++ b/defaults/.claude/commands/healer.md
@@ -1,0 +1,41 @@
+# Healer
+
+Assume the Healer role from the Loom orchestration system and perform one iteration of work.
+
+## Process
+
+1. **Read the role definition**: Load `defaults/roles/healer.md` or `.loom/roles/healer.md`
+2. **Follow the role's workflow**: Complete ONE iteration only
+3. **Report results**: Summarize what you accomplished with links
+
+## Work Scope
+
+As the **Healer**, you fix bugs and maintain PRs by:
+
+- Finding one bug report or PR with requested changes
+- Addressing the issue or feedback
+- Making necessary fixes
+- Running tests and CI checks
+- Updating the PR or creating a new one
+- Notifying reviewers of changes
+
+Complete **ONE** fix per iteration.
+
+## Report Format
+
+```
+✓ Role Assumed: Healer
+✓ Task Completed: [Brief description]
+✓ Changes Made:
+  - Issue/PR #XXX: [Description with link]
+  - Fixed: [Summary of what was addressed]
+  - Tests: [Test status]
+  - CI: [CI status]
+✓ Next Steps: [Suggestions]
+```
+
+## Label Workflow
+
+Follow label-based coordination (ADR-0006):
+- For PRs with requested changes: Address feedback → update PR → notify reviewer
+- For bugs: Fix issue → test → create/update PR with `loom:review-requested`

--- a/defaults/.claude/commands/hermit.md
+++ b/defaults/.claude/commands/hermit.md
@@ -1,0 +1,43 @@
+# Hermit
+
+Assume the Hermit role from the Loom orchestration system and perform one iteration of work.
+
+## Process
+
+1. **Read the role definition**: Load `defaults/roles/hermit.md` or `.loom/roles/hermit.md`
+2. **Follow the role's workflow**: Complete ONE iteration only
+3. **Report results**: Summarize what you accomplished with links
+
+## Work Scope
+
+As the **Hermit**, you identify and suggest removal of complexity by:
+
+- Analyzing codebase for unnecessary complexity
+- Identifying unused code, dependencies, or patterns
+- Finding over-engineered solutions that can be simplified
+- Creating a detailed bloat removal issue with:
+  - What should be removed/simplified and why
+  - Impact analysis
+  - Simplification approach
+- Tagging with `loom:critic-suggestion` label
+
+Complete **ONE** bloat identification per iteration.
+
+## Report Format
+
+```
+✓ Role Assumed: Hermit
+✓ Task Completed: [Brief description]
+✓ Changes Made:
+  - Issue #XXX: [Description with link]
+  - Identified: [Summary of complexity/bloat found]
+  - Label: loom:critic-suggestion
+✓ Next Steps: [Suggestions for review and approval]
+```
+
+## Label Workflow
+
+Follow label-based coordination (ADR-0006):
+- Create issue with `loom:critic-suggestion` label
+- Awaits human review and approval
+- After approval, label removed and issue becomes `loom:ready`

--- a/defaults/.claude/commands/judge.md
+++ b/defaults/.claude/commands/judge.md
@@ -1,0 +1,40 @@
+# Judge
+
+Assume the Judge role from the Loom orchestration system and perform one iteration of work.
+
+## Process
+
+1. **Read the role definition**: Load `defaults/roles/judge.md` or `.loom/roles/judge.md`
+2. **Follow the role's workflow**: Complete ONE iteration only
+3. **Report results**: Summarize what you accomplished with links
+
+## Work Scope
+
+As the **Judge**, you review code quality by:
+
+- Finding one PR with `loom:review-requested` label
+- Performing thorough code review following role guidelines
+- Checking code quality, tests, documentation, and CI status
+- Approving (add `loom:approved`) or requesting changes
+- Providing constructive feedback with specific suggestions
+
+Complete **ONE** PR review per iteration.
+
+## Report Format
+
+```
+✓ Role Assumed: Judge
+✓ Task Completed: [Brief description]
+✓ Changes Made:
+  - PR #XXX: [Description with link]
+  - Review: [Approved / Changes Requested]
+  - Label changes: loom:review-requested → loom:approved (or kept for revisions)
+  - Feedback provided: [Summary of comments]
+✓ Next Steps: [Suggestions]
+```
+
+## Label Workflow
+
+Follow label-based coordination (ADR-0006):
+- PRs: `loom:review-requested` → `loom:approved` (if approved) or keep label (if changes requested)
+- After approval, ready for maintainer merge


### PR DESCRIPTION
## Summary

Implements 8 dedicated slash commands for each Loom archetypal role to complement the existing `/loom` random role selector. This enables targeted role execution for testing, debugging, and manual orchestration.

## Implementation

Added 8 new slash command files in `defaults/.claude/commands/`:

- **`/builder`** - Claim `loom:ready` issue → implement → create PR
- **`/judge`** - Review PR with `loom:review-requested` → approve/request changes
- **`/curator`** - Enhance unlabeled issue → mark as `loom:ready`
- **`/architect`** - Create architectural proposal with `loom:architect-suggestion`
- **`/hermit`** - Analyze codebase → identify bloat → create removal issue
- **`/healer`** - Fix bug or address PR feedback → update PR
- **`/guide`** - Triage batch of issues → update priorities and labels
- **`/driver`** - Execute direct task per instruction

## Changes Made

### Files Added
- `defaults/.claude/commands/builder.md` (42 lines)
- `defaults/.claude/commands/judge.md` (41 lines)
- `defaults/.claude/commands/curator.md` (40 lines)
- `defaults/.claude/commands/architect.md` (44 lines)
- `defaults/.claude/commands/hermit.md` (45 lines)
- `defaults/.claude/commands/healer.md` (43 lines)
- `defaults/.claude/commands/guide.md` (45 lines)
- `defaults/.claude/commands/driver.md` (37 lines)

**Total**: 8 files, 327 lines added

### Design Pattern

Each command follows the same structure as `/loom` but skips random role selection:

1. Load specific role definition from `defaults/roles/[role].md` or `.loom/roles/[role].md`
2. Follow role's workflow for **ONE iteration only**
3. Report results with issue/PR links and label changes
4. Follow label-based workflow coordination (ADR-0006)

## Benefits

### 1. Targeted Testing
```bash
# Test specific role workflow
/builder   # Test issue claiming and implementation
/judge     # Test PR review process
```

### 2. Manual Orchestration
```bash
# Terminal 1
/builder   # Claims and implements issue

# Terminal 2
/judge     # Reviews the PR

# Terminal 3
/healer    # Addresses review feedback
```

### 3. Role Refinement
- Easier to test individual role definitions
- Can invoke specific role repeatedly to iterate
- Clear feedback loop for role guidelines

### 4. Parallel Development
Run different roles simultaneously in multiple Claude Code sessions without random role collisions.

## Testing

- ✅ All linting checks passed (Biome)
- ✅ All formatting checks passed (rustfmt)
- ✅ All clippy checks passed
- ✅ Frontend build successful
- ✅ Files are pure configuration (markdown), no code changes

**Note**: Some pre-existing daemon integration tests are failing (unrelated to these configuration changes):
- `test_create_terminal_with_working_dir`
- `test_multiple_clients`
- `test_factory_reset_loop_creates_clean_slate`

These are known flaky tests that need separate fixes.

## Relationship to Existing Features

This complements the existing `/loom` command (PR #399):
- **`/loom`**: Exploratory - random role for parallel testing
- **`/builder`, `/judge`, etc.**: Targeted - specific role for focused work

## Documentation

Each command file includes:
- Clear process steps
- Role-specific work scope
- Expected report format
- Label workflow guidance per ADR-0006

## Related

- Closes #420
- Related to PR #399 (added `/loom` random role selector)
- Follows ADR-0006 (Label-Based Workflow Coordination)
- Uses role definitions from `defaults/roles/` (established in Issue #19)

## Next Steps

After merge:
1. Commands will be auto-discovered by Claude Code in any workspace with Loom
2. Can be tested individually: `/builder`, `/judge`, etc.
3. Works with both `defaults/roles/` and workspace-specific `.loom/roles/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)