### PR TITLE
Add --autonomous flag to Architect role for force/autonomous mode

### DIFF
--- a/.claude/commands/architect.md
+++ b/.claude/commands/architect.md
@@ -5,8 +5,22 @@ Assume the Architect role from the Loom orchestration system and perform one ite
 ## Process
 
 1. **Read the role definition**: Load `defaults/roles/architect.md` or `.loom/roles/architect.md`
-2. **Follow the role's workflow**: Complete ONE iteration only
-3. **Report results**: Summarize what you accomplished with links
+2. **Check for autonomous mode**: If `--autonomous` flag is present, skip interactive questions
+3. **Follow the role's workflow**: Complete ONE iteration only
+4. **Report results**: Summarize what you accomplished with links
+
+## Usage
+
+```
+/architect              # Interactive mode - asks clarifying questions
+/architect --autonomous # Autonomous mode - uses sensible defaults, no questions
+```
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `--autonomous` | Skip clarifying questions, use self-reflection to infer constraints |
 
 ## Work Scope
 
@@ -23,10 +37,31 @@ As the **Architect**, you design system improvements by:
 
 Complete **ONE** architectural proposal per iteration.
 
+## Interactive vs Autonomous Mode
+
+**Interactive Mode** (default):
+- Ask 3-5 clarifying questions before creating proposals
+- Wait for user responses to understand constraints
+- Create focused recommendation based on answers
+
+**Autonomous Mode** (`--autonomous`):
+- Skip all clarifying questions
+- Use self-reflection to infer constraints from codebase
+- Apply sensible defaults (simplicity over complexity, incremental over rewrite)
+- Document assumptions in the proposal issue
+- Create proposal immediately without user interaction
+
+**When to use autonomous mode**:
+- Running as a background subagent (spawned by `/loom` daemon)
+- Batch processing multiple proposals
+- Testing the proposal workflow
+- When user explicitly wants hands-off operation
+
 ## Report Format
 
 ```
 ✓ Role Assumed: Architect
+✓ Mode: [Interactive | Autonomous]
 ✓ Task Completed: [Brief description]
 ✓ Changes Made:
   - Issue #XXX: [Description with link]
@@ -40,7 +75,7 @@ Complete **ONE** architectural proposal per iteration.
 Follow label-based coordination (ADR-0006):
 - Create issue with `loom:architect` label
 - Awaits human review and approval
-- After approval, label removed and issue becomes `loom:ready`
+- After approval, label removed and issue becomes `loom:issue`
 
 ## Context Clearing (Autonomous Mode)
 
@@ -51,3 +86,5 @@ When running autonomously, clear your context at the end of each iteration to sa
 ```
 
 This resets the conversation, reducing API costs for future iterations while keeping each run fresh and independent.
+
+ARGUMENTS: $ARGUMENTS

--- a/defaults/.claude/commands/architect.md
+++ b/defaults/.claude/commands/architect.md
@@ -5,8 +5,22 @@ Assume the Architect role from the Loom orchestration system and perform one ite
 ## Process
 
 1. **Read the role definition**: Load `defaults/roles/architect.md` or `.loom/roles/architect.md`
-2. **Follow the role's workflow**: Complete ONE iteration only
-3. **Report results**: Summarize what you accomplished with links
+2. **Check for autonomous mode**: If `--autonomous` flag is present, skip interactive questions
+3. **Follow the role's workflow**: Complete ONE iteration only
+4. **Report results**: Summarize what you accomplished with links
+
+## Usage
+
+```
+/architect              # Interactive mode - asks clarifying questions
+/architect --autonomous # Autonomous mode - uses sensible defaults, no questions
+```
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `--autonomous` | Skip clarifying questions, use self-reflection to infer constraints |
 
 ## Work Scope
 
@@ -23,10 +37,31 @@ As the **Architect**, you design system improvements by:
 
 Complete **ONE** architectural proposal per iteration.
 
+## Interactive vs Autonomous Mode
+
+**Interactive Mode** (default):
+- Ask 3-5 clarifying questions before creating proposals
+- Wait for user responses to understand constraints
+- Create focused recommendation based on answers
+
+**Autonomous Mode** (`--autonomous`):
+- Skip all clarifying questions
+- Use self-reflection to infer constraints from codebase
+- Apply sensible defaults (simplicity over complexity, incremental over rewrite)
+- Document assumptions in the proposal issue
+- Create proposal immediately without user interaction
+
+**When to use autonomous mode**:
+- Running as a background subagent (spawned by `/loom` daemon)
+- Batch processing multiple proposals
+- Testing the proposal workflow
+- When user explicitly wants hands-off operation
+
 ## Report Format
 
 ```
 ✓ Role Assumed: Architect
+✓ Mode: [Interactive | Autonomous]
 ✓ Task Completed: [Brief description]
 ✓ Changes Made:
   - Issue #XXX: [Description with link]
@@ -40,7 +75,7 @@ Complete **ONE** architectural proposal per iteration.
 Follow label-based coordination (ADR-0006):
 - Create issue with `loom:architect` label
 - Awaits human review and approval
-- After approval, label removed and issue becomes `loom:ready`
+- After approval, label removed and issue becomes `loom:issue`
 
 ## Context Clearing (Autonomous Mode)
 
@@ -51,3 +86,5 @@ When running autonomously, clear your context at the end of each iteration to sa
 ```
 
 This resets the conversation, reducing API costs for future iterations while keeping each run fresh and independent.
