### PR TITLE
Prevent dual daemon conflicts with session ID tracking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,6 +230,7 @@ The daemon state file provides comprehensive information for debugging, crash re
   "last_poll": "2026-01-23T11:30:00Z",
   "running": true,
   "iteration": 42,
+  "daemon_session_id": "1706400000-12345",
 
   "shepherds": {
     "shepherd-1": {

--- a/defaults/.claude/commands/loom-parent.md
+++ b/defaults/.claude/commands/loom-parent.md
@@ -286,6 +286,102 @@ GUIDE/CHAMPION/DOCTOR/AUDITOR:
 - Proposals are auto-promoted to `loom:issue` by the daemon
 - Only `loom:blocked` issues require human intervention
 
+## CRITICAL: Dual Daemon Prevention
+
+**Before starting the parent loop, you MUST check for an existing daemon instance.**
+
+This prevents the critical bug where two daemon instances compete for `daemon-state.json`, causing state corruption, duplicate shepherd spawns, and unpredictable behavior.
+
+### Checking for Existing Daemon
+
+```python
+def check_for_existing_daemon():
+    """Check if another daemon instance is already running.
+
+    Uses PID file (.loom/daemon-loop.pid) as the primary check,
+    and daemon_session_id in state file as a secondary check.
+
+    Returns True if safe to start, False if another daemon is running.
+    """
+    pid_file = ".loom/daemon-loop.pid"
+
+    # Check PID file (shell wrapper daemon)
+    if exists(pid_file):
+        pid = read_file(pid_file).strip()
+        # Check if process is still alive
+        result = run(f"kill -0 {pid} 2>/dev/null && echo alive || echo dead")
+        if result.strip() == "alive":
+            print(f"ERROR: Daemon loop already running (PID: {pid})")
+            print(f"  The shell wrapper daemon-loop.sh is active.")
+            print(f"  Stop it first: touch .loom/stop-daemon")
+            print(f"  Or check status: ./.loom/scripts/daemon-loop.sh --status")
+            return False
+        else:
+            print(f"Warning: Removing stale PID file (PID {pid} is not running)")
+            rm(pid_file)
+
+    # Check state file for active LLM-interpreted daemon
+    state_file = ".loom/daemon-state.json"
+    if exists(state_file):
+        state = json.load(open(state_file))
+        if state.get("running") == True and state.get("daemon_session_id"):
+            session_id = state["daemon_session_id"]
+            last_poll = state.get("last_poll")
+            if last_poll:
+                # Check if last poll was recent (within 5 minutes)
+                # If so, another daemon is likely still active
+                poll_age_seconds = seconds_since(last_poll)
+                if poll_age_seconds < 300:
+                    print(f"WARNING: Another daemon session may be active")
+                    print(f"  Session ID: {session_id}")
+                    print(f"  Last poll: {last_poll} ({poll_age_seconds}s ago)")
+                    print(f"  If you are sure no other daemon is running, delete .loom/daemon-state.json")
+                    print(f"  Proceeding with caution - will use session ID to detect conflicts")
+
+    return True
+```
+
+### Continuation Detection
+
+**CRITICAL**: When Claude Code runs out of context and auto-continues, the continuation MUST NOT re-invoke the parent loop. If you detect that you are in a continuation (e.g., conversation history shows a previous `/loom` invocation that was running), do NOT start a new parent loop. Instead:
+
+1. Check if `.loom/daemon-state.json` shows `running: true` with a recent `last_poll`
+2. If yes, you are likely a continuation of a previous daemon session
+3. Do NOT start a new parent loop - this would create a dual-daemon conflict
+4. Instead, print a warning and exit:
+
+```python
+def detect_continuation():
+    """Detect if this is a continuation of a previous daemon session.
+
+    When Claude Code runs out of context and auto-continues, the new
+    session may try to re-invoke /loom. This detects that scenario.
+    """
+    if exists(".loom/daemon-state.json"):
+        state = json.load(open(".loom/daemon-state.json"))
+        if state.get("running") == True:
+            last_poll = state.get("last_poll")
+            if last_poll:
+                poll_age = seconds_since(last_poll)
+                # If last poll was very recent, another daemon is likely running
+                if poll_age < 300:  # 5 minutes
+                    print("=" * 60)
+                    print("  CONTINUATION DETECTED - NOT STARTING NEW DAEMON")
+                    print("=" * 60)
+                    print(f"  daemon-state.json shows running=true")
+                    print(f"  Last poll: {poll_age}s ago")
+                    print(f"  Session ID: {state.get('daemon_session_id', 'unknown')}")
+                    print()
+                    print("  This appears to be a continuation of a previous session.")
+                    print("  Starting a second daemon would cause state corruption.")
+                    print()
+                    print("  To force restart: rm .loom/daemon-state.json && /loom")
+                    print("  To stop daemon:   touch .loom/stop-daemon")
+                    print("=" * 60)
+                    return True
+    return False
+```
+
 ## Startup Validation
 
 Before entering the main loop, validate role configuration:
@@ -313,6 +409,12 @@ def validate_at_startup():
 
 ```python
 def start_daemon(force_mode=False, debug_mode=False):
+    # 0. CRITICAL: Check for existing daemon instance (dual-daemon prevention)
+    if detect_continuation():
+        return  # Don't start - continuation of previous session detected
+    if not check_for_existing_daemon():
+        return  # Don't start - another daemon is running
+
     # 1. Rotate existing state file to preserve session history
     run("./.loom/scripts/rotate-daemon-state.sh")
 
@@ -320,6 +422,12 @@ def start_daemon(force_mode=False, debug_mode=False):
     state = load_or_create_state(".loom/daemon-state.json")
     state["started_at"] = now()
     state["running"] = True
+
+    # 2b. Generate and store session ID for conflict detection
+    import time, os
+    session_id = f"{int(time.time())}-{os.getpid()}"
+    state["daemon_session_id"] = session_id
+    print(f"  Session ID: {session_id}")
 
     # 3. Set force mode if enabled
     if force_mode:
@@ -343,7 +451,7 @@ def start_daemon(force_mode=False, debug_mode=False):
     save_daemon_state(state)
 
     # 7. Enter thin parent loop
-    parent_loop(force_mode, debug_mode)
+    parent_loop(force_mode, debug_mode, session_id)
 ```
 
 ### Parent Loop (Thin - Context Efficient)
@@ -351,7 +459,7 @@ def start_daemon(force_mode=False, debug_mode=False):
 **CRITICAL**: The parent loop does MINIMAL work. All orchestration happens in iteration subagents.
 
 ```python
-def parent_loop(force_mode=False, debug_mode=False):
+def parent_loop(force_mode=False, debug_mode=False, session_id=None):
     """Thin parent loop - spawns iteration subagents to do actual work."""
 
     iteration = 0
@@ -367,6 +475,7 @@ def parent_loop(force_mode=False, debug_mode=False):
     print("=" * 60)
     print(f"  Force mode: {'ENABLED' if force_mode else 'disabled'}")
     print(f"  Debug: {'ENABLED' if debug_mode else 'disabled'}")
+    print(f"  Session ID: {session_id}")
     print(f"  Execution backend: {execution_mode.upper()}")
     if execution_mode == "tmux":
         print("    -> Using tmux agent pool (loom attach to inspect)")
@@ -388,6 +497,21 @@ def parent_loop(force_mode=False, debug_mode=False):
             print(f"\nIteration {iteration}: Shutdown signal detected")
             graceful_shutdown()
             break
+
+        # ====================================
+        # STEP 1b: SESSION OWNERSHIP CHECK (dual-daemon prevention)
+        # ====================================
+        # Verify our session ID still matches the state file.
+        # If another daemon has taken over, yield gracefully.
+        if session_id and exists(".loom/daemon-state.json"):
+            state = json.load(open(".loom/daemon-state.json"))
+            file_session_id = state.get("daemon_session_id")
+            if file_session_id and file_session_id != session_id:
+                print(f"\nIteration {iteration}: SESSION CONFLICT DETECTED")
+                print(f"  Our session:  {session_id}")
+                print(f"  File session: {file_session_id}")
+                print(f"  Another daemon has taken over. Yielding.")
+                break
 
         # ====================================
         # STEP 2: SPAWN ITERATION SUBAGENT (does ALL work)
@@ -527,6 +651,7 @@ The daemon maintains state in `.loom/daemon-state.json`:
   "iteration": 42,
   "force_mode": false,
   "debug_mode": false,
+  "daemon_session_id": "1706400000-12345",
   "shepherds": { ... },
   "support_roles": { ... },
   "pipeline_state": { ... },
@@ -540,6 +665,10 @@ The daemon maintains state in `.loom/daemon-state.json`:
   }
 }
 ```
+
+**daemon_session_id**: Unique identifier (format: `timestamp-PID`) for the current daemon session.
+Used for dual-daemon conflict detection - before writing state, the daemon verifies its session
+ID still matches the file to prevent state corruption from competing daemon instances.
 
 **spawn_retry_queue**: Tracks spawn failures per issue to prevent infinite retry loops.
 After `MAX_SPAWN_FAILURES` (3) consecutive failures, the issue is marked as `loom:blocked`.

--- a/defaults/.claude/commands/loom-reference.md
+++ b/defaults/.claude/commands/loom-reference.md
@@ -21,6 +21,7 @@ The daemon maintains state in `.loom/daemon-state.json`. This file provides comp
   "iteration": 42,
   "force_mode": false,
   "debug_mode": false,
+  "daemon_session_id": "1706400000-12345",
 
   "shepherds": {
     "shepherd-1": {

--- a/defaults/.claude/commands/loom.md
+++ b/defaults/.claude/commands/loom.md
@@ -52,6 +52,12 @@ ELSE (no "iterate" in arguments, e.g., "/loom" or "/loom --force"):
 - Eventually hits context limits after a few hours
 - System becomes unresponsive and requires restart
 
+**FAILURE MODE TO AVOID**: Starting a second daemon instance (dual-daemon conflict):
+- When a Claude Code session runs out of context and auto-continues, the continuation may re-invoke `/loom`
+- Two daemon instances competing for `daemon-state.json` causes state corruption
+- **Always check for existing daemon before starting** (see `loom-parent.md` for details)
+- The parent loop uses a `daemon_session_id` field to detect and prevent conflicts
+
 ### Check Your Mode Now
 
 Before proceeding, check the arguments: `{{ARGUMENTS}}`

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -199,6 +199,8 @@ LOOM_POLL_INTERVAL=60 ./.loom/scripts/daemon-loop.sh
 
 **Note**: The `/loom` command relies on the LLM correctly implementing the two-tier architecture (parent loop spawning iteration subagents). While this generally works, the shell wrapper provides more deterministic behavior for production use.
 
+**Dual Daemon Prevention**: Both `daemon-loop.sh` and `/loom` use PID-based locking and session ID tracking to prevent multiple daemon instances from running simultaneously. If a second daemon is started, it will detect the conflict and refuse to start. The `daemon_session_id` field in `daemon-state.json` (format: `timestamp-PID`) enables each daemon to verify it still owns the state file before writing updates. This prevents state corruption when Claude Code sessions are auto-continued.
+
 **Force Mode** (`--force`):
 
 When running with `--force`, the daemon enables aggressive autonomous development:
@@ -654,6 +656,7 @@ The daemon state file provides comprehensive information for debugging, crash re
   "last_poll": "2026-01-23T11:30:00Z",
   "running": true,
   "iteration": 42,
+  "daemon_session_id": "1706400000-12345",
 
   "shepherds": {
     "shepherd-1": {


### PR DESCRIPTION
## Summary

Prevents dual daemon instances from competing for `daemon-state.json` by adding session ID tracking and hardening the LLM-interpreted `/loom` mode with PID lock checking and continuation detection.

**Root cause**: When a Claude Code session runs out of context and is auto-continued, the continuation re-invokes the daemon parent loop, creating a second daemon instance while the first instance's shepherds are still running. Two daemons writing to the same state file causes state corruption.

**Solution**: Defense-in-depth with three layers of protection:

1. **Session ID tracking** (`daemon_session_id` field in `daemon-state.json`): Each daemon generates a unique `timestamp-PID` session ID at startup. Before every iteration and state write, the daemon validates its session ID still matches the state file. On mismatch, the daemon yields gracefully.

2. **PID lock hardening for /loom mode**: The LLM-interpreted `/loom` parent mode now checks for existing daemon instances (both shell wrapper via PID file and other LLM daemons via recent `last_poll` timestamp) before starting.

3. **Continuation detection**: The `/loom` parent mode detects when it appears to be a continuation of a previous daemon session (state file shows `running: true` with recent `last_poll`) and refuses to start a second instance.

### Files Changed

- `defaults/scripts/daemon-loop.sh` - Session ID generation, ownership validation per iteration, session ID in status output
- `defaults/.claude/commands/loom-parent.md` - Dual daemon prevention checks, continuation detection, session ownership validation in parent loop
- `defaults/.claude/commands/loom-iteration.md` - Session ID validation before state writes
- `defaults/.claude/commands/loom.md` - Document dual-daemon failure mode
- `defaults/.claude/commands/loom-reference.md` - Add `daemon_session_id` to state schema
- `defaults/CLAUDE.md` - Document dual daemon prevention behavior
- `CLAUDE.md` - Add `daemon_session_id` to state file example

Closes #1395