### PR TITLE
chore: add ghloc lines-of-code badge to README

### DIFF
--- a/.github/workflows/loc.yml
+++ b/.github/workflows/loc.yml
@@ -1,0 +1,15 @@
+name: Lines of Code
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  loc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rjwalters/ghloc@main

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![codecov](https://codecov.io/gh/rjwalters/loom/branch/main/graph/badge.svg)](https://codecov.io/gh/rjwalters/loom)
 [![GitHub Release](https://img.shields.io/github/v/release/rjwalters/loom?include_prereleases)](https://github.com/rjwalters/loom/releases)
+[![Lines of Code](https://raw.githubusercontent.com/rjwalters/loom/main/.ghloc/badge.svg)](https://github.com/rjwalters/loom)
 
 **AI-powered development orchestration using GitHub as the coordination layer.**
 


### PR DESCRIPTION
## Summary
- Add `rjwalters/ghloc` GitHub Action workflow (runs on push to main)
- Add LOC badge to README alongside existing codecov and release badges

## Test plan
- [ ] Verify workflow runs successfully after merge (generates `.ghloc/badge.svg`)
- [ ] Verify badge renders on repo page once SVG is committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)