### PR TITLE
fix: kill MCP-degraded sessions instead of continuing in degraded state

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/base.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/base.py
@@ -99,7 +99,7 @@ GHOST_SESSION_BACKOFF_SECONDS = [10, 30, 60]
 # Similar to LOW_OUTPUT_RETRY_STRATEGIES.  See issue #2644.
 GHOST_RETRY_STRATEGIES: dict[str, tuple[int, list[int]]] = {
     "auth_failure": (0, []),           # Auth issues won't resolve with retries
-    "mcp_init_failure": (1, [30]),     # MCP might recover after rebuild
+    "mcp_init_failure": (3, [10, 30, 60]),  # MCP failures need retries; startup monitor now kills degraded sessions (issue #2652)
     "api_unreachable": (1, [30]),      # API blip might be transient
     "wrapper_crash": (0, []),          # Script errors won't self-heal
     "unknown": (GHOST_SESSION_MAX_RETRIES, list(GHOST_SESSION_BACKOFF_SECONDS)),


### PR DESCRIPTION
## Summary

Fixes the #1 cause of shepherd failures: MCP initialization failures causing ghost sessions in subprocess workers (especially judge).

- **Startup monitor** now kills Claude CLI sessions on any MCP/plugin failure, even when the loom MCP server connected successfully. Previously it continued in a degraded state where injected commands were never processed.
- **Added "plugins failed"** to the startup failure detection patterns (previously only matched "MCP server(s) failed").
- **Increased MCP failure ghost retry budget** from 1 retry to 3 retries with escalating backoff [10, 30, 60]s, matching the "unknown" strategy. This is needed since sessions are now killed more aggressively.

## Test plan

- [x] New tests: `TestRunPhaseWithRetryGhostCauseSpecific` (3 tests for cause-specific retry behavior)
- [x] All existing ghost session tests pass (22 total)
- [x] Full test suite passes (803/804, 1 pre-existing failure unrelated to this change)

Closes #2652