### PR TITLE
fix: reject fallback approval when rejection signals also present

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/judge.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/judge.py
@@ -361,10 +361,21 @@ class JudgePhase:
         )
 
         has_approval = self._has_approval_comment(ctx)
+        has_rejection = self._has_rejection_comment(ctx)
         checks_ok = self._pr_checks_passing(ctx)
 
         if not has_approval:
             log_info("[force-mode] No approval comment found in PR — fallback denied")
+            return False
+
+        # Rejection signals override approval signals (issue #2598).
+        # When both are present (e.g., a checklist-style review with ✅ for
+        # passing items and ❌ for the overall verdict), this is a rejection.
+        if has_rejection:
+            log_info(
+                "[force-mode] Both approval and rejection signals found "
+                "— deferring to rejection fallback"
+            )
             return False
 
         if not checks_ok:

--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -5232,6 +5232,8 @@ class TestJudgeFallbackApproval:
         gh_run_results = [
             # _has_approval_comment: gh pr view --json comments
             MagicMock(returncode=0, stdout="LGTM, looks good!\n"),
+            # _has_rejection_comment: gh pr view --json comments (no rejection)
+            MagicMock(returncode=0, stdout="LGTM, looks good!\n"),
             # _pr_checks_passing: gh pr view --json statusCheckRollup,mergeable
             MagicMock(
                 returncode=0,
@@ -5351,6 +5353,7 @@ class TestJudgeFallbackApproval:
             ),
             patch("loom_tools.shepherd.phases.judge.time.sleep"),
             patch.object(judge, "_has_approval_comment", return_value=True),
+            patch.object(judge, "_has_rejection_comment", return_value=False),
             patch.object(judge, "_pr_checks_passing", return_value=True),
             patch(
                 "loom_tools.shepherd.phases.judge.subprocess.run",
@@ -5383,6 +5386,7 @@ class TestJudgeFallbackApproval:
             ),
             patch("loom_tools.shepherd.phases.judge.time.sleep"),
             patch.object(judge, "_has_approval_comment", return_value=True),
+            patch.object(judge, "_has_rejection_comment", return_value=False),
             patch.object(judge, "_pr_checks_passing", return_value=True),
             patch(
                 "loom_tools.shepherd.phases.judge.subprocess.run",
@@ -5411,6 +5415,7 @@ class TestJudgeFallbackApproval:
             ),
             patch("loom_tools.shepherd.phases.judge.time.sleep"),
             patch.object(judge, "_has_approval_comment", return_value=True),
+            patch.object(judge, "_has_rejection_comment", return_value=False),
             patch.object(judge, "_pr_checks_passing", return_value=True),
             patch(
                 "loom_tools.shepherd.phases.judge.subprocess.run",
@@ -5456,6 +5461,7 @@ class TestJudgeFallbackApproval:
             ),
             patch("loom_tools.shepherd.phases.judge.time.sleep"),
             patch.object(judge, "_has_approval_comment", return_value=True),
+            patch.object(judge, "_has_rejection_comment", return_value=False),
             patch.object(judge, "_pr_checks_passing", return_value=True),
             patch(
                 "loom_tools.shepherd.phases.judge.subprocess.run",
@@ -5482,6 +5488,89 @@ class TestJudgeFallbackApproval:
         # but the key assertion is that we succeed despite has_pr_label returning False.
         # Before the fix, this test would fail because the code would reach line 211
         # and call has_pr_label("loom:pr") which returns False, causing a failure.
+
+    def test_fallback_approval_defers_when_both_approval_and_rejection_present(
+        self, mock_context: MagicMock
+    ) -> None:
+        """Fallback approval should defer to rejection when both signals are present.
+
+        This is the core fix for issue #2598: when a judge review contains both
+        approval signals (e.g., ✅ in a code quality checklist) and rejection
+        signals (e.g., ❌ Changes Requested), the rejection must win. The
+        approval fallback should return False so the rejection fallback handles it.
+        """
+        ctx = self._make_force_context(mock_context)
+
+        judge = JudgePhase()
+
+        with (
+            patch.object(judge, "validate", return_value=False),
+            patch(
+                "loom_tools.shepherd.phases.judge.run_phase_with_retry", return_value=0
+            ),
+            patch("loom_tools.shepherd.phases.judge.time.sleep"),
+            # Both approval and rejection signals present
+            patch.object(judge, "_has_approval_comment", return_value=True),
+            patch.object(judge, "_has_rejection_comment", return_value=True),
+            patch.object(judge, "_pr_checks_passing", return_value=True),
+            # Rejection fallback applies loom:changes-requested
+            patch(
+                "loom_tools.shepherd.phases.judge.subprocess.run",
+                return_value=MagicMock(returncode=0),
+            ),
+        ):
+            result = judge.run(ctx)
+
+        # Should route to changes-requested, NOT approval
+        assert result.status == PhaseStatus.SUCCESS
+        assert result.data.get("changes_requested") is True
+        assert result.data.get("fallback_used") is True
+        assert "changes requested" in result.message.lower()
+
+    def test_try_fallback_approval_returns_false_with_mixed_signals(
+        self, mock_context: MagicMock
+    ) -> None:
+        """_try_fallback_approval should return False when rejection signals coexist.
+
+        Directly tests the fix for issue #2598: a checklist-style review with
+        ✅ items (code quality) and ❌ verdict triggers both approval and rejection
+        detection. The method must return False to let the rejection fallback handle it.
+        """
+        ctx = self._make_force_context(mock_context)
+
+        judge = JudgePhase()
+
+        mixed_comment = (
+            "❌ **Changes Requested**\n"
+            "\n"
+            "## Code Quality\n"
+            "✅ Shell scripts use `date -u` for UTC\n"
+            "✅ Proper error handling\n"
+            "\n"
+            "## Missing Work\n"
+            "- Script A not updated\n"
+            "- Script B not updated\n"
+        )
+
+        gh_run_results = [
+            # _has_approval_comment: gh pr view --json comments
+            MagicMock(returncode=0, stdout=mixed_comment),
+            # _has_rejection_comment: gh pr view --json comments
+            MagicMock(returncode=0, stdout=mixed_comment),
+            # _pr_checks_passing: gh pr view --json statusCheckRollup,mergeable
+            MagicMock(
+                returncode=0,
+                stdout=json.dumps({"mergeable": "MERGEABLE", "statusCheckRollup": []}),
+            ),
+        ]
+
+        with patch(
+            "loom_tools.shepherd.phases.judge.subprocess.run",
+            side_effect=gh_run_results,
+        ):
+            result = judge._try_fallback_approval(ctx)
+
+        assert result is False
 
 
 class TestJudgeDiagnostics:
@@ -6209,6 +6298,8 @@ class TestJudgeFallbackChangesRequested:
 
         gh_run_results = [
             # _try_fallback_approval -> _has_approval_comment: no approval
+            MagicMock(returncode=0, stdout="Changes requested\n"),
+            # _try_fallback_approval -> _has_rejection_comment
             MagicMock(returncode=0, stdout="Changes requested\n"),
             # _try_fallback_approval -> _pr_checks_passing
             MagicMock(


### PR DESCRIPTION
Closes #2598

## Summary

When both approval and rejection signals are present in PR comments (e.g., a checklist-style review with ✅ for passing items and ❌ for the overall verdict), the force-mode fallback approval logic incorrectly fires because it checks for approval signals before rejection signals. This causes rejected PRs to be auto-approved and merged with incomplete work.

## Changes

- **`loom-tools/src/loom_tools/shepherd/phases/judge.py`**: In `_try_fallback_approval()`, added a check for rejection signals (`_has_rejection_comment`) before returning approval. When both approval and rejection signals coexist, the method now returns `False`, deferring to the rejection fallback handler.

- **`loom-tools/tests/shepherd/test_phases.py`**: Added 2 new tests and updated existing tests:
  - `test_fallback_approval_defers_when_both_approval_and_rejection_present`: End-to-end test verifying that mixed signals route to changes-requested, not approval
  - `test_try_fallback_approval_returns_false_with_mixed_signals`: Unit test directly verifying the `_try_fallback_approval` method returns `False` with mixed signal comments
  - Updated existing fallback tests to mock `_has_rejection_comment` where needed

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Unit test: mock PR comments with both ✅ and ❌ signals, verify rejection wins | ✅ | `test_try_fallback_approval_returns_false_with_mixed_signals` passes |
| Unit test: approval-only comments still work | ✅ | Existing `test_fallback_approval_*` tests still pass (19 total) |
| Unit test: rejection-only comments still route to doctor | ✅ | `TestJudgeFallbackChangesRequested` tests pass |
| All 782 phase tests pass | ✅ | `pytest loom-tools/tests/shepherd/test_phases.py` — 782 passed |