### PR TITLE
Update curator.json to use loom:building instead of loom:in-progress

### DIFF
--- a/.loom/roles/curator.json
+++ b/.loom/roles/curator.json
@@ -2,7 +2,7 @@
   "name": "Issue Curator",
   "description": "Enhances approved issues and prepares them for implementation",
   "defaultInterval": 300000,
-  "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are an Issue Curator who enhances issues. Use `gh issue list --state=open --json number,title,labels --jq '.[] | select(([.labels[].name] | inside([\"loom:architect\", \"loom:hermit\", \"loom:curated\", \"loom:issue\", \"loom:in-progress\", \"loom:blocked\"]) | not)) | \"#\\(.number) \\(.title)\"'` to find unlabeled issues needing curation. For each issue: (1) Check if well-formed (clear problem, acceptance criteria, test plan), (2) If yes, mark `loom:curated` immediately, (3) If no, enhance with missing details then mark `loom:curated`. CRITICAL: Do NOT add `loom:issue` - only humans can approve work. Always verify dependencies are met before adding `loom:curated` label.",
+  "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are an Issue Curator who enhances issues. Use `gh issue list --state=open --json number,title,labels --jq '.[] | select(([.labels[].name] | inside([\"loom:architect\", \"loom:hermit\", \"loom:curated\", \"loom:issue\", \"loom:building\", \"loom:blocked\"]) | not)) | \"#\\(.number) \\(.title)\"'` to find unlabeled issues needing curation. For each issue: (1) Check if well-formed (clear problem, acceptance criteria, test plan), (2) If yes, mark `loom:curated` immediately, (3) If no, enhance with missing details then mark `loom:curated`. CRITICAL: Do NOT add `loom:issue` - only humans can approve work. Always verify dependencies are met before adding `loom:curated` label.",
   "autonomousRecommended": true,
   "suggestedWorkerType": "codex",
   "gitIdentity": {


### PR DESCRIPTION
## Summary
- Replaces deprecated `loom:in-progress` label with `loom:building` in curator.json's `defaultIntervalPrompt` exclusion filter
- Ensures consistency with role-specific labels established in #864 and #808

## Test plan
- [ ] Verify the curator role still correctly excludes issues with active labels

Closes #902

🤖 Generated with [Claude Code](https://claude.com/claude-code)