### PR TITLE
Fix gh-cached invalidation for pr/issue view commands

### DIFF
--- a/defaults/scripts/gh-cached
+++ b/defaults/scripts/gh-cached
@@ -131,7 +131,7 @@ def cache_get(key: str) -> tuple[str | None, int | None]:
         return None, None
 
 
-def cache_put(key: str, stdout: str, returncode: int, ttl: int) -> None:
+def cache_put(key: str, stdout: str, returncode: int, ttl: int, args: list[str] | None = None) -> None:
     """Write a cache entry."""
     ensure_cache_dir()
     enforce_max_size()
@@ -141,6 +141,7 @@ def cache_put(key: str, stdout: str, returncode: int, ttl: int) -> None:
         "ttl": ttl,
         "stdout": stdout,
         "returncode": returncode,
+        "args": args or [],
     }
     path = cache_path(key)
     try:
@@ -183,7 +184,9 @@ def invalidate_for_resource(resource_type: str, resource_id: str | None) -> None
     """Invalidate cached entries related to a resource.
 
     After a mutation like `gh issue edit 42 ...`, we invalidate any cached
-    entries whose command args contain the resource type and id.
+    entries whose original command args reference the same resource type and id.
+    Falls back to checking stdout for backward compatibility with cache entries
+    that predate the args field.
     """
     if not resource_id:
         return
@@ -198,13 +201,18 @@ def invalidate_for_resource(resource_type: str, resource_id: str | None) -> None
             try:
                 with open(path) as f:
                     data = json.load(f)
+                args = data.get("args", [])
+                # Primary: check if the cached command's args reference this resource
+                if args and resource_type in args and resource_id in args:
+                    debug(f"INVALIDATE (args match) {name}")
+                    os.unlink(path)
+                    count += 1
+                    continue
+                # Fallback: check stdout for backward compatibility with
+                # cache entries that don't have stored args
                 stdout = data.get("stdout", "")
-                # Heuristic: if the cached output mentions this resource,
-                # or if the cache key was derived from a command referencing it,
-                # invalidate it. Since we can't reconstruct the original args
-                # from the hash, we take the conservative approach of invalidating
-                # entries that contain the resource id in their output.
                 if resource_id in stdout:
+                    debug(f"INVALIDATE (stdout match) {name}")
                     os.unlink(path)
                     count += 1
             except (json.JSONDecodeError, OSError):
@@ -402,7 +410,7 @@ def main() -> int:
 
     # Only cache successful responses
     if rc == 0:
-        cache_put(key, stdout, rc, parsed["ttl"])
+        cache_put(key, stdout, rc, parsed["ttl"], args=args)
 
     increment_stat("misses")
     return rc


### PR DESCRIPTION
Closes #1740

## Summary

- Store original command args in cache entries alongside stdout and metadata
- Update `invalidate_for_resource` to match against stored args (primary) with stdout fallback for backward compatibility
- Pass args through from `main()` to `cache_put()` on cache miss

## Problem

After a mutation like `gh pr edit 1729 --add-label "loom:pr"`, the invalidation logic searched for `"1729"` in cached stdout. But `gh pr view 1729 --json labels` outputs `{"labels":[{"name":"loom:pr"}]}` — which doesn't contain `"1729"`. The cache entry survived invalidation, returning stale data on next read.

This caused shepherd issue #1721 to fail at judge phase validation — the Judge correctly added `loom:pr` but the validation script got stale cached data without it.

## Solution

Store the original command args (`["pr", "view", "1729", "--json", "labels"]`) in each cache entry. During invalidation, check if both `resource_type` and `resource_id` appear in the stored args. Falls back to the old stdout-scanning heuristic for backward compatibility with pre-existing cache entries that lack the `args` field.

## Criterion Verification

| Criterion | Status | Verification |
|-----------|--------|-------------|
| Args stored in cache entries | Pass | `cache_put` now accepts and stores `args` parameter |
| Invalidation matches by args | Pass | `invalidate_for_resource` checks `resource_type in args and resource_id in args` |
| Backward-compatible stdout fallback | Pass | Old entries without `args` field still invalidated via stdout scan |
| Unrelated entries preserved | Pass | Entries for different resources are not affected |
| No breaking changes | Pass | `args` parameter is optional with default `None` |

## Test plan

- [x] Verified cache_put stores args in entry JSON
- [x] Verified invalidation works via args match (the exact bug scenario)
- [x] Verified stdout fallback works for old-format entries without args
- [x] Verified unrelated entries are not invalidated
- [x] Verified list entries with resource ID in stdout still invalidated
- [x] Verified backward compat: cache_put without args defaults to empty list
- [x] Python syntax validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)