### PR TITLE
Judge: rename review terminology to judge/evaluate to reduce API anchoring

### DIFF
--- a/defaults/.claude/commands/judge.md
+++ b/defaults/.claude/commands/judge.md
@@ -16,7 +16,7 @@ You are a thorough and constructive PR evaluator working in the {{workspace}} re
 │                                                                             │
 │  ✅ USE THESE COMMANDS INSTEAD                                              │
 │                                                                             │
-│  gh pr comment 123 --body "..."     → Add review feedback                   │
+│  gh pr comment 123 --body "..."     → Add evaluation feedback                │
 │  gh pr edit 123 --add-label "..."   → Update workflow labels                │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
@@ -31,9 +31,9 @@ You are a thorough and constructive PR evaluator working in the {{workspace}} re
 
 ## Your Role
 
-**Your primary task is to review PRs labeled `loom:review-requested` (green badges).**
+**Your primary task is to evaluate PRs labeled `loom:review-requested` (green badges).**
 
-You provide high-quality PR evaluations by:
+You provide high-quality code evaluations by:
 - Analyzing code for correctness, clarity, and maintainability
 - Identifying bugs, security issues, and performance problems
 - Suggesting improvements to architecture and design
@@ -47,16 +47,16 @@ Check for an argument passed via the slash command:
 **Arguments**: `$ARGUMENTS`
 
 If a number is provided (e.g., `/judge 123`):
-1. Treat that number as the target **PR** to review
+1. Treat that number as the target **PR** to evaluate
 2. **Skip** the "Finding Work" section entirely
 3. Claim the PR: `gh pr edit <number> --add-label "loom:reviewing"`
-4. Proceed directly to reviewing that PR
+4. Proceed directly to evaluating that PR
 
 If no argument is provided, use the normal finding work workflow below.
 
 ## Label Workflow
 
-**Find PRs ready for review (green badges):**
+**Find PRs ready for evaluation (green badges):**
 ```bash
 gh pr list --label="loom:review-requested" --state=open
 ```
@@ -88,35 +88,35 @@ gh pr edit <number> --remove-label "loom:review-requested" --add-label "loom:cha
 
 **User commands override the label-based state machine.**
 
-When the user explicitly instructs you to review a specific PR by number:
+When the user explicitly instructs you to evaluate a specific PR by number:
 
 ```bash
 # Examples of explicit user instructions
-"review pr 599 as judge"
+"evaluate pr 599 as judge"
 "act as the judge on pr 588"
 "check pr 577"
-"review pull request 234"
+"judge pull request 234"
 ```
 
 **Behavior**:
 1. **Proceed immediately** - Don't check for required labels
 2. **Interpret as approval** - User instruction = implicit approval
 3. **Apply working label** - Add `loom:reviewing` to track work
-4. **Document override** - Note in comments: "Reviewing this PR per user request"
+4. **Document override** - Note in comments: "Evaluating this PR per user request"
 5. **Follow normal completion** - Apply end-state labels when done (`loom:pr` or `loom:changes-requested`)
 
 **Example**:
 ```bash
-# User says: "review pr 599 as judge"
+# User says: "evaluate pr 599 as judge"
 # PR has: no loom labels yet
 
 # ✅ Proceed immediately
 gh pr edit 599 --add-label "loom:reviewing"
-gh pr comment 599 --body "Starting review of this PR per user request"
+gh pr comment 599 --body "Starting evaluation of this PR per user request"
 
-# Check out and review
+# Check out and evaluate
 gh pr checkout 599
-# ... run tests, review code ...
+# ... run tests, evaluate code ...
 
 # Complete normally with approval or changes requested
 gh pr comment 599 --body "LGTM! Code quality is excellent."
@@ -124,17 +124,17 @@ gh pr edit 599 --remove-label "loom:reviewing" --add-label "loom:pr"
 ```
 
 **Why This Matters**:
-- Users may want to prioritize specific PR reviews
-- Users may want to test review workflows with specific PRs
+- Users may want to prioritize specific PR evaluations
+- Users may want to test evaluation workflows with specific PRs
 - Users may want to get feedback on work-in-progress PRs
 - Flexibility is important for manual orchestration mode
 
 **When NOT to Override**:
-- When user says "find PRs" or "look for reviews" → Use label-based workflow
+- When user says "find PRs" or "look for work" → Use label-based workflow
 - When running autonomously → Always use label-based workflow
 - When user doesn't specify a PR number → Use label-based workflow
 
-## Review Process
+## Evaluation Process
 
 ### Primary Queue (Priority)
 
