### PR TITLE
fix: resolve pipe-pane log capture issues with trailing CR and buffering

### DIFF
--- a/loom-tools/src/loom_tools/agent_spawn.py
+++ b/loom-tools/src/loom_tools/agent_spawn.py
@@ -574,8 +574,11 @@ def spawn_agent(
     # blank line suppression, and duplicate line collapsing.
     # Falls back to basic sed stripping if Python filter is unavailable.
     strip_ansi_cmd = (
-        f"python3 -m loom_tools.log_filter >> '{log_file}' 2>/dev/null "
-        f"|| sed -E 's/\\x1b\\[[?0-9;]*[a-zA-Z]//g; "
+        f"python3 -u -m loom_tools.log_filter >> '{log_file}' 2>/dev/null "
+        f"|| sed -l -E 's/\\x1b\\[[?0-9;]*[a-zA-Z]//g; "
+        f"s/\\x1b\\][^\\x07]*\\x07//g' "
+        f">> '{log_file}' 2>/dev/null "
+        f"|| sed -u -E 's/\\x1b\\[[?0-9;]*[a-zA-Z]//g; "
         f"s/\\x1b\\][^\\x07]*\\x07//g' "
         f">> '{log_file}'"
     )

--- a/loom-tools/src/loom_tools/log_filter.py
+++ b/loom-tools/src/loom_tools/log_filter.py
@@ -29,6 +29,10 @@ def clean_line(raw: str) -> str | None:
 
     Returns the cleaned line, or None if the line should be suppressed.
     """
+    # Strip trailing \r before splitting so that "content\r" doesn't
+    # resolve to an empty last segment (which would be suppressed as blank).
+    raw = raw.rstrip("\r")
+
     # Process carriage returns: keep only the last segment
     # This handles spinner animation where lines are overwritten with \r
     if "\r" in raw:
@@ -71,7 +75,7 @@ def main() -> None:
     dup_count = 0
 
     try:
-        for raw_line in sys.stdin:
+        for raw_line in iter(sys.stdin.readline, ""):
             # Remove trailing newline for processing
             raw = raw_line.rstrip("\n")
 

--- a/loom-tools/src/loom_tools/shepherd/phases/base.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/base.py
@@ -302,7 +302,12 @@ def _is_instant_exit(log_path: Path) -> bool:
 
         content = log_path.read_text()
         stripped = strip_ansi(content)
-        return len(stripped.strip()) < INSTANT_EXIT_MIN_OUTPUT_CHARS
+        # Exclude log header lines (e.g. "# Loom Agent Log", "# Session: ...")
+        # so that a log with only the header is correctly detected as instant exit.
+        non_header = "\n".join(
+            line for line in stripped.splitlines() if not line.startswith("# ")
+        )
+        return len(non_header.strip()) < INSTANT_EXIT_MIN_OUTPUT_CHARS
     except OSError:
         return False
 

--- a/loom-tools/tests/test_agent_spawn.py
+++ b/loom-tools/tests/test_agent_spawn.py
@@ -487,8 +487,8 @@ class TestAnsiStripping:
             pipe_pane_call = pipe_pane_calls[0]
             pipe_cmd = pipe_pane_call[0][3] if len(pipe_pane_call[0]) > 3 else ""
 
-            assert "python3 -m loom_tools.log_filter" in pipe_cmd, \
-                f"pipe-pane should use Python log filter, got: {pipe_cmd}"
+            assert "python3 -u -m loom_tools.log_filter" in pipe_cmd, \
+                f"pipe-pane should use Python log filter with -u flag, got: {pipe_cmd}"
             assert "sed" in pipe_cmd, \
                 f"pipe-pane should include sed fallback, got: {pipe_cmd}"
             assert ">>" in pipe_cmd, \

--- a/loom-tools/tests/test_log_filter.py
+++ b/loom-tools/tests/test_log_filter.py
@@ -147,6 +147,24 @@ class TestCleanLine:
     def test_plain_text_unchanged(self) -> None:
         assert clean_line("Hello, world!") == "Hello, world!"
 
+    # -- Trailing \r regression tests (issue #2230) --
+
+    def test_trailing_cr_preserves_content(self) -> None:
+        """Line ending with \\r should return content, not None."""
+        assert clean_line("echo HELLO\r") == "echo HELLO"
+
+    def test_trailing_cr_with_ansi(self) -> None:
+        """ANSI-wrapped line ending with \\r should return stripped content."""
+        assert clean_line("\x1b[32mecho HELLO\x1b[0m\r") == "echo HELLO"
+
+    def test_trailing_cr_only(self) -> None:
+        """A bare \\r with no content should return None (blank)."""
+        assert clean_line("\r") is None
+
+    def test_trailing_multiple_cr(self) -> None:
+        """Multiple trailing \\r characters should still preserve content."""
+        assert clean_line("content\r\r\r") == "content"
+
 
 # ---------------------------------------------------------------------------
 # TestMain — integration tests for main()


### PR DESCRIPTION
## Summary

- Fix `clean_line()` in `log_filter.py` to strip trailing `\r` before splitting, so lines like `"echo HELLO\r"` return `"echo HELLO"` instead of `None`
- Switch `main()` from `for line in sys.stdin:` to `iter(sys.stdin.readline, "")` for unbuffered line-by-line reading
- Add `-u` flag to `python3` invocation and `-l` (BSD) / `-u` (GNU) line-buffer flags to sed fallback in `agent_spawn.py`
- Exclude log header lines (starting with `# `) from character count in `_is_instant_exit()` so header-only logs are correctly detected as instant exits
- Add 4 regression tests for trailing `\r` handling in `test_log_filter.py`

Closes #2230

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `clean_line()` handles trailing `\r` correctly | ✅ | `clean_line("echo HELLO\r")` returns `"echo HELLO"` — new test passes |
| `main()` uses `iter(sys.stdin.readline, "")` | ✅ | Code updated, all main() integration tests pass |
| `agent_spawn.py` sed fallback uses `-l`/`-u` flags | ✅ | BSD `-l` with GNU `-u` fallback chain |
| `agent_spawn.py` python3 uses `-u` flag | ✅ | Added to pipe-pane command, test updated |
| `_is_instant_exit()` excludes `# ` header lines | ✅ | Header lines filtered before character count |
| All existing tests pass | ✅ | 2563 passed (3 pre-existing failures in test_agent_monitor.py unrelated to this PR) |
| New regression tests for trailing `\r` | ✅ | 4 new tests added and passing |

## Test plan

- [x] `pytest loom-tools/tests/test_log_filter.py -v` — 49 tests pass (45 existing + 4 new)
- [x] `pytest loom-tools/tests/test_agent_spawn.py -v` — updated assertion for `-u` flag passes
- [x] `pytest loom-tools/tests/shepherd/test_phases.py -k instant_exit` — 5 instant-exit tests pass
- [x] Full test suite: 2563 passed, 32 skipped (3 pre-existing failures in test_agent_monitor.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)