### PR TITLE
Add persistent issue claim registry for reliable work distribution (#1159)

### DIFF
--- a/loom-daemon/src/activity/db.rs
+++ b/loom-daemon/src/activity/db.rs
@@ -10,9 +10,9 @@ use std::path::PathBuf;
 
 use super::models::{
     ActivityEntry, AgentInput, AgentMetric, AgentOutput, BudgetConfig, BudgetPeriod, BudgetStatus,
-    CostByIssue, CostByPr, CostByRole, CostSummary, InputContext, InputType, PrReworkStats,
-    ProductivitySummary, PromptChanges, PromptGitHubEvent, PromptSuccessStats, QualityMetrics,
-    RunwayProjection, TokenUsage,
+    ClaimResult, ClaimType, CostByIssue, CostByPr, CostByRole, CostSummary, InputContext, InputType,
+    IssueClaim, PrReworkStats, ProductivitySummary, PromptChanges, PromptGitHubEvent,
+    PromptSuccessStats, QualityMetrics, RunwayProjection, TokenUsage,
 };
 use super::schema::init_schema;
 use super::test_parser;
@@ -1366,6 +1366,461 @@ impl ActivityDb {
             exhaustion_date,
             lookback_days,
         }))
+    }
+
+    // ========================================================================
+    // Issue Claim Registry Methods (Issue #1159)
+    // ========================================================================
+
+    /// Attempt to claim an issue or PR for a terminal.
+    ///
+    /// This uses INSERT OR IGNORE with a unique constraint to prevent race conditions.
+    /// If the claim already exists, it checks if the claim is stale (based on TTL)
+    /// and can be reclaimed.
+    ///
+    /// # Arguments
+    /// * `number` - The issue or PR number to claim
+    /// * `claim_type` - Whether this is an issue or PR claim
+    /// * `terminal_id` - The terminal claiming the work
+    /// * `label` - Optional GitHub label associated with this claim
+    /// * `agent_role` - Optional agent role for tracking
+    /// * `stale_threshold_secs` - How many seconds before a claim is considered stale (default: 3600 = 1 hour)
+    pub fn claim_issue(
+        &self,
+        number: i32,
+        claim_type: ClaimType,
+        terminal_id: &str,
+        label: Option<&str>,
+        agent_role: Option<&str>,
+        stale_threshold_secs: Option<i64>,
+    ) -> Result<ClaimResult> {
+
+        let now = Utc::now();
+        let claim_type_str = claim_type.as_str();
+        let stale_threshold = stale_threshold_secs.unwrap_or(3600); // Default 1 hour
+
+        // First, try to insert a new claim
+        let insert_result = self.conn.execute(
+            r"
+            INSERT OR IGNORE INTO issue_claims (number, claim_type, terminal_id, claimed_at, last_heartbeat, label, agent_role)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+            ",
+            params![
+                number,
+                claim_type_str,
+                terminal_id,
+                now.to_rfc3339(),
+                now.to_rfc3339(),
+                label,
+                agent_role,
+            ],
+        )?;
+
+        // If insert succeeded (rows_affected == 1), we got the claim
+        if insert_result == 1 {
+            let claim_id = self.conn.last_insert_rowid();
+            return Ok(ClaimResult::Success { claim_id });
+        }
+
+        // Insert failed due to unique constraint - check existing claim
+        let existing: (i64, String, String) = self.conn.query_row(
+            r"
+            SELECT id, terminal_id, last_heartbeat
+            FROM issue_claims
+            WHERE number = ?1 AND claim_type = ?2
+            ",
+            params![number, claim_type_str],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )?;
+
+        let (existing_id, existing_terminal, heartbeat_str) = existing;
+        let heartbeat = DateTime::parse_from_rfc3339(&heartbeat_str)
+            .map_err(|e| anyhow::anyhow!("Invalid timestamp: {e}"))?
+            .with_timezone(&Utc);
+
+        // Check if the existing claim is stale
+        let age_secs = (now - heartbeat).num_seconds();
+
+        if age_secs > stale_threshold {
+            // Claim is stale - reclaim it
+            self.conn.execute(
+                r"
+                UPDATE issue_claims
+                SET terminal_id = ?1, claimed_at = ?2, last_heartbeat = ?3, label = ?4, agent_role = ?5
+                WHERE id = ?6
+                ",
+                params![
+                    terminal_id,
+                    now.to_rfc3339(),
+                    now.to_rfc3339(),
+                    label,
+                    agent_role,
+                    existing_id,
+                ],
+            )?;
+
+            Ok(ClaimResult::Reclaimed {
+                claim_id: existing_id,
+                previous_terminal: existing_terminal,
+            })
+        } else {
+            // Claim is still active - return the current owner
+            let claimed_at_str: String = self.conn.query_row(
+                r"SELECT claimed_at FROM issue_claims WHERE id = ?1",
+                params![existing_id],
+                |row| row.get(0),
+            )?;
+            let claimed_at = DateTime::parse_from_rfc3339(&claimed_at_str)
+                .map_err(|e| anyhow::anyhow!("Invalid timestamp: {e}"))?
+                .with_timezone(&Utc);
+
+            Ok(ClaimResult::AlreadyClaimed {
+                terminal_id: existing_terminal,
+                claimed_at,
+            })
+        }
+    }
+
+    /// Release a claim on an issue or PR.
+    ///
+    /// This removes the claim from the registry. Can be called when work is complete
+    /// or if the agent decides to abandon the work.
+    ///
+    /// # Arguments
+    /// * `number` - The issue or PR number to release
+    /// * `claim_type` - Whether this is an issue or PR claim
+    /// * `terminal_id` - Optional: only release if owned by this terminal
+    pub fn release_claim(
+        &self,
+        number: i32,
+        claim_type: ClaimType,
+        terminal_id: Option<&str>,
+    ) -> Result<bool> {
+        let claim_type_str = claim_type.as_str();
+
+        let rows = if let Some(tid) = terminal_id {
+            self.conn.execute(
+                r"DELETE FROM issue_claims WHERE number = ?1 AND claim_type = ?2 AND terminal_id = ?3",
+                params![number, claim_type_str, tid],
+            )?
+        } else {
+            self.conn.execute(
+                r"DELETE FROM issue_claims WHERE number = ?1 AND claim_type = ?2",
+                params![number, claim_type_str],
+            )?
+        };
+
+        Ok(rows > 0)
+    }
+
+    /// Update the heartbeat for an active claim.
+    ///
+    /// This should be called periodically by agents to indicate they are still
+    /// working on a claimed issue. Claims without heartbeat updates will be
+    /// considered stale after the TTL threshold.
+    pub fn heartbeat_claim(
+        &self,
+        number: i32,
+        claim_type: ClaimType,
+        terminal_id: &str,
+    ) -> Result<bool> {
+        let now = Utc::now();
+        let claim_type_str = claim_type.as_str();
+
+        let rows = self.conn.execute(
+            r"
+            UPDATE issue_claims
+            SET last_heartbeat = ?1
+            WHERE number = ?2 AND claim_type = ?3 AND terminal_id = ?4
+            ",
+            params![now.to_rfc3339(), number, claim_type_str, terminal_id],
+        )?;
+
+        Ok(rows > 0)
+    }
+
+    /// Get a specific claim if it exists.
+    pub fn get_claim(
+        &self,
+        number: i32,
+        claim_type: ClaimType,
+    ) -> Result<Option<IssueClaim>> {
+        use super::models::{ClaimType, IssueClaim};
+
+        let claim_type_str = claim_type.as_str();
+
+        let result = self.conn.query_row(
+            r"
+            SELECT id, number, claim_type, terminal_id, claimed_at, last_heartbeat, label, agent_role
+            FROM issue_claims
+            WHERE number = ?1 AND claim_type = ?2
+            ",
+            params![number, claim_type_str],
+            |row| {
+                let claimed_at_str: String = row.get(4)?;
+                let heartbeat_str: String = row.get(5)?;
+
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, i32>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    claimed_at_str,
+                    heartbeat_str,
+                    row.get::<_, Option<String>>(6)?,
+                    row.get::<_, Option<String>>(7)?,
+                ))
+            },
+        );
+
+        match result {
+            Ok((id, num, ct_str, tid, claimed_str, heartbeat_str, label, role)) => {
+                let claimed_at = DateTime::parse_from_rfc3339(&claimed_str)
+                    .map_err(|e| anyhow::anyhow!("Invalid timestamp: {e}"))?
+                    .with_timezone(&Utc);
+                let last_heartbeat = DateTime::parse_from_rfc3339(&heartbeat_str)
+                    .map_err(|e| anyhow::anyhow!("Invalid timestamp: {e}"))?
+                    .with_timezone(&Utc);
+
+                Ok(Some(IssueClaim {
+                    id: Some(id),
+                    number: num,
+                    claim_type: ClaimType::from_str(&ct_str).unwrap_or(ClaimType::Issue),
+                    terminal_id: tid,
+                    claimed_at,
+                    last_heartbeat,
+                    label,
+                    agent_role: role,
+                }))
+            }
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Get all active claims.
+    pub fn get_all_claims(&self) -> Result<Vec<IssueClaim>> {
+        use super::models::{ClaimType, IssueClaim};
+
+        let mut stmt = self.conn.prepare(
+            r"
+            SELECT id, number, claim_type, terminal_id, claimed_at, last_heartbeat, label, agent_role
+            FROM issue_claims
+            ORDER BY claimed_at
+            ",
+        )?;
+
+        let claims = stmt.query_map([], |row| {
+            let claimed_at_str: String = row.get(4)?;
+            let heartbeat_str: String = row.get(5)?;
+            let ct_str: String = row.get(2)?;
+
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i32>(1)?,
+                ct_str,
+                row.get::<_, String>(3)?,
+                claimed_at_str,
+                heartbeat_str,
+                row.get::<_, Option<String>>(6)?,
+                row.get::<_, Option<String>>(7)?,
+            ))
+        })?;
+
+        let mut result = Vec::new();
+        for claim in claims {
+            let (id, num, ct_str, tid, claimed_str, heartbeat_str, label, role) = claim?;
+
+            let claimed_at = DateTime::parse_from_rfc3339(&claimed_str)
+                .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?
+                .with_timezone(&Utc);
+            let last_heartbeat = DateTime::parse_from_rfc3339(&heartbeat_str)
+                .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?
+                .with_timezone(&Utc);
+
+            result.push(IssueClaim {
+                id: Some(id),
+                number: num,
+                claim_type: ClaimType::from_str(&ct_str).unwrap_or(ClaimType::Issue),
+                terminal_id: tid,
+                claimed_at,
+                last_heartbeat,
+                label,
+                agent_role: role,
+            });
+        }
+
+        Ok(result)
+    }
+
+    /// Get claims for a specific terminal.
+    pub fn get_claims_by_terminal(&self, terminal_id: &str) -> Result<Vec<IssueClaim>> {
+        use super::models::{ClaimType, IssueClaim};
+
+        let mut stmt = self.conn.prepare(
+            r"
+            SELECT id, number, claim_type, terminal_id, claimed_at, last_heartbeat, label, agent_role
+            FROM issue_claims
+            WHERE terminal_id = ?1
+            ORDER BY claimed_at
+            ",
+        )?;
+
+        let claims = stmt.query_map(params![terminal_id], |row| {
+            let claimed_at_str: String = row.get(4)?;
+            let heartbeat_str: String = row.get(5)?;
+            let ct_str: String = row.get(2)?;
+
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i32>(1)?,
+                ct_str,
+                row.get::<_, String>(3)?,
+                claimed_at_str,
+                heartbeat_str,
+                row.get::<_, Option<String>>(6)?,
+                row.get::<_, Option<String>>(7)?,
+            ))
+        })?;
+
+        let mut result = Vec::new();
+        for claim in claims {
+            let (id, num, ct_str, tid, claimed_str, heartbeat_str, label, role) = claim?;
+
+            let claimed_at = DateTime::parse_from_rfc3339(&claimed_str)
+                .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?
+                .with_timezone(&Utc);
+            let last_heartbeat = DateTime::parse_from_rfc3339(&heartbeat_str)
+                .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?
+                .with_timezone(&Utc);
+
+            result.push(IssueClaim {
+                id: Some(id),
+                number: num,
+                claim_type: ClaimType::from_str(&ct_str).unwrap_or(ClaimType::Issue),
+                terminal_id: tid,
+                claimed_at,
+                last_heartbeat,
+                label,
+                agent_role: role,
+            });
+        }
+
+        Ok(result)
+    }
+
+    /// Get stale claims (those without heartbeat for longer than threshold).
+    ///
+    /// # Arguments
+    /// * `stale_threshold_secs` - How many seconds before a claim is considered stale
+    pub fn get_stale_claims(&self, stale_threshold_secs: i64) -> Result<Vec<IssueClaim>> {
+        use super::models::{ClaimType, IssueClaim};
+
+        let threshold_time = Utc::now() - chrono::Duration::seconds(stale_threshold_secs);
+
+        let mut stmt = self.conn.prepare(
+            r"
+            SELECT id, number, claim_type, terminal_id, claimed_at, last_heartbeat, label, agent_role
+            FROM issue_claims
+            WHERE last_heartbeat < ?1
+            ORDER BY last_heartbeat
+            ",
+        )?;
+
+        let claims = stmt.query_map(params![threshold_time.to_rfc3339()], |row| {
+            let claimed_at_str: String = row.get(4)?;
+            let heartbeat_str: String = row.get(5)?;
+            let ct_str: String = row.get(2)?;
+
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i32>(1)?,
+                ct_str,
+                row.get::<_, String>(3)?,
+                claimed_at_str,
+                heartbeat_str,
+                row.get::<_, Option<String>>(6)?,
+                row.get::<_, Option<String>>(7)?,
+            ))
+        })?;
+
+        let mut result = Vec::new();
+        for claim in claims {
+            let (id, num, ct_str, tid, claimed_str, heartbeat_str, label, role) = claim?;
+
+            let claimed_at = DateTime::parse_from_rfc3339(&claimed_str)
+                .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?
+                .with_timezone(&Utc);
+            let last_heartbeat = DateTime::parse_from_rfc3339(&heartbeat_str)
+                .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?
+                .with_timezone(&Utc);
+
+            result.push(IssueClaim {
+                id: Some(id),
+                number: num,
+                claim_type: ClaimType::from_str(&ct_str).unwrap_or(ClaimType::Issue),
+                terminal_id: tid,
+                claimed_at,
+                last_heartbeat,
+                label,
+                agent_role: role,
+            });
+        }
+
+        Ok(result)
+    }
+
+    /// Release all stale claims and return the count of claims released.
+    ///
+    /// This is used during daemon startup for crash recovery.
+    pub fn release_stale_claims(&self, stale_threshold_secs: i64) -> Result<usize> {
+        let threshold_time = Utc::now() - chrono::Duration::seconds(stale_threshold_secs);
+
+        let rows = self.conn.execute(
+            r"DELETE FROM issue_claims WHERE last_heartbeat < ?1",
+            params![threshold_time.to_rfc3339()],
+        )?;
+
+        Ok(rows)
+    }
+
+    /// Release all claims for a specific terminal.
+    ///
+    /// This is used when a terminal is destroyed or restarted.
+    pub fn release_terminal_claims(&self, terminal_id: &str) -> Result<usize> {
+        let rows = self.conn.execute(
+            r"DELETE FROM issue_claims WHERE terminal_id = ?1",
+            params![terminal_id],
+        )?;
+
+        Ok(rows)
+    }
+
+    /// Get a summary of all claims for visibility.
+    pub fn get_claims_summary(&self, stale_threshold_secs: i64) -> Result<super::models::ClaimsSummary> {
+        use super::models::ClaimsSummary;
+
+        let all_claims = self.get_all_claims()?;
+        let stale_claims = self.get_stale_claims(stale_threshold_secs)?;
+
+        let mut by_type = std::collections::HashMap::new();
+        let mut by_terminal: std::collections::HashMap<String, Vec<i32>> = std::collections::HashMap::new();
+
+        for claim in &all_claims {
+            *by_type.entry(claim.claim_type.as_str().to_string()).or_insert(0) += 1;
+            by_terminal
+                .entry(claim.terminal_id.clone())
+                .or_default()
+                .push(claim.number);
+        }
+
+        #[allow(clippy::cast_possible_wrap)]
+        Ok(ClaimsSummary {
+            total_claims: all_claims.len() as i64,
+            by_type,
+            by_terminal,
+            stale_claims,
+        })
     }
 }
 
