### PR TITLE
Update test to exceed error-line tolerance threshold

### DIFF
--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -2248,7 +2248,11 @@ class TestBuilderFallbackComparison:
     def test_fallback_new_errors_detected(
         self, mock_context: MagicMock
     ) -> None:
-        """Fallback: new error lines in worktree -> FAILED."""
+        """Fallback: new error lines in worktree -> FAILED.
+
+        Uses 7 error lines in worktree vs 1 in baseline (diff=6) to exceed
+        the _ERROR_LINE_TOLERANCE of 5, ensuring new errors are detected.
+        """
         builder = BuilderPhase()
         worktree_mock = MagicMock()
         worktree_mock.is_dir.return_value = True
@@ -2257,10 +2261,12 @@ class TestBuilderFallbackComparison:
         baseline_result = subprocess.CompletedProcess(
             args=[], returncode=1, stdout="Error: old bug\n", stderr=""
         )
+        # 7 error lines total (1 original + 6 new) exceeds tolerance of 5
+        new_errors = "".join(f"Error: new regression {i}\n" for i in range(6))
         worktree_result = subprocess.CompletedProcess(
             args=[],
             returncode=1,
-            stdout="Error: old bug\nError: new regression\n",
+            stdout=f"Error: old bug\n{new_errors}",
             stderr="",
         )
         with (


### PR DESCRIPTION
## Summary
- Update `test_fallback_new_errors_detected` to use 6 new error lines instead of 1
- This ensures the test properly exceeds the `_ERROR_LINE_TOLERANCE = 5` threshold
- The test was failing because 1 new line was within the tolerance (≤5)

Closes #1983

## Test plan
- [x] Verify the specific test passes: `pytest tests/shepherd/test_phases.py::TestBuilderFallbackComparison::test_fallback_new_errors_detected -v`
- [x] Run full CI suite: `pnpm check:ci:lite`

🤖 Generated with [Claude Code](https://claude.com/claude-code)