### PR TITLE
feat: add automatic rebase phase before merge in shepherd pipeline

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/cli.py
+++ b/loom-tools/src/loom_tools/shepherd/cli.py
@@ -32,6 +32,7 @@ from loom_tools.shepherd.phases import (
     MergePhase,
     PhaseStatus,
     PreflightPhase,
+    RebasePhase,
     ReflectionPhase,
 )
 from loom_tools.shepherd.phases.reflection import RunSummary
@@ -1063,6 +1064,40 @@ def orchestrate(ctx: ShepherdContext) -> int:
         if ctx.config.stop_after == "pr":
             _print_phase_header("STOPPING: Reached --to pr")
             return ShepherdExitCode.SUCCESS
+
+        # ─── PHASE 5.5: Rebase (if needed) ────────────────────────────────
+        _print_phase_header("PHASE 5.5: REBASE")
+        phase_start = time.time()
+        rebase = RebasePhase()
+        result = rebase.run(ctx)
+        elapsed = int(time.time() - phase_start)
+
+        if result.is_shutdown:
+            raise ShutdownSignal(result.message)
+
+        if result.status == PhaseStatus.FAILED:
+            log_error(result.message)
+            _run_reflection(
+                ctx,
+                exit_code=ShepherdExitCode.NEEDS_INTERVENTION,
+                duration=int(time.time() - start_time),
+                phase_durations=phase_durations,
+                completed_phases=completed_phases,
+                judge_retries=judge_retries,
+                doctor_attempts=doctor_attempts,
+                test_fix_attempts=test_fix_attempts,
+                warnings=run_warnings,
+            )
+            return ShepherdExitCode.NEEDS_INTERVENTION
+
+        if result.status == PhaseStatus.SKIPPED:
+            completed_phases.append("Rebase (up to date)")
+        else:
+            phase_durations["Rebase"] = elapsed
+            completed_phases.append("Rebase (rebased on main)")
+            ctx.report_milestone(
+                "phase_completed", phase="rebase", duration_seconds=elapsed, status="rebased"
+            )
 
         # ─── PHASE 6: Merge Gate ──────────────────────────────────────────
         _print_phase_header("PHASE 6: MERGE GATE")

--- a/loom-tools/src/loom_tools/shepherd/phases/__init__.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/__init__.py
@@ -13,6 +13,7 @@ from loom_tools.shepherd.phases.doctor import DoctorPhase
 from loom_tools.shepherd.phases.judge import JudgePhase
 from loom_tools.shepherd.phases.merge import MergePhase
 from loom_tools.shepherd.phases.preflight import PreflightPhase
