### PR TITLE
Add agent_monitor module to loom-tools (agent-wait-bg.sh migration)

### DIFF
--- a/loom-tools/.gitignore
+++ b/loom-tools/.gitignore
@@ -1,0 +1,30 @@
+# Virtual environment
+.venv/
+venv/
+env/
+
+# Python cache
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+
+# Distribution / packaging
+dist/
+build/
+*.egg-info/
+*.egg
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# pytest
+.pytest_cache/
+.coverage
+htmlcov/
+
+# mypy
+.mypy_cache/

--- a/loom-tools/pyproject.toml
+++ b/loom-tools/pyproject.toml
@@ -9,6 +9,9 @@ description = "Shared Python utilities for Loom orchestration scripts"
 requires-python = ">=3.10"
 license = "MIT"
 
+[project.scripts]
+loom-agent-monitor = "loom_tools.agent_monitor:main"
+
 [tool.setuptools.packages.find]
 where = ["src"]
 

--- a/loom-tools/src/loom_tools/__init__.py
+++ b/loom-tools/src/loom_tools/__init__.py
@@ -1,3 +1,7 @@
 """Shared Python utilities for Loom orchestration scripts."""
 
 __version__ = "0.1.0"
+
+from loom_tools.agent_monitor import AgentMonitor, monitor_agent
+
+__all__ = ["AgentMonitor", "monitor_agent", "__version__"]

