### PR TITLE
fix: consolidate loom:failed:* labels into loom:blocked

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -80,29 +80,7 @@
   description: Enhanced by Curator, awaiting human approval
   color: "10B981"  # emerald-500
 
-# Phase Failure Labels (explicit failure states for debugging)
-- name: loom:failed:builder
-  description: Builder phase failed - no PR created
-  color: "DC2626"  # red-600
-
-- name: loom:failed:builder-tests
-  description: Builder test verification failed - branch pushed, no PR
-  color: "F97316"  # orange-500
-
-- name: loom:failed:judge
-  description: Judge phase failed - no review outcome
-  color: "DC2626"  # red-600
-
-- name: loom:failed:doctor
-  description: Doctor phase failed - could not address feedback
-  color: "DC2626"  # red-600
-
 # Status Labels
-# DEPRECATED: loom:needs-fix - use loom:failed:builder-tests instead
-- name: loom:needs-fix
-  description: "[DEPRECATED] Use loom:failed:builder-tests. Builder test verification failed."
-  color: "F97316"  # orange-500 - action needed but work is partially done
-
 - name: loom:blocked
   description: Implementation blocked, needs help or clarification
   color: "EF4444"  # red-500

--- a/defaults/.claude/commands/shepherd-lifecycle.md
+++ b/defaults/.claude/commands/shepherd-lifecycle.md
@@ -37,7 +37,7 @@ This section documents the expected GitHub label states at each shepherd phase b
 | Phase | Issue Labels | PR Labels | Recovery |
 |-------|--------------|-----------|----------|
 | Curator | (unchanged) | - | Retry curator |
-| Builder (test failure) | `loom:needs-fix` | - | Worktree preserved, Doctor/Builder fixes tests |
+| Builder (test failure) | `loom:blocked` | - | Worktree preserved, Doctor/Builder fixes tests |
 | Builder (other failure) | `loom:blocked` | - | See diagnostics comment |
 | Judge | `loom:blocked` | (unchanged) | Manual review required |
 | Doctor | `loom:blocked` | (unchanged) | Manual fix required |
@@ -55,16 +55,12 @@ Issue Lifecycle:
                     ┌─────────────┐                         ┌─────────────┐
                     │loom:blocked │ ◀─── (failure) ─────── │loom:building│
                     └─────────────┘                         └─────────────┘
-                                                             │     │
-                                                   (test fail) (PR merged)
-                                                             ▼        ▼
-                                                  ┌───────────────┐ ┌─────────────┐
-                                                  │loom:needs-fix │ │  (closed)   │
-                                                  └───────────────┘ └─────────────┘
-                                                          │
-                                                  (Doctor fixes tests)
-                                                          ▼
-                                                  back to loom:building
+                                                                    │
+                                                              (PR merged)
+                                                                    ▼
+                                                             ┌─────────────┐
+                                                             │  (closed)   │
+                                                             └─────────────┘
 
 PR Lifecycle:
 ┌─────────────────────┐     ┌───────────────────────┐     ┌─────────────┐

--- a/loom-tools/src/loom_tools/recovery_stats.py
+++ b/loom-tools/src/loom_tools/recovery_stats.py
@@ -2,7 +2,7 @@
 
 .. deprecated::
     This module is deprecated. Auto-recovery was removed from the shepherd
-    system in favor of explicit failure labels (loom:failed:builder, etc.).
+    system in favor of the unified loom:blocked label.
     Recovery events are no longer generated, so this module only provides
     historical analysis of pre-existing events.
 

--- a/loom-tools/src/loom_tools/shepherd/contracts.py
+++ b/loom-tools/src/loom_tools/shepherd/contracts.py
@@ -4,7 +4,7 @@ This module provides a contract-based approach to phase validation.
 Each phase has preconditions that must be satisfied BEFORE the phase runs.
 If preconditions are not met, the phase is skipped with a clear failure message.
 
-Contract violations apply explicit failure labels (e.g., loom:failed:builder)
+Contract violations apply the loom:blocked label
 and add diagnostic comments to the issue for manual intervention.
 """
 
@@ -27,7 +27,7 @@ class Contract:
         name: Short name for the contract (e.g., "issue_open")
         check: Function that returns True if contract is satisfied
         violation_message: Human-readable message when contract is violated
-        failure_label: Optional label to apply on violation (e.g., "loom:failed:builder")
+        failure_label: Optional label to apply on violation (e.g., "loom:blocked")
     """
 
     name: str
