### PR TITLE
Reset stall counter after L3 pool restart

### DIFF
--- a/loom-tools/src/loom_tools/daemon_v2/iteration.py
+++ b/loom-tools/src/loom_tools/daemon_v2/iteration.py
@@ -351,3 +351,5 @@ def _escalate_level_3(ctx: DaemonContext) -> None:
             log_info(f"STALL-L3: Cleared {cleared} stale progress file(s)")
 
     log_success(f"STALL-L3: Pool restart complete - killed {killed} session(s)")
+
+    ctx.consecutive_stalled = 0

--- a/loom-tools/tests/daemon_v2/test_stall_escalation.py
+++ b/loom-tools/tests/daemon_v2/test_stall_escalation.py
@@ -353,6 +353,15 @@ class TestEscalateLevel3:
         _escalate_level_3(ctx)  # Should not raise
 
     @patch("loom_tools.daemon_v2.iteration.kill_stuck_session")
+    @patch("loom_tools.daemon_v2.iteration.session_exists", return_value=False)
+    def test_resets_stall_counter(self, mock_exists, mock_kill):
+        """Level 3 should reset consecutive_stalled to 0 after execution."""
+        ctx = _make_ctx(stalled=10)
+        ctx.state = DaemonState()
+        _escalate_level_3(ctx)
+        assert ctx.consecutive_stalled == 0
+
+    @patch("loom_tools.daemon_v2.iteration.kill_stuck_session")
     @patch("loom_tools.daemon_v2.iteration.session_exists", return_value=True)
     def test_reverts_issue_labels(self, mock_exists, mock_kill):
         """Level 3 should revert issue labels for reclaimed shepherds."""


### PR DESCRIPTION
## Summary

- Add `ctx.consecutive_stalled = 0` at the end of `_escalate_level_3()` to reset the stall counter after a full pool restart
- Add `test_resets_stall_counter` test in `TestEscalateLevel3` to verify the counter reset

## Why

Without this reset, once the stall counter reaches the L3 threshold it never resets, causing L3 (pool restart) to fire on every subsequent iteration indefinitely — a death spiral. This is the companion fix to #2150.

## Test plan

- [x] New unit test: `test_resets_stall_counter` — calls `_escalate_level_3()` with `ctx.consecutive_stalled = 10`, verifies it's `0` after
- [x] All 37 existing tests in `test_stall_escalation.py` pass unchanged

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|-------------|
| `ctx.consecutive_stalled = 0` added after `log_success()` in `_escalate_level_3()` | Done | Line 356 of `iteration.py` |
| New test `test_resets_stall_counter` in `TestEscalateLevel3` | Done | Line 355 of `test_stall_escalation.py` |
| Existing tests unaffected | Done | All 37 tests pass |

Closes #2151

🤖 Generated with [Claude Code](https://claude.com/claude-code)