### PR TITLE
fix: add diagnostic logging and MCP_PREFLIGHT_FAILED sentinel to wrapper pre-flight

### DIFF
--- a/defaults/scripts/claude-wrapper.sh
+++ b/defaults/scripts/claude-wrapper.sh
@@ -1238,12 +1238,18 @@ run_preflight_checks() {
         fi
     fi
 
+    log_info "Running MCP server pre-flight check..."
     if ! check_mcp_server; then
         log_error "MCP server pre-flight check failed"
+        # Write sentinel so the shepherd can distinguish MCP pre-flight failures
+        # from generic low-output sessions.  Mirrors AUTH_PREFLIGHT_FAILED.
+        # See issue #2706.
+        echo "# MCP_PREFLIGHT_FAILED" >&2
         return 1
     fi
+    log_info "MCP server pre-flight check passed"
 
-    log_info "Pre-flight checks passed"
+    log_info "All pre-flight checks passed"
     return 0
 }
 
@@ -1277,6 +1283,7 @@ main() {
     fi
 
     # Run Claude with retry logic
+    log_info "Pre-flight complete, launching Claude CLI..."
     run_with_retry "$@"
     exit_code=$?
 

--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -14951,6 +14951,30 @@ class TestIsMcpFailure:
         )
         assert _is_mcp_failure(log) is False
 
+    def test_mcp_preflight_sentinel_detected(self, tmp_path: Path) -> None:
+        """MCP_PREFLIGHT_FAILED sentinel should be detected as MCP failure.
+
+        The wrapper writes this sentinel when check_mcp_server() fails before
+        the CLI even starts.  See issue #2706.
+        """
+        log = tmp_path / "session.log"
+        log.write_text(
+            "[INFO] Claude wrapper starting\n"
+            "[INFO] Running MCP server pre-flight check...\n"
+            "[ERROR] MCP server pre-flight check failed\n"
+            "# MCP_PREFLIGHT_FAILED\n"
+        )
+        assert _is_mcp_failure(log) is True
+
+    def test_mcp_preflight_sentinel_with_ansi(self, tmp_path: Path) -> None:
+        """MCP pre-flight sentinel detected even with ANSI escape codes."""
+        log = tmp_path / "session.log"
+        log.write_text(
+            "\033[0;31m[ERROR] MCP server pre-flight check failed\033[0m\n"
+            "# MCP_PREFLIGHT_FAILED\n"
+        )
+        assert _is_mcp_failure(log) is True
+
 
 class TestStripSpinnerNoise:
     """Test _strip_spinner_noise helper function."""


### PR DESCRIPTION
## Summary
Adds explicit diagnostic logging around the MCP server pre-flight check in `claude-wrapper.sh` and a `MCP_PREFLIGHT_FAILED` sentinel so the shepherd can classify MCP pre-flight failures for targeted retry. Previously, failures between the auth pre-flight and `CLAUDE_CLI_START` produced no log output, making 0-char builder sessions impossible to diagnose.

## Changes
- Add `log_info "Running MCP server pre-flight check..."` before `check_mcp_server()`
- Add `log_info "MCP server pre-flight check passed"` after successful check
- Add `# MCP_PREFLIGHT_FAILED` sentinel to stderr on MCP pre-flight failure (mirrors `AUTH_PREFLIGHT_FAILED`)
- Add `log_info "Pre-flight complete, launching Claude CLI..."` before `run_with_retry()`
- Change "Pre-flight checks passed" to "All pre-flight checks passed" for clarity
- Add `_MCP_PREFLIGHT_SENTINEL` constant to shepherd `base.py` and integrate into `_is_mcp_failure()`
- Add 2 tests for sentinel detection (with and without ANSI codes)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Log before `check_mcp_server()` | ✅ | Added `Running MCP server pre-flight check...` |
| Log after `check_mcp_server()` success/failure | ✅ | Added pass/fail messages + sentinel |
| Log before `run_with_retry()` | ✅ | Added `Pre-flight complete, launching Claude CLI...` |
| Every exit path between pre-flight and CLAUDE_CLI_START writes diagnostic | ✅ | MCP failure, stop signal, and normal flow all log |
| Shepherd can classify MCP pre-flight failures | ✅ | `_is_mcp_failure()` detects `MCP_PREFLIGHT_FAILED` sentinel |

## Test Plan
- Ran `TestIsMcpFailure` class (22 tests): all pass including 2 new sentinel tests
- Ran full Python test suite (3360 passed, 32 skipped)
- Changes in both `defaults/scripts/claude-wrapper.sh` and `.loom/scripts/claude-wrapper.sh` are identical

Closes #2706