### PR TITLE
Add exit code 5 for Doctor to signal pre-existing failures

### DIFF
--- a/defaults/.claude/commands/doctor.md
+++ b/defaults/.claude/commands/doctor.md
@@ -686,6 +686,40 @@ Keep it brief (3-6 words) and descriptive:
 - **Be honest**: If you're idle, say so
 - **Be brief**: Task description should be 3-6 words max
 
+## Pre-existing Failures
+
+When working on test failures during shepherd orchestration, you may discover that the failures are **pre-existing** — they existed before the builder's changes and are unrelated to the current issue. In this case, you should signal this explicitly rather than making no changes.
+
+### When to Signal Pre-existing Failures
+
+Signal pre-existing failures when ALL of these conditions are true:
+1. You've been asked to fix test failures (not PR review feedback)
+2. After analysis, you determine the failures are NOT caused by the builder's changes
+3. The failures would exist even if the builder's changes were reverted
+4. Fixing the failures is outside the scope of the current issue
+
+### How to Signal
+
+Use the special exit code **5** to explicitly communicate that failures are pre-existing:
+
+```bash
+# After determining failures are pre-existing, exit with code 5
+exit 5
+```
+
+### Benefits of Explicit Signaling
+
+- **Faster pipeline**: Shepherd immediately continues to PR creation
+- **Clear audit trail**: Logs show "Doctor determined failures are pre-existing (exit code 5)"
+- **Better observability**: Explicit signal vs. inferred from no commits
+- **Reduced ambiguity**: No guessing whether Doctor attempted a fix or decided not to
+
+### What NOT to Do
+
+- **Don't exit 5 if you made any commits** — the shepherd will verify and may fail
+- **Don't exit 5 for failures you could reasonably fix** — only for truly unrelated issues
+- **Don't exit 5 for PR review feedback** — this is only for test failure recovery
+
 ## Completion
 
 **Work completion is detected automatically.**

--- a/loom-tools/src/loom_tools/shepherd/phases/base.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/base.py
@@ -290,6 +290,7 @@ def run_worker_phase(
         - 0: Success
         - 3: Shutdown signal
         - 4: Agent stuck after retry
+        - 5: Failures are pre-existing (Doctor only)
         - Other: Error
     """
     scripts_dir = ctx.scripts_dir

--- a/loom-tools/src/loom_tools/shepherd/phases/doctor.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/doctor.py
@@ -71,6 +71,15 @@ class DoctorPhase:
                 phase_name="doctor",
             )
 
+        if exit_code == 5:
+            # Doctor explicitly signaled failures are pre-existing
+            return PhaseResult(
+                status=PhaseStatus.SKIPPED,
+                message="doctor determined failures are pre-existing",
+                phase_name="doctor",
+                data={"preexisting": True},
+            )
+
         # Validate phase
         if not self.validate(ctx):
             return PhaseResult(

--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -17,6 +17,7 @@ from loom_tools.shepherd.phases import (
     BasePhase,
     BuilderPhase,
     CuratorPhase,
+    DoctorPhase,
     JudgePhase,
     MergePhase,
     PhaseResult,
@@ -3922,3 +3923,60 @@ class TestBuilderShouldSkipDoctorRecovery:
                 mock_context, ["cargo", "test"]
             )
         assert result is False
+
+
+class TestDoctorPhaseExitCode5:
+    """Test Doctor phase handling of exit code 5 (pre-existing failures)."""
+
+    def test_exit_code_5_returns_skipped_with_preexisting_flag(
+        self, mock_context: MagicMock
+    ) -> None:
+        """Exit code 5 should return SKIPPED status with preexisting flag."""
+        doctor = DoctorPhase()
+        mock_context.pr_number = 123
+        mock_context.check_shutdown.return_value = False
+
+        with patch(
+            "loom_tools.shepherd.phases.doctor.run_phase_with_retry"
+        ) as mock_run:
+            mock_run.return_value = 5
+            result = doctor.run(mock_context)
+
+        assert result.status == PhaseStatus.SKIPPED
+        assert result.data.get("preexisting") is True
+        assert "pre-existing" in result.message.lower()
+
+    def test_exit_code_0_validates_and_returns_success(
+        self, mock_context: MagicMock
+    ) -> None:
+        """Exit code 0 should validate phase and return SUCCESS."""
+        doctor = DoctorPhase()
+        mock_context.pr_number = 123
+        mock_context.check_shutdown.return_value = False
+
+        with (
+            patch(
+                "loom_tools.shepherd.phases.doctor.run_phase_with_retry"
+            ) as mock_run,
+            patch.object(doctor, "validate") as mock_validate,
+        ):
+            mock_run.return_value = 0
+            mock_validate.return_value = True
+            result = doctor.run(mock_context)
+
+        assert result.status == PhaseStatus.SUCCESS
+
+    def test_exit_code_5_does_not_mark_blocked(self, mock_context: MagicMock) -> None:
+        """Exit code 5 should NOT mark issue as blocked (unlike exit code 4)."""
+        doctor = DoctorPhase()
+        mock_context.pr_number = 123
+        mock_context.check_shutdown.return_value = False
+
+        with patch(
+            "loom_tools.shepherd.phases.doctor.run_phase_with_retry"
+        ) as mock_run:
+            mock_run.return_value = 5
+            result = doctor.run(mock_context)
+
+        # Should not call _mark_issue_blocked
+        mock_context.label_cache.invalidate_issue.assert_not_called()


### PR DESCRIPTION
## Summary

- Add exit code 5 for Doctor agents to explicitly signal that test failures are pre-existing
- Update shepherd orchestration to handle exit code 5 in test failure recovery
- Document the new behavior in the Doctor role definition

## Changes

### Python Implementation
- **doctor.py**: Handle exit code 5, return SKIPPED status with `preexisting: True` data flag
- **cli.py**: Handle exit code 5 in test failure recovery flow - skip re-verification and continue to PR creation
- **base.py**: Document exit code 5 in the `run_worker_phase` docstring

### Documentation
- **doctor.md**: Add "Pre-existing Failures" section explaining when and how to use exit code 5

### Tests
- **test_phases.py**: Add 3 tests for exit code 5 handling:
  - `test_exit_code_5_returns_skipped_with_preexisting_flag`
  - `test_exit_code_0_validates_and_returns_success`
  - `test_exit_code_5_does_not_mark_blocked`

## Benefits

- **Explicit intent**: Doctor communicates its assessment directly rather than the shepherd guessing
- **Faster pipeline**: Shepherd immediately continues to PR creation without counting commits
- **Better observability**: Clear "Doctor determined failures are pre-existing (exit code 5)" in logs
- **Reduced ambiguity**: No guessing whether Doctor attempted a fix or decided not to

## Test plan

- [x] All existing shepherd tests pass (382 tests)
- [x] New exit code 5 tests pass (3 tests)
- [x] Code imports successfully
- [ ] Manual test: Run shepherd on issue with pre-existing test failures, Doctor exits with code 5

Closes #1948

🤖 Generated with [Claude Code](https://claude.com/claude-code)