### PR TITLE
Preserve existing CLAUDE.md content during Loom installation

### DIFF
--- a/loom-daemon/src/init.rs
+++ b/loom-daemon/src/init.rs
@@ -200,7 +200,9 @@ fn validate_loom_source_repo(workspace_path: &Path) -> ValidationReport {
             }
         }
     } else {
-        report.issues.push("Missing .loom/roles/ directory".to_string());
+        report
+            .issues
+            .push("Missing .loom/roles/ directory".to_string());
     }
 
     // Check scripts
@@ -211,13 +213,17 @@ fn validate_loom_source_repo(workspace_path: &Path) -> ValidationReport {
                 let path = entry.path();
                 if path.extension().is_some_and(|e| e == "sh") {
                     if let Some(name) = path.file_stem() {
-                        report.scripts_found.push(name.to_string_lossy().to_string());
+                        report
+                            .scripts_found
+                            .push(name.to_string_lossy().to_string());
                     }
                 }
             }
         }
     } else {
-        report.issues.push("Missing .loom/scripts/ directory".to_string());
+        report
+            .issues
+            .push("Missing .loom/scripts/ directory".to_string());
     }
 
     // Check .claude/commands/
@@ -228,13 +234,17 @@ fn validate_loom_source_repo(workspace_path: &Path) -> ValidationReport {
                 let path = entry.path();
                 if path.extension().is_some_and(|e| e == "md") {
                     if let Some(name) = path.file_stem() {
-                        report.commands_found.push(name.to_string_lossy().to_string());
+                        report
+                            .commands_found
+                            .push(name.to_string_lossy().to_string());
                     }
                 }
             }
         }
     } else {
-        report.issues.push("Missing .claude/commands/ directory".to_string());
+        report
+            .issues
+            .push("Missing .claude/commands/ directory".to_string());
     }
 
     // Check documentation files
@@ -249,10 +259,7 @@ fn validate_loom_source_repo(workspace_path: &Path) -> ValidationReport {
     }
 
     // Check labels.yml
-    report.has_labels_yml = workspace_path
-        .join(".github")
-        .join("labels.yml")
-        .exists();
+    report.has_labels_yml = workspace_path.join(".github").join("labels.yml").exists();
     if !report.has_labels_yml {
         report.issues.push("Missing .github/labels.yml".to_string());
     }
