### PR TITLE
Fix 13 failing tests in test_phases.py due to missing mock attributes

### DIFF
--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -55,6 +55,7 @@ def mock_context() -> MagicMock:
     ctx.worktree_path = Path("/fake/repo/.loom/worktrees/issue-42")
     ctx.pr_number = None
     ctx.label_cache = MagicMock()
+    ctx.warnings = []
     return ctx
 
 
@@ -9999,6 +10000,8 @@ class TestRunPhaseWithRetryInstantExit:
         ctx.repo_root = Path("/fake/repo")
         ctx.scripts_dir = Path("/fake/repo/.loom/scripts")
         ctx.progress_dir = Path("/tmp/progress")
+        ctx.label_cache = MagicMock()
+        ctx.pr_number = None
         return ctx
 
     def test_retries_on_instant_exit_then_succeeds(
@@ -10637,6 +10640,8 @@ class TestRunPhaseWithRetryMcpFailure:
         ctx.repo_root = Path("/fake/repo")
         ctx.scripts_dir = Path("/fake/repo/.loom/scripts")
         ctx.progress_dir = Path("/tmp/progress")
+        ctx.label_cache = MagicMock()
+        ctx.pr_number = None
         return ctx
 
     def test_retries_on_mcp_failure_then_succeeds(


### PR DESCRIPTION
## Summary

- Add `label_cache = MagicMock()` and `pr_number = None` to `TestRunPhaseWithRetryInstantExit` and `TestRunPhaseWithRetryMcpFailure` fixtures
- Add `warnings = []` to the module-level `mock_context` fixture

These mock attributes were missing after production code added `label_cache` and `warnings` to `ShepherdContext`, but the test mocks (using `spec=ShepherdContext`) weren't updated.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| All 13 failing tests pass | Done | `python3 -m pytest ...` — 13 passed |
| No regressions | Done | Full suite: 560 passed, 0 failed |

## Test plan

- [x] Run the 13 previously-failing tests → all pass
- [x] Run full `test_phases.py` suite → 560 passed (vs 547 before)

Closes #2375

🤖 Generated with [Claude Code](https://claude.com/claude-code)