### PR TITLE
Fix hardcoded 'defaults/' paths in role files breaking installed workspaces

### DIFF
--- a/defaults/.claude/commands/architect.md
+++ b/defaults/.claude/commands/architect.md
@@ -164,7 +164,7 @@ When creating a proposal:
 4. **Create the issue**: Use `gh issue create` with focused recommendation
 5. **Add labels**: `loom:architect` + tier label
 
-**For templates and examples**, read `defaults/.claude/commands/architect-patterns.md`.
+**For templates and examples**, read `.claude/commands/architect-patterns.md`.
 
 ### Quick Issue Creation
 
@@ -202,7 +202,7 @@ For large features that span multiple phases (4+ issues with dependencies), crea
 - Multiple shepherds could work in parallel
 - Implementation order matters
 
-**For epic templates and workflow**, read `defaults/.claude/commands/architect-patterns.md`.
+**For epic templates and workflow**, read `.claude/commands/architect-patterns.md`.
 
 ```bash
 # Create epic issue
@@ -260,7 +260,7 @@ Regularly review:
 - **Champion rejects**: Closes issue with explanation
 - **Builder implements**: Picks up `loom:issue` issues
 
-**For detailed label workflow and exceptions**, read `defaults/.claude/commands/architect-reference.md`.
+**For detailed label workflow and exceptions**, read `.claude/commands/architect-reference.md`.
 
 ---
 

--- a/defaults/.claude/commands/hermit.md
+++ b/defaults/.claude/commands/hermit.md
@@ -4,7 +4,7 @@ You are a code simplification specialist working in the {{workspace}} repository
 
 ## Reference Files
 
-For detailed patterns, examples, and scripts, see: `defaults/.claude/commands/hermit-patterns.md`
+For detailed patterns, examples, and scripts, see: `.claude/commands/hermit-patterns.md`
 
 ## Your Role
 

--- a/defaults/.claude/commands/loom.md
+++ b/defaults/.claude/commands/loom.md
@@ -13,14 +13,14 @@ Arguments provided: `{{ARGUMENTS}}`
 ```
 IF arguments contain "iterate":
     -> Execute ITERATION MODE
-    -> Read and follow: defaults/.claude/commands/loom-iteration.md
+    -> Read and follow: .claude/commands/loom-iteration.md
     -> Run exactly ONE iteration with fresh context
     -> Return a compact 1-line summary and EXIT
     -> DO NOT loop, DO NOT spawn iteration subagents
 
 ELSE (no "iterate" in arguments, e.g., "/loom" or "/loom --force"):
     -> Execute PARENT LOOP MODE
-    -> Read and follow: defaults/.claude/commands/loom-parent.md
+    -> Read and follow: .claude/commands/loom-parent.md
     -> Run the THIN parent loop
     -> Spawn iteration subagents via Task() for each iteration
     -> Continue until shutdown signal
@@ -50,8 +50,8 @@ ELSE (no "iterate" in arguments, e.g., "/loom" or "/loom --force"):
 
 Before proceeding, check the arguments: `{{ARGUMENTS}}`
 
-- Contains "iterate"? -> Read `defaults/.claude/commands/loom-iteration.md` and execute iteration mode
-- No "iterate"? -> Read `defaults/.claude/commands/loom-parent.md` and execute parent loop mode
+- Contains "iterate"? -> Read `.claude/commands/loom-iteration.md` and execute iteration mode
+- No "iterate"? -> Read `.claude/commands/loom-parent.md` and execute parent loop mode
 
 ## Two-Tier Architecture Overview
 
@@ -141,12 +141,12 @@ You do NOT require human input for any of the above. The only human intervention
 Based on the arguments `{{ARGUMENTS}}`:
 
 1. **Read the appropriate mode file:**
-   - For parent mode: Read `defaults/.claude/commands/loom-parent.md`
-   - For iteration mode: Read `defaults/.claude/commands/loom-iteration.md`
+   - For parent mode: Read `.claude/commands/loom-parent.md`
+   - For iteration mode: Read `.claude/commands/loom-iteration.md`
 
 2. **Follow the instructions in that file** to execute the daemon
 
-3. **For reference documentation:** See `defaults/.claude/commands/loom-reference.md`
+3. **For reference documentation:** See `.claude/commands/loom-reference.md`
 
 ## Terminal Probe Protocol
 

--- a/defaults/.claude/commands/shepherd.md
+++ b/defaults/.claude/commands/shepherd.md
@@ -23,7 +23,7 @@ This role definition is split across multiple files for maintainability:
 | **shepherd.md** (this file) | Core orchestration role, principles, phase flow, error handling |
 | **shepherd-lifecycle.md** | Detailed workflow steps, MCP terminal management, state tracking |
 
-For detailed step-by-step workflow examples, MCP terminal triggering sequences, and auto-configuration logic, read `defaults/.claude/commands/shepherd-lifecycle.md`.
+For detailed step-by-step workflow examples, MCP terminal triggering sequences, and auto-configuration logic, read `.claude/commands/shepherd-lifecycle.md`.
 
 ## Core Principles
 


### PR DESCRIPTION
## Summary

- Fixes hardcoded `defaults/.claude/commands/` path references in role files that break the `/loom` command in installed workspaces
- Replaces 12 path references across 4 files with `.claude/commands/` which works in both source and installed repos
- **Root cause**: After installation, agents try to read files like `defaults/.claude/commands/loom-parent.md` which doesn't exist - the files are at `.claude/commands/` instead

## Test plan

- [ ] Verify `grep -r "defaults/" defaults/.claude/commands/*.md` returns no results
- [ ] `/loom --force` works in the Loom source repository
- [ ] After installing to a fresh repo, `/loom --force` works in the installed workspace

Closes #1308

Generated with [Claude Code](https://claude.com/claude-code)