### PR TITLE
Improve installation to verify and document slash commands (#850)

### DIFF
--- a/defaults/.claude/commands/loom.md
+++ b/defaults/.claude/commands/loom.md
@@ -4,11 +4,27 @@ Randomly select and assume an archetypal role from the Loom orchestration system
 
 ## Process
 
-1. **List available roles**: Check `defaults/roles/*.md` or `.loom/roles/*.md`
-2. **Select one at random**: Use current timestamp or random selection
-3. **Read the role definition**: Load the markdown file for the selected role
-4. **Follow the role's workflow**: Complete ONE iteration only (one task, one PR review, one issue triage, etc.)
-5. **Report results**: Summarize what you accomplished with links to issues/PRs modified
+1. **List available roles**: 9 roles available (builder, judge, curator, doctor, champion, architect, hermit, guide, driver)
+2. **Select role using time-based selection**: Use `Date.now() % 13` for weighted random selection
+3. **Role mapping** (core operational roles are double-weighted):
+   ```
+   0: builder    (2x weight)
+   1: builder    (2x weight)
+   2: judge      (2x weight)
+   3: judge      (2x weight)
+   4: curator    (2x weight)
+   5: curator    (2x weight)
+   6: doctor     (2x weight)
+   7: doctor     (2x weight)
+   8: champion   (1x weight)
+   9: architect  (1x weight)
+   10: hermit    (1x weight)
+   11: guide     (1x weight)
+   12: driver    (1x weight)
+   ```
+4. **Read the role definition**: Load `.loom/roles/<role>.md` or `defaults/roles/<role>.md`
+5. **Follow the role's workflow**: Complete ONE iteration only (one task, one PR review, one issue triage, etc.)
+6. **Report results**: Summarize what you accomplished with links to issues/PRs modified
 
 ## Available Roles
 
@@ -63,6 +79,9 @@ Follow the label-based coordination system (ADR-0006):
 
 ## Notes
 
+- **Time-based selection**: Uses `Date.now() % 13` for deterministic but unpredictable role selection (no bash permissions needed!)
+- **Weighted distribution**: Core operational roles (builder, judge, curator, doctor) are 2x more likely to be selected than supporting roles
+- **Zero permissions**: No bash/python execution required - pure time-based mathematics
 - This command simulates one terminal's work in the Loom multi-terminal orchestration system
 - Multiple Claude Code sessions can run `/loom` in parallel for distributed work
 - Each iteration should be atomic and complete (don't leave partial work)
@@ -76,7 +95,9 @@ Follow the label-based coordination system (ADR-0006):
 /loom
 
 # Claude responds:
-"🎭 Rolling random role... Assuming the Judge role for this iteration.
+"🎭 Selecting role using time-based weighted selection...
+   Time index: Date.now() % 13 = 2
+   Selected: Judge (2x weighted - core operational role)
 
 Looking for PRs with loom:review-requested...
 Found PR #401 - 'Add terminal restart functionality'

--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -278,6 +278,8 @@ EXPECTED_FILES=(
   ".loom/scripts/worktree.sh"
   "CLAUDE.md"
   ".github/labels.yml"
+  ".claude/commands"
+  ".claude/settings.json"
 )
 
 info "Verifying installation files..."

--- a/scripts/install/create-pr.sh
+++ b/scripts/install/create-pr.sh
@@ -79,7 +79,8 @@ Install Loom ${LOOM_VERSION} orchestration framework
 
 Adds Loom configuration and GitHub workflow integration:
 - .loom/ directory with configuration and scripts
-- .claude/ MCP servers and prompts
+- .claude/commands/ slash commands for roles (/builder, /judge, etc.)
+- .claude/settings.json tool permissions
 - .github/ labels and workflows
 - Documentation (CLAUDE.md, AGENTS.md)
 
@@ -115,7 +116,8 @@ Closes #${ISSUE_NUMBER}
 ## What's included:
 
 - ✅ \`.loom/\` - Configuration, roles, and scripts
-- ✅ \`.claude/\` - MCP servers and prompts (target-specific only)
+- ✅ \`.claude/commands/\` - Slash commands for roles (/builder, /judge, /curator, etc.)
+- ✅ \`.claude/settings.json\` - Claude Code tool permissions
 - ✅ \`.github/\` - Labels and workflows
 - ✅ \`CLAUDE.md\`/\`AGENTS.md\` - Documentation with Loom reference
 


### PR DESCRIPTION
## Summary

This PR improves the Loom installation process to better verify and document slash commands:

- Add `.claude/commands/` and `.claude/settings.json` to EXPECTED_FILES verification in `install-loom.sh` to catch installation failures early
- Update PR body and commit message in `create-pr.sh` to explicitly mention slash commands (`/builder`, `/judge`, etc.)
- Sync `defaults/.claude/commands/loom.md` with the latest version containing time-based weighted role selection from #811

## Investigation Results

Investigation confirmed that the installation **WAS** already correctly installing `.claude/commands/`. My testing shows:
1. `loom-daemon init` properly copies all files from `defaults/.claude/commands/` to the target workspace
2. `git add -A` in `create-pr.sh` stages all the command files
3. The files are committed and would appear in the PR

The original issue description may have been based on a misunderstanding:
- The issue says "`.claude/commands/` only exists in `.loom/worktrees/issue-N/.claude/commands/`"
- This suggests looking at the worktree path in the **source Loom repo**, not the **target repo after merging**
- After merging an installation PR, the slash commands DO appear in the target repo's `.claude/commands/`

## Changes

1. **install-loom.sh**: Added `.claude/commands` and `.claude/settings.json` to EXPECTED_FILES array
2. **create-pr.sh**: Updated commit message and PR body to explicitly list slash commands
3. **defaults/.claude/commands/loom.md**: Synced with current version (was out of date)

## Test Plan

- [x] Verified `loom-daemon init` installs `.claude/commands/` correctly
- [x] Verified all command files are staged by `git add -A`
- [x] Verified updated `loom.md` with time-based selection is installed
- [x] Verified EXPECTED_FILES check would catch missing commands

Closes #850

🤖 Generated with [Claude Code](https://claude.com/claude-code)