### PR TITLE
Enable Curator to enhance Hermit and Architect proposals

### DIFF
--- a/.loom/roles/curator.md
+++ b/.loom/roles/curator.md
@@ -41,7 +41,7 @@ Use this command to find issues that need curation (already filters out claimed 
 # Find issues without suggestion labels, curated, issue, or in-progress
 # (These need curator enhancement)
 gh issue list --state=open --json number,title,labels \
-  --jq '.[] | select(([.labels[].name] | inside(["loom:architect", "loom:hermit", "loom:curated", "loom:issue", "loom:in-progress"]) | not)) | "#\(.number) \(.title)"'
+  --jq '.[] | select(([.labels[].name] | inside(["loom:curated", "loom:issue", "loom:in-progress"]) | not)) | "#\(.number) \(.title)"'
 ```
 
 Or simpler (may include some false positives):


### PR DESCRIPTION
## Summary

Enables Curator to enhance Hermit and Architect proposal issues, fixing a systematic gap in the multi-agent workflow.

## Problem Solved

Previously, Curator's work-finding query excluded `loom:architect` and `loom:hermit` labels, preventing Curators from enhancing proposal issues before human review. This meant humans reviewed lower-quality proposals without technical context.

## Solution

**Single-line fix**: Removed `loom:architect` and `loom:hermit` from the exclusion filter in `.loom/roles/curator.md:44`.

**Before:**
```bash
--jq '.[] | select(([.labels[].name] | inside(["loom:architect", "loom:hermit", "loom:curated", "loom:issue", "loom:in-progress"]) | not)) | "#\(.number) \(.title)"'
```

**After:**
```bash
--jq '.[] | select(([.labels[].name] | inside(["loom:curated", "loom:issue", "loom:in-progress"]) | not)) | "#\(.number) \(.title)"'
```

## Impact

✅ **Workflow Quality**: Proposals now get technical details before human review  
✅ **Faster Decisions**: Humans review better-quality proposals  
✅ **Higher Quality Work**: Better proposals → better implementations  
✅ **Agent Collaboration**: Curator + Architect/Hermit coordination improved  

## Changes Made

**File Modified**: `.loom/roles/curator.md` (line 44)
- Removed: `"loom:architect", "loom:hermit"` from exclusion array
- Result: Curator can now enhance all proposal issues

## Acceptance Criteria

- [x] Curator work-finding query excludes only `loom:curated`, `loom:issue`, and `loom:in-progress`
- [x] Curator can enhance issues with `loom:hermit` label
- [x] Curator can enhance issues with `loom:architect` label
- [x] Curator can still enhance unlabeled issues
- [x] Single-line change as specified

## Test Plan

**Verification:**
- Query syntax is valid (jq array contains only 3 labels instead of 5)
- Curator will now see Hermit/Architect proposals in work-finding search
- No CI checks needed (documentation-only change)

**Expected Behavior:**
- Next Curator iteration will be able to enhance proposal issues
- Proposals will get implementation guidance before human approval
- Improved workflow efficiency immediately

## Notes

- **Quick win**: < 5 minutes to implement
- **High ROI**: Every future proposal benefits
- **Zero risk**: Documentation-only change
- **Marked urgent** by Guide role for good reason

Closes #523

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>