### PR TITLE
Fix cleanup script to auto-remove closed issue worktrees in --yes mode

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -101,8 +101,15 @@ if [[ ${#CLOSED_ISSUE_WORKTREES[@]} -gt 0 ]]; then
 
   # Auto-remove in non-interactive mode
   if [ "$NON_INTERACTIVE" = true ]; then
-    echo "Non-interactive mode: skipping closed issue worktree removal"
-    echo "ℹ Run with manual confirmation to remove them"
+    echo "Non-interactive mode: automatically removing closed issue worktrees"
+    for entry in "${CLOSED_ISSUE_WORKTREES[@]}"; do
+      worktree_path="${entry%%:*}"
+      issue_num="${entry##*:}"
+      echo "Removing worktree for closed issue #$issue_num..."
+      git worktree remove "$worktree_path" --force
+      echo "✓ Removed: $worktree_path"
+    done
+    echo "✓ Removed ${#CLOSED_ISSUE_WORKTREES[@]} closed issue worktree(s)"
   else
     echo "Found ${#CLOSED_ISSUE_WORKTREES[@]} worktree(s) for closed issues."
     read -p "Force remove all closed issue worktrees? (y/N) " -n 1 -r


### PR DESCRIPTION
## Problem

The cleanup script's `--yes` mode was not fully non-interactive. It would skip closed issue worktree removal with a message:

```
Non-interactive mode: skipping closed issue worktree removal
ℹ Run with manual confirmation to remove them
```

This defeated the purpose of the `--yes` flag for Claude Code automation.

## Solution

Changed the non-interactive mode behavior to automatically remove closed issue worktrees.

**Before:**
```bash
./scripts/cleanup.sh --yes
→ Skipped closed issue worktree removal (required manual confirmation)
→ Only auto-removed orphaned worktrees
```

**After:**
```bash
./scripts/cleanup.sh --yes
→ Automatically removes all closed issue worktrees
→ Automatically removes orphaned worktrees
→ Fully non-interactive
```

## Example Output

```
Non-interactive mode: automatically removing closed issue worktrees
Removing worktree for closed issue #207...
✓ Removed: /Users/rwalters/GitHub/loom/.loom/worktrees/issue-207
Removing worktree for closed issue #317...
✓ Removed: /Users/rwalters/GitHub/loom/.loom/worktrees/issue-317
✓ Removed 5 closed issue worktree(s)
```

## Testing

✅ Tested with 5 closed issue worktrees - all removed successfully
✅ Non-interactive mode is now fully automated
✅ Interactive mode still prompts with default 'N' for safety

This makes the `--yes` flag consistent and usable for Claude Code automation.