### PR TITLE
Enable Champion to promote Architect/Hermit proposals

### DIFF
--- a/.loom/roles/champion.md
+++ b/.loom/roles/champion.md
@@ -43,9 +43,33 @@ gh issue list \
 
 If found, proceed to Issue Promotion workflow below.
 
+### Priority 3: Architect/Hermit Proposals Ready to Promote
+
+If no curated issues need promotion, check for well-formed proposals:
+
+```bash
+# Check for Architect proposals
+gh issue list \
+  --label="loom:architect" \
+  --state=open \
+  --json number,title,body,labels,comments \
+  --jq '.[] | "#\(.number) \(.title) [architect]"'
+
+# Check for Hermit proposals
+gh issue list \
+  --label="loom:hermit" \
+  --state=open \
+  --json number,title,body,labels,comments \
+  --jq '.[] | "#\(.number) \(.title) [hermit]"'
+```
+
+If found, proceed to Issue Promotion workflow below. Architect/Hermit proposals use the same 8 evaluation criteria as curated issues.
+
+**Note**: Proposals from Architect and Hermit roles are typically well-formed since these roles generate detailed, implementation-ready issues. Champion should promote proposals that meet all quality criteria without requiring human intervention for routine proposals.
+
 ### No Work Available
 
-If neither queue has work, report "No work for Champion" and stop.
+If no queues have work, report "No work for Champion" and stop.
 
 ---
 
@@ -53,16 +77,19 @@ If neither queue has work, report "No work for Champion" and stop.
 
 ## Overview
 
-Evaluate `loom:curated` issues and promote obviously beneficial work to `loom:issue` status.
+Evaluate proposal issues (`loom:curated`, `loom:architect`, `loom:hermit`) and promote obviously beneficial work to `loom:issue` status.
 
 You operate as the middle tier in a three-tier approval system:
-1. **Curator** enhances raw issues → marks as `loom:curated`
-2. **Champion** (you) evaluates curated issues → promotes to `loom:issue`
+1. **Roles create proposals**:
+   - **Curator** enhances raw issues → marks as `loom:curated`
+   - **Architect** creates feature/improvement proposals → marks as `loom:architect`
+   - **Hermit** creates simplification proposals → marks as `loom:hermit`
+2. **Champion** (you) evaluates all proposals → promotes qualifying ones to `loom:issue`
 3. **Human** provides final override and can reject Champion decisions
 
 ## Evaluation Criteria
 
-For each `loom:curated` issue, evaluate against these **8 criteria**. All must pass for promotion:
+For each proposal issue (`loom:curated`, `loom:architect`, or `loom:hermit`), evaluate against these **8 criteria**. All must pass for promotion:
 
 ### 1. Clear Problem Statement
 - [ ] Issue describes a specific problem or opportunity
@@ -90,7 +117,7 @@ For each `loom:curated` issue, evaluate against these **8 criteria**. All must p
 - [ ] Can be implemented atomically
 
 ### 6. Quality Standards
-- [ ] Curator added meaningful context (not just reformatting)
+- [ ] Proposal adds meaningful context (not just reformatting)
 - [ ] Technical details are accurate
 - [ ] References to code/files are correct
 
@@ -100,7 +127,7 @@ For each `loom:curated` issue, evaluate against these **8 criteria**. All must p
 - [ ] Performance impact is noted if relevant
 
 ### 8. Completeness
-- [ ] All sections from curator template are filled
+- [ ] All relevant sections are filled (problem, solution, acceptance criteria)
 - [ ] Code references include file paths and line numbers
 - [ ] Test strategy is outlined
 
@@ -113,11 +140,11 @@ Use conservative judgment. **Do NOT promote** if:
 - **Missing context**: References non-existent files or outdated code
 - **Duplicate work**: Another issue or PR already addresses this
 - **Requires discussion**: Needs stakeholder input or design decisions
-- **Incomplete curation**: Curator added minimal enhancement
+- **Incomplete proposal**: Minimal context or missing key sections
 - **Too ambitious**: Multi-week effort or touches many systems
 - **Unverified claims**: "This will fix X" without evidence
 
-**When in doubt, do NOT promote.** Leave a comment explaining concerns and keep `loom:curated` label.
+**When in doubt, do NOT promote.** Leave a comment explaining concerns and keep the original proposal label (`loom:curated`, `loom:architect`, or `loom:hermit`).
 
 ## Promotion Workflow
 
@@ -168,7 +195,7 @@ This issue has been evaluated and promoted to \`loom:issue\` status. All quality
 
 ### Step 4: Reject (One or More Criteria Fail)
 
-If any criteria fail, leave detailed feedback but keep `loom:curated` label:
+If any criteria fail, leave detailed feedback but keep the original proposal label:
 
 ```bash
 gh issue comment <number> --body "**Champion Review: NEEDS REVISION**
@@ -182,13 +209,13 @@ This issue requires additional work before promotion to \`loom:issue\`:
 - [Specific suggestion 1]
 - [Specific suggestion 2]
 
-Leaving \`loom:curated\` label. Curator or issue author can address these concerns and resubmit.
+Keeping original proposal label. The proposing role or issue author can address these concerns and resubmit.
 
 ---
 *Automated by Champion role*"
 ```
 
-Do NOT remove the `loom:curated` label when rejecting.
+Do NOT remove the proposal label (`loom:curated`, `loom:architect`, or `loom:hermit`) when rejecting.
 
 ## Issue Promotion Rate Limiting
 
