### PR TITLE
fix: --merge mode implies --allow-dirty-main in shepherd

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/cli.py
+++ b/loom-tools/src/loom_tools/shepherd/cli.py
@@ -1890,6 +1890,12 @@ def main(argv: list[str] | None = None) -> int:
     repo_root = find_repo_root()
     _auto_navigate_out_of_worktree(repo_root)
 
+    # --force / --merge implies --allow-dirty-main: the user wants fully
+    # autonomous operation and the builder works in an isolated worktree,
+    # so uncommitted main changes shouldn't block.
+    if args.force:
+        args.allow_dirty_main = True
+
     # Pre-flight check: warn if main repo has uncommitted changes.
     # This prevents confusion when tests pass in main but fail in worktrees
     # (or vice versa) due to uncommitted local changes.


### PR DESCRIPTION
## Summary

When running `shepherd` with `--merge` / `-m` (full automation mode), uncommitted changes in the main repo would block execution with exit code 4. This contradicts the intent of merge mode, which is fully autonomous operation.

- Add `args.allow_dirty_main = True` when `args.force` (set by `--merge`/`-m`) is enabled
- The dirty-main warning still prints (useful for debugging), but no longer blocks in merge mode
- Builder works in an isolated worktree anyway, so uncommitted main changes don't affect it

Closes #2410