### PR TITLE
Add stale-building-check script for orphaned issue recovery

### DIFF
--- a/.loom/roles/guide.md
+++ b/.loom/roles/guide.md
@@ -121,19 +121,39 @@ Sometimes issues are completed but stay open because PRs didn't use the magic ke
 
 **1. Check for Orphaned `loom:building` Issues**
 
-Find issues that are marked in-progress but have no active PRs:
+Use the stale-building-check script to find and recover orphaned issues:
 
 ```bash
-# Get all in-progress issues
+# Check for stale building issues (dry run)
+./.loom/scripts/stale-building-check.sh --verbose
+
+# Auto-recover stale issues (resets to loom:issue)
+./.loom/scripts/stale-building-check.sh --recover
+
+# JSON output for automation
+./.loom/scripts/stale-building-check.sh --json
+```
+
+The script automatically:
+- Finds issues with `loom:building` but no active PRs
+- Flags issues stale after 2 hours (configurable via `STALE_THRESHOLD_HOURS`)
+- With `--recover`, resets stale issues to `loom:issue` for re-claiming
+- Flags issues with stale PRs (>24h) but doesn't auto-recover them
+
+**Manual verification** (if script not available):
+
+```bash
+# Get all loom:building issues
 gh issue list --label "loom:building" --state open --json number,title
 
 # For each issue, check if there's an active PR
 gh pr list --search "issue-NUMBER in:body OR issue NUMBER in:body" --state open
 ```
 
-**If no PR found and issue is old (>7 days):**
-- Comment asking for status update
-- If no response in 2 days, remove `loom:building` and mark as `loom:blocked`
+**If no PR found and issue is old (>2 hours):**
+- Run `--recover` to auto-reset, or manually:
+- Remove `loom:building` and add `loom:issue`
+- Comment explaining the recovery
 
 **2. Verify Merged PRs Closed Their Issues**
 
