### PR TITLE
Add missing runtime artifacts and logs dir to uninstall script

### DIFF
--- a/scripts/uninstall-loom.sh
+++ b/scripts/uninstall-loom.sh
@@ -314,6 +314,11 @@ RUNTIME_ARTIFACTS=(
   ".loom/daemon-state.json"
   ".loom/config.json"
   ".loom/stop-daemon"
+  ".loom/manifest.json"
+  ".loom/loom-source-path"
+  ".loom/metrics_state.json"
+  ".loom/stuck-config.json"
+  ".loom/activity.db"
 )
 
 for artifact in "${RUNTIME_ARTIFACTS[@]}"; do
@@ -355,6 +360,7 @@ done
 RUNTIME_DIRS=(
   ".loom/worktrees"
   ".loom/progress"
+  ".loom/logs"
 )
 
 # 5. Mark CLAUDE.md and .gitignore for smart removal


### PR DESCRIPTION
Closes #1917

## Summary

- Add 5 missing runtime artifacts to `RUNTIME_ARTIFACTS` array in `scripts/uninstall-loom.sh`: `manifest.json`, `loom-source-path`, `metrics_state.json`, `stuck-config.json`, `activity.db`
- Add `.loom/logs` to `RUNTIME_DIRS` array so the logs subdirectory and its contents are cleaned up during uninstall

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `manifest.json` removed | Done | Added to `RUNTIME_ARTIFACTS` at line 317 |
| `loom-source-path` removed | Done | Added to `RUNTIME_ARTIFACTS` at line 318 |
| `logs/` directory removed | Done | Added to `RUNTIME_DIRS` at line 363 |
| `metrics_state.json` removed | Done | Added to `RUNTIME_ARTIFACTS` at line 319 |
| `stuck-config.json` removed | Done | Added to `RUNTIME_ARTIFACTS` at line 320 |
| `activity.db` removed | Done | Added to `RUNTIME_ARTIFACTS` at line 321 |
| `.loom/` fully removed after uninstall | Covered | Step 7 cleanup removes empty `.loom/` dir |
| Reinstall succeeds without `--force` | Covered | No leftover files to trigger force requirement |

## Test Plan

- Fresh install, then uninstall: `.loom/` fully removed
- Install + daemon run, then uninstall: all new artifacts removed
- Dry-run mode: new artifacts appear in removal list
- `--keep-config`: config preserved, new artifacts still listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)