### PR TITLE
Add graceful shutdown support for shepherds

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -68,3 +68,7 @@
 - name: loom:urgent
   description: Critical/blocking issue requiring immediate attention
   color: "DC2626"  # red-600
+
+- name: loom:abort
+  description: Signal to abort shepherd for this issue (returns to loom:issue)
+  color: "F97316"  # orange-500 - warning/signal color

--- a/.loom/scripts/check-shutdown.sh
+++ b/.loom/scripts/check-shutdown.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# check-shutdown.sh - Check for shepherd shutdown signals
+#
+# Usage:
+#   ./.loom/scripts/check-shutdown.sh           # Check global shutdown signal
+#   ./.loom/scripts/check-shutdown.sh <issue>   # Also check issue-specific abort
+#
+# Exit codes:
+#   0 - Shutdown signal detected (should exit gracefully)
+#   1 - No shutdown signal (continue normally)
+#
+# This script is used by shepherds to check for graceful shutdown signals
+# at phase boundaries during orchestration.
+
+set -e
+
+# Navigate to repository root (handle being called from worktree)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || echo "$SCRIPT_DIR/../..")"
+
+# Handle worktrees - find the main workspace
+if [ -f "$REPO_ROOT/.git" ]; then
+    # We're in a worktree, find main workspace
+    MAIN_WORKSPACE="$(git -C "$REPO_ROOT" worktree list | head -1 | awk '{print $1}')"
+else
+    MAIN_WORKSPACE="$REPO_ROOT"
+fi
+
+LOOM_DIR="$MAIN_WORKSPACE/.loom"
+ISSUE_NUMBER="$1"
+
+# Check for global shutdown signal
+if [ -f "$LOOM_DIR/stop-shepherds" ]; then
+    echo "SHUTDOWN:global"
+    exit 0
+fi
+
+# Check for issue-specific abort (if issue number provided)
+if [ -n "$ISSUE_NUMBER" ]; then
+    LABELS=$(gh issue view "$ISSUE_NUMBER" --json labels --jq '.labels[].name' 2>/dev/null || echo "")
+    if echo "$LABELS" | grep -q "loom:abort"; then
+        echo "SHUTDOWN:abort:$ISSUE_NUMBER"
+        exit 0
+    fi
+fi
+
+# No shutdown signal
+exit 1


### PR DESCRIPTION
## Summary

Implements graceful shutdown support for shepherds, allowing them to exit cleanly at phase boundaries when the Loom daemon receives a stop signal.

## Changes

- **shepherd.md**: Added "Graceful Shutdown Handling" section with:
  - Shutdown signal checking at phase boundaries
  - `check_shutdown_signal()` function that checks for `.loom/stop-shepherds`
  - Logic to revert issue labels and add explanatory comment on exit
  - Support for per-issue abort via `loom:abort` label

- **loom.md**: Updated graceful shutdown procedure:
  - Daemon now creates `.loom/stop-shepherds` signal file
  - Reduced wait timeout from 5 minutes to 2 minutes (shepherds exit faster at boundaries)
  - Proper cleanup of signal files after shutdown

- **check-shutdown.sh**: New helper script for checking shutdown signals:
  - Checks global shutdown signal (`.loom/stop-shepherds`)
  - Optionally checks issue-specific abort (`loom:abort` label)
  - Returns appropriate exit codes for script integration

- **labels.yml**: Added `loom:abort` label for per-issue abort signaling

## Test Plan

- [ ] Create shepherd orchestration, then touch `.loom/stop-daemon` - verify shepherd exits at next phase boundary
- [ ] Verify issue reverts to `loom:issue` state when shepherd exits gracefully
- [ ] Test `.loom/scripts/check-shutdown.sh` returns correct exit codes
- [ ] Verify `loom:abort` label triggers per-issue abort

Closes #1085