### PR TITLE
Consolidate MCP Servers into a Unified mcp-loom Package

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -871,11 +871,19 @@ echo "Proposals: $(gh issue list --label 'loom:architect,loom:hermit' --state op
 
 ## MCP Hooks for Programmatic Control
 
-Loom provides MCP (Model Context Protocol) servers that allow Claude Code to programmatically control the Loom application. This enables automation, testing, and advanced workflows.
+Loom provides a unified MCP (Model Context Protocol) server that allows Claude Code to programmatically control the Loom application. This enables automation, testing, and advanced workflows.
 
-### Available MCP Servers
+### Unified MCP Server
 
-**loom-terminals** - Terminal management via daemon socket:
+All Loom MCP tools are now provided through a single `mcp-loom` package, consolidating the previous `mcp-loom-logs`, `mcp-loom-ui`, and `mcp-loom-terminals` packages.
+
+**Log Tools:**
+- `tail_daemon_log` - Tail daemon log file
+- `tail_tauri_log` - Tail Tauri application log
+- `list_terminal_logs` - List available terminal output logs
+- `tail_terminal_log` - Tail a specific terminal's output log
+
+**Terminal Tools:**
 - `list_terminals` - List all active terminal sessions
 - `get_terminal_output` - Get recent output from a terminal
 - `get_selected_terminal` - Get info about the currently selected terminal
@@ -889,9 +897,12 @@ Loom provides MCP (Model Context Protocol) servers that allow Claude Code to pro
 - `check_tmux_server_health` - Check tmux server status
 - `get_tmux_server_info` - Get tmux server details
 - `toggle_tmux_verbose_logging` - Enable tmux debug logging
+- `start_autonomous_mode` - Start autonomous mode for all terminals
+- `stop_autonomous_mode` - Stop autonomous mode
+- `launch_interval` - Manually trigger interval prompt
 - `get_agent_metrics` - Get agent performance metrics for self-aware behavior
 
-**loom-ui** - UI control via file-based IPC:
+**UI Tools:**
 - `read_console_log` - Read browser console logs
 - `read_state_file` - Read workspace state
 - `read_config_file` - Read workspace config
@@ -910,22 +921,25 @@ Loom provides MCP (Model Context Protocol) servers that allow Claude Code to pro
 
 ```bash
 # Create a terminal with specific role
-mcp__loom-terminals__create_terminal --name "Builder" --role "builder"
+mcp__loom__create_terminal --name "Builder" --role "builder"
 
 # Configure autonomous operation
-mcp__loom-terminals__configure_terminal \
+mcp__loom__configure_terminal \
   --terminal_id terminal-1 \
   --target_interval 300000 \
   --interval_prompt "Check for new issues"
 
 # Trigger immediate autonomous run
-mcp__loom-ui__trigger_run_now --terminalId terminal-1
+mcp__loom__trigger_run_now --terminalId terminal-1
 
 # Stop all terminals
-mcp__loom-ui__stop_engine
+mcp__loom__stop_engine
 
 # Get comprehensive state
-mcp__loom-ui__get_ui_state
+mcp__loom__get_ui_state
+
+# View logs
+mcp__loom__tail_daemon_log --lines 50
 ```
 
 ### Agent Performance Metrics
@@ -938,16 +952,16 @@ Agents can query their own performance metrics to make informed decisions. This 
 **Via MCP Tool**:
 ```bash
 # Get overall metrics summary
-mcp__loom-terminals__get_agent_metrics --command summary --period week
+mcp__loom__get_agent_metrics --command summary --period week
 
 # Get effectiveness metrics for a specific role
-mcp__loom-terminals__get_agent_metrics --command effectiveness --role builder
+mcp__loom__get_agent_metrics --command effectiveness --role builder
 
 # Get cost breakdown for a specific issue
-mcp__loom-terminals__get_agent_metrics --command costs --issue 123
+mcp__loom__get_agent_metrics --command costs --issue 123
 
 # Get velocity trends
-mcp__loom-terminals__get_agent_metrics --command velocity
+mcp__loom__get_agent_metrics --command velocity
 ```
 
 **Via CLI Script**:
@@ -982,27 +996,26 @@ fi
 
 ### MCP Server Configuration
 
-Add these MCP servers to your Claude Code configuration:
+Add the unified Loom MCP server to your Claude Code configuration:
 
 ```json
 {
   "mcpServers": {
-    "loom-terminals": {
+    "loom": {
       "command": "node",
-      "args": ["/path/to/loom/mcp-loom-terminals/dist/index.js"],
-      "env": {
-        "LOOM_WORKSPACE": "/path/to/your/workspace"
-      }
-    },
-    "loom-ui": {
-      "command": "node",
-      "args": ["/path/to/loom/mcp-loom-ui/dist/index.js"],
+      "args": ["/path/to/loom/mcp-loom/dist/index.js"],
       "env": {
         "LOOM_WORKSPACE": "/path/to/your/workspace"
       }
     }
   }
 }
+```
+
+Or run the setup script to generate `.mcp.json` automatically:
+
+```bash
+./scripts/setup-mcp.sh
 ```
 
 ## Resources

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -124,9 +124,9 @@ MCP server providing tools for Claude Code to interact with Loom's state and log
 ```json
 {
   "mcpServers": {
-    "loom-ui": {
+    "loom": {
       "command": "node",
-      "args": ["mcp-loom-ui/dist/index.js"],
+      "args": ["mcp-loom/dist/index.js"],
       "env": {
         "LOOM_WORKSPACE": "/Users/rwalters/GitHub/loom"
       }
@@ -138,10 +138,10 @@ MCP server providing tools for Claude Code to interact with Loom's state and log
 **Usage Example** (from Claude Code):
 ```bash
 # Read recent console logs to see workspace start progress
-mcp__loom-ui__read_console_log
+mcp__loom__read_console_log
 
 # Check terminal state after start
-mcp__loom-ui__read_state_file
+mcp__loom__read_state_file
 
 # Check terminal configuration
 mcp__loom-ui__read_config_file

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -86,51 +86,40 @@ MCP servers are automatically available when you clone the Loom repository. They
 # Check MCP configuration
 cat .mcp.json
 
