### PR TITLE
Reduce CLAUDE.md size to improve performance

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -1,0 +1,189 @@
+# Loom Daemon Reference
+
+Detailed configuration and state management for the Loom daemon (Layer 2).
+
+## Daemon Configuration Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `ISSUE_THRESHOLD` | 3 | Trigger Architect/Hermit when `loom:issue` count below this |
+| `MAX_PROPOSALS` | 5 | Maximum pending proposal issues |
+| `MAX_SHEPHERDS` | 3 | Maximum concurrent shepherd processes |
+| `ISSUES_PER_SHEPHERD` | 2 | Scale factor: target = ready_issues / ISSUES_PER_SHEPHERD |
+| `POLL_INTERVAL` | 60 | Seconds between daemon loop iterations |
+| `ISSUE_STRATEGY` | fifo | Issue selection strategy (see below) |
+
+## Issue Selection Strategy
+
+Set via `LOOM_ISSUE_STRATEGY` environment variable. Controls the order in which shepherds pick up issues from the ready queue. The `loom:urgent` label always takes precedence regardless of strategy.
+
+| Strategy | Description |
+|----------|-------------|
+| `fifo` | **Default.** Oldest issues first (FIFO). Prevents starvation where new issues indefinitely deprioritize older ones. |
+| `lifo` | Newest issues first (LIFO). Original GitHub CLI default behavior. |
+| `priority` | Same as `fifo` but explicitly named. Issues with `loom:urgent` label first (oldest to newest), then remaining issues oldest to newest. |
+
+**Priority behavior:**
+- Issues with `loom:urgent` label are **always** processed first, regardless of strategy
+- Within the urgent partition, issues are sorted by age (oldest first)
+- Non-urgent issues are then sorted according to the selected strategy
+
+**Example:**
+```bash
+# Use FIFO (default) - prevents issue starvation
+LOOM_ISSUE_STRATEGY=fifo /loom
+
+# Use LIFO - newest issues first (for fast iteration)
+LOOM_ISSUE_STRATEGY=lifo /loom
+
+# Priority mode - explicit about urgent-first ordering
+LOOM_ISSUE_STRATEGY=priority /loom
+```
+
+## Daemon State File
+
+The daemon state file (`.loom/daemon-state.json`) provides comprehensive information for debugging, crash recovery, and system observability.
+
+### Full State Structure
+
+```json
+{
+  "started_at": "2026-01-23T10:00:00Z",
+  "last_poll": "2026-01-23T11:30:00Z",
+  "running": true,
+  "iteration": 42,
+
+  "shepherds": {
+    "shepherd-1": {
+      "status": "working",
+      "issue": 123,
+      "task_id": "abc123",
+      "output_file": "/tmp/claude/.../abc123.output",
+      "started": "2026-01-23T10:15:00Z",
+      "last_phase": "builder",
+      "pr_number": null
+    },
+    "shepherd-2": {
+      "status": "idle",
+      "issue": null,
+      "idle_since": "2026-01-23T11:00:00Z",
+      "idle_reason": "no_ready_issues",
+      "last_issue": 100,
+      "last_completed": "2026-01-23T10:58:00Z"
+    }
+  },
+
+  "pipeline_state": {
+    "ready": ["#1083", "#1080"],
+    "building": ["#1044"],
+    "review_requested": ["PR #1056"],
+    "changes_requested": ["PR #1059"],
+    "ready_to_merge": ["PR #1058"],
+    "blocked": [
+      {
+        "type": "pr",
+        "number": 1059,
+        "reason": "merge_conflicts",
+        "detected_at": "2026-01-23T11:20:00Z"
+      }
+    ],
+    "last_updated": "2026-01-23T11:30:00Z"
+  },
+
+  "warnings": [
+    {
+      "time": "2026-01-23T11:10:00Z",
+      "type": "blocked_pr",
+      "severity": "warning",
+      "message": "PR #1059 has merge conflicts",
+      "context": {"pr_number": 1059, "requires_role": "doctor"},
+      "acknowledged": false
+    }
+  ],
+
+  "completed_issues": [100, 101, 102],
+  "total_prs_merged": 3,
+  "last_architect_trigger": "2026-01-23T10:00:00Z",
+  "last_hermit_trigger": "2026-01-23T10:30:00Z"
+}
+```
+
+### Shepherd Status Values
+
+- `working` - Actively processing an issue
+- `idle` - No issue assigned, waiting for work
+- `errored` - Encountered an error, may need intervention
+- `paused` - Manually paused via signal or stuck detection
+
+### Idle Reasons
+
+- `no_ready_issues` - No issues with `loom:issue` label available
+- `at_capacity` - All shepherd slots filled
+- `completed_issue` - Just finished an issue, waiting for next
+- `rate_limited` - Paused due to API rate limits
+- `shutdown_signal` - Paused due to graceful shutdown
+
+### Warning Types
+
+- `blocked_pr` - PR has merge conflicts or failed checks
+- `shepherd_error` - Shepherd encountered recoverable error
+- `role_failure` - Support role failed to complete
+- `stuck_agent` - Agent detected as stuck
+
+## Session Rotation
+
+When a new daemon session starts, the existing `daemon-state.json` is automatically rotated to preserve session history:
+
+```
+.loom/
+├── daemon-state.json          # Current session (always this name)
+├── 00-daemon-state.json       # First archived session
+├── 01-daemon-state.json       # Second archived session
+├── 02-daemon-state.json       # Third archived session
+└── ...
+```
+
+**Why session rotation?**
+- Debugging patterns across multiple sessions
+- Analyzing daemon behavior over time
+- Post-mortem analysis when issues occur
+- Understanding long-term trends in the development pipeline
+
+**Configuration**:
+- `LOOM_MAX_ARCHIVED_SESSIONS` - Maximum sessions to keep (default: 10)
+
+**Commands**:
+```bash
+# Preview session rotation
+./.loom/scripts/rotate-daemon-state.sh --dry-run
+
+# Manually prune old sessions
+./.loom/scripts/daemon-cleanup.sh prune-sessions
+
+# Keep more archived sessions
+./.loom/scripts/rotate-daemon-state.sh --max-sessions 20
+```
+
+Archived sessions include a `session_summary` field with final statistics:
+```json
+{
+  "session_summary": {
+    "session_id": 5,
+    "archived_at": "2026-01-24T15:30:00Z",
+    "issues_completed": 12,
+    "prs_merged": 10,
+    "total_iterations": 156
+  }
+}
+```
+
+## Required Terminal Configuration
+
+| Terminal ID | Role | Purpose |
+|-------------|------|---------|
+| shepherd-1, shepherd-2, shepherd-3 | shepherd.md | Issue orchestration pool |
+| terminal-architect | architect.md | Work generation (proposals) |
+| terminal-hermit | hermit.md | Simplification proposals |
+| terminal-guide | guide.md | Backlog triage (always running) |
+| terminal-champion | champion.md | Auto-merge (always running) |
+| terminal-doctor | doctor.md | PR conflict resolution (always running) |

