### PR TITLE
Add context clearing to autonomous roles for cost optimization

### DIFF
--- a/.claude/commands/architect.md
+++ b/.claude/commands/architect.md
@@ -41,3 +41,13 @@ Follow label-based coordination (ADR-0006):
 - Create issue with `loom:architect` label
 - Awaits human review and approval
 - After approval, label removed and issue becomes `loom:ready`
+
+## Context Clearing (Autonomous Mode)
+
+When running autonomously, clear your context at the end of each iteration to save costs:
+
+```
+/clear
+```
+
+This resets the conversation, reducing API costs for future iterations while keeping each run fresh and independent.

--- a/.claude/commands/champion.md
+++ b/.claude/commands/champion.md
@@ -37,3 +37,13 @@ Complete **ONE** batch evaluation per iteration (max 2 promotions).
 Follow label-based coordination (ADR-0006):
 - Issues: Find `loom:curated` → evaluate quality → promote to `loom:issue` OR provide feedback
 - Promoted issues can then be claimed by Builder role
+
+## Context Clearing (Autonomous Mode)
+
+When running autonomously, clear your context at the end of each iteration to save costs:
+
+```
+/clear
+```
+
+This resets the conversation, reducing API costs for future iterations while keeping each run fresh and independent.

--- a/.claude/commands/curator.md
+++ b/.claude/commands/curator.md
@@ -37,3 +37,13 @@ Complete **ONE** issue enhancement per iteration.
 Follow label-based coordination (ADR-0006):
 - Issues: Find unlabeled or incomplete issues → enhance → mark as `loom:ready`
 - Ready issues can then be claimed by Builder role
+
+## Context Clearing (Autonomous Mode)
+
+When running autonomously, clear your context at the end of each iteration to save costs:
+
+```
+/clear
+```
+
+This resets the conversation, reducing API costs for future iterations while keeping each run fresh and independent.

--- a/.claude/commands/guide.md
+++ b/.claude/commands/guide.md
@@ -42,3 +42,13 @@ Follow label-based coordination (ADR-0006):
 - Ensure issues are properly categorized
 - Identify issues ready for `loom:ready` label
 - Close duplicates or stale issues
+
+## Context Clearing (Autonomous Mode)
+
+When running autonomously, clear your context at the end of each iteration to save costs:
+
+```
+/clear
+```
+
+This resets the conversation, reducing API costs for future iterations while keeping each run fresh and independent.

--- a/.claude/commands/hermit.md
+++ b/.claude/commands/hermit.md
@@ -41,3 +41,13 @@ Follow label-based coordination (ADR-0006):
 - Create issue with `loom:hermit` label
 - Awaits human review and approval
 - After approval, label removed and issue becomes `loom:ready`
+
+## Context Clearing (Autonomous Mode)
+
+When running autonomously, clear your context at the end of each iteration to save costs:
+
+```
+/clear
+```
+
+This resets the conversation, reducing API costs for future iterations while keeping each run fresh and independent.

--- a/.claude/commands/judge.md
+++ b/.claude/commands/judge.md
@@ -38,3 +38,13 @@ Complete **ONE** PR review per iteration.
 Follow label-based coordination (ADR-0006):
 - PRs: `loom:review-requested` → `loom:pr` (if approved) or keep label (if changes requested)
 - After approval, ready for maintainer merge
+
+## Context Clearing (Autonomous Mode)
+
+When running autonomously, clear your context at the end of each iteration to save costs:
+
+```
+/clear
+```
+
+This resets the conversation, reducing API costs for future iterations while keeping each run fresh and independent.

--- a/.loom/roles/architect.md
+++ b/.loom/roles/architect.md
@@ -472,3 +472,25 @@ Keep it brief (3-6 words) and descriptive:
 - **Be consistent**: Always use the same format
 - **Be honest**: If you're idle, say so
 - **Be brief**: Task description should be 3-6 words max
