### PR TITLE
fix: replace herestring with pipe in claude-wrapper.sh

### DIFF
--- a/defaults/scripts/claude-wrapper.sh
+++ b/defaults/scripts/claude-wrapper.sh
@@ -421,7 +421,7 @@ _auth_cache_write() {
     local now
     now=$(date +%s)
 
-    python3 -c "
+    printf '%s' "${output}" | python3 -c "
 import json, sys
 data = {
     'time': ${now},
@@ -430,7 +430,7 @@ data = {
 }
 with open('${cache_file}', 'w') as f:
     json.dump(data, f)
-" <<< "${output}" 2>/dev/null || true
+" 2>/dev/null || true
 }
 
 # Pre-flight check: verify authentication status


### PR DESCRIPTION
Closes #2559

## Summary

- Replace `<<<` herestring with `printf '%s' | ...` pipe in `_auth_cache_write()` function (`defaults/scripts/claude-wrapper.sh:424`)

## Problem

Intermittent `syntax error near unexpected token '<<<'` failures during shepherd runs caused 3 wasted judge invocations before succeeding on the 4th attempt, adding ~2 minutes of wasted time.

## Fix

Replaced the bash herestring (`<<<`) with a POSIX-standard pipe (`printf '%s' "${output}" | python3 ...`). This is functionally identical — `sys.stdin.read()` receives the same data — but avoids the herestring mechanism entirely.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|-------------|
| Replace `<<<` with pipe | Done | `printf '%s' \| python3` used instead |
| Zero behavioral change | Done | `sys.stdin.read()` receives same data via pipe |
| Script passes syntax check | Done | `bash -n` passes |
| Only one occurrence in file | Done | `grep '<<<'` returns no matches |

## Test Plan

- [x] `bash -n defaults/scripts/claude-wrapper.sh` — syntax check passes
- [x] Verified no remaining `<<<` usage in the file
- [x] Change is a 1:1 replacement with identical data flow