### PR TITLE
Update design doc label colors from blue to purple

### DIFF
--- a/docs/design/issue-332-label-state-machine.md
+++ b/docs/design/issue-332-label-state-machine.md
@@ -23,7 +23,7 @@ The current label workflow has several issues:
 
 | Label | Color | Set By | Meaning |
 |-------|-------|--------|---------|
-| `loom:architect` | 🔵 #3B82F6 | Architect | Proposal awaiting human review |
+| `loom:architect` | 🟣 #9333EA | Architect | Proposal awaiting human review |
 | `loom:hermit` | 🟣 #9333EA | Critic | Removal/simplification awaiting review |
 | `loom:curated` | 🟢 #10B981 | Curator | Enhanced with implementation details |
 | `loom:issue` | 🔵 #3B82F6 | **Human** | **Approved for work** (replaces `loom:ready`) |
@@ -227,7 +227,7 @@ The current label workflow has several issues:
 
 ```bash
 # Create new labels
-gh label create "loom:architect" --color "3B82F6" --description "Architect proposal awaiting human review"
+gh label create "loom:architect" --color "9333EA" --description "Architect proposal awaiting human review"
 gh label create "loom:curated" --color "10B981" --description "Enhanced by Curator, awaiting human approval"
 gh label edit "loom:issue" --color "3B82F6" --description "Approved for work by human (replaces loom:ready)"
 ```


### PR DESCRIPTION
## Summary

Updates the label state machine design document to reflect the purple color change for `loom:architect` and `loom:hermit` labels that was implemented in PR #557.

## Changes

- **Line 26**: Changed `loom:architect` from 🔵 #3B82F6 to 🟣 #9333EA
- **Line 230**: Updated migration command to use purple color (#9333EA)
- Both proposal labels now consistently show purple in documentation

## Context

PR #557 successfully changed these label colors in `.github/labels.yml` and applied them to GitHub, but the design documentation still referenced the old blue color. This PR brings the documentation into sync with the actual implementation.

## Verification

Verified consistency with source of truth:
```bash
$ gh label list | grep -E "loom:architect|loom:hermit"
loom:architect  Architect proposal awaiting user approval  #9333EA
loom:hermit     Hermit removal/simplification proposal      #9333EA
```

Both labels correctly show purple (#9333EA) in GitHub.

## Files Modified

- `docs/design/issue-332-label-state-machine.md` (2 changes)
  - Line 26: Label color table
  - Line 230: Migration command example

Closes #560