### PR TITLE
Add session limit awareness with claude-monitor integration

### DIFF
--- a/.loom/scripts/check-usage.sh
+++ b/.loom/scripts/check-usage.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# check-usage.sh - Query claude-monitor database for session usage
+#
+# Usage:
+#   ./.loom/scripts/check-usage.sh           # Returns JSON with usage data
+#   ./.loom/scripts/check-usage.sh --status  # Human-readable status
+#
+# Exit codes:
+#   0 - Data returned successfully
+#   1 - Database not found or query failed
+#
+# This script queries the claude-monitor SQLite database to get current
+# session usage. Used by the Loom daemon to detect approaching rate limits.
+#
+# Requires: claude-monitor browser extension
+# See: https://github.com/rjwalters/claude-monitor
+
+set -e
+
+DB_PATH="$HOME/.claude-monitor/usage.db"
+
+# Check if database exists
+if [ ! -f "$DB_PATH" ]; then
+    if [ "$1" = "--status" ]; then
+        echo "NO_DATABASE: claude-monitor not installed"
+        echo ""
+        echo "For multi-day autonomous operation, install claude-monitor:"
+        echo "  https://github.com/rjwalters/claude-monitor"
+    else
+        echo '{"error": "NO_DATABASE", "message": "claude-monitor not installed"}'
+    fi
+    exit 1
+fi
+
+# Check if sqlite3 is available
+if ! command -v sqlite3 &> /dev/null; then
+    if [ "$1" = "--status" ]; then
+        echo "ERROR: sqlite3 not found"
+    else
+        echo '{"error": "NO_SQLITE3", "message": "sqlite3 command not found"}'
+    fi
+    exit 1
+fi
+
+if [ "$1" = "--status" ]; then
+    # Human-readable format
+    result=$(sqlite3 "$DB_PATH" "
+        SELECT
+            session_percent,
+            session_reset,
+            weekly_all_percent,
+            weekly_reset,
+            datetime(timestamp, 'localtime') as local_time
+        FROM usage_history
+        WHERE is_synthetic = 0
+        ORDER BY timestamp DESC
+        LIMIT 1
+    " -separator '|' 2>/dev/null)
+
+    if [ -z "$result" ]; then
+        echo "NO_DATA: No usage data in database"
+        echo "Make sure claude.ai/settings/usage is open in your browser"
+        exit 1
+    fi
+
+    IFS='|' read -r session_pct session_reset weekly_pct weekly_reset timestamp <<< "$result"
+
+    echo "Claude Usage Status (as of $timestamp)"
+    echo "========================================"
+    echo ""
+    echo "Session:     ${session_pct}% used"
+    echo "  Resets:    $session_reset"
+    echo ""
+    echo "Weekly:      ${weekly_pct}% used"
+    echo "  Resets:    $weekly_reset"
+    echo ""
+
+    # Provide recommendation
+    if [ "${session_pct%.*}" -ge 97 ]; then
+        echo "⚠️  RECOMMENDATION: Pause operations until session resets"
+    elif [ "${session_pct%.*}" -ge 80 ]; then
+        echo "⚠️  WARNING: Approaching session limit"
+    else
+        echo "✓ Session usage is healthy"
+    fi
+else
+    # JSON format for programmatic use
+    sqlite3 "$DB_PATH" "
+        SELECT json_object(
+            'session_percent', session_percent,
+            'session_reset', session_reset,
+            'weekly_all_percent', weekly_all_percent,
+            'weekly_reset', weekly_reset,
+            'timestamp', timestamp,
+            'data_age_seconds', CAST((julianday('now') - julianday(timestamp)) * 86400 AS INTEGER)
+        )
+        FROM usage_history
+        WHERE is_synthetic = 0
+        ORDER BY timestamp DESC
+        LIMIT 1
+    " 2>/dev/null || {
+        echo '{"error": "QUERY_FAILED", "message": "Failed to query database"}'
+        exit 1
+    }
+fi


### PR DESCRIPTION
## Summary

Implements session limit awareness for the Loom daemon by integrating with claude-monitor. This enables multi-day autonomous operation where the daemon can pause gracefully when approaching session limits and resume automatically when limits reset.

## Changes

- **`.loom/scripts/check-usage.sh`**: New helper script
  - Queries claude-monitor SQLite database at `~/.claude-monitor/usage.db`
  - Returns JSON with `session_percent`, `session_reset`, `weekly_all_percent`, `weekly_reset`
  - Supports `--status` flag for human-readable output
  - Gracefully handles missing database (exit code 1)

- **`.loom/roles/loom.md`**: Updated daemon role
  - Added "Session Limit Awareness" section explaining the integration
  - Added step 2 "SESSION LIMIT CHECK" to the daemon iteration loop
  - When session >= 97%, daemon enters pause mode
  - Pause behavior differs from shutdown: issues stay in `loom:building`
  - Updated daemon-state.json format with `session_limit_awareness` object
  - Updated status report to show Claude usage metrics

## How It Works

1. **Startup**: Daemon checks for `~/.claude-monitor/usage.db`
   - If found: session limit awareness enabled
   - If not found: shows install recommendation, operates normally

2. **Each iteration**: Daemon calls `check-usage.sh`
   - If session_percent >= 97%: pause mode
   - Creates `.loom/stop-shepherds` signal
   - Waits for shepherds to reach phase boundary
   - Sleeps until session reset time
   - Resumes automatically

3. **Pause vs Shutdown**: Key difference
   - Shutdown: reverts issues to `loom:issue`
   - Pause: keeps issues in `loom:building`, preserves shepherd assignments

## Test Plan

- [x] `check-usage.sh` returns valid JSON when database exists
- [x] `check-usage.sh --status` shows human-readable output
- [x] `check-usage.sh` exits with code 1 when database missing
- [ ] Daemon shows usage in status report when claude-monitor available
- [ ] Daemon pauses when session_percent >= 97%
- [ ] Daemon resumes after session resets

## Dependencies

Requires [claude-monitor](https://github.com/rjwalters/claude-monitor) browser extension for proactive pausing. Without it, daemon operates normally with reactive error handling only.

Closes #1089