### PR TITLE
Fix daemon-state.json race condition: make spawn-support-role.sh read-only

### DIFF
--- a/defaults/.claude/commands/loom-iteration.md
+++ b/defaults/.claude/commands/loom-iteration.md
@@ -148,7 +148,7 @@ def loom_iterate(force_mode=False, debug_mode=False):
         for c in completions:
             debug(f"Completion detected: {c.agent_id} issue=#{c.issue} status={c.status}")
 
-    # 4b. Check support role completions (Guide, Champion, Doctor, Auditor)
+    # 4b. Check support role completions (all 7 roles: Guide, Champion, Doctor, Auditor, Judge, Architect, Hermit)
     completed_support_roles = check_support_role_completions(state, debug_mode)
     if completed_support_roles:
         debug(f"Support roles completed: {completed_support_roles}")
@@ -166,24 +166,23 @@ def loom_iterate(force_mode=False, debug_mode=False):
         debug(f"Shepherd pool: {format_shepherd_pool(state)}")
         spawned_shepherds = auto_spawn_shepherds(state, snapshot_data, execution_mode, debug_mode)
 
-    # 7. CRITICAL: Act on recommended_actions: trigger_architect, trigger_hermit
-    triggered_generation = {"architect": False, "hermit": False}
+    # 7. Check workflow demand (demand-based spawning for champion/doctor/judge)
+    demand_spawned = check_workflow_demand(state, snapshot_data, recommended_actions, debug_mode)
 
-    if "trigger_architect" in recommended_actions:
-        triggered_generation["architect"] = trigger_architect_role(state, debug_mode)
+    # 8. CRITICAL: Act on recommended_actions: trigger ALL support roles (interval-based)
+    # This now includes architect and hermit alongside guide, champion, doctor, auditor, judge.
+    # All 7 roles use the unified spawn-support-role.sh infrastructure.
+    ensured_roles = auto_ensure_support_roles(state, snapshot_data, recommended_actions, debug_mode, demand_spawned)
 
-    if "trigger_hermit" in recommended_actions:
-        triggered_generation["hermit"] = trigger_hermit_role(state, debug_mode)
+    # Extract work generation results from ensured_roles (for summary formatting)
+    triggered_generation = {
+        "architect": ensured_roles.get("architect", False),
+        "hermit": ensured_roles.get("hermit", False)
+    }
 
     # Log work generation even when not triggered (for debugging)
     if needs_work_gen and not triggered_generation["architect"] and not triggered_generation["hermit"]:
         debug(f"Work generation needed but not triggered: architect_cooldown_ok={architect_cooldown_ok}, hermit_cooldown_ok={hermit_cooldown_ok}")
-
-    # 7.5. Check workflow demand (demand-based spawning)
-    demand_spawned = check_workflow_demand(state, snapshot_data, recommended_actions, debug_mode)
-
-    # 8. CRITICAL: Act on recommended_actions: trigger support roles (interval-based)
-    ensured_roles = auto_ensure_support_roles(state, snapshot_data, recommended_actions, debug_mode, demand_spawned)
 
     # 9. Stuck detection
     stuck_count = check_stuck_agents(state, debug_mode)
@@ -703,101 +702,33 @@ This {proposal_type} proposal has been automatically promoted to `loom:issue` by
 
 **CRITICAL**: Work generation keeps the pipeline fed. When `daemon-snapshot.sh` includes `trigger_architect` or `trigger_hermit` in `recommended_actions`, the iteration MUST spawn these roles.
 
