### PR TITLE
Add Installing Loom section to CLAUDE.md

### DIFF
--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -12,6 +12,34 @@ Loom is a multi-terminal desktop application for macOS that orchestrates AI-powe
 
 **Loom Repository**: https://github.com/rjwalters/loom
 
+## Installing Loom
+
+To install Loom into a target repository, run from the **Loom source repository**:
+
+```bash
+./install.sh /path/to/target-repo
+```
+
+**Options**:
+- `--yes` or `-y`: Non-interactive mode (skips confirmation prompts)
+
+**Installation Methods**:
+The installer offers two methods:
+1. **Quick Install** - Fast direct installation using loom-daemon init. Good for personal projects or quick testing.
+2. **Full Install** - Creates GitHub issue, uses git worktree, syncs labels, creates PR. Recommended for team projects.
+
+**Getting the Installer**:
+Clone the Loom repository: https://github.com/rjwalters/loom
+
+**Advanced Usage** (Full Install workflow only):
+For more control, you can use `scripts/install-loom.sh` directly:
+```bash
+./scripts/install-loom.sh [OPTIONS] /path/to/target-repo
+```
+Additional options for `install-loom.sh`:
+- `--force` or `-f`: Force overwrite existing files and enable auto-merge
+- `--clean`: Uninstall first, then fresh install
+
 ## Three-Layer Architecture
 
 Loom uses a three-layer orchestration architecture for scalable automation:


### PR DESCRIPTION
## Summary

- Adds an "Installing Loom" section to `defaults/CLAUDE.md` after "What is Loom?" and before "Three-Layer Architecture"
- Documents the primary install command (`./install.sh /path/to/target-repo`)
- Documents the available flag: `--yes`/`-y` for non-interactive mode
- Explains the two installation methods (Quick Install vs Full Install)
- Links to the Loom repository for obtaining the installer
- Documents advanced usage with `scripts/install-loom.sh` and its additional flags (`--force`, `--clean`)

## Test plan

- [x] Verify section appears after "What is Loom?" and before "Three-Layer Architecture"
- [x] Verify documented flags match what `install.sh` and `scripts/install-loom.sh` actually accept
- [x] Verify example commands are correct

Closes #1443

🤖 Generated with [Claude Code](https://claude.com/claude-code)