### PR TITLE
Tighten philosophy document to ~200 lines

### DIFF
--- a/docs/philosophy/where-are-all-the-projects.md
+++ b/docs/philosophy/where-are-all-the-projects.md
@@ -26,109 +26,43 @@ The answer might be uncomfortable: **The people best positioned to build them ar
 
 **The Evolution Timeline:**
 
-**Early Era (2019-2022):**
-- **GPT-2 (2019):** Barely coherent, toy-level code generation
-- **GPT-3 (2020):** Impressive but unreliable, hallucinated APIs
-- **Codex/Copilot (2021-2022):** Useful autocomplete, but not transformative
-- **Early ChatGPT (Nov 2022):** Good at explaining, bad at implementing
+**Early Era (2019-2024):** GPT-2/3 (unreliable), Copilot (autocomplete), ChatGPT (good explanations, poor implementation), Claude 3.5 Sonnet (June 2024 - decent but not transformative). Experts concluded: "It's just fancy autocomplete" or "I have to fix everything it writes."
 
-**The Devin Debacle (Early 2024):**
-- **Devin (March 12, 2024):** Cognition AI launches the "world's first AI software engineer" with viral demo videos. Claimed 13.86% success on SWE-bench. Reality: struggled with basic tasks, got stuck in loops, produced buggy code.
-- **Devon & Others (April 2024):** Wave of open-source clones (Devon, OpenDevin/OpenHands, Devika) emerge. Most barely functional, confirming experts' worst fears.
-- **Expert reaction:** "See? I told you autonomous AI coding doesn't work"
-- **Damage done:** Poisoned the well for serious agentic tools that came after
+**The Devin Debacle (March 2024):** Cognition AI launches Devin as "world's first AI software engineer" with viral demos. Reality: struggled with basic tasks. Wave of open-source clones (Devon, OpenDevin, Devika) emerge, mostly broken. Expert reaction: "See? Autonomous AI coding doesn't work." **This poisoned the well.**
 
-**The Breakthrough (Mid-2024):**
-- **Claude 3.5 Sonnet (June 20, 2024):** Massive capability jump. Anthropic releases model that's genuinely competent at complex coding tasks.
-- **Cursor Composer (Mid-2024):** Multi-file editing feature launches in beta, becomes default by late 2024
-- **Replit Agent (September 2024):** First viable "at-scale" autonomous software agent, introduces "vibe coding" for beginners
-- **Cline/Claude Dev (2024):** VSCode extension brings autonomous agentic coding to developers' existing editors
-- **Cursor Agent Mode (November 2024):** Cursor v0.43 adds Composer Agent, enabling autonomous multi-file refactoring
+**The Platform Maturation (Late 2024):** Windsurf (November 2024), Cursor Composer, Replit Agent, Cline. Tools mature from experiments to production-grade, but still limited by underlying model capabilities.
 
-**The Maturation (Late 2024 - Early 2025):**
-- **Windsurf Editor (November 13, 2024):** Codeium launches first "agentic IDE" with Cascade chat innovation, free tier with no rate limits
-- **Claude Code CLI (February 24, 2025):** Anthropic releases official command-line agentic tool alongside Claude 3.7 Sonnet
-- **Replit Agent v2 (February 25, 2025):** More autonomous version capable of end-to-end products
-- **Amazon Kiro (July 15, 2025 preview):** AWS enters the space with "spec-driven" approach, positioning against "vibe coding chaos"
-- **Replit Agent 3 (September 10, 2025):** Extended autonomous coding with industrial-grade reliability
-- **Woz (October 2025):** Raises $6M for "anti-vibe coding" approach combining AI with human expert oversight
+**The Real Inflection Point (2025):** Claude Code CLI (February 2025), Claude Sonnet 4.5 (late 2024/early 2025), GPT-5. **This is when the models finally became genuinely competent programmers.** Amazon Kiro (July 2025), Woz (October 2025) show major players betting on the space.
 
