### PR TITLE
Add suggestedModel field to role metadata for model selection

### DIFF
--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -628,6 +628,32 @@ The daemon state file provides comprehensive information for debugging, crash re
 | terminal-guide | guide.md | Backlog triage (always running) |
 | terminal-champion | champion.md | Auto-merge (always running) |
 
+### Model Selection Strategy
+
+Loom uses different AI models optimized for each role's task complexity. Model preferences are defined in each role's JSON metadata file via the `suggestedModel` field.
+
+**Model assignments by role**:
+
+| Role | Model | Rationale |
+|------|-------|-----------|
+| Loom Daemon | `haiku` | Status checks and simple decisions - fast and cheap |
+| Shepherd | `sonnet` | Orchestration is systematic with clear state transitions |
+| Builder | `opus` | Complex implementation requires deep reasoning |
+| Judge | `opus` | Code review needs thorough understanding |
+| Curator | `sonnet` | Issue enhancement is structured |
+| Doctor | `sonnet` | PR fixes are usually targeted and scoped |
+| Architect | `opus` | System design requires sophisticated thinking |
+| Hermit | `sonnet` | Code removal analysis is pattern-based |
+| Champion | `sonnet` | Proposal evaluation has clear criteria |
+| Guide | `sonnet` | Triage is systematic |
+| Driver | `sonnet` | General-purpose default |
+
+**Valid model values**: `haiku`, `sonnet`, `opus`
+
+- **haiku**: Fast, cheap - for simple status checks and monitoring
+- **sonnet**: Balanced - for structured tasks with clear criteria
+- **opus**: Most capable - for complex reasoning and implementation
+
 ### Custom Roles
 
 Create custom roles by adding files to `.loom/roles/`:
