### PR TITLE
fix: disambiguate error-line counts from structured failure counts

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/cli.py
+++ b/loom-tools/src/loom_tools/shepherd/cli.py
@@ -570,7 +570,7 @@ def orchestrate(ctx: ShepherdContext) -> int:
                     # Doctor made things worse — abort immediately
                     log_error(
                         f"Doctor introduced regressions "
-                        f"({prev_error_count} → {current_error_count} new errors), "
+                        f"({prev_error_count} → {current_error_count} test failure(s)), "
                         f"aborting test-fix loop"
                     )
                     phase_durations["Builder"] = builder_total_elapsed

--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -2393,10 +2393,21 @@ class BuilderPhase:
                                 ctx, primary_output
                             )
 
-                log_warning(
-                    f"Baseline also fails but worktree introduces "
-                    f"{len(new_errors)} new error(s)"
-                )
+                # Prefer structured failure count for clearer messaging.
+                # _compare_test_results returned False (structured
+                # comparison failed), but one side may still parse.
+                worktree_fc = self._parse_failure_count(worktree_output)
+                if worktree_fc is not None:
+                    log_warning(
+                        f"Baseline also fails but worktree has "
+                        f"{worktree_fc} test failure(s) "
+                        f"({len(new_errors)} error-indicator lines in diff)"
+                    )
+                else:
+                    log_warning(
+                        f"Baseline also fails but worktree introduces "
+                        f"{len(new_errors)} new error-indicator line(s)"
+                    )
 
         # Tests failed with new errors (or no baseline available)
         summary = self._parse_test_summary(primary_output)


### PR DESCRIPTION
## Summary

- Use structured failure count (from test runner summary) when available in warning messages, clearly distinguishing it from error-indicator line counts
- Prevents confusing output like "166 new errors" vs "1 new error" where the two numbers measure different things
- Updated doctor regression message to say "test failure(s)" instead of "new errors" for consistency

## Test plan

- [ ] Run shepherd on an issue with test failures to verify improved messaging
- [ ] Verify `_parse_failure_count` is used when structured data is available
- [ ] Verify fallback to error-indicator line count with updated terminology

Closes #2451

🤖 Generated with [Claude Code](https://claude.com/claude-code)