### PR TITLE
Document label state at each shepherd phase boundary

### DIFF
--- a/defaults/scripts/validate-phase.sh
+++ b/defaults/scripts/validate-phase.sh
@@ -174,7 +174,9 @@ mark_blocked() {
     local diagnostics="${2:-}"
     # Atomic transition to prevent state machine violation
     gh issue edit "$ISSUE" --remove-label "loom:building" --add-label "loom:blocked" 2>/dev/null || true
-    local comment_body="**Phase contract failed**: \`$PHASE\` phase did not produce expected outcome. $reason"
+    local comment_body="**Phase contract failed**: \`$PHASE\` phase did not produce expected outcome. $reason
+
+For label state documentation and manual recovery steps, see [\`.claude/commands/shepherd-lifecycle.md\`](../blob/main/.claude/commands/shepherd-lifecycle.md#label-state-machine)."
     if [[ -n "$diagnostics" ]]; then
         comment_body="$comment_body
 


### PR DESCRIPTION
## Summary

- Added comprehensive "Label State Machine" section to `.claude/commands/shepherd-lifecycle.md`
- Documents phase entry states, exit states (success/failure), and state diagrams
- Includes manual recovery commands for each phase
- Links validate-phase.sh blocked comments to the new documentation

## Test plan

- [ ] Verify documentation renders correctly in GitHub markdown
- [ ] Confirm recovery commands work as documented
- [ ] Check that blocked issue comments now include documentation link

Closes #1555

🤖 Generated with [Claude Code](https://claude.com/claude-code)