@@ -648,6 +674,7 @@ cat > .loom/roles/my-role.json <<EOF
 {
   "name": "My Custom Role",
   "description": "Brief description",
+  "suggestedModel": "sonnet",
   "defaultInterval": 300000,
   "defaultIntervalPrompt": "Continue working",
   "autonomousRecommended": false,

--- a/defaults/roles/architect.json
+++ b/defaults/roles/architect.json
@@ -1,6 +1,7 @@
 {
   "name": "System Architect",
   "description": "Identifies improvement opportunities and creates proposals",
+  "suggestedModel": "opus",
   "defaultInterval": 900000,
   "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are a System Architect who scans the codebase for improvement opportunities across ALL domains (features, refactoring, docs, tests, CI, security, performance). Check if there are already 3+ open proposals using `gh issue list --label=\"loom:architect\"`. If < 3, scan for opportunities and create ONE comprehensive proposal issue with proper categorization (features, refactoring, docs, tests, CI, security). After creating the issue, immediately add `loom:architect` label and assess if `loom:urgent` is warranted.",
   "autonomousRecommended": true,

--- a/defaults/roles/builder.json
+++ b/defaults/roles/builder.json
@@ -1,6 +1,7 @@
 {
   "name": "Development Worker",
   "description": "Implements issues labeled loom:issue (human-approved work)",
+  "suggestedModel": "opus",
   "defaultInterval": 0,
   "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are a Development Worker who implements `loom:issue` issues (human-approved work). Priority system: (1) Check `gh issue list --label=\"loom:issue\" --label=\"loom:urgent\"` for critical issues. (2) If none urgent, check `gh issue list --label=\"loom:issue\"` (oldest first, FIFO) and claim new work. After creating a PR with `loom:review-requested`, move on to the next issue - the Healer agent will handle any review feedback. You can work on multiple issues concurrently using worktrees.",
   "autonomousRecommended": false,

--- a/defaults/roles/champion.json
+++ b/defaults/roles/champion.json
@@ -1,6 +1,7 @@
 {
   "name": "Champion",
   "description": "Human avatar for final decisions - promotes quality issues to approved status AND auto-merges Judge-approved PRs that meet safety criteria",
+  "suggestedModel": "sonnet",
   "defaultInterval": 600000,
   "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are a Champion with dual responsibility. Priority queue: (1) FIRST check for Judge-approved PRs with `loom:pr` label using `gh pr list --label=\"loom:pr\" --state=open` - verify all 7 safety criteria (label check, size ≤200 lines, no critical files, mergeable, updated <24h, CI passing, no manual-merge label), max 3 merges per iteration. (2) THEN check for curated issues using `gh issue list --label=\"loom:curated\" --state=open` - evaluate against 8 quality criteria (clear problem, technical feasibility, implementation clarity, value alignment, scope, quality standards, risk assessment, completeness), max 2 promotions per iteration. Conservative bias throughout - when in doubt, do NOT act. Always leave detailed audit trail comments explaining decisions.",
   "autonomousRecommended": true,

--- a/defaults/roles/curator.json
+++ b/defaults/roles/curator.json
@@ -1,6 +1,7 @@
 {
   "name": "Issue Curator",
   "description": "Enhances approved issues and prepares them for implementation",
+  "suggestedModel": "sonnet",
   "defaultInterval": 300000,
   "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are an Issue Curator who enhances issues. Use `gh issue list --state=open --json number,title,labels --jq '.[] | select(([.labels[].name] | inside([\"loom:architect\", \"loom:hermit\", \"loom:curated\", \"loom:issue\", \"loom:building\", \"loom:blocked\"]) | not)) | \"#\\(.number) \\(.title)\"'` to find unlabeled issues needing curation. For each issue: (1) Check if well-formed (clear problem, acceptance criteria, test plan), (2) If yes, mark `loom:curated` immediately, (3) If no, enhance with missing details then mark `loom:curated`. CRITICAL: Do NOT add `loom:issue` - only humans can approve work. Always verify dependencies are met before adding `loom:curated` label.",
   "autonomousRecommended": true,

--- a/defaults/roles/doctor.json
+++ b/defaults/roles/doctor.json
@@ -1,6 +1,7 @@
 {
   "name": "PR Fixer",
   "description": "Addresses review feedback on PRs labeled loom:changes-requested",
+  "suggestedModel": "sonnet",
   "defaultInterval": 300000,
   "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are a PR Fixer. Check for PRs needing attention: (1) Find PRs with changes requested: `gh pr list --label=\"loom:changes-requested\" --state=open`, (2) For each PR, check review comments: `gh pr view <number>`, (3) Check out the PR branch with `gh pr checkout <number>`, address the feedback, run `pnpm check:ci`, commit and push your fixes, then update labels (remove `loom:changes-requested`, add `loom:review-requested`) and comment that feedback is addressed. For complex changes that require substantial refactoring, create an issue with `loom:pr-feedback` + `loom:urgent` labels instead.",
   "autonomousRecommended": true,

--- a/defaults/roles/driver.json
+++ b/defaults/roles/driver.json
@@ -1,6 +1,7 @@
 {
   "name": "Plain Shell",
   "description": "Standard shell environment with no specialized role",
+  "suggestedModel": "sonnet",
   "defaultInterval": 0,
   "defaultIntervalPrompt": "",
   "autonomousRecommended": false,

--- a/defaults/roles/guide.json
+++ b/defaults/roles/guide.json
@@ -1,6 +1,7 @@
 {
   "name": "Triage",
   "description": "Continuously prioritizes loom:issue issues by managing loom:urgent labels",
+  "suggestedModel": "sonnet",
   "defaultInterval": 900000,
   "defaultIntervalPrompt": "Review all loom:issue issues and update loom:urgent labels to reflect current top 3 priorities",
   "autonomousRecommended": true,

--- a/defaults/roles/hermit.json
+++ b/defaults/roles/hermit.json
@@ -1,6 +1,7 @@
 {
   "name": "Hermit",
   "description": "Identifies and proposes removal of unnecessary complexity, bloat, and over-engineering",
+  "suggestedModel": "sonnet",
   "defaultInterval": 900000,
   "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are a Hermit. Analyze the codebase for opportunities to simplify, remove bloat, or eliminate unnecessary complexity. Look for: unused dependencies, dead code, over-engineered abstractions, commented-out code, duplicated logic, and unnecessary features. If you find something concrete worth removing, create a GitHub issue with the `loom:hermit` label explaining what to remove, why it's bloat, and the benefits of removal. Be specific and provide evidence (e.g., grep results showing no usage).",
   "autonomousRecommended": true,

--- a/defaults/roles/judge.json
+++ b/defaults/roles/judge.json
@@ -1,6 +1,7 @@
 {
   "name": "Code Review Specialist",
   "description": "Reviews PRs labeled loom:review-requested",
+  "suggestedModel": "opus",
   "defaultInterval": 300000,
   "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are a Code Review Specialist. Check `gh pr list --label=\"loom:review-requested\"` for PRs needing review. For each PR: check out branch, run `pnpm check:ci`, review code thoroughly. When complete: approve with `gh pr review --approve` and update labels (remove `loom:review-requested`, add `loom:pr`), or request changes with `gh pr review --request-changes` and update labels (remove `loom:review-requested`, add `loom:changes-requested` for Fixer to address).",
   "autonomousRecommended": true,

--- a/defaults/roles/loom.json
+++ b/defaults/roles/loom.json
@@ -1,6 +1,7 @@
 {
   "name": "Loom Daemon",
   "description": "Layer 2 system orchestrator that monitors system state, generates work by triggering Architect/Hermit, and scales shepherd pool based on demand",
+  "suggestedModel": "haiku",
   "defaultInterval": 60000,
   "defaultIntervalPrompt": "Run one daemon loop iteration: assess system state, check shepherd completions, generate work if backlog is low, scale shepherds based on demand, ensure Guide, Champion, and Doctor are running.",
   "autonomousRecommended": true,

--- a/defaults/roles/shepherd.json
+++ b/defaults/roles/shepherd.json
@@ -1,6 +1,7 @@
 {
   "name": "Shepherd",
   "description": "Meta-agent that shepherds issues through the full development lifecycle by coordinating other role terminals via MCP",
+  "suggestedModel": "sonnet",
   "defaultInterval": 0,
   "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are the Shepherd who coordinates other terminals to shepherd issues from creation to merged PR. When given an issue number, analyze its current state and progress it through the workflow: Curator → Approval → Builder → Judge → (Doctor loop if needed) → Merge. Use MCP to trigger terminals with fresh context. Track progress in issue comments for crash recovery.",
   "autonomousRecommended": false,


### PR DESCRIPTION
## Summary

- Add `suggestedModel` field to all role JSON files in `defaults/roles/`
- Model assignments optimized for each role's task complexity:
  - **opus**: builder, judge, architect (complex reasoning)
  - **sonnet**: shepherd, curator, doctor, champion, hermit, guide, driver (structured tasks)
  - **haiku**: loom daemon (status checks, simple decisions)
- Document model selection strategy in `defaults/CLAUDE.md`
- Update custom role example to include `suggestedModel` field

## Test plan

- [x] Verify all role JSON files have valid `suggestedModel` field
- [ ] Verify JSON files are valid (no syntax errors)
- [ ] Test that existing role loading still works

Closes #1194

🤖 Generated with [Claude Code](https://claude.com/claude-code)