### PR TITLE
Fix SIGINT handling during interactive prompts in install/uninstall scripts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,10 @@
 
 set -euo pipefail
 
+# Handle Ctrl-C and SIGTERM during interactive prompts
+trap 'echo ""; echo -e "\033[0;34mℹ Installation cancelled\033[0m"; exit 130' SIGINT
+trap 'exit 143' SIGTERM
+
 # ANSI color codes
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -105,7 +105,9 @@ cleanup_on_error() {
   fi
 }
 
-trap cleanup_on_error EXIT SIGINT SIGTERM
+trap cleanup_on_error EXIT
+trap 'exit 130' SIGINT
+trap 'exit 143' SIGTERM
 
 # Validate arguments
 if [[ -z "$TARGET_PATH" ]]; then

--- a/scripts/uninstall-loom.sh
+++ b/scripts/uninstall-loom.sh
@@ -112,7 +112,9 @@ cleanup_on_error() {
   fi
 }
 
-trap cleanup_on_error EXIT SIGINT SIGTERM
+trap cleanup_on_error EXIT
+trap 'exit 130' SIGINT
+trap 'exit 143' SIGTERM
 
 # Validate arguments
 if [[ -z "$TARGET_PATH" ]]; then

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -4,6 +4,10 @@
 
 set -euo pipefail
 
+# Handle Ctrl-C and SIGTERM during interactive prompts
+trap 'echo ""; echo -e "\033[0;34mℹ Uninstall cancelled\033[0m"; exit 130' SIGINT
+trap 'exit 143' SIGTERM
+
 # ANSI color codes
 RED='\033[0;31m'
 GREEN='\033[0;32m'


### PR DESCRIPTION
## Summary

Fixes Ctrl-C (SIGINT) being silently ignored during interactive `read` prompts in the install and uninstall scripts.

**Root cause**: Both core scripts used `trap cleanup_on_error EXIT SIGINT SIGTERM` which meant SIGINT called `cleanup_on_error` directly. That function checks `$?` and does cleanup but never calls `exit`, so the trap handler returns and bash suppresses the default SIGINT behavior, causing the `read` prompt to repeat instead of terminating.

**Fix**: Separate the EXIT trap from signal traps:
- `trap cleanup_on_error EXIT` - cleanup runs on any exit
- `trap 'exit 130' SIGINT` - Ctrl-C triggers exit with standard SIGINT code (128+2)
- `trap 'exit 143' SIGTERM` - SIGTERM triggers exit with standard code (128+15)

The `exit` call from the signal trap triggers the EXIT trap, which runs `cleanup_on_error` with a non-zero `$?`, performing cleanup before the script terminates.

**Wrapper scripts** (`install.sh`, `uninstall.sh`) also get SIGINT/SIGTERM traps added before their first `read` prompts.

## Files Changed

- `scripts/install-loom.sh` - Split combined trap into separate EXIT/SIGINT/SIGTERM handlers
- `scripts/uninstall-loom.sh` - Split combined trap into separate EXIT/SIGINT/SIGTERM handlers
- `install.sh` - Add SIGINT/SIGTERM trap before interactive prompts
- `uninstall.sh` - Add SIGINT/SIGTERM trap before interactive prompts

## Test Plan

- [ ] Ctrl-C during `read` prompt in `scripts/install-loom.sh` exits immediately
- [ ] Ctrl-C during `read` prompt in `scripts/uninstall-loom.sh` exits immediately
- [ ] Ctrl-C during `read` prompt in `install.sh` exits with "Installation cancelled"
- [ ] Ctrl-C during `read` prompt in `uninstall.sh` exits with "Uninstall cancelled"
- [ ] Cleanup (worktree removal) still runs when Ctrl-C is pressed after worktree creation
- [ ] Normal completion path is unaffected (traps disabled at end with `trap - EXIT SIGINT SIGTERM`)

Closes #1351