### PR TITLE
Add skip_precondition error class for --from flag failures

### DIFF
--- a/defaults/scripts/record-blocked-reason.sh
+++ b/defaults/scripts/record-blocked-reason.sh
@@ -17,6 +17,7 @@
 #   merge_failed          - PR merge failed (conflicts, checks)
 #   rate_limited          - API rate limit exceeded
 #   worktree_failed       - Failed to create worktree
+#   skip_precondition     - --from flag precondition failed (e.g., no PR exists, PR not approved)
 #   unknown               - Unclassified error
 
 set -euo pipefail

--- a/defaults/scripts/shepherd-loop.sh
+++ b/defaults/scripts/shepherd-loop.sh
@@ -539,6 +539,7 @@ fail_with_reason() {
         judge:*"validation"*)             error_class="judge_validation" ;;
         doctor:*"validation"*)            error_class="doctor_validation" ;;
         curator:*"validation"*)           error_class="unknown" ;;  # Curator failures are non-blocking
+        *:*"skipped via --from"*)         error_class="skip_precondition" ;;  # --from flag precondition failed
         *)                                error_class="unknown" ;;
     esac
 


### PR DESCRIPTION
## Summary

- Adds `skip_precondition` error class for `--from` flag failures in shepherd-loop.sh
- Updates error class documentation in record-blocked-reason.sh

## Context

When using `--from` flag to skip phases, the shepherd can fail with specific errors that previously mapped to `unknown`:

```bash
fail_with_reason "builder" "skipped via --from but no PR exists"
fail_with_reason "judge" "skipped via --from but PR not approved"
```

These failures now map to `skip_precondition`, distinguishing operator errors (using `--from` incorrectly) from system failures.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Add error class pattern for `--from` failures | ✅ | Added `*:*"skipped via --from"*) error_class="skip_precondition"` pattern in shepherd-loop.sh:542 |
| Update record-blocked-reason.sh documentation | ✅ | Added `skip_precondition` to error classes list at line 20 |

## Test Plan

- [x] Verify pattern matches `--from` failure messages via code inspection
- [x] Verify no existing patterns conflict with new pattern (placed before catchall `*`)
- [x] Run shellcheck - no errors

Closes #1687

🤖 Generated with [Claude Code](https://claude.com/claude-code)