### PR TITLE
Add deterministic spawn-support-role.sh for daemon direct mode (#1357)

### DIFF
--- a/defaults/scripts/spawn-support-role.sh
+++ b/defaults/scripts/spawn-support-role.sh
@@ -1,0 +1,513 @@
+#!/bin/bash
+# spawn-support-role.sh - Deterministic support role spawn logic
+#
+# This script encapsulates the decision logic for spawning support roles
+# (Guide, Champion, Doctor, Auditor, Judge) in the daemon. It replaces
+# LLM-interpreted pseudocode with deterministic bash logic.
+#
+# The script does NOT spawn roles itself - it evaluates whether a role
+# should be spawned and updates daemon-state.json accordingly. The actual
+# spawning (Task subagent, tmux session, or MCP) is handled by the caller
+# (the iteration subagent or daemon-loop.sh).
+#
+# Usage:
+#   spawn-support-role.sh <role> [--demand] [--check-only] [--json]
+#   spawn-support-role.sh --check-all [--json]
+#   spawn-support-role.sh --mark-running <role> --task-id <id>
+#   spawn-support-role.sh --mark-completed <role>
+#   spawn-support-role.sh --help
+#
+# Options:
+#   <role>            Role name: guide, champion, doctor, auditor, judge
+#   --demand          Demand-based spawn (skip interval check)
+#   --check-only      Only check if spawn is needed, don't modify state
+#   --check-all       Check all support roles and output combined result
+#   --mark-running    Mark a role as running with the given task_id
+#   --mark-completed  Mark a role as completed (transition to idle)
+#   --json            Output JSON instead of human-readable text
+#   --help            Show this help message
+#
+# Exit Codes:
+#   0 - Role should be spawned (or state updated successfully)
+#   1 - Role should NOT be spawned (already running, interval not elapsed)
+#   2 - Error (invalid role, missing state file, etc.)
+#
+# Environment Variables:
+#   LOOM_GUIDE_INTERVAL      Guide re-trigger interval in seconds (default: 900)
+#   LOOM_CHAMPION_INTERVAL   Champion re-trigger interval in seconds (default: 600)
+#   LOOM_DOCTOR_INTERVAL     Doctor re-trigger interval in seconds (default: 300)
+#   LOOM_AUDITOR_INTERVAL    Auditor re-trigger interval in seconds (default: 600)
+#   LOOM_JUDGE_INTERVAL      Judge re-trigger interval in seconds (default: 300)
+#
+# Examples:
+#   # Check if Guide should be spawned (interval-based)
+#   spawn-support-role.sh guide
+#
+#   # Check if Champion should be spawned on-demand
+#   spawn-support-role.sh champion --demand
+#
+#   # Check all roles and get JSON output
+#   spawn-support-role.sh --check-all --json
+#
+#   # Mark role as running after successful Task spawn
+#   spawn-support-role.sh --mark-running champion --task-id a7dc1e0
+#
+#   # Mark role as completed
+#   spawn-support-role.sh --mark-completed champion
+
+set -euo pipefail
+
+# Find the repository root (works from any subdirectory)
+find_repo_root() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.git" ]] || [[ -f "$dir/.git" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo "Error: Not in a git repository" >&2
+    return 1
+}
+
+REPO_ROOT=$(find_repo_root)
+STATE_FILE="$REPO_ROOT/.loom/daemon-state.json"
+
+# Default intervals (in seconds)
+GUIDE_INTERVAL="${LOOM_GUIDE_INTERVAL:-900}"        # 15 minutes
+CHAMPION_INTERVAL="${LOOM_CHAMPION_INTERVAL:-600}"  # 10 minutes
+DOCTOR_INTERVAL="${LOOM_DOCTOR_INTERVAL:-300}"      # 5 minutes
+AUDITOR_INTERVAL="${LOOM_AUDITOR_INTERVAL:-600}"    # 10 minutes
+JUDGE_INTERVAL="${LOOM_JUDGE_INTERVAL:-300}"        # 5 minutes
+
+# Valid roles
+VALID_ROLES=("guide" "champion" "doctor" "auditor" "judge")
+
+show_help() {
+    cat <<'EOF'
+spawn-support-role.sh - Deterministic support role spawn logic
+
+USAGE:
+    spawn-support-role.sh <role> [--demand] [--check-only] [--json]
+    spawn-support-role.sh --check-all [--json]
+    spawn-support-role.sh --mark-running <role> --task-id <id>
+    spawn-support-role.sh --mark-completed <role>
+    spawn-support-role.sh --help
+
+ROLES:
+    guide       Backlog triage (interval: 15 min)
+    champion    PR merging and proposal evaluation (interval: 10 min)
+    doctor      PR conflict resolution (interval: 5 min)
+    auditor     Main branch validation (interval: 10 min)
+    judge       PR review (interval: 5 min)
+
+OPTIONS:
+    --demand        Demand-based spawn (skip interval check)
+    --check-only    Only check if spawn is needed, don't modify state
+    --check-all     Check all roles and output combined result
+    --mark-running  Mark a role as running with a task_id
+    --mark-completed Mark a role as completed (transition to idle)
+    --json          Output JSON format
+    --help          Show this help message
+
+EXIT CODES:
+    0 - Role should be spawned (or state updated)
+    1 - Role should NOT be spawned
+    2 - Error
+
+ENVIRONMENT VARIABLES:
+    LOOM_GUIDE_INTERVAL      (default: 900)
+    LOOM_CHAMPION_INTERVAL   (default: 600)
+    LOOM_DOCTOR_INTERVAL     (default: 300)
+    LOOM_AUDITOR_INTERVAL    (default: 600)
+    LOOM_JUDGE_INTERVAL      (default: 300)
+EOF
+}
+
+# Get the interval for a role
+get_interval() {
+    local role="$1"
+    case "$role" in
+        guide)    echo "$GUIDE_INTERVAL" ;;
+        champion) echo "$CHAMPION_INTERVAL" ;;
+        doctor)   echo "$DOCTOR_INTERVAL" ;;
+        auditor)  echo "$AUDITOR_INTERVAL" ;;
+        judge)    echo "$JUDGE_INTERVAL" ;;
+        *)        echo "0" ;;
+    esac
+}
+
+# Validate role name
+validate_role() {
+    local role="$1"
+    for valid in "${VALID_ROLES[@]}"; do
+        if [[ "$role" == "$valid" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Validate task_id format (7-char hex)
+validate_task_id() {
+    local task_id="$1"
+    if [[ -z "$task_id" ]]; then
+        return 1
+    fi
+    # Real Task tool IDs are 7-char lowercase hex strings
+    if [[ "$task_id" =~ ^[a-f0-9]{7}$ ]]; then
+        return 0
+    fi
+    return 1
+}
+
+# Convert ISO timestamp (UTC) to epoch seconds (cross-platform)
+iso_to_epoch() {
+    local timestamp="$1"
+    if [[ -z "$timestamp" || "$timestamp" == "null" ]]; then
+        echo "0"
+        return
+    fi
+    if [[ "$(uname)" == "Darwin" ]]; then
+        # macOS: date -j -f interprets as local time, so we must set TZ=UTC
+        TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$timestamp" "+%s" 2>/dev/null || echo "0"
+    else
+        # Linux: date -d handles ISO 8601 with timezone suffix natively
+        date -d "$timestamp" "+%s" 2>/dev/null || echo "0"
+    fi
+}
+
+# Check if a role should be spawned
+# Returns: JSON object with decision and reason
+check_role() {
+    local role="$1"
+    local demand_mode="${2:-false}"
+    local now_epoch
+    now_epoch=$(date +%s)
+
+    # Ensure state file exists
+    if [[ ! -f "$STATE_FILE" ]]; then
+        echo '{"should_spawn":true,"reason":"no_state_file","role":"'"$role"'"}'
+        return 0
+    fi
+
+    # Read role status from state
+    local status
+    status=$(jq -r ".support_roles.${role}.status // \"idle\"" "$STATE_FILE" 2>/dev/null || echo "idle")
+
+    # Check if already running - never spawn duplicates
+    if [[ "$status" == "running" ]]; then
+        local task_id
+        task_id=$(jq -r ".support_roles.${role}.task_id // \"\"" "$STATE_FILE" 2>/dev/null || echo "")
+
+        # Validate the task_id - if fabricated, treat as idle
+        if [[ -n "$task_id" && "$task_id" != "null" ]]; then
+            if validate_task_id "$task_id"; then
+                echo '{"should_spawn":false,"reason":"already_running","role":"'"$role"'","task_id":"'"$task_id"'"}'
+                return 1
+            else
+                # Fabricated task_id - treat as idle
+                echo '{"should_spawn":true,"reason":"fabricated_task_id","role":"'"$role"'","stale_task_id":"'"$task_id"'"}'
+                return 0
+            fi
+        fi
+        # Running but no task_id - something is wrong, allow spawn
+        echo '{"should_spawn":true,"reason":"running_no_task_id","role":"'"$role"'"}'
+        return 0
+    fi
+
+    # In demand mode, skip interval check
+    if [[ "$demand_mode" == "true" ]]; then
+        echo '{"should_spawn":true,"reason":"demand","role":"'"$role"'"}'
+        return 0
+    fi
+
+    # Check interval
+    local interval
+    interval=$(get_interval "$role")
+
+    local last_completed
+    last_completed=$(jq -r ".support_roles.${role}.last_completed // \"\"" "$STATE_FILE" 2>/dev/null || echo "")
+
+    if [[ -z "$last_completed" || "$last_completed" == "null" ]]; then
+        # Never completed - needs trigger
+        echo '{"should_spawn":true,"reason":"never_run","role":"'"$role"'"}'
+        return 0
+    fi
+
+    local last_epoch
+    last_epoch=$(iso_to_epoch "$last_completed")
+
+    if [[ "$last_epoch" == "0" ]]; then
+        # Invalid timestamp - needs trigger
+        echo '{"should_spawn":true,"reason":"invalid_timestamp","role":"'"$role"'"}'
+        return 0
+    fi
+
+    local elapsed=$((now_epoch - last_epoch))
+
+    if [[ $elapsed -gt $interval ]]; then
+        echo '{"should_spawn":true,"reason":"interval_elapsed","role":"'"$role"'","elapsed_seconds":'"$elapsed"',"interval_seconds":'"$interval"'}'
+        return 0
+    fi
+
+    local remaining=$((interval - elapsed))
+    echo '{"should_spawn":false,"reason":"interval_not_elapsed","role":"'"$role"'","elapsed_seconds":'"$elapsed"',"interval_seconds":'"$interval"',"remaining_seconds":'"$remaining"'}'
+    return 1
+}
+
+# Check all roles and output combined result
+check_all_roles() {
+    local json_output="${1:-false}"
+    local results="[]"
+    local any_should_spawn=false
+
+    for role in "${VALID_ROLES[@]}"; do
+        local result
+        result=$(check_role "$role" "false") && true || true
+
+        local should_spawn
+        should_spawn=$(echo "$result" | jq -r '.should_spawn')
+
+        if [[ "$should_spawn" == "true" ]]; then
+            any_should_spawn=true
+        fi
+
+        results=$(echo "$results" | jq --argjson entry "$result" '. + [$entry]')
+    done
+
+    if [[ "$json_output" == "true" ]]; then
+        jq -n \
+            --argjson results "$results" \
+            --argjson any_should_spawn "$any_should_spawn" \
+            '{roles: $results, any_should_spawn: $any_should_spawn}'
+    else
+        for role in "${VALID_ROLES[@]}"; do
+            local entry
+            entry=$(echo "$results" | jq -r ".[] | select(.role == \"$role\")")
+            local should_spawn reason
+            should_spawn=$(echo "$entry" | jq -r '.should_spawn')
+            reason=$(echo "$entry" | jq -r '.reason')
+
+            if [[ "$should_spawn" == "true" ]]; then
+                echo "  $role: SPAWN ($reason)"
+            else
+                local remaining
+                remaining=$(echo "$entry" | jq -r '.remaining_seconds // "n/a"')
+                echo "  $role: SKIP ($reason, ${remaining}s remaining)"
+            fi
+        done
+    fi
+
+    if [[ "$any_should_spawn" == "true" ]]; then
+        return 0
+    fi
+    return 1
+}
+
+# Mark a role as running in daemon-state.json
+mark_running() {
+    local role="$1"
+    local task_id="$2"
+    local now_iso
+    now_iso=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+    # Validate task_id format
+    if ! validate_task_id "$task_id"; then
+        echo "Error: Invalid task_id format: '$task_id' (expected 7-char hex like 'a7dc1e0')" >&2
+        return 2
+    fi
+
+    if [[ ! -f "$STATE_FILE" ]]; then
+        echo "Error: State file not found: $STATE_FILE" >&2
+        return 2
+    fi
+
+    # Atomic update using temp file
+    local temp_file
+    temp_file=$(mktemp)
+    if jq --arg role "$role" \
+          --arg task_id "$task_id" \
+          --arg started_at "$now_iso" \
+          '.support_roles[$role] = (.support_roles[$role] // {}) + {
+              status: "running",
+              task_id: $task_id,
+              started_at: $started_at
+          }' "$STATE_FILE" > "$temp_file" 2>/dev/null; then
+        mv "$temp_file" "$STATE_FILE"
+        echo "Marked $role as running (task_id=$task_id)"
+        return 0
+    else
+        rm -f "$temp_file"
+        echo "Error: Failed to update state file" >&2
+        return 2
+    fi
+}
+
+# Mark a role as completed in daemon-state.json
+mark_completed() {
+    local role="$1"
+    local now_iso
+    now_iso=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+    if [[ ! -f "$STATE_FILE" ]]; then
+        echo "Error: State file not found: $STATE_FILE" >&2
+        return 2
+    fi
+
+    # Atomic update using temp file
+    local temp_file
+    temp_file=$(mktemp)
+    if jq --arg role "$role" \
+          --arg last_completed "$now_iso" \
+          '.support_roles[$role] = (.support_roles[$role] // {}) + {
+              status: "idle",
+              task_id: null,
+              output_file: null,
+              last_completed: $last_completed
+          }' "$STATE_FILE" > "$temp_file" 2>/dev/null; then
+        mv "$temp_file" "$STATE_FILE"
+        echo "Marked $role as completed"
+        return 0
+    else
+        rm -f "$temp_file"
+        echo "Error: Failed to update state file" >&2
+        return 2
+    fi
+}
+
+# Main entry point
+main() {
+    local role=""
+    local demand_mode=false
+    local check_only=false
+    local check_all=false
+    local json_output=false
+    local mark_running_mode=false
+    local mark_completed_mode=false
+    local task_id=""
+
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --demand)
+                demand_mode=true
+                shift
+                ;;
+            --check-only)
+                check_only=true
+                shift
+                ;;
+            --check-all)
+                check_all=true
+                shift
+                ;;
+            --json)
+                json_output=true
+                shift
+                ;;
+            --mark-running)
+                mark_running_mode=true
+                role="$2"
+                shift 2
+                ;;
+            --mark-completed)
+                mark_completed_mode=true
+                role="$2"
+                shift 2
+                ;;
+            --task-id)
+                task_id="$2"
+                shift 2
+                ;;
+            --help|-h)
+                show_help
+                exit 0
+                ;;
+            -*)
+                echo "Unknown option: $1" >&2
+                exit 2
+                ;;
+            *)
+                if [[ -z "$role" ]]; then
+                    role="$1"
+                else
+                    echo "Unexpected argument: $1" >&2
+                    exit 2
+                fi
+                shift
+                ;;
+        esac
+    done
+
+    # Handle --check-all
+    if [[ "$check_all" == "true" ]]; then
+        check_all_roles "$json_output" && exit 0 || exit $?
+    fi
+
+    # Handle --mark-running
+    if [[ "$mark_running_mode" == "true" ]]; then
+        if [[ -z "$role" ]]; then
+            echo "Error: --mark-running requires a role name" >&2
+            exit 2
+        fi
+        if ! validate_role "$role"; then
+            echo "Error: Invalid role: $role" >&2
+            exit 2
+        fi
+        if [[ -z "$task_id" ]]; then
+            echo "Error: --mark-running requires --task-id" >&2
+            exit 2
+        fi
+        mark_running "$role" "$task_id"
+        exit $?
+    fi
+
+    # Handle --mark-completed
+    if [[ "$mark_completed_mode" == "true" ]]; then
+        if [[ -z "$role" ]]; then
+            echo "Error: --mark-completed requires a role name" >&2
+            exit 2
+        fi
+        if ! validate_role "$role"; then
+            echo "Error: Invalid role: $role" >&2
+            exit 2
+        fi
+        mark_completed "$role"
+        exit $?
+    fi
+
+    # Handle role check (default mode)
+    if [[ -z "$role" ]]; then
+        echo "Error: No role specified" >&2
+        echo "Usage: spawn-support-role.sh <role> [--demand] [--check-only] [--json]" >&2
+        exit 2
+    fi
+
+    if ! validate_role "$role"; then
+        echo "Error: Invalid role: $role (valid: ${VALID_ROLES[*]})" >&2
+        exit 2
+    fi
+
+    local result exit_code
+    result=$(check_role "$role" "$demand_mode") && exit_code=0 || exit_code=$?
+
+    if [[ "$json_output" == "true" ]]; then
+        echo "$result"
+    else
+        local should_spawn reason
+        should_spawn=$(echo "$result" | jq -r '.should_spawn')
+        reason=$(echo "$result" | jq -r '.reason')
+
+        if [[ "$should_spawn" == "true" ]]; then
+            echo "SPAWN $role ($reason)"
+        else
+            echo "SKIP $role ($reason)"
+        fi
+    fi
+
+    exit $exit_code
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Create `spawn-support-role.sh` deterministic bash script that encapsulates all support role spawn decision logic: interval checking, idempotency, demand mode, state management, and fabricated task_id detection
- Update `loom-iteration.md` to use the script for all spawn decisions (`check_workflow_demand`, `auto_ensure_support_roles`) and state transitions (`check_support_role_completions`)
- Fix UTC timezone handling on macOS for interval calculations