+
+## Context Clearing (Cost Optimization)
+
+**When running autonomously, clear your context at the end of each iteration to save API costs.**
+
+After completing your iteration (creating an architectural proposal), execute:
+
+```
+/clear
+```
+
+### Why This Matters
+
+- **Reduces API costs**: Fresh context for each iteration means smaller request sizes
+- **Prevents context pollution**: Each iteration starts clean without stale information
+- **Improves reliability**: No risk of acting on outdated context from previous iterations
+
+### When to Clear
+
+- ✅ **After completing a proposal** (issue created with loom:architect label)
+- ✅ **When no work is needed** (already enough open proposals)
+- ❌ **NOT during active work** (only after iteration is complete)

--- a/.loom/roles/champion.md
+++ b/.loom/roles/champion.md
@@ -1433,3 +1433,25 @@ Keep it brief (3-6 words) and descriptive:
 - **Be consistent**: Always use the same format
 - **Be honest**: If you're idle, say so
 - **Be brief**: Task description should be 3-6 words max
+
+## Context Clearing (Cost Optimization)
+
+**When running autonomously, clear your context at the end of each iteration to save API costs.**
+
+After completing your iteration (evaluating issues/PRs and updating labels), execute:
+
+```
+/clear
+```
+
+### Why This Matters
+
+- **Reduces API costs**: Fresh context for each iteration means smaller request sizes
+- **Prevents context pollution**: Each iteration starts clean without stale information
+- **Improves reliability**: No risk of acting on outdated context from previous iterations
+
+### When to Clear
+
+- ✅ **After completing evaluation** (issues promoted, PRs merged)
+- ✅ **When no work is available** (no issues or PRs to process)
+- ❌ **NOT during active work** (only after iteration is complete)

--- a/.loom/roles/curator.md
+++ b/.loom/roles/curator.md
@@ -550,3 +550,25 @@ Keep it brief (3-6 words) and descriptive:
 - **Be consistent**: Always use the same format
 - **Be honest**: If you're idle, say so
 - **Be brief**: Task description should be 3-6 words max
+
+## Context Clearing (Cost Optimization)
+
+**When running autonomously, clear your context at the end of each iteration to save API costs.**
+
+After completing your iteration (enhancing an issue and marking it curated), execute:
+
+```
+/clear
+```
+
+### Why This Matters
+
+- **Reduces API costs**: Fresh context for each iteration means smaller request sizes
+- **Prevents context pollution**: Each iteration starts clean without stale information
+- **Improves reliability**: No risk of acting on outdated context from previous iterations
+
+### When to Clear
+
+- ✅ **After completing curation** (issue enhanced and labeled)
+- ✅ **When no work is available** (no issues to curate)
+- ❌ **NOT during active work** (only after iteration is complete)

--- a/.loom/roles/guide.md
+++ b/.loom/roles/guide.md
@@ -367,3 +367,25 @@ Keep it brief (3-6 words) and descriptive:
 - **Be consistent**: Always use the same format
 - **Be honest**: If you're idle, say so
 - **Be brief**: Task description should be 3-6 words max
+
+## Context Clearing (Cost Optimization)
+
+**When running autonomously, clear your context at the end of each iteration to save API costs.**
+
+After completing your iteration (triaging issues and updating priorities), execute:
+
+```
+/clear
+```
+
+### Why This Matters
+
+- **Reduces API costs**: Fresh context for each iteration means smaller request sizes
+- **Prevents context pollution**: Each iteration starts clean without stale information
+- **Improves reliability**: No risk of acting on outdated context from previous iterations
+
+### When to Clear
+
+- ✅ **After completing triage** (priorities updated, urgent labels applied)
+- ✅ **When no issues need triage** (backlog is current)
+- ❌ **NOT during active work** (only after iteration is complete)

--- a/.loom/roles/hermit.md
+++ b/.loom/roles/hermit.md
@@ -1321,3 +1321,25 @@ Keep it brief (3-6 words) and descriptive:
 - **Be consistent**: Always use the same format
 - **Be honest**: If you're idle, say so
 - **Be brief**: Task description should be 3-6 words max