--- a/.loom/docs/troubleshooting.md
+++ b/.loom/docs/troubleshooting.md
@@ -1,0 +1,237 @@
+# Loom Troubleshooting Guide
+
+## Common Issues
+
+### Cleaning Up Stale Worktrees and Branches
+
+Use the `clean.sh` helper script to restore your repository to a clean state:
+
+```bash
+# Interactive mode - prompts for confirmation (default)
+./.loom/scripts/clean.sh
+
+# Preview mode - shows what would be cleaned without making changes
+./.loom/scripts/clean.sh --dry-run
+
+# Non-interactive mode - auto-confirms all prompts (for CI/automation)
+./.loom/scripts/clean.sh --force
+
+# Deep clean - also removes build artifacts (target/, node_modules/)
+./.loom/scripts/clean.sh --deep
+
+# Combine flags
+./.loom/scripts/clean.sh --deep --force  # Non-interactive deep clean
+./.loom/scripts/clean.sh --deep --dry-run  # Preview deep clean
+```
+
+**What clean.sh does**:
+- Removes worktrees for closed GitHub issues (prompts per worktree in interactive mode)
+- Deletes local feature branches for closed issues
+- Cleans up Loom tmux sessions
+- (Optional with `--deep`) Removes `target/` and `node_modules/` directories
+
+**IMPORTANT**: For **CI pipelines and automation**, always use `--force` flag to prevent hanging on prompts:
+```bash
+./.loom/scripts/clean.sh --force  # Non-interactive, safe for automation
+```
+
+**Manual cleanup** (if needed):
+```bash
+# List worktrees
+git worktree list
+
+# Remove specific stale worktree
+git worktree remove .loom/worktrees/issue-42 --force
+
+# Prune orphaned worktrees
+git worktree prune
+```
+
+### Labels out of sync
+
+```bash
+# Re-sync labels from configuration
+gh label sync --file .github/labels.yml
+```
+
+### Terminal won't start (Tauri App)
+
+```bash
+# Check daemon logs
+tail -f ~/.loom/daemon.log
+
+# Check terminal logs
+tail -f /tmp/loom-terminal-1.out
+```
+
+### Claude Code not found
+
+```bash
+# Ensure Claude Code CLI is in PATH
+which claude
+
+# Install if missing (see Claude Code documentation)
+```
+
+### Orphaned issues stuck in loom:building state
+
+When an agent crashes or is cancelled while building, issues can get stuck in `loom:building` state without a PR. Use the stale-building-check script to detect and recover these:
+
+```bash
+# Check for stale building issues (dry run)
+./.loom/scripts/stale-building-check.sh
+
+# Show detailed progress
+./.loom/scripts/stale-building-check.sh --verbose
+
+# Auto-recover stale issues (resets to loom:issue)
+./.loom/scripts/stale-building-check.sh --recover
+
+# JSON output for automation
+./.loom/scripts/stale-building-check.sh --json
+```
+
+**Configuration via environment**:
+- `STALE_THRESHOLD_HOURS=2` - Hours before issue without PR is considered stale
+- `STALE_WITH_PR_HOURS=24` - Hours before issue with stale PR is flagged
+
+**What it does**:
+- Finds issues with `loom:building` label that have been stuck
+- Checks if there's an associated PR (by branch name or body reference)
+- Issues without PRs older than threshold are flagged/recovered
+- Issues with stale PRs are flagged but not auto-recovered (need manual review)
+
+## Stuck Agent Detection
+
+The Loom daemon automatically detects stuck or struggling agents and can trigger interventions.
+
+### Check for stuck agents
+
+```bash
+# Run stuck detection check
+./.loom/scripts/stuck-detection.sh check
+
+# Check with JSON output
+./.loom/scripts/stuck-detection.sh check --json
+
+# Check specific agent
+./.loom/scripts/stuck-detection.sh check-agent shepherd-1
+```
+
+### View stuck detection status
+
+```bash
+# Show status summary
+./.loom/scripts/stuck-detection.sh status
+
+# View intervention history
+./.loom/scripts/stuck-detection.sh history
+./.loom/scripts/stuck-detection.sh history shepherd-1
+```
+
+### Configure stuck detection thresholds
+
+```bash
+# Adjust thresholds
+./.loom/scripts/stuck-detection.sh configure \
+  --idle-threshold 900 \
+  --working-threshold 2400 \
+  --intervention-mode escalate
+
+# Intervention modes: none, alert, suggest, pause, clarify, escalate
+```
+
+### Handle stuck agents
+
+```bash
+# Clear intervention for specific agent
+./.loom/scripts/stuck-detection.sh clear shepherd-1
+
+# Clear all interventions
+./.loom/scripts/stuck-detection.sh clear all
+
+# Resume a paused agent
+./.loom/scripts/signal.sh clear shepherd-1
+```
+
+### Stuck indicators
+
+| Indicator | Default Threshold | Description |
+|-----------|-------------------|-------------|
+| `no_progress` | 10 minutes | No output written to task output file |
+| `extended_work` | 30 minutes | Working on same issue without creating PR |
+| `looping` | 3 occurrences | Repeated similar error patterns |
+| `error_spike` | 5 errors | Multiple errors in short period |
+
+### Intervention types
+
+| Type | Trigger | Action |
+|------|---------|--------|
+| `alert` | Low severity | Write to `.loom/interventions/`, human reviews |
+| `suggest` | Medium severity | Suggest role switch (e.g., Builder -> Doctor) |
+| `pause` | High severity | Auto-pause via signal.sh, requires manual restart |
+| `clarify` | Error spike | Suggest requesting clarification from issue author |
+| `escalate` | Critical | Full escalation: pause + alert + human notification |
+
+## Daemon Troubleshooting (Layer 2)
+
+### Check daemon state
+
+```bash
+# View current daemon state
+cat .loom/daemon-state.json | jq
+
+# Check if daemon is running
+jq '.running' .loom/daemon-state.json
+
+# View active shepherds
+jq '.shepherds | to_entries[] | select(.value.issue != null)' .loom/daemon-state.json
+```
+
+### Graceful shutdown
+
+```bash
+# Signal daemon to stop
+touch .loom/stop-daemon
+
+# Monitor shutdown progress
+watch -n 5 'cat .loom/daemon-state.json | jq ".shepherds"'
+```
+
+### Force stop (use with caution)
+
+```bash
+# Remove stop signal if exists
+rm -f .loom/stop-daemon
+
+# Clear daemon state (will restart fresh)
+rm -f .loom/daemon-state.json
+```
+
+### Stuck shepherd
+
+```bash
+# Check shepherd assignments
+jq '.shepherds' .loom/daemon-state.json
+
+# Check if assigned issue is blocked
+gh issue view <issue-number> --json labels --jq '.labels[].name'
+
+# Manually clear stuck shepherd (daemon will reassign)
+jq '.shepherds["shepherd-1"] = {"issue": null, "idle_since": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"}' \
+  .loom/daemon-state.json > tmp.json && mv tmp.json .loom/daemon-state.json
+```
+
+### Work generation not triggering
+
+```bash
+# Check issue count vs threshold
+echo "Ready issues: $(gh issue list --label 'loom:issue' --state open --json number --jq 'length')"
+echo "Threshold: 3 (default)"
+
+# Check cooldown timestamps
+jq '.last_architect_trigger, .last_hermit_trigger' .loom/daemon-state.json
+
+# Check proposal count
+echo "Proposals: $(gh issue list --label 'loom:architect,loom:hermit' --state open --json number --jq 'length')"
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,49 +14,34 @@ Loom is a multi-terminal desktop application for macOS that orchestrates AI-powe
 
 ## Three-Layer Architecture
 
-Loom uses a three-layer orchestration architecture for scalable automation:
-
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │                    Layer 3: Human Observer                      │
 │  - Watches system health and intervenes when needed             │
 │  - Overrides Champion on controversial proposals                │
-│  - Handles edge cases and blocked issues                        │
-│  - Provides strategic direction                                 │
 └─────────────────────────────────────────────────────────────────┘
-                              │
                               │ observes/intervenes
                               ▼
 ┌─────────────────────────────────────────────────────────────────┐
 │                    Layer 2: Loom Daemon                         │
 │  /loom - Continuous system orchestrator                         │
-│  - Monitors system state (issue counts, PR status)              │
-│  - Generates work (triggers Architect/Hermit when backlog low)  │
-│  - Scales shepherd pool based on demand                         │
-│  - Maintains daemon-state.json for crash recovery               │
+│  - Monitors state, generates work, scales shepherds             │
 └─────────────────────────────────────────────────────────────────┘
-                              │
                               │ spawns/manages
                               ▼
 ┌─────────────────────────────────────────────────────────────────┐
 │                    Layer 1: Shepherds                           │
 │  /shepherd <issue> - Single-issue lifecycle orchestrator        │
 │  - Coordinates: Curator → Builder → Judge → Doctor → Merge      │
-│  - Handles full lifecycle including code review (Judge phase)   │
-│  - Tracks progress in issue comments                            │
 └─────────────────────────────────────────────────────────────────┘
-                              │
                               │ triggers
                               ▼
 ┌─────────────────────────────────────────────────────────────────┐
 │                    Worker Roles                                 │
 │  Curator, Builder, Judge, Doctor, etc.                          │
 │  - Execute single tasks (curate issue, build feature, review)   │
-│  - Standalone - no knowledge of orchestration                   │
 └─────────────────────────────────────────────────────────────────┘
 ```
-
-### Layer Summary
 
 | Layer | Role | Purpose | Mode |
 |-------|------|---------|------|
@@ -65,231 +50,66 @@ Loom uses a three-layer orchestration architecture for scalable automation:
 | Layer 1 | `/shepherd <issue>` | Issue orchestration - lifecycle from creation to merge | Per-issue |
 | Layer 0 | `/builder`, `/judge`, etc. | Task execution - single focused work units | Per-task |
 
