### PR TITLE
Finalize daemon-state.json on graceful shutdown

### DIFF
--- a/scripts/daemon-cleanup.sh
+++ b/scripts/daemon-cleanup.sh
@@ -310,6 +310,49 @@ handle_daemon_shutdown() {
   # Note: Don't clean worktrees on shutdown - shepherds might be in progress
   # Let daemon-startup handle that on next run
 
+  # Finalize daemon-state.json: set running=false, stopped_at, reset support roles and shepherds
+  if [[ -f "$DAEMON_STATE" ]]; then
+    info "Finalizing daemon-state.json..."
+    local stopped_at
+    stopped_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+    if [[ "$DRY_RUN" == true ]]; then
+      info "[DRY-RUN] Would set running=false, stopped_at=$stopped_at, reset support roles and shepherds to idle"
+    else
+      jq --arg stopped_at "$stopped_at" '
+        .running = false |
+        .stopped_at = $stopped_at |
+        if .support_roles then
+          .support_roles |= with_entries(
+            .value.status = "idle" |
+            .value.task_id = null |
+            .value.last_completed = $stopped_at
+          )
+        else . end |
+        if .shepherds then
+          .shepherds |= with_entries(
+            .value.status = "idle" |
+            .value.issue = null |
+            .value.task_id = null |
+            .value.idle_since = $stopped_at |
+            .value.idle_reason = "shutdown_signal"
+          )
+        else . end
+      ' "$DAEMON_STATE" > "${DAEMON_STATE}.tmp" && mv "${DAEMON_STATE}.tmp" "$DAEMON_STATE"
+      success "daemon-state.json finalized (running=false, stopped_at=$stopped_at)"
+    fi
+  fi
+
+  # Run session reflection if available
+  if [[ -x "$SCRIPT_DIR/session-reflection.sh" ]]; then
+    info "Running session reflection..."
+    if [[ "$DRY_RUN" == true ]]; then
+      "$SCRIPT_DIR/session-reflection.sh" --dry-run 2>/dev/null || warning "session-reflection.sh failed"
+    else
+      "$SCRIPT_DIR/session-reflection.sh" 2>/dev/null || warning "session-reflection.sh failed"
+    fi
+  fi
+
   if [[ "$DRY_RUN" != true ]]; then
     update_cleanup_timestamp "daemon-shutdown"
   fi


### PR DESCRIPTION
## Summary

- Update `handle_daemon_shutdown` in `daemon-cleanup.sh` to finalize `daemon-state.json` before exit
- Sets `running: false` and `stopped_at` timestamp
- Resets all `support_roles` to `status: "idle"` with `task_id: null`
- Resets all `shepherds` to idle with `idle_reason: "shutdown_signal"`
- Invokes `session-reflection.sh` if available

Closes #1388

## Test plan

- [ ] Run `./scripts/daemon-cleanup.sh daemon-shutdown` with a mock daemon-state.json and verify running=false, stopped_at set, roles reset
- [ ] Run with `--dry-run` and verify no state file changes
- [ ] Run without daemon-state.json present and verify no errors
- [ ] Verify jq handles missing support_roles/shepherds keys gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)