### PR TITLE
Fix duplicate check mark in installation output

### DIFF
--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -477,7 +477,7 @@ cp "$LOOM_ROOT/scripts/cleanup-branches.sh" ".loom/scripts/cleanup-branches.sh" 
   error "Failed to copy cleanup-branches.sh"
 chmod +x ".loom/scripts/cleanup.sh"
 chmod +x ".loom/scripts/cleanup-branches.sh"
-success "✓ Installed cleanup scripts to .loom/scripts/"
+success "Installed cleanup scripts to .loom/scripts/"
 echo ""
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Fixes a cosmetic bug in the installation script where the cleanup scripts installation message was displaying a double check mark ("✓ ✓ Installed cleanup scripts...").

**Root cause**: The `success()` function already adds a `✓` prefix to messages, but line 480 was passing a string that already contained the check mark.

**Fix**: Removed the duplicate `✓` from the string passed to `success()`.

Closes #1222

---
*Generated by Shepherd (force-merge mode)*