+from loom_tools.shepherd.phases.rebase import RebasePhase
 from loom_tools.shepherd.phases.reflection import ReflectionPhase
 
 __all__ = [
@@ -27,5 +28,6 @@ __all__ = [
     "JudgePhase",
     "MergePhase",
     "PreflightPhase",
+    "RebasePhase",
     "ReflectionPhase",
 ]

--- a/loom-tools/src/loom_tools/shepherd/phases/rebase.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/rebase.py
@@ -1,0 +1,99 @@
+"""Rebase phase implementation."""
+
+from __future__ import annotations
+
+import subprocess
+
+from loom_tools.common.git import attempt_rebase, force_push_branch, is_branch_behind
+from loom_tools.shepherd.context import ShepherdContext
+from loom_tools.shepherd.labels import add_pr_label, remove_pr_label
+from loom_tools.shepherd.phases.base import BasePhase, PhaseResult
+
+
+class RebasePhase(BasePhase):
+    """Phase 5.5: Rebase — Update feature branch onto main before merge."""
+
+    phase_name = "rebase"
+
+    def should_skip(self, ctx: ShepherdContext) -> tuple[bool, str]:
+        """Rebase phase never skips via --from."""
+        return False, ""
+
+    def run(self, ctx: ShepherdContext) -> PhaseResult:
+        """Run rebase phase.
+
+        1. Check for shutdown signal
+        2. Verify we have a worktree to operate in
+        3. Fetch and check if branch is behind origin/main
+        4. If not behind, skip (already up to date)
+        5. If behind, attempt rebase
+        6. On success: force-push, remove loom:merge-conflict label
+        7. On failure: apply loom:merge-conflict label, add diagnostic comment
+        """
+        if ctx.check_shutdown():
+            return self.shutdown("shutdown signal detected")
+
+        if ctx.worktree_path is None or not ctx.worktree_path.is_dir():
+            return self.failed(
+                "no worktree path available for rebase",
+                {"reason": "no_worktree"},
+            )
+
+        cwd = ctx.worktree_path
+
+        # Check if branch is behind origin/main
+        if not is_branch_behind("origin/main", cwd=cwd):
+            return self.skipped("branch is already up to date with origin/main")
+
+        # Attempt rebase
+        ctx.report_milestone("heartbeat", action="rebasing onto origin/main")
+        success, detail = attempt_rebase("origin/main", cwd=cwd)
+
+        if success:
+            # Force-push the rebased branch
+            if not force_push_branch(cwd=cwd):
+                return self.failed(
+                    "rebase succeeded but force-push failed",
+                    {"reason": "push_failed"},
+                )
+
+            # Remove merge-conflict label if present
+            if ctx.pr_number is not None:
+                remove_pr_label(ctx.pr_number, "loom:merge-conflict", ctx.repo_root)
+                ctx.label_cache.invalidate_pr(ctx.pr_number)
+
+            return self.success("rebased onto origin/main and force-pushed")
+
+        # Rebase failed — apply merge-conflict label and comment
+        if ctx.pr_number is not None:
+            add_pr_label(ctx.pr_number, "loom:merge-conflict", ctx.repo_root)
+            ctx.label_cache.invalidate_pr(ctx.pr_number)
+
+            # Add diagnostic comment
+            body = (
+                f"**Shepherd rebase failed** for issue #{ctx.config.issue}.\n\n"
+                f"The feature branch has conflicts with `main` that cannot be "
+                f"automatically resolved.\n\n"
+                f"```\n{detail}\n```\n\n"
+                f"A human or Doctor agent needs to resolve these conflicts."
+            )
+            subprocess.run(
+                ["gh", "pr", "comment", str(ctx.pr_number), "--body", body],
+                cwd=ctx.repo_root,
+                capture_output=True,
+                check=False,
+            )
+
+        return self.failed(
+            f"rebase onto origin/main failed: {detail}",
+            {"reason": "merge_conflict", "detail": detail},
+        )
+
+    def validate(self, ctx: ShepherdContext) -> bool:
+        """Validate rebase phase contract.
+
+        After a successful rebase the branch should not be behind origin/main.
+        """
+        if ctx.worktree_path is None or not ctx.worktree_path.is_dir():
+            return False
+        return not is_branch_behind("origin/main", cwd=ctx.worktree_path)

--- a/loom-tools/tests/shepherd/test_rebase.py
+++ b/loom-tools/tests/shepherd/test_rebase.py
@@ -1,0 +1,292 @@
+"""Tests for the rebase phase."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from loom_tools.shepherd.config import ShepherdConfig
+from loom_tools.shepherd.context import ShepherdContext
+from loom_tools.shepherd.phases.base import PhaseStatus
+from loom_tools.shepherd.phases.rebase import RebasePhase
+
+
+@pytest.fixture
+def mock_context(tmp_path: Path) -> MagicMock:
+    """Create a mock ShepherdContext with a real worktree directory."""
+    ctx = MagicMock(spec=ShepherdContext)
+    ctx.config = ShepherdConfig(issue=42)
+    ctx.repo_root = Path("/fake/repo")
+    ctx.worktree_path = tmp_path / "worktree"
+    ctx.worktree_path.mkdir()
+    ctx.pr_number = 100
+    ctx.label_cache = MagicMock()
+    ctx.check_shutdown.return_value = False
+    ctx.report_milestone = MagicMock(return_value=True)
+    return ctx
+
+
+class TestRebasePhase:
+    """Tests for RebasePhase."""
+
+    def test_branch_up_to_date_skips(self, mock_context: MagicMock) -> None:
+        """When branch is not behind origin/main, phase should be SKIPPED."""
+        phase = RebasePhase()
+
+        with patch(
+            "loom_tools.shepherd.phases.rebase.is_branch_behind", return_value=False
+        ):
+            result = phase.run(mock_context)
+
+        assert result.status == PhaseStatus.SKIPPED
+        assert "up to date" in result.message
+
+    def test_rebase_succeeds_and_pushes(self, mock_context: MagicMock) -> None:
+        """When rebase succeeds, should force-push and return SUCCESS."""
+        phase = RebasePhase()
+
+        with (
+            patch(
+                "loom_tools.shepherd.phases.rebase.is_branch_behind", return_value=True
+            ),
+            patch(
+                "loom_tools.shepherd.phases.rebase.attempt_rebase",
+                return_value=(True, ""),
+            ),
+            patch(
+                "loom_tools.shepherd.phases.rebase.force_push_branch",
+                return_value=True,
+            ),
+            patch(
+                "loom_tools.shepherd.phases.rebase.remove_pr_label"
+            ) as mock_remove,
+        ):
+            result = phase.run(mock_context)
+
+        assert result.status == PhaseStatus.SUCCESS
+        assert "rebased" in result.message
+        mock_remove.assert_called_once_with(100, "loom:merge-conflict", mock_context.repo_root)
+        mock_context.label_cache.invalidate_pr.assert_called_with(100)
+
+    def test_rebase_succeeds_removes_merge_conflict_label(
+        self, mock_context: MagicMock
+    ) -> None:
+        """Successful rebase should remove loom:merge-conflict label from PR."""
+        phase = RebasePhase()
+
+        with (
+            patch(
+                "loom_tools.shepherd.phases.rebase.is_branch_behind", return_value=True
+            ),
+            patch(
+                "loom_tools.shepherd.phases.rebase.attempt_rebase",
+                return_value=(True, ""),
+            ),
+            patch(
+                "loom_tools.shepherd.phases.rebase.force_push_branch",
+                return_value=True,
+            ),
+            patch(
+                "loom_tools.shepherd.phases.rebase.remove_pr_label"
+            ) as mock_remove,
+        ):
+            result = phase.run(mock_context)
+
+        assert result.status == PhaseStatus.SUCCESS
+        mock_remove.assert_called_once_with(100, "loom:merge-conflict", mock_context.repo_root)
+
+    def test_rebase_conflict_fails_and_labels(self, mock_context: MagicMock) -> None:
+        """When rebase has conflicts, should FAIL and apply loom:merge-conflict."""
+        phase = RebasePhase()
+        conflict_detail = "Conflicting files:\nsrc/main.py\nsrc/utils.py"
+
+        with (
+            patch(
+                "loom_tools.shepherd.phases.rebase.is_branch_behind", return_value=True
+            ),
+            patch(
+                "loom_tools.shepherd.phases.rebase.attempt_rebase",
+                return_value=(False, conflict_detail),
+            ),
+            patch(
+                "loom_tools.shepherd.phases.rebase.add_pr_label"
+            ) as mock_add,
+            patch("subprocess.run") as mock_subprocess,
+        ):
+            result = phase.run(mock_context)
+
+        assert result.status == PhaseStatus.FAILED
+        assert "merge_conflict" in result.data.get("reason", "")
+        mock_add.assert_called_once_with(100, "loom:merge-conflict", mock_context.repo_root)
+        # Should also post a diagnostic comment
+        mock_subprocess.assert_called_once()
+        call_args = mock_subprocess.call_args
+        assert "gh" in call_args[0][0][0]
+        assert "pr" in call_args[0][0][1]
+        assert "comment" in call_args[0][0][2]
+
+    def test_no_worktree_fails_gracefully(self, mock_context: MagicMock) -> None:
+        """When no worktree path is available, should FAIL gracefully."""
+        mock_context.worktree_path = None
+        phase = RebasePhase()
+
+        result = phase.run(mock_context)
+
+        assert result.status == PhaseStatus.FAILED
+        assert "no worktree" in result.message
+        assert result.data.get("reason") == "no_worktree"
+
+    def test_nonexistent_worktree_fails_gracefully(
+        self, mock_context: MagicMock
+    ) -> None:
+        """When worktree path doesn't exist on disk, should FAIL gracefully."""
+        mock_context.worktree_path = Path("/nonexistent/path")
+        phase = RebasePhase()
+
+        result = phase.run(mock_context)
+
+        assert result.status == PhaseStatus.FAILED
+        assert "no worktree" in result.message
+
+    def test_shutdown_signal(self, mock_context: MagicMock) -> None:
+        """When shutdown is signaled, should return SHUTDOWN."""
+        mock_context.check_shutdown.return_value = True
+        phase = RebasePhase()
+
+        result = phase.run(mock_context)
+
+        assert result.status == PhaseStatus.SHUTDOWN
+        assert result.is_shutdown
+
+    def test_force_push_failure(self, mock_context: MagicMock) -> None:
+        """When rebase succeeds but force-push fails, should return FAILED."""
+        phase = RebasePhase()
+
+        with (
+            patch(
+                "loom_tools.shepherd.phases.rebase.is_branch_behind", return_value=True
+            ),
+            patch(
+                "loom_tools.shepherd.phases.rebase.attempt_rebase",
+                return_value=(True, ""),
+            ),
+            patch(
+                "loom_tools.shepherd.phases.rebase.force_push_branch",
+                return_value=False,
+            ),
+        ):
+            result = phase.run(mock_context)
+
+        assert result.status == PhaseStatus.FAILED
+        assert "push_failed" in result.data.get("reason", "")
+
+    def test_no_pr_number_skips_label_operations(
+        self, mock_context: MagicMock
+    ) -> None:
+        """When pr_number is None, should skip label add/remove but still rebase."""
+        mock_context.pr_number = None
+        phase = RebasePhase()
+
+        with (
+            patch(
+                "loom_tools.shepherd.phases.rebase.is_branch_behind", return_value=True
+            ),
+            patch(
+                "loom_tools.shepherd.phases.rebase.attempt_rebase",
+                return_value=(True, ""),
+            ),
+            patch(
+                "loom_tools.shepherd.phases.rebase.force_push_branch",
+                return_value=True,
+            ),
+            patch(
+                "loom_tools.shepherd.phases.rebase.remove_pr_label"
+            ) as mock_remove,
+        ):
+            result = phase.run(mock_context)
+
+        assert result.status == PhaseStatus.SUCCESS
+        mock_remove.assert_not_called()
+
+    def test_conflict_no_pr_number_skips_label_and_comment(
+        self, mock_context: MagicMock
+    ) -> None:
+        """When rebase fails and pr_number is None, should not add labels or comment."""
+        mock_context.pr_number = None
+        phase = RebasePhase()
+
+        with (
+            patch(
+                "loom_tools.shepherd.phases.rebase.is_branch_behind", return_value=True
+            ),
+            patch(
+                "loom_tools.shepherd.phases.rebase.attempt_rebase",
+                return_value=(False, "conflicts"),
+            ),
+            patch(
+                "loom_tools.shepherd.phases.rebase.add_pr_label"
+            ) as mock_add,
+            patch("subprocess.run") as mock_subprocess,
+        ):
+            result = phase.run(mock_context)
+
+        assert result.status == PhaseStatus.FAILED
+        mock_add.assert_not_called()
+        mock_subprocess.assert_not_called()
+
+    def test_phase_name_is_rebase(self) -> None:
+        """Phase name should be 'rebase'."""
+        phase = RebasePhase()
+        assert phase.phase_name == "rebase"
+
+    def test_reports_heartbeat_before_rebase(self, mock_context: MagicMock) -> None:
+        """Should report a heartbeat milestone before attempting the rebase."""
+        phase = RebasePhase()
+
+        with (
+            patch(
+                "loom_tools.shepherd.phases.rebase.is_branch_behind", return_value=True
+            ),
+            patch(
+                "loom_tools.shepherd.phases.rebase.attempt_rebase",
+                return_value=(True, ""),
+            ),
+            patch(
+                "loom_tools.shepherd.phases.rebase.force_push_branch",
+                return_value=True,
+            ),
+            patch("loom_tools.shepherd.phases.rebase.remove_pr_label"),
+        ):
+            phase.run(mock_context)
+
+        mock_context.report_milestone.assert_called_with(
+            "heartbeat", action="rebasing onto origin/main"
+        )
+
+
+class TestRebasePhaseValidate:
+    """Tests for RebasePhase.validate()."""
+
+    def test_validate_passes_when_not_behind(self, mock_context: MagicMock) -> None:
+        """validate() should return True when branch is not behind."""
+        phase = RebasePhase()
+        with patch(
+            "loom_tools.shepherd.phases.rebase.is_branch_behind", return_value=False
+        ):
+            assert phase.validate(mock_context) is True
+
+    def test_validate_fails_when_behind(self, mock_context: MagicMock) -> None:
+        """validate() should return False when branch is still behind."""
+        phase = RebasePhase()
+        with patch(
+            "loom_tools.shepherd.phases.rebase.is_branch_behind", return_value=True
+        ):
+            assert phase.validate(mock_context) is False
+
+    def test_validate_fails_without_worktree(self, mock_context: MagicMock) -> None:
+        """validate() should return False when no worktree is available."""
+        mock_context.worktree_path = None
+        phase = RebasePhase()
+        assert phase.validate(mock_context) is False


### PR DESCRIPTION
## Summary

- Adds Phase 5.5 (Rebase) to the shepherd pipeline between judge approval and the merge gate
- When a PR's feature branch falls behind `main`, automatically rebases onto `origin/main` and force-pushes with `--force-with-lease`
- If rebase fails due to real conflicts, applies `loom:merge-conflict` label with diagnostic comment and exits with `NEEDS_INTERVENTION`

Closes #2398

## Changes

- **`loom-tools/src/loom_tools/common/git.py`** — 3 new git utilities: `is_branch_behind()`, `attempt_rebase()`, `force_push_branch()`
- **`loom-tools/src/loom_tools/shepherd/phases/rebase.py`** — New `RebasePhase` class following existing phase patterns
- **`loom-tools/src/loom_tools/shepherd/cli.py`** — Wire rebase phase into orchestration loop
- **`loom-tools/tests/shepherd/test_rebase.py`** — 15 unit tests for all rebase scenarios
- **`loom-tools/tests/shepherd/test_cli.py`** — 2 new integration tests + updated existing tests for RebasePhase mock

## Test plan

- [x] `test_rebase.py` — 15 unit tests (skip, success, conflict, no worktree, shutdown, push failure, label ops, validate)
- [x] `test_cli.py` — 118 tests pass (2 new integration tests verifying phase ordering and failure handling)
- [x] `test_phases.py` — 596 tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)