### PR TITLE
fix: push ghloc badge to separate branch to avoid ruleset conflict

### DIFF
--- a/.github/workflows/loc.yml
+++ b/.github/workflows/loc.yml
@@ -12,4 +12,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - uses: rjwalters/ghloc@main
+        continue-on-error: true
+
+      - name: Push badge to ghloc branch
+        run: |
+          if [ ! -d .ghloc ]; then
+            echo "No .ghloc directory generated, skipping"
+            exit 0
+          fi
+          cp -r .ghloc /tmp/ghloc-output
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin ghloc || true
+          git checkout --orphan ghloc
+          git rm -rf .
+          cp -r /tmp/ghloc-output .ghloc
+          git add .ghloc
+          git commit -m "Update LOC badge and chart [skip ci]"
+          git push origin ghloc --force

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![codecov](https://codecov.io/gh/rjwalters/loom/branch/main/graph/badge.svg)](https://codecov.io/gh/rjwalters/loom)
 [![GitHub Release](https://img.shields.io/github/v/release/rjwalters/loom?include_prereleases)](https://github.com/rjwalters/loom/releases)
-[![Lines of Code](https://raw.githubusercontent.com/rjwalters/loom/main/.ghloc/badge.svg)](https://github.com/rjwalters/loom)
+[![Lines of Code](https://raw.githubusercontent.com/rjwalters/loom/ghloc/.ghloc/badge.svg)](https://github.com/rjwalters/loom)
 
 **AI-powered development orchestration using GitHub as the coordination layer.**
 


### PR DESCRIPTION
## Summary
- The `ghloc` action's direct push to main is blocked by branch protection rules
- Updated workflow to let the action generate files (`continue-on-error`), then push them to an orphan `ghloc` branch
- Updated badge URL in README to point at `ghloc` branch instead of `main`
- Reverted the unnecessary ruleset bypass actor that was added during debugging

## Test plan
- [ ] Verify LOC workflow succeeds after merge (pushes to `ghloc` branch)
- [ ] Verify badge renders correctly from `ghloc` branch URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)