### PR TITLE
fix: use issue title instead of generic PR titles in shepherd

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -3432,7 +3432,7 @@ class BuilderPhase:
                         "--head",
                         branch,
                         "--title",
-                        f"Issue #{ctx.config.issue}",
+                        ctx.issue_title or f"Issue #{ctx.config.issue}",
                         "--label",
                         "loom:review-requested",
                         "--body",
@@ -3525,7 +3525,7 @@ class BuilderPhase:
         if "create_pr" in steps:
             if attempt >= 2:
                 instructions.append(
-                    f"- Run: gh pr create --title 'Issue #{ctx.config.issue}' "
+                    f"- Run: gh pr create --title {shlex.quote(ctx.issue_title or f'Issue #{ctx.config.issue}')} "
                     f"--label loom:review-requested "
                     f"--body 'Closes #{ctx.config.issue}'"
                 )


### PR DESCRIPTION
Closes #2546

## Summary
- Builder phase now uses actual issue title from GitHub for PR titles instead of generic "Issue #N"
- Recovery commands in diagnostic comments also use the issue title
- Falls back to "Issue #N" when title is unavailable
- Shell-escapes titles with special characters via `shlex.quote()`

## Changes
- `cli.py`: Updated `_mark_builder_test_failure`, `_format_diagnostics_for_comment`, and `_mark_builder_no_pr` to use issue title
- `builder.py`: Updated `gh pr create` command to use `ctx.issue_title` 
- `test_cli.py`: Added 3 new tests for title usage, fallback, and escaping

## Test plan
- [x] All 144 existing tests pass
- [x] New tests verify title is used in recovery commands
- [x] New tests verify fallback to "Issue #N" when title empty
- [x] New tests verify shell escaping of special characters