-# Verify packages exist
-ls mcp-loom-ui/ mcp-loom-logs/ mcp-loom-terminals/
+# Verify unified package exists
+ls mcp-loom/
 ```
 
 ### Configuration
 
-MCP servers are configured in `.mcp.json`:
+The unified MCP server is configured in `.mcp.json`:
 
 ```json
 {
   "mcpServers": {
-    "loom-ui": {
+    "loom": {
       "command": "node",
-      "args": ["mcp-loom-ui/dist/index.js"],
+      "args": ["mcp-loom/dist/index.js"],
       "env": {
         "LOOM_WORKSPACE": "/Users/you/GitHub/loom"
-      }
-    },
-    "loom-logs": {
-      "command": "node",
-      "args": ["mcp-loom-logs/dist/index.js"]
-    },
-    "loom-terminals": {
-      "command": "node",
-      "args": ["mcp-loom-terminals/dist/index.js"],
-      "env": {
-        "LOOM_SOCKET_PATH": "/tmp/loom-daemon.sock"
       }
     }
   }
 }
 ```
 
-### Building MCP Servers
-
-MCP servers need to be built before use:
+Or generate the configuration automatically:
 
 ```bash
-# Build all MCP servers
-pnpm build
+./scripts/setup-mcp.sh
+```
 
-# Or build individually
-cd mcp-loom-ui && pnpm build
-cd mcp-loom-logs && pnpm build
-cd mcp-loom-terminals && pnpm build
+### Building MCP Server
+
+The MCP server needs to be built before use:
+
+```bash
+cd mcp-loom && npm install && npm run build
 ```
 
 ### Usage from Claude Code

--- a/mcp-loom-logs/README.md
+++ b/mcp-loom-logs/README.md
@@ -1,5 +1,8 @@
 # MCP Loom Logs
 
+> **DEPRECATED**: This package has been consolidated into the unified `mcp-loom` package.
+> Please use `mcp-loom` instead. See [mcp-loom/README.md](../mcp-loom/README.md) for migration instructions.
+
 MCP server for monitoring Loom application logs in real-time.
 
 ## Features

--- a/mcp-loom-terminals/README.md
+++ b/mcp-loom-terminals/README.md
@@ -1,5 +1,8 @@
 # MCP Loom Terminals
 
+> **DEPRECATED**: This package has been consolidated into the unified `mcp-loom` package.
+> Please use `mcp-loom` instead. See [mcp-loom/README.md](../mcp-loom/README.md) for migration instructions.
+
 MCP server for interacting with Loom terminal sessions. Provides tools to list terminals, read their output, and send commands.
 
 ## Features

--- a/mcp-loom/README.md
+++ b/mcp-loom/README.md
@@ -1,0 +1,172 @@
+# @loom/mcp - Unified Loom MCP Server
+
+A unified Model Context Protocol (MCP) server that provides programmatic control over Loom for Claude Code integration.
+
+This package consolidates three previously separate MCP servers:
+- `mcp-loom-logs` - Log monitoring tools
+- `mcp-loom-ui` - UI control and state management tools
+- `mcp-loom-terminals` - Terminal management tools
+
+## Installation
+
+```bash
+cd mcp-loom
+npm install
+npm run build
+```
+
+## Configuration
+
+Add to your MCP settings (`.mcp.json` or Claude Desktop config):
+
+```json
+{
+  "mcpServers": {
+    "loom": {
+      "command": "node",
+      "args": ["/path/to/loom/mcp-loom/dist/index.js"],
+      "env": {
+        "LOOM_WORKSPACE": "/path/to/your/workspace"
+      }
+    }
+  }
+}
+```
+
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `LOOM_WORKSPACE` | Path to the Loom workspace | `~/GitHub/loom` |
+| `LOOM_SOCKET_PATH` | Path to daemon socket | `~/.loom/loom-daemon.sock` |
+
+## Available Tools
+
+### Log Tools
+
+| Tool | Description |
+|------|-------------|
+| `tail_daemon_log` | Tail the Loom daemon log file (~/.loom/daemon.log) |
+| `tail_tauri_log` | Tail the Tauri application log file (~/.loom/tauri.log) |
+| `list_terminal_logs` | List all available terminal output logs |
+| `tail_terminal_log` | Tail a specific terminal's output log |
+
+### UI Tools
+
+| Tool | Description |
+|------|-------------|
+| `read_console_log` | Read browser console log for debugging |
+| `trigger_start` | Start engine with confirmation dialog |
+| `trigger_force_start` | Start engine without confirmation |
+| `trigger_factory_reset` | Reset workspace with confirmation |
+| `trigger_force_factory_reset` | Reset workspace without confirmation |
+| `read_state_file` | Read workspace state file |
+| `read_config_file` | Read workspace config file |
+| `get_heartbeat` | Check if Loom app is running |
+| `trigger_restart_terminal` | Restart a specific terminal |
+| `stop_engine` | Stop all terminals |
+| `trigger_run_now` | Execute interval prompt immediately |
+| `get_ui_state` | Get comprehensive UI state |
+| `get_random_file` | Get random file from workspace |
+
+### Terminal Tools
+
+| Tool | Description |
+|------|-------------|
+| `list_terminals` | List all active terminal sessions |
+| `get_terminal_output` | Get recent output from a terminal |
+| `get_selected_terminal` | Get info about selected terminal |
+| `send_terminal_input` | Send input to a terminal |
+| `check_tmux_server_health` | Check tmux server status |
+| `get_tmux_server_info` | Get tmux server details |
+| `toggle_tmux_verbose_logging` | Enable tmux debug logging |
+| `create_terminal` | Create a new terminal session |
+| `delete_terminal` | Delete a terminal session |
+| `restart_terminal` | Restart a terminal preserving config |
+| `configure_terminal` | Update terminal settings |
+| `set_primary_terminal` | Set primary terminal in UI |
+| `clear_terminal_history` | Clear terminal scrollback |
+| `start_autonomous_mode` | Start autonomous mode |
+| `stop_autonomous_mode` | Stop autonomous mode |
+| `launch_interval` | Trigger interval prompt manually |
+| `get_agent_metrics` | Get agent performance metrics |
+
+## Example Usage
+
+```typescript
+// Via Claude Code MCP integration
+const terminals = await mcp__loom__list_terminals();
+const state = await mcp__loom__get_ui_state();
+const logs = await mcp__loom__tail_daemon_log({ lines: 50 });
+
+// Create and configure a terminal
+await mcp__loom__create_terminal({ name: "Builder", role: "builder" });
+await mcp__loom__configure_terminal({
+  terminal_id: "terminal-1",
+  role_config: { targetInterval: 300000 }
+});
+```
+
+## Migration from Separate Packages
+
+If you were using the separate `mcp-loom-logs`, `mcp-loom-ui`, or `mcp-loom-terminals` packages, update your configuration:
+
+**Before (multiple servers):**
+```json
+{
+  "mcpServers": {
+    "loom-logs": { "command": "node", "args": ["mcp-loom-logs/dist/index.js"] },
+    "loom-ui": { "command": "node", "args": ["mcp-loom-ui/dist/index.js"] },
+    "loom-terminals": { "command": "node", "args": ["mcp-loom-terminals/dist/index.js"] }
+  }
+}
+```
+
+**After (unified server):**
+```json
+{
+  "mcpServers": {
+    "loom": {
+      "command": "node",
+      "args": ["mcp-loom/dist/index.js"],
+      "env": { "LOOM_WORKSPACE": "/path/to/workspace" }
+    }
+  }
+}
+```
+
+All tool names remain the same, so no code changes are needed for tool calls.
+
+## Development
+
+```bash
+# Watch mode for development
+npm run watch
+
+# Build for production
+npm run build
+```
+
+## Architecture
+
+```
+mcp-loom/
+├── src/
+│   ├── index.ts           # Main server entry point
+│   ├── types.ts           # Shared TypeScript types
+│   ├── shared/
+│   │   ├── config.ts      # Workspace/state file utilities
+│   │   ├── ipc.ts         # File-based IPC with retry
+│   │   ├── daemon.ts      # Socket-based daemon communication
+│   │   └── formatting.ts  # Log/output formatting
+│   └── tools/
+│       ├── logs.ts        # Log tools
+│       ├── ui.ts          # UI tools
+│       └── terminals.ts   # Terminal tools
+├── package.json
+└── tsconfig.json
+```
+
+## License
+
+MIT

--- a/mcp-loom/package-lock.json
+++ b/mcp-loom/package-lock.json
@@ -1,0 +1,1428 @@
+{
+  "name": "@loom/mcp",
+  "version": "0.3.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@loom/mcp",
+      "version": "0.3.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.3",
+        "fast-glob": "^3.3.2",
+        "ignore": "^6.0.2",
+        "strip-ansi": "^7.1.2"
+      },
+      "bin": {
+        "mcp-loom": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.18.10",
+        "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.25.3",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.3.tgz",
+      "integrity": "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "jose": "^6.1.1",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.7.tgz",
+      "integrity": "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.11.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.5.tgz",
+      "integrity": "sha512-WemPi9/WfyMwZs+ZUXdiwcCh9Y+m7L+8vki9MzDw3jJ+W9Lc+12HGsd368Qc1vZi1xwW8BWMMsnK5efYKPdt4g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-6.0.2.tgz",
+      "integrity": "sha512-InwqeHHN2XpumIkMvpl/DCJVrAHgCsG5+cn1XlnLWGwtZBm8QJfSusItfrwx81CTp5agNZqpKU2J/ccC5nGT4A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    }
+  }
+}

--- a/mcp-loom/package.json
+++ b/mcp-loom/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@loom/mcp",
+  "version": "0.3.0",
+  "description": "Unified MCP server for Loom - combines logs, UI, and terminal tools",
+  "type": "module",
+  "bin": {
+    "mcp-loom": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc --watch"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.25.3",
+    "fast-glob": "^3.3.2",
+    "ignore": "^6.0.2",
+    "strip-ansi": "^7.1.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.18.10",
+    "typescript": "^5.9.3"
+  }
+}

--- a/mcp-loom/src/index.ts
+++ b/mcp-loom/src/index.ts
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+/**
+ * Loom MCP Server - Unified Model Context Protocol server for Loom
+ *
+ * Consolidates three previously separate MCP servers:
+ * - mcp-loom-logs: Log monitoring tools
+ * - mcp-loom-ui: UI control and state management tools
+ * - mcp-loom-terminals: Terminal management tools
+ *
+ * All tools are now available through a single MCP server instance.
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+import { handleLogTool, logTools } from "./tools/logs.js";
+import { handleTerminalTool, terminalTools } from "./tools/terminals.js";
+import { handleUITool, uiTools } from "./tools/ui.js";
+
+// Combine all tools from all modules
+const allTools = [...logTools, ...uiTools, ...terminalTools];
+
+// Create the unified MCP server
+const server = new Server(
+  {
+    name: "loom",
+    version: "0.3.0",
+  },
+  {
+    capabilities: {
+      tools: {},
+    },
+  }
+);
+
+// Register tool list handler
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return { tools: allTools };
+});
+
+// Register tool call handler
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+
+  try {
+    // Determine which module handles this tool
+    const logToolNames = logTools.map((t) => t.name);
+    const uiToolNames = uiTools.map((t) => t.name);
+    const terminalToolNames = terminalTools.map((t) => t.name);
+
+    let content: { type: "text"; text: string }[];
+
+    if (logToolNames.includes(name)) {
+      content = await handleLogTool(name, args as Record<string, unknown>);
+    } else if (uiToolNames.includes(name)) {
+      content = await handleUITool(name, args as Record<string, unknown>);
+    } else if (terminalToolNames.includes(name)) {
+      content = await handleTerminalTool(name, args as Record<string, unknown>);
+    } else {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Unknown tool: ${name}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    return { content };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Error: ${errorMessage}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+});
+
+// Start the server
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error("Loom MCP server running on stdio (unified: logs + ui + terminals)");
+}
+
+main().catch((error) => {
+  console.error("Fatal error in main():", error);
+  process.exit(1);
+});

--- a/mcp-loom/src/shared/config.ts
+++ b/mcp-loom/src/shared/config.ts
@@ -1,0 +1,154 @@
+/**
+ * Shared configuration utilities for Loom MCP server
+ *
+ * Handles workspace path resolution, state file reading/writing,
+ * and config file operations.
+ */
+
+import { access, readFile, stat, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { ConfigFile, StateFile } from "../types.js";
+
+/** Global Loom directory in user's home */
+export const LOOM_DIR = join(homedir(), ".loom");
+
+/** Daemon log file path */
+export const DAEMON_LOG = join(LOOM_DIR, "daemon.log");
+
+/** Tauri application log file path */
+export const TAURI_LOG = join(LOOM_DIR, "tauri.log");
+
+/** Browser console log file path */
+export const CONSOLE_LOG_PATH = join(LOOM_DIR, "console.log");
+
+/** Global state file path */
+export const STATE_FILE = join(LOOM_DIR, "state.json");
+
+/** MCP command file for file-based IPC */
+export const MCP_COMMAND_FILE = join(LOOM_DIR, "mcp-command.json");
+
+/** MCP acknowledgment file for file-based IPC */
+export const MCP_ACK_FILE = join(LOOM_DIR, "mcp-ack.json");
+
+/** Daemon socket path (can be overridden via LOOM_SOCKET_PATH env var) */
+export const SOCKET_PATH =
+  process.env.LOOM_SOCKET_PATH || join(LOOM_DIR, "loom-daemon.sock");
+
+/**
+ * Get the workspace path from environment or default
+ */
+export function getWorkspacePath(): string {
+  return process.env.LOOM_WORKSPACE || join(homedir(), "GitHub", "loom");
+}
+
+/**
+ * Read a file and check if it exists
+ */
+export async function readFileIfExists(filePath: string): Promise<string | null> {
+  try {
+    await access(filePath);
+    return await readFile(filePath, "utf-8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Read the global state file
+ */
+export async function readStateFile(): Promise<StateFile | null> {
+  try {
+    const fileStats = await stat(STATE_FILE);
+    if (!fileStats.isFile()) {
+      return null;
+    }
+
+    const content = await readFile(STATE_FILE, "utf-8");
+    return JSON.parse(content) as StateFile;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Write the global state file
+ */
+export async function writeStateFile(state: StateFile): Promise<void> {
+  state.lastUpdated = new Date().toISOString();
+  await writeFile(STATE_FILE, JSON.stringify(state, null, 2), "utf-8");
+}
+
+/**
+ * Read the workspace config file
+ */
+export async function readConfigFile(): Promise<ConfigFile | null> {
+  try {
+    const workspacePath = getWorkspacePath();
+    const configPath = join(workspacePath, ".loom", "config.json");
+
+    const fileStats = await stat(configPath);
+    if (!fileStats.isFile()) {
+      return null;
+    }
+
+    const content = await readFile(configPath, "utf-8");
+    return JSON.parse(content) as ConfigFile;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Write the workspace config file
+ */
+export async function writeConfigFile(config: ConfigFile): Promise<void> {
+  const workspacePath = getWorkspacePath();
+  const configPath = join(workspacePath, ".loom", "config.json");
+  await writeFile(configPath, JSON.stringify(config, null, 2), "utf-8");
+}
+
+/**
+ * Read the workspace state file (returns as string for compatibility)
+ */
+export async function readWorkspaceStateFile(): Promise<string> {
+  try {
+    const workspacePath = getWorkspacePath();
+    const statePath = join(workspacePath, ".loom", "state.json");
+
+    await access(statePath);
+    return await readFile(statePath, "utf-8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return "State file not found. Workspace may not be initialized.";
+    }
+    throw error;
+  }
+}
+
+/**
+ * Read the workspace config file (returns as string for compatibility)
+ */
+export async function readWorkspaceConfigFile(): Promise<string> {
+  try {
+    const workspacePath = getWorkspacePath();
+    const configPath = join(workspacePath, ".loom", "config.json");
+
+    await access(configPath);
+    return await readFile(configPath, "utf-8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return "Config file not found. Workspace may not be initialized.";
+    }
+    throw error;
+  }
+}

--- a/mcp-loom/src/shared/daemon.ts
+++ b/mcp-loom/src/shared/daemon.ts
@@ -1,0 +1,47 @@
+/**
+ * Daemon socket communication for Loom MCP server
+ *
+ * Handles direct socket communication with the Loom daemon process.
+ */
+
+import { Socket } from "node:net";
+import { SOCKET_PATH } from "./config.js";
+
+/**
+ * Send a request to the Loom daemon and get the response
+ *
+ * Uses Unix domain socket to communicate with the running daemon.
+ * The daemon expects JSON-encoded requests and returns JSON-encoded responses.
+ *
+ * @param request - The request object to send
+ * @returns The parsed response from the daemon
+ * @throws Error if connection fails or response cannot be parsed
+ */
+export async function sendDaemonRequest(request: unknown): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const socket = new Socket();
+    let buffer = "";
+
+    socket.on("data", (data) => {
+      buffer += data.toString();
+    });
+
+    socket.on("end", () => {
+      try {
+        const response = JSON.parse(buffer);
+        resolve(response);
+      } catch (error) {
+        reject(new Error(`Failed to parse daemon response: ${error}`));
+      }
+    });
+
+    socket.on("error", (error) => {
+      reject(new Error(`Failed to connect to Loom daemon at ${SOCKET_PATH}: ${error.message}`));
+    });
+
+    socket.connect(SOCKET_PATH, () => {
+      socket.write(JSON.stringify(request));
+      socket.write("\n");
+    });
+  });
+}

--- a/mcp-loom/src/shared/formatting.ts
+++ b/mcp-loom/src/shared/formatting.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared formatting utilities for Loom MCP server
+ *
+ * Provides consistent log and output formatting across all tools.
+ */
+
+import type { LogResult } from "../types.js";
+
+/**
+ * Format log output with metadata header
+ *
+ * Creates a consistent format for displaying log contents with
+ * information about lines returned and total available.
+ */
+export function formatLogOutput(result: LogResult, logName: string): string {
+  if (result.error) {
+    return `--- ${logName} (0 lines, file empty or does not exist) ---\n${result.error}`;
+  }
+  if (result.linesReturned === 0) {
+    return `--- ${logName} (0 lines, file empty) ---\n(empty log file)`;
+  }
+  return `--- ${logName} (${result.linesReturned} lines returned, ${result.totalLines} total lines available) ---\n${result.content}`;
+}
+
+/**
+ * Format terminal output with metadata header
+ *
+ * Similar to formatLogOutput but specifically for terminal output.
+ */
+export function formatTerminalOutput(result: LogResult, terminalId: string): string {
+  if (result.error) {
+    return `--- Terminal ${terminalId} Output (0 lines, file empty or does not exist) ---\n${result.error}`;
+  }
+  if (result.linesReturned === 0) {
+    return `--- Terminal ${terminalId} Output (0 lines, file empty) ---\n(empty terminal output)`;
+  }
+  return `--- Terminal ${terminalId} Output (${result.linesReturned} lines returned, ${result.totalLines} total lines available) ---\n${result.content}`;
+}

--- a/mcp-loom/src/shared/ipc.ts
+++ b/mcp-loom/src/shared/ipc.ts
@@ -1,0 +1,89 @@
+/**
+ * File-based IPC utilities for Loom MCP server
+ *
+ * Implements a file-based command/acknowledgment pattern for
+ * communication with the Loom UI application.
+ */
+
+import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { LOOM_DIR, MCP_ACK_FILE, MCP_COMMAND_FILE } from "./config.js";
+
+/**
+ * Write MCP command to control file for Loom to pick up with retry and exponential backoff
+ *
+ * This is a file-based IPC mechanism with acknowledgment. The process:
+ * 1. Write command to MCP_COMMAND_FILE
+ * 2. Wait for acknowledgment in MCP_ACK_FILE
+ * 3. Retry with exponential backoff until ack or timeout
+ *
+ * @param command - The command string to send
+ * @returns Status message about command processing
+ */
+export async function writeMCPCommand(command: string): Promise<string> {
+  // Ensure .loom directory exists
+  try {
+    await mkdir(LOOM_DIR, { recursive: true });
+  } catch (_error) {
+    // Directory might already exist, that's fine
+  }
+
+  // Clean up old acknowledgment file before writing new command
+  try {
+    await rm(MCP_ACK_FILE);
+  } catch (_error) {
+    // Ack file might not exist, that's fine
+  }
+
+  // Write command with timestamp
+  const commandData = {
+    command,
+    timestamp: new Date().toISOString(),
+  };
+
+  await writeFile(MCP_COMMAND_FILE, JSON.stringify(commandData, null, 2));
+
+  // Retry with exponential backoff to wait for acknowledgment
+  const maxRetries = 8; // Max 8 retries
+  const baseDelay = 100; // Start with 100ms
+  const maxDelay = 5000; // Cap at 5 seconds
+  let totalWaitTime = 0;
+
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    // Calculate exponential backoff delay: 100ms, 200ms, 400ms, 800ms, 1600ms, 3200ms, 5000ms, 5000ms
+    const delay = Math.min(baseDelay * 2 ** attempt, maxDelay);
+    totalWaitTime += delay;
+
+    // Wait before checking for acknowledgment
+    await new Promise((resolve) => setTimeout(resolve, delay));
+
+    // Check if acknowledgment file exists
+    try {
+      await stat(MCP_ACK_FILE);
+
+      // Read acknowledgment data
+      const ackContent = await readFile(MCP_ACK_FILE, "utf-8");
+      const ackData = JSON.parse(ackContent);
+
+      // Verify the ack is for our command
+      if (ackData.command === command && ackData.timestamp === commandData.timestamp) {
+        // Clean up acknowledgment file
+        try {
+          await rm(MCP_ACK_FILE);
+        } catch (_error) {
+          // Ignore cleanup errors
+        }
+
+        if (ackData.success) {
+          return `MCP command '${command}' processed successfully (waited ${totalWaitTime}ms, attempt ${attempt + 1}/${maxRetries})`;
+        } else {
+          return `MCP command '${command}' acknowledged but execution failed (waited ${totalWaitTime}ms, attempt ${attempt + 1}/${maxRetries})`;
+        }
+      }
+    } catch (_error) {
+      // Ack file doesn't exist yet or couldn't be read, continue retrying
+    }
+  }
+
+  // Max retries exceeded - give up but don't error
+  return `MCP command '${command}' written but no acknowledgment received after ${maxRetries} retries (${totalWaitTime}ms total). The command may still be processing.`;
+}

--- a/mcp-loom/src/tools/logs.ts
+++ b/mcp-loom/src/tools/logs.ts
@@ -1,0 +1,232 @@
+/**
+ * Log tools for Loom MCP server
+ *
+ * Provides tools for monitoring Loom application logs:
+ * - Daemon log (daemon activity, terminal creation, IPC)
+ * - Tauri log (frontend activity, state changes, UI errors)
+ * - Terminal logs (per-terminal output)
+ */
+
+import { readdir, readFile, stat } from "node:fs/promises";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { DAEMON_LOG, TAURI_LOG } from "../shared/config.js";
+import { formatLogOutput } from "../shared/formatting.js";
+import type { LogResult } from "../types.js";
+
+interface LogTailOptions {
+  lines?: number;
+}
+
+/**
+ * Tail a log file, returning the last N lines
+ */
+async function tailLogFile(filePath: string, options: LogTailOptions = {}): Promise<LogResult> {
+  const { lines = 20 } = options;
+
+  try {
+    const fileStats = await stat(filePath);
+    if (!fileStats.isFile()) {
+      return {
+        content: "",
+        linesReturned: 0,
+        totalLines: 0,
+        error: `${filePath} is not a file`,
+      };
+    }
+
+    const content = await readFile(filePath, "utf-8");
+    const allLines = content.split("\n");
+    // Filter out empty lines at the end
+    const nonEmptyLines = allLines.filter(
+      (line, index) => line !== "" || index < allLines.length - 1
+    );
+    const totalLines = nonEmptyLines.filter(Boolean).length;
+
+    // Get last N lines (excluding empty trailing line)
+    const relevantLines = allLines.slice(-lines - 1, -1).filter(Boolean);
+    const linesReturned = relevantLines.length;
+
+    return {
+      content: relevantLines.join("\n"),
+      linesReturned,
+      totalLines,
+    };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return {
+        content: "",
+        linesReturned: 0,
+        totalLines: 0,
+        error: `Log file not found: ${filePath}\n\nThis usually means:\n- Loom hasn't been started yet, or\n- Logging to file hasn't been configured`,
+      };
+    }
+    return {
+      content: "",
+      linesReturned: 0,
+      totalLines: 0,
+      error: `Error reading log: ${error}`,
+    };
+  }
+}
+
+/**
+ * List all terminal output logs in /tmp
+ */
+async function listTerminalLogs(): Promise<string[]> {
+  try {
+    const tmpFiles = await readdir("/tmp");
+    return tmpFiles
+      .filter((f) => f.startsWith("loom-") && f.endsWith(".out"))
+      .map((f) => `/tmp/${f}`);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Get output from a specific terminal's log file
+ */
+async function getTerminalLog(terminalId: string, lines: number = 20): Promise<LogResult> {
+  const logPath = `/tmp/loom-${terminalId}.out`;
+  return tailLogFile(logPath, { lines });
+}
+
+/**
+ * Log tool definitions
+ */
+export const logTools: Tool[] = [
+  {
+    name: "tail_daemon_log",
+    description:
+      "Tail the Loom daemon log file (~/.loom/daemon.log). Shows recent daemon activity including terminal creation, IPC requests, and errors.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        lines: {
+          type: "number",
+          description: "Number of lines to show (default: 20)",
+          default: 20,
+        },
+      },
+    },
+  },
+  {
+    name: "tail_tauri_log",
+    description:
+      "Tail the Loom Tauri application log file (~/.loom/tauri.log). Shows frontend activity, state changes, and UI errors.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        lines: {
+          type: "number",
+          description: "Number of lines to show (default: 20)",
+          default: 20,
+        },
+      },
+    },
+  },
+  {
+    name: "list_terminal_logs",
+    description:
+      "List all available terminal output logs (/tmp/loom-*.out). Each terminal's output is captured to a separate file.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+  },
+  {
+    name: "tail_terminal_log",
+    description:
+      "Tail a specific terminal's output log. Terminal IDs are like 'terminal-1', 'terminal-2', etc.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        terminal_id: {
+          type: "string",
+          description: "Terminal ID (e.g., 'terminal-1')",
+        },
+        lines: {
+          type: "number",
+          description: "Number of lines to show (default: 20)",
+          default: 20,
+        },
+      },
+      required: ["terminal_id"],
+    },
+  },
+];
+
+/**
+ * Handle log tool calls
+ */
+export async function handleLogTool(
+  name: string,
+  args?: Record<string, unknown>
+): Promise<{ type: "text"; text: string }[]> {
+  switch (name) {
+    case "tail_daemon_log": {
+      const lines = (args?.lines as number) || 20;
+      const result = await tailLogFile(DAEMON_LOG, { lines });
+      return [
+        {
+          type: "text",
+          text: formatLogOutput(result, "Daemon Log"),
+        },
+      ];
+    }
+
+    case "tail_tauri_log": {
+      const lines = (args?.lines as number) || 20;
+      const result = await tailLogFile(TAURI_LOG, { lines });
+      return [
+        {
+          type: "text",
+          text: formatLogOutput(result, "Tauri Log"),
+        },
+      ];
+    }
+
+    case "list_terminal_logs": {
+      const logs = await listTerminalLogs();
+      if (logs.length === 0) {
+        return [
+          {
+            type: "text",
+            text: "No terminal logs found. Terminals may not have been created yet.",
+          },
+        ];
+      }
+      return [
+        {
+          type: "text",
+          text: `=== Available Terminal Logs ===\n\n${logs.join("\n")}`,
+        },
+      ];
+    }
+
+    case "tail_terminal_log": {
+      const terminalId = args?.terminal_id as string;
+      const lines = (args?.lines as number) || 20;
+
+      if (!terminalId) {
+        return [
+          {
+            type: "text",
+            text: "Error: terminal_id is required",
+          },
+        ];
+      }
+
+      const result = await getTerminalLog(terminalId, lines);
+      return [
+        {
+          type: "text",
+          text: formatLogOutput(result, `Terminal ${terminalId} Log`),
+        },
+      ];
+    }
+
+    default:
+      throw new Error(`Unknown log tool: ${name}`);
+  }
+}

--- a/mcp-loom/src/tools/terminals.ts
+++ b/mcp-loom/src/tools/terminals.ts
@@ -1,0 +1,1502 @@
+/**
+ * Terminal tools for Loom MCP server
+ *
+ * Provides tools for managing Loom terminal sessions:
+ * - List, create, delete, restart terminals
+ * - Send input to terminals
+ * - Get terminal output
+ * - Configure terminal settings
+ * - Control autonomous mode
+ * - Monitor tmux health
+ * - Query agent metrics
+ */
+
+import { exec } from "node:child_process";
+import { readFile, stat, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import stripAnsi from "strip-ansi";
+import {
+  getWorkspacePath,
+  readConfigFile,
+  readStateFile,
+  writeConfigFile,
+  writeStateFile,
+} from "../shared/config.js";
+import { sendDaemonRequest } from "../shared/daemon.js";
+import { formatTerminalOutput } from "../shared/formatting.js";
+import { writeMCPCommand } from "../shared/ipc.js";
+import type {
+  AgentMetricsResult,
+  ConfigureTerminalOptions,
+  CreateTerminalConfig,
+  LogResult,
+  Terminal,
+} from "../types.js";
+
+const execAsync = promisify(exec);
+
+/**
+ * List all active terminals from the daemon
+ */
+async function listTerminals(): Promise<Terminal[]> {
+  try {
+    const response = (await sendDaemonRequest({
+      type: "ListTerminals",
+    })) as { type: string; payload?: { terminals: Terminal[] } };
+
+    if (response.type === "TerminalList" && response.payload?.terminals) {
+      return response.payload.terminals;
+    }
+
+    return [];
+  } catch (_error) {
+    // If daemon is not running, fall back to state file
+    const state = await readStateFile();
+    if (!state) return [];
+
+    // Map state file format to Terminal format
+    return state.terminals.map((t) => ({
+      id: t.id,
+      name: t.id, // State file doesn't have name
+      role: undefined,
+      working_dir: t.worktreePath,
+      tmux_session: `loom-${t.id}`,
+      created_at: 0,
+      isPrimary: t.isPrimary,
+    }));
+  }
+}
+
+/**
+ * Get terminal output from the log file
+ */
+async function getTerminalOutput(terminalId: string, lines = 20): Promise<LogResult> {
+  try {
+    const logPath = `/tmp/loom-${terminalId}.out`;
+    const content = await readFile(logPath, "utf-8");
+    const allLines = content.split("\n");
+    const totalLines = allLines.filter(Boolean).length;
+
+    // Get last N lines (excluding empty trailing line)
+    const relevantLines = allLines.slice(-lines - 1, -1).filter(Boolean);
+    const linesReturned = relevantLines.length;
+
+    // Strip ANSI escape sequences from output before returning
+    const cleanOutput = relevantLines.map((line) => stripAnsi(line)).join("\n");
+
+    return {
+      content: cleanOutput,
+      linesReturned,
+      totalLines,
+    };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return {
+        content: "",
+        linesReturned: 0,
+        totalLines: 0,
+        error: `Terminal output file not found for ${terminalId}.\n\nThis usually means:\n- The terminal hasn't been created yet, or\n- The terminal was closed`,
+      };
+    }
+    return {
+      content: "",
+      linesReturned: 0,
+      totalLines: 0,
+      error: `Error reading terminal output: ${error}`,
+    };
+  }
+}
+
+/**
+ * Send input to a terminal
+ */
+async function sendTerminalInput(terminalId: string, input: string): Promise<string> {
+  try {
+    const response = (await sendDaemonRequest({
+      type: "SendInput",
+      payload: {
+        id: terminalId,
+        data: input,
+      },
+    })) as { type: string };
+
+    if (response.type === "Success") {
+      return "Input sent successfully";
+    }
+
+    return `Unexpected response: ${response.type}`;
+  } catch (error) {
+    return `Error sending input: ${error}`;
+  }
+}
+
+/**
+ * Check tmux server health
+ */
+async function checkTmuxServerHealth(): Promise<{
+  serverRunning: boolean;
+  sessionCount: number;
+  sessions: string[];
+  errorMessage?: string;
+}> {
+  try {
+    const { stdout } = await execAsync("tmux -L loom list-sessions -F '#{session_name}'");
+    const sessions = stdout
+      .trim()
+      .split("\n")
+      .filter((s) => s.startsWith("loom-"));
+
+    return {
+      serverRunning: true,
+      sessionCount: sessions.length,
+      sessions,
+    };
+  } catch (error: unknown) {
+    const err = error as { code?: number; stderr?: string };
+    return {
+      serverRunning: false,
+      sessionCount: 0,
+      sessions: [],
+      errorMessage: err.stderr || String(error),
+    };
+  }
+}
+
+/**
+ * Get tmux server information
+ */
+async function getTmuxServerInfo(): Promise<{
+  serverProcess?: string;
+  socketPath: string;
+  socketExists: boolean;
+  tmuxVersion?: string;
+  errorMessage?: string;
+}> {
+  const uid = process.getuid?.() || 0;
+  const socketPath = `/private/tmp/tmux-${uid}/loom`;
+
+  try {
+    const socketExists = await stat(socketPath)
+      .then(() => true)
+      .catch(() => false);
+
+    let serverProcess: string | undefined;
+    try {
+      const { stdout } = await execAsync("ps aux | grep 'tmux.*-L loom' | grep -v grep");
+      serverProcess = stdout.trim();
+    } catch {
+      serverProcess = undefined;
+    }
+
+    let tmuxVersion: string | undefined;
+    try {
+      const { stdout } = await execAsync("tmux -V");
+      tmuxVersion = stdout.trim();
+    } catch {
+      tmuxVersion = undefined;
+    }
+
+    return {
+      serverProcess,
+      socketPath,
+      socketExists,
+      tmuxVersion,
+    };
+  } catch (error) {
+    return {
+      socketPath,
+      socketExists: false,
+      errorMessage: String(error),
+    };
+  }
+}
+
+/**
+ * Toggle tmux verbose logging
+ */
+async function toggleTmuxVerboseLogging(): Promise<{
+  success: boolean;
+  message: string;
+  pid?: string;
+}> {
+  try {
+    const { stdout } = await execAsync("pgrep -f 'tmux.*-L loom'");
+    const pid = stdout.trim();
+
+    if (!pid) {
+      return {
+        success: false,
+        message: "tmux server not found (no process matching 'tmux.*-L loom')",
+      };
+    }
+
+    await execAsync(`kill -SIGUSR2 ${pid}`);
+
+    return {
+      success: true,
+      message: `Sent SIGUSR2 to tmux server (PID ${pid}) - check for tmux-server-${pid}.log`,
+      pid,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      message: `Error toggling tmux verbose logging: ${error}`,
+    };
+  }
+}
+
+/**
+ * Generate a unique terminal ID
+ */
+async function generateTerminalId(): Promise<string> {
+  const terminals = await listTerminals();
+  const existingIds = terminals.map((t) => t.id);
+
+  let maxNum = 0;
+  for (const id of existingIds) {
+    const match = id.match(/^terminal-(\d+)$/);
+    if (match) {
+      const num = parseInt(match[1], 10);
+      if (num > maxNum) {
+        maxNum = num;
+      }
+    }
+  }
+
+  return `terminal-${maxNum + 1}`;
+}
+
+/**
+ * Create a new terminal
+ */
+async function createTerminal(config: CreateTerminalConfig): Promise<{
+  success: boolean;
+  terminal_id?: string;
+  error?: string;
+}> {
+  try {
+    const terminalId = await generateTerminalId();
+    const name = config.name || `${config.role || "default"}-${Date.now()}`;
+
+    const response = (await sendDaemonRequest({
+      type: "CreateTerminal",
+      payload: {
+        config_id: terminalId,
+        name,
+        working_dir: config.workingDir || null,
+        role: config.role || null,
+        instance_number: 0,
+      },
+    })) as { type: string; payload?: { id: string }; message?: string };
+
+    if (response.type === "TerminalCreated" && response.payload?.id) {
+      return {
+        success: true,
+        terminal_id: response.payload.id,
+      };
+    }
+
+    if (response.type === "Error") {
+      return {
+        success: false,
+        error: response.message || "Unknown error creating terminal",
+      };
+    }
+
+    return {
+      success: false,
+      error: `Unexpected response: ${response.type}`,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: `Error creating terminal: ${error}`,
+    };
+  }
+}
+
+/**
+ * Delete a terminal
+ */
+async function deleteTerminal(terminalId: string): Promise<{
+  success: boolean;
+  error?: string;
+}> {
+  try {
+    const response = (await sendDaemonRequest({
+      type: "DestroyTerminal",
+      payload: {
+        id: terminalId,
+      },
+    })) as { type: string; message?: string };
+
+    if (response.type === "Success") {
+      return { success: true };
+    }
+
+    if (response.type === "Error") {
+      return {
+        success: false,
+        error: response.message || "Unknown error deleting terminal",
+      };
+    }
+
+    return {
+      success: false,
+      error: `Unexpected response: ${response.type}`,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: `Error deleting terminal: ${error}`,
+    };
+  }
+}
+
+/**
+ * Restart a terminal
+ */
+async function restartTerminal(terminalId: string): Promise<{
+  success: boolean;
+  terminal_id?: string;
+  error?: string;
+}> {
+  try {
+    const terminals = await listTerminals();
+    const terminal = terminals.find((t) => t.id === terminalId);
+
+    if (!terminal) {
+      return {
+        success: false,
+        error: `Terminal ${terminalId} not found`,
+      };
+    }
+
+    const savedConfig = {
+      name: terminal.name,
+      role: terminal.role,
+      working_dir: terminal.working_dir,
+    };
+
+    const destroyResult = await deleteTerminal(terminalId);
+    if (!destroyResult.success) {
+      return {
+        success: false,
+        error: `Failed to destroy terminal: ${destroyResult.error}`,
+      };
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    const response = (await sendDaemonRequest({
+      type: "CreateTerminal",
+      payload: {
+        config_id: terminalId,
+        name: savedConfig.name,
+        working_dir: savedConfig.working_dir || null,
+        role: savedConfig.role || null,
+        instance_number: 0,
+      },
+    })) as { type: string; payload?: { id: string }; message?: string };
+
+    if (response.type === "TerminalCreated" && response.payload?.id) {
+      return {
+        success: true,
+        terminal_id: response.payload.id,
+      };
+    }
+
+    if (response.type === "Error") {
+      return {
+        success: false,
+        error: response.message || "Unknown error recreating terminal",
+      };
+    }
+
+    return {
+      success: false,
+      error: `Unexpected response: ${response.type}`,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: `Error restarting terminal: ${error}`,
+    };
+  }
+}
+
+/**
+ * Configure a terminal
+ */
+async function configureTerminal(
+  terminalId: string,
+  options: ConfigureTerminalOptions
+): Promise<{
+  success: boolean;
+  error?: string;
+}> {
+  try {
+    if (!options.name && !options.role && !options.roleConfig && !options.theme) {
+      return {
+        success: false,
+        error: "At least one configuration option must be provided",
+      };
+    }
+
+    const config = await readConfigFile();
+    if (!config) {
+      return {
+        success: false,
+        error: "Config file not found. Workspace may not be initialized.",
+      };
+    }
+
+    const terminalIndex = config.terminals.findIndex((t) => t.id === terminalId);
+    if (terminalIndex === -1) {
+      return {
+        success: false,
+        error: `Terminal ${terminalId} not found in config`,
+      };
+    }
+
+    const terminal = config.terminals[terminalIndex];
+
+    if (options.name !== undefined) {
+      terminal.name = options.name;
+    }
+    if (options.role !== undefined) {
+      terminal.role = options.role;
+    }
+    if (options.theme !== undefined) {
+      terminal.theme = options.theme;
+    }
+    if (options.roleConfig !== undefined) {
+      terminal.roleConfig = {
+        ...terminal.roleConfig,
+        ...options.roleConfig,
+      };
+    }
+
+    config.terminals[terminalIndex] = terminal;
+    await writeConfigFile(config);
+
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: `Error configuring terminal: ${error}`,
+    };
+  }
+}
+
+/**
+ * Set the primary terminal
+ */
+async function setPrimaryTerminal(terminalId: string): Promise<{
+  success: boolean;
+  error?: string;
+}> {
+  try {
+    const terminals = await listTerminals();
+    const terminal = terminals.find((t) => t.id === terminalId);
+
+    if (!terminal) {
+      return {
+        success: false,
+        error: `Terminal ${terminalId} not found`,
+      };
+    }
+
+    let state = await readStateFile();
+    if (!state) {
+      state = {
+        terminals: terminals.map((t) => ({
+          id: t.id,
+          status: "idle",
+          isPrimary: t.id === terminalId,
+          worktreePath: t.working_dir,
+          lastIntervalRun: undefined,
+        })),
+        selectedTerminalId: terminalId,
+        lastUpdated: new Date().toISOString(),
+        nextAgentNumber: terminals.length + 1,
+      };
+    } else {
+      for (const t of state.terminals) {
+        t.isPrimary = t.id === terminalId;
+      }
+      state.selectedTerminalId = terminalId;
+    }
+
+    await writeStateFile(state);
+
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: `Error setting primary terminal: ${error}`,
+    };
+  }
+}
+
+/**
+ * Clear terminal history
+ */
+async function clearTerminalHistory(terminalId: string): Promise<{
+  success: boolean;
+  error?: string;
+}> {
+  try {
+    const terminals = await listTerminals();
+    const terminal = terminals.find((t) => t.id === terminalId);
+
+    if (!terminal) {
+      return {
+        success: false,
+        error: `Terminal ${terminalId} not found`,
+      };
+    }
+
+    try {
+      await execAsync(`tmux -L loom clear-history -t "${terminal.tmux_session}"`);
+    } catch (error) {
+      const stderr = (error as { stderr?: string }).stderr || "";
+      if (!stderr.includes("no server running") && !stderr.includes("session not found")) {
+        // Log warning but continue
+      }
+    }
+
+    const outputFile = `/tmp/loom-${terminalId}.out`;
+    try {
+      await writeFile(outputFile, "", "utf-8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        return {
+          success: false,
+          error: `Failed to clear output log file: ${error}`,
+        };
+      }
+    }
+
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: `Error clearing terminal history: ${error}`,
+    };
+  }
+}
+
+/**
+ * Get agent performance metrics
+ */
+async function getAgentMetrics(options: {
+  command?: string;
+  role?: string;
+  period?: string;
+  format?: string;
+  issue?: number;
+}): Promise<AgentMetricsResult> {
+  const workspacePath = getWorkspacePath();
+  const scriptPath = join(workspacePath, ".loom", "scripts", "agent-metrics.sh");
+
+  try {
+    await stat(scriptPath);
+  } catch {
+    return {
+      success: false,
+      error: `Agent metrics script not found at ${scriptPath}. Ensure Loom is installed.`,
+      format: "text",
+      output: "",
+    };
+  }
+
+  const args: string[] = [];
+
+  if (options.command && options.command !== "summary") {
+    args.push(options.command);
+  }
+
+  if (options.role) {
+    args.push("--role", options.role);
+  }
+
+  if (options.period) {
+    args.push("--period", options.period);
+  }
+
+  const format = options.format || "json";
+  args.push("--format", format);
+
+  if (options.issue) {
+    args.push("--issue", String(options.issue));
+  }
+
+  try {
+    const { stdout, stderr } = await execAsync(`bash "${scriptPath}" ${args.join(" ")}`, {
+      cwd: workspacePath,
+    });
+
+    if (stderr) {
+      console.error("agent-metrics.sh stderr:", stderr);
+    }
+
+    let data: unknown;
+    if (format === "json") {
+      try {
+        data = JSON.parse(stdout.trim());
+      } catch {
+        return {
+          success: true,
+          output: stdout.trim(),
+          format: "text",
+        };
+      }
+    }
+
+    return {
+      success: true,
+      data,
+      output: stdout.trim(),
+      format: format as "json" | "text",
+    };
+  } catch (error) {
+    const err = error as { stderr?: string; message?: string };
+    return {
+      success: false,
+      error: err.stderr || err.message || String(error),
+      format: "text",
+      output: "",
+    };
+  }
+}
+
+/**
+ * Terminal tool definitions
+ */
+export const terminalTools: Tool[] = [
+  {
+    name: "list_terminals",
+    description:
+      "List all active Loom terminal sessions with their IDs, names, roles, and working directories. Use this to discover which terminals are available.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+  },
+  {
+    name: "get_terminal_output",
+    description:
+      "Get the recent output from a specific terminal. Returns the last N lines of output (default 20). Use this to see what a terminal is currently showing.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        terminal_id: {
+          type: "string",
+          description: "Terminal ID (e.g., 'terminal-1', 'terminal-2')",
+        },
+        lines: {
+          type: "number",
+          description: "Number of lines to show (default: 20)",
+          default: 20,
+        },
+      },
+      required: ["terminal_id"],
+    },
+  },
+  {
+    name: "get_selected_terminal",
+    description:
+      "Get information about the currently selected (primary) terminal in Loom. Returns the terminal's ID, name, role, and recent output.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        lines: {
+          type: "number",
+          description: "Number of output lines to include (default: 20)",
+          default: 20,
+        },
+      },
+    },
+  },
+  {
+    name: "send_terminal_input",
+    description:
+      "Send input (commands or text) to a specific terminal. Use this to execute commands in a terminal. Note: Input is sent as literal text, so include '\\n' for Enter key.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        terminal_id: {
+          type: "string",
+          description: "Terminal ID (e.g., 'terminal-1')",
+        },
+        input: {
+          type: "string",
+          description: "Text or command to send. Use '\\n' to send Enter, '\\u0003' for Ctrl+C",
+        },
+      },
+      required: ["terminal_id", "input"],
+    },
+  },
+  {
+    name: "check_tmux_server_health",
+    description:
+      "Check if tmux server is running and count active loom sessions. Use this to verify tmux server status and detect crashes.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+  },
+  {
+    name: "get_tmux_server_info",
+    description:
+      "Get tmux server information including PID, socket path, and version. Use this to diagnose tmux server issues and verify socket paths.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+  },
+  {
+    name: "toggle_tmux_verbose_logging",
+    description:
+      "Toggle tmux verbose logging by sending SIGUSR2 to the tmux server. Creates tmux-server-{PID}.log file. Use this for deep debugging of tmux issues.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+  },
+  {
+    name: "create_terminal",
+    description:
+      "Create a new Loom terminal session. Returns the new terminal's ID which can be used for other operations. The terminal will be created with its own tmux session.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: {
+          type: "string",
+          description: "Human-readable name for the terminal (e.g., 'Builder', 'Judge')",
+        },
+        role: {
+          type: "string",
+          description: "Role for the terminal (e.g., 'builder', 'judge', 'curator')",
+        },
+        role_file: {
+          type: "string",
+          description: "Role definition file (e.g., 'builder.md', 'judge.md')",
+        },
+        target_interval: {
+          type: "number",
+          description: "Interval in milliseconds for autonomous operation (0 for manual)",
+          default: 0,
+        },
+        interval_prompt: {
+          type: "string",
+          description: "Prompt to send at each interval for autonomous terminals",
+          default: "",
+        },
+        theme: {
+          type: "string",
+          description: "Terminal theme (optional)",
+        },
+        working_dir: {
+          type: "string",
+          description: "Working directory for the terminal (optional, defaults to workspace root)",
+        },
+      },
+    },
+  },
+  {
+    name: "delete_terminal",
+    description:
+      "Delete (destroy) a Loom terminal session. This will kill the tmux session, clean up the output log file, and remove any associated worktree if it's not used by other terminals.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        terminal_id: {
+          type: "string",
+          description: "Terminal ID to delete (e.g., 'terminal-1')",
+        },
+      },
+      required: ["terminal_id"],
+    },
+  },
+  {
+    name: "restart_terminal",
+    description:
+      "Restart a Loom terminal session. This preserves the terminal's configuration (ID, name, role, working directory) but creates a fresh tmux session. Useful for recovering from stuck states or clearing terminal history.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        terminal_id: {
+          type: "string",
+          description: "Terminal ID to restart (e.g., 'terminal-1')",
+        },
+      },
+      required: ["terminal_id"],
+    },
+  },
+  {
+    name: "configure_terminal",
+    description:
+      "Update a terminal's configuration settings. Changes are saved to the config file and take effect on next terminal restart or when the UI hot-reloads the configuration. Use this to change terminal name, role, theme, or autonomous interval settings.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        terminal_id: {
+          type: "string",
+          description: "Terminal ID to configure (e.g., 'terminal-1')",
+        },
+        name: {
+          type: "string",
+          description: "New human-readable name for the terminal",
+        },
+        role: {
+          type: "string",
+          description: "New role for the terminal (e.g., 'claude-code-worker')",
+        },
+        role_config: {
+          type: "object",
+          description: "Role configuration settings",
+          properties: {
+            worker_type: {
+              type: "string",
+              description: "Worker type (e.g., 'claude')",
+            },
+            role_file: {
+              type: "string",
+              description: "Role definition file (e.g., 'builder.md', 'judge.md')",
+            },
+            target_interval: {
+              type: "number",
+              description: "Interval in milliseconds for autonomous operation (0 for manual)",
+            },
+            interval_prompt: {
+              type: "string",
+              description: "Prompt to send at each interval for autonomous terminals",
+            },
+          },
+        },
+        theme: {
+          type: "string",
+          description: "Terminal theme (e.g., 'ocean', 'forest', 'sunset')",
+        },
+      },
+      required: ["terminal_id"],
+    },
+  },
+  {
+    name: "set_primary_terminal",
+    description:
+      "Set the primary (selected) terminal in the Loom UI. This updates the UI state to focus on the specified terminal. The terminal must exist.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        terminal_id: {
+          type: "string",
+          description: "Terminal ID to set as primary (e.g., 'terminal-1')",
+        },
+      },
+      required: ["terminal_id"],
+    },
+  },
+  {
+    name: "clear_terminal_history",
+    description:
+      "Clear a terminal's scrollback history and output log. This clears the tmux scrollback buffer and truncates the output log file. Useful for clearing sensitive data or resetting terminal state without restarting.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        terminal_id: {
+          type: "string",
+          description: "Terminal ID to clear history for (e.g., 'terminal-1')",
+        },
+      },
+      required: ["terminal_id"],
+    },
+  },
+  {
+    name: "start_autonomous_mode",
+    description:
+      "Start autonomous mode for all configured terminals. This starts the interval prompt timers for all terminals that have a targetInterval configured. Terminals will receive their intervalPrompt at their configured intervals when idle.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+  },
+  {
+    name: "stop_autonomous_mode",
+    description:
+      "Stop autonomous mode for all terminals. This pauses all interval prompt timers, preventing automatic prompts from being sent. Terminals remain running but won't receive autonomous prompts until autonomous mode is started again.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+  },
+  {
+    name: "launch_interval",
+    description:
+      "Manually trigger the interval prompt for a specific terminal immediately. This sends the terminal's configured intervalPrompt without waiting for the next scheduled interval. Works regardless of whether autonomous mode is enabled. Useful for testing autonomous behavior or manually triggering work.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        terminal_id: {
+          type: "string",
+          description: "Terminal ID to trigger the interval prompt for (e.g., 'terminal-1')",
+        },
+      },
+      required: ["terminal_id"],
+    },
+  },
+  {
+    name: "get_agent_metrics",
+    description:
+      "Get agent performance metrics for self-aware behavior. Enables agents to query their own effectiveness, costs, and velocity. Use this to check if struggling with a task type, select approaches based on historical success, or decide to escalate when below threshold. Part of Phase 5 (Autonomous Learning).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        command: {
+          type: "string",
+          enum: ["summary", "effectiveness", "costs", "velocity"],
+          description:
+            "Type of metrics to retrieve: summary (overall metrics), effectiveness (success rates by role), costs (cost breakdown by issue), velocity (development velocity trends)",
+          default: "summary",
+        },
+        role: {
+          type: "string",
+          enum: [
+            "builder",
+            "judge",
+            "curator",
+            "architect",
+            "hermit",
+            "doctor",
+            "guide",
+            "champion",
+            "shepherd",
+          ],
+          description: "Filter metrics by agent role (optional)",
+        },
+        period: {
+          type: "string",
+          enum: ["today", "week", "month", "all"],
+          description: "Time period for metrics: today, week, month, or all (default: week)",
+          default: "week",
+        },
+        format: {
+          type: "string",
+          enum: ["json", "text"],
+          description: "Output format: json for programmatic use, text for human-readable",
+          default: "json",
+        },
+        issue: {
+          type: "number",
+          description: "Filter costs by specific issue number (only for 'costs' command)",
+        },
+      },
+    },
+  },
+];
+
+/**
+ * Handle terminal tool calls
+ */
+export async function handleTerminalTool(
+  name: string,
+  args?: Record<string, unknown>
+): Promise<{ type: "text"; text: string }[]> {
+  switch (name) {
+    case "list_terminals": {
+      const terminals = await listTerminals();
+
+      if (terminals.length === 0) {
+        return [
+          {
+            type: "text",
+            text: "No active terminals found. Either Loom hasn't been started yet, or all terminals have been closed.",
+          },
+        ];
+      }
+
+      const terminalList = terminals
+        .map((t) => {
+          const parts = [
+            `ID: ${t.id}`,
+            `Name: ${t.name}`,
+            t.role ? `Role: ${t.role}` : null,
+            t.working_dir ? `Working Dir: ${t.working_dir}` : null,
+            `Session: ${t.tmux_session}`,
+          ]
+            .filter(Boolean)
+            .join("\n  ");
+          return `* ${parts}`;
+        })
+        .join("\n\n");
+
+      return [
+        {
+          type: "text",
+          text: `=== Active Loom Terminals (${terminals.length}) ===\n\n${terminalList}`,
+        },
+      ];
+    }
+
+    case "get_terminal_output": {
+      const terminalId = args?.terminal_id as string;
+      const lines = (args?.lines as number) || 20;
+
+      if (!terminalId) {
+        return [{ type: "text", text: "Error: terminal_id is required" }];
+      }
+
+      const result = await getTerminalOutput(terminalId, lines);
+      return [{ type: "text", text: formatTerminalOutput(result, terminalId) }];
+    }
+
+    case "get_selected_terminal": {
+      const lines = (args?.lines as number) || 20;
+      const state = await readStateFile();
+
+      if (!state || !state.selectedTerminalId) {
+        return [{ type: "text", text: "No terminal is currently selected in Loom." }];
+      }
+
+      const terminals = await listTerminals();
+      const terminal = terminals.find((t) => t.id === state.selectedTerminalId);
+
+      if (!terminal) {
+        return [
+          {
+            type: "text",
+            text: `Selected terminal ${state.selectedTerminalId} not found.`,
+          },
+        ];
+      }
+
+      const result = await getTerminalOutput(terminal.id, lines);
+      const info = [
+        `ID: ${terminal.id}`,
+        `Name: ${terminal.name}`,
+        terminal.role ? `Role: ${terminal.role}` : null,
+        terminal.working_dir ? `Working Dir: ${terminal.working_dir}` : null,
+        `Session: ${terminal.tmux_session}`,
+      ]
+        .filter(Boolean)
+        .join("\n");
+
+      return [
+        {
+          type: "text",
+          text: `=== Currently Selected Terminal ===\n\n${info}\n\n${formatTerminalOutput(result, terminal.id)}`,
+        },
+      ];
+    }
+
+    case "send_terminal_input": {
+      const terminalId = args?.terminal_id as string;
+      const input = args?.input as string;
+
+      if (!terminalId || !input) {
+        return [{ type: "text", text: "Error: terminal_id and input are required" }];
+      }
+
+      const result = await sendTerminalInput(terminalId, input);
+      return [{ type: "text", text: result }];
+    }
+
+    case "check_tmux_server_health": {
+      const health = await checkTmuxServerHealth();
+
+      if (!health.serverRunning) {
+        return [
+          {
+            type: "text",
+            text: `=== tmux Server Health ===\n\nServer Status: NOT RUNNING\n\nError: ${health.errorMessage || "Server not responding"}\n\nThis usually means:\n- tmux server crashed\n- No tmux sessions have been created yet\n- Socket path issue\n\nTo start the server, create a new terminal or run:\n  tmux -L loom new-session -d`,
+          },
+        ];
+      }
+
+      const sessionList = health.sessions.map((s) => `  - ${s}`).join("\n");
+      return [
+        {
+          type: "text",
+          text: `=== tmux Server Health ===\n\nServer Status: RUNNING\nSession Count: ${health.sessionCount}\n\nActive loom sessions:\n${sessionList || "  (none)"}`,
+        },
+      ];
+    }
+
+    case "get_tmux_server_info": {
+      const info = await getTmuxServerInfo();
+
+      let statusText = `=== tmux Server Information ===\n\n`;
+      statusText += `Socket Path: ${info.socketPath}\n`;
+      statusText += `Socket Exists: ${info.socketExists ? "Yes" : "No"}\n\n`;
+
+      if (info.tmuxVersion) {
+        statusText += `tmux Version: ${info.tmuxVersion}\n\n`;
+      }
+
+      if (info.serverProcess) {
+        statusText += `Server Process:\n${info.serverProcess}\n`;
+      } else {
+        statusText += `Server Process: Not found (no matching process)\n`;
+      }
+
+      return [{ type: "text", text: statusText }];
+    }
+
+    case "toggle_tmux_verbose_logging": {
+      const result = await toggleTmuxVerboseLogging();
+
+      if (!result.success) {
+        return [
+          {
+            type: "text",
+            text: `=== Toggle tmux Verbose Logging ===\n\nFailed\n\n${result.message}`,
+          },
+        ];
+      }
+
+      return [
+        {
+          type: "text",
+          text: `=== Toggle tmux Verbose Logging ===\n\nSuccess\n\n${result.message}\n\nNote: Verbose logging writes to tmux-server-${result.pid}.log in the current directory where the tmux server was started.`,
+        },
+      ];
+    }
+
+    case "create_terminal": {
+      const config: CreateTerminalConfig = {
+        name: args?.name as string | undefined,
+        role: args?.role as string | undefined,
+        roleFile: args?.role_file as string | undefined,
+        targetInterval: args?.target_interval as number | undefined,
+        intervalPrompt: args?.interval_prompt as string | undefined,
+        theme: args?.theme as string | undefined,
+        workingDir: args?.working_dir as string | undefined,
+      };
+
+      const result = await createTerminal(config);
+
+      if (!result.success) {
+        return [
+          {
+            type: "text",
+            text: `=== Create Terminal ===\n\nFailed\n\n${result.error}`,
+          },
+        ];
+      }
+
+      const details = [
+        `Terminal ID: ${result.terminal_id}`,
+        config.name ? `Name: ${config.name}` : null,
+        config.role ? `Role: ${config.role}` : null,
+        config.roleFile ? `Role File: ${config.roleFile}` : null,
+        config.workingDir ? `Working Dir: ${config.workingDir}` : null,
+      ]
+        .filter(Boolean)
+        .join("\n");
+
+      return [
+        {
+          type: "text",
+          text: `=== Create Terminal ===\n\nSuccess\n\n${details}\n\nThe terminal has been created with its own tmux session. You can now send commands to it using send_terminal_input.`,
+        },
+      ];
+    }
+
+    case "delete_terminal": {
+      const terminalId = args?.terminal_id as string;
+
+      if (!terminalId) {
+        return [{ type: "text", text: "Error: terminal_id is required" }];
+      }
+
+      const result = await deleteTerminal(terminalId);
+
+      if (!result.success) {
+        return [
+          {
+            type: "text",
+            text: `=== Delete Terminal ===\n\nFailed\n\n${result.error}`,
+          },
+        ];
+      }
+
+      return [
+        {
+          type: "text",
+          text: `=== Delete Terminal ===\n\nSuccess\n\nTerminal ${terminalId} has been deleted.\n\nCleanup performed:\n- tmux session killed\n- Output log file removed\n- Worktree cleaned up (if not used by other terminals)`,
+        },
+      ];
+    }
+
+    case "restart_terminal": {
+      const terminalId = args?.terminal_id as string;
+
+      if (!terminalId) {
+        return [{ type: "text", text: "Error: terminal_id is required" }];
+      }
+
+      const result = await restartTerminal(terminalId);
+
+      if (!result.success) {
+        return [
+          {
+            type: "text",
+            text: `=== Restart Terminal ===\n\nFailed\n\n${result.error}`,
+          },
+        ];
+      }
+
+      return [
+        {
+          type: "text",
+          text: `=== Restart Terminal ===\n\nSuccess\n\nTerminal ${result.terminal_id} has been restarted.\n\nThe terminal's configuration (ID, name, role, working directory) was preserved, but a fresh tmux session was created.\n\nNote: Any running processes in the terminal were terminated and terminal history was cleared.`,
+        },
+      ];
+    }
+
+    case "configure_terminal": {
+      const terminalId = args?.terminal_id as string;
+
+      if (!terminalId) {
+        return [{ type: "text", text: "Error: terminal_id is required" }];
+      }
+
+      const roleConfigArgs = args?.role_config as
+        | {
+            worker_type?: string;
+            role_file?: string;
+            target_interval?: number;
+            interval_prompt?: string;
+          }
+        | undefined;
+
+      const options: ConfigureTerminalOptions = {};
+
+      if (args?.name !== undefined) {
+        options.name = args.name as string;
+      }
+      if (args?.role !== undefined) {
+        options.role = args.role as string;
+      }
+      if (args?.theme !== undefined) {
+        options.theme = args.theme as string;
+      }
+      if (roleConfigArgs !== undefined) {
+        options.roleConfig = {};
+        if (roleConfigArgs.worker_type !== undefined) {
+          options.roleConfig.workerType = roleConfigArgs.worker_type;
+        }
+        if (roleConfigArgs.role_file !== undefined) {
+          options.roleConfig.roleFile = roleConfigArgs.role_file;
+        }
+        if (roleConfigArgs.target_interval !== undefined) {
+          options.roleConfig.targetInterval = roleConfigArgs.target_interval;
+        }
+        if (roleConfigArgs.interval_prompt !== undefined) {
+          options.roleConfig.intervalPrompt = roleConfigArgs.interval_prompt;
+        }
+      }
+
+      const result = await configureTerminal(terminalId, options);
+
+      if (!result.success) {
+        return [
+          {
+            type: "text",
+            text: `=== Configure Terminal ===\n\nFailed\n\n${result.error}`,
+          },
+        ];
+      }
+
+      const changedFields = Object.keys(options)
+        .map((key) => {
+          if (key === "roleConfig" && options.roleConfig) {
+            return Object.keys(options.roleConfig)
+              .map((k) => `roleConfig.${k}`)
+              .join(", ");
+          }
+          return key;
+        })
+        .join(", ");
+
+      return [
+        {
+          type: "text",
+          text: `=== Configure Terminal ===\n\nSuccess\n\nTerminal ${terminalId} configuration updated.\n\nUpdated fields: ${changedFields}\n\nNote: Changes are saved to the config file. The terminal may need to be restarted for some changes to take effect, or the UI will hot-reload the configuration.`,
+        },
+      ];
+    }
+
+    case "set_primary_terminal": {
+      const terminalId = args?.terminal_id as string;
+
+      if (!terminalId) {
+        return [{ type: "text", text: "Error: terminal_id is required" }];
+      }
+
+      const result = await setPrimaryTerminal(terminalId);
+
+      if (!result.success) {
+        return [
+          {
+            type: "text",
+            text: `=== Set Primary Terminal ===\n\nFailed\n\n${result.error}`,
+          },
+        ];
+      }
+
+      return [
+        {
+          type: "text",
+          text: `=== Set Primary Terminal ===\n\nSuccess\n\nTerminal ${terminalId} is now the primary (selected) terminal.\n\nThe UI will focus on this terminal.`,
+        },
+      ];
+    }
+
+    case "clear_terminal_history": {
+      const terminalId = args?.terminal_id as string;
+
+      if (!terminalId) {
+        return [{ type: "text", text: "Error: terminal_id is required" }];
+      }
+
+      const result = await clearTerminalHistory(terminalId);
+
+      if (!result.success) {
+        return [
+          {
+            type: "text",
+            text: `=== Clear Terminal History ===\n\nFailed\n\n${result.error}`,
+          },
+        ];
+      }
+
+      return [
+        {
+          type: "text",
+          text: `=== Clear Terminal History ===\n\nSuccess\n\nTerminal ${terminalId} history has been cleared.\n\nCleared:\n- tmux scrollback buffer\n- Output log file (/tmp/loom-${terminalId}.out)`,
+        },
+      ];
+    }
+
+    case "start_autonomous_mode": {
+      const result = await writeMCPCommand("start_autonomous_mode");
+      const success = result.includes("successfully");
+
+      if (!success) {
+        return [
+          {
+            type: "text",
+            text: `=== Start Autonomous Mode ===\n\nFailed\n\n${result}`,
+          },
+        ];
+      }
+
+      return [
+        {
+          type: "text",
+          text: `=== Start Autonomous Mode ===\n\nSuccess\n\nAutonomous mode has been started for all configured terminals.\n\nTerminals with targetInterval > 0 will now receive their intervalPrompt when idle.\n\n${result}`,
+        },
+      ];
+    }
+
+    case "stop_autonomous_mode": {
+      const result = await writeMCPCommand("stop_autonomous_mode");
+      const success = result.includes("successfully");
+
+      if (!success) {
+        return [
+          {
+            type: "text",
+            text: `=== Stop Autonomous Mode ===\n\nFailed\n\n${result}`,
+          },
+        ];
+      }
+
+      return [
+        {
+          type: "text",
+          text: `=== Stop Autonomous Mode ===\n\nSuccess\n\nAutonomous mode has been stopped for all terminals.\n\nTerminals will no longer receive automatic interval prompts until autonomous mode is started again.\n\n${result}`,
+        },
+      ];
+    }
+
+    case "launch_interval": {
+      const terminalId = args?.terminal_id as string;
+
+      if (!terminalId) {
+        return [{ type: "text", text: "Error: terminal_id is required" }];
+      }
+
+      const result = await writeMCPCommand(`launch_interval:${terminalId}`);
+      const success = result.includes("successfully");
+
+      if (!success) {
+        return [
+          {
+            type: "text",
+            text: `=== Launch Interval ===\n\nFailed\n\n${result}`,
+          },
+        ];
+      }
+
+      return [
+        {
+          type: "text",
+          text: `=== Launch Interval ===\n\nSuccess\n\nInterval prompt triggered for terminal ${terminalId}.\n\nThe terminal's configured intervalPrompt has been sent.\n\n${result}`,
+        },
+      ];
+    }
+
+    case "get_agent_metrics": {
+      const command = (args?.command as string) || "summary";
+      const role = args?.role as string | undefined;
+      const period = (args?.period as string) || "week";
+      const format = (args?.format as string) || "json";
+      const issue = args?.issue as number | undefined;
+
+      const result = await getAgentMetrics({
+        command,
+        role,
+        period,
+        format,
+        issue,
+      });
+
+      if (!result.success) {
+        return [
+          {
+            type: "text",
+            text: `=== Agent Metrics ===\n\nFailed\n\n${result.error}`,
+          },
+        ];
+      }
+
+      const header = `=== Agent Metrics (${command}) ===\n`;
+      const filterInfo = [
+        role ? `Role: ${role}` : null,
+        `Period: ${period}`,
+        issue ? `Issue: #${issue}` : null,
+      ]
+        .filter(Boolean)
+        .join(" | ");
+
+      const output =
+        format === "json" && result.data ? JSON.stringify(result.data, null, 2) : result.output;
+
+      return [
+        {
+          type: "text",
+          text: `${header}${filterInfo ? filterInfo + "\n\n" : "\n"}${output}`,
+        },
+      ];
+    }
+
+    default:
+      throw new Error(`Unknown terminal tool: ${name}`);
+  }
+}

