### PR TITLE
fix: add root cause verification to prevent superficial builder fixes

### DIFF
--- a/defaults/.claude/commands/builder-pr.md
+++ b/defaults/.claude/commands/builder-pr.md
@@ -245,6 +245,11 @@ Issue #123 acceptance criteria:
 2. [ ] Criterion B - Verified by: [describe how you checked]
 3. [ ] Criterion C - Verified by: [describe how you checked]
 
+Root cause verification (for process/behavior issues):
+- [ ] Changes address root cause, not just surface symptom
+- [ ] Fix is structural (enforcement, validation, inlining) not just documentation
+- [ ] If documentation-only: justified why docs will change behavior this time
+
 Local verification:
 - [ ] `pnpm check:ci` passes (or equivalent)
 - [ ] Relevant tests pass

--- a/defaults/.claude/commands/builder.md
+++ b/defaults/.claude/commands/builder.md
@@ -495,6 +495,41 @@ cargo fmt            # Format code
 - **Create quality PRs**: Clear description, references issue, requests review
 - **Get unstuck**: Mark `loom:blocked` if you can't proceed, explain why
 
+## Root Cause Verification
+
+**CRITICAL**: Before creating a PR, verify that your changes address the **root cause** of the problem, not just the surface symptom. This is especially important for process-improvement issues.
+
+### The Superficial Fix Anti-Pattern
+
+When an issue reports a process failure (e.g., "builder doesn't follow instructions in document X"), the tempting fix is to add a cross-reference or note pointing to document X. **This is almost never sufficient.** If the documentation already existed and wasn't followed, adding another pointer to it won't change behavior.
+
+**Superficial fixes to avoid:**
+- Adding parenthetical cross-references (e.g., `"see builder-pr.md"`)
+- Adding comments pointing to existing documentation
+- Rewording existing instructions without structural changes
+- Adding "reminder" notes that duplicate existing guidance
+
+### What Constitutes a Structural Fix
+
+A structural fix changes the **mechanism**, not just the **documentation**:
+
+| Problem Type | Superficial Fix | Structural Fix |
+|---|---|---|
+| Agent doesn't follow template | Add note "see template" | Inline the template at point of use, or add validation that rejects non-conforming output |
+| Agent skips a workflow step | Add reminder to docs | Add a checkpoint/gate that blocks progression without the step |
+| Agent produces low-quality output | Add quality guidelines | Add a self-check with concrete pass/fail criteria |
+| Process isn't enforced | Document the process | Add script enforcement or pre-commit hooks |
+
+### Pre-PR Root Cause Check
+
+Before creating your PR, answer these questions:
+
+1. **What is the root cause?** (Not "what does the issue say" but "why does this problem actually occur?")
+2. **Would my fix prevent recurrence?** If the same situation arises again, will my changes actually produce a different outcome?
+3. **Am I changing mechanism or just documentation?** If I'm only changing `.md` files with no structural enforcement, is that truly sufficient?
+
+If your fix is documentation-only for a process issue, you must justify why documentation alone will change behavior this time when it didn't before. If you can't justify it, find a structural approach.
+
 ## When You Can't Determine Changes
 
 **If you investigate an issue but cannot determine what code changes to make, you MUST leave a comment on the issue before exiting.** This preserves context for the next attempt (human or automated).

--- a/defaults/.claude/commands/curator.md
+++ b/defaults/.claude/commands/curator.md
@@ -236,6 +236,14 @@ Issue #99: "fix the crash bug"
 - Add planning details (architecture, dependencies, risks)
 - Assess and add `loom:urgent` label if issue is time-sensitive or critical
 
+### Process-Improvement Issues
+
+Issues about agent behavior or workflow failures need special curation to prevent superficial fixes (e.g., adding cross-references instead of structural changes). When curating these issues:
+
+- **Require structural acceptance criteria**: Criteria must demand demonstrable behavior change, not just documentation updates. Bad: "Update builder instructions". Good: "Builder must include a Summary section in every PR body" or "Add a validation step that rejects PRs without structured descriptions".
+- **Identify the root cause**: Document *why* the current process fails, not just *what* fails. If documentation already exists but isn't followed, say so explicitly.
+- **Specify a verification method**: Include a concrete test that can distinguish a superficial fix from a real one. Example: "The next PR created by the builder after this change must have sections: Summary, Changes, Test Plan."
+
 ### Organization
 - Apply appropriate labels (bug, enhancement, P0/P1/P2, etc.)
 - Set milestones for release planning


### PR DESCRIPTION
## Summary

Add structural guardrails to prevent the builder from producing superficial fixes for process-improvement issues. Previously, when an issue reported "builder doesn't follow document X", the builder would add a cross-reference to document X rather than making structural changes that actually solve the problem (e.g., PR #2675 for issue #2664).

## Changes

- **builder.md**: New "Root Cause Verification" section with anti-pattern examples, structural fix comparison table, and a 3-question pre-PR self-check
- **builder-pr.md**: Root cause verification checklist items added to the Pre-PR Verification Checklist
- **curator.md**: New "Process-Improvement Issues" subsection requiring structural acceptance criteria, root cause documentation, and concrete verification methods

## Test Plan

- [ ] Verify builder.md, builder-pr.md, and curator.md render correctly
- [ ] Verify symlinks in defaults/roles/ still resolve correctly
- [ ] Next process-improvement issue handled by builder should produce structural changes, not documentation-only fixes

Closes #2680