### PR TITLE
Add persistent cross-session failure tracking for daemon issues

### DIFF
--- a/loom-tools/src/loom_tools/common/issue_failures.py
+++ b/loom-tools/src/loom_tools/common/issue_failures.py
@@ -1,0 +1,262 @@
+"""Persistent cross-session failure log for issues.
+
+Writes failure history to ``.loom/issue-failures.json`` so that retry metadata
+survives daemon restarts. The in-memory ``blocked_issue_retries`` dict in
+``daemon-state.json`` is ephemeral per session; this file provides the
+durable record.
+
+File format::
+
+    {
+        "entries": {
+            "42": {
+                "issue": 42,
+                "total_failures": 3,
+                "error_class": "builder_stuck",
+                "phase": "builder",
+                "details": "timed out after 30 minutes",
+                "first_failure_at": "2026-01-20T10:00:00Z",
+                "last_failure_at": "2026-01-22T14:30:00Z",
+                "last_success_at": null
+            }
+        },
+        "updated_at": "2026-01-22T14:30:00Z"
+    }
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from loom_tools.common.paths import LoomPaths
+from loom_tools.common.state import read_json_file, write_json_file
+
+logger = logging.getLogger(__name__)
+
+# After this many total failures, auto-block the issue
+MAX_FAILURES_BEFORE_BLOCK = 5
+
+# Backoff schedule: attempt -> iterations to skip
+# 1st failure: 0, 2nd: 2, 3rd: 4, 4th: 8, 5th: auto-block
+BACKOFF_BASE = 2
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@dataclass
+class IssueFailureEntry:
+    """Persistent failure record for a single issue."""
+
+    issue: int = 0
+    total_failures: int = 0
+    error_class: str = "unknown"
+    phase: str = ""
+    details: str = ""
+    first_failure_at: str | None = None
+    last_failure_at: str | None = None
+    last_success_at: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> IssueFailureEntry:
+        return cls(
+            issue=data.get("issue", 0),
+            total_failures=data.get("total_failures", 0),
+            error_class=data.get("error_class", "unknown"),
+            phase=data.get("phase", ""),
+            details=data.get("details", ""),
+            first_failure_at=data.get("first_failure_at"),
+            last_failure_at=data.get("last_failure_at"),
+            last_success_at=data.get("last_success_at"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "issue": self.issue,
+            "total_failures": self.total_failures,
+            "error_class": self.error_class,
+            "phase": self.phase,
+            "details": self.details,
+        }
+        if self.first_failure_at is not None:
+            d["first_failure_at"] = self.first_failure_at
+        if self.last_failure_at is not None:
+            d["last_failure_at"] = self.last_failure_at
+        if self.last_success_at is not None:
+            d["last_success_at"] = self.last_success_at
+        return d
+
+    def backoff_iterations(self) -> int:
+        """Calculate number of daemon iterations to skip before retrying.
+
+        Schedule:
+            1st failure: 0 iterations (retry immediately)
+            2nd failure: 2 iterations
+            3rd failure: 4 iterations
+            4th failure: 8 iterations
+            5th+: should be auto-blocked (MAX_FAILURES_BEFORE_BLOCK)
+        """
+        if self.total_failures <= 1:
+            return 0
+        if self.total_failures >= MAX_FAILURES_BEFORE_BLOCK:
+            return -1  # Signal: should be auto-blocked
+        return BACKOFF_BASE ** (self.total_failures - 1)
+
+    @property
+    def should_auto_block(self) -> bool:
+        return self.total_failures >= MAX_FAILURES_BEFORE_BLOCK
+
+
+@dataclass
+class IssueFailureLog:
+    """The full persistent failure log."""
+
+    entries: dict[str, IssueFailureEntry] = field(default_factory=dict)
+    updated_at: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> IssueFailureLog:
+        entries_raw = data.get("entries", {})
+        entries = {
+            k: IssueFailureEntry.from_dict(v)
+            for k, v in entries_raw.items()
+        }
+        return cls(
+            entries=entries,
+            updated_at=data.get("updated_at"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "entries": {k: v.to_dict() for k, v in self.entries.items()},
+            "updated_at": self.updated_at,
+        }
+
+
+def load_failure_log(repo_root: Path) -> IssueFailureLog:
+    """Load the persistent failure log from disk.
+
+    Returns an empty log if the file is missing or corrupt.
+    """
+    paths = LoomPaths(repo_root)
+    fpath = paths.issue_failures_file
+
+    if not fpath.is_file():
+        return IssueFailureLog()
+
+    try:
+        data = read_json_file(fpath)
+        if isinstance(data, dict):
+            return IssueFailureLog.from_dict(data)
+    except Exception:
+        logger.warning("Corrupt issue-failures.json, starting fresh")
+
+    return IssueFailureLog()
+
+
+def save_failure_log(repo_root: Path, log: IssueFailureLog) -> None:
+    """Save the persistent failure log to disk."""
+    paths = LoomPaths(repo_root)
+    log.updated_at = _now_iso()
+    write_json_file(paths.issue_failures_file, log.to_dict())
+
+
+def record_failure(
+    repo_root: Path,
+    issue: int,
+    *,
+    error_class: str = "unknown",
+    phase: str = "",
+    details: str = "",
+) -> IssueFailureEntry:
+    """Record a failure for an issue in the persistent log.
+
+    Increments total_failures and updates metadata. Returns the updated entry.
+    """
+    log = load_failure_log(repo_root)
+    issue_key = str(issue)
+    now = _now_iso()
+
+    entry = log.entries.get(issue_key)
+    if entry is None:
+        entry = IssueFailureEntry(
+            issue=issue,
+            total_failures=0,
+            first_failure_at=now,
+        )
+
+    entry.total_failures += 1
+    entry.error_class = error_class
+    entry.phase = phase
+    entry.details = details
+    entry.last_failure_at = now
+
+    log.entries[issue_key] = entry
+    save_failure_log(repo_root, log)
+
+    logger.info(
+        "Recorded failure #%d for issue #%d (class=%s, phase=%s)",
+        entry.total_failures,
+        issue,
+        error_class,
+        phase,
+    )
+    return entry
+
+
+def record_success(repo_root: Path, issue: int) -> None:
+    """Record a successful completion for an issue.
+
+    Removes the issue from the persistent failure log since it succeeded.
+    """
+    log = load_failure_log(repo_root)
+    issue_key = str(issue)
+
+    if issue_key in log.entries:
+        del log.entries[issue_key]
+        save_failure_log(repo_root, log)
+        logger.info("Cleared failure history for issue #%d (success)", issue)
+
+
+def get_failure_entry(repo_root: Path, issue: int) -> IssueFailureEntry | None:
+    """Get the failure entry for a specific issue, or None if not tracked."""
+    log = load_failure_log(repo_root)
+    return log.entries.get(str(issue))
+
+
+def merge_into_daemon_state(
+    repo_root: Path,
+    blocked_issue_retries: dict[str, Any],
+) -> dict[str, Any]:
+    """Merge persistent failure log into daemon state's blocked_issue_retries.
+
+    For each entry in the persistent failure log, if the daemon state doesn't
+    already have retry data (or has lower counts), update it from the
+    persistent log.
+
+    Returns the merged blocked_issue_retries dict.
+    """
+    log = load_failure_log(repo_root)
+
+    for issue_key, entry in log.entries.items():
+        existing = blocked_issue_retries.get(issue_key, {})
+        existing_count = existing.get("retry_count", 0)
+
+        # Use persistent log's count if higher
+        if entry.total_failures > existing_count:
+            existing["retry_count"] = entry.total_failures
+            existing["error_class"] = entry.error_class
+            existing["last_blocked_phase"] = entry.phase
+            existing["last_blocked_details"] = entry.details
+            if entry.last_failure_at:
+                existing["last_blocked_at"] = entry.last_failure_at
+            if entry.total_failures >= MAX_FAILURES_BEFORE_BLOCK:
+                existing["retry_exhausted"] = True
+            blocked_issue_retries[issue_key] = existing
+
+    return blocked_issue_retries

--- a/loom-tools/src/loom_tools/common/paths.py
+++ b/loom-tools/src/loom_tools/common/paths.py
@@ -41,6 +41,7 @@ class LoomPaths:
     STOP_SHEPHERDS_FILE = "stop-shepherds"
     RECOVERY_EVENTS_FILE = "recovery-events.json"
     BASELINE_HEALTH_FILE = "baseline-health.json"
+    ISSUE_FAILURES_FILE = "issue-failures.json"
 
     def __init__(self, repo_root: Path) -> None:
         """Initialize with repository root path.
