### PR TITLE
Fix Task() subagent_type documentation to use general-purpose

### DIFF
--- a/defaults/.claude/README.md
+++ b/defaults/.claude/README.md
@@ -186,10 +186,12 @@ The Loom Shepherd (or daemon) can spawn subagents for each phase:
 
 ```python
 # Spawn builder subagent with fresh context
+# Note: subagent_type is always "general-purpose" - role selection
+# happens via the slash command in the prompt (e.g., "/builder 123")
 result = Task(
     description="Builder phase for issue #123",
     prompt="/builder 123",
-    subagent_type="loom-builder",
+    subagent_type="general-purpose",
     run_in_background=False
 )
 ```
@@ -205,7 +207,7 @@ result = Task(
 | Feature | Slash Commands | Subagents |
 |---------|----------------|-----------|
 | Context | Shared with main conversation | Isolated, fresh context |
-| Invocation | `/builder 123` | `Task(subagent_type="loom-builder")` |
+| Invocation | `/builder 123` | `Task(subagent_type="general-purpose", prompt="/builder 123")` |
 | Use case | Manual orchestration | Automated orchestration |
 | Visibility | In main conversation | Spawned as separate task |
 

--- a/defaults/.claude/commands/shepherd.md
+++ b/defaults/.claude/commands/shepherd.md
@@ -232,6 +232,7 @@ Example for each phase:
 result = Task(
     description=f"Curate issue #{issue_number}",
     prompt=f"/curator {issue_number}",
+    subagent_type="general-purpose",
     model="sonnet",
     run_in_background=False
 )
@@ -240,6 +241,7 @@ result = Task(
 result = Task(
     description=f"Build issue #{issue_number}",
     prompt=f"/builder {issue_number}",
+    subagent_type="general-purpose",
     model="opus",
     run_in_background=False
 )
@@ -248,6 +250,7 @@ result = Task(
 result = Task(
     description=f"Review PR #{pr_number}",
     prompt=f"/judge {pr_number}",
+    subagent_type="general-purpose",
     model="opus",
     run_in_background=False
 )
@@ -256,6 +259,7 @@ result = Task(
 result = Task(
     description=f"Address feedback on PR #{pr_number}",
     prompt=f"/doctor {pr_number}",
+    subagent_type="general-purpose",
     model="sonnet",
     run_in_background=False
 )


### PR DESCRIPTION
## Summary

- Updates `shepherd.md` to add `subagent_type="general-purpose"` to all four Task() examples (Curator, Builder, Judge, Doctor phases)
- Updates `README.md` to replace `subagent_type="loom-builder"` with `subagent_type="general-purpose"`
- Adds clarifying comment explaining that role selection happens via the slash command in the prompt, not via custom subagent types

## Test plan

- [x] Search codebase for any remaining references to `subagent_type="loom-*"` - none found
- [x] Verify all Task() calls in documentation use `subagent_type="general-purpose"`
- [x] Confirm documentation now aligns with shepherd-lifecycle.md and loom-parent.md patterns

Closes #1313

Generated with [Claude Code](https://claude.ai/code)