### PR TITLE
Consolidate duplicate cleanup scripts into unified clean.sh

### DIFF
--- a/defaults/scripts/clean.sh
+++ b/defaults/scripts/clean.sh
@@ -1,6 +1,19 @@
 #!/usr/bin/env bash
-# Loom Cleanup - Restore repository to clean state
-# Usage: ./.loom/scripts/clean.sh [--deep] [--dry-run]
+# Loom Unified Cleanup - Consolidates clean.sh, cleanup.sh, and safe-worktree-cleanup.sh
+# Usage: ./.loom/scripts/clean.sh [options]
+#
+# This is the unified cleanup script for Loom. It consolidates the functionality of:
+#   - clean.sh (general cleanup with UI polish)
+#   - cleanup.sh (build artifacts and worktree cleanup)
+#   - safe-worktree-cleanup.sh (safe cleanup with grace period and merge checks)
+#
+# AGENT USAGE INSTRUCTIONS:
+#   Non-interactive mode (for Claude Code):
+#     ./scripts/clean.sh --force
+#     ./scripts/clean.sh -f
+#
+#   Interactive mode (prompts for confirmation):
+#     ./scripts/clean.sh
 
 set -euo pipefail
 
@@ -12,38 +25,32 @@ YELLOW='\033[1;33m'
 CYAN='\033[0;36m'
 NC='\033[0m'
 
-error() {
-  echo -e "${RED}✗ Error: $*${NC}" >&2
-  exit 1
-}
-
-info() {
-  echo -e "${BLUE}ℹ $*${NC}"
-}
-
-success() {
-  echo -e "${GREEN}✓ $*${NC}"
-}
-
-warning() {
-  echo -e "${YELLOW}⚠ $*${NC}"
-}
-
-header() {
-  echo -e "${CYAN}$*${NC}"
-}
+error() { echo -e "${RED}Error: $*${NC}" >&2; exit 1; }
+info() { echo -e "${BLUE}$*${NC}"; }
+success() { echo -e "${GREEN}$*${NC}"; }
+warning() { echo -e "${YELLOW}$*${NC}"; }
+header() { echo -e "${CYAN}$*${NC}"; }
 
 # Find git repository root (works from any subdirectory)
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || \
   error "Not in a git repository"
 
-# Parse arguments
+# Configuration
 DRY_RUN=false
 DEEP_CLEAN=false
 FORCE=false
+SAFE_MODE=false
+GRACE_PERIOD=600  # 10 minutes in seconds (for --safe mode)
+WORKTREES_ONLY=false
+BRANCHES_ONLY=false
+TMUX_ONLY=false
 
-for arg in "$@"; do
-  case $arg in
+# State file for tracking cleanup (used in --safe mode)
+DAEMON_STATE="$REPO_ROOT/.loom/daemon-state.json"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
     --dry-run)
       DRY_RUN=true
       shift
@@ -52,104 +59,285 @@ for arg in "$@"; do
       DEEP_CLEAN=true
       shift
       ;;
-    --force|-f)
+    --force|-f|--yes|-y)
       FORCE=true
       shift
       ;;
+    --safe)
+      SAFE_MODE=true
+      shift
+      ;;
+    --grace-period)
+      GRACE_PERIOD="$2"
+      shift 2
+      ;;
+    --worktrees-only|--worktrees)
+      WORKTREES_ONLY=true
+      shift
+      ;;
+    --branches-only|--branches)
+      BRANCHES_ONLY=true
+      shift
+      ;;
+    --tmux-only|--tmux)
+      TMUX_ONLY=true
+      shift
+      ;;
     --help|-h)
-      echo "Loom Cleanup - Restore repository to clean state"
-      echo ""
-      echo "Usage: ./.loom/scripts/clean.sh [options]"
-      echo ""
-      echo "Options:"
-      echo "  --dry-run    Show what would be cleaned without making changes"
-      echo "  --deep       Deep clean (includes build artifacts)"
-      echo "  -f, --force  Non-interactive mode (auto-confirm all prompts)"
-      echo "  -h, --help   Show this help message"
-      echo ""
-      echo "Standard cleanup:"
-      echo "  • Stale worktrees (for closed issues)"
-      echo "  • Merged local branches"
-      echo "  • Loom tmux sessions"
-      echo ""
-      echo "Deep cleanup (--deep):"
-      echo "  • All of the above, plus:"
-      echo "  • target/ directory (Rust build artifacts)"
-      echo "  • node_modules/ directory"
-      echo ""
+      cat <<EOF
+Loom Unified Cleanup - Restore repository to clean state
+
+Usage: ./.loom/scripts/clean.sh [options]
+
+Options:
+  --dry-run              Show what would be cleaned without making changes
+  --deep                 Deep clean (includes build artifacts)
+  -f, --force, -y, --yes Non-interactive mode (auto-confirm all prompts)
+  --safe                 Safe mode: only remove worktrees with MERGED PRs,
+                         check for uncommitted changes, apply grace period
+  --grace-period N       Seconds to wait after PR merge (default: 600, requires --safe)
+  --worktrees-only       Only clean worktrees (skip branches and tmux)
+  --branches-only        Only clean branches (skip worktrees and tmux)
+  --tmux-only            Only clean tmux sessions (skip worktrees and branches)
+  -h, --help             Show this help message
+
+Standard cleanup:
+  - Stale worktrees (for closed issues)
+  - Merged local branches for closed issues
+  - Loom tmux sessions (loom-*)
+
+Deep cleanup (--deep):
+  - All of the above, plus:
+  - target/ directory (Rust build artifacts)
+  - node_modules/ directory
+
+Safe mode (--safe):
+  - Only removes worktrees when PR is MERGED (not just closed)
+  - Checks for uncommitted changes before removal
+  - Applies grace period after merge to avoid race conditions
+  - Tracks cleanup state in daemon-state.json
+
+Examples:
+  ./.loom/scripts/clean.sh                     # Interactive standard cleanup
+  ./.loom/scripts/clean.sh --force             # Non-interactive cleanup (CI/automation)
+  ./.loom/scripts/clean.sh --deep              # Include build artifacts
+  ./.loom/scripts/clean.sh --safe              # Safe mode (MERGED PRs only)
+  ./.loom/scripts/clean.sh --safe --force      # Safe mode, non-interactive
+  ./.loom/scripts/clean.sh --worktrees-only    # Just worktrees
+  ./.loom/scripts/clean.sh --branches-only     # Just branches
+
+Backwards Compatibility:
+  This script is called by cleanup.sh and safe-worktree-cleanup.sh
+  for backwards compatibility. Those scripts are now thin wrappers.
+EOF
       exit 0
       ;;
     *)
-      error "Unknown option: $arg\nUse --help for usage information"
+      error "Unknown option: $1\nUse --help for usage information"
       ;;
   esac
 done
 
-# Show banner
-echo ""
-header "╔═══════════════════════════════════════════════════════════╗"
-if [[ "$DEEP_CLEAN" == true ]]; then
-  header "║                  Loom Deep Cleanup                        ║"
-else
-  header "║                  Loom Cleanup                             ║"
-fi
-if [[ "$DRY_RUN" == true ]]; then
-  header "║                  (DRY RUN MODE)                           ║"
-fi
-header "╚═══════════════════════════════════════════════════════════╝"
-echo ""
+# =============================================================================
+# HELPER FUNCTIONS
+# =============================================================================
+
+check_pr_merged() {
+  local issue_num="$1"
+  local branch_name="feature/issue-${issue_num}"
+
+  # Find PR by head branch
+  local pr_info
+  pr_info=$(gh pr list --head "$branch_name" --state all --json number,state,mergedAt --jq '.[0] // empty' 2>/dev/null || echo "")
+
+  if [[ -z "$pr_info" ]]; then
+    # Try searching by issue reference
+    pr_info=$(gh pr list --search "Closes #${issue_num}" --state all --json number,state,mergedAt --jq '.[0] // empty' 2>/dev/null || echo "")
+  fi
+
+  if [[ -z "$pr_info" ]]; then
+    echo "NO_PR"
+    return
+  fi
+
+  local state merged_at
+  state=$(echo "$pr_info" | jq -r '.state // "UNKNOWN"')
+  merged_at=$(echo "$pr_info" | jq -r '.mergedAt // "null"')
+
+  if [[ "$merged_at" != "null" && "$merged_at" != "" ]]; then
+    echo "MERGED:$merged_at"
+  elif [[ "$state" == "CLOSED" ]]; then
+    echo "CLOSED_NO_MERGE"
+  elif [[ "$state" == "OPEN" ]]; then
+    echo "OPEN"
+  else
+    echo "UNKNOWN"
+  fi
+}
+
+check_uncommitted_changes() {
+  local worktree_path="$1"
+
+  if [[ ! -d "$worktree_path" ]]; then
+    echo "false"
+    return
+  fi
+
+  # Check for any uncommitted changes (staged or unstaged)
+  if git -C "$worktree_path" diff --quiet 2>/dev/null && \
+     git -C "$worktree_path" diff --cached --quiet 2>/dev/null; then
+    echo "false"
+  else
+    echo "true"
+  fi
+}
+
+check_grace_period() {
+  local merged_at="$1"
+  local now
+  now=$(date +%s)
+
+  # Parse merged_at timestamp
+  local merged_ts
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS
+    merged_ts=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$merged_at" +%s 2>/dev/null || echo "0")
+  else
+    # Linux
+    merged_ts=$(date -d "$merged_at" +%s 2>/dev/null || echo "0")
+  fi
+
+  local elapsed=$((now - merged_ts))
+
+  if [[ $elapsed -gt $GRACE_PERIOD ]]; then
+    echo "passed:$elapsed"
+  else
+    echo "waiting:$((GRACE_PERIOD - elapsed))"
+  fi
+}
+
+update_cleanup_state() {
+  local issue_num="$1"
+  local status="$2"
+
+  if [[ ! -f "$DAEMON_STATE" ]]; then
+    return
+  fi
+
+  local timestamp
+  timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  # Initialize cleanup section if needed
+  if ! jq -e '.cleanup' "$DAEMON_STATE" >/dev/null 2>&1; then
+    jq '.cleanup = {"lastRun": null, "lastCleaned": [], "pendingCleanup": [], "errors": []}' \
+      "$DAEMON_STATE" > "${DAEMON_STATE}.tmp" && mv "${DAEMON_STATE}.tmp" "$DAEMON_STATE"
+  fi
+
+  case "$status" in
+    cleaned)
+      jq ".cleanup.lastCleaned += [\"issue-${issue_num}\"] | .cleanup.lastRun = \"$timestamp\"" \
+        "$DAEMON_STATE" > "${DAEMON_STATE}.tmp" && mv "${DAEMON_STATE}.tmp" "$DAEMON_STATE"
+      ;;
+    pending)
+      jq ".cleanup.pendingCleanup += [\"issue-${issue_num}\"] | .cleanup.pendingCleanup |= unique" \
+        "$DAEMON_STATE" > "${DAEMON_STATE}.tmp" && mv "${DAEMON_STATE}.tmp" "$DAEMON_STATE"
+      ;;
+    error)
+      jq ".cleanup.errors += [{\"issue\": $issue_num, \"timestamp\": \"$timestamp\"}]" \
+        "$DAEMON_STATE" > "${DAEMON_STATE}.tmp" && mv "${DAEMON_STATE}.tmp" "$DAEMON_STATE"
+      ;;
+  esac
+}
+
+cleanup_worktree() {
+  local worktree_path="$1"
+  local issue_num="$2"
+  local branch_name="feature/issue-${issue_num}"
+
+  if [[ "$DRY_RUN" == true ]]; then
+    info "Would remove: $worktree_path"
+    info "Would delete branch: $branch_name"
+    return 0
+  fi
+
+  # Remove worktree
+  if git worktree remove "$worktree_path" --force 2>/dev/null; then
+    success "Removed worktree: $worktree_path"
+  else
+    warning "Failed to remove worktree: $worktree_path"
+    return 1
+  fi
+
+  # Delete local branch (if it exists)
+  if git branch -d "$branch_name" 2>/dev/null; then
+    success "Deleted branch: $branch_name"
+  elif git branch -D "$branch_name" 2>/dev/null; then
+    success "Force-deleted branch: $branch_name"
+  else
+    info "Branch already deleted or doesn't exist: $branch_name"
+  fi
+
+  return 0
+}
+
+# =============================================================================
+# MAIN
+# =============================================================================
 
 cd "$REPO_ROOT"
 
