### PR TITLE
Handle 'main already used by worktree' error in merge instructions

### DIFF
--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -752,6 +752,28 @@ If setup fails, it's usually due to:
 
 ### Common Issues
 
+**'main already used by worktree' error during PR merge**:
+
+When running `gh pr merge` from a worktree, you may see this error:
+```
+fatal: 'main' is already used by worktree at '/path/to/repo'
+```
+
+This is **expected behavior**, not a failure. The merge succeeds on GitHub, but git cannot switch to `main` locally because another worktree has it checked out.
+
+**Solution**: Verify merge success via GitHub API instead of exit code:
+```bash
+# After gh pr merge, check the actual state:
+PR_STATE=$(gh pr view <PR_NUMBER> --json state --jq '.state')
+if [ "$PR_STATE" = "MERGED" ]; then
+  echo "Merge succeeded (local checkout error can be ignored)"
+fi
+```
+
+The Shepherd and Champion roles handle this automatically by verifying PR state via the GitHub API rather than relying on `gh pr merge` exit codes.
+
+---
+
 **Cleaning Up Stale Worktrees and Branches**:
 
 Use the `clean.sh` helper script to restore your repository to a clean state:


### PR DESCRIPTION
## Summary

- Update shepherd.md and champion.md to verify PR merge success via GitHub API instead of relying on exit codes
- Add troubleshooting documentation in CLAUDE.md explaining the expected worktree checkout error
- The pattern is: always check `gh pr view --json state` to determine if merge succeeded

## Test plan

- [ ] Verify shepherd merge workflow recognizes worktree checkout error as non-fatal
- [ ] Verify champion merge workflow recognizes worktree checkout error as non-fatal
- [ ] Run a test merge from a worktree to confirm API verification works

Closes #1208

🤖 Generated with [Claude Code](https://claude.com/claude-code)