### PR TITLE
fix: strip global MCP plugins from agent config to prevent ghost sessions

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/base.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/base.py
@@ -94,9 +94,11 @@ MCP_FAILURE_MIN_OUTPUT_CHARS = 500
 
 # Maximum retries for MCP failure detection, with longer backoff.
 # MCP failures are often systemic (stale build, resource contention)
-# so we use longer backoff than low-output.
+# so we use longer backoff than low-output.  The MCP server can take
+# up to 20s to become ready after a restart, so the initial backoff
+# must be at least that long to avoid wasting attempts.  See issue #2799.
 MCP_FAILURE_MAX_RETRIES = 3
-MCP_FAILURE_BACKOFF_SECONDS = [5, 15, 30]
+MCP_FAILURE_BACKOFF_SECONDS = [20, 30, 60]
 
 # Startup monitor resolution marker.  When this substring appears in a session
 # log, the wrapper's startup monitor confirmed that all *project* MCP servers
@@ -118,7 +120,7 @@ GHOST_SESSION_BACKOFF_SECONDS = [10, 30, 60]
 # Similar to LOW_OUTPUT_RETRY_STRATEGIES.  See issue #2644.
 GHOST_RETRY_STRATEGIES: dict[str, tuple[int, list[int]]] = {
     "auth_failure": (0, []),           # Auth issues won't resolve with retries
-    "mcp_init_failure": (3, [10, 30, 60]),  # MCP failures need retries; startup monitor now kills degraded sessions (issue #2652)
+    "mcp_init_failure": (3, [20, 30, 60]),  # MCP server needs ~20s to be ready; see issue #2799
     "api_unreachable": (1, [30]),      # API blip might be transient
     "wrapper_crash": (0, []),          # Script errors won't self-heal
     "unknown": (GHOST_SESSION_MAX_RETRIES, list(GHOST_SESSION_BACKOFF_SECONDS)),

--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -17505,7 +17505,7 @@ class TestRunPhaseWithRetryGhostCauseSpecific:
             )
 
         _, backoff = GHOST_RETRY_STRATEGIES["mcp_init_failure"]
-        assert backoff == [10, 30, 60]
+        assert backoff == [20, 30, 60]
         sleep_calls = [c.args[0] for c in mock_sleep.call_args_list]
         assert sleep_calls == backoff
 


### PR DESCRIPTION
## Summary

Global MCP plugins (e.g. `rust-analyzer-lsp`, `swift-lsp`) loaded from `~/.claude/settings.json` fail in headless agent sessions and can prevent Claude CLI from processing input, producing ghost sessions that waste 3+ minutes of retry time per shepherd run. This change isolates agents from global plugins by copying `settings.json` with `enabledPlugins` stripped, rather than symlinking it.

## Changes

- **Python (`claude_config.py`)**: Added `_copy_settings_without_plugins()` — copies settings.json stripping the `enabledPlugins` key. Removed `settings.json` from `_SHARED_CONFIG_FILES` (no longer symlinked). Called during `setup_agent_config_dir()`.
- **Rust (`terminal.rs`)**: Added equivalent `copy_settings_without_plugins()` function. Same removal from `SHARED_CONFIG_FILES`. Both implementations kept in sync.
- **Backoff tuning (`base.py`)**: Increased `MCP_FAILURE_BACKOFF_SECONDS` from `[5, 15, 30]` to `[20, 30, 60]` and ghost `mcp_init_failure` backoff from `[10, 30, 60]` to `[20, 30, 60]` — the MCP server needs ~20s to become ready after restart.
- **Tests**: 6 new Python tests for `_copy_settings_without_plugins()`, 4 new Rust tests, updated 2 existing tests for the new backoff values and settings.json handling.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Global plugins stripped from agent settings | ✅ | `_copy_settings_without_plugins` removes `enabledPlugins` key |
| All other settings preserved (model, theme, permissions) | ✅ | Tests verify all non-plugin keys are copied |
| Python and Rust implementations in sync | ✅ | Both use copy-and-strip approach, same key removal |
| Idempotent (existing settings.json not overwritten) | ✅ | Both check `!dst.exists()` before copying |
| MCP backoff tuning applied | ✅ | Backoff values updated, tests updated to match |

## Test Plan

- [x] 37 Python claude_config tests pass (6 new)
- [x] 20 Rust claude_config tests pass (4 new)
- [x] 851 Python phase tests pass (1 updated for backoff)
- [x] Full test suite: 888 Python tests + 20 Rust tests, all passing

Closes #2799