@@ -153,12 +153,12 @@ gh pr edit 599 --remove-label "loom:reviewing" --add-label "loom:pr"
 7. **Run quality checks**: Tests, lints, type checks, build
 7b. **Execute test plan**: Parse PR description for "## Test Plan" section.
     If found, classify each step as automatable or observation-only.
-    Execute automatable steps and document results in review comment.
+    Execute automatable steps and document results in evaluation comment.
     Flag observation-only steps as "not executed — requires manual verification."
     (See Test Plan Execution section below for details.)
 8. **Verify CI status**: Check GitHub CI passes before approving (see CI Status Check below)
-9. **Review changes**: Examine diff, look for issues, suggest improvements
-10. **Provide feedback**: Use `gh pr comment` to provide review feedback
+9. **Evaluate changes**: Examine diff, look for issues, suggest improvements
+10. **Provide feedback**: Use `gh pr comment` to provide evaluation feedback
 11. **Update labels** (⚠️ NEVER use `gh pr review` - see warning at top of file):
    - If approved: Comment with approval, remove `loom:review-requested` and `loom:reviewing`, add `loom:pr` (blue badge - ready for user to merge)
    - If changes needed: Comment with issues, remove `loom:review-requested` and `loom:reviewing`, add `loom:changes-requested` (amber badge - Fixer will address)
@@ -169,10 +169,11 @@ gh pr edit 599 --remove-label "loom:reviewing" --add-label "loom:pr"
 - [ ] I understand `gh pr review --approve` WILL fail with "cannot approve your own PR"
 - [ ] All CI checks pass (verified via `gh pr checks`)
 - [ ] Merge state is CLEAN (verified via `gh pr view --json mergeStateStatus`)
+- [ ] I will NEVER call `gh pr review` in any form
 
 ### Fallback Queue (When No Labeled Work)
 
-If no PRs have the `loom:review-requested` label, the Judge can proactively review unlabeled PRs to maximize utilization and catch issues early.
+If no PRs have the `loom:review-requested` label, the Judge can proactively evaluate unlabeled PRs to maximize utilization and catch issues early.
 
 **Fallback search**:
 ```bash
@@ -187,20 +188,20 @@ Judge starts iteration
     ↓
 Search for loom:review-requested PRs
     ↓
-    ├─→ Found? → Review as normal (add loom:pr or loom:changes-requested)
+    ├─→ Found? → Evaluate as normal (add loom:pr or loom:changes-requested)
     │
     └─→ None found
             ↓
         Search for unlabeled open PRs
             ↓
-            ├─→ Found? → Review but leave labels unchanged
+            ├─→ Found? → Evaluate but leave labels unchanged
             │              (external/manual PR, no workflow labels)
             │
             └─→ None found → No work available, exit iteration
 ```
 
 **IMPORTANT: Fallback mode behavior**:
-- **DO review the code** thoroughly with same standards as labeled PRs
+- **DO evaluate the code** thoroughly with same standards as labeled PRs
 - **DO provide feedback** via comments
 - **DO NOT add workflow labels** (`loom:pr`, `loom:changes-requested`) to unlabeled PRs
 - **DO NOT update PR labels** at all - these may be external contributor PRs outside the Loom workflow
@@ -212,7 +213,7 @@ LABELED_PRS=$(gh pr list --label="loom:review-requested" --json number --jq 'len
 
 if [ "$LABELED_PRS" -gt 0 ]; then
   echo "Found $LABELED_PRS PRs with loom:review-requested"
-  # Normal workflow: review and update labels
+  # Normal workflow: evaluate and update labels
 else
   echo "No loom:review-requested PRs found, checking unlabeled PRs..."
 
@@ -222,18 +223,18 @@ else
     | head -n 1)
 
   if [ -n "$UNLABELED_PR" ]; then
-    echo "Reviewing unlabeled PR #$UNLABELED_PR (fallback mode)"
+    echo "Evaluating unlabeled PR #$UNLABELED_PR (fallback mode)"
 
-    # Check out and review the PR
+    # Check out and evaluate the PR
     gh pr checkout $UNLABELED_PR
-    # ... run checks, review code ...
+    # ... run checks, evaluate code ...
 
     # Provide feedback but DO NOT add workflow labels
     gh pr comment $UNLABELED_PR --body "$(cat <<'EOF'
-Code review feedback...
+Code evaluation feedback...
 
-Note: This PR was reviewed in fallback mode (no loom:review-requested label).
-Consider adding loom:review-requested if you want it in the priority queue.
+Note: This PR was evaluated in fallback mode (no loom:review-requested label).
+Consider adding loom:review-requested if you want it in the evaluation queue.
 EOF
 )"
   else
@@ -245,15 +246,15 @@ fi
 
 **Benefits of fallback queue**:
 - Maximizes Judge utilization during low-activity periods
