### PR TITLE
docs: rewrite contributing guide for AI-developed project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,402 +1,99 @@
 # Contributing to Loom
 
-Thank you for your interest in contributing to Loom!
+Loom is not a typical open-source project. It is built primarily by AI agents — Claude Code instances orchestrated by the Loom system itself. There is no core team of human developers writing code day-to-day. Instead, the system generates work, builds features, reviews its own PRs, and merges them.
 
-## About Loom Development
+This means the most valuable thing you can do is **use Loom on real projects and tell us what happens**.
 
-Loom is developed **using Loom itself** - our AI agents (Worker, Curator, Reviewer, Architect, Critic) collaborate through GitHub to build and improve the project. This means:
+## How to Contribute
 
-- **Code development** is handled by autonomous AI agents
-- **External contributions** are primarily limited to suggestions and issue reports
-- **All pull requests** are created and reviewed by the agent system
+### Use Loom
 
-## How External Contributors Can Help
+The single most impactful contribution is running Loom against a real codebase. The agents can't discover problems they don't encounter. Every time you use Loom and something goes wrong — a confusing error, a broken workflow, a daemon that hangs, a PR that doesn't make sense — that's information we need.
 
-While direct code contributions follow a unique workflow, external contributors can still make valuable contributions:
+Install Loom, point it at a project, and see what happens. The [Getting Started Guide](docs/guides/getting-started.md) will walk you through setup.
 
-### 1. Report Bugs
+### Report Bugs
 
