### PR TITLE
Add follow-up issue creation workflow to Judge role

### DIFF
--- a/.loom/roles/judge.md
+++ b/.loom/roles/judge.md
@@ -286,6 +286,84 @@ EOF
 )"
 ```
 
+## Creating Follow-Up Issues
+
+When reviewing PRs, you may approve code that is functional and correct, but identify opportunities for non-blocking improvements (refactoring, documentation, performance optimizations, etc.). Rather than letting these suggestions get lost in PR comments, create follow-up issues to track them.
+
+### When to Create Follow-Up Issues
+
+**Create follow-up issues for:**
+- Non-blocking improvements (refactoring, optimization)
+- Documentation enhancements
+- Future feature additions suggested by the PR
+- Technical debt discovered during review
+- Minor quality improvements not worth blocking the PR
+
+**Do NOT create follow-up issues for:**
+- Blocking issues (use "Changes Requested" instead)
+- Critical bugs (request changes to fix in current PR)
+- Issues already tracked elsewhere
+
+### How to Create Follow-Up Issues
+
+After deciding to approve a PR, but before adding the `loom:pr` label:
+
+```bash
+# Create unlabeled follow-up issue (Curator will enhance it)
+gh issue create --title "Add rate limiting to login endpoint" --body "$(cat <<'EOF'
+## Follow-up from PR #123
+
+While reviewing the authentication implementation in PR #123, identified an opportunity to add rate limiting to the login endpoint.
+
+**Suggested approach:**
+- Use existing rate-limit middleware
+- Apply 5 attempts per 15 minutes per IP
+- Return 429 status code when exceeded
+
+**Context**: PR #123 successfully implements core authentication, but rate limiting would improve security against brute-force attacks.
+EOF
+)"
+
+# Create additional follow-up issues as needed
+gh issue create --title "Document password reset flow in README" --body "..."
+
+# Then proceed with PR approval
+gh pr comment 123 --body "$(cat <<'EOF'
+✅ **Approved!** Authentication implementation is solid.
+
+Created follow-up issues for suggested improvements:
+- #124: Add rate limiting to login endpoint
+- #125: Document password reset flow in README
+
+Code quality is excellent, tests pass, ready to merge.
+EOF
+)"
+gh pr edit 123 --remove-label "loom:review-requested" --add-label "loom:pr"
+```
+
+### Follow-Up Issue Template
+
+Use this format for consistency:
+
+```markdown
+## Follow-up from PR #XXX
+
+[Brief description of the improvement opportunity]
+
+**Suggested approach:**
+- [Specific recommendation 1]
+- [Specific recommendation 2]
+
+**Context**: [Why this came up during review, why it wasn't blocking]
+```
+
+### Important Notes
+
+- **Create as unlabeled issues**: Curator will enhance them with full specs
+- **Reference the PR**: Always include "Follow-up from PR #XXX" in the body
+- **Be specific**: Provide enough context for Curator/Builder to understand
+- **Don't over-create**: Only track improvements that add real value
+
 ## Example Commands
 
 ```bash


### PR DESCRIPTION
## Summary

Adds documentation to the Judge role for creating follow-up issues during PR reviews. This ensures non-blocking improvement suggestions don't get lost in PR comments.

## Changes

- Added new "Creating Follow-Up Issues" section to `.loom/roles/judge.md`
- Documented when to create follow-up issues vs. request changes
- Provided clear examples and consistent template format
- Follow-up issues reference the originating PR for traceability
- Issues created as unlabeled for Curator to enhance

## Implementation Approach

Implemented **Option 3: Manual Process Documentation** from the issue enhancement:
- No code changes required
- Judges manually create follow-up issues as needed
- Full flexibility for Judge to decide what warrants tracking
- Simplest approach with immediate value

## Test Plan

- [x] Verified `.loom/roles/judge.md` passes Biome linting
- [x] Reviewed section placement (after "Raising Concerns", before "Example Commands")
- [x] Confirmed examples use proper markdown formatting
- [x] Template format matches existing issue creation patterns in role

## Documentation Quality

The new section includes:
- ✅ Clear guidance on when to create follow-up issues
- ✅ Practical examples with actual bash commands
- ✅ Consistent issue template for Judge to use
- ✅ Important notes about labeling and specificity

Closes #531