### PR TITLE
Replace alert() calls with toast notification system

### DIFF
--- a/src/lib/git-menu.ts
+++ b/src/lib/git-menu.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/tauri";
+import { showToast } from "./toast";
 
 /**
  * git-menu.ts - Git menu UI and branch management
@@ -310,7 +311,7 @@ export async function openBranchListDialog(workspacePath: string): Promise<void>
         })
       );
     } catch (error) {
-      alert(`Failed to switch branch: ${error}`);
+      showToast(`Failed to switch branch: ${error}`, "error");
     }
   });
 
@@ -334,7 +335,7 @@ export async function openBranchListDialog(workspacePath: string): Promise<void>
       document.body.removeChild(modal);
       openBranchListDialog(workspacePath);
     } catch (error) {
-      alert(`Failed to delete branch: ${error}`);
+      showToast(`Failed to delete branch: ${error}`, "error");
     }
   });
 }

--- a/src/lib/recovery-handlers.ts
+++ b/src/lib/recovery-handlers.ts
@@ -10,6 +10,7 @@ import { invoke } from "@tauri-apps/api/tauri";
 import { Logger } from "./logger";
 import type { AppState } from "./state";
 import { TerminalStatus } from "./state";
+import { showToast } from "./toast";
 
 const logger = Logger.forComponent("recovery-handlers");
 
@@ -40,7 +41,7 @@ export async function handleRecoverNewSession(
 
   try {
     if (!state.hasWorkspace()) {
-      alert("Cannot recover: no workspace selected");
+      showToast("Cannot recover: no workspace selected", "error");
       return;
     }
 
@@ -48,7 +49,7 @@ export async function handleRecoverNewSession(
     const terminal = state.getTerminals().find((t) => t.id === terminalId);
 
     if (!terminal) {
-      alert("Cannot recover: terminal not found");
+      showToast("Cannot recover: terminal not found", "error");
       return;
     }
 
@@ -87,7 +88,7 @@ export async function handleRecoverNewSession(
     logger.info("Recovery complete", { terminalId: newTerminalId });
   } catch (error) {
     logger.error("Failed to recover terminal", error, { terminalId });
-    alert(`Failed to create new session: ${error}`);
+    showToast(`Failed to create new session: ${error}`, "error");
   }
 }
 
@@ -118,7 +119,7 @@ export async function handleRecoverAttachSession(id: string, state: AppState): P
     // Manual recovery handlers are deprecated but kept for compatibility
   } catch (error) {
     logger.error("Failed to list sessions", error, { terminalId: id });
-    alert(`Failed to list available sessions: ${error}`);
+    showToast(`Failed to list available sessions: ${error}`, "error");
   }
 }
 
@@ -161,7 +162,7 @@ export async function handleAttachToSession(
     logger.info("Attached successfully", { terminalId, sessionName });
   } catch (error) {
     logger.error("Failed to attach to session", error, { terminalId, sessionName });
-    alert(`Failed to attach to session: ${error}`);
+    showToast(`Failed to attach to session: ${error}`, "error");
   }
 }
 
@@ -197,6 +198,6 @@ export async function handleKillSession(sessionName: string, _state: AppState): 
     // Manual recovery handlers are deprecated but kept for compatibility
   } catch (error) {
     logger.error("Failed to kill session", error, { sessionName });
-    alert(`Failed to kill session: ${error}`);
+    showToast(`Failed to kill session: ${error}`, "error");
   }
 }

--- a/src/lib/terminal-actions.ts
+++ b/src/lib/terminal-actions.ts
@@ -13,6 +13,7 @@ import type { OutputPoller } from "./output-poller";
 import type { AppState } from "./state";
 import { TerminalStatus } from "./state";
 import type { TerminalManager } from "./terminal-manager";
+import { showToast } from "./toast";
 
 const logger = Logger.forComponent("terminal-actions");
 
@@ -72,7 +73,7 @@ export async function handleRunNowClick(
     logger.error("Failed to execute interval prompt", error as Error, {
       terminalId,
     });
-    alert(`Failed to run interval prompt: ${error}`);
+    showToast(`Failed to run interval prompt: ${error}`, "error");
   }
 }
 
@@ -176,7 +177,7 @@ export async function handleRestartTerminal(
     });
     // Reset status to idle on error
     state.updateTerminal(terminalId, { status: TerminalStatus.Idle });
-    alert(`Failed to restart terminal: ${error}`);
+    showToast(`Failed to restart terminal: ${error}`, "error");
   }
 }
 
@@ -376,6 +377,6 @@ export async function createPlainTerminal(deps: {
     state.setPrimary(id);
   } catch (error) {
     logger.error("Failed to create terminal", error, { workspacePath });
-    alert(`Failed to create terminal: ${error}`);
+    showToast(`Failed to create terminal: ${error}`, "error");
   }
 }

--- a/src/lib/terminal-activity-modal.ts
+++ b/src/lib/terminal-activity-modal.ts
@@ -9,6 +9,7 @@ import { save } from "@tauri-apps/api/dialog";
 import { writeTextFile } from "@tauri-apps/api/fs";
 import { invoke } from "@tauri-apps/api/tauri";
 import type { ActivityEntry } from "./state";
+import { showToast } from "./toast";
 
 /**
  * Show the activity modal for a specific terminal
@@ -285,11 +286,10 @@ async function exportActivity(terminalId: string, format: "csv" | "json"): Promi
 
     if (filePath) {
       await writeTextFile(filePath, content);
-      // TODO: Show success toast instead of alert
-      alert(`Activity exported to ${filePath}`);
+      showToast(`Activity exported to ${filePath}`, "success");
     }
   } catch (error) {
-    alert(`Export failed: ${error}`);
+    showToast(`Export failed: ${error}`, "error");
   }
 }
 

--- a/src/lib/terminal-lifecycle.ts
+++ b/src/lib/terminal-lifecycle.ts
@@ -4,6 +4,7 @@ import { Logger } from "./logger";
 import { startOfflineScheduler } from "./offline-scheduler";
 import type { AppState, Terminal } from "./state";
 import { TerminalStatus } from "./state";
+import { showToast } from "./toast";
 
 const logger = Logger.forComponent("terminal-lifecycle");
 
@@ -204,7 +205,7 @@ export async function launchAgentsForTerminals(
       launchedTerminalIds.push(terminal.id);
 
       // Show error to user so they know what failed
-      alert(errorMessage);
+      showToast(errorMessage, "error", 5000);
 
       // Continue with other terminals even if one fails
     }
@@ -404,10 +405,10 @@ export async function reconnectTerminals(deps: TerminalLifecycleDependencies): P
   } catch (error) {
     logger.error("Failed to reconnect terminals", error as Error);
     // Non-fatal - workspace is still loaded
-    alert(
-      `Warning: Could not reconnect to daemon terminals.\n\n` +
-        `Error: ${error}\n\n` +
-        `Terminals may need to be recreated. Check Help → Daemon Status for more info.`
+    showToast(
+      `Warning: Could not reconnect to daemon terminals. Error: ${error}. Terminals may need to be recreated.`,
+      "error",
+      7000
     );
   }
 }

--- a/src/lib/terminal-settings-modal.ts
+++ b/src/lib/terminal-settings-modal.ts
@@ -2,6 +2,7 @@ import { saveCurrentConfiguration } from "./config";
 import { Logger } from "./logger";
 import type { AppState, Terminal } from "./state";
 import { TERMINAL_THEMES } from "./themes";
+import { showToast } from "./toast";
 
 const logger = Logger.forComponent("terminal-settings-modal");
 
@@ -445,7 +446,7 @@ async function applySettings(
     const roleFile = roleFileSelect.value;
 
     if (!name) {
-      alert("Please enter a terminal name");
+      showToast("Please enter a terminal name", "error");
       return;
     }
 
@@ -556,7 +557,7 @@ async function applySettings(
             workspacePath,
             workerType,
           });
-          alert(`Failed to launch agent: ${error}`);
+          showToast(`Failed to launch agent: ${error}`, "error");
         }
       }
     }
@@ -580,6 +581,6 @@ async function applySettings(
     modal.remove();
     renderFn();
   } catch (error) {
-    alert(`Failed to apply settings: ${error}`);
+    showToast(`Failed to apply settings: ${error}`, "error");
   }
 }

--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -1,0 +1,41 @@
+/**
+ * Simple toast notification system
+ *
+ * Provides non-blocking toast notifications as a replacement for blocking alert() calls.
+ * Supports success, error, and info message types with automatic dismiss.
+ */
+
+export type ToastType = "success" | "error" | "info";
+
+/**
+ * Show a toast notification
+ *
+ * @param message - The message to display
+ * @param type - The type of toast (success, error, or info)
+ * @param duration - How long to show the toast in milliseconds (default: 3000)
+ */
+export function showToast(
+  message: string,
+  type: ToastType = "info",
+  duration: number = 3000
+): void {
+  // Create toast element
+  const toast = document.createElement("div");
+  toast.className = `toast toast-${type}`;
+  toast.textContent = message;
+  toast.setAttribute("role", "status");
+  toast.setAttribute("aria-live", "polite");
+
+  // Add to DOM
+  document.body.appendChild(toast);
+
+  // Trigger show animation (need small delay for CSS transition)
+  setTimeout(() => toast.classList.add("show"), 10);
+
+  // Auto-dismiss after duration
+  setTimeout(() => {
+    toast.classList.remove("show");
+    // Remove from DOM after fade-out animation completes
+    setTimeout(() => toast.remove(), 300);
+  }, duration);
+}

