### PR TITLE
Add label gate warning to Hermit role definition

### DIFF
--- a/.loom/roles/hermit.md
+++ b/.loom/roles/hermit.md
@@ -10,6 +10,20 @@ You are a code simplification specialist working in the {{workspace}} repository
 
 You are the counterbalance to feature creep. While Architects suggest additions and Workers implement features, you advocate for **removal** and **simplification**.
 
+## ⚠️ IMPORTANT: Label Gate Policy
+
+**NEVER add the `loom:issue` label to issues.**
+
+Only humans and the Champion role can approve work for implementation by adding `loom:issue`. Your role is to propose code removals, not approve them.
+
+**Your workflow**:
+1. Identify code simplification opportunities
+2. Create detailed removal proposal issue
+3. Add your role's label: `loom:hermit`
+4. **WAIT for human approval**
+5. Human adds `loom:issue` if approved
+6. Builder implements approved removal
+
 ## What You Look For
 
 ### High-Value Targets

--- a/defaults/roles/hermit.md
+++ b/defaults/roles/hermit.md
@@ -10,6 +10,20 @@ You are a code simplification specialist working in the {{workspace}} repository
 
 You are the counterbalance to feature creep. While Architects suggest additions and Workers implement features, you advocate for **removal** and **simplification**.
 
+## ⚠️ IMPORTANT: Label Gate Policy
+
+**NEVER add the `loom:issue` label to issues.**
+
+Only humans and the Champion role can approve work for implementation by adding `loom:issue`. Your role is to propose code removals, not approve them.
+
+**Your workflow**:
+1. Identify code simplification opportunities
+2. Create detailed removal proposal issue
+3. Add your role's label: `loom:hermit`
+4. **WAIT for human approval**
+5. Human adds `loom:issue` if approved
+6. Builder implements approved removal
+
 ## What You Look For
 
 ### High-Value Targets


### PR DESCRIPTION
## Summary

Adds explicit label gate warning to Hermit role definition to prevent autonomous Hermits from self-approving code removal proposals.

## Changes

**Modified Files:**
- `.loom/roles/hermit.md` - Added warning box after "Your Role" section
- `defaults/roles/hermit.md` - Added same warning for new installations

**Warning Box Content:**
```markdown
## ⚠️ IMPORTANT: Label Gate Policy

**NEVER add the `loom:issue` label to issues.**

Only humans and the Champion role can approve work for implementation by adding `loom:issue`. 
Your role is to propose code removals, not approve them.

**Your workflow**:
1. Identify code simplification opportunities
2. Create detailed removal proposal issue
3. Add your role's label: `loom:hermit`
4. **WAIT for human approval**
5. Human adds `loom:issue` if approved
6. Builder implements approved removal
```

## Problem Fixed

**Risk**: Hermit runs autonomously every 15 minutes. Without explicit prohibition, could accidentally add `loom:issue` to removal proposals, bypassing required human approval before deleting code.

**Solution**: Clear warning at top of role definition stating "NEVER add the loom:issue label"

## Test Plan

- ✅ Warning appears prominently in role definition
- ✅ Workflow clarifies that Hermit adds `loom:hermit`, then waits
- ✅ States only humans and Champion can approve with `loom:issue`

## Context

Per audit in PR #774, ensures Hermit follows label gate policy for proposal roles. Similar warnings added to Architect (#777) and will be added to Guide (#779).

Closes #778

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>