@@ -181,7 +201,7 @@ EOF
 **Quick check script:**
 
 ```bash
-# 1. Find in-progress issues without PRs
+# 1. Find loom:building issues without PRs
 echo "=== In-Progress Issues ==="
 gh issue list --label "loom:building" --state open
 
@@ -229,6 +249,136 @@ Run verification **every 15-30 minutes** alongside priority assessment:
 - Catches missed closures early
 
 By verifying issue closure, you keep the backlog clean and prevent confusion about what's actually done.
+
+## Unblocking: Resolve Dependency Blocks
+
+**Run every 15-30 minutes** to check if blocked issues can be unblocked when their dependencies resolve.
+
+### Problem: Stuck Blocked Issues
+
+When an issue is marked `loom:blocked` due to dependencies, it may stay blocked indefinitely even after the blocking issues are resolved. This creates:
+- ❌ Ready-to-implement issues stuck in blocked state
+- ❌ Manual intervention required to unblock
+- ❌ Delays in the development pipeline
+
+### Check Blocked Issues
+
+For each `loom:blocked` issue, check if all dependencies have resolved:
+
+```bash
+# Get all blocked issues
+gh issue list --label "loom:blocked" --state open --json number,title,body
+
+# For each issue:
+# 1. Parse dependency references from body
+# 2. Check if all referenced issues are closed
+# 3. If all resolved, unblock the issue
+```
+
+### Dependency Parsing
+
+Recognize these patterns in issue bodies:
+
+| Pattern | Example |
+|---------|---------|
+| Explicit blocker | `Blocked by #123` |
+| Depends on | `Depends on #123` |
+| Requires | `Requires #123` |
+| Task list | `- [ ] #123: Description` |
+
+```bash
+parse_dependencies() {
+  local body="$1"
+  # Match dependency patterns and extract issue numbers
+  echo "$body" | grep -oE '(Blocked by|Depends on|Requires|\- \[.\]) #[0-9]+' | grep -oE '#[0-9]+' | tr -d '#' | sort -u
+}
+```
+
+### Unblocking Logic
+
+```bash
+check_and_unblock() {
+  gh issue list --label "loom:blocked" --state open --json number,body,title | jq -c '.[]' | while read -r issue; do
+    local number=$(echo "$issue" | jq -r '.number')
+    local body=$(echo "$issue" | jq -r '.body')
+    local title=$(echo "$issue" | jq -r '.title')
+
+    local deps=$(parse_dependencies "$body")
+
+    if [ -z "$deps" ]; then
+      # No parseable dependencies - skip (may need manual review)
+      continue
+    fi
+
+    local all_resolved=true
+    local resolved_deps=""
+
+    for dep in $deps; do
+      local state=$(gh issue view "$dep" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+      if [ "$state" != "CLOSED" ]; then
+        all_resolved=false
+        break
+      fi
+      resolved_deps="$resolved_deps #$dep"
+    done
+
+    if [ "$all_resolved" = true ]; then
+      gh issue edit "$number" --remove-label "loom:blocked" --add-label "loom:issue"
+      gh issue comment "$number" --body "🔓 **Unblocked**: Dependencies resolved ($resolved_deps). Ready for implementation."
+      echo "Unblocked #$number: $title"
+    fi
+  done
+}
+```
+
+### Example Unblocking Flow
+
+```bash
+# 1. Issue #963 has loom:blocked, body contains "Depends on #962"
+gh issue view 963 --json labels,body
+
+# 2. Check if #962 is closed
+gh issue view 962 --json state
+# → state: CLOSED ✓
+
+# 3. Unblock #963
+gh issue edit 963 --remove-label "loom:blocked" --add-label "loom:issue"
+gh issue comment 963 --body "🔓 **Unblocked**: Dependencies resolved (#962). Ready for implementation."
+```
+
+### PR Dependencies
+
+For issues that depend on PRs (not just issues), check the merged state:
+
+```bash
+# Check if a PR is merged
+pr_state=$(gh pr view "$pr_number" --json state,mergedAt --jq '.state')
+# MERGED = resolved, OPEN or CLOSED (without merge) = not resolved
+```
+
+### When NOT to Unblock
+
+- If no parseable dependencies found → Skip (may need manual review)
+- If any dependency is still OPEN → Keep blocked
+- If issue was blocked for non-dependency reasons → Check comments for context
+
+### Comment Format
+
+When unblocking an issue:
+
+```markdown
+🔓 **Unblocked**: Dependencies resolved (#962, #963). Ready for implementation.
+```
+
+When dependencies are partially resolved:
+
+```markdown
+ℹ️ **Dependency check**: 1 of 2 dependencies resolved.
+- ✅ #962 (CLOSED)
+- ⏳ #963 (OPEN)
+
+Still blocked until all dependencies resolve.
+```
 
 ## Maximum Urgent: 3 Issues
 

