### PR TITLE
Fix daemon iteration subagents CLI option errors for support roles

### DIFF
--- a/defaults/.claude/commands/loom.md
+++ b/defaults/.claude/commands/loom.md
@@ -168,7 +168,9 @@ In Manual Orchestration Mode, use the **Task tool with `run_in_background: true`
 ```
 Task(
   subagent_type: "general-purpose",
-  prompt: """Execute the shepherd workflow by invoking the Skill tool:
+  prompt: """You must invoke the Skill tool to execute the shepherd workflow.
+
+IMPORTANT: Do NOT use CLI commands like 'claude --skill=shepherd'. Use the Skill tool:
 
 Skill(skill="shepherd", args="123 --force-pr")
 
@@ -177,7 +179,21 @@ Follow all shepherd workflow steps until the issue is complete or blocked.""",
 ) → Returns task_id and output_file
 ```
 
-**IMPORTANT**: Task subagents don't automatically interpret slash commands (like `/shepherd`) as Skill invocations. They see the prompt as plain text. You MUST explicitly instruct the subagent to use the Skill tool with `Skill(skill="...", args="...")` syntax.
+**CRITICAL - Correct Tool Invocation**: Task subagents must use the **Skill tool**, NOT CLI commands.
+
+```
+✅ CORRECT - Use the Skill tool:
+   Skill(skill="guide")
+   Skill(skill="shepherd", args="123 --force-pr")
+
+❌ WRONG - These will fail with CLI errors:
+   claude --skill=guide
+   claude --role guide
+   /guide
+   bash("claude --skill=guide")
+```
+
+Task subagents receive their prompts as plain text. They must be explicitly instructed to invoke the Skill tool. The prompts in this file use `Skill(skill="...")` notation which the subagent should interpret as a tool call.
 
 ### Task Spawn Verification
 
@@ -204,6 +220,18 @@ def verify_task_spawn(result, description="task"):
         # If we get here without exception, task exists
         # Status can be "running", "completed", or "failed"
         if check.status in ["running", "completed"]:
+            # Check output for CLI error patterns that indicate misuse
+            if check.output:
+                cli_error_patterns = [
+                    "error: unknown option",
+                    "Did you mean",
+                    "unrecognized command",
+                    "command not found"
+                ]
+                for pattern in cli_error_patterns:
+                    if pattern in check.output:
+                        print(f"  SPAWN FAILED: {description} - CLI error detected: {pattern}")
+                        return False
             return True
         elif check.status == "failed":
             print(f"  SPAWN FAILED: {description} - task immediately failed")
@@ -219,6 +247,7 @@ def verify_task_spawn(result, description="task"):
 - Task() can return a task_id even when the underlying spawn fails
 - Recording invalid task_ids pollutes daemon-state.json
 - Invalid task_ids cause `TaskOutput` to report "completed" spuriously
+- CLI error patterns (like "error: unknown option") indicate the subagent misinterpreted the prompt
 - This leads to incorrect shepherd completion detection and state corruption
 
 ## Iteration Mode (`/loom iterate`)