--- a/src/lib/worker-modal.ts
+++ b/src/lib/worker-modal.ts
@@ -3,6 +3,7 @@ import { saveCurrentConfiguration } from "./config";
 import { Logger } from "./logger";
 import type { AppState } from "./state";
 import { TerminalStatus } from "./state";
+import { showToast } from "./toast";
 
 const logger = Logger.forComponent("worker-modal");
 
@@ -82,7 +83,7 @@ export async function showWorkerModal(state: AppState, renderFn: () => void): Pr
   // Get workspace path from state
   const workspacePath = state.getWorkspace();
   if (!workspacePath) {
-    alert("No workspace selected");
+    showToast("No workspace selected", "error");
     return;
   }
 
@@ -97,8 +98,10 @@ export async function showWorkerModal(state: AppState, renderFn: () => void): Pr
 
     if (!hasApiKey) {
       logger.warn("ANTHROPIC_API_KEY not set", { workspacePath });
-      alert(
-        "Warning: ANTHROPIC_API_KEY not set in .env file.\n\nWorkers won't function without it. Add the key to your .env file and restart Loom."
+      showToast(
+        "Warning: ANTHROPIC_API_KEY not set in .env file. Workers won't function without it.",
+        "error",
+        5000
       );
     }
 
@@ -106,8 +109,10 @@ export async function showWorkerModal(state: AppState, renderFn: () => void): Pr
     const hasClaudeCode = await invoke<boolean>("check_claude_code");
     if (!hasClaudeCode) {
       logger.warn("Claude Code not found in PATH", { workspacePath });
-      alert(
-        "Warning: Claude Code not found in PATH.\n\nWorkers won't function without it. Install with:\nnpm install -g @anthropic-ai/claude-code"
+      showToast(
+        "Warning: Claude Code not found in PATH. Install with: npm install -g @anthropic-ai/claude-code",
+        "error",
+        5000
       );
     }
 
@@ -167,7 +172,7 @@ export async function showWorkerModal(state: AppState, renderFn: () => void): Pr
     };
     document.addEventListener("keydown", escapeHandler);
   } catch (error) {
-    alert(`Failed to open worker modal: ${error}`);
+    showToast(`Failed to open worker modal: ${error}`, "error");
   }
 }
 
