### PR TITLE
Add merge-pr.sh helper for worktree-safe PR merges

### DIFF
--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -216,7 +216,7 @@ gh issue edit 42 --add-label "loom:issue"  # Approve for work
 
 # Merge approved PRs
 gh pr list --label="loom:pr"
-gh pr merge 50 --squash
+./.loom/scripts/merge-pr.sh 50
 ```
 
 ## Label Reference

--- a/defaults/.claude/commands/champion-reference.md
+++ b/defaults/.claude/commands/champion-reference.md
@@ -475,20 +475,13 @@ echo ""
 echo "STEP 3/5: Executing squash merge..."
 echo ""
 
-MERGE_OUTPUT=$(gh pr merge "$PR_NUMBER" --squash --auto --delete-branch 2>&1)
-MERGE_EXIT_CODE=$?
-
-# Verify actual merge state via GitHub API
-PR_STATE=$(gh pr view "$PR_NUMBER" --json state --jq '.state')
-
-if [ "$PR_STATE" = "MERGED" ]; then
-  echo "Successfully merged PR #$PR_NUMBER"
-  echo ""
-else
+# Use merge-pr.sh for worktree-safe merge via GitHub API
+./.loom/scripts/merge-pr.sh "$PR_NUMBER" --auto || {
   echo "Merge failed!"
-  echo "Error output: $MERGE_OUTPUT"
   exit 1
-fi
+}
+echo "Successfully merged PR #$PR_NUMBER"
+echo ""
 
 # ============================================
 # STEP 4: Verify Issue Closure

--- a/defaults/.claude/commands/imagine.md
+++ b/defaults/.claude/commands/imagine.md
@@ -227,15 +227,10 @@ PR_NUMBER=$(gh pr list --label "loom:review-requested" --json number --jq '.[0].
 
 if [ -n "$PR_NUMBER" ]; then
   echo "Merging Loom installation PR #$PR_NUMBER..."
-  gh pr merge "$PR_NUMBER" --squash --admin --delete-branch
-
-  # Verify merge
-  PR_STATE=$(gh pr view "$PR_NUMBER" --json state --jq '.state')
-  if [ "$PR_STATE" = "MERGED" ]; then
-    echo "Loom installed successfully"
-  else
+  ./.loom/scripts/merge-pr.sh "$PR_NUMBER" --admin || {
     echo "WARNING: PR merge may have failed, please check manually"
-  fi
+  }
+  echo "Loom installed successfully"
 else
   echo "WARNING: Could not find Loom installation PR"
 fi

--- a/defaults/.claude/commands/shepherd-lifecycle.md
+++ b/defaults/.claude/commands/shepherd-lifecycle.md
@@ -469,66 +469,12 @@ if [ "$PHASE" = "gate2" ]; then
   if [ "$FORCE_MERGE" = "true" ]; then
     echo "Force-merge mode: auto-merging PR"
 
-    # IMPORTANT: Worktree Checkout Error Handling
-    # ============================================
-    # When running from a worktree, `gh pr merge` may succeed on GitHub but fail
-    # locally with: "fatal: 'main' is already used by worktree at '/path/to/repo'"
-    #
-    # This is EXPECTED behavior - the merge completes remotely but git can't switch
-    # to main locally because another worktree already has it checked out.
-    #
-    # Solution: Always verify PR state via GitHub API rather than relying on exit code.
-    # The exit code of `gh pr merge` is unreliable when running from worktrees.
-
-    MERGE_OUTPUT=$(gh pr merge $PR_NUMBER --squash --delete-branch 2>&1)
-    MERGE_EXIT=$?
-
-    # Always verify actual merge state via GitHub API (exit code is unreliable in worktrees)
-    PR_STATE=$(gh pr view $PR_NUMBER --json state --jq '.state')
-
-    if [ "$PR_STATE" = "MERGED" ]; then
-      # Merge succeeded - any error was just the local checkout failure (expected in worktrees)
-      if [ $MERGE_EXIT -ne 0 ]; then
-        if echo "$MERGE_OUTPUT" | grep -q "already used by worktree"; then
-          echo "PR merged successfully (local checkout skipped - worktree conflict is expected)"
-        else
-          echo "PR merged successfully (non-fatal local error ignored)"
-        fi
-      else
-        echo "PR merged successfully"
-      fi
-    else
-      # Merge actually failed on GitHub - this is a real error that needs handling
-      echo "Merge failed (PR state: $PR_STATE)"
-
-      # Check for merge conflicts
-      MERGEABLE=$(gh pr view $PR_NUMBER --json mergeable --jq '.mergeable')
-      if [ "$MERGEABLE" = "CONFLICTING" ]; then
-        echo "Attempting conflict resolution..."
-        git fetch origin main
-        git checkout $BRANCH_NAME 2>/dev/null || git checkout -b $BRANCH_NAME origin/$BRANCH_NAME
-        git merge origin/main --no-edit || {
-          # Auto-resolve conflicts if possible
-          git checkout --theirs .
-          git add -A
-          git commit -m "Resolve merge conflicts (auto-resolved)"
-        }
-        git push origin $BRANCH_NAME
-
-        # Retry merge and verify via API (not exit code)
-        gh pr merge $PR_NUMBER --squash --delete-branch 2>&1
-        PR_STATE=$(gh pr view $PR_NUMBER --json state --jq '.state')
-        if [ "$PR_STATE" = "MERGED" ]; then
-          echo "PR merged successfully after conflict resolution"
-        else
-          echo "Merge failed after conflict resolution"
-          exit 1
-        fi
-      else
-        echo "Merge failed: $MERGE_OUTPUT"
-        exit 1
-      fi
-    fi
+    # Use merge-pr.sh for worktree-safe merge via GitHub API
+    ./.loom/scripts/merge-pr.sh $PR_NUMBER --cleanup-worktree || {
+      echo "Merge failed for PR #$PR_NUMBER"
+      exit 1
+    }
+    echo "PR merged successfully"
 
     gh issue comment $ISSUE_NUMBER --body "**Auto-merged** PR #$PR_NUMBER via \`/shepherd --force-merge\`"
   else

--- a/defaults/.claude/commands/shepherd.md
+++ b/defaults/.claude/commands/shepherd.md
@@ -78,7 +78,7 @@ Curator -> [auto-approve] -> Builder -> Judge -> [STOP at loom:pr]
 When `--force-merge` is specified:
 1. **Gate 1 (Approval)**: Auto-add `loom:issue` label instead of waiting
 2. **Judge Phase**: Runs normally using label-based reviews (not GitHub's review API)
-3. **Gate 2 (Merge)**: Auto-merge PR via `gh pr merge --squash` after Judge approval
+3. **Gate 2 (Merge)**: Auto-merge PR via `merge-pr.sh` (GitHub API) after Judge approval
 4. **Conflict Resolution**: If merge conflicts exist, attempt automatic resolution
 
 ```bash

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -935,25 +935,14 @@ If setup fails, it's usually due to:
 
 ### Common Issues
 
