### PR TITLE
Print skipped PHASE 5: DOCTOR header when Judge approves first try

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/cli.py
+++ b/loom-tools/src/loom_tools/shepherd/cli.py
@@ -398,6 +398,11 @@ def orchestrate(ctx: ShepherdContext) -> int:
                 log_error(result.message)
                 return 1
 
+        # Print skipped header if Doctor never ran (Judge approved first try)
+        if doctor_attempts == 0 and not skip:
+            _print_phase_header("PHASE 5: DOCTOR (skipped - no changes requested)")
+            completed_phases.append("Doctor (skipped)")
+
         if judge_total_elapsed > 0:
             phase_durations["Judge"] = judge_total_elapsed
         if doctor_total_elapsed > 0:


### PR DESCRIPTION
## Summary

- When Judge approves PR without requesting changes, print `PHASE 5: DOCTOR (skipped - no changes requested)` to maintain sequential phase numbering (1→2→3→4→5→6) in shepherd output
- Adds 3 tests covering: skipped header on first-try approval, no skipped header when Doctor runs, no skipped header when Judge itself was skipped

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|-------------|
| Judge approves → shows PHASE 5 skipped header | Verified | `test_doctor_skipped_header_when_judge_approves_first_try` |
| Judge requests changes → Doctor shows attempt header | Verified | `test_no_skipped_header_when_doctor_runs` |
| Phase numbering remains sequential 1-6 | Verified | All code paths produce sequential headers |

## Test plan

- [x] New test: Doctor skipped header appears when Judge approves first try
- [x] New test: Doctor attempt header (not skipped) appears when Judge requests changes
- [x] New test: No Doctor header when Judge itself is skipped (--from merge)
- [x] Existing tests pass: 186 tests in `tests/shepherd/` all green

Closes #1767

🤖 Generated with [Claude Code](https://claude.com/claude-code)