### PR TITLE
fix: add duration gate to MCP failure detection

### DIFF
--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import subprocess
 import time
 from pathlib import Path
@@ -30,6 +31,7 @@ from loom_tools.shepherd.phases.base import (
     INSTANT_EXIT_MIN_OUTPUT_CHARS,
     INSTANT_EXIT_THRESHOLD_SECONDS,
     MCP_FAILURE_BACKOFF_SECONDS,
+    MCP_FAILURE_DURATION_THRESHOLD,
     MCP_FAILURE_MAX_RETRIES,
     _is_instant_exit,
     _is_mcp_failure,
@@ -10528,6 +10530,59 @@ class TestIsMcpFailure:
         log = tmp_path / "session.log"
         log.write_text("")
         assert _is_mcp_failure(log) is False
+
+    def test_productive_session_with_mcp_pattern_returns_false(
+        self, tmp_path: Path
+    ) -> None:
+        """Long-running session with MCP status-bar text should NOT be flagged.
+
+        This is the false-positive scenario from issue #2374: the builder
+        runs for minutes doing real work, but the Claude CLI status bar
+        shows '1 MCP server failed', triggering a spurious retry.
+        """
+        log = tmp_path / "session.log"
+        log.write_text(
+            "Claude CLI started. Loading /builder skill.\n"
+            "bypasspermissionson · 1 MCP server failed · /mcp\n"
+            "Running git log --oneline -20 main\n"
+            "Implementing feature for issue #42...\n"
+        )
+        # Simulate a session that ran for well over the threshold
+        stat = log.stat()
+        os.utime(log, (stat.st_atime, stat.st_mtime + MCP_FAILURE_DURATION_THRESHOLD + 60))
+        assert _is_mcp_failure(log) is False
+
+    def test_short_session_with_mcp_pattern_returns_true(
+        self, tmp_path: Path
+    ) -> None:
+        """Short-lived session with MCP pattern IS a real MCP failure."""
+        log = tmp_path / "session.log"
+        log.write_text("1 MCP server failed\n")
+        # File just created: ctime == mtime, duration 0 < threshold
+        assert _is_mcp_failure(log) is True
+
+    def test_session_above_threshold_returns_false(
+        self, tmp_path: Path
+    ) -> None:
+        """Session clearly above the duration threshold should NOT be flagged."""
+        log = tmp_path / "session.log"
+        log.write_text("1 MCP server failed\n")
+        stat = log.stat()
+        # Use threshold + 5 to safely clear any floating-point rounding
+        # from os.utime updating st_ctime.
+        os.utime(log, (stat.st_atime, stat.st_mtime + MCP_FAILURE_DURATION_THRESHOLD + 5))
+        assert _is_mcp_failure(log) is False
+
+    def test_session_well_below_threshold_returns_true(
+        self, tmp_path: Path
+    ) -> None:
+        """Session well below the duration threshold should be flagged."""
+        log = tmp_path / "session.log"
+        log.write_text("1 MCP server failed\n")
+        stat = log.stat()
+        # 10 seconds is well below the 30-second threshold
+        os.utime(log, (stat.st_atime, stat.st_mtime + 10))
+        assert _is_mcp_failure(log) is True
 
 
 class TestRunWorkerPhaseMcpFailure:


### PR DESCRIPTION
## Summary

- Adds a 30-second duration threshold to `_is_mcp_failure()` so that productive sessions (where "MCP server failed" appears as CLI status-bar text) are not flagged as MCP initialization failures
- Sessions below the threshold are still correctly detected and retried
- Adds 4 new tests covering productive-session false positives and duration threshold behavior

## Criterion Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Add duration/output check to `_is_mcp_failure()` | Done | Duration gate added at `base.py:313-317` — sessions ≥ 30s return False before pattern matching |
| Prevent false positives on productive sessions | Done | New test `test_productive_session_with_mcp_pattern_returns_false` verifies 90s session with MCP text is not flagged |
| Short-lived MCP failures still detected | Done | Existing tests + new `test_short_session_with_mcp_pattern_returns_true` confirm short sessions are still caught |
| Add tests for productive-session case | Done | 4 new tests in `TestIsMcpFailure` class |
| No regressions in existing MCP failure tests | Done | All 11 `TestIsMcpFailure` tests pass, all 18 related tests pass |

## Test plan

- [x] `pytest TestIsMcpFailure` — 11 tests pass (7 existing + 4 new)
- [x] `pytest TestRunWorkerPhaseMcpFailure` — 2 tests pass
- [x] `pytest TestIsInstantExit` — 5 tests pass (no regression)
- [x] `pytest test_phases.py` — 330 pass, 1 pre-existing failure (unrelated `TestStaleBranchDetection`)

Closes #2374

🤖 Generated with [Claude Code](https://claude.com/claude-code)