### PR TITLE
feat: two-tier startup detection and diagnostic capture for stalled shepherds

### DIFF
--- a/loom-tools/src/loom_tools/agent_spawn.py
+++ b/loom-tools/src/loom_tools/agent_spawn.py
@@ -197,6 +197,22 @@ def _capture_session_output(name: str, session_name: str) -> None:
         log_warning(f"Failed to capture session output: {exc}")
 
 
+def capture_tmux_output(name: str, lines: int = 200) -> str:
+    """Capture the current tmux pane output for a session.
+
+    Uses ``tmux capture-pane`` to read the visible buffer content.
+    Returns the captured output as a string, or empty string on failure.
+    """
+    session_name = f"{SESSION_PREFIX}{name}"
+    try:
+        result = _tmux("capture-pane", "-t", session_name, "-p", "-S", f"-{lines}")
+        if result.returncode == 0:
+            return result.stdout
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    return ""
+
+
 def kill_stuck_session(name: str) -> None:
     """Kill a stuck session with graceful then forced shutdown."""
     session_name = f"{SESSION_PREFIX}{name}"

--- a/loom-tools/src/loom_tools/daemon_v2/config.py
+++ b/loom-tools/src/loom_tools/daemon_v2/config.py
@@ -21,6 +21,8 @@ DEFAULT_CHAMPION_INTERVAL = 600  # seconds
 DEFAULT_DOCTOR_INTERVAL = 300  # seconds
 DEFAULT_AUDITOR_INTERVAL = 600  # seconds
 DEFAULT_JUDGE_INTERVAL = 300  # seconds
+DEFAULT_STARTUP_GRACE_PERIOD = 120  # seconds before early warning
+DEFAULT_NO_PROGRESS_GRACE_PERIOD = 300  # seconds before hard reclaim
 DEFAULT_STALL_DIAGNOSTIC_THRESHOLD = 3  # consecutive stalled iterations
 DEFAULT_STALL_RECOVERY_THRESHOLD = 5
 DEFAULT_STALL_RESTART_THRESHOLD = 10
@@ -59,6 +61,10 @@ class DaemonConfig:
     auditor_interval: int = DEFAULT_AUDITOR_INTERVAL
     judge_interval: int = DEFAULT_JUDGE_INTERVAL
 
+    # Shepherd startup detection thresholds
+    startup_grace_period: int = DEFAULT_STARTUP_GRACE_PERIOD
+    no_progress_grace_period: int = DEFAULT_NO_PROGRESS_GRACE_PERIOD
+
     # Stall escalation thresholds
     stall_diagnostic_threshold: int = DEFAULT_STALL_DIAGNOSTIC_THRESHOLD
     stall_recovery_threshold: int = DEFAULT_STALL_RECOVERY_THRESHOLD
@@ -89,6 +95,8 @@ class DaemonConfig:
             issue_threshold=env_int("LOOM_ISSUE_THRESHOLD", DEFAULT_ISSUE_THRESHOLD),
             issue_strategy=os.environ.get("LOOM_ISSUE_STRATEGY", "fifo"),
             max_proposals=env_int("LOOM_MAX_PROPOSALS", DEFAULT_MAX_PROPOSALS),
+            startup_grace_period=env_int("LOOM_STARTUP_GRACE_PERIOD", DEFAULT_STARTUP_GRACE_PERIOD),
+            no_progress_grace_period=env_int("LOOM_NO_PROGRESS_GRACE_PERIOD", DEFAULT_NO_PROGRESS_GRACE_PERIOD),
             architect_cooldown=env_int("LOOM_ARCHITECT_COOLDOWN", DEFAULT_ARCHITECT_COOLDOWN),
             hermit_cooldown=env_int("LOOM_HERMIT_COOLDOWN", DEFAULT_HERMIT_COOLDOWN),
             guide_interval=env_int("LOOM_GUIDE_INTERVAL", DEFAULT_GUIDE_INTERVAL),

--- a/loom-tools/src/loom_tools/models/daemon_state.py
+++ b/loom-tools/src/loom_tools/models/daemon_state.py
@@ -20,6 +20,7 @@ class ShepherdEntry:
     last_issue: int | None = None
     last_completed: str | None = None
     execution_mode: str | None = None
+    startup_warning_at: str | None = None
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ShepherdEntry:
@@ -36,6 +37,7 @@ class ShepherdEntry:
             last_issue=data.get("last_issue"),
             last_completed=data.get("last_completed"),
             execution_mode=data.get("execution_mode"),
+            startup_warning_at=data.get("startup_warning_at"),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -43,7 +45,7 @@ class ShepherdEntry:
         for k in (
             "issue", "task_id", "output_file", "started", "last_phase",
             "pr_number", "idle_since", "idle_reason", "last_issue",
-            "last_completed", "execution_mode",
+            "last_completed", "execution_mode", "startup_warning_at",
         ):
             v = getattr(self, k)
             if v is not None:

--- a/loom-tools/src/loom_tools/snapshot.py
+++ b/loom-tools/src/loom_tools/snapshot.py
@@ -75,7 +75,7 @@ class SnapshotConfig:
     # CI health check configuration
     ci_health_check_enabled: bool = True  # Enable CI status monitoring
     # Heartbeat grace period for newly spawned shepherds
-    heartbeat_grace_period: int = 600  # 10 minutes
+    heartbeat_grace_period: int = 300  # 5 minutes
     # Shorter grace period for shepherds that have already reported heartbeats
     heartbeat_active_grace_period: int = 180  # 3 minutes
     # Spinning issue detection: auto-escalate after N review cycles
@@ -113,7 +113,7 @@ class SnapshotConfig:
             systematic_failure_cooldown=_int("LOOM_SYSTEMATIC_FAILURE_COOLDOWN", 1800),
             systematic_failure_max_probes=_int("LOOM_SYSTEMATIC_FAILURE_MAX_PROBES", 3),
             ci_health_check_enabled=os.environ.get("LOOM_CI_HEALTH_CHECK", "true").lower() not in ("false", "0", "no"),
-            heartbeat_grace_period=_int("LOOM_HEARTBEAT_GRACE_PERIOD", 600),
+            heartbeat_grace_period=_int("LOOM_HEARTBEAT_GRACE_PERIOD", 300),
             heartbeat_active_grace_period=_int("LOOM_HEARTBEAT_ACTIVE_GRACE_PERIOD", 180),
             spinning_review_threshold=_int("LOOM_SPINNING_REVIEW_THRESHOLD", 3),
         )
@@ -1704,7 +1704,7 @@ ENVIRONMENT VARIABLES:
     LOOM_JUDGE_INTERVAL      Judge re-trigger interval in seconds (default: 300)
     LOOM_ISSUE_STRATEGY      Issue selection strategy (default: fifo)
     LOOM_HEARTBEAT_STALE_THRESHOLD  Heartbeat staleness threshold (default: 120)
-    LOOM_HEARTBEAT_GRACE_PERIOD     Grace period for new shepherds (default: 600)
+    LOOM_HEARTBEAT_GRACE_PERIOD     Grace period for new shepherds (default: 300s)
     LOOM_HEARTBEAT_ACTIVE_GRACE_PERIOD  Shorter grace for active shepherds (default: 180)
     LOOM_TMUX_SOCKET         Tmux socket name (default: loom)
     LOOM_MAX_RETRY_COUNT     Max retries for blocked issues (default: 3)

--- a/loom-tools/tests/test_snapshot.py
+++ b/loom-tools/tests/test_snapshot.py
@@ -400,14 +400,14 @@ class TestHeartbeatStaleness:
         assert cfg.heartbeat_grace_period == 900
 
     def test_grace_period_default(self) -> None:
-        """Default grace period is 600 seconds."""
+        """Default grace period is 300 seconds (reduced from 600 in #2198)."""
         cfg = SnapshotConfig()
-        assert cfg.heartbeat_grace_period == 600
+        assert cfg.heartbeat_grace_period == 300
 
     def test_grace_period_default_from_env(self) -> None:
-        """Default grace period via from_env() is 600 seconds."""
+        """Default grace period via from_env() is 300 seconds."""
         cfg = SnapshotConfig.from_env()
-        assert cfg.heartbeat_grace_period == 600
+        assert cfg.heartbeat_grace_period == 300
 
     def test_active_grace_period_detects_death_faster(self, tmp_path: pathlib.Path) -> None:
         """Shepherd spawned 4 min ago with stale heartbeat -> stale (past active grace, not full grace).


### PR DESCRIPTION
## Summary

- Implements two-tier detection for shepherds that fail to start without creating a progress file
  - **Tier 1 (120s)**: Log warning + capture tmux snapshot for debugging, set `startup_warning_at` to prevent duplicate warnings — does NOT kill
  - **Tier 2 (300s)**: Save full diagnostic output to `.loom/logs/stall-diagnostic-{name}-{timestamp}.log`, then reclaim the shepherd
- Captures tmux pane output before killing any stale session in `force_reclaim_stale_shepherds` for post-mortem analysis
- Reduces `heartbeat_grace_period` from 600s to 300s to match the new `NO_PROGRESS_GRACE_PERIOD`
- Makes both thresholds configurable via `DaemonConfig` / `LOOM_STARTUP_GRACE_PERIOD` and `LOOM_NO_PROGRESS_GRACE_PERIOD` env vars

## Files Changed

| File | Change |
|------|--------|
| `shepherds.py` | Split `_check_no_progress_file` into two tiers, add `_has_progress_data` and `_save_diagnostic_output` helpers, capture tmux before kill |
| `daemon_state.py` | Add `startup_warning_at` field to `ShepherdEntry` |
| `agent_spawn.py` | Add `capture_tmux_output()` utility function |
| `config.py` | Add `startup_grace_period` and `no_progress_grace_period` config fields |
| `snapshot.py` | Reduce `heartbeat_grace_period` default from 600s to 300s |
| `test_no_progress_detection.py` | 25 tests covering Tier 1 warning, Tier 2 reclaim, diagnostic capture, constants, and integration |
| `test_snapshot.py` | Update grace period assertions to 300s |

## Test Plan

- [x] Tier 1 warning fires at ~120s and sets `startup_warning_at`
- [x] Tier 1 warning does NOT duplicate on repeated calls
- [x] Tier 2 reclaim fires at ~300s and returns True
- [x] Shepherd within startup grace (60s) triggers neither warning nor reclaim
- [x] Healthy shepherd with progress file is never flagged
- [x] Diagnostic output saved to `.loom/logs/stall-diagnostic-*.log`
- [x] Empty tmux output skips file creation
- [x] `capture_tmux_output` called before `kill_stuck_session` (ordering verified)
- [x] `startup_warning_at` cleared on shepherd reset
- [x] All 149 daemon_v2 tests pass, all 130 snapshot tests pass
- [x] No regressions in full test suite (2359 passed, 3 pre-existing failures unrelated)

Closes #2198