### PR TITLE
Add cleanup script for build artifacts and orphaned worktrees

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "check:all": "pnpm lint && pnpm format:rust && pnpm clippy && pnpm check && pnpm build && pnpm test:unit",
     "check:ci": "pnpm lint && pnpm format:rust && pnpm clippy:locked && pnpm check && pnpm build && pnpm test && pnpm test:unit:coverage",
     "worktree": "./scripts/worktree.sh",
+    "clean": "./scripts/cleanup.sh",
+    "clean:full": "./scripts/cleanup.sh && pnpm install",
     "prepare": "husky"
   },
   "repository": {

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Loom Cleanup Script - Remove build artifacts and orphaned worktrees
+
+set -e  # Exit on error
+
+echo "🧹 Loom Cleanup"
+echo ""
+
+# Track if we're in main workspace
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Clean Rust build artifacts
+if [ -d "$PROJECT_ROOT/target" ]; then
+  SIZE=$(du -sh "$PROJECT_ROOT/target" 2>/dev/null | cut -f1 || echo "unknown")
+  echo "Removing target/ ($SIZE)"
+  rm -rf "$PROJECT_ROOT/target"
+  echo "✓ Removed target/"
+else
+  echo "ℹ No target/ directory found"
+fi
+
+echo ""
+
+# Clean node_modules
+if [ -d "$PROJECT_ROOT/node_modules" ]; then
+  SIZE=$(du -sh "$PROJECT_ROOT/node_modules" 2>/dev/null | cut -f1 || echo "unknown")
+  echo "Removing node_modules/ ($SIZE)"
+  rm -rf "$PROJECT_ROOT/node_modules"
+  echo "✓ Removed node_modules/"
+else
+  echo "ℹ No node_modules/ directory found"
+fi
+
+echo ""
+
+# Clean orphaned worktrees
+echo "Checking for orphaned worktrees..."
+cd "$PROJECT_ROOT"
+
+# Show what would be pruned
+PRUNE_OUTPUT=$(git worktree prune --dry-run --verbose 2>&1 || true)
+
+if [ -n "$PRUNE_OUTPUT" ]; then
+  echo "$PRUNE_OUTPUT"
+  echo ""
+  read -p "Remove orphaned worktrees? (y/N) " -n 1 -r
+  echo
+  if [[ $REPLY =~ ^[Yy]$ ]]; then
+    git worktree prune --verbose
+    echo "✓ Orphaned worktrees removed"
+  else
+    echo "ℹ Skipped worktree cleanup"
+  fi
+else
+  echo "✓ No orphaned worktrees found"
+fi
+
+echo ""
+echo "✅ Cleanup complete!"
+echo ""
+echo "To restore dependencies, run:"
+echo "  pnpm install"


### PR DESCRIPTION
## Summary

Implements issue #423 by adding a cleanup script that removes build artifacts and orphaned worktrees to recover disk space.

## Changes

- Created `scripts/cleanup.sh` with safe cleanup logic:
  - Removes `target/` directory (Rust build artifacts)
  - Removes `node_modules/` (npm packages)
  - Prompts for orphaned worktree cleanup (git worktree prune)
  - Shows disk space recovered for each operation
- Made script executable
- Added npm scripts to `package.json`:
  - `pnpm clean` - Run cleanup script
  - `pnpm clean:full` - Run cleanup + reinstall dependencies

## Benefits

- ✅ Easy recovery of disk space (2+ GB typically)
- ✅ Fresh start when debugging build issues
- ✅ Cleanup of orphaned worktrees from crashed agents
- ✅ Consistent cleanup process across team

## Testing

- ✓ Tested script execution successfully (shows proper messages)
- ✓ Verified pnpm scripts work correctly
- ✓ Linting and formatting checks pass

## Notes

- Pre-existing daemon integration test failures are unrelated to these changes
- Changes are isolated to script addition and npm scripts only
- Script uses safe patterns (prompts before worktree removal)

Closes #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)