### PR TITLE
Route /shepherd to Python implementation via wrapper script

### DIFF
--- a/defaults/.claude/commands/shepherd.md
+++ b/defaults/.claude/commands/shepherd.md
@@ -33,10 +33,10 @@ Parse the issue number and any flags from the arguments.
 
 ## Execution
 
-Invoke the shell script with all provided arguments:
+Invoke the shepherd wrapper with all provided arguments:
 
 ```bash
-./.loom/scripts/shepherd-loop.sh $ARGUMENTS
+./.loom/scripts/loom-shepherd.sh $ARGUMENTS
 ```
 
 Run this command now. Report the exit status when complete.
@@ -45,4 +45,6 @@ Run this command now. Report the exit status when complete.
 
 For detailed orchestration workflow, phase definitions, and troubleshooting:
 - **Lifecycle details**: `.claude/commands/shepherd-lifecycle.md`
-- **Shell script**: `.loom/scripts/shepherd-loop.sh`
+- **Wrapper script**: `.loom/scripts/loom-shepherd.sh` (routes to Python or shell)
+- **Python implementation**: `loom-tools/src/loom_tools/shepherd/`
+- **Shell script (fallback)**: `.loom/scripts/shepherd-loop.sh`

--- a/defaults/scripts/loom-shepherd.sh
+++ b/defaults/scripts/loom-shepherd.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Wrapper to invoke Python shepherd with proper environment
+#
+# This script provides the entry point for /shepherd command, routing to
+# the Python-based shepherd implementation (loom-tools package).
+#
+# Benefits over direct shell script:
+#   - Handles PYTHONPATH setup for both pip-installed and source installs
+#   - Maps CLI flags for user-facing parity (--merge/-m → --force/-f)
+#   - Graceful fallback to shell script if Python unavailable
+#   - Single change point for shepherd command routing
+#
+# Usage:
+#   ./.loom/scripts/loom-shepherd.sh <issue-number> [options]
+#
+# Options (user-facing):
+#   --merge, -m     Auto-approve, auto-merge after approval (maps to --force)
+#   --to <phase>    Stop after specified phase (curated, pr, approved)
+#   --from <phase>  Start from specified phase (curator, builder, judge, merge)
+#   --task-id <id>  Use specific task ID
+#
+# See shepherd.md for full documentation.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LOOM_TOOLS="$REPO_ROOT/loom-tools"
+
+# Map --merge/-m to --force/-f for CLI parity
+# The Python CLI uses --force internally, but users expect --merge per documentation
+args=()
+for arg in "$@"; do
+    case "$arg" in
+        --merge|-m)
+            args+=("--force")
+            ;;
+        *)
+            args+=("$arg")
+            ;;
+    esac
+done
+
+# Try Python implementation first
+# Priority order:
+#   1. Virtual environment in loom-tools (development setup)
+#   2. System-installed loom-shepherd (pip install)
+#   3. Fallback to shell script (transition period)
+
+if [[ -x "$LOOM_TOOLS/.venv/bin/loom-shepherd" ]]; then
+    # Development setup: use venv directly
+    exec "$LOOM_TOOLS/.venv/bin/loom-shepherd" "${args[@]}"
+elif command -v loom-shepherd &>/dev/null; then
+    # System-installed
+    exec loom-shepherd "${args[@]}"
+else
+    # Fallback to shell script
+    # Note: Shell script uses --merge/-m directly, so pass original args
+    echo "[WARN] Python shepherd not available, falling back to shell script" >&2
+    exec "$SCRIPT_DIR/shepherd-loop.sh" "$@"
+fi


### PR DESCRIPTION
## Summary

- Adds `loom-shepherd.sh` wrapper script that routes `/shepherd` to the Python implementation
- Maps user-facing `--merge/-m` flags to Python's `--force/-f` for CLI parity
- Provides graceful fallback to shell script if Python environment is not available (transition period)
- Updates `shepherd.md` command to invoke the wrapper instead of shell script directly

## Test plan

- [x] **Basic invocation**: Wrapper correctly finds shell fallback when Python not available
- [x] **Merge flag mapping**: `--merge` is mapped to `--force` in args array for Python
- [x] **Short flag mapping**: `-m` is mapped to `--force` in args array for Python
- [x] **Other flag passthrough**: `--to`, `--from`, `--task-id` pass through unchanged
- [x] **Shellcheck validation**: Script passes shellcheck with no warnings
- [ ] **Python invocation**: When Python shepherd is available, it's used (not tested - Python not installed in CI)

## Verification Commands

```bash
# Test flag mapping (trace mode shows args array construction)
bash -x defaults/scripts/loom-shepherd.sh 123 --merge 2>&1 | grep args

# Test the wrapper invokes shell fallback
./defaults/scripts/loom-shepherd.sh 123 --to curated
```

Closes #1676

🤖 Generated with [Claude Code](https://claude.com/claude-code)