### PR TITLE
Add quickstart API template (Cloudflare Workers + Hono)

### DIFF
--- a/quickstarts/api/.github/labels.yml
+++ b/quickstarts/api/.github/labels.yml
@@ -1,0 +1,58 @@
+# Loom workflow labels
+- name: "loom:issue"
+  color: "0E8A16"
+  description: "Issue approved for work, ready for Builder"
+
+- name: "loom:building"
+  color: "1D76DB"
+  description: "Builder is actively implementing this"
+
+- name: "loom:review-requested"
+  color: "FBCA04"
+  description: "PR ready for Judge review"
+
+- name: "loom:pr"
+  color: "0E8A16"
+  description: "PR approved, ready to merge"
+
+- name: "loom:changes-requested"
+  color: "E99695"
+  description: "PR requires changes"
+
+- name: "loom:curated"
+  color: "D4C5F9"
+  description: "Issue enhanced by Curator, awaiting approval"
+
+- name: "loom:blocked"
+  color: "B60205"
+  description: "Implementation blocked"
+
+# Standard labels
+- name: "bug"
+  color: "D73A4A"
+  description: "Something isn't working"
+
+- name: "enhancement"
+  color: "A2EEEF"
+  description: "New feature or request"
+
+- name: "documentation"
+  color: "0075CA"
+  description: "Improvements or additions to documentation"
+
+- name: "good first issue"
+  color: "7057FF"
+  description: "Good for newcomers"
+
+# API-specific labels
+- name: "breaking-change"
+  color: "FF0000"
+  description: "Breaking API change"
+
+- name: "security"
+  color: "D93F0B"
+  description: "Security-related issue or fix"
+
+- name: "performance"
+  color: "5319E7"
+  description: "Performance improvement"

