### PR TITLE
chore: bump version to v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-02-15
+
+### Summary
+
+Reliability and stability release focused on shepherd pipeline hardening, per-agent config isolation, and analytics integration.
+
+### Added
+
+- Shepherd reflection phase for post-run analysis and upstream issue filing (#2275)
+- Per-agent `CLAUDE_CONFIG_DIR` isolation for concurrent session stability (#2285, #2313)
+- Analytics pipeline UI integration (Phases 3-5) (#2373)
+- Pre-implementation reproducibility check in builder phase (#2363)
+- Dedicated timeout and stuck recovery for doctor test-fix phase (#2347)
+- MCP server failure detection and recovery in shepherd pipeline (#2310)
+- Dual-mode GitHub API layer with REST fallback (#2255)
+- Pre-flight auth check in claude-wrapper.sh (#2332)
+- `--skip-builder` and `--pr` flags for shepherd (#2314)
+- Installer integration test suite for install/reinstall/uninstall paths (#2272)
+- Kill orphaned claude processes during terminal/session lifecycle (#2273)
+- Wrapper retry state reporting for shepherd observability (#2311)
+
+### Fixed
+
+- Detect already-merged PRs in shepherd validation to prevent unnecessary builder runs (#2384)
+- Replace broken `st_mtime`-`st_ctime` duration gate with output volume check (#2382)
+- Remove `mcp.json` from shared config symlinks to fix MCP init failures (#2380)
+- Duration gate for MCP failure detection to prevent false positives (#2377)
+- Label cleanup handler for shepherd partial failures (#2372)
+- Broaden shepherd builder recovery to use PR existence as primary signal (#2371)
+- Detect `loom:changes-requested` label in judge unexpected-result branch (#2364)
+- Set PYTHONPATH in worktree subprocesses to resolve imports correctly (#2361)
+- Push doctor test-fix commits to remote before re-verification (#2351)
+- Shepherd recovers from builder non-zero exit when PR already created (#2346)
+- Check for existing judge approval before retrying on MCP/exit failures (#2340)
+- Ensure agents skip Claude Code onboarding wizard (#2336)
+- Clone macOS Keychain credentials for per-agent config dir isolation (#2323)
+- Baseline comparison parses biome/clippy errors and detects cross-tool mismatches (#2331)
+- Regression guard for doctor test-fix loop (#2317)
+- Prevent theme picker from blocking agents in isolated config dirs (#2302)
+- TTY fallback in claude-wrapper to avoid hanging when no terminal available (#2297)
+- Prevent unsafe worktree removal during merge and agent destroy (#2251)
+- Enforce `merge-pr.sh` over `gh pr merge` to prevent worktree errors (#2306)
+- Ad-hoc sign Rust test binaries on macOS to prevent `_dyld_start` hangs (#2304)
+
+### Changed
+
+- Replace husky/lint-staged with plain `.githooks/` directory (#2305)
+- Split loom-daemon into lib + binary to prevent test hang (#2337)
+
 ## [0.2.0] - 2026-01-24
 
 ### Summary
@@ -156,6 +205,7 @@ Existing v0.1.x installations can upgrade cleanly:
 - Installation script for target repositories
 - Quickstart templates for webapp, desktop, and API projects
 
-[Unreleased]: https://github.com/rjwalters/loom/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/rjwalters/loom/compare/v0.2.3...HEAD
+[0.2.3]: https://github.com/rjwalters/loom/compare/v0.2.0...v0.2.3
 [0.2.0]: https://github.com/rjwalters/loom/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/rjwalters/loom/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 This repository uses **Loom** for AI-powered development orchestration.
 
-**Loom Version**: {{LOOM_VERSION}}
+**Loom Version**: 0.2.3
 **Installation Date**: {{INSTALL_DATE}}
 
 ## What is Loom?

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "app"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2404,7 +2404,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "loom-api"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -2421,7 +2421,7 @@ dependencies = [
 
 [[package]]
 name = "loom-daemon"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/loom-api/Cargo.toml
+++ b/loom-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loom-api"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 description = "External REST API for Loom analytics data access"
 

--- a/loom-daemon/Cargo.toml
+++ b/loom-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loom-daemon"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 [dependencies]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loom",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A multi-terminal desktop application for macOS that orchestrates AI-powered development workers using git worktrees and GitHub as the coordination layer.",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.2.2"
+version = "0.2.3"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Loom",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "identifier": "com.github.rjwalters.loom",
   "build": {
     "beforeBuildCommand": "pnpm build",


### PR DESCRIPTION
## Summary
- Bump version to 0.2.3 across all packages (package.json, Cargo.toml, tauri.conf.json, CLAUDE.md)
- Add v0.2.3 changelog entry with full release notes

## Notes
Tag `v0.2.3` and GitHub release already created. Once merged, the tag will need to be moved to the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)