### PR TITLE
fix: remove incorrect 100x scaling of usage API utilization

### DIFF
--- a/loom-tools/src/loom_tools/common/usage.py
+++ b/loom-tools/src/loom_tools/common/usage.py
@@ -103,8 +103,8 @@ def _transform_api_response(api_data: dict[str, Any]) -> dict[str, Any]:
     API shape (simplified)::
 
         {
-          "five_hour": {"utilization": 0.42, "resets_at": "2026-01-23T15:00:00Z"},
-          "seven_day": {"utilization": 0.15, "resets_at": "2026-01-27T00:00:00Z"}
+          "five_hour": {"utilization": 42.0, "resets_at": "2026-01-23T15:00:00Z"},
+          "seven_day": {"utilization": 15.0, "resets_at": "2026-01-27T00:00:00Z"}
         }
 
     Output shape::
@@ -127,9 +127,9 @@ def _transform_api_response(api_data: dict[str, Any]) -> dict[str, Any]:
     weekly_util = seven.get("utilization")
 
     return {
-        "session_percent": round(session_util * 100, 1) if session_util is not None else None,
+        "session_percent": round(session_util, 1) if session_util is not None else None,
         "session_reset": five.get("resets_at"),
-        "weekly_all_percent": round(weekly_util * 100, 1) if weekly_util is not None else None,
+        "weekly_all_percent": round(weekly_util, 1) if weekly_util is not None else None,
         "weekly_reset": seven.get("resets_at"),
         "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "data_age_seconds": 0,

--- a/loom-tools/tests/test_usage.py
+++ b/loom-tools/tests/test_usage.py
@@ -128,8 +128,8 @@ class TestTransformApiResponse:
 
     def test_full_response(self):
         api_data = {
-            "five_hour": {"utilization": 0.42, "resets_at": "2026-01-23T15:00:00Z"},
-            "seven_day": {"utilization": 0.15, "resets_at": "2026-01-27T00:00:00Z"},
+            "five_hour": {"utilization": 42.0, "resets_at": "2026-01-23T15:00:00Z"},
+            "seven_day": {"utilization": 15.0, "resets_at": "2026-01-27T00:00:00Z"},
         }
         result = _transform_api_response(api_data)
         assert result["session_percent"] == 42.0
@@ -140,7 +140,7 @@ class TestTransformApiResponse:
         assert "timestamp" in result
 
     def test_missing_five_hour(self):
-        result = _transform_api_response({"seven_day": {"utilization": 0.3}})
+        result = _transform_api_response({"seven_day": {"utilization": 30.0}})
         assert result["session_percent"] is None
         assert result["session_reset"] is None
         assert result["weekly_all_percent"] == 30.0
@@ -202,8 +202,8 @@ class TestGetUsage:
     def test_success_writes_cache(self, tmp_path):
         (tmp_path / ".loom").mkdir()
         api_data = {
-            "five_hour": {"utilization": 0.6, "resets_at": "2026-01-23T15:00:00Z"},
-            "seven_day": {"utilization": 0.2, "resets_at": "2026-01-27T00:00:00Z"},
+            "five_hour": {"utilization": 60.0, "resets_at": "2026-01-23T15:00:00Z"},
+            "seven_day": {"utilization": 20.0, "resets_at": "2026-01-27T00:00:00Z"},
         }
         with mock.patch("loom_tools.common.usage._read_keychain_token", return_value="tok"):
             with mock.patch("loom_tools.common.usage._call_usage_api", return_value=api_data):


### PR DESCRIPTION
## Summary

- The Anthropic OAuth usage API returns `utilization` as a percentage (0–100), not a fraction (0–1)
- PR #2206 introduced a `* 100` transform that inflated values (e.g., 72% → 7200%), causing every shepherd build to hit the 99% rate limit threshold
- Removes the multiplication and updates docstring/tests to match the real API format

## Test plan

- [x] All 31 `test_usage.py` tests pass
- [x] Verified live API returns percentage values (e.g., `"utilization": 72.0`)
- [x] Confirmed `get_usage()` now returns correct percentages after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)