### PR TITLE
fix: push doctor test-fix commits to remote before re-verification

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/cli.py
+++ b/loom-tools/src/loom_tools/shepherd/cli.py
@@ -663,6 +663,11 @@ def orchestrate(ctx: ShepherdContext) -> int:
                         status="success",
                     )
 
+                    # Push doctor's fixes to remote immediately so CI starts
+                    # and work is preserved even if the shepherd crashes.
+                    if not builder.push_branch(ctx):
+                        log_warning("Could not push doctor fixes to remote, continuing anyway")
+
                 # Re-run test verification
                 _print_phase_header(f"PHASE 3c: TEST VERIFICATION (after Doctor attempt {test_fix_attempts})")
                 test_start = time.time()

--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -2916,6 +2916,15 @@ class BuilderPhase:
 
         log_info(f"Cleaned up worktree and reverted labels for issue #{ctx.config.issue}")
 
+    def push_branch(self, ctx: ShepherdContext) -> bool:
+        """Push the current branch to remote.
+
+        Returns True if the push succeeded or the branch was already pushed.
+        Public wrapper so the shepherd orchestrator can trigger a push
+        (e.g. after the doctor applies test fixes).
+        """
+        return self._push_branch(ctx)
+
     def _push_branch(self, ctx: ShepherdContext) -> bool:
         """Push the current branch to remote.
 


### PR DESCRIPTION
Closes #2342

## Summary

- After the doctor successfully applies test fixes, the shepherd now pushes commits to the remote branch **before** re-running local test verification
- Push failure is non-fatal (logged as warning, does not block the test-fix loop)
- Push only happens on the doctor SUCCESS path, not on FAILED/STUCK/SHUTDOWN/SKIPPED paths
- Added public `BuilderPhase.push_branch()` method wrapping the existing private `_push_branch()`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Push after doctor commits, before re-verification | Done | `cli.py:666-669` calls `builder.push_branch(ctx)` in the doctor SUCCESS else-branch |
| Push failure is non-fatal warning | Done | `if not builder.push_branch(ctx): log_warning(...)` matches `_push_branch()` behavior |
| Existing tests pass | Done | 94 passed (4 pre-existing failures unrelated to this change) |
| Push only on SUCCESS path | Done | Code is inside the `else` branch that handles doctor SUCCESS only |

## Test plan

- [x] `test_push_called_after_doctor_success` - verifies `push_branch` is called after doctor SUCCESS
- [x] `test_push_not_called_after_doctor_failure` - verifies `push_branch` is NOT called when doctor FAILED
- [x] `test_push_failure_is_nonfatal` - verifies push failure doesn't block the workflow (returns SUCCESS)
- [x] All existing shepherd CLI tests pass with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)