@@ -198,12 +203,12 @@ async function launchWorker(
   const prompt = promptTextarea.value.trim();
 
   if (!name) {
-    alert("Please enter a worker name");
+    showToast("Please enter a worker name", "error");
     return;
   }
 
   if (!prompt) {
-    alert("Please enter a system prompt");
+    showToast("Please enter a system prompt", "error");
     return;
   }
 
@@ -262,6 +267,6 @@ async function launchWorker(
     state.setPrimary(id);
     renderFn();
   } catch (error) {
-    alert(`Failed to launch worker: ${error}`);
+    showToast(`Failed to launch worker: ${error}`, "error");
   }
 }

--- a/src/lib/workspace-lifecycle.ts
+++ b/src/lib/workspace-lifecycle.ts
@@ -4,6 +4,7 @@ import { loadWorkspaceConfig, saveCurrentConfiguration, setConfigWorkspace } fro
 import { Logger } from "./logger";
 import type { AppState, Terminal } from "./state";
 import { TerminalStatus } from "./state";
+import { showToast } from "./toast";
 import { expandTildePath } from "./workspace-utils";
 
 const logger = Logger.forComponent("workspace-lifecycle");
@@ -134,7 +135,7 @@ export async function handleWorkspacePathInput(
         logger.error("Failed to initialize workspace", error as Error, {
           workspacePath: expandedPath,
         });
-        alert(`Failed to initialize workspace: ${error}`);
+        showToast(`Failed to initialize workspace: ${error}`, "error");
         return;
       }
 
@@ -176,7 +177,7 @@ export async function handleWorkspacePathInput(
               terminalName: agent.name,
               workspacePath: expandedPath,
             });
-            alert(`Failed to create terminal ${agent.name}: ${error}`);
+            showToast(`Failed to create terminal ${agent.name}: ${error}`, "error");
           }
         }
 
