### PR TITLE
Increase API rate limit threshold from 90% to 99%

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/config.py
+++ b/loom-tools/src/loom_tools/shepherd/config.py
@@ -96,7 +96,7 @@ class ShepherdConfig:
 
     # Rate limiting
     rate_limit_threshold: int = field(
-        default_factory=lambda: _get_env_int("LOOM_RATE_LIMIT_THRESHOLD", 90)
+        default_factory=lambda: _get_env_int("LOOM_RATE_LIMIT_THRESHOLD", 99)
     )
 
     # Worktree marker file name

--- a/loom-tools/tests/shepherd/test_errors.py
+++ b/loom-tools/tests/shepherd/test_errors.py
@@ -75,15 +75,15 @@ class TestRateLimitError:
 
     def test_stores_usage_and_threshold(self) -> None:
         """Error should store usage and threshold values."""
-        err = RateLimitError(95.5, 90.0)
-        assert err.usage_percent == 95.5
-        assert err.threshold == 90.0
+        err = RateLimitError(99.5, 99.0)
+        assert err.usage_percent == 99.5
+        assert err.threshold == 99.0
 
     def test_formats_message(self) -> None:
         """Error message should include usage percentage."""
-        err = RateLimitError(95.5, 90.0)
-        assert "95.5%" in str(err)
-        assert "90.0%" in str(err)
+        err = RateLimitError(99.5, 99.0)
+        assert "99.5%" in str(err)
+        assert "99.0%" in str(err)
 
 
 class TestIssueNotFoundError:


### PR DESCRIPTION
## Summary

- Updated default API rate limit threshold from 90% to 99% in shepherd config
- Updated test assertions to use the new threshold values

## Rationale

The 90% threshold was overly conservative and interrupted legitimate work. Increasing to 99% allows operations to continue until the rate limit is nearly exhausted, which is more practical since rate limits reset regularly. It's better to complete work and occasionally hit the limit than to stop prematurely at 90%.

The threshold can still be customized via the `LOOM_RATE_LIMIT_THRESHOLD` environment variable if needed.

## Test plan

- [x] Verified default threshold is 99% via direct Python test
- [x] Verified environment variable override still works
- [x] All 253 shepherd tests pass
- [x] Error message formatting tests updated and passing

Closes #1854

🤖 Generated with [Claude Code](https://claude.com/claude-code)