### PR TITLE
Add code comments documenting intentional label and review behaviors

### DIFF
--- a/defaults/.claude/commands/judge.md
+++ b/defaults/.claude/commands/judge.md
@@ -23,6 +23,12 @@ You are a thorough and constructive code reviewer working in the {{workspace}} r
 
 **Why?** In Loom, the same agent often creates AND reviews PRs. GitHub prohibits self-approval via their API. This is NOT a bug - it's by design. The workaround is Loom's label-based system.
 
+**Design Decision (documented for future reference):**
+- GitHub's API prevents self-review: the same account cannot review its own PR
+- Comment-based approval provides a visible audit trail with review rationale
+- Label-based workflow (`loom:pr`) is the coordination mechanism, not GitHub review status
+- This approach is intentional, not a limitation to work around
+
 ## Your Role
 
 **Your primary task is to review PRs labeled `loom:review-requested` (green badges).**

--- a/defaults/scripts/merge-pr.sh
+++ b/defaults/scripts/merge-pr.sh
@@ -206,6 +206,8 @@ LINKED_ISSUE=$(echo "$PR_BODY" | grep -oE '(Closes|closes|Fixes|fixes|Resolves|r
 if [[ -n "$LINKED_ISSUE" ]]; then
   info "Found linked issue: #$LINKED_ISSUE"
   # Remove workflow labels that shouldn't persist on closed issues
+  # NOTE: Origin labels (loom:architect, loom:hermit, loom:auditor) are intentionally
+  # preserved for audit trail - they indicate where the issue originated from
   for label in loom:building loom:issue loom:curated loom:curating loom:treating loom:blocked; do
     gh issue edit "$LINKED_ISSUE" --remove-label "$label" 2>/dev/null && \
       info "  Removed label: $label" || true


### PR DESCRIPTION
## Summary

Adds inline code comments to document intentional design decisions that might otherwise appear to be bugs or oversights, as identified in the post-mortem of shepherd run for #1639.

## Changes

### 1. Origin labels preserved on closed issues
**File**: `defaults/scripts/merge-pr.sh`

Added comment explaining that the label cleanup intentionally preserves origin labels (`loom:architect`, `loom:hermit`, `loom:auditor`) for audit trail purposes.

### 2. Judge uses comment-based approval
**File**: `defaults/.claude/commands/judge.md`

Added a "Design Decision" section explaining why:
- GitHub's API prevents self-review (same account can't review its own PR)
- Comment provides visible audit trail with review rationale  
- Label-based workflow (`loom:pr`) is the coordination mechanism
- This is intentional, not a limitation to work around

## Test plan

- [x] Verify comments are correctly placed and accurately describe the design decisions
- [x] Verify shellcheck passes on modified script
- [x] Review that comments match the rationale from issue #1659

Closes #1659

🤖 Generated with [Claude Code](https://claude.ai/code)