### PR TITLE
fix: install hooks via loom-daemon init to prevent loss during reinstall

### DIFF
--- a/loom-daemon/src/init/mod.rs
+++ b/loom-daemon/src/init/mod.rs
@@ -607,11 +607,8 @@ mod tests {
         fs::create_dir_all(defaults.join("hooks")).unwrap();
         fs::write(defaults.join("config.json"), "{}").unwrap();
         fs::write(defaults.join("roles").join("builder.md"), "builder").unwrap();
-        fs::write(
-            defaults.join("hooks").join("guard-destructive.sh"),
-            "#!/bin/bash\n# guard hook",
-        )
-        .unwrap();
+        fs::write(defaults.join("hooks").join("guard-destructive.sh"), "#!/bin/bash\n# guard hook")
+            .unwrap();
 
         let result =
             initialize_workspace(workspace.to_str().unwrap(), defaults.to_str().unwrap(), false);


### PR DESCRIPTION
## Summary

- Adds `.loom/hooks/` as a managed directory in `loom-daemon init`, matching the existing pattern for `roles/` and `scripts/`
- On fresh install: copies hooks from `defaults/hooks/` to `.loom/hooks/`
- On reinstall: cleans stale hooks then copies fresh from defaults (same behavior as roles/scripts)
- Ensures hook files are executable after copying
- Adds verification that copied hooks match their sources
- Includes two unit tests: fresh install and reinstall scenarios

## Root Cause

Hooks (e.g., `guard-destructive.sh`) were only installed by `install-loom.sh`'s hook copy step, not by `loom-daemon init`. Any code path that called `loom-daemon init` without the subsequent hook copy would lose hooks — causing `PreToolUse:Bash hook error` on every Bash tool call and silently disabling the destructive command guard.

## Test plan

- [ ] `cargo check -p loom-daemon` passes
- [ ] `cargo clippy -p loom-daemon -- -D warnings` passes
- [ ] Unit tests `test_hooks_installed_on_fresh_install` and `test_hooks_preserved_on_reinstall` pass
- [ ] Fresh install via `./install.sh --quick` includes hooks in `.loom/hooks/`
- [ ] Reinstall via `./install.sh` preserves/updates hooks

Closes #2250

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>