### PR TITLE
feat: retry builder once on worktree escape with main cleanup

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/config.py
+++ b/loom-tools/src/loom_tools/shepherd/config.py
@@ -185,6 +185,9 @@ class ShepherdConfig:
     test_fix_max_retries: int = field(
         default_factory=lambda: env_int("LOOM_TEST_FIX_MAX_RETRIES", 2)
     )
+    escape_max_retries: int = field(
+        default_factory=lambda: env_int("LOOM_ESCAPE_MAX_RETRIES", 1)
+    )
 
     # Rate limiting
     rate_limit_threshold: int = field(


### PR DESCRIPTION
## Summary
When the builder escapes its worktree and modifies main instead of the issue worktree, the shepherd now reverts the dirty files on main, resets the stale worktree, and retries the builder once before failing. This recovers from the transient Claude Code path-resolution issue that caused ~28 builder failures on 2026-02-17.

## Changes
- Add `escape_max_retries` config field (default 1, env `LOOM_ESCAPE_MAX_RETRIES`) to `ShepherdConfig`
- Add retry loop in `BuilderPhase.run()` that triggers on worktree escape detection
- Add `_revert_escaped_main_files()` method that uses `git checkout`/`git clean` to restore main
- Handle fatal exit codes (shutdown, non-zero) during escape retry
- Re-snapshot main dirty baseline before each retry attempt
- Add tests for `_revert_escaped_main_files` (tracked, untracked, mixed files) and config

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Revert dirty files on main | ✅ | `_revert_escaped_main_files()` runs `git checkout` for tracked and `git clean` for untracked files |
| Reset stale worktree | ✅ | Calls existing `_reset_stale_worktree(ctx)` before retry |
| Re-snapshot baseline | ✅ | `_main_dirty_baseline` updated before retry |
| Retry builder once | ✅ | `run_phase_with_retry()` re-invoked inside while loop |
| Second escape returns FAILED | ✅ | Loop exits when `escape_retries >= escape_max_retries` |
| Configurable retry cap | ✅ | `escape_max_retries` field with env var override |

## Test Plan
- All 24 escape detection tests pass (including 7 new tests)
- All 1321 shepherd tests pass
- New tests cover: no-op on clean, tracked file revert, untracked file removal, mixed files, config defaults, env override, zero-disables

Closes #2751