### PR TITLE
Make loom:curating label application more explicit in curator.md

### DIFF
--- a/defaults/.claude/commands/curator.md
+++ b/defaults/.claude/commands/curator.md
@@ -21,10 +21,14 @@ Check for an argument passed via the slash command:
 **Arguments**: `$ARGUMENTS`
 
 If a number is provided (e.g., `/curator 42`):
-1. Treat that number as the target **issue** to curate
+1. **FIRST, claim the issue immediately** by running this command:
+   ```bash
+   gh issue edit <number> --add-label "loom:curating"
+   ```
 2. **Skip** the "Finding Work" section entirely
-3. Claim the issue: `gh issue edit <number> --add-label "loom:curating"`
-4. Proceed directly to curation
+3. Proceed directly to curation
+
+**CRITICAL**: You MUST run the `gh issue edit` command above BEFORE doing any other work. The `loom:curating` label signals that you have claimed the issue and prevents duplicate work.
 
 If no argument is provided, use the normal "Finding Work" workflow below.
 
@@ -142,6 +146,19 @@ gh issue edit <number> --add-label "loom:curating"
 ```
 
 This signals to other Curators that you're working on this issue. The search command above already filters out claimed issues, so you won't see issues other Curators are enhancing.
+
+## Before Starting Curation
+
+**STOP**: Before enhancing any issue, verify you have claimed it:
+
+- [ ] Issue has `loom:curating` label
+
+If the label is missing, run:
+```bash
+gh issue edit <number> --add-label "loom:curating"
+```
+
+**Why this matters**: The `loom:curating` label prevents duplicate work by signaling to other Curators that you've claimed this issue. Skipping this step can cause coordination failures.
 
 ## Triage: Ready or Needs Enhancement?
 


### PR DESCRIPTION
## Summary

- Made the `loom:curating` label application more explicit in curator.md when an issue number argument is provided
- The label command is now the **FIRST** step with explicit bash code block formatting
- Added a **CRITICAL** note emphasizing the command must run before any other work
- Added a "Before Starting Curation" checklist gate to verify the label before proceeding

## Test plan

- [ ] Deploy to a test Loom instance
- [ ] Run `/shepherd <issue>` on an uncurated issue
- [ ] Verify the curator phase applies `loom:curating` label before starting enhancement work
- [ ] Verify the `loom:curating` label is visible in the issue's label history

Closes #1533

🤖 Generated with [Claude Code](https://claude.com/claude-code)