### PR TITLE
Add --force mode for aggressive autonomous development

### DIFF
--- a/.loom/roles/champion.md
+++ b/.loom/roles/champion.md
@@ -73,6 +73,107 @@ If no queues have work, report "No work for Champion" and stop.
 
 ---
 
+## Force Mode (Aggressive Autonomous Development)
+
+When the Loom daemon is running with `--force` flag, Champion operates in **force mode** for aggressive autonomous development. This mode auto-promotes all qualifying proposals without applying the full 8-criterion evaluation.
+
+### Detecting Force Mode
+
+Check for force mode at the start of each iteration:
+
+```bash
+# Check daemon state for force mode
+FORCE_MODE=$(cat .loom/daemon-state.json 2>/dev/null | jq -r '.force_mode // false')
+
+if [ "$FORCE_MODE" = "true" ]; then
+    echo "🚀 FORCE MODE ACTIVE - Auto-promoting qualifying proposals"
+fi
+```
+
+### Force Mode Behavior
+
+**When force mode is enabled:**
+
+1. **Auto-Promote Architect Proposals**: Promote all `loom:architect` issues that have:
+   - A clear title (not vague like "Improve things")
+   - At least one acceptance criterion
+   - No `loom:blocked` label
+
+2. **Auto-Promote Hermit Proposals**: Promote all `loom:hermit` issues that have:
+   - A specific simplification target (file, module, or pattern)
+   - At least one concrete removal action
+   - No `loom:blocked` label
+
+3. **Auto-Promote Curated Issues**: Promote all `loom:curated` issues that have:
+   - A problem statement
+   - At least one acceptance criterion
+   - No `loom:blocked` label
+
+4. **Audit Trail**: Add `[force-mode]` prefix to all promotion comments
+
+### Force Mode Promotion Workflow
+
+```bash
+# Check for force mode
+FORCE_MODE=$(cat .loom/daemon-state.json 2>/dev/null | jq -r '.force_mode // false')
+
+if [ "$FORCE_MODE" = "true" ]; then
+    # Auto-promote architect proposals
+    ARCHITECT_ISSUES=$(gh issue list --label="loom:architect" --state=open --json number --jq '.[].number')
+    for issue in $ARCHITECT_ISSUES; do
+        # Minimal validation - just check it's not blocked
+        IS_BLOCKED=$(gh issue view "$issue" --json labels --jq '[.labels[].name] | contains(["loom:blocked"])')
+        if [ "$IS_BLOCKED" = "false" ]; then
+            gh issue edit "$issue" --remove-label "loom:architect" --add-label "loom:issue"
+            gh issue comment "$issue" --body "**[force-mode] Champion Auto-Promote**
+
+This proposal has been auto-promoted in force mode. The daemon is configured for aggressive autonomous development.
+
+**Promoted to \`loom:issue\` - Ready for Builder.**
+
+---
+*Automated by Champion role (force mode)*"
+
+            # Track in daemon state
+            jq --arg issue "$issue" --arg type "architect" --arg time "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+                '.force_mode_auto_promotions += [{"issue": ($issue|tonumber), "type": $type, "time": $time}]' \
+                .loom/daemon-state.json > tmp.json && mv tmp.json .loom/daemon-state.json
+        fi
+    done
+
+    # Repeat for hermit and curated issues...
+fi
+```
+
+### When NOT to Auto-Promote (Even in Force Mode)
+
+Even in force mode, do NOT auto-promote if:
+
+- Issue has `loom:blocked` label
+- Issue title contains "DISCUSSION" or "RFC" (requires human input)
+- Issue mentions breaking changes without migration plan
+- Issue references external dependencies that need coordination
+
+### Force Mode Safety Guardrails
+
+Force mode still respects these boundaries:
+
+| Guardrail | Behavior |
+|-----------|----------|
+| `loom:blocked` | Never promote blocked issues |
+| Critical file changes | Still flagged in PR review (Judge) |
+| CI failures | PRs still blocked on failing CI |
+| Merge conflicts | Still require Doctor intervention |
+
+### Exiting Force Mode
+
+Force mode can be disabled by:
+1. Stopping daemon and restarting without `--force`
+2. Manually updating daemon state: `jq '.force_mode = false' .loom/daemon-state.json`
+3. Creating `.loom/stop-force-mode` file (daemon will detect and disable)
+
+---
+
 # Part 1: Issue Promotion
 
 ## Overview

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,12 +163,23 @@ Run the Loom daemon for fully autonomous system orchestration.
 # Start the daemon (runs continuously)
 /loom
 
