### PR TITLE
Fix duplicate log entries in spawn-shell-shepherd.sh

### DIFF
--- a/defaults/scripts/spawn-shell-shepherd.sh
+++ b/defaults/scripts/spawn-shell-shepherd.sh
@@ -231,8 +231,8 @@ if [[ -n "$MODE" ]]; then
     SHEPHERD_CMD="$SHEPHERD_CMD $MODE"
 fi
 
-# Append to log file and output to tmux
-SHEPHERD_CMD="$SHEPHERD_CMD 2>&1 | tee -a '$LOG_FILE'"
+# Redirect stderr to stdout (logging handled by pipe-pane below)
+SHEPHERD_CMD="$SHEPHERD_CMD 2>&1"
 
 # Create new detached session with working directory
 if ! tmux -L "$TMUX_SOCKET" new-session -d -s "$FULL_SESSION_NAME" -c "$REPO_ROOT"; then


### PR DESCRIPTION
## Summary
- Remove redundant `tee` output piping that duplicated every log line
- Keep only the tmux-native `pipe-pane` approach which is more robust
- Preserve stderr-to-stdout redirection for proper output handling

## Root Cause
The script used two overlapping mechanisms to capture output:
1. Line 235: `| tee -a '$LOG_FILE'` in the command string
2. Line 248: `tmux pipe-pane "cat >> '$LOG_FILE'"`

Both wrote every line to the same log file, causing duplication.

## Test plan
- [ ] Verify shell shepherd output still appears in tmux session
- [ ] Verify output is captured in log file without duplication
- [ ] Verify ANSI escape codes are captured (expected with pipe-pane)

Closes #1454

🤖 Generated with [Claude Code](https://claude.com/claude-code)