### PR TITLE
fix: orphan recovery cleans stale worktrees left by crashed shepherds

### DIFF
--- a/loom-tools/src/loom_tools/claim.py
+++ b/loom-tools/src/loom_tools/claim.py
@@ -314,6 +314,25 @@ def check_claim(repo_root: pathlib.Path, issue_number: int) -> int:
     return 0
 
 
+def has_valid_claim(repo_root: pathlib.Path, issue_number: int) -> bool:
+    """Check if an issue has a valid (non-expired) claim.
+
+    Unlike ``check_claim``, this returns a boolean and does not print
+    anything, making it suitable for programmatic checks.
+    """
+    claim_dir = _get_claim_dir(repo_root, issue_number)
+    claim_file = claim_dir / "claim.json"
+
+    if not claim_dir.exists() or not claim_file.exists():
+        return False
+
+    existing = _read_claim(claim_file)
+    if not existing:
+        return False
+
+    return not _is_expired(existing.expires_at)
+
+
 def list_claims(repo_root: pathlib.Path) -> int:
     """List all active claims."""
     _ensure_claims_dir(repo_root)


### PR DESCRIPTION
## Summary

- Adds `_cleanup_stale_worktree()` to orphan recovery that removes worktrees with 0 commits ahead of main and only build artifact changes (node_modules, Cargo.lock, .venv, etc.)
- Adds `has_valid_claim()` to claim.py so orphan recovery can skip issues actively claimed by CLI shepherds
- Passes `repo_root` through the recovery call chain to enable claim checks and worktree cleanup
- Recovery comments now include worktree cleanup action when performed

## Test plan

- [x] `TestCleanupStaleWorktree` - 6 tests covering: no worktree, stale worktree cleanup, commits ahead preserved, meaningful changes preserved, build-artifacts-only cleaned, git failure handled
- [x] `TestRecoverIssueClaimsAndWorktree` - 5 tests covering: valid claim skips recovery, no claim proceeds, stale worktree cleaned, no repo_root skips both, comment mentions cleanup
- [x] `TestCheckUntrackedBuildingClaims` - 3 tests covering: valid claim skips orphan detection, no claim still orphaned, no repo_root still orphaned
- [x] `TestHasValidClaim` - 4 tests covering: no claim, active claim, expired claim, incomplete claim
- [x] All 108 tests passing

Closes #2432

🤖 Generated with [Claude Code](https://claude.com/claude-code)