### PR TITLE
Add async coordination primitives for autonomous prompt execution

### DIFF
--- a/src/lib/async-primitives.test.ts
+++ b/src/lib/async-primitives.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it, vi } from "vitest";
+import { AsyncLock, PromiseDeduplicator } from "./async-primitives";
+
+describe("AsyncLock", () => {
+  it("allows single acquisition", async () => {
+    const lock = new AsyncLock();
+
+    expect(lock.isLocked()).toBe(false);
+
+    const release = await lock.acquire();
+
+    expect(lock.isLocked()).toBe(true);
+
+    release();
+
+    expect(lock.isLocked()).toBe(false);
+  });
+
+  it("prevents concurrent access", async () => {
+    const lock = new AsyncLock();
+    const execOrder: number[] = [];
+
+    // First task acquires lock, holds for 50ms
+    const task1 = (async () => {
+      const release = await lock.acquire();
+      execOrder.push(1);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      execOrder.push(2);
+      release();
+    })();
+
+    // Give task1 a moment to acquire the lock
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Second task waits for lock
+    const task2 = (async () => {
+      const release = await lock.acquire();
+      execOrder.push(3);
+      release();
+    })();
+
+    await Promise.all([task1, task2]);
+
+    // Task 1 should complete before task 2 starts
+    expect(execOrder).toEqual([1, 2, 3]);
+  });
+
+  it("processes waiting queue in order", async () => {
+    const lock = new AsyncLock();
+    const execOrder: number[] = [];
+
+    // Acquire lock first
+    const release1 = await lock.acquire();
+
+    // Queue up multiple waiters
+    const task2 = lock.acquire().then((release) => {
+      execOrder.push(2);
+      release();
+    });
+
+    const task3 = lock.acquire().then((release) => {
+      execOrder.push(3);
+      release();
+    });
+
+    const task4 = lock.acquire().then((release) => {
+      execOrder.push(4);
+      release();
+    });
+
+    expect(lock.queueLength).toBe(3);
+
+    // Release the initial lock
+    release1();
+
+    await Promise.all([task2, task3, task4]);
+
+    // Should process in FIFO order
+    expect(execOrder).toEqual([2, 3, 4]);
+  });
+
+  it("reports queue length correctly", async () => {
+    const lock = new AsyncLock();
+
+    expect(lock.queueLength).toBe(0);
+
+    const release = await lock.acquire();
+
+    // Queue up waiters
+    const promises = [lock.acquire(), lock.acquire(), lock.acquire()];
+
+    // Give time for promises to queue
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(lock.queueLength).toBe(3);
+
+    release();
+
+    await Promise.all(promises.map((p) => p.then((r) => r())));
+
+    expect(lock.queueLength).toBe(0);
+  });
+});
+
+describe("PromiseDeduplicator", () => {
+  it("executes operation normally when not in flight", async () => {
+    const dedup = new PromiseDeduplicator<string>();
+
+    const result = await dedup.execute("key1", async () => {
+      return "success";
+    });
+
+    expect(result).toBe("success");
+  });
+
+  it("skips duplicate in-flight operations", async () => {
+    const dedup = new PromiseDeduplicator<string>();
+    let execCount = 0;
+
+    const operation = async () => {
+      execCount++;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      return "result";
+    };
+
+    // Start both at the same time
+    const [result1, result2] = await Promise.all([
+      dedup.execute("key1", operation),
+      dedup.execute("key1", operation),
+    ]);
+
+    expect(result1).toBe("result");
+    expect(result2).toBeUndefined();
+    expect(execCount).toBe(1);
+  });
+
+  it("allows different keys to execute concurrently", async () => {
+    const dedup = new PromiseDeduplicator<string>();
+    let execCount = 0;
+
+    const operation = async (key: string) => {
+      execCount++;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      return `result-${key}`;
+    };
+
+    const [result1, result2] = await Promise.all([
+      dedup.execute("key1", () => operation("key1")),
+      dedup.execute("key2", () => operation("key2")),
+    ]);
+
+    expect(result1).toBe("result-key1");
+    expect(result2).toBe("result-key2");
+    expect(execCount).toBe(2);
+  });
+
+  it("reports in-flight status correctly", async () => {
+    const dedup = new PromiseDeduplicator<void>();
+
+    expect(dedup.isInFlight("key1")).toBe(false);
+
+    let resolveOp: () => void;
+    const opPromise = new Promise<void>((resolve) => {
+      resolveOp = resolve;
+    });
+
+    const execPromise = dedup.execute("key1", () => opPromise);
+
+    // Give time for execution to start
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(dedup.isInFlight("key1")).toBe(true);
+
+    resolveOp!();
+    await execPromise;
+
+    expect(dedup.isInFlight("key1")).toBe(false);
+  });
+
+  it("clears in-flight status on error", async () => {
+    const dedup = new PromiseDeduplicator<string>();
+
+    const failingOperation = async () => {
+      throw new Error("test error");
+    };
+
+    await expect(dedup.execute("key1", failingOperation)).rejects.toThrow("test error");
+
+    // Should clear in-flight status even after error
+    expect(dedup.isInFlight("key1")).toBe(false);
+  });
+
+  it("allows re-execution after previous completes", async () => {
+    const dedup = new PromiseDeduplicator<number>();
+    let counter = 0;
+
+    const operation = async () => {
+      counter++;
+      return counter;
+    };
+
+    const result1 = await dedup.execute("key1", operation);
+    expect(result1).toBe(1);
+
+    const result2 = await dedup.execute("key1", operation);
+    expect(result2).toBe(2);
+  });
+
+  it("returns in-flight keys", async () => {
+    const dedup = new PromiseDeduplicator<void>();
+
+    let resolveOp1: () => void;
+    let resolveOp2: () => void;
+
+    const op1 = new Promise<void>((resolve) => {
+      resolveOp1 = resolve;
+    });
+    const op2 = new Promise<void>((resolve) => {
+      resolveOp2 = resolve;
+    });
+
+    const exec1 = dedup.execute("key1", () => op1);
+    const exec2 = dedup.execute("key2", () => op2);
+
+    // Give time for executions to start
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const keys = dedup.getInFlightKeys();
+    expect(keys).toContain("key1");
+    expect(keys).toContain("key2");
+    expect(dedup.inFlightCount).toBe(2);
+
+    resolveOp1!();
+    resolveOp2!();
+    await Promise.all([exec1, exec2]);
+
+    expect(dedup.getInFlightKeys()).toEqual([]);
+    expect(dedup.inFlightCount).toBe(0);
+  });
+
+  it("handles void operations correctly", async () => {
+    const dedup = new PromiseDeduplicator<void>();
+    const sideEffect = vi.fn();
+
+    await dedup.execute("key1", async () => {
+      sideEffect();
+    });
+
+    expect(sideEffect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/async-primitives.ts
+++ b/src/lib/async-primitives.ts
@@ -1,0 +1,140 @@
+/**
+ * Async coordination primitives for preventing concurrent operations.
+ *
+ * This module provides utilities to manage async operations and prevent
+ * race conditions in the autonomous agent system.
+ */
+
+import { Logger } from "./logger";
+
+const logger = Logger.forComponent("async-primitives");
+
+/**
+ * Provides mutual exclusion for async operations.
+ * Only one operation can hold the lock at a time.
+ *
+ * @example
+ * ```ts
+ * const lock = new AsyncLock();
+ *
+ * async function criticalSection() {
+ *   const release = await lock.acquire();
+ *   try {
+ *     // Only one operation can be here at a time
+ *     await doSomething();
+ *   } finally {
+ *     release();
+ *   }
+ * }
+ * ```
+ */
+export class AsyncLock {
+  private locked = false;
+  private waitQueue: Array<() => void> = [];
+
+  /**
+   * Acquire the lock. If the lock is held, waits until it becomes available.
+   *
+   * @returns A release function that must be called to release the lock
+   */
+  async acquire(): Promise<() => void> {
+    while (this.locked) {
+      await new Promise<void>((resolve) => this.waitQueue.push(resolve));
+    }
+    this.locked = true;
+
+    // Return release function
+    return () => {
+      this.locked = false;
+      const next = this.waitQueue.shift();
+      if (next) next();
+    };
+  }
+
+  /**
+   * Check if the lock is currently held.
+   */
+  isLocked(): boolean {
+    return this.locked;
+  }
+
+  /**
+   * Get the number of operations waiting for the lock.
+   */
+  get queueLength(): number {
+    return this.waitQueue.length;
+  }
+}
+
+/**
+ * Deduplicates in-flight async operations by key.
+ * If an operation is already running for a key, returns undefined instead
+ * of starting a duplicate.
+ *
+ * This implements the "skip duplicates" strategy for concurrent operations,
+ * preventing resource waste and potential race conditions.
+ *
+ * @example
+ * ```ts
+ * const dedup = new PromiseDeduplicator<void>();
+ *
+ * async function sendPrompt(terminalId: string) {
+ *   const result = await dedup.execute(terminalId, async () => {
+ *     await actualSendPrompt(terminalId);
+ *   });
+ *
+ *   if (result === undefined) {
+ *     console.log('Skipped duplicate prompt');
+ *   }
+ * }
+ * ```
+ */
+export class PromiseDeduplicator<T> {
+  private inFlight = new Map<string, Promise<T>>();
+
+  /**
+   * Execute an operation, skipping if one is already in flight for the key.
+   *
+   * @param key - Unique identifier for the operation (e.g., terminal ID)
+   * @param operation - The async operation to execute
+   * @returns The operation result, or undefined if skipped due to duplicate
+   */
+  async execute(key: string, operation: () => Promise<T>): Promise<T | undefined> {
+    // Skip if already in flight
+    if (this.inFlight.has(key)) {
+      logger.info("Skipping duplicate operation", { key });
+      return undefined;
+    }
+
+    const promise = operation();
+    this.inFlight.set(key, promise);
+
+    try {
+      const result = await promise;
+      return result;
+    } finally {
+      this.inFlight.delete(key);
+    }
+  }
+
+  /**
+   * Check if an operation is currently in flight for the given key.
+   */
+  isInFlight(key: string): boolean {
+    return this.inFlight.has(key);
+  }
+
+  /**
+   * Get all keys with in-flight operations.
+   */
+  getInFlightKeys(): string[] {
+    return Array.from(this.inFlight.keys());
+  }
+
+  /**
+   * Get the count of in-flight operations.
+   */
+  get inFlightCount(): number {
+    return this.inFlight.size;
+  }
+}


### PR DESCRIPTION
## Summary

- Implements `AsyncLock` and `PromiseDeduplicator` classes to prevent concurrent autonomous prompt execution on the same terminal
- Updates `autonomous-manager.ts` to use `PromiseDeduplicator` instead of simple `Set<string>` tracking

This addresses the race condition identified in issue #713 where concurrent calls to `sendAutonomousPrompt()` for the same terminal could slip through due to check-then-act race conditions.

## Test plan

- [x] Run `npx vitest run src/lib/async-primitives.test.ts` - 12 tests pass
- [x] Run `npx vitest run src/lib/autonomous-manager.test.ts` - 32 tests pass
- [ ] Manual testing with Loom app to verify autonomous mode works correctly

Closes #713

---
Generated with [Claude Code](https://claude.com/claude-code)