### PR TITLE
Add git/GitHub initialization for non-git directories

### DIFF
--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -132,9 +132,126 @@ export NON_INTERACTIVE
 TARGET_PATH="$(cd "$TARGET_PATH" 2>/dev/null && pwd)" || \
   error "Target path does not exist: $TARGET_PATH"
 
-# Check if target is a git repository
+# Check if target is a git repository - offer to initialize if not
 if ! git -C "$TARGET_PATH" rev-parse --git-dir >/dev/null 2>&1; then
-  error "Target path is not a git repository: $TARGET_PATH"
+  if [[ "$NON_INTERACTIVE" == "true" ]]; then
+    # In non-interactive mode, require --init-git flag for git initialization
+    error "Target path is not a git repository: $TARGET_PATH\n       Use interactive mode to initialize git, or run 'git init' first."
+  fi
+
+  echo ""
+  warning "$TARGET_PATH is not a git repository."
+  echo ""
+  echo "Would you like to initialize git and set up GitHub?"
+  echo ""
+  echo "This will:"
+  echo "  1. Run 'git init' in the directory"
+  echo "  2. Create a sensible .gitignore file"
+  echo "  3. Create an initial commit"
+  echo "  4. Create a GitHub repository and set up remote (required for Full Install)"
+  echo ""
+  read -r -p "Initialize git and GitHub? [y/N] " -n 1 INIT_GIT
+  echo ""
+
+  if [[ ! $INIT_GIT =~ ^[Yy]$ ]]; then
+    error "Full Install requires a git repository with GitHub remote.\n       Run 'git init' and 'gh repo create' manually, or use Quick Install."
+  fi
+
+  # Initialize git
+  info "Initializing git repository..."
+  cd "$TARGET_PATH"
+  git init --quiet || error "Failed to initialize git repository"
+  success "Git repository initialized"
+
+  # Create basic .gitignore if it doesn't exist
+  if [[ ! -f "$TARGET_PATH/.gitignore" ]]; then
+    info "Creating .gitignore..."
+    cat > "$TARGET_PATH/.gitignore" << 'GITIGNORE'
+# Dependencies
+node_modules/
+vendor/
+
+# Build outputs
+dist/
+build/
+target/
+*.o
+*.a
+*.so
+*.dylib
+
+# IDE/Editor
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Environment files
+.env
+.env.local
+.env.*.local
+
+# Logs
+*.log
+logs/
+
+# Loom (will be added by installation)
+# .loom/state.json
+# .loom/worktrees/
+# .loom/*.log
+GITIGNORE
+    success "Created .gitignore"
+  fi
+
+  # Create initial commit
+  info "Creating initial commit..."
+  git add -A
+  git commit -m "Initial commit" --quiet || error "Failed to create initial commit"
+  success "Initial commit created"
+  echo ""
+
+  # GitHub repository creation is required for Full Install
+  info "Full Install requires a GitHub repository."
+  echo ""
+
+  # Check GitHub authentication
+  if ! gh auth status &> /dev/null; then
+    warning "GitHub CLI is not authenticated"
+    info "Please authenticate with GitHub:"
+    echo ""
+    gh auth login || error "GitHub authentication failed"
+    echo ""
+  fi
+
+  # Prompt for repository visibility
+  echo "Repository visibility:"
+  echo "  1. Private (default)"
+  echo "  2. Public"
+  read -r -p "Choose visibility [1/2]: " -n 1 VISIBILITY
+  echo ""
+
+  VISIBILITY_FLAG="--private"
+  if [[ "$VISIBILITY" == "2" ]]; then
+    VISIBILITY_FLAG="--public"
+  fi
+
+  # Get directory name for repo name suggestion
+  DIR_NAME=$(basename "$TARGET_PATH")
+  read -r -p "Repository name [$DIR_NAME]: " REPO_NAME
+  REPO_NAME="${REPO_NAME:-$DIR_NAME}"
+
+  info "Creating GitHub repository: $REPO_NAME..."
+  if gh repo create "$REPO_NAME" $VISIBILITY_FLAG --source="$TARGET_PATH" --push; then
+    success "GitHub repository created and pushed"
+  else
+    error "Failed to create GitHub repository. Cannot proceed with Full Install."
+  fi
+  echo ""
 fi
 
 # If target is inside a worktree, resolve to the main repository root


### PR DESCRIPTION
## Summary

When the installer detects that the target directory is not a git repository, it now offers to initialize git and optionally set up a GitHub repository instead of just erroring out.

**Changes:**
- `install.sh` (Quick Install): Prompts to run git init, creates .gitignore, creates initial commit, optionally creates GitHub repository
- `scripts/install-loom.sh` (Full Install): Same flow but GitHub repository creation is required (needed for issues, PRs, labels)
- Non-interactive mode requires manual git init for safety

Closes #1139

## Test plan

- [ ] Run `./install.sh /tmp/new-project` on a non-git directory and verify the prompts work
- [ ] Verify declining git init shows appropriate error
- [ ] Verify accepting git init creates proper .gitignore and initial commit
- [ ] Verify GitHub repo creation works when accepted
- [ ] Verify Full Install (`scripts/install-loom.sh`) requires GitHub for non-git directories
- [ ] Verify non-interactive mode (`--yes`) shows clear error message for non-git directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)