### PR TITLE
Fix installation script label timing issues

### DIFF
--- a/defaults/.github/labels.yml
+++ b/defaults/.github/labels.yml
@@ -8,6 +8,10 @@
   description: Approved for work by human (ready for Builder to claim)
   color: "3B82F6"  # blue-500
 
+- name: loom:building
+  description: Builder is implementing this issue
+  color: "1d76db"  # blue
+
 - name: loom:in-progress
   description: "Issue: Worker implementing | PR: Reviewer reviewing or Worker addressing feedback"
   color: "F59E0B"  # amber-500

--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -308,6 +308,17 @@ fi
 
 echo ""
 
+# Now that labels are synced, ensure the tracking issue has the loom:building label
+info "Ensuring tracking issue has loom:building label..."
+cd "$TARGET_PATH"
+if gh issue edit "$ISSUE_NUMBER" --add-label "loom:building" 2>/dev/null; then
+  success "Added loom:building label to issue #${ISSUE_NUMBER}"
+else
+  warning "Could not add loom:building label to issue #${ISSUE_NUMBER}"
+fi
+
+echo ""
+
 # ============================================================================
 # STEP 6: Create Pull Request
 # ============================================================================

--- a/scripts/install/create-issue.sh
+++ b/scripts/install/create-issue.sh
@@ -55,15 +55,23 @@ info "Creating installation issue..."
 
 # Create issue and capture the URL from output
 # (Compatible with older gh CLI versions that don't support --json)
+# NOTE: Don't add label during creation - labels are synced in Step 5
 ISSUE_URL=$(gh issue create \
   --title "Install Loom ${LOOM_VERSION} (${LOOM_COMMIT})" \
-  --body "$ISSUE_BODY" \
-  --label "loom:building" 2>&1 | grep -o 'https://[^ ]*')
+  --body "$ISSUE_BODY" 2>&1 | grep -o 'https://[^ ]*')
 
 # Extract issue number from URL
 ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -o '[0-9]*$')
 
 success "Created issue #${ISSUE_NUMBER}"
+
+# Try to add loom:building label if it exists (graceful failure if label doesn't exist yet)
+info "Adding loom:building label..."
+if gh issue edit "$ISSUE_NUMBER" --add-label "loom:building" 2>/dev/null; then
+  success "Added loom:building label"
+else
+  info "Label will be added after label sync (Step 5)"
+fi
 
 # Output the issue number (stdout, so it can be captured by caller)
 echo "$ISSUE_NUMBER"


### PR DESCRIPTION
## Summary

Fixes installation script failures when deploying to new repositories by addressing label timing issues.

Closes #617

## Problem

The installation script tried to create a tracking issue with `--label "loom:building"` **before** syncing labels to the target repository, causing installation failures with:
```
label `loom:building` not found
```

## Solution

### Fix 1: Remove label from initial issue creation
**File**: `scripts/install/create-issue.sh`
- Removed `--label "loom:building"` from `gh issue create` command
- Added graceful attempt to add label after creation (fails silently if label doesn't exist)
- Label will be properly added after Step 5 (label sync)

### Fix 2: Ensure label is added after sync
**File**: `scripts/install-loom.sh`
- Added Step 5b after label sync to ensure tracking issue gets `loom:building` label
- Handles both success and failure gracefully with appropriate logging

### Fix 3: Add missing label to defaults
**File**: `defaults/.github/labels.yml`
- Added `loom:building` label definition to defaults
- Ensures future installations include this label when syncing

## Changes

- `scripts/install/create-issue.sh` (lines 56-77): Label handling fix
- `scripts/install-loom.sh` (lines 311-320): Post-sync label addition
- `defaults/.github/labels.yml` (lines 11-13): New label definition

## Testing

✅ Tested installation to rulehunt/rulehunt repository
- Issue #173 created successfully
- Labels synced correctly
- PR #174 created successfully
- All installation steps completed

## Impact

- **Risk**: Low - graceful degradation if labels missing
- **Benefit**: Robust installation for new repositories
- **Breaking**: No - backwards compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>