### PR TITLE
Fix Judge phase header showing wrong attempt counter

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/cli.py
+++ b/loom-tools/src/loom_tools/shepherd/cli.py
@@ -571,7 +571,7 @@ def orchestrate(ctx: ShepherdContext) -> int:
         doctor_total_elapsed = 0
 
         while not pr_approved and doctor_attempts < ctx.config.doctor_max_retries:
-            _print_phase_header(f"PHASE 4: JUDGE (attempt {doctor_attempts + 1})")
+            _print_phase_header(f"PHASE 4: JUDGE (attempt {judge_retries + 1})")
 
             phase_start = time.time()
             result = judge.run(ctx)


### PR DESCRIPTION
## Summary

- Fix bug where Judge phase header showed `doctor_attempts + 1` instead of `judge_retries + 1`
- Add test to verify Judge phase header shows correct retry count on retries

Closes #2008

## Test plan

- [x] New test `test_judge_header_shows_correct_retry_count` verifies fix
- [x] All 51 CLI tests pass
- [x] Code review confirms change from `doctor_attempts` to `judge_retries` on line 574

🤖 Generated with [Claude Code](https://claude.com/claude-code)