### PR TITLE
Add phase result helpers to BasePhase

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/__init__.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/__init__.py
@@ -1,6 +1,11 @@
 """Phase runner implementations for shepherd orchestration."""
 
-from loom_tools.shepherd.phases.base import PhaseResult, PhaseRunner, PhaseStatus
+from loom_tools.shepherd.phases.base import (
+    BasePhase,
+    PhaseResult,
+    PhaseRunner,
+    PhaseStatus,
+)
 from loom_tools.shepherd.phases.approval import ApprovalPhase
 from loom_tools.shepherd.phases.builder import BuilderPhase
 from loom_tools.shepherd.phases.curator import CuratorPhase
@@ -9,6 +14,7 @@ from loom_tools.shepherd.phases.judge import JudgePhase
 from loom_tools.shepherd.phases.merge import MergePhase
 
 __all__ = [
+    "BasePhase",
     "PhaseResult",
     "PhaseRunner",
     "PhaseStatus",

--- a/loom-tools/src/loom_tools/shepherd/phases/base.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/base.py
@@ -81,6 +81,120 @@ class PhaseRunner(Protocol):
         ...
 
 
+class BasePhase:
+    """Base class for phase runners with helper methods for creating PhaseResults.
+
+    Subclasses should set the ``phase_name`` class attribute to the name of
+    the phase (e.g., "builder", "judge"). This name is automatically used
+    in all PhaseResult objects created via the helper methods.
+
+    Example usage::
+
+        class MyPhase(BasePhase):
+            phase_name = "my_phase"
+
+            def run(self, ctx: ShepherdContext) -> PhaseResult:
+                if some_error:
+                    return self.failed("something went wrong", {"detail": "info"})
+                return self.success("phase completed")
+    """
+
+    phase_name: str = ""
+
+    def result(
+        self,
+        status: PhaseStatus,
+        message: str = "",
+        data: dict[str, Any] | None = None,
+    ) -> PhaseResult:
+        """Create a PhaseResult with this phase's name.
+
+        Args:
+            status: The status of the phase result.
+            message: A human-readable message describing the result.
+            data: Optional dictionary of additional data.
+
+        Returns:
+            A PhaseResult with the phase_name set automatically.
+        """
+        return PhaseResult(
+            status=status,
+            message=message,
+            phase_name=self.phase_name,
+            data=data or {},
+        )
+
+    def success(
+        self, message: str = "", data: dict[str, Any] | None = None
+    ) -> PhaseResult:
+        """Create a successful PhaseResult.
+
+        Args:
+            message: A human-readable message describing the success.
+            data: Optional dictionary of additional data.
+
+        Returns:
+            A PhaseResult with SUCCESS status.
+        """
+        return self.result(PhaseStatus.SUCCESS, message, data)
+
+    def failed(
+        self, message: str = "", data: dict[str, Any] | None = None
+    ) -> PhaseResult:
+        """Create a failed PhaseResult.
+
+        Args:
+            message: A human-readable message describing the failure.
+            data: Optional dictionary of additional data.
+
+        Returns:
+            A PhaseResult with FAILED status.
+        """
+        return self.result(PhaseStatus.FAILED, message, data)
+
+    def skipped(
+        self, message: str = "", data: dict[str, Any] | None = None
+    ) -> PhaseResult:
+        """Create a skipped PhaseResult.
+
+        Args:
+            message: A human-readable message describing why skipped.
+            data: Optional dictionary of additional data.
+
+        Returns:
+            A PhaseResult with SKIPPED status.
+        """
+        return self.result(PhaseStatus.SKIPPED, message, data)
+
+    def shutdown(
+        self, message: str = "", data: dict[str, Any] | None = None
+    ) -> PhaseResult:
+        """Create a shutdown PhaseResult.
+
+        Args:
+            message: A human-readable message describing the shutdown.
+            data: Optional dictionary of additional data.
+
+        Returns:
+            A PhaseResult with SHUTDOWN status.
+        """
+        return self.result(PhaseStatus.SHUTDOWN, message, data)
+
+    def stuck(
+        self, message: str = "", data: dict[str, Any] | None = None
+    ) -> PhaseResult:
+        """Create a stuck PhaseResult.
+
+        Args:
+            message: A human-readable message describing the stuck state.
+            data: Optional dictionary of additional data.
+
+        Returns:
+            A PhaseResult with STUCK status.
+        """
+        return self.result(PhaseStatus.STUCK, message, data)
+
+
 def _read_heartbeats(
     progress_file: Path, *, phase: str | None = None
 ) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Summary

- Add `BasePhase` class with helper methods for creating `PhaseResult` objects
- Helpers auto-populate `phase_name` from the class attribute, eliminating boilerplate
- Migrate `CuratorPhase` as demonstration of the new pattern
- Other phases can be migrated incrementally in follow-up work

## Changes

- **base.py**: Add `BasePhase` class with `result()`, `success()`, `failed()`, `skipped()`, `shutdown()`, `stuck()` helpers
- **curator.py**: Migrate to inherit from `BasePhase` and use helpers
- **__init__.py**: Export `BasePhase`
- **test_phases.py**: Add comprehensive tests for `BasePhase` helpers

## Before/After

**Before:**
```python
return PhaseResult(
    status=PhaseStatus.FAILED,
    message="error occurred",
    phase_name="builder",  # Manual, risk of typo
    data={"detail": "info"},
)
```

**After:**
```python
return self.failed("error occurred", {"detail": "info"})
```

## Test plan

- [x] All 146 phase tests pass
- [x] All 1261 loom-tools tests pass
- [x] New `TestBasePhase` test class with 8 tests covering all helpers

Closes #1861

🤖 Generated with [Claude Code](https://claude.com/claude-code)