### PR TITLE
Issue #2026: Remove remaining AGENTS.md references

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,7 @@ your-repo/
 │   └── scripts/         # Helper scripts
 ├── .claude/commands/    # Slash commands
 ├── .github/labels.yml   # Workflow labels
-├── CLAUDE.md            # AI context document
-└── AGENTS.md            # Agent coordination guide
+└── CLAUDE.md            # AI context document
 ```
 
 ## Usage

--- a/defaults/.loom/CLAUDE.md
+++ b/defaults/.loom/CLAUDE.md
@@ -514,7 +514,6 @@ which claude
 - **Main Repository**: https://github.com/rjwalters/loom
 - **Getting Started**: https://github.com/rjwalters/loom#getting-started
 - **Role Definitions**: See `.loom/roles/*.md` in this repository
-- **Workflow Details**: See `.loom/AGENTS.md` in this repository
 
 ### Local Configuration
 

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -1546,7 +1546,6 @@ Or run the setup script to generate `.mcp.json` automatically:
 - **Main Repository**: https://github.com/rjwalters/loom
 - **Getting Started**: https://github.com/rjwalters/loom#getting-started
 - **Role Definitions**: See `.loom/roles/*.md` in this repository
-- **Workflow Details**: See `.loom/AGENTS.md` in this repository
 
 ### Local Configuration
 

--- a/defaults/README.md
+++ b/defaults/README.md
@@ -7,7 +7,6 @@ This directory contains default configuration files and templates for Loom works
 - `config.json` - Default configuration for new workspaces
 - `roles/` - System prompt templates for different terminal roles
 - `CLAUDE.md` - AI development context template (copied to workspace root)
-- `AGENTS.md` - Repository guidelines template (copied to workspace root)
 - `.claude/` - Claude Code configuration template (copied to workspace root)
 - `.codex/` - Codex configuration template (copied to workspace root)
 - `.github/` - GitHub workflow and issue templates (copied to workspace root)
@@ -42,7 +41,6 @@ loom-daemon init --defaults /path/to/custom-defaults /path/to/repo
 2. Copies this entire `defaults/` directory to `.loom/`
 3. Copies scaffolding files to workspace root:
    - `CLAUDE.md` - AI development context
-   - `AGENTS.md` - Agent workflow guide
    - `.claude/` - Claude Code configuration
    - `.github/` - GitHub labels and workflows
 4. Updates `.gitignore` with Loom ephemeral patterns
@@ -79,7 +77,6 @@ loom-daemon init --defaults /path/to/my-org-loom-defaults /path/to/project
 ### Repository Scaffolding
 During workspace initialization, Loom automatically copies scaffolding files to the workspace root **if they don't already exist**:
 - `CLAUDE.md` → `<workspace>/CLAUDE.md`
-- `AGENTS.md` → `<workspace>/AGENTS.md`
 - `.claude/` → `<workspace>/.claude/`
 - `.codex/` → `<workspace>/.codex/`
 - `.github/` → `<workspace>/.github/`

--- a/defaults/scripts/verify-install.sh
+++ b/defaults/scripts/verify-install.sh
@@ -103,7 +103,7 @@ ${BOLD}TRACKED FILE LOCATIONS:${NC}
     .github/labels.yml             Label definitions
     .github/ISSUE_TEMPLATE/*       Issue templates
     .github/workflows/*.yml        GitHub workflows
-    CLAUDE.md, .loom/AGENTS.md     Top-level docs
+    CLAUDE.md                       Top-level docs
     .loom/CLAUDE.md, .loom/README.md
     .codex/config.toml             Codex configuration
     loom                           CLI wrapper
@@ -189,9 +189,6 @@ collect_tracked_files() {
     # Top-level docs
     if [[ -f "$root/CLAUDE.md" ]]; then
         files+=("CLAUDE.md")
-    fi
-    if [[ -f "$root/.loom/AGENTS.md" ]]; then
-        files+=(".loom/AGENTS.md")
     fi
     if [[ -f "$root/.loom/CLAUDE.md" ]]; then
         files+=(".loom/CLAUDE.md")

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -42,7 +42,7 @@ loom-daemon init [OPTIONS] [PATH]
 Initializes a Loom workspace by:
 1. Validating the target is a git repository
 2. Copying `.loom/` configuration from defaults
-3. Installing repository scaffolding (CLAUDE.md, AGENTS.md, .claude/, .github/)
+3. Installing repository scaffolding (CLAUDE.md, .claude/, .github/)
 4. Updating `.gitignore` with Loom ephemeral patterns
 
 **Examples:**

--- a/docs/guides/ci-cd-setup.md
+++ b/docs/guides/ci-cd-setup.md
@@ -109,7 +109,7 @@ jobs:
         run: |
           git config user.name "Loom Bot"
           git config user.email "loom-bot@your-org.com"
-          git add .loom CLAUDE.md AGENTS.md .claude .gitignore
+          git add .loom CLAUDE.md .claude .gitignore
           git diff --staged --quiet || git commit -m "chore: update Loom configuration"
           git push
 ```
@@ -269,7 +269,6 @@ setup-loom:
     paths:
       - .loom/
       - CLAUDE.md
-      - AGENTS.md
       - .claude/
     expire_in: 1 week
 
@@ -324,7 +323,7 @@ sync-loom-config:
     # Commit if changes detected
     - git config user.name "Loom Sync Bot"
     - git config user.email "loom-bot@your-org.com"
-    - git add .loom CLAUDE.md AGENTS.md .claude .gitignore
+    - git add .loom CLAUDE.md .claude .gitignore
     - git diff --staged --quiet || (git commit -m "chore: sync Loom config" && git push)
 ```
 
@@ -471,7 +470,6 @@ jobs:
           paths:
             - .loom
             - CLAUDE.md
-            - AGENTS.md
 
 workflows:
   main:
@@ -827,7 +825,6 @@ loom-defaults/
 ├── README.md
 ├── config.json
 ├── CLAUDE.md
-├── AGENTS.md
 ├── roles/
 ├── .claude/
 └── .github/

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -45,7 +45,6 @@ The `init` subcommand sets up a Loom workspace by:
 2. **Copying** `.loom/` configuration from defaults
 3. **Installing** repository scaffolding:
    - `CLAUDE.md` - AI context documentation
-   - `AGENTS.md` - Agent workflow guide
    - `.claude/` - Claude Code configuration
    - `.codex/` - Codex configuration (if available)
    - `.github/` - GitHub workflow templates and labels
@@ -153,7 +152,6 @@ The defaults directory must contain:
 defaults/
 ├── config.json           # Default config template
 ├── CLAUDE.md             # AI context template
-├── AGENTS.md             # Agent workflow template
 ├── .loom-README.md       # .loom/ directory documentation
 ├── roles/                # Role definitions
 │   ├── architect.md

--- a/docs/guides/common-tasks.md
+++ b/docs/guides/common-tasks.md
@@ -18,7 +18,6 @@ loom-daemon init
 - `.loom/config.json` - Terminal configurations and role assignments
 - `.loom/roles/` - Default role definitions (builder.md, judge.md, etc.)
 - `CLAUDE.md` - AI context documentation for the repository
-- `AGENTS.md` - Agent workflow and coordination guide
 - `.claude/` - Claude Code slash commands
 - `.github/labels.yml` - GitHub label definitions
 - `.gitignore` updates - Ephemeral pattern additions
@@ -171,7 +170,7 @@ loom-daemon init
 loom-daemon init --force
 
 # Option 3: Manual cleanup
-rm -rf .loom CLAUDE.md AGENTS.md .claude
+rm -rf .loom CLAUDE.md .claude
 loom-daemon init
 ```
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -32,7 +32,6 @@ Running `loom-daemon init` creates these files in your repository:
 
 **Documentation (Commit these)**:
 - `CLAUDE.md` - AI context document for Claude Code (11KB template)
-- `AGENTS.md` - Workflow coordination guide for agents
 
 **Tooling (Commit these)**:
 - `.claude/commands/` - Claude Code slash commands for each role
@@ -346,13 +345,11 @@ After installing Loom (via GUI or CLI), you'll find the following files in your 
 
 ```
 CLAUDE.md             # Technical context for Claude Code agents
-AGENTS.md             # Agent workflow and coordination guide
 ```
 
 **What to do:**
 1. Review `CLAUDE.md` to understand the codebase structure and patterns
-2. Read `AGENTS.md` to learn about agent roles and workflows
-3. Update `CLAUDE.md` with project-specific context as you build
+2. Update `CLAUDE.md` with project-specific context as you build
 
 ### Claude Code Configuration
 
@@ -396,7 +393,6 @@ Loom automatically updates `.gitignore` with ephemeral patterns:
 - ✅ `.loom/config.json` - Share terminal roles across team
 - ✅ `.loom/roles/` - Custom role definitions
 - ✅ `CLAUDE.md` - AI context documentation
-- ✅ `AGENTS.md` - Agent workflow guide
 - ✅ `.claude/` - Slash commands and config
 - ✅ `.github/` - Labels and workflows
 

--- a/scripts/install/create-pr.sh
+++ b/scripts/install/create-pr.sh
@@ -92,7 +92,7 @@ Adds Loom configuration and GitHub workflow integration:
 - .claude/commands/ slash commands for roles (/builder, /judge, etc.)
 - .claude/settings.json tool permissions
 - .github/ labels and workflows
-- Documentation (CLAUDE.md, AGENTS.md)
+- Documentation (CLAUDE.md)
 
 Loom Version: ${LOOM_VERSION}
 Loom Commit: ${LOOM_COMMIT}
@@ -146,7 +146,7 @@ Adds Loom configuration and GitHub workflow integration:
 - .loom/ directory with configuration and scripts
 - .claude/ MCP servers and prompts
 - .github/ labels (workflows skipped - requires 'workflow' scope)
-- Documentation (CLAUDE.md, AGENTS.md)
+- Documentation (CLAUDE.md)
 
 Note: GitHub workflow files were skipped due to missing 'workflow' scope.
 To add workflows later, run: gh auth refresh -s workflow
@@ -214,7 +214,7 @@ This PR adds Loom orchestration framework to the repository.
 - ✅ \`.claude/commands/\` - Slash commands for roles (/builder, /judge, /curator, etc.)
 - ✅ \`.claude/settings.json\` - Claude Code tool permissions
 - ✅ \`.github/\` - Labels and workflows
-- ✅ \`CLAUDE.md\`/\`AGENTS.md\` - Documentation with Loom reference
+- ✅ \`CLAUDE.md\` - Documentation with Loom reference
 
 ## GitHub Labels
 

--- a/scripts/uninstall-loom.sh
+++ b/scripts/uninstall-loom.sh
@@ -891,7 +891,7 @@ Removes Loom configuration, roles, scripts, and tooling:
 - .claude/ slash commands and agent definitions
 - .codex/ configuration
 - .github/ Loom-specific labels and workflows
-- CLAUDE.md and AGENTS.md documentation
+- CLAUDE.md documentation
 - .gitignore Loom patterns
 - Runtime artifacts (state files, logs)"
 

--- a/src/lib/workspace-lifecycle.ts
+++ b/src/lib/workspace-lifecycle.ts
@@ -69,7 +69,7 @@ async function expandAndValidatePath(
 /**
  * Ensure repository scaffolding is set up
  *
- * Creates CLAUDE.md, .claude/, .codex/, AGENTS.md if needed
+ * Creates CLAUDE.md, .claude/, .codex/ if needed
  *
  * @param workspacePath - Path to workspace
  */


### PR DESCRIPTION
## Summary

Follow-up to #2024 which deleted AGENTS.md files but left references in documentation and scripts.

## Changes

- Remove AGENTS.md references from `docs/guides/*.md` files
- Update `defaults/README.md` to not mention AGENTS.md
- Update `defaults/CLAUDE.md` and `defaults/.loom/CLAUDE.md` Resources sections
- Update `defaults/scripts/verify-install.sh` to not check for AGENTS.md
- Update `scripts/install/create-pr.sh` and `scripts/uninstall-loom.sh`
- Update `src/lib/workspace-lifecycle.ts`

Closes #2026

## Test Plan

- [ ] Build passes (`pnpm check:ci:lite`)
- [ ] Grep for remaining AGENTS.md references returns only build artifacts

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)