### PR TITLE
Fix GitHub label sync to create all required labels and remove defaults

### DIFF
--- a/scripts/install/sync-labels.sh
+++ b/scripts/install/sync-labels.sh
@@ -41,16 +41,35 @@ fi
 
 info "Syncing GitHub labels from $LABELS_FILE..."
 
-# Sync labels using gh CLI
+# Remove default GitHub labels that clutter issue tracking
+DEFAULT_LABELS=(
+  "bug"
+  "documentation"
+  "duplicate"
+  "enhancement"
+  "good first issue"
+  "help wanted"
+  "invalid"
+  "question"
+  "wontfix"
+)
+
+info "Removing default GitHub labels..."
+for label in "${DEFAULT_LABELS[@]}"; do
+  if gh label delete "$label" --yes 2>/dev/null; then
+    info "Deleted default label: $label"
+  fi
+done
+
+# Sync Loom workflow labels
 # This will:
 # - Create missing labels
 # - Update existing labels with new descriptions/colors
-# - NOT delete labels that aren't in the file (safe for existing repos)
-if gh label sync --file "$LABELS_FILE" --dry-run; then
-  info "Label sync dry-run successful, applying changes..."
-  gh label sync --file "$LABELS_FILE"
+info "Syncing Loom workflow labels..."
+if gh label sync --file "$LABELS_FILE" --force; then
   success "GitHub labels synced"
 else
-  warning "Label sync failed, continuing anyway"
-  warning "You may need to sync labels manually: gh label sync --file $LABELS_FILE"
+  error "Label sync failed"
+  error "Please sync labels manually: gh label sync --file $LABELS_FILE --force"
+  exit 1
 fi


### PR DESCRIPTION
## Summary

Fixes #453 by improving the GitHub label sync process during Loom installation.

## Problems Solved

### 1. Missing labels after installation
The `loom:issue` label (and potentially other labels) were not being created during installation because:
- The script used `--dry-run` which could cause compatibility issues
- Failures were treated as warnings, allowing installation to continue silently
- No explicit `--force` flag to ensure labels are created

### 2. Default GitHub labels cluttering issue tracker
Standard GitHub labels (bug, enhancement, etc.) remained in installed repositories, creating confusion with Loom's workflow labels.

## Changes

### scripts/install/sync-labels.sh

**Before syncing Loom labels:**
- Added `DEFAULT_LABELS` array with 9 standard GitHub default labels
- Loop to delete each default label using `gh label delete --yes`
- Errors suppressed (`2>/dev/null`) since labels may not exist

**Label sync improvements:**
- Removed `--dry-run` check (potential compatibility issue)
- Added `--force` flag to ensure labels are created/updated
- Changed failure handling from `warning` to `error` with `exit 1`
- Installation now fails visibly if label sync doesn't work

## Testing

- ✅ Script syntax validated with `bash -n`
- ✅ Biome linting passes
- ✅ Rust formatting passes
- ⏳ Manual testing on real repository (recommended for reviewer)

## Expected Behavior

After this fix, when Loom is installed in a repository:

1. **Default labels removed**: All 9 standard GitHub labels deleted
2. **Loom labels created**: All 9 Loom workflow labels created reliably
3. **Visible failures**: Installation fails with clear error if sync doesn't work

## Labels Definition

All required labels are defined in `defaults/.github/labels.yml`:
- `loom:issue` - Approved for work by human (ready for Builder to claim)
- `loom:in-progress` - Issue: Worker implementing | PR: Reviewer reviewing
- `loom:review-requested` - PR ready for Judge to review
- `loom:pr` - PR approved by Judge, ready for human to merge
- `loom:architect` - Architect proposal awaiting user approval
- `loom:hermit` - Hermit removal/simplification proposal awaiting approval
- `loom:curated` - Enhanced by Curator, awaiting human approval
- `loom:blocked` - Implementation blocked, needs help or clarification
- `loom:urgent` - Critical/blocking issue requiring immediate attention

## Review Notes

This is a bash script change only, no Rust or TypeScript code affected.

Reviewer should test by:
1. Creating a test repository with default GitHub labels
2. Running Loom installation on it
3. Verifying all 9 Loom labels exist
4. Verifying default labels are removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)