### PR TITLE
feat: shepherd post-run reflection phase

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/config.py
+++ b/loom-tools/src/loom_tools/shepherd/config.py
@@ -18,6 +18,7 @@ class Phase(Enum):
     JUDGE = "judge"
     DOCTOR = "doctor"
     MERGE = "merge"
+    REFLECTION = "reflection"
 
 
 class ExecutionMode(Enum):
@@ -187,6 +188,9 @@ class ShepherdConfig:
 
     # Worktree marker file name
     worktree_marker_file: str = ".loom-in-use"
+
+    # Reflection phase control
+    no_reflect: bool = False
 
     @property
     def is_force_mode(self) -> bool:

--- a/loom-tools/src/loom_tools/shepherd/phases/__init__.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/__init__.py
@@ -13,6 +13,7 @@ from loom_tools.shepherd.phases.doctor import DoctorPhase
 from loom_tools.shepherd.phases.judge import JudgePhase
 from loom_tools.shepherd.phases.merge import MergePhase
 from loom_tools.shepherd.phases.preflight import PreflightPhase
+from loom_tools.shepherd.phases.reflection import ReflectionPhase
 
 __all__ = [
     "BasePhase",
@@ -26,4 +27,5 @@ __all__ = [
     "JudgePhase",
     "MergePhase",
     "PreflightPhase",
+    "ReflectionPhase",
 ]

--- a/loom-tools/src/loom_tools/shepherd/phases/reflection.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/reflection.py
@@ -1,0 +1,324 @@
+"""Reflection phase implementation.
+
+Post-run analysis that reviews shepherd performance and optionally
+files upstream issues on rjwalters/loom when actionable improvements
+are identified.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from loom_tools.common.logging import log_info, log_warning
+from loom_tools.shepherd.phases.base import BasePhase, PhaseResult
+
+if TYPE_CHECKING:
+    from loom_tools.shepherd.context import ShepherdContext
+
+# Thresholds for flagging anomalies
+SLOW_PHASE_THRESHOLD_SECONDS = 300  # 5 minutes
+HIGH_RETRY_THRESHOLD = 2
+
+# Upstream repo for filing issues
+UPSTREAM_REPO = "rjwalters/loom"
+
+# Title prefix for searchability
+TITLE_PREFIX = "[shepherd-reflection]"
+
+
+@dataclass
+class Finding:
+    """A single actionable finding from run analysis."""
+
+    category: str  # e.g., "slow_phase", "excessive_retries", "builder_failure"
+    title: str  # Short title for the finding
+    details: str  # Detailed description with context
+    severity: str = "enhancement"  # "enhancement" or "bug"
+
+
+@dataclass
+class RunSummary:
+    """Summary of a shepherd run for reflection analysis."""
+
+    issue: int = 0
+    issue_title: str = ""
+    mode: str = "default"
+    task_id: str = ""
+    duration: int = 0
+    exit_code: int = 0
+    phase_durations: dict[str, int] = field(default_factory=dict)
+    completed_phases: list[str] = field(default_factory=list)
+    judge_retries: int = 0
+    doctor_attempts: int = 0
+    test_fix_attempts: int = 0
+    warnings: list[str] = field(default_factory=list)
+
+
+class ReflectionPhase(BasePhase):
+    """Phase 7: Post-run reflection and upstream issue filing.
+
+    Analyzes the shepherd run for anomalies and actionable improvements.
+    Files issues on the upstream Loom repository when warranted.
+
+    This phase is best-effort: failures do not affect the shepherd exit code.
+    """
+
+    phase_name = "reflection"
+
+    def __init__(self, run_summary: RunSummary | None = None) -> None:
+        self.run_summary = run_summary or RunSummary()
+
+    def should_skip(self, ctx: ShepherdContext) -> tuple[bool, str]:
+        """Skip if --no-reflect is set."""
+        if getattr(ctx.config, "no_reflect", False):
+            return True, "reflection disabled via --no-reflect"
+        return False, ""
+
+    def run(self, ctx: ShepherdContext) -> PhaseResult:
+        """Analyze run and file upstream issues if warranted."""
+        findings = self._analyze_run(self.run_summary)
+
+        if not findings:
+            log_info("Reflection: no actionable findings")
+            return self.success("no findings", data={"findings_count": 0})
+
+        log_info(f"Reflection: {len(findings)} finding(s) detected")
+
+        filed_count = 0
+        for finding in findings:
+            log_info(f"  - [{finding.severity}] {finding.title}")
+            if self._should_file_issue(finding, ctx):
+                if self._file_upstream_issue(finding, self.run_summary, ctx):
+                    filed_count += 1
+
+        return self.success(
+            f"{len(findings)} findings, {filed_count} issues filed",
+            data={
+                "findings_count": len(findings),
+                "filed_count": filed_count,
+            },
+        )
+
+    def validate(self, ctx: ShepherdContext) -> bool:
+        """Reflection phase always validates (best-effort)."""
+        return True
+
+    def _analyze_run(self, summary: RunSummary) -> list[Finding]:
+        """Analyze run data and return actionable findings."""
+        findings: list[Finding] = []
+
+        # Check for slow phases
+        for phase_name, duration in summary.phase_durations.items():
+            if duration > SLOW_PHASE_THRESHOLD_SECONDS:
+                findings.append(
+                    Finding(
+                        category="slow_phase",
+                        title=f"Slow {phase_name} phase ({duration}s)",
+                        details=(
+                            f"The {phase_name} phase took {duration}s "
+                            f"(threshold: {SLOW_PHASE_THRESHOLD_SECONDS}s). "
+                            f"Issue #{summary.issue}: {summary.issue_title}. "
+                            f"Mode: {summary.mode}."
+                        ),
+                        severity="enhancement",
+                    )
+                )
+
+        # Check for excessive retries
+        if summary.judge_retries >= HIGH_RETRY_THRESHOLD:
+            findings.append(
+                Finding(
+                    category="excessive_retries",
+                    title=f"Judge required {summary.judge_retries} retries",
+                    details=(
+                        f"The Judge phase needed {summary.judge_retries} retries "
+                        f"for issue #{summary.issue}. This may indicate problems "
+                        f"with review prompt clarity or PR complexity."
+                    ),
+                    severity="enhancement",
+                )
+            )
+
+        if summary.doctor_attempts >= HIGH_RETRY_THRESHOLD:
+            findings.append(
+                Finding(
+                    category="excessive_retries",
+                    title=f"Doctor required {summary.doctor_attempts} attempts",
+                    details=(
+                        f"The Doctor phase ran {summary.doctor_attempts} times "
+                        f"for issue #{summary.issue}. This may indicate "
+                        f"insufficient feedback specificity from the Judge."
+                    ),
+                    severity="enhancement",
+                )
+            )
+
+        if summary.test_fix_attempts >= HIGH_RETRY_THRESHOLD:
+            findings.append(
+                Finding(
+                    category="excessive_retries",
+                    title=f"Test-fix loop ran {summary.test_fix_attempts} times",
+                    details=(
+                        f"The builder test-fix loop required "
+                        f"{summary.test_fix_attempts} iterations for "
+                        f"issue #{summary.issue}."
+                    ),
+                    severity="enhancement",
+                )
+            )
+
+        # Check for builder failure (non-zero exit)
+        if summary.exit_code == 1:  # BUILDER_FAILED
+            findings.append(
+                Finding(
+                    category="builder_failure",
+                    title="Builder failed to create PR",
+                    details=(
+                        f"Builder phase failed for issue #{summary.issue}: "
+                        f"{summary.issue_title}. "
+                        f"Completed phases: {', '.join(summary.completed_phases)}."
+                    ),
+                    severity="bug",
+                )
+            )
+
+        # Check for stale artifacts in warnings
+        stale_warnings = [w for w in summary.warnings if "stale" in w.lower()]
+        if stale_warnings:
+            findings.append(
+                Finding(
+                    category="stale_artifacts",
+                    title="Stale artifacts detected at startup",
+                    details=(
+                        f"Stale artifacts were found during issue #{summary.issue} "
+                        f"orchestration: {'; '.join(stale_warnings)}. "
+                        f"Consider auto-cleanup before builder phase."
+                    ),
+                    severity="enhancement",
+                )
+            )
+
+        # Check for missing baseline
+        baseline_warnings = [
+            w for w in summary.warnings if "baseline" in w.lower()
+        ]
+        if baseline_warnings:
+            findings.append(
+                Finding(
+                    category="missing_baseline",
+                    title="Baseline health cache missing",
+                    details=(
+                        f"No baseline health cache was available during "
+                        f"issue #{summary.issue} orchestration. "
+                        f"This reduces confidence in test results."
+                    ),
+                    severity="enhancement",
+                )
+            )
+
+        return findings
+
+    def _should_file_issue(
+        self, finding: Finding, ctx: ShepherdContext
+    ) -> bool:
+        """Check if an issue should be filed (no duplicates)."""
+        # Search for existing open issues with similar title
+        search_query = f"{TITLE_PREFIX} {finding.category}"
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "issue",
+                    "list",
+                    "--repo",
+                    UPSTREAM_REPO,
+                    "--search",
+                    search_query,
+                    "--state",
+                    "open",
+                    "--json",
+                    "number,title",
+                    "--limit",
+                    "5",
+                ],
+                cwd=ctx.repo_root,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                existing = json.loads(result.stdout)
+                if existing:
+                    log_info(
+                        f"  Skipping (existing issue #{existing[0]['number']})"
+                    )
+                    return False
+        except (json.JSONDecodeError, OSError):
+            # If we can't check, err on the side of not filing
+            return False
+
+        return True
+
+    def _file_upstream_issue(
+        self,
+        finding: Finding,
+        summary: RunSummary,
+        ctx: ShepherdContext,
+    ) -> bool:
+        """File an issue on the upstream Loom repository."""
+        title = f"{TITLE_PREFIX} {finding.title}"
+        body = (
+            f"## Automated Shepherd Reflection\n\n"
+            f"{finding.details}\n\n"
+            f"## Run Context\n\n"
+            f"- **Issue**: #{summary.issue}\n"
+            f"- **Mode**: {summary.mode}\n"
+            f"- **Task ID**: {summary.task_id}\n"
+            f"- **Duration**: {summary.duration}s\n"
+            f"- **Exit code**: {summary.exit_code}\n"
+            f"- **Phase timings**: {json.dumps(summary.phase_durations)}\n"
+        )
+
+        if summary.warnings:
+            body += f"- **Warnings**: {'; '.join(summary.warnings)}\n"
+
+        body += (
+            f"\n---\n"
+            f"*Filed automatically by shepherd reflection phase.*"
+        )
+
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "issue",
+                    "create",
+                    "--repo",
+                    UPSTREAM_REPO,
+                    "--title",
+                    title,
+                    "--label",
+                    finding.severity,
+                    "--body",
+                    body,
+                ],
+                cwd=ctx.repo_root,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if result.returncode == 0:
+                issue_url = result.stdout.strip()
+                log_info(f"  Filed: {issue_url}")
+                return True
+            else:
+                log_warning(
+                    f"  Failed to file issue: {result.stderr.strip()}"
+                )
+                return False
+        except OSError as exc:
+            log_warning(f"  Failed to file issue: {exc}")
+            return False

--- a/loom-tools/tests/shepherd/test_reflection.py
+++ b/loom-tools/tests/shepherd/test_reflection.py
@@ -1,0 +1,227 @@
+"""Tests for the reflection phase."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from loom_tools.shepherd.config import ShepherdConfig
+from loom_tools.shepherd.context import ShepherdContext
+from loom_tools.shepherd.phases.base import PhaseStatus
+from loom_tools.shepherd.phases.reflection import (
+    HIGH_RETRY_THRESHOLD,
+    SLOW_PHASE_THRESHOLD_SECONDS,
+    TITLE_PREFIX,
+    UPSTREAM_REPO,
+    ReflectionPhase,
+    RunSummary,
+)
+
+
+@pytest.fixture
+def mock_context() -> MagicMock:
+    """Create a mock ShepherdContext."""
+    ctx = MagicMock(spec=ShepherdContext)
+    ctx.config = ShepherdConfig(issue=42)
+    ctx.repo_root = Path("/fake/repo")
+    ctx.issue_title = "Test issue"
+    return ctx
+
+
+@pytest.fixture
+def clean_summary() -> RunSummary:
+    """Create a clean run summary with no anomalies."""
+    return RunSummary(
+        issue=42,
+        issue_title="Test issue",
+        mode="force-merge",
+        task_id="abc1234",
+        duration=120,
+        exit_code=0,
+        phase_durations={"Curator": 30, "Builder": 60, "Judge": 20, "Merge": 10},
+        completed_phases=["Curator", "Builder", "Judge", "Merge"],
+        judge_retries=0,
+        doctor_attempts=0,
+        test_fix_attempts=0,
+        warnings=[],
+    )
+
+
+class TestReflectionPhaseShouldSkip:
+    """Test should_skip logic."""
+
+    def test_skips_when_no_reflect_set(self, mock_context: MagicMock) -> None:
+        mock_context.config.no_reflect = True
+        phase = ReflectionPhase()
+        skip, reason = phase.should_skip(mock_context)
+        assert skip is True
+        assert "no-reflect" in reason
+
+    def test_does_not_skip_by_default(self, mock_context: MagicMock) -> None:
+        phase = ReflectionPhase()
+        skip, _ = phase.should_skip(mock_context)
+        assert skip is False
+
+
+class TestReflectionPhaseAnalysis:
+    """Test finding detection logic."""
+
+    def test_clean_run_produces_no_findings(self, clean_summary: RunSummary) -> None:
+        phase = ReflectionPhase(run_summary=clean_summary)
+        findings = phase._analyze_run(clean_summary)
+        assert len(findings) == 0
+
+    def test_detects_slow_phase(self, clean_summary: RunSummary) -> None:
+        clean_summary.phase_durations["Builder"] = SLOW_PHASE_THRESHOLD_SECONDS + 100
+        phase = ReflectionPhase(run_summary=clean_summary)
+        findings = phase._analyze_run(clean_summary)
+        slow_findings = [f for f in findings if f.category == "slow_phase"]
+        assert len(slow_findings) == 1
+        assert "Builder" in slow_findings[0].title
+
+    def test_detects_excessive_judge_retries(self, clean_summary: RunSummary) -> None:
+        clean_summary.judge_retries = HIGH_RETRY_THRESHOLD
+        phase = ReflectionPhase(run_summary=clean_summary)
+        findings = phase._analyze_run(clean_summary)
+        retry_findings = [f for f in findings if f.category == "excessive_retries"]
+        assert len(retry_findings) == 1
+        assert "Judge" in retry_findings[0].title
+
+    def test_detects_excessive_doctor_attempts(
+        self, clean_summary: RunSummary
+    ) -> None:
+        clean_summary.doctor_attempts = HIGH_RETRY_THRESHOLD
+        phase = ReflectionPhase(run_summary=clean_summary)
+        findings = phase._analyze_run(clean_summary)
+        retry_findings = [f for f in findings if f.category == "excessive_retries"]
+        assert len(retry_findings) == 1
+        assert "Doctor" in retry_findings[0].title
+
+    def test_detects_excessive_test_fix_attempts(
+        self, clean_summary: RunSummary
+    ) -> None:
+        clean_summary.test_fix_attempts = HIGH_RETRY_THRESHOLD
+        phase = ReflectionPhase(run_summary=clean_summary)
+        findings = phase._analyze_run(clean_summary)
+        retry_findings = [f for f in findings if f.category == "excessive_retries"]
+        assert len(retry_findings) == 1
+        assert "test-fix" in retry_findings[0].title.lower()
+
+    def test_detects_builder_failure(self, clean_summary: RunSummary) -> None:
+        clean_summary.exit_code = 1  # BUILDER_FAILED
+        phase = ReflectionPhase(run_summary=clean_summary)
+        findings = phase._analyze_run(clean_summary)
+        failure_findings = [f for f in findings if f.category == "builder_failure"]
+        assert len(failure_findings) == 1
+        assert failure_findings[0].severity == "bug"
+
+    def test_detects_stale_artifacts(self, clean_summary: RunSummary) -> None:
+        clean_summary.warnings = ["Stale branch feature/issue-42 exists on remote"]
+        phase = ReflectionPhase(run_summary=clean_summary)
+        findings = phase._analyze_run(clean_summary)
+        stale_findings = [f for f in findings if f.category == "stale_artifacts"]
+        assert len(stale_findings) == 1
+
+    def test_detects_missing_baseline(self, clean_summary: RunSummary) -> None:
+        clean_summary.warnings = ["No baseline health cache found"]
+        phase = ReflectionPhase(run_summary=clean_summary)
+        findings = phase._analyze_run(clean_summary)
+        baseline_findings = [
+            f for f in findings if f.category == "missing_baseline"
+        ]
+        assert len(baseline_findings) == 1
+
+    def test_multiple_findings(self, clean_summary: RunSummary) -> None:
+        clean_summary.phase_durations["Judge"] = 600
+        clean_summary.judge_retries = 3
+        clean_summary.warnings = ["Stale branch exists"]
+        phase = ReflectionPhase(run_summary=clean_summary)
+        findings = phase._analyze_run(clean_summary)
+        assert len(findings) >= 3
+
+
+class TestReflectionPhaseDuplicateCheck:
+    """Test duplicate issue detection."""
+
+    @patch("loom_tools.shepherd.phases.reflection.subprocess.run")
+    def test_skips_when_duplicate_exists(
+        self,
+        mock_run: MagicMock,
+        mock_context: MagicMock,
+        clean_summary: RunSummary,
+    ) -> None:
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps([{"number": 100, "title": "existing issue"}]),
+        )
+        from loom_tools.shepherd.phases.reflection import Finding
+
+        finding = Finding(
+            category="slow_phase",
+            title="Slow Builder phase",
+            details="details",
+        )
+        phase = ReflectionPhase(run_summary=clean_summary)
+        assert phase._should_file_issue(finding, mock_context) is False
+
+    @patch("loom_tools.shepherd.phases.reflection.subprocess.run")
+    def test_files_when_no_duplicate(
+        self,
+        mock_run: MagicMock,
+        mock_context: MagicMock,
+        clean_summary: RunSummary,
+    ) -> None:
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps([]),
+        )
+        from loom_tools.shepherd.phases.reflection import Finding
+
+        finding = Finding(
+            category="slow_phase",
+            title="Slow Builder phase",
+            details="details",
+        )
+        phase = ReflectionPhase(run_summary=clean_summary)
+        assert phase._should_file_issue(finding, mock_context) is True
+
+
+class TestReflectionPhaseRun:
+    """Test the full run method."""
+
+    @patch.object(ReflectionPhase, "_file_upstream_issue", return_value=False)
+    @patch.object(ReflectionPhase, "_should_file_issue", return_value=False)
+    def test_clean_run_returns_success(
+        self,
+        mock_should_file: MagicMock,
+        mock_file: MagicMock,
+        mock_context: MagicMock,
+        clean_summary: RunSummary,
+    ) -> None:
+        phase = ReflectionPhase(run_summary=clean_summary)
+        result = phase.run(mock_context)
+        assert result.status == PhaseStatus.SUCCESS
+        assert result.data["findings_count"] == 0
+
+    @patch.object(ReflectionPhase, "_file_upstream_issue", return_value=True)
+    @patch.object(ReflectionPhase, "_should_file_issue", return_value=True)
+    def test_anomalous_run_files_issues(
+        self,
+        mock_should_file: MagicMock,
+        mock_file: MagicMock,
+        mock_context: MagicMock,
+        clean_summary: RunSummary,
+    ) -> None:
+        clean_summary.exit_code = 1  # Builder failure triggers a finding
+        phase = ReflectionPhase(run_summary=clean_summary)
+        result = phase.run(mock_context)
+        assert result.status == PhaseStatus.SUCCESS
+        assert result.data["findings_count"] >= 1
+        assert result.data["filed_count"] >= 1
+
+    def test_validate_always_true(self, mock_context: MagicMock) -> None:
+        phase = ReflectionPhase()
+        assert phase.validate(mock_context) is True


