### PR TITLE
Update Curator and Healer roles to use role-specific labels

### DIFF
--- a/defaults/roles/curator.md
+++ b/defaults/roles/curator.md
@@ -22,7 +22,7 @@ The workflow with two-gate approval:
 - **User approves Architect**: Adds `loom:issue` label to architect suggestions (or closes to reject)
 - **You process**: Find issues needing enhancement, improve them, then add `loom:curated`
 - **User approves Curator**: Adds `loom:issue` label to curated issues (human approval required)
-- **Worker implements**: Picks up `loom:issue` issues and changes to `loom:in-progress`
+- **Worker implements**: Picks up `loom:issue` issues and changes to `loom:building`
 - **Worker completes**: Creates PR and closes issue (or marks `loom:blocked` if stuck)
 
 **CRITICAL**: You mark issues as `loom:curated` after enhancement. You do NOT add `loom:issue` - only humans can approve work for implementation.
@@ -55,9 +55,7 @@ If no Priority 1 issues exist, find unlabeled issues:
 
 ```bash
 gh issue list --state=open --json number,title,labels \
-  --jq '.[] | select(([.labels[].name] |
-  inside(["loom:architect", "loom:hermit", "loom:curated", "loom:issue", "loom:in-progress", "external"]) | not)) |
-  "#\(.number): \(.title)"'
+  --jq '.[] | select(([.labels[].name] | inside(["loom:architect", "loom:hermit", "loom:curated", "loom:issue", "loom:curating", "external"]) | not)) | "#\(.number) \(.title)"'
 ```
 
 **Workflow**:
@@ -72,7 +70,7 @@ gh issue list --state=open --json number,title,labels \
 
 ```bash
 # Claim the issue before starting enhancement
-gh issue edit <number> --add-label "loom:in-progress"
+gh issue edit <number> --add-label "loom:curating"
 ```
 
 This signals to other Curators that you're working on this issue. The search command above already filters out claimed issues, so you won't see issues other Curators are enhancing.
@@ -94,8 +92,8 @@ When you find an unlabeled issue, **first assess if it's already implementation-
 ✅ **Mark it `loom:curated` immediately** - the issue is already well-formed:
 
 ```bash
-# Signal completion by removing in-progress and adding curated
-gh issue edit <number> --remove-label "loom:in-progress" --add-label "loom:curated"
+# Signal completion by removing curating and adding curated
+gh issue edit <number> --remove-label "loom:curating" --add-label "loom:curated"
 ```
 
 **IMPORTANT**: Do NOT add `loom:issue` - only humans can approve work for implementation.
@@ -119,7 +117,7 @@ Issue #84: "Expand frontend unit test coverage"
 - ✅ Includes test plan (Phase 1, 2, 3 approach)
 - ✅ No dependencies mentioned
 
-→ Action: `gh issue edit 84 --remove-label "loom:in-progress" --add-label "loom:curated"`
+→ Action: `gh issue edit 84 --remove-label "loom:curating" --add-label "loom:curated"`
 → Result: Awaits human approval (`loom:issue`) before Worker can start
 ```
 
@@ -210,7 +208,7 @@ EOF
 )"
 
 # 3. Mark as curated and unclaim (human will approve with loom:issue)
-gh issue edit 100 --remove-label "loom:in-progress" --add-label "loom:curated"
+gh issue edit 100 --remove-label "loom:curating" --add-label "loom:curated"
 ```
 
 ### When to Amend Description (Improve Original)
@@ -321,8 +319,8 @@ gh issue edit <number> --add-label "loom:blocked"
 ### When Dependencies Complete
 
 GitHub automatically checks boxes when issues close. When you see all boxes checked:
-1. Claim the issue if not already claimed: `gh issue edit <number> --add-label "loom:in-progress"`
-2. Remove `loom:blocked` label and add `loom:curated`: `gh issue edit <number> --remove-label "loom:blocked" --remove-label "loom:in-progress" --add-label "loom:curated"`
+1. Claim the issue if not already claimed: `gh issue edit <number> --add-label "loom:curating"`
+2. Remove `loom:blocked` label and add `loom:curated`: `gh issue edit <number> --remove-label "loom:blocked" --remove-label "loom:curating" --add-label "loom:curated"`
 3. Issue awaits human approval (`loom:issue`) before Workers can claim
 
 ## Issue Quality Checklist
@@ -345,13 +343,13 @@ Before marking an issue as `loom:curated`, ensure it has:
 - **Find work**: See "Finding Work" section above for commands
 - **Claim the issue**: Before starting enhancement work
   ```bash
-  gh issue edit <number> --add-label "loom:in-progress"
+  gh issue edit <number> --add-label "loom:curating"
   ```
 - **Review issue**: Read description, check code references, understand context
 - **Enhance issue**: Add missing details, implementation options, test plans
 - **Mark curated and unclaim** (NOT approved for work):
   ```bash
-  gh issue edit <number> --remove-label "loom:in-progress" --add-label "loom:curated"
+  gh issue edit <number> --remove-label "loom:curating" --add-label "loom:curated"
   ```
 - **NEVER add `loom:issue`**: Only humans can approve work for implementation
 - **Monitor workflow**: Check for `loom:blocked` issues that need help

