### PR TITLE
Add spinning issue detection: auto-escalate after N review cycles

### DIFF
--- a/loom-tools/src/loom_tools/daemon_v2/actions/spinning.py
+++ b/loom-tools/src/loom_tools/daemon_v2/actions/spinning.py
@@ -1,0 +1,120 @@
+"""Escalate spinning issues — PRs stuck in review cycles."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from loom_tools.common.github import gh_run
+from loom_tools.common.logging import log_info, log_warning
+from loom_tools.common.time_utils import now_utc
+
+
+def escalate_spinning_issues(
+    spinning_prs: list[dict[str, Any]],
+) -> int:
+    """Block linked issues for PRs stuck in review cycles.
+
+    For each spinning PR, closes the PR with a comment explaining the
+    review cycle pattern, and labels the linked issue as ``loom:blocked``
+    so a human can investigate.
+
+    Returns the number of issues escalated.
+    """
+    escalated = 0
+
+    for entry in spinning_prs:
+        pr_number = entry.get("pr_number")
+        review_cycles = entry.get("review_cycles", 0)
+        linked_issue = entry.get("linked_issue")
+
+        if pr_number is None:
+            continue
+
+        log_warning(
+            f"Spinning PR #{pr_number} detected: {review_cycles} review cycles"
+            + (f" (linked to issue #{linked_issue})" if linked_issue else "")
+        )
+
+        # Add comment to the PR explaining the escalation
+        timestamp = now_utc().strftime("%Y-%m-%dT%H:%M:%SZ")
+        pr_comment = (
+            f"**Spinning Issue Detected — Auto-Escalated**\n\n"
+            f"This PR has been through **{review_cycles}** review cycles "
+            f"(judge requests changes → doctor fixes → judge requests changes again) "
+            f"without converging.\n\n"
+            f"The review loop has been automatically escalated for human intervention.\n\n"
+            f"---\n"
+            f"*Detected by daemon spinning issue detection at {timestamp}*"
+        )
+        try:
+            gh_run(
+                ["pr", "comment", str(pr_number), "--body", pr_comment],
+                check=False,
+            )
+        except Exception:
+            log_warning(f"Failed to comment on PR #{pr_number}")
+
+        # Close the spinning PR to stop the cycle
+        try:
+            gh_run(
+                ["pr", "close", str(pr_number)],
+                check=False,
+            )
+            log_info(f"Closed spinning PR #{pr_number}")
+        except Exception:
+            log_warning(f"Failed to close PR #{pr_number}")
+
+        # Block the linked issue if we found one
+        if linked_issue is not None:
+            if _block_linked_issue(linked_issue, pr_number, review_cycles, timestamp):
+                escalated += 1
+
+    if escalated > 0:
+        log_info(f"Escalated {escalated} spinning issue(s)")
+
+    return escalated
+
+
+def _block_linked_issue(
+    issue: int,
+    pr_number: int,
+    review_cycles: int,
+    timestamp: str,
+) -> bool:
+    """Label a linked issue as blocked due to spinning PR.
+
+    Returns True if the issue was successfully blocked.
+    """
+    try:
+        gh_run(
+            [
+                "issue", "edit", str(issue),
+                "--remove-label", "loom:building",
+                "--add-label", "loom:blocked",
+            ],
+            check=False,
+        )
+
+        comment = (
+            f"**Spinning Issue — Auto-Blocked**\n\n"
+            f"PR #{pr_number} went through **{review_cycles}** review cycles without "
+            f"converging (judge requests changes → doctor fixes → repeat).\n\n"
+            f"The PR has been closed and this issue has been blocked for human review.\n\n"
+            f"**Possible causes:**\n"
+            f"- Judge standards exceed the doctor's ability to fix\n"
+            f"- Fundamental design issue requiring a different approach\n"
+            f"- Conflicting or unclear acceptance criteria\n\n"
+            f"A maintainer should investigate the review history on PR #{pr_number} "
+            f"before re-labeling as `loom:issue`.\n\n"
+            f"---\n"
+            f"*Auto-blocked by daemon spinning issue detection at {timestamp}*"
+        )
+        gh_run(
+            ["issue", "comment", str(issue), "--body", comment],
+            check=False,
+        )
+        log_info(f"Blocked issue #{issue} (linked to spinning PR #{pr_number})")
+        return True
+    except Exception:
+        log_warning(f"Failed to block issue #{issue}")
+        return False

--- a/loom-tools/src/loom_tools/daemon_v2/iteration.py
+++ b/loom-tools/src/loom_tools/daemon_v2/iteration.py
@@ -12,6 +12,7 @@ from loom_tools.common.time_utils import now_utc
 from loom_tools.models.daemon_state import SystematicFailure
 from loom_tools.daemon_v2.actions.completions import check_completions, handle_completion
 from loom_tools.daemon_v2.actions.proposals import promote_proposals
+from loom_tools.daemon_v2.actions.spinning import escalate_spinning_issues
 from loom_tools.agent_spawn import kill_stuck_session, session_exists
 from loom_tools.daemon_v2.actions.shepherds import (
     _unclaim_issue,
@@ -121,6 +122,12 @@ def run_iteration(ctx: DaemonContext) -> IterationResult:
             run_orphan_recovery(ctx.repo_root, recover=True, verbose=ctx.config.debug_mode)
         except Exception as e:
             log_warning(f"Orphan recovery failed: {e}")
+
+    # Escalate spinning issues (PRs stuck in review cycles)
+    if "escalate_spinning_issues" in actions:
+        spinning_data = ctx.snapshot.get("prs", {}).get("spinning", [])
+        if spinning_data:
+            escalate_spinning_issues(spinning_data)
 
     # 7. Stall escalation
     _update_stall_counter(ctx, result)

--- a/loom-tools/tests/test_spinning.py
+++ b/loom-tools/tests/test_spinning.py
@@ -1,0 +1,78 @@
+"""Tests for daemon_v2 spinning issue escalation."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+from loom_tools.daemon_v2.actions.spinning import escalate_spinning_issues
+
+
+class TestEscalateSpinningIssues:
+    """Tests for escalate_spinning_issues action."""
+
+    def test_empty_list(self) -> None:
+        assert escalate_spinning_issues([]) == 0
+
+    @mock.patch("loom_tools.daemon_v2.actions.spinning.gh_run")
+    def test_escalates_with_linked_issue(self, mock_gh: mock.MagicMock) -> None:
+        mock_gh.return_value = mock.MagicMock(returncode=0)
+        spinning = [
+            {"pr_number": 100, "review_cycles": 5, "linked_issue": 42},
+        ]
+        result = escalate_spinning_issues(spinning)
+        assert result == 1
+
+        # Verify gh calls: comment on PR, close PR, edit issue labels, comment on issue
+        calls = mock_gh.call_args_list
+        assert len(calls) == 4
+
+        # PR comment
+        assert calls[0][0][0][:3] == ["pr", "comment", "100"]
+        # PR close
+        assert calls[1][0][0] == ["pr", "close", "100"]
+        # Issue label edit
+        assert calls[2][0][0][:3] == ["issue", "edit", "42"]
+        assert "--add-label" in calls[2][0][0]
+        assert "loom:blocked" in calls[2][0][0]
+        # Issue comment
+        assert calls[3][0][0][:3] == ["issue", "comment", "42"]
+
+    @mock.patch("loom_tools.daemon_v2.actions.spinning.gh_run")
+    def test_no_linked_issue_still_closes_pr(self, mock_gh: mock.MagicMock) -> None:
+        mock_gh.return_value = mock.MagicMock(returncode=0)
+        spinning = [
+            {"pr_number": 100, "review_cycles": 5, "linked_issue": None},
+        ]
+        result = escalate_spinning_issues(spinning)
+        assert result == 0  # No issue to escalate
+
+        # Still comments and closes the PR
+        calls = mock_gh.call_args_list
+        assert len(calls) == 2  # comment + close (no issue operations)
+
+    @mock.patch("loom_tools.daemon_v2.actions.spinning.gh_run")
+    def test_multiple_spinning_prs(self, mock_gh: mock.MagicMock) -> None:
+        mock_gh.return_value = mock.MagicMock(returncode=0)
+        spinning = [
+            {"pr_number": 100, "review_cycles": 5, "linked_issue": 42},
+            {"pr_number": 200, "review_cycles": 3, "linked_issue": 50},
+        ]
+        result = escalate_spinning_issues(spinning)
+        assert result == 2
+
+    @mock.patch("loom_tools.daemon_v2.actions.spinning.gh_run")
+    def test_gh_failure_handled_gracefully(self, mock_gh: mock.MagicMock) -> None:
+        mock_gh.side_effect = Exception("API error")
+        spinning = [
+            {"pr_number": 100, "review_cycles": 5, "linked_issue": 42},
+        ]
+        # Should not raise
+        result = escalate_spinning_issues(spinning)
+        assert result == 0  # Failed to block the issue
+
+    def test_missing_pr_number_skipped(self) -> None:
+        spinning = [
+            {"review_cycles": 5, "linked_issue": 42},
+        ]
+        result = escalate_spinning_issues(spinning)
+        assert result == 0


