### PR TITLE
Fix merge-pr.sh worktree path calculation (double-nested)

### DIFF
--- a/defaults/scripts/merge-pr.sh
+++ b/defaults/scripts/merge-pr.sh
@@ -28,8 +28,32 @@ info() { echo -e "${BLUE}$*${NC}"; }
 success() { echo -e "${GREEN}$*${NC}"; }
 warning() { echo -e "${YELLOW}$*${NC}"; }
 
-# Find git repository root
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || \
+# Find the main repository root (works from worktrees too)
+# When run from a worktree, git rev-parse --show-toplevel returns the worktree path,
+# not the main repository. This function navigates via the gitdir to find the actual root.
+find_main_repo_root() {
+  local dir
+  dir="$(git rev-parse --show-toplevel 2>/dev/null)" || return 1
+
+  # Check if this is a worktree (has .git file, not directory)
+  if [[ -f "$dir/.git" ]]; then
+    local gitdir
+    gitdir=$(cat "$dir/.git" | sed 's/^gitdir: //')
+    # gitdir is like /path/to/repo/.git/worktrees/issue-123
+    # main repo is 3 levels up from there
+    local main_repo
+    main_repo=$(dirname "$(dirname "$(dirname "$gitdir")")")
+    if [[ -d "$main_repo/.loom" ]]; then
+      echo "$main_repo"
+      return 0
+    fi
+  fi
+
+  # Not a worktree or fallback - return the git root
+  echo "$dir"
+}
+
+REPO_ROOT="$(find_main_repo_root)" || \
   error "Not in a git repository"
 
 # Auto-detect owner/repo from git remote


### PR DESCRIPTION
## Summary
- Fix incorrect worktree path calculation in merge-pr.sh
- Add find_main_repo_root() function to handle worktree-aware path resolution

## Problem
When running `merge-pr.sh` from inside a worktree with `--cleanup-worktree`, the script was calculating an incorrect double-nested path:
```
No worktree found at .../issue-1543/.loom/worktrees/issue-1543
```

## Root Cause
`git rev-parse --show-toplevel` returns the worktree path when run from inside a worktree, not the main repository root. This caused the worktree cleanup path to be calculated relative to the worktree itself.

## Solution
Add a `find_main_repo_root()` function that:
1. Detects if running in a worktree by checking for `.git` file (vs directory)
2. Parses the gitdir path from the `.git` file
3. Navigates up from the gitdir to find the main repository root
4. Falls back to `git rev-parse --show-toplevel` for non-worktree contexts

## Test plan
- [x] Verified syntax with `bash -n`
- [x] Tested function in isolation from main repo and worktree contexts
- [x] Confirmed path resolution returns `/Users/rwalters/GitHub/loom` from both contexts

Closes #1549

🤖 Generated with [Claude Code](https://claude.com/claude-code)