### PR TITLE
Split activity db.rs into domain-specific submodules

### DIFF
--- a/loom-daemon/src/activity/claims.rs
+++ b/loom-daemon/src/activity/claims.rs
@@ -1,0 +1,752 @@
+//! Issue claim registry for reliable work distribution.
+//!
+//! Extracted from `db.rs` (Issue #1159) — provides claim/release operations,
+//! heartbeat-based liveness, stale claim detection, and crash recovery.
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use rusqlite::{params, Connection};
+
+use super::models::{ClaimResult, ClaimType, ClaimsSummary, IssueClaim};
+
+// ========================================================================
+// Claim Operations
+// ========================================================================
+
+/// Attempt to claim an issue or PR for a terminal.
+///
+/// This uses INSERT OR IGNORE with a unique constraint to prevent race conditions.
+/// If the claim already exists, it checks if the claim is stale (based on TTL)
+/// and can be reclaimed.
+///
+/// # Arguments
+/// * `number` - The issue or PR number to claim
+/// * `claim_type` - Whether this is an issue or PR claim
+/// * `terminal_id` - The terminal claiming the work
+/// * `label` - Optional GitHub label associated with this claim
+/// * `agent_role` - Optional agent role for tracking
+/// * `stale_threshold_secs` - How many seconds before a claim is considered stale (default: 3600 = 1 hour)
+pub(super) fn claim_issue(
+    conn: &Connection,
+    number: i32,
+    claim_type: ClaimType,
+    terminal_id: &str,
+    label: Option<&str>,
+    agent_role: Option<&str>,
+    stale_threshold_secs: Option<i64>,
+) -> Result<ClaimResult> {
+    let now = Utc::now();
+    let claim_type_str = claim_type.as_str();
+    let stale_threshold = stale_threshold_secs.unwrap_or(3600); // Default 1 hour
+
+    // First, try to insert a new claim
+    let insert_result = conn.execute(
+        r"
+        INSERT OR IGNORE INTO issue_claims (number, claim_type, terminal_id, claimed_at, last_heartbeat, label, agent_role)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+        ",
+        params![
+            number,
+            claim_type_str,
+            terminal_id,
+            now.to_rfc3339(),
+            now.to_rfc3339(),
+            label,
+            agent_role,
+        ],
+    )?;
+
+    // If insert succeeded (rows_affected == 1), we got the claim
+    if insert_result == 1 {
+        let claim_id = conn.last_insert_rowid();
+        return Ok(ClaimResult::Success { claim_id });
+    }
+
+    // Insert failed due to unique constraint - check existing claim
+    let existing: (i64, String, String) = conn.query_row(
+        r"
+        SELECT id, terminal_id, last_heartbeat
+        FROM issue_claims
+        WHERE number = ?1 AND claim_type = ?2
+        ",
+        params![number, claim_type_str],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+    )?;
+
+    let (existing_id, existing_terminal, heartbeat_str) = existing;
+    let heartbeat = DateTime::parse_from_rfc3339(&heartbeat_str)
+        .map_err(|e| anyhow::anyhow!("Invalid timestamp: {e}"))?
+        .with_timezone(&Utc);
+
+    // Check if the existing claim is stale
+    let age_secs = (now - heartbeat).num_seconds();
+
+    if age_secs > stale_threshold {
+        // Claim is stale - reclaim it
+        conn.execute(
+            r"
+            UPDATE issue_claims
+            SET terminal_id = ?1, claimed_at = ?2, last_heartbeat = ?3, label = ?4, agent_role = ?5
+            WHERE id = ?6
+            ",
+            params![
+                terminal_id,
+                now.to_rfc3339(),
+                now.to_rfc3339(),
+                label,
+                agent_role,
+                existing_id,
+            ],
+        )?;
+
+        Ok(ClaimResult::Reclaimed {
+            claim_id: existing_id,
+            previous_terminal: existing_terminal,
+        })
+    } else {
+        // Claim is still active - return the current owner
+        let claimed_at_str: String = conn.query_row(
+            r"SELECT claimed_at FROM issue_claims WHERE id = ?1",
+            params![existing_id],
+            |row| row.get(0),
+        )?;
+        let claimed_at = DateTime::parse_from_rfc3339(&claimed_at_str)
+            .map_err(|e| anyhow::anyhow!("Invalid timestamp: {e}"))?
+            .with_timezone(&Utc);
+
+        Ok(ClaimResult::AlreadyClaimed {
+            terminal_id: existing_terminal,
+            claimed_at,
+        })
+    }
+}
+
+/// Release a claim on an issue or PR.
+///
+/// This removes the claim from the registry. Can be called when work is complete
+/// or if the agent decides to abandon the work.
+///
+/// # Arguments
+/// * `number` - The issue or PR number to release
+/// * `claim_type` - Whether this is an issue or PR claim
+/// * `terminal_id` - Optional: only release if owned by this terminal
+pub(super) fn release_claim(
+    conn: &Connection,
+    number: i32,
+    claim_type: ClaimType,
+    terminal_id: Option<&str>,
+) -> Result<bool> {
+    let claim_type_str = claim_type.as_str();
+
+    let rows = if let Some(tid) = terminal_id {
+        conn.execute(
+            r"DELETE FROM issue_claims WHERE number = ?1 AND claim_type = ?2 AND terminal_id = ?3",
+            params![number, claim_type_str, tid],
+        )?
+    } else {
+        conn.execute(
+            r"DELETE FROM issue_claims WHERE number = ?1 AND claim_type = ?2",
+            params![number, claim_type_str],
+        )?
+    };
+
+    Ok(rows > 0)
+}
+
+/// Update the heartbeat for an active claim.
+///
+/// This should be called periodically by agents to indicate they are still
+/// working on a claimed issue. Claims without heartbeat updates will be
+/// considered stale after the TTL threshold.
+pub(super) fn heartbeat_claim(
+    conn: &Connection,
+    number: i32,
+    claim_type: ClaimType,
+    terminal_id: &str,
+) -> Result<bool> {
+    let now = Utc::now();
+    let claim_type_str = claim_type.as_str();
+
+    let rows = conn.execute(
+        r"
+        UPDATE issue_claims
+        SET last_heartbeat = ?1
+        WHERE number = ?2 AND claim_type = ?3 AND terminal_id = ?4
+        ",
+        params![now.to_rfc3339(), number, claim_type_str, terminal_id],
+    )?;
+
+    Ok(rows > 0)
+}
+
+// ========================================================================
+// Claim Queries
+// ========================================================================
+
+/// Get a specific claim if it exists.
+pub(super) fn get_claim(
+    conn: &Connection,
+    number: i32,
+    claim_type: ClaimType,
+) -> Result<Option<IssueClaim>> {
+    let claim_type_str = claim_type.as_str();
+
+    let result = conn.query_row(
+        r"
+        SELECT id, number, claim_type, terminal_id, claimed_at, last_heartbeat, label, agent_role
+        FROM issue_claims
+        WHERE number = ?1 AND claim_type = ?2
+        ",
+        params![number, claim_type_str],
+        |row| {
+            let claimed_at_str: String = row.get(4)?;
+            let heartbeat_str: String = row.get(5)?;
+
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i32>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                claimed_at_str,
+                heartbeat_str,
+                row.get::<_, Option<String>>(6)?,
+                row.get::<_, Option<String>>(7)?,
+            ))
+        },
+    );
+
+    match result {
+        Ok((id, num, ct_str, tid, claimed_str, heartbeat_str, label, role)) => {
+            let claimed_at = DateTime::parse_from_rfc3339(&claimed_str)
+                .map_err(|e| anyhow::anyhow!("Invalid timestamp: {e}"))?
+                .with_timezone(&Utc);
+            let last_heartbeat = DateTime::parse_from_rfc3339(&heartbeat_str)
+                .map_err(|e| anyhow::anyhow!("Invalid timestamp: {e}"))?
+                .with_timezone(&Utc);
+
+            Ok(Some(IssueClaim {
+                id: Some(id),
+                number: num,
+                claim_type: ClaimType::from_str(&ct_str).unwrap_or(ClaimType::Issue),
+                terminal_id: tid,
+                claimed_at,
+                last_heartbeat,
+                label,
+                agent_role: role,
+            }))
+        }
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Get all active claims.
+pub(super) fn get_all_claims(conn: &Connection) -> Result<Vec<IssueClaim>> {
+    let mut stmt = conn.prepare(
+        r"
+        SELECT id, number, claim_type, terminal_id, claimed_at, last_heartbeat, label, agent_role
+        FROM issue_claims
+        ORDER BY claimed_at
+        ",
+    )?;
+
+    let claims = stmt.query_map([], |row| {
+        let claimed_at_str: String = row.get(4)?;
+        let heartbeat_str: String = row.get(5)?;
+        let ct_str: String = row.get(2)?;
+
+        Ok((
+            row.get::<_, i64>(0)?,
+            row.get::<_, i32>(1)?,
+            ct_str,
+            row.get::<_, String>(3)?,
+            claimed_at_str,
+            heartbeat_str,
+            row.get::<_, Option<String>>(6)?,
+            row.get::<_, Option<String>>(7)?,
+        ))
+    })?;
+
+    let mut result = Vec::new();
+    for claim in claims {
+        let (id, num, ct_str, tid, claimed_str, heartbeat_str, label, role) = claim?;
+
+        let claimed_at = DateTime::parse_from_rfc3339(&claimed_str)
+            .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?
+            .with_timezone(&Utc);
+        let last_heartbeat = DateTime::parse_from_rfc3339(&heartbeat_str)
+            .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?
+            .with_timezone(&Utc);
+
+        result.push(IssueClaim {
+            id: Some(id),
+            number: num,
+            claim_type: ClaimType::from_str(&ct_str).unwrap_or(ClaimType::Issue),
+            terminal_id: tid,
+            claimed_at,
+            last_heartbeat,
+            label,
+            agent_role: role,
+        });
+    }
+
+    Ok(result)
+}
+
+/// Get claims for a specific terminal.
+pub(super) fn get_claims_by_terminal(
+    conn: &Connection,
+    terminal_id: &str,
+) -> Result<Vec<IssueClaim>> {
+    let mut stmt = conn.prepare(
+        r"
+        SELECT id, number, claim_type, terminal_id, claimed_at, last_heartbeat, label, agent_role
+        FROM issue_claims
+        WHERE terminal_id = ?1
+        ORDER BY claimed_at
+        ",
+    )?;
+
+    let claims = stmt.query_map(params![terminal_id], |row| {
+        let claimed_at_str: String = row.get(4)?;
+        let heartbeat_str: String = row.get(5)?;
+        let ct_str: String = row.get(2)?;
+
+        Ok((
+            row.get::<_, i64>(0)?,
+            row.get::<_, i32>(1)?,
+            ct_str,
+            row.get::<_, String>(3)?,
+            claimed_at_str,
+            heartbeat_str,
+            row.get::<_, Option<String>>(6)?,
+            row.get::<_, Option<String>>(7)?,
+        ))
+    })?;
+
+    let mut result = Vec::new();
+    for claim in claims {
+        let (id, num, ct_str, tid, claimed_str, heartbeat_str, label, role) = claim?;
+
+        let claimed_at = DateTime::parse_from_rfc3339(&claimed_str)
+            .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?
+            .with_timezone(&Utc);
+        let last_heartbeat = DateTime::parse_from_rfc3339(&heartbeat_str)
+            .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?
+            .with_timezone(&Utc);
+
+        result.push(IssueClaim {
+            id: Some(id),
+            number: num,
+            claim_type: ClaimType::from_str(&ct_str).unwrap_or(ClaimType::Issue),
+            terminal_id: tid,
+            claimed_at,
+            last_heartbeat,
+            label,
+            agent_role: role,
+        });
+    }
+
+    Ok(result)
+}
+
+/// Get stale claims (those without heartbeat for longer than threshold).
+///
+/// # Arguments
+/// * `stale_threshold_secs` - How many seconds before a claim is considered stale
+pub(super) fn get_stale_claims(
+    conn: &Connection,
+    stale_threshold_secs: i64,
+) -> Result<Vec<IssueClaim>> {
+    let threshold_time = Utc::now() - chrono::Duration::seconds(stale_threshold_secs);
+
+    let mut stmt = conn.prepare(
+        r"
+        SELECT id, number, claim_type, terminal_id, claimed_at, last_heartbeat, label, agent_role
+        FROM issue_claims
+        WHERE last_heartbeat < ?1
+        ORDER BY last_heartbeat
+        ",
+    )?;
+
+    let claims = stmt.query_map(params![threshold_time.to_rfc3339()], |row| {
+        let claimed_at_str: String = row.get(4)?;
+        let heartbeat_str: String = row.get(5)?;
+        let ct_str: String = row.get(2)?;
+
+        Ok((
+            row.get::<_, i64>(0)?,
+            row.get::<_, i32>(1)?,
+            ct_str,
+            row.get::<_, String>(3)?,
+            claimed_at_str,
+            heartbeat_str,
+            row.get::<_, Option<String>>(6)?,
+            row.get::<_, Option<String>>(7)?,
+        ))
+    })?;
+
+    let mut result = Vec::new();
+    for claim in claims {
+        let (id, num, ct_str, tid, claimed_str, heartbeat_str, label, role) = claim?;
+
+        let claimed_at = DateTime::parse_from_rfc3339(&claimed_str)
+            .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?
+            .with_timezone(&Utc);
+        let last_heartbeat = DateTime::parse_from_rfc3339(&heartbeat_str)
+            .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?
+            .with_timezone(&Utc);
+
+        result.push(IssueClaim {
+            id: Some(id),
+            number: num,
+            claim_type: ClaimType::from_str(&ct_str).unwrap_or(ClaimType::Issue),
+            terminal_id: tid,
+            claimed_at,
+            last_heartbeat,
+            label,
+            agent_role: role,
+        });
+    }
+
+    Ok(result)
+}
+
+// ========================================================================
+// Claim Lifecycle
+// ========================================================================
+
+/// Release all stale claims and return the count of claims released.
+///
+/// This is used during daemon startup for crash recovery.
+pub(super) fn release_stale_claims(conn: &Connection, stale_threshold_secs: i64) -> Result<usize> {
+    let threshold_time = Utc::now() - chrono::Duration::seconds(stale_threshold_secs);
+
+    let rows = conn.execute(
+        r"DELETE FROM issue_claims WHERE last_heartbeat < ?1",
+        params![threshold_time.to_rfc3339()],
+    )?;
+
+    Ok(rows)
+}
+
+/// Release all claims for a specific terminal.
+///
+/// This is used when a terminal is destroyed or restarted.
+pub(super) fn release_terminal_claims(conn: &Connection, terminal_id: &str) -> Result<usize> {
+    let rows =
+        conn.execute(r"DELETE FROM issue_claims WHERE terminal_id = ?1", params![terminal_id])?;
+
+    Ok(rows)
+}
+
+/// Get a summary of all claims for visibility.
+pub(super) fn get_claims_summary(
+    conn: &Connection,
+    stale_threshold_secs: i64,
+) -> Result<ClaimsSummary> {
+    let all_claims = get_all_claims(conn)?;
+    let stale_claims = get_stale_claims(conn, stale_threshold_secs)?;
+
+    let mut by_type = std::collections::HashMap::new();
+    let mut by_terminal: std::collections::HashMap<String, Vec<i32>> =
+        std::collections::HashMap::new();
+
+    for claim in &all_claims {
+        *by_type
+            .entry(claim.claim_type.as_str().to_string())
+            .or_insert(0) += 1;
+        by_terminal
+            .entry(claim.terminal_id.clone())
+            .or_default()
+            .push(claim.number);
+    }
+
+    #[allow(clippy::cast_possible_wrap)]
+    Ok(ClaimsSummary {
+        total_claims: all_claims.len() as i64,
+        by_type,
+        by_terminal,
+        stale_claims,
+    })
+}
+
+// ========================================================================
+// Tests
+// ========================================================================
+
+#[cfg(test)]
+#[allow(
+    clippy::panic,
+    clippy::unwrap_used,
+    clippy::redundant_closure_for_method_calls
+)]
+mod tests {
+    use super::super::db::ActivityDb;
+    use super::super::models::{ClaimResult, ClaimType};
+    use super::*;
+    use rusqlite::params;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_claim_issue_success() -> Result<()> {
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        let result = db.claim_issue(
+            123,
+            ClaimType::Issue,
+            "terminal-1",
+            Some("loom:building"),
+            Some("builder"),
+            None,
+        )?;
+
+        match result {
+            ClaimResult::Success { claim_id } => {
+                assert!(claim_id > 0);
+            }
+            _ => panic!("Expected ClaimResult::Success"),
+        }
+
+        let claim = db.get_claim(123, ClaimType::Issue)?;
+        assert!(claim.is_some());
+        let claim = claim.unwrap();
+        assert_eq!(claim.number, 123);
+        assert_eq!(claim.terminal_id, "terminal-1");
+        assert_eq!(claim.label, Some("loom:building".to_string()));
+        assert_eq!(claim.agent_role, Some("builder".to_string()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_claim_issue_already_claimed() -> Result<()> {
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        let _result1 = db.claim_issue(123, ClaimType::Issue, "terminal-1", None, None, None)?;
+
+        let result2 = db.claim_issue(123, ClaimType::Issue, "terminal-2", None, None, None)?;
+
+        match result2 {
+            ClaimResult::AlreadyClaimed { terminal_id, .. } => {
+                assert_eq!(terminal_id, "terminal-1");
+            }
+            _ => panic!("Expected ClaimResult::AlreadyClaimed"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_claim_issue_reclaim_stale() -> Result<()> {
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        let _result1 = db.claim_issue(123, ClaimType::Issue, "terminal-1", None, None, None)?;
+
+        // Manually make it stale by updating the heartbeat to the past
+        let old_time = Utc::now() - chrono::Duration::hours(2);
+        db.conn.execute(
+            "UPDATE issue_claims SET last_heartbeat = ?1 WHERE number = 123",
+            params![old_time.to_rfc3339()],
+        )?;
+
+        // Now claim with stale threshold of 1 hour - should reclaim
+        let result2 =
+            db.claim_issue(123, ClaimType::Issue, "terminal-2", None, None, Some(3600))?;
+
+        match result2 {
+            ClaimResult::Reclaimed {
+                previous_terminal, ..
+            } => {
+                assert_eq!(previous_terminal, "terminal-1");
+            }
+            _ => panic!("Expected ClaimResult::Reclaimed"),
+        }
+
+        let claim = db.get_claim(123, ClaimType::Issue)?.unwrap();
+        assert_eq!(claim.terminal_id, "terminal-2");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_release_claim() -> Result<()> {
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        db.claim_issue(123, ClaimType::Issue, "terminal-1", None, None, None)?;
+
+        let released = db.release_claim(123, ClaimType::Issue, Some("terminal-1"))?;
+        assert!(released);
+
+        let claim = db.get_claim(123, ClaimType::Issue)?;
+        assert!(claim.is_none());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_release_claim_wrong_terminal() -> Result<()> {
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        db.claim_issue(123, ClaimType::Issue, "terminal-1", None, None, None)?;
+
+        let released = db.release_claim(123, ClaimType::Issue, Some("terminal-2"))?;
+        assert!(!released);
+
+        let claim = db.get_claim(123, ClaimType::Issue)?;
+        assert!(claim.is_some());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_heartbeat_claim() -> Result<()> {
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        db.claim_issue(123, ClaimType::Issue, "terminal-1", None, None, None)?;
+
+        let claim_before = db.get_claim(123, ClaimType::Issue)?.unwrap();
+        let heartbeat_before = claim_before.last_heartbeat;
+
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        let updated = db.heartbeat_claim(123, ClaimType::Issue, "terminal-1")?;
+        assert!(updated);
+
+        let claim_after = db.get_claim(123, ClaimType::Issue)?.unwrap();
+        assert!(claim_after.last_heartbeat > heartbeat_before);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_terminal_claims() -> Result<()> {
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        db.claim_issue(123, ClaimType::Issue, "terminal-1", None, None, None)?;
+        db.claim_issue(456, ClaimType::Pr, "terminal-1", None, None, None)?;
+        db.claim_issue(789, ClaimType::Issue, "terminal-2", None, None, None)?;
+
+        let claims = db.get_claims_by_terminal("terminal-1")?;
+        assert_eq!(claims.len(), 2);
+
+        let claims = db.get_claims_by_terminal("terminal-2")?;
+        assert_eq!(claims.len(), 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_stale_claims() -> Result<()> {
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        db.claim_issue(123, ClaimType::Issue, "terminal-1", None, None, None)?;
+        db.claim_issue(456, ClaimType::Issue, "terminal-2", None, None, None)?;
+
+        let old_time = Utc::now() - chrono::Duration::hours(2);
+        db.conn.execute(
+            "UPDATE issue_claims SET last_heartbeat = ?1 WHERE number = 123",
+            params![old_time.to_rfc3339()],
+        )?;
+
+        let stale = db.get_stale_claims(3600)?;
+        assert_eq!(stale.len(), 1);
+        assert_eq!(stale[0].number, 123);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_release_stale_claims() -> Result<()> {
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        db.claim_issue(123, ClaimType::Issue, "terminal-1", None, None, None)?;
+        db.claim_issue(456, ClaimType::Issue, "terminal-2", None, None, None)?;
+
+        let old_time = Utc::now() - chrono::Duration::hours(2);
+        db.conn.execute(
+            "UPDATE issue_claims SET last_heartbeat = ?1 WHERE number = 123",
+            params![old_time.to_rfc3339()],
+        )?;
+
+        let count = db.release_stale_claims(3600)?;
+        assert_eq!(count, 1);
+
+        let all = db.get_all_claims()?;
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].number, 456);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_release_terminal_claims() -> Result<()> {
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        db.claim_issue(123, ClaimType::Issue, "terminal-1", None, None, None)?;
+        db.claim_issue(456, ClaimType::Pr, "terminal-1", None, None, None)?;
+        db.claim_issue(789, ClaimType::Issue, "terminal-2", None, None, None)?;
+
+        let count = db.release_terminal_claims("terminal-1")?;
+        assert_eq!(count, 2);
+
+        let all = db.get_all_claims()?;
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].terminal_id, "terminal-2");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_claims_summary() -> Result<()> {
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        db.claim_issue(100, ClaimType::Issue, "terminal-1", None, None, None)?;
+        db.claim_issue(101, ClaimType::Issue, "terminal-1", None, None, None)?;
+        db.claim_issue(200, ClaimType::Pr, "terminal-2", None, None, None)?;
+
+        let old_time = Utc::now() - chrono::Duration::hours(2);
+        db.conn.execute(
+            "UPDATE issue_claims SET last_heartbeat = ?1 WHERE number = 100",
+            params![old_time.to_rfc3339()],
+        )?;
+
+        let summary = db.get_claims_summary(3600)?;
+        assert_eq!(summary.total_claims, 3);
+        assert_eq!(summary.by_type.get("issue"), Some(&2));
+        assert_eq!(summary.by_type.get("pr"), Some(&1));
+        assert_eq!(summary.by_terminal.get("terminal-1").map(|v| v.len()), Some(2));
+        assert_eq!(summary.by_terminal.get("terminal-2").map(|v| v.len()), Some(1));
+        assert_eq!(summary.stale_claims.len(), 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_claim_type_isolation() -> Result<()> {
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        db.claim_issue(123, ClaimType::Issue, "terminal-1", None, None, None)?;
+        db.claim_issue(123, ClaimType::Pr, "terminal-2", None, None, None)?;
+
+        let issue_claim = db.get_claim(123, ClaimType::Issue)?.unwrap();
+        let pr_claim = db.get_claim(123, ClaimType::Pr)?.unwrap();
+
+        assert_eq!(issue_claim.terminal_id, "terminal-1");
+        assert_eq!(pr_claim.terminal_id, "terminal-2");
+
+        Ok(())
+    }
+}

--- a/loom-daemon/src/activity/cost_analytics.rs
+++ b/loom-daemon/src/activity/cost_analytics.rs
@@ -1,0 +1,880 @@
+//! Cost analytics and budget management.
+//!
+//! Extracted from `db.rs` (Issue #1064) — provides budget configuration,
+//! cost breakdowns by role/issue/PR, budget status checks, and runway projections.
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use rusqlite::{params, Connection};
+
+use super::models::{
+    BudgetConfig, BudgetPeriod, BudgetStatus, CostByIssue, CostByPr, CostByRole, CostSummary,
+    RunwayProjection,
+};
+
+// ========================================================================
+// Budget Configuration
+// ========================================================================
+
+/// Save or update a budget configuration.
+///
+/// If the budget for the given period already exists, it will be updated.
+/// Otherwise, a new record will be created.
+pub(super) fn save_budget_config(conn: &Connection, config: &BudgetConfig) -> Result<i64> {
+    // Deactivate any existing budget for this period
+    conn.execute(
+        r"UPDATE budget_config SET is_active = 0 WHERE period = ?1 AND is_active = 1",
+        params![config.period.as_str()],
+    )?;
+
+    // Insert new budget
+    conn.execute(
+        r"
+        INSERT INTO budget_config (period, limit_usd, alert_threshold, is_active, created_at, updated_at)
+        VALUES (?1, ?2, ?3, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+        ",
+        params![
+            config.period.as_str(),
+            config.limit_usd,
+            config.alert_threshold,
+        ],
+    )?;
+
+    Ok(conn.last_insert_rowid())
+}
+
+/// Get the active budget configuration for a period.
+pub(super) fn get_budget_config(
+    conn: &Connection,
+    period: BudgetPeriod,
+) -> Result<Option<BudgetConfig>> {
+    let result = conn.query_row(
+        r"
+        SELECT id, period, limit_usd, alert_threshold, created_at, updated_at, is_active
+        FROM budget_config
+        WHERE period = ?1 AND is_active = 1
+        ORDER BY created_at DESC
+        LIMIT 1
+        ",
+        params![period.as_str()],
+        |row| {
+            let period_str: String = row.get(1)?;
+            let created_str: String = row.get(4)?;
+            let updated_str: String = row.get(5)?;
+
+            let period = BudgetPeriod::from_str(&period_str).ok_or_else(|| {
+                rusqlite::Error::ToSqlConversionFailure(
+                    format!("Invalid period: {period_str}").into(),
+                )
+            })?;
+
+            let created_at = DateTime::parse_from_rfc3339(&created_str)
+                .map_or_else(|_| Utc::now(), |dt| dt.with_timezone(&Utc));
+
+            let updated_at = DateTime::parse_from_rfc3339(&updated_str)
+                .map_or_else(|_| Utc::now(), |dt| dt.with_timezone(&Utc));
+
+            Ok(BudgetConfig {
+                id: row.get(0)?,
+                period,
+                limit_usd: row.get(2)?,
+                alert_threshold: row.get(3)?,
+                created_at,
+                updated_at,
+                is_active: row.get(6)?,
+            })
+        },
+    );
+
+    match result {
+        Ok(config) => Ok(Some(config)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Get all active budget configurations.
+pub(super) fn get_all_budget_configs(conn: &Connection) -> Result<Vec<BudgetConfig>> {
+    let mut stmt = conn.prepare(
+        r"
+        SELECT id, period, limit_usd, alert_threshold, created_at, updated_at, is_active
+        FROM budget_config
+        WHERE is_active = 1
+        ORDER BY period
+        ",
+    )?;
+
+    let configs = stmt.query_map([], |row| {
+        let period_str: String = row.get(1)?;
+        let created_str: String = row.get(4)?;
+        let updated_str: String = row.get(5)?;
+
+        let period = BudgetPeriod::from_str(&period_str).ok_or_else(|| {
+            rusqlite::Error::ToSqlConversionFailure(format!("Invalid period: {period_str}").into())
+        })?;
+
+        let created_at = DateTime::parse_from_rfc3339(&created_str)
+            .map_or_else(|_| Utc::now(), |dt| dt.with_timezone(&Utc));
+
+        let updated_at = DateTime::parse_from_rfc3339(&updated_str)
+            .map_or_else(|_| Utc::now(), |dt| dt.with_timezone(&Utc));
+
+        Ok(BudgetConfig {
+            id: row.get(0)?,
+            period,
+            limit_usd: row.get(2)?,
+            alert_threshold: row.get(3)?,
+            created_at,
+            updated_at,
+            is_active: row.get(6)?,
+        })
+    })?;
+
+    configs.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+}
+
+// ========================================================================
+// Cost Queries
+// ========================================================================
+
+/// Get cost summary for a date range.
+///
+/// Returns aggregated cost metrics including total cost, request count,
+/// token usage, and average cost per request.
+pub(super) fn get_cost_summary(
+    conn: &Connection,
+    start_date: DateTime<Utc>,
+    end_date: DateTime<Utc>,
+) -> Result<CostSummary> {
+    let result = conn.query_row(
+        r"
+        SELECT
+            COALESCE(SUM(cost_usd), 0.0) as total_cost,
+            COALESCE(COUNT(*), 0) as request_count,
+            COALESCE(SUM(tokens_input), 0) as total_input_tokens,
+            COALESCE(SUM(tokens_output), 0) as total_output_tokens
+        FROM resource_usage
+        WHERE timestamp >= ?1 AND timestamp < ?2
+        ",
+        params![start_date.to_rfc3339(), end_date.to_rfc3339()],
+        |row| {
+            let total_cost: f64 = row.get(0)?;
+            let request_count: i64 = row.get(1)?;
+            Ok((total_cost, request_count, row.get::<_, i64>(2)?, row.get::<_, i64>(3)?))
+        },
+    )?;
+
+    let (total_cost, request_count, total_input_tokens, total_output_tokens) = result;
+    #[allow(clippy::cast_precision_loss)]
+    let avg_cost_per_request = if request_count > 0 {
+        total_cost / request_count as f64
+    } else {
+        0.0
+    };
+
+    Ok(CostSummary {
+        start_date,
+        end_date,
+        total_cost,
+        request_count,
+        total_input_tokens,
+        total_output_tokens,
+        avg_cost_per_request,
+    })
+}
+
+/// Get cost breakdown by agent role.
+pub(super) fn get_cost_by_role(conn: &Connection) -> Result<Vec<CostByRole>> {
+    let mut stmt = conn.prepare(
+        r"
+        SELECT
+            COALESCE(ai.agent_role, 'unknown') as agent_role,
+            COALESCE(SUM(ru.cost_usd), 0.0) as total_cost,
+            COUNT(*) as request_count,
+            COALESCE(AVG(ru.cost_usd), 0.0) as avg_cost,
+            COALESCE(SUM(ru.tokens_input), 0) as total_input_tokens,
+            COALESCE(SUM(ru.tokens_output), 0) as total_output_tokens,
+            MIN(ru.timestamp) as first_usage,
+            MAX(ru.timestamp) as last_usage
+        FROM resource_usage ru
+        LEFT JOIN agent_inputs ai ON ru.input_id = ai.id
+        GROUP BY COALESCE(ai.agent_role, 'unknown')
+        ORDER BY total_cost DESC
+        ",
+    )?;
+
+    let results = stmt.query_map([], |row| {
+        let first_usage_str: Option<String> = row.get(6)?;
+        let last_usage_str: Option<String> = row.get(7)?;
+
+        let first_usage = first_usage_str
+            .and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
+            .map(|dt| dt.with_timezone(&Utc));
+
+        let last_usage = last_usage_str
+            .and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
+            .map(|dt| dt.with_timezone(&Utc));
+
+        Ok(CostByRole {
+            agent_role: row.get(0)?,
+            total_cost: row.get(1)?,
+            request_count: row.get(2)?,
+            avg_cost: row.get(3)?,
+            total_input_tokens: row.get(4)?,
+            total_output_tokens: row.get(5)?,
+            first_usage,
+            last_usage,
+        })
+    })?;
+
+    results.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+}
+
+/// Get cost breakdown by GitHub issue.
+pub(super) fn get_cost_by_issue(
+    conn: &Connection,
+    issue_number: Option<i32>,
+) -> Result<Vec<CostByIssue>> {
+    if let Some(issue_num) = issue_number {
+        let mut stmt = conn.prepare(
+            r"
+            SELECT
+                pg.issue_number,
+                COALESCE(SUM(ru.cost_usd), 0.0) as total_cost,
+                COUNT(DISTINCT ru.input_id) as prompt_count,
+                COALESCE(SUM(ru.tokens_input), 0) as total_input_tokens,
+                COALESCE(SUM(ru.tokens_output), 0) as total_output_tokens,
+                MIN(ru.timestamp) as first_usage,
+                MAX(ru.timestamp) as last_usage
+            FROM resource_usage ru
+            JOIN agent_inputs ai ON ru.input_id = ai.id
+            JOIN prompt_github pg ON ai.id = pg.input_id
+            WHERE pg.issue_number = ?1
+            GROUP BY pg.issue_number
+            ",
+        )?;
+        let results = stmt.query_map(params![issue_num], parse_cost_by_issue)?;
+        results.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    } else {
+        let mut stmt = conn.prepare(
+            r"
+            SELECT
+                pg.issue_number,
+                COALESCE(SUM(ru.cost_usd), 0.0) as total_cost,
+                COUNT(DISTINCT ru.input_id) as prompt_count,
+                COALESCE(SUM(ru.tokens_input), 0) as total_input_tokens,
+                COALESCE(SUM(ru.tokens_output), 0) as total_output_tokens,
+                MIN(ru.timestamp) as first_usage,
+                MAX(ru.timestamp) as last_usage
+            FROM resource_usage ru
+            JOIN agent_inputs ai ON ru.input_id = ai.id
+            JOIN prompt_github pg ON ai.id = pg.input_id
+            WHERE pg.issue_number IS NOT NULL
+            GROUP BY pg.issue_number
+            ORDER BY total_cost DESC
+            ",
+        )?;
+        let results = stmt.query_map([], parse_cost_by_issue)?;
+        results.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+}
+
+/// Get cost breakdown by pull request.
+pub(super) fn get_cost_by_pr(conn: &Connection, pr_number: Option<i32>) -> Result<Vec<CostByPr>> {
+    if let Some(pr_num) = pr_number {
+        let mut stmt = conn.prepare(
+            r"
+            SELECT
+                pg.pr_number,
+                COALESCE(SUM(ru.cost_usd), 0.0) as total_cost,
+                COUNT(DISTINCT ru.input_id) as prompt_count,
+                COALESCE(SUM(ru.tokens_input), 0) as total_input_tokens,
+                COALESCE(SUM(ru.tokens_output), 0) as total_output_tokens,
+                MIN(ru.timestamp) as first_usage,
+                MAX(ru.timestamp) as last_usage
+            FROM resource_usage ru
+            JOIN agent_inputs ai ON ru.input_id = ai.id
+            JOIN prompt_github pg ON ai.id = pg.input_id
+            WHERE pg.pr_number = ?1
+            GROUP BY pg.pr_number
+            ",
+        )?;
+        let results = stmt.query_map(params![pr_num], parse_cost_by_pr)?;
+        results.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    } else {
+        let mut stmt = conn.prepare(
+            r"
+            SELECT
+                pg.pr_number,
+                COALESCE(SUM(ru.cost_usd), 0.0) as total_cost,
+                COUNT(DISTINCT ru.input_id) as prompt_count,
+                COALESCE(SUM(ru.tokens_input), 0) as total_input_tokens,
+                COALESCE(SUM(ru.tokens_output), 0) as total_output_tokens,
+                MIN(ru.timestamp) as first_usage,
+                MAX(ru.timestamp) as last_usage
+            FROM resource_usage ru
+            JOIN agent_inputs ai ON ru.input_id = ai.id
+            JOIN prompt_github pg ON ai.id = pg.input_id
+            WHERE pg.pr_number IS NOT NULL
+            GROUP BY pg.pr_number
+            ORDER BY total_cost DESC
+            ",
+        )?;
+        let results = stmt.query_map([], parse_cost_by_pr)?;
+        results.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+}
+
+// ========================================================================
+// Budget Status & Runway
+// ========================================================================
+
+/// Get budget status for a specific period.
+///
+/// Calculates current spend within the period and compares against the budget limit.
+pub(super) fn get_budget_status(
+    conn: &Connection,
+    period: BudgetPeriod,
+) -> Result<Option<BudgetStatus>> {
+    let Some(config) = get_budget_config(conn, period)? else {
+        return Ok(None);
+    };
+
+    let (period_start, period_end) = get_period_bounds(period);
+    let summary = get_cost_summary(conn, period_start, period_end)?;
+
+    let spent = summary.total_cost;
+    let remaining = (config.limit_usd - spent).max(0.0);
+    let usage_percent = if config.limit_usd > 0.0 {
+        (spent / config.limit_usd) * 100.0
+    } else {
+        0.0
+    };
+    let alert_triggered = (spent / config.limit_usd) >= config.alert_threshold;
+    let budget_exceeded = spent >= config.limit_usd;
+
+    Ok(Some(BudgetStatus {
+        config,
+        spent,
+        remaining,
+        usage_percent,
+        alert_triggered,
+        budget_exceeded,
+        period_start,
+        period_end,
+    }))
+}
+
+/// Project runway based on recent burn rate.
+///
+/// Uses the last N days of spending to calculate average daily cost and
+/// estimate when the budget will be exhausted.
+pub(super) fn project_runway(
+    conn: &Connection,
+    period: BudgetPeriod,
+    lookback_days: i32,
+) -> Result<Option<RunwayProjection>> {
+    let Some(config) = get_budget_config(conn, period)? else {
+        return Ok(None);
+    };
+
+    // Get current period status
+    let (period_start, _) = get_period_bounds(period);
+    let status = get_budget_status(conn, period)?;
+    let remaining_budget = status.map_or(config.limit_usd, |s| s.remaining);
+
+    // Calculate average daily cost over lookback period
+    let lookback_start = Utc::now() - chrono::Duration::days(i64::from(lookback_days));
+    let lookback_end = Utc::now();
+    let lookback_summary = get_cost_summary(conn, lookback_start, lookback_end)?;
+
+    let avg_daily_cost = if lookback_days > 0 {
+        lookback_summary.total_cost / f64::from(lookback_days)
+    } else {
+        0.0
+    };
+
+    let days_remaining = if avg_daily_cost > 0.0 {
+        remaining_budget / avg_daily_cost
+    } else {
+        f64::INFINITY
+    };
+
+    #[allow(clippy::cast_possible_truncation)]
+    let exhaustion_date = if avg_daily_cost > 0.0 && days_remaining.is_finite() {
+        Some(period_start + chrono::Duration::days(days_remaining as i64))
+    } else {
+        None
+    };
+
+    Ok(Some(RunwayProjection {
+        remaining_budget,
+        avg_daily_cost,
+        days_remaining,
+        exhaustion_date,
+        lookback_days,
+    }))
+}
+
+// ========================================================================
+// Helper Functions
+// ========================================================================
+
+/// Helper function to parse `CostByIssue` from a row
+fn parse_cost_by_issue(row: &rusqlite::Row) -> rusqlite::Result<CostByIssue> {
+    let first_usage_str: Option<String> = row.get(5)?;
+    let last_usage_str: Option<String> = row.get(6)?;
+
+    let first_usage = first_usage_str
+        .and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
+        .map(|dt| dt.with_timezone(&Utc));
+
+    let last_usage = last_usage_str
+        .and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
+        .map(|dt| dt.with_timezone(&Utc));
+
+    Ok(CostByIssue {
+        issue_number: row.get(0)?,
+        total_cost: row.get(1)?,
+        prompt_count: row.get(2)?,
+        total_input_tokens: row.get(3)?,
+        total_output_tokens: row.get(4)?,
+        first_usage,
+        last_usage,
+    })
+}
+
+/// Helper function to parse `CostByPr` from a row
+fn parse_cost_by_pr(row: &rusqlite::Row) -> rusqlite::Result<CostByPr> {
+    let first_usage_str: Option<String> = row.get(5)?;
+    let last_usage_str: Option<String> = row.get(6)?;
+
+    let first_usage = first_usage_str
+        .and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
+        .map(|dt| dt.with_timezone(&Utc));
+
+    let last_usage = last_usage_str
+        .and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
+        .map(|dt| dt.with_timezone(&Utc));
+
+    Ok(CostByPr {
+        pr_number: row.get(0)?,
+        total_cost: row.get(1)?,
+        prompt_count: row.get(2)?,
+        total_input_tokens: row.get(3)?,
+        total_output_tokens: row.get(4)?,
+        first_usage,
+        last_usage,
+    })
+}
+
+/// Calculate the start and end timestamps for a budget period
+pub(super) fn get_period_bounds(period: BudgetPeriod) -> (DateTime<Utc>, DateTime<Utc>) {
+    use chrono::{Datelike, Duration, TimeZone};
+
+    let now = Utc::now();
+    let today = Utc
+        .with_ymd_and_hms(now.year(), now.month(), now.day(), 0, 0, 0)
+        .unwrap();
+
+    match period {
+        BudgetPeriod::Daily => (today, today + Duration::days(1)),
+        BudgetPeriod::Weekly => {
+            // Start from Monday of current week
+            let days_since_monday = now.weekday().num_days_from_monday();
+            let week_start = today - Duration::days(i64::from(days_since_monday));
+            (week_start, week_start + Duration::weeks(1))
+        }
+        BudgetPeriod::Monthly => {
+            // Start from first day of current month
+            let month_start = Utc
+                .with_ymd_and_hms(now.year(), now.month(), 1, 0, 0, 0)
+                .unwrap();
+            // End is first day of next month
+            let next_month = if now.month() == 12 {
+                Utc.with_ymd_and_hms(now.year() + 1, 1, 1, 0, 0, 0).unwrap()
+            } else {
+                Utc.with_ymd_and_hms(now.year(), now.month() + 1, 1, 0, 0, 0)
+                    .unwrap()
+            };
+            (month_start, next_month)
+        }
+    }
+}
+
+// ========================================================================
+// Tests
+// ========================================================================
+
+#[cfg(test)]
+#[allow(
+    clippy::panic,
+    clippy::unwrap_used,
+    clippy::redundant_closure_for_method_calls
+)]
+mod tests {
+    use super::super::db::ActivityDb;
+    use super::super::models::{BudgetConfig, BudgetPeriod};
+    use super::super::resource_usage::ResourceUsage;
+    use super::*;
+    use crate::activity::models::{AgentInput, InputContext, InputType};
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_save_and_get_budget_config() -> Result<()> {
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        let config = BudgetConfig {
+            id: None,
+            period: BudgetPeriod::Monthly,
+            limit_usd: 100.0,
+            alert_threshold: 0.8,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            is_active: true,
+        };
+
+        let id = db.save_budget_config(&config)?;
+        assert!(id > 0);
+
+        let retrieved = db.get_budget_config(BudgetPeriod::Monthly)?;
+        assert!(retrieved.is_some());
+        if let Some(c) = retrieved {
+            assert_eq!(c.period, BudgetPeriod::Monthly);
+            assert!((c.limit_usd - 100.0).abs() < 0.001);
+            assert!((c.alert_threshold - 0.8).abs() < 0.001);
+            assert!(c.is_active);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_budget_config_replaces_previous() -> Result<()> {
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        let config1 = BudgetConfig {
+            id: None,
+            period: BudgetPeriod::Monthly,
+            limit_usd: 100.0,
+            alert_threshold: 0.8,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            is_active: true,
+        };
+        db.save_budget_config(&config1)?;
+
+        let config2 = BudgetConfig {
+            id: None,
+            period: BudgetPeriod::Monthly,
+            limit_usd: 200.0,
+            alert_threshold: 0.9,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            is_active: true,
+        };
+        db.save_budget_config(&config2)?;
+
+        let retrieved = db.get_budget_config(BudgetPeriod::Monthly)?;
+        assert!(retrieved.is_some());
+        if let Some(c) = retrieved {
+            assert!((c.limit_usd - 200.0).abs() < 0.001);
+            assert!((c.alert_threshold - 0.9).abs() < 0.001);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_all_budget_configs() -> Result<()> {
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        for (period, limit) in [
+            (BudgetPeriod::Daily, 10.0),
+            (BudgetPeriod::Weekly, 50.0),
+            (BudgetPeriod::Monthly, 200.0),
+        ] {
+            let config = BudgetConfig {
+                id: None,
+                period,
+                limit_usd: limit,
+                alert_threshold: 0.8,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+                is_active: true,
+            };
+            db.save_budget_config(&config)?;
+        }
+
+        let configs = db.get_all_budget_configs()?;
+        assert_eq!(configs.len(), 3);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_cost_summary() -> Result<()> {
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        for i in 0..5 {
+            let input = AgentInput {
+                id: None,
+                terminal_id: "terminal-1".to_string(),
+                timestamp: Utc::now(),
+                input_type: InputType::Manual,
+                content: format!("command {i}"),
+                agent_role: Some("builder".to_string()),
+                context: InputContext::default(),
+            };
+            let input_id = db.record_input(&input)?;
+
+            let usage = ResourceUsage {
+                input_id: Some(input_id),
+                model: "claude-3-5-sonnet".to_string(),
+                tokens_input: 1000,
+                tokens_output: 500,
+                tokens_cache_read: None,
+                tokens_cache_write: None,
+                cost_usd: 0.01,
+                duration_ms: Some(1000),
+                provider: "anthropic".to_string(),
+                timestamp: Utc::now(),
+            };
+            db.record_resource_usage(&usage)?;
+        }
+
+        let start = Utc::now() - chrono::Duration::hours(1);
+        let end = Utc::now() + chrono::Duration::hours(1);
+        let summary = db.get_cost_summary(start, end)?;
+
+        assert_eq!(summary.request_count, 5);
+        assert!((summary.total_cost - 0.05).abs() < 0.001);
+        assert_eq!(summary.total_input_tokens, 5000);
+        assert_eq!(summary.total_output_tokens, 2500);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_cost_by_role() -> Result<()> {
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        for (role, cost) in [("builder", 0.05), ("judge", 0.02), ("curator", 0.01)] {
+            let input = AgentInput {
+                id: None,
+                terminal_id: "terminal-1".to_string(),
+                timestamp: Utc::now(),
+                input_type: InputType::Manual,
+                content: "test command".to_string(),
+                agent_role: Some(role.to_string()),
+                context: InputContext::default(),
+            };
+            let input_id = db.record_input(&input)?;
+
+            let usage = ResourceUsage {
+                input_id: Some(input_id),
+                model: "claude-3-5-sonnet".to_string(),
+                tokens_input: 1000,
+                tokens_output: 500,
+                tokens_cache_read: None,
+                tokens_cache_write: None,
+                cost_usd: cost,
+                duration_ms: Some(1000),
+                provider: "anthropic".to_string(),
+                timestamp: Utc::now(),
+            };
+            db.record_resource_usage(&usage)?;
+        }
+
+        let by_role = db.get_cost_by_role()?;
+        assert_eq!(by_role.len(), 3);
+
+        let builder = by_role.iter().find(|r| r.agent_role == "builder");
+        assert!(builder.is_some());
+        if let Some(b) = builder {
+            assert!((b.total_cost - 0.05).abs() < 0.001);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_budget_status() -> Result<()> {
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        let config = BudgetConfig {
+            id: None,
+            period: BudgetPeriod::Monthly,
+            limit_usd: 100.0,
+            alert_threshold: 0.8,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            is_active: true,
+        };
+        db.save_budget_config(&config)?;
+
+        for i in 0..5 {
+            let input = AgentInput {
+                id: None,
+                terminal_id: "terminal-1".to_string(),
+                timestamp: Utc::now(),
+                input_type: InputType::Manual,
+                content: format!("command {i}"),
+                agent_role: Some("builder".to_string()),
+                context: InputContext::default(),
+            };
+            let input_id = db.record_input(&input)?;
+
+            let usage = ResourceUsage {
+                input_id: Some(input_id),
+                model: "claude-3-5-sonnet".to_string(),
+                tokens_input: 1000,
+                tokens_output: 500,
+                tokens_cache_read: None,
+                tokens_cache_write: None,
+                cost_usd: 10.0,
+                duration_ms: Some(1000),
+                provider: "anthropic".to_string(),
+                timestamp: Utc::now(),
+            };
+            db.record_resource_usage(&usage)?;
+        }
+
+        let status = db.get_budget_status(BudgetPeriod::Monthly)?;
+        assert!(status.is_some());
+        if let Some(s) = status {
+            assert!((s.spent - 50.0).abs() < 0.001);
+            assert!((s.remaining - 50.0).abs() < 0.001);
+            assert!((s.usage_percent - 50.0).abs() < 0.1);
+            assert!(!s.alert_triggered);
+            assert!(!s.budget_exceeded);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_budget_status_alert_triggered() -> Result<()> {
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        let config = BudgetConfig {
+            id: None,
+            period: BudgetPeriod::Monthly,
+            limit_usd: 100.0,
+            alert_threshold: 0.8,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            is_active: true,
+        };
+        db.save_budget_config(&config)?;
+
+        let input = AgentInput {
+            id: None,
+            terminal_id: "terminal-1".to_string(),
+            timestamp: Utc::now(),
+            input_type: InputType::Manual,
+            content: "expensive operation".to_string(),
+            agent_role: Some("builder".to_string()),
+            context: InputContext::default(),
+        };
+        let input_id = db.record_input(&input)?;
+
+        let usage = ResourceUsage {
+            input_id: Some(input_id),
+            model: "claude-opus-4".to_string(),
+            tokens_input: 10000,
+            tokens_output: 5000,
+            tokens_cache_read: None,
+            tokens_cache_write: None,
+            cost_usd: 85.0,
+            duration_ms: Some(5000),
+            provider: "anthropic".to_string(),
+            timestamp: Utc::now(),
+        };
+        db.record_resource_usage(&usage)?;
+
+        let status = db.get_budget_status(BudgetPeriod::Monthly)?;
+        assert!(status.is_some());
+        if let Some(s) = status {
+            assert!(s.alert_triggered);
+            assert!(!s.budget_exceeded);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_project_runway() -> Result<()> {
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        let config = BudgetConfig {
+            id: None,
+            period: BudgetPeriod::Monthly,
+            limit_usd: 100.0,
+            alert_threshold: 0.8,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            is_active: true,
+        };
+        db.save_budget_config(&config)?;
+
+        for day in 0..5 {
+            let input = AgentInput {
+                id: None,
+                terminal_id: "terminal-1".to_string(),
+                timestamp: Utc::now() - chrono::Duration::days(day),
+                input_type: InputType::Manual,
+                content: format!("day {day} work"),
+                agent_role: Some("builder".to_string()),
+                context: InputContext::default(),
+            };
+            let input_id = db.record_input(&input)?;
+
+            let usage = ResourceUsage {
+                input_id: Some(input_id),
+                model: "claude-3-5-sonnet".to_string(),
+                tokens_input: 1000,
+                tokens_output: 500,
+                tokens_cache_read: None,
+                tokens_cache_write: None,
+                cost_usd: 10.0,
+                duration_ms: Some(1000),
+                provider: "anthropic".to_string(),
+                timestamp: Utc::now() - chrono::Duration::days(day),
+            };
+            db.record_resource_usage(&usage)?;
+        }
+
+        let projection = db.project_runway(BudgetPeriod::Monthly, 7)?;
+        assert!(projection.is_some());
+        if let Some(p) = projection {
+            assert!(p.avg_daily_cost > 0.0);
+            assert!(p.days_remaining > 0.0);
+            assert!(p.exhaustion_date.is_some());
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_budget_not_configured() -> Result<()> {
+        let temp_file = NamedTempFile::new()?;
+        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
+
+        let status = db.get_budget_status(BudgetPeriod::Monthly)?;
+        assert!(status.is_none());
+
+        let projection = db.project_runway(BudgetPeriod::Monthly, 7)?;
+        assert!(projection.is_none());
+
+        Ok(())
+    }
+}

--- a/loom-daemon/src/activity/db.rs
+++ b/loom-daemon/src/activity/db.rs
@@ -1,7 +1,14 @@
 //! Database operations for activity tracking.
 //!
-//! This module contains the `ActivityDb` struct and all methods for
+//! This module contains the `ActivityDb` struct and core methods for
 //! recording and querying agent activity data.
+//!
+//! Domain-specific operations are delegated to submodules:
+//! - [`super::claims`]: Issue claim registry
+//! - [`super::cost_analytics`]: Budget and cost analysis
+//! - [`super::metrics`]: Task metrics and productivity
+//! - [`super::prompts`]: Prompt tracking (git changes, GitHub events)
+//! - [`super::quality`]: Quality metrics (tests, PR reviews, rework)
 
 use anyhow::Result;
 use chrono::{DateTime, Utc};
@@ -15,11 +22,11 @@ use super::models::{
     PromptSuccessStats, QualityMetrics, RunwayProjection, TokenUsage,
 };
 use super::schema::init_schema;
-use super::test_parser;
+use super::{claims, cost_analytics, metrics, prompts, quality};
 
 /// Activity database for tracking agent inputs and results
 pub struct ActivityDb {
-    conn: Connection,
+    pub(super) conn: Connection,
 }
 
 impl ActivityDb {
@@ -132,36 +139,18 @@ impl ActivityDb {
         Ok(count)
     }
 
-    /// Start tracking a new task
+    // ========================================================================
+    // Task Metrics Methods
+    // Delegated to metrics module
+    // ========================================================================
+
+    /// Start tracking a new task.
     #[allow(dead_code)]
     pub fn start_task(&self, metric: &AgentMetric) -> Result<i64> {
-        let context_json = metric.context.as_deref();
-
-        self.conn.execute(
-            r"
-            INSERT INTO agent_metrics (
-                terminal_id, agent_role, agent_system, task_type,
-                github_issue, github_pr, started_at, status, context
-            )
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
-            ",
-            params![
-                &metric.terminal_id,
-                &metric.agent_role,
-                &metric.agent_system,
-                &metric.task_type,
-                metric.github_issue,
-                metric.github_pr,
-                metric.started_at.to_rfc3339(),
-                &metric.status,
-                context_json,
-            ],
-        )?;
-
-        Ok(self.conn.last_insert_rowid())
+        metrics::start_task(&self.conn, metric)
     }
 
-    /// Complete a task and calculate wall time
+    /// Complete a task and calculate wall time.
     #[allow(dead_code)]
     pub fn complete_task(
         &self,
@@ -169,40 +158,10 @@ impl ActivityDb {
         status: &str,
         outcome_type: Option<&str>,
     ) -> Result<()> {
-        let now = Utc::now();
-
-        // Get started_at from database
-        let started_at: String = self.conn.query_row(
-            "SELECT started_at FROM agent_metrics WHERE id = ?1",
-            params![metric_id],
-            |row| row.get(0),
-        )?;
-
-        let started = DateTime::parse_from_rfc3339(&started_at)?.with_timezone(&Utc);
-        let wall_time_seconds = (now - started).num_seconds();
-
-        self.conn.execute(
-            r"
-            UPDATE agent_metrics
-            SET completed_at = ?1,
-                wall_time_seconds = ?2,
-                status = ?3,
-                outcome_type = ?4
-            WHERE id = ?5
-            ",
-            params![
-                now.to_rfc3339(),
-                wall_time_seconds,
-                status,
-                outcome_type,
-                metric_id
-            ],
-        )?;
-
-        Ok(())
+        metrics::complete_task(&self.conn, metric_id, status, outcome_type)
     }
 
-    /// Update task quality metrics (commits, CI failures, etc.)
+    /// Update task quality metrics (commits, CI failures, etc.).
     #[allow(dead_code)]
     pub fn update_task_metrics(
         &self,
@@ -212,261 +171,48 @@ impl ActivityDb {
         commits_count: Option<i32>,
         lines_changed: Option<i32>,
     ) -> Result<()> {
-        self.conn.execute(
-            r"
-            UPDATE agent_metrics
-            SET test_failures = COALESCE(?1, test_failures),
-                ci_failures = COALESCE(?2, ci_failures),
-                commits_count = COALESCE(?3, commits_count),
-                lines_changed = COALESCE(?4, lines_changed)
-            WHERE id = ?5
-            ",
-            params![
-                test_failures,
-                ci_failures,
-                commits_count,
-                lines_changed,
-                metric_id
-            ],
-        )?;
-
-        Ok(())
+        metrics::update_task_metrics(
+            &self.conn,
+            metric_id,
+            test_failures,
+            ci_failures,
+            commits_count,
+            lines_changed,
+        )
     }
 
-    /// Record token usage for an API request
-    ///
-    /// Records comprehensive LLM resource usage including token counts, cache usage,
-    /// duration, and cost. If a `metric_id` is provided, also updates the aggregate
-    /// token counts in `agent_metrics`.
+    /// Record token usage for an API request.
     #[allow(dead_code)]
     pub fn record_token_usage(&self, usage: &TokenUsage) -> Result<i64> {
-        self.conn.execute(
-            r"
-            INSERT INTO token_usage (
-                input_id, metric_id, timestamp, prompt_tokens,
-                completion_tokens, total_tokens, model, estimated_cost_usd,
-                tokens_cache_read, tokens_cache_write, duration_ms, provider
-            )
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
-            ",
-            params![
-                usage.input_id,
-                usage.metric_id,
-                usage.timestamp.to_rfc3339(),
-                usage.prompt_tokens,
-                usage.completion_tokens,
-                usage.total_tokens,
-                &usage.model,
-                usage.estimated_cost_usd,
-                usage.tokens_cache_read,
-                usage.tokens_cache_write,
-                usage.duration_ms,
-                &usage.provider,
-            ],
-        )?;
-
-        // Update aggregate token counts in agent_metrics if metric_id is provided
-        if let Some(metric_id) = usage.metric_id {
-            self.conn.execute(
-                r"
-                UPDATE agent_metrics
-                SET input_tokens = input_tokens + ?1,
-                    output_tokens = output_tokens + ?2,
-                    total_tokens = total_tokens + ?3,
-                    estimated_cost_usd = estimated_cost_usd + ?4
-                WHERE id = ?5
-                ",
-                params![
-                    usage.prompt_tokens,
-                    usage.completion_tokens,
-                    usage.total_tokens,
-                    usage.estimated_cost_usd,
-                    metric_id
-                ],
-            )?;
-        }
-
-        Ok(self.conn.last_insert_rowid())
+        metrics::record_token_usage(&self.conn, usage)
     }
 
-    /// Record a prompt-GitHub correlation event
-    ///
-    /// Links a prompt (agent input) with a GitHub action it triggered,
-    /// such as creating an issue, opening a PR, or changing labels.
-    pub fn record_prompt_github_event(&self, event: &PromptGitHubEvent) -> Result<i64> {
-        let label_before_json = event
-            .label_before
-            .as_ref()
-            .map(serde_json::to_string)
-            .transpose()?;
-
-        let label_after_json = event
-            .label_after
-            .as_ref()
-            .map(serde_json::to_string)
-            .transpose()?;
-
-        self.conn.execute(
-            r"
-            INSERT INTO prompt_github (input_id, issue_number, pr_number, label_before, label_after, event_type)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6)
-            ",
-            params![
-                event.input_id,
-                event.issue_number,
-                event.pr_number,
-                label_before_json,
-                label_after_json,
-                event.event_type.as_str(),
-            ],
-        )?;
-
-        Ok(self.conn.last_insert_rowid())
-    }
-
-    /// Get prompt-GitHub events for a specific input
-    #[allow(dead_code)]
-    pub fn get_prompt_github_events(&self, input_id: i64) -> Result<Vec<PromptGitHubEvent>> {
-        use super::models::PromptGitHubEventType;
-
-        let mut stmt = self.conn.prepare(
-            r"
-            SELECT id, input_id, issue_number, pr_number, label_before, label_after, event_type
-            FROM prompt_github
-            WHERE input_id = ?1
-            ORDER BY id
-            ",
-        )?;
-
-        let events = stmt.query_map(params![input_id], |row| {
-            let id: i64 = row.get(0)?;
-            let input_id: Option<i64> = row.get(1)?;
-            let issue_number: Option<i32> = row.get(2)?;
-            let pr_number: Option<i32> = row.get(3)?;
-            let label_before_json: Option<String> = row.get(4)?;
-            let label_after_json: Option<String> = row.get(5)?;
-            let event_type_str: String = row.get(6)?;
-
-            let label_before = label_before_json
-                .map(|json| serde_json::from_str(&json))
-                .transpose()
-                .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?;
-
-            let label_after = label_after_json
-                .map(|json| serde_json::from_str(&json))
-                .transpose()
-                .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?;
-
-            let event_type = PromptGitHubEventType::from_str(&event_type_str).ok_or_else(|| {
-                rusqlite::Error::ToSqlConversionFailure(
-                    format!("Invalid event_type: {event_type_str}").into(),
-                )
-            })?;
-
-            Ok(PromptGitHubEvent {
-                id: Some(id),
-                input_id,
-                issue_number,
-                pr_number,
-                label_before,
-                label_after,
-                event_type,
-            })
-        })?;
-
-        events.collect::<Result<Vec<_>, _>>().map_err(Into::into)
-    }
-
-    /// Get metrics for a specific task
+    /// Get metrics for a specific task.
     #[allow(dead_code)]
     pub fn get_task_metrics(&self, metric_id: i64) -> Result<AgentMetric> {
-        Ok(self.conn.query_row(
-            r"
-            SELECT id, terminal_id, agent_role, agent_system, task_type,
-                   github_issue, github_pr, started_at, completed_at,
-                   wall_time_seconds, active_time_seconds, input_tokens,
-                   output_tokens, total_tokens, estimated_cost_usd, status,
-                   outcome_type, test_failures, ci_failures, commits_count,
-                   lines_changed, context
-            FROM agent_metrics
-            WHERE id = ?1
-            ",
-            params![metric_id],
-            |row| {
-                let started_str: String = row.get(7)?;
-                let completed_str: Option<String> = row.get(8)?;
-
-                let started_at = DateTime::parse_from_rfc3339(&started_str)
-                    .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?
-                    .with_timezone(&Utc);
-
-                let completed_at = if let Some(completed) = completed_str {
-                    Some(
-                        DateTime::parse_from_rfc3339(&completed)
-                            .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?
-                            .with_timezone(&Utc),
-                    )
-                } else {
-                    None
-                };
-
-                Ok(AgentMetric {
-                    id: Some(row.get(0)?),
-                    terminal_id: row.get(1)?,
-                    agent_role: row.get(2)?,
-                    agent_system: row.get(3)?,
-                    task_type: row.get(4)?,
-                    github_issue: row.get(5)?,
-                    github_pr: row.get(6)?,
-                    started_at,
-                    completed_at,
-                    wall_time_seconds: row.get(9)?,
-                    active_time_seconds: row.get(10)?,
-                    input_tokens: row.get(11)?,
-                    output_tokens: row.get(12)?,
-                    total_tokens: row.get(13)?,
-                    estimated_cost_usd: row.get(14)?,
-                    status: row.get(15)?,
-                    outcome_type: row.get(16)?,
-                    test_failures: row.get(17)?,
-                    ci_failures: row.get(18)?,
-                    commits_count: row.get(19)?,
-                    lines_changed: row.get(20)?,
-                    context: row.get(21)?,
-                })
-            },
-        )?)
+        metrics::get_task_metrics(&self.conn, metric_id)
     }
 
-    /// Get productivity summary grouped by agent system
+    /// Get productivity summary grouped by agent system.
     #[allow(dead_code)]
     pub fn get_productivity_summary(&self) -> Result<ProductivitySummary> {
-        let mut stmt = self.conn.prepare(
-            r"
-            SELECT
-                agent_system,
-                COUNT(*) as tasks_completed,
-                AVG(wall_time_seconds / 60.0) as avg_minutes,
-                AVG(total_tokens) as avg_tokens,
-                SUM(estimated_cost_usd) as total_cost
-            FROM agent_metrics
-            WHERE status = 'success' AND completed_at IS NOT NULL
-            GROUP BY agent_system
-            ORDER BY tasks_completed DESC
-            ",
-        )?;
+        metrics::get_productivity_summary(&self.conn)
+    }
 
-        let results = stmt.query_map([], |row| {
-            Ok((
-                row.get(0)?, // agent_system
-                row.get(1)?, // tasks_completed
-                row.get(2)?, // avg_minutes
-                row.get(3)?, // avg_tokens
-                row.get(4)?, // total_cost
-            ))
-        })?;
+    // ========================================================================
+    // Prompt Tracking Methods
+    // Delegated to prompts module
+    // ========================================================================
 
-        results.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    /// Record a prompt-GitHub correlation event.
+    pub fn record_prompt_github_event(&self, event: &PromptGitHubEvent) -> Result<i64> {
+        prompts::record_prompt_github_event(&self.conn, event)
+    }
+
+    /// Get prompt-GitHub events for a specific input.
+    #[allow(dead_code)]
+    pub fn get_prompt_github_events(&self, input_id: i64) -> Result<Vec<PromptGitHubEvent>> {
+        prompts::get_prompt_github_events(&self.conn, input_id)
     }
 
     /// Get terminal activity history (inputs joined with outputs)
@@ -541,220 +287,53 @@ impl ActivityDb {
         entries.collect::<Result<Vec<_>, _>>().map_err(Into::into)
     }
 
-    /// Record git changes associated with a prompt
+    /// Record git changes associated with a prompt.
     pub fn record_prompt_changes(&self, changes: &PromptChanges) -> Result<i64> {
-        self.conn.execute(
-            r"
-            INSERT INTO prompt_changes (
-                input_id, before_commit, after_commit, files_changed,
-                lines_added, lines_removed, tests_added, tests_modified
-            )
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
-            ",
-            params![
-                changes.input_id,
-                &changes.before_commit,
-                &changes.after_commit,
-                changes.files_changed,
-                changes.lines_added,
-                changes.lines_removed,
-                changes.tests_added,
-                changes.tests_modified,
-            ],
-        )?;
-
-        Ok(self.conn.last_insert_rowid())
+        prompts::record_prompt_changes(&self.conn, changes)
     }
 
-    /// Get prompt changes for a specific input
+    /// Get prompt changes for a specific input.
     #[allow(dead_code)]
     pub fn get_prompt_changes(&self, input_id: i64) -> Result<Option<PromptChanges>> {
-        let result = self.conn.query_row(
-            r"
-            SELECT id, input_id, before_commit, after_commit, files_changed,
-                   lines_added, lines_removed, tests_added, tests_modified
-            FROM prompt_changes
-            WHERE input_id = ?1
-            ",
-            params![input_id],
-            |row| {
-                Ok(PromptChanges {
-                    id: Some(row.get(0)?),
-                    input_id: row.get(1)?,
-                    before_commit: row.get(2)?,
-                    after_commit: row.get(3)?,
-                    files_changed: row.get(4)?,
-                    lines_added: row.get(5)?,
-                    lines_removed: row.get(6)?,
-                    tests_added: row.get(7)?,
-                    tests_modified: row.get(8)?,
-                })
-            },
-        );
-
-        match result {
-            Ok(changes) => Ok(Some(changes)),
-            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
-            Err(e) => Err(e.into()),
-        }
+        prompts::get_prompt_changes(&self.conn, input_id)
     }
 
-    /// Get total lines changed across all prompts for a terminal
+    /// Get total lines changed across all prompts for a terminal.
     #[allow(dead_code)]
     pub fn get_terminal_changes_summary(&self, terminal_id: &str) -> Result<(i64, i64, i64)> {
-        // Returns (total_files_changed, total_lines_added, total_lines_removed)
-        let result = self.conn.query_row(
-            r"
-            SELECT
-                COALESCE(SUM(pc.files_changed), 0),
-                COALESCE(SUM(pc.lines_added), 0),
-                COALESCE(SUM(pc.lines_removed), 0)
-            FROM prompt_changes pc
-            JOIN agent_inputs ai ON pc.input_id = ai.id
-            WHERE ai.terminal_id = ?1
-            ",
-            params![terminal_id],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-        )?;
-
-        Ok(result)
+        prompts::get_terminal_changes_summary(&self.conn, terminal_id)
     }
 
-    /// Record quality metrics for an input/output
+    // ========================================================================
+    // Quality Metrics Methods
+    // Delegated to quality module
+    // ========================================================================
+
+    /// Record quality metrics for an input/output.
     #[allow(dead_code)]
     pub fn record_quality_metrics(&self, metrics: &QualityMetrics) -> Result<i64> {
-        self.conn.execute(
-            r"
-            INSERT INTO quality_metrics (
-                input_id, timestamp, tests_passed, tests_failed, tests_skipped,
-                test_runner, lint_errors, format_errors, build_success,
-                pr_approved, pr_changes_requested, rework_count, human_rating
-            )
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
-            ",
-            params![
-                metrics.input_id,
-                metrics.timestamp.to_rfc3339(),
-                metrics.tests_passed,
-                metrics.tests_failed,
-                metrics.tests_skipped,
-                &metrics.test_runner,
-                metrics.lint_errors,
-                metrics.format_errors,
-                metrics.build_success,
-                metrics.pr_approved,
-                metrics.pr_changes_requested,
-                metrics.rework_count,
-                metrics.human_rating,
-            ],
-        )?;
-
-        Ok(self.conn.last_insert_rowid())
+        quality::record_quality_metrics(&self.conn, metrics)
     }
 
-    /// Parse and record quality metrics from terminal output
-    ///
-    /// Automatically parses test results, lint errors, and build status from
-    /// the output content and stores them in the database.
+    /// Parse and record quality metrics from terminal output.
     #[allow(dead_code)]
     pub fn record_quality_from_output(&self, input_id: i64, output: &str) -> Result<Option<i64>> {
-        let test_results = test_parser::parse_test_results(output);
-        let lint_results = test_parser::parse_lint_results(output);
-        let build_status = test_parser::parse_build_status(output);
-
-        // Only record if we found at least some quality metrics
-        if test_results.is_none() && lint_results.is_none() && build_status.is_none() {
-            return Ok(None);
-        }
-
-        let metrics = QualityMetrics {
-            id: None,
-            input_id: Some(input_id),
-            timestamp: Utc::now(),
-            tests_passed: test_results.as_ref().map(|t| t.passed),
-            tests_failed: test_results.as_ref().map(|t| t.failed),
-            tests_skipped: test_results.as_ref().map(|t| t.skipped),
-            test_runner: test_results.and_then(|t| t.runner),
-            lint_errors: lint_results.as_ref().map(|l| l.lint_errors),
-            format_errors: lint_results.map(|l| l.format_errors),
-            build_success: build_status,
-            pr_approved: None,
-            pr_changes_requested: None,
-            rework_count: None, // Rework count is updated separately via increment_rework_count
-            human_rating: None,
-        };
-
-        Ok(Some(self.record_quality_metrics(&metrics)?))
+        quality::record_quality_from_output(&self.conn, input_id, output)
     }
 
-    /// Get quality metrics for a specific input
+    /// Get quality metrics for a specific input.
     #[allow(dead_code)]
     pub fn get_quality_metrics(&self, input_id: i64) -> Result<Option<QualityMetrics>> {
-        let result = self.conn.query_row(
-            r"
-            SELECT id, input_id, timestamp, tests_passed, tests_failed, tests_skipped,
-                   test_runner, lint_errors, format_errors, build_success,
-                   pr_approved, pr_changes_requested, rework_count, human_rating
-            FROM quality_metrics
-            WHERE input_id = ?1
-            ",
-            params![input_id],
-            |row| {
-                let timestamp_str: String = row.get(2)?;
-                let timestamp = DateTime::parse_from_rfc3339(&timestamp_str)
-                    .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?
-                    .with_timezone(&Utc);
-
-                Ok(QualityMetrics {
-                    id: Some(row.get(0)?),
-                    input_id: row.get(1)?,
-                    timestamp,
-                    tests_passed: row.get(3)?,
-                    tests_failed: row.get(4)?,
-                    tests_skipped: row.get(5)?,
-                    test_runner: row.get(6)?,
-                    lint_errors: row.get(7)?,
-                    format_errors: row.get(8)?,
-                    build_success: row.get(9)?,
-                    pr_approved: row.get(10)?,
-                    pr_changes_requested: row.get(11)?,
-                    rework_count: row.get(12)?,
-                    human_rating: row.get(13)?,
-                })
-            },
-        );
-
-        match result {
-            Ok(metrics) => Ok(Some(metrics)),
-            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
-            Err(e) => Err(e.into()),
-        }
+        quality::get_quality_metrics(&self.conn, input_id)
     }
 
-    /// Get aggregate test outcomes for a terminal
-    ///
-    /// Returns a tuple of (passed, failed, skipped) counts across all quality metrics
-    /// for the given terminal.
+    /// Get aggregate test outcomes for a terminal.
     #[allow(dead_code)]
     pub fn get_terminal_test_summary(&self, terminal_id: &str) -> Result<(i64, i64, i64)> {
-        let result = self.conn.query_row(
-            r"
-            SELECT
-                COALESCE(SUM(qm.tests_passed), 0) as total_passed,
-                COALESCE(SUM(qm.tests_failed), 0) as total_failed,
-                COALESCE(SUM(qm.tests_skipped), 0) as total_skipped
-            FROM quality_metrics qm
-            JOIN agent_inputs ai ON qm.input_id = ai.id
-            WHERE ai.terminal_id = ?1
-            ",
-            params![terminal_id],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-        )?;
-
-        Ok(result)
+        quality::get_terminal_test_summary(&self.conn, terminal_id)
     }
 
-    /// Update PR review status for a quality metrics record
+    /// Update PR review status for a quality metrics record.
     #[allow(dead_code)]
     pub fn update_pr_review_status(
         &self,
@@ -762,104 +341,25 @@ impl ActivityDb {
         approved: Option<bool>,
         changes_requested: Option<bool>,
     ) -> Result<()> {
-        self.conn.execute(
-            r"
-            UPDATE quality_metrics
-            SET pr_approved = COALESCE(?1, pr_approved),
-                pr_changes_requested = COALESCE(?2, pr_changes_requested)
-            WHERE input_id = ?3
-            ",
-            params![approved, changes_requested, input_id],
-        )?;
-
-        Ok(())
+        quality::update_pr_review_status(&self.conn, input_id, approved, changes_requested)
     }
 
-    /// Increment the rework count for a quality metrics record
-    ///
-    /// Called when a PR receives `changes_requested` feedback, indicating
-    /// another review cycle is needed.
+    /// Increment the rework count for a quality metrics record.
     #[allow(dead_code)]
     pub fn increment_rework_count(&self, input_id: i64) -> Result<i32> {
-        self.conn.execute(
-            r"
-            UPDATE quality_metrics
-            SET rework_count = COALESCE(rework_count, 0) + 1
-            WHERE input_id = ?1
-            ",
-            params![input_id],
-        )?;
-
-        // Return the new rework count
-        let count: i32 = self.conn.query_row(
-            "SELECT COALESCE(rework_count, 0) FROM quality_metrics WHERE input_id = ?1",
-            params![input_id],
-            |row| row.get(0),
-        )?;
-
-        Ok(count)
+        quality::increment_rework_count(&self.conn, input_id)
     }
 
-    /// Get PR rework statistics
-    ///
-    /// Returns summary statistics for PR review cycles:
-    /// - Average rework count per PR
-    /// - Max rework count
-    /// - Total PRs with rework (count > 0)
-    /// - Total PRs tracked
+    /// Get PR rework statistics.
     #[allow(dead_code)]
     pub fn get_pr_rework_stats(&self) -> Result<PrReworkStats> {
-        let result = self.conn.query_row(
-            r"
-            SELECT
-                COALESCE(AVG(CASE WHEN rework_count > 0 THEN rework_count END), 0) as avg_rework,
-                COALESCE(MAX(rework_count), 0) as max_rework,
-                SUM(CASE WHEN rework_count > 0 THEN 1 ELSE 0 END) as prs_with_rework,
-                COUNT(*) as total_prs
-            FROM quality_metrics
-            WHERE pr_approved IS NOT NULL OR pr_changes_requested IS NOT NULL
-            ",
-            [],
-            |row| {
-                Ok(PrReworkStats {
-                    avg_rework_count: row.get(0)?,
-                    max_rework_count: row.get(1)?,
-                    prs_with_rework: row.get(2)?,
-                    total_prs_tracked: row.get(3)?,
-                })
-            },
-        )?;
-
-        Ok(result)
+        quality::get_pr_rework_stats(&self.conn)
     }
 
-    /// Get quality metrics correlation: prompts that led to passing tests
-    ///
-    /// Returns the count and average test pass rate for prompts with quality metrics.
+    /// Get quality metrics correlation: prompts that led to passing tests.
     #[allow(dead_code)]
     pub fn get_prompt_success_correlation(&self) -> Result<PromptSuccessStats> {
-        let result = self.conn.query_row(
-            r"
-            SELECT
-                COUNT(*) as total_prompts,
-                SUM(CASE WHEN tests_failed = 0 AND tests_passed > 0 THEN 1 ELSE 0 END) as passing_prompts,
-                AVG(CASE WHEN tests_passed + tests_failed > 0
-                    THEN CAST(tests_passed AS REAL) / (tests_passed + tests_failed)
-                    ELSE NULL END) as avg_pass_rate
-            FROM quality_metrics
-            WHERE tests_passed IS NOT NULL OR tests_failed IS NOT NULL
-            ",
-            [],
-            |row| {
-                Ok(PromptSuccessStats {
-                    total_prompts_with_tests: row.get(0)?,
-                    prompts_with_all_passing: row.get(1)?,
-                    avg_test_pass_rate: row.get::<_, Option<f64>>(2)?.unwrap_or(0.0),
-                })
-            },
-        )?;
-
-        Ok(result)
+        quality::get_prompt_success_correlation(&self.conn)
     }
 
     /// Record resource usage parsed from terminal output
@@ -978,419 +478,77 @@ impl ActivityDb {
 
     // ========================================================================
     // Cost Analytics Methods (Issue #1064)
+    // Delegated to cost_analytics module
     // ========================================================================
 
     /// Save or update a budget configuration.
-    ///
-    /// If the budget for the given period already exists, it will be updated.
-    /// Otherwise, a new record will be created.
-    #[allow(dead_code)] // Available for future budget management features
+    #[allow(dead_code)]
     pub fn save_budget_config(&self, config: &BudgetConfig) -> Result<i64> {
-        // Deactivate any existing budget for this period
-        self.conn.execute(
-            r"UPDATE budget_config SET is_active = 0 WHERE period = ?1 AND is_active = 1",
-            params![config.period.as_str()],
-        )?;
-
-        // Insert new budget
-        self.conn.execute(
-            r"
-            INSERT INTO budget_config (period, limit_usd, alert_threshold, is_active, created_at, updated_at)
-            VALUES (?1, ?2, ?3, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
-            ",
-            params![
-                config.period.as_str(),
-                config.limit_usd,
-                config.alert_threshold,
-            ],
-        )?;
-
-        Ok(self.conn.last_insert_rowid())
+        cost_analytics::save_budget_config(&self.conn, config)
     }
 
     /// Get the active budget configuration for a period.
     #[allow(dead_code)]
     pub fn get_budget_config(&self, period: BudgetPeriod) -> Result<Option<BudgetConfig>> {
-        let result = self.conn.query_row(
-            r"
-            SELECT id, period, limit_usd, alert_threshold, created_at, updated_at, is_active
-            FROM budget_config
-            WHERE period = ?1 AND is_active = 1
-            ORDER BY created_at DESC
-            LIMIT 1
-            ",
-            params![period.as_str()],
-            |row| {
-                let period_str: String = row.get(1)?;
-                let created_str: String = row.get(4)?;
-                let updated_str: String = row.get(5)?;
-
-                let period = BudgetPeriod::from_str(&period_str).ok_or_else(|| {
-                    rusqlite::Error::ToSqlConversionFailure(
-                        format!("Invalid period: {period_str}").into(),
-                    )
-                })?;
-
-                let created_at = DateTime::parse_from_rfc3339(&created_str)
-                    .map_or_else(|_| Utc::now(), |dt| dt.with_timezone(&Utc));
-
-                let updated_at = DateTime::parse_from_rfc3339(&updated_str)
-                    .map_or_else(|_| Utc::now(), |dt| dt.with_timezone(&Utc));
-
-                Ok(BudgetConfig {
-                    id: row.get(0)?,
-                    period,
-                    limit_usd: row.get(2)?,
-                    alert_threshold: row.get(3)?,
-                    created_at,
-                    updated_at,
-                    is_active: row.get(6)?,
-                })
-            },
-        );
-
-        match result {
-            Ok(config) => Ok(Some(config)),
-            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
-            Err(e) => Err(e.into()),
-        }
+        cost_analytics::get_budget_config(&self.conn, period)
     }
 
     /// Get all active budget configurations.
     #[allow(dead_code)]
     pub fn get_all_budget_configs(&self) -> Result<Vec<BudgetConfig>> {
-        let mut stmt = self.conn.prepare(
-            r"
-            SELECT id, period, limit_usd, alert_threshold, created_at, updated_at, is_active
-            FROM budget_config
-            WHERE is_active = 1
-            ORDER BY period
-            ",
-        )?;
-
-        let configs = stmt.query_map([], |row| {
-            let period_str: String = row.get(1)?;
-            let created_str: String = row.get(4)?;
-            let updated_str: String = row.get(5)?;
-
-            let period = BudgetPeriod::from_str(&period_str).ok_or_else(|| {
-                rusqlite::Error::ToSqlConversionFailure(
-                    format!("Invalid period: {period_str}").into(),
-                )
-            })?;
-
-            let created_at = DateTime::parse_from_rfc3339(&created_str)
-                .map_or_else(|_| Utc::now(), |dt| dt.with_timezone(&Utc));
-
-            let updated_at = DateTime::parse_from_rfc3339(&updated_str)
-                .map_or_else(|_| Utc::now(), |dt| dt.with_timezone(&Utc));
-
-            Ok(BudgetConfig {
-                id: row.get(0)?,
-                period,
-                limit_usd: row.get(2)?,
-                alert_threshold: row.get(3)?,
-                created_at,
-                updated_at,
-                is_active: row.get(6)?,
-            })
-        })?;
-
-        configs.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+        cost_analytics::get_all_budget_configs(&self.conn)
     }
 
     /// Get cost summary for a date range.
-    ///
-    /// Returns aggregated cost metrics including total cost, request count,
-    /// token usage, and average cost per request.
     #[allow(dead_code)]
     pub fn get_cost_summary(
         &self,
         start_date: DateTime<Utc>,
         end_date: DateTime<Utc>,
     ) -> Result<CostSummary> {
-        let result = self.conn.query_row(
-            r"
-            SELECT
-                COALESCE(SUM(cost_usd), 0.0) as total_cost,
-                COALESCE(COUNT(*), 0) as request_count,
-                COALESCE(SUM(tokens_input), 0) as total_input_tokens,
-                COALESCE(SUM(tokens_output), 0) as total_output_tokens
-            FROM resource_usage
-            WHERE timestamp >= ?1 AND timestamp < ?2
-            ",
-            params![start_date.to_rfc3339(), end_date.to_rfc3339()],
-            |row| {
-                let total_cost: f64 = row.get(0)?;
-                let request_count: i64 = row.get(1)?;
-                Ok((total_cost, request_count, row.get::<_, i64>(2)?, row.get::<_, i64>(3)?))
-            },
-        )?;
-
-        let (total_cost, request_count, total_input_tokens, total_output_tokens) = result;
-        #[allow(clippy::cast_precision_loss)]
-        let avg_cost_per_request = if request_count > 0 {
-            total_cost / request_count as f64
-        } else {
-            0.0
-        };
-
-        Ok(CostSummary {
-            start_date,
-            end_date,
-            total_cost,
-            request_count,
-            total_input_tokens,
-            total_output_tokens,
-            avg_cost_per_request,
-        })
+        cost_analytics::get_cost_summary(&self.conn, start_date, end_date)
     }
 
     /// Get cost breakdown by agent role.
     #[allow(dead_code)]
     pub fn get_cost_by_role(&self) -> Result<Vec<CostByRole>> {
-        let mut stmt = self.conn.prepare(
-            r"
-            SELECT
-                COALESCE(ai.agent_role, 'unknown') as agent_role,
-                COALESCE(SUM(ru.cost_usd), 0.0) as total_cost,
-                COUNT(*) as request_count,
-                COALESCE(AVG(ru.cost_usd), 0.0) as avg_cost,
-                COALESCE(SUM(ru.tokens_input), 0) as total_input_tokens,
-                COALESCE(SUM(ru.tokens_output), 0) as total_output_tokens,
-                MIN(ru.timestamp) as first_usage,
-                MAX(ru.timestamp) as last_usage
-            FROM resource_usage ru
-            LEFT JOIN agent_inputs ai ON ru.input_id = ai.id
-            GROUP BY COALESCE(ai.agent_role, 'unknown')
-            ORDER BY total_cost DESC
-            ",
-        )?;
-
-        let results = stmt.query_map([], |row| {
-            let first_usage_str: Option<String> = row.get(6)?;
-            let last_usage_str: Option<String> = row.get(7)?;
-
-            let first_usage = first_usage_str
-                .and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
-                .map(|dt| dt.with_timezone(&Utc));
-
-            let last_usage = last_usage_str
-                .and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
-                .map(|dt| dt.with_timezone(&Utc));
-
-            Ok(CostByRole {
-                agent_role: row.get(0)?,
-                total_cost: row.get(1)?,
-                request_count: row.get(2)?,
-                avg_cost: row.get(3)?,
-                total_input_tokens: row.get(4)?,
-                total_output_tokens: row.get(5)?,
-                first_usage,
-                last_usage,
-            })
-        })?;
-
-        results.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+        cost_analytics::get_cost_by_role(&self.conn)
     }
 
     /// Get cost breakdown by GitHub issue.
     #[allow(dead_code)]
     pub fn get_cost_by_issue(&self, issue_number: Option<i32>) -> Result<Vec<CostByIssue>> {
-        if let Some(issue_num) = issue_number {
-            let mut stmt = self.conn.prepare(
-                r"
-                SELECT
-                    pg.issue_number,
-                    COALESCE(SUM(ru.cost_usd), 0.0) as total_cost,
-                    COUNT(DISTINCT ru.input_id) as prompt_count,
-                    COALESCE(SUM(ru.tokens_input), 0) as total_input_tokens,
-                    COALESCE(SUM(ru.tokens_output), 0) as total_output_tokens,
-                    MIN(ru.timestamp) as first_usage,
-                    MAX(ru.timestamp) as last_usage
-                FROM resource_usage ru
-                JOIN agent_inputs ai ON ru.input_id = ai.id
-                JOIN prompt_github pg ON ai.id = pg.input_id
-                WHERE pg.issue_number = ?1
-                GROUP BY pg.issue_number
-                ",
-            )?;
-            let results = stmt.query_map(params![issue_num], parse_cost_by_issue)?;
-            results.collect::<Result<Vec<_>, _>>().map_err(Into::into)
-        } else {
-            let mut stmt = self.conn.prepare(
-                r"
-                SELECT
-                    pg.issue_number,
-                    COALESCE(SUM(ru.cost_usd), 0.0) as total_cost,
-                    COUNT(DISTINCT ru.input_id) as prompt_count,
-                    COALESCE(SUM(ru.tokens_input), 0) as total_input_tokens,
-                    COALESCE(SUM(ru.tokens_output), 0) as total_output_tokens,
-                    MIN(ru.timestamp) as first_usage,
-                    MAX(ru.timestamp) as last_usage
-                FROM resource_usage ru
-                JOIN agent_inputs ai ON ru.input_id = ai.id
-                JOIN prompt_github pg ON ai.id = pg.input_id
-                WHERE pg.issue_number IS NOT NULL
-                GROUP BY pg.issue_number
-                ORDER BY total_cost DESC
-                ",
-            )?;
-            let results = stmt.query_map([], parse_cost_by_issue)?;
-            results.collect::<Result<Vec<_>, _>>().map_err(Into::into)
-        }
+        cost_analytics::get_cost_by_issue(&self.conn, issue_number)
     }
 
     /// Get cost breakdown by pull request.
     #[allow(dead_code)]
     pub fn get_cost_by_pr(&self, pr_number: Option<i32>) -> Result<Vec<CostByPr>> {
-        if let Some(pr_num) = pr_number {
-            let mut stmt = self.conn.prepare(
-                r"
-                SELECT
-                    pg.pr_number,
-                    COALESCE(SUM(ru.cost_usd), 0.0) as total_cost,
-                    COUNT(DISTINCT ru.input_id) as prompt_count,
-                    COALESCE(SUM(ru.tokens_input), 0) as total_input_tokens,
-                    COALESCE(SUM(ru.tokens_output), 0) as total_output_tokens,
-                    MIN(ru.timestamp) as first_usage,
-                    MAX(ru.timestamp) as last_usage
-                FROM resource_usage ru
-                JOIN agent_inputs ai ON ru.input_id = ai.id
-                JOIN prompt_github pg ON ai.id = pg.input_id
-                WHERE pg.pr_number = ?1
-                GROUP BY pg.pr_number
-                ",
-            )?;
-            let results = stmt.query_map(params![pr_num], parse_cost_by_pr)?;
-            results.collect::<Result<Vec<_>, _>>().map_err(Into::into)
-        } else {
-            let mut stmt = self.conn.prepare(
-                r"
-                SELECT
-                    pg.pr_number,
-                    COALESCE(SUM(ru.cost_usd), 0.0) as total_cost,
-                    COUNT(DISTINCT ru.input_id) as prompt_count,
-                    COALESCE(SUM(ru.tokens_input), 0) as total_input_tokens,
-                    COALESCE(SUM(ru.tokens_output), 0) as total_output_tokens,
-                    MIN(ru.timestamp) as first_usage,
-                    MAX(ru.timestamp) as last_usage
-                FROM resource_usage ru
-                JOIN agent_inputs ai ON ru.input_id = ai.id
-                JOIN prompt_github pg ON ai.id = pg.input_id
-                WHERE pg.pr_number IS NOT NULL
-                GROUP BY pg.pr_number
-                ORDER BY total_cost DESC
-                ",
-            )?;
-            let results = stmt.query_map([], parse_cost_by_pr)?;
-            results.collect::<Result<Vec<_>, _>>().map_err(Into::into)
-        }
+        cost_analytics::get_cost_by_pr(&self.conn, pr_number)
     }
 
     /// Get budget status for a specific period.
-    ///
-    /// Calculates current spend within the period and compares against the budget limit.
     #[allow(dead_code)]
     pub fn get_budget_status(&self, period: BudgetPeriod) -> Result<Option<BudgetStatus>> {
-        let Some(config) = self.get_budget_config(period)? else {
-            return Ok(None);
-        };
-
-        let (period_start, period_end) = get_period_bounds(period);
-        let summary = self.get_cost_summary(period_start, period_end)?;
-
-        let spent = summary.total_cost;
-        let remaining = (config.limit_usd - spent).max(0.0);
-        let usage_percent = if config.limit_usd > 0.0 {
-            (spent / config.limit_usd) * 100.0
-        } else {
-            0.0
-        };
-        let alert_triggered = (spent / config.limit_usd) >= config.alert_threshold;
-        let budget_exceeded = spent >= config.limit_usd;
-
-        Ok(Some(BudgetStatus {
-            config,
-            spent,
-            remaining,
-            usage_percent,
-            alert_triggered,
-            budget_exceeded,
-            period_start,
-            period_end,
-        }))
+        cost_analytics::get_budget_status(&self.conn, period)
     }
 
     /// Project runway based on recent burn rate.
-    ///
-    /// Uses the last N days of spending to calculate average daily cost and
-    /// estimate when the budget will be exhausted.
     #[allow(dead_code)]
     pub fn project_runway(
         &self,
         period: BudgetPeriod,
         lookback_days: i32,
     ) -> Result<Option<RunwayProjection>> {
-        let Some(config) = self.get_budget_config(period)? else {
-            return Ok(None);
-        };
-
-        // Get current period status
-        let (period_start, _) = get_period_bounds(period);
-        let status = self.get_budget_status(period)?;
-        let remaining_budget = status.map_or(config.limit_usd, |s| s.remaining);
-
-        // Calculate average daily cost over lookback period
-        let lookback_start = Utc::now() - chrono::Duration::days(i64::from(lookback_days));
-        let lookback_end = Utc::now();
-        let lookback_summary = self.get_cost_summary(lookback_start, lookback_end)?;
-
-        let avg_daily_cost = if lookback_days > 0 {
-            lookback_summary.total_cost / f64::from(lookback_days)
-        } else {
-            0.0
-        };
-
-        let days_remaining = if avg_daily_cost > 0.0 {
-            remaining_budget / avg_daily_cost
-        } else {
-            f64::INFINITY
-        };
-
-        #[allow(clippy::cast_possible_truncation)]
-        let exhaustion_date = if avg_daily_cost > 0.0 && days_remaining.is_finite() {
-            Some(period_start + chrono::Duration::days(days_remaining as i64))
-        } else {
-            None
-        };
-
-        Ok(Some(RunwayProjection {
-            remaining_budget,
-            avg_daily_cost,
-            days_remaining,
-            exhaustion_date,
-            lookback_days,
-        }))
+        cost_analytics::project_runway(&self.conn, period, lookback_days)
     }
 
     // ========================================================================
     // Issue Claim Registry Methods (Issue #1159)
+    // Delegated to claims module
     // ========================================================================
 
     /// Attempt to claim an issue or PR for a terminal.
-    ///
-    /// This uses INSERT OR IGNORE with a unique constraint to prevent race conditions.
-    /// If the claim already exists, it checks if the claim is stale (based on TTL)
-    /// and can be reclaimed.
-    ///
-    /// # Arguments
-    /// * `number` - The issue or PR number to claim
-    /// * `claim_type` - Whether this is an issue or PR claim
-    /// * `terminal_id` - The terminal claiming the work
-    /// * `label` - Optional GitHub label associated with this claim
-    /// * `agent_role` - Optional agent role for tracking
-    /// * `stale_threshold_secs` - How many seconds before a claim is considered stale (default: 3600 = 1 hour)
     pub fn claim_issue(
         &self,
         number: i32,
@@ -1400,400 +558,66 @@ impl ActivityDb {
         agent_role: Option<&str>,
         stale_threshold_secs: Option<i64>,
     ) -> Result<ClaimResult> {
-        let now = Utc::now();
-        let claim_type_str = claim_type.as_str();
-        let stale_threshold = stale_threshold_secs.unwrap_or(3600); // Default 1 hour
-
-        // First, try to insert a new claim
-        let insert_result = self.conn.execute(
-            r"
-            INSERT OR IGNORE INTO issue_claims (number, claim_type, terminal_id, claimed_at, last_heartbeat, label, agent_role)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
-            ",
-            params![
-                number,
-                claim_type_str,
-                terminal_id,
-                now.to_rfc3339(),
-                now.to_rfc3339(),
-                label,
-                agent_role,
-            ],
-        )?;
-
-        // If insert succeeded (rows_affected == 1), we got the claim
-        if insert_result == 1 {
-            let claim_id = self.conn.last_insert_rowid();
-            return Ok(ClaimResult::Success { claim_id });
-        }
-
-        // Insert failed due to unique constraint - check existing claim
-        let existing: (i64, String, String) = self.conn.query_row(
-            r"
-            SELECT id, terminal_id, last_heartbeat
-            FROM issue_claims
-            WHERE number = ?1 AND claim_type = ?2
-            ",
-            params![number, claim_type_str],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-        )?;
-
-        let (existing_id, existing_terminal, heartbeat_str) = existing;
-        let heartbeat = DateTime::parse_from_rfc3339(&heartbeat_str)
-            .map_err(|e| anyhow::anyhow!("Invalid timestamp: {e}"))?
-            .with_timezone(&Utc);
-
-        // Check if the existing claim is stale
-        let age_secs = (now - heartbeat).num_seconds();
-
-        if age_secs > stale_threshold {
-            // Claim is stale - reclaim it
-            self.conn.execute(
-                r"
-                UPDATE issue_claims
-                SET terminal_id = ?1, claimed_at = ?2, last_heartbeat = ?3, label = ?4, agent_role = ?5
-                WHERE id = ?6
-                ",
-                params![
-                    terminal_id,
-                    now.to_rfc3339(),
-                    now.to_rfc3339(),
-                    label,
-                    agent_role,
-                    existing_id,
-                ],
-            )?;
-
-            Ok(ClaimResult::Reclaimed {
-                claim_id: existing_id,
-                previous_terminal: existing_terminal,
-            })
-        } else {
-            // Claim is still active - return the current owner
-            let claimed_at_str: String = self.conn.query_row(
-                r"SELECT claimed_at FROM issue_claims WHERE id = ?1",
-                params![existing_id],
-                |row| row.get(0),
-            )?;
-            let claimed_at = DateTime::parse_from_rfc3339(&claimed_at_str)
-                .map_err(|e| anyhow::anyhow!("Invalid timestamp: {e}"))?
-                .with_timezone(&Utc);
-
-            Ok(ClaimResult::AlreadyClaimed {
-                terminal_id: existing_terminal,
-                claimed_at,
-            })
-        }
+        claims::claim_issue(
+            &self.conn,
+            number,
+            claim_type,
+            terminal_id,
+            label,
+            agent_role,
+            stale_threshold_secs,
+        )
     }
 
     /// Release a claim on an issue or PR.
-    ///
-    /// This removes the claim from the registry. Can be called when work is complete
-    /// or if the agent decides to abandon the work.
-    ///
-    /// # Arguments
-    /// * `number` - The issue or PR number to release
-    /// * `claim_type` - Whether this is an issue or PR claim
-    /// * `terminal_id` - Optional: only release if owned by this terminal
     pub fn release_claim(
         &self,
         number: i32,
         claim_type: ClaimType,
         terminal_id: Option<&str>,
     ) -> Result<bool> {
-        let claim_type_str = claim_type.as_str();
-
-        let rows = if let Some(tid) = terminal_id {
-            self.conn.execute(
-                r"DELETE FROM issue_claims WHERE number = ?1 AND claim_type = ?2 AND terminal_id = ?3",
-                params![number, claim_type_str, tid],
-            )?
-        } else {
-            self.conn.execute(
-                r"DELETE FROM issue_claims WHERE number = ?1 AND claim_type = ?2",
-                params![number, claim_type_str],
-            )?
-        };
-
-        Ok(rows > 0)
+        claims::release_claim(&self.conn, number, claim_type, terminal_id)
     }
 
     /// Update the heartbeat for an active claim.
-    ///
-    /// This should be called periodically by agents to indicate they are still
-    /// working on a claimed issue. Claims without heartbeat updates will be
-    /// considered stale after the TTL threshold.
     pub fn heartbeat_claim(
         &self,
         number: i32,
         claim_type: ClaimType,
         terminal_id: &str,
     ) -> Result<bool> {
-        let now = Utc::now();
-        let claim_type_str = claim_type.as_str();
-
-        let rows = self.conn.execute(
-            r"
-            UPDATE issue_claims
-            SET last_heartbeat = ?1
-            WHERE number = ?2 AND claim_type = ?3 AND terminal_id = ?4
-            ",
-            params![now.to_rfc3339(), number, claim_type_str, terminal_id],
-        )?;
-
-        Ok(rows > 0)
+        claims::heartbeat_claim(&self.conn, number, claim_type, terminal_id)
     }
 
     /// Get a specific claim if it exists.
     pub fn get_claim(&self, number: i32, claim_type: ClaimType) -> Result<Option<IssueClaim>> {
-        use super::models::{ClaimType, IssueClaim};
-
-        let claim_type_str = claim_type.as_str();
-
-        let result = self.conn.query_row(
-            r"
-            SELECT id, number, claim_type, terminal_id, claimed_at, last_heartbeat, label, agent_role
-            FROM issue_claims
-            WHERE number = ?1 AND claim_type = ?2
-            ",
-            params![number, claim_type_str],
-            |row| {
-                let claimed_at_str: String = row.get(4)?;
-                let heartbeat_str: String = row.get(5)?;
-
-                Ok((
-                    row.get::<_, i64>(0)?,
-                    row.get::<_, i32>(1)?,
-                    row.get::<_, String>(2)?,
-                    row.get::<_, String>(3)?,
-                    claimed_at_str,
-                    heartbeat_str,
-                    row.get::<_, Option<String>>(6)?,
-                    row.get::<_, Option<String>>(7)?,
-                ))
-            },
-        );
-
-        match result {
-            Ok((id, num, ct_str, tid, claimed_str, heartbeat_str, label, role)) => {
-                let claimed_at = DateTime::parse_from_rfc3339(&claimed_str)
-                    .map_err(|e| anyhow::anyhow!("Invalid timestamp: {e}"))?
-                    .with_timezone(&Utc);
-                let last_heartbeat = DateTime::parse_from_rfc3339(&heartbeat_str)
-                    .map_err(|e| anyhow::anyhow!("Invalid timestamp: {e}"))?
-                    .with_timezone(&Utc);
-
-                Ok(Some(IssueClaim {
-                    id: Some(id),
-                    number: num,
-                    claim_type: ClaimType::from_str(&ct_str).unwrap_or(ClaimType::Issue),
-                    terminal_id: tid,
-                    claimed_at,
-                    last_heartbeat,
-                    label,
-                    agent_role: role,
-                }))
-            }
-            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
-            Err(e) => Err(e.into()),
-        }
+        claims::get_claim(&self.conn, number, claim_type)
     }
 
     /// Get all active claims.
     pub fn get_all_claims(&self) -> Result<Vec<IssueClaim>> {
-        use super::models::{ClaimType, IssueClaim};
-
-        let mut stmt = self.conn.prepare(
-            r"
-            SELECT id, number, claim_type, terminal_id, claimed_at, last_heartbeat, label, agent_role
-            FROM issue_claims
-            ORDER BY claimed_at
-            ",
-        )?;
-
-        let claims = stmt.query_map([], |row| {
-            let claimed_at_str: String = row.get(4)?;
-            let heartbeat_str: String = row.get(5)?;
-            let ct_str: String = row.get(2)?;
-
-            Ok((
-                row.get::<_, i64>(0)?,
-                row.get::<_, i32>(1)?,
-                ct_str,
-                row.get::<_, String>(3)?,
-                claimed_at_str,
-                heartbeat_str,
-                row.get::<_, Option<String>>(6)?,
-                row.get::<_, Option<String>>(7)?,
-            ))
-        })?;
-
-        let mut result = Vec::new();
-        for claim in claims {
-            let (id, num, ct_str, tid, claimed_str, heartbeat_str, label, role) = claim?;
-
-            let claimed_at = DateTime::parse_from_rfc3339(&claimed_str)
-                .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?
-                .with_timezone(&Utc);
-            let last_heartbeat = DateTime::parse_from_rfc3339(&heartbeat_str)
-                .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?
-                .with_timezone(&Utc);
-
-            result.push(IssueClaim {
-                id: Some(id),
-                number: num,
-                claim_type: ClaimType::from_str(&ct_str).unwrap_or(ClaimType::Issue),
-                terminal_id: tid,
-                claimed_at,
-                last_heartbeat,
-                label,
-                agent_role: role,
-            });
-        }
-
-        Ok(result)
+        claims::get_all_claims(&self.conn)
     }
 
     /// Get claims for a specific terminal.
     pub fn get_claims_by_terminal(&self, terminal_id: &str) -> Result<Vec<IssueClaim>> {
-        use super::models::{ClaimType, IssueClaim};
-
-        let mut stmt = self.conn.prepare(
-            r"
-            SELECT id, number, claim_type, terminal_id, claimed_at, last_heartbeat, label, agent_role
-            FROM issue_claims
-            WHERE terminal_id = ?1
-            ORDER BY claimed_at
-            ",
-        )?;
-
-        let claims = stmt.query_map(params![terminal_id], |row| {
-            let claimed_at_str: String = row.get(4)?;
-            let heartbeat_str: String = row.get(5)?;
-            let ct_str: String = row.get(2)?;
-
-            Ok((
-                row.get::<_, i64>(0)?,
-                row.get::<_, i32>(1)?,
-                ct_str,
-                row.get::<_, String>(3)?,
-                claimed_at_str,
-                heartbeat_str,
-                row.get::<_, Option<String>>(6)?,
-                row.get::<_, Option<String>>(7)?,
-            ))
-        })?;
-
-        let mut result = Vec::new();
-        for claim in claims {
-            let (id, num, ct_str, tid, claimed_str, heartbeat_str, label, role) = claim?;
-
-            let claimed_at = DateTime::parse_from_rfc3339(&claimed_str)
-                .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?
-                .with_timezone(&Utc);
-            let last_heartbeat = DateTime::parse_from_rfc3339(&heartbeat_str)
-                .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?
-                .with_timezone(&Utc);
-
-            result.push(IssueClaim {
-                id: Some(id),
-                number: num,
-                claim_type: ClaimType::from_str(&ct_str).unwrap_or(ClaimType::Issue),
-                terminal_id: tid,
-                claimed_at,
-                last_heartbeat,
-                label,
-                agent_role: role,
-            });
-        }
-
-        Ok(result)
+        claims::get_claims_by_terminal(&self.conn, terminal_id)
     }
 
     /// Get stale claims (those without heartbeat for longer than threshold).
-    ///
-    /// # Arguments
-    /// * `stale_threshold_secs` - How many seconds before a claim is considered stale
+    #[allow(dead_code)]
     pub fn get_stale_claims(&self, stale_threshold_secs: i64) -> Result<Vec<IssueClaim>> {
-        use super::models::{ClaimType, IssueClaim};
-
-        let threshold_time = Utc::now() - chrono::Duration::seconds(stale_threshold_secs);
-
-        let mut stmt = self.conn.prepare(
-            r"
-            SELECT id, number, claim_type, terminal_id, claimed_at, last_heartbeat, label, agent_role
-            FROM issue_claims
-            WHERE last_heartbeat < ?1
-            ORDER BY last_heartbeat
-            ",
-        )?;
-
-        let claims = stmt.query_map(params![threshold_time.to_rfc3339()], |row| {
-            let claimed_at_str: String = row.get(4)?;
-            let heartbeat_str: String = row.get(5)?;
-            let ct_str: String = row.get(2)?;
-
-            Ok((
-                row.get::<_, i64>(0)?,
-                row.get::<_, i32>(1)?,
-                ct_str,
-                row.get::<_, String>(3)?,
-                claimed_at_str,
-                heartbeat_str,
-                row.get::<_, Option<String>>(6)?,
-                row.get::<_, Option<String>>(7)?,
-            ))
-        })?;
-
-        let mut result = Vec::new();
-        for claim in claims {
-            let (id, num, ct_str, tid, claimed_str, heartbeat_str, label, role) = claim?;
-
-            let claimed_at = DateTime::parse_from_rfc3339(&claimed_str)
-                .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?
-                .with_timezone(&Utc);
-            let last_heartbeat = DateTime::parse_from_rfc3339(&heartbeat_str)
-                .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?
-                .with_timezone(&Utc);
-
-            result.push(IssueClaim {
-                id: Some(id),
-                number: num,
-                claim_type: ClaimType::from_str(&ct_str).unwrap_or(ClaimType::Issue),
-                terminal_id: tid,
-                claimed_at,
-                last_heartbeat,
-                label,
-                agent_role: role,
-            });
-        }
-
-        Ok(result)
+        claims::get_stale_claims(&self.conn, stale_threshold_secs)
     }
 
     /// Release all stale claims and return the count of claims released.
-    ///
-    /// This is used during daemon startup for crash recovery.
     pub fn release_stale_claims(&self, stale_threshold_secs: i64) -> Result<usize> {
-        let threshold_time = Utc::now() - chrono::Duration::seconds(stale_threshold_secs);
-
-        let rows = self.conn.execute(
-            r"DELETE FROM issue_claims WHERE last_heartbeat < ?1",
-            params![threshold_time.to_rfc3339()],
-        )?;
-
-        Ok(rows)
+        claims::release_stale_claims(&self.conn, stale_threshold_secs)
     }
 
     /// Release all claims for a specific terminal.
-    ///
-    /// This is used when a terminal is destroyed or restarted.
     pub fn release_terminal_claims(&self, terminal_id: &str) -> Result<usize> {
-        let rows = self
-            .conn
-            .execute(r"DELETE FROM issue_claims WHERE terminal_id = ?1", params![terminal_id])?;
-
-        Ok(rows)
+        claims::release_terminal_claims(&self.conn, terminal_id)
     }
 
     /// Get a summary of all claims for visibility.
@@ -1801,114 +625,7 @@ impl ActivityDb {
         &self,
         stale_threshold_secs: i64,
     ) -> Result<super::models::ClaimsSummary> {
-        use super::models::ClaimsSummary;
-
-        let all_claims = self.get_all_claims()?;
-        let stale_claims = self.get_stale_claims(stale_threshold_secs)?;
-
-        let mut by_type = std::collections::HashMap::new();
-        let mut by_terminal: std::collections::HashMap<String, Vec<i32>> =
-            std::collections::HashMap::new();
-
-        for claim in &all_claims {
-            *by_type
-                .entry(claim.claim_type.as_str().to_string())
-                .or_insert(0) += 1;
-            by_terminal
-                .entry(claim.terminal_id.clone())
-                .or_default()
-                .push(claim.number);
-        }
-
-        #[allow(clippy::cast_possible_wrap)]
-        Ok(ClaimsSummary {
-            total_claims: all_claims.len() as i64,
-            by_type,
-            by_terminal,
-            stale_claims,
-        })
-    }
-}
-
-/// Helper function to parse `CostByIssue` from a row
-fn parse_cost_by_issue(row: &rusqlite::Row) -> rusqlite::Result<CostByIssue> {
-    let first_usage_str: Option<String> = row.get(5)?;
-    let last_usage_str: Option<String> = row.get(6)?;
-
-    let first_usage = first_usage_str
-        .and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
-        .map(|dt| dt.with_timezone(&Utc));
-
-    let last_usage = last_usage_str
-        .and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
-        .map(|dt| dt.with_timezone(&Utc));
-
-    Ok(CostByIssue {
-        issue_number: row.get(0)?,
-        total_cost: row.get(1)?,
-        prompt_count: row.get(2)?,
-        total_input_tokens: row.get(3)?,
-        total_output_tokens: row.get(4)?,
-        first_usage,
-        last_usage,
-    })
-}
-
-/// Helper function to parse `CostByPr` from a row
-fn parse_cost_by_pr(row: &rusqlite::Row) -> rusqlite::Result<CostByPr> {
-    let first_usage_str: Option<String> = row.get(5)?;
-    let last_usage_str: Option<String> = row.get(6)?;
-
-    let first_usage = first_usage_str
-        .and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
-        .map(|dt| dt.with_timezone(&Utc));
-
-    let last_usage = last_usage_str
-        .and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
-        .map(|dt| dt.with_timezone(&Utc));
-
-    Ok(CostByPr {
-        pr_number: row.get(0)?,
-        total_cost: row.get(1)?,
-        prompt_count: row.get(2)?,
-        total_input_tokens: row.get(3)?,
-        total_output_tokens: row.get(4)?,
-        first_usage,
-        last_usage,
-    })
-}
-
-/// Calculate the start and end timestamps for a budget period
-fn get_period_bounds(period: BudgetPeriod) -> (DateTime<Utc>, DateTime<Utc>) {
-    use chrono::{Datelike, Duration, TimeZone};
-
-    let now = Utc::now();
-    let today = Utc
-        .with_ymd_and_hms(now.year(), now.month(), now.day(), 0, 0, 0)
-        .unwrap();
-
-    match period {
-        BudgetPeriod::Daily => (today, today + Duration::days(1)),
-        BudgetPeriod::Weekly => {
-            // Start from Monday of current week
-            let days_since_monday = now.weekday().num_days_from_monday();
-            let week_start = today - Duration::days(i64::from(days_since_monday));
-            (week_start, week_start + Duration::weeks(1))
-        }
-        BudgetPeriod::Monthly => {
-            // Start from first day of current month
-            let month_start = Utc
-                .with_ymd_and_hms(now.year(), now.month(), 1, 0, 0, 0)
-                .unwrap();
-            // End is first day of next month
-            let next_month = if now.month() == 12 {
-                Utc.with_ymd_and_hms(now.year() + 1, 1, 1, 0, 0, 0).unwrap()
-            } else {
-                Utc.with_ymd_and_hms(now.year(), now.month() + 1, 1, 0, 0, 0)
-                    .unwrap()
-            };
-            (month_start, next_month)
-        }
+        claims::get_claims_summary(&self.conn, stale_threshold_secs)
     }
 }
 
@@ -3208,718 +1925,6 @@ test result: FAILED. 9 passed; 1 failed; 0 ignored
         Ok(())
     }
 
-    // ========================================================================
-    // Cost Analytics Tests (Issue #1064)
-    // ========================================================================
-
-    #[test]
-    fn test_save_and_get_budget_config() -> Result<()> {
-        let temp_file = NamedTempFile::new()?;
-        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
-
-        // Create a monthly budget
-        let config = BudgetConfig {
-            id: None,
-            period: BudgetPeriod::Monthly,
-            limit_usd: 100.0,
-            alert_threshold: 0.8,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            is_active: true,
-        };
-
-        let id = db.save_budget_config(&config)?;
-        assert!(id > 0);
-
-        // Retrieve and verify
-        let retrieved = db.get_budget_config(BudgetPeriod::Monthly)?;
-        assert!(retrieved.is_some());
-        if let Some(c) = retrieved {
-            assert_eq!(c.period, BudgetPeriod::Monthly);
-            assert!((c.limit_usd - 100.0).abs() < 0.001);
-            assert!((c.alert_threshold - 0.8).abs() < 0.001);
-            assert!(c.is_active);
-        }
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_budget_config_replaces_previous() -> Result<()> {
-        let temp_file = NamedTempFile::new()?;
-        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
-
-        // Create initial budget
-        let config1 = BudgetConfig {
-            id: None,
-            period: BudgetPeriod::Monthly,
-            limit_usd: 100.0,
-            alert_threshold: 0.8,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            is_active: true,
-        };
-        db.save_budget_config(&config1)?;
-
-        // Create new budget - should deactivate the old one
-        let config2 = BudgetConfig {
-            id: None,
-            period: BudgetPeriod::Monthly,
-            limit_usd: 200.0,
-            alert_threshold: 0.9,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            is_active: true,
-        };
-        db.save_budget_config(&config2)?;
-
-        // Should get the new budget
-        let retrieved = db.get_budget_config(BudgetPeriod::Monthly)?;
-        assert!(retrieved.is_some());
-        if let Some(c) = retrieved {
-            assert!((c.limit_usd - 200.0).abs() < 0.001);
-            assert!((c.alert_threshold - 0.9).abs() < 0.001);
-        }
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_get_all_budget_configs() -> Result<()> {
-        let temp_file = NamedTempFile::new()?;
-        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
-
-        // Create budgets for different periods
-        for (period, limit) in [
-            (BudgetPeriod::Daily, 10.0),
-            (BudgetPeriod::Weekly, 50.0),
-            (BudgetPeriod::Monthly, 200.0),
-        ] {
-            let config = BudgetConfig {
-                id: None,
-                period,
-                limit_usd: limit,
-                alert_threshold: 0.8,
-                created_at: Utc::now(),
-                updated_at: Utc::now(),
-                is_active: true,
-            };
-            db.save_budget_config(&config)?;
-        }
-
-        let configs = db.get_all_budget_configs()?;
-        assert_eq!(configs.len(), 3);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_get_cost_summary() -> Result<()> {
-        use super::super::resource_usage::ResourceUsage;
-
-        let temp_file = NamedTempFile::new()?;
-        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
-
-        // Record some resource usage
-        for i in 0..5 {
-            let input = AgentInput {
-                id: None,
-                terminal_id: "terminal-1".to_string(),
-                timestamp: Utc::now(),
-                input_type: InputType::Manual,
-                content: format!("command {i}"),
-                agent_role: Some("builder".to_string()),
-                context: InputContext::default(),
-            };
-            let input_id = db.record_input(&input)?;
-
-            let usage = ResourceUsage {
-                input_id: Some(input_id),
-                model: "claude-3-5-sonnet".to_string(),
-                tokens_input: 1000,
-                tokens_output: 500,
-                tokens_cache_read: None,
-                tokens_cache_write: None,
-                cost_usd: 0.01,
-                duration_ms: Some(1000),
-                provider: "anthropic".to_string(),
-                timestamp: Utc::now(),
-            };
-            db.record_resource_usage(&usage)?;
-        }
-
-        // Get summary for a wide range
-        let start = Utc::now() - chrono::Duration::hours(1);
-        let end = Utc::now() + chrono::Duration::hours(1);
-        let summary = db.get_cost_summary(start, end)?;
-
-        assert_eq!(summary.request_count, 5);
-        assert!((summary.total_cost - 0.05).abs() < 0.001);
-        assert_eq!(summary.total_input_tokens, 5000);
-        assert_eq!(summary.total_output_tokens, 2500);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_get_cost_by_role() -> Result<()> {
-        use super::super::resource_usage::ResourceUsage;
-
-        let temp_file = NamedTempFile::new()?;
-        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
-
-        // Record usage for different roles
-        for (role, cost) in [("builder", 0.05), ("judge", 0.02), ("curator", 0.01)] {
-            let input = AgentInput {
-                id: None,
-                terminal_id: "terminal-1".to_string(),
-                timestamp: Utc::now(),
-                input_type: InputType::Manual,
-                content: "test command".to_string(),
-                agent_role: Some(role.to_string()),
-                context: InputContext::default(),
-            };
-            let input_id = db.record_input(&input)?;
-
-            let usage = ResourceUsage {
-                input_id: Some(input_id),
-                model: "claude-3-5-sonnet".to_string(),
-                tokens_input: 1000,
-                tokens_output: 500,
-                tokens_cache_read: None,
-                tokens_cache_write: None,
-                cost_usd: cost,
-                duration_ms: Some(1000),
-                provider: "anthropic".to_string(),
-                timestamp: Utc::now(),
-            };
-            db.record_resource_usage(&usage)?;
-        }
-
-        let by_role = db.get_cost_by_role()?;
-        assert_eq!(by_role.len(), 3);
-
-        // Builder should have highest cost
-        let builder = by_role.iter().find(|r| r.agent_role == "builder");
-        assert!(builder.is_some());
-        if let Some(b) = builder {
-            assert!((b.total_cost - 0.05).abs() < 0.001);
-        }
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_get_budget_status() -> Result<()> {
-        use super::super::resource_usage::ResourceUsage;
-
-        let temp_file = NamedTempFile::new()?;
-        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
-
-        // Set up a monthly budget of $100 with 80% alert threshold
-        let config = BudgetConfig {
-            id: None,
-            period: BudgetPeriod::Monthly,
-            limit_usd: 100.0,
-            alert_threshold: 0.8,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            is_active: true,
-        };
-        db.save_budget_config(&config)?;
-
-        // Record $50 of usage
-        for i in 0..5 {
-            let input = AgentInput {
-                id: None,
-                terminal_id: "terminal-1".to_string(),
-                timestamp: Utc::now(),
-                input_type: InputType::Manual,
-                content: format!("command {i}"),
-                agent_role: Some("builder".to_string()),
-                context: InputContext::default(),
-            };
-            let input_id = db.record_input(&input)?;
-
-            let usage = ResourceUsage {
-                input_id: Some(input_id),
-                model: "claude-3-5-sonnet".to_string(),
-                tokens_input: 1000,
-                tokens_output: 500,
-                tokens_cache_read: None,
-                tokens_cache_write: None,
-                cost_usd: 10.0, // $10 each = $50 total
-                duration_ms: Some(1000),
-                provider: "anthropic".to_string(),
-                timestamp: Utc::now(),
-            };
-            db.record_resource_usage(&usage)?;
-        }
-
-        let status = db.get_budget_status(BudgetPeriod::Monthly)?;
-        assert!(status.is_some());
-        if let Some(s) = status {
-            assert!((s.spent - 50.0).abs() < 0.001);
-            assert!((s.remaining - 50.0).abs() < 0.001);
-            assert!((s.usage_percent - 50.0).abs() < 0.1);
-            assert!(!s.alert_triggered); // 50% < 80%
-            assert!(!s.budget_exceeded);
-        }
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_get_budget_status_alert_triggered() -> Result<()> {
-        use super::super::resource_usage::ResourceUsage;
-
-        let temp_file = NamedTempFile::new()?;
-        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
-
-        // Set up budget with 80% threshold
-        let config = BudgetConfig {
-            id: None,
-            period: BudgetPeriod::Monthly,
-            limit_usd: 100.0,
-            alert_threshold: 0.8,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            is_active: true,
-        };
-        db.save_budget_config(&config)?;
-
-        // Record $85 of usage (85% > 80% threshold)
-        let input = AgentInput {
-            id: None,
-            terminal_id: "terminal-1".to_string(),
-            timestamp: Utc::now(),
-            input_type: InputType::Manual,
-            content: "expensive operation".to_string(),
-            agent_role: Some("builder".to_string()),
-            context: InputContext::default(),
-        };
-        let input_id = db.record_input(&input)?;
-
-        let usage = ResourceUsage {
-            input_id: Some(input_id),
-            model: "claude-opus-4".to_string(),
-            tokens_input: 10000,
-            tokens_output: 5000,
-            tokens_cache_read: None,
-            tokens_cache_write: None,
-            cost_usd: 85.0,
-            duration_ms: Some(5000),
-            provider: "anthropic".to_string(),
-            timestamp: Utc::now(),
-        };
-        db.record_resource_usage(&usage)?;
-
-        let status = db.get_budget_status(BudgetPeriod::Monthly)?;
-        assert!(status.is_some());
-        if let Some(s) = status {
-            assert!(s.alert_triggered); // 85% > 80%
-            assert!(!s.budget_exceeded); // But not over 100%
-        }
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_project_runway() -> Result<()> {
-        use super::super::resource_usage::ResourceUsage;
-
-        let temp_file = NamedTempFile::new()?;
-        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
-
-        // Set up a monthly budget of $100
-        let config = BudgetConfig {
-            id: None,
-            period: BudgetPeriod::Monthly,
-            limit_usd: 100.0,
-            alert_threshold: 0.8,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            is_active: true,
-        };
-        db.save_budget_config(&config)?;
-
-        // Record $10/day for 5 days
-        for day in 0..5 {
-            let input = AgentInput {
-                id: None,
-                terminal_id: "terminal-1".to_string(),
-                timestamp: Utc::now() - chrono::Duration::days(day),
-                input_type: InputType::Manual,
-                content: format!("day {day} work"),
-                agent_role: Some("builder".to_string()),
-                context: InputContext::default(),
-            };
-            let input_id = db.record_input(&input)?;
-
-            let usage = ResourceUsage {
-                input_id: Some(input_id),
-                model: "claude-3-5-sonnet".to_string(),
-                tokens_input: 1000,
-                tokens_output: 500,
-                tokens_cache_read: None,
-                tokens_cache_write: None,
-                cost_usd: 10.0,
-                duration_ms: Some(1000),
-                provider: "anthropic".to_string(),
-                timestamp: Utc::now() - chrono::Duration::days(day),
-            };
-            db.record_resource_usage(&usage)?;
-        }
-
-        let projection = db.project_runway(BudgetPeriod::Monthly, 7)?;
-        assert!(projection.is_some());
-        if let Some(p) = projection {
-            // Average daily cost should be around $50/7 days (not all days had usage)
-            assert!(p.avg_daily_cost > 0.0);
-            assert!(p.days_remaining > 0.0);
-            assert!(p.exhaustion_date.is_some());
-        }
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_budget_not_configured() -> Result<()> {
-        let temp_file = NamedTempFile::new()?;
-        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
-
-        // No budget configured
-        let status = db.get_budget_status(BudgetPeriod::Monthly)?;
-        assert!(status.is_none());
-
-        let projection = db.project_runway(BudgetPeriod::Monthly, 7)?;
-        assert!(projection.is_none());
-
-        Ok(())
-    }
-
-    // ========================================================================
-    // Issue Claim Registry Tests (Issue #1159)
-    // ========================================================================
-
-    #[test]
-    fn test_claim_issue_success() -> Result<()> {
-        use super::super::models::{ClaimResult, ClaimType};
-
-        let temp_file = NamedTempFile::new()?;
-        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
-
-        // Claim an issue
-        let result = db.claim_issue(
-            123,
-            ClaimType::Issue,
-            "terminal-1",
-            Some("loom:building"),
-            Some("builder"),
-            None,
-        )?;
-
-        match result {
-            ClaimResult::Success { claim_id } => {
-                assert!(claim_id > 0);
-            }
-            _ => panic!("Expected ClaimResult::Success"),
-        }
-
-        // Verify the claim exists
-        let claim = db.get_claim(123, ClaimType::Issue)?;
-        assert!(claim.is_some());
-        let claim = claim.unwrap();
-        assert_eq!(claim.number, 123);
-        assert_eq!(claim.terminal_id, "terminal-1");
-        assert_eq!(claim.label, Some("loom:building".to_string()));
-        assert_eq!(claim.agent_role, Some("builder".to_string()));
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_claim_issue_already_claimed() -> Result<()> {
-        use super::super::models::{ClaimResult, ClaimType};
-
-        let temp_file = NamedTempFile::new()?;
-        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
-
-        // First claim
-        let _result1 = db.claim_issue(123, ClaimType::Issue, "terminal-1", None, None, None)?;
-
-        // Second claim should fail
-        let result2 = db.claim_issue(123, ClaimType::Issue, "terminal-2", None, None, None)?;
-
-        match result2 {
-            ClaimResult::AlreadyClaimed { terminal_id, .. } => {
-                assert_eq!(terminal_id, "terminal-1");
-            }
-            _ => panic!("Expected ClaimResult::AlreadyClaimed"),
-        }
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_claim_issue_reclaim_stale() -> Result<()> {
-        use super::super::models::{ClaimResult, ClaimType};
-
-        let temp_file = NamedTempFile::new()?;
-        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
-
-        // First claim
-        let _result1 = db.claim_issue(123, ClaimType::Issue, "terminal-1", None, None, None)?;
-
-        // Manually make it stale by updating the heartbeat to the past
-        let old_time = Utc::now() - chrono::Duration::hours(2);
-        db.conn.execute(
-            "UPDATE issue_claims SET last_heartbeat = ?1 WHERE number = 123",
-            params![old_time.to_rfc3339()],
-        )?;
-
-        // Now claim with stale threshold of 1 hour - should reclaim
-        let result2 =
-            db.claim_issue(123, ClaimType::Issue, "terminal-2", None, None, Some(3600))?;
-
-        match result2 {
-            ClaimResult::Reclaimed {
-                previous_terminal, ..
-            } => {
-                assert_eq!(previous_terminal, "terminal-1");
-            }
-            _ => panic!("Expected ClaimResult::Reclaimed"),
-        }
-
-        // Verify the claim is now owned by terminal-2
-        let claim = db.get_claim(123, ClaimType::Issue)?.unwrap();
-        assert_eq!(claim.terminal_id, "terminal-2");
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_release_claim() -> Result<()> {
-        use super::super::models::ClaimType;
-
-        let temp_file = NamedTempFile::new()?;
-        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
-
-        // Claim an issue
-        db.claim_issue(123, ClaimType::Issue, "terminal-1", None, None, None)?;
-
-        // Release it
-        let released = db.release_claim(123, ClaimType::Issue, Some("terminal-1"))?;
-        assert!(released);
-
-        // Verify it's gone
-        let claim = db.get_claim(123, ClaimType::Issue)?;
-        assert!(claim.is_none());
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_release_claim_wrong_terminal() -> Result<()> {
-        use super::super::models::ClaimType;
-
-        let temp_file = NamedTempFile::new()?;
-        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
-
-        // Claim an issue
-        db.claim_issue(123, ClaimType::Issue, "terminal-1", None, None, None)?;
-
-        // Try to release from wrong terminal
-        let released = db.release_claim(123, ClaimType::Issue, Some("terminal-2"))?;
-        assert!(!released);
-
-        // Verify it still exists
-        let claim = db.get_claim(123, ClaimType::Issue)?;
-        assert!(claim.is_some());
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_heartbeat_claim() -> Result<()> {
-        use super::super::models::ClaimType;
-
-        let temp_file = NamedTempFile::new()?;
-        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
-
-        // Claim an issue
-        db.claim_issue(123, ClaimType::Issue, "terminal-1", None, None, None)?;
-
-        let claim_before = db.get_claim(123, ClaimType::Issue)?.unwrap();
-        let heartbeat_before = claim_before.last_heartbeat;
-
-        // Wait a tiny bit and update heartbeat
-        std::thread::sleep(std::time::Duration::from_millis(10));
-
-        let updated = db.heartbeat_claim(123, ClaimType::Issue, "terminal-1")?;
-        assert!(updated);
-
-        let claim_after = db.get_claim(123, ClaimType::Issue)?.unwrap();
-        assert!(claim_after.last_heartbeat > heartbeat_before);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_get_terminal_claims() -> Result<()> {
-        use super::super::models::ClaimType;
-
-        let temp_file = NamedTempFile::new()?;
-        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
-
-        // Claim multiple issues for terminal-1
-        db.claim_issue(123, ClaimType::Issue, "terminal-1", None, None, None)?;
-        db.claim_issue(456, ClaimType::Pr, "terminal-1", None, None, None)?;
-
-        // Claim one for terminal-2
-        db.claim_issue(789, ClaimType::Issue, "terminal-2", None, None, None)?;
-
-        // Get claims for terminal-1
-        let claims = db.get_claims_by_terminal("terminal-1")?;
-        assert_eq!(claims.len(), 2);
-
-        // Get claims for terminal-2
-        let claims = db.get_claims_by_terminal("terminal-2")?;
-        assert_eq!(claims.len(), 1);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_get_stale_claims() -> Result<()> {
-        use super::super::models::ClaimType;
-
-        let temp_file = NamedTempFile::new()?;
-        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
-
-        // Claim an issue
-        db.claim_issue(123, ClaimType::Issue, "terminal-1", None, None, None)?;
-        db.claim_issue(456, ClaimType::Issue, "terminal-2", None, None, None)?;
-
-        // Make one stale
-        let old_time = Utc::now() - chrono::Duration::hours(2);
-        db.conn.execute(
-            "UPDATE issue_claims SET last_heartbeat = ?1 WHERE number = 123",
-            params![old_time.to_rfc3339()],
-        )?;
-
-        // Get stale claims (1 hour threshold)
-        let stale = db.get_stale_claims(3600)?;
-        assert_eq!(stale.len(), 1);
-        assert_eq!(stale[0].number, 123);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_release_stale_claims() -> Result<()> {
-        use super::super::models::ClaimType;
-
-        let temp_file = NamedTempFile::new()?;
-        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
-
-        // Claim issues
-        db.claim_issue(123, ClaimType::Issue, "terminal-1", None, None, None)?;
-        db.claim_issue(456, ClaimType::Issue, "terminal-2", None, None, None)?;
-
-        // Make one stale
-        let old_time = Utc::now() - chrono::Duration::hours(2);
-        db.conn.execute(
-            "UPDATE issue_claims SET last_heartbeat = ?1 WHERE number = 123",
-            params![old_time.to_rfc3339()],
-        )?;
-
-        // Release stale claims
-        let count = db.release_stale_claims(3600)?;
-        assert_eq!(count, 1);
-
-        // Verify only fresh claim remains
-        let all = db.get_all_claims()?;
-        assert_eq!(all.len(), 1);
-        assert_eq!(all[0].number, 456);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_release_terminal_claims() -> Result<()> {
-        use super::super::models::ClaimType;
-
-        let temp_file = NamedTempFile::new()?;
-        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
-
-        // Claim multiple for terminal-1
-        db.claim_issue(123, ClaimType::Issue, "terminal-1", None, None, None)?;
-        db.claim_issue(456, ClaimType::Pr, "terminal-1", None, None, None)?;
-
-        // Claim one for terminal-2
-        db.claim_issue(789, ClaimType::Issue, "terminal-2", None, None, None)?;
-
-        // Release all claims for terminal-1
-        let count = db.release_terminal_claims("terminal-1")?;
-        assert_eq!(count, 2);
-
-        // Verify only terminal-2's claim remains
-        let all = db.get_all_claims()?;
-        assert_eq!(all.len(), 1);
-        assert_eq!(all[0].terminal_id, "terminal-2");
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_claims_summary() -> Result<()> {
-        use super::super::models::ClaimType;
-
-        let temp_file = NamedTempFile::new()?;
-        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
-
-        // Claim several issues
-        db.claim_issue(100, ClaimType::Issue, "terminal-1", None, None, None)?;
-        db.claim_issue(101, ClaimType::Issue, "terminal-1", None, None, None)?;
-        db.claim_issue(200, ClaimType::Pr, "terminal-2", None, None, None)?;
-
-        // Make one stale
-        let old_time = Utc::now() - chrono::Duration::hours(2);
-        db.conn.execute(
-            "UPDATE issue_claims SET last_heartbeat = ?1 WHERE number = 100",
-            params![old_time.to_rfc3339()],
-        )?;
-
-        let summary = db.get_claims_summary(3600)?;
-        assert_eq!(summary.total_claims, 3);
-        assert_eq!(summary.by_type.get("issue"), Some(&2));
-        assert_eq!(summary.by_type.get("pr"), Some(&1));
-        assert_eq!(summary.by_terminal.get("terminal-1").map(|v| v.len()), Some(2));
-        assert_eq!(summary.by_terminal.get("terminal-2").map(|v| v.len()), Some(1));
-        assert_eq!(summary.stale_claims.len(), 1);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_claim_type_isolation() -> Result<()> {
-        use super::super::models::ClaimType;
-
-        let temp_file = NamedTempFile::new()?;
-        let db = ActivityDb::new(temp_file.path().to_path_buf())?;
-
-        // Claim same number as both issue and PR (should work)
-        db.claim_issue(123, ClaimType::Issue, "terminal-1", None, None, None)?;
-        db.claim_issue(123, ClaimType::Pr, "terminal-2", None, None, None)?;
-
-        // Both should exist
-        let issue_claim = db.get_claim(123, ClaimType::Issue)?.unwrap();
-        let pr_claim = db.get_claim(123, ClaimType::Pr)?.unwrap();
-
-        assert_eq!(issue_claim.terminal_id, "terminal-1");
-        assert_eq!(pr_claim.terminal_id, "terminal-2");
-
-        Ok(())
-    }
+    // Cost Analytics tests: see cost_analytics.rs
+    // Issue Claim Registry tests: see claims.rs
 }

--- a/loom-daemon/src/activity/metrics.rs
+++ b/loom-daemon/src/activity/metrics.rs
@@ -1,0 +1,265 @@
+//! Task-level agent metrics and productivity tracking.
+//!
+//! Extracted from `db.rs` — provides task lifecycle management (start, complete),
+//! task quality metrics updates, token usage recording, and productivity summaries.
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use rusqlite::{params, Connection};
+
+use super::models::{AgentMetric, ProductivitySummary, TokenUsage};
+
+// ========================================================================
+// Task Lifecycle
+// ========================================================================
+
+/// Start tracking a new task.
+pub(super) fn start_task(conn: &Connection, metric: &AgentMetric) -> Result<i64> {
+    let context_json = metric.context.as_deref();
+
+    conn.execute(
+        r"
+        INSERT INTO agent_metrics (
+            terminal_id, agent_role, agent_system, task_type,
+            github_issue, github_pr, started_at, status, context
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+        ",
+        params![
+            &metric.terminal_id,
+            &metric.agent_role,
+            &metric.agent_system,
+            &metric.task_type,
+            metric.github_issue,
+            metric.github_pr,
+            metric.started_at.to_rfc3339(),
+            &metric.status,
+            context_json,
+        ],
+    )?;
+
+    Ok(conn.last_insert_rowid())
+}
+
+/// Complete a task and calculate wall time.
+pub(super) fn complete_task(
+    conn: &Connection,
+    metric_id: i64,
+    status: &str,
+    outcome_type: Option<&str>,
+) -> Result<()> {
+    let now = Utc::now();
+
+    // Get started_at from database
+    let started_at: String = conn.query_row(
+        "SELECT started_at FROM agent_metrics WHERE id = ?1",
+        params![metric_id],
+        |row| row.get(0),
+    )?;
+
+    let started = DateTime::parse_from_rfc3339(&started_at)?.with_timezone(&Utc);
+    let wall_time_seconds = (now - started).num_seconds();
+
+    conn.execute(
+        r"
+        UPDATE agent_metrics
+        SET completed_at = ?1,
+            wall_time_seconds = ?2,
+            status = ?3,
+            outcome_type = ?4
+        WHERE id = ?5
+        ",
+        params![
+            now.to_rfc3339(),
+            wall_time_seconds,
+            status,
+            outcome_type,
+            metric_id
+        ],
+    )?;
+
+    Ok(())
+}
+
+/// Update task quality metrics (commits, CI failures, etc.).
+pub(super) fn update_task_metrics(
+    conn: &Connection,
+    metric_id: i64,
+    test_failures: Option<i32>,
+    ci_failures: Option<i32>,
+    commits_count: Option<i32>,
+    lines_changed: Option<i32>,
+) -> Result<()> {
+    conn.execute(
+        r"
+        UPDATE agent_metrics
+        SET test_failures = COALESCE(?1, test_failures),
+            ci_failures = COALESCE(?2, ci_failures),
+            commits_count = COALESCE(?3, commits_count),
+            lines_changed = COALESCE(?4, lines_changed)
+        WHERE id = ?5
+        ",
+        params![
+            test_failures,
+            ci_failures,
+            commits_count,
+            lines_changed,
+            metric_id
+        ],
+    )?;
+
+    Ok(())
+}
+
+// ========================================================================
+// Task Queries
+// ========================================================================
+
+/// Get metrics for a specific task.
+pub(super) fn get_task_metrics(conn: &Connection, metric_id: i64) -> Result<AgentMetric> {
+    Ok(conn.query_row(
+        r"
+        SELECT id, terminal_id, agent_role, agent_system, task_type,
+               github_issue, github_pr, started_at, completed_at,
+               wall_time_seconds, active_time_seconds, input_tokens,
+               output_tokens, total_tokens, estimated_cost_usd, status,
+               outcome_type, test_failures, ci_failures, commits_count,
+               lines_changed, context
+        FROM agent_metrics
+        WHERE id = ?1
+        ",
+        params![metric_id],
+        |row| {
+            let started_str: String = row.get(7)?;
+            let completed_str: Option<String> = row.get(8)?;
+
+            let started_at = DateTime::parse_from_rfc3339(&started_str)
+                .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?
+                .with_timezone(&Utc);
+
+            let completed_at = if let Some(completed) = completed_str {
+                Some(
+                    DateTime::parse_from_rfc3339(&completed)
+                        .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?
+                        .with_timezone(&Utc),
+                )
+            } else {
+                None
+            };
+
+            Ok(AgentMetric {
+                id: Some(row.get(0)?),
+                terminal_id: row.get(1)?,
+                agent_role: row.get(2)?,
+                agent_system: row.get(3)?,
+                task_type: row.get(4)?,
+                github_issue: row.get(5)?,
+                github_pr: row.get(6)?,
+                started_at,
+                completed_at,
+                wall_time_seconds: row.get(9)?,
+                active_time_seconds: row.get(10)?,
+                input_tokens: row.get(11)?,
+                output_tokens: row.get(12)?,
+                total_tokens: row.get(13)?,
+                estimated_cost_usd: row.get(14)?,
+                status: row.get(15)?,
+                outcome_type: row.get(16)?,
+                test_failures: row.get(17)?,
+                ci_failures: row.get(18)?,
+                commits_count: row.get(19)?,
+                lines_changed: row.get(20)?,
+                context: row.get(21)?,
+            })
+        },
+    )?)
+}
+
+/// Get productivity summary grouped by agent system.
+pub(super) fn get_productivity_summary(conn: &Connection) -> Result<ProductivitySummary> {
+    let mut stmt = conn.prepare(
+        r"
+        SELECT
+            agent_system,
+            COUNT(*) as tasks_completed,
+            AVG(wall_time_seconds / 60.0) as avg_minutes,
+            AVG(total_tokens) as avg_tokens,
+            SUM(estimated_cost_usd) as total_cost
+        FROM agent_metrics
+        WHERE status = 'success' AND completed_at IS NOT NULL
+        GROUP BY agent_system
+        ORDER BY tasks_completed DESC
+        ",
+    )?;
+
+    let results = stmt.query_map([], |row| {
+        Ok((
+            row.get(0)?, // agent_system
+            row.get(1)?, // tasks_completed
+            row.get(2)?, // avg_minutes
+            row.get(3)?, // avg_tokens
+            row.get(4)?, // total_cost
+        ))
+    })?;
+
+    results.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+}
+
+// ========================================================================
+// Token Usage
+// ========================================================================
+
+/// Record token usage for an API request.
+///
+/// Records comprehensive LLM resource usage including token counts, cache usage,
+/// duration, and cost. If a `metric_id` is provided, also updates the aggregate
+/// token counts in `agent_metrics`.
+pub(super) fn record_token_usage(conn: &Connection, usage: &TokenUsage) -> Result<i64> {
+    conn.execute(
+        r"
+        INSERT INTO token_usage (
+            input_id, metric_id, timestamp, prompt_tokens,
+            completion_tokens, total_tokens, model, estimated_cost_usd,
+            tokens_cache_read, tokens_cache_write, duration_ms, provider
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+        ",
+        params![
+            usage.input_id,
+            usage.metric_id,
+            usage.timestamp.to_rfc3339(),
+            usage.prompt_tokens,
+            usage.completion_tokens,
+            usage.total_tokens,
+            &usage.model,
+            usage.estimated_cost_usd,
+            usage.tokens_cache_read,
+            usage.tokens_cache_write,
+            usage.duration_ms,
+            &usage.provider,
+        ],
+    )?;
+
+    // Update aggregate token counts in agent_metrics if metric_id is provided
+    if let Some(metric_id) = usage.metric_id {
+        conn.execute(
+            r"
+            UPDATE agent_metrics
+            SET input_tokens = input_tokens + ?1,
+                output_tokens = output_tokens + ?2,
+                total_tokens = total_tokens + ?3,
+                estimated_cost_usd = estimated_cost_usd + ?4
+            WHERE id = ?5
+            ",
+            params![
+                usage.prompt_tokens,
+                usage.completion_tokens,
+                usage.total_tokens,
+                usage.estimated_cost_usd,
+                metric_id
+            ],
+        )?;
+    }
+
+    Ok(conn.last_insert_rowid())
+}

--- a/loom-daemon/src/activity/mod.rs
+++ b/loom-daemon/src/activity/mod.rs
@@ -36,8 +36,13 @@
 //! db.record_input(&input)?;
 //! ```
 
+mod claims;
+mod cost_analytics;
 mod db;
+mod metrics;
 mod models;
+mod prompts;
+mod quality;
 pub mod resource_usage;
 mod schema;
 pub mod stats;

--- a/loom-daemon/src/activity/prompts.rs
+++ b/loom-daemon/src/activity/prompts.rs
@@ -1,0 +1,191 @@
+//! Prompt tracking: git changes and GitHub event correlation.
+//!
+//! Extracted from `db.rs` — provides recording and querying of prompt-level
+//! tracking data including git changes per prompt and GitHub event correlation.
+
+use anyhow::Result;
+use rusqlite::{params, Connection};
+
+use super::models::{PromptChanges, PromptGitHubEvent, PromptGitHubEventType};
+
+// ========================================================================
+// Prompt Changes (Git)
+// ========================================================================
+
+/// Record git changes associated with a prompt.
+pub(super) fn record_prompt_changes(conn: &Connection, changes: &PromptChanges) -> Result<i64> {
+    conn.execute(
+        r"
+        INSERT INTO prompt_changes (
+            input_id, before_commit, after_commit, files_changed,
+            lines_added, lines_removed, tests_added, tests_modified
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+        ",
+        params![
+            changes.input_id,
+            &changes.before_commit,
+            &changes.after_commit,
+            changes.files_changed,
+            changes.lines_added,
+            changes.lines_removed,
+            changes.tests_added,
+            changes.tests_modified,
+        ],
+    )?;
+
+    Ok(conn.last_insert_rowid())
+}
+
+/// Get prompt changes for a specific input.
+pub(super) fn get_prompt_changes(
+    conn: &Connection,
+    input_id: i64,
+) -> Result<Option<PromptChanges>> {
+    let result = conn.query_row(
+        r"
+        SELECT id, input_id, before_commit, after_commit, files_changed,
+               lines_added, lines_removed, tests_added, tests_modified
+        FROM prompt_changes
+        WHERE input_id = ?1
+        ",
+        params![input_id],
+        |row| {
+            Ok(PromptChanges {
+                id: Some(row.get(0)?),
+                input_id: row.get(1)?,
+                before_commit: row.get(2)?,
+                after_commit: row.get(3)?,
+                files_changed: row.get(4)?,
+                lines_added: row.get(5)?,
+                lines_removed: row.get(6)?,
+                tests_added: row.get(7)?,
+                tests_modified: row.get(8)?,
+            })
+        },
+    );
+
+    match result {
+        Ok(changes) => Ok(Some(changes)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Get total lines changed across all prompts for a terminal.
+pub(super) fn get_terminal_changes_summary(
+    conn: &Connection,
+    terminal_id: &str,
+) -> Result<(i64, i64, i64)> {
+    // Returns (total_files_changed, total_lines_added, total_lines_removed)
+    let result = conn.query_row(
+        r"
+        SELECT
+            COALESCE(SUM(pc.files_changed), 0),
+            COALESCE(SUM(pc.lines_added), 0),
+            COALESCE(SUM(pc.lines_removed), 0)
+        FROM prompt_changes pc
+        JOIN agent_inputs ai ON pc.input_id = ai.id
+        WHERE ai.terminal_id = ?1
+        ",
+        params![terminal_id],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+    )?;
+
+    Ok(result)
+}
+
+// ========================================================================
+// Prompt GitHub Events
+// ========================================================================
+
+/// Record a prompt-GitHub correlation event.
+///
+/// Links a prompt (agent input) with a GitHub action it triggered,
+/// such as creating an issue, opening a PR, or changing labels.
+pub(super) fn record_prompt_github_event(
+    conn: &Connection,
+    event: &PromptGitHubEvent,
+) -> Result<i64> {
+    let label_before_json = event
+        .label_before
+        .as_ref()
+        .map(serde_json::to_string)
+        .transpose()?;
+
+    let label_after_json = event
+        .label_after
+        .as_ref()
+        .map(serde_json::to_string)
+        .transpose()?;
+
+    conn.execute(
+        r"
+        INSERT INTO prompt_github (input_id, issue_number, pr_number, label_before, label_after, event_type)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+        ",
+        params![
+            event.input_id,
+            event.issue_number,
+            event.pr_number,
+            label_before_json,
+            label_after_json,
+            event.event_type.as_str(),
+        ],
+    )?;
+
+    Ok(conn.last_insert_rowid())
+}
+
+/// Get prompt-GitHub events for a specific input.
+pub(super) fn get_prompt_github_events(
+    conn: &Connection,
+    input_id: i64,
+) -> Result<Vec<PromptGitHubEvent>> {
+    let mut stmt = conn.prepare(
+        r"
+        SELECT id, input_id, issue_number, pr_number, label_before, label_after, event_type
+        FROM prompt_github
+        WHERE input_id = ?1
+        ORDER BY id
+        ",
+    )?;
+
+    let events = stmt.query_map(params![input_id], |row| {
+        let id: i64 = row.get(0)?;
+        let input_id: Option<i64> = row.get(1)?;
+        let issue_number: Option<i32> = row.get(2)?;
+        let pr_number: Option<i32> = row.get(3)?;
+        let label_before_json: Option<String> = row.get(4)?;
+        let label_after_json: Option<String> = row.get(5)?;
+        let event_type_str: String = row.get(6)?;
+
+        let label_before = label_before_json
+            .map(|json| serde_json::from_str(&json))
+            .transpose()
+            .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?;
+
+        let label_after = label_after_json
+            .map(|json| serde_json::from_str(&json))
+            .transpose()
+            .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?;
+
+        let event_type = PromptGitHubEventType::from_str(&event_type_str).ok_or_else(|| {
+            rusqlite::Error::ToSqlConversionFailure(
+                format!("Invalid event_type: {event_type_str}").into(),
+            )
+        })?;
+
+        Ok(PromptGitHubEvent {
+            id: Some(id),
+            input_id,
+            issue_number,
+            pr_number,
+            label_before,
+            label_after,
+            event_type,
+        })
+    })?;
+
+    events.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+}

--- a/loom-daemon/src/activity/quality.rs
+++ b/loom-daemon/src/activity/quality.rs
@@ -1,0 +1,267 @@
+//! Quality metrics tracking for test results, PR reviews, and rework cycles.
+//!
+//! Extracted from `db.rs` — provides recording and querying of quality metrics
+//! including test results, lint/format status, PR review outcomes, and rework tracking.
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use rusqlite::{params, Connection};
+
+use super::models::{PrReworkStats, PromptSuccessStats, QualityMetrics};
+use super::test_parser;
+
+// ========================================================================
+// Quality Metrics Recording
+// ========================================================================
+
+/// Record quality metrics for an input/output.
+pub(super) fn record_quality_metrics(conn: &Connection, metrics: &QualityMetrics) -> Result<i64> {
+    conn.execute(
+        r"
+        INSERT INTO quality_metrics (
+            input_id, timestamp, tests_passed, tests_failed, tests_skipped,
+            test_runner, lint_errors, format_errors, build_success,
+            pr_approved, pr_changes_requested, rework_count, human_rating
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+        ",
+        params![
+            metrics.input_id,
+            metrics.timestamp.to_rfc3339(),
+            metrics.tests_passed,
+            metrics.tests_failed,
+            metrics.tests_skipped,
+            &metrics.test_runner,
+            metrics.lint_errors,
+            metrics.format_errors,
+            metrics.build_success,
+            metrics.pr_approved,
+            metrics.pr_changes_requested,
+            metrics.rework_count,
+            metrics.human_rating,
+        ],
+    )?;
+
+    Ok(conn.last_insert_rowid())
+}
+
+/// Parse and record quality metrics from terminal output.
+///
+/// Automatically parses test results, lint errors, and build status from
+/// the output content and stores them in the database.
+pub(super) fn record_quality_from_output(
+    conn: &Connection,
+    input_id: i64,
+    output: &str,
+) -> Result<Option<i64>> {
+    let test_results = test_parser::parse_test_results(output);
+    let lint_results = test_parser::parse_lint_results(output);
+    let build_status = test_parser::parse_build_status(output);
+
+    // Only record if we found at least some quality metrics
+    if test_results.is_none() && lint_results.is_none() && build_status.is_none() {
+        return Ok(None);
+    }
+
+    let metrics = QualityMetrics {
+        id: None,
+        input_id: Some(input_id),
+        timestamp: Utc::now(),
+        tests_passed: test_results.as_ref().map(|t| t.passed),
+        tests_failed: test_results.as_ref().map(|t| t.failed),
+        tests_skipped: test_results.as_ref().map(|t| t.skipped),
+        test_runner: test_results.and_then(|t| t.runner),
+        lint_errors: lint_results.as_ref().map(|l| l.lint_errors),
+        format_errors: lint_results.map(|l| l.format_errors),
+        build_success: build_status,
+        pr_approved: None,
+        pr_changes_requested: None,
+        rework_count: None,
+        human_rating: None,
+    };
+
+    Ok(Some(record_quality_metrics(conn, &metrics)?))
+}
+
+// ========================================================================
+// Quality Metrics Queries
+// ========================================================================
+
+/// Get quality metrics for a specific input.
+pub(super) fn get_quality_metrics(
+    conn: &Connection,
+    input_id: i64,
+) -> Result<Option<QualityMetrics>> {
+    let result = conn.query_row(
+        r"
+        SELECT id, input_id, timestamp, tests_passed, tests_failed, tests_skipped,
+               test_runner, lint_errors, format_errors, build_success,
+               pr_approved, pr_changes_requested, rework_count, human_rating
+        FROM quality_metrics
+        WHERE input_id = ?1
+        ",
+        params![input_id],
+        |row| {
+            let timestamp_str: String = row.get(2)?;
+            let timestamp = DateTime::parse_from_rfc3339(&timestamp_str)
+                .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?
+                .with_timezone(&Utc);
+
+            Ok(QualityMetrics {
+                id: Some(row.get(0)?),
+                input_id: row.get(1)?,
+                timestamp,
+                tests_passed: row.get(3)?,
+                tests_failed: row.get(4)?,
+                tests_skipped: row.get(5)?,
+                test_runner: row.get(6)?,
+                lint_errors: row.get(7)?,
+                format_errors: row.get(8)?,
+                build_success: row.get(9)?,
+                pr_approved: row.get(10)?,
+                pr_changes_requested: row.get(11)?,
+                rework_count: row.get(12)?,
+                human_rating: row.get(13)?,
+            })
+        },
+    );
+
+    match result {
+        Ok(metrics) => Ok(Some(metrics)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Get aggregate test outcomes for a terminal.
+///
+/// Returns a tuple of (passed, failed, skipped) counts across all quality metrics
+/// for the given terminal.
+pub(super) fn get_terminal_test_summary(
+    conn: &Connection,
+    terminal_id: &str,
+) -> Result<(i64, i64, i64)> {
+    let result = conn.query_row(
+        r"
+        SELECT
+            COALESCE(SUM(qm.tests_passed), 0) as total_passed,
+            COALESCE(SUM(qm.tests_failed), 0) as total_failed,
+            COALESCE(SUM(qm.tests_skipped), 0) as total_skipped
+        FROM quality_metrics qm
+        JOIN agent_inputs ai ON qm.input_id = ai.id
+        WHERE ai.terminal_id = ?1
+        ",
+        params![terminal_id],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+    )?;
+
+    Ok(result)
+}
+
+// ========================================================================
+// PR Review Status
+// ========================================================================
+
+/// Update PR review status for a quality metrics record.
+pub(super) fn update_pr_review_status(
+    conn: &Connection,
+    input_id: i64,
+    approved: Option<bool>,
+    changes_requested: Option<bool>,
+) -> Result<()> {
+    conn.execute(
+        r"
+        UPDATE quality_metrics
+        SET pr_approved = COALESCE(?1, pr_approved),
+            pr_changes_requested = COALESCE(?2, pr_changes_requested)
+        WHERE input_id = ?3
+        ",
+        params![approved, changes_requested, input_id],
+    )?;
+
+    Ok(())
+}
+
+/// Increment the rework count for a quality metrics record.
+///
+/// Called when a PR receives `changes_requested` feedback, indicating
+/// another review cycle is needed.
+pub(super) fn increment_rework_count(conn: &Connection, input_id: i64) -> Result<i32> {
+    conn.execute(
+        r"
+        UPDATE quality_metrics
+        SET rework_count = COALESCE(rework_count, 0) + 1
+        WHERE input_id = ?1
+        ",
+        params![input_id],
+    )?;
+
+    // Return the new rework count
+    let count: i32 = conn.query_row(
+        "SELECT COALESCE(rework_count, 0) FROM quality_metrics WHERE input_id = ?1",
+        params![input_id],
+        |row| row.get(0),
+    )?;
+
+    Ok(count)
+}
+
+/// Get PR rework statistics.
+///
+/// Returns summary statistics for PR review cycles:
+/// - Average rework count per PR
+/// - Max rework count
+/// - Total PRs with rework (count > 0)
+/// - Total PRs tracked
+pub(super) fn get_pr_rework_stats(conn: &Connection) -> Result<PrReworkStats> {
+    let result = conn.query_row(
+        r"
+        SELECT
+            COALESCE(AVG(CASE WHEN rework_count > 0 THEN rework_count END), 0) as avg_rework,
+            COALESCE(MAX(rework_count), 0) as max_rework,
+            SUM(CASE WHEN rework_count > 0 THEN 1 ELSE 0 END) as prs_with_rework,
+            COUNT(*) as total_prs
+        FROM quality_metrics
+        WHERE pr_approved IS NOT NULL OR pr_changes_requested IS NOT NULL
+        ",
+        [],
+        |row| {
+            Ok(PrReworkStats {
+                avg_rework_count: row.get(0)?,
+                max_rework_count: row.get(1)?,
+                prs_with_rework: row.get(2)?,
+                total_prs_tracked: row.get(3)?,
+            })
+        },
+    )?;
+
+    Ok(result)
+}
+
+/// Get quality metrics correlation: prompts that led to passing tests.
+///
+/// Returns the count and average test pass rate for prompts with quality metrics.
+pub(super) fn get_prompt_success_correlation(conn: &Connection) -> Result<PromptSuccessStats> {
+    let result = conn.query_row(
+        r"
+        SELECT
+            COUNT(*) as total_prompts,
+            SUM(CASE WHEN tests_failed = 0 AND tests_passed > 0 THEN 1 ELSE 0 END) as passing_prompts,
+            AVG(CASE WHEN tests_passed + tests_failed > 0
+                THEN CAST(tests_passed AS REAL) / (tests_passed + tests_failed)
+                ELSE NULL END) as avg_pass_rate
+        FROM quality_metrics
+        WHERE tests_passed IS NOT NULL OR tests_failed IS NOT NULL
+        ",
+        [],
+        |row| {
+            Ok(PromptSuccessStats {
+                total_prompts_with_tests: row.get(0)?,
+                prompts_with_all_passing: row.get(1)?,
+                avg_test_pass_rate: row.get::<_, Option<f64>>(2)?.unwrap_or(0.0),
+            })
+        },
+    )?;
+
+    Ok(result)
+}


### PR DESCRIPTION
## Summary

- Extracts 5 domain modules from the monolithic `db.rs` (3,925 → 615 lines): `claims.rs`, `cost_analytics.rs`, `metrics.rs`, `prompts.rs`, `quality.rs`
- `ActivityDb` retains core operations and delegates to submodules via thin wrapper methods
- Public API unchanged — no breaking changes

## Test plan

- [x] `cargo check -p loom-daemon` — compiles with zero warnings
- [x] `cargo clippy -p loom-daemon` — zero warnings
- [x] `cargo test -p loom-daemon -- activity` — all 88 tests pass
- [x] Tests for extracted modules (claims, cost_analytics) run in their new locations

Closes #1881

🤖 Generated with [Claude Code](https://claude.com/claude-code)