### PR TITLE
Fix Champion to remove proposal labels when promoting to loom:issue

### DIFF
--- a/.loom/roles/champion.md
+++ b/.loom/roles/champion.md
@@ -138,8 +138,12 @@ Check each of the 8 criteria above. If ANY criterion fails, skip to Step 4 (reje
 If all 8 criteria pass, promote the issue:
 
 ```bash
-# Add loom:issue (keep loom:curated as historical context)
+# Remove proposal label and add loom:issue
+# IMPORTANT: Only one proposal label can exist at a time, but check all for robustness
 gh issue edit <number> \
+  --remove-label "loom:curated" \
+  --remove-label "loom:architect" \
+  --remove-label "loom:hermit" \
   --add-label "loom:issue"
 
 # Add promotion comment

--- a/defaults/roles/champion.md
+++ b/defaults/roles/champion.md
@@ -138,8 +138,12 @@ Check each of the 8 criteria above. If ANY criterion fails, skip to Step 4 (reje
 If all 8 criteria pass, promote the issue:
 
 ```bash
-# Add loom:issue (keep loom:curated as historical context)
+# Remove proposal label and add loom:issue
+# IMPORTANT: Only one proposal label can exist at a time, but check all for robustness
 gh issue edit <number> \
+  --remove-label "loom:curated" \
+  --remove-label "loom:architect" \
+  --remove-label "loom:hermit" \
   --add-label "loom:issue"
 
 # Add promotion comment


### PR DESCRIPTION
## Summary

When Champion promotes a proposal to `loom:issue`, it now explicitly removes the original proposal labels (`loom:curated`, `loom:architect`, `loom:hermit`) to prevent double-labeled issues.

**Before**: Issues ended up with both labels:
```
#1083: [loom:issue, loom:architect]  # Should only be loom:issue
#1080: [loom:issue, loom:hermit]     # Should only be loom:issue
```

**After**: Proposal label is removed when promoting:
```bash
gh issue edit <number> \
  --remove-label "loom:curated" \
  --remove-label "loom:architect" \
  --remove-label "loom:hermit" \
  --add-label "loom:issue"
```

## Changes

- Updated `.loom/roles/champion.md` - Step 3 (Promote) now removes proposal labels
- Updated `defaults/roles/champion.md` - Same change for defaults template

## Test Plan

- [ ] Verify the gh command removes all three proposal labels when run manually
- [ ] Confirm the label transitions work correctly in practice

Closes #1134