### PR TITLE
fix: lower stuck detection thresholds from 1-2h to 5-10min

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/base.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/base.py
@@ -623,10 +623,12 @@ def run_worker_phase(
 
     wait_cmd.extend(["--task-id", ctx.config.task_id])
 
-    # Set LOOM_STUCK_ACTION for retry behavior
+    # Use --max-idle for stuck termination (sets critical threshold + action=retry).
+    # Default 600s (10 min) matches agent-wait-bg.sh default.  See issue #2406.
+    wait_cmd.extend(["--max-idle", "600"])
+
     env = os.environ.copy()
     env.pop("CLAUDECODE", None)  # Prevent nested session guard from blocking subprocess
-    env["LOOM_STUCK_ACTION"] = "retry"
 
     # Launch wait process (non-blocking) so we can poll for heartbeats
     wait_proc = subprocess.Popen(


### PR DESCRIPTION
## Summary

- Lower default stuck detection thresholds from 1h/2h to 5min/10min (warning/critical)
- Change default stuck action from `warn` (no intervention) to `retry` (kill and retry)
- Add `--max-idle` CLI flag to `agent-wait-bg.sh` for easy threshold control
- Add worktree file-change detection as additional progress signal alongside tmux pane monitoring
- Document the relationship between general idle detection and prompt-stuck detection subsystems

A stuck builder ran for 150 minutes undetected because thresholds were far too high and the default action took no intervention.

## Test plan

- [x] All 640 shepherd phase tests pass
- [x] Script help text updated and verified
- [x] Hardlink between `defaults/scripts/` and `.loom/scripts/` confirmed (single edit updates both)

Closes #2406

🤖 Generated with [Claude Code](https://claude.com/claude-code)