### PR TITLE
Handle MERGED state in shepherd issue check

### DIFF
--- a/defaults/scripts/shepherd-loop.sh
+++ b/defaults/scripts/shepherd-loop.sh
@@ -686,11 +686,11 @@ main() {
         exit 1
     fi
 
-    # Check if issue is already closed
+    # Check if issue is already closed or merged
     local issue_state
     issue_state=$(gh issue view "$ISSUE" --json state --jq '.state' 2>/dev/null)
-    if [[ "$issue_state" == "CLOSED" ]]; then
-        log_info "Issue #$ISSUE is already closed - no orchestration needed"
+    if [[ "$issue_state" != "OPEN" ]]; then
+        log_info "Issue #$ISSUE is already $issue_state - no orchestration needed"
         exit 0
     fi
 


### PR DESCRIPTION
## Summary

- Changed the shepherd state check from matching only `"CLOSED"` to rejecting any non-`"OPEN"` state
- This catches `MERGED` PRs and any future states GitHub may add
- Updated the log message to include the actual state value for better diagnostics

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|-------------|
| Handle CLOSED state | Passed | `!= "OPEN"` catches CLOSED |
| Handle MERGED state | Passed | `!= "OPEN"` catches MERGED |
| Handle future states | Passed | `!= "OPEN"` catches any non-OPEN state |
| Graceful exit with message | Passed | Logs actual state: "already CLOSED/MERGED" |
| Open issues proceed normally | Passed | `"OPEN" != "OPEN"` is false, continues |

## Test Plan

- [x] Shepherd on closed issue - exits with "already CLOSED"
- [x] Shepherd on merged PR - exits with "already MERGED" (previously missed)
- [x] Shepherd on open issue - proceeds normally
- [x] Edge case: `gh issue view` failure is handled by pre-existing existence check at line 675

Closes #1574

🤖 Generated with [Claude Code](https://claude.com/claude-code)