### PR TITLE
fix: rename --min-idle-elapsed to --min-session-age for clarity

### DIFF
--- a/loom-tools/src/loom_tools/agent_monitor.py
+++ b/loom-tools/src/loom_tools/agent_monitor.py
@@ -936,10 +936,12 @@ def main() -> None:
         help="Seconds between proactive phase contract checks (default: 90)",
     )
     parser.add_argument(
-        "--min-idle-elapsed",
+        "--min-session-age",
+        "--min-idle-elapsed",  # deprecated alias
         type=int,
         default=10,
-        help="Override idle prompt detection threshold (default: 10)",
+        dest="min_session_age",
+        help="Minimum session age (seconds) before idle prompt detection activates (default: 10)",
     )
     parser.add_argument("--json", action="store_true", help="Output result as JSON")
 
@@ -956,7 +958,7 @@ def main() -> None:
         pr_number=args.pr,
         idle_timeout=args.idle_timeout,
         contract_interval=args.contract_interval,
-        min_idle_elapsed=args.min_idle_elapsed,
+        min_session_age=args.min_session_age,
     )
 
     result = asyncio.run(monitor_agent(config))

--- a/loom-tools/src/loom_tools/models/agent_wait.py
+++ b/loom-tools/src/loom_tools/models/agent_wait.py
@@ -155,7 +155,7 @@ class MonitorConfig:
     pr_number: int | None = None
     idle_timeout: int = 60
     contract_interval: int = 90
-    min_idle_elapsed: int = 10
+    min_session_age: int = 10
     heartbeat_interval: int = 60
     stuck_config: StuckConfig = field(default_factory=StuckConfig)
 
@@ -172,7 +172,7 @@ class MonitorConfig:
         pr_number: int | None = None,
         idle_timeout: int = 60,
         contract_interval: int = 90,
-        min_idle_elapsed: int = 10,
+        min_session_age: int = 10,
     ) -> MonitorConfig:
         """Create config from CLI arguments."""
         return cls(
@@ -186,6 +186,6 @@ class MonitorConfig:
             pr_number=pr_number,
             idle_timeout=idle_timeout,
             contract_interval=contract_interval,
-            min_idle_elapsed=min_idle_elapsed,
+            min_session_age=min_session_age,
             stuck_config=StuckConfig.from_env(),
         )

--- a/loom-tools/src/loom_tools/shepherd/phases/base.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/base.py
@@ -721,7 +721,7 @@ def run_worker_phase(
         wait_cmd.extend(["--phase", phase])
         # Work-producing roles need longer idle thresholds
         if phase in ("builder", "doctor", "judge"):
-            wait_cmd.extend(["--min-idle-elapsed", "120"])
+            wait_cmd.extend(["--min-session-age", "120"])
 
     if worktree:
         wait_cmd.extend(["--worktree", str(worktree)])

--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -6872,7 +6872,7 @@ class TestRunWorkerPhaseClaudeCodeEnv:
 
 
 class TestRunWorkerPhaseIdleThreshold:
-    """Test run_worker_phase min-idle-elapsed threshold configuration."""
+    """Test run_worker_phase min-session-age threshold configuration."""
 
     @pytest.fixture
     def mock_context(self, tmp_path: Path) -> MagicMock:
@@ -6934,11 +6934,11 @@ class TestRunWorkerPhaseIdleThreshold:
             )
 
         if expected_threshold:
-            assert "--min-idle-elapsed" in captured_wait_cmd
-            idx = captured_wait_cmd.index("--min-idle-elapsed")
+            assert "--min-session-age" in captured_wait_cmd
+            idx = captured_wait_cmd.index("--min-session-age")
             assert captured_wait_cmd[idx + 1] == expected_threshold
         else:
-            assert "--min-idle-elapsed" not in captured_wait_cmd
+            assert "--min-session-age" not in captured_wait_cmd
 
 
 class TestReadHeartbeats:

--- a/loom-tools/tests/test_agent_wait.py
+++ b/loom-tools/tests/test_agent_wait.py
@@ -227,7 +227,7 @@ class TestMonitorConfig:
         assert config.pr_number is None
         assert config.idle_timeout == 60
         assert config.contract_interval == 90
-        assert config.min_idle_elapsed == 10
+        assert config.min_session_age == 10
         assert config.heartbeat_interval == 60
 
     def test_from_args_minimal(self) -> None:
@@ -248,7 +248,7 @@ class TestMonitorConfig:
             pr_number=100,
             idle_timeout=30,
             contract_interval=60,
-            min_idle_elapsed=5,
+            min_session_age=5,
         )
         assert config.name == "builder-issue-42"
         assert config.timeout == 1800