--- a/mcp-loom/src/types.ts
+++ b/mcp-loom/src/types.ts
@@ -1,0 +1,109 @@
+/**
+ * Shared TypeScript types for Loom MCP server
+ */
+
+/**
+ * Result structure for log/output operations
+ */
+export interface LogResult {
+  content: string;
+  linesReturned: number;
+  totalLines: number;
+  error?: string;
+}
+
+/**
+ * Terminal state from daemon
+ */
+export interface Terminal {
+  id: string;
+  name: string;
+  role?: string;
+  working_dir?: string;
+  tmux_session: string;
+  created_at: number;
+  isPrimary?: boolean;
+}
+
+/**
+ * State file structure
+ */
+export interface StateFile {
+  daemonPid?: number;
+  nextAgentNumber: number;
+  terminals: Array<{
+    id: string;
+    status: string;
+    isPrimary: boolean;
+    worktreePath?: string;
+    agentPid?: number;
+    agentStatus?: string;
+    lastIntervalRun?: number;
+  }>;
+  selectedTerminalId: string | null;
+  lastUpdated: string;
+}
+
+/**
+ * Role configuration for a terminal
+ */
+export interface RoleConfig {
+  workerType?: string;
+  roleFile?: string;
+  targetInterval?: number;
+  intervalPrompt?: string;
+}
+
+/**
+ * Terminal configuration in config.json
+ */
+export interface TerminalConfig {
+  id: string;
+  name: string;
+  role?: string;
+  roleConfig?: RoleConfig;
+  theme?: string;
+}
+
+/**
+ * Workspace config file structure
+ */
+export interface ConfigFile {
+  version: string;
+  offlineMode?: boolean;
+  terminals: TerminalConfig[];
+}
+
+/**
+ * Configuration for creating a terminal
+ */
+export interface CreateTerminalConfig {
+  name?: string;
+  role?: string;
+  roleFile?: string;
+  targetInterval?: number;
+  intervalPrompt?: string;
+  theme?: string;
+  workingDir?: string;
+}
+
+/**
+ * Configuration options for updating a terminal
+ */
+export interface ConfigureTerminalOptions {
+  name?: string;
+  role?: string;
+  roleConfig?: Partial<RoleConfig>;
+  theme?: string;
+}
+
+/**
+ * Agent metrics result structure
+ */
+export interface AgentMetricsResult {
+  success: boolean;
+  data?: unknown;
+  error?: string;
+  format: "json" | "text";
+  output: string;
+}

