### PR TITLE
feat: add WORKTREE_ESCAPE exit code to prevent cross-issue escalation

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/exit_codes.py
+++ b/loom-tools/src/loom_tools/shepherd/exit_codes.py
@@ -27,6 +27,7 @@ class ShepherdExitCode(IntEnum):
     | 6         | No changes needed             | Mark blocked, await human review  |
     | 7         | Transient API error           | Requeue issue, retry after backoff|
     | 9         | Systemic failure (auth/API)   | Requeue issue, do NOT retry       |
+    | 12        | Worktree escape (transient)   | Requeue issue, retry normally     |
 
     Using IntEnum allows these to be used directly as exit codes:
         return ShepherdExitCode.SUCCESS
@@ -75,6 +76,12 @@ class ShepherdExitCode(IntEnum):
     # See issue #2521.
     SYSTEMIC_FAILURE = 9
 
+    # Builder escaped its worktree and modified main instead.
+    # Transient issue — not indicative of a problem with the issue itself.
+    # Should not contribute to cross-issue systematic failure escalation.
+    # See issue #2752.
+    WORKTREE_ESCAPE = 12
+
 
 # Convenience mapping for code interpretation
 EXIT_CODE_DESCRIPTIONS = {
@@ -88,6 +95,7 @@ EXIT_CODE_DESCRIPTIONS = {
     ShepherdExitCode.TRANSIENT_ERROR: "Transient API error - safe to retry after backoff",
     ShepherdExitCode.BUDGET_EXHAUSTED: "Budget exhausted - issue may need decomposition",
     ShepherdExitCode.SYSTEMIC_FAILURE: "Systemic failure (auth/API) - do not retry immediately",
+    ShepherdExitCode.WORKTREE_ESCAPE: "Worktree escape - builder modified main instead of worktree",
 }
 
 

--- a/loom-tools/tests/shepherd/test_cli.py
+++ b/loom-tools/tests/shepherd/test_cli.py
@@ -4207,6 +4207,29 @@ class TestRecordFallbackFailure:
         )
         mock_detect.assert_called_once_with(Path("/fake/repo"))
 
+    @patch("loom_tools.common.systematic_failure.detect_systematic_failure", return_value=None)
+    @patch("loom_tools.common.systematic_failure.record_blocked_reason")
+    def test_records_worktree_escape_class(
+        self,
+        mock_record: MagicMock,
+        mock_detect: MagicMock,
+    ) -> None:
+        """Should record builder_worktree_escape for worktree escape exit code."""
+        ctx = MagicMock()
+        ctx.config.issue = 42
+        ctx.repo_root = Path("/fake/repo")
+
+        _record_fallback_failure(ctx, ShepherdExitCode.WORKTREE_ESCAPE)
+
+        mock_record.assert_called_once_with(
+            Path("/fake/repo"),
+            42,
+            error_class="builder_worktree_escape",
+            phase="builder",
+            details="Builder escaped worktree and modified main instead (fallback cleanup)",
+        )
+        mock_detect.assert_called_once_with(Path("/fake/repo"))
+
     @patch("loom_tools.common.systematic_failure.detect_systematic_failure")
     @patch("loom_tools.common.systematic_failure.record_blocked_reason")
     def test_survives_record_failure(

--- a/loom-tools/tests/shepherd/test_exit_codes.py
+++ b/loom-tools/tests/shepherd/test_exit_codes.py
@@ -51,6 +51,10 @@ class TestShepherdExitCode:
         """TRANSIENT_ERROR should be 7."""
         assert ShepherdExitCode.TRANSIENT_ERROR == 7
 
+    def test_worktree_escape_is_twelve(self) -> None:
+        """WORKTREE_ESCAPE should be 12."""
+        assert ShepherdExitCode.WORKTREE_ESCAPE == 12
+
     def test_can_use_as_int(self) -> None:
         """Exit codes should be usable as integers."""
         assert int(ShepherdExitCode.SUCCESS) == 0
@@ -111,6 +115,11 @@ class TestDescribeExitCode:
         """Should describe TRANSIENT_ERROR exit code."""
         desc = describe_exit_code(7)
         assert "transient" in desc.lower() or "retry" in desc.lower()
+
+    def test_describes_worktree_escape(self) -> None:
+        """Should describe WORKTREE_ESCAPE exit code."""
+        desc = describe_exit_code(12)
+        assert "worktree" in desc.lower() or "escape" in desc.lower()
 
     def test_unknown_code_returns_message(self) -> None:
         """Should return message for unknown exit codes."""


### PR DESCRIPTION
## Summary
Adds a distinct `WORKTREE_ESCAPE` exit code (12) and `builder_worktree_escape` error class so that worktree escapes are not lumped with `builder_unknown_failure` in the systematic failure detector. This prevents cross-issue escalation when multiple unrelated issues each experience a single transient worktree escape.

## Changes
- Added `WORKTREE_ESCAPE = 12` to `ShepherdExitCode` enum with description
- Updated builder non-test failure classification to check `worktree_escape` in result data before falling through to `BUILDER_FAILED`
- Updated `_record_fallback_failure` to classify `WORKTREE_ESCAPE` as `builder_worktree_escape` error class
- Added tests for the new exit code value, description, and fallback failure classification

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| New WORKTREE_ESCAPE exit code exists | ✅ | Added as value 12 in ShepherdExitCode enum |
| worktree_escape in result data maps to new exit code | ✅ | Checked before auth_failure in cli.py:818-819 |
| _record_fallback_failure classifies as builder_worktree_escape | ✅ | New elif branch in cli.py:2049-2050 |
| Existing tests still pass | ✅ | All 48 tests pass (31 exit codes + 17 escape detection) |
| New tests cover the classification | ✅ | test_worktree_escape_is_twelve, test_describes_worktree_escape, test_records_worktree_escape_class |

## Test Plan
- `pytest loom-tools/tests/shepherd/test_exit_codes.py` — 16 tests pass (including 2 new)
- `pytest loom-tools/tests/shepherd/test_cli.py::TestRecordFallbackFailure` — 6 tests pass (including 1 new)
- `pytest loom-tools/tests/shepherd/test_builder_escape_detection.py` — 17 tests pass (unchanged)

Closes #2752