@@ -3128,6 +3583,321 @@ test result: FAILED. 9 passed; 1 failed; 0 ignored
 
         let projection = db.project_runway(BudgetPeriod::Monthly, 7)?;
         assert!(projection.is_none());
+
+        Ok(())
+    }
+
+    // ========================================================================
+    // Issue Claim Registry Tests (Issue #1159)
+    // ========================================================================
+
+    #[test]
+    fn test_claim_issue_success() -> Result<()> {
+        use super::super::models::{ClaimResult, ClaimType};
+
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        // Claim an issue
+        let result = db.claim_issue(123, ClaimType::Issue, "terminal-1", Some("loom:building"), Some("builder"), None)?;
+
+        match result {
+            ClaimResult::Success { claim_id } => {
+                assert!(claim_id > 0);
+            }
+            _ => panic!("Expected ClaimResult::Success"),
+        }
+
+        // Verify the claim exists
+        let claim = db.get_claim(123, ClaimType::Issue)?;
+        assert!(claim.is_some());
+        let claim = claim.unwrap();
+        assert_eq!(claim.number, 123);
+        assert_eq!(claim.terminal_id, "terminal-1");
+        assert_eq!(claim.label, Some("loom:building".to_string()));
+        assert_eq!(claim.agent_role, Some("builder".to_string()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_claim_issue_already_claimed() -> Result<()> {
+        use super::super::models::{ClaimResult, ClaimType};
+
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        // First claim
+        let _result1 = db.claim_issue(123, ClaimType::Issue, "terminal-1", None, None, None)?;
+
+        // Second claim should fail
+        let result2 = db.claim_issue(123, ClaimType::Issue, "terminal-2", None, None, None)?;
+
+        match result2 {
+            ClaimResult::AlreadyClaimed { terminal_id, .. } => {
+                assert_eq!(terminal_id, "terminal-1");
+            }
+            _ => panic!("Expected ClaimResult::AlreadyClaimed"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_claim_issue_reclaim_stale() -> Result<()> {
+        use super::super::models::{ClaimResult, ClaimType};
+
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        // First claim
+        let _result1 = db.claim_issue(123, ClaimType::Issue, "terminal-1", None, None, None)?;
+
+        // Manually make it stale by updating the heartbeat to the past
+        let old_time = Utc::now() - chrono::Duration::hours(2);
+        db.conn.execute(
+            "UPDATE issue_claims SET last_heartbeat = ?1 WHERE number = 123",
+            params![old_time.to_rfc3339()],
+        )?;
+
+        // Now claim with stale threshold of 1 hour - should reclaim
+        let result2 = db.claim_issue(123, ClaimType::Issue, "terminal-2", None, None, Some(3600))?;
+
+        match result2 {
+            ClaimResult::Reclaimed { previous_terminal, .. } => {
+                assert_eq!(previous_terminal, "terminal-1");
+            }
+            _ => panic!("Expected ClaimResult::Reclaimed"),
+        }
+
+        // Verify the claim is now owned by terminal-2
+        let claim = db.get_claim(123, ClaimType::Issue)?.unwrap();
+        assert_eq!(claim.terminal_id, "terminal-2");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_release_claim() -> Result<()> {
+        use super::super::models::ClaimType;
+
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        // Claim an issue
+        db.claim_issue(123, ClaimType::Issue, "terminal-1", None, None, None)?;
+
+        // Release it
+        let released = db.release_claim(123, ClaimType::Issue, Some("terminal-1"))?;
+        assert!(released);
+
+        // Verify it's gone
+        let claim = db.get_claim(123, ClaimType::Issue)?;
+        assert!(claim.is_none());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_release_claim_wrong_terminal() -> Result<()> {
+        use super::super::models::ClaimType;
+
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        // Claim an issue
+        db.claim_issue(123, ClaimType::Issue, "terminal-1", None, None, None)?;
+
+        // Try to release from wrong terminal
+        let released = db.release_claim(123, ClaimType::Issue, Some("terminal-2"))?;
+        assert!(!released);
+
+        // Verify it still exists
+        let claim = db.get_claim(123, ClaimType::Issue)?;
+        assert!(claim.is_some());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_heartbeat_claim() -> Result<()> {
+        use super::super::models::ClaimType;
+
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        // Claim an issue
+        db.claim_issue(123, ClaimType::Issue, "terminal-1", None, None, None)?;
+
+        let claim_before = db.get_claim(123, ClaimType::Issue)?.unwrap();
+        let heartbeat_before = claim_before.last_heartbeat;
+
+        // Wait a tiny bit and update heartbeat
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        let updated = db.heartbeat_claim(123, ClaimType::Issue, "terminal-1")?;
+        assert!(updated);
+
+        let claim_after = db.get_claim(123, ClaimType::Issue)?.unwrap();
+        assert!(claim_after.last_heartbeat > heartbeat_before);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_terminal_claims() -> Result<()> {
+        use super::super::models::ClaimType;
+
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        // Claim multiple issues for terminal-1
+        db.claim_issue(123, ClaimType::Issue, "terminal-1", None, None, None)?;
+        db.claim_issue(456, ClaimType::Pr, "terminal-1", None, None, None)?;
+
+        // Claim one for terminal-2
+        db.claim_issue(789, ClaimType::Issue, "terminal-2", None, None, None)?;
+
+        // Get claims for terminal-1
+        let claims = db.get_claims_by_terminal("terminal-1")?;
+        assert_eq!(claims.len(), 2);
+
+        // Get claims for terminal-2
+        let claims = db.get_claims_by_terminal("terminal-2")?;
+        assert_eq!(claims.len(), 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_stale_claims() -> Result<()> {
+        use super::super::models::ClaimType;
+
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        // Claim an issue
+        db.claim_issue(123, ClaimType::Issue, "terminal-1", None, None, None)?;
+        db.claim_issue(456, ClaimType::Issue, "terminal-2", None, None, None)?;
+
+        // Make one stale
+        let old_time = Utc::now() - chrono::Duration::hours(2);
+        db.conn.execute(
+            "UPDATE issue_claims SET last_heartbeat = ?1 WHERE number = 123",
+            params![old_time.to_rfc3339()],
+        )?;
+
+        // Get stale claims (1 hour threshold)
+        let stale = db.get_stale_claims(3600)?;
+        assert_eq!(stale.len(), 1);
+        assert_eq!(stale[0].number, 123);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_release_stale_claims() -> Result<()> {
+        use super::super::models::ClaimType;
+
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        // Claim issues
+        db.claim_issue(123, ClaimType::Issue, "terminal-1", None, None, None)?;
+        db.claim_issue(456, ClaimType::Issue, "terminal-2", None, None, None)?;
+
+        // Make one stale
+        let old_time = Utc::now() - chrono::Duration::hours(2);
+        db.conn.execute(
+            "UPDATE issue_claims SET last_heartbeat = ?1 WHERE number = 123",
+            params![old_time.to_rfc3339()],
+        )?;
+
+        // Release stale claims
+        let count = db.release_stale_claims(3600)?;
+        assert_eq!(count, 1);
+
+        // Verify only fresh claim remains
+        let all = db.get_all_claims()?;
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].number, 456);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_release_terminal_claims() -> Result<()> {
+        use super::super::models::ClaimType;
+
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        // Claim multiple for terminal-1
+        db.claim_issue(123, ClaimType::Issue, "terminal-1", None, None, None)?;
+        db.claim_issue(456, ClaimType::Pr, "terminal-1", None, None, None)?;
+
+        // Claim one for terminal-2
+        db.claim_issue(789, ClaimType::Issue, "terminal-2", None, None, None)?;
+
+        // Release all claims for terminal-1
+        let count = db.release_terminal_claims("terminal-1")?;
+        assert_eq!(count, 2);
+
+        // Verify only terminal-2's claim remains
+        let all = db.get_all_claims()?;
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].terminal_id, "terminal-2");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_claims_summary() -> Result<()> {
+        use super::super::models::ClaimType;
+
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        // Claim several issues
+        db.claim_issue(100, ClaimType::Issue, "terminal-1", None, None, None)?;
+        db.claim_issue(101, ClaimType::Issue, "terminal-1", None, None, None)?;
+        db.claim_issue(200, ClaimType::Pr, "terminal-2", None, None, None)?;
+
+        // Make one stale
+        let old_time = Utc::now() - chrono::Duration::hours(2);
+        db.conn.execute(
+            "UPDATE issue_claims SET last_heartbeat = ?1 WHERE number = 100",
+            params![old_time.to_rfc3339()],
+        )?;
+
+        let summary = db.get_claims_summary(3600)?;
+        assert_eq!(summary.total_claims, 3);
+        assert_eq!(summary.by_type.get("issue"), Some(&2));
+        assert_eq!(summary.by_type.get("pr"), Some(&1));
+        assert_eq!(summary.by_terminal.get("terminal-1").map(|v| v.len()), Some(2));
+        assert_eq!(summary.by_terminal.get("terminal-2").map(|v| v.len()), Some(1));
+        assert_eq!(summary.stale_claims.len(), 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_claim_type_isolation() -> Result<()> {
+        use super::super::models::ClaimType;
+
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        // Claim same number as both issue and PR (should work)
+        db.claim_issue(123, ClaimType::Issue, "terminal-1", None, None, None)?;
+        db.claim_issue(123, ClaimType::Pr, "terminal-2", None, None, None)?;
+
+        // Both should exist
+        let issue_claim = db.get_claim(123, ClaimType::Issue)?.unwrap();
+        let pr_claim = db.get_claim(123, ClaimType::Pr)?.unwrap();
+
+        assert_eq!(issue_claim.terminal_id, "terminal-1");
+        assert_eq!(pr_claim.terminal_id, "terminal-2");
 
         Ok(())
     }

--- a/loom-daemon/src/activity/mod.rs
+++ b/loom-daemon/src/activity/mod.rs
@@ -86,3 +86,7 @@ pub use tuning::{
     create_tuning_schema, EffectivenessSnapshot, ProposalStatus, TunableParameter, TuningConfig,
     TuningHistory, TuningProposal, TuningSummary,
 };
+
+// Issue claim registry types (Issue #1159)
+// Used for reliable work distribution and crash recovery
+pub use models::{ClaimResult, ClaimsSummary, ClaimType, IssueClaim};


### PR DESCRIPTION
## Summary

- Implements a centralized database-backed claim registry that prevents race conditions when multiple agents try to claim the same issue
- Uses atomic database operations (INSERT OR IGNORE with unique constraint) to prevent concurrent claiming
- Includes TTL-based stale claim detection with configurable threshold (default: 1 hour)
- Adds heartbeat mechanism for active agents to renew their claims
- Implements crash recovery: daemon automatically releases stale claims on startup

## Key Changes

**New Data Models** (`models.rs`):
- `ClaimType` enum (Issue, Pr)
- `IssueClaim` struct with terminal ID, timestamps, labels, and role
- `ClaimResult` enum (Success, AlreadyClaimed, Reclaimed)
- `ClaimsSummary` for system visibility

**Database Schema** (`schema.rs`):
- New `issue_claims` table with unique constraint on (number, claim_type)
- Indexes for efficient terminal and heartbeat queries

**IPC API** (`types.rs`, `ipc.rs`):
- `ClaimIssue`: Atomically claim an issue/PR
- `ReleaseClaim`: Release a claim with optional ownership check
- `HeartbeatClaim`: Update heartbeat to prevent stale detection
- `GetClaim/GetAllClaims/GetTerminalClaims`: Query claims
- `GetClaimsSummary`: Overview with stale detection
- `ReleaseStaleCliams`: Crash recovery cleanup
- `ReleaseTerminalClaims`: Terminal cleanup

**Startup Recovery** (`main.rs`):
- Daemon releases stale claims on startup
- Configurable via `LOOM_CLAIM_TTL_SECS` environment variable

## Test plan

- [x] 12 new unit tests covering all claim operations
- [x] All 167 existing tests pass
- [x] Manual verification of claim/release cycle
- [x] Stale claim reclamation tested
- [x] Terminal claim isolation verified

Closes #1159

---
Generated with [Claude Code](https://claude.com/claude-code)