### PR TITLE
Add contradictory label detection and exclusion group enforcement

### DIFF
--- a/loom-tools/src/loom_tools/health_check.py
+++ b/loom-tools/src/loom_tools/health_check.py
@@ -47,6 +47,7 @@ from loom_tools.common.repo import find_repo_root
 from loom_tools.common.state import read_daemon_state, read_json_file
 from loom_tools.common.time_utils import elapsed_seconds, format_duration, now_utc
 from loom_tools.models.daemon_state import DaemonState
+from loom_tools.shepherd.labels import LABEL_EXCLUSION_GROUPS
 
 
 # Default thresholds
@@ -116,6 +117,7 @@ class PipelineState:
     review_requested: list[dict[str, Any]] = field(default_factory=list)
     ready_to_merge: list[dict[str, Any]] = field(default_factory=list)
     blocked: list[dict[str, Any]] = field(default_factory=list)
+    changes_requested: list[dict[str, Any]] = field(default_factory=list)
 
     @property
     def ready_count(self) -> int:
@@ -154,6 +156,7 @@ class HealthReport:
     pipeline: PipelineState = field(default_factory=PipelineState)
     orphaned_building: list[int] = field(default_factory=list)
     stale_building: list[StaleIssue] = field(default_factory=list)
+    contradictory_labels: list[dict[str, Any]] = field(default_factory=list)
     support_roles: list[SupportRoleStatus] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
     criticals: list[str] = field(default_factory=list)
@@ -251,6 +254,7 @@ def get_pipeline_state() -> PipelineState:
         (["pr", "list", "--label", "loom:review-requested", "--state", "open", "--json", "number,title"],),
         (["pr", "list", "--label", "loom:pr", "--state", "open", "--json", "number,title"],),
         (["issue", "list", "--label", "loom:blocked", "--state", "open", "--json", "number,title"],),
+        (["pr", "list", "--label", "loom:changes-requested", "--state", "open", "--json", "number,title"],),
     ]
 
     results = gh_parallel_queries(queries)
@@ -261,6 +265,7 @@ def get_pipeline_state() -> PipelineState:
         review_requested=results[2],
         ready_to_merge=results[3],
         blocked=results[4],
+        changes_requested=results[5],
     )
 
 


### PR DESCRIPTION
## Summary

- Define `LABEL_EXCLUSION_GROUPS` in `labels.py` with two exclusion groups: PR states (`loom:pr`, `loom:changes-requested`, `loom:review-requested`) and issue states (`loom:issue`, `loom:building`, `loom:blocked`)
- Add `enforce_exclusion` keyword argument to `transition_labels()` that automatically removes conflicting labels from the same exclusion group when adding a label
- Add `detect_contradictory_labels()` to `snapshot.py` that leverages existing parallel pipeline queries to find entities with mutually exclusive labels — no additional API calls needed
- Surface contradictory label warnings in `compute_health()` and include them in the validation section of the snapshot output

## Test plan

- [x] All 134 tests in `test_health_check.py` and `test_snapshot.py` pass
- [x] Pre-existing failure in `test_agent_monitor.py` is unrelated (async plugin missing)
- [ ] Judge verifies exclusion group definitions match the label state machine
- [ ] Judge verifies `detect_contradictory_labels()` correctly maps pipeline keys to labels

Closes #2161

🤖 Generated with [Claude Code](https://claude.com/claude-code)