### PR TITLE
Add loom:reviewing label for Judge workflow consistency

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -25,6 +25,10 @@
   description: Healer is fixing this bug or addressing PR feedback
   color: "F59E0B"  # amber-500 - matches other in-progress states
 
+- name: loom:reviewing
+  description: Judge is actively reviewing this PR
+  color: "F59E0B"  # amber-500 - matches other in-progress states
+
 - name: loom:review-requested
   description: PR ready for Judge to review
   color: "10B981"  # emerald-500

--- a/defaults/.github/labels.yml
+++ b/defaults/.github/labels.yml
@@ -29,6 +29,10 @@
   description: Healer is fixing this bug or addressing PR feedback
   color: "F59E0B"  # amber-500 - matches other in-progress states
 
+- name: loom:reviewing
+  description: Judge is actively reviewing this PR
+  color: "F59E0B"  # amber-500 - matches other in-progress states
+
 - name: loom:review-requested
   description: PR ready for Judge to review
   color: "10B981"  # emerald-500

--- a/defaults/roles/judge.md
+++ b/defaults/roles/judge.md
@@ -147,14 +147,15 @@ gh pr edit 599 --remove-label "loom:reviewing" --add-label "loom:pr"
 ### Primary Queue (Priority)
 
 1. **Find work**: `gh pr list --label="loom:review-requested" --state=open`
-2. **Understand context**: Read PR description and linked issues
-3. **Check out code**: `gh pr checkout <number>` to get the branch locally
-4. **Run quality checks**: Tests, lints, type checks, build
-5. **Review changes**: Examine diff, look for issues, suggest improvements
-6. **Provide feedback**: Use `gh pr comment` to provide review feedback
-7. **Update labels**:
-   - If approved: Comment with approval, remove `loom:review-requested`, add `loom:pr` (blue badge - ready for user to merge)
-   - If changes needed: Comment with issues, remove `loom:review-requested`, add `loom:changes-requested` (amber badge - Fixer will address)
+2. **Claim PR**: `gh pr edit <number> --add-label "loom:reviewing"` to signal you're working on it
+3. **Understand context**: Read PR description and linked issues
+4. **Check out code**: `gh pr checkout <number>` to get the branch locally
+5. **Run quality checks**: Tests, lints, type checks, build
+6. **Review changes**: Examine diff, look for issues, suggest improvements
+7. **Provide feedback**: Use `gh pr comment` to provide review feedback
+8. **Update labels**:
+   - If approved: Comment with approval, remove `loom:review-requested` and `loom:reviewing`, add `loom:pr` (blue badge - ready for user to merge)
+   - If changes needed: Comment with issues, remove `loom:review-requested` and `loom:reviewing`, add `loom:changes-requested` (amber badge - Fixer will address)
 
 ### Fallback Queue (When No Labeled Work)
 


### PR DESCRIPTION
## Summary

Adds the `loom:reviewing` label to the Loom workflow system and updates Judge role documentation to use it consistently.

**Changes:**
- ✅ Added `loom:reviewing` label with amber color (F59E0B) to both label files
- ✅ Updated Judge Review Process to include claiming PRs with `loom:reviewing` (step 2)
- ✅ Updated label cleanup to remove both `loom:review-requested` and `loom:reviewing` on completion
- ✅ Synced label to GitHub repository

**Rationale:**
Every other role has a specific "in progress" label to claim work:
- Builder: `loom:building`
- Curator: `loom:curating`
- Healer: `loom:healing`
- Judge: `loom:reviewing` ← Added this missing piece

This ensures workflow consistency and clear state visibility across all agent roles.

Closes #640

🤖 Generated with [Claude Code](https://claude.com/claude-code)