### PR TITLE
Add role completeness validation at daemon startup

### DIFF
--- a/defaults/scripts/validate-roles.sh
+++ b/defaults/scripts/validate-roles.sh
@@ -1,0 +1,239 @@
+#!/bin/bash
+#
+# validate-roles.sh - Validate Loom role configuration completeness
+#
+# This script checks that all configured roles have their dependencies
+# properly configured, preventing silent failures where work gets stuck.
+#
+# Usage:
+#   ./validate-roles.sh [OPTIONS]
+#
+# Options:
+#   --json        Output as JSON for programmatic use
+#   --strict      Exit with error code if warnings found
+#   --quiet       Only output errors/warnings, not success messages
+#   --help        Show this help message
+#
+# Exit codes:
+#   0 - Valid (or warnings in non-strict mode)
+#   1 - Errors found
+#   2 - Warnings found (strict mode only)
+#
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Default options
+JSON_OUTPUT=false
+STRICT_MODE=false
+QUIET_MODE=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --json)
+            JSON_OUTPUT=true
+            shift
+            ;;
+        --strict)
+            STRICT_MODE=true
+            shift
+            ;;
+        --quiet)
+            QUIET_MODE=true
+            shift
+            ;;
+        --help)
+            head -27 "$0" | tail -23
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# Find workspace root (look for .loom directory)
+find_workspace_root() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.loom" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    return 1
+}
+
+WORKSPACE_ROOT=$(find_workspace_root) || {
+    if [[ "$JSON_OUTPUT" == "true" ]]; then
+        echo '{"error": "Not in a Loom workspace (no .loom directory found)"}'
+    else
+        echo -e "${RED}Error: Not in a Loom workspace (no .loom directory found)${NC}" >&2
+    fi
+    exit 1
+}
+
+CONFIG_FILE="$WORKSPACE_ROOT/.loom/config.json"
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+    if [[ "$JSON_OUTPUT" == "true" ]]; then
+        echo '{"error": "Config file not found: '"$CONFIG_FILE"'"}'
+    else
+        echo -e "${RED}Error: Config file not found: $CONFIG_FILE${NC}" >&2
+    fi
+    exit 1
+fi
+
+# Extract configured roles from config.json
+# Uses jq to parse terminals and extract roleFile names
+get_configured_roles() {
+    jq -r '.terminals[]?.roleConfig?.roleFile // empty' "$CONFIG_FILE" 2>/dev/null | \
+        sed 's/\.md$//' | \
+        sort -u
+}
+
+# Define role dependencies
+# Format: role:dependency:message
+ROLE_DEPENDENCIES=(
+    "champion:doctor:Champion can set loom:changes-requested, but Doctor is not configured to handle it"
+    "builder:judge:Builder creates PRs with loom:review-requested, but Judge is not configured to review them"
+    "judge:doctor:Judge can request changes with loom:changes-requested, but Doctor is not configured to address them"
+    "judge:champion:Judge approves PRs with loom:pr, but Champion is not configured to merge them"
+    "curator:champion:Curator marks issues loom:curated, but no Champion configured to auto-promote them"
+)
+
+# Check if a role is configured
+is_role_configured() {
+    local role="$1"
+    local configured_roles="$2"
+    echo "$configured_roles" | grep -q "^${role}$"
+}
+
+# Main validation logic
+validate_roles() {
+    local configured_roles
+    configured_roles=$(get_configured_roles)
+
+    # Initialize arrays (need to handle empty case for set -u)
+    local -a warnings=()
+
+    # Check each dependency
+    for dep_entry in "${ROLE_DEPENDENCIES[@]}"; do
+        IFS=':' read -r role dependency message <<< "$dep_entry"
+
+        # If the role is configured, check if its dependency is also configured
+        if is_role_configured "$role" "$configured_roles"; then
+            if ! is_role_configured "$dependency" "$configured_roles"; then
+                warnings+=("$role|$dependency|$message")
+            fi
+        fi
+    done
+
+    # Output results
+    if [[ "$JSON_OUTPUT" == "true" ]]; then
+        output_json "$configured_roles" "${warnings[@]+"${warnings[@]}"}"
+    else
+        output_text "$configured_roles" "${warnings[@]+"${warnings[@]}"}"
+    fi
+
+    # Determine exit code
+    if [[ ${#warnings[@]} -gt 0 && "$STRICT_MODE" == "true" ]]; then
+        return 2
+    fi
+    return 0
+}
+
+output_json() {
+    local configured_roles="$1"
+    shift
+    local warnings=("$@")
+
+    # Build JSON array for configured roles
+    local roles_json
+    roles_json=$(echo "$configured_roles" | jq -R -s 'split("\n") | map(select(length > 0))')
+
+    # Build JSON array for warnings
+    local warnings_json="[]"
+    if [[ ${#warnings[@]} -gt 0 ]]; then
+        warnings_json="["
+        local first=true
+        for warning in "${warnings[@]}"; do
+            IFS='|' read -r role dependency message <<< "$warning"
+            if [[ "$first" != "true" ]]; then
+                warnings_json+=","
+            fi
+            warnings_json+="{\"role\":\"$role\",\"missing_dependency\":\"$dependency\",\"message\":\"$message\"}"
+            first=false
+        done
+        warnings_json+="]"
+    fi
+
+    # Output complete JSON
+    cat <<EOF
+{
+  "valid": true,
+  "configured_roles": $roles_json,
+  "warnings": $warnings_json,
+  "errors": [],
+  "workspace": "$WORKSPACE_ROOT"
+}
+EOF
+}
+
+output_text() {
+    local configured_roles="$1"
+    shift
+    local all_args=("$@")
+
+    # Split warnings and errors (errors would be after a sentinel, but we don't have errors yet)
+    local warnings=("${all_args[@]}")
+
+    # Print configured roles
+    if [[ "$QUIET_MODE" != "true" ]]; then
+        local roles_list
+        roles_list=$(echo "$configured_roles" | tr '\n' ', ' | sed 's/,$//')
+        echo -e "${GREEN}Configured roles:${NC} $roles_list"
+        echo
+    fi
+
+    # Print warnings
+    if [[ ${#warnings[@]} -gt 0 && "${warnings[0]}" != "" ]]; then
+        echo -e "${YELLOW}ROLE CONFIGURATION WARNINGS:${NC}"
+        for warning in "${warnings[@]}"; do
+            if [[ -n "$warning" ]]; then
+                IFS='|' read -r role dependency message <<< "$warning"
+                local role_upper
+                local dep_upper
+                role_upper=$(echo "$role" | tr '[:lower:]' '[:upper:]')
+                dep_upper=$(echo "$dependency" | tr '[:lower:]' '[:upper:]')
+                echo -e "  ${YELLOW}-${NC} ${BLUE}${role_upper}${NC} -> ${BLUE}${dep_upper}${NC}: $message"
+            fi
+        done
+        echo
+        echo "The daemon will continue, but some workflows may get stuck."
+        echo "Consider adding the missing roles to .loom/config.json"
+        echo
+
+        # Suggest fix
+        echo -e "${GREEN}To fix:${NC}"
+        echo "  1. Open .loom/config.json"
+        echo "  2. Add terminal configurations for missing roles"
+        echo "  3. Restart the daemon"
+    elif [[ "$QUIET_MODE" != "true" ]]; then
+        echo -e "${GREEN}All role dependencies are satisfied.${NC}"
+    fi
+}
+
+# Run validation
+validate_roles
+exit_code=$?
+exit $exit_code

--- a/loom-daemon/src/role_validation.rs
+++ b/loom-daemon/src/role_validation.rs
@@ -1,0 +1,382 @@
+//! Role validation module for Loom daemon
+//!
+//! This module validates that all configured roles have their dependencies
+//! properly configured, preventing silent failures where work gets stuck.
+//!
+//! # Role Dependencies
+//!
+//! Roles have dependencies on other roles to handle specific label transitions:
+//!
+//! | Role | Creates Label | Requires Role | To Handle |
+//! |------|---------------|---------------|-----------|
+//! | Champion | `loom:changes-requested` | Doctor | Address PR feedback |
+//! | Builder | `loom:review-requested` | Judge | Review PRs |
+//! | Judge | `loom:pr` | Champion | Auto-merge approved PRs |
+//! | Judge | `loom:changes-requested` | Doctor | Address feedback |
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use loom_daemon::role_validation::{validate_role_completeness, ValidationMode};
+//!
+//! let config_json = r#"{"terminals": [...]}"#;
+//! let result = validate_role_completeness(config_json, ValidationMode::Warn);
+//!
+//! for warning in &result.warnings {
+//!     println!("Warning: {} -> {}: {}",
+//!         warning.role, warning.missing_dependency, warning.message);
+//! }
+//! ```
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+/// Validation mode for role completeness checks
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ValidationMode {
+    /// Skip validation entirely
+    Ignore,
+    /// Log warnings but continue (default)
+    #[default]
+    Warn,
+    /// Fail startup if any warnings
+    Strict,
+}
+
+impl std::str::FromStr for ValidationMode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "ignore" => Ok(Self::Ignore),
+            "warn" => Ok(Self::Warn),
+            "strict" => Ok(Self::Strict),
+            _ => Err(format!("Unknown validation mode: {s}")),
+        }
+    }
+}
+
+/// A warning about a missing role dependency
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoleWarning {
+    /// The role that has the dependency
+    pub role: String,
+    /// The missing dependency role
+    pub missing_dependency: String,
+    /// Human-readable message explaining the issue
+    pub message: String,
+}
+
+/// Result of role completeness validation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidationResult {
+    /// Whether the validation passed (no errors)
+    pub valid: bool,
+    /// List of configured roles found
+    pub configured_roles: Vec<String>,
+    /// Warnings about missing dependencies
+    pub warnings: Vec<RoleWarning>,
+    /// Errors that prevent startup
+    pub errors: Vec<String>,
+}
+
+/// Role dependency definition
+struct RoleDependency {
+    role: &'static str,
+    dependency: &'static str,
+    message: &'static str,
+}
+
+/// All known role dependencies
+const ROLE_DEPENDENCIES: &[RoleDependency] = &[
+    RoleDependency {
+        role: "champion",
+        dependency: "doctor",
+        message: "Champion can set loom:changes-requested, but Doctor is not configured to handle it",
+    },
+    RoleDependency {
+        role: "builder",
+        dependency: "judge",
+        message: "Builder creates PRs with loom:review-requested, but Judge is not configured to review them",
+    },
+    RoleDependency {
+        role: "judge",
+        dependency: "doctor",
+        message: "Judge can request changes with loom:changes-requested, but Doctor is not configured to address them",
+    },
+    RoleDependency {
+        role: "judge",
+        dependency: "champion",
+        message: "Judge approves PRs with loom:pr, but Champion is not configured to merge them",
+    },
+    RoleDependency {
+        role: "curator",
+        dependency: "champion",
+        message: "Curator marks issues loom:curated, but no Champion configured to auto-promote them",
+    },
+];
+
+/// Minimal config structure for extracting roles
+#[derive(Debug, Deserialize)]
+struct LoomConfig {
+    terminals: Option<Vec<Terminal>>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Terminal {
+    role_config: Option<RoleConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RoleConfig {
+    role_file: Option<String>,
+}
+
+/// Extract role names from a config JSON string
+///
+/// Parses the config and extracts role names from terminal configurations.
+/// Role names are derived from roleFile values (e.g., "judge.md" -> "judge").
+pub fn extract_roles_from_config(config_json: &str) -> Result<Vec<String>, String> {
+    let config: LoomConfig =
+        serde_json::from_str(config_json).map_err(|e| format!("Failed to parse config: {e}"))?;
+
+    let mut roles = Vec::new();
+
+    if let Some(terminals) = config.terminals {
+        for terminal in terminals {
+            if let Some(role_config) = terminal.role_config {
+                if let Some(role_file) = role_config.role_file {
+                    // Extract role name from filename (e.g., "judge.md" -> "judge")
+                    let role_name = role_file.trim_end_matches(".md").to_string();
+                    if !role_name.is_empty() {
+                        roles.push(role_name);
+                    }
+                }
+            }
+        }
+    }
+
+    roles.sort();
+    roles.dedup();
+
+    Ok(roles)
+}
+
+/// Validate that all role dependencies are satisfied
+///
+/// # Arguments
+///
+/// * `config_json` - JSON string containing the Loom config
+/// * `mode` - Validation mode (Ignore, Warn, or Strict)
+///
+/// # Returns
+///
+/// Validation result with any warnings or errors found
+pub fn validate_role_completeness(config_json: &str, mode: ValidationMode) -> ValidationResult {
+    if mode == ValidationMode::Ignore {
+        return ValidationResult {
+            valid: true,
+            configured_roles: Vec::new(),
+            warnings: Vec::new(),
+            errors: Vec::new(),
+        };
+    }
+
+    let configured_roles = match extract_roles_from_config(config_json) {
+        Ok(roles) => roles,
+        Err(e) => {
+            return ValidationResult {
+                valid: false,
+                configured_roles: Vec::new(),
+                warnings: Vec::new(),
+                errors: vec![e],
+            };
+        }
+    };
+
+    let role_set: HashSet<&str> = configured_roles.iter().map(|s| s.as_str()).collect();
+    let mut warnings = Vec::new();
+
+    // Check each dependency
+    for dep in ROLE_DEPENDENCIES {
+        if role_set.contains(dep.role) && !role_set.contains(dep.dependency) {
+            warnings.push(RoleWarning {
+                role: dep.role.to_string(),
+                missing_dependency: dep.dependency.to_string(),
+                message: dep.message.to_string(),
+            });
+        }
+    }
+
+    ValidationResult {
+        valid: true,
+        configured_roles,
+        warnings,
+        errors: Vec::new(),
+    }
+}
+
+/// Validate role completeness from a config file path
+///
+/// Convenience function that reads the config file and validates it.
+pub fn validate_from_file(
+    config_path: &std::path::Path,
+    mode: ValidationMode,
+) -> Result<ValidationResult, String> {
+    let config_json =
+        std::fs::read_to_string(config_path).map_err(|e| format!("Failed to read config: {e}"))?;
+
+    Ok(validate_role_completeness(&config_json, mode))
+}
+
+/// Format validation result for console output
+pub fn format_validation_result(result: &ValidationResult, verbose: bool) -> String {
+    let mut output = String::new();
+
+    if verbose {
+        output.push_str(&format!(
+            "Configured roles: {}\n",
+            result.configured_roles.join(", ")
+        ));
+    }
+
+    if !result.warnings.is_empty() {
+        output.push_str("\nROLE CONFIGURATION WARNINGS:\n");
+        for warning in &result.warnings {
+            output.push_str(&format!(
+                "  - {} -> {}: {}\n",
+                warning.role.to_uppercase(),
+                warning.missing_dependency.to_uppercase(),
+                warning.message
+            ));
+        }
+        output.push_str("\nThe daemon will continue, but some workflows may get stuck.\n");
+        output.push_str("Consider adding the missing roles to .loom/config.json\n");
+    } else if verbose {
+        output.push_str("All role dependencies are satisfied.\n");
+    }
+
+    if !result.errors.is_empty() {
+        output.push_str("\nROLE CONFIGURATION ERRORS:\n");
+        for error in &result.errors {
+            output.push_str(&format!("  - {error}\n"));
+        }
+    }
+
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_roles_from_config() {
+        let config = r#"{
+            "terminals": [
+                {
+                    "id": "terminal-1",
+                    "name": "Judge",
+                    "roleConfig": {
+                        "roleFile": "judge.md"
+                    }
+                },
+                {
+                    "id": "terminal-2",
+                    "name": "Builder",
+                    "roleConfig": {
+                        "roleFile": "builder.md"
+                    }
+                }
+            ]
+        }"#;
+
+        let roles = extract_roles_from_config(config).unwrap();
+        assert_eq!(roles, vec!["builder", "judge"]);
+    }
+
+    #[test]
+    fn test_validate_missing_doctor() {
+        let config = r#"{
+            "terminals": [
+                {
+                    "id": "terminal-1",
+                    "name": "Judge",
+                    "roleConfig": {
+                        "roleFile": "judge.md"
+                    }
+                },
+                {
+                    "id": "terminal-2",
+                    "name": "Champion",
+                    "roleConfig": {
+                        "roleFile": "champion.md"
+                    }
+                }
+            ]
+        }"#;
+
+        let result = validate_role_completeness(config, ValidationMode::Warn);
+
+        assert!(result.valid);
+        assert!(!result.warnings.is_empty());
+
+        // Should warn about missing doctor for both judge and champion
+        let doctor_warnings: Vec<_> = result
+            .warnings
+            .iter()
+            .filter(|w| w.missing_dependency == "doctor")
+            .collect();
+        assert_eq!(doctor_warnings.len(), 2);
+    }
+
+    #[test]
+    fn test_validate_all_dependencies_satisfied() {
+        let config = r#"{
+            "terminals": [
+                {"roleConfig": {"roleFile": "judge.md"}},
+                {"roleConfig": {"roleFile": "champion.md"}},
+                {"roleConfig": {"roleFile": "doctor.md"}},
+                {"roleConfig": {"roleFile": "builder.md"}},
+                {"roleConfig": {"roleFile": "curator.md"}}
+            ]
+        }"#;
+
+        let result = validate_role_completeness(config, ValidationMode::Warn);
+
+        assert!(result.valid);
+        assert!(result.warnings.is_empty());
+    }
+
+    #[test]
+    fn test_validate_ignore_mode() {
+        let config = r#"{"terminals": []}"#;
+
+        let result = validate_role_completeness(config, ValidationMode::Ignore);
+
+        assert!(result.valid);
+        assert!(result.configured_roles.is_empty());
+        assert!(result.warnings.is_empty());
+    }
+
+    #[test]
+    fn test_format_validation_result() {
+        let result = ValidationResult {
+            valid: true,
+            configured_roles: vec!["judge".to_string(), "champion".to_string()],
+            warnings: vec![RoleWarning {
+                role: "champion".to_string(),
+                missing_dependency: "doctor".to_string(),
+                message: "Test warning".to_string(),
+            }],
+            errors: Vec::new(),
+        };
+
+        let output = format_validation_result(&result, true);
+        assert!(output.contains("ROLE CONFIGURATION WARNINGS"));
+        assert!(output.contains("CHAMPION"));
+        assert!(output.contains("DOCTOR"));
+    }
+}


### PR DESCRIPTION
## Summary

- Implements issue #1136 - daemon now validates that all configured roles have their dependencies satisfied
- Prevents silent failures where work gets stuck (e.g., PRs with `loom:changes-requested` when Doctor is not configured)
- Adds validation to both the `/loom` skill and the Rust `loom-daemon` binary

## Changes

1. **defaults/roles/loom.md** - Added "Startup Validation" section documenting role dependencies and validation behavior
2. **defaults/scripts/validate-roles.sh** - New shell script for CLI validation with `--json`, `--strict`, and `--quiet` options
3. **loom-daemon/src/role_validation.rs** - New Rust module with validation logic and 5 unit tests
4. **loom-daemon/src/main.rs** - Added `validate` subcommand to loom-daemon CLI

## Role Dependencies Checked

| Role | Requires | For Label |
|------|----------|-----------|
| Champion | Doctor | `loom:changes-requested` |
| Builder | Judge | `loom:review-requested` |
| Judge | Doctor | `loom:changes-requested` |
| Judge | Champion | `loom:pr` |
| Curator | Champion | `loom:curated` |

## Validation Modes

- **ignore** - Skip validation entirely
- **warn** (default) - Log warnings but continue startup
- **strict** - Fail startup if any warnings (for CI)

## Test Plan

- [x] Unit tests pass (5 new tests in `role_validation.rs`)
- [x] All existing tests pass (155 total)
- [x] Shell script validates correctly and outputs JSON
- [x] Rust CLI `validate` subcommand works
- [ ] Verify validation runs at daemon startup in Manual Orchestration Mode
- [ ] Verify validation runs at daemon startup in Tauri App Mode

Closes #1136

---

Generated with [Claude Code](https://claude.ai/code)