### PR TITLE
perf: skip baseline test run when preflight confirms main is healthy

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/cli.py
+++ b/loom-tools/src/loom_tools/shepherd/cli.py
@@ -514,8 +514,11 @@ def orchestrate(ctx: ShepherdContext) -> int:
                 _mark_baseline_blocked(ctx, result)
                 return ShepherdExitCode.NEEDS_INTERVENTION
 
+            # Store preflight result so builder can skip baseline tests
+            ctx.preflight_baseline_status = result.data.get("baseline_status")
+
             # Capture missing baseline warning for reflection
-            if result.data.get("baseline_status") == "unknown":
+            if ctx.preflight_baseline_status == "unknown":
                 run_warnings.append("No baseline health cache found")
 
             # Log result inline (no header for passing checks)

--- a/loom-tools/src/loom_tools/shepherd/context.py
+++ b/loom-tools/src/loom_tools/shepherd/context.py
@@ -56,6 +56,10 @@ class ShepherdContext:
     # Low-output cause classification (set by run_phase_with_retry)
     last_low_output_cause: str | None = field(default=None, init=False)
 
+    # Preflight baseline status (set by orchestrator after preflight phase).
+    # "healthy" means baseline tests pass and builder can skip re-running them.
+    preflight_baseline_status: str | None = field(default=None, init=False)
+
     # Progress tracking state
     _progress_initialized: bool = field(default=False, init=False, repr=False)
 

--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -2181,6 +2181,15 @@ class BuilderPhase:
         if not ctx.repo_root or not ctx.repo_root.is_dir():
             return None
 
+        # Skip baseline when preflight already confirmed main is healthy.
+        # Returning None tells the comparison logic to treat any worktree
+        # failure as genuinely new, which is correct when main is known-good.
+        if ctx.preflight_baseline_status == "healthy":
+            log_info(
+                f"Skipping baseline (preflight confirmed healthy): {display_name}"
+            )
+            return None
+
         if use_provided_cmd:
             baseline_cmd = test_cmd
         else:


### PR DESCRIPTION
## Summary

- Thread `preflight_baseline_status` through `ShepherdContext` so the builder knows whether the preflight already confirmed main is healthy
- Short-circuit `_run_baseline_tests()` (return `None`) when preflight status is `"healthy"`, avoiding a redundant full test suite run on main
- Saves several minutes per shepherd session (multiplied by 3 concurrent shepherds)

## Changes

| File | Change |
|------|--------|
| `context.py` | Add `preflight_baseline_status` field to `ShepherdContext` |
| `cli.py` | Store preflight result on context after successful preflight phase |
| `builder.py` | Early return from `_run_baseline_tests()` when preflight is healthy |
| `test_phases.py` | 5 new tests covering skip/no-skip behavior and end-to-end verification |

## Test plan

- [x] `test_skips_baseline_when_preflight_healthy` — returns `None` with no subprocess spawned
- [x] `test_runs_baseline_when_preflight_unknown` — still runs baseline normally
- [x] `test_runs_baseline_when_preflight_failing` — still runs baseline normally
- [x] `test_runs_baseline_when_preflight_none` — still runs baseline normally (preflight skipped)
- [x] `test_worktree_failure_treated_as_new_when_baseline_skipped` — worktree failures are not excused when baseline is skipped
- [x] All 11 existing `TestBuilderBaselineTests` pass (no regressions)
- [x] All 29 baseline/preflight related tests pass

Closes #2702

🤖 Generated with [Claude Code](https://claude.com/claude-code)