@@ -509,7 +538,9 @@ def auto_spawn_shepherds():
         # because Task subagents don't automatically interpret slash commands.
         result = Task(
             description=f"Shepherd issue #{issue}",
-            prompt=f"""Execute the shepherd workflow by invoking the Skill tool:
+            prompt=f"""You must invoke the Skill tool to execute the shepherd workflow.
+
+IMPORTANT: Do NOT use CLI commands like 'claude --skill=shepherd'. Use the Skill tool:
 
 Skill(skill="shepherd", args="{issue} --force-pr")
 
@@ -545,7 +576,9 @@ def auto_generate_work():
         if architect_cooldown_ok() and architect_proposals < 2:
             result = Task(
                 description="Architect work generation",
-                prompt="""Execute the architect role by invoking the Skill tool:
+                prompt="""You must invoke the Skill tool to execute the architect role.
+
+IMPORTANT: Do NOT use CLI commands like 'claude --skill=architect'. Use the Skill tool:
 
 Skill(skill="architect", args="--autonomous")
 
@@ -562,7 +595,9 @@ Complete one work generation iteration.""",
         if hermit_cooldown_ok() and hermit_proposals < 2:
             result = Task(
                 description="Hermit simplification proposals",
-                prompt="""Execute the hermit role by invoking the Skill tool:
+                prompt="""You must invoke the Skill tool to execute the hermit role.
+
+IMPORTANT: Do NOT use CLI commands like 'claude --skill=hermit'. Use the Skill tool:
 
 Skill(skill="hermit")
 
@@ -587,7 +622,9 @@ def auto_ensure_support_roles():
     if not guide_is_running() or guide_idle_time() > GUIDE_INTERVAL:
         result = Task(
             description="Guide backlog triage",
-            prompt="""Execute the guide role by invoking the Skill tool:
+            prompt="""You must invoke the Skill tool to execute the guide role.
+
+IMPORTANT: Do NOT use CLI commands like 'claude --skill=guide'. Use the Skill tool:
 
 Skill(skill="guide")
 
@@ -603,7 +640,9 @@ Complete one triage iteration.""",
     if not champion_is_running() or champion_idle_time() > CHAMPION_INTERVAL:
         result = Task(
             description="Champion PR merge",
-            prompt="""Execute the champion role by invoking the Skill tool:
+            prompt="""You must invoke the Skill tool to execute the champion role.
+
+IMPORTANT: Do NOT use CLI commands like 'claude --skill=champion'. Use the Skill tool:
 
 Skill(skill="champion")
 
@@ -619,7 +658,9 @@ Complete one PR evaluation and merge iteration.""",
     if not doctor_is_running() or doctor_idle_time() > DOCTOR_INTERVAL:
         result = Task(
             description="Doctor PR conflict resolution",
-            prompt="""Execute the doctor role by invoking the Skill tool:
+            prompt="""You must invoke the Skill tool to execute the doctor role.
+
+IMPORTANT: Do NOT use CLI commands like 'claude --skill=doctor'. Use the Skill tool:
 
 Skill(skill="doctor")
 
@@ -1088,7 +1129,9 @@ def auto_spawn_shepherds(debug_mode=False):
         # because Task subagents don't automatically interpret slash commands.
         result = Task(
             description=f"Shepherd issue #{issue}",
-            prompt=f"""Execute the shepherd workflow by invoking the Skill tool:
+            prompt=f"""You must invoke the Skill tool to execute the shepherd workflow.
+
+IMPORTANT: Do NOT use CLI commands like 'claude --skill=shepherd'. Use the Skill tool:
 
 Skill(skill="shepherd", args="{issue} --force-pr")
 
@@ -1154,7 +1197,9 @@ def trigger_architect_role(state, debug_mode=False):
 
     result = Task(
         description="Architect work generation",
-        prompt="""Execute the architect role by invoking the Skill tool:
+        prompt="""You must invoke the Skill tool to execute the architect role.
+
+IMPORTANT: Do NOT use CLI commands like 'claude --skill=architect'. Use the Skill tool:
 
 Skill(skill="architect", args="--autonomous")
 
@@ -1190,7 +1235,9 @@ def trigger_hermit_role(state, debug_mode=False):
 
     result = Task(
         description="Hermit simplification proposals",
-        prompt="""Execute the hermit role by invoking the Skill tool:
+        prompt="""You must invoke the Skill tool to execute the hermit role.
+
+IMPORTANT: Do NOT use CLI commands like 'claude --skill=hermit'. Use the Skill tool:
 
 Skill(skill="hermit")
 
@@ -1258,7 +1305,9 @@ def auto_ensure_support_roles(debug_mode=False):
     if not guide_running or guide_idle > GUIDE_INTERVAL:
         result = Task(
             description="Guide backlog triage",
-            prompt="""Execute the guide role by invoking the Skill tool:
+            prompt="""You must invoke the Skill tool to execute the guide role.
+
+IMPORTANT: Do NOT use CLI commands like 'claude --skill=guide'. Use the Skill tool:
 
 Skill(skill="guide")
 
@@ -1286,7 +1335,9 @@ Complete one triage iteration.""",
     if not champion_running or champion_idle > CHAMPION_INTERVAL:
         result = Task(
             description="Champion PR merge",
-            prompt="""Execute the champion role by invoking the Skill tool:
+            prompt="""You must invoke the Skill tool to execute the champion role.
+
+IMPORTANT: Do NOT use CLI commands like 'claude --skill=champion'. Use the Skill tool:
 
 Skill(skill="champion")
 
@@ -1314,7 +1365,9 @@ Complete one PR evaluation and merge iteration.""",
     if not doctor_running or doctor_idle > DOCTOR_INTERVAL:
         result = Task(
             description="Doctor PR conflict resolution",
-            prompt="""Execute the doctor role by invoking the Skill tool:
+            prompt="""You must invoke the Skill tool to execute the doctor role.
+
+IMPORTANT: Do NOT use CLI commands like 'claude --skill=doctor'. Use the Skill tool:
 
 Skill(skill="doctor")
 
@@ -1342,7 +1395,9 @@ Complete one PR conflict resolution iteration.""",
     if not auditor_running or auditor_idle > AUDITOR_INTERVAL:
         result = Task(
             description="Auditor main branch validation",
-            prompt="""Execute the auditor role by invoking the Skill tool:
+            prompt="""You must invoke the Skill tool to execute the auditor role.
+
+IMPORTANT: Do NOT use CLI commands like 'claude --skill=auditor'. Use the Skill tool:
 
 Skill(skill="auditor")
 


### PR DESCRIPTION
## Summary

Fix the bug where daemon iteration subagents were using invalid CLI options (like `--role` or `--skill=`) to spawn support roles instead of properly invoking the Skill tool.

## Changes

1. **Enhanced the IMPORTANT section** (now CRITICAL) with explicit examples of correct vs incorrect patterns:
   - Correct: `Skill(skill="guide")`
   - Wrong: `claude --skill=guide`, `claude --role guide`, `/guide`

2. **Updated all Task prompts** for support roles (Guide, Champion, Doctor, Auditor, Architect, Hermit, Shepherd) to:
   - Start with "You must invoke the Skill tool..."
   - Include explicit warning: "Do NOT use CLI commands like 'claude --skill=...'"
   - Keep the Skill tool syntax example

3. **Enhanced `verify_task_spawn`** to detect CLI error patterns in task output:
   - Checks for "error: unknown option", "Did you mean", "unrecognized command", "command not found"
   - Logs CLI error detection for debugging

## Test Plan

- [ ] Run `/loom --force` in a test repository
- [ ] Check `.loom/daemon-state.json` support_roles section has valid task_ids
- [ ] Verify task output files show successful skill invocations (no CLI errors)
- [ ] Run `grep -i "error: unknown option" /tmp/claude/.../task-*.output` to confirm no CLI errors

Closes #1275