### PR TITLE
Fix stuck-at-prompt detection to use age-based tracking

### DIFF
--- a/loom-tools/src/loom_tools/models/agent_wait.py
+++ b/loom-tools/src/loom_tools/models/agent_wait.py
@@ -51,7 +51,10 @@ class StuckConfig:
 
     warning_threshold: int = 300  # 5 minutes
     critical_threshold: int = 600  # 10 minutes
-    prompt_stuck_threshold: int = 30  # 30 seconds
+    # Prompt stuck detection: check every 10s, fire after 30s stuck
+    prompt_stuck_check_interval: int = 10  # how often to check
+    prompt_stuck_age_threshold: int = 30  # how long stuck before detection
+    prompt_stuck_recovery_cooldown: int = 60  # seconds before re-trying recovery
     action: StuckAction = StuckAction.WARN
 
     @classmethod
@@ -68,8 +71,14 @@ class StuckConfig:
         return cls(
             warning_threshold=int(os.environ.get("LOOM_STUCK_WARNING", "300")),
             critical_threshold=int(os.environ.get("LOOM_STUCK_CRITICAL", "600")),
-            prompt_stuck_threshold=int(
-                os.environ.get("LOOM_PROMPT_STUCK_THRESHOLD", "30")
+            prompt_stuck_check_interval=int(
+                os.environ.get("LOOM_PROMPT_STUCK_CHECK_INTERVAL", "10")
+            ),
+            prompt_stuck_age_threshold=int(
+                os.environ.get("LOOM_PROMPT_STUCK_AGE_THRESHOLD", "30")
+            ),
+            prompt_stuck_recovery_cooldown=int(
+                os.environ.get("LOOM_PROMPT_STUCK_RECOVERY_COOLDOWN", "60")
             ),
             action=action,
         )

--- a/loom-tools/tests/test_agent_wait.py
+++ b/loom-tools/tests/test_agent_wait.py
@@ -58,17 +58,29 @@ class TestStuckConfig:
         config = StuckConfig()
         assert config.warning_threshold == 300
         assert config.critical_threshold == 600
-        assert config.prompt_stuck_threshold == 30
+        assert config.prompt_stuck_check_interval == 10
+        assert config.prompt_stuck_age_threshold == 30
+        assert config.prompt_stuck_recovery_cooldown == 60
         assert config.action == StuckAction.WARN
 
     def test_from_env_defaults(self) -> None:
         with mock.patch.dict(os.environ, {}, clear=True):
             # Remove our env vars if they exist
-            for key in ["LOOM_STUCK_WARNING", "LOOM_STUCK_CRITICAL", "LOOM_STUCK_ACTION", "LOOM_PROMPT_STUCK_THRESHOLD"]:
+            for key in [
+                "LOOM_STUCK_WARNING",
+                "LOOM_STUCK_CRITICAL",
+                "LOOM_STUCK_ACTION",
+                "LOOM_PROMPT_STUCK_CHECK_INTERVAL",
+                "LOOM_PROMPT_STUCK_AGE_THRESHOLD",
+                "LOOM_PROMPT_STUCK_RECOVERY_COOLDOWN",
+            ]:
                 os.environ.pop(key, None)
             config = StuckConfig.from_env()
         assert config.warning_threshold == 300
         assert config.critical_threshold == 600
+        assert config.prompt_stuck_check_interval == 10
+        assert config.prompt_stuck_age_threshold == 30
+        assert config.prompt_stuck_recovery_cooldown == 60
         assert config.action == StuckAction.WARN
 
     def test_from_env_custom(self) -> None:
@@ -76,12 +88,16 @@ class TestStuckConfig:
             "LOOM_STUCK_WARNING": "180",
             "LOOM_STUCK_CRITICAL": "360",
             "LOOM_STUCK_ACTION": "pause",
-            "LOOM_PROMPT_STUCK_THRESHOLD": "15",
+            "LOOM_PROMPT_STUCK_CHECK_INTERVAL": "5",
+            "LOOM_PROMPT_STUCK_AGE_THRESHOLD": "15",
+            "LOOM_PROMPT_STUCK_RECOVERY_COOLDOWN": "30",
         }):
             config = StuckConfig.from_env()
         assert config.warning_threshold == 180
         assert config.critical_threshold == 360
-        assert config.prompt_stuck_threshold == 15
+        assert config.prompt_stuck_check_interval == 5
+        assert config.prompt_stuck_age_threshold == 15
+        assert config.prompt_stuck_recovery_cooldown == 30
         assert config.action == StuckAction.PAUSE
 
     def test_from_env_invalid_action(self) -> None:


### PR DESCRIPTION
## Summary

- Fixes slow stuck-at-prompt detection by separating check interval from age threshold
- Renames `LOOM_PROMPT_STUCK_THRESHOLD` to three distinct configuration variables
- Adds actual stuck-age tracking to record when stuck state was first detected
- Adds recovery cooldown so recovery can be re-attempted after configurable timeout
- Updates both bash (agent-wait-bg.sh) and Python (agent_monitor.py) implementations

### New Configuration Variables

| Variable | Default | Description |
|----------|---------|-------------|
| `LOOM_PROMPT_STUCK_CHECK_INTERVAL` | 10s | How often to poll for stuck state |
| `LOOM_PROMPT_STUCK_AGE_THRESHOLD` | 30s | How long stuck before detection fires |
| `LOOM_PROMPT_STUCK_RECOVERY_COOLDOWN` | 60s | Seconds before re-attempting recovery |

With defaults (check=10s, age=30s, poll=5s), detection fires within ~35-40s of becoming stuck, instead of the previous 122s delay.

### Verification Table

| Criterion | Verified | Method |
|-----------|----------|--------|
| Rename `LOOM_PROMPT_STUCK_THRESHOLD` to `LOOM_PROMPT_STUCK_CHECK_INTERVAL` | ✓ | Variable renamed in shell and Python |
| Add actual stuck-age tracking | ✓ | `prompt_stuck_since` timestamp tracks first detection |
| Detection within ~35-40s | ✓ | Logic uses check_interval + age_threshold timing |
| Reset recovery flag after configurable timeout | ✓ | `PROMPT_STUCK_RECOVERY_COOLDOWN` with timestamp tracking |
| Logging clarifies check interval vs stuck age | ✓ | Log messages now show `stuck_duration` vs `elapsed` |
| Python/bash parity maintained | ✓ | Both implementations updated with same logic |

## Test plan

- [x] shellcheck passes on agent-wait-bg.sh
- [x] Python tests pass for StuckConfig changes
- [x] Variable renames verified across codebase
- [ ] Manual testing: Start builder, simulate stuck-at-prompt, verify detection within ~35-40s

Closes #1670

🤖 Generated with [Claude Code](https://claude.com/claude-code)