@@ -134,6 +135,11 @@ class LoomPaths:
     def baseline_health_file(self) -> Path:
         """Path to .loom/baseline-health.json."""
         return self.loom_dir / self.BASELINE_HEALTH_FILE
+
+    @property
+    def issue_failures_file(self) -> Path:
+        """Path to .loom/issue-failures.json."""
+        return self.loom_dir / self.ISSUE_FAILURES_FILE
 
     @property
     def recovery_events_file(self) -> Path:

--- a/loom-tools/src/loom_tools/daemon_v2/iteration.py
+++ b/loom-tools/src/loom_tools/daemon_v2/iteration.py
@@ -53,7 +53,10 @@ def run_iteration(ctx: DaemonContext) -> IterationResult:
     # 1. Capture fresh snapshot
     log_info("Capturing system state...")
     try:
-        ctx.snapshot = build_snapshot(repo_root=ctx.repo_root)
+        ctx.snapshot = build_snapshot(
+            repo_root=ctx.repo_root,
+            _current_iteration=ctx.iteration,
+        )
     except Exception as e:
         log_error(f"Failed to capture snapshot: {e}")
         return IterationResult(

--- a/loom-tools/tests/test_issue_failures.py
+++ b/loom-tools/tests/test_issue_failures.py
@@ -1,0 +1,387 @@
+"""Tests for loom_tools.common.issue_failures (persistent cross-session failure log)."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+from loom_tools.common.issue_failures import (
+    BACKOFF_BASE,
+    MAX_FAILURES_BEFORE_BLOCK,
+    IssueFailureEntry,
+    IssueFailureLog,
+    get_failure_entry,
+    load_failure_log,
+    merge_into_daemon_state,
+    record_failure,
+    record_success,
+    save_failure_log,
+)
+from loom_tools.snapshot import filter_issues_by_failure_backoff
+
+
+@pytest.fixture
+def repo(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Create a minimal repo with .loom directory."""
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".loom").mkdir()
+    return tmp_path
+
+
+def _write_failures(repo: pathlib.Path, data: dict) -> None:
+    (repo / ".loom" / "issue-failures.json").write_text(json.dumps(data))
+
+
+def _read_failures(repo: pathlib.Path) -> dict:
+    return json.loads((repo / ".loom" / "issue-failures.json").read_text())
+
+
+# ── IssueFailureEntry ──────────────────────────────────────────
+
+
+class TestIssueFailureEntry:
+    def test_backoff_first_failure(self) -> None:
+        entry = IssueFailureEntry(total_failures=1)
+        assert entry.backoff_iterations() == 0
+
+    def test_backoff_second_failure(self) -> None:
+        entry = IssueFailureEntry(total_failures=2)
+        assert entry.backoff_iterations() == BACKOFF_BASE
+
+    def test_backoff_third_failure(self) -> None:
+        entry = IssueFailureEntry(total_failures=3)
+        assert entry.backoff_iterations() == BACKOFF_BASE ** 2
+
+    def test_backoff_fourth_failure(self) -> None:
+        entry = IssueFailureEntry(total_failures=4)
+        assert entry.backoff_iterations() == BACKOFF_BASE ** 3
+
+    def test_backoff_at_max(self) -> None:
+        entry = IssueFailureEntry(total_failures=MAX_FAILURES_BEFORE_BLOCK)
+        assert entry.backoff_iterations() == -1
+
+    def test_should_auto_block_false(self) -> None:
+        entry = IssueFailureEntry(total_failures=4)
+        assert entry.should_auto_block is False
+
+    def test_should_auto_block_true(self) -> None:
+        entry = IssueFailureEntry(total_failures=MAX_FAILURES_BEFORE_BLOCK)
+        assert entry.should_auto_block is True
+
+    def test_round_trip(self) -> None:
+        entry = IssueFailureEntry(
+            issue=42,
+            total_failures=3,
+            error_class="builder_stuck",
+            phase="builder",
+            details="timed out",
+            first_failure_at="2026-01-01T00:00:00Z",
+            last_failure_at="2026-01-03T00:00:00Z",
+        )
+        restored = IssueFailureEntry.from_dict(entry.to_dict())
+        assert restored.issue == 42
+        assert restored.total_failures == 3
+        assert restored.error_class == "builder_stuck"
+        assert restored.phase == "builder"
+        assert restored.details == "timed out"
+        assert restored.first_failure_at == "2026-01-01T00:00:00Z"
+        assert restored.last_failure_at == "2026-01-03T00:00:00Z"
+
+
+# ── Load / Save ────────────────────────────────────────────────
+
+
+class TestLoadSave:
+    def test_load_missing_file(self, repo: pathlib.Path) -> None:
+        log = load_failure_log(repo)
+        assert log.entries == {}
+
+    def test_save_and_load(self, repo: pathlib.Path) -> None:
+        log = IssueFailureLog(
+            entries={
+                "42": IssueFailureEntry(
+                    issue=42,
+                    total_failures=2,
+                    error_class="builder_stuck",
+                    phase="builder",
+                ),
+            }
+        )
+        save_failure_log(repo, log)
+
+        loaded = load_failure_log(repo)
+        assert "42" in loaded.entries
+        assert loaded.entries["42"].total_failures == 2
+        assert loaded.entries["42"].error_class == "builder_stuck"
+        assert loaded.updated_at is not None
+
+    def test_load_corrupt_file(self, repo: pathlib.Path) -> None:
+        (repo / ".loom" / "issue-failures.json").write_text("not json{{{")
+        log = load_failure_log(repo)
+        assert log.entries == {}
+
+    def test_load_empty_file(self, repo: pathlib.Path) -> None:
+        (repo / ".loom" / "issue-failures.json").write_text("")
+        log = load_failure_log(repo)
+        assert log.entries == {}
+
+
+# ── record_failure ─────────────────────────────────────────────
+
+
+class TestRecordFailure:
+    def test_records_first_failure(self, repo: pathlib.Path) -> None:
+        entry = record_failure(
+            repo, 42, error_class="builder_stuck", phase="builder", details="timed out"
+        )
+        assert entry.total_failures == 1
+        assert entry.error_class == "builder_stuck"
+        assert entry.phase == "builder"
+        assert entry.details == "timed out"
+        assert entry.first_failure_at is not None
+        assert entry.last_failure_at is not None
+
+    def test_increments_total_failures(self, repo: pathlib.Path) -> None:
+        record_failure(repo, 42, error_class="builder_stuck")
+        entry = record_failure(repo, 42, error_class="judge_stuck", phase="judge")
+        assert entry.total_failures == 2
+        assert entry.error_class == "judge_stuck"
+
+    def test_preserves_first_failure_at(self, repo: pathlib.Path) -> None:
+        e1 = record_failure(repo, 42, error_class="builder_stuck")
+        first = e1.first_failure_at
+        e2 = record_failure(repo, 42, error_class="judge_stuck")
+        assert e2.first_failure_at == first
+
+    def test_multiple_issues(self, repo: pathlib.Path) -> None:
+        record_failure(repo, 42, error_class="builder_stuck")
+        record_failure(repo, 99, error_class="judge_stuck")
+
+        log = load_failure_log(repo)
+        assert "42" in log.entries
+        assert "99" in log.entries
+
+    def test_persists_to_disk(self, repo: pathlib.Path) -> None:
+        record_failure(repo, 42, error_class="builder_stuck")
+        data = _read_failures(repo)
+        assert "42" in data["entries"]
+        assert data["entries"]["42"]["total_failures"] == 1
+
+
+# ── record_success ─────────────────────────────────────────────
+
+
+class TestRecordSuccess:
+    def test_clears_entry_on_success(self, repo: pathlib.Path) -> None:
+        record_failure(repo, 42, error_class="builder_stuck")
+        record_success(repo, 42)
+
+        log = load_failure_log(repo)
+        assert "42" not in log.entries
+
+    def test_noop_for_untracked_issue(self, repo: pathlib.Path) -> None:
+        record_success(repo, 999)
+        # No file created if no failures were recorded
+        log = load_failure_log(repo)
+        assert log.entries == {}
+
+    def test_preserves_other_entries(self, repo: pathlib.Path) -> None:
+        record_failure(repo, 42, error_class="builder_stuck")
+        record_failure(repo, 99, error_class="judge_stuck")
+        record_success(repo, 42)
+
+        log = load_failure_log(repo)
+        assert "42" not in log.entries
+        assert "99" in log.entries
+
+
+# ── get_failure_entry ──────────────────────────────────────────
+
+
+class TestGetFailureEntry:
+    def test_returns_entry(self, repo: pathlib.Path) -> None:
+        record_failure(repo, 42, error_class="builder_stuck")
+        entry = get_failure_entry(repo, 42)
+        assert entry is not None
+        assert entry.total_failures == 1
+
+    def test_returns_none_when_absent(self, repo: pathlib.Path) -> None:
+        entry = get_failure_entry(repo, 999)
+        assert entry is None
+
+
+# ── merge_into_daemon_state ────────────────────────────────────
+
+
+class TestMergeIntoDaemonState:
+    def test_merge_into_empty_state(self, repo: pathlib.Path) -> None:
+        record_failure(repo, 42, error_class="builder_stuck", phase="builder")
+        record_failure(repo, 42, error_class="builder_stuck", phase="builder")
+
+        retries: dict = {}
+        result = merge_into_daemon_state(repo, retries)
+        assert "42" in result
+        assert result["42"]["retry_count"] == 2
+        assert result["42"]["error_class"] == "builder_stuck"
+
+    def test_merge_preserves_higher_count(self, repo: pathlib.Path) -> None:
+        record_failure(repo, 42, error_class="builder_stuck")
+
+        retries = {"42": {"retry_count": 5, "error_class": "old"}}
+        result = merge_into_daemon_state(repo, retries)
+        # Existing count is higher, so should be preserved
+        assert result["42"]["retry_count"] == 5
+        assert result["42"]["error_class"] == "old"
+
+    def test_merge_updates_when_persistent_higher(self, repo: pathlib.Path) -> None:
+        for _ in range(3):
+            record_failure(repo, 42, error_class="builder_stuck", phase="builder")
+
+        retries = {"42": {"retry_count": 1, "error_class": "old"}}
+        result = merge_into_daemon_state(repo, retries)
+        assert result["42"]["retry_count"] == 3
+        assert result["42"]["error_class"] == "builder_stuck"
+
+    def test_merge_sets_retry_exhausted(self, repo: pathlib.Path) -> None:
+        for _ in range(MAX_FAILURES_BEFORE_BLOCK):
+            record_failure(repo, 42, error_class="builder_stuck")
+
+        retries: dict = {}
+        result = merge_into_daemon_state(repo, retries)
+        assert result["42"]["retry_exhausted"] is True
+
+    def test_merge_no_failures(self, repo: pathlib.Path) -> None:
+        retries = {"42": {"retry_count": 1}}
+        result = merge_into_daemon_state(repo, retries)
+        # No persistent failures, so original should be unchanged
+        assert result["42"]["retry_count"] == 1
+
+
+# ── filter_issues_by_failure_backoff ───────────────────────────
+
+
+class TestFilterIssuesByFailureBackoff:
+    def test_no_failures_passes_all(self) -> None:
+        log = IssueFailureLog()
+        issues = [{"number": 1}, {"number": 2}, {"number": 3}]
+        result = filter_issues_by_failure_backoff(issues, log, current_iteration=1)
+        assert len(result) == 3
+
+    def test_first_failure_passes(self) -> None:
+        log = IssueFailureLog(
+            entries={"1": IssueFailureEntry(issue=1, total_failures=1)}
+        )
+        issues = [{"number": 1}]
+        result = filter_issues_by_failure_backoff(issues, log, current_iteration=1)
+        assert len(result) == 1
+
+    def test_second_failure_backoff(self) -> None:
+        log = IssueFailureLog(
+            entries={"1": IssueFailureEntry(issue=1, total_failures=2)}
+        )
+        issues = [{"number": 1}]
+
+        # backoff for 2nd failure = BACKOFF_BASE = 2
+        # iteration 1: 1 % (2+1) = 1, skip
+        result = filter_issues_by_failure_backoff(issues, log, current_iteration=1)
+        assert len(result) == 0
+
+        # iteration 3: 3 % (2+1) = 0, pass
+        result = filter_issues_by_failure_backoff(issues, log, current_iteration=3)
+        assert len(result) == 1
+
+    def test_auto_block_always_skipped(self) -> None:
+        log = IssueFailureLog(
+            entries={
+                "1": IssueFailureEntry(
+                    issue=1, total_failures=MAX_FAILURES_BEFORE_BLOCK
+                )
+            }
+        )
+        issues = [{"number": 1}]
+        # Should be skipped regardless of iteration
+        for iteration in range(100):
+            result = filter_issues_by_failure_backoff(issues, log, current_iteration=iteration)
+            assert len(result) == 0
+
+    def test_mixed_issues(self) -> None:
+        log = IssueFailureLog(
+            entries={
+                "1": IssueFailureEntry(issue=1, total_failures=2),  # backoff
+                "3": IssueFailureEntry(issue=3, total_failures=MAX_FAILURES_BEFORE_BLOCK),  # blocked
+            }
+        )
+        issues = [{"number": 1}, {"number": 2}, {"number": 3}]
+
+        # At iteration 1: issue 1 in backoff, issue 2 has no failures, issue 3 auto-blocked
+        result = filter_issues_by_failure_backoff(issues, log, current_iteration=1)
+        assert len(result) == 1
+        assert result[0]["number"] == 2
+
+    def test_issue_without_number_passes(self) -> None:
+        log = IssueFailureLog(
+            entries={"1": IssueFailureEntry(issue=1, total_failures=MAX_FAILURES_BEFORE_BLOCK)}
+        )
+        issues = [{"title": "no number"}]
+        result = filter_issues_by_failure_backoff(issues, log, current_iteration=1)
+        assert len(result) == 1
+
+
+# ── Integration ────────────────────────────────────────────────
+
+
+class TestIntegration:
+    def test_full_lifecycle(self, repo: pathlib.Path) -> None:
+        """Record failures -> check backoff -> succeed -> verify clean."""
+        # Record 3 failures
+        for _ in range(3):
+            record_failure(repo, 42, error_class="builder_stuck", phase="builder")
+
+        entry = get_failure_entry(repo, 42)
+        assert entry is not None
+        assert entry.total_failures == 3
+
+        # Verify backoff is active
+        log = load_failure_log(repo)
+        issues = [{"number": 42}]
+        result = filter_issues_by_failure_backoff(issues, log, current_iteration=1)
+        assert len(result) == 0  # Should be in backoff
+
+        # Record success
+        record_success(repo, 42)
+        entry = get_failure_entry(repo, 42)
+        assert entry is None
+
+        # Verify issue passes filter now
+        log = load_failure_log(repo)
+        result = filter_issues_by_failure_backoff(issues, log, current_iteration=1)
+        assert len(result) == 1
+
+    def test_auto_block_at_threshold(self, repo: pathlib.Path) -> None:
+        """Issue auto-blocked after MAX_FAILURES_BEFORE_BLOCK failures."""
+        for _ in range(MAX_FAILURES_BEFORE_BLOCK):
+            entry = record_failure(repo, 42, error_class="builder_stuck")
+
+        assert entry.should_auto_block is True
+        assert entry.total_failures == MAX_FAILURES_BEFORE_BLOCK
+
+    def test_merge_then_filter(self, repo: pathlib.Path) -> None:
+        """Merge on startup -> filter during iteration."""
+        # Simulate previous session failures
+        for _ in range(3):
+            record_failure(repo, 42, error_class="builder_stuck", phase="builder")
+
+        # Simulate daemon startup merge
+        retries: dict = {}
+        retries = merge_into_daemon_state(repo, retries)
+        assert retries["42"]["retry_count"] == 3
+
+        # Simulate iteration filtering
+        log = load_failure_log(repo)
+        issues = [{"number": 42}, {"number": 99}]
+        result = filter_issues_by_failure_backoff(issues, log, current_iteration=1)
+        # Issue 42 should be in backoff, 99 should pass
+        assert len(result) == 1
+        assert result[0]["number"] == 99


### PR DESCRIPTION
## Summary

- Adds `.loom/issue-failures.json` as a persistent failure log that survives daemon restarts
- Issues get exponential backoff (0→2→4→8 iterations) based on cumulative failure count
- After 5 total failures, issues are auto-labeled `loom:blocked` with a comment documenting the failure pattern
- Daemon startup merges persistent failure history into session state (`blocked_issue_retries`)
- Successful issue completion clears the failure entry
- Includes 36 unit tests covering backoff calculation, persistence, merge logic, and integration

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Failure history persists across restarts | Done | `issue_failures.py` writes to `.loom/issue-failures.json` |
| Exponential backoff | Done | `backoff_iterations()`: 0, 2, 4, 8 schedule |
| Auto-block after 5 failures | Done | `_auto_block_issue()` in completions.py |
| Startup loads/merges failure history | Done | `_merge_persistent_failures()` in loop.py |
| Cleanup on success | Done | `record_success()` removes entry |
| Entries include required fields | Done | issue, error_class, phase, timestamp, count |

## Test plan

- [x] 36 unit tests pass covering all functionality
- [ ] Judge validates backoff logic correctness
- [ ] Integration test: daemon restart preserves failure counts

Closes #2169