### PR TITLE
Add jot and shuf to Claude Code permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -56,6 +56,8 @@
       "Bash(convert:*)",
       "Bash(magick:*)",
       "Bash(iconutil:*)",
+      "Bash(jot:*)",
+      "Bash(shuf:*)",
       "WebSearch",
       "Read(/tmp/**)",
       "Write(/tmp/**)"

--- a/defaults/.claude/settings.json
+++ b/defaults/.claude/settings.json
@@ -56,6 +56,8 @@
       "Bash(convert:*)",
       "Bash(magick:*)",
       "Bash(iconutil:*)",
+      "Bash(jot:*)",
+      "Bash(shuf:*)",
       "WebSearch",
       "Read(/tmp/**)",
       "Write(/tmp/**)"


### PR DESCRIPTION
## Summary

Adds `jot` and `shuf` command permissions to Claude Code settings to support cross-platform random number generation in the `/loom` command.

## Problem

The `/loom` command uses random number generation to select roles, but alternative methods like `jot` (BSD/macOS) and `shuf` (GNU) were not permitted, causing permission prompts and workflow interruptions.

## Changes

**Files Modified**:
- `.claude/settings.json` - Added `Bash(jot:*)` and `Bash(shuf:*)` permissions
- `defaults/.claude/settings.json` - Same permissions added for consistency during installation

**Permissions Added**:
```json
"Bash(jot:*)",   // BSD utility for random numbers (native on macOS)
"Bash(shuf:*)"   // GNU utility for shuffling/random selection
```

## Benefits

- **Cross-platform support**: `jot` works on macOS, `shuf` works on Linux
- **No permission prompts**: Commands are pre-approved for autonomous agent workflows
- **Better randomization**: Purpose-built tools vs arithmetic expansion
- **Cleaner syntax**: `jot -r 1 0 7` vs `echo $(($(date +%s) % 8))`

## Test Plan

✅ Verified both files have identical permission additions
✅ JSON syntax is valid
✅ Permissions follow existing pattern (`Bash(command:*)`)
✅ Changes are minimal and focused (2 lines per file)

## Related

- Curator enhancement in issue #518 recommended adding these permissions
- `/loom` command will benefit from cleaner random role selection
- Installation script copies `defaults/.claude/settings.json` to target repos

Closes #518