### PR TITLE
Improve Champion role interval prompt to match specificity of other roles

### DIFF
--- a/.loom/roles/champion.json
+++ b/.loom/roles/champion.json
@@ -2,7 +2,7 @@
   "name": "Champion",
   "description": "Promotes high-quality curated issues to approved status",
   "defaultInterval": 600000,
-  "defaultIntervalPrompt": "Check for curated issues ready to promote to approved status",
+  "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are a Champion who evaluates `loom:curated` issues for promotion to `loom:issue` status. Use `gh issue list --label=\"loom:curated\" --state=open` to find issues needing evaluation. For each issue (max 2 per iteration): (1) Evaluate against 8 quality criteria (clear problem, technical feasibility, implementation clarity, value alignment, scope, quality standards, risk assessment, completeness), (2) If ALL criteria pass: remove `loom:curated`, add `loom:issue`, and comment with approval reason, (3) If ANY criteria fail: keep `loom:curated`, comment with specific concerns and recommendations. Conservative bias - when in doubt, do NOT promote. Always leave audit trail comments.",
   "autonomousRecommended": true,
   "suggestedWorkerType": "claude"
 }


### PR DESCRIPTION
## Summary

Updates the Champion role's interval prompt to match the specificity and detail level of other role prompts (Curator, Judge, Builder), providing clear workflow guidance for autonomous agents.

## Problem

The Champion role had a vague interval prompt: "Check for curated issues ready to promote to approved status"

This lacked:
- Specific command to find curated issues
- Details about the 8 evaluation criteria
- Rate limiting (max 2 per iteration)
- Label workflow (what to add/remove)
- Emphasis on conservative bias and audit trail

## Solution

Updated `.loom/roles/champion.json` with a comprehensive interval prompt that includes:

✅ Specific `gh` command: `gh issue list --label="loom:curated" --state=open`
✅ Mentions 8 quality criteria for evaluation
✅ Specifies rate limit (max 2 per iteration)
✅ Includes label workflow (remove curated, add issue)
✅ Emphasizes conservative bias ("when in doubt, do NOT promote")
✅ Reminds agent to leave audit trail comments

## Changes

### `.loom/roles/champion.json`

**Before:**
```json
"defaultIntervalPrompt": "Check for curated issues ready to promote to approved status"
```

**After:**
```json
"defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are a Champion who evaluates `loom:curated` issues for promotion to `loom:issue` status. Use `gh issue list --label=\"loom:curated\" --state=open` to find issues needing evaluation. For each issue (max 2 per iteration): (1) Evaluate against 8 quality criteria (clear problem, technical feasibility, implementation clarity, value alignment, scope, quality standards, risk assessment, completeness), (2) If ALL criteria pass: remove `loom:curated`, add `loom:issue`, and comment with approval reason, (3) If ANY criteria fail: keep `loom:curated`, comment with specific concerns and recommendations. Conservative bias - when in doubt, do NOT promote. Always leave audit trail comments."
```

## Test Plan

**Verified:**
- [x] JSON syntax is valid
- [x] Prompt length comparable to other detailed roles
- [x] All 7 acceptance criteria met:
  - [x] Includes specific `gh` command
  - [x] Mentions 8 evaluation criteria
  - [x] Specifies rate limit (max 2 per iteration)
  - [x] Includes label workflow
  - [x] Emphasizes audit trail comments
  - [x] Mentions conservative bias
  - [x] Matches specificity of other roles

**Manual testing needed:**
- [ ] Configure terminal with Champion role
- [ ] Verify interval prompt shows the updated text
- [ ] Run Champion iteration and verify it follows the workflow

## Benefits

- ✅ **Consistency**: Matches specificity of Curator/Judge/Builder prompts
- ✅ **Clarity**: Agent knows exactly what to do and how to do it
- ✅ **Quality**: Reinforces the 8 criteria and conservative approach
- ✅ **Audit trail**: Emphasizes importance of leaving comments

## Risk Assessment

**Risk Level**: Low

- Single configuration file modified
- No code changes
- JSON syntax validated
- Prompt content reviewed against role definition file

Closes #685

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>