### PR TITLE
feat: surface low-output cause classification in builder diagnostics

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/context.py
+++ b/loom-tools/src/loom_tools/shepherd/context.py
@@ -53,6 +53,9 @@ class ShepherdContext:
     # Caches
     label_cache: LabelCache = field(init=False)
 
+    # Low-output cause classification (set by run_phase_with_retry)
+    last_low_output_cause: str | None = field(default=None, init=False)
+
     # Progress tracking state
     _progress_initialized: bool = field(default=False, init=False, repr=False)
 

--- a/loom-tools/src/loom_tools/shepherd/phases/base.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/base.py
@@ -1176,6 +1176,9 @@ def run_phase_with_retry(
             paths = LoomPaths(ctx.repo_root)
             log_path = paths.worker_log_file(role, ctx.config.issue)
             cause = _classify_low_output_cause(log_path)
+            # Surface the classification on the context so callers
+            # (e.g., _gather_diagnostics) can include it.  See issue #2562.
+            ctx.last_low_output_cause = cause
             cause_max_retries, cause_backoff = LOW_OUTPUT_RETRY_STRATEGIES.get(
                 cause, LOW_OUTPUT_RETRY_STRATEGIES["unknown"]
             )
@@ -1195,7 +1198,8 @@ def run_phase_with_retry(
                 log_warning(
                     f"Low-output attempt for {role} took {attempt_elapsed:.0f}s "
                     f"(>{LOW_OUTPUT_MAX_ATTEMPT_SECONDS}s), "
-                    f"likely infrastructure issue — not retrying"
+                    f"likely infrastructure issue — not retrying "
+                    f"(cause: {cause})"
                 )
                 return 6
 

--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -2794,6 +2794,11 @@ class BuilderPhase:
             diag["log_has_implementation_activity"] = False
             diag["log_has_mcp_failure_markers"] = False
 
+        # -- Low-output cause classification (set by run_phase_with_retry) ---
+        # Surfaced here so the diagnostic summary is self-contained
+        # without having to cross-reference the retry log.  See issue #2562.
+        diag["low_output_cause"] = ctx.last_low_output_cause
+
         # -- Worktree state --------------------------------------------------
         wt = ctx.worktree_path
         diag["worktree_exists"] = bool(wt and wt.is_dir())
@@ -2976,6 +2981,8 @@ class BuilderPhase:
         if diag["log_errors"]:
             last_error = diag["log_errors"][-1]
             parts.append(last_error)
+        if diag["low_output_cause"]:
+            parts.append(f"low_output_cause={diag['low_output_cause']}")
         if diag["worktree_exists"]:
             if diag["has_uncommitted_changes"]:
                 uncommitted_note = f"{diag['uncommitted_file_count']} files"

--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -1123,6 +1123,7 @@ class TestBuilderDiagnostics:
         mock_context.worktree_path = tmp_path / "nonexistent"
         mock_context.config = ShepherdConfig(issue=42)
         mock_context.repo_root = tmp_path
+        mock_context.last_low_output_cause = None
 
         builder = BuilderPhase()
 
@@ -1153,6 +1154,7 @@ class TestBuilderDiagnostics:
         assert "PR" in parts[2] or "no PR" in parts[2]
         assert "labels=" in parts[3]
         assert "log=" in parts[4]
+        assert diag["low_output_cause"] is None
 
 
 class TestBuilderQualityValidation:


### PR DESCRIPTION
Closes #2562

## Summary

- Store the low-output cause classification (`auth_timeout`, `auth_lock_contention`, `api_unreachable`, `unknown`) on `ShepherdContext.last_low_output_cause` from `run_phase_with_retry`
- Include `low_output_cause` in `_gather_diagnostics()` dict and human-readable summary
- Append cause to the infrastructure-timeout warning message for better log context

## Changes

| File | Change |
|------|--------|
| `context.py` | Add `last_low_output_cause: str \| None` field to `ShepherdContext` |
| `base.py` | Set `ctx.last_low_output_cause = cause` after classification; append cause to slow-attempt warning |
| `builder.py` | Include `low_output_cause` in diagnostics dict and summary string |
| `test_phases.py` | Set `last_low_output_cause = None` on mock context; assert `low_output_cause` in diagnostics |

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Classification surfaced to diagnostics | Done | `diag["low_output_cause"]` populated from `ctx.last_low_output_cause` |
| Appears in human-readable summary | Done | `low_output_cause=<cause>` in summary when set |
| Context stores cause for callers | Done | `ctx.last_low_output_cause` set in `run_phase_with_retry` |
| Existing tests pass | Done | 1197 shepherd tests pass |

## Test plan

- [x] All 1197 shepherd tests pass (`pytest tests/shepherd/`)
- [x] Existing `test_diagnostics_summary_format` updated and passing
- [x] Low-output cause absent from summary when `None` (no false positives)