### PR TITLE
Update documentation after .claude/agents/ removal

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -98,43 +98,39 @@ Interact with the Loom application UI and state:
 
 **Note**: When you first open the project, Claude Code will prompt you to approve these MCP servers. You can also enable them automatically by setting `"enableAllProjectMcpServers": true` in your `.claude/settings.local.json`.
 
-## Subagents
+## Slash Commands
 
-The `agents/` directory contains Claude Code subagents that are automatically invoked based on task descriptions. Each subagent is specialized for a specific role in the Loom development workflow.
+The `commands/` directory contains slash commands that invoke Loom roles. Each command instructs Claude to assume a specific role defined in `.loom/roles/`.
 
-### Available Subagents
+### Available Commands
 
-| Agent | Description | Tools | Model |
-|-------|-------------|-------|-------|
-| **builder** | Implements features for `loom:issue` issues and creates PRs | Full (Write, Edit, TodoWrite) | Sonnet |
-| **judge** | Reviews PRs with `loom:review-requested` label | Read-only | Sonnet |
-| **curator** | Enhances issues and marks them as `loom:curated` | Read-only | Sonnet |
-| **architect** | Creates architectural proposals with `loom:architect` | Full (can write docs) | Opus |
-| **hermit** | Identifies bloat and creates simplification issues | Read-only | Sonnet |
-| **doctor** | Addresses PR feedback and resolves conflicts | Full (fixes PRs) | Sonnet |
-| **guide** | Triages issues and applies `loom:urgent` to top 3 | Read-only | Sonnet |
-| **driver** | General shell environment for ad-hoc tasks | Full | Sonnet |
+| Command | Role | Purpose |
+|---------|------|---------|
+| `/builder` | Builder | Implements features for `loom:issue` issues and creates PRs |
+| `/judge` | Judge | Reviews PRs with `loom:review-requested` label |
+| `/curator` | Curator | Enhances issues and marks them as `loom:curated` |
+| `/architect` | Architect | Creates architectural proposals with `loom:architect` |
+| `/hermit` | Hermit | Identifies bloat and creates simplification issues |
+| `/doctor` | Doctor | Addresses PR feedback and resolves conflicts |
+| `/guide` | Guide | Triages issues and applies `loom:urgent` to top 3 |
+| `/champion` | Champion | Auto-merges approved PRs with `loom:pr` label |
 
-### How Subagents Work
+### How Slash Commands Work
 
-**Automatic Invocation**: Claude Code automatically selects and invokes the appropriate subagent based on your task description. For example:
-- "Review PR #123" → Invokes the **judge** subagent
-- "Implement issue #456" → Invokes the **builder** subagent
-- "Find unused dependencies" → Invokes the **hermit** subagent
+**Manual Invocation**: Use slash commands to assume a role:
+```bash
+/builder    # Assume Builder role, find and implement a loom:issue
+/judge      # Assume Judge role, review a PR with loom:review-requested
+```
 
-**YAML Frontmatter**: Each subagent file has frontmatter defining:
-- `name` - Agent identifier
-- `description` - When Claude should invoke this agent (critical for auto-selection)
-- `tools` - Allowed tools (restricts capabilities for safety)
-- `model` - Which model to use (sonnet or opus)
-
-**Tool Restrictions**:
-- **Read-only agents** (judge, curator, hermit, guide): Can read code and create issues/comments but cannot modify files
-- **Write-enabled agents** (builder, doctor, architect, driver): Can modify files, create commits, and push changes
+Each slash command tells Claude to:
+1. Read the role definition from `.loom/roles/<role>.md`
+2. Follow the role's workflow guidelines
+3. Complete ONE iteration of the role's task
 
 ### Agent Roles in Workflow
 
-The subagents work together following the label-based workflow:
+The roles work together following the label-based workflow:
 
 1. **architect** scans codebase → creates proposals with `loom:architect`
 2. **User approves** → adds `loom:issue` label
@@ -146,24 +142,15 @@ The subagents work together following the label-based workflow:
 8. **doctor** fixes feedback → transitions back to `loom:review-requested`
 9. **User merges** → issue auto-closes
 
-### Creating Custom Subagents
+### Creating Custom Commands
 
-To create a custom subagent:
+To create a custom slash command:
 
-1. Create `defaults/.claude/agents/your-agent.md`
-2. Add YAML frontmatter:
-   ```yaml
-   ---
-   name: your-agent
-   description: Clear description of when to invoke this agent
-   tools: Bash, Read, Grep, Glob, Task
-   model: sonnet
-   ---
-   ```
-3. Write agent instructions below frontmatter
-4. Claude Code will automatically detect and use it
+1. Create `.claude/commands/your-command.md`
+2. Reference a role file or write custom instructions
+3. Use it with `/your-command`
 
