### PR TITLE
Remove duplicate Next Steps from Quick Install output

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -261,12 +261,7 @@ case "$METHOD" in
     echo ""
     success "Quick installation complete!"
     echo ""
-    info "Next steps:"
-    echo "  1. Review installed files in $TARGET_PATH"
-    echo "  2. Commit the changes: git add -A && git commit -m 'Add Loom configuration'"
-    echo "  3. Start using Loom:"
-    echo "     - Open Loom.app and select this workspace, OR"
-    echo "     - Use Claude Code: cd $TARGET_PATH && /builder"
+    info "Don't forget to commit: git add -A && git commit -m 'Add Loom configuration'"
     ;;
 
   2)


### PR DESCRIPTION
## Summary

- Removed duplicate "Next steps:" section from `install.sh` Quick Install (type-1) path
- The `loom-daemon init` command already prints comprehensive "Next steps:" guidance
- Replaced redundant section with single-line reminder about committing changes

## Problem

Running `./install.sh` with type-1 install showed two "Next Steps" sections:

1. From `loom-daemon init`:
   - Review config, customize roles, start Loom app

2. From `install.sh` (duplicate):
   - Review files, commit changes, start Loom

These overlapped and caused confusion.

## Solution

Keep daemon's comprehensive output, add only the commit reminder that daemon doesn't mention:

```
✓ Quick installation complete!

ℹ Don't forget to commit: git add -A && git commit -m 'Add Loom configuration'
```

## Test plan

- [ ] Run `./install.sh` with type-1 install and verify only one "Next steps" section appears
- [ ] Verify commit reminder is displayed

Closes #838

🤖 Generated with [Claude Code](https://claude.com/claude-code)