### PR TITLE
Add config schema versioning for safe future migrations

### DIFF
--- a/defaults/config.json
+++ b/defaults/config.json
@@ -1,4 +1,5 @@
 {
+  "version": "2",
   "offlineMode": false,
   "terminals": [
     {

--- a/docs/guides/architecture-patterns.md
+++ b/docs/guides/architecture-patterns.md
@@ -158,6 +158,7 @@ Loom stores workspace-specific configuration in `.loom/config.json` within each 
 
 ```json
 {
+  "version": "2",
   "nextAgentNumber": 4,
   "agents": [
     {
@@ -182,6 +183,63 @@ Loom stores workspace-specific configuration in `.loom/config.json` within each 
   ]
 }
 ```
+
+**Config Versioning**:
+
+Loom uses an explicit `version` field to enable safe future migrations:
+
+- **Current version**: `"2"` (string literal, not number)
+- **Migration**: Happens automatically when loading config files
+- **v1 → v2**: Detects configs missing `version` field or with `"version": "1"`
+- **Future-proof**: Unknown versions throw clear error prompting user to upgrade Loom
+
+**Example Migration**:
+```typescript
+// Old config (v1) without version field
+{
+  "nextAgentNumber": 4,
+  "agents": [...]
+}
+
+// Automatically migrated to v2 on load
+{
+  "version": "2",
+  "nextAgentNumber": 4,
+  "agents": [...]
+}
+
+// Config auto-saved with version after migration
+```
+
+**Adding Future Versions** (example for v3):
+
+When config schema changes:
+
+1. Add new migration function in `src/lib/config.ts`:
+   ```typescript
+   function migrateFromV2(raw: unknown): LoomConfig {
+     const v2 = raw as V2Config;
+
+     // Transform v2 → v3 (e.g., rename field, add new required field)
+     return {
+       version: "3",
+       terminals: v2.agents.map(transformAgent),
+       // ... new fields ...
+     };
+   }
+   ```
+
+2. Update `migrateToLatest()` switch:
+   ```typescript
+   switch (version) {
+     case "1": return migrateFromV2(migrateFromV1(raw));
+     case "2": return migrateFromV2(raw);
+     case "3": return raw as LoomConfig;
+     default: throw new Error(`Unsupported version "${version}"`);
+   }
+   ```
+
+3. Update version constant and save logic to use `"3"`
 
 **Why Workspace-Specific Config?**
 - Each git repo has independent agent numbering and terminal configurations


### PR DESCRIPTION
## Summary

Implements explicit config schema versioning to enable safe future migrations as requested in #242.

**Key Changes:**
- Added `version: "2"` field to `LoomConfig` interface (string literal type)
- Implemented automatic v1 → v2 migration on config load
- Configs without version field or with `"version": "1"` are auto-migrated
- Unknown versions throw clear error prompting user to upgrade Loom
- Auto-saves migrated configs to persist version field

**Migration Logic:**
- `migrateFromV1()`: Transforms v1 configs to v2 format
- `migrateToLatest()`: Switch-based version router for future extensibility
- `loadConfig()`: Detects version, migrates if needed, saves if changed
- `saveConfig()`: Always ensures version "2" is present

**Testing:**
- Added 8 comprehensive unit tests covering all migration scenarios
- All config tests pass (29/29)
- Tests cover: v1→v2 migration, explicit v1, v2 no-op, future version rejection, missing version, field preservation, saveConfig versioning, empty workspace

**Documentation:**
- Updated CLAUDE.md with Config Versioning section
- Updated architecture-patterns.md to match
- Includes example for adding future versions (v3)
- Documents automatic migration behavior

**Future Extensibility:**
The version system is designed for easy extension. To add v3:
1. Add `migrateFromV2()` function
2. Update `migrateToLatest()` switch case
3. Update version constant to "3"

See documentation for complete example.

## Test plan

- [x] All config unit tests pass (29/29)
- [x] v1 → v2 migration tested
- [x] v2 no-op tested
- [x] Future version rejection tested
- [x] Field preservation during migration tested
- [x] Documentation updated
- [ ] Manual test: Load workspace with v1 config, verify auto-migration
- [ ] Manual test: Verify migrated config saves with version field

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)