-### Layer Responsibilities
-
-**Layer 3 (Human Observer)**:
-- Override Champion decisions on controversial proposals (Champion handles routine approvals)
-- Monitor system health via daemon-state.json
-- Intervene for blocked issues or stuck agents
-- Provide strategic direction on what to build
-
-**Layer 2 (Loom Daemon)**:
-- Automatically maintained by `/loom` - no manual updates needed
-- Triggers Architect/Hermit when issue backlog is low
-- Spawns shepherds for ready issues (`loom:issue`)
-- Tracks state for crash recovery
-
-**Layer 1 (Shepherds)**:
-- Fully autonomous once spawned
-- Handles entire issue lifecycle including Judge review
-- Uses `--force-pr` by default (stops at ready-to-merge), or `--force-merge` for full automation
-
-### When to Use Which Layer
-
-**Use `/shepherd <issue>`** (Layer 1) when:
-- You have a specific issue to implement
-- You want to orchestrate one issue through its full lifecycle
-- Running manual orchestration mode
-
-**Use `/loom`** (Layer 2) when:
-- You want fully autonomous development
-- The system should generate its own work
-- Multiple issues need parallel processing
-- Running production-scale orchestration
+**Use `/shepherd <issue>`** when you have a specific issue to implement.
+**Use `/loom`** for fully autonomous development with work generation.
 
 ## Usage Modes
 
-Loom supports two complementary workflows:
-
 ### 1. Manual Orchestration Mode (MOM)
 
-Use Claude Code terminals with specialized roles for hands-on development coordination.
+Use Claude Code terminals with specialized roles for hands-on development:
 
-**Setup**:
 1. Open Claude Code in this repository
-2. Use slash commands to assume roles: `/builder`, `/judge`, `/curator`, etc.
-3. Each terminal acts as a specialized agent following role guidelines
-
-**When to use MOM**:
-- Learning Loom workflows
-- Direct control over agent actions
-- Debugging and iterating on processes
-- Working with smaller teams
-
-**Example workflow**:
-```bash
-# Terminal 1: Builder working on feature
-/builder
-# Claims loom:issue issue, implements, creates PR
-
-# Terminal 2: Judge reviewing PRs
-/judge
-# Reviews PR with loom:review-requested, provides feedback
-
-# Terminal 3: Curator maintaining issues
-/curator
-# Enhances unlabeled issues, marks as loom:curated
-```
+2. Use slash commands: `/builder`, `/judge`, `/curator`, etc.
+3. Each terminal acts as a specialized agent
 
 ### 2. Tauri App Mode
 
-Launch the Loom desktop application for automated orchestration with visual terminal management.
+Launch the Loom desktop application for automated orchestration:
 
-**Setup**:
-1. Install Loom app (see main repository for download)
-2. Open Loom application
-3. Select this repository as workspace
-4. Configure terminals with roles and intervals
-5. Start engine - terminals launch automatically
-
-**When to use Tauri App**:
-- Production-scale development
-- Fully autonomous agent workflows
-- Visual monitoring of multiple agents
-- Hands-off orchestration
-
-**Features**:
-- Visual terminal multiplexing
-- Real-time agent monitoring
-- Autonomous mode with configurable intervals
-- Persistent workspace configuration
+1. Install Loom app, open it, select this repository
+2. Configure terminals with roles and intervals
+3. Start engine - terminals launch automatically
 
 ### 3. Daemon Mode (Layer 2)
 
-Run the Loom daemon for fully autonomous system orchestration.
-
-**Setup**:
 ```bash
-# Start the daemon (runs continuously)
-/loom
-
-# Start with force mode for aggressive autonomous development
-/loom --force
-
-# The daemon will:
-# 1. Monitor system state every 60 seconds
-# 2. Trigger Architect/Hermit when backlog is low
-# 3. Spawn shepherds for ready issues
-# 4. Ensure Guide, Champion, and Doctor keep running
+/loom           # Start daemon (runs continuously)
+/loom --force   # Aggressive autonomous development
 ```
 
-**Force Mode** (`--force`):
+**Force Mode** enables: auto-promotion of proposals, audit trail with `[force-mode]` markers, safety guardrails still apply.
 
-When running with `--force`, the daemon enables aggressive autonomous development:
-- Champion auto-promotes all `loom:architect` and `loom:hermit` proposals
-- Champion auto-promotes all `loom:curated` issues
-- Audit trail with `[force-mode]` markers on all auto-promoted items
-- Safety guardrails still apply (no force-push, respect `loom:blocked`)
-
-**Example daemon workflow**:
-```
-Daemon Loop:
-  ├── Assess: 2 ready issues, 1 building, 0 proposals
-  ├── Generate: Trigger Architect (backlog < threshold)
-  ├── Scale: Spawn shepherd-1 for issue #123
-  ├── Scale: Spawn shepherd-2 for issue #456
-  ├── Ensure: Guide running, Champion running, Doctor running
-  └── Sleep 60s, repeat
-
-Shepherd-1 (issue #123):
-  └── Curator → Builder → Judge → Merge ✓
-
-Shepherd-2 (issue #456):
-  └── Curator → Builder → Judge → Doctor → Judge → Merge ✓
-```
-
-**Graceful shutdown**:
-```bash
-# Signal the daemon to stop
-touch .loom/stop-daemon
-
-# Daemon will:
-# 1. Stop spawning new shepherds
-# 2. Wait for active shepherds to complete (max 5 min)
-# 3. Clean up state and exit
-```
+**Graceful shutdown**: `touch .loom/stop-daemon`
 
 ## Agent Roles
 
-Loom provides specialized roles for different development tasks. Each role follows specific guidelines and uses GitHub labels for coordination.
+### Orchestration Roles
 
-### Orchestration Roles (Layer 1 & 2)
+| Role | File | Purpose |
+|------|------|---------|
+| Loom Daemon | `loom.md` | System orchestration, work generation (Layer 2) |
+| Shepherd | `shepherd.md` | Single-issue lifecycle orchestration (Layer 1) |
 
-**Loom Daemon** (Autonomous 1min, `loom.md`) - *Layer 2*
-- **Purpose**: System-level orchestration and work generation
-- **Workflow**: Monitors state → triggers Architect/Hermit → scales shepherds → ensures support roles
-- **When to use**: Fully autonomous development with automatic work generation
+### Worker Roles
 
-**Shepherd** (Manual, `shepherd.md`) - *Layer 1*
-- **Purpose**: Single-issue lifecycle orchestration
-- **Workflow**: Coordinates Curator → Builder → Judge → Doctor → Merge for one issue
-- **When to use**: Orchestrating a specific issue through its full development lifecycle
+| Role | File | Purpose | Mode |
+|------|------|---------|------|
+| Builder | `builder.md` | Implement features and fixes | Manual |
+| Judge | `judge.md` | Review pull requests | Autonomous 5min |
+| Champion | `champion.md` | Evaluate proposals, auto-merge PRs | Autonomous 10min |
+| Curator | `curator.md` | Enhance and organize issues | Autonomous 5min |
+| Architect | `architect.md` | Create architectural proposals | Autonomous 15min |
+| Hermit | `hermit.md` | Identify simplification opportunities | Autonomous 15min |
+| Doctor | `doctor.md` | Fix bugs and address PR feedback | Manual |
+| Guide | `guide.md` | Prioritize and triage issues | Autonomous 15min |
+| Driver | `driver.md` | Direct command execution | Manual |
 
