### PR TITLE
Add label gate warning to Architect role definition

### DIFF
--- a/defaults/roles/architect.md
+++ b/defaults/roles/architect.md
@@ -6,6 +6,20 @@ You are a software architect focused on identifying improvement opportunities an
 
 **Your primary task is to propose new features, refactors, and improvements.** You scan the codebase periodically and identify opportunities across all domains:
 
+## ⚠️ IMPORTANT: Label Gate Policy
+
+**NEVER add the `loom:issue` label to issues.**
+
+Only humans and the Champion role can approve work for implementation by adding `loom:issue`. Your role is to propose architectural changes, not approve them.
+
+**Your workflow**:
+1. Analyze codebase for architectural improvements
+2. Create detailed proposal issue
+3. Add your role's label: `loom:architect`
+4. **WAIT for human approval**
+5. Human adds `loom:issue` if approved
+6. Builder implements approved proposal
+
 ### Architecture & Features
 - System architecture improvements
 - New features that align with the architecture


### PR DESCRIPTION
## Summary

Fixes #777

This PR adds a prominent warning box to the Architect role definition to explicitly prohibit adding the `loom:issue` label, preventing accidental self-approval of architectural proposals.

## Changes

- **`defaults/roles/architect.md`**: Added "⚠️ IMPORTANT: Label Gate Policy" section after "Your Role"

## Warning Box Content

The new section includes:
1. **Clear prohibition**: "NEVER add the loom:issue label to issues"
2. **Role clarification**: Only humans and Champion can approve proposals by adding `loom:issue`
3. **Workflow steps**: Shows correct flow (propose → wait → human approves → builder implements)

## Placement

Warning box appears immediately after the "Your Role" summary, before the "Architecture & Features" subsection. This makes it impossible to miss when reading the role definition.

## Before
```markdown
## Your Role

**Your primary task is to propose new features, refactors, and improvements.**

### Architecture & Features
- System architecture improvements
```

## After
```markdown
## Your Role

**Your primary task is to propose new features, refactors, and improvements.**

## ⚠️ IMPORTANT: Label Gate Policy

**NEVER add the `loom:issue` label to issues.**

Only humans and the Champion role can approve work...

**Your workflow**:
1. Analyze codebase for architectural improvements
2. Create detailed proposal issue
3. Add your role's label: `loom:architect`
4. **WAIT for human approval**
5. Human adds `loom:issue` if approved
6. Builder implements approved proposal

### Architecture & Features
- System architecture improvements
```

## Testing

- ✅ Verified warning box appears prominently at top of role definition
- ✅ Warning clearly states "NEVER add loom:issue"
- ✅ Workflow steps match the intended label-based coordination flow

## Impact

- Prevents Architect from accidentally approving own architectural proposals
- Maintains human control over `loom:issue` label gate
- Consistent with warnings added to Curator (#776) and other roles in PR #774

🤖 Generated with [Claude Code](https://claude.com/claude-code)