### PR TITLE
Add shared loom-tools.sh helper for consistent CLI error handling

### DIFF
--- a/defaults/scripts/agent-metrics.sh
+++ b/defaults/scripts/agent-metrics.sh
@@ -16,9 +16,10 @@
 
 set -euo pipefail
 
-# Try the installed Python entry point first, fall back to module invocation
-if command -v loom-agent-metrics >/dev/null 2>&1; then
-    exec loom-agent-metrics "$@"
-else
-    exec python3 -m loom_tools.agent_metrics "$@"
-fi
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source shared loom-tools helper
+source "$SCRIPT_DIR/lib/loom-tools.sh"
+
+# Run the command with proper fallback chain
+run_loom_tool "agent-metrics" "agent_metrics" "$@"

--- a/defaults/scripts/agent-spawn.sh
+++ b/defaults/scripts/agent-spawn.sh
@@ -13,9 +13,10 @@
 
 set -euo pipefail
 
-# Try the installed Python entry point first, fall back to module invocation
-if command -v loom-agent-spawn >/dev/null 2>&1; then
-    exec loom-agent-spawn "$@"
-else
-    exec python3 -m loom_tools.agent_spawn "$@"
-fi
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source shared loom-tools helper
+source "$SCRIPT_DIR/lib/loom-tools.sh"
+
+# Run the command with proper fallback chain
+run_loom_tool "agent-spawn" "agent_spawn" "$@"

--- a/defaults/scripts/agent-wait.sh
+++ b/defaults/scripts/agent-wait.sh
@@ -15,16 +15,10 @@
 
 set -euo pipefail
 
-# Check if Python CLI is available
-if command -v loom-agent-wait >/dev/null 2>&1; then
-    exec loom-agent-wait "$@"
-fi
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Fallback: try running as a Python module
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-if [[ -d "${REPO_ROOT}/loom-tools/src/loom_tools" ]]; then
-    exec python3 -m loom_tools.agent_wait "$@"
-fi
+# Source shared loom-tools helper
+source "$SCRIPT_DIR/lib/loom-tools.sh"
 
-echo "ERROR: loom-agent-wait not found. Install loom-tools: pip install -e loom-tools/" >&2
-exit 2
+# Run the command with proper fallback chain
+run_loom_tool "agent-wait" "agent_wait" "$@"

--- a/defaults/scripts/daemon-cleanup.sh
+++ b/defaults/scripts/daemon-cleanup.sh
@@ -15,9 +15,10 @@
 
 set -euo pipefail
 
-# Try the installed Python entry point first, fall back to module invocation
-if command -v loom-daemon-cleanup >/dev/null 2>&1; then
-    exec loom-daemon-cleanup "$@"
-else
-    exec python3 -m loom_tools.daemon_cleanup "$@"
-fi
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source shared loom-tools helper
+source "$SCRIPT_DIR/lib/loom-tools.sh"
+
+# Run the command with proper fallback chain
+run_loom_tool "daemon-cleanup" "daemon_cleanup" "$@"

--- a/defaults/scripts/health-check.sh
+++ b/defaults/scripts/health-check.sh
@@ -16,9 +16,10 @@
 
 set -euo pipefail
 
-# Try the installed Python entry point first, fall back to module invocation
-if command -v loom-health-monitor >/dev/null 2>&1; then
-    exec loom-health-monitor "$@"
-else
-    exec python3 -m loom_tools.health_monitor "$@"
-fi
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source shared loom-tools helper
+source "$SCRIPT_DIR/lib/loom-tools.sh"
+
+# Run the command with proper fallback chain
+run_loom_tool "health-monitor" "health_monitor" "$@"

