### PR TITLE
fix: guard auth failure reclassification with non-zero exit check

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/base.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/base.py
@@ -998,7 +998,9 @@ def run_worker_phase(
     # Check for auth pre-flight failure first (exit code 9).  Auth failures
     # are NOT transient when a parent Claude session holds the config lock,
     # so retrying is futile.  See issue #2508.
-    if _is_auth_failure(log_path):
+    # Only reclassify non-zero exits — a successful process (exit 0) should
+    # never be overridden by log pattern matching.  See issue #2540.
+    if wait_exit != 0 and _is_auth_failure(log_path):
         log_warning(
             f"Auth pre-flight failure for {role} session '{name}': "
             f"authentication check failed (not retryable, log: {log_path})"


### PR DESCRIPTION
## Summary

Fixes the shepherd overriding exit code 0 → 9 when `[ERROR] Authentication check timed out` appears in the builder log. The `_is_auth_failure()` check was called unconditionally, causing successful builder runs to be misclassified as auth failures.

**Root cause**: `run_worker_phase()` called `_is_auth_failure(log_path)` without checking `wait_exit`, so a builder that exited 0 (success) but had auth timeout warnings in the log was reclassified to exit 9 (auth failure). This caused the shepherd to treat the run as failed and strip `loom:review-requested` from the PR.

**Fix**: Guard the `_is_auth_failure()` call with `wait_exit != 0` so only non-zero exits are reclassified.

Closes #2540

## Changes

- `base.py:1001`: Added `wait_exit != 0` guard before `_is_auth_failure()` check
- Updated `test_auth_failure_returns_code_9` to use non-zero process exit (was incorrectly encoding the buggy behavior)
- Updated `test_auth_failure_takes_priority_over_instant_exit` to use non-zero process exit
- Added `test_exit_0_not_overridden_by_auth_pattern` — verifies exit 0 is preserved even when auth patterns are in the log

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|-------------|
| `run_worker_phase()` returns 0 when process exits 0, even with auth error in log | Verified | New test `test_exit_0_not_overridden_by_auth_pattern` passes |
| `run_worker_phase()` returns 9 when process exits non-zero AND auth patterns found | Verified | Updated `test_auth_failure_returns_code_9` passes with exit 1 |
| Existing auth-failure detection preserved for non-zero exits | Verified | All 24 auth-related tests pass |

## Test Plan

- [x] `pytest -k "auth"` — 24/24 tests pass
- [x] Exit code 6 (instant-exit) and 7 (MCP failure) paths unaffected (no changes to those code paths)