### PR TITLE
Add optional issue/PR number argument to role commands

### DIFF
--- a/.claude/commands/builder.md
+++ b/.claude/commands/builder.md
@@ -2,17 +2,25 @@
 
 Assume the Builder role from the Loom orchestration system and perform one iteration of work.
 
+## Usage
+
+```
+/builder              # Find and build one loom:ready issue
+/builder 123          # Build issue #123 specifically
+```
+
 ## Process
 
 1. **Read the role definition**: Load `defaults/roles/builder.md` or `.loom/roles/builder.md`
-2. **Follow the role's workflow**: Complete ONE iteration only
-3. **Report results**: Summarize what you accomplished with links
+2. **Parse arguments**: If an issue number is provided, work on that issue; otherwise find one
+3. **Follow the role's workflow**: Complete ONE iteration only
+4. **Report results**: Summarize what you accomplished with links
 
 ## Work Scope
 
 As the **Builder**, you implement features and fixes by:
 
-- Finding one `loom:ready` issue
+- Working on the specified issue, OR finding one `loom:ready` issue
 - Claiming it (remove `loom:ready`, add `loom:building`)
 - Creating a worktree with `./.loom/scripts/worktree.sh <issue-number>`
 - Implementing the feature/fix

--- a/.claude/commands/curator.md
+++ b/.claude/commands/curator.md
@@ -2,17 +2,25 @@
 
 Assume the Curator role from the Loom orchestration system and perform one iteration of work.
 
+## Usage
+
+```
+/curator              # Find and curate one unlabeled issue
+/curator 123          # Curate issue #123 specifically
+```
+
 ## Process
 
 1. **Read the role definition**: Load `defaults/roles/curator.md` or `.loom/roles/curator.md`
-2. **Follow the role's workflow**: Complete ONE iteration only
-3. **Report results**: Summarize what you accomplished with links
+2. **Parse arguments**: If an issue number is provided, work on that issue; otherwise find one
+3. **Follow the role's workflow**: Complete ONE iteration only
+4. **Report results**: Summarize what you accomplished with links
 
 ## Work Scope
 
 As the **Curator**, you enhance issue quality by:
 
-- Finding one unlabeled or under-specified issue
+- Working on the specified issue, OR finding one unlabeled or under-specified issue
 - Reading and understanding the issue
 - Adding technical context, implementation details, or acceptance criteria
 - Clarifying ambiguities and edge cases

--- a/.claude/commands/doctor.md
+++ b/.claude/commands/doctor.md
@@ -2,17 +2,26 @@
 
 Assume the Doctor role from the Loom orchestration system and perform one iteration of work.
 
+## Usage
+
+```
+/doctor               # Find one bug report or PR with requested changes
+/doctor 456           # Address feedback on PR #456 specifically
+/doctor 123 --issue   # Fix bug in issue #123 specifically
+```
+
 ## Process
 
 1. **Read the role definition**: Load `defaults/roles/doctor.md` or `.loom/roles/doctor.md`
-2. **Follow the role's workflow**: Complete ONE iteration only
-3. **Report results**: Summarize what you accomplished with links
+2. **Parse arguments**: If a number is provided, work on that PR (or issue with `--issue`); otherwise find one
+3. **Follow the role's workflow**: Complete ONE iteration only
+4. **Report results**: Summarize what you accomplished with links
 
 ## Work Scope
 
 As the **Doctor**, you fix bugs and maintain PRs by:
 
-- Finding one bug report or PR with requested changes
+- Working on the specified PR/issue, OR finding one bug report or PR with requested changes
 - Addressing the issue or feedback
 - Making necessary fixes
 - Running tests and CI checks

--- a/.claude/commands/judge.md
+++ b/.claude/commands/judge.md
@@ -2,17 +2,25 @@
 
 Assume the Judge role from the Loom orchestration system and perform one iteration of work.
 
+## Usage
+
+```
+/judge                # Find and review one PR with loom:review-requested
+/judge 456            # Review PR #456 specifically
+```
+
 ## Process
 
 1. **Read the role definition**: Load `defaults/roles/judge.md` or `.loom/roles/judge.md`
-2. **Follow the role's workflow**: Complete ONE iteration only
-3. **Report results**: Summarize what you accomplished with links
+2. **Parse arguments**: If a PR number is provided, review that PR; otherwise find one
+3. **Follow the role's workflow**: Complete ONE iteration only
+4. **Report results**: Summarize what you accomplished with links
 
 ## Work Scope
 
 As the **Judge**, you review code quality by:
 
-- Finding one PR with `loom:review-requested` label
+- Reviewing the specified PR, OR finding one PR with `loom:review-requested` label
 - Performing thorough code review following role guidelines
 - Checking code quality, tests, documentation, and CI status
 - Approving (add `loom:pr`) or requesting changes


### PR DESCRIPTION
## Summary

- Enable `/curator`, `/builder`, `/judge`, and `/doctor` commands to accept an optional first argument
- Argument is interpreted as issue number (curator, builder) or PR number (judge, doctor)
- Allows direct invocation like `/builder 123` instead of requiring auto-discovery
- Doctor supports `--issue` flag to disambiguate between PR and issue

## Test plan

- [ ] Verify `/curator 123` curates issue #123 directly
- [ ] Verify `/builder 123` builds issue #123 directly
- [ ] Verify `/judge 456` reviews PR #456 directly
- [ ] Verify `/doctor 456` addresses PR #456 feedback directly
- [ ] Verify `/doctor 123 --issue` fixes issue #123 directly
- [ ] Verify commands without arguments still auto-discover work

🤖 Generated with [Claude Code](https://claude.com/claude-code)