### PR TITLE
fix: increase test verification timeout default to 600s

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/config.py
+++ b/loom-tools/src/loom_tools/shepherd/config.py
@@ -166,6 +166,9 @@ class ShepherdConfig:
     poll_interval: int = field(
         default_factory=lambda: env_int("LOOM_POLL_INTERVAL", 5)
     )
+    test_verify_timeout: int = field(
+        default_factory=lambda: env_int("LOOM_TEST_VERIFY_TIMEOUT", 600)
+    )
 
     # Retry limits
     doctor_max_retries: int = field(

--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -42,9 +42,6 @@ from loom_tools.shepherd.phases.base import (
 
 logger = logging.getLogger(__name__)
 
-# Default timeout for test verification (seconds)
-_TEST_VERIFY_TIMEOUT = int(os.environ.get("LOOM_TEST_VERIFY_TIMEOUT", "300"))
-
 # Pre-implementation reproducibility check settings
 _REPRODUCIBILITY_RUNS = 3  # Number of times to run each test for flakiness
 _REPRODUCIBILITY_TIMEOUT = 120  # seconds per run
@@ -1644,7 +1641,7 @@ class BuilderPhase:
                     cwd=ctx.worktree_path,
                     text=True,
                     capture_output=True,
-                    timeout=_TEST_VERIFY_TIMEOUT,
+                    timeout=ctx.config.test_verify_timeout,
                     check=False,
                     env=_build_worktree_env(ctx.worktree_path),
                 )
@@ -1938,7 +1935,7 @@ class BuilderPhase:
                 cwd=ctx.repo_root,
                 text=True,
                 capture_output=True,
-                timeout=_TEST_VERIFY_TIMEOUT,
+                timeout=ctx.config.test_verify_timeout,
                 check=False,
             )
         except subprocess.TimeoutExpired:
@@ -2073,7 +2070,7 @@ class BuilderPhase:
                 cwd=ctx.worktree_path,
                 text=True,
                 capture_output=True,
-                timeout=_TEST_VERIFY_TIMEOUT,
+                timeout=ctx.config.test_verify_timeout,
                 check=False,
                 env=_build_worktree_env(ctx.worktree_path),
             )
@@ -2259,7 +2256,7 @@ class BuilderPhase:
                 cwd=ctx.worktree_path,
                 text=True,
                 capture_output=True,
-                timeout=_TEST_VERIFY_TIMEOUT,
+                timeout=ctx.config.test_verify_timeout,
                 check=False,
                 env=_build_worktree_env(ctx.worktree_path),
             )

--- a/loom-tools/tests/shepherd/test_config.py
+++ b/loom-tools/tests/shepherd/test_config.py
@@ -231,6 +231,22 @@ class TestShepherdConfig:
             config = ShepherdConfig(issue=42)
             assert config.test_fix_max_retries == 5
 
+    def test_test_verify_timeout_default(self) -> None:
+        """test_verify_timeout should default to 600."""
+        config = ShepherdConfig(issue=42)
+        assert config.test_verify_timeout == 600
+
+    def test_test_verify_timeout_env_override(self) -> None:
+        """LOOM_TEST_VERIFY_TIMEOUT env var should override default."""
+        with patch.dict(os.environ, {"LOOM_TEST_VERIFY_TIMEOUT": "900"}):
+            config = ShepherdConfig(issue=42)
+            assert config.test_verify_timeout == 900
+
+    def test_test_verify_timeout_explicit(self) -> None:
+        """test_verify_timeout can be explicitly set."""
+        config = ShepherdConfig(issue=42, test_verify_timeout=1200)
+        assert config.test_verify_timeout == 1200
+
     def test_worktree_marker_file(self) -> None:
         """Worktree marker file should have default value."""
         config = ShepherdConfig(issue=42)


### PR DESCRIPTION
## Summary

- Increases test verification timeout default from 300s to 600s to support larger test suites
- Moves `_TEST_VERIFY_TIMEOUT` module constant from `builder.py` into `ShepherdConfig.test_verify_timeout`, consistent with other shepherd timeout patterns
- Configurable via `LOOM_TEST_VERIFY_TIMEOUT` environment variable or explicit `ShepherdConfig` parameter

## Test plan

- [x] All 35 config tests pass (including 3 new tests for the field)
- [x] All 665 phase tests pass
- [x] All 36 builder reproducibility tests pass

Closes #2390

🤖 Generated with [Claude Code](https://claude.com/claude-code)