### PR TITLE
Add atomic label state transitions to prevent inconsistent states

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -10,7 +10,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-from loom_tools.common.git import get_changed_files, get_commit_count
+from loom_tools.common.git import get_changed_files
 from loom_tools.common.logging import log_error, log_info, log_success, log_warning
 from loom_tools.common.paths import LoomPaths, NamingConventions
 from loom_tools.common.state import parse_command_output, read_json_file
@@ -19,13 +19,11 @@ from loom_tools.shepherd.config import Phase
 from loom_tools.shepherd.context import ShepherdContext
 from loom_tools.shepherd.issue_quality import (
     Severity,
-    validate_issue_quality,
     validate_issue_quality_with_gates,
 )
 from loom_tools.shepherd.labels import (
-    add_issue_label,
     get_pr_for_issue,
-    remove_issue_label,
+    transition_issue_labels,
 )
 from loom_tools.shepherd.phases.base import (
     PhaseResult,
@@ -102,10 +100,14 @@ class BuilderPhase:
             ctx.pr_number = pr
             # Report milestone
             ctx.report_milestone("pr_created", pr_number=pr)
-            # Ensure issue has loom:building label
+            # Ensure issue has loom:building label (atomic transition)
             if not ctx.has_issue_label("loom:building"):
-                remove_issue_label(ctx.config.issue, "loom:issue", ctx.repo_root)
-                add_issue_label(ctx.config.issue, "loom:building", ctx.repo_root)
+                transition_issue_labels(
+                    ctx.config.issue,
+                    add=["loom:building"],
+                    remove=["loom:issue"],
+                    repo_root=ctx.repo_root,
+                )
                 ctx.label_cache.invalidate_issue(ctx.config.issue)
             # Create marker if worktree exists
             if ctx.worktree_path and ctx.worktree_path.is_dir():
@@ -136,17 +138,25 @@ class BuilderPhase:
         # Report phase entry
         ctx.report_milestone("phase_entered", phase="builder")
 
-        # Claim the issue
-        remove_issue_label(ctx.config.issue, "loom:issue", ctx.repo_root)
-        add_issue_label(ctx.config.issue, "loom:building", ctx.repo_root)
+        # Claim the issue (atomic transition: loom:issue -> loom:building)
+        transition_issue_labels(
+            ctx.config.issue,
+            add=["loom:building"],
+            remove=["loom:issue"],
+            repo_root=ctx.repo_root,
+        )
         ctx.label_cache.invalidate_issue(ctx.config.issue)
 
         # Pre-flight issue quality validation (may block with configured gates)
         quality_result = self._run_quality_validation(ctx)
         if quality_result is not None:
-            # Quality validation blocked - revert claim
-            remove_issue_label(ctx.config.issue, "loom:building", ctx.repo_root)
-            add_issue_label(ctx.config.issue, "loom:issue", ctx.repo_root)
+            # Quality validation blocked - revert claim (atomic transition)
+            transition_issue_labels(
+                ctx.config.issue,
+                add=["loom:issue"],
+                remove=["loom:building"],
+                repo_root=ctx.repo_root,
+            )
             ctx.label_cache.invalidate_issue(ctx.config.issue)
             return quality_result
 
@@ -188,9 +198,13 @@ class BuilderPhase:
         )
 
         if exit_code == 3:
-            # Revert claim on shutdown
-            remove_issue_label(ctx.config.issue, "loom:building", ctx.repo_root)
-            add_issue_label(ctx.config.issue, "loom:issue", ctx.repo_root)
+            # Revert claim on shutdown (atomic transition)
+            transition_issue_labels(
+                ctx.config.issue,
+                add=["loom:issue"],
+                remove=["loom:building"],
+                repo_root=ctx.repo_root,
+            )
             ctx.label_cache.invalidate_issue(ctx.config.issue)
             return PhaseResult(
                 status=PhaseStatus.SHUTDOWN,
@@ -1220,7 +1234,7 @@ class BuilderPhase:
                 "comment",
                 str(ctx.config.issue),
                 "--body",
-                f"**Shepherd blocked**: Builder agent was stuck and did not recover after retry. Diagnostics saved to `.loom/diagnostics/`.",
+                "**Shepherd blocked**: Builder agent was stuck and did not recover after retry. Diagnostics saved to `.loom/diagnostics/`.",
             ],
             cwd=ctx.repo_root,
             capture_output=True,
@@ -1394,9 +1408,13 @@ class BuilderPhase:
         # Clean up the worktree
         self._cleanup_stale_worktree(ctx)
 
