### PR TITLE
fix: detect builder crash/timeout vs legitimate no-changes-needed

### DIFF
--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -10555,6 +10555,96 @@ class TestBuilderMainBranchDirtyDetection:
         assert builder._is_no_changes_needed(diag) is True
 
 
+class TestBuilderImplementationActivityDetection:
+    """Test _is_no_changes_needed rejects false positives from builder crash/timeout.
+
+    When the builder log shows Edit/Write tool calls with substantial output,
+    the builder was actively implementing — not concluding 'no changes needed.'
+    See issue #2425.
+    """
+
+    def test_implementation_activity_blocks_no_changes_needed(self) -> None:
+        """Builder with Edit/Write activity should NOT be 'no changes needed'."""
+        builder = BuilderPhase()
+        diag = {
+            "worktree_exists": True,
+            "has_uncommitted_changes": False,
+            "commits_ahead": 0,
+            "remote_branch_exists": False,
+            "pr_number": None,
+            "main_branch_dirty": False,
+            "log_has_implementation_activity": True,
+        }
+        assert builder._is_no_changes_needed(diag) is False
+
+    def test_no_implementation_activity_allows_no_changes_needed(self) -> None:
+        """Builder without implementation activity can be 'no changes needed'."""
+        builder = BuilderPhase()
+        diag = {
+            "worktree_exists": True,
+            "has_uncommitted_changes": False,
+            "commits_ahead": 0,
+            "remote_branch_exists": False,
+            "pr_number": None,
+            "main_branch_dirty": False,
+            "log_has_implementation_activity": False,
+        }
+        assert builder._is_no_changes_needed(diag) is True
+
+    def test_missing_activity_key_defaults_safe(self) -> None:
+        """Missing log_has_implementation_activity defaults to False (no block)."""
+        builder = BuilderPhase()
+        diag = {
+            "worktree_exists": True,
+            "has_uncommitted_changes": False,
+            "commits_ahead": 0,
+            "remote_branch_exists": False,
+            "pr_number": None,
+            # log_has_implementation_activity not present — backwards compat
+        }
+        assert builder._is_no_changes_needed(diag) is True
+
+    def test_activity_with_git_work_still_returns_false(self) -> None:
+        """Implementation activity + git artifacts = not 'no changes needed'."""
+        builder = BuilderPhase()
+        diag = {
+            "worktree_exists": True,
+            "has_uncommitted_changes": True,
+            "commits_ahead": 0,
+            "remote_branch_exists": False,
+            "pr_number": None,
+            "log_has_implementation_activity": True,
+        }
+        # Already False due to has_uncommitted_changes — activity is redundant
+        assert builder._is_no_changes_needed(diag) is False
+
+
+class TestImplementationToolRegex:
+    """Test _IMPLEMENTATION_TOOL_RE matches expected patterns."""
+
+    def test_matches_edit_tool(self) -> None:
+        from loom_tools.shepherd.phases.builder import _IMPLEMENTATION_TOOL_RE
+
+        assert _IMPLEMENTATION_TOOL_RE.search("✓ Edit loom-tools/src/foo.py")
+
+    def test_matches_write_tool(self) -> None:
+        from loom_tools.shepherd.phases.builder import _IMPLEMENTATION_TOOL_RE
+
+        assert _IMPLEMENTATION_TOOL_RE.search("✓ Write /tmp/new_file.py")
+
+    def test_matches_wrote_to(self) -> None:
+        from loom_tools.shepherd.phases.builder import _IMPLEMENTATION_TOOL_RE
+
+        assert _IMPLEMENTATION_TOOL_RE.search("Wrote to /Users/dev/project/src/main.py")
+
+    def test_no_match_on_read_only(self) -> None:
+        from loom_tools.shepherd.phases.builder import _IMPLEMENTATION_TOOL_RE
+
+        assert not _IMPLEMENTATION_TOOL_RE.search(
+            "Read file src/lib.rs\nGrep results: 3 matches"
+        )
+
+
 class TestBuilderGatherDiagnosticsMainBranch:
     """Test that _gather_diagnostics includes main branch dirty state."""
 


### PR DESCRIPTION
## Summary

- Adds log content analysis to `_is_no_changes_needed()` to distinguish a builder that crashed/timed out mid-work from one that legitimately concluded no changes were needed
- When the builder log shows Edit/Write tool calls with substantial output (>2000 chars), treats the outcome as a builder failure instead of "no changes needed"
- New diagnostics fields (`log_cli_output_length`, `log_has_implementation_activity`) populated in `_gather_diagnostics()` and consumed by `_is_no_changes_needed()`

## Test plan

- [x] All 587 existing `test_phases.py` tests pass
- [x] All 34 `test_builder_reproducibility.py` tests pass
- [x] 8 new tests: `TestBuilderImplementationActivityDetection` (4 tests) + `TestImplementationToolRegex` (4 tests)
- [ ] Verify in production that a builder crash with Edit/Write activity in log is correctly classified as failure instead of no-changes-needed

Closes #2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)