### PR TITLE
Fix test path for relocated loom CLI wrapper

### DIFF
--- a/loom-tools/tests/test_installation_verification.py
+++ b/loom-tools/tests/test_installation_verification.py
@@ -203,7 +203,7 @@ class TestWrapperScriptRouting:
         self, defaults_dir: pathlib.Path
     ) -> None:
         """The 'loom' CLI wrapper should route health to Python."""
-        cli_wrapper = defaults_dir / "loom"
+        cli_wrapper = defaults_dir / ".loom" / "bin" / "loom"
         assert cli_wrapper.exists(), "loom CLI wrapper not found"
 
         content = cli_wrapper.read_text()


### PR DESCRIPTION
## Summary

- Update `test_cli_wrapper_health_routes_to_python` test path from `defaults/loom` to `defaults/.loom/bin/loom`

The loom CLI wrapper was moved to the new location in commit 1cfe8ae (#2032) but the test was not updated.

## Acceptance Criteria Verification

| Criterion | Verification |
|-----------|--------------|
| Manual verification: `pnpm check:ci:lite` passes without "loom CLI wrapper not found" error | ✅ Test passes: `pytest loom-tools/tests/test_installation_verification.py::TestWrapperScriptRouting::test_cli_wrapper_health_routes_to_python -v` |
| Automated tests: The test itself validates the fix | ✅ Test passes (was failing before fix) |
| Regression: Other tests in `TestWrapperScriptRouting` class still pass | ✅ All 5 tests in class pass |

## Test Plan

```bash
python3 -m pytest loom-tools/tests/test_installation_verification.py::TestWrapperScriptRouting -v
# All 5 tests pass
```

Closes #2049

🤖 Generated with [Claude Code](https://claude.com/claude-code)