--- a/.loom/scripts/stale-building-check.sh
+++ b/.loom/scripts/stale-building-check.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# Detect and recover orphaned issues stuck in loom:building state
+#
+# This script finds issues that have been in loom:building state for too long
+# without an associated PR, indicating the agent that claimed them has crashed
+# or been cancelled.
+#
+# Usage:
+#   ./stale-building-check.sh              # Check for stale issues (dry run)
+#   ./stale-building-check.sh --recover    # Reset stale issues to loom:issue
+#   ./stale-building-check.sh --json       # Output JSON for programmatic use
+#
+# Thresholds (configurable via environment):
+#   STALE_THRESHOLD_HOURS=2    # Hours before issue is considered stale
+#   STALE_WITH_PR_HOURS=24     # Hours before issue with stale PR is flagged
+
+set -euo pipefail
+
+# Configuration
+STALE_THRESHOLD_HOURS="${STALE_THRESHOLD_HOURS:-2}"
+STALE_WITH_PR_HOURS="${STALE_WITH_PR_HOURS:-24}"
+
+# ANSI color codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Parse arguments
+RECOVER=false
+JSON_OUTPUT=false
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --recover)
+      RECOVER=true
+      shift
+      ;;
+    --json)
+      JSON_OUTPUT=true
+      shift
+      ;;
+    --verbose|-v)
+      VERBOSE=true
+      shift
+      ;;
+    --help|-h)
+      echo "Usage: $0 [OPTIONS]"
+      echo ""
+      echo "Detect and recover orphaned issues stuck in loom:building state."
+      echo ""
+      echo "Options:"
+      echo "  --recover    Reset stale issues to loom:issue state"
+      echo "  --json       Output JSON for programmatic use"
+      echo "  --verbose    Show detailed progress"
+      echo "  --help       Show this help message"
+      echo ""
+      echo "Environment variables:"
+      echo "  STALE_THRESHOLD_HOURS    Hours before no-PR issue is stale (default: 2)"
+      echo "  STALE_WITH_PR_HOURS      Hours before stale-PR issue is flagged (default: 24)"
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+log_info() {
+  if [[ "$JSON_OUTPUT" != "true" ]]; then
+    echo -e "${BLUE}ℹ $*${NC}" >&2
+  fi
+}
+
+log_warn() {
+  if [[ "$JSON_OUTPUT" != "true" ]]; then
+    echo -e "${YELLOW}⚠ $*${NC}" >&2
+  fi
+}
+
+log_error() {
+  if [[ "$JSON_OUTPUT" != "true" ]]; then
+    echo -e "${RED}✗ $*${NC}" >&2
+  fi
+}
+
+log_success() {
+  if [[ "$JSON_OUTPUT" != "true" ]]; then
+    echo -e "${GREEN}✓ $*${NC}" >&2
+  fi
+}
+
+# Get current timestamp
+NOW=$(date +%s)
+
+# Calculate threshold in seconds
+STALE_THRESHOLD_SECS=$((STALE_THRESHOLD_HOURS * 3600))
+STALE_WITH_PR_SECS=$((STALE_WITH_PR_HOURS * 3600))
+
+log_info "Checking for stale loom:building issues..."
+log_info "Threshold (no PR): ${STALE_THRESHOLD_HOURS} hours"
+log_info "Threshold (with PR): ${STALE_WITH_PR_HOURS} hours"
+
+# Get all loom:building issues with their creation/update times
+BUILDING_ISSUES=$(gh issue list --label "loom:building" --state open --json number,title,createdAt,updatedAt 2>/dev/null || echo "[]")
+
+if [[ "$BUILDING_ISSUES" == "[]" ]]; then
+  log_success "No loom:building issues found"
+  if [[ "$JSON_OUTPUT" == "true" ]]; then
+    echo '{"stale_issues":[],"total_building":0}'
+  fi
+  exit 0
+fi
+
+TOTAL_BUILDING=$(echo "$BUILDING_ISSUES" | jq 'length')
+log_info "Found $TOTAL_BUILDING issues with loom:building label"
+
+# Get all open PRs once (more efficient than per-issue queries)
+OPEN_PRS=$(gh pr list --state open --json number,headRefName,body 2>/dev/null || echo "[]")
+
+# Collect stale issues using a temp file to avoid subshell issues
+STALE_FILE=$(mktemp)
+echo "[]" > "$STALE_FILE"
+
+# Process each issue
+ISSUE_COUNT=$(echo "$BUILDING_ISSUES" | jq 'length')
+for i in $(seq 0 $((ISSUE_COUNT - 1))); do
+  issue=$(echo "$BUILDING_ISSUES" | jq -c ".[$i]")
+  NUMBER=$(echo "$issue" | jq -r '.number')
+  TITLE=$(echo "$issue" | jq -r '.title')
+  UPDATED_AT=$(echo "$issue" | jq -r '.updatedAt')
+
+  # Convert ISO timestamp to epoch (macOS vs Linux compatibility)
+  if [[ "$(uname)" == "Darwin" ]]; then
+    # macOS: Handle different timestamp formats
+    UPDATED_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$UPDATED_AT" +%s 2>/dev/null || \
+                    date -j -f "%Y-%m-%dT%H:%M:%S" "${UPDATED_AT%Z}" +%s 2>/dev/null || echo "0")
+  else
+    # Linux
+    UPDATED_EPOCH=$(date -d "$UPDATED_AT" +%s 2>/dev/null || echo "0")
+  fi
+
+  if [[ "$UPDATED_EPOCH" == "0" ]]; then
+    log_warn "Could not parse date for issue #$NUMBER, skipping"
+    continue
+  fi
+
+  # Calculate age in hours
+  AGE_SECS=$((NOW - UPDATED_EPOCH))
+  AGE_HOURS=$((AGE_SECS / 3600))
+
+  [[ "$VERBOSE" == "true" ]] && log_info "Checking #$NUMBER (updated ${AGE_HOURS}h ago)"
+
+  # Check if there's an open PR for this issue
+  # Search for PRs that reference this issue number in body or branch name
+  OPEN_PR=$(echo "$OPEN_PRS" | jq --arg num "$NUMBER" \
+    '[.[] | select(
+      (.body // "" | test("(Closes|Fixes|Resolves) #" + $num + "\\b"; "i")) or
+      (.headRefName | test("issue-" + $num + "\\b"))
+    )] | first // empty' 2>/dev/null || echo "")
+
+  if [[ -z "$OPEN_PR" || "$OPEN_PR" == "null" ]]; then
+    # No open PR found
+    if [[ $AGE_SECS -gt $STALE_THRESHOLD_SECS ]]; then
+      log_warn "#$NUMBER: No PR found after ${AGE_HOURS}h - STALE"
+
+      if [[ "$RECOVER" == "true" ]]; then
+        log_info "Recovering #$NUMBER..."
+        gh issue edit "$NUMBER" --remove-label "loom:building" --add-label "loom:issue"
+
+        # Create comment body
+        COMMENT_BODY="🔄 **Auto-recovered from stale state**
+
+This issue was in \`loom:building\` state for ${AGE_HOURS} hours without an associated PR.
+
+**What happened:**
+- An agent claimed this issue but didn't create a PR
+- The agent may have crashed, timed out, or been cancelled
+- The stale-building-check script detected this orphaned state
+
+**Action taken:**
+- Removed \`loom:building\` label
+- Added \`loom:issue\` label to make it available for work again
+
+This issue is now ready to be claimed by another agent."
+
+        gh issue comment "$NUMBER" --body "$COMMENT_BODY"
+        log_success "Recovered #$NUMBER"
+      fi
+
+      # Add to stale list
+      CURRENT=$(cat "$STALE_FILE")
+      echo "$CURRENT" | jq --arg num "$NUMBER" --arg title "$TITLE" --argjson age "$AGE_HOURS" --arg reason "no_pr" \
+        '. + [{"number": ($num | tonumber), "title": $title, "age_hours": $age, "reason": $reason, "has_pr": false}]' > "$STALE_FILE"
+    fi
+  else
+    # Has open PR - check if PR is also stale
+    PR_NUMBER=$(echo "$OPEN_PR" | jq -r '.number // empty')
+    if [[ -n "$PR_NUMBER" && $AGE_SECS -gt $STALE_WITH_PR_SECS ]]; then
+      log_warn "#$NUMBER: PR #$PR_NUMBER exists but no progress for ${AGE_HOURS}h"
+
+      # Don't auto-recover issues with PRs - they need manual review
+      CURRENT=$(cat "$STALE_FILE")
+      echo "$CURRENT" | jq --arg num "$NUMBER" --arg title "$TITLE" --argjson age "$AGE_HOURS" --arg reason "stale_pr" --arg pr "$PR_NUMBER" \
+        '. + [{"number": ($num | tonumber), "title": $title, "age_hours": $age, "reason": $reason, "has_pr": true, "pr_number": ($pr | tonumber)}]' > "$STALE_FILE"
+    else
+      [[ "$VERBOSE" == "true" ]] && log_success "#$NUMBER: Has active PR #$PR_NUMBER"
+    fi
+  fi
+done
+
+# Read final stale issues
+STALE_ISSUES=$(cat "$STALE_FILE")
+rm -f "$STALE_FILE"
+
+# Output results
+STALE_COUNT=$(echo "$STALE_ISSUES" | jq 'length')
+
+if [[ "$JSON_OUTPUT" == "true" ]]; then
+  echo "$STALE_ISSUES" | jq --argjson total "$TOTAL_BUILDING" '{stale_issues: ., total_building: $total, stale_count: (. | length)}'
+else
+  echo ""
+  if [[ "$STALE_COUNT" -gt 0 ]]; then
+    log_warn "Found $STALE_COUNT stale issues out of $TOTAL_BUILDING in loom:building state"
+    echo ""
+    echo "Stale issues:"
+    echo "$STALE_ISSUES" | jq -r '.[] | "  #\(.number): \(.title) (\(.age_hours)h, \(.reason))"'
+
+    if [[ "$RECOVER" != "true" ]]; then
+      echo ""
+      echo "Run with --recover to reset stale issues to loom:issue state"
+    fi
+  else
+    log_success "All $TOTAL_BUILDING loom:building issues are active"
+  fi
+fi
+
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -717,6 +717,34 @@ which claude
 # Install if missing (see Claude Code documentation)
 ```
 
