### PR TITLE
Remove stale cleanup script copy from install workflow

### DIFF
--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -526,16 +526,6 @@ done
 success "All Loom files installed"
 echo ""
 
-# Install cleanup scripts to .loom/scripts/
-info "Installing cleanup scripts..."
-cp "$LOOM_ROOT/scripts/cleanup.sh" ".loom/scripts/cleanup.sh" || \
-  error "Failed to copy cleanup.sh"
-cp "$LOOM_ROOT/scripts/cleanup-branches.sh" ".loom/scripts/cleanup-branches.sh" || \
-  error "Failed to copy cleanup-branches.sh"
-chmod +x ".loom/scripts/cleanup.sh"
-chmod +x ".loom/scripts/cleanup-branches.sh"
-success "Installed cleanup scripts to .loom/scripts/"
-
 # Install Loom CLI wrapper (./loom)
 if [[ -f "$LOOM_ROOT/defaults/loom" ]]; then
   info "Installing Loom CLI wrapper..."


### PR DESCRIPTION
## Summary
- `scripts/cleanup.sh` was deleted in e2b5e69 but `install-loom.sh` still tried to copy it, causing installation to fail with `Failed to copy cleanup.sh`
- These scripts are already installed by `loom-daemon init` from `defaults/scripts/`, so the manual copy step was redundant

## Test plan
- [x] Ran `./scripts/install-loom.sh --clean --yes ../kicad-tools` — completed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)