### PR TITLE
Add loom:triage label to labels.yml

### DIFF
--- a/.github/CONFIGURATION.md
+++ b/.github/CONFIGURATION.md
@@ -83,6 +83,7 @@ The issue template integrates with Loom's label-based workflow coordination:
 | Label | Meaning | Who Sets It |
 |-------|---------|-------------|
 | `external` | External contribution | Workflow (automatic) |
+| `loom:triage` | New issue awaiting Curator enhancement | Issue template (automatic) |
 | `loom:curated` | Enhanced by Curator, awaiting human approval | Curator agent |
 | `loom:issue` | Approved for work, ready for Builder | Human (from curated) |
 | `loom:building` | Builder is implementing | Builder agent |

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -4,6 +4,10 @@
 # Or manually: gh label create/edit commands
 
 # Core Workflow States
+- name: loom:triage
+  description: New issue awaiting Curator enhancement
+  color: "9CA3AF"  # gray-400 - neutral initial state
+
 - name: loom:issue
   description: Approved for work by human (ready for Builder to claim)
   color: "3B82F6"  # blue-500

--- a/defaults/.github/CONFIGURATION.md
+++ b/defaults/.github/CONFIGURATION.md
@@ -83,6 +83,7 @@ The issue template integrates with Loom's label-based workflow coordination:
 | Label | Meaning | Who Sets It |
 |-------|---------|-------------|
 | `external` | External contribution | Workflow (automatic) |
+| `loom:triage` | New issue awaiting Curator enhancement | Issue template (automatic) |
 | `loom:curated` | Enhanced by Curator, awaiting human approval | Curator agent |
 | `loom:issue` | Approved for work, ready for Builder | Human (from curated) |
 | `loom:building` | Builder is implementing | Builder agent |

--- a/defaults/.github/labels.yml
+++ b/defaults/.github/labels.yml
@@ -4,6 +4,10 @@
 # Or manually: gh label create/edit commands
 
 # Core Workflow States
+- name: loom:triage
+  description: New issue awaiting Curator enhancement
+  color: "9CA3AF"  # gray-400 - neutral initial state
+
 - name: loom:issue
   description: Approved for work by human (ready for Builder to claim)
   color: "3B82F6"  # blue-500


### PR DESCRIPTION
## Summary
- Adds `loom:triage` label to `.github/labels.yml` and `defaults/.github/labels.yml`
- Updates `loom:triage` entry in label tables in both CONFIGURATION.md files
- Resolves inconsistency where label was referenced but not defined

## Context
The `loom:triage` label was documented and used in issue templates but not defined in `labels.yml`, meaning `gh label sync` wouldn't create it in new installations.

## Test plan
- [ ] Verify YAML syntax is valid
- [ ] Verify `gh label sync --file .github/labels.yml` works without errors
- [ ] Confirm label appears in documentation tables

Closes #904

🤖 Generated with [Claude Code](https://claude.com/claude-code)