### PR TITLE
Add support for project-specific post-worktree hooks

### DIFF
--- a/.loom/scripts/worktree.sh
+++ b/.loom/scripts/worktree.sh
@@ -107,6 +107,21 @@ Safety Features:
   ✓ Non-interactive (safe for AI agents)
   ✓ Reuses existing branches automatically
   ✓ Automatically initializes git submodules
+  ✓ Runs project-specific hooks after creation
+
+Project-Specific Hooks:
+  Create .loom/hooks/post-worktree.sh to run custom setup after worktree creation.
+  This file is NOT overwritten by Loom upgrades.
+
+  The hook receives three arguments:
+    \$1 - Absolute path to the new worktree
+    \$2 - Branch name (e.g., feature/issue-42)
+    \$3 - Issue number
+
+  Example hook (.loom/hooks/post-worktree.sh):
+    #!/bin/bash
+    cd "\$1"
+    pnpm install  # or: lake exe cache get, pip install -e ., etc.
 
 Resuming Abandoned Work:
   If an agent abandoned work on issue #42, a new agent can resume:
@@ -369,6 +384,29 @@ if git worktree add "${CREATE_ARGS[@]}"; then
 
         # Return to original directory
         cd - > /dev/null
+    fi
+
+    # Run project-specific post-worktree hook if it exists
+    # This allows projects to add custom setup steps (e.g., pnpm install, lake exe cache get)
+    # The hook is stored in .loom/hooks/ which is NOT overwritten by Loom upgrades
+    MAIN_WORKSPACE_DIR=$(git rev-parse --show-toplevel 2>/dev/null)
+    POST_WORKTREE_HOOK="$MAIN_WORKSPACE_DIR/.loom/hooks/post-worktree.sh"
+    if [[ -x "$POST_WORKTREE_HOOK" ]]; then
+        if [[ "$JSON_OUTPUT" != "true" ]]; then
+            print_info "Running project-specific post-worktree hook..."
+        fi
+
+        # Run the hook from the new worktree directory
+        # Pass: worktree path, branch name, issue number
+        if (cd "$ABS_WORKTREE_PATH" && "$POST_WORKTREE_HOOK" "$ABS_WORKTREE_PATH" "$BRANCH_NAME" "$ISSUE_NUMBER"); then
+            if [[ "$JSON_OUTPUT" != "true" ]]; then
+                print_success "Post-worktree hook completed"
+            fi
+        else
+            if [[ "$JSON_OUTPUT" != "true" ]]; then
+                print_warning "Post-worktree hook failed (worktree still created)"
+            fi
+        fi
     fi
 
     # Output results


### PR DESCRIPTION
## Summary

Projects can now create `.loom/hooks/post-worktree.sh` to run custom setup after worktree creation. This hook file is NOT overwritten by Loom upgrades, allowing projects to add setup steps like:

- **Node.js**: `pnpm install`
- **Lean 4**: `lake exe cache get`  
- **Python**: `pip install -e .`
- **Rust**: Fetch cargo registry

## Implementation

The hook is called after submodule initialization and before the success message. It receives three arguments:

| Argument | Description |
|----------|-------------|
| `$1` | Absolute path to the new worktree |
| `$2` | Branch name (e.g., `feature/issue-42`) |
| `$3` | Issue number |

Example hook:
```bash
#!/bin/bash
cd "$1"
pnpm install
```

## Test plan

- [x] Bash syntax validation passes for both scripts
- [ ] Manual test: Create `.loom/hooks/post-worktree.sh` and verify it runs after worktree creation
- [ ] Manual test: Verify hook failure doesn't block worktree creation

Closes #926

---
Generated with [Claude Code](https://claude.com/claude-code)