-```python
-def trigger_architect_role(state, debug_mode=False):
-    """Trigger Architect role to generate new proposals. Returns True if triggered.
-
-    Uses slash command directly - Claude Code executes /architect natively.
-    """
-
-    def debug(msg):
-        if debug_mode:
-            print(f"[DEBUG] {msg}")
-
-    debug("Triggering Architect for work generation")
-
-    # Use slash command directly - Claude Code executes this natively
-    result = Task(
-        description="Architect work generation",
-        prompt="/architect --autonomous",
-        run_in_background=True
-    )
-
-    if not verify_task_spawn(result, "Architect"):
-        print(f"  SPAWN FAILED: Architect verification failed")
-        return False
-
-    # Validate task_id format to catch fabricated IDs
-    if not validate_task_id(result.task_id):
-        print(f"  SPAWN FAILED: Architect - fabricated task_id: '{result.task_id}'")
-        return False
-
-    try:
-        record_support_role(state, "architect", result.task_id, result.output_file)
-    except ValueError as e:
-        print(f"  SPAWN FAILED: Architect - {e}")
-        return False
-
-    state["last_architect_trigger"] = now()
-    save_daemon_state(state)
-    print(f"  AUTO-TRIGGERED: Architect (work generation, verified, task_id={result.task_id})")
-    return True
-
-
-def trigger_hermit_role(state, debug_mode=False):
-    """Trigger Hermit role to generate simplification proposals. Returns True if triggered.
-
-    Uses slash command directly - Claude Code executes /hermit natively.
-    """
-
-    def debug(msg):
-        if debug_mode:
-            print(f"[DEBUG] {msg}")
-
-    debug("Triggering Hermit for simplification proposals")
-
-    # Use slash command directly - Claude Code executes this natively
-    result = Task(
-        description="Hermit simplification proposals",
-        prompt="/hermit",
-        run_in_background=True
-    )
-
-    if not verify_task_spawn(result, "Hermit"):
-        print(f"  SPAWN FAILED: Hermit verification failed")
-        return False
-
-    # Validate task_id format to catch fabricated IDs
-    if not validate_task_id(result.task_id):
-        print(f"  SPAWN FAILED: Hermit - fabricated task_id: '{result.task_id}'")
-        return False
-
-    try:
-        record_support_role(state, "hermit", result.task_id, result.output_file)
-    except ValueError as e:
-        print(f"  SPAWN FAILED: Hermit - {e}")
-        return False
-
-    state["last_hermit_trigger"] = now()
-    save_daemon_state(state)
-    print(f"  AUTO-TRIGGERED: Hermit (simplification analysis, verified, task_id={result.task_id})")
-    return True
-```
+**Note**: `trigger_architect_role()` and `trigger_hermit_role()` have been removed. Architect and
+hermit now use the unified `trigger_support_role()` function (same as guide, champion, doctor,
+auditor, and judge). This eliminates separate state management paths and ensures all support roles
+use `spawn-support-role.sh` for deterministic state management. The top-level
+`last_architect_trigger` and `last_hermit_trigger` fields in daemon-state.json are no longer
+written; cooldown is now tracked via `support_roles.architect.last_completed` and
+`support_roles.hermit.last_completed`.
 
 ## Deterministic Support Role Spawning
 
 Support role spawning uses the deterministic `spawn-support-role.sh` script for all
-spawn decisions and state management. This eliminates LLM interpretation variability
-and ensures reliable support role operation in direct mode.
+spawn decisions. The script is read-only (pure decision function) and does not modify
+daemon-state.json. State management is handled in-memory by the iteration subagent,
+which is the sole writer of daemon-state.json. This eliminates both LLM interpretation
+variability and race conditions between concurrent writers.
 
 ### spawn-support-role.sh
 
-The script handles:
+The script is a **pure decision function** (read-only) that handles:
 - **Interval checking**: Whether enough time has elapsed since last completion
 - **Idempotency**: Never spawns if role already running with valid task_id
 - **Demand mode**: Immediate spawn when `--demand` flag passed (skips interval)
-- **State management**: `--mark-running` and `--mark-completed` for atomic state updates
-- **Fabricated ID detection**: Resets roles stuck with invalid task IDs
+- **Fabricated ID detection**: Detects roles stuck with invalid task IDs
+
+**State management** (marking roles as running/completed) is handled entirely by the
+iteration subagent in-memory. The iteration subagent is the sole writer of
+daemon-state.json, which eliminates race conditions between concurrent writers.
 
 ```bash
 # Check if a role should be spawned (interval-based)
@@ -811,12 +742,6 @@ The script handles:
 # Check all roles at once
 ./.loom/scripts/spawn-support-role.sh --check-all --json
 # {"roles":[...],"any_should_spawn":true}
-
-# After successful Task spawn, mark role as running
-./.loom/scripts/spawn-support-role.sh --mark-running champion --task-id a7dc1e0
-
-# After task completion, mark role as idle
-./.loom/scripts/spawn-support-role.sh --mark-completed champion
 ```
 
 ## Workflow Demand (Demand-Based Spawning)