-**Expert Conclusions (Formed at Various Points):**
-- 2020-2022: "It's just fancy autocomplete"
-- 2022-2023: "I have to fix everything it writes anyway"
-- Early 2024: "Autonomous agents are vaporware" ← **Devin/Devon reinforced this**
-- Mid-2024 onwards: *Most experts stopped evaluating*
-
-These conclusions were **reasonable based on when they tried the tools**. But the field is evolving in months, not years.
+**The timing tragedy:** Most experts evaluated in 2024, formed reasonable negative conclusions, and haven't revisited. The models that actually work well enough for expert-level work only emerged in 2025.
 
 **The Critical Gap:**
 
-Many experts last seriously evaluated AI coding in **early 2024** (the Devin era) and haven't revisited. They completely missed:
+The models that finally work (Sonnet 4.5, GPT-5) only emerged in 2025. Most experts evaluated in 2024 or earlier. The gap:
 
-- **Claude 3.5 Sonnet** being 10x better than what powered Devin
-- **Cursor Composer, Windsurf, Cline** maturing from experiments to production tools
-- **Claude Code CLI and Loom** showing what well-designed agentic systems can do
-- The paradigm shift from "autonomous agents" to **"collaborative agents with human oversight"**
-- Amazon, Anthropic, and other major players validating the space
+- Context windows: 4K → 200K tokens (50x)
+- Tool use: None → Full CLI, file ops, MCP protocols
+- Reasoning: Pattern matching → Multi-step architectural planning
+- Code quality: Needs heavy editing → Production-ready
 
-**The capability gap is staggering:**
-- Claude 3.5 Sonnet (2024) vs GPT-3 (2020): Like comparing a senior engineer to a CS101 student
-- Context windows: 4K tokens → 200K tokens (50x increase)
-- Tool use: None → Full CLI, file ops, web search, MCP protocols
-- Reasoning: Pattern matching → Multi-step planning with verification
-- Code understanding: Superficial → Deep architectural comprehension
-
-**Most experts haven't updated their priors in 6-18 months.** In AI timescales, that's multiple generations.
+**Most experts haven't updated their priors in 12-24 months.** The capability jump from "decent autocomplete" to "genuine coding peer" happened in that window.
 
 ---
 
 ## The Targeting Problem
 
-**Vibecoding platforms have not been designed for expert programmers.**
+**Vibecoding platforms market to beginners, not experts.**
 
-Look at how these tools position themselves:
+Most tools position as: "Build apps without coding" (Replit, Woz, Bolt), "Generate UI from prompts" (v0), or "AI pair programmer" (Copilot). Even sophisticated tools like Cursor and Windsurf market with viral demos: "Look, I built Instagram in 5 minutes!"
 
-**Beginner-Focused Messaging:**
-- **Replit Agent:** "Build apps without coding" - explicitly targets non-programmers
-- **v0 (Vercel):** "Generate UI from prompts" - sounds like WYSIWYG drag-and-drop
-- **Bolt.new:** "Prompt, run, edit, deploy" - full-stack apps from chat
-- **Woz:** "Enable anyone to build software businesses - no coding required"
+**Experts see this and think:**
+- "I don't need help typing, I need help with architecture"
+- "This is for beginners building todo apps"
+- "I'm not the target audience"
 
-**Workflow-Replacement Messaging:**
-- **Cursor:** "AI-first code editor" - implies you need to abandon VS Code
-- **Windsurf:** "First agentic IDE" - suggests leaving your current setup
-- **Amazon Kiro:** "Beyond vibe coding" - but still positioned as IDE replacement
+**The reality:** Tools like Claude Code CLI, Cursor Composer, and Windsurf can handle expert-level work: multi-file refactoring across large codebases, complex architectural migrations, database schema changes, performance optimization. But the marketing shows toy examples.
 
