### PR TITLE
fix: add guardrail against builder manually closing issues

### DIFF
--- a/defaults/.claude/commands/builder.md
+++ b/defaults/.claude/commands/builder.md
@@ -536,6 +536,15 @@ Without a comment, the next attempt starts from scratch with zero context. The c
 - Don't leave a vague comment like "couldn't figure it out" — be specific about what you investigated
 - Don't skip the `loom:blocked` label — the comment is supplemental, not a replacement
 
+### CRITICAL: Never Close Issues
+
+You MUST NOT close issues under any circumstances. Issues should only close via PR auto-close (`Closes #N` in the PR body). This includes:
+- DO NOT close issues you believe "don't need changes" — add label `loom:blocked` with a comment explaining why, then exit
+- DO NOT close duplicates — flag them for human review instead
+- DO NOT close issues for any reason — only GitHub's PR auto-close mechanism should close issues
+
+**Why this matters**: Closing an issue manually destroys a legitimate feature request and bypasses the PR review pipeline. The phase validator will detect this and reopen the issue, but the interruption to shepherd orchestration and loss of builder context is already done.
+
 ## Complexity Assessment
 
 For detailed complexity assessment and decomposition guidance, see **builder-complexity.md**.

--- a/loom-tools/src/loom_tools/validate_phase.py
+++ b/loom-tools/src/loom_tools/validate_phase.py
@@ -595,18 +595,21 @@ def validate_builder(
                 "builder", issue, ValidationStatus.SATISFIED,
                 f"Issue #{issue} is closed with merged PR #{merged_pr}",
             )
-        # No PR found — builder closed the issue without implementing anything
+        # No PR found — builder closed the issue without implementing anything.
+        # Reopen the issue to prevent destruction of legitimate feature requests.
         if not check_only:
+            _run_gh(["issue", "reopen", str(issue)], repo_root)
             _mark_phase_failed(
                 issue, "builder",
                 "Issue was closed without an associated PR. "
-                "Builder may have abandoned the issue instead of implementing it.",
+                "Builder may have abandoned the issue instead of implementing it. "
+                "Issue has been automatically reopened.",
                 repo_root,
                 failure_label="loom:failed:builder",
             )
         return ValidationResult(
             "builder", issue, ValidationStatus.FAILED,
-            f"Issue #{issue} was closed without a PR — builder abandoned issue",
+            f"Issue #{issue} was closed without a PR — builder abandoned issue (reopened)",
         )
 
     # Find existing PR


### PR DESCRIPTION
## Summary

- Add "CRITICAL: Never Close Issues" section to `builder.md` role definition, matching the existing pattern in `curator.md`
- Update phase validator to automatically **reopen** issues when a builder closes one without creating a PR (previously it only flagged the failure but left the issue closed, destroying the feature request)
- Update test to verify the reopen behavior

Closes #2407

## Test plan

- [x] All 57 `test_validate_phase.py` tests pass
- [x] `test_issue_closed_without_pr_fails` verifies issue is reopened and message includes "(reopened)"
- [x] `test_issue_closed_without_pr_check_only` verifies no side effects in check-only mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)