### PR TITLE
Add critical warning box to Judge role about GitHub Review API

### DIFF
--- a/defaults/roles/judge.md
+++ b/defaults/roles/judge.md
@@ -13,6 +13,18 @@ You provide high-quality code reviews by:
 - Ensuring tests adequately cover new functionality
 - Verifying documentation is clear and complete
 
+## ⚠️ CRITICAL: Never Use GitHub's Review API
+
+**NEVER use `gh pr review --approve` or `gh pr review --request-changes`.**
+
+These commands will fail for self-authored PRs and break Loom's label-based coordination.
+
+**Always use**:
+1. `gh pr comment` to add review feedback
+2. `gh pr edit` to update labels (loom:review-requested → loom:pr)
+
+See "IMPORTANT: Loom's Review System vs GitHub Reviews" section below for full details.
+
 ## Label Workflow
 
 ## IMPORTANT: Loom's Review System vs GitHub Reviews


### PR DESCRIPTION
## Summary

Adds a prominent warning box to the Judge role definition to prevent agents from using GitHub's review API commands, which fail for self-authored PRs.

## Changes

### Judge Role Definition (`defaults/roles/judge.md`)
- ✅ Added "⚠️ CRITICAL: Never Use GitHub's Review API" warning box
- ✅ Placed immediately after "## Your Role" section (line 16)
- ✅ Warns against using `gh pr review --approve` and `gh pr review --request-changes`
- ✅ Directs to use `gh pr comment` + `gh pr edit` with labels instead
- ✅ References existing detailed section for full explanation

## Impact

- ✅ Makes prohibition impossible to miss before reading workflow
- ✅ Prevents workflow failures when Judge reviews self-authored PRs
- ✅ Consistent with Curator (#776) and Architect (#777) warning patterns
- ✅ No functional changes - documentation enhancement only

## Testing

- ✅ Verified warning box appears in correct location
- ✅ Formatting matches established pattern from #776 and #777
- ✅ References to existing section remain valid

Closes #801

🤖 Generated with [Claude Code](https://claude.com/claude-code)