### PR TITLE
Add generic gh_list() for GitHub CLI queries

### DIFF
--- a/loom-tools/src/loom_tools/clean.py
+++ b/loom-tools/src/loom_tools/clean.py
@@ -21,10 +21,10 @@ import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
-from loom_tools.common.github import gh_run
+from loom_tools.common.github import gh_list, gh_run
 from loom_tools.common.logging import log_error, log_info, log_success, log_warning
 from loom_tools.common.repo import find_repo_root
-from loom_tools.common.state import read_json_file, safe_parse_json, write_json_file
+from loom_tools.common.state import read_json_file, write_json_file
 from loom_tools.common.time_utils import parse_iso_timestamp
 from loom_tools.common.worktree_safety import find_processes_using_directory
 
@@ -64,51 +64,30 @@ def check_pr_merged(issue_num: int) -> PRStatus:
     """
     branch_name = f"feature/issue-{issue_num}"
 
-    # Find PR by head branch
     try:
-        result = gh_run(
-            [
-                "pr",
-                "list",
-                "--head",
-                branch_name,
-                "--state",
-                "all",
-                "--json",
-                "number,state,mergedAt",
-                "--jq",
-                ".[0] // empty",
-            ],
-            check=False,
+        # Find PR by head branch
+        prs = gh_list(
+            "pr",
+            head=branch_name,
+            state="all",
+            fields=["number", "state", "mergedAt"],
+            limit=1,
         )
 
-        pr_info = result.stdout.strip() if result.returncode == 0 else ""
-
-        if not pr_info:
+        if not prs:
             # Try searching by issue reference
-            result = gh_run(
-                [
-                    "pr",
-                    "list",
-                    "--search",
-                    f"Closes #{issue_num}",
-                    "--state",
-                    "all",
-                    "--json",
-                    "number,state,mergedAt",
-                    "--jq",
-                    ".[0] // empty",
-                ],
-                check=False,
+            prs = gh_list(
+                "pr",
+                search=f"Closes #{issue_num}",
+                state="all",
+                fields=["number", "state", "mergedAt"],
+                limit=1,
             )
-            pr_info = result.stdout.strip() if result.returncode == 0 else ""
 
-        if not pr_info:
+        if not prs:
             return PRStatus(status="NO_PR")
 
-        data = safe_parse_json(pr_info)
-        if not isinstance(data, dict):
-            return PRStatus(status="UNKNOWN")
+        data = prs[0]
         state = data.get("state", "UNKNOWN")
         merged_at = data.get("mergedAt")
 

--- a/loom-tools/tests/test_github.py
+++ b/loom-tools/tests/test_github.py
@@ -6,7 +6,12 @@ import json
 import subprocess
 from unittest import mock
 
-from loom_tools.common.github import gh_get_default_branch_ci_status
+from loom_tools.common.github import (
+    gh_get_default_branch_ci_status,
+    gh_issue_list,
+    gh_list,
+    gh_pr_list,
+)
 
 
 class TestGhGetDefaultBranchCiStatus:
@@ -141,3 +146,184 @@ class TestGhGetDefaultBranchCiStatus:
         # Should only see one CI run (the first/latest), which passed
         assert result["status"] == "passing"
         assert result["total_runs"] == 1
+
+
+class TestGhList:
+    """Tests for gh_list function."""
+
+    def test_issue_list_basic(self) -> None:
+        """Basic issue list returns parsed JSON."""
+        mock_issues = [
+            {"number": 1, "title": "Issue 1", "labels": [], "state": "OPEN"},
+            {"number": 2, "title": "Issue 2", "labels": [], "state": "OPEN"},
+        ]
+        with mock.patch("loom_tools.common.github.gh_run") as mock_gh:
+            mock_gh.return_value = mock.Mock(
+                returncode=0,
+                stdout=json.dumps(mock_issues),
+            )
+            result = gh_list("issue")
+
+        assert len(result) == 2
+        assert result[0]["number"] == 1
+        mock_gh.assert_called_once()
+        call_args = mock_gh.call_args[0][0]
+        assert call_args[0] == "issue"
+        assert "list" in call_args
+
+    def test_pr_list_basic(self) -> None:
+        """Basic PR list returns parsed JSON."""
+        mock_prs = [
+            {"number": 10, "title": "PR 1", "labels": [], "state": "OPEN"},
+        ]
+        with mock.patch("loom_tools.common.github.gh_run") as mock_gh:
+            mock_gh.return_value = mock.Mock(
+                returncode=0,
+                stdout=json.dumps(mock_prs),
+            )
+            result = gh_list("pr")
+
+        assert len(result) == 1
+        assert result[0]["number"] == 10
+        call_args = mock_gh.call_args[0][0]
+        assert call_args[0] == "pr"
+
+    def test_with_labels_filter(self) -> None:
+        """Labels are passed to gh command."""
+        with mock.patch("loom_tools.common.github.gh_run") as mock_gh:
+            mock_gh.return_value = mock.Mock(returncode=0, stdout="[]")
+            gh_list("issue", labels=["bug", "urgent"])
+
+        call_args = mock_gh.call_args[0][0]
+        assert "--label" in call_args
+        label_idx = call_args.index("--label")
+        assert call_args[label_idx + 1] == "bug,urgent"
+
+    def test_with_state_filter(self) -> None:
+        """State is passed to gh command."""
+        with mock.patch("loom_tools.common.github.gh_run") as mock_gh:
+            mock_gh.return_value = mock.Mock(returncode=0, stdout="[]")
+            gh_list("pr", state="closed")
+
+        call_args = mock_gh.call_args[0][0]
+        assert "--state" in call_args
+        state_idx = call_args.index("--state")
+        assert call_args[state_idx + 1] == "closed"
+
+    def test_with_custom_fields(self) -> None:
+        """Custom fields are passed to gh command."""
+        with mock.patch("loom_tools.common.github.gh_run") as mock_gh:
+            mock_gh.return_value = mock.Mock(returncode=0, stdout="[]")
+            gh_list("issue", fields=["number", "url", "createdAt"])
+
+        call_args = mock_gh.call_args[0][0]
+        assert "--json" in call_args
+        json_idx = call_args.index("--json")
+        assert call_args[json_idx + 1] == "number,url,createdAt"
+
+    def test_with_search_parameter(self) -> None:
+        """Search query is passed to gh command."""
+        with mock.patch("loom_tools.common.github.gh_run") as mock_gh:
+            mock_gh.return_value = mock.Mock(returncode=0, stdout="[]")
+            gh_list("pr", search="Closes #123")
+
+        call_args = mock_gh.call_args[0][0]
+        assert "--search" in call_args
+        search_idx = call_args.index("--search")
+        assert call_args[search_idx + 1] == "Closes #123"
+
+    def test_with_head_parameter(self) -> None:
+        """Head branch filter is passed to gh command."""
+        with mock.patch("loom_tools.common.github.gh_run") as mock_gh:
+            mock_gh.return_value = mock.Mock(returncode=0, stdout="[]")
+            gh_list("pr", head="feature/issue-42")
+
+        call_args = mock_gh.call_args[0][0]
+        assert "--head" in call_args
+        head_idx = call_args.index("--head")
+        assert call_args[head_idx + 1] == "feature/issue-42"
+
+    def test_with_limit_parameter(self) -> None:
+        """Limit is passed to gh command."""
+        with mock.patch("loom_tools.common.github.gh_run") as mock_gh:
+            mock_gh.return_value = mock.Mock(returncode=0, stdout="[]")
+            gh_list("issue", limit=5)
+
+        call_args = mock_gh.call_args[0][0]
+        assert "--limit" in call_args
+        limit_idx = call_args.index("--limit")
+        assert call_args[limit_idx + 1] == "5"
+
+    def test_empty_result(self) -> None:
+        """Empty stdout returns empty list."""
+        with mock.patch("loom_tools.common.github.gh_run") as mock_gh:
+            mock_gh.return_value = mock.Mock(returncode=0, stdout="")
+            result = gh_list("issue")
+
+        assert result == []
+
+    def test_whitespace_only_result(self) -> None:
+        """Whitespace-only stdout returns empty list."""
+        with mock.patch("loom_tools.common.github.gh_run") as mock_gh:
+            mock_gh.return_value = mock.Mock(returncode=0, stdout="   \n  ")
+            result = gh_list("pr")
+
+        assert result == []
+
+    def test_nonzero_return_code(self) -> None:
+        """Non-zero return code returns empty list."""
+        with mock.patch("loom_tools.common.github.gh_run") as mock_gh:
+            mock_gh.return_value = mock.Mock(returncode=1, stdout="[]")
+            result = gh_list("issue")
+
+        assert result == []
+
+    def test_invalid_json(self) -> None:
+        """Invalid JSON returns empty list."""
+        with mock.patch("loom_tools.common.github.gh_run") as mock_gh:
+            mock_gh.return_value = mock.Mock(returncode=0, stdout="not valid json")
+            result = gh_list("pr")
+
+        assert result == []
+
+    def test_default_fields_used(self) -> None:
+        """Default fields are used when not specified."""
+        with mock.patch("loom_tools.common.github.gh_run") as mock_gh:
+            mock_gh.return_value = mock.Mock(returncode=0, stdout="[]")
+            gh_list("issue")
+
+        call_args = mock_gh.call_args[0][0]
+        json_idx = call_args.index("--json")
+        fields = call_args[json_idx + 1]
+        assert "number" in fields
+        assert "title" in fields
+        assert "labels" in fields
+        assert "state" in fields
+
+
+class TestGhIssueListWrapper:
+    """Tests for gh_issue_list thin wrapper."""
+
+    def test_calls_gh_list_with_issue_type(self) -> None:
+        """gh_issue_list calls gh_list with entity_type='issue'."""
+        with mock.patch("loom_tools.common.github.gh_list") as mock_list:
+            mock_list.return_value = []
+            gh_issue_list(labels=["bug"], state="closed", fields=["number"])
+
+        mock_list.assert_called_once_with(
+            "issue", labels=["bug"], state="closed", fields=["number"]
+        )
+
+
+class TestGhPrListWrapper:
+    """Tests for gh_pr_list thin wrapper."""
+
+    def test_calls_gh_list_with_pr_type(self) -> None:
+        """gh_pr_list calls gh_list with entity_type='pr'."""
+        with mock.patch("loom_tools.common.github.gh_list") as mock_list:
+            mock_list.return_value = []
+            gh_pr_list(labels=["ready"], state="open", fields=["url"])
+
+        mock_list.assert_called_once_with(
+            "pr", labels=["ready"], state="open", fields=["url"]
+        )


### PR DESCRIPTION
## Summary

- Create a unified `gh_list()` function that handles both issue and PR listing with a common interface
- Convert `gh_issue_list()` and `gh_pr_list()` to thin wrappers around `gh_list()`
- Migrate `clean.py` `check_pr_merged()` to use `gh_list()` for PR queries
- Add comprehensive tests covering all parameters and edge cases

## Changes

**loom-tools/src/loom_tools/common/github.py:**
- Add `EntityType` type alias for `"issue" | "pr"`
- Add `gh_list()` function with parameters: `entity_type`, `labels`, `state`, `fields`, `search`, `head`, `limit`
- Handles empty results, non-zero return codes, and invalid JSON gracefully
- Update `gh_issue_list()` and `gh_pr_list()` as thin wrappers

**loom-tools/src/loom_tools/clean.py:**
- Migrate `check_pr_merged()` to use `gh_list()` with `head` and `search` parameters
- Remove unused `json` import

**loom-tools/tests/test_github.py:**
- Add `TestGhList` class with 13 tests covering all parameters and edge cases
- Add `TestGhIssueListWrapper` and `TestGhPrListWrapper` to verify wrapper behavior

## Acceptance Criteria

- [x] Generic `gh_list()` function created with entity_type parameter
- [x] Supports all existing parameters: labels, state, fields
- [x] Supports additional PR-specific parameters: search, head
- [x] Supports limit parameter
- [x] Existing `gh_issue_list()` and `gh_pr_list()` are thin wrappers
- [x] `clean.py` migrated to use `gh_list()` for PR queries
- [x] All existing tests pass (1272 passed)
- [x] New tests cover: empty results, invalid JSON, non-zero return code

**Note:** The acceptance criteria mentioned using `parse_command_output()` from #1855, but that utility doesn't appear to exist in the codebase (issue #1855 is closed but the code wasn't found). JSON parsing is handled directly within `gh_list()`.

## Test plan

- [x] Run `uv run pytest tests/test_github.py -v` - all 24 tests pass
- [x] Run `uv run pytest tests/test_clean.py -v` - all tests pass
- [x] Run full test suite `uv run pytest` - 1272 passed, 1 skipped
- [x] Verify no new lint issues in modified files

Closes #1859

🤖 Generated with [Claude Code](https://claude.com/claude-code)