### PR TITLE
Document loom:in-progress migration code for future removal (#903)

### DIFF
--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -105,7 +105,14 @@ pub fn reset_github_labels() -> Result<LabelResetResult, String> {
         errors: Vec::new(),
     };
 
-    // Step 1: Remove loom:in-progress from all open issues
+    // Step 1: Migration cleanup - Remove deprecated loom:in-progress label
+    //
+    // MIGRATION CODE: This handles cleanup of the deprecated `loom:in-progress` label.
+    // Background: loom:in-progress was deprecated in favor of role-specific labels
+    // (loom:building, loom:curating, loom:reviewing, loom:treating) in PR #808 (Dec 2025).
+    //
+    // This code can be removed after March 2026 when all installations have migrated.
+    // See: Issue #791 (deprecation request), PR #808 (implementation), Issue #903 (this review)
     let issues_output = Command::new("gh")
         .args([
             "issue",


### PR DESCRIPTION
## Summary

- Documents the `reset_github_labels()` migration code with clear comments explaining:
  - Why it exists (cleanup of deprecated `loom:in-progress` label)
  - When it can be removed (after March 2026)
  - Related issues/PRs for context

## Decision

**Keep migration code for one release cycle** as recommended in the issue.

Rationale:
- PR #808 (deprecation of `loom:in-progress`) was just merged (Dec 2025)
- Repos installed before that may still have the deprecated label
- The migration code only runs during factory reset and is harmless
- Comments now clearly indicate when this code can be removed

## Test plan

- [x] Code formatting verified with `rustfmt --check`
- [x] Changes are documentation comments only (no logic changes)

Closes #903

🤖 Generated with [Claude Code](https://claude.com/claude-code)