### PR TITLE
Unify GitHub label operations in labels.py

### DIFF
--- a/loom-tools/tests/shepherd/test_labels.py
+++ b/loom-tools/tests/shepherd/test_labels.py
@@ -17,17 +17,17 @@ class TestLabelCache:
         """Cache miss should fetch labels from API."""
         cache = LabelCache()
 
-        with patch.object(cache, "_fetch_issue_labels", return_value={"label1", "label2"}) as mock:
+        with patch.object(cache, "_fetch_labels", return_value={"label1", "label2"}) as mock:
             labels = cache.get_issue_labels(42)
             assert labels == {"label1", "label2"}
-            mock.assert_called_once_with(42)
+            mock.assert_called_once_with("issue", 42)
 
     def test_cache_hit_returns_cached(self) -> None:
         """Cache hit should return cached labels without API call."""
         cache = LabelCache()
         cache._issue_labels[42] = {"cached"}
 
-        with patch.object(cache, "_fetch_issue_labels") as mock:
+        with patch.object(cache, "_fetch_labels") as mock:
             labels = cache.get_issue_labels(42)
             assert labels == {"cached"}
             mock.assert_not_called()
@@ -37,10 +37,10 @@ class TestLabelCache:
         cache = LabelCache()
         cache._issue_labels[42] = {"old_label"}
 
-        with patch.object(cache, "_fetch_issue_labels", return_value={"new_label"}) as mock:
+        with patch.object(cache, "_fetch_labels", return_value={"new_label"}) as mock:
             labels = cache.get_issue_labels(42, refresh=True)
             assert labels == {"new_label"}
-            mock.assert_called_once_with(42)
+            mock.assert_called_once_with("issue", 42)
 
     def test_has_issue_label_true(self) -> None:
         """has_issue_label should return True when label exists."""
@@ -120,3 +120,79 @@ class TestLabelCache:
         """Should fall back to gh when gh-cached not available."""
         cache = LabelCache()
         assert cache._gh_cmd == "gh"
+
+
+class TestGenericLabelOperations:
+    """Test generic (unified) label operations."""
+
+    def test_get_labels_generic(self) -> None:
+        """get_labels should work with entity_type parameter."""
+        cache = LabelCache()
+
+        with patch.object(cache, "_fetch_labels", return_value={"label1"}) as mock:
+            labels = cache.get_labels("issue", 42)
+            assert labels == {"label1"}
+            mock.assert_called_once_with("issue", 42)
+
+    def test_get_labels_pr(self) -> None:
+        """get_labels should work for PRs."""
+        cache = LabelCache()
+
+        with patch.object(cache, "_fetch_labels", return_value={"pr_label"}) as mock:
+            labels = cache.get_labels("pr", 100)
+            assert labels == {"pr_label"}
+            mock.assert_called_once_with("pr", 100)
+
+    def test_has_label_generic(self) -> None:
+        """has_label should work with entity_type parameter."""
+        cache = LabelCache()
+        cache.set_labels("issue", 42, {"loom:issue"})
+
+        assert cache.has_label("issue", 42, "loom:issue") is True
+        assert cache.has_label("issue", 42, "loom:blocked") is False
+
+    def test_set_labels_generic(self) -> None:
+        """set_labels should work with entity_type parameter."""
+        cache = LabelCache()
+        cache.set_labels("pr", 100, {"pr_label"})
+
+        assert cache.get_labels("pr", 100) == {"pr_label"}
+
+    def test_invalidate_entity_specific(self) -> None:
+        """invalidate_entity should clear specific entity cache."""
+        cache = LabelCache()
+        cache.set_labels("issue", 42, {"label1"})
+        cache.set_labels("issue", 43, {"label2"})
+        cache.set_labels("pr", 42, {"pr_label"})
+
+        cache.invalidate_entity("issue", 42)
+
+        # Issue 42 should be gone, but issue 43 and PR 42 should remain
+        assert ("issue", 42) not in cache._labels
+        assert ("issue", 43) in cache._labels
+        assert ("pr", 42) in cache._labels
+
+    def test_invalidate_entity_all_of_type(self) -> None:
+        """invalidate_entity(type, None) should clear all of that type."""
+        cache = LabelCache()
+        cache.set_labels("issue", 42, {"label1"})
+        cache.set_labels("issue", 43, {"label2"})
+        cache.set_labels("pr", 42, {"pr_label"})
+
+        cache.invalidate_entity("issue")
+
+        # All issues should be gone, but PRs should remain
+        assert ("issue", 42) not in cache._labels
+        assert ("issue", 43) not in cache._labels
+        assert ("pr", 42) in cache._labels
+
+    def test_cache_key_prevents_collisions(self) -> None:
+        """Issue and PR with same number should have separate cache entries."""
+        cache = LabelCache()
+        cache.set_labels("issue", 42, {"issue_label"})
+        cache.set_labels("pr", 42, {"pr_label"})
+
+        assert cache.get_labels("issue", 42) == {"issue_label"}
+        assert cache.get_labels("pr", 42) == {"pr_label"}
+        assert ("issue", 42) in cache._labels
+        assert ("pr", 42) in cache._labels


### PR DESCRIPTION
## Summary

- Refactor `LabelCache` to use unified cache with `EntityType` parameter
- Add generic methods that eliminate code duplication between issue/PR operations
- Keep backward-compatible convenience methods for existing callers
- Cache key now includes entity type to prevent issue/PR collisions

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Generic `_fetch_labels(entity_type, number)` replaces both methods | ✅ | `_fetch_labels` at line 44, `_fetch_issue_labels`/`_fetch_pr_labels` now delegate to it |
| Generic `get_labels(entity_type, number)` replaces both methods | ✅ | `get_labels` at line 61, `get_issue_labels`/`get_pr_labels` delegate to it |
| Generic `has_label(entity_type, number, label)` replaces both methods | ✅ | `has_label` at line 78, `has_issue_label`/`has_pr_label` delegate to it |
| Generic `add_label(entity_type, number, label)` replaces both methods | ✅ | Module-level `add_label` at line 282, `add_issue_label`/`add_pr_label` delegate to it |
| Generic `remove_label(entity_type, number, label)` replaces both methods | ✅ | Module-level `remove_label` at line 303, `remove_issue_label`/`remove_pr_label` delegate to it |
| Cache key includes entity type to prevent collisions | ✅ | Cache uses `dict[tuple[EntityType, int], set[str]]` at line 22 |
| Backward-compatible convenience methods remain | ✅ | All existing public methods retained as thin wrappers |
| All existing tests pass | ✅ | 1315 passed, 1 skipped |

## Test Plan

- [x] All existing `test_labels.py` tests pass
- [x] New tests added for generic operations (`TestGenericLabelOperations`)
- [x] Full loom-tools test suite passes (1315 tests)
- [x] Ruff check and format pass

Closes #1858

🤖 Generated with [Claude Code](https://claude.com/claude-code)