### PR TITLE
fix: prevent app crash when daemon is unavailable on launch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "app"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2379,7 +2379,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "loom-api"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -2396,7 +2396,7 @@ dependencies = [
 
 [[package]]
 name = "loom-daemon"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",


### PR DESCRIPTION
Closes #2253

## Summary

- Moves daemon connection from blocking `setup()` to a background `tokio::spawn` task, so the app launches immediately even when the daemon is unavailable
- Switches `DaemonManager` state from `std::sync::Mutex` to `tokio::sync::Mutex` to safely hold the guard across `.await` in the spawned task
- Uses `try_lock()` in the synchronous window close handler for daemon cleanup
- Logs a warning instead of crashing when daemon connection fails

## Root Cause

The original code used `block_on(ensure_daemon_running).map_err()?` inside the Tauri `setup()` closure. When the daemon was unavailable, the error propagated and caused Tauri to abort with SIGABRT in `did_finish_launching`.

## Test plan

- [x] `pnpm check:ci:lite` passes (1983 passed, 1 pre-existing failure unrelated to this change)
- [ ] Launch app with daemon running - verify daemon connects in background
- [ ] Launch app without daemon - verify app opens normally with warning logged
- [ ] Close app - verify daemon cleanup still works via `try_lock()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)