### PR TITLE
Pass command at Claude CLI launch instead of post-TUI dispatch

### DIFF
--- a/defaults/scripts/agent-spawn.sh
+++ b/defaults/scripts/agent-spawn.sh
@@ -40,7 +40,6 @@ set -euo pipefail
 # Configuration
 TMUX_SOCKET="loom"
 SESSION_PREFIX="loom-"
-READINESS_TIMEOUT_SECONDS=30
 STUCK_SESSION_THRESHOLD_SECONDS=${LOOM_STUCK_SESSION_THRESHOLD:-300}  # 5 minutes
 
 # Colors for output


### PR DESCRIPTION
## Summary

- Pass the role command directly to Claude CLI at launch instead of sending it via tmux after TUI is ready
- Remove TUI readiness detection logic (~30 lines) that was unreliable
- Remove command dispatch retry logic (~100 lines) that was a workaround for timing issues
- Simplify to a single processing verification loop

## Problem

The previous approach had a fundamental timing problem:

1. Launch Claude CLI
2. Wait for TUI prompt (❯) to render
3. Wait additional time for "TUI input handler to initialize"
4. Send command via tmux

The ❯ prompt character renders before the input handler is ready to receive keystrokes, causing frequent failures where the command was never processed.

## Solution

Claude CLI accepts a prompt argument at launch. By passing the command directly at launch, the TUI timing issues are eliminated entirely:

```bash
# Before (unreliable)
tmux send-keys "claude --dangerously-skip-permissions" C-m
# ... wait for prompt ...
# ... wait for TUI init ...
tmux send-keys "/builder 42" C-m  # Often fails

# After (reliable)
tmux send-keys "claude --dangerously-skip-permissions \"/builder 42\"" C-m
```

## Changes

- Build role command earlier, append as quoted argument to claude command
- Remove prompt detection polling loop (507-519)
- Remove TUI initialization wait (523-534)
- Remove command dispatch with retry/backoff logic (536-635)
- Simplify to single processing verification loop
- Replace 4 environment variables with 1 (`LOOM_SPAWN_VERIFY_TIMEOUT`)

## Test plan

- [ ] Spawn a builder agent: `./.loom/scripts/agent-spawn.sh --role builder --args "42" --name test-builder`
- [ ] Verify the agent processes the command without retries
- [ ] Test with shepherd: `./.loom/scripts/agent-spawn.sh --role shepherd --args "123 --force" --name test-shepherd`
- [ ] Test error path: verify proper cleanup if Claude doesn't start processing

Closes #1559

🤖 Generated with [Claude Code](https://claude.com/claude-code)