--- a/defaults/scripts/lib/loom-tools.sh
+++ b/defaults/scripts/lib/loom-tools.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# loom-tools.sh - Shared helpers for locating and invoking loom-tools commands
+#
+# This library provides consistent patterns for:
+#   1. Locating loom-tools (source dir or installed)
+#   2. Running loom-tools commands with proper fallbacks
+#   3. Providing helpful error messages when loom-tools is missing
+#
+# Usage:
+#   source "$(dirname "${BASH_SOURCE[0]}")/lib/loom-tools.sh"
+#   run_loom_tool "agent-spawn" "agent_spawn" "$@"
+
+# Find the repository root from the script location
+_find_repo_root() {
+    local dir="${1:-$(pwd)}"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.git" ]] || [[ -d "$dir/.loom" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    return 1
+}
+
+# Locate loom-tools directory
+# Sets LOOM_TOOLS_DIR if found, returns 1 if not
+# Priority:
+#   1. Local loom-tools in repo (for Loom source repository)
+#   2. Loom source path recorded during installation (for target repos)
+find_loom_tools() {
+    local script_dir="${1:-$(pwd)}"
+    local repo_root
+
+    repo_root="$(_find_repo_root "$script_dir")" || return 1
+
+    # Check for local loom-tools (Loom source repo)
+    if [[ -d "$repo_root/loom-tools/src/loom_tools" ]]; then
+        LOOM_TOOLS_DIR="$repo_root/loom-tools"
+        LOOM_TOOLS_SRC="$repo_root/loom-tools/src"
+        return 0
+    fi
+
+    # Check for recorded loom source path (target repo)
+    if [[ -f "$repo_root/.loom/loom-source-path" ]]; then
+        local loom_source
+        loom_source="$(cat "$repo_root/.loom/loom-source-path")"
+        if [[ -d "$loom_source/loom-tools/src/loom_tools" ]]; then
+            LOOM_TOOLS_DIR="$loom_source/loom-tools"
+            LOOM_TOOLS_SRC="$loom_source/loom-tools/src"
+            return 0
+        fi
+    fi
+
+    LOOM_TOOLS_DIR=""
+    LOOM_TOOLS_SRC=""
+    return 1
+}
+
+# Run a loom-tools command with proper fallback chain
+# Arguments:
+#   $1 - CLI command name (e.g., "agent-spawn" for loom-agent-spawn)
+#   $2 - Python module name (e.g., "agent_spawn" for loom_tools.agent_spawn)
+#   $@ - Arguments to pass to the command
+#
+# Priority:
+#   1. System-installed CLI (loom-<name>)
+#   2. venv CLI in loom-tools directory
+#   3. Python module with PYTHONPATH set
+#   4. Error with helpful message
+run_loom_tool() {
+    local cli_name="$1"
+    local module_name="$2"
+    shift 2
+
+    local full_cli="loom-${cli_name}"
+
+    # Try system-installed CLI first
+    if command -v "$full_cli" >/dev/null 2>&1; then
+        exec "$full_cli" "$@"
+    fi
+
+    # Try to find loom-tools directory
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[1]}")" && pwd)"
+
+    if find_loom_tools "$script_dir"; then
+        # Try venv CLI
+        if [[ -x "$LOOM_TOOLS_DIR/.venv/bin/$full_cli" ]]; then
+            exec "$LOOM_TOOLS_DIR/.venv/bin/$full_cli" "$@"
+        fi
+
+        # Try Python module with PYTHONPATH
+        if [[ -d "$LOOM_TOOLS_SRC/loom_tools" ]]; then
+            PYTHONPATH="${LOOM_TOOLS_SRC}:${PYTHONPATH:-}" exec python3 -m "loom_tools.${module_name}" "$@"
+        fi
+    fi
+
+    # Not found - provide helpful error message
+    _loom_tool_not_found_error "$cli_name" "$module_name"
+}
+
+# Print helpful error message when loom-tools is not found
+_loom_tool_not_found_error() {
+    local cli_name="$1"
+    local module_name="$2"
+    local full_cli="loom-${cli_name}"
+
+    echo "[ERROR] $full_cli not found." >&2
+    echo "" >&2
+    echo "The loom-tools package is required but not installed." >&2
+    echo "" >&2
+    echo "To install:" >&2
+
+    local script_dir repo_root
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[1]}")" && pwd)"
+    if repo_root="$(_find_repo_root "$script_dir")"; then
+        if [[ -d "$repo_root/loom-tools" ]]; then
+            echo "  cd $repo_root && pipx install --editable ./loom-tools" >&2
+            echo "" >&2
+            echo "Or using pip:" >&2
+            echo "  pip install -e $repo_root/loom-tools" >&2
+        elif [[ -f "$repo_root/.loom/loom-source-path" ]]; then
+            local loom_source
+            loom_source="$(cat "$repo_root/.loom/loom-source-path")"
+            echo "  pipx install --editable $loom_source/loom-tools" >&2
+        else
+            echo "  pipx install loom-tools" >&2
+        fi
+    else
+        echo "  pipx install loom-tools" >&2
+    fi
+
+    exit 1
+}

--- a/defaults/scripts/loom-status.sh
+++ b/defaults/scripts/loom-status.sh
@@ -12,9 +12,10 @@
 
 set -euo pipefail
 
-# Try the installed Python entry point first, fall back to module invocation
-if command -v loom-status >/dev/null 2>&1; then
-    exec loom-status "$@"
-else
-    exec python3 -m loom_tools.status "$@"
-fi
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source shared loom-tools helper
+source "$SCRIPT_DIR/lib/loom-tools.sh"
+
+# Run the command with proper fallback chain
+run_loom_tool "status" "status" "$@"

--- a/defaults/scripts/recover-orphaned-shepherds.sh
+++ b/defaults/scripts/recover-orphaned-shepherds.sh
@@ -12,9 +12,10 @@
 
 set -euo pipefail
 
