### PR TITLE
docs: add test failure diagnostic patterns to Doctor role instructions

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -1960,7 +1960,7 @@ class BuilderPhase:
 
             # New failure from supplemental test
             combined = (result.stdout + "\n" + result.stderr).strip()
-            tail_lines = combined.splitlines()[-10:]
+            tail_lines = combined.splitlines()[-50:]
             summary = self._parse_test_summary(combined)
             changed_files = get_changed_files(cwd=ctx.worktree_path) if ctx.worktree_path else []
 
@@ -2423,7 +2423,7 @@ class BuilderPhase:
 
         # Tests failed with new errors
         summary = self._parse_test_summary(output)
-        tail_lines = output.strip().splitlines()[-10:]
+        tail_lines = output.strip().splitlines()[-50:]
         tail_text = "\n".join(tail_lines)
 
         if summary:
@@ -2431,7 +2431,7 @@ class BuilderPhase:
         else:
             log_error(f"Tests failed (exit code {result.returncode}, {elapsed}s)")
 
-        log_info(f"Test output (last 10 lines):\n{tail_text}")
+        log_info(f"Test output (last 50 lines):\n{tail_text}")
         ctx.report_milestone(
             "heartbeat",
             action=f"test verification failed ({elapsed}s)",
@@ -2803,7 +2803,7 @@ class BuilderPhase:
         # Tests failed with new errors (or no baseline available)
         summary = self._parse_test_summary(primary_output)
         combined = primary_output.strip()
-        tail_lines = combined.splitlines()[-10:]
+        tail_lines = combined.splitlines()[-50:]
         tail_text = "\n".join(tail_lines)
 
         if summary:
@@ -2811,7 +2811,7 @@ class BuilderPhase:
         else:
             log_error(f"Tests failed (exit code {result.returncode}, {elapsed}s)")
 
-        log_info(f"Test output (last 10 lines):\n{tail_text}")
+        log_info(f"Test output (last 50 lines):\n{tail_text}")
         ctx.report_milestone(
             "heartbeat",
             action=f"test verification failed ({elapsed}s)",


### PR DESCRIPTION
## Summary
Improves the Doctor's ability to fix simple test assertion mismatches by adding structured diagnostic patterns to the test-fix mode instructions and increasing the test output context provided in failure context files.

## Changes
- Add new step in Doctor test-fix mode: explicitly re-run the failing test to see full traceback (was missing before)
- Add "Test Failure Diagnostic Patterns" section with 4 recognized patterns and fix strategies:
  - Pattern 1: Assertion value mismatch (most common — the specific failure class from issue #2730)
  - Pattern 2: Missing import or attribute
  - Pattern 3: Mock setup mismatch
  - Pattern 4: Structural change (new/removed fields)
- Add general diagnostic checklist as fallback
- Increase `test_output_tail` from 10 to 50 lines in the builder's test failure context, capturing assertion details that were previously truncated

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Doctor instructions include pattern for assertion value mismatches | ✅ | Pattern 1 in doctor.md covers `assert_called_once_with`, `assert X == Y`, and mock call mismatches with concrete example from the issue |
| Doctor has step-by-step strategy for assertion fixes | ✅ | 5-step strategy: find test → read assertion → read implementation → update test → verify |
| Doctor is told to re-run tests for full output | ✅ | New step 5 explicitly instructs re-running the test command |
| Test output context captures assertion details | ✅ | `test_output_tail` increased from 10 to 50 lines in all 3 builder failure paths |

## Test Plan
- `pytest loom-tools/tests/shepherd/test_doctor_phase.py` — all 6 tests pass
- Verified `builder.py` module imports correctly
- Verified all `splitlines()[-10:]` occurrences updated to `[-50:]`

Closes #2730