### PR TITLE
Remove unused getCurrentTheme() function from theme.ts

### DIFF
--- a/src/lib/theme.test.ts
+++ b/src/lib/theme.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { getCurrentTheme, initTheme, toggleTheme } from "./theme";
+import { initTheme, toggleTheme } from "./theme";
 
 describe("theme", () => {
   let matchMediaMock: any;
@@ -100,66 +100,52 @@ describe("theme", () => {
       document.documentElement.classList.remove("dark");
 
       toggleTheme(); // light -> dark
-      expect(getCurrentTheme()).toBe("dark");
+      expect(document.documentElement.classList.contains("dark")).toBe(true);
 
       toggleTheme(); // dark -> light
-      expect(getCurrentTheme()).toBe("light");
+      expect(document.documentElement.classList.contains("dark")).toBe(false);
 
       toggleTheme(); // light -> dark
-      expect(getCurrentTheme()).toBe("dark");
-    });
-  });
-
-  describe("getCurrentTheme", () => {
-    it("returns 'dark' when dark class is present", () => {
-      document.documentElement.classList.add("dark");
-
-      expect(getCurrentTheme()).toBe("dark");
-    });
-
-    it("returns 'light' when dark class is absent", () => {
-      document.documentElement.classList.remove("dark");
-
-      expect(getCurrentTheme()).toBe("light");
+      expect(document.documentElement.classList.contains("dark")).toBe(true);
     });
   });
 
   describe("integration", () => {
-    it("initTheme and getCurrentTheme work together", () => {
+    it("initTheme sets dark class correctly", () => {
       localStorage.setItem("theme", "dark");
       matchMediaMock.mockReturnValue({ matches: false });
 
       initTheme();
 
-      expect(getCurrentTheme()).toBe("dark");
+      expect(document.documentElement.classList.contains("dark")).toBe(true);
     });
 
-    it("toggleTheme and getCurrentTheme work together", () => {
+    it("toggleTheme updates dark class correctly", () => {
       document.documentElement.classList.remove("dark");
 
-      expect(getCurrentTheme()).toBe("light");
+      expect(document.documentElement.classList.contains("dark")).toBe(false);
 
       toggleTheme();
 
-      expect(getCurrentTheme()).toBe("dark");
+      expect(document.documentElement.classList.contains("dark")).toBe(true);
 
       toggleTheme();
 
-      expect(getCurrentTheme()).toBe("light");
+      expect(document.documentElement.classList.contains("dark")).toBe(false);
     });
 
-    it("full workflow: init -> toggle -> getCurrentTheme", () => {
+    it("full workflow: init -> toggle -> check dark class", () => {
       localStorage.setItem("theme", "light");
       matchMediaMock.mockReturnValue({ matches: false });
 
       initTheme();
-      expect(getCurrentTheme()).toBe("light");
+      expect(document.documentElement.classList.contains("dark")).toBe(false);
 
       toggleTheme();
-      expect(getCurrentTheme()).toBe("dark");
+      expect(document.documentElement.classList.contains("dark")).toBe(true);
 
       toggleTheme();
-      expect(getCurrentTheme()).toBe("light");
+      expect(document.documentElement.classList.contains("dark")).toBe(false);
     });
   });
 });

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -10,7 +10,3 @@ export function toggleTheme(): void {
   const isDark = document.documentElement.classList.toggle("dark");
   localStorage.setItem("theme", isDark ? "dark" : "light");
 }
-
-export function getCurrentTheme(): "dark" | "light" {
-  return document.documentElement.classList.contains("dark") ? "dark" : "light";
-}


### PR DESCRIPTION
## Summary

Removes the unused `getCurrentTheme()` export function from `theme.ts` that was only used in tests.

## Changes

**src/lib/theme.ts**:
- Removed `getCurrentTheme()` function (lines 14-16)

**src/lib/theme.test.ts**:
- Removed `getCurrentTheme` from import statement
- Updated all test assertions to directly check `document.documentElement.classList.contains("dark")`
- Removed dedicated `getCurrentTheme` test suite (was redundant with DOM checks)
- Updated integration test descriptions to reflect direct DOM checking
- Simplified test logic - now clearer and more direct

## Rationale

This function was exported but **never used in production code** (verified via ripgrep):
- Only appeared in test file imports
- Tests can directly check DOM state instead of using a wrapper
- Direct DOM checks are actually clearer: `expect(document.documentElement.classList.contains("dark")).toBe(true)`

## Benefits

- **API Surface**: Reduces exported API (simpler public interface)
- **Test Clarity**: Direct DOM checks are clearer than wrapper function
- **Maintenance**: One less function to maintain and document
- **Lines of Code**: Removed 3 lines from theme.ts, simplified test imports

## Testing

✅ All 12 tests still passing after changes:
- `initTheme` tests (5 tests) - unchanged, still passing
- `toggleTheme` tests (4 tests) - updated to check DOM directly, still passing
- Integration tests (3 tests) - updated to check DOM directly, still passing

```bash
pnpm test:unit src/lib/theme.test.ts
# ✓ 12 passed (12)
```

✅ Linting passes for changed files:
```bash
pnpm biome check src/lib/theme.ts src/lib/theme.test.ts
# Checked 2 files in 12ms. No fixes applied.
```

✅ No remaining usage of `getCurrentTheme`:
```bash
rg "getCurrentTheme" --type ts
# (no results)
```

## Risk Assessment

**Risk Level**: Low

- Function never used in production code
- All tests still pass with direct DOM checks
- No breaking changes for external consumers

Closes #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)