### PR TITLE
Downgrade ci_failing to info-level to prevent spurious stall escalation

### DIFF
--- a/loom-tools/src/loom_tools/daemon_v2/iteration.py
+++ b/loom-tools/src/loom_tools/daemon_v2/iteration.py
@@ -209,11 +209,11 @@ def _update_stall_counter(ctx: DaemonContext, result: IterationResult) -> None:
         ctx.consecutive_stalled = 0
         return
 
-    if health == "healthy":
+    if health in ("healthy", "degraded"):
         ctx.consecutive_stalled = 0
         return
 
-    # Stalled: unhealthy and no progress
+    # Stalled: warning-level issues present and no progress
     ctx.consecutive_stalled += 1
     log_warning(
         f"Consecutive stalled iterations: {ctx.consecutive_stalled} "

--- a/loom-tools/src/loom_tools/snapshot.py
+++ b/loom-tools/src/loom_tools/snapshot.py
@@ -976,7 +976,7 @@ def compute_health(
         failed_runs = ci_status.get("failed_runs", [])
         warnings.append({
             "code": "ci_failing",
-            "level": "warning",
+            "level": "info",
             "message": ci_status.get("message", f"CI failing on main: {len(failed_runs)} workflow(s) failed"),
         })
 


### PR DESCRIPTION
## Summary

- Downgrade `ci_failing` warning from `"warning"` to `"info"` level in `compute_health()`, so CI failure produces `"degraded"` health status instead of `"stalled"`
- Treat `"degraded"` health the same as `"healthy"` in `_update_stall_counter()` — reset the stall counter instead of incrementing it
- Add tests for `ci_failing` co-occurring with genuine warnings, degraded-resets-counter, and 15-iteration no-escalation edge case

Closes #2150

## Test plan

- [x] `test_ci_failing` asserts `status == "degraded"` and `level == "info"`
- [x] `test_ci_failing_with_warning_level_issue` asserts `ci_failing` (info) + `orphaned_issues` (warning) → `"stalled"`
- [x] `test_degraded_health_does_not_increment` asserts `consecutive_stalled == 0`
- [x] `test_degraded_health_resets_counter` asserts counter resets from 5 → 0
- [x] `test_ci_failing_only_does_not_escalate_over_many_iterations` asserts 15 iterations of degraded never escalates
- [x] All existing stalled-health tests still pass (2328 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)