### PR TITLE
Change loom:architect and loom:hermit label colors to purple

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -23,11 +23,11 @@
 # Agent Proposal Labels
 - name: loom:architect
   description: Architect proposal awaiting user approval
-  color: "3B82F6"  # blue-500
+  color: "9333EA"  # purple-600
 
 - name: loom:hermit
   description: Hermit removal/simplification proposal awaiting user approval
-  color: "3B82F6"  # blue-500
+  color: "9333EA"  # purple-600
 
 - name: loom:curated
   description: Enhanced by Curator, awaiting human approval


### PR DESCRIPTION
## Summary

Changes `loom:architect` and `loom:hermit` label colors from blue to purple to improve visual distinction in GitHub UI.

## Problem

The proposal labels (`loom:architect`, `loom:hermit`) currently use blue color (#3B82F6), which is identical to action-required labels like `loom:issue` and `loom:pr`. This creates visual confusion:

- **Blue** signals "approved for work" / "ready for action"
- **Proposal labels** are actually "awaiting human approval" / "informational"

Users couldn't visually distinguish between approved work and pending proposals.

## Solution

Updated both labels to purple (#9333EA):
- Visually distinct from blue action labels
- Signals "under review" / "pending approval" state
- Maintains consistency (both proposal types use same color)

## Changes

- `.github/labels.yml`: Changed `loom:architect` color to `9333EA` (purple-600)
- `.github/labels.yml`: Changed `loom:hermit` color to `9333EA` (purple-600)
- Applied label changes to GitHub using `gh label edit`

## Test Plan

✅ Verified label colors in GitHub CLI: `gh label list | grep "loom:architect\|loom:hermit"`
✅ Confirmed purple color (#9333EA) appears for both labels
✅ Checked visual distinction from blue action labels
✅ Biome lint checks pass

**Note**: Build failure is unrelated - caused by missing `loom-daemon` binary, not this YAML change.

## Label Color Semantics

After this change:
- **Blue** (#3B82F6): Action required - `loom:issue`, `loom:pr`
- **Purple** (#9333EA): Proposal/review - `loom:architect`, `loom:hermit` ← NEW!
- **Orange** (#F59E0B): In progress - `loom:in-progress`
- **Green** (#10B981): Curated - `loom:curated`
- **Red** (#EF4444): Blocked - `loom:blocked`

Closes #541