### PR TITLE
Clean managed directories on reinstall to remove stale files

### DIFF
--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -422,8 +422,11 @@ fn handle_cli_command(command: Commands) -> Result<()> {
                     println!("  📁 .github/        - GitHub workflow templates");
                     println!("  📄 .gitignore      - Updated with Loom patterns");
 
-                    // Print report of what was added vs preserved
-                    if !report.added.is_empty() || !report.preserved.is_empty() {
+                    // Print report of what was added vs preserved vs removed
+                    if !report.added.is_empty()
+                        || !report.preserved.is_empty()
+                        || !report.removed.is_empty()
+                    {
                         println!();
                         if !report.added.is_empty() {
                             println!("Files added ({}):", report.added.len());
@@ -445,6 +448,12 @@ fn handle_cli_command(command: Commands) -> Result<()> {
                             println!("\nFiles updated ({}):", report.updated.len());
                             for file in &report.updated {
                                 println!("  ~ {file}");
+                            }
+                        }
+                        if !report.removed.is_empty() {
+                            println!("\nFiles removed ({}):", report.removed.len());
+                            for file in &report.removed {
+                                println!("  - {file}");
                             }
                         }
                         if !report.verification_failures.is_empty() {


### PR DESCRIPTION
## Summary

- On reinstall, `.loom/roles/` and `.loom/scripts/` are now cleaned before copying fresh defaults, preventing stale files (e.g., shell scripts ported to Python) from lingering and confusing agents
- Added `clean_managed_dir()` helper that recursively removes all files in a directory while tracking removals in a new `removed` field on `InitReport`
- CLI output now displays removed files with `-` prefix alongside existing `+`/`=`/`~` markers

Closes #1798

## Test plan

- [x] `cargo test -p loom-daemon` — all 146 unit tests pass including 2 new/updated init tests
- [x] `cargo clippy -p loom-daemon` — clean, no warnings
- [ ] Manual verification: install Loom to a test repo, add extra files to `.loom/scripts/`, reinstall, confirm extra files are removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)