### PR TITLE
Update documentation for command module refactoring (issue #421)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,17 @@ loom/
 ├── src/                          # TypeScript frontend
 │   ├── main.ts                   # Entry point, state init, events
 │   └── lib/                      # State, config, UI, theme
-├── src-tauri/                    # Rust backend (IPC commands)
+├── src-tauri/                    # Rust backend (Tauri commands)
+│   ├── src/
+│   │   ├── main.rs               # Entry point, command registration
+│   │   ├── commands/             # Domain-specific command modules
+│   │   │   ├── terminal.rs       # Terminal management
+│   │   │   ├── workspace.rs      # Workspace operations
+│   │   │   ├── config.rs         # Config/state I/O
+│   │   │   ├── github.rs         # GitHub integration
+│   │   │   └── ...               # 9 modules total, 51 commands
+│   │   └── menu.rs               # Menu building
+│   └── tauri.conf.json           # Tauri configuration
 ├── loom-daemon/                  # Rust daemon (terminal management)
 ├── .loom/                        # Workspace config (gitignored)
 │   ├── config.json               # Agent counter, terminal roles

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -86,13 +86,22 @@ graph TB
 ### Backend Layer
 
 #### Tauri Commands
-- **Location:** `src-tauri/src/main.rs`
-- **Responsibilities:**
-  - Validate git repositories
-  - Read role files and metadata
-  - Manage GitHub labels
-  - Write console logs
-  - Communicate with daemon
+- **Location:** `src-tauri/src/commands/` (domain-specific modules)
+- **Entry Point:** `src-tauri/src/main.rs` (command registration, minimal setup)
+- **Module Organization:**
+  - `terminal.rs` (12 commands) - Terminal lifecycle, I/O, session management
+  - `workspace.rs` (7 commands) - Git repo validation, Loom initialization, worktree helpers
+  - `config.rs` (5 commands) - Config/state file operations, role metadata
+  - `github.rs` (5 commands) - Label management, remote validation, issue operations
+  - `project.rs` (2 commands) - Local and GitHub project creation
+  - `daemon.rs` (2 commands) - Health checks and status queries
+  - `filesystem.rs` (3 commands) - File read/write, console logging
+  - `system.rs` (5 commands) - Dependency checks, environment variables, process checks
+  - `ui.rs` (5 commands) - Event emission, workspace triggers
+- **Benefits:**
+  - Clear domain boundaries reduce merge conflicts
+  - Easier to locate and maintain command implementations
+  - Modular structure scales well as command count grows
 
 #### Daemon Client
 - **Location:** `src-tauri/src/daemon_client.rs`
@@ -428,8 +437,24 @@ loom/
 │
 ├── src-tauri/                    # Backend (Rust)
 │   ├── src/
-│   │   ├── main.rs               # Tauri commands
-│   │   └── daemon_client.rs      # Daemon communication
+│   │   ├── main.rs               # App entry point, command registration
+│   │   ├── commands/             # Domain-specific command modules
+│   │   │   ├── mod.rs            # Module index with re-exports
+│   │   │   ├── terminal.rs       # Terminal management (12 commands)
+│   │   │   ├── workspace.rs      # Workspace operations (7 commands)
+│   │   │   ├── config.rs         # Config/state I/O (5 commands)
+│   │   │   ├── github.rs         # GitHub integration (5 commands)
+│   │   │   ├── project.rs        # Project creation (2 commands)
+│   │   │   ├── daemon.rs         # Daemon health (2 commands)
+│   │   │   ├── filesystem.rs     # File operations (3 commands)
+│   │   │   ├── system.rs         # System checks (5 commands)
+│   │   │   └── ui.rs             # UI events (5 commands)
+│   │   ├── menu.rs               # Menu building and event handling
+│   │   ├── daemon_client.rs      # Daemon communication
+│   │   ├── daemon_manager.rs     # Daemon lifecycle management
+│   │   ├── dependency_checker.rs # System dependency validation
+│   │   ├── logging.rs            # Logging macros
+│   │   └── mcp_watcher.rs        # MCP command file watcher
 │   ├── tauri.conf.json           # Tauri configuration
 │   └── Cargo.toml                # Rust dependencies
 │

--- a/docs/guides/architecture-patterns.md
+++ b/docs/guides/architecture-patterns.md
@@ -563,3 +563,173 @@ if (useWorktree && !worktreePath) {
 - Command execution ordering
 - Path handling with spaces and special characters
 - Terminal input simulation
+## 9. Command Module Organization
+
+**Files**: `src-tauri/src/commands/`, `src-tauri/src/main.rs`
+
+Tauri commands are organized into domain-specific modules rather than a monolithic main.rs file. This pattern improves maintainability, reduces merge conflicts, and makes the codebase easier to navigate.
+
+### Module Structure
+
+```
+src-tauri/src/
+├── main.rs                # Minimal entry point (command registration, app setup)
+├── commands/
+│   ├── mod.rs             # Module index with re-exports
+│   ├── terminal.rs        # Terminal management (12 commands)
+│   ├── workspace.rs       # Workspace operations (7 commands)
+│   ├── config.rs          # Config/state I/O (5 commands)
+│   ├── github.rs          # GitHub integration (5 commands)
+│   ├── project.rs         # Project creation (2 commands)
+│   ├── daemon.rs          # Daemon health checks (2 commands)
+│   ├── filesystem.rs      # File operations (3 commands)
+│   ├── system.rs          # System checks (5 commands)
+│   └── ui.rs              # UI events (5 commands)
+└── menu.rs                # Menu building and event handling
+```
+
+### Why Domain-Specific Modules?
+
+**Before Refactoring** (Issue #421):
+- 1,885 lines in main.rs
+- All 51 commands in one file
+- High risk of merge conflicts
+- Difficult to navigate and locate commands
+
+**After Refactoring**:
+- 290 lines in main.rs (85% reduction)
+- Commands grouped by domain
+- Clear boundaries reduce conflicts
+- Easy to find related functionality
+
+### Implementation Pattern
+
+**1. Command Module** (`src-tauri/src/commands/workspace.rs`):
+```rust
+use std::path::Path;
+
+#[tauri::command]
+pub fn validate_git_repo(path: &str) -> Result<bool, String> {
+    let workspace_path = Path::new(path);
+    
+    if !workspace_path.exists() {
+        return Err("Path does not exist".to_string());
+    }
+    
+    if !workspace_path.is_dir() {
+        return Err("Path is not a directory".to_string());
+    }
+    
+    let git_path = workspace_path.join(".git");
+    if !git_path.exists() {
+        return Err("Not a git repository".to_string());
+    }
+    
+    Ok(true)
+}
+
+// Helper functions (also pub for use by other modules if needed)
+pub fn find_git_root() -> Option<PathBuf> {
+    // Implementation...
+}
+```
+
+**2. Module Index** (`src-tauri/src/commands/mod.rs`):
+```rust
+pub mod config;
+pub mod daemon;
+pub mod filesystem;
+pub mod github;
+pub mod project;
+pub mod system;
+pub mod terminal;
+pub mod ui;
+pub mod workspace;
+
+// Re-export all command functions
+pub use config::*;
+pub use daemon::*;
+pub use filesystem::*;
+pub use github::*;
+pub use project::*;
+pub use system::*;
+pub use terminal::*;
+pub use ui::*;
+pub use workspace::*;
+```
+
+**3. Main Entry Point** (`src-tauri/src/main.rs`):
+```rust
+mod commands;
+mod menu;
+
+#[allow(clippy::wildcard_imports)]
+use commands::*;
+
+fn main() {
+    tauri::Builder::default()
+        .invoke_handler(tauri::generate_handler![
+            // Legacy commands
+            get_cli_workspace,
+            // System commands
+            check_system_dependencies,
+            get_env_var,
+            // ... all 51 commands registered here ...
+        ])
+        .run(tauri::generate_context!())
+}
+```
+
+### Domain Boundaries
+
+| Module | Responsibility | Key Commands |
+|--------|---------------|--------------|
+| `terminal.rs` | Terminal lifecycle and I/O | `create_terminal`, `send_terminal_input`, `get_terminal_output` |
+| `workspace.rs` | Git repo validation and setup | `validate_git_repo`, `initialize_loom_workspace` |
+| `config.rs` | Configuration and state persistence | `read_config`, `write_state`, `read_role_file` |
+| `github.rs` | GitHub API integration | `check_label_exists`, `reset_github_labels` |
+| `project.rs` | Project creation workflows | `create_local_project`, `create_github_repository` |
+| `daemon.rs` | Daemon health monitoring | `check_daemon_health`, `get_daemon_status` |
+| `filesystem.rs` | File I/O operations | `read_text_file`, `write_file`, `append_to_console_log` |
+| `system.rs` | System dependency checks | `check_system_dependencies`, `check_claude_code` |
+| `ui.rs` | UI events and triggers | `emit_event`, `trigger_start`, `trigger_factory_reset` |
+
+### Guidelines for Adding Commands
+
+1. **Choose the Right Module**: Place commands in the module that matches their primary responsibility
+2. **Keep Functions Public**: Command functions and shared helpers must be `pub`
+3. **Re-export in mod.rs**: Add `pub use module_name::*;` for new modules
+4. **Register in main.rs**: Add command to `generate_handler![]` macro
+5. **Maintain Domain Purity**: Avoid cross-domain dependencies where possible
+
+### Benefits
+
+1. **Reduced Merge Conflicts**: Smaller files mean less chance of simultaneous edits
+2. **Improved Navigation**: Jump to domain module instead of searching large file
+3. **Clear Ownership**: Each module has a focused responsibility
+4. **Scalability**: Easy to add new domains as command count grows
+5. **Better Testing**: Can test domain modules independently
+6. **Code Review**: Reviewers can focus on specific domains
+
+### Example: Adding a New Command
+
+```rust
+// 1. Add to appropriate module (commands/workspace.rs)
+#[tauri::command]
+pub fn check_workspace_clean(path: &str) -> Result<bool, String> {
+    // Implementation
+    Ok(true)
+}
+
+// 2. Re-export from commands/mod.rs (already done via `pub use workspace::*;`)
+
+// 3. Register in main.rs
+.invoke_handler(tauri::generate_handler![
+    // ... existing commands ...
+    check_workspace_clean,  // Add here
+])
+```
+
+**See Also**:
+- [docs/guides/common-tasks.md](common-tasks.md#adding-a-new-tauri-command) - Step-by-step guide for adding commands
+- [docs/architecture/system-overview.md](../architecture/system-overview.md) - Full system architecture

--- a/docs/guides/common-tasks.md
+++ b/docs/guides/common-tasks.md
@@ -36,27 +36,74 @@
 
 ## Adding a New Tauri Command
 
-1. **Add Rust command** in `src-tauri/src/main.rs`:
+Tauri commands are organized into domain-specific modules in `src-tauri/src/commands/`.
+
+### Choose the Right Module
+
+| Module | Purpose | Example Commands |
+|--------|---------|------------------|
+| `terminal.rs` | Terminal management | `create_terminal`, `send_terminal_input` |
+| `workspace.rs` | Workspace operations | `validate_git_repo`, `initialize_loom_workspace` |
+| `config.rs` | Config/state file I/O | `read_config`, `write_state` |
+| `github.rs` | GitHub integration | `check_label_exists`, `reset_github_labels` |
+| `project.rs` | Project creation | `create_local_project` |
+| `daemon.rs` | Daemon health checks | `check_daemon_health` |
+| `filesystem.rs` | File I/O operations | `read_text_file`, `write_file` |
+| `system.rs` | System dependency checks | `check_system_dependencies` |
+| `ui.rs` | UI events and triggers | `emit_event`, `trigger_start` |
+
+### Steps
+
+1. **Add command to appropriate module** (e.g., `src-tauri/src/commands/workspace.rs`):
    ```rust
    #[tauri::command]
-   fn my_command(param: String) -> Result<ReturnType, String> {
+   pub fn my_command(param: String) -> Result<ReturnType, String> {
        // Implementation
        Ok(result)
    }
    ```
+   Note: Command functions must be `pub` to be re-exported.
 
-2. **Register command** in `main()`:
+2. **Re-export from `commands/mod.rs`**:
    ```rust
-   tauri::Builder::default()
-       .invoke_handler(tauri::generate_handler![my_command])
+   // In src-tauri/src/commands/mod.rs
+   pub mod workspace;
+
+   // Re-export individual commands
+   pub use workspace::my_command;
+   ```
+   Or use wildcard re-export if the module has many related commands:
+   ```rust
+   pub use workspace::*;
    ```
 
-3. **Call from TypeScript** in `src/main.ts`:
+3. **Register in `src-tauri/src/main.rs` invoke_handler**:
+   ```rust
+   .invoke_handler(tauri::generate_handler![
+       // Legacy commands
+       get_cli_workspace,
+       // System commands
+       check_system_dependencies,
+       // ... existing commands ...
+       my_command,  // Add your command here
+   ])
+   ```
+
+4. **Call from TypeScript**:
    ```typescript
    import { invoke } from '@tauri-apps/api/tauri';
 
    const result = await invoke<ReturnType>('my_command', { param: value });
    ```
 
-4. **Add required APIs** to `src-tauri/tauri.conf.json` allowlist if needed
-5. **Update Cargo.toml** if new Tauri features required
+5. **Add required APIs** to `src-tauri/tauri.conf.json` allowlist if needed
+6. **Update Cargo.toml** if new Tauri features required
+
+### Creating a New Command Module
+
+If you need a new domain area not covered by existing modules:
+
+1. Create `src-tauri/src/commands/my_module.rs`
+2. Add `pub mod my_module;` to `src-tauri/src/commands/mod.rs`
+3. Re-export commands: `pub use my_module::*;`
+4. Import in `main.rs`: Commands are available via the wildcard import `use commands::*;`


### PR DESCRIPTION
## Summary

Follow-up to #427: Updates documentation to reflect the new domain-based command module organization.

## Changes

This PR updates all developer-facing documentation after the main.rs refactoring:

### 1. **docs/guides/common-tasks.md**
- Added module selection table showing all 9 command domains
- Updated "Adding a New Tauri Command" workflow (now 6 steps)
- Added guidance for creating new command modules
- Emphasized `pub` visibility requirement for command functions

### 2. **docs/architecture/system-overview.md**
- Updated "Tauri Commands" section with detailed module organization
- Added benefits list (reduced conflicts, easier maintenance, scalability)
- Expanded project structure tree showing full `commands/` hierarchy
- Listed all 9 modules with command counts

### 3. **docs/guides/architecture-patterns.md**
- Added **Pattern #9: Command Module Organization** (complete new section)
- Included before/after metrics (1,885 → 290 lines in main.rs)
- Provided implementation examples for all three layers
- Added domain boundaries reference table
- Included guidelines for adding new commands

### 4. **CLAUDE.md**
- Updated project structure tree to show `commands/` directory
- Added detail about 9 modules and 51 total commands
- Maintains high-level overview with pointers to detailed docs

## Why This PR

- Ensures documentation matches the refactored codebase
- Provides clear guidance for adding new commands
- Reduces friction for new contributors
- Documents architectural pattern for future reference

## Files Changed

- 4 documentation files
- 270 insertions, 18 deletions
- Zero code changes (docs only)

## Related

- Implements documentation for #421
- Follow-up to #427 (code refactoring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)