### PR TITLE
Fix lint errors in token usage tracking

### DIFF
--- a/src/lib/activity-logger.ts
+++ b/src/lib/activity-logger.ts
@@ -138,7 +138,7 @@ export interface TokenUsageSummary {
  */
 export async function queryTokenUsageByRole(
   workspacePath: string,
-  since?: string,
+  since?: string
 ): Promise<TokenUsageSummary[]> {
   try {
     return await invoke("query_token_usage_by_role", {
@@ -146,6 +146,7 @@ export async function queryTokenUsageByRole(
       since,
     });
   } catch (error) {
+    // biome-ignore lint/suspicious/noConsole: Error logging in catch block
     console.error("[activity-logger] Failed to query token usage:", error);
     return [];
   }
@@ -169,7 +170,7 @@ export interface DailyTokenUsage {
  */
 export async function queryTokenUsageTimeline(
   workspacePath: string,
-  days = 30,
+  days = 30
 ): Promise<DailyTokenUsage[]> {
   try {
     return await invoke("query_token_usage_timeline", {
@@ -177,6 +178,7 @@ export async function queryTokenUsageTimeline(
       days,
     });
   } catch (error) {
+    // biome-ignore lint/suspicious/noConsole: Error logging in catch block
     console.error("[activity-logger] Failed to query token timeline:", error);
     return [];
   }


### PR DESCRIPTION
## Summary
- Add biome-ignore comments for console.error statements in token usage functions
- Fix formatting issues (trailing commas)

## Details
PR #606 added token usage tracking with console.error logging for debugging, but these statements triggered lint failures. This PR adds the appropriate biome-ignore comments to allow error logging in catch blocks while maintaining code quality standards.

### Changes
- `queryTokenUsageByRole()` - Added biome-ignore for console.error
- `queryTokenUsageTimeline()` - Added biome-ignore for console.error
- Fixed formatting (removed trailing commas per biome rules)

### Testing
- ✅ `pnpm lint` passes
- ✅ All console.error statements properly documented with biome-ignore comments

## Related Issues
Fixes CI failures from PR #606 and #607

🤖 Generated with [Claude Code](https://claude.com/claude-code)