### PR TITLE
Fix clean install flow: add --local flag to uninstall-loom.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -422,10 +422,10 @@ case "$METHOD" in
       echo ""
     fi
 
-    # Handle --clean: run uninstall first, then fresh install
+    # Handle --clean: run local uninstall first, then fresh install
     if [[ "$FORCE_FLAG" == "--clean" ]]; then
-      info "Running uninstall before fresh install..."
-      "$LOOM_ROOT/scripts/uninstall-loom.sh" --yes "$TARGET_PATH" || \
+      info "Running local uninstall before fresh install..."
+      "$LOOM_ROOT/scripts/uninstall-loom.sh" --yes --local "$TARGET_PATH" || \
         error "Uninstall failed - aborting clean install"
       echo ""
       info "Uninstall complete, proceeding with fresh install..."

--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -278,18 +278,17 @@ if [[ "$CLEAN_FIRST" == "true" ]]; then
 
   # Check if Loom is installed (has .loom directory)
   if [[ -d "$TARGET_PATH/.loom" ]]; then
-    info "Running uninstall-loom.sh to clean existing installation..."
+    info "Running local uninstall to clean existing installation..."
 
     # Build uninstall flags from current flags
-    UNINSTALL_FLAGS=""
+    # Always use --local so removal happens in working directory (not a worktree)
+    # This way the install worktree captures both removals and additions in one PR
+    UNINSTALL_FLAGS="--local"
     if [[ "$NON_INTERACTIVE" == "true" ]]; then
-      UNINSTALL_FLAGS="--yes"
-    fi
-    if [[ "$FORCE_OVERWRITE" == "true" ]]; then
-      UNINSTALL_FLAGS="$UNINSTALL_FLAGS --force"
+      UNINSTALL_FLAGS="$UNINSTALL_FLAGS --yes"
     fi
 
-    # Run uninstall script
+    # Run uninstall script in local mode
     "$LOOM_ROOT/scripts/uninstall-loom.sh" $UNINSTALL_FLAGS "$TARGET_PATH" || \
       error "Clean install failed - uninstall step encountered an error"
 


### PR DESCRIPTION
## Summary

Fixes the broken clean install flow where `install.sh` option 1 (clean install) did not actually remove old files before installing new ones. The root cause was that `uninstall-loom.sh` created a separate worktree and PR, leaving the main working directory untouched for the subsequent install step.

- Add `--local` / `-l` flag to `uninstall-loom.sh` that removes Loom files directly in the working directory (skips worktree creation and PR creation)
- Update `install.sh` Quick Install clean flow to use `--local` so uninstall happens in-place before fresh install
- Update `install-loom.sh` Full Install clean flow to use `--local` so the install worktree captures both removals and additions in a single PR

Closes #1381

## Test plan

- [ ] Verify `uninstall-loom.sh --yes --local /path/to/repo` removes Loom files in the working directory, stages changes, and exits without creating a worktree or PR
- [ ] Verify `uninstall-loom.sh --yes /path/to/repo` (without `--local`) still creates a worktree and PR as before (existing behavior unchanged)
- [ ] Verify `install.sh` with clean install option 1 (Quick Install) actually removes old files before installing new ones
- [ ] Verify `install.sh` with clean install option 2 (Full Install) produces a single PR with both removals and additions
- [ ] Verify `--local` mode skips gh CLI authentication checks (not needed when no PR is created)
- [ ] Verify `--help` output shows the new `--local` flag

Generated with [Claude Code](https://claude.com/claude-code)