### PR TITLE
docs: add double-prefix anti-pattern and issue title prefix mapping to builder guides

### DIFF
--- a/defaults/.claude/commands/builder-pr.md
+++ b/defaults/.claude/commands/builder-pr.md
@@ -392,6 +392,12 @@ Issue #2557
 Builder should generate descriptive PR titles instead of generic 'Issue #N'
 ```
 
+**WRONG (double prefix — issue title's own prefix copied and another prefix prepended):**
+```
+feat: bug: MCP status bar noise misclassifies builder failures as MCP failures
+fix: feat: add workspace snapshot caching for daemon state
+```
+
 **CORRECT (describes what the code change actually does):**
 ```
 fix: standardize timestamp format to ISO 8601 UTC across log scripts
@@ -400,6 +406,26 @@ refactor: rename instant-exit to low-output terminology
 docs: update troubleshooting guide for worktree cleanup
 fix: prevent duplicate label transitions in shepherd phase validator
 ```
+
+### Issue Title Prefix Mapping
+
+Issue titles sometimes use non-standard prefixes (like `bug:`) that are **not** valid conventional commit types. If you're tempted to use an issue title as inspiration for your PR title, be aware that you must strip and remap the issue prefix — never copy it verbatim.
+
+| Issue Title Prefix | Correct PR Prefix | Notes |
+|-------------------|-------------------|-------|
+| `bug:` | `fix:` | `bug:` is not a conventional commit type |
+| `feature:` | `feat:` | Abbreviate to `feat:` |
+| `feat:` | `feat:` | Already valid — but still rewrite the description |
+| `fix:` | `fix:` | Already valid — but still rewrite the description |
+| `docs:` | `docs:` | Already valid — but still rewrite the description |
+| `chore:` | `chore:` | Already valid — but still rewrite the description |
+
+**CRITICAL**: Never prepend a new prefix to a title that already has one. `feat: bug: MCP status bar...` is malformed. Instead:
+1. Strip the issue title prefix entirely
+2. Map to the correct conventional commit type using the table above
+3. Rewrite the summary to describe what your **code change does**, not what the issue says
+
+Remember: even if an issue title has a valid prefix, the PR title should describe your diff — not copy the issue title.
 
 ### Why This Matters
 
@@ -415,6 +441,7 @@ Before creating a PR, verify your title:
 - [ ] Describes what the PR **does**, not what issue it addresses
 - [ ] Does NOT contain generic phrases like "implement changes for", "address issue", or "implement feature from"
 - [ ] Does NOT reference an issue number in the title (issue references go in the PR body)
+- [ ] Does NOT contain double prefixes (e.g., `feat: bug:`, `fix: feat:`) — strip any prefix from the issue title before composing your own
 - [ ] Is under 70 characters
 - [ ] A reader can understand the change from the title alone without looking at the diff
 

--- a/defaults/.claude/commands/builder.md
+++ b/defaults/.claude/commands/builder.md
@@ -705,7 +705,12 @@ git diff   # Read the actual changes
 #
 #   WRONG: "feat: implement changes for issue #2678"
 #   WRONG: "Builder generates generic commit/PR titles despite explicit anti-patterns"
+#   WRONG: "feat: bug: MCP status bar noise..." (double prefix — copied issue title prefix)
 #   RIGHT: "docs: add mandatory diff-review step before commit/PR creation"
+#
+#   NOTE: If the issue title starts with a prefix like "bug:", "feat:", etc.,
+#   do NOT copy it verbatim. Strip the issue prefix and derive your own from the diff.
+#   "bug:" → use "fix:" in the PR title. See builder-pr.md for the full mapping.
 
 # Step 3: Use the same approach for the PR title
 ```


### PR DESCRIPTION
## Summary

Builder agents were creating malformed PR titles like `feat: bug: MCP status bar noise...` by blindly prepending a conventional commit prefix to issue titles that already had their own prefix. This PR adds structural guidance to prevent this:

1. Explicit `feat: bug: ...` anti-pattern example in the Examples section of builder-pr.md
2. New "Issue Title Prefix Mapping" subsection with a table mapping issue prefixes (e.g., `bug:`) to correct conventional commit types (e.g., `fix:`)
3. New checklist item in PR Title Checklist: "Does NOT contain double prefixes"
4. Inline note in builder.md's MANDATORY section warning about the double-prefix anti-pattern and pointing to builder-pr.md for the mapping

## Changes
- `defaults/.claude/commands/builder-pr.md`: Add WRONG double-prefix example, new "Issue Title Prefix Mapping" subsection, and double-prefix checklist item
- `defaults/.claude/commands/builder.md`: Add double-prefix anti-pattern to the MANDATORY diff-review section inline comment

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Detect if issue title already has a conventional commit prefix | ✅ | New "Issue Title Prefix Mapping" section gives explicit guidance |
| Map `bug:` → `fix:` (and other issue-style → conventional types) | ✅ | Mapping table covers `bug:`, `feature:`, `feat:`, `fix:`, `docs:`, `chore:` |
| Guidance to infer appropriate prefix if absent | ✅ | Existing "How to Derive the Title" + mapping table cover both cases |
| Prevent double-prefix titles like `feat: bug: ...` | ✅ | New WRONG example + checklist item + CRITICAL note in mapping section |

## Test Plan

Documentation-only change. Verified by reading the updated sections in context:
- The double-prefix WRONG example is concrete and immediately recognizable
- The prefix mapping table is the first reference point when looking at an issue title
- The PR title checklist now has an explicit gate for double prefixes
- The MANDATORY section in builder.md now warns inline at the point of action

## Pre-existing Issues (Not Addressed)

`pnpm check:ci` fails in the worktree due to missing `loom-daemon-aarch64-apple-darwin` build artifact — this pre-existing failure also exists on main branch and is unrelated to these documentation changes.

Closes #2796