### PR TITLE
Guard against missing .loom/scripts when branch predates Loom install

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/context.py
+++ b/loom-tools/src/loom_tools/shepherd/context.py
@@ -113,8 +113,17 @@ class ShepherdContext:
 
         Returns:
             CompletedProcess result
+
+        Raises:
+            FileNotFoundError: If the script does not exist (e.g. the
+                working tree is on a branch that predates Loom installation).
         """
         script_path = self.scripts_dir / script_name
+        if not script_path.is_file():
+            raise FileNotFoundError(
+                f"Script not found: {script_path} — "
+                "the branch may predate Loom installation"
+            )
         cmd = [str(script_path), *args]
         return subprocess.run(
             cmd,

--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -218,6 +218,12 @@ class BuilderPhase:
                     capture=True,
                 )
                 ctx.report_milestone("worktree_created", path=str(ctx.worktree_path))
+            except FileNotFoundError as exc:
+                return PhaseResult(
+                    status=PhaseStatus.FAILED,
+                    message=str(exc),
+                    phase_name="builder",
+                )
             except subprocess.CalledProcessError as exc:
                 detail = (exc.stderr or exc.stdout or "").strip()
                 msg = "failed to create worktree"

--- a/loom-tools/src/loom_tools/shepherd/phases/merge.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/merge.py
@@ -47,6 +47,12 @@ class MergePhase:
                     phase_name="merge",
                     data={"merged": True},
                 )
+            except FileNotFoundError as exc:
+                return PhaseResult(
+                    status=PhaseStatus.FAILED,
+                    message=str(exc),
+                    phase_name="merge",
+                )
             except subprocess.CalledProcessError:
                 self._mark_issue_blocked(
                     ctx, "merge_failed", f"failed to merge PR #{ctx.pr_number}"


### PR DESCRIPTION
## Summary

Closes #2147

- Adds `is_file()` guards in `run_worker_phase` for `agent-spawn.sh`, `agent-wait-bg.sh`, and `agent-destroy.sh` scripts — missing spawn/wait returns exit code 1 gracefully, missing destroy silently skips cleanup
- Adds `FileNotFoundError` guard in `ShepherdContext.run_script()` with a descriptive error message about the branch predating Loom installation
- Adds `FileNotFoundError` handling in builder and merge phase callers of `run_script`
- Adds 5 new tests covering all missing-script scenarios
- Updates existing test fixtures to use `tmp_path` with real script files (required by the new guards)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|-------------|
| No crash when `.loom/scripts/` is missing | Pass | `is_file()` guards return exit code 1 or skip cleanup instead of crashing |
| Clear error message | Pass | Warning log includes "the branch may predate Loom installation" |
| All existing tests pass | Pass | 2258 passed, 32 skipped, 0 new failures (3 pre-existing failures in `test_agent_monitor.py::TestSignalChecking` unrelated to this change) |
| New tests for missing scripts | Pass | 5 new tests: 3 in `test_phases.py`, 2 in `test_context.py` |

## Test plan

- [x] Run full test suite: `PYTHONPATH=src python3 -m pytest tests/` — 2258 passed
- [x] New tests cover: missing spawn script, missing wait script, missing destroy script, missing `run_script` target, existing script works normally
- [x] Verified pre-existing test failures are unrelated (signal checking tests fail on main too)