### PR TITLE
Clarify separation between health-monitor and terminal-probe

### DIFF
--- a/src/lib/terminal-probe.ts
+++ b/src/lib/terminal-probe.ts
@@ -1,17 +1,34 @@
 /**
- * terminal-probe.ts - Smart terminal type detection
+ * terminal-probe.ts - Terminal type detection utility
  *
- * This module provides a bash-compatible probe command that can identify
- * whether a terminal is running an AI agent (Claude Code, Codex, etc.) or
- * a plain shell environment. The probe uses bash comments that agents interpret
- * as prompts, while shells simply ignore them.
+ * Architecture:
+ * - This module is the CHECKER: implements HOW to detect terminal type
+ * - Generates probe commands and parses responses to identify agent vs shell
+ * - Is STATELESS - does not schedule periodic checks or track state
+ *
+ * Separation of Concerns:
+ * - terminal-probe.ts (this file): CHECKER - terminal TYPE detection via probe commands
+ * - health-monitor.ts: SCHEDULER - periodic checks, activity timestamps, daemon connectivity
+ *
+ * These modules are intentionally separate:
+ * - Terminal probing checks what TYPE a terminal is (AI agent vs plain shell)
+ * - Health monitoring checks if terminals are ALIVE (session exists, responding)
  *
  * Design:
  * - Bash shells: Comments are ignored, `true` command succeeds silently
  * - AI agents: See comments as questions and respond with structured data
  *
- * This replaces the fragile "2" hack that caused "command not found" errors
- * and only worked for Claude Code's bypass permissions prompt.
+ * Usage:
+ *   const probeCmd = generateProbeCommand();
+ *   const output = await sendToTerminal(terminalId, probeCmd);
+ *   const response = parseProbeResponse(output);
+ *   // response.type === "agent" | "shell" | "unknown"
+ *
+ * DO NOT add scheduling logic here - that's health-monitor's job.
+ * This module should remain stateless and focused on detection.
+ *
+ * @see health-monitor.ts for periodic health checks
+ * @see terminal-state-parser.ts for passive state detection (alternative approach)
  */
 
 export interface ProbeResponse {


### PR DESCRIPTION
## Summary

Adds architectural documentation and tests to clarify the separation of concerns between `health-monitor.ts` and `terminal-probe.ts`:

| Module | Role | Responsibilities |
|--------|------|------------------|
| **health-monitor.ts** | SCHEDULER | Decides WHEN to check; uses IPC for session/daemon checks; tracks activity via passive observation |
| **terminal-probe.ts** | CHECKER | Determines terminal TYPE; sends probe commands and parses responses; stateless pure functions |

### Changes

- **Module docstrings**: Added architectural guidance explaining the separation, cross-references, and "DO NOT" guidelines
- **Inline comments**: Added at key integration points (IPC calls, activity recording)
- **Tests**: Added "Separation of Concerns" test suites to both files verifying:
  - health-monitor uses IPC (not terminal commands)
  - health-monitor tracks state over time
  - terminal-probe is stateless (pure functions)
  - terminal-probe has no side effects

### Why This Matters

- **Prevents future duplication**: Clear boundaries documented in code
- **Easier maintenance**: Know which module to modify for each concern
- **Better testing**: Test scheduler and checker independently
- **Clearer architecture**: Explicit separation of concerns

Closes #743

## Test plan

- [x] All 84 tests pass (40 health-monitor + 44 terminal-probe)
- [x] TypeScript type check passes
- [x] New tests verify architectural separation

🤖 Generated with [Claude Code](https://claude.com/claude-code)