### PR TITLE
Replace sed ANSI stripping with Python log filter for cleaner agent logs

### DIFF
--- a/loom-tools/src/loom_tools/agent_spawn.py
+++ b/loom-tools/src/loom_tools/agent_spawn.py
@@ -513,13 +513,13 @@ def spawn_agent(
         log_error(f"Failed to create tmux session: {session_name}")
         return SpawnResult(status="error", name=name, error="session_create_failed")
 
-    # Set up output capture via pipe-pane with ANSI stripping
-    # The sed command removes:
-    # - Standard ANSI escape sequences: ESC[...m (colors, cursor, etc.)
-    # - Terminal mode queries: ESC[?...h/l (like ?2026h/l)
-    # - OSC sequences: ESC]...BEL (title setting, etc.)
+    # Set up output capture via pipe-pane with Python log filter
+    # The Python filter handles ANSI stripping, CR processing,
+    # blank line suppression, and duplicate line collapsing.
+    # Falls back to basic sed stripping if Python filter is unavailable.
     strip_ansi_cmd = (
-        f"sed -E 's/\\x1b\\[[?0-9;]*[a-zA-Z]//g; "
+        f"python3 -m loom_tools.log_filter >> '{log_file}' 2>/dev/null "
+        f"|| sed -E 's/\\x1b\\[[?0-9;]*[a-zA-Z]//g; "
         f"s/\\x1b\\][^\\x07]*\\x07//g' "
         f">> '{log_file}'"
     )

--- a/loom-tools/src/loom_tools/common/logging.py
+++ b/loom-tools/src/loom_tools/common/logging.py
@@ -22,7 +22,7 @@ _ANSI_ESCAPE_PATTERN = re.compile(
     \x1b  # ESC character
     (?:
         \[  # CSI sequences: ESC [
-        [0-9;]*  # parameters
+        [?0-9;]*  # parameters (including ? for private modes)
         [A-Za-z]  # final character
         |
         \]  # OSC sequences: ESC ]

--- a/loom-tools/src/loom_tools/log_filter.py
+++ b/loom-tools/src/loom_tools/log_filter.py
@@ -1,0 +1,110 @@
+"""Stdin-to-stdout log filter for tmux pipe-pane output.
+
+Replaces the sed-based ANSI stripping with a Python filter that handles:
+- ANSI escape sequence stripping (via strip_ansi)
+- Carriage return processing (keep only final line segment)
+- Backspace character removal
+- Blank/whitespace-only line suppression
+- Consecutive duplicate line collapsing (spinner frame deduplication)
+- Non-printable character cleanup
+
+Usage in pipe-pane:
+    python3 -m loom_tools.log_filter >> /path/to/log.log
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import unicodedata
+
+from loom_tools.common.logging import strip_ansi
+
+# Characters to strip beyond ANSI sequences
+_CONTROL_CHARS = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+
+
+def clean_line(raw: str) -> str | None:
+    """Clean a single line of terminal output.
+
+    Returns the cleaned line, or None if the line should be suppressed.
+    """
+    # Process carriage returns: keep only the last segment
+    # This handles spinner animation where lines are overwritten with \r
+    if "\r" in raw:
+        segments = raw.split("\r")
+        raw = segments[-1]
+
+    # Strip ANSI escape sequences
+    line = strip_ansi(raw)
+
+    # Remove backspace characters and the character they erase
+    while "\x08" in line:
+        # Remove char + backspace pair, or leading backspace
+        line = re.sub(r"[^\x08]\x08", "", line, count=1)
+        line = re.sub(r"^\x08+", "", line)
+
+    # Remove remaining control characters (except \n, \t)
+    line = _CONTROL_CHARS.sub("", line)
+
+    # Remove Unicode control/format characters (category Cc/Cf) except common ones
+    cleaned = []
+    for ch in line:
+        cat = unicodedata.category(ch)
+        if cat == "Cc" and ch not in ("\n", "\t"):
+            continue
+        if cat == "Cf":
+            continue
+        cleaned.append(ch)
+    line = "".join(cleaned)
+
+    # Suppress blank/whitespace-only lines
+    if not line.strip():
+        return None
+
+    return line
+
+
+def main() -> None:
+    """Read stdin line by line, clean, deduplicate, and write to stdout."""
+    prev_line: str | None = None
+    dup_count = 0
+
+    try:
+        for raw_line in sys.stdin:
+            # Remove trailing newline for processing
+            raw = raw_line.rstrip("\n")
+
+            cleaned = clean_line(raw)
+            if cleaned is None:
+                continue
+
+            # Collapse consecutive duplicate lines
+            if cleaned == prev_line:
+                dup_count += 1
+                continue
+
+            # If we had duplicates, emit a summary
+            if dup_count > 0 and prev_line is not None:
+                sys.stdout.write(f"  [repeated {dup_count} more time{'s' if dup_count > 1 else ''}]\n")
+                sys.stdout.flush()
+
+            sys.stdout.write(cleaned + "\n")
+            sys.stdout.flush()
+            prev_line = cleaned
+            dup_count = 0
+
+    except (BrokenPipeError, KeyboardInterrupt):
+        pass
+    finally:
+        # Flush any trailing duplicate count
+        if dup_count > 0 and prev_line is not None:
+            try:
+                sys.stdout.write(f"  [repeated {dup_count} more time{'s' if dup_count > 1 else ''}]\n")
+                sys.stdout.flush()
+            except (BrokenPipeError, OSError):
+                pass
+
+
+if __name__ == "__main__":
+    main()

--- a/loom-tools/tests/test_agent_spawn.py
+++ b/loom-tools/tests/test_agent_spawn.py
@@ -444,8 +444,8 @@ class TestAnsiStripping:
         assert strip_ansi(colored_with_title) == expected
 
     @patch("loom_tools.agent_spawn._tmux")
-    def test_spawn_agent_uses_sed_filter(self, mock_tmux: MagicMock) -> None:
-        """Test that spawn_agent sets up pipe-pane with sed ANSI stripping."""
+    def test_spawn_agent_uses_python_log_filter(self, mock_tmux: MagicMock) -> None:
+        """Test that spawn_agent sets up pipe-pane with Python log filter."""
         from loom_tools.agent_spawn import spawn_agent
 
         mock_tmux.return_value = subprocess.CompletedProcess(
@@ -481,10 +481,13 @@ class TestAnsiStripping:
 
             assert len(pipe_pane_calls) >= 1, "pipe-pane should be called"
 
-            # Check the pipe-pane command includes sed with ANSI stripping
+            # Check the pipe-pane command uses Python log filter with sed fallback
             pipe_pane_call = pipe_pane_calls[0]
             pipe_cmd = pipe_pane_call[0][3] if len(pipe_pane_call[0]) > 3 else ""
 
-            assert "sed" in pipe_cmd, f"pipe-pane should use sed, got: {pipe_cmd}"
-            assert "\\x1b" in pipe_cmd, f"sed command should strip ANSI sequences: {pipe_cmd}"
-            assert ">>" in pipe_cmd, f"sed command should append to log file: {pipe_cmd}"
+            assert "python3 -m loom_tools.log_filter" in pipe_cmd, \
+                f"pipe-pane should use Python log filter, got: {pipe_cmd}"
+            assert "sed" in pipe_cmd, \
+                f"pipe-pane should include sed fallback, got: {pipe_cmd}"
+            assert ">>" in pipe_cmd, \
+                f"command should append to log file: {pipe_cmd}"


### PR DESCRIPTION
## Summary

Replaces the basic `sed` ANSI-stripping pipeline in tmux `pipe-pane` with a Python-based log filter (`loom_tools.log_filter`) that properly cleans terminal output for readable log files.

### Changes
- **New `loom_tools/log_filter.py`**: Handles ANSI escape sequences, carriage return processing, backspace removal, blank line suppression, and consecutive duplicate line collapsing
- **Updated `agent_spawn.py`**: Uses the Python filter as the pipe-pane command, with sed fallback
- **Updated tests**: Adapted agent_spawn tests for new filter command

Closes #2130