-### Worker Roles (Layer 0)
-
-**Builder** (Manual, `builder.md`)
-- **Purpose**: Implement features and fixes
-- **Workflow**: Claims `loom:issue` → implements → tests → creates PR with `loom:review-requested`
-- **When to use**: Feature development, bug fixes, refactoring
-
-**Judge** (Autonomous 5min, `judge.md`)
-- **Purpose**: Review pull requests
-- **Workflow**: Finds `loom:review-requested` PRs → reviews → approves or requests changes
-- **When to use**: Code quality assurance, automated reviews
-
-**Champion** (Autonomous 10min, `champion.md`)
-- **Purpose**: Evaluate proposals and auto-merge approved PRs
-- **Workflow**: Evaluates `loom:curated`, `loom:architect`, `loom:hermit` proposals → promotes to `loom:issue`. Also finds `loom:pr` PRs → verifies safety criteria → auto-merges if safe
-- **When to use**: Default daemon mode - handles both proposal promotion and PR merging
-- **Note**: Not needed for PR merging when shepherds run with `--force-merge` (shepherds handle their own merges)
-
-**Curator** (Autonomous 5min, `curator.md`)
-- **Purpose**: Enhance and organize issues
-- **Workflow**: Finds unlabeled issues → adds context → marks as `loom:curated` (Champion evaluates → `loom:issue`)
-- **When to use**: Issue backlog maintenance, quality improvement
-
-**Architect** (Autonomous 15min, `architect.md`)
-- **Purpose**: Create architectural proposals
-- **Workflow**: Analyzes codebase → creates proposal issues with `loom:architect`
-- **When to use**: System design, technical decision making
-
-**Hermit** (Autonomous 15min, `hermit.md`)
-- **Purpose**: Identify code simplification opportunities
-- **Workflow**: Analyzes complexity → creates removal proposals with `loom:hermit`
-- **When to use**: Code simplification, reducing technical debt
-
-**Doctor** (Manual, `doctor.md`)
-- **Purpose**: Fix bugs and address PR feedback
-- **Workflow**: Claims bug reports or addresses PR comments → fixes → pushes changes
-- **When to use**: Bug fixes, PR maintenance
-
-**Guide** (Autonomous 15min, `guide.md`)
-- **Purpose**: Prioritize and triage issues
-- **Workflow**: Reviews issue backlog → updates priorities → organizes labels
-- **When to use**: Project planning, issue organization
-
-**Driver** (Manual, `driver.md`)
-- **Purpose**: Direct command execution
-- **Workflow**: Plain shell environment for custom tasks
-- **When to use**: Ad-hoc tasks, debugging, manual operations
-
-### Role Definitions
-
-Full role definitions with detailed guidelines are available in:
-- `.loom/roles/loom.md` - Layer 2 daemon orchestration
-- `.loom/roles/shepherd.md` - Layer 1 issue orchestration
-- `.loom/roles/builder.md` - Feature implementation
-- `.loom/roles/judge.md` - Code review
-- `.loom/roles/curator.md` - Issue enhancement
-- `.loom/roles/doctor.md` - Bug fixes and PR feedback
-- `.loom/roles/champion.md` - Auto-merge approved PRs
-- `.loom/roles/architect.md` - Architectural proposals
-- `.loom/roles/hermit.md` - Code simplification
-- `.loom/roles/guide.md` - Issue triage and prioritization
+Full role definitions: `.loom/roles/*.md`
 
 ## Label-Based Workflow
 
-Agents coordinate work through GitHub labels. This enables autonomous operation without direct communication.
+Agents coordinate through GitHub labels. See `.github/labels.yml` for full definitions.
 
 ### Label Flow
 
@@ -299,10 +119,7 @@ Agents coordinate work through GitHub labels. This enables autonomous operation 
            ↑ Curator      ↑ Builder
 
 (created) → loom:curating → loom:curated → loom:issue
-           ↑ Curator        ↑ Curator      ↑ Human approves
-
-(bug) → loom:treating → (fixed)
-       ↑ Doctor
+           ↑ Curator        ↑ Curator      ↑ Champion approves
 ```
 
 **PR Lifecycle**:
@@ -313,209 +130,67 @@ Agents coordinate work through GitHub labels. This enables autonomous operation 
 
 **Proposal Lifecycle**:
 ```
-(created) → loom:architect → (evaluated) → loom:issue
-           ↑ Architect       ↑ Champion    ↑ Ready for Builder
-
-(created) → loom:hermit → (evaluated) → loom:issue
-           ↑ Hermit       ↑ Champion    ↑ Ready for Builder
+(created) → loom:architect/loom:hermit → (evaluated) → loom:issue
+           ↑ Architect/Hermit            ↑ Champion    ↑ Ready for Builder
 ```
 
-**Epic Lifecycle**:
-```
-(created) → loom:epic → (evaluated) → Phase 1 issues created
-           ↑ Architect  ↑ Champion    ↓ loom:architect + loom:epic-phase
-
-Phase 1 complete → Phase 2 issues created → ... → Epic closed
-                   ↑ Champion auto-creates
-```
-
-Epics are multi-phase work items that decompose into individual issues. When Champion approves an epic, it creates Phase 1 issues with `loom:architect` and `loom:epic-phase` labels. As phases complete, Champion automatically creates subsequent phase issues until the epic is fully implemented.
-
-**Note**: Champion evaluates proposals from Architect and Hermit roles using the same 8 quality criteria as curated issues. Well-formed proposals are promoted automatically; only ambiguous or controversial proposals require human intervention.
-
-### Label Definitions
-
-**Workflow Labels**:
-- **`loom:issue`**: Issue approved for work, ready for Builder to claim
-- **`loom:building`**: Builder is actively implementing this issue
-- **`loom:curating`**: Curator is actively enhancing this issue
-- **`loom:treating`**: Doctor is actively fixing this bug or addressing PR feedback
-- **`loom:review-requested`**: PR ready for Judge to review
-- **`loom:changes-requested`**: PR requires changes (Judge requested modifications)
-- **`loom:pr`**: PR approved by Judge, ready for Champion to auto-merge
-
-**Proposal Labels**:
-- **`loom:architect`**: Architectural proposal awaiting Champion evaluation
-- **`loom:hermit`**: Simplification proposal awaiting Champion evaluation
-- **`loom:curated`**: Issue enhanced by Curator, awaiting Champion evaluation
-
-**Epic Labels**:
-- **`loom:epic`**: Multi-phase epic proposal awaiting Champion evaluation
-- **`loom:epic-phase`**: Issue is part of an epic phase (references parent epic)
-
-**Status Labels**:
-- **`loom:blocked`**: Implementation blocked, needs help or clarification
-- **`loom:urgent`**: Critical issue requiring immediate attention
+**Epic Lifecycle**: `loom:epic` → Champion creates phased `loom:architect` + `loom:epic-phase` issues.
 
 ## Git Worktree Workflow
 
-Loom uses git worktrees to isolate agent work. Loom supports two types of worktrees depending on the usage mode:
+Loom uses git worktrees to isolate agent work.
 
-### Worktree Strategy Overview
+**Terminal Worktrees** (`.loom/worktrees/terminal-N`): Agent isolation in Tauri App Mode only.
 
-**Terminal Worktrees** (`.loom/worktrees/terminal-N`):
-- **Purpose**: Agent isolation in Tauri App Mode
-- **When**: Created automatically for each terminal in the Loom desktop application
-- **Why**: Allows multiple autonomous agents to work on different branches simultaneously without conflicts
-- **Scope**: Per terminal/agent (persistent across app restarts)
-- **Used in**: Tauri App Mode only
+**Issue Worktrees** (`.loom/worktrees/issue-N`): Issue-specific work for Builder agents.
 
-**Issue Worktrees** (`.loom/worktrees/issue-N`):
-- **Purpose**: Issue-specific work isolation for Builder agents
-- **When**: Created manually by Builder when claiming an issue (both MOM and Tauri App)
-- **Why**: Isolates work on specific issues with dedicated feature branches
-- **Scope**: Per issue (temporary, cleaned up when PR is merged)
-- **Used in**: Both Manual Orchestration Mode and Tauri App Mode
-
-### When to Use Which Worktree Type
-
-**Manual Orchestration Mode (Claude Code CLI)**:
-- No terminal worktrees (agents work in main workspace initially)
-- Builder creates issue worktrees via `./.loom/scripts/worktree.sh <issue-number>`
-- Single agent per terminal, human-controlled
-
-**Tauri App Mode (Autonomous Agents)**:
-- Automatic terminal worktrees for agent isolation (`.loom/worktrees/terminal-N`)
-- Builder ALSO creates issue worktrees when claiming work (`.loom/worktrees/issue-N`)
-- Multiple autonomous agents can run simultaneously
-- Builder works in issue worktree, not terminal worktree
-
-### Creating Worktrees (for Agents)
-
-When claiming an issue, create a worktree:
+### Creating Worktrees
 
 ```bash
-# Agent claims issue #42
+# Claim issue and create worktree
 gh issue edit 42 --remove-label "loom:issue" --add-label "loom:building"
-
-# Create worktree for issue
 ./.loom/scripts/worktree.sh 42
-# Creates: .loom/worktrees/issue-42
-# Branch: feature/issue-42
-
-# Change to worktree
 cd .loom/worktrees/issue-42
 
