### PR TITLE
feat: dedicated timeout and stuck recovery for doctor test-fix

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/config.py
+++ b/loom-tools/src/loom_tools/shepherd/config.py
@@ -157,6 +157,9 @@ class ShepherdConfig:
     doctor_timeout: int = field(
         default_factory=lambda: env_int("LOOM_DOCTOR_TIMEOUT", 3600)
     )
+    doctor_test_fix_timeout: int = field(
+        default_factory=lambda: env_int("LOOM_DOCTOR_TEST_FIX_TIMEOUT", 600)
+    )
     poll_interval: int = field(
         default_factory=lambda: env_int("LOOM_POLL_INTERVAL", 5)
     )

--- a/loom-tools/tests/shepherd/test_config.py
+++ b/loom-tools/tests/shepherd/test_config.py
@@ -159,6 +159,22 @@ class TestShepherdConfig:
         assert config.should_skip_phase(Phase.JUDGE) is True
         assert config.should_skip_phase(Phase.MERGE) is False
 
+    def test_doctor_test_fix_timeout_default(self) -> None:
+        """doctor_test_fix_timeout should default to 600."""
+        config = ShepherdConfig(issue=42)
+        assert config.doctor_test_fix_timeout == 600
+
+    def test_doctor_test_fix_timeout_env_override(self) -> None:
+        """LOOM_DOCTOR_TEST_FIX_TIMEOUT env var should override default."""
+        with patch.dict(os.environ, {"LOOM_DOCTOR_TEST_FIX_TIMEOUT": "120"}):
+            config = ShepherdConfig(issue=42)
+            assert config.doctor_test_fix_timeout == 120
+
+    def test_doctor_test_fix_timeout_explicit(self) -> None:
+        """doctor_test_fix_timeout can be explicitly set."""
+        config = ShepherdConfig(issue=42, doctor_test_fix_timeout=300)
+        assert config.doctor_test_fix_timeout == 300
+
     def test_get_phase_timeout(self) -> None:
         """Phase timeouts should be returned correctly."""
         config = ShepherdConfig(

--- a/loom-tools/tests/shepherd/test_doctor_phase.py
+++ b/loom-tools/tests/shepherd/test_doctor_phase.py
@@ -1,0 +1,189 @@
+"""Tests for DoctorPhase, focused on run_test_fix behavior."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from loom_tools.shepherd.config import ShepherdConfig
+from loom_tools.shepherd.context import ShepherdContext
+from loom_tools.shepherd.phases import DoctorPhase, PhaseResult, PhaseStatus
+from loom_tools.shepherd.phases.doctor import DoctorDiagnostics
+
+
+@pytest.fixture
+def mock_context() -> MagicMock:
+    """Create a mock ShepherdContext for doctor tests."""
+    ctx = MagicMock(spec=ShepherdContext)
+    ctx.config = ShepherdConfig(issue=42)
+    ctx.repo_root = Path("/fake/repo")
+    ctx.scripts_dir = Path("/fake/repo/.loom/scripts")
+    ctx.worktree_path = Path("/fake/repo/.loom/worktrees/issue-42")
+    ctx.pr_number = 100
+    ctx.label_cache = MagicMock()
+    ctx.check_shutdown.return_value = False
+    return ctx
+
+
+@pytest.fixture
+def test_failure_data() -> dict:
+    """Sample test failure data for run_test_fix."""
+    return {
+        "test_output_tail": "FAILED test_foo - AssertionError",
+        "test_summary": "1 failed, 5 passed",
+        "test_command": "pnpm check:ci",
+        "changed_files": ["src/main.py"],
+    }
+
+
+class TestRunTestFixTimeout:
+    """Test that run_test_fix uses the shorter doctor_test_fix_timeout."""
+
+    @patch("loom_tools.shepherd.phases.doctor.run_phase_with_retry")
+    def test_uses_test_fix_timeout(
+        self, mock_run: MagicMock, mock_context: MagicMock, test_failure_data: dict
+    ) -> None:
+        """run_test_fix should use doctor_test_fix_timeout, not doctor_timeout."""
+        mock_context.config.doctor_timeout = 3600
+        mock_context.config.doctor_test_fix_timeout = 600
+        mock_run.return_value = 0
+
+        phase = DoctorPhase()
+        with patch.object(phase, "_get_commit_count", return_value=0):
+            with patch.object(
+                phase,
+                "_diagnose_doctor_outcome",
+                return_value=DoctorDiagnostics(commits_made=1),
+            ):
+                with patch.object(
+                    phase, "_write_test_failure_context", return_value=None
+                ):
+                    phase.run_test_fix(mock_context, test_failure_data)
+
+        # Verify the timeout passed to run_phase_with_retry
+        _, kwargs = mock_run.call_args
+        assert kwargs["timeout"] == 600
+
+    @patch("loom_tools.shepherd.phases.doctor.run_phase_with_retry")
+    def test_respects_env_override(
+        self, mock_run: MagicMock, mock_context: MagicMock, test_failure_data: dict
+    ) -> None:
+        """Custom doctor_test_fix_timeout should be respected."""
+        mock_context.config.doctor_test_fix_timeout = 120
+        mock_run.return_value = 0
+
+        phase = DoctorPhase()
+        with patch.object(phase, "_get_commit_count", return_value=0):
+            with patch.object(
+                phase,
+                "_diagnose_doctor_outcome",
+                return_value=DoctorDiagnostics(commits_made=0),
+            ):
+                with patch.object(
+                    phase, "_write_test_failure_context", return_value=None
+                ):
+                    phase.run_test_fix(mock_context, test_failure_data)
+
+        _, kwargs = mock_run.call_args
+        assert kwargs["timeout"] == 120
+
+
+class TestRunTestFixStuckRecovery:
+    """Test stuck-but-committed recovery in run_test_fix."""
+
+    @patch("loom_tools.shepherd.phases.doctor.run_phase_with_retry")
+    def test_stuck_with_commits_returns_success(
+        self, mock_run: MagicMock, mock_context: MagicMock, test_failure_data: dict
+    ) -> None:
+        """When test-fix is stuck (exit 4) but made commits, treat as success."""
+        mock_run.return_value = 4  # stuck exit code
+
+        phase = DoctorPhase()
+        with patch.object(phase, "_get_commit_count", return_value=5):
+            with patch.object(
+                phase,
+                "_diagnose_doctor_outcome",
+                return_value=DoctorDiagnostics(commits_made=2),
+            ):
+                with patch.object(
+                    phase, "_write_test_failure_context", return_value=None
+                ):
+                    result = phase.run_test_fix(mock_context, test_failure_data)
+
+        assert result.status == PhaseStatus.SUCCESS
+        assert "hung after commit" in result.message
+        assert result.data["commits_made"] == 2
+
+    @patch("loom_tools.shepherd.phases.doctor.run_phase_with_retry")
+    def test_stuck_with_commits_reports_milestone(
+        self, mock_run: MagicMock, mock_context: MagicMock, test_failure_data: dict
+    ) -> None:
+        """Stuck-but-committed recovery should report a heartbeat milestone."""
+        mock_run.return_value = 4
+
+        phase = DoctorPhase()
+        with patch.object(phase, "_get_commit_count", return_value=5):
+            with patch.object(
+                phase,
+                "_diagnose_doctor_outcome",
+                return_value=DoctorDiagnostics(commits_made=1),
+            ):
+                with patch.object(
+                    phase, "_write_test_failure_context", return_value=None
+                ):
+                    phase.run_test_fix(mock_context, test_failure_data)
+
+        mock_context.report_milestone.assert_any_call(
+            "heartbeat",
+            action="doctor-test-fix stuck but committed fix, treating as success",
+        )
+
+    @patch("loom_tools.shepherd.phases.doctor.run_phase_with_retry")
+    def test_stuck_without_commits_returns_stuck(
+        self, mock_run: MagicMock, mock_context: MagicMock, test_failure_data: dict
+    ) -> None:
+        """When test-fix is stuck (exit 4) with no commits, return STUCK."""
+        mock_run.return_value = 4
+
+        phase = DoctorPhase()
+        with patch.object(phase, "_get_commit_count", return_value=5):
+            with patch.object(
+                phase,
+                "_diagnose_doctor_outcome",
+                return_value=DoctorDiagnostics(commits_made=0),
+            ):
+                with patch.object(
+                    phase, "_write_test_failure_context", return_value=None
+                ):
+                    result = phase.run_test_fix(mock_context, test_failure_data)
+
+        assert result.status == PhaseStatus.STUCK
+        assert "stuck during test-fix" in result.message
+
+
+class TestFullDoctorRunUnchanged:
+    """Verify the full doctor run() still uses doctor_timeout (not test-fix timeout)."""
+
+    @patch("loom_tools.shepherd.phases.doctor.run_phase_with_retry")
+    def test_full_doctor_uses_doctor_timeout(
+        self, mock_run: MagicMock, mock_context: MagicMock
+    ) -> None:
+        """Full doctor run() should use doctor_timeout, not doctor_test_fix_timeout."""
+        mock_context.config.doctor_timeout = 3600
+        mock_context.config.doctor_test_fix_timeout = 600
+        mock_run.return_value = 0
+
+        phase = DoctorPhase()
+        with patch.object(phase, "_get_commit_count", return_value=0):
+            with patch.object(
+                phase,
+                "_diagnose_doctor_outcome",
+                return_value=DoctorDiagnostics(commits_made=0),
+            ):
+                with patch.object(phase, "validate", return_value=True):
+                    phase.run(mock_context)
+
+        _, kwargs = mock_run.call_args
+        assert kwargs["timeout"] == 3600

--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -9137,10 +9137,10 @@ class TestDoctorLabelRecovery:
 class TestDoctorTestFixWithDiagnostics:
     """Test run_test_fix includes diagnostics in failure results."""
 
-    def test_stuck_result_includes_diagnostics(
+    def test_stuck_with_commits_recovers_as_success(
         self, mock_context: MagicMock
     ) -> None:
-        """run_test_fix STUCK result should include diagnostics."""
+        """run_test_fix STUCK with commits should recover as SUCCESS."""
         from loom_tools.shepherd.phases.doctor import DoctorDiagnostics
 
         doctor = DoctorPhase()
@@ -9158,7 +9158,8 @@ class TestDoctorTestFixWithDiagnostics:
             mock_run.return_value = 4  # Stuck
             result = doctor.run_test_fix(mock_context, {})
 
-        assert result.status == PhaseStatus.STUCK
+        assert result.status == PhaseStatus.SUCCESS
+        assert "hung after commit" in result.message
         assert result.data.get("commits_made") == 1
 
     def test_failed_result_includes_failure_mode(


### PR DESCRIPTION
## Summary

- Adds `doctor_test_fix_timeout` config field (default 600s via `LOOM_DOCTOR_TEST_FIX_TIMEOUT`) so the test-fix subprocess uses a shorter, proportionate timeout instead of the full 3600s doctor timeout
- When the test-fix subprocess gets stuck (exit code 4) but has already committed fixes, the shepherd now recovers it as SUCCESS instead of marking the issue as stuck
- Full doctor phase (PR changes-requested mode) retains its existing 3600s timeout unchanged

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Doctor test-fix uses separate shorter timeout (600s default) | PASS | `config.py:160-162` — new `doctor_test_fix_timeout` field with `LOOM_DOCTOR_TEST_FIX_TIMEOUT` env var |
| Stuck subprocess with commits treated as success | PASS | `doctor.py:712-727` — checks `diagnostics.made_progress` when exit code is 4 |
| Full doctor phase retains 3600s timeout | PASS | `doctor.py:143` — `run()` still uses `ctx.config.doctor_timeout` |
| Config tests updated | PASS | `test_config.py` — 3 new tests for default, env override, and explicit value |
| New test for stuck-but-committed recovery | PASS | `test_doctor_phase.py` — 6 tests covering timeout usage, stuck recovery, and full doctor unchanged |

## Test Plan

- [x] Config tests: default value (600), env override, explicit set — all pass
- [x] Doctor phase tests: timeout used in run_test_fix, stuck+commits=SUCCESS, stuck+no_commits=STUCK, full doctor uses doctor_timeout — all pass
- [x] Updated pre-existing `test_stuck_result_includes_diagnostics` to match new behavior (now `test_stuck_with_commits_recovers_as_success`)
- [x] 41 tests pass across modified/new test files

Closes #2341

🤖 Generated with [Claude Code](https://claude.com/claude-code)