### PR TITLE
fix: handle git rename entries in parse_porcelain_path

### DIFF
--- a/loom-tools/tests/test_porcelain_parsing.py
+++ b/loom-tools/tests/test_porcelain_parsing.py
@@ -22,9 +22,21 @@ class TestParsePorcelainPath:
     def test_quoted_path_with_spaces(self) -> None:
         assert parse_porcelain_path(' M "path with spaces/file"') == "path with spaces/file"
 
-    def test_rename_format(self) -> None:
-        # Callers split on " -> " further if needed
-        assert parse_porcelain_path("R  old -> new") == "old -> new"
+    def test_rename_returns_new_path(self) -> None:
+        assert parse_porcelain_path("R  old_name.py -> new_name.py") == "new_name.py"
+
+    def test_rename_with_directories(self) -> None:
+        assert parse_porcelain_path("R  src/old.py -> src/new.py") == "src/new.py"
+
+    def test_rename_with_quoted_paths(self) -> None:
+        assert (
+            parse_porcelain_path('R  "old name.py" -> "new name.py"')
+            == "new name.py"
+        )
+
+    def test_non_rename_with_arrow_in_path(self) -> None:
+        # A modified file whose name contains " -> " should not be split
+        assert parse_porcelain_path(" M file -> backup.py") == "file -> backup.py"
 
     def test_short_line(self) -> None:
         # "M " is not valid porcelain (2 chars < 3 min), falls through to strip


### PR DESCRIPTION
## Summary

- Fix `parse_porcelain_path` to extract only the destination path from git rename entries (`R  old -> new`), so callers using the result for `git add` or path matching get a valid file path instead of `old -> new`
- Only applies to lines where the status code starts with `R`; non-rename lines with `->` in the filename are unaffected
- Adds test coverage for rename scenarios (simple, with directories, with quoted paths) and a guard test for arrow-in-filename edge case

Closes #2587

## Test plan

- [x] All 17 `test_porcelain_parsing.py` tests pass
- [ ] Judge review

🤖 Generated with [Claude Code](https://claude.com/claude-code)