-        # Revert issue label so it can be picked up again
-        remove_issue_label(ctx.config.issue, "loom:building", ctx.repo_root)
-        add_issue_label(ctx.config.issue, "loom:issue", ctx.repo_root)
+        # Revert issue label so it can be picked up again (atomic transition)
+        transition_issue_labels(
+            ctx.config.issue,
+            add=["loom:issue"],
+            remove=["loom:building"],
+            repo_root=ctx.repo_root,
+        )
         ctx.label_cache.invalidate_issue(ctx.config.issue)
 
         log_info(f"Cleaned up worktree and reverted labels for issue #{ctx.config.issue}")
@@ -1444,9 +1462,13 @@ class BuilderPhase:
         # Push whatever commits exist to remote
         self._push_branch(ctx)
 
-        # Transition label: loom:building -> loom:needs-fix
-        remove_issue_label(ctx.config.issue, "loom:building", ctx.repo_root)
-        add_issue_label(ctx.config.issue, "loom:needs-fix", ctx.repo_root)
+        # Transition label: loom:building -> loom:needs-fix (atomic)
+        transition_issue_labels(
+            ctx.config.issue,
+            add=["loom:needs-fix"],
+            remove=["loom:building"],
+            repo_root=ctx.repo_root,
+        )
         ctx.label_cache.invalidate_issue(ctx.config.issue)
 
         # Write test failure context file for Doctor phase

--- a/loom-tools/tests/shepherd/test_labels.py
+++ b/loom-tools/tests/shepherd/test_labels.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-import pytest
-
-from loom_tools.shepherd.labels import LabelCache
+from loom_tools.shepherd.labels import (
+    LabelCache,
+    transition_labels,
+    transition_issue_labels,
+    transition_pr_labels,
+)
 
 
 class TestLabelCache:
@@ -196,3 +199,163 @@ class TestGenericLabelOperations:
         assert cache.get_labels("pr", 42) == {"pr_label"}
         assert ("issue", 42) in cache._labels
         assert ("pr", 42) in cache._labels
