### PR TITLE
fix: generalize spinner regex for extended thinking output

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/base.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/base.py
@@ -69,11 +69,14 @@ MCP_FAILURE_BACKOFF_SECONDS = [5, 15, 30]
 # capture can produce garbled spinner frames (interleaved characters from
 # animated spinners) and repeated "(thinking)" lines that inflate the
 # character count without representing productive work.  See issue #2465.
-# Regex for known spinner phrases matched per-line (already stripped).
-# Matches "Tinkering…", "Thinking...", "Processing...", etc.
+# Regex for spinner/thinking phrases matched per-line (already stripped).
+# Matches any single capitalized word followed by ellipsis, e.g.
+# "Tinkering…", "Thinking...", "Bloviating…", "Mulling...", etc.
+# Claude's extended thinking mode uses many creative gerund phrases
+# beyond the original fixed list, so we match the general pattern
+# instead of enumerating them.  See issue #2421.
 _SPINNER_PHRASE_RE = re.compile(
-    r"^(?:Tinkering|Thinking|Processing|Analyzing|Loading|Working)"
-    r"(?:…|\.{2,3})$"
+    r"^[A-Z][a-z]+(?:…|\.{2,3})$"
 )
 
 # Characters used by Claude CLI animated spinners.  Lines dominated by


### PR DESCRIPTION
## Summary
- Generalized `_SPINNER_PHRASE_RE` from a fixed word list (`Tinkering|Thinking|Processing|...`) to a pattern matching any single capitalized word followed by ellipsis (`^[A-Z][a-z]+(?:…|\.{2,3})$`)
- Claude's extended thinking mode uses creative phrases like "Bloviating…", "Mulling...", "Cogitating…" that were inflating output volume past the 500-char threshold, defeating MCP failure detection
- Added tests for extended thinking phrase stripping and MCP failure detection with extended thinking output

## Test plan
- [x] All 643 existing tests pass
- [x] New `test_strips_extended_thinking_phrases` verifies creative thinking phrases are stripped
- [x] New `TestIsMcpFailureExtendedThinking` class verifies MCP failure is detected despite extended thinking output
- [x] Existing spinner noise and MCP failure tests still pass (no regressions)

Closes #2421

🤖 Generated with [Claude Code](https://claude.com/claude-code)