### PR TITLE
Fix daemon self-sabotage: gitignore runtime files and fix empty args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ Thumbs.db
 .loom/.daemon.log
 .loom/daemon.sock
 .loom/daemon-state.json
+.loom/daemon-loop.pid
+.loom/daemon-metrics.json
 .loom/loom-source-path
 .loom/[0-9][0-9]-daemon-state.json
 .loom/stuck-history.json

--- a/defaults/scripts/loom-daemon.sh
+++ b/defaults/scripts/loom-daemon.sh
@@ -83,10 +83,10 @@ fi
 
 if [[ -n "$LOOM_TOOLS" ]] && [[ -x "$LOOM_TOOLS/.venv/bin/loom-daemon" ]]; then
     # Use venv from loom-tools directory
-    exec "$LOOM_TOOLS/.venv/bin/loom-daemon" "${args[@]}"
+    exec "$LOOM_TOOLS/.venv/bin/loom-daemon" ${args[@]+"${args[@]}"}
 elif command -v loom-daemon &>/dev/null; then
     # System-installed
-    exec loom-daemon "${args[@]}"
+    exec loom-daemon ${args[@]+"${args[@]}"}
 else
     echo "[ERROR] Python daemon not available." >&2
     echo "" >&2


### PR DESCRIPTION
## Summary
- Add `daemon-loop.pid` and `daemon-metrics.json` to `.gitignore` so the daemon's own runtime files don't trigger the shepherd's dirty-main check
- Fix `${args[@]}` empty array expansion in `loom-daemon.sh` that fails with `set -u`

## Test plan
- [ ] Run `/loom` without arguments — should start without `unbound variable` error
- [ ] Verify `git status` shows clean after daemon creates runtime files
- [ ] Shepherds should not fail with dirty-main check due to daemon files

Closes #2109

🤖 Generated with [Claude Code](https://claude.com/claude-code)