### PR TITLE
Phase 2: Side-by-side layout (terminal + analytics)

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@
   </head>
   <body class="bg-gray-200 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
     <div id="app" class="h-screen flex flex-col">
-      <!-- Header -->
-      <header id="header" class="h-16 px-6 flex items-center justify-between border-b border-gray-300 dark:border-gray-700 bg-gray-200 dark:bg-gray-900">
+      <!-- Header (simplified) -->
+      <header id="header" class="h-12 px-4 flex items-center justify-between border-b border-gray-300 dark:border-gray-700 bg-gray-200 dark:bg-gray-900">
         <div class="flex items-center gap-4">
           <div id="workspace-name" class="text-lg font-bold">
             <!-- Dynamically rendered: "Loom" or repo name -->
@@ -26,15 +26,34 @@
         </div>
       </header>
 
-      <!-- Primary Terminal -->
-      <main id="primary-terminal" class="flex-1 p-4 bg-gray-200 dark:bg-gray-900">
-        <!-- Terminal content here -->
-      </main>
+      <!-- Main Content: Terminal + Analytics side-by-side -->
+      <div id="main-content" class="flex-1 flex overflow-hidden">
+        <!-- Terminal View (left panel) -->
+        <div id="terminal-view" class="flex-1 min-w-[300px] p-4 bg-gray-200 dark:bg-gray-900">
+          <!-- Terminal content renders here -->
+        </div>
 
-      <!-- Mini Terminal Row -->
-      <footer id="mini-terminal-row" class="h-40 mb-4 border-t border-gray-300 dark:border-gray-700 bg-gray-100 dark:bg-gray-800">
-        <!-- Mini terminals here -->
-      </footer>
+        <!-- Resize Handle -->
+        <div id="resize-handle" class="w-1 cursor-col-resize bg-gray-300 dark:bg-gray-600 hover:bg-blue-400 dark:hover:bg-blue-500 transition-colors flex-shrink-0"></div>
+
+        <!-- Analytics View (right panel) -->
+        <div id="analytics-view" class="flex-1 min-w-[300px] overflow-auto p-4 bg-gray-100 dark:bg-gray-800">
+          <!-- Analytics dashboard content (Phase 5) -->
+          <div class="h-full flex items-center justify-center text-gray-400 dark:text-gray-500">
+            <p class="text-lg">Analytics Dashboard (Coming Soon)</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Status Bar -->
+      <div id="status-bar" class="h-8 px-4 flex items-center justify-between border-t border-gray-300 dark:border-gray-700 bg-gray-100 dark:bg-gray-800 text-xs text-gray-600 dark:text-gray-400">
+        <div id="status-left">
+          <!-- Session status -->
+        </div>
+        <div id="status-right">
+          <!-- Quick actions -->
+        </div>
+      </div>
     </div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/src/lib/resize-handle.ts
