### PR TITLE
Fix integration test flakiness from daemon restoring orphan sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ Thumbs.db
 .loom/progress/
 .loom/diagnostics/
 .loom/guide-docs-state.json
+.loom/metrics_state.json
 
 # Loom workspace config (DO commit for team sharing)
 # - config.json: Persistent terminal configurations (roles, themes, intervals)

--- a/loom-daemon/tests/integration_basic.rs
+++ b/loom-daemon/tests/integration_basic.rs
@@ -5,14 +5,17 @@
 mod common;
 
 use common::{
-    capture_terminal_output, cleanup_test_sessions, tmux_session_exists, TestClient, TestDaemon,
+    capture_terminal_output, cleanup_all_loom_sessions, cleanup_test_sessions, tmux_session_exists,
+    TestClient, TestDaemon,
 };
 use serial_test::serial;
 
 /// Cleanup helper to run before/after tests.
-/// Only cleans up sessions belonging to the current test binary.
+/// Cleans ALL loom sessions to prevent the daemon from restoring orphan sessions
+/// from other test binaries or previous runs. This is necessary because the daemon
+/// calls `restore_from_tmux()` on startup which imports any existing loom-* sessions.
 fn setup() {
-    cleanup_test_sessions();
+    cleanup_all_loom_sessions();
 }
 
 /// Test 1.1: Basic Ping/Pong communication

--- a/loom-daemon/tests/integration_factory_reset.rs
+++ b/loom-daemon/tests/integration_factory_reset.rs
@@ -5,16 +5,19 @@
 mod common;
 
 use common::{
-    cleanup_test_sessions, get_test_tmux_sessions, kill_tmux_session, tmux_session_exists,
-    TestClient, TestDaemon,
+    cleanup_all_loom_sessions, cleanup_test_sessions, get_test_tmux_sessions, kill_tmux_session,
+    tmux_session_exists, TestClient, TestDaemon,
 };
 use serial_test::serial;
 use tokio::time::{sleep, Duration};
 use uuid::Uuid;
 
-/// Ensure we always begin with a clean slate of tmux sessions for this binary.
+/// Ensure we always begin with a clean slate of tmux sessions.
+/// Cleans ALL loom sessions to prevent the daemon from restoring orphan sessions
+/// from other test binaries or previous runs. This is necessary because the daemon
+/// calls `restore_from_tmux()` on startup which imports any existing loom-* sessions.
 fn setup() {
-    cleanup_test_sessions();
+    cleanup_all_loom_sessions();
 }
 
 /// Create the standard set of 7 workspace terminals and return their IDs


### PR DESCRIPTION
## Summary

- Fix integration test flakiness caused by daemon restoring orphan tmux sessions
- Add `.loom/metrics_state.json` to `.gitignore`

## Problem

The daemon calls `restore_from_tmux()` on startup which imports ALL existing `loom-*` tmux sessions into its registry. When tests from different binaries (security, basic, factory_reset) ran in parallel or didn't clean up properly, orphan sessions could persist and cause test failures like:

```
assertion `left == right` failed: Should have no terminals after destroy
  left: 1
 right: 0
```

## Solution

Changed `integration_basic.rs` and `integration_factory_reset.rs` to use `cleanup_all_loom_sessions()` in setup() instead of `cleanup_test_sessions()`. This ensures the daemon doesn't restore orphan sessions from previous runs or other test binaries.

## Test plan

- [x] All integration tests pass: `cargo test -p loom-daemon --test integration_basic --test integration_factory_reset --test integration_security`
- [x] Full `pnpm check:ci:lite` passes

## Related

- #1942 (builder test verification scope - now unblocked)
- #1952 (daemon restore behavior documentation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)