-# Check for active worktrees
+# Show banner
 echo ""
-header "Checking Active Worktrees"
-echo ""
-
-ACTIVE_WORKTREES=$(git worktree list | tail -n +2 || true)
-
-if [[ -n "$ACTIVE_WORKTREES" ]]; then
-  warning "Active worktrees detected:"
-  echo "$ACTIVE_WORKTREES" | while read -r line; do
-    echo "  $line"
-  done
-  echo ""
-  info "Active worktrees will be preserved"
-  SKIP_ACTIVE=true
+header "========================================"
+if [[ "$DEEP_CLEAN" == true ]]; then
+  header "  Loom Deep Cleanup"
+elif [[ "$SAFE_MODE" == true ]]; then
+  header "  Loom Safe Cleanup"
 else
-  success "No active worktrees"
-  SKIP_ACTIVE=false
+  header "  Loom Cleanup"
 fi
+if [[ "$DRY_RUN" == true ]]; then
+  header "  (DRY RUN MODE)"
+fi
+header "========================================"
+echo ""
 
 # Show what will be cleaned
-echo ""
-header "Cleanup Plan"
-echo ""
+if [[ "$WORKTREES_ONLY" == false && "$BRANCHES_ONLY" == false && "$TMUX_ONLY" == false ]]; then
+  info "Cleanup targets:"
+  echo "  - Orphaned worktrees (git worktree prune)"
+  echo "  - Local branches for closed issues"
+  echo "  - Loom tmux sessions (loom-*)"
 
-info "Standard cleanup:"
-echo "  • Orphaned worktrees (git worktree prune)"
-echo "  • Merged local branches for closed issues"
-echo "  • Loom tmux sessions (loom-*)"
-
-if [[ "$DEEP_CLEAN" == true ]]; then
-  echo ""
-  warning "Deep cleanup additions:"
-  if [[ -d "target" ]]; then
-    SIZE=$(du -sh target 2>/dev/null | cut -f1)
-    echo "  • target/ directory ($SIZE)"
-  else
-    echo "  • target/ directory (not present)"
+  if [[ "$SAFE_MODE" == true ]]; then
+    echo ""
+    warning "Safe mode enabled:"
+    echo "  - Only removes worktrees with MERGED PRs"
+    echo "  - Checks for uncommitted changes"
+    echo "  - Grace period: ${GRACE_PERIOD}s after merge"
   fi
-  if [[ -d "node_modules" ]]; then
-    SIZE=$(du -sh node_modules 2>/dev/null | cut -f1)
-    echo "  • node_modules/ directory ($SIZE)"
-  else
-    echo "  • node_modules/ directory (not present)"
+
+  if [[ "$DEEP_CLEAN" == true ]]; then
+    echo ""
+    warning "Deep cleanup additions:"
+    if [[ -d "target" ]]; then
+      SIZE=$(du -sh target 2>/dev/null | cut -f1)
+      echo "  - target/ directory ($SIZE)"
+    else
+      echo "  - target/ directory (not present)"
+    fi
+    if [[ -d "node_modules" ]]; then
+      SIZE=$(du -sh node_modules 2>/dev/null | cut -f1)
+      echo "  - node_modules/ directory ($SIZE)"
+    else
+      echo "  - node_modules/ directory (not present)"
+    fi
   fi
 fi
 
 echo ""
 
+# Confirmation
 if [[ "$DRY_RUN" == true ]]; then
   warning "DRY RUN - No changes will be made"
   CONFIRM=y
@@ -168,170 +356,266 @@ fi
 
 echo ""
 
+# Counters for summary
+cleaned_worktrees=0
+skipped_open=0
+skipped_not_merged=0
+skipped_grace=0
+skipped_uncommitted=0
+cleaned_branches=0
+kept_branches=0
+killed_tmux=0
+errors=0
+
 # =============================================================================
-# CLEANUP: Orphaned Worktrees
+# CLEANUP: Worktrees
 # =============================================================================
 
-header "Cleaning Orphaned Worktrees"
-echo ""
+if [[ "$BRANCHES_ONLY" == false && "$TMUX_ONLY" == false ]]; then
+  header "Cleaning Worktrees"
+  echo ""
 
-# First check for stale worktrees pointing to closed issues
-if [[ "$SKIP_ACTIVE" == true ]]; then
   # Get active worktree paths
-  ACTIVE_PATHS=$(git worktree list | tail -n +2 | awk '{print $1}')
+  ACTIVE_PATHS=$(git worktree list | tail -n +2 | awk '{print $1}' || true)
 
   # Check each .loom/worktrees/issue-* directory
   if [[ -d ".loom/worktrees" ]]; then
     for worktree_dir in .loom/worktrees/issue-*; do
-      if [[ -d "$worktree_dir" ]]; then
-        worktree_path="$(cd "$worktree_dir" && pwd)"
-
-        # Check if this is an active worktree
-        if echo "$ACTIVE_PATHS" | grep -q "^$worktree_path$"; then
-          # Extract issue number
-          issue_num=$(basename "$worktree_dir" | sed 's/issue-//')
-
-          # Check if issue is closed
-          if command -v gh &> /dev/null; then
-            status=$(gh issue view "$issue_num" --json state --jq .state 2>/dev/null || echo "UNKNOWN")
-
-            if [[ "$status" == "CLOSED" ]]; then
-              warning "Worktree for closed issue #$issue_num is still active"
-
-              if [[ "$DRY_RUN" == true ]]; then
-                info "Would remove: $worktree_dir"
-              elif [[ "$FORCE" == true ]]; then
-                info "Auto-removing: $worktree_dir"
-                git worktree remove "$worktree_path" --force && success "Removed: $worktree_dir" || warning "Failed to remove: $worktree_dir"
-              else
-                read -r -p "  Force remove this worktree? [y/N] " -n 1 REMOVE_WORKTREE
-                echo ""
-
-                if [[ $REMOVE_WORKTREE =~ ^[Yy]$ ]]; then
-                  git worktree remove "$worktree_path" --force && success "Removed: $worktree_dir" || warning "Failed to remove: $worktree_dir"
-                else
-                  info "Skipping: $worktree_dir"
-                  echo "  Run manually: git worktree remove $worktree_path --force"
-                fi
-              fi
-            else
-              info "Preserving active worktree for issue #$issue_num ($status)"
-            fi
-          fi
-        fi
+      if [[ ! -d "$worktree_dir" ]]; then
+        continue
       fi
-    done
-  fi
-fi
 
-# Prune orphaned references
-if [[ "$DRY_RUN" == true ]]; then
-  PRUNE_OUTPUT=$(git worktree prune --dry-run --verbose 2>&1 || true)
-  if [[ -n "$PRUNE_OUTPUT" ]]; then
-    echo "$PRUNE_OUTPUT"
-  else
-    success "No orphaned worktrees to prune"
-  fi
-else
-  git worktree prune --verbose 2>&1 || success "No orphaned worktrees to prune"
-fi
-
-echo ""
-
-# =============================================================================
-# CLEANUP: Merged Branches
-# =============================================================================
-
-header "Cleaning Merged Branches"
-echo ""
-
-# Check if cleanup-branches.sh exists (only in Loom repo, not target repos)
-if [[ -f "scripts/cleanup-branches.sh" ]]; then
-  if [[ "$DRY_RUN" == true ]]; then
-    ./scripts/cleanup-branches.sh --dry-run
-  else
-    ./scripts/cleanup-branches.sh
-  fi
-else
-  # Manual branch cleanup for target repositories
-  branches=$(git branch | grep "feature/issue-" | sed 's/^[*+ ]*//' || true)
-
-  if [[ -z "$branches" ]]; then
-    success "No feature branches found"
-  else
-    checked=0
-    closed=0
-    open=0
-
-    for branch in $branches; do
-      # Extract issue number
-      issue_num=$(echo "$branch" | sed 's/feature\/issue-//' | sed 's/-.*//' | sed 's/[^0-9].*//')
+      worktree_path="$(cd "$worktree_dir" && pwd)"
+      issue_num=$(basename "$worktree_dir" | sed 's/issue-//')
 
       if [[ ! "$issue_num" =~ ^[0-9]+$ ]]; then
         continue
       fi
 
