### PR TITLE
Instruct builder to explicitly exit after PR creation

### DIFF
--- a/defaults/.claude/commands/builder.md
+++ b/defaults/.claude/commands/builder.md
@@ -521,6 +521,12 @@ Keep it brief (3-6 words) and descriptive:
 
 ## Completion
 
-**Work completion is detected automatically.**
+After successfully creating the PR:
 
-When you complete your task (PR created with `loom:review-requested` label, or issue marked as `loom:blocked`), the orchestration layer detects this and terminates the session automatically. No explicit exit command is needed.
+1. **Verify the PR was created** with `loom:review-requested` label:
+   ```bash
+   gh pr view <number> --json labels,number,url
+   ```
+2. **Exit the session** - the shepherd will continue the workflow
+
+**Work completion is detected automatically.** When you complete your task (PR created with `loom:review-requested` label, or issue marked as `loom:blocked`), the orchestration layer terminates the session. However, you should explicitly exit after verifying PR creation to avoid unnecessary delays in the pipeline.


### PR DESCRIPTION
## Summary

- Update the builder role's Completion section to explicitly instruct builders to exit after PR creation instead of relying on external detection mechanisms
- Builder now verifies PR creation and exits promptly, reducing pipeline delays from 90-180 seconds to near-instant

## Changes

Updated `.claude/commands/builder.md` to:
1. Add explicit step to verify PR was created with `loom:review-requested` label
2. Instruct builder to exit the session after verification
3. Clarify that while detection is automatic, explicit exit avoids unnecessary delays

## Test plan

- [ ] Run a shepherd for a new issue and observe builder behavior
- [ ] Verify builder exits within ~10s of PR creation (not 90-180s)
- [ ] Confirm shepherd detects completion and proceeds to judge phase without delay

## Acceptance Criteria

| Criterion | Verification |
|-----------|--------------|
| Update builder.md "Completion" section to explicitly instruct exit after PR creation | Updated completion section with explicit exit instruction |
| Builder verifies PR created successfully before exiting | Added `gh pr view` verification step |
| Session terminates promptly (within seconds, not minutes) | Explicit exit instruction enables prompt termination |

Closes #1669

---
Generated with [Claude Code](https://claude.ai/code)