### PR TITLE
Fix staged changes left behind after --clean install with no changes needed

### DIFF
--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -681,6 +681,15 @@ if [[ "$PR_URL_RAW" == *"NO_CHANGES_NEEDED"* ]]; then
   git worktree remove "${WORKTREE_PATH}" --force 2>/dev/null || true
   git branch -D "${BRANCH_NAME}" 2>/dev/null || true
 
+  # Restore any staged changes left by --clean uninstall
+  # When --clean runs uninstall in --local mode, it stages file deletions
+  # Since no changes are needed, we restore those files to their original state
+  if [[ "$CLEAN_FIRST" == "true" ]]; then
+    info "Restoring files staged by uninstall..."
+    git -C "$TARGET_PATH" restore --staged . 2>/dev/null || true
+    git -C "$TARGET_PATH" checkout -- . 2>/dev/null || true
+  fi
+
   # Disable error trap and exit successfully
   trap - EXIT SIGINT SIGTERM
 


### PR DESCRIPTION
## Summary

- Restores staged changes when `--clean` install detects no changes needed
- Only runs restore when `--clean` flag was used to avoid affecting normal install flow
- Uses `git restore --staged .` and `git checkout -- .` to clean both index and working tree

## Test plan

- [ ] Test Case 1: Run `./scripts/install-loom.sh --clean --yes /path/to/already-installed-repo` and verify working directory is clean after completion
- [ ] Test Case 2: Run `./scripts/install-loom.sh --yes /path/to/already-installed-repo` (without --clean) and verify normal behavior unchanged
- [ ] Test Case 3: Run `./scripts/install-loom.sh --clean --yes /path/to/repo` on a repo that needs actual changes and verify PR is created normally

Closes #1399

🤖 Generated with [Claude Code](https://claude.com/claude-code)