### PR TITLE
fix: append --print mode output to log file before session exit

### DIFF
--- a/defaults/scripts/claude-wrapper.sh
+++ b/defaults/scripts/claude-wrapper.sh
@@ -914,6 +914,18 @@ run_with_retry() {
         stop_output_monitor "${startup_monitor_pid_file}"
 
         output=$(cat "${temp_output}")
+
+        # In --print mode, pipe-pane may not flush before session exit.
+        # Append captured output to the log file so log-based heuristics
+        # (_is_instant_exit, _is_mcp_failure) have content to analyze
+        # and post-mortem debugging is possible.  See issue #2550.
+        if [[ "$_has_slash_cmd" == "true" && -n "${TERMINAL_ID}" ]]; then
+            local _log_file="${WORKSPACE}/.loom/logs/loom-${TERMINAL_ID}.log"
+            if [[ -f "$_log_file" && -s "${temp_output}" ]]; then
+                cat "${temp_output}" >> "$_log_file"
+            fi
+        fi
+
         rm -f "${temp_output}"
 
         # Check exit code


### PR DESCRIPTION
## Summary

Fixes the pipe-pane capture gap that left builder logs empty after `--print` mode runs, causing false-positive instant-exit detection and making post-mortem debugging impossible.

**Root cause**: When `claude-wrapper.sh` uses `--print` mode (slash command detection), the tmux session tears down before `pipe-pane` finishes flushing its buffer, so the captured CLI output never reaches the log file.

**Fix**: Before deleting the temporary output file, append its contents to the terminal log file. Guarded by:
- `_has_slash_cmd == "true"` — only activates in `--print` mode
- `TERMINAL_ID` non-empty — standalone wrapper invocations unaffected
- Log file exists (`-f`) and temp output is non-empty (`-s`)

## Acceptance Criteria Verification

| Criterion | Verification |
|-----------|-------------|
| Builder logs for successful `--print` mode runs contain actual CLI output | `cat "${temp_output}" >> "$_log_file"` writes output before `rm -f` |
| `_is_instant_exit()` returns `False` for `--print` mode runs | Log now has content after sentinel, exceeding `INSTANT_EXIT_MIN_OUTPUT_CHARS` |
| `_is_mcp_failure()` does not false-positive on `--print` logs with content | Log content means output volume check passes correctly |
| Non-`--print` mode behavior unchanged | Guard `_has_slash_cmd == "true"` prevents activation in interactive/no-TTY paths |
| Standalone wrapper invocations unaffected | Guard `-n "${TERMINAL_ID}"` prevents activation without Loom context |

## Test Plan

- [x] `bash -n` syntax check passes
- [x] 748 shepherd phase tests pass (no regressions)
- [x] 1429/1430 loom-tools tests pass (1 pre-existing failure in `test_agent_monitor.py`)
- [x] Pre-existing lint errors confirmed on base branch (unrelated HTML a11y issues)

Closes #2550

🤖 Generated with [Claude Code](https://claude.com/claude-code)