@@ -892,10 +817,13 @@ Uses `spawn-support-role.sh` (without `--demand`) for interval-based spawn decis
 
 ```python
 def auto_ensure_support_roles(state, snapshot_data, recommended_actions, debug_mode=False, demand_spawned=None):
-    """Automatically keep Guide, Champion, Doctor, Auditor, and Judge running.
+    """Automatically keep Guide, Champion, Doctor, Auditor, Judge, Architect, and Hermit running.
 
     Uses spawn-support-role.sh for deterministic interval checking. The script
     handles all interval math, idempotency, and fabricated task_id detection.
+
+    Architect and hermit are managed here alongside the other support roles,
+    using the same spawn-support-role.sh infrastructure for unified state management.
     """
 
     if demand_spawned is None:
@@ -905,19 +833,22 @@ def auto_ensure_support_roles(state, snapshot_data, recommended_actions, debug_m
         if debug_mode:
             print(f"[DEBUG] {msg}")
 
-    ensured_roles = {"guide": False, "champion": False, "doctor": False, "auditor": False, "judge": False}
+    ensured_roles = {"guide": False, "champion": False, "doctor": False, "auditor": False, "judge": False, "architect": False, "hermit": False}
 
     debug("Checking support roles via spawn-support-role.sh (interval-based)")
     debug(f"Recommended actions: {recommended_actions}")
     debug(f"Demand-spawned: {demand_spawned}")
 
     # Define which roles to check and their trigger actions
+    # Architect and hermit use trigger_architect/trigger_hermit actions from daemon-snapshot.sh
     role_checks = [
         ("guide", "trigger_guide", "Guide backlog triage", False),
         ("champion", "trigger_champion", "Champion PR merge", demand_spawned.get("champion", False)),
         ("doctor", "trigger_doctor", "Doctor PR conflict resolution", demand_spawned.get("doctor", False)),
         ("auditor", "trigger_auditor", "Auditor main branch validation", False),
         ("judge", "trigger_judge", "Judge PR review", demand_spawned.get("judge", False)),
+        ("architect", "trigger_architect", "Architect work generation", False),
+        ("hermit", "trigger_hermit", "Hermit simplification proposals", False),
     ]
 
     for role_name, trigger_action, description, already_spawned in role_checks:
@@ -953,8 +884,10 @@ def trigger_support_role(state, role_name, description, debug_mode=False):
     Uses slash command directly - Claude Code executes /role natively.
     This avoids the Skill-in-Task anti-pattern that expands role prompts into subagent context.
 
-    After successful spawn, uses spawn-support-role.sh --mark-running to
-    record the task_id in daemon-state.json atomically.
+    After successful spawn, updates in-memory state only. The iteration subagent
+    is the sole writer of daemon-state.json - state is saved once at the end of
+    the iteration via save_daemon_state(state). This eliminates race conditions
+    between the iteration subagent and spawn-support-role.sh.
     """
 
     def debug(msg):
@@ -968,7 +901,9 @@ def trigger_support_role(state, role_name, description, debug_mode=False):
         "champion": "/champion",
         "doctor": "/doctor",
         "auditor": "/auditor",
-        "judge": "/judge"
+        "judge": "/judge",
+        "architect": "/architect --autonomous",
+        "hermit": "/hermit"
     }
 
     prompt = role_prompts.get(role_name)
@@ -994,11 +929,9 @@ def trigger_support_role(state, role_name, description, debug_mode=False):
         print(f"    The Task tool was likely not actually invoked")
         return False
 
-    # Use deterministic script to record state atomically
-    mark_result = run(f"./.loom/scripts/spawn-support-role.sh --mark-running {role_name} --task-id {result.task_id}")
-    debug(f"State update: {mark_result.strip()}")
-
-    # Also update in-memory state for consistency within this iteration
+    # Update in-memory state only - iteration writes state file once at end
+    # This eliminates the race condition where spawn-support-role.sh --mark-running
+    # would write to daemon-state.json concurrently with the iteration subagent
     if "support_roles" not in state:
         state["support_roles"] = {}
     state["support_roles"][role_name] = {
@@ -1008,20 +941,24 @@ def trigger_support_role(state, role_name, description, debug_mode=False):
         "started_at": now()
     }
 
+    debug(f"State update: {role_name} marked running in-memory (task_id={result.task_id})")
     print(f"  AUTO-SPAWNED: {role_name.capitalize()} (verified, task_id={result.task_id})")
     return True
 ```
 
 ## Check Support Role Completions
 