@@ -266,10 +273,9 @@ fn validate_loom_source_repo(workspace_path: &Path) -> ValidationReport {
     }
 
     if report.scripts_found.len() < 2 {
-        report.issues.push(format!(
-            "Expected at least 2 scripts, found {}",
-            report.scripts_found.len()
-        ));
+        report
+            .issues
+            .push(format!("Expected at least 2 scripts, found {}", report.scripts_found.len()));
     }
 
     if report.commands_found.len() < 4 {
@@ -783,6 +789,113 @@ fn force_merge_dir_with_report(
     Ok(())
 }
 
+/// Loom section markers for CLAUDE.md content preservation
+const LOOM_SECTION_START: &str = "<!-- BEGIN LOOM ORCHESTRATION -->";
+const LOOM_SECTION_END: &str = "<!-- END LOOM ORCHESTRATION -->";
+
+/// Check if content appears to be project-specific (not just Loom template)
+///
+/// Returns true if the content contains substantive project documentation
+/// beyond just the Loom boilerplate.
+fn has_project_specific_content(content: &str) -> bool {
+    let trimmed = content.trim();
+
+    // Empty or very short content is not project-specific
+    if trimmed.is_empty() || trimmed.len() < 20 {
+        return false;
+    }
+
+    // If it has our section markers, check for content outside the Loom section
+    if content.contains(LOOM_SECTION_START) && content.contains(LOOM_SECTION_END) {
+        if let (Some(start_idx), Some(end_idx)) =
+            (content.find(LOOM_SECTION_START), content.find(LOOM_SECTION_END))
+        {
+            let before_loom = content[..start_idx].trim();
+            let after_end = end_idx + LOOM_SECTION_END.len();
+            let after_loom = if after_end < content.len() {
+                content[after_end..].trim()
+            } else {
+                ""
+            };
+
+            // Has project content if there's meaningful content before or after the Loom section
+            return (!before_loom.is_empty() && before_loom.len() > 20)
+                || (!after_loom.is_empty() && after_loom.len() > 20);
+        }
+    }
+
+    // Check for indicators that this is NOT just the Loom template
+    // The Loom template starts with "# Loom Orchestration - Repository Guide"
+    let is_loom_template = content.contains("# Loom Orchestration - Repository Guide")
+        || content.contains("This repository uses **Loom** for AI-powered development");
+
+    if !is_loom_template {
+        // Definitely project-specific if it doesn't have Loom template markers
+        return true;
+    }
+
+    // Check if there's content BEFORE the Loom header that looks project-specific
+    if let Some(loom_header_idx) = content.find("# Loom Orchestration") {
+        let before_header = content[..loom_header_idx].trim();
+        if !before_header.is_empty() && before_header.len() > 50 {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// Extract project-specific content from existing CLAUDE.md
+///
+/// If the file uses section markers, extracts content outside the Loom section.
+/// Otherwise, if it's clearly project-specific content, returns all of it.
+fn extract_project_content(content: &str) -> Option<String> {
+    // First, check if we have section markers
+    if let (Some(start), Some(end)) =
+        (content.find(LOOM_SECTION_START), content.find(LOOM_SECTION_END))
+    {
+        // Extract content before the Loom section
+        let before = content[..start].trim();
+        // Extract content after the Loom section (after the end marker)
+        let after_end = end + LOOM_SECTION_END.len();
+        let after = if after_end < content.len() {
+            content[after_end..].trim()
+        } else {
+            ""
+        };
+
+        let mut project_content = String::new();
+        if !before.is_empty() {
+            project_content.push_str(before);
+        }
+        if !after.is_empty() {
+            if !project_content.is_empty() {
+                project_content.push_str("\n\n");
+            }
+            project_content.push_str(after);
+        }
+
+        if !project_content.is_empty() {
+            return Some(project_content);
+        }
+    }
+
+    // No section markers - check if the whole file is project-specific
+    if has_project_specific_content(content) {
+        // Check if it's pure project content (no Loom template at all)
+        if !content.contains("# Loom Orchestration - Repository Guide") {
+            return Some(content.trim().to_string());
+        }
+    }
+
+    None
+}
+
+/// Wrap Loom content in section markers
+fn wrap_loom_content(content: &str) -> String {
+    format!("{}\n{}\n{}", LOOM_SECTION_START, content.trim(), LOOM_SECTION_END)
+}
+
 /// Setup repository scaffolding files
 ///
 /// Copies CLAUDE.md, AGENTS.md, .claude/, .codex/, and .github/ to the workspace.
@@ -793,7 +906,13 @@ fn force_merge_dir_with_report(
 ///   - `{{REPO_OWNER}}`, `{{REPO_NAME}}`: Repository info from git remote
 ///   - `{{LOOM_VERSION}}`, `{{LOOM_COMMIT}}`, `{{INSTALL_DATE}}`: Loom installation metadata
 ///
+/// **CLAUDE.md Preservation**:
+/// - If existing CLAUDE.md has project-specific content, it is preserved above the Loom section
+/// - Loom content is wrapped in `<!-- BEGIN LOOM ORCHESTRATION -->` markers
+/// - On reinstall, only the Loom section is updated; project content is kept
+///
 /// Custom files (files in workspace that don't exist in defaults) are always preserved.
+#[allow(clippy::too_many_lines)]
 fn setup_repository_scaffolding(
     workspace_path: &Path,
     defaults_path: &Path,
@@ -866,15 +985,95 @@ fn setup_repository_scaffolding(
             Ok(())
         };
 
-    // Copy target-repo-specific CLAUDE.md and AGENTS.md from defaults/.loom/
+    // Copy target-repo-specific CLAUDE.md from defaults/.loom/
     // (NOT defaults/CLAUDE.md which is for Loom repo itself)
-    // These files contain template variables that need to be substituted
-    copy_file_with_substitution(
-        &defaults_path.join(".loom").join("CLAUDE.md"),
-        &workspace_path.join("CLAUDE.md"),
-        "CLAUDE.md",
-        report,
-    )?;
+    // This file contains template variables that need to be substituted
+    //
+    // CLAUDE.md Preservation Logic:
+    // - If existing CLAUDE.md has project-specific content, preserve it above the Loom section
+    // - Loom content is wrapped in section markers for future updates
+    // - On reinstall, only the Loom section is updated; project content is kept
+    let claude_md_src = defaults_path.join(".loom").join("CLAUDE.md");
+    let claude_md_dst = workspace_path.join("CLAUDE.md");
+
+    if claude_md_src.exists() {
+        let existed = claude_md_dst.exists();
+
+        // Read the new Loom template content
+        let loom_content = fs::read_to_string(&claude_md_src)
+            .map_err(|e| format!("Failed to read CLAUDE.md template: {e}"))?;
+
+        // Substitute template variables in Loom content
+        let loom_substituted = substitute_template_variables(
+            &loom_content,
+            repo_owner.as_deref(),
+            repo_name.as_deref(),
+            &loom_metadata,
+        );
+
+        // Wrap Loom content in section markers
+        let wrapped_loom = wrap_loom_content(&loom_substituted);
+
+        let final_content = if existed {
+            // Read existing content
+            let existing_content = fs::read_to_string(&claude_md_dst)
+                .map_err(|e| format!("Failed to read existing CLAUDE.md: {e}"))?;
+
+            // Check if existing file already has Loom section markers
+            if existing_content.contains(LOOM_SECTION_START) {
+                // Replace just the Loom section, preserve everything else
+                if let (Some(start_idx), Some(end_idx)) = (
+                    existing_content.find(LOOM_SECTION_START),
+                    existing_content.find(LOOM_SECTION_END),
+                ) {
+                    let before = &existing_content[..start_idx];
+                    let after_end = end_idx + LOOM_SECTION_END.len();
+                    let after = if after_end < existing_content.len() {
+                        &existing_content[after_end..]
+                    } else {
+                        ""
+                    };
+
+                    format!("{}{}{}", before.trim_end(), wrapped_loom, after)
+                } else {
+                    // Malformed markers - just use the new content
+                    wrapped_loom
+                }
+            } else if let Some(project_content) = extract_project_content(&existing_content) {
+                // Has project content without markers - preserve it above Loom section
+                format!("{project_content}\n\n{wrapped_loom}")
+            } else if force {
+                // No project content and force mode - replace entirely
+                wrapped_loom
+            } else {
+                // No project content but not force mode - preserve existing
+                report.preserved.push("CLAUDE.md".to_string());
+                existing_content
+            }
+        } else {
+            // New file - just use wrapped Loom content
+            wrapped_loom
+        };
+
+        // Only write if we're creating new or updating
+        if !existed {
+            fs::write(&claude_md_dst, &final_content)
+                .map_err(|e| format!("Failed to write CLAUDE.md: {e}"))?;
+            report.added.push("CLAUDE.md".to_string());
+        } else if force || final_content != fs::read_to_string(&claude_md_dst).unwrap_or_default() {
+            // Check if content actually changed to avoid unnecessary writes
+            let current = fs::read_to_string(&claude_md_dst).unwrap_or_default();
+            if final_content != current {
+                fs::write(&claude_md_dst, &final_content)
+                    .map_err(|e| format!("Failed to write CLAUDE.md: {e}"))?;
+                if existed && !report.preserved.contains(&"CLAUDE.md".to_string()) {
+                    report.updated.push("CLAUDE.md".to_string());
+                }
+            } else if !report.preserved.contains(&"CLAUDE.md".to_string()) {
+                report.preserved.push("CLAUDE.md".to_string());
+            }
+        }
+    }
 
     copy_file_with_substitution(
         &defaults_path.join(".loom").join("AGENTS.md"),
@@ -1454,7 +1653,14 @@ mod tests {
 
         // Create .claude/commands/
         fs::create_dir_all(workspace.join(".claude").join("commands")).unwrap();
-        fs::write(workspace.join(".claude").join("commands").join("builder.md"), "").unwrap();
+        fs::write(
+            workspace
+                .join(".claude")
+                .join("commands")
+                .join("builder.md"),
+            "",
+        )
+        .unwrap();
 
         // Create docs
         fs::write(workspace.join("CLAUDE.md"), "").unwrap();
@@ -1485,5 +1691,250 @@ mod tests {
         assert!(validation.has_claude_md);
         assert!(validation.has_agents_md);
         assert!(validation.has_labels_yml);
+    }
+
+    #[test]
+    fn test_has_project_specific_content_empty() {
+        assert!(!has_project_specific_content(""));
+        assert!(!has_project_specific_content("   "));
+    }
+
+    #[test]
+    fn test_has_project_specific_content_loom_only() {
+        let loom_only = r#"# Loom Orchestration - Repository Guide
+
+This repository uses **Loom** for AI-powered development orchestration.
+
+## What is Loom?
+
+Loom is a multi-terminal desktop application..."#;
+
+        assert!(!has_project_specific_content(loom_only));
+    }
+
+    #[test]
+    fn test_has_project_specific_content_project_only() {
+        let project_only = r#"# My Project
+
+This is my awesome Rust project for doing amazing things.
+
+## Setup
+
+Run `cargo build` to build the project."#;
+
+        assert!(has_project_specific_content(project_only));
+    }
+
+    #[test]
+    fn test_has_project_specific_content_with_markers() {
+        let with_markers = format!(
+            r#"# My Project
+
+This is project-specific content.
+
+{}
+# Loom Orchestration - Repository Guide
+...Loom content...
+{}"#,
+            LOOM_SECTION_START, LOOM_SECTION_END
+        );
+
+        assert!(has_project_specific_content(&with_markers));
+    }
+
+    #[test]
+    fn test_extract_project_content_no_markers_loom_only() {
+        let loom_only = r#"# Loom Orchestration - Repository Guide
+
+This repository uses **Loom** for AI-powered development."#;
+
+        assert!(extract_project_content(loom_only).is_none());
+    }
+
+    #[test]
+    fn test_extract_project_content_no_markers_project_only() {
+        let project_only = r#"# My Project
+
+This is my project documentation."#;
+
+        let result = extract_project_content(project_only);
+        assert!(result.is_some());
+        assert!(result.unwrap().contains("My Project"));
+    }
+
+    #[test]
+    fn test_extract_project_content_with_markers() {
+        let with_markers = format!(
+            r#"# My Project
+
+Project-specific content here.
+
+{}
+# Loom Orchestration
+Loom content here
+{}
+
+More project content after."#,
+            LOOM_SECTION_START, LOOM_SECTION_END
+        );
+
+        let result = extract_project_content(&with_markers);
+        assert!(result.is_some());
+        let extracted = result.unwrap();
+        assert!(extracted.contains("My Project"));
+        assert!(extracted.contains("Project-specific content"));
+        assert!(extracted.contains("More project content after"));
+        assert!(!extracted.contains("Loom Orchestration"));
+        assert!(!extracted.contains(LOOM_SECTION_START));
+    }
+
+    #[test]
+    fn test_wrap_loom_content() {
+        let content = "# Loom Orchestration\n\nLoom content here.";
+        let wrapped = wrap_loom_content(content);
+
+        assert!(wrapped.starts_with(LOOM_SECTION_START));
+        assert!(wrapped.ends_with(LOOM_SECTION_END));
+        assert!(wrapped.contains("Loom content here"));
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn test_claude_md_preservation_new_install() {
+        let temp_dir = TempDir::new().unwrap();
+        let workspace = temp_dir.path();
+        let defaults = temp_dir.path().join("defaults");
+
+        // Setup git repo
+        fs::create_dir(workspace.join(".git")).unwrap();
+
+        // Create defaults with CLAUDE.md template
+        fs::create_dir_all(defaults.join(".loom")).unwrap();
+        fs::write(
+            defaults.join(".loom").join("CLAUDE.md"),
+            "# Loom Orchestration - Repository Guide\n\nLoom content here.",
+        )
+        .unwrap();
+
+        // No existing CLAUDE.md in workspace
+        assert!(!workspace.join("CLAUDE.md").exists());
+
+        // Run setup
+        let mut report = InitReport::default();
+        setup_repository_scaffolding(workspace, &defaults, false, &mut report).unwrap();
+
+        // Verify CLAUDE.md was created with section markers
+        assert!(workspace.join("CLAUDE.md").exists());
+        let content = fs::read_to_string(workspace.join("CLAUDE.md")).unwrap();
+        assert!(content.contains(LOOM_SECTION_START));
+        assert!(content.contains(LOOM_SECTION_END));
+        assert!(content.contains("Loom Orchestration"));
+        assert!(report.added.contains(&"CLAUDE.md".to_string()));
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn test_claude_md_preservation_existing_project_content() {
+        let temp_dir = TempDir::new().unwrap();
+        let workspace = temp_dir.path();
+        let defaults = temp_dir.path().join("defaults");
+
+        // Setup git repo
+        fs::create_dir(workspace.join(".git")).unwrap();
+
+        // Create defaults with CLAUDE.md template
+        fs::create_dir_all(defaults.join(".loom")).unwrap();
+        fs::write(
+            defaults.join(".loom").join("CLAUDE.md"),
+            "# Loom Orchestration - Repository Guide\n\nNew Loom content.",
+        )
+        .unwrap();
+
+        // Create existing CLAUDE.md with project-specific content
+        fs::write(
+            workspace.join("CLAUDE.md"),
+            r#"# My Awesome Project
+
+This project does amazing things with Rust.
+
+## Getting Started
+
+Run `cargo run` to start."#,
+        )
+        .unwrap();
+
+        // Run setup with force=true
+        let mut report = InitReport::default();
+        setup_repository_scaffolding(workspace, &defaults, true, &mut report).unwrap();
+
+        // Verify project content was preserved above Loom section
+        let content = fs::read_to_string(workspace.join("CLAUDE.md")).unwrap();
+        assert!(content.contains("My Awesome Project"));
+        assert!(content.contains("amazing things with Rust"));
+        assert!(content.contains(LOOM_SECTION_START));
+        assert!(content.contains(LOOM_SECTION_END));
+        assert!(content.contains("Loom Orchestration"));
+
+        // Project content should come BEFORE Loom section
+        let project_pos = content.find("My Awesome Project").unwrap();
+        let loom_pos = content.find(LOOM_SECTION_START).unwrap();
+        assert!(project_pos < loom_pos);
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn test_claude_md_preservation_update_loom_section_only() {
+        let temp_dir = TempDir::new().unwrap();
+        let workspace = temp_dir.path();
+        let defaults = temp_dir.path().join("defaults");
+
+        // Setup git repo
+        fs::create_dir(workspace.join(".git")).unwrap();
+
+        // Create defaults with NEW CLAUDE.md template
+        fs::create_dir_all(defaults.join(".loom")).unwrap();
+        fs::write(
+            defaults.join(".loom").join("CLAUDE.md"),
+            "# Loom Orchestration - Repository Guide\n\nUPDATED Loom content v2.0.",
+        )
+        .unwrap();
+
+        // Create existing CLAUDE.md with markers (previous install)
+        let existing = format!(
+            r#"# My Project
+
+Project docs here.
+
+{}
+# Loom Orchestration - Repository Guide
+
+Old Loom content v1.0.
+{}"#,
+            LOOM_SECTION_START, LOOM_SECTION_END
+        );
+        fs::write(workspace.join("CLAUDE.md"), existing).unwrap();
+
+        // Run setup with force=true
+        let mut report = InitReport::default();
+        setup_repository_scaffolding(workspace, &defaults, true, &mut report).unwrap();
+
+        // Verify project content was preserved, Loom section was updated
+        let content = fs::read_to_string(workspace.join("CLAUDE.md")).unwrap();
+        assert!(content.contains("My Project"));
+        assert!(content.contains("Project docs here"));
+        assert!(content.contains("UPDATED Loom content v2.0"));
+        assert!(!content.contains("Old Loom content v1.0"));
+
+        // Should only have ONE set of markers
+        assert_eq!(
+            content.matches(LOOM_SECTION_START).count(),
+            1,
+            "Should have exactly one start marker"
+        );
+        assert_eq!(
+            content.matches(LOOM_SECTION_END).count(),
+            1,
+            "Should have exactly one end marker"
+        );
     }
 }

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -343,7 +343,9 @@ fn handle_cli_command(command: Commands) -> Result<()> {
                             println!("\nRoles found: {}", validation.roles_found.join(", "));
                         }
 
-                        println!("\nℹ️  Self-installation skips file copying to prevent data loss.");
+                        println!(
+                            "\nℹ️  Self-installation skips file copying to prevent data loss."
+                        );
                         println!("   The Loom repo's .loom/ directory IS the source of truth.");
                         println!("\nTo use Loom orchestration:");
                         println!("  - Open Claude Code terminals with /builder, /judge, etc.");


### PR DESCRIPTION
## Summary

- Preserves existing project-specific CLAUDE.md content when installing or reinstalling Loom
- Wraps Loom content in HTML comment markers (`<!-- BEGIN LOOM ORCHESTRATION -->` and `<!-- END LOOM ORCHESTRATION -->`)
- On reinstall, only the Loom section is updated; project documentation is preserved
- Detects project-specific content in existing files without markers and prepends it to the Loom section

## Test plan

- [x] All 24 init tests pass, including 4 new tests for CLAUDE.md preservation
- [ ] Test fresh install to new repository (CLAUDE.md should have markers)
- [ ] Test reinstall to repo with project-specific CLAUDE.md (content should be preserved)
- [ ] Test reinstall to repo with markers (only Loom section should update)

Closes #1129

🤖 Generated with [Claude Code](https://claude.com/claude-code)