### PR TITLE
Fix installation cleanup to handle interrupts (Ctrl+C)

### DIFF
--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -106,7 +106,7 @@ cleanup_on_error() {
   fi
 }
 
-trap cleanup_on_error EXIT
+trap cleanup_on_error EXIT SIGINT SIGTERM
 
 # Validate arguments
 if [[ -z "$TARGET_PATH" ]]; then
@@ -335,7 +335,7 @@ if [[ "$PR_URL" == "NO_CHANGES_NEEDED" ]]; then
   git branch -D "${BRANCH_NAME}" 2>/dev/null || true
 
   # Disable error trap and exit successfully
-  trap - EXIT
+  trap - EXIT SIGINT SIGTERM
 
   echo ""
   success "Loom is already installed in this repository"
@@ -358,7 +358,7 @@ echo ""
 CURRENT_STEP="Complete"
 
 # Disable error trap - we completed successfully
-trap - EXIT
+trap - EXIT SIGINT SIGTERM
 
 echo ""
 header "╔═══════════════════════════════════════════════════════════╗"


### PR DESCRIPTION
## Summary

Fixes #554 - Installation cleanup now properly handles user interrupts (Ctrl+C) and process termination signals.

## Problem

The installation script `scripts/install-loom.sh` only trapped EXIT signals. If a user pressed Ctrl+C (SIGINT) or the process was killed (SIGTERM) during installation, the cleanup function wouldn't run, potentially leaving behind:
- Unclosed GitHub tracking issues
- Stray git worktrees and branches

## Solution

Added SIGINT and SIGTERM to the trap handler so cleanup runs on:
- Script errors (EXIT)
- User interrupt via Ctrl+C (SIGINT)
- Process termination (SIGTERM)

## Changes

Updated `scripts/install-loom.sh`:
1. Line 109: Changed `trap cleanup_on_error EXIT` → `trap cleanup_on_error EXIT SIGINT SIGTERM`
2. Line 338: Changed `trap - EXIT` → `trap - EXIT SIGINT SIGTERM`
3. Line 361: Changed `trap - EXIT` → `trap - EXIT SIGINT SIGTERM`

## Test Plan

- [x] Verified trap handles EXIT, SIGINT, and SIGTERM
- [x] All trap removal statements updated consistently
- [x] Created and ran test script simulating abort scenarios
- [x] Confirmed cleanup properly triggers on interrupt

## Testing

Created `/tmp/test-cleanup-abort.sh` to simulate installation abort and verified that the cleanup function:
- Detects the issue number that was created
- Would close the tracking issue with explanatory comment
- Would remove the installation worktree
- Would delete the feature branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)