-# Try the installed Python entry point first, fall back to module invocation
-if command -v loom-recover-orphans >/dev/null 2>&1; then
-    exec loom-recover-orphans "$@"
-else
-    exec python3 -m loom_tools.orphan_recovery "$@"
-fi
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source shared loom-tools helper
+source "$SCRIPT_DIR/lib/loom-tools.sh"
+
+# Run the command with proper fallback chain
+run_loom_tool "recover-orphans" "orphan_recovery" "$@"

--- a/defaults/scripts/report-milestone.sh
+++ b/defaults/scripts/report-milestone.sh
@@ -13,9 +13,10 @@
 
 set -euo pipefail
 
-# Try the installed Python entry point first, fall back to module invocation
-if command -v loom-milestone >/dev/null 2>&1; then
-    exec loom-milestone "$@"
-else
-    exec python3 -m loom_tools.milestones "$@"
-fi
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source shared loom-tools helper
+source "$SCRIPT_DIR/lib/loom-tools.sh"
+
+# Run the command with proper fallback chain
+run_loom_tool "milestone" "milestones" "$@"

--- a/defaults/scripts/validate-daemon-state.sh
+++ b/defaults/scripts/validate-daemon-state.sh
@@ -5,9 +5,10 @@
 
 set -euo pipefail
 
-# Try the installed Python entry point first, fall back to module invocation
-if command -v loom-validate-state >/dev/null 2>&1; then
-    exec loom-validate-state "$@"
-else
-    exec python3 -m loom_tools.validate_state "$@"
-fi
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source shared loom-tools helper
+source "$SCRIPT_DIR/lib/loom-tools.sh"
+
+# Run the command with proper fallback chain
+run_loom_tool "validate-state" "validate_state" "$@"

--- a/loom-tools/tests/test_installation_verification.py
+++ b/loom-tools/tests/test_installation_verification.py
@@ -179,9 +179,11 @@ class TestWrapperScriptRouting:
         assert script.exists(), "health-check.sh not found"
 
         content = script.read_text()
-        assert "loom-health-monitor" in content, (
-            "health-check.sh doesn't delegate to loom-health-monitor"
-        )
+        # Accept either direct command reference or run_loom_tool helper
+        assert (
+            "loom-health-monitor" in content
+            or 'run_loom_tool "health-monitor"' in content
+        ), "health-check.sh doesn't delegate to loom-health-monitor"
 
     def test_daemon_cleanup_delegates_to_python(
         self, defaults_dir: pathlib.Path
@@ -191,9 +193,11 @@ class TestWrapperScriptRouting:
         assert script.exists(), "daemon-cleanup.sh not found"
 
         content = script.read_text()
-        assert "loom-daemon-cleanup" in content, (
-            "daemon-cleanup.sh doesn't delegate to loom-daemon-cleanup"
-        )
+        # Accept either direct command reference or run_loom_tool helper
+        assert (
+            "loom-daemon-cleanup" in content
+            or 'run_loom_tool "daemon-cleanup"' in content
+        ), "daemon-cleanup.sh doesn't delegate to loom-daemon-cleanup"
 
     def test_cli_wrapper_health_routes_to_python(
         self, defaults_dir: pathlib.Path


### PR DESCRIPTION
## Summary

- Add shared `.loom/scripts/lib/loom-tools.sh` helper library for consistent CLI command resolution and error handling
- Update all loom-tools wrapper scripts to use the shared helper, providing clear error messages when loom-tools is missing
- Update installation verification tests to accept both the old direct pattern and new `run_loom_tool` helper pattern

## Problem

When loom-tools CLI commands aren't installed via pipx, wrapper scripts like `agent-spawn.sh` would fail silently with confusing errors like `python3 -m loom_tools.xxx: ModuleNotFoundError`. Users had no clear indication of what was wrong or how to fix it.

## Solution

Centralized the command resolution logic into a shared helper that:

1. **Tries system-installed CLI first** (`loom-<name>` in PATH)
2. **Falls back to venv CLI** if loom-tools directory found (`.venv/bin/loom-<name>`)
3. **Falls back to Python module** with PYTHONPATH properly set
4. **Provides helpful error messages** with installation instructions if all methods fail

Example error when loom-tools not installed:
```
[ERROR] loom-agent-spawn not found.

The loom-tools package is required but not installed.

To install:
  cd /path/to/repo && pipx install --editable ./loom-tools

Or using pip:
  pip install -e /path/to/repo/loom-tools
```

## Test plan

- [x] All 1308 loom-tools tests pass
- [x] `pnpm lint` passes
- [x] Verified `run_loom_tool` helper correctly locates loom-tools source directory
- [x] Verified helpful error message shown when loom-tools not available
- [x] Updated tests accept both old direct pattern and new helper pattern

Closes #1850

🤖 Generated with [Claude Code](https://claude.com/claude-code)