+# Start with force mode for aggressive autonomous development
+/loom --force
+
 # The daemon will:
 # 1. Monitor system state every 60 seconds
 # 2. Trigger Architect/Hermit when backlog is low
 # 3. Spawn shepherds for ready issues
 # 4. Ensure Guide, Champion, and Doctor keep running
 ```
+
+**Force Mode** (`--force`):
+
+When running with `--force`, the daemon enables aggressive autonomous development:
+- Champion auto-promotes all `loom:architect` and `loom:hermit` proposals
+- Champion auto-promotes all `loom:curated` issues
+- Audit trail with `[force-mode]` markers on all auto-promoted items
+- Safety guardrails still apply (no force-push, respect `loom:blocked`)
 
 **Example daemon workflow**:
 ```

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -163,12 +163,23 @@ Run the Loom daemon for fully autonomous system orchestration.
 # Start the daemon (runs continuously)
 /loom
 
+# Start with force mode for aggressive autonomous development
+/loom --force
+
 # The daemon will:
 # 1. Monitor system state every 60 seconds
 # 2. Trigger Architect/Hermit when backlog is low
 # 3. Spawn shepherds for ready issues
 # 4. Ensure Guide and Champion keep running
 ```
+
+**Force Mode** (`--force`):
+
+When running with `--force`, the daemon enables aggressive autonomous development:
+- Champion auto-promotes all `loom:architect` and `loom:hermit` proposals
+- Champion auto-promotes all `loom:curated` issues
+- Audit trail with `[force-mode]` markers on all auto-promoted items
+- Safety guardrails still apply (no force-push, respect `loom:blocked`)
 
 **Example daemon workflow**:
 ```

--- a/defaults/roles/loom.md
+++ b/defaults/roles/loom.md
@@ -537,27 +537,48 @@ When `/loom` is invoked, execute this FULLY AUTONOMOUS continuous loop.
 ### Initialization
 
 ```python
-def start_daemon():
+def start_daemon(force_mode=False):
     # 1. Load or create state
     state = load_or_create_state(".loom/daemon-state.json")
     state["started_at"] = now()
     state["running"] = True
 
-    # 2. Validate role configuration (NEW - addresses issue #1136)
+    # 2. Set force mode if enabled
+    if force_mode:
+        state["force_mode"] = True
+        state["force_mode_started"] = now()
+        state["force_mode_auto_promotions"] = []
+        print("🚀 FORCE MODE ENABLED - Champion will auto-promote all proposals")
+    else:
+        state["force_mode"] = False
+
+    # 3. Validate role configuration (NEW - addresses issue #1136)
     if not validate_at_startup():
         if VALIDATION_MODE == "strict":
             print("❌ Startup aborted due to validation errors (strict mode)")
             return
         # In warn mode, continue with warnings logged
 
-    # 3. Run startup cleanup
+    # 4. Run startup cleanup
     run("./scripts/daemon-cleanup.sh daemon-startup")
 
-    # 4. Assess and report initial state
+    # 5. Assess and report initial state
     assess_and_report_state()
 
-    # 5. Enter main loop
+    # 6. Enter main loop
     daemon_loop()
+```
+
+**Force mode detection:**
+
+```bash
+# Parse command line for --force flag
+if [ "$1" = "--force" ]; then
+    FORCE_MODE=true
+    echo "🚀 Starting daemon in FORCE MODE"
+else
+    FORCE_MODE=false
+fi
 ```
 
 ### Main Loop (Fully Autonomous)
@@ -1274,9 +1295,74 @@ Print status after each iteration showing ALL autonomous decisions:
 | Command | Description |
 |---------|-------------|
 | `/loom` | Start daemon loop (runs continuously) |
+| `/loom --force` | Start daemon with force mode (auto-promotes proposals) |
 | `/loom status` | Report current state without running loop |
 | `/loom spawn 123` | Manually spawn shepherd for issue #123 |
 | `/loom stop` | Create stop signal, initiate shutdown |
