### PR TITLE
Fix worktree cleanup to run git from repo root

### DIFF
--- a/defaults/scripts/worktree.sh
+++ b/defaults/scripts/worktree.sh
@@ -469,8 +469,11 @@ if [[ -d "$WORKTREE_PATH" ]]; then
             fi
 
             # Remove the stale worktree (safety checks passed)
-            local_branch=$(git -C "$WORKTREE_PATH" rev-parse --abbrev-ref HEAD 2>/dev/null) || local_branch=""
-            git worktree remove "$WORKTREE_PATH" --force 2>/dev/null || {
+            # Use absolute path and git -C to avoid CWD-inside-worktree issues
+            ABS_WORKTREE="$(cd "$WORKTREE_PATH" 2>/dev/null && pwd -P || echo "$WORKTREE_PATH")"
+            REPO_DIR="$(pwd -P)"
+            local_branch=$(git -C "$ABS_WORKTREE" rev-parse --abbrev-ref HEAD 2>/dev/null) || local_branch=""
+            git -C "$REPO_DIR" worktree remove "$ABS_WORKTREE" --force 2>/dev/null || {
                 print_error "Failed to remove stale worktree"
                 exit 1
             }

--- a/loom-tools/src/loom_tools/worktree.py
+++ b/loom-tools/src/loom_tools/worktree.py
@@ -226,12 +226,17 @@ def _check_stale_worktree(worktree_path: pathlib.Path, json_output: bool = False
             result = _run_git(["rev-parse", "--abbrev-ref", "HEAD"], cwd=worktree_path, check=False)
             branch = result.stdout.strip() if result.returncode == 0 else ""
 
-            # Remove worktree
-            _run_git(["worktree", "remove", str(worktree_path), "--force"], check=False)
+            # Remove worktree (run from repo root to avoid CWD-inside-worktree issues)
+            repo_root = _get_main_workspace()
+            _run_git(
+                ["worktree", "remove", str(worktree_path), "--force"],
+                cwd=repo_root,
+                check=False,
+            )
 
             # Delete empty branch if possible
             if branch and branch != "main":
-                result = _run_git(["branch", "-d", branch], check=False)
+                result = _run_git(["branch", "-d", branch], cwd=repo_root, check=False)
                 if result.returncode == 0 and not json_output:
                     log_info(f"Removed empty branch: {branch}")
 


### PR DESCRIPTION
## Summary
- Fix three locations where `git worktree remove` could run with CWD inside the worktree being deleted, causing the shell to become permanently broken
- `worktree.py`: pass `cwd=repo_root` to `_run_git` for stale worktree removal and branch deletion
- `terminal.rs`: derive repo root from worktree path ancestors and set `.current_dir()` on git commands
- `worktree.sh`: use `git -C` with absolute paths instead of bare `git worktree remove` with relative paths

## Test plan
- [x] Python syntax check passes
- [x] Rust `cargo check` passes
- [x] Bash syntax check passes
- [x] Python worktree tests pass (67 passed, 1 skipped)
- [x] Rust `cargo test` passes (pre-existing integration test isolation issues unrelated to this change)
- [ ] Manual: run shepherd with `--merge` on an issue, verify shell remains functional after worktree cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)