### PR TITLE
Fix --clean install leaving staged deletions in main

### DIFF
--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -295,6 +295,15 @@ if [[ "$CLEAN_FIRST" == "true" ]]; then
 
     echo ""
     success "Uninstall complete - proceeding with fresh installation"
+
+    # Clean up staged deletions from uninstall
+    # The uninstall ran in --local mode, staging file deletions directly in the
+    # main working directory. The fresh install will happen in a worktree, so
+    # main must stay clean to avoid leftover staged changes after completion.
+    info "Cleaning staged changes from uninstall..."
+    git -C "$TARGET_PATH" restore --staged . 2>/dev/null || true
+    git -C "$TARGET_PATH" checkout -- . 2>/dev/null || true
+
     echo ""
   else
     info "No existing Loom installation detected - proceeding with fresh install"


### PR DESCRIPTION
## Summary

- Fixes `--clean` install leaving staged file deletions in the main working directory after completion
- Adds `git restore --staged .` and `git checkout -- .` cleanup immediately after the uninstall phase, before worktree creation
- Mirrors the existing cleanup pattern already present in the `NO_CHANGES_NEEDED` early-exit path (lines 750-754)

Closes #2126

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Staged deletions cleaned after uninstall | Done | `restore --staged` + `checkout` added after line 297 |
| Cleanup only runs when uninstall actually ran | Done | Inside `if [[ -d "$TARGET_PATH/.loom" ]]` block |
| Mirrors existing cleanup pattern | Done | Same `git -C` commands as lines 752-753 |
| No impact on fresh install (no existing .loom) | Done | Cleanup is inside the existing-installation branch |

## Test plan

- [ ] Run `./scripts/install-loom.sh --clean -y /path/to/target` on a repo with existing Loom — verify `git status` shows clean working directory after completion
- [ ] After PR merge, `git checkout main && git pull` in target repo succeeds with no conflicts
- [ ] Run `--clean` install when target already has latest version — should hit existing cleanup at line 750 and exit cleanly
- [ ] Run `--clean` install when target has no `.loom` directory — should skip uninstall entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)