### PR TITLE
Document worktree strategy: terminal vs issue worktrees

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,36 @@ Agents coordinate work through GitHub labels. This enables autonomous operation 
 
 ## Git Worktree Workflow
 
-Loom uses git worktrees to isolate agent work. Each issue gets its own worktree.
+Loom uses git worktrees to isolate agent work. Loom supports two types of worktrees depending on the usage mode:
+
+### Worktree Strategy Overview
+
+**Terminal Worktrees** (`.loom/worktrees/terminal-N`):
+- **Purpose**: Agent isolation in Tauri App Mode
+- **When**: Created automatically for each terminal in the Loom desktop application
+- **Why**: Allows multiple autonomous agents to work on different branches simultaneously without conflicts
+- **Scope**: Per terminal/agent (persistent across app restarts)
+- **Used in**: Tauri App Mode only
+
+**Issue Worktrees** (`.loom/worktrees/issue-N`):
+- **Purpose**: Issue-specific work isolation for Builder agents
+- **When**: Created manually by Builder when claiming an issue (both MOM and Tauri App)
+- **Why**: Isolates work on specific issues with dedicated feature branches
+- **Scope**: Per issue (temporary, cleaned up when PR is merged)
+- **Used in**: Both Manual Orchestration Mode and Tauri App Mode
+
+### When to Use Which Worktree Type
+
+**Manual Orchestration Mode (Claude Code CLI)**:
+- No terminal worktrees (agents work in main workspace initially)
+- Builder creates issue worktrees via `./.loom/scripts/worktree.sh <issue-number>`
+- Single agent per terminal, human-controlled
+
+**Tauri App Mode (Autonomous Agents)**:
+- Automatic terminal worktrees for agent isolation (`.loom/worktrees/terminal-N`)
+- Builder ALSO creates issue worktrees when claiming work (`.loom/worktrees/issue-N`)
+- Multiple autonomous agents can run simultaneously
+- Builder works in issue worktree, not terminal worktree
 
 ### Creating Worktrees (for Agents)
 


### PR DESCRIPTION
## Summary

Documents Loom's dual-worktree strategy to eliminate confusion between terminal worktrees (Tauri App Mode agent isolation) and issue worktrees (Builder issue-specific work).

## Problem

Issue #686 identified confusion about two different worktree patterns:
- **Terminal worktrees**: `.loom/worktrees/terminal-N` (automatic in Tauri App)
- **Issue worktrees**: `.loom/worktrees/issue-N` (created by Builder via worktree.sh)

This led to nested worktree situations and unclear expectations about which worktree to use.

## Solution

After investigation (see issue comments), the **hybrid approach is correct and intentional**. This PR documents the strategy clearly.

## Changes

### `CLAUDE.md`
- **Added** "Worktree Strategy Overview" section explaining both worktree types
- **Added** "When to Use Which Worktree Type" section clarifying MOM vs Tauri App usage
- **Documented** terminal worktrees (agent isolation in Tauri App Mode)
- **Documented** issue worktrees (Builder issue-specific work isolation)

### `.loom/roles/builder.md`
- **Added** new section "Working in Tauri App Mode" (after line 161)
- **Documented** dual-worktree workflow for autonomous agents
- **Explained** why two worktrees are needed (terminal isolation + issue isolation)
- **Included** step-by-step workflow for creating and using issue worktrees from terminal worktrees
- **Added** troubleshooting guidance for shell working directory resets
- **Provided** examples of correct command chaining

### `.loom/scripts/worktree.sh`
- **No changes needed** - script already provides helpful "Next steps" output with `cd` command

## Benefits

- ✅ Eliminates confusion about worktree strategy
- ✅ Clarifies terminal vs issue worktrees
- ✅ Documents when each type is used
- ✅ Provides clear workflow for Tauri App Mode builders
- ✅ Includes troubleshooting guidance
- ✅ No code changes required (documentation only)

## Test Plan

- ✅ Linting passes (`pnpm lint`)
- ✅ Documentation-only changes (no functional changes)
- ✅ Markdown formatting is correct
- ✅ Examples are accurate and match actual workflow

**Manual Testing Suggested**:
- [ ] MOM workflow: Builder creates issue worktree from main workspace
- [ ] Tauri App workflow: Builder creates issue worktree from terminal worktree
- [ ] Verify worktree.sh detects nesting and navigates correctly
- [ ] Confirm documentation matches actual behavior

## Acceptance Criteria

From issue #686:

- [x] Document terminal worktree purpose (agent isolation in Tauri App)
- [x] Document issue worktree purpose (Builder issue work)
- [x] Update Builder role docs with Tauri App workflow
- [x] Add troubleshooting guide for shell cwd resets
- [x] Update CLAUDE.md with worktree strategy explanation
- [ ] Manual testing in both MOM and Tauri App modes

## Architecture Decision

This PR documents the **hybrid approach (Option C)** as the correct and intentional architecture:
- Terminal worktrees provide agent isolation in Tauri App Mode
- Issue worktrees provide issue-specific work isolation
- Both are needed for different purposes
- No code changes required - this is a documentation clarification

Closes #686