### PR TITLE
Fix builder validation to use branch-based PR lookup

### DIFF
--- a/defaults/scripts/validate-phase.sh
+++ b/defaults/scripts/validate-phase.sh
@@ -204,8 +204,10 @@ validate_builder() {
     fi
 
     # Check if a PR already exists for this issue
+    # Use branch-based lookup (deterministic) instead of search API (has indexing lag)
+    # Branch name follows convention from worktree.sh: feature/issue-<number>
     local pr
-    pr=$(gh pr list --search "Closes #${ISSUE}" --state open --json number --jq '.[0].number' 2>/dev/null) || true
+    pr=$(gh pr list --head "feature/issue-${ISSUE}" --state open --json number --jq '.[0].number' 2>/dev/null) || true
 
     if [[ -n "$pr" && "$pr" != "null" ]]; then
         # Check for loom:review-requested label


### PR DESCRIPTION
## Summary

- Changed `validate_builder()` in `validate-phase.sh` to use `--head "feature/issue-<number>"` instead of `--search "Closes #<number>"` for finding PRs
- This eliminates the GitHub search API indexing lag that caused false validation failures

## Problem

GitHub's search API has indexing lag - newly created PRs don't appear in search results immediately. When shepherd validation ran right after builder completion, the search found nothing even though the PR existed, causing:
- False "No changes in worktree to recover" errors
- Incorrect `loom:blocked` labels
- Aborted orchestration
- Required human intervention

## Solution

Use deterministic branch-based lookup (`--head "feature/issue-N"`) instead of search-based lookup. Branch names are created by `worktree.sh` and are immediately queryable without relying on search indexing.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Use `--head` flag instead of `--search` | ✅ | Line 210 uses `gh pr list --head "feature/issue-${ISSUE}"` |
| Branch name matches worktree.sh convention | ✅ | Uses `feature/issue-<number>` as created by worktree.sh:328 |
| No search API dependency | ✅ | Removed `--search "Closes #${ISSUE}"` |

## Test plan

- [x] shellcheck passes on validate-phase.sh
- [x] bash syntax validation passes
- [ ] Run validation on issue with newly created PR to verify immediate detection

Closes #1477

🤖 Generated with [Claude Code](https://claude.com/claude-code)