### PR TITLE
Fix daemon iteration subagent invocation pattern

### DIFF
--- a/defaults/.claude/commands/loom.md
+++ b/defaults/.claude/commands/loom.md
@@ -823,9 +823,17 @@ def parent_loop(force_mode=False):
         # - Stuck detection
         # - Save state to JSON
 
+        # NOTE: We must explicitly instruct the subagent to use the Skill tool
+        # because Task subagents don't automatically interpret "/loom" as a Skill invocation.
+        # They see it as plain text unless we tell them to invoke the skill.
         result = Task(
             description=f"Daemon iteration {iteration}",
-            prompt=f"/loom iterate {force_flag}",
+            prompt=f"""Execute the Loom daemon iteration by invoking the Skill tool:
+
+Skill(skill="loom", args="iterate {force_flag}")
+
+Return ONLY the compact summary line (e.g., "ready=5 building=2 shepherds=2/3").
+Do not include any other text or explanation.""",
             subagent_type="general-purpose",
             run_in_background=False,  # Wait for iteration to complete
             model="haiku"  # Fast, cheap - iteration work is straightforward


### PR DESCRIPTION
## Summary

Fixes the daemon's subagent-per-iteration architecture by updating the parent loop to explicitly instruct iteration subagents to use the Skill tool.

## Problem

When the parent loop spawned iteration subagents with `prompt="/loom iterate"`, the subagents didn't recognize this as a Skill invocation - they saw it as plain text. This caused the subagent to respond:

> "I don't see a `/loom iterate` command in the available Loom scripts..."

The daemon had to fall back to executing iteration logic directly in the parent loop, defeating the purpose of the subagent-per-iteration architecture (which is designed to prevent context accumulation).

## Solution

Update the Task invocation prompt to explicitly instruct the subagent to use the Skill tool:

```python
# Before (broken)
prompt=f"/loom iterate {force_flag}"

# After (fixed)
prompt=f"""Execute the Loom daemon iteration by invoking the Skill tool:

Skill(skill="loom", args="iterate {force_flag}")

Return ONLY the compact summary line (e.g., "ready=5 building=2 shepherds=2/3").
Do not include any other text or explanation."""
```

## Testing

- Run `/loom --force` in a test repository
- Verify iteration subagents execute properly and return summaries
- Confirm summaries appear in parent output: `Iteration N: ready=X building=Y shepherds=Z/M`

Closes #1204

---
🤖 Generated by Shepherd orchestration