### PR TITLE
Fix stale cleanup.sh references in package.json and README

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "check:ci": "pnpm lint && pnpm format:rust && pnpm clippy:locked && pnpm check && pnpm build && pnpm test && pnpm test:unit:coverage",
     "worktree": "./scripts/worktree.sh",
     "worktree:return": "./.loom/scripts/worktree-return.sh",
-    "clean": "./scripts/cleanup.sh",
-    "clean:full": "./scripts/cleanup.sh && pnpm install",
+    "clean": "./clean.sh",
+    "clean:full": "./clean.sh && pnpm install",
     "prepare": "husky"
   },
   "repository": {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -137,17 +137,29 @@ The stop script handles this automatically by checking if the PID is still alive
 
 ## Maintenance Scripts
 
-### cleanup.sh
-**Removes build artifacts and orphaned worktrees**
+### clean.sh / loom-clean
+**Unified cleanup for stale worktrees, branches, and build artifacts**
 
 Cleans up:
-- `target/` - Rust build artifacts
-- `node_modules/` - Node dependencies
-- Orphaned git worktrees (with confirmation)
+- Stale git worktrees (for closed/merged issues)
+- Merged local feature branches
+- Loom tmux sessions
+- Build artifacts (`target/`, `node_modules/`) with `--deep`
+
+Flags:
+- `--force` — Non-interactive mode (auto-confirm all prompts)
+- `--deep` — Include build artifacts (target/, node_modules/)
+- `--dry-run` — Show what would be cleaned without making changes
+- `--safe` — Only remove worktrees with merged PRs
 
 Usage:
 ```bash
-./scripts/cleanup.sh
+./clean.sh                  # Interactive standard cleanup
+./clean.sh --force          # Non-interactive cleanup
+./clean.sh --deep           # Include build artifacts
+./clean.sh --dry-run        # Preview only
+./clean.sh --safe --force   # Safe mode, non-interactive
+loom-clean                  # Direct invocation (requires loom-tools venv)
 ```
 
 ### cleanup-branches.sh


### PR DESCRIPTION
## Summary

- Updated `package.json` clean/clean:full scripts from `./scripts/cleanup.sh` (non-existent) to `./clean.sh` (the root wrapper)
- Updated `scripts/README.md` to document `clean.sh`/`loom-clean` with current flags (`--force`, `--deep`, `--dry-run`, `--safe`)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `pnpm run clean` executes successfully | Verified | Script path resolves to `./clean.sh` which exists and delegates to `loom-clean` |
| `pnpm run clean:full` executes `./clean.sh && pnpm install` | Verified | Path updated, `&& pnpm install` chain preserved |
| `scripts/README.md` no longer references non-existent `cleanup.sh` | Verified | `grep scripts/cleanup.sh` returns no matches |
| README documents `clean.sh`/`loom-clean` with current flags | Verified | Section documents `--force`, `--deep`, `--dry-run`, `--safe` with usage examples |
| No other files reference non-existent `scripts/cleanup.sh` | Verified | Repo-wide grep confirms zero references |

## Test Plan

- [x] Verify `package.json` JSON is valid
- [x] Verify no remaining references to `scripts/cleanup.sh`
- [x] Verify `scripts/README.md` accurately documents current cleanup tooling

Closes #1762

🤖 Generated with [Claude Code](https://claude.com/claude-code)