### PR TITLE
Fix stale worktree registration blocking reinstall after uninstall

### DIFF
--- a/scripts/install/create-worktree.sh
+++ b/scripts/install/create-worktree.sh
@@ -99,6 +99,10 @@ if [[ -d "$WORKTREE_PATH" ]]; then
   git worktree remove "$WORKTREE_PATH" --force 2>/dev/null || true
 fi
 
+# Prune any stale worktree metadata (defensive: handles incomplete uninstall)
+info "Pruning stale worktree metadata..."
+git worktree prune 2>/dev/null || true
+
 # Find an available branch name (handle case where remote branch exists)
 BRANCH_NAME="$BASE_BRANCH_NAME"
 SUFFIX=2

--- a/scripts/uninstall-loom.sh
+++ b/scripts/uninstall-loom.sh
@@ -557,6 +557,9 @@ if [[ "$LOCAL_MODE" != "true" ]]; then
     git worktree remove "$WORKTREE_PATH" --force 2>/dev/null || true
   fi
 
+  # Prune any stale worktree metadata (defensive: handles incomplete cleanup)
+  git worktree prune 2>/dev/null || true
+
   # Find available branch name
   BRANCH_NAME="$BASE_BRANCH_NAME"
   SUFFIX=2
@@ -632,6 +635,12 @@ for dir in "${RUNTIME_DIRS[@]}"; do
     REMOVED_COUNT=$((REMOVED_COUNT + 1))
   fi
 done
+
+# Prune stale worktree metadata from git's internal tracking
+# This prevents "missing but already registered worktree" errors on reinstall
+info "Pruning git worktree metadata..."
+cd "$TARGET_PATH"
+git worktree prune 2>/dev/null || true
 
 success "Removed $REMOVED_COUNT files/directories"
 echo ""


### PR DESCRIPTION
Closes #1397

## Summary

After uninstalling and reinstalling Loom, `git worktree add` fails with "missing but already registered worktree" because the uninstall script removes the physical worktree directories but does not prune git's internal metadata in `.git/worktrees/`. The install script's retry loop then creates orphaned branches without fixing the root cause.

## Changes

Adds `git worktree prune` in three strategic locations:

1. **`scripts/uninstall-loom.sh` (runtime cleanup)** -- After removing `.loom/worktrees/` and `.loom/progress/` directories, prune git's internal worktree metadata so stale registrations are cleaned up as part of uninstall.

2. **`scripts/install/create-worktree.sh` (defensive)** -- Before attempting to create the installation worktree, prune any stale metadata left over from an incomplete prior uninstall.

3. **`scripts/uninstall-loom.sh` (worktree creation)** -- Before creating the uninstall branch worktree, prune stale metadata for the same defensive reason.

## Test plan

- [ ] Install Loom to a test repo
- [ ] Merge the installation PR
- [ ] Uninstall Loom
- [ ] Verify `git worktree list` shows no stale entries
- [ ] Reinstall Loom -- should succeed without retry attempts or orphaned branches