### PR TITLE
Add enriched error messages for git worktree setup failures

### DIFF
--- a/src/lib/terminal-actions.ts
+++ b/src/lib/terminal-actions.ts
@@ -398,8 +398,9 @@ export async function createPlainTerminal(deps: {
     // Return the created terminal
     return newTerminal;
   } catch (error) {
-    logger.error("Failed to create terminal", error, { workspacePath });
-    showToast(`Failed to create terminal: ${error}`, "error");
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logger.error("Failed to create terminal", error, { workspacePath, errorMessage });
+    showToast(`Failed to create terminal: ${errorMessage}`, "error");
     return undefined;
   }
 }


### PR DESCRIPTION
## Summary

- Add `enrichWorktreeError()` function to transform generic git errors into user-friendly, actionable messages
- Update `setupWorktreeForAgent()` and `setupTerminalWorktree()` to use error enrichment
- Improve error surfacing in `createPlainTerminal()` to properly extract error messages
- Add comprehensive test coverage with 14 new tests for all error scenarios

## Error Scenarios Handled

| Scenario | Before | After |
|----------|--------|-------|
| Terminal not found | "Terminal not found" | "Cannot create worktree: terminal '{id}' not ready. This is a bug in terminal creation order (see issue #734)." |
| Not a git repository | "fatal: not a git repository" | "Cannot create worktree: '{path}' is not a git repository. Please initialize git (git init) or select a different workspace." |
| Worktree exists | "fatal: '{path}' already exists" | "Cannot create worktree: directory '{path}' already exists. This may be from a previous session. Try removing it or restart Loom." |
| Branch collision | "fatal: a branch named 'X' already exists" | "Cannot create worktree: branch '{name}' already exists. This may be left over from a crash. Try: git branch -D {name}" |
| Permission denied | "mkdir: cannot create directory" | "Cannot create worktree: insufficient permissions to create '{path}'. Check file system permissions." |
| Invalid HEAD | "fatal: invalid reference: HEAD" | "Cannot create worktree: HEAD is invalid or detached. Please ensure you have at least one commit in the repository." |

## Test plan

- [x] All 27 tests pass in `worktree-manager.test.ts`
- [x] 14 new tests cover error enrichment scenarios
- [x] TypeScript type checking passes
- [x] Biome linting passes

Closes #748

🤖 Generated with [Claude Code](https://claude.com/claude-code)