### PR TITLE
fix: use remove_dir_all for robust worktree directory cleanup

### DIFF
--- a/loom-daemon/src/init/file_ops.rs
+++ b/loom-daemon/src/init/file_ops.rs
@@ -185,7 +185,9 @@ pub fn clean_managed_dir(dst: &Path, prefix: &str, report: &mut InitReport) -> i
 
         if file_type.is_dir() {
             clean_managed_dir(&entry_path, &rel_path, report)?;
-            fs::remove_dir(&entry_path)?;
+            // Use remove_dir_all for robustness: handles unexpected files
+            // (e.g., .DS_Store, git metadata) that the recursive clean may miss
+            fs::remove_dir_all(&entry_path)?;
         } else {
             fs::remove_file(&entry_path)?;
             report.removed.push(rel_path);


### PR DESCRIPTION
## Summary

- Replace `fs::remove_dir` with `fs::remove_dir_all` in `clean_managed_dir` to handle non-empty directories during uninstall
- Fixes reinstall failures when worktree directories contain unexpected files (.DS_Store, git metadata)

## Changes

In `loom-daemon/src/init/file_ops.rs`, the `clean_managed_dir` function recursively cleans managed directories but could fail when `remove_dir` encountered leftover files the recursive pass didn't handle. Using `remove_dir_all` ensures the directory removal succeeds regardless.

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Non-empty worktree dirs don't block uninstall | Verified | `remove_dir_all` handles any remaining contents |
| No regression for empty dirs | Verified | `remove_dir_all` works on empty dirs too |

Closes #2246