## Problem

The daemon iteration subagent in direct mode relies on LLM-interpreted pseudocode for support role spawning. This causes variability and unreliability -- the snapshot correctly generates `recommended_actions` like `trigger_guide`, `trigger_champion`, etc., but the LLM may not execute them deterministically.

## Solution

The new `spawn-support-role.sh` script handles all decision logic deterministically:

```bash
# Check if a role should be spawned (interval-based)
./.loom/scripts/spawn-support-role.sh guide --json
# {"should_spawn":true,"reason":"interval_elapsed",...}

# Check demand-based (skips interval)
./.loom/scripts/spawn-support-role.sh champion --demand --json

# Record state after successful Task spawn
./.loom/scripts/spawn-support-role.sh --mark-running champion --task-id a7dc1e0

# Record completion
./.loom/scripts/spawn-support-role.sh --mark-completed champion
```

The iteration subagent now calls this script for decisions and state management, with the actual Task spawning still handled by the LLM (which is the part that works reliably).

## Test plan

- [x] Verify `--help` output
- [x] Verify interval-based check returns correct decision for never-run roles
- [x] Verify demand mode skips interval check
- [x] Verify idempotency: already-running role returns `should_spawn:false`
- [x] Verify `--mark-running` with valid task_id updates state atomically
- [x] Verify `--mark-running` with fabricated task_id is rejected (exit 2)
- [x] Verify `--mark-completed` transitions state to idle
- [x] Verify interval check works after completion (remaining time calculated)
- [x] Verify fabricated task_id detection in running roles
- [x] Verify `--check-all` produces combined output for all roles
- [x] Verify UTC timezone handling on macOS
- [x] Verify exit codes: 0=spawn, 1=skip, 2=error

Closes #1357