### PR TITLE
Add --min-idle-elapsed flag to prevent builder idle false positives

### DIFF
--- a/defaults/scripts/agent-wait.sh
+++ b/defaults/scripts/agent-wait.sh
@@ -60,6 +60,7 @@ ${YELLOW}USAGE:${NC}
 ${YELLOW}OPTIONS:${NC}
     --timeout <seconds>        Maximum time to wait (default: $DEFAULT_TIMEOUT)
     --poll-interval <seconds>  Time between checks (default: $DEFAULT_POLL_INTERVAL)
+    --min-idle-elapsed <secs>  Minimum seconds before idle prompt detection (default: $MIN_IDLE_ELAPSED)
     --json                     Output result as JSON
     --help                     Show this help message
 
@@ -245,6 +246,10 @@ main() {
                 ;;
             --poll-interval)
                 poll_interval="$2"
+                shift 2
+                ;;
+            --min-idle-elapsed)
+                MIN_IDLE_ELAPSED="$2"
                 shift 2
                 ;;
             --json)

--- a/defaults/scripts/shepherd-loop.sh
+++ b/defaults/scripts/shepherd-loop.sh
@@ -585,6 +585,12 @@ run_phase() {
 
     if [[ -n "$phase" ]]; then
         wait_args+=(--phase "$phase")
+        # Work-producing roles (builder, doctor) need longer idle thresholds
+        # to avoid false positives during skill loading, permission prompts,
+        # and initial codebase exploration (see issue #1623)
+        case "$phase" in
+            builder|doctor) wait_args+=(--min-idle-elapsed 120) ;;
+        esac
     fi
     if [[ -n "$worktree" ]]; then
         wait_args+=(--worktree "$worktree")


### PR DESCRIPTION
## Summary
- Add `--min-idle-elapsed` flag to `agent-wait.sh` to override the `MIN_IDLE_ELAPSED` threshold
- Thread the flag through `agent-wait-bg.sh` to the inner `agent-wait.sh` invocation
- Set 120s threshold for builder/doctor phases in `shepherd-loop.sh` (vs 10s default for support roles)

This prevents the idle prompt detector from declaring builders complete during skill loading, permission prompts, or initial codebase exploration — the root cause of systematic builder failures observed across multiple shepherd runs.

## Test plan
- [ ] Run `shepherd-loop.sh <issue> -f` — builder should not be declared idle within 120s
- [ ] Run a curator or judge phase — should still detect idle within ~20s
- [ ] Pass `--min-idle-elapsed 5` explicitly to `agent-wait.sh` — should override default
- [ ] Omit `--min-idle-elapsed` — should use default 10s (backward compatible)

Closes #1623

🤖 Generated with [Claude Code](https://claude.com/claude-code)