### PR TITLE
Add tmux agent launcher script

### DIFF
--- a/defaults/scripts/agent-spawn.sh
+++ b/defaults/scripts/agent-spawn.sh
@@ -153,8 +153,8 @@ check_tmux() {
         local major minor
         major=$(echo "$version" | cut -d. -f1)
         minor=$(echo "$version" | cut -d. -f2)
-        if [[ "$major" -lt 2 ]] && [[ "$minor" -lt 8 ]]; then
-            log_warn "tmux version $version may not support all features (recommend >= 2.0)"
+        if [[ "$major" -lt 1 ]] || { [[ "$major" -eq 1 ]] && [[ "$minor" -lt 8 ]]; }; then
+            log_warn "tmux version $version may not support all features (recommend >= 1.8)"
         fi
     fi
 


### PR DESCRIPTION
## Summary

- Adds `agent-spawn.sh` - the foundational building block for tmux-based agent management
- Enables spawning persistent, inspectable, and interactive Claude Code agents in tmux sessions
- Integrates with existing infrastructure (claude-wrapper.sh, signal.sh, worktree.sh)

## Key Features

- Creates tmux sessions with predictable names (`loom-<name>`) 
- Uses dedicated tmux socket (`-L loom-agents`) to prevent namespace collisions
- Captures all output to `.loom/logs/<session-name>.log` via `pipe-pane`
- Integrates with signal.sh for graceful shutdown
- Wraps Claude CLI with claude-wrapper.sh for resilience (retries, backoff)
- Supports git worktrees for isolated development
- Handles idempotency - re-running with same name handled gracefully

## Interface

```bash
# Spawn a shepherd agent for issue 42
./.loom/scripts/agent-spawn.sh --role shepherd --args "42 --force" --name shepherd-1

# Spawn a builder agent in a worktree
./.loom/scripts/agent-spawn.sh --role builder --args "42" --name builder-1 \
    --worktree .loom/worktrees/issue-42

# Check if a session exists  
./.loom/scripts/agent-spawn.sh --check shepherd-1

# List all sessions
./.loom/scripts/agent-spawn.sh --list

# Attach to a running session
tmux -L loom-agents attach -t loom-shepherd-1

# Stop a session gracefully
./.loom/scripts/signal.sh stop shepherd-1
```

## Test plan

- [x] Test help output works
- [x] Test invalid role validation returns error
- [x] Test missing parameter validation returns error
- [x] Test invalid worktree path validation returns error
- [x] Test check on non-existent session returns exit code 1
- [x] Test stop signal detection prevents spawning
- [x] Test actual agent spawn creates session
- [x] Test check on existing session returns exit code 0
- [x] Test list command shows active sessions
- [x] Test log file is created with correct header
- [x] Test idempotency - re-running with same name handles gracefully
- [x] Test session cleanup

Closes #1329

🤖 Generated with [Claude Code](https://claude.com/claude-code)