### PR TITLE
fix: increase stuck_max_retries default from 1 to 2

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/config.py
+++ b/loom-tools/src/loom_tools/shepherd/config.py
@@ -178,7 +178,7 @@ class ShepherdConfig:
         default_factory=lambda: env_int("LOOM_JUDGE_MAX_RETRIES", 3)
     )
     stuck_max_retries: int = field(
-        default_factory=lambda: env_int("LOOM_STUCK_MAX_RETRIES", 1)
+        default_factory=lambda: env_int("LOOM_STUCK_MAX_RETRIES", 2)
     )
     builder_completion_retries: int = field(
         default_factory=lambda: env_int("LOOM_BUILDER_COMPLETION_RETRIES", 2)

--- a/loom-tools/tests/shepherd/test_config.py
+++ b/loom-tools/tests/shepherd/test_config.py
@@ -207,7 +207,7 @@ class TestShepherdConfig:
         config = ShepherdConfig(issue=42)
         assert config.doctor_max_retries == 3
         assert config.judge_max_retries == 3
-        assert config.stuck_max_retries == 1
+        assert config.stuck_max_retries == 2
 
     def test_judge_max_retries_env_override(self) -> None:
         """LOOM_JUDGE_MAX_RETRIES env var should override default."""


### PR DESCRIPTION
## Summary
Increases the default `stuck_max_retries` from 1 to 2 so the startup monitor's clean-restart strategy has an actual retry available when transient MCP failures occur.

## Changes
- Changed default value of `LOOM_STUCK_MAX_RETRIES` from `1` to `2` in `config.py`
- Updated corresponding test assertion in `test_config.py`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Default stuck_max_retries is 2 | ✅ | Changed default in config.py line 181 |
| Startup monitor gets a retry attempt | ✅ | With max_retries=2, attempt 1 can fail and attempt 2 retries |
| Existing env var override still works | ✅ | All 35 config tests pass |

## Test Plan
- `uv run pytest tests/shepherd/test_config.py` — 35/35 pass

Closes #2734