### PR TITLE
Builder: Verify all acceptance criteria before creating PR

### DIFF
--- a/defaults/.claude/commands/builder.md
+++ b/defaults/.claude/commands/builder.md
@@ -22,7 +22,7 @@ This role definition is split across multiple files for maintainability:
 | **builder.md** (this file) | Core workflow, labels, finding work, guidelines |
 | **builder-worktree.md** | Git worktree workflows, Tauri App mode, parallel claiming |
 | **builder-complexity.md** | Complexity assessment, issue decomposition, scope management |
-| **builder-pr.md** | PR creation, test output, quality requirements |
+| **builder-pr.md** | PR creation, **acceptance criteria verification**, test output, quality requirements |
 
 ## Argument Handling
 
@@ -374,6 +374,10 @@ gh issue list --label="loom:issue" --state=open --json number,title,labels \
 For detailed PR creation and quality requirements, see **builder-pr.md**.
 
 **Quick reference:**
+- **Verify ALL acceptance criteria** before creating PR (see builder-pr.md for details)
+- Extract criteria from issue body/comments (checkboxes, numbered items, "must"/"should" statements)
+- Verify each criterion explicitly with concrete checks (not "I think it works")
+- Include criterion verification table in PR description
 - Add `loom:review-requested` label when creating PR
 - Use "Closes #N" syntax for auto-close
 - Never touch PR labels after creation


### PR DESCRIPTION
## Summary

Add comprehensive guidance for Builders to explicitly verify ALL acceptance criteria from issues before creating PRs. This addresses the problem observed in issue #1441 where Builder fixed 3/4 shellcheck warnings but missed one file, requiring manual intervention during orchestration.

## Changes

- Add new "Acceptance Criteria Verification: REQUIRED Before PR Creation" section to `builder-pr.md`
- Add step-by-step guidance for extracting, verifying, and documenting acceptance criteria
- Update PR creation templates and examples to include verification table
- Update `builder.md` quick reference to emphasize criteria verification

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Builder extracts acceptance criteria from issue body | ✅ | Added Step 1 with patterns (checkboxes, numbered items, must/should) |
| Builder verifies each criterion before creating PR | ✅ | Added Step 2 (verify during implementation) and Step 3 (pre-PR checklist) |
| Builder includes criterion verification in PR description | ✅ | Added Step 4 with table template and updated PR creation example |
| Reduced PRs with missing requirements | ✅ | Entire section makes verification explicit and mandatory |

## Test Plan

1. Create issue with 4+ specific acceptance criteria
2. Run `/builder <issue>`
3. Verify Builder explicitly checks each criterion per new guidance
4. Verify PR description maps to acceptance criteria using the new template

Closes #1459