--- a/mcp-loom/tsconfig.json
+++ b/mcp-loom/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/scripts/setup-mcp.sh
+++ b/scripts/setup-mcp.sh
@@ -8,21 +8,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Get the workspace root (parent of scripts/)
 WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# Generate .mcp.json
+# Generate .mcp.json with unified loom server
 cat > "$WORKSPACE_ROOT/.mcp.json" <<EOF
 {
   "mcpServers": {
-    "loom-logs": {
+    "loom": {
       "command": "node",
-      "args": ["$WORKSPACE_ROOT/mcp-loom-logs/dist/index.js"]
-    },
-    "loom-terminals": {
-      "command": "node",
-      "args": ["$WORKSPACE_ROOT/mcp-loom-terminals/dist/index.js"]
-    },
-    "loom-ui": {
-      "command": "node",
-      "args": ["$WORKSPACE_ROOT/mcp-loom-ui/dist/index.js"],
+      "args": ["$WORKSPACE_ROOT/mcp-loom/dist/index.js"],
       "env": {
         "LOOM_WORKSPACE": "$WORKSPACE_ROOT"
       }
@@ -31,4 +23,6 @@ cat > "$WORKSPACE_ROOT/.mcp.json" <<EOF
 }
 EOF
 
-echo "✓ Generated .mcp.json with workspace: $WORKSPACE_ROOT"
+echo "Generated .mcp.json with unified loom MCP server"
+echo "  Workspace: $WORKSPACE_ROOT"
+echo "  Server: mcp-loom/dist/index.js"


### PR DESCRIPTION
## Summary

- Create unified `mcp-loom` package consolidating `mcp-loom-logs`, `mcp-loom-ui`, and `mcp-loom-terminals`
- Extract shared utilities (config, ipc, daemon, formatting) into modular `src/shared/` directory
- Organize tools by domain (`src/tools/logs.ts`, `src/tools/ui.ts`, `src/tools/terminals.ts`)
- Update `scripts/setup-mcp.sh` to generate config for unified server
- Update documentation (CLAUDE.md, docs/mcp/README.md, docs/guides/testing.md)
- Add deprecation notices to old packages

Closes #1137

## Test plan

- [ ] Build the new package: `cd mcp-loom && npm install && npm run build`
- [ ] Run `./scripts/setup-mcp.sh` and verify `.mcp.json` is generated correctly
- [ ] Verify all tools are available via Claude Code MCP integration
- [ ] Test log tools: `tail_daemon_log`, `list_terminal_logs`
- [ ] Test UI tools: `get_ui_state`, `read_config_file`
- [ ] Test terminal tools: `list_terminals` (when daemon is running)

Generated with [Claude Code](https://claude.com/claude-code)