### PR TITLE
fix: detect and abort builder planning stalls early

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/config.py
+++ b/loom-tools/src/loom_tools/shepherd/config.py
@@ -160,6 +160,9 @@ class ShepherdConfig:
     doctor_test_fix_timeout: int = field(
         default_factory=lambda: env_int("LOOM_DOCTOR_TEST_FIX_TIMEOUT", 600)
     )
+    planning_timeout: int = field(
+        default_factory=lambda: env_int("LOOM_PLANNING_TIMEOUT", 600)
+    )
     poll_interval: int = field(
         default_factory=lambda: env_int("LOOM_POLL_INTERVAL", 5)
     )


### PR DESCRIPTION
## Summary

- Adds planning-stage timeout (`LOOM_PLANNING_TIMEOUT`, default 600s) to detect when the builder agent stalls in the `planning` checkpoint without progressing to implementation
- Polls the checkpoint file during the `run_worker_phase` wait loop alongside heartbeats; terminates the builder and returns exit code 8 if the planning stage persists beyond the timeout
- Exit code 8 is not retried (planning stalls are not transient) and produces a clear FAILED result with `planning_stall=True` diagnostic data

Closes #2443

## Test plan

- [x] 6 new tests covering planning stall detection at three levels:
  - `TestBuilderPhase::test_planning_stall_returns_failed` - builder phase handles exit code 8
  - `TestRunWorkerPhasePlanningStall` - 3 tests for checkpoint monitoring in wait loop
  - `TestRunPhaseWithRetryPlanningStall` - 2 tests for no-retry behavior and parameter passthrough
- [x] All 618 existing shepherd phase tests pass
- [x] All 38 checkpoint tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)