### PR TITLE
fix: use origin/main..HEAD in builder validation to prevent false positives

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -3154,7 +3154,7 @@ class BuilderPhase:
 
             # Commits ahead of main
             log_res = subprocess.run(
-                ["git", "-C", str(wt), "log", "--oneline", "main..HEAD"],
+                ["git", "-C", str(wt), "log", "--oneline", "origin/main..HEAD"],
                 capture_output=True,
                 text=True,
                 check=False,
@@ -3171,7 +3171,7 @@ class BuilderPhase:
             # See issue #2605.
             if commits:
                 diff_res = subprocess.run(
-                    ["git", "-C", str(wt), "diff", "--name-only", "main..HEAD"],
+                    ["git", "-C", str(wt), "diff", "--name-only", "origin/main..HEAD"],
                     capture_output=True,
                     text=True,
                     check=False,


### PR DESCRIPTION
## Summary

- Fixes `_validate_builder_output` diagnostics using `main..HEAD` instead of `origin/main..HEAD`, which caused false "wrong issue" detection when local `main` was behind `origin/main`
- Two locations in builder.py updated: commit log check (line 3157) and diff file list (line 3174)

Closes #2720

## Test plan

- [x] All 17 tests in `test_builder_escape_detection.py` pass
- [x] All 14 validation tests in `test_phases.py` pass (substring match `"main..HEAD" in cmd_str` works for both old and new patterns)
- [ ] Verify in daemon mode that builder validation no longer falsely flags merged-PR commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)