### PR TITLE
feat: detect editable pip installs before worktree cleanup

### DIFF
--- a/defaults/scripts/loom-daemon.sh
+++ b/defaults/scripts/loom-daemon.sh
@@ -85,7 +85,19 @@ if [[ -n "$LOOM_TOOLS" ]] && [[ -x "$LOOM_TOOLS/.venv/bin/loom-daemon" ]]; then
     # Use venv from loom-tools directory
     exec "$LOOM_TOOLS/.venv/bin/loom-daemon" ${args[@]+"${args[@]}"}
 elif command -v loom-daemon &>/dev/null; then
-    # System-installed
+    # System-installed - verify loom_tools can be imported
+    if ! python3 -c "import loom_tools" 2>/dev/null; then
+        echo "[ERROR] loom-daemon is installed but cannot import loom_tools." >&2
+        echo "" >&2
+        echo "  This usually means the editable install source directory was deleted" >&2
+        echo "  (e.g., a worktree was removed while loom-tools was pip install -e'd from it)." >&2
+        echo "" >&2
+        echo "  To fix:" >&2
+        echo "    1. Reinstall loom-tools: pip install loom-tools" >&2
+        echo "    2. Or reinstall from source: pip install -e /path/to/loom/loom-tools" >&2
+        echo "" >&2
+        exit 1
+    fi
     exec loom-daemon ${args[@]+"${args[@]}"}
 else
     echo "[ERROR] Python daemon not available." >&2


### PR DESCRIPTION
Closes #2192

## Summary

- Add `find_editable_pip_installs()` to detect packages installed in editable mode (`pip install -e`) whose source lives inside a worktree
- Skip worktrees with active editable installs during `loom-clean` (with `--force` override)
- Add import verification to `loom-daemon.sh` system-installed fallback to catch broken installs with clear error message
- Report `skipped_editable` count in cleanup summary

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|-------------|
| `loom-clean` detects editable pip installs pointing into a worktree | ✅ | `find_editable_pip_installs()` checks `pip list --editable` and `pip show` Location |
| Worktrees with active editable installs are skipped with a warning | ✅ | `clean_worktrees()` logs warning and increments `skipped_editable` |
| `--force` bypasses the editable install check with a logged warning | ✅ | Force mode logs warning but does not skip |
| `loom-daemon.sh` verifies `loom-daemon` can import `loom_tools` before exec | ✅ | Added `python3 -c "import loom_tools"` check before system-installed fallback |
| `loom-daemon.sh` prints clear error with fix instructions on import failure | ✅ | Error message explains cause and provides reinstall instructions |
| `CleanupStats` reports `skipped_editable` count in summary | ✅ | `print_summary()` shows count when > 0 |

## Test Plan

- [x] 8 new tests for `find_editable_pip_installs()` covering: inside worktree, outside worktree, pip not found, pip error, no editable packages, invalid JSON, Location-only field, no Python interpreters
- [x] 2 new tests for `print_summary()` with `skipped_editable` (shows when > 0, hidden when 0)
- [x] `CleanupStats.skipped_editable` default value test
- [x] All 35 test_clean.py tests pass
- [x] Full Python test suite passes (2483 passed, 1 skipped)

## Files Changed

| File | Change |
|------|--------|
| `loom-tools/src/loom_tools/clean.py` | Add `skipped_editable` field, `find_editable_pip_installs()`, editable check in `clean_worktrees()`, summary output |
| `defaults/scripts/loom-daemon.sh` | Add import verification before system-installed `exec loom-daemon` |
| `loom-tools/tests/test_clean.py` | Add `TestFindEditablePipInstalls` class (8 tests), summary tests (2 tests), stats default test |

🤖 Generated with [Claude Code](https://claude.com/claude-code)