### PR TITLE
Fix install.sh failing on worktree creation

### DIFF
--- a/scripts/install/create-worktree.sh
+++ b/scripts/install/create-worktree.sh
@@ -57,7 +57,7 @@ while true; do
   # Clean up any existing local branch with this name
   if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
     info "Removing existing local branch: $BRANCH_NAME"
-    git branch -D "$BRANCH_NAME" 2>/dev/null || true
+    git branch -D "$BRANCH_NAME" >/dev/null 2>&1 || true
   fi
 
   # Try to create worktree with this branch name


### PR DESCRIPTION
## Summary

Fixes the installation script failing during worktree creation with error:
```
✗ Error: Invalid worktree path returned: Deleted branch feature/loom-installation (was 796c5fd).
.loom/worktrees/issue-542
```

## Root Cause

In `scripts/install/create-worktree.sh`, when deleting an existing branch before creating a worktree, the `git branch -D` command outputs "Deleted branch..." to stdout. This message gets captured by the parent script along with the worktree path, causing validation to fail.

## Changes

**File**: `scripts/install/create-worktree.sh:60`

```diff
- git branch -D "$BRANCH_NAME" 2>/dev/null || true
+ git branch -D "$BRANCH_NAME" >/dev/null 2>&1 || true
```

Redirects both stdout and stderr to `/dev/null` to suppress the deletion message.

## Testing

- ✅ Creates worktree when branch doesn't exist (clean output)
- ✅ Creates worktree when branch exists (deletion message suppressed)
- ✅ Output validation passes: `.loom/worktrees/issue-N|branch-name`
- ✅ Tested with multiple installation attempts

## Impact

- **Before**: Installation fails at "Create Worktree" step
- **After**: Installation completes successfully

This is a critical bug fix that unblocks installation for all users.