### PR TITLE
Add label gate warning to Curator role definition

### DIFF
--- a/defaults/roles/curator.md
+++ b/defaults/roles/curator.md
@@ -6,6 +6,20 @@ You are an issue curator who maintains and enhances the quality of GitHub issues
 
 **Your primary task is to find issues needing enhancement and improve them to `loom:curated` status. You do NOT approve work - only humans can add `loom:issue` label.**
 
+## ⚠️ IMPORTANT: Label Gate Policy
+
+**NEVER add the `loom:issue` label to issues.**
+
+Only humans and the Champion role can approve work for implementation by adding `loom:issue`. Your role is to curate/prepare issues, not approve them.
+
+**Your workflow**:
+1. Find unlabeled issues
+2. Enhance with technical details and context
+3. Add your role's label: `loom:curated`
+4. **WAIT for human approval**
+5. Human adds `loom:issue` if approved
+6. Builder implements approved work
+
 You improve issues by:
 - Clarifying vague descriptions and requirements
 - Adding missing context and technical details


### PR DESCRIPTION
## Summary

Fixes #776

This PR adds a prominent warning box to the Curator role definition to explicitly prohibit adding the `loom:issue` label, preventing accidental auto-approval of work.

## Changes

- **`defaults/roles/curator.md`**: Added "⚠️ IMPORTANT: Label Gate Policy" section after "Your Role"

## Warning Box Content

The new section includes:
1. **Clear prohibition**: "NEVER add the loom:issue label to issues"
2. **Role clarification**: Only humans and Champion can approve work by adding `loom:issue`
3. **Workflow steps**: Shows correct flow (curate → wait → human approves → builder implements)

## Placement

Warning box appears immediately after the "Your Role" summary, before the "You improve issues by" list. This makes it impossible to miss when reading the role definition.

## Before
```markdown
## Your Role

**Your primary task is to find issues needing enhancement...**

You improve issues by:
- Clarifying vague descriptions
```

## After
```markdown
## Your Role

**Your primary task is to find issues needing enhancement...**

## ⚠️ IMPORTANT: Label Gate Policy

**NEVER add the `loom:issue` label to issues.**

Only humans and the Champion role can approve work...

**Your workflow**:
1. Find unlabeled issues
2. Enhance with technical details
3. Add your role's label: `loom:curated`
4. **WAIT for human approval**
5. Human adds `loom:issue` if approved
6. Builder implements approved work

You improve issues by:
- Clarifying vague descriptions
```

## Testing

- ✅ Verified warning box appears prominently at top of role definition
- ✅ Warning clearly states "NEVER add loom:issue"
- ✅ Workflow steps match the intended label-based coordination flow

## Impact

- Prevents Curator from accidentally approving work for implementation
- Maintains human control over `loom:issue` label gate
- Consistent with warnings added to other roles in PR #774

🤖 Generated with [Claude Code](https://claude.com/claude-code)