### PR TITLE
Extend pipe-pane sed filter to strip CR, BS, and bare escapes

### DIFF
--- a/defaults/scripts/cli/loom-logs.sh
+++ b/defaults/scripts/cli/loom-logs.sh
@@ -174,9 +174,11 @@ get_log_path() {
     return 1
 }
 
-# Strip ANSI escape codes (optional, for cleaner output)
+# Strip ANSI escape codes and terminal control characters for cleaner output.
+# Removes CSI sequences, OSC sequences, carriage returns, backspaces,
+# and bare escape sequences.
 strip_ansi() {
-    sed 's/\x1b\[[0-9;]*m//g'
+    sed -E 's/\x1b\[[?0-9;]*[a-zA-Z]//g; s/\x1b\][^\x07]*\x07//g; s/\r//g; s/\x08//g; s/\x1b[^][]//g'
 }
 
 # Main logic

--- a/defaults/scripts/lib/pipe-pane-cmd.sh
+++ b/defaults/scripts/lib/pipe-pane-cmd.sh
@@ -8,6 +8,9 @@
 #   - Standard ANSI escape sequences: ESC[...letter (colors, cursor, modes)
 #   - Terminal mode queries: ESC[?...h/l (like ?2026h/l)
 #   - OSC sequences: ESC]...BEL (title setting, etc.)
+#   - Carriage returns (\r) from TUI line rewriting
+#   - Backspaces (\x08) from cursor corrections
+#   - Bare escape sequences (ESC not followed by [ or ]) from raw cursor movement
 #
 # Usage:
 #   source "$(dirname "${BASH_SOURCE[0]}")/lib/pipe-pane-cmd.sh"
@@ -24,5 +27,5 @@ pipe_pane_cmd() {
         echo "pipe_pane_cmd: log_file argument required" >&2
         return 1
     fi
-    echo "sed -E 's/\\x1b\\[[?0-9;]*[a-zA-Z]//g; s/\\x1b\\][^\\x07]*\\x07//g' >> '${log_file}'"
+    echo "sed -E 's/\\x1b\\[[?0-9;]*[a-zA-Z]//g; s/\\x1b\\][^\\x07]*\\x07//g; s/\\r//g; s/\\x08//g; s/\\x1b[^][]//g' >> '${log_file}'"
 }

--- a/loom-daemon/src/terminal.rs
+++ b/loom-daemon/src/terminal.rs
@@ -11,8 +11,11 @@ use std::process::Command;
 /// - Standard ANSI escape sequences: ESC[...letter (colors, cursor, modes)
 /// - Terminal mode queries: ESC[?...h/l (like ?2026h/l)
 /// - OSC sequences: ESC]...BEL (title setting, etc.)
+/// - Carriage returns (\r) from TUI line rewriting
+/// - Backspaces (\x08) from cursor corrections
+/// - Bare escape sequences (ESC not followed by [ or ]) from raw cursor movement
 fn pipe_pane_cmd(output_file: &str) -> String {
-    format!("sed -E 's/\\x1b\\[[?0-9;]*[a-zA-Z]//g; s/\\x1b\\][^\\x07]*\\x07//g' >> {output_file}")
+    format!("sed -E 's/\\x1b\\[[?0-9;]*[a-zA-Z]//g; s/\\x1b\\][^\\x07]*\\x07//g; s/\\r//g; s/\\x08//g; s/\\x1b[^][]//g' >> {output_file}")
 }
 
 pub struct TerminalManager {


### PR DESCRIPTION
## Summary

The log capture pipeline only stripped CSI and OSC escape sequences, leaving carriage returns (`\r`), backspaces (`\x08`), and bare escape sequences from Claude Code's TUI in the output. This caused garbled log files that made daemon monitoring and stuck detection unreliable.

- Added three new sed substitution rules (`\r`, `\x08`, bare `ESC`) to the pipe-pane filter
- Updated all three locations where the filter is defined: `pipe-pane-cmd.sh`, `terminal.rs`, `loom-logs.sh`
- Synchronized doc comments across all three files

## Test plan

- [ ] Verify `pipe-pane-cmd.sh` outputs the updated sed command with all 5 substitution rules
- [ ] Verify `terminal.rs` `pipe_pane_cmd()` generates matching sed command
- [ ] Verify `loom-logs.sh` `strip_ansi()` function uses the same regex set
- [ ] Run a terminal session and confirm log output is free of `\r`, `\x08`, and bare escape artifacts

Closes #2156

🤖 Generated with [Claude Code](https://claude.com/claude-code)