### PR TITLE
Add explicit mode detection to prevent daemon context accumulation

### DIFF
--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -158,7 +158,31 @@ Launch the Loom desktop application for automated orchestration with visual term
 
 Run the Loom daemon for fully autonomous system orchestration.
 
-**Setup**:
+**Two options for running the daemon:**
+
+| Option | Command | Best For |
+|--------|---------|----------|
+| **Shell Wrapper** (recommended) | `./.loom/scripts/daemon-loop.sh` | Production, long-running sessions |
+| **LLM-interpreted** | `/loom` | Development, debugging, testing |
+
+**Option A: Shell Wrapper (Recommended for Production)**
+
+```bash
+# Start daemon with shell wrapper
+./.loom/scripts/daemon-loop.sh
+
+# Start in force mode
+./.loom/scripts/daemon-loop.sh --force
+
+# Run in background
+nohup ./.loom/scripts/daemon-loop.sh --force > /dev/null 2>&1 &
+
+# Custom poll interval (default: 120s)
+LOOM_POLL_INTERVAL=60 ./.loom/scripts/daemon-loop.sh
+```
+
+**Option B: LLM-interpreted (For Development/Testing)**
+
 ```bash
 # Start the daemon (runs continuously)
 /loom
@@ -172,6 +196,8 @@ Run the Loom daemon for fully autonomous system orchestration.
 # 3. Spawn shepherds for ready issues
 # 4. Ensure Guide and Champion keep running
 ```
+
+**Note**: The `/loom` command relies on the LLM correctly implementing the two-tier architecture (parent loop spawning iteration subagents). While this generally works, the shell wrapper provides more deterministic behavior for production use.
 
 **Force Mode** (`--force`):
 
@@ -209,38 +235,17 @@ touch .loom/stop-daemon
 # 3. Clean up state and exit
 ```
 
-**Shell Script Wrapper** (Alternative to LLM-interpreted loop):
-
-For more deterministic daemon operation, use the shell script wrapper instead of the LLM-interpreted parent loop:
-
-```bash
-# Start daemon with shell wrapper (recommended for production)
-./.loom/scripts/daemon-loop.sh
-
-# Start in force mode
-./.loom/scripts/daemon-loop.sh --force
-
-# Run in background
-nohup ./.loom/scripts/daemon-loop.sh --force > /dev/null 2>&1 &
-
-# Custom poll interval (default: 120s)
-LOOM_POLL_INTERVAL=60 ./.loom/scripts/daemon-loop.sh
-
-# Stop daemon gracefully (same as regular daemon)
-touch .loom/stop-daemon
-```
-
 **Why use the shell wrapper?**
-- Deterministic loop behavior (no LLM interpretation variability)
-- Timeout protection prevents hung iterations (default: 5 minutes)
-- Can run in background, screen, or tmux
-- Consistent logging to `.loom/daemon.log`
-- Each iteration is a fresh Claude session (no context accumulation)
+- **Deterministic loop behavior**: No LLM interpretation variability
+- **Timeout protection**: Prevents hung iterations (default: 5 minutes)
+- **Background operation**: Can run in background, screen, or tmux
+- **Consistent logging**: Logs to `.loom/daemon.log`
+- **Context isolation**: Each iteration is a fresh Claude session (no context accumulation)
 
-**Trade-offs**:
+**Trade-offs of shell wrapper**:
 - Requires `claude` CLI in PATH
 - Slightly higher latency per iteration (CLI startup)
-- No conversation context between iterations (by design)
+- No conversation context between iterations (by design - this is a feature for long-running operation)
 
 ## Agent Roles
 


### PR DESCRIPTION
## Summary

- Add "CRITICAL: Mode Detection" section at the start of `loom.md` that forces the LLM to consciously check arguments and choose the correct execution mode
- Update `CLAUDE.md` to recommend the shell wrapper for production daemon use and clarify reliability differences between the two approaches
- Reorganize daemon mode documentation with a clear comparison table

## Problem

When running `/loom --force`, the daemon was running as a single long-running agent that accumulated full context from all tool calls, eventually hitting context limits. This happened because the LLM did not reliably implement the documented two-tier architecture (parent loop spawning iteration subagents).

## Solution

Added explicit mode detection at the very start of `loom.md` that:

1. Makes mode selection explicit and unambiguous with a clear decision tree
2. Documents the failure mode to avoid (running iteration logic directly in parent context causes context accumulation)
3. Provides clear instructions for which code path to execute based on the presence of "iterate" in arguments

Also updated documentation to recommend the shell wrapper (`daemon-loop.sh`) for production use, which provides deterministic behavior without relying on LLM interpretation.

## Test Plan

- [ ] Verify `/loom --force` correctly spawns iteration subagents instead of running iteration logic directly
- [ ] Verify `/loom iterate --force` executes exactly one iteration and returns a compact summary
- [ ] Verify documentation clearly explains the two options for running the daemon

Closes #1286

---
Generated with [Claude Code](https://claude.com/claude-code)