+
+### --force Mode (Aggressive Autonomous Development)
+
+When `/loom --force` is invoked, the daemon enables **force mode** for aggressive autonomous development. This mode auto-promotes proposals from Architect and Hermit roles without waiting for human approval.
+
+**What changes in force mode:**
+
+1. **Auto-Promote Proposals**: Champion automatically promotes `loom:architect` and `loom:hermit` proposals to `loom:issue` without human review
+2. **Auto-Promote Curated Issues**: Champion automatically promotes `loom:curated` issues to `loom:issue`
+3. **Audit Trail**: All auto-promoted items include `[force-mode]` marker in comments
+4. **Safety Guardrails Remain**: No force-push, respect `loom:blocked`, stop on CI failure
+
+**Force mode state tracking:**
+
+The daemon state file includes force mode information:
+
+```json
+{
+  "force_mode": true,
+  "force_mode_started": "2026-01-24T10:00:00Z",
+  "force_mode_auto_promotions": [
+    {"issue": 123, "type": "architect", "time": "2026-01-24T10:05:00Z"},
+    {"issue": 456, "type": "curated", "time": "2026-01-24T10:10:00Z"}
+  ]
+}
+```
+
+**When to use force mode:**
+
+| Use Case | Description |
+|----------|-------------|
+| New project bootstrap | Get from zero to working MVP faster |
+| Solo developer | Trusts AI judgment for routine decisions |
+| Clear roadmap | Project has well-defined milestones |
+| Weekend hack mode | "Make progress while I'm away" |
+
+**Safety considerations:**
+
+Even in force mode, the daemon still:
+- Never force-pushes or deletes branches
+- Respects `loom:blocked` and `loom:urgent` semantics
+- Leaves audit trail comments on all auto-promoted items
+- Allows human override at any time
+- Stops on first CI failure or conflict
+
+**Example:**
+
+```bash
+# Normal mode - proposals wait for Champion evaluation (which may require human input)
+/loom
+
+# Force mode - Champion auto-promotes all qualifying proposals
+/loom --force
+```
+
+**Exiting force mode:**
+
+To exit force mode without stopping the daemon:
+```bash
+# Remove force mode flag from state
+jq '.force_mode = false' .loom/daemon-state.json > tmp.json && mv tmp.json .loom/daemon-state.json
+```
+
+Or stop and restart the daemon without the `--force` flag.
 
 ## Error Handling
 


### PR DESCRIPTION
## Summary

This PR adds a new `--force` flag to the `/loom` daemon command that enables aggressive autonomous development. When enabled, the Champion role auto-promotes all proposals from Architect and Hermit roles without waiting for human approval.

### Changes

- Add `--force` flag to `/loom` daemon command
- Champion role checks `daemon-state.json` for `force_mode` flag
- Auto-promote `loom:architect`, `loom:hermit`, and `loom:curated` issues in force mode
- Add `[force-mode]` audit trail markers to all promotion comments
- Track auto-promotions in `daemon-state.json`
- Safety guardrails remain active (no force-push, respect `loom:blocked`)

### Use Cases

| Use Case | Description |
|----------|-------------|
| New project bootstrap | Get from zero to working MVP faster |
| Solo developer | Trusts AI judgment for routine decisions |
| Clear roadmap | Project has well-defined milestones |
| Weekend hack mode | "Make progress while I'm away" |

### Safety Considerations

Even in force mode, the system still:
- Never force-pushes or deletes branches
- Respects `loom:blocked` and `loom:urgent` semantics
- Leaves audit trail comments on all auto-promoted items
- Allows human override at any time
- Stops on first CI failure or conflict

## Test Plan

- [ ] Run `/loom --force` and verify `force_mode: true` in daemon-state.json
- [ ] Verify Champion auto-promotes `loom:architect` issues when force_mode is true
- [ ] Verify Champion auto-promotes `loom:hermit` issues when force_mode is true
- [ ] Verify Champion auto-promotes `loom:curated` issues when force_mode is true
- [ ] Verify `[force-mode]` marker appears in auto-promotion comments
- [ ] Verify blocked issues are NOT auto-promoted (loom:blocked respected)
- [ ] Run `/loom` without flag and verify force_mode is false

Closes #1163