### PR TITLE
Add name-based test comparison to reduce false positive regressions

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -627,7 +627,20 @@ class BuilderPhase:
                 # Worktree has same or fewer failures — pre-existing
                 return None
 
-            # Worktree has more failures — new regressions
+            # Stage 1.5: Refine with test name comparison
+            # When worktree has more failures, check if they're genuinely new
+            # tests or just flaky count discrepancies
+            baseline_names = self._extract_failing_test_names(baseline_output)
+            worktree_names = self._extract_failing_test_names(worktree_output)
+            if baseline_names and worktree_names:
+                new_failures = worktree_names - baseline_names
+                if not new_failures:
+                    # Same tests failing — count discrepancy is noise
+                    return None
+                # Genuinely new test failures detected
+                return True
+
+            # Name extraction failed for at least one side — trust counts
             return True
 
         # If only one side parsed, we can't do structured comparison


### PR DESCRIPTION
## Summary

- Adds a "Stage 1.5" name-based refinement step to `_compare_test_results()` in the builder phase
- When the worktree has a higher failure count than baseline, extracts individual failing test names from both outputs using the existing `_extract_failing_test_names()` method
- If both sides produce parseable names and no genuinely new test names appear, treats the count discrepancy as noise rather than a regression
- Falls back to count-based comparison when name extraction fails for either side

## Changes

**`builder.py`**: Modified `_compare_test_results()` (lines 630-644) to add name-based comparison between the existing count check (Stage 1) and the line-based fallback (Stage 2). Reuses the existing `_extract_failing_test_names()` method which already supports pytest, cargo test, and vitest/jest output formats.

**`test_phases.py`**: Added 8 new test cases to `TestBuilderCompareTestResults`:
- Same test names with count discrepancy → noise (returns None)
- Genuinely new test name → regression detected (returns True)
- Regression test for #2006 scenario (different cargo tests)
- Flaky test swap with same count
- Name extraction fails one side → trusts counts
- Name extraction fails both sides → trusts counts
- Multi-runner (pytest + vitest) names don't collide

## Test plan

- [x] Unit tests for name-based comparison (same names, new names, edge cases)
- [x] Regression test for #2006 scenario
- [x] Fallback tests when name extraction fails
- [x] Multi-runner test
- [x] All 291 existing tests in test_phases.py still pass

Closes #2043

🤖 Generated with [Claude Code](https://claude.com/claude-code)