### PR TITLE
Add --force option to /loom orchestrator

### DIFF
--- a/.claude/commands/loom.md
+++ b/.claude/commands/loom.md
@@ -29,7 +29,26 @@ You don't do the work yourself - you orchestrate other terminals via MCP.
 /loom 123
 /loom 456 --to curated    # Stop after curator phase
 /loom 789 --resume        # Resume from last checkpoint
+/loom 321 --force         # Bypass approval gates, push to merge
 ```
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `--to <phase>` | Stop after specified phase (curated, pr, approved) |
+| `--resume` | Resume from last checkpoint in issue comments |
+| `--force` | Bypass approval gates - auto-approve and auto-merge |
+
+### --force Mode
+
+When `--force` is specified, the orchestrator:
+1. **Skips Gate 1**: Auto-adds `loom:issue` label instead of waiting for human approval
+2. **Skips Gate 2**: Auto-merges the PR after Judge approval instead of waiting
+
+Use `--force` when you've already decided to implement an issue and want hands-off orchestration.
+
+**Warning**: Force mode will merge PRs without human review of the merge decision. The Judge still reviews code quality, but the final merge happens automatically.
 
 ## Phase Flow
 

--- a/defaults/.claude/commands/loom.md
+++ b/defaults/.claude/commands/loom.md
@@ -29,7 +29,26 @@ You don't do the work yourself - you orchestrate other terminals via MCP.
 /loom 123
 /loom 456 --to curated    # Stop after curator phase
 /loom 789 --resume        # Resume from last checkpoint
+/loom 321 --force         # Bypass approval gates, push to merge
 ```
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `--to <phase>` | Stop after specified phase (curated, pr, approved) |
+| `--resume` | Resume from last checkpoint in issue comments |
+| `--force` | Bypass approval gates - auto-approve and auto-merge |
+
+### --force Mode
+
+When `--force` is specified, the orchestrator:
+1. **Skips Gate 1**: Auto-adds `loom:issue` label instead of waiting for human approval
+2. **Skips Gate 2**: Auto-merges the PR after Judge approval instead of waiting
+
+Use `--force` when you've already decided to implement an issue and want hands-off orchestration.
+
+**Warning**: Force mode will merge PRs without human review of the merge decision. The Judge still reviews code quality, but the final merge happens automatically.
 
 ## Phase Flow
 


### PR DESCRIPTION
## Summary

Adds a `--force` flag to the `/loom` orchestrator that bypasses approval gates for hands-off orchestration.

## Changes

When `--force` is specified:
- **Gate 1 (Approval)**: Auto-adds `loom:issue` label instead of waiting for human approval
- **Gate 2 (Merge)**: Auto-merges PR via `gh pr merge --squash` after Judge approval

## Use Cases

- Dogfooding/testing the orchestration system
- Trusted issues where implementation decision is already made  
- Automated pipelines where human gates aren't needed

## Usage

```bash
/loom 123 --force
```

## Flow Comparison

**Normal mode:**
```
Curator → [wait approval] → Builder → Judge → [wait merge] → Complete
```

**Force mode:**
```
Curator → [auto-approve] → Builder → Judge → [auto-merge] → Complete
```

## Warning

Force mode merges PRs without human review of the merge decision. The Judge still reviews code quality, but the final merge happens automatically.

## Test Plan

- [ ] `/loom 713 --force` auto-approves and proceeds to Builder
- [ ] After Judge approval, PR is auto-merged
- [ ] Progress comments show auto-approve/auto-merge actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)