### PR TITLE
Add .loom/issue-failures.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ Thumbs.db
 .loom/[0-9][0-9]-daemon-state.json
 .loom/stuck-history.json
 .loom/alerts.json
+.loom/issue-failures.json
 .loom/health-metrics.json
 .loom/interventions/
 .loom/worktrees/


### PR DESCRIPTION
## Summary

Add `.loom/issue-failures.json` to `.gitignore` alongside other runtime JSON files. This file was introduced in PR #2172 for persistent cross-session failure tracking and is a daemon runtime file that should not be committed.

Closes #2173

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| `.loom/issue-failures.json` in `.gitignore` | Verified | Added after `.loom/alerts.json` in the runtime state section |
| `git status` does not show the file | Verified | `git check-ignore .loom/issue-failures.json` confirms the rule matches |

## Changes

- `.gitignore`: Added `.loom/issue-failures.json` entry in the "Loom runtime state" section (line 49, between `alerts.json` and `health-metrics.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)