### PR TITLE
fix: prevent theme picker from blocking agents in isolated config dirs

### DIFF
--- a/loom-tools/src/loom_tools/common/claude_config.py
+++ b/loom-tools/src/loom_tools/common/claude_config.py
@@ -22,6 +22,7 @@ _SHARED_CONFIG_FILES = [
     "config.json",
     "mcp.json",
     ".mcp.json",
+    ".claude.json",
 ]
 
 # Shared directories to symlink from ~/.claude/ (read-only caches)


### PR DESCRIPTION
## Summary

- Add `.claude.json` to `_SHARED_CONFIG_FILES` in `claude_config.py` so onboarding-complete state is symlinked into isolated `CLAUDE_CONFIG_DIR`, preventing the interactive theme/style picker from appearing
- Extend `check_stuck_at_prompt()` in `agent-wait-bg.sh` to detect theme picker prompt patterns (`Choose the text style`, `Choose a theme`, numbered option lines)
- When theme picker is detected, kill the session for respawn instead of trying Enter nudge (which won't work for interactive pickers)
- Add 3 new tests: `.claude.json` in shared files list, symlink creation when file exists, graceful skip when file is missing

Closes #2301

## Criterion Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `.claude.json` in shared config list | Done | Added at line 25, test confirms inclusion |
| Symlink created when source exists | Done | Test with monkeypatched `Path.home()` confirms symlink |
| Graceful skip when source missing | Done | Test confirms no error when `~/.claude/.claude.json` absent |
| Theme picker pattern detection | Done | Extended regex in `check_stuck_at_prompt()` |
| Kill-and-respawn for theme picker | Done | `attempt_prompt_stuck_recovery()` kills session on theme picker |
| Bash syntax valid | Done | `bash -n` passes |

## Test plan

- [x] `python3 -m pytest tests/test_claude_config.py -v` — 13/13 pass
- [x] `bash -n defaults/scripts/agent-wait-bg.sh` — syntax OK
- [ ] Manual: spawn agent with isolated CLAUDE_CONFIG_DIR, verify no theme picker
- [ ] Manual: verify stuck detection recognizes theme picker patterns in tmux pane