### PR TITLE
fix: preserve porcelain status prefix in builder artifact filtering

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -2688,7 +2688,9 @@ class BuilderPhase:
             check=False,
         )
         if result.returncode == 0 and result.stdout.strip():
-            return set(result.stdout.strip().splitlines())
+            return set(
+                line for line in result.stdout.splitlines() if line
+            )
         return set()
 
     def _gather_diagnostics(self, ctx: ShepherdContext) -> dict[str, Any]:
@@ -2767,7 +2769,7 @@ class BuilderPhase:
                 check=False,
             )
             commits = (
-                log_res.stdout.strip().splitlines()
+                [line for line in log_res.stdout.splitlines() if line]
                 if log_res.returncode == 0 and log_res.stdout.strip()
                 else []
             )
@@ -2781,7 +2783,7 @@ class BuilderPhase:
                 check=False,
             )
             uncommitted_files = (
-                status_res.stdout.strip().splitlines()
+                [line for line in status_res.stdout.splitlines() if line]
                 if status_res.returncode == 0 and status_res.stdout.strip()
                 else []
             )
@@ -2901,7 +2903,9 @@ class BuilderPhase:
         )
         main_dirty_files: list[str] = []
         if main_status.returncode == 0 and main_status.stdout.strip():
-            main_dirty_files = main_status.stdout.strip().splitlines()
+            main_dirty_files = [
+                line for line in main_status.stdout.splitlines() if line
+            ]
 
         # Filter out pre-existing dirty files using the baseline snapshot
         if self._main_dirty_baseline is not None:
@@ -3503,7 +3507,7 @@ class BuilderPhase:
         if status_result.returncode != 0:
             return False  # Can't determine status, don't treat as stale
         uncommitted = (
-            status_result.stdout.strip().splitlines()
+            [line for line in status_result.stdout.splitlines() if line]
             if status_result.stdout.strip()
             else []
         )
@@ -3872,7 +3876,9 @@ class BuilderPhase:
             check=False,
         )
         if status_result.returncode == 0 and status_result.stdout.strip():
-            porcelain_lines = status_result.stdout.strip().splitlines()
+            porcelain_lines = [
+                line for line in status_result.stdout.splitlines() if line
+            ]
             meaningful, _ = self._filter_build_artifacts(porcelain_lines)
             if not meaningful:
                 log_info(

--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -12187,8 +12187,7 @@ class TestBuilderMainDirtyBaseline:
 
         builder = BuilderPhase()
         # Simulate baseline snapshot taken before builder spawn.
-        # Note: .strip().splitlines() strips leading space from 1st line.
-        builder._main_dirty_baseline = {"M src/lib.rs", " M src/parser.rs"}
+        builder._main_dirty_baseline = {" M src/lib.rs", " M src/parser.rs"}
 
         def fake_run(cmd, **kwargs):
             cmd_str = " ".join(str(c) for c in cmd)
@@ -12235,8 +12234,8 @@ class TestBuilderMainDirtyBaseline:
         log_dir.mkdir(parents=True)
 
         builder = BuilderPhase()
-        # Baseline had one file (first line after .strip() loses leading space)
-        builder._main_dirty_baseline = {"M src/lib.rs"}
+        # Baseline had one file
+        builder._main_dirty_baseline = {" M src/lib.rs"}
 
         def fake_run(cmd, **kwargs):
             cmd_str = " ".join(str(c) for c in cmd)
@@ -12327,9 +12326,8 @@ class TestBuilderMainDirtyBaseline:
         ):
             baseline = builder._snapshot_main_dirty(mock_context)
 
-        # .strip() removes leading whitespace from entire string,
-        # so first line loses its leading space from porcelain format
-        assert baseline == {"M src/lib.rs", " M src/parser.rs"}
+        # Leading whitespace in porcelain status is preserved
+        assert baseline == {" M src/lib.rs", " M src/parser.rs"}
 
     def test_snapshot_main_dirty_clean(
         self, mock_context: MagicMock, tmp_path: Path


### PR DESCRIPTION
## Summary

- Replace `stdout.strip().splitlines()` with `[line for line in stdout.splitlines() if line]` at all 6 call sites in `builder.py` that parse `git status --porcelain` output
- The `.strip()` call was stripping the leading space from the first line's 2-char status prefix (e.g. `" M file"` became `"M file"`), shifting `line[3:]` and causing `_filter_build_artifacts` to misclassify files
- Update 2 tests that were encoding the buggy behavior in their baselines

## Test plan

- [x] All 679 tests in `test_phases.py` pass
- [x] `test_snapshot_main_dirty` now asserts leading space is preserved
- [x] `test_new_dirty_files_detected` baseline corrected to match un-stripped output

Closes #2493

🤖 Generated with [Claude Code](https://claude.com/claude-code)