### PR TITLE
fix: improve recovery PR quality when builder exits without completing git workflow

### DIFF
--- a/loom-tools/src/loom_tools/validate_phase.py
+++ b/loom-tools/src/loom_tools/validate_phase.py
@@ -988,12 +988,15 @@ def validate_builder(
     # Detect whether the builder was rate-limited (affects PR messaging)
     rate_limited = _is_rate_limited_builder_exit(issue, repo_root)
 
-    # Fetch issue title for the PR title
+    # Fetch issue title and generate a conventional PR title
+    from loom_tools.common.paths import NamingConventions
+
     r_title = _run_gh(
         ["issue", "view", str(issue), "--json", "title", "--jq", ".title"],
         repo_root,
     )
-    pr_title = r_title.stdout.strip() if r_title.returncode == 0 and r_title.stdout.strip() else f"Issue #{issue}"
+    raw_title = r_title.stdout.strip() if r_title.returncode == 0 and r_title.stdout.strip() else None
+    pr_title = NamingConventions.pr_title(raw_title, issue)
 
     pr_body = _build_recovery_pr_body(issue, worktree, rate_limited=rate_limited)
 


### PR DESCRIPTION
Closes #2775

## Summary

- Extracted `_build_direct_completion_pr_body()` in builder.py to generate richer PR bodies with commit log, diff stats, recovery note, and test plan sections
- Fixed `validate_phase.py` recovery to use `NamingConventions.pr_title()` instead of raw issue titles for consistent PR title formatting
- Added recovery milestone logging when direct completion succeeds for better observability
- Updated 7 existing tests and added 2 new tests for the PR body generation

## Changes

**builder.py**: The direct completion PR body was previously just `## Summary` + issue title + `## Changes` + diff stat. Now includes:
- `Closes #N` reference
- Recovery note explaining the PR was auto-created
- `## Changes` section with diff stats  
- `## Commits` section with commit log
- `## Test plan` section with verification checklist

**validate_phase.py**: Recovery PRs now use `NamingConventions.pr_title(title, issue)` instead of the raw issue title, producing conventional commit-style titles (e.g., "fix: handle auth timeout (#42)" instead of "Handle auth timeout").

## Test plan

- [x] All 935 tests pass (847 phase tests + 88 validate_phase tests)
- [x] 2 new tests for `_build_direct_completion_pr_body` (with/without diff stats)
- [x] 7 existing direct completion tests updated for new body generation