@@ -149,19 +149,19 @@ BUILDER_CONTRACTS = [
         name="issue_exists",
         check=_check_issue_exists,
         violation_message="Issue does not exist",
-        failure_label="loom:failed:builder",
+        failure_label="loom:blocked",
     ),
     Contract(
         name="issue_open",
         check=_check_issue_open,
         violation_message="Issue is not open",
-        failure_label="loom:failed:builder",
+        failure_label="loom:blocked",
     ),
     Contract(
         name="issue_ready",
         check=_check_issue_has_loom_issue_label,
         violation_message="Issue does not have loom:issue label (not ready for work)",
-        failure_label="loom:failed:builder",
+        failure_label="loom:blocked",
     ),
     Contract(
         name="no_existing_pr",
@@ -177,19 +177,19 @@ JUDGE_CONTRACTS = [
         name="pr_exists",
         check=_check_pr_exists,
         violation_message="No PR exists for this issue",
-        failure_label="loom:failed:judge",
+        failure_label="loom:blocked",
     ),
     Contract(
         name="pr_open",
         check=_check_pr_is_open,
         violation_message="PR is not open",
-        failure_label="loom:failed:judge",
+        failure_label="loom:blocked",
     ),
     Contract(
         name="review_requested",
         check=_check_pr_has_review_requested,
         violation_message="PR does not have loom:review-requested label",
-        failure_label="loom:failed:judge",
+        failure_label="loom:blocked",
     ),
 ]
 
@@ -199,19 +199,19 @@ DOCTOR_CONTRACTS = [
         name="pr_exists",
         check=_check_pr_exists,
         violation_message="No PR exists for this issue",
-        failure_label="loom:failed:doctor",
+        failure_label="loom:blocked",
     ),
     Contract(
         name="pr_open",
         check=_check_pr_is_open,
         violation_message="PR is not open",
-        failure_label="loom:failed:doctor",
+        failure_label="loom:blocked",
     ),
     Contract(
         name="changes_requested",
         check=_check_pr_has_changes_requested,
         violation_message="PR does not have loom:changes-requested label",
-        failure_label="loom:failed:doctor",
+        failure_label="loom:blocked",
     ),
 ]
 

--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -4412,7 +4412,7 @@ class BuilderPhase:
         1. Stages all changes (git add -A)
         2. Creates a WIP commit with descriptive message
         3. Pushes the commit to remote
-        4. Labels the issue as loom:needs-fix for Doctor to pick up
+        4. Labels the issue as loom:blocked for Doctor to pick up
         5. Adds a comment explaining the situation
 
         Args:
@@ -4492,10 +4492,10 @@ class BuilderPhase:
             log_warning("Could not push WIP commit to remote")
             # Continue anyway - local commit still preserves work
 
-        # Transition label: loom:building -> loom:needs-fix
+        # Transition label: loom:building -> loom:blocked
         transition_issue_labels(
             ctx.config.issue,
-            add=["loom:needs-fix"],
+            add=["loom:blocked"],
             remove=["loom:building"],
             repo_root=ctx.repo_root,
         )
@@ -4549,7 +4549,7 @@ class BuilderPhase:
 
         log_info(
             f"Preserved interrupted work for issue #{ctx.config.issue} "
-            f"(WIP commit, labeled loom:needs-fix)"
+            f"(WIP commit, labeled loom:blocked)"
         )
         return True
 
@@ -4561,17 +4561,17 @@ class BuilderPhase:
         Instead of cleaning up, this method:
         1. Keeps the worktree intact (with marker for protection)
         2. Pushes existing commits to remote
