### PR TITLE
Port detect-systematic-failure.sh and record-blocked-reason.sh to Python

### DIFF
--- a/loom-tools/src/loom_tools/common/systematic_failure.py
+++ b/loom-tools/src/loom_tools/common/systematic_failure.py
@@ -1,0 +1,244 @@
+"""Native Python replacements for detect-systematic-failure.sh and record-blocked-reason.sh.
+
+Provides functions to record blocked issue metadata and detect systematic
+failure patterns in ``daemon-state.json``, eliminating the need for shell
+subprocess calls from shepherd phase modules.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from loom_tools.common.config import env_int
+from loom_tools.common.paths import LoomPaths
+from loom_tools.common.state import read_json_file, write_json_file
+from loom_tools.models.daemon_state import SystematicFailure
+
+logger = logging.getLogger(__name__)
+
+# Maximum number of recent failures kept in the sliding window
+_MAX_RECENT_FAILURES = 20
+
+
+def _now_iso() -> str:
+    """Return current UTC time as ISO 8601 string."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _get_threshold() -> int:
+    return env_int("LOOM_SYSTEMATIC_FAILURE_THRESHOLD", default=3)
+
+
+def _get_cooldown() -> int:
+    return env_int("LOOM_SYSTEMATIC_FAILURE_COOLDOWN", default=1800)
+
+
+def record_blocked_reason(
+    repo_root: Path,
+    issue: int,
+    *,
+    error_class: str = "unknown",
+    phase: str = "",
+    details: str = "",
+) -> None:
+    """Record structured failure metadata when an issue becomes blocked.
+
+    Updates ``blocked_issue_retries`` and appends to ``recent_failures``
+    in ``daemon-state.json``.  This is the Python equivalent of
+    ``record-blocked-reason.sh``.
+
+    Args:
+        repo_root: Repository root path.
+        issue: Issue number being blocked.
+        error_class: Classification of the error.
+        phase: Shepherd phase where the error occurred.
+        details: Human-readable description of the failure.
+    """
+    paths = LoomPaths(repo_root)
+    state_file = paths.daemon_state_file
+
+    if not state_file.is_file():
+        return
+
+    data = read_json_file(state_file)
+    if not isinstance(data, dict):
+        return
+
+    now = _now_iso()
+    issue_key = str(issue)
+
+    # Update or create blocked_issue_retries entry
+    retries = data.setdefault("blocked_issue_retries", {})
+    existing = retries.get(issue_key, {})
+    existing.setdefault("retry_count", 0)
+    existing.setdefault("last_retry_at", None)
+    existing.setdefault("retry_exhausted", False)
+    existing["error_class"] = error_class
+    existing["last_blocked_at"] = now
+    existing["last_blocked_phase"] = phase
+    existing["last_blocked_details"] = details
+    retries[issue_key] = existing
+
+    # Append to recent_failures sliding window
+    failures: list[dict] = data.setdefault("recent_failures", [])
+    failures.append(
+        {
+            "issue": issue,
+            "error_class": error_class,
+            "phase": phase,
+            "timestamp": now,
+        }
+    )
+    # Keep only last N failures
+    data["recent_failures"] = failures[-_MAX_RECENT_FAILURES:]
+
+    write_json_file(state_file, data)
+
+
+def detect_systematic_failure(
+    repo_root: Path,
+    *,
+    update: bool = True,
+) -> SystematicFailure | None:
+    """Analyse recent failures for systematic patterns and optionally update state.
+
+    Checks whether the last *threshold* failures share the same
+    ``error_class``.  When detected and *update* is ``True``, writes the
+    ``systematic_failure`` field to ``daemon-state.json``.
+
+    This is the Python equivalent of ``detect-systematic-failure.sh --update``.
+
+    Args:
+        repo_root: Repository root path.
+        update: If ``True``, update the daemon state file.
+
+    Returns:
+        A :class:`SystematicFailure` if a pattern is detected, ``None``
+        otherwise.
+    """
+    paths = LoomPaths(repo_root)
+    state_file = paths.daemon_state_file
+
+    if not state_file.is_file():
+        return None
+
+    data = read_json_file(state_file)
+    if not isinstance(data, dict):
+        return None
+
+    threshold = _get_threshold()
+    cooldown = _get_cooldown()
+
+    failures_raw: list[dict] = data.get("recent_failures", [])
+    if len(failures_raw) < threshold:
+        if update:
+            data["systematic_failure"] = {}
+            write_json_file(state_file, data)
+        return None
+
+    # Check the last N failures for the same error class
+    last_n = failures_raw[-threshold:]
+    classes = {f.get("error_class", "unknown") for f in last_n}
+
+    if len(classes) != 1:
+        if update:
+            data["systematic_failure"] = {}
+            write_json_file(state_file, data)
+        return None
+
+    # Systematic failure detected
+    pattern = classes.pop()
+    now = _now_iso()
+    now_dt = datetime.now(timezone.utc)
+    cooldown_until_dt = now_dt + timedelta(seconds=cooldown)
+    cooldown_until = cooldown_until_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    sf = SystematicFailure(
+        active=True,
+        pattern=pattern,
+        count=threshold,
+        detected_at=now,
+        cooldown_until=cooldown_until,
+        probe_count=0,
+    )
+
+    if update:
+        data["systematic_failure"] = sf.to_dict()
+        write_json_file(state_file, data)
+
+    logger.warning(
+        "Systematic failure detected: pattern=%s, threshold=%d",
+        pattern,
+        threshold,
+    )
+    return sf
+
+
+def clear_systematic_failure(repo_root: Path) -> None:
+    """Clear systematic failure state and recent failures.
+
+    Equivalent to ``detect-systematic-failure.sh --clear`` and
+    ``--probe-success``.
+
+    Args:
+        repo_root: Repository root path.
+    """
+    paths = LoomPaths(repo_root)
+    state_file = paths.daemon_state_file
+
+    if not state_file.is_file():
+        return
+
+    data = read_json_file(state_file)
+    if not isinstance(data, dict):
+        return
+
+    data["systematic_failure"] = {}
+    data["recent_failures"] = []
+    write_json_file(state_file, data)
+
+
+def probe_started(repo_root: Path) -> int:
+    """Increment probe count and extend cooldown with exponential backoff.
+
+    Equivalent to ``detect-systematic-failure.sh --probe-started``.
+
+    Args:
+        repo_root: Repository root path.
+
+    Returns:
+        The new probe count.
+    """
+    paths = LoomPaths(repo_root)
+    state_file = paths.daemon_state_file
+
+    if not state_file.is_file():
+        return 0
+
+    data = read_json_file(state_file)
+    if not isinstance(data, dict):
+        return 0
+
+    cooldown_base = _get_cooldown()
+
+    sf_raw: dict = data.get("systematic_failure", {})
+    current_count = sf_raw.get("probe_count", 0)
+    new_count = current_count + 1
+
+    # Exponential backoff: base * 2^probe_count
+    effective_cooldown = cooldown_base * (1 << new_count)
+
+    now_dt = datetime.now(timezone.utc)
+    cooldown_until_dt = now_dt + timedelta(seconds=effective_cooldown)
+    cooldown_until = cooldown_until_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    sf_raw["probe_count"] = new_count
+    sf_raw["cooldown_until"] = cooldown_until
+    data["systematic_failure"] = sf_raw
+    write_json_file(state_file, data)
+
+    return new_count
+
+

