### PR TITLE
Reduce shepherd poll interval default from 15s to 5s

### DIFF
--- a/defaults/scripts/shepherd-loop.sh
+++ b/defaults/scripts/shepherd-loop.sh
@@ -30,7 +30,7 @@
 #   LOOM_JUDGE_TIMEOUT       Seconds for judge phase (default: 900)
 #   LOOM_DOCTOR_TIMEOUT      Seconds for doctor phase (default: 900)
 #   LOOM_DOCTOR_MAX_RETRIES  Maximum doctor retry attempts (default: 3)
-#   LOOM_POLL_INTERVAL       Seconds between completion checks (default: 15)
+#   LOOM_POLL_INTERVAL       Seconds between completion checks (default: 5)
 #
 # Example:
 #   # Shepherd issue 42 (creates PR without waiting, default)
@@ -51,7 +51,7 @@ BUILDER_TIMEOUT="${LOOM_BUILDER_TIMEOUT:-1800}"
 JUDGE_TIMEOUT="${LOOM_JUDGE_TIMEOUT:-900}"
 DOCTOR_TIMEOUT="${LOOM_DOCTOR_TIMEOUT:-900}"
 DOCTOR_MAX_RETRIES="${LOOM_DOCTOR_MAX_RETRIES:-3}"
-POLL_INTERVAL="${LOOM_POLL_INTERVAL:-15}"
+POLL_INTERVAL="${LOOM_POLL_INTERVAL:-5}"
 
 # ─── Colors ───────────────────────────────────────────────────────────────────
 
@@ -163,7 +163,7 @@ ${YELLOW}ENVIRONMENT:${NC}
     LOOM_JUDGE_TIMEOUT       Seconds for judge phase (default: 900)
     LOOM_DOCTOR_TIMEOUT      Seconds for doctor phase (default: 900)
     LOOM_DOCTOR_MAX_RETRIES  Maximum doctor retry attempts (default: 3)
-    LOOM_POLL_INTERVAL       Seconds between completion checks (default: 15)
+    LOOM_POLL_INTERVAL       Seconds between completion checks (default: 5)
 
 ${YELLOW}EXAMPLES:${NC}
     # Create PR without waiting (default behavior)


### PR DESCRIPTION
## Summary

- Reduces the default poll interval in shepherd-loop.sh from 15 seconds to 5 seconds
- Updates documentation in header comments and help text to reflect the new default
- Poll interval remains configurable via `LOOM_POLL_INTERVAL` environment variable

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Poll interval configurable (env var or param) | ✅ | `LOOM_POLL_INTERVAL` environment variable exists (unchanged) |
| Default reduced to 5-10 seconds | ✅ | Changed from 15 to 5 seconds |
| No noticeable increase in CPU usage | ✅ | Check is just a `pgrep` call - minimal overhead |

## Test plan

- [ ] Run shepherd orchestration with new interval
- [ ] Measure total orchestration time improvement (expect ~1 minute faster)
- [ ] Verify no issues with faster polling

## Impact

Over a full orchestration with 4-5 phases, reducing from 15s to 5s poll interval should save approximately 40-50 seconds of unnecessary waiting between phase transitions.

Closes #1456

🤖 Generated with [Claude Code](https://claude.com/claude-code)