+
+
+class TestAtomicLabelTransitions:
+    """Tests for atomic label transition functions."""
+
+    def test_transition_labels_add_and_remove(self) -> None:
+        """transition_labels should use single gh command with both flags."""
+        with patch("loom_tools.shepherd.labels.subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            result = transition_labels(
+                "issue",
+                42,
+                add=["loom:building"],
+                remove=["loom:issue"],
+            )
+
+            assert result is True
+            mock_run.assert_called_once()
+            call_args = mock_run.call_args[0][0]
+            assert call_args == [
+                "gh", "issue", "edit", "42",
+                "--remove-label", "loom:issue",
+                "--add-label", "loom:building",
+            ]
+
+    def test_transition_labels_add_only(self) -> None:
+        """transition_labels should work with only add."""
+        with patch("loom_tools.shepherd.labels.subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            result = transition_labels("issue", 42, add=["loom:building"])
+
+            assert result is True
+            call_args = mock_run.call_args[0][0]
+            assert "--add-label" in call_args
+            assert "loom:building" in call_args
+            assert "--remove-label" not in call_args
+
+    def test_transition_labels_remove_only(self) -> None:
+        """transition_labels should work with only remove."""
+        with patch("loom_tools.shepherd.labels.subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            result = transition_labels("issue", 42, remove=["loom:issue"])
+
+            assert result is True
+            call_args = mock_run.call_args[0][0]
+            assert "--remove-label" in call_args
+            assert "loom:issue" in call_args
+            assert "--add-label" not in call_args
+
+    def test_transition_labels_noop(self) -> None:
+        """transition_labels should return True with no changes."""
+        with patch("loom_tools.shepherd.labels.subprocess.run") as mock_run:
+            result = transition_labels("issue", 42)
+
+            assert result is True
+            mock_run.assert_not_called()
+
+    def test_transition_labels_failure(self) -> None:
+        """transition_labels should return False on failure."""
+        with patch("loom_tools.shepherd.labels.subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 1
+            result = transition_labels(
+                "issue",
+                42,
+                add=["loom:building"],
+                remove=["loom:issue"],
+            )
+
+            assert result is False
+
+    def test_transition_labels_multiple_add_remove(self) -> None:
+        """transition_labels should handle multiple labels."""
+        with patch("loom_tools.shepherd.labels.subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            result = transition_labels(
+                "issue",
+                42,
+                add=["loom:building", "loom:wip"],
+                remove=["loom:issue", "loom:curated"],
+            )
+
+            assert result is True
+            call_args = mock_run.call_args[0][0]
+            # Check all labels are present
+            assert call_args.count("--add-label") == 2
+            assert call_args.count("--remove-label") == 2
+            assert "loom:building" in call_args
+            assert "loom:wip" in call_args
+            assert "loom:issue" in call_args
+            assert "loom:curated" in call_args
+
+    def test_transition_labels_pr(self) -> None:
+        """transition_labels should work for PRs."""
+        with patch("loom_tools.shepherd.labels.subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            result = transition_labels(
+                "pr",
+                100,
+                add=["loom:pr"],
+                remove=["loom:review-requested"],
+            )
+
+            assert result is True
+            call_args = mock_run.call_args[0][0]
+            assert call_args[:4] == ["gh", "pr", "edit", "100"]
+
+    def test_transition_issue_labels_convenience(self) -> None:
+        """transition_issue_labels should delegate to transition_labels."""
+        with patch("loom_tools.shepherd.labels.transition_labels") as mock:
+            mock.return_value = True
+            result = transition_issue_labels(
+                42,
+                add=["loom:building"],
+                remove=["loom:issue"],
+                repo_root=Path("/repo"),
+            )
+
+            assert result is True
+            mock.assert_called_once_with(
+                "issue",
+                42,
+                add=["loom:building"],
+                remove=["loom:issue"],
+                repo_root=Path("/repo"),
+            )
+
+    def test_transition_pr_labels_convenience(self) -> None:
+        """transition_pr_labels should delegate to transition_labels."""
+        with patch("loom_tools.shepherd.labels.transition_labels") as mock:
+            mock.return_value = True
+            result = transition_pr_labels(
+                100,
+                add=["loom:pr"],
+                remove=["loom:review-requested"],
+                repo_root=Path("/repo"),
+            )
+
+            assert result is True
+            mock.assert_called_once_with(
+                "pr",
+                100,
+                add=["loom:pr"],
+                remove=["loom:review-requested"],
+                repo_root=Path("/repo"),
+            )
+
+    def test_transition_labels_with_repo_root(self) -> None:
+        """transition_labels should pass repo_root to subprocess."""
+        with patch("loom_tools.shepherd.labels.subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            repo_root = Path("/fake/repo")
+            transition_labels(
+                "issue",
+                42,
+                add=["loom:building"],
+                repo_root=repo_root,
+            )
+
+            mock_run.assert_called_once()
+            assert mock_run.call_args[1]["cwd"] == repo_root

--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -279,8 +279,7 @@ class TestBuilderPhase:
             patch(
                 "loom_tools.shepherd.phases.builder.get_pr_for_issue", return_value=None
             ),
-            patch("loom_tools.shepherd.phases.builder.remove_issue_label"),
-            patch("loom_tools.shepherd.phases.builder.add_issue_label"),
+            patch("loom_tools.shepherd.phases.builder.transition_issue_labels"),
         ):
             result = builder.run(mock_context)
 
@@ -310,8 +309,7 @@ class TestBuilderPhase:
             patch(
                 "loom_tools.shepherd.phases.builder.get_pr_for_issue", return_value=None
             ),
-            patch("loom_tools.shepherd.phases.builder.remove_issue_label"),
-            patch("loom_tools.shepherd.phases.builder.add_issue_label"),
+            patch("loom_tools.shepherd.phases.builder.transition_issue_labels"),
         ):
             result = builder.run(mock_context)
 
@@ -338,8 +336,7 @@ class TestBuilderPhase:
                 "loom_tools.shepherd.phases.builder.get_pr_for_issue",
                 side_effect=[None, None, None],
             ),
-            patch("loom_tools.shepherd.phases.builder.remove_issue_label"),
-            patch("loom_tools.shepherd.phases.builder.add_issue_label"),
+            patch("loom_tools.shepherd.phases.builder.transition_issue_labels"),
             patch(
                 "loom_tools.shepherd.phases.builder.run_phase_with_retry",
                 return_value=0,
@@ -375,8 +372,7 @@ class TestBuilderPhase:
             patch(
                 "loom_tools.shepherd.phases.builder.get_pr_for_issue", return_value=None
             ),
-            patch("loom_tools.shepherd.phases.builder.remove_issue_label"),
-            patch("loom_tools.shepherd.phases.builder.add_issue_label"),
+            patch("loom_tools.shepherd.phases.builder.transition_issue_labels"),
             patch(
                 "loom_tools.shepherd.phases.builder.run_phase_with_retry",
                 return_value=0,
@@ -413,8 +409,7 @@ class TestBuilderPhase:
             patch(
                 "loom_tools.shepherd.phases.builder.get_pr_for_issue", return_value=None
             ),
-            patch("loom_tools.shepherd.phases.builder.remove_issue_label"),
-            patch("loom_tools.shepherd.phases.builder.add_issue_label"),
+            patch("loom_tools.shepherd.phases.builder.transition_issue_labels"),
             patch(
                 "loom_tools.shepherd.phases.builder.run_phase_with_retry",
                 return_value=1,
@@ -443,8 +438,7 @@ class TestBuilderPhase:
             patch(
                 "loom_tools.shepherd.phases.builder.get_pr_for_issue", return_value=None
             ),
-            patch("loom_tools.shepherd.phases.builder.remove_issue_label"),
-            patch("loom_tools.shepherd.phases.builder.add_issue_label"),
+            patch("loom_tools.shepherd.phases.builder.transition_issue_labels"),
             patch(
                 "loom_tools.shepherd.phases.builder.run_phase_with_retry",
                 return_value=4,
@@ -1382,8 +1376,7 @@ class TestBuilderRunTestFailureIntegration:
                 "loom_tools.shepherd.phases.builder.run_phase_with_retry",
                 return_value=0,
             ),
-            patch("loom_tools.shepherd.phases.builder.remove_issue_label"),
-            patch("loom_tools.shepherd.phases.builder.add_issue_label"),
+            patch("loom_tools.shepherd.phases.builder.transition_issue_labels"),
             patch("loom_tools.shepherd.phases.builder.get_pr_for_issue", return_value=None),
         ):
             result = builder.run(mock_context)
@@ -1421,8 +1414,7 @@ class TestBuilderRunTestFailureIntegration:
                 "loom_tools.shepherd.phases.builder.run_phase_with_retry",
                 return_value=0,
             ),
-            patch("loom_tools.shepherd.phases.builder.remove_issue_label"),
-            patch("loom_tools.shepherd.phases.builder.add_issue_label"),
+            patch("loom_tools.shepherd.phases.builder.transition_issue_labels"),
             # Return None first (no existing PR), then 123 (PR created by validate)
             patch(
                 "loom_tools.shepherd.phases.builder.get_pr_for_issue",
@@ -1476,8 +1468,8 @@ class TestBuilderPreserveOnTestFailure:
         comment_calls = [c for c in calls if "comment" in str(c)]
         assert len(comment_calls) >= 1
 
-        # Should have called remove_issue_label and add_issue_label via labels module
-        # (Those are patched separately in the mock_context)
+        # Should have called transition_issue_labels via labels module
+        # (Patched separately in the mock_context)
 
         # Report milestone should be called with blocked reason
         mock_context.report_milestone.assert_called()
@@ -1508,10 +1500,7 @@ class TestBuilderPreserveOnTestFailure:
                 ),
             ),
             patch(
-                "loom_tools.shepherd.phases.builder.remove_issue_label",
-            ),
-            patch(
-                "loom_tools.shepherd.phases.builder.add_issue_label",
+                "loom_tools.shepherd.phases.builder.transition_issue_labels",
             ),
         ):
             builder._preserve_on_test_failure(mock_context, test_result)
