### PR TITLE
Update Builder role to use loom:building label

### DIFF
--- a/.loom/roles/builder.md
+++ b/.loom/roles/builder.md
@@ -26,7 +26,7 @@ You help with general development tasks including:
 - **Find work**: `gh issue list --label="loom:issue" --state=open` (sorted oldest-first)
 - **Pick oldest**: Always choose the oldest `loom:issue` issue first (FIFO queue)
 - **Check dependencies**: Verify all task list items are checked before claiming
-- **Claim issue**: `gh issue edit <number> --remove-label "loom:issue" --add-label "loom:in-progress"`
+- **Claim issue**: `gh issue edit <number> --remove-label "loom:issue" --add-label "loom:building"`
 - **Do the work**: Implement, test, commit, create PR
 - **Mark PR for review**: `gh pr create --label "loom:review-requested"`
 - **Complete**: Issue auto-closes when PR merges, or mark `loom:blocked` if stuck
@@ -63,7 +63,7 @@ git worktree add .loom/worktrees/issue-84 -b feature/issue-84 main
 
 ```bash
 # 1. Claim an issue
-gh issue edit 84 --remove-label "loom:issue" --add-label "loom:in-progress"
+gh issue edit 84 --remove-label "loom:issue" --add-label "loom:building"
 
 # 2. Create worktree using helper
 ./.loom/scripts/worktree.sh 84
@@ -223,13 +223,13 @@ gh issue view 100 --comments
 gh issue edit 100 --remove-label "loom:issue" --add-label "loom:blocked"
 
 # Otherwise, claim normally
-gh issue edit 100 --remove-label "loom:issue" --add-label "loom:in-progress"
+gh issue edit 100 --remove-label "loom:issue" --add-label "loom:building"
 ```
 
 ## Guidelines
 
 - **Pick the right work**: Choose issues labeled `loom:issue` (human-approved) that match your capabilities
-- **Update labels**: Always mark issues as `loom:in-progress` when starting
+- **Update labels**: Always mark issues as `loom:building` when starting
 - **Read before writing**: Examine existing code to understand patterns and conventions
 - **Test your changes**: Run relevant tests after making modifications
 - **Follow conventions**: Match the existing code style and architecture

--- a/defaults/roles/builder.md
+++ b/defaults/roles/builder.md
@@ -26,7 +26,7 @@ You help with general development tasks including:
 - **Find work**: `gh issue list --label="loom:issue" --state=open` (sorted oldest-first)
 - **Pick oldest**: Always choose the oldest `loom:issue` issue first (FIFO queue)
 - **Check dependencies**: Verify all task list items are checked before claiming
-- **Claim issue**: `gh issue edit <number> --remove-label "loom:issue" --add-label "loom:in-progress"`
+- **Claim issue**: `gh issue edit <number> --remove-label "loom:issue" --add-label "loom:building"`
 - **Do the work**: Implement, test, commit, create PR
 - **Mark PR for review**: `gh pr create --label "loom:review-requested"`
 - **Complete**: Issue auto-closes when PR merges, or mark `loom:blocked` if stuck
@@ -63,7 +63,7 @@ git worktree add .loom/worktrees/issue-84 -b feature/issue-84 main
 
 ```bash
 # 1. Claim an issue
-gh issue edit 84 --remove-label "loom:issue" --add-label "loom:in-progress"
+gh issue edit 84 --remove-label "loom:issue" --add-label "loom:building"
 
 # 2. Create worktree using helper
 ./.loom/scripts/worktree.sh 84
@@ -223,13 +223,13 @@ gh issue view 100 --comments
 gh issue edit 100 --remove-label "loom:issue" --add-label "loom:blocked"
 
 # Otherwise, claim normally
-gh issue edit 100 --remove-label "loom:issue" --add-label "loom:in-progress"
+gh issue edit 100 --remove-label "loom:issue" --add-label "loom:building"
 ```
 
 ## Guidelines
 
 - **Pick the right work**: Choose issues labeled `loom:issue` (human-approved) that match your capabilities
-- **Update labels**: Always mark issues as `loom:in-progress` when starting
+- **Update labels**: Always mark issues as `loom:building` when starting
 - **Read before writing**: Examine existing code to understand patterns and conventions
 - **Test your changes**: Run relevant tests after making modifications
 - **Follow conventions**: Match the existing code style and architecture
@@ -286,12 +286,12 @@ gh issue list --label="loom:issue" --state=open --json number,title,labels \
 
 ## Assessing Complexity Before Claiming
 
-**IMPORTANT**: Always assess complexity BEFORE claiming an issue. Never mark an issue as `loom:in-progress` unless you're committed to completing it.
+**IMPORTANT**: Always assess complexity BEFORE claiming an issue. Never mark an issue as `loom:building` unless you're committed to completing it.
 
 ### Why Assess First?
 
 **The Problem with Claim-First-Assess-Later**:
-- Issue locked with `loom:in-progress` (invisible to other Builders)
+- Issue locked with `loom:building` (invisible to other Builders)
 - No PR created if you abandon it (looks stalled)
 - Requires manual intervention to unclaim
 - Wastes your time reading/planning complex tasks
@@ -317,7 +317,7 @@ Before claiming an issue, estimate the work required:
 ### Decision Tree
 
 **If Simple (< 3 hours)**:
-1. ✅ Claim immediately: `gh issue edit <number> --remove-label "loom:issue" --add-label "loom:in-progress"`
+1. ✅ Claim immediately: `gh issue edit <number> --remove-label "loom:issue" --add-label "loom:building"`
 2. Create worktree: `./.loom/scripts/worktree.sh <number>`
 3. Implement → Test → PR
 


### PR DESCRIPTION
## Summary

Updates Builder role documentation to use the new `loom:building` label instead of `loom:in-progress`, aligning with ADR-0006 label-based workflow coordination.

## Changes

- **defaults/roles/builder.md**: Replaced 7 occurrences of `loom:in-progress` with `loom:building`
- **.loom/roles/builder.md**: Replaced 4 occurrences of `loom:in-progress` with `loom:building`

## Implementation Details

All changes are documentation-only updates to the Builder role markdown files:
- Command examples showing how to claim issues
- Guidelines explaining Builder workflow
- Complexity assessment instructions
- Scope management documentation

## Test Plan

- ✅ Verified no other files were modified (git diff --stat shows only 2 files)
- ✅ Confirmed all `loom:in-progress` references in Builder role files replaced
- ✅ Verified `loom:building` label exists in GitHub (created in #574)
- ✅ Changes are isolated to Builder role documentation (other files with `loom:in-progress` are separate issues)

## Impact

- No functional changes
- Documentation now matches the current label state machine
- Builders will use correct label when claiming issues
- Aligns with Curator, Healer, and Judge roles which already use specific labels

Closes #568