### PR TITLE
Increase shepherd timeouts to prevent premature agent termination

### DIFF
--- a/defaults/scripts/agent-wait-bg.sh
+++ b/defaults/scripts/agent-wait-bg.sh
@@ -90,8 +90,9 @@ CONTRACT_INTERVAL_OVERRIDE=${LOOM_CONTRACT_INTERVAL_OVERRIDE:-0}
 CONTRACT_INITIAL_DELAY=180
 
 # Stuck detection thresholds (configurable via environment variables)
-STUCK_WARNING_THRESHOLD=${LOOM_STUCK_WARNING:-300}   # 5 min default
-STUCK_CRITICAL_THRESHOLD=${LOOM_STUCK_CRITICAL:-600} # 10 min default
+# Note: Set high to avoid killing agents mid-work (see issue #2001)
+STUCK_WARNING_THRESHOLD=${LOOM_STUCK_WARNING:-3600}   # 1 hour default
+STUCK_CRITICAL_THRESHOLD=${LOOM_STUCK_CRITICAL:-7200} # 2 hour default
 STUCK_ACTION=${LOOM_STUCK_ACTION:-warn}              # warn, pause, restart, retry
 
 # "Stuck at prompt" detection - command visible but not processing

--- a/loom-tools/src/loom_tools/shepherd/config.py
+++ b/loom-tools/src/loom_tools/shepherd/config.py
@@ -140,17 +140,18 @@ class ShepherdConfig:
     stop_after: str | None = None  # "curated", "pr", "approved"
 
     # Timeouts (seconds) - loaded from environment or defaults
+    # Note: Timeouts set high to avoid killing agents mid-work (see issue #2001)
     curator_timeout: int = field(
-        default_factory=lambda: env_int("LOOM_CURATOR_TIMEOUT", 300)
+        default_factory=lambda: env_int("LOOM_CURATOR_TIMEOUT", 3600)
     )
     builder_timeout: int = field(
-        default_factory=lambda: env_int("LOOM_BUILDER_TIMEOUT", 3600)
+        default_factory=lambda: env_int("LOOM_BUILDER_TIMEOUT", 14400)
     )
     judge_timeout: int = field(
-        default_factory=lambda: env_int("LOOM_JUDGE_TIMEOUT", 600)
+        default_factory=lambda: env_int("LOOM_JUDGE_TIMEOUT", 3600)
     )
     doctor_timeout: int = field(
-        default_factory=lambda: env_int("LOOM_DOCTOR_TIMEOUT", 900)
+        default_factory=lambda: env_int("LOOM_DOCTOR_TIMEOUT", 3600)
     )
     poll_interval: int = field(
         default_factory=lambda: env_int("LOOM_POLL_INTERVAL", 5)

--- a/loom-tools/tests/shepherd/test_config.py
+++ b/loom-tools/tests/shepherd/test_config.py
@@ -161,10 +161,11 @@ class TestShepherdConfig:
     def test_default_timeouts(self) -> None:
         """Default timeouts should be set from environment or defaults."""
         config = ShepherdConfig(issue=42)
-        assert config.curator_timeout == 300
-        assert config.builder_timeout == 3600
-        assert config.judge_timeout == 600
-        assert config.doctor_timeout == 900
+        # Note: Timeouts set high to avoid killing agents mid-work (see issue #2001)
+        assert config.curator_timeout == 3600
+        assert config.builder_timeout == 14400
+        assert config.judge_timeout == 3600
+        assert config.doctor_timeout == 3600
         assert config.poll_interval == 5
 
     def test_default_retry_limits(self) -> None:


### PR DESCRIPTION
## Summary

- Increased all shepherd phase timeouts significantly to prevent agents from being killed mid-work
- Increased stuck detection thresholds to match

## Problem

The shepherd was killing agents mid-work because the timeout and stuck detection thresholds were too aggressive. This was observed when the judge phase was terminated while still running tests (see issue #2001 investigation).

## Changes

| Setting | Old Value | New Value |
|---------|-----------|-----------|
| `curator_timeout` | 300s (5 min) | 3600s (1 hour) |
| `builder_timeout` | 3600s (1 hour) | 14400s (4 hours) |
| `judge_timeout` | 600s (10 min) | 3600s (1 hour) |
| `doctor_timeout` | 900s (15 min) | 3600s (1 hour) |
| `STUCK_WARNING_THRESHOLD` | 300s (5 min) | 3600s (1 hour) |
| `STUCK_CRITICAL_THRESHOLD` | 600s (10 min) | 7200s (2 hours) |

Environment variables still allow overriding these defaults if needed.

## Test plan

- [x] All shepherd tests pass
- [x] Full CI lite check passes (except pre-existing unrelated failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)