### PR TITLE
Integrate tmux agent pool with /loom daemon mode

### DIFF
--- a/defaults/.claude/commands/loom-iteration.md
+++ b/defaults/.claude/commands/loom-iteration.md
@@ -11,17 +11,82 @@ You are the Layer 2 Loom Daemon running in ITERATION MODE in the {{workspace}} r
 In iteration mode, you:
 1. Load state from JSON
 2. Check shutdown signal
-3. Assess system state via `daemon-snapshot.sh`
-4. Check subagent completions
-5. Auto-promote proposals (if force mode)
-6. Spawn shepherds for ready issues
-7. Trigger work generation
-8. Ensure support roles
-9. Detect stuck agents
-10. Save state to JSON
-11. **Return a compact 1-line summary and EXIT**
+3. Detect execution mode (mcp > tmux > direct)
+4. Assess system state via `daemon-snapshot.sh`
+5. Check subagent completions
+6. Auto-promote proposals (if force mode)
+7. Spawn shepherds for ready issues (using appropriate dispatch method)
+8. Trigger work generation
+9. Ensure support roles
+10. Detect stuck agents
+11. Save state to JSON
+12. **Return a compact 1-line summary and EXIT**
 
 **CRITICAL**: After completing the iteration, return ONLY the summary line. Do NOT loop. Do NOT spawn iteration subagents. The parent loop handles repetition.
+
+## Execution Mode Detection
+
+The daemon supports three execution backends, selected automatically in priority order:
+
+| Mode | Detection | Description |
+|------|-----------|-------------|
+| `mcp` | MCP tools available (Tauri app running) | Delegate to Tauri-managed terminals |
+| `tmux` | `tmux -L loom has-session` succeeds | Delegate to tmux-backed agent sessions |
+| `direct` | Default fallback | Spawn Task subagents directly |
+
+**Mode selection is automatic** - the daemon detects which backend is available and uses the highest-priority option.
+
+```python
+def detect_execution_mode(debug_mode=False):
+    """Detect available execution backend in priority order: mcp > tmux > direct."""
+
+    def debug(msg):
+        if debug_mode:
+            print(f"[DEBUG] {msg}")
+
+    # Priority 1: Check for MCP (Tauri app running)
+    # MCP mode is detected by checking if mcp__loom_terminals tools are available
+    # For now, we check via the get_ui_state heartbeat approach
+    try:
+        heartbeat = mcp__loom_ui__get_heartbeat()
+        if heartbeat and heartbeat.get("status") in ["healthy", "active", "idle"]:
+            debug("Mode detection: MCP available (Tauri app running)")
+            return "mcp"
+    except Exception:
+        pass  # MCP not available
+
+    # Priority 2: Check for tmux agent pool
+    result = run("tmux -L loom has-session 2>/dev/null && echo 'yes' || echo 'no'")
+    if result.strip() == "yes":
+        # Verify we have shepherd agents available
+        sessions = run("tmux -L loom list-sessions -F '#{session_name}' 2>/dev/null || true")
+        shepherd_sessions = [s for s in sessions.strip().split('\n') if 'shepherd' in s.lower()]
+        if len(shepherd_sessions) > 0:
+            debug(f"Mode detection: tmux pool available ({len(shepherd_sessions)} shepherd sessions)")
+            return "tmux"
+        debug("Mode detection: tmux server running but no shepherd sessions")
+
+    # Priority 3: Fall back to direct mode (Task subagents)
+    debug("Mode detection: using direct mode (Task subagents)")
+    return "direct"
+
+
+def get_tmux_idle_shepherds(debug_mode=False):
+    """Get list of idle shepherd agents in the tmux pool."""
+
+    def debug(msg):
+        if debug_mode:
+            print(f"[DEBUG] {msg}")
+
+    # Get all shepherd sessions
+    sessions = run("tmux -L loom list-sessions -F '#{session_name}' 2>/dev/null || true")
+    shepherd_sessions = [s for s in sessions.strip().split('\n') if s.startswith('loom-shepherd')]
+
+    # For now, assume all shepherd sessions are available
+    # More sophisticated status detection can be added later via progress files
+    debug(f"tmux shepherd sessions: {shepherd_sessions}")
+    return shepherd_sessions
+```
 
 ## Iteration Execution
 
