### PR TITLE
Update repository URLs from loomhq to rjwalters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -405,7 +405,7 @@ gh issue edit 42 --remove-label "loom:building"
 
 - **Main Documentation**: `.loom/CLAUDE.md` (comprehensive usage guide)
 - **Role Definitions**: `.loom/roles/*.md` (detailed role guidelines)
-- **Loom Repository**: https://github.com/loomhq/loom
+- **Loom Repository**: https://github.com/rjwalters/loom
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This repository uses **Loom** for AI-powered development orchestration.
 
 Loom is a multi-terminal desktop application for macOS that orchestrates AI-powered development workers using git worktrees and GitHub as the coordination layer. It enables both automated orchestration (Tauri App Mode) and manual coordination (Manual Orchestration Mode).
 
-**Loom Repository**: https://github.com/loomhq/loom
+**Loom Repository**: https://github.com/rjwalters/loom
 
 ## Three-Layer Architecture
 
@@ -981,8 +981,8 @@ Add these MCP servers to your Claude Code configuration:
 
 ### Loom Documentation
 
-- **Main Repository**: https://github.com/loomhq/loom
-- **Getting Started**: https://github.com/loomhq/loom#getting-started
+- **Main Repository**: https://github.com/rjwalters/loom
+- **Getting Started**: https://github.com/rjwalters/loom#getting-started
 - **Role Definitions**: See `.loom/roles/*.md` in this repository
 - **Workflow Details**: See `.loom/AGENTS.md` in this repository
 
@@ -996,8 +996,8 @@ Add these MCP servers to your Claude Code configuration:
 ## Support
 
 For issues with Loom itself:
-- **GitHub Issues**: https://github.com/loomhq/loom/issues
-- **Documentation**: https://github.com/loomhq/loom/blob/main/CLAUDE.md
+- **GitHub Issues**: https://github.com/rjwalters/loom/issues
+- **Documentation**: https://github.com/rjwalters/loom/blob/main/CLAUDE.md
 
 For issues specific to this repository:
 - Use the repository's normal issue tracker

--- a/defaults/.loom/AGENTS.md
+++ b/defaults/.loom/AGENTS.md
@@ -405,7 +405,7 @@ gh issue edit 42 --remove-label "loom:building"
 
 - **Main Documentation**: `.loom/CLAUDE.md` (comprehensive usage guide)
 - **Role Definitions**: `.loom/roles/*.md` (detailed role guidelines)
-- **Loom Repository**: https://github.com/loomhq/loom
+- **Loom Repository**: https://github.com/rjwalters/loom
 
 ---
 

--- a/defaults/.loom/CLAUDE.md
+++ b/defaults/.loom/CLAUDE.md
@@ -10,7 +10,7 @@ This repository uses **Loom** for AI-powered development orchestration.
 
 Loom is a multi-terminal desktop application for macOS that orchestrates AI-powered development workers using git worktrees and GitHub as the coordination layer. It enables both automated orchestration (Tauri App Mode) and manual coordination (Manual Orchestration Mode).
 
-**Loom Repository**: https://github.com/loomhq/loom
+**Loom Repository**: https://github.com/rjwalters/loom
 
 ## Usage Modes
 
@@ -510,8 +510,8 @@ which claude
 
 ### Loom Documentation
 
-- **Main Repository**: https://github.com/loomhq/loom
-- **Getting Started**: https://github.com/loomhq/loom#getting-started
+- **Main Repository**: https://github.com/rjwalters/loom
+- **Getting Started**: https://github.com/rjwalters/loom#getting-started
 - **Role Definitions**: See `.loom/roles/*.md` in this repository
 - **Workflow Details**: See `.loom/AGENTS.md` in this repository
 
@@ -525,8 +525,8 @@ which claude
 ## Support
 
 For issues with Loom itself:
-- **GitHub Issues**: https://github.com/loomhq/loom/issues
-- **Documentation**: https://github.com/loomhq/loom/blob/main/CLAUDE.md
+- **GitHub Issues**: https://github.com/rjwalters/loom/issues
+- **Documentation**: https://github.com/rjwalters/loom/blob/main/CLAUDE.md
 
 For issues specific to this repository:
 - Use the repository's normal issue tracker

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -10,7 +10,7 @@ This repository uses **Loom** for AI-powered development orchestration.
 
 Loom is a multi-terminal desktop application for macOS that orchestrates AI-powered development workers using git worktrees and GitHub as the coordination layer. It enables both automated orchestration (Tauri App Mode) and manual coordination (Manual Orchestration Mode).
 
