### PR TITLE
fix: strip CLAUDECODE env var to prevent nested session guard

### DIFF
--- a/defaults/scripts/claude-wrapper.sh
+++ b/defaults/scripts/claude-wrapper.sh
@@ -347,6 +347,7 @@ run_with_retry() {
         # stdout with a pipe fd, causing Claude to switch to non-interactive --print mode.
         start_output_monitor "${temp_output}" "${monitor_pid_file}"
         set +e  # Temporarily disable errexit to capture exit code
+        unset CLAUDECODE  # Prevent nested session guard from blocking subprocess
         script -q "${temp_output}" claude "$@"
         exit_code=$?
         set -e

--- a/loom-tools/src/loom_tools/agent_spawn.py
+++ b/loom-tools/src/loom_tools/agent_spawn.py
@@ -590,6 +590,8 @@ def spawn_agent(
     _tmux("set-environment", "-t", session_name, "LOOM_TERMINAL_ID", name)
     _tmux("set-environment", "-t", session_name, "LOOM_WORKSPACE", str(working_dir))
     _tmux("set-environment", "-t", session_name, "LOOM_ROLE", role)
+    # Unset CLAUDECODE to prevent nested session guard from blocking subprocess
+    _tmux("set-environment", "-t", session_name, "-u", "CLAUDECODE")
 
     # Build the role slash command
     role_cmd = f"/{role}"

--- a/loom-tools/src/loom_tools/shepherd/phases/base.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/base.py
@@ -428,6 +428,7 @@ def run_worker_phase(
 
     # Set LOOM_STUCK_ACTION for retry behavior
     env = os.environ.copy()
+    env.pop("CLAUDECODE", None)  # Prevent nested session guard from blocking subprocess
     env["LOOM_STUCK_ACTION"] = "retry"
 
     # Launch wait process (non-blocking) so we can poll for heartbeats

--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -5536,6 +5536,104 @@ class TestRunWorkerPhaseMissingScripts:
         assert exit_code == 0
 
 
+class TestRunWorkerPhaseClaudeCodeEnv:
+    """Test run_worker_phase strips CLAUDECODE from environment (issue #2240)."""
+
+    def test_claudecode_stripped_from_subprocess_env(self, tmp_path: Path) -> None:
+        """CLAUDECODE env var must be removed before spawning subprocesses."""
+        ctx = MagicMock(spec=ShepherdContext)
+        ctx.config = ShepherdConfig(issue=42, task_id="test-123")
+        ctx.repo_root = tmp_path
+        scripts_dir = tmp_path / ".loom" / "scripts"
+        scripts_dir.mkdir(parents=True)
+        (scripts_dir / "agent-spawn.sh").touch()
+        (scripts_dir / "agent-wait-bg.sh").touch()
+        ctx.scripts_dir = scripts_dir
+        ctx.progress_dir = tmp_path / ".loom" / "progress"
+
+        captured_env = {}
+
+        def mock_spawn(cmd, **kwargs):
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        def mock_popen(cmd, **kwargs):
+            captured_env.update(kwargs.get("env", {}))
+            proc = MagicMock()
+            proc.poll.return_value = 0
+            proc.returncode = 0
+            return proc
+
+        with (
+            patch("subprocess.run", side_effect=mock_spawn),
+            patch("subprocess.Popen", side_effect=mock_popen),
+            patch("time.sleep"),
+            patch(
+                "loom_tools.shepherd.phases.base._is_instant_exit",
+                return_value=False,
+            ),
+            patch.dict("os.environ", {"CLAUDECODE": "1"}, clear=False),
+        ):
+            run_worker_phase(
+                ctx,
+                role="builder",
+                name="builder-issue-42",
+                timeout=600,
+                phase="builder",
+            )
+
+        assert "CLAUDECODE" not in captured_env
+        assert captured_env.get("LOOM_STUCK_ACTION") == "retry"
+
+    def test_works_when_claudecode_not_set(self, tmp_path: Path) -> None:
+        """No error when CLAUDECODE is not in the environment."""
+        ctx = MagicMock(spec=ShepherdContext)
+        ctx.config = ShepherdConfig(issue=42, task_id="test-123")
+        ctx.repo_root = tmp_path
+        scripts_dir = tmp_path / ".loom" / "scripts"
+        scripts_dir.mkdir(parents=True)
+        (scripts_dir / "agent-spawn.sh").touch()
+        (scripts_dir / "agent-wait-bg.sh").touch()
+        ctx.scripts_dir = scripts_dir
+        ctx.progress_dir = tmp_path / ".loom" / "progress"
+
+        def mock_spawn(cmd, **kwargs):
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        def mock_popen(cmd, **kwargs):
+            proc = MagicMock()
+            proc.poll.return_value = 0
+            proc.returncode = 0
+            return proc
+
+        env_without_claudecode = {
+            k: v for k, v in __import__("os").environ.items() if k != "CLAUDECODE"
+        }
+
+        with (
+            patch("subprocess.run", side_effect=mock_spawn),
+            patch("subprocess.Popen", side_effect=mock_popen),
+            patch("time.sleep"),
+            patch(
+                "loom_tools.shepherd.phases.base._is_instant_exit",
+                return_value=False,
+            ),
+            patch.dict("os.environ", env_without_claudecode, clear=True),
+        ):
+            exit_code = run_worker_phase(
+                ctx,
+                role="builder",
+                name="builder-issue-42",
+                timeout=600,
+                phase="builder",
+            )
+
+        assert exit_code == 0
+
+
 class TestRunWorkerPhaseIdleThreshold:
     """Test run_worker_phase min-idle-elapsed threshold configuration."""
 


### PR DESCRIPTION
## Summary

- Strip `CLAUDECODE` environment variable from subprocess environments in all three spawn points to prevent Claude Code v2.1.39's nested session guard from blocking Loom's shepherd orchestrator
- Add tests verifying the env var is stripped in both `base.py` (shepherd phase runner) and `agent_spawn.py` (tmux agent spawner)

Closes #2240

## Changes

| File | Change |
|------|--------|
| `loom-tools/src/loom_tools/shepherd/phases/base.py` | `env.pop("CLAUDECODE", None)` after `os.environ.copy()` |
| `defaults/scripts/claude-wrapper.sh` | `unset CLAUDECODE` before `script -q` invocation |
| `loom-tools/src/loom_tools/agent_spawn.py` | `_tmux("set-environment", "-t", ..., "-u", "CLAUDECODE")` |
| `loom-tools/tests/shepherd/test_phases.py` | 2 tests: env var stripped, no error when absent |
| `loom-tools/tests/test_agent_spawn.py` | 1 test: tmux unset-environment call issued |

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|-------------|
| CLAUDECODE stripped in base.py | Pass | `env.pop("CLAUDECODE", None)` on line 431; test asserts absent in Popen env |
| CLAUDECODE unset in claude-wrapper.sh | Pass | `unset CLAUDECODE` on line 350, before `script -q` |
| CLAUDECODE unset in agent_spawn.py | Pass | `set-environment -u CLAUDECODE` on line 594; test asserts call issued |
| No regression when var absent | Pass | Dedicated test with env cleared of CLAUDECODE |
| All existing tests pass | Pass | 497 phase tests + 53 agent_spawn tests green |

## Test plan

- [x] `pytest loom-tools/tests/shepherd/test_phases.py::TestRunWorkerPhaseClaudeCodeEnv` — 2 passed
- [x] `pytest loom-tools/tests/test_agent_spawn.py::TestClaudeCodeEnvUnset` — 1 passed
- [x] Full `test_phases.py` suite — 497 passed
- [x] Full `test_agent_spawn.py` suite — 53 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)