### PR TITLE
Replace worker type if-else chain with strategy pattern

### DIFF
--- a/src/lib/terminal-settings-modal.ts
+++ b/src/lib/terminal-settings-modal.ts
@@ -6,6 +6,7 @@ import type { AppState, Terminal } from "./state";
 import { TERMINAL_THEMES } from "./themes";
 import { showToast } from "./toast";
 import { parseJSONWithDefault } from "./validation";
+import { getSimpleWorkerLauncher } from "./worker-type-registry";
 
 const logger = Logger.forComponent("terminal-settings-modal");
 
@@ -573,18 +574,9 @@ async function applySettings(
       const workspacePath = state.workspace.getWorkspace();
       if (workspacePath && roleConfig.roleFile) {
         try {
-          if (workerType === "github-copilot") {
-            const { launchGitHubCopilotAgent } = await import("./agent-launcher");
-            await launchGitHubCopilotAgent(terminal.id);
-          } else if (workerType === "gemini") {
-            const { launchGeminiCLIAgent } = await import("./agent-launcher");
-            await launchGeminiCLIAgent(terminal.id);
-          } else if (workerType === "deepseek") {
-            const { launchDeepSeekAgent } = await import("./agent-launcher");
-            await launchDeepSeekAgent(terminal.id);
-          } else if (workerType === "grok") {
-            const { launchGrokAgent } = await import("./agent-launcher");
-            await launchGrokAgent(terminal.id);
+          const simpleLauncher = getSimpleWorkerLauncher(workerType);
+          if (simpleLauncher) {
+            await simpleLauncher(terminal.id);
           } else {
             const { launchAgentInTerminal } = await import("./agent-launcher");
             const { invoke } = await import("@tauri-apps/api/core");

--- a/src/lib/worker-type-registry.ts
+++ b/src/lib/worker-type-registry.ts
@@ -1,0 +1,47 @@
+/**
+ * Worker Type Registry
+ *
+ * Maps simple worker types to their launcher functions.
+ * This eliminates the if-else chain in terminal-settings-modal.ts by providing
+ * O(1) lookup for worker type launchers.
+ *
+ * Worker types in this registry are "simple" launchers that only need a terminal ID.
+ * Complex launchers (Claude, Codex) that require worktree setup are handled separately.
+ */
+
+export type WorkerTypeLauncher = (terminalId: string) => Promise<void>;
+
+/**
+ * Registry of simple worker type launchers.
+ *
+ * Each entry maps a worker type to an async launcher function.
+ * These launchers use dynamic imports to avoid loading unnecessary dependencies.
+ */
+export const SIMPLE_WORKER_LAUNCHERS: Record<string, WorkerTypeLauncher> = {
+  "github-copilot": async (terminalId: string) => {
+    const { launchGitHubCopilotAgent } = await import("./agent-launcher");
+    return launchGitHubCopilotAgent(terminalId);
+  },
+  gemini: async (terminalId: string) => {
+    const { launchGeminiCLIAgent } = await import("./agent-launcher");
+    return launchGeminiCLIAgent(terminalId);
+  },
+  deepseek: async (terminalId: string) => {
+    const { launchDeepSeekAgent } = await import("./agent-launcher");
+    return launchDeepSeekAgent(terminalId);
+  },
+  grok: async (terminalId: string) => {
+    const { launchGrokAgent } = await import("./agent-launcher");
+    return launchGrokAgent(terminalId);
+  },
+};
+
+/**
+ * Get a launcher for a simple worker type.
+ *
+ * @param workerType - The worker type to look up
+ * @returns The launcher function if found, undefined otherwise
+ */
+export function getSimpleWorkerLauncher(workerType: string): WorkerTypeLauncher | undefined {
+  return SIMPLE_WORKER_LAUNCHERS[workerType];
+}


### PR DESCRIPTION
## Summary
- Create `worker-type-registry.ts` with a lookup table for simple worker type launchers
- Replace 12-line if-else chain in `terminal-settings-modal.ts` with 4-line registry lookup
- O(1) lookup instead of O(n) conditional chain for better performance

## Changes
- **New file**: `src/lib/worker-type-registry.ts` - Registry mapping worker types to their launcher functions
- **Modified**: `src/lib/terminal-settings-modal.ts` - Uses registry instead of if-else chain

Closes #590

## Test plan
- [x] TypeScript type checking passes
- [ ] Verify simple worker types (github-copilot, gemini, deepseek, grok) launch correctly
- [ ] Verify Claude/Codex complex path still works with worktree handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)