### PR TITLE
Fix branch cleanup scripts to handle worktree marker

### DIFF
--- a/defaults/scripts/clean.sh
+++ b/defaults/scripts/clean.sh
@@ -230,7 +230,7 @@ if [[ -f "scripts/cleanup-branches.sh" ]]; then
   fi
 else
   # Manual branch cleanup for target repositories
-  branches=$(git branch | grep "feature/issue-" | sed 's/^[* ]*//' || true)
+  branches=$(git branch | grep "feature/issue-" | sed 's/^[*+ ]*//' || true)
 
   if [[ -z "$branches" ]]; then
     success "No feature branches found"

--- a/scripts/cleanup-branches.sh
+++ b/scripts/cleanup-branches.sh
@@ -33,7 +33,7 @@ if [[ "$1" == "--dry-run" ]]; then
 fi
 
 # Get all feature branches
-branches=$(git branch | grep "feature/issue-" | sed 's/^[* ]*//' || true)
+branches=$(git branch | grep "feature/issue-" | sed 's/^[*+ ]*//' || true)
 
 if [ -z "$branches" ]; then
   echo "No feature branches found matching pattern 'feature/issue-*'"


### PR DESCRIPTION
## Summary

Fixed issue number extraction in branch cleanup scripts that was failing for branches with active worktrees.

## Problem

The `git branch` command uses different markers to indicate branch state:
- `*` - current branch
- `+` - branch with active worktree
- ` ` - regular branch

The cleanup scripts (`scripts/cleanup-branches.sh` and `defaults/scripts/clean.sh`) were only stripping `*` and spaces from branch names, leaving the `+` marker in the output. This caused the sed pattern for extracting issue numbers to fail, resulting in:

```
? Skipping + (couldn't extract issue number)
```

## Solution

Changed the sed pattern from `'s/^[* ]*//'` to `'s/^[*+ ]*//'` to properly handle all git branch markers.

## Testing

Tested with dry run on repository with active worktrees:

**Before fix:**
```
? Skipping + (couldn't extract issue number)
? Skipping + (couldn't extract issue number)
```

**After fix:**
```
○ Issue #317 is OPEN - keeping feature/issue-317
✓ Issue #366 is CLOSED - deleting feature/issue-366
✓ Issue #487 is CLOSED - deleting feature/issue-487
✓ Issue #489 is CLOSED - deleting feature/issue-489
```

## Files Changed

- `scripts/cleanup-branches.sh` - Fixed branch name extraction
- `defaults/scripts/clean.sh` - Fixed branch name extraction in fallback cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>