### PR TITLE
Fix --clean reinstall not updating Loom files

### DIFF
--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -493,11 +493,11 @@ success "loom-daemon binary ready"
 
 # Run loom-daemon init in the worktree
 cd "$TARGET_PATH/$WORKTREE_PATH"
-# Use --force to overwrite existing installation when requested
+# Use --force to overwrite existing installation when requested (--force or --clean flags)
 # Otherwise, use merge mode to preserve custom project roles/commands
 # Use --defaults to point to Loom's defaults directory
 INIT_FLAGS=""
-if [ "$FORCE_OVERWRITE" = true ]; then
+if [ "$FORCE_OVERWRITE" = true ] || [ "$CLEAN_FIRST" = true ]; then
   INIT_FLAGS="--force"
 fi
 "$LOOM_ROOT/target/release/loom-daemon" init $INIT_FLAGS --defaults "$LOOM_ROOT/defaults" . || \


### PR DESCRIPTION
## Summary

- Fix `--clean` reinstall preserving stale Loom files instead of updating them
- Add `CLEAN_FIRST` to condition that triggers `--force` mode for `loom-daemon init`

## Root Cause

When running `./install.sh <repo> --clean`:
1. Uninstall removes files from **working directory** (via `--local` flag)
2. Worktree is created from `origin/main` (which still has old committed files)
3. `loom-daemon init` ran **without** `--force`, preserving existing files in worktree

## Fix

The condition at line 500 now includes `CLEAN_FIRST`:

```bash
if [ "$FORCE_OVERWRITE" = true ] || [ "$CLEAN_FIRST" = true ]; then
  INIT_FLAGS="--force"
fi
```

## Acceptance Criteria Verification

| Criterion | Verification |
|-----------|--------------|
| `--clean` flag causes `loom-daemon init` to run with `--force` | ✅ Condition updated to include `CLEAN_FIRST` |
| Fresh install after `--clean` contains all latest Loom files | ✅ `--force` flag overwrites existing files |
| `--force` flag behavior unchanged | ✅ Original condition preserved, only added OR clause |
| Help text reflects expected behavior | ✅ Help says "fresh install" which is now accurate |

## Test plan

- [ ] Verify `--clean` now triggers force mode (check INIT_FLAGS in debug output)
- [ ] Verify `--force` alone still works
- [ ] Verify `--clean --force` together works (both imply force)

Closes #1534

🤖 Generated with [Claude Code](https://claude.com/claude-code)