### PR TITLE
Add graceful 'no changes needed' pathway to shepherd

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/exit_codes.py
+++ b/loom-tools/src/loom_tools/shepherd/exit_codes.py
@@ -24,6 +24,7 @@ class ShepherdExitCode(IntEnum):
     | 3         | Shutdown signal received      | Clean exit, requeue               |
     | 4         | Stuck/blocked, needs help     | Alert human                       |
     | 5         | Skipped (already complete)    | No action                         |
+    | 6         | No changes needed             | Close issue, mark complete        |
 
     Using IntEnum allows these to be used directly as exit codes:
         return ShepherdExitCode.SUCCESS
@@ -52,6 +53,10 @@ class ShepherdExitCode(IntEnum):
     # Issue was already complete (closed, merged, etc.) - nothing to do
     SKIPPED = 5
 
+    # Builder analyzed issue and determined no changes are needed
+    # The reported problem doesn't exist or is already resolved on main
+    NO_CHANGES_NEEDED = 6
+
 
 # Convenience mapping for code interpretation
 EXIT_CODE_DESCRIPTIONS = {
@@ -61,6 +66,7 @@ EXIT_CODE_DESCRIPTIONS = {
     ShepherdExitCode.SHUTDOWN: "Shutdown signal received",
     ShepherdExitCode.NEEDS_INTERVENTION: "Stuck/blocked - needs human intervention",
     ShepherdExitCode.SKIPPED: "Skipped - issue already complete",
+    ShepherdExitCode.NO_CHANGES_NEEDED: "No changes needed - problem already resolved",
 }
 
 

--- a/loom-tools/tests/shepherd/test_exit_codes.py
+++ b/loom-tools/tests/shepherd/test_exit_codes.py
@@ -43,6 +43,10 @@ class TestShepherdExitCode:
         """SKIPPED should be 5."""
         assert ShepherdExitCode.SKIPPED == 5
 
+    def test_no_changes_needed_is_six(self) -> None:
+        """NO_CHANGES_NEEDED should be 6."""
+        assert ShepherdExitCode.NO_CHANGES_NEEDED == 6
+
     def test_can_use_as_int(self) -> None:
         """Exit codes should be usable as integers."""
         assert int(ShepherdExitCode.SUCCESS) == 0
@@ -93,6 +97,11 @@ class TestDescribeExitCode:
         """Should describe SKIPPED exit code."""
         desc = describe_exit_code(5)
         assert "skip" in desc.lower() or "complete" in desc.lower()
+
+    def test_describes_no_changes_needed(self) -> None:
+        """Should describe NO_CHANGES_NEEDED exit code."""
+        desc = describe_exit_code(6)
+        assert "no changes" in desc.lower() or "resolved" in desc.lower()
 
     def test_unknown_code_returns_message(self) -> None:
         """Should return message for unknown exit codes."""

--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -5744,6 +5744,83 @@ class TestBuilderHasIncompleteWork:
         assert builder._has_incomplete_work(diag) is False
 
 
+class TestBuilderIsNoChangesNeeded:
+    """Test _is_no_changes_needed for detecting 'no changes needed' condition."""
+
+    def test_no_worktree_returns_false(self) -> None:
+        """Without worktree, cannot determine no changes needed."""
+        builder = BuilderPhase()
+        diag = {"worktree_exists": False}
+        assert builder._is_no_changes_needed(diag) is False
+
+    def test_worktree_with_no_work_returns_true(self) -> None:
+        """Worktree exists but no work done = no changes needed."""
+        builder = BuilderPhase()
+        diag = {
+            "worktree_exists": True,
+            "has_uncommitted_changes": False,
+            "commits_ahead": 0,
+            "remote_branch_exists": False,
+            "pr_number": None,
+        }
+        assert builder._is_no_changes_needed(diag) is True
+
+    def test_uncommitted_changes_returns_false(self) -> None:
+        """Uncommitted changes mean work in progress, not no changes needed."""
+        builder = BuilderPhase()
+        diag = {
+            "worktree_exists": True,
+            "has_uncommitted_changes": True,
+            "commits_ahead": 0,
+            "remote_branch_exists": False,
+            "pr_number": None,
+        }
+        assert builder._is_no_changes_needed(diag) is False
+
+    def test_commits_ahead_returns_false(self) -> None:
+        """Commits ahead mean work was done, not no changes needed."""
+        builder = BuilderPhase()
+        diag = {
+            "worktree_exists": True,
+            "has_uncommitted_changes": False,
+            "commits_ahead": 1,
+            "remote_branch_exists": False,
+            "pr_number": None,
+        }
+        assert builder._is_no_changes_needed(diag) is False
+
+    def test_remote_branch_exists_returns_false(self) -> None:
+        """Remote branch existing means work was pushed, not no changes needed."""
+        builder = BuilderPhase()
+        diag = {
+            "worktree_exists": True,
+            "has_uncommitted_changes": False,
+            "commits_ahead": 0,
+            "remote_branch_exists": True,
+            "pr_number": None,
+        }
+        assert builder._is_no_changes_needed(diag) is False
+
+    def test_pr_exists_returns_false(self) -> None:
+        """PR existing means work was done, not no changes needed."""
+        builder = BuilderPhase()
+        diag = {
+            "worktree_exists": True,
+            "has_uncommitted_changes": False,
+            "commits_ahead": 0,
+            "remote_branch_exists": True,
+            "pr_number": 100,
+        }
+        assert builder._is_no_changes_needed(diag) is False
+
+    def test_handles_missing_keys_gracefully(self) -> None:
+        """Should handle missing keys by treating them as falsy."""
+        builder = BuilderPhase()
+        # Only worktree_exists is provided, all others should default
+        diag = {"worktree_exists": True}
+        assert builder._is_no_changes_needed(diag) is True
+
+
 class TestBuilderDirectCompletion:
     """Test _direct_completion for mechanical fallback operations."""
 


### PR DESCRIPTION
## Summary
- Adds graceful handling when Builder determines no changes are needed for an issue
- New `NO_CHANGES_NEEDED` exit code (6) for shepherd orchestration
- Issue is closed with explanatory comment instead of being marked as failed
- No failure labels applied for this valid completion state

## Changes
- `exit_codes.py`: Add `NO_CHANGES_NEEDED = 6` to `ShepherdExitCode` enum
- `builder.py`: Add `_is_no_changes_needed()` detection method that checks if worktree exists but no work was done (no commits, no uncommitted changes, no remote branch, no PR)
- `cli.py`: Add `_handle_no_changes_needed()` handler that closes issue with comment and cleans up worktree
- Tests for both the new exit code and the detection logic

## Test plan
- [x] Unit tests verify `NO_CHANGES_NEEDED` exit code is 6
- [x] Unit tests verify `_is_no_changes_needed()` detection logic
- [x] Unit tests verify `describe_exit_code()` handles code 6

Closes #2096

🤖 Generated with [Claude Code](https://claude.com/claude-code)