### PR TITLE
Reject PR numbers in shepherd with clear error

### DIFF
--- a/defaults/scripts/shepherd-loop.sh
+++ b/defaults/scripts/shepherd-loop.sh
@@ -677,6 +677,15 @@ main() {
         exit 1
     fi
 
+    # Verify it's an issue, not a pull request
+    local item_url
+    item_url=$(gh issue view "$ISSUE" --json url --jq '.url' 2>/dev/null)
+    if [[ "$item_url" == */pull/* ]]; then
+        log_error "#$ISSUE is a pull request, not an issue"
+        log_info "Hint: Use 'gh pr view $ISSUE' to see PR details"
+        exit 1
+    fi
+
     # Check if issue is already closed
     local issue_state
     issue_state=$(gh issue view "$ISSUE" --json state --jq '.state' 2>/dev/null)


### PR DESCRIPTION
## Summary

- Adds validation in `shepherd-loop.sh` to detect when a PR number is passed instead of an issue number
- Checks if the URL from `gh issue view` contains `/pull/` pattern to identify PRs
- Exits with a clear error message directing users to use `gh pr view` instead

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Run `/shepherd <merged-pr-number>` - should error immediately | ✅ | Tested with PR #1572 - URL contains `/pull/`, triggers error path |
| Run `/shepherd <open-pr-number>` - should error immediately | ✅ | Same logic - `/pull/` pattern detection works for any PR state |
| Run `/shepherd <valid-issue-number>` - should proceed normally | ✅ | Tested with issue #1574 - URL contains `/issues/`, passes validation |

## Test Output

```
# PR detection (should fail)
URL: https://github.com/rjwalters/loom/pull/1572
SUCCESS: Correctly detected as PR

# Issue detection (should pass)
URL: https://github.com/rjwalters/loom/issues/1574
SUCCESS: Correctly identified as issue (not a PR)
```

## Error Message Format

When a user passes a PR number:
```
Error: #1265 is a pull request, not an issue
Hint: Use 'gh pr view 1265' to see PR details
```

Closes #1573