### PR TITLE
Add philosophy document: Where are all the AI-generated projects?

### DIFF
--- a/docs/philosophy/where-are-all-the-projects.md
+++ b/docs/philosophy/where-are-all-the-projects.md
@@ -1,0 +1,320 @@
+# The Expert Paradox: Why the Best Programmers Are Missing the AI Revolution
+
+*Why hasn't vibecoding produced an explosion of high-quality open source projects?*
+
+---
+
+## The Puzzle
+
+We're living through what should be a golden age of open source. AI coding assistants have:
+- Dramatically lowered the barrier to entry
+- Made prototyping 10x faster
+- Eliminated entire classes of boilerplate tedium
+- Given solo developers the productivity of small teams
+
+**And yet...**
+
+Where are the new high-quality open source projects from this new paradigm? Where's the explosion of innovative tools, frameworks, and libraries we'd expect?
+
+The answer might be uncomfortable: **The people best positioned to build them aren't using these tools.**
+
+---
+
+## The Expert's Dilemma
+
+### Their Priors Are Out of Date
+
+**The Evolution Timeline:**
+
+**Early Era (2019-2022):**
+- **GPT-2 (2019):** Barely coherent, toy-level code generation
+- **GPT-3 (2020):** Impressive but unreliable, hallucinated APIs
+- **Codex/Copilot (2021-2022):** Useful autocomplete, but not transformative
+- **Early ChatGPT (Nov 2022):** Good at explaining, bad at implementing
+
+**The Devin Debacle (Early 2024):**
+- **Devin (March 12, 2024):** Cognition AI launches the "world's first AI software engineer" with viral demo videos. Claimed 13.86% success on SWE-bench. Reality: struggled with basic tasks, got stuck in loops, produced buggy code.
+- **Devon & Others (April 2024):** Wave of open-source clones (Devon, OpenDevin/OpenHands, Devika) emerge. Most barely functional, confirming experts' worst fears.
+- **Expert reaction:** "See? I told you autonomous AI coding doesn't work"
+- **Damage done:** Poisoned the well for serious agentic tools that came after
+
+**The Breakthrough (Mid-2024):**
+- **Claude 3.5 Sonnet (June 20, 2024):** Massive capability jump. Anthropic releases model that's genuinely competent at complex coding tasks.
+- **Cursor Composer (Mid-2024):** Multi-file editing feature launches in beta, becomes default by late 2024
+- **Replit Agent (September 2024):** First viable "at-scale" autonomous software agent, introduces "vibe coding" for beginners
+- **Cline/Claude Dev (2024):** VSCode extension brings autonomous agentic coding to developers' existing editors
+- **Cursor Agent Mode (November 2024):** Cursor v0.43 adds Composer Agent, enabling autonomous multi-file refactoring
+
+**The Maturation (Late 2024 - Early 2025):**
+- **Windsurf Editor (November 13, 2024):** Codeium launches first "agentic IDE" with Cascade chat innovation, free tier with no rate limits
+- **Claude Code CLI (February 24, 2025):** Anthropic releases official command-line agentic tool alongside Claude 3.7 Sonnet
+- **Replit Agent v2 (February 25, 2025):** More autonomous version capable of end-to-end products
+- **Amazon Kiro (July 15, 2025 preview):** AWS enters the space with "spec-driven" approach, positioning against "vibe coding chaos"
+- **Replit Agent 3 (September 10, 2025):** Extended autonomous coding with industrial-grade reliability
+- **Woz (October 2025):** Raises $6M for "anti-vibe coding" approach combining AI with human expert oversight
+
+**Expert Conclusions (Formed at Various Points):**
+- 2020-2022: "It's just fancy autocomplete"
+- 2022-2023: "I have to fix everything it writes anyway"
+- Early 2024: "Autonomous agents are vaporware" ← **Devin/Devon reinforced this**
+- Mid-2024 onwards: *Most experts stopped evaluating*
+
+These conclusions were **reasonable based on when they tried the tools**. But the field is evolving in months, not years.
+
+**The Critical Gap:**
+
+Many experts last seriously evaluated AI coding in **early 2024** (the Devin era) and haven't revisited. They completely missed:
+
+- **Claude 3.5 Sonnet** being 10x better than what powered Devin
+- **Cursor Composer, Windsurf, Cline** maturing from experiments to production tools
+- **Claude Code CLI and Loom** showing what well-designed agentic systems can do
+- The paradigm shift from "autonomous agents" to **"collaborative agents with human oversight"**
+- Amazon, Anthropic, and other major players validating the space
+
+**The capability gap is staggering:**
+- Claude 3.5 Sonnet (2024) vs GPT-3 (2020): Like comparing a senior engineer to a CS101 student
+- Context windows: 4K tokens → 200K tokens (50x increase)
+- Tool use: None → Full CLI, file ops, web search, MCP protocols
+- Reasoning: Pattern matching → Multi-step planning with verification
+- Code understanding: Superficial → Deep architectural comprehension
+
+**Most experts haven't updated their priors in 6-18 months.** In AI timescales, that's multiple generations.
+
+---
+
+## The Targeting Problem
+
+**Vibecoding platforms have not been designed for expert programmers.**
+
+Look at how these tools position themselves:
+
+**Beginner-Focused Messaging:**
+- **Replit Agent:** "Build apps without coding" - explicitly targets non-programmers
+- **v0 (Vercel):** "Generate UI from prompts" - sounds like WYSIWYG drag-and-drop
+- **Bolt.new:** "Prompt, run, edit, deploy" - full-stack apps from chat
+- **Woz:** "Enable anyone to build software businesses - no coding required"
+
+**Workflow-Replacement Messaging:**
+- **Cursor:** "AI-first code editor" - implies you need to abandon VS Code
+- **Windsurf:** "First agentic IDE" - suggests leaving your current setup
+- **Amazon Kiro:** "Beyond vibe coding" - but still positioned as IDE replacement
+
+**Assistant/Copilot Messaging:**
+- **GitHub Copilot:** "AI pair programmer" - helper, not peer
+- **Cline:** "Autonomous coding agent" - but buried as a VS Code extension
+- **Codeium:** Started as autocomplete, expanded to Windsurf
+
+**Expert-Skeptic Messaging (Rare):**
+- **Claude Code CLI:** "Agentic coding from your terminal" - actually targets CLI-native developers
+- **Cursor Composer:** Multi-file refactoring (but overshadowed by beginner marketing)
+- **Loom:** Agent orchestration (but it's developer tooling for *building* with AI, not a product)
+
+**What expert programmers see and think:**
+- "I don't need help typing code, I need help with architecture" ← Wrong framing
+- "This is for non-programmers building todo apps" ← Partially true but limiting
+- "I'm not the target audience" ← Self-selection out of the market
+- "Real work requires VS Code/Neovim, not some new IDE" ← Windsurf/Cursor are VS Code forks!
+
+**The reality experts miss:**
+
+Tools like **Claude Code, Cursor Composer, Windsurf Cascade, and Loom** are genuinely powerful enough for expert work:
+- Multi-file refactoring across large codebases
+- Complex architectural changes with test verification
+- Database migrations and API redesigns
+- Performance optimization with profiling integration
+- Autonomous PR creation with comprehensive testing
+
+**But they're marketed for beginner delight, not expert skepticism.**
+
+The platforms optimized for viral demos ("Look, I built Instagram in 5 minutes!") rather than demonstrating sophisticated use cases experts care about ("I refactored 40 files to migrate from REST to GraphQL and all tests pass").
+
+**The messaging gap is massive:** Experts don't realize these tools can handle their actual work because the marketing shows toy examples.
+
+---
+
+## The Emotional Resistance
+
+### The John Henry Effect
+
+John Henry was a steel-driving man who died proving he could outwork a steam drill. Expert programmers are having their John Henry moment.
+
+**The identity threat is real:**
+- "I spent 20 years mastering this craft"
+- "My value comes from knowing how to implement complex systems"
+- "If AI can write code, what am I worth?"
+
+**Rational fear:**
+- Will companies realize they can hire fewer seniors?
+- Will my hard-won expertise become commoditized?
+- Am I about to be replaced?
+
+**Emotional defense mechanisms:**
+- Dismiss AI capabilities ("it's just pattern matching")
+- Focus on edge cases where AI fails ("see, it can't do X")
+- Overvalue human-written code quality ("AI code is always messy")
+- Gatekeep the craft ("real programmers don't use autocomplete")
+
+**This isn't weakness—it's normal human psychology when your livelihood is threatened.**
+
+### The Craftsman's Trap
+
+Great programmers take pride in their code. They've internalized principles like:
+- Code should be elegant
+- Abstractions should be beautiful
+- Implementation details matter
+- The craft itself has intrinsic value
+
+**AI-generated code violates these aesthetics:**
+- It's often verbose where a human would be terse
+- It favors explicitness over cleverness
+- It uses patterns that feel "naive"
+- It doesn't have "style"
+
+Expert programmers **feel** that AI code is worse, even when it objectively works correctly and is more maintainable.
+
+**The trap:** They're optimizing for the wrong metric. Code isn't literature. It's instructions for machines. Clarity beats elegance. Working beats beautiful.
+
+But you can't logic someone out of an emotional attachment to their craft.
+
+---
+
+## The Paradigm Shift They're Missing
+
+### Old Bottleneck: Implementation Speed
+*"How fast can I write this code?"*
+
+**Expert advantage:** 10x faster than juniors at implementation
+- Know idioms and patterns by heart
+- Type quickly, minimal syntax errors
+- Navigate codebases efficiently
+- Debug quickly from experience
+
+**AI disrupts this:** AI can implement as fast as seniors (or faster)
+
+### New Bottleneck: Specification Clarity
+*"How clearly can I define what needs to be built?"*
+
+**Expert advantage:** Should be 10x better at specification
+- Understand edge cases and failure modes
+- Know what questions to ask
+- Anticipate integration issues
+- See architectural implications
+
+**But experts aren't pivoting:** They're still competing on implementation speed (which AI commoditized) rather than doubling down on specification clarity (where they have unmatched advantage).
+
+---
+
+## What They're Missing
+
+### The Multiplication Effect
+
+**Expert knowledge × AI implementation speed = unprecedented productivity**
+
+An expert programmer with Claude Code should be able to:
+- Architect a system in the morning
+- Have a working prototype by afternoon
+- Iterate through 3-4 design alternatives in a day
+- Ship production-quality code by end of week
+
+**Without AI:**
+- Architect in the morning
+- Spend a week implementing
+- Too invested to throw away and try alternative
+- Ship in 2-3 weeks
+
+**The expert who embraces AI isn't competing with the AI. They're competing with other experts.**
+
+And the ones who figure out how to leverage AI will be 10x more productive than the ones who resist.
+
+---
+
+## Why This Matters for Open Source
+
+### The Missing Projects
+
+The high-quality open source projects that should exist but don't:
+- Not "yet another todo app" (beginners can build those now)
+- But **architecturally sophisticated systems** that require expert judgment:
+  - Novel database designs
+  - Compilers and language tools
+  - Distributed systems frameworks
+  - Performance optimization libraries
+  - Developer tooling with deep CLI/editor integration
+
+**These require:**
+1. Deep technical expertise (expert knowledge)
+2. Significant implementation effort (AI can help)
+3. Sustained iteration (AI accelerates this)
+
+Beginners with AI can build apps. **Experts with AI could build infrastructure.**
+
+But experts aren't at the table yet.
+
+---
+
+## The Path Forward
+
+### For Experts Who Are Skeptical
+
+**1. Update your priors**
+- Try Claude 3.5 Sonnet or GPT-4.5 (not GPT-3 from 2020)
+- Use it for a real project, not a toy example
+- Give it 2 weeks of daily use before judging
+
+**2. Reframe the paradigm**
+- You're not being replaced by AI
+- You're being given a force multiplier
+- Your expertise becomes MORE valuable (specification > implementation)
+- The craft shifts from "writing code" to "architecting intent"
+
+**3. Find tools designed for experts**
+- Claude Code CLI (file ops, terminal control, full autonomy)
+- Cursor Composer (multi-file refactors, codebase-wide changes)
+- Loom (orchestrate multiple AI agents like a team)
+
+These aren't "autocomplete+" tools. They're **peer-level collaborators** if you learn to work with them.
+
+**4. Experiment with delegation**
+- Let AI write the boring parts (tests, boilerplate, data transformations)
+- Focus your energy on hard problems (architecture, API design, optimization)
+- Review instead of implementing
+- Specify instead of typing
+
+**5. Build the project you've been putting off**
+- That tool you've wanted to build for years but never had time
+- That open source contribution that seemed too daunting
+- That architectural experiment you couldn't afford to try
+
+AI doesn't make expertise obsolete. **It removes the implementation bottleneck that was keeping expertise locked up.**
+
+---
+
+## The Opportunity
+
+**Right now, there's a vacuum.**
+
+Beginners are using AI to build apps (great!), but they lack the architectural sophistication to build foundational tools.
+
+Experts have the sophistication but aren't using the tools.
+
+**The first wave of experts who embrace AI will have an enormous advantage:**
+- They'll build the infrastructure for the next generation
+- They'll create the projects that define the new paradigm
+- They'll establish patterns and practices others will follow
+- They'll be the ones who actually **multiply their impact** instead of being displaced
+
+---
+
+## The Question
+
+Will you update your priors? Or will you wait until the gap is so obvious that you're playing catch-up?
+
+**The vibecoding revolution won't happen without experts.** But experts won't join without overcoming their (understandable) resistance.
+
+Loom exists because we believe expert judgment + AI implementation = the future of software development.
+
+The explosion of high-quality open source projects is waiting on the other side of that transition.
+
+---
+
+*Related reading: [Working with AI: Insights from Building Loom](./working-with-ai.md)*


### PR DESCRIPTION
## Summary

Adds a new philosophy document exploring why the AI coding revolution hasn't produced an explosion of high-quality open source projects yet.

## What Changed

Created `docs/philosophy/where-are-all-the-projects.md` with:

### Comprehensive Timeline (2019-2025)
- **Early Era**: GPT-2, GPT-3, Copilot, ChatGPT
- **The Devin Debacle (March 2024)**: Hype and crash that poisoned the well
- **The Breakthrough (Mid-2024)**: Claude 3.5 Sonnet, Cursor Composer, Replit Agent
- **The Maturation (Late 2024-2025)**: Windsurf, Claude Code CLI, Amazon Kiro, Woz

### Key Analysis

**1. Out-of-date Priors**
- Experts tried tools in the Devin era (early 2024) and haven't revisited
- Missing massive improvements in just 6-18 months
- Formed reasonable conclusions that are now obsolete

**2. Targeting Problem**
- Platforms market to beginners with toy demos ("Build Instagram in 5 minutes!")
- Not demonstrating sophisticated use cases experts care about
- Experts self-selecting out: "I'm not the target audience"

**3. Emotional Resistance**
- John Henry effect: identity threat when craft is commoditized
- Craftsman's trap: optimizing for code elegance vs. working software
- Fear of replacement is normal human psychology

**4. Missing the Paradigm Shift**
- Old bottleneck: Implementation speed (commoditized by AI)
- New bottleneck: Specification clarity (where expertise matters)
- Experts still competing on the wrong metric

### Why This Matters

- Positions Loom as the tool for experts who want to leverage AI
- Validates skepticism while showing what they're missing
- Explains the vacuum: beginners build apps, but infrastructure requires expert judgment + AI speed
- Complements existing philosophy docs

## Related

Closes #765

Complements:
- `docs/philosophy/working-with-ai.md` - How to work with AI effectively
- `docs/philosophy/agent-archetypes.md` - How to organize AI agent teams

🤖 Generated with [Claude Code](https://claude.com/claude-code)