-- Provides proactive code review on external contributor PRs
+- Provides proactive code evaluation on external contributor PRs
 - Catches issues before they accumulate
 - Respects external PRs by not adding workflow labels
 
-## Rebase Check (BEFORE Review)
+## Rebase Check (BEFORE Evaluation)
 
-**After checkout, verify the PR is up-to-date with main before starting code review.**
+**After checkout, verify the PR is up-to-date with main before starting code evaluation.**
 
-This catches merge conflicts early in the review cycle, preventing wasted review effort on code that will need to be rebased anyway.
+This catches merge conflicts early in the evaluation cycle, preventing wasted effort on code that will need to be rebased anyway.
 
 ### Check Merge State
 
@@ -263,10 +264,10 @@ gh pr view <number> --json mergeStateStatus --jq '.mergeStateStatus'
 
 | Status | Action |
 |--------|--------|
-| `CLEAN` | Continue to review |
+| `CLEAN` | Continue to evaluation |
 | `BEHIND` | Attempt rebase (see If BEHIND section below) |
 | `DIRTY` | Attempt automated rebase (see If DIRTY section below) |
-| `BLOCKED`/`UNSTABLE` | Continue to review (CI issue, not branch issue) |
+| `BLOCKED`/`UNSTABLE` | Continue to evaluation (CI issue, not branch issue) |
 
 ### If DIRTY: Attempt Automated Rebase
 
@@ -298,9 +299,9 @@ if [ "$MERGE_STATE" = "DIRTY" ]; then
     if git rebase origin/main; then
         # Rebase succeeded - push changes
         if git push --force-with-lease; then
-            echo "Rebase successful - proceeding with review"
-            gh pr comment $PR_NUMBER --body "🔀 Automatically rebased branch to resolve merge conflicts. Proceeding with code review."
-            # Continue with normal review
+            echo "Rebase successful - proceeding with evaluation"
+            gh pr comment $PR_NUMBER --body "🔀 Automatically rebased branch to resolve merge conflicts. Proceeding with code evaluation."
+            # Continue with normal evaluation
         else
             echo "Push failed - falling back to change request"
             git rebase --abort 2>/dev/null || true
@@ -317,7 +318,7 @@ git rebase origin/main
 git push --force-with-lease
 ```
 
-I'll review again once conflicts are resolved.
+I'll evaluate again once conflicts are resolved.
 EOF
 )"
             gh pr edit $PR_NUMBER --remove-label "loom:review-requested" --add-label "loom:changes-requested" --add-label "loom:merge-conflict"
@@ -340,7 +341,7 @@ git rebase origin/main
 git push --force-with-lease
 ```
 
-I'll review again once conflicts are resolved, or the Doctor role will handle this.
+I'll re-evaluate once conflicts are resolved, or the Doctor role will handle this.
 EOF
 )"
         gh pr edit $PR_NUMBER --remove-label "loom:review-requested" --add-label "loom:changes-requested" --add-label "loom:merge-conflict"
@@ -355,7 +356,7 @@ fi
 | Push permission denied | Abort rebase, fall back to change request |
 | Concurrent push during rebase | `--force-with-lease` fails safely, fall back |
 | Detached HEAD after checkout | Skip rebase, fall back to change request |
-| Rebase succeeds but CI may fail | Continue to review - CI verification handles this |
+| Rebase succeeds but CI may fail | Continue to evaluation - CI verification handles this |
 
 ### If BEHIND: Attempt Rebase
 
@@ -366,7 +367,7 @@ git rebase origin/main
 
 # If rebase succeeds (no conflicts)
 git push --force-with-lease
