### PR TITLE
Shepherd: Fail fast if issue is already closed

### DIFF
--- a/defaults/scripts/shepherd-loop.sh
+++ b/defaults/scripts/shepherd-loop.sh
@@ -435,6 +435,14 @@ main() {
         exit 1
     fi
 
+    # Check if issue is already closed
+    local issue_state
+    issue_state=$(gh issue view "$ISSUE" --json state --jq '.state' 2>/dev/null)
+    if [[ "$issue_state" == "CLOSED" ]]; then
+        log_info "Issue #$ISSUE is already closed - no orchestration needed"
+        exit 0
+    fi
+
     local issue_title
     issue_title=$(gh issue view "$ISSUE" --json title --jq '.title' 2>/dev/null)
     log_info "Title: $issue_title"


### PR DESCRIPTION
## Summary

- Shepherd now checks issue state at startup before proceeding with orchestration
- If the issue is already CLOSED, it exits early with exit code 0 and an informative message
- This prevents wasting resources running through multiple phases (worktree creation, builder spawn, validation) only to fail

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Shepherd checks issue state at startup | ✅ | Added check at line 438-444, immediately after existence check |
| Clean exit with informative message for closed issues | ✅ | `log_info "Issue #$ISSUE is already closed - no orchestration needed"` |
| Exit code 0 (success, not failure) for already-closed issues | ✅ | `exit 0` (success, not error) |
| Works regardless of labels on the closed issue | ✅ | Check uses `.state` field only, not labels |

## Test plan

- [ ] Run `/shepherd <closed-issue-number>` - should exit immediately with success
- [ ] Run `/shepherd <open-issue-number>` - should proceed normally
- [ ] Verify bash syntax: `bash -n shepherd-loop.sh` passes

Closes #1483

🤖 Generated with [Claude Code](https://claude.com/claude-code)