### PR TITLE
fix: enforce merge-pr.sh over gh pr merge

### DIFF
--- a/.loom/hooks/guard-destructive.sh
+++ b/.loom/hooks/guard-destructive.sh
@@ -305,6 +305,14 @@ for pattern in "${ASK_PATTERNS[@]}"; do
 done
 
 # =============================================================================
+# LOOM: Prefer merge-pr.sh over gh pr merge
+# =============================================================================
+
+if echo "$COMMAND" | grep -qE 'gh\s+pr\s+merge'; then
+    deny "Use ./.loom/scripts/merge-pr.sh <PR_NUMBER> instead of 'gh pr merge'. The script merges via the GitHub API without local checkout, which avoids worktree errors."
+fi
+
+# =============================================================================
 # ALLOW - Everything else passes through
 # =============================================================================
 

--- a/defaults/.claude/commands/champion-pr-merge.md
+++ b/defaults/.claude/commands/champion-pr-merge.md
@@ -722,7 +722,7 @@ If more than 3 PRs qualify for auto-merge, select the 3 oldest (by creation date
 
 ## Error Handling
 
-If `gh pr merge` fails for any reason:
+If the merge fails for any reason:
 
 1. **Capture error message**
 2. **Add comment to PR** with error details

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -39,6 +39,10 @@ Additional options for `install-loom.sh`:
 - `--force` or `-f`: Force overwrite existing files and enable auto-merge
 - `--clean`: Uninstall first, then fresh install
 
+## Critical Rules
+
+**Never use `gh pr merge`** — Always use `./.loom/scripts/merge-pr.sh <PR_NUMBER>` instead. The `gh pr merge` command attempts a local checkout which fails in worktrees. The merge script uses the GitHub API directly. A PreToolUse hook enforces this.
+
 ## Three-Layer Architecture
 
 Loom uses a three-layer orchestration architecture for scalable automation:

--- a/defaults/hooks/guard-destructive.sh
+++ b/defaults/hooks/guard-destructive.sh
@@ -294,6 +294,14 @@ for pattern in "${ASK_PATTERNS[@]}"; do
 done
 
 # =============================================================================
+# LOOM: Prefer merge-pr.sh over gh pr merge
+# =============================================================================
+
+if echo "$COMMAND" | grep -qE 'gh\s+pr\s+merge'; then
+    deny "Use ./.loom/scripts/merge-pr.sh <PR_NUMBER> instead of 'gh pr merge'. The script merges via the GitHub API without local checkout, which avoids worktree errors."
+fi
+
+# =============================================================================
 # ALLOW - Everything else passes through
 # =============================================================================
 

--- a/loom-tools/src/loom_tools/shepherd/cli.py
+++ b/loom-tools/src/loom_tools/shepherd/cli.py
@@ -934,7 +934,7 @@ def orchestrate(ctx: ShepherdContext) -> int:
         else:
             completed_phases.append("Merge (awaiting merge)")
             log_info(f"PR #{ctx.pr_number} is approved and ready for Champion to merge ({elapsed}s)")
-            log_info(f"To merge manually: gh pr merge {ctx.pr_number} --squash --delete-branch")
+            log_info(f"To merge manually: ./.loom/scripts/merge-pr.sh {ctx.pr_number}")
 
         # ─── Complete ─────────────────────────────────────────────────────
         duration = int(time.time() - start_time)


### PR DESCRIPTION
## Summary

- Add PreToolUse hook in `guard-destructive.sh` that denies `gh pr merge` and directs agents to use `./.loom/scripts/merge-pr.sh` instead
- Add prominent "Critical Rules" section to `defaults/CLAUDE.md` so agents see the rule early
- Fix shepherd log message that was suggesting `gh pr merge` for manual merges
- Fix stale `gh pr merge` reference in champion-pr-merge.md error handling section

## Context

`gh pr merge` fails inside worktrees with `fatal: 'main' is already used by worktree`. Loom provides `merge-pr.sh` which merges via the GitHub API (no local checkout), but agents still default to `gh pr merge` because it wasn't enforced prominently enough.

Closes #2290

## Test plan

- [x] Hook correctly denies `gh pr merge 123 --squash` with guidance message
- [x] 718/719 Python tests pass (1 pre-existing failure unrelated to this change)
- [x] Grep confirms no remaining agent-facing `gh pr merge` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)