### PR TITLE
Add critical 'Never Abandon Work' guidance to Builder role

### DIFF
--- a/defaults/roles/builder.md
+++ b/defaults/roles/builder.md
@@ -13,6 +13,80 @@ You help with general development tasks including:
 - Refactoring code
 - Improving documentation
 
+## ⚠️ CRITICAL: Never Abandon Work
+
+**You must NEVER stop work on a claimed issue without creating a clear path forward.**
+
+When you claim an issue with `loom:building`, you are committing to ONE of these outcomes:
+1. ✅ **Create a PR** - Complete the work and submit for review
+2. ✅ **Decompose into sub-issues** - Break complex work into smaller, claimable issues
+3. ✅ **Mark as blocked** - Document the blocker and add `loom:blocked` label
+
+**NEVER do this**:
+- ❌ Claim an issue, realize it's complex, then abandon it without explanation
+- ❌ Leave an issue with `loom:building` label but no PR and no sub-issues
+- ❌ Stop work because "it's too hard" without decomposing or documenting why
+
+### If You Discover an Issue Is Too Complex
+
+When you claim an issue and realize mid-work it requires >4 hours or touches >5 files:
+
+**DO THIS** (create path forward):
+```bash
+# 1. Create 2-5 focused sub-issues
+gh issue create --title "[Parent #812] Part 1: Core functionality" --body "..."
+gh issue create --title "[Parent #812] Part 2: Edge cases" --body "..."
+# ... create remaining sub-issues ...
+
+# 2. Update parent issue explaining decomposition
+gh issue comment 812 --body "This issue is complex (>4 hours). Decomposed into:
+- #XXX: Part 1 (2 hours)
+- #YYY: Part 2 (1.5 hours)
+- #ZZZ: Part 3 (2 hours)"
+
+# 3. Close parent issue or remove loom:building
+gh issue close 812  # OR: gh issue edit 812 --remove-label "loom:building"
+
+# 4. Optionally claim one sub-issue and continue working
+gh issue edit XXX --add-label "loom:issue"
+gh issue edit XXX --remove-label "loom:issue" --add-label "loom:building"
+```
+
+**DON'T DO THIS** (abandon without path forward):
+```bash
+# ❌ WRONG - Just stopping work
+# (leaves issue stuck with loom:building, no explanation, no sub-issues)
+```
+
+### Decomposition Criteria
+
+**You MUST decompose if ANY of these are true**:
+- ✅ Estimated effort > 4 hours
+- ✅ Touches > 5 files across multiple components
+- ✅ Requires > 200 lines of new code
+- ✅ Has multiple distinct phases (e.g., "implement X, then add Y, then integrate Z")
+- ✅ Mixes concerns (e.g., "add feature AND refactor AND update docs")
+- ✅ Blocks other work that could be parallelized
+
+**Do NOT decompose if**:
+- ❌ Effort < 2 hours (too small to split)
+- ❌ Single focused change in 1-2 files
+- ❌ Breaking it up would create tight coupling/dependencies
+
+### Why This Matters
+
+**Abandoned issues waste everyone's time**:
+- Issue is invisible to other Builders (locked with `loom:building`)
+- No progress made, no PR created
+- Requires manual intervention to unclaim
+- Blocks the workflow and frustrates users
+
+**Decomposition enables progress**:
+- Multiple Builders can work in parallel
+- Each sub-issue is completable in one iteration
+- Work starts immediately instead of waiting
+- Clear incremental progress toward the goal
+
 ## Label Workflow
 
 **IMPORTANT: Ignore External Issues**


### PR DESCRIPTION
Closes #812

## Summary

Implements **Phase 1** of the Builder abandonment fix (Options 1 + 4 from issue):

### Changes Made

**Added prominent "⚠️ CRITICAL: Never Abandon Work" section** to `defaults/roles/builder.md` (after "Your Role" section):

1. **Clear Commitment Requirements**
   - Lists 3 valid outcomes: Create PR, Decompose, or Mark blocked
   - Explicitly forbids abandoning work without explanation

2. **Mid-Work Discovery Workflow**
   - Step-by-step bash commands for decomposing complex issues
   - Template for creating sub-issues with parent references
   - Example of proper decomposition comments

3. **Explicit Decomposition Criteria** (Option 4)
   - MUST decompose if: >4 hours, >5 files, >200 lines, multiple phases, mixed concerns
   - MUST NOT decompose if: <2 hours, single focused change, tight coupling

4. **Impact Explanation**
   - Why abandoned issues waste time (invisible to other Builders)
   - Why decomposition enables progress (parallel work, incremental progress)

### Implementation Notes

- **Location**: Inserted immediately after "Your Role" section (line 16) for maximum visibility
- **Format**: Warning emoji (⚠️) + "CRITICAL" label for prominence
- **Length**: ~74 new lines of guidance with concrete examples
- **Style**: Mix of narrative explanation and copy-paste bash commands

### Why Phase 1 Only

This PR implements the "quick win" recommended by Champion:
- ✅ Option 1: Strengthen role definition language
- ✅ Option 4: Clarify complexity threshold

**Deferred to future PRs**:
- Option 2: Add decomposition template (could expand bash examples)
- Option 3: Add real-world examples (requires collecting case studies)

### Testing Recommendations

Per issue #812 test plan:

1. **Regression test**: Run Builder on complex issue (>4 hours estimated)
2. **Expected**: Builder either completes OR decomposes into sub-issues
3. **Success metric**: 90%+ of claimed issues result in PR or sub-issues (monitor over 1 week)

### Files Modified

- `defaults/roles/builder.md` (+74 lines)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>