### PR TITLE
Clean up stale shepherd progress files from manual runs

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/context.py
+++ b/loom-tools/src/loom_tools/shepherd/context.py
@@ -6,6 +6,7 @@ import logging
 import os
 import subprocess
 import tempfile
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -88,8 +89,6 @@ class ShepherdContext:
 
         stale_threshold = 24 * 3600  # 24 hours in seconds
         deleted = 0
-        import time
-
         now = time.time()
         for progress_file in progress_dir.glob("shepherd-*.json"):
             try:


### PR DESCRIPTION
Closes #2762

> **Note:** This PR was created automatically via the builder recovery path. The builder produced changes but exited before creating a PR. Reviewers should examine the diff carefully.

## Changes

```
loom-tools/src/loom_tools/shepherd/context.py | 36 +++++++++++++++++++++++++++
 1 file changed, 36 insertions(+)
```

## Commits

- `542b3c1 feat: clean up stale shepherd progress files from manual runs`

## Test plan

- [ ] Review diff carefully (recovery-created PR)
- [ ] Verify changes match issue requirements
- [ ] Run tests locally if needed