### PR TITLE
feat: standardize log timestamps to UTC ISO 8601 format

### DIFF
--- a/.loom/hooks/guard-destructive.sh
+++ b/.loom/hooks/guard-destructive.sh
@@ -28,7 +28,7 @@ log_hook_error() {
     local msg="$1"
     # Ensure log directory exists
     mkdir -p "$(dirname "$HOOK_ERROR_LOG")" 2>/dev/null || true
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] [guard-destructive] $msg" >> "$HOOK_ERROR_LOG" 2>/dev/null || true
+    echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] [guard-destructive] $msg" >> "$HOOK_ERROR_LOG" 2>/dev/null || true
 }
 
 # Top-level error trap: on ANY unexpected error, output valid JSON "allow"

--- a/.loom/hooks/guard-worktree-paths.sh
+++ b/.loom/hooks/guard-worktree-paths.sh
@@ -22,7 +22,7 @@ HOOK_ERROR_LOG="${MAIN_ROOT}/.loom/logs/hook-errors.log"
 
 log_hook_error() {
     mkdir -p "$(dirname "$HOOK_ERROR_LOG")" 2>/dev/null || true
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] [guard-worktree-paths] $1" >> "$HOOK_ERROR_LOG" 2>/dev/null || true
+    echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] [guard-worktree-paths] $1" >> "$HOOK_ERROR_LOG" 2>/dev/null || true
 }
 
 # Top-level error trap: on ANY unexpected error, allow to prevent infinite retry loops

--- a/defaults/hooks/guard-destructive.sh
+++ b/defaults/hooks/guard-destructive.sh
@@ -26,7 +26,7 @@ log_hook_error() {
     local msg="$1"
     # Ensure log directory exists
     mkdir -p "$(dirname "$HOOK_ERROR_LOG")" 2>/dev/null || true
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] [guard-destructive] $msg" >> "$HOOK_ERROR_LOG" 2>/dev/null || true
+    echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] [guard-destructive] $msg" >> "$HOOK_ERROR_LOG" 2>/dev/null || true
 }
 
 # Top-level error trap: on ANY unexpected error, output valid JSON "allow"

--- a/defaults/scripts/agent-destroy.sh
+++ b/defaults/scripts/agent-destroy.sh
@@ -28,11 +28,11 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
-log_info() { echo -e "${BLUE}[$(date '+%H:%M:%S')]${NC} $*" >&2; }
-log_success() { echo -e "${GREEN}[$(date '+%H:%M:%S')] ✓${NC} $*" >&2; }
+log_info() { echo -e "${BLUE}[$(date -u '+%Y-%m-%dT%H:%M:%SZ')]${NC} $*" >&2; }
+log_success() { echo -e "${GREEN}[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] ✓${NC} $*" >&2; }
 # shellcheck disable=SC2329  # log_warn kept for API consistency with other scripts
-log_warn() { echo -e "${YELLOW}[$(date '+%H:%M:%S')] ⚠${NC} $*" >&2; }
-log_error() { echo -e "${RED}[$(date '+%H:%M:%S')] ✗${NC} $*" >&2; }
+log_warn() { echo -e "${YELLOW}[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] ⚠${NC} $*" >&2; }
+log_error() { echo -e "${RED}[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] ✗${NC} $*" >&2; }
 
 # shellcheck disable=SC2120
 find_repo_root() {

--- a/defaults/scripts/spawn-shell-shepherd.sh
+++ b/defaults/scripts/spawn-shell-shepherd.sh
@@ -52,11 +52,11 @@ fi
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
 
-log_info() { echo -e "${BLUE}[$(date '+%H:%M:%S')]${NC} $*" >&2; }
-log_success() { echo -e "${GREEN}[$(date '+%H:%M:%S')] ✓${NC} $*" >&2; }
+log_info() { echo -e "${BLUE}[$(date -u '+%Y-%m-%dT%H:%M:%SZ')]${NC} $*" >&2; }
+log_success() { echo -e "${GREEN}[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] ✓${NC} $*" >&2; }
 # shellcheck disable=SC2329  # Standard logging helper, may be used in future
-log_warn() { echo -e "${YELLOW}[$(date '+%H:%M:%S')] ⚠${NC} $*" >&2; }
-log_error() { echo -e "${RED}[$(date '+%H:%M:%S')] ✗${NC} $*" >&2; }
+log_warn() { echo -e "${YELLOW}[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] ⚠${NC} $*" >&2; }
+log_error() { echo -e "${RED}[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] ✗${NC} $*" >&2; }
 
 # Find the repository root (works from any subdirectory including worktrees)
 find_repo_root() {

--- a/loom-tools/src/loom_tools/shepherd/phases/base.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/base.py
@@ -546,9 +546,9 @@ def _print_heartbeat(action: str) -> None:
     """Print a heartbeat status line to stderr.
 
     Uses dim/gray ANSI to differentiate from cyan phase headers.
-    Format: ``[HH:MM:SS] ⟳ action``
+    Format: ``[YYYY-MM-DDTHH:MM:SSZ] ⟳ action``
     """
-    ts = time.strftime("%H:%M:%S")
+    ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
     # \033[2m = dim, \033[0m = reset
     print(f"\033[2m[{ts}] \u27f3 {action}\033[0m", file=sys.stderr)
 


### PR DESCRIPTION
Closes #2600

## Summary

- Standardized all log timestamp formats across shell scripts and Python to use UTC ISO 8601 (`2026-02-17T09:20:46Z`)
- Shell scripts: replaced `date '+%H:%M:%S'` and `date '+%Y-%m-%d %H:%M:%S'` with `date -u '+%Y-%m-%dT%H:%M:%SZ'`
- Python heartbeat: replaced `time.strftime("%H:%M:%S")` with `time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())`

## Files Changed

| File | Old Format | New Format |
|------|-----------|------------|
| `defaults/scripts/agent-destroy.sh` | `%H:%M:%S` | `date -u '+%Y-%m-%dT%H:%M:%SZ'` |
| `defaults/scripts/spawn-shell-shepherd.sh` | `%H:%M:%S` | `date -u '+%Y-%m-%dT%H:%M:%SZ'` |
| `defaults/hooks/guard-destructive.sh` | `%Y-%m-%d %H:%M:%S` | `date -u '+%Y-%m-%dT%H:%M:%SZ'` |
| `.loom/hooks/guard-destructive.sh` | `%Y-%m-%d %H:%M:%S` | `date -u '+%Y-%m-%dT%H:%M:%SZ'` |
| `.loom/hooks/guard-worktree-paths.sh` | `%Y-%m-%d %H:%M:%S` | `date -u '+%Y-%m-%dT%H:%M:%SZ'` |
| `loom-tools/.../phases/base.py` | `%H:%M:%S` (local) | `%Y-%m-%dT%H:%M:%SZ` (UTC) |

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|-------------|
| Updated scripts produce UTC ISO 8601 timestamps | Pass | All `date` calls use `-u '+%Y-%m-%dT%H:%M:%SZ'` |
| shellcheck passes on modified scripts | Pass | Only pre-existing SC2016 info (unrelated) |
| No remaining non-standard patterns | Pass | `grep` for old patterns returns zero matches |
| `spawn-shell-shepherd.sh` internally consistent | Pass | All log functions now use same format |