### PR TITLE
fix: accept --resume flag in shepherd CLI

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/cli.py
+++ b/loom-tools/src/loom_tools/shepherd/cli.py
@@ -179,6 +179,13 @@ EXAMPLES:
         help="Skip builder phase and use specified PR number directly",
     )
 
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Resume from prior work (existing branch/checkpoint). "
+        "Passed automatically by daemon when prior work is detected.",
+    )
+
     # Deprecated flags
     parser.add_argument(
         "--wait",
@@ -347,6 +354,7 @@ def _create_config(args: argparse.Namespace) -> ShepherdConfig:
         no_reflect=args.no_reflect,
         skip_builder=skip_builder,
         pr_number_override=pr_number_override,
+        resume=args.resume,
     )
 
     if args.task_id:

--- a/loom-tools/src/loom_tools/shepherd/config.py
+++ b/loom-tools/src/loom_tools/shepherd/config.py
@@ -199,6 +199,9 @@ class ShepherdConfig:
     skip_builder: bool = False
     pr_number_override: int | None = None
 
+    # Resume from prior work (existing branch/checkpoint)
+    resume: bool = False
+
     @property
     def is_force_mode(self) -> bool:
         """True if running in force mode (auto-approve, auto-merge)."""

--- a/loom-tools/tests/shepherd/test_cli.py
+++ b/loom-tools/tests/shepherd/test_cli.py
@@ -114,6 +114,16 @@ class TestParseArgs:
         with pytest.raises(SystemExit):
             _parse_args(["42", "--pr", "abc"])
 
+    def test_parses_resume(self) -> None:
+        """Should parse --resume flag."""
+        args = _parse_args(["42", "--resume"])
+        assert args.resume is True
+
+    def test_resume_default_false(self) -> None:
+        """--resume should default to False."""
+        args = _parse_args(["42"])
+        assert args.resume is False
+
 
 class TestCreateConfig:
     """Test config creation from args."""
@@ -198,6 +208,18 @@ class TestCreateConfig:
         config = _create_config(args)
         assert config.skip_builder is False
         assert config.pr_number_override is None
+
+    def test_resume_sets_config(self) -> None:
+        """--resume should set resume=True in config."""
+        args = _parse_args(["42", "--resume"])
+        config = _create_config(args)
+        assert config.resume is True
+
+    def test_resume_default(self) -> None:
+        """Default config should have resume=False."""
+        args = _parse_args(["42"])
+        config = _create_config(args)
+        assert config.resume is False
 
 
 class TestAutoNavigateOutOfWorktree:


### PR DESCRIPTION
## Summary

- Add `--resume` flag to the shepherd CLI argument parser so the daemon can pass it without causing `unrecognized arguments` errors
- Add `resume` field to `ShepherdConfig` dataclass (currently accepted but not yet acted upon — the shepherd already handles prior work via worktree/branch detection)
- Add tests for argument parsing and config creation

Closes #2386

## Test plan

- [x] `TestParseArgs::test_parses_resume` — verifies `--resume` is parsed
- [x] `TestParseArgs::test_resume_default_false` — verifies default is False
- [x] `TestCreateConfig::test_resume_sets_config` — verifies config propagation
- [x] `TestCreateConfig::test_resume_default` — verifies config default

🤖 Generated with [Claude Code](https://claude.com/claude-code)