### PR TITLE
Include commit hash in PR title during installation

### DIFF
--- a/scripts/install/create-pr.sh
+++ b/scripts/install/create-pr.sh
@@ -115,7 +115,7 @@ EOF
 # Create pull request
 # Output goes to stderr so it doesn't interfere with URL capture
 PR_OUTPUT=$(gh pr create \
-  --title "Install Loom ${LOOM_VERSION}" \
+  --title "Install Loom ${LOOM_VERSION} (${LOOM_COMMIT})" \
   --body "$PR_BODY" \
   --label "loom:review-requested" 2>&1)
 


### PR DESCRIPTION
## Summary

Include commit hash in PR title during Loom installation to match issue title format and improve traceability.

## Problem

During Loom installation on target repositories, the issue title includes the commit hash but the PR title does not:

- **Issue title**: `Install Loom 0.1.0 (abc1234)` ✅
- **PR title**: `Install Loom 0.1.0` ❌

This inconsistency makes it harder to track which exact Loom version was installed when looking at PRs.

## Changes

- Modified `scripts/install/create-pr.sh` line 118
- Changed PR title from `Install Loom ${LOOM_VERSION}` to `Install Loom ${LOOM_VERSION} (${LOOM_COMMIT})`
- PR title now matches issue title format exactly

## Test Plan

✅ Verified linting and formatting checks pass
✅ Change is a single-line shell script modification
✅ No code logic changes, only string formatting

The change will be fully tested when the next Loom installation runs on a target repository, where both issue and PR titles will include the commit hash.

## Impact

- ✅ Better traceability for installations
- ✅ Consistency between issue and PR titles
- ✅ Easier debugging of installation-related issues
- ✅ Clear audit trail in repository history

Closes #549