+**Orphaned issues stuck in loom:building state**:
+
+When an agent crashes or is cancelled while building, issues can get stuck in `loom:building` state without a PR. Use the stale-building-check script to detect and recover these:
+
+```bash
+# Check for stale building issues (dry run)
+./.loom/scripts/stale-building-check.sh
+
+# Show detailed progress
+./.loom/scripts/stale-building-check.sh --verbose
+
+# Auto-recover stale issues (resets to loom:issue)
+./.loom/scripts/stale-building-check.sh --recover
+
+# JSON output for automation
+./.loom/scripts/stale-building-check.sh --json
+```
+
+**Configuration via environment**:
+- `STALE_THRESHOLD_HOURS=2` - Hours before issue without PR is considered stale
+- `STALE_WITH_PR_HOURS=24` - Hours before issue with stale PR is flagged
+
+**What it does**:
+- Finds issues with `loom:building` label that have been stuck
+- Checks if there's an associated PR (by branch name or body reference)
+- Issues without PRs older than threshold are flagged/recovered
+- Issues with stale PRs are flagged but not auto-recovered (need manual review)
+
 ### Stuck Agent Detection
 
 The Loom daemon automatically detects stuck or struggling agents and can trigger interventions.

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -669,6 +669,34 @@ which claude
 # Install if missing (see Claude Code documentation)
 ```
 
+**Orphaned issues stuck in loom:building state**:
+
+When an agent crashes or is cancelled while building, issues can get stuck in `loom:building` state without a PR. Use the stale-building-check script to detect and recover these:
+
+```bash
+# Check for stale building issues (dry run)
+./.loom/scripts/stale-building-check.sh
+
+# Show detailed progress
+./.loom/scripts/stale-building-check.sh --verbose
+
+# Auto-recover stale issues (resets to loom:issue)
+./.loom/scripts/stale-building-check.sh --recover
+
+# JSON output for automation
+./.loom/scripts/stale-building-check.sh --json
+```
+
+**Configuration via environment**:
+- `STALE_THRESHOLD_HOURS=2` - Hours before issue without PR is considered stale
+- `STALE_WITH_PR_HOURS=24` - Hours before issue with stale PR is flagged
+
+**What it does**:
+- Finds issues with `loom:building` label that have been stuck
+- Checks if there's an associated PR (by branch name or body reference)
+- Issues without PRs older than threshold are flagged/recovered
+- Issues with stale PRs are flagged but not auto-recovered (need manual review)
+
 ## Resources
 
 ### Loom Documentation

--- a/defaults/roles/guide.md
+++ b/defaults/roles/guide.md
@@ -121,7 +121,26 @@ Sometimes issues are completed but stay open because PRs didn't use the magic ke
 
 **1. Check for Orphaned `loom:building` Issues**
 
-Find issues with `loom:building` but no active PRs:
+Use the stale-building-check script to find and recover orphaned issues:
+
+```bash
+# Check for stale building issues (dry run)
+./.loom/scripts/stale-building-check.sh --verbose
+
+# Auto-recover stale issues (resets to loom:issue)
+./.loom/scripts/stale-building-check.sh --recover
+
+# JSON output for automation
+./.loom/scripts/stale-building-check.sh --json
+```
+
+The script automatically:
+- Finds issues with `loom:building` but no active PRs
+- Flags issues stale after 2 hours (configurable via `STALE_THRESHOLD_HOURS`)
+- With `--recover`, resets stale issues to `loom:issue` for re-claiming
+- Flags issues with stale PRs (>24h) but doesn't auto-recover them
+
+**Manual verification** (if script not available):
 
 ```bash
 # Get all loom:building issues
