### PR TITLE
Add judge retry mechanism in shepherd orchestrator

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/config.py
+++ b/loom-tools/src/loom_tools/shepherd/config.py
@@ -80,6 +80,9 @@ class ShepherdConfig:
     doctor_max_retries: int = field(
         default_factory=lambda: env_int("LOOM_DOCTOR_MAX_RETRIES", 3)
     )
+    judge_max_retries: int = field(
+        default_factory=lambda: env_int("LOOM_JUDGE_MAX_RETRIES", 1)
+    )
     stuck_max_retries: int = field(
         default_factory=lambda: env_int("LOOM_STUCK_MAX_RETRIES", 1)
     )

--- a/loom-tools/tests/shepherd/test_config.py
+++ b/loom-tools/tests/shepherd/test_config.py
@@ -168,7 +168,19 @@ class TestShepherdConfig:
         """Default retry limits should be set."""
         config = ShepherdConfig(issue=42)
         assert config.doctor_max_retries == 3
+        assert config.judge_max_retries == 1
         assert config.stuck_max_retries == 1
+
+    def test_judge_max_retries_env_override(self) -> None:
+        """LOOM_JUDGE_MAX_RETRIES env var should override default."""
+        with patch.dict(os.environ, {"LOOM_JUDGE_MAX_RETRIES": "3"}):
+            config = ShepherdConfig(issue=42)
+            assert config.judge_max_retries == 3
+
+    def test_judge_max_retries_explicit(self) -> None:
+        """judge_max_retries can be explicitly set."""
+        config = ShepherdConfig(issue=42, judge_max_retries=5)
+        assert config.judge_max_retries == 5
 
     def test_worktree_marker_file(self) -> None:
         """Worktree marker file should have default value."""


### PR DESCRIPTION
## Summary

- Adds judge-specific retry logic in the shepherd orchestrator when the judge phase returns `FAILED` (no label outcome), instead of immediately exiting with `return 1`
- Introduces `judge_max_retries` config field (default: 1, configurable via `LOOM_JUDGE_MAX_RETRIES` env var) separate from the existing doctor retry counter
- Adds `_mark_judge_exhausted` helper that transitions `loom:building` → `loom:blocked` with diagnostic comment and systematic failure tracking when retries are exhausted
- Reports `judge_retry` milestones for daemon observability

Closes #1909

## Criterion Verification

| Criterion | Status | Verification |
|-----------|--------|-------------|
| Judge FAILED triggers retry before giving up | ✅ | `test_judge_failure_triggers_retry_then_succeeds` |
| Separate judge retry counter from doctor_attempts | ✅ | `judge_retries` var independent of `doctor_attempts` |
| Exhausted retries → loom:blocked with diagnostic comment | ✅ | `test_judge_retry_exhaustion_marks_blocked`, `TestMarkJudgeExhausted` |
| Blocked reason recorded via systematic failure tracking | ✅ | `test_records_blocked_reason` |
| Milestone reporting for judge retries | ✅ | `test_judge_failure_retry_reports_milestones` |
| Approved/changes_requested paths unchanged | ✅ | `test_approved_path_unchanged_with_retry_logic`, `test_changes_requested_path_unchanged_with_retry_logic` |
| Force mode fallback runs before judge retry | ✅ | Fallback is in judge.py (unchanged), retry logic is in the orchestrator's handling of FAILED result |
| Config defaults and env override | ✅ | `test_default_retry_limits`, `test_judge_max_retries_env_override`, `test_judge_max_retries_explicit` |

## Test plan

- [x] `test_judge_failure_triggers_retry_then_succeeds` — Judge FAILED → retry → approved → completes
- [x] `test_judge_retry_exhaustion_marks_blocked` — Judge always FAILED → marks blocked, returns 1
- [x] `test_approved_path_unchanged_with_retry_logic` — Approved first try works identically
- [x] `test_changes_requested_path_unchanged_with_retry_logic` — Doctor loop works identically
- [x] `test_judge_failure_retry_reports_milestones` — Milestone includes attempt/max/reason
- [x] `TestMarkJudgeExhausted` — Label transition, blocked reason recording, diagnostic comment
- [x] `test_judge_max_retries_env_override` — LOOM_JUDGE_MAX_RETRIES env var works
- [x] `test_judge_max_retries_explicit` — Explicit config value works
- [x] All 1481 Python tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)