### PR TITLE
Allow Curator to process architect/hermit proposals

### DIFF
--- a/defaults/.claude/agents/curator.md
+++ b/defaults/.claude/agents/curator.md
@@ -23,16 +23,19 @@ You improve issues by:
 
 ## Label Workflow
 
-The workflow with two-gate approval:
+The workflow with parallel curation and user review:
 
-- **Architect creates**: Issues with `loom:architect-suggestion` label (awaiting user approval)
-- **User approves Architect**: Adds `loom:issue` label to architect suggestions (or closes to reject)
-- **You process**: Find issues needing enhancement, improve them, then add `loom:curated`
-- **User approves Curator**: Adds `loom:issue` label to curated issues (human approval required)
+- **Architect creates**: Issues with `loom:architect` label (proposal awaiting user approval)
+- **Hermit creates**: Issues with `loom:hermit` label (simplification awaiting user approval)
+- **You process**: Can enhance ANY issue including architect/hermit proposals, then add `loom:curated`
+- **User reviews**: Sees BOTH the proposal AND your implementation plan before approving
+- **User approves**: Removes `loom:architect`/`loom:hermit`, keeps `loom:curated`, or adds `loom:issue` for ready work
 - **Worker implements**: Picks up `loom:issue` issues and changes to `loom:in-progress`
 - **Worker completes**: Creates PR and closes issue (or marks `loom:blocked` if stuck)
 
 **CRITICAL**: You mark issues as `loom:curated` after enhancement. You do NOT add `loom:issue` - only humans can approve work for implementation.
+
+**NEW**: You CAN curate issues with `loom:architect` or `loom:hermit` labels. This allows users to review both the proposal and implementation plan together, enabling faster decision-making.
 
 **IMPORTANT: Ignore External Issues**
 
@@ -45,10 +48,10 @@ The workflow with two-gate approval:
 Use this command to find issues that need curation:
 
 ```bash
-# Find issues without suggestion labels, curated, issue, or in-progress
-# (These need curator enhancement)
+# Find issues needing curator enhancement (includes architect/hermit suggestions)
+# Excludes only: curated, issue, or in-progress
 gh issue list --state=open --json number,title,labels \
-  --jq '.[] | select(([.labels[].name] | inside(["loom:architect-suggestion", "loom:critic-suggestion", "loom:curated", "loom:issue", "loom:in-progress"]) | not)) | "#\(.number) \(.title)"'
+  --jq '.[] | select(([.labels[].name] | inside(["loom:curated", "loom:issue", "loom:in-progress"]) | not)) | "#\(.number) \(.title)"'
 ```
 
 Or simpler (may include some false positives):

--- a/defaults/roles/curator.md
+++ b/defaults/roles/curator.md
@@ -16,16 +16,19 @@ You improve issues by:
 
 ## Label Workflow
 
-The workflow with two-gate approval:
+The workflow with parallel curation and user review:
 
-- **Architect creates**: Issues with `loom:architect-suggestion` label (awaiting user approval)
-- **User approves Architect**: Adds `loom:issue` label to architect suggestions (or closes to reject)
-- **You process**: Find issues needing enhancement, improve them, then add `loom:curated`
-- **User approves Curator**: Adds `loom:issue` label to curated issues (human approval required)
+- **Architect creates**: Issues with `loom:architect` label (proposal awaiting user approval)
+- **Hermit creates**: Issues with `loom:hermit` label (simplification awaiting user approval)
+- **You process**: Can enhance ANY issue including architect/hermit proposals, then add `loom:curated`
+- **User reviews**: Sees BOTH the proposal AND your implementation plan before approving
+- **User approves**: Removes `loom:architect`/`loom:hermit`, keeps `loom:curated`, or adds `loom:issue` for ready work
 - **Worker implements**: Picks up `loom:issue` issues and changes to `loom:in-progress`
 - **Worker completes**: Creates PR and closes issue (or marks `loom:blocked` if stuck)
 
 **CRITICAL**: You mark issues as `loom:curated` after enhancement. You do NOT add `loom:issue` - only humans can approve work for implementation.
+
+**NEW**: You CAN curate issues with `loom:architect` or `loom:hermit` labels. This allows users to review both the proposal and implementation plan together, enabling faster decision-making.
 
 **IMPORTANT: Ignore External Issues**
 
@@ -38,10 +41,10 @@ The workflow with two-gate approval:
 Use this command to find issues that need curation:
 
 ```bash
-# Find issues without suggestion labels, curated, issue, or in-progress
-# (These need curator enhancement)
+# Find issues needing curator enhancement (includes architect/hermit suggestions)
+# Excludes only: curated, issue, or in-progress
 gh issue list --state=open --json number,title,labels \
-  --jq '.[] | select(([.labels[].name] | inside(["loom:architect-suggestion", "loom:critic-suggestion", "loom:curated", "loom:issue", "loom:in-progress"]) | not)) | "#\(.number) \(.title)"'
+  --jq '.[] | select(([.labels[].name] | inside(["loom:curated", "loom:issue", "loom:in-progress"]) | not)) | "#\(.number) \(.title)"'
 ```
 
 Or simpler (may include some false positives):


### PR DESCRIPTION
## Summary

This PR enables the Curator to work on issues labeled `loom:architect` or `loom:hermit`, allowing parallel curation while users review proposals. This speeds up the workflow by letting users see both the proposal and implementation plan together before approving.

## Changes

**Files Modified:**
- `defaults/roles/curator.md` - Updated jq filter and label workflow documentation
- `defaults/.claude/agents/curator.md` - Same updates for agent version

**Specific Changes:**
1. **Updated jq filter** (lines 41-44):
   - **Before**: Excluded `loom:architect-suggestion` and `loom:critic-suggestion`
   - **After**: Excludes only `loom:curated`, `loom:issue`, and `loom:in-progress`
   - Allows Curator to find and enhance architect/hermit proposals

2. **Updated Label Workflow section** (lines 17-31):
   - Changed from sequential approval to parallel review model
   - Updated old label names (`loom:architect-suggestion` → `loom:architect`, `loom:critic-suggestion` → `loom:hermit`)
   - Clarified that Curator can process ANY issue including proposals
   - Added explanation of parallel review benefits

## Benefits

- **Faster decision-making**: Users review proposal + implementation plan together
- **No unnecessary delays**: No waiting for sequential approval gates
- **Better context**: Curator adds implementation details while proposal is fresh
- **Streamlined workflow**: Reduces total time from proposal to implementation

## Test Plan

- [x] Updated jq filter allows issues with `loom:architect` or `loom:hermit` labels
- [x] Curator documentation clearly explains the new parallel workflow
- [x] Both role file and agent file updated consistently
- [x] Linting and formatting checks pass (`pnpm lint && pnpm format:rust`)

## Related

Closes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)