### PR TITLE
fix: detect worktree escape in shepherd no-changes-needed logic

### DIFF
--- a/defaults/scripts/strip-ansi.sh
+++ b/defaults/scripts/strip-ansi.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Strip ANSI escape sequences and clean terminal output from stdin.
+# Delegates to Python loom_tools.log_filter for robust handling of
+# cursor sequences, spinner animations, and other TUI artifacts.
+#
+# Usage:
+#   cat .loom/logs/loom-builder-issue-42.log | ./.loom/scripts/strip-ansi.sh
+#   ./.loom/scripts/strip-ansi.sh < .loom/logs/loom-builder-issue-42.log
+exec python3 -m loom_tools.log_filter


### PR DESCRIPTION
## Summary

- Add `main_branch_dirty` check to `_gather_diagnostics()` to detect when the builder modifies files on main instead of in the worktree
- Update `_is_no_changes_needed()` to return False when main has uncommitted changes, preventing false "no changes needed" issue closures
- Add explicit warning log when worktree escape is detected at both builder call sites
- Add `strip-ansi.sh` wrapper script referenced in diagnostic comments

Closes #2399

## Test plan

- [x] New unit tests for `_is_no_changes_needed` with `main_branch_dirty` field (3 cases: dirty blocks, clean allows, missing key defaults safe)
- [x] New integration tests for `_gather_diagnostics` main branch state detection (3 cases: dirty detected, clean detected, summary includes warning)
- [x] All 570 existing shepherd tests pass
- [x] Full loom-tools test suite passes (2879 passed, 3 pre-existing failures in test_agent_monitor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)