### PR TITLE
Fix installation PR to target correct base branch

### DIFF
--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -212,9 +212,10 @@ fi
 WORKTREE_OUTPUT=$("$LOOM_ROOT/scripts/install/create-worktree.sh" "$TARGET_PATH" "$ISSUE_NUMBER") || \
   error "Failed to create worktree"
 
-# Parse output: WORKTREE_PATH|BRANCH_NAME
+# Parse output: WORKTREE_PATH|BRANCH_NAME|BASE_BRANCH
 WORKTREE_PATH=$(echo "$WORKTREE_OUTPUT" | cut -d'|' -f1)
 BRANCH_NAME=$(echo "$WORKTREE_OUTPUT" | cut -d'|' -f2)
+BASE_BRANCH=$(echo "$WORKTREE_OUTPUT" | cut -d'|' -f3)
 
 # Validate worktree path format (should be relative path starting with .loom/worktrees/)
 if [[ ! "$WORKTREE_PATH" =~ ^\.loom/worktrees/ ]]; then
@@ -227,6 +228,7 @@ fi
 
 info "Worktree: $WORKTREE_PATH"
 info "Branch: $BRANCH_NAME"
+info "Base branch: $BASE_BRANCH"
 echo ""
 
 # ============================================================================
@@ -330,7 +332,7 @@ if [[ ! -x "$LOOM_ROOT/scripts/install/create-pr.sh" ]]; then
   error "Installation script not found: create-pr.sh"
 fi
 
-PR_URL=$("$LOOM_ROOT/scripts/install/create-pr.sh" "$TARGET_PATH/$WORKTREE_PATH" "$ISSUE_NUMBER") || \
+PR_URL=$("$LOOM_ROOT/scripts/install/create-pr.sh" "$TARGET_PATH/$WORKTREE_PATH" "$ISSUE_NUMBER" "$BASE_BRANCH") || \
   error "Failed to create pull request"
 
 # Check if installation was already complete (no changes needed)

--- a/scripts/install/create-pr.sh
+++ b/scripts/install/create-pr.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 WORKTREE_PATH="${1:-.}"
 ISSUE_NUMBER="${2:-}"
+BASE_BRANCH="${3:-}"
 LOOM_VERSION="${LOOM_VERSION:-unknown}"
 LOOM_COMMIT="${LOOM_COMMIT:-unknown}"
 
@@ -29,6 +30,10 @@ success() {
 
 if [[ -z "$ISSUE_NUMBER" ]]; then
   error "Issue number required as second argument"
+fi
+
+if [[ -z "$BASE_BRANCH" ]]; then
+  error "Base branch required as third argument"
 fi
 
 cd "$WORKTREE_PATH"
@@ -115,6 +120,7 @@ EOF
 # Create pull request
 # Output goes to stderr so it doesn't interfere with URL capture
 PR_OUTPUT=$(gh pr create \
+  --base "$BASE_BRANCH" \
   --title "Install Loom ${LOOM_VERSION} (${LOOM_COMMIT})" \
   --body "$PR_BODY" \
   --label "loom:review-requested" 2>&1)

--- a/scripts/install/create-worktree.sh
+++ b/scripts/install/create-worktree.sh
@@ -106,6 +106,6 @@ fi
 success "Worktree created: $WORKTREE_PATH"
 success "Branch name: $BRANCH_NAME"
 
-# Output the worktree path and branch name (stdout, so it can be captured by caller)
-# Format: WORKTREE_PATH|BRANCH_NAME
-echo "${WORKTREE_PATH}|${BRANCH_NAME}"
+# Output the worktree path, branch name, and base branch (stdout, so it can be captured by caller)
+# Format: WORKTREE_PATH|BRANCH_NAME|BASE_BRANCH
+echo "${WORKTREE_PATH}|${BRANCH_NAME}|${BASE_BRANCH}"


### PR DESCRIPTION
## Summary
Fixes installation PR merge conflicts by explicitly targeting the correct base branch.

## Problem
During Loom installation, PRs could have merge conflicts because:
- create-worktree.sh detects base branch (main/master) and creates worktree from it
- create-pr.sh doesn't specify --base, so GitHub uses repo default branch
- Mismatch causes PR to target wrong branch → merge conflicts

## Solution
Pass base branch through installation pipeline:
1. create-worktree.sh outputs: WORKTREE_PATH|BRANCH_NAME|BASE_BRANCH
2. install-loom.sh parses and passes base branch to create-pr.sh  
3. create-pr.sh uses --base in gh pr create

## Changes
- scripts/install/create-worktree.sh:111 - Add base branch to output
- scripts/install-loom.sh:218,231,335 - Parse and pass base branch
- scripts/install/create-pr.sh:8,36,123 - Accept and use base branch

## Testing
PR now always targets the same branch the worktree was created from, regardless of GitHub's default branch setting.

Closes #658