### PR TITLE
Fix installation to use --force flag for loom-daemon init

### DIFF
--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -212,7 +212,8 @@ success "loom-daemon binary ready"
 
 # Run loom-daemon init in the worktree
 cd "$TARGET_PATH/$WORKTREE_PATH"
-"$LOOM_ROOT/target/release/loom-daemon" init . || \
+# Use --force in case .loom already exists in the target repo
+"$LOOM_ROOT/target/release/loom-daemon" init --force . || \
   error "loom-daemon init failed"
 
 echo ""


### PR DESCRIPTION
## Problem

Installation was failing when targeting repositories that already have a `.loom` directory:

```
❌ Failed to initialize workspace: Workspace already initialized (.loom directory exists). Use --force to overwrite.
✗ Error: loom-daemon init failed
```

## Solution

Added `--force` flag to the `loom-daemon init` command in the installation script.

```bash
# Before
loom-daemon init .

# After  
loom-daemon init --force .
```

This is safe because:
- Installation runs in a dedicated worktree (`.loom/worktrees/issue-XXX`)
- The worktree is specifically for creating the installation PR
- We want to overwrite any existing configuration with fresh Loom setup

## Testing

This fix will allow the installation to complete successfully on the `../rulehunt` repository which already has a `.loom` directory.