### PR TITLE
Document that force mode does not skip Judge phase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ Launch the Loom desktop application for automated orchestration:
 /loom --force   # Aggressive autonomous development
 ```
 
-**Force Mode** enables: auto-promotion of proposals, audit trail with `[force-mode]` markers, safety guardrails still apply.
+**Force Mode** enables: auto-promotion of proposals, auto-merge after Judge approval, audit trail with `[force-mode]` markers, safety guardrails still apply. Force mode does **not** skip the Judge phase (code review always runs due to GitHub's self-review API restriction).
 
 **Graceful shutdown**: `touch .loom/stop-daemon`
 

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -234,8 +234,12 @@ LOOM_POLL_INTERVAL=60 ./.loom/scripts/daemon-loop.sh
 When running with `--force`, the daemon enables aggressive autonomous development:
 - Champion auto-promotes all `loom:architect` and `loom:hermit` proposals
 - Champion auto-promotes all `loom:curated` issues
+- Shepherds auto-approve issues at Gate 1 (skip human approval)
+- Shepherds auto-merge PRs at Gate 2 (after Judge approval)
 - Audit trail with `[force-mode]` markers on all auto-promoted items
 - Safety guardrails still apply (no force-push, respect `loom:blocked`)
+
+**Force mode does NOT skip code review.** The Judge phase always runs, even in force mode. This is because GitHub's API prevents self-approval of PRs (`gh pr review --approve` fails when the same user created the PR). Loom's label-based review system (`loom:review-requested` -> `loom:pr`) works around this restriction and functions identically in both normal and force modes. Force mode's value is auto-promotion and auto-merge, not review bypass.
 
 **Example daemon workflow**:
 ```

--- a/defaults/scripts/shepherd-loop.sh
+++ b/defaults/scripts/shepherd-loop.sh
@@ -15,7 +15,7 @@
 #   ./.loom/scripts/shepherd-loop.sh <issue-number> [options]
 #
 # Options:
-#   --force, -f     Auto-approve, resolve conflicts, auto-merge after approval
+#   --force, -f     Auto-approve, auto-merge after approval (does NOT skip Judge review)
 #   --wait          Wait for human approval at each gate (explicit non-default)
 #   --to <phase>    Stop after specified phase (curated, pr, approved)
 #   --task-id <id>  Use specific task ID (generated if not provided)
@@ -197,9 +197,14 @@ ${YELLOW}PHASES:${NC}
     1. Curator    - Enhance issue with implementation guidance
     2. Approval   - Wait for loom:issue label (or auto-approve in force mode)
     3. Builder    - Create worktree, implement, create PR
-    4. Judge      - Review PR, approve or request changes
+    4. Judge      - Review PR, approve or request changes (always runs, even in force mode)
     5. Doctor     - Address requested changes (if any)
     6. Merge      - Auto-merge (--force) or wait for human
+
+${YELLOW}NOTE:${NC}
+    Force mode does NOT skip the Judge phase. Code review always runs because
+    GitHub's API prevents self-approval of PRs. Force mode enables auto-approval
+    at phase 2 and auto-merge at phase 6.
 
 ${YELLOW}ENVIRONMENT:${NC}
     LOOM_CURATOR_TIMEOUT     Seconds for curator phase (default: 300)


### PR DESCRIPTION
## Summary

- Documents that `--force` mode does not skip the Judge phase in shepherd orchestration
- Clarifies that force mode's value is auto-promotion (Gate 1) and auto-merge (Gate 2), not review bypass
- Explains the GitHub self-review API restriction that makes Judge review necessary in all modes

## Changes

- **CLAUDE.md**: Updated force mode one-liner to mention Judge phase limitation
- **defaults/CLAUDE.md**: Added explicit paragraph explaining force mode does not skip code review, added Gate 1/Gate 2 bullet points
- **defaults/.claude/commands/shepherd-lifecycle.md**: Added mode behavior comparison table showing all phases, added note at Judge phase step
- **defaults/scripts/shepherd-loop.sh**: Updated `--force` flag description and help text to clarify Judge always runs

## Criterion Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Document that force mode cannot bypass Judge | Verified | Added to CLAUDE.md, defaults/CLAUDE.md, shepherd-lifecycle.md, shepherd-loop.sh |
| Explain GitHub self-review restriction | Verified | Each location explains the API limitation |
| Clarify what force mode does vs doesn't do | Verified | Mode comparison table in shepherd-lifecycle.md |
| No code changes needed (Option D) | Verified | All changes are documentation/help text only |

## Test plan

- [ ] Shell script syntax valid (`bash -n shepherd-loop.sh` passes)
- [ ] No functional changes - documentation only
- [ ] `shepherd-loop.sh --help` shows updated phase descriptions

Closes #1556