### PR TITLE
fix: exclude pre-existing dirty files from worktree escape detection

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -150,6 +150,11 @@ def _build_worktree_env(worktree_path: Path | None) -> dict[str, str] | None:
 class BuilderPhase:
     """Phase 3: Builder - Create worktree, implement, create PR."""
 
+    def __init__(self) -> None:
+        # Baseline snapshot of main's dirty files before builder spawns.
+        # Used to distinguish pre-existing dirt from worktree escapes.
+        self._main_dirty_baseline: set[str] | None = None
+
     def should_skip(self, ctx: ShepherdContext) -> tuple[bool, str]:
         """Check if builder phase should be skipped.
 
@@ -333,6 +338,10 @@ class BuilderPhase:
 
         # Create marker to prevent premature cleanup
         self._create_worktree_marker(ctx)
+
+        # Snapshot main's dirty state before spawning the builder so we can
+        # distinguish pre-existing dirt from actual worktree escapes later.
+        self._main_dirty_baseline = self._snapshot_main_dirty(ctx)
 
         # Run builder worker with retry
         exit_code = run_phase_with_retry(
@@ -2484,6 +2493,23 @@ class BuilderPhase:
         paths = LoomPaths(ctx.repo_root)
         return paths.builder_log_file(ctx.config.issue)
 
+    @staticmethod
+    def _snapshot_main_dirty(ctx: ShepherdContext) -> set[str]:
+        """Snapshot main's dirty files (git status --porcelain lines).
+
+        Called before the builder spawns so that _gather_diagnostics can
+        distinguish pre-existing dirt from new files added by a worktree escape.
+        """
+        result = subprocess.run(
+            ["git", "-C", str(ctx.repo_root), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return set(result.stdout.strip().splitlines())
+        return set()
+
     def _gather_diagnostics(self, ctx: ShepherdContext) -> dict[str, Any]:
         """Collect diagnostic info about the builder environment.
 
@@ -2670,9 +2696,8 @@ class BuilderPhase:
 
         # -- Main branch state (detect worktree escape) -----------------------
         # Check if the builder accidentally modified files on main instead
-        # of in the worktree.  This is a critical signal for
-        # _is_no_changes_needed() — if main is dirty after a builder run
-        # with a clean worktree, the builder likely escaped the worktree.
+        # of in the worktree.  Only flag files that are NEW since the builder
+        # started — pre-existing dirty files are not evidence of escape.
         main_status = subprocess.run(
             ["git", "-C", str(ctx.repo_root), "status", "--porcelain"],
             capture_output=True,
@@ -2682,9 +2707,19 @@ class BuilderPhase:
         main_dirty_files: list[str] = []
         if main_status.returncode == 0 and main_status.stdout.strip():
             main_dirty_files = main_status.stdout.strip().splitlines()
-        diag["main_branch_dirty"] = bool(main_dirty_files)
-        diag["main_dirty_file_count"] = len(main_dirty_files)
-        diag["main_dirty_files"] = main_dirty_files[:10]  # Cap for readability
+
+        # Filter out pre-existing dirty files using the baseline snapshot
+        if self._main_dirty_baseline is not None:
+            new_dirty_files = [
+                f for f in main_dirty_files
+                if f not in self._main_dirty_baseline
+            ]
+        else:
+            new_dirty_files = main_dirty_files
+
+        diag["main_branch_dirty"] = bool(new_dirty_files)
+        diag["main_dirty_file_count"] = len(new_dirty_files)
+        diag["main_dirty_files"] = new_dirty_files[:10]  # Cap for readability
 
         # -- Human-readable summary -----------------------------------------
         parts: list[str] = []
@@ -2721,7 +2756,11 @@ class BuilderPhase:
             parts.append(f"checkpoint={diag['checkpoint_stage']}")
         if diag["main_branch_dirty"]:
             parts.append(
-                f"WARNING: main branch dirty ({diag['main_dirty_file_count']} files)"
+                f"WARNING: main branch dirty ({diag['main_dirty_file_count']} NEW files)"
+            )
+        elif main_dirty_files and not new_dirty_files:
+            parts.append(
+                f"main branch dirty ({len(main_dirty_files)} pre-existing files, ignored)"
             )
         parts.append(f"log={diag['log_file']}")
         diag["summary"] = "; ".join(parts)
@@ -2886,16 +2925,18 @@ class BuilderPhase:
         but crashed or timed out before committing.  This is a builder failure,
         not a "no changes needed" determination.  See issue #2425.
 
-        If main has uncommitted changes, the builder may have escaped the
-        worktree and modified files on main instead.  This is NOT a "no
-        changes needed" situation — it's a worktree escape bug.
+        If main has NEW uncommitted changes (compared to pre-builder baseline),
+        the builder may have escaped the worktree and modified files on main
+        instead.  This is NOT a "no changes needed" situation — it's a
+        worktree escape bug.  Pre-existing dirty files are excluded from this
+        check (see issue #2457).
         """
         if not diag.get("worktree_exists"):
             return False
 
-        # If main branch is dirty, the builder may have escaped the worktree
-        # and made changes on main instead.  Never treat this as "no changes
-        # needed" — it requires human intervention to recover.
+        # If main branch has NEW dirty files (not pre-existing), the builder
+        # may have escaped the worktree and made changes on main instead.
+        # Never treat this as "no changes needed".
         if diag.get("main_branch_dirty", False):
             return False
 


### PR DESCRIPTION
## Summary

- Snapshots main's `git status --porcelain` output before spawning the builder
- After builder completes, compares current dirty files against the baseline snapshot
- Only flags **new** dirty files (not in baseline) as potential worktree escapes
- Pre-existing dirty files are reported in the diagnostic summary as informational rather than as warnings

## Changes

- `BuilderPhase.__init__`: Added `_main_dirty_baseline` attribute
- `BuilderPhase._snapshot_main_dirty`: New static method to capture main's dirty state
- `BuilderPhase.run`: Snapshots baseline before `run_phase_with_retry`
- `BuilderPhase._gather_diagnostics`: Filters dirty files against baseline
- Updated comments in `_is_no_changes_needed` to reflect the new behavior

## Test plan

- [x] New tests in `TestBuilderMainDirtyBaseline`:
  - Pre-existing dirty files are excluded from escape detection
  - New dirty files are correctly detected
  - No baseline (None) preserves backwards-compatible behavior
  - `_snapshot_main_dirty` returns correct set for dirty and clean states
- [x] All existing `TestBuilderMainBranchDirty` and `TestNoChangesNeeded` tests pass
- [x] 20 related tests pass (diagnostics, artifacts, stale worktree)

Closes #2457