### PR TITLE
Open settings modal automatically when adding new terminal from '+' button

### DIFF
--- a/src/lib/terminal-actions.ts
+++ b/src/lib/terminal-actions.ts
@@ -343,7 +343,7 @@ export async function createPlainTerminal(deps: {
   workspacePath: string;
   generateNextConfigId: (terminals: import("./state").Terminal[]) => string;
   saveCurrentConfig: () => Promise<void>;
-}): Promise<void> {
+}): Promise<Terminal | undefined> {
   const { state, workspacePath, generateNextConfigId, saveCurrentConfig } = deps;
 
   // Generate terminal name
@@ -375,7 +375,7 @@ export async function createPlainTerminal(deps: {
     logger.info("Created worktree", { name, id, worktreePath });
 
     // Add to state with default role (plain shell / driver)
-    state.addTerminal({
+    const newTerminal: Terminal = {
       id,
       name,
       worktreePath,
@@ -383,7 +383,8 @@ export async function createPlainTerminal(deps: {
       isPrimary: false,
       role: "default",
       theme: "default",
-    });
+    };
+    state.addTerminal(newTerminal);
 
     // Announce terminal creation to screen readers
     announceTerminalCreated(name);
@@ -393,8 +394,12 @@ export async function createPlainTerminal(deps: {
 
     // Switch to new terminal
     state.setPrimary(id);
+
+    // Return the created terminal
+    return newTerminal;
   } catch (error) {
     logger.error("Failed to create terminal", error, { workspacePath });
     showToast(`Failed to create terminal: ${error}`, "error");
+    return undefined;
   }
 }

--- a/src/lib/ui-event-handlers.ts
+++ b/src/lib/ui-event-handlers.ts
@@ -510,13 +510,18 @@ export function setupMainEventListeners(deps: {
           return;
         }
 
-        // Create plain terminal
-        createPlainTerminal({
+        // Create plain terminal and open settings modal
+        const newTerminal = await createPlainTerminal({
           state,
           workspacePath: state.getWorkspaceOrThrow(),
           generateNextConfigId,
           saveCurrentConfig,
         });
+
+        // Automatically open settings modal for the newly created terminal
+        if (newTerminal) {
+          showTerminalSettingsModal(newTerminal, state, render);
+        }
         return;
       }
 


### PR DESCRIPTION
## Summary

Automatically opens the settings modal after creating a new terminal via the "+" button, improving the user experience by allowing immediate configuration without requiring an extra click.

## Changes

**Modified `createPlainTerminal()` (terminal-actions.ts)**:
- Changed return type from `Promise<void>` to `Promise<Terminal | undefined>`
- Returns the created terminal object for caller to use
- Returns `undefined` on error (backward compatible)

**Updated "+" Button Handler (ui-event-handlers.ts)**:
- Now awaits terminal creation to get the terminal object
- Automatically calls `showTerminalSettingsModal()` with the new terminal
- Only opens modal if terminal was created successfully

## User Flow

**Before**:
1. User clicks "+" button
2. Terminal created with defaults
3. User must manually click settings icon to configure
4. Settings modal opens

**After**:
1. User clicks "+" button  
2. Terminal created with defaults
3. ✨ Settings modal opens automatically
4. User configures immediately or clicks Cancel to keep defaults

## Benefits

- ✅ **Reduces friction**: One less click to configure new terminals
- ✅ **Guided workflow**: Create → Configure → Use
- ✅ **Better for new users**: Prompts immediate configuration
- ✅ **Optional**: Users can cancel to keep default settings
- ✅ **Backward compatible**: Existing callers can ignore return value

## Implementation Details

**Type Safety**:
- Terminal object properly typed
- Undefined handling for error cases
- No breaking changes to existing callers

**Backward Compatibility**:
- Existing code calling `createPlainTerminal()` (main.ts menu handler) continues to work
- Return value is optional - callers can ignore it if not needed
- Only the "+" button handler uses the returned terminal

## Edge Cases Handled

- **Terminal creation failure**: Modal doesn't open if creation fails
- **Null checks**: Only opens modal when `newTerminal` is defined
- **Multiple clicks**: Existing creation logic prevents duplicates

## Testing

**Manual Test Plan**:
- [x] Click "+" button and verify modal opens automatically
- [x] Configure terminal in modal and verify settings save
- [x] Click Cancel in modal and verify terminal has defaults
- [x] Click settings icon on existing terminal (regression test)
- [x] Menu File → New Terminal works without issues
- [x] TypeScript compilation passes
- [x] Linter passes

## Risk Assessment

**Very Low Risk**:
- Small, focused change (2 files, ~15 lines)
- Backward compatible return type change
- No existing functionality broken
- Well-isolated feature addition

Closes #683