### PR TITLE
feat: wire run_warnings and add failure-path reflection coverage

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/context.py
+++ b/loom-tools/src/loom_tools/shepherd/context.py
@@ -38,6 +38,7 @@ class ShepherdContext:
     pr_number: int | None = None
     worktree_path: Path | None = None
     completed_phases: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
 
     # Caches
     label_cache: LabelCache = field(init=False)
@@ -133,6 +134,7 @@ class ShepherdContext:
             text=True,
             capture_output=capture,
             check=check,
+            stdin=subprocess.DEVNULL,
         )
 
     def validate_issue(self) -> dict[str, Any]:
@@ -221,11 +223,12 @@ class ShepherdContext:
                 check=False,
             )
             if result.returncode == 0 and result.stdout.strip():
-                logger.warning(
-                    "Stale branch %s exists on remote. "
-                    "Previous attempt may have left artifacts.",
-                    branch_name,
+                msg = (
+                    f"Stale branch {branch_name} exists on remote. "
+                    "Previous attempt may have left artifacts."
                 )
+                logger.warning(msg)
+                self.warnings.append(msg)
         except OSError:
             # git not available or other OS error — skip the check
             pass


### PR DESCRIPTION
## Summary

- Add `_run_reflection()` calls to all 7 failure exit paths in `orchestrate()` so reflection analysis runs on failures, not just successes
- Wire `run_warnings` collection: stale branch warnings from context init + missing baseline health warnings from approval phase
- Add `warnings` field to `ShepherdContext` dataclass
- Fix `subprocess.run` deadlock in `run_script()` by adding `stdin=subprocess.DEVNULL` (prevents hang under pytest-asyncio)
- Fix `test_existing_script_runs_normally` to mock subprocess (avoids asyncio event loop deadlock with `asyncio_mode=auto`)

Closes #2276

## Test plan

- [x] All 84 shepherd CLI tests pass
- [x] All 24 shepherd context tests pass
- [x] Fixed pre-existing hanging test (`test_existing_script_runs_normally`)
- [x] Updated test mocks for additional `time.time()` calls from `_run_reflection`

🤖 Generated with [Claude Code](https://claude.com/claude-code)