### PR TITLE
Add /tmp access permissions to Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -54,7 +54,9 @@
       "Bash(convert:*)",
       "Bash(magick:*)",
       "Bash(iconutil:*)",
-      "WebSearch"
+      "WebSearch",
+      "Read(/tmp/**)",
+      "Write(/tmp/**)"
     ]
   }
 }

--- a/defaults/.claude/settings.json
+++ b/defaults/.claude/settings.json
@@ -54,7 +54,9 @@
       "Bash(convert:*)",
       "Bash(magick:*)",
       "Bash(iconutil:*)",
-      "WebSearch"
+      "WebSearch",
+      "Read(/tmp/**)",
+      "Write(/tmp/**)"
     ]
   }
 }


### PR DESCRIPTION
## Summary

Add Read and Write permissions for `/tmp/**` to Claude Code settings to enable agents to work with temporary files and logs without prompts.

## Changes

**Permissions Added**:
- `Read(/tmp/**)` - Read terminal output logs
- `Write(/tmp/**)` - Create temporary test files

**Files Updated**:
- `.claude/settings.json` - Loom's own settings
- `defaults/.claude/settings.json` - Installation template

## Benefits

1. **Terminal Logs**: Agents can read Loom's terminal output logs at `/tmp/loom-terminal-{id}.out` without permission prompts
2. **Debugging**: Access to temporary log files for diagnostics
3. **Testing**: Create temporary test files during development
4. **Consistency**: Same permissions apply to all Loom installations via the defaults template

## Test Plan

- [x] Verify permissions syntax is correct
- [x] Confirm both files updated (Loom settings + installation template)
- [ ] Test that agents can read `/tmp/loom-terminal-*.out` without prompts
- [ ] Test that agents can write temporary files to `/tmp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)