### PR TITLE
Integrate Auditor agent into daemon as main branch validator

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -47,18 +47,6 @@
   description: PR approved by Judge, ready for human to merge
   color: "3B82F6"  # blue-500
 
-- name: loom:auditing
-  description: Auditor is verifying runtime behavior of this PR
-  color: "F59E0B"  # amber-500 - matches other in-progress states
-
-- name: loom:audited
-  description: PR passed runtime audit by Auditor
-  color: "10B981"  # emerald-500 - success state
-
-- name: loom:audit-failed
-  description: PR failed runtime audit (bug issue created)
-  color: "EF4444"  # red-500 - failure state
-
 # Agent Proposal Labels
 - name: loom:architect
   description: Architect proposal awaiting user approval

--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -16,6 +16,10 @@ Detailed configuration and state management for the Loom daemon (Layer 2).
 | `HERMIT_COOLDOWN` | 1800 | Seconds between Hermit role triggers (30 min) |
 | `MAX_ARCHITECT_PROPOSALS` | 2 | Maximum open `loom:architect` proposals before stopping triggers |
 | `MAX_HERMIT_PROPOSALS` | 2 | Maximum open `loom:hermit` proposals before stopping triggers |
+| `GUIDE_INTERVAL` | 900 | Seconds between Guide role re-triggers (15 min) |
+| `CHAMPION_INTERVAL` | 600 | Seconds between Champion role re-triggers (10 min) |
+| `DOCTOR_INTERVAL` | 300 | Seconds between Doctor role re-triggers (5 min) |
+| `AUDITOR_INTERVAL` | 600 | Seconds between Auditor role re-triggers (10 min) |
 
 ## Work Generation
 
@@ -252,3 +256,4 @@ Archived sessions include a `session_summary` field with final statistics:
 | terminal-guide | guide.md | Backlog triage (always running) |
 | terminal-champion | champion.md | Auto-merge (always running) |
 | terminal-doctor | doctor.md | PR conflict resolution (always running) |
+| terminal-auditor | auditor.md | Main branch validation (always running) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ Launch the Loom desktop application for automated orchestration:
 | Doctor | `doctor.md` | Fix bugs and address PR feedback | Manual |
 | Guide | `guide.md` | Prioritize and triage issues | Autonomous 15min |
 | Driver | `driver.md` | Direct command execution | Manual |
-| Auditor | `auditor.md` | Verify runtime behavior of built software | Autonomous 10min |
+| Auditor | `auditor.md` | Validate main branch build and runtime | Autonomous 10min |
 
 Full role definitions: `.loom/roles/*.md`
 
@@ -469,6 +469,7 @@ Archived sessions include a `session_summary` field with final statistics:
 | terminal-guide | guide.md | Backlog triage (always running) |
 | terminal-champion | champion.md | Auto-merge (always running) |
 | terminal-doctor | doctor.md | PR conflict resolution (always running) |
+| terminal-auditor | auditor.md | Main branch validation (always running) |
 
 ### Custom Roles
 

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -306,6 +306,11 @@ Loom provides specialized roles for different development tasks. Each role follo
 - **Workflow**: Plain shell environment for custom tasks
 - **When to use**: Ad-hoc tasks, debugging, manual operations
 
+**Auditor** (Autonomous 10min, `auditor.md`)
+- **Purpose**: Validate main branch build and runtime
+- **Workflow**: Pulls main → builds → tests → runs → creates bug issues if problems found
+- **When to use**: Continuous integration health monitoring
+
 ### Role Definitions
 
 Full role definitions with detailed guidelines are available in:
@@ -319,6 +324,7 @@ Full role definitions with detailed guidelines are available in:
 - `.loom/roles/architect.md` - Architectural proposals
 - `.loom/roles/hermit.md` - Code simplification
 - `.loom/roles/guide.md` - Issue triage and prioritization
+- `.loom/roles/auditor.md` - Main branch validation
 
 ## Label-Based Workflow
 


### PR DESCRIPTION
## Summary

- Add Auditor as a daemon support role with 10-minute cooldown interval
- Refocus auditor.md from PR-level auditing to main branch validation (build/test/run verification)
- Update daemon-snapshot.sh to track auditor state and include trigger_auditor in recommended_actions
- Remove unused labels (loom:auditing, loom:audited, loom:audit-failed) that were for PR-level auditing
- Update documentation across CLAUDE.md, daemon-reference.md, and defaults/CLAUDE.md

## Test plan

- [ ] Verify daemon-snapshot.sh syntax is valid (bash -n passed)
- [ ] Verify auditor appears in support_roles output of daemon-snapshot.sh
- [ ] Verify trigger_auditor appears in recommended_actions when auditor is idle
- [ ] Verify AUDITOR_INTERVAL environment variable is documented and used
- [ ] Verify labels.yml no longer contains loom:auditing, loom:audited, loom:audit-failed

Closes #1268

---
Generated with [Claude Code](https://claude.com/claude-code)