--- a/quickstarts/api/.gitignore
+++ b/quickstarts/api/.gitignore
@@ -1,0 +1,35 @@
+# Dependencies
+node_modules
+
+# Build outputs
+dist
+.wrangler
+
+# Environment
+.env
+.env.local
+.env.*.local
+.dev.vars
+
+# Editor
+.vscode/*
+!.vscode/extensions.json
+.idea
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+npm-debug.log*
+pnpm-debug.log*
+
+# Loom
+.loom/config.json
+.loom/worktrees/
+
+# Generated types
+worker-configuration.d.ts

--- a/quickstarts/api/.loom/roles/builder.md
+++ b/quickstarts/api/.loom/roles/builder.md
@@ -1,0 +1,95 @@
+# Builder Role - API Template
+
+You are a Builder working on a RESTful API using Cloudflare Workers, Hono, D1, and TypeScript.
+
+## Tech Stack
+
+- **Framework**: Hono (with zod-openapi for typed routes)
+- **Runtime**: Cloudflare Workers
+- **Database**: D1 (SQLite) + KV (sessions/cache)
+- **Validation**: Zod schemas
+- **Documentation**: OpenAPI/Swagger
+- **Linting**: Biome
+
+## Your Workflow
+
+1. **Find work**: Check for issues labeled `loom:issue`
+   ```bash
+   gh issue list --label="loom:issue"
+   ```
+
+2. **Claim issue**: Remove `loom:issue`, add `loom:building`
+   ```bash
+   gh issue edit <number> --remove-label "loom:issue" --add-label "loom:building"
+   ```
+
+3. **Create worktree**:
+   ```bash
+   ./.loom/scripts/worktree.sh <issue-number>
+   cd .loom/worktrees/issue-<number>
+   ```
+
+4. **Implement**: Follow the patterns established in this codebase
+   - Routes go in `src/routes/`
+   - Middleware goes in `src/middleware/`
+   - Schemas go in `src/schemas/`
+   - Utilities go in `src/lib/`
+
+5. **Test locally**:
+   ```bash
+   pnpm install
+   pnpm dev
+   # API available at http://localhost:8787
+   # Docs at http://localhost:8787/docs
+   ```
+
+6. **Create PR**:
+   ```bash
+   git push -u origin feature/issue-<number>
+   gh pr create --label "loom:review-requested" --body "Closes #<number>"
+   ```
+
+## Code Standards
+
+- Use TypeScript strict mode
+- Define Zod schemas for all request/response types
+- Use OpenAPI route definitions for automatic docs
+- Handle errors with HTTPException
+- Keep routes focused and middleware reusable
+
+## Common Tasks
+
+### Adding a new route
+
+1. Create schema in `src/schemas/myschema.ts`
+2. Create route file `src/routes/myroute.ts` with OpenAPIHono
+3. Mount in `src/index.ts` with `app.route("/api/myroute", myRoutes)`
+
+### Adding middleware
+
+1. Create middleware in `src/middleware/`
+2. Type with `MiddlewareHandler<{ Bindings: Env }>`
+3. Apply to routes with `.use()`
+
+### Database changes
+
+1. Create migration in `migrations/000N_description.sql`
+2. Apply locally: `pnpm db:migrate`
+3. Apply to production: `pnpm db:migrate:prod`
+
+### Testing endpoints
+
+```bash
+# Health check
+curl http://localhost:8787/health
+
+# Register
+curl -X POST http://localhost:8787/api/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"email":"test@example.com","password":"password123","name":"Test"}'
+
+# Login
+curl -X POST http://localhost:8787/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"test@example.com","password":"password123"}'
+```

--- a/quickstarts/api/.loom/roles/judge.md
+++ b/quickstarts/api/.loom/roles/judge.md
@@ -1,0 +1,69 @@
+# Judge Role - API Template
+
+You are a Judge reviewing pull requests for a Cloudflare Workers API.
+
+## Tech Stack
+
+- **Framework**: Hono with zod-openapi
+- **Runtime**: Cloudflare Workers
+- **Database**: D1 + KV
+- **Validation**: Zod schemas
+- **Linting**: Biome
+
+## Your Workflow
+
+1. **Find PRs to review**:
+   ```bash
+   gh pr list --label="loom:review-requested"
+   ```
+
+2. **Review the PR**:
+   ```bash
+   gh pr checkout <number>
+   pnpm install
+   pnpm dev      # Test endpoints
+   pnpm lint     # Check code quality
+   ```
+
+3. **Provide feedback**:
+   - If approved: `gh pr review <number> --approve`
+   - If changes needed: `gh pr review <number> --request-changes --body "..."`
+
+4. **Update labels**:
+   - Approved: `--remove-label "loom:review-requested" --add-label "loom:pr"`
+   - Changes needed: Keep `loom:review-requested`
+
+## Review Checklist
+
+### Security
+- [ ] Input validation using Zod schemas
+- [ ] SQL injection prevention (parameterized queries)
+- [ ] Auth checks on protected routes
+- [ ] Rate limiting applied appropriately
+- [ ] No secrets in code or logs
+- [ ] Proper error messages (no stack traces in production)
+
+### API Design
+- [ ] RESTful route structure
+- [ ] Consistent error response format
+- [ ] OpenAPI documentation for new endpoints
+- [ ] Appropriate HTTP status codes
+- [ ] Request/response types validated
+
+### Code Quality
+- [ ] TypeScript strict mode satisfied
+- [ ] No console.log in production code
+- [ ] Middleware is reusable
+- [ ] Error handling uses HTTPException
+- [ ] Code passes linting (`pnpm lint`)
+
+### Database
+- [ ] Migrations are idempotent (IF NOT EXISTS)
+- [ ] Indexes for queried columns
+- [ ] Foreign keys cascade appropriately
+- [ ] No N+1 query patterns
+
+### General
+- [ ] Changes match issue requirements
+- [ ] Tests cover new functionality
+- [ ] Documentation updated if needed

--- a/quickstarts/api/.loom/scripts/worktree.sh
+++ b/quickstarts/api/.loom/scripts/worktree.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Worktree helper script for Loom quickstart API
+# Usage: ./.loom/scripts/worktree.sh <issue-number>
+
+set -e
+
+ISSUE_NUMBER="$1"
+WORKTREE_DIR=".loom/worktrees/issue-$ISSUE_NUMBER"
+BRANCH_NAME="feature/issue-$ISSUE_NUMBER"
+
+if [ -z "$ISSUE_NUMBER" ]; then
+  echo "Usage: $0 <issue-number>"
+  echo "Example: $0 42"
+  exit 1
+fi
+
+# Check if we're already in a worktree
+if git rev-parse --is-inside-work-tree &>/dev/null; then
+  TOPLEVEL=$(git rev-parse --show-toplevel)
+  if [ -f "$TOPLEVEL/.git" ]; then
+    echo "Error: Already in a worktree. Navigate to main repository first."
+    exit 1
+  fi
+fi
+
+# Create the worktree
+echo "Creating worktree for issue #$ISSUE_NUMBER..."
+git worktree add "$WORKTREE_DIR" -b "$BRANCH_NAME" main
+
+echo ""
+echo "Worktree created successfully!"
+echo ""
+echo "Next steps:"
+echo "  cd $WORKTREE_DIR"
+echo "  pnpm install"
+echo "  pnpm dev"
+echo ""
+echo "When done:"
+echo "  git add -A"
+echo "  git commit -m 'Your message'"
+echo "  git push -u origin $BRANCH_NAME"
+echo "  gh pr create --label 'loom:review-requested'"

--- a/quickstarts/api/README.md
+++ b/quickstarts/api/README.md
@@ -1,0 +1,291 @@
+# Loom Quickstart: API
+
+A modern API backend template pre-configured for Loom AI-powered development.
+
+## Stack
+
+- **Framework**: Hono (with zod-openapi)
+- **Runtime**: Cloudflare Workers
+- **Database**: D1 (SQLite) + KV (sessions/cache)
+- **Validation**: Zod schemas
+- **Documentation**: OpenAPI/Swagger UI
+- **Linting**: Biome
+
+## Features
+
+- RESTful route structure with type-safe handlers
+- JWT authentication with PBKDF2 password hashing
+- Rate limiting via Cloudflare KV
+- OpenAPI spec generation with Swagger UI
+- CORS and security headers configured
+- D1 migrations system
+- Pre-configured Loom roles and workflows
+
+## API Endpoints
+
+| Method | Path | Description | Auth |
+|--------|------|-------------|------|
+| GET | `/health` | Health check | No |
+| GET | `/docs` | Swagger UI | No |
+| GET | `/openapi.json` | OpenAPI spec | No |
+| POST | `/api/auth/register` | Register new user | No |
+| POST | `/api/auth/login` | Login, returns JWT | No |
+| POST | `/api/auth/refresh` | Refresh JWT | Yes |
+| GET | `/api/users` | List users | Admin |
+| GET | `/api/users/:id` | Get user | Owner/Admin |
+| PUT | `/api/users/:id` | Update user | Owner/Admin |
+| DELETE | `/api/users/:id` | Delete user | Admin |
+
+## Quick Start
+
+### 1. Copy the template
+
+```bash
+# From the Loom repository
+cp -r quickstarts/api ~/projects/my-api
+cd ~/projects/my-api
+
+# Initialize git
+git init
+git add -A
+git commit -m "Initial commit from loom-quickstart-api"
+```
+
+### 2. Install dependencies
+
+```bash
+pnpm install
+```
+
+### 3. Set up Cloudflare
+
+```bash
+# Login to Cloudflare
+npx wrangler login
+
+# Create D1 database
+npx wrangler d1 create loom-api-db
+# Copy the database_id to wrangler.toml
+
+# Create KV namespace
+npx wrangler kv:namespace create "sessions"
+# Copy the id to wrangler.toml
+
+# Set JWT secret
+npx wrangler secret put JWT_SECRET
+# Enter a strong random string
+
+# Run migrations
+pnpm db:migrate
+```
+
+### 4. Start development
+
+```bash
+pnpm dev
+```
+
+Visit `http://localhost:8787/docs` to see the Swagger UI.
+
+## Project Structure
+
+```
+├── .loom/
+│   ├── roles/
+│   │   ├── builder.md      # API-specific build guidance
+│   │   └── judge.md        # API review criteria
+│   └── scripts/
+│       └── worktree.sh
+├── .github/
+│   └── labels.yml
+├── migrations/
+│   └── 0001_initial.sql    # D1 schema
+├── src/
+│   ├── routes/
+│   │   ├── auth.ts         # Auth endpoints
+│   │   ├── users.ts        # User CRUD
+│   │   └── health.ts       # Health check
+│   ├── middleware/
+│   │   ├── auth.ts         # JWT verification, RBAC
+│   │   ├── rate-limit.ts   # Rate limiting
+│   │   └── error.ts        # Error handling
+│   ├── schemas/
+│   │   ├── auth.ts         # Auth Zod schemas
+│   │   └── user.ts         # User Zod schemas
+│   ├── lib/
+│   │   ├── jwt.ts          # JWT creation/verification
+│   │   └── password.ts     # PBKDF2 hashing
+│   ├── types.ts            # Type definitions
+│   └── index.ts            # Hono app entry
+├── wrangler.toml
+├── README.md
+└── package.json
+```
+
+## Development Workflow with Loom
+
+### Setting up Loom labels
+
+```bash
+gh label sync --file .github/labels.yml
+```
+
+### Working on an issue
+
+1. Find an issue to work on:
+   ```bash
+   gh issue list --label="loom:issue"
+   ```
+
+2. Claim the issue:
+   ```bash
+   gh issue edit <number> --remove-label "loom:issue" --add-label "loom:building"
+   ```
+
+3. Create a worktree:
+   ```bash
+   ./.loom/scripts/worktree.sh <number>
+   cd .loom/worktrees/issue-<number>
+   ```
+
+4. Implement and test:
+   ```bash
+   pnpm install
+   pnpm dev
+   # Test with curl or Swagger UI
+   pnpm lint
+   ```
+
+5. Create a PR:
+   ```bash
+   git add -A
+   git commit -m "Implement feature X"
+   git push -u origin feature/issue-<number>
+   gh pr create --label "loom:review-requested" --body "Closes #<number>"
+   ```
+
+## Customization
+
+### Adding new routes
+
+1. Create schemas in `src/schemas/myschema.ts`:
+   ```typescript
+   import { z } from "zod";
+
+   export const MyInputSchema = z.object({
+     name: z.string().min(1),
+   });
+   ```
+
+2. Create route file `src/routes/myroute.ts`:
+   ```typescript
+   import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
+   import type { Env } from "../types";
+   import { MyInputSchema } from "../schemas/myschema";
+
+   export const myRoutes = new OpenAPIHono<{ Bindings: Env }>();
+
+   const myRoute = createRoute({
+     method: "post",
+     path: "/",
+     tags: ["My Route"],
+     request: {
+       body: {
+         content: { "application/json": { schema: MyInputSchema } },
+       },
+     },
+     responses: {
+       200: { description: "Success" },
+     },
+   });
+
+   myRoutes.openapi(myRoute, async (c) => {
+     const { name } = c.req.valid("json");
+     return c.json({ message: `Hello, ${name}` });
+   });
+   ```
+
+3. Mount in `src/index.ts`:
+   ```typescript
+   import { myRoutes } from "./routes/myroute";
+   app.route("/api/my", myRoutes);
+   ```
+
+### Adding middleware
+
+```typescript
+import type { MiddlewareHandler } from "hono";
+import type { Env } from "../types";
+
+export const myMiddleware: MiddlewareHandler<{ Bindings: Env }> = async (c, next) => {
+  // Before handler
+  console.log("Request:", c.req.url);
+
+  await next();
+
+  // After handler
+  console.log("Response:", c.res.status);
+};
+```
+
+### Database changes
+
+1. Create migration in `migrations/000N_description.sql`
+2. Apply locally: `pnpm db:migrate`
+3. Apply to production: `pnpm db:migrate:prod`
+
+## Authentication
+
+### Register a user
+
+```bash
+curl -X POST http://localhost:8787/api/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"email":"user@example.com","password":"password123","name":"Test User"}'
+```
+
+### Login
+
+```bash
+curl -X POST http://localhost:8787/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"user@example.com","password":"password123"}'
+```
+
+### Use the token
+
+```bash
+curl http://localhost:8787/api/users/USER_ID \
+  -H "Authorization: Bearer YOUR_TOKEN"
+```
+
+## Deployment
+
+```bash
+# Deploy to Cloudflare Workers
+pnpm deploy
+
+# Run production migrations
+pnpm db:migrate:prod
+```
+
+## Scripts
+
+| Script | Description |
+|--------|-------------|
+| `pnpm dev` | Start development server |
+| `pnpm deploy` | Deploy to Cloudflare Workers |
+| `pnpm db:migrate` | Run D1 migrations locally |
+| `pnpm db:migrate:prod` | Run D1 migrations in production |
+| `pnpm lint` | Check code with Biome |
+| `pnpm lint:fix` | Fix linting issues |
+| `pnpm test` | Run tests |
+| `pnpm types` | Generate wrangler types |
+
+## Learn More
+
+- [Loom Documentation](https://github.com/loomhq/loom)
+- [Hono](https://hono.dev/)
+- [Cloudflare Workers](https://developers.cloudflare.com/workers/)
+- [Cloudflare D1](https://developers.cloudflare.com/d1/)
+- [Zod](https://zod.dev/)

--- a/quickstarts/api/biome.json
+++ b/quickstarts/api/biome.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "organizeImports": {
+    "enabled": true
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "files": {
+    "ignore": ["dist/", "node_modules/", ".wrangler/"]
+  }
+}

--- a/quickstarts/api/migrations/0001_initial.sql
+++ b/quickstarts/api/migrations/0001_initial.sql
@@ -1,0 +1,32 @@
+-- Initial schema for Loom Quickstart API
+-- Users table with auth support
+
+CREATE TABLE IF NOT EXISTS users (
+  id TEXT PRIMARY KEY,
+  email TEXT UNIQUE NOT NULL,
+  name TEXT NOT NULL,
+  password_hash TEXT NOT NULL,
+  role TEXT NOT NULL DEFAULT 'user' CHECK (role IN ('user', 'admin')),
+  created_at TEXT DEFAULT (datetime('now')),
+  updated_at TEXT DEFAULT (datetime('now'))
+);
+
+-- Create indexes
+CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
+CREATE INDEX IF NOT EXISTS idx_users_role ON users(role);
+
+-- API keys for service-to-service auth (optional)
+CREATE TABLE IF NOT EXISTS api_keys (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  key_hash TEXT UNIQUE NOT NULL,
+  user_id TEXT NOT NULL,
+  permissions TEXT DEFAULT '[]', -- JSON array of permissions
+  last_used_at TEXT,
+  expires_at TEXT,
+  created_at TEXT DEFAULT (datetime('now')),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_keys_key_hash ON api_keys(key_hash);
+CREATE INDEX IF NOT EXISTS idx_api_keys_user_id ON api_keys(user_id);

--- a/quickstarts/api/package.json
+++ b/quickstarts/api/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "loom-quickstart-api",
+  "version": "0.1.0",
+  "description": "Loom quickstart template for API backends with Cloudflare Workers, Hono, and D1",
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "db:migrate": "wrangler d1 migrations apply loom-api-db --local",
+    "db:migrate:prod": "wrangler d1 migrations apply loom-api-db --remote",
+    "lint": "biome check .",
+    "lint:fix": "biome check --write .",
+    "format": "biome format --write .",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "types": "wrangler types"
+  },
+  "dependencies": {
+    "@hono/swagger-ui": "^0.4.1",
+    "@hono/zod-openapi": "^0.18.0",
+    "hono": "^4.6.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.0.0",
+    "@cloudflare/workers-types": "^4.20241218.0",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8",
+    "wrangler": "^3.99.0"
+  }
+}

--- a/quickstarts/api/src/index.ts
+++ b/quickstarts/api/src/index.ts
@@ -1,0 +1,64 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { swaggerUI } from "@hono/swagger-ui";
+import { cors } from "hono/cors";
+import { logger } from "hono/logger";
+import { secureHeaders } from "hono/secure-headers";
+
+import type { Env } from "./types";
+import { errorHandler } from "./middleware/error";
+import { rateLimiter } from "./middleware/rate-limit";
+import { authRoutes } from "./routes/auth";
+import { userRoutes } from "./routes/users";
+import { healthRoutes } from "./routes/health";
+
+const app = new OpenAPIHono<{ Bindings: Env }>();
+
+// Global middleware
+app.use("*", logger());
+app.use("*", secureHeaders());
+app.use(
+  "*",
+  cors({
+    origin: ["http://localhost:3000", "http://localhost:5173"],
+    allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allowHeaders: ["Content-Type", "Authorization"],
+    credentials: true,
+  })
+);
+
+// Rate limiting on API routes
+app.use("/api/*", rateLimiter);
+
+// Error handling
+app.onError(errorHandler);
+
+// Mount routes
+app.route("/", healthRoutes);
+app.route("/api/auth", authRoutes);
+app.route("/api/users", userRoutes);
+
+// OpenAPI documentation
+app.doc("/openapi.json", {
+  openapi: "3.0.0",
+  info: {
+    title: "Loom Quickstart API",
+    version: "0.1.0",
+    description: "A RESTful API template built with Hono on Cloudflare Workers",
+  },
+  servers: [
+    { url: "http://localhost:8787", description: "Development" },
+  ],
+});
+
+// Swagger UI
+app.get(
+  "/docs",
+  swaggerUI({
+    url: "/openapi.json",
+  })
+);
+
+// Root redirect to docs
+app.get("/", (c) => c.redirect("/docs"));
+
+export default app;

--- a/quickstarts/api/src/lib/jwt.ts
+++ b/quickstarts/api/src/lib/jwt.ts
@@ -1,0 +1,118 @@
+import type { JwtPayload } from "../types";
+
+/**
+ * Create a JWT token using Web Crypto API (edge-compatible)
+ */
+export async function createJwt(
+  payload: Omit<JwtPayload, "iat" | "exp">,
+  secret: string,
+  expiresIn: string
+): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  const exp = now + parseExpiration(expiresIn);
+
+  const fullPayload: JwtPayload = {
+    ...payload,
+    iat: now,
+    exp,
+  };
+
+  const header = { alg: "HS256", typ: "JWT" };
+  const encodedHeader = base64UrlEncode(JSON.stringify(header));
+  const encodedPayload = base64UrlEncode(JSON.stringify(fullPayload));
+  const signatureInput = `${encodedHeader}.${encodedPayload}`;
+
+  const signature = await sign(signatureInput, secret);
+
+  return `${signatureInput}.${signature}`;
+}
+
+/**
+ * Verify and decode a JWT token
+ */
+export async function verifyJwt(token: string, secret: string): Promise<JwtPayload> {
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    throw new Error("Invalid token format");
+  }
+
+  const [encodedHeader, encodedPayload, signature] = parts;
+  const signatureInput = `${encodedHeader}.${encodedPayload}`;
+
+  // Verify signature
+  const expectedSignature = await sign(signatureInput, secret);
+  if (signature !== expectedSignature) {
+    throw new Error("Invalid signature");
+  }
+
+  // Decode payload
+  const payload = JSON.parse(base64UrlDecode(encodedPayload)) as JwtPayload;
+
+  // Check expiration
+  const now = Math.floor(Date.now() / 1000);
+  if (payload.exp < now) {
+    throw new Error("Token expired");
+  }
+
+  return payload;
+}
+
+/**
+ * Sign data using HMAC-SHA256
+ */
+async function sign(data: string, secret: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const keyData = encoder.encode(secret);
+  const dataBuffer = encoder.encode(data);
+
+  const key = await crypto.subtle.importKey(
+    "raw",
+    keyData,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+
+  const signature = await crypto.subtle.sign("HMAC", key, dataBuffer);
+  return base64UrlEncode(String.fromCharCode(...new Uint8Array(signature)));
+}
+
+/**
+ * Parse expiration string (e.g., "7d", "1h", "30m")
+ */
+function parseExpiration(exp: string): number {
+  const match = exp.match(/^(\d+)([smhd])$/);
+  if (!match) {
+    throw new Error(`Invalid expiration format: ${exp}`);
+  }
+
+  const value = parseInt(match[1], 10);
+  const unit = match[2];
+
+  switch (unit) {
+    case "s":
+      return value;
+    case "m":
+      return value * 60;
+    case "h":
+      return value * 60 * 60;
+    case "d":
+      return value * 60 * 60 * 24;
+    default:
+      throw new Error(`Unknown time unit: ${unit}`);
+  }
+}
+
+function base64UrlEncode(str: string): string {
+  const base64 = btoa(str);
+  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function base64UrlDecode(str: string): string {
+  let base64 = str.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = base64.length % 4;
+  if (padding) {
+    base64 += "=".repeat(4 - padding);
+  }
+  return atob(base64);
+}

--- a/quickstarts/api/src/lib/password.ts
+++ b/quickstarts/api/src/lib/password.ts
@@ -1,0 +1,55 @@
+/**
+ * Hash password using PBKDF2 (edge-compatible)
+ */
+export async function hashPassword(
+  password: string,
+  salt?: string
+): Promise<{ hash: string; salt: string }> {
+  const encoder = new TextEncoder();
+  const passwordSalt =
+    salt || btoa(String.fromCharCode(...crypto.getRandomValues(new Uint8Array(16))));
+
+  const keyMaterial = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(password),
+    "PBKDF2",
+    false,
+    ["deriveBits"]
+  );
+
+  const derivedBits = await crypto.subtle.deriveBits(
+    {
+      name: "PBKDF2",
+      salt: encoder.encode(passwordSalt),
+      iterations: 100000,
+      hash: "SHA-256",
+    },
+    keyMaterial,
+    256
+  );
+
+  const hash = btoa(String.fromCharCode(...new Uint8Array(derivedBits)));
+  return { hash: `${passwordSalt}:${hash}`, salt: passwordSalt };
+}
+
+/**
+ * Verify password against stored hash
+ */
+export async function verifyPassword(
+  password: string,
+  storedHash: string
+): Promise<boolean> {
+  const [salt, expectedHash] = storedHash.split(":");
+  if (!salt || !expectedHash) return false;
+
+  const { hash } = await hashPassword(password, salt);
+  const [, computedHash] = hash.split(":");
+
+  // Constant-time comparison to prevent timing attacks
+  if (computedHash.length !== expectedHash.length) return false;
+  let result = 0;
+  for (let i = 0; i < computedHash.length; i++) {
+    result |= computedHash.charCodeAt(i) ^ expectedHash.charCodeAt(i);
+  }
+  return result === 0;
+}

--- a/quickstarts/api/src/middleware/auth.ts
+++ b/quickstarts/api/src/middleware/auth.ts
@@ -1,0 +1,71 @@
+import type { MiddlewareHandler } from "hono";
+import { HTTPException } from "hono/http-exception";
+import type { Env, JwtPayload } from "../types";
+import { verifyJwt } from "../lib/jwt";
+
+declare module "hono" {
+  interface ContextVariableMap {
+    user: JwtPayload;
+  }
+}
+
+/**
+ * Authentication middleware - validates JWT token
+ */
+export const requireAuth: MiddlewareHandler<{ Bindings: Env }> = async (c, next) => {
+  const authHeader = c.req.header("Authorization");
+
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    throw new HTTPException(401, { message: "Missing or invalid authorization header" });
+  }
+
+  const token = authHeader.substring(7);
+
+  try {
+    const payload = await verifyJwt(token, c.env.JWT_SECRET);
+    c.set("user", payload);
+    await next();
+  } catch {
+    throw new HTTPException(401, { message: "Invalid or expired token" });
+  }
+};
+
+/**
+ * Role-based access control middleware
+ */
+export const requireRole = (
+  ...allowedRoles: string[]
+): MiddlewareHandler<{ Bindings: Env }> => {
+  return async (c, next) => {
+    const user = c.get("user");
+
+    if (!user) {
+      throw new HTTPException(401, { message: "Authentication required" });
+    }
+
+    if (!allowedRoles.includes(user.role)) {
+      throw new HTTPException(403, { message: "Insufficient permissions" });
+    }
+
+    await next();
+  };
+};
+
+/**
+ * Optional auth - sets user if token present, continues otherwise
+ */
+export const optionalAuth: MiddlewareHandler<{ Bindings: Env }> = async (c, next) => {
+  const authHeader = c.req.header("Authorization");
+
+  if (authHeader?.startsWith("Bearer ")) {
+    const token = authHeader.substring(7);
+    try {
+      const payload = await verifyJwt(token, c.env.JWT_SECRET);
+      c.set("user", payload);
+    } catch {
+      // Token invalid, continue without user
+    }
+  }
+
+  await next();
+};

