### PR TITLE
Use portable shebang in shell scripts for macOS compatibility

### DIFF
--- a/.loom/scripts/cleanup-branches.sh
+++ b/.loom/scripts/cleanup-branches.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Loom Branch Cleanup Script - Remove feature branches for closed issues
 #
 # This script automatically cleans up stale feature branches by checking

--- a/.loom/scripts/cleanup.sh
+++ b/.loom/scripts/cleanup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Loom Cleanup Script - Remove build artifacts and orphaned worktrees
 #
 # AGENT USAGE INSTRUCTIONS:

--- a/.loom/scripts/worktree-return.sh
+++ b/.loom/scripts/worktree-return.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Loom Worktree Return Helper Script
 # Returns from an issue worktree to the terminal worktree that created it

--- a/.loom/scripts/worktree.sh
+++ b/.loom/scripts/worktree.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Loom Worktree Helper Script
 # Safely creates and manages git worktrees for agent development


### PR DESCRIPTION
## Summary

- Update shebangs from `#!/bin/bash` to `#!/usr/bin/env bash` in four shell scripts
- Improves portability for systems where bash is not at `/bin/bash` (Homebrew on macOS, NixOS, etc.)

## Changes

| File | Change |
|------|--------|
| `.loom/scripts/worktree.sh` | `#!/bin/bash` → `#!/usr/bin/env bash` |
| `.loom/scripts/worktree-return.sh` | `#!/bin/bash` → `#!/usr/bin/env bash` |
| `.loom/scripts/cleanup.sh` | `#!/bin/bash` → `#!/usr/bin/env bash` |
| `.loom/scripts/cleanup-branches.sh` | `#!/bin/bash` → `#!/usr/bin/env bash` |

Note: `clean.sh` already used the portable shebang.

## Test plan

- [x] Verified all scripts display help correctly after the change
- [x] Confirmed scripts execute properly with the new shebang

Closes #849

🤖 Generated with [Claude Code](https://claude.com/claude-code)