### PR TITLE
feat: add -t/--timeout-min flag for time-bounded daemon runs

### DIFF
--- a/defaults/.claude/commands/loom.md
+++ b/defaults/.claude/commands/loom.md
@@ -51,6 +51,8 @@ The daemon will:
 | `/loom` | Start daemon in normal mode |
 | `/loom --merge` | Start in force mode (auto-promote, auto-merge) |
 | `/loom --force` | Alias for --merge |
+| `/loom -t 180` | Run for 3 hours then gracefully stop |
+| `/loom --timeout-min 60 --merge` | Merge mode for 1 hour |
 | `/loom --debug` | Start with debug logging |
 | `/loom status` | Check if daemon is running |
 | `/loom health` | Show daemon health status |

--- a/defaults/scripts/loom-daemon.sh
+++ b/defaults/scripts/loom-daemon.sh
@@ -17,6 +17,7 @@
 # Options (user-facing):
 #   --force, -f      Enable force mode (auto-promote proposals, auto-merge)
 #   --merge, -m      Alias for --force (for CLI parity with /loom --merge)
+#   --timeout-min N, -t N  Stop daemon after N minutes (0 = no timeout)
 #   --debug, -d      Enable debug logging
 #   --status         Check if daemon is running
 #   --health         Show daemon health status

--- a/loom-tools/src/loom_tools/daemon_v2/config.py
+++ b/loom-tools/src/loom_tools/daemon_v2/config.py
@@ -38,6 +38,7 @@ class DaemonConfig:
     iteration_timeout: int = DEFAULT_ITERATION_TIMEOUT
     force_mode: bool = False
     debug_mode: bool = False
+    timeout_min: int = 0  # 0 = no timeout
 
     # Shepherd configuration
     max_shepherds: int = DEFAULT_MAX_SHEPHERDS
@@ -69,18 +70,21 @@ class DaemonConfig:
         *,
         force_mode: bool = False,
         debug_mode: bool = False,
+        timeout_min: int = 0,
     ) -> DaemonConfig:
         """Create config from environment variables.
 
         Args:
             force_mode: Enable force mode (auto-promote, auto-merge)
             debug_mode: Enable debug logging
+            timeout_min: Stop daemon after N minutes (0 = no timeout)
         """
         return cls(
             poll_interval=env_int("LOOM_POLL_INTERVAL", DEFAULT_POLL_INTERVAL),
             iteration_timeout=env_int("LOOM_ITERATION_TIMEOUT", DEFAULT_ITERATION_TIMEOUT),
             force_mode=force_mode or env_bool("LOOM_FORCE_MODE", False),
             debug_mode=debug_mode or env_bool("LOOM_DEBUG_MODE", False),
+            timeout_min=timeout_min or env_int("LOOM_TIMEOUT_MIN", 0),
             max_shepherds=env_int("LOOM_MAX_SHEPHERDS", DEFAULT_MAX_SHEPHERDS),
             issue_threshold=env_int("LOOM_ISSUE_THRESHOLD", DEFAULT_ISSUE_THRESHOLD),
             issue_strategy=os.environ.get("LOOM_ISSUE_STRATEGY", "fifo"),


### PR DESCRIPTION
## Summary

Adds a `-t` / `--timeout-min` flag to the daemon CLI so it automatically performs a graceful shutdown after a specified duration.

- `/loom -t 180` runs the daemon for 3 hours then stops
- `/loom --timeout-min 60 --merge` runs merge mode for 1 hour
- Timeout is recorded as `timeout_at` in `daemon-state.json`
- Also configurable via `LOOM_TIMEOUT_MIN` environment variable
- Whichever triggers first wins: timeout, stop signal, or Ctrl+C

Closes #2207

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `/loom -t 180` runs daemon for 180 minutes then gracefully stops | Verified | Deadline computed as `time.time() + N*60`, checked at each iteration start |
| `/loom --timeout-min 60` is equivalent long form | Verified | argparse maps both `-t` and `--timeout-min` to `args.timeout_min` |
| Timeout is recorded in daemon state | Verified | `timeout_at` ISO timestamp written to `daemon-state.json` and shown in `--status` |
| Works alongside `--merge` and other existing flags | Verified | Independent flag, all flags compose naturally via argparse |
| Daemon logs when it stops due to timeout vs other reasons | Verified | Logs "TIMEOUT reached (N minutes elapsed)" distinct from "SHUTDOWN_SIGNAL detected" |

## Changes

- **`config.py`**: Added `timeout_min` field to `DaemonConfig` with `LOOM_TIMEOUT_MIN` env var support
- **`cli.py`**: Added `-t`/`--timeout-min` argument, passes to config, shown in `--status` output
- **`loop.py`**: Computes deadline at loop start, checks at each iteration, records `timeout_at` in state file, shows in header
- **`loom-daemon.sh`**: Documented new flag in header comments (flag passes through naturally)
- **`loom.md`**: Added timeout examples to commands quick reference

## Test plan

- [x] All 1728 existing tests pass (0 failures)
- [x] No new lint errors introduced (2 pre-existing lint warnings unchanged)
- [ ] Manual: `loom-daemon -t 1` should exit after ~1 minute
- [ ] Manual: `loom-daemon --timeout-min 1 --force` should combine correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)