-**Assistant/Copilot Messaging:**
-- **GitHub Copilot:** "AI pair programmer" - helper, not peer
-- **Cline:** "Autonomous coding agent" - but buried as a VS Code extension
-- **Codeium:** Started as autocomplete, expanded to Windsurf
-
-**Expert-Skeptic Messaging (Rare):**
-- **Claude Code CLI:** "Agentic coding from your terminal" - actually targets CLI-native developers
-- **Cursor Composer:** Multi-file refactoring (but overshadowed by beginner marketing)
-- **Loom:** Agent orchestration (but it's developer tooling for *building* with AI, not a product)
-
-**What expert programmers see and think:**
-- "I don't need help typing code, I need help with architecture" ← Wrong framing
-- "This is for non-programmers building todo apps" ← Partially true but limiting
-- "I'm not the target audience" ← Self-selection out of the market
-- "Real work requires VS Code/Neovim, not some new IDE" ← Windsurf/Cursor are VS Code forks!
-
-**The reality experts miss:**
-
-Tools like **Claude Code, Cursor Composer, Windsurf Cascade, and Loom** are genuinely powerful enough for expert work:
-- Multi-file refactoring across large codebases
-- Complex architectural changes with test verification
-- Database migrations and API redesigns
-- Performance optimization with profiling integration
-- Autonomous PR creation with comprehensive testing
-
-**But they're marketed for beginner delight, not expert skepticism.**
-
-The platforms optimized for viral demos ("Look, I built Instagram in 5 minutes!") rather than demonstrating sophisticated use cases experts care about ("I refactored 40 files to migrate from REST to GraphQL and all tests pass").
-
-**The messaging gap is massive:** Experts don't realize these tools can handle their actual work because the marketing shows toy examples.
+The messaging gap is massive. Experts self-select out based on positioning alone.
 
 ---
 
@@ -136,45 +70,23 @@ The platforms optimized for viral demos ("Look, I built Instagram in 5 minutes!"
 
 ### The John Henry Effect
 
-John Henry was a steel-driving man who died proving he could outwork a steam drill. Expert programmers are having their John Henry moment.
+Expert programmers spent 20 years mastering implementation. Now AI can implement as fast as they can. The identity threat is real: "If AI can write code, what am I worth?"
 
-**The identity threat is real:**
-- "I spent 20 years mastering this craft"
-- "My value comes from knowing how to implement complex systems"
-- "If AI can write code, what am I worth?"
-
-**Rational fear:**
-- Will companies realize they can hire fewer seniors?
-- Will my hard-won expertise become commoditized?
-- Am I about to be replaced?
-
-**Emotional defense mechanisms:**
+**Defense mechanisms:**
 - Dismiss AI capabilities ("it's just pattern matching")
-- Focus on edge cases where AI fails ("see, it can't do X")
-- Overvalue human-written code quality ("AI code is always messy")
-- Gatekeep the craft ("real programmers don't use autocomplete")
+- Focus on edge cases where AI fails
+- Overvalue human code aesthetics
+- Gatekeep ("real programmers don't use autocomplete")
 
-**This isn't weakness—it's normal human psychology when your livelihood is threatened.**
+This isn't weakness—it's normal human psychology when your livelihood is threatened.
 
 ### The Craftsman's Trap
 
-Great programmers take pride in their code. They've internalized principles like:
-- Code should be elegant
-- Abstractions should be beautiful
-- Implementation details matter
-- The craft itself has intrinsic value
+Great programmers take pride in elegant, terse code with beautiful abstractions. AI code is often verbose, explicit, and "naive."
 
-**AI-generated code violates these aesthetics:**
-- It's often verbose where a human would be terse
-- It favors explicitness over cleverness
-- It uses patterns that feel "naive"
-- It doesn't have "style"
+Experts **feel** AI code is worse, even when it objectively works and is more maintainable.
 
-Expert programmers **feel** that AI code is worse, even when it objectively works correctly and is more maintainable.
-
-**The trap:** They're optimizing for the wrong metric. Code isn't literature. It's instructions for machines. Clarity beats elegance. Working beats beautiful.
-
-But you can't logic someone out of an emotional attachment to their craft.
+**The trap:** They're optimizing for the wrong metric. Code isn't literature. Working beats beautiful. But you can't logic someone out of an emotional attachment to their craft.
 
 ---
 
@@ -254,64 +166,27 @@ But experts aren't at the table yet.
 
 ## The Path Forward
 
-### For Experts Who Are Skeptical
+**Update your priors:** Try Sonnet 4.5 or GPT-5 (not 2024-era models). Use it for a real project for 2 weeks.
 
-**1. Update your priors**
-- Try Claude 3.5 Sonnet or GPT-4.5 (not GPT-3 from 2020)
-- Use it for a real project, not a toy example
-- Give it 2 weeks of daily use before judging
+**Reframe the paradigm:** You're not being replaced—you're getting a force multiplier. Your expertise becomes MORE valuable. The craft shifts from "writing code" to "architecting intent."
 
-**2. Reframe the paradigm**
-- You're not being replaced by AI
-- You're being given a force multiplier
-- Your expertise becomes MORE valuable (specification > implementation)
-- The craft shifts from "writing code" to "architecting intent"
+**Find the right tools:** Claude Code CLI, Cursor Composer, and similar aren't autocomplete—they're peer-level collaborators for experts who learn to work with them.
 
-**3. Find tools designed for experts**
-- Claude Code CLI (file ops, terminal control, full autonomy)
-- Cursor Composer (multi-file refactors, codebase-wide changes)
-- Loom (orchestrate multiple AI agents like a team)
+**Experiment with delegation:** Let AI handle tests, boilerplate, data transformations. Focus your energy on architecture, API design, optimization. Review instead of implementing.
 
-These aren't "autocomplete+" tools. They're **peer-level collaborators** if you learn to work with them.
+**Build what you've been putting off:** That tool you never had time for. That open source contribution that seemed too daunting. That architectural experiment you couldn't afford to try.
 
-**4. Experiment with delegation**
-- Let AI write the boring parts (tests, boilerplate, data transformations)
-- Focus your energy on hard problems (architecture, API design, optimization)
-- Review instead of implementing
-- Specify instead of typing
-
-**5. Build the project you've been putting off**
-- That tool you've wanted to build for years but never had time
-- That open source contribution that seemed too daunting
-- That architectural experiment you couldn't afford to try
-
-AI doesn't make expertise obsolete. **It removes the implementation bottleneck that was keeping expertise locked up.**
+AI removes the implementation bottleneck that was keeping expertise locked up.
 
 ---
 
 ## The Opportunity
 
-**Right now, there's a vacuum.**
+Right now there's a vacuum. Beginners are building apps, but lack the sophistication for infrastructure. Experts have the sophistication but aren't using the tools.
 
-Beginners are using AI to build apps (great!), but they lack the architectural sophistication to build foundational tools.
+The first wave of experts who embrace AI will build the infrastructure for the next generation, create the projects that define the new paradigm, and multiply their impact instead of being displaced.
 
-Experts have the sophistication but aren't using the tools.
-
-**The first wave of experts who embrace AI will have an enormous advantage:**
-- They'll build the infrastructure for the next generation
-- They'll create the projects that define the new paradigm
-- They'll establish patterns and practices others will follow
-- They'll be the ones who actually **multiply their impact** instead of being displaced
-
----
-
-## The Question
-
-Will you update your priors? Or will you wait until the gap is so obvious that you're playing catch-up?
-
-**The vibecoding revolution won't happen without experts.** But experts won't join without overcoming their (understandable) resistance.
-
-Loom exists because we believe expert judgment + AI implementation = the future of software development.
+Will you update your priors? Or wait until the gap is so obvious you're playing catch-up?
 
 The explosion of high-quality open source projects is waiting on the other side of that transition.
 


### PR DESCRIPTION
## Summary

Tightens  from 320 lines to 195 lines while retaining all key insights.

## Changes

**Timeline section:** Consolidated from 4 detailed eras into 4 focused paragraphs
- Emphasized that real inflection point was 2025 (Sonnet 4.5, GPT-5), not 2024
- Claude 3.5 Sonnet was "decent but not transformative"
- The models that work well enough for experts only emerged in 2025

**Targeting problem:** Compressed from ~40 lines to ~12 lines
- Removed exhaustive platform categorization
- Kept core insight: marketing shows toy examples, experts self-select out

**Emotional resistance:** Shortened from ~30 lines to ~20 lines
- Preserved John Henry effect and craftsman's trap
- More concise without losing punch

**Path forward:** Condensed from ~25 lines to ~10 lines
- Bullet lists → Short paragraphs
- Removed redundancy

**Conclusion:** Removed Loom marketing
- Cut "Loom exists because..." paragraph
- Cleaner ending focused on the opportunity

## Result

Document is now more focused and punchy. Goes from ~320 lines to 195 lines (target was 200-250).

Closes #767

🤖 Generated with [Claude Code](https://claude.com/claude-code)