### PR TITLE
fix: guard-worktree-paths prefix check and shell injection

### DIFF
--- a/.loom/hooks/guard-worktree-paths.sh
+++ b/.loom/hooks/guard-worktree-paths.sh
@@ -66,10 +66,10 @@ fi
 # Normalize the path: resolve .. and . components without requiring the file to exist.
 # Use Python's os.path.normpath for reliable path normalization (handles ../ etc.)
 # Falls back to the raw path if Python is unavailable.
-NORM_PATH=$(python3 -c "import os; print(os.path.normpath('$FILE_PATH'))" 2>/dev/null) || NORM_PATH="$FILE_PATH"
+NORM_PATH=$(printf '%s' "$FILE_PATH" | python3 -c "import os,sys; print(os.path.normpath(sys.stdin.read()))" 2>/dev/null) || NORM_PATH="$FILE_PATH"
 
 # Check if the normalized path starts with the worktree path
-if [[ "$NORM_PATH" == "$WORKTREE_REAL"* ]] || [[ "$NORM_PATH" == "$WORKTREE_PATH"* ]]; then
+if [[ "$NORM_PATH/" == "$WORKTREE_REAL/"* ]] || [[ "$NORM_PATH/" == "$WORKTREE_PATH/"* ]]; then
     # Path is within the worktree — allow
     exit 0
 fi


### PR DESCRIPTION
## Summary

Fix two defense-in-depth security issues in `guard-worktree-paths.sh`:

1. **Path prefix check allows cross-worktree access** — Bare prefix comparison (`issue-42*`) would match `issue-420`. Fixed by appending `/` before comparing.
2. **Shell injection in Python normalization** — File paths with single quotes could break the Python string literal. Fixed by piping through stdin.

Closes #2475