### PR TITLE
Fix claude-wrapper.sh TTY detection broken by tee pipe

### DIFF
--- a/defaults/scripts/claude-wrapper.sh
+++ b/defaults/scripts/claude-wrapper.sh
@@ -194,10 +194,12 @@ run_with_retry() {
         temp_output=$(mktemp)
 
         # Run claude with all arguments passed to wrapper
-        # Use script or unbuffer to preserve interactivity if available
+        # Use macOS `script` to preserve TTY (so Claude CLI sees isatty(stdout) = true)
+        # while still capturing output to a file. A plain pipe (`| tee`) would replace
+        # stdout with a pipe fd, causing Claude to switch to non-interactive --print mode.
         set +e  # Temporarily disable errexit to capture exit code
-        claude "$@" 2>&1 | tee "${temp_output}"
-        exit_code="${PIPESTATUS[0]}"
+        script -q "${temp_output}" claude "$@"
+        exit_code=$?
         set -e
 
         output=$(cat "${temp_output}")


### PR DESCRIPTION
## Summary

Fixes the TTY detection issue in `claude-wrapper.sh` that broke all tmux-based agent spawning via `agent-spawn.sh`.

- Replace `claude "$@" 2>&1 | tee "${temp_output}"` with `script -q "${temp_output}" claude "$@"` to preserve TTY
- Use `$?` instead of `${PIPESTATUS[0]}` since `script` runs the command directly (no pipe)

The `tee` pipe replaced stdout with a pipe fd, causing Claude CLI's `isatty(stdout)` check to fail and switch to `--print` mode, which requires stdin input and errors out immediately.

The macOS `script -q` command runs the process with a pseudo-TTY while capturing all output to a file, preserving both interactivity and output logging.

Closes #1409

## Test plan

- [ ] Run `agent-spawn.sh --role curator --name test-curator --args "1407"` and verify Claude starts interactively
- [ ] Attach to tmux session and confirm slash command is received
- [ ] Verify `.loom/logs/loom-test-curator.log` captures output
- [ ] Verify retry logic still works on transient errors