### PR TITLE
Clear current_phase on shepherd completion milestone

### DIFF
--- a/defaults/scripts/report-milestone.sh
+++ b/defaults/scripts/report-milestone.sh
@@ -254,7 +254,7 @@ add_milestone() {
         --arg event "$event" \
         '.milestones += [$milestone] | .last_heartbeat = $timestamp |
          if $event == "phase_entered" then .current_phase = $milestone.data.phase
-         elif $event == "completed" then .status = "completed"
+         elif $event == "completed" then .status = "completed" | .current_phase = null
          elif $event == "blocked" then .status = "blocked"
          elif $event == "error" then .status = (if $milestone.data.will_retry then "retrying" else "errored" end)
          else . end')


### PR DESCRIPTION
## Summary

When a shepherd reports a `completed` milestone via `report-milestone.sh`, the progress file's `current_phase` field was left showing the last active phase (e.g. `"judge"`). This was misleading when reading the progress file, even though `status: "completed"` correctly indicated completion.

Now `current_phase` is set to `null` when the `completed` event is recorded.

Closes #1726

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `current_phase` is null when `status` is `completed` | ✅ | Tested: `report-milestone.sh completed` sets `current_phase: null` |
| Existing tests still pass | ✅ | All 160 shepherd tests pass |

## Test Results

Manual testing of `report-milestone.sh`:
- `phase_entered` → correctly sets `current_phase` to phase name ✅
- `completed` → sets `current_phase` to `null` ✅
- `blocked` → preserves `current_phase` (unchanged) ✅
- `error` → preserves `current_phase` (unchanged) ✅

Shepherd test suite: 160/160 passed ✅

## Changes

Single line change in `defaults/scripts/report-milestone.sh`:
```diff
- elif $event == "completed" then .status = "completed"
+ elif $event == "completed" then .status = "completed" | .current_phase = null
```