### PR TITLE
Fix CI failures: shellcheck errors and label-external-issues workflow

### DIFF
--- a/.github/workflows/label-external-issues.yml
+++ b/.github/workflows/label-external-issues.yml
@@ -3,27 +3,13 @@ name: Label external issues
 on:
   issues:
     types: [opened]
-  push:
-    paths:
-      - '.github/workflows/label-external-issues.yml'
 
 permissions:
   issues: write
   contents: read
 
 jobs:
-  # Guard job to prevent workflow failure on push events
-  # GitHub Actions marks runs as failed when no jobs execute, so this ensures
-  # at least one job runs. Using explicit true condition for clarity.
-  validate:
-    if: ${{ true }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Workflow syntax valid
-        run: echo "Workflow file validated successfully"
-
   label_external:
-    if: ${{ github.event_name == 'issues' }}
     runs-on: ubuntu-latest
     steps:
       - name: Check if author is a collaborator

--- a/defaults/scripts/shepherd-loop.sh
+++ b/defaults/scripts/shepherd-loop.sh
@@ -408,7 +408,7 @@ report_final_status() {
 
     # Always remove worktree marker on exit (prevents orphaned markers)
     # The marker prevents cleanup scripts from removing the worktree during orchestration
-    remove_worktree_marker
+    remove_worktree_marker "$ACTIVE_WORKTREE_PATH"
 
     # Only report errors for non-zero exits (excluding shutdown which is 0)
     # Also requires TASK_ID to be set and progress file to exist (created after 'started' milestone)


### PR DESCRIPTION
## Summary
- Fix shellcheck errors in clean.sh (SC2168: 'local' outside functions)
- Fix shellcheck warning in shepherd-loop.sh (SC2120: unused function parameters)
- Fix label-external-issues workflow failing on all push events

Closes #1525

## Test plan
- [x] CI passes on this PR (shellcheck should pass)
- [ ] label-external-issues workflow should no longer fail on push events (it simply won't trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)