### PR TITLE
Add explicit Rust formatting guidance to Builder documentation

### DIFF
--- a/defaults/.claude/commands/builder-pr.md
+++ b/defaults/.claude/commands/builder-pr.md
@@ -278,9 +278,38 @@ Closes #123
 | Shellcheck fixes | `shellcheck <file>` or `find ... -exec shellcheck {} \;` |
 | TypeScript errors | `pnpm tsc --noEmit` |
 | Lint issues | `pnpm lint` or scoped `biome check <file>` |
+| Rust formatting | `cargo fmt --all -- --check` (see Language-Specific section below) |
 | Test passes | `pnpm test -- <pattern>` |
 | File exists/content | `cat <file>` or `grep <pattern> <file>` |
 | Config changes | Read file and verify expected content |
+
+### Language-Specific Verification
+
+**Rust Code Changes**
+
+If you modified any `.rs` files, run these checks **before committing**:
+
+```bash
+# Format all Rust files (applies formatting)
+cargo fmt
+
+# Verify formatting (check only, no changes - returns non-zero if unformatted)
+cargo fmt --all -- --check
+```
+
+**Why format before commit (not just rely on CI)?**
+
+1. **Defense in depth** - Pre-commit hooks can fail silently in worktrees or with PATH issues
+2. **Early feedback** - Catch formatting issues immediately instead of after CI failure
+3. **Save a Doctor cycle** - `pnpm check:ci` includes format verification; catching it early avoids a fix cycle
+
+**Add to your pre-PR checklist when modifying Rust:**
+
+```markdown
+Local verification:
+- [ ] `pnpm check:ci` passes
+- [ ] `cargo fmt --all -- --check` returns 0 (Rust files only)
+```
 
 ### Red Flags: Don't Create PR Yet
 


### PR DESCRIPTION
## Summary

Add explicit guidance for Rust formatting verification to the Builder role documentation. This helps catch Rust formatting issues early rather than during CI, avoiding unnecessary Doctor fix cycles when pre-commit hooks fail silently in worktree contexts.

## Changes

- Add "Rust formatting" row to the Common Verification Commands table in `builder-pr.md`
- Add new "Language-Specific Verification" section with detailed Rust formatting guidance
- Include `cargo fmt` and `cargo fmt --all -- --check` commands
- Explain why early formatting verification is beneficial (defense in depth, early feedback, save Doctor cycle)
- Provide checklist item template for Rust file modifications

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Add Rust formatting to Pre-PR Verification section | ✅ | Added to Common Verification Commands table and new Language-Specific section |
| Documentation is clear and actionable | ✅ | Includes specific commands and rationale |
| Guidance doesn't conflict with existing `pnpm check:ci` instructions | ✅ | Complements existing guidance, explains relationship |

## Test Plan

- [x] Manual verification: Documentation updates are clear and actionable
- [x] Manual verification: New section integrates well with existing builder-pr.md structure
- [x] Edge case: Guidance complements (not conflicts with) existing `pnpm check:ci` instructions

Closes #1977