### PR TITLE
Champion: Auto-create follow-on issues from merged PRs

### DIFF
--- a/defaults/roles/champion.json
+++ b/defaults/roles/champion.json
@@ -9,5 +9,13 @@
   "stuckThresholds": {
     "maxNoOutput": 300000,
     "maxNeedsInput": 120000
+  },
+  "followonIssues": {
+    "enabled": true,
+    "minTodosForIssue": 3,
+    "criticalPatterns": ["FIXME:", "HACK:", "XXX:"],
+    "standardPatterns": ["TODO:", "FUTURE:"],
+    "bodySections": ["Follow-on Work", "Follow-on", "Out of Scope", "Future Work", "Deferred", "Phase 2", "Phase II"],
+    "reviewIndicators": ["not blocking", "consider for future", "technical debt", "would be nice", "future enhancement", "could be improved"]
   }
 }


### PR DESCRIPTION
## Summary

- Adds Step 5.5 to Champion PR merge workflow to auto-create follow-on issues when PRs are merged
- Captures TODO/FIXME/HACK/XXX/FUTURE patterns from PR diffs with file:line attribution
- Parses PR body sections like "Follow-on Work", "Out of Scope", "Deferred", "Phase 2"
- Parses review comments for deferred suggestions ("not blocking", "consider for future", etc.)
- Applies threshold logic to avoid noise: requires critical patterns, explicit sections, or 3+ TODOs
- Includes duplicate detection to prevent redundant issues
- Supports force mode behavior: creates with `loom:issue` directly vs `loom:curated` for normal mode
- Adds configuration schema to champion.json with customizable patterns and thresholds

## Test plan

- [ ] Create PR with 3+ TODO comments in code, verify consolidated follow-on issue created after merge
- [ ] Create PR with "## Follow-on Work" section in body, verify items captured in issue
- [ ] Merge PR with Judge review comment containing "not blocking but consider...", verify captured
- [ ] Merge PR with no follow-on indicators, verify no spurious issue created
- [ ] Test duplicate detection: merge PR twice rapidly, verify only one follow-on issue exists
- [ ] Test force mode: verify follow-on issue gets `loom:issue` label when daemon in force mode

Closes #1340

Generated with [Claude Code](https://claude.com/claude-code)