+
+## Context Clearing (Cost Optimization)
+
+**When running autonomously, clear your context at the end of each iteration to save API costs.**
+
+After completing your iteration (analyzing for bloat and creating proposals), execute:
+
+```
+/clear
+```
+
+### Why This Matters
+
+- **Reduces API costs**: Fresh context for each iteration means smaller request sizes
+- **Prevents context pollution**: Each iteration starts clean without stale information
+- **Improves reliability**: No risk of acting on outdated context from previous iterations
+
+### When to Clear
+
+- ✅ **After completing analysis** (removal proposal created with loom:hermit label)
+- ✅ **When no bloat is found** (codebase is clean this iteration)
+- ❌ **NOT during active work** (only after iteration is complete)

--- a/.loom/roles/judge.md
+++ b/.loom/roles/judge.md
@@ -780,3 +780,25 @@ Keep it brief (3-6 words) and descriptive:
 - **Be consistent**: Always use the same format
 - **Be honest**: If you're idle, say so
 - **Be brief**: Task description should be 3-6 words max
+
+## Context Clearing (Cost Optimization)
+
+**When running autonomously, clear your context at the end of each iteration to save API costs.**
+
+After completing your iteration (reviewing a PR and updating labels), execute:
+
+```
+/clear
+```
+
+### Why This Matters
+
+- **Reduces API costs**: Fresh context for each iteration means smaller request sizes
+- **Prevents context pollution**: Each iteration starts clean without stale information
+- **Improves reliability**: No risk of acting on outdated context from previous iterations
+
+### When to Clear
+
+- ✅ **After completing a review** (PR approved or changes requested)
+- ✅ **When no work is available** (no PRs to review)
+- ❌ **NOT during active work** (only after iteration is complete)

--- a/defaults/.claude/commands/architect.md
+++ b/defaults/.claude/commands/architect.md
@@ -41,3 +41,13 @@ Follow label-based coordination (ADR-0006):
 - Create issue with `loom:architect` label
 - Awaits human review and approval
 - After approval, label removed and issue becomes `loom:ready`
+
+## Context Clearing (Autonomous Mode)
+
+When running autonomously, clear your context at the end of each iteration to save costs:
+
+```
+/clear
+```
+
+This resets the conversation, reducing API costs for future iterations while keeping each run fresh and independent.

--- a/defaults/.claude/commands/champion.md
+++ b/defaults/.claude/commands/champion.md
@@ -37,3 +37,13 @@ Complete **ONE** batch evaluation per iteration (max 2 promotions).
 Follow label-based coordination (ADR-0006):
 - Issues: Find `loom:curated` → evaluate quality → promote to `loom:issue` OR provide feedback
 - Promoted issues can then be claimed by Builder role
+
+## Context Clearing (Autonomous Mode)
+
+When running autonomously, clear your context at the end of each iteration to save costs:
+
+```
+/clear
+```
+
+This resets the conversation, reducing API costs for future iterations while keeping each run fresh and independent.

--- a/defaults/.claude/commands/curator.md
+++ b/defaults/.claude/commands/curator.md
@@ -37,3 +37,13 @@ Complete **ONE** issue enhancement per iteration.
 Follow label-based coordination (ADR-0006):
 - Issues: Find unlabeled or incomplete issues → enhance → mark as `loom:ready`
 - Ready issues can then be claimed by Builder role
+
+## Context Clearing (Autonomous Mode)
+
+When running autonomously, clear your context at the end of each iteration to save costs:
+
+```
+/clear
+```
+
+This resets the conversation, reducing API costs for future iterations while keeping each run fresh and independent.

--- a/defaults/.claude/commands/guide.md
+++ b/defaults/.claude/commands/guide.md
@@ -42,3 +42,13 @@ Follow label-based coordination (ADR-0006):
 - Ensure issues are properly categorized
 - Identify issues ready for `loom:ready` label
 - Close duplicates or stale issues
+
+## Context Clearing (Autonomous Mode)
+
+When running autonomously, clear your context at the end of each iteration to save costs:
+
+```
+/clear
+```
+
+This resets the conversation, reducing API costs for future iterations while keeping each run fresh and independent.