+++ b/src/lib/resize-handle.ts
@@ -1,0 +1,187 @@
+/**
+ * Resize handle functionality for the terminal/analytics split view.
+ *
+ * Provides drag-to-resize with:
+ * - Mouse drag support
+ * - Minimum width constraints (300px per panel)
+ * - localStorage persistence of split position
+ * - Smooth visual feedback during drag
+ */
+
+const STORAGE_KEY = "loom:split-position";
+const MIN_WIDTH = 300;
+const DEFAULT_RATIO = 0.5;
+
+let isDragging = false;
+let startX = 0;
+let startLeftWidth = 0;
+
+/**
+ * Get the stored split ratio or default to 50/50
+ */
+function getStoredRatio(): number {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      const ratio = parseFloat(stored);
+      if (!Number.isNaN(ratio) && ratio >= 0 && ratio <= 1) {
+        return ratio;
+      }
+    }
+  } catch {
+    // localStorage might be unavailable
+  }
+  return DEFAULT_RATIO;
+}
+
+/**
+ * Store the split ratio for persistence
+ */
+function storeRatio(ratio: number): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, ratio.toFixed(4));
+  } catch {
+    // localStorage might be unavailable
+  }
+}
+
+/**
+ * Apply the split ratio to the panels
+ */
+function applySplitRatio(ratio: number): void {
+  const mainContent = document.getElementById("main-content");
+  const terminalView = document.getElementById("terminal-view");
+  const analyticsView = document.getElementById("analytics-view");
+
+  if (!mainContent || !terminalView || !analyticsView) return;
+
+  const totalWidth = mainContent.clientWidth - 4; // Account for resize handle width
+  const leftWidth = Math.max(MIN_WIDTH, Math.min(totalWidth - MIN_WIDTH, totalWidth * ratio));
+  const rightWidth = totalWidth - leftWidth;
+
+  // Use flex-basis to set widths
+  terminalView.style.flexBasis = `${leftWidth}px`;
+  terminalView.style.flexGrow = "0";
+  terminalView.style.flexShrink = "0";
+
+  analyticsView.style.flexBasis = `${rightWidth}px`;
+  analyticsView.style.flexGrow = "0";
+  analyticsView.style.flexShrink = "0";
+}
+
+/**
+ * Handle mouse down on resize handle
+ */
+function handleMouseDown(e: MouseEvent): void {
+  const terminalView = document.getElementById("terminal-view");
+  const resizeHandle = document.getElementById("resize-handle");
+
+  if (!terminalView || !resizeHandle) return;
+
+  isDragging = true;
+  startX = e.clientX;
+  startLeftWidth = terminalView.getBoundingClientRect().width;
+
+  // Add dragging class for visual feedback
+  resizeHandle.classList.add("dragging");
+  terminalView.classList.add("resizing");
+  document.getElementById("analytics-view")?.classList.add("resizing");
+
+  // Prevent text selection during drag
+  document.body.style.cursor = "col-resize";
+  document.body.style.userSelect = "none";
+
+  e.preventDefault();
+}
+
+/**
+ * Handle mouse move during drag
+ */
+function handleMouseMove(e: MouseEvent): void {
+  if (!isDragging) return;
+
+  const mainContent = document.getElementById("main-content");
+  const terminalView = document.getElementById("terminal-view");
+  const analyticsView = document.getElementById("analytics-view");
+
+  if (!mainContent || !terminalView || !analyticsView) return;
+
+  const deltaX = e.clientX - startX;
+  const totalWidth = mainContent.clientWidth - 4; // Account for resize handle
+  let newLeftWidth = startLeftWidth + deltaX;
+
+  // Apply constraints
+  newLeftWidth = Math.max(MIN_WIDTH, Math.min(totalWidth - MIN_WIDTH, newLeftWidth));
+  const newRightWidth = totalWidth - newLeftWidth;
+
+  // Apply widths
+  terminalView.style.flexBasis = `${newLeftWidth}px`;
+  analyticsView.style.flexBasis = `${newRightWidth}px`;
+}
+
+/**
+ * Handle mouse up to end drag
+ */
+function handleMouseUp(): void {
+  if (!isDragging) return;
+
+  isDragging = false;
+
+  const mainContent = document.getElementById("main-content");
+  const terminalView = document.getElementById("terminal-view");
+  const resizeHandle = document.getElementById("resize-handle");
+  const analyticsView = document.getElementById("analytics-view");
+
+  // Remove dragging classes
+  resizeHandle?.classList.remove("dragging");
+  terminalView?.classList.remove("resizing");
+  analyticsView?.classList.remove("resizing");
+
+  // Restore cursor
+  document.body.style.cursor = "";
+  document.body.style.userSelect = "";
+
+  // Calculate and store the ratio
+  if (mainContent && terminalView) {
+    const totalWidth = mainContent.clientWidth - 4;
+    const leftWidth = terminalView.getBoundingClientRect().width;
+    const ratio = leftWidth / totalWidth;
+    storeRatio(ratio);
+  }
+}
+
+/**
+ * Handle window resize to maintain split ratio
+ */
+function handleWindowResize(): void {
+  if (isDragging) return;
+
+  const ratio = getStoredRatio();
+  applySplitRatio(ratio);
+}
+
+let initialized = false;
+
+/**
+ * Initialize the resize handle functionality.
+ * Should be called once when the app starts.
+ */
+export function initializeResizeHandle(): void {
+  if (initialized) return;
+  initialized = true;
+
+  const resizeHandle = document.getElementById("resize-handle");
+  if (!resizeHandle) return;
+
+  // Apply initial split ratio from storage
+  const storedRatio = getStoredRatio();
+  applySplitRatio(storedRatio);
+
+  // Add event listeners
+  resizeHandle.addEventListener("mousedown", handleMouseDown);
+  document.addEventListener("mousemove", handleMouseMove);
+  document.addEventListener("mouseup", handleMouseUp);
+
+  // Handle window resize
+  window.addEventListener("resize", handleWindowResize);
+}

--- a/src/lib/ui/index.ts
+++ b/src/lib/ui/index.ts
@@ -4,9 +4,19 @@
 export { renderHeader } from "./header";
 export { getStatusColor } from "./helpers";
 export { renderLoadingState } from "./loading";
-export { renderMiniTerminals } from "./terminal-grid";
 export {
   type HealthCheckTiming,
   renderMissingSessionError,
   renderPrimaryTerminal,
 } from "./terminal-primary";
+
+// Placeholder exports for Phase 5 implementation
+export function renderAnalyticsView(): void {
+  // Analytics dashboard implementation (Phase 5)
+  // For now, the placeholder HTML in index.html is sufficient
+}
+
+export function renderStatusBar(): void {
+  // Status bar implementation (Phase 5)
+  // For now, the placeholder HTML in index.html is sufficient
+}

