### PR TITLE
fix: tolerate non-critical MCP server failures in startup monitor

### DIFF
--- a/defaults/scripts/claude-wrapper.sh
+++ b/defaults/scripts/claude-wrapper.sh
@@ -824,6 +824,16 @@ start_startup_monitor() {
                     break
                 fi
 
+                # Check if the critical "loom" MCP server connected successfully.
+                # If it did, the failure is a non-critical server (e.g. stale sphere
+                # config) and the session can continue working.
+                local debug_log="${CLAUDE_CONFIG_DIR:-}/debug/latest"
+                if [[ -L "${debug_log}" || -f "${debug_log}" ]] && \
+                   grep -q 'MCP server "loom": Successfully connected' "${debug_log}" 2>/dev/null; then
+                    log_warn "Startup monitor: loom MCP server OK despite other MCP failures — continuing"
+                    break
+                fi
+
                 log_warn "Startup monitor: killing degraded CLI session for retry"
                 pkill -INT -P $$ -f "claude" 2>/dev/null || true
                 break


### PR DESCRIPTION
## Summary

- The startup monitor in `claude-wrapper.sh` killed builder sessions whenever **any** MCP server failed to start, even non-critical ones (e.g. a stale `sphere` config in `~/.claude.json`)
- Now checks the Claude Code debug log (`$CLAUDE_CONFIG_DIR/debug/latest`) after detecting a failure to verify whether the critical `loom` MCP server connected successfully
- If loom is OK: logs a warning and lets the session continue
- If loom failed or debug log unavailable: kills as before (existing behavior preserved)

Discovered while working on #2608

## Test plan

- [ ] Run `/shepherd 2608 -m` with a stale sphere MCP config present — builder should no longer be killed
- [ ] Verify the log shows the "loom MCP server OK despite other MCP failures" warning
- [ ] Verify that if the loom server itself fails, the session is still killed and retried

🤖 Generated with [Claude Code](https://claude.com/claude-code)
