### PR TITLE
Add missing error class mappings to fail_with_reason

### DIFF
--- a/defaults/scripts/shepherd-loop.sh
+++ b/defaults/scripts/shepherd-loop.sh
@@ -536,8 +536,13 @@ fail_with_reason() {
         builder:*"worktree"*)             error_class="worktree_failed" ;;
         builder:*"validation"*)           error_class="builder_validation" ;;
         builder:*"could not find PR"*)    error_class="builder_validation" ;;
+        builder:*"agent stuck"*)          error_class="builder_stuck" ;;
         judge:*"validation"*)             error_class="judge_validation" ;;
+        judge:*"agent stuck"*)            error_class="judge_stuck" ;;
         doctor:*"validation"*)            error_class="doctor_validation" ;;
+        doctor:*"agent stuck"*)           error_class="doctor_stuck" ;;
+        doctor:*"max retries"*)           error_class="doctor_exhausted" ;;
+        merge:*"failed to merge"*)        error_class="merge_failed" ;;
         curator:*"validation"*)           error_class="unknown" ;;  # Curator failures are non-blocking
         *)                                error_class="unknown" ;;
     esac


### PR DESCRIPTION
## Summary

- Adds 5 missing error class mappings to `fail_with_reason()` in shepherd-loop.sh
- These error classes were documented in `record-blocked-reason.sh` but had no mapping in the case statement

## Changes

Added mappings for:
| Pattern | Error Class |
|---------|-------------|
| `builder:*"agent stuck"*` | `builder_stuck` |
| `judge:*"agent stuck"*` | `judge_stuck` |
| `doctor:*"agent stuck"*` | `doctor_stuck` |
| `doctor:*"max retries"*` | `doctor_exhausted` |
| `merge:*"failed to merge"*` | `merge_failed` |

## Impact

The retry system can now properly classify these failure types, improving the effectiveness of automatic retry logic introduced in #1617.

## Verification

| Criterion | Verified |
|-----------|----------|
| All 5 documented error classes mapped | ✅ |
| Pattern matches actual fail_with_reason calls | ✅ |
| Shell syntax valid | ✅ |

## Test plan

- [x] Shell script syntax validation (`bash -n`) passes
- [x] Patterns match existing `fail_with_reason` call sites in the code

Closes #1685

🤖 Generated with [Claude Code](https://claude.com/claude-code)