### PR TITLE
Add Champion role to configuration and documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Use Claude Code terminals with specialized roles for hands-on development coordi
 ```bash
 # Terminal 1: Builder working on feature
 /builder
-# Claims loom:ready issue, implements, creates PR
+# Claims loom:issue issue, implements, creates PR
 
 # Terminal 2: Judge reviewing PRs
 /judge
@@ -43,7 +43,7 @@ Use Claude Code terminals with specialized roles for hands-on development coordi
 
 # Terminal 3: Curator maintaining issues
 /curator
-# Enhances unlabeled issues, marks as loom:ready
+# Enhances unlabeled issues, marks as loom:curated
 ```
 
 ### 2. Tauri App Mode
@@ -84,6 +84,11 @@ Loom provides specialized roles for different development tasks. Each role follo
 - **Purpose**: Review pull requests
 - **Workflow**: Finds `loom:review-requested` PRs → reviews → approves or requests changes
 - **When to use**: Code quality assurance, automated reviews
+
+**Champion** (Autonomous 10min, `champion.md`)
+- **Purpose**: Auto-merge approved PRs
+- **Workflow**: Finds `loom:pr` PRs → verifies safety criteria → auto-merges if safe
+- **When to use**: Reducing manual merge overhead for approved PRs
 
 **Curator** (Autonomous 5min, `curator.md`)
 - **Purpose**: Enhance and organize issues
@@ -133,12 +138,18 @@ Agents coordinate work through GitHub labels. This enables autonomous operation 
 ```
 (created) → loom:issue → loom:building → (closed)
            ↑ Curator      ↑ Builder
+
+(created) → loom:curating → loom:curated → loom:issue
+           ↑ Curator        ↑ Curator      ↑ Human approves
+
+(bug) → loom:treating → (fixed)
+       ↑ Doctor
 ```
 
 **PR Lifecycle**:
 ```
-(created) → loom:review-requested → loom:pr → (merged)
-           ↑ Builder                ↑ Judge    ↑ Human
+(created) → loom:review-requested → loom:pr → (auto-merged)
+           ↑ Builder                ↑ Judge    ↑ Champion
 ```
 
 **Proposal Lifecycle**:
@@ -152,14 +163,21 @@ Agents coordinate work through GitHub labels. This enables autonomous operation 
 
 ### Label Definitions
 
+**Workflow Labels**:
 - **`loom:issue`**: Issue approved for work, ready for Builder to claim
-- **`loom:building`**: Issue being implemented OR PR under review
+- **`loom:building`**: Builder is actively implementing this issue
+- **`loom:curating`**: Curator is actively enhancing this issue
+- **`loom:treating`**: Doctor is actively fixing this bug or addressing PR feedback
 - **`loom:review-requested`**: PR ready for Judge to review
-- **`loom:pr`**: PR approved by Judge, ready for human to merge
+- **`loom:pr`**: PR approved by Judge, ready for Champion to auto-merge
+
+**Proposal Labels**:
 - **`loom:architect`**: Architectural proposal awaiting user approval
 - **`loom:hermit`**: Simplification proposal awaiting user approval
-- **`loom:curated`**: Issue enhanced by Curator, awaiting approval
-- **`loom:blocked`**: Implementation blocked, needs help
+- **`loom:curated`**: Issue enhanced by Curator, awaiting human approval
+
+**Status Labels**:
+- **`loom:blocked`**: Implementation blocked, needs help or clarification
 - **`loom:urgent`**: Critical issue requiring immediate attention
 
 ## Git Worktree Workflow

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -85,6 +85,11 @@ Loom provides specialized roles for different development tasks. Each role follo
 - **Workflow**: Finds `loom:review-requested` PRs → reviews → approves or requests changes
 - **When to use**: Code quality assurance, automated reviews
 
+**Champion** (Autonomous 10min, `champion.md`)
+- **Purpose**: Auto-merge approved PRs
+- **Workflow**: Finds `loom:pr` PRs → verifies safety criteria → auto-merges if safe
+- **When to use**: Reducing manual merge overhead for approved PRs
+
 **Curator** (Autonomous 5min, `curator.md`)
 - **Purpose**: Enhance and organize issues
 - **Workflow**: Finds unlabeled issues → adds context → marks as `loom:issue`

--- a/defaults/config.json
+++ b/defaults/config.json
@@ -37,6 +37,18 @@
         "intervalPrompt": "Identify code simplification and removal opportunities"
       },
       "theme": "sunset"
+    },
+    {
+      "id": "terminal-4",
+      "name": "Champion",
+      "role": "claude-code-worker",
+      "roleConfig": {
+        "workerType": "claude",
+        "roleFile": "champion.md",
+        "targetInterval": 600000,
+        "intervalPrompt": "Check for PRs ready to auto-merge with loom:pr label"
+      },
+      "theme": "midnight"
     }
   ]
 }


### PR DESCRIPTION
Completes Phase 4 of Champion integration (#681) by adding the Champion role to default configuration and updating all documentation.

## Summary

This PR completes the Champion role integration started in #678, #679, and #680 by:
- Adding Champion to default terminal configuration
- Documenting Champion in both root and defaults CLAUDE.md files
- Updating label workflow diagrams to show Champion's auto-merge process
- Fixing outdated label references and improving label documentation organization

## Changes

### Documentation Updates

**CLAUDE.md** and **defaults/CLAUDE.md**:
- ✅ Added Champion to "Available Roles" section
  - Purpose: Auto-merge approved PRs
  - Workflow: Finds `loom:pr` PRs → verifies safety → auto-merges
  - Autonomous: 10-minute interval
- ✅ Updated PR lifecycle workflow to show Champion auto-merge
- ✅ Added missing issue lifecycle workflows (`loom:curating`, `loom:treating`)
- ✅ Reorganized label definitions into logical groups (Workflow, Proposal, Status)
- ✅ Fixed deprecated `loom:ready` references → `loom:issue`
- ✅ Updated `loom:building` definition to be more specific
- ✅ Updated `loom:pr` definition to reference Champion auto-merge

### Configuration Updates

**defaults/config.json**:
- ✅ Added Champion as `terminal-4`
  - 10-minute interval (`targetInterval: 600000`)
  - Autonomous mode enabled
  - Midnight theme
  - Interval prompt: "Check for PRs ready to auto-merge with loom:pr label"

## Test Plan

- [x] Verify Champion role file exists (`.loom/roles/champion.md`)
- [x] Verify Champion documented in both CLAUDE.md files
- [x] Verify Champion added to defaults/config.json
- [x] Verify all label references updated correctly
- [x] Verify workflow diagrams include Champion
- [x] Verify label definitions are comprehensive and organized

## Dependencies

Requires completed phases:
- ✅ #678 - Phase 1: Champion role definition
- ✅ #679 - Phase 2: Safety verification logic
- ✅ #680 - Phase 3: Auto-merge process

## Breaking Changes

None - purely additive documentation and configuration updates.

Closes #681