### PR TITLE
Add MCP autonomous mode controls (start/stop, launch_interval)

### DIFF
--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -54,19 +54,24 @@ MCP (Model Context Protocol) is a standard protocol for connecting AI agents to 
 
 ### 3. [mcp-loom-terminals](./loom-terminals.md)
 
-**Purpose**: Interact with terminal sessions via daemon IPC
+**Purpose**: Interact with terminal sessions via daemon IPC and control autonomous mode
 
 **Key Tools**:
 - `list_terminals` - List active terminals with metadata
 - `get_terminal_output` - Read terminal output
 - `get_selected_terminal` - Get currently selected terminal
 - `send_terminal_input` - Send commands to terminals
+- `start_autonomous_mode` - Start interval prompts for all terminals
+- `stop_autonomous_mode` - Stop all interval prompts
+- `launch_interval` - Manually trigger interval prompt for a terminal
 
 **When to Use**:
 - Sending commands to agent terminals
 - Monitoring agent activity in real-time
 - Interactive terminal sessions
 - Automating terminal workflows
+- Controlling autonomous agent execution
+- Testing autonomous mode behavior
 
 ---
 
@@ -459,7 +464,7 @@ For detailed tool documentation, see individual server references:
 
 - **[mcp-loom-ui API Reference](./loom-ui.md)** - 7 tools for UI interaction
 - **[mcp-loom-logs API Reference](./loom-logs.md)** - 4 tools for log access
-- **[mcp-loom-terminals API Reference](./loom-terminals.md)** - 4 tools for terminal control
+- **[mcp-loom-terminals API Reference](./loom-terminals.md)** - 7 tools for terminal and autonomous mode control
 
 ---
 

