### PR TITLE
fix: detect no-changes-needed marker even when accidentally committed

### DIFF
--- a/defaults/.claude/commands/builder.md
+++ b/defaults/.claude/commands/builder.md
@@ -325,6 +325,8 @@ echo "Bug is already fixed on main — verified by running the test suite" > .no
 
 The marker file should contain a brief explanation of why no changes are needed.
 
+**IMPORTANT: Do NOT commit the marker file.** Leave it as an untracked file in the worktree. The shepherd checks for the marker file on disk — if you `git add` and commit it, the commit shows as work done and defeats the detection mechanism.
+
 **Why this matters:** Without this marker file, the shepherd cannot distinguish between "builder deliberately decided no changes are needed" and "builder crashed/was killed before doing anything." An empty worktree without the marker is treated as a builder failure, not a deliberate decision.
 
 **Do NOT create this file if:**

--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -8693,6 +8693,105 @@ class TestBuilderIsNoChangesNeeded:
         assert builder._is_no_changes_needed(diag) is False
 
 
+class TestBuilderIsNoChangesNeededCommittedMarkerFallback:
+    """Test _is_no_changes_needed fallback when builder commits the marker file.
+
+    Issue #2605: if the builder accidentally commits .no-changes-needed,
+    commits_ahead > 0 would block detection.  The fallback checks whether
+    the *only* committed file is the marker itself and still returns True.
+    """
+
+    def test_only_marker_committed_with_marker_on_disk_returns_true(self) -> None:
+        """Marker committed as only file + marker on disk = no changes needed."""
+        builder = BuilderPhase()
+        diag = {
+            "worktree_exists": True,
+            "has_uncommitted_changes": False,
+            "commits_ahead": 1,
+            "committed_files": [".no-changes-needed"],
+            "remote_branch_exists": False,
+            "pr_number": None,
+            "log_cli_output_length": 1000,
+            "no_changes_marker_exists": True,
+        }
+        assert builder._is_no_changes_needed(diag) is True
+
+    def test_marker_plus_real_code_committed_returns_false(self) -> None:
+        """Marker committed alongside real code changes = real work done."""
+        builder = BuilderPhase()
+        diag = {
+            "worktree_exists": True,
+            "has_uncommitted_changes": False,
+            "commits_ahead": 1,
+            "committed_files": [".no-changes-needed", "src/main.py"],
+            "remote_branch_exists": False,
+            "pr_number": None,
+            "log_cli_output_length": 1000,
+            "no_changes_marker_exists": True,
+        }
+        assert builder._is_no_changes_needed(diag) is False
+
+    def test_only_marker_committed_but_no_marker_on_disk_returns_false(self) -> None:
+        """Marker committed but somehow removed from disk = no positive signal."""
+        builder = BuilderPhase()
+        diag = {
+            "worktree_exists": True,
+            "has_uncommitted_changes": False,
+            "commits_ahead": 1,
+            "committed_files": [".no-changes-needed"],
+            "remote_branch_exists": False,
+            "pr_number": None,
+            "log_cli_output_length": 1000,
+            "no_changes_marker_exists": False,
+        }
+        assert builder._is_no_changes_needed(diag) is False
+
+    def test_only_marker_committed_with_remote_branch_returns_false(self) -> None:
+        """Marker committed + remote branch pushed = too far along for fallback."""
+        builder = BuilderPhase()
+        diag = {
+            "worktree_exists": True,
+            "has_uncommitted_changes": False,
+            "commits_ahead": 1,
+            "committed_files": [".no-changes-needed"],
+            "remote_branch_exists": True,
+            "pr_number": None,
+            "log_cli_output_length": 1000,
+            "no_changes_marker_exists": True,
+        }
+        assert builder._is_no_changes_needed(diag) is False
+
+    def test_only_marker_committed_insufficient_output_returns_false(self) -> None:
+        """Marker committed but session too short = builder failure, not deliberate."""
+        builder = BuilderPhase()
+        diag = {
+            "worktree_exists": True,
+            "has_uncommitted_changes": False,
+            "commits_ahead": 1,
+            "committed_files": [".no-changes-needed"],
+            "remote_branch_exists": False,
+            "pr_number": None,
+            "log_cli_output_length": 50,
+            "no_changes_marker_exists": True,
+        }
+        assert builder._is_no_changes_needed(diag) is False
+
+    def test_real_code_committed_without_marker_returns_false(self) -> None:
+        """Real code committed without marker = normal work (no fallback)."""
+        builder = BuilderPhase()
+        diag = {
+            "worktree_exists": True,
+            "has_uncommitted_changes": False,
+            "commits_ahead": 2,
+            "committed_files": ["src/main.py", "tests/test_main.py"],
+            "remote_branch_exists": False,
+            "pr_number": None,
+            "log_cli_output_length": 1000,
+            "no_changes_marker_exists": False,
+        }
+        assert builder._is_no_changes_needed(diag) is False
+
+
 class TestBuilderStaleWorktreeRecovery:
     """Test stale worktree detection and recovery (issue #1995)."""
 


### PR DESCRIPTION
## Summary

- Builder role instructions now explicitly prohibit committing the `.no-changes-needed` marker file
- Shepherd's `_is_no_changes_needed()` has fallback logic: if the only committed file is the marker itself, it still correctly returns `True`
- Added `committed_files` diagnostic field to `_gather_diagnostics()` to support the fallback check

Closes #2605

## Test plan

- [x] 6 new unit tests for the committed-marker fallback covering: marker-only commit, marker+code commit, missing marker on disk, remote branch exists, insufficient output, and no marker at all
- [x] All existing `TestBuilderIsNoChangesNeeded` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)