-If you find a bug:
-- Search existing issues to avoid duplicates
-- Create a new issue with a clear, descriptive title
-- Include steps to reproduce, expected vs actual behavior
-- Add system information (OS, Loom version)
-- Label with `bug` (if you have permissions)
+When something breaks, [open an issue](https://github.com/rjwalters/loom/issues/new). Good bug reports include:
 
-The Architect agent will review bug reports and may create proposals for fixes.
+- **What you were doing** — which mode (daemon, manual, app), which roles were active
+- **What went wrong** — error messages, unexpected behavior, things that got stuck
+- **Logs if you have them** — daemon state, terminal output, GitHub Actions logs
+- **Your environment** — macOS version, Loom version, how you installed it
 
-### 2. Suggest Features
+Don't worry about formatting it perfectly. A rough report is infinitely more useful than silence.
 
-Have an idea for improving Loom?
-- Search existing issues to see if it's been suggested
-- Create a new issue with a detailed description
-- Explain the use case and expected benefits
-- Label with `enhancement` (if you have permissions)
+### Request Features
 
-The Architect agent periodically scans issues and creates `loom:proposal` issues for features it deems valuable. The maintainers review these proposals and approve by removing the `loom:proposal` label.
+If you find yourself wishing Loom did something differently, [open an issue](https://github.com/rjwalters/loom/issues/new). Describe the workflow you want, not just the feature. "I want Loom to handle monorepos" is good. "I want a `--monorepo` flag" is less useful because it assumes an implementation.
 
-### 3. Improve Documentation
+The system's Architect agent scans issues and generates proposals for features it considers viable. Maintainers review and approve proposals, and then the Builder agents implement them.
 
-Documentation improvements are always welcome:
-- Fix typos or unclear explanations
-- Add examples or clarifications
-- Update outdated information
-- Expand guides based on your experience
+### Share Your Experience
 
-Documentation changes follow the same PR process (see below).
+Comment on existing issues with additional context. If you hit the same bug someone else reported, say so — frequency signals priority. If you tried a workaround, share it. If you have opinions about how a feature should work, weigh in.
 
-### 4. Participate in Discussions
+## What About Pull Requests?
 
-- Comment on issues with insights or additional context
-- Help other users in discussions
-- Share your experience using Loom
-- Suggest workflow improvements
+PRs in this repository are almost exclusively created by the agent system. The typical lifecycle is:
+
+1. A human (or the Architect agent) creates an issue
+2. The Curator agent refines it with technical details
+3. The Builder agent implements it in a worktree
+4. The Judge agent reviews the PR
+5. The Champion agent merges it
+
+If you want to submit a PR directly, you're welcome to, but know that it will be reviewed by both AI agents and the maintainer. For small fixes (typos, broken links, documentation clarifications), a PR is fine. For anything substantial, open an issue first — the system may be able to build it faster than you expect, and the issue ensures your intent is captured even if the implementation takes a different shape.
+
+### If You Do Submit a PR
+
+Run `pnpm check:ci` before pushing. This runs the full CI suite locally (linting, formatting, type checking, tests). PRs that fail CI won't be merged.
 
 ## Development Setup
 
-If you want to explore the codebase or test changes locally:
+If you want to explore the codebase or run Loom locally:
 
-### Prerequisites
-
-- **Node.js** 20+ and pnpm
-- **Rust** 1.60+ (stable)
-- **tmux** (for terminal management)
-- **Git**
-- **GitHub CLI** (`gh`) for issue/PR management
-
-### Installation
+**Prerequisites**: Node.js 20+, pnpm, Rust (stable), tmux, Git, GitHub CLI (`gh`)
 
 ```bash
-# Clone the repository
 git clone https://github.com/rjwalters/loom.git
 cd loom
-
-# Install dependencies
 pnpm install
-
-# Start development environment
 pnpm app:dev
 ```
 
-### Alternative: Headless Installation
-
-You can also initialize Loom in a repository using the CLI without the GUI:
+Or headless (no GUI):
 
 ```bash
-# Build the daemon
-cd loom
 cargo build --release -p loom-daemon
-
-# Initialize a repository
-./target/release/loom-daemon init /path/to/repo
-
-# Or initialize the Loom repo itself
-./target/release/loom-daemon init .
+./target/release/loom-daemon init /path/to/your/repo
 ```
 
-This is useful for:
-- Testing initialization logic
-- Setting up Loom in CI/CD environments
-- Bulk repository initialization
-- Development without running the full GUI
-
-**See also:**
-- [Getting Started Guide](docs/guides/getting-started.md) - Complete setup walkthrough
-- [CLI Reference](docs/guides/cli-reference.md) - Full `loom-daemon init` documentation
-
-For detailed development workflows, see [DEV_WORKFLOW.md](docs/guides/dev-workflow.md).
-
-## Development Workflow
-
-### Working on an Issue
-
-If you'd like to work on an issue (subject to maintainer approval):
-
-```bash
-# 1. Claim the issue
-gh issue edit <number> --add-label "loom:building"
-
-# 2. Create a worktree
-pnpm worktree <issue-number>
-cd .loom/worktrees/issue-<number>
-
-# 3. Make your changes
-# ... implement, test, document ...
-
-# 4. CRITICAL: Run full CI suite locally
-pnpm check:ci
-
-# 5. Commit and push
-git add -A
-git commit -m "Your descriptive commit message"
-git push -u origin feature/issue-<number>
-
-# 6. Create PR
-gh pr create --label "loom:review-requested"
-```
-
-### IMPORTANT: Pre-PR Checklist
-
-Before creating or updating a Pull Request, you **MUST** run:
-
-```bash
-pnpm check:ci
-```
-
-This runs the complete CI suite locally:
-- Biome linting and formatting (TypeScript/JavaScript)
-- Rust formatting (rustfmt)
-- Clippy with all CI flags
-- Cargo check
-- Frontend build (TypeScript + Vite)
-- All tests
-
-**If `pnpm check:ci` fails, fix the issues before creating your PR.** PRs that fail CI will not be merged.
-
-## Code Style and Conventions
-
-### TypeScript/JavaScript
-
-- **Linter**: Biome (configured in `biome.json`)
-- **Format on save**: Enabled in VSCode settings
-- **Strict mode**: TypeScript strict mode enabled
-- **Commands**:
-  - `pnpm lint` - Check for linting issues
-  - `pnpm lint:fix` - Auto-fix linting issues
-  - `pnpm format` - Check formatting
-  - `pnpm format:write` - Auto-format code
-
-### Rust
-
-- **Formatter**: rustfmt (configured in `rustfmt.toml`)
-- **Linter**: Clippy (configured in `.cargo/config.toml`)
-- **Commands**:
-  - `pnpm clippy` - Run Clippy with exact CI flags
-  - `pnpm clippy:fix` - Auto-fix Clippy issues
-  - `pnpm format:rust` - Check Rust formatting
-  - `pnpm format:rust:write` - Auto-format Rust code
-
-### Git Hooks
-
-Pre-commit hooks automatically run via husky and lint-staged:
-- TypeScript/JavaScript files are formatted and linted with Biome
-- Rust files are formatted with rustfmt and linted with Clippy
-
-If hooks fail, the commit will be blocked - fix issues before retrying.
-
-## Testing
-
-Loom has comprehensive testing at multiple levels:
-
-```bash
-# Run all tests
-pnpm test
-
-# Run daemon integration tests
-pnpm daemon:test
-
-# Run with verbose output
-pnpm daemon:test:verbose
-```
-
-**Requirements**: Tests require `tmux` installed (`brew install tmux` on macOS)
-
-See [docs/guides/testing.md](docs/guides/testing.md) for detailed testing documentation.
-
-## Pull Request Process
-
-1. **Create a feature branch** from `main`
-2. **Implement your changes** following code style conventions
-3. **Test thoroughly** - manual testing and automated tests
-4. **Run `pnpm check:ci`** - ensure all checks pass locally
-5. **Create a PR** with a clear description
-6. **Address review feedback** from the Reviewer agent
-7. **Wait for approval** - maintainer will merge when ready
-
-### PR Description Guidelines
-
-Your PR description should include:
-- **Summary**: Brief description of what changed
-- **Motivation**: Why this change is needed
-- **Test Plan**: How you tested the changes
-- **Related Issues**: Link to issue (e.g., "Closes #123")
-
-### Label Workflow
-
-Loom uses GitHub labels for coordination:
-
-- **`loom:building`**: Issue is being worked on
-- **`loom:review-requested`**: PR ready for review
-- **`loom:changes-requested`**: PR needs fixes
-- **`loom:pr`**: PR approved, ready to merge
-
-See [WORKFLOWS.md](WORKFLOWS.md) for complete label workflow documentation.
-
-## Common Mistakes to Avoid
-
-1. Running `cargo clippy` directly instead of `pnpm clippy` (misses CI flags)
-2. Using `app:dev` when working on Loom codebase (causes restart loops - use `app:preview` instead)
-3. Missing dark mode variants on Tailwind classes
-4. Creating nested worktrees (use `pnpm worktree --check` to verify location)
-5. Not running `pnpm check:ci` before creating PR
-
-## Git Worktree Helper
-
-Loom uses git worktrees for isolated development:
-
-```bash
-# Create worktree for an issue
-pnpm worktree <issue-number>
-
-# Check current worktree status
-pnpm worktree --check
-
-# Show help
-pnpm worktree --help
-```
-
-**Always use the helper script** - it prevents nested worktrees and ensures correct paths.
+See the [Getting Started Guide](docs/guides/getting-started.md) and [CLI Reference](docs/guides/cli-reference.md) for details.
 
 ## Project Structure
 
 ```
 loom/
-├── src/                    # TypeScript frontend
-│   ├── lib/               # State, config, UI, theme
-│   └── main.ts            # Application entry point
-├── src-tauri/             # Rust backend (Tauri commands)
-├── loom-daemon/           # Rust daemon (terminal management)
-├── .loom/                 # Workspace config (gitignored)
-├── defaults/              # Default configuration templates
-├── docs/                  # Detailed documentation
-│   ├── guides/           # Development guides
-│   ├── adr/              # Architecture decision records
-│   └── workflows/        # Agent workflow docs
-└── package.json          # pnpm scripts
+├── src/                    # TypeScript frontend (Svelte + Tauri)
+├── src-tauri/              # Rust backend (Tauri commands)
+├── loom-daemon/            # Rust daemon (terminal management)
+├── .loom/                  # Workspace config and agent roles
+├── defaults/               # Default configuration templates
+├── docs/                   # Documentation
+└── scripts/                # Installation and setup scripts
 ```
-
-## Additional Resources
-
-### Essential Documentation
-
-- **[README.md](README.md)** - Project overview and vision
-- **[CLAUDE.md](CLAUDE.md)** - AI development context and patterns
-- **[DEV_WORKFLOW.md](docs/guides/dev-workflow.md)** - Development workflow with hot reload
-- **[DEVELOPMENT.md](docs/guides/development.md)** - Code quality and testing
-- **[WORKFLOWS.md](docs/workflows.md)** - Agent coordination via labels
-
-### Development Guides
-
-- **[Architecture Patterns](docs/guides/architecture-patterns.md)** - Observer pattern, IPC, worktrees
-- **[TypeScript Conventions](docs/guides/typescript-conventions.md)** - Strict mode, type safety
-- **[Code Quality](docs/guides/code-quality.md)** - Linting, formatting, CI/CD
-- **[Testing](docs/guides/testing.md)** - Testing strategies and MCP tools
-- **[Git Workflow](docs/guides/git-workflow.md)** - Branch strategy, commits, PRs
-- **[Common Tasks](docs/guides/common-tasks.md)** - Adding features, properties
-- **[Styling](docs/guides/styling.md)** - TailwindCSS, theme system
-
-### External Documentation
-
-- **[Tauri Documentation](https://tauri.app/)** - Desktop app framework
-- **[Biome Documentation](https://biomejs.dev/)** - Linter and formatter
-- **[Rust Book](https://doc.rust-lang.org/book/)** - Rust programming
-- **[TypeScript Documentation](https://www.typescriptlang.org/docs/)** - TypeScript language
-- **[TailwindCSS Documentation](https://tailwindcss.com/docs)** - Utility-first CSS
-
-## Release Process
-
-Loom uses automated release workflows to build and distribute binaries.
-
-### Creating a Release
-
-Releases are triggered automatically when a version tag is pushed:
-
-```bash
-# 1. Update version in Cargo.toml files
-# loom-daemon/Cargo.toml
-# src-tauri/Cargo.toml
-
-# 2. Create and push version tag
-git tag -a v0.2.0 -m "Release v0.2.0"
-git push origin v0.2.0
-```
-
-### Release Workflow
-
-The release workflow (`.github/workflows/release.yml`) automatically:
-
-1. **Builds macOS binary** - Compiles Tauri app for macOS
-2. **Creates DMG installer** - Packages app into distributable DMG
-3. **Generates changelog** - Auto-generates from merged PRs and commits
-4. **Creates GitHub Release** - Publishes release with changelog and DMG attachment
-
-### Changelog Generation
-
-Changelogs are auto-generated from GitHub PR labels:
-
-- **Features** (`enhancement`, `feature` labels) → 🚀 Features section
-- **Bug Fixes** (`bug` label) → 🐛 Bug Fixes section
-- **Documentation** (`documentation` label) → 📚 Documentation section
-- **Maintenance** (`chore`, `dependencies` labels) → 🧹 Maintenance section
-
-**Best Practice**: Always label PRs appropriately before merging to ensure accurate changelogs.
-
-### Performance Benchmarks
-
-The benchmark workflow (`.github/workflows/benchmark.yml`) runs automatically on:
-
-- **Push to main** - Tracks performance over time
-- **Pull requests** - Detects performance regressions
-
-Benchmark results are stored and tracked using `github-action-benchmark`:
-
-- **Alert threshold**: 150% (warns if performance degrades by >50%)
-- **Fail on alert**: true (fails CI if threshold exceeded)
-- **Comment on PRs**: Automatically posts performance comparison
-
-### Running Benchmarks Locally
-
-```bash
-# Run all Criterion benchmarks
-cargo bench --workspace
-
-# Run specific benchmark
-cargo bench --package loom-daemon --bench terminal_benchmarks
-
-# View results
-open target/criterion/report/index.html
-```
-
-### Distribution
-
-Release artifacts are attached to GitHub releases:
-
-- **Loom-macOS.dmg** - macOS installer for Apple Silicon and Intel
-
-Users can download the DMG from the [Releases page](https://github.com/rjwalters/loom/releases).
 
 ## Code of Conduct
 
-Be respectful and constructive in all interactions:
-- Be kind and courteous
-- Respect differing viewpoints and experiences
-- Accept constructive criticism gracefully
-- Focus on what's best for the community and project
-- Show empathy towards other community members
+Be respectful and constructive. This is a small project and a weird one — AI building software is new territory for everyone. Patience and good faith go a long way.
 
 ## License
 
-By contributing to Loom, you agree that your contributions will be licensed under the MIT License.
-
-See [LICENSE](LICENSE) for the full license text.
+Contributions are licensed under the [MIT License](LICENSE).
 
 ## Questions?
 
-- **General questions**: Open a GitHub Discussion
-- **Bug reports**: Create an issue with the `bug` label
-- **Feature requests**: Create an issue with the `enhancement` label
-- **Security issues**: See [SECURITY.md](SECURITY.md) (if it exists) or contact maintainers directly
-
----
-
-**Thank you for contributing to Loom!** Your suggestions and feedback help make this project better.
+- **Bug reports and feature requests**: [GitHub Issues](https://github.com/rjwalters/loom/issues)
+- **General discussion**: [GitHub Discussions](https://github.com/rjwalters/loom/discussions)
+- **Security concerns**: Contact the maintainer directly


### PR DESCRIPTION
## Summary

- Rewrites CONTRIBUTING.md to reflect that this project is primarily built by AI agents
- Reframes contributions around usage, bug reports, and feature requests rather than traditional PRs
- Cuts from 400 lines to 100 by removing agent-facing details (code style, worktree workflows, label mechanics)

## Context

The previous guide was written in a traditional open-source style with detailed PR workflows, code conventions, and worktree instructions. That doesn't match how this project actually works — code is written by agents, and the most valuable human contribution is using Loom and reporting what breaks.

## Test plan

- [ ] Review rendered markdown on GitHub
- [ ] Verify all links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)