-**'main already used by worktree' error during PR merge**:
+**Merging PRs from worktrees**:
 
-When running `gh pr merge` from a worktree, you may see this error:
-```
-fatal: 'main' is already used by worktree at '/path/to/repo'
-```
-
-This is **expected behavior**, not a failure. The merge succeeds on GitHub, but git cannot switch to `main` locally because another worktree has it checked out.
-
-**Solution**: Verify merge success via GitHub API instead of exit code:
+Use `merge-pr.sh` instead of `gh pr merge` to avoid worktree checkout errors:
 ```bash
-# After gh pr merge, check the actual state:
-PR_STATE=$(gh pr view <PR_NUMBER> --json state --jq '.state')
-if [ "$PR_STATE" = "MERGED" ]; then
-  echo "Merge succeeded (local checkout error can be ignored)"
-fi
+./.loom/scripts/merge-pr.sh <PR_NUMBER>
 ```
 
-The Shepherd and Champion roles handle this automatically by verifying PR state via the GitHub API rather than relying on `gh pr merge` exit codes.
+This merges via the GitHub API (no local checkout), deletes the remote branch, and optionally cleans up the local worktree with `--cleanup-worktree`. All Loom roles (Shepherd, Champion) use this script automatically.
 
 ---
 

--- a/docs/guides/quickstart-tutorial.md
+++ b/docs/guides/quickstart-tutorial.md
@@ -267,13 +267,16 @@ Then the Builder would address the feedback and re-request review.
 Once the PR is approved (`loom:pr` label), you can merge it:
 
 ```bash
-gh pr merge 43 --squash --delete-branch
+./.loom/scripts/merge-pr.sh 43
 ```
 
 **Expected output:**
 ```
-✓ Squashed and merged pull request #43 into main
-✓ Deleted branch feature/issue-42
+Merging PR #43: Fix widget alignment
+Branch: feature/issue-42
+PR #43 merged successfully
+Branch 'feature/issue-42' deleted
+Done
 ```
 
 The issue (#42) will automatically close because the PR had "Closes #42" in the description.


### PR DESCRIPTION
## Summary
- Adds `defaults/scripts/merge-pr.sh` that merges PRs via the GitHub API (`repos/{owner}/{repo}/pulls/{number}/merge`) instead of `gh pr merge`, eliminating "already used by worktree" errors
- Supports `--cleanup-worktree`, `--dry-run`, `--auto`, and `--admin` flags
- Replaces ~55 lines of inline workaround code in shepherd-lifecycle.md and similar patterns in champion-pr-merge.md, champion-reference.md, imagine.md
- Updates documentation (CLAUDE.md, WORKFLOWS.md, quickstart tutorial, shepherd.md)

Closes #1421

## Test plan
- [ ] Merge a PR from inside a worktree — should succeed without "already used by worktree" error
- [ ] Merge a PR from main repo directory — should succeed normally
- [ ] Attempt to merge an already-merged PR — should exit cleanly with informative message
- [ ] Attempt to merge a PR with merge conflicts — should fail with clear error
- [ ] Verify `--cleanup-worktree` removes the local worktree after successful merge
- [ ] Verify branch is deleted on remote after merge
- [ ] Verify `--dry-run` shows actions without executing
- [ ] Verify `--auto` enables auto-merge for PRs with ruleset requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)