### PR TITLE
Enable squash merge in Loom installer instead of regular merge

### DIFF
--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -889,16 +889,16 @@ The setup script configures these repository settings:
 
 | Setting | Value | Why |
 |---------|-------|-----|
-| `allow_merge_commit` | true | Default merge strategy - preserves clear history of PRs |
-| `allow_squash_merge` | false | Disabled - preserves individual commits from agents |
-| `allow_rebase_merge` | false | Disabled - keeps merge commits visible |
+| `allow_merge_commit` | false | Disabled - use squash merge instead |
+| `allow_squash_merge` | true | Default merge strategy - flattens PR to single commit |
+| `allow_rebase_merge` | false | Disabled - use squash merge instead |
 | `delete_branch_on_merge` | true | Auto-cleanup feature branches after merge |
 | `allow_auto_merge` | true | Enables Champion role to auto-merge approved PRs |
 | `allow_update_branch` | true | Suggests keeping branches up-to-date with base |
 
 #### Why These Settings?
 
-- **Merge commits only**: Maintains clear history showing which PRs introduced changes; important for understanding agent work
+- **Squash merge only**: Flattens each PR into a single commit for clean history; each issue becomes one atomic commit on main
 - **Delete branches after merge**: Prevents accumulation of stale branches from issue worktrees
 - **Auto-merge enabled**: Required for Champion role to automatically merge approved PRs
 - **Suggest updating branches**: Helps agents keep branches current with main

--- a/scripts/install/setup-repository-settings.sh
+++ b/scripts/install/setup-repository-settings.sh
@@ -5,7 +5,7 @@
 #   ./scripts/install/setup-repository-settings.sh /path/to/target-repo [--dry-run]
 #
 # Configures:
-#   - Merge strategy (merge commits only)
+#   - Merge strategy (squash merge only)
 #   - Auto-delete head branches
 #   - Allow auto-merge
 #   - Suggest updating branches
@@ -79,8 +79,8 @@ fi
 
 # Define the settings to apply
 SETTINGS_JSON='{
-  "allow_merge_commit": true,
-  "allow_squash_merge": false,
+  "allow_merge_commit": false,
+  "allow_squash_merge": true,
   "allow_rebase_merge": false,
   "delete_branch_on_merge": true,
   "allow_auto_merge": true,
@@ -95,8 +95,8 @@ if [[ "$DRY_RUN" == "true" ]]; then
   echo "  Repository: ${OWNER}/${REPO}"
   echo ""
   echo "  Settings to be configured:"
-  echo "    allow_merge_commit: true (preserve commit history)"
-  echo "    allow_squash_merge: false (disabled)"
+  echo "    allow_merge_commit: false (disabled)"
+  echo "    allow_squash_merge: true (default strategy - flattens PR to single commit)"
   echo "    allow_rebase_merge: false (disabled)"
   echo "    delete_branch_on_merge: true (auto-cleanup branches)"
   echo "    allow_auto_merge: true (enables Champion auto-merge)"
@@ -114,9 +114,9 @@ then
   success "Repository settings configured successfully"
   echo ""
   echo "Applied settings:"
-  echo "  - Allow merge commits: Yes (default strategy)"
-  echo "  - Allow squash merging: No (preserves commit history)"
-  echo "  - Allow rebase merging: No (keeps merge commits visible)"
+  echo "  - Allow merge commits: No (disabled)"
+  echo "  - Allow squash merging: Yes (default strategy - flattens PR to single commit)"
+  echo "  - Allow rebase merging: No (disabled)"
   echo "  - Delete branches on merge: Yes (auto-cleanup)"
   echo "  - Allow auto-merge: Yes (enables Champion workflow)"
   echo "  - Suggest updating branches: Yes"
@@ -134,8 +134,8 @@ else
   echo "  1. Go to: https://github.com/${OWNER}/${REPO}/settings"
   echo "  2. Scroll to 'Pull Requests' section"
   echo "  3. Configure merge options:"
-  echo "     - Enable: Allow merge commits"
-  echo "     - Disable: Allow squash merging"
+  echo "     - Disable: Allow merge commits"
+  echo "     - Enable: Allow squash merging"
   echo "     - Disable: Allow rebase merging"
   echo "     - Enable: Always suggest updating pull request branches"
   echo "     - Enable: Automatically delete head branches"


### PR DESCRIPTION
## Summary

Fix installer to enable squash merge (which Shepherd and Champion roles use) instead of disabling it.

## Changes

- `scripts/install/setup-repository-settings.sh`: Set `allow_merge_commit=false`, `allow_squash_merge=true`
- `defaults/CLAUDE.md`: Updated Repository Settings documentation to reflect squash merge strategy

## Root Cause

The Loom installer (`scripts/install/setup-repository-settings.sh`) was setting:
```json
{
  "allow_merge_commit": true,
  "allow_squash_merge": false  // Disabled!
}
```

But Shepherd and Champion roles use `gh pr merge --squash`, which fails with "Squash merges are not allowed on this repository".

## Test Plan

- [ ] Run `./scripts/install/setup-repository-settings.sh /path/to/repo --dry-run` and verify output shows squash merge enabled
- [ ] Install on a fresh repository and verify GitHub settings show squash merge enabled
- [ ] Run `/shepherd <issue> --force-merge` on an installed repo - merge should succeed

Closes #1258