### PR TITLE
fix: shepherd stderr output lost when invoked non-interactively

### DIFF
--- a/defaults/scripts/loom-shepherd.sh
+++ b/defaults/scripts/loom-shepherd.sh
@@ -83,6 +83,11 @@ if [[ -n "$unmerged" ]]; then
     exit 1
 fi
 
+# Disable Python output buffering so stderr reaches callers immediately.
+# Without this, output is lost when invoked non-interactively (e.g., Claude Code
+# Bash tool, Task agents) because Python buffers stderr and may not flush before exit.
+export PYTHONUNBUFFERED=1
+
 # Try Python implementation first
 # Priority order:
 #   1. Virtual environment in loom-tools (from source or recorded path)


### PR DESCRIPTION
Closes #2765

> **Note:** This PR was created automatically via the builder recovery path. The builder produced changes but exited before creating a PR. Reviewers should examine the diff carefully.

## Changes

```
defaults/scripts/loom-shepherd.sh | 5 +++++
 1 file changed, 5 insertions(+)
```

## Commits

- `40e23ec fix: shepherd stderr output lost when invoked non-interactively`

## Test plan

- [ ] Review diff carefully (recovery-created PR)
- [ ] Verify changes match issue requirements
- [ ] Run tests locally if needed