### PR TITLE
Fix installation script verification order

### DIFF
--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -267,8 +267,6 @@ EXPECTED_FILES=(
   ".loom/config.json"
   ".loom/roles"
   ".loom/scripts/worktree.sh"
-  ".loom/scripts/cleanup.sh"
-  ".loom/scripts/cleanup-branches.sh"
   "CLAUDE.md"
   ".github/labels.yml"
 )


### PR DESCRIPTION
## Summary

Fixes installation failures caused by incorrect file verification in the install script.

The installation script was checking for cleanup scripts (`.loom/scripts/cleanup.sh` and `.loom/scripts/cleanup-branches.sh`) in the expected files list before they were copied. These scripts are copied by the install script itself, not created by `loom-daemon init`, causing the verification to fail with:

```
Expected file not created: .loom/scripts/cleanup.sh
```

This PR removes these scripts from the `EXPECTED_FILES` array since they're handled separately by the installation process.

## Changes

- Removed `.loom/scripts/cleanup.sh` from `EXPECTED_FILES` array in `scripts/install-loom.sh`
- Removed `.loom/scripts/cleanup-branches.sh` from `EXPECTED_FILES` array in `scripts/install-loom.sh`

## Test Plan

- [x] Verified installation completes without verification errors
- [x] Confirmed cleanup scripts are still correctly installed
- [x] Tested full installation flow on clean repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)