### PR TITLE
Update Champion command to include architect/hermit proposals and force mode

### DIFF
--- a/.claude/commands/champion.md
+++ b/.claude/commands/champion.md
@@ -5,20 +5,51 @@ Assume the Champion role from the Loom orchestration system and perform one iter
 ## Process
 
 1. **Read the role definition**: Load `defaults/roles/champion.md` or `.loom/roles/champion.md`
-2. **Follow the role's workflow**: Complete ONE iteration only
-3. **Report results**: Summarize what you accomplished with links
+2. **Check for force mode**: Read `.loom/daemon-state.json` to see if `force_mode` is enabled
+3. **Follow the role's workflow**: Complete ONE iteration only
+4. **Report results**: Summarize what you accomplished with links
 
 ## Work Scope
 
-As the **Champion**, you promote high-quality curated issues by:
+As the **Champion**, you handle TWO critical responsibilities in priority order:
 
-- Finding issues with `loom:curated` label (max 2 per iteration)
-- Evaluating against 8 quality criteria (all must pass)
-- Promoting to `loom:issue` status if quality standards met
-- Providing detailed feedback if revision needed
-- Using conservative bias: when in doubt, don't promote
+### Priority 1: Safe PRs Ready to Auto-Merge
 
-Complete **ONE** batch evaluation per iteration (max 2 promotions).
+Find Judge-approved PRs with `loom:pr` label and auto-merge if all 7 safety criteria pass:
+- Label check (has `loom:pr`, no `loom:manual-merge`)
+- Size check (total lines changed <= 200)
+- Critical file exclusion (no config files, workflows, etc.)
+- Merge conflict check (must be mergeable)
+- Recency check (updated within 24 hours)
+- CI status check (all checks passing or no checks required)
+- Human override check (no `loom:manual-merge`)
+
+### Priority 2: Curated Issues Ready to Promote
+
+Find Curator-enhanced issues with `loom:curated` label:
+- Evaluate against 8 quality criteria (all must pass)
+- Promote to `loom:issue` status if quality standards met
+- Provide detailed feedback if revision needed
+
+### Priority 3: Architect/Hermit Proposals Ready to Promote
+
+Find work generation proposals with `loom:architect` or `loom:hermit` labels:
+- Evaluate against same 8 quality criteria as curated issues
+- Promote to `loom:issue` status if quality standards met
+- Well-formed proposals from Architect/Hermit are typically ready
+
+## Force Mode
+
+When `daemon-state.json` has `force_mode: true`, Champion operates aggressively:
+
+1. **Auto-promote all qualifying proposals** without full 8-criterion evaluation
+2. **Minimal validation only**: Clear title, at least one acceptance criterion, no `loom:blocked`
+3. **Audit trail**: Add `[force-mode]` prefix to all promotion comments
+
+Check for force mode:
+```bash
+FORCE_MODE=$(cat .loom/daemon-state.json 2>/dev/null | jq -r '.force_mode // false')
+```
 
 ## Report Format
 
@@ -26,17 +57,33 @@ Complete **ONE** batch evaluation per iteration (max 2 promotions).
 ✓ Role Assumed: Champion
 ✓ Task Completed: [Brief description]
 ✓ Changes Made:
-  - Issue #XXX: [Promoted/Rejected with link]
+  - PR #XXX: [Merged/Skipped with reason and link]
+  - Issue #YYY: [Promoted/Rejected with link]
   - Evaluation: [Summary of criteria assessment]
