### PR TITLE
Remove unused Rust dependencies from desktop quickstart template

### DIFF
--- a/quickstarts/desktop/src-tauri/Cargo.toml
+++ b/quickstarts/desktop/src-tauri/Cargo.toml
@@ -13,16 +13,11 @@ rust-version = "1.70"
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-serde_json = "1"
-serde = { version = "1", features = ["derive"] }
 tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-shell = "2"
 tauri-plugin-sql = { version = "2", features = ["sqlite"] }
-tokio = { version = "1", features = ["full"] }
-anyhow = "1"
-dirs = "6.0"
 
 [features]
 custom-protocol = ["tauri/custom-protocol"]


### PR DESCRIPTION
## Summary

- Remove 5 unused Rust dependencies from `quickstarts/desktop/src-tauri/Cargo.toml`: anyhow, dirs, serde, serde_json, tokio
- These dependencies are declared but never used in the actual code (verified by cargo-machete and manual inspection)
- Reduces build time, binary size, and security surface area for template users

## Test plan

- [x] Verified source files (`main.rs`, `commands.rs`) do not use any of the removed dependencies
- [x] Changes are purely subtractive - removing unused dependencies cannot break functionality

Closes #1033

Generated with [Claude Code](https://claude.com/claude-code)