### PR TITLE
Fix app:dev command with tmux-based development mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "daemon:preview": "cargo run --package loom-daemon --release",
     "daemon:build": "cargo build --package loom-daemon --release && rm -f target/release/loom-daemon-aarch64-apple-darwin && cp target/release/loom-daemon target/release/loom-daemon-aarch64-apple-darwin",
     "daemon:test": "cargo test --package loom-daemon",
-    "app:dev": "./scripts/setup-mcp.sh && pnpm daemon:dev & sleep 2 && pnpm tauri:dev",
+    "app:dev": "./scripts/dev-app.sh",
     "app:preview": "pnpm build && pnpm tauri build --debug --bundles app && RUST_LOG=info pnpm daemon:preview & sleep 5 && ./target/debug/bundle/macos/Loom.app/Contents/MacOS/Loom --workspace \"$(pwd)\"",
     "app:build": "pnpm daemon:build && pnpm tauri:build",
     "test:factory-reset": "pnpm build && pnpm tauri build --debug --bundles app && RUST_LOG=info pnpm daemon:preview & sleep 5 && ./target/debug/bundle/macos/Loom.app/Contents/MacOS/Loom --workspace \"$(pwd)\"",

--- a/scripts/dev-app-instructions.sh
+++ b/scripts/dev-app-instructions.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Instructions for app:dev - explains why it needs to be run in a real terminal
+
+cat << 'EOF'
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Loom Development Mode - Manual Setup Required
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+ℹ️  The `pnpm app:dev` command requires a real terminal (TTY) to create
+   a tmux split-screen session for development.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+🎯 RECOMMENDED APPROACH - Two Separate Terminals:
+
+   Terminal 1 (Daemon Monitoring):
+   $ cd /Users/rwalters/GitHub/loom
+   $ pnpm daemon:dev
+
+   Terminal 2 (Tauri App):
+   $ cd /Users/rwalters/GitHub/loom
+   $ pnpm tauri dev
+
+   This gives you:
+   ✅ Hot reload for frontend changes
+   ✅ Interactive daemon monitoring
+   ✅ Easy to automate from Claude Code
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+⚡ ALTERNATIVE - Use Preview Mode:
+
+   $ pnpm app:preview
+
+   This builds once and runs without hot reload.
+   Recommended when agents work on Loom's codebase (prevents restart loops).
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+🤖 FOR CLAUDE CODE AUTOMATION:
+
+   Use the two-terminal approach with Loom's MCP terminal tools:
+
+   1. Start daemon in terminal-1:
+      mcp__loom-terminals__send_terminal_input \
+        --terminal-id=terminal-1 \
+        --input="cd ~/GitHub/loom && pnpm daemon:dev\n"
+
+   2. Start Tauri in terminal-2 (after 5 seconds):
+      mcp__loom-terminals__send_terminal_input \
+        --terminal-id=terminal-2 \
+        --input="cd ~/GitHub/loom && pnpm tauri dev\n"
+
+   3. Monitor both terminals:
+      mcp__loom-terminals__get_terminal_output --terminal-id=terminal-1
+      mcp__loom-terminals__get_terminal_output --terminal-2
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+EOF

