### PR TITLE
Fix clippy lint errors in activity logging code

### DIFF
--- a/src-tauri/src/commands/activity.rs
+++ b/src-tauri/src/commands/activity.rs
@@ -203,7 +203,7 @@ fn open_activity_db(workspace_path: &str) -> SqliteResult<Connection> {
     Ok(conn)
 }
 
-/// Log activity entry to SQLite database
+/// Log activity entry to `SQLite` database
 #[tauri::command]
 #[allow(clippy::needless_pass_by_value)]
 pub fn log_activity(workspace_path: String, entry: ActivityEntry) -> Result<(), String> {
@@ -253,7 +253,7 @@ pub fn log_activity(workspace_path: String, entry: ActivityEntry) -> Result<(), 
     Ok(())
 }
 
-/// Read recent activity entries from SQLite database
+/// Read recent activity entries from `SQLite` database
 #[tauri::command]
 pub fn read_recent_activity(
     workspace_path: &str,
@@ -359,11 +359,11 @@ pub struct TokenUsageSummary {
 /// Query token usage statistics grouped by role
 #[tauri::command]
 pub fn query_token_usage_by_role(
-    workspace_path: String,
+    workspace_path: &str,
     since: Option<String>,
 ) -> Result<Vec<TokenUsageSummary>, String> {
     let conn =
-        open_activity_db(&workspace_path).map_err(|e| format!("Failed to open database: {e}"))?;
+        open_activity_db(workspace_path).map_err(|e| format!("Failed to open database: {e}"))?;
 
     let query = if since.is_some() {
         "SELECT
@@ -440,11 +440,11 @@ pub struct DailyTokenUsage {
 /// Query token usage over time, grouped by date and role
 #[tauri::command]
 pub fn query_token_usage_timeline(
-    workspace_path: String,
+    workspace_path: &str,
     days: Option<i32>,
 ) -> Result<Vec<DailyTokenUsage>, String> {
     let conn =
-        open_activity_db(&workspace_path).map_err(|e| format!("Failed to open database: {e}"))?;
+        open_activity_db(workspace_path).map_err(|e| format!("Failed to open database: {e}"))?;
 
     let days_val = days.unwrap_or(30);
 


### PR DESCRIPTION
## Summary

Fixes #624 by resolving 4 clippy lint errors in the activity logging code that were blocking PR #616 (CI workflow).

## Changes

Fixed 4 clippy lint errors in `src-tauri/src/commands/activity.rs`:

1. **Line 206**: Added backticks around `SQLite` in doc comment
   - Before: `/// Log activity entry to SQLite database`
   - After: `/// Log activity entry to \`SQLite\` database`

2. **Line 256**: Added backticks around `SQLite` in doc comment
   - Before: `/// Read recent activity entries from SQLite database`  
   - After: `/// Read recent activity entries from \`SQLite\` database`

3. **Line 362**: Changed parameter type from `String` to `&str` in `query_token_usage_by_role`
   - Before: `workspace_path: String,`
   - After: `workspace_path: &str,`
   - Also updated function call from `&workspace_path` to `workspace_path`

4. **Line 443**: Changed parameter type from `String` to `&str` in `query_token_usage_timeline`
   - Before: `workspace_path: String,`
   - After: `workspace_path: &str,`
   - Also updated function call from `&workspace_path` to `workspace_path`

## Testing

- ✅ `pnpm clippy:locked` passes with no errors
- ✅ All 4 clippy errors resolved
- ✅ Code compiles successfully

## Impact

- **Unblocks**: PR #616 (CI workflow) - CI will now pass
- **Risk**: Minimal - simple lint fixes with no behavioral changes
- **Breaking**: None - API signatures unchanged (both `String` and `&str` work from Tauri frontend)

## Context

These lint errors were introduced in PR #606 (activity logging) but weren't caught because there was no CI running clippy. PR #616 adds CI that correctly catches these issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)