### PR TITLE
Handle worktree merge gracefully in Loom orchestrator

### DIFF
--- a/.loom/roles/loom.md
+++ b/.loom/roles/loom.md
@@ -669,20 +669,40 @@ if [ "$PHASE" = "gate2" ]; then
   if [ "$FORCE_MERGE" = "true" ]; then
     echo "Force-merge mode: auto-merging PR"
 
-    # Check for merge conflicts and attempt resolution
-    if ! gh pr merge $PR_NUMBER --squash --delete-branch 2>/dev/null; then
-      echo "Merge failed, attempting conflict resolution..."
-      git fetch origin main
-      git checkout $BRANCH_NAME
-      git merge origin/main --no-edit || {
-        # Auto-resolve conflicts if possible
-        git checkout --theirs .
-        git add -A
-        git commit -m "Resolve merge conflicts (auto-resolved)"
-      }
-      git push origin $BRANCH_NAME
-      gh pr merge $PR_NUMBER --squash --delete-branch
-    fi
+    # Attempt merge - may fail locally when running from worktree (main already checked out)
+    # The gh CLI succeeds on GitHub but fails on local checkout, so we verify actual state
+    MERGE_OUTPUT=$(gh pr merge $PR_NUMBER --squash --delete-branch 2>&1) || {
+      MERGE_EXIT=$?
+
+      # Check if merge actually succeeded on GitHub despite local error
+      PR_STATE=$(gh pr view $PR_NUMBER --json state,mergedAt --jq '.state')
+      if [ "$PR_STATE" = "MERGED" ]; then
+        echo "✓ PR merged successfully (local checkout skipped - worktree conflict)"
+      else
+        # Genuine merge failure - attempt conflict resolution
+        echo "Merge failed, attempting conflict resolution..."
+        git fetch origin main
+        git checkout $BRANCH_NAME
+        git merge origin/main --no-edit || {
+          # Auto-resolve conflicts if possible
+          git checkout --theirs .
+          git add -A
+          git commit -m "Resolve merge conflicts (auto-resolved)"
+        }
+        git push origin $BRANCH_NAME
+
+        # Retry merge with verification
+        gh pr merge $PR_NUMBER --squash --delete-branch 2>&1 || {
+          # Verify again in case it succeeded despite error
+          PR_STATE=$(gh pr view $PR_NUMBER --json state --jq '.state')
+          if [ "$PR_STATE" != "MERGED" ]; then
+            echo "✗ Merge failed after conflict resolution"
+            exit 1
+          fi
+          echo "✓ PR merged successfully after conflict resolution"
+        }
+      fi
+    }
 
     gh issue comment $ISSUE_NUMBER --body "🚀 **Auto-merged** PR #$PR_NUMBER via \`/loom --force-merge\`"
   else


### PR DESCRIPTION
## Summary

When running `/loom --force-merge` from an issue worktree, the `gh pr merge` command would fail locally with:

```
fatal: 'main' is already used by worktree at '/Users/rwalters/GitHub/loom'
```

The PR merge actually succeeds on GitHub, but the CLI fails when trying to checkout main locally (which is already checked out in the parent workspace).

## Changes

Implements a verify-on-error pattern in both `.loom/roles/loom.md` and `defaults/roles/loom.md`:

1. Attempt merge with `gh pr merge`
2. If command fails, check actual PR state on GitHub via `gh pr view`
3. If PR is `MERGED` despite local error, report success with clean message
4. Only attempt conflict resolution if merge genuinely failed

## Test Plan

- Run `/loom <issue> --force-merge` from an issue worktree
- Verify merge completes successfully without false failure messages
- Verify genuine merge failures still trigger conflict resolution

Closes #999