### PR TITLE
Add philosophy of vibe coding document

### DIFF
--- a/docs/philosophy/philosophy-of-vibe-coding.md
+++ b/docs/philosophy/philosophy-of-vibe-coding.md
@@ -1,0 +1,97 @@
+# The Philosophical Foundations of Vibe Coding
+
+This entry examines how philosophical theories of knowledge help us understand what programmers actually do when they code with AI assistance. The argument traces a shift from viewing knowledge as mental representation to understanding it as embodied, distributed practice. "Vibe coding" by instructing agents to implement software is not a departure from serious software development but the latest expression of how programming has always worked: as material engagement with computational media rather than pure logical construction.
+
+## Table of Contents
+
+1. The Representational Paradigm
+2. Use and Practice
+3. Indwelling and Tacit Knowledge
+4. Enactivism and Extended Mind
+5. Vibe Coding as Material Practice
+6. Conclusion
+
+Bibliography
+
+---
+
+## 1. The Representational Paradigm
+
+Early analytic philosophy treated knowledge as mental representation of reality. For Bertrand Russell and the early Wittgenstein, propositions were logical pictures that mirrored the structure of facts (Wittgenstein 1922, 2.1–2.12). Language mapped onto the world through correspondence rules. The knower stood apart from reality, constructing symbolic models that could be evaluated for accuracy.
+
+Early practice in software development inherited this representational ideal. Formal verification, type systems, and proof-carrying code all assume computation is symbol manipulation that can guarantee correspondence between specification and behavior. To write code is to construct a formal model precise enough that it can execute. The programmer is theorist, the program is description, debugging is error correction in the mapping.
+
+This picture still governs how we talk about correctness. But it misses something about how programming actually happens.
+
+## 2. Use and Practice
+
+The later Wittgenstein rejected his earlier work in the *Tractatus*. In the *Philosophical Investigations*, meaning is no longer mental representation but use within a practice (Wittgenstein 1953, §23, §43). You understand "checkmate" not by grasping what it represents but by knowing how to play chess. Learning means being inducted into a form of life through examples, correction, and imitation. There are parallels here to existentialist ideas of "being-in-the-world" from Heidegger.
+
+Programming languages are social practices. A function's meaning includes more than its formal semantics—it includes when to use it, what problems it solves, how it fits conventions. "Readable code" is code that other practitioners can pick up and continue. The criteria shift from logical correctness to practical intelligibility.
+
+This explains why experienced programmers recognize "code smells" that resist formal specification. Why refactoring aims at clarity more than logic. Code is a move in a collaborative practice, not just a description of computation.
+
+## 3. Indwelling and Tacit Knowledge
+
+Michael Polanyi, though less well known than other figures in this lineage, pushed these ideas further. All explicit knowledge rests on tacit integration (Polanyi 1958, 1966). Polanyi, who was trained as a physical chemist before turning to philosophy, argued that we attend *from* subsidiary elements *to* a focal whole. The craftsman attends from the hammer to the nail. The driver attends from the pedals to the road. The reader attends from letters to meaning. Tools become extensions of the body as a kind of media through which we perceive.
+
+This is Polanyi's concept of "indwelling". The skilled practitioner incorporates tools into their sensory apparatus. Knowledge is not mental representation but embodied skill developed through practice.
+
+For programming, the development environment—editor, compiler, debugger, and cloud tools like GitHub and AWS—is not external to cognition but part of it. The experienced programmer doesn't think about syntax highlighting or autocomplete. These function tacitly. They attend *from* the tools *to* the problem. Debugging can be feel more than formal method. Code completion can be anticipated thought rather than suggestion from outside.
+
+Programming knowledge distributes across neural substrate, symbolic systems, and technical tools. You can't separate the programmer's understanding from the coupled system they work within. Expertise is not just knowing things but skilled navigation of an entire ecology.
+
+## 4. Enactivism and Extended Mind
+
+Late twentieth-century cognitive science generalized this insight. Francisco Varela and colleagues argued that cognition is not internal computation but enacted through interaction (Varela et al. 1991). Andy Clark and David Chalmers went further: when external resources couple reliably to an organism and play the right functional role, they *are* part of cognition (Clark & Chalmers 1998). The mind extends into its tools.
+
+In programming this coupling is explicit. Keystroke triggers feedback. Programmer responds. System updates. Understanding emerges in the loop between human and machine. The "thought" happens in the interaction, not just in one skull.
+
+AI assistance intensifies this. Large language models trained on collective code embody distilled patterns from millions of programmers. When you prompt an AI to complete a function or explain an error, you're routing cognition through a new medium that effortlessly consults documentation, recalls patterns, and connects to related knowledge. All are forms of distributed cognition.
+
+The model's parameters are crystallized experience. Drawing on them is no different in principle from drawing on memory or libraries. They differ in latency and interface, not in kind. A hierarchy of cognitive caches: neuron, RAM, disk, network, AI model all become part of an extended cognitive system.
+
+## 5. Vibe Coding as Material Practice
+
+This brings us to "vibe coding", in which programmers focus on directing agents to implement ideas by prompt in an attempt to feel through problems and iterate rapidly without consciously thinking about syntax or implementation details. Critics worry this is superficial, that it undermines genuine understanding. But the philosophical trajectory suggests otherwise.
+
+Heidegger distinguished between present-at-hand (objects of detached analysis) and ready-to-hand (tools absorbed into practice). Tools recede from awareness when they work smoothly. They become present-at-hand only when they break (Heidegger 1927, §15–16). Expert programmers have always worked this way—thinking *in* the language rather than *about* it, attending through tools to problems.
+
+Vibe coding is this process intensified. The AI becomes another ready-to-hand tool. You're not consulting an external oracle but extending your cognitive reach through a new medium. The code is still the medium in which certain thoughts can be thought.
+
+Does the programmer "understand" what the AI generates? Wrong question. Understanding is not all-or-nothing mental possession but distributed capacity demonstrated through practice. Can you maintain the code? Extend it? Debug it? Integrate it appropriately? Then you understand it, in the way that matters.
+
+Programming has never been pure applied logic. It's craft that develops through practice, enacted through tools, and embedded in communities. AI tools reshape this practice without fundamentally changing its character.
+
+## 6. Conclusion
+
+Programming has always been more than logical construction. It's embodied practice, distributed across tools and communities, enacted through skilled engagement. The philosophical shift from representation to participation, from mental models to extended cognition, clarifies what programmers actually do.
+
+Vibe coding with AI doesn't undermine this. It makes explicit what was always implicit: that programming is thinking through computational media, that expertise is navigating an ecology of processes rather than possessing private knowledge, that the boundaries of cognition are fluid and tool-dependent.
+
+The worry that AI "does the thinking for us" assumes a model of thinking that philosophy has been dismantling for decades. Better question: does the coupled human-AI system produce maintainable, appropriate solutions? That's what understanding means in practice.
+
+---
+
+## Bibliography
+
+* **Clark, A. & Chalmers, D. (1998).** "The Extended Mind." *Analysis* 58 (1): 7–19.
+  * Cognitive processes extend beyond brain and body to reliably coupled environmental resources.
+
+* **Heidegger, M. (1927).** *Sein und Zeit* [Being and Time]. Tübingen: Niemeyer.
+  * Ready-to-hand vs. present-at-hand: how tools become absorbed into skilled practice.
+
+* **Polanyi, M. (1958).** *Personal Knowledge: Towards a Post-Critical Philosophy.* Chicago: University of Chicago Press.
+  * All explicit knowledge rests on tacit integration; we attend *from* subsidiaries *to* focal wholes.
+
+* **Polanyi, M. (1966).** *The Tacit Dimension.* New York: Doubleday.
+  * "We know more than we can tell"—concise presentation of indwelling and tacit knowledge.
+
+* **Varela, F., Thompson, E., & Rosch, E. (1991).** *The Embodied Mind.* Cambridge, MA: MIT Press.
+  * Cognition is enactive sense-making through interaction, not internal computation.
+
+* **Wittgenstein, L. (1922).** *Tractatus Logico-Philosophicus.* London: Routledge.
+  * Early Wittgenstein's representational account: propositions as logical pictures of reality.
+
+* **Wittgenstein, L. (1953).** *Philosophical Investigations.* Oxford: Blackwell.
+  * Later Wittgenstein: meaning is use within practices, not mental representation.


### PR DESCRIPTION
This document explores the philosophical underpinnings of 'vibe coding', emphasizing the transition from traditional views of knowledge as mental representation to understanding it as embodied and distributed practice. It discusses concepts such as enactivism, tacit knowledge, and the role of AI in programming.