### PR TITLE
Investigate MCP server startup failure adding ~5s latency per agent phase

### DIFF
--- a/defaults/scripts/claude-wrapper.sh
+++ b/defaults/scripts/claude-wrapper.sh
@@ -856,7 +856,7 @@ start_startup_monitor() {
     local monitor_pid_file="$2"
 
     (
-        local check_interval=5
+        local check_interval=2
         local elapsed=0
 
         while [[ "${elapsed}" -lt "${STARTUP_MONITOR_WINDOW}" ]]; do
@@ -895,8 +895,9 @@ start_startup_monitor() {
                 # Poll for loom MCP connection within the grace period.
                 # Check BEFORE sleeping so that if the MCP connected before
                 # the failure was noticed (common case — MCP init ~1-3s,
-                # first output check at ~5s) we skip the delay entirely.
+                # first output check at ~2s) we skip the delay entirely.
                 # See issue #2660 for why single-shot was insufficient.
+                # See issue #2763 for check_interval reduction (5s → 2s).
                 # If all project MCPs connected, the session is allowed to
                 # continue (global plugin failures won't self-resolve).
                 # Otherwise, we kill the session to avoid a degraded state


### PR DESCRIPTION
Closes #2763

> **Note:** This PR was created automatically via the builder recovery path. The builder produced changes but exited before creating a PR. Reviewers should examine the diff carefully.

## Changes

```
defaults/scripts/claude-wrapper.sh | 65 +++++++++++++++++++++++---------------
 1 file changed, 40 insertions(+), 25 deletions(-)
```

## Commits

- `3c2a35f feat: investigate MCP server startup failure adding ~5s latency per agent phase`

## Test plan

- [ ] Review diff carefully (recovery-created PR)
- [ ] Verify changes match issue requirements
- [ ] Run tests locally if needed