### PR TITLE
fix: add CLI start sentinel to prevent wrapper pre-flight defeating instant-exit detection

### DIFF
--- a/defaults/scripts/claude-wrapper.sh
+++ b/defaults/scripts/claude-wrapper.sh
@@ -571,6 +571,10 @@ run_with_retry() {
         # Falls back to direct execution when no TTY is available (e.g., when spawned
         # from Claude Code's Bash tool rather than a tmux terminal).
         start_output_monitor "${temp_output}" "${monitor_pid_file}"
+        # Write sentinel marker so _is_instant_exit() in the shepherd can
+        # distinguish wrapper pre-flight output from actual Claude CLI output.
+        # The "# " prefix means it is also filtered as a header line.
+        echo "# CLAUDE_CLI_START" >&2
         set +e  # Temporarily disable errexit to capture exit code
         unset CLAUDECODE  # Prevent nested session guard from blocking subprocess
         # Export per-agent config dir if set (for session isolation)


### PR DESCRIPTION
## Summary
- Adds a `# CLAUDE_CLI_START` sentinel marker in `claude-wrapper.sh` just before invoking the `claude` CLI
- Updates `_is_instant_exit()` and `_is_mcp_failure()` in `base.py` to only count output after the last sentinel, ignoring wrapper pre-flight boilerplate
- Adds 6 new tests covering sentinel-based detection, backward compatibility, and multi-sentinel (retry) scenarios

Closes #2401

## Test plan
- [x] All 22 existing + new instant-exit and MCP failure detection tests pass
- [ ] Verify sentinel appears in log files during actual shepherd runs
- [ ] Confirm instant-exit detection works when Claude CLI is SIGKILLed after wrapper pre-flight

🤖 Generated with [Claude Code](https://claude.com/claude-code)