### PR TITLE
Add system dependency checks to install scripts

### DIFF
--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -150,9 +150,55 @@ echo ""
 info "Target: $TARGET_PATH"
 echo ""
 
+# Check required dependencies
+header "Checking Dependencies"
+echo ""
+
+MISSING_DEPS=()
+
 # Check if node is available (needed for version extraction)
-if ! command -v node &> /dev/null; then
-  error "Node.js is required but not found in PATH\n       Install from: https://nodejs.org/"
+if command -v node &> /dev/null; then
+  success "node: $(node --version)"
+else
+  MISSING_DEPS+=("node")
+fi
+
+# Check for pnpm (needed to build daemon)
+if command -v pnpm &> /dev/null; then
+  success "pnpm: $(pnpm --version)"
+else
+  MISSING_DEPS+=("pnpm")
+fi
+
+# Check for cargo (needed to build daemon)
+if command -v cargo &> /dev/null; then
+  success "cargo: $(cargo --version | head -1)"
+else
+  MISSING_DEPS+=("cargo")
+fi
+
+echo ""
+
+# Report missing dependencies
+if [[ ${#MISSING_DEPS[@]} -gt 0 ]]; then
+  echo -e "${RED}✗ Missing required dependencies: ${MISSING_DEPS[*]}${NC}"
+  echo ""
+  info "Please install the missing dependencies:"
+  for dep in "${MISSING_DEPS[@]}"; do
+    case "$dep" in
+      node)
+        echo "  • Node.js: brew install node (or https://nodejs.org/)"
+        ;;
+      pnpm)
+        echo "  • pnpm: npm install -g pnpm (or https://pnpm.io/installation)"
+        ;;
+      cargo)
+        echo "  • Rust/Cargo: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
+        ;;
+    esac
+  done
+  echo ""
+  error "Cannot proceed without required dependencies"
 fi
 
 # Extract Loom version from package.json


### PR DESCRIPTION
## Summary

- Add "Checking System Dependencies" section at start of `install.sh` to detect required packages upfront
- Check for git, node, pnpm, cargo with version display on success
- Show warning for optional gh (GitHub CLI) if missing
- Display installation instructions for any missing dependencies
- Prompt user to exit and install missing deps before continuing
- Add matching dependency checks to `scripts/install-loom.sh`

This prevents cryptic "cargo: command not found" errors during installation by detecting missing dependencies upfront and providing clear guidance.

## Test Plan

- [x] Verified script syntax with `bash -n`
- [x] Tested dependency check output on a test repository
- [x] Verified Rust formatting passes

Closes #836

🤖 Generated with [Claude Code](https://claude.com/claude-code)