@@ -1612,8 +1601,7 @@ class TestBuilderTestFailureContext:
                     args=[], returncode=0, stdout="", stderr=""
                 ),
             ),
-            patch("loom_tools.shepherd.phases.builder.remove_issue_label"),
-            patch("loom_tools.shepherd.phases.builder.add_issue_label"),
+            patch("loom_tools.shepherd.phases.builder.transition_issue_labels"),
         ):
             builder._preserve_on_test_failure(ctx, test_result)
 
@@ -1737,8 +1725,7 @@ class TestBuilderTestFailureContext:
                     args=[], returncode=0, stdout="", stderr=""
                 ),
             ),
-            patch("loom_tools.shepherd.phases.builder.remove_issue_label"),
-            patch("loom_tools.shepherd.phases.builder.add_issue_label"),
+            patch("loom_tools.shepherd.phases.builder.transition_issue_labels"),
         ):
             # Should not raise even with worktree_path=None
             builder._preserve_on_test_failure(ctx, test_result)


### PR DESCRIPTION
## Summary

- Adds `transition_labels()`, `transition_issue_labels()`, and `transition_pr_labels()` functions to `labels.py` that perform add + remove in a single `gh` CLI command
- Replaces all sequential `remove_issue_label()`/`add_issue_label()` calls in `builder.py` with atomic `transition_issue_labels()` calls
- Adds comprehensive tests for the new atomic transition functions

Closes #2048

## Test plan

- [x] All 1758 existing tests pass (1 skipped)
- [x] 10 new tests for `transition_labels`, `transition_issue_labels`, `transition_pr_labels` covering: add+remove, add-only, remove-only, noop, failure, multiple labels, PR support, repo_root passthrough
- [x] Ruff lint passes on all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)