### PR TITLE
fix: ensure shepherd logging is visible when invoked non-interactively

### DIFF
--- a/loom-tools/src/loom_tools/common/logging.py
+++ b/loom-tools/src/loom_tools/common/logging.py
@@ -56,7 +56,7 @@ def _emit(color: str, label: str, message: str) -> None:
         line = f"{color}{ts} [{label}]{_RESET} {message}"
     else:
         line = f"{ts} [{label}] {message}"
-    print(line, file=sys.stderr)
+    print(line, file=sys.stderr, flush=True)
 
 
 def log_info(message: str) -> None:


### PR DESCRIPTION
## Summary

Fixes #2797: shepherd CLI output was invisible when invoked non-interactively (Claude Code Bash tool, piped contexts) because Python block-buffers stderr when it's not a tty.

**Three-layer fix:**
- `logging._emit()`: add `flush=True` so every `log_info`/`log_warning`/`log_error`/`log_success` call flushes stderr immediately, without relying on `PYTHONUNBUFFERED`
- `cli._print_phase_header()`: add `flush=True` to phase banner prints
- `cli.main()`: call `sys.stderr.reconfigure(line_buffering=True)` at startup to cover all remaining print-to-stderr calls

The wrapper script fix (removing `exec`, adding `PYTHONUNBUFFERED=1`) was previously applied in #2794. These changes make the CLI robust even when invoked directly without the wrapper — e.g., `python3 -m loom_tools.shepherd.cli 42 --force`.

**Regression test:** Added `test_log_output_visible_non_interactively` in `test_logging.py` that runs the logging functions via subprocess without `PYTHONUNBUFFERED` and asserts all output is captured in stderr.

## Test plan

- [x] `PYTHONPATH=loom-tools/src:$PYTHONPATH python3 -m pytest loom-tools/tests/test_logging.py -v` — 13 tests pass (includes new non-interactive test)
- [x] `PYTHONPATH=loom-tools/src:$PYTHONPATH python3 -m pytest loom-tools/tests/ -k "logging or shepherd or wrapper"` — 1508 tests pass
- [x] `PYTHONPATH=loom-tools/src:$PYTHONPATH python3 -m pytest loom-tools/tests/test_installation_verification.py` — 61 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)