### PR TITLE
fix: replace stale gh pr review instructions with comment-based workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,8 +177,10 @@ gh pr create --label "loom:review-requested"
 
 1. Find PR: `gh pr list --label="loom:review-requested"`
 2. Review: `gh pr checkout 123`
-3. Approve: `gh pr review 123 --approve && gh pr edit 123 --remove-label "loom:review-requested" --add-label "loom:pr"`
-4. Or request changes: `gh pr review 123 --request-changes --body "Feedback"`
+3. Approve: `gh pr comment 123 --body "LGTM! Approved." && gh pr edit 123 --remove-label "loom:review-requested" --add-label "loom:pr"`
+4. Or request changes: `gh pr comment 123 --body "Changes needed: ..." && gh pr edit 123 --remove-label "loom:review-requested" --add-label "loom:changes-requested"`
+
+**Note**: Use `gh pr comment` instead of `gh pr review --approve` — GitHub's API prevents self-review, and Loom agents often create and review the same PR. Labels are the coordination mechanism.
 
 ### Curator Workflow
 

--- a/defaults/.claude/agents/loom-judge.md
+++ b/defaults/.claude/agents/loom-judge.md
@@ -16,8 +16,8 @@ Follow the complete role definition in `.loom/roles/judge.md` for:
 - **Verifying CI passes** with `gh pr checks` before approval (REQUIRED)
 - **Checking merge state** with `gh pr view --json mergeStateStatus` (must be CLEAN)
 - Code quality and security assessment
-- Approval workflow: `gh pr review --approve`, update labels (remove `loom:review-requested`, add `loom:pr`)
-- Change request workflow: `gh pr review --request-changes`, update labels (remove `loom:review-requested`, add `loom:changes-requested`)
+- Approval workflow: `gh pr comment` with feedback, then update labels (remove `loom:review-requested`, add `loom:pr`)
+- Change request workflow: `gh pr comment` with feedback, then update labels (remove `loom:review-requested`, add `loom:changes-requested`)
 - Providing specific, actionable feedback
 
-Use label-based reviews (comment + label changes) rather than GitHub's review API for self-approval compatibility.
+**Important**: Use `gh pr comment` + label changes — never `gh pr review --approve` or `--request-changes` (GitHub API prevents self-review, and Loom agents share the same account).

--- a/defaults/.loom/CLAUDE.md
+++ b/defaults/.loom/CLAUDE.md
@@ -286,15 +286,15 @@ gh pr create --label "loom:review-requested"
    # Review code, run tests, check for issues
    ```
 
-3. **Provide feedback**:
+3. **Provide feedback** (use comments + labels, not `gh pr review` which fails with self-review restriction):
    ```bash
    # If changes needed:
-   gh pr review 123 --request-changes --body "Feedback here"
-   gh pr edit 123 --remove-label "loom:review-requested"
+   gh pr comment 123 --body "Changes needed: ..." && \
+     gh pr edit 123 --remove-label "loom:review-requested" --add-label "loom:changes-requested"
 
    # If approved:
-   gh pr review 123 --approve
-   gh pr edit 123 --remove-label "loom:review-requested" --add-label "loom:pr"
+   gh pr comment 123 --body "LGTM! Approved." && \
+     gh pr edit 123 --remove-label "loom:review-requested" --add-label "loom:pr"
    ```
 
 ### As a Curator (Autonomous or Manual)

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -538,15 +538,15 @@ If you need to clean up worktrees:
    # Review code, run tests, check for issues
    ```
 
-3. **Provide feedback**:
+3. **Provide feedback** (use comments + labels, not `gh pr review` which fails with self-review restriction):
    ```bash
    # If changes needed:
-   gh pr review 123 --request-changes --body "Feedback here"
-   gh pr edit 123 --remove-label "loom:review-requested"
+   gh pr comment 123 --body "Changes needed: ..." && \
+     gh pr edit 123 --remove-label "loom:review-requested" --add-label "loom:changes-requested"
 
    # If approved:
-   gh pr review 123 --approve
-   gh pr edit 123 --remove-label "loom:review-requested" --add-label "loom:pr"
+   gh pr comment 123 --body "LGTM! Approved." && \
+     gh pr edit 123 --remove-label "loom:review-requested" --add-label "loom:pr"
    ```
 
 ### As a Curator (Autonomous or Manual)

