### PR TITLE
Change default shepherd merge behavior from --force-merge to --force-pr

### DIFF
--- a/.loom/roles/loom.md
+++ b/.loom/roles/loom.md
@@ -127,7 +127,7 @@ In Manual Orchestration Mode, use the **Task tool with `run_in_background: true`
 ```
 Task(
   subagent_type: "general-purpose",
-  prompt: "/shepherd 123 --force-merge",
+  prompt: "/shepherd 123 --force-pr",
   run_in_background: true
 ) → Returns task_id and output_file
 ```
@@ -212,7 +212,7 @@ def auto_spawn_shepherds():
         # Spawn shepherd subagent
         Task(
             description=f"Shepherd issue #{issue}",
-            prompt=f"/shepherd {issue} --force-merge",
+            prompt=f"/shepherd {issue} --force-pr",
             run_in_background=True
         )
 
@@ -475,7 +475,7 @@ def auto_spawn_shepherds():
         # Spawn shepherd
         result = Task(
             description=f"Shepherd issue #{issue}",
-            prompt=f"/shepherd {issue} --force-merge",
+            prompt=f"/shepherd {issue} --force-pr",
             run_in_background=True
         )
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ Loom uses a three-layer orchestration architecture for scalable automation:
 **Layer 1 (Shepherds)**:
 - Fully autonomous once spawned
 - Handles entire issue lifecycle including Judge review
-- Uses `--force-merge` for autonomous operation or waits for human merge
+- Uses `--force-pr` by default (stops at ready-to-merge), or `--force-merge` for full automation
 
 ### When to Use Which Layer
 
@@ -229,8 +229,8 @@ Loom provides specialized roles for different development tasks. Each role follo
 **Champion** (Autonomous 10min, `champion.md`)
 - **Purpose**: Auto-merge approved PRs
 - **Workflow**: Finds `loom:pr` PRs → verifies safety criteria → auto-merges if safe
-- **When to use**: Manual orchestration mode where humans review before merge
-- **Note**: Not needed when shepherds use `--force-merge` (shepherds handle their own merges)
+- **When to use**: Default daemon mode with `--force-pr` (human reviews PR before Champion merges)
+- **Note**: Not used when shepherds run with `--force-merge` (shepherds handle their own merges)
 
 **Curator** (Autonomous 5min, `curator.md`)
 - **Purpose**: Enhance and organize issues

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -206,8 +206,8 @@ Loom provides specialized roles for different development tasks. Each role follo
 **Champion** (Autonomous 10min, `champion.md`)
 - **Purpose**: Auto-merge approved PRs
 - **Workflow**: Finds `loom:pr` PRs → verifies safety criteria → auto-merges if safe
-- **When to use**: Manual orchestration mode where humans review before merge
-- **Note**: Not needed when shepherds use `--force-merge` mode
+- **When to use**: Default daemon mode with `--force-pr` (human reviews PR before Champion merges)
+- **Note**: Not used when shepherds run with `--force-merge` (shepherds handle their own merges)
 
 **Curator** (Autonomous 5min, `curator.md`)
 - **Purpose**: Enhance and organize issues

--- a/defaults/roles/loom.md
+++ b/defaults/roles/loom.md
@@ -73,7 +73,7 @@ In Manual Orchestration Mode, use the **Task tool with `run_in_background: true`
 ```
 Task(
   subagent_type: "general-purpose",
-  prompt: "/shepherd 123 --force-merge",
+  prompt: "/shepherd 123 --force-pr",
   run_in_background: true
 ) → Returns task_id and output_file
 ```
@@ -146,7 +146,7 @@ def auto_spawn_shepherds():
         # Spawn shepherd subagent
         Task(
             description=f"Shepherd issue #{issue}",
-            prompt=f"/shepherd {issue} --force-merge",
+            prompt=f"/shepherd {issue} --force-pr",
             run_in_background=True
         )
 
@@ -404,7 +404,7 @@ def auto_spawn_shepherds():
         # Spawn shepherd
         result = Task(
             description=f"Shepherd issue #{issue}",
-            prompt=f"/shepherd {issue} --force-merge",
+            prompt=f"/shepherd {issue} --force-pr",
             run_in_background=True
         )
 


### PR DESCRIPTION
## Summary

- Change daemon's default shepherd spawn behavior from `--force-merge` to `--force-pr`
- Provides safer default where humans review PRs before merge
- Champion role handles merging approved PRs on its interval
- Users can still use `--force-merge` for fully automated operation

## Changes

| File | Change |
|------|--------|
| `defaults/roles/loom.md` | Update 3 spawn locations to use `--force-pr` |
| `.loom/roles/loom.md` | Same changes (installed copy) |
| `CLAUDE.md` | Update documentation for new default |
| `defaults/CLAUDE.md` | Update documentation (installation template) |

## Workflow Change

**Before (--force-merge default):**
```
Daemon → Shepherd --force-merge → Auto-merge after Judge
```

**After (--force-pr default):**
```
Daemon → Shepherd --force-pr → Stops at loom:pr → Champion merges
                                    ↑
                             Human reviews here
```

## Test plan

- [ ] Verify daemon spawns shepherds with `--force-pr` flag
- [ ] Verify PRs stop at `loom:pr` label waiting for merge
- [ ] Verify Champion role picks up and merges approved PRs
- [ ] Verify `--force-merge` still works when explicitly configured

Closes #1127

🤖 Generated with [Claude Code](https://claude.com/claude-code)