### PR TITLE
fix: index.html lint errors blocking shepherd

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,11 +15,11 @@
           </div>
         </div>
         <div class="flex items-center gap-2">
-          <button id="theme-toggle" class="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded" aria-label="Toggle theme">
+          <button type="button" id="theme-toggle" class="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded" aria-label="Toggle theme">
             <span id="theme-icon">🌓</span>
           </button>
-          <button id="close-workspace-btn" class="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded text-gray-600 dark:text-gray-400 hover:text-red-500 dark:hover:text-red-400" aria-label="Close workspace" title="Close Workspace">
-            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <button type="button" id="close-workspace-btn" class="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded text-gray-600 dark:text-gray-400 hover:text-red-500 dark:hover:text-red-400" aria-label="Close workspace" title="Close Workspace">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" role="img" aria-label="Close">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
             </svg>
           </button>


### PR DESCRIPTION
## Summary
- Add `type="button"` to theme toggle and close workspace buttons
- Add `role="img" aria-label="Close"` to close workspace SVG icon

Fixes 3 biome lint errors that were causing shepherd baseline tests to fail.

## Test plan
- [x] `pnpm lint` passes