### PR TITLE
Update Biome schema version from 2.3.12 to 2.3.13

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.12/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.13/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/quickstarts/api/biome.json
+++ b/quickstarts/api/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.12/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.13/schema.json",
   "root": false,
   "vcs": {
     "enabled": true,

--- a/quickstarts/desktop/biome.json
+++ b/quickstarts/desktop/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.12/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.13/schema.json",
   "root": false,
   "vcs": {
     "enabled": true,

--- a/quickstarts/webapp/biome.json
+++ b/quickstarts/webapp/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.12/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.13/schema.json",
   "root": false,
   "assist": {
     "actions": {


### PR DESCRIPTION
## Summary
- Updates Biome JSON schema version from 2.3.12 to 2.3.13 across all `biome.json` files (root, api, desktop, webapp quickstarts)

Closes #1934

## Test plan
- [ ] Verify `pnpm lint` passes with the new schema version
- [ ] Confirm no biome configuration regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)