### PR TITLE
Fix Builder stalling on PR reviews - hand off to Healer

### DIFF
--- a/.loom/roles/builder.json
+++ b/.loom/roles/builder.json
@@ -2,7 +2,7 @@
   "name": "Development Worker",
   "description": "Implements issues labeled loom:issue (human-approved work)",
   "defaultInterval": 0,
-  "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are a Development Worker who implements `loom:issue` issues (human-approved work). Priority system: (1) Check urgent: `gh pr list --author=@me --state=open`, if active PR exists, check if it's been merged or has new review comments needing attention. (2) If no active PR, check `gh issue list --label=\"loom:issue\" --label=\"loom:urgent\"` for critical issues. (3) If none urgent, check `gh issue list --label=\"loom:issue\"` (oldest first, FIFO). Workers stick with ONE PR until merged - don't start new issues while you have an open PR.",
+  "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are a Development Worker who implements `loom:issue` issues (human-approved work). Priority system: (1) Check `gh issue list --label=\"loom:issue\" --label=\"loom:urgent\"` for critical issues. (2) If none urgent, check `gh issue list --label=\"loom:issue\"` (oldest first, FIFO) and claim new work. After creating a PR with `loom:review-requested`, move on to the next issue - the Healer agent will handle any review feedback. You can work on multiple issues concurrently using worktrees.",
   "autonomousRecommended": false,
   "suggestedWorkerType": "claude",
   "gitIdentity": {

--- a/.loom/roles/builder.md
+++ b/.loom/roles/builder.md
@@ -701,6 +701,7 @@ EOF
 - Use the TodoWrite tool to plan and track multi-step tasks
 - Run lint, format, and type checks before considering complete
 - **Create PR**: **Use "Closes #123" syntax** (see section above), add `loom:review-requested` label
+- **After PR creation**: Move on to the next `loom:issue` - the Healer agent handles PR review feedback
 - When blocked: Add comment explaining blocker, mark `loom:blocked`
 - Stay focused on assigned issue - create separate issues for other work
 


### PR DESCRIPTION
## Summary

Updates Builder role configuration to eliminate stalling behavior when PRs are awaiting review. Builder now immediately moves on to new `loom:issue` work after creating a PR, with Healer handling all PR review feedback.

## Changes

### `.loom/roles/builder.json`
- **Removed**: "Check urgent: `gh pr list --author=@me`" from priority system
- **Removed**: "Workers stick with ONE PR until merged" restriction
- **Added**: "After creating a PR with `loom:review-requested`, move on to the next issue"
- **Added**: "Healer agent will handle any review feedback"
- **Added**: "You can work on multiple issues concurrently using worktrees"

### `.loom/roles/builder.md`
- **Added**: Line 704 "After PR creation: Move on to the next `loom:issue` - the Healer agent handles PR review feedback"

## Benefits

- ✅ Clear role separation: Builder builds, Healer heals
- ✅ Builder stays productive instead of stalling
- ✅ Healer handles all PR feedback loops
- ✅ Worktree isolation prevents conflicts
- ✅ Higher throughput in autonomous mode
- ✅ No role confusion or overlap

## Test Plan

- ✅ Linting passes (`pnpm lint`)
- ✅ Changes are documentation-only (JSON config + Markdown)
- ✅ Verified healer.md covers PR review feedback responsibilities
- ✅ Updated interval prompt matches issue specification
- ✅ builder.md clarifies Builder → Healer handoff

## Acceptance Criteria Met

- [x] Update `builder.json` interval prompt to remove "stick with ONE PR" restriction
- [x] Builder immediately moves to next `loom:issue` after creating PR (via updated interval prompt)
- [x] Builder does NOT check for review comments on its own PRs (removed from priority system)
- [x] Documentation clarifies Builder → Healer handoff (line 704 in builder.md)
- [x] Healer picks up PR review comments (verified healer.md lines 7-16, 38-53)
- [ ] Test in autonomous mode (requires manual verification)

Closes #688