### PR TITLE
fix: stop gitignoring .loom/config.json so it stays tracked across reinstalls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,7 +190,7 @@ gh pr create --label "loom:review-requested"
 
 ### Workspace Configuration
 
-Configuration stored in `.loom/config.json` (gitignored):
+Configuration stored in `.loom/config.json` (committed to git for team sharing):
 
 ```json
 {

--- a/defaults/.claude/commands/imagine.md
+++ b/defaults/.claude/commands/imagine.md
@@ -178,14 +178,27 @@ build/
 .DS_Store
 Thumbs.db
 
-# Loom
-.loom/config.json
+# Loom runtime state (don't commit these)
+.loom-in-use
 .loom/state.json
 .loom/daemon-state.json
-.loom/*.json
-!.loom/roles/*.json
+.loom/[0-9][0-9]-daemon-state.json
+.loom/daemon-metrics.json
+.loom/health-metrics.json
+.loom/stuck-history.json
+.loom/alerts.json
+.loom/manifest.json
 .loom/worktrees/
 .loom/interventions/
+.loom/claims/
+.loom/signals/
+.loom/status/
+.loom/progress/
+.loom/diagnostics/
+.loom/metrics/
+.loom/logs/
+.loom/*.log
+.loom/*.sock
 EOF
 
 # Initial commit

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -567,7 +567,7 @@ If you need to clean up worktrees:
 
 ### Workspace Configuration
 
-Configuration is stored in `.loom/config.json` (gitignored, local to your machine):
+Configuration is stored in `.loom/config.json` (committed to git for team sharing):
 
 ```json
 {


### PR DESCRIPTION
## Summary

Fixes the issue where `.loom/config.json` was being gitignored after reinstall, preventing it from being tracked in version control.

**Root causes:**
- The `/imagine` command's gitignore template used `.loom/*.json` (a broad glob) which caught `config.json`
- Documentation in `defaults/CLAUDE.md` and `CLAUDE.md` incorrectly described `config.json` as "gitignored"
- The installer's `post_init.rs` had no migration logic to remove legacy broad patterns from existing `.gitignore` files

**Changes:**
- **`defaults/.claude/commands/imagine.md`**: Replaced `.loom/*.json` glob with specific runtime state file patterns
- **`defaults/CLAUDE.md`** and **`CLAUDE.md`**: Fixed documentation to say "committed to git for team sharing"
- **`loom-daemon/src/init/post_init.rs`**: Added migration to remove legacy `.loom/*.json` and `.loom/config.json` entries from existing `.gitignore` files during install. Also synced 3 missing ephemeral patterns (`.loom-checkpoint`, `.loom/issue-failures.json`, `.loom/usage-cache.json`)

## Test plan

- [x] All 5 `post_init` unit tests pass (including new `removes_legacy_broad_json_pattern` test)
- [x] Full `check:ci:lite` passes (236 Rust tests + 2689 Python tests)
- [ ] Verify `/imagine` creates projects where `config.json` is trackable
- [ ] Verify reinstall on a repo with legacy `.loom/*.json` pattern migrates correctly

Closes #2248

🤖 Generated with [Claude Code](https://claude.com/claude-code)