### PR TITLE
Simplify shepherd CLI: default to force-pr, add --force/-f alias

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -320,13 +320,13 @@ Shepherds report progress milestones to `.loom/progress/` for daemon visibility.
 {
   "task_id": "a7dc1e0",
   "issue": 123,
-  "mode": "force-pr",
+  "mode": "default",
   "started_at": "2026-01-25T10:00:00Z",
   "current_phase": "builder",
   "last_heartbeat": "2026-01-25T10:15:00Z",
   "status": "working",
   "milestones": [
-    {"event": "started", "timestamp": "2026-01-25T10:00:00Z", "data": {"issue": 123, "mode": "force-pr"}},
+    {"event": "started", "timestamp": "2026-01-25T10:00:00Z", "data": {"issue": 123, "mode": "default"}},
     {"event": "phase_entered", "timestamp": "2026-01-25T10:01:00Z", "data": {"phase": "curator"}},
     {"event": "phase_entered", "timestamp": "2026-01-25T10:05:00Z", "data": {"phase": "builder"}},
     {"event": "worktree_created", "timestamp": "2026-01-25T10:06:00Z", "data": {"path": ".loom/worktrees/issue-123"}},
@@ -354,8 +354,8 @@ Shepherds report progress milestones to `.loom/progress/` for daemon visibility.
 Shepherds use the `report-milestone.sh` script:
 
 ```bash
-# Report shepherd started
-./.loom/scripts/report-milestone.sh started --task-id abc123 --issue 42 --mode force-pr
+# Report shepherd started (mode is "default", "force", or "wait")
+./.loom/scripts/report-milestone.sh started --task-id abc123 --issue 42 --mode default
 
 # Report phase transition
 ./.loom/scripts/report-milestone.sh phase_entered --task-id abc123 --phase builder

--- a/defaults/.claude/commands/loom-iteration.md
+++ b/defaults/.claude/commands/loom-iteration.md
@@ -283,7 +283,7 @@ def auto_spawn_shepherds(state, snapshot_data, debug_mode=False):
 
     # Determine shepherd mode based on daemon's force_mode
     force_mode = state.get("force_mode", False)
-    shepherd_flag = "--force-merge" if force_mode else "--force-pr"
+    shepherd_flag = "--force" if force_mode else ""  # default is force-pr behavior
 
     debug(f"Issue selection: {len(ready_issues)} ready issues, {active_count}/{max_shepherds} shepherds active")
     debug(f"Shepherd mode: {shepherd_flag} (force_mode={force_mode})")
@@ -966,7 +966,7 @@ When running with `--debug`, iteration produces verbose logging:
 [DEBUG] Spawning tmux shepherd: shepherd-issue-456 for issue #456
 [DEBUG] Spawning decision: shepherd assigned to #456 (verified)
 [DEBUG]   tmux session: loom-shepherd-issue-456
-[DEBUG] Shepherd mode: --force-merge (force_mode=true)
+[DEBUG] Shepherd mode: --force (force_mode=true)
 [DEBUG] Checking support roles via spawn-support-role.sh (interval-based)
 [DEBUG] guide: spawn needed (interval_elapsed)
 [DEBUG] State update: guide marked running in-memory (tmux session: loom-guide)

--- a/defaults/.claude/commands/loom-parent.md
+++ b/defaults/.claude/commands/loom-parent.md
@@ -112,7 +112,7 @@ uses **tmux agent-spawn.sh** to create ephemeral tmux sessions:
 
 ```bash
 # Iteration spawns shepherd as tmux worker
-./.loom/scripts/agent-spawn.sh --role shepherd --name "shepherd-issue-123" --args "123 --force-pr" --on-demand
+./.loom/scripts/agent-spawn.sh --role shepherd --name "shepherd-issue-123" --args "123" --on-demand
 
 # Wait for completion
 ./.loom/scripts/agent-wait.sh "shepherd-issue-123" --timeout 1800
@@ -122,8 +122,9 @@ uses **tmux agent-spawn.sh** to create ephemeral tmux sessions:
 ```
 
 **Shepherd Force Mode Flags**:
-- `--force-merge`: Full automation - auto-merge after Judge approval (use when daemon is in force mode)
-- `--force-pr`: Stops at `loom:pr` (ready-to-merge), requires Champion for merge (default)
+- `--force` or `-f`: Full automation - auto-merge after Judge approval (use when daemon is in force mode)
+- (default): Stops at `loom:pr` (ready-to-merge), requires Champion for merge
+- `--wait`: Explicit wait for human approval at each gate
 
 **Delegation Summary**:
 
@@ -523,7 +524,7 @@ The `.loom/stop-shepherds` file acts as a coordination signal:
 When `/loom --force` is invoked, the daemon enables **force mode**:
 
 1. **Auto-Promote Proposals**: Champion automatically promotes `loom:architect`, `loom:hermit`, and `loom:curated` proposals to `loom:issue`
-2. **Shepherd Auto-Merge**: Shepherds use `--force-merge` flag
+2. **Shepherd Auto-Merge**: Shepherds use `--force` flag
 3. **Audit Trail**: All auto-promoted items include `[force-mode]` marker
 
 **Use cases**: New project bootstrap, solo developer, weekend hack mode

--- a/defaults/.claude/commands/shepherd-lifecycle.md
+++ b/defaults/.claude/commands/shepherd-lifecycle.md
@@ -454,11 +454,11 @@ fi
 
 ```bash
 if [ "$PHASE" = "gate1" ]; then
-  # Check if --force-pr or --force-merge mode - auto-approve
-  if [ "$FORCE_PR" = "true" ] || [ "$FORCE_MERGE" = "true" ]; then
-    echo "Force mode: auto-approving issue"
+  # Check if --force or default mode - auto-approve
+  if [ "$FORCE_MODE" = "true" ] || [ "$DEFAULT_MODE" = "true" ]; then
+    echo "Auto-approving issue (force/default mode)"
     gh issue edit $ISSUE_NUMBER --add-label "loom:issue"
-    gh issue comment $ISSUE_NUMBER --body "**Auto-approved** via \`/shepherd --force-pr\` or \`--force-merge\`"
+    gh issue comment $ISSUE_NUMBER --body "**Auto-approved** via shepherd orchestration"
   else
     # Wait for human or Champion to promote to loom:issue
     TIMEOUT=1800  # 30 minutes
@@ -616,16 +616,16 @@ fi
 
 ```bash
 if [ "$PHASE" = "gate2" ]; then
-  # Check if --force-pr mode - stop here, don't merge
-  if [ "$FORCE_PR" = "true" ]; then
-    echo "Force-pr mode: stopping at loom:pr state"
-    gh issue comment $ISSUE_NUMBER --body "**PR approved** - stopping at \`loom:pr\` per \`--force-pr\`. Ready for human merge."
+  # Check if default mode - stop here, don't merge
+  if [ "$DEFAULT_MODE" = "true" ]; then
+    echo "Default mode: stopping at loom:pr state"
+    gh issue comment $ISSUE_NUMBER --body "**PR approved** - stopping at \`loom:pr\`. Ready for human merge or Champion auto-merge."
     exit 0
   fi
 
-  # Check if --force-merge mode - auto-merge with conflict resolution
-  if [ "$FORCE_MERGE" = "true" ]; then
-    echo "Force-merge mode: auto-merging PR"
+  # Check if --force mode - auto-merge with conflict resolution
+  if [ "$FORCE_MODE" = "true" ]; then
+    echo "Force mode: auto-merging PR"
 
     # Use merge-pr.sh for worktree-safe merge via GitHub API
     ./.loom/scripts/merge-pr.sh $PR_NUMBER --cleanup-worktree || {
@@ -634,7 +634,7 @@ if [ "$PHASE" = "gate2" ]; then
     }
     echo "PR merged successfully"
 
-    gh issue comment $ISSUE_NUMBER --body "**Auto-merged** PR #$PR_NUMBER via \`/shepherd --force-merge\`"
+    gh issue comment $ISSUE_NUMBER --body "**Auto-merged** PR #$PR_NUMBER via \`/shepherd --force\`"
   else
     # Trigger Champion or wait for human merge
     CHAMPION_TERMINAL="terminal-5"  # if exists

--- a/defaults/.claude/commands/shepherd.md
+++ b/defaults/.claude/commands/shepherd.md
@@ -12,17 +12,22 @@ Parse the issue number and any flags from the arguments.
 
 | Flag | Description |
 |------|-------------|
-| `--force-pr` | Auto-approve issue, run through Judge, stop at `loom:pr` |
-| `--force-merge` | Auto-approve, resolve conflicts, auto-merge after approval |
+| `--force` or `-f` | Auto-approve, resolve conflicts, auto-merge after approval |
+| `--wait` | Wait for human approval at each gate (explicit non-default) |
 | `--to <phase>` | Stop after specified phase (curated, pr, approved) |
 | `--task-id <id>` | Continue from previous checkpoint |
+
+**Deprecated options** (still work with deprecation warnings):
+- `--force-pr` - Now the default behavior
+- `--force-merge` - Use `--force` or `-f` instead
 
 ## Examples
 
 ```bash
-/shepherd 123                    # Normal orchestration (wait for human approval)
-/shepherd 123 --force-pr         # Auto-approve, stop at reviewed PR
-/shepherd 123 --force-merge      # Fully automated, auto-merge after review
+/shepherd 123                    # Create PR without waiting (default)
+/shepherd 123 --force            # Fully automated, auto-merge after review
+/shepherd 123 -f                 # Same as above (short form)
+/shepherd 123 --wait             # Wait for human approval at each gate
 /shepherd 123 --to curated       # Stop after curation phase
 ```
 

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -110,7 +110,7 @@ Loom uses a three-layer orchestration architecture for scalable automation:
 **Layer 1 (Shepherds)**:
 - Fully autonomous once spawned
 - Handles entire issue lifecycle including Judge review
-- Uses `--force-pr` by default (stops at ready-to-merge), or `--force-merge` for full automation
+- Creates PR without waiting by default (stops at ready-to-merge), or use `--force` for full automation with auto-merge
 
 ### When to Use Which Layer
 
@@ -309,7 +309,7 @@ Loom provides specialized roles for different development tasks. Each role follo
 - **Purpose**: Evaluate proposals and auto-merge approved PRs
 - **Workflow**: Evaluates `loom:curated`, `loom:architect`, `loom:hermit` proposals → promotes to `loom:issue`. Also finds `loom:pr` PRs → verifies safety criteria → auto-merges if safe
 - **When to use**: Default daemon mode - handles both proposal promotion and PR merging
-- **Note**: Not needed for PR merging when shepherds run with `--force-merge` (shepherds handle their own merges)
+- **Note**: Not needed for PR merging when shepherds run with `--force` (shepherds handle their own merges)
 
 **Curator** (Autonomous 5min, `curator.md`)
 - **Purpose**: Enhance and organize issues

--- a/defaults/scripts/cli/loom-help.sh
+++ b/defaults/scripts/cli/loom-help.sh
@@ -93,7 +93,7 @@ ${YELLOW}QUICK START:${NC}
     ./loom attach shepherd-1
 
     ${GRAY}# Send a command to an agent${NC}
-    ./loom send shepherd-1 "/shepherd 123 --force-pr"
+    ./loom send shepherd-1 "/shepherd 123"
 
     ${GRAY}# View logs${NC}
     ./loom logs shepherd-1

--- a/defaults/scripts/cli/loom-send.sh
+++ b/defaults/scripts/cli/loom-send.sh
@@ -7,7 +7,8 @@
 #   loom send --help                     Show help
 #
 # Examples:
-#   loom send shepherd-1 "/shepherd 123 --force-pr"
+#   loom send shepherd-1 "/shepherd 123"
+#   loom send shepherd-1 "/shepherd 123 --force"
 #   loom send terminal-2 "/builder 456"
 #   loom send champion "/champion"
 #
@@ -82,7 +83,8 @@ ${YELLOW}OPTIONS:${NC}
     --json            Output result as JSON
 
 ${YELLOW}EXAMPLES:${NC}
-    loom send shepherd-1 "/shepherd 123 --force-pr"
+    loom send shepherd-1 "/shepherd 123"
+    loom send shepherd-1 "/shepherd 123 --force"
     loom send terminal-2 "/builder 456"
     loom send champion "/champion"
 


### PR DESCRIPTION
## Summary

- Changes default shepherd mode from `normal` to `force-pr` (create PR without waiting)
- Adds `--force` / `-f` flags as alias for `--force-merge` 
- Adds `--wait` flag for explicit human approval mode
- Deprecates `--force-pr` and `--force-merge` with warnings

## Test plan

- [x] Run `/shepherd --help` - shows new flags and deprecated section
- [x] Run `spawn-shell-shepherd.sh --help` - shows new flags
- [x] Verify shellcheck passes on modified scripts
- [x] Review all updated documentation for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1470
