### PR TITLE
Add retry logic to installation method selection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -143,8 +143,25 @@ echo "   - Uses git worktree for clean separation"
 echo "   - Syncs labels and creates PR for review"
 echo "   - Recommended for team projects"
 echo ""
-read -r -p "Choose installation method [1/2]: " -n 1 METHOD
-echo ""
+
+# Retry loop for method selection (up to 3 attempts)
+METHOD=""
+for attempt in 1 2 3; do
+  read -r -p "Choose installation method [1/2]: " -n 1 METHOD
+  echo ""
+
+  if [[ "$METHOD" == "1" || "$METHOD" == "2" ]]; then
+    break
+  fi
+
+  if [[ $attempt -lt 3 ]]; then
+    warning "Invalid choice '$METHOD'. Please enter 1 or 2."
+    echo ""
+  else
+    error "Invalid choice after 3 attempts. Please run again and select 1 or 2."
+  fi
+done
+
 echo ""
 
 case "$METHOD" in
@@ -217,10 +234,6 @@ case "$METHOD" in
 
     # Run the full installation workflow
     exec "$LOOM_ROOT/scripts/install-loom.sh" "$TARGET_PATH"
-    ;;
-
-  *)
-    error "Invalid choice. Please run again and select 1 or 2."
     ;;
 esac
 


### PR DESCRIPTION
## Summary

- Adds retry logic with up to 3 attempts for installation method selection
- Improves user experience by handling quick typers who may enter 'y' instead of '1' or '2'
- Shows helpful warning messages on invalid input before final error

## Changes

- Added retry loop (up to 3 attempts) for method selection in install.sh
- Display warning messages on invalid input attempts 1-2
- Display error message on final attempt (3)
- Removed redundant error case in switch statement since input is now pre-validated

## Test Plan

- [ ] Run `./install.sh` and test entering invalid input like 'y' or 'x'
- [ ] Verify user gets 3 attempts before script exits
- [ ] Verify valid input '1' or '2' proceeds with installation
- [ ] Verify helpful warning messages appear on invalid attempts

🤖 Generated with [Claude Code](https://claude.com/claude-code)