@@ -53,6 +118,14 @@ def loom_iterate(force_mode=False, debug_mode=False):
     if exists(".loom/stop-daemon"):
         debug("Shutdown signal detected")
         return "SHUTDOWN_SIGNAL"
+
+    # 2b. Detect execution mode (mcp > tmux > direct)
+    execution_mode = state.get("execution_mode")
+    if not execution_mode or iteration == 1:
+        execution_mode = detect_execution_mode(debug_mode)
+        state["execution_mode"] = execution_mode
+        save_daemon_state(state)
+    debug(f"Execution mode: {execution_mode}")
 
     # 3. CRITICAL: Get system state via daemon-snapshot.sh
     # This is the CANONICAL source for all state and recommended actions
@@ -91,7 +164,7 @@ def loom_iterate(force_mode=False, debug_mode=False):
     spawned_shepherds = []
     if "spawn_shepherds" in recommended_actions:
         debug(f"Shepherd pool: {format_shepherd_pool(state)}")
-        spawned_shepherds = auto_spawn_shepherds(state, snapshot_data, debug_mode)
+        spawned_shepherds = auto_spawn_shepherds(state, snapshot_data, execution_mode, debug_mode)
 
     # 7. CRITICAL: Act on recommended_actions: trigger_architect, trigger_hermit
     triggered_generation = {"architect": False, "hermit": False}
@@ -142,6 +215,7 @@ ready=5 building=2 shepherds=2/3 +shepherd=#123 +architect
 ```
 
 **Summary components:**
+- `mode=X` - Execution mode (mcp/tmux/direct) - only shown on first iteration
 - `ready=N` - Issues with loom:issue label
 - `building=N` - Issues with loom:building label
 - `shepherds=N/M` - Active/max shepherds
@@ -164,12 +238,13 @@ ready=5 building=2 shepherds=2/3 +shepherd=#123 +architect
 
 **Example summaries:**
 ```
-ready=5 building=2 shepherds=2/3
+mode=tmux ready=5 building=2 shepherds=2/3
 ready=3 building=3 shepherds=3/3 +shepherd=#456 completed=#123
 ready=0 building=1 shepherds=1/3 +architect +hermit
 ready=2 building=2 shepherds=2/3 stuck=1
 ready=2 building=2 shepherds=2/3 spawn-fail=1
 ready=3 building=0 shepherds=0/3 promoted=3
+mode=direct ready=5 building=0 shepherds=0/3 (tmux pool not detected)
 SHUTDOWN_SIGNAL
 ```
 
@@ -244,8 +319,8 @@ fi
 > delegation (e.g., `Task(prompt="/builder 123")`). See `shepherd.md` for details.
 
 ```python
-def auto_spawn_shepherds(state, snapshot_data, debug_mode=False):
-    """Automatically spawn shepherds - NO human decision required."""
+def auto_spawn_shepherds(state, snapshot_data, execution_mode, debug_mode=False):
+    """Automatically spawn shepherds using the appropriate execution backend."""
 
     def debug(msg):
         if debug_mode:
@@ -264,9 +339,23 @@ def auto_spawn_shepherds(state, snapshot_data, debug_mode=False):
 
     debug(f"Issue selection: {len(ready_issues)} ready issues, {active_count}/{max_shepherds} shepherds active")
     debug(f"Shepherd mode: {shepherd_flag} (force_mode={force_mode})")
+    debug(f"Execution mode: {execution_mode}")
 
     spawned = []
     spawn_failures = 0
