### PR TITLE
feat: detect degraded builder sessions early (rate limits, Crystallizing loops)

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/base.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/base.py
@@ -95,6 +95,30 @@ MCP_FAILURE_BACKOFF_SECONDS = [5, 15, 30]
 GHOST_SESSION_MAX_RETRIES = 3
 GHOST_SESSION_RETRY_DELAY_SECONDS = 5
 
+# Degraded session detection patterns.
+# These appear in Claude CLI output when the session is running under
+# rate limits or has entered a non-productive loop (e.g., "Crystallizing..."
+# repeated).  A degraded session produces no useful work and should be
+# aborted early rather than waiting for the full timeout.  See issue #2631.
+DEGRADED_SESSION_PATTERNS = [
+    # Rate limit warnings embedded in Claude CLI output
+    re.compile(r"You've used \d+% of your weekly limit", re.IGNORECASE),
+    # Crystallizing loop — Claude's extended thinking under resource pressure
+    re.compile(r"Crystallizing", re.IGNORECASE),
+]
+
+# Minimum number of "Crystallizing" occurrences in the last N lines
+# to classify a session as degraded (a single occurrence during normal
+# thinking is not concerning).
+DEGRADED_CRYSTALLIZING_THRESHOLD = 5
+
+# Minimum lines of log tail to scan for degraded session patterns.
+DEGRADED_SCAN_TAIL_LINES = 100
+
+# How often (in seconds) to scan the log for degradation during polling.
+# Must be a multiple of _HEARTBEAT_POLL_INTERVAL for alignment.
+_DEGRADED_SCAN_INTERVAL = 30
+
 # Systemic failure patterns detected in session logs.
 # These indicate infrastructure-level failures (auth timeout, API outage)
 # that will NOT resolve with retries.  When detected after a low-output
@@ -783,6 +807,101 @@ def _is_ghost_session(log_path: Path) -> bool:
         return False
 
 
+def _is_degraded_session(log_path: Path) -> bool:
+    """Check if a session log indicates a degraded session (rate limits, Crystallizing loops).
+
+    A degraded session is one where the builder ran but produced no useful work
+    because it was resource-constrained.  This manifests as:
+    - Rate limit warnings ("You've used 87% of your weekly limit")
+    - Repeated "Crystallizing..." output (Claude's extended thinking under pressure)
+
+    Degraded sessions are distinct from low-output sessions (which never started)
+    and stuck sessions (which started but stopped making progress).  A degraded
+    session actively produces output but the output is non-productive.
+
+    Detection requires BOTH:
+    1. A rate limit warning in the log, AND
+    2. Excessive "Crystallizing" repetitions (>= DEGRADED_CRYSTALLIZING_THRESHOLD)
+
+    This two-signal approach prevents false positives: a single rate limit warning
+    during an otherwise productive session is harmless, and brief "Crystallizing"
+    during normal thinking is expected.  The combination indicates the session has
+    entered a non-recoverable degraded state.  See issue #2631.
+
+    Args:
+        log_path: Path to the worker session log file.
+
+    Returns:
+        True if the session shows signs of degradation.
+    """
+    if not log_path.is_file():
+        return False
+
+    try:
+        content = log_path.read_text()
+        stripped = strip_ansi(content)
+        cli_output = _get_cli_output(stripped)
+        if not cli_output:
+            return False
+
+        # Signal 1: Rate limit warning present
+        has_rate_limit = bool(DEGRADED_SESSION_PATTERNS[0].search(cli_output))
+        if not has_rate_limit:
+            return False
+
+        # Signal 2: Excessive Crystallizing repetitions
+        lines = cli_output.splitlines()
+        tail = lines[-DEGRADED_SCAN_TAIL_LINES:]
+        crystallizing_count = sum(
+            1 for line in tail if DEGRADED_SESSION_PATTERNS[1].search(line)
+        )
+        return crystallizing_count >= DEGRADED_CRYSTALLIZING_THRESHOLD
+
+    except OSError:
+        return False
+
+
+def _scan_log_for_degradation(log_path: Path) -> bool:
+    """Quick scan of a live log file for degradation patterns.
+
+    This is a lighter-weight version of ``_is_degraded_session()`` designed
+    for in-flight polling during ``run_worker_phase()``.  It reads only the
+    tail of the file to minimize I/O overhead.
+
+    Returns True if the log shows both rate limit warnings and excessive
+    "Crystallizing" repetitions.  See issue #2631.
+    """
+    if not log_path.is_file():
+        return False
+
+    try:
+        # Read only the tail to minimize I/O during polling
+        with open(log_path, "rb") as f:
+            f.seek(0, 2)
+            file_size = f.tell()
+            # Read last ~10KB (enough for DEGRADED_SCAN_TAIL_LINES of output)
+            start_pos = max(0, file_size - 10_000)
+            f.seek(start_pos)
+            content = f.read().decode("utf-8", errors="replace")
+
+        stripped = strip_ansi(content)
+        lines = stripped.splitlines()
+        tail = lines[-DEGRADED_SCAN_TAIL_LINES:]
+        text = "\n".join(tail)
+
+        has_rate_limit = bool(DEGRADED_SESSION_PATTERNS[0].search(text))
+        if not has_rate_limit:
+            return False
+
+        crystallizing_count = sum(
+            1 for line in tail if DEGRADED_SESSION_PATTERNS[1].search(line)
+        )
+        return crystallizing_count >= DEGRADED_CRYSTALLIZING_THRESHOLD
+
+    except OSError:
+        return False
+
+
 def _classify_low_output_cause(log_path: Path) -> str:
     """Classify the root cause of a low-output session from the worker log.
 
@@ -863,6 +982,7 @@ def run_worker_phase(
         - 8: Planning stall detected (stuck in planning checkpoint)
         - 9: Auth pre-flight failure (not retryable, see issue #2508)
         - 10: Ghost session detected (instant exit, no work — see issue #2604)
+        - 11: Degraded session detected (rate limits + Crystallizing loop, see issue #2631)
         - Other: Error
     """
     scripts_dir = ctx.scripts_dir
