### PR TITLE
fix: use loom:triage label for reflection-filed issues

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/reflection.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/reflection.py
@@ -28,6 +28,9 @@ UPSTREAM_REPO = "rjwalters/loom"
 # Title prefix for searchability
 TITLE_PREFIX = "[shepherd-reflection]"
 
+# Label applied to reflection-filed issues (goes through normal triage pipeline)
+REFLECTION_ISSUE_LABEL = "loom:triage"
+
 
 @dataclass
 class Finding:
@@ -301,7 +304,7 @@ class ReflectionPhase(BasePhase):
                     "--title",
                     title,
                     "--label",
-                    finding.severity,
+                    REFLECTION_ISSUE_LABEL,
                     "--body",
                     body,
                 ],


### PR DESCRIPTION
## Summary

- Reflection phase was using `finding.severity` ("enhancement"/"bug") as the GitHub label when filing upstream issues, but those labels don't exist in this repo
- Added `REFLECTION_ISSUE_LABEL = "loom:triage"` constant and use it in `_file_upstream_issue` instead of `finding.severity`
- Added test verifying the correct label is passed to `gh issue create`

Closes #2326

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| reflection.py uses `loom:triage` instead of severity | Verified | `REFLECTION_ISSUE_LABEL = "loom:triage"` on line 32, used on line 307 |
| All existing tests pass | Verified | 17/17 tests pass |
| New test covers label usage | Verified | `TestReflectionPhaseFileUpstream.test_uses_loom_triage_label` |

## Test plan

- [x] All 17 reflection tests pass (`pytest tests/shepherd/test_reflection.py`)
- [x] New test verifies `gh issue create` receives `loom:triage` label, not severity

🤖 Generated with [Claude Code](https://claude.com/claude-code)