### PR TITLE
fix: guard instant-exit and MCP failure reclassification with non-zero exit check

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/base.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/base.py
@@ -1014,7 +1014,7 @@ def run_worker_phase(
 
     # Check for MCP failure (exit code 7) — more specific than instant-exit,
     # with different retry/backoff strategy.  See issues #2135, #2279.
-    if _is_mcp_failure(log_path):
+    if wait_exit != 0 and _is_mcp_failure(log_path):
         errors = extract_log_errors(log_path)
         cause = f": {errors[-1]}" if errors else ""
         log_warning(
@@ -1022,7 +1022,7 @@ def run_worker_phase(
             f"(exit code {wait_exit}, log: {log_path})"
         )
         return 7
-    if _is_instant_exit(log_path):
+    if wait_exit != 0 and _is_instant_exit(log_path):
         errors = extract_log_errors(log_path)
         cause = f": {errors[-1]}" if errors else ""
         log_warning(


### PR DESCRIPTION
Closes #2545

## Summary

- Gate `_is_instant_exit()` and `_is_mcp_failure()` calls on `wait_exit != 0` in `run_worker_phase()`, matching the existing guard on `_is_auth_failure()` from PR #2543
- A successful process (exit code 0) should never be overridden by log-based heuristics

## Changes

**`loom-tools/src/loom_tools/shepherd/phases/base.py`** (~lines 1017, 1025):
- Added `wait_exit != 0` guard before `_is_mcp_failure()` check
- Added `wait_exit != 0` guard before `_is_instant_exit()` check

**`loom-tools/tests/shepherd/test_phases.py`**:
- Added `test_exit_0_not_overridden_by_instant_exit_pattern` — verifies exit 0 is preserved when instant-exit log pattern matches
- Added `test_exit_0_not_overridden_by_mcp_failure_pattern` — verifies exit 0 is preserved when MCP failure log pattern matches
- Updated existing tests (`test_instant_exit_returns_code_6`, `test_mcp_failure_returns_code_7`, `test_mcp_failure_checked_before_instant_exit`) to use non-zero exit codes, consistent with the new guard behavior

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|-------------|
| `_is_instant_exit` gated on `wait_exit != 0` | Pass | Line 1025: `if wait_exit != 0 and _is_instant_exit(log_path)` |
| `_is_mcp_failure` gated on `wait_exit != 0` | Pass | Line 1017: `if wait_exit != 0 and _is_mcp_failure(log_path)` |
| Unit test: exit 0 + instant-exit pattern → returns 0 | Pass | `test_exit_0_not_overridden_by_instant_exit_pattern` |
| Unit test: exit 0 + MCP failure pattern → returns 0 | Pass | `test_exit_0_not_overridden_by_mcp_failure_pattern` |
| Non-zero exits still trigger reclassification | Pass | All 744 tests pass |

## Test Plan

- [x] All 744 tests in `test_phases.py` pass
- [x] New tests verify exit code 0 skips both instant-exit and MCP failure reclassification
- [x] Existing tests updated to use non-zero exit codes where they were testing reclassification behavior