### PR TITLE
fix: complete file-based claim locking to prevent orphaned claims

### DIFF
--- a/loom-tools/src/loom_tools/daemon_v2/iteration.py
+++ b/loom-tools/src/loom_tools/daemon_v2/iteration.py
@@ -6,6 +6,7 @@ import subprocess
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from loom_tools.claim import release_claim
 from loom_tools.common.logging import log_error, log_info, log_success, log_warning
 from loom_tools.common.state import read_daemon_state, write_json_file
 from loom_tools.common.time_utils import now_utc
@@ -434,9 +435,10 @@ def _escalate_level_3(ctx: DaemonContext) -> None:
             kill_stuck_session(name)
             killed += 1
 
-        # Revert issue label
+        # Revert issue label and release file-based claim
         issue = entry.issue
         if issue is not None:
+            release_claim(ctx.repo_root, issue)
             try:
                 _unclaim_issue(issue)
                 log_info(f"STALL-L3: Reverted issue #{issue} labels")


### PR DESCRIPTION
## Summary

- Adds `release_claim` calls to all code paths that release or requeue issues, preventing file-based claims from becoming orphaned and blocking reassignment for up to 2 hours (TTL expiry)
- Covers L3 pool restart (`iteration.py`), transient error retry and non-transient failure (`completions.py`), daemon shutdown label revert and shepherd-complete cleanup (`daemon_cleanup.py`)
- Includes the existing local diff for spawn-path claim acquisition and L2 stall recovery (`shepherds.py`) and shepherd CLI entry/exit (`cli.py`)

## Test plan

- [x] All 35 `test_claim.py` tests pass
- [x] All 290 daemon-related tests pass
- [x] Full suite: 2885 passed, 0 new failures (11 pre-existing unrelated failures)
- [ ] Verify in live daemon session that claims are released on shutdown, transient retry, and L3 restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)