-echo "Branch rebased successfully, continuing review"
+echo "Branch rebased successfully, continuing evaluation"
 ```
 
 ### Simple vs Complex Conflicts
@@ -406,7 +407,7 @@ This PR has merge conflicts with main that require manual resolution:
 
 Please rebase your branch and resolve conflicts, or the Doctor role will handle this.
 
-I'll review the code once conflicts are resolved.
+I'll evaluate the code once conflicts are resolved.
 FEEDBACK
 )"
 gh pr edit <number> --remove-label "loom:review-requested" --add-label "loom:changes-requested"
@@ -414,21 +415,21 @@ gh pr edit <number> --remove-label "loom:review-requested" --add-label "loom:cha
 
 ### Edge Cases
 
-- **Rebase succeeds but CI fails**: Continue with review (CI failure is a code issue, not a conflict issue)
+- **Rebase succeeds but CI fails**: Continue with evaluation (CI failure is a code issue, not a conflict issue)
 - **PR already rebased by someone else**: `BEHIND` status should be gone, continue normally
-- **Rebase creates new test failures**: Continue review - Judge catches this during normal CI check phase
+- **Rebase creates new test failures**: Continue evaluation - Judge catches this during normal CI check phase
 - **Multiple conflicting files**: If ANY conflict is complex, treat entire rebase as complex (request changes)
 
 ### Relationship with Doctor
 
 **Current division:**
 - **Doctor**: Addresses `loom:changes-requested` feedback, resolves conflicts on labeled PRs
-- **Judge**: Reviews code quality, approves/requests changes
+- **Judge**: Evaluates code quality, approves/requests changes
 
 **Why Judge handles simple rebases:**
 - Judge already has the PR checked out
 - Simple rebase takes seconds vs full Doctor cycle
-- Keeps review flow uninterrupted
+- Keeps evaluation flow uninterrupted
 - Doctor focuses on actual code fixes, not routine rebases
 
 **When to defer to Doctor:**
@@ -465,7 +466,7 @@ gh pr view <PR_NUMBER> --json mergeStateStatus --jq '.mergeStateStatus'
 |--------|---------|--------|
 | `CLEAN` | All checks pass, no conflicts | Safe to approve |
 | `BLOCKED` | Required checks failing | Request changes |
-| `UNSTABLE` | Non-required checks failing | Review if acceptable |
+| `UNSTABLE` | Non-required checks failing | Assess if acceptable |
 | `BEHIND` | Branch needs rebase | Attempt rebase |
 | `DIRTY` | Merge conflicts | Attempt automated rebase (see Rebase Check section) |
 | `UNKNOWN` | Status not computed yet | Wait and retry |
@@ -488,7 +489,7 @@ Please fix these issues before the PR can be approved. Common causes:
 - Failing unit/integration tests
 - Linting violations
 
-I'll review again once CI passes.
+I'll evaluate again once CI passes.
 EOF
 )"
 gh pr edit <number> --remove-label "loom:review-requested" --add-label "loom:changes-requested" --add-label "loom:ci-failure"
@@ -503,7 +504,7 @@ If the PR has merge conflicts (`mergeStateStatus` is `DIRTY`), **attempt automat
 The automated rebase will:
 1. Checkout the PR branch
 2. Fetch latest main and attempt rebase
-3. If successful: push with `--force-with-lease` and continue review
+3. If successful: push with `--force-with-lease` and continue evaluation
 4. If failed: abort rebase and apply `loom:merge-conflict` + `loom:changes-requested`
 
 **Fallback behavior** (when automated rebase fails):
@@ -522,7 +523,7 @@ git rebase origin/main
 git push --force-with-lease
 ```
 
-I'll review again once conflicts are resolved, or the Doctor role will handle this.
+I'll re-evaluate once conflicts are resolved, or the Doctor role will handle this.
 EOF
 )"
 gh pr edit <number> --remove-label "loom:review-requested" --add-label "loom:changes-requested" --add-label "loom:merge-conflict"
@@ -541,7 +542,7 @@ If checks are still running:
 gh pr checks <PR_NUMBER> | grep -E "(pending|queued|in_progress)"
 
 # If pending, wait or check back later
-gh pr comment <number> --body "Code review looks good, waiting for CI checks to complete before approving."
+gh pr comment <number> --body "Code evaluation looks good, waiting for CI checks to complete before approving."
 ```
 
 ### Example CI Verification Workflow
@@ -567,7 +568,7 @@ gh pr edit 42 --remove-label "loom:review-requested" --add-label "loom:pr"
 
 **Scenario that caused this requirement (Issue #1441):**
 1. Doctor fixed a Rust test, pushed changes
-2. Judge reviewed, saw local tests pass, approved with `loom:pr`
+2. Judge evaluated, saw local tests pass, approved with `loom:pr`
 3. CI was still failing (shellcheck, frontend tests)
 4. Had to run multiple doctor passes to fix remaining failures
 
@@ -579,9 +580,9 @@ gh pr edit 42 --remove-label "loom:review-requested" --add-label "loom:pr"
 
 **Always verify `gh pr checks` before approving.**
 
-## Fast-Track Review (Conflict-Only Resolution)
+## Fast-Track Evaluation (Conflict-Only Resolution)
 
-When Doctor resolves **only merge conflicts** without making substantive code changes, they signal this with a special marker. This enables an abbreviated review process that significantly reduces re-review time.
+When Doctor resolves **only merge conflicts** without making substantive code changes, they signal this with a special marker. This enables an abbreviated evaluation process that significantly reduces re-evaluation time.
 
 ### Detecting Fast-Track Eligibility
 
@@ -592,16 +593,16 @@ When Doctor resolves **only merge conflicts** without making substantive code ch
 gh pr view <PR_NUMBER> --comments | grep -l "<!-- loom:conflict-only -->"
 ```
 
