### PR TITLE
Fix outdated .mcp.json referencing removed MCP server packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,19 @@ jobs:
           ln -sf loom-daemon target/release/loom-daemon-x86_64-unknown-linux-gnu
       - run: cargo test --workspace
 
+  mcp-build:
+    name: MCP Server Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Build unified MCP server
+        run: cd mcp-loom && npm install && npm run build
+      - name: Verify build output
+        run: test -f mcp-loom/dist/index.js
+
   backend-build:
     name: Daemon Build Check
     runs-on: ubuntu-latest

--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -563,6 +563,23 @@ fi
 echo ""
 
 # ============================================================================
+# STEP 4b: Build MCP Server and Generate Configuration
+# ============================================================================
+CURRENT_STEP="MCP Setup"
+header "Step 4b: MCP Server Setup"
+echo ""
+
+info "Building unified MCP server..."
+if "$LOOM_ROOT/scripts/setup-mcp.sh"; then
+  success "MCP server configured"
+else
+  warning "MCP setup failed - MCP tools will not be available"
+  info "Run manually later: $LOOM_ROOT/scripts/setup-mcp.sh"
+fi
+
+echo ""
+
+# ============================================================================
 # STEP 5: Configure Branch Protection
 # ============================================================================
 CURRENT_STEP="Configure Branch Protection"

--- a/scripts/setup-mcp.sh
+++ b/scripts/setup-mcp.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Generate .mcp.json with current workspace path
+# Builds the unified MCP server if dist/index.js is missing
 
 set -euo pipefail
 
@@ -7,6 +8,26 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Get the workspace root (parent of scripts/)
 WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+MCP_DIR="$WORKSPACE_ROOT/mcp-loom"
+MCP_ENTRY="$MCP_DIR/dist/index.js"
+
+# Build the unified MCP server if not already built
+if [[ ! -f "$MCP_ENTRY" ]]; then
+  echo "MCP server not built, building mcp-loom..."
+  if command -v node &> /dev/null; then
+    (cd "$MCP_DIR" && npm install --silent && npm run build) || {
+      echo "Warning: Failed to build mcp-loom. MCP tools will not be available." >&2
+      echo "  Run manually: cd mcp-loom && npm install && npm run build" >&2
+      exit 1
+    }
+    echo "MCP server built successfully"
+  else
+    echo "Warning: node not found. Cannot build mcp-loom." >&2
+    echo "  Install Node.js and run: cd mcp-loom && npm install && npm run build" >&2
+    exit 1
+  fi
+fi
 
 # Generate .mcp.json with unified loom server
 cat > "$WORKSPACE_ROOT/.mcp.json" <<EOF


### PR DESCRIPTION
## Summary

Fixes the outdated `.mcp.json` which referenced three removed MCP server packages (`mcp-loom-logs`, `mcp-loom-terminals`, `mcp-loom-ui`) instead of the unified `mcp-loom` package. This caused "MCP servers failed" errors on Claude Code startup.

### Changes

- **`scripts/setup-mcp.sh`**: Auto-builds `mcp-loom` if `dist/index.js` is missing, so running the setup script always produces a working configuration
- **`.github/workflows/ci.yml`**: Added `mcp-build` CI job to verify the unified MCP server builds successfully, preventing future regressions
- **`scripts/install-loom.sh`**: Integrated MCP setup as Step 4b in the installation flow, so MCP is automatically configured when Loom is installed

### How to fix locally

After merging, run `./scripts/setup-mcp.sh` to regenerate `.mcp.json` (this is gitignored). The script will automatically build the MCP server if needed.

Closes #1384

🤖 Generated with [Claude Code](https://claude.com/claude-code)