### PR TITLE
docs: Guide document maintenance update

### DIFF
--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -6,9 +6,201 @@ Entries are grouped by date, newest first. Each entry references the merged PR o
 
 <!-- Maintained automatically by the Guide triage agent. Manual edits are fine but may be overwritten. -->
 
+### 2026-02-10
+
+- **PR #2209**: feat: add -t/--timeout-min flag for time-bounded daemon runs
+- **PR #2208**: fix: remove incorrect 100x scaling of usage API utilization
+- **PR #2206**: feat: replace SQLite usage checking with direct Anthropic OAuth API
+- **PR #2195**: Issue #2194: write loom-source-path to target repo root
+- **PR #2193**: feat: detect editable pip installs before worktree cleanup
+- **PR #2191**: Fix label sync script logic
+- **PR #2190**: Bump the all-dependencies group with 6 updates
+- **PR #2189**: Bump the production-dependencies group with 2 updates
+- **PR #2188**: Bump the dev-dependencies group with 4 updates
+- **Issue #2207** (closed): Add -t/--timeout-min flag to /loom for time-bounded daemon runs
+- **Issue #2203** (closed): Champion should be able to promote or close any open issue
+- **Issue #2196** (closed): Daemon should auto-resolve contradictory labels
+- **Issue #2194** (closed): Installation does not create .loom/loom-source-path file
+- **Issue #2192** (closed): loom-daemon breaks after worktree cleanup: editable install points to deleted path
+
+### 2026-02-06
+
+- **PR #2187**: Add tmux liveness detection for support role completion
+- **PR #2186**: Add idempotency checks to Loom installation pipeline
+- **PR #2185**: Add retry_blocked_issues action handler for blocked issue recovery
+- **PR #2184**: Increase shepherd no-progress grace period from 300s to 600s
+- **PR #2183**: Revert shepherd issue labels during daemon graceful shutdown
+- **PR #2182**: Terminate child tmux sessions during daemon graceful shutdown
+- **PR #2175**: Add spinning issue detection: auto-escalate after N review cycles
+- **PR #2174**: Add .loom/issue-failures.json to .gitignore
+- **PR #2172**: Add persistent cross-session failure tracking for daemon issues
+- **PR #2171**: Detect shepherds stuck without progress files
+- **PR #2167**: Fix judge/shepherd review workflow mismatch causing systematic judge_exhausted
+- **PR #2166**: Fix PreToolUse hook error infinite retry loop
+- **PR #2165**: Prevent .loom runtime files from triggering dirty-repo check
+- **PR #2164**: Add heartbeat grace period for newly spawned shepherds
+- **PR #2163**: Add contradictory label detection and exclusion group enforcement
+- **PR #2162**: Extend pipe-pane sed filter to strip CR, BS, and bare escapes
+- **PR #2155**: Downgrade ci_failing to info-level to prevent spurious stall escalation
+- **PR #2154**: Clear systematic failure state on L3 pool restart
+- **PR #2153**: Reset stall counter after L3 pool restart
+- **PR #2149**: Guard against missing .loom/scripts when branch predates Loom install
+- **PR #2148**: Add escalating stall recovery to daemon iteration loop
+- **PR #2146**: Dispatch targeted doctor/judge agents for orphaned PRs
+- **PR #2145**: Fix stale shepherd count in iteration summary and spawning decisions
+- **PR #2141**: Add create_pr to direct completion mechanical steps
+- **PR #2140**: Handle exit code 6 (instant-exit) in judge phase
+- **PR #2137**: Fix shepherd Judge phase silent failure with 0s session duration
+- **PR #2136**: Add test suite for log_filter module
+- **PR #2133**: Filter .loom/ runtime files from shepherd dirty-repo check
+- **PR #2132**: Replace sed ANSI stripping with Python log filter for cleaner agent logs
+- **PR #2131**: Fix daemon runtime files missing from .gitignore template
+- **Issue #2181** (closed): Support roles have no completion mechanism and run indefinitely
+- **Issue #2180** (closed): Loom installation creates redundant 'Install Loom' PRs on every reinstall
+- **Issue #2179** (closed): Blocked issues are retried endlessly without escalation or backoff
+- **Issue #2178** (closed): Shepherds frequently stall with no progress file within grace period
+- **Issue #2177** (closed): Daemon shutdown does not revert GitHub labels on in-progress issues
+- **Issue #2176** (closed): Daemon shutdown does not kill child tmux sessions
+- **Issue #2173** (closed): Add .loom/issue-failures.json to .gitignore
+- **Issue #2170** (closed): Spinning issue detection: auto-escalate after N shepherd cycles
+- **Issue #2169** (closed): Cross-session failure tracking and exponential backoff
+- **Issue #2168** (closed): Stuck shepherd detection: heartbeat-based liveness checks
+- **Issue #2161** (closed): Contradictory label state allowed on same PR
+- **Issue #2160** (closed): Stale heartbeat detection too aggressive
+- **Issue #2159** (closed): Repeated PreToolUse hook errors block shepherd progress
+- **Issue #2158** (closed): Shepherds error on uncommitted .loom/ files in main repo
+- **Issue #2157** (closed): Judge/Shepherd review workflow mismatch causes systematic judge_exhausted
+- **Issue #2156** (closed): Logs unreadable: pipe-pane ANSI stripping missing or broken
+- **Issue #2152** (closed): Systematic failure suppresses spawning even after L3 pool restart
+- **Issue #2151** (closed): L3 pool restart does not reset stall counter
+- **Issue #2150** (closed): ci_failing warning creates unrecoverable stall loop
+- **Issue #2147** (closed): Shepherd judge phase crashes when branch predates Loom installation
+- **Issue #2144** (closed): Daemon 'stalled' health status persists without corrective action
+- **Issue #2143** (closed): Daemon reports stale shepherd count due to timing gap
+- **Issue #2142** (closed): Daemon should dispatch targeted agents for orphaned PRs
+- **Issue #2139** (closed): Judge CLI sessions exit immediately (0s duration)
+- **Issue #2138** (closed): Builder completion phase fails to create PR
+- **Issue #2135** (closed): Shepherd Judge phase fails silently with 0s session duration
+- **Issue #2134** (closed): Add unit tests for loom_tools.log_filter module
+- **Issue #2130** (closed): Shepherd tmux logs are raw terminal output
+- **Issue #2129** (closed): Shepherd dirty-repo check too strict for .loom/ runtime files
+- **Issue #2128** (closed): Daemon runtime files not included in .gitignore template
+
+### 2026-02-05
+
+- **PR #2127**: Fix --clean install leaving staged deletions in main
+- **PR #2125**: Fix security audit failures: update bytes and MCP SDK
+- **PR #2124**: Fix E2E terminal-management tests with proper mock terminal data
+- **PR #2123**: Fix default mode not auto-approving past approval gate
+- **PR #2122**: Add transient API error recovery for autonomous agents
+- **PR #2121**: Add test failure analysis tooling for shepherd block rate investigation
+- **PR #2120**: Add PreToolUse hook to block destructive agent commands
+- **PR #2112**: Fix daemon self-sabotage: gitignore runtime files and fix empty args
+- **Issue #2126** (closed): Clean reinstall leaves target repo in dirty state
+- **Issue #2119** (closed): Implement PreToolUse hooks to block destructive agent commands
+- **Issue #2118** (closed): Implement API error recovery for shepherd/daemon orchestration
+- **Issue #2116** (closed): Shepherd: default mode should auto-promote past approval gate
+- **Issue #2109** (closed): Daemon runtime files missing from .gitignore
+- **Issue #2105** (closed): E2E terminal-management tests failing on main
+- **Issue #2100** (closed): Investigate shepherd test failure patterns (20% block rate)
+
+### 2026-02-04
+
+- **PR #2117**: Add scoped test execution to Judge role
+- **Issue #2114** (closed): Judge: scope test execution to changed files
+
+### 2026-02-03
+
+- **PR #2115**: Add approval phase timeout and heartbeat reporting
+- **PR #2113**: Fix daemon-shepherd approval deadlock
+- **PR #2108**: Add Python daemon implementation (daemon_v2) for deterministic orchestration
+- **PR #2107**: Fix CI: workflow YAML syntax and E2E test mocks
+- **PR #2106**: Fix scoped test detection for nested pyproject.toml
+- **PR #2104**: Shepherd: Structured builder checkpoints to detect partial progress
+- **PR #2103**: Add WIP commit preservation when builder exits with uncommitted changes
+- **PR #2102**: Remove dead multi-terminal and prediction code (Phase 7)
+- **Issue #2111** (closed): Approval phase has no timeout or heartbeat reporting
+- **Issue #2110** (closed): Shepherd approval gate deadlocks daemon-spawned shepherds
+- **Issue #2099** (closed): Scoped test detection misses nested pyproject.toml
+- **Issue #2056** (closed): Shepherd: Structured builder checkpoints
+
+### 2026-02-02
+
+- **PR #2101**: Add stale worktree recovery to builder phase
+- **PR #2098**: Extend name-based test comparison to line-based fallback path
+- **PR #2097**: Add graceful 'no changes needed' pathway to shepherd
+- **PR #2094**: Add output-based test ecosystem detection for umbrella commands
+- **PR #2093**: Add scoped test verification to builder phase
+- **PR #2092**: Add CI-aware validation to doctor phase
+- **PR #2091**: Add diagnostics to 'no PR created' shepherd failure
+- **PR #2090**: Update shepherd CLI tests to use ShepherdExitCode enum values
+- **PR #2089**: Prefer loom-tools source over installed CLI in development
+- **PR #2087**: Fix race condition in judge phase fallback approval
+- **PR #2086**: Prevent curator from closing issues during curation
+- **PR #2081**: Document judge_retry and phase_completed milestone events
+- **PR #2080**: Phase 6: Rewrite main.ts for single-session analytics-first model
+- **PR #2079**: Distinguish doctor failure modes for better label state recovery
+- **PR #2078**: Improve builder completion retry prompting with diagnostic context
+- **PR #2077**: Add granular exit codes for shepherd partial success states
+- **PR #2076**: Fix PR creation gap after doctor test-fix loop
+- **PR #2075**: Bump clap from 4.5.54 to 4.5.56
+- **PR #2074**: Bump the dev-dependencies group with 2 updates
+- **Issue #2096** (closed): Shepherd: Handle 'no changes needed' gracefully
+- **Issue #2095** (closed): Builder: Verify problem exists before attempting fix
+- **Issue #2088** (closed): Fix shepherd CLI tests for granular exit codes
+- **Issue #2085** (closed): Detect stale loom-tools installation
+- **Issue #2084** (closed): Curator agent should not close issues
+- **Issue #2083** (closed): Shepherd fallback label application has race condition
+- **Issue #2082** (closed): Doctor validation fails when CI is still pending
+- **Issue #2068** (closed): Distinguish doctor failure modes
+- **Issue #2067** (closed): Increase builder completion retry limit
+- **Issue #2066** (closed): Extend name-based test comparison to line-based fallback
+- **Issue #2065** (closed): Add diagnostics to 'no PR created' shepherd failure
+- **Issue #2064** (closed): Fix PR creation gap after doctor test-fix loop
+- **Issue #2045** (closed): Shepherd: Granular exit codes for partial success states
+- **Issue #2044** (closed): Shepherd: Scoped test execution based on changed files
+- **Issue #2031** (closed): Fix unused variable warning in loom-daemon scaffolding.rs
+
 ### 2026-02-01
 
