### PR TITLE
fix: prevent duplicate 'Phase contract failed' comments in judge retry loop

### DIFF
--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -5038,6 +5038,47 @@ class TestJudgePhase:
         # Should sleep between attempts (2 sleeps for 3 attempts)
         assert mock_sleep.call_count == 2
 
+    def test_validation_retries_use_check_only_for_non_final_attempts(
+        self, mock_context: MagicMock
+    ) -> None:
+        """Non-final validation retries should use check_only=True (#2558).
+
+        This prevents duplicate 'Phase contract failed' comments from being
+        posted on every retry attempt.  Only the final attempt (when all
+        retries are exhausted) should use check_only=False so the comment
+        and failure label are applied exactly once.
+        """
+        mock_context.pr_number = 100
+        mock_context.check_shutdown.return_value = False
+
+        judge = JudgePhase()
+        check_only_values: list[bool] = []
+
+        def capture_check_only(ctx: ShepherdContext, *, check_only: bool = False) -> bool:
+            check_only_values.append(check_only)
+            return False  # Always fail to exhaust retries
+
+        fake_diag = {
+            "summary": "test",
+            "log_file": "/fake",
+            "log_exists": False,
+            "log_tail": [],
+            "pr_reviews": [],
+            "pr_labels": [],
+        }
+        with (
+            patch.object(judge, "validate", side_effect=capture_check_only),
+            patch(
+                "loom_tools.shepherd.phases.judge.run_phase_with_retry", return_value=0
+            ),
+            patch("loom_tools.shepherd.phases.judge.time.sleep"),
+            patch.object(judge, "_gather_diagnostics", return_value=fake_diag),
+        ):
+            judge.run(mock_context)
+
+        # 3 attempts: first two should be check_only=True, last should be False
+        assert check_only_values == [True, True, False]
+
     def test_cache_invalidated_before_validation(self, mock_context: MagicMock) -> None:
         """Cache should be invalidated BEFORE validation, not after.
 
@@ -5054,7 +5095,7 @@ class TestJudgePhase:
         def track_invalidate(pr: int | None = None) -> None:
             call_order.append("invalidate")
 
-        def track_validate(ctx: ShepherdContext) -> bool:
+        def track_validate(ctx: ShepherdContext, **kwargs: object) -> bool:
             call_order.append("validate")
             return True
 


### PR DESCRIPTION
## Summary

- Pass `check_only=True` for non-final validation retries in the judge phase so that `_mark_phase_failed()` (which posts a comment and applies a failure label) only fires on the last attempt
- Previously, each of the 3 validation retries would post an identical "Phase contract failed" comment, and combined with the outer judge retry loop this could produce up to 9 duplicate comments

## Test plan

- [x] New test `test_validation_retries_use_check_only_for_non_final_attempts` verifies `check_only` values are `[True, True, False]` across the 3 retry attempts
- [x] All 44 existing judge phase tests pass
- [x] All 57 validate_phase tests pass

Closes #2558

🤖 Generated with [Claude Code](https://claude.com/claude-code)