### PR TITLE
fix: extract merge-pr.sh from main branch when missing on PR checkout

### DIFF
--- a/defaults/.claude/commands/champion-pr-merge.md
+++ b/defaults/.claude/commands/champion-pr-merge.md
@@ -329,6 +329,10 @@ PR_NUMBER=$1
 
 echo "Attempting to merge PR #$PR_NUMBER..."
 
+# Ensure we're on main so .loom/scripts exists (issue #2289)
+# merge-pr.sh may not exist on PR branches checked out via gh pr checkout
+git checkout main 2>/dev/null || true
+
 # Use merge-pr.sh for worktree-safe merge via GitHub API
 # --auto enables auto-merge if ruleset requires wait
 ./.loom/scripts/merge-pr.sh "$PR_NUMBER" --auto || {

--- a/defaults/.claude/commands/champion-reference.md
+++ b/defaults/.claude/commands/champion-reference.md
@@ -482,6 +482,9 @@ echo ""
 echo "STEP 3/5: Executing squash merge..."
 echo ""
 
+# Ensure we're on main so .loom/scripts exists (issue #2289)
+git checkout main 2>/dev/null || true
+
 # Use merge-pr.sh for worktree-safe merge via GitHub API
 ./.loom/scripts/merge-pr.sh "$PR_NUMBER" --auto || {
   echo "Merge failed!"

--- a/defaults/.claude/commands/shepherd-lifecycle.md
+++ b/defaults/.claude/commands/shepherd-lifecycle.md
@@ -765,6 +765,9 @@ if [ "$PHASE" = "gate2" ]; then
   if [ "$FORCE_MODE" = "true" ]; then
     echo "Force mode: auto-merging PR"
 
+    # Ensure we're on main so .loom/scripts exists (issue #2289)
+    git checkout main 2>/dev/null || true
+
     # Use merge-pr.sh for worktree-safe merge via GitHub API
     ./.loom/scripts/merge-pr.sh $PR_NUMBER --cleanup-worktree || {
       echo "Merge failed for PR #$PR_NUMBER"

--- a/loom-tools/src/loom_tools/shepherd/phases/merge.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/merge.py
@@ -48,9 +48,14 @@ class MergePhase:
                     data={"merged": True},
                 )
             except FileNotFoundError as exc:
+                self._mark_issue_blocked(
+                    ctx,
+                    "script_not_found",
+                    f"merge-pr.sh not found on current branch or main: {exc}",
+                )
                 return PhaseResult(
                     status=PhaseStatus.FAILED,
-                    message=str(exc),
+                    message=f"merge-pr.sh not available: {exc}",
                     phase_name="merge",
                 )
             except subprocess.CalledProcessError:


### PR DESCRIPTION
## Summary

- Adds a `git show main:` fallback in `run_script()` to extract scripts from `main` branch when they don't exist on the current branch (e.g., after `gh pr checkout`)
- Updates merge phase to mark issue as blocked (instead of silently failing) when `merge-pr.sh` is unavailable on both current branch and main
- Adds `git checkout main` guards in Champion and Shepherd role files before merge script calls

Closes #2289

## Test plan

- [x] New tests for `run_script` fallback path (5 tests in `test_context.py`)
- [x] New test for merge phase `FileNotFoundError` handler (1 test in `test_phases.py`)
- [x] All 545 tests pass (1 pre-existing failure in `TestStaleBranchDetection` unrelated to this PR)
- [ ] Manual verification: Check out a PR branch, confirm merge-pr.sh fallback works

🤖 Generated with [Claude Code](https://claude.com/claude-code)