### PR TITLE
Make worktree script non-interactive for AI agents

### DIFF
--- a/defaults/AGENTS.md
+++ b/defaults/AGENTS.md
@@ -39,7 +39,19 @@ git push -u origin feature/issue-42
 cd ../..
 ```
 
-Worktrees provide isolated directories for parallel work without conflicts. The script prevents nested worktrees and ensures sandbox-safe paths.
+### Resuming Abandoned Work
+
+If a previous agent abandoned work on an issue, you can resume seamlessly:
+
+```bash
+# The branch feature/issue-42 exists, but worktree was removed
+./.loom/scripts/worktree.sh 42
+# → Reuses existing branch (no prompt)
+# → Creates fresh worktree
+# → Continue where previous agent left off
+```
+
+The script is **non-interactive** and automatically reuses existing branches, making it safe for AI agents to resume abandoned work without user intervention.
 
 ## Daemon & Configuration Notes
 Agent role prompts live under `.loom/roles/`; keep Markdown and any sibling JSON metadata in sync. Workspace overrides persist in `~/.loom/`, so mention reset steps (`Help → Daemon Status → Yes`) when altering stateful behavior. Document new environment variables or defaults under `defaults/` before requesting review.


### PR DESCRIPTION
## Summary

Removes the blocking interactive prompt from the worktree helper script, allowing AI agents to seamlessly resume abandoned work.

## Problem

When an agent abandons work on an issue, the branch `feature/issue-42` exists but the worktree is gone. When a new agent tries to resume:

```bash
./.loom/scripts/worktree.sh 42
```

The script would prompt: `Use existing branch? (y/n)` and **block waiting for input**.

AI agents can't respond to interactive prompts, so this would hang indefinitely.

## Solution

Made the script **non-interactive** by automatically reusing existing branches without prompting.

### Changes

- Removed `read -p` prompt that blocked agents
- Added clear warning message when reusing branches
- Updated help text with "Resuming Abandoned Work" section
- Updated AGENTS.md template with resume workflow

### Behavior Matrix

| Scenario | Old Behavior | New Behavior |
|----------|-------------|--------------|
| Fresh worktree | ✅ Create branch + worktree | ✅ Create branch + worktree |
| Worktree exists | ✅ Show cd instructions | ✅ Show cd instructions |
| Branch exists, no worktree | ❌ **Prompt (blocks agents)** | ✅ **Auto-reuse (no prompt)** |

## Testing

Verified all three scenarios:

```bash
✅ Test 1: Fresh worktree creation
✅ Test 2: Worktree already exists  
✅ Test 3: Resume with existing branch (no prompt)
```

## Use Case

```bash
# Builder-1 starts issue #42 but gets stuck
./.loom/scripts/worktree.sh 42
cd .loom/worktrees/issue-42
# ... makes some commits, then gives up ...

# Daemon destroys terminal-1 (auto-removes worktree)
# Branch feature/issue-42 still exists with partial work

# Builder-2 resumes seamlessly (no manual intervention)
./.loom/scripts/worktree.sh 42  # ✅ Auto-reuses branch, creates fresh worktree
cd .loom/worktrees/issue-42
# ... continues where Builder-1 left off ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)