--- a/scripts/dev-app.sh
+++ b/scripts/dev-app.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Development mode using tmux split for daemon + Tauri
+# Creates a tmux session with daemon monitoring in top pane, Tauri in bottom pane
+
+set -e
+
+SESSION_NAME="loom-dev"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+BOLD='\033[1m'
+
+# Check if we're in an interactive terminal with a TTY
+if [ ! -t 0 ] && [ ! -t 1 ]; then
+    # Non-interactive - show instructions instead
+    ./scripts/dev-app-instructions.sh
+    exit 0
+fi
+
+# Check if tmux is available
+if ! command -v tmux &> /dev/null; then
+    echo -e "${RED}Error: tmux is not installed${NC}"
+    echo "Install with: brew install tmux"
+    echo ""
+    echo -e "${YELLOW}Alternative: Run in two separate terminals:${NC}"
+    echo "  Terminal 1: pnpm daemon:dev"
+    echo "  Terminal 2: pnpm tauri dev"
+    exit 1
+fi
+
+# Check if session already exists
+if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+    echo -e "${YELLOW}⚠ Development session already running${NC}"
+    echo -e "${CYAN}Attaching to existing session...${NC}"
+    tmux attach-session -t "$SESSION_NAME"
+    exit 0
+fi
+
+echo -e "${BOLD}${CYAN}╔════════════════════════════════════════╗${NC}"
+echo -e "${BOLD}${CYAN}║   Loom Development Mode (tmux split)  ║${NC}"
+echo -e "${BOLD}${CYAN}╚════════════════════════════════════════╝${NC}"
+echo ""
+echo -e "${BLUE}Creating tmux session: $SESSION_NAME${NC}"
+echo -e "${BLUE}  Top pane: Daemon monitoring${NC}"
+echo -e "${BLUE}  Bottom pane: Tauri dev server${NC}"
+echo ""
+echo -e "${CYAN}Keyboard shortcuts:${NC}"
+echo -e "  Ctrl+B then ↑/↓  - Switch between panes"
+echo -e "  Ctrl+B then [    - Scroll mode (q to exit)"
+echo -e "  Ctrl+B then d    - Detach (leave running)"
+echo -e "  Ctrl+C twice     - Stop both processes"
+echo ""
+echo -e "${GREEN}Starting in 2 seconds...${NC}"
+sleep 2
+
+# Setup MCP first
+./scripts/setup-mcp.sh > /dev/null
+
+# Get absolute path
+WORKSPACE="$(pwd)"
+
+# Create new session with daemon in first window
+# Use -d to start detached
+tmux new-session -d -s "$SESSION_NAME" -n "loom"
+
+# Send daemon command to first pane
+tmux send-keys -t "$SESSION_NAME:0.0" "cd '$WORKSPACE' && pnpm daemon:dev" C-m
+
+# Split horizontally and create bottom pane
+tmux split-window -v -t "$SESSION_NAME:0"
+
+# Send Tauri command to second pane after a delay
+tmux send-keys -t "$SESSION_NAME:0.1" "cd '$WORKSPACE' && sleep 5 && pnpm tauri dev" C-m
+
+# Adjust pane sizes (60% top daemon, 40% bottom Tauri)
+tmux resize-pane -t "$SESSION_NAME:0.0" -y 60%
+
+# Select the top pane (daemon) by default for monitoring
+tmux select-pane -t "$SESSION_NAME:0.0"
+
+# Check if we're in an interactive terminal
+if [ -t 1 ]; then
+    # Interactive mode - attach to the session
+    echo -e "${GREEN}Attaching to session...${NC}"
+    tmux attach-session -t "$SESSION_NAME"
+else
+    # Non-interactive mode (e.g., run from Claude Code) - leave detached
+    echo -e "${GREEN}✓ Development session started in background${NC}"
+    echo -e "${CYAN}Session name: $SESSION_NAME${NC}"
+    echo ""
+    echo -e "${YELLOW}To attach to the session, run:${NC}"
+    echo -e "  ${BOLD}tmux attach-session -t $SESSION_NAME${NC}"
+    echo ""
+    echo -e "${YELLOW}To view session status:${NC}"
+    echo -e "  ${BOLD}tmux list-sessions${NC}"
+    echo ""
+    echo -e "${YELLOW}To stop the session:${NC}"
+    echo -e "  ${BOLD}tmux kill-session -t $SESSION_NAME${NC}"
+    echo -e "  ${BOLD}# or use: pnpm app:quit${NC}"
+fi


### PR DESCRIPTION
## Summary

Fixes the broken `pnpm app:dev` command that was causing "command failed with exit code 1" errors and unresponsive UI.

## Problem

The old `app:dev` command tried to run an interactive daemon script (`dev-daemon.sh`) in the background using `&`. The daemon script uses:
- `clear` (screen clearing)
- Colored output
- `tail -f` for log monitoring

Running these interactive features in the background caused conflicts and made the UI unresponsive.

## Solution

Created a tmux-based development mode that intelligently adapts to the execution context:

**Interactive mode** (real terminal):
- Creates a split tmux session (`loom-dev`)
- Top pane: Daemon monitoring with colored output
- Bottom pane: Tauri dev server with hot reload
- User can switch between panes, scroll, detach/reattach

**Non-interactive mode** (Claude Code, automation):
- Shows clear instructions explaining why tmux needs a TTY
- Provides alternative approaches:
  - Two-terminal workflow (recommended)
  - Preview mode (`pnpm app:preview`)
  - MCP automation examples for Claude Code

## Changes

- **scripts/dev-app.sh**: New tmux-based development script
- **scripts/dev-app-instructions.sh**: Clear documentation for non-interactive contexts
- **package.json**: Updated `app:dev` script to use `./scripts/dev-app.sh`

## Benefits

✅ Works correctly in both human and AI agent workflows  
✅ Provides clear documentation when automation isn't possible  
✅ Enables hot reload development with proper daemon monitoring  
✅ No more unresponsive UI from backgrounded interactive scripts

## Testing

```bash
# Interactive mode (from real terminal)
pnpm app:dev

# Non-interactive mode (from Claude Code)  
pnpm app:dev
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)