### PR TITLE
fix: reject fallback approval when rejection signals also present

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/judge.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/judge.py
@@ -340,10 +340,21 @@ class JudgePhase:
         )
 
         has_approval = self._has_approval_comment(ctx)
+        has_rejection = self._has_rejection_comment(ctx)
         checks_ok = self._pr_checks_passing(ctx)
 
         if not has_approval:
             log_info("[force-mode] No approval comment found in PR — fallback denied")
+            return False
+
+        # Rejection signals override approval signals (issue #2598).
+        # When both are present (e.g., a checklist-style review with ✅ for
+        # passing items and ❌ for the overall verdict), this is a rejection.
+        if has_rejection:
+            log_info(
+                "[force-mode] Both approval and rejection signals found "
+                "— deferring to rejection fallback"
+            )
             return False
 
         if not checks_ok:


### PR DESCRIPTION
## Summary

Fixes #2598. When a judge review contains both approval signals (✅ in code quality checklists) and rejection signals (❌ Changes Requested), the force-mode fallback incorrectly fires the approval path first, causing rejected PRs to be auto-approved and merged with incomplete work.

## Changes

- **`loom-tools/src/loom_tools/shepherd/phases/judge.py`**: In `_try_fallback_approval()`, added a call to `_has_rejection_comment()` before returning True. When both approval and rejection signals are present, returns False to defer to the rejection fallback.
- **`loom-tools/tests/shepherd/test_phases.py`**: Added 2 new tests for the mixed-signal scenario, updated 5 existing tests to mock `_has_rejection_comment` (needed because `_try_fallback_approval` now calls it).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|-------------|
| Mixed signals (✅ + ❌) → rejection wins | ✅ | `test_fallback_approval_defers_when_both_approval_and_rejection_present` |
| Approval-only comments still work | ✅ | `test_fallback_activates_in_force_mode_with_approval_and_checks` (updated) |
| Rejection-only comments route to doctor | ✅ | `test_fallback_activates_in_force_mode_with_rejection_comment` (updated) |
| Direct `_try_fallback_approval` returns False on mixed | ✅ | `test_try_fallback_approval_returns_false_with_mixed_signals` |

## Test Plan

- [x] All 1221 shepherd tests pass
- [x] Unit test: mixed signals → rejection wins (via `run()` and direct method)
- [x] Unit test: approval-only still works
- [x] Unit test: rejection-only still routes to doctor

Closes #2598

🤖 Generated with [Claude Code](https://claude.com/claude-code)