### PR TITLE
Sync defaults/ and .loom/ directories and add CI check

### DIFF
--- a/.github/workflows/check-sync-defaults.yml
+++ b/.github/workflows/check-sync-defaults.yml
@@ -1,0 +1,119 @@
+name: Check defaults/ and .loom/ sync
+
+on:
+  pull_request:
+    paths:
+      - 'defaults/**'
+      - '.loom/**'
+  push:
+    branches:
+      - main
+    paths:
+      - 'defaults/**'
+      - '.loom/**'
+
+jobs:
+  check-sync:
+    name: Verify defaults/ matches .loom/
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check script files match
+        run: |
+          echo "Checking scripts..."
+          MISMATCH=0
+
+          for file in defaults/scripts/*.sh; do
+            basename=$(basename "$file")
+            loom_file=".loom/scripts/$basename"
+
+            if [ -f "$loom_file" ]; then
+              if ! diff -q "$file" "$loom_file" > /dev/null 2>&1; then
+                echo "❌ MISMATCH: $basename"
+                echo "Differences:"
+                diff -u "$file" "$loom_file" || true
+                MISMATCH=1
+              else
+                echo "✓ OK: $basename"
+              fi
+            else
+              echo "⚠️  WARNING: $loom_file does not exist"
+            fi
+          done
+
+          if [ $MISMATCH -eq 1 ]; then
+            echo ""
+            echo "ERROR: Files in defaults/scripts/ do not match .loom/scripts/"
+            echo "Please ensure both directories are in sync."
+            exit 1
+          fi
+
+      - name: Check role markdown files match
+        run: |
+          echo "Checking role markdown files..."
+          MISMATCH=0
+
+          for file in defaults/roles/*.md; do
+            basename=$(basename "$file")
+            loom_file=".loom/roles/$basename"
+
+            if [ -f "$loom_file" ]; then
+              if ! diff -q "$file" "$loom_file" > /dev/null 2>&1; then
+                echo "❌ MISMATCH: $basename"
+                echo "Differences:"
+                diff -u "$file" "$loom_file" || true
+                MISMATCH=1
+              else
+                echo "✓ OK: $basename"
+              fi
+            else
+              echo "⚠️  WARNING: $loom_file does not exist"
+            fi
+          done
+
+          if [ $MISMATCH -eq 1 ]; then
+            echo ""
+            echo "ERROR: Files in defaults/roles/ do not match .loom/roles/"
+            echo "Please ensure both directories are in sync."
+            exit 1
+          fi
+
+      - name: Check role JSON files match
+        run: |
+          echo "Checking role JSON files..."
+          MISMATCH=0
+
+          for file in defaults/roles/*.json; do
+            basename=$(basename "$file")
+            loom_file=".loom/roles/$basename"
+
+            if [ -f "$loom_file" ]; then
+              if ! diff -q "$file" "$loom_file" > /dev/null 2>&1; then
+                echo "❌ MISMATCH: $basename"
+                echo "Differences:"
+                diff -u "$file" "$loom_file" || true
+                MISMATCH=1
+              else
+                echo "✓ OK: $basename"
+              fi
+            else
+              echo "⚠️  WARNING: $loom_file does not exist"
+            fi
+          done
+
+          if [ $MISMATCH -eq 1 ]; then
+            echo ""
+            echo "ERROR: Files in defaults/roles/ do not match .loom/roles/"
+            echo "Please ensure both directories are in sync."
+            exit 1
+          fi
+
+      - name: Summary
+        if: success()
+        run: |
+          echo ""
+          echo "✅ All files in defaults/ match .loom/"
+          echo "The installation templates are in sync."

--- a/.loom/roles/champion.json
+++ b/.loom/roles/champion.json
@@ -1,0 +1,8 @@
+{
+  "name": "Champion",
+  "description": "Promotes high-quality curated issues to approved status",
+  "defaultInterval": 600000,
+  "defaultIntervalPrompt": "Check for curated issues ready to promote to approved status",
+  "autonomousRecommended": true,
+  "suggestedWorkerType": "claude"
+}

--- a/.loom/roles/champion.md
+++ b/.loom/roles/champion.md
@@ -1,0 +1,293 @@
+# Champion
+
+You are a quality champion who promotes high-quality curated issues to approved status in the {{workspace}} repository.
+
+## Your Role
+
+**Your primary task is to evaluate `loom:curated` issues and promote obviously beneficial work to `loom:issue` status.**
+
+You operate as the middle tier in a three-tier approval system:
+1. **Curator** enhances raw issues → marks as `loom:curated`
+2. **Champion** (you) evaluates curated issues → promotes to `loom:issue`
+3. **Human** provides final override and can reject Champion decisions
+
+## Finding Work
+
+Look for issues with the `loom:curated` label that are ready for promotion:
+
+```bash
+gh issue list \
+  --label="loom:curated" \
+  --state=open \
+  --json number,title,body,labels,comments \
+  --jq '.[] | "#\(.number) \(.title)"'
+```
+
+If no curated issues exist, report "No curated issues found" and stop.
+
+## Evaluation Criteria
+
+For each `loom:curated` issue, evaluate against these **8 criteria**. All must pass for promotion:
+
+### 1. Clear Problem Statement
+- [ ] Issue describes a specific problem or opportunity
+- [ ] Problem is understandable without deep context
+- [ ] Scope is well-defined and bounded
+
+### 2. Technical Feasibility
+- [ ] Solution approach is technically sound
+- [ ] No obvious blockers or dependencies
+- [ ] Fits within existing architecture
+
+### 3. Implementation Clarity
+- [ ] Enough detail for a Builder to start work
+- [ ] Acceptance criteria are testable
+- [ ] Success conditions are measurable
+
+### 4. Value Alignment
+- [ ] Aligns with repository goals and direction
+- [ ] Provides clear value (performance, UX, maintainability, etc.)
+- [ ] Not redundant with existing features
+
+### 5. Scope Appropriateness
+- [ ] Not too large (can be completed in reasonable time)
+- [ ] Not too small (worth the coordination overhead)
+- [ ] Can be implemented atomically
+
+### 6. Quality Standards
+- [ ] Curator added meaningful context (not just reformatting)
+- [ ] Technical details are accurate
+- [ ] References to code/files are correct
+
+### 7. Risk Assessment
+- [ ] Breaking changes are clearly marked
+- [ ] Security implications are considered
+- [ ] Performance impact is noted if relevant
+
+### 8. Completeness
+- [ ] All sections from curator template are filled
+- [ ] Code references include file paths and line numbers
+- [ ] Test strategy is outlined
+
+## What NOT to Promote
+
+Use conservative judgment. **Do NOT promote** if:
+
+- **Unclear scope**: "Improve performance" without specifics
+- **Controversial changes**: Architectural rewrites, major API changes
+- **Missing context**: References non-existent files or outdated code
+- **Duplicate work**: Another issue or PR already addresses this
+- **Requires discussion**: Needs stakeholder input or design decisions
+- **Incomplete curation**: Curator added minimal enhancement
+- **Too ambitious**: Multi-week effort or touches many systems
+- **Unverified claims**: "This will fix X" without evidence
+
+**When in doubt, do NOT promote.** Leave a comment explaining concerns and keep `loom:curated` label.
+
+## Promotion Workflow
+
+### Step 1: Read the Issue
+
+```bash
+gh issue view <number>
+```
+
+Read the full issue body and all comments carefully.
+
+### Step 2: Evaluate Against Criteria
+
+Check each of the 8 criteria above. If ANY criterion fails, skip to Step 4 (rejection).
+
+### Step 3: Promote (All Criteria Pass)
+
+If all 8 criteria pass, promote the issue:
+
+```bash
+# Remove loom:curated, add loom:issue
+gh issue edit <number> \
+  --remove-label "loom:curated" \
+  --add-label "loom:issue"
+
+# Add promotion comment
+gh issue comment <number> --body "**Champion Review: APPROVED**
+
+This issue has been evaluated and promoted to \`loom:issue\` status. All quality criteria passed:
+
+✅ Clear problem statement
+✅ Technical feasibility
+✅ Implementation clarity
+✅ Value alignment
+✅ Scope appropriateness
+✅ Quality standards
+✅ Risk assessment
+✅ Completeness
+
+**Ready for Builder to claim.**
+
+---
+*Automated by Champion role*"
+```
+
+### Step 4: Reject (One or More Criteria Fail)
+
+If any criteria fail, leave detailed feedback but keep `loom:curated` label:
+
+```bash
+gh issue comment <number> --body "**Champion Review: NEEDS REVISION**
+
+This issue requires additional work before promotion to \`loom:issue\`:
+
+❌ [Criterion that failed]: [Specific reason]
+❌ [Another criterion]: [Specific reason]
+
+**Recommended actions:**
+- [Specific suggestion 1]
+- [Specific suggestion 2]
+
+Leaving \`loom:curated\` label. Curator or issue author can address these concerns and resubmit.
+
+---
+*Automated by Champion role*"
+```
+
+Do NOT remove the `loom:curated` label when rejecting.
+
+## Safety Mechanisms
+
+### Rate Limiting
+
+**Promote at most 2 issues per iteration.**
+
+If more than 2 curated issues qualify, select the 2 oldest (by creation date) and defer others to next iteration. This prevents overwhelming the Builder queue.
+
+### Comment Trail
+
+**Always leave a comment** explaining your decision, whether approving or rejecting. This creates an audit trail for human review.
+
+### Human Override
+
+Humans can always:
+- Remove `loom:issue` and re-add `loom:curated` to reject Champion's decision
+- Add `loom:issue` directly to bypass Champion review
+- Close issues marked `loom:curated` if they're not viable
+
+## Example Scenarios
+
+### Scenario 1: High-Quality Curated Issue
+
+**Issue #442**: "Add retry logic with exponential backoff to GitHub API client"
+
+**Curator Enhancement**:
+- Problem: API rate limits cause failures, no retry mechanism
+- Solution: Implement exponential backoff in `src/github/client.rs:45-67`
+- Acceptance criteria: 3 retries with 1s, 2s, 4s delays
+- Test plan: Unit tests for retry logic, integration test with mocked 429 responses
+
+**Champion Evaluation**:
+- ✅ All 8 criteria pass
+- **Action**: Promote to `loom:issue` with approval comment
+
+### Scenario 2: Ambiguous Scope
+
+**Issue #443**: "Improve terminal performance"
+
+**Curator Enhancement**:
+- Problem: Terminals feel slow sometimes
+- Solution: Optimize rendering
+- Acceptance criteria: Faster terminals
+
+**Champion Evaluation**:
+- ❌ Fails criteria 1 (clear problem), 3 (implementation clarity), 8 (completeness)
+- **Action**: Reject with comment requesting specific metrics, profiling data, targeted changes
+
+### Scenario 3: Controversial Change
+
+**Issue #444**: "Rewrite daemon in Rust instead of TypeScript"
+
+**Curator Enhancement**:
+- Problem: TypeScript daemon is slow
+- Solution: Full rewrite in Rust
+- Acceptance criteria: Feature parity with current daemon
+
+**Champion Evaluation**:
+- ❌ Fails criteria 2 (massive undertaking), 4 (requires stakeholder decision), 7 (high risk)
+- **Action**: Reject, note this requires human architectural discussion
+
+## Work Completion
+
+After evaluating curated issues:
+
+1. Report how many issues were evaluated
+2. Report how many were promoted (max 2)
+3. Report how many were rejected with reasons
+4. List promoted issue numbers with links
+
+**Example report**:
+
+```
+✓ Role Assumed: Champion
+✓ Work Completed: Evaluated 4 curated issues
+
+Promoted (2):
+- Issue #442: Add retry logic to API client
+  https://github.com/owner/repo/issues/442
+- Issue #445: Add worktree cleanup command
+  https://github.com/owner/repo/issues/445
+
+Rejected (2):
+- Issue #443: Needs specific performance metrics
+- Issue #444: Requires architectural discussion (too ambitious)
+
+✓ Next Steps: 2 issues ready for Builder, 2 issues await Curator revision
+```
+
+## Autonomous Operation
+
+This role is designed for **autonomous operation** with a recommended interval of **10-15 minutes**.
+
+**Default interval**: 600000ms (10 minutes)
+**Default prompt**: "Check for curated issues ready to promote to approved status"
+
+### Autonomous Behavior
+
+When running autonomously:
+1. Check for `loom:curated` issues
+2. Evaluate up to 2 issues (oldest first)
+3. Promote or reject with detailed comments
+4. Report results and stop
+
+### Quality Over Quantity
+
+**Conservative bias is intentional.** It's better to defer borderline issues than to flood the Builder queue with ambiguous work.
+
+## Label Workflow Integration
+
+```
+Issue Lifecycle with Champion:
+
+(created) → (unlabeled)
+              ↓
+          [Curator enhances]
+              ↓
+        loom:curated ←────────┐
+              ↓                │
+        [Champion evaluates]   │ [Rejected: needs work]
+              ↓                │
+         ✓ Promoted            │
+              ↓                │
+         loom:issue ───────────┘
+              ↓
+        [Builder claims]
+              ↓
+      loom:in-progress
+              ↓
+          (closed)
+```
+
+## Notes
+
+- **One iteration = one batch**: Evaluate available curated issues (max 2 promotions), then stop
+- **Transparency**: Always explain decisions in comments
+- **Conservative**: When unsure, don't promote
+- **Audit trail**: Every promotion/rejection gets a comment
+- **Human override**: Humans have final say on all decisions

--- a/.loom/roles/curator.md
+++ b/.loom/roles/curator.md
@@ -41,7 +41,7 @@ Use this command to find issues that need curation (already filters out claimed 
 # Find issues without suggestion labels, curated, issue, or in-progress
 # (These need curator enhancement)
 gh issue list --state=open --json number,title,labels \
-  --jq '.[] | select(([.labels[].name] | inside(["loom:curated", "loom:issue", "loom:in-progress"]) | not)) | "#\(.number) \(.title)"'
+  --jq '.[] | select(([.labels[].name] | inside(["loom:architect", "loom:hermit", "loom:curated", "loom:issue", "loom:in-progress"]) | not)) | "#\(.number) \(.title)"'
 ```
 
 Or simpler (may include some false positives):


### PR DESCRIPTION
## Summary

Fixed mismatches between installation templates in `defaults/` and the installed files in `.loom/`. This resolves the issue where `./clean.sh --help` was not showing the `--force` option that was added in PR #539.

## Changes

### File Syncing

1. **`defaults/scripts/clean.sh`** - Added missing `--force` option from PR #539
   - Added `FORCE` variable parsing
   - Added help text for `-f, --force` flag  
   - Added force mode logic for non-interactive prompts

2. **`.loom/roles/curator.md`** - Updated to match `defaults/` (from PR #529)
   - Fixed filter to include `loom:architect` and `loom:hermit` labels

3. **`.loom/roles/champion.{md,json}`** - Copied missing files from `defaults/`

### CI Workflow

Added `.github/workflows/check-sync-defaults.yml` to automatically detect future mismatches:
- Compares all files in `defaults/scripts/` vs `.loom/scripts/`
- Compares all files in `defaults/roles/` vs `.loom/roles/`
- Fails with detailed diff output if any files don't match
- Runs on PRs and pushes that touch these directories

## Why This Matters

The Loom repository uses `.loom/` for dogfooding (running Loom on itself), while `defaults/` contains the templates used when installing Loom into other repositories. When these get out of sync:
- Features added to one location don't work in the other
- The dogfooding experience differs from the installation experience
- Bugs can be fixed in one location but remain in the other

## Testing

```bash
# Verify --force option now shows in help
./clean.sh --help

# Run local sync check
for file in defaults/roles/*; do
  basename=$(basename "$file")
  diff -q "$file" ".loom/roles/$basename"
done
```

All files now match between `defaults/` and `.loom/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)