### PR TITLE
fix: surface root cause from session log in instant-exit diagnostics

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -37,6 +37,7 @@ from loom_tools.shepherd.phases.base import (
     PhaseResult,
     PhaseStatus,
     _get_cli_output,
+    extract_log_errors,
     run_phase_with_retry,
 )
 
@@ -2726,6 +2727,10 @@ class BuilderPhase:
         log_path = self._get_log_path(ctx)
         diag["log_file"] = str(log_path)
         diag["log_exists"] = log_path.is_file()
+        # Extract last [ERROR] lines from the log for root-cause surfacing.
+        # These are included in the diagnostic summary for exit codes 6/7
+        # so the shepherd output is self-contained.  See issue #2513.
+        diag["log_errors"] = extract_log_errors(log_path)
         if log_path.is_file():
             try:
                 log_content = log_path.read_text()
@@ -2936,6 +2941,12 @@ class BuilderPhase:
 
         # -- Human-readable summary -----------------------------------------
         parts: list[str] = []
+        # Surface root cause errors from the log at the front of the
+        # summary so they're immediately visible in shepherd output
+        # instead of buried in the log file.  See issue #2513.
+        if diag["log_errors"]:
+            last_error = diag["log_errors"][-1]
+            parts.append(last_error)
         if diag["worktree_exists"]:
             if diag["has_uncommitted_changes"]:
                 uncommitted_note = f"{diag['uncommitted_file_count']} files"

--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -10948,6 +10948,79 @@ class TestDoctorCIWaiting:
 
 
 # ---------------------------------------------------------------------------
+# Log error extraction tests (issue #2513)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractLogErrors:
+    """Test extract_log_errors helper function."""
+
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        from loom_tools.shepherd.phases.base import extract_log_errors
+
+        assert extract_log_errors(tmp_path / "nonexistent.log") == []
+
+    def test_no_errors_returns_empty(self, tmp_path: Path) -> None:
+        from loom_tools.shepherd.phases.base import extract_log_errors
+
+        log = tmp_path / "session.log"
+        log.write_text("# CLAUDE_CLI_START\nSome normal output\n")
+        assert extract_log_errors(log) == []
+
+    def test_extracts_single_error(self, tmp_path: Path) -> None:
+        from loom_tools.shepherd.phases.base import extract_log_errors
+
+        log = tmp_path / "session.log"
+        log.write_text(
+            "# CLAUDE_CLI_START\n"
+            "[2026-01-23 10:15:00] [ERROR] Authentication pre-flight check failed\n"
+        )
+        assert extract_log_errors(log) == ["Authentication pre-flight check failed"]
+
+    def test_extracts_multiple_errors_returns_last_n(self, tmp_path: Path) -> None:
+        from loom_tools.shepherd.phases.base import extract_log_errors
+
+        log = tmp_path / "session.log"
+        log.write_text(
+            "[2026-01-23 10:15:00] [ERROR] Error one\n"
+            "[2026-01-23 10:15:01] [ERROR] Error two\n"
+            "[2026-01-23 10:15:02] [ERROR] Error three\n"
+            "[2026-01-23 10:15:03] [ERROR] Error four\n"
+        )
+        # Default max_errors=3, should return last 3
+        result = extract_log_errors(log)
+        assert result == ["Error two", "Error three", "Error four"]
+
+    def test_max_errors_parameter(self, tmp_path: Path) -> None:
+        from loom_tools.shepherd.phases.base import extract_log_errors
+
+        log = tmp_path / "session.log"
+        log.write_text(
+            "[ERROR] First\n"
+            "[ERROR] Second\n"
+            "[ERROR] Third\n"
+        )
+        assert extract_log_errors(log, max_errors=1) == ["Third"]
+
+    def test_strips_ansi_codes(self, tmp_path: Path) -> None:
+        from loom_tools.shepherd.phases.base import extract_log_errors
+
+        log = tmp_path / "session.log"
+        # ANSI color codes around [ERROR]
+        log.write_text(
+            "\033[31m[ERROR]\033[0m Auth check failed\n"
+        )
+        assert extract_log_errors(log) == ["Auth check failed"]
+
+    def test_handles_error_without_timestamp(self, tmp_path: Path) -> None:
+        from loom_tools.shepherd.phases.base import extract_log_errors
+
+        log = tmp_path / "session.log"
+        log.write_text("[ERROR] Simple error message\n")
+        assert extract_log_errors(log) == ["Simple error message"]
+
+
+# ---------------------------------------------------------------------------
 # Instant-exit detection tests (issue #2135)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds `extract_log_errors()` helper that extracts `[ERROR]` lines from session log files (ANSI-stripped, last N errors)
- Surfaces the last error in diagnostic summaries so shepherd output is self-contained for debugging
- Enhances `run_worker_phase()` and `run_phase_with_retry()` log warnings to include root cause from session logs

## Problem

When a shepherd session exhausts instant-exit retries, the diagnostic message reported **worktree state** rather than **why the session failed**. The actual root cause (e.g., "Authentication pre-flight check failed") was buried in the log file.

## Before

```
[ERROR] builder subprocess exited with code 6: worktree exists (branch=feature/issue-2396, commits_ahead=0, uncommitted=only build artifacts); remote branch missing; no PR; labels=[loom:curated, loom:building]
```

## After

```
[ERROR] builder subprocess exited with code 6: Authentication pre-flight check failed; worktree exists (branch=feature/issue-2396, commits_ahead=0, uncommitted=only build artifacts); remote branch missing; no PR; labels=[loom:curated, loom:building]
```

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Root cause surfaced in diagnostic | Verified | `extract_log_errors()` extracts last `[ERROR]` line, prepended to summary |
| Works for exit code 6 (instant-exit) | Verified | Enhanced in both `run_worker_phase()` and `run_phase_with_retry()` |
| Works for exit code 7 (MCP failure) | Verified | Same treatment for MCP failure path |
| Log path still included | Verified | `log=` field preserved at end of summary |
| No regression | Verified | All 3082 Python tests pass |

## Test plan

- [x] 7 new unit tests for `extract_log_errors()` covering edge cases
- [x] Full test suite passes (3082 passed, 1 skipped)

Closes #2513

🤖 Generated with [Claude Code](https://claude.com/claude-code)