### PR TITLE
Add follow-up issue creation guidance to Judge role

### DIFF
--- a/defaults/roles/judge.md
+++ b/defaults/roles/judge.md
@@ -246,6 +246,65 @@ gh pr edit 42 --remove-label "loom:review-requested" --add-label "loom:pr"
   - If approved: Remove `loom:review-requested`, add `loom:pr` (blue badge)
   - If changes needed: Remove `loom:review-requested`, add `loom:changes-requested` (amber badge)
 
+## Handling Minor Concerns
+
+When you identify issues during review, take concrete action - never leave concerns as "notes for future" without creating an issue.
+
+### Decision Framework
+
+**If the concern should block merge:**
+- Request changes with specific guidance
+- Remove `loom:review-requested`, add `loom:changes-requested`
+- Include clear explanation of what needs fixing
+
+**If the concern is minor but worth tracking:**
+1. Create a follow-up issue to track the work
+2. Reference the new issue in your approval comment
+3. Approve the PR and add `loom:pr` label
+
+**If the concern is not worth tracking:**
+- Don't mention it in the review at all
+
+**Never leave concerns as "note for future"** - they will be forgotten and undermine code quality over time.
+
+### Creating Follow-up Issues
+
+**When to create follow-up issues:**
+- Documentation inconsistencies (like outdated color references)
+- Minor refactoring opportunities (not critical but would improve code)
+- Test coverage gaps (existing tests pass but could be more comprehensive)
+- Non-critical bugs (workarounds exist, low impact)
+
+**Example workflow:**
+```bash
+# Judge finds minor documentation issue during review
+# Instead of just noting it, create an issue:
+
+gh issue create --title "Update design doc to reflect new label colors" --body "$(cat <<'EOF'
+While reviewing PR #557, noticed that `docs/design/issue-332-label-state-machine.md:26`
+still references `loom:architect` as blue (#3B82F6) when it should be purple (#9333EA).
+
+## Changes Needed
+- Line 26: Update `loom:architect` color from blue to purple
+- Verify all color references are consistent with `.github/labels.yml`
+
+Discovered during code review of PR #557.
+EOF
+)"
+
+# Then approve with reference to the issue
+gh pr comment 557 --body "✅ **Approved!** Created #XXX to track documentation update. Code quality is excellent."
+gh pr edit 557 --remove-label "loom:review-requested" --add-label "loom:pr"
+```
+
+### Benefits
+
+- ✅ **No forgotten concerns**: Every issue gets tracked
+- ✅ **Clear expectations**: You must decide if concern is blocking or not
+- ✅ **Better backlog**: Minor issues populate the backlog for future work
+- ✅ **Accountability**: Follow-up work is visible and trackable
+- ✅ **Faster reviews**: Don't block PRs on minor concerns, track them instead
+
 ## Raising Concerns
 
 During code review, you may discover bugs or issues that aren't related to the current PR:


### PR DESCRIPTION
## Summary

Adds guidance to the Judge role definition for handling minor concerns discovered during code review with concrete action rather than vague "notes for future."

## Problem

During review of PR #557, the Judge identified a documentation inconsistency but only noted it as "Note for future cleanup" without taking concrete action. This creates a risk that concerns will be forgotten, undermining code quality over time.

**Current behavior:**
- Judge notes concern but doesn't create issue or request changes
- Concern gets forgotten
- Code quality degrades

## Solution

Add "Handling Minor Concerns" section to Judge role definition (`defaults/roles/judge.md`) with:

### Decision Framework
Judges must choose ONE of three options when identifying concerns:

1. **Block merge** - Request changes with specific guidance
2. **Create follow-up issue** - Track minor concern for future work  
3. **Don't mention** - If truly not worth tracking

**Never leave concerns as "notes for future"** without creating an issue.

### Creating Follow-up Issues

Provides example workflow:
```bash
# Create issue for minor concern
gh issue create --title "..." --body "..."

# Reference in approval
gh pr comment <number> --body "✅ **Approved!** Created #XXX to track..."
gh pr edit <number> --remove-label "loom:review-requested" --add-label "loom:pr"
```

## Benefits

- ✅ **No forgotten concerns**: Every issue gets tracked
- ✅ **Clear expectations**: Judge must decide if concern is blocking
- ✅ **Better backlog**: Minor issues populate backlog for future work
- ✅ **Accountability**: Follow-up work visible and trackable
- ✅ **Faster reviews**: Don't block PRs on minor concerns

## Changes

- **1 file modified**: `defaults/roles/judge.md` (+59 lines)
- Added "Handling Minor Concerns" section after "Feedback Style"
- Includes decision framework, example workflow, and benefits

## Test Plan

✅ Documentation change only - no code to test
✅ Biome lint checks pass
✅ Clear guidance for Judges on handling minor concerns
✅ Example matches real scenario from PR #557 (which created issue #560)

## Impact

**Before**: 
- Judge notes concern as "note for future cleanup"
- Concern is forgotten
- Example: PR #557 documentation inconsistency

**After**:
- Judge creates issue for minor concern (like issue #560)
- Concern is tracked and implemented (like PR #564)
- Clear process prevents forgotten concerns

Closes #559