--- a/src/lib/ui/loading.ts
+++ b/src/lib/ui/loading.ts
@@ -4,7 +4,7 @@ import { escapeHtml } from "./helpers";
  * Render loading state during factory reset
  */
 export function renderLoadingState(message: string = "Resetting workspace..."): void {
-  const container = document.getElementById("primary-terminal");
+  const container = document.getElementById("terminal-view");
   if (!container) return;
 
   container.innerHTML = `

--- a/src/lib/ui/terminal-primary.ts
+++ b/src/lib/ui/terminal-primary.ts
@@ -83,7 +83,7 @@ export function renderPrimaryTerminal(
   hasWorkspace: boolean,
   displayedWorkspacePath: string
 ): void {
-  const container = document.getElementById("primary-terminal");
+  const container = document.getElementById("terminal-view");
   if (!container) return;
 
   if (!terminal) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,7 @@ import {
 } from "./lib/keyboard-navigation";
 import { Logger } from "./lib/logger";
 import { getOutputPoller } from "./lib/output-poller";
+import { initializeResizeHandle } from "./lib/resize-handle";
 import { initializeScreenReaderAnnouncer } from "./lib/screen-reader-announcer";
 // Note: Recovery handlers removed - app now auto-recovers missing sessions
 import { AppState, setAppState, type Terminal, TerminalStatus } from "./lib/state";
@@ -46,12 +47,7 @@ import {
 import { getTerminalManager } from "./lib/terminal-manager";
 import { initTheme, toggleTheme } from "./lib/theme";
 import { showToast } from "./lib/toast";
-import {
-  renderHeader,
-  renderLoadingState,
-  renderMiniTerminals,
-  renderPrimaryTerminal,
-} from "./lib/ui";
+import { renderHeader, renderLoadingState, renderPrimaryTerminal } from "./lib/ui";
 import {
   attachWorkspaceEventListeners,
   setupMainEventListeners,
@@ -219,18 +215,6 @@ function render() {
     hasWorkspace,
     state.workspace.getDisplayedWorkspace()
   );
-
-  // Render mini terminals with health data
-  const terminalHealthMap = new Map(
-    Array.from(systemHealth.terminals.entries()).map(([id, health]) => [
-      id,
-      {
-        lastActivity: health.lastActivity,
-        isStale: health.isStale,
-      },
-    ])
-  );
-  renderMiniTerminals(state.terminals.getTerminals(), hasWorkspace, terminalHealthMap);
 
   // Re-attach workspace event listeners if they were just rendered
   if (!hasWorkspace) {
@@ -677,6 +661,9 @@ const browseWorkspaceWithCallback = () => browseWorkspace(handleWorkspacePathInp
       handleWorkspacePathInput,
       render,
     });
+
+    // Initialize resize handle for terminal/analytics split view
+    initializeResizeHandle();
 
     // Set up all event listeners (consolidated in ui-event-handlers.ts)
     setupMainEventListeners({

--- a/src/style.css
+++ b/src/style.css
@@ -33,9 +33,32 @@
   background-color: var(--color-gray-500);
 }
 
-/* Smooth scrolling */
-#mini-terminal-row > div {
-  scroll-behavior: smooth;
+/* Resize handle styles */
+#resize-handle {
+  touch-action: none;
+  user-select: none;
+}
+
+#resize-handle:hover,
+#resize-handle.dragging {
+  background-color: var(--color-blue-400);
+}
+
+.dark #resize-handle:hover,
+.dark #resize-handle.dragging {
+  background-color: var(--color-blue-500);
+}
+
+/* Split layout constraints */
+#terminal-view,
+#analytics-view {
+  min-width: 300px;
+  transition: flex-basis 0.05s ease-out;
+}
+
+#terminal-view.resizing,
+#analytics-view.resizing {
+  transition: none;
 }
 
 /* Instant background color change for terminal header */


### PR DESCRIPTION
## Summary

- Replace multi-terminal layout with side-by-side split view
- Terminal on left, analytics placeholder on right (50/50 default)
- Resizable divider with drag-to-resize functionality
- Split position persists across reloads via localStorage
- Simplified header (h-12) with theme toggle and workspace close
- Status bar placeholder at bottom

## Changes

| File | Change |
|------|--------|
| `index.html` | New HTML structure: `terminal-view` + `analytics-view` panels |
| `src/lib/resize-handle.ts` | New module for drag-to-resize behavior |
| `src/lib/ui/terminal-primary.ts` | Target `#terminal-view` instead of `#primary-terminal` |
| `src/lib/ui/loading.ts` | Target `#terminal-view` |
| `src/lib/ui/index.ts` | Remove `renderMiniTerminals`, add `renderAnalyticsView`/`renderStatusBar` placeholders |
| `src/lib/ui-event-handlers.ts` | Remove mini-terminal-row event handlers |
| `src/main.ts` | Remove `renderMiniTerminals` call, init resize handle |
| `src/style.css` | Resize handle and split layout styles |

## Test plan

- [ ] `pnpm dev` shows terminal on left, analytics placeholder on right
- [ ] Resize handle drags to adjust split ratio
- [ ] Split position persists across page reloads
- [ ] Status bar visible at bottom
- [ ] Header simplified (no multi-terminal buttons)
- [ ] Workspace selector still renders when no workspace loaded
- [ ] No TypeScript compilation errors (`pnpm tsc --noEmit`)
- [ ] All vitest tests pass

## Breaking Changes

HTML structure changed - JS that queries `#primary-terminal` or `#mini-terminal-row` needs updating in Phase 6.

Closes #1895

🤖 Generated with [Claude Code](https://claude.ai/claude-code)