### PR TITLE
feat: fast-fail shepherd on systemic auth failures instead of retrying

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/exit_codes.py
+++ b/loom-tools/src/loom_tools/shepherd/exit_codes.py
@@ -26,6 +26,7 @@ class ShepherdExitCode(IntEnum):
     | 5         | Skipped (already complete)    | No action                         |
     | 6         | No changes needed             | Mark blocked, await human review  |
     | 7         | Transient API error           | Requeue issue, retry after backoff|
+    | 9         | Systemic failure (auth/API)   | Requeue issue, do NOT retry       |
 
     Using IntEnum allows these to be used directly as exit codes:
         return ShepherdExitCode.SUCCESS
@@ -68,6 +69,12 @@ class ShepherdExitCode(IntEnum):
     # After 2 occurrences, daemon triggers architect decomposition
     BUDGET_EXHAUSTED = 8
 
+    # Systemic infrastructure failure (auth timeout, API outage, etc.)
+    # Retries will NOT help — the problem is environmental, not issue-specific.
+    # Daemon should requeue the issue but NOT retry immediately.
+    # See issue #2521.
+    SYSTEMIC_FAILURE = 9
+
 
 # Convenience mapping for code interpretation
 EXIT_CODE_DESCRIPTIONS = {
@@ -80,6 +87,7 @@ EXIT_CODE_DESCRIPTIONS = {
     ShepherdExitCode.NO_CHANGES_NEEDED: "No changes needed - marked blocked for human review",
     ShepherdExitCode.TRANSIENT_ERROR: "Transient API error - safe to retry after backoff",
     ShepherdExitCode.BUDGET_EXHAUSTED: "Budget exhausted - issue may need decomposition",
+    ShepherdExitCode.SYSTEMIC_FAILURE: "Systemic failure (auth/API) - do not retry immediately",
 }
 
 

--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -13811,6 +13811,52 @@ class TestIsAuthFailure:
         )
         assert _is_auth_failure(log) is True
 
+    def test_pattern_fallback_auth_timed_out(self, tmp_path: Path) -> None:
+        """Auth failure detected via error pattern when sentinel is absent."""
+        log = tmp_path / "test.log"
+        log.write_text(
+            "# Loom Agent Log\n"
+            "[ERROR] Authentication check timed out after 3 attempts\n"
+        )
+        assert _is_auth_failure(log) is True
+
+    def test_pattern_fallback_preflight_failed(self, tmp_path: Path) -> None:
+        """Auth failure detected via preflight-failed pattern (no sentinel)."""
+        log = tmp_path / "test.log"
+        log.write_text(
+            "# Loom Agent Log\n"
+            "[ERROR] Authentication pre-flight check failed\n"
+        )
+        assert _is_auth_failure(log) is True
+
+    def test_pattern_fallback_api_unreachable(self, tmp_path: Path) -> None:
+        """API unreachable pattern detected as systemic failure."""
+        log = tmp_path / "test.log"
+        log.write_text(
+            "# Loom Agent Log\n"
+            "[ERROR] API endpoint unreachable\n"
+        )
+        assert _is_auth_failure(log) is True
+
+    def test_pattern_fallback_auth_check_failed(self, tmp_path: Path) -> None:
+        """Auth check failed pattern detected as systemic failure."""
+        log = tmp_path / "test.log"
+        log.write_text(
+            "# Loom Agent Log\n"
+            "[ERROR] Authentication check failed\n"
+        )
+        assert _is_auth_failure(log) is True
+
+    def test_no_false_positive_on_similar_text(self, tmp_path: Path) -> None:
+        """Non-error messages containing similar words should not match."""
+        log = tmp_path / "test.log"
+        log.write_text(
+            "# Loom Agent Log\n"
+            "[INFO] Authentication check passed\n"
+            "[INFO] API endpoint available\n"
+        )
+        assert _is_auth_failure(log) is False
+
 
 class TestRunWorkerPhaseAuthFailure:
     """Test that run_worker_phase returns exit code 9 for auth failures."""


### PR DESCRIPTION
## Summary

- Enhance `_is_auth_failure()` to detect systemic failures via log patterns (not just the `AUTH_PREFLIGHT_FAILED` sentinel), catching cases where the wrapper sentinel was not written
- Add `SYSTEMIC_FAILURE = 9` to `ShepherdExitCode` enum so the daemon can distinguish systemic failures from builder failures
- Handle exit code 9 in `CuratorPhase` to abort the entire shepherd run on auth failure
- Propagate `auth_failure` flag through `cli.py` orchestrator to return `SYSTEMIC_FAILURE` instead of `BUILDER_FAILED`

This reduces auth-timeout failure time from ~14 minutes (retrying across phases) to ~2 minutes (single attempt + detection).

## Test plan

- [x] 5 new tests for pattern-based auth failure detection (timed out, preflight failed, API unreachable, auth check failed, no false positives)
- [x] All 10 `TestIsAuthFailure` tests pass
- [x] Time guard tests from #2528 (`TestInstantExitElapsedTimeGuard`) still pass — time guard preserved
- [x] Full Python test suite passes (3094 tests)

Closes #2521

🤖 Generated with [Claude Code](https://claude.com/claude-code)