### PR TITLE
fix: use run_phase_with_retry in completion phase

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -3082,7 +3082,7 @@ class BuilderPhase:
         Returns:
             Exit code from the completion worker (0=success)
         """
-        from loom_tools.shepherd.phases.base import run_worker_phase
+        from loom_tools.shepherd.phases.base import run_phase_with_retry
 
         steps = self._diagnose_remaining_steps(diag, ctx.config.issue)
 
@@ -3187,11 +3187,12 @@ class BuilderPhase:
             f"Do NOT implement anything new - just complete the git/PR workflow."
         )
 
-        exit_code = run_worker_phase(
+        exit_code = run_phase_with_retry(
             ctx,
             role="builder",
             name=f"builder-complete-{ctx.config.issue}",
             timeout=300,  # 5 minutes should be enough to commit/push/PR
+            max_retries=1,
             phase="builder",
             worktree=ctx.worktree_path,
             args=completion_args,

--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -8247,7 +8247,7 @@ class TestBuilderCompletionPhaseTargetedInstructions:
         }
 
         with patch(
-            "loom_tools.shepherd.phases.base.run_worker_phase", return_value=0
+            "loom_tools.shepherd.phases.base.run_phase_with_retry", return_value=0
         ) as mock_run:
             builder._run_completion_phase(mock_context, diag, attempt=2)
 
@@ -8272,7 +8272,7 @@ class TestBuilderCompletionPhaseTargetedInstructions:
         }
 
         with patch(
-            "loom_tools.shepherd.phases.base.run_worker_phase", return_value=0
+            "loom_tools.shepherd.phases.base.run_phase_with_retry", return_value=0
         ) as mock_run:
             builder._run_completion_phase(mock_context, diag, attempt=1)
 
@@ -8297,7 +8297,7 @@ class TestBuilderCompletionPhaseTargetedInstructions:
         }
 
         with patch(
-            "loom_tools.shepherd.phases.base.run_worker_phase", return_value=0
+            "loom_tools.shepherd.phases.base.run_phase_with_retry", return_value=0
         ) as mock_run:
             builder._run_completion_phase(mock_context, diag, attempt=1)
 
@@ -8324,7 +8324,7 @@ class TestBuilderCompletionPhaseTargetedInstructions:
         }
 
         with patch(
-            "loom_tools.shepherd.phases.base.run_worker_phase", return_value=0
+            "loom_tools.shepherd.phases.base.run_phase_with_retry", return_value=0
         ) as mock_run:
             builder._run_completion_phase(mock_context, diag, attempt=2)
 
@@ -8351,7 +8351,7 @@ class TestBuilderCompletionPhaseTargetedInstructions:
         }
 
         with patch(
-            "loom_tools.shepherd.phases.base.run_worker_phase", return_value=0
+            "loom_tools.shepherd.phases.base.run_phase_with_retry", return_value=0
         ) as mock_run:
             builder._run_completion_phase(mock_context, diag, attempt=1)
 
@@ -8376,7 +8376,7 @@ class TestBuilderCompletionPhaseTargetedInstructions:
         }
 
         with patch(
-            "loom_tools.shepherd.phases.base.run_worker_phase", return_value=0
+            "loom_tools.shepherd.phases.base.run_phase_with_retry", return_value=0
         ) as mock_run:
             builder._run_completion_phase(mock_context, diag, attempt=2)
 
@@ -8400,7 +8400,7 @@ class TestBuilderCompletionPhaseTargetedInstructions:
         }
 
         with patch(
-            "loom_tools.shepherd.phases.base.run_worker_phase", return_value=0
+            "loom_tools.shepherd.phases.base.run_phase_with_retry", return_value=0
         ) as mock_run:
             builder._run_completion_phase(mock_context, diag, attempt=2)
 


### PR DESCRIPTION
## Summary

- Completion phase (`_run_completion_phase`) now uses `run_phase_with_retry` instead of `run_worker_phase`, adding automatic retry logic for transient MCP failures (exit code 7) and instant exits (exit code 6)
- Uses `max_retries=1` for the inner retry so transient failures are handled before consuming outer completion attempts
- Updated 7 test mocks to match the new function call

## Context

Observed during shepherd run for #2397: the builder made correct code changes but exited without committing. Both completion attempts failed due to MCP server initialization failures because the completion phase bypassed `run_phase_with_retry`.

Closes #2440

## Test plan

- [x] All 7 `TestBuilderCompletionPhaseTargetedInstructions` tests pass
- [x] All 22 completion-related tests pass
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)