### PR TITLE
fix: copy loom-daemon binary instead of rebuilding in worktrees

### DIFF
--- a/.loom/hooks/post-worktree.sh
+++ b/.loom/hooks/post-worktree.sh
@@ -1,19 +1,21 @@
 #!/usr/bin/env bash
-# Post-worktree hook: pre-build loom-daemon binary for Tauri compatibility
+# Post-worktree hook: provide loom-daemon binary for Tauri compatibility
 #
 # Called by worktree.sh after creating a new worktree.
 # Arguments: $1=worktree_path  $2=branch_name  $3=issue_number
 # Working directory: the new worktree
 #
-# Builds loom-daemon in release mode so that src-tauri/tauri.conf.json's
-# externalBin reference ("../target/release/loom-daemon") is satisfied.
-# This enables full `check:ci` and E2E tests in worktrees.
+# Copies loom-daemon from the main workspace's target/release/ instead of
+# rebuilding from scratch. This avoids cargo lock contention and minutes-long
+# release builds that block parallel worktrees.
+#
+# Falls back to building only if the main workspace binary doesn't exist.
 
 set -euo pipefail
 
 WORKTREE_PATH="${1:?worktree path required}"
 
-# Only build if the worktree has a Cargo workspace with loom-daemon
+# Only proceed if the worktree has a Cargo workspace with loom-daemon
 if [[ ! -f "$WORKTREE_PATH/Cargo.toml" ]]; then
     exit 0
 fi
@@ -24,17 +26,31 @@ fi
 
 # Skip if the binary already exists (e.g., reusing an existing worktree)
 if [[ -x "$WORKTREE_PATH/target/release/loom-daemon" ]]; then
-    echo "  loom-daemon binary already exists, skipping build"
+    echo "  loom-daemon binary already exists, skipping"
     exit 0
 fi
 
-# Check that cargo is available
+# Find the main workspace (parent of .loom/worktrees/)
+MAIN_WORKSPACE="$(cd "$WORKTREE_PATH" && git rev-parse --git-common-dir 2>/dev/null | xargs dirname)"
+MAIN_BINARY="$MAIN_WORKSPACE/target/release/loom-daemon"
+
+# Try to copy from main workspace first (instant, no cargo lock contention)
+if [[ -x "$MAIN_BINARY" ]]; then
+    mkdir -p "$WORKTREE_PATH/target/release"
+    if cp "$MAIN_BINARY" "$WORKTREE_PATH/target/release/loom-daemon"; then
+        echo "  loom-daemon copied from main workspace (skipped rebuild)"
+        exit 0
+    fi
+fi
+
+# Fallback: build if main binary doesn't exist and cargo is available
 if ! command -v cargo &>/dev/null; then
-    echo "  cargo not found, skipping loom-daemon build"
+    echo "  cargo not found and no main workspace binary, skipping loom-daemon setup"
     exit 0
 fi
 
 echo "  Building loom-daemon (release) for Tauri compatibility..."
+echo "  (main workspace binary not found at $MAIN_BINARY)"
 if cargo build --release -p loom-daemon --manifest-path "$WORKTREE_PATH/Cargo.toml" 2>&1; then
     echo "  loom-daemon build complete"
 else


### PR DESCRIPTION
## Summary
- Replaces full `cargo build --release` in post-worktree hook with a simple `cp` from the main workspace's `target/release/loom-daemon`
- Eliminates cargo lock contention that was blocking parallel worktrees, tests, and rust-analyzer
- Falls back to building only if the main workspace binary doesn't exist

Closes #2291

## Test plan
- [ ] Create a new worktree and verify loom-daemon is copied (not rebuilt)
- [ ] Verify no cargo lock contention during worktree creation
- [ ] Verify fallback build works when main binary is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)