### PR TITLE
Add per-phase timing to shepherd output

### DIFF
--- a/loom-tools/tests/shepherd/test_cli.py
+++ b/loom-tools/tests/shepherd/test_cli.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 import sys
+import time
 from io import StringIO
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
-from loom_tools.shepherd.cli import _create_config, _parse_args, main
-from loom_tools.shepherd.config import ExecutionMode, Phase
+from loom_tools.shepherd.cli import _create_config, _parse_args, main, orchestrate
+from loom_tools.shepherd.config import ExecutionMode, Phase, ShepherdConfig
+from loom_tools.shepherd.phases import PhaseResult, PhaseStatus
 
 
 class TestParseArgs:
@@ -141,3 +143,371 @@ class TestMain:
             with patch("loom_tools.shepherd.cli.ShepherdContext"):
                 result = main(["42"])
                 assert result == 1
+
+
+def _make_ctx(
+    *,
+    mode: ExecutionMode = ExecutionMode.FORCE_MERGE,
+    start_from: Phase | None = None,
+    stop_after: str | None = None,
+) -> MagicMock:
+    """Create a mock ShepherdContext for orchestration tests."""
+    config = ShepherdConfig(
+        issue=42,
+        mode=mode,
+        start_from=start_from,
+        stop_after=stop_after,
+        task_id="test123",
+    )
+    ctx = MagicMock()
+    ctx.config = config
+    ctx.repo_root = "/fake/repo"
+    ctx.issue_title = "Test issue"
+    ctx.pr_number = 100
+    ctx.report_milestone = MagicMock(return_value=True)
+    return ctx
+
+
+def _success_result(phase: str = "", **data: object) -> PhaseResult:
+    """Create a successful PhaseResult."""
+    return PhaseResult(status=PhaseStatus.SUCCESS, message=f"{phase} done", phase_name=phase, data=data)
+
+
+class TestPhaseTiming:
+    """Test per-phase timing in orchestrate()."""
+
+    @patch("loom_tools.shepherd.cli.MergePhase")
+    @patch("loom_tools.shepherd.cli.JudgePhase")
+    @patch("loom_tools.shepherd.cli.BuilderPhase")
+    @patch("loom_tools.shepherd.cli.ApprovalPhase")
+    @patch("loom_tools.shepherd.cli.CuratorPhase")
+    @patch("loom_tools.shepherd.cli.time")
+    def test_phase_durations_populated(
+        self,
+        mock_time: MagicMock,
+        MockCurator: MagicMock,
+        MockApproval: MagicMock,
+        MockBuilder: MagicMock,
+        MockJudge: MagicMock,
+        MockMerge: MagicMock,
+    ) -> None:
+        """Phase durations dict should be populated after orchestration."""
+        # Simulate time progression: each phase takes a known duration
+        # time.time() calls: start_time, curator_start, curator_end, approval_start, approval_end,
+        #   builder_start, builder_end, judge_start, judge_end, merge_start, merge_end, duration_calc
+        mock_time.time = MagicMock(side_effect=[
+            0,     # start_time
+            0,     # curator phase_start
+            10,    # curator elapsed (10s)
+            10,    # approval phase_start
+            15,    # approval elapsed (5s)
+            15,    # builder phase_start
+            115,   # builder elapsed (100s)
+            115,   # judge phase_start
+            165,   # judge elapsed (50s)
+            165,   # merge phase_start
+            170,   # merge elapsed (5s)
+            170,   # duration calc
+        ])
+
+        ctx = _make_ctx()
+
+        # Curator: runs normally
+        curator_inst = MockCurator.return_value
+        curator_inst.should_skip.return_value = (False, "")
+        curator_inst.run.return_value = _success_result("curator")
+
+        # Approval: success
+        MockApproval.return_value.run.return_value = _success_result("approval")
+
+        # Builder: success
+        builder_inst = MockBuilder.return_value
+        builder_inst.should_skip.return_value = (False, "")
+        builder_inst.run.return_value = _success_result("builder")
+
+        # Judge: approved
+        judge_inst = MockJudge.return_value
+        judge_inst.should_skip.return_value = (False, "")
+        judge_inst.run.return_value = _success_result("judge", approved=True)
+
+        # Merge: merged
+        MockMerge.return_value.run.return_value = _success_result("merge", merged=True)
+
+        result = orchestrate(ctx)
+        assert result == 0
+
+        # Verify phase_completed milestones were reported with timing
+        milestone_calls = [
+            c for c in ctx.report_milestone.call_args_list
+            if c[0][0] == "phase_completed"
+        ]
+        assert len(milestone_calls) == 5  # curator, approval, builder, judge, merge
+
+        # Check specific phase timing in milestone calls
+        phases_reported = {c.kwargs["phase"]: c.kwargs["duration_seconds"] for c in milestone_calls}
+        assert phases_reported["curator"] == 10
+        assert phases_reported["approval"] == 5
+        assert phases_reported["builder"] == 100
+        assert phases_reported["judge"] == 50
+        assert phases_reported["merge"] == 5
+
+    @patch("loom_tools.shepherd.cli.MergePhase")
+    @patch("loom_tools.shepherd.cli.JudgePhase")
+    @patch("loom_tools.shepherd.cli.BuilderPhase")
+    @patch("loom_tools.shepherd.cli.ApprovalPhase")
+    @patch("loom_tools.shepherd.cli.CuratorPhase")
+    @patch("loom_tools.shepherd.cli.time")
+    def test_summary_includes_duration_and_percentage(
+        self,
+        mock_time: MagicMock,
+        MockCurator: MagicMock,
+        MockApproval: MagicMock,
+        MockBuilder: MagicMock,
+        MockJudge: MagicMock,
+        MockMerge: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Final summary should include per-phase duration and percentage."""
+        mock_time.time = MagicMock(side_effect=[
+            0,     # start_time
+            0,     # curator phase_start
+            50,    # curator elapsed (50s)
+            50,    # approval phase_start
+            50,    # approval elapsed (0s)
+            50,    # builder phase_start
+            400,   # builder elapsed (350s)
+            400,   # judge phase_start
+            550,   # judge elapsed (150s)
+            550,   # merge phase_start
+            600,   # merge elapsed (50s)
+            600,   # duration calc
+        ])
+
+        ctx = _make_ctx()
+
+        curator_inst = MockCurator.return_value
+        curator_inst.should_skip.return_value = (False, "")
+        curator_inst.run.return_value = _success_result("curator")
+
+        MockApproval.return_value.run.return_value = _success_result("approval")
+
+        builder_inst = MockBuilder.return_value
+        builder_inst.should_skip.return_value = (False, "")
+        builder_inst.run.return_value = _success_result("builder")
+
+        judge_inst = MockJudge.return_value
+        judge_inst.should_skip.return_value = (False, "")
+        judge_inst.run.return_value = _success_result("judge", approved=True)
+
+        MockMerge.return_value.run.return_value = _success_result("merge", merged=True)
+
+        result = orchestrate(ctx)
+        assert result == 0
+
+        captured = capsys.readouterr()
+        # log_info writes to stderr
+        assert "Builder: 350s" in captured.err
+        assert "Judge: 150s" in captured.err
+        assert "Merge: 50s" in captured.err
+
+    @patch("loom_tools.shepherd.cli.MergePhase")
+    @patch("loom_tools.shepherd.cli.DoctorPhase")
+    @patch("loom_tools.shepherd.cli.JudgePhase")
+    @patch("loom_tools.shepherd.cli.BuilderPhase")
+    @patch("loom_tools.shepherd.cli.ApprovalPhase")
+    @patch("loom_tools.shepherd.cli.CuratorPhase")
+    @patch("loom_tools.shepherd.cli.time")
+    def test_judge_doctor_retry_accumulates_timing(
+        self,
+        mock_time: MagicMock,
+        MockCurator: MagicMock,
+        MockApproval: MagicMock,
+        MockBuilder: MagicMock,
+        MockJudge: MagicMock,
+        MockDoctor: MagicMock,
+        MockMerge: MagicMock,
+    ) -> None:
+        """Judge/Doctor retry loop should accumulate timing per attempt."""
+        # Flow: curator(skip) -> approval -> builder(skip) -> judge1(changes) -> doctor1 -> judge2(approved) -> merge
+        mock_time.time = MagicMock(side_effect=[
+            0,     # start_time
+            0,     # approval phase_start
+            5,     # approval elapsed (5s)
+            # Judge attempt 1
+            5,     # judge phase_start
+            125,   # judge elapsed (120s)
+            # Doctor attempt 1
+            125,   # doctor phase_start
+            220,   # doctor elapsed (95s)
+            # Judge attempt 2
+            220,   # judge phase_start
+            300,   # judge elapsed (80s)
+            # Merge
+            300,   # merge phase_start
+            310,   # merge elapsed (10s)
+            310,   # duration calc
+        ])
+
+        ctx = _make_ctx(start_from=Phase.BUILDER)
+
+        # Curator: skipped (start_from=builder means curator & builder skip)
+        curator_inst = MockCurator.return_value
+        curator_inst.should_skip.return_value = (True, "skipped via --from")
+
+        MockApproval.return_value.run.return_value = _success_result("approval")
+
+        builder_inst = MockBuilder.return_value
+        builder_inst.should_skip.return_value = (True, "skipped via --from")
+
+        # Judge: first attempt requests changes, second approves
+        judge_inst = MockJudge.return_value
+        judge_inst.should_skip.return_value = (False, "")
+        judge_inst.run.side_effect = [
+            _success_result("judge", changes_requested=True),
+            _success_result("judge", approved=True),
+        ]
+
+        # Doctor: applies fixes
+        MockDoctor.return_value.run.return_value = _success_result("doctor")
+
+        # Merge: success
+        MockMerge.return_value.run.return_value = _success_result("merge", merged=True)
+
+        result = orchestrate(ctx)
+        assert result == 0
+
+        # Verify milestones: should have two judge phase_completed and one doctor phase_completed
+        milestone_calls = [
+            c for c in ctx.report_milestone.call_args_list
+            if c[0][0] == "phase_completed"
+        ]
+        judge_milestones = [c for c in milestone_calls if c.kwargs["phase"] == "judge"]
+        doctor_milestones = [c for c in milestone_calls if c.kwargs["phase"] == "doctor"]
+
+        assert len(judge_milestones) == 2
+        assert judge_milestones[0].kwargs["duration_seconds"] == 120
+        assert judge_milestones[0].kwargs["status"] == "changes_requested"
+        assert judge_milestones[1].kwargs["duration_seconds"] == 80
+        assert judge_milestones[1].kwargs["status"] == "approved"
+
+        assert len(doctor_milestones) == 1
+        assert doctor_milestones[0].kwargs["duration_seconds"] == 95
+
+    @patch("loom_tools.shepherd.cli.MergePhase")
+    @patch("loom_tools.shepherd.cli.JudgePhase")
+    @patch("loom_tools.shepherd.cli.BuilderPhase")
+    @patch("loom_tools.shepherd.cli.ApprovalPhase")
+    @patch("loom_tools.shepherd.cli.CuratorPhase")
+    @patch("loom_tools.shepherd.cli.time")
+    def test_skipped_phases_not_in_timing(
+        self,
+        mock_time: MagicMock,
+        MockCurator: MagicMock,
+        MockApproval: MagicMock,
+        MockBuilder: MagicMock,
+        MockJudge: MagicMock,
+        MockMerge: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Skipped phases should not appear in timing summary."""
+        # Curator and Builder skipped via --from judge
+        mock_time.time = MagicMock(side_effect=[
+            0,     # start_time
+            0,     # approval phase_start
+            2,     # approval elapsed (2s)
+            2,     # judge phase_start
+            52,    # judge elapsed (50s)
+            52,    # merge phase_start
+            60,    # merge elapsed (8s)
+            60,    # duration calc
+        ])
+
+        ctx = _make_ctx(start_from=Phase.JUDGE)
+
+        # Curator: skipped
+        curator_inst = MockCurator.return_value
+        curator_inst.should_skip.return_value = (True, "skipped via --from")
+
+        MockApproval.return_value.run.return_value = _success_result("approval")
+
+        # Builder: skipped
+        builder_inst = MockBuilder.return_value
+        builder_inst.should_skip.return_value = (True, "skipped via --from")
+
+        # Judge: skipped (--from merge skips judge too)
+        judge_inst = MockJudge.return_value
+        judge_inst.should_skip.return_value = (False, "")
+        judge_inst.run.return_value = _success_result("judge", approved=True)
+
+        MockMerge.return_value.run.return_value = _success_result("merge", merged=True)
+
+        result = orchestrate(ctx)
+        assert result == 0
+
+        captured = capsys.readouterr()
+        # Curator and Builder should NOT appear in timing output
+        assert "Curator:" not in captured.err
+        assert "Builder:" not in captured.err
+        # Judge and Merge should appear
+        assert "Judge: 50s" in captured.err
+        assert "Merge: 8s" in captured.err
+
+    @patch("loom_tools.shepherd.cli.MergePhase")
+    @patch("loom_tools.shepherd.cli.JudgePhase")
+    @patch("loom_tools.shepherd.cli.BuilderPhase")
+    @patch("loom_tools.shepherd.cli.ApprovalPhase")
+    @patch("loom_tools.shepherd.cli.CuratorPhase")
+    @patch("loom_tools.shepherd.cli.time")
+    def test_completion_messages_include_elapsed(
+        self,
+        mock_time: MagicMock,
+        MockCurator: MagicMock,
+        MockApproval: MagicMock,
+        MockBuilder: MagicMock,
+        MockJudge: MagicMock,
+        MockMerge: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Each phase completion log should include elapsed time."""
+        mock_time.time = MagicMock(side_effect=[
+            0,     # start_time
+            0,     # curator phase_start
+            30,    # curator elapsed (30s)
+            30,    # approval phase_start
+            30,    # approval elapsed (0s)
+            30,    # builder phase_start
+            200,   # builder elapsed (170s)
+            200,   # judge phase_start
+            300,   # judge elapsed (100s)
+            300,   # merge phase_start
+            305,   # merge elapsed (5s)
+            305,   # duration calc
+        ])
+
+        ctx = _make_ctx()
+
+        curator_inst = MockCurator.return_value
+        curator_inst.should_skip.return_value = (False, "")
+        curator_inst.run.return_value = _success_result("curator")
+
+        MockApproval.return_value.run.return_value = _success_result("approval")
+
+        builder_inst = MockBuilder.return_value
+        builder_inst.should_skip.return_value = (False, "")
+        builder_inst.run.return_value = _success_result("builder")
+
+        judge_inst = MockJudge.return_value
+        judge_inst.should_skip.return_value = (False, "")
+        judge_inst.run.return_value = _success_result("judge", approved=True)
+
+        MockMerge.return_value.run.return_value = _success_result("merge", merged=True)
+
+        result = orchestrate(ctx)
+        assert result == 0
+
+        captured = capsys.readouterr()
+        # log_success/log_info write to stderr
+        assert "(30s)" in captured.err   # Curator
+        assert "(170s)" in captured.err  # Builder
+        assert "(100s)" in captured.err  # Judge
+        assert "(5s)" in captured.err    # Merge


### PR DESCRIPTION
## Summary

- Track elapsed time for each shepherd phase (Curator, Approval, Builder, Judge, Doctor, Merge)
- Display timing in phase completion messages (e.g., `Builder phase complete - PR #100 created (372s)`)
- Show per-phase breakdown with percentages in final summary
- Report `phase_completed` milestones with timing data for daemon visibility
- Accumulate Judge/Doctor retry loop timing per attempt separately
- Skipped phases correctly omitted from timing summary

Closes #1723

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|-------------|
| Each phase completion message includes elapsed time | Done | All `log_success` calls now append `({elapsed}s)` |
| Final summary includes per-phase breakdown with percentages | Done | Summary shows `- Builder: 372s (65%)` format |
| Timing data written to progress file via milestones | Done | `phase_completed` event with `duration_seconds` and `status` |

## Test Plan

- [x] Unit test: `test_phase_durations_populated` - Verifies milestone calls with correct duration per phase
- [x] Unit test: `test_summary_includes_duration_and_percentage` - Verifies summary output format
- [x] Unit test: `test_judge_doctor_retry_accumulates_timing` - Verifies retry loop tracks each attempt separately
- [x] Unit test: `test_skipped_phases_not_in_timing` - Verifies skipped phases omitted from timing
- [x] Unit test: `test_completion_messages_include_elapsed` - Verifies each log message includes `(Ns)`
- All 24 shepherd CLI tests pass, 750 total Python tests pass (4 pre-existing failures in unrelated test_agent_monitor.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)