### PR TITLE
Fix install.sh quick reinstall to pass --force and --defaults to loom-daemon init

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -419,7 +419,7 @@ elif [[ -d "$TARGET_PATH/.loom" ]]; then
     fi
 
     # Run loom-daemon init
-    "$LOOM_ROOT/target/release/loom-daemon" init "$TARGET_PATH" || \
+    "$LOOM_ROOT/target/release/loom-daemon" init --force --defaults "$LOOM_ROOT/defaults" "$TARGET_PATH" || \
       error "Installation failed"
     echo ""
     success "Quick reinstallation complete!"


### PR DESCRIPTION
Closes #1916

## Summary

The quick reinstall path in `install.sh` (line 422) called `loom-daemon init` without `--force` or `--defaults` flags, causing "Workspace already initialized" errors when running `./install.sh --quick` twice in succession. The full install path (`scripts/install-loom.sh:516`) already passed both flags correctly.

## Changes

Single-line fix: added `--force --defaults "$LOOM_ROOT/defaults"` to the `loom-daemon init` call in the quick reinstall path.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `install.sh` quick reinstall path passes `--force` to `loom-daemon init` | ✅ | `--force` flag added at line 422 |
| `install.sh` quick reinstall path passes `--defaults "$LOOM_ROOT/defaults"` to `loom-daemon init` | ✅ | `--defaults` flag added at line 422 |
| Running `./install.sh --quick /path/to/repo` twice in succession completes without error | ✅ | `--force` flag prevents "already initialized" error on second run |

## Test Plan

- [ ] Fresh install: `./install.sh --quick /path/to/repo` succeeds (no regression)
- [ ] Reinstall: Run the same command again immediately - should succeed without error
- [ ] Partial uninstall: Manually leave a file in `.loom/` before reinstall - should still succeed due to `--force`
- [ ] Verify installed config uses defaults from loom source (not stale local config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)