### PR TITLE
fix: _has_incomplete_work returns false positive when PR already exists

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -3488,7 +3488,9 @@ class BuilderPhase:
         commits_ahead = diag.get("commits_ahead", 0)
 
         if commits_ahead > 0:
-            # Real builder progress — always treat as incomplete
+            # Real builder progress — but check if workflow is already complete
+            if diag.get("pr_number") is not None and diag.get("pr_has_review_label", False):
+                return False  # PR exists with correct label — workflow is done
             return True
 
         if diag.get("has_uncommitted_changes", False):

--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -9036,6 +9036,19 @@ class TestBuilderHasIncompleteWork:
         }
         assert builder._has_incomplete_work(diag) is True
 
+    def test_commits_ahead_with_review_requested_pr_returns_false(self) -> None:
+        """PR exists with loom:review-requested and commits ahead — workflow is done (#2709)."""
+        builder = BuilderPhase()
+        diag = {
+            "worktree_exists": True,
+            "has_uncommitted_changes": False,
+            "commits_ahead": 2,
+            "remote_branch_exists": True,
+            "pr_number": 456,
+            "pr_has_review_label": True,
+        }
+        assert builder._has_incomplete_work(diag) is False
+
     def test_remote_exists_no_pr_with_commits_returns_true(self) -> None:
         """Remote branch pushed with commits but no PR should be incomplete."""
         builder = BuilderPhase()


### PR DESCRIPTION
## Summary

- Fix `_has_incomplete_work()` to return `False` when a PR exists with `loom:review-requested` label, even when `commits_ahead > 0`
- Add test case covering the scenario where the PR is in its finished state but commits are ahead of main

## Test plan

- [x] New test `test_commits_ahead_with_review_requested_pr_returns_false` verifies the fix
- [x] All existing `TestBuilderHasIncompleteWork` tests still pass (10/10)
- [x] Previously-failing `test_mark_phase_failed_uses_quiet_to_defer_comments` passes after rebase

Closes #2709

🤖 Generated with [Claude Code](https://claude.com/claude-code)