### PR TITLE
Fix stale worktree detection for abandoned worktrees at same commit as main

### DIFF
--- a/defaults/scripts/worktree.sh
+++ b/defaults/scripts/worktree.sh
@@ -517,6 +517,63 @@ if [[ -d "$WORKTREE_PATH" ]]; then
                 echo ""
             fi
             # Fall through to create fresh worktree below
+        elif [[ "$local_commits_ahead" == "0" && "$local_commits_behind" == "0" && -z "$local_uncommitted" ]]; then
+            # Worktree at same commit as main, no commits, no uncommitted changes
+            # Check if remote branch exists - if not, this is an abandoned worktree
+            if ! git ls-remote --heads origin "$BRANCH_NAME" 2>/dev/null | grep -q .; then
+                # No commits + no remote = abandoned worktree, safe to clean
+                if ! is_worktree_safe_to_remove "$WORKTREE_PATH"; then
+                    # Safety check failed - reuse the worktree instead of removing
+                    if [[ "$JSON_OUTPUT" != "true" ]]; then
+                        print_info "Worktree appears abandoned but cannot be safely removed - reusing"
+                        echo ""
+                        print_info "To use this worktree: cd $WORKTREE_PATH"
+                    fi
+                    exit 0
+                fi
+
+                if [[ "$JSON_OUTPUT" != "true" ]]; then
+                    print_warning "Abandoned worktree detected (0 commits, at same commit as main, no remote branch)"
+                    print_info "Removing abandoned worktree and recreating from current main..."
+                fi
+
+                # Remove the abandoned worktree (safety checks passed)
+                ABS_WORKTREE="$(cd "$WORKTREE_PATH" 2>/dev/null && pwd -P || echo "$WORKTREE_PATH")"
+                REPO_DIR="$(pwd -P)"
+                local_branch=$(git -C "$ABS_WORKTREE" rev-parse --abbrev-ref HEAD 2>/dev/null) || local_branch=""
+                git -C "$REPO_DIR" worktree remove "$ABS_WORKTREE" --force 2>/dev/null || {
+                    print_error "Failed to remove abandoned worktree"
+                    exit 1
+                }
+
+                # Delete the empty branch if it exists
+                if [[ -n "$local_branch" && "$local_branch" != "main" ]]; then
+                    if git branch -d "$local_branch" 2>/dev/null; then
+                        if [[ "$JSON_OUTPUT" != "true" ]]; then
+                            print_info "Removed empty branch: $local_branch"
+                        fi
+                    else
+                        if [[ "$JSON_OUTPUT" != "true" ]]; then
+                            print_warning "Could not delete branch $local_branch (may have upstream references)"
+                        fi
+                    fi
+                fi
+
+                if [[ "$JSON_OUTPUT" != "true" ]]; then
+                    print_success "Abandoned worktree cleaned up"
+                    echo ""
+                fi
+                # Fall through to create fresh worktree below
+            else
+                # Remote branch exists - preserve worktree
+                if [[ "$JSON_OUTPUT" != "true" ]]; then
+                    print_info "Worktree is registered with git"
+                    print_info "Remote branch exists - preserving worktree"
+                    echo ""
+                    print_info "To use this worktree: cd $WORKTREE_PATH"
+                fi
+                exit 0
+            fi
         else
             if [[ "$JSON_OUTPUT" != "true" ]]; then
                 print_info "Worktree is registered with git"


### PR DESCRIPTION
## Summary

- Adds detection for abandoned worktrees that are at the same commit as main (not behind)
- These worktrees have: 0 commits ahead, 0 commits behind, no uncommitted changes, no remote branch
- Such worktrees are safely cleaned up and recreated fresh from current main

## Acceptance Criteria Verification

| Criterion | Verification |
|-----------|-------------|
| Stale worktree with 0 commits ahead, 0 commits behind, no remote branch is detected | ✅ New `elif` condition at line 520 checks these exact conditions |
| Stale worktree is cleaned up automatically | ✅ Same cleanup logic as existing stale detection (lines 540-565) |
| Warning message logged before cleanup | ✅ `print_warning "Abandoned worktree detected..."` at line 536 |
| Branch is deleted if it exists locally | ✅ Branch deletion logic at lines 550-559 |

## Test Plan

- [ ] **Manual verification**: Create worktree, don't push/commit, re-run worktree script
  1. Create worktree: `./.loom/scripts/worktree.sh 9999`
  2. Verify worktree exists: `ls .loom/worktrees/issue-9999`
  3. Re-run script: `./.loom/scripts/worktree.sh 9999`
  4. Should detect stale and recreate (verify warning message)
- [ ] **Negative test**: Worktree with commits ahead should NOT be cleaned
  1. Create worktree, make a commit
  2. Re-run script - should preserve worktree
- [ ] **Negative test**: Worktree with remote branch should NOT be cleaned
  1. Create worktree, push branch (even without commits)
  2. Re-run script - should preserve worktree

Closes #1955

🤖 Generated with [Claude Code](https://claude.com/claude-code)