### PR TITLE
feat: builder zero-output failures should surface post-mortem in validation error message

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -3613,6 +3613,11 @@ class BuilderPhase:
             parts.append(last_error)
         if diag["low_output_cause"]:
             parts.append(f"low_output_cause={diag['low_output_cause']}")
+        # Surface post-mortem analysis in the summary so operators can
+        # distinguish rate limits, auth failures, and MCP crashes from
+        # the validation error message alone.  See issue #2801.
+        if diag.get("postmortem") and diag["postmortem"].get("summary"):
+            parts.append(f"postmortem: {diag['postmortem']['summary']}")
         if diag["worktree_exists"]:
             if diag["has_uncommitted_changes"]:
                 uncommitted_note = f"{diag['uncommitted_file_count']} files"


### PR DESCRIPTION
Closes #2801

> **Note:** This PR was created automatically via the builder recovery path. The builder produced changes but exited before creating a PR. Reviewers should examine the diff carefully.

## Changes

```
.../src/loom_tools/shepherd/phases/builder.py      |  5 +++
 loom-tools/tests/shepherd/test_phases.py           | 42 +++++++++++++++++++++-
 2 files changed, 46 insertions(+), 1 deletion(-)
```

## Commits

- `58afb7b feat: builder zero-output failures should surface post-mortem in validation error message`

## Test plan

- [ ] Review diff carefully (recovery-created PR)
- [ ] Verify changes match issue requirements
- [ ] Run tests locally if needed