+- **PR #2073**: Judge: rename review terminology to judge/evaluate
+- **PR #2071**: Add supplemental Python test verification when pipeline short-circuits
+- **PR #2070**: Add post-worktree hook to pre-build loom-daemon binary
+- **PR #2069**: Document repository-scoped GitHub token setup
+- **PR #2063**: Improve builder completion phase with targeted retry
+- **PR #2062**: DRY up pipe-pane log capture: strip ANSI escape sequences
+- **PR #2061**: Add file-based analytics dashboard (Phase 5)
+- **PR #2057**: Add shepherd pre-flight baseline health check
+- **PR #2054**: Add name-based test comparison to reduce false positive regressions
+- **PR #2053**: Enable Doctor to fix builder test failures
+- **PR #2052**: Add atomic label state transitions
+- **PR #2051**: Fix test path for relocated loom CLI wrapper
+- **PR #2050**: Fix completion phase shell command parsing broken by newlines
+- **PR #2042**: Document worktree deletion dangers
+- **PR #2041**: Symlink node_modules from main workspace to worktrees
+- **PR #2040**: Add builder completion retry phase for incomplete work
+- **PR #2039**: Increase shepherd timeouts to prevent premature agent termination
+- **PR #2038**: Implement input logging layer for terminal analytics
+- **PR #2037**: Strip ANSI escape sequences from builder logs
+- **PR #2035**: Remove auto-recovery from shepherd, add phase contracts
+- **PR #2034**: Remove remaining AGENTS.md references
+- **PR #2033**: Issue #1978: Auto-recovered PR
+- **PR #2032**: Issue #2025: Auto-recovered PR
+- **PR #2030**: Issue #1956: Auto-recovered PR
+- **PR #2029**: Issue #1979: Auto-recovered PR
 - **PR #1912**: Add diagnostic output on judge validation failure
