### PR TITLE
fix: handle stage_and_commit in direct completion

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -3056,22 +3056,26 @@ class BuilderPhase:
     ) -> bool:
         """Attempt to complete mechanical operations directly in Python.
 
-        Handles simple operations (push branch, create PR, add label) without
-        spawning a full agent. Returns True if all remaining steps were
-        completed.
+        Handles simple operations (stage/commit, push branch, create PR, add
+        label) without spawning a full agent. Returns True if all remaining
+        steps were completed.
         """
         steps = self._diagnose_remaining_steps(diag, ctx.config.issue)
 
         # Only handle purely mechanical steps directly
-        mechanical_steps = {"push_branch", "add_review_label", "create_pr"}
+        mechanical_steps = {
+            "stage_and_commit", "push_branch", "add_review_label", "create_pr",
+        }
         if not steps or not set(steps).issubset(mechanical_steps):
             return False
 
         # Safety guard: refuse to create a PR when there are 0 commits
-        # ahead of main.  A PR with an empty diff is useless and creates
-        # cleanup work.  This guards against edge cases where
-        # _diagnose_remaining_steps logic is bypassed.
-        if "create_pr" in steps and diag.get("commits_ahead", 0) == 0:
+        # ahead of main AND we're not about to create one via stage_and_commit.
+        if (
+            "create_pr" in steps
+            and diag.get("commits_ahead", 0) == 0
+            and "stage_and_commit" not in steps
+        ):
             log_warning(
                 f"Direct completion: refusing to create PR for issue "
                 f"#{ctx.config.issue} with 0 commits ahead of main"
@@ -3084,7 +3088,39 @@ class BuilderPhase:
         )
 
         for step in steps:
-            if step == "push_branch":
+            if step == "stage_and_commit":
+                result = subprocess.run(
+                    ["git", "add", "-A"],
+                    cwd=ctx.worktree_path,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                if result.returncode != 0:
+                    log_warning(
+                        f"Direct completion: git add failed: "
+                        f"{result.stderr.strip()[:200]}"
+                    )
+                    return False
+                result = subprocess.run(
+                    [
+                        "git", "commit", "-m",
+                        f"fix: implement changes for issue #{ctx.config.issue}",
+                    ],
+                    cwd=ctx.worktree_path,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                if result.returncode != 0:
+                    log_warning(
+                        f"Direct completion: git commit failed: "
+                        f"{result.stderr.strip()[:200]}"
+                    )
+                    return False
+                log_success("Direct completion: changes staged and committed")
+
+            elif step == "push_branch":
                 if not self._push_branch(ctx):
                     log_warning("Direct completion: push failed")
                     return False

--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -8143,13 +8143,18 @@ class TestBuilderDirectCompletion:
         """Should return False when non-mechanical steps remain."""
         builder = BuilderPhase()
         diag = {
-            "has_uncommitted_changes": True,
-            "commits_ahead": 0,
+            "has_uncommitted_changes": False,
+            "commits_ahead": 1,
             "remote_branch_exists": False,
             "pr_number": None,
             "pr_has_review_label": False,
         }
-        result = builder._direct_completion(mock_context, diag)
+        # Inject a hypothetical non-mechanical step
+        with patch.object(
+            builder, "_diagnose_remaining_steps",
+            return_value=["resolve_conflicts", "push_branch"],
+        ):
+            result = builder._direct_completion(mock_context, diag)
         assert result is False
 
     def test_push_failure_returns_false(self, mock_context: MagicMock) -> None:
@@ -8300,11 +8305,44 @@ class TestBuilderDirectCompletion:
         call_args = mock_run.call_args[0][0]
         assert "feature/issue-55" in call_args
 
-    def test_stage_and_commit_with_create_pr_returns_false(
+    def test_stage_and_commit_full_pipeline(
         self, mock_context: MagicMock
     ) -> None:
-        """Multi-step with non-mechanical stage_and_commit should fall through."""
+        """Should handle stage_and_commit + push + create_pr as mechanical steps."""
         builder = BuilderPhase()
+        mock_context.repo_root = Path("/fake/repo")
+        mock_context.worktree_path = Path("/fake/worktree")
+        diag = {
+            "has_uncommitted_changes": True,
+            "commits_ahead": 0,
+            "remote_branch_exists": False,
+            "pr_number": None,
+            "pr_has_review_label": False,
+            "branch": "feature/issue-42",
+        }
+
+        with (
+            patch.object(builder, "_push_branch", return_value=True),
+            patch(
+                "loom_tools.shepherd.phases.builder.subprocess.run"
+            ) as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stderr="")
+            result = builder._direct_completion(mock_context, diag)
+
+        assert result is True
+        # Verify git add, git commit, and gh pr create were all called
+        calls = [c[0][0] for c in mock_run.call_args_list]
+        assert calls[0] == ["git", "add", "-A"]
+        assert calls[1][:2] == ["git", "commit"]
+        assert calls[2][:3] == ["gh", "pr", "create"]
+
+    def test_stage_and_commit_git_add_failure(
+        self, mock_context: MagicMock
+    ) -> None:
+        """Should return False when git add fails."""
+        builder = BuilderPhase()
+        mock_context.worktree_path = Path("/fake/worktree")
         diag = {
             "has_uncommitted_changes": True,
             "commits_ahead": 0,
@@ -8312,8 +8350,69 @@ class TestBuilderDirectCompletion:
             "pr_number": None,
             "pr_has_review_label": False,
         }
-        result = builder._direct_completion(mock_context, diag)
+
+        with patch(
+            "loom_tools.shepherd.phases.builder.subprocess.run"
+        ) as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=1, stderr="fatal: not a git repository"
+            )
+            result = builder._direct_completion(mock_context, diag)
+
         assert result is False
+
+    def test_stage_and_commit_git_commit_failure(
+        self, mock_context: MagicMock
+    ) -> None:
+        """Should return False when git commit fails."""
+        builder = BuilderPhase()
+        mock_context.worktree_path = Path("/fake/worktree")
+        diag = {
+            "has_uncommitted_changes": True,
+            "commits_ahead": 0,
+            "remote_branch_exists": False,
+            "pr_number": None,
+            "pr_has_review_label": False,
+        }
+
+        add_ok = MagicMock(returncode=0, stderr="")
+        commit_fail = MagicMock(returncode=1, stderr="nothing to commit")
+
+        with patch(
+            "loom_tools.shepherd.phases.builder.subprocess.run"
+        ) as mock_run:
+            mock_run.side_effect = [add_ok, commit_fail]
+            result = builder._direct_completion(mock_context, diag)
+
+        assert result is False
+
+    def test_stage_and_commit_allows_zero_commits_ahead_for_create_pr(
+        self, mock_context: MagicMock
+    ) -> None:
+        """create_pr safety guard should not block when stage_and_commit will create a commit."""
+        builder = BuilderPhase()
+        mock_context.repo_root = Path("/fake/repo")
+        mock_context.worktree_path = Path("/fake/worktree")
+        diag = {
+            "has_uncommitted_changes": True,
+            "commits_ahead": 0,  # 0 now, but stage_and_commit will create one
+            "remote_branch_exists": False,
+            "pr_number": None,
+            "pr_has_review_label": False,
+            "branch": "feature/issue-42",
+        }
+
+        with (
+            patch.object(builder, "_push_branch", return_value=True),
+            patch(
+                "loom_tools.shepherd.phases.builder.subprocess.run"
+            ) as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stderr="")
+            result = builder._direct_completion(mock_context, diag)
+
+        # Should succeed — stage_and_commit makes the 0-commit guard inapplicable
+        assert result is True
 
 
 class TestBuilderCompletionRetryDefault:


### PR DESCRIPTION
## Summary

- Adds `stage_and_commit` to the `mechanical_steps` set in `_direct_completion()`, enabling it to run `git add -A && git commit` directly via subprocess instead of spawning a full LLM agent
- Relaxes the `create_pr` zero-commits safety guard when `stage_and_commit` is in the pipeline (the commit will be created before PR creation)
- Adds 4 new tests covering the full pipeline, git add/commit failures, and the safety guard relaxation

## Test plan

- [x] All 14 `TestBuilderDirectCompletion` tests pass (including 4 new ones)
- [x] Full Python test suite passes (2987 passed, 1 skipped)
- [ ] Verify in a real shepherd run that `stage_and_commit` is handled directly when builder exits without committing

Closes #2420

🤖 Generated with [Claude Code](https://claude.com/claude-code)