-      ((checked++))
+      echo "Checking worktree: issue-$issue_num"
 
-      # Check issue status
-      if command -v gh &> /dev/null; then
-        status=$(gh issue view "$issue_num" --json state --jq .state 2>/dev/null || echo "NOT_FOUND")
+      # Check issue state
+      if ! command -v gh &> /dev/null; then
+        warning "  gh CLI not found, skipping GitHub checks"
+        continue
+      fi
 
-        if [[ "$status" == "CLOSED" ]]; then
-          echo -e "${GREEN}✓${NC} Issue #$issue_num is CLOSED - deleting $branch"
-          if [[ "$DRY_RUN" == false ]]; then
-            git branch -D "$branch" 2>/dev/null
+      issue_state=$(gh issue view "$issue_num" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+
+      if [[ "$issue_state" != "CLOSED" ]]; then
+        info "  Issue #$issue_num is $issue_state - preserving"
+        ((skipped_open++)) || true
+        continue
+      fi
+
+      # Safe mode: additional checks
+      if [[ "$SAFE_MODE" == true ]]; then
+        # Check PR merge status
+        pr_status=$(check_pr_merged "$issue_num")
+
+        case "$pr_status" in
+          MERGED:*)
+            merged_at="${pr_status#MERGED:}"
+            ;;
+          CLOSED_NO_MERGE)
+            warning "  PR closed without merge - skipping (may need investigation)"
+            ((skipped_not_merged++)) || true
+            continue
+            ;;
+          OPEN)
+            info "  PR still open - skipping"
+            ((skipped_open++)) || true
+            continue
+            ;;
+          NO_PR)
+            warning "  No PR found for closed issue - skipping"
+            ((skipped_not_merged++)) || true
+            continue
+            ;;
+          *)
+            warning "  Unknown PR status - skipping"
+            ((errors++)) || true
+            continue
+            ;;
+        esac
+
+        # Check grace period (unless --force)
+        if [[ "$FORCE" != true ]]; then
+          grace_status=$(check_grace_period "$merged_at")
+          case "$grace_status" in
+            waiting:*)
+              remaining="${grace_status#waiting:}"
+              info "  PR merged but grace period not passed (${remaining}s remaining)"
+              update_cleanup_state "$issue_num" "pending"
+              ((skipped_grace++)) || true
+              continue
+              ;;
+          esac
+        fi
+
+        # Check for uncommitted changes (unless --force)
+        if [[ "$FORCE" != true ]]; then
+          has_changes=$(check_uncommitted_changes "$worktree_path")
+          if [[ "$has_changes" == "true" ]]; then
+            warning "  Uncommitted changes detected - skipping"
+            ((skipped_uncommitted++)) || true
+            continue
           fi
-          ((closed++))
-        elif [[ "$status" == "OPEN" ]]; then
-          echo -e "${BLUE}○${NC} Issue #$issue_num is OPEN - keeping $branch"
-          ((open++))
+        fi
+
+        # All checks passed - cleanup with state tracking
+        if cleanup_worktree "$worktree_path" "$issue_num"; then
+          if [[ "$DRY_RUN" != true ]]; then
+            update_cleanup_state "$issue_num" "cleaned"
+          fi
+          ((cleaned_worktrees++)) || true
+        else
+          if [[ "$DRY_RUN" != true ]]; then
+            update_cleanup_state "$issue_num" "error"
+          fi
+          ((errors++)) || true
+        fi
+      else
+        # Standard mode: just check if issue is closed
+        warning "  Issue #$issue_num is CLOSED"
+
+        if [[ "$DRY_RUN" == true ]]; then
+          info "  Would remove: $worktree_dir"
+          ((cleaned_worktrees++)) || true
+        elif [[ "$FORCE" == true ]]; then
+          info "  Auto-removing: $worktree_dir"
+          if cleanup_worktree "$worktree_path" "$issue_num"; then
+            ((cleaned_worktrees++)) || true
+          else
+            ((errors++)) || true
+          fi
+        else
+          read -r -p "  Force remove this worktree? [y/N] " -n 1 REMOVE_WORKTREE
+          echo ""
+
+          if [[ $REMOVE_WORKTREE =~ ^[Yy]$ ]]; then
+            if cleanup_worktree "$worktree_path" "$issue_num"; then
+              ((cleaned_worktrees++)) || true
+            else
+              ((errors++)) || true
+            fi
+          else
+            info "  Skipping: $worktree_dir"
+            ((skipped_open++)) || true
+          fi
         fi
       fi
     done
-
-    echo ""
-    echo "Summary:"
-    echo "  Checked: $checked branches"
-    if [[ "$DRY_RUN" == true ]]; then
-      echo -e "  ${YELLOW}Would delete${NC}: $closed (closed issues)"
-    else
-      echo -e "  ${GREEN}Deleted${NC}: $closed (closed issues)"
-    fi
-    echo -e "  ${BLUE}Kept${NC}:    $open (open issues)"
+  else
+    info "No worktrees directory found"
   fi
+
+  # Prune orphaned references
+  echo ""
+  header "Pruning Orphaned References"
+  if [[ "$DRY_RUN" == true ]]; then
+    PRUNE_OUTPUT=$(git worktree prune --dry-run --verbose 2>&1 || true)
+    if [[ -n "$PRUNE_OUTPUT" ]]; then
+      echo "$PRUNE_OUTPUT"
+    else
+      success "No orphaned worktrees to prune"
+    fi
+  else
+    git worktree prune --verbose 2>&1 || success "No orphaned worktrees to prune"
+  fi
+
+  echo ""
 fi
 
-echo ""
+# =============================================================================
+# CLEANUP: Branches
+# =============================================================================
+
+if [[ "$WORKTREES_ONLY" == false && "$TMUX_ONLY" == false ]]; then
+  header "Cleaning Merged Branches"
+  echo ""
+
+  # Check if cleanup-branches.sh exists (only in Loom repo, not target repos)
+  if [[ -f "scripts/cleanup-branches.sh" ]]; then
+    if [[ "$DRY_RUN" == true ]]; then
+      ./scripts/cleanup-branches.sh --dry-run
+    elif [[ "$FORCE" == true ]]; then
+      ./scripts/cleanup-branches.sh --force
+    else
+      ./scripts/cleanup-branches.sh
+    fi
+  else
+    # Manual branch cleanup for target repositories
+    branches=$(git branch | grep "feature/issue-" | sed 's/^[*+ ]*//' || true)
+
+    if [[ -z "$branches" ]]; then
+      success "No feature branches found"
+    else
+      for branch in $branches; do
+        # Extract issue number
+        issue_num=$(echo "$branch" | sed 's/feature\/issue-//' | sed 's/-.*//' | sed 's/[^0-9].*//')
+
+        if [[ ! "$issue_num" =~ ^[0-9]+$ ]]; then
+          continue
+        fi
+
+        # Check issue status
+        if command -v gh &> /dev/null; then
+          status=$(gh issue view "$issue_num" --json state --jq .state 2>/dev/null || echo "NOT_FOUND")
+
+          if [[ "$status" == "CLOSED" ]]; then
+            echo -e "${GREEN}  Issue #$issue_num CLOSED${NC} - deleting $branch"
+            if [[ "$DRY_RUN" == false ]]; then
+              git branch -D "$branch" 2>/dev/null && ((cleaned_branches++)) || ((errors++))
+            else
+              ((cleaned_branches++)) || true
+            fi
+          elif [[ "$status" == "OPEN" ]]; then
+            echo -e "${BLUE}  Issue #$issue_num OPEN${NC} - keeping $branch"
+            ((kept_branches++)) || true
+          fi
+        fi
+      done
+    fi
+  fi
+
+  echo ""
+fi
 
 # =============================================================================
 # CLEANUP: Tmux Sessions
 # =============================================================================
 
-header "Cleaning Loom Tmux Sessions"
-echo ""
-
-LOOM_SESSIONS=$(tmux list-sessions 2>/dev/null | grep '^loom-' | cut -d: -f1 || true)
-
-if [[ -n "$LOOM_SESSIONS" ]]; then
-  echo "Found Loom tmux sessions:"
-  echo "$LOOM_SESSIONS" | while read -r session; do
-    echo "  • $session"
-  done
+if [[ "$WORKTREES_ONLY" == false && "$BRANCHES_ONLY" == false ]]; then
+  header "Cleaning Loom Tmux Sessions"
   echo ""
 
-  if [[ "$DRY_RUN" == true ]]; then
-    info "Would kill these sessions"
-  else
-    echo "$LOOM_SESSIONS" | while read -r session; do
-      tmux kill-session -t "$session" 2>/dev/null && success "Killed: $session"
-    done
-  fi
-else
-  success "No Loom tmux sessions found"
-fi
+  LOOM_SESSIONS=$(tmux list-sessions 2>/dev/null | grep '^loom-' | cut -d: -f1 || true)
 
