### PR TITLE
Add Loom CLI for tmux agent pool management

### DIFF
--- a/defaults/loom
+++ b/defaults/loom
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# Loom CLI - tmux agent pool management
+#
+# Usage: ./loom <command> [options]
+#
+# Commands:
+#   start     Spawn agent pool from config
+#   status    Display agent pool state
+#   stop      Graceful shutdown
+#   attach    Open live tmux session
+#   scale     Dynamic agent scaling
+#   logs      Tail agent output
+#   help      Show help
+#
+# Examples:
+#   ./loom start                  Start all configured agents
+#   ./loom start --only shepherd  Start only shepherd agents
+#   ./loom status                 Show current state
+#   ./loom attach shepherd-1      Connect to terminal
+#   ./loom stop                   Graceful shutdown
+#   ./loom stop --force           Force kill all sessions
+#   ./loom scale shepherd 3       Scale shepherd pool to 3
+#   ./loom logs terminal-1        Tail agent output
+#
+# For more details:
+#   ./loom help
+#   ./loom <command> --help
+
+set -euo pipefail
+
+# Determine script location (works even when symlinked)
+if [[ -L "${BASH_SOURCE[0]}" ]]; then
+    SCRIPT_DIR="$(cd "$(dirname "$(readlink "${BASH_SOURCE[0]}")")" && pwd)"
+else
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fi
+
+# Find the repository root by looking for .loom directory
+find_repo_root() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.loom" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        # Check if this is a worktree by looking for .git file
+        if [[ -f "$dir/.git" ]]; then
+            local gitdir
+            gitdir=$(sed 's/^gitdir: //' "$dir/.git")
+            local main_repo
+            main_repo=$(dirname "$(dirname "$(dirname "$gitdir")")")
+            if [[ -d "$main_repo/.loom" ]]; then
+                echo "$main_repo"
+                return 0
+            fi
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo ""
+}
+
+REPO_ROOT=$(find_repo_root)
+if [[ -z "$REPO_ROOT" ]]; then
+    echo "Error: Not in a Loom workspace (.loom directory not found)" >&2
+    echo "Run 'loom help' or initialize Loom in this repository" >&2
+    exit 1
+fi
+
+CLI_DIR="$REPO_ROOT/.loom/scripts/cli"
+
+# ANSI colors (disabled if not a terminal)
+if [[ -t 1 ]]; then
+    RED='\033[0;31m'
+    YELLOW='\033[1;33m'
+    NC='\033[0m'
+else
+    RED=''
+    YELLOW=''
+    NC=''
+fi
+
+# Dispatch to subcommands
+case "${1:-help}" in
+    start)
+        shift
+        if [[ -f "$CLI_DIR/loom-start.sh" ]]; then
+            exec "$CLI_DIR/loom-start.sh" "$@"
+        else
+            echo -e "${RED}Error: loom-start.sh not found${NC}" >&2
+            exit 1
+        fi
+        ;;
+    status)
+        shift
+        # Use existing loom-status.sh if available
+        if [[ -f "$REPO_ROOT/.loom/scripts/loom-status.sh" ]]; then
+            exec "$REPO_ROOT/.loom/scripts/loom-status.sh" "$@"
+        elif [[ -f "$CLI_DIR/loom-status.sh" ]]; then
+            exec "$CLI_DIR/loom-status.sh" "$@"
+        else
+            echo -e "${RED}Error: loom-status.sh not found${NC}" >&2
+            exit 1
+        fi
+        ;;
+    stop)
+        shift
+        if [[ -f "$CLI_DIR/loom-stop.sh" ]]; then
+            exec "$CLI_DIR/loom-stop.sh" "$@"
+        else
+            echo -e "${RED}Error: loom-stop.sh not found${NC}" >&2
+            exit 1
+        fi
+        ;;
+    attach)
+        shift
+        if [[ -f "$CLI_DIR/loom-attach.sh" ]]; then
+            exec "$CLI_DIR/loom-attach.sh" "$@"
+        else
+            echo -e "${RED}Error: loom-attach.sh not found${NC}" >&2
+            exit 1
+        fi
+        ;;
+    scale)
+        shift
+        if [[ -f "$CLI_DIR/loom-scale.sh" ]]; then
+            exec "$CLI_DIR/loom-scale.sh" "$@"
+        else
+            echo -e "${RED}Error: loom-scale.sh not found${NC}" >&2
+            exit 1
+        fi
+        ;;
+    logs)
+        shift
+        if [[ -f "$CLI_DIR/loom-logs.sh" ]]; then
+            exec "$CLI_DIR/loom-logs.sh" "$@"
+        else
+            echo -e "${RED}Error: loom-logs.sh not found${NC}" >&2
+            exit 1
+        fi
+        ;;
+    help|--help|-h)
+        shift || true
+        if [[ -f "$CLI_DIR/loom-help.sh" ]]; then
+            exec "$CLI_DIR/loom-help.sh" "$@"
+        else
+            # Inline help if loom-help.sh not yet installed
+            cat <<'EOF'
+Loom CLI - tmux agent pool management
+
+USAGE:
+    ./loom <command> [options]
+
+COMMANDS:
+    start     Spawn agent pool from .loom/config.json
+    status    Display agent pool state and work queues
+    stop      Graceful shutdown (or --force to kill immediately)
+    attach    Open live tmux session for an agent
+    scale     Dynamic agent scaling
+    logs      Tail agent output
+    help      Show this help message
+
+EXAMPLES:
+    ./loom start                  Start all configured agents
+    ./loom start --only shepherd  Start only shepherd agents
+    ./loom status                 Show current state
+    ./loom status --json          Machine-readable status
+    ./loom attach shepherd-1      Connect to agent terminal
+    ./loom stop                   Graceful shutdown
+    ./loom stop --force           Force kill all sessions
+    ./loom stop shepherd-1        Stop single agent
+    ./loom scale shepherd 3       Scale shepherd pool to 3
+    ./loom logs terminal-1        Tail agent output
+    ./loom logs --all             Tail all agent logs
+
+For command-specific help:
+    ./loom <command> --help
+EOF
+            exit 0
+        fi
+        ;;
+    version|--version|-v)
+        echo "Loom CLI v0.1.0"
+        exit 0
+        ;;
+    *)
+        echo -e "${RED}Error: Unknown command '$1'${NC}" >&2
+        echo "Run './loom help' for available commands" >&2
+        exit 1
+        ;;
+esac

