### PR TITLE
Fix installation failures on repos with many worktrees or stale refs

### DIFF
--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -139,7 +139,9 @@ fi
 
 # If target is inside a worktree, resolve to the main repository root
 # git worktree list --porcelain returns the main worktree first
-MAIN_WORKTREE=$(git -C "$TARGET_PATH" worktree list --porcelain 2>/dev/null | grep -m1 '^worktree ' | cut -d' ' -f2-)
+# Note: Use head -4 before grep to avoid SIGPIPE when repo has many worktrees
+# (grep -m1 exits early, causing SIGPIPE to git with pipefail enabled)
+MAIN_WORKTREE=$(git -C "$TARGET_PATH" worktree list --porcelain 2>/dev/null | head -4 | grep -m1 '^worktree ' | cut -d' ' -f2- || true)
 if [[ -n "$MAIN_WORKTREE" ]] && [[ "$TARGET_PATH" != "$MAIN_WORKTREE" ]]; then
   warning "Target path is inside a worktree: $TARGET_PATH"
   info "Resolving to main repository root: $MAIN_WORKTREE"

--- a/scripts/install/create-worktree.sh
+++ b/scripts/install/create-worktree.sh
@@ -40,10 +40,33 @@ BASE_BRANCH_NAME="feature/loom-installation"
 info "Creating worktree for issue #${ISSUE_NUMBER}..."
 
 # Detect the default branch (usually 'main' or 'master')
-# First try to get it from the remote HEAD
+# Strategy: Try multiple detection methods and validate the result
+
+# Method 1: Try git symbolic-ref (but this can be stale)
 DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo "")
 
-# If that fails, check if 'main' or 'master' exists locally
+# Method 2: If symbolic-ref returned a value, validate it exists on remote
+if [[ -n "$DEFAULT_BRANCH" ]]; then
+  # Fetch to update remote refs first
+  git fetch origin --prune 2>/dev/null || true
+
+  # Check if the branch actually exists on remote
+  if ! git show-ref --verify --quiet "refs/remotes/origin/${DEFAULT_BRANCH}"; then
+    info "Detected branch '${DEFAULT_BRANCH}' from symbolic-ref but it doesn't exist on remote"
+    DEFAULT_BRANCH=""
+  fi
+fi
+
+# Method 3: If still empty, check for common branch names on remote
+if [[ -z "$DEFAULT_BRANCH" ]]; then
+  if git show-ref --verify --quiet refs/remotes/origin/main; then
+    DEFAULT_BRANCH="main"
+  elif git show-ref --verify --quiet refs/remotes/origin/master; then
+    DEFAULT_BRANCH="master"
+  fi
+fi
+
+# Method 4: Fall back to local branches
 if [[ -z "$DEFAULT_BRANCH" ]]; then
   if git show-ref --verify --quiet refs/heads/main; then
     DEFAULT_BRANCH="main"
@@ -57,13 +80,23 @@ if [[ -z "$DEFAULT_BRANCH" ]]; then
 fi
 
 # Ensure we're branching from the latest state
-if [[ "$DEFAULT_BRANCH" == "main" ]] || [[ "$DEFAULT_BRANCH" == "master" ]]; then
-  info "Fetching latest changes from origin/${DEFAULT_BRANCH}..."
-  git fetch origin "${DEFAULT_BRANCH}:${DEFAULT_BRANCH}" 2>/dev/null || true
-fi
+# Fetch the branch from origin first
+info "Fetching latest changes from origin/${DEFAULT_BRANCH}..."
+git fetch origin "${DEFAULT_BRANCH}" 2>/dev/null || true
 
-info "Branching from: ${DEFAULT_BRANCH}"
-BASE_BRANCH="$DEFAULT_BRANCH"
+# Verify the branch exists (locally or as remote ref)
+# Prefer origin/DEFAULT_BRANCH as the base to ensure we have the latest
+if git show-ref --verify --quiet "refs/remotes/origin/${DEFAULT_BRANCH}"; then
+  BASE_BRANCH="origin/${DEFAULT_BRANCH}"
+  info "Branching from: ${BASE_BRANCH}"
+elif git show-ref --verify --quiet "refs/heads/${DEFAULT_BRANCH}"; then
+  BASE_BRANCH="${DEFAULT_BRANCH}"
+  info "Branching from: ${BASE_BRANCH}"
+else
+  # Fall back to HEAD if we can't find the branch
+  BASE_BRANCH="HEAD"
+  info "Could not find ${DEFAULT_BRANCH}, branching from HEAD"
+fi
 
 # Clean up any existing worktree
 if [[ -d "$WORKTREE_PATH" ]]; then
@@ -108,4 +141,7 @@ success "Branch name: $BRANCH_NAME"
 
 # Output the worktree path, branch name, and base branch (stdout, so it can be captured by caller)
 # Format: WORKTREE_PATH|BRANCH_NAME|BASE_BRANCH
-printf "%s|%s|%s" "${WORKTREE_PATH}" "${BRANCH_NAME}" "${BASE_BRANCH}"
+# Note: For PR target, always use DEFAULT_BRANCH (not BASE_BRANCH which might be HEAD)
+# Strip origin/ prefix if present
+TARGET_BRANCH="${DEFAULT_BRANCH#origin/}"
+printf "%s|%s|%s" "${WORKTREE_PATH}" "${BRANCH_NAME}" "${TARGET_BRANCH}"


### PR DESCRIPTION
## Summary

Fixes installation failures observed when installing Loom on the lean-genius repository.

**Issue 1: SIGPIPE error (exit code 141)**
- When repo has many worktrees (66KB+ of porcelain output), `grep -m1` exits early causing SIGPIPE to git with `pipefail` enabled
- Added `head -4 |` before grep to limit input and `|| true` to handle failures

**Issue 2: Stale branch ref detection**
- Local `refs/remotes/origin/HEAD` can be stale (pointing to `master` when remote HEAD is actually `main`)
- Now validates detected branch exists on remote before using it
- Falls back to checking remote refs for main/master

**Issue 3: Invalid PR base branch**
- When falling back to `HEAD` for worktree creation, this was incorrectly passed as PR base branch
- PR target now always uses `DEFAULT_BRANCH`, not `BASE_BRANCH` (which might be HEAD)

## Test plan

- [x] Tested installation on lean-genius repository (66KB worktree output, stale master ref)
- [x] Installation completes successfully with PR #938 created

🤖 Generated with [Claude Code](https://claude.com/claude-code)