### PR TITLE
fix: return empty from _get_cli_output when sentinel is missing

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/base.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/base.py
@@ -397,7 +397,13 @@ def _get_cli_output(stripped: str) -> str:
         if line.strip() == _CLI_START_SENTINEL:
             sentinel_idx = i
 
-    start = (sentinel_idx + 1) if sentinel_idx is not None else 0
+    if sentinel_idx is None:
+        # No sentinel means Claude CLI never started — wrapper failed
+        # before reaching execution.  Return empty string so callers
+        # correctly treat this as an instant exit.  See issue #2473.
+        return ""
+
+    start = sentinel_idx + 1
     return "\n".join(line for line in lines[start:] if not line.startswith("# "))
 
 


### PR DESCRIPTION
## Summary

- Fix `_get_cli_output()` to return empty string when no `# CLAUDE_CLI_START` sentinel is found, instead of falling back to all non-header lines
- This prevents wrapper pre-flight output from defeating instant-exit detection in `_is_mcp_failure()` and builder diagnostics
- Add sentinel to MCP failure tests that were relying on the broken fallback behavior
- Add new test `test_no_sentinel_with_mcp_pattern_returns_false` covering the bug scenario

Closes #2473

## Test plan

- [x] All 32 related tests pass (instant-exit, MCP failure, sentinel)
- [ ] Verify shepherd retries correctly when wrapper dies before Claude starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)