### PR TITLE
fix: ad-hoc sign Rust test binaries on macOS to prevent _dyld_start hangs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -39,6 +39,11 @@ rustflags = [
     "-A", "clippy::module_name_repetitions",
 ]
 
+[target.aarch64-apple-darwin]
+# Ad-hoc sign test binaries before execution to prevent _dyld_start hangs
+# on macOS ARM64. See issue #2298.
+runner = ".cargo/macos-test-runner.sh"
+
 [alias]
 # Convenient aliases for common tasks
 clippy-all = "clippy --workspace --all-targets --all-features"

--- a/.cargo/macos-test-runner.sh
+++ b/.cargo/macos-test-runner.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# macOS test runner for cargo
+#
+# Workaround for _dyld_start hangs on macOS ARM64 (issue #2298).
+# Ad-hoc signs test binaries before execution to satisfy macOS
+# code signature verification, preventing dyld from hanging
+# during binary load.
+#
+# Configured via .cargo/config.toml:
+#   [target.aarch64-apple-darwin]
+#   runner = ".cargo/macos-test-runner.sh"
+
+binary="$1"
+shift
+
+# Ad-hoc sign the binary to prevent _dyld_start verification hangs.
+# -f: force replace any existing signature
+# -s -: use ad-hoc identity (no developer certificate needed)
+codesign -f -s - "$binary" 2>/dev/null
+
+exec "$binary" "$@"


### PR DESCRIPTION
## Summary

- Add `.cargo/macos-test-runner.sh` that ad-hoc signs test binaries via `codesign -f -s -` before execution
- Configure `.cargo/config.toml` with `[target.aarch64-apple-darwin] runner` to use the script automatically
- Only applies on macOS ARM64; Linux CI is unaffected

## Criterion Verification

| Criterion | Status | Verification |
|-----------|--------|-------------|
| Test binaries signed before execution | Pass | Runner calls `codesign -f -s -` on every binary |
| Only macOS ARM64 affected | Pass | Uses `[target.aarch64-apple-darwin]` section |
| cargo check/clippy unaffected | Pass | Verified both pass without changes |
| All existing tests pass | Pass | 241 tests pass (216 unit + 25 integration) |

## Test plan

- [x] `cargo test -p loom-daemon -p loom-api` passes (241 tests)
- [x] `cargo check -p loom-daemon -p loom-api` passes
- [x] `cargo clippy -p loom-daemon -p loom-api` passes
- [x] Runner script is executable and signs binaries correctly

Closes #2298

🤖 Generated with [Claude Code](https://claude.com/claude-code)