### PR TITLE
DRY up pipe-pane log capture: strip ANSI escape sequences everywhere

### DIFF
--- a/defaults/scripts/cli/loom-scale.sh
+++ b/defaults/scripts/cli/loom-scale.sh
@@ -42,6 +42,9 @@ if [[ -z "$REPO_ROOT" ]]; then
     exit 1
 fi
 
+# Source shared pipe-pane helper
+source "$REPO_ROOT/.loom/scripts/lib/pipe-pane-cmd.sh"
+
 LOG_DIR="/tmp"
 TMUX_SOCKET="loom"
 
@@ -214,8 +217,8 @@ spawn_role_agent() {
     # Create tmux session
     tmux -L "$TMUX_SOCKET" new-session -d -s "$session_name" -n "$role"
 
-    # Set up output capture
-    tmux -L "$TMUX_SOCKET" pipe-pane -t "$session_name" -o "cat >> '$log_file'"
+    # Set up output capture with ANSI stripping
+    tmux -L "$TMUX_SOCKET" pipe-pane -t "$session_name" -o "$(pipe_pane_cmd "$log_file")"
 
     # Change to workspace
     tmux -L "$TMUX_SOCKET" send-keys -t "$session_name" "cd '$REPO_ROOT'" C-m

--- a/defaults/scripts/lib/pipe-pane-cmd.sh
+++ b/defaults/scripts/lib/pipe-pane-cmd.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# pipe-pane-cmd.sh - Shared pipe-pane command with ANSI escape sequence stripping
+#
+# Provides a single canonical definition of the pipe-pane filter command
+# used across all shell-based tmux pipe-pane call sites.
+#
+# The sed command removes:
+#   - Standard ANSI escape sequences: ESC[...letter (colors, cursor, modes)
+#   - Terminal mode queries: ESC[?...h/l (like ?2026h/l)
+#   - OSC sequences: ESC]...BEL (title setting, etc.)
+#
+# Usage:
+#   source "$(dirname "${BASH_SOURCE[0]}")/lib/pipe-pane-cmd.sh"
+#   tmux pipe-pane -t "$session" "$(pipe_pane_cmd "$log_file")"
+
+# Build the pipe-pane filter command for a given log file path.
+# Arguments:
+#   $1 - Path to the log file (will be single-quoted in output)
+# Output:
+#   The sed command string suitable for passing to tmux pipe-pane
+pipe_pane_cmd() {
+    local log_file="$1"
+    if [[ -z "$log_file" ]]; then
+        echo "pipe_pane_cmd: log_file argument required" >&2
+        return 1
+    fi
+    echo "sed -E 's/\\x1b\\[[?0-9;]*[a-zA-Z]//g; s/\\x1b\\][^\\x07]*\\x07//g' >> '${log_file}'"
+}

--- a/defaults/scripts/spawn-shell-shepherd.sh
+++ b/defaults/scripts/spawn-shell-shepherd.sh
@@ -215,6 +215,9 @@ REPO_ROOT=$(find_repo_root) || {
     exit 1
 }
 
+# Source shared pipe-pane helper
+source "$REPO_ROOT/.loom/scripts/lib/pipe-pane-cmd.sh"
+
 # ─── Main ─────────────────────────────────────────────────────────────────────
 
 FULL_SESSION_NAME="${SESSION_PREFIX}${SESSION_NAME}"
@@ -277,8 +280,8 @@ if ! tmux -L "$TMUX_SOCKET" new-session -d -s "$FULL_SESSION_NAME" -c "$REPO_ROO
     exit 1
 fi
 
-# Set up output capture via pipe-pane
-tmux -L "$TMUX_SOCKET" pipe-pane -t "$FULL_SESSION_NAME" "cat >> '$LOG_FILE'" 2>/dev/null || true
+# Set up output capture via pipe-pane with ANSI stripping
+tmux -L "$TMUX_SOCKET" pipe-pane -t "$FULL_SESSION_NAME" "$(pipe_pane_cmd "$LOG_FILE")" 2>/dev/null || true
 
 # Set environment variables for the session
 tmux -L "$TMUX_SOCKET" set-environment -t "$FULL_SESSION_NAME" LOOM_TERMINAL_ID "$SESSION_NAME"


### PR DESCRIPTION
Closes #2060

## Summary

- Add shared shell helper (`defaults/scripts/lib/pipe-pane-cmd.sh`) that outputs the canonical sed pipe-pane filter command for ANSI stripping
- Update `spawn-shell-shepherd.sh` and `loom-scale.sh` to use the shared helper instead of plain `cat`
- Add `pipe_pane_cmd()` function in `loom-daemon/src/terminal.rs` to replace plain `cat` in both the create and recovery pipe-pane paths
- All pipe-pane call sites now strip ANSI escape sequences, matching the pattern already used in `agent_spawn.py`

## Test plan

- [x] `pnpm check:ci:lite` passes (1808 passed, 1 skipped)
- [x] Rust daemon compiles with `cargo build -p loom-daemon`
- [ ] Verify shell shepherd log output is clean of ANSI sequences
- [ ] Verify Tauri daemon terminal logs are clean of ANSI sequences

🤖 Generated with [Claude Code](https://claude.com/claude-code)