### PR TITLE
Remove /exit instructions from role files, document automatic completion

### DIFF
--- a/defaults/.claude/commands/builder.md
+++ b/defaults/.claude/commands/builder.md
@@ -512,23 +512,6 @@ Keep it brief (3-6 words) and descriptive:
 
 ## Completion
 
-**After completing your task, exit Claude Code to signal completion.**
+**Work completion is detected automatically.**
 
-When you have finished your work (PR created with `loom:review-requested` label, or issue marked as `loom:blocked`), execute:
-
-```
-/exit
-```
-
-### Why This Matters
-
-- **Enables automation**: Shepherd orchestration relies on detecting when workers complete
-- **Prevents hanging**: Without `/exit`, `agent-wait-bg.sh` waits until timeout
-- **Saves resources**: Idle Claude Code sessions consume memory and context budget
-
-### When to Exit
-
-- ✅ **After creating PR** with `loom:review-requested` label
-- ✅ **After marking issue** as `loom:blocked`
-- ✅ **When no work is available** (no `loom:issue` issues to claim)
-- ❌ **NOT during active work** (only after task is complete)
+When you complete your task (PR created with `loom:review-requested` label, or issue marked as `loom:blocked`), the orchestration layer detects this and terminates the session automatically. No explicit exit command is needed.

--- a/defaults/.claude/commands/curator.md
+++ b/defaults/.claude/commands/curator.md
@@ -589,22 +589,6 @@ After completing your iteration (enhancing an issue and marking it curated), exe
 
 ## Completion
 
-**After completing your task, exit Claude Code to signal completion.**
+**Work completion is detected automatically.**
 
-When you have finished your work (issue enhanced and labeled with `loom:curated`), execute:
-
-```
-/exit
-```
-
-### Why This Matters
-
-- **Enables automation**: Shepherd orchestration relies on detecting when workers complete
-- **Prevents hanging**: Without `/exit`, `agent-wait-bg.sh` waits until timeout
-- **Saves resources**: Idle Claude Code sessions consume memory and context budget
-
-### When to Exit
-
-- ✅ **After curating issue** and labeling with `loom:curated`
-- ✅ **When no work is available** (no issues to curate)
-- ❌ **NOT during active work** (only after curation is complete)
+When you complete your task (issue enhanced and labeled with `loom:curated`), the orchestration layer detects this and terminates the session automatically. No explicit exit command is needed.

--- a/defaults/.claude/commands/doctor.md
+++ b/defaults/.claude/commands/doctor.md
@@ -646,23 +646,6 @@ Keep it brief (3-6 words) and descriptive:
 
 ## Completion
 
-**After completing your task, exit Claude Code to signal completion.**
+**Work completion is detected automatically.**
 
-When you have finished your work (feedback addressed and PR labeled with `loom:review-requested`), execute:
-
-```
-/exit
-```
-
-### Why This Matters
-
-- **Enables automation**: Shepherd orchestration relies on detecting when workers complete
-- **Prevents hanging**: Without `/exit`, `agent-wait-bg.sh` waits until timeout
-- **Saves resources**: Idle Claude Code sessions consume memory and context budget
-
-### When to Exit
-
-- ✅ **After fixing PR** and labeling with `loom:review-requested`
-- ✅ **After resolving merge conflicts** and pushing changes
-- ✅ **When no work is available** (no PRs with `loom:changes-requested` or conflicts)
-- ❌ **NOT during active work** (only after fixes are complete)
+When you complete your task (feedback addressed and PR labeled with `loom:review-requested`), the orchestration layer detects this and terminates the session automatically. No explicit exit command is needed.

--- a/defaults/.claude/commands/judge.md
+++ b/defaults/.claude/commands/judge.md
@@ -843,23 +843,6 @@ After completing your iteration (reviewing a PR and updating labels), execute:
 
 ## Completion
 
-**After completing your task, exit Claude Code to signal completion.**
+**Work completion is detected automatically.**
 
-When you have finished your work (PR reviewed and labeled with `loom:pr` or `loom:changes-requested`), execute:
-
-```
-/exit
-```
-
-### Why This Matters
-
-- **Enables automation**: Shepherd orchestration relies on detecting when workers complete
-- **Prevents hanging**: Without `/exit`, `agent-wait-bg.sh` waits until timeout
-- **Saves resources**: Idle Claude Code sessions consume memory and context budget
-
-### When to Exit
-
-- ✅ **After approving PR** (labeled with `loom:pr`)
-- ✅ **After requesting changes** (labeled with `loom:changes-requested`)
-- ✅ **When no work is available** (no PRs with `loom:review-requested`)
-- ❌ **NOT during active work** (only after review is complete)
+When you complete your task (PR reviewed and labeled with `loom:pr` or `loom:changes-requested`), the orchestration layer detects this and terminates the session automatically. No explicit exit command is needed.


### PR DESCRIPTION
## Summary

- Replace verbose `/exit` instructions in curator, builder, judge, and doctor role files with brief note about automatic completion detection
- Update roles/README.md to explain phase contract completion mechanism
- Remove implementation details (`validate-phase.sh`) from agent-facing docs as agents don't need to know the internals

## Details

Work completion is now detected automatically via phase contracts:

| Role | Completion Criteria |
|------|---------------------|
| Curator | `loom:curated` label on issue |
| Builder | PR with `loom:review-requested` label linked to issue |
| Judge | `loom:pr` or `loom:changes-requested` on PR |
| Doctor | `loom:review-requested` label after fixes |

The `/exit` instructions were misleading since agents can't actually execute Claude Code slash commands. The phase contract detection was already implemented and working.

## Test plan

- [x] Verify role files have simplified completion sections
- [x] Verify README documents the completion detection mechanism
- [ ] Manual testing: Run each role type and verify session terminates after phase contract is satisfied

Closes #1505

🤖 Generated with [Claude Code](https://claude.com/claude-code)