-echo ""
+  if [[ -n "$LOOM_SESSIONS" ]]; then
+    echo "Found Loom tmux sessions:"
+    echo "$LOOM_SESSIONS" | while read -r session; do
+      echo "  - $session"
+    done
+    echo ""
+
+    if [[ "$DRY_RUN" == true ]]; then
+      info "Would kill these sessions"
+      killed_tmux=$(echo "$LOOM_SESSIONS" | wc -l | tr -d ' ')
+    else
+      echo "$LOOM_SESSIONS" | while read -r session; do
+        if tmux kill-session -t "$session" 2>/dev/null; then
+          success "Killed: $session"
+          ((killed_tmux++)) || true
+        fi
+      done
+    fi
+  else
+    success "No Loom tmux sessions found"
+  fi
+
+  echo ""
+fi
 
 # =============================================================================
 # DEEP CLEANUP: Build Artifacts
@@ -377,21 +661,54 @@ fi
 # =============================================================================
 
 echo ""
-header "═══════════════════════════════════════════════════════════"
+header "========================================"
+header "  Summary"
+header "========================================"
 echo ""
 
 if [[ "$DRY_RUN" == true ]]; then
-  success "Dry run complete - no changes made"
-  echo ""
-  info "To actually clean, run: ./.loom/scripts/clean.sh"
-  if [[ "$DEEP_CLEAN" == true ]]; then
-    echo "                        ./.loom/scripts/clean.sh --deep"
+  echo "  Would clean: $cleaned_worktrees worktree(s)"
+else
+  echo "  Cleaned: $cleaned_worktrees worktree(s)"
+fi
+
+if [[ "$SAFE_MODE" == true ]]; then
+  echo "  Skipped (open/not merged): $((skipped_open + skipped_not_merged))"
+  echo "  Skipped (grace period): $skipped_grace"
+  echo "  Skipped (uncommitted): $skipped_uncommitted"
+fi
+
+if [[ "$cleaned_branches" -gt 0 || "$kept_branches" -gt 0 ]]; then
+  if [[ "$DRY_RUN" == true ]]; then
+    echo "  Would delete: $cleaned_branches branch(es)"
+  else
+    echo "  Deleted: $cleaned_branches branch(es)"
   fi
+  echo "  Kept: $kept_branches branch(es)"
+fi
+
+if [[ "$killed_tmux" -gt 0 ]]; then
+  if [[ "$DRY_RUN" == true ]]; then
+    echo "  Would kill: $killed_tmux tmux session(s)"
+  else
+    echo "  Killed: $killed_tmux tmux session(s)"
+  fi
+fi
+
+if [[ "$errors" -gt 0 ]]; then
+  echo "  Errors: $errors"
+fi
+
+echo ""
+
+if [[ "$DRY_RUN" == true ]]; then
+  warning "Dry run complete - no changes made"
+  info "Run without --dry-run to perform cleanup"
 else
   success "Cleanup complete!"
-  echo ""
 
   if [[ "$DEEP_CLEAN" == true ]]; then
+    echo ""
     info "To restore dependencies, run:"
     echo "  pnpm install"
   fi

--- a/defaults/scripts/cleanup.sh
+++ b/defaults/scripts/cleanup.sh
@@ -1,9 +1,10 @@
-#!/bin/bash
-# Loom Cleanup Script - Remove build artifacts and orphaned worktrees
+#!/usr/bin/env bash
+# Loom Cleanup Script - WRAPPER (backwards compatibility)
+#
+# This script is a thin wrapper around clean.sh for backwards compatibility.
+# The unified clean.sh now handles all cleanup functionality.
 #
 # AGENT USAGE INSTRUCTIONS:
-#   This script cleans up Loom build artifacts and orphaned worktrees.
-#
 #   Non-interactive mode (for Claude Code):
 #     ./scripts/cleanup.sh --yes
 #     ./scripts/cleanup.sh -y
@@ -11,166 +12,58 @@
 #   Interactive mode (prompts for confirmation):
 #     ./scripts/cleanup.sh
 #
-#   What this script does:
-#     1. Removes target/ directory (Rust build artifacts)
-#     2. Removes node_modules/ directory (Node dependencies)
-#     3. Detects worktrees for closed issues and offers to remove them
-#     4. Prunes orphaned git worktrees (with confirmation unless --yes)
+# DEPRECATED: Use clean.sh instead:
+#   ./scripts/clean.sh --deep --force   # Equivalent to cleanup.sh --yes
 #
-#   After running, restore dependencies with: pnpm install
+# What this wrapper does:
+#   Maps cleanup.sh arguments to clean.sh equivalents
+#   Always includes --deep (build artifacts)
 
-set -e  # Exit on error
+set -euo pipefail
 
-# Parse command line arguments
-NON_INTERACTIVE=false
+# Find script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Map arguments
+ARGS=("--deep")  # cleanup.sh always cleans build artifacts
+
 for arg in "$@"; do
   case $arg in
     -y|--yes)
-      NON_INTERACTIVE=true
-      shift
+      ARGS+=("--force")
+      ;;
+    --help|-h)
+      cat <<EOF
+Loom Cleanup Script - DEPRECATED WRAPPER
+
+This script is a thin wrapper around clean.sh for backwards compatibility.
+Please use clean.sh directly for more options.
+
+Usage: ./scripts/cleanup.sh [options]
+
+Options:
+  -y, --yes    Non-interactive mode (auto-confirm all prompts)
+  -h, --help   Show this help message
+
+What it does:
+  1. Removes target/ directory (Rust build artifacts)
+  2. Removes node_modules/ directory (Node dependencies)
+  3. Detects worktrees for closed issues and offers to remove them
+  4. Prunes orphaned git worktrees
+
+Equivalent clean.sh commands:
+  ./scripts/cleanup.sh           ->  ./scripts/clean.sh --deep
+  ./scripts/cleanup.sh --yes     ->  ./scripts/clean.sh --deep --force
+
+After running, restore dependencies with: pnpm install
+EOF
+      exit 0
+      ;;
+    *)
+      ARGS+=("$arg")
       ;;
   esac
 done
 
