### PR TITLE
fix: generate structured PR body in _direct_completion

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -3847,6 +3847,25 @@ class BuilderPhase:
                         f"for branch {branch}, skipping creation"
                     )
                     continue
+                # Build structured PR body with Summary and Changes
+                diff_stat_result = subprocess.run(
+                    ["git", "diff", "--stat", "origin/main...HEAD"],
+                    cwd=ctx.worktree_path or ctx.repo_root,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                diff_stat = diff_stat_result.stdout.strip()
+                pr_body_parts = [
+                    "## Summary",
+                    ctx.issue_title or f"Issue #{ctx.config.issue}",
+                    "",
+                    "## Changes",
+                    f"```\n{diff_stat}\n```" if diff_stat else "_No file changes detected._",
+                    "",
+                    f"Closes #{ctx.config.issue}",
+                ]
+                pr_body = "\n".join(pr_body_parts)
                 result = subprocess.run(
                     [
                         "gh",
@@ -3859,7 +3878,7 @@ class BuilderPhase:
                         "--label",
                         "loom:review-requested",
                         "--body",
-                        f"Closes #{ctx.config.issue}",
+                        pr_body,
                     ],
                     cwd=ctx.repo_root,
                     capture_output=True,

--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -9703,9 +9703,10 @@ class TestBuilderDirectCompletion:
                 "loom_tools.shepherd.phases.builder.subprocess.run"
             ) as mock_run,
         ):
-            # First call: gh pr list (no existing PR), second: gh pr create
+            # gh pr list, git diff --stat, gh pr create
             mock_run.side_effect = [
                 MagicMock(returncode=0, stdout="", stderr=""),
+                MagicMock(returncode=0, stdout="file.py | 2 +-\n", stderr=""),
                 MagicMock(returncode=0, stderr=""),
             ]
             result = builder._direct_completion(mock_context, diag)
@@ -9714,15 +9715,22 @@ class TestBuilderDirectCompletion:
         # Verify gh pr list check was called first
         check_args = mock_run.call_args_list[0][0][0]
         assert check_args[:3] == ["gh", "pr", "list"]
-        # Verify gh pr create was called
-        call_args = mock_run.call_args_list[1][0][0]
+        # Verify git diff --stat was called
+        diff_args = mock_run.call_args_list[1][0][0]
+        assert diff_args[:3] == ["git", "diff", "--stat"]
+        # Verify gh pr create was called with structured body
+        call_args = mock_run.call_args_list[2][0][0]
         assert call_args[:3] == ["gh", "pr", "create"]
         assert "--head" in call_args
         assert "feature/issue-42" in call_args
         assert "--label" in call_args
         assert "loom:review-requested" in call_args
         assert "--body" in call_args
-        assert "Closes #42" in call_args
+        body_idx = call_args.index("--body")
+        body = call_args[body_idx + 1]
+        assert "## Summary" in body
+        assert "## Changes" in body
+        assert "Closes #42" in body
 
     def test_add_label_only(self, mock_context: MagicMock) -> None:
         """Should add label directly when that's the only step."""
@@ -9772,8 +9780,9 @@ class TestBuilderDirectCompletion:
                 "loom_tools.shepherd.phases.builder.subprocess.run"
             ) as mock_run,
         ):
-            # First call: gh pr list (no existing PR), second: gh pr create
+            # gh pr list, git diff --stat, gh pr create
             mock_run.side_effect = [
+                MagicMock(returncode=0, stdout="", stderr=""),
                 MagicMock(returncode=0, stdout="", stderr=""),
                 MagicMock(returncode=0, stderr=""),
             ]
@@ -9826,15 +9835,20 @@ class TestBuilderDirectCompletion:
         with patch(
             "loom_tools.shepherd.phases.builder.subprocess.run"
         ) as mock_run:
-            # First call: gh pr list (no existing PR), second: gh pr create
+            # gh pr list, git diff --stat, gh pr create
             mock_run.side_effect = [
                 MagicMock(returncode=0, stdout="", stderr=""),
+                MagicMock(returncode=0, stdout="builder.py | 10 ++++\n", stderr=""),
                 MagicMock(returncode=0, stderr=""),
             ]
             result = builder._direct_completion(mock_context, diag)
 
         assert result is True
-        call_args = mock_run.call_args_list[1][0][0]
+        # git diff --stat call
+        diff_args = mock_run.call_args_list[1][0][0]
+        assert diff_args[:3] == ["git", "diff", "--stat"]
+        # gh pr create call
+        call_args = mock_run.call_args_list[2][0][0]
         assert call_args[:3] == ["gh", "pr", "create"]
         assert "--head" in call_args
         assert "feature/issue-42" in call_args
@@ -9844,7 +9858,12 @@ class TestBuilderDirectCompletion:
         assert "--label" in call_args
         assert "loom:review-requested" in call_args
         assert "--body" in call_args
