### PR TITLE
Revert shepherd issue labels during daemon graceful shutdown

### DIFF
--- a/loom-tools/tests/test_daemon_cleanup.py
+++ b/loom-tools/tests/test_daemon_cleanup.py
@@ -1,4 +1,4 @@
-"""Tests for daemon_cleanup session termination during shutdown."""
+"""Tests for daemon_cleanup session termination and label revert during shutdown."""
 
 from __future__ import annotations
 
@@ -6,7 +6,12 @@ import json
 import pathlib
 from unittest import mock
 
-from loom_tools.daemon_cleanup import _terminate_active_sessions
+from loom_tools.daemon_cleanup import (
+    _revert_shepherd_labels,
+    _terminate_active_sessions,
+    handle_daemon_shutdown,
+    load_config,
+)
 
 
 class TestTerminateActiveSessions:
@@ -256,3 +261,188 @@ class TestTerminateActiveSessions:
         # Since "custom-session" doesn't start with "loom-",
         # removeprefix("loom-") returns it unchanged
         m_kill.assert_called_once_with("custom-session")
+
+
+class TestRevertShepherdLabels:
+    """Tests for _revert_shepherd_labels() during daemon shutdown."""
+
+    def _write_state(self, state_path: pathlib.Path, data: dict) -> None:
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        state_path.write_text(json.dumps(data))
+
+    def test_reverts_labels_for_working_shepherds(self, tmp_path: pathlib.Path) -> None:
+        """Working shepherds with issues should have labels reverted."""
+        state_path = tmp_path / ".loom" / "daemon-state.json"
+        self._write_state(state_path, {
+            "shepherds": {
+                "shepherd-1": {"status": "working", "issue": 42},
+                "shepherd-2": {"status": "working", "issue": 43},
+            },
+        })
+
+        with mock.patch("loom_tools.common.github.gh_run") as m_gh:
+            _revert_shepherd_labels(state_path)
+
+        assert m_gh.call_count == 2
+        m_gh.assert_any_call([
+            "issue", "edit", "42",
+            "--remove-label", "loom:building",
+            "--add-label", "loom:issue",
+        ])
+        m_gh.assert_any_call([
+            "issue", "edit", "43",
+            "--remove-label", "loom:building",
+            "--add-label", "loom:issue",
+        ])
+
+    def test_skips_non_working_shepherds(self, tmp_path: pathlib.Path) -> None:
+        """Shepherds with status != 'working' should not have labels reverted."""
+        state_path = tmp_path / ".loom" / "daemon-state.json"
+        self._write_state(state_path, {
+            "shepherds": {
+                "shepherd-1": {"status": "idle", "issue": None},
+                "shepherd-2": {"status": "errored", "issue": 50},
+                "shepherd-3": {"status": "paused", "issue": 60},
+            },
+        })
+
+        with mock.patch("loom_tools.common.github.gh_run") as m_gh:
+            _revert_shepherd_labels(state_path)
+
+        m_gh.assert_not_called()
+
+    def test_skips_working_shepherd_with_null_issue(self, tmp_path: pathlib.Path) -> None:
+        """Working shepherds with no issue should not trigger label revert."""
+        state_path = tmp_path / ".loom" / "daemon-state.json"
+        self._write_state(state_path, {
+            "shepherds": {
+                "shepherd-1": {"status": "working", "issue": None},
+            },
+        })
+
+        with mock.patch("loom_tools.common.github.gh_run") as m_gh:
+            _revert_shepherd_labels(state_path)
+
+        m_gh.assert_not_called()
+
+    def test_continues_on_gh_failure(self, tmp_path: pathlib.Path) -> None:
+        """If gh_run raises an exception, shutdown should continue gracefully."""
+        state_path = tmp_path / ".loom" / "daemon-state.json"
+        self._write_state(state_path, {
+            "shepherds": {
+                "shepherd-1": {"status": "working", "issue": 42},
+                "shepherd-2": {"status": "working", "issue": 43},
+            },
+        })
+
+        # First call raises, second succeeds
+        with mock.patch("loom_tools.common.github.gh_run") as m_gh:
+            m_gh.side_effect = [Exception("API error"), None]
+            _revert_shepherd_labels(state_path)
+
+        # Both calls were attempted despite the first failing
+        assert m_gh.call_count == 2
+
+    def test_no_shepherds(self, tmp_path: pathlib.Path) -> None:
+        """Shutdown with zero shepherds should complete without errors."""
+        state_path = tmp_path / ".loom" / "daemon-state.json"
+        self._write_state(state_path, {
+            "shepherds": {},
+        })
+
+        with mock.patch("loom_tools.common.github.gh_run") as m_gh:
+            _revert_shepherd_labels(state_path)
+
+        m_gh.assert_not_called()
+
+    def test_missing_state_file(self, tmp_path: pathlib.Path) -> None:
+        """Should not error when state file doesn't exist."""
+        state_path = tmp_path / ".loom" / "daemon-state.json"
+
+        with mock.patch("loom_tools.common.github.gh_run") as m_gh:
+            _revert_shepherd_labels(state_path)
+
+        m_gh.assert_not_called()
+
+    def test_dry_run_does_not_call_gh(self, tmp_path: pathlib.Path) -> None:
+        """Dry run should log but not call GitHub API."""
+        state_path = tmp_path / ".loom" / "daemon-state.json"
+        self._write_state(state_path, {
+            "shepherds": {
+                "shepherd-1": {"status": "working", "issue": 42},
+            },
+        })
+
+        with mock.patch("loom_tools.common.github.gh_run") as m_gh:
+            _revert_shepherd_labels(state_path, dry_run=True)
+
+        m_gh.assert_not_called()
+
+    def test_mixed_shepherds_only_reverts_working_with_issue(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """Only working shepherds with a non-null issue should be reverted."""
+        state_path = tmp_path / ".loom" / "daemon-state.json"
+        self._write_state(state_path, {
+            "shepherds": {
+                "shepherd-1": {"status": "working", "issue": 42},
+                "shepherd-2": {"status": "idle", "issue": None},
+                "shepherd-3": {"status": "working", "issue": None},
+                "shepherd-4": {"status": "errored", "issue": 50},
+            },
+        })
+
+        with mock.patch("loom_tools.common.github.gh_run") as m_gh:
+            _revert_shepherd_labels(state_path)
+
+        m_gh.assert_called_once_with([
+            "issue", "edit", "42",
+            "--remove-label", "loom:building",
+            "--add-label", "loom:issue",
+        ])
+
+
+class TestHandleDaemonShutdownLabelRevert:
+    """Integration test: handle_daemon_shutdown calls label revert."""
+
+    def _write_state(self, state_path: pathlib.Path, data: dict) -> None:
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        state_path.write_text(json.dumps(data))
+
+    def test_shutdown_reverts_labels_before_resetting_state(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """handle_daemon_shutdown should revert labels before resetting shepherds to idle."""
+        repo_root = tmp_path
+        loom_dir = repo_root / ".loom"
+        state_path = loom_dir / "daemon-state.json"
+        self._write_state(state_path, {
+            "running": True,
+            "shepherds": {
+                "shepherd-1": {"status": "working", "issue": 42},
+            },
+            "support_roles": {},
+        })
+
+        config = load_config()
+
+        with mock.patch("loom_tools.daemon_cleanup._run_archive_logs"), \
+             mock.patch("loom_tools.daemon_cleanup.session_exists", return_value=False), \
+             mock.patch("loom_tools.daemon_cleanup.kill_stuck_session"), \
+             mock.patch("loom_tools.common.github.gh_run") as m_gh, \
+             mock.patch("loom_tools.daemon_cleanup.find_repo_root", return_value=repo_root):
+            handle_daemon_shutdown(repo_root, config)
+
+        # Label revert should have been called
+        m_gh.assert_called_once_with([
+            "issue", "edit", "42",
+            "--remove-label", "loom:building",
+            "--add-label", "loom:issue",
+        ])
+
+        # State should be finalized (shepherd reset to idle)
+        with open(state_path) as f:
+            final_state = json.load(f)
+        assert final_state["running"] is False
+        assert final_state["shepherds"]["shepherd-1"]["status"] == "idle"
+        assert final_state["shepherds"]["shepherd-1"]["issue"] is None


### PR DESCRIPTION
Closes #2177

## Summary

- Added `_revert_shepherd_labels()` to `daemon_cleanup.py` that swaps `loom:building` → `loom:issue` for each working shepherd during daemon shutdown
- Called before state finalization in `handle_daemon_shutdown()` so labels are reverted while state still shows which shepherds own which issues
- Graceful degradation: GitHub API errors are logged as warnings but don't prevent shutdown from completing
- Dry-run mode logs what would be reverted without calling the API

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Working shepherds get labels reverted | Verified | `test_reverts_labels_for_working_shepherds` |
| Non-working/null-issue shepherds skipped | Verified | `test_skips_non_working_shepherds`, `test_skips_working_shepherd_with_null_issue` |
| GitHub API failure doesn't block shutdown | Verified | `test_continues_on_gh_failure` |
| Zero shepherds completes cleanly | Verified | `test_no_shepherds` |
| Integration with handle_daemon_shutdown | Verified | `test_shutdown_reverts_labels_before_resetting_state` |
| Dry-run mode respected | Verified | `test_dry_run_does_not_call_gh` |

## Test Plan

- [x] Unit test: Mock `gh_run` and verify label revert for each working shepherd with a non-null issue
- [x] Unit test: Verify gh_run exception during label revert doesn't block shutdown
- [x] Unit test: Verify non-working/null-issue shepherds are not label-reverted
- [x] Unit test: Zero active shepherds completes without errors
- [x] Integration test: `handle_daemon_shutdown` calls label revert before state reset
- [x] Full test suite: 2411 passed, 3 pre-existing failures (unrelated async tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)