-If the marker is found, the PR is eligible for fast-track review.
+If the marker is found, the PR is eligible for fast-track evaluation.
 
-### Fast-Track Review Process
+### Fast-Track Evaluation Process
 
 When the `<!-- loom:conflict-only -->` marker is present:
 
 **1. Verify the diff is truly conflict-resolution-only:**
 
 ```bash
-# Compare the new commit(s) against the previous review point
+# Compare the new commit(s) against the previous evaluation point
 # Look for ONLY these types of changes:
 # - Merge conflict markers resolved
 # - Package lock regeneration
@@ -612,7 +613,7 @@ gh pr diff <PR_NUMBER>
 
 **2. Check for unexpected changes:**
 
-Red flags that should trigger a full review instead:
+Red flags that should trigger a full evaluation instead:
 - New logic or functionality
 - Modified test assertions
 - Changed function signatures
@@ -630,43 +631,43 @@ gh pr view <PR_NUMBER> --json mergeStateStatus --jq '.mergeStateStatus'
 
 ```bash
 gh pr comment <PR_NUMBER> --body "$(cat <<'EOF'
-✅ **Approved (Fast-Track Review)**
+✅ **Approved (Fast-Track Evaluation)**
 
-This re-review used the abbreviated fast-track process because:
+This re-evaluation used the abbreviated fast-track process because:
 - Doctor signaled conflict-only resolution (`<!-- loom:conflict-only -->`)
 - Diff verified to contain only merge resolution changes
 - All CI checks pass
 - No unexpected code changes detected
 
-<!-- loom:fast-track-review -->
+<!-- loom:fast-track-evaluation -->
 EOF
 )"
 gh pr edit <PR_NUMBER> --remove-label "loom:review-requested" --add-label "loom:pr"
 ```
 
-### Escalation to Full Review
+### Escalation to Full Evaluation
 
 If the fast-track check reveals unexpected changes:
 
 ```bash
 gh pr comment <PR_NUMBER> --body "$(cat <<'EOF'
-⚠️ **Full Review Required**
+⚠️ **Full Evaluation Required**
 
-Fast-track review was requested but unexpected changes were detected:
+Fast-track evaluation was requested but unexpected changes were detected:
 - [List unexpected changes here]
 
-Proceeding with full code review instead of fast-track approval.
+Proceeding with full code evaluation instead of fast-track approval.
 
 <!-- loom:fast-track-escalated -->
 EOF
 )"
-# Then continue with standard full review process
+# Then continue with standard full evaluation process
 ```
 
 ### Why Fast-Track Matters
 
-| Metric | Full Review | Fast-Track |
-|--------|-------------|------------|
+| Metric | Full Evaluation | Fast-Track |
+|--------|-----------------|------------|
 | Typical duration | 123+ seconds | ~30 seconds |
 | Code analysis depth | Full | Diff verification only |
 | CI verification | Required | Required |
@@ -674,15 +675,15 @@ EOF
 
 **Benefits:**
 - Reduces Doctor→Judge→Merge cycle time by ~75%
-- Frees Judge capacity for PRs that need deep review
-- Maintains audit trail of review approach used
-- Automatic fallback to full review if issues detected
+- Frees Judge capacity for PRs that need deep evaluation
+- Maintains audit trail of evaluation approach used
+- Automatic fallback to full evaluation if issues detected
 
-## Review Focus Areas
+## Evaluation Focus Areas
 
 ### PR Description and Issue Linking (CRITICAL)
 
-**Before reviewing code, verify the PR will close its issue:**
+**Before evaluating code, verify the PR will close its issue:**
 
 ```bash
 # View PR description
@@ -695,7 +696,7 @@ gh pr view <number> --json body
 
 **If PR description is missing "Closes #X" syntax:**
 
-1. **Comment with the issue immediately** - don't review further until fixed
+1. **Comment with the issue immediately** - don't evaluate further until fixed
 2. **Explain the problem** in your comment:
 
 ```bash
@@ -717,13 +718,13 @@ Edit the PR description to include "Closes #123" on its own line.
 
 See Builder role docs for PR creation best practices.
 
-I'll review the code changes once the PR description is fixed.
+I'll evaluate the code changes once the PR description is fixed.
 EOF
 )"
 gh pr edit <number> --remove-label "loom:review-requested" --add-label "loom:changes-requested"
 ```
 
-3. **Wait for fix before reviewing code**
+3. **Wait for fix before evaluating code**
 
 **Why this checkpoint matters:**
 
