### PR TITLE
fix: suppress judge phase contract failure comments during retries

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/judge.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/judge.py
@@ -298,8 +298,12 @@ class JudgePhase:
                     if bypass_result is not None:
                         return bypass_result
 
-                # All recovery paths exhausted — NOW post the failure
-                # comment and apply the failure label (#2588).
+                # All internal recovery paths exhausted.  Do NOT post a
+                # failure comment here — the CLI-level retry loop may
+                # re-run the judge phase, and premature comments create
+                # noise (#2661).  The CLI's _mark_judge_exhausted()
+                # handles the comment + label once *all* retries are
+                # truly exhausted.
                 from loom_tools.validate_phase import _mark_phase_failed
 
                 _mark_phase_failed(
@@ -308,6 +312,7 @@ class JudgePhase:
                     f"Judge phase did not produce a review decision on PR #{ctx.pr_number}.",
                     ctx.repo_root,
                     failure_label="loom:failed:judge",
+                    quiet=True,
                 )
                 # Add context about loom:review-requested state (issue #1998)
                 if ctx.has_pr_label("loom:review-requested"):


### PR DESCRIPTION
## Summary

- Pass `quiet=True` to `_mark_phase_failed()` in the judge phase's internal failure path, so intermediate failures don't post noisy "Phase contract failed" comments on issues
- The CLI-level `_mark_judge_exhausted()` already handles comment + label when all retries are truly exhausted — this was the only source of duplicate comments
- Added test verifying `quiet=True` is passed, and updated existing test to assert the parameter

Closes #2661

## Test plan

- [x] All 94 judge-related tests pass
- [x] New test `test_mark_phase_failed_uses_quiet_to_defer_comments` verifies exact call signature
- [x] Existing test updated to assert `quiet=True` kwarg

🤖 Generated with [Claude Code](https://claude.com/claude-code)