### PR TITLE
fix: downgrade progress file missing errors to warnings

### DIFF
--- a/loom-tools/src/loom_tools/milestones.py
+++ b/loom-tools/src/loom_tools/milestones.py
@@ -231,11 +231,10 @@ def report_milestone(
             return True
 
         # All other events require an existing progress file.
+        # The file may have been deleted by a concurrent shepherd cleaning
+        # up stale progress for the same issue — use warning, not error.
         if not progress_file.is_file():
-            log_error(f"No progress file found for task {task_id}")
-            log_error(
-                f"Run 'report-milestone.sh started --task-id {task_id} --issue N' first"
-            )
+            log_warning(f"No progress file found for task {task_id} (may have been cleaned up by another shepherd)")
             return False
 
         raw = read_json_file(progress_file)

--- a/loom-tools/src/loom_tools/shepherd/context.py
+++ b/loom-tools/src/loom_tools/shepherd/context.py
@@ -467,6 +467,17 @@ class ShepherdContext:
                         "Subsequent milestones will be skipped.",
                         self.config.task_id,
                     )
+            elif not result:
+                # Progress file may have been deleted mid-run by a concurrent
+                # shepherd cleaning up stale files for the same issue.
+                # Re-engage the silent suppression guard so subsequent
+                # milestone calls don't produce repeated error messages.
+                self._progress_initialized = False
+                logger.debug(
+                    "Progress file for task %s appears to have been removed. "
+                    "Disabling further milestone reporting.",
+                    self.config.task_id,
+                )
 
             return result
         except Exception as exc:


### PR DESCRIPTION
## Summary

- Downgrades "No progress file found" from `log_error` to `log_warning` in `milestones.py` since the file can legitimately be deleted by a concurrent shepherd cleaning up stale progress
- Re-engages the `_progress_initialized = False` guard in `context.py` when progress file disappears mid-run, preventing repeated warning messages on subsequent milestone calls

## Test plan

- [ ] Run shepherd with concurrent progress file cleanup to verify no error spam
- [ ] Verify initial "started" milestone still logs errors on failure
- [ ] Verify subsequent milestones are silently suppressed after file disappears

Closes #2397