### PR TITLE
Add retry logic for stale branch errors in merge-pr.sh

### DIFF
--- a/defaults/scripts/shepherd-loop.sh
+++ b/defaults/scripts/shepherd-loop.sh
@@ -806,8 +806,8 @@ main() {
         else
             log_error "Failed to merge PR #$pr_number"
             add_label "$ISSUE" "loom:blocked"
-            gh issue comment "$ISSUE" --body "**Shepherd blocked**: Failed to auto-merge PR #$pr_number. May have merge conflicts." >/dev/null 2>&1 || true
-            fail_with_reason "merge" "failed to auto-merge PR #$pr_number"
+            gh issue comment "$ISSUE" --body "**Shepherd blocked**: Failed to merge PR #$pr_number. Branch may be out of date or have merge conflicts." >/dev/null 2>&1 || true
+            fail_with_reason "merge" "failed to merge PR #$pr_number"
         fi
     elif [[ "$MODE" == "force-pr" ]]; then
         log_info "Stopping at loom:pr state (force-pr mode)"


### PR DESCRIPTION
## Summary
- Adds retry logic (up to 3 attempts) in `merge-pr.sh` when GitHub API returns "Base branch was modified" error
- Uses GitHub API `PUT /update-branch` endpoint to update the PR branch before retrying merge
- Implements exponential backoff (5s, 10s, 20s) between retry attempts
- Updates `shepherd-loop.sh` error message from "May have merge conflicts" to "Branch may be out of date or have merge conflicts" for accuracy

## Test plan
- [ ] Create a PR and merge another PR to main while shepherd is in builder phase
- [ ] Verify merge-pr.sh logs show "Branch is behind base branch, updating..."
- [ ] Verify branch update succeeds and merge completes on retry
- [ ] Verify shepherd-loop.sh error message is updated if merge ultimately fails

Closes #1475

🤖 Generated with [Claude Code](https://claude.com/claude-code)