### PR TITLE
Fix installation script worktree output parsing (#507)

### DIFF
--- a/scripts/install/create-worktree.sh
+++ b/scripts/install/create-worktree.sh
@@ -61,7 +61,7 @@ while true; do
   fi
 
   # Try to create worktree with this branch name
-  if git worktree add -b "$BRANCH_NAME" "$WORKTREE_PATH" "$CURRENT_BRANCH" 2>/dev/null; then
+  if git worktree add -b "$BRANCH_NAME" "$WORKTREE_PATH" "$CURRENT_BRANCH" >&2 2>&1; then
     # Success! Branch name is available
     break
   fi


### PR DESCRIPTION
## Summary

Fixes the Full Install workflow (`./install.sh` Option 2) which was failing at Step 3 with "Invalid worktree path returned" error.

### Root Cause
The `git worktree add` command in `scripts/install/create-worktree.sh` was outputting "HEAD is now at..." to stdout, corrupting the pipe-delimited format (`WORKTREE_PATH|BRANCH_NAME`) expected by the parent installation script.

### Changes
- **scripts/install/create-worktree.sh**: Redirect git output to stderr using `>&2 2>&1`
- **docs/guides/troubleshooting.md**: Add Installation Issues section documenting the problem and solution

### Testing
Verified the fix produces clean output:
```
.loom/worktrees/issue-507|feature/issue-507
```

Closes #507

## Test Plan
- [x] Test worktree script output format manually
- [ ] Run full installation workflow with `./install.sh ~/GitHub/rulehunt`
- [ ] Verify installation completes without errors
- [ ] Verify worktree is created with correct branch name

🤖 Generated with [Claude Code](https://claude.com/claude-code)