### PR TITLE
Reduce default line count for MCP log tools from 100 to 20

### DIFF
--- a/mcp-loom-logs/src/index.ts
+++ b/mcp-loom-logs/src/index.ts
@@ -17,7 +17,7 @@ interface LogTailOptions {
 }
 
 async function tailLogFile(filePath: string, options: LogTailOptions = {}): Promise<string> {
-  const { lines = 100 } = options;
+  const { lines = 20 } = options;
 
   try {
     const fileStats = await stat(filePath);
@@ -55,7 +55,7 @@ async function listTerminalLogs(): Promise<string[]> {
   }
 }
 
-async function getTerminalLog(terminalId: string, lines: number = 100): Promise<string> {
+async function getTerminalLog(terminalId: string, lines: number = 20): Promise<string> {
   const logPath = `/tmp/loom-${terminalId}.out`;
   return tailLogFile(logPath, { lines });
 }
@@ -84,8 +84,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           properties: {
             lines: {
               type: "number",
-              description: "Number of lines to show (default: 100)",
-              default: 100,
+              description: "Number of lines to show (default: 20)",
+              default: 20,
             },
           },
         },
@@ -99,8 +99,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           properties: {
             lines: {
               type: "number",
-              description: "Number of lines to show (default: 100)",
-              default: 100,
+              description: "Number of lines to show (default: 20)",
+              default: 20,
             },
           },
         },
@@ -127,8 +127,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             lines: {
               type: "number",
-              description: "Number of lines to show (default: 100)",
-              default: 100,
+              description: "Number of lines to show (default: 20)",
+              default: 20,
             },
           },
           required: ["terminal_id"],
@@ -144,7 +144,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   try {
     switch (name) {
       case "tail_daemon_log": {
-        const lines = (args?.lines as number) || 100;
+        const lines = (args?.lines as number) || 20;
         const content = await tailLogFile(DAEMON_LOG, { lines });
         return {
           content: [
@@ -157,7 +157,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case "tail_tauri_log": {
-        const lines = (args?.lines as number) || 100;
+        const lines = (args?.lines as number) || 20;
         const content = await tailLogFile(TAURI_LOG, { lines });
         return {
           content: [
@@ -193,7 +193,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       case "tail_terminal_log": {
         const terminalId = args?.terminal_id as string;
-        const lines = (args?.lines as number) || 100;
+        const lines = (args?.lines as number) || 20;
 
         if (!terminalId) {
           return {

--- a/mcp-loom-terminals/src/index.ts
+++ b/mcp-loom-terminals/src/index.ts
@@ -201,7 +201,7 @@ async function listTerminals(): Promise<Terminal[]> {
 /**
  * Get terminal output from the log file
  */
-async function getTerminalOutput(terminalId: string, lines = 100): Promise<string> {
+async function getTerminalOutput(terminalId: string, lines = 20): Promise<string> {
   try {
     const logPath = `/tmp/loom-${terminalId}.out`;
     const content = await readFile(logPath, "utf-8");
@@ -906,7 +906,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       {
         name: "get_terminal_output",
         description:
-          "Get the recent output from a specific terminal. Returns the last N lines of output (default 100). Use this to see what a terminal is currently showing.",
+          "Get the recent output from a specific terminal. Returns the last N lines of output (default 20). Use this to see what a terminal is currently showing.",
         inputSchema: {
           type: "object",
           properties: {
@@ -916,8 +916,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             lines: {
               type: "number",
-              description: "Number of lines to show (default: 100)",
-              default: 100,
+              description: "Number of lines to show (default: 20)",
+              default: 20,
             },
           },
           required: ["terminal_id"],
@@ -932,8 +932,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           properties: {
             lines: {
               type: "number",
-              description: "Number of output lines to include (default: 50)",
-              default: 50,
+              description: "Number of output lines to include (default: 20)",
+              default: 20,
             },
           },
         },
@@ -1217,7 +1217,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       case "get_terminal_output": {
         const terminalId = args?.terminal_id as string;
-        const lines = (args?.lines as number) || 100;
+        const lines = (args?.lines as number) || 20;
 
         if (!terminalId) {
           return {
@@ -1242,7 +1242,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case "get_selected_terminal": {
-        const lines = (args?.lines as number) || 50;
+        const lines = (args?.lines as number) || 20;
         const state = await readStateFile();
 
         if (!state || !state.selectedTerminalId) {

--- a/mcp-loom-ui/src/index.ts
+++ b/mcp-loom-ui/src/index.ts
@@ -24,7 +24,7 @@ const CONSOLE_LOG_PATH = join(LOOM_DIR, "console.log");
 /**
  * Read the browser console log file
  */
-async function readConsoleLog(lines = 100): Promise<string> {
+async function readConsoleLog(lines = 20): Promise<string> {
   try {
     await access(CONSOLE_LOG_PATH);
     const content = await readFile(CONSOLE_LOG_PATH, "utf-8");
@@ -473,8 +473,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           properties: {
             lines: {
               type: "number",
-              description: "Number of recent lines to return (default: 100)",
-              default: 100,
+              description: "Number of recent lines to return (default: 20)",
+              default: 20,
             },
           },
         },
@@ -624,7 +624,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   try {
     switch (name) {
       case "read_console_log": {
-        const lines = (args?.lines as number) || 100;
+        const lines = (args?.lines as number) || 20;
         const log = await readConsoleLog(lines);
         return {
           content: [


### PR DESCRIPTION
## Summary

- Reduced default line count for all MCP log reading tools from 100 to 20 lines
- This significantly reduces token usage (~5x reduction) while still providing useful context
- Users can still request more lines explicitly via the `lines` parameter

## Updated Functions

| Package | Function | Old Default | New Default |
|---------|----------|-------------|-------------|
| mcp-loom-ui | `read_console_log` | 100 | 20 |
| mcp-loom-terminals | `get_terminal_output` | 100 | 20 |
| mcp-loom-terminals | `get_selected_terminal` | 50 | 20 |
| mcp-loom-logs | `tail_daemon_log` | 100 | 20 |
| mcp-loom-logs | `tail_tauri_log` | 100 | 20 |
| mcp-loom-logs | `tail_terminal_log` | 100 | 20 |

## Test plan

- [ ] Verify MCP tools return ~20 lines by default
- [ ] Verify explicit `lines` parameter still works (e.g., `lines: 100`)
- [ ] Confirm reduced token usage warnings in typical debugging

Closes #761

🤖 Generated with [Claude Code](https://claude.com/claude-code)