-echo "🧹 Loom Cleanup"
-echo ""
-
-# Track if we're in main workspace
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-
-# Clean Rust build artifacts
-if [ -d "$PROJECT_ROOT/target" ]; then
-  SIZE=$(du -sh "$PROJECT_ROOT/target" 2>/dev/null | cut -f1 || echo "unknown")
-  echo "Removing target/ ($SIZE)"
-  rm -rf "$PROJECT_ROOT/target"
-  echo "✓ Removed target/"
-else
-  echo "ℹ No target/ directory found"
-fi
-
-echo ""
-
-# Clean node_modules
-if [ -d "$PROJECT_ROOT/node_modules" ]; then
-  SIZE=$(du -sh "$PROJECT_ROOT/node_modules" 2>/dev/null | cut -f1 || echo "unknown")
-  echo "Removing node_modules/ ($SIZE)"
-  rm -rf "$PROJECT_ROOT/node_modules"
-  echo "✓ Removed node_modules/"
-else
-  echo "ℹ No node_modules/ directory found"
-fi
-
-echo ""
-
-# Check for worktrees associated with closed issues
-echo "Checking for worktrees associated with closed issues..."
-cd "$PROJECT_ROOT"
-
-CLOSED_ISSUE_WORKTREES=()
-
-# List all worktrees and check if their issues are closed
-while IFS= read -r worktree_line; do
-  # Extract worktree path (format: /path/to/worktree COMMIT [branch-name])
-  worktree_path=$(echo "$worktree_line" | awk '{print $1}')
-
-  # Skip the main worktree
-  if [[ "$worktree_path" == "$PROJECT_ROOT" ]]; then
-    continue
-  fi
-
-  # Extract issue number from path (e.g., .loom/worktrees/issue-123)
-  if [[ "$worktree_path" =~ issue-([0-9]+) ]]; then
-    issue_num="${BASH_REMATCH[1]}"
-
-    # Check if issue is closed using gh
-    if command -v gh &> /dev/null; then
-      issue_state=$(gh issue view "$issue_num" --json state --jq .state 2>/dev/null || echo "")
-
-      if [[ "$issue_state" == "CLOSED" ]]; then
-        CLOSED_ISSUE_WORKTREES+=("$worktree_path:$issue_num")
-        echo "⚠ Worktree for closed issue #$issue_num is still active"
-        echo "ℹ Path: $worktree_path"
-      fi
-    fi
-  fi
-done < <(git worktree list --porcelain | grep "worktree " | sed 's/worktree //')
-
-if [[ ${#CLOSED_ISSUE_WORKTREES[@]} -gt 0 ]]; then
-  echo ""
-
-  # Auto-remove in non-interactive mode
-  if [ "$NON_INTERACTIVE" = true ]; then
-    echo "Non-interactive mode: automatically removing closed issue worktrees"
-    for entry in "${CLOSED_ISSUE_WORKTREES[@]}"; do
-      worktree_path="${entry%%:*}"
-      issue_num="${entry##*:}"
-      echo "Removing worktree for closed issue #$issue_num..."
-      git worktree remove "$worktree_path" --force
-      echo "✓ Removed: $worktree_path"
-    done
-    echo "✓ Removed ${#CLOSED_ISSUE_WORKTREES[@]} closed issue worktree(s)"
-  else
-    echo "Found ${#CLOSED_ISSUE_WORKTREES[@]} worktree(s) for closed issues."
-    read -p "Force remove all closed issue worktrees? (y/N) " -n 1 -r
-    echo
-
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
-      for entry in "${CLOSED_ISSUE_WORKTREES[@]}"; do
-        worktree_path="${entry%%:*}"
-        issue_num="${entry##*:}"
-        echo "Removing worktree for closed issue #$issue_num..."
-        git worktree remove "$worktree_path" --force
-        echo "✓ Removed: $worktree_path"
-      done
-      echo "✓ Removed ${#CLOSED_ISSUE_WORKTREES[@]} closed issue worktree(s)"
-    else
-      echo "ℹ Skipped closed issue worktree cleanup"
-      echo "ℹ To remove individually:"
-      for entry in "${CLOSED_ISSUE_WORKTREES[@]}"; do
-        worktree_path="${entry%%:*}"
-        issue_num="${entry##*:}"
-        echo "  git worktree remove $worktree_path --force  # issue #$issue_num"
-      done
-    fi
-  fi
-else
-  echo "✓ No worktrees found for closed issues"
-fi
-
-echo ""
-
-# Clean orphaned worktrees
-echo "Checking for orphaned worktrees..."
-
-# Show what would be pruned
-PRUNE_OUTPUT=$(git worktree prune --dry-run --verbose 2>&1 || true)
-
-if [ -n "$PRUNE_OUTPUT" ]; then
-  echo "$PRUNE_OUTPUT"
-  echo ""
-
-  # Auto-confirm in non-interactive mode
-  if [ "$NON_INTERACTIVE" = true ]; then
-    echo "Non-interactive mode: automatically removing orphaned worktrees"
-    git worktree prune --verbose
-    echo "✓ Orphaned worktrees removed"
-  else
-    read -p "Remove orphaned worktrees? (y/N) " -n 1 -r
-    echo
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
-      git worktree prune --verbose
-      echo "✓ Orphaned worktrees removed"
-    else
-      echo "ℹ Skipped worktree cleanup"
-    fi
-  fi
-else
-  echo "✓ No orphaned worktrees found"
-fi
-
-echo ""
-echo "✅ Cleanup complete!"
-echo ""
-echo "To restore dependencies, run:"
-echo "  pnpm install"
+# Call the unified clean.sh
+exec "$SCRIPT_DIR/clean.sh" "${ARGS[@]}"

--- a/defaults/scripts/safe-worktree-cleanup.sh
+++ b/defaults/scripts/safe-worktree-cleanup.sh
@@ -1,58 +1,42 @@
 #!/usr/bin/env bash
-# Safe worktree cleanup - only removes worktrees for MERGED PRs
-# Usage: ./scripts/safe-worktree-cleanup.sh [--dry-run] [--force] [--grace-period N]
+# Safe worktree cleanup - WRAPPER (backwards compatibility)
 #
-# Unlike blunt cleanup, this script:
-# - Only removes worktrees when the PR is MERGED (not just closed)
-# - Checks for uncommitted changes before removal
-# - Applies a grace period after merge to avoid race conditions
-# - Tracks cleanup state in daemon-state.json
+# This script is a thin wrapper around clean.sh for backwards compatibility.
+# The unified clean.sh now handles all cleanup functionality with --safe mode.
+#
+# DEPRECATED: Use clean.sh --safe instead:
+#   ./scripts/clean.sh --safe              # Equivalent to safe-worktree-cleanup.sh
+#   ./scripts/clean.sh --safe --force      # Equivalent to safe-worktree-cleanup.sh --force
+#
+# What this wrapper does:
+#   Maps safe-worktree-cleanup.sh arguments to clean.sh --safe equivalents
+#   Always includes --safe and --worktrees-only
 
 set -euo pipefail
 
-# ANSI color codes
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-BLUE='\033[0;34m'
-YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
-NC='\033[0m'
+# Find script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-error() { echo -e "${RED}Error: $*${NC}" >&2; exit 1; }
-info() { echo -e "${BLUE}$*${NC}"; }
-success() { echo -e "${GREEN}$*${NC}"; }
-warning() { echo -e "${YELLOW}$*${NC}"; }
-header() { echo -e "${CYAN}$*${NC}"; }
+# Map arguments - safe-worktree-cleanup.sh is worktrees-only with safe mode
+ARGS=("--safe" "--worktrees-only")
 
-# Configuration
-DRY_RUN=false
-FORCE=false
-GRACE_PERIOD=600  # 10 minutes in seconds
-
-# Detect repository root
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || error "Not in a git repository"
-
-# State file for tracking cleanup
-DAEMON_STATE="$REPO_ROOT/.loom/daemon-state.json"
-
-# Parse arguments
-while [[ $# -gt 0 ]]; do
-  case $1 in
+for arg in "$@"; do
+  case $arg in
     --dry-run)
-      DRY_RUN=true
-      shift
+      ARGS+=("--dry-run")
       ;;
     --force|-f)
-      FORCE=true
-      shift
+      ARGS+=("--force")
       ;;
     --grace-period)
-      GRACE_PERIOD="$2"
-      shift 2
+      ARGS+=("--grace-period")
       ;;
     --help|-h)
       cat <<EOF
-Safe worktree cleanup - only removes worktrees for MERGED PRs
+Safe worktree cleanup - DEPRECATED WRAPPER
+
+This script is a thin wrapper around clean.sh --safe for backwards compatibility.
+Please use clean.sh --safe directly for more options.
 
 Usage: ./scripts/safe-worktree-cleanup.sh [options]
 
@@ -74,299 +58,19 @@ Cleanup Criteria:
   2. The PR is MERGED (has mergedAt timestamp)
   3. Grace period has passed since merge
   4. No uncommitted changes exist (unless --force)
+
+Equivalent clean.sh commands:
+  ./scripts/safe-worktree-cleanup.sh             ->  ./scripts/clean.sh --safe --worktrees-only
+  ./scripts/safe-worktree-cleanup.sh --force     ->  ./scripts/clean.sh --safe --worktrees-only --force
+  ./scripts/safe-worktree-cleanup.sh --dry-run   ->  ./scripts/clean.sh --safe --worktrees-only --dry-run
 EOF
       exit 0
       ;;
     *)
-      error "Unknown option: $1\nUse --help for usage information"
+      ARGS+=("$arg")
       ;;
   esac
 done
 
