### PR TITLE
Fix uninstall confirmation message for --local mode

### DIFF
--- a/scripts/uninstall-loom.sh
+++ b/scripts/uninstall-loom.sh
@@ -476,7 +476,11 @@ fi
 if [[ "$NON_INTERACTIVE" != "true" ]]; then
   TOTAL_REMOVALS=$(( ${#REMOVE_FILES[@]} + ${#REMOVE_UNKNOWN_FILES[@]} + ${#SMART_REMOVE_FILES[@]} ))
   echo ""
-  warning "This will modify $TOTAL_REMOVALS files in a new branch and create a PR."
+  if [[ "$LOCAL_MODE" == "true" ]]; then
+    warning "This will modify $TOTAL_REMOVALS files in the working directory."
+  else
+    warning "This will modify $TOTAL_REMOVALS files in a new branch and create a PR."
+  fi
   read -r -p "Proceed with uninstall? [y/N] " -n 1 PROCEED
   echo ""
   if [[ ! $PROCEED =~ ^[Yy]$ ]]; then


### PR DESCRIPTION
## Summary

Fixes the uninstall confirmation prompt to display the correct message based on mode:

- **Local mode** (`--local`): "This will modify N files in the working directory"
- **PR mode** (default): "This will modify N files in a new branch and create a PR"

Previously, the prompt always showed the PR mode message even when `--local` was passed.

## Changes

- `scripts/uninstall-loom.sh`: Added conditional check on `$LOCAL_MODE` to display the appropriate confirmation message

Closes #1383