### PR TITLE
Fix installation script to handle existing branches gracefully

### DIFF
--- a/scripts/install/create-worktree.sh
+++ b/scripts/install/create-worktree.sh
@@ -43,11 +43,19 @@ info "Creating worktree for issue #${ISSUE_NUMBER}..."
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 info "Branching from: ${CURRENT_BRANCH}"
 
-# Create worktree
+# Clean up any existing worktree
 if [[ -d "$WORKTREE_PATH" ]]; then
-  error "Worktree already exists: $WORKTREE_PATH"
+  info "Removing existing worktree: $WORKTREE_PATH"
+  git worktree remove "$WORKTREE_PATH" --force 2>/dev/null || true
 fi
 
+# Clean up any existing local branch
+if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
+  info "Removing existing local branch: $BRANCH_NAME"
+  git branch -D "$BRANCH_NAME" 2>/dev/null || true
+fi
+
+# Create worktree (will create new local branch from current branch)
 git worktree add -b "$BRANCH_NAME" "$WORKTREE_PATH" "$CURRENT_BRANCH" || \
   error "Failed to create worktree"
 


### PR DESCRIPTION
## Summary
- Fixed `create-worktree.sh` to clean up existing worktrees and branches before creating new ones
- Installation script now handles retries gracefully without requiring manual cleanup
- Added informative messages during cleanup process

## Problem
The installation script failed when users retried installation after a previous failure because:
- A worktree directory already existed from the previous attempt
- A local branch named `feature/loom-installation` already existed
- The script would error out with "fatal: a branch named 'feature/loom-installation' already exists"

## Solution
Updated `scripts/install/create-worktree.sh` to:
1. Remove existing worktree directory if present (with `--force` flag)
2. Delete existing local branch with the same name
3. Create fresh worktree and branch

## Test plan
- [x] Verify script handles fresh installation (no existing worktree/branch)
- [x] Verify script handles retry after failed installation (existing worktree/branch)
- [ ] Test full installation workflow with retry scenario
- [ ] Verify cleanup messages are displayed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)