### PR TITLE
Fix state schema mismatch: support tmux_session for support roles

### DIFF
--- a/loom-tools/src/loom_tools/models/daemon_state.py
+++ b/loom-tools/src/loom_tools/models/daemon_state.py
@@ -55,6 +55,7 @@ class ShepherdEntry:
 class SupportRoleEntry:
     status: str = "idle"
     task_id: str | None = None
+    tmux_session: str | None = None
     started: str | None = None
     last_completed: str | None = None
 
@@ -63,13 +64,14 @@ class SupportRoleEntry:
         return cls(
             status=data.get("status", "idle"),
             task_id=data.get("task_id"),
+            tmux_session=data.get("tmux_session"),
             started=data.get("started"),
             last_completed=data.get("last_completed"),
         )
 
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {"status": self.status}
-        for k in ("task_id", "started", "last_completed"):
+        for k in ("task_id", "tmux_session", "started", "last_completed"):
             v = getattr(self, k)
             if v is not None:
                 d[k] = v

--- a/loom-tools/tests/test_models.py
+++ b/loom-tools/tests/test_models.py
@@ -110,6 +110,35 @@ class TestSupportRoleEntry:
         assert out["task_id"] == "22"
         assert "last_completed" not in out
 
+    def test_round_trip_with_tmux_session(self) -> None:
+        """Test tmux_session field (used by agent-spawn.sh execution model)."""
+        data = {
+            "status": "running",
+            "tmux_session": "loom-guide",
+            "started": "2026-01-27T04:18:07Z",
+        }
+        entry = SupportRoleEntry.from_dict(data)
+        assert entry.tmux_session == "loom-guide"
+        out = entry.to_dict()
+        assert out["status"] == "running"
+        assert out["tmux_session"] == "loom-guide"
+        assert "task_id" not in out  # task_id is None, should not appear
+
+    def test_both_task_id_and_tmux_session(self) -> None:
+        """Test that both identifiers can coexist (backward compatibility)."""
+        data = {
+            "status": "running",
+            "task_id": "abc1234",
+            "tmux_session": "loom-guide",
+            "started": "2026-01-27T04:18:07Z",
+        }
+        entry = SupportRoleEntry.from_dict(data)
+        assert entry.task_id == "abc1234"
+        assert entry.tmux_session == "loom-guide"
+        out = entry.to_dict()
+        assert out["task_id"] == "abc1234"
+        assert out["tmux_session"] == "loom-guide"
+
 
 class TestWarning:
     def test_round_trip(self) -> None:


### PR DESCRIPTION
## Summary
- Add `tmux_session` field to `SupportRoleEntry` model in `daemon_state.py`
- Update `spawn-support-role.sh` to check `tmux_session` first (preferred for agent-spawn.sh execution model)
- Validate tmux sessions exist via `tmux -L loom has-session`
- Fall back to `task_id` check for backward compatibility with Task() execution
- Add tests for `tmux_session` round-trip

## Test plan
- [x] Run `test_models.py::TestSupportRoleEntry` tests
- [x] Verify all 30 model tests pass
- [ ] Integration test: daemon spawns support role, state has `tmux_session`, `spawn-support-role.sh --check` correctly detects running

Closes #1799

🤖 Generated with [Claude Code](https://claude.com/claude-code)