+- **Issue #2072** (closed): Judge: rename 'review' terminology to reduce API anchoring
+- **Issue #2060** (closed): DRY up pipe-pane log capture
+- **Issue #2058** (closed): Document repository-scoped GitHub token setup
+- **Issue #2055** (closed): Shepherd: Improve builder completion phase
+- **Issue #2049** (closed): Fix missing defaults/loom CLI wrapper
+- **Issue #2048** (closed): Shepherd: Atomic label state transitions
+- **Issue #2047** (closed): Shepherd: Pre-flight baseline health check
+- **Issue #2046** (closed): Shepherd: Enable Doctor to fix test failures
+- **Issue #2043** (closed): Shepherd: Compare specific test names
+- **Issue #2036** (closed): Document: Agents must not delete worktrees directly
+- **Issue #2026** (closed): Clean up remaining AGENTS.md references
+- **Issue #2025** (closed): Move ./loom CLI wrapper into .loom/ folder
 - **Issue #1908** (closed): Shepherd: judge worker silently fails without submitting review
 
 ### 2026-01-31

--- a/WORK_PLAN.md
+++ b/WORK_PLAN.md
@@ -8,53 +8,40 @@ Prioritized roadmap of upcoming work, maintained by the Guide role.
 
 Issues requiring immediate attention (`loom:urgent`).
 
-*No urgent issues.*
+- **#2201**: Daemon needs strategy for issues that exceed single-session context budget *(tier:goal-advancing)*
+- **#2205**: Daemon should report when stalled waiting on human input *(tier:goal-supporting)*
+- **#2200**: Installer doesn't copy guard-destructive.sh hook to target repo *(tier:goal-supporting)*
 
 ## Ready
 
 Human-approved issues ready for implementation (`loom:issue`).
 
-*No ready issues.* The backlog is empty -- all approved work is currently being built.
+- **#2202**: Remove orphaned ab_testing.rs backend (1,341 LOC dead code) *(tier:maintenance)*
 
 ## In Progress
 
 Issues actively being worked by shepherds (`loom:building`).
 
-- **#1881**: Split activity database module (db.rs) into domain-specific submodules *(tier:maintenance)*
-- **#1883**: Split commands/activity.rs (4,117 lines) into domain-specific submodules *(tier:maintenance)*
-- **#1888**: Decompose loom-daemon init.rs (2,316 lines) into focused initialization submodules *(tier:maintenance)*
+- **#2199**: Daemon should capture shepherd output on kill for post-mortem debugging *(loom:curated)*
+- **#2198**: Shepherd spawns without writing progress file -- silent failure mode *(loom:curated)*
+- **#2197**: Stale heartbeat detection too slow -- 8+ minutes to reclaim stuck shepherd *(loom:curated)*
 
 ## Proposed
 
 Issues under evaluation (`loom:architect`, `loom:hermit`, `loom:curated`).
 
-- **#1888**: Decompose loom-daemon init.rs -- also has `loom:architect` *(tier:maintenance)*
-- **#1899**: Add post-worktree hook to pre-build daemon binary *(tier:goal-supporting, no workflow label)*
+*No proposed issues awaiting evaluation. All curated issues have been promoted to `loom:issue`.*
 
 ## Epics
 
-Active epics and their phase progress (`loom:epic`).
-
-### #1893: Reshape Loom into Analytics-First Claude Wrapper
-
-Progress: **1/7 phases complete (14%)**
-
-| Phase | Issue | Status |
-|-------|-------|--------|
-| Phase 1 | #1894 Config v3 & State Simplification | CLOSED |
-| Phase 2 | #1895 Side-by-Side Layout (Terminal + Analytics) | OPEN |
-| Phase 3 | #1896 Claude Code Session Manager | OPEN |
-| Phase 4 | #1897 Input Logging Layer | OPEN |
-| Phase 5 | #1898 File-Based Analytics Dashboard | OPEN |
-| Phase 6 | #1901 Rewrite main.ts for Single-Session + Analytics | OPEN |
-| Phase 7 | #1902 Remove Dead Multi-Terminal and Prediction Code | OPEN |
-
-*All remaining phases are `tier:goal-advancing` but not yet promoted to `loom:issue`.*
+No active epics. Previous epic #1893 (Reshape Loom into Analytics-First Claude Wrapper) completed all 7 phases and is now closed.
 
 ## Backlog Balance
 
 | Tier | Count |
 |------|-------|
-| Tier 1 (goal-advancing) | 7 (epic + 6 phases) |
-| Tier 2 (goal-supporting) | 1 (#1899) |
-| Tier 3 (maintenance) | 3 (#1881, #1883, #1888) |
+| Tier 1 (goal-advancing) | 1 (#2201) |
+| Tier 2 (goal-supporting) | 2 (#2205, #2200) |
+| Tier 3 (maintenance) | 1 (#2202) |
+
+**Note:** The backlog is lean. The 3 building issues (#2197-#2199) are all daemon reliability improvements that complement the urgent queue. Once building completes, the pipeline will need new proposals from Architect/Hermit roles.


### PR DESCRIPTION
## Summary

Automated document maintenance by the Guide triage agent.

### Changes
- **WORK_LOG.md**: Appended 192 new entries covering 90+ merged PRs and closed issues from 2026-02-01 through 2026-02-10
- **WORK_PLAN.md**: Regenerated roadmap from current GitHub label state — all previously referenced issues (#1881-#1902) are now closed; updated with current urgent/ready/building pipeline

### Context
The documents were significantly stale (last updated 2026-02-01). This catches up all completed work from the past 9 days, including the completion of Epic #1893 (Analytics-First Claude Wrapper) and major daemon reliability improvements.

---
*Automated by Guide role - document maintenance phase*