### PR TITLE
bug: shepherd output invisible when invoked from Claude Code Bash tool

### DIFF
--- a/defaults/scripts/check-usage.sh
+++ b/defaults/scripts/check-usage.sh
@@ -13,7 +13,10 @@
 # OAuth token from the macOS Keychain and calls the Anthropic usage API.
 
 if command -v loom-usage &>/dev/null; then
-    exec loom-usage "$@"
+    # No exec — exec makes output invisible in CLI tool contexts
+    # (e.g., Claude Code Bash tool). See loom-shepherd.sh for full rationale.
+    loom-usage "$@"
+    exit $?
 fi
 
-exec python3 -m loom_tools.common.usage "$@"
+python3 -m loom_tools.common.usage "$@"

--- a/defaults/scripts/loom-daemon.sh
+++ b/defaults/scripts/loom-daemon.sh
@@ -94,7 +94,9 @@ fi
 
 if [[ -n "$LOOM_TOOLS" ]] && [[ -x "$LOOM_TOOLS/.venv/bin/loom-daemon" ]]; then
     # Use venv from loom-tools directory
-    exec "$LOOM_TOOLS/.venv/bin/loom-daemon" ${args[@]+"${args[@]}"}
+    # Note: intentionally NOT using exec — see loom-shepherd.sh for rationale.
+    # exec makes output invisible in CLI tool contexts (Claude Code Bash tool).
+    "$LOOM_TOOLS/.venv/bin/loom-daemon" ${args[@]+"${args[@]}"}
 elif command -v loom-daemon &>/dev/null; then
     # System-installed - verify loom_tools can be imported
     if ! python3 -c "import loom_tools" 2>/dev/null; then
@@ -109,7 +111,8 @@ elif command -v loom-daemon &>/dev/null; then
         echo "" >&2
         exit 1
     fi
-    exec loom-daemon ${args[@]+"${args[@]}"}
+    # No exec — same rationale as above
+    loom-daemon ${args[@]+"${args[@]}"}
 else
     echo "[ERROR] Python daemon not available." >&2
     echo "" >&2

--- a/defaults/scripts/loom-shepherd.sh
+++ b/defaults/scripts/loom-shepherd.sh
@@ -96,10 +96,15 @@ export PYTHONUNBUFFERED=1
 
 if [[ -n "$LOOM_TOOLS" ]] && [[ -x "$LOOM_TOOLS/.venv/bin/loom-shepherd" ]]; then
     # Use venv from loom-tools directory
-    exec "$LOOM_TOOLS/.venv/bin/loom-shepherd" "${args[@]}"
+    # Note: intentionally NOT using exec. exec replaces the shell process,
+    # which causes output to be invisible in some CLI tool contexts (e.g.,
+    # Claude Code Bash tool) because the tool loses its output capture handle
+    # on the replaced process. Running as a child preserves output capture
+    # while set -e ensures exit code propagation.
+    "$LOOM_TOOLS/.venv/bin/loom-shepherd" "${args[@]}"
 elif command -v loom-shepherd &>/dev/null; then
-    # System-installed
-    exec loom-shepherd "${args[@]}"
+    # System-installed (same rationale as above — no exec)
+    loom-shepherd "${args[@]}"
 else
     echo "[ERROR] Python shepherd not available." >&2
     echo "" >&2

--- a/loom-tools/tests/test_installation_verification.py
+++ b/loom-tools/tests/test_installation_verification.py
@@ -153,7 +153,7 @@ class TestWrapperScriptRouting:
     def test_shepherd_wrapper_routes_to_python(
         self, defaults_dir: pathlib.Path, repo_root: pathlib.Path
     ) -> None:
-        """loom-shepherd.sh should exec the Python loom-shepherd command."""
+        """loom-shepherd.sh should invoke the Python loom-shepherd command."""
         script = defaults_dir / "scripts" / "loom-shepherd.sh"
         assert script.exists(), "loom-shepherd.sh not found in defaults/scripts/"
 
@@ -162,9 +162,10 @@ class TestWrapperScriptRouting:
         assert ".venv/bin/loom-shepherd" in content, (
             "loom-shepherd.sh doesn't check for venv Python binary"
         )
-        # Should exec the binary
-        assert 'exec "$LOOM_TOOLS/.venv/bin/loom-shepherd"' in content, (
-            "loom-shepherd.sh doesn't exec the venv binary"
+        # Should invoke the binary (without exec — exec breaks output capture
+        # in CLI tool contexts like Claude Code Bash tool)
+        assert '"$LOOM_TOOLS/.venv/bin/loom-shepherd" "${args[@]}"' in content, (
+            "loom-shepherd.sh doesn't invoke the venv binary"
         )
         # Should also check PATH fallback
         assert "command -v loom-shepherd" in content, (


### PR DESCRIPTION
Closes #2783

> **Note:** This PR was created automatically via the builder recovery path. The builder produced changes but exited before creating a PR. Reviewers should examine the diff carefully.

## Changes

```
defaults/scripts/check-usage.sh                    |  7 +++++--
 defaults/scripts/loom-daemon.sh                    |  7 +++++--
 defaults/scripts/loom-shepherd.sh                  | 11 ++++++++---
 loom-tools/tests/test_installation_verification.py |  9 +++++----
 4 files changed, 23 insertions(+), 11 deletions(-)
```

## Commits

- `a652637 feat: bug: shepherd output invisible when invoked from Claude Code Bash tool`

## Test plan

- [ ] Review diff carefully (recovery-created PR)
- [ ] Verify changes match issue requirements
- [ ] Run tests locally if needed