### PR TITLE
Document worktree deletion dangers to prevent shell corruption

### DIFF
--- a/.loom/docs/troubleshooting.md
+++ b/.loom/docs/troubleshooting.md
@@ -35,12 +35,18 @@ loom-clean --deep --dry-run  # Preview deep clean
 loom-clean --force  # Non-interactive, safe for automation
 ```
 
-**Manual cleanup** (if needed):
+**Manual cleanup** (if needed, but use with caution):
+
+**WARNING**: Running `git worktree remove` while your shell is in the worktree directory will corrupt your shell state. Always ensure you've navigated out of the worktree first, or use `loom-clean` which handles this safely.
+
 ```bash
+# First, ensure you're NOT in the worktree you're removing
+cd /path/to/main/repo
+
 # List worktrees
 git worktree list
 
-# Remove specific stale worktree
+# Remove specific stale worktree (only after navigating out!)
 git worktree remove .loom/worktrees/issue-42 --force
 
 # Prune orphaned worktrees

--- a/defaults/.claude/commands/builder-worktree.md
+++ b/defaults/.claude/commands/builder-worktree.md
@@ -54,8 +54,8 @@ gh pr create --label "loom:review-requested"
 # 6. Return to main workspace
 cd ../..  # Back to workspace root
 
-# 7. Clean up worktree (optional - done automatically on terminal destroy)
-git worktree remove .loom/worktrees/issue-84
+# 7. Worktree cleanup is automatic - DO NOT manually delete worktrees
+# Worktrees are cleaned up automatically when PRs merge or by loom-clean
 ```
 
 ### Collision Detection
@@ -147,6 +147,12 @@ cd .loom/worktrees/issue-XX
 - Easier to reimplement than untangle
 
 ### Never Do This
+
+**Don't delete worktrees manually with `git worktree remove`**
+- Running `git worktree remove` while your shell is in the worktree corrupts shell state
+- Even `pwd` will fail with "No such file or directory" errors
+- Use `loom-clean` for safe cleanup (handles edge cases)
+- Worktrees auto-cleanup when PRs merge
 
 **Don't switch to the main repository directory to work on features**
 - Always work in worktrees for isolation

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -461,9 +461,19 @@ gh pr create --label "loom:review-requested"
 
 - **Always use the helper script**: `./.loom/scripts/worktree.sh <issue-number>`
 - **Never run git worktree directly**: The helper prevents nested worktrees
+- **Never delete worktrees manually**: Use `loom-clean` for cleanup (see warning below)
 - **One worktree per issue**: Keeps work isolated and organized
 - **Semantic naming**: Worktrees named `.loom/worktrees/issue-{number}`
 - **Clean up when done**: Worktrees are automatically removed when PRs are merged
+
+**WARNING: Never delete worktrees directly with `git worktree remove`**
+
+Running `git worktree remove` while your shell is in or referencing the worktree directory will corrupt your shell state. Even basic commands like `pwd` will fail with "No such file or directory" errors.
+
+If you need to clean up worktrees:
+1. Use `loom-clean` or `loom-clean --force` (handles edge cases safely)
+2. For stuck shepherds, use `./.loom/scripts/recover-orphaned-shepherds.sh`
+3. Let worktrees auto-cleanup when PRs merge
 
 ### Worktree Helper Commands
 
@@ -1019,12 +1029,18 @@ loom-clean --deep --dry-run  # Preview deep clean
 loom-clean --force  # Non-interactive, safe for automation
 ```
 
-**Manual cleanup** (if needed):
+**Manual cleanup** (if needed, but use with caution):
+
+**WARNING**: Running `git worktree remove` while your shell is in the worktree directory will corrupt your shell state. Always ensure you've navigated out of the worktree first, or use `loom-clean` which handles this safely.
+
 ```bash
+# First, ensure you're NOT in the worktree you're removing
+cd /path/to/main/repo
+
 # List worktrees
 git worktree list
 
-# Remove specific stale worktree
+# Remove specific stale worktree (only after navigating out!)
 git worktree remove .loom/worktrees/issue-42 --force
 
 # Prune orphaned worktrees

--- a/docs/guides/quickstart-tutorial.md
+++ b/docs/guides/quickstart-tutorial.md
@@ -381,13 +381,18 @@ gh auth login
 
 **Solution:**
 ```bash
-# Remove old worktree
+# IMPORTANT: First navigate OUT of any worktree directory
+cd /path/to/main/repo
+
+# Remove old worktree (only from main repo, not from inside a worktree!)
 git worktree remove .loom/worktrees/issue-42 --force
 git worktree prune
 
 # Try again
 ./.loom/scripts/worktree.sh 42
 ```
+
+**Note**: Running `git worktree remove` while your shell is in the worktree will corrupt your shell state. Always navigate out first!
 
 ### Issue: "Permission denied" when creating issues/PRs
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -33,6 +33,7 @@ This guide helps you diagnose and fix common issues in Loom.
 3. **Cleanup and retry:**
    ```bash
    # Clean up any partial installation
+   # IMPORTANT: Run from the target-repo root, NOT from inside a worktree
    cd /path/to/target-repo
    git worktree list  # Find orphaned worktrees
    git worktree remove .loom/worktrees/issue-XXX --force
@@ -143,14 +144,19 @@ This guide helps you diagnose and fix common issues in Loom.
 
 **Symptom:** `pnpm worktree <issue>` fails with errors
 
+**WARNING**: Running `git worktree remove` while your shell is in the worktree directory will corrupt your shell state. Always navigate out of the worktree first!
+
 **Common errors and solutions:**
 
 1. **"fatal: 'path' already exists"**
    ```bash
+   # First navigate OUT of the worktree
+   cd /path/to/loom
+
    # Check if worktree exists
    git worktree list
 
-   # Remove if orphaned
+   # Remove if orphaned (only from main repo directory!)
    git worktree remove .loom/worktrees/issue-<number> --force
 
    # Or if that fails


### PR DESCRIPTION
## Summary

- Add explicit warnings in CLAUDE.md and role documentation about never deleting worktrees manually
- Document that agents must use `.loom/scripts/loom-clean.sh` instead of `git worktree remove`
- Add warnings to troubleshooting guides and builder worktree documentation
- Explain the shell corruption issue that occurs when deleting the current working directory

## Test plan

- [x] Documentation changes only - review for clarity and completeness
- [x] Verify warnings appear in all relevant files (CLAUDE.md, troubleshooting.md, builder-worktree.md)

Closes #2036

🤖 Generated with [Claude Code](https://claude.com/claude-code)