### PR DESCRIPTION
## Summary

Adds a reflection phase (Phase 7) to the shepherd orchestration pipeline that analyzes run performance and files upstream issues on `rjwalters/loom` when actionable improvements are identified.

- **New phase**: `ReflectionPhase` following existing `BasePhase` pattern
- **Anomaly detection**: slow phases (>5min), excessive retries, builder failures, stale artifacts, missing baseline health
- **Upstream issue filing**: checks for duplicates before creating issues with `[shepherd-reflection]` prefix
- **Best-effort**: reflection failures never affect shepherd exit code
- **Opt-out**: `--no-reflect` flag to disable

### Files changed

| File | Change |
|------|--------|
| `phases/reflection.py` | New `ReflectionPhase` class with `RunSummary` data model |
| `phases/__init__.py` | Export `ReflectionPhase` |
| `config.py` | Add `REFLECTION` to Phase enum, `no_reflect` to ShepherdConfig |
| `cli.py` | Wire reflection into orchestrate(), add `--no-reflect` arg, `_run_reflection()` helper |
| `tests/shepherd/test_reflection.py` | 16 unit tests covering analysis, dedup, skip logic |

## Test plan

- [x] 16 new unit tests all pass
- [x] Full shepherd test suite passes (799 tests)
- [x] `pnpm check:ci:lite` passes (2689 tests, 1 pre-existing skip)
- [x] `--no-reflect` flag properly skips reflection
- [x] Clean runs produce no findings
- [x] Anomalous runs detect correct finding categories
- [x] Duplicate detection prevents filing existing issues

Closes #2271

🤖 Generated with [Claude Code](https://claude.com/claude-code)