--- a/quickstarts/api/src/middleware/error.ts
+++ b/quickstarts/api/src/middleware/error.ts
@@ -1,0 +1,48 @@
+import type { ErrorHandler } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { ZodError } from "zod";
+
+export interface ApiError {
+  error: string;
+  message: string;
+  details?: unknown;
+}
+
+export const errorHandler: ErrorHandler = (err, c) => {
+  console.error(`[Error] ${err.message}`, err.stack);
+
+  // Handle Zod validation errors
+  if (err instanceof ZodError) {
+    return c.json<ApiError>(
+      {
+        error: "Validation Error",
+        message: "Invalid request data",
+        details: err.errors.map((e) => ({
+          path: e.path.join("."),
+          message: e.message,
+        })),
+      },
+      400
+    );
+  }
+
+  // Handle HTTP exceptions
+  if (err instanceof HTTPException) {
+    return c.json<ApiError>(
+      {
+        error: err.message,
+        message: err.message,
+      },
+      err.status
+    );
+  }
+
+  // Handle generic errors
+  return c.json<ApiError>(
+    {
+      error: "Internal Server Error",
+      message: "An unexpected error occurred",
+    },
+    500
+  );
+};

--- a/quickstarts/api/src/middleware/rate-limit.ts
+++ b/quickstarts/api/src/middleware/rate-limit.ts
@@ -1,0 +1,56 @@
+import type { MiddlewareHandler } from "hono";
+import { HTTPException } from "hono/http-exception";
+import type { Env } from "../types";
+
+interface RateLimitConfig {
+  windowMs: number; // Time window in milliseconds
+  maxRequests: number; // Max requests per window
+}
+
+const DEFAULT_CONFIG: RateLimitConfig = {
+  windowMs: 60 * 1000, // 1 minute
+  maxRequests: 100, // 100 requests per minute
+};
+
+/**
+ * Rate limiter using Cloudflare KV for distributed state
+ * Falls back to allowing requests if KV is unavailable
+ */
+export const rateLimiter: MiddlewareHandler<{ Bindings: Env }> = async (c, next) => {
+  const config = DEFAULT_CONFIG;
+  const ip = c.req.header("CF-Connecting-IP") || c.req.header("X-Forwarded-For") || "unknown";
+  const key = `ratelimit:${ip}`;
+  const now = Date.now();
+  const windowStart = now - config.windowMs;
+
+  try {
+    // Get current rate limit data from KV
+    const data = await c.env.KV.get(key, "json") as { requests: number[]; } | null;
+    const requests = data?.requests?.filter((t) => t > windowStart) || [];
+
+    if (requests.length >= config.maxRequests) {
+      throw new HTTPException(429, {
+        message: "Too many requests. Please try again later.",
+      });
+    }
+
+    // Add current request timestamp
+    requests.push(now);
+
+    // Store updated data with TTL
+    await c.env.KV.put(key, JSON.stringify({ requests }), {
+      expirationTtl: Math.ceil(config.windowMs / 1000),
+    });
+
+    // Add rate limit headers
+    c.header("X-RateLimit-Limit", config.maxRequests.toString());
+    c.header("X-RateLimit-Remaining", (config.maxRequests - requests.length).toString());
+    c.header("X-RateLimit-Reset", (now + config.windowMs).toString());
+  } catch (err) {
+    if (err instanceof HTTPException) throw err;
+    // If KV fails, allow the request but log the error
+    console.error("[RateLimit] KV error:", err);
+  }
+
+  await next();
+};

