### PR TITLE
chore: bump version to v0.2.2

### DIFF
--- a/loom-api/Cargo.toml
+++ b/loom-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loom-api"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "External REST API for Loom analytics data access"
 

--- a/loom-daemon/Cargo.toml
+++ b/loom-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loom-daemon"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 [dependencies]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loom",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A multi-terminal desktop application for macOS that orchestrates AI-powered development workers using git worktrees and GitHub as the coordination layer.",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.2.1"
+version = "0.2.2"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Loom",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "identifier": "com.github.rjwalters.loom",
   "build": {
     "beforeBuildCommand": "pnpm build",


### PR DESCRIPTION
## Summary

Version bump to v0.2.2.

## Changelog since v0.2.1

### Bug Fixes
- fix: strip CLAUDECODE env var to prevent nested session guard (#2241)
- fix: resolve pipe-pane log capture issues with trailing CR and buffering (#2231)
- fix: use same test command for baseline comparison in scoped tests (#2235)
- fix: push ghloc badge to separate branch to avoid ruleset conflict (#2228)

### Features
- feat: add uv sync to shepherd worktree dependency setup (#2239)
- feat: reject epic/tracking issues before builder phase (#2237)
- feat: add unit tests for loom-daemon core modules (#2229)

### Other
- test: improve test coverage for src-tauri Rust backend (#2232)
- docs: rewrite contributing guide for AI-developed project (#2233)
- chore: add ghloc lines-of-code badge to README (#2224)