### PR TITLE
Fix approval phase message parsing in Python shepherd output

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/cli.py
+++ b/loom-tools/src/loom_tools/shepherd/cli.py
@@ -271,7 +271,7 @@ def orchestrate(ctx: ShepherdContext) -> int:
             raise ShutdownSignal(result.message)
 
         phase_durations["Approval"] = elapsed
-        completed_phases.append(f"Approval ({result.message.split('(')[-1].rstrip(')')}")
+        completed_phases.append(f"Approval ({result.data.get('summary', result.message)})")
         if result.status == PhaseStatus.SUCCESS:
             log_success(f"{result.message} ({elapsed}s)")
             ctx.report_milestone(

--- a/loom-tools/src/loom_tools/shepherd/phases/approval.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/approval.py
@@ -32,6 +32,7 @@ class ApprovalPhase:
                 status=PhaseStatus.SUCCESS,
                 message="issue already approved (has loom:issue label)",
                 phase_name="approval",
+                data={"summary": "already approved"},
             )
 
         # In force mode, auto-approve
@@ -42,6 +43,7 @@ class ApprovalPhase:
                 status=PhaseStatus.SUCCESS,
                 message="issue auto-approved (force mode)",
                 phase_name="approval",
+                data={"summary": "force mode"},
             )
 
         # Wait for human approval
@@ -53,6 +55,7 @@ class ApprovalPhase:
                     status=PhaseStatus.SUCCESS,
                     message="issue approved by human",
                     phase_name="approval",
+                    data={"summary": "human approved"},
                 )
 
             # Check for shutdown


### PR DESCRIPTION
## Summary

- Store clean summary descriptions in `PhaseResult.data["summary"]` for each approval outcome
- Replace fragile `message.split('(')[-1].rstrip(')')` parsing with `result.data.get('summary', result.message)` 
- Add regression tests verifying both the fix and the old broken behavior

## Context

Closes #1713

The approval phase `completed_phases` entry used fragile string parsing to extract a short description from the full message. For messages like `"issue already approved (has loom:issue label)"`, the `split('(')[-1].rstrip(')')` approach produced `"Approval (has loom:issue label"` — missing the closing parenthesis. For messages without parentheses like `"issue approved by human"`, it produced the entire message without closing paren.

## Criterion Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| No malformed parentheses in output | Verified | Tests confirm `"Approval (already approved)"`, `"Approval (force mode)"`, `"Approval (human approved)"` |
| Backwards compatible when data missing | Verified | Falls back to `result.message` when no `summary` key in data |
| All existing tests pass | Verified | 120 shepherd tests pass |

## Test plan

- [x] All 24 existing CLI tests pass
- [x] All 120 shepherd tests pass (excluding pre-existing import error in test_phases.py)
- [x] 4 new regression tests added covering summary lookup, fallback, and both broken-output cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)