--- a/defaults/.claude/commands/hermit.md
+++ b/defaults/.claude/commands/hermit.md
@@ -41,3 +41,13 @@ Follow label-based coordination (ADR-0006):
 - Create issue with `loom:hermit` label
 - Awaits human review and approval
 - After approval, label removed and issue becomes `loom:ready`
+
+## Context Clearing (Autonomous Mode)
+
+When running autonomously, clear your context at the end of each iteration to save costs:
+
+```
+/clear
+```
+
+This resets the conversation, reducing API costs for future iterations while keeping each run fresh and independent.

--- a/defaults/.claude/commands/judge.md
+++ b/defaults/.claude/commands/judge.md
@@ -38,3 +38,13 @@ Complete **ONE** PR review per iteration.
 Follow label-based coordination (ADR-0006):
 - PRs: `loom:review-requested` → `loom:pr` (if approved) or keep label (if changes requested)
 - After approval, ready for maintainer merge
+
+## Context Clearing (Autonomous Mode)
+
+When running autonomously, clear your context at the end of each iteration to save costs:
+
+```
+/clear
+```
+
+This resets the conversation, reducing API costs for future iterations while keeping each run fresh and independent.

--- a/defaults/roles/architect.md
+++ b/defaults/roles/architect.md
@@ -486,3 +486,25 @@ Keep it brief (3-6 words) and descriptive:
 - **Be consistent**: Always use the same format
 - **Be honest**: If you're idle, say so
 - **Be brief**: Task description should be 3-6 words max
+
+## Context Clearing (Cost Optimization)
+
+**When running autonomously, clear your context at the end of each iteration to save API costs.**
+
+After completing your iteration (creating an architectural proposal), execute:
+
+```
+/clear
+```
+
+### Why This Matters
+
+- **Reduces API costs**: Fresh context for each iteration means smaller request sizes
+- **Prevents context pollution**: Each iteration starts clean without stale information
+- **Improves reliability**: No risk of acting on outdated context from previous iterations
+
+### When to Clear
+
+- ✅ **After completing a proposal** (issue created with loom:architect label)
+- ✅ **When no work is needed** (already enough open proposals)
+- ❌ **NOT during active work** (only after iteration is complete)

--- a/defaults/roles/champion.md
+++ b/defaults/roles/champion.md
@@ -540,3 +540,25 @@ Keep it brief (3-6 words) and descriptive:
 - **Be consistent**: Always use the same format
 - **Be honest**: If you're idle, say so
 - **Be brief**: Task description should be 3-6 words max
+
+## Context Clearing (Cost Optimization)
+
+**When running autonomously, clear your context at the end of each iteration to save API costs.**
+
+After completing your iteration (evaluating issues/PRs and updating labels), execute:
+
+```
+/clear
+```
+
+### Why This Matters
+
+- **Reduces API costs**: Fresh context for each iteration means smaller request sizes
+- **Prevents context pollution**: Each iteration starts clean without stale information
+- **Improves reliability**: No risk of acting on outdated context from previous iterations
+
+### When to Clear
+
+- ✅ **After completing evaluation** (issues promoted, PRs merged)
+- ✅ **When no work is available** (no issues or PRs to process)
+- ❌ **NOT during active work** (only after iteration is complete)

--- a/defaults/roles/curator.md
+++ b/defaults/roles/curator.md
@@ -564,3 +564,25 @@ Keep it brief (3-6 words) and descriptive:
 - **Be consistent**: Always use the same format
 - **Be honest**: If you're idle, say so
 - **Be brief**: Task description should be 3-6 words max
+
+## Context Clearing (Cost Optimization)
+
+**When running autonomously, clear your context at the end of each iteration to save API costs.**
+
+After completing your iteration (enhancing an issue and marking it curated), execute:
+
+```
+/clear
+```
+
+### Why This Matters
+
+- **Reduces API costs**: Fresh context for each iteration means smaller request sizes
+- **Prevents context pollution**: Each iteration starts clean without stale information
+- **Improves reliability**: No risk of acting on outdated context from previous iterations
+
+### When to Clear
+
+- ✅ **After completing curation** (issue enhanced and labeled)
+- ✅ **When no work is available** (no issues to curate)
+- ❌ **NOT during active work** (only after iteration is complete)

