### PR TITLE
Fix installation targeting worktree instead of main repo

### DIFF
--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -123,9 +123,23 @@ fi
 # Export for sub-scripts
 export NON_INTERACTIVE
 
-# Resolve target to absolute path
-TARGET_PATH="$(cd "$TARGET_PATH" && pwd 2>/dev/null)" || \
+# Resolve target to absolute path (git repository root, not worktree)
+TARGET_PATH="$(cd "$TARGET_PATH" 2>/dev/null && pwd)" || \
   error "Target path does not exist: $TARGET_PATH"
+
+# Check if target is a git repository
+if ! git -C "$TARGET_PATH" rev-parse --git-dir >/dev/null 2>&1; then
+  error "Target path is not a git repository: $TARGET_PATH"
+fi
+
+# If target is inside a worktree, resolve to the main repository root
+# git worktree list --porcelain returns the main worktree first
+MAIN_WORKTREE=$(git -C "$TARGET_PATH" worktree list --porcelain 2>/dev/null | grep -m1 '^worktree ' | cut -d' ' -f2-)
+if [[ -n "$MAIN_WORKTREE" ]] && [[ "$TARGET_PATH" != "$MAIN_WORKTREE" ]]; then
+  warning "Target path is inside a worktree: $TARGET_PATH"
+  info "Resolving to main repository root: $MAIN_WORKTREE"
+  TARGET_PATH="$MAIN_WORKTREE"
+fi
 
 echo ""
 header "╔═══════════════════════════════════════════════════════════╗"


### PR DESCRIPTION
## Summary
- Fixes bug where loom installation would target a worktree directory instead of the main repository root
- Uses `git worktree list --porcelain` to resolve to the main worktree when the target path is inside a worktree
- Adds warning message when this resolution occurs

Fixes #856

🤖 Generated with [Claude Code](https://claude.com/claude-code)