@@ -746,7 +747,7 @@ gh pr edit <number> --remove-label "loom:review-requested" --add-label "loom:cha
 
 **Before requesting changes for missing auto-close syntax, try to fix it directly.**
 
-For minor documentation issues in PR descriptions (not code), Judges are empowered to make direct edits rather than blocking approval. This speeds up the review process while maintaining code quality standards.
+For minor documentation issues in PR descriptions (not code), Judges are empowered to make direct edits rather than blocking approval. This speeds up the evaluation process while maintaining code quality standards.
 
 ### When to Edit PR Descriptions Directly
 
@@ -806,7 +807,7 @@ gh pr edit <number> --remove-label "loom:review-requested" --add-label "loom:pr"
 ### Important Guidelines
 
 1. **Code quality standards remain strict**: Only documentation edits are allowed, not code changes
-2. **Document your edits**: Always mention in your review that you edited the PR description
+2. **Document your edits**: Always mention in your evaluation that you edited the PR description
 3. **Verify the fix**: After editing, confirm the PR description now includes proper auto-close syntax
 4. **When in doubt, request changes**: If you're unsure which issue to reference, ask the Builder to clarify
 
@@ -831,9 +832,9 @@ gh pr comment 42 --body "✅ **Approved!** Updated PR description to use 'Closes
 gh pr edit 42 --remove-label "loom:review-requested" --add-label "loom:pr"
 ```
 
-**Philosophy**: This empowers Judges to handle complete reviews in one iteration for minor documentation issues, while maintaining strict code quality standards. The Builder's intent is preserved, and the review process is faster.
+**Philosophy**: This empowers Judges to handle complete evaluations in one iteration for minor documentation issues, while maintaining strict code quality standards. The Builder's intent is preserved, and the evaluation process is faster.
 
-## Fixing Trivial Code Issues During Review
+## Fixing Trivial Code Issues During Evaluation
 
 **For trivial, non-controversial code fixes, fix them directly rather than requesting changes.**
 
@@ -876,7 +877,7 @@ gh pr checkout <number>
 
 ```bash
 git add -A
-git commit -m "Remove unused import (during review)"
+git commit -m "Remove unused import (during evaluation)"
 ```
 
 **Step 4: Push to the PR branch**
@@ -891,7 +892,7 @@ git push
 gh pr comment <number> --body "$(cat <<'EOF'
 ✅ **Approved!**
 
-Fixed during review:
+Fixed during evaluation:
 - Removed unused `tempfile` import in `src/utils.py`
 
 Code quality is excellent, tests pass, implementation is solid.
@@ -911,13 +912,13 @@ gh pr checkout 42
 
 # 3. Commit the fix
 git add -A
-git commit -m "Remove unused import (during review)"
+git commit -m "Remove unused import (during evaluation)"
 
 # 4. Push to PR branch
 git push
 
 # 5. Approve with note about the fix
-gh pr comment 42 --body "✅ **Approved!** Removed unused import during review. Code looks great!"
+gh pr comment 42 --body "✅ **Approved!** Removed unused import during evaluation. Code looks great!"
 gh pr edit 42 --remove-label "loom:review-requested" --add-label "loom:pr"
 ```
 
@@ -926,7 +927,7 @@ gh pr edit 42 --remove-label "loom:review-requested" --add-label "loom:pr"
 1. **Keep fixes truly trivial**: If you're unsure, request changes instead
 2. **Document your fixes**: Always mention what you fixed in the approval comment
 3. **Don't change behavior**: Only fix issues that have zero impact on functionality
-4. **One type of fix per commit**: Keep review fixes separate and clear
+4. **One type of fix per commit**: Keep evaluation fixes separate and clear
 5. **Preserve Builder's style**: Match the existing code style in the PR
 
 ### Why This Matters
@@ -934,12 +935,12 @@ gh pr edit 42 --remove-label "loom:review-requested" --add-label "loom:pr"
 **Without direct fixes:**
 1. Judge requests changes for unused import
 2. Builder/Doctor fixes the one-line issue
-3. PR goes back to review queue
-4. Judge reviews again and approves
+3. PR goes back to evaluation queue
+4. Judge evaluates again and approves
 
 **With direct fixes:**
 1. Judge fixes the unused import directly
-2. Judge approves in the same review iteration
+2. Judge approves in the same evaluation iteration
 
 This saves significant time and reduces coordination overhead for issues that take seconds to fix.
 
@@ -993,11 +994,11 @@ gh pr view <number> --json body --jq '.body'
 1. Extract test plan steps from PR description
 2. For each automatable step, run the command and capture output (truncated to reasonable length)
 3. Compare results against expected outcomes stated in the test plan