-**Loom Repository**: https://github.com/loomhq/loom
+**Loom Repository**: https://github.com/rjwalters/loom
 
 ## Three-Layer Architecture
 
@@ -673,8 +673,8 @@ which claude
 
 ### Loom Documentation
 
-- **Main Repository**: https://github.com/loomhq/loom
-- **Getting Started**: https://github.com/loomhq/loom#getting-started
+- **Main Repository**: https://github.com/rjwalters/loom
+- **Getting Started**: https://github.com/rjwalters/loom#getting-started
 - **Role Definitions**: See `.loom/roles/*.md` in this repository
 - **Workflow Details**: See `.loom/AGENTS.md` in this repository
 
@@ -688,8 +688,8 @@ which claude
 ## Support
 
 For issues with Loom itself:
-- **GitHub Issues**: https://github.com/loomhq/loom/issues
-- **Documentation**: https://github.com/loomhq/loom/blob/main/CLAUDE.md
+- **GitHub Issues**: https://github.com/rjwalters/loom/issues
+- **Documentation**: https://github.com/rjwalters/loom/blob/main/CLAUDE.md
 
 For issues specific to this repository:
 - Use the repository's normal issue tracker

--- a/loom-daemon/src/init.rs
+++ b/loom-daemon/src/init.rs
@@ -166,8 +166,7 @@ pub fn is_loom_source_repo(workspace_path: &Path) -> bool {
     // Method 3: Check git remote for known Loom repositories
     if let Some((owner, repo)) = extract_repo_info(workspace_path) {
         // Match various Loom repository locations
-        let is_loom_repo = (owner == "loomhq" && repo == "loom")
-            || (owner == "rjwalters" && repo == "loom")
+        let is_loom_repo = (owner == "rjwalters" && repo == "loom")
             || repo == "loom" && workspace_path.join("src-tauri").is_dir();
 
         if is_loom_repo {

--- a/loom-daemon/src/metrics_collector.rs
+++ b/loom-daemon/src/metrics_collector.rs
@@ -28,7 +28,7 @@ use std::time::Duration;
 pub struct MetricsConfig {
     /// Path to workspace directory
     pub workspace_path: String,
-    /// GitHub repository owner (e.g., "loomhq")
+    /// GitHub repository owner (e.g., "rjwalters")
     pub repo_owner: String,
     /// GitHub repository name (e.g., "loom")
     pub repo_name: String,
@@ -198,7 +198,7 @@ fn validate_github_workspace(workspace_path: &str) -> Result<(String, String)> {
 ///
 /// let config = metrics_collector::MetricsConfig {
 ///     workspace_path: "/path/to/workspace".to_string(),
-///     repo_owner: "loomhq".to_string(),
+///     repo_owner: "rjwalters".to_string(),
 ///     repo_name: "loom".to_string(),
 ///     interval_secs: 900,
 ///     db_path: "/path/to/activity.db".to_string(),

--- a/quickstarts/README.md
+++ b/quickstarts/README.md
@@ -50,7 +50,7 @@ API-first backend with Cloudflare Workers and Hono.
 
 ```bash
 # Clone Loom if you haven't
-git clone https://github.com/loomhq/loom.git
+git clone https://github.com/rjwalters/loom.git
 
 # Copy template to new location
 cp -r loom/quickstarts/webapp ~/projects/my-app

--- a/quickstarts/api/README.md
+++ b/quickstarts/api/README.md
@@ -284,7 +284,7 @@ pnpm db:migrate:prod
 
 ## Learn More
 
-- [Loom Documentation](https://github.com/loomhq/loom)
+- [Loom Documentation](https://github.com/rjwalters/loom)
 - [Hono](https://hono.dev/)
 - [Cloudflare Workers](https://developers.cloudflare.com/workers/)
 - [Cloudflare D1](https://developers.cloudflare.com/d1/)

--- a/quickstarts/desktop/README.md
+++ b/quickstarts/desktop/README.md
@@ -220,7 +220,7 @@ For cross-compilation, see the [Tauri cross-compilation guide](https://tauri.app
 
 ## Learn More
 
-- [Loom Documentation](https://github.com/loomhq/loom)
+- [Loom Documentation](https://github.com/rjwalters/loom)
 - [Tauri 2.0 Guides](https://tauri.app/v2/guides/)
 - [React](https://react.dev)
 - [Tailwind CSS](https://tailwindcss.com)

--- a/quickstarts/desktop/src/pages/SettingsPage.tsx
+++ b/quickstarts/desktop/src/pages/SettingsPage.tsx
@@ -119,7 +119,7 @@ export function SettingsPage() {
               <Button
                 variant="outline"
                 className="w-full"
-                onClick={() => open("https://github.com/loomhq/loom")}
+                onClick={() => open("https://github.com/rjwalters/loom")}
               >
                 <ExternalLink className="mr-2 h-4 w-4" />
                 View on GitHub

--- a/quickstarts/webapp/README.md
+++ b/quickstarts/webapp/README.md
@@ -192,7 +192,7 @@ npx wrangler secret put MY_SECRET
 
 ## Learn More
 
-- [Loom Documentation](https://github.com/loomhq/loom)
+- [Loom Documentation](https://github.com/rjwalters/loom)
 - [Cloudflare Pages](https://developers.cloudflare.com/pages/)
 - [Cloudflare D1](https://developers.cloudflare.com/d1/)
 - [React](https://react.dev)

--- a/quickstarts/webapp/src/pages/HomePage.tsx
+++ b/quickstarts/webapp/src/pages/HomePage.tsx
@@ -29,7 +29,7 @@ export function HomePage() {
               <Link to="/login">Get Started</Link>
             </Button>
             <Button asChild variant="outline" size="lg">
-              <a href="https://github.com/loomhq/loom" target="_blank" rel="noopener noreferrer">
+              <a href="https://github.com/rjwalters/loom" target="_blank" rel="noopener noreferrer">
                 Learn More
               </a>
             </Button>

--- a/quickstarts/webapp/src/pages/__tests__/HomePage.test.tsx
+++ b/quickstarts/webapp/src/pages/__tests__/HomePage.test.tsx
@@ -60,7 +60,7 @@ describe("HomePage", () => {
     renderWithProviders(<HomePage />);
 
     const learnMoreLink = screen.getByRole("link", { name: /learn more/i });
-    expect(learnMoreLink).toHaveAttribute("href", "https://github.com/loomhq/loom");
+    expect(learnMoreLink).toHaveAttribute("href", "https://github.com/rjwalters/loom");
     expect(learnMoreLink).toHaveAttribute("target", "_blank");
     expect(learnMoreLink).toHaveAttribute("rel", "noopener noreferrer");
   });

--- a/scripts/install/create-issue.sh
+++ b/scripts/install/create-issue.sh
@@ -67,7 +67,7 @@ Loom is a multi-terminal desktop application for macOS that orchestrates AI-powe
 
 ## Repository
 
-https://github.com/loomhq/loom
+https://github.com/rjwalters/loom
 EOF
 )
 


### PR DESCRIPTION
## Summary

Replace all references to the old `loomhq/loom` repository with the correct `rjwalters/loom` repository URL. This prevents confusion when installing Loom on other projects.

## Changes

**Documentation** (15 files):
- CLAUDE.md, AGENTS.md
- defaults/CLAUDE.md, defaults/.loom/CLAUDE.md, defaults/.loom/AGENTS.md

**Rust code**:
- loom-daemon/src/init.rs - Simplified self-installation detection
- loom-daemon/src/metrics_collector.rs - Updated example and comments

**Quickstart templates**:
- quickstarts/README.md, api/README.md, desktop/README.md, webapp/README.md
- SettingsPage.tsx, HomePage.tsx and test

**Installation scripts**:
- scripts/install/create-issue.sh

## Test plan

- [x] `grep -r "loomhq" .` returns no results
- [x] All URL references now point to rjwalters/loom

🤖 Generated with [Claude Code](https://claude.com/claude-code)