### PR TITLE
Reduce CI minutes on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,54 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
+  # Detect which file groups changed to skip irrelevant jobs on PRs
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: read
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+      backend: ${{ steps.filter.outputs.backend }}
+      mcp: ${{ steps.filter.outputs.mcp }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            frontend:
+              - 'src/**'
+              - 'e2e/**'
+              - 'defaults/**/*.ts'
+              - 'defaults/**/*.js'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'tsconfig.json'
+              - 'biome.json'
+              - '.github/workflows/ci.yml'
+            backend:
+              - 'src-tauri/**'
+              - 'loom-daemon/**'
+              - 'loom-api/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '.github/workflows/ci.yml'
+            mcp:
+              - 'mcp-loom/**'
+              - '.github/workflows/ci.yml'
+
   frontend-lint:
     name: Frontend Linting
+    needs: changes
+    if: always() && (github.event_name == 'push' || needs.changes.outputs.frontend == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,6 +67,8 @@ jobs:
 
   frontend-typecheck:
     name: TypeScript Type Checking
+    needs: changes
+    if: always() && (github.event_name == 'push' || needs.changes.outputs.frontend == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -38,6 +84,8 @@ jobs:
 
   frontend-tests:
     name: Frontend Unit Tests
+    needs: changes
+    if: always() && (github.event_name == 'push' || needs.changes.outputs.frontend == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -50,10 +98,11 @@ jobs:
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:unit
-      # Vitest unit tests only, no Rust tests needed here
 
-  backend-lint:
-    name: Rust Linting
+  backend-lint-and-check:
+    name: Rust Linting & Build Check
+    needs: changes
+    if: always() && (github.event_name == 'push' || needs.changes.outputs.backend == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -72,9 +121,12 @@ jobs:
           # Create platform-specific symlink expected by Tauri
           ln -sf loom-daemon target/release/loom-daemon-x86_64-unknown-linux-gnu
       - run: cargo clippy --package loom-daemon --package loom-api -- -D warnings -A clippy::cast_precision_loss -A clippy::cast_possible_truncation -A clippy::cast_sign_loss -A clippy::too_many_lines -A clippy::panic -A clippy::unwrap_used -A clippy::nonminimal_bool -A clippy::redundant_closure -A clippy::redundant_closure_for_method_calls -A clippy::format_push_string -A clippy::uninlined_format_args
+      - run: cargo check --workspace --all-targets
 
   backend-tests:
     name: Rust Unit Tests
+    needs: changes
+    if: always() && (github.event_name == 'push' || needs.changes.outputs.backend == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -93,6 +145,8 @@ jobs:
 
   mcp-build:
     name: MCP Server Build
+    needs: changes
+    if: always() && (github.event_name == 'push' || needs.changes.outputs.mcp == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -103,21 +157,3 @@ jobs:
         run: cd mcp-loom && npm install && npm run build
       - name: Verify build output
         run: test -f mcp-loom/dist/index.js
-
-  backend-build:
-    name: Daemon Build Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update || true
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev librsvg2-dev libappindicator3-dev patchelf
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: Build daemon binary (required for Tauri app)
-        run: |
-          cargo build --package loom-daemon --release
-          # Create platform-specific symlink expected by Tauri
-          ln -sf loom-daemon target/release/loom-daemon-x86_64-unknown-linux-gnu
-      - run: cargo check --workspace --all-targets

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,6 +4,18 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'src/**'
+      - 'e2e/**'
+      - 'src-tauri/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/e2e.yml'
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   e2e-tests:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,8 +4,17 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'Cargo.lock'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/security.yml'
   schedule:
     - cron: '0 0 * * 0'  # Weekly on Sunday
+
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   cargo-audit:
@@ -34,6 +43,8 @@ jobs:
 
   codeql:
     name: CodeQL Analysis
+    # Only run on push to main and weekly schedule, not on PRs
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-22.04
     permissions:
       security-events: write


### PR DESCRIPTION
## Summary

- Narrow `pull_request` triggers to `[opened, synchronize, reopened]` on `ci.yml`, `e2e.yml`, and `security.yml` — prevents CI re-runs on label changes, title edits, assignments
- Add `dorny/paths-filter` to `ci.yml` for per-job-group path filtering: frontend jobs trigger only on `src/`, `e2e/`, `package.json` etc.; backend jobs only on Rust/Cargo files; MCP build only on `mcp-loom/`
- Add workflow-level path filters to `e2e.yml` (frontend, E2E, and Tauri source only)
- Restrict `security.yml` PR trigger to lockfile changes only (`Cargo.lock`, `pnpm-lock.yaml`); skip CodeQL on PRs entirely (weekly cron + push to main is sufficient)
- Merge `backend-lint` and `backend-build` into `backend-lint-and-check`, eliminating one of three redundant `cargo build --package loom-daemon --release` invocations
- Add concurrency groups to all three workflows to cancel stale in-progress runs when new commits are pushed
- Push to `main` remains unfiltered (full CI suite always runs on merge)

All workflows self-include their own workflow file in path filters so workflow changes are still testable.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|-------------|
| Workflows specify `pull_request: types: [opened, synchronize, reopened]` | Verified | All three workflows updated |
| `ci.yml` has path-filtered job groups | Verified | `dorny/paths-filter` with frontend/backend/mcp groups |
| `e2e.yml` only runs on relevant PR changes | Verified | Path filter on `src/`, `e2e/`, `src-tauri/`, `package.json`, `pnpm-lock.yaml` |
| `security.yml` restricted to lockfile changes | Verified | Path filter on `Cargo.lock`, `pnpm-lock.yaml` |
| Workflows self-include their own file in path filters | Verified | Each group includes `.github/workflows/<self>.yml` |
| `push: branches: [main]` triggers remain unfiltered | Verified | No path filters on push triggers |
| Daemon deduplication | Verified | Merged `backend-lint` + `backend-build` → `backend-lint-and-check` (3 builds → 2) |

Closes #1900

🤖 Generated with [Claude Code](https://claude.com/claude-code)