### PR TITLE
Increase builder timeout from 30 to 60 minutes

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/config.py
+++ b/loom-tools/src/loom_tools/shepherd/config.py
@@ -64,7 +64,7 @@ class ShepherdConfig:
         default_factory=lambda: env_int("LOOM_CURATOR_TIMEOUT", 300)
     )
     builder_timeout: int = field(
-        default_factory=lambda: env_int("LOOM_BUILDER_TIMEOUT", 1800)
+        default_factory=lambda: env_int("LOOM_BUILDER_TIMEOUT", 3600)
     )
     judge_timeout: int = field(
         default_factory=lambda: env_int("LOOM_JUDGE_TIMEOUT", 600)


### PR DESCRIPTION
## Summary

- Doubles the default `LOOM_BUILDER_TIMEOUT` from 1800s (30 min) to 3600s (60 min)
- Large Rust refactoring issues (2000-4000 line file decompositions) were failing to produce commits within the 30-minute window
- Still overridable via `LOOM_BUILDER_TIMEOUT` env var

## Test plan

- [ ] Verify `ShepherdConfig().builder_timeout` defaults to 3600
- [ ] Verify `LOOM_BUILDER_TIMEOUT=1800` override still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)