### PR TITLE
Upgrade daemon iteration model from haiku to sonnet

### DIFF
--- a/defaults/.claude/commands/loom.md
+++ b/defaults/.claude/commands/loom.md
@@ -836,7 +836,7 @@ Return ONLY the compact summary line (e.g., "ready=5 building=2 shepherds=2/3").
 Do not include any other text or explanation.""",
             subagent_type="general-purpose",
             run_in_background=False,  # Wait for iteration to complete
-            model="haiku"  # Fast, cheap - iteration work is straightforward
+            model="sonnet"  # Iteration logic is complex - needs reliable instruction following
         )
 
         # ═══════════════════════════════════════════════════

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -671,7 +671,7 @@ Loom uses different AI models optimized for each role's task complexity. Model p
 
 | Role | Model | Rationale |
 |------|-------|-----------|
-| Loom Daemon | `haiku` | Status checks and simple decisions - fast and cheap |
+| Loom Daemon | `sonnet` | Iteration logic is complex - needs reliable instruction following |
 | Shepherd | `sonnet` | Orchestration is systematic with clear state transitions |
 | Builder | `opus` | Complex implementation requires deep reasoning |
 | Judge | `opus` | Code review needs thorough understanding |

--- a/defaults/roles/loom.json
+++ b/defaults/roles/loom.json
@@ -1,7 +1,7 @@
 {
   "name": "Loom Daemon",
   "description": "Layer 2 system orchestrator that monitors system state, generates work by triggering Architect/Hermit, and scales shepherd pool based on demand",
-  "suggestedModel": "haiku",
+  "suggestedModel": "sonnet",
   "defaultInterval": 60000,
   "defaultIntervalPrompt": "Run one daemon loop iteration: assess system state, check shepherd completions, generate work if backlog is low, scale shepherds based on demand, ensure Guide, Champion, and Doctor are running.",
   "autonomousRecommended": true,


### PR DESCRIPTION
## Summary

- Upgrade daemon iteration subagent model from `haiku` to `sonnet`
- Update documentation to reflect the model change
- Update role JSON metadata with new suggested model

The daemon's subagent-per-iteration architecture was using haiku for iteration subagents, but haiku completes iterations too quickly (~20 seconds) and skips most prescribed steps. The iteration logic is actually complex (10+ steps, state management, spawning decisions), so sonnet should follow instructions more reliably.

This implements **Option B** from issue #1224. If sonnet proves too costly or slow in production, we can fall back to Option A (shell script wrapper).

## Test plan

- [ ] Start daemon with `/loom` and observe iteration behavior
- [ ] Verify iterations complete all prescribed steps (state assessment, spawning, work generation)
- [ ] Confirm parent loop receives proper summaries

Closes #1224

🤖 Generated with [Claude Code](https://claude.com/claude-code)