### PR TITLE
Require Curator to add test plan and file refs before marking curated

### DIFF
--- a/defaults/.claude/commands/curator.md
+++ b/defaults/.claude/commands/curator.md
@@ -332,9 +332,14 @@ $CURRENT
 ### Implementation Guidance
 [Technical approach, options, or recommendations]
 
+### Affected Files
+- \`path/to/file.ts\` - [what changes are needed]
+- \`path/to/other.py\` - [what changes are needed]
+
 ### Test Plan
-- [ ] Test case 1
-- [ ] Test case 2
+- [ ] Manual verification: [describe how to verify the fix/feature works]
+- [ ] Automated tests: [list test files to add/modify, or \"N/A\"]
+- [ ] Edge cases: [any special scenarios to verify]
 "
 
 # 3. Update issue body
@@ -418,10 +423,83 @@ Before marking an issue as `loom:curated`, ensure it has:
 - ✅ Links to related issues/PRs/docs/code
 - ✅ For bugs: reproduction steps and expected behavior
 - ✅ For features: user stories and use cases
-- ✅ Test plan checklist
+- ✅ **Test Plan section** (see Required Sections below)
+- ✅ **Affected Files section** (see Required Sections below)
 - ✅ **Dependencies verified**: All task list items checked (or no Dependencies section)
 - ✅ Priority label (`loom:urgent` if critical, otherwise none)
 - ✅ Labeled as `loom:curated` when complete (NOT `loom:issue` - human approval required)
+
+### Required Sections
+
+**CRITICAL**: Curator must ADD these sections if missing. The Builder quality check validates their presence.
+
+#### Test Plan Section
+
+Every curated issue MUST have a `## Test Plan` section with verification steps:
+
+```markdown
+## Test Plan
+
+- [ ] Manual verification: [describe how to verify the fix/feature works]
+- [ ] Automated tests: [list test files to add/modify, or "N/A" if no code tests needed]
+- [ ] Edge cases: [any special scenarios to verify]
+```
+
+**Why this matters**: Builder quality validation looks for `## Test Plan` heading. Without it, Builders receive warnings and may miss important verification steps.
+
+#### Affected Files Section
+
+Every curated issue MUST have an `## Affected Files` section listing files/components to modify:
+
+```markdown
+## Affected Files
+
+- `path/to/file.ts` - [what changes are needed]
+- `path/to/another.py` - [what changes are needed]
+```
+
+**How to find affected files**:
+1. Use `grep` or `rg` to search for relevant code patterns
+2. Check related issues/PRs for file references
+3. Explore the codebase structure to identify components
+4. If truly unknown: "To be determined during implementation" (but try to provide guidance)
+
+**Why this matters**: Builder quality validation looks for file path references. Without them, Builders must do additional exploration and may miss relevant code.
+
+#### How to Add Missing Sections
+
+When enhancing an issue, check for these sections. If missing, ADD them:
+
+```bash
+# 1. Read current issue
+gh issue view 100 --comments
+
+# 2. Research codebase for affected files
+rg "relevant_pattern" --type py --files-with-matches
+rg "function_name" --type ts -l
+
+# 3. Add enhancement with required sections
+gh issue comment 100 --body "$(cat <<'EOF'
+## Implementation Guidance
+
+[Your technical analysis...]
+
+## Affected Files
+
+- `src/module/file.ts` - Add new validation logic
+- `tests/module/file.test.ts` - Add test cases for validation
+
+## Test Plan
+
+- [ ] Manual verification: Run the feature and verify [expected behavior]
+- [ ] Automated tests: Add tests in `tests/module/file.test.ts`
+- [ ] Integration test: Verify end-to-end flow works correctly
+EOF
+)"
+
+# 4. Mark as curated
+gh issue edit 100 --remove-label "loom:curating" --add-label "loom:curated"
+```
 
 ## Working Style
 
@@ -521,6 +599,41 @@ Start with **Option 1** for v0.3.0 (quick win), then add **Option 2** in v0.4.0 
 - #92: Database schema design (required for option 3)
 - Similar feature in Warp terminal: [link]
 ---
+```
+
+### Missing Test Plan & File Refs → Complete Enhancement
+```markdown
+Issue: "Fix terminal output truncation bug"
+
+Original (missing key sections):
+- Has problem description: "Output gets cut off"
+- Has acceptance criteria checkboxes
+- Missing: Test Plan, Affected Files
+
+Added enhancement:
+---
+## Implementation Guidance
+
+The issue is in the output buffer management. When the buffer exceeds
+MAX_LINES, the truncation logic has an off-by-one error.
+
+## Affected Files
+
+- `src/terminal/buffer.ts` - Fix truncation boundary calculation in `trimBuffer()`
+- `src/terminal/buffer.test.ts` - Add test for boundary condition
+- `src/constants.ts` - MAX_LINES constant definition (reference only)
+
+## Test Plan
+
+- [ ] Manual verification: Generate output exceeding MAX_LINES, verify last line is complete
+- [ ] Automated tests: Add test case in `buffer.test.ts` for exact boundary
+- [ ] Edge cases: Test with MAX_LINES-1, MAX_LINES, MAX_LINES+1 line counts
+---
+
+Why this pattern matters:
+- Builder knows exactly which files to modify
+- Test plan provides clear verification steps
+- Builder quality validation passes without warnings
 ```
 
 ## Advanced Curation


### PR DESCRIPTION
## Summary

- Updates Curator role to require Test Plan and Affected Files sections before marking issues as `loom:curated`
- Adds comprehensive guidance on how to add these sections when missing
- Provides templates and examples for Curators to follow
- Ensures Builder quality validation passes without warnings for curated issues

## Changes

1. **Issue Quality Checklist** (lines 426-430): Updated to explicitly require Test Plan and Affected Files sections
2. **New "Required Sections" subsection** (lines 432-502): Comprehensive guidance including:
   - Test Plan section template and rationale
   - Affected Files section template and guidance on finding files
   - Step-by-step workflow for adding missing sections
3. **Amendment template** (lines 335-342): Updated to include Affected Files and Test Plan sections
4. **New curation pattern** (lines 604-637): Example showing how to enhance an issue missing test plan and file refs

## Acceptance Criteria Verification

| Criterion | Verification |
|-----------|--------------|
| Curator adds test plan section if missing | ✅ Required Sections subsection (line 436-448) requires and provides template for Test Plan |
| Curator adds file references section if identifiable | ✅ Required Sections subsection (line 450-467) requires Affected Files with guidance on finding files |
| Builder quality check passes without warnings for curated issues | ✅ Templates match the regex patterns in `issue_quality.py`: `## Test Plan` heading and file path references like `path/to/file.ts` |

## Test Plan

- [ ] Manual verification: Run `/curator <issue-number>` on an issue missing test plan/file refs, verify Curator adds them
- [ ] Integration test: Process an issue through full Shepherd pipeline, verify Builder quality check passes without warnings

Closes #2002

🤖 Generated with [Claude Code](https://claude.com/claude-code)