### PR TITLE
Rename loom.md to shepherd.md

### DIFF
--- a/.loom/roles/shepherd.md
+++ b/.loom/roles/shepherd.md
@@ -1,6 +1,6 @@
-# Loom Orchestrator
+# Shepherd
 
-You are the Loom meta-agent working in the {{workspace}} repository. You orchestrate other role terminals to shepherd issues from creation through to merged PR.
+You are the Shepherd working in the {{workspace}} repository. You orchestrate other role terminals to shepherd issues from creation through to merged PR.
 
 ## Your Role
 
@@ -1027,7 +1027,7 @@ Only report an error if Direct Mode itself fails.
 When orchestration completes or pauses, provide a summary:
 
 ```
-✓ Role Assumed: Loom Orchestrator
+✓ Role Assumed: Shepherd
 ✓ Issue: #<number> - <title>
 ✓ Phases Completed:
   - Curator: ✅ (loom:curated)
@@ -1044,13 +1044,13 @@ When orchestration completes or pauses, provide a summary:
 When you receive a probe command, respond with:
 
 ```
-AGENT:Loom:orchestrating-issue-<number>
+AGENT:Shepherd:orchestrating-issue-<number>
 ```
 
 Or if idle:
 
 ```
-AGENT:Loom:idle-awaiting-orchestration-request
+AGENT:Shepherd:idle-awaiting-orchestration-request
 ```
 
 ## Context Clearing

--- a/defaults/roles/shepherd.md
+++ b/defaults/roles/shepherd.md
@@ -1,6 +1,6 @@
-# Loom Orchestrator
+# Shepherd
 
-You are the Loom meta-agent working in the {{workspace}} repository. You orchestrate other role terminals to shepherd issues from creation through to merged PR.
+You are the Shepherd working in the {{workspace}} repository. You orchestrate other role terminals to shepherd issues from creation through to merged PR.
 
 ## Your Role
 
@@ -615,7 +615,7 @@ gh issue comment $ISSUE_NUMBER --body "⚠️ **Orchestration paused**: Cannot c
 When orchestration completes or pauses, provide a summary:
 
 ```
-✓ Role Assumed: Loom Orchestrator
+✓ Role Assumed: Shepherd
 ✓ Issue: #<number> - <title>
 ✓ Phases Completed:
   - Curator: ✅ (loom:curated)
@@ -632,13 +632,13 @@ When orchestration completes or pauses, provide a summary:
 When you receive a probe command, respond with:
 
 ```
-AGENT:Loom:orchestrating-issue-<number>
+AGENT:Shepherd:orchestrating-issue-<number>
 ```
 
 Or if idle:
 
 ```
-AGENT:Loom:idle-awaiting-orchestration-request
+AGENT:Shepherd:idle-awaiting-orchestration-request
 ```
 
 ## Context Clearing


### PR DESCRIPTION
## Summary

Rename the orchestrator role file from `loom.md` to `shepherd.md` and update all internal references. This is part of the larger effort to separate the Loom platform name from the Shepherd orchestrator role.

## Changes

### Files Renamed
- `.loom/roles/loom.md` → `.loom/roles/shepherd.md`
- `defaults/roles/loom.md` → `defaults/roles/shepherd.md`

### Content Updates
| Location | Old Value | New Value |
|----------|-----------|-----------|
| Title | `# Loom Orchestrator` | `# Shepherd` |
| Description | `Loom meta-agent` | `Shepherd` |
| Report format | `Role Assumed: Loom Orchestrator` | `Role Assumed: Shepherd` |
| Probe response (active) | `AGENT:Loom:orchestrating-issue-<n>` | `AGENT:Shepherd:orchestrating-issue-<n>` |
| Probe response (idle) | `AGENT:Loom:idle-awaiting-orchestration-request` | `AGENT:Shepherd:idle-awaiting-orchestration-request` |

### No Functional Changes
- All MCP calls remain the same
- All state tracking remains the same
- All --force-pr and --force-merge modes remain the same
- This is purely a terminology/naming change

## Test Plan

- [x] File successfully renamed in both locations
- [x] No remaining "Loom Orchestrator" or "Loom meta-agent" references
- [x] Probe responses updated
- [x] Report format updated

## Related

Part of epic #989 (Rename /loom to /shepherd and Create Layer 2 /loom)

Closes #990