### PR TITLE
Add priority system for Healer role to fix merge conflicts on approved PRs

### DIFF
--- a/.loom/roles/healer.md
+++ b/.loom/roles/healer.md
@@ -19,21 +19,38 @@ You help PRs move toward merge by:
 
 ## Finding Work
 
-**Find PRs with changes requested (amber badges) that aren't already claimed:**
+Healers prioritize work in the following order:
+
+### Priority 1: Approved PRs with Merge Conflicts (URGENT)
+
+**Find approved PRs with merge conflicts that aren't already claimed:**
 ```bash
-# Filter out PRs with loom:in-progress to avoid duplicate work
+gh pr list --label="loom:approved" --state=open --search "is:open conflicts:>0" --json number,title,labels \
+  | jq -r '.[] | select(.labels | all(.name != "loom:in-progress")) | "#\(.number): \(.title)"'
+```
+
+**Why highest priority?**
+- These PRs are **blocking** - already approved but can't merge
+- Conflicts get harder to resolve over time
+- Delays merge of completed work
+
+### Priority 2: PRs with Changes Requested (NORMAL)
+
+**Find PRs with review feedback that aren't already claimed:**
+```bash
 gh pr list --label="loom:changes-requested" --state=open --json number,title,labels \
   | jq -r '.[] | select(.labels | all(.name != "loom:in-progress")) | "#\(.number): \(.title)"'
 ```
 
-**Find PRs with merge conflicts:**
+### Other PRs Needing Attention
+
+**Find PRs with merge conflicts (any label):**
 ```bash
 gh pr list --state=open --search "is:open conflicts:>0"
 ```
 
-**Find all PRs that might need attention:**
+**Find all open PRs:**
 ```bash
-# List all open PRs, then check each one
 gh pr list --state=open
 ```
 

--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -163,8 +163,14 @@ gh pr edit 50 --remove-label "loom:review-requested" --add-label "loom:changes-r
 
 ### Fixer Workflow
 
+**Healers prioritize work in the following order:**
+
 ```bash
-# Find PRs needing fixes (exclude already claimed)
+# Priority 1 (URGENT): Approved PRs with merge conflicts - BLOCKING
+gh pr list --label="loom:approved" --state=open --search "is:open conflicts:>0" --json number,title,labels \
+  | jq -r '.[] | select(.labels | all(.name != "loom:in-progress")) | "#\(.number): \(.title)"'
+
+# Priority 2 (NORMAL): PRs with review feedback
 gh pr list --label="loom:changes-requested" --state=open --json number,title,labels \
   | jq -r '.[] | select(.labels | all(.name != "loom:in-progress")) | "#\(.number): \(.title)"'
 
@@ -173,7 +179,7 @@ gh pr edit 50 --add-label "loom:in-progress"
 
 # Fix and signal ready for re-review (amber → green, remove in-progress)
 gh pr checkout 50
-# ... address feedback ...
+# ... address feedback or resolve conflicts ...
 pnpm check:ci
 git push
 gh pr edit 50 --remove-label "loom:changes-requested" --remove-label "loom:in-progress" --add-label "loom:review-requested"

--- a/defaults/roles/healer.md
+++ b/defaults/roles/healer.md
@@ -19,21 +19,38 @@ You help PRs move toward merge by:
 
 ## Finding Work
 
-**Find PRs with changes requested (amber badges) that aren't already claimed:**
+Healers prioritize work in the following order:
+
+### Priority 1: Approved PRs with Merge Conflicts (URGENT)
+
+**Find approved PRs with merge conflicts that aren't already claimed:**
 ```bash
-# Filter out PRs with loom:in-progress to avoid duplicate work
+gh pr list --label="loom:approved" --state=open --search "is:open conflicts:>0" --json number,title,labels \
+  | jq -r '.[] | select(.labels | all(.name != "loom:in-progress")) | "#\(.number): \(.title)"'
+```
+
+**Why highest priority?**
+- These PRs are **blocking** - already approved but can't merge
+- Conflicts get harder to resolve over time
+- Delays merge of completed work
+
+### Priority 2: PRs with Changes Requested (NORMAL)
+
+**Find PRs with review feedback that aren't already claimed:**
+```bash
 gh pr list --label="loom:changes-requested" --state=open --json number,title,labels \
   | jq -r '.[] | select(.labels | all(.name != "loom:in-progress")) | "#\(.number): \(.title)"'
 ```
 
-**Find PRs with merge conflicts:**
+### Other PRs Needing Attention
+
+**Find PRs with merge conflicts (any label):**
 ```bash
 gh pr list --state=open --search "is:open conflicts:>0"
 ```
 
-**Find all PRs that might need attention:**
+**Find all open PRs:**
 ```bash
-# List all open PRs, then check each one
 gh pr list --state=open
 ```
 


### PR DESCRIPTION
## Summary

Implements a two-tier priority system for the Healer role to ensure approved PRs with merge conflicts are fixed before addressing regular review feedback.

## Changes

### Priority System

**Priority 1 (URGENT):** Approved PRs with merge conflicts
- These PRs are **blocking** - already reviewed and approved but can't merge
- Conflicts get harder to resolve over time
- Delays merge of completed work

**Priority 2 (NORMAL):** PRs with review feedback
- Important but not blocking merges
- Existing `loom:changes-requested` workflow

### Files Modified

1. **`defaults/roles/healer.md`** - Updated "Finding Work" section with priority system
2. **`.loom/roles/healer.md`** - Synced dogfooding instance with defaults
3. **`WORKFLOWS.md`** - Documented Healer priority order in Fixer Workflow section

### Commands

```bash
# Priority 1 (URGENT): Approved PRs with merge conflicts
gh pr list --label="loom:approved" --state=open --search "is:open conflicts:>0" --json number,title,labels \
  | jq -r '.[] | select(.labels | all(.name != "loom:in-progress")) | "#\(.number): \(.title)"'

# Priority 2 (NORMAL): PRs with review feedback
gh pr list --label="loom:changes-requested" --state=open --json number,title,labels \
  | jq -r '.[] | select(.labels | all(.name != "loom:in-progress")) | "#\(.number): \(.title)"'
```

Both commands maintain the existing claiming pattern (filter out `loom:in-progress` to prevent duplicate work).

## Testing

- ✅ Command syntax validated
- ✅ Biome linting passes
- ✅ Rust formatting passes
- ✅ Documentation updated consistently across all files

## Rationale

Approved PRs that develop merge conflicts are **blocking** the pipeline - they've already been reviewed and approved, but can't merge until conflicts are resolved. Prioritizing these fixes ensures completed work can merge quickly, while review feedback (though important) is handled as a secondary priority since it doesn't block merges.

Closes #487