### PR TITLE
Focus PROCESSING_INDICATORS on spinner chars, not status words

### DIFF
--- a/defaults/scripts/lib/constants.sh
+++ b/defaults/scripts/lib/constants.sh
@@ -35,6 +35,7 @@
 # Note: The pattern uses alternation (|) for grep -E compatibility.
 # Spinner characters are the most reliable indicators of activity.
 #
+# shellcheck disable=SC2034  # Variable is used by scripts that source this file
 PROCESSING_INDICATORS='⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏|✻|✶|✳|✢|✽|·|⏺|◐|◓|◑|◒|● '
 
 # ==============================================================================

--- a/defaults/scripts/lib/constants.sh
+++ b/defaults/scripts/lib/constants.sh
@@ -15,17 +15,27 @@
 # Pattern for detecting Claude Code activity in a tmux pane.
 # Used to determine if Claude is actively processing a command.
 #
-# This includes:
-# - Braille spinner characters (Claude thinking indicator)
-# - Status text indicators (Beaming, Loading, etc.)
-# - Progress indicators (●, ✓, spinning characters)
-# - Activity keywords (thinking, streaming, Wandering)
+# IMPORTANT: Claude Code uses a large, changing library of status words
+# (Beaming, Manifesting, Crafting, Wandering, etc.). Do NOT try to enumerate
+# them all - they change between versions. Instead, we detect:
+#
+# 1. Spinner characters (stable across versions):
+#    - Braille spinners: ⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏
+#    - Star spinners (v2.1.25+): ✻✶✳✢✽·
+#    - Circle spinners: ◐◓◑◒
+#
+# 2. Tool/progress indicators:
+#    - ⏺ (tool execution)
+#    - ● (active indicator, followed by status text)
 #
 # Used by:
 # - agent-spawn.sh: Verify Claude started processing after spawn
 # - agent-wait-bg.sh: Detect stuck-at-prompt condition
 #
-PROCESSING_INDICATORS='⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏|Beaming|Loading|● |✓ |◐|◓|◑|◒|thinking|streaming|Wandering'
+# Note: The pattern uses alternation (|) for grep -E compatibility.
+# Spinner characters are the most reliable indicators of activity.
+#
+PROCESSING_INDICATORS='⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏|✻|✶|✳|✢|✽|·|⏺|◐|◓|◑|◒|● '
 
 # ==============================================================================
 # Future shared constants can be added below

--- a/defaults/scripts/validate-phase.sh
+++ b/defaults/scripts/validate-phase.sh
@@ -174,7 +174,9 @@ mark_blocked() {
     local diagnostics="${2:-}"
     # Atomic transition to prevent state machine violation
     gh issue edit "$ISSUE" --remove-label "loom:building" --add-label "loom:blocked" 2>/dev/null || true
-    local comment_body="**Phase contract failed**: \`$PHASE\` phase did not produce expected outcome. $reason"
+    local comment_body="**Phase contract failed**: \`$PHASE\` phase did not produce expected outcome. $reason
+
+For label state documentation and manual recovery steps, see [\`.claude/commands/shepherd-lifecycle.md\`](../blob/main/.claude/commands/shepherd-lifecycle.md#label-state-machine)."
     if [[ -n "$diagnostics" ]]; then
         comment_body="$comment_body
 


### PR DESCRIPTION
## Summary
- Remove status word enumeration (Beaming, Loading, etc.) from PROCESSING_INDICATORS
- Focus on spinner characters which are more stable across Claude Code versions
- Add star spinners (✻✶✳✢✽·) for Claude Code v2.1.25+ support
- Improve documentation explaining why we detect spinners not words

## Rationale
Claude Code uses a large, changing library of status words that vary between versions. Trying to enumerate them all leads to maintenance burden and missed detections. Spinner characters are the actual UI elements that indicate activity and are more stable.

## Test plan
- [x] Syntax validation: `bash -n defaults/scripts/lib/constants.sh`
- [x] Pattern matches star spinners: `echo "✻" | grep -qE "$PROCESSING_INDICATORS"`
- [x] Pattern matches braille spinners: `echo "⠋" | grep -qE "$PROCESSING_INDICATORS"`
- [x] Pattern matches active indicator: `echo "● " | grep -qE "$PROCESSING_INDICATORS"`

**Note**: This PR is based on #1566 which introduces the shared constants.sh file.

Closes #1568

🤖 Generated with [Claude Code](https://claude.com/claude-code)