### PR TITLE
fix: remove mcp.json from shared config symlinks to fix MCP init failures

### DIFF
--- a/loom-tools/src/loom_tools/common/claude_config.py
+++ b/loom-tools/src/loom_tools/common/claude_config.py
@@ -5,7 +5,7 @@ agents don't fight over sessions, lock files, and temp directories in the
 shared ~/.claude/ directory.
 
 Each agent gets .loom/claude-config/{agent-name}/ with:
-- Symlinks to shared read-only config (settings.json, config.json, etc.)
+- Symlinks to shared read-only config (settings.json, config.json)
 - Fresh empty directories for mutable per-session state
 """
 
@@ -22,11 +22,13 @@ from loom_tools.common.paths import LoomPaths
 log = logging.getLogger(__name__)
 
 # Shared config files to symlink from ~/.claude/ (read-only)
+# Note: mcp.json / .mcp.json are intentionally excluded — they are
+# project-scoped configs that Claude Code discovers from the working
+# directory / git root.  Symlinking them from ~/.claude/ shadows the
+# correct project-level config and causes MCP initialization failures.
 _SHARED_CONFIG_FILES = [
     "settings.json",
     "config.json",
-    "mcp.json",
-    ".mcp.json",
 ]
 
 # Shared directories to symlink from ~/.claude/ (read-only caches)

--- a/loom-tools/tests/test_claude_config.py
+++ b/loom-tools/tests/test_claude_config.py
@@ -88,6 +88,11 @@ class TestSetupAgentConfigDir:
         """State file .claude.json is handled separately, not in shared list."""
         assert ".claude.json" not in _SHARED_CONFIG_FILES
 
+    def test_mcp_json_not_in_shared_config_files(self) -> None:
+        """MCP configs are project-scoped, not user-global — must not be symlinked."""
+        assert "mcp.json" not in _SHARED_CONFIG_FILES
+        assert ".mcp.json" not in _SHARED_CONFIG_FILES
+
     def test_symlinks_state_file_from_home_root(
         self, mock_repo: pathlib.Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary

- Removed `mcp.json` and `.mcp.json` from `_SHARED_CONFIG_FILES` in `claude_config.py` — these are project-scoped configs that Claude Code discovers from the working directory, not user-global configs that should be symlinked from `~/.claude/`
- Added regression test verifying MCP configs stay excluded from the shared list
- Fixes ~4% MCP initialization failure rate across shepherd sessions

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| `mcp.json` removed from `_SHARED_CONFIG_FILES` | Pass | Lines 28-29 removed |
| `.mcp.json` removed from `_SHARED_CONFIG_FILES` | Pass | Lines 28-29 removed |
| Comment explains exclusion rationale | Pass | 3-line comment added |
| Existing tests still pass | Pass | 30/30 tests pass |
| Regression test added | Pass | `test_mcp_json_not_in_shared_config_files` |

## Test Plan

- [x] `pytest loom-tools/tests/test_claude_config.py` — 30 passed

Closes #2378

🤖 Generated with [Claude Code](https://claude.com/claude-code)