### PR TITLE
feat: add MCP server failure detection and recovery

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/judge.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/judge.py
@@ -160,6 +160,18 @@ class JudgePhase:
                 data={"instant_exit": True},
             )
 
+        if exit_code == 7:
+            # MCP server failure: Claude CLI exited because MCP server failed to init
+            self._mark_issue_blocked(
+                ctx, "judge_mcp_failure", "MCP server failure after retry"
+            )
+            return PhaseResult(
+                status=PhaseStatus.FAILED,
+                message="judge MCP server failure after retry (MCP server failed to initialize)",
+                phase_name="judge",
+                data={"mcp_failure": True},
+            )
+
         # Invalidate caches BEFORE validation so the first attempt
         # fetches fresh data instead of stale cached labels.
         ctx.label_cache.invalidate_pr(ctx.pr_number)


### PR DESCRIPTION
## Summary

- Add pre-flight MCP health check in `claude-wrapper.sh` with auto-rebuild capability when `mcp-loom/dist/` is stale or missing
- Add MCP-specific failure detection (exit code 7) in shepherd phase runners, distinct from generic instant-exit (exit code 6)
- Implement separate retry counter with longer backoff (5s, 15s, 30s) for MCP failures, suitable for systemic initialization issues
- Add MCP failure handling in judge phase to mark issues blocked on MCP failures
- Add 15 new tests covering MCP failure detection, retry behavior, and backoff timing

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|-------------|
| Pre-flight MCP health check in claude-wrapper.sh | Done | `check_mcp_server()` function with smoke test and `_try_mcp_rebuild()` |
| MCP failure patterns detected in phase runner logs | Done | `_is_mcp_failure()` with regex patterns, ANSI stripping |
| Distinct exit code (7) for MCP failures vs instant-exit (6) | Done | Checked before instant-exit in `run_worker_phase()` |
| Retry with longer backoff for MCP failures | Done | `MCP_FAILURE_BACKOFF_SECONDS = [5, 15, 30]`, separate counter |
| Judge handles exit code 7 appropriately | Done | Marks issue blocked with `judge_mcp_failure` error class |

## Test Plan

- [x] 7 unit tests for `_is_mcp_failure()` pattern detection (no file, patterns, regex, normal log, case insensitive, ANSI stripped, empty)
- [x] 2 unit tests for `run_worker_phase()` MCP exit code 7 behavior
- [x] 6 unit tests for `run_phase_with_retry()` MCP retry/backoff behavior
- [x] All 7 existing instant-exit tests still pass (no regression)
- [x] Shell syntax check passes on `claude-wrapper.sh`

Closes #2279