--- a/quickstarts/api/src/routes/auth.ts
+++ b/quickstarts/api/src/routes/auth.ts
@@ -1,0 +1,256 @@
+import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
+import { HTTPException } from "hono/http-exception";
+import type { Env, User } from "../types";
+import { createJwt } from "../lib/jwt";
+import { hashPassword, verifyPassword } from "../lib/password";
+import {
+  LoginSchema,
+  RegisterSchema,
+  AuthResponseSchema,
+  ErrorSchema,
+} from "../schemas/auth";
+
+export const authRoutes = new OpenAPIHono<{ Bindings: Env }>();
+
+// POST /auth/register
+const registerRoute = createRoute({
+  method: "post",
+  path: "/register",
+  tags: ["Auth"],
+  summary: "Register a new user",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: RegisterSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    201: {
+      description: "User registered successfully",
+      content: {
+        "application/json": {
+          schema: AuthResponseSchema,
+        },
+      },
+    },
+    400: {
+      description: "Validation error",
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+    },
+    409: {
+      description: "Email already exists",
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+    },
+  },
+});
+
+authRoutes.openapi(registerRoute, async (c) => {
+  const { email, password, name } = c.req.valid("json");
+
+  // Hash password
+  const { hash: passwordHash } = await hashPassword(password);
+  const id = crypto.randomUUID();
+
+  try {
+    await c.env.DB.prepare(
+      "INSERT INTO users (id, email, name, password_hash, role) VALUES (?, ?, ?, ?, ?)"
+    )
+      .bind(id, email, name, passwordHash, "user")
+      .run();
+
+    // Generate JWT
+    const accessToken = await createJwt(
+      { sub: id, email, role: "user" },
+      c.env.JWT_SECRET,
+      c.env.JWT_EXPIRES_IN
+    );
+
+    const expiresAt = new Date(
+      Date.now() + parseExpirationMs(c.env.JWT_EXPIRES_IN)
+    ).toISOString();
+
+    return c.json(
+      {
+        user: { id, email, name, role: "user" },
+        accessToken,
+        expiresAt,
+      },
+      201
+    );
+  } catch (e) {
+    if ((e as Error).message.includes("UNIQUE constraint failed")) {
+      throw new HTTPException(409, { message: "Email already exists" });
+    }
+    throw e;
+  }
+});
+
+// POST /auth/login
+const loginRoute = createRoute({
+  method: "post",
+  path: "/login",
+  tags: ["Auth"],
+  summary: "Login with email and password",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: LoginSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Login successful",
+      content: {
+        "application/json": {
+          schema: AuthResponseSchema,
+        },
+      },
+    },
+    401: {
+      description: "Invalid credentials",
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+    },
+  },
+});
+
+authRoutes.openapi(loginRoute, async (c) => {
+  const { email, password } = c.req.valid("json");
+
+  const user = await c.env.DB.prepare(
+    "SELECT id, email, name, password_hash, role FROM users WHERE email = ?"
+  )
+    .bind(email)
+    .first<User & { password_hash: string }>();
+
+  if (!user) {
+    throw new HTTPException(401, { message: "Invalid email or password" });
+  }
+
+  const validPassword = await verifyPassword(password, user.password_hash);
+  if (!validPassword) {
+    throw new HTTPException(401, { message: "Invalid email or password" });
+  }
+
+  // Generate JWT
+  const accessToken = await createJwt(
+    { sub: user.id, email: user.email, role: user.role },
+    c.env.JWT_SECRET,
+    c.env.JWT_EXPIRES_IN
+  );
+
+  const expiresAt = new Date(
+    Date.now() + parseExpirationMs(c.env.JWT_EXPIRES_IN)
+  ).toISOString();
+
+  return c.json({
+    user: { id: user.id, email: user.email, name: user.name, role: user.role },
+    accessToken,
+    expiresAt,
+  });
+});
+
+// POST /auth/refresh
+const refreshRoute = createRoute({
+  method: "post",
+  path: "/refresh",
+  tags: ["Auth"],
+  summary: "Refresh access token",
+  security: [{ bearerAuth: [] }],
+  responses: {
+    200: {
+      description: "Token refreshed successfully",
+      content: {
+        "application/json": {
+          schema: AuthResponseSchema,
+        },
+      },
+    },
+    401: {
+      description: "Invalid or expired token",
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+    },
+  },
+});
+
+authRoutes.openapi(refreshRoute, async (c) => {
+  // For now, just require a valid auth header to refresh
+  // In production, you'd use refresh tokens stored in KV
+  const authHeader = c.req.header("Authorization");
+  if (!authHeader?.startsWith("Bearer ")) {
+    throw new HTTPException(401, { message: "Authorization required" });
+  }
+
+  const token = authHeader.substring(7);
+  const { verifyJwt } = await import("../lib/jwt");
+
+  try {
+    const payload = await verifyJwt(token, c.env.JWT_SECRET);
+
+    // Generate new token
+    const accessToken = await createJwt(
+      { sub: payload.sub, email: payload.email, role: payload.role },
+      c.env.JWT_SECRET,
+      c.env.JWT_EXPIRES_IN
+    );
+
+    const expiresAt = new Date(
+      Date.now() + parseExpirationMs(c.env.JWT_EXPIRES_IN)
+    ).toISOString();
+
+    return c.json({
+      user: {
+        id: payload.sub,
+        email: payload.email,
+        name: "", // Would fetch from DB in production
+        role: payload.role,
+      },
+      accessToken,
+      expiresAt,
+    });
+  } catch {
+    throw new HTTPException(401, { message: "Invalid or expired token" });
+  }
+});
+
+function parseExpirationMs(exp: string): number {
+  const match = exp.match(/^(\d+)([smhd])$/);
+  if (!match) return 7 * 24 * 60 * 60 * 1000; // Default 7 days
+
+  const value = parseInt(match[1], 10);
+  const unit = match[2];
+
+  switch (unit) {
+    case "s":
+      return value * 1000;
+    case "m":
+      return value * 60 * 1000;
+    case "h":
+      return value * 60 * 60 * 1000;
+    case "d":
+      return value * 24 * 60 * 60 * 1000;
+    default:
+      return 7 * 24 * 60 * 60 * 1000;
+  }
+}