### PR DESCRIPTION
Closes #2170

## Summary

- Adds spinning PR detection to the daemon snapshot: queries `CHANGES_REQUESTED` review count for PRs labeled `loom:changes-requested`
- PRs with >= N review cycles (default 3, configurable via `LOOM_SPINNING_REVIEW_THRESHOLD`) are flagged as spinning
- Daemon iteration handles the `escalate_spinning_issues` action: closes the spinning PR, blocks the linked issue with `loom:blocked`, and adds diagnostic comments explaining the review cycle pattern
- New `spinning_prs` health warning surfaces in the snapshot for operator visibility
- 21 new tests covering detection, health warnings, recommended actions, config, and escalation

## Changes

| File | Description |
|------|-------------|
| `snapshot.py` | `SpinningPR` dataclass, `detect_spinning_prs()`, config + health + actions integration |
| `daemon_v2/actions/spinning.py` | New module: `escalate_spinning_issues()` closes PRs and blocks linked issues |
| `daemon_v2/iteration.py` | Wires escalation action into the iteration loop |
| `tests/test_snapshot.py` | Tests for detection, health warnings, recommended actions, config |
| `tests/test_spinning.py` | Tests for the escalation action module |

## Test plan

- [x] All 2422 tests pass (21 new, up from 2401 baseline)
- [ ] Manual validation: verify `gh api` review count query returns expected results
- [ ] Verify `LOOM_SPINNING_REVIEW_THRESHOLD` env var override works in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)