### PR TITLE
fix: skip auth pre-flight check for shepherd subprocess sessions

### DIFF
--- a/defaults/scripts/claude-wrapper.sh
+++ b/defaults/scripts/claude-wrapper.sh
@@ -958,7 +958,9 @@ run_preflight_checks() {
 
     check_api_reachable  # Non-fatal, just logs
 
-    if ! check_auth_status; then
+    if [[ -n "${LOOM_SHEPHERD_TASK_ID:-}" ]]; then
+        log_info "Skipping auth pre-flight (shepherd subprocess, task=${LOOM_SHEPHERD_TASK_ID})"
+    elif ! check_auth_status; then
         if [[ "${SKIP_PERMISSIONS_MODE}" == "true" ]]; then
             log_warn "Authentication pre-flight check failed (non-fatal in --dangerously-skip-permissions mode)"
         else

--- a/loom-tools/src/loom_tools/shepherd/phases/base.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/base.py
@@ -794,9 +794,12 @@ def run_worker_phase(
     # times internally *and* the Python code retries up to 3 times on top,
     # causing up to 15 total CLI invocations instead of the intended 3.
     # See issue #2516.
+    #
+    # Pass LOOM_SHEPHERD_TASK_ID so subprocess claude-wrapper.sh can skip
+    # the auth pre-flight check (see issue #2524).
     spawn_env = os.environ.copy()
     spawn_env["LOOM_MAX_RETRIES"] = "1"
-
+    spawn_env["LOOM_SHEPHERD_TASK_ID"] = ctx.config.task_id
     spawn_result = subprocess.run(
         spawn_cmd,
         cwd=ctx.repo_root,

--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -6985,6 +6985,55 @@ class TestRunWorkerPhaseClaudeCodeEnv:
         assert exit_code == 0
 
 
+class TestRunWorkerPhaseShepherdTaskId:
+    """Test run_worker_phase passes LOOM_SHEPHERD_TASK_ID to spawn env (issue #2524)."""
+
+    def test_shepherd_task_id_in_spawn_env(self, tmp_path: Path) -> None:
+        """LOOM_SHEPHERD_TASK_ID must be set in spawn subprocess env."""
+        ctx = MagicMock(spec=ShepherdContext)
+        ctx.config = ShepherdConfig(issue=42, task_id="abc-789")
+        ctx.repo_root = tmp_path
+        scripts_dir = tmp_path / ".loom" / "scripts"
+        scripts_dir.mkdir(parents=True)
+        (scripts_dir / "agent-spawn.sh").touch()
+        (scripts_dir / "agent-wait-bg.sh").touch()
+        ctx.scripts_dir = scripts_dir
+        ctx.progress_dir = tmp_path / ".loom" / "progress"
+
+        spawn_env_captured = {}
+
+        def mock_spawn(cmd, **kwargs):
+            spawn_env_captured.update(kwargs.get("env", {}))
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        def mock_popen(cmd, **kwargs):
+            proc = MagicMock()
+            proc.poll.return_value = 0
+            proc.returncode = 0
+            return proc
+
+        with (
+            patch("subprocess.run", side_effect=mock_spawn),
+            patch("subprocess.Popen", side_effect=mock_popen),
+            patch("time.sleep"),
+            patch(
+                "loom_tools.shepherd.phases.base._is_instant_exit",
+                return_value=False,
+            ),
+        ):
+            run_worker_phase(
+                ctx,
+                role="builder",
+                name="builder-issue-42",
+                timeout=600,
+                phase="builder",
+            )
+
+        assert spawn_env_captured.get("LOOM_SHEPHERD_TASK_ID") == "abc-789"
+
+
 class TestRunWorkerPhaseIdleThreshold:
     """Test run_worker_phase min-session-age threshold configuration."""
 


### PR DESCRIPTION
## Summary

- Shepherd-spawned worker sessions now skip the `claude auth status` pre-flight check by detecting the `LOOM_SHEPHERD_TASK_ID` environment variable
- The env var is set by `run_worker_phase()` in `base.py`, propagated through `agent_spawn.py` to the tmux session, and checked in `claude-wrapper.sh`
- Eliminates 45-120 seconds of wasted time per subprocess spawn from auth lock contention

## Changes

- `defaults/scripts/claude-wrapper.sh`: Skip auth check when `LOOM_SHEPHERD_TASK_ID` is set
- `loom-tools/src/loom_tools/shepherd/phases/base.py`: Pass `LOOM_SHEPHERD_TASK_ID` in spawn env
- `loom-tools/src/loom_tools/agent_spawn.py`: Propagate `LOOM_SHEPHERD_TASK_ID` to tmux session and inline command

## Test plan

- [x] Unit test: `LOOM_SHEPHERD_TASK_ID` is set in spawn subprocess env (`TestRunWorkerPhaseShepherdTaskId`)
- [x] Unit test: `LOOM_SHEPHERD_TASK_ID` propagated to tmux session and inline command (`TestShepherdTaskIdPropagation`)
- [x] Unit test: No propagation when env var absent (`test_no_shepherd_task_id_when_absent`)
- [x] Existing tests pass (CLAUDECODE stripping, config dir isolation, idle threshold)

Closes #2524

🤖 Generated with [Claude Code](https://claude.com/claude-code)