### PR TITLE
Fix completion phase shell command parsing broken by newlines

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -1293,10 +1293,14 @@ class BuilderPhase:
         log_info(f"Instructions:\n{instruction_text}")
 
         # Use a special completion prompt as args
+        # IMPORTANT: Args must be single-line because they're passed through tmux send-keys.
+        # Newlines break shell command parsing (causes "dquote>" prompts).
+        # Join instructions with semicolons instead of newlines.
+        instruction_oneline = "; ".join(instructions)
         completion_args = (
             f"COMPLETION_MODE: Your previous session ended before completing the workflow. "
             f"You are in worktree .loom/worktrees/issue-{ctx.config.issue} with changes ready. "
-            f"Complete these steps:\n{instruction_text}\n"
+            f"Complete these steps: {instruction_oneline}. "
             f"Do NOT implement anything new - just complete the git/PR workflow."
         )
 


### PR DESCRIPTION
## Summary

- Fix builder completion retry mechanism breaking due to newlines in shell command
- Multi-line instructions were causing `dquote>` prompts in tmux send-keys
- Join instructions with semicolons instead of newlines to keep command on single line

## Problem

The builder completion retry mechanism (#2040) passes instructions like:
```
- Stage and commit all changes
- Create PR with loom:review-requested label
- Verify PR was created
```

When passed through tmux send-keys, the newlines cause the shell to interpret this as multiple lines, resulting in:
```
dquote> - Stage and commit all changes
dquote> - Create PR with loom:review-requested label...
```

The shell waits indefinitely for a closing quote, causing the completion phase to fail.

## Solution

Join instructions with semicolons instead of newlines:
```python
instruction_oneline = "; ".join(instructions)
completion_args = f"Complete these steps: {instruction_oneline}. Do NOT implement..."
```

## Test plan

- [x] Verified Python syntax compiles correctly
- [x] Manual review of the fix
- [ ] Test with a shepherd run where builder leaves incomplete work

🤖 Generated with [Claude Code](https://claude.com/claude-code)