### PR TITLE
Fix hardcoded defaults/ path references in installed target repos

### DIFF
--- a/defaults/.loom-README.md
+++ b/defaults/.loom-README.md
@@ -92,7 +92,7 @@ Create `.loom/roles/my-role.json`:
 3. Configure autonomous mode if desired
 4. Save
 
-See [../defaults/roles/README.md](../defaults/roles/README.md) for detailed role creation guide.
+See the [Loom roles documentation](https://github.com/rjwalters/loom/blob/main/defaults/roles/README.md) for detailed role creation guide.
 
 ## Customizing Agent Configuration
 
@@ -128,7 +128,7 @@ To restore default configuration:
 1. **File** → **Factory Reset Workspace...**
 2. Confirm the operation
 3. All `.loom/` contents will be deleted
-4. Default configuration will be restored from `defaults/`
+4. Default configuration will be restored from Loom's bundled defaults
 
 **Warning**: This deletes all custom roles and configurations!
 
@@ -161,7 +161,7 @@ This allows teams to share agent roles and configurations while keeping runtime 
 
 ## More Information
 
-- System roles: [../defaults/roles/](../defaults/roles/)
-- Role creation guide: [../defaults/roles/README.md](../defaults/roles/README.md)
-- Workflow guide: [../WORKFLOWS.md](../WORKFLOWS.md)
-- Development guide: [../CLAUDE.md](../CLAUDE.md)
+- System roles: `.loom/roles/` (local copies) or [Loom defaults](https://github.com/rjwalters/loom/tree/main/defaults/roles)
+- Role creation guide: [Loom roles documentation](https://github.com/rjwalters/loom/blob/main/defaults/roles/README.md)
+- Workflow guide: [CLAUDE.md](../CLAUDE.md) (in your repository root)
+- Loom documentation: [https://github.com/rjwalters/loom](https://github.com/rjwalters/loom)

--- a/defaults/AGENTS.md
+++ b/defaults/AGENTS.md
@@ -1,7 +1,7 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-The Vite-powered frontend lives in `src/` with feature modules under `src/lib/` and colocated Vitest specs (`*.test.ts`). Tauri glue code and native bindings reside in `src-tauri/`, while the Rust daemon runs from `loom-daemon/`. Runtime defaults and role templates sit in `defaults/` and `.loom/roles/`; automation helpers live in `scripts/`, and production bundles emit to `dist/`.
+Role templates and runtime configuration live in `.loom/roles/`. Custom roles can be created in this directory and will be available in both the CLI (via `/my-role`) and the Tauri App terminal settings.
 
 ## Build, Test, and Development Commands
 - `pnpm app:dev` boots the daemon then Tauri for an end-to-end local session.
@@ -54,4 +54,4 @@ If a previous agent abandoned work on an issue, you can resume seamlessly:
 The script is **non-interactive** and automatically reuses existing branches, making it safe for AI agents to resume abandoned work without user intervention.
 
 ## Daemon & Configuration Notes
-Agent role prompts live under `.loom/roles/`; keep Markdown and any sibling JSON metadata in sync. Workspace overrides persist in `~/.loom/`, so mention reset steps (`Help → Daemon Status → Yes`) when altering stateful behavior. Document new environment variables or defaults under `defaults/` before requesting review.
+Agent role prompts live under `.loom/roles/`; keep Markdown and any sibling JSON metadata in sync. Workspace overrides persist in `~/.loom/`, so mention reset steps (`Help → Daemon Status → Yes`) when altering stateful behavior.

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -1312,7 +1312,7 @@ LOOM_STUCK_AGENT_THRESHOLD=10        # Minutes without heartbeat
 LOOM_ERROR_RATE_THRESHOLD=20         # % error rate threshold
 ```
 
-Or via `defaults/config.json`:
+Or via `.loom/config.json`:
 
 ```json
 {


### PR DESCRIPTION
## Summary
- Fix broken documentation links and references that point to `defaults/` paths that don't exist in installed target repositories
- Replace relative `../defaults/` paths with GitHub URLs or local `.loom/` paths as appropriate
- Update `defaults/config.json` reference to `.loom/config.json` (the actual location in installed repos)

## Test plan
- [ ] Verify no `defaults/` references remain in files that get copied to target repos (except URLs to source repo)
- [ ] Check that documentation links in installed repos point to valid locations

Closes #1312

---
Generated with [Claude Code](https://claude.com/claude-code)