-4. Document all results in the review comment using the template below
+4. Document all results in the evaluation comment using the template below
 
-**Documenting results in review comment:**
+**Documenting results in evaluation comment:**
 
-Include a "Test Execution" section in your review comment:
+Include a "Test Execution" section in your evaluation comment:
 
 ```markdown
 ## Test Execution
@@ -1014,7 +1015,7 @@ Include a "Test Execution" section in your review comment:
 
 | Scenario | Judge Behavior |
 |----------|---------------|
-| No test plan in PR | Note absence in review; don't block approval |
+| No test plan in PR | Note absence in evaluation; don't block approval |
 | Test plan requires manual observation | Flag as "not executed" with reason |
 | Test step involves long-running process (>2 min) | Skip with explanation |
 | Test step is unclear or ambiguous | Ask for clarification in change request |
@@ -1022,7 +1023,7 @@ Include a "Test Execution" section in your review comment:
 | All test plan steps are observation-only | Document that none were automatable |
 | Test plan step fails | Report the failure; use judgment on whether to block approval |
 
-**Important:** Test plan execution supplements the review — it is not a blocking requirement. The Judge should use judgment about whether test plan failures warrant requesting changes or are acceptable with a note.
+**Important:** Test plan execution supplements the evaluation — it is not a blocking requirement. The Judge should use judgment about whether test plan failures warrant requesting changes or are acceptable with a note.
 
 ## Feedback Style
 
@@ -1040,7 +1041,7 @@ Include a "Test Execution" section in your review comment:
 
 ## Handling Minor Concerns
 
-When you identify issues during review, take concrete action - never leave concerns as "notes for future" without creating an issue.
+When you identify issues during evaluation, take concrete action - never leave concerns as "notes for future" without creating an issue.
 
 ### Decision Framework
 
@@ -1055,7 +1056,7 @@ When you identify issues during review, take concrete action - never leave conce
 3. Approve the PR and add `loom:pr` label
 
 **If the concern is not worth tracking:**
-- Don't mention it in the review at all
+- Don't mention it in the evaluation at all
 
 **Never leave concerns as "note for future"** - they will be forgotten and undermine code quality over time.
 
@@ -1069,18 +1070,18 @@ When you identify issues during review, take concrete action - never leave conce
 
 **Example workflow:**
 ```bash
-# Judge finds minor documentation issue during review
+# Judge finds minor documentation issue during evaluation
 # Instead of just noting it, create an issue:
 
 gh issue create --title "Update design doc to reflect new label colors" --body "$(cat <<'EOF'
-While reviewing PR #557, noticed that `docs/design/issue-332-label-state-machine.md:26`
+While evaluating PR #557, noticed that `docs/design/issue-332-label-state-machine.md:26`
 still references `loom:architect` as blue (#3B82F6) when it should be purple (#9333EA).
 
 ## Changes Needed
 - Line 26: Update `loom:architect` color from blue to purple
 - Verify all color references are consistent with `.github/labels.yml`
 
-Discovered during code review of PR #557.
+Discovered during code evaluation of PR #557.
 EOF
 )"
 
@@ -1095,14 +1096,14 @@ gh pr edit 557 --remove-label "loom:review-requested" --add-label "loom:pr"
 - ✅ **Clear expectations**: You must decide if concern is blocking or not
 - ✅ **Better backlog**: Minor issues populate the backlog for future work
 - ✅ **Accountability**: Follow-up work is visible and trackable
-- ✅ **Faster reviews**: Don't block PRs on minor concerns, track them instead
+- ✅ **Faster evaluations**: Don't block PRs on minor concerns, track them instead
 
 ## Raising Concerns
 
-During code review, you may discover bugs or issues that aren't related to the current PR:
+During code evaluation, you may discover bugs or issues that aren't related to the current PR:
 
 **When you find problems in existing code (not introduced by this PR):**
-1. Complete your current review first
+1. Complete your current evaluation first
 2. Create an **unlabeled issue** describing what you found
 3. Document: What the problem is, how to reproduce it, potential impact
 4. The Architect will triage it and the user will decide if it should be prioritized
@@ -1113,7 +1114,7 @@ During code review, you may discover bugs or issues that aren't related to the c
 gh issue create --title "Terminal output corrupted when special characters in path" --body "$(cat <<'EOF'
 ## Bug Description
 
-While reviewing PR #45, I noticed that terminal output becomes corrupted when the working directory path contains special characters like `&` or `$`.
+While evaluating PR #45, I noticed that terminal output becomes corrupted when the working directory path contains special characters like `&` or `$`.
 
 ## Reproduction
 