--- a/defaults/scripts/cli/loom-attach.sh
+++ b/defaults/scripts/cli/loom-attach.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# loom attach - Open live tmux session for an agent
+#
+# Usage:
+#   loom attach <agent-name>      Attach to agent terminal
+#   loom attach --list            List available sessions
+#   loom attach --help            Show help
+#
+# Examples:
+#   loom attach shepherd-1        Attach to shepherd-1 terminal
+#   loom attach terminal-2        Attach to terminal-2
+#
+# Keyboard shortcuts when attached:
+#   Ctrl+B then d                 Detach (leave agent running)
+#   Ctrl+B then [                 Scroll mode (q to exit)
+#   Ctrl+B then ?                 Show all shortcuts
+
+set -euo pipefail
+
+# Find repository root
+find_repo_root() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.loom" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        if [[ -f "$dir/.git" ]]; then
+            local gitdir
+            gitdir=$(sed 's/^gitdir: //' "$dir/.git")
+            local main_repo
+            main_repo=$(dirname "$(dirname "$(dirname "$gitdir")")")
+            if [[ -d "$main_repo/.loom" ]]; then
+                echo "$main_repo"
+                return 0
+            fi
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo ""
+}
+
+REPO_ROOT=$(find_repo_root)
+
+# ANSI colors
+if [[ -t 1 ]]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    CYAN='\033[0;36m'
+    BOLD='\033[1m'
+    NC='\033[0m'
+else
+    RED=''
+    GREEN=''
+    YELLOW=''
+    CYAN=''
+    BOLD=''
+    NC=''
+fi
+
+# Show help
+show_help() {
+    cat <<EOF
+${BOLD}loom attach - Open live tmux session for an agent${NC}
+
+${YELLOW}USAGE:${NC}
+    loom attach <agent-name>      Attach to agent terminal
+    loom attach --list            List available sessions
+    loom attach --help            Show this help
+
+${YELLOW}EXAMPLES:${NC}
+    loom attach shepherd-1        Attach to shepherd-1 terminal
+    loom attach terminal-2        Attach to terminal-2
+
+${YELLOW}KEYBOARD SHORTCUTS (when attached):${NC}
+    Ctrl+B then d                 Detach (leave agent running)
+    Ctrl+B then [                 Scroll mode (q to exit)
+    Ctrl+B then ?                 Show all shortcuts
+
+${YELLOW}SESSION NAMING:${NC}
+    Loom uses tmux sessions with the naming pattern:
+      loom-<agent-name>           e.g., loom-shepherd-1, loom-terminal-2
+
+    You can specify either the full session name or just the agent name:
+      loom attach loom-shepherd-1  (full name)
+      loom attach shepherd-1       (short name - loom- prefix added)
+EOF
+}
+
+# List available sessions
+list_sessions() {
+    echo -e "${BOLD}Available Loom sessions:${NC}"
+    echo ""
+
+    # Check if tmux is running with loom socket
+    if ! tmux -L loom list-sessions 2>/dev/null; then
+        echo -e "${YELLOW}No Loom sessions found${NC}"
+        echo ""
+        echo "Start agents with: ./loom start"
+        return 0
+    fi
+
+    echo ""
+    echo -e "${CYAN}To attach:${NC} loom attach <name>"
+}
+
+# Main logic
+main() {
+    local agent_name=""
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --help|-h)
+                show_help
+                exit 0
+                ;;
+            --list|-l)
+                list_sessions
+                exit 0
+                ;;
+            -*)
+                echo -e "${RED}Error: Unknown option '$1'${NC}" >&2
+                echo "Use 'loom attach --help' for usage" >&2
+                exit 1
+                ;;
+            *)
+                agent_name="$1"
+                shift
+                ;;
+        esac
+    done
+
+    if [[ -z "$agent_name" ]]; then
+        echo -e "${RED}Error: Agent name required${NC}" >&2
+        echo "Usage: loom attach <agent-name>" >&2
+        echo ""
+        echo "Available sessions:"
+        tmux -L loom list-sessions 2>/dev/null || echo "  (none running)"
+        exit 1
+    fi
+
+    # Check if tmux is installed
+    if ! command -v tmux &> /dev/null; then
+        echo -e "${RED}Error: tmux is not installed${NC}" >&2
+        echo "Install with: brew install tmux (macOS) or apt-get install tmux (Linux)" >&2
+        exit 1
+    fi
+
+    # Normalize session name (add loom- prefix if not present)
+    local session_name="$agent_name"
+    if [[ ! "$session_name" =~ ^loom- ]]; then
+        session_name="loom-$agent_name"
+    fi
+
+    # Check if session exists
+    if ! tmux -L loom has-session -t "$session_name" 2>/dev/null; then
+        echo -e "${RED}Error: Session '$session_name' is not running${NC}" >&2
+        echo ""
+        echo "Available sessions:"
+        tmux -L loom list-sessions 2>/dev/null || echo "  (none running)"
+        echo ""
+        echo "Use './loom status' to see all agents" >&2
+        exit 1
+    fi
+
+    echo -e "${GREEN}Attaching to $session_name...${NC}"
+    echo -e "${CYAN}Tip: Press Ctrl+B then d to detach${NC}"
+    echo ""
+
+    # Attach to the session
+    exec tmux -L loom attach -t "$session_name"
+}
+
+main "$@"

--- a/defaults/scripts/cli/loom-help.sh
+++ b/defaults/scripts/cli/loom-help.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# loom help - Show help for Loom CLI
+#
+# Usage:
+#   loom help              Show main help
+#   loom help <command>    Show help for specific command
+#   loom --help            Same as 'loom help'
+
+set -euo pipefail
+
+# Find repository root
+find_repo_root() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.loom" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        if [[ -f "$dir/.git" ]]; then
+            local gitdir
+            gitdir=$(sed 's/^gitdir: //' "$dir/.git")
+            local main_repo
+            main_repo=$(dirname "$(dirname "$(dirname "$gitdir")")")
+            if [[ -d "$main_repo/.loom" ]]; then
+                echo "$main_repo"
+                return 0
+            fi
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo ""
+}
+
+REPO_ROOT=$(find_repo_root)
+CLI_DIR=""
+if [[ -n "$REPO_ROOT" ]]; then
+    CLI_DIR="$REPO_ROOT/.loom/scripts/cli"
+fi
+
+# ANSI colors
+if [[ -t 1 ]]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    CYAN='\033[0;36m'
+    GRAY='\033[0;90m'
+    BOLD='\033[1m'
+    NC='\033[0m'
+else
+    RED=''
+    GREEN=''
+    YELLOW=''
+    CYAN=''
+    GRAY=''
+    BOLD=''
+    NC=''
+fi
+
+# Show main help
+show_main_help() {
+    cat <<EOF
+${BOLD}Loom CLI - tmux agent pool management${NC}
+
+Loom is a multi-terminal orchestration system for AI-powered development.
+This CLI provides management of tmux-backed agent pools.
+
+${YELLOW}USAGE:${NC}
+    ./loom <command> [options]
+
+${YELLOW}COMMANDS:${NC}
+    ${GREEN}start${NC}     Spawn agent pool from .loom/config.json
+    ${GREEN}status${NC}    Display agent pool state and work queues
+    ${GREEN}stop${NC}      Graceful shutdown (or --force to kill immediately)
+    ${GREEN}attach${NC}    Open live tmux session for an agent
+    ${GREEN}scale${NC}     Dynamic agent scaling
+    ${GREEN}logs${NC}      Tail agent output
+    ${GREEN}help${NC}      Show this help message
+
+${YELLOW}QUICK START:${NC}
+    ${GRAY}# Start all configured agents${NC}
+    ./loom start
+
+    ${GRAY}# Check what's running${NC}
+    ./loom status
+
+    ${GRAY}# View an agent's terminal${NC}
+    ./loom attach shepherd-1
+
+    ${GRAY}# View logs${NC}
+    ./loom logs shepherd-1
+
+    ${GRAY}# Stop everything${NC}
+    ./loom stop
+
+${YELLOW}EXAMPLES:${NC}
+    ./loom start                  Start all configured agents
+    ./loom start --only shepherd  Start only shepherd agents
+    ./loom status                 Show current state
+    ./loom status --json          Machine-readable status
+    ./loom attach shepherd-1      Connect to agent terminal
+    ./loom stop                   Graceful shutdown
+    ./loom stop --force           Force kill all sessions
+    ./loom stop shepherd-1        Stop single agent
+    ./loom scale shepherd 3       Scale shepherd pool to 3
+    ./loom logs terminal-1        Tail agent output
+    ./loom logs --all             Tail all agent logs
+
+${YELLOW}SSH AND REMOTE:${NC}
+    All commands work over SSH without \$DISPLAY.
+    For non-interactive scripts, use --yes flag to skip prompts.
+
+${YELLOW}CONFIGURATION:${NC}
+    Agents are configured in .loom/config.json:
+
+    {
+      "terminals": [
+        {
+          "id": "terminal-1",
+          "name": "Builder",
+          "roleConfig": {
+            "roleFile": "builder.md"
+          }
+        }
+      ]
+    }
+
+${YELLOW}TMUX SOCKET:${NC}
+    Loom uses a dedicated tmux socket named "loom" for isolation.
+    Sessions are named "loom-<agent-id>" (e.g., loom-shepherd-1).
+
+    To manually interact with Loom tmux sessions:
+    ${GRAY}tmux -L loom list-sessions${NC}
+    ${GRAY}tmux -L loom attach -t loom-shepherd-1${NC}
+
+${YELLOW}FOR MORE HELP:${NC}
+    ./loom <command> --help    Command-specific help
+    ./loom help <command>      Same as above
+
+${YELLOW}RELATED COMMANDS:${NC}
+    /loom                     Run the daemon (Layer 2 orchestration)
+    /shepherd <issue>         Orchestrate a single issue lifecycle
+    /builder, /judge, etc.    Assume specialized agent roles
+
+${GRAY}Loom CLI v0.1.0${NC}
+EOF
+}
+
+# Show command-specific help
+show_command_help() {
+    local command="$1"
+
+    case "$command" in
+        start)
+            if [[ -n "$CLI_DIR" && -f "$CLI_DIR/loom-start.sh" ]]; then
+                exec "$CLI_DIR/loom-start.sh" --help
+            else
+                echo -e "${RED}Error: start command not installed${NC}"
+                exit 1
+            fi
+            ;;
+        status)
+            if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/scripts/loom-status.sh" ]]; then
+                exec "$REPO_ROOT/.loom/scripts/loom-status.sh" --help
+            else
+                echo -e "${RED}Error: status command not installed${NC}"
+                exit 1
+            fi
+            ;;
+        stop)
+            if [[ -n "$CLI_DIR" && -f "$CLI_DIR/loom-stop.sh" ]]; then
+                exec "$CLI_DIR/loom-stop.sh" --help
+            else
+                echo -e "${RED}Error: stop command not installed${NC}"
+                exit 1
+            fi
+            ;;
+        attach)
+            if [[ -n "$CLI_DIR" && -f "$CLI_DIR/loom-attach.sh" ]]; then
+                exec "$CLI_DIR/loom-attach.sh" --help
+            else
+                echo -e "${RED}Error: attach command not installed${NC}"
+                exit 1
+            fi
+            ;;
+        scale)
+            if [[ -n "$CLI_DIR" && -f "$CLI_DIR/loom-scale.sh" ]]; then
+                exec "$CLI_DIR/loom-scale.sh" --help
+            else
+                echo -e "${RED}Error: scale command not installed${NC}"
+                exit 1
+            fi
+            ;;
+        logs)
+            if [[ -n "$CLI_DIR" && -f "$CLI_DIR/loom-logs.sh" ]]; then
+                exec "$CLI_DIR/loom-logs.sh" --help
+            else
+                echo -e "${RED}Error: logs command not installed${NC}"
+                exit 1
+            fi
+            ;;
+        help)
+            show_main_help
+            ;;
+        *)
+            echo -e "${RED}Error: Unknown command '$command'${NC}"
+            echo ""
+            echo "Available commands: start, status, stop, attach, scale, logs, help"
+            exit 1
+            ;;
+    esac
+}
+
+# Main
+main() {
+    case "${1:-}" in
+        ""|--help|-h)
+            show_main_help
+            ;;
+        *)
+            show_command_help "$1"
+            ;;
+    esac
+}
+
+main "$@"

