### PR TITLE
Add automated rebase for DIRTY PRs in Judge review process

### DIFF
--- a/quickstarts/api/.loom/roles/judge.md
+++ b/quickstarts/api/.loom/roles/judge.md
@@ -23,7 +23,7 @@ You are a Judge reviewing pull requests for a Cloudflare Workers API.
    # Check if branch needs rebase
    gh pr view <number> --json mergeStateStatus --jq '.mergeStateStatus'
    # If BEHIND: git fetch origin main && git rebase origin/main && git push --force-with-lease
-   # If DIRTY: Request changes (merge conflict)
+   # If DIRTY: Attempt automated rebase first, fall back to request changes if rebase fails
    ```
 
 3. **Review the PR**:

--- a/quickstarts/desktop/.loom/roles/judge.md
+++ b/quickstarts/desktop/.loom/roles/judge.md
@@ -23,7 +23,7 @@ You are a Judge reviewing pull requests for a Tauri desktop application.
    # Check if branch needs rebase
    gh pr view <number> --json mergeStateStatus --jq '.mergeStateStatus'
    # If BEHIND: git fetch origin main && git rebase origin/main && git push --force-with-lease
-   # If DIRTY: Request changes (merge conflict)
+   # If DIRTY: Attempt automated rebase first, fall back to request changes if rebase fails
    ```
 
 3. **Review the PR**:

--- a/quickstarts/webapp/.loom/roles/judge.md
+++ b/quickstarts/webapp/.loom/roles/judge.md
@@ -41,7 +41,7 @@ You are a Judge reviewing pull requests for a modern web application.
    # Check if branch needs rebase
    gh pr view <number> --json mergeStateStatus --jq '.mergeStateStatus'
    # If BEHIND: git fetch origin main && git rebase origin/main && git push --force-with-lease
-   # If DIRTY: Request changes (merge conflict)
+   # If DIRTY: Attempt automated rebase first, fall back to request changes if rebase fails
    ```
 
 3. **Review the PR**:


### PR DESCRIPTION
## Summary

This PR adds automatic rebase capability to the Judge role when encountering PRs with merge conflicts (DIRTY mergeStateStatus). Previously, Judge would immediately request changes and route to Doctor. Now Judge will attempt automated rebase first:

1. Checkout the PR branch
2. Fetch latest main and attempt automated rebase
3. If successful: push with `--force-with-lease` and continue review
4. If failed: fall back to requesting changes with `loom:merge-conflict` label

This reduces the Doctor→Judge→Merge cycle for simple conflicts that can be auto-resolved.

## Changes

- Added new step 3 "Check merge state" in Review Process section
- Added comprehensive "If DIRTY: Attempt Automated Rebase" section with:
  - Detailed bash workflow
  - Edge case handling table
  - Fallback behavior documentation
- Updated merge state tables to reference automated rebase
- Updated "When Merge Conflicts Exist" section to reference new workflow
- Updated all quickstart templates (api, desktop, webapp) with brief note

## Edge Cases Handled

| Scenario | Handling |
|----------|----------|
| Push permission denied | Abort rebase, fall back to change request |
| Concurrent push during rebase | `--force-with-lease` fails safely, fall back |
| Detached HEAD after checkout | Skip rebase, fall back to change request |
| Rebase succeeds but CI may fail | Continue to review - CI verification handles this |

## Test Plan

- [ ] Create PR with trivial conflict (both sides edited different parts of same file)
- [ ] Verify Judge automatically rebases and pushes
- [ ] Verify Judge proceeds to code review without routing to Doctor
- [ ] Create PR with complex conflict (same lines edited)
- [ ] Verify Judge attempts rebase, detects conflict, aborts
- [ ] Verify Judge applies `loom:merge-conflict` + `loom:changes-requested`
- [ ] Verify Shepherd routes to Doctor as before
- [ ] Clean PR with no conflicts: verify Judge skips rebase step entirely

Closes #1666

🤖 Generated with [Claude Code](https://claude.com/claude-code)