### PR TITLE
fix: preserve builder exit code via sidecar file when agent-wait returns 0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ Thumbs.db
 .loom/status/
 .loom/progress/
 .loom/retry-state/
+.loom/exit-codes/
 .loom/diagnostics/
 .loom/guide-docs-state.json
 .loom/metrics_state.json


### PR DESCRIPTION
## Summary

- **claude-wrapper.sh** now writes its exit code to `.loom/exit-codes/<session>.exit` on every exit path (normal, pre-flight failure, signal kill via SIGHUP)
- **run_worker_phase()** reads the sidecar file after agent-wait returns and overrides `wait_exit = 0` when the wrapper actually exited non-zero
- Stale sidecar files from previous runs are cleaned up before spawning new sessions
- Added `.loom/exit-codes/` to `.gitignore`
- 4 new tests covering: sidecar override, zero passthrough, missing file, stale cleanup

## Test plan

- [x] All 842 existing tests pass (including 34 RunWorkerPhase tests)
- [x] 4 new `TestRunWorkerPhaseSidecarExitCode` tests pass
- [x] Wrapper script passes `bash -n` syntax check
- [ ] Manual verification: run `/shepherd <issue> -m` and observe that MCP startup failures are immediately detected instead of entering the 7-minute test verification path

Closes #2737

🤖 Generated with [Claude Code](https://claude.com/claude-code)