### PR TITLE
Add configurable issue selection strategy to daemon-snapshot.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -547,6 +547,34 @@ The Loom daemon uses these configuration parameters:
 | `MAX_SHEPHERDS` | 3 | Maximum concurrent shepherd processes |
 | `ISSUES_PER_SHEPHERD` | 2 | Scale factor: target = ready_issues / ISSUES_PER_SHEPHERD |
 | `POLL_INTERVAL` | 60 | Seconds between daemon loop iterations |
+| `ISSUE_STRATEGY` | fifo | Issue selection strategy (see below) |
+
+**Issue Selection Strategy** (`LOOM_ISSUE_STRATEGY`):
+
+Controls the order in which shepherds pick up issues from the ready queue. The `loom:urgent` label always takes precedence regardless of strategy.
+
+| Strategy | Description |
+|----------|-------------|
+| `fifo` | **Default.** Oldest issues first (FIFO). Prevents starvation where new issues indefinitely deprioritize older ones. |
+| `lifo` | Newest issues first (LIFO). Original GitHub CLI default behavior. |
+| `priority` | Same as `fifo` but explicitly named. Issues with `loom:urgent` label first (oldest to newest), then remaining issues oldest to newest. |
+
+**Priority behavior:**
+- Issues with `loom:urgent` label are **always** processed first, regardless of strategy
+- Within the urgent partition, issues are sorted by age (oldest first)
+- Non-urgent issues are then sorted according to the selected strategy
+
+**Example:**
+```bash
+# Use FIFO (default) - prevents issue starvation
+LOOM_ISSUE_STRATEGY=fifo /loom
+
+# Use LIFO - newest issues first (for fast iteration)
+LOOM_ISSUE_STRATEGY=lifo /loom
+
+# Priority mode - explicit about urgent-first ordering
+LOOM_ISSUE_STRATEGY=priority /loom
+```
 
 **Daemon State File** (`.loom/daemon-state.json`):
 

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -565,6 +565,34 @@ The Loom daemon uses these configuration parameters:
 | `MAX_SHEPHERDS` | 3 | Maximum concurrent shepherd processes |
 | `ISSUES_PER_SHEPHERD` | 2 | Scale factor: target = ready_issues / ISSUES_PER_SHEPHERD |
 | `POLL_INTERVAL` | 60 | Seconds between daemon loop iterations |
+| `ISSUE_STRATEGY` | fifo | Issue selection strategy (see below) |
+
+**Issue Selection Strategy** (`LOOM_ISSUE_STRATEGY`):
+
+Controls the order in which shepherds pick up issues from the ready queue. The `loom:urgent` label always takes precedence regardless of strategy.
+
+| Strategy | Description |
+|----------|-------------|
+| `fifo` | **Default.** Oldest issues first (FIFO). Prevents starvation where new issues indefinitely deprioritize older ones. |
+| `lifo` | Newest issues first (LIFO). Original GitHub CLI default behavior. |
+| `priority` | Same as `fifo` but explicitly named. Issues with `loom:urgent` label first (oldest to newest), then remaining issues oldest to newest. |
+
+**Priority behavior:**
+- Issues with `loom:urgent` label are **always** processed first, regardless of strategy
+- Within the urgent partition, issues are sorted by age (oldest first)
+- Non-urgent issues are then sorted according to the selected strategy
+
+**Example:**
+```bash
+# Use FIFO (default) - prevents issue starvation
+LOOM_ISSUE_STRATEGY=fifo /loom
+
+# Use LIFO - newest issues first (for fast iteration)
+LOOM_ISSUE_STRATEGY=lifo /loom
+
+# Priority mode - explicit about urgent-first ordering
+LOOM_ISSUE_STRATEGY=priority /loom
+```
 
 **Session Reflection Configuration**:
 


### PR DESCRIPTION
## Summary

- Add `LOOM_ISSUE_STRATEGY` environment variable with three strategies:
  - `fifo` (default): Oldest issues first, prevents starvation
  - `lifo`: Newest issues first (original GitHub CLI behavior)
  - `priority`: Same as fifo but explicitly named
- Always respect `loom:urgent` label as highest priority regardless of strategy
- Include `createdAt` in issue queries for accurate sorting
- Add `issue_strategy` to config output in daemon snapshot
- Update CLAUDE.md documentation with strategy details
- Update loom.md role documentation with priority-aware comments

## Test plan

- [x] Script syntax validation passes (`bash -n`)
- [x] Script executes successfully with `--pretty` flag
- [x] `LOOM_ISSUE_STRATEGY=fifo` uses fifo ordering
- [x] `LOOM_ISSUE_STRATEGY=lifo` uses lifo ordering  
- [x] `LOOM_ISSUE_STRATEGY=priority` uses priority ordering
- [x] Invalid strategy shows warning and falls back to fifo
- [x] Config output includes `issue_strategy` field
- [ ] Manual verification with actual urgent vs non-urgent issues

Closes #1237

---
Generated with [Claude Code](https://claude.com/claude-code)