-  - Label changes: [loom:curated → loom:issue OR kept for revision]
+  - Label changes: [loom:curated → loom:issue, loom:architect → loom:issue, etc.]
 ✓ Next Steps: [Suggestions]
 ```
 
 ## Label Workflow
 
 Follow label-based coordination (ADR-0006):
-- Issues: Find `loom:curated` → evaluate quality → promote to `loom:issue` OR provide feedback
+
+**PR Workflow**:
+- Find `loom:pr` → verify safety criteria → auto-merge OR skip with comment
+
+**Issue Workflow**:
+- Find `loom:curated` → evaluate quality → promote to `loom:issue` OR provide feedback
+- Find `loom:architect` → evaluate quality → promote to `loom:issue` OR provide feedback
+- Find `loom:hermit` → evaluate quality → promote to `loom:issue` OR provide feedback
 - Promoted issues can then be claimed by Builder role
+
+## Conservative Bias
+
+**When in doubt, don't act.**
+
+- For PRs: Skip and leave comment explaining why
+- For issues: Keep original label and provide revision feedback
+- It's better to require human intervention than to approve/merge risky changes
 
 ## Context Clearing (Autonomous Mode)
 

--- a/defaults/.claude/commands/champion.md
+++ b/defaults/.claude/commands/champion.md
@@ -5,20 +5,51 @@ Assume the Champion role from the Loom orchestration system and perform one iter
 ## Process
 
 1. **Read the role definition**: Load `defaults/roles/champion.md` or `.loom/roles/champion.md`
-2. **Follow the role's workflow**: Complete ONE iteration only
-3. **Report results**: Summarize what you accomplished with links
+2. **Check for force mode**: Read `.loom/daemon-state.json` to see if `force_mode` is enabled
+3. **Follow the role's workflow**: Complete ONE iteration only
+4. **Report results**: Summarize what you accomplished with links
 
 ## Work Scope
 
-As the **Champion**, you promote high-quality curated issues by:
+As the **Champion**, you handle TWO critical responsibilities in priority order:
 
-- Finding issues with `loom:curated` label (max 2 per iteration)
-- Evaluating against 8 quality criteria (all must pass)
-- Promoting to `loom:issue` status if quality standards met
-- Providing detailed feedback if revision needed
-- Using conservative bias: when in doubt, don't promote
+### Priority 1: Safe PRs Ready to Auto-Merge
 
-Complete **ONE** batch evaluation per iteration (max 2 promotions).
+Find Judge-approved PRs with `loom:pr` label and auto-merge if all 7 safety criteria pass:
+- Label check (has `loom:pr`, no `loom:manual-merge`)
+- Size check (total lines changed <= 200)
+- Critical file exclusion (no config files, workflows, etc.)
+- Merge conflict check (must be mergeable)
+- Recency check (updated within 24 hours)
+- CI status check (all checks passing or no checks required)
+- Human override check (no `loom:manual-merge`)
+
+### Priority 2: Curated Issues Ready to Promote
+
+Find Curator-enhanced issues with `loom:curated` label:
+- Evaluate against 8 quality criteria (all must pass)
+- Promote to `loom:issue` status if quality standards met
+- Provide detailed feedback if revision needed
+
+### Priority 3: Architect/Hermit Proposals Ready to Promote
+
+Find work generation proposals with `loom:architect` or `loom:hermit` labels:
+- Evaluate against same 8 quality criteria as curated issues
+- Promote to `loom:issue` status if quality standards met
+- Well-formed proposals from Architect/Hermit are typically ready
+
+## Force Mode
+
+When `daemon-state.json` has `force_mode: true`, Champion operates aggressively:
+
+1. **Auto-promote all qualifying proposals** without full 8-criterion evaluation
+2. **Minimal validation only**: Clear title, at least one acceptance criterion, no `loom:blocked`
+3. **Audit trail**: Add `[force-mode]` prefix to all promotion comments
+
+Check for force mode:
+```bash
+FORCE_MODE=$(cat .loom/daemon-state.json 2>/dev/null | jq -r '.force_mode // false')
+```
 
 ## Report Format
 
@@ -26,17 +57,33 @@ Complete **ONE** batch evaluation per iteration (max 2 promotions).
 ✓ Role Assumed: Champion
 ✓ Task Completed: [Brief description]
 ✓ Changes Made:
-  - Issue #XXX: [Promoted/Rejected with link]
+  - PR #XXX: [Merged/Skipped with reason and link]
+  - Issue #YYY: [Promoted/Rejected with link]
   - Evaluation: [Summary of criteria assessment]
-  - Label changes: [loom:curated → loom:issue OR kept for revision]
+  - Label changes: [loom:curated → loom:issue, loom:architect → loom:issue, etc.]
 ✓ Next Steps: [Suggestions]
 ```
 
 ## Label Workflow
 
 Follow label-based coordination (ADR-0006):
-- Issues: Find `loom:curated` → evaluate quality → promote to `loom:issue` OR provide feedback
+
+**PR Workflow**:
+- Find `loom:pr` → verify safety criteria → auto-merge OR skip with comment
+
+**Issue Workflow**:
+- Find `loom:curated` → evaluate quality → promote to `loom:issue` OR provide feedback
+- Find `loom:architect` → evaluate quality → promote to `loom:issue` OR provide feedback
+- Find `loom:hermit` → evaluate quality → promote to `loom:issue` OR provide feedback
 - Promoted issues can then be claimed by Builder role
+
+## Conservative Bias
+
+**When in doubt, don't act.**
+
+- For PRs: Skip and leave comment explaining why
+- For issues: Keep original label and provide revision feedback
+- It's better to require human intervention than to approve/merge risky changes
 
 ## Context Clearing (Autonomous Mode)
 


### PR DESCRIPTION
## Summary

- Updates Champion command file (`.claude/commands/champion.md`) to reflect its expanded responsibilities
- Adds Priority 1 (PR auto-merge), Priority 3 (architect/hermit proposals), and force mode documentation
- Syncs both `.claude/commands/champion.md` and `defaults/.claude/commands/champion.md`

## Problem

The Champion command file only mentioned `loom:curated` issues, but the role definition (`champion.md`) has been updated to handle:
- PR auto-merge with `loom:pr` label
- Architect proposals with `loom:architect` label  
- Hermit proposals with `loom:hermit` label
- Force mode for aggressive autonomous development

This caused confusion in `--force` mode where Champion wouldn't evaluate architect/hermit proposals because the command summary didn't mention them.

## Changes

**Before:**
```
As the Champion, you promote high-quality curated issues by:
- Finding issues with loom:curated label (max 2 per iteration)
```

**After:**
```
As the Champion, you handle TWO critical responsibilities in priority order:
- Priority 1: Safe PRs Ready to Auto-Merge (loom:pr)
- Priority 2: Curated Issues Ready to Promote (loom:curated)
- Priority 3: Architect/Hermit Proposals Ready to Promote (loom:architect, loom:hermit)
```

## Test plan

- [ ] Run `/champion` and verify it checks all three priority levels
- [ ] Verify Champion evaluates architect proposals when no curated issues exist
- [ ] Verify force mode detection works via `daemon-state.json`
- [ ] Verify both command files are in sync

Closes #1176

:robot: Generated with [Claude Code](https://claude.com/claude-code)