### PR TITLE
chore: bump version to 0.2.1 and fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,23 +70,30 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
+      - name: Get app version
+        id: version
+        run: |
+          APP_VERSION=$(jq -r '.version' src-tauri/tauri.conf.json)
+          echo "app_version=${APP_VERSION}" >> "$GITHUB_OUTPUT"
+
       - name: Create universal binary (optional)
         run: |
           # Create universal DMG filename
           VERSION="${{ github.event.release.tag_name || inputs.tag || 'dev' }}"
+          APP_VERSION="${{ steps.version.outputs.app_version }}"
 
           # The individual .app bundles are in:
           # - target/aarch64-apple-darwin/release/bundle/macos/Loom.app
           # - target/x86_64-apple-darwin/release/bundle/macos/Loom.app
 
           # Rename DMGs with version and architecture
-          if [ -f "target/aarch64-apple-darwin/release/bundle/dmg/Loom_0.1.0_aarch64.dmg" ]; then
-            cp "target/aarch64-apple-darwin/release/bundle/dmg/Loom_0.1.0_aarch64.dmg" \
+          if [ -f "target/aarch64-apple-darwin/release/bundle/dmg/Loom_${APP_VERSION}_aarch64.dmg" ]; then
+            cp "target/aarch64-apple-darwin/release/bundle/dmg/Loom_${APP_VERSION}_aarch64.dmg" \
                "target/Loom-${VERSION}-aarch64.dmg"
           fi
 
-          if [ -f "target/x86_64-apple-darwin/release/bundle/dmg/Loom_0.1.0_x64.dmg" ]; then
-            cp "target/x86_64-apple-darwin/release/bundle/dmg/Loom_0.1.0_x64.dmg" \
+          if [ -f "target/x86_64-apple-darwin/release/bundle/dmg/Loom_${APP_VERSION}_x64.dmg" ]; then
+            cp "target/x86_64-apple-darwin/release/bundle/dmg/Loom_${APP_VERSION}_x64.dmg" \
                "target/Loom-${VERSION}-x64.dmg"
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to Loom will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.2.0] - 2026-01-24
 
 ### Summary
@@ -154,5 +156,6 @@ Existing v0.1.x installations can upgrade cleanly:
 - Installation script for target repositories
 - Quickstart templates for webapp, desktop, and API projects
 
+[Unreleased]: https://github.com/rjwalters/loom/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/rjwalters/loom/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/rjwalters/loom/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "app"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2379,7 +2379,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "loom-api"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -2396,7 +2396,7 @@ dependencies = [
 
 [[package]]
 name = "loom-daemon"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/loom-api/Cargo.toml
+++ b/loom-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loom-api"
-version = "0.1.0"
+version = "0.2.1"
 edition = "2021"
 description = "External REST API for Loom analytics data access"
 

--- a/loom-daemon/Cargo.toml
+++ b/loom-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loom-daemon"
-version = "0.1.0"
+version = "0.2.1"
 edition = "2021"
 
 [dependencies]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loom",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A multi-terminal desktop application for macOS that orchestrates AI-powered development workers using git worktrees and GitHub as the coordination layer.",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.1.0"
+version = "0.2.1"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Loom",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "com.github.rjwalters.loom",
   "build": {
     "beforeBuildCommand": "pnpm build",


### PR DESCRIPTION
## Summary
- Sync all package versions to 0.2.1 (Cargo crates were still at 0.1.0)
- Fix hardcoded `Loom_0.1.0` DMG paths in `release.yml` with dynamic version lookup from `tauri.conf.json`
- Add `[Unreleased]` section to CHANGELOG for tracking 0.2.1 changes

## Release steps after merge
1. Update CHANGELOG `[Unreleased]` → `[0.2.1] - YYYY-MM-DD`
2. `git tag v0.2.1 && git push origin v0.2.1`
3. Create GitHub release from the tag — `release.yml` builds and attaches macOS DMGs

## Test plan
- [ ] Verify `cargo check --workspace` passes (Tauri binary warning is pre-existing)
- [ ] Verify version consistency across all manifests

🤖 Generated with [Claude Code](https://claude.com/claude-code)