### PR TITLE
Add stuck agent recovery with kill-and-retry for shepherd phases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ Thumbs.db
 .loom/signals/
 .loom/status/
 .loom/progress/
+.loom/diagnostics/
 
 # Loom workspace config (DO commit for team sharing)
 # - config.json: Persistent terminal configurations (roles, themes, intervals)


### PR DESCRIPTION
## Summary

When stuck detection reaches the critical threshold during shepherd orchestration, the system now takes automated recovery action instead of just logging a warning.

**Changes:**

- **`agent-wait-bg.sh`**: Added `capture_stuck_diagnostics()` function that saves tmux pane content and log tail before killing a stuck session. Added `retry` action value to `LOOM_STUCK_ACTION`. Existing `restart` action also now captures diagnostics.
- **`shepherd-loop.sh`**: Added `run_phase_with_retry()` wrapper that sets `LOOM_STUCK_ACTION=retry` and retries the phase once (configurable via `LOOM_STUCK_MAX_RETRIES`) on exit code 4 (stuck agent). All phase callers (curator, builder, judge, doctor) updated to use the retry wrapper and handle exit code 4 by marking issues as `loom:blocked` with diagnostic context.
- **`.gitignore`**: Added `.loom/diagnostics/` for stuck agent diagnostic files.

**Recovery flow:**
1. Agent detected as stuck (no progress for 600s)
2. Diagnostics captured (tmux pane content + log tail) to `.loom/diagnostics/`
3. Stuck session killed
4. Phase retried once
5. If retry also gets stuck, issue transitions to `loom:blocked` with a comment

**Configuration:**
- `LOOM_STUCK_MAX_RETRIES` - Max retry attempts per phase (default: 1)
- `LOOM_STUCK_ACTION` - Still defaults to `warn` globally, but `run_phase_with_retry` overrides to `retry`

Closes #1517

## Test plan

- [ ] Verify `bash -n` syntax check passes for both scripts
- [ ] Verify CI shellcheck passes
- [ ] Review that `run_phase_with_retry` correctly passes through all arguments to `run_phase`
- [ ] Review that exit code 4 handling correctly transitions to `loom:blocked`
- [ ] Review that diagnostics capture is non-fatal (uses `|| true`)
- [ ] Verify `.loom/diagnostics/` is gitignored