### PR TITLE
Strip ANSI escape sequences from builder logs for readability

### DIFF
--- a/loom-tools/tests/test_agent_spawn.py
+++ b/loom-tools/tests/test_agent_spawn.py
@@ -352,3 +352,139 @@ class TestRunValidation:
     ) -> None:
         config = SpawnConfig(role="builder", name="test")
         assert run(config) == 1
+
+
+class TestAnsiStripping:
+    """Tests for ANSI escape sequence stripping in log output."""
+
+    def test_ansi_strip_regex_removes_color_codes(self) -> None:
+        """Test that the sed regex removes standard ANSI color codes."""
+        import re
+
+        # The regex pattern used in pipe-pane (Python escaped version)
+        pattern = r"\x1b\[[?0-9;]*[a-zA-Z]"
+
+        test_cases = [
+            # Standard color codes
+            ("\x1b[0m", ""),  # Reset
+            ("\x1b[31m", ""),  # Red foreground
+            ("\x1b[1;32m", ""),  # Bold green
+            ("\x1b[38;2;226;141;109m", ""),  # 24-bit color (RGB)
+            # Cursor movement
+            ("\x1b[2C", ""),  # Move cursor right
+            ("\x1b[6A", ""),  # Move cursor up
+            # Terminal mode queries (like ?2026h/l)
+            ("\x1b[?2026h", ""),  # Private mode set
+            ("\x1b[?2026l", ""),  # Private mode reset
+            # Text with escape sequences
+            ("\x1b[31mError\x1b[0m", "Error"),  # Red "Error"
+            ("Normal \x1b[1mBold\x1b[0m text", "Normal Bold text"),
+            ("\x1b[?2026l\x1b[?2026h\n\x1b[2C\x1b[6A\x1b[38;2;226;141;109mComposing…\x1b[39m",
+             "\nComposing…"),
+        ]
+
+        for input_str, expected in test_cases:
+            result = re.sub(pattern, "", input_str)
+            assert result == expected, f"Failed for {repr(input_str)}: got {repr(result)}"
+
+    def test_ansi_strip_regex_removes_osc_sequences(self) -> None:
+        """Test that the sed regex removes OSC (Operating System Command) sequences."""
+        import re
+
+        # OSC sequence pattern (title setting, etc.)
+        pattern = r"\x1b\][^\x07]*\x07"
+
+        test_cases = [
+            # Title setting sequence: ESC ] 0 ; title BEL
+            ("\x1b]0;Terminal Title\x07", ""),
+            # Icon name: ESC ] 1 ; name BEL
+            ("\x1b]1;icon\x07", ""),
+            # Window title: ESC ] 2 ; title BEL
+            ("\x1b]2;Window\x07", ""),
+            # With surrounding text
+            ("Before\x1b]0;title\x07After", "BeforeAfter"),
+        ]
+
+        for input_str, expected in test_cases:
+            result = re.sub(pattern, "", input_str)
+            assert result == expected, f"Failed for {repr(input_str)}: got {repr(result)}"
+
+    def test_combined_ansi_stripping(self) -> None:
+        """Test both ANSI and OSC patterns together as used in spawn_agent."""
+        import re
+
+        # Combined pattern matching what's in agent_spawn.py
+        ansi_pattern = r"\x1b\[[?0-9;]*[a-zA-Z]"
+        osc_pattern = r"\x1b\][^\x07]*\x07"
+
+        def strip_ansi(text: str) -> str:
+            text = re.sub(ansi_pattern, "", text)
+            text = re.sub(osc_pattern, "", text)
+            return text
+
+        # Real-world example from the issue diagnostic
+        sample_output = (
+            "\x1b[?2026l\x1b[?2026h\n"
+            "\x1b[2C\x1b[6A\x1b[38;2;226;141;109mComposing…\x1b[39m\n"
+            "\x1b[?2026l\n"
+        )
+        # After stripping: the first line has escape codes then newline,
+        # second line has escape codes then "Composing…" then newline,
+        # third line has escape code then newline
+        expected = "\nComposing…\n\n"
+        assert strip_ansi(sample_output) == expected
+
+        # Another example with colors and OSC
+        colored_with_title = (
+            "\x1b]0;claude\x07"  # Set window title
+            "\x1b[1;32m✓\x1b[0m Task complete\n"  # Green checkmark
+            "\x1b[31mError:\x1b[0m Something went wrong\n"  # Red error
+        )
+        expected = "✓ Task complete\nError: Something went wrong\n"
+        assert strip_ansi(colored_with_title) == expected
+
+    @patch("loom_tools.agent_spawn._tmux")
+    def test_spawn_agent_uses_sed_filter(self, mock_tmux: MagicMock) -> None:
+        """Test that spawn_agent sets up pipe-pane with sed ANSI stripping."""
+        from loom_tools.agent_spawn import spawn_agent
+
+        mock_tmux.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=""
+        )
+
+        # Create a mock repo with required structure
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            (tmp_path / ".git").mkdir()
+            (tmp_path / ".loom" / "logs").mkdir(parents=True)
+            (tmp_path / ".loom" / "roles").mkdir(parents=True)
+            (tmp_path / ".loom" / "roles" / "builder.md").write_text("# Builder")
+
+            # Call spawn_agent (it will fail at verification, but we just need
+            # to check the pipe-pane call)
+            spawn_agent(
+                role="builder",
+                name="test-agent",
+                args="",
+                worktree="",
+                repo_root=tmp_path,
+                verify_timeout=0,  # Skip verification
+            )
+
+            # Find the pipe-pane call
+            pipe_pane_calls = [
+                call for call in mock_tmux.call_args_list
+                if call[0] and call[0][0] == "pipe-pane"
+            ]
+
+            assert len(pipe_pane_calls) >= 1, "pipe-pane should be called"
+
+            # Check the pipe-pane command includes sed with ANSI stripping
+            pipe_pane_call = pipe_pane_calls[0]
+            pipe_cmd = pipe_pane_call[0][3] if len(pipe_pane_call[0]) > 3 else ""
+
+            assert "sed" in pipe_cmd, f"pipe-pane should use sed, got: {pipe_cmd}"
+            assert "\\x1b" in pipe_cmd, f"sed command should strip ANSI sequences: {pipe_cmd}"
+            assert ">>" in pipe_cmd, f"sed command should append to log file: {pipe_cmd}"