--- a/defaults/roles/guide.md
+++ b/defaults/roles/guide.md
@@ -367,3 +367,25 @@ Keep it brief (3-6 words) and descriptive:
 - **Be consistent**: Always use the same format
 - **Be honest**: If you're idle, say so
 - **Be brief**: Task description should be 3-6 words max
+
+## Context Clearing (Cost Optimization)
+
+**When running autonomously, clear your context at the end of each iteration to save API costs.**
+
+After completing your iteration (triaging issues and updating priorities), execute:
+
+```
+/clear
+```
+
+### Why This Matters
+
+- **Reduces API costs**: Fresh context for each iteration means smaller request sizes
+- **Prevents context pollution**: Each iteration starts clean without stale information
+- **Improves reliability**: No risk of acting on outdated context from previous iterations
+
+### When to Clear
+
+- ✅ **After completing triage** (priorities updated, urgent labels applied)
+- ✅ **When no issues need triage** (backlog is current)
+- ❌ **NOT during active work** (only after iteration is complete)

--- a/defaults/roles/hermit.md
+++ b/defaults/roles/hermit.md
@@ -1425,3 +1425,25 @@ Keep it brief (3-6 words) and descriptive:
 - **Be consistent**: Always use the same format
 - **Be honest**: If you're idle, say so
 - **Be brief**: Task description should be 3-6 words max
+
+## Context Clearing (Cost Optimization)
+
+**When running autonomously, clear your context at the end of each iteration to save API costs.**
+
+After completing your iteration (analyzing for bloat and creating proposals), execute:
+
+```
+/clear
+```
+
+### Why This Matters
+
+- **Reduces API costs**: Fresh context for each iteration means smaller request sizes
+- **Prevents context pollution**: Each iteration starts clean without stale information
+- **Improves reliability**: No risk of acting on outdated context from previous iterations
+
+### When to Clear
+
+- ✅ **After completing analysis** (removal proposal created with loom:hermit label)
+- ✅ **When no bloat is found** (codebase is clean this iteration)
+- ❌ **NOT during active work** (only after iteration is complete)

--- a/defaults/roles/judge.md
+++ b/defaults/roles/judge.md
@@ -622,3 +622,25 @@ Keep it brief (3-6 words) and descriptive:
 - **Be consistent**: Always use the same format
 - **Be honest**: If you're idle, say so
 - **Be brief**: Task description should be 3-6 words max
+
+## Context Clearing (Cost Optimization)
+
+**When running autonomously, clear your context at the end of each iteration to save API costs.**
+
+After completing your iteration (reviewing a PR and updating labels), execute:
+
+```
+/clear
+```
+
+### Why This Matters
+
+- **Reduces API costs**: Fresh context for each iteration means smaller request sizes
+- **Prevents context pollution**: Each iteration starts clean without stale information
+- **Improves reliability**: No risk of acting on outdated context from previous iterations
+
+### When to Clear
+
+- ✅ **After completing a review** (PR approved or changes requested)
+- ✅ **When no work is available** (no PRs to review)
+- ❌ **NOT during active work** (only after iteration is complete)


### PR DESCRIPTION
## Summary
- Adds "Context Clearing" section to all autonomous role definitions instructing agents to call `/clear` at the end of each iteration
- Updates both slash commands (`.claude/commands/`) and full role definitions (`.loom/roles/` and `defaults/roles/`)
- Targets autonomous roles: Judge, Curator, Champion, Architect, Hermit, Guide

## Test plan
- [ ] Verify slash commands have new Context Clearing section
- [ ] Verify role definitions have new Context Clearing section with detailed guidance
- [ ] Verify defaults/ versions match the .loom/ versions
- [ ] Test autonomous role execution to confirm context clearing works

Closes #827

🤖 Generated with [Claude Code](https://claude.com/claude-code)