### PR TITLE
Fix Curator Priority 1 search missing loom:curating filter

### DIFF
--- a/defaults/roles/curator.md
+++ b/defaults/roles/curator.md
@@ -92,7 +92,7 @@ Issues with `loom:issue` (human-approved) but missing `loom:curated`:
 
 ```bash
 gh issue list --label="loom:issue" --state=open --json number,title,labels \
-  --jq '.[] | select(([.labels[].name] | contains(["loom:curated"]) | not) and ([.labels[].name] | contains(["external"]) | not)) |
+  --jq '.[] | select(([.labels[].name] | contains(["loom:curated"]) | not) and ([.labels[].name] | contains(["loom:curating"]) | not) and ([.labels[].name] | contains(["external"]) | not)) |
   "#\(.number): \(.title)"'
 ```
 


### PR DESCRIPTION
## Summary

Fixes #787 

This PR adds the missing `loom:curating` filter to the Curator Priority 1 search query. Without this filter, multiple curators could attempt to claim the same issue that's already being worked on.

## Changes

- **`defaults/roles/curator.md:95`**: Added `loom:curating` filter to Priority 1 search query

## Before
```bash
gh issue list --label="loom:issue" --state=open --json number,title,labels \
  --jq '.[] | select(([.labels[].name] | contains(["loom:curated"]) | not) and ([.labels[].name] | contains(["external"]) | not)) |
  "#\(.number): \(.title)"'
```

## After
```bash
gh issue list --label="loom:issue" --state=open --json number,title,labels \
  --jq '.[] | select(([.labels[].name] | contains(["loom:curated"]) | not) and ([.labels[].name] | contains(["loom:curating"]) | not) and ([.labels[].name] | contains(["external"]) | not)) |
  "#\(.number): \(.title)"'
```

This matches the pattern already used in Priority 2 search (lines 106-112).

## Testing

- Verified the jq filter syntax matches Priority 2 search pattern
- Confirmed the filter excludes issues with `loom:curating` label

## Impact

- Prevents duplicate curator work on the same issue
- Maintains consistency between Priority 1 and Priority 2 searches

🤖 Generated with [Claude Code](https://claude.com/claude-code)