--- a/quickstarts/api/src/routes/health.ts
+++ b/quickstarts/api/src/routes/health.ts
@@ -1,0 +1,59 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import type { Env } from "../types";
+
+export const healthRoutes = new OpenAPIHono<{ Bindings: Env }>();
+
+const healthRoute = createRoute({
+  method: "get",
+  path: "/health",
+  tags: ["Health"],
+  summary: "Health check endpoint",
+  responses: {
+    200: {
+      description: "Service is healthy",
+      content: {
+        "application/json": {
+          schema: z.object({
+            status: z.string(),
+            app: z.string(),
+            timestamp: z.string(),
+            database: z.string(),
+          }),
+        },
+      },
+    },
+    503: {
+      description: "Service is unhealthy",
+      content: {
+        "application/json": {
+          schema: z.object({
+            status: z.string(),
+            error: z.string(),
+          }),
+        },
+      },
+    },
+  },
+});
+
+healthRoutes.openapi(healthRoute, async (c) => {
+  try {
+    // Quick database health check
+    await c.env.DB.prepare("SELECT 1").first();
+
+    return c.json({
+      status: "healthy",
+      app: c.env.APP_NAME,
+      timestamp: new Date().toISOString(),
+      database: "connected",
+    });
+  } catch {
+    return c.json(
+      {
+        status: "unhealthy",
+        error: "Database unavailable",
+      },
+      503
+    );
+  }
+});