--- a/docs/mcp/loom-terminals.md
+++ b/docs/mcp/loom-terminals.md
@@ -287,6 +287,172 @@ mcp__loom-terminals__send_terminal_input({
 
 ---
 
+### `start_autonomous_mode`
+
+Start autonomous mode for all configured terminals. This starts the interval prompt timers for all terminals that have a `targetInterval` configured.
+
+**Parameters:**
+
+None
+
+**Returns:**
+
+Status message indicating success or failure with timing information.
+
+**Success Response:**
+```
+=== Start Autonomous Mode ===
+
+✅ Success
+
+Autonomous mode has been started for all configured terminals.
+
+Terminals with targetInterval > 0 will now receive their intervalPrompt when idle.
+
+MCP command 'start_autonomous_mode' processed successfully (waited 200ms, attempt 2/8)
+```
+
+**Error Response:**
+```
+=== Start Autonomous Mode ===
+
+❌ Failed
+
+MCP command 'start_autonomous_mode' written but no acknowledgment received after 8 retries...
+```
+
+**How It Works:**
+- Sends `start_autonomous_mode` command via file-based IPC to `~/.loom/mcp-command.json`
+- Loom application watches for this file and starts interval prompt timers
+- Uses exponential backoff to wait for acknowledgment
+
+**Example:**
+```typescript
+// Start autonomous mode for all terminals
+mcp__loom-terminals__start_autonomous_mode()
+```
+
+**Use Cases:**
+- Starting automated agent workflows
+- Enabling interval prompts after workspace setup
+- Resuming autonomous operation after manual intervention
+- Integration testing of autonomous behavior
+
+---
+
+### `stop_autonomous_mode`
+
+Stop autonomous mode for all terminals. This pauses all interval prompt timers, preventing automatic prompts from being sent.
+
+**Parameters:**
+
+None
+
+**Returns:**
+
+Status message indicating success or failure with timing information.
+
+**Success Response:**
+```
+=== Stop Autonomous Mode ===
+
+✅ Success
+
+Autonomous mode has been stopped for all terminals.
+
+Terminals will no longer receive automatic interval prompts until autonomous mode is started again.
+
+MCP command 'stop_autonomous_mode' processed successfully (waited 150ms, attempt 1/8)
+```
+
+**Error Response:**
+```
+=== Stop Autonomous Mode ===
+
+❌ Failed
+
+MCP command 'stop_autonomous_mode' written but no acknowledgment received after 8 retries...
+```
+
+**How It Works:**
+- Sends `stop_autonomous_mode` command via file-based IPC
+- Loom application stops all interval prompt timers
+- Terminals remain running but won't receive autonomous prompts
+
+**Example:**
+```typescript
+// Stop autonomous mode
+mcp__loom-terminals__stop_autonomous_mode()
+```
+
+**Use Cases:**
+- Pausing automated workflows for manual intervention
+- Debugging autonomous behavior
+- Temporarily disabling prompts while making changes
+- Graceful shutdown of autonomous operations
+
+---
+
+### `launch_interval`
+
+Manually trigger the interval prompt for a specific terminal immediately. This sends the terminal's configured `intervalPrompt` without waiting for the next scheduled interval.
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `terminal_id` | string | **Yes** | - | Terminal ID to trigger (e.g., `terminal-1`) |
+
+**Returns:**
+
+Status message indicating success or failure with timing information.
+
+**Success Response:**
+```
+=== Launch Interval ===
+
+✅ Success
+
+Interval prompt triggered for terminal terminal-2.
+
+The terminal's configured intervalPrompt has been sent.
+
+MCP command 'launch_interval:terminal-2' processed successfully (waited 180ms, attempt 2/8)
+```
+
+**Error Response:**
+```
+=== Launch Interval ===
+
+❌ Failed
+
+MCP command 'launch_interval:terminal-2' acknowledged but execution failed...
+```
+
+**How It Works:**
+- Sends `launch_interval:{terminal_id}` command via file-based IPC
+- Loom application triggers the interval prompt for the specified terminal
+- Works regardless of whether autonomous mode is currently enabled
+
+**Example:**
+```typescript
+// Trigger interval prompt for terminal-2
+mcp__loom-terminals__launch_interval({
+  terminal_id: "terminal-2"
+})
+```
+
+**Use Cases:**
+- Testing interval prompts without waiting
+- Manually triggering agent work cycles
+- Debugging autonomous prompt behavior
+- On-demand agent activation
+- Integration testing
+
+**Note:** This is similar to `trigger_run_now` in `mcp-loom-ui` but available in the terminals server for convenience.
+
+---
+
 ## Environment Variables
 
 | Variable | Default | Description |

--- a/src-tauri/src/mcp_watcher.rs
+++ b/src-tauri/src/mcp_watcher.rs
@@ -162,6 +162,22 @@ fn process_command_file(window: &WebviewWindow, command_file: &PathBuf) {
             );
             window.emit("run-now-terminal", terminal_id)
         }
+        "start_autonomous_mode" => {
+            safe_eprintln!("[MCP Watcher] Emitting start-autonomous-mode event");
+            window.emit("start-autonomous-mode", ())
+        }
+        "stop_autonomous_mode" => {
+            safe_eprintln!("[MCP Watcher] Emitting stop-autonomous-mode event");
+            window.emit("stop-autonomous-mode", ())
+        }
+        cmd if cmd.starts_with("launch_interval:") => {
+            // Parse terminal ID from command string
+            let terminal_id = cmd.strip_prefix("launch_interval:").unwrap_or("");
+            safe_eprintln!(
+                "[MCP Watcher] Emitting launch-interval-terminal event for terminal: {terminal_id}"
+            );
+            window.emit("launch-interval-terminal", terminal_id)
+        }
         _ => {
             safe_eprintln!("[MCP Watcher] Unknown command: {}", mcp_cmd.command);
             Ok(())

--- a/src/lib/interval-prompt-manager.test.ts
+++ b/src/lib/interval-prompt-manager.test.ts
@@ -1,0 +1,313 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppState, TerminalStatus } from "./state";
+
+// Mock dependencies
+vi.mock("./logger", () => ({
+  Logger: {
+    forComponent: vi.fn(() => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    })),
+  },
+}));
+
+vi.mock("./agent-launcher", () => ({
+  sendPromptToAgent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("./terminal-state-parser", () => ({
+  detectTerminalState: vi.fn().mockResolvedValue({
+    status: "idle",
+    isWaiting: true,
+    hasError: false,
+  }),
+}));
+
+describe("interval-prompt-manager", () => {
+  let state: AppState;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    state = new AppState();
+
+    // Clear the singleton instance
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  describe("getIntervalPromptManager", () => {
+    it("returns singleton instance", async () => {
+      const { getIntervalPromptManager } = await import("./interval-prompt-manager");
+      const manager1 = getIntervalPromptManager();
+      const manager2 = getIntervalPromptManager();
+
+      expect(manager1).toBe(manager2);
+    });
+  });
+
+  describe("start/stop", () => {
+    it("starts management for terminal with valid interval", async () => {
+      const { getIntervalPromptManager } = await import("./interval-prompt-manager");
+      const manager = getIntervalPromptManager();
+
+      state.terminals.addTerminal({
+        id: "term-1",
+        name: "Test Terminal",
+        status: TerminalStatus.Idle,
+        isPrimary: false,
+        roleConfig: {
+          targetInterval: 60000,
+          intervalPrompt: "Continue working",
+        },
+      });
+
+      const terminal = state.terminals.getTerminal("term-1")!;
+      manager.start(terminal);
+
+      expect(manager.isManaged("term-1")).toBe(true);
+    });
+
+    it("stops management for terminal", async () => {
+      const { getIntervalPromptManager } = await import("./interval-prompt-manager");
+      const manager = getIntervalPromptManager();
+
+      state.terminals.addTerminal({
+        id: "term-1",
+        name: "Test Terminal",
+        status: TerminalStatus.Idle,
+        isPrimary: false,
+        roleConfig: {
+          targetInterval: 60000,
+          intervalPrompt: "Continue working",
+        },
+      });
+
+      const terminal = state.terminals.getTerminal("term-1")!;
+      manager.start(terminal);
+      expect(manager.isManaged("term-1")).toBe(true);
+
+      manager.stop("term-1");
+      expect(manager.isManaged("term-1")).toBe(false);
+    });
+
+    it("does not start management for terminal without interval", async () => {
+      const { getIntervalPromptManager } = await import("./interval-prompt-manager");
+      const manager = getIntervalPromptManager();
+
+      state.terminals.addTerminal({
+        id: "term-1",
+        name: "Test Terminal",
+        status: TerminalStatus.Idle,
+        isPrimary: false,
+        roleConfig: {
+          targetInterval: -1, // Invalid interval
+          intervalPrompt: "Continue working",
+        },
+      });
+
+      const terminal = state.terminals.getTerminal("term-1")!;
+      manager.start(terminal);
+
+      expect(manager.isManaged("term-1")).toBe(false);
+    });
+  });
+
+  describe("startAll/stopAll", () => {
+    it("starts management for all eligible terminals", async () => {
+      const { getIntervalPromptManager } = await import("./interval-prompt-manager");
+      const manager = getIntervalPromptManager();
+
+      // Add multiple terminals
+      state.terminals.addTerminal({
+        id: "term-1",
+        name: "Terminal 1",
+        status: TerminalStatus.Idle,
+        isPrimary: false,
+        roleConfig: {
+          targetInterval: 60000,
+          intervalPrompt: "Work on issues",
+        },
+      });
+
+      state.terminals.addTerminal({
+        id: "term-2",
+        name: "Terminal 2",
+        status: TerminalStatus.Idle,
+        isPrimary: false,
+        roleConfig: {
+          targetInterval: 120000,
+          intervalPrompt: "Review PRs",
+        },
+      });
+
+      state.terminals.addTerminal({
+        id: "term-3",
+        name: "Manual Terminal",
+        status: TerminalStatus.Idle,
+        isPrimary: false,
+        // No roleConfig - should not be managed
+      });
+
+      manager.startAll(state);
+
+      expect(manager.isManaged("term-1")).toBe(true);
+      expect(manager.isManaged("term-2")).toBe(true);
+      expect(manager.isManaged("term-3")).toBe(false);
+    });
+
+    it("stops management for all terminals", async () => {
+      const { getIntervalPromptManager } = await import("./interval-prompt-manager");
+      const manager = getIntervalPromptManager();
+
+      // Add and start terminals
+      state.terminals.addTerminal({
+        id: "term-1",
+        name: "Terminal 1",
+        status: TerminalStatus.Idle,
+        isPrimary: false,
+        roleConfig: {
+          targetInterval: 60000,
+          intervalPrompt: "Work on issues",
+        },
+      });
+
+      state.terminals.addTerminal({
+        id: "term-2",
+        name: "Terminal 2",
+        status: TerminalStatus.Idle,
+        isPrimary: false,
+        roleConfig: {
+          targetInterval: 120000,
+          intervalPrompt: "Review PRs",
+        },
+      });
+
+      manager.startAll(state);
+      expect(manager.isManaged("term-1")).toBe(true);
+      expect(manager.isManaged("term-2")).toBe(true);
+
+      manager.stopAll();
+      expect(manager.isManaged("term-1")).toBe(false);
+      expect(manager.isManaged("term-2")).toBe(false);
+    });
+  });
+
+  describe("runNow", () => {
+    it("manually triggers prompt for managed terminal", async () => {
+      const { getIntervalPromptManager } = await import("./interval-prompt-manager");
+      const { sendPromptToAgent } = await import("./agent-launcher");
+      const manager = getIntervalPromptManager();
+
+      state.terminals.addTerminal({
+        id: "term-1",
+        name: "Test Terminal",
+        status: TerminalStatus.Idle,
+        isPrimary: false,
+        roleConfig: {
+          targetInterval: 60000,
+          intervalPrompt: "Custom prompt",
+        },
+      });
+
+      const terminal = state.terminals.getTerminal("term-1")!;
+      manager.start(terminal);
+
+      await manager.runNow(terminal);
+
+      expect(sendPromptToAgent).toHaveBeenCalledWith("term-1", "Custom prompt");
+    });
+
+    it("does nothing for unmanaged terminal", async () => {
+      const { getIntervalPromptManager } = await import("./interval-prompt-manager");
+      const { sendPromptToAgent } = await import("./agent-launcher");
+      const manager = getIntervalPromptManager();
+
+      state.terminals.addTerminal({
+        id: "term-1",
+        name: "Test Terminal",
+        status: TerminalStatus.Idle,
+        isPrimary: false,
+      });
+
+      const terminal = state.terminals.getTerminal("term-1")!;
+      // Don't start management
+
+      await manager.runNow(terminal);
+
+      expect(sendPromptToAgent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getStatus/getAllStatus", () => {
+    it("returns status for managed terminal", async () => {
+      const { getIntervalPromptManager } = await import("./interval-prompt-manager");
+      const manager = getIntervalPromptManager();
+
+      state.terminals.addTerminal({
+        id: "term-1",
+        name: "Test Terminal",
+        status: TerminalStatus.Idle,
+        isPrimary: false,
+        roleConfig: {
+          targetInterval: 60000,
+          intervalPrompt: "Work prompt",
+        },
+      });
+
+      const terminal = state.terminals.getTerminal("term-1")!;
+      manager.start(terminal);
+
+      const status = manager.getStatus("term-1");
+      expect(status).toBeDefined();
+      expect(status?.terminalId).toBe("term-1");
+      expect(status?.minInterval).toBe(60000);
+      expect(status?.intervalPrompt).toBe("Work prompt");
+    });
+
+    it("returns undefined for unmanaged terminal", async () => {
+      const { getIntervalPromptManager } = await import("./interval-prompt-manager");
+      const manager = getIntervalPromptManager();
+
+      const status = manager.getStatus("nonexistent");
+      expect(status).toBeUndefined();
+    });
+
+    it("returns all managed terminal statuses", async () => {
+      const { getIntervalPromptManager } = await import("./interval-prompt-manager");
+      const manager = getIntervalPromptManager();
+
+      state.terminals.addTerminal({
+        id: "term-1",
+        name: "Terminal 1",
+        status: TerminalStatus.Idle,
+        isPrimary: false,
+        roleConfig: {
+          targetInterval: 60000,
+          intervalPrompt: "Prompt 1",
+        },
+      });
+
+      state.terminals.addTerminal({
+        id: "term-2",
+        name: "Terminal 2",
+        status: TerminalStatus.Idle,
+        isPrimary: false,
+        roleConfig: {
+          targetInterval: 120000,
+          intervalPrompt: "Prompt 2",
+        },
+      });
+
+      manager.startAll(state);
+
+      const allStatus = manager.getAllStatus();
+      expect(allStatus).toHaveLength(2);
+      expect(allStatus.map((s) => s.terminalId).sort()).toEqual(["term-1", "term-2"]);
+    });
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -703,6 +703,42 @@ if (!eventListenersRegistered) {
     await handleRunNowClick(terminalId, { state });
   });
 
+  // Start Autonomous Mode - triggered by MCP command
+  listen("start-autonomous-mode", async () => {
+    logger?.info("Starting autonomous mode via MCP command");
+    const { getIntervalPromptManager } = await import("./lib/interval-prompt-manager");
+    const intervalManager = getIntervalPromptManager();
+    intervalManager.startAll(state);
+    logger?.info("Autonomous mode started for all configured terminals");
+    showToast("Autonomous mode started for all terminals.", "success");
+  });
+
+  // Stop Autonomous Mode - triggered by MCP command
+  listen("stop-autonomous-mode", async () => {
+    logger?.info("Stopping autonomous mode via MCP command");
+    const { getIntervalPromptManager } = await import("./lib/interval-prompt-manager");
+    const intervalManager = getIntervalPromptManager();
+    intervalManager.stopAll();
+    logger?.info("Autonomous mode stopped for all terminals");
+    showToast("Autonomous mode stopped for all terminals.", "info");
+  });
+
+  // Launch Interval - triggered by MCP command (same as run-now but with different event name)
+  listen("launch-interval-terminal", async (event) => {
+    const terminalId = event.payload as string;
+    if (!terminalId) {
+      logger?.error(
+        "Launch interval event received without terminal ID",
+        new Error("Missing terminal ID")
+      );
+      return;
+    }
+
+    logger?.info("Launching interval prompt via MCP command", { terminalId });
+    const { handleRunNowClick } = await import("./lib/terminal-actions");
+    await handleRunNowClick(terminalId, { state });
+  });
+
   listen("toggle-theme", () => {
     toggleTheme();
   });


### PR DESCRIPTION
## Summary

- Adds three new MCP tools for autonomous mode control in the `mcp-loom-terminals` server:
  - `start_autonomous_mode`: Start interval prompt timers for all configured terminals
  - `stop_autonomous_mode`: Stop all interval prompt timers (pause autonomous mode)
  - `launch_interval`: Manually trigger interval prompt for a specific terminal

- Uses file-based IPC with acknowledgment for reliable command delivery
- Includes comprehensive documentation updates and unit tests

## Test plan

- [ ] Build MCP server with `pnpm build` in `mcp-loom-terminals/`
- [ ] Start Loom app with configured terminals  
- [ ] Test `start_autonomous_mode` - verify terminals receive prompts at configured intervals
- [ ] Test `stop_autonomous_mode` - verify prompts stop
- [ ] Test `launch_interval` - verify manual trigger sends configured prompt
- [ ] Verify unit tests pass with `pnpm vitest run src/lib/interval-prompt-manager.test.ts`

Closes #804

🤖 Generated with [Claude Code](https://claude.com/claude-code)