### PR TITLE
Add non-interactive mode to clean.sh script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,12 +349,45 @@ EOF
 
 ### Common Issues
 
-**Worktree already exists**:
+**Cleaning Up Stale Worktrees and Branches**:
+
+Use the `clean.sh` helper script to restore your repository to a clean state:
+
+```bash
+# Interactive mode - prompts for confirmation (default)
+./.loom/scripts/clean.sh
+
+# Preview mode - shows what would be cleaned without making changes
+./.loom/scripts/clean.sh --dry-run
+
+# Non-interactive mode - auto-confirms all prompts (for CI/automation)
+./.loom/scripts/clean.sh --force
+
+# Deep clean - also removes build artifacts (target/, node_modules/)
+./.loom/scripts/clean.sh --deep
+
+# Combine flags
+./.loom/scripts/clean.sh --deep --force  # Non-interactive deep clean
+./.loom/scripts/clean.sh --deep --dry-run  # Preview deep clean
+```
+
+**What clean.sh does**:
+- Removes worktrees for closed GitHub issues (prompts per worktree in interactive mode)
+- Deletes local feature branches for closed issues
+- Cleans up Loom tmux sessions
+- (Optional with `--deep`) Removes `target/` and `node_modules/` directories
+
+**IMPORTANT**: For **CI pipelines and automation**, always use `--force` flag to prevent hanging on prompts:
+```bash
+./.loom/scripts/clean.sh --force  # Non-interactive, safe for automation
+```
+
+**Manual cleanup** (if needed):
 ```bash
 # List worktrees
 git worktree list
 
-# Remove stale worktree
+# Remove specific stale worktree
 git worktree remove .loom/worktrees/issue-42 --force
 
 # Prune orphaned worktrees

--- a/defaults/.loom/CLAUDE.md
+++ b/defaults/.loom/CLAUDE.md
@@ -344,12 +344,45 @@ EOF
 
 ### Common Issues
 
-**Worktree already exists**:
+**Cleaning Up Stale Worktrees and Branches**:
+
+Use the `clean.sh` helper script to restore your repository to a clean state:
+
+```bash
+# Interactive mode - prompts for confirmation (default)
+./.loom/scripts/clean.sh
+
+# Preview mode - shows what would be cleaned without making changes
+./.loom/scripts/clean.sh --dry-run
+
+# Non-interactive mode - auto-confirms all prompts (for CI/automation)
+./.loom/scripts/clean.sh --force
+
+# Deep clean - also removes build artifacts (target/, node_modules/)
+./.loom/scripts/clean.sh --deep
+
+# Combine flags
+./.loom/scripts/clean.sh --deep --force  # Non-interactive deep clean
+./.loom/scripts/clean.sh --deep --dry-run  # Preview deep clean
+```
+
+**What clean.sh does**:
+- Removes worktrees for closed GitHub issues (prompts per worktree in interactive mode)
+- Deletes local feature branches for closed issues
+- Cleans up Loom tmux sessions
+- (Optional with `--deep`) Removes `target/` and `node_modules/` directories
+
+**IMPORTANT**: For **CI pipelines and automation**, always use `--force` flag to prevent hanging on prompts:
+```bash
+./.loom/scripts/clean.sh --force  # Non-interactive, safe for automation
+```
+
+**Manual cleanup** (if needed):
 ```bash
 # List worktrees
 git worktree list
 
-# Remove stale worktree
+# Remove specific stale worktree
 git worktree remove .loom/worktrees/issue-42 --force
 
 # Prune orphaned worktrees


### PR DESCRIPTION
## Summary

- Added `--force` (`-f`) flag to `.loom/scripts/clean.sh` for non-interactive execution
- Script now prompts for each closed worktree removal in interactive mode (default)
- Documented clean.sh usage comprehensively in CLAUDE.md files

## Changes

### Script Enhancement
- New `--force` flag enables non-interactive mode (auto-confirms all prompts)
- Interactive mode now prompts individually for each closed worktree removal
- Supports flag combinations: `--deep --force`, `--dry-run`, etc.

### Documentation
- Updated `CLAUDE.md` with clean.sh usage guide
- Updated `defaults/.loom/CLAUDE.md` (template for target repos)
- Highlighted importance of `--force` flag for CI/automation

## Test Plan

- [x] Interactive mode prompts for worktree removal
- [x] `--force` flag auto-confirms all prompts
- [x] `--dry-run` shows what would be cleaned
- [x] Flag combinations work correctly
- [x] Documentation is clear and accurate

## Motivation

The clean script previously skipped worktrees for closed issues without prompting, requiring manual cleanup. This change:
1. Makes interactive mode safer by prompting for each removal
2. Supports automation with `--force` flag for CI pipelines
3. Maintains consistent behavior with `--dry-run` preview mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)