### PR TITLE
Add loom:merge-conflict and loom:ci-failure labels for differentiated PR feedback

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -43,6 +43,14 @@
   description: "PR requires changes before re-review (Judge requested modifications)"
   color: "F59E0B"  # amber-500 - matches other "action required" labels
 
+- name: loom:merge-conflict
+  description: "PR has merge conflicts requiring resolution"
+  color: "DC2626"  # red-600 - indicates broken state
+
+- name: loom:ci-failure
+  description: "PR has failing CI checks"
+  color: "DC2626"  # red-600 - indicates broken state
+
 - name: loom:pr
   description: PR approved by Judge, ready for human to merge
   color: "3B82F6"  # blue-500


### PR DESCRIPTION
## Summary
- Add `loom:merge-conflict` and `loom:ci-failure` labels for categorizing PR issues
- Update Judge role to detect and apply specific labels for merge conflicts and CI failures
- Update Shepherd to log specific issue types when routing to Doctor phase
- Include issue type in diagnostic information when builds are blocked

## Test plan
- [ ] Create a PR with merge conflicts, verify Judge applies `loom:merge-conflict`
- [ ] Create a PR with failing CI, verify Judge applies `loom:ci-failure`
- [ ] Create a PR with code quality issues, verify Judge applies only `loom:changes-requested`
- [ ] Verify Shepherd correctly logs the issue type before invoking Doctor
- [ ] Verify labels sync correctly with `gh label sync`

Closes #1657

🤖 Generated with [Claude Code](https://claude.com/claude-code)