### PR TITLE
Fix daemon-cleanup.sh path references for installed repositories

### DIFF
--- a/defaults/.claude/commands/loom-parent.md
+++ b/defaults/.claude/commands/loom-parent.md
@@ -319,7 +319,7 @@ def start_daemon(force_mode=False, debug_mode=False):
             return
 
     # 5. Run startup cleanup
-    run("./scripts/daemon-cleanup.sh daemon-startup")
+    run("./.loom/scripts/daemon-cleanup.sh daemon-startup")
 
     # 6. Save initial state
     save_daemon_state(state)
@@ -453,7 +453,7 @@ def graceful_shutdown():
     # Cleanup signals and state
     rm(".loom/stop-shepherds")
     rm(".loom/stop-daemon")
-    run("./scripts/daemon-cleanup.sh daemon-shutdown")
+    run("./.loom/scripts/daemon-cleanup.sh daemon-shutdown")
     state["running"] = False
     state["stopped_at"] = now()
     save_daemon_state()

--- a/defaults/.claude/commands/loom-reference.md
+++ b/defaults/.claude/commands/loom-reference.md
@@ -449,13 +449,13 @@ The daemon integrates with cleanup scripts to manage task artifacts and worktree
 
 ```bash
 # Archive task outputs to .loom/logs/{date}/
-./scripts/archive-logs.sh [--dry-run] [--retention-days N]
+./.loom/scripts/archive-logs.sh [--dry-run] [--retention-days N]
 
 # Safe worktree cleanup (only MERGED PRs)
-./scripts/safe-worktree-cleanup.sh [--dry-run] [--grace-period N]
+./.loom/scripts/safe-worktree-cleanup.sh [--dry-run] [--grace-period N]
 
 # Event-driven daemon cleanup
-./scripts/daemon-cleanup.sh <event> [options]
+./.loom/scripts/daemon-cleanup.sh <event> [options]
 ```
 
 ### Cleanup Configuration


### PR DESCRIPTION
## Summary

- Fix daemon-cleanup.sh, archive-logs.sh, and safe-worktree-cleanup.sh path references in loom-parent.md and loom-reference.md to use `./.loom/scripts/` instead of `./scripts/`
- The scripts are already correctly copied during `loom-daemon init` (from `defaults/scripts/` to `.loom/scripts/`), but the pseudocode and documentation referenced the wrong paths, causing daemon startup/shutdown cleanup to fail in installed repositories

## Details

The `loom-parent.md` pseudocode referenced:
- `./scripts/daemon-cleanup.sh daemon-startup` (line 322)
- `./scripts/daemon-cleanup.sh daemon-shutdown` (line 456)

These paths only work in the Loom source repository where `scripts/` is at the repo root. In installed repositories, these scripts live at `.loom/scripts/` and must be referenced as `./.loom/scripts/daemon-cleanup.sh`.

Similarly, `loom-reference.md` documented cleanup scripts using `./scripts/` paths instead of `./.loom/scripts/`.

## Test plan

- [x] Verified all `daemon-cleanup.sh` references now use `./.loom/scripts/` path
- [x] Verified `archive-logs.sh` reference now uses `./.loom/scripts/` path
- [x] Verified `safe-worktree-cleanup.sh` reference now uses `./.loom/scripts/` path
- [x] Confirmed `.claude/commands` is a symlink to `defaults/.claude/commands`, so both are fixed
- [x] Confirmed no other incorrect path references remain in defaults/

Closes #1363