### PR TITLE
Reduce GitHub API calls in shepherd orchestration

### DIFF
--- a/defaults/scripts/agent-wait-bg.sh
+++ b/defaults/scripts/agent-wait-bg.sh
@@ -66,7 +66,10 @@ DEFAULT_IDLE_TIMEOUT=60
 # waiting for idle timeout. This detects completion much faster for phases
 # like builder where the signal is on GitHub (PR exists) rather than in logs.
 # Set to 0 to disable proactive checking (fall back to idle timeout only).
-DEFAULT_CONTRACT_INTERVAL=30
+# Note: The idle timeout (DEFAULT_IDLE_TIMEOUT=60) still provides faster
+# detection when the agent is actually idle, so this interval can be longer
+# without significantly impacting completion detection latency.
+DEFAULT_CONTRACT_INTERVAL=90
 
 # Stuck detection thresholds (configurable via environment variables)
 STUCK_WARNING_THRESHOLD=${LOOM_STUCK_WARNING:-300}   # 5 min default


### PR DESCRIPTION
## Summary

Reduces redundant GitHub API calls across the shepherd orchestration pipeline. These changes target the Phase 1 quick wins identified in #1605.

- **Bundle label checks**: `has_label()` now caches fetched labels and reuses them for subsequent checks on the same issue, with automatic invalidation on label mutations
- **Batch issue metadata**: The 4 separate `gh issue view` calls at shepherd startup (number, url, state, title) are consolidated into a single call that also pre-populates the label cache
- **Cache PR numbers**: `get_pr_for_issue()` caches the result after first discovery so the second call (post-validation) is free; branch-based lookup is now tried first (deterministic, no indexing lag)
- **PR passthrough to validate-phase.sh**: When `--pr` is provided, `validate_builder()` uses the cached PR number directly instead of running its own 4-pattern search
- **Increase contract interval**: `DEFAULT_CONTRACT_INTERVAL` raised from 30s to 90s; the 60s idle timeout still provides fast detection when agents are actually idle

**Estimated savings**: ~340-400 API calls per 30-minute builder phase per shepherd. With 3 concurrent shepherds, ~1,000-1,200 fewer calls per build cycle.

## Criterion Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Bundle label checks (fetch once, check locally) | Done | `has_label()` with `_CACHED_ISSUE_LABELS` cache + `invalidate_issue_label_cache()` on mutations |
| Reduce contract check interval | Done | `DEFAULT_CONTRACT_INTERVAL=90` (from 30), comment explaining idle timeout mitigation |
| Cache PR lookups after first discovery | Done | `_CACHED_PR_NUMBER` cache in `get_pr_for_issue()` + `--pr` passthrough in `validate-phase.sh` |
| Batch initial issue metadata queries | Done | Single `gh issue view --json url,state,title,labels` replacing 4 calls |
| Branch-based PR lookup tried first | Done | Reordered `get_pr_for_issue()` to try `--head` before search patterns |

## Test plan

- [ ] Run a full shepherd cycle and verify phase transitions detect correctly
- [ ] Verify label cache invalidation works after `add_label`/`remove_label` calls
- [ ] Verify approval polling loop gets fresh label data each iteration
- [ ] Confirm PR cache returns correct results on second `get_pr_for_issue()` call
- [ ] Run `bash -n` syntax check on all 3 modified scripts (verified locally)

Closes #1605

🤖 Generated with [Claude Code](https://claude.com/claude-code)