### PR TITLE
Use loom:pr label for installation PRs

### DIFF
--- a/scripts/install/create-pr.sh
+++ b/scripts/install/create-pr.sh
@@ -228,7 +228,7 @@ GH_PR_OUTPUT=$(gh pr create \
   --base "$BASE_BRANCH" \
   --title "Install Loom ${LOOM_VERSION} (${LOOM_COMMIT})" \
   --body "$PR_BODY" \
-  --label "loom:review-requested" 2>&1)
+  --label "loom:pr" 2>&1)
 
 # Extract URL from output (gh CLI outputs the PR URL as the last line)
 PR_URL=$(echo "$GH_PR_OUTPUT" | grep -oE 'https://github\.com/[^[:space:]]+/pull/[0-9]+' | head -1 | tr -d '[:space:]')


### PR DESCRIPTION
## Summary

Installation PRs contain generated configuration files that don't need the same code review process as feature PRs. This changes the installation PR creation to use `loom:pr` instead of `loom:review-requested`, allowing the PR to go directly to Champion for auto-merge.

## Changes

- Change label in `scripts/install/create-pr.sh` from `loom:review-requested` to `loom:pr`

## Test plan

- [ ] Verify installation script creates PR with `loom:pr` label
- [ ] Confirm PR goes directly to Champion (skips Judge queue)

Closes #1200

🤖 Generated with [Claude Code](https://claude.com/claude-code)