### PR TITLE
Add in-session orphan recovery and spawn retry limits

### DIFF
--- a/defaults/.claude/commands/loom-parent.md
+++ b/defaults/.claude/commands/loom-parent.md
@@ -514,9 +514,19 @@ The daemon maintains state in `.loom/daemon-state.json`:
   "shepherds": { ... },
   "support_roles": { ... },
   "pipeline_state": { ... },
-  "warnings": [ ... ]
+  "warnings": [ ... ],
+  "spawn_retry_queue": {
+    "123": {
+      "failures": 2,
+      "last_attempt": "2026-01-23T11:25:00Z",
+      "last_error": "verification_failed"
+    }
+  }
 }
 ```
+
+**spawn_retry_queue**: Tracks spawn failures per issue to prevent infinite retry loops.
+After `MAX_SPAWN_FAILURES` (3) consecutive failures, the issue is marked as `loom:blocked`.
 
 For detailed state file format, see `loom-reference.md`.
 


### PR DESCRIPTION
## Summary

- Run orphan recovery every 5 iterations (not just at startup) to catch crashed shepherds within ~10 minutes
- Add `spawn_retry_queue` to track failed spawn attempts per issue - after 3 consecutive failures, the issue is marked as `loom:blocked` to prevent infinite retry loops
- Add `check_orphaned_shepherds()` function that calls `recover-orphaned-shepherds.sh --recover --json`
- Document `spawn_retry_queue` in daemon state file format

Closes #1355

## Test plan

- [ ] Verify orphan recovery runs every 5 iterations by checking debug output with `/loom iterate --debug`
- [ ] Verify spawn failures are tracked in `daemon-state.json` under `spawn_retry_queue`
- [ ] Verify that after 3 spawn failures, the issue is marked as `loom:blocked`
- [ ] Verify the `recovered=N` counter in iteration summary includes both orphan recovery and stale building counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)