### PR TITLE
Add diagnostic context to builder phase failure paths

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import logging
 import subprocess
 from pathlib import Path
+from typing import Any
 
 from loom_tools.shepherd.config import Phase
 from loom_tools.shepherd.context import ShepherdContext
@@ -19,6 +21,8 @@ from loom_tools.shepherd.phases.base import (
     PhaseStatus,
     run_phase_with_retry,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class BuilderPhase:
@@ -122,11 +126,16 @@ class BuilderPhase:
                     capture=True,
                 )
                 ctx.report_milestone("worktree_created", path=str(ctx.worktree_path))
-            except subprocess.CalledProcessError:
+            except subprocess.CalledProcessError as exc:
+                detail = (exc.stderr or exc.stdout or "").strip()
+                msg = "failed to create worktree"
+                if detail:
+                    msg = f"{msg}: {detail}"
                 return PhaseResult(
                     status=PhaseStatus.FAILED,
-                    message="failed to create worktree",
+                    message=msg,
                     phase_name="builder",
+                    data={"error_detail": detail},
                 )
 
         # Create marker to prevent premature cleanup
@@ -162,25 +171,48 @@ class BuilderPhase:
                 status=PhaseStatus.STUCK,
                 message="builder stuck after retry",
                 phase_name="builder",
+                data={"log_file": str(self._get_log_path(ctx))},
+            )
+
+        if exit_code not in (0, 3, 4):
+            # Unexpected non-zero exit from builder subprocess
+            diag = self._gather_diagnostics(ctx)
+            return PhaseResult(
+                status=PhaseStatus.FAILED,
+                message=(
+                    f"builder subprocess exited with code {exit_code}: "
+                    f"{diag['summary']}"
+                ),
+                phase_name="builder",
+                data={"exit_code": exit_code, "diagnostics": diag},
             )
 
         # Validate phase
         if not self.validate(ctx):
             # Cleanup stale worktree
+            diag = self._gather_diagnostics(ctx)
             self._cleanup_stale_worktree(ctx)
             return PhaseResult(
                 status=PhaseStatus.FAILED,
-                message="builder phase validation failed",
+                message=(
+                    f"builder phase validation failed: {diag['summary']}"
+                ),
                 phase_name="builder",
+                data={"diagnostics": diag},
             )
 
         # Get PR number
         pr = get_pr_for_issue(ctx.config.issue, repo_root=ctx.repo_root)
         if pr is None:
+            diag = self._gather_diagnostics(ctx)
             return PhaseResult(
                 status=PhaseStatus.FAILED,
-                message=f"could not find PR for issue #{ctx.config.issue}",
+                message=(
+                    f"could not find PR for issue #{ctx.config.issue}: "
+                    f"{diag['summary']}"
+                ),
                 phase_name="builder",
+                data={"diagnostics": diag},
             )
 
         ctx.pr_number = pr
@@ -232,6 +264,138 @@ class BuilderPhase:
             return float(session_pct) >= ctx.config.rate_limit_threshold
         except (json.JSONDecodeError, ValueError):
             return False