@@ -377,6 +378,6 @@ export async function handleWorkspacePathInput(
     }
   } catch (error) {
     logger.error("Error handling workspace", error as Error, { workspacePath: expandedPath });
-    alert(`Error: ${error}`);
+    showToast(`Error: ${error}`, "error");
   }
 }

--- a/src/lib/workspace-reset.ts
+++ b/src/lib/workspace-reset.ts
@@ -5,6 +5,7 @@ import type { OutputPoller } from "./output-poller";
 import { createTerminalsWithRetry, type TerminalConfig } from "./parallel-terminal-creator";
 import type { AppState, Terminal } from "./state";
 import type { TerminalManager } from "./terminal-manager";
+import { showToast } from "./toast";
 import { cleanupWorkspace } from "./workspace-cleanup";
 
 const logger = Logger.forComponent("workspace-reset");
@@ -81,7 +82,7 @@ export async function resetWorkspaceToDefaults(
       workspacePath,
       source: logPrefix,
     });
-    alert(`Failed to reset workspace: ${error}`);
+    showToast(`Failed to reset workspace: ${error}`, "error");
     return;
   }
 
@@ -188,9 +189,10 @@ export async function resetWorkspaceToDefaults(
           }
         );
 
-        alert(
-          `Failed to create ${failed.length} terminal(s) after retries: ${failedNames}\n\n` +
-            `Successfully created ${succeeded.length} of ${config.agents.length} terminals.`
+        showToast(
+          `Failed to create ${failed.length} terminal(s) after retries: ${failedNames}. Successfully created ${succeeded.length} of ${config.agents.length} terminals.`,
+          "error",
+          7000
         );
       }
 
@@ -263,7 +265,7 @@ export async function resetWorkspaceToDefaults(
       workspacePath,
       source: logPrefix,
     });
-    alert(`Failed to reload config: ${error}`);
+    showToast(`Failed to reload config: ${error}`, "error");
   }
 
   // Re-render

--- a/src/lib/workspace-start.ts
+++ b/src/lib/workspace-start.ts
@@ -3,6 +3,7 @@ import type { OutputPoller } from "./output-poller";
 import { createTerminalsWithRetry, type TerminalConfig } from "./parallel-terminal-creator";
 import type { AppState, Terminal } from "./state";
 import type { TerminalManager } from "./terminal-manager";
+import { showToast } from "./toast";
 import { cleanupWorkspace } from "./workspace-cleanup";
 
 const logger = Logger.forComponent("workspace-start");
@@ -143,9 +144,10 @@ export async function startWorkspaceEngine(
           }
         );
 
-        alert(
-          `Failed to create ${failed.length} terminal(s) after retries: ${failedNames}\n\n` +
-            `Successfully created ${succeeded.length} of ${config.agents.length} terminals.`
+        showToast(
+          `Failed to create ${failed.length} terminal(s) after retries: ${failedNames}. Successfully created ${succeeded.length} of ${config.agents.length} terminals.`,
+          "error",
+          7000
         );
       }
 
@@ -253,7 +255,7 @@ export async function startWorkspaceEngine(
       workspacePath,
       source: logPrefix,
     });
-    alert(`Failed to start Loom engine: ${error}`);
+    showToast(`Failed to start Loom engine: ${error}`, "error");
   }
 
   // Re-render

--- a/src/lib/workspace-utils.ts
+++ b/src/lib/workspace-utils.ts
@@ -10,6 +10,7 @@ import { homeDir } from "@tauri-apps/api/path";
 import { invoke } from "@tauri-apps/api/tauri";
 import { Logger } from "./logger";
 import type { Terminal } from "./state";
+import { showToast } from "./toast";
 
 const logger = Logger.forComponent("workspace-utils");
 
@@ -140,7 +141,7 @@ export async function browseWorkspace(
     }
   } catch (error) {
     logger.error("Error selecting workspace", error);
-    alert("Failed to select workspace. Please try again.");
+    showToast("Failed to select workspace. Please try again.", "error");
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,7 @@ import {
 // NOTE: saveCurrentConfig is defined locally in this file
 import { getTerminalManager } from "./lib/terminal-manager";
 import { initTheme, toggleTheme } from "./lib/theme";
+import { showToast } from "./lib/toast";
 import {
   renderHeader,
   renderLoadingState,
@@ -737,14 +738,14 @@ async function showDaemonStatusDialog() {
           initializeTerminalDisplay,
           saveCurrentConfig,
         });
-        alert("Terminal reconnection complete! Check the console for details.");
+        showToast("Terminal reconnection complete! Check the console for details.", "success");
       }
     } else {
       // Just show status without reconnect option
-      alert(`Daemon Status\n\n${statusText}\n\nSocket: ${status.socket_path}`);
+      showToast(`Daemon Status: ${statusText}. Socket: ${status.socket_path}`, "info", 5000);
     }
   } catch (error) {
-    alert(`Failed to get daemon status: ${error}`);
+    showToast(`Failed to get daemon status: ${error}`, "error");
   }
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -118,3 +118,53 @@
   border: 1px solid rgba(0, 0, 0, 0.1);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
