### PR TITLE
fix: fail fast on auth pre-flight timeout instead of retrying for ~5 minutes

### DIFF
--- a/defaults/scripts/claude-wrapper.sh
+++ b/defaults/scripts/claude-wrapper.sh
@@ -957,6 +957,9 @@ run_preflight_checks() {
 
     if ! check_auth_status; then
         log_error "Authentication pre-flight check failed"
+        # Write sentinel so the shepherd can distinguish auth failures from
+        # generic instant-exits and avoid futile retries.  See issue #2508.
+        echo "# AUTH_PREFLIGHT_FAILED" >> "${LOG_FILE}"
         return 1
     fi
 


### PR DESCRIPTION
## Summary

- Wrapper writes `# AUTH_PREFLIGHT_FAILED` sentinel to log when auth check fails, so the shepherd can distinguish auth failures from generic instant-exits
- New `_is_auth_failure()` detection in `base.py` returns exit code 9 (checked before MCP/instant-exit)
- Exit code 9 is non-retryable in `run_phase_with_retry` — fails immediately instead of wasting ~5 minutes on futile retry cascades
- Builder phase handles exit code 9 with a clear error message and worktree cleanup

Closes #2508

## Test plan

- [x] 9 new tests covering `_is_auth_failure()`, `run_worker_phase` returning code 9, `run_phase_with_retry` not retrying code 9
- [x] All 696 existing + new tests pass
- [x] Auth failure checked before instant-exit to ensure correct priority

🤖 Generated with [Claude Code](https://claude.com/claude-code)