### PR TITLE
fix: mark issues as blocked instead of closing when builder finds no changes

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/exit_codes.py
+++ b/loom-tools/src/loom_tools/shepherd/exit_codes.py
@@ -24,7 +24,7 @@ class ShepherdExitCode(IntEnum):
     | 3         | Shutdown signal received      | Clean exit, requeue               |
     | 4         | Stuck/blocked, needs help     | Alert human                       |
     | 5         | Skipped (already complete)    | No action                         |
-    | 6         | No changes needed             | Close issue, mark complete        |
+    | 6         | No changes needed             | Mark blocked, await human review  |
     | 7         | Transient API error           | Requeue issue, retry after backoff|
 
     Using IntEnum allows these to be used directly as exit codes:
@@ -55,7 +55,7 @@ class ShepherdExitCode(IntEnum):
     SKIPPED = 5
 
     # Builder analyzed issue and determined no changes are needed
-    # The reported problem doesn't exist or is already resolved on main
+    # Issue is marked blocked for human review — builder never closes issues
     NO_CHANGES_NEEDED = 6
 
     # Transient API error (500, rate limit, network issue, etc.)
@@ -77,7 +77,7 @@ EXIT_CODE_DESCRIPTIONS = {
     ShepherdExitCode.SHUTDOWN: "Shutdown signal received",
     ShepherdExitCode.NEEDS_INTERVENTION: "Stuck/blocked - needs human intervention",
     ShepherdExitCode.SKIPPED: "Skipped - issue already complete",
-    ShepherdExitCode.NO_CHANGES_NEEDED: "No changes needed - problem already resolved",
+    ShepherdExitCode.NO_CHANGES_NEEDED: "No changes needed - marked blocked for human review",
     ShepherdExitCode.TRANSIENT_ERROR: "Transient API error - safe to retry after backoff",
     ShepherdExitCode.BUDGET_EXHAUSTED: "Budget exhausted - issue may need decomposition",
 }

--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -361,7 +361,6 @@ class BuilderPhase:
                         data={
                             "no_changes_needed": True,
                             "reason": "already_resolved",
-                            "close_issue": True,
                             "diagnostics": diag,
                         },
                     )
@@ -523,7 +522,6 @@ class BuilderPhase:
                         data={
                             "no_changes_needed": True,
                             "reason": "already_resolved",
-                            "close_issue": True,
                             "diagnostics": diag,
                         },
                     )


### PR DESCRIPTION
## Summary

- Changes `_handle_no_changes_needed()` to add a `loom:blocked` label and comment instead of closing the issue
- Removes `"close_issue": True` from builder phase `PhaseResult` data (two locations)
- Updates exit code 6 description from "close issue, mark complete" to "mark blocked, await human review"
- Updates all docstrings referencing the old behavior

Closes #2269

## Test plan

- [x] All 23 exit code tests pass (description assertion still matches "no changes")
- [x] All 8 `_is_no_changes_needed` detection tests pass (logic unchanged)
- [x] Full CI-lite suite: 2673 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)