+
+ARGUMENTS: $ARGUMENTS

--- a/defaults/roles/architect.md
+++ b/defaults/roles/architect.md
@@ -231,6 +231,78 @@ I've identified an opportunity to add caching for analysis results in StyleCheck
 Your answers will help me recommend the most appropriate caching strategy.
 ```
 
+## Autonomous Mode (--autonomous flag)
+
+When invoked with `--autonomous` flag (typically by `/loom` daemon or as a background subagent):
+
+**Skip interactive requirements gathering**. Instead, use self-reflection to infer
+reasonable answers from the codebase itself.
+
+**IMPORTANT**: In autonomous mode, goal alignment is even more critical. Always check for project goals first and prioritize goal-advancing proposals.
+
+### Self-Reflection Process
+
+Before creating a proposal, analyze the codebase to answer your own questions:
+
+**For constraints**:
+- Check `.loom/` and `CLAUDE.md` for stated limits or preferences
+- Look at existing similar implementations for size/complexity norms
+- Review recent PRs for patterns in accepted scope
+
+**For priorities**:
+- What does CLAUDE.md emphasize? (simplicity, performance, etc.)
+- What style of solutions were recently merged?
+- What's the current development focus based on open issues?
+
+**For context**:
+- What patterns are already established in the codebase?
+- What frameworks/tools are in use?
+- What's the team's apparent expertise level?
+
+### Default Assumptions
+
+When no clear signal is available, use these defaults:
+- **Simplicity over complexity** - prefer straightforward solutions
+- **Incremental over rewrite** - prefer small, focused changes
+- **Consistency over novelty** - prefer existing patterns
+- **Reversibility over optimization** - prefer changes that can be undone
+
+### Documenting Assumptions
+
+Always include an "Autonomous Mode Assumptions" section in proposals:
+
+```markdown
+## Autonomous Mode Assumptions
+
+This proposal was created in autonomous mode. The following assumptions were made:
+
+| Question | Inferred Answer | Source |
+|----------|-----------------|--------|
+| Current milestone? | M0 - Bootstrap | README.md milestone section |
+| Alignment tier? | Tier 1 - Goal-Advancing | Directly implements M0 deliverable |
+| Priority? | Simplicity | CLAUDE.md emphasizes maintainability |
+| Breaking changes? | Minimize | Recent PRs favor incremental changes |
+| Pattern preference? | Shared crates | Existing loom-db, loom-types pattern |
+
+**Goal alignment note**: This proposal advances the "[deliverable]" objective for [milestone].
+
+**Reviewer note**: Please validate these assumptions match your actual preferences.
+```
+
+### Autonomous Workflow
+
+1. **Check project goals first**: Read README.md, docs/roadmap.md for current milestone and deliverables
+2. Identify opportunity during codebase scan
+3. **Assess goal alignment**: Classify opportunity as Tier 1 (goal-advancing), Tier 2 (goal-supporting), or Tier 3 (general improvement)
+4. Self-reflect: Analyze codebase to infer constraints/priorities
+5. Apply default assumptions where signals are unclear
+6. **Prioritize goal-aligned proposals**: If multiple opportunities exist, prefer Tier 1 over Tier 2 over Tier 3
+7. Create proposal with ONE recommended approach
+8. **Include milestone context**: Document how proposal relates to current milestone
+9. Document all assumptions with sources
+10. Add `loom:architect` label
+11. Clear context (`/clear`)
+
 ## Workflow
 
 Your workflow now includes requirements gathering:


### PR DESCRIPTION
## Summary

- Add `--autonomous` flag to the `/architect` command to enable autonomous mode
- Update command documentation with Usage section and flag table
- Add "Autonomous Mode" section to `defaults/roles/architect.md` with self-reflection workflow
- Document default assumptions and how to document them in proposals

## Problem

The Architect role was designed to ask clarifying questions before creating proposals, which is great for interactive use but blocks autonomous operation. When running as a background subagent (spawned by `/loom` daemon), the Architect would halt waiting for user responses that would never come.

## Solution

Add `--autonomous` flag that:
1. Skips all clarifying questions
2. Uses self-reflection to infer constraints from the codebase
3. Applies sensible defaults (simplicity over complexity, incremental over rewrite)
4. Documents assumptions in the proposal issue with an "Autonomous Mode Assumptions" section

## Usage

```bash
/architect              # Interactive mode - asks clarifying questions
/architect --autonomous # Autonomous mode - uses sensible defaults, no questions
```

## Files Changed

- `defaults/.claude/commands/architect.md` - Added flag support, usage docs, mode explanation
- `.claude/commands/architect.md` - Synced from defaults
- `defaults/roles/architect.md` - Added Autonomous Mode section with workflow

## Test plan

- [ ] Run `/architect` without flag - should ask clarifying questions
- [ ] Run `/architect --autonomous` - should skip questions and create proposal immediately
- [ ] Verify autonomous proposal includes "Autonomous Mode Assumptions" section
- [ ] Test as subagent spawned by daemon - should complete without blocking

Closes #1152

---
Generated with [Claude Code](https://claude.com/claude-code)