### PR TITLE
Fix curator recovery leaving stale loom:curating label

### DIFF
--- a/defaults/scripts/shepherd-loop.sh
+++ b/defaults/scripts/shepherd-loop.sh
@@ -766,6 +766,9 @@ main() {
                 fail_with_reason "curator" "validation failed"
             fi
 
+            # Belt-and-suspenders: ensure loom:curating is removed after curator completes
+            gh issue edit "$ISSUE" --remove-label "loom:curating" 2>/dev/null || true
+
             completed_phases+=("Curator")
             log_success "Curator phase complete"
         fi

--- a/defaults/scripts/validate-phase.sh
+++ b/defaults/scripts/validate-phase.sh
@@ -349,7 +349,7 @@ validate_curator() {
 
     # Recovery: apply loom:curated label (curator may have enhanced but not labeled)
     echo -e "${YELLOW}Attempting recovery: applying loom:curated label${NC}"
-    if gh issue edit "$ISSUE" --add-label "loom:curated" 2>/dev/null; then
+    if gh issue edit "$ISSUE" --remove-label "loom:curating" --add-label "loom:curated" 2>/dev/null; then
         report_milestone "heartbeat" --action "recovery: applied loom:curated label"
         output_result "recovered" "Applied loom:curated label" "apply_label"
         return 0


### PR DESCRIPTION
## Summary

- Fix `validate_curator()` recovery in `validate-phase.sh` to remove `loom:curating` when adding `loom:curated`, preventing issues from being stuck with both labels simultaneously
- Add belt-and-suspenders `loom:curating` removal in `shepherd-loop.sh` after curator phase completes successfully

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Recovery path removes loom:curating | Done | `--remove-label "loom:curating"` added to `gh issue edit` on line 352 of validate-phase.sh |
| No issues left with both labels | Done | Both recovery path and normal completion path now clean up loom:curating |
| Removing non-existent label is safe | Done | `gh issue edit --remove-label` is a no-op when label isn't present; `2>/dev/null` and `\|\| true` handle errors |

## Test plan

- [ ] Verify `validate-phase.sh curator <issue>` recovery removes `loom:curating` when adding `loom:curated`
- [ ] Verify `--remove-label` on a non-existent label is a no-op (no errors)
- [ ] Verify shepherd-loop.sh removes `loom:curating` after successful curator phase

Closes #1565

🤖 Generated with [Claude Code](https://claude.com/claude-code)