@@ -984,6 +1104,11 @@ def run_worker_phase(
     # If it stays there beyond planning_timeout, terminate the worker.
     _planning_first_seen: float | None = None
 
+    # Degraded session detection state (issue #2631).
+    # Periodically scan the log for rate limit + Crystallizing patterns
+    # and abort early rather than waiting for the full timeout.
+    _last_degraded_scan: float = time.monotonic()
+
     while wait_proc.poll() is None:
         heartbeats = _read_heartbeats(progress_file, phase=phase)
         for hb in heartbeats[seen_heartbeats:]:
@@ -1028,6 +1153,35 @@ def run_worker_phase(
             else:
                 # Checkpoint advanced past planning (or doesn't exist yet)
                 _planning_first_seen = None
+
+        # In-flight degraded session detection (issue #2631).
+        # Periodically scan the log for rate limit + Crystallizing patterns.
+        # Abort early to avoid wasting the entire builder time budget on a
+        # session that will never produce useful output.
+        degraded_elapsed = time.monotonic() - _last_degraded_scan
+        if degraded_elapsed >= _DEGRADED_SCAN_INTERVAL:
+            _last_degraded_scan = time.monotonic()
+            degraded_log_path = LoomPaths(ctx.repo_root).worker_log_file(
+                role, ctx.config.issue
+            )
+            if _scan_log_for_degradation(degraded_log_path):
+                log_warning(
+                    f"Degraded session detected: {role} session '{name}' "
+                    f"shows rate limit warnings and Crystallizing loop, "
+                    f"terminating early (log: {degraded_log_path})"
+                )
+                wait_proc.terminate()
+                wait_proc.wait(timeout=30)
+                destroy_script = scripts_dir / "agent-destroy.sh"
+                if destroy_script.is_file():
+                    subprocess.run(
+                        [str(destroy_script), name, "--force"],
+                        cwd=ctx.repo_root,
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                        check=False,
+                    )
+                return 11  # Degraded session
 
         time.sleep(_HEARTBEAT_POLL_INTERVAL)
 
@@ -1088,6 +1242,20 @@ def run_worker_phase(
         )
         return 10
 
+    # Check for degraded session (exit code 11) — rate limits + Crystallizing.
+    # Degraded sessions produce output but it's non-productive garbage.
+    # This is NOT retryable: the underlying resource constraint (rate limits)
+    # will persist until the limit resets.  Check before MCP/low-output
+    # because degraded sessions may have substantial output volume.
+    # See issue #2631.
+    if _is_degraded_session(log_path):
+        log_warning(
+            f"Degraded session detected for {role} session '{name}': "
+            f"rate limit warnings and Crystallizing loop "
+            f"(exit code {wait_exit}, log: {log_path})"
+        )
+        return 11
+
     # Check for MCP failure (exit code 7) — more specific than low-output,
     # with different retry/backoff strategy.  See issues #2135, #2279.
     if wait_exit != 0 and _is_mcp_failure(log_path):
@@ -1133,6 +1301,8 @@ def run_phase_with_retry(
     times with longer backoff (MCP failures are often systemic).
     On exit code 8 (planning stall), returns immediately (not retryable).
     On exit code 9 (auth failure), returns immediately (not retryable).
+    On exit code 11 (degraded session), returns immediately (not retryable;
+    rate limits won't resolve with retries).  See issue #2631.
     On exit code 10 (ghost session), retries up to GHOST_SESSION_MAX_RETRIES
     times on a **separate** budget that does not deplete the main retry
     counters.  Ghost sessions are infrastructure failures (0s duration,
@@ -1148,7 +1318,8 @@ def run_phase_with_retry(
         Exit code: 0=success, 3=shutdown, 4=stuck after retries,
                    6=low-output after retries, 7=MCP failure after retries,
                    8=planning stall, 9=auth failure,
-                   10=ghost session after retries, other=error
+                   10=ghost session after retries,
+                   11=degraded session, other=error
     """
     stuck_retries = 0
     low_output_retries = 0
@@ -1183,6 +1354,14 @@ def run_phase_with_retry(
         # attempt with zero chance of success.  See issue #2508.
         if exit_code == 9:
             return 9
+
+        # --- Degraded session (exit code 11) ---
+        # Not retryable: the builder session was degraded by rate limits
+        # and entered a Crystallizing loop.  The underlying rate limit
+        # won't resolve with retries — the daemon should back off or
+        # pick a different issue.  See issue #2631.
+        if exit_code == 11:
+            return 11
 
         # --- Pre-retry approval check (judge phase only) ---
         # If the judge already completed its work (applied loom:pr or

--- a/loom-tools/tests/shepherd/test_degraded_session_detection.py
+++ b/loom-tools/tests/shepherd/test_degraded_session_detection.py
@@ -1,0 +1,217 @@
+"""Tests for degraded session detection (issue #2631).
+
+Tests the detection of builder sessions running under rate limits that enter
+a non-productive Crystallizing loop.  Detection requires BOTH:
+1. A rate limit warning ("You've used X% of your weekly limit")
+2. Excessive "Crystallizing..." repetitions (>= threshold)
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from loom_tools.shepherd.config import ShepherdConfig
+from loom_tools.shepherd.context import ShepherdContext
+from loom_tools.shepherd.phases.base import (
+    DEGRADED_CRYSTALLIZING_THRESHOLD,
+    DEGRADED_SCAN_TAIL_LINES,
+    _is_degraded_session,
+    _scan_log_for_degradation,
+)
+from loom_tools.shepherd.phases.builder import BuilderPhase, PhaseStatus
+
+
+# ---------------------------------------------------------------------------
+# Fixtures & helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_log(tmp_path: Path) -> Path:
+    """Return a path for a temporary log file."""
+    return tmp_path / "loom-builder-issue-42.log"
+
+
+def _write_log(log_path: Path, content: str) -> None:
+    """Write log content with the CLI start sentinel."""
+    log_path.write_text(f"# CLAUDE_CLI_START\n{content}")
+
+
+def _make_degraded_log(
+    *,
+    rate_limit_pct: int = 87,
+    crystallizing_count: int = DEGRADED_CRYSTALLIZING_THRESHOLD,
+    extra_lines: str = "",
+) -> str:
+    """Build a realistic degraded session log body."""
+    lines = [
+        f"You've used {rate_limit_pct}% of your weekly limit · resets Feb 20 at 11am",
+    ]
+    if extra_lines:
+        lines.append(extra_lines)
+    lines.extend(["Crystallizing…"] * crystallizing_count)
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# _is_degraded_session tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsDegradedSession:
+    """Test _is_degraded_session() post-session detection."""
+
+    def test_degraded_with_both_signals(self, tmp_log: Path) -> None:
+        """Rate limit + Crystallizing above threshold → degraded."""
+        _write_log(tmp_log, _make_degraded_log())
+        assert _is_degraded_session(tmp_log) is True
+
+    def test_not_degraded_without_rate_limit(self, tmp_log: Path) -> None:
+        """Crystallizing alone without rate limit warning → not degraded."""
+        content = "\n".join(
+            ["Crystallizing…"] * (DEGRADED_CRYSTALLIZING_THRESHOLD + 5)
+        )
+        _write_log(tmp_log, content)
+        assert _is_degraded_session(tmp_log) is False
+
+    def test_not_degraded_with_few_crystallizing(self, tmp_log: Path) -> None:
+        """Rate limit warning + few Crystallizing → not degraded."""
+        content = _make_degraded_log(
+            crystallizing_count=DEGRADED_CRYSTALLIZING_THRESHOLD - 1
+        )
+        _write_log(tmp_log, content)
+        assert _is_degraded_session(tmp_log) is False
+
+    def test_not_degraded_on_normal_session(self, tmp_log: Path) -> None:
+        """Normal productive session → not degraded."""
+        _write_log(
+            tmp_log,
+            "Read tool output...\nEdit tool applied...\nTests passed\n",
+        )
+        assert _is_degraded_session(tmp_log) is False
+
+    def test_not_degraded_on_missing_file(self, tmp_log: Path) -> None:
+        """Missing log file → not degraded."""
+        assert _is_degraded_session(tmp_log) is False
+
+    def test_not_degraded_on_empty_file(self, tmp_log: Path) -> None:
+        """Empty log file → not degraded."""
+        tmp_log.write_text("")
+        assert _is_degraded_session(tmp_log) is False
+
+    def test_not_degraded_without_sentinel(self, tmp_log: Path) -> None:
+        """Log without CLI start sentinel → not degraded (CLI never started)."""
+        tmp_log.write_text(
+            _make_degraded_log(crystallizing_count=20)
+        )
+        assert _is_degraded_session(tmp_log) is False
+
+    def test_exact_threshold_is_degraded(self, tmp_log: Path) -> None:
+        """Exactly at Crystallizing threshold → degraded."""
+        content = _make_degraded_log(
+            crystallizing_count=DEGRADED_CRYSTALLIZING_THRESHOLD
+        )
+        _write_log(tmp_log, content)
+        assert _is_degraded_session(tmp_log) is True
+
+    def test_rate_limit_with_different_percentages(self, tmp_log: Path) -> None:
+        """Different rate limit percentages should all trigger detection."""
+        for pct in (50, 75, 87, 99):
+            _write_log(tmp_log, _make_degraded_log(rate_limit_pct=pct))
+            assert _is_degraded_session(tmp_log) is True, f"Failed for {pct}%"
+
+
+# ---------------------------------------------------------------------------
+# _scan_log_for_degradation tests (in-flight polling variant)
+# ---------------------------------------------------------------------------
+
+
+class TestScanLogForDegradation:
+    """Test _scan_log_for_degradation() for in-flight log scanning."""
+
+    def test_detects_degradation(self, tmp_log: Path) -> None:
+        """Detects degradation from log tail during polling."""
+        _write_log(tmp_log, _make_degraded_log(crystallizing_count=10))
+        assert _scan_log_for_degradation(tmp_log) is True
+
+    def test_no_degradation_in_normal_log(self, tmp_log: Path) -> None:
+        """Normal log does not trigger degradation."""
+        _write_log(tmp_log, "Working on feature...\nEdit applied.\nTests pass.\n")
+        assert _scan_log_for_degradation(tmp_log) is False
+
+    def test_no_degradation_without_rate_limit(self, tmp_log: Path) -> None:
+        """Crystallizing without rate limit in tail → not degraded."""
+        content = "\n".join(["Crystallizing…"] * 20)
+        _write_log(tmp_log, content)
+        assert _scan_log_for_degradation(tmp_log) is False
+
+    def test_handles_missing_file(self, tmp_log: Path) -> None:
+        """Missing file returns False without error."""
+        assert _scan_log_for_degradation(tmp_log) is False
+
+
+# ---------------------------------------------------------------------------
+# Builder phase exit code 11 handling
+# ---------------------------------------------------------------------------
+
+
+class TestBuilderDegradedSessionHandling:
+    """Test BuilderPhase handling of exit code 11 (degraded session)."""
+
+    @pytest.fixture
+    def mock_context(self) -> MagicMock:
+        ctx = MagicMock(spec=ShepherdContext)
+        ctx.config = ShepherdConfig(issue=42)
+        ctx.repo_root = Path("/fake/repo")
+        ctx.scripts_dir = Path("/fake/repo/.loom/scripts")
+        ctx.worktree_path = MagicMock()
+        ctx.worktree_path.is_dir.return_value = True
+        ctx.worktree_path.name = "issue-42"
+        ctx.worktree_path.__str__ = lambda self: "/fake/repo/.loom/worktrees/issue-42"
+        ctx.pr_number = None
+        ctx.label_cache = MagicMock()
+        ctx.check_shutdown.return_value = False
+        return ctx
+
+    def test_exit_code_11_returns_failed_with_degraded_flag(
+        self, mock_context: MagicMock
+    ) -> None:
+        """Exit code 11 should produce a FAILED result with degraded_session=True."""
+        builder = BuilderPhase()
+
+        with patch(
+            "loom_tools.shepherd.phases.builder.run_phase_with_retry",
+            return_value=11,
+        ), patch(
+            "loom_tools.shepherd.phases.builder.transition_issue_labels",
+        ), patch(
+            "loom_tools.shepherd.phases.builder.get_pr_for_issue",
+            return_value=None,
+        ), patch(
+            "loom_tools.shepherd.phases.builder.validate_issue_quality_with_gates",
+            return_value=None,
+        ), patch.object(
+            builder, "_is_rate_limited", return_value=False
+        ), patch.object(
+            builder, "_cleanup_stale_worktree",
+        ), patch.object(
+            builder, "_snapshot_main_dirty", return_value=set()
+        ), patch.object(
+            builder, "_run_quality_validation", return_value=None
+        ), patch.object(
+            builder, "_run_reproducibility_check", return_value=None
+        ), patch.object(
+            builder, "_get_log_path",
+            return_value=Path("/fake/logs/builder-42.log"),
+        ):
+            result = builder.run(mock_context)
+
+        assert result.status == PhaseStatus.FAILED
+        assert result.data.get("degraded_session") is True
+        assert result.data.get("exit_code") == 11
+        assert "rate limit" in result.message.lower()
+        assert "crystallizing" in result.message.lower()


### PR DESCRIPTION
Closes #2631

## Summary

- Add degraded session detection to the builder phase that identifies when a Claude CLI session is running under rate limits and enters a non-productive "Crystallizing" loop
- Detection requires both signals: a rate limit warning AND excessive Crystallizing repetitions (>= 5 in last 100 lines)
- In-flight polling scans the log every 30 seconds during builder execution for early abort
- Post-session detection catches degraded sessions on process exit
- Exit code 11 is not retryable (rate limits won't resolve with retries)
- Diagnostics enriched with degradation pattern metrics

## Test plan

- [x] 14 unit tests covering detection functions and builder phase exit code 11 handling
- [x] Full Python test suite passes (3327 passed)
- [x] Rust tests pass
- [x] Lint and clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)