### PR TITLE
Handle exit code 6 (instant-exit) in judge phase

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/judge.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/judge.py
@@ -148,6 +148,18 @@ class JudgePhase:
                 phase_name="judge",
             )
 
+        if exit_code == 6:
+            # Instant-exit: CLI sessions exited in <5s with no output after retries
+            self._mark_issue_blocked(
+                ctx, "judge_instant_exit", "agent instant-exit after retry"
+            )
+            return PhaseResult(
+                status=PhaseStatus.FAILED,
+                message="judge instant-exit after retry (CLI sessions exited in <5s with no output)",
+                phase_name="judge",
+                data={"instant_exit": True},
+            )
+
         # Invalidate caches BEFORE validation so the first attempt
         # fetches fresh data instead of stale cached labels.
         ctx.label_cache.invalidate_pr(ctx.pr_number)


### PR DESCRIPTION
## Summary

- Adds explicit exit code 6 handling in `JudgePhase.run()` between the exit code 4 (stuck) handler and the validation block
- When `run_phase_with_retry` returns 6 (CLI sessions exited in <5s with no output after all retries), the judge phase now marks the issue as blocked with `judge_instant_exit` error class and returns `PhaseStatus.FAILED` with `instant_exit: True` data
- Previously, exit code 6 fell through to validation (which would also fail), producing misleading diagnostics that masked the actual root cause

## Test plan

- [x] Added `test_exit_code_6_instant_exit_marks_blocked` - verifies exit code 6 produces FAILED status with correct data, calls `_mark_issue_blocked` with `judge_instant_exit`, and does NOT proceed to validation
- [x] Added `test_exit_code_6_in_force_mode_skips_fallback` - verifies force mode doesn't attempt fallback approval detection for instant-exit (no comments exist to detect)
- [x] All 487 existing phase tests pass
- [x] Source file passes ruff lint

## Criterion Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Exit code 6 returns `PhaseStatus.FAILED` with `instant_exit: True` | Verified | `test_exit_code_6_instant_exit_marks_blocked` |
| Issue marked blocked with `judge_instant_exit` error class | Verified | `_mark_issue_blocked` called with correct args |
| Validation not called on exit code 6 | Verified | `mock_validate.assert_not_called()` |
| Force mode skips fallback on exit code 6 | Verified | `test_exit_code_6_in_force_mode_skips_fallback` |

Closes #2139

🤖 Generated with [Claude Code](https://claude.com/claude-code)