### PR TITLE
feat: capture terminal scrollback before killing stuck sessions

### DIFF
--- a/loom-tools/src/loom_tools/common/tmux_session.py
+++ b/loom-tools/src/loom_tools/common/tmux_session.py
@@ -50,6 +50,23 @@ class TmuxSession:
         except Exception:
             return ""
 
+    def capture_scrollback(self, lines: int = 200) -> str:
+        """Capture scrollback history from the tmux pane.
+
+        Args:
+            lines: Number of scrollback lines to capture (default 200).
+
+        Returns:
+            The captured scrollback text, or empty string on failure.
+        """
+        try:
+            result = self._run(
+                "capture-pane", "-t", self.name, "-p", "-S", f"-{lines}"
+            )
+            return result.stdout if result.returncode == 0 else ""
+        except Exception:
+            return ""
+
     def send_keys(self, keys: str, *extra: str) -> bool:
         """Send keys to this tmux session.
 


### PR DESCRIPTION
## Summary

When `kill_stuck_session()` terminates a stuck tmux session, it now captures up to 200 lines of scrollback history and saves it to `.loom/logs/<session>-killed-<timestamp>.log` before sending Ctrl-C. This provides post-mortem debugging data for understanding why sessions got stuck.

### Changes

- **`tmux_session.py`**: Added `capture_scrollback(lines=200)` method to `TmuxSession` class using `tmux capture-pane -p -S -<lines>`
- **`agent_spawn.py`**: Added `_capture_session_output()` helper that captures scrollback and writes to log file; modified `kill_stuck_session()` to call capture before shutdown
- **`test_agent_spawn.py`**: Added 8 tests covering: successful capture, empty/whitespace output skipping, capture failure resilience, missing repo handling, log directory creation, and integration with kill flow

### Design decisions

- Capture runs inside `kill_stuck_session()` so all 3 call sites (STALL-L2, STALL-L3, pre-spawn) benefit automatically
- Capture happens **before** Ctrl-C to preserve the original terminal state
- Best-effort with double safety: `_capture_session_output` catches all exceptions internally, and `kill_stuck_session` also wraps the call in try/except
- Empty/whitespace-only output produces no log file to avoid clutter
- Unique filenames via timestamp prevent collisions during concurrent STALL-L3 kills

### Acceptance criteria verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Scrollback captured before kill | Pass | `_capture_session_output` called before Ctrl-C send |
| Output saved to `.loom/logs/` | Pass | Written to `<session>-killed-<timestamp>.log` |
| Capture failure doesn't prevent kill | Pass | Double try/except ensures kill always proceeds |
| Empty pane skipped | Pass | No file written for empty/whitespace output |
| Log directory auto-created | Pass | `os.makedirs(exist_ok=True)` via `mkdir(parents=True)` |
| All existing tests still pass | Pass | 2522 passed, 1 skipped |

Closes #2199