-        3. Labels the issue ``loom:needs-fix`` so Doctor/Builder can continue
+        3. Labels the issue ``loom:blocked`` so Doctor/Builder can continue
         4. Writes test failure context to a file for Doctor to read
         5. Adds a comment with test failure context
         """
         # Push whatever commits exist to remote
         self._push_branch(ctx)
 
-        # Transition label: loom:building -> loom:needs-fix (atomic)
+        # Transition label: loom:building -> loom:blocked (atomic)
         transition_issue_labels(
             ctx.config.issue,
-            add=["loom:needs-fix"],
+            add=["loom:blocked"],
             remove=["loom:building"],
             repo_root=ctx.repo_root,
         )
@@ -4634,7 +4634,7 @@ class BuilderPhase:
 
         log_info(
             f"Preserved worktree for issue #{ctx.config.issue} "
-            f"(test failure, labeled loom:needs-fix)"
+            f"(test failure, labeled loom:blocked)"
         )
 
     # Maps file extension → set of test ecosystems that extension can affect.

--- a/loom-tools/src/loom_tools/shepherd/phases/judge.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/judge.py
@@ -311,7 +311,7 @@ class JudgePhase:
                     "judge",
                     f"Judge phase did not produce a review decision on PR #{ctx.pr_number}.",
                     ctx.repo_root,
-                    failure_label="loom:failed:judge",
+                    failure_label="loom:blocked",
                     quiet=True,
                 )
                 # Add context about loom:review-requested state (issue #1998)

--- a/loom-tools/src/loom_tools/validate_phase.py
+++ b/loom-tools/src/loom_tools/validate_phase.py
@@ -6,7 +6,7 @@ with both a programmatic API and a CLI (``loom-validate-phase``).
 Phase contract validators check that the expected artifacts exist after a
 shepherd phase completes (e.g. the builder created a PR with the correct
 label). When a contract is not satisfied, the validator marks the issue with
-an appropriate failure label (e.g., ``loom:failed:builder``) and provides
+the ``loom:blocked`` label and provides
 diagnostic information for manual intervention.
 
 Note: Auto-recovery was removed in favor of explicit failure visibility.
@@ -280,7 +280,7 @@ def _mark_phase_failed(
         reason: Human-readable failure reason
         repo_root: Repository root path
         diagnostics: Optional diagnostic markdown to append
-        failure_label: Specific failure label to apply (e.g., "loom:failed:builder")
+        failure_label: Specific failure label to apply (e.g., "loom:blocked")
                       If None, uses "loom:blocked" as fallback
         quiet: If True, skip label changes and diagnostic comment.
                Used during intermediate recovery attempts to avoid noisy
@@ -673,7 +673,7 @@ def validate_builder(
                 "Builder may have abandoned the issue instead of implementing it. "
                 "Issue has been automatically reopened.",
                 repo_root,
-                failure_label="loom:failed:builder",
+                failure_label="loom:blocked",
                 quiet=quiet,
             )
         return ValidationResult(
@@ -749,7 +749,7 @@ def validate_builder(
             f"Builder did not create a PR. Searched for: branch 'feature/issue-{issue}' "
             f"and 'Closes/Fixes/Resolves #{issue}' in PR body. No worktree available.",
             repo_root,
-            failure_label="loom:failed:builder",
+            failure_label="loom:blocked",
             quiet=quiet,
         )
         return ValidationResult("builder", issue, ValidationStatus.FAILED, msg)
@@ -761,7 +761,7 @@ def validate_builder(
             issue, "builder",
             "Builder did not create a PR and worktree path does not exist.",
             repo_root, diag.to_markdown(),
-            failure_label="loom:failed:builder",
+            failure_label="loom:blocked",
             quiet=quiet,
         )
         return ValidationResult(
@@ -779,7 +779,7 @@ def validate_builder(
             issue, "builder",
             "Builder did not create a PR and worktree is not a valid git directory.",
             repo_root,
-            failure_label="loom:failed:builder",
+            failure_label="loom:blocked",
             quiet=quiet,
         )
         return ValidationResult(
@@ -800,7 +800,7 @@ def validate_builder(
                 issue, "builder",
                 "Builder did not create a PR. Worktree had no uncommitted or unpushed changes.",
                 repo_root, diag.to_markdown(),
-                failure_label="loom:failed:builder",
+                failure_label="loom:blocked",
                 quiet=quiet,
             )
             return ValidationResult(
@@ -822,7 +822,7 @@ def validate_builder(
                 "Builder did not produce substantive changes. "
                 "Only marker/infrastructure files were found in the worktree.",
                 repo_root, diag.to_markdown(),
-                failure_label="loom:failed:builder",
+                failure_label="loom:blocked",
                 quiet=quiet,
             )
             return ValidationResult(
@@ -855,7 +855,7 @@ def validate_builder(
                     issue, "builder",
                     f"Recovery failed: git add failed: {r.stderr.strip()[:200]}",
                     repo_root, diag.to_markdown(),
-                    failure_label="loom:failed:builder",
+                    failure_label="loom:blocked",
                     quiet=quiet,
                 )
                 return ValidationResult(
@@ -874,7 +874,7 @@ def validate_builder(
                     issue, "builder",
                     f"Recovery failed: git commit failed: {r.stderr.strip()[:200]}",
                     repo_root, diag.to_markdown(),
-                    failure_label="loom:failed:builder",
+                    failure_label="loom:blocked",
                     quiet=quiet,
                 )
                 return ValidationResult(
@@ -893,7 +893,7 @@ def validate_builder(
             issue, "builder",
             f"Recovery failed: git push failed: {r.stderr.strip()[:200]}",
             repo_root, diag.to_markdown(),
-            failure_label="loom:failed:builder",
+            failure_label="loom:blocked",
             quiet=quiet,
         )
         return ValidationResult(
@@ -928,7 +928,7 @@ def validate_builder(
             issue, "builder",
             f"Recovery failed: gh pr create failed: {r.stderr.strip()[:200]}",
             repo_root, diag.to_markdown(),
-            failure_label="loom:failed:builder",
+            failure_label="loom:blocked",
             quiet=quiet,
         )
         return ValidationResult(
@@ -1012,7 +1012,7 @@ def validate_judge(
             issue, "judge",
             f"Judge phase did not produce a review decision on PR #{pr_number}.",
             repo_root,
-            failure_label="loom:failed:judge",
+            failure_label="loom:blocked",
             quiet=quiet,
         )
 
@@ -1055,7 +1055,7 @@ def validate_doctor(
             issue, "doctor",
             f"Doctor phase did not apply loom:review-requested to PR #{pr_number}.",
             repo_root,
-            failure_label="loom:failed:doctor",
+            failure_label="loom:blocked",
             quiet=quiet,
         )
 

--- a/loom-tools/tests/shepherd/test_contracts.py
+++ b/loom-tools/tests/shepherd/test_contracts.py
@@ -24,11 +24,11 @@ class TestContract:
             name="test_contract",
             check=lambda ctx: True,
             violation_message="Test failed",
-            failure_label="loom:failed:test",
+            failure_label="loom:blocked",
         )
         assert c.name == "test_contract"
         assert c.violation_message == "Test failed"
-        assert c.failure_label == "loom:failed:test"
+        assert c.failure_label == "loom:blocked"
 
     def test_contract_without_failure_label(self) -> None:
         """Contract can be created without failure_label."""
@@ -80,17 +80,17 @@ class TestPhaseContracts:
         for contract in PHASE_CONTRACTS["builder"]:
             # Most builder contracts should have failure labels
             if contract.name != "no_existing_pr":
-                assert contract.failure_label == "loom:failed:builder"
+                assert contract.failure_label == "loom:blocked"
 
     def test_judge_has_failure_labels(self) -> None:
         """Judge contracts should specify failure labels."""
         for contract in PHASE_CONTRACTS["judge"]:
-            assert contract.failure_label == "loom:failed:judge"
+            assert contract.failure_label == "loom:blocked"
 
     def test_doctor_has_failure_labels(self) -> None:
         """Doctor contracts should specify failure labels."""
         for contract in PHASE_CONTRACTS["doctor"]:
-            assert contract.failure_label == "loom:failed:doctor"
+            assert contract.failure_label == "loom:blocked"
 
 
 class TestCheckPreconditions:
@@ -180,7 +180,7 @@ class TestApplyContractViolation:
             name="test",
             check=lambda c: True,
             violation_message="test failed",
-            failure_label="loom:failed:test",
+            failure_label="loom:blocked",
         )
         violation = ContractViolation(phase="test", contract=contract)
 
@@ -189,7 +189,7 @@ class TestApplyContractViolation:
         # Should have made two calls: edit labels and add comment
         assert mock_run.call_count == 2
         label_call = mock_run.call_args_list[0]
-        assert "loom:failed:test" in label_call[0][0]
+        assert "loom:blocked" in label_call[0][0]
 
     @patch("subprocess.run")
     def test_skips_label_when_not_specified(self, mock_run: MagicMock) -> None:
@@ -228,7 +228,7 @@ class TestApplyContractViolation:
             name="pr_exists",
             check=lambda c: True,
             violation_message="No PR exists",
-            failure_label="loom:failed:judge",
+            failure_label="loom:blocked",
         )
         violation = ContractViolation(
             phase="judge",

--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -2911,7 +2911,7 @@ class TestBuilderCommitInterruptedWork:
         # Verify label transitions
         mock_transition.assert_called_once_with(
             42,
-            add=["loom:needs-fix"],
+            add=["loom:blocked"],
             remove=["loom:building"],
             repo_root=tmp_path,
         )

--- a/loom-tools/tests/test_validate_phase.py
+++ b/loom-tools/tests/test_validate_phase.py
@@ -459,7 +459,7 @@ class TestValidateBuilder:
         assert "reopen" in reopen_call[0][0]
         mock_phase_failed.assert_called_once()
         call_kwargs = mock_phase_failed.call_args[1]
-        assert call_kwargs.get("failure_label") == "loom:failed:builder"
+        assert call_kwargs.get("failure_label") == "loom:blocked"
 
     @patch("loom_tools.validate_phase._find_pr_for_issue")
     @patch("loom_tools.validate_phase._run_gh")
@@ -487,7 +487,7 @@ class TestValidateBuilder:
         mock_phase_failed.assert_called_once()
         # Verify failure_label is passed
         call_kwargs = mock_phase_failed.call_args[1]
-        assert call_kwargs.get("failure_label") == "loom:failed:builder"
+        assert call_kwargs.get("failure_label") == "loom:blocked"
 
     @patch("loom_tools.validate_phase._find_pr_for_issue")
     @patch("loom_tools.validate_phase._run_gh")
@@ -836,7 +836,7 @@ class TestValidateJudge:
         mock_phase_failed.assert_called_once()
         # Verify failure_label is passed
         call_kwargs = mock_phase_failed.call_args[1]
-        assert call_kwargs.get("failure_label") == "loom:failed:judge"
+        assert call_kwargs.get("failure_label") == "loom:blocked"
 
     @patch("loom_tools.validate_phase._run_gh")
     def test_neither_label_check_only(self, mock_gh: MagicMock, tmp_path: Path):
@@ -905,7 +905,7 @@ class TestValidateDoctor:
         mock_phase_failed.assert_called_once()
         # Verify failure_label is passed
         call_kwargs = mock_phase_failed.call_args[1]
-        assert call_kwargs.get("failure_label") == "loom:failed:doctor"
+        assert call_kwargs.get("failure_label") == "loom:blocked"
 
     @patch("loom_tools.validate_phase._run_gh")
     def test_missing_label_check_only(self, mock_gh: MagicMock, tmp_path: Path):


### PR DESCRIPTION
## Summary

- Replaced all 4 phase-specific failure labels (`loom:failed:builder`, `loom:failed:builder-tests`, `loom:failed:judge`, `loom:failed:doctor`) with the single `loom:blocked` label
- Removed the deprecated `loom:needs-fix` label
- Simplified `_apply_failure_label()` in shepherd CLI — no longer needs fallback logic since we're using `loom:blocked` directly
- Removed the `_REQUIRED_FAILURE_LABELS` startup check from the daemon loop (no longer needed)
- Updated all contracts, phase validators, and tests accordingly

## Motivation

Each label add/remove is a separate GitHub API call. The granular failure labels existed for observability, but phase-specific failure details are already tracked in `daemon-state.json`, shepherd progress files, and issue comments. The labels themselves just signal "this issue needs attention" — which is exactly what `loom:blocked` already means.

Closes #2684

## Test plan

- [x] All validate_phase tests pass (63 passed)
- [x] All contracts tests pass (16 passed)
- [x] All shepherd CLI tests pass (20 mark/cleanup tests + 11 fallback tests)
- [x] Builder phase tests pass (6 commit_interrupted tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)