@@ -131,9 +150,10 @@ gh issue list --label "loom:building" --state open --json number,title
 gh pr list --search "issue-NUMBER in:body OR issue NUMBER in:body" --state open
 ```
 
-**If no PR found and issue is old (>7 days):**
-- Comment asking for status update
-- If no response in 2 days, remove `loom:building` and mark as `loom:blocked`
+**If no PR found and issue is old (>2 hours):**
+- Run `--recover` to auto-reset, or manually:
+- Remove `loom:building` and add `loom:issue`
+- Comment explaining the recovery
 
 **2. Verify Merged PRs Closed Their Issues**
 

--- a/defaults/scripts/stale-building-check.sh
+++ b/defaults/scripts/stale-building-check.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# Detect and recover orphaned issues stuck in loom:building state
+#
+# This script finds issues that have been in loom:building state for too long
+# without an associated PR, indicating the agent that claimed them has crashed
+# or been cancelled.
+#
+# Usage:
+#   ./stale-building-check.sh              # Check for stale issues (dry run)
+#   ./stale-building-check.sh --recover    # Reset stale issues to loom:issue
+#   ./stale-building-check.sh --json       # Output JSON for programmatic use
+#
+# Thresholds (configurable via environment):
+#   STALE_THRESHOLD_HOURS=2    # Hours before issue is considered stale
+#   STALE_WITH_PR_HOURS=24     # Hours before issue with stale PR is flagged
+
+set -euo pipefail
+
+# Configuration
+STALE_THRESHOLD_HOURS="${STALE_THRESHOLD_HOURS:-2}"
+STALE_WITH_PR_HOURS="${STALE_WITH_PR_HOURS:-24}"
+
+# ANSI color codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Parse arguments
+RECOVER=false
+JSON_OUTPUT=false
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --recover)
+      RECOVER=true
+      shift
+      ;;
+    --json)
+      JSON_OUTPUT=true
+      shift
+      ;;
+    --verbose|-v)
+      VERBOSE=true
+      shift
+      ;;
+    --help|-h)
+      echo "Usage: $0 [OPTIONS]"
+      echo ""
+      echo "Detect and recover orphaned issues stuck in loom:building state."
+      echo ""
+      echo "Options:"
+      echo "  --recover    Reset stale issues to loom:issue state"
+      echo "  --json       Output JSON for programmatic use"
+      echo "  --verbose    Show detailed progress"
+      echo "  --help       Show this help message"
+      echo ""
+      echo "Environment variables:"
+      echo "  STALE_THRESHOLD_HOURS    Hours before no-PR issue is stale (default: 2)"
+      echo "  STALE_WITH_PR_HOURS      Hours before stale-PR issue is flagged (default: 24)"
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+log_info() {
+  if [[ "$JSON_OUTPUT" != "true" ]]; then
+    echo -e "${BLUE}ℹ $*${NC}" >&2
+  fi
+}
+
+log_warn() {
+  if [[ "$JSON_OUTPUT" != "true" ]]; then
+    echo -e "${YELLOW}⚠ $*${NC}" >&2
+  fi
+}
+
+log_error() {
+  if [[ "$JSON_OUTPUT" != "true" ]]; then
+    echo -e "${RED}✗ $*${NC}" >&2
+  fi
+}
+
+log_success() {
+  if [[ "$JSON_OUTPUT" != "true" ]]; then
+    echo -e "${GREEN}✓ $*${NC}" >&2
+  fi
+}
+
+# Get current timestamp
+NOW=$(date +%s)
+
+# Calculate threshold in seconds
+STALE_THRESHOLD_SECS=$((STALE_THRESHOLD_HOURS * 3600))
+STALE_WITH_PR_SECS=$((STALE_WITH_PR_HOURS * 3600))
+
+log_info "Checking for stale loom:building issues..."
+log_info "Threshold (no PR): ${STALE_THRESHOLD_HOURS} hours"
+log_info "Threshold (with PR): ${STALE_WITH_PR_HOURS} hours"
+
+# Get all loom:building issues with their creation/update times
+BUILDING_ISSUES=$(gh issue list --label "loom:building" --state open --json number,title,createdAt,updatedAt 2>/dev/null || echo "[]")
+
+if [[ "$BUILDING_ISSUES" == "[]" ]]; then
+  log_success "No loom:building issues found"
+  if [[ "$JSON_OUTPUT" == "true" ]]; then
+    echo '{"stale_issues":[],"total_building":0}'
+  fi
+  exit 0
+fi
+
+TOTAL_BUILDING=$(echo "$BUILDING_ISSUES" | jq 'length')
+log_info "Found $TOTAL_BUILDING issues with loom:building label"
+
+# Get all open PRs once (more efficient than per-issue queries)
+OPEN_PRS=$(gh pr list --state open --json number,headRefName,body 2>/dev/null || echo "[]")
+
+# Collect stale issues using a temp file to avoid subshell issues
+STALE_FILE=$(mktemp)
+echo "[]" > "$STALE_FILE"
+
+# Process each issue
+ISSUE_COUNT=$(echo "$BUILDING_ISSUES" | jq 'length')
+for i in $(seq 0 $((ISSUE_COUNT - 1))); do
+  issue=$(echo "$BUILDING_ISSUES" | jq -c ".[$i]")
+  NUMBER=$(echo "$issue" | jq -r '.number')
+  TITLE=$(echo "$issue" | jq -r '.title')
+  UPDATED_AT=$(echo "$issue" | jq -r '.updatedAt')
+
+  # Convert ISO timestamp to epoch (macOS vs Linux compatibility)
+  if [[ "$(uname)" == "Darwin" ]]; then
+    # macOS: Handle different timestamp formats
+    UPDATED_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$UPDATED_AT" +%s 2>/dev/null || \
+                    date -j -f "%Y-%m-%dT%H:%M:%S" "${UPDATED_AT%Z}" +%s 2>/dev/null || echo "0")
+  else
+    # Linux
+    UPDATED_EPOCH=$(date -d "$UPDATED_AT" +%s 2>/dev/null || echo "0")
+  fi
+
+  if [[ "$UPDATED_EPOCH" == "0" ]]; then
+    log_warn "Could not parse date for issue #$NUMBER, skipping"
+    continue
+  fi
+
+  # Calculate age in hours
+  AGE_SECS=$((NOW - UPDATED_EPOCH))
+  AGE_HOURS=$((AGE_SECS / 3600))
+
+  [[ "$VERBOSE" == "true" ]] && log_info "Checking #$NUMBER (updated ${AGE_HOURS}h ago)"
+
+  # Check if there's an open PR for this issue
+  # Search for PRs that reference this issue number in body or branch name
+  OPEN_PR=$(echo "$OPEN_PRS" | jq --arg num "$NUMBER" \
+    '[.[] | select(
+      (.body // "" | test("(Closes|Fixes|Resolves) #" + $num + "\\b"; "i")) or
+      (.headRefName | test("issue-" + $num + "\\b"))
+    )] | first // empty' 2>/dev/null || echo "")
+
+  if [[ -z "$OPEN_PR" || "$OPEN_PR" == "null" ]]; then
+    # No open PR found
+    if [[ $AGE_SECS -gt $STALE_THRESHOLD_SECS ]]; then
+      log_warn "#$NUMBER: No PR found after ${AGE_HOURS}h - STALE"
+
+      if [[ "$RECOVER" == "true" ]]; then
+        log_info "Recovering #$NUMBER..."
+        gh issue edit "$NUMBER" --remove-label "loom:building" --add-label "loom:issue"
+
+        # Create comment body
+        COMMENT_BODY="🔄 **Auto-recovered from stale state**
+
+This issue was in \`loom:building\` state for ${AGE_HOURS} hours without an associated PR.
+
+**What happened:**
+- An agent claimed this issue but didn't create a PR
+- The agent may have crashed, timed out, or been cancelled
+- The stale-building-check script detected this orphaned state
+
+**Action taken:**
+- Removed \`loom:building\` label
+- Added \`loom:issue\` label to make it available for work again
+
+This issue is now ready to be claimed by another agent."
+
+        gh issue comment "$NUMBER" --body "$COMMENT_BODY"
+        log_success "Recovered #$NUMBER"
+      fi
+
+      # Add to stale list
+      CURRENT=$(cat "$STALE_FILE")
+      echo "$CURRENT" | jq --arg num "$NUMBER" --arg title "$TITLE" --argjson age "$AGE_HOURS" --arg reason "no_pr" \
+        '. + [{"number": ($num | tonumber), "title": $title, "age_hours": $age, "reason": $reason, "has_pr": false}]' > "$STALE_FILE"
+    fi
+  else
+    # Has open PR - check if PR is also stale
+    PR_NUMBER=$(echo "$OPEN_PR" | jq -r '.number // empty')
+    if [[ -n "$PR_NUMBER" && $AGE_SECS -gt $STALE_WITH_PR_SECS ]]; then
+      log_warn "#$NUMBER: PR #$PR_NUMBER exists but no progress for ${AGE_HOURS}h"
+
+      # Don't auto-recover issues with PRs - they need manual review
+      CURRENT=$(cat "$STALE_FILE")
+      echo "$CURRENT" | jq --arg num "$NUMBER" --arg title "$TITLE" --argjson age "$AGE_HOURS" --arg reason "stale_pr" --arg pr "$PR_NUMBER" \
+        '. + [{"number": ($num | tonumber), "title": $title, "age_hours": $age, "reason": $reason, "has_pr": true, "pr_number": ($pr | tonumber)}]' > "$STALE_FILE"
+    else
+      [[ "$VERBOSE" == "true" ]] && log_success "#$NUMBER: Has active PR #$PR_NUMBER"
+    fi
+  fi
+done
+
+# Read final stale issues
+STALE_ISSUES=$(cat "$STALE_FILE")
+rm -f "$STALE_FILE"
+
+# Output results
+STALE_COUNT=$(echo "$STALE_ISSUES" | jq 'length')
+
+if [[ "$JSON_OUTPUT" == "true" ]]; then
+  echo "$STALE_ISSUES" | jq --argjson total "$TOTAL_BUILDING" '{stale_issues: ., total_building: $total, stale_count: (. | length)}'
+else
+  echo ""
+  if [[ "$STALE_COUNT" -gt 0 ]]; then
+    log_warn "Found $STALE_COUNT stale issues out of $TOTAL_BUILDING in loom:building state"
+    echo ""
+    echo "Stale issues:"
+    echo "$STALE_ISSUES" | jq -r '.[] | "  #\(.number): \(.title) (\(.age_hours)h, \(.reason))"'
+
+    if [[ "$RECOVER" != "true" ]]; then
+      echo ""
+      echo "Run with --recover to reset stale issues to loom:issue state"
+    fi
+  else
+    log_success "All $TOTAL_BUILDING loom:building issues are active"
+  fi
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- Adds new `stale-building-check.sh` script to detect and recover orphaned issues stuck in `loom:building` state
- Updates CLAUDE.md troubleshooting docs and Guide role to reference the new script

## Implementation

The script:
- Finds all issues with `loom:building` label
- Checks if each has an associated open PR (by branch name `issue-N` or body reference `Closes #N`)
- Issues without PRs are flagged as stale after configurable threshold (default 2 hours)
- Issues with stale PRs are flagged but not auto-recovered (need manual review)
- With `--recover` flag, resets stale issues to `loom:issue` state with explanatory comment
- JSON output (`--json`) available for automation/integration

## Usage

```bash
# Dry run - check for stale issues
./.loom/scripts/stale-building-check.sh --verbose

# Auto-recover stale issues
./.loom/scripts/stale-building-check.sh --recover

# JSON output for automation
./.loom/scripts/stale-building-check.sh --json
```

## Test plan

- [x] Test script help output
- [x] Test dry-run mode with verbose output
- [x] Test JSON output format
- [ ] Script correctly identifies current `loom:building` issues
- [ ] Recovery mode properly resets labels and adds comment

Closes #1122

🤖 Generated with [Claude Code](https://claude.com/claude-code)