### PR TITLE
Fix installation script to handle idempotent installs gracefully

### DIFF
--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -322,6 +322,29 @@ fi
 PR_URL=$("$LOOM_ROOT/scripts/install/create-pr.sh" "$TARGET_PATH/$WORKTREE_PATH" "$ISSUE_NUMBER") || \
   error "Failed to create pull request"
 
+# Check if installation was already complete (no changes needed)
+if [[ "$PR_URL" == "NO_CHANGES_NEEDED" ]]; then
+  info "Loom is already installed - cleaning up..."
+
+  # Close the tracking issue
+  cd "$TARGET_PATH"
+  gh issue close "${ISSUE_NUMBER}" --comment "Loom is already installed. No changes needed." 2>/dev/null || true
+
+  # Remove the worktree
+  git worktree remove "${WORKTREE_PATH}" --force 2>/dev/null || true
+  git branch -D "${BRANCH_NAME}" 2>/dev/null || true
+
+  # Disable error trap and exit successfully
+  trap - EXIT
+
+  echo ""
+  success "Loom is already installed in this repository"
+  echo ""
+  info "No pull request was created because all files are up to date."
+  echo ""
+  exit 0
+fi
+
 if [[ ! "$PR_URL" =~ ^https:// ]]; then
   error "Invalid PR URL returned: $PR_URL"
 fi

--- a/scripts/install/create-pr.sh
+++ b/scripts/install/create-pr.sh
@@ -43,7 +43,11 @@ git add -A
 
 # Check if there are changes to commit
 if git diff --staged --quiet; then
-  error "No changes to commit"
+  info "No changes to commit - Loom is already installed"
+  info "Skipping commit and PR creation"
+  # Exit successfully with a special marker that the caller can detect
+  echo "NO_CHANGES_NEEDED"
+  exit 0
 fi
 
 # Create commit message


### PR DESCRIPTION
## Problem

The installation script was failing when run on a repository that already had Loom installed (e.g., running `install.sh` on the Loom repository itself). The error occurred at Step 6:

```
Step 6: Creating Pull Request

ℹ Committing Loom installation...
✗ Error: No changes to commit
✗ Error: Failed to create pull request
```

**Root cause**: When creating a worktree from `main` that already has Loom installed, `loom-daemon init` detects existing files and doesn't create changes, causing `create-pr.sh` to fail.

## Solution

Made the installation process truly **idempotent** by gracefully handling the case where Loom is already installed:

### Changes

1. **`scripts/install/create-pr.sh`**:
   - Detects when no changes exist after `git add -A`
   - Returns `NO_CHANGES_NEEDED` marker instead of erroring
   - Exits successfully with informative messages

2. **`scripts/install-loom.sh`**:
   - Checks for the `NO_CHANGES_NEEDED` marker
   - Closes the tracking issue with explanation: "Loom is already installed. No changes needed."
   - Cleans up the worktree and branch
   - Exits gracefully with success message

### Benefits

- ✅ Can run installation script multiple times safely
- ✅ No error when Loom is already installed
- ✅ Proper cleanup of tracking issue and worktree
- ✅ Clear messaging to users about what happened

### Testing

Verified by running `./scripts/install-loom.sh --yes .` on the Loom repository:
- Created tracking issue #551
- Detected no changes after init
- Closed issue #551 with explanation
- Cleaned up worktree and branch
- Exited successfully

## Use Cases

This fix is especially useful when:
- Installing Loom onto the Loom repository itself (for testing)
- Re-running installation after a failed attempt
- Testing the installation process repeatedly
- Users accidentally run the installer twice

🤖 Generated with Claude Code