### PR TITLE
fix: move provider index creation to migration to prevent startup crash

### DIFF
--- a/loom-daemon/src/activity/schema.rs
+++ b/loom-daemon/src/activity/schema.rs
@@ -580,7 +580,12 @@ mod tests {
         init_schema(&conn).unwrap();
 
         // Verify migration added the new columns
-        for col in ["provider", "tokens_cache_read", "tokens_cache_write", "duration_ms"] {
+        for col in [
+            "provider",
+            "tokens_cache_read",
+            "tokens_cache_write",
+            "duration_ms",
+        ] {
             let ok = conn
                 .prepare(&format!("SELECT {col} FROM token_usage LIMIT 0"))
                 .is_ok();


### PR DESCRIPTION
## Summary

Fixes a startup crash on existing databases where `init_schema()` tried to create an index on the `provider` column before the migration added it.

- Moved `idx_token_usage_provider` creation from the `execute_batch` to `migrate_token_usage_table()`, so it runs after the column is added
- Added 3 regression tests covering old-schema migration, fresh DB, and idempotency

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| App starts with old `activity.db` (missing `provider` column) | Verified | `test_init_schema_with_old_token_usage_table` passes |
| App starts with fresh database | Verified | `test_init_schema_fresh_database` passes |
| New columns exist after migration | Verified | Test checks `provider`, `tokens_cache_read`, `tokens_cache_write`, `duration_ms` |
| `idx_token_usage_provider` index exists after migration | Verified | Both tests assert index presence in `sqlite_master` |
| `init_schema()` is idempotent | Verified | `test_init_schema_idempotent` calls it twice without error |

## Test plan

```
cargo test -p loom-daemon -- activity::schema::tests
# 3 passed; 0 failed
```

Closes #2264