### PR TITLE
Fix derivable Default impl clippy warning in AgentStatus

### DIFF
--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -83,9 +83,10 @@ pub struct TerminalInfo {
     pub last_interval_run: Option<i64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentStatus {
+    #[default]
     NotStarted,
     Initializing,
     Ready,
@@ -93,10 +94,4 @@ pub enum AgentStatus {
     WaitingForInput,
     Error,
     Stopped,
-}
-
-impl Default for AgentStatus {
-    fn default() -> Self {
-        Self::NotStarted
-    }
 }


### PR DESCRIPTION
## Summary

- Replace manual `impl Default for AgentStatus` with `#[derive(Default)]`
- Add `#[default]` attribute to `NotStarted` variant

Closes #861

## Test plan

- [x] Verified `cargo clippy -p loom-daemon --all-targets -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)