### PR TITLE
Suppress agent log output in Python shepherd subprocess calls

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/base.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/base.py
@@ -126,11 +126,13 @@ def run_worker_phase(
         spawn_cmd.extend(["--worktree", str(worktree)])
 
     # Spawn the worker
+    # Redirect to DEVNULL to suppress output - agent logs are captured to
+    # .loom/logs/<session>.log for debugging purposes
     spawn_result = subprocess.run(
         spawn_cmd,
         cwd=ctx.repo_root,
-        text=True,
-        capture_output=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
         check=False,
     )
 
@@ -168,11 +170,13 @@ def run_worker_phase(
     env["LOOM_STUCK_ACTION"] = "retry"
 
     # Wait for completion
+    # Redirect to DEVNULL to suppress output - agent logs are captured to
+    # .loom/logs/<session>.log for debugging purposes
     wait_result = subprocess.run(
         wait_cmd,
         cwd=ctx.repo_root,
-        text=True,
-        capture_output=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
         check=False,
         env=env,
     )
@@ -184,8 +188,8 @@ def run_worker_phase(
     subprocess.run(
         destroy_cmd,
         cwd=ctx.repo_root,
-        text=True,
-        capture_output=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
         check=False,
     )
 


### PR DESCRIPTION
## Summary

- Replace `capture_output=True` with explicit `stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL` for all three subprocess calls (spawn, wait, destroy) in the Python shepherd's phase execution
- This prevents captured stdout/stderr from agent-spawn.sh and agent-wait-bg.sh from leaking after the "ORCHESTRATION COMPLETE" message
- Agent logs remain available in `.loom/logs/<session>.log` for debugging purposes

## Acceptance Criteria Verification

| Criterion | Verification |
|-----------|--------------|
| No log messages appear after "ORCHESTRATION COMPLETE" | Subprocess output is now redirected to DEVNULL instead of captured, preventing any output leakage |
| Agent logs still captured to `.loom/logs/<session>.log` | Log capture happens in the shell scripts themselves, not affected by Python subprocess handling |
| Phase output (success/failure messages) still displays correctly | Phase output comes from Python print statements, not subprocess output |
| Consistent behavior in `--force` mode | Same subprocess handling for all modes |

## Test Plan

- [x] Python syntax check passes
- [x] mypy type check passes (no issues found)
- [x] All 19 shepherd phase tests pass

Closes #1667

🤖 Generated with [Claude Code](https://claude.com/claude-code)