### PR TITLE
fix: block pip install -e inside worktrees to prevent .pth collision

### DIFF
--- a/.loom/hooks/guard-destructive.sh
+++ b/.loom/hooks/guard-destructive.sh
@@ -313,6 +313,26 @@ if echo "$COMMAND" | grep -qE 'gh\s+pr\s+merge'; then
 fi
 
 # =============================================================================
+# LOOM: Block pip install -e inside worktrees (issue #2495)
+#
+# Editable pip installs overwrite a global .pth file in site-packages.
+# When multiple builders run in parallel worktrees, each 'pip install -e .'
+# clobbers the .pth to point at its own worktree, causing all other Python
+# processes to import from the wrong source tree.
+#
+# PYTHONPATH is already set by agent-spawn.sh and _build_worktree_env()
+# so editable installs are unnecessary inside worktrees.
+# =============================================================================
+
+WORKTREE_PATH="${LOOM_WORKTREE_PATH:-}"
+if [[ -n "$WORKTREE_PATH" ]]; then
+    if echo "$COMMAND" | grep -qE '(pip|pip3|uv pip)\s+install\s+.*-e\s' || \
+       echo "$COMMAND" | grep -qE '(pip|pip3|uv pip)\s+install\s+.*--editable\s'; then
+        deny "BLOCKED: 'pip install -e' is not allowed inside worktrees. Editable installs overwrite the global .pth file, breaking parallel builders (see issue #2495). PYTHONPATH is already configured for this worktree — imports resolve correctly without editable installs."
+    fi
+fi
+
+# =============================================================================
 # ALLOW - Everything else passes through
 # =============================================================================
 


### PR DESCRIPTION
## Summary

- Add PreToolUse guard to block `pip install -e` (editable installs) when `LOOM_WORKTREE_PATH` is set
- Guard covers `pip`, `pip3`, and `uv pip` with both `-e` and `--editable` flags
- Editable installs from worktrees overwrite a global `.pth` file in site-packages, causing all other Python processes to import from the wrong source tree
- PYTHONPATH is already configured by `agent-spawn.sh` and `_build_worktree_env()`, so editable installs are unnecessary in worktrees

## Test plan

- [x] All 92 existing guard-destructive tests pass
- [x] 10 new tests added for pip install worktree guard (6 deny, 4 allow)
- [x] Verifies `pip install -e` is blocked in worktree context (`LOOM_WORKTREE_PATH` set)
- [x] Verifies `pip install -e` is allowed outside worktrees
- [x] Verifies non-editable pip installs are allowed in worktrees

Closes #2495

🤖 Generated with [Claude Code](https://claude.com/claude-code)