### PR TITLE
fix: guard _commit_interrupted_work and _has_incomplete_work against artifacts

### DIFF
--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -2379,6 +2379,43 @@ class TestBuilderCommitInterruptedWork:
 
         assert result is False
 
+    def test_commit_interrupted_work_artifacts_only_skips_commit(
+        self, tmp_path: Path, mock_context: MagicMock
+    ) -> None:
+        """Should return False when only build artifact files are uncommitted."""
+        builder = BuilderPhase()
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        mock_context.worktree_path = worktree
+        mock_context.config.issue = 42
+
+        def fake_run(cmd, **kwargs):
+            cmd_str = " ".join(str(c) for c in cmd)
+            result = subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="", stderr=""
+            )
+            if "status --porcelain" in cmd_str:
+                result.stdout = "M  Cargo.lock\n"  # Only artifact
+            return result
+
+        calls: list[str] = []
+
+        def tracking_run(cmd, **kwargs):
+            cmd_str = " ".join(str(c) for c in cmd)
+            calls.append(cmd_str)
+            return fake_run(cmd, **kwargs)
+
+        with patch(
+            "loom_tools.shepherd.phases.builder.subprocess.run",
+            side_effect=tracking_run,
+        ):
+            result = builder._commit_interrupted_work(mock_context, "test reason")
+
+        assert result is False
+        # Should NOT have called git add or git commit
+        assert not any("add -A" in c for c in calls), "Should not stage artifacts"
+        assert not any("commit -m" in c for c in calls), "Should not create commit"
+
 
 class TestBuilderHasUncommittedChanges:
     """Test BuilderPhase._has_uncommitted_changes helper."""
@@ -6790,7 +6827,8 @@ class TestBuilderHasIncompleteWork:
         diag = {"worktree_exists": False}
         assert builder._has_incomplete_work(diag) is False
 
-    def test_uncommitted_changes_returns_true(self) -> None:
+    def test_uncommitted_changes_no_checkpoint_returns_false(self) -> None:
+        """Uncommitted changes without a checkpoint means builder never started."""
         builder = BuilderPhase()
         diag = {
             "worktree_exists": True,
@@ -6799,6 +6837,20 @@ class TestBuilderHasIncompleteWork:
             "remote_branch_exists": False,
             "pr_number": None,
             "pr_has_review_label": False,
+        }
+        assert builder._has_incomplete_work(diag) is False
+
+    def test_uncommitted_changes_with_checkpoint_returns_true(self) -> None:
+        """Uncommitted changes with a checkpoint means builder made progress."""
+        builder = BuilderPhase()
+        diag = {
+            "worktree_exists": True,
+            "has_uncommitted_changes": True,
+            "commits_ahead": 0,
+            "remote_branch_exists": False,
+            "pr_number": None,
+            "pr_has_review_label": False,
+            "checkpoint_stage": "implementing",
         }
         assert builder._has_incomplete_work(diag) is True
 


### PR DESCRIPTION
Closes #2280

## Summary

Fixes two bugs where build artifact files (e.g. `Cargo.lock` from post-worktree hooks) could trigger false completion phases:

- **`_commit_interrupted_work()`**: Now filters build artifacts before creating WIP commits. When only artifact files are uncommitted, the commit is skipped entirely, preventing `commits_ahead > 0` that would trick the completion phase into activating.

- **`_has_incomplete_work()`**: Now requires a checkpoint when `commits_ahead == 0` and only uncommitted changes exist. Without a checkpoint, the builder never started meaningful work, so a full retry is more appropriate than a completion phase.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|-------------|
| `_commit_interrupted_work()` skips WIP commits for artifact-only changes | Pass | New test `test_commit_interrupted_work_artifacts_only_skips_commit` |
| `_has_incomplete_work()` returns False when no checkpoint + uncommitted only | Pass | Updated test `test_uncommitted_changes_no_checkpoint_returns_false` |
| Builder crash without commits/checkpoint triggers full retry | Pass | Returns False → not incomplete → shepherd retries |
| Existing completion phase unchanged when `commits_ahead > 0` | Pass | `test_commits_ahead_returns_true` still passes |
| Existing checkpoint recovery unchanged | Pass | Checkpoint stages (tested, committed, pushed) still trigger True |

## Test plan

- [x] `test_commit_interrupted_work_artifacts_only_skips_commit` — verifies no WIP commit for Cargo.lock-only changes
- [x] `test_uncommitted_changes_no_checkpoint_returns_false` — updated from prior test to expect False without checkpoint
- [x] `test_uncommitted_changes_with_checkpoint_returns_true` — new test for uncommitted + checkpoint → True
- [x] All 801 shepherd tests pass (pre-existing `TestStaleBranchDetection` failure excluded)
- [x] All 15 directly related tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)