--- a/defaults/roles/healer.md
+++ b/defaults/roles/healer.md
@@ -26,7 +26,7 @@ Healers prioritize work in the following order:
 **Find approved PRs with merge conflicts that aren't already claimed:**
 ```bash
 gh pr list --label="loom:approved" --state=open --search "is:open conflicts:>0" --json number,title,labels \
-  | jq -r '.[] | select(.labels | all(.name != "loom:in-progress")) | "#\(.number): \(.title)"'
+  | jq -r '.[] | select(.labels | all(.name != "loom:healing")) | "#\(.number): \(.title)"'
 ```
 
 **Why highest priority?**
@@ -39,7 +39,7 @@ gh pr list --label="loom:approved" --state=open --search "is:open conflicts:>0" 
 **Find PRs with review feedback that aren't already claimed:**
 ```bash
 gh pr list --label="loom:changes-requested" --state=open --json number,title,labels \
-  | jq -r '.[] | select(.labels | all(.name != "loom:in-progress")) | "#\(.number): \(.title)"'
+  | jq -r '.[] | select(.labels | all(.name != "loom:healing")) | "#\(.number): \(.title)"'
 ```
 
 ### Other PRs Needing Attention
@@ -57,9 +57,9 @@ gh pr list --state=open
 ## Work Process
 
 1. **Find PRs needing attention**: Look for `loom:changes-requested` label that aren't already claimed (see above)
-2. **Claim the PR**: Add `loom:in-progress` to prevent duplicate work
+2. **Claim the PR**: Add `loom:healing` to prevent duplicate work
    ```bash
-   gh pr edit <number> --add-label "loom:in-progress"
+   gh pr edit <number> --add-label "loom:healing"
    ```
 3. **Check PR details**: `gh pr view <number>` - look for "Changes requested" reviews or conflicts
 4. **Read feedback**: Understand what the reviewer is asking for
@@ -72,7 +72,7 @@ gh pr list --state=open
 7. **Verify quality**: Run `pnpm check:ci` to ensure all checks pass
 8. **Commit and push**: Push your fixes to the PR branch
 9. **Signal completion and unclaim**:
-   - Remove `loom:changes-requested` and `loom:in-progress` labels
+   - Remove `loom:changes-requested` and `loom:healing` labels
    - Add `loom:review-requested` label (green badge)
    - Comment to notify reviewer that feedback is addressed
 
@@ -162,13 +162,13 @@ pnpm exec tsc --noEmit # If review mentioned types
 ```bash
 # Find PRs with changes requested that aren't already claimed
 gh pr list --label="loom:changes-requested" --state=open --json number,title,labels \
-  | jq -r '.[] | select(.labels | all(.name != "loom:in-progress")) | "#\(.number): \(.title)"'
+  | jq -r '.[] | select(.labels | all(.name != "loom:healing")) | "#\(.number): \(.title)"'
 
 # Find PRs with merge conflicts
 gh pr list --state=open --search "is:open conflicts:>0"
 
 # Claim the PR before starting work
-gh pr edit 42 --add-label "loom:in-progress"
+gh pr edit 42 --add-label "loom:healing"
 
 # View PR details and review status
 gh pr view 42
@@ -195,7 +195,7 @@ git commit -m "Address review feedback
 git push
 
 # Signal completion and unclaim (amber → green, remove in-progress)
-gh pr edit 42 --remove-label "loom:changes-requested" --remove-label "loom:in-progress" --add-label "loom:review-requested"
+gh pr edit 42 --remove-label "loom:changes-requested" --remove-label "loom:healing" --add-label "loom:review-requested"
 gh pr comment 42 --body "✅ Review feedback addressed:
 - Fixed null handling in foo.ts:15
 - Added test case for error condition


### PR DESCRIPTION
## Summary

Update Curator and Healer role definitions to use role-specific labels instead of the generic `loom:in-progress` label. This provides clearer workflow visibility and enables better tracking of which role is working on each issue/PR.

## Changes

### Curator Role (`defaults/roles/curator.md`)
- Replaced all `loom:in-progress` references with `loom:curating` (9 occurrences)
- Updated workflow examples and command snippets
- Updated search/filter commands to exclude `loom:curating` instead of `loom:in-progress`

### Healer Role (`defaults/roles/healer.md`)
- Replaced all `loom:in-progress` references with `loom:healing` (8 occurrences)
- Updated PR claiming workflow
- Updated completion workflow to remove `loom:healing` label

## Verification

- ✅ No `loom:in-progress` references remain in Curator role file
- ✅ No `loom:in-progress` references remain in Healer role file
- ✅ Biome linting passes clean
- ✅ Documentation-only changes (no code modifications)

## Context

Part of the role-specific label workflow initiative:
- #567: Labels created in GitHub repository
- #568: Builder role updated to use `loom:building`
- #569: This PR (Curator and Healer updates)
- #570: Documentation updates (pending)

## Benefits

- **Role Visibility**: Immediately clear which role is working on an issue/PR
- **Workflow Clarity**: `loom:curating` shows Curator enhancement in progress
- **Better Monitoring**: Can track Curator/Healer activity separately from other roles
- **Consistency**: Aligns with Builder's `loom:building` label pattern

Closes #569

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>