### PR TITLE
Add loom:changes-requested label to defaults template

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,7 @@ Agents coordinate work through GitHub labels. This enables autonomous operation 
 - **`loom:curating`**: Curator is actively enhancing this issue
 - **`loom:treating`**: Doctor is actively fixing this bug or addressing PR feedback
 - **`loom:review-requested`**: PR ready for Judge to review
+- **`loom:changes-requested`**: PR requires changes (Judge requested modifications)
 - **`loom:pr`**: PR approved by Judge, ready for Champion to auto-merge
 
 **Proposal Labels**:

--- a/defaults/.github/labels.yml
+++ b/defaults/.github/labels.yml
@@ -8,13 +8,11 @@
   description: Approved for work by human (ready for Builder to claim)
   color: "3B82F6"  # blue-500
 
-- name: loom:building
-  description: Builder is implementing this issue
-  color: "1d76db"  # blue
-
-- name: loom:in-progress
-  description: "Issue: Worker implementing | PR: Reviewer reviewing or Worker addressing feedback"
-  color: "F59E0B"  # amber-500
+# DEPRECATED: loom:in-progress removed (use role-specific labels)
+# - loom:building (Builder implementing issue)
+# - loom:curating (Curator enhancing issue)
+# - loom:reviewing (Judge reviewing PR)
+# - loom:treating (Doctor fixing bug/PR feedback)
 
 # Role-Specific Workflow Labels
 - name: loom:building
@@ -36,6 +34,10 @@
 - name: loom:review-requested
   description: PR ready for Judge to review
   color: "10B981"  # emerald-500
+
+- name: loom:changes-requested
+  description: "PR requires changes before re-review (Judge requested modifications)"
+  color: "F59E0B"  # amber-500 - matches other "action required" labels
 
 - name: loom:pr
   description: PR approved by Judge, ready for human to merge

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -169,6 +169,7 @@ Agents coordinate work through GitHub labels. This enables autonomous operation 
 - **`loom:curating`**: Curator is actively enhancing this issue
 - **`loom:treating`**: Doctor is actively fixing this bug or addressing PR feedback
 - **`loom:review-requested`**: PR ready for Judge to review
+- **`loom:changes-requested`**: PR requires changes (Judge requested modifications)
 - **`loom:pr`**: PR approved by Judge, ready for human to merge
 
 **Proposal Labels**:


### PR DESCRIPTION
## Summary

- Add missing `loom:changes-requested` label to `defaults/.github/labels.yml` template
- Clean up duplicate `loom:building` definition and remove deprecated `loom:in-progress` label
- Add `loom:changes-requested` to Label Definitions section in both CLAUDE.md files

## Problem

The defaults template installed to new repositories was missing the `loom:changes-requested` label. This caused Judge agents to fail when trying to request PR changes:

```bash
gh pr edit <number> --add-label "loom:changes-requested"
# Error: 'loom:changes-requested' not found
```

The main `.github/labels.yml` already had this label (added in #810), but the defaults template was out of sync.

## Test Plan

- [ ] Verify `defaults/.github/labels.yml` includes `loom:changes-requested`
- [ ] Verify no duplicate label definitions remain
- [ ] Verify documentation in both CLAUDE.md files lists the new label

Closes #830

🤖 Generated with [Claude Code](https://claude.com/claude-code)