--- a/loom-tools/src/loom_tools/agent_monitor.py
+++ b/loom-tools/src/loom_tools/agent_monitor.py
@@ -1,0 +1,918 @@
+"""Agent monitoring with stuck detection and signal handling.
+
+This module provides async monitoring of Claude Code agents in tmux sessions,
+detecting completion, handling shutdown signals, and implementing stuck detection.
+
+Replaces the shell script agent-wait-bg.sh with full feature parity.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import pathlib
+import re
+import subprocess
+import time
+from dataclasses import dataclass, field
+
+from loom_tools.common.logging import log_info, log_success, log_warning
+from loom_tools.common.repo import find_repo_root
+from loom_tools.models.agent_wait import (
+    CompletionReason,
+    ContractCheckResult,
+    MonitorConfig,
+    SignalType,
+    StuckAction,
+    WaitResult,
+    WaitStatus,
+)
+
+# tmux configuration (must match agent-spawn.sh)
+TMUX_SOCKET = "loom"
+SESSION_PREFIX = "loom-"
+
+# Pattern for detecting Claude is processing (from agent-wait-bg.sh)
+PROCESSING_INDICATORS = "esc to interrupt"
+
+# Progress tracking directory
+PROGRESS_DIR = pathlib.Path("/tmp/loom-agent-progress")
+
+
+@dataclass
+class ProgressTracker:
+    """Tracks agent progress via tmux pane content hashing."""
+
+    name: str
+    last_hash: str = ""
+    last_progress_time: float = field(default_factory=time.time)
+
+    def check_progress(self, session_name: str) -> bool:
+        """Check if pane content has changed. Returns True if progress detected."""
+        content = capture_pane(session_name)
+        if not content:
+            return False
+
+        current_hash = hashlib.md5(content.encode()).hexdigest()
+        if current_hash != self.last_hash:
+            self.last_hash = current_hash
+            self.last_progress_time = time.time()
+            return True
+        return False
+
+    def get_idle_time(self) -> int:
+        """Get seconds since last progress."""
+        return int(time.time() - self.last_progress_time)
+
+
+def capture_pane(session_name: str) -> str:
+    """Capture current tmux pane content."""
+    try:
+        result = subprocess.run(
+            ["tmux", "-L", TMUX_SOCKET, "capture-pane", "-t", session_name, "-p"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return result.stdout if result.returncode == 0 else ""
+    except Exception:
+        return ""
+
+
+def send_keys(session_name: str, keys: str) -> bool:
+    """Send keys to tmux session."""
+    try:
+        subprocess.run(
+            ["tmux", "-L", TMUX_SOCKET, "send-keys", "-t", session_name, keys],
+            check=True,
+            capture_output=True,
+        )
+        return True
+    except Exception:
+        return False
+
+
+def kill_session(session_name: str) -> bool:
+    """Kill a tmux session."""
+    try:
+        subprocess.run(
+            ["tmux", "-L", TMUX_SOCKET, "kill-session", "-t", session_name],
+            check=False,
+            capture_output=True,
+        )
+        return True
+    except Exception:
+        return False
+
+
+def session_exists(session_name: str) -> bool:
+    """Check if tmux session exists."""
+    try:
+        result = subprocess.run(
+            ["tmux", "-L", TMUX_SOCKET, "has-session", "-t", session_name],
+            capture_output=True,
+            check=False,
+        )
+        return result.returncode == 0
+    except Exception:
+        return False
+
+
+class AgentMonitor:
+    """Monitors a Claude Code agent in a tmux session.
+
+    Provides completion detection, stuck detection, and signal handling
+    for autonomous agent orchestration.
+    """
+
+    def __init__(self, config: MonitorConfig) -> None:
+        self.config = config
+        self.session_name = f"{SESSION_PREFIX}{config.name}"
+        self.repo_root = find_repo_root()
+        self.log_file = self.repo_root / ".loom" / "logs" / f"{self.session_name}.log"
+
+        self.progress_tracker = ProgressTracker(name=config.name)
+        self.start_time = time.time()
+
+        # State tracking
+        self._completion_detected = False
+        self._completion_reason: CompletionReason | None = None
+        self._idle_contract_checked = False
+        self._last_contract_check = 0.0
+        self._stuck_warned = False
+        self._stuck_critical_reported = False
+        self._prompt_stuck_checked = False
+        self._prompt_stuck_recovery_attempted = False
+        self._prompt_resolved = False
+        self._last_heartbeat_time = self.start_time
+
+    @property
+    def elapsed(self) -> int:
+        """Seconds elapsed since monitoring started."""
+        return int(time.time() - self.start_time)
+
+    async def monitor(self) -> WaitResult:
+        """Main monitoring loop. Returns when agent completes or a signal is detected."""
+        log_info(
+            f"Monitoring agent '{self.config.name}' "
+            f"(poll: {self.config.poll_interval}s, timeout: {self.config.timeout}s)"
+        )
+
+        if self.config.task_id:
+            log_info(
+                f"Heartbeat emission: every {self.config.heartbeat_interval}s "
+                f"(task-id: {self.config.task_id})"
+            )
+
+        if self.config.phase and self.config.contract_interval > 0:
+            log_info(
+                f"Proactive contract checking: every {self.config.contract_interval}s "
+                f"for phase '{self.config.phase}'"
+            )
+
+        sc = self.config.stuck_config
+        log_info(
+            f"Stuck detection: warning={sc.warning_threshold}s, "
+            f"critical={sc.critical_threshold}s, action={sc.action.value}"
+        )
+        log_info(f"Prompt stuck detection: threshold={sc.prompt_stuck_threshold}s")
+
+        while True:
+            # Check timeout
+            if self.elapsed >= self.config.timeout:
+                return WaitResult(
+                    status=WaitStatus.TIMEOUT,
+                    name=self.config.name,
+                    elapsed=self.elapsed,
+                )
+
+            # Check if session still exists
+            if not session_exists(self.session_name):
+                return WaitResult(
+                    status=WaitStatus.SESSION_NOT_FOUND,
+                    name=self.config.name,
+                    elapsed=self.elapsed,
+                )
+
+            # Check for interactive prompts (plan mode approval)
+            if not self._prompt_resolved:
+                if self._check_and_resolve_prompts():
+                    self._prompt_resolved = True
+
+            # Check for shutdown signals
+            signal = await self._check_signals()
+            if signal:
+                return WaitResult(
+                    status=WaitStatus.SIGNAL,
+                    name=self.config.name,
+                    elapsed=self.elapsed,
+                    signal_type=signal,
+                )
+
+            # Check shepherd progress file for errored status (fast error detection)
+            if self.config.task_id:
+                if self._check_errored_status():
+                    log_warning(
+                        f"Shepherd errored (progress file status), "
+                        f"terminating session '{self.session_name}'"
+                    )
+                    kill_session(self.session_name)
+                    return WaitResult(
+                        status=WaitStatus.ERRORED,
+                        name=self.config.name,
+                        elapsed=self.elapsed,
+                        error_message="progress_file_errored",
+                    )
+
+            # Fast "stuck at prompt" detection
+            result = self._check_prompt_stuck()
+            if result:
+                return result
+
+            # Proactive phase contract checking
+            if not self._completion_detected:
+                if self._check_proactive_contract():
+                    self._completion_detected = True
+                    self._completion_reason = CompletionReason.PHASE_CONTRACT_SATISFIED
+
+            # Idle-triggered contract checking (backup)
+            if not self._completion_detected:
+                if self._check_idle_contract():
+                    self._completion_detected = True
+                    self._completion_reason = CompletionReason.PHASE_CONTRACT_SATISFIED
+
+            # Reset idle check flag if there's been new activity
+            if self._idle_contract_checked:
+                idle_time = self._get_log_idle_time()
+                if idle_time >= 0 and idle_time < self.config.idle_timeout:
+                    self._idle_contract_checked = False
+
+            # Check completion patterns in log (backup detection)
+            if not self._completion_detected:
+                reason = self._check_completion_patterns()
+                if reason:
+                    if reason == CompletionReason.EXPLICIT_EXIT:
+                        self._completion_detected = True
+                        self._completion_reason = reason
+                    elif self.config.phase and self.config.issue:
+                        # Verify phase contract before trusting pattern
+                        log_info(
+                            f"Completion pattern detected ({reason.value}) - "
+                            "verifying phase contract"
+                        )
+                        await asyncio.sleep(3)
+                        if self._verify_phase_contract():
+                            self._completion_detected = True
+                            self._completion_reason = reason
+                            log_info("Phase contract verified - terminating session")
+                        else:
+                            log_warning(
+                                "Completion pattern detected but phase contract "
+                                "not yet satisfied - continuing to wait"
+                            )
+                    else:
+                        self._completion_detected = True
+                        self._completion_reason = reason
+
+            # Handle completion
+            if self._completion_detected:
+                return await self._handle_completion()
+
+            # Update progress tracking
+            self.progress_tracker.check_progress(self.session_name)
+
+            # Check stuck status
+            stuck_result = self._check_stuck_status()
+            if stuck_result:
+                return stuck_result
+
+            # Emit periodic heartbeat
+            await self._emit_heartbeat()
+
+            await asyncio.sleep(self.config.poll_interval)
+
+    async def _check_signals(self) -> SignalType | None:
+        """Check for shutdown signals. Returns signal type if detected."""
+        # Check global shutdown signal
+        stop_file = self.repo_root / ".loom" / "stop-shepherds"
+        if stop_file.exists():
+            log_warning("Shutdown signal detected (stop-shepherds)")
+            return SignalType.SHUTDOWN
+
+        # Check per-issue abort label
+        if self.config.issue:
+            try:
+                result = subprocess.run(
+                    [
+                        "gh",
+                        "issue",
+                        "view",
+                        str(self.config.issue),
+                        "--json",
+                        "labels",
+                        "--jq",
+                        ".labels[].name",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                if "loom:abort" in result.stdout:
+                    log_warning(f"Abort signal detected for issue #{self.config.issue}")
+                    return SignalType.ABORT
+            except Exception:
+                pass
+
+        return None
+
+    def _check_errored_status(self) -> bool:
+        """Check shepherd progress file for errored status."""
+        if not self.config.task_id:
+            return False
+
+        progress_file = (
+            self.repo_root
+            / ".loom"
+            / "progress"
+            / f"shepherd-{self.config.task_id}.json"
+        )
+        if not progress_file.exists():
+            return False
+
+        try:
+            data = json.loads(progress_file.read_text())
+            return data.get("status") == "errored"
+        except Exception:
+            return False
+
+    def _check_and_resolve_prompts(self) -> bool:
+        """Check for and auto-resolve interactive prompts (e.g., plan mode)."""
+        pane_content = capture_pane(self.session_name)
+        if not pane_content:
+            return False
+
+        # Detect Claude Code plan mode approval prompt
+        if "Would you like to proceed" in pane_content:
+            log_info(
+                f"Plan mode approval prompt detected in {self.session_name} - "
+                "auto-approving"
+            )
+            send_keys(self.session_name, "1")
+            send_keys(self.session_name, "Enter")
+            return True
+
+        return False
+
+    def _check_prompt_stuck(self) -> WaitResult | None:
+        """Fast detection of 'stuck at prompt' state."""
+        sc = self.config.stuck_config
+
+        if self._prompt_stuck_checked and not self._prompt_stuck_recovery_attempted:
+            return None
+        if self._prompt_stuck_recovery_attempted:
+            # Check if now processing
+            pane_content = capture_pane(self.session_name)
+            if pane_content and PROCESSING_INDICATORS in pane_content:
+                self._prompt_stuck_checked = False
+                self._prompt_stuck_recovery_attempted = False
+            return None
+
+        if self.elapsed < sc.prompt_stuck_threshold:
+            return None
+
+        if self._is_stuck_at_prompt():
+            self._prompt_stuck_checked = True
+            log_warning(
+                f"Agent appears stuck at prompt "
+                f"(command visible but not processing after {self.elapsed}s)"
+            )
+
+            self._prompt_stuck_recovery_attempted = True
+            role_cmd = self._extract_role_command()
+
+            if self._attempt_prompt_stuck_recovery(role_cmd):
+                log_success("Agent recovered from stuck-at-prompt state")
+                self._prompt_stuck_checked = False
+            else:
+                log_warning(
+                    "Stuck-at-prompt recovery failed - "
+                    "waiting for general stuck detection"
+                )
+        else:
+            self._prompt_stuck_checked = True
+
+        return None
+
+    def _is_stuck_at_prompt(self) -> bool:
+        """Check if agent is stuck at prompt - command visible but not processing."""
+        pane_content = capture_pane(self.session_name)
+        if not pane_content:
+            return False
+
+        # Check for role slash command visible at the prompt line
+        command_at_prompt = bool(
+            re.search(
+                r"❯\s*/?(builder|judge|curator|doctor|shepherd)", pane_content
+            )
+        )
+
+        # Check for processing indicators
+        processing = PROCESSING_INDICATORS in pane_content
+
+        return command_at_prompt and not processing
+
+    def _extract_role_command(self) -> str:
+        """Extract the likely role command from the session name for retry."""
+        name = self.config.name
+        if name.startswith("builder-issue-"):
+            issue_num = name[len("builder-issue-") :]
+            return f"/builder {issue_num}"
+        return ""
+
+    def _attempt_prompt_stuck_recovery(self, role_cmd: str) -> bool:
+        """Attempt to recover an agent stuck at the prompt."""
+        # Strategy 1: Try an Enter key nudge
+        log_info("Trying Enter key nudge to recover stuck prompt...")
+        send_keys(self.session_name, "Enter")
+        time.sleep(3)
+
+        pane_content = capture_pane(self.session_name)
+        if pane_content and PROCESSING_INDICATORS in pane_content:
+            log_success("Agent recovered with Enter key nudge")
+            return True
+
+        # Strategy 2: Re-send role command if available
+        if role_cmd:
+            log_info(f"Enter nudge failed, re-sending role command: {role_cmd}")
+            time.sleep(2)
+            send_keys(self.session_name, role_cmd)
+            send_keys(self.session_name, "Enter")
+            time.sleep(3)
+
+            pane_content = capture_pane(self.session_name)
+            if pane_content and PROCESSING_INDICATORS in pane_content:
+                log_success("Agent recovered with full command retry")
+                return True
+
+        log_warning("Prompt stuck recovery failed - intervention may be needed")
+        return False
+
+    def _check_proactive_contract(self) -> bool:
+        """Proactive phase contract checking at regular intervals."""
+        if not self.config.phase:
+            return False
+        if self.config.contract_interval <= 0:
+            return False
+
+        now = time.time()
+        since_last = now - self._last_contract_check
+        if since_last < self.config.contract_interval:
+            return False
+
+        self._last_contract_check = now
+        result = self._check_phase_contract(check_only=True)
+        if result.satisfied:
+            log_info(
+                f"Phase contract satisfied ({result.status}) via proactive check"
+            )
+            log_info("Agent completed work but didn't exit - terminating session")
+            return True
+
+        return False
+
+    def _check_idle_contract(self) -> bool:
+        """Check phase contract when agent is idle."""
+        if not self.config.phase:
+            return False
+        if self._idle_contract_checked:
+            return False
+
+        idle_time = self._get_log_idle_time()
+        if idle_time < 0 or idle_time < self.config.idle_timeout:
+            return False
+
+        log_info(
+            f"Agent idle for {idle_time}s (threshold: {self.config.idle_timeout}s) "
+            "- checking phase contract"
+        )
+
+        result = self._check_phase_contract(check_only=True)
+        if result.satisfied:
+            log_info(f"Phase contract satisfied ({result.status}) - terminating session")
+            return True
+
+        self._idle_contract_checked = True
+        log_info("Phase contract not satisfied - continuing to wait")
+        return False
+
+    def _verify_phase_contract(self) -> bool:
+        """Verify phase contract is satisfied."""
+        result = self._check_phase_contract(check_only=True)
+        return result.satisfied
+
+    def _check_phase_contract(self, check_only: bool = False) -> ContractCheckResult:
+        """Check phase contract via validate-phase.sh."""
+        if not self.config.phase or not self.config.issue:
+            return ContractCheckResult(satisfied=False)
+
+        script_path = self.repo_root / ".loom" / "scripts" / "validate-phase.sh"
+        if not script_path.exists():
+            return ContractCheckResult(satisfied=False)
+
+        args = [
+            str(script_path),
+            self.config.phase,
+            str(self.config.issue),
+        ]
+        if self.config.worktree:
+            args.extend(["--worktree", self.config.worktree])
+        if self.config.pr_number:
+            args.extend(["--pr", str(self.config.pr_number)])
+        if check_only:
+            args.append("--check-only")
+        args.append("--json")
+
+        try:
+            result = subprocess.run(
+                args,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                data = json.loads(result.stdout)
+                return ContractCheckResult.from_json(data)
+        except Exception:
+            pass
+
+        return ContractCheckResult(satisfied=False)
+
+    def _get_log_idle_time(self) -> int:
+        """Get seconds since log file was last modified."""
+        if not self.log_file.exists():
+            return -1
+
+        try:
+            mtime = self.log_file.stat().st_mtime
+            return int(time.time() - mtime)
+        except Exception:
+            return -1
+
+    def _check_completion_patterns(self) -> CompletionReason | None:
+        """Check for role-specific completion patterns in log file."""
+        if not self.log_file.exists():
+            return None
+
+        try:
+            # Read last 100 lines
+            with open(self.log_file) as f:
+                lines = f.readlines()
+            recent_log = "".join(lines[-100:])
+        except Exception:
+            return None
+
+        if not recent_log:
+            return None
+
+        # Extract phase from session name
+        phase = self._extract_phase()
+
+        # Generic completion: /exit command
+        if re.search(r"(^|\s+|❯\s*|>\s*)/exit\s*$", recent_log, re.MULTILINE):
+            return CompletionReason.EXPLICIT_EXIT
+
+        # Phase-specific patterns
+        if phase == "builder":
+            if re.search(r"https://github\.com/.*/pull/[0-9]+", recent_log):
+                return CompletionReason.BUILDER_PR_CREATED
+        elif phase == "judge":
+            if re.search(
+                r'add-label.*loom:pr|add-label.*loom:changes-requested|'
+                r'--add-label "loom:pr"|--add-label "loom:changes-requested"',
+                recent_log,
+            ):
+                return CompletionReason.JUDGE_REVIEW_COMPLETE
+        elif phase == "doctor":
+            if re.search(
+                r"remove-label.*loom:treating.*add-label.*loom:review-requested|"
+                r"remove-label.*loom:changes-requested.*add-label.*loom:review-requested",
+                recent_log,
+            ):
+                return CompletionReason.DOCTOR_FIXES_COMPLETE
+        elif phase == "curator":
+            if re.search(
+                r'add-label.*loom:curated|--add-label "loom:curated"', recent_log
+            ):
+                return CompletionReason.CURATOR_CURATION_COMPLETE
+        else:
+            # Unknown phase - check all patterns as fallback
+            if re.search(r"https://github\.com/.*/pull/[0-9]+", recent_log):
+                return CompletionReason.BUILDER_PR_CREATED
+            if re.search(
+                r'add-label.*loom:pr|add-label.*loom:changes-requested|'
+                r'--add-label "loom:pr"|--add-label "loom:changes-requested"',
+                recent_log,
+            ):
+                return CompletionReason.JUDGE_REVIEW_COMPLETE
+            if re.search(
+                r'add-label.*loom:curated|--add-label "loom:curated"', recent_log
+            ):
+                return CompletionReason.CURATOR_CURATION_COMPLETE
+
+        return None
+
+    def _extract_phase(self) -> str:
+        """Extract phase from session name."""
+        if self.config.phase:
+            return self.config.phase
+
+        base_name = self.config.name
+        for phase in ("builder", "judge", "curator", "doctor", "shepherd"):
+            if base_name.startswith(phase):
+                return phase
+        return ""
+
+    async def _handle_completion(self) -> WaitResult:
+        """Handle detected completion."""
+        reason = self._completion_reason or CompletionReason.PHASE_CONTRACT_SATISFIED
+
+        if reason == CompletionReason.EXPLICIT_EXIT:
+            log_info(
+                f"/exit detected in output - sending /exit to prompt "
+                f"and terminating '{self.session_name}'"
+            )
+            send_keys(self.session_name, "/exit")
+            send_keys(self.session_name, "Enter")
+            await asyncio.sleep(1)
+
+        # Clean up
+        self._cleanup_progress_files()
+        kill_session(self.session_name)
+
+        log_success(f"Agent '{self.config.name}' completed ({reason.value} after {self.elapsed}s)")
+
+        return WaitResult(
+            status=WaitStatus.COMPLETED,
+            name=self.config.name,
+            elapsed=self.elapsed,
+            reason=reason,
+        )
+
+    def _check_stuck_status(self) -> WaitResult | None:
+        """Check for stuck agent status."""
+        sc = self.config.stuck_config
+        idle_time = self.progress_tracker.get_idle_time()
+
+        if idle_time > sc.critical_threshold and not self._stuck_critical_reported:
+            self._stuck_critical_reported = True
+            return self._handle_stuck("CRITICAL", idle_time)
+
+        if (
+            idle_time > sc.warning_threshold
+            and not self._stuck_warned
+            and not self._stuck_critical_reported
+        ):
+            self._stuck_warned = True
+            if sc.action == StuckAction.WARN:
+                log_warning(
+                    f"WARNING: Agent '{self.config.name}' may be stuck "
+                    f"(no progress for {idle_time}s)"
+                )
+            else:
+                log_warning(
+                    f"Agent '{self.config.name}' showing signs of being stuck "
+                    f"(no progress for {idle_time}s)"
+                )
+
+        return None
+
+    def _handle_stuck(self, status: str, idle_time: int) -> WaitResult | None:
+        """Handle stuck agent based on configured action."""
+        sc = self.config.stuck_config
+
+        if sc.action == StuckAction.WARN:
+            log_warning(
+                f"CRITICAL: Agent '{self.config.name}' appears stuck "
+                f"(no progress for {idle_time}s)"
+            )
+            return None
+
+        if sc.action == StuckAction.PAUSE:
+            log_warning(
+                f"PAUSE: Pausing stuck agent '{self.config.name}' "
+                f"(no progress for {idle_time}s)"
+            )
+            # Signal the agent to pause via .loom/signals
+            signal_dir = self.repo_root / ".loom" / "signals"
+            signal_dir.mkdir(parents=True, exist_ok=True)
+            signal_file = signal_dir / f"pause-{self.config.name}"
+            signal_file.write_text(
+                f"{time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())} - "
+                f"Auto-paused: stuck detection (idle {idle_time}s)\n"
+            )
+            self._cleanup_progress_files()
+            return WaitResult(
+                status=WaitStatus.STUCK,
+                name=self.config.name,
+                elapsed=self.elapsed,
+                stuck_status=status,
+                stuck_action="paused",
+                idle_time=idle_time,
+            )
+
+        if sc.action in (StuckAction.RESTART, StuckAction.RETRY):
+            action_name = "RESTART" if sc.action == StuckAction.RESTART else "RETRY"
+            log_warning(
+                f"{action_name}: Killing stuck agent '{self.config.name}' "
+                f"(no progress for {idle_time}s)"
+            )
+            self._capture_stuck_diagnostics(idle_time)
+            kill_session(self.session_name)
+            self._cleanup_progress_files()
+            return WaitResult(
+                status=WaitStatus.STUCK,
+                name=self.config.name,
+                elapsed=self.elapsed,
+                stuck_status=status,
+                stuck_action=sc.action.value,
+                idle_time=idle_time,
+            )
+
+        return None
+
+    def _capture_stuck_diagnostics(self, idle_time: int) -> None:
+        """Capture diagnostic information from a stuck agent."""
+        diag_dir = self.repo_root / ".loom" / "diagnostics"
+        diag_dir.mkdir(parents=True, exist_ok=True)
+
+        timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        diag_file = diag_dir / f"stuck-{self.config.name}-{int(time.time())}.txt"
+
+        content = [
+            "=== Stuck Agent Diagnostics ===",
+            f"Agent: {self.config.name}",
+            f"Session: {self.session_name}",
+            f"Timestamp: {timestamp}",
+            f"Idle time: {idle_time}s",
+            "",
+            "=== Tmux Pane Content (last visible) ===",
+            capture_pane(self.session_name) or "(session not available)",
+            "",
+            "=== Log File Tail ===",
+        ]
+
+        if self.log_file.exists():
+            try:
+                with open(self.log_file) as f:
+                    lines = f.readlines()
+                content.append("".join(lines[-50:]))
+            except Exception:
+                content.append("(could not read log)")
+        else:
+            content.append(f"(no log file found at {self.log_file})")
+
+        diag_file.write_text("\n".join(content))
+        log_info(f"Diagnostics captured to {diag_file}")
+
+    def _cleanup_progress_files(self) -> None:
+        """Clean up progress tracking files."""
+        for suffix in ("", ".hash", ".time"):
+            progress_file = PROGRESS_DIR / f"{self.config.name}{suffix}"
+            try:
+                progress_file.unlink(missing_ok=True)
+            except Exception:
+                pass
+
+    async def _emit_heartbeat(self) -> None:
+        """Emit periodic heartbeat to keep shepherd progress file fresh."""
+        if not self.config.task_id:
+            return
+
+        now = time.time()
+        since_last = now - self._last_heartbeat_time
+        if since_last < self.config.heartbeat_interval:
+            return
+
+        self._last_heartbeat_time = now
+
+        script_path = self.repo_root / ".loom" / "scripts" / "report-milestone.sh"
+        if not script_path.exists():
+            return
+
+        elapsed_min = self.elapsed // 60
+        phase_desc = self.config.phase or "agent"
+
+        try:
+            subprocess.run(
+                [
+                    str(script_path),
+                    "heartbeat",
+                    "--task-id",
+                    self.config.task_id,
+                    "--action",
+                    f"{phase_desc} running ({elapsed_min}m elapsed)",
+                    "--quiet",
+                ],
+                capture_output=True,
+                check=False,
+            )
+        except Exception:
+            pass
+
+
+async def monitor_agent(config: MonitorConfig) -> WaitResult:
+    """Monitor an agent and return the result when done."""
+    monitor = AgentMonitor(config)
+    return await monitor.monitor()
+
+
+def main() -> None:
+    """CLI entry point for agent monitoring."""
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(
+        description="Monitor a Claude Code agent in a tmux session"
+    )
+    parser.add_argument("name", help="Agent session name")
+    parser.add_argument(
+        "--timeout", type=int, default=3600, help="Maximum time to wait (default: 3600)"
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=int,
+        default=5,
+        help="Time between signal checks (default: 5)",
+    )
+    parser.add_argument("--issue", type=int, help="Issue number for per-issue abort")
+    parser.add_argument(
+        "--task-id", help="Shepherd task ID for heartbeat emission"
+    )
+    parser.add_argument(
+        "--phase", help="Phase name (curator, builder, judge, doctor)"
+    )
+    parser.add_argument("--worktree", help="Worktree path for builder phase recovery")
+    parser.add_argument("--pr", type=int, help="PR number for judge/doctor validation")
+    parser.add_argument(
+        "--idle-timeout",
+        type=int,
+        default=60,
+        help="Time without output before checking phase contract (default: 60)",
+    )
+    parser.add_argument(
+        "--contract-interval",
+        type=int,
+        default=90,
+        help="Seconds between proactive phase contract checks (default: 90)",
+    )
+    parser.add_argument(
+        "--min-idle-elapsed",
+        type=int,
+        default=10,
+        help="Override idle prompt detection threshold (default: 10)",
+    )
+    parser.add_argument("--json", action="store_true", help="Output result as JSON")
+
+    args = parser.parse_args()
+
+    config = MonitorConfig.from_args(
+        name=args.name,
+        timeout=args.timeout,
+        poll_interval=args.poll_interval,
+        issue=args.issue,
+        task_id=args.task_id,
+        phase=args.phase,
+        worktree=args.worktree,
+        pr_number=args.pr,
+        idle_timeout=args.idle_timeout,
+        contract_interval=args.contract_interval,
+        min_idle_elapsed=args.min_idle_elapsed,
+    )
+
+    result = asyncio.run(monitor_agent(config))
+
+    if args.json:
+        print(json.dumps(result.to_dict()))
+    else:
+        # Exit with appropriate code
+        if result.status == WaitStatus.COMPLETED:
+            log_success(f"Agent completed: {result.reason.value if result.reason else 'unknown'}")
+        elif result.status == WaitStatus.SIGNAL:
+            log_warning(f"Signal detected: {result.signal_type.value if result.signal_type else 'unknown'}")
+
+    # Exit codes matching agent-wait-bg.sh
+    exit_codes = {
+        WaitStatus.COMPLETED: 0,
+        WaitStatus.TIMEOUT: 1,
+        WaitStatus.SESSION_NOT_FOUND: 2,
+        WaitStatus.SIGNAL: 3,
+        WaitStatus.STUCK: 4,
+        WaitStatus.ERRORED: 4,
+    }
+    sys.exit(exit_codes.get(result.status, 1))
+
+
+if __name__ == "__main__":
+    main()

--- a/loom-tools/src/loom_tools/models/__init__.py
+++ b/loom-tools/src/loom_tools/models/__init__.py
@@ -1,0 +1,60 @@
+"""Data models for Loom orchestration state files."""
+
+from loom_tools.models.agent_wait import (
+    CompletionReason,
+    ContractCheckResult,
+    MonitorConfig,
+    SignalType,
+    StuckAction,
+    StuckConfig,
+    WaitResult,
+    WaitStatus,
+)
+from loom_tools.models.daemon_state import (
+    DaemonState,
+    PipelineState,
+    ShepherdEntry,
+    SupportRoleEntry,
+    Warning,
+)
+from loom_tools.models.health import Alert, AlertsFile, HealthMetrics, MetricEntry
+from loom_tools.models.progress import Milestone, ShepherdProgress
+from loom_tools.models.stuck import (
+    StuckDetection,
+    StuckHistory,
+    StuckHistoryEntry,
+    StuckMetrics,
+    StuckThresholds,
+)
+
+__all__ = [
+    # agent_wait
+    "CompletionReason",
+    "ContractCheckResult",
+    "MonitorConfig",
+    "SignalType",
+    "StuckAction",
+    "StuckConfig",
+    "WaitResult",
+    "WaitStatus",
+    # daemon_state
+    "DaemonState",
+    "PipelineState",
+    "ShepherdEntry",
+    "SupportRoleEntry",
+    "Warning",
+    # health
+    "Alert",
+    "AlertsFile",
+    "HealthMetrics",
+    "MetricEntry",
+    # progress
+    "Milestone",
+    "ShepherdProgress",
+    # stuck
+    "StuckDetection",
+    "StuckHistory",
+    "StuckHistoryEntry",
+    "StuckMetrics",
+    "StuckThresholds",
+]

--- a/loom-tools/src/loom_tools/models/agent_wait.py
+++ b/loom-tools/src/loom_tools/models/agent_wait.py
@@ -1,0 +1,182 @@
+"""Models for agent monitoring wait results and completion states."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class WaitStatus(Enum):
+    """Exit status for agent monitoring."""
+
+    COMPLETED = "completed"
+    TIMEOUT = "timeout"
+    SESSION_NOT_FOUND = "session_not_found"
+    SIGNAL = "signal"
+    STUCK = "stuck"
+    ERRORED = "errored"
+
+
+class SignalType(Enum):
+    """Types of shutdown signals detected."""
+
+    SHUTDOWN = "shutdown"
+    ABORT = "abort"
+
+
+class CompletionReason(Enum):
+    """Reasons an agent completed its work."""
+
+    EXPLICIT_EXIT = "explicit_exit"
+    PHASE_CONTRACT_SATISFIED = "phase_contract_satisfied"
+    BUILDER_PR_CREATED = "builder_pr_created"
+    JUDGE_REVIEW_COMPLETE = "judge_review_complete"
+    DOCTOR_FIXES_COMPLETE = "doctor_fixes_complete"
+    CURATOR_CURATION_COMPLETE = "curator_curation_complete"
+
+
+class StuckAction(Enum):
+    """Actions to take when agent is detected as stuck."""
+
+    WARN = "warn"
+    PAUSE = "pause"
+    RESTART = "restart"
+    RETRY = "retry"
+
+
+@dataclass
+class StuckConfig:
+    """Configuration for stuck detection thresholds."""
+
+    warning_threshold: int = 300  # 5 minutes
+    critical_threshold: int = 600  # 10 minutes
+    prompt_stuck_threshold: int = 30  # 30 seconds
+    action: StuckAction = StuckAction.WARN
+
+    @classmethod
+    def from_env(cls) -> StuckConfig:
+        """Load stuck detection config from environment variables."""
+        import os
+
+        action_str = os.environ.get("LOOM_STUCK_ACTION", "warn").lower()
+        try:
+            action = StuckAction(action_str)
+        except ValueError:
+            action = StuckAction.WARN
+
+        return cls(
+            warning_threshold=int(os.environ.get("LOOM_STUCK_WARNING", "300")),
+            critical_threshold=int(os.environ.get("LOOM_STUCK_CRITICAL", "600")),
+            prompt_stuck_threshold=int(
+                os.environ.get("LOOM_PROMPT_STUCK_THRESHOLD", "30")
+            ),
+            action=action,
+        )
+
+
+@dataclass
+class WaitResult:
+    """Result from agent monitoring wait operation."""
+
+    status: WaitStatus
+    name: str
+    elapsed: int = 0
+    reason: CompletionReason | None = None
+    signal_type: SignalType | None = None
+    stuck_status: str | None = None
+    stuck_action: str | None = None
+    idle_time: int | None = None
+    error_message: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to JSON-serializable dict."""
+        d: dict[str, Any] = {
+            "status": self.status.value,
+            "name": self.name,
+            "elapsed": self.elapsed,
+        }
+        if self.reason is not None:
+            d["reason"] = self.reason.value
+        if self.signal_type is not None:
+            d["signal_type"] = self.signal_type.value
+        if self.stuck_status is not None:
+            d["stuck_status"] = self.stuck_status
+        if self.stuck_action is not None:
+            d["action"] = self.stuck_action
+        if self.idle_time is not None:
+            d["idle_time"] = self.idle_time
+        if self.error_message is not None:
+            d["error"] = self.error_message
+        return d
+
+
+@dataclass
+class ContractCheckResult:
+    """Result from phase contract validation."""
+
+    satisfied: bool
+    status: str = "not_satisfied"
+    message: str = ""
+    recovery_action: str = "none"
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> ContractCheckResult:
+        """Parse from validate-phase.sh JSON output."""
+        status = data.get("status", "unknown")
+        return cls(
+            satisfied=status in ("satisfied", "recovered"),
+            status=status,
+            message=data.get("message", ""),
+            recovery_action=data.get("recovery_action", "none"),
+        )
+
+
+@dataclass
+class MonitorConfig:
+    """Configuration for agent monitoring."""
+
+    name: str
+    timeout: int = 3600
+    poll_interval: int = 5
+    issue: int | None = None
+    task_id: str | None = None
+    phase: str | None = None
+    worktree: str | None = None
+    pr_number: int | None = None
+    idle_timeout: int = 60
+    contract_interval: int = 90
+    min_idle_elapsed: int = 10
+    heartbeat_interval: int = 60
+    stuck_config: StuckConfig = field(default_factory=StuckConfig)
+
+    @classmethod
+    def from_args(
+        cls,
+        name: str,
+        timeout: int = 3600,
+        poll_interval: int = 5,
+        issue: int | None = None,
+        task_id: str | None = None,
+        phase: str | None = None,
+        worktree: str | None = None,
+        pr_number: int | None = None,
+        idle_timeout: int = 60,
+        contract_interval: int = 90,
+        min_idle_elapsed: int = 10,
+    ) -> MonitorConfig:
+        """Create config from CLI arguments."""
+        return cls(
+            name=name,
+            timeout=timeout,
+            poll_interval=poll_interval,
+            issue=issue,
+            task_id=task_id,
+            phase=phase,
+            worktree=worktree,
+            pr_number=pr_number,
+            idle_timeout=idle_timeout,
+            contract_interval=contract_interval,
+            min_idle_elapsed=min_idle_elapsed,
+            stuck_config=StuckConfig.from_env(),
+        )

--- a/loom-tools/tests/fixtures/stuck-history.json
+++ b/loom-tools/tests/fixtures/stuck-history.json
@@ -10,10 +10,7 @@
         "stuck": true,
         "severity": "elevated",
         "suggested_intervention": "clarify",
-        "indicators": [
-          "no_progress:759s",
-          "error_spike:59"
-        ],
+        "indicators": ["no_progress:759s", "error_spike:59"],
         "metrics": {
           "idle_seconds": 759,
           "working_seconds": -27972,
@@ -38,9 +35,7 @@
         "stuck": true,
         "severity": "elevated",
         "suggested_intervention": "clarify",
-        "indicators": [
-          "error_spike:26"
-        ],
+        "indicators": ["error_spike:26"],
         "metrics": {
           "idle_seconds": 365,
           "working_seconds": -28392,

--- a/loom-tools/tests/test_agent_monitor.py
+++ b/loom-tools/tests/test_agent_monitor.py
@@ -1,0 +1,475 @@
+"""Tests for agent_monitor module."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import pathlib
+import tempfile
+from unittest import mock
+
+import pytest
+
+from loom_tools.agent_monitor import (
+    AgentMonitor,
+    ProgressTracker,
+    capture_pane,
+    kill_session,
+    monitor_agent,
+    send_keys,
+    session_exists,
+)
+from loom_tools.models.agent_wait import (
+    CompletionReason,
+    MonitorConfig,
+    SignalType,
+    StuckAction,
+    StuckConfig,
+    WaitResult,
+    WaitStatus,
+)
+
+
+class TestProgressTracker:
+    def test_initial_state(self) -> None:
+        tracker = ProgressTracker(name="test-agent")
+        assert tracker.name == "test-agent"
+        assert tracker.last_hash == ""
+        assert tracker.last_progress_time > 0
+
+    def test_get_idle_time(self) -> None:
+        tracker = ProgressTracker(name="test-agent")
+        # Initial idle time should be very small (just created)
+        assert tracker.get_idle_time() < 2
+
+    def test_check_progress_no_content(self) -> None:
+        tracker = ProgressTracker(name="test-agent")
+        with mock.patch("loom_tools.agent_monitor.capture_pane", return_value=""):
+            result = tracker.check_progress("loom-test-agent")
+        assert result is False
+
+    def test_check_progress_content_changed(self) -> None:
+        tracker = ProgressTracker(name="test-agent")
+        tracker.last_hash = "old_hash"
+
+        with mock.patch("loom_tools.agent_monitor.capture_pane", return_value="new content"):
+            result = tracker.check_progress("loom-test-agent")
+        assert result is True
+        assert tracker.last_hash != "old_hash"
+
+    def test_check_progress_content_unchanged(self) -> None:
+        tracker = ProgressTracker(name="test-agent")
+        content = "unchanged content"
+        import hashlib
+        expected_hash = hashlib.md5(content.encode()).hexdigest()
+        tracker.last_hash = expected_hash
+
+        with mock.patch("loom_tools.agent_monitor.capture_pane", return_value=content):
+            result = tracker.check_progress("loom-test-agent")
+        assert result is False
+
+
+class TestTmuxHelpers:
+    def test_capture_pane_subprocess_error(self) -> None:
+        with mock.patch("subprocess.run", side_effect=Exception("tmux not found")):
+            result = capture_pane("test-session")
+        assert result == ""
+
+    def test_capture_pane_success(self) -> None:
+        mock_result = mock.Mock()
+        mock_result.returncode = 0
+        mock_result.stdout = "pane content"
+        with mock.patch("subprocess.run", return_value=mock_result):
+            result = capture_pane("test-session")
+        assert result == "pane content"
+
+    def test_send_keys_success(self) -> None:
+        with mock.patch("subprocess.run") as mock_run:
+            result = send_keys("test-session", "hello")
+        assert result is True
+        mock_run.assert_called_once()
+
+    def test_send_keys_failure(self) -> None:
+        with mock.patch("subprocess.run", side_effect=Exception("failed")):
+            result = send_keys("test-session", "hello")
+        assert result is False
+
+    def test_kill_session_success(self) -> None:
+        with mock.patch("subprocess.run") as mock_run:
+            result = kill_session("test-session")
+        assert result is True
+        mock_run.assert_called_once()
+
+    def test_session_exists_true(self) -> None:
+        mock_result = mock.Mock()
+        mock_result.returncode = 0
+        with mock.patch("subprocess.run", return_value=mock_result):
+            result = session_exists("test-session")
+        assert result is True
+
+    def test_session_exists_false(self) -> None:
+        mock_result = mock.Mock()
+        mock_result.returncode = 1
+        with mock.patch("subprocess.run", return_value=mock_result):
+            result = session_exists("test-session")
+        assert result is False
+
+
+class TestAgentMonitor:
+    @pytest.fixture
+    def temp_repo(self, tmp_path: pathlib.Path) -> pathlib.Path:
+        """Create a temporary repo structure."""
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir()
+        (loom_dir / "logs").mkdir()
+        (loom_dir / "scripts").mkdir()
+        (loom_dir / "progress").mkdir()
+
+        # Create .git directory to make it look like a repo
+        (tmp_path / ".git").mkdir()
+
+        return tmp_path
+
+    @pytest.fixture
+    def basic_config(self) -> MonitorConfig:
+        return MonitorConfig(
+            name="builder-issue-42",
+            timeout=10,
+            poll_interval=1,
+            issue=42,
+            stuck_config=StuckConfig(
+                warning_threshold=5,
+                critical_threshold=10,
+            ),
+        )
+
+    def test_elapsed(self, basic_config: MonitorConfig, temp_repo: pathlib.Path) -> None:
+        with mock.patch("loom_tools.agent_monitor.find_repo_root", return_value=temp_repo):
+            monitor = AgentMonitor(basic_config)
+            assert monitor.elapsed >= 0
+
+    def test_session_name(self, basic_config: MonitorConfig, temp_repo: pathlib.Path) -> None:
+        with mock.patch("loom_tools.agent_monitor.find_repo_root", return_value=temp_repo):
+            monitor = AgentMonitor(basic_config)
+            assert monitor.session_name == "loom-builder-issue-42"
+
+    def test_extract_phase_from_config(self, temp_repo: pathlib.Path) -> None:
+        config = MonitorConfig(name="test", phase="curator")
+        with mock.patch("loom_tools.agent_monitor.find_repo_root", return_value=temp_repo):
+            monitor = AgentMonitor(config)
+            assert monitor._extract_phase() == "curator"
+
+    def test_extract_phase_from_name(self, temp_repo: pathlib.Path) -> None:
+        config = MonitorConfig(name="builder-issue-42")
+        with mock.patch("loom_tools.agent_monitor.find_repo_root", return_value=temp_repo):
+            monitor = AgentMonitor(config)
+            assert monitor._extract_phase() == "builder"
+
+    def test_extract_role_command_builder(self, temp_repo: pathlib.Path) -> None:
+        config = MonitorConfig(name="builder-issue-42")
+        with mock.patch("loom_tools.agent_monitor.find_repo_root", return_value=temp_repo):
+            monitor = AgentMonitor(config)
+            assert monitor._extract_role_command() == "/builder 42"
+
+    def test_extract_role_command_other(self, temp_repo: pathlib.Path) -> None:
+        config = MonitorConfig(name="judge-123")
+        with mock.patch("loom_tools.agent_monitor.find_repo_root", return_value=temp_repo):
+            monitor = AgentMonitor(config)
+            assert monitor._extract_role_command() == ""
+
+    def test_check_errored_status_no_task_id(self, temp_repo: pathlib.Path) -> None:
+        config = MonitorConfig(name="test")
+        with mock.patch("loom_tools.agent_monitor.find_repo_root", return_value=temp_repo):
+            monitor = AgentMonitor(config)
+            assert monitor._check_errored_status() is False
+
+    def test_check_errored_status_file_exists_errored(self, temp_repo: pathlib.Path) -> None:
+        config = MonitorConfig(name="test", task_id="abc123")
+        progress_file = temp_repo / ".loom" / "progress" / "shepherd-abc123.json"
+        progress_file.write_text(json.dumps({"status": "errored"}))
+
+        with mock.patch("loom_tools.agent_monitor.find_repo_root", return_value=temp_repo):
+            monitor = AgentMonitor(config)
+            assert monitor._check_errored_status() is True
+
+    def test_check_errored_status_file_exists_working(self, temp_repo: pathlib.Path) -> None:
+        config = MonitorConfig(name="test", task_id="abc123")
+        progress_file = temp_repo / ".loom" / "progress" / "shepherd-abc123.json"
+        progress_file.write_text(json.dumps({"status": "working"}))
+
+        with mock.patch("loom_tools.agent_monitor.find_repo_root", return_value=temp_repo):
+            monitor = AgentMonitor(config)
+            assert monitor._check_errored_status() is False
+
+
+class TestCompletionPatterns:
+    @pytest.fixture
+    def temp_repo(self, tmp_path: pathlib.Path) -> pathlib.Path:
+        """Create a temporary repo structure with log file."""
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir()
+        (loom_dir / "logs").mkdir()
+        (loom_dir / "scripts").mkdir()
+        (tmp_path / ".git").mkdir()
+        return tmp_path
+
+    def test_explicit_exit_pattern(self, temp_repo: pathlib.Path) -> None:
+        config = MonitorConfig(name="builder-issue-42")
+        log_file = temp_repo / ".loom" / "logs" / "loom-builder-issue-42.log"
+        log_file.write_text("some output\n❯ /exit\nmore output")
+
+        with mock.patch("loom_tools.agent_monitor.find_repo_root", return_value=temp_repo):
+            monitor = AgentMonitor(config)
+            reason = monitor._check_completion_patterns()
+
+        assert reason == CompletionReason.EXPLICIT_EXIT
+
+    def test_builder_pr_created_pattern(self, temp_repo: pathlib.Path) -> None:
+        config = MonitorConfig(name="builder-issue-42", phase="builder")
+        log_file = temp_repo / ".loom" / "logs" / "loom-builder-issue-42.log"
+        log_file.write_text("PR created: https://github.com/owner/repo/pull/123\n")
+
+        with mock.patch("loom_tools.agent_monitor.find_repo_root", return_value=temp_repo):
+            monitor = AgentMonitor(config)
+            reason = monitor._check_completion_patterns()
+
+        assert reason == CompletionReason.BUILDER_PR_CREATED
+
+    def test_judge_review_complete_pattern(self, temp_repo: pathlib.Path) -> None:
+        config = MonitorConfig(name="judge-pr-100", phase="judge")
+        log_file = temp_repo / ".loom" / "logs" / "loom-judge-pr-100.log"
+        log_file.write_text('gh pr edit 100 --add-label "loom:pr"\n')
+
+        with mock.patch("loom_tools.agent_monitor.find_repo_root", return_value=temp_repo):
+            monitor = AgentMonitor(config)
+            reason = monitor._check_completion_patterns()
+
+        assert reason == CompletionReason.JUDGE_REVIEW_COMPLETE
+
+    def test_curator_complete_pattern(self, temp_repo: pathlib.Path) -> None:
+        config = MonitorConfig(name="curator-issue-50", phase="curator")
+        log_file = temp_repo / ".loom" / "logs" / "loom-curator-issue-50.log"
+        log_file.write_text('gh issue edit 50 --add-label "loom:curated"\n')
+
+        with mock.patch("loom_tools.agent_monitor.find_repo_root", return_value=temp_repo):
+            monitor = AgentMonitor(config)
+            reason = monitor._check_completion_patterns()
+
+        assert reason == CompletionReason.CURATOR_CURATION_COMPLETE
+
+    def test_no_completion_pattern(self, temp_repo: pathlib.Path) -> None:
+        config = MonitorConfig(name="builder-issue-42", phase="builder")
+        log_file = temp_repo / ".loom" / "logs" / "loom-builder-issue-42.log"
+        log_file.write_text("Still working on implementation...\n")
+
+        with mock.patch("loom_tools.agent_monitor.find_repo_root", return_value=temp_repo):
+            monitor = AgentMonitor(config)
+            reason = monitor._check_completion_patterns()
+
+        assert reason is None
+
+    def test_no_log_file(self, temp_repo: pathlib.Path) -> None:
+        config = MonitorConfig(name="builder-issue-42")
+
+        with mock.patch("loom_tools.agent_monitor.find_repo_root", return_value=temp_repo):
+            monitor = AgentMonitor(config)
+            reason = monitor._check_completion_patterns()
+
+        assert reason is None
+
+
+class TestStuckDetection:
+    @pytest.fixture
+    def temp_repo(self, tmp_path: pathlib.Path) -> pathlib.Path:
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir()
+        (loom_dir / "logs").mkdir()
+        (loom_dir / "scripts").mkdir()
+        (loom_dir / "signals").mkdir()
+        (loom_dir / "diagnostics").mkdir()
+        (tmp_path / ".git").mkdir()
+        return tmp_path
+
+    def test_check_stuck_status_not_stuck(self, temp_repo: pathlib.Path) -> None:
+        config = MonitorConfig(
+            name="test-agent",
+            stuck_config=StuckConfig(warning_threshold=300, critical_threshold=600),
+        )
+        with mock.patch("loom_tools.agent_monitor.find_repo_root", return_value=temp_repo):
+            monitor = AgentMonitor(config)
+            # Progress tracker just initialized, so idle time is ~0
+            result = monitor._check_stuck_status()
+
+        assert result is None
+
+    def test_handle_stuck_warn_action(self, temp_repo: pathlib.Path) -> None:
+        config = MonitorConfig(
+            name="test-agent",
+            stuck_config=StuckConfig(action=StuckAction.WARN),
+        )
+        with mock.patch("loom_tools.agent_monitor.find_repo_root", return_value=temp_repo):
+            monitor = AgentMonitor(config)
+            result = monitor._handle_stuck("CRITICAL", 600)
+
+        # WARN action should not return a result (continue waiting)
+        assert result is None
+
+    def test_handle_stuck_pause_action(self, temp_repo: pathlib.Path) -> None:
+        config = MonitorConfig(
+            name="test-agent",
+            stuck_config=StuckConfig(action=StuckAction.PAUSE),
+        )
+        with mock.patch("loom_tools.agent_monitor.find_repo_root", return_value=temp_repo):
+            monitor = AgentMonitor(config)
+            result = monitor._handle_stuck("CRITICAL", 600)
+
+        assert result is not None
+        assert result.status == WaitStatus.STUCK
+        assert result.stuck_action == "paused"
+
+        # Check signal file was created
+        signal_file = temp_repo / ".loom" / "signals" / "pause-test-agent"
+        assert signal_file.exists()
+
+    def test_handle_stuck_restart_action(self, temp_repo: pathlib.Path) -> None:
+        config = MonitorConfig(
+            name="test-agent",
+            stuck_config=StuckConfig(action=StuckAction.RESTART),
+        )
+        with mock.patch("loom_tools.agent_monitor.find_repo_root", return_value=temp_repo):
+            with mock.patch("loom_tools.agent_monitor.kill_session") as mock_kill:
+                with mock.patch("loom_tools.agent_monitor.capture_pane", return_value="test content"):
+                    monitor = AgentMonitor(config)
+                    result = monitor._handle_stuck("CRITICAL", 600)
+
+        assert result is not None
+        assert result.status == WaitStatus.STUCK
+        assert result.stuck_action == "restart"
+        mock_kill.assert_called_once()
+
+
+class TestSignalChecking:
+    @pytest.fixture
+    def temp_repo(self, tmp_path: pathlib.Path) -> pathlib.Path:
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir()
+        (loom_dir / "logs").mkdir()
+        (loom_dir / "scripts").mkdir()
+        (tmp_path / ".git").mkdir()
+        return tmp_path
+
+    @pytest.mark.asyncio
+    async def test_check_signals_none(self, temp_repo: pathlib.Path) -> None:
+        config = MonitorConfig(name="test-agent")
+        with mock.patch("loom_tools.agent_monitor.find_repo_root", return_value=temp_repo):
+            monitor = AgentMonitor(config)
+            signal = await monitor._check_signals()
+
+        assert signal is None
+
+    @pytest.mark.asyncio
+    async def test_check_signals_shutdown(self, temp_repo: pathlib.Path) -> None:
+        config = MonitorConfig(name="test-agent")
+        stop_file = temp_repo / ".loom" / "stop-shepherds"
+        stop_file.touch()
+
+        with mock.patch("loom_tools.agent_monitor.find_repo_root", return_value=temp_repo):
+            monitor = AgentMonitor(config)
+            signal = await monitor._check_signals()
+
+        assert signal == SignalType.SHUTDOWN
+
+    @pytest.mark.asyncio
+    async def test_check_signals_abort(self, temp_repo: pathlib.Path) -> None:
+        config = MonitorConfig(name="test-agent", issue=42)
+
+        mock_result = mock.Mock()
+        mock_result.stdout = "loom:abort\nloom:building\n"
+
+        with mock.patch("loom_tools.agent_monitor.find_repo_root", return_value=temp_repo):
+            with mock.patch("subprocess.run", return_value=mock_result):
+                monitor = AgentMonitor(config)
+                signal = await monitor._check_signals()
+
+        assert signal == SignalType.ABORT
+
+
+class TestPromptResolution:
+    @pytest.fixture
+    def temp_repo(self, tmp_path: pathlib.Path) -> pathlib.Path:
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir()
+        (loom_dir / "logs").mkdir()
+        (tmp_path / ".git").mkdir()
+        return tmp_path
+
+    def test_check_and_resolve_prompts_no_prompt(self, temp_repo: pathlib.Path) -> None:
+        config = MonitorConfig(name="test-agent")
+        with mock.patch("loom_tools.agent_monitor.find_repo_root", return_value=temp_repo):
+            with mock.patch("loom_tools.agent_monitor.capture_pane", return_value="normal output"):
+                monitor = AgentMonitor(config)
+                result = monitor._check_and_resolve_prompts()
+
+        assert result is False
+
+    def test_check_and_resolve_prompts_plan_mode(self, temp_repo: pathlib.Path) -> None:
+        config = MonitorConfig(name="test-agent")
+        pane_content = """
+Would you like to proceed?
+1. Yes, clear context and bypass permissions
+2. Yes, and bypass permissions
+        """
+        with mock.patch("loom_tools.agent_monitor.find_repo_root", return_value=temp_repo):
+            with mock.patch("loom_tools.agent_monitor.capture_pane", return_value=pane_content):
+                with mock.patch("loom_tools.agent_monitor.send_keys") as mock_send:
+                    monitor = AgentMonitor(config)
+                    result = monitor._check_and_resolve_prompts()
+
+        assert result is True
+        # Should send "1" and then Enter
+        assert mock_send.call_count == 2
+
+
+class TestStuckAtPrompt:
+    @pytest.fixture
+    def temp_repo(self, tmp_path: pathlib.Path) -> pathlib.Path:
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir()
+        (loom_dir / "logs").mkdir()
+        (tmp_path / ".git").mkdir()
+        return tmp_path
+
+    def test_is_stuck_at_prompt_not_stuck(self, temp_repo: pathlib.Path) -> None:
+        config = MonitorConfig(name="builder-issue-42")
+        pane_content = "Working on implementation...\nesc to interrupt"
+
+        with mock.patch("loom_tools.agent_monitor.find_repo_root", return_value=temp_repo):
+            with mock.patch("loom_tools.agent_monitor.capture_pane", return_value=pane_content):
+                monitor = AgentMonitor(config)
+                result = monitor._is_stuck_at_prompt()
+
+        assert result is False
+
+    def test_is_stuck_at_prompt_command_processing(self, temp_repo: pathlib.Path) -> None:
+        config = MonitorConfig(name="builder-issue-42")
+        pane_content = "❯ /builder 42\nesc to interrupt"
+
+        with mock.patch("loom_tools.agent_monitor.find_repo_root", return_value=temp_repo):
+            with mock.patch("loom_tools.agent_monitor.capture_pane", return_value=pane_content):
+                monitor = AgentMonitor(config)
+                result = monitor._is_stuck_at_prompt()
+
+        # Not stuck because processing indicators are present
+        assert result is False
+
+    def test_is_stuck_at_prompt_stuck(self, temp_repo: pathlib.Path) -> None:
+        config = MonitorConfig(name="builder-issue-42")
+        pane_content = "❯ /builder 42\nWaiting..."
+
+        with mock.patch("loom_tools.agent_monitor.find_repo_root", return_value=temp_repo):
+            with mock.patch("loom_tools.agent_monitor.capture_pane", return_value=pane_content):
+                monitor = AgentMonitor(config)
+                result = monitor._is_stuck_at_prompt()
+
+        # Stuck: command visible but no processing indicators
+        assert result is True

