### PR TITLE
fix: handle exit codes 6/7/8/9 in curator phase to prevent false-positive success

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/curator.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/curator.py
@@ -61,6 +61,18 @@ class CuratorPhase(BasePhase):
             # Curator stuck - not critical, can proceed
             return self.skipped("curator stuck after retry - skipping curation")
 
+        if exit_code == 6:
+            return self.failed("curator instant-exit after retries exhausted")
+
+        if exit_code == 7:
+            return self.failed("curator MCP failure after retries exhausted")
+
+        if exit_code == 8:
+            return self.failed("curator planning stall (not retryable)")
+
+        if exit_code == 9:
+            return self.failed("curator auth pre-flight failed (not retryable)")
+
         # Validate phase
         if not self.validate(ctx):
             return self.failed("curator phase validation failed")


### PR DESCRIPTION
## Summary

When `run_phase_with_retry` returned exit codes 6 (instant-exit), 7 (MCP failure), 8 (planning stall), or 9 (auth pre-flight failure), the curator phase fell through to `validate()` which applied `loom:curated` via recovery — reporting success despite zero actual curation work.

- Add explicit handlers for exit codes 6, 7, 8, and 9 in `CuratorPhase.run()` before the `validate()` fallthrough
- Add 7 unit tests covering each exit code, a regression test verifying `validate()` is not called on exit code 6, and a happy-path test confirming exit code 0 still validates

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Exit code 6 returns FAILED | Verified | `test_exit_code_6_returns_failed` |
| Exit code 7 returns FAILED | Verified | `test_exit_code_7_returns_failed` |
| Exit code 8 returns FAILED | Verified | `test_exit_code_8_returns_failed` |
| Exit code 9 returns FAILED | Verified | `test_exit_code_9_returns_failed` |
| Exit code 6 does NOT call validate | Verified | `test_exit_code_6_does_not_call_validate` |
| Exit code 0 still validates (happy path) | Verified | `test_exit_code_0_still_validates` |
| No regressions | Verified | 715 tests pass |

Closes #2520