### PR TITLE
fix: derive meaningful commit messages in builder recovery paths

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -18,7 +18,11 @@ from loom_tools.checkpoints import (
     read_checkpoint,
     write_checkpoint,
 )
-from loom_tools.common.git import get_changed_files, parse_porcelain_path
+from loom_tools.common.git import (
+    derive_commit_message,
+    get_changed_files,
+    parse_porcelain_path,
+)
 from loom_tools.common.logging import log_error, log_info, log_success, log_warning
 from loom_tools.common.paths import LoomPaths, NamingConventions
 from loom_tools.common.state import parse_command_output, read_json_file
@@ -4347,8 +4351,13 @@ class BuilderPhase:
             )
             return False
 
-        # Commit
-        commit_msg = f"feat: implement changes for issue #{ctx.config.issue}"
+        # Commit — derive a meaningful message from the issue title
+        commit_msg = derive_commit_message(
+            ctx.config.issue,
+            str(ctx.worktree_path),
+            str(ctx.repo_root),
+            staged_files=files_to_stage,
+        )
         commit_result = subprocess.run(
             ["git", "-C", str(ctx.worktree_path), "commit", "-m", commit_msg],
             capture_output=True,

--- a/loom-tools/src/loom_tools/validate_phase.py
+++ b/loom-tools/src/loom_tools/validate_phase.py
@@ -27,7 +27,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
-from loom_tools.common.git import parse_porcelain_path
+from loom_tools.common.git import derive_commit_message, parse_porcelain_path
 from loom_tools.common.logging import log_warning, strip_ansi
 from loom_tools.common.paths import LoomPaths
 from loom_tools.common.state import find_progress_for_issue
@@ -874,7 +874,9 @@ def validate_builder(
                     "Recovery failed: could not stage changes.",
                 )
 
-            commit_msg = f"feat: implement changes for issue #{issue}"
+            commit_msg = derive_commit_message(
+                issue, worktree, repo_root, staged_files=files_to_stage,
+            )
             r = subprocess.run(
                 ["git", "-C", worktree, "commit", "-m", commit_msg],
                 capture_output=True, text=True, check=False,

--- a/loom-tools/tests/test_derive_commit_message.py
+++ b/loom-tools/tests/test_derive_commit_message.py
@@ -1,0 +1,96 @@
+"""Tests for derive_commit_message in loom_tools.common.git."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from loom_tools.common.git import derive_commit_message
+
+
+class TestDeriveCommitMessage:
+    """Unit tests for deriving meaningful commit messages from issue context."""
+
+    @patch("loom_tools.common.git.subprocess.run")
+    def test_uses_issue_title_when_available(self, mock_run: MagicMock) -> None:
+        """Should use the issue title via NamingConventions.pr_title()."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="Builder recovery creates generic commit messages\n",
+        )
+        result = derive_commit_message(42, "/tmp/worktree", "/tmp/repo")
+        assert result == "feat: builder recovery creates generic commit messages"
+
+    @patch("loom_tools.common.git.subprocess.run")
+    def test_preserves_conventional_prefix_from_title(
+        self, mock_run: MagicMock
+    ) -> None:
+        """Should preserve existing conventional commit prefixes in issue title."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="fix: validate PR title format\n",
+        )
+        result = derive_commit_message(42, "/tmp/worktree")
+        assert result == "fix: validate PR title format"
+
+    @patch("loom_tools.common.git.subprocess.run")
+    def test_falls_back_to_files_when_gh_fails(self, mock_run: MagicMock) -> None:
+        """Should use file names when gh issue view fails."""
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="error")
+        result = derive_commit_message(
+            42,
+            "/tmp/worktree",
+            staged_files=["src/main.py", "src/utils.py"],
+        )
+        assert result == "feat: update main.py, utils.py for issue #42"
+
+    @patch("loom_tools.common.git.subprocess.run")
+    def test_truncates_long_file_list(self, mock_run: MagicMock) -> None:
+        """Should truncate file lists longer than 3 files."""
+        mock_run.return_value = MagicMock(returncode=1, stdout="")
+        files = ["a.py", "b.py", "c.py", "d.py", "e.py"]
+        result = derive_commit_message(42, "/tmp/worktree", staged_files=files)
+        assert "a.py, b.py, c.py and 2 more" in result
+        assert "issue #42" in result
+
+    @patch("loom_tools.common.git.subprocess.run")
+    def test_falls_back_to_generic_when_no_context(
+        self, mock_run: MagicMock
+    ) -> None:
+        """Should produce generic message when nothing else is available."""
+        mock_run.return_value = MagicMock(returncode=1, stdout="")
+        result = derive_commit_message(42, "/tmp/worktree")
+        assert result == "feat: implement changes for issue #42"
+
+    @patch("loom_tools.common.git.subprocess.run")
+    def test_handles_empty_issue_title(self, mock_run: MagicMock) -> None:
+        """Should fall back when issue title is empty string."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="\n")
+        result = derive_commit_message(
+            42, "/tmp/worktree", staged_files=["config.py"]
+        )
+        assert result == "feat: update config.py for issue #42"
+
+    @patch("loom_tools.common.git.subprocess.run")
+    def test_handles_subprocess_exception(self, mock_run: MagicMock) -> None:
+        """Should not crash when subprocess raises an exception."""
+        mock_run.side_effect = OSError("gh not found")
+        result = derive_commit_message(42, "/tmp/worktree")
+        assert result == "feat: implement changes for issue #42"
+
+    @patch("loom_tools.common.git.subprocess.run")
+    def test_uses_repo_root_for_gh_cwd(self, mock_run: MagicMock) -> None:
+        """Should pass repo_root as cwd to gh when provided."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="Fix bug\n")
+        derive_commit_message(42, "/tmp/worktree", "/tmp/repo")
+        call_kwargs = mock_run.call_args
+        assert call_kwargs.kwargs.get("cwd") == "/tmp/repo"
+
+    @patch("loom_tools.common.git.subprocess.run")
+    def test_uses_worktree_as_cwd_when_no_repo_root(
+        self, mock_run: MagicMock
+    ) -> None:
+        """Should fall back to worktree path as cwd when repo_root is None."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="Fix bug\n")
+        derive_commit_message(42, "/tmp/worktree")
+        call_kwargs = mock_run.call_args
+        assert call_kwargs.kwargs.get("cwd") == "/tmp/worktree"


### PR DESCRIPTION
## Summary

- Added `derive_commit_message()` to `loom_tools.common.git` that fetches the issue title via `gh issue view` and formats it as a conventional commit message using `NamingConventions.pr_title()`
- Falls back to a file-list summary (e.g. "feat: update main.py, utils.py for issue #42") when the title is unavailable, then to the generic message as last resort
- Updated both recovery paths: `validate_phase.py` (phase validation recovery) and `builder.py` (`_stage_and_commit` direct completion)

Closes #2655

## Test plan

- [x] 9 new tests for `derive_commit_message` covering title derivation, conventional prefix preservation, file-list fallback, truncation, error handling, and cwd routing
- [x] Updated 2 existing `TestBuilderStageAndCommit` tests to mock `derive_commit_message`
- [x] All 115 tests in affected suites pass (validate_phase, paths, porcelain_parsing)
- [ ] Verify in integration: trigger a builder recovery to confirm real commit messages use issue title

🤖 Generated with [Claude Code](https://claude.com/claude-code)