### PR TITLE
Add --force flag to loom-daemon init in install.sh --clean path

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -552,7 +552,7 @@ case "$METHOD" in
         error "Uninstall failed - aborting clean install"
       echo ""
       info "Uninstall complete, proceeding with fresh install..."
-      "$LOOM_ROOT/target/release/loom-daemon" init --defaults "$LOOM_ROOT/defaults" "$TARGET_PATH" || \
+      "$LOOM_ROOT/target/release/loom-daemon" init --force --defaults "$LOOM_ROOT/defaults" "$TARGET_PATH" || \
         error "Installation failed"
     else
       # Run loom-daemon init

--- a/loom-daemon/src/terminal.rs
+++ b/loom-daemon/src/terminal.rs
@@ -226,7 +226,7 @@ impl TerminalManager {
                     let repo_root = path
                         .ancestors()
                         .find(|p| p.join(".loom").is_dir() && p.join(".git").exists())
-                        .map(|p| p.to_path_buf());
+                        .map(std::path::Path::to_path_buf);
 
                     // First try to remove the worktree via git
                     let mut cmd = Command::new("git");


### PR DESCRIPTION
## Summary

- Add missing `--force` flag to `loom-daemon init` call in the `--clean` install path (line 555), matching the pattern from PR #1929
- Fix pre-existing Clippy `redundant_closure_for_method_calls` lint in `loom-daemon/src/terminal.rs`

Closes #1930

## Test plan

- [ ] Verify `pnpm check:ci:lite` passes (confirmed locally)
- [ ] Verify `--clean` install path passes `--force --defaults` to `loom-daemon init`

🤖 Generated with [Claude Code](https://claude.com/claude-code)