### PR TITLE
fix: make test verification timeout configurable via LOOM_TEST_VERIFY_TIMEOUT

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -41,7 +41,7 @@ from loom_tools.shepherd.phases.base import (
 logger = logging.getLogger(__name__)
 
 # Default timeout for test verification (seconds)
-_TEST_VERIFY_TIMEOUT = 300
+_TEST_VERIFY_TIMEOUT = int(os.environ.get("LOOM_TEST_VERIFY_TIMEOUT", "300"))
 
 # Pre-implementation reproducibility check settings
 _REPRODUCIBILITY_RUNS = 3  # Number of times to run each test for flakiness


### PR DESCRIPTION
## Summary

- Makes the hardcoded 300s test verification timeout in the builder phase configurable via the `LOOM_TEST_VERIFY_TIMEOUT` environment variable
- Follows the existing pattern used by other shepherd timeouts (`LOOM_BUILDER_TIMEOUT`, `LOOM_CURATOR_TIMEOUT`, etc.)
- Default remains 300s for backward compatibility

Closes #2393

## Test plan

- [x] All 391 builder-related tests pass
- [ ] Verify custom timeout works: `LOOM_TEST_VERIFY_TIMEOUT=900 /shepherd <issue>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)