### PR TITLE
feat: add --skip-builder and --pr flags to shepherd

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/config.py
+++ b/loom-tools/src/loom_tools/shepherd/config.py
@@ -192,6 +192,10 @@ class ShepherdConfig:
     # Reflection phase control
     no_reflect: bool = False
 
+    # Skip builder and use existing PR
+    skip_builder: bool = False
+    pr_number_override: int | None = None
+
     @property
     def is_force_mode(self) -> bool:
         """True if running in force mode (auto-approve, auto-merge)."""

--- a/loom-tools/tests/shepherd/test_cli.py
+++ b/loom-tools/tests/shepherd/test_cli.py
@@ -88,6 +88,31 @@ class TestParseArgs:
         args = _parse_args(["42"])
         assert args.allow_dirty_main is False
 
+    def test_parses_skip_builder(self) -> None:
+        """Should parse --skip-builder flag."""
+        args = _parse_args(["42", "--skip-builder"])
+        assert args.skip_builder is True
+
+    def test_skip_builder_default_false(self) -> None:
+        """--skip-builder should default to False."""
+        args = _parse_args(["42"])
+        assert args.skip_builder is False
+
+    def test_parses_pr_number(self) -> None:
+        """Should parse --pr with integer."""
+        args = _parse_args(["42", "--pr", "312"])
+        assert args.pr_number == 312
+
+    def test_pr_default_none(self) -> None:
+        """--pr should default to None."""
+        args = _parse_args(["42"])
+        assert args.pr_number is None
+
+    def test_pr_rejects_non_integer(self) -> None:
+        """--pr should reject non-integer values."""
+        with pytest.raises(SystemExit):
+            _parse_args(["42", "--pr", "abc"])
+
 
 class TestCreateConfig:
     """Test config creation from args."""
@@ -151,6 +176,27 @@ class TestCreateConfig:
         args = _parse_args(["42", "--task-id", "abc1234"])
         config = _create_config(args)
         assert config.task_id == "abc1234"
+
+    def test_skip_builder(self) -> None:
+        """--skip-builder should set skip_builder."""
+        args = _parse_args(["42", "--skip-builder"])
+        config = _create_config(args)
+        assert config.skip_builder is True
+        assert config.pr_number_override is None
+
+    def test_pr_number_sets_skip_builder(self) -> None:
+        """--pr should set pr_number_override and imply skip_builder."""
+        args = _parse_args(["42", "--pr", "312"])
+        config = _create_config(args)
+        assert config.pr_number_override == 312
+        assert config.skip_builder is True
+
+    def test_skip_builder_default(self) -> None:
+        """Default config should have skip_builder=False."""
+        args = _parse_args(["42"])
+        config = _create_config(args)
+        assert config.skip_builder is False
+        assert config.pr_number_override is None
 
 
 class TestAutoNavigateOutOfWorktree:


### PR DESCRIPTION
## Summary

- Adds `--skip-builder` flag to skip the builder phase and auto-detect an existing PR for the issue
- Adds `--pr <N>` flag to skip the builder phase and use a specific PR number directly
- `--pr` implies `--skip-builder`; both proceed directly to the judge phase

## Use Cases

- **Manual builder recovery**: Builder failed, human created PR manually
- **Iterative development**: PR created outside shepherd, want judge review + auto-merge
- **Re-running after judge failure**: PR exists but judge timed out, retry judge+merge only

## Changes

- `config.py`: Added `skip_builder` and `pr_number_override` fields to `ShepherdConfig`
- `cli.py`: Added `--skip-builder` and `--pr` CLI arguments, updated epilog examples
- `builder.py`: Extended `should_skip()` to check new config options before existing logic
- `test_cli.py`: Added 8 tests for arg parsing and config creation
- `test_phases.py`: Added 4 tests for builder skip logic with new flags

## Test plan

- [x] TestParseArgs: --skip-builder, --pr parsing, --pr rejects non-integer
- [x] TestCreateConfig: --skip-builder, --pr implies skip_builder, defaults
- [x] TestBuilderPhase: --pr override, --skip-builder with/without existing PR
- [x] All 585+ shepherd tests pass (1 pre-existing failure unrelated to this change)

Closes #2270

🤖 Generated with [Claude Code](https://claude.com/claude-code)