### PR TITLE
Fix install PR creation failing silently on error

### DIFF
--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -736,8 +736,10 @@ if [[ ! -x "$LOOM_ROOT/scripts/install/create-pr.sh" ]]; then
   error "Installation script not found: create-pr.sh"
 fi
 
-PR_URL_RAW=$("$LOOM_ROOT/scripts/install/create-pr.sh" "$TARGET_PATH/$WORKTREE_PATH" "$BASE_BRANCH") || \
-  error "Failed to create pull request"
+PR_URL_RAW=$("$LOOM_ROOT/scripts/install/create-pr.sh" "$TARGET_PATH/$WORKTREE_PATH" "$BASE_BRANCH") || {
+  # create-pr.sh prints detailed error info to stderr (visible above)
+  error "Failed to create pull request (see details above)"
+}
 
 # Check if installation was already complete (no changes needed)
 # IMPORTANT: Check this BEFORE trying to parse as URL


### PR DESCRIPTION
## Summary

- Fix `set -euo pipefail` causing `create-pr.sh` to exit before error details are printed when `gh pr create` fails
- Handle "PR already exists" case on reinstall by looking up and reusing the existing PR
- Improve error message in caller to reference stderr output

## Test plan

- [ ] Run `./install.sh <repo>` on a repo with no existing installation PR — should create PR normally
- [ ] Run `./install.sh <repo> --clean` on a repo that already has an open `feature/loom-installation` PR — should detect and reuse existing PR
- [ ] Simulate `gh pr create` failure (e.g. invalid repo) — should show actual `gh` error output instead of generic message

🤖 Generated with [Claude Code](https://claude.com/claude-code)