### PR TITLE
Fix judge/shepherd review workflow mismatch causing systematic judge_exhausted (#2157)

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/config.py
+++ b/loom-tools/src/loom_tools/shepherd/config.py
@@ -165,7 +165,7 @@ class ShepherdConfig:
         default_factory=lambda: env_int("LOOM_DOCTOR_MAX_RETRIES", 3)
     )
     judge_max_retries: int = field(
-        default_factory=lambda: env_int("LOOM_JUDGE_MAX_RETRIES", 1)
+        default_factory=lambda: env_int("LOOM_JUDGE_MAX_RETRIES", 3)
     )
     stuck_max_retries: int = field(
         default_factory=lambda: env_int("LOOM_STUCK_MAX_RETRIES", 1)

--- a/loom-tools/tests/shepherd/test_cli.py
+++ b/loom-tools/tests/shepherd/test_cli.py
@@ -1150,8 +1150,8 @@ class TestJudgeRetry:
         ])
 
         ctx = _make_ctx(start_from=Phase.BUILDER)
-        # Default judge_max_retries=1, so 1 retry allowed
-        assert ctx.config.judge_max_retries == 1
+        # Default judge_max_retries=3, so 3 retries allowed
+        assert ctx.config.judge_max_retries == 3
 
         curator_inst = MockCurator.return_value
         curator_inst.should_skip.return_value = (True, "skipped via --from")
@@ -1209,6 +1209,8 @@ class TestJudgeRetry:
         ])
 
         ctx = _make_ctx(start_from=Phase.BUILDER)
+        # Use judge_max_retries=1 for this test to focus on exhaustion logic
+        ctx.config.judge_max_retries = 1
 
         curator_inst = MockCurator.return_value
         curator_inst.should_skip.return_value = (True, "skipped via --from")
@@ -1410,7 +1412,7 @@ class TestJudgeRetry:
         ]
         assert len(retry_calls) == 1
         assert retry_calls[0].kwargs["attempt"] == 1
-        assert retry_calls[0].kwargs["max_retries"] == 1
+        assert retry_calls[0].kwargs["max_retries"] == 3
         assert "validation failed" in retry_calls[0].kwargs["reason"]
 
 

--- a/loom-tools/tests/shepherd/test_config.py
+++ b/loom-tools/tests/shepherd/test_config.py
@@ -190,7 +190,7 @@ class TestShepherdConfig:
         """Default retry limits should be set."""
         config = ShepherdConfig(issue=42)
         assert config.doctor_max_retries == 3
-        assert config.judge_max_retries == 1
+        assert config.judge_max_retries == 3
         assert config.stuck_max_retries == 1
 
     def test_judge_max_retries_env_override(self) -> None:


### PR DESCRIPTION
## Summary

- Remove `_has_changes_requested_review()` which checked GitHub's native review API — the judge agent uses a comment + label workflow ("judging"), so native review state is never populated
- Align fallback detection, diagnostics, and summary messages to use comment-based judging workflow instead of GitHub review terminology
- Increase `judge_max_retries` default from 1 to 3 to prevent premature `judge_exhausted` on transient failures

## Changes

| File | Change |
|------|--------|
| `shepherd/config.py` | `judge_max_retries` default 1 → 3 |
| `shepherd/phases/judge.py` | Remove `_has_changes_requested_review()`, update fallback to use rejection comments only, align diagnostics terminology |
| `tests/shepherd/test_cli.py` | Update retry count assertions |
| `tests/shepherd/test_config.py` | Update default config assertion |
| `tests/shepherd/test_phases.py` | Remove review-state patches, update diagnostic string assertions |

## Test plan

- [ ] Existing shepherd tests pass with updated assertions
- [ ] Judge fallback changes-requested detection works via rejection comments only
- [ ] Diagnostics report "no judge comments detected" instead of "no GitHub reviews"
- [ ] Default retry count is 3 (env override still works)

Closes #2157