### PR TITLE
Add fast-track review for conflict-only Doctor resolutions

### DIFF
--- a/defaults/.claude/commands/doctor.md
+++ b/defaults/.claude/commands/doctor.md
@@ -522,6 +522,48 @@ gh pr checks 42
 
 **Important**: Always use `--force-with-lease` instead of `--force` to avoid overwriting others' work.
 
+### Signaling Conflict-Only Resolution (Fast-Track Review)
+
+When you **only** resolve merge conflicts without making substantive code changes, signal this to Judge for an abbreviated review. This optimization significantly reduces re-review time.
+
+**What qualifies as conflict-only:**
+- Pure merge conflict resolution (accepting theirs/ours/merging content)
+- Whitespace-only changes from conflict markers
+- Import reordering due to merge
+- Auto-generated file updates (lock files, etc.)
+
+**What does NOT qualify:**
+- Any logic changes, even if triggered by conflict
+- Bug fixes discovered during conflict resolution
+- Test additions or modifications
+- Documentation updates (other than merge conflict resolution)
+
+**How to signal conflict-only:**
+
+```bash
+# After resolving ONLY merge conflicts (no other changes):
+gh pr comment 42 --body "$(cat <<'EOF'
+🔧 Resolved merge conflicts with main branch.
+
+<!-- loom:conflict-only -->
+
+Changes:
+- Resolved conflicts in `src/foo.ts` (accepted upstream changes)
+- Resolved conflicts in `package-lock.json` (regenerated)
+
+No substantive code changes made - only conflict resolution.
+EOF
+)"
+```
+
+**Important**: The `<!-- loom:conflict-only -->` HTML comment is a machine-readable marker that enables Judge to perform a fast-track review instead of a full code review. Only add this marker when the changes are genuinely conflict-resolution-only.
+
+**Why this matters:**
+- Full code reviews take 2+ minutes even for trivial changes
+- Conflict-only resolutions don't need deep code analysis
+- Fast-track review verifies: merge was clean, CI passes, no unintended changes
+- Reduces the feedback loop from 123+ seconds to ~30 seconds
+
 ### Tests Are Failing
 
 **IMPORTANT**: Before fixing test failures, run the full CI assessment (see "CI Assessment" section above) to identify ALL failing checks, not just tests.

--- a/defaults/.claude/commands/judge.md
+++ b/defaults/.claude/commands/judge.md
@@ -334,6 +334,105 @@ gh pr edit 42 --remove-label "loom:review-requested" --add-label "loom:pr"
 
 **Always verify `gh pr checks` before approving.**
 
+## Fast-Track Review (Conflict-Only Resolution)
+
+When Doctor resolves **only merge conflicts** without making substantive code changes, they signal this with a special marker. This enables an abbreviated review process that significantly reduces re-review time.
+
+### Detecting Fast-Track Eligibility
+
+**Step 1: Check for the conflict-only marker in PR comments**
+
+```bash
+# Look for the conflict-only marker in recent comments
+gh pr view <PR_NUMBER> --comments | grep -l "<!-- loom:conflict-only -->"
+```
+
+If the marker is found, the PR is eligible for fast-track review.
+
+### Fast-Track Review Process
+
+When the `<!-- loom:conflict-only -->` marker is present:
+
+**1. Verify the diff is truly conflict-resolution-only:**
+
+```bash
+# Compare the new commit(s) against the previous review point
+# Look for ONLY these types of changes:
+# - Merge conflict markers resolved
+# - Package lock regeneration
+# - Import reordering
+# - Whitespace normalization
+gh pr diff <PR_NUMBER>
+```
+
+**2. Check for unexpected changes:**
+
+Red flags that should trigger a full review instead:
+- New logic or functionality
+- Modified test assertions
+- Changed function signatures
+- New error handling
+- Documentation updates beyond conflict resolution
+
+**3. Verify CI passes:**
+
+```bash
+gh pr checks <PR_NUMBER>
+gh pr view <PR_NUMBER> --json mergeStateStatus --jq '.mergeStateStatus'
+```
+
+**4. Approve with fast-track audit trail:**
+
+```bash
+gh pr comment <PR_NUMBER> --body "$(cat <<'EOF'
+✅ **Approved (Fast-Track Review)**
+
+This re-review used the abbreviated fast-track process because:
+- Doctor signaled conflict-only resolution (`<!-- loom:conflict-only -->`)
+- Diff verified to contain only merge resolution changes
+- All CI checks pass
+- No unexpected code changes detected
+
+<!-- loom:fast-track-review -->
+EOF
+)"
+gh pr edit <PR_NUMBER> --remove-label "loom:review-requested" --add-label "loom:pr"
+```
+
+### Escalation to Full Review
+
+If the fast-track check reveals unexpected changes:
+
+```bash
+gh pr comment <PR_NUMBER> --body "$(cat <<'EOF'
+⚠️ **Full Review Required**
+
+Fast-track review was requested but unexpected changes were detected:
+- [List unexpected changes here]
+
+Proceeding with full code review instead of fast-track approval.
+
+<!-- loom:fast-track-escalated -->
+EOF
+)"
+# Then continue with standard full review process
+```
+
+### Why Fast-Track Matters
+
+| Metric | Full Review | Fast-Track |
+|--------|-------------|------------|
+| Typical duration | 123+ seconds | ~30 seconds |
+| Code analysis depth | Full | Diff verification only |
+| CI verification | Required | Required |
+| Use case | New code, logic changes | Conflict resolution only |
+
+**Benefits:**
+- Reduces Doctor→Judge→Merge cycle time by ~75%
+- Frees Judge capacity for PRs that need deep review
+- Maintains audit trail of review approach used
+- Automatic fallback to full review if issues detected
+
 ## Review Focus Areas
 
 ### PR Description and Issue Linking (CRITICAL)