--- a/quickstarts/api/src/routes/users.ts
+++ b/quickstarts/api/src/routes/users.ts
@@ -1,0 +1,267 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { HTTPException } from "hono/http-exception";
+import type { Env, User } from "../types";
+import { requireAuth, requireRole } from "../middleware/auth";
+import {
+  UserSchema,
+  UserListSchema,
+  UpdateUserSchema,
+  UserParamsSchema,
+} from "../schemas/user";
+import { ErrorSchema } from "../schemas/auth";
+
+export const userRoutes = new OpenAPIHono<{ Bindings: Env }>();
+
+// Apply auth middleware to all routes
+userRoutes.use("*", requireAuth);
+
+// GET /users - List all users (admin only)
+const listUsersRoute = createRoute({
+  method: "get",
+  path: "/",
+  tags: ["Users"],
+  summary: "List all users",
+  security: [{ bearerAuth: [] }],
+  request: {
+    query: z.object({
+      limit: z.string().optional().default("50"),
+      offset: z.string().optional().default("0"),
+    }),
+  },
+  responses: {
+    200: {
+      description: "List of users",
+      content: {
+        "application/json": {
+          schema: UserListSchema,
+        },
+      },
+    },
+    403: {
+      description: "Forbidden - Admin only",
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+    },
+  },
+});
+
+userRoutes.openapi(listUsersRoute, requireRole("admin"), async (c) => {
+  const { limit, offset } = c.req.valid("query");
+
+  const [countResult, usersResult] = await Promise.all([
+    c.env.DB.prepare("SELECT COUNT(*) as count FROM users").first<{
+      count: number;
+    }>(),
+    c.env.DB.prepare(
+      "SELECT id, email, name, role, created_at, updated_at FROM users ORDER BY created_at DESC LIMIT ? OFFSET ?"
+    )
+      .bind(parseInt(limit), parseInt(offset))
+      .all<User>(),
+  ]);
+
+  return c.json({
+    users: usersResult.results,
+    total: countResult?.count || 0,
+  });
+});
+
+// GET /users/:id - Get user by ID
+const getUserRoute = createRoute({
+  method: "get",
+  path: "/{id}",
+  tags: ["Users"],
+  summary: "Get user by ID",
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: UserParamsSchema,
+  },
+  responses: {
+    200: {
+      description: "User details",
+      content: {
+        "application/json": {
+          schema: z.object({ user: UserSchema }),
+        },
+      },
+    },
+    404: {
+      description: "User not found",
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+    },
+  },
+});
+
+userRoutes.openapi(getUserRoute, async (c) => {
+  const { id } = c.req.valid("param");
+  const currentUser = c.get("user");
+
+  // Users can only view their own profile unless admin
+  if (currentUser.sub !== id && currentUser.role !== "admin") {
+    throw new HTTPException(403, { message: "Cannot view other users" });
+  }
+
+  const user = await c.env.DB.prepare(
+    "SELECT id, email, name, role, created_at, updated_at FROM users WHERE id = ?"
+  )
+    .bind(id)
+    .first<User>();
+
+  if (!user) {
+    throw new HTTPException(404, { message: "User not found" });
+  }
+
+  return c.json({ user });
+});
+
+// PUT /users/:id - Update user
+const updateUserRoute = createRoute({
+  method: "put",
+  path: "/{id}",
+  tags: ["Users"],
+  summary: "Update user",
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: UserParamsSchema,
+    body: {
+      content: {
+        "application/json": {
+          schema: UpdateUserSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "User updated",
+      content: {
+        "application/json": {
+          schema: z.object({ user: UserSchema }),
+        },
+      },
+    },
+    403: {
+      description: "Forbidden",
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+    },
+    404: {
+      description: "User not found",
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+    },
+  },
+});
+
+userRoutes.openapi(updateUserRoute, async (c) => {
+  const { id } = c.req.valid("param");
+  const updates = c.req.valid("json");
+  const currentUser = c.get("user");
+
+  // Users can only update their own profile unless admin
+  if (currentUser.sub !== id && currentUser.role !== "admin") {
+    throw new HTTPException(403, { message: "Cannot update other users" });
+  }
+
+  // Build dynamic update query
+  const fields: string[] = [];
+  const values: (string | undefined)[] = [];
+
+  if (updates.name !== undefined) {
+    fields.push("name = ?");
+    values.push(updates.name);
+  }
+  if (updates.email !== undefined) {
+    fields.push("email = ?");
+    values.push(updates.email);
+  }
+
+  if (fields.length === 0) {
+    throw new HTTPException(400, { message: "No fields to update" });
+  }
+
+  fields.push("updated_at = datetime('now')");
+  values.push(id);
+
+  await c.env.DB.prepare(
+    `UPDATE users SET ${fields.join(", ")} WHERE id = ?`
+  )
+    .bind(...values)
+    .run();
+
+  const user = await c.env.DB.prepare(
+    "SELECT id, email, name, role, created_at, updated_at FROM users WHERE id = ?"
+  )
+    .bind(id)
+    .first<User>();
+
+  if (!user) {
+    throw new HTTPException(404, { message: "User not found" });
+  }
+
+  return c.json({ user });
+});
+
+// DELETE /users/:id - Delete user (admin only)
+const deleteUserRoute = createRoute({
+  method: "delete",
+  path: "/{id}",
+  tags: ["Users"],
+  summary: "Delete user",
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: UserParamsSchema,
+  },
+  responses: {
+    200: {
+      description: "User deleted",
+      content: {
+        "application/json": {
+          schema: z.object({ success: z.boolean() }),
+        },
+      },
+    },
+    403: {
+      description: "Forbidden - Admin only",
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+    },
+    404: {
+      description: "User not found",
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+    },
+  },
+});
+
+userRoutes.openapi(deleteUserRoute, requireRole("admin"), async (c) => {
+  const { id } = c.req.valid("param");
+
+  const result = await c.env.DB.prepare("DELETE FROM users WHERE id = ?")
+    .bind(id)
+    .run();
+
+  if (result.meta.changes === 0) {
+    throw new HTTPException(404, { message: "User not found" });
+  }
+
+  return c.json({ success: true });
+});

