### PR TITLE
Add cleanup mechanisms for task artifacts and worktrees

### DIFF
--- a/defaults/scripts/archive-logs.sh
+++ b/defaults/scripts/archive-logs.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# Archive task outputs and daemon logs with retention policy
+# Usage: ./scripts/archive-logs.sh [--dry-run] [--prune-only] [--retention-days N]
+#
+# Archives task output files to .loom/logs/{date}/ before deletion.
+# Prunes archives older than retention period (default: 7 days).
+
+set -euo pipefail
+
+# ANSI color codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+error() { echo -e "${RED}Error: $*${NC}" >&2; exit 1; }
+info() { echo -e "${BLUE}$*${NC}"; }
+success() { echo -e "${GREEN}$*${NC}"; }
+warning() { echo -e "${YELLOW}$*${NC}"; }
+header() { echo -e "${CYAN}$*${NC}"; }
+
+# Configuration
+RETENTION_DAYS=7
+DRY_RUN=false
+PRUNE_ONLY=false
+
+# Detect repository root
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || error "Not in a git repository"
+
+# Archive directory
+ARCHIVE_DIR="$REPO_ROOT/.loom/logs"
+
+# Task output locations (Claude Code uses these)
+TASK_OUTPUT_DIR="/tmp/claude"
+ALTERNATIVE_TASK_DIR="/private/tmp/claude"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --prune-only)
+      PRUNE_ONLY=true
+      shift
+      ;;
+    --retention-days)
+      RETENTION_DAYS="$2"
+      shift 2
+      ;;
+    --help|-h)
+      cat <<EOF
+Archive task outputs and daemon logs with retention policy
+
+Usage: ./scripts/archive-logs.sh [options]
+
+Options:
+  --dry-run           Show what would be archived/pruned without making changes
+  --prune-only        Only prune old archives, don't archive new files
+  --retention-days N  Days to retain archives (default: 7)
+  -h, --help          Show this help message
+
+Archive Structure:
+  .loom/logs/
+  +-- 2026-01-23/
+  |   +-- issue-123-shepherd.log
+  |   +-- issue-124-builder.log
+  |   +-- daemon-2026-01-23T10-00-00Z.log
+  +-- 2026-01-22/
+      +-- ...
+
+What Gets Archived:
+  - Task output files from /tmp/claude/.../tasks/*.output
+  - Daemon state snapshots (on shutdown)
+
+What Gets Pruned:
+  - Archive directories older than retention period
+EOF
+      exit 0
+      ;;
+    *)
+      error "Unknown option: $1\nUse --help for usage information"
+      ;;
+  esac
+done
+
+# Functions
+archive_task_outputs() {
+  header "Archiving Task Outputs"
+  echo ""
+
+  local today=$(date +%Y-%m-%d)
+  local archive_subdir="$ARCHIVE_DIR/$today"
+  local archived=0
+  local skipped=0
+
+  # Find task output directories
+  for base_dir in "$TASK_OUTPUT_DIR" "$ALTERNATIVE_TASK_DIR"; do
+    if [[ ! -d "$base_dir" ]]; then
+      continue
+    fi
+
+    # Look for workspace-specific task directories
+    # Pattern: /tmp/claude/-Users-name-GitHub-repo/tasks/*.output
+    find "$base_dir" -type d -name "tasks" 2>/dev/null | while read -r task_dir; do
+      # Find output files - use nullglob to handle no matches
+      shopt -s nullglob
+      for output_file in "$task_dir"/*.output; do
+        if [[ ! -f "$output_file" ]]; then
+          continue
+        fi
+
+        local filename=$(basename "$output_file")
+        local task_id="${filename%.output}"
+
+        # Try to extract issue number from file content or filename
+        local issue_num=""
+        if [[ -f "$output_file" ]]; then
+          # Look for issue number patterns in the output
+          issue_num=$(grep -oE 'issue[- ]?#?([0-9]+)' "$output_file" 2>/dev/null | head -1 | grep -oE '[0-9]+' || true)
+        fi
+
+        # Create archive filename
+        local archive_name
+        if [[ -n "$issue_num" ]]; then
+          archive_name="issue-${issue_num}-${task_id}.log"
+        else
+          archive_name="task-${task_id}.log"
+        fi
+
+        if [[ "$DRY_RUN" == true ]]; then
+          info "Would archive: $output_file -> $archive_subdir/$archive_name"
+          ((archived++)) || true
+        else
+          # Create archive directory
+          mkdir -p "$archive_subdir"
+
+          # Copy with metadata preservation
+          cp -p "$output_file" "$archive_subdir/$archive_name"
+
+          # Remove original
+          rm "$output_file"
+
+          success "Archived: $archive_name"
+          ((archived++)) || true
+        fi
+      done
+    done
+  done
+
+  if [[ $archived -eq 0 ]]; then
+    info "No task outputs found to archive"
+  else
+    if [[ "$DRY_RUN" == true ]]; then
+      info "Would archive $archived file(s)"
+    else
+      success "Archived $archived file(s) to $archive_subdir"
+    fi
+  fi
+
+  echo ""
+}
+
+prune_old_archives() {
+  header "Pruning Old Archives"
+  echo ""
+
+  if [[ ! -d "$ARCHIVE_DIR" ]]; then
+    info "No archive directory found"
+    echo ""
+    return
+  fi
+
+  local cutoff_date=$(date -v-${RETENTION_DAYS}d +%Y-%m-%d 2>/dev/null || date -d "-${RETENTION_DAYS} days" +%Y-%m-%d)
+  local pruned=0
+
+  # Find directories matching date pattern
+  for date_dir in "$ARCHIVE_DIR"/????-??-??; do
+    if [[ ! -d "$date_dir" ]]; then
+      continue
+    fi
+
+    local dir_date=$(basename "$date_dir")
+
+    # Compare dates (lexicographic comparison works for YYYY-MM-DD format)
+    if [[ "$dir_date" < "$cutoff_date" ]]; then
+      if [[ "$DRY_RUN" == true ]]; then
+        info "Would prune: $date_dir"
+        ((pruned++)) || true
+      else
+        rm -rf "$date_dir"
+        success "Pruned: $date_dir"
+        ((pruned++)) || true
+      fi
+    fi
+  done
+
+  if [[ $pruned -eq 0 ]]; then
+    info "No archives older than $RETENTION_DAYS days"
+  else
+    if [[ "$DRY_RUN" == true ]]; then
+      info "Would prune $pruned archive(s)"
+    else
+      success "Pruned $pruned archive(s)"
+    fi
+  fi
+
+  echo ""
+}
+
+archive_daemon_state() {
+  header "Archiving Daemon State"
+  echo ""
+
+  local daemon_state="$REPO_ROOT/.loom/daemon-state.json"
+
+  if [[ ! -f "$daemon_state" ]]; then
+    info "No daemon state file found"
+    echo ""
+    return
+  fi
+
+  # Check if daemon is stopped (we only archive stopped daemon states)
+  local running=$(jq -r '.running // true' "$daemon_state" 2>/dev/null || echo "true")
+
+  if [[ "$running" == "true" ]]; then
+    info "Daemon is running, skipping state archive"
+    echo ""
+    return
+  fi
+
+  local today=$(date +%Y-%m-%d)
+  local timestamp=$(date +%Y-%m-%dT%H-%M-%SZ)
+  local archive_subdir="$ARCHIVE_DIR/$today"
+  local archive_name="daemon-state-${timestamp}.json"
+
+  if [[ "$DRY_RUN" == true ]]; then
+    info "Would archive: $daemon_state -> $archive_subdir/$archive_name"
+  else
+    mkdir -p "$archive_subdir"
+    cp -p "$daemon_state" "$archive_subdir/$archive_name"
+    success "Archived daemon state: $archive_name"
+  fi
+
+  echo ""
+}
+
+show_archive_stats() {
+  header "Archive Statistics"
+  echo ""
+
+  if [[ ! -d "$ARCHIVE_DIR" ]]; then
+    info "No archives found"
+    return
+  fi
+
+  local total_size=$(du -sh "$ARCHIVE_DIR" 2>/dev/null | cut -f1 || echo "0")
+  local dir_count=$(find "$ARCHIVE_DIR" -maxdepth 1 -type d -name "????-??-??" 2>/dev/null | wc -l | tr -d ' ')
+  local file_count=$(find "$ARCHIVE_DIR" -type f 2>/dev/null | wc -l | tr -d ' ')
+
+  echo "  Archive location: $ARCHIVE_DIR"
+  echo "  Total size: $total_size"
+  echo "  Date directories: $dir_count"
+  echo "  Total files: $file_count"
+  echo "  Retention policy: $RETENTION_DAYS days"
+  echo ""
+}
+
+# Main
+header "================================="
+header "  Loom Log Archiver"
+if [[ "$DRY_RUN" == true ]]; then
+  header "  (DRY RUN MODE)"
+fi
+header "================================="
+echo ""
+
+if [[ "$PRUNE_ONLY" == true ]]; then
+  prune_old_archives
+else
+  archive_task_outputs
+  archive_daemon_state
+  prune_old_archives
+fi
+
+show_archive_stats
+
+if [[ "$DRY_RUN" == true ]]; then
+  warning "Dry run complete - no changes made"
+  info "Run without --dry-run to archive and prune"
+else
+  success "Archive complete!"
+fi

--- a/defaults/scripts/daemon-cleanup.sh
+++ b/defaults/scripts/daemon-cleanup.sh
@@ -1,0 +1,378 @@
+#!/usr/bin/env bash
+# Daemon cleanup integration - event-driven cleanup for the Loom daemon
+# Usage: ./scripts/daemon-cleanup.sh <event> [options]
+#
+# Events:
+#   shepherd-complete <issue-number> - Cleanup after shepherd finishes an issue
+#   daemon-startup                   - Cleanup stale artifacts from previous session
+#   daemon-shutdown                  - Archive logs and cleanup before exit
+#   periodic                         - Conservative periodic cleanup
+
+set -euo pipefail
+
+# ANSI color codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+error() { echo -e "${RED}Error: $*${NC}" >&2; exit 1; }
+info() { echo -e "${BLUE}$*${NC}"; }
+success() { echo -e "${GREEN}$*${NC}"; }
+warning() { echo -e "${YELLOW}$*${NC}"; }
+header() { echo -e "${CYAN}$*${NC}"; }
+
+# Detect repository root
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || error "Not in a git repository"
+
+# Paths
+DAEMON_STATE="$REPO_ROOT/.loom/daemon-state.json"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Configuration (can be overridden via environment or daemon-state.json)
+CLEANUP_ENABLED="${LOOM_CLEANUP_ENABLED:-true}"
+ARCHIVE_LOGS="${LOOM_ARCHIVE_LOGS:-true}"
+RETENTION_DAYS="${LOOM_RETENTION_DAYS:-7}"
+PERIODIC_INTERVAL_MINUTES="${LOOM_CLEANUP_INTERVAL:-360}"  # 6 hours
+GRACE_PERIOD="${LOOM_GRACE_PERIOD:-600}"  # 10 minutes
+
+# Check for help first
+for arg in "$@"; do
+  if [[ "$arg" == "--help" || "$arg" == "-h" ]]; then
+    cat <<EOF
+Daemon cleanup integration - event-driven cleanup for the Loom daemon
+
+Usage: ./scripts/daemon-cleanup.sh <event> [options]
+
+Events:
+  shepherd-complete <issue>   Cleanup after shepherd finishes an issue
+  daemon-startup              Cleanup stale artifacts from previous session
+  daemon-shutdown             Archive logs and cleanup before exit
+  periodic                    Conservative periodic cleanup
+
+Options:
+  --dry-run                   Show what would be cleaned
+  --issue <number>            Issue number (for shepherd-complete)
+  -h, --help                  Show this help message
+
+Environment Variables:
+  LOOM_CLEANUP_ENABLED        Enable/disable cleanup (default: true)
+  LOOM_ARCHIVE_LOGS           Archive logs before deletion (default: true)
+  LOOM_RETENTION_DAYS         Days to retain archives (default: 7)
+  LOOM_CLEANUP_INTERVAL       Minutes between periodic cleanups (default: 360)
+  LOOM_GRACE_PERIOD           Seconds after PR merge before cleanup (default: 600)
+
+Examples:
+  # After shepherd completes issue #123
+  ./scripts/daemon-cleanup.sh shepherd-complete 123
+
+  # On daemon startup
+  ./scripts/daemon-cleanup.sh daemon-startup
+
+  # Preview periodic cleanup
+  ./scripts/daemon-cleanup.sh periodic --dry-run
+EOF
+    exit 0
+  fi
+done
+
+# Parse arguments
+EVENT="${1:-}"
+shift || true
+
+DRY_RUN=false
+ISSUE_NUMBER=""
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --issue)
+      ISSUE_NUMBER="$2"
+      shift 2
+      ;;
+    [0-9]*)
+      ISSUE_NUMBER="$1"
+      shift
+      ;;
+    *)
+      error "Unknown option: $1\nUse --help for usage information"
+      ;;
+  esac
+done
+
+# Validate
+if [[ -z "$EVENT" ]]; then
+  error "Event type required. Use --help for usage information"
+fi
+
+if [[ "$CLEANUP_ENABLED" != "true" ]]; then
+  info "Cleanup disabled (LOOM_CLEANUP_ENABLED=$CLEANUP_ENABLED)"
+  exit 0
+fi
+
+# Helper: Check if any shepherds are active
+has_active_shepherds() {
+  if [[ ! -f "$DAEMON_STATE" ]]; then
+    echo "false"
+    return
+  fi
+
+  local active=$(jq '[.shepherds // {} | to_entries[] | select(.value.issue != null)] | length' "$DAEMON_STATE" 2>/dev/null || echo "0")
+
+  if [[ "$active" -gt 0 ]]; then
+    echo "true"
+  else
+    echo "false"
+  fi
+}
+
+# Helper: Check if specific issue has active shepherd
+is_issue_being_worked() {
+  local issue_num="$1"
+
+  if [[ ! -f "$DAEMON_STATE" ]]; then
+    echo "false"
+    return
+  fi
+
+  local working=$(jq --arg issue "$issue_num" '[.shepherds // {} | to_entries[] | select(.value.issue == ($issue | tonumber))] | length' "$DAEMON_STATE" 2>/dev/null || echo "0")
+
+  if [[ "$working" -gt 0 ]]; then
+    echo "true"
+  else
+    echo "false"
+  fi
+}
+
+# Helper: Update cleanup timestamp
+update_cleanup_timestamp() {
+  local event="$1"
+  local timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  if [[ ! -f "$DAEMON_STATE" ]]; then
+    return
+  fi
+
+  # Initialize cleanup section if needed
+  if ! jq -e '.cleanup' "$DAEMON_STATE" >/dev/null 2>&1; then
+    jq '.cleanup = {"lastRun": null, "lastCleaned": [], "pendingCleanup": [], "errors": []}' \
+      "$DAEMON_STATE" > "${DAEMON_STATE}.tmp" && mv "${DAEMON_STATE}.tmp" "$DAEMON_STATE"
+  fi
+
+  jq --arg ts "$timestamp" --arg event "$event" '.cleanup.lastRun = $ts | .cleanup.lastEvent = $event' \
+    "$DAEMON_STATE" > "${DAEMON_STATE}.tmp" && mv "${DAEMON_STATE}.tmp" "$DAEMON_STATE"
+}
+
+# Event: shepherd-complete
+# Triggered when a shepherd finishes working on an issue
+handle_shepherd_complete() {
+  if [[ -z "$ISSUE_NUMBER" ]]; then
+    error "Issue number required for shepherd-complete event"
+  fi
+
+  header "Shepherd Complete Cleanup: Issue #$ISSUE_NUMBER"
+  echo ""
+
+  # Check if PR is merged
+  local branch_name="feature/issue-${ISSUE_NUMBER}"
+  local pr_state=$(gh pr list --head "$branch_name" --state all --json state,mergedAt --jq '.[0] // empty' 2>/dev/null || echo "")
+
+  if [[ -z "$pr_state" ]]; then
+    info "No PR found for issue #$ISSUE_NUMBER, skipping cleanup"
+    return
+  fi
+
+  local merged_at=$(echo "$pr_state" | jq -r '.mergedAt // "null"')
+
+  if [[ "$merged_at" == "null" || -z "$merged_at" ]]; then
+    info "PR not merged yet, scheduling for later cleanup"
+    if [[ "$DRY_RUN" != true ]]; then
+      jq --arg issue "issue-$ISSUE_NUMBER" '.cleanup.pendingCleanup += [$issue] | .cleanup.pendingCleanup |= unique' \
+        "$DAEMON_STATE" > "${DAEMON_STATE}.tmp" && mv "${DAEMON_STATE}.tmp" "$DAEMON_STATE" 2>/dev/null || true
+    fi
+    return
+  fi
+
+  # Archive logs for this issue
+  if [[ "$ARCHIVE_LOGS" == "true" ]]; then
+    info "Archiving logs for issue #$ISSUE_NUMBER..."
+    if [[ "$DRY_RUN" == true ]]; then
+      "$SCRIPT_DIR/archive-logs.sh" --dry-run 2>/dev/null || true
+    else
+      "$SCRIPT_DIR/archive-logs.sh" 2>/dev/null || true
+    fi
+  fi
+
+  # Clean up worktree (with grace period)
+  local worktree_path="$REPO_ROOT/.loom/worktrees/issue-$ISSUE_NUMBER"
+
+  if [[ -d "$worktree_path" ]]; then
+    info "Cleaning worktree for issue #$ISSUE_NUMBER..."
+    if [[ "$DRY_RUN" == true ]]; then
+      "$SCRIPT_DIR/safe-worktree-cleanup.sh" --dry-run --grace-period "$GRACE_PERIOD" 2>/dev/null || true
+    else
+      "$SCRIPT_DIR/safe-worktree-cleanup.sh" --grace-period "$GRACE_PERIOD" 2>/dev/null || true
+    fi
+  fi
+
+  if [[ "$DRY_RUN" != true ]]; then
+    update_cleanup_timestamp "shepherd-complete"
+  fi
+
+  success "Shepherd complete cleanup finished for issue #$ISSUE_NUMBER"
+}
+
+# Event: daemon-startup
+# Cleanup stale artifacts from previous daemon session
+handle_daemon_startup() {
+  header "Daemon Startup Cleanup"
+  echo ""
+
+  # Archive any orphaned task outputs from previous session
+  if [[ "$ARCHIVE_LOGS" == "true" ]]; then
+    info "Archiving orphaned task outputs..."
+    if [[ "$DRY_RUN" == true ]]; then
+      "$SCRIPT_DIR/archive-logs.sh" --dry-run 2>/dev/null || warning "archive-logs.sh not found"
+    else
+      "$SCRIPT_DIR/archive-logs.sh" 2>/dev/null || warning "archive-logs.sh not found"
+    fi
+  fi
+
+  # Process any pending cleanups from previous session
+  if [[ -f "$DAEMON_STATE" ]]; then
+    local pending=$(jq -r '.cleanup.pendingCleanup // [] | .[]' "$DAEMON_STATE" 2>/dev/null || echo "")
+
+    if [[ -n "$pending" ]]; then
+      info "Processing pending cleanups from previous session..."
+      for item in $pending; do
+        issue_num=$(echo "$item" | sed 's/issue-//')
+        info "  Processing: $item"
+        if [[ "$DRY_RUN" != true ]]; then
+          # Remove from pending list
+          jq --arg item "$item" '.cleanup.pendingCleanup -= [$item]' \
+            "$DAEMON_STATE" > "${DAEMON_STATE}.tmp" && mv "${DAEMON_STATE}.tmp" "$DAEMON_STATE"
+        fi
+      done
+    fi
+  fi
+
+  # Run safe worktree cleanup
+  info "Cleaning stale worktrees..."
+  if [[ "$DRY_RUN" == true ]]; then
+    "$SCRIPT_DIR/safe-worktree-cleanup.sh" --dry-run 2>/dev/null || warning "safe-worktree-cleanup.sh not found"
+  else
+    "$SCRIPT_DIR/safe-worktree-cleanup.sh" 2>/dev/null || warning "safe-worktree-cleanup.sh not found"
+  fi
+
+  # Prune old archives
+  info "Pruning old archives..."
+  if [[ "$DRY_RUN" == true ]]; then
+    "$SCRIPT_DIR/archive-logs.sh" --prune-only --dry-run --retention-days "$RETENTION_DAYS" 2>/dev/null || true
+  else
+    "$SCRIPT_DIR/archive-logs.sh" --prune-only --retention-days "$RETENTION_DAYS" 2>/dev/null || true
+  fi
+
+  if [[ "$DRY_RUN" != true ]]; then
+    update_cleanup_timestamp "daemon-startup"
+  fi
+
+  success "Daemon startup cleanup complete"
+}
+
+# Event: daemon-shutdown
+# Archive logs and cleanup before daemon exits
+handle_daemon_shutdown() {
+  header "Daemon Shutdown Cleanup"
+  echo ""
+
+  # Archive all current task outputs
+  if [[ "$ARCHIVE_LOGS" == "true" ]]; then
+    info "Archiving task outputs..."
+    if [[ "$DRY_RUN" == true ]]; then
+      "$SCRIPT_DIR/archive-logs.sh" --dry-run 2>/dev/null || warning "archive-logs.sh not found"
+    else
+      "$SCRIPT_DIR/archive-logs.sh" 2>/dev/null || warning "archive-logs.sh not found"
+    fi
+  fi
+
+  # Note: Don't clean worktrees on shutdown - shepherds might be in progress
+  # Let daemon-startup handle that on next run
+
+  if [[ "$DRY_RUN" != true ]]; then
+    update_cleanup_timestamp "daemon-shutdown"
+  fi
+
+  success "Daemon shutdown cleanup complete"
+}
+
+# Event: periodic
+# Conservative periodic cleanup (respects active shepherds)
+handle_periodic() {
+  header "Periodic Cleanup"
+  echo ""
+
+  # Check if any shepherds are active
+  if [[ "$(has_active_shepherds)" == "true" ]]; then
+    info "Active shepherds detected - running conservative cleanup only"
+  fi
+
+  # Archive task outputs (safe even with active shepherds)
+  if [[ "$ARCHIVE_LOGS" == "true" ]]; then
+    info "Archiving task outputs..."
+    if [[ "$DRY_RUN" == true ]]; then
+      "$SCRIPT_DIR/archive-logs.sh" --dry-run 2>/dev/null || warning "archive-logs.sh not found"
+    else
+      "$SCRIPT_DIR/archive-logs.sh" 2>/dev/null || warning "archive-logs.sh not found"
+    fi
+  fi
+
+  # Only clean worktrees if no active shepherds or in force mode
+  if [[ "$(has_active_shepherds)" == "false" ]]; then
+    info "No active shepherds - running full worktree cleanup..."
+    if [[ "$DRY_RUN" == true ]]; then
+      "$SCRIPT_DIR/safe-worktree-cleanup.sh" --dry-run 2>/dev/null || warning "safe-worktree-cleanup.sh not found"
+    else
+      "$SCRIPT_DIR/safe-worktree-cleanup.sh" 2>/dev/null || warning "safe-worktree-cleanup.sh not found"
+    fi
+  else
+    info "Skipping worktree cleanup (active shepherds)"
+  fi
+
+  # Prune old archives
+  info "Pruning old archives..."
+  if [[ "$DRY_RUN" == true ]]; then
+    "$SCRIPT_DIR/archive-logs.sh" --prune-only --dry-run --retention-days "$RETENTION_DAYS" 2>/dev/null || true
+  else
+    "$SCRIPT_DIR/archive-logs.sh" --prune-only --retention-days "$RETENTION_DAYS" 2>/dev/null || true
+  fi
+
+  if [[ "$DRY_RUN" != true ]]; then
+    update_cleanup_timestamp "periodic"
+  fi
+
+  success "Periodic cleanup complete"
+}
+
+# Main dispatch
+case "$EVENT" in
+  shepherd-complete)
+    handle_shepherd_complete
+    ;;
+  daemon-startup)
+    handle_daemon_startup
+    ;;
+  daemon-shutdown)
+    handle_daemon_shutdown
+    ;;
+  periodic)
+    handle_periodic
+    ;;
+  *)
+    error "Unknown event: $EVENT\nValid events: shepherd-complete, daemon-startup, daemon-shutdown, periodic"
+    ;;
+esac

--- a/defaults/scripts/safe-worktree-cleanup.sh
+++ b/defaults/scripts/safe-worktree-cleanup.sh
@@ -1,0 +1,372 @@
+#!/usr/bin/env bash
+# Safe worktree cleanup - only removes worktrees for MERGED PRs
+# Usage: ./scripts/safe-worktree-cleanup.sh [--dry-run] [--force] [--grace-period N]
+#
+# Unlike blunt cleanup, this script:
+# - Only removes worktrees when the PR is MERGED (not just closed)
+# - Checks for uncommitted changes before removal
+# - Applies a grace period after merge to avoid race conditions
+# - Tracks cleanup state in daemon-state.json
+
+set -euo pipefail
+
+# ANSI color codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+error() { echo -e "${RED}Error: $*${NC}" >&2; exit 1; }
+info() { echo -e "${BLUE}$*${NC}"; }
+success() { echo -e "${GREEN}$*${NC}"; }
+warning() { echo -e "${YELLOW}$*${NC}"; }
+header() { echo -e "${CYAN}$*${NC}"; }
+
+# Configuration
+DRY_RUN=false
+FORCE=false
+GRACE_PERIOD=600  # 10 minutes in seconds
+
+# Detect repository root
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || error "Not in a git repository"
+
+# State file for tracking cleanup
+DAEMON_STATE="$REPO_ROOT/.loom/daemon-state.json"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --force|-f)
+      FORCE=true
+      shift
+      ;;
+    --grace-period)
+      GRACE_PERIOD="$2"
+      shift 2
+      ;;
+    --help|-h)
+      cat <<EOF
+Safe worktree cleanup - only removes worktrees for MERGED PRs
+
+Usage: ./scripts/safe-worktree-cleanup.sh [options]
+
+Options:
+  --dry-run           Show what would be cleaned without making changes
+  -f, --force         Skip grace period and uncommitted changes check
+  --grace-period N    Seconds to wait after PR merge (default: 600 = 10 min)
+  -h, --help          Show this help message
+
+Safety Features:
+  - Only cleans worktrees with MERGED PRs (not just closed)
+  - Checks for uncommitted changes before removal
+  - Grace period after merge to avoid race conditions
+  - Tracks cleanup state in daemon-state.json
+
+Cleanup Criteria:
+  A worktree is cleaned when ALL of the following are true:
+  1. The associated issue is CLOSED
+  2. The PR is MERGED (has mergedAt timestamp)
+  3. Grace period has passed since merge
+  4. No uncommitted changes exist (unless --force)
+EOF
+      exit 0
+      ;;
+    *)
+      error "Unknown option: $1\nUse --help for usage information"
+      ;;
+  esac
+done
+
+# Functions
+check_pr_merged() {
+  local issue_num="$1"
+  local branch_name="feature/issue-${issue_num}"
+
+  # Find PR by head branch
+  local pr_info=$(gh pr list --head "$branch_name" --state all --json number,state,mergedAt --jq '.[0] // empty' 2>/dev/null || echo "")
+
+  if [[ -z "$pr_info" ]]; then
+    # Try searching by issue reference
+    pr_info=$(gh pr list --search "Closes #${issue_num}" --state all --json number,state,mergedAt --jq '.[0] // empty' 2>/dev/null || echo "")
+  fi
+
+  if [[ -z "$pr_info" ]]; then
+    echo "NO_PR"
+    return
+  fi
+
+  local state=$(echo "$pr_info" | jq -r '.state // "UNKNOWN"')
+  local merged_at=$(echo "$pr_info" | jq -r '.mergedAt // "null"')
+
+  if [[ "$merged_at" != "null" && "$merged_at" != "" ]]; then
+    echo "MERGED:$merged_at"
+  elif [[ "$state" == "CLOSED" ]]; then
+    echo "CLOSED_NO_MERGE"
+  elif [[ "$state" == "OPEN" ]]; then
+    echo "OPEN"
+  else
+    echo "UNKNOWN"
+  fi
+}
+
+check_uncommitted_changes() {
+  local worktree_path="$1"
+
+  if [[ ! -d "$worktree_path" ]]; then
+    echo "false"
+    return
+  fi
+
+  # Check for any uncommitted changes (staged or unstaged)
+  if git -C "$worktree_path" diff --quiet 2>/dev/null && \
+     git -C "$worktree_path" diff --cached --quiet 2>/dev/null; then
+    echo "false"
+  else
+    echo "true"
+  fi
+}
+
+check_grace_period() {
+  local merged_at="$1"
+  local now=$(date +%s)
+
+  # Parse merged_at timestamp
+  local merged_ts
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS
+    merged_ts=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$merged_at" +%s 2>/dev/null || echo "0")
+  else
+    # Linux
+    merged_ts=$(date -d "$merged_at" +%s 2>/dev/null || echo "0")
+  fi
+
+  local elapsed=$((now - merged_ts))
+
+  if [[ $elapsed -gt $GRACE_PERIOD ]]; then
+    echo "passed:$elapsed"
+  else
+    echo "waiting:$((GRACE_PERIOD - elapsed))"
+  fi
+}
+
+cleanup_worktree() {
+  local worktree_path="$1"
+  local issue_num="$2"
+  local branch_name="feature/issue-${issue_num}"
+
+  if [[ "$DRY_RUN" == true ]]; then
+    info "Would remove: $worktree_path"
+    info "Would delete branch: $branch_name"
+    return 0
+  fi
+
+  # Remove worktree
+  if git worktree remove "$worktree_path" --force 2>/dev/null; then
+    success "Removed worktree: $worktree_path"
+  else
+    warning "Failed to remove worktree: $worktree_path"
+    return 1
+  fi
+
+  # Delete local branch (if it exists)
+  if git branch -d "$branch_name" 2>/dev/null; then
+    success "Deleted branch: $branch_name"
+  elif git branch -D "$branch_name" 2>/dev/null; then
+    success "Force-deleted branch: $branch_name"
+  else
+    info "Branch already deleted or doesn't exist: $branch_name"
+  fi
+
+  return 0
+}
+
+update_cleanup_state() {
+  local issue_num="$1"
+  local status="$2"
+
+  if [[ ! -f "$DAEMON_STATE" ]]; then
+    return
+  fi
+
+  local timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  # Initialize cleanup section if needed
+  if ! jq -e '.cleanup' "$DAEMON_STATE" >/dev/null 2>&1; then
+    jq '.cleanup = {"lastRun": null, "lastCleaned": [], "pendingCleanup": [], "errors": []}' \
+      "$DAEMON_STATE" > "${DAEMON_STATE}.tmp" && mv "${DAEMON_STATE}.tmp" "$DAEMON_STATE"
+  fi
+
+  case "$status" in
+    cleaned)
+      jq ".cleanup.lastCleaned += [\"issue-${issue_num}\"] | .cleanup.lastRun = \"$timestamp\"" \
+        "$DAEMON_STATE" > "${DAEMON_STATE}.tmp" && mv "${DAEMON_STATE}.tmp" "$DAEMON_STATE"
+      ;;
+    pending)
+      jq ".cleanup.pendingCleanup += [\"issue-${issue_num}\"] | .cleanup.pendingCleanup |= unique" \
+        "$DAEMON_STATE" > "${DAEMON_STATE}.tmp" && mv "${DAEMON_STATE}.tmp" "$DAEMON_STATE"
+      ;;
+    error)
+      jq ".cleanup.errors += [{\"issue\": $issue_num, \"timestamp\": \"$timestamp\"}]" \
+        "$DAEMON_STATE" > "${DAEMON_STATE}.tmp" && mv "${DAEMON_STATE}.tmp" "$DAEMON_STATE"
+      ;;
+  esac
+}
+
+# Main
+cd "$REPO_ROOT"
+
+header "========================================"
+header "  Safe Worktree Cleanup"
+if [[ "$DRY_RUN" == true ]]; then
+  header "  (DRY RUN MODE)"
+fi
+header "========================================"
+echo ""
+
+# Get worktree directory
+WORKTREE_DIR="$REPO_ROOT/.loom/worktrees"
+
+if [[ ! -d "$WORKTREE_DIR" ]]; then
+  info "No worktrees directory found"
+  exit 0
+fi
+
+# Counters
+cleaned=0
+skipped_open=0
+skipped_not_merged=0
+skipped_grace=0
+skipped_uncommitted=0
+errors=0
+
+# Process each worktree
+for worktree_path in "$WORKTREE_DIR"/issue-*; do
+  if [[ ! -d "$worktree_path" ]]; then
+    continue
+  fi
+
+  issue_num=$(basename "$worktree_path" | sed 's/issue-//')
+
+  if [[ ! "$issue_num" =~ ^[0-9]+$ ]]; then
+    continue
+  fi
+
+  echo "Checking worktree: issue-$issue_num"
+
+  # Check issue state
+  issue_state=$(gh issue view "$issue_num" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+
+  if [[ "$issue_state" != "CLOSED" ]]; then
+    info "  Issue #$issue_num is $issue_state - skipping"
+    ((skipped_open++)) || true
+    continue
+  fi
+
+  # Check PR merge status
+  pr_status=$(check_pr_merged "$issue_num")
+
+  case "$pr_status" in
+    MERGED:*)
+      merged_at="${pr_status#MERGED:}"
+      ;;
+    CLOSED_NO_MERGE)
+      warning "  PR closed without merge - skipping (may need investigation)"
+      ((skipped_not_merged++)) || true
+      continue
+      ;;
+    OPEN)
+      info "  PR still open - skipping"
+      ((skipped_open++)) || true
+      continue
+      ;;
+    NO_PR)
+      warning "  No PR found for issue - skipping"
+      ((skipped_not_merged++)) || true
+      continue
+      ;;
+    *)
+      warning "  Unknown PR status - skipping"
+      ((errors++)) || true
+      continue
+      ;;
+  esac
+
+  # Check grace period
+  if [[ "$FORCE" != true ]]; then
+    grace_status=$(check_grace_period "$merged_at")
+    case "$grace_status" in
+      waiting:*)
+        remaining="${grace_status#waiting:}"
+        info "  PR merged but grace period not passed (${remaining}s remaining)"
+        update_cleanup_state "$issue_num" "pending"
+        ((skipped_grace++)) || true
+        continue
+        ;;
+    esac
+  fi
+
+  # Check for uncommitted changes
+  if [[ "$FORCE" != true ]]; then
+    has_changes=$(check_uncommitted_changes "$worktree_path")
+    if [[ "$has_changes" == "true" ]]; then
+      warning "  Uncommitted changes detected - skipping"
+      warning "    To force: ./scripts/safe-worktree-cleanup.sh --force"
+      ((skipped_uncommitted++)) || true
+      continue
+    fi
+  fi
+
+  # All checks passed - cleanup
+  if cleanup_worktree "$worktree_path" "$issue_num"; then
+    if [[ "$DRY_RUN" != true ]]; then
+      update_cleanup_state "$issue_num" "cleaned"
+    fi
+    ((cleaned++)) || true
+  else
+    if [[ "$DRY_RUN" != true ]]; then
+      update_cleanup_state "$issue_num" "error"
+    fi
+    ((errors++)) || true
+  fi
+done
+
+# Prune orphaned git worktree references
+echo ""
+header "Pruning Orphaned References"
+if [[ "$DRY_RUN" == true ]]; then
+  git worktree prune --dry-run --verbose 2>&1 || true
+else
+  git worktree prune --verbose 2>&1 || true
+fi
+
+# Summary
+echo ""
+header "========================================"
+header "  Summary"
+header "========================================"
+echo ""
+
+if [[ "$DRY_RUN" == true ]]; then
+  echo "  Would clean: $cleaned worktree(s)"
+else
+  echo "  Cleaned: $cleaned worktree(s)"
+fi
+echo "  Skipped (open): $skipped_open"
+echo "  Skipped (not merged): $skipped_not_merged"
+echo "  Skipped (grace period): $skipped_grace"
+echo "  Skipped (uncommitted): $skipped_uncommitted"
+echo "  Errors: $errors"
+echo ""
+
+if [[ "$DRY_RUN" == true ]]; then
+  warning "Dry run complete - no changes made"
+  info "Run without --dry-run to perform cleanup"
+else
+  success "Cleanup complete!"
+fi

--- a/scripts/archive-logs.sh
+++ b/scripts/archive-logs.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# Archive task outputs and daemon logs with retention policy
+# Usage: ./scripts/archive-logs.sh [--dry-run] [--prune-only] [--retention-days N]
+#
+# Archives task output files to .loom/logs/{date}/ before deletion.
+# Prunes archives older than retention period (default: 7 days).
+
+set -euo pipefail
+
+# ANSI color codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+error() { echo -e "${RED}Error: $*${NC}" >&2; exit 1; }
+info() { echo -e "${BLUE}$*${NC}"; }
+success() { echo -e "${GREEN}$*${NC}"; }
+warning() { echo -e "${YELLOW}$*${NC}"; }
+header() { echo -e "${CYAN}$*${NC}"; }
+
+# Configuration
+RETENTION_DAYS=7
+DRY_RUN=false
+PRUNE_ONLY=false
+
+# Detect repository root
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || error "Not in a git repository"
+
+# Archive directory
+ARCHIVE_DIR="$REPO_ROOT/.loom/logs"
+
+# Task output locations (Claude Code uses these)
+TASK_OUTPUT_DIR="/tmp/claude"
+ALTERNATIVE_TASK_DIR="/private/tmp/claude"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --prune-only)
+      PRUNE_ONLY=true
+      shift
+      ;;
+    --retention-days)
+      RETENTION_DAYS="$2"
+      shift 2
+      ;;
+    --help|-h)
+      cat <<EOF
+Archive task outputs and daemon logs with retention policy
+
+Usage: ./scripts/archive-logs.sh [options]
+
+Options:
+  --dry-run           Show what would be archived/pruned without making changes
+  --prune-only        Only prune old archives, don't archive new files
+  --retention-days N  Days to retain archives (default: 7)
+  -h, --help          Show this help message
+
+Archive Structure:
+  .loom/logs/
+  +-- 2026-01-23/
+  |   +-- issue-123-shepherd.log
+  |   +-- issue-124-builder.log
+  |   +-- daemon-2026-01-23T10-00-00Z.log
+  +-- 2026-01-22/
+      +-- ...
+
+What Gets Archived:
+  - Task output files from /tmp/claude/.../tasks/*.output
+  - Daemon state snapshots (on shutdown)
+
+What Gets Pruned:
+  - Archive directories older than retention period
+EOF
+      exit 0
+      ;;
+    *)
+      error "Unknown option: $1\nUse --help for usage information"
+      ;;
+  esac
+done
+
+# Functions
+archive_task_outputs() {
+  header "Archiving Task Outputs"
+  echo ""
+
+  local today=$(date +%Y-%m-%d)
+  local archive_subdir="$ARCHIVE_DIR/$today"
+  local archived=0
+  local skipped=0
+
+  # Find task output directories
+  for base_dir in "$TASK_OUTPUT_DIR" "$ALTERNATIVE_TASK_DIR"; do
+    if [[ ! -d "$base_dir" ]]; then
+      continue
+    fi
+
+    # Look for workspace-specific task directories
+    # Pattern: /tmp/claude/-Users-name-GitHub-repo/tasks/*.output
+    find "$base_dir" -type d -name "tasks" 2>/dev/null | while read -r task_dir; do
+      # Find output files - use nullglob to handle no matches
+      shopt -s nullglob
+      for output_file in "$task_dir"/*.output; do
+        if [[ ! -f "$output_file" ]]; then
+          continue
+        fi
+
+        local filename=$(basename "$output_file")
+        local task_id="${filename%.output}"
+
+        # Try to extract issue number from file content or filename
+        local issue_num=""
+        if [[ -f "$output_file" ]]; then
+          # Look for issue number patterns in the output
+          issue_num=$(grep -oE 'issue[- ]?#?([0-9]+)' "$output_file" 2>/dev/null | head -1 | grep -oE '[0-9]+' || true)
+        fi
+
+        # Create archive filename
+        local archive_name
+        if [[ -n "$issue_num" ]]; then
+          archive_name="issue-${issue_num}-${task_id}.log"
+        else
+          archive_name="task-${task_id}.log"
+        fi
+
+        if [[ "$DRY_RUN" == true ]]; then
+          info "Would archive: $output_file -> $archive_subdir/$archive_name"
+          ((archived++)) || true
+        else
+          # Create archive directory
+          mkdir -p "$archive_subdir"
+
+          # Copy with metadata preservation
+          cp -p "$output_file" "$archive_subdir/$archive_name"
+
+          # Remove original
+          rm "$output_file"
+
+          success "Archived: $archive_name"
+          ((archived++)) || true
+        fi
+      done
+    done
+  done
+
+  if [[ $archived -eq 0 ]]; then
+    info "No task outputs found to archive"
+  else
+    if [[ "$DRY_RUN" == true ]]; then
+      info "Would archive $archived file(s)"
+    else
+      success "Archived $archived file(s) to $archive_subdir"
+    fi
+  fi
+
+  echo ""
+}
+
+prune_old_archives() {
+  header "Pruning Old Archives"
+  echo ""
+
+  if [[ ! -d "$ARCHIVE_DIR" ]]; then
+    info "No archive directory found"
+    echo ""
+    return
+  fi
+
+  local cutoff_date=$(date -v-${RETENTION_DAYS}d +%Y-%m-%d 2>/dev/null || date -d "-${RETENTION_DAYS} days" +%Y-%m-%d)
+  local pruned=0
+
+  # Find directories matching date pattern
+  for date_dir in "$ARCHIVE_DIR"/????-??-??; do
+    if [[ ! -d "$date_dir" ]]; then
+      continue
+    fi
+
+    local dir_date=$(basename "$date_dir")
+
+    # Compare dates (lexicographic comparison works for YYYY-MM-DD format)
+    if [[ "$dir_date" < "$cutoff_date" ]]; then
+      if [[ "$DRY_RUN" == true ]]; then
+        info "Would prune: $date_dir"
+        ((pruned++)) || true
+      else
+        rm -rf "$date_dir"
+        success "Pruned: $date_dir"
+        ((pruned++)) || true
+      fi
+    fi
+  done
+
+  if [[ $pruned -eq 0 ]]; then
+    info "No archives older than $RETENTION_DAYS days"
+  else
+    if [[ "$DRY_RUN" == true ]]; then
+      info "Would prune $pruned archive(s)"
+    else
+      success "Pruned $pruned archive(s)"
+    fi
+  fi
+
+  echo ""
+}
+
+archive_daemon_state() {
+  header "Archiving Daemon State"
+  echo ""
+
+  local daemon_state="$REPO_ROOT/.loom/daemon-state.json"
+
+  if [[ ! -f "$daemon_state" ]]; then
+    info "No daemon state file found"
+    echo ""
+    return
+  fi
+
+  # Check if daemon is stopped (we only archive stopped daemon states)
+  local running=$(jq -r '.running // true' "$daemon_state" 2>/dev/null || echo "true")
+
+  if [[ "$running" == "true" ]]; then
+    info "Daemon is running, skipping state archive"
+    echo ""
+    return
+  fi
+
+  local today=$(date +%Y-%m-%d)
+  local timestamp=$(date +%Y-%m-%dT%H-%M-%SZ)
+  local archive_subdir="$ARCHIVE_DIR/$today"
+  local archive_name="daemon-state-${timestamp}.json"
+
+  if [[ "$DRY_RUN" == true ]]; then
+    info "Would archive: $daemon_state -> $archive_subdir/$archive_name"
+  else
+    mkdir -p "$archive_subdir"
+    cp -p "$daemon_state" "$archive_subdir/$archive_name"
+    success "Archived daemon state: $archive_name"
+  fi
+
+  echo ""
+}
+
+show_archive_stats() {
+  header "Archive Statistics"
+  echo ""
+
+  if [[ ! -d "$ARCHIVE_DIR" ]]; then
+    info "No archives found"
+    return
+  fi
+
+  local total_size=$(du -sh "$ARCHIVE_DIR" 2>/dev/null | cut -f1 || echo "0")
+  local dir_count=$(find "$ARCHIVE_DIR" -maxdepth 1 -type d -name "????-??-??" 2>/dev/null | wc -l | tr -d ' ')
+  local file_count=$(find "$ARCHIVE_DIR" -type f 2>/dev/null | wc -l | tr -d ' ')
+
+  echo "  Archive location: $ARCHIVE_DIR"
+  echo "  Total size: $total_size"
+  echo "  Date directories: $dir_count"
+  echo "  Total files: $file_count"
+  echo "  Retention policy: $RETENTION_DAYS days"
+  echo ""
+}
+
+# Main
+header "================================="
+header "  Loom Log Archiver"
+if [[ "$DRY_RUN" == true ]]; then
+  header "  (DRY RUN MODE)"
+fi
+header "================================="
+echo ""
+
+if [[ "$PRUNE_ONLY" == true ]]; then
+  prune_old_archives
+else
+  archive_task_outputs
+  archive_daemon_state
+  prune_old_archives
+fi
+
+show_archive_stats
+
+if [[ "$DRY_RUN" == true ]]; then
+  warning "Dry run complete - no changes made"
+  info "Run without --dry-run to archive and prune"
+else
+  success "Archive complete!"
+fi

--- a/scripts/daemon-cleanup.sh
+++ b/scripts/daemon-cleanup.sh
@@ -1,0 +1,378 @@
+#!/usr/bin/env bash
+# Daemon cleanup integration - event-driven cleanup for the Loom daemon
+# Usage: ./scripts/daemon-cleanup.sh <event> [options]
+#
+# Events:
+#   shepherd-complete <issue-number> - Cleanup after shepherd finishes an issue
+#   daemon-startup                   - Cleanup stale artifacts from previous session
+#   daemon-shutdown                  - Archive logs and cleanup before exit
+#   periodic                         - Conservative periodic cleanup
+
+set -euo pipefail
+
+# ANSI color codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+error() { echo -e "${RED}Error: $*${NC}" >&2; exit 1; }
+info() { echo -e "${BLUE}$*${NC}"; }
+success() { echo -e "${GREEN}$*${NC}"; }
+warning() { echo -e "${YELLOW}$*${NC}"; }
+header() { echo -e "${CYAN}$*${NC}"; }
+
+# Detect repository root
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || error "Not in a git repository"
+
+# Paths
+DAEMON_STATE="$REPO_ROOT/.loom/daemon-state.json"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Configuration (can be overridden via environment or daemon-state.json)
+CLEANUP_ENABLED="${LOOM_CLEANUP_ENABLED:-true}"
+ARCHIVE_LOGS="${LOOM_ARCHIVE_LOGS:-true}"
+RETENTION_DAYS="${LOOM_RETENTION_DAYS:-7}"
+PERIODIC_INTERVAL_MINUTES="${LOOM_CLEANUP_INTERVAL:-360}"  # 6 hours
+GRACE_PERIOD="${LOOM_GRACE_PERIOD:-600}"  # 10 minutes
+
+# Check for help first
+for arg in "$@"; do
+  if [[ "$arg" == "--help" || "$arg" == "-h" ]]; then
+    cat <<EOF
+Daemon cleanup integration - event-driven cleanup for the Loom daemon
+
+Usage: ./scripts/daemon-cleanup.sh <event> [options]
+
+Events:
+  shepherd-complete <issue>   Cleanup after shepherd finishes an issue
+  daemon-startup              Cleanup stale artifacts from previous session
+  daemon-shutdown             Archive logs and cleanup before exit
+  periodic                    Conservative periodic cleanup
+
+Options:
+  --dry-run                   Show what would be cleaned
+  --issue <number>            Issue number (for shepherd-complete)
+  -h, --help                  Show this help message
+
+Environment Variables:
+  LOOM_CLEANUP_ENABLED        Enable/disable cleanup (default: true)
+  LOOM_ARCHIVE_LOGS           Archive logs before deletion (default: true)
+  LOOM_RETENTION_DAYS         Days to retain archives (default: 7)
+  LOOM_CLEANUP_INTERVAL       Minutes between periodic cleanups (default: 360)
+  LOOM_GRACE_PERIOD           Seconds after PR merge before cleanup (default: 600)
+
+Examples:
+  # After shepherd completes issue #123
+  ./scripts/daemon-cleanup.sh shepherd-complete 123
+
+  # On daemon startup
+  ./scripts/daemon-cleanup.sh daemon-startup
+
+  # Preview periodic cleanup
+  ./scripts/daemon-cleanup.sh periodic --dry-run
+EOF
+    exit 0
+  fi
+done
+
+# Parse arguments
+EVENT="${1:-}"
+shift || true
+
+DRY_RUN=false
+ISSUE_NUMBER=""
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --issue)
+      ISSUE_NUMBER="$2"
+      shift 2
+      ;;
+    [0-9]*)
+      ISSUE_NUMBER="$1"
+      shift
+      ;;
+    *)
+      error "Unknown option: $1\nUse --help for usage information"
+      ;;
+  esac
+done
+
+# Validate
+if [[ -z "$EVENT" ]]; then
+  error "Event type required. Use --help for usage information"
+fi
+
+if [[ "$CLEANUP_ENABLED" != "true" ]]; then
+  info "Cleanup disabled (LOOM_CLEANUP_ENABLED=$CLEANUP_ENABLED)"
+  exit 0
+fi
+
+# Helper: Check if any shepherds are active
+has_active_shepherds() {
+  if [[ ! -f "$DAEMON_STATE" ]]; then
+    echo "false"
+    return
+  fi
+
+  local active=$(jq '[.shepherds // {} | to_entries[] | select(.value.issue != null)] | length' "$DAEMON_STATE" 2>/dev/null || echo "0")
+
+  if [[ "$active" -gt 0 ]]; then
+    echo "true"
+  else
+    echo "false"
+  fi
+}
+
+# Helper: Check if specific issue has active shepherd
+is_issue_being_worked() {
+  local issue_num="$1"
+
+  if [[ ! -f "$DAEMON_STATE" ]]; then
+    echo "false"
+    return
+  fi
+
+  local working=$(jq --arg issue "$issue_num" '[.shepherds // {} | to_entries[] | select(.value.issue == ($issue | tonumber))] | length' "$DAEMON_STATE" 2>/dev/null || echo "0")
+
+  if [[ "$working" -gt 0 ]]; then
+    echo "true"
+  else
+    echo "false"
+  fi
+}
+
+# Helper: Update cleanup timestamp
+update_cleanup_timestamp() {
+  local event="$1"
+  local timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  if [[ ! -f "$DAEMON_STATE" ]]; then
+    return
+  fi
+
+  # Initialize cleanup section if needed
+  if ! jq -e '.cleanup' "$DAEMON_STATE" >/dev/null 2>&1; then
+    jq '.cleanup = {"lastRun": null, "lastCleaned": [], "pendingCleanup": [], "errors": []}' \
+      "$DAEMON_STATE" > "${DAEMON_STATE}.tmp" && mv "${DAEMON_STATE}.tmp" "$DAEMON_STATE"
+  fi
+
+  jq --arg ts "$timestamp" --arg event "$event" '.cleanup.lastRun = $ts | .cleanup.lastEvent = $event' \
+    "$DAEMON_STATE" > "${DAEMON_STATE}.tmp" && mv "${DAEMON_STATE}.tmp" "$DAEMON_STATE"
+}
+
+# Event: shepherd-complete
+# Triggered when a shepherd finishes working on an issue
+handle_shepherd_complete() {
+  if [[ -z "$ISSUE_NUMBER" ]]; then
+    error "Issue number required for shepherd-complete event"
+  fi
+
+  header "Shepherd Complete Cleanup: Issue #$ISSUE_NUMBER"
+  echo ""
+
+  # Check if PR is merged
+  local branch_name="feature/issue-${ISSUE_NUMBER}"
+  local pr_state=$(gh pr list --head "$branch_name" --state all --json state,mergedAt --jq '.[0] // empty' 2>/dev/null || echo "")
+
+  if [[ -z "$pr_state" ]]; then
+    info "No PR found for issue #$ISSUE_NUMBER, skipping cleanup"
+    return
+  fi
+
+  local merged_at=$(echo "$pr_state" | jq -r '.mergedAt // "null"')
+
+  if [[ "$merged_at" == "null" || -z "$merged_at" ]]; then
+    info "PR not merged yet, scheduling for later cleanup"
+    if [[ "$DRY_RUN" != true ]]; then
+      jq --arg issue "issue-$ISSUE_NUMBER" '.cleanup.pendingCleanup += [$issue] | .cleanup.pendingCleanup |= unique' \
+        "$DAEMON_STATE" > "${DAEMON_STATE}.tmp" && mv "${DAEMON_STATE}.tmp" "$DAEMON_STATE" 2>/dev/null || true
+    fi
+    return
+  fi
+
+  # Archive logs for this issue
+  if [[ "$ARCHIVE_LOGS" == "true" ]]; then
+    info "Archiving logs for issue #$ISSUE_NUMBER..."
+    if [[ "$DRY_RUN" == true ]]; then
+      "$SCRIPT_DIR/archive-logs.sh" --dry-run 2>/dev/null || true
+    else
+      "$SCRIPT_DIR/archive-logs.sh" 2>/dev/null || true
+    fi
+  fi
+
+  # Clean up worktree (with grace period)
+  local worktree_path="$REPO_ROOT/.loom/worktrees/issue-$ISSUE_NUMBER"
+
+  if [[ -d "$worktree_path" ]]; then
+    info "Cleaning worktree for issue #$ISSUE_NUMBER..."
+    if [[ "$DRY_RUN" == true ]]; then
+      "$SCRIPT_DIR/safe-worktree-cleanup.sh" --dry-run --grace-period "$GRACE_PERIOD" 2>/dev/null || true
+    else
+      "$SCRIPT_DIR/safe-worktree-cleanup.sh" --grace-period "$GRACE_PERIOD" 2>/dev/null || true
+    fi
+  fi
+
+  if [[ "$DRY_RUN" != true ]]; then
+    update_cleanup_timestamp "shepherd-complete"
+  fi
+
+  success "Shepherd complete cleanup finished for issue #$ISSUE_NUMBER"
+}
+
+# Event: daemon-startup
+# Cleanup stale artifacts from previous daemon session
+handle_daemon_startup() {
+  header "Daemon Startup Cleanup"
+  echo ""
+
+  # Archive any orphaned task outputs from previous session
+  if [[ "$ARCHIVE_LOGS" == "true" ]]; then
+    info "Archiving orphaned task outputs..."
+    if [[ "$DRY_RUN" == true ]]; then
+      "$SCRIPT_DIR/archive-logs.sh" --dry-run 2>/dev/null || warning "archive-logs.sh not found"
+    else
+      "$SCRIPT_DIR/archive-logs.sh" 2>/dev/null || warning "archive-logs.sh not found"
+    fi
+  fi
+
+  # Process any pending cleanups from previous session
+  if [[ -f "$DAEMON_STATE" ]]; then
+    local pending=$(jq -r '.cleanup.pendingCleanup // [] | .[]' "$DAEMON_STATE" 2>/dev/null || echo "")
+
+    if [[ -n "$pending" ]]; then
+      info "Processing pending cleanups from previous session..."
+      for item in $pending; do
+        issue_num=$(echo "$item" | sed 's/issue-//')
+        info "  Processing: $item"
+        if [[ "$DRY_RUN" != true ]]; then
+          # Remove from pending list
+          jq --arg item "$item" '.cleanup.pendingCleanup -= [$item]' \
+            "$DAEMON_STATE" > "${DAEMON_STATE}.tmp" && mv "${DAEMON_STATE}.tmp" "$DAEMON_STATE"
+        fi
+      done
+    fi
+  fi
+
+  # Run safe worktree cleanup
+  info "Cleaning stale worktrees..."
+  if [[ "$DRY_RUN" == true ]]; then
+    "$SCRIPT_DIR/safe-worktree-cleanup.sh" --dry-run 2>/dev/null || warning "safe-worktree-cleanup.sh not found"
+  else
+    "$SCRIPT_DIR/safe-worktree-cleanup.sh" 2>/dev/null || warning "safe-worktree-cleanup.sh not found"
+  fi
+
+  # Prune old archives
+  info "Pruning old archives..."
+  if [[ "$DRY_RUN" == true ]]; then
+    "$SCRIPT_DIR/archive-logs.sh" --prune-only --dry-run --retention-days "$RETENTION_DAYS" 2>/dev/null || true
+  else
+    "$SCRIPT_DIR/archive-logs.sh" --prune-only --retention-days "$RETENTION_DAYS" 2>/dev/null || true
+  fi
+
+  if [[ "$DRY_RUN" != true ]]; then
+    update_cleanup_timestamp "daemon-startup"
+  fi
+
+  success "Daemon startup cleanup complete"
+}
+
+# Event: daemon-shutdown
+# Archive logs and cleanup before daemon exits
+handle_daemon_shutdown() {
+  header "Daemon Shutdown Cleanup"
+  echo ""
+
+  # Archive all current task outputs
+  if [[ "$ARCHIVE_LOGS" == "true" ]]; then
+    info "Archiving task outputs..."
+    if [[ "$DRY_RUN" == true ]]; then
+      "$SCRIPT_DIR/archive-logs.sh" --dry-run 2>/dev/null || warning "archive-logs.sh not found"
+    else
+      "$SCRIPT_DIR/archive-logs.sh" 2>/dev/null || warning "archive-logs.sh not found"
+    fi
+  fi
+
+  # Note: Don't clean worktrees on shutdown - shepherds might be in progress
+  # Let daemon-startup handle that on next run
+
+  if [[ "$DRY_RUN" != true ]]; then
+    update_cleanup_timestamp "daemon-shutdown"
+  fi
+
+  success "Daemon shutdown cleanup complete"
+}
+
+# Event: periodic
+# Conservative periodic cleanup (respects active shepherds)
+handle_periodic() {
+  header "Periodic Cleanup"
+  echo ""
+
+  # Check if any shepherds are active
+  if [[ "$(has_active_shepherds)" == "true" ]]; then
+    info "Active shepherds detected - running conservative cleanup only"
+  fi
+
+  # Archive task outputs (safe even with active shepherds)
+  if [[ "$ARCHIVE_LOGS" == "true" ]]; then
+    info "Archiving task outputs..."
+    if [[ "$DRY_RUN" == true ]]; then
+      "$SCRIPT_DIR/archive-logs.sh" --dry-run 2>/dev/null || warning "archive-logs.sh not found"
+    else
+      "$SCRIPT_DIR/archive-logs.sh" 2>/dev/null || warning "archive-logs.sh not found"
+    fi
+  fi
+
+  # Only clean worktrees if no active shepherds or in force mode
+  if [[ "$(has_active_shepherds)" == "false" ]]; then
+    info "No active shepherds - running full worktree cleanup..."
+    if [[ "$DRY_RUN" == true ]]; then
+      "$SCRIPT_DIR/safe-worktree-cleanup.sh" --dry-run 2>/dev/null || warning "safe-worktree-cleanup.sh not found"
+    else
+      "$SCRIPT_DIR/safe-worktree-cleanup.sh" 2>/dev/null || warning "safe-worktree-cleanup.sh not found"
+    fi
+  else
+    info "Skipping worktree cleanup (active shepherds)"
+  fi
+
+  # Prune old archives
+  info "Pruning old archives..."
+  if [[ "$DRY_RUN" == true ]]; then
+    "$SCRIPT_DIR/archive-logs.sh" --prune-only --dry-run --retention-days "$RETENTION_DAYS" 2>/dev/null || true
+  else
+    "$SCRIPT_DIR/archive-logs.sh" --prune-only --retention-days "$RETENTION_DAYS" 2>/dev/null || true
+  fi
+
+  if [[ "$DRY_RUN" != true ]]; then
+    update_cleanup_timestamp "periodic"
+  fi
+
+  success "Periodic cleanup complete"
+}
+
+# Main dispatch
+case "$EVENT" in
+  shepherd-complete)
+    handle_shepherd_complete
+    ;;
+  daemon-startup)
+    handle_daemon_startup
+    ;;
+  daemon-shutdown)
+    handle_daemon_shutdown
+    ;;
+  periodic)
+    handle_periodic
+    ;;
+  *)
+    error "Unknown event: $EVENT\nValid events: shepherd-complete, daemon-startup, daemon-shutdown, periodic"
+    ;;
+esac

--- a/scripts/safe-worktree-cleanup.sh
+++ b/scripts/safe-worktree-cleanup.sh
@@ -1,0 +1,372 @@
+#!/usr/bin/env bash
+# Safe worktree cleanup - only removes worktrees for MERGED PRs
+# Usage: ./scripts/safe-worktree-cleanup.sh [--dry-run] [--force] [--grace-period N]
+#
+# Unlike blunt cleanup, this script:
+# - Only removes worktrees when the PR is MERGED (not just closed)
+# - Checks for uncommitted changes before removal
+# - Applies a grace period after merge to avoid race conditions
+# - Tracks cleanup state in daemon-state.json
+
+set -euo pipefail
+
+# ANSI color codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+error() { echo -e "${RED}Error: $*${NC}" >&2; exit 1; }
+info() { echo -e "${BLUE}$*${NC}"; }
+success() { echo -e "${GREEN}$*${NC}"; }
+warning() { echo -e "${YELLOW}$*${NC}"; }
+header() { echo -e "${CYAN}$*${NC}"; }
+
+# Configuration
+DRY_RUN=false
+FORCE=false
+GRACE_PERIOD=600  # 10 minutes in seconds
+
+# Detect repository root
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || error "Not in a git repository"
+
+# State file for tracking cleanup
+DAEMON_STATE="$REPO_ROOT/.loom/daemon-state.json"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --force|-f)
+      FORCE=true
+      shift
+      ;;
+    --grace-period)
+      GRACE_PERIOD="$2"
+      shift 2
+      ;;
+    --help|-h)
+      cat <<EOF
+Safe worktree cleanup - only removes worktrees for MERGED PRs
+
+Usage: ./scripts/safe-worktree-cleanup.sh [options]
+
+Options:
+  --dry-run           Show what would be cleaned without making changes
+  -f, --force         Skip grace period and uncommitted changes check
+  --grace-period N    Seconds to wait after PR merge (default: 600 = 10 min)
+  -h, --help          Show this help message
+
+Safety Features:
+  - Only cleans worktrees with MERGED PRs (not just closed)
+  - Checks for uncommitted changes before removal
+  - Grace period after merge to avoid race conditions
+  - Tracks cleanup state in daemon-state.json
+
+Cleanup Criteria:
+  A worktree is cleaned when ALL of the following are true:
+  1. The associated issue is CLOSED
+  2. The PR is MERGED (has mergedAt timestamp)
+  3. Grace period has passed since merge
+  4. No uncommitted changes exist (unless --force)
+EOF
+      exit 0
+      ;;
+    *)
+      error "Unknown option: $1\nUse --help for usage information"
+      ;;
+  esac
+done
+
+# Functions
+check_pr_merged() {
+  local issue_num="$1"
+  local branch_name="feature/issue-${issue_num}"
+
+  # Find PR by head branch
+  local pr_info=$(gh pr list --head "$branch_name" --state all --json number,state,mergedAt --jq '.[0] // empty' 2>/dev/null || echo "")
+
+  if [[ -z "$pr_info" ]]; then
+    # Try searching by issue reference
+    pr_info=$(gh pr list --search "Closes #${issue_num}" --state all --json number,state,mergedAt --jq '.[0] // empty' 2>/dev/null || echo "")
+  fi
+
+  if [[ -z "$pr_info" ]]; then
+    echo "NO_PR"
+    return
+  fi
+
+  local state=$(echo "$pr_info" | jq -r '.state // "UNKNOWN"')
+  local merged_at=$(echo "$pr_info" | jq -r '.mergedAt // "null"')
+
+  if [[ "$merged_at" != "null" && "$merged_at" != "" ]]; then
+    echo "MERGED:$merged_at"
+  elif [[ "$state" == "CLOSED" ]]; then
+    echo "CLOSED_NO_MERGE"
+  elif [[ "$state" == "OPEN" ]]; then
+    echo "OPEN"
+  else
+    echo "UNKNOWN"
+  fi
+}
+
+check_uncommitted_changes() {
+  local worktree_path="$1"
+
+  if [[ ! -d "$worktree_path" ]]; then
+    echo "false"
+    return
+  fi
+
+  # Check for any uncommitted changes (staged or unstaged)
+  if git -C "$worktree_path" diff --quiet 2>/dev/null && \
+     git -C "$worktree_path" diff --cached --quiet 2>/dev/null; then
+    echo "false"
+  else
+    echo "true"
+  fi
+}
+
+check_grace_period() {
+  local merged_at="$1"
+  local now=$(date +%s)
+
+  # Parse merged_at timestamp
+  local merged_ts
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS
+    merged_ts=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$merged_at" +%s 2>/dev/null || echo "0")
+  else
+    # Linux
+    merged_ts=$(date -d "$merged_at" +%s 2>/dev/null || echo "0")
+  fi
+
+  local elapsed=$((now - merged_ts))
+
+  if [[ $elapsed -gt $GRACE_PERIOD ]]; then
+    echo "passed:$elapsed"
+  else
+    echo "waiting:$((GRACE_PERIOD - elapsed))"
+  fi
+}
+
+cleanup_worktree() {
+  local worktree_path="$1"
+  local issue_num="$2"
+  local branch_name="feature/issue-${issue_num}"
+
+  if [[ "$DRY_RUN" == true ]]; then
+    info "Would remove: $worktree_path"
+    info "Would delete branch: $branch_name"
+    return 0
+  fi
+
+  # Remove worktree
+  if git worktree remove "$worktree_path" --force 2>/dev/null; then
+    success "Removed worktree: $worktree_path"
+  else
+    warning "Failed to remove worktree: $worktree_path"
+    return 1
+  fi
+
+  # Delete local branch (if it exists)
+  if git branch -d "$branch_name" 2>/dev/null; then
+    success "Deleted branch: $branch_name"
+  elif git branch -D "$branch_name" 2>/dev/null; then
+    success "Force-deleted branch: $branch_name"
+  else
+    info "Branch already deleted or doesn't exist: $branch_name"
+  fi
+
+  return 0
+}
+
+update_cleanup_state() {
+  local issue_num="$1"
+  local status="$2"
+
+  if [[ ! -f "$DAEMON_STATE" ]]; then
+    return
+  fi
+
+  local timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  # Initialize cleanup section if needed
+  if ! jq -e '.cleanup' "$DAEMON_STATE" >/dev/null 2>&1; then
+    jq '.cleanup = {"lastRun": null, "lastCleaned": [], "pendingCleanup": [], "errors": []}' \
+      "$DAEMON_STATE" > "${DAEMON_STATE}.tmp" && mv "${DAEMON_STATE}.tmp" "$DAEMON_STATE"
+  fi
+
+  case "$status" in
+    cleaned)
+      jq ".cleanup.lastCleaned += [\"issue-${issue_num}\"] | .cleanup.lastRun = \"$timestamp\"" \
+        "$DAEMON_STATE" > "${DAEMON_STATE}.tmp" && mv "${DAEMON_STATE}.tmp" "$DAEMON_STATE"
+      ;;
+    pending)
+      jq ".cleanup.pendingCleanup += [\"issue-${issue_num}\"] | .cleanup.pendingCleanup |= unique" \
+        "$DAEMON_STATE" > "${DAEMON_STATE}.tmp" && mv "${DAEMON_STATE}.tmp" "$DAEMON_STATE"
+      ;;
+    error)
+      jq ".cleanup.errors += [{\"issue\": $issue_num, \"timestamp\": \"$timestamp\"}]" \
+        "$DAEMON_STATE" > "${DAEMON_STATE}.tmp" && mv "${DAEMON_STATE}.tmp" "$DAEMON_STATE"
+      ;;
+  esac
+}
+
+# Main
+cd "$REPO_ROOT"
+
+header "========================================"
+header "  Safe Worktree Cleanup"
+if [[ "$DRY_RUN" == true ]]; then
+  header "  (DRY RUN MODE)"
+fi
+header "========================================"
+echo ""
+
+# Get worktree directory
+WORKTREE_DIR="$REPO_ROOT/.loom/worktrees"
+
+if [[ ! -d "$WORKTREE_DIR" ]]; then
+  info "No worktrees directory found"
+  exit 0
+fi
+
+# Counters
+cleaned=0
+skipped_open=0
+skipped_not_merged=0
+skipped_grace=0
+skipped_uncommitted=0
+errors=0
+
+# Process each worktree
+for worktree_path in "$WORKTREE_DIR"/issue-*; do
+  if [[ ! -d "$worktree_path" ]]; then
+    continue
+  fi
+
+  issue_num=$(basename "$worktree_path" | sed 's/issue-//')
+
+  if [[ ! "$issue_num" =~ ^[0-9]+$ ]]; then
+    continue
+  fi
+
+  echo "Checking worktree: issue-$issue_num"
+
+  # Check issue state
+  issue_state=$(gh issue view "$issue_num" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+
+  if [[ "$issue_state" != "CLOSED" ]]; then
+    info "  Issue #$issue_num is $issue_state - skipping"
+    ((skipped_open++)) || true
+    continue
+  fi
+
+  # Check PR merge status
+  pr_status=$(check_pr_merged "$issue_num")
+
+  case "$pr_status" in
+    MERGED:*)
+      merged_at="${pr_status#MERGED:}"
+      ;;
+    CLOSED_NO_MERGE)
+      warning "  PR closed without merge - skipping (may need investigation)"
+      ((skipped_not_merged++)) || true
+      continue
+      ;;
+    OPEN)
+      info "  PR still open - skipping"
+      ((skipped_open++)) || true
+      continue
+      ;;
+    NO_PR)
+      warning "  No PR found for issue - skipping"
+      ((skipped_not_merged++)) || true
+      continue
+      ;;
+    *)
+      warning "  Unknown PR status - skipping"
+      ((errors++)) || true
+      continue
+      ;;
+  esac
+
+  # Check grace period
+  if [[ "$FORCE" != true ]]; then
+    grace_status=$(check_grace_period "$merged_at")
+    case "$grace_status" in
+      waiting:*)
+        remaining="${grace_status#waiting:}"
+        info "  PR merged but grace period not passed (${remaining}s remaining)"
+        update_cleanup_state "$issue_num" "pending"
+        ((skipped_grace++)) || true
+        continue
+        ;;
+    esac
+  fi
+
+  # Check for uncommitted changes
+  if [[ "$FORCE" != true ]]; then
+    has_changes=$(check_uncommitted_changes "$worktree_path")
+    if [[ "$has_changes" == "true" ]]; then
+      warning "  Uncommitted changes detected - skipping"
+      warning "    To force: ./scripts/safe-worktree-cleanup.sh --force"
+      ((skipped_uncommitted++)) || true
+      continue
+    fi
+  fi
+
+  # All checks passed - cleanup
+  if cleanup_worktree "$worktree_path" "$issue_num"; then
+    if [[ "$DRY_RUN" != true ]]; then
+      update_cleanup_state "$issue_num" "cleaned"
+    fi
+    ((cleaned++)) || true
+  else
+    if [[ "$DRY_RUN" != true ]]; then
+      update_cleanup_state "$issue_num" "error"
+    fi
+    ((errors++)) || true
+  fi
+done
+
+# Prune orphaned git worktree references
+echo ""
+header "Pruning Orphaned References"
+if [[ "$DRY_RUN" == true ]]; then
+  git worktree prune --dry-run --verbose 2>&1 || true
+else
+  git worktree prune --verbose 2>&1 || true
+fi
+
+# Summary
+echo ""
+header "========================================"
+header "  Summary"
+header "========================================"
+echo ""
+
+if [[ "$DRY_RUN" == true ]]; then
+  echo "  Would clean: $cleaned worktree(s)"
+else
+  echo "  Cleaned: $cleaned worktree(s)"
+fi
+echo "  Skipped (open): $skipped_open"
+echo "  Skipped (not merged): $skipped_not_merged"
+echo "  Skipped (grace period): $skipped_grace"
+echo "  Skipped (uncommitted): $skipped_uncommitted"
+echo "  Errors: $errors"
+echo ""
+
+if [[ "$DRY_RUN" == true ]]; then
+  warning "Dry run complete - no changes made"
+  info "Run without --dry-run to perform cleanup"
+else
+  success "Cleanup complete!"
+fi


### PR DESCRIPTION
## Summary
- Implements event-driven cleanup system for the Loom daemon with three new scripts
- Archives task outputs to `.loom/logs/{date}/` with configurable retention period
- Only removes worktrees when PR is **MERGED** (not just closed), with grace period and uncommitted changes check
- Tracks cleanup state in `daemon-state.json` for debugging and crash recovery

## Changes

### New Scripts
1. **archive-logs.sh**: Archives task output files before deletion with retention policy
2. **safe-worktree-cleanup.sh**: Safe worktree cleanup that only removes merged PRs
3. **daemon-cleanup.sh**: Event-driven cleanup integration for daemon lifecycle events

### Safety Features
- Worktrees only removed after PR merged AND grace period elapsed (default 10 min)
- Uncommitted changes detected and preserved (skipped with warning)
- All scripts support `--dry-run` mode for testing
- Cleanup state tracked in daemon-state.json

### Events Supported
| Event | Trigger | What Gets Cleaned |
|-------|---------|-------------------|
| shepherd-complete | After shepherd finishes | Task outputs, worktree (if PR merged) |
| daemon-startup | When daemon starts | Stale artifacts from previous session |
| daemon-shutdown | Before daemon exits | Archive task outputs |
| periodic | Configurable interval | Conservative cleanup respecting active shepherds |

## Test plan
- [x] `./scripts/archive-logs.sh --help` shows usage
- [x] `./scripts/safe-worktree-cleanup.sh --help` shows usage
- [x] `./scripts/daemon-cleanup.sh --help` shows usage
- [x] `./scripts/archive-logs.sh --dry-run` runs without errors
- [x] `./scripts/safe-worktree-cleanup.sh --dry-run` runs without errors
- [x] `./scripts/daemon-cleanup.sh periodic --dry-run` runs without errors

Closes #1027

Generated with [Claude Code](https://claude.com/claude-code)