### PR TITLE
Add Sourcegraph Amp CLI support as worker type

### DIFF
--- a/src-tauri/src/dependency_checker.rs
+++ b/src-tauri/src/dependency_checker.rs
@@ -12,6 +12,7 @@ pub struct DependencyStatus {
     pub gemini_cli_available: bool,
     pub deepseek_cli_available: bool,
     pub grok_cli_available: bool,
+    pub amp_cli_available: bool,
 }
 
 pub fn check_dependencies() -> DependencyStatus {
@@ -24,6 +25,7 @@ pub fn check_dependencies() -> DependencyStatus {
         gemini_cli_available: check_command("gemini"),
         deepseek_cli_available: check_command("deepseek"),
         grok_cli_available: check_command("grok"),
+        amp_cli_available: check_command("amp"),
     }
 }
 

--- a/src/lib/agent-launcher.ts
+++ b/src/lib/agent-launcher.ts
@@ -394,6 +394,32 @@ export async function launchGrokAgent(terminalId: string): Promise<void> {
 }
 
 /**
+ * Launch Sourcegraph Amp CLI in a terminal
+ *
+ * This uses the Amp CLI to start an interactive coding session
+ * in the terminal. The agent runs visibly where users can see output and interact.
+ *
+ * @param terminalId - The terminal ID to launch Amp in
+ * @returns Promise that resolves when Amp is launched
+ */
+export async function launchAmpAgent(terminalId: string): Promise<void> {
+  // Build Amp CLI command for interactive mode
+  const command = "amp";
+
+  // Send command to terminal
+  await invoke("send_terminal_input", {
+    id: terminalId,
+    data: command,
+  });
+
+  // Press Enter to execute
+  await invoke("send_terminal_input", {
+    id: terminalId,
+    data: "\r",
+  });
+}
+
+/**
  * Launch Codex agent in a terminal with system prompt
  *
  * This launches Codex with configuration similar to Claude Code:

--- a/src/lib/dependency-checker.test.ts
+++ b/src/lib/dependency-checker.test.ts
@@ -29,6 +29,7 @@ describe("dependency-checker", () => {
         gemini_cli_available: false,
         deepseek_cli_available: false,
         grok_cli_available: false,
+        amp_cli_available: false,
       });
 
       const result = await checkAndReportDependencies();
@@ -47,6 +48,7 @@ describe("dependency-checker", () => {
         gemini_cli_available: false,
         deepseek_cli_available: false,
         grok_cli_available: false,
+        amp_cli_available: false,
       });
 
       vi.mocked(ask).mockResolvedValue(false);
@@ -67,6 +69,7 @@ describe("dependency-checker", () => {
         gemini_cli_available: false,
         deepseek_cli_available: false,
         grok_cli_available: false,
+        amp_cli_available: false,
       });
 
       vi.mocked(ask).mockResolvedValue(false);
@@ -87,6 +90,7 @@ describe("dependency-checker", () => {
         gemini_cli_available: false,
         deepseek_cli_available: false,
         grok_cli_available: false,
+        amp_cli_available: false,
       });
 
       vi.mocked(ask).mockResolvedValue(false);
@@ -110,6 +114,7 @@ describe("dependency-checker", () => {
         gemini_cli_available: false,
         deepseek_cli_available: false,
         grok_cli_available: false,
+        amp_cli_available: false,
       });
 
       const result = await checkAndReportDependencies();
@@ -128,6 +133,25 @@ describe("dependency-checker", () => {
         gemini_cli_available: true,
         deepseek_cli_available: false,
         grok_cli_available: false,
+        amp_cli_available: false,
+      });
+
+      const result = await checkAndReportDependencies();
+
+      expect(result).toBe(true);
+    });
+
+    it("accepts Amp CLI as valid agent", async () => {
+      vi.mocked(invoke).mockResolvedValue({
+        tmux_available: true,
+        git_available: true,
+        claude_code_available: false,
+        gh_available: false,
+        gh_copilot_available: false,
+        gemini_cli_available: false,
+        deepseek_cli_available: false,
+        grok_cli_available: false,
+        amp_cli_available: true,
       });
 
       const result = await checkAndReportDependencies();
@@ -147,6 +171,7 @@ describe("dependency-checker", () => {
           gemini_cli_available: false,
           deepseek_cli_available: false,
           grok_cli_available: false,
+          amp_cli_available: false,
         })
         // Second call: Claude installed
         .mockResolvedValueOnce({
@@ -158,6 +183,7 @@ describe("dependency-checker", () => {
           gemini_cli_available: false,
           deepseek_cli_available: false,
           grok_cli_available: false,
+          amp_cli_available: false,
         });
 
       vi.mocked(ask).mockResolvedValue(true);
@@ -179,6 +205,7 @@ describe("dependency-checker", () => {
         gemini_cli_available: false,
         deepseek_cli_available: false,
         grok_cli_available: false,
+        amp_cli_available: false,
       });
 
       vi.mocked(ask).mockResolvedValue(false);
@@ -200,6 +227,7 @@ describe("dependency-checker", () => {
         gemini_cli_available: false,
         deepseek_cli_available: false,
         grok_cli_available: false,
+        amp_cli_available: false,
       });
 
       const types = await getAvailableWorkerTypes();
@@ -217,6 +245,7 @@ describe("dependency-checker", () => {
         gemini_cli_available: false,
         deepseek_cli_available: false,
         grok_cli_available: false,
+        amp_cli_available: false,
       });
 
       const types = await getAvailableWorkerTypes();
@@ -234,6 +263,7 @@ describe("dependency-checker", () => {
         gemini_cli_available: false,
         deepseek_cli_available: false,
         grok_cli_available: false,
+        amp_cli_available: false,
       });
 
       const types = await getAvailableWorkerTypes();
@@ -252,6 +282,7 @@ describe("dependency-checker", () => {
         gemini_cli_available: false,
         deepseek_cli_available: false,
         grok_cli_available: false,
+        amp_cli_available: false,
       });
 
       const types = await getAvailableWorkerTypes();
@@ -269,6 +300,7 @@ describe("dependency-checker", () => {
         gemini_cli_available: true,
         deepseek_cli_available: false,
         grok_cli_available: false,
+        amp_cli_available: false,
       });
 
       const types = await getAvailableWorkerTypes();
@@ -286,6 +318,7 @@ describe("dependency-checker", () => {
         gemini_cli_available: false,
         deepseek_cli_available: true,
         grok_cli_available: false,
+        amp_cli_available: false,
       });
 
       const types = await getAvailableWorkerTypes();
@@ -303,11 +336,30 @@ describe("dependency-checker", () => {
         gemini_cli_available: false,
         deepseek_cli_available: false,
         grok_cli_available: true,
+        amp_cli_available: false,
       });
 
       const types = await getAvailableWorkerTypes();
 
       expect(types).toContainEqual({ value: "grok", label: "xAI Grok" });
+    });
+
+    it("returns Amp when available", async () => {
+      vi.mocked(invoke).mockResolvedValue({
+        tmux_available: true,
+        git_available: true,
+        claude_code_available: false,
+        gh_available: false,
+        gh_copilot_available: false,
+        gemini_cli_available: false,
+        deepseek_cli_available: false,
+        grok_cli_available: false,
+        amp_cli_available: true,
+      });
+
+      const types = await getAvailableWorkerTypes();
+
+      expect(types).toContainEqual({ value: "amp", label: "Sourcegraph Amp" });
     });
 
     it("returns multiple worker types when multiple agents available", async () => {
@@ -320,6 +372,7 @@ describe("dependency-checker", () => {
         gemini_cli_available: true,
         deepseek_cli_available: false,
         grok_cli_available: false,
+        amp_cli_available: false,
       });
 
       const types = await getAvailableWorkerTypes();

--- a/src/lib/dependency-checker.ts
+++ b/src/lib/dependency-checker.ts
@@ -10,6 +10,7 @@ interface DependencyStatus {
   gemini_cli_available: boolean;
   deepseek_cli_available: boolean;
   grok_cli_available: boolean;
+  amp_cli_available: boolean;
 }
 
 export async function checkAndReportDependencies(): Promise<boolean> {
@@ -26,7 +27,8 @@ export async function checkAndReportDependencies(): Promise<boolean> {
     (status.gh_available && status.gh_copilot_available) ||
     status.gemini_cli_available ||
     status.deepseek_cli_available ||
-    status.grok_cli_available;
+    status.grok_cli_available ||
+    status.amp_cli_available;
 
   // If we have critical deps and at least one agent, we're good
   if (criticalMissing.length === 0 && hasAtLeastOneAgent) {
@@ -79,6 +81,11 @@ export async function checkAndReportDependencies(): Promise<boolean> {
       message += "   • grok - xAI Grok CLI\n";
       message += "     Install: brew install xai/tap/grok-cli\n\n";
     }
+
+    if (!status.amp_cli_available) {
+      message += "   • amp - Sourcegraph Amp CLI\n";
+      message += "     Install: See https://github.com/sourcegraph/amp\n\n";
+    }
   }
 
   message += "Would you like to retry after installation?";
@@ -128,6 +135,10 @@ export async function getAvailableWorkerTypes(): Promise<Array<{ value: string; 
 
   if (status.grok_cli_available) {
     available.push({ value: "grok", label: "xAI Grok" });
+  }
+
+  if (status.amp_cli_available) {
+    available.push({ value: "amp", label: "Sourcegraph Amp" });
   }
 
   return available;

--- a/src/lib/terminal-lifecycle.ts
+++ b/src/lib/terminal-lifecycle.ts
@@ -126,6 +126,9 @@ export async function launchAgentsForTerminals(
       } else if (workerType === "grok") {
         const { launchGrokAgent } = await import("./agent-launcher");
         await launchGrokAgent(terminal.id);
+      } else if (workerType === "amp") {
+        const { launchAmpAgent } = await import("./agent-launcher");
+        await launchAmpAgent(terminal.id);
       } else if (workerType === "codex") {
         // Codex with worktree support (optional - starts in main workspace if empty)
         const { launchCodexAgent } = await import("./agent-launcher");


### PR DESCRIPTION
## Summary

Adds support for Sourcegraph Amp CLI as a worker type in Loom. This allows users to configure terminals to use Amp as their AI coding assistant.

- Added `amp_cli_available` check in Rust dependency checker
- Added Amp to TypeScript dependency checker interface and availability checks
- Added `launchAmpAgent()` function in agent-launcher.ts
- Added Amp worker type handling in terminal-lifecycle.ts
- Added comprehensive tests for Amp CLI support

## Changes

| File | Change |
|------|--------|
| `src-tauri/src/dependency_checker.rs` | Added `amp_cli_available` field and check |
| `src/lib/dependency-checker.ts` | Added Amp to interface, availability checks, and installation instructions |
| `src/lib/agent-launcher.ts` | Added `launchAmpAgent()` function |
| `src/lib/terminal-lifecycle.ts` | Added Amp worker type launch handling |
| `src/lib/dependency-checker.test.ts` | Added tests for Amp CLI detection and availability |

## Test Plan

- [x] All dependency-checker tests pass (18 tests)
- [x] All agent-launcher tests pass (28 tests)
- [x] TypeScript biome lint passes
- [x] Rust clippy passes for dependency_checker.rs
- [ ] Manual test: Verify Amp appears in worker type dropdown when installed
- [ ] Manual test: Configure a terminal with Amp worker type and verify launch

Closes #821

🤖 Generated with [Claude Code](https://claude.com/claude-code)