### PR TITLE
Guide: maintain README, WORK_LOG, and WORK_PLAN at repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ Thumbs.db
 .loom/status/
 .loom/progress/
 .loom/diagnostics/
+.loom/guide-docs-state.json
 
 # Loom workspace config (DO commit for team sharing)
 # - config.json: Persistent terminal configurations (roles, themes, intervals)

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -1,0 +1,7 @@
+# Work Log
+
+Chronological record of completed work in this repository, maintained by the Guide role.
+
+Entries are grouped by date, newest first. Each entry references the merged PR or closed issue.
+
+<!-- Maintained automatically by the Guide triage agent. Manual edits are fine but may be overwritten. -->

--- a/WORK_PLAN.md
+++ b/WORK_PLAN.md
@@ -1,0 +1,29 @@
+# Work Plan
+
+Prioritized roadmap of upcoming work, maintained by the Guide role.
+
+<!-- Maintained automatically by the Guide triage agent. Manual edits are fine but may be overwritten. -->
+
+## Urgent
+
+Issues requiring immediate attention (`loom:urgent`).
+
+*No urgent issues.*
+
+## Ready
+
+Human-approved issues ready for implementation (`loom:issue`).
+
+*No ready issues.*
+
+## Proposed
+
+Issues under evaluation (`loom:architect`, `loom:hermit`, `loom:curated`).
+
+*No proposed issues.*
+
+## Epics
+
+Active epics and their phase progress (`loom:epic`).
+
+*No active epics.*


### PR DESCRIPTION
## Summary

Adds a document maintenance phase to the Guide triage agent so it keeps three living documents current at the repository root:

- **WORK_LOG.md** — Chronological record of merged PRs and closed issues, grouped by date
- **WORK_PLAN.md** — Prioritized roadmap regenerated from current GitHub label state (Urgent/Ready/Proposed/Epics)
- **README.md** — Updated conservatively when merged PRs touch architectural files

All document changes go through the standard PR review pipeline (`docs/guide-update-*` branches with `loom:review-requested`), with duplicate PR prevention and high-water mark tracking via `.loom/guide-docs-state.json`.

### Changes

| File | Change |
|------|--------|
| `defaults/.claude/commands/guide.md` | Added Document Maintenance section with 5-step workflow (check for open docs PR, update WORK_LOG, update WORK_PLAN, check README staleness, create bundled docs PR) |
| `WORK_LOG.md` | Created initial template at repo root |
| `WORK_PLAN.md` | Created initial template with Urgent/Ready/Proposed/Epics sections |
| `.gitignore` | Added `.loom/guide-docs-state.json` to prevent committing runtime state |

### Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| WORK_LOG.md created with initial template | Verified | File exists at repo root with header and format comment |
| WORK_PLAN.md created with initial template | Verified | File exists with Urgent, Ready, Proposed, Epics sections |
| Guide role includes document maintenance phase | Verified | New section in guide.md with state tracking, PR workflow, change detection |
| High-water marks prevent duplicate entries | Verified | `guide-docs-state.json` tracks `last_processed_pr` and `last_processed_issue` |
| Only one docs PR open at a time | Verified | Step 1 checks for open `docs/guide-update` PRs and skips if found |
| WORK_PLAN regenerated only when labels change | Verified | Content hash comparison in `update_work_plan()` |
| README updates are conservative | Verified | Only triggers on architectural file changes, stale sections only |
| All changes go through PR workflow | Verified | `create_docs_pr()` creates branch, commits, pushes, creates PR |
| State file is gitignored | Verified | `.loom/guide-docs-state.json` added to `.gitignore` |
| Existing `discover_project_goals()` unchanged | Verified | No modifications to existing Goal Discovery section |

Closes #1784