### PR TITLE
Extract PROCESSING_INDICATORS pattern to shared location

### DIFF
--- a/defaults/scripts/agent-spawn.sh
+++ b/defaults/scripts/agent-spawn.sh
@@ -37,6 +37,13 @@
 
 set -euo pipefail
 
+# Script directory for sourcing shared libraries
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source shared constants (provides PROCESSING_INDICATORS pattern)
+# shellcheck source=lib/constants.sh
+source "${SCRIPT_DIR}/lib/constants.sh"
+
 # Configuration
 TMUX_SOCKET="loom"
 SESSION_PREFIX="loom-"
@@ -512,12 +519,7 @@ EOF
     # Verify the command is being processed.
     # Since we pass the command at launch, Claude should start processing immediately
     # after startup. We poll for processing indicators to confirm.
-    #
-    # Pattern for detecting Claude is processing a command:
-    # - Spinner characters (Claude thinking)
-    # - Progress/status text
-    # - Tool use indicators
-    local PROCESSING_INDICATORS='⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏|Beaming|Loading|● |✓ |◐|◓|◑|◒|thinking|streaming'
+    # PROCESSING_INDICATORS is sourced from lib/constants.sh
 
     # Configurable verify parameters (via environment or defaults)
     local verify_timeout="${LOOM_SPAWN_VERIFY_TIMEOUT:-30}"  # Total time to wait for processing

--- a/defaults/scripts/agent-wait-bg.sh
+++ b/defaults/scripts/agent-wait-bg.sh
@@ -70,8 +70,9 @@ STUCK_ACTION=${LOOM_STUCK_ACTION:-warn}              # warn, pause, restart, ret
 # This is a distinct, faster-detectable failure mode from general stuck detection
 PROMPT_STUCK_THRESHOLD=${LOOM_PROMPT_STUCK_THRESHOLD:-30}  # 30 seconds default
 
-# Pattern for detecting Claude is processing a command (shared with agent-spawn.sh)
-PROCESSING_INDICATORS='⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏|Beaming|Loading|● |✓ |◐|◓|◑|◒|thinking|streaming|Wandering'
+# Source shared constants (provides PROCESSING_INDICATORS pattern)
+# shellcheck source=lib/constants.sh
+source "${SCRIPT_DIR}/lib/constants.sh"
 
 # Progress tracking file prefix
 PROGRESS_DIR="/tmp/loom-agent-progress"

--- a/defaults/scripts/lib/constants.sh
+++ b/defaults/scripts/lib/constants.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# constants.sh - Shared constants for Loom scripts
+#
+# This file provides shared patterns and constants used across multiple
+# Loom scripts to ensure consistency and avoid drift.
+#
+# Usage:
+#   # At the top of your script, after determining SCRIPT_DIR:
+#   source "${SCRIPT_DIR}/lib/constants.sh"
+
+# ==============================================================================
+# Processing Detection Patterns
+# ==============================================================================
+#
+# Pattern for detecting Claude Code activity in a tmux pane.
+# Used to determine if Claude is actively processing a command.
+#
+# This includes:
+# - Braille spinner characters (Claude thinking indicator)
+# - Status text indicators (Beaming, Loading, etc.)
+# - Progress indicators (●, ✓, spinning characters)
+# - Activity keywords (thinking, streaming, Wandering)
+#
+# Used by:
+# - agent-spawn.sh: Verify Claude started processing after spawn
+# - agent-wait-bg.sh: Detect stuck-at-prompt condition
+#
+PROCESSING_INDICATORS='⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏|Beaming|Loading|● |✓ |◐|◓|◑|◒|thinking|streaming|Wandering'
+
+# ==============================================================================
+# Future shared constants can be added below
+# ==============================================================================


### PR DESCRIPTION
## Summary
- Create new `defaults/scripts/lib/constants.sh` with shared `PROCESSING_INDICATORS` pattern
- Update `agent-spawn.sh` to source the shared constants
- Update `agent-wait-bg.sh` to source the shared constants
- Remove duplicate inline definitions that had drifted out of sync

## Test plan
- [x] Scripts pass bash syntax check (`bash -n`)
- [x] Constants file can be sourced correctly
- [ ] Verify agent-spawn.sh correctly detects Claude processing indicators
- [ ] Verify agent-wait-bg.sh correctly detects stuck-at-prompt condition

Closes #1554

🤖 Generated with [Claude Code](https://claude.com/claude-code)