--- a/loom-tools/src/loom_tools/shepherd/cli.py
+++ b/loom-tools/src/loom_tools/shepherd/cli.py
@@ -512,23 +512,20 @@ def _mark_doctor_exhausted(ctx: ShepherdContext) -> None:
         check=False,
     )
 
-    # Record blocked reason
-    ctx.run_script(
-        "record-blocked-reason.sh",
-        [
-            str(ctx.config.issue),
-            "--error-class",
-            "doctor_exhausted",
-            "--phase",
-            "doctor",
-            "--details",
-            f"max retries ({ctx.config.doctor_max_retries}) exceeded",
-        ],
-        check=False,
+    # Record blocked reason and update systematic failure tracking
+    from loom_tools.common.systematic_failure import (
+        detect_systematic_failure,
+        record_blocked_reason,
     )
 
-    # Update systematic failure tracking
-    ctx.run_script("detect-systematic-failure.sh", ["--update"], check=False)
+    record_blocked_reason(
+        ctx.repo_root,
+        ctx.config.issue,
+        error_class="doctor_exhausted",
+        phase="doctor",
+        details=f"max retries ({ctx.config.doctor_max_retries}) exceeded",
+    )
+    detect_systematic_failure(ctx.repo_root)
 
     # Add comment
     subprocess.run(

--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -799,23 +799,20 @@ class BuilderPhase:
             check=False,
         )
 
-        # Record blocked reason
-        ctx.run_script(
-            "record-blocked-reason.sh",
-            [
-                str(ctx.config.issue),
-                "--error-class",
-                error_class,
-                "--phase",
-                "builder",
-                "--details",
-                details,
-            ],
-            check=False,
+        # Record blocked reason and update systematic failure tracking
+        from loom_tools.common.systematic_failure import (
+            detect_systematic_failure,
+            record_blocked_reason,
         )
 
-        # Update systematic failure tracking
-        ctx.run_script("detect-systematic-failure.sh", ["--update"], check=False)
+        record_blocked_reason(
+            ctx.repo_root,
+            ctx.config.issue,
+            error_class=error_class,
+            phase="builder",
+            details=details,
+        )
+        detect_systematic_failure(ctx.repo_root)
 
         # Add comment
         subprocess.run(

--- a/loom-tools/src/loom_tools/shepherd/phases/doctor.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/doctor.py
@@ -126,23 +126,20 @@ class DoctorPhase:
             check=False,
         )
 
-        # Record blocked reason
-        ctx.run_script(
-            "record-blocked-reason.sh",
-            [
-                str(ctx.config.issue),
-                "--error-class",
-                error_class,
-                "--phase",
-                "doctor",
-                "--details",
-                details,
-            ],
-            check=False,
+        # Record blocked reason and update systematic failure tracking
+        from loom_tools.common.systematic_failure import (
+            detect_systematic_failure,
+            record_blocked_reason,
         )
 
-        # Update systematic failure tracking
-        ctx.run_script("detect-systematic-failure.sh", ["--update"], check=False)
+        record_blocked_reason(
+            ctx.repo_root,
+            ctx.config.issue,
+            error_class=error_class,
+            phase="doctor",
+            details=details,
+        )
+        detect_systematic_failure(ctx.repo_root)
 
         # Add comment
         subprocess.run(

--- a/loom-tools/src/loom_tools/shepherd/phases/judge.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/judge.py
@@ -386,23 +386,20 @@ class JudgePhase:
             check=False,
         )
 
-        # Record blocked reason
-        ctx.run_script(
-            "record-blocked-reason.sh",
-            [
-                str(ctx.config.issue),
-                "--error-class",
-                error_class,
-                "--phase",
-                "judge",
-                "--details",
-                details,
-            ],
-            check=False,
+        # Record blocked reason and update systematic failure tracking
+        from loom_tools.common.systematic_failure import (
+            detect_systematic_failure,
+            record_blocked_reason,
         )
 
-        # Update systematic failure tracking
-        ctx.run_script("detect-systematic-failure.sh", ["--update"], check=False)
+        record_blocked_reason(
+            ctx.repo_root,
+            ctx.config.issue,
+            error_class=error_class,
+            phase="judge",
+            details=details,
+        )
+        detect_systematic_failure(ctx.repo_root)
 
         # Add comment
         subprocess.run(

--- a/loom-tools/src/loom_tools/shepherd/phases/merge.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/merge.py
@@ -119,23 +119,20 @@ class MergePhase:
             check=False,
         )
 
-        # Record blocked reason
-        ctx.run_script(
-            "record-blocked-reason.sh",
-            [
-                str(ctx.config.issue),
-                "--error-class",
-                error_class,
-                "--phase",
-                "merge",
-                "--details",
-                details,
-            ],
-            check=False,
+        # Record blocked reason and update systematic failure tracking
+        from loom_tools.common.systematic_failure import (
+            detect_systematic_failure,
+            record_blocked_reason,
         )
 
-        # Update systematic failure tracking
-        ctx.run_script("detect-systematic-failure.sh", ["--update"], check=False)
+        record_blocked_reason(
+            ctx.repo_root,
+            ctx.config.issue,
+            error_class=error_class,
+            phase="merge",
+            details=details,
+        )
+        detect_systematic_failure(ctx.repo_root)
 
         # Add comment
         subprocess.run(

--- a/loom-tools/tests/test_systematic_failure.py
+++ b/loom-tools/tests/test_systematic_failure.py
@@ -1,0 +1,371 @@
+"""Tests for loom_tools.common.systematic_failure."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+from loom_tools.common.systematic_failure import (
+    clear_systematic_failure,
+    detect_systematic_failure,
+    probe_started,
+    record_blocked_reason,
+)
+
+
+@pytest.fixture
+def repo(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Create a minimal repo with .loom directory and empty daemon state."""
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".loom").mkdir()
+    _write_state(tmp_path, {"running": True})
+    return tmp_path
+
+
+def _write_state(repo: pathlib.Path, data: dict) -> None:
+    (repo / ".loom" / "daemon-state.json").write_text(json.dumps(data))
+
+
+def _read_state(repo: pathlib.Path) -> dict:
+    return json.loads((repo / ".loom" / "daemon-state.json").read_text())
+
+
+# ── record_blocked_reason ────────────────────────────────────────
+
+
+class TestRecordBlockedReason:
+    def test_records_retry_metadata(self, repo: pathlib.Path) -> None:
+        record_blocked_reason(
+            repo, 42, error_class="builder_stuck", phase="builder", details="timed out"
+        )
+        state = _read_state(repo)
+
+        retries = state["blocked_issue_retries"]
+        assert "42" in retries
+        entry = retries["42"]
+        assert entry["error_class"] == "builder_stuck"
+        assert entry["last_blocked_phase"] == "builder"
+        assert entry["last_blocked_details"] == "timed out"
+        assert entry["retry_count"] == 0
+        assert entry["retry_exhausted"] is False
+
+    def test_appends_to_recent_failures(self, repo: pathlib.Path) -> None:
+        record_blocked_reason(repo, 42, error_class="builder_stuck", phase="builder")
+        state = _read_state(repo)
+
+        failures = state["recent_failures"]
+        assert len(failures) == 1
+        assert failures[0]["issue"] == 42
+        assert failures[0]["error_class"] == "builder_stuck"
+        assert failures[0]["phase"] == "builder"
+        assert "timestamp" in failures[0]
+
+    def test_preserves_existing_retry_count(self, repo: pathlib.Path) -> None:
+        _write_state(
+            repo,
+            {
+                "blocked_issue_retries": {
+                    "42": {"retry_count": 2, "last_retry_at": "2026-01-01T00:00:00Z"}
+                }
+            },
+        )
+        record_blocked_reason(repo, 42, error_class="judge_stuck", phase="judge")
+        state = _read_state(repo)
+
+        entry = state["blocked_issue_retries"]["42"]
+        assert entry["retry_count"] == 2
+        assert entry["error_class"] == "judge_stuck"
+
+    def test_sliding_window_caps_at_20(self, repo: pathlib.Path) -> None:
+        # Pre-populate with 20 failures
+        existing = [
+            {"issue": i, "error_class": "old", "phase": "builder", "timestamp": "t"}
+            for i in range(20)
+        ]
+        _write_state(repo, {"recent_failures": existing})
+
+        record_blocked_reason(repo, 99, error_class="new_failure", phase="merge")
+        state = _read_state(repo)
+
+        assert len(state["recent_failures"]) == 20
+        assert state["recent_failures"][-1]["error_class"] == "new_failure"
+        # First entry should be issue 1, not issue 0
+        assert state["recent_failures"][0]["issue"] == 1
+
+    def test_no_state_file_is_noop(self, tmp_path: pathlib.Path) -> None:
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".loom").mkdir()
+        # No daemon-state.json exists
+        record_blocked_reason(tmp_path, 42, error_class="builder_stuck")
+        # Should not raise
+
+    def test_multiple_issues(self, repo: pathlib.Path) -> None:
+        record_blocked_reason(repo, 10, error_class="builder_stuck", phase="builder")
+        record_blocked_reason(repo, 20, error_class="judge_stuck", phase="judge")
+        state = _read_state(repo)
+
+        assert "10" in state["blocked_issue_retries"]
+        assert "20" in state["blocked_issue_retries"]
+        assert len(state["recent_failures"]) == 2
+
+
+# ── detect_systematic_failure ────────────────────────────────────
+
+
+class TestDetectSystematicFailure:
+    def test_no_failures_returns_none(self, repo: pathlib.Path) -> None:
+        result = detect_systematic_failure(repo)
+        assert result is None
+
+    def test_below_threshold_returns_none(self, repo: pathlib.Path) -> None:
+        _write_state(
+            repo,
+            {
+                "recent_failures": [
+                    {"error_class": "builder_stuck"},
+                    {"error_class": "builder_stuck"},
+                ]
+            },
+        )
+        result = detect_systematic_failure(repo)
+        assert result is None
+
+    def test_detects_same_error_class(self, repo: pathlib.Path) -> None:
+        _write_state(
+            repo,
+            {
+                "recent_failures": [
+                    {"error_class": "builder_stuck"},
+                    {"error_class": "builder_stuck"},
+                    {"error_class": "builder_stuck"},
+                ]
+            },
+        )
+        result = detect_systematic_failure(repo)
+        assert result is not None
+        assert result.active is True
+        assert result.pattern == "builder_stuck"
+        assert result.count == 3
+        assert result.probe_count == 0
+
+    def test_mixed_classes_returns_none(self, repo: pathlib.Path) -> None:
+        _write_state(
+            repo,
+            {
+                "recent_failures": [
+                    {"error_class": "builder_stuck"},
+                    {"error_class": "judge_stuck"},
+                    {"error_class": "builder_stuck"},
+                ]
+            },
+        )
+        result = detect_systematic_failure(repo)
+        assert result is None
+
+    def test_only_checks_last_n(self, repo: pathlib.Path) -> None:
+        """Earlier mixed failures shouldn't prevent detection."""
+        _write_state(
+            repo,
+            {
+                "recent_failures": [
+                    {"error_class": "judge_stuck"},
+                    {"error_class": "builder_stuck"},
+                    {"error_class": "builder_stuck"},
+                    {"error_class": "builder_stuck"},
+                ]
+            },
+        )
+        result = detect_systematic_failure(repo)
+        assert result is not None
+        assert result.pattern == "builder_stuck"
+
+    def test_updates_state_file(self, repo: pathlib.Path) -> None:
+        _write_state(
+            repo,
+            {
+                "recent_failures": [
+                    {"error_class": "merge_failed"},
+                    {"error_class": "merge_failed"},
+                    {"error_class": "merge_failed"},
+                ]
+            },
+        )
+        detect_systematic_failure(repo, update=True)
+        state = _read_state(repo)
+
+        sf = state["systematic_failure"]
+        assert sf["active"] is True
+        assert sf["pattern"] == "merge_failed"
+        assert sf["count"] == 3
+        assert sf["probe_count"] == 0
+        assert "detected_at" in sf
+        assert "cooldown_until" in sf
+
+    def test_clears_state_when_no_pattern(self, repo: pathlib.Path) -> None:
+        _write_state(
+            repo,
+            {
+                "systematic_failure": {"active": True, "pattern": "old"},
+                "recent_failures": [
+                    {"error_class": "a"},
+                    {"error_class": "b"},
+                    {"error_class": "c"},
+                ],
+            },
+        )
+        result = detect_systematic_failure(repo, update=True)
+        assert result is None
+
+        state = _read_state(repo)
+        assert state["systematic_failure"] == {}
+
+    def test_no_state_file_returns_none(self, tmp_path: pathlib.Path) -> None:
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".loom").mkdir()
+        result = detect_systematic_failure(tmp_path)
+        assert result is None
+
+    def test_no_update_mode(self, repo: pathlib.Path) -> None:
+        _write_state(
+            repo,
+            {
+                "recent_failures": [
+                    {"error_class": "builder_stuck"},
+                    {"error_class": "builder_stuck"},
+                    {"error_class": "builder_stuck"},
+                ]
+            },
+        )
+        result = detect_systematic_failure(repo, update=False)
+        assert result is not None
+
+        # State file should not be modified
+        state = _read_state(repo)
+        assert "systematic_failure" not in state
+
+    def test_custom_threshold(
+        self, repo: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("LOOM_SYSTEMATIC_FAILURE_THRESHOLD", "2")
+        _write_state(
+            repo,
+            {
+                "recent_failures": [
+                    {"error_class": "doctor_exhausted"},
+                    {"error_class": "doctor_exhausted"},
+                ]
+            },
+        )
+        result = detect_systematic_failure(repo)
+        assert result is not None
+        assert result.count == 2
+
+
+# ── clear_systematic_failure ─────────────────────────────────────
+
+
+class TestClearSystematicFailure:
+    def test_clears_failure_and_recent(self, repo: pathlib.Path) -> None:
+        _write_state(
+            repo,
+            {
+                "systematic_failure": {"active": True, "pattern": "builder_stuck"},
+                "recent_failures": [{"error_class": "builder_stuck"}],
+                "other_field": "preserved",
+            },
+        )
+        clear_systematic_failure(repo)
+        state = _read_state(repo)
+
+        assert state["systematic_failure"] == {}
+        assert state["recent_failures"] == []
+        assert state["other_field"] == "preserved"
+
+    def test_no_state_file_is_noop(self, tmp_path: pathlib.Path) -> None:
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".loom").mkdir()
+        clear_systematic_failure(tmp_path)
+
+
+# ── probe_started ────────────────────────────────────────────────
+
+
+class TestProbeStarted:
+    def test_increments_probe_count(self, repo: pathlib.Path) -> None:
+        _write_state(
+            repo,
+            {
+                "systematic_failure": {
+                    "active": True,
+                    "probe_count": 0,
+                }
+            },
+        )
+        count = probe_started(repo)
+        assert count == 1
+
+        state = _read_state(repo)
+        assert state["systematic_failure"]["probe_count"] == 1
+        assert "cooldown_until" in state["systematic_failure"]
+
+    def test_exponential_backoff(self, repo: pathlib.Path) -> None:
+        _write_state(
+            repo,
+            {
+                "systematic_failure": {
+                    "active": True,
+                    "probe_count": 2,
+                }
+            },
+        )
+        count = probe_started(repo)
+        assert count == 3
+
+    def test_no_state_file_returns_zero(self, tmp_path: pathlib.Path) -> None:
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".loom").mkdir()
+        count = probe_started(tmp_path)
+        assert count == 0
+
+
+# ── Integration: record + detect ─────────────────────────────────
+
+
+class TestIntegration:
+    def test_record_then_detect(self, repo: pathlib.Path) -> None:
+        """Recording 3 failures with the same class triggers detection."""
+        for _ in range(3):
+            record_blocked_reason(
+                repo, 42, error_class="builder_stuck", phase="builder"
+            )
+
+        result = detect_systematic_failure(repo)
+        assert result is not None
+        assert result.pattern == "builder_stuck"
+
+    def test_mixed_records_no_detection(self, repo: pathlib.Path) -> None:
+        """Mixed error classes don't trigger detection."""
+        record_blocked_reason(repo, 42, error_class="builder_stuck", phase="builder")
+        record_blocked_reason(repo, 43, error_class="judge_stuck", phase="judge")
+        record_blocked_reason(repo, 44, error_class="merge_failed", phase="merge")
+
+        result = detect_systematic_failure(repo)
+        assert result is None
+
+    def test_full_lifecycle(self, repo: pathlib.Path) -> None:
+        """Record failures -> detect -> clear -> verify clean."""
+        for i in range(3):
+            record_blocked_reason(
+                repo, i, error_class="worktree_failed", phase="builder"
+            )
+
+        sf = detect_systematic_failure(repo)
+        assert sf is not None
+        assert sf.active is True
+
+        clear_systematic_failure(repo)
+        state = _read_state(repo)
+        assert state["systematic_failure"] == {}
+        assert state["recent_failures"] == []


### PR DESCRIPTION
## Summary

- Replaces 12 shell subprocess calls (`record-blocked-reason.sh` and `detect-systematic-failure.sh`) across 5 Python modules with native Python implementations
- Creates `loom_tools/common/systematic_failure.py` with `record_blocked_reason()`, `detect_systematic_failure()`, `clear_systematic_failure()`, and `probe_started()` functions
- Adds `RecentFailure` dataclass and `recent_failures` field to `DaemonState` model, and adds missing `BlockedIssueRetry` fields (`error_class`, `last_blocked_at`, `last_blocked_phase`, `last_blocked_details`)
- Includes 24 unit tests covering all functions, edge cases, and integration scenarios

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Identical daemon-state.json updates | Verified | JSON structure matches shell script output format |
| All subprocess calls replaced | Verified | `grep` shows no remaining `.sh` calls in Python source (only docstrings) |
| Uses existing common/ infrastructure | Verified | Uses `read_json_file`, `write_json_file`, `LoomPaths`, `env_int` |
| Unit testable | Verified | 24 tests pass including integration scenarios |
| Shell scripts preserved | Verified | Scripts not modified, remain as deprecated fallbacks |
| No regressions | Verified | 1400 existing tests pass (3 pre-existing async failures unrelated) |

## Files Changed

| File | Change |
|------|--------|
| `common/systematic_failure.py` | New module with Python implementations |
| `models/daemon_state.py` | Added `RecentFailure`, extended `BlockedIssueRetry`, added `recent_failures` to `DaemonState` |
| `shepherd/phases/builder.py` | Replaced subprocess calls with Python function calls |
| `shepherd/phases/judge.py` | Replaced subprocess calls with Python function calls |
| `shepherd/phases/doctor.py` | Replaced subprocess calls with Python function calls |
| `shepherd/phases/merge.py` | Replaced subprocess calls with Python function calls |
| `shepherd/cli.py` | Replaced subprocess calls in doctor_exhausted handler |
| `tests/test_systematic_failure.py` | 24 new tests |

## Test plan

- [x] All 24 new tests pass (`pytest tests/test_systematic_failure.py`)
- [x] Full test suite passes (1400/1400, 3 pre-existing async failures unrelated)
- [x] DaemonState model round-trip serialization verified
- [ ] Integration test: shepherd blocking an issue records failure metadata correctly

Closes #1882

🤖 Generated with [Claude Code](https://claude.com/claude-code)