--- a/quickstarts/api/src/schemas/auth.ts
+++ b/quickstarts/api/src/schemas/auth.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+export const LoginSchema = z.object({
+  email: z.string().email("Invalid email address"),
+  password: z.string().min(1, "Password is required"),
+});
+
+export const RegisterSchema = z.object({
+  email: z.string().email("Invalid email address"),
+  password: z.string().min(8, "Password must be at least 8 characters"),
+  name: z.string().min(1, "Name is required").max(100),
+});
+
+export const RefreshTokenSchema = z.object({
+  refreshToken: z.string().min(1, "Refresh token is required"),
+});
+
+export const AuthResponseSchema = z.object({
+  user: z.object({
+    id: z.string(),
+    email: z.string(),
+    name: z.string(),
+    role: z.string(),
+  }),
+  accessToken: z.string(),
+  refreshToken: z.string().optional(),
+  expiresAt: z.string(),
+});
+
+export const ErrorSchema = z.object({
+  error: z.string(),
+  message: z.string(),
+  details: z.unknown().optional(),
+});
+
+export type LoginInput = z.infer<typeof LoginSchema>;
+export type RegisterInput = z.infer<typeof RegisterSchema>;
+export type AuthResponse = z.infer<typeof AuthResponseSchema>;

--- a/quickstarts/api/src/schemas/user.ts
+++ b/quickstarts/api/src/schemas/user.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+export const UserSchema = z.object({
+  id: z.string(),
+  email: z.string().email(),
+  name: z.string(),
+  role: z.enum(["user", "admin"]),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+
+export const UserListSchema = z.object({
+  users: z.array(UserSchema),
+  total: z.number(),
+});
+
+export const UpdateUserSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  email: z.string().email().optional(),
+});
+
+export const UserParamsSchema = z.object({
+  id: z.string().uuid("Invalid user ID"),
+});
+
+export type User = z.infer<typeof UserSchema>;
+export type UserList = z.infer<typeof UserListSchema>;
+export type UpdateUserInput = z.infer<typeof UpdateUserSchema>;

