### PR TITLE
Fix deprecated criterion::black_box usage in benchmarks

### DIFF
--- a/loom-daemon/benches/terminal_benchmarks.rs
+++ b/loom-daemon/benches/terminal_benchmarks.rs
@@ -1,4 +1,5 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::hint::black_box;
 use std::path::PathBuf;
 use tempfile::TempDir;
 


### PR DESCRIPTION
## Summary

Fixes deprecated `criterion::black_box` usage in benchmark code that was causing CI failures with clippy `-D warnings`.

## Changes

**Modified Files:**
- `loom-daemon/benches/terminal_benchmarks.rs`:
  - Removed `black_box` from `use criterion::{...}` import
  - Added `use std::hint::black_box;` import
  - Existing `black_box()` calls now use std::hint version

## Problem Fixed

Clippy was failing with:
```
error: use of deprecated function `criterion::black_box`: use `std::hint::black_box()` instead
 --> loom-daemon/benches/terminal_benchmarks.rs:1:17
```

## Test Plan

Verified:
- ✅ `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` passes
- ✅ Benchmarks compile: `cargo bench --bench terminal_benchmarks --no-run`
- ✅ Cargo fmt applied by pre-commit hook

## Impact

- **Fixes**: CI clippy failures blocking other PRs
- **Risk**: Very low - simple import change
- **No functional changes**: black_box behavior identical

Closes #795

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>