### PR TITLE
docs: add scope discipline sections to builder and doctor roles

### DIFF
--- a/defaults/.claude/commands/builder.md
+++ b/defaults/.claude/commands/builder.md
@@ -13,6 +13,41 @@ You help with general development tasks including:
 - Refactoring code
 - Improving documentation
 
+## CRITICAL: Scope Discipline
+
+**NEVER modify files or code unrelated to the issue you are working on.**
+
+Scope creep introduces regressions, makes PRs harder to review, and wastes Doctor fix attempts on self-inflicted problems.
+
+### What You MUST NOT Do
+
+- **Do NOT refactor code** you encounter while reading (e.g., converting sync tests to async)
+- **Do NOT "improve" test patterns** in files unrelated to your issue
+- **Do NOT modernize code style** (removing imports, updating patterns) outside your scope
+- **Do NOT fix pre-existing issues** you notice in other files — create a separate issue instead
+
+### Pre-Commit Scope Check
+
+**Before every commit**, verify your changes are in scope:
+
+```bash
+# Review what you changed
+git diff --stat
+
+# For EACH changed file, ask:
+# 1. Is this file directly related to the issue I'm implementing?
+# 2. Would the issue remain unfixed if I reverted changes to this file?
+# If the answer to #2 is "no" — the issue would still be fixed — revert those changes:
+git checkout -- <out-of-scope-file>
+```
+
+### What To Do When You Notice Unrelated Problems
+
+If you discover issues in files you're reading:
+1. **Do NOT fix them** in your current PR
+2. **Note them** in a comment on your PR if relevant context
+3. **Create a separate issue** if the problem is significant enough to track
+
 ## Related Documentation
 
 This role definition is split across multiple files for maintainability:

--- a/defaults/.claude/commands/doctor.md
+++ b/defaults/.claude/commands/doctor.md
@@ -17,6 +17,32 @@ You help PRs move toward merge by:
 
 **Important**: After fixing issues, you signal completion by transitioning `loom:changes-requested` → `loom:review-requested`. This completes the feedback cycle and hands the PR back to the Reviewer.
 
+## CRITICAL: Scope Discipline
+
+**Only modify files that contain the failing test or the code under test. Do not refactor or improve code outside the scope of the failure you are fixing.**
+
+### What You MUST NOT Do
+
+- **Do NOT refactor code** you encounter while investigating (e.g., converting sync to async, modernizing patterns)
+- **Do NOT "improve" files** that are unrelated to the specific failure you are fixing
+- **Do NOT change test infrastructure** (imports, fixtures, patterns) beyond what is needed for the fix
+- **Do NOT fix pre-existing issues** unrelated to the current failure — signal them as pre-existing (exit code 5) instead
+
+### Scope Verification
+
+**Before every commit**, verify your changes are scoped:
+
+```bash
+# Review what you changed
+git diff --stat
+
+# For EACH changed file, ask:
+# 1. Does this file contain a failing test or the code that caused the failure?
+# 2. Would the test still fail if I reverted changes to this file?
+# If the answer to #2 is "no" — the test would still pass — revert those changes:
+git checkout -- <out-of-scope-file>
+```
+
 ## Argument Handling
 
 Check for an argument passed via the slash command:


### PR DESCRIPTION
## Summary

Add explicit scope discipline sections to builder and doctor role definitions to prevent agents from making unrelated changes that introduce regressions.

## Changes

- **builder.md**: Add "CRITICAL: Scope Discipline" section with forbidden actions, pre-commit scope check procedure, and guidance on handling unrelated problems
- **doctor.md**: Add "CRITICAL: Scope Discipline" section with scope verification procedure specific to test fix context

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Builder role has anti-scope-creep instructions | ✅ | Added section with explicit rules and pre-commit check |
| Doctor role has anti-scope-creep instructions | ✅ | Added section constraining changes to failing test files and code under test |
| Instructions include concrete enforcement mechanism | ✅ | Pre-commit `git diff --stat` check with revert command for out-of-scope files |

## Test Plan

These are documentation-only changes to role definition files. The changes add structural enforcement (pre-commit scope check procedure) rather than just advisory text.

Closes #2731