+
+/* Toast notification styles */
+.toast {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  padding: 12px 20px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  opacity: 0;
+  transition: opacity 0.3s ease-in-out;
+  z-index: 10000;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  max-width: 400px;
+  word-wrap: break-word;
+}
+
+.toast.show {
+  opacity: 1;
+}
+
+/* Toast type variants */
+.toast-success {
+  background-color: #10b981;
+  color: white;
+}
+
+.toast-error {
+  background-color: #ef4444;
+  color: white;
+}
+
+.toast-info {
+  background-color: #3b82f6;
+  color: white;
+}
+
+/* Dark mode variants */
+.dark .toast-success {
+  background-color: #059669;
+}
+
+.dark .toast-error {
+  background-color: #dc2626;
+}
+
+.dark .toast-info {
+  background-color: #2563eb;
+}


### PR DESCRIPTION
## Summary

Replaces all 37 blocking `alert()` calls throughout the codebase with a non-blocking toast notification system. This implements the Hermit proposal from #519.

## Changes Made

### New Toast Notification System
- **Created** `src/lib/toast.ts`: Lightweight vanilla TypeScript toast implementation (~40 LOC)
  - Supports `success`, `error`, and `info` notification types
  - Configurable auto-dismiss duration (default 3000ms)
  - Proper ARIA labels (`role="status"`, `aria-live="polite"`) for accessibility
  - No external dependencies (aligns with project philosophy)

- **Added** CSS styles in `src/style.css`:
  - Fixed positioning (bottom-right corner)
  - Fade-in/fade-out animations
  - Dark mode variants with appropriate colors
  - Type-specific colors (success=green, error=red, info=blue)

### Alert() Replacement Summary
Replaced **37 total alert() calls** across **12 files**:

| File | Calls Replaced |
|------|---------------|
| `src/lib/worker-modal.ts` | 7 |
| `src/lib/recovery-handlers.ts` | 6 |
| `src/lib/workspace-lifecycle.ts` | 3 |
| `src/lib/workspace-reset.ts` | 3 |
| `src/lib/terminal-actions.ts` | 3 |
| `src/lib/terminal-settings-modal.ts` | 3 |
| `src/main.ts` | 3 |
| `src/lib/terminal-activity-modal.ts` | 2 |
| `src/lib/terminal-lifecycle.ts` | 2 |
| `src/lib/workspace-start.ts` | 2 |
| `src/lib/git-menu.ts` | 2 |
| `src/lib/workspace-utils.ts` | 1 |

### Key Improvements

**Better UX:**
- ✅ Non-blocking - users can continue working while notifications display
- ✅ No workflow interruption - autonomous terminals continue running
- ✅ Multiple notifications can stack without blocking
- ✅ Auto-dismiss prevents notification buildup

**Consistency:**
- ✅ Unified styling across all notifications
- ✅ Dark mode support throughout
- ✅ Consistent positioning and behavior

**Accessibility:**
- ✅ Proper ARIA labels for screen readers
- ✅ Polite announcements don't interrupt user flow

**Technical:**
- ✅ Vanilla TypeScript (no external dependencies)
- ✅ Minimal implementation (~40 LOC)
- ✅ All notifications use appropriate types (error/success/info)
- ✅ Longer duration (5-7s) for critical messages

## Test Plan

- [x] TypeScript compilation passes (`pnpm check`)
- [x] Linting passes (`pnpm lint`)
- [x] Build succeeds (`pnpm build`)
- [x] All 37 alert() calls replaced
- [ ] Manual testing: Trigger error scenarios to see toast notifications
- [ ] Manual testing: Verify dark mode toast appearance
- [ ] Manual testing: Test notification auto-dismiss timing

## Notable Implementation Details

1. **Removed the TODO comment** in `terminal-activity-modal.ts:288` that explicitly requested this change
2. **Used longer durations** (5-7s) for critical error messages that users need to read
3. **Condensed multi-line messages** from alert() (which supported `\n\n`) into single-line toast messages
4. **Preserved error context** while keeping messages concise for toast format

## Breaking Changes

None - this is purely an internal UX improvement with no API changes.

## Related

Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)