### PR TITLE
Use unified clean.sh for worktree cleanup on daemon startup

### DIFF
--- a/scripts/daemon-cleanup.sh
+++ b/scripts/daemon-cleanup.sh
@@ -261,12 +261,19 @@ handle_daemon_startup() {
     fi
   fi
 
-  # Run safe worktree cleanup
+  # Run worktree cleanup using unified clean.sh
+  # Uses --force to prevent interactive prompts during autonomous operation
+  # Uses --worktrees-only to avoid side effects (branch/tmux cleanup) during startup
   info "Cleaning stale worktrees..."
+  local clean_script="$REPO_ROOT/.loom/scripts/clean.sh"
+  if [[ ! -x "$clean_script" ]]; then
+    # Fallback for Loom repository itself (not an installed target repo)
+    clean_script="$REPO_ROOT/defaults/scripts/clean.sh"
+  fi
   if [[ "$DRY_RUN" == true ]]; then
-    "$SCRIPT_DIR/safe-worktree-cleanup.sh" --dry-run 2>/dev/null || warning "safe-worktree-cleanup.sh not found"
+    "$clean_script" --force --worktrees-only --dry-run 2>/dev/null || warning "clean.sh not found"
   else
-    "$SCRIPT_DIR/safe-worktree-cleanup.sh" 2>/dev/null || warning "safe-worktree-cleanup.sh not found"
+    "$clean_script" --force --worktrees-only 2>/dev/null || warning "clean.sh not found"
   fi
 
   # Prune old archives


### PR DESCRIPTION
## Summary

- Replace `safe-worktree-cleanup.sh` with `clean.sh --force --worktrees-only` in the `daemon-startup` handler of `daemon-cleanup.sh`
- Adds fallback path resolution for both installed target repos (`.loom/scripts/clean.sh`) and the Loom repo itself (`defaults/scripts/clean.sh`)
- Stale worktrees for closed issues are now automatically cleaned on daemon startup without interactive prompts

## Test plan

- [x] `bash -n` syntax check passes
- [x] `./scripts/daemon-cleanup.sh daemon-startup --dry-run` runs successfully, correctly preserves open issue worktrees and would clean closed ones

Closes #1362

🤖 Generated with [Claude Code](https://claude.com/claude-code)