@@ -1521,8 +1548,14 @@ When running autonomously:
 # Label Workflow Integration
 
 ```
-Issue Lifecycle:
+Issue Lifecycle (Curated):
 (created) → loom:curated → [Champion evaluates] → loom:issue → [Builder] → (closed)
+
+Issue Lifecycle (Architect Proposal):
+(created by Architect) → loom:architect → [Champion evaluates] → loom:issue → [Builder] → (closed)
+
+Issue Lifecycle (Hermit Proposal):
+(created by Hermit) → loom:hermit → [Champion evaluates] → loom:issue → [Builder] → (closed)
 
 PR Lifecycle:
 (created) → loom:review-requested → [Judge] → loom:pr → [Champion merges] → (merged)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Loom uses a three-layer orchestration architecture for scalable automation:
 ┌─────────────────────────────────────────────────────────────────┐
 │                    Layer 3: Human Observer                      │
 │  - Watches system health and intervenes when needed             │
-│  - Approves architectural proposals (loom:architect → loom:issue)│
+│  - Overrides Champion on controversial proposals                │
 │  - Handles edge cases and blocked issues                        │
 │  - Provides strategic direction                                 │
 └─────────────────────────────────────────────────────────────────┘
@@ -68,7 +68,7 @@ Loom uses a three-layer orchestration architecture for scalable automation:
 ### Layer Responsibilities
 
 **Layer 3 (Human Observer)**:
-- Approve Architect/Hermit proposals (convert `loom:architect` → `loom:issue`)
+- Override Champion decisions on controversial proposals (Champion handles routine approvals)
 - Monitor system health via daemon-state.json
 - Intervene for blocked issues or stuck agents
 - Provide strategic direction on what to build
@@ -227,14 +227,14 @@ Loom provides specialized roles for different development tasks. Each role follo
 - **When to use**: Code quality assurance, automated reviews
 
 **Champion** (Autonomous 10min, `champion.md`)
-- **Purpose**: Auto-merge approved PRs
-- **Workflow**: Finds `loom:pr` PRs → verifies safety criteria → auto-merges if safe
-- **When to use**: Default daemon mode with `--force-pr` (human reviews PR before Champion merges)
-- **Note**: Not used when shepherds run with `--force-merge` (shepherds handle their own merges)
+- **Purpose**: Evaluate proposals and auto-merge approved PRs
+- **Workflow**: Evaluates `loom:curated`, `loom:architect`, `loom:hermit` proposals → promotes to `loom:issue`. Also finds `loom:pr` PRs → verifies safety criteria → auto-merges if safe
+- **When to use**: Default daemon mode - handles both proposal promotion and PR merging
+- **Note**: Not needed for PR merging when shepherds run with `--force-merge` (shepherds handle their own merges)
 
 **Curator** (Autonomous 5min, `curator.md`)
 - **Purpose**: Enhance and organize issues
-- **Workflow**: Finds unlabeled issues → adds context → marks as `loom:curated` (human approves → `loom:issue`)
+- **Workflow**: Finds unlabeled issues → adds context → marks as `loom:curated` (Champion evaluates → `loom:issue`)
 - **When to use**: Issue backlog maintenance, quality improvement
 
 **Architect** (Autonomous 15min, `architect.md`)
@@ -302,12 +302,14 @@ Agents coordinate work through GitHub labels. This enables autonomous operation 
 
 **Proposal Lifecycle**:
 ```
-(created) → loom:architect → (approved) → loom:issue
-           ↑ Architect       ↑ Human      ↑ Ready for Builder
+(created) → loom:architect → (evaluated) → loom:issue
+           ↑ Architect       ↑ Champion    ↑ Ready for Builder
 
-(created) → loom:hermit → (approved) → loom:issue
-           ↑ Hermit       ↑ Human      ↑ Ready for Builder
+(created) → loom:hermit → (evaluated) → loom:issue
+           ↑ Hermit       ↑ Champion    ↑ Ready for Builder
 ```
+
+**Note**: Champion evaluates proposals from Architect and Hermit roles using the same 8 quality criteria as curated issues. Well-formed proposals are promoted automatically; only ambiguous or controversial proposals require human intervention.
 
 ### Label Definitions
 
@@ -321,9 +323,9 @@ Agents coordinate work through GitHub labels. This enables autonomous operation 
 - **`loom:pr`**: PR approved by Judge, ready for Champion to auto-merge
 
 **Proposal Labels**:
-- **`loom:architect`**: Architectural proposal awaiting user approval
-- **`loom:hermit`**: Simplification proposal awaiting user approval
-- **`loom:curated`**: Issue enhanced by Curator, awaiting human approval
+- **`loom:architect`**: Architectural proposal awaiting Champion evaluation
+- **`loom:hermit`**: Simplification proposal awaiting Champion evaluation
+- **`loom:curated`**: Issue enhanced by Curator, awaiting Champion evaluation
 
 **Status Labels**:
 - **`loom:blocked`**: Implementation blocked, needs help or clarification


### PR DESCRIPTION
## Summary

- Fixes a state machine logic error where Architect/Hermit proposals blocked autonomous operation
- Extends Champion role to evaluate and promote all three proposal types (loom:curated, loom:architect, loom:hermit)
- Uses the same 8 quality criteria for all proposal types
- Preserves human override capability for controversial proposals

## Test plan

- [ ] Verify Champion now searches for `loom:architect` and `loom:hermit` labeled issues in Priority 3
- [ ] Verify evaluation criteria language is proposal-agnostic
- [ ] Verify Label Workflow Integration section shows all three issue lifecycles
- [ ] Verify CLAUDE.md documentation reflects Champion as evaluator (not just human)


Generated with [Claude Code](https://claude.com/claude-code)