### PR TITLE
fix: prevent unsafe worktree removal during merge and agent destroy

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/merge.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/merge.py
@@ -38,7 +38,7 @@ class MergePhase:
             try:
                 ctx.run_script(
                     "merge-pr.sh",
-                    [str(ctx.pr_number), "--cleanup-worktree"],
+                    [str(ctx.pr_number)],
                     check=True,
                 )
                 return PhaseResult(


### PR DESCRIPTION
## Summary

- **Remove `--cleanup-worktree` from merge phase** (`merge.py`): The shepherd merge phase was passing `--cleanup-worktree` to `merge-pr.sh`, which bypassed Python safety checks (`worktree_safety.py`) and could remove worktrees while other terminals had their CWD inside them. Now relies on deferred cleanup via `loom-clean --safe` which uses the full safety layer.
- **Add process detection to `agent-destroy.sh`**: Added `lsof`-based check before `git worktree remove --force` to detect other processes using the worktree, matching the safety guarantees of the Python `worktree_safety.py` path.
- **Add regression test**: New test `test_merge_does_not_pass_cleanup_worktree` ensures the merge phase never regresses to passing `--cleanup-worktree`.

Closes #2243

## Test plan

- [x] All 5 `TestMergePhase` tests pass (including new regression test)
- [x] Full test suite passes (2613 passed, 1 pre-existing failure in unrelated `test_recovery_stats.py`)
- [ ] Manual: start two terminals, have one `cd` into a worktree, run merge-pr.sh from other — worktree NOT removed
- [ ] Manual: verify `loom-clean` successfully removes worktree after all terminals leave

🤖 Generated with [Claude Code](https://claude.com/claude-code)