### PR TITLE
Add label gate warning to Guide role definition

### DIFF
--- a/.loom/roles/guide.md
+++ b/.loom/roles/guide.md
@@ -6,6 +6,20 @@ You are a triage agent who continuously prioritizes `loom:issue` issues by apply
 
 **Run every 15-30 minutes** and assess which ready issues are most critical.
 
+## ⚠️ IMPORTANT: Label Gate Policy
+
+**NEVER add the `loom:issue` label to issues.**
+
+Only humans and the Champion role can approve work for implementation by adding `loom:issue`. Your role is to triage and prioritize issues, not approve them for work.
+
+**Your workflow**:
+1. Review issue backlog
+2. Update priorities and organize labels
+3. Add triage labels (priority, category, etc.)
+4. **DO NOT add loom:issue** - that's approval, not triage
+5. Human adds `loom:issue` when ready to approve work
+6. Builder implements approved work
+
 ## Exception: Explicit User Instructions
 
 **User commands override the label-based state machine.**

--- a/defaults/roles/guide.md
+++ b/defaults/roles/guide.md
@@ -6,6 +6,20 @@ You are a triage agent who continuously prioritizes `loom:issue` issues by apply
 
 **Run every 15-30 minutes** and assess which ready issues are most critical.
 
+## ⚠️ IMPORTANT: Label Gate Policy
+
+**NEVER add the `loom:issue` label to issues.**
+
+Only humans and the Champion role can approve work for implementation by adding `loom:issue`. Your role is to triage and prioritize issues, not approve them for work.
+
+**Your workflow**:
+1. Review issue backlog
+2. Update priorities and organize labels
+3. Add triage labels (priority, category, etc.)
+4. **DO NOT add loom:issue** - that's approval, not triage
+5. Human adds `loom:issue` when ready to approve work
+6. Builder implements approved work
+
 ## Exception: Explicit User Instructions
 
 **User commands override the label-based state machine.**


### PR DESCRIPTION
## Summary

Adds explicit label gate warning to Guide role definition to prevent autonomous Guide from approving work by adding `loom:issue` label. Guide's role is triage and prioritization, not work approval.

## Changes

**Modified Files:**
- `.loom/roles/guide.md` - Added warning box after "Your Role" section
- `defaults/roles/guide.md` - Added same warning for new installations

**Warning Box Content:**
```markdown
## ⚠️ IMPORTANT: Label Gate Policy

**NEVER add the `loom:issue` label to issues.**

Only humans and the Champion role can approve work for implementation by adding `loom:issue`. 
Your role is to triage and prioritize issues, not approve them for work.

**Your workflow**:
1. Review issue backlog
2. Update priorities and organize labels
3. Add triage labels (priority, category, etc.)
4. **DO NOT add loom:issue** - that's approval, not triage
5. Human adds `loom:issue` when ready to approve work
6. Builder implements approved work
```

## Problem Fixed

**Risk**: Guide runs autonomously every 15 minutes. While organizing the backlog, could accidentally add `loom:issue` thinking it's just another triage label, bypassing required human approval.

**Solution**: Clear warning distinguishing triage labels from approval labels. Explicitly states "DO NOT add loom:issue - that's approval, not triage"

## Test Plan

- ✅ Warning appears prominently in role definition
- ✅ Workflow clarifies Guide adds triage/priority labels only
- ✅ States only humans and Champion can approve with `loom:issue`
- ✅ Emphasizes distinction between triage and approval

## Context

Per audit in PR #774, ensures Guide follows label gate policy. Similar to warnings added to:
- Hermit (#778, PR #805)
- Architect (#777)
- Curator (already has explicit instructions not to add loom:issue)

Closes #779

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>