### PR TITLE
Fix console logger initialization race condition

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -101,7 +101,7 @@ import {
 // NOTE: handleWorkspacePathInput is a local wrapper that calls handleWorkspacePathInputCore from src/lib/workspace-lifecycle.ts
 
 // Logger will be initialized in async IIFE after Tauri IPC is ready
-let logger: ReturnType<typeof Logger.forComponent> | undefined;
+let logger = undefined as ReturnType<typeof Logger.forComponent> | undefined;
 
 // Initialize theme
 initTheme();
@@ -428,8 +428,8 @@ state.onChange(render);
 if (!eventListenersRegistered) {
   logger?.info("Registering event listeners (first time only)");
 
-  // Render immediately so users see the loading screen before async init
-  render();
+  // NOTE: Initial render is now done in the async IIFE after logger is initialized
+  // render(); // Commented out - causes "Cannot access uninitialized variable" error
   eventListenersRegistered = true;
 
   // Listen for CLI workspace argument from Rust backend


### PR DESCRIPTION
## Summary

Fixes the "Cannot access uninitialized variable" error that prevented console logging from working after the Tauri v2 upgrade in #657.

## Problem

After merging #657, the console logger wasn't writing logs to `~/.loom/console.log` because of a variable initialization race condition. The `logger` variable was being accessed before it was initialized, causing a ReferenceError.

## Root Cause

The `logger` variable is declared with `let` but not initialized until the async IIFE runs. However, several callbacks (health monitor, event listeners) were trying to access `logger` before the async IIFE completed:

1. `healthMonitor.onHealthUpdate(() => render())` - registered at module level
2. `render()` call at line 432 - executed before async IIFE
3. `render()` function uses `logger?.info()` which throws on uninitialized variable

JavaScript's Temporal Dead Zone (TDZ) prevents accessing a `let` variable before it's assigned, even with optional chaining.

## Solution

1. **Explicitly initialize logger**: Changed from `let logger: Type` to `let logger = undefined as Type` to ensure it has a value from the start
2. **Remove premature render call**: Commented out the `render()` call at line 432 that happened before logger initialization
3. **Initial render handled by async IIFE**: The app initialization flow now properly renders after logger is set up

## Testing

- ✅ Verified console logs are written to `~/.loom/console.log`
- ✅ Tested with `pnpm app:dev:headless`  
- ✅ Confirmed MCP tools can read console logs with `mcp__loom-ui__read_console_log`
- ✅ No more "Cannot access uninitialized variable" errors
- ✅ Factory reset MCP command tested successfully

## Verification

Console log file now shows logs:
```
-rw-r--r--@ 1 rwalters  staff   157K Oct 22 20:18 /Users/rwalters/.loom/console.log
```

Sample log entries:
```json
[2025-10-23T03:18:01.260Z] [INFO] {"timestamp":"2025-10-23T03:18:01.260Z","level":"INFO","message":"Rendering","context":{"component":"main","hasWorkspace":true}}
```

Fixes the remaining issue from #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)