### PR TITLE
fix: use same test command for baseline comparison in scoped tests

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -1418,8 +1418,10 @@ class BuilderPhase:
         if not ctx.worktree_path or not ctx.worktree_path.is_dir():
             return None
 
-        # Run baseline tests on main
-        baseline_result = self._run_baseline_tests(ctx, test_cmd, display_name)
+        # Run baseline tests on main using the same command as the worktree
+        baseline_result = self._run_baseline_tests(
+            ctx, test_cmd, display_name, use_provided_cmd=True
+        )
 
         log_info(f"Running tests: {display_name}")
         ctx.report_milestone("heartbeat", action=f"verifying tests: {display_name}")


### PR DESCRIPTION
## Summary

- Pass `use_provided_cmd=True` in `_run_single_test_with_baseline` so baseline runs the same scoped command as the worktree instead of auto-detecting via `_detect_test_command`
- Fixes baseline comparison running `pnpm check:ci` (stub) while worktree runs `uv run pytest`, making pre-existing failure detection impossible

Closes #2234

## Test plan

- [x] All 495 shepherd phase tests pass
- [ ] End-to-end: run shepherd on a Python-only change in a repo with stub `package.json` scripts and a pre-existing test failure — verify failure is correctly identified as pre-existing

🤖 Generated with [Claude Code](https://claude.com/claude-code)