### PR TITLE
Fix PreToolUse hook error infinite retry loop (#2159)

### DIFF
--- a/defaults/scripts/claude-wrapper.sh
+++ b/defaults/scripts/claude-wrapper.sh
@@ -226,7 +226,8 @@ start_output_monitor() {
                 local found_error=false
                 for pattern in "500 Internal Server Error" "Rate limit exceeded" \
                     "overloaded" "temporarily unavailable" "503 Service" \
-                    "502 Bad Gateway" "No messages returned"; do
+                    "502 Bad Gateway" "No messages returned" \
+                    "PreToolUse.*hook error"; do
                     if echo "${tail_content}" | grep -qi "${pattern}" 2>/dev/null; then
                         found_error=true
                         break


### PR DESCRIPTION
## Summary

- Make `guard-destructive.sh` resilient to all internal errors by replacing `set -euo pipefail` with an ERR trap that always exits 0, preventing Claude Code from displaying "PreToolUse:Bash hook error"
- Add `PreToolUse.*hook error` pattern to `claude-wrapper.sh` output monitor as a safety net for any remaining hook failures
- Add diagnostic logging to `.loom/logs/hook-errors.log` for debugging hook issues

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `guard-destructive.sh` never exits with hook error | Verified | ERR trap catches all errors, exits 0. Tested with invalid JSON, empty stdin, non-existent cwd, missing jq |
| `claude-wrapper.sh` detects repeated hook errors | Verified | Added `PreToolUse.*hook error` to output monitor pattern list, uses existing idle timeout (60s default) |
| Shepherd phase retry handles hook-error termination | Verified | Output monitor sends SIGINT → claude exits non-zero → `run_phase_with_retry` handles restart |
| Diagnostic logging for debugging | Verified | Errors logged to `.loom/logs/hook-errors.log` with timestamps, line numbers, error context |

## Changes

### `.loom/hooks/guard-destructive.sh`
- Removed `set -euo pipefail` (was causing script to exit on any command failure)
- Added ERR trap that logs error and exits 0 (allow) on any unexpected failure
- Added `log_hook_error()` for diagnostic logging to `.loom/logs/hook-errors.log`
- Added `jq` availability check before parsing
- Made stdin reading resilient (`cat 2>/dev/null || INPUT=""`)
- Made jq parsing resilient (`|| COMMAND=""`, `|| CWD=""`)
- Added `[[ -d "$CWD" ]]` check before running git in cwd (handles deleted worktrees)
- Added fallback raw JSON output in `deny()` and `ask()` if jq fails

### `defaults/scripts/claude-wrapper.sh`
- Added `PreToolUse.*hook error` to output monitor error pattern list

## Test plan

- [x] `guard-destructive.sh` with valid JSON + valid cwd → allows (exit 0, no output)
- [x] `guard-destructive.sh` with blocked command → denies with valid JSON
- [x] `guard-destructive.sh` with invalid JSON stdin → allows (exit 0, no output)
- [x] `guard-destructive.sh` with empty stdin → allows (exit 0, no output)
- [x] `guard-destructive.sh` with non-existent cwd → allows, logs diagnostic
- [x] `guard-destructive.sh` with worktree cwd → works correctly
- [x] `guard-destructive.sh` with ask-pattern command → outputs valid ask JSON
- [x] Diagnostic log created at `.loom/logs/hook-errors.log` with correct format
- [x] Bash syntax validation passes for both scripts

Closes #2159

🤖 Generated with [Claude Code](https://claude.com/claude-code)