### PR TITLE
Clippy warnings on main branch (pre-existing failures tolerated by builder)

### DIFF
--- a/loom-daemon/tests/integration_basic.rs
+++ b/loom-daemon/tests/integration_basic.rs
@@ -91,6 +91,7 @@ async fn test_create_terminal() {
 /// Test 2.2: Create terminal with working directory
 #[tokio::test]
 #[serial]
+#[allow(clippy::panic)]
 async fn test_create_terminal_with_working_dir() {
     setup();
 


### PR DESCRIPTION
Closes #2764

> **Note:** This PR was created automatically via the builder recovery path. The builder produced changes but exited before creating a PR. Reviewers should examine the diff carefully.

## Changes

```
loom-daemon/tests/integration_basic.rs | 1 +
 1 file changed, 1 insertion(+)
```

## Commits

- `5347fdc feat: clippy warnings on main branch (pre-existing failures tolerated by builder)`

## Test plan

- [ ] Review diff carefully (recovery-created PR)
- [ ] Verify changes match issue requirements
- [ ] Run tests locally if needed