### PR TITLE
fix: use issue title instead of "Issue #N" for PR titles in shepherd

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -3432,7 +3432,7 @@ class BuilderPhase:
                         "--head",
                         branch,
                         "--title",
-                        f"Issue #{ctx.config.issue}",
+                        ctx.issue_title or f"Issue #{ctx.config.issue}",
                         "--label",
                         "loom:review-requested",
                         "--body",
@@ -3525,7 +3525,7 @@ class BuilderPhase:
         if "create_pr" in steps:
             if attempt >= 2:
                 instructions.append(
-                    f"- Run: gh pr create --title 'Issue #{ctx.config.issue}' "
+                    f"- Run: gh pr create --title {shlex.quote(ctx.issue_title or f'Issue #{ctx.config.issue}')} "
                     f"--label loom:review-requested "
                     f"--body 'Closes #{ctx.config.issue}'"
                 )


### PR DESCRIPTION
Closes #2546

## Summary

PR titles created by the shepherd's completion and recovery paths now use the actual issue title (`ctx.issue_title`) instead of the generic `"Issue #N"` format, making PRs immediately identifiable without opening them.

## Changes

| File | Location | Fix |
|------|----------|-----|
| `builder.py:3435` | Direct completion subprocess call | Use `ctx.issue_title` |
| `builder.py:3528` | Agent fallback instructions | Use `ctx.issue_title` with `shlex.quote` |
| `cli.py:1364` | Test failure recovery snippet | Added `--title` flag with `ctx.issue_title` |
| `cli.py:1685` | No-PR diagnostics recovery snippet | Added `--title` flag via new `issue_title` parameter |

All locations gracefully fall back to `"Issue #N"` if `issue_title` is unavailable. Shell commands use `shlex.quote()` for safe escaping of special characters in titles.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Direct completion (`builder.py:3435`) uses issue title | ✅ | Uses `ctx.issue_title or f"Issue #{ctx.config.issue}"` |
| Agent fallback instructions (`builder.py:3528`) include issue title | ✅ | Uses `shlex.quote(ctx.issue_title or ...)` |
| Recovery path in `cli.py:1363` specifies `--title` flag | ✅ | Added `--title` with `shlex.quote(ctx.issue_title or ...)` |
| Recovery path in `cli.py:1682` specifies `--title` flag | ✅ | Added `issue_title` param and `shlex.quote` |
| Graceful fallback to `f"Issue #{issue}"` | ✅ | All locations use `or f"Issue #{...}"` pattern |

## Test Results

893 tests passed (4 new tests added):
- `TestFormatDiagnosticsForComment::test_uses_issue_title_in_recovery_commands`
- `TestFormatDiagnosticsForComment::test_falls_back_to_issue_number_when_no_title`
- `TestFormatDiagnosticsForComment::test_escapes_special_characters_in_title`
- `TestBuilderDirectCompletion::test_create_pr_uses_issue_title`