### PR TITLE
Fix biome lint errors across quickstarts and src/lib

### DIFF
--- a/quickstarts/desktop/src/pages/SettingsPage.tsx
+++ b/quickstarts/desktop/src/pages/SettingsPage.tsx
@@ -45,11 +45,16 @@ export function SettingsPage() {
           </CardHeader>
           <CardContent className="space-y-4">
             <div>
-              <label className="text-sm font-medium">Theme</label>
+              <label className="text-sm font-medium" htmlFor="theme-selector">
+                Theme
+              </label>
               <p className="text-sm text-muted-foreground mb-3">
                 Select your preferred color scheme
               </p>
-              <div className="flex gap-2">
+              <fieldset
+                id="theme-selector"
+                className="flex gap-2 border-0 p-0 m-0"
+              >
                 <Button
                   variant={theme === "light" ? "default" : "outline"}
                   onClick={() => setTheme("light")}
@@ -68,7 +73,7 @@ export function SettingsPage() {
                 >
                   System
                 </Button>
-              </div>
+              </fieldset>
               <p className="mt-2 text-xs text-muted-foreground">
                 Currently using: {resolvedTheme} mode
               </p>
@@ -85,12 +90,17 @@ export function SettingsPage() {
           </CardHeader>
           <CardContent className="space-y-4">
             <div>
-              <label className="text-sm font-medium">App Data Directory</label>
+              <label className="text-sm font-medium" htmlFor="app-data-dir">
+                App Data Directory
+              </label>
               <p className="text-sm text-muted-foreground mb-2">
                 SQLite database and application settings
               </p>
               <div className="flex gap-2">
-                <code className="flex-1 rounded-md bg-muted px-3 py-2 text-sm font-mono overflow-x-auto">
+                <code
+                  id="app-data-dir"
+                  className="flex-1 rounded-md bg-muted px-3 py-2 text-sm font-mono overflow-x-auto"
+                >
                   {appDataDir || "Loading..."}
                 </code>
                 <Button

--- a/quickstarts/webapp/functions/api/[[route]].ts
+++ b/quickstarts/webapp/functions/api/[[route]].ts
@@ -23,12 +23,6 @@ interface Project {
   updated_at: string;
 }
 
-interface Session {
-  id: string;
-  user_id: string;
-  expires_at: string;
-}
-
 // Session configuration
 const SESSION_COOKIE_NAME = "loom-session";
 const SESSION_DURATION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days

--- a/quickstarts/webapp/src/components/ui/toaster.tsx
+++ b/quickstarts/webapp/src/components/ui/toaster.tsx
@@ -62,7 +62,14 @@ export function Toaster({ children }: { children?: React.ReactNode }) {
             </div>
             <Toast.Close className="absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100">
               <span className="sr-only">Close</span>
-              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <svg
+                className="h-4 w-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                aria-label="Close"
+                role="img"
+              >
                 <path
                   strokeLinecap="round"
                   strokeLinejoin="round"

--- a/quickstarts/webapp/src/pages/DashboardPage.tsx
+++ b/quickstarts/webapp/src/pages/DashboardPage.tsx
@@ -25,6 +25,7 @@ export function DashboardPage() {
               strokeWidth="2"
               className="h-4 w-4 text-muted-foreground"
             >
+              <title>Total Projects</title>
               <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
               <circle cx="9" cy="7" r="4" />
               <path d="M22 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75" />
@@ -48,6 +49,7 @@ export function DashboardPage() {
               strokeWidth="2"
               className="h-4 w-4 text-muted-foreground"
             >
+              <title>Active Tasks</title>
               <rect width="20" height="14" x="2" y="5" rx="2" />
               <path d="M2 10h20" />
             </svg>
@@ -70,6 +72,7 @@ export function DashboardPage() {
               strokeWidth="2"
               className="h-4 w-4 text-muted-foreground"
             >
+              <title>Completed</title>
               <path d="M22 12h-4l-3 9L9 3l-3 9H2" />
             </svg>
           </CardHeader>
@@ -91,6 +94,7 @@ export function DashboardPage() {
               strokeWidth="2"
               className="h-4 w-4 text-muted-foreground"
             >
+              <title>Uptime</title>
               <path d="M12 2v20M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
             </svg>
           </CardHeader>
@@ -114,8 +118,8 @@ export function DashboardPage() {
                 { action: "Deployed to production", time: "4 hours ago" },
                 { action: "Updated database schema", time: "Yesterday" },
                 { action: "Added new team member", time: "2 days ago" },
-              ].map((item, i) => (
-                <div key={i} className="flex items-center">
+              ].map((item) => (
+                <div key={item.action} className="flex items-center">
                   <div className="h-2 w-2 rounded-full bg-primary mr-3" />
                   <div className="flex-1">
                     <p className="text-sm font-medium">{item.action}</p>
@@ -132,16 +136,28 @@ export function DashboardPage() {
             <CardDescription>Common tasks and shortcuts</CardDescription>
           </CardHeader>
           <CardContent className="space-y-2">
-            <button className="w-full text-left px-4 py-2 rounded-md hover:bg-accent transition-colors">
+            <button
+              type="button"
+              className="w-full text-left px-4 py-2 rounded-md hover:bg-accent transition-colors"
+            >
               Create new project
             </button>
-            <button className="w-full text-left px-4 py-2 rounded-md hover:bg-accent transition-colors">
+            <button
+              type="button"
+              className="w-full text-left px-4 py-2 rounded-md hover:bg-accent transition-colors"
+            >
               Deploy changes
             </button>
-            <button className="w-full text-left px-4 py-2 rounded-md hover:bg-accent transition-colors">
+            <button
+              type="button"
+              className="w-full text-left px-4 py-2 rounded-md hover:bg-accent transition-colors"
+            >
               View analytics
             </button>
-            <button className="w-full text-left px-4 py-2 rounded-md hover:bg-accent transition-colors">
+            <button
+              type="button"
+              className="w-full text-left px-4 py-2 rounded-md hover:bg-accent transition-colors"
+            >
               Manage team
             </button>
           </CardContent>

--- a/src/lib/comparative-analysis-modal.ts
+++ b/src/lib/comparative-analysis-modal.ts
@@ -925,7 +925,10 @@ function setupCreateEventHandlers(modal: ModalBuilder, workspacePath: string): v
     if (container) {
       const newVariant = document.createElement("div");
       newVariant.innerHTML = createVariantInput(variantCount, `Variant ${variantCount + 1}`, "");
-      container.appendChild(newVariant.firstElementChild!);
+      const firstChild = newVariant.firstElementChild;
+      if (firstChild) {
+        container.appendChild(firstChild);
+      }
       variantCount++;
 
       // Add remove handler for the new variant

--- a/src/lib/terminal-manager.test.ts
+++ b/src/lib/terminal-manager.test.ts
@@ -60,7 +60,6 @@ let nextFitDimensions = { cols: 80, rows: 24 };
 
 vi.mock("@xterm/xterm", () => {
   // Create a proper constructor function that can be called with `new`
-  // biome-ignore lint/complexity/useArrowFunction: Must use function for constructor behavior
   const MockTerminal = function (this: typeof mockTerminalInstance) {
     Object.assign(this, mockTerminalInstance);
     return this;


### PR DESCRIPTION
## Summary

- Fix all 13 biome lint errors and 2 warnings across 6 files in `quickstarts/` and `src/lib/`
- Errors include missing label-control associations, SVGs without titles, missing button types, unused interfaces, array index keys, non-null assertions, and stale suppression comments

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `pnpm check:ci` passes with 0 biome errors | Verified | `pnpm biome check .` returns 0 errors (4 pre-existing info-level schema version messages only) |
| No new biome errors or warnings introduced | Verified | All changes reduce error count, no new diagnostics |
| SVG titles match their contextual card titles | Verified | "Total Projects", "Active Tasks", "Completed", "Uptime" match CardTitle text |
| Button types explicitly set to "button" | Verified | All 4 quick action buttons have `type="button"` |
| Labels properly associated with controls | Verified | `htmlFor`/`id` pairs for theme selector and app data directory |
| Unused Session interface removed | Verified | Interface removed from `[[route]].ts` |

## Files Changed (6)

- `quickstarts/desktop/src/pages/SettingsPage.tsx` — label accessibility, fieldset for theme group
- `quickstarts/webapp/functions/api/[[route]].ts` — remove unused Session interface
- `quickstarts/webapp/src/components/ui/toaster.tsx` — SVG accessibility for close button
- `quickstarts/webapp/src/pages/DashboardPage.tsx` — SVG titles, button types, stable keys
- `src/lib/comparative-analysis-modal.ts` — null check instead of non-null assertion
- `src/lib/terminal-manager.test.ts` — remove unused biome-ignore suppression

## Test plan

- [x] `pnpm biome check .` — 0 errors
- [x] `pnpm vitest run src/lib/terminal-manager.test.ts` — 59/59 tests pass
- [x] Pre-commit hooks (lint-staged + biome) pass

Closes #1773

🤖 Generated with [Claude Code](https://claude.com/claude-code)