### PR TITLE
Fix unbound variable error in install.sh during reinstall

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -356,7 +356,7 @@ elif [[ -d "$TARGET_PATH/.loom" ]]; then
   if [[ "$NON_INTERACTIVE" == true ]]; then
     INSTALL_FLAGS+=(--yes)
   fi
-  exec "$LOOM_ROOT/scripts/install-loom.sh" "${INSTALL_FLAGS[@]}" "$TARGET_PATH"
+  exec "$LOOM_ROOT/scripts/install-loom.sh" ${INSTALL_FLAGS[@]+"${INSTALL_FLAGS[@]}"} "$TARGET_PATH"
 else
   FORCE_FLAG=""
   SELF_INSTALL=false


### PR DESCRIPTION
## Summary

- Fix bash `set -u` compatibility issue with empty array expansion on line 359
- Use `${INSTALL_FLAGS[@]+"${INSTALL_FLAGS[@]}"}` idiom for safe expansion
- Enables reinstallation to work on macOS (bash 3.2) without `--yes` flag

## Test plan

- [x] Verify old behavior fails with empty array under `set -u`
- [x] Verify new behavior handles empty array correctly
- [x] Verify new behavior handles populated array (`--yes`) correctly
- [ ] Manual test: reinstall on macOS without `--yes` flag

Closes #1433

🤖 Generated with [Claude Code](https://claude.com/claude-code)