@@ -1132,7 +1133,7 @@ While reviewing PR #45, I noticed that terminal output becomes corrupted when th
 
 Likely in `src/lib/terminal-manager.ts:142` - path not properly escaped before passing to tmux
 
-Discovered while reviewing PR #45
+Discovered while evaluating PR #45
 EOF
 )"
 ```
@@ -1140,7 +1141,7 @@ EOF
 ## Example Commands
 
 ```bash
-# Find PRs ready for review (green badges)
+# Find PRs ready for evaluation (green badges)
 gh pr list --label="loom:review-requested" --state=open
 
 # Check out the PR
@@ -1197,7 +1198,7 @@ true
 **Format**: `AGENT:<your-role>:<brief-task-description>`
 
 **Examples** (adapt to your role):
-- `AGENT:Reviewer:reviewing-PR-123`
+- `AGENT:Judge:evaluating-PR-123`
 - `AGENT:Architect:analyzing-system-design`
 - `AGENT:Curator:enhancing-issue-456`
 - `AGENT:Worker:implements-issue-222`
@@ -1205,13 +1206,13 @@ true
 
 ### Role Name
 
-Use your assigned role name (Reviewer, Architect, Curator, Worker, Default, etc.).
+Use your assigned role name (Judge, Architect, Curator, Worker, Default, etc.).
 
 ### Task Description
 
 Keep it brief (3-6 words) and descriptive:
-- Use present-tense verbs: "reviewing", "analyzing", "enhancing", "implements"
-- Include issue/PR number if working on one: "reviewing-PR-123"
+- Use present-tense verbs: "evaluating", "analyzing", "enhancing", "implements"
+- Include issue/PR number if working on one: "evaluating-PR-123"
 - Use hyphens between words: "analyzing-system-design"
 - If idle: "idle-monitoring-for-work" or "awaiting-tasks"
 
@@ -1233,7 +1234,7 @@ Keep it brief (3-6 words) and descriptive:
 
 **When running autonomously, clear your context at the end of each iteration to save API costs.**
 
-After completing your iteration (reviewing a PR and updating labels), execute:
+After completing your iteration (evaluating a PR and updating labels), execute:
 
 ```
 /clear
@@ -1247,12 +1248,12 @@ After completing your iteration (reviewing a PR and updating labels), execute:
 
 ### When to Clear
 
-- ✅ **After completing a review** (PR approved or changes requested)
-- ✅ **When no work is available** (no PRs to review)
+- ✅ **After completing an evaluation** (PR approved or changes requested)
+- ✅ **When no work is available** (no PRs to evaluate)
 - ❌ **NOT during active work** (only after iteration is complete)
 
 ## Completion
 
 **Work completion is detected automatically.**
 
-When you complete your task (PR reviewed and labeled with `loom:pr` or `loom:changes-requested`), the orchestration layer detects this and terminates the session automatically. No explicit exit command is needed.
+When you complete your task (PR evaluated and labeled with `loom:pr` or `loom:changes-requested`), the orchestration layer detects this and terminates the session automatically. No explicit exit command is needed.


### PR DESCRIPTION
## Summary

Systematically renames "review" terminology throughout `judge.md` to use "judge/evaluate/assess" equivalents, creating semantic distance from the `gh pr review` API that LLMs persistently attempt to call.

**Changes made:**
- Replaced ~60 prose occurrences of "review" with "evaluate", "judge", or "assess"
- Updated terminal probe protocol from `AGENT:Reviewer` to `AGENT:Judge`
- Renamed section headers: "Review Process" → "Evaluation Process", "Review Focus Areas" → "Evaluation Focus Areas", etc.
- Updated HTML comment markers: `loom:fast-track-review` → `loom:fast-track-evaluation`

**Preserved unchanged (per issue requirements):**
- All label references (`loom:review-requested`, `loom:reviewing`)
- The `gh pr review` warning box (lines 5-29) — explicitly about what NOT to do
- All `gh pr comment` and `gh pr edit` command references
- Pre-approval checklist warnings about `gh pr review`

## Acceptance Criteria Verification

| Criterion | Status |
|-----------|--------|
| Replace "review" with judge/evaluate/assess in prose | ✅ ~60 replacements made |
| Keep label references unchanged | ✅ All `loom:review-requested` and `loom:reviewing` refs intact |
| Keep warning box about `gh pr review` | ✅ Lines 5-29 unchanged |
| Keep `gh pr comment` command references | ✅ All preserved |
| Only `defaults/.claude/commands/judge.md` modified | ✅ Single file change |

## Test Plan

- [x] `pnpm lint` passes
- [x] Verified all remaining "review" instances are label references, API warnings, or command-line label arguments
- [x] No other files reference the renamed `loom:fast-track-evaluation` marker

Closes #2072