### PR TITLE
fix: add timeouts to wrapper pre-flight checks and delay before stuck retries

### DIFF
--- a/defaults/scripts/claude-wrapper.sh
+++ b/defaults/scripts/claude-wrapper.sh
@@ -200,8 +200,9 @@ check_mcp_server() {
     fi
 
     # Extract the MCP server entry point from .mcp.json
+    # Use timeout to prevent hanging on resource-contended systems (see issue #2472).
     local mcp_entry
-    mcp_entry=$(python3 -c "
+    mcp_entry=$(timeout 10 python3 -c "
 import json, sys
 with open('${mcp_config}') as f:
     cfg = json.load(f)
@@ -313,8 +314,16 @@ check_auth_status() {
 
     # Unset CLAUDECODE to avoid nested-session guard when running inside
     # a Claude Code session (e.g., during testing or shepherd-spawned builds).
-    auth_output=$(CLAUDECODE='' claude auth status --json 2>&1) || auth_exit_code=$?
+    # Use timeout to prevent hanging after a long first attempt leaves
+    # auth in a bad state (see issue #2472).
+    auth_output=$(timeout 15 bash -c 'CLAUDECODE="" claude auth status --json 2>&1') || auth_exit_code=$?
     auth_exit_code="${auth_exit_code:-0}"
+
+    # timeout exits with 124 when the command times out
+    if [[ "${auth_exit_code}" -eq 124 ]]; then
+        log_error "Authentication check timed out after 15s"
+        return 1
+    fi
 
     if [[ "${auth_exit_code}" -ne 0 ]]; then
         log_error "Authentication check command failed (exit ${auth_exit_code})"

--- a/loom-tools/src/loom_tools/shepherd/phases/base.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/base.py
@@ -740,3 +740,10 @@ def run_phase_with_retry(
             "heartbeat",
             action=f"retrying stuck {role} (attempt {stuck_retries})",
         )
+
+        # Allow cleanup (tmux session teardown, MCP port release) to
+        # complete before spawning the retry.  Without this delay, the
+        # new wrapper's pre-flight checks race against the previous
+        # session's resource cleanup and can hang or fail silently.
+        # See issue #2472.
+        time.sleep(5)


### PR DESCRIPTION
## Summary

Closes #2472

- Add 15s timeout to `claude auth status` in `check_auth_status()`, with explicit error logging on timeout (exit code 124)
- Add 10s timeout to the Python MCP config extraction in `check_mcp_server()` to prevent hanging on resource-contended systems
- Add 5s cleanup delay before stuck retries in `run_phase_with_retry()` to allow tmux session teardown and MCP port release to complete before respawning

## Context

When the builder's first attempt runs long (~30 min) and is killed by stuck detection, the retry's wrapper pre-flight checks could hang indefinitely — `claude auth status` had no timeout and the MCP Python extraction subprocess had no timeout. Combined with no delay between kill and retry, the new wrapper raced against the old session's cleanup. The wrapper was then killed mid-command-substitution by the external timeout, causing silent failure with no diagnostic output.

## Test plan

- [x] All 781 phase-related Python tests pass
- [x] All 12 instant-exit/MCP failure specific tests pass
- [ ] Verify `timeout 15 bash -c 'CLAUDECODE="" claude auth status --json 2>&1'` works correctly on macOS
- [ ] Verify stuck retry delay doesn't cause issues with shepherd timeout calculations

🤖 Generated with [Claude Code](https://claude.com/claude-code)