### PR TITLE
fix: gitignore .loom-test-failure-context.json to prevent circular biome failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ Thumbs.db
 # Loom runtime state (don't commit these)
 .loom-in-use
 .loom-checkpoint
+.loom-test-failure-context.json
 .loom/.daemon.pid
 .loom/.daemon.log
 .loom/daemon.sock


### PR DESCRIPTION
## Summary

- Add `.loom-test-failure-context.json` to `.gitignore` so biome won't lint this transient shepherd artifact
- This prevents the circular failure where: test fails → shepherd writes context file → biome flags context file → doctor can't fix meta-problem → loop exhausts retries

## Context

This file is written by the builder/doctor phases when tests fail, to pass failure context between phases. Since biome has `useIgnoreFile: true`, gitignoring it is the simplest fix. The file was never meant to be committed.

## Test plan

- [x] Verified `pnpm lint` passes with the artifact file present in worktree
- [x] Confirmed biome checks 255 files (previously 263 when the artifact was included)

Closes #2318

🤖 Generated with [Claude Code](https://claude.com/claude-code)