### PR TITLE
Add loom:changes-requested label with amber color

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -30,8 +30,8 @@
   color: "10B981"  # emerald-500
 
 - name: loom:changes-requested
-  description: PR requires changes before approval (Judge requested changes)
-  color: "EF4444"  # red-500
+  description: PR needs revisions before approval
+  color: "F59E0B"  # amber-500 - indicates work needed, matches loom:in-progress
 
 - name: loom:pr
   description: PR approved by Judge, ready for human to merge


### PR DESCRIPTION
## Summary

Adds the `loom:changes-requested` label to GitHub with amber color (#F59E0B) for visual consistency with `loom:in-progress`. This label is used by the Judge role when requesting changes on PRs.

## Changes

- **`.github/labels.yml`**: Updated `loom:changes-requested` label definition
  - Changed color from red (`EF4444`) to amber (`F59E0B`)
  - Updated description to: "PR needs revisions before approval"
  - Added comment explaining color choice (matches `loom:in-progress`)

## Implementation Details

The label was already defined in `.github/labels.yml` but:
1. Had incorrect color (red instead of amber)
2. Didn't exist in GitHub yet (not synced)

Fixed by:
1. Updating color to `F59E0B` (amber-500) to match `loom:in-progress`
2. Running `./scripts/install/sync-labels.sh .` to sync to GitHub

## Test Plan

- ✅ Updated label definition in `.github/labels.yml`
- ✅ Synced labels using sync script (output: "Created label: loom:changes-requested")
- ✅ Verified label exists in GitHub: `gh label list | grep loom:changes-requested`
- ✅ Confirmed color is amber (#F59E0B) matching `loom:in-progress`

## Label Workflow Context

This label fits into the PR review workflow:

```
PR created → loom:review-requested (green)
         ↓
    Judge reviews
         ↓
    ┌────┴────┐
    ↓         ↓
approved      changes needed
    ↓         ↓
loom:pr      loom:changes-requested (amber)
(blue)           ↓
              Healer fixes
                 ↓
           loom:review-requested (green)
```

The amber color provides visual consistency:
- `loom:in-progress` (amber): Issue work in progress
- `loom:changes-requested` (amber): PR work in progress (revisions needed)

## Impact

- Judge role can now properly label PRs requiring changes
- Visual consistency with other "work in progress" states
- Completes the PR review workflow label set

Closes #585