### PR TITLE
Improve builder completion retry with diagnostics and direct fallback

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/config.py
+++ b/loom-tools/src/loom_tools/shepherd/config.py
@@ -168,7 +168,7 @@ class ShepherdConfig:
         default_factory=lambda: env_int("LOOM_STUCK_MAX_RETRIES", 1)
     )
     builder_completion_retries: int = field(
-        default_factory=lambda: env_int("LOOM_BUILDER_COMPLETION_RETRIES", 1)
+        default_factory=lambda: env_int("LOOM_BUILDER_COMPLETION_RETRIES", 2)
     )
 
     # Rate limiting


### PR DESCRIPTION
## Summary

- **Diagnostic-driven completion**: `_gather_diagnostics` now detects existing PRs (number, labels), enabling targeted completion instructions (e.g., "just add label" vs "create PR from scratch")
- **Expanded incomplete work detection**: `_has_incomplete_work` now catches remote-exists-no-PR and PR-missing-label states, not just uncommitted/ahead-of-main
- **Direct mechanical fallback**: New `_direct_completion` method runs `git push` / `gh pr create` / `gh pr edit --add-label` directly via subprocess after agent retries exhaust, eliminating full agent overhead for trivial operations
- **Progressive retry simplification**: Completion phase instructions escalate urgency on later attempts; default retries bumped from 1→2
- **Comprehensive tests**: 25+ new test cases covering all diagnostic states, incomplete work detection, direct fallback paths, and instruction generation

Closes #2055

## Test plan

- [x] All 313 phase tests pass
- [x] Full Python test suite (1728 passed, 32 skipped)
- [x] No new lint issues introduced (verified with ruff)
- [x] Unit tests for `_has_incomplete_work` cover all 7 state combinations
- [x] Unit tests for `_direct_completion` cover push+PR, push failure, label-only, PR failure, and skip-push paths
- [x] Unit tests for `_run_completion_phase` verify PR-aware instructions, urgency escalation, and commit/push instructions
- [x] Unit tests for diagnostics verify PR detection with/without label and no-PR case
- [x] Default `builder_completion_retries` verified as 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)