### PR TITLE
Preserve custom project roles/commands during reinstallation

### DIFF
--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -264,7 +264,7 @@ fn handle_cli_command(command: Commands) -> Result<()> {
             println!("  Defaults:  {defaults}");
 
             match init::initialize_workspace(workspace_str, &defaults, force) {
-                Ok(()) => {
+                Ok(report) => {
                     println!("\n✅ Loom workspace initialized successfully!");
                     println!("\nFiles installed:");
                     println!("  📁 .loom/          - Configuration directory");
@@ -276,6 +276,32 @@ fn handle_cli_command(command: Commands) -> Result<()> {
                     println!("  📁 .codex/         - Codex configuration");
                     println!("  📁 .github/        - GitHub workflow templates");
                     println!("  📄 .gitignore      - Updated with Loom patterns");
+
+                    // Print report of what was added vs preserved
+                    if !report.added.is_empty() || !report.preserved.is_empty() {
+                        println!();
+                        if !report.added.is_empty() {
+                            println!("Files added ({}):", report.added.len());
+                            for file in &report.added {
+                                println!("  + {file}");
+                            }
+                        }
+                        if !report.preserved.is_empty() {
+                            println!("\nFiles preserved ({}):", report.preserved.len());
+                            for file in &report.preserved {
+                                println!("  = {file}");
+                            }
+                            println!("\n  ℹ️  Preserved files were not overwritten. To update them,");
+                            println!("     delete them and run install again, or use --force.");
+                        }
+                        if !report.updated.is_empty() && force {
+                            println!("\nFiles updated ({}):", report.updated.len());
+                            for file in &report.updated {
+                                println!("  ~ {file}");
+                            }
+                        }
+                    }
+
                     println!("\nNext steps:");
                     println!("  1. Commit the changes: git add -A && git commit -m 'Add Loom configuration'");
                     println!("  2. Choose your workflow:");

--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -346,9 +346,10 @@ success "loom-daemon binary ready"
 
 # Run loom-daemon init in the worktree
 cd "$TARGET_PATH/$WORKTREE_PATH"
-# Use --force in case .loom already exists in the target repo
+# Use merge mode (no --force) to preserve custom project roles/commands
+# New files are added, existing files are preserved
 # Use --defaults to point to Loom's defaults directory
-"$LOOM_ROOT/target/release/loom-daemon" init --force --defaults "$LOOM_ROOT/defaults" . || \
+"$LOOM_ROOT/target/release/loom-daemon" init --defaults "$LOOM_ROOT/defaults" . || \
   error "loom-daemon init failed"
 
 echo ""


### PR DESCRIPTION
## Summary

- Changes installation behavior from force-overwrite to merge mode
- Custom project roles like `.loom/roles/designer.md` are now preserved during reinstall
- Custom commands like `.claude/commands/mycommand.md` are now preserved
- New Loom files are added, existing files are not overwritten
- Prints report showing what was added vs preserved after installation

## Test plan

- [x] All 95 existing tests pass
- [x] Builds successfully in release mode
- [ ] Test fresh install to new repo
- [ ] Test reinstall preserves custom files
- [ ] Test --force mode overwrites files

Closes #1045

🤖 Generated with [Claude Code](https://claude.com/claude-code)