-Uses `spawn-support-role.sh --mark-completed` for atomic state transitions:
+Updates in-memory state when support roles complete. The iteration subagent is the
+sole writer of daemon-state.json, so all state transitions happen in-memory and
+are persisted in the single `save_daemon_state(state)` call at the end of the iteration.
 
 ```python
 def check_support_role_completions(state, debug_mode=False):
-    """Check if any support roles have completed and update their state.
+    """Check if any support roles have completed and update their in-memory state.
 
-    Uses spawn-support-role.sh --mark-completed for atomic state updates
-    when a role transitions from running to idle.
+    All state updates happen in-memory only. The iteration subagent writes
+    daemon-state.json once at the end of the iteration, eliminating race
+    conditions between concurrent writers.
     """
 
     def debug(msg):
@@ -1049,9 +986,7 @@ def check_support_role_completions(state, debug_mode=False):
         if not validate_task_id(task_id):
             debug(f"WARNING: {role_name.capitalize()} has fabricated task_id in state: '{task_id}'")
             debug(f"  Resetting {role_name} to idle (task was never actually spawned)")
-            # Use deterministic script for atomic state update
-            run(f"./.loom/scripts/spawn-support-role.sh --mark-completed {role_name}")
-            # Update in-memory state
+            # Update in-memory state only - written at end of iteration
             role_info["status"] = "idle"
             role_info["last_completed"] = now_iso
             role_info["last_error"] = f"fabricated_task_id: {task_id}"
@@ -1065,9 +1000,7 @@ def check_support_role_completions(state, debug_mode=False):
             check = TaskOutput(task_id=task_id, block=False, timeout=1000)
 
             if check.status == "completed":
-                # Use deterministic script for atomic state update
-                run(f"./.loom/scripts/spawn-support-role.sh --mark-completed {role_name}")
-                # Update in-memory state
+                # Update in-memory state only - written at end of iteration
                 role_info["status"] = "idle"
                 role_info["last_completed"] = now_iso
                 role_info["task_id"] = None
@@ -1077,9 +1010,7 @@ def check_support_role_completions(state, debug_mode=False):
                 debug(f"{role_name.capitalize()} completed (task {task_id})")
 
             elif check.status == "failed":
-                # Use deterministic script for atomic state update
-                run(f"./.loom/scripts/spawn-support-role.sh --mark-completed {role_name}")
-                # Update in-memory state
+                # Update in-memory state only - written at end of iteration
                 role_info["status"] = "idle"
                 role_info["last_completed"] = now_iso
                 role_info["last_error"] = "task_failed"


### PR DESCRIPTION
## Summary

Fixes the race condition between `spawn-support-role.sh` and the iteration subagent both writing to `daemon-state.json` concurrently. The script is now a **pure decision function** (read-only), and the iteration subagent is the sole writer of `daemon-state.json`.

- **Remove `mark_running()` and `mark_completed()`** functions and their CLI flags (`--mark-running`, `--mark-completed`, `--task-id`) from `spawn-support-role.sh`
- **Update `trigger_support_role()`** to manage support role state in-memory instead of calling the script to write state
- **Update `check_support_role_completions()`** to manage completions in-memory instead of calling the script to write state
- **Migrate architect/hermit** to unified `support_roles` state tracking in `daemon-snapshot.sh`

## Architecture Change

**Before**: Both the iteration subagent AND `spawn-support-role.sh --mark-running` wrote to `daemon-state.json`, causing race conditions when 5+ support roles were spawned per iteration.

**After**: Only the iteration subagent writes `daemon-state.json` (once at end of iteration). `spawn-support-role.sh` is read-only -- it reads the state file to make spawn decisions but never modifies it.

## Test Plan

- [x] `shellcheck` passes on `spawn-support-role.sh` and `daemon-snapshot.sh`
- [x] `spawn-support-role.sh guide --json` returns correct spawn decision
- [x] `spawn-support-role.sh champion --demand --json` returns correct demand decision
- [x] `spawn-support-role.sh --check-all --json` returns all 7 roles
- [x] `spawn-support-role.sh --help` shows updated help (no `--mark-running`/`--mark-completed`)
- [x] Old flags (`--mark-running`, `--mark-completed`) are rejected with exit code 2
- [x] `daemon-state.json` is NOT modified by any script invocation (md5 verified)
- [x] Pre-existing CI lint errors are unrelated to this change

Closes #1387