### PR TITLE
fix: sync Rust SHARED_CONFIG_FILES with Python to exclude mcp.json

### DIFF
--- a/loom-daemon/src/terminal.rs
+++ b/loom-daemon/src/terminal.rs
@@ -20,7 +20,7 @@ mod claude_config {
     /// Must match the Python `_SHARED_CONFIG_FILES` list.
     /// NOTE: .claude.json is NOT here — it lives at ~/.claude.json (home root),
     /// not inside ~/.claude/. It's handled separately via `resolve_state_file()`.
-    const SHARED_CONFIG_FILES: &[&str] = &["settings.json", "config.json", "mcp.json", ".mcp.json"];
+    const SHARED_CONFIG_FILES: &[&str] = &["settings.json", "config.json"];
 
     /// Shared directories to symlink from ~/.claude/ (read-only caches).
     /// Must match the Python `_SHARED_CONFIG_DIRS` list.


### PR DESCRIPTION
## Summary

- Remove `mcp.json` and `.mcp.json` from the Rust `SHARED_CONFIG_FILES` constant in `loom-daemon/src/terminal.rs` to match the Python fix from PR #2380
- Prevents MCP config shadowing in Tauri App Mode when `~/.claude/mcp.json` exists

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Remove mcp.json from Rust constant | Done | Constant now matches Python: `["settings.json", "config.json"]` |
| Rust and Python lists in sync | Done | Both have identical entries |
| Build passes | Done | `cargo check -p loom-daemon` succeeds |

Closes #2460