### PR TITLE
Add package.json template for non-Node projects during installation

### DIFF
--- a/defaults/package.json
+++ b/defaults/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "loom-workspace",
+  "version": "1.0.0",
+  "description": "Loom-managed workspace with AI development orchestration",
+  "private": true,
+  "scripts": {
+    "worktree:return": "./.loom/scripts/worktree-return.sh",
+    "check:ci": "echo 'No CI checks configured. Customize this script for your project.' && exit 0",
+    "check:all": "echo 'No checks configured. Customize this script for your project.' && exit 0",
+    "test": "echo 'No tests configured. Customize this script for your project.' && exit 0",
+    "lint": "echo 'No linter configured. Customize this script for your project.' && exit 0"
+  }
+}


### PR DESCRIPTION
## Summary

Worker roles reference pnpm scripts (`check:ci`, `worktree:return`, `test`, `lint`, etc.) that don't exist in non-Node projects like Rust repositories. This causes agents to waste time when these scripts aren't available.

## Changes

- Add `defaults/package.json` with stub scripts for common pnpm commands
- Update `loom-daemon init` to copy `package.json` only if one doesn't already exist
- Add unit tests to verify `package.json` copy behavior

## package.json Contents

The template provides:
- `worktree:return`: Points to `.loom/scripts/worktree-return.sh`
- `check:ci`, `check:all`, `test`, `lint`: No-op stubs with helpful messages

## Behavior

- **New installs (no package.json)**: Template is copied, providing working stub scripts
- **Existing package.json**: NEVER overwritten, even in force mode - preserves project's real package.json

## Test Plan

- [x] Unit tests pass for both copy scenarios
- [x] `cargo check` compiles successfully
- [x] `cargo fmt --check` passes
- [ ] Manual test: Install Loom on a Rust-only project and verify pnpm commands work

Closes #829