-See the [Claude Code subagent documentation](https://docs.claude.com/en/docs/claude-code/agents) for more details.
+See `.loom/roles/README.md` for creating custom role definitions.
 
 ## Documentation
 

--- a/.loom/roles/README.md
+++ b/.loom/roles/README.md
@@ -2,23 +2,12 @@
 
 This directory contains role definition templates for different terminal roles in Loom.
 
-## ⚠️ Important: Source of Truth
+## Source of Truth
 
 **This directory is the single source of truth for all Loom role definitions.**
 
-- **Edit role files HERE** (in `defaults/roles/*.md`)
-- **Do NOT edit** `.claude/agents/*.md` files directly - they are auto-generated
-- **After editing**, run `pnpm generate:agents` to regenerate Claude Code agent files
-
-### Why This Pattern?
-
-Claude Code agents cannot reference external files - they must be self-contained. To solve this:
-
-1. **Source**: `defaults/roles/*.md` (edit these)
-2. **Generate**: Run `pnpm generate:agents`
-3. **Result**: `.claude/agents/*.md` (YAML frontmatter + role content)
-
-This prevents duplication errors and ensures `.loom/roles/` is always the authoritative source.
+- **Edit role files HERE** (in `defaults/roles/*.md` or `.loom/roles/*.md`)
+- Slash commands (`.claude/commands/*.md`) reference these role files directly
 
 ## Available Prompts
 

--- a/defaults/.claude/README.md
+++ b/defaults/.claude/README.md
@@ -98,43 +98,39 @@ Interact with the Loom application UI and state:
 
 **Note**: When you first open the project, Claude Code will prompt you to approve these MCP servers. You can also enable them automatically by setting `"enableAllProjectMcpServers": true` in your `.claude/settings.local.json`.
 
-## Subagents
+## Slash Commands
 
-The `agents/` directory contains Claude Code subagents that are automatically invoked based on task descriptions. Each subagent is specialized for a specific role in the Loom development workflow.
+The `commands/` directory contains slash commands that invoke Loom roles. Each command instructs Claude to assume a specific role defined in `.loom/roles/`.
 
-### Available Subagents
+### Available Commands
 
-| Agent | Description | Tools | Model |
-|-------|-------------|-------|-------|
-| **builder** | Implements features for `loom:issue` issues and creates PRs | Full (Write, Edit, TodoWrite) | Sonnet |
-| **judge** | Reviews PRs with `loom:review-requested` label | Read-only | Sonnet |
-| **curator** | Enhances issues and marks them as `loom:curated` | Read-only | Sonnet |
-| **architect** | Creates architectural proposals with `loom:architect` | Full (can write docs) | Opus |
-| **hermit** | Identifies bloat and creates simplification issues | Read-only | Sonnet |
-| **doctor** | Addresses PR feedback and resolves conflicts | Full (fixes PRs) | Sonnet |
-| **guide** | Triages issues and applies `loom:urgent` to top 3 | Read-only | Sonnet |
-| **driver** | General shell environment for ad-hoc tasks | Full | Sonnet |
+| Command | Role | Purpose |
+|---------|------|---------|
+| `/builder` | Builder | Implements features for `loom:issue` issues and creates PRs |
+| `/judge` | Judge | Reviews PRs with `loom:review-requested` label |
+| `/curator` | Curator | Enhances issues and marks them as `loom:curated` |
+| `/architect` | Architect | Creates architectural proposals with `loom:architect` |
+| `/hermit` | Hermit | Identifies bloat and creates simplification issues |
+| `/doctor` | Doctor | Addresses PR feedback and resolves conflicts |
+| `/guide` | Guide | Triages issues and applies `loom:urgent` to top 3 |
+| `/champion` | Champion | Auto-merges approved PRs with `loom:pr` label |
 
-### How Subagents Work
+### How Slash Commands Work
 
-**Automatic Invocation**: Claude Code automatically selects and invokes the appropriate subagent based on your task description. For example:
-- "Review PR #123" → Invokes the **judge** subagent
-- "Implement issue #456" → Invokes the **builder** subagent
-- "Find unused dependencies" → Invokes the **hermit** subagent
+**Manual Invocation**: Use slash commands to assume a role:
+```bash
+/builder    # Assume Builder role, find and implement a loom:issue
+/judge      # Assume Judge role, review a PR with loom:review-requested
+```
 
-**YAML Frontmatter**: Each subagent file has frontmatter defining:
-- `name` - Agent identifier
-- `description` - When Claude should invoke this agent (critical for auto-selection)
-- `tools` - Allowed tools (restricts capabilities for safety)
-- `model` - Which model to use (sonnet or opus)
-
-**Tool Restrictions**:
-- **Read-only agents** (judge, curator, hermit, guide): Can read code and create issues/comments but cannot modify files
-- **Write-enabled agents** (builder, doctor, architect, driver): Can modify files, create commits, and push changes
+Each slash command tells Claude to:
+1. Read the role definition from `.loom/roles/<role>.md`
+2. Follow the role's workflow guidelines
+3. Complete ONE iteration of the role's task
 
 ### Agent Roles in Workflow
 
-The subagents work together following the label-based workflow:
+The roles work together following the label-based workflow:
 
 1. **architect** scans codebase → creates proposals with `loom:architect`
 2. **User approves** → adds `loom:issue` label
@@ -146,24 +142,15 @@ The subagents work together following the label-based workflow:
 8. **doctor** fixes feedback → transitions back to `loom:review-requested`
 9. **User merges** → issue auto-closes
 
-### Creating Custom Subagents
+### Creating Custom Commands
 
-To create a custom subagent:
+To create a custom slash command:
 
-1. Create `defaults/.claude/agents/your-agent.md`
-2. Add YAML frontmatter:
-   ```yaml
-   ---
-   name: your-agent
-   description: Clear description of when to invoke this agent
-   tools: Bash, Read, Grep, Glob, Task
-   model: sonnet
-   ---
-   ```
-3. Write agent instructions below frontmatter
-4. Claude Code will automatically detect and use it
+1. Create `.claude/commands/your-command.md`
+2. Reference a role file or write custom instructions
+3. Use it with `/your-command`
 
-See the [Claude Code subagent documentation](https://docs.claude.com/en/docs/claude-code/agents) for more details.
+See `.loom/roles/README.md` for creating custom role definitions.
 
 ## Documentation
 

--- a/defaults/roles/README.md
+++ b/defaults/roles/README.md
@@ -2,23 +2,12 @@
 
 This directory contains role definition templates for different terminal roles in Loom.
 
-## ⚠️ Important: Source of Truth
+## Source of Truth
 
 **This directory is the single source of truth for all Loom role definitions.**
 
-- **Edit role files HERE** (in `defaults/roles/*.md`)
-- **Do NOT edit** `.claude/agents/*.md` files directly - they are auto-generated
-- **After editing**, run `pnpm generate:agents` to regenerate Claude Code agent files
-
-### Why This Pattern?
-
-Claude Code agents cannot reference external files - they must be self-contained. To solve this:
-
-1. **Source**: `defaults/roles/*.md` (edit these)
-2. **Generate**: Run `pnpm generate:agents`
-3. **Result**: `.claude/agents/*.md` (YAML frontmatter + role content)
-
-This prevents duplication errors and ensures `.loom/roles/` is always the authoritative source.
+- **Edit role files HERE** (in `defaults/roles/*.md` or `.loom/roles/*.md`)
+- Slash commands (`.claude/commands/*.md`) reference these role files directly
 
 ## Available Prompts
 


### PR DESCRIPTION
## Summary

Updates documentation to remove stale references to the deleted `.claude/agents/` directory. This PR completes the verification task from #571, confirming that the `.claude/agents/` removal in #527 does not break functionality.

## Changes

- **`.loom/roles/README.md`**: Removed obsolete agent generation instructions
- **`defaults/roles/README.md`**: Removed obsolete agent generation instructions
- **`.claude/README.md`**: Replaced "Subagents" section with "Slash Commands" section
- **`defaults/.claude/README.md`**: Replaced "Subagents" section with "Slash Commands" section

## Verification Results

### Manual Testing ✅

| Component | Status | Notes |
|-----------|--------|-------|
| Slash commands exist | ✅ | All 10 commands in `.claude/commands/` |
| Role files exist | ✅ | All 10 roles in `.loom/roles/` |
| Commands reference roles | ✅ | Commands reference `defaults/roles/*.md` or `.loom/roles/*.md` |
| No broken references | ✅ | Zero references to `.claude/agents/` after fixes |

### Installation Script ✅

| Check | Status | Notes |
|-------|--------|-------|
| Doesn't create agents/ | ✅ | Only installs `.claude/commands` and `.claude/settings.json` |
| defaults/.claude/ clean | ✅ | No agents/ directory in defaults |

### Architecture Verification ✅

The `.claude/agents/` directory was **legacy code** that was never used:

1. **Slash commands** (`.claude/commands/*.md`) tell Claude to read role definitions from `.loom/roles/`
2. **Role definitions** (`.loom/roles/*.md`) contain the actual agent instructions
3. **No automatic agent delegation** - Loom uses explicit slash commands, not Claude's subagent system

The hypothesis from #527 is confirmed: `.claude/agents/` was unnecessary duplication.

## Test Plan

- [x] Verify no broken references to `.claude/agents/`
- [x] Verify slash commands reference role files correctly
- [x] Verify installation script behavior
- [x] Update stale documentation

Closes #571