### PR TITLE
Clarify Judge review process: Use Loom labels, not GitHub Reviews

### DIFF
--- a/.claude/commands/judge.md
+++ b/.claude/commands/judge.md
@@ -93,5 +93,7 @@ try {
 ## Label Workflow
 
 Follow label-based coordination (ADR-0006):
-- PRs: `loom:review-requested` → `loom:pr` (if approved) or keep label (if changes requested)
+- PRs: `loom:review-requested` → `loom:pr` (if approved) or `loom:changes-requested` (if changes needed)
 - After approval, ready for maintainer merge
+
+**IMPORTANT**: Never use `gh pr review --approve/--request-changes`. These commands fail for self-authored PRs. Always use comments (`gh pr comment`) + label changes (`gh pr edit`) as shown in the role definition.

--- a/defaults/roles/judge.md
+++ b/defaults/roles/judge.md
@@ -15,6 +15,58 @@ You provide high-quality code reviews by:
 
 ## Label Workflow
 
+## IMPORTANT: Loom's Review System vs GitHub Reviews
+
+**Loom uses label-based reviews, NOT GitHub's review API.**
+
+### Don't Use: GitHub Review API
+
+**Never use these commands** - they fail for self-authored PRs:
+```bash
+# WRONG - Will fail with "cannot approve your own PR"
+gh pr review 123 --approve
+gh pr review 123 --request-changes
+gh pr review 123 --comment
+```
+
+**Why these fail**:
+- GitHub enforces separation of duties (authors can't approve own PRs)
+- Not suitable for single-developer workflows or autonomous agents
+- Breaks Loom's label-based coordination system
+
+### Always Use: Loom Label System
+
+Loom reviews are done through **comments + label changes**:
+
+**Approval workflow**:
+```bash
+# 1. Add comprehensive review comment
+gh pr comment <number> --body "✅ **Approved!** [detailed feedback]"
+
+# 2. Change labels to indicate approval
+gh pr edit <number> \
+  --remove-label "loom:review-requested" \
+  --add-label "loom:pr"
+```
+
+**Request changes workflow**:
+```bash
+# 1. Add review comment with specific feedback
+gh pr comment <number> --body "❌ **Changes Requested** [detailed issues]"
+
+# 2. Update labels
+gh pr edit <number> \
+  --remove-label "loom:review-requested" \
+  --add-label "loom:changes-requested"
+```
+
+**Why Loom's approach is better**:
+- ✅ Works for all PRs (including self-authored)
+- ✅ Enables autonomous Judge agents
+- ✅ Supports label-based coordination (see CLAUDE.md)
+- ✅ Human can override by changing labels
+- ✅ Preserves review comments for documentation
+
 **IMPORTANT**: Update labels on the **PR**, not the Issue. The Issue stays at `loom:building` until the PR is merged.
 
 **Find PRs ready for review (green badges):**


### PR DESCRIPTION
## Summary

Adds explicit warning against using GitHub's review API in Judge role documentation to prevent confusion when encountering "cannot approve your own PR" errors.

Closes #621

## Problem

While the Judge role examples already use the correct label-based approach, there was no explicit prohibition against using GitHub's review API (`gh pr review --approve/--request-changes`). This could lead LLM agents to default to these commands, which fail for self-authored PRs.

## Solution

**File 1: `defaults/roles/judge.md`**

Added new "IMPORTANT: Loom's Review System vs GitHub Reviews" section after line 16:
- ❌ "Don't Use: GitHub Review API" - Explicit prohibition with examples
- ✅ "Always Use: Loom Label System" - Correct workflow with examples
- Explains WHY GitHub review API fails (separation of duties)
- Explains WHY Loom's approach is better (autonomous agents, self-authored PRs)

**File 2: `.claude/commands/judge.md`**

Added warning note in Label Workflow section (line 99):
- States never to use `gh pr review` commands
- Directs to use comments + label changes instead

## Changes

- `defaults/roles/judge.md` (lines 18-68): New explicit warning section
- `.claude/commands/judge.md` (line 99): Warning note added

## Testing

✅ Verified new section appears correctly in judge.md
✅ Confirmed examples show proper `gh pr comment` + `gh pr edit` pattern
✅ Checked slash command has warning note

## Benefits

✅ Eliminates confusion about "cannot approve own PR" errors
✅ Prevents LLM agents from defaulting to GitHub review API
✅ Makes documentation more explicit and foolproof
✅ Enables Judge role to review any PR (including self-authored)
✅ Supports autonomous Judge agents in single-developer repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>