### PR TITLE
fix: set GIT_WORK_TREE/GIT_DIR for worktree builder agents to prevent escape

### DIFF
--- a/loom-tools/src/loom_tools/agent_spawn.py
+++ b/loom-tools/src/loom_tools/agent_spawn.py
@@ -609,6 +609,20 @@ def spawn_agent(
         _tmux("set-environment", "-t", session_name, "PYTHONPATH", pythonpath_val)
         pythonpath_prefix = f"PYTHONPATH='{pythonpath_val}' "
 
+    # Pin git operations to the worktree so that absolute paths cannot
+    # accidentally resolve to the main repo (see issue #2418).
+    if worktree and working_dir != repo_root:
+        git_file = working_dir / ".git"
+        if git_file.exists():
+            _tmux(
+                "set-environment", "-t", session_name,
+                "GIT_WORK_TREE", str(working_dir),
+            )
+            _tmux(
+                "set-environment", "-t", session_name,
+                "GIT_DIR", str(git_file),
+            )
+
     # Build the role slash command
     role_cmd = f"/{role}"
     if args:


### PR DESCRIPTION
## Summary

Prevents builder agents from accidentally modifying the main repo when using absolute paths that resolve outside the worktree. Sets `GIT_WORK_TREE` and `GIT_DIR` environment variables in the tmux session when spawning builders in worktrees.

## Changes

- **`agent_spawn.py`**: After existing PYTHONPATH setup, adds logic to set `GIT_WORK_TREE` (worktree dir) and `GIT_DIR` (worktree `.git` file) in the tmux environment when `worktree` is specified and `working_dir` differs from `repo_root`
- **`test_agent_spawn.py`**: Adds `TestGitWorktreePinning` class with 3 tests:
  - Verifies env vars are set for worktree agents
  - Verifies no env vars when working at repo root
  - Verifies no env vars when no worktree specified

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| GIT_WORK_TREE set for worktree builders | Verified | `test_sets_git_env_for_worktree` passes |
| GIT_DIR set to worktree .git file | Verified | Same test confirms `.git` path |
| Not set when working at repo root | Verified | `test_no_git_env_when_working_in_repo_root` passes |
| Not set for non-worktree agents | Verified | `test_no_git_env_when_no_worktree` passes |
| Only applies when .git file exists | Verified | Guard condition `git_file.exists()` in code |

## Test Plan

- [x] 3 new unit tests pass (`TestGitWorktreePinning`)
- [x] Existing tests unaffected

Closes #2418