-# Functions
-check_pr_merged() {
-  local issue_num="$1"
-  local branch_name="feature/issue-${issue_num}"
-
-  # Find PR by head branch
-  local pr_info=$(gh pr list --head "$branch_name" --state all --json number,state,mergedAt --jq '.[0] // empty' 2>/dev/null || echo "")
-
-  if [[ -z "$pr_info" ]]; then
-    # Try searching by issue reference
-    pr_info=$(gh pr list --search "Closes #${issue_num}" --state all --json number,state,mergedAt --jq '.[0] // empty' 2>/dev/null || echo "")
-  fi
-
-  if [[ -z "$pr_info" ]]; then
-    echo "NO_PR"
-    return
-  fi
-
-  local state=$(echo "$pr_info" | jq -r '.state // "UNKNOWN"')
-  local merged_at=$(echo "$pr_info" | jq -r '.mergedAt // "null"')
-
-  if [[ "$merged_at" != "null" && "$merged_at" != "" ]]; then
-    echo "MERGED:$merged_at"
-  elif [[ "$state" == "CLOSED" ]]; then
-    echo "CLOSED_NO_MERGE"
-  elif [[ "$state" == "OPEN" ]]; then
-    echo "OPEN"
-  else
-    echo "UNKNOWN"
-  fi
-}
-
-check_uncommitted_changes() {
-  local worktree_path="$1"
-
-  if [[ ! -d "$worktree_path" ]]; then
-    echo "false"
-    return
-  fi
-
-  # Check for any uncommitted changes (staged or unstaged)
-  if git -C "$worktree_path" diff --quiet 2>/dev/null && \
-     git -C "$worktree_path" diff --cached --quiet 2>/dev/null; then
-    echo "false"
-  else
-    echo "true"
-  fi
-}
-
-check_grace_period() {
-  local merged_at="$1"
-  local now=$(date +%s)
-
-  # Parse merged_at timestamp
-  local merged_ts
-  if [[ "$OSTYPE" == "darwin"* ]]; then
-    # macOS
-    merged_ts=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$merged_at" +%s 2>/dev/null || echo "0")
-  else
-    # Linux
-    merged_ts=$(date -d "$merged_at" +%s 2>/dev/null || echo "0")
-  fi
-
-  local elapsed=$((now - merged_ts))
-
-  if [[ $elapsed -gt $GRACE_PERIOD ]]; then
-    echo "passed:$elapsed"
-  else
-    echo "waiting:$((GRACE_PERIOD - elapsed))"
-  fi
-}
-
-cleanup_worktree() {
-  local worktree_path="$1"
-  local issue_num="$2"
-  local branch_name="feature/issue-${issue_num}"
-
-  if [[ "$DRY_RUN" == true ]]; then
-    info "Would remove: $worktree_path"
-    info "Would delete branch: $branch_name"
-    return 0
-  fi
-
-  # Remove worktree
-  if git worktree remove "$worktree_path" --force 2>/dev/null; then
-    success "Removed worktree: $worktree_path"
-  else
-    warning "Failed to remove worktree: $worktree_path"
-    return 1
-  fi
-
-  # Delete local branch (if it exists)
-  if git branch -d "$branch_name" 2>/dev/null; then
-    success "Deleted branch: $branch_name"
-  elif git branch -D "$branch_name" 2>/dev/null; then
-    success "Force-deleted branch: $branch_name"
-  else
-    info "Branch already deleted or doesn't exist: $branch_name"
-  fi
-
-  return 0
-}
-
-update_cleanup_state() {
-  local issue_num="$1"
-  local status="$2"
-
-  if [[ ! -f "$DAEMON_STATE" ]]; then
-    return
-  fi
-
-  local timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-
-  # Initialize cleanup section if needed
-  if ! jq -e '.cleanup' "$DAEMON_STATE" >/dev/null 2>&1; then
-    jq '.cleanup = {"lastRun": null, "lastCleaned": [], "pendingCleanup": [], "errors": []}' \
-      "$DAEMON_STATE" > "${DAEMON_STATE}.tmp" && mv "${DAEMON_STATE}.tmp" "$DAEMON_STATE"
-  fi
-
-  case "$status" in
-    cleaned)
-      jq ".cleanup.lastCleaned += [\"issue-${issue_num}\"] | .cleanup.lastRun = \"$timestamp\"" \
-        "$DAEMON_STATE" > "${DAEMON_STATE}.tmp" && mv "${DAEMON_STATE}.tmp" "$DAEMON_STATE"
-      ;;
-    pending)
-      jq ".cleanup.pendingCleanup += [\"issue-${issue_num}\"] | .cleanup.pendingCleanup |= unique" \
-        "$DAEMON_STATE" > "${DAEMON_STATE}.tmp" && mv "${DAEMON_STATE}.tmp" "$DAEMON_STATE"
-      ;;
-    error)
-      jq ".cleanup.errors += [{\"issue\": $issue_num, \"timestamp\": \"$timestamp\"}]" \
-        "$DAEMON_STATE" > "${DAEMON_STATE}.tmp" && mv "${DAEMON_STATE}.tmp" "$DAEMON_STATE"
-      ;;
-  esac
-}
-
-# Main
-cd "$REPO_ROOT"
-
-header "========================================"
-header "  Safe Worktree Cleanup"
-if [[ "$DRY_RUN" == true ]]; then
-  header "  (DRY RUN MODE)"
-fi
-header "========================================"
-echo ""
-
-# Get worktree directory
-WORKTREE_DIR="$REPO_ROOT/.loom/worktrees"
-
-if [[ ! -d "$WORKTREE_DIR" ]]; then
-  info "No worktrees directory found"
-  exit 0
-fi
-
-# Counters
-cleaned=0
-skipped_open=0
-skipped_not_merged=0
-skipped_grace=0
-skipped_uncommitted=0
-errors=0
-
-# Process each worktree
-for worktree_path in "$WORKTREE_DIR"/issue-*; do
-  if [[ ! -d "$worktree_path" ]]; then
-    continue
-  fi
-
-  issue_num=$(basename "$worktree_path" | sed 's/issue-//')
-
-  if [[ ! "$issue_num" =~ ^[0-9]+$ ]]; then
-    continue
-  fi
-
-  echo "Checking worktree: issue-$issue_num"
-
-  # Check issue state
-  issue_state=$(gh issue view "$issue_num" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
-
-  if [[ "$issue_state" != "CLOSED" ]]; then
-    info "  Issue #$issue_num is $issue_state - skipping"
-    ((skipped_open++)) || true
-    continue
-  fi
-
-  # Check PR merge status
-  pr_status=$(check_pr_merged "$issue_num")
-
-  case "$pr_status" in
-    MERGED:*)
-      merged_at="${pr_status#MERGED:}"
-      ;;
-    CLOSED_NO_MERGE)
-      warning "  PR closed without merge - skipping (may need investigation)"
-      ((skipped_not_merged++)) || true
-      continue
-      ;;
-    OPEN)
-      info "  PR still open - skipping"
-      ((skipped_open++)) || true
-      continue
-      ;;
-    NO_PR)
-      warning "  No PR found for issue - skipping"
-      ((skipped_not_merged++)) || true
-      continue
-      ;;
-    *)
-      warning "  Unknown PR status - skipping"
-      ((errors++)) || true
-      continue
-      ;;
-  esac
-
-  # Check grace period
-  if [[ "$FORCE" != true ]]; then
-    grace_status=$(check_grace_period "$merged_at")
-    case "$grace_status" in
-      waiting:*)
-        remaining="${grace_status#waiting:}"
-        info "  PR merged but grace period not passed (${remaining}s remaining)"
-        update_cleanup_state "$issue_num" "pending"
-        ((skipped_grace++)) || true
-        continue
-        ;;
-    esac
-  fi
-
-  # Check for uncommitted changes
-  if [[ "$FORCE" != true ]]; then
-    has_changes=$(check_uncommitted_changes "$worktree_path")
-    if [[ "$has_changes" == "true" ]]; then
-      warning "  Uncommitted changes detected - skipping"
-      warning "    To force: ./scripts/safe-worktree-cleanup.sh --force"
-      ((skipped_uncommitted++)) || true
-      continue
-    fi
-  fi
-
-  # All checks passed - cleanup
-  if cleanup_worktree "$worktree_path" "$issue_num"; then
-    if [[ "$DRY_RUN" != true ]]; then
-      update_cleanup_state "$issue_num" "cleaned"
-    fi
-    ((cleaned++)) || true
-  else
-    if [[ "$DRY_RUN" != true ]]; then
-      update_cleanup_state "$issue_num" "error"
-    fi
-    ((errors++)) || true
-  fi
-done
-
-# Prune orphaned git worktree references
-echo ""
-header "Pruning Orphaned References"
-if [[ "$DRY_RUN" == true ]]; then
-  git worktree prune --dry-run --verbose 2>&1 || true
-else
-  git worktree prune --verbose 2>&1 || true
-fi
-
-# Summary
-echo ""
-header "========================================"
-header "  Summary"
-header "========================================"
-echo ""
-
-if [[ "$DRY_RUN" == true ]]; then
-  echo "  Would clean: $cleaned worktree(s)"
-else
-  echo "  Cleaned: $cleaned worktree(s)"
-fi
-echo "  Skipped (open): $skipped_open"
-echo "  Skipped (not merged): $skipped_not_merged"
-echo "  Skipped (grace period): $skipped_grace"
-echo "  Skipped (uncommitted): $skipped_uncommitted"
-echo "  Errors: $errors"
-echo ""
-
-if [[ "$DRY_RUN" == true ]]; then
-  warning "Dry run complete - no changes made"
-  info "Run without --dry-run to perform cleanup"
-else
-  success "Cleanup complete!"
-fi
+# Call the unified clean.sh
+exec "$SCRIPT_DIR/clean.sh" "${ARGS[@]}"

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,9 +1,10 @@
-#!/bin/bash
-# Loom Cleanup Script - Remove build artifacts and orphaned worktrees
+#!/usr/bin/env bash
+# Loom Cleanup Script - WRAPPER (backwards compatibility)
+#
+# This script is a thin wrapper around defaults/scripts/clean.sh for backwards compatibility.
+# The unified clean.sh now handles all cleanup functionality.
 #
 # AGENT USAGE INSTRUCTIONS:
-#   This script cleans up Loom build artifacts and orphaned worktrees.
-#
 #   Non-interactive mode (for Claude Code):
 #     ./scripts/cleanup.sh --yes
 #     ./scripts/cleanup.sh -y
@@ -11,166 +12,59 @@
 #   Interactive mode (prompts for confirmation):
 #     ./scripts/cleanup.sh
 #
-#   What this script does:
-#     1. Removes target/ directory (Rust build artifacts)
-#     2. Removes node_modules/ directory (Node dependencies)
-#     3. Detects worktrees for closed issues and offers to remove them
-#     4. Prunes orphaned git worktrees (with confirmation unless --yes)
+# DEPRECATED: Use defaults/scripts/clean.sh instead:
+#   ./defaults/scripts/clean.sh --deep --force   # Equivalent to cleanup.sh --yes
 #
-#   After running, restore dependencies with: pnpm install
+# What this wrapper does:
+#   Maps cleanup.sh arguments to clean.sh equivalents
+#   Always includes --deep (build artifacts)
 
-set -e  # Exit on error
+set -euo pipefail
 
-# Parse command line arguments
-NON_INTERACTIVE=false
+# Find script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Map arguments
+ARGS=("--deep")  # cleanup.sh always cleans build artifacts
+
 for arg in "$@"; do
   case $arg in
     -y|--yes)
-      NON_INTERACTIVE=true
-      shift
+      ARGS+=("--force")
+      ;;
+    --help|-h)
+      cat <<EOF
+Loom Cleanup Script - DEPRECATED WRAPPER
+
+This script is a thin wrapper around clean.sh for backwards compatibility.
+Please use defaults/scripts/clean.sh directly for more options.
+
+Usage: ./scripts/cleanup.sh [options]
+
+Options:
+  -y, --yes    Non-interactive mode (auto-confirm all prompts)
+  -h, --help   Show this help message
+
+What it does:
+  1. Removes target/ directory (Rust build artifacts)
+  2. Removes node_modules/ directory (Node dependencies)
+  3. Detects worktrees for closed issues and offers to remove them
+  4. Prunes orphaned git worktrees
+
+Equivalent clean.sh commands:
+  ./scripts/cleanup.sh           ->  ./defaults/scripts/clean.sh --deep
+  ./scripts/cleanup.sh --yes     ->  ./defaults/scripts/clean.sh --deep --force
+
+After running, restore dependencies with: pnpm install
+EOF
+      exit 0
+      ;;
+    *)
+      ARGS+=("$arg")
       ;;
   esac
 done
 
