### PR TITLE
Add installation idempotency via version tracking

### DIFF
--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -388,6 +388,39 @@ fi
 echo ""
 
 # ============================================================================
+# VERSION CHECK: Skip if already installed at target version
+# ============================================================================
+if [[ -f "$TARGET_PATH/.loom/version.json" ]]; then
+  INSTALLED_VERSION=$(grep -o '"loom_version"[[:space:]]*:[[:space:]]*"[^"]*"' \
+    "$TARGET_PATH/.loom/version.json" 2>/dev/null | \
+    sed 's/.*"loom_version"[[:space:]]*:[[:space:]]*"//;s/"//')
+  INSTALLED_COMMIT=$(grep -o '"loom_commit"[[:space:]]*:[[:space:]]*"[^"]*"' \
+    "$TARGET_PATH/.loom/version.json" 2>/dev/null | \
+    sed 's/.*"loom_commit"[[:space:]]*:[[:space:]]*"//;s/"//')
+
+  if [[ "$INSTALLED_VERSION" == "$LOOM_VERSION" ]] && \
+     [[ "$INSTALLED_COMMIT" == "$LOOM_COMMIT" ]]; then
+
+    if [[ "$FORCE_OVERWRITE" != "true" ]]; then
+      # Disable error trap - this is a successful exit
+      trap - EXIT SIGINT SIGTERM
+
+      echo ""
+      success "Loom ${LOOM_VERSION} (${LOOM_COMMIT}) is already installed"
+      echo ""
+      info "No installation needed - already at target version."
+      info "To force reinstallation: $0 --force $TARGET_PATH"
+      echo ""
+      exit 0
+    else
+      warning "Force mode enabled - reinstalling despite matching version"
+    fi
+  else
+    info "Version change detected: ${INSTALLED_VERSION:-unknown}@${INSTALLED_COMMIT:-unknown} -> ${LOOM_VERSION}@${LOOM_COMMIT}"
+  fi
+fi
+
+# ============================================================================
 # STEP 2: Create Installation Worktree
 # ============================================================================
 CURRENT_STEP="Create Worktree"

--- a/scripts/uninstall-loom.sh
+++ b/scripts/uninstall-loom.sh
@@ -290,6 +290,7 @@ fi
 # 3. Add runtime artifacts
 RUNTIME_ARTIFACTS=(
   ".loom/state.json"
+  ".loom/version.json"
   ".loom/daemon-state.json"
   ".loom/config.json"
   ".loom/stop-daemon"
@@ -666,6 +667,7 @@ if [[ -f "$WORKTREE_ABS/.gitignore" ]]; then
   # Loom-specific patterns to remove (exact matches)
   LOOM_PATTERNS=(
     ".loom/state.json"
+    ".loom/version.json"
     ".loom/worktrees/"
     ".loom/*.log"
     ".loom/*.sock"


### PR DESCRIPTION
## Summary

- Writes `.loom/version.json` during `loom-daemon init` with version, commit hash, and timestamp
- Install script checks version.json before creating worktrees/PRs; skips when already at target version
- Adds `--force` flag support to bypass the version check
- Adds `.loom/version.json` to gitignore patterns and uninstall cleanup lists
- Includes 3 new Rust unit tests for version file writing, init integration, and gitignore coverage

Closes #1360

## Test plan

- [ ] Run `cargo test -p loom-daemon -- init` to verify all 23 tests pass
- [ ] Fresh install: verify `.loom/version.json` is created with correct content
- [ ] Re-run install with same version: verify early exit with "already installed" message
- [ ] Re-run install with `--force`: verify it proceeds despite matching version
- [ ] Bump version in package.json, re-run: verify version mismatch is detected and install proceeds
- [ ] Run uninstall: verify `.loom/version.json` is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)