### PR TITLE
Add --autonomous flag to Architect role for daemon operation

### DIFF
--- a/.loom/roles/architect.md
+++ b/.loom/roles/architect.md
@@ -123,6 +123,68 @@ I've identified an opportunity to add caching for analysis results in StyleCheck
 Your answers will help me recommend the most appropriate caching strategy.
 ```
 
+## Autonomous Mode (--autonomous flag)
+
+When invoked with `--autonomous` flag (typically by `/loom` daemon):
+
+**Skip interactive requirements gathering**. Instead, use self-reflection to infer
+reasonable answers from the codebase itself.
+
+### Self-Reflection Process
+
+Before creating a proposal, analyze the codebase to answer your own questions:
+
+**For constraints**:
+- Check `.loom/` and `CLAUDE.md` for stated limits or preferences
+- Look at existing similar implementations for size/complexity norms
+- Review recent PRs for patterns in accepted scope
+
+**For priorities**:
+- What does CLAUDE.md emphasize? (simplicity, performance, etc.)
+- What style of solutions were recently merged?
+- What's the current development focus based on open issues?
+
+**For context**:
+- What patterns are already established in the codebase?
+- What frameworks/tools are in use?
+- What's the team's apparent expertise level?
+
+### Default Assumptions
+
+When no clear signal is available, use these defaults:
+- **Simplicity over complexity** - prefer straightforward solutions
+- **Incremental over rewrite** - prefer small, focused changes
+- **Consistency over novelty** - prefer existing patterns
+- **Reversibility over optimization** - prefer changes that can be undone
+
+### Documenting Assumptions
+
+Always include an "Autonomous Mode Assumptions" section in proposals:
+
+```markdown
+## Autonomous Mode Assumptions
+
+This proposal was created in autonomous mode. The following assumptions were made:
+
+| Question | Inferred Answer | Source |
+|----------|-----------------|--------|
+| Priority? | Simplicity | CLAUDE.md emphasizes maintainability |
+| Breaking changes? | Minimize | Recent PRs favor incremental changes |
+| Pattern preference? | Shared crates | Existing loom-db, loom-types pattern |
+
+**Reviewer note**: Please validate these assumptions match your actual preferences.
+```
+
+### Autonomous Workflow
+
+1. Identify opportunity during codebase scan
+2. Self-reflect: Analyze codebase to infer constraints/priorities
+3. Apply default assumptions where signals are unclear
+4. Create proposal with ONE recommended approach
+5. Document all assumptions with sources
+6. Add `loom:architect` label
+7. Clear context (`/clear`)
+
 ## Workflow
 
 Your workflow now includes requirements gathering:

--- a/.loom/roles/loom.md
+++ b/.loom/roles/loom.md
@@ -238,7 +238,7 @@ def auto_generate_work():
         if architect_cooldown_ok() and architect_proposals < 2:
             Task(
                 description="Architect work generation",
-                prompt="/architect",
+                prompt="/architect --autonomous",
                 run_in_background=True
             )
             update_last_architect_trigger()
@@ -508,7 +508,7 @@ def auto_generate_work():
     if architect_proposals < MAX_ARCHITECT_PROPOSALS and architect_elapsed > ARCHITECT_COOLDOWN:
         result = Task(
             description="Architect work generation",
-            prompt="/architect",
+            prompt="/architect --autonomous",
             run_in_background=True
         )
         record_support_role("architect", result.task_id, result.output_file)


### PR DESCRIPTION
## Summary

- Add new "Autonomous Mode (--autonomous flag)" section to `.loom/roles/architect.md` that enables self-reflective requirements inference instead of interactive questioning
- Update `.loom/roles/loom.md` to pass `--autonomous` flag when daemon triggers Architect

## Details

When running in daemon mode, the Architect was getting stuck waiting for human answers to clarifying questions that never came. This PR adds an `--autonomous` flag that:

1. **Self-reflection process**: Analyze the codebase to infer constraints, priorities, and context instead of asking questions
2. **Default assumptions**: Use sensible defaults (simplicity, incremental changes, consistency) when no clear signal available
3. **Document assumptions**: Include an "Autonomous Mode Assumptions" section in proposals so reviewers can validate the inferences

The daemon now invokes `/architect --autonomous` to enable fully autonomous proposal generation.

## Test plan

- [ ] Run `/architect` manually - should ask clarifying questions (interactive mode unchanged)
- [ ] Run `/architect --autonomous` manually - should create proposal without questions
- [ ] Run `/loom` daemon - should trigger Architect with `--autonomous` flag
- [ ] Verify proposals include "Autonomous Mode Assumptions" section

Closes #1100

🤖 Generated with [Claude Code](https://claude.com/claude-code)