### PR TITLE
Fix installation scripts to use squash merge and auto-apply settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ Thumbs.db
 .loom/daemon-state.json
 .loom/[0-9][0-9]-daemon-state.json
 .loom/stuck-history.json
+.loom/alerts.json
+.loom/health-metrics.json
 .loom/interventions/
 .loom/worktrees/
 .loom/state.json

--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -543,8 +543,16 @@ header "Step 5b: Configure Repository Settings"
 echo ""
 
 if [[ "$NON_INTERACTIVE" == "true" ]]; then
-  info "Non-interactive mode: Skipping repository settings"
-  info "To configure manually, run: $LOOM_ROOT/scripts/install/setup-repository-settings.sh $TARGET_PATH"
+  # In non-interactive mode, apply repository settings automatically
+  # This is needed for auto-merge to work on the installation PR
+  info "Applying repository settings (required for auto-merge)..."
+  if "$LOOM_ROOT/scripts/install/setup-repository-settings.sh" "$TARGET_PATH"; then
+    echo ""
+  else
+    echo ""
+    warning "Failed to configure repository settings (may require admin permissions)"
+    info "Auto-merge may not be available for the installation PR"
+  fi
 else
   echo ""
   read -p "Configure repository merge and auto-merge settings? (y/N) " -n 1 -r

--- a/scripts/install/create-pr.sh
+++ b/scripts/install/create-pr.sh
@@ -250,14 +250,15 @@ info "Attempting to merge installation PR..."
 
 MERGE_STATUS="manual"
 
-# First try immediate merge (works when no review requirements or 0 approvals)
-if gh pr merge "$PR_URL" --merge --delete-branch 2>/dev/null; then
+# First try immediate squash merge (works when no review requirements or 0 approvals)
+# Note: We use --squash because Loom's repository settings disable merge commits
+if gh pr merge "$PR_URL" --squash --delete-branch 2>/dev/null; then
   success "Installation PR merged successfully"
   MERGE_STATUS="merged"
 else
   # If immediate merge fails, try enabling auto-merge
   info "Immediate merge not available (branch protection may require reviews)"
-  if gh pr merge "$PR_URL" --auto --merge --delete-branch 2>/dev/null; then
+  if gh pr merge "$PR_URL" --auto --squash --delete-branch 2>/dev/null; then
     success "Auto-merge enabled - PR will merge once requirements are met"
     MERGE_STATUS="auto"
   else


### PR DESCRIPTION
## Summary

- **install-loom.sh**: Auto-apply repository settings in non-interactive mode instead of skipping. This is required for auto-merge to work on installation PRs.
- **create-pr.sh**: Use `--squash` instead of `--merge` for installation PR merge. This matches actual repository settings (`allow_squash_merge: true`, `allow_merge_commit: false`).
- **.gitignore**: Add `alerts.json` and `health-metrics.json` (runtime state files from health monitoring system).

## Test plan

- [ ] Run `./scripts/install-loom.sh --yes /tmp/test-repo` and verify repository settings are applied
- [ ] Verify installation PR uses squash merge strategy
- [ ] Confirm health monitoring runtime files are gitignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)