### PR DESCRIPTION
## Summary

- Modifies `agent_spawn.py` pipe-pane command to use sed for filtering ANSI escape sequences
- Improves log readability by removing color codes, cursor movements, and terminal mode queries
- Adds comprehensive tests for ANSI stripping regex patterns

## Changes

1. **loom-tools/src/loom_tools/agent_spawn.py** - Replaces `cat >> log` with `sed -E '...' >> log` to strip:
   - Standard ANSI sequences (colors, cursor movement)
   - Terminal mode queries (ESC[?...h/l)
   - OSC sequences (title setting)

2. **loom-tools/tests/test_agent_spawn.py** - Adds `TestAnsiStripping` class with tests for:
   - Color code stripping
   - OSC sequence stripping
   - Combined real-world examples
   - Verification that spawn_agent uses the sed filter

## Test plan

- [x] Unit tests verify regex patterns strip ANSI sequences correctly
- [x] Integration test confirms spawn_agent uses sed filter in pipe-pane
- [x] All 44 agent_spawn tests pass
- [ ] Manual verification with a running builder to confirm readable logs

## Criterion Verification

| Criterion | Verified |
|-----------|----------|
| Logs should be human-readable | ✅ ANSI sequences stripped |
| Regex handles standard ANSI (ESC[...m) | ✅ Tested |
| Regex handles terminal modes (ESC[?...h/l) | ✅ Tested |
| Regex handles OSC sequences (ESC]...BEL) | ✅ Tested |
| Tests added for ANSI stripping | ✅ 4 new tests |

Closes #2001

🤖 Generated with [Claude Code](https://claude.com/claude-code)