--- a/defaults/scripts/cli/loom-logs.sh
+++ b/defaults/scripts/cli/loom-logs.sh
@@ -1,0 +1,328 @@
+#!/usr/bin/env bash
+# loom logs - Tail agent output
+#
+# Usage:
+#   loom logs <agent-name>        Tail specific agent's output
+#   loom logs --all               Tail all agent logs (interleaved)
+#   loom logs --list              List available log files
+#   loom logs -n <lines>          Show last N lines (default: 50)
+#   loom logs --help              Show help
+#
+# Examples:
+#   loom logs shepherd-1          Tail shepherd-1 output
+#   loom logs terminal-1 -n 100   Show last 100 lines
+#   loom logs --all               Follow all agent logs
+
+set -euo pipefail
+
+# Find repository root
+find_repo_root() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.loom" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        if [[ -f "$dir/.git" ]]; then
+            local gitdir
+            gitdir=$(sed 's/^gitdir: //' "$dir/.git")
+            local main_repo
+            main_repo=$(dirname "$(dirname "$(dirname "$gitdir")")")
+            if [[ -d "$main_repo/.loom" ]]; then
+                echo "$main_repo"
+                return 0
+            fi
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo ""
+}
+
+REPO_ROOT=$(find_repo_root)
+
+# Default log directory
+LOG_DIR="/tmp"
+
+# ANSI colors
+if [[ -t 1 ]]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    CYAN='\033[0;36m'
+    GRAY='\033[0;90m'
+    BOLD='\033[1m'
+    NC='\033[0m'
+else
+    RED=''
+    GREEN=''
+    YELLOW=''
+    CYAN=''
+    GRAY=''
+    BOLD=''
+    NC=''
+fi
+
+# Show help
+show_help() {
+    cat <<EOF
+${BOLD}loom logs - Tail agent output${NC}
+
+${YELLOW}USAGE:${NC}
+    loom logs <agent-name>        Tail specific agent's output
+    loom logs --all               Tail all agent logs (interleaved)
+    loom logs --list              List available log files
+    loom logs -n <lines>          Show last N lines (default: 50)
+    loom logs --follow, -f        Follow log output (default for single agent)
+    loom logs --no-follow         Show lines but don't follow
+    loom logs --help              Show this help
+
+${YELLOW}EXAMPLES:${NC}
+    loom logs shepherd-1          Tail shepherd-1 output (follows)
+    loom logs terminal-1 -n 100   Show last 100 lines then follow
+    loom logs --all               Follow all agent logs interleaved
+    loom logs shepherd-1 --no-follow  Just show last lines, don't follow
+
+${YELLOW}LOG LOCATIONS:${NC}
+    Agent output is captured to:
+      /tmp/loom-<agent-name>.out  e.g., /tmp/loom-shepherd-1.out
+
+    Daemon log:
+      .loom/daemon.log
+
+${YELLOW}TIPS:${NC}
+    Press Ctrl+C to stop following logs
+    Use --list to see all available log files
+EOF
+}
+
+# List available log files
+list_logs() {
+    echo -e "${BOLD}Available Loom log files:${NC}"
+    echo ""
+
+    local found=false
+
+    # Check for agent output files
+    for logfile in "$LOG_DIR"/loom-*.out; do
+        if [[ -f "$logfile" ]]; then
+            found=true
+            local name
+            name=$(basename "$logfile" .out | sed 's/^loom-//')
+            local size
+            size=$(du -h "$logfile" | cut -f1)
+            local modified
+            modified=$(stat -f "%Sm" -t "%Y-%m-%d %H:%M" "$logfile" 2>/dev/null || stat -c "%y" "$logfile" 2>/dev/null | cut -d. -f1)
+            echo -e "  ${GREEN}$name${NC}  ${GRAY}($size, modified $modified)${NC}"
+        fi
+    done
+
+    # Check for daemon log
+    if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/daemon.log" ]]; then
+        found=true
+        local size
+        size=$(du -h "$REPO_ROOT/.loom/daemon.log" | cut -f1)
+        echo -e "  ${CYAN}daemon${NC}  ${GRAY}($size) - .loom/daemon.log${NC}"
+    fi
+
+    if [[ "$found" == "false" ]]; then
+        echo -e "${YELLOW}No log files found${NC}"
+        echo ""
+        echo "Start agents with: ./loom start"
+    else
+        echo ""
+        echo -e "${CYAN}To view:${NC} loom logs <name>"
+    fi
+}
+
+# Get log file path for an agent
+get_log_path() {
+    local agent_name="$1"
+
+    # Special case: daemon log
+    if [[ "$agent_name" == "daemon" ]]; then
+        if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/daemon.log" ]]; then
+            echo "$REPO_ROOT/.loom/daemon.log"
+            return 0
+        fi
+        return 1
+    fi
+
+    # Try with loom- prefix first
+    local logfile="$LOG_DIR/loom-$agent_name.out"
+    if [[ -f "$logfile" ]]; then
+        echo "$logfile"
+        return 0
+    fi
+
+    # Try without loom- prefix (in case full name was given)
+    if [[ "$agent_name" =~ ^loom- ]]; then
+        local short_name="${agent_name#loom-}"
+        logfile="$LOG_DIR/loom-$short_name.out"
+        if [[ -f "$logfile" ]]; then
+            echo "$logfile"
+            return 0
+        fi
+    fi
+
+    # Also try the raw name
+    logfile="$LOG_DIR/$agent_name.out"
+    if [[ -f "$logfile" ]]; then
+        echo "$logfile"
+        return 0
+    fi
+
+    return 1
+}
+
+# Strip ANSI escape codes (optional, for cleaner output)
+strip_ansi() {
+    sed 's/\x1b\[[0-9;]*m//g'
+}
+
+# Main logic
+main() {
+    local agent_name=""
+    local follow=true
+    local lines=50
+    local show_all=false
+    local strip_colors=false
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --help|-h)
+                show_help
+                exit 0
+                ;;
+            --list|-l)
+                list_logs
+                exit 0
+                ;;
+            --all|-a)
+                show_all=true
+                shift
+                ;;
+            --follow|-f)
+                follow=true
+                shift
+                ;;
+            --no-follow)
+                follow=false
+                shift
+                ;;
+            -n)
+                if [[ -z "${2:-}" ]]; then
+                    echo -e "${RED}Error: -n requires a number${NC}" >&2
+                    exit 1
+                fi
+                lines="$2"
+                shift 2
+                ;;
+            --strip-colors)
+                strip_colors=true
+                shift
+                ;;
+            -*)
+                echo -e "${RED}Error: Unknown option '$1'${NC}" >&2
+                echo "Use 'loom logs --help' for usage" >&2
+                exit 1
+                ;;
+            *)
+                agent_name="$1"
+                shift
+                ;;
+        esac
+    done
+
+    # Show all logs interleaved
+    if [[ "$show_all" == "true" ]]; then
+        local log_files=()
+
+        # Collect all loom log files
+        for logfile in "$LOG_DIR"/loom-*.out; do
+            if [[ -f "$logfile" ]]; then
+                log_files+=("$logfile")
+            fi
+        done
+
+        # Add daemon log if exists
+        if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/daemon.log" ]]; then
+            log_files+=("$REPO_ROOT/.loom/daemon.log")
+        fi
+
+        if [[ ${#log_files[@]} -eq 0 ]]; then
+            echo -e "${YELLOW}No log files found${NC}" >&2
+            echo "Start agents with: ./loom start" >&2
+            exit 1
+        fi
+
+        echo -e "${CYAN}Following ${#log_files[@]} log file(s)...${NC}"
+        echo -e "${GRAY}Press Ctrl+C to stop${NC}"
+        echo ""
+
+        if [[ "$follow" == "true" ]]; then
+            # Use tail -f with file headers
+            exec tail -f "${log_files[@]}"
+        else
+            # Show last lines from each
+            for logfile in "${log_files[@]}"; do
+                local name
+                name=$(basename "$logfile")
+                echo -e "${BOLD}==> $name <==${NC}"
+                tail -n "$lines" "$logfile"
+                echo ""
+            done
+        fi
+        exit 0
+    fi
+
+    # Single agent log
+    if [[ -z "$agent_name" ]]; then
+        echo -e "${RED}Error: Agent name required${NC}" >&2
+        echo "Usage: loom logs <agent-name>" >&2
+        echo ""
+        echo "Use 'loom logs --list' to see available log files" >&2
+        exit 1
+    fi
+
+    # Get log file path
+    local logfile
+    if ! logfile=$(get_log_path "$agent_name"); then
+        echo -e "${RED}Error: Log file not found for '$agent_name'${NC}" >&2
+        echo ""
+        echo "Available log files:"
+        for lf in "$LOG_DIR"/loom-*.out; do
+            if [[ -f "$lf" ]]; then
+                local name
+                name=$(basename "$lf" .out | sed 's/^loom-//')
+                echo "  $name"
+            fi
+        done
+        if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/daemon.log" ]]; then
+            echo "  daemon"
+        fi
+        exit 1
+    fi
+
+    echo -e "${CYAN}Showing logs for: $agent_name${NC}"
+    echo -e "${GRAY}File: $logfile${NC}"
+    if [[ "$follow" == "true" ]]; then
+        echo -e "${GRAY}Press Ctrl+C to stop${NC}"
+    fi
+    echo ""
+
+    if [[ "$follow" == "true" ]]; then
+        if [[ "$strip_colors" == "true" ]]; then
+            tail -n "$lines" -f "$logfile" | strip_ansi
+        else
+            exec tail -n "$lines" -f "$logfile"
+        fi
+    else
+        if [[ "$strip_colors" == "true" ]]; then
+            tail -n "$lines" "$logfile" | strip_ansi
+        else
+            tail -n "$lines" "$logfile"
+        fi
+    fi
+}
+
+main "$@"

--- a/defaults/scripts/cli/loom-scale.sh
+++ b/defaults/scripts/cli/loom-scale.sh
@@ -1,0 +1,412 @@
+#!/usr/bin/env bash
+# loom scale - Dynamic agent scaling
+#
+# Usage:
+#   loom scale <role> <count>     Scale role to target count
+#   loom scale --status           Show current scale
+#   loom scale --help             Show help
+#
+# Examples:
+#   loom scale shepherd 3         Scale shepherd agents to 3
+#   loom scale shepherd 0         Stop all shepherds
+#   loom scale builder 2          Scale builder agents to 2
+
+set -euo pipefail
+
+# Find repository root
+find_repo_root() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.loom" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        if [[ -f "$dir/.git" ]]; then
+            local gitdir
+            gitdir=$(sed 's/^gitdir: //' "$dir/.git")
+            local main_repo
+            main_repo=$(dirname "$(dirname "$(dirname "$gitdir")")")
+            if [[ -d "$main_repo/.loom" ]]; then
+                echo "$main_repo"
+                return 0
+            fi
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo ""
+}
+
+REPO_ROOT=$(find_repo_root)
+if [[ -z "$REPO_ROOT" ]]; then
+    echo "Error: Not in a Loom workspace (.loom directory not found)" >&2
+    exit 1
+fi
+
+CONFIG_FILE="$REPO_ROOT/.loom/config.json"
+LOG_DIR="/tmp"
+TMUX_SOCKET="loom"
+
+# ANSI colors
+if [[ -t 1 ]]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    CYAN='\033[0;36m'
+    GRAY='\033[0;90m'
+    BOLD='\033[1m'
+    NC='\033[0m'
+else
+    RED=''
+    GREEN=''
+    YELLOW=''
+    CYAN=''
+    GRAY=''
+    BOLD=''
+    NC=''
+fi
+
+# Show help
+show_help() {
+    cat <<EOF
+${BOLD}loom scale - Dynamic agent scaling${NC}
+
+${YELLOW}USAGE:${NC}
+    loom scale <role> <count>     Scale role to target count
+    loom scale --status           Show current scaling status
+    loom scale --dry-run          Preview scaling changes
+    loom scale --help             Show this help
+
+${YELLOW}OPTIONS:${NC}
+    --dry-run         Preview what would change without doing it
+    --force           Force scale-down even if agents are working
+    --status          Show current scale for each role
+
+${YELLOW}EXAMPLES:${NC}
+    loom scale shepherd 3         Scale shepherd agents to 3
+    loom scale shepherd 0         Stop all shepherds
+    loom scale builder 2          Scale builder agents to 2
+    loom scale --status           Show current agent counts
+
+${YELLOW}ROLES:${NC}
+    Common roles: shepherd, builder, judge, curator, champion, architect
+
+${YELLOW}HOW IT WORKS:${NC}
+    Scale up:
+      - Creates new tmux sessions for additional agents
+      - Uses role template from existing config or defaults
+
+    Scale down:
+      - Gracefully stops excess agents (oldest first)
+      - Warns if agents are actively working
+      - Use --force to skip warnings
+EOF
+}
+
+# Check dependencies
+check_dependencies() {
+    local missing=()
+
+    if ! command -v tmux &> /dev/null; then
+        missing+=("tmux")
+    fi
+
+    if ! command -v jq &> /dev/null; then
+        missing+=("jq")
+    fi
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        echo -e "${RED}Error: Missing required dependencies: ${missing[*]}${NC}" >&2
+        exit 1
+    fi
+}
+
+# Get running sessions for a role
+get_role_sessions() {
+    local role="$1"
+    tmux -L "$TMUX_SOCKET" list-sessions -F "#{session_name}" 2>/dev/null | grep "^loom-.*$role" || true
+}
+
+# Count running sessions for a role
+count_role_sessions() {
+    local role="$1"
+    local count
+    count=$(get_role_sessions "$role" | wc -l | tr -d ' ')
+    echo "$count"
+}
+
+# Get highest numbered session for a role
+get_max_role_number() {
+    local role="$1"
+    local max=0
+
+    while read -r session; do
+        if [[ -n "$session" ]]; then
+            # Extract number from session name (e.g., loom-shepherd-3 -> 3)
+            local num
+            num=$(echo "$session" | grep -oE '[0-9]+$' || echo "0")
+            if [[ "$num" -gt "$max" ]]; then
+                max="$num"
+            fi
+        fi
+    done < <(get_role_sessions "$role")
+
+    echo "$max"
+}
+
+# Show current scaling status
+show_status() {
+    echo -e "${BOLD}Current Agent Scale${NC}"
+    echo ""
+
+    # Get all running loom sessions
+    local sessions
+    sessions=$(tmux -L "$TMUX_SOCKET" list-sessions -F "#{session_name}" 2>/dev/null | grep "^loom-" || true)
+
+    if [[ -z "$sessions" ]]; then
+        echo -e "${GRAY}No agents running${NC}"
+        return 0
+    fi
+
+    # Count by role pattern
+    declare -A role_counts
+
+    while read -r session; do
+        if [[ -n "$session" ]]; then
+            # Extract role name (e.g., loom-shepherd-1 -> shepherd)
+            local role
+            role=$(echo "$session" | sed 's/^loom-//' | sed 's/-[0-9]*$//')
+            role_counts["$role"]=$((${role_counts["$role"]:-0} + 1))
+        fi
+    done <<< "$sessions"
+
+    # Display counts
+    for role in "${!role_counts[@]}"; do
+        local count="${role_counts[$role]}"
+        echo -e "  ${CYAN}$role:${NC} $count"
+    done
+
+    echo ""
+    echo -e "${GRAY}Total: $(echo "$sessions" | wc -l | tr -d ' ') session(s)${NC}"
+}
+
+# Spawn a new agent for a role
+spawn_role_agent() {
+    local role="$1"
+    local number="$2"
+    local dry_run="${3:-false}"
+
+    local agent_id="$role-$number"
+    local session_name="loom-$agent_id"
+    local log_file="$LOG_DIR/loom-$agent_id.out"
+
+    # Check if already running
+    if tmux -L "$TMUX_SOCKET" has-session -t "$session_name" 2>/dev/null; then
+        echo -e "  ${GRAY}$agent_id:${NC} Already running, skipping"
+        return 0
+    fi
+
+    if [[ "$dry_run" == "true" ]]; then
+        echo -e "  ${CYAN}$agent_id:${NC} Would create"
+        return 0
+    fi
+
+    echo -e "  ${GREEN}$agent_id:${NC} Creating..."
+
+    # Create tmux session
+    tmux -L "$TMUX_SOCKET" new-session -d -s "$session_name" -n "$role"
+
+    # Set up output capture
+    tmux -L "$TMUX_SOCKET" pipe-pane -t "$session_name" -o "cat >> '$log_file'"
+
+    # Change to workspace
+    tmux -L "$TMUX_SOCKET" send-keys -t "$session_name" "cd '$REPO_ROOT'" C-m
+
+    # Start claude with role
+    local role_file="${role}.md"
+    local role_path="$REPO_ROOT/.loom/roles/$role_file"
+
+    if [[ -f "$role_path" ]]; then
+        tmux -L "$TMUX_SOCKET" send-keys -t "$session_name" "claude -p '/$role' --dangerously-skip-permissions" C-m
+    else
+        echo -e "    ${YELLOW}Warning: Role file not found: $role_file${NC}"
+        tmux -L "$TMUX_SOCKET" send-keys -t "$session_name" "claude --dangerously-skip-permissions" C-m
+    fi
+
+    return 0
+}
+
+# Stop an agent
+stop_role_agent() {
+    local session_name="$1"
+    local force="${2:-false}"
+    local dry_run="${3:-false}"
+
+    if [[ "$dry_run" == "true" ]]; then
+        echo -e "  ${YELLOW}$session_name:${NC} Would stop"
+        return 0
+    fi
+
+    echo -e "  ${YELLOW}$session_name:${NC} Stopping..."
+
+    if [[ "$force" == "true" ]]; then
+        tmux -L "$TMUX_SOCKET" kill-session -t "$session_name" 2>/dev/null || true
+    else
+        # Graceful stop
+        tmux -L "$TMUX_SOCKET" send-keys -t "$session_name" C-c 2>/dev/null || true
+        sleep 1
+        tmux -L "$TMUX_SOCKET" send-keys -t "$session_name" "exit" C-m 2>/dev/null || true
+        sleep 2
+
+        # Force kill if still running
+        if tmux -L "$TMUX_SOCKET" has-session -t "$session_name" 2>/dev/null; then
+            tmux -L "$TMUX_SOCKET" kill-session -t "$session_name" 2>/dev/null || true
+        fi
+    fi
+
+    return 0
+}
+
+# Main logic
+main() {
+    local role=""
+    local target=""
+    local dry_run=false
+    local force=false
+    local show_status_flag=false
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --help|-h)
+                show_help
+                exit 0
+                ;;
+            --status)
+                show_status_flag=true
+                shift
+                ;;
+            --dry-run)
+                dry_run=true
+                shift
+                ;;
+            --force|-f)
+                force=true
+                shift
+                ;;
+            -*)
+                echo -e "${RED}Error: Unknown option '$1'${NC}" >&2
+                echo "Use 'loom scale --help' for usage" >&2
+                exit 1
+                ;;
+            *)
+                if [[ -z "$role" ]]; then
+                    role="$1"
+                elif [[ -z "$target" ]]; then
+                    target="$1"
+                else
+                    echo -e "${RED}Error: Too many arguments${NC}" >&2
+                    exit 1
+                fi
+                shift
+                ;;
+        esac
+    done
+
+    # Check dependencies
+    check_dependencies
+
+    # Show status
+    if [[ "$show_status_flag" == "true" ]]; then
+        show_status
+        exit 0
+    fi
+
+    # Validate arguments
+    if [[ -z "$role" ]]; then
+        echo -e "${RED}Error: Role name required${NC}" >&2
+        echo "Usage: loom scale <role> <count>" >&2
+        exit 1
+    fi
+
+    if [[ -z "$target" ]]; then
+        echo -e "${RED}Error: Target count required${NC}" >&2
+        echo "Usage: loom scale <role> <count>" >&2
+        exit 1
+    fi
+
+    if ! [[ "$target" =~ ^[0-9]+$ ]]; then
+        echo -e "${RED}Error: Target must be a number${NC}" >&2
+        exit 1
+    fi
+
+    # Get current count
+    local current
+    current=$(count_role_sessions "$role")
+
+    echo -e "${BOLD}Scaling $role: $current -> $target${NC}"
+    echo ""
+
+    if [[ "$current" -eq "$target" ]]; then
+        echo -e "${GRAY}Already at target scale${NC}"
+        exit 0
+    fi
+
+    if [[ "$dry_run" == "true" ]]; then
+        echo -e "${YELLOW}Dry run - showing what would change:${NC}"
+        echo ""
+    fi
+
+    if [[ "$target" -gt "$current" ]]; then
+        # Scale up
+        local to_add=$((target - current))
+        echo -e "${GREEN}Scaling up: +$to_add agent(s)${NC}"
+        echo ""
+
+        local max_num
+        max_num=$(get_max_role_number "$role")
+
+        for ((i = 1; i <= to_add; i++)); do
+            local new_num=$((max_num + i))
+            spawn_role_agent "$role" "$new_num" "$dry_run"
+        done
+    else
+        # Scale down
+        local to_remove=$((current - target))
+        echo -e "${YELLOW}Scaling down: -$to_remove agent(s)${NC}"
+        echo ""
+
+        if [[ "$force" != "true" && "$dry_run" != "true" ]]; then
+            echo -e "${YELLOW}Warning: This will stop $to_remove running agent(s)${NC}"
+            echo -e "${GRAY}Use --force to skip this warning${NC}"
+            echo ""
+            read -r -p "Continue? [y/N] " -n 1 confirm
+            echo ""
+            if [[ ! $confirm =~ ^[Yy]$ ]]; then
+                echo "Cancelled"
+                exit 0
+            fi
+            echo ""
+        fi
+
+        # Get sessions to stop (oldest first, which typically have lowest numbers)
+        local sessions_to_stop
+        sessions_to_stop=$(get_role_sessions "$role" | sort | tail -n "$to_remove")
+
+        while read -r session; do
+            if [[ -n "$session" ]]; then
+                stop_role_agent "$session" "$force" "$dry_run"
+            fi
+        done <<< "$sessions_to_stop"
+    fi
+
+    echo ""
+
+    if [[ "$dry_run" == "true" ]]; then
+        echo -e "${CYAN}Dry run complete. Remove --dry-run to apply changes.${NC}"
+    else
+        local new_count
+        new_count=$(count_role_sessions "$role")
+        echo -e "${GREEN}Scale complete: $role now at $new_count${NC}"
+    fi
+}
+
+main "$@"

