### PR TITLE
validate-phase.sh: Builder validation should accept closed issues as success

### DIFF
--- a/defaults/scripts/validate-phase.sh
+++ b/defaults/scripts/validate-phase.sh
@@ -194,6 +194,15 @@ validate_curator() {
 }
 
 validate_builder() {
+    # First: Check if issue is already closed (builder may have resolved without PR)
+    # This is valid for verification tasks, documentation issues, research tasks, etc.
+    local issue_state
+    issue_state=$(gh issue view "$ISSUE" --json state --jq '.state' 2>/dev/null) || true
+    if [[ "$issue_state" == "CLOSED" ]]; then
+        output_result "satisfied" "Issue #$ISSUE is closed (resolved without PR)"
+        return 0
+    fi
+
     # Check if a PR already exists for this issue
     local pr
     pr=$(gh pr list --search "Closes #${ISSUE}" --state open --json number --jq '.[0].number' 2>/dev/null) || true


### PR DESCRIPTION
## Summary
- Adds issue state check at the start of `validate_builder()` function
- If issue is CLOSED, validation passes immediately (valid for verification/research/docs tasks)
- Existing PR validation logic remains unchanged for open issues

Closes #1480

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Validation passes when issue is CLOSED, even without a PR | ✅ | `./defaults/scripts/validate-phase.sh builder 1464` returns "satisfied" |
| Validation message indicates "resolved without PR" | ✅ | Message: "Issue #1464 is closed (resolved without PR)" |
| Still validates PR exists for issues that remain open | ✅ | `./defaults/scripts/validate-phase.sh builder 1461` correctly finds PR #1473 |
| Test with verification-type issue | ✅ | Tested with #1464 (the verification task mentioned in issue) |

## Test plan
- [x] Verify closed issue validation: `./defaults/scripts/validate-phase.sh builder 1464`
- [x] Verify JSON output works: `./defaults/scripts/validate-phase.sh builder 1464 --json`
- [x] Verify open issue with PR still validates: `./defaults/scripts/validate-phase.sh builder 1461`
- [x] Verify open issue without PR correctly fails: `./defaults/scripts/validate-phase.sh builder 1465`
- [x] Verify shellcheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)