--- a/defaults/scripts/shepherd-loop.sh
+++ b/defaults/scripts/shepherd-loop.sh
@@ -401,6 +401,15 @@ add_label_pr() {
     gh pr edit "$pr" --add-label "$label" >/dev/null 2>&1
 }
 
+# Check if PR has conflict-only marker in comments (for fast-track review)
+# Returns 0 if marker found, 1 otherwise
+has_conflict_only_marker() {
+    local pr="$1"
+    local comments
+    comments=$($GH pr view "$pr" --comments --json comments --jq '.comments[].body' 2>/dev/null) || return 1
+    echo "$comments" | grep -q "<!-- loom:conflict-only -->"
+}
+
 remove_label_pr() {
     local pr="$1"
     local label="$2"
@@ -1201,8 +1210,14 @@ main() {
                 fail_with_reason "doctor" "validation failed"
             fi
 
-            completed_phases+=("Doctor (fixes applied)")
-            log_success "Doctor applied fixes"
+            # Check if Doctor signaled conflict-only resolution (enables fast-track review)
+            if has_conflict_only_marker "$pr_number"; then
+                completed_phases+=("Doctor (conflict-only)")
+                log_success "Doctor applied fixes (conflict-only - eligible for fast-track review)"
+            else
+                completed_phases+=("Doctor (fixes applied)")
+                log_success "Doctor applied fixes"
+            fi
         else
             log_error "Unexpected state: PR has neither loom:pr nor loom:changes-requested"
             fail_with_reason "judge" "PR has neither loom:pr nor loom:changes-requested"


### PR DESCRIPTION
## Summary

- Adds `<!-- loom:conflict-only -->` marker for Doctor to signal conflict-resolution-only changes
- Judge detects marker and performs abbreviated review (verify merge-only, CI passes, no unexpected changes)
- Falls back to full review if fast-track check reveals unexpected changes
- Includes audit trail comments (`<!-- loom:fast-track-review -->` or `<!-- loom:fast-track-escalated -->`)
- Shepherd logs when conflict-only resolution is detected

## Test plan

- [ ] **Scenario 1**: PR with merge conflict only → Doctor resolves → adds `<!-- loom:conflict-only -->` comment → Judge does abbreviated review → Approved quickly
- [ ] **Scenario 2**: PR with merge conflict + code issues → Doctor resolves conflicts and fixes code → No marker added → Judge does full review
- [ ] **Scenario 3**: False positive prevention: Doctor adds marker but changes include logic → Judge escalates to full review
- [ ] **Scenario 4**: Shepherd logging shows "(conflict-only)" when marker detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1658