### PR TITLE
Remove stale activity-logger.ts reference from vitest config

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,7 +28,6 @@ export default defineConfig({
         "src/lib/desktop-manager.ts",
         // Logging utilities
         "src/lib/console-logger.ts",
-        "src/lib/activity-logger.ts", // TODO: Add tests in follow-up PR
         // Test utilities
         "src/lib/test-utils/**",
       ],


### PR DESCRIPTION
## Summary
- Removes stale coverage exclusion for `activity-logger.ts` which was deleted in PR #880

## Test plan
- [x] No functional change - just config cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)