@@ -260,4 +260,4 @@ class TestMonitorConfig:
         assert config.pr_number == 100
         assert config.idle_timeout == 30
         assert config.contract_interval == 60
-        assert config.min_idle_elapsed == 5
+        assert config.min_session_age == 5

--- a/loom-tools/tests/test_agent_wait_sync.py
+++ b/loom-tools/tests/test_agent_wait_sync.py
@@ -10,7 +10,7 @@ from unittest import mock
 import pytest
 
 from loom_tools.agent_wait import (
-    DEFAULT_MIN_IDLE_ELAPSED,
+    DEFAULT_MIN_SESSION_AGE,
     DEFAULT_POLL_INTERVAL,
     DEFAULT_TIMEOUT,
     IDLE_PROMPT_CONFIRM_COUNT,
@@ -35,7 +35,7 @@ class TestWaitConfig:
         assert config.name == "test-agent"
         assert config.timeout == DEFAULT_TIMEOUT
         assert config.poll_interval == DEFAULT_POLL_INTERVAL
-        assert config.min_idle_elapsed == DEFAULT_MIN_IDLE_ELAPSED
+        assert config.min_session_age == DEFAULT_MIN_SESSION_AGE
         assert config.json_output is False
 
     def test_custom_values(self) -> None:
@@ -43,13 +43,13 @@ class TestWaitConfig:
             name="builder-42",
             timeout=1800,
             poll_interval=10,
-            min_idle_elapsed=20,
+            min_session_age=20,
             json_output=True,
         )
         assert config.name == "builder-42"
         assert config.timeout == 1800
         assert config.poll_interval == 10
-        assert config.min_idle_elapsed == 20
+        assert config.min_session_age == 20
         assert config.json_output is True
 
 
@@ -411,7 +411,7 @@ class TestWaitForAgent:
         self, temp_repo: pathlib.Path
     ) -> None:
         """Non-blocking mode (timeout=0) with young session should skip idle check."""
-        config = WaitConfig(name="test-agent", timeout=0, min_idle_elapsed=10)
+        config = WaitConfig(name="test-agent", timeout=0, min_session_age=10)
 
         with mock.patch("loom_tools.agent_wait.find_repo_root", return_value=temp_repo):
             with mock.patch("loom_tools.agent_wait.session_exists", return_value=True):
@@ -424,7 +424,7 @@ class TestWaitForAgent:
                         with mock.patch(
                             "loom_tools.agent_wait.claude_is_running", return_value=True
                         ):
-                            # Session is only 2s old, below min_idle_elapsed=10
+                            # Session is only 2s old, below min_session_age=10
                             with mock.patch(
                                 "loom_tools.agent_wait.get_session_age", return_value=2
                             ):
@@ -441,7 +441,7 @@ class TestWaitForAgent:
         self, temp_repo: pathlib.Path
     ) -> None:
         """Non-blocking mode (timeout=0) with old enough session detects idle."""
-        config = WaitConfig(name="test-agent", timeout=0, min_idle_elapsed=10)
+        config = WaitConfig(name="test-agent", timeout=0, min_session_age=10)
 
         with mock.patch("loom_tools.agent_wait.find_repo_root", return_value=temp_repo):
             with mock.patch("loom_tools.agent_wait.session_exists", return_value=True):
@@ -478,7 +478,7 @@ class TestConstants:
         """Verify defaults match agent-wait.sh constants."""
         assert DEFAULT_TIMEOUT == 3600
         assert DEFAULT_POLL_INTERVAL == 5
-        assert DEFAULT_MIN_IDLE_ELAPSED == 10
+        assert DEFAULT_MIN_SESSION_AGE == 10
         assert IDLE_PROMPT_CONFIRM_COUNT == 2
 
     def test_processing_indicators_match(self) -> None:


### PR DESCRIPTION
## Summary

- Renames `--min-idle-elapsed` to `--min-session-age` across all Python modules, shell scripts, and tests
- Preserves `--min-idle-elapsed` as a deprecated alias for backward compatibility
- No functional changes — only naming clarity

The `--min-idle-elapsed` flag name was misleading because it doesn't control idle detection generally. It controls the **minimum session age** before idle prompt detection activates (a grace period to prevent false positives on freshly created sessions). This naming caused confusion with the separate `LOOM_STUCK_*` stuck detection system.

Closes #2409

## Test plan

- [x] All 68 tests in `test_agent_wait_sync.py`, `test_agent_wait.py`, and `test_phases.py::TestRunWorkerPhaseIdleThreshold` pass
- [ ] Verify deprecated `--min-idle-elapsed` alias still works in agent-wait-bg.sh and Python CLI
- [ ] Verify shepherd phases pass `--min-session-age` correctly (builder/doctor/judge get 120s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)