-# Do the work...
-# ... implement, test, commit ...
-
-# Push and create PR
+# Work, commit, push, create PR
 git push -u origin feature/issue-42
 gh pr create --label "loom:review-requested"
 ```
 
-### Worktree Best Practices
+### Best Practices
 
-- **Always use the helper script**: `./.loom/scripts/worktree.sh <issue-number>`
-- **Never run git worktree directly**: The helper prevents nested worktrees
-- **One worktree per issue**: Keeps work isolated and organized
-- **Semantic naming**: Worktrees named `.loom/worktrees/issue-{number}`
-- **Clean up when done**: Worktrees are automatically removed when PRs are merged
-
-### Worktree Helper Commands
-
-```bash
-# Create worktree for issue
-./.loom/scripts/worktree.sh 42
-
-# Check if you're in a worktree
-./.loom/scripts/worktree.sh --check
-
-# Show help
-./.loom/scripts/worktree.sh --help
-```
+- Always use `./.loom/scripts/worktree.sh <issue-number>`
+- Never run `git worktree` directly (helper prevents nested worktrees)
+- Worktrees auto-removed when PRs merged
 
 ## Development Workflow
 
-### As a Builder (Manual Mode)
+### Builder Workflow
 
-1. **Find ready issue**:
-   ```bash
-   gh issue list --label="loom:issue"
-   ```
+1. Find issue: `gh issue list --label="loom:issue"`
+2. Claim: `gh issue edit 42 --remove-label "loom:issue" --add-label "loom:building"`
+3. Create worktree: `./.loom/scripts/worktree.sh 42 && cd .loom/worktrees/issue-42`
+4. Implement, test, commit
+5. Create PR: `git push -u origin feature/issue-42 && gh pr create --label "loom:review-requested" --body "Closes #42"`
 
-2. **Claim issue**:
-   ```bash
-   gh issue edit 42 --remove-label "loom:issue" --add-label "loom:building"
-   ```
+### Judge Workflow
 
-3. **Create worktree**:
-   ```bash
-   ./.loom/scripts/worktree.sh 42
-   cd .loom/worktrees/issue-42
-   ```
+1. Find PR: `gh pr list --label="loom:review-requested"`
+2. Review: `gh pr checkout 123`
+3. Approve: `gh pr review 123 --approve && gh pr edit 123 --remove-label "loom:review-requested" --add-label "loom:pr"`
+4. Or request changes: `gh pr review 123 --request-changes --body "Feedback"`
 
-4. **Implement and test**:
-   ```bash
-   # Make changes...
-   # Run tests...
-   git add -A
-   git commit -m "Implement feature X"
-   ```
+### Curator Workflow
 
-5. **Create PR**:
-   ```bash
-   git push -u origin feature/issue-42
-   gh pr create --label "loom:review-requested" --body "Closes #42"
-   ```
-
-### As a Judge (Autonomous or Manual)
-
-1. **Find PR to review**:
-   ```bash
-   gh pr list --label="loom:review-requested"
-   ```
-
-2. **Review PR**:
-   ```bash
-   gh pr checkout 123
-   # Review code, run tests, check for issues
-   ```
-
-3. **Provide feedback**:
-   ```bash
-   # If changes needed:
-   gh pr review 123 --request-changes --body "Feedback here"
-   gh pr edit 123 --remove-label "loom:review-requested"
-
-   # If approved:
-   gh pr review 123 --approve
-   gh pr edit 123 --remove-label "loom:review-requested" --add-label "loom:pr"
-   ```
-
-### As a Curator (Autonomous or Manual)
-
-1. **Find unlabeled issues**:
-   ```bash
-   gh issue list --label="!loom:issue,!loom:building,!loom:architect,!loom:hermit,!loom:curated,!loom:curating"
-   ```
-
-2. **Enhance issue**:
-   ```bash
-   # Add technical details, acceptance criteria, references
-   gh issue edit 42 --body "Enhanced description..."
-   ```
-
-3. **Mark as curated** (human will approve to add `loom:issue`):
-   ```bash
-   gh issue edit 42 --add-label "loom:curated"
-   ```
+1. Find unlabeled issues: `gh issue list --label="!loom:issue,!loom:building,!loom:architect,!loom:hermit,!loom:curated,!loom:curating"`
+2. Enhance issue with technical details
+3. Mark curated: `gh issue edit 42 --add-label "loom:curated"`
 
 ## Configuration
 
 ### Workspace Configuration
 
-Configuration is stored in `.loom/config.json` (gitignored, local to your machine):
+Configuration stored in `.loom/config.json` (gitignored):
 
 ```json
 {
@@ -536,748 +211,91 @@ Configuration is stored in `.loom/config.json` (gitignored, local to your machin
 }
 ```
 
-### Daemon Configuration (Layer 2)
+### Daemon Configuration
 
-The Loom daemon uses these configuration parameters:
-
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `ISSUE_THRESHOLD` | 3 | Trigger Architect/Hermit when `loom:issue` count below this |
-| `MAX_PROPOSALS` | 5 | Maximum pending proposal issues |
-| `MAX_SHEPHERDS` | 3 | Maximum concurrent shepherd processes |
-| `ISSUES_PER_SHEPHERD` | 2 | Scale factor: target = ready_issues / ISSUES_PER_SHEPHERD |
-| `POLL_INTERVAL` | 60 | Seconds between daemon loop iterations |
-| `ISSUE_STRATEGY` | fifo | Issue selection strategy (see below) |
-
-**Issue Selection Strategy** (`LOOM_ISSUE_STRATEGY`):
-
-Controls the order in which shepherds pick up issues from the ready queue. The `loom:urgent` label always takes precedence regardless of strategy.
-
-| Strategy | Description |
-|----------|-------------|
-| `fifo` | **Default.** Oldest issues first (FIFO). Prevents starvation where new issues indefinitely deprioritize older ones. |
-| `lifo` | Newest issues first (LIFO). Original GitHub CLI default behavior. |
-| `priority` | Same as `fifo` but explicitly named. Issues with `loom:urgent` label first (oldest to newest), then remaining issues oldest to newest. |
-
-**Priority behavior:**
-- Issues with `loom:urgent` label are **always** processed first, regardless of strategy
-- Within the urgent partition, issues are sorted by age (oldest first)
-- Non-urgent issues are then sorted according to the selected strategy
-
-**Example:**
-```bash
-# Use FIFO (default) - prevents issue starvation
-LOOM_ISSUE_STRATEGY=fifo /loom
-
-# Use LIFO - newest issues first (for fast iteration)
-LOOM_ISSUE_STRATEGY=lifo /loom
-
-# Priority mode - explicit about urgent-first ordering
-LOOM_ISSUE_STRATEGY=priority /loom
-```
-
-**Daemon State File** (`.loom/daemon-state.json`):
-
-The daemon state file provides comprehensive information for debugging, crash recovery, and system observability.
-
-```json
-{
-  "started_at": "2026-01-23T10:00:00Z",
-  "last_poll": "2026-01-23T11:30:00Z",
-  "running": true,
-  "iteration": 42,
-
-  "shepherds": {
-    "shepherd-1": {
-      "status": "working",
-      "issue": 123,
-      "task_id": "abc123",
-      "output_file": "/tmp/claude/.../abc123.output",
-      "started": "2026-01-23T10:15:00Z",
-      "last_phase": "builder",
-      "pr_number": null
-    },
-    "shepherd-2": {
-      "status": "idle",
-      "issue": null,
-      "idle_since": "2026-01-23T11:00:00Z",
-      "idle_reason": "no_ready_issues",
-      "last_issue": 100,
-      "last_completed": "2026-01-23T10:58:00Z"
-    }
-  },
-
-  "pipeline_state": {
-    "ready": ["#1083", "#1080"],
-    "building": ["#1044"],
-    "review_requested": ["PR #1056"],
-    "changes_requested": ["PR #1059"],
-    "ready_to_merge": ["PR #1058"],
-    "blocked": [
-      {
-        "type": "pr",
-        "number": 1059,
-        "reason": "merge_conflicts",
-        "detected_at": "2026-01-23T11:20:00Z"
-      }
-    ],
-    "last_updated": "2026-01-23T11:30:00Z"
-  },
-
-  "warnings": [
-    {
-      "time": "2026-01-23T11:10:00Z",
-      "type": "blocked_pr",
-      "severity": "warning",
-      "message": "PR #1059 has merge conflicts",
-      "context": {"pr_number": 1059, "requires_role": "doctor"},
-      "acknowledged": false
-    }
-  ],
-
-  "completed_issues": [100, 101, 102],
-  "total_prs_merged": 3,
-  "last_architect_trigger": "2026-01-23T10:00:00Z",
-  "last_hermit_trigger": "2026-01-23T10:30:00Z"
-}
-```
-
-**Shepherd Status Values**:
-- `working` - Actively processing an issue
-- `idle` - No issue assigned, waiting for work
-- `errored` - Encountered an error, may need intervention
-- `paused` - Manually paused via signal or stuck detection
-
-**Idle Reasons**:
-- `no_ready_issues` - No issues with `loom:issue` label available
-- `at_capacity` - All shepherd slots filled
-- `completed_issue` - Just finished an issue, waiting for next
-- `rate_limited` - Paused due to API rate limits
-- `shutdown_signal` - Paused due to graceful shutdown
-
-**Warning Types**:
-- `blocked_pr` - PR has merge conflicts or failed checks
-- `shepherd_error` - Shepherd encountered recoverable error
-- `role_failure` - Support role failed to complete
-- `stuck_agent` - Agent detected as stuck
-
-**Session Rotation**:
-
-When a new daemon session starts, the existing `daemon-state.json` is automatically rotated to preserve session history:
-
-```
-.loom/
-├── daemon-state.json          # Current session (always this name)
-├── 00-daemon-state.json       # First archived session
-├── 01-daemon-state.json       # Second archived session
-├── 02-daemon-state.json       # Third archived session
-└── ...
-```
-
-**Why session rotation?**
-- Debugging patterns across multiple sessions
-- Analyzing daemon behavior over time
-- Post-mortem analysis when issues occur
-- Understanding long-term trends in the development pipeline
-
-**Configuration**:
-- `LOOM_MAX_ARCHIVED_SESSIONS` - Maximum sessions to keep (default: 10)
-
-**Commands**:
-```bash
-# Preview session rotation
-./.loom/scripts/rotate-daemon-state.sh --dry-run
-
-# Manually prune old sessions
-./.loom/scripts/daemon-cleanup.sh prune-sessions
-
-# Keep more archived sessions
-./.loom/scripts/rotate-daemon-state.sh --max-sessions 20
-```
-
-Archived sessions include a `session_summary` field with final statistics:
-```json
-{
-  "session_summary": {
-    "session_id": 5,
-    "archived_at": "2026-01-24T15:30:00Z",
-    "issues_completed": 12,
-    "prs_merged": 10,
-    "total_iterations": 156
-  }
-}
-```
-
-**Required Terminal Configuration for Daemon**:
-
-| Terminal ID | Role | Purpose |
-|-------------|------|---------|
-| shepherd-1, shepherd-2, shepherd-3 | shepherd.md | Issue orchestration pool |
-| terminal-architect | architect.md | Work generation (proposals) |
-| terminal-hermit | hermit.md | Simplification proposals |
-| terminal-guide | guide.md | Backlog triage (always running) |
-| terminal-champion | champion.md | Auto-merge (always running) |
-| terminal-doctor | doctor.md | PR conflict resolution (always running) |
+See `.loom/docs/daemon-reference.md` for detailed daemon configuration including:
+- Configuration parameters (ISSUE_THRESHOLD, MAX_SHEPHERDS, etc.)
+- Issue selection strategies (fifo, lifo, priority)
+- Daemon state file structure
+- Session rotation
 
 ### Custom Roles
 
 Create custom roles by adding files to `.loom/roles/`:
 
 ```bash
-# Create custom role definition
 cat > .loom/roles/my-role.md <<EOF
 # My Custom Role
-
 You are a specialist in {{workspace}}.
-
 ## Your Role
 ...
-EOF
-
-# Optional: Add metadata
-cat > .loom/roles/my-role.json <<EOF
-{
-  "name": "My Custom Role",
-  "description": "Brief description",
-  "defaultInterval": 300000,
-  "defaultIntervalPrompt": "Continue working",
-  "autonomousRecommended": false,
-  "suggestedWorkerType": "claude"
-}
 EOF
 ```
 
 ### Branch Protection
 
-Loom works best with branch protection enabled on your default branch. Branch protection ensures all changes go through the PR workflow and prevents accidental direct commits.
-
-#### During Installation
-
-The installation script optionally configures branch protection:
-
-**Interactive mode**: Prompts you to enable protection
-```bash
-./scripts/install-loom.sh /path/to/repo
-# Will prompt: Configure branch protection rules for 'main' branch? (y/N)
-```
-
-**Non-interactive mode**: Skips branch protection (configure manually)
-```bash
-./scripts/install-loom.sh --yes /path/to/repo
-# Skips protection setup for automation safety
-```
-
-#### Manual Configuration
-
-Configure branch protection after installation:
+Loom works best with branch protection enabled. During installation:
 
 ```bash
-./scripts/install/setup-branch-protection.sh /path/to/repo main
+./scripts/install-loom.sh /path/to/repo  # Interactive, prompts for protection
+./scripts/install-loom.sh --yes /path/to/repo  # Non-interactive, skip protection
 ```
 
-Or configure via GitHub Settings:
-1. Go to: `Settings > Branches` in your repository
-2. Add rule for your default branch (usually `main`)
-3. Enable:
-   - Require pull request reviews (1 approval)
-   - Dismiss stale reviews on new commits
-   - Prevent force pushes
-   - Prevent branch deletion
-
-#### Protection Rules Applied
-
-The setup script configures these rules:
-- ✅ Require pull request before merging
-- ✅ Require 1 approval (can be bypassed by admins)
-- ✅ Dismiss stale reviews when new commits pushed
-- ✅ Prevent force pushes
-- ✅ Prevent branch deletion
-
-#### Why Branch Protection?
-
-**Enforces Loom workflow**:
-- All changes require pull requests
-- PRs require Judge review before merge
-- Prevents bypassing label-based coordination
-- Maintains audit trail of all changes
-
-**Requirements**:
-- Admin permissions on target repository
-- GitHub CLI authenticated
-- Default branch must exist
-
-**Troubleshooting**:
-If setup fails, it's usually due to:
-- Lacking admin permissions (ask repo owner)
-- Branch doesn't exist yet (push at least one commit)
-- GitHub API unreachable (check network/auth)
+Manual configuration: `./scripts/install/setup-branch-protection.sh /path/to/repo main`
 
 ### Repository Settings
 
-Loom works best with specific repository settings that support the automated workflow. These settings optimize merge behavior and enable auto-merge capabilities.
-
-#### During Installation
-
-The installation script optionally configures repository settings:
-
-**Interactive mode**: Prompts you to configure settings
-```bash
-./scripts/install-loom.sh /path/to/repo
-# Will prompt: Configure repository merge and auto-merge settings? (y/N)
-```
-
-**Non-interactive mode**: Skips repository settings (configure manually)
-```bash
-./scripts/install-loom.sh --yes /path/to/repo
-# Skips settings for automation safety
-```
-
-#### Manual Configuration
-
-Configure repository settings after installation:
+Configure merge settings during installation or manually:
 
 ```bash
 ./scripts/install/setup-repository-settings.sh /path/to/repo
+./scripts/install/setup-repository-settings.sh /path/to/repo --dry-run  # Preview
 ```
 
-Preview changes without applying (dry-run mode):
-
-```bash
-./scripts/install/setup-repository-settings.sh /path/to/repo --dry-run
-```
-
-Or configure via GitHub Settings:
-1. Go to: `Settings > General` in your repository
-2. Scroll to "Pull Requests" section
-3. Configure merge options as described below
-
-#### Settings Applied
-
-The setup script configures these repository settings:
-
-| Setting | Value | Why |
-|---------|-------|-----|
-| `allow_merge_commit` | true | Default merge strategy - preserves clear history of PRs |
-| `allow_squash_merge` | false | Disabled - preserves individual commits from agents |
-| `allow_rebase_merge` | false | Disabled - keeps merge commits visible |
-| `delete_branch_on_merge` | true | Auto-cleanup feature branches after merge |
-| `allow_auto_merge` | true | Enables Champion role to auto-merge approved PRs |
-| `allow_update_branch` | true | Suggests keeping branches up-to-date with base |
-
-#### Why These Settings?
-
-- **Merge commits only**: Maintains clear history showing which PRs introduced changes; important for understanding agent work
-- **Delete branches after merge**: Prevents accumulation of stale branches from issue worktrees
-- **Auto-merge enabled**: Required for Champion role to automatically merge approved PRs
-- **Suggest updating branches**: Helps agents keep branches current with main
-
-**Requirements**:
-- Admin permissions on target repository
-- GitHub CLI authenticated
-
-**Troubleshooting**:
-If setup fails, it's usually due to:
-- Lacking admin permissions (ask repo owner)
-- GitHub API unreachable (check network/auth)
+Settings applied: merge commits only (no squash/rebase), delete branches on merge, auto-merge enabled.
 
 ## Troubleshooting
 
-### Common Issues
+See `.loom/docs/troubleshooting.md` for detailed troubleshooting including:
+- Cleaning up stale worktrees and branches
+- Stuck agent detection and intervention
+- Daemon troubleshooting
+- Common issues and solutions
 
-**Cleaning Up Stale Worktrees and Branches**:
-
-Use the `clean.sh` helper script to restore your repository to a clean state:
+**Quick fixes**:
 
 ```bash
-# Interactive mode - prompts for confirmation (default)
-./.loom/scripts/clean.sh
-
-# Preview mode - shows what would be cleaned without making changes
-./.loom/scripts/clean.sh --dry-run
-
-# Non-interactive mode - auto-confirms all prompts (for CI/automation)
-./.loom/scripts/clean.sh --force
-
-# Deep clean - also removes build artifacts (target/, node_modules/)
-./.loom/scripts/clean.sh --deep
-
-# Combine flags
-./.loom/scripts/clean.sh --deep --force  # Non-interactive deep clean
-./.loom/scripts/clean.sh --deep --dry-run  # Preview deep clean
+./.loom/scripts/clean.sh --force        # Clean stale worktrees/branches
+./.loom/scripts/stale-building-check.sh --recover  # Recover stuck issues
+gh label sync --file .github/labels.yml  # Re-sync labels
+touch .loom/stop-daemon                  # Graceful daemon shutdown
 ```
 
-**What clean.sh does**:
-- Removes worktrees for closed GitHub issues (prompts per worktree in interactive mode)
-- Deletes local feature branches for closed issues
-- Cleans up Loom tmux sessions
-- (Optional with `--deep`) Removes `target/` and `node_modules/` directories
+## MCP Hooks
 
-**IMPORTANT**: For **CI pipelines and automation**, always use `--force` flag to prevent hanging on prompts:
+Loom provides a unified MCP server (`mcp-loom`) for programmatic control. See the mcp-loom package README for full tool documentation.
+
+**Key tools**: `list_terminals`, `create_terminal`, `send_terminal_input`, `get_agent_metrics`, `trigger_start`, `stop_engine`
+
+**Setup**:
 ```bash
-./.loom/scripts/clean.sh --force  # Non-interactive, safe for automation
+./scripts/setup-mcp.sh  # Generates .mcp.json
 ```
 
-**Manual cleanup** (if needed):
+**Agent metrics** for self-aware behavior:
 ```bash
-# List worktrees
-git worktree list
-
-# Remove specific stale worktree
-git worktree remove .loom/worktrees/issue-42 --force
-
-# Prune orphaned worktrees
-git worktree prune
-```
-
-**Labels out of sync**:
-```bash
-# Re-sync labels from configuration
-gh label sync --file .github/labels.yml
-```
-
-**Terminal won't start (Tauri App)**:
-```bash
-# Check daemon logs
-tail -f ~/.loom/daemon.log
-
-# Check terminal logs
-tail -f /tmp/loom-terminal-1.out
-```
-
-**Claude Code not found**:
-```bash
-# Ensure Claude Code CLI is in PATH
-which claude
-
-# Install if missing (see Claude Code documentation)
-```
-
-**Orphaned issues stuck in loom:building state**:
-
-When an agent crashes or is cancelled while building, issues can get stuck in `loom:building` state without a PR. Use the stale-building-check script to detect and recover these:
-
-```bash
-# Check for stale building issues (dry run)
-./.loom/scripts/stale-building-check.sh
-
-# Show detailed progress
-./.loom/scripts/stale-building-check.sh --verbose
-
-# Auto-recover stale issues (resets to loom:issue)
-./.loom/scripts/stale-building-check.sh --recover
-
-# JSON output for automation
-./.loom/scripts/stale-building-check.sh --json
-```
-
-**Configuration via environment**:
-- `STALE_THRESHOLD_HOURS=2` - Hours before issue without PR is considered stale
-- `STALE_WITH_PR_HOURS=24` - Hours before issue with stale PR is flagged
-
-**What it does**:
-- Finds issues with `loom:building` label that have been stuck
-- Checks if there's an associated PR (by branch name or body reference)
-- Issues without PRs older than threshold are flagged/recovered
-- Issues with stale PRs are flagged but not auto-recovered (need manual review)
-
-### Stuck Agent Detection
-
-The Loom daemon automatically detects stuck or struggling agents and can trigger interventions.
-
-**Check for stuck agents**:
-```bash
-# Run stuck detection check
-./.loom/scripts/stuck-detection.sh check
-
-# Check with JSON output
-./.loom/scripts/stuck-detection.sh check --json
-
-# Check specific agent
-./.loom/scripts/stuck-detection.sh check-agent shepherd-1
-```
-
-**View stuck detection status**:
-```bash
-# Show status summary
-./.loom/scripts/stuck-detection.sh status
-
-# View intervention history
-./.loom/scripts/stuck-detection.sh history
-./.loom/scripts/stuck-detection.sh history shepherd-1
-```
-
-**Configure stuck detection thresholds**:
-```bash
-# Adjust thresholds
-./.loom/scripts/stuck-detection.sh configure \
-  --idle-threshold 900 \
-  --working-threshold 2400 \
-  --intervention-mode escalate
-
-# Intervention modes: none, alert, suggest, pause, clarify, escalate
-```
-
-**Handle stuck agents**:
-```bash
-# Clear intervention for specific agent
-./.loom/scripts/stuck-detection.sh clear shepherd-1
-
-# Clear all interventions
-./.loom/scripts/stuck-detection.sh clear all
-
-# Resume a paused agent
-./.loom/scripts/signal.sh clear shepherd-1
-```
-
-**Stuck indicators**:
-| Indicator | Default Threshold | Description |
-|-----------|-------------------|-------------|
-| `no_progress` | 10 minutes | No output written to task output file |
-| `extended_work` | 30 minutes | Working on same issue without creating PR |
-| `looping` | 3 occurrences | Repeated similar error patterns |
-| `error_spike` | 5 errors | Multiple errors in short period |
-
-**Intervention types**:
-| Type | Trigger | Action |
-|------|---------|--------|
-| `alert` | Low severity | Write to `.loom/interventions/`, human reviews |
-| `suggest` | Medium severity | Suggest role switch (e.g., Builder -> Doctor) |
-| `pause` | High severity | Auto-pause via signal.sh, requires manual restart |
-| `clarify` | Error spike | Suggest requesting clarification from issue author |
-| `escalate` | Critical | Full escalation: pause + alert + human notification |
-
-### Daemon Troubleshooting (Layer 2)
-
-**Check daemon state**:
-```bash
-# View current daemon state
-cat .loom/daemon-state.json | jq
-
-# Check if daemon is running
-jq '.running' .loom/daemon-state.json
-
-# View active shepherds
-jq '.shepherds | to_entries[] | select(.value.issue != null)' .loom/daemon-state.json
-```
-
-**Graceful shutdown**:
-```bash
-# Signal daemon to stop
-touch .loom/stop-daemon
-
-# Monitor shutdown progress
-watch -n 5 'cat .loom/daemon-state.json | jq ".shepherds"'
-```
-
-**Force stop** (use with caution):
-```bash
-# Remove stop signal if exists
-rm -f .loom/stop-daemon
-
-# Clear daemon state (will restart fresh)
-rm -f .loom/daemon-state.json
-```
-
-**Stuck shepherd**:
-```bash
-# Check shepherd assignments
-jq '.shepherds' .loom/daemon-state.json
-
-# Check if assigned issue is blocked
-gh issue view <issue-number> --json labels --jq '.labels[].name'
-
-# Manually clear stuck shepherd (daemon will reassign)
-jq '.shepherds["shepherd-1"] = {"issue": null, "idle_since": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"}' \
-  .loom/daemon-state.json > tmp.json && mv tmp.json .loom/daemon-state.json
-```
-
-**Work generation not triggering**:
-```bash
-# Check issue count vs threshold
-echo "Ready issues: $(gh issue list --label 'loom:issue' --state open --json number --jq 'length')"
-echo "Threshold: 3 (default)"
-
-# Check cooldown timestamps
-jq '.last_architect_trigger, .last_hermit_trigger' .loom/daemon-state.json
-
-# Check proposal count
-echo "Proposals: $(gh issue list --label 'loom:architect,loom:hermit' --state open --json number --jq 'length')"
-```
-
-## MCP Hooks for Programmatic Control
-
-Loom provides a unified MCP (Model Context Protocol) server that allows Claude Code to programmatically control the Loom application. This enables automation, testing, and advanced workflows.
-
-### Unified MCP Server
-
-All Loom MCP tools are now provided through a single `mcp-loom` package, consolidating the previous `mcp-loom-logs`, `mcp-loom-ui`, and `mcp-loom-terminals` packages.
-
-**Log Tools:**
-- `tail_daemon_log` - Tail daemon log file
-- `tail_tauri_log` - Tail Tauri application log
-- `list_terminal_logs` - List available terminal output logs
-- `tail_terminal_log` - Tail a specific terminal's output log
-
-**Terminal Tools:**
-- `list_terminals` - List all active terminal sessions
-- `get_terminal_output` - Get recent output from a terminal
-- `get_selected_terminal` - Get info about the currently selected terminal
-- `send_terminal_input` - Send input to a terminal
-- `create_terminal` - Create a new terminal session
-- `delete_terminal` - Delete a terminal session
-- `restart_terminal` - Restart a terminal preserving its config
-- `configure_terminal` - Update terminal settings (name, role, interval)
-- `set_primary_terminal` - Set which terminal is selected in the UI
-- `clear_terminal_history` - Clear terminal scrollback and log file
-- `check_tmux_server_health` - Check tmux server status
-- `get_tmux_server_info` - Get tmux server details
-- `toggle_tmux_verbose_logging` - Enable tmux debug logging
-- `start_autonomous_mode` - Start autonomous mode for all terminals
-- `stop_autonomous_mode` - Stop autonomous mode
-- `launch_interval` - Manually trigger interval prompt
-- `get_agent_metrics` - Get agent performance metrics for self-aware behavior
-
-**UI Tools:**
-- `read_console_log` - Read browser console logs
-- `read_state_file` - Read workspace state
-- `read_config_file` - Read workspace config
-- `get_heartbeat` - Check if Loom app is running
-- `get_ui_state` - Get comprehensive UI state (terminals, workspace, engine)
-- `trigger_start` - Start engine with confirmation dialog
-- `trigger_force_start` - Start engine without confirmation
-- `trigger_factory_reset` - Reset workspace with confirmation
-- `trigger_force_factory_reset` - Reset workspace without confirmation
-- `trigger_restart_terminal` - Restart a specific terminal
-- `stop_engine` - Stop all terminals and clean up
-- `trigger_run_now` - Execute interval prompt immediately
-- `get_random_file` - Get random file from workspace
-
-### Example Usage
-
-```bash
-# Create a terminal with specific role
-mcp__loom__create_terminal --name "Builder" --role "builder"
-
-# Configure autonomous operation
-mcp__loom__configure_terminal \
-  --terminal_id terminal-1 \
-  --target_interval 300000 \
-  --interval_prompt "Check for new issues"
-
-# Trigger immediate autonomous run
-mcp__loom__trigger_run_now --terminalId terminal-1
-
-# Stop all terminals
-mcp__loom__stop_engine
-
-# Get comprehensive state
-mcp__loom__get_ui_state
-
-# View logs
-mcp__loom__tail_daemon_log --lines 50
-```
-
-### Agent Performance Metrics
-
-Agents can query their own performance metrics to make informed decisions. This enables self-aware behavior where agents can:
-- Check if struggling with a task type and escalate
-- Select approaches based on historical success rates
-- Monitor costs and adjust behavior accordingly
-
-**Via MCP Tool**:
-```bash
-# Get overall metrics summary
+./.loom/scripts/agent-metrics.sh --role builder  # Check your effectiveness
 mcp__loom__get_agent_metrics --command summary --period week
-
-# Get effectiveness metrics for a specific role
-mcp__loom__get_agent_metrics --command effectiveness --role builder
-
-# Get cost breakdown for a specific issue
-mcp__loom__get_agent_metrics --command costs --issue 123
-
-# Get velocity trends
-mcp__loom__get_agent_metrics --command velocity
-```
-
-**Via CLI Script**:
-```bash
-# Get my metrics as a builder
-./.loom/scripts/agent-metrics.sh --role builder
-
-# Check effectiveness by role
-./.loom/scripts/agent-metrics.sh effectiveness
-
-# Get cost for specific issue
-./.loom/scripts/agent-metrics.sh costs --issue 123
-
-# JSON output for programmatic use
-./.loom/scripts/agent-metrics.sh summary --format json
-```
-
-**Metrics Available**:
-- **Summary**: Total prompts, tokens, cost, issues worked, PRs created, success rate
-- **Effectiveness**: Per-role success rates, average cost, average duration
-- **Costs**: Cost per issue, tokens per issue, time spent
-- **Velocity**: Issues closed, PRs merged, cycle time trends
-
-**Example Use Case (Agent Escalation)**:
-```bash
-# Check if success rate is below threshold
-success_rate=$(./loom/scripts/agent-metrics.sh --role builder --format json | jq '.success_rate')
-if (( $(echo "$success_rate < 70" | bc -l) )); then
-    echo "Consider escalating - success rate below threshold"
-fi
-```
-
-### MCP Server Configuration
-
-Add the unified Loom MCP server to your Claude Code configuration:
-
-```json
-{
-  "mcpServers": {
-    "loom": {
-      "command": "node",
-      "args": ["/path/to/loom/mcp-loom/dist/index.js"],
-      "env": {
-        "LOOM_WORKSPACE": "/path/to/your/workspace"
-      }
-    }
-  }
-}
-```
-
-Or run the setup script to generate `.mcp.json` automatically:
-
-```bash
-./scripts/setup-mcp.sh
 ```
 
 ## Resources
 
-### Loom Documentation
-
 - **Main Repository**: https://github.com/rjwalters/loom
-- **Getting Started**: https://github.com/rjwalters/loom#getting-started
-- **Role Definitions**: See `.loom/roles/*.md` in this repository
-- **Workflow Details**: See `.loom/AGENTS.md` in this repository
-
-### Local Configuration
-
-- **Configuration**: `.loom/config.json` (your local terminal setup)
-- **Role Definitions**: `.loom/roles/*.md` (default and custom roles)
-- **Scripts**: `.loom/scripts/` (helper scripts for worktrees, etc.)
-- **GitHub Labels**: `.github/labels.yml` (label definitions)
-
-## Support
-
-For issues with Loom itself:
-- **GitHub Issues**: https://github.com/rjwalters/loom/issues
-- **Documentation**: https://github.com/rjwalters/loom/blob/main/CLAUDE.md
-
-For issues specific to this repository:
-- Use the repository's normal issue tracker
-- Tag issues with Loom-related labels when applicable
+- **Role Definitions**: `.loom/roles/*.md`
+- **Label Definitions**: `.github/labels.yml`
+- **Troubleshooting**: `.loom/docs/troubleshooting.md`
+- **Daemon Reference**: `.loom/docs/daemon-reference.md`
+- **Scripts**: `.loom/scripts/`
 
 ---
 


### PR DESCRIPTION
## Summary

- Reduces CLAUDE.md from ~43.7k to ~11.5k characters (74% reduction)
- Extracts verbose documentation to `.loom/docs/` folder:
  - `troubleshooting.md` - All troubleshooting content
  - `daemon-reference.md` - Detailed daemon configuration
- Preserves all essential information with links to detailed docs
- Consolidates redundant content (labels now reference `.github/labels.yml`)
- Tightens prose, converts verbose explanations to tables

Closes #1246

## Test Plan

- [x] `wc -c CLAUDE.md` shows 11,461 characters (under 40,000 target)
- [ ] Links in CLAUDE.md resolve correctly to extracted docs
- [ ] Agent roles still load and function properly

---

Generated with [Claude Code](https://claude.ai/code)