--- a/quickstarts/api/src/types.ts
+++ b/quickstarts/api/src/types.ts
@@ -1,0 +1,30 @@
+export interface Env {
+  DB: D1Database;
+  KV: KVNamespace;
+  APP_NAME: string;
+  JWT_SECRET: string;
+  JWT_EXPIRES_IN: string;
+}
+
+export interface User {
+  id: string;
+  email: string;
+  name: string;
+  role: "user" | "admin";
+  created_at: string;
+  updated_at: string;
+}
+
+export interface JwtPayload {
+  sub: string; // user id
+  email: string;
+  role: string;
+  iat: number;
+  exp: number;
+}
+
+export interface Session {
+  userId: string;
+  createdAt: number;
+  expiresAt: number;
+}

--- a/quickstarts/api/tsconfig.json
+++ b/quickstarts/api/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types/2023-07-01"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "allowSyntheticDefaultImports": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*", "worker-configuration.d.ts"],
+  "exclude": ["node_modules"]
+}

--- a/quickstarts/api/wrangler.toml
+++ b/quickstarts/api/wrangler.toml
@@ -1,0 +1,28 @@
+#:schema node_modules/wrangler/config-schema.json
+name = "loom-quickstart-api"
+main = "src/index.ts"
+compatibility_date = "2024-12-01"
+
+# D1 Database binding
+[[d1_databases]]
+binding = "DB"
+database_name = "loom-api-db"
+database_id = "YOUR_DATABASE_ID"  # Update after running: wrangler d1 create loom-api-db
+
+# KV Namespace for sessions/cache
+[[kv_namespaces]]
+binding = "KV"
+id = "YOUR_KV_ID"  # Update after running: wrangler kv:namespace create "sessions"
+
+# Environment variables (set via wrangler secret or dashboard)
+[vars]
+APP_NAME = "Loom API"
+JWT_EXPIRES_IN = "7d"
+
+# Development overrides
+[env.dev.vars]
+APP_NAME = "Loom API (Dev)"
+
+# Uncomment for production settings
+# [env.production]
+# routes = [{ pattern = "api.example.com", zone_name = "example.com" }]


### PR DESCRIPTION
## Summary

Add a complete API backend template to the quickstart system, complementing the webapp template.

### Features
- **Framework**: Hono with zod-openapi for typed routes
- **Auth**: JWT authentication with PBKDF2 password hashing
- **RBAC**: Role-based access control middleware
- **Rate Limiting**: Via Cloudflare KV with sliding window
- **Documentation**: OpenAPI spec + Swagger UI at /docs
- **Database**: D1 SQLite with migrations
- **Security**: CORS, secure headers, constant-time comparison

### API Endpoints
```
GET    /health           # Health check
GET    /docs             # Swagger UI
POST   /api/auth/register
POST   /api/auth/login
POST   /api/auth/refresh
GET    /api/users        # Admin only
GET    /api/users/:id    # Owner/Admin
PUT    /api/users/:id    # Owner/Admin
DELETE /api/users/:id    # Admin only
```

### Template Structure
```
quickstarts/api/
├── .loom/roles/          # API-specific builder/judge roles
├── src/routes/           # Hono route handlers
├── src/middleware/       # Auth, rate limiting, error handling
├── src/schemas/          # Zod validation schemas
├── src/lib/              # JWT and password utilities
├── migrations/           # D1 schema migrations
└── README.md             # Setup and usage guide
```

## Test plan

- [ ] Copy template and run `pnpm install`
- [ ] Set up wrangler.toml with D1 and KV IDs
- [ ] Run `pnpm dev` and verify Swagger UI at /docs
- [ ] Test auth flow: register → login → use JWT
- [ ] Test RBAC: regular user vs admin access
- [ ] Verify rate limiting returns 429 on abuse
- [ ] Run `pnpm lint` passes

Closes #919

🤖 Generated with [Claude Code](https://claude.com/claude-code)