### PR TITLE
Fix issue number extraction in install script

### DIFF
--- a/scripts/install/create-issue.sh
+++ b/scripts/install/create-issue.sh
@@ -58,10 +58,10 @@ info "Creating installation issue..."
 # NOTE: Don't add label during creation - labels are synced in Step 5
 ISSUE_URL=$(gh issue create \
   --title "Install Loom ${LOOM_VERSION} (${LOOM_COMMIT})" \
-  --body "$ISSUE_BODY" 2>&1 | grep -o 'https://[^ ]*')
+  --body "$ISSUE_BODY" 2>&1 | grep -o 'https://[^ ]*' | head -1)
 
 # Extract issue number from URL
-ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -o '[0-9]*$')
+ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -o '[0-9]\+$')
 
 success "Created issue #${ISSUE_NUMBER}"
 


### PR DESCRIPTION
## Summary

Fixes the install script failure where issue number extraction was failing.

## Problem

The `install.sh` script was failing during Step 2 with:
```
✗ Error: Invalid issue number returned: https://github.com/rjwalters/loom/issues/653
653
```

## Root Cause

In `scripts/install/create-issue.sh`:
1. The `gh issue create` command outputs the URL to stderr
2. The grep pattern `https://[^ ]*` could capture multiple URLs if present in output
3. The issue number extraction regex `[0-9]*$` matches zero or more digits, which is too permissive

## Solution

- Added `| head -1` to ensure only the first URL is captured (scripts/install/create-issue.sh:61)
- Changed regex from `[0-9]*$` to `[0-9]\+$` to match one or more digits (scripts/install/create-issue.sh:64)

## Testing

- Verified extraction logic with test script
- Tested that the regex correctly extracts issue numbers from GitHub URLs

Closes #654

🤖 Generated with [Claude Code](https://claude.com/claude-code)