### PR TITLE
fix: detect no-changes-needed marker even when accidentally committed

### DIFF
--- a/defaults/.claude/commands/builder.md
+++ b/defaults/.claude/commands/builder.md
@@ -325,6 +325,8 @@ echo "Bug is already fixed on main — verified by running the test suite" > .no
 
 The marker file should contain a brief explanation of why no changes are needed.
 
+**IMPORTANT: Do NOT commit the marker file.** Leave it as an untracked file in the worktree. The shepherd checks for the marker file on disk — if you `git add` and commit it, the commit shows as work done and defeats the detection mechanism.
+
 **Why this matters:** Without this marker file, the shepherd cannot distinguish between "builder deliberately decided no changes are needed" and "builder crashed/was killed before doing anything." An empty worktree without the marker is treated as a builder failure, not a deliberate decision.
 
 **Do NOT create this file if:**

--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -2828,6 +2828,24 @@ class BuilderPhase:
             )
             diag["commits_ahead"] = len(commits)
 
+            # Files changed in commits ahead of main (for fallback detection
+            # when builder accidentally commits the no-changes marker).
+            # See issue #2605.
+            if commits:
+                diff_res = subprocess.run(
+                    ["git", "-C", str(wt), "diff", "--name-only", "main..HEAD"],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                diag["committed_files"] = (
+                    [f for f in diff_res.stdout.splitlines() if f]
+                    if diff_res.returncode == 0 and diff_res.stdout.strip()
+                    else []
+                )
+            else:
+                diag["committed_files"] = []
+
             # Uncommitted changes (with file count for diagnostic prompts)
             status_res = subprocess.run(
                 ["git", "-C", str(wt), "status", "--porcelain"],
@@ -2854,6 +2872,7 @@ class BuilderPhase:
         else:
             diag["branch"] = None
             diag["commits_ahead"] = 0
+            diag["committed_files"] = []
             diag["has_uncommitted_changes"] = False
             diag["uncommitted_file_count"] = 0
             diag["artifact_file_count"] = 0
@@ -3281,16 +3300,31 @@ class BuilderPhase:
         if diag.get("main_branch_dirty", False):
             return False
 
-        # All indicators of work must be absent
+        # All indicators of work must be absent — but if the builder
+        # accidentally committed *only* the marker file, treat that as
+        # equivalent to no work done (defense-in-depth for issue #2605).
+        commits_ahead = diag.get("commits_ahead", 0)
+        committed_files = diag.get("committed_files", [])
+        only_marker_committed = (
+            commits_ahead > 0
+            and committed_files == [NO_CHANGES_MARKER]
+        )
+
         has_any_work = (
             diag.get("has_uncommitted_changes", False)
-            or diag.get("commits_ahead", 0) > 0
+            or (commits_ahead > 0 and not only_marker_committed)
             or diag.get("remote_branch_exists", False)
             or diag.get("pr_number") is not None
         )
 
         if has_any_work:
             return False
+
+        if only_marker_committed:
+            log_warning(
+                "Builder accidentally committed the .no-changes-needed marker "
+                "file — treating as 'no changes needed' anyway (issue #2605)"
+            )
 
         # Session quality gate: if the builder log shows too little output,
         # the session was degraded/failed and never actually analyzed the issue.


### PR DESCRIPTION
## Summary

- Builder role instructions now explicitly prohibit committing the `.no-changes-needed` marker file
- Shepherd's `_is_no_changes_needed()` has fallback logic: if the only committed file is the marker itself, it still correctly returns `True`
- Added `committed_files` diagnostic field to `_gather_diagnostics()` to support the fallback check

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Builder role instructions explicitly prohibit committing the marker file | Verified | Added explicit "Do NOT commit the marker file" warning in `defaults/.claude/commands/builder.md:327-328` |
| Shepherd detects marker even when accidentally committed | Verified | `_is_no_changes_needed()` now checks if only committed file is the marker; `test_only_marker_committed_with_marker_on_disk_returns_true` passes |
| Still correctly identifies real work alongside marker | Verified | `test_marker_plus_real_code_committed_returns_false` passes |
| Existing tests continue to pass | Verified | All 767 tests pass |
| New tests cover fallback detection | Verified | 6 new tests in `TestBuilderIsNoChangesNeededCommittedMarkerFallback` |

## Test plan

- [x] All existing `TestBuilderIsNoChangesNeeded` tests pass (8 tests)
- [x] All new fallback tests pass (6 tests covering: only-marker committed, marker+code committed, marker committed but removed from disk, marker with remote branch, insufficient output, real code without marker)
- [x] Integration tests pass (`TestBuilderNoChangesMarkerIntegration`, `TestBuilderMainBranchDirtyDetection`)
- [x] Full test suite: 767 passed

Closes #2605

🤖 Generated with [Claude Code](https://claude.com/claude-code)