-echo "🧹 Loom Cleanup"
-echo ""
-
-# Track if we're in main workspace
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-
-# Clean Rust build artifacts
-if [ -d "$PROJECT_ROOT/target" ]; then
-  SIZE=$(du -sh "$PROJECT_ROOT/target" 2>/dev/null | cut -f1 || echo "unknown")
-  echo "Removing target/ ($SIZE)"
-  rm -rf "$PROJECT_ROOT/target"
-  echo "✓ Removed target/"
-else
-  echo "ℹ No target/ directory found"
-fi
-
-echo ""
-
-# Clean node_modules
-if [ -d "$PROJECT_ROOT/node_modules" ]; then
-  SIZE=$(du -sh "$PROJECT_ROOT/node_modules" 2>/dev/null | cut -f1 || echo "unknown")
-  echo "Removing node_modules/ ($SIZE)"
-  rm -rf "$PROJECT_ROOT/node_modules"
-  echo "✓ Removed node_modules/"
-else
-  echo "ℹ No node_modules/ directory found"
-fi
-
-echo ""
-
-# Check for worktrees associated with closed issues
-echo "Checking for worktrees associated with closed issues..."
-cd "$PROJECT_ROOT"
-
-CLOSED_ISSUE_WORKTREES=()
-
-# List all worktrees and check if their issues are closed
-while IFS= read -r worktree_line; do
-  # Extract worktree path (format: /path/to/worktree COMMIT [branch-name])
-  worktree_path=$(echo "$worktree_line" | awk '{print $1}')
-
-  # Skip the main worktree
-  if [[ "$worktree_path" == "$PROJECT_ROOT" ]]; then
-    continue
-  fi
-
-  # Extract issue number from path (e.g., .loom/worktrees/issue-123)
-  if [[ "$worktree_path" =~ issue-([0-9]+) ]]; then
-    issue_num="${BASH_REMATCH[1]}"
-
-    # Check if issue is closed using gh
-    if command -v gh &> /dev/null; then
-      issue_state=$(gh issue view "$issue_num" --json state --jq .state 2>/dev/null || echo "")
-
-      if [[ "$issue_state" == "CLOSED" ]]; then
-        CLOSED_ISSUE_WORKTREES+=("$worktree_path:$issue_num")
-        echo "⚠ Worktree for closed issue #$issue_num is still active"
-        echo "ℹ Path: $worktree_path"
-      fi
-    fi
-  fi
-done < <(git worktree list --porcelain | grep "worktree " | sed 's/worktree //')
-
-if [[ ${#CLOSED_ISSUE_WORKTREES[@]} -gt 0 ]]; then
-  echo ""
-
-  # Auto-remove in non-interactive mode
-  if [ "$NON_INTERACTIVE" = true ]; then
-    echo "Non-interactive mode: automatically removing closed issue worktrees"
-    for entry in "${CLOSED_ISSUE_WORKTREES[@]}"; do
-      worktree_path="${entry%%:*}"
-      issue_num="${entry##*:}"
-      echo "Removing worktree for closed issue #$issue_num..."
-      git worktree remove "$worktree_path" --force
-      echo "✓ Removed: $worktree_path"
-    done
-    echo "✓ Removed ${#CLOSED_ISSUE_WORKTREES[@]} closed issue worktree(s)"
-  else
-    echo "Found ${#CLOSED_ISSUE_WORKTREES[@]} worktree(s) for closed issues."
-    read -p "Force remove all closed issue worktrees? (y/N) " -n 1 -r
-    echo
-
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
-      for entry in "${CLOSED_ISSUE_WORKTREES[@]}"; do
-        worktree_path="${entry%%:*}"
-        issue_num="${entry##*:}"
-        echo "Removing worktree for closed issue #$issue_num..."
-        git worktree remove "$worktree_path" --force
-        echo "✓ Removed: $worktree_path"
-      done
-      echo "✓ Removed ${#CLOSED_ISSUE_WORKTREES[@]} closed issue worktree(s)"
-    else
-      echo "ℹ Skipped closed issue worktree cleanup"
-      echo "ℹ To remove individually:"
-      for entry in "${CLOSED_ISSUE_WORKTREES[@]}"; do
-        worktree_path="${entry%%:*}"
-        issue_num="${entry##*:}"
-        echo "  git worktree remove $worktree_path --force  # issue #$issue_num"
-      done
-    fi
-  fi
-else
-  echo "✓ No worktrees found for closed issues"
-fi
-
-echo ""
-
-# Clean orphaned worktrees
-echo "Checking for orphaned worktrees..."
-
-# Show what would be pruned
-PRUNE_OUTPUT=$(git worktree prune --dry-run --verbose 2>&1 || true)
-
-if [ -n "$PRUNE_OUTPUT" ]; then
-  echo "$PRUNE_OUTPUT"
-  echo ""
-
-  # Auto-confirm in non-interactive mode
-  if [ "$NON_INTERACTIVE" = true ]; then
-    echo "Non-interactive mode: automatically removing orphaned worktrees"
-    git worktree prune --verbose
-    echo "✓ Orphaned worktrees removed"
-  else
-    read -p "Remove orphaned worktrees? (y/N) " -n 1 -r
-    echo
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
-      git worktree prune --verbose
-      echo "✓ Orphaned worktrees removed"
-    else
-      echo "ℹ Skipped worktree cleanup"
-    fi
-  fi
-else
-  echo "✓ No orphaned worktrees found"
-fi
-
-echo ""
-echo "✅ Cleanup complete!"
-echo ""
-echo "To restore dependencies, run:"
-echo "  pnpm install"
+# Call the unified clean.sh from defaults/scripts/
+exec "$PROJECT_ROOT/defaults/scripts/clean.sh" "${ARGS[@]}"

--- a/scripts/safe-worktree-cleanup.sh
+++ b/scripts/safe-worktree-cleanup.sh
@@ -1,58 +1,43 @@
 #!/usr/bin/env bash
-# Safe worktree cleanup - only removes worktrees for MERGED PRs
-# Usage: ./scripts/safe-worktree-cleanup.sh [--dry-run] [--force] [--grace-period N]
+# Safe worktree cleanup - WRAPPER (backwards compatibility)
 #
-# Unlike blunt cleanup, this script:
-# - Only removes worktrees when the PR is MERGED (not just closed)
-# - Checks for uncommitted changes before removal
-# - Applies a grace period after merge to avoid race conditions
-# - Tracks cleanup state in daemon-state.json
+# This script is a thin wrapper around defaults/scripts/clean.sh for backwards compatibility.
+# The unified clean.sh now handles all cleanup functionality with --safe mode.
+#
+# DEPRECATED: Use defaults/scripts/clean.sh --safe instead:
+#   ./defaults/scripts/clean.sh --safe              # Equivalent to safe-worktree-cleanup.sh
+#   ./defaults/scripts/clean.sh --safe --force      # Equivalent to safe-worktree-cleanup.sh --force
+#
+# What this wrapper does:
+#   Maps safe-worktree-cleanup.sh arguments to clean.sh --safe equivalents
+#   Always includes --safe and --worktrees-only
 
 set -euo pipefail
 
-# ANSI color codes
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-BLUE='\033[0;34m'
-YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
-NC='\033[0m'
+# Find script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-error() { echo -e "${RED}Error: $*${NC}" >&2; exit 1; }
-info() { echo -e "${BLUE}$*${NC}"; }
-success() { echo -e "${GREEN}$*${NC}"; }
-warning() { echo -e "${YELLOW}$*${NC}"; }
-header() { echo -e "${CYAN}$*${NC}"; }
+# Map arguments - safe-worktree-cleanup.sh is worktrees-only with safe mode
+ARGS=("--safe" "--worktrees-only")
 
-# Configuration
-DRY_RUN=false
-FORCE=false
-GRACE_PERIOD=600  # 10 minutes in seconds
-
-# Detect repository root
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || error "Not in a git repository"
-
-# State file for tracking cleanup
-DAEMON_STATE="$REPO_ROOT/.loom/daemon-state.json"
-
-# Parse arguments
-while [[ $# -gt 0 ]]; do
-  case $1 in
+for arg in "$@"; do
+  case $arg in
     --dry-run)
-      DRY_RUN=true
-      shift
+      ARGS+=("--dry-run")
       ;;
     --force|-f)
-      FORCE=true
-      shift
+      ARGS+=("--force")
       ;;
     --grace-period)
-      GRACE_PERIOD="$2"
-      shift 2
+      ARGS+=("--grace-period")
       ;;
     --help|-h)
       cat <<EOF
-Safe worktree cleanup - only removes worktrees for MERGED PRs
+Safe worktree cleanup - DEPRECATED WRAPPER
+
+This script is a thin wrapper around clean.sh --safe for backwards compatibility.
+Please use defaults/scripts/clean.sh --safe directly for more options.
 
 Usage: ./scripts/safe-worktree-cleanup.sh [options]
 
@@ -74,299 +59,19 @@ Cleanup Criteria:
   2. The PR is MERGED (has mergedAt timestamp)
   3. Grace period has passed since merge
   4. No uncommitted changes exist (unless --force)
+
+Equivalent clean.sh commands:
+  ./scripts/safe-worktree-cleanup.sh             ->  ./defaults/scripts/clean.sh --safe --worktrees-only
+  ./scripts/safe-worktree-cleanup.sh --force     ->  ./defaults/scripts/clean.sh --safe --worktrees-only --force
+  ./scripts/safe-worktree-cleanup.sh --dry-run   ->  ./defaults/scripts/clean.sh --safe --worktrees-only --dry-run
 EOF
       exit 0
       ;;
     *)
-      error "Unknown option: $1\nUse --help for usage information"
+      ARGS+=("$arg")
       ;;
   esac
 done
 
