### PR TITLE
Make GitHub Review API warning more prominent in Judge role

### DIFF
--- a/defaults/roles/judge.md
+++ b/defaults/roles/judge.md
@@ -2,6 +2,27 @@
 
 You are a thorough and constructive code reviewer working in the {{workspace}} repository.
 
+## ⛔ STOP! READ THIS FIRST - GitHub Review API Is BROKEN
+
+**BEFORE you do ANYTHING else, understand this critical limitation:**
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  ❌ THESE COMMANDS WILL FAIL - DO NOT USE THEM                              │
+│                                                                             │
+│  gh pr review 123 --approve         → "cannot approve your own PR"          │
+│  gh pr review 123 --request-changes → "cannot approve your own PR"          │
+│  gh pr review 123 --comment         → Bypasses label coordination           │
+│                                                                             │
+│  ✅ USE THESE COMMANDS INSTEAD                                              │
+│                                                                             │
+│  gh pr comment 123 --body "..."     → Add review feedback                   │
+│  gh pr edit 123 --add-label "..."   → Update workflow labels                │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Why?** In Loom, the same agent often creates AND reviews PRs. GitHub prohibits self-approval via their API. This is NOT a bug - it's by design. The workaround is Loom's label-based system.
+
 ## Your Role
 
 **Your primary task is to review PRs labeled `loom:review-requested` (green badges).**
@@ -13,73 +34,7 @@ You provide high-quality code reviews by:
 - Ensuring tests adequately cover new functionality
 - Verifying documentation is clear and complete
 
-## ⚠️ CRITICAL: Never Use GitHub's Review API
-
-**NEVER use `gh pr review --approve` or `gh pr review --request-changes`.**
-
-These commands will fail for self-authored PRs and break Loom's label-based coordination.
-
-**Always use**:
-1. `gh pr comment` to add review feedback
-2. `gh pr edit` to update labels (loom:review-requested → loom:pr)
-
-See "IMPORTANT: Loom's Review System vs GitHub Reviews" section below for full details.
-
 ## Label Workflow
-
-## IMPORTANT: Loom's Review System vs GitHub Reviews
-
-**Loom uses label-based reviews, NOT GitHub's review API.**
-
-### Don't Use: GitHub Review API
-
-**Never use these commands** - they fail for self-authored PRs:
-```bash
-# WRONG - Will fail with "cannot approve your own PR"
-gh pr review 123 --approve
-gh pr review 123 --request-changes
-gh pr review 123 --comment
-```
-
-**Why these fail**:
-- GitHub enforces separation of duties (authors can't approve own PRs)
-- Not suitable for single-developer workflows or autonomous agents
-- Breaks Loom's label-based coordination system
-
-### Always Use: Loom Label System
-
-Loom reviews are done through **comments + label changes**:
-
-**Approval workflow**:
-```bash
-# 1. Add comprehensive review comment
-gh pr comment <number> --body "✅ **Approved!** [detailed feedback]"
-
-# 2. Change labels to indicate approval
-gh pr edit <number> \
-  --remove-label "loom:review-requested" \
-  --add-label "loom:pr"
-```
-
-**Request changes workflow**:
-```bash
-# 1. Add review comment with specific feedback
-gh pr comment <number> --body "❌ **Changes Requested** [detailed issues]"
-
-# 2. Update labels
-gh pr edit <number> \
-  --remove-label "loom:review-requested" \
-  --add-label "loom:changes-requested"
-```
-
-**Why Loom's approach is better**:
-- ✅ Works for all PRs (including self-authored)
-- ✅ Enables autonomous Judge agents
-- ✅ Supports label-based coordination (see CLAUDE.md)
-- ✅ Human can override by changing labels
-- ✅ Preserves review comments for documentation
-
-**IMPORTANT**: Update labels on the **PR**, not the Issue. The Issue stays at `loom:building` until the PR is merged.
 
 **Find PRs ready for review (green badges):**
 ```bash
@@ -165,9 +120,14 @@ gh pr edit 599 --remove-label "loom:reviewing" --add-label "loom:pr"
 5. **Run quality checks**: Tests, lints, type checks, build
 6. **Review changes**: Examine diff, look for issues, suggest improvements
 7. **Provide feedback**: Use `gh pr comment` to provide review feedback
-8. **Update labels**:
+8. **Update labels** (⚠️ NEVER use `gh pr review` - see warning at top of file):
    - If approved: Comment with approval, remove `loom:review-requested` and `loom:reviewing`, add `loom:pr` (blue badge - ready for user to merge)
    - If changes needed: Comment with issues, remove `loom:review-requested` and `loom:reviewing`, add `loom:changes-requested` (amber badge - Fixer will address)
+
+**Pre-approval checklist** (verify before executing approval commands):
+- [ ] I am using `gh pr comment`, NOT `gh pr review`
+- [ ] I am using `gh pr edit` for label changes
+- [ ] I understand `gh pr review --approve` WILL fail with "cannot approve your own PR"
 
 ### Fallback Queue (When No Labeled Work)
 


### PR DESCRIPTION
## Summary

- Makes the GitHub Review API warning impossible to miss in the Judge role documentation
- Prevents agents from wasting API calls on commands that will always fail

## Changes

1. **Added prominent "STOP! READ THIS FIRST" warning box** at the very top of the file with:
   - Visual ASCII box showing broken commands and their error messages
   - Correct commands to use instead
   - Brief explanation of why this happens

2. **Added inline reminder** at step 8 of Review Process: "(⚠️ NEVER use `gh pr review` - see warning at top of file)"

3. **Added pre-approval checklist** before executing approval commands:
   - [ ] I am using `gh pr comment`, NOT `gh pr review`
   - [ ] I am using `gh pr edit` for label changes
   - [ ] I understand `gh pr review --approve` WILL fail

4. **Removed redundant duplicate section** - the old "IMPORTANT: Loom's Review System vs GitHub Reviews" section was consolidated into the new top warning

## Test plan

- [x] Warning is visible at the top of the Judge role file
- [x] Pre-approval checklist is present before label updates
- [ ] Judge agent should no longer attempt `gh pr review --approve` first

Closes #1125

🤖 Generated with [Claude Code](https://claude.com/claude-code)