### PR TITLE
Add comprehensive MCP hooks for programmatic UI control

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -525,6 +525,89 @@ which claude
 # Install if missing (see Claude Code documentation)
 ```
 
+## MCP Hooks for Programmatic Control
+
+Loom provides MCP (Model Context Protocol) servers that allow Claude Code to programmatically control the Loom application. This enables automation, testing, and advanced workflows.
+
+### Available MCP Servers
+
+**loom-terminals** - Terminal management via daemon socket:
+- `list_terminals` - List all active terminal sessions
+- `get_terminal_output` - Get recent output from a terminal
+- `get_selected_terminal` - Get info about the currently selected terminal
+- `send_terminal_input` - Send input to a terminal
+- `create_terminal` - Create a new terminal session
+- `delete_terminal` - Delete a terminal session
+- `restart_terminal` - Restart a terminal preserving its config
+- `configure_terminal` - Update terminal settings (name, role, interval)
+- `set_primary_terminal` - Set which terminal is selected in the UI
+- `clear_terminal_history` - Clear terminal scrollback and log file
+- `check_tmux_server_health` - Check tmux server status
+- `get_tmux_server_info` - Get tmux server details
+- `toggle_tmux_verbose_logging` - Enable tmux debug logging
+
+**loom-ui** - UI control via file-based IPC:
+- `read_console_log` - Read browser console logs
+- `read_state_file` - Read workspace state
+- `read_config_file` - Read workspace config
+- `get_heartbeat` - Check if Loom app is running
+- `get_ui_state` - Get comprehensive UI state (terminals, workspace, engine)
+- `trigger_start` - Start engine with confirmation dialog
+- `trigger_force_start` - Start engine without confirmation
+- `trigger_factory_reset` - Reset workspace with confirmation
+- `trigger_force_factory_reset` - Reset workspace without confirmation
+- `trigger_restart_terminal` - Restart a specific terminal
+- `stop_engine` - Stop all terminals and clean up
+- `trigger_run_now` - Execute interval prompt immediately
+- `get_random_file` - Get random file from workspace
+
+### Example Usage
+
+```bash
+# Create a terminal with specific role
+mcp__loom-terminals__create_terminal --name "Builder" --role "builder"
+
+# Configure autonomous operation
+mcp__loom-terminals__configure_terminal \
+  --terminal_id terminal-1 \
+  --target_interval 300000 \
+  --interval_prompt "Check for new issues"
+
+# Trigger immediate autonomous run
+mcp__loom-ui__trigger_run_now --terminalId terminal-1
+
+# Stop all terminals
+mcp__loom-ui__stop_engine
+
+# Get comprehensive state
+mcp__loom-ui__get_ui_state
+```
+
+### MCP Server Configuration
+
+Add these MCP servers to your Claude Code configuration:
+
+```json
+{
+  "mcpServers": {
+    "loom-terminals": {
+      "command": "node",
+      "args": ["/path/to/loom/mcp-loom-terminals/dist/index.js"],
+      "env": {
+        "LOOM_WORKSPACE": "/path/to/your/workspace"
+      }
+    },
+    "loom-ui": {
+      "command": "node",
+      "args": ["/path/to/loom/mcp-loom-ui/dist/index.js"],
+      "env": {
+        "LOOM_WORKSPACE": "/path/to/your/workspace"
+      }
+    }
+  }
+}
+```
+
 ## Resources
 
 ### Loom Documentation

--- a/src-tauri/src/mcp_watcher.rs
+++ b/src-tauri/src/mcp_watcher.rs
@@ -150,6 +150,18 @@ fn process_command_file(window: &WebviewWindow, command_file: &PathBuf) {
             );
             window.emit("restart-terminal", terminal_id)
         }
+        "stop_engine" => {
+            safe_eprintln!("[MCP Watcher] Emitting stop-engine event");
+            window.emit("stop-engine", ())
+        }
+        cmd if cmd.starts_with("run_now:") => {
+            // Parse terminal ID from command string
+            let terminal_id = cmd.strip_prefix("run_now:").unwrap_or("");
+            safe_eprintln!(
+                "[MCP Watcher] Emitting run-now-terminal event for terminal: {terminal_id}"
+            );
+            window.emit("run-now-terminal", terminal_id)
+        }
         _ => {
             safe_eprintln!("[MCP Watcher] Unknown command: {}", mcp_cmd.command);
             Ok(())


### PR DESCRIPTION
## Summary

Implements comprehensive MCP hooks for programmatic UI control as requested in #735.

- **New terminal management tools** in `mcp-loom-terminals`: `configure_terminal`, `set_primary_terminal`, `clear_terminal_history`
- **New engine control tools** in `mcp-loom-ui`: `stop_engine`, `trigger_run_now`, `get_ui_state`
- **Backend event handlers** for stop-engine and run-now-terminal events
- **Documentation** added to CLAUDE.md with all available MCP tools

## Test plan

- [ ] Verify `configure_terminal` updates config.json correctly
- [ ] Verify `set_primary_terminal` changes the selected terminal
- [ ] Verify `clear_terminal_history` clears tmux scrollback and log file
- [ ] Verify `stop_engine` stops all terminals and cleans up
- [ ] Verify `trigger_run_now` executes interval prompt for a terminal
- [ ] Verify `get_ui_state` returns comprehensive state information
- [ ] Verify documentation is accurate

Closes #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)