+
+    def _get_log_path(self, ctx: ShepherdContext) -> Path:
+        """Return the expected builder log file path."""
+        return (
+            ctx.repo_root
+            / ".loom"
+            / "logs"
+            / f"loom-builder-issue-{ctx.config.issue}.log"
+        )
+
+    def _gather_diagnostics(self, ctx: ShepherdContext) -> dict[str, Any]:
+        """Collect diagnostic info about the builder environment.
+
+        Inspects worktree state, remote branch, issue labels, and the
+        builder log file.  The returned dict is safe to include in
+        ``PhaseResult.data`` and its ``"summary"`` key provides a
+        human-readable string for error messages.
+
+        All git/gh commands are best-effort; failures are recorded but
+        never raised.
+        """
+        diag: dict[str, Any] = {}
+
+        # -- Log file -------------------------------------------------------
+        log_path = self._get_log_path(ctx)
+        diag["log_file"] = str(log_path)
+        diag["log_exists"] = log_path.is_file()
+        if log_path.is_file():
+            try:
+                lines = log_path.read_text().splitlines()
+                diag["log_tail"] = lines[-20:] if len(lines) > 20 else lines
+            except OSError:
+                diag["log_tail"] = []
+        else:
+            diag["log_tail"] = []
+
+        # -- Worktree state --------------------------------------------------
+        wt = ctx.worktree_path
+        diag["worktree_exists"] = bool(wt and wt.is_dir())
+        if wt and wt.is_dir():
+            # Current branch
+            branch_res = subprocess.run(
+                ["git", "-C", str(wt), "rev-parse", "--abbrev-ref", "HEAD"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            diag["branch"] = (
+                branch_res.stdout.strip() if branch_res.returncode == 0 else None
+            )
+
+            # Commits ahead of main
+            log_res = subprocess.run(
+                ["git", "-C", str(wt), "log", "--oneline", "main..HEAD"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            commits = (
+                log_res.stdout.strip().splitlines()
+                if log_res.returncode == 0 and log_res.stdout.strip()
+                else []
+            )
+            diag["commits_ahead"] = len(commits)
+
+            # Uncommitted changes
+            status_res = subprocess.run(
+                ["git", "-C", str(wt), "status", "--porcelain"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            diag["has_uncommitted_changes"] = bool(
+                status_res.returncode == 0 and status_res.stdout.strip()
+            )
+        else:
+            diag["branch"] = None
+            diag["commits_ahead"] = 0
+            diag["has_uncommitted_changes"] = False
+
+        # -- Remote branch ---------------------------------------------------
+        branch_name = f"feature/issue-{ctx.config.issue}"
+        ls_res = subprocess.run(
+            ["git", "ls-remote", "--heads", "origin", branch_name],
+            cwd=ctx.repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        diag["remote_branch_exists"] = bool(
+            ls_res.returncode == 0 and ls_res.stdout.strip()
+        )
+
+        # -- Issue labels ----------------------------------------------------
+        label_res = subprocess.run(
+            [
+                "gh",
+                "issue",
+                "view",
+                str(ctx.config.issue),
+                "--json",
+                "labels",
+                "--jq",
+                "[.labels[].name] | join(\", \")",
+            ],
+            cwd=ctx.repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        diag["issue_labels"] = (
+            label_res.stdout.strip() if label_res.returncode == 0 else "unknown"
+        )
+
+        # -- Human-readable summary -----------------------------------------
+        parts: list[str] = []
+        if diag["worktree_exists"]:
+            parts.append(
+                f"worktree exists (branch={diag['branch']}, "
+                f"commits_ahead={diag['commits_ahead']}, "
+                f"uncommitted={diag['has_uncommitted_changes']})"
+            )
+        else:
+            parts.append("worktree does not exist")
+        parts.append(
+            f"remote branch {'exists' if diag['remote_branch_exists'] else 'missing'}"
+        )
+        parts.append(f"labels=[{diag['issue_labels']}]")
+        parts.append(f"log={diag['log_file']}")
+        diag["summary"] = "; ".join(parts)
+
+        return diag
 
     def _create_worktree_marker(self, ctx: ShepherdContext) -> None:
         """Create marker file to prevent premature cleanup."""

--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -130,6 +130,298 @@ class TestBuilderPhase:
 
         assert skip is False
 
+    def test_worktree_failure_includes_error_detail(self, mock_context: MagicMock) -> None:
+        """Worktree creation failure should include subprocess error output."""
+        mock_context.check_shutdown.return_value = False
+        wt_mock = MagicMock()
+        wt_mock.is_dir.return_value = False
+        wt_mock.__bool__ = lambda self: True
+        mock_context.worktree_path = wt_mock
+
+        exc = subprocess.CalledProcessError(1, "worktree.sh")
+        exc.stderr = "fatal: branch already exists"
+        exc.stdout = ""
+        mock_context.run_script.side_effect = exc
+
+        builder = BuilderPhase()
+
+        with (
+            patch("loom_tools.shepherd.phases.builder.get_pr_for_issue", return_value=None),
+            patch("loom_tools.shepherd.phases.builder.remove_issue_label"),
+            patch("loom_tools.shepherd.phases.builder.add_issue_label"),
+        ):
+            result = builder.run(mock_context)
+
+        assert result.status == PhaseStatus.FAILED
+        assert "failed to create worktree" in result.message
+        assert "branch already exists" in result.message
+        assert result.data.get("error_detail") == "fatal: branch already exists"
+
+    def test_worktree_failure_minimal_when_no_output(self, mock_context: MagicMock) -> None:
+        """Worktree creation failure with no subprocess output stays concise."""
+        mock_context.check_shutdown.return_value = False
+        wt_mock = MagicMock()
+        wt_mock.is_dir.return_value = False
+        wt_mock.__bool__ = lambda self: True
+        mock_context.worktree_path = wt_mock
+
+        exc = subprocess.CalledProcessError(1, "worktree.sh")
+        exc.stderr = ""
+        exc.stdout = ""
+        mock_context.run_script.side_effect = exc
+
+        builder = BuilderPhase()
+
+        with (
+            patch("loom_tools.shepherd.phases.builder.get_pr_for_issue", return_value=None),
+            patch("loom_tools.shepherd.phases.builder.remove_issue_label"),
+            patch("loom_tools.shepherd.phases.builder.add_issue_label"),
+        ):
+            result = builder.run(mock_context)
+
+        assert result.status == PhaseStatus.FAILED
+        assert result.message == "failed to create worktree"
+        assert result.data.get("error_detail") == ""
+
+    def test_pr_not_found_includes_diagnostics(self, mock_context: MagicMock) -> None:
+        """PR-not-found failure should include diagnostic context."""
+        mock_context.check_shutdown.return_value = False
+        wt_mock = MagicMock()
+        wt_mock.is_dir.return_value = True
+        wt_mock.__bool__ = lambda self: True
+        mock_context.worktree_path = wt_mock
+
+        builder = BuilderPhase()
+        fake_diag = {
+            "summary": "worktree exists (branch=feature/issue-42, commits_ahead=2, uncommitted=False); remote branch exists; labels=[loom:building]; log=/fake/log",
+            "worktree_exists": True,
+        }
+
+        with (
+            patch("loom_tools.shepherd.phases.builder.get_pr_for_issue", side_effect=[None, None, None]),
+            patch("loom_tools.shepherd.phases.builder.remove_issue_label"),
+            patch("loom_tools.shepherd.phases.builder.add_issue_label"),
+            patch("loom_tools.shepherd.phases.builder.run_phase_with_retry", return_value=0),
+            patch.object(builder, "validate", return_value=True),
+            patch.object(builder, "_gather_diagnostics", return_value=fake_diag),
+            patch.object(builder, "_create_worktree_marker"),
+        ):
+            result = builder.run(mock_context)
+
+        assert result.status == PhaseStatus.FAILED
+        assert "could not find PR for issue #42" in result.message
+        assert "worktree exists" in result.message
+        assert result.data.get("diagnostics") == fake_diag
+
+    def test_validation_failure_includes_diagnostics(self, mock_context: MagicMock) -> None:
+        """Validation failure should include diagnostic context."""
+        mock_context.check_shutdown.return_value = False
+        wt_mock = MagicMock()
+        wt_mock.is_dir.return_value = True
+        wt_mock.__bool__ = lambda self: True
+        mock_context.worktree_path = wt_mock
+
+        builder = BuilderPhase()
+        fake_diag = {
+            "summary": "worktree does not exist; remote branch missing; labels=[loom:building]; log=/fake/log",
+        }
+
+        with (
+            patch("loom_tools.shepherd.phases.builder.get_pr_for_issue", return_value=None),
+            patch("loom_tools.shepherd.phases.builder.remove_issue_label"),
+            patch("loom_tools.shepherd.phases.builder.add_issue_label"),
+            patch("loom_tools.shepherd.phases.builder.run_phase_with_retry", return_value=0),
+            patch.object(builder, "validate", return_value=False),
+            patch.object(builder, "_gather_diagnostics", return_value=fake_diag),
+            patch.object(builder, "_create_worktree_marker"),
+            patch.object(builder, "_cleanup_stale_worktree"),
+        ):
+            result = builder.run(mock_context)
+
+        assert result.status == PhaseStatus.FAILED
+        assert "builder phase validation failed" in result.message
+        assert "worktree does not exist" in result.message
+        assert result.data.get("diagnostics") == fake_diag
+
+    def test_unexpected_exit_code_includes_diagnostics(self, mock_context: MagicMock) -> None:
+        """Non-zero/non-special exit codes should include diagnostics."""
+        mock_context.check_shutdown.return_value = False
+        wt_mock = MagicMock()
+        wt_mock.is_dir.return_value = True
+        wt_mock.__bool__ = lambda self: True
+        mock_context.worktree_path = wt_mock
+
+        builder = BuilderPhase()
+        fake_diag = {"summary": "worktree exists; remote branch exists; labels=[loom:building]; log=/fake/log"}
+
+        with (
+            patch("loom_tools.shepherd.phases.builder.get_pr_for_issue", return_value=None),
+            patch("loom_tools.shepherd.phases.builder.remove_issue_label"),
+            patch("loom_tools.shepherd.phases.builder.add_issue_label"),
+            patch("loom_tools.shepherd.phases.builder.run_phase_with_retry", return_value=1),
+            patch.object(builder, "_gather_diagnostics", return_value=fake_diag),
+            patch.object(builder, "_create_worktree_marker"),
+        ):
+            result = builder.run(mock_context)
+
+        assert result.status == PhaseStatus.FAILED
+        assert "exited with code 1" in result.message
+        assert result.data.get("exit_code") == 1
+        assert result.data.get("diagnostics") == fake_diag
+
+    def test_stuck_builder_includes_log_path(self, mock_context: MagicMock) -> None:
+        """Builder stuck (exit 4) should include log file path in data."""
+        mock_context.check_shutdown.return_value = False
+        wt_mock = MagicMock()
+        wt_mock.is_dir.return_value = True
+        wt_mock.__bool__ = lambda self: True
+        mock_context.worktree_path = wt_mock
+
+        builder = BuilderPhase()
+
+        with (
+            patch("loom_tools.shepherd.phases.builder.get_pr_for_issue", return_value=None),
+            patch("loom_tools.shepherd.phases.builder.remove_issue_label"),
+            patch("loom_tools.shepherd.phases.builder.add_issue_label"),
+            patch("loom_tools.shepherd.phases.builder.run_phase_with_retry", return_value=4),
+            patch.object(builder, "_mark_issue_blocked"),
+            patch.object(builder, "_create_worktree_marker"),
+        ):
+            result = builder.run(mock_context)
+
+        assert result.status == PhaseStatus.STUCK
+        assert "log_file" in result.data
+        assert "loom-builder-issue-42.log" in result.data["log_file"]
+
+
+class TestBuilderDiagnostics:
+    """Test BuilderPhase._gather_diagnostics helper."""
+
+    def test_diagnostics_when_worktree_exists(self, mock_context: MagicMock, tmp_path: Path) -> None:
+        """Should report worktree state when worktree directory exists."""
+        # Create a real worktree dir so is_dir() works
+        wt_dir = tmp_path / "worktree"
+        wt_dir.mkdir()
+        mock_context.worktree_path = wt_dir
+        mock_context.config = ShepherdConfig(issue=42)
+        mock_context.repo_root = tmp_path
+
+        # Create a log file
+        log_dir = tmp_path / ".loom" / "logs"
+        log_dir.mkdir(parents=True)
+        log_file = log_dir / "loom-builder-issue-42.log"
+        log_file.write_text("line1\nline2\nline3\n")
+
+        builder = BuilderPhase()
+
+        # Mock git and gh subprocess calls
+        def fake_run(cmd, **kwargs):
+            cmd_str = " ".join(str(c) for c in cmd)
+            result = subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+            if "rev-parse" in cmd_str:
+                result.stdout = "feature/issue-42\n"
+            elif "log" in cmd_str and "main..HEAD" in cmd_str:
+                result.stdout = "abc1234 commit 1\ndef5678 commit 2\n"
+            elif "status --porcelain" in cmd_str:
+                result.stdout = ""
+            elif "ls-remote" in cmd_str:
+                result.stdout = "abc123\trefs/heads/feature/issue-42\n"
+            elif "gh" in cmd_str:
+                result.stdout = "loom:building"
+            return result
+
+        with patch("loom_tools.shepherd.phases.builder.subprocess.run", side_effect=fake_run):
+            diag = builder._gather_diagnostics(mock_context)
+
+        assert diag["worktree_exists"] is True
+        assert diag["branch"] == "feature/issue-42"
+        assert diag["commits_ahead"] == 2
+        assert diag["has_uncommitted_changes"] is False
+        assert diag["remote_branch_exists"] is True
+        assert diag["log_exists"] is True
+        assert diag["log_tail"] == ["line1", "line2", "line3"]
+        assert "worktree exists" in diag["summary"]
+        assert "remote branch exists" in diag["summary"]
+
+    def test_diagnostics_when_worktree_missing(self, mock_context: MagicMock, tmp_path: Path) -> None:
+        """Should report worktree missing when directory doesn't exist."""
+        mock_context.worktree_path = tmp_path / "nonexistent"
+        mock_context.config = ShepherdConfig(issue=99)
+        mock_context.repo_root = tmp_path
+
+        builder = BuilderPhase()
+
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(args=cmd, returncode=1, stdout="", stderr="")
+
+        with patch("loom_tools.shepherd.phases.builder.subprocess.run", side_effect=fake_run):
+            diag = builder._gather_diagnostics(mock_context)
+
+        assert diag["worktree_exists"] is False
+        assert diag["branch"] is None
+        assert diag["commits_ahead"] == 0
+        assert diag["has_uncommitted_changes"] is False
+        assert diag["remote_branch_exists"] is False
+        assert diag["log_exists"] is False
+        assert "worktree does not exist" in diag["summary"]
+        assert "remote branch missing" in diag["summary"]
+
+    def test_diagnostics_log_tail_truncated(self, mock_context: MagicMock, tmp_path: Path) -> None:
+        """Should include only last 20 lines of log when file is large."""
+        mock_context.worktree_path = tmp_path / "nonexistent"
+        mock_context.config = ShepherdConfig(issue=42)
+        mock_context.repo_root = tmp_path
+
+        log_dir = tmp_path / ".loom" / "logs"
+        log_dir.mkdir(parents=True)
+        log_file = log_dir / "loom-builder-issue-42.log"
+        lines = [f"line {i}" for i in range(50)]
+        log_file.write_text("\n".join(lines))
+
+        builder = BuilderPhase()
+
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(args=cmd, returncode=1, stdout="", stderr="")
+
+        with patch("loom_tools.shepherd.phases.builder.subprocess.run", side_effect=fake_run):
+            diag = builder._gather_diagnostics(mock_context)
+
+        assert len(diag["log_tail"]) == 20
+        assert diag["log_tail"][0] == "line 30"
+        assert diag["log_tail"][-1] == "line 49"
+
+    def test_get_log_path(self, mock_context: MagicMock) -> None:
+        """Should return correct log path based on issue number."""
+        builder = BuilderPhase()
+        path = builder._get_log_path(mock_context)
+        assert path == Path("/fake/repo/.loom/logs/loom-builder-issue-42.log")
+
+    def test_diagnostics_summary_format(self, mock_context: MagicMock, tmp_path: Path) -> None:
+        """Summary should contain all key diagnostic sections."""
+        mock_context.worktree_path = tmp_path / "nonexistent"
+        mock_context.config = ShepherdConfig(issue=42)
+        mock_context.repo_root = tmp_path
+
+        builder = BuilderPhase()
+
+        def fake_run(cmd, **kwargs):
+            cmd_str = " ".join(str(c) for c in cmd)
+            if "gh" in cmd_str:
+                return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="loom:building, loom:curated", stderr="")
+            return subprocess.CompletedProcess(args=cmd, returncode=1, stdout="", stderr="")
+
+        with patch("loom_tools.shepherd.phases.builder.subprocess.run", side_effect=fake_run):
+            diag = builder._gather_diagnostics(mock_context)
+
+        summary = diag["summary"]
+        # Should have 4 semicolon-separated sections
+        parts = summary.split("; ")
+        assert len(parts) == 4
+        assert "worktree" in parts[0]
+        assert "remote branch" in parts[1]
+        assert "labels=" in parts[2]
+        assert "log=" in parts[3]
+
 
 class TestJudgePhase:
     """Test JudgePhase."""


### PR DESCRIPTION
## Summary
- Adds `_gather_diagnostics()` helper to `BuilderPhase` that collects worktree state, remote branch status, issue labels, log file path, and last 20 lines of builder output
- Enriches **worktree creation failure** to include the subprocess error output (e.g., "branch already exists")
- Enriches **PR-not-found failure** with full diagnostic context (worktree state, remote branch, labels, log path)
- Enriches **validation failure** with the same diagnostic context
- Adds new handling for **unexpected non-zero exit codes** from builder subprocess with diagnostics
- Adds **log file path** to the builder-stuck (exit 4) `PhaseResult.data`
- All diagnostics are best-effort (git/gh failures are captured, never raised)

## Test plan
- [x] 11 new unit tests covering all enriched failure paths and the diagnostics helper
- [x] Worktree creation failure includes underlying error detail
- [x] Worktree creation failure with no output stays concise
- [x] PR-not-found includes diagnostic summary
- [x] Validation failure includes diagnostic summary
- [x] Unexpected exit codes include exit code and diagnostics
- [x] Builder stuck includes log file path
- [x] `_gather_diagnostics()` reports worktree state when dir exists
- [x] `_gather_diagnostics()` reports missing when dir absent
- [x] Log tail truncated to last 20 lines
- [x] Summary has correct 4-section format
- [x] `_get_log_path()` returns correct path
- [x] All 42 phase tests pass, full suite (856 tests) passes

Closes #1737

🤖 Generated with [Claude Code](https://claude.com/claude-code)