+
+    # For tmux mode, get available idle shepherd sessions
+    tmux_idle_shepherds = []
+    if execution_mode == "tmux":
+        tmux_idle_shepherds = get_tmux_idle_shepherds(debug_mode)
+        # Filter to only idle ones (not currently assigned to issues)
+        assigned_shepherds = set()
+        for shepherd_id, info in state.get("shepherds", {}).items():
+            if info.get("issue") and info.get("tmux_session"):
+                assigned_shepherds.add(info["tmux_session"])
+        tmux_idle_shepherds = [s for s in tmux_idle_shepherds if s not in assigned_shepherds]
+        debug(f"tmux idle shepherds: {tmux_idle_shepherds}")
+        max_shepherds = len(tmux_idle_shepherds) + active_count  # Limit to available tmux sessions
 
     while active_count < max_shepherds and len(ready_issues) > 0:
         issue = ready_issues.pop(0)["number"]
@@ -276,42 +365,131 @@ def auto_spawn_shepherds(state, snapshot_data, debug_mode=False):
         # Claim immediately (atomic operation)
         run(f"gh issue edit {issue} --remove-label 'loom:issue' --add-label 'loom:building'")
 
-        # Spawn shepherd
-        result = Task(
-            description=f"Shepherd issue #{issue}",
-            prompt=f"""You must invoke the Skill tool to execute the shepherd workflow.
+        # Dispatch based on execution mode
+        if execution_mode == "tmux":
+            # tmux mode: Send command to idle shepherd session
+            result = dispatch_shepherd_tmux(issue, shepherd_flag, tmux_idle_shepherds, state, debug_mode)
+        else:
+            # direct mode: Spawn Task subagent
+            result = dispatch_shepherd_direct(issue, shepherd_flag, debug_mode)
+
+        # Verify spawn succeeded
+        if not result.get("success"):
+            debug(f"Spawn failed for #{issue}: {result.get('error', 'unknown')}, reverting labels")
+            run(f"gh issue edit {issue} --remove-label 'loom:building' --add-label 'loom:issue'")
+            spawn_failures += 1
+            continue
+
+        debug(f"Spawning decision: shepherd assigned to #{issue} (verified)")
+
+        # Record assignment based on mode
+        if execution_mode == "tmux":
+            debug(f"  tmux session: {result['tmux_session']}")
+            record_shepherd_assignment_tmux(state, issue, result["tmux_session"])
+            # Remove from idle pool
+            if result["tmux_session"] in tmux_idle_shepherds:
+                tmux_idle_shepherds.remove(result["tmux_session"])
+        else:
+            debug(f"  Task ID: {result['task_id']}")
+            debug(f"  Output file: {result['output_file']}")
+            record_shepherd_assignment(state, issue, result["task_id"], result["output_file"])
+
+        active_count += 1
+        spawned.append(issue)
+
+        mode_suffix = f"tmux:{result.get('tmux_session', '')}" if execution_mode == "tmux" else "direct"
+        print(f"  AUTO-SPAWNED: shepherd for issue #{issue} ({shepherd_flag}, {mode_suffix})")
+
+    if len(spawned) == 0 and len(ready_issues) == 0:
+        debug("No shepherds spawned: no ready issues available")
+    elif len(spawned) == 0:
+        if execution_mode == "tmux" and len(tmux_idle_shepherds) == 0:
+            debug("No shepherds spawned: no idle tmux sessions available")
+        else:
+            debug(f"No shepherds spawned: at capacity ({max_shepherds} max)")
+
+    return {"spawned": spawned, "failures": spawn_failures}
+
+
+def dispatch_shepherd_tmux(issue, shepherd_flag, idle_shepherds, state, debug_mode=False):
+    """Dispatch shepherd work to an idle tmux session via loom send."""
+
+    def debug(msg):
+        if debug_mode:
+            print(f"[DEBUG] {msg}")
+
+    if len(idle_shepherds) == 0:
+        return {"success": False, "error": "no_idle_shepherds"}
+
+    # Pick first idle shepherd
+    tmux_session = idle_shepherds[0]
+    agent_name = tmux_session.replace("loom-", "")  # e.g., "shepherd-1"
+
+    # Send the shepherd command
+    command = f"/shepherd {issue} {shepherd_flag}"
+    debug(f"Sending to {tmux_session}: {command}")
+
+    result = run(f'./.loom/scripts/cli/loom-send.sh "{agent_name}" "{command}" --json')
+
+    try:
+        send_result = json.loads(result)
+        if send_result.get("success"):
+            return {
+                "success": True,
+                "tmux_session": tmux_session,
+                "command": command
+            }
+        else:
+            return {"success": False, "error": send_result.get("error", "send_failed")}
+    except Exception as e:
+        debug(f"Failed to parse loom send result: {e}")
+        return {"success": False, "error": str(e)}
+
+
+def dispatch_shepherd_direct(issue, shepherd_flag, debug_mode=False):
+    """Dispatch shepherd as a Task subagent (direct mode)."""
+
+    def debug(msg):
+        if debug_mode:
+            print(f"[DEBUG] {msg}")
+
+    result = Task(
+        description=f"Shepherd issue #{issue}",
+        prompt=f"""You must invoke the Skill tool to execute the shepherd workflow.
 
 IMPORTANT: Do NOT use CLI commands like 'claude --skill=shepherd'. Use the Skill tool:
 
 Skill(skill="shepherd", args="{issue} {shepherd_flag}")
 
 Follow all shepherd workflow steps until the issue is complete or blocked.""",
-            run_in_background=True
-        )
+        run_in_background=True
+    )
 
-        # Verify the task actually started before recording
-        if not verify_task_spawn(result, f"shepherd for #{issue}"):
-            debug(f"Spawn verification failed for #{issue}, reverting labels")
-            run(f"gh issue edit {issue} --remove-label 'loom:building' --add-label 'loom:issue'")
-            spawn_failures += 1
-            continue
+    # Verify the task actually started before recording
+    if not verify_task_spawn(result, f"shepherd for #{issue}"):
+        return {"success": False, "error": "verification_failed"}
 
-        debug(f"Spawning decision: shepherd assigned to #{issue} (verified)")
-        debug(f"  Task ID: {result.task_id}")
-        debug(f"  Output file: {result.output_file}")
+    return {
+        "success": True,
+        "task_id": result.task_id,
+        "output_file": result.output_file
+    }
 
-        record_shepherd_assignment(state, issue, result.task_id, result.output_file)
-        active_count += 1
-        spawned.append(issue)
 
-        print(f"  AUTO-SPAWNED: shepherd for issue #{issue} ({shepherd_flag}, verified)")
+def record_shepherd_assignment_tmux(state, issue, tmux_session):
+    """Record shepherd assignment for tmux mode."""
+    if "shepherds" not in state:
+        state["shepherds"] = {}
 
-    if len(spawned) == 0 and len(ready_issues) == 0:
-        debug("No shepherds spawned: no ready issues available")
-    elif len(spawned) == 0:
-        debug(f"No shepherds spawned: at capacity ({max_shepherds} max)")
-
-    return {"spawned": spawned, "failures": spawn_failures}
+    shepherd_id = tmux_session.replace("loom-", "")  # e.g., "shepherd-1"
+    state["shepherds"][shepherd_id] = {
+        "status": "working",
+        "issue": issue,
+        "tmux_session": tmux_session,
+        "started": now(),
+        "execution_mode": "tmux"
+    }
+    save_daemon_state(state)
 ```
 
 ## Auto-Promote Proposals (Force Mode Only)
@@ -784,8 +962,11 @@ if "iterate" in args:
 
 When running with `--debug`, iteration produces verbose logging:
 
+**Direct Mode (Task subagents):**
 ```
 [DEBUG] Iteration 5 starting at 2026-01-25T10:30:00Z
+[DEBUG] Mode detection: using direct mode (Task subagents)
+[DEBUG] Execution mode: direct
 [DEBUG] Pipeline state: ready=3 building=1 review_requested=2
 [DEBUG] Shepherd pool: shepherd-1=working(#123) shepherd-2=idle shepherd-3=idle
 [DEBUG] Issue selection: Considering #456 (age: 2h, priority: normal)
@@ -796,4 +977,19 @@ When running with `--debug`, iteration produces verbose logging:
 [DEBUG]   Output file: /tmp/claude/.../abc123.output
 [DEBUG]   Command: /shepherd 456 --force-merge
 [DEBUG] Iteration 5 completed in 1.2s
+```
+
+**tmux Mode (tmux agent pool):**
+```
+[DEBUG] Iteration 5 starting at 2026-01-25T10:30:00Z
+[DEBUG] Mode detection: tmux pool available (3 shepherd sessions)
+[DEBUG] Execution mode: tmux
+[DEBUG] Pipeline state: ready=3 building=1 review_requested=2
+[DEBUG] tmux shepherd sessions: ['loom-shepherd-1', 'loom-shepherd-2', 'loom-shepherd-3']
+[DEBUG] tmux idle shepherds: ['loom-shepherd-2', 'loom-shepherd-3']
+[DEBUG] Issue selection: Claiming #456
+[DEBUG] Sending to loom-shepherd-2: /shepherd 456 --force-merge
+[DEBUG] Spawning decision: shepherd assigned to #456 (verified)
+[DEBUG]   tmux session: loom-shepherd-2
+[DEBUG] Iteration 5 completed in 0.8s
 ```

--- a/defaults/loom
+++ b/defaults/loom
@@ -8,6 +8,7 @@
 #   status    Display agent pool state
 #   stop      Graceful shutdown
 #   attach    Open live tmux session
+#   send      Send command to agent session
 #   scale     Dynamic agent scaling
 #   logs      Tail agent output
 #   help      Show help
@@ -138,6 +139,15 @@ case "${1:-help}" in
             exit 1
         fi
         ;;
+    send)
+        shift
+        if [[ -f "$CLI_DIR/loom-send.sh" ]]; then
+            exec "$CLI_DIR/loom-send.sh" "$@"
+        else
+            echo -e "${RED}Error: loom-send.sh not found${NC}" >&2
+            exit 1
+        fi
+        ;;
     help|--help|-h)
         shift || true
         if [[ -f "$CLI_DIR/loom-help.sh" ]]; then
@@ -155,6 +165,7 @@ COMMANDS:
     status    Display agent pool state and work queues
     stop      Graceful shutdown (or --force to kill immediately)
     attach    Open live tmux session for an agent
+    send      Send command to agent session
     scale     Dynamic agent scaling
     logs      Tail agent output
     help      Show this help message
@@ -165,6 +176,7 @@ EXAMPLES:
     ./loom status                 Show current state
     ./loom status --json          Machine-readable status
     ./loom attach shepherd-1      Connect to agent terminal
+    ./loom send shepherd-1 "/shepherd 123"  Send command to agent
     ./loom stop                   Graceful shutdown
     ./loom stop --force           Force kill all sessions
     ./loom stop shepherd-1        Stop single agent

--- a/defaults/scripts/cli/loom-help.sh
+++ b/defaults/scripts/cli/loom-help.sh
@@ -72,6 +72,7 @@ ${YELLOW}COMMANDS:${NC}
     ${GREEN}status${NC}    Display agent pool state and work queues
     ${GREEN}stop${NC}      Graceful shutdown (or --force to kill immediately)
     ${GREEN}attach${NC}    Open live tmux session for an agent
+    ${GREEN}send${NC}      Send command to agent session
     ${GREEN}scale${NC}     Dynamic agent scaling
     ${GREEN}logs${NC}      Tail agent output
     ${GREEN}help${NC}      Show this help message
@@ -86,6 +87,9 @@ ${YELLOW}QUICK START:${NC}
     ${GRAY}# View an agent's terminal${NC}
     ./loom attach shepherd-1
 
+    ${GRAY}# Send a command to an agent${NC}
+    ./loom send shepherd-1 "/shepherd 123 --force-pr"
+
     ${GRAY}# View logs${NC}
     ./loom logs shepherd-1
 
@@ -98,6 +102,7 @@ ${YELLOW}EXAMPLES:${NC}
     ./loom status                 Show current state
     ./loom status --json          Machine-readable status
     ./loom attach shepherd-1      Connect to agent terminal
+    ./loom send shepherd-1 "/shepherd 123"  Send command to agent
     ./loom stop                   Graceful shutdown
     ./loom stop --force           Force kill all sessions
     ./loom stop shepherd-1        Stop single agent
@@ -198,13 +203,21 @@ show_command_help() {
                 exit 1
             fi
             ;;
+        send)
+            if [[ -n "$CLI_DIR" && -f "$CLI_DIR/loom-send.sh" ]]; then
+                exec "$CLI_DIR/loom-send.sh" --help
+            else
+                echo -e "${RED}Error: send command not installed${NC}"
+                exit 1
+            fi
+            ;;
         help)
             show_main_help
             ;;
         *)
             echo -e "${RED}Error: Unknown command '$command'${NC}"
             echo ""
-            echo "Available commands: start, status, stop, attach, scale, logs, help"
+            echo "Available commands: start, status, stop, attach, send, scale, logs, help"
             exit 1
             ;;
     esac

--- a/defaults/scripts/cli/loom-send.sh
+++ b/defaults/scripts/cli/loom-send.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+# loom send - Send command to a tmux agent session
+#
+# Usage:
+#   loom send <agent-name> "<command>"   Send command to agent
+#   loom send --list                     List available sessions
+#   loom send --help                     Show help
+#
+# Examples:
+#   loom send shepherd-1 "/shepherd 123 --force-pr"
+#   loom send terminal-2 "/builder 456"
+#   loom send champion "/champion"
+#
+# Notes:
+#   - Commands are sent with a trailing newline (Enter key)
+#   - Returns immediately (non-blocking)
+#   - Agent must be running in tmux pool
+
+set -euo pipefail
+
+# Find repository root
+find_repo_root() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.loom" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        if [[ -f "$dir/.git" ]]; then
+            local gitdir
+            gitdir=$(sed 's/^gitdir: //' "$dir/.git")
+            local main_repo
+            main_repo=$(dirname "$(dirname "$(dirname "$gitdir")")")
+            if [[ -d "$main_repo/.loom" ]]; then
+                echo "$main_repo"
+                return 0
+            fi
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo ""
+}
+
+REPO_ROOT=$(find_repo_root)
+TMUX_SOCKET="loom"
+
+# ANSI colors
+if [[ -t 1 ]]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    CYAN='\033[0;36m'
+    GRAY='\033[0;90m'
+    BOLD='\033[1m'
+    NC='\033[0m'
+else
+    RED=''
+    GREEN=''
+    YELLOW=''
+    CYAN=''
+    GRAY=''
+    BOLD=''
+    NC=''
+fi
+
+# Show help
+show_help() {
+    cat <<EOF
+${BOLD}loom send - Send command to a tmux agent session${NC}
+
+${YELLOW}USAGE:${NC}
+    loom send <agent-name> "<command>"   Send command to agent
+    loom send --list                     List available sessions
+    loom send --help                     Show this help
+
+${YELLOW}OPTIONS:${NC}
+    --list, -l        List available sessions to send to
+    --no-newline      Don't append newline (Enter key)
+    --wait <ms>       Wait for specified milliseconds after sending
+    --json            Output result as JSON
+
+${YELLOW}EXAMPLES:${NC}
+    loom send shepherd-1 "/shepherd 123 --force-pr"
+    loom send terminal-2 "/builder 456"
+    loom send champion "/champion"
+
+${YELLOW}SESSION NAMING:${NC}
+    Loom uses tmux sessions with the naming pattern:
+      loom-<agent-name>           e.g., loom-shepherd-1, loom-terminal-2
+
+    You can specify either the full session name or just the agent name:
+      loom send loom-shepherd-1 "..."   (full name)
+      loom send shepherd-1 "..."        (short name - loom- prefix added)
+
+${YELLOW}NOTES:${NC}
+    - Commands are sent with a trailing newline (Enter key) by default
+    - Returns immediately after sending (non-blocking)
+    - Use with daemon iteration to dispatch work to tmux agents
+    - Exit code 0 = success, 1 = error, 2 = session not found
+EOF
+}
+
+# List available sessions
+list_sessions() {
+    local json_output="${1:-false}"
+
+    if [[ "$json_output" == "true" ]]; then
+        # JSON output
+        local sessions
+        sessions=$(tmux -L "$TMUX_SOCKET" list-sessions -F "#{session_name}" 2>/dev/null || true)
+
+        if [[ -z "$sessions" ]]; then
+            echo '{"sessions":[],"count":0}'
+            return 0
+        fi
+
+        local json_array="["
+        local first=true
+        while IFS= read -r session; do
+            if [[ -n "$session" ]]; then
+                if [[ "$first" == "true" ]]; then
+                    first=false
+                else
+                    json_array+=","
+                fi
+                json_array+="\"$session\""
+            fi
+        done <<< "$sessions"
+        json_array+="]"
+
+        local count
+        count=$(echo "$sessions" | grep -c . || echo "0")
+        echo "{\"sessions\":$json_array,\"count\":$count}"
+        return 0
+    fi
+
+    echo -e "${BOLD}Available Loom sessions:${NC}"
+    echo ""
+
+    # Check if tmux is running with loom socket
+    if ! tmux -L "$TMUX_SOCKET" list-sessions 2>/dev/null; then
+        echo -e "${YELLOW}No Loom sessions found${NC}"
+        echo ""
+        echo "Start agents with: loom start"
+        return 0
+    fi
+
+    echo ""
+    echo -e "${CYAN}To send command:${NC} loom send <name> \"<command>\""
+}
+
+# Send command to session
+send_to_session() {
+    local session_name="$1"
+    local command="$2"
+    local append_newline="${3:-true}"
+    local wait_ms="${4:-0}"
+    local json_output="${5:-false}"
+
+    # Normalize session name (add loom- prefix if not present)
+    if [[ ! "$session_name" =~ ^loom- ]]; then
+        session_name="loom-$session_name"
+    fi
+
+    # Check if session exists
+    if ! tmux -L "$TMUX_SOCKET" has-session -t "$session_name" 2>/dev/null; then
+        if [[ "$json_output" == "true" ]]; then
+            echo "{\"success\":false,\"error\":\"session_not_found\",\"session\":\"$session_name\"}"
+        else
+            echo -e "${RED}Error: Session '$session_name' is not running${NC}" >&2
+            echo "" >&2
+            echo "Available sessions:" >&2
+            tmux -L "$TMUX_SOCKET" list-sessions 2>/dev/null || echo "  (none running)" >&2
+        fi
+        return 2
+    fi
+
+    # Send the command
+    if [[ "$append_newline" == "true" ]]; then
+        # Send with Enter key
+        tmux -L "$TMUX_SOCKET" send-keys -t "$session_name" "$command" C-m
+    else
+        # Send without Enter key
+        tmux -L "$TMUX_SOCKET" send-keys -t "$session_name" "$command"
+    fi
+
+    # Wait if specified
+    if [[ "$wait_ms" -gt 0 ]]; then
+        # Convert ms to seconds for sleep (bash doesn't support ms natively)
+        local wait_sec
+        wait_sec=$(echo "scale=3; $wait_ms / 1000" | bc)
+        sleep "$wait_sec"
+    fi
+
+    if [[ "$json_output" == "true" ]]; then
+        echo "{\"success\":true,\"session\":\"$session_name\",\"command\":$(printf '%s' "$command" | jq -Rs .)}"
+    else
+        echo -e "${GREEN}Sent to $session_name${NC}"
+    fi
+
+    return 0
+}
+
+# Main logic
+main() {
+    local agent_name=""
+    local command=""
+    local append_newline=true
+    local wait_ms=0
+    local json_output=false
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --help|-h)
+                show_help
+                exit 0
+                ;;
+            --list|-l)
+                list_sessions "$json_output"
+                exit 0
+                ;;
+            --no-newline)
+                append_newline=false
+                shift
+                ;;
+            --wait)
+                if [[ -z "${2:-}" ]]; then
+                    echo -e "${RED}Error: --wait requires a value in milliseconds${NC}" >&2
+                    exit 1
+                fi
+                wait_ms="$2"
+                shift 2
+                ;;
+            --json)
+                json_output=true
+                shift
+                ;;
+            -*)
+                echo -e "${RED}Error: Unknown option '$1'${NC}" >&2
+                echo "Use 'loom send --help' for usage" >&2
+                exit 1
+                ;;
+            *)
+                if [[ -z "$agent_name" ]]; then
+                    agent_name="$1"
+                elif [[ -z "$command" ]]; then
+                    command="$1"
+                else
+                    echo -e "${RED}Error: Too many arguments${NC}" >&2
+                    echo "Usage: loom send <agent-name> \"<command>\"" >&2
+                    exit 1
+                fi
+                shift
+                ;;
+        esac
+    done
+
+    # Check if tmux is installed
+    if ! command -v tmux &> /dev/null; then
+        if [[ "$json_output" == "true" ]]; then
+            echo '{"success":false,"error":"tmux_not_installed"}'
+        else
+            echo -e "${RED}Error: tmux is not installed${NC}" >&2
+            echo "Install with: brew install tmux (macOS) or apt-get install tmux (Linux)" >&2
+        fi
+        exit 1
+    fi
+
+    # Validate arguments
+    if [[ -z "$agent_name" ]]; then
+        if [[ "$json_output" == "true" ]]; then
+            echo '{"success":false,"error":"missing_agent_name"}'
+        else
+            echo -e "${RED}Error: Agent name required${NC}" >&2
+            echo "Usage: loom send <agent-name> \"<command>\"" >&2
+        fi
+        exit 1
+    fi
+
+    if [[ -z "$command" ]]; then
+        if [[ "$json_output" == "true" ]]; then
+            echo '{"success":false,"error":"missing_command"}'
+        else
+            echo -e "${RED}Error: Command required${NC}" >&2
+            echo "Usage: loom send <agent-name> \"<command>\"" >&2
+        fi
+        exit 1
+    fi
+
+    send_to_session "$agent_name" "$command" "$append_newline" "$wait_ms" "$json_output"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

This PR integrates the tmux agent pool (Phase 1 + Phase 2) with the `/loom` daemon orchestration. The enhancement adds inspectable, persistent terminals for shepherds and support roles, replacing opaque Task subagent execution when a tmux pool is available.

- **Execution mode detection**: Daemon auto-detects available backends (MCP > tmux > direct) and uses the highest-priority option
- **New `loom send` CLI command**: Dispatches work to tmux agent sessions non-blocking
- **tmux shepherd dispatch**: Shepherds dispatched via `loom send` when tmux pool is running
- **Graceful fallback**: Falls back to Task subagents (direct mode) when no tmux pool detected
- **Observability**: tmux pool status included in daemon-snapshot.sh output

## Test plan

- [ ] Verify `loom send --help` shows correct usage
- [ ] Verify `loom send --list` shows available sessions (or "none running")
- [ ] Start tmux pool with `./loom start` and verify sessions created
- [ ] Run `/loom --debug` and verify "Execution mode: tmux" appears
- [ ] Verify shepherd dispatched via tmux mode (check logs)
- [ ] Stop tmux pool and verify fallback to "Execution mode: direct"
- [ ] Run `daemon-snapshot.sh --pretty` and verify tmux_pool section present

## Files Changed

| File | Change |
|------|--------|
| `defaults/scripts/cli/loom-send.sh` | New - Send command to tmux agent |
| `defaults/.claude/commands/loom-iteration.md` | Add tmux mode detection and dispatch |
| `defaults/.claude/commands/loom-parent.md` | Add mode announcement in startup banner |
| `defaults/scripts/daemon-snapshot.sh` | Add tmux pool status detection |
| `defaults/loom` | Add `send` command routing |
| `defaults/scripts/cli/loom-help.sh` | Add `send` command help |
| `defaults/scripts/cli/*.sh` | CLI infrastructure (start, stop, attach, scale, logs) |
| `scripts/install-loom.sh` | Install `./loom` CLI wrapper |

Closes #1331

---
Generated with [Claude Code](https://claude.com/claude-code)