### PR TITLE
Fix false-positive stuck-at-prompt warnings on agent startup

### DIFF
--- a/defaults/scripts/agent-wait-bg.sh
+++ b/defaults/scripts/agent-wait-bg.sh
@@ -883,7 +883,7 @@ main() {
     local last_contract_check=0
     local stuck_warned=false
     local stuck_critical_reported=false
-    local last_prompt_stuck_check=0
+    local last_prompt_stuck_check=$start_time
     local prompt_stuck_recovery_attempted=false
     local last_heartbeat_time=$start_time
     COMPLETION_REASON=""


### PR DESCRIPTION
## Summary

- Fixes false-positive stuck-at-prompt warnings that occurred immediately after agent startup
- Changes `last_prompt_stuck_check` initialization from `0` to `$start_time`
- Follows the same pattern already used for `last_heartbeat_time`

## Root Cause

When `last_prompt_stuck_check` was initialized to `0`, the stuck-at-prompt detection could fire immediately on the first loop iteration since `(current_time - 0)` would always exceed `PROMPT_STUCK_THRESHOLD` (30 seconds).

## Verification

| Acceptance Criteria | Verified |
|---------------------|----------|
| `last_prompt_stuck_check` initialized to `$start_time` | ✅ Line 886 changed |
| Follows same pattern as `last_heartbeat_time` | ✅ Both now use `$start_time` |
| Bash syntax valid | ✅ `bash -n` passes |
| No other similar `=0` bugs in same area | ✅ Checked - `last_contract_check=0` is intentional (protected by `get_adaptive_contract_interval`) |

## Test Plan

1. Start a shepherd or builder agent
2. Verify NO stuck-at-prompt warnings appear for at least 30 seconds after startup
3. First stuck detection should only occur after `PROMPT_STUCK_THRESHOLD` (30s) elapses

Closes #1683

🤖 Generated with [Claude Code](https://claude.com/claude-code)