### PR TITLE
Add task ID validation to enforce format in daemon state

### DIFF
--- a/defaults/scripts/daemon-snapshot.sh
+++ b/defaults/scripts/daemon-snapshot.sh
@@ -696,6 +696,31 @@ TMUX_AVAILABLE=$(echo "$TMUX_POOL" | jq -r '.available')
 TMUX_SHEPHERD_COUNT=$(echo "$TMUX_POOL" | jq -r '.shepherd_count')
 TMUX_EXECUTION_MODE=$(echo "$TMUX_POOL" | jq -r '.execution_mode')
 
+# Validate task IDs in daemon-state.json
+INVALID_TASK_IDS="[]"
+if [[ -f "$DAEMON_STATE_FILE" ]]; then
+    # Check shepherd task IDs
+    while IFS=$'\t' read -r key task_id; do
+        [[ -z "$key" ]] && continue
+        if [[ ! "$task_id" =~ ^[a-f0-9]{7}$ ]]; then
+            INVALID_TASK_IDS=$(echo "$INVALID_TASK_IDS" | jq \
+                --arg loc "shepherds" --arg key "$key" --arg tid "$task_id" \
+                '. + [{location: $loc, key: $key, task_id: $tid}]')
+        fi
+    done <<< "$(jq -r '.shepherds // {} | to_entries[] | select(.value.task_id != null and .value.task_id != "") | "\(.key)\t\(.value.task_id)"' "$DAEMON_STATE_FILE" 2>/dev/null || echo "")"
+
+    # Check support role task IDs
+    while IFS=$'\t' read -r key task_id; do
+        [[ -z "$key" ]] && continue
+        if [[ ! "$task_id" =~ ^[a-f0-9]{7}$ ]]; then
+            INVALID_TASK_IDS=$(echo "$INVALID_TASK_IDS" | jq \
+                --arg loc "support_roles" --arg key "$key" --arg tid "$task_id" \
+                '. + [{location: $loc, key: $key, task_id: $tid}]')
+        fi
+    done <<< "$(jq -r '.support_roles // {} | to_entries[] | select(.value.task_id != null and .value.task_id != "") | "\(.key)\t\(.value.task_id)"' "$DAEMON_STATE_FILE" 2>/dev/null || echo "")"
+fi
+INVALID_TASK_ID_COUNT=$(echo "$INVALID_TASK_IDS" | jq 'length')
+
 # Count stale heartbeats for warnings
 STALE_HEARTBEAT_COUNT=$(echo "$SHEPHERD_PROGRESS" | jq '[.[] | select(.heartbeat_stale == true and .status == "working")] | length')
 
@@ -775,6 +800,11 @@ if [[ "$ORPHANED_COUNT" -gt 0 ]]; then
     ACTIONS=$(echo "$ACTIONS" | jq '. + ["recover_orphans"]')
 fi
 
+# Add validate_state action if invalid task IDs detected
+if [[ "$INVALID_TASK_ID_COUNT" -gt 0 ]]; then
+    ACTIONS=$(echo "$ACTIONS" | jq '. + ["validate_state"]')
+fi
+
 # Build the final JSON output
 TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
@@ -841,6 +871,8 @@ OUTPUT=$(jq -n \
     --argjson tmux_available "$TMUX_AVAILABLE" \
     --argjson tmux_shepherd_count "$TMUX_SHEPHERD_COUNT" \
     --arg tmux_execution_mode "$TMUX_EXECUTION_MODE" \
+    --argjson invalid_task_ids "$INVALID_TASK_IDS" \
+    --argjson invalid_task_id_count "$INVALID_TASK_ID_COUNT" \
     '{
         timestamp: $timestamp,
         pipeline: {
@@ -863,6 +895,10 @@ OUTPUT=$(jq -n \
             stale_heartbeat_count: $stale_heartbeat_count,
             orphaned: $orphaned_shepherds,
             orphaned_count: $orphaned_count
+        },
+        validation: {
+            invalid_task_ids: $invalid_task_ids,
+            invalid_task_id_count: $invalid_task_id_count
         },
         support_roles: {
             guide: {

--- a/defaults/scripts/report-milestone.sh
+++ b/defaults/scripts/report-milestone.sh
@@ -368,6 +368,12 @@ validate_args() {
         exit 1
     fi
 
+    # Validate task ID format: must be exactly 7 lowercase hex characters
+    if [[ ! "$TASK_ID" =~ ^[a-f0-9]{7}$ ]]; then
+        echo -e "${RED}Error: Invalid task_id '$TASK_ID' - must be exactly 7 lowercase hex characters (e.g., a7dc1e0)${NC}" >&2
+        exit 1
+    fi
+
     case "$EVENT" in
         started)
             if [[ -z "$ISSUE" ]]; then


### PR DESCRIPTION
## Summary

- Adds deterministic task ID validation (`^[a-f0-9]{7}$`) across daemon scripts to prevent state corruption from invalid LLM-generated task IDs
- New `validate-daemon-state.sh` script detects and optionally fixes invalid entries in `daemon-state.json`
- Integrates validation into `report-milestone.sh` (reject at write time), `daemon-snapshot.sh` (warn in output), and `recover-orphaned-shepherds.sh` (detect as orphan indicator)

Closes #1354

## Test plan

- [x] `validate-daemon-state.sh --json` correctly detects all 6 invalid task IDs in `.loom/daemon-state.json.backup`
- [x] `report-milestone.sh` rejects invalid task IDs (e.g., `--task-id "20"`) with clear error
- [x] `report-milestone.sh` accepts valid task IDs (e.g., `--task-id "a7dc1e0"`)
- [x] All 4 modified scripts pass `bash -n` syntax validation
- [ ] `validate-daemon-state.sh --fix` cleans invalid entries (manual verification)
- [ ] `daemon-snapshot.sh` includes `validation.invalid_task_ids` in output
- [ ] `recover-orphaned-shepherds.sh` flags invalid task IDs as `invalid_task_id` orphan type

🤖 Generated with [Claude Code](https://claude.com/claude-code)