### PR TITLE
Fix daemon runtime files missing from .gitignore template

### DIFF
--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -204,10 +204,8 @@ Thumbs.db
 *.log
 logs/
 
-# Loom (will be added by installation)
-# .loom/state.json
-# .loom/worktrees/
-# .loom/*.log
+# Loom runtime state (added by loom-daemon init)
+# These patterns are also managed by loom-daemon's update_gitignore().
 GITIGNORE
     success "Created .gitignore"
   fi


### PR DESCRIPTION
## Summary

- Expanded `update_gitignore()` in `loom-daemon/src/init/post_init.rs` to include all 30 daemon runtime file patterns (previously only 3)
- Added 4 comprehensive unit tests covering creation, append, idempotency, and completeness
- Updated `scripts/install-loom.sh` .gitignore template to defer to daemon-managed patterns

## Problem

The daemon creates runtime files (`.loom/progress/`, `.loom/logs/`, `.loom/daemon-metrics.json`, etc.) that weren't in the `.gitignore` template. This caused all shepherds to fail with exit code 4 (dirty repo check) because these files appeared as untracked changes. In observed sessions, all 3 shepherds were blocked for the entire 45-minute daemon session.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `.loom/daemon-metrics.json` in .gitignore | Done | Added to ephemeral_patterns list |
| `.loom/logs/` in .gitignore | Done | Added to ephemeral_patterns list |
| `.loom/progress/` in .gitignore | Done | Added to ephemeral_patterns list |
| All source repo .gitignore patterns covered | Done | `covers_all_source_repo_gitignore_patterns` test verifies all 30 patterns |
| No duplicate entries on re-run | Done | `does_not_duplicate_patterns_on_repeated_runs` test verifies idempotency |

## Test plan

- [ ] `cargo test -p loom-daemon` passes (4 new tests in `post_init::tests`)
- [ ] Manual verification: start daemon, confirm shepherds no longer fail dirty repo check

Closes #2128

🤖 Generated with [Claude Code](https://claude.com/claude-code)