### PR TITLE
Remove unused greet() Tauri command

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -32,11 +32,6 @@ struct GhIssue {
 }
 
 #[tauri::command]
-fn greet(name: &str) -> String {
-    format!("Hello, {name}! Welcome to Loom.")
-}
-
-#[tauri::command]
 #[allow(clippy::needless_pass_by_value)]
 fn get_cli_workspace(cli_workspace: tauri::State<CliWorkspace>) -> Option<String> {
     cli_workspace.0.lock().ok()?.clone()
@@ -1763,7 +1758,6 @@ fn main() {
             }
         })
         .invoke_handler(tauri::generate_handler![
-            greet,
             get_cli_workspace,
             check_system_dependencies,
             validate_git_repo,


### PR DESCRIPTION
## Summary
- Remove unused `greet()` Tauri command identified as dead code
- Delete function definition (4 lines)
- Remove from `invoke_handler` registration

## Context
The `greet()` function was identified during bloat assessment (Issue #177). This command is never called from the frontend and serves no purpose in the current codebase.

## Impact
- Cleaner command list
- Reduced maintenance burden  
- No functional changes (command was unused)

## Test plan
- [x] `pnpm check:ci` passes
- [x] `pnpm clippy` passes
- [x] `pnpm format` passes
- [x] `pnpm build` succeeds
- [x] No functional regressions (command was unused)

Closes #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)