### PR TITLE
feat: reject epic/tracking issues before builder phase

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/cli.py
+++ b/loom-tools/src/loom_tools/shepherd/cli.py
@@ -16,6 +16,7 @@ from loom_tools.shepherd.context import ShepherdContext
 from loom_tools.shepherd.errors import (
     IssueBlockedError,
     IssueClosedError,
+    IssueIsEpicError,
     IssueNotFoundError,
     ShepherdError,
     ShutdownSignal,
@@ -347,6 +348,9 @@ def orchestrate(ctx: ShepherdContext) -> int:
             ctx.validate_issue()
         except IssueClosedError as e:
             log_info(f"Issue #{ctx.config.issue} is already {e.state} - no orchestration needed")
+            return ShepherdExitCode.SKIPPED
+        except IssueIsEpicError as e:
+            log_info(str(e))
             return ShepherdExitCode.SKIPPED
 
         log_info(f"Issue: #{ctx.config.issue}")

--- a/loom-tools/src/loom_tools/shepherd/context.py
+++ b/loom-tools/src/loom_tools/shepherd/context.py
@@ -15,6 +15,7 @@ from loom_tools.shepherd.config import ShepherdConfig
 from loom_tools.shepherd.errors import (
     IssueBlockedError,
     IssueClosedError,
+    IssueIsEpicError,
     IssueNotFoundError,
 )
 from loom_tools.shepherd.labels import LabelCache, remove_issue_label
@@ -181,6 +182,12 @@ class ShepherdContext:
         # Pre-populate label cache
         labels = {label["name"] for label in meta.get("labels", [])}
         self.label_cache.set_issue_labels(issue, labels)
+
+        # Check for epic labels — epics cannot be implemented directly.
+        # loom:epic-phase issues are individual work items and are allowed through.
+        if "loom:epic-phase" not in labels:
+            if "loom:epic" in labels or "epic" in labels:
+                raise IssueIsEpicError(issue)
 
         # Check for blocked label
         if "loom:blocked" in labels:

--- a/loom-tools/src/loom_tools/shepherd/errors.py
+++ b/loom-tools/src/loom_tools/shepherd/errors.py
@@ -64,6 +64,18 @@ class IssueClosedError(ShepherdError):
         super().__init__(f"Issue #{issue} is already {state}")
 
 
+class IssueIsEpicError(ShepherdError):
+    """Issue is an epic/tracking issue that cannot be implemented directly."""
+
+    def __init__(self, issue: int) -> None:
+        self.issue = issue
+        super().__init__(
+            f"Issue #{issue} is an epic (tracking issue). "
+            "Epics cannot be implemented directly. "
+            "Decompose into individual issues and shepherd those instead."
+        )
+
+
 class PRNotFoundError(ShepherdError):
     """Pull request not found for issue."""
 


### PR DESCRIPTION
## Summary

- Adds early detection of `loom:epic` and `epic` labels in `validate_issue()` so the shepherd exits immediately with `SKIPPED (5)` instead of spawning a builder that wastes ~4 hours on non-implementable tracking issues
- `loom:epic-phase` issues are allowed through since they are concrete work items
- Epic rejection applies even in force mode (epics are fundamentally not implementable)

## Changes

| File | Change |
|------|--------|
| `errors.py` | New `IssueIsEpicError` exception |
| `context.py` | Epic label detection in `validate_issue()` after label cache population |
| `cli.py` | Catch `IssueIsEpicError` and return `SKIPPED` exit code |
| `test_context.py` | 6 test cases covering epic rejection, phase passthrough, force mode |

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| `loom:epic` label rejected | Pass | `test_loom_epic_label_raises_error` |
| `epic` label rejected | Pass | `test_epic_label_raises_error` |
| `loom:epic-phase` NOT rejected | Pass | `test_epic_phase_label_is_allowed` |
| Both `loom:epic` + `loom:epic-phase` allowed | Pass | `test_epic_with_epic_phase_is_allowed` |
| Epic + `loom:issue` still rejected | Pass | `test_epic_with_loom_issue_rejected` |
| Force mode still rejects epics | Pass | `test_epic_rejected_even_in_force_mode` |

## Test plan

- [x] All 6 new epic rejection unit tests pass
- [x] All 761 shepherd tests pass
- [x] Full Python test suite passes (2604 passed, 1 skipped)
- [ ] Manual verification: `loom-shepherd <epic-issue>` exits with SKIPPED

Closes #2236

🤖 Generated with [Claude Code](https://claude.com/claude-code)