--- a/defaults/scripts/cli/loom-start.sh
+++ b/defaults/scripts/cli/loom-start.sh
@@ -1,0 +1,393 @@
+#!/usr/bin/env bash
+# loom start - Spawn agent pool from config
+#
+# Usage:
+#   loom start                    Start all configured agents
+#   loom start --only <role>      Start only agents with matching role
+#   loom start --dry-run          Show what would be started
+#   loom start --help             Show help
+#
+# Examples:
+#   loom start                    Start all agents from config
+#   loom start --only shepherd    Start only shepherd agents
+#   loom start --only builder     Start only builder agents
+
+set -euo pipefail
+
+# Find repository root
+find_repo_root() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.loom" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        if [[ -f "$dir/.git" ]]; then
+            local gitdir
+            gitdir=$(sed 's/^gitdir: //' "$dir/.git")
+            local main_repo
+            main_repo=$(dirname "$(dirname "$(dirname "$gitdir")")")
+            if [[ -d "$main_repo/.loom" ]]; then
+                echo "$main_repo"
+                return 0
+            fi
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo ""
+}
+
+REPO_ROOT=$(find_repo_root)
+if [[ -z "$REPO_ROOT" ]]; then
+    echo "Error: Not in a Loom workspace (.loom directory not found)" >&2
+    exit 1
+fi
+
+CONFIG_FILE="$REPO_ROOT/.loom/config.json"
+LOG_DIR="/tmp"
+TMUX_SOCKET="loom"
+
+# ANSI colors
+if [[ -t 1 ]]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    CYAN='\033[0;36m'
+    GRAY='\033[0;90m'
+    BOLD='\033[1m'
+    NC='\033[0m'
+else
+    RED=''
+    GREEN=''
+    YELLOW=''
+    CYAN=''
+    GRAY=''
+    BOLD=''
+    NC=''
+fi
+
+# Show help
+show_help() {
+    cat <<EOF
+${BOLD}loom start - Spawn agent pool from config${NC}
+
+${YELLOW}USAGE:${NC}
+    loom start                    Start all configured agents
+    loom start --only <role>      Start only agents with matching role
+    loom start --dry-run          Show what would be started
+    loom start --yes              Skip confirmation prompts
+    loom start --help             Show this help
+
+${YELLOW}OPTIONS:${NC}
+    --only <role>     Filter agents by role file (e.g., shepherd, builder, judge)
+    --dry-run         Preview what would be started without doing it
+    --yes, -y         Non-interactive mode, skip prompts
+    --force           Force restart of already-running agents
+
+${YELLOW}EXAMPLES:${NC}
+    loom start                    Start all agents from config
+    loom start --only shepherd    Start only shepherd agents
+    loom start --only builder     Start only builder agents
+    loom start --dry-run          Preview what would start
+
+${YELLOW}CONFIGURATION:${NC}
+    Agents are configured in .loom/config.json with this structure:
+
+    {
+      "terminals": [
+        {
+          "id": "terminal-1",
+          "name": "Builder",
+          "role": "claude-code-worker",
+          "roleConfig": {
+            "roleFile": "builder.md",
+            "targetInterval": 0,
+            "intervalPrompt": ""
+          }
+        }
+      ]
+    }
+
+${YELLOW}REQUIREMENTS:${NC}
+    - tmux must be installed
+    - claude CLI must be in PATH
+    - .loom/config.json must exist
+EOF
+}
+
+# Check dependencies
+check_dependencies() {
+    local missing=()
+
+    if ! command -v tmux &> /dev/null; then
+        missing+=("tmux")
+    fi
+
+    if ! command -v jq &> /dev/null; then
+        missing+=("jq")
+    fi
+
+    if ! command -v claude &> /dev/null; then
+        missing+=("claude")
+    fi
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        echo -e "${RED}Error: Missing required dependencies: ${missing[*]}${NC}" >&2
+        echo "" >&2
+        echo "Install with:" >&2
+        for dep in "${missing[@]}"; do
+            case $dep in
+                tmux)
+                    echo "  brew install tmux (macOS) or apt-get install tmux (Linux)" >&2
+                    ;;
+                jq)
+                    echo "  brew install jq (macOS) or apt-get install jq (Linux)" >&2
+                    ;;
+                claude)
+                    echo "  npm install -g @anthropic-ai/claude-code" >&2
+                    ;;
+            esac
+        done
+        exit 1
+    fi
+}
+
+# Check if config file exists
+check_config() {
+    if [[ ! -f "$CONFIG_FILE" ]]; then
+        echo -e "${RED}Error: Configuration file not found: $CONFIG_FILE${NC}" >&2
+        echo "" >&2
+        echo "Have you initialized Loom in this repository?" >&2
+        echo "Run: ./scripts/install-loom.sh" >&2
+        exit 1
+    fi
+
+    # Validate JSON
+    if ! jq empty "$CONFIG_FILE" 2>/dev/null; then
+        echo -e "${RED}Error: Invalid JSON in $CONFIG_FILE${NC}" >&2
+        exit 1
+    fi
+}
+
+# Get session name for a terminal
+get_session_name() {
+    local terminal_id="$1"
+    echo "loom-$terminal_id"
+}
+
+# Check if session is already running
+is_session_running() {
+    local session_name="$1"
+    tmux -L "$TMUX_SOCKET" has-session -t "$session_name" 2>/dev/null
+}
+
+# Spawn a single agent
+spawn_agent() {
+    local terminal_id="$1"
+    local terminal_name="$2"
+    local role_file="$3"
+    local interval="${4:-0}"
+    local interval_prompt="${5:-}"
+    local dry_run="${6:-false}"
+    local force="${7:-false}"
+
+    local session_name
+    session_name=$(get_session_name "$terminal_id")
+    local log_file="$LOG_DIR/loom-$terminal_id.out"
+
+    # Check if already running
+    if is_session_running "$session_name"; then
+        if [[ "$force" == "true" ]]; then
+            echo -e "  ${YELLOW}$terminal_name ($terminal_id):${NC} Stopping existing session..."
+            if [[ "$dry_run" != "true" ]]; then
+                tmux -L "$TMUX_SOCKET" kill-session -t "$session_name" 2>/dev/null || true
+                sleep 1
+            fi
+        else
+            echo -e "  ${GRAY}$terminal_name ($terminal_id):${NC} Already running, skipping"
+            return 0
+        fi
+    fi
+
+    if [[ "$dry_run" == "true" ]]; then
+        echo -e "  ${CYAN}$terminal_name ($terminal_id):${NC} Would start (role: $role_file)"
+        return 0
+    fi
+
+    echo -e "  ${GREEN}$terminal_name ($terminal_id):${NC} Starting..."
+
+    # Create tmux session detached
+    tmux -L "$TMUX_SOCKET" new-session -d -s "$session_name" -n "$terminal_name"
+
+    # Set up output capture
+    # Note: tmux pipe-pane captures all output to the log file
+    tmux -L "$TMUX_SOCKET" pipe-pane -t "$session_name" -o "cat >> '$log_file'"
+
+    # Change to workspace directory
+    tmux -L "$TMUX_SOCKET" send-keys -t "$session_name" "cd '$REPO_ROOT'" C-m
+
+    # Build claude command
+    local claude_cmd="claude"
+
+    # Add role if specified
+    if [[ -n "$role_file" && "$role_file" != "null" ]]; then
+        # Check if role file exists
+        local role_path="$REPO_ROOT/.loom/roles/$role_file"
+        if [[ -f "$role_path" ]]; then
+            # Use the skill system with /<role> command
+            local role_name="${role_file%.md}"
+            claude_cmd="claude -p '/$role_name'"
+        else
+            echo -e "    ${YELLOW}Warning: Role file not found: $role_file${NC}"
+        fi
+    fi
+
+    # Add dangerously-skip-permissions for autonomous agents
+    claude_cmd="$claude_cmd --dangerously-skip-permissions"
+
+    # Send the command
+    tmux -L "$TMUX_SOCKET" send-keys -t "$session_name" "$claude_cmd" C-m
+
+    # If interval is set, we need to handle autonomous mode
+    # For now, just start the agent - the interval prompt handling
+    # would need to be implemented in the agent itself
+
+    return 0
+}
+
+# Main logic
+main() {
+    local only_role=""
+    local dry_run=false
+    local non_interactive=false
+    local force=false
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --help|-h)
+                show_help
+                exit 0
+                ;;
+            --only)
+                if [[ -z "${2:-}" ]]; then
+                    echo -e "${RED}Error: --only requires a role name${NC}" >&2
+                    exit 1
+                fi
+                only_role="$2"
+                shift 2
+                ;;
+            --dry-run)
+                dry_run=true
+                shift
+                ;;
+            --yes|-y)
+                non_interactive=true
+                shift
+                ;;
+            --force)
+                force=true
+                shift
+                ;;
+            -*)
+                echo -e "${RED}Error: Unknown option '$1'${NC}" >&2
+                echo "Use 'loom start --help' for usage" >&2
+                exit 1
+                ;;
+            *)
+                echo -e "${RED}Error: Unexpected argument '$1'${NC}" >&2
+                exit 1
+                ;;
+        esac
+    done
+
+    # Check dependencies
+    check_dependencies
+
+    # Check config
+    check_config
+
+    # Parse terminals from config
+    local terminals
+    terminals=$(jq -c '.terminals // []' "$CONFIG_FILE")
+
+    local terminal_count
+    terminal_count=$(echo "$terminals" | jq 'length')
+
+    if [[ "$terminal_count" -eq 0 ]]; then
+        echo -e "${YELLOW}No terminals configured in $CONFIG_FILE${NC}"
+        exit 0
+    fi
+
+    # Filter by role if specified
+    if [[ -n "$only_role" ]]; then
+        terminals=$(echo "$terminals" | jq -c "[.[] | select(.roleConfig.roleFile | test(\"$only_role\"; \"i\"))]")
+        terminal_count=$(echo "$terminals" | jq 'length')
+
+        if [[ "$terminal_count" -eq 0 ]]; then
+            echo -e "${YELLOW}No terminals found matching role '$only_role'${NC}"
+            exit 0
+        fi
+    fi
+
+    # Display summary
+    echo -e "${BOLD}Loom Agent Pool${NC}"
+    echo ""
+    echo -e "  Workspace: ${CYAN}$REPO_ROOT${NC}"
+    echo -e "  Config: ${CYAN}$CONFIG_FILE${NC}"
+    echo -e "  Agents: ${CYAN}$terminal_count${NC}"
+    if [[ -n "$only_role" ]]; then
+        echo -e "  Filter: ${CYAN}$only_role${NC}"
+    fi
+    echo ""
+
+    # Show what will be started
+    if [[ "$dry_run" == "true" ]]; then
+        echo -e "${YELLOW}Dry run - showing what would be started:${NC}"
+        echo ""
+    else
+        echo -e "${GREEN}Starting agents:${NC}"
+        echo ""
+    fi
+
+    # Start each terminal
+    local started=0
+    local skipped=0
+    local failed=0
+
+    echo "$terminals" | jq -c '.[]' | while read -r terminal; do
+        local id name role_file interval interval_prompt
+
+        id=$(echo "$terminal" | jq -r '.id // ""')
+        name=$(echo "$terminal" | jq -r '.name // .id')
+        role_file=$(echo "$terminal" | jq -r '.roleConfig.roleFile // ""')
+        interval=$(echo "$terminal" | jq -r '.roleConfig.targetInterval // 0')
+        interval_prompt=$(echo "$terminal" | jq -r '.roleConfig.intervalPrompt // ""')
+
+        if [[ -z "$id" ]]; then
+            echo -e "  ${RED}Error: Terminal missing id field${NC}"
+            continue
+        fi
+
+        if spawn_agent "$id" "$name" "$role_file" "$interval" "$interval_prompt" "$dry_run" "$force"; then
+            ((started++)) || true
+        else
+            ((failed++)) || true
+        fi
+    done
+
+    echo ""
+
+    if [[ "$dry_run" == "true" ]]; then
+        echo -e "${CYAN}Dry run complete. Use 'loom start' to actually start agents.${NC}"
+    else
+        echo -e "${GREEN}Agent pool started.${NC}"
+        echo ""
+        echo "Commands:"
+        echo "  loom status      Show agent status"
+        echo "  loom attach <id> Attach to agent terminal"
+        echo "  loom logs <id>   View agent output"
+        echo "  loom stop        Stop all agents"
+    fi
+}
+
+main "$@"

