### PR TITLE
Improve builder completion phase with targeted retry

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/config.py
+++ b/loom-tools/src/loom_tools/shepherd/config.py
@@ -168,7 +168,7 @@ class ShepherdConfig:
         default_factory=lambda: env_int("LOOM_STUCK_MAX_RETRIES", 1)
     )
     builder_completion_retries: int = field(
-        default_factory=lambda: env_int("LOOM_BUILDER_COMPLETION_RETRIES", 1)
+        default_factory=lambda: env_int("LOOM_BUILDER_COMPLETION_RETRIES", 2)
     )
     test_fix_max_retries: int = field(
         default_factory=lambda: env_int("LOOM_TEST_FIX_MAX_RETRIES", 2)


### PR DESCRIPTION
## Summary

Improves the builder completion retry phase to diagnose specific failure states and send targeted recovery instructions, reducing the most common shepherd failure mode.

### Changes

- **Diagnostic-driven completion**: `_gather_diagnostics()` now detects existing PR number and label state. New `_diagnose_remaining_steps()` determines exactly what's missing (commit, push, PR, or label).
- **Expanded incomplete work detection**: `_has_incomplete_work()` now returns `True` for "remote exists but no PR" and "PR exists but missing label" states, not just uncommitted/unpushed changes.
- **Multiple retry attempts**: Default completion retries bumped from 1 to 2 (configurable via `LOOM_BUILDER_COMPLETION_RETRIES`). Re-diagnosis between attempts detects partial progress.
- **Progressive instruction simplification**: Attempt 2+ uses explicit `git`/`gh` commands instead of general instructions.
- **Direct fallback**: New `_direct_completion()` runs mechanical operations (push branch, add label) directly in Python after retries are exhausted, avoiding agent overhead for trivial operations.

### Acceptance Criteria Verification

| Criterion | Verified |
|-----------|----------|
| Completion phase diagnoses specific missing steps before retrying | `_diagnose_remaining_steps()` with 6 test cases |
| Instructions sent to completion agent are targeted | `_run_completion_phase()` builds step-specific instructions, 3 test cases |
| At least 2 completion retry attempts (configurable) | Default bumped to 2, `TestBuilderCompletionRetryDefault` |
| Direct Python fallback for mechanical operations | `_direct_completion()` with 5 test cases |
| Re-diagnosis between attempts to detect partial progress | Loop re-calls `_gather_diagnostics()` each iteration |
| Tests for each diagnostic state and retry path | 25 new tests across 6 test classes |

### Files Changed

- `loom-tools/src/loom_tools/shepherd/config.py` — Default retries: 1 → 2
- `loom-tools/src/loom_tools/shepherd/phases/builder.py` — All completion logic changes
- `loom-tools/tests/shepherd/test_phases.py` — 25 new tests, 1 updated test

Closes #2055