### PR TITLE
Fix shell stub scripts for non-interactive environments

### DIFF
--- a/defaults/scripts/agent-spawn.sh
+++ b/defaults/scripts/agent-spawn.sh
@@ -13,4 +13,9 @@
 
 set -euo pipefail
 
-exec loom-agent-spawn "$@"
+# Try the installed Python entry point first, fall back to module invocation
+if command -v loom-agent-spawn >/dev/null 2>&1; then
+    exec loom-agent-spawn "$@"
+else
+    exec python3 -m loom_tools.agent_spawn "$@"
+fi

--- a/defaults/scripts/daemon-cleanup.sh
+++ b/defaults/scripts/daemon-cleanup.sh
@@ -15,4 +15,9 @@
 
 set -euo pipefail
 
-exec loom-daemon-cleanup "$@"
+# Try the installed Python entry point first, fall back to module invocation
+if command -v loom-daemon-cleanup >/dev/null 2>&1; then
+    exec loom-daemon-cleanup "$@"
+else
+    exec python3 -m loom_tools.daemon_cleanup "$@"
+fi

--- a/defaults/scripts/health-check.sh
+++ b/defaults/scripts/health-check.sh
@@ -16,4 +16,9 @@
 
 set -euo pipefail
 
-exec loom-health-monitor "$@"
+# Try the installed Python entry point first, fall back to module invocation
+if command -v loom-health-monitor >/dev/null 2>&1; then
+    exec loom-health-monitor "$@"
+else
+    exec python3 -m loom_tools.health_monitor "$@"
+fi

--- a/defaults/scripts/loom-status.sh
+++ b/defaults/scripts/loom-status.sh
@@ -12,4 +12,9 @@
 
 set -euo pipefail
 
-exec loom-status "$@"
+# Try the installed Python entry point first, fall back to module invocation
+if command -v loom-status >/dev/null 2>&1; then
+    exec loom-status "$@"
+else
+    exec python3 -m loom_tools.status "$@"
+fi

--- a/defaults/scripts/recover-orphaned-shepherds.sh
+++ b/defaults/scripts/recover-orphaned-shepherds.sh
@@ -12,4 +12,9 @@
 
 set -euo pipefail
 
-exec loom-recover-orphans "$@"
+# Try the installed Python entry point first, fall back to module invocation
+if command -v loom-recover-orphans >/dev/null 2>&1; then
+    exec loom-recover-orphans "$@"
+else
+    exec python3 -m loom_tools.orphan_recovery "$@"
+fi

--- a/defaults/scripts/report-milestone.sh
+++ b/defaults/scripts/report-milestone.sh
@@ -13,4 +13,9 @@
 
 set -euo pipefail
 
-exec loom-milestone "$@"
+# Try the installed Python entry point first, fall back to module invocation
+if command -v loom-milestone >/dev/null 2>&1; then
+    exec loom-milestone "$@"
+else
+    exec python3 -m loom_tools.milestones "$@"
+fi

--- a/defaults/scripts/validate-daemon-state.sh
+++ b/defaults/scripts/validate-daemon-state.sh
@@ -2,4 +2,12 @@
 # validate-daemon-state.sh - Thin stub delegating to Python implementation
 #
 # See loom-tools/src/loom_tools/validate_state.py for the full implementation.
-exec loom-validate-state "$@"
+
+set -euo pipefail
+
+# Try the installed Python entry point first, fall back to module invocation
+if command -v loom-validate-state >/dev/null 2>&1; then
+    exec loom-validate-state "$@"
+else
+    exec python3 -m loom_tools.validate_state "$@"
+fi


### PR DESCRIPTION
## Summary
- Add fallback to `python3 -m loom_tools.*` when the installed CLI command is not in PATH
- Fixes "command not found" errors in non-interactive shells (like Claude Code) where Homebrew paths aren't automatically included

## Files Changed
- `defaults/scripts/agent-spawn.sh`
- `defaults/scripts/daemon-cleanup.sh`
- `defaults/scripts/health-check.sh`
- `defaults/scripts/loom-status.sh`
- `defaults/scripts/recover-orphaned-shepherds.sh`
- `defaults/scripts/report-milestone.sh`
- `defaults/scripts/validate-daemon-state.sh`

## Test Plan
- [x] Verified scripts work with fallback: `bash -c './defaults/scripts/daemon-cleanup.sh --help'`
- [x] Verified scripts work with fallback: `bash -c './defaults/scripts/health-check.sh --help'`

Closes #1837

🤖 Generated with [Claude Code](https://claude.com/claude-code)