### PR TITLE
Fix state machine violation: loom:building and loom:blocked mutual exclusivity

### DIFF
--- a/defaults/.claude/commands/builder.md
+++ b/defaults/.claude/commands/builder.md
@@ -47,8 +47,17 @@ If no argument is provided, use the normal "Finding Work" workflow below.
 | Action | Remove | Add |
 |--------|--------|-----|
 | Claim issue | `loom:issue` | `loom:building` |
-| Block issue | - | `loom:blocked` |
+| Block issue | `loom:building` | `loom:blocked` |
 | Create PR | - | `loom:review-requested` (on new PR only) |
+
+**IMPORTANT**: `loom:building` and `loom:blocked` are **mutually exclusive** - an issue cannot be in both states. Always use atomic transitions:
+```bash
+# CORRECT: Atomic transition to blocked state
+gh issue edit <number> --remove-label "loom:building" --add-label "loom:blocked"
+
+# WRONG: Leaves issue in invalid state with both labels
+gh issue edit <number> --add-label "loom:blocked"
+```
 
 ### Labels You NEVER Touch
 
@@ -326,9 +335,9 @@ Open the issue and look for:
 If you discover a dependency while working:
 
 1. **Add Dependencies section** to the issue
-2. **Mark as blocked**:
+2. **Mark as blocked** (atomic transition from building to blocked):
    ```bash
-   gh issue edit <number> --add-label "loom:blocked"
+   gh issue edit <number> --remove-label "loom:building" --add-label "loom:blocked"
    ```
 3. **Create comment** explaining the dependency
 4. **Wait** for dependency to be resolved, or switch to another issue

--- a/defaults/scripts/shepherd-loop.sh
+++ b/defaults/scripts/shepherd-loop.sh
@@ -775,7 +775,8 @@ main() {
 
             if [[ $doctor_attempts -ge $DOCTOR_MAX_RETRIES ]]; then
                 log_error "Doctor max retries ($DOCTOR_MAX_RETRIES) exceeded"
-                add_label "$ISSUE" "loom:blocked"
+                # Atomic transition: loom:building -> loom:blocked (mutually exclusive states)
+                gh issue edit "$ISSUE" --remove-label "loom:building" --add-label "loom:blocked" >/dev/null 2>&1 || true
                 gh issue comment "$ISSUE" --body "**Shepherd blocked**: Doctor could not resolve Judge feedback after $DOCTOR_MAX_RETRIES attempts." >/dev/null 2>&1 || true
                 fail_with_reason "doctor" "max retries ($DOCTOR_MAX_RETRIES) exceeded"
             fi
@@ -845,7 +846,8 @@ main() {
             log_success "PR #$pr_number merged successfully"
         else
             log_error "Failed to merge PR #$pr_number"
-            add_label "$ISSUE" "loom:blocked"
+            # Atomic transition: loom:building -> loom:blocked (mutually exclusive states)
+            gh issue edit "$ISSUE" --remove-label "loom:building" --add-label "loom:blocked" >/dev/null 2>&1 || true
             gh issue comment "$ISSUE" --body "**Shepherd blocked**: Failed to merge PR #$pr_number. Branch may be out of date or have merge conflicts." >/dev/null 2>&1 || true
             fail_with_reason "merge" "failed to merge PR #$pr_number"
         fi

--- a/defaults/scripts/validate-phase.sh
+++ b/defaults/scripts/validate-phase.sh
@@ -161,10 +161,12 @@ EOF
 }
 
 # Helper: mark issue as blocked
+# Uses atomic transition: loom:building -> loom:blocked (mutually exclusive states)
 mark_blocked() {
     local reason="$1"
     local diagnostics="${2:-}"
-    gh issue edit "$ISSUE" --add-label "loom:blocked" 2>/dev/null || true
+    # Atomic transition to prevent state machine violation
+    gh issue edit "$ISSUE" --remove-label "loom:building" --add-label "loom:blocked" 2>/dev/null || true
     local comment_body="**Phase contract failed**: \`$PHASE\` phase did not produce expected outcome. $reason"
     if [[ -n "$diagnostics" ]]; then
         comment_body="$comment_body


### PR DESCRIPTION
## Summary

- Fixes state machine violation where issues could have both `loom:building` and `loom:blocked` labels simultaneously
- Updates shepherd-loop.sh to use atomic label transitions at doctor max retries and merge failure paths
- Updates validate-phase.sh `mark_blocked()` helper to use atomic transition
- Documents mutual exclusivity in builder.md

## Test plan

- [x] Verify no issues currently have both labels: `gh issue list --label="loom:building" --label="loom:blocked"` returns empty
- [x] Shell scripts pass syntax check (`bash -n`)
- [x] Lint passes (`pnpm lint`)
- [ ] Manual test: Simulate blocked scenario and verify only `loom:blocked` label present

Closes #1506

🤖 Generated with [Claude Code](https://claude.com/claude-code)