### PR TITLE
Fix install-loom.sh to launch Claude Code from Loom repo

### DIFF
--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -65,13 +65,12 @@ export TARGET_PATH
 info "Launching Claude Code with /install-loom command..."
 echo ""
 
-# Launch Claude Code in target repository with slash command
-cd "$TARGET_PATH"
-
 # Check if claude CLI is available
 if ! command -v claude &> /dev/null; then
   error "Claude Code CLI (claude) is not installed or not in PATH"
 fi
 
-# Launch Claude Code with the install-loom slash command
+# Launch Claude Code from Loom repo (where /install-loom command exists)
+# Target path is passed via TARGET_PATH environment variable
+cd "$LOOM_ROOT"
 exec claude code "/install-loom"


### PR DESCRIPTION
## Problem

The `install-loom.sh` script was launching Claude Code from the **target repository**, but the `/install-loom` slash command only exists in the **Loom repository's** `.claude/commands/` directory.

This created a chicken-and-egg problem:
1. Script sets environment variables (LOOM_VERSION, LOOM_COMMIT, LOOM_ROOT, TARGET_PATH)
2. Script changes to target repo: `cd "$TARGET_PATH"`
3. Script launches Claude Code: `claude code "/install-loom"`
4. Claude Code looks for `.claude/commands/install-loom.md` in the current directory (target repo)
5. **File doesn't exist** - command not available!

## Solution

Launch Claude Code from the **Loom repository** where the `/install-loom` command exists:

```bash
# Launch Claude Code from Loom repo (where /install-loom command exists)
# Target path is passed via TARGET_PATH environment variable
cd "$LOOM_ROOT"
exec claude code "/install-loom"
```

The target path is already passed via the `TARGET_PATH` environment variable, so the `/install-loom` command can still access it.

## Changes

- scripts/install-loom.sh:69-76
  - Changed `cd "$TARGET_PATH"` to `cd "$LOOM_ROOT"` 
  - Moved directory change to after CLI validation
  - Added clarifying comment about why we stay in Loom repo

## Testing

After this fix:
```bash
./scripts/install-loom.sh ../stylecheck
# ✅ Launches Claude Code with /install-loom command available
# ✅ Command orchestrates full installation workflow
# ✅ Creates issue, worktree, installs files, syncs labels, creates PR
```

Closes #449