--- a/loom-tools/tests/test_agent_wait.py
+++ b/loom-tools/tests/test_agent_wait.py
@@ -1,0 +1,247 @@
+"""Tests for agent_wait models."""
+
+from __future__ import annotations
+
+import os
+from unittest import mock
+
+import pytest
+
+from loom_tools.models.agent_wait import (
+    CompletionReason,
+    ContractCheckResult,
+    MonitorConfig,
+    SignalType,
+    StuckAction,
+    StuckConfig,
+    WaitResult,
+    WaitStatus,
+)
+
+
+class TestWaitStatus:
+    def test_enum_values(self) -> None:
+        assert WaitStatus.COMPLETED.value == "completed"
+        assert WaitStatus.TIMEOUT.value == "timeout"
+        assert WaitStatus.SESSION_NOT_FOUND.value == "session_not_found"
+        assert WaitStatus.SIGNAL.value == "signal"
+        assert WaitStatus.STUCK.value == "stuck"
+        assert WaitStatus.ERRORED.value == "errored"
+
+
+class TestSignalType:
+    def test_enum_values(self) -> None:
+        assert SignalType.SHUTDOWN.value == "shutdown"
+        assert SignalType.ABORT.value == "abort"
+
+
+class TestCompletionReason:
+    def test_enum_values(self) -> None:
+        assert CompletionReason.EXPLICIT_EXIT.value == "explicit_exit"
+        assert CompletionReason.PHASE_CONTRACT_SATISFIED.value == "phase_contract_satisfied"
+        assert CompletionReason.BUILDER_PR_CREATED.value == "builder_pr_created"
+        assert CompletionReason.JUDGE_REVIEW_COMPLETE.value == "judge_review_complete"
+        assert CompletionReason.DOCTOR_FIXES_COMPLETE.value == "doctor_fixes_complete"
+        assert CompletionReason.CURATOR_CURATION_COMPLETE.value == "curator_curation_complete"
+
+
+class TestStuckAction:
+    def test_enum_values(self) -> None:
+        assert StuckAction.WARN.value == "warn"
+        assert StuckAction.PAUSE.value == "pause"
+        assert StuckAction.RESTART.value == "restart"
+        assert StuckAction.RETRY.value == "retry"
+
+
+class TestStuckConfig:
+    def test_defaults(self) -> None:
+        config = StuckConfig()
+        assert config.warning_threshold == 300
+        assert config.critical_threshold == 600
+        assert config.prompt_stuck_threshold == 30
+        assert config.action == StuckAction.WARN
+
+    def test_from_env_defaults(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            # Remove our env vars if they exist
+            for key in ["LOOM_STUCK_WARNING", "LOOM_STUCK_CRITICAL", "LOOM_STUCK_ACTION", "LOOM_PROMPT_STUCK_THRESHOLD"]:
+                os.environ.pop(key, None)
+            config = StuckConfig.from_env()
+        assert config.warning_threshold == 300
+        assert config.critical_threshold == 600
+        assert config.action == StuckAction.WARN
+
+    def test_from_env_custom(self) -> None:
+        with mock.patch.dict(os.environ, {
+            "LOOM_STUCK_WARNING": "180",
+            "LOOM_STUCK_CRITICAL": "360",
+            "LOOM_STUCK_ACTION": "pause",
+            "LOOM_PROMPT_STUCK_THRESHOLD": "15",
+        }):
+            config = StuckConfig.from_env()
+        assert config.warning_threshold == 180
+        assert config.critical_threshold == 360
+        assert config.prompt_stuck_threshold == 15
+        assert config.action == StuckAction.PAUSE
+
+    def test_from_env_invalid_action(self) -> None:
+        with mock.patch.dict(os.environ, {"LOOM_STUCK_ACTION": "invalid"}):
+            config = StuckConfig.from_env()
+        assert config.action == StuckAction.WARN  # Falls back to default
+
+
+class TestWaitResult:
+    def test_basic_result(self) -> None:
+        result = WaitResult(
+            status=WaitStatus.COMPLETED,
+            name="builder-issue-42",
+            elapsed=120,
+            reason=CompletionReason.BUILDER_PR_CREATED,
+        )
+        assert result.status == WaitStatus.COMPLETED
+        assert result.name == "builder-issue-42"
+        assert result.elapsed == 120
+        assert result.reason == CompletionReason.BUILDER_PR_CREATED
+
+    def test_to_dict_minimal(self) -> None:
+        result = WaitResult(
+            status=WaitStatus.TIMEOUT,
+            name="test-agent",
+            elapsed=3600,
+        )
+        d = result.to_dict()
+        assert d == {
+            "status": "timeout",
+            "name": "test-agent",
+            "elapsed": 3600,
+        }
+        # None values should not appear
+        assert "reason" not in d
+        assert "signal_type" not in d
+        assert "stuck_status" not in d
+
+    def test_to_dict_full(self) -> None:
+        result = WaitResult(
+            status=WaitStatus.STUCK,
+            name="test-agent",
+            elapsed=600,
+            stuck_status="CRITICAL",
+            stuck_action="paused",
+            idle_time=600,
+        )
+        d = result.to_dict()
+        assert d["status"] == "stuck"
+        assert d["stuck_status"] == "CRITICAL"
+        assert d["action"] == "paused"
+        assert d["idle_time"] == 600
+
+    def test_to_dict_with_signal(self) -> None:
+        result = WaitResult(
+            status=WaitStatus.SIGNAL,
+            name="test-agent",
+            elapsed=50,
+            signal_type=SignalType.ABORT,
+        )
+        d = result.to_dict()
+        assert d["signal_type"] == "abort"
+
+    def test_to_dict_with_error(self) -> None:
+        result = WaitResult(
+            status=WaitStatus.ERRORED,
+            name="test-agent",
+            elapsed=30,
+            error_message="progress_file_errored",
+        )
+        d = result.to_dict()
+        assert d["error"] == "progress_file_errored"
+
+
+class TestContractCheckResult:
+    def test_defaults(self) -> None:
+        result = ContractCheckResult(satisfied=False)
+        assert result.satisfied is False
+        assert result.status == "not_satisfied"
+        assert result.message == ""
+        assert result.recovery_action == "none"
+
+    def test_from_json_satisfied(self) -> None:
+        data = {
+            "phase": "builder",
+            "issue": 42,
+            "status": "satisfied",
+            "message": "PR #100 exists with loom:review-requested",
+            "recovery_action": "none",
+        }
+        result = ContractCheckResult.from_json(data)
+        assert result.satisfied is True
+        assert result.status == "satisfied"
+        assert "PR #100" in result.message
+
+    def test_from_json_recovered(self) -> None:
+        data = {
+            "status": "recovered",
+            "message": "Applied loom:curated label",
+            "recovery_action": "apply_label",
+        }
+        result = ContractCheckResult.from_json(data)
+        assert result.satisfied is True
+        assert result.status == "recovered"
+        assert result.recovery_action == "apply_label"
+
+    def test_from_json_failed(self) -> None:
+        data = {
+            "status": "failed",
+            "message": "No PR found",
+        }
+        result = ContractCheckResult.from_json(data)
+        assert result.satisfied is False
+        assert result.status == "failed"
+
+
+class TestMonitorConfig:
+    def test_defaults(self) -> None:
+        config = MonitorConfig(name="test-agent")
+        assert config.name == "test-agent"
+        assert config.timeout == 3600
+        assert config.poll_interval == 5
+        assert config.issue is None
+        assert config.task_id is None
+        assert config.phase is None
+        assert config.worktree is None
+        assert config.pr_number is None
+        assert config.idle_timeout == 60
+        assert config.contract_interval == 90
+        assert config.min_idle_elapsed == 10
+        assert config.heartbeat_interval == 60
+
+    def test_from_args_minimal(self) -> None:
+        config = MonitorConfig.from_args(name="builder-issue-42")
+        assert config.name == "builder-issue-42"
+        assert config.timeout == 3600
+        assert isinstance(config.stuck_config, StuckConfig)
+
+    def test_from_args_full(self) -> None:
+        config = MonitorConfig.from_args(
+            name="builder-issue-42",
+            timeout=1800,
+            poll_interval=10,
+            issue=42,
+            task_id="abc123",
+            phase="builder",
+            worktree=".loom/worktrees/issue-42",
+            pr_number=100,
+            idle_timeout=30,
+            contract_interval=60,
+            min_idle_elapsed=5,
+        )
+        assert config.name == "builder-issue-42"
+        assert config.timeout == 1800
+        assert config.poll_interval == 10
+        assert config.issue == 42
+        assert config.task_id == "abc123"
+        assert config.phase == "builder"
+        assert config.worktree == ".loom/worktrees/issue-42"
+        assert config.pr_number == 100
+        assert config.idle_timeout == 30
+        assert config.contract_interval == 60
+        assert config.min_idle_elapsed == 5


### PR DESCRIPTION
## Summary

- Migrates `agent-wait-bg.sh` (1,144 lines) to Python `loom_tools/agent_monitor.py`
- Implements async agent monitoring with full feature parity to the shell script
- Adds CLI entry point `loom-agent-monitor` matching original script interface

## Key Features

- **Completion detection**: Proactive + idle-triggered phase contract checking via `validate-phase.sh`
- **Pattern matching**: Role-specific log patterns (builder PR created, judge review complete, etc.)
- **Stuck detection**: Configurable warning/critical thresholds with WARN/PAUSE/RESTART/RETRY actions
- **Fast stuck-at-prompt detection**: ~30s vs 5min general threshold, with recovery (Enter nudge + command retry)
- **Signal handling**: Detects `stop-shepherds` file and `loom:abort` label
- **Error detection**: Reads shepherd progress file status for fast error detection
- **Interactive prompt resolution**: Auto-approves plan mode prompts
- **Heartbeat emission**: Keeps progress files fresh to prevent false stale detection

## Files Changed

| File | Change |
|------|--------|
| `loom_tools/agent_monitor.py` | Main async monitoring module (650+ lines) |
| `loom_tools/models/agent_wait.py` | WaitResult, MonitorConfig, StuckConfig dataclasses |
| `tests/test_agent_monitor.py` | Unit tests (39 tests) |
| `tests/test_agent_wait.py` | Model tests (20 tests) |
| `pyproject.toml` | CLI entry point registration |

## Test plan

- [x] Unit tests: 59 new tests, all passing
- [x] Existing tests: 114 total tests pass
- [x] CLI help: `loom-agent-monitor --help` works
- [x] Backward compatibility: Same CLI flags as `agent-wait-bg.sh`
- [ ] Integration: Needs testing with actual tmux sessions (future PR)

## Migration Path

This PR implements the Python module. Integration into `shepherd-loop.sh` will follow in a future PR with feature flag support for parallel testing.

Closes #1639

🤖 Generated with [Claude Code](https://claude.com/claude-code)