### PR TITLE
Initialize git submodules automatically in worktree script

### DIFF
--- a/.loom/scripts/worktree.sh
+++ b/.loom/scripts/worktree.sh
@@ -106,6 +106,7 @@ Safety Features:
   ✓ Prevents nested worktrees
   ✓ Non-interactive (safe for AI agents)
   ✓ Reuses existing branches automatically
+  ✓ Automatically initializes git submodules
 
 Resuming Abandoned Work:
   If an agent abandoned work on issue #42, a new agent can resume:
@@ -296,6 +297,23 @@ fi
 if git worktree add "${CREATE_ARGS[@]}"; then
     # Get absolute path to worktree
     ABS_WORKTREE_PATH=$(cd "$WORKTREE_PATH" && pwd)
+
+    # Initialize git submodules if .gitmodules exists
+    if [[ -f .gitmodules ]]; then
+        if [[ "$JSON_OUTPUT" != "true" ]]; then
+            print_info "Initializing git submodules..."
+        fi
+
+        if git -C "$ABS_WORKTREE_PATH" submodule update --init --recursive 2>/dev/null; then
+            if [[ "$JSON_OUTPUT" != "true" ]]; then
+                print_success "Submodules initialized"
+            fi
+        else
+            if [[ "$JSON_OUTPUT" != "true" ]]; then
+                print_warning "Failed to initialize submodules (this may cause test failures)"
+            fi
+        fi
+    fi
 
     # Store return-to directory if provided
     if [[ -n "$RETURN_TO_DIR" ]]; then


### PR DESCRIPTION
## Summary

When creating a new worktree, the script now automatically initializes git submodules if a `.gitmodules` file exists. This ensures worktrees behave consistently with the main repository and prevents test failures in projects that depend on submodules.

## Changes

- After creating a worktree, check if `.gitmodules` exists in the repository
- If present, run `git submodule update --init --recursive` in the new worktree
- Display appropriate status messages (info/success/warning) based on the outcome
- Updated help text to list this as a safety feature

## Test Plan

- [x] Verified help text shows new safety feature
- [x] Script syntax is valid (no bash errors)
- [ ] Manual testing on a repository with submodules (recommend testing on nistmemsql repo)

Closes #828