### PR TITLE
Preserve loom:curated label when Champion promotes issues

### DIFF
--- a/.loom/roles/champion.md
+++ b/.loom/roles/champion.md
@@ -138,9 +138,8 @@ Check each of the 8 criteria above. If ANY criterion fails, skip to Step 4 (reje
 If all 8 criteria pass, promote the issue:
 
 ```bash
-# Remove loom:curated, add loom:issue
+# Add loom:issue (keep loom:curated as historical context)
 gh issue edit <number> \
-  --remove-label "loom:curated" \
   --add-label "loom:issue"
 
 # Add promotion comment

--- a/defaults/roles/champion.md
+++ b/defaults/roles/champion.md
@@ -138,9 +138,8 @@ Check each of the 8 criteria above. If ANY criterion fails, skip to Step 4 (reje
 If all 8 criteria pass, promote the issue:
 
 ```bash
-# Remove loom:curated, add loom:issue
+# Add loom:issue (keep loom:curated as historical context)
 gh issue edit <number> \
-  --remove-label "loom:curated" \
   --add-label "loom:issue"
 
 # Add promotion comment

--- a/docs/guides/quickstart-tutorial.md
+++ b/docs/guides/quickstart-tutorial.md
@@ -104,12 +104,12 @@ You should see the Curator's enhancement comment with implementation details.
 Once you review the Curator's enhancement, approve it for implementation:
 
 ```bash
-gh issue edit 42 --remove-label "loom:curated" --add-label "loom:issue"
+gh issue edit 42 --add-label "loom:issue"
 ```
 
 **Label transition:**
 ```
-loom:curated → loom:issue (ready for Builder to claim)
+loom:curated + loom:issue (ready for Builder to claim, curated label preserved)
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Fix Champion role to preserve `loom:curated` label when promoting issues to `loom:issue`
- Previously, Champion was removing `loom:curated` when adding `loom:issue`
- Now both labels coexist, preserving historical context that the issue was enhanced by Curator

## Test plan
- [ ] Verify Champion promotion workflow keeps `loom:curated` label
- [ ] Verify documentation accurately reflects the new behavior

Closes #823

🤖 Generated with [Claude Code](https://claude.com/claude-code)