-# Functions
-check_pr_merged() {
-  local issue_num="$1"
-  local branch_name="feature/issue-${issue_num}"
-
-  # Find PR by head branch
-  local pr_info=$(gh pr list --head "$branch_name" --state all --json number,state,mergedAt --jq '.[0] // empty' 2>/dev/null || echo "")
-
-  if [[ -z "$pr_info" ]]; then
-    # Try searching by issue reference
-    pr_info=$(gh pr list --search "Closes #${issue_num}" --state all --json number,state,mergedAt --jq '.[0] // empty' 2>/dev/null || echo "")
-  fi
-
-  if [[ -z "$pr_info" ]]; then
-    echo "NO_PR"
-    return
-  fi
-
-  local state=$(echo "$pr_info" | jq -r '.state // "UNKNOWN"')
-  local merged_at=$(echo "$pr_info" | jq -r '.mergedAt // "null"')
-
-  if [[ "$merged_at" != "null" && "$merged_at" != "" ]]; then
-    echo "MERGED:$merged_at"
-  elif [[ "$state" == "CLOSED" ]]; then
-    echo "CLOSED_NO_MERGE"
-  elif [[ "$state" == "OPEN" ]]; then
-    echo "OPEN"
-  else
-    echo "UNKNOWN"
-  fi
-}
-
-check_uncommitted_changes() {
-  local worktree_path="$1"
-
-  if [[ ! -d "$worktree_path" ]]; then
-    echo "false"
-    return
-  fi
-
-  # Check for any uncommitted changes (staged or unstaged)
-  if git -C "$worktree_path" diff --quiet 2>/dev/null && \
-     git -C "$worktree_path" diff --cached --quiet 2>/dev/null; then
-    echo "false"
-  else
-    echo "true"
-  fi
-}
-
-check_grace_period() {
-  local merged_at="$1"
-  local now=$(date +%s)
-
-  # Parse merged_at timestamp
-  local merged_ts
-  if [[ "$OSTYPE" == "darwin"* ]]; then
-    # macOS
-    merged_ts=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$merged_at" +%s 2>/dev/null || echo "0")
-  else
-    # Linux
-    merged_ts=$(date -d "$merged_at" +%s 2>/dev/null || echo "0")
-  fi
-
-  local elapsed=$((now - merged_ts))
-
-  if [[ $elapsed -gt $GRACE_PERIOD ]]; then
-    echo "passed:$elapsed"
-  else
-    echo "waiting:$((GRACE_PERIOD - elapsed))"
-  fi
-}
-
-cleanup_worktree() {
-  local worktree_path="$1"
-  local issue_num="$2"
-  local branch_name="feature/issue-${issue_num}"
-
-  if [[ "$DRY_RUN" == true ]]; then
-    info "Would remove: $worktree_path"
-    info "Would delete branch: $branch_name"
-    return 0
-  fi
-
-  # Remove worktree
-  if git worktree remove "$worktree_path" --force 2>/dev/null; then
-    success "Removed worktree: $worktree_path"
-  else
-    warning "Failed to remove worktree: $worktree_path"
-    return 1
-  fi
-
-  # Delete local branch (if it exists)
-  if git branch -d "$branch_name" 2>/dev/null; then
-    success "Deleted branch: $branch_name"
-  elif git branch -D "$branch_name" 2>/dev/null; then
-    success "Force-deleted branch: $branch_name"
-  else
-    info "Branch already deleted or doesn't exist: $branch_name"
-  fi
-
-  return 0
-}
-
-update_cleanup_state() {
-  local issue_num="$1"
-  local status="$2"
-
-  if [[ ! -f "$DAEMON_STATE" ]]; then
-    return
-  fi
-
-  local timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-
-  # Initialize cleanup section if needed
-  if ! jq -e '.cleanup' "$DAEMON_STATE" >/dev/null 2>&1; then
-    jq '.cleanup = {"lastRun": null, "lastCleaned": [], "pendingCleanup": [], "errors": []}' \
-      "$DAEMON_STATE" > "${DAEMON_STATE}.tmp" && mv "${DAEMON_STATE}.tmp" "$DAEMON_STATE"
-  fi
-
-  case "$status" in
-    cleaned)
-      jq ".cleanup.lastCleaned += [\"issue-${issue_num}\"] | .cleanup.lastRun = \"$timestamp\"" \
-        "$DAEMON_STATE" > "${DAEMON_STATE}.tmp" && mv "${DAEMON_STATE}.tmp" "$DAEMON_STATE"
-      ;;
-    pending)
-      jq ".cleanup.pendingCleanup += [\"issue-${issue_num}\"] | .cleanup.pendingCleanup |= unique" \
-        "$DAEMON_STATE" > "${DAEMON_STATE}.tmp" && mv "${DAEMON_STATE}.tmp" "$DAEMON_STATE"
-      ;;
-    error)
-      jq ".cleanup.errors += [{\"issue\": $issue_num, \"timestamp\": \"$timestamp\"}]" \
-        "$DAEMON_STATE" > "${DAEMON_STATE}.tmp" && mv "${DAEMON_STATE}.tmp" "$DAEMON_STATE"
-      ;;
-  esac
-}
-
-# Main
-cd "$REPO_ROOT"
-
-header "========================================"
-header "  Safe Worktree Cleanup"
-if [[ "$DRY_RUN" == true ]]; then
-  header "  (DRY RUN MODE)"
-fi
-header "========================================"
-echo ""
-
-# Get worktree directory
-WORKTREE_DIR="$REPO_ROOT/.loom/worktrees"
-
-if [[ ! -d "$WORKTREE_DIR" ]]; then
-  info "No worktrees directory found"
-  exit 0
-fi
-
-# Counters
-cleaned=0
-skipped_open=0
-skipped_not_merged=0
-skipped_grace=0
-skipped_uncommitted=0
-errors=0
-
-# Process each worktree
-for worktree_path in "$WORKTREE_DIR"/issue-*; do
-  if [[ ! -d "$worktree_path" ]]; then
-    continue
-  fi
-
-  issue_num=$(basename "$worktree_path" | sed 's/issue-//')
-
-  if [[ ! "$issue_num" =~ ^[0-9]+$ ]]; then
-    continue
-  fi
-
-  echo "Checking worktree: issue-$issue_num"
-
-  # Check issue state
-  issue_state=$(gh issue view "$issue_num" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
-
-  if [[ "$issue_state" != "CLOSED" ]]; then
-    info "  Issue #$issue_num is $issue_state - skipping"
-    ((skipped_open++)) || true
-    continue
-  fi
-
-  # Check PR merge status
-  pr_status=$(check_pr_merged "$issue_num")
-
-  case "$pr_status" in
-    MERGED:*)
-      merged_at="${pr_status#MERGED:}"
-      ;;
-    CLOSED_NO_MERGE)
-      warning "  PR closed without merge - skipping (may need investigation)"
-      ((skipped_not_merged++)) || true
-      continue
-      ;;
-    OPEN)
-      info "  PR still open - skipping"
-      ((skipped_open++)) || true
-      continue
-      ;;
-    NO_PR)
-      warning "  No PR found for issue - skipping"
-      ((skipped_not_merged++)) || true
-      continue
-      ;;
-    *)
-      warning "  Unknown PR status - skipping"
-      ((errors++)) || true
-      continue
-      ;;
-  esac
-
-  # Check grace period
-  if [[ "$FORCE" != true ]]; then
-    grace_status=$(check_grace_period "$merged_at")
-    case "$grace_status" in
-      waiting:*)
-        remaining="${grace_status#waiting:}"
-        info "  PR merged but grace period not passed (${remaining}s remaining)"
-        update_cleanup_state "$issue_num" "pending"
-        ((skipped_grace++)) || true
-        continue
-        ;;
-    esac
-  fi
-
-  # Check for uncommitted changes
-  if [[ "$FORCE" != true ]]; then
-    has_changes=$(check_uncommitted_changes "$worktree_path")
-    if [[ "$has_changes" == "true" ]]; then
-      warning "  Uncommitted changes detected - skipping"
-      warning "    To force: ./scripts/safe-worktree-cleanup.sh --force"
-      ((skipped_uncommitted++)) || true
-      continue
-    fi
-  fi
-
-  # All checks passed - cleanup
-  if cleanup_worktree "$worktree_path" "$issue_num"; then
-    if [[ "$DRY_RUN" != true ]]; then
-      update_cleanup_state "$issue_num" "cleaned"
-    fi
-    ((cleaned++)) || true
-  else
-    if [[ "$DRY_RUN" != true ]]; then
-      update_cleanup_state "$issue_num" "error"
-    fi
-    ((errors++)) || true
-  fi
-done
-
-# Prune orphaned git worktree references
-echo ""
-header "Pruning Orphaned References"
-if [[ "$DRY_RUN" == true ]]; then
-  git worktree prune --dry-run --verbose 2>&1 || true
-else
-  git worktree prune --verbose 2>&1 || true
-fi
-
-# Summary
-echo ""
-header "========================================"
-header "  Summary"
-header "========================================"
-echo ""
-
-if [[ "$DRY_RUN" == true ]]; then
-  echo "  Would clean: $cleaned worktree(s)"
-else
-  echo "  Cleaned: $cleaned worktree(s)"
-fi
-echo "  Skipped (open): $skipped_open"
-echo "  Skipped (not merged): $skipped_not_merged"
-echo "  Skipped (grace period): $skipped_grace"
-echo "  Skipped (uncommitted): $skipped_uncommitted"
-echo "  Errors: $errors"
-echo ""
-
-if [[ "$DRY_RUN" == true ]]; then
-  warning "Dry run complete - no changes made"
-  info "Run without --dry-run to perform cleanup"
-else
-  success "Cleanup complete!"
-fi
+# Call the unified clean.sh from defaults/scripts/
+exec "$PROJECT_ROOT/defaults/scripts/clean.sh" "${ARGS[@]}"


### PR DESCRIPTION
## Summary

- Consolidates three overlapping cleanup scripts (`clean.sh`, `cleanup.sh`, `safe-worktree-cleanup.sh`) into a single unified `clean.sh` with modular flags
- Old script names work as backwards-compatible wrappers
- Net reduction of ~500 lines through elimination of duplicate code

## Changes

**Unified `clean.sh` features:**
- Standard cleanup: worktrees, branches, tmux sessions  
- `--deep`: include build artifacts (target/, node_modules/)
- `--safe`: only cleanup MERGED PRs with grace period + uncommitted change checks
- `--worktrees-only`, `--branches-only`, `--tmux-only`: targeted cleanup
- `--grace-period N`: configurable grace period for safe mode
- `--force/-f/--yes/-y`: non-interactive mode for CI/automation

**Backwards compatibility:**
- `cleanup.sh` -> wrapper for `clean.sh --deep`
- `safe-worktree-cleanup.sh` -> wrapper for `clean.sh --safe --worktrees-only`

## Metrics

| Metric | Before | After |
|--------|--------|-------|
| Total lines | 948 | 862 |
| Files with full implementation | 3 | 1 |
| Net insertions/deletions | - | +695 / -1182 |

## Test plan

- [ ] Test `clean.sh --help` shows unified help text
- [ ] Test `clean.sh --dry-run` works in standard mode
- [ ] Test `clean.sh --safe --dry-run` works in safe mode
- [ ] Test `cleanup.sh --yes` still works (wrapper)
- [ ] Test `safe-worktree-cleanup.sh --dry-run` still works (wrapper)
- [ ] Test daemon-cleanup.sh still functions (calls safe-worktree-cleanup.sh wrapper)

Closes #1153

---
Generated with [Claude Code](https://claude.com/claude-code)