### PR TITLE
Change loom:architect and loom:hermit label colors from blue to purple

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -44,11 +44,11 @@
 # Agent Proposal Labels
 - name: loom:architect
   description: Architect proposal awaiting user approval
-  color: "3B82F6"  # blue-500
+  color: "9333EA"  # purple (violet-600)
 
 - name: loom:hermit
   description: Hermit removal/simplification proposal awaiting user approval
-  color: "3B82F6"  # blue-500
+  color: "9333EA"  # purple (violet-600)
 
 - name: loom:curated
   description: Enhanced by Curator, awaiting human approval


### PR DESCRIPTION
## Summary

Updates the label colors for `loom:architect` and `loom:hermit` from blue (#3B82F6) to purple (#9333EA) to align with the design specification.

## Problem

The `.github/labels.yml` file currently defines these proposal labels as blue, but the design document (`docs/design/issue-332-label-state-machine.md:26-27`) specifies they should be purple to visually distinguish proposal labels from approved work labels.

**Current state:**
- `loom:architect`: Blue (#3B82F6) ❌
- `loom:hermit`: Blue (#3B82F6) ❌

**Design spec:**
- `loom:architect`: Purple (#9333EA) ✅
- `loom:hermit`: Purple (#9333EA) ✅

## Solution

Changed color codes in `.github/labels.yml`:
- Line 47: `loom:architect` color: `"3B82F6"` → `"9333EA"`
- Line 51: `loom:hermit` color: `"3B82F6"` → `"9333EA"`

## Changes

### `.github/labels.yml`

**Before:**
```yaml
- name: loom:architect
  color: "3B82F6"  # blue-500

- name: loom:hermit
  color: "3B82F6"  # blue-500
```

**After:**
```yaml
- name: loom:architect
  color: "9333EA"  # purple (violet-600)

- name: loom:hermit
  color: "9333EA"  # purple (violet-600)
```

## Test Plan

**Automated:**
- [x] File modified successfully
- [x] Commit created with proper message

**Manual testing needed:**
- [ ] Sync labels to GitHub: `gh label edit loom:architect --color "9333EA"`
- [ ] Sync labels to GitHub: `gh label edit loom:hermit --color "9333EA"`
- [ ] Verify labels appear purple in GitHub UI
- [ ] Check existing issues with these labels display correctly

## Acceptance Criteria

From issue #694:

- [x] Update `.github/labels.yml` line 47: `loom:architect` color changed to `"9333EA"`
- [x] Update `.github/labels.yml` line 51: `loom:hermit` color changed to `"9333EA"`
- [ ] Sync labels to GitHub (requires manual step or CI)
- [ ] Verify colors appear as purple in GitHub UI
- [ ] Design doc already correct (no doc changes needed)

## Benefits

- **Visual clarity**: Proposal labels (purple) now distinct from approved work (blue)
- **Design compliance**: Matches specification in issue-332 design document
- **User experience**: Easier to identify proposal-type issues at a glance

## Risk Assessment

**Risk Level**: Minimal

- Configuration-only change (no code logic)
- 2 lines modified in labels file
- No workflow impact (labels function identically)
- Requires label sync to GitHub after merge

Closes #694

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>