--- a/defaults/scripts/cli/loom-stop.sh
+++ b/defaults/scripts/cli/loom-stop.sh
@@ -1,0 +1,349 @@
+#!/usr/bin/env bash
+# loom stop - Graceful shutdown of agent pool
+#
+# Usage:
+#   loom stop                     Graceful shutdown (waits for phase boundaries)
+#   loom stop --force             Force kill immediately
+#   loom stop <agent-name>        Stop single agent
+#   loom stop --help              Show help
+#
+# Examples:
+#   loom stop                     Graceful shutdown of all agents
+#   loom stop --force             Force kill all sessions
+#   loom stop shepherd-1          Stop only shepherd-1
+
+set -euo pipefail
+
+# Find repository root
+find_repo_root() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.loom" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        if [[ -f "$dir/.git" ]]; then
+            local gitdir
+            gitdir=$(sed 's/^gitdir: //' "$dir/.git")
+            local main_repo
+            main_repo=$(dirname "$(dirname "$(dirname "$gitdir")")")
+            if [[ -d "$main_repo/.loom" ]]; then
+                echo "$main_repo"
+                return 0
+            fi
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo ""
+}
+
+REPO_ROOT=$(find_repo_root)
+if [[ -z "$REPO_ROOT" ]]; then
+    echo "Error: Not in a Loom workspace (.loom directory not found)" >&2
+    exit 1
+fi
+
+STOP_SIGNAL="$REPO_ROOT/.loom/stop-daemon"
+LOG_DIR="/tmp"
+TMUX_SOCKET="loom"
+GRACEFUL_TIMEOUT="${LOOM_STOP_TIMEOUT:-300}"  # 5 minutes default
+
+# ANSI colors
+if [[ -t 1 ]]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    CYAN='\033[0;36m'
+    GRAY='\033[0;90m'
+    BOLD='\033[1m'
+    NC='\033[0m'
+else
+    RED=''
+    GREEN=''
+    YELLOW=''
+    CYAN=''
+    GRAY=''
+    BOLD=''
+    NC=''
+fi
+
+# Show help
+show_help() {
+    cat <<EOF
+${BOLD}loom stop - Graceful shutdown of agent pool${NC}
+
+${YELLOW}USAGE:${NC}
+    loom stop                     Graceful shutdown (waits for phase boundaries)
+    loom stop --force             Force kill immediately
+    loom stop <agent-name>        Stop single agent
+    loom stop --timeout <secs>    Custom timeout for graceful shutdown
+    loom stop --help              Show this help
+
+${YELLOW}OPTIONS:${NC}
+    --force, -f           Force kill sessions immediately (no graceful wait)
+    --timeout <seconds>   Maximum time to wait for graceful shutdown (default: 300)
+    --yes, -y             Non-interactive mode, skip confirmation
+    --clean               Also clean up log files after stop
+
+${YELLOW}EXAMPLES:${NC}
+    loom stop                     Graceful shutdown all agents
+    loom stop --force             Force kill all sessions
+    loom stop shepherd-1          Stop only shepherd-1
+    loom stop --timeout 60        Wait max 60 seconds for graceful shutdown
+
+${YELLOW}GRACEFUL SHUTDOWN:${NC}
+    By default, stop signals agents to complete their current phase:
+
+    1. Creates .loom/stop-daemon signal file
+    2. Agents check this file and stop at phase boundaries
+    3. Waits up to timeout for agents to complete
+    4. After timeout, kills remaining sessions
+    5. Cleans up signal files
+
+${YELLOW}ENVIRONMENT:${NC}
+    LOOM_STOP_TIMEOUT     Override default timeout (seconds)
+EOF
+}
+
+# Get list of running loom sessions
+get_running_sessions() {
+    tmux -L "$TMUX_SOCKET" list-sessions -F "#{session_name}" 2>/dev/null | grep "^loom-" || true
+}
+
+# Count running sessions
+count_sessions() {
+    local count
+    count=$(get_running_sessions | wc -l | tr -d ' ')
+    echo "$count"
+}
+
+# Stop a single session
+stop_session() {
+    local session_name="$1"
+    local force="${2:-false}"
+
+    if [[ "$force" == "true" ]]; then
+        # Force kill
+        tmux -L "$TMUX_SOCKET" kill-session -t "$session_name" 2>/dev/null || true
+    else
+        # Send Ctrl+C to interrupt current operation
+        tmux -L "$TMUX_SOCKET" send-keys -t "$session_name" C-c 2>/dev/null || true
+        sleep 1
+        # Then exit the shell
+        tmux -L "$TMUX_SOCKET" send-keys -t "$session_name" "exit" C-m 2>/dev/null || true
+    fi
+}
+
+# Wait for sessions to stop
+wait_for_sessions() {
+    local timeout="$1"
+    local start_time
+    start_time=$(date +%s)
+
+    echo -e "${CYAN}Waiting for agents to complete (max ${timeout}s)...${NC}"
+
+    while true; do
+        local current_count
+        current_count=$(count_sessions)
+
+        if [[ "$current_count" -eq 0 ]]; then
+            echo -e "${GREEN}All agents stopped${NC}"
+            return 0
+        fi
+
+        local elapsed
+        elapsed=$(($(date +%s) - start_time))
+
+        if [[ $elapsed -ge $timeout ]]; then
+            echo -e "${YELLOW}Timeout reached with $current_count session(s) still running${NC}"
+            return 1
+        fi
+
+        echo -e "  ${GRAY}$current_count session(s) still running (${elapsed}s elapsed)${NC}"
+        sleep 5
+    done
+}
+
+# Clean up log files
+cleanup_logs() {
+    echo -e "${CYAN}Cleaning up log files...${NC}"
+
+    local count=0
+    for logfile in "$LOG_DIR"/loom-*.out; do
+        if [[ -f "$logfile" ]]; then
+            rm -f "$logfile"
+            ((count++)) || true
+        fi
+    done
+
+    if [[ $count -gt 0 ]]; then
+        echo -e "  ${GREEN}Removed $count log file(s)${NC}"
+    else
+        echo -e "  ${GRAY}No log files to clean${NC}"
+    fi
+}
+
+# Main logic
+main() {
+    local force=false
+    local timeout="$GRACEFUL_TIMEOUT"
+    local non_interactive=false
+    local clean_logs=false
+    local target_agent=""
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --help|-h)
+                show_help
+                exit 0
+                ;;
+            --force|-f)
+                force=true
+                shift
+                ;;
+            --timeout)
+                if [[ -z "${2:-}" ]]; then
+                    echo -e "${RED}Error: --timeout requires a number${NC}" >&2
+                    exit 1
+                fi
+                timeout="$2"
+                shift 2
+                ;;
+            --yes|-y)
+                non_interactive=true
+                shift
+                ;;
+            --clean)
+                clean_logs=true
+                shift
+                ;;
+            -*)
+                echo -e "${RED}Error: Unknown option '$1'${NC}" >&2
+                echo "Use 'loom stop --help' for usage" >&2
+                exit 1
+                ;;
+            *)
+                target_agent="$1"
+                shift
+                ;;
+        esac
+    done
+
+    # Check if tmux is available
+    if ! command -v tmux &> /dev/null; then
+        echo -e "${RED}Error: tmux is not installed${NC}" >&2
+        exit 1
+    fi
+
+    # Single agent stop
+    if [[ -n "$target_agent" ]]; then
+        local session_name="$target_agent"
+        if [[ ! "$session_name" =~ ^loom- ]]; then
+            session_name="loom-$target_agent"
+        fi
+
+        if ! tmux -L "$TMUX_SOCKET" has-session -t "$session_name" 2>/dev/null; then
+            echo -e "${YELLOW}Session '$session_name' is not running${NC}"
+            exit 0
+        fi
+
+        echo -e "${BOLD}Stopping $session_name...${NC}"
+
+        if [[ "$force" == "true" ]]; then
+            tmux -L "$TMUX_SOCKET" kill-session -t "$session_name"
+            echo -e "${GREEN}Session killed${NC}"
+        else
+            stop_session "$session_name" false
+            sleep 2
+
+            if tmux -L "$TMUX_SOCKET" has-session -t "$session_name" 2>/dev/null; then
+                echo -e "${YELLOW}Session still running, force killing...${NC}"
+                tmux -L "$TMUX_SOCKET" kill-session -t "$session_name" 2>/dev/null || true
+            fi
+            echo -e "${GREEN}Session stopped${NC}"
+        fi
+
+        exit 0
+    fi
+
+    # All agents stop
+    local current_count
+    current_count=$(count_sessions)
+
+    if [[ "$current_count" -eq 0 ]]; then
+        echo -e "${GRAY}No Loom sessions running${NC}"
+
+        # Clean up stale signal file if exists
+        if [[ -f "$STOP_SIGNAL" ]]; then
+            rm -f "$STOP_SIGNAL"
+            echo -e "${GRAY}Removed stale stop signal${NC}"
+        fi
+
+        if [[ "$clean_logs" == "true" ]]; then
+            cleanup_logs
+        fi
+
+        exit 0
+    fi
+
+    echo -e "${BOLD}Loom Stop${NC}"
+    echo ""
+    echo -e "  Running sessions: ${CYAN}$current_count${NC}"
+    echo ""
+
+    if [[ "$force" == "true" ]]; then
+        echo -e "${YELLOW}Force stopping all sessions...${NC}"
+        echo ""
+
+        get_running_sessions | while read -r session; do
+            echo -e "  ${RED}Killing:${NC} $session"
+            tmux -L "$TMUX_SOCKET" kill-session -t "$session" 2>/dev/null || true
+        done
+
+        echo ""
+        echo -e "${GREEN}All sessions killed${NC}"
+    else
+        echo -e "${CYAN}Starting graceful shutdown...${NC}"
+        echo ""
+
+        # Create stop signal file
+        touch "$STOP_SIGNAL"
+        echo -e "  ${GREEN}Created stop signal: $STOP_SIGNAL${NC}"
+
+        # Send Ctrl+C to all sessions to interrupt current operations
+        get_running_sessions | while read -r session; do
+            echo -e "  ${CYAN}Signaling:${NC} $session"
+            tmux -L "$TMUX_SOCKET" send-keys -t "$session" C-c 2>/dev/null || true
+        done
+
+        echo ""
+
+        # Wait for graceful shutdown
+        if wait_for_sessions "$timeout"; then
+            echo ""
+        else
+            echo ""
+            echo -e "${YELLOW}Force killing remaining sessions...${NC}"
+
+            get_running_sessions | while read -r session; do
+                echo -e "  ${RED}Killing:${NC} $session"
+                tmux -L "$TMUX_SOCKET" kill-session -t "$session" 2>/dev/null || true
+            done
+        fi
+
+        # Remove stop signal
+        rm -f "$STOP_SIGNAL"
+        echo -e "${GRAY}Removed stop signal${NC}"
+    fi
+
+    # Clean up logs if requested
+    if [[ "$clean_logs" == "true" ]]; then
+        echo ""
+        cleanup_logs
+    fi
+
+    echo ""
+    echo -e "${GREEN}Shutdown complete${NC}"
+}
+
+main "$@"

--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -478,6 +478,15 @@ cp "$LOOM_ROOT/scripts/cleanup-branches.sh" ".loom/scripts/cleanup-branches.sh" 
 chmod +x ".loom/scripts/cleanup.sh"
 chmod +x ".loom/scripts/cleanup-branches.sh"
 success "Installed cleanup scripts to .loom/scripts/"
+
+# Install Loom CLI wrapper (./loom)
+if [[ -f "$LOOM_ROOT/defaults/loom" ]]; then
+  info "Installing Loom CLI wrapper..."
+  cp "$LOOM_ROOT/defaults/loom" "./loom" || \
+    error "Failed to copy Loom CLI"
+  chmod +x "./loom"
+  success "Installed ./loom CLI"
+fi
 echo ""
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- Add CLI entry point `./loom` that dispatches to subcommands for managing tmux-backed agent pools
- Implement `loom start` to spawn agent pool from `.loom/config.json` with `--only` filtering
- Implement `loom stop` for graceful shutdown with `--force` option and single-agent stopping
- Implement `loom attach` to connect to agent terminals via tmux
- Implement `loom scale` for dynamic agent scaling (scale up/down by role)
- Implement `loom logs` to tail agent output with `--all` option for interleaved logs
- Integrate `loom status` with existing `loom-status.sh` for consistent output
- Update `install-loom.sh` to copy CLI wrapper to workspace root during installation

## Test plan

- [x] Verify shell script syntax: `bash -n defaults/loom && bash -n defaults/scripts/cli/*.sh`
- [x] Verify `./loom help` displays comprehensive usage information
- [x] Verify each subcommand has `--help` documentation
- [x] Verify daemon tests pass: `pnpm daemon:test`
- [ ] Manual test: Run `./loom start --dry-run` in an installed workspace
- [ ] Manual test: Run `./loom status` to verify integration with existing status script
- [ ] Manual test: Run `./loom logs --list` to verify log discovery

Closes #1330

Generated with [Claude Code](https://claude.com/claude-code)