### PR TITLE
Clarify Skill vs Task usage across shepherd and daemon role files

### DIFF
--- a/defaults/.claude/commands/loom-iteration.md
+++ b/defaults/.claude/commands/loom-iteration.md
@@ -216,7 +216,7 @@ fi
 
 > **WARNING: Shepherds MUST be invoked via Skill tool for full lifecycle**
 >
-> When spawning shepherds, you must use the Skill tool invocation pattern shown below.
+> When the daemon spawns shepherds, you must use the Skill tool invocation pattern shown below.
 >
 > **DO NOT** give shepherds explicit step-by-step instructions.
 >
@@ -227,7 +227,11 @@ fi
 > )
 > ```
 >
-> The Skill tool ensures the shepherd follows the complete workflow: Curator -> Builder -> Judge -> Doctor (if needed) -> Merge
+> The Skill tool ensures the shepherd gets its full role prompt expanded so it can follow the complete workflow: Curator -> Builder -> Judge -> Doctor (if needed) -> Merge.
+>
+> **Note**: This Skill-in-Task pattern applies to **daemon→shepherd** invocations only.
+> Shepherds themselves use plain `Task` subagents with slash-command prompts for phase
+> delegation (e.g., `Task(prompt="/builder 123")`). See `shepherd.md` for details.
 
 ```python
 def auto_spawn_shepherds(state, snapshot_data, debug_mode=False):

--- a/defaults/.claude/commands/loom-parent.md
+++ b/defaults/.claude/commands/loom-parent.md
@@ -90,10 +90,14 @@ Follow all shepherd workflow steps until the issue is complete or blocked.""",
 - `--force-merge`: Full automation - auto-merge after Judge approval (use when daemon is in force mode)
 - `--force-pr`: Stops at `loom:pr` (ready-to-merge), requires Champion for merge (default)
 
-**CRITICAL - Correct Tool Invocation**: Task subagents must use the **Skill tool**, NOT CLI commands.
+**CRITICAL - Correct Tool Invocation**: Daemon-spawned subagents must use the **Skill tool**, NOT CLI commands.
+
+> **Scope**: This Skill-in-Task pattern applies to **daemon→shepherd** and **daemon→support role**
+> invocations only. Shepherds themselves use plain `Task` subagents with slash-command prompts
+> for phase delegation (e.g., `Task(prompt="/builder 123")`). See `shepherd.md` for details.
 
 ```
-CORRECT - Use the Skill tool:
+CORRECT - Use the Skill tool (daemon spawning shepherds/support roles):
    Skill(skill="guide")
    Skill(skill="shepherd", args="123 --force-merge")
 

--- a/defaults/.claude/commands/shepherd.md
+++ b/defaults/.claude/commands/shepherd.md
@@ -213,6 +213,14 @@ When orchestrating issue #N, follow this progression:
 
 ### Direct Mode Role Execution Pattern
 
+> **IMPORTANT**: In Direct Mode, always use `Task` subagents for phase delegation.
+> Do NOT use the `Skill` tool — it expands the role prompt into your conversation,
+> replacing your orchestration context. Only `Task` preserves your control flow.
+>
+> The `Skill` tool is used by the *daemon* to invoke *shepherds* (so the shepherd
+> gets its full role prompt expanded). Shepherds themselves use plain `Task` subagents
+> with slash-command prompts for phase delegation.
+
 For each phase, the shepherd spawns a Task subagent:
 
 1. **Announce the phase**: `"Starting [Role] phase..."`


### PR DESCRIPTION
## Summary

- Added explicit warning in `shepherd.md` Direct Mode section: always use `Task` subagents for phase delegation, never `Skill`
- Scoped the Skill-in-Task guidance in `loom-parent.md` to daemon→shepherd invocations only
- Scoped the Skill tool warning in `loom-iteration.md` to daemon→shepherd invocations only, with cross-reference to `shepherd.md`

The root cause was conflicting guidance: daemon files said "must use Skill tool" without scoping it to daemon→shepherd invocations, which shepherds could misinterpret as applying to their own phase delegation (Curator, Builder, Judge, Doctor).

Closes #1318

## Test plan

- [ ] Run `/shepherd <issue> --force-merge` on a test issue and verify all phases execute sequentially using Task subagents
- [ ] Run `/shepherd <issue> --force-pr` and verify it stops after Judge approval with `loom:pr` label
- [ ] Verify each phase runs with fresh context (no context pollution between phases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)