### PR TITLE
fix: prioritize claim check and add logging in orphan recovery

### DIFF
--- a/loom-tools/src/loom_tools/claim.py
+++ b/loom-tools/src/loom_tools/claim.py
@@ -282,29 +282,6 @@ def release_claim(
     return 0
 
 
-def has_valid_claim(repo_root: pathlib.Path, issue_number: int) -> bool:
-    """Check if an issue has a valid (non-expired) claim.
-
-    This is a non-mutating check suitable for use by other modules
-    (e.g., orphan recovery) to determine if an issue is actively claimed
-    before taking recovery actions.
-
-    Returns:
-        True if a non-expired claim exists for the issue, False otherwise.
-    """
-    claim_dir = _get_claim_dir(repo_root, issue_number)
-    claim_file = claim_dir / "claim.json"
-
-    if not claim_dir.exists() or not claim_file.exists():
-        return False
-
-    existing = _read_claim(claim_file)
-    if not existing:
-        return False
-
-    return not _is_expired(existing.expires_at)
-
-
 def check_claim(repo_root: pathlib.Path, issue_number: int) -> int:
     """Check if an issue is claimed and print claim metadata.
 


### PR DESCRIPTION
## Summary

- Reorders `check_untracked_building()` to check file-based claims **first** (local, no API call) before the label-age grace period check (requires GitHub API), making the most reliable protection the primary one
- Adds warning logs to all failure paths in `_get_building_label_age()` so label-age check bypasses are no longer silent
- Removes duplicate `has_valid_claim()` definition in `claim.py`

## Test plan

- [x] All 111 existing + 6 new orphan recovery tests pass
- [x] All 39 claim tests pass
- [x] New `TestGetBuildingLabelAgeLogging` tests verify warnings are emitted on each failure path
- [x] New `TestClaimCheckOrdering` tests verify claim check short-circuits before API call

Closes #2589

🤖 Generated with [Claude Code](https://claude.com/claude-code)