### PR TITLE
Clean stale tmux sessions on daemon startup

### DIFF
--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -152,10 +152,16 @@ async fn main() -> Result<()> {
 
     let activity_db = Arc::new(Mutex::new(activity_db));
 
-    // Initialize terminal manager
+    // Initialize terminal manager and clean up stale sessions
     let mut tm = TerminalManager::new();
     tm.restore_from_tmux()?;
     log::info!("Restored {} terminals", tm.list_terminals().len());
+
+    match tm.clean_stale_sessions() {
+        Ok(0) => log::debug!("No stale tmux sessions to clean"),
+        Ok(count) => log::info!("Cleaned {count} stale tmux session(s) from previous run"),
+        Err(e) => log::warn!("Failed to clean stale tmux sessions: {e}"),
+    }
 
     let tm = Arc::new(Mutex::new(tm));
 

--- a/scripts/clean-tmux.sh
+++ b/scripts/clean-tmux.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 # Kill all loom-* tmux sessions for clean development
+# Uses the loom tmux socket (-L loom) where daemon sessions live
 
 echo "Killing all loom-* tmux sessions..."
-tmux list-sessions 2>/dev/null | grep '^loom-' | cut -d: -f1 | while read session; do
+tmux -L loom list-sessions -F '#{session_name}' 2>/dev/null | grep '^loom-' | while read -r session; do
   echo "  Killing: $session"
-  tmux kill-session -t "$session" 2>/dev/null
+  tmux -L loom kill-session -t "$session" 2>/dev/null
 done
 
 echo "Done! All loom sessions cleaned."


### PR DESCRIPTION
## Summary

- Add `clean_stale_sessions()` method to `TerminalManager` that runs after `restore_from_tmux()` during daemon startup, killing orphaned `loom-*` tmux sessions from previous daemon runs
- Fix `clean-tmux.sh` to use the correct `-L loom` tmux socket instead of the default socket

## Test plan

- [x] `cargo clippy --package loom-daemon` passes with no warnings
- [x] All 145 unit tests pass
- [ ] Manual: start daemon, create shepherd sessions, restart daemon — verify stale sessions are cleaned up and logged

Closes #1788

🤖 Generated with [Claude Code](https://claude.com/claude-code)