### PR TITLE
Simplify idle detection to use 'esc to interrupt' status bar text

### DIFF
--- a/defaults/scripts/agent-wait-bg.sh
+++ b/defaults/scripts/agent-wait-bg.sh
@@ -89,7 +89,9 @@ STUCK_ACTION=${LOOM_STUCK_ACTION:-warn}              # warn, pause, restart, ret
 PROMPT_STUCK_THRESHOLD=${LOOM_PROMPT_STUCK_THRESHOLD:-30}  # 30 seconds default
 
 # Pattern for detecting Claude is processing a command (shared with agent-spawn.sh)
-PROCESSING_INDICATORS='⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏|Beaming|Loading|● |✓ |◐|◓|◑|◒|thinking|streaming|Wandering'
+# Claude Code shows "esc to interrupt" in the status bar whenever it is working
+# (thinking, running tools, streaming). This text is absent when idle at prompt.
+PROCESSING_INDICATORS='esc to interrupt'
 
 # Progress tracking file prefix
 PROGRESS_DIR="/tmp/loom-agent-progress"

--- a/defaults/scripts/agent-wait.sh
+++ b/defaults/scripts/agent-wait.sh
@@ -150,7 +150,9 @@ check_exit_command() {
 }
 
 # Pattern for detecting Claude is actively processing (shared with agent-wait-bg.sh)
-PROCESSING_INDICATORS='⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏|Beaming|Loading|● |✓ |◐|◓|◑|◒|thinking|streaming|Wandering'
+# Claude Code shows "esc to interrupt" in the status bar whenever it is working
+# (thinking, running tools, streaming). This text is absent when idle at prompt.
+PROCESSING_INDICATORS='esc to interrupt'
 
 # Check if Claude is sitting at an idle prompt (task completed, waiting for input).
 # This detects the case where a support role has finished its work but the Claude


### PR DESCRIPTION
## Summary

- Replace brittle enumeration of Claude Code spinner characters and busy words (`Beaming|Loading|Wandering|...`) with a single reliable signal: `esc to interrupt`
- Claude Code always shows this text in the status bar while actively working (thinking, running tools, streaming) and removes it when idle at prompt
- Fixes false positive idle detection that killed a builder mid-research because `Zigzagging…` wasn't in the enumerated word list

## Context

Issue #1616 reported builders going idle without engaging. Investigation of the builder logs showed:
1. The builder was actively exploring code (reading files, running Explore agents)
2. Claude Code displayed `Zigzagging…` as its busy word — not in the `PROCESSING_INDICATORS` list
3. The idle detector didn't recognize the activity, saw the `❯` prompt between tool calls, and terminated the session after 126s

The old approach required maintaining an ever-growing list of specific busy words. The new approach uses a single stable UI element that's always present during active work.

## Test plan

- [x] Verified `esc to interrupt` matches active Claude Code status bar text
- [x] Verified it does NOT match idle prompt state (`❯`, separator lines, `bypass permissions` without suffix)
- [x] Confirmed hardlinked `.loom/scripts/` copies are also updated

Closes #1616

🤖 Generated with [Claude Code](https://claude.com/claude-code)