--- a/defaults/roles/judge.json
+++ b/defaults/roles/judge.json
@@ -3,7 +3,7 @@
   "description": "Reviews PRs labeled loom:review-requested",
   "suggestedModel": "opus",
   "defaultInterval": 300000,
-  "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are a Code Review Specialist. Check `gh pr list --label=\"loom:review-requested\"` for PRs needing review. For each PR: check out branch, run `pnpm check:ci`, review code thoroughly. When complete: approve with `gh pr review --approve` and update labels (remove `loom:review-requested`, add `loom:pr`), or request changes with `gh pr review --request-changes` and update labels (remove `loom:review-requested`, add `loom:changes-requested` for Fixer to address).",
+  "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are a Code Review Specialist. Check `gh pr list --label=\"loom:review-requested\"` for PRs needing review. For each PR: check out branch, run `pnpm check:ci`, review code thoroughly. When complete: post feedback with `gh pr comment` and update labels — approve by adding `loom:pr` (remove `loom:review-requested`), or request changes by adding `loom:changes-requested` (remove `loom:review-requested`). Do NOT use `gh pr review --approve` (fails with self-review restriction).",
   "autonomousRecommended": true,
   "suggestedWorkerType": "codex",
   "gitIdentity": {

--- a/docs/guides/quickstart-tutorial.md
+++ b/docs/guides/quickstart-tutorial.md
@@ -232,7 +232,7 @@ Please review PR #43
 If everything looks good, the Judge will:
 
 ```bash
-gh pr review 43 --approve --body "LGTM!
+gh pr comment 43 --body "LGTM!
 
 ✅ Code follows project conventions
 ✅ Tests pass
@@ -240,6 +240,8 @@ gh pr review 43 --approve --body "LGTM!
 
 gh pr edit 43 --remove-label "loom:review-requested" --add-label "loom:pr"
 ```
+
+> **Note**: Loom uses `gh pr comment` instead of `gh pr review --approve` because GitHub's API prevents self-review when the same account creates and reviews PRs. The `loom:pr` label is the coordination mechanism for approval.
 
 **Label transition:**
 ```

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -152,12 +152,12 @@ gh pr list --label="loom:review-requested"
 gh pr checkout 50
 pnpm check:all
 
-# Approve (green → blue)
-gh pr review 50 --approve
+# Approve (green → blue) — use comment + label, not gh pr review (self-review restriction)
+gh pr comment 50 --body "LGTM! Approved."
 gh pr edit 50 --remove-label "loom:review-requested" --add-label "loom:pr"
 
 # Request changes (green → amber)
-gh pr review 50 --request-changes
+gh pr comment 50 --body "Changes needed: ..."
 gh pr edit 50 --remove-label "loom:review-requested" --add-label "loom:changes-requested"
 ```
 


### PR DESCRIPTION
## Summary

- Replace `gh pr review --approve` / `--request-changes` with `gh pr comment` + label changes in 7 documentation files
- GitHub's API prevents self-review, and Loom agents often create and review the same PR
- The judge.md role definition already documented the correct workaround, but these files were inconsistent

### Files updated
- `defaults/roles/judge.json` — `defaultIntervalPrompt` (the autonomous agent prompt)
- `defaults/CLAUDE.md` — "As a Judge" section
- `defaults/.loom/CLAUDE.md` — "As a Judge" section
- `CLAUDE.md` — "Judge Workflow" section
- `defaults/.claude/agents/loom-judge.md` — Agent prompt
- `docs/guides/quickstart-tutorial.md` — Tutorial example
- `docs/workflows.md` — Workflow reference

## Test plan

- [x] Verify `pnpm lint` shows no new errors (pre-existing lint errors unchanged)
- [ ] Verify documentation renders correctly
- [ ] Verify Judge agent uses comment-based workflow in practice

Closes #2665

🤖 Generated with [Claude Code](https://claude.com/claude-code)