### PR TITLE
feat: detect and surface human-input-needed blockers in daemon

### DIFF
--- a/loom-tools/src/loom_tools/models/daemon_state.py
+++ b/loom-tools/src/loom_tools/models/daemon_state.py
@@ -307,6 +307,7 @@ class DaemonState:
     blocked_issue_retries: dict[str, BlockedIssueRetry] = field(default_factory=dict)
     recent_failures: list[RecentFailure] = field(default_factory=list)
     transient_retries: dict[str, TransientRetryEntry] = field(default_factory=dict)
+    needs_human_input: list[dict[str, Any]] = field(default_factory=list)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> DaemonState:
@@ -361,6 +362,7 @@ class DaemonState:
             blocked_issue_retries=blocked_issue_retries,
             recent_failures=recent_failures,
             transient_retries=transient_retries,
+            needs_human_input=data.get("needs_human_input", []),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -383,6 +385,7 @@ class DaemonState:
             "transient_retries": {
                 k: v.to_dict() for k, v in self.transient_retries.items()
             },
+            "needs_human_input": self.needs_human_input,
         }
         for k in (
             "started_at", "last_poll", "daemon_session_id",

--- a/loom-tools/src/loom_tools/status.py
+++ b/loom-tools/src/loom_tools/status.py
@@ -265,6 +265,7 @@ def render_shepherds(
                     "completed_issue": " - awaiting next",
                     "rate_limited": " - rate limited",
                     "shutdown_signal": " - shutdown",
+                    "needs_human_input": " - waiting for human input",
                 }
                 reason_display = reason_map.get(entry.idle_reason, f" - {entry.idle_reason}")
 

--- a/loom-tools/tests/test_iteration.py
+++ b/loom-tools/tests/test_iteration.py
@@ -248,3 +248,28 @@ class TestRunIterationIntegration:
         assert ctx.snapshot["computed"]["available_shepherd_slots"] == 1
         assert result.completions_handled == 1
         assert "shepherds=2/3" in result.summary
+
+
+class TestBuildSummaryHumanInput:
+    """Tests for human-input-needed indicator in _build_summary."""
+
+    def test_summary_includes_human_input_count(self, tmp_path: pathlib.Path) -> None:
+        """Summary shows human_input_needed when blockers exist."""
+        ctx = _make_ctx(tmp_path)
+        ctx.snapshot["computed"]["needs_human_input"] = [
+            {"type": "approval_needed", "count": 2, "description": "2 curated"},
+            {"type": "proposal_review", "count": 1, "description": "1 architect"},
+        ]
+
+        result = IterationResult(status="success", summary="")
+        summary = _build_summary(ctx, result)
+        assert "human_input_needed=3" in summary
+
+    def test_summary_no_human_input_when_empty(self, tmp_path: pathlib.Path) -> None:
+        """Summary omits human_input_needed when no blockers."""
+        ctx = _make_ctx(tmp_path)
+        ctx.snapshot["computed"]["needs_human_input"] = []
+
+        result = IterationResult(status="success", summary="")
+        summary = _build_summary(ctx, result)
+        assert "human_input_needed" not in summary

--- a/loom-tools/tests/test_models.py
+++ b/loom-tools/tests/test_models.py
@@ -80,6 +80,34 @@ class TestDaemonState:
         assert ds.running is False
         assert ds.shepherds == {}
 
+    def test_needs_human_input_default(self) -> None:
+        ds = DaemonState.from_dict({})
+        assert ds.needs_human_input == []
+
+    def test_needs_human_input_round_trip(self) -> None:
+        blockers = [
+            {"type": "approval_needed", "count": 2, "description": "2 curated issue(s) awaiting approval"},
+            {"type": "proposal_review", "count": 1, "description": "1 architect proposal(s) awaiting review"},
+        ]
+        ds = DaemonState(needs_human_input=blockers)
+        out = ds.to_dict()
+        assert out["needs_human_input"] == blockers
+        ds2 = DaemonState.from_dict(out)
+        assert ds2.needs_human_input == blockers
+
+    def test_needs_human_input_from_existing_state(self) -> None:
+        """needs_human_input field is preserved when loading existing state files."""
+        data = {
+            "running": True,
+            "iteration": 5,
+            "needs_human_input": [
+                {"type": "blocked", "count": 3, "description": "3 blocked issues"},
+            ],
+        }
+        ds = DaemonState.from_dict(data)
+        assert len(ds.needs_human_input) == 1
+        assert ds.needs_human_input[0]["type"] == "blocked"
+
 
 class TestShepherdEntry:
     def test_idle_entry(self) -> None:

--- a/loom-tools/tests/test_snapshot.py
+++ b/loom-tools/tests/test_snapshot.py
@@ -1689,3 +1689,223 @@ class TestSnapshotConfigSpinning:
         cfg = SnapshotConfig()
         d = cfg.to_dict()
         assert d["spinning_review_threshold"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Human-input-needed blocker detection
+# ---------------------------------------------------------------------------
+
+
+class TestNeedsHumanInputActions:
+    """Tests for needs_human_input in compute_recommended_actions."""
+
+    def _base_kwargs(self) -> dict:
+        return {
+            "ready_count": 0,
+            "building_count": 0,
+            "blocked_count": 0,
+            "total_proposals": 0,
+            "architect_count": 0,
+            "hermit_count": 0,
+            "review_count": 0,
+            "changes_count": 0,
+            "merge_count": 0,
+            "available_shepherd_slots": 3,
+            "needs_work_generation": False,
+            "architect_cooldown_ok": False,
+            "hermit_cooldown_ok": False,
+            "support_roles": {r: SupportRoleState() for r in
+                              ("guide", "champion", "doctor", "auditor", "judge", "architect", "hermit")},
+            "orphaned_count": 0,
+            "invalid_task_id_count": 0,
+            "curated_count": 0,
+        }
+
+    def test_no_blockers_no_action(self) -> None:
+        """Empty pipeline with no curated/proposals → no needs_human_input action."""
+        kw = self._base_kwargs()
+        actions, demand = compute_recommended_actions(**kw)
+        assert "needs_human_input" not in actions
+        assert demand["human_input_blockers"] == []
+
+    def test_curated_issues_trigger_action(self) -> None:
+        """Curated issues awaiting approval trigger needs_human_input."""
+        kw = self._base_kwargs()
+        kw["curated_count"] = 2
+        kw["total_proposals"] = 2
+        actions, demand = compute_recommended_actions(**kw)
+        assert "needs_human_input" in actions
+        assert len(demand["human_input_blockers"]) == 1
+        assert demand["human_input_blockers"][0]["type"] == "approval_needed"
+        assert demand["human_input_blockers"][0]["count"] == 2
+
+    def test_architect_proposals_trigger_action(self) -> None:
+        """Architect proposals trigger needs_human_input."""
+        kw = self._base_kwargs()
+        kw["architect_count"] = 1
+        kw["total_proposals"] = 1
+        actions, demand = compute_recommended_actions(**kw)
+        assert "needs_human_input" in actions
+        blockers = demand["human_input_blockers"]
+        assert any(b["type"] == "proposal_review" for b in blockers)
+
+    def test_hermit_proposals_trigger_action(self) -> None:
+        """Hermit proposals trigger needs_human_input."""
+        kw = self._base_kwargs()
+        kw["hermit_count"] = 1
+        kw["total_proposals"] = 1
+        actions, demand = compute_recommended_actions(**kw)
+        assert "needs_human_input" in actions
+        blockers = demand["human_input_blockers"]
+        assert any(b["type"] == "proposal_review" for b in blockers)
+
+    def test_blocked_issues_trigger_action(self) -> None:
+        """Blocked issues trigger needs_human_input when pipeline is waiting."""
+        kw = self._base_kwargs()
+        kw["blocked_count"] = 3
+        actions, demand = compute_recommended_actions(**kw)
+        assert "needs_human_input" in actions
+        blockers = demand["human_input_blockers"]
+        assert any(b["type"] == "blocked" for b in blockers)
+        assert blockers[0]["count"] == 3
+
+    def test_multiple_blocker_types(self) -> None:
+        """Multiple blocker types all surface."""
+        kw = self._base_kwargs()
+        kw["curated_count"] = 2
+        kw["architect_count"] = 1
+        kw["hermit_count"] = 1
+        kw["blocked_count"] = 1
+        kw["total_proposals"] = 4
+        actions, demand = compute_recommended_actions(**kw)
+        assert "needs_human_input" in actions
+        blockers = demand["human_input_blockers"]
+        assert len(blockers) == 4
+        types = {b["type"] for b in blockers}
+        assert types == {"approval_needed", "proposal_review", "blocked"}
+
+    def test_no_action_when_pipeline_busy(self) -> None:
+        """Human-input blockers don't fire when pipeline is actively working."""
+        kw = self._base_kwargs()
+        kw["ready_count"] = 2  # Has ready work → "spawn_shepherds", no "wait"
+        kw["curated_count"] = 3
+        kw["total_proposals"] = 3
+        actions, demand = compute_recommended_actions(**kw)
+        assert "needs_human_input" not in actions
+        assert demand["human_input_blockers"] == []
+
+    def test_no_false_positive_empty_pipeline(self) -> None:
+        """Genuinely empty pipeline (no issues at all) → no needs_human_input."""
+        kw = self._base_kwargs()
+        actions, demand = compute_recommended_actions(**kw)
+        assert "needs_human_input" not in actions
+        assert demand["human_input_blockers"] == []
+
+
+class TestNeedsHumanInputHealth:
+    """Tests for needs_human_input warning in compute_health."""
+
+    def test_no_warning_when_pipeline_active(self) -> None:
+        """Active pipeline (ready issues) → no needs_human_input warning."""
+        status, warnings = compute_health(
+            ready_count=2, building_count=0, blocked_count=0,
+            total_proposals=3, stale_heartbeat_count=0, orphaned_count=0,
+            usage_healthy=True, session_percent=50.0,
+            curated_count=2, architect_count=1, hermit_count=0,
+        )
+        assert not any(w["code"] == "needs_human_input" for w in warnings)
+
+    def test_warning_when_idle_with_curated(self) -> None:
+        """Idle pipeline with curated issues → needs_human_input warning (stalled)."""
+        status, warnings = compute_health(
+            ready_count=0, building_count=0, blocked_count=0,
+            total_proposals=2, stale_heartbeat_count=0, orphaned_count=0,
+            usage_healthy=True, session_percent=50.0,
+            curated_count=2, architect_count=0, hermit_count=0,
+        )
+        assert status == "stalled"
+        hi_warns = [w for w in warnings if w["code"] == "needs_human_input"]
+        assert len(hi_warns) == 1
+        assert "2 curated issue(s) need approval" in hi_warns[0]["message"]
+
+    def test_warning_with_mixed_proposals(self) -> None:
+        """Idle pipeline with mixed proposals → detailed message."""
+        status, warnings = compute_health(
+            ready_count=0, building_count=0, blocked_count=0,
+            total_proposals=4, stale_heartbeat_count=0, orphaned_count=0,
+            usage_healthy=True, session_percent=50.0,
+            curated_count=1, architect_count=2, hermit_count=1,
+        )
+        assert status == "stalled"
+        hi_warns = [w for w in warnings if w["code"] == "needs_human_input"]
+        assert len(hi_warns) == 1
+        msg = hi_warns[0]["message"]
+        assert "1 curated issue(s) need approval" in msg
+        assert "2 architect proposal(s) need review" in msg
+        assert "1 hermit proposal(s) need review" in msg
+
+    def test_no_warning_genuinely_empty(self) -> None:
+        """Genuinely empty pipeline → no needs_human_input warning."""
+        status, warnings = compute_health(
+            ready_count=0, building_count=0, blocked_count=0,
+            total_proposals=0, stale_heartbeat_count=0, orphaned_count=0,
+            usage_healthy=True, session_percent=50.0,
+            curated_count=0, architect_count=0, hermit_count=0,
+        )
+        assert not any(w["code"] == "needs_human_input" for w in warnings)
+
+    def test_coexists_with_proposal_backlog(self) -> None:
+        """needs_human_input coexists with proposal_backlog (different levels)."""
+        status, warnings = compute_health(
+            ready_count=0, building_count=0, blocked_count=0,
+            total_proposals=2, stale_heartbeat_count=0, orphaned_count=0,
+            usage_healthy=True, session_percent=50.0,
+            curated_count=2, architect_count=0, hermit_count=0,
+        )
+        codes = [w["code"] for w in warnings]
+        assert "proposal_backlog" in codes
+        assert "needs_human_input" in codes
+        # proposal_backlog is info, needs_human_input is warning
+        pb = next(w for w in warnings if w["code"] == "proposal_backlog")
+        hi = next(w for w in warnings if w["code"] == "needs_human_input")
+        assert pb["level"] == "info"
+        assert hi["level"] == "warning"
+
+
+class TestBuildSnapshotNeedsHumanInput:
+    """Tests for needs_human_input in build_snapshot output."""
+
+    def _mock_pipeline(self) -> dict:
+        return {
+            "ready_issues": [],
+            "building_issues": [],
+            "blocked_issues": [],
+            "architect_proposals": [{"number": 10, "title": "Proposal", "labels": []}],
+            "hermit_proposals": [],
+            "curated_issues": [
+                {"number": 20, "title": "Curated", "labels": [{"name": "loom:curated"}]},
+            ],
+            "review_requested": [],
+            "changes_requested": [],
+            "ready_to_merge": [],
+            "usage": {"session_percent": 50},
+        }
+
+    def test_snapshot_includes_needs_human_input(self, tmp_path: pathlib.Path) -> None:
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir()
+        (loom_dir / "daemon-state.json").write_text("{}")
+
+        snapshot = build_snapshot(
+            cfg=_cfg(),
+            repo_root=tmp_path,
+            _now=NOW,
+            _pipeline_data=self._mock_pipeline(),
+            _tmux_pool=TmuxPool(),
+        )
+        computed = snapshot["computed"]
+        assert "needs_human_input" in computed
+        blockers = computed["needs_human_input"]
+        assert len(blockers) >= 1
+        types = {b["type"] for b in blockers}
+        assert "approval_needed" in types or "proposal_review" in types


### PR DESCRIPTION
## Summary

- Detects when the daemon is stalled due to needing human input (curated issues awaiting approval, architect/hermit proposals awaiting review, blocked issues)
- Surfaces these blockers in health warnings (`needs_human_input` at warning level → stalled status), recommended actions, daemon state, iteration summaries, and stall counter logs
- Adds `needs_human_input` field to `daemon-state.json` for external tool consumption

Closes #2205

## Criterion Verification

| Criterion | Status | Verification |
|-----------|--------|-------------|
| Detect curated issues awaiting approval | Pass | `compute_recommended_actions()` checks `curated_count` when pipeline idle |
| Detect architect/hermit proposals awaiting review | Pass | Both types detected separately with counts |
| Detect blocked issues needing intervention | Pass | `blocked_count` included in blockers |
| Surface in health warnings | Pass | `needs_human_input` warning at "warning" level pushes status to "stalled" |
| Surface in recommended actions | Pass | `needs_human_input` action emitted with structured blocker details |
| Persist in daemon-state.json | Pass | `DaemonState.needs_human_input` field serialized/deserialized |
| Log actionable items during stall | Pass | `_update_stall_counter()` logs specific blocker descriptions |
| Include in iteration summary | Pass | `human_input_needed=N` shown in summary line |
| No false positives on empty pipeline | Pass | Unit test verifies empty pipeline → no blockers |
| No false positives when pipeline busy | Pass | Unit test verifies active pipeline → no blockers |

## Test plan

- [x] Unit tests — `compute_recommended_actions()` detects human-input blockers (8 tests)
- [x] Unit tests — `compute_health()` emits `needs_human_input` warning (5 tests)
- [x] Unit tests — `build_snapshot()` includes `needs_human_input` in computed section
- [x] Unit tests — `DaemonState` model round-trips `needs_human_input` field (3 tests)
- [x] Unit tests — `_build_summary()` includes `human_input_needed` count (2 tests)
- [x] Edge case — No false positives on genuinely empty pipeline
- [x] Edge case — No false positives when pipeline has ready work
- [x] Full test suite: 2533 passed, 0 failed

## Files changed

| File | Change |
|------|--------|
| `snapshot.py` | Added `curated_count`/`architect_count`/`hermit_count` params; human-input blocker detection in actions and health |
| `daemon_state.py` | Added `needs_human_input` field with from_dict/to_dict support |
| `iteration.py` | Stall counter logs blocker details; summary shows count; state populated from snapshot |
| `status.py` | Added `needs_human_input` idle reason display |
| `test_snapshot.py` | 16 new tests for blocker detection in actions, health, and snapshot |
| `test_models.py` | 3 new tests for DaemonState needs_human_input field |
| `test_iteration.py` | 2 new tests for summary human_input_needed indicator |