### PR TITLE
fix: ensure scripts/lib/ copied and executable during installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -74,6 +74,26 @@ install_hooks_and_cli() {
   fi
 }
 
+# Verify critical installation files exist
+verify_install() {
+  local target="$1"
+  local critical_files=(
+    ".loom/config.json"
+    ".loom/scripts/worktree.sh"
+    ".loom/scripts/lib/loom-tools.sh"
+  )
+  local missing=0
+  for file in "${critical_files[@]}"; do
+    if [[ ! -f "$target/$file" ]]; then
+      warning "Missing critical file: $file"
+      missing=$((missing + 1))
+    fi
+  done
+  if [[ $missing -gt 0 ]]; then
+    warning "$missing critical file(s) missing after installation"
+  fi
+}
+
 # Determine Loom repository root
 LOOM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -450,6 +470,7 @@ elif [[ -d "$TARGET_PATH/.loom" ]]; then
 
     # Install hooks and CLI wrapper (not handled by loom-daemon init)
     install_hooks_and_cli "$LOOM_ROOT" "$TARGET_PATH"
+    verify_install "$TARGET_PATH"
 
     echo ""
     success "Quick reinstallation complete!"
@@ -591,6 +612,7 @@ case "$METHOD" in
 
     # Install hooks and CLI wrapper (not handled by loom-daemon init)
     install_hooks_and_cli "$LOOM_ROOT" "$TARGET_PATH"
+    verify_install "$TARGET_PATH"
 
     echo ""
     success "Quick installation complete!"

--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -715,6 +715,7 @@ EXPECTED_FILES=(
   ".loom/config.json"
   ".loom/roles"
   ".loom/scripts/worktree.sh"
+  ".loom/scripts/lib/loom-tools.sh"
   ".loom/hooks/guard-destructive.sh"
   "CLAUDE.md"
   ".github/labels.yml"


### PR DESCRIPTION
## Summary

- Renames `make_hooks_executable` to `make_shell_scripts_executable` and applies it recursively to both `hooks/` and `scripts/` directories (including `scripts/lib/`), ensuring all `.sh` files are executable even if permissions were stripped by git or filesystem operations
- Adds `lib/loom-tools.sh` to the verified file list in both `install.sh` (Quick Install) and `scripts/install-loom.sh` (Full Install)
- Adds 3 Rust tests covering: fresh install with `scripts/lib/`, reinstall with stale `lib/` cleanup, and recursive executable permission setting

Closes #2392

## Test plan

- [x] All 39 init module tests pass (including 3 new tests)
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` clean
- [ ] Verify `pnpm check:ci:lite` passes (1 pre-existing failure in `test_cli.py::TestMain::test_returns_int` unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)