### PR TITLE
Add --force flag to loom-clean calls in daemon_cleanup.py

### DIFF
--- a/loom-tools/src/loom_tools/daemon_cleanup.py
+++ b/loom-tools/src/loom_tools/daemon_cleanup.py
@@ -167,13 +167,14 @@ def _run_loom_clean(
     dry_run: bool = False,
     grace_period: int | None = None,
 ) -> None:
-    """Run ``loom-clean --safe --worktrees-only``."""
+    """Run ``loom-clean --safe --worktrees-only --force``."""
     loom_clean = _find_loom_clean(repo_root)
     if loom_clean is None:
         log_warning("loom-clean not found (install loom-tools)")
         return
 
-    cmd = [loom_clean, "--safe", "--worktrees-only"]
+    # Always include --force for non-interactive daemon operation
+    cmd = [loom_clean, "--safe", "--worktrees-only", "--force"]
     if dry_run:
         cmd.append("--dry-run")
     if grace_period is not None:


### PR DESCRIPTION
## Summary
- Fixes `daemon-cleanup.sh` hanging when running non-interactively
- Adds `--force` flag to `_run_loom_clean()` function in `daemon_cleanup.py`
- Affects all three call sites: `handle_shepherd_complete`, `handle_daemon_startup`, and `handle_periodic`

## Test plan
- [ ] Verify daemon startup doesn't hang on cleanup prompt
- [ ] Verify periodic cleanup runs without interactive prompts
- [ ] Verify shepherd-complete cleanup runs non-interactively

Closes #1791

🤖 Generated with [Claude Code](https://claude.com/claude-code)