-        assert "Closes #42" in call_args
+        body_idx = call_args.index("--body")
+        body = call_args[body_idx + 1]
+        assert "## Summary" in body
+        assert "## Changes" in body
+        assert "builder.py | 10 ++++" in body
+        assert "Closes #42" in body
 
     def test_create_pr_skips_when_pr_already_exists(
         self, mock_context: MagicMock
@@ -9896,17 +9915,17 @@ class TestBuilderDirectCompletion:
         with patch(
             "loom_tools.shepherd.phases.builder.subprocess.run"
         ) as mock_run:
-            # First call: gh pr list fails (transient error), second: gh pr create
+            # gh pr list fails, git diff --stat, gh pr create
             mock_run.side_effect = [
                 MagicMock(returncode=1, stdout="", stderr="network error"),
+                MagicMock(returncode=0, stdout="", stderr=""),
                 MagicMock(returncode=0, stderr=""),
             ]
             result = builder._direct_completion(mock_context, diag)
 
         assert result is True
-        # Both calls should have been made
-        assert mock_run.call_count == 2
-        create_args = mock_run.call_args_list[1][0][0]
+        assert mock_run.call_count == 3
+        create_args = mock_run.call_args_list[2][0][0]
         assert create_args[:3] == ["gh", "pr", "create"]
 
     def test_create_pr_zero_commits_returns_false(self, mock_context: MagicMock) -> None:
@@ -9940,8 +9959,9 @@ class TestBuilderDirectCompletion:
         with patch(
             "loom_tools.shepherd.phases.builder.subprocess.run"
         ) as mock_run:
-            # First call: gh pr list (no existing PR), second: gh pr create (fails)
+            # gh pr list, git diff --stat, gh pr create (fails)
             mock_run.side_effect = [
+                MagicMock(returncode=0, stdout="", stderr=""),
                 MagicMock(returncode=0, stdout="", stderr=""),
                 MagicMock(returncode=1, stderr="GraphQL: error"),
             ]
@@ -9968,8 +9988,9 @@ class TestBuilderDirectCompletion:
         with patch(
             "loom_tools.shepherd.phases.builder.subprocess.run"
         ) as mock_run:
-            # First call: gh pr list (no existing PR), second: gh pr create
+            # gh pr list, git diff --stat, gh pr create
             mock_run.side_effect = [
+                MagicMock(returncode=0, stdout="", stderr=""),
                 MagicMock(returncode=0, stdout="", stderr=""),
                 MagicMock(returncode=0, stderr=""),
             ]
@@ -9978,7 +9999,7 @@ class TestBuilderDirectCompletion:
         # Both the check and create calls should use the custom branch
         check_args = mock_run.call_args_list[0][0][0]
         assert "custom/my-branch" in check_args
-        create_args = mock_run.call_args_list[1][0][0]
+        create_args = mock_run.call_args_list[2][0][0]
         assert "custom/my-branch" in create_args
 
     def test_create_pr_fallback_branch_name(
@@ -10000,14 +10021,15 @@ class TestBuilderDirectCompletion:
         with patch(
             "loom_tools.shepherd.phases.builder.subprocess.run"
         ) as mock_run:
-            # First call: gh pr list (no existing PR), second: gh pr create
+            # gh pr list, git diff --stat, gh pr create
             mock_run.side_effect = [
+                MagicMock(returncode=0, stdout="", stderr=""),
                 MagicMock(returncode=0, stdout="", stderr=""),
                 MagicMock(returncode=0, stderr=""),
             ]
             builder._direct_completion(mock_context, diag)
 
-        create_args = mock_run.call_args_list[1][0][0]
+        create_args = mock_run.call_args_list[2][0][0]
         assert "feature/issue-55" in create_args
 
     def test_stage_and_commit_failure_returns_false(
@@ -10056,7 +10078,9 @@ class TestBuilderDirectCompletion:
                 "loom_tools.shepherd.phases.builder.subprocess.run"
             ) as mock_run,
         ):
+            # gh pr list, git diff --stat, gh pr create
             mock_run.side_effect = [
+                MagicMock(returncode=0, stdout="", stderr=""),
                 MagicMock(returncode=0, stdout="", stderr=""),
                 MagicMock(returncode=0, stderr=""),
             ]


### PR DESCRIPTION
## Summary
_direct_completion creates PRs with bare 'Closes #N' body instead of structured template. Now generates a proper body with Summary and Changes sections.

## Changes
```
loom-tools/src/loom_tools/shepherd/phases/builder.py | 21 ++++++++-
loom-tools/tests/shepherd/test_phases.py             | 58 +++++++++++++-------
```

- Added `git diff --stat` call before PR creation to gather file change summary
- Build structured PR body with `## Summary` (from issue title) and `## Changes` (from diff stat) sections
- Updated all 8 affected test cases to account for the additional subprocess call

Closes #2711

🤖 Generated with [Claude Code](https://claude.com/claude-code)