### PR TITLE
Add builder completion retry phase for incomplete work

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/config.py
+++ b/loom-tools/src/loom_tools/shepherd/config.py
@@ -166,6 +166,9 @@ class ShepherdConfig:
     stuck_max_retries: int = field(
         default_factory=lambda: env_int("LOOM_STUCK_MAX_RETRIES", 1)
     )
+    builder_completion_retries: int = field(
+        default_factory=lambda: env_int("LOOM_BUILDER_COMPLETION_RETRIES", 1)
+    )
 
     # Rate limiting
     rate_limit_threshold: int = field(


### PR DESCRIPTION
## Summary

- Adds retry logic when builder exits before completing commit/push/PR workflow
- Detects incomplete work patterns (uncommitted changes, unpushed commits, missing PR)
- Spawns focused "completion phase" with explicit instructions to finish the workflow
- Configurable via `LOOM_BUILDER_COMPLETION_RETRIES` env var (default: 1)

## Test plan

- [x] All 480 shepherd tests pass
- [ ] Manual test: Create issue, run `/shepherd <issue> -m`, verify completion retry triggers when builder leaves incomplete work

🤖 Generated with [Claude Code](https://claude.com/claude-code)