### PR TITLE
fix: classify small-log short-duration sessions as ghost to protect builder retry budget

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/base.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/base.py
@@ -190,6 +190,19 @@ _TOOL_CALL_MARKER = "⏺"
 # classified as low-output (exit code 6) instead of ghost (exit code 10).
 GHOST_SESSION_WALL_CLOCK_THRESHOLD = 30.0
 
+# Maximum raw log file size (in bytes) for the size-based ghost detection
+# fallback.  Sessions with a small raw log AND short wall-clock duration
+# are almost certainly infrastructure failures (MCP-startup kill, spawn
+# race, API blip) even when their cleaned output appears "substantial"
+# due to the Claude CLI banner or wrapper pre-flight boilerplate.
+# The canonical example: wrapper kills Claude after detecting "MCP server
+# failed" in the first 50 lines — log contains only preflight + banner
+# (~2.7KB) but may have ≥100 chars of cleaned CLI output because not all
+# banner lines are filtered.  5KB provides a generous margin above the
+# observed 2.7KB while staying well below any session that did real work.
+# See issue #2800.
+GHOST_SMALL_LOG_THRESHOLD_BYTES = 5 * 1024  # 5 KB
+
 # Systemic failure patterns detected in session logs.
 # These indicate infrastructure-level failures (auth timeout, API outage)
 # that will NOT resolve with retries.  When detected after a low-output
@@ -888,12 +901,25 @@ def _is_ghost_session(
     signal to distinguish ghost sessions (infrastructure failures) from
     long-running stuck sessions.  See issue #2659.
 
-    1. If the log contains meaningful CLI output → **not a ghost**.
+    1. If the log contains meaningful CLI output → **not a ghost** …unless
+       the raw log is tiny (< GHOST_SMALL_LOG_THRESHOLD_BYTES) *and* the
+       session was very short (≤ GHOST_SESSION_WALL_CLOCK_THRESHOLD). See
+       item 3 below.
     2. If no meaningful output, check duration:
        - Wall-clock ≤ GHOST_SESSION_WALL_CLOCK_THRESHOLD (30s) → ghost.
        - File-timestamp fallback ≤ same threshold → ghost.
        - Duration exceeds threshold → not a ghost (classified as
          low-output via exit code 6 instead).
+    3. **Size-based fallback** (issue #2800): even when cleaned content
+       appears "substantial" (≥ 100 chars), a session whose *raw* log is
+       < 5 KB *and* ran for < 30s is almost certainly an infrastructure
+       failure.  The canonical case is the startup monitor killing Claude
+       after detecting "MCP server failed" in the first 50 lines — the log
+       contains only wrapper preflight + the Claude CLI banner (~2.7 KB),
+       but after ANSI-stripping, some banner lines survive the UI-chrome
+       filter and push the cleaned char count over 100.  Treating these
+       as ghost sessions (exit code 10) routes them to the separate
+       ``ghost_retries`` budget instead of failing immediately.
 
     The wide 30s threshold accommodates MCP initialization delays that
     can push ghost sessions to 7s+ of wall-clock time while producing
@@ -926,7 +952,18 @@ def _is_ghost_session(
         cli_output = _get_cli_output(stripped)
         cleaned = _strip_ui_chrome(_strip_spinner_noise(cli_output))
         if len(cleaned.strip()) >= LOW_OUTPUT_MIN_CHARS:
-            # Meaningful output present — not a ghost regardless of duration.
+            # The cleaned output looks substantial, but if the raw log is
+            # tiny AND the session was very short, the "content" is just
+            # banner/preflight boilerplate that survived stripping — not
+            # real work.  Classify as ghost so it uses the separate
+            # ghost_retries budget instead of failing immediately.
+            # See issue #2800.
+            if wall_clock_duration is not None and (
+                len(content) < GHOST_SMALL_LOG_THRESHOLD_BYTES
+                and wall_clock_duration <= GHOST_SESSION_WALL_CLOCK_THRESHOLD
+            ):
+                return True
+            # Meaningful output in a non-tiny log — not a ghost.
             return False
 
         # No meaningful output.  Use duration as a secondary signal to
@@ -1843,21 +1880,6 @@ def run_worker_phase(
         )
         return 11
 
-    # Check for thinking stall (exit code 14) — output with zero tool calls.
-    # The session produced thinking/spinner output but never invoked a tool,
-    # indicating extended thinking under resource pressure.  Not retryable:
-    # the same conditions will produce the same result.  Check after degraded
-    # (which is more specific) and before MCP/low-output.  See issue #2784.
-    if _is_thinking_stall_session(log_path):
-        if postmortem is not None:
-            log_warning(f"Post-mortem: {postmortem['summary']}")
-        log_warning(
-            f"Thinking stall detected for {role} session '{actual_name}': "
-            f"output produced but zero tool calls "
-            f"(exit code {wait_exit}, log: {log_path})"
-        )
-        return 14
-
     # Check for MCP failure (exit code 7) — more specific than low-output,
     # with different retry/backoff strategy.  See issues #2135, #2279.
     #
@@ -1866,7 +1888,14 @@ def run_worker_phase(
     # it starts, receives the prompt, can't use MCP tools, produces nothing,
     # and exits "cleanly."  The _is_mcp_failure() function already gates on
     # low output volume, so productive sessions aren't misclassified.
-    # See issue #2767.
+    #
+    # IMPORTANT: Check MCP failure BEFORE thinking stall.  MCP failure
+    # sessions show the CLI startup UI (>100 chars, no tool calls) which
+    # matches the thinking stall pattern.  Thinking stall is not retryable
+    # (exit 14) but MCP failure is (exit 7).  Since _is_mcp_failure() gates
+    # on low output volume, productive sessions that genuinely stall in
+    # extended thinking won't be misclassified as MCP failures — they have
+    # too much output to pass the MCP volume gate.  See issues #2767, #2804.
     if _is_mcp_failure(log_path):
         # Gather postmortem lazily for exit-0 MCP failures (postmortem is
         # only pre-gathered for non-zero exits above).  See issue #2766.
@@ -1884,6 +1913,24 @@ def run_worker_phase(
         )
         log_warning(f"Post-mortem: {postmortem['summary']}")
         return 7
+
+    # Check for thinking stall (exit code 14) — output with zero tool calls.
+    # The session produced thinking/spinner output but never invoked a tool,
+    # indicating extended thinking under resource pressure.  Not retryable:
+    # the same conditions will produce the same result.  Check after degraded
+    # (which is more specific) and after MCP failure (which is retryable and
+    # would otherwise be misclassified as thinking stall).
+    # See issues #2784, #2804.
+    if _is_thinking_stall_session(log_path):
+        if postmortem is not None:
+            log_warning(f"Post-mortem: {postmortem['summary']}")
+        log_warning(
+            f"Thinking stall detected for {role} session '{actual_name}': "
+            f"output produced but zero tool calls "
+            f"(exit code {wait_exit}, log: {log_path})"
+        )
+        return 14
+
     if wait_exit != 0 and _is_low_output_session(log_path):
         assert postmortem is not None
         log_warning(

--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -28,6 +28,8 @@ from loom_tools.shepherd.phases.base import (
     GHOST_RETRY_STRATEGIES,
     GHOST_SESSION_BACKOFF_SECONDS,
     GHOST_SESSION_MAX_RETRIES,
+    GHOST_SESSION_WALL_CLOCK_THRESHOLD,
+    GHOST_SMALL_LOG_THRESHOLD_BYTES,
     LOW_OUTPUT_BACKOFF_SECONDS,
     LOW_OUTPUT_MAX_ATTEMPT_SECONDS,
     LOW_OUTPUT_MAX_RETRIES,
@@ -2536,6 +2538,9 @@ class TestBuilderRunTestFailureIntegration:
             ),
             patch.object(builder, "_preserve_on_test_failure") as mock_preserve,
             patch.object(builder, "_cleanup_on_failure") as mock_cleanup,
+            # validate returns False: PR does not yet exist, so fast-path skips
+            # test verification must run (issue #2803).
+            patch.object(builder, "validate", return_value=False),
             patch(
                 "loom_tools.shepherd.phases.builder.run_phase_with_retry",
                 return_value=0,
@@ -2589,6 +2594,49 @@ class TestBuilderRunTestFailureIntegration:
 
         assert result.status == PhaseStatus.SUCCESS
         # Test verification should NOT have been called
+        mock_test_verify.assert_not_called()
+
+    def test_run_skips_test_verification_when_pr_already_exists(
+        self, mock_context: MagicMock
+    ) -> None:
+        """run() should skip test verification when PR with loom:review-requested exists.
+
+        When the builder worker exits and the PR already has loom:review-requested,
+        the shepherd should skip test verification and proceed directly to the judge
+        phase. This eliminates ~7 minutes of dead time between builder and judge.
+        See issue #2803.
+        """
+        builder = BuilderPhase()
+        mock_context.config.issue = 42
+        mock_context.repo_root = Path("/fake/repo")
+        mock_context.check_shutdown.return_value = False
+        mock_context.has_issue_label.return_value = False
+        worktree_mock = MagicMock()
+        worktree_mock.is_dir.return_value = True
+        mock_context.worktree_path = worktree_mock
+
+        with (
+            patch.object(builder, "_is_rate_limited", return_value=False),
+            patch.object(builder, "_run_quality_validation", return_value=None),
+            patch.object(builder, "_create_worktree_marker"),
+            patch.object(builder, "_run_test_verification") as mock_test_verify,
+            # validate returns True: PR with loom:review-requested already exists
+            patch.object(builder, "validate", return_value=True),
+            patch(
+                "loom_tools.shepherd.phases.builder.run_phase_with_retry",
+                return_value=0,
+            ),
+            patch("loom_tools.shepherd.phases.builder.transition_issue_labels"),
+            # Return None first (no existing PR check), then 123 (PR found)
+            patch(
+                "loom_tools.shepherd.phases.builder.get_pr_for_issue",
+                side_effect=[None, 123],
+            ),
+        ):
+            result = builder.run(mock_context)
+
+        assert result.status == PhaseStatus.SUCCESS
+        # Test verification should NOT have been called (PR already exists)
         mock_test_verify.assert_not_called()
 
 
@@ -15735,6 +15783,54 @@ class TestRunWorkerPhaseMcpFailure:
         # _is_low_output_session should NOT be called when MCP failure is detected
         mock_low_output.assert_not_called()
 
+    def test_mcp_failure_checked_before_thinking_stall(
+        self, mock_context: MagicMock
+    ) -> None:
+        """MCP failure (retryable, exit 7) should take priority over thinking stall.
+
+        An MCP failure session shows the CLI startup UI (>100 chars, no tool calls)
+        which matches the thinking stall pattern.  Since thinking stall is not
+        retryable (exit 14) but MCP failure is (exit 7), MCP failure must be
+        checked first.  See issue #2804.
+        """
+
+        def mock_spawn(cmd, **kwargs):
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        def mock_popen(cmd, **kwargs):
+            proc = MagicMock()
+            proc.poll.return_value = 0
+            proc.returncode = 0
+            return proc
+
+        with (
+            patch("subprocess.run", side_effect=mock_spawn),
+            patch("subprocess.Popen", side_effect=mock_popen),
+            patch("time.sleep"),
+            patch(
+                "loom_tools.shepherd.phases.base._is_mcp_failure", return_value=True
+            ) as mock_mcp,
+            patch(
+                "loom_tools.shepherd.phases.base._is_thinking_stall_session",
+                return_value=True,
+            ) as mock_stall,
+        ):
+            exit_code = run_worker_phase(
+                mock_context,
+                role="builder",
+                name="builder-issue-42",
+                timeout=600,
+                phase="builder",
+            )
+
+        # MCP failure (7) takes priority over thinking stall (14)
+        assert exit_code == 7
+        mock_mcp.assert_called_once()
+        # _is_thinking_stall_session should NOT be called when MCP failure is detected
+        mock_stall.assert_not_called()
+
 
 class TestRunPhaseWithRetryMcpFailure:
     """Test that run_phase_with_retry retries on MCP failure (code 7)."""
@@ -16894,12 +16990,19 @@ class TestIsGhostSession:
         assert _is_ghost_session(log, wall_clock_duration=7.0) is True
 
     def test_meaningful_output_long_duration_not_ghost(self, tmp_path: Path) -> None:
-        """Session with meaningful output is NOT a ghost regardless of duration."""
+        """Large log with meaningful output is NOT a ghost regardless of duration.
+
+        A session that produced substantial content (log > 5 KB) did real work
+        and should not be classified as a ghost even with a short wall-clock
+        duration.  The size-based fallback (issue #2800) only fires for tiny
+        logs, so this test uses a log file that exceeds the threshold.
+        """
         log = tmp_path / "session.log"
-        log.write_text(
-            "# CLAUDE_CLI_START\n"
-            + "x" * (LOW_OUTPUT_MIN_CHARS + 1)
-        )
+        # Use enough content to exceed both LOW_OUTPUT_MIN_CHARS AND
+        # GHOST_SMALL_LOG_THRESHOLD_BYTES so neither check fires.
+        content = "x" * GHOST_SMALL_LOG_THRESHOLD_BYTES
+        log.write_text("# CLAUDE_CLI_START\n" + content)
+        assert log.stat().st_size >= GHOST_SMALL_LOG_THRESHOLD_BYTES
         assert _is_ghost_session(log, wall_clock_duration=2.0) is False
 
     def test_sentinel_present_no_cli_output_zero_duration(self, tmp_path: Path) -> None:
@@ -16931,6 +17034,115 @@ class TestIsGhostSession:
             "───────────────────\n"
         )
         assert _is_ghost_session(log) is True
+
+    # --- Size-based fallback detection (issue #2800) ---
+
+    def test_small_log_short_duration_is_ghost_even_with_content(
+        self, tmp_path: Path
+    ) -> None:
+        """Small raw log + short wall-clock → ghost even if cleaned content ≥ 100 chars.
+
+        MCP-failure sessions killed by the startup monitor contain only
+        wrapper preflight + the CLI banner (~2.7 KB).  After ANSI-stripping,
+        some banner lines survive the UI-chrome filter and push the cleaned
+        char count over 100.  The size-based fallback classifies them as
+        ghost sessions so they use the separate ghost_retries budget.
+        See issue #2800.
+        """
+        log = tmp_path / "session.log"
+        # Build a log that:
+        # 1. Has a CLI start sentinel (so _get_cli_output returns something)
+        # 2. Has enough content after cleaning to exceed LOW_OUTPUT_MIN_CHARS
+        # 3. Has a raw file size < GHOST_SMALL_LOG_THRESHOLD_BYTES
+        # Simulate partial banner content that isn't fully stripped (e.g.,
+        # text not matched by any _UI_CHROME_LINE_PATTERNS regex).
+        cli_content = "x" * (LOW_OUTPUT_MIN_CHARS + 50)  # > 100 cleaned chars
+        log_text = f"# CLAUDE_CLI_START\n{cli_content}\n"
+        assert len(log_text) < GHOST_SMALL_LOG_THRESHOLD_BYTES, (
+            "Test setup error: log is too large to test size-based detection"
+        )
+        log.write_text(log_text)
+
+        # Small log + short wall-clock → ghost (size-based fallback fires)
+        assert _is_ghost_session(log, wall_clock_duration=15.0) is True
+
+    def test_small_log_long_duration_not_ghost(self, tmp_path: Path) -> None:
+        """Small raw log but long wall-clock duration → NOT a ghost.
+
+        Even a tiny log should not be classified as a ghost if the session
+        ran for longer than GHOST_SESSION_WALL_CLOCK_THRESHOLD.  A session
+        that ran for 45s, even if it produced little output, should use the
+        low-output retry path rather than the ghost path.
+        """
+        log = tmp_path / "session.log"
+        cli_content = "x" * (LOW_OUTPUT_MIN_CHARS + 50)
+        log.write_text(f"# CLAUDE_CLI_START\n{cli_content}\n")
+
+        # Small log BUT long wall-clock → not a ghost
+        assert _is_ghost_session(log, wall_clock_duration=45.0) is False
+
+    def test_large_log_short_duration_not_ghost(self, tmp_path: Path) -> None:
+        """Large raw log + short wall-clock → NOT a ghost (real work happened).
+
+        A session that produced a large log did real work, even if it exited
+        quickly.  The size-based fallback must not misclassify these.
+        """
+        log = tmp_path / "session.log"
+        # Build a log that exceeds GHOST_SMALL_LOG_THRESHOLD_BYTES
+        padding = "x" * GHOST_SMALL_LOG_THRESHOLD_BYTES
+        log.write_text(f"# CLAUDE_CLI_START\n{padding}\n")
+        assert log.stat().st_size >= GHOST_SMALL_LOG_THRESHOLD_BYTES
+
+        # Large log → not a ghost regardless of duration
+        assert _is_ghost_session(log, wall_clock_duration=5.0) is False
+
+    def test_small_log_short_duration_mcp_failure_is_ghost(
+        self, tmp_path: Path
+    ) -> None:
+        """MCP-failure session with small log + short duration IS a ghost.
+
+        The canonical case from issue #2800: the startup monitor kills Claude
+        after detecting 'MCP server failed'.  The log has wrapper preflight
+        + CLI banner + the MCP error text, totalling ~2.7 KB.  After cleaning,
+        the MCP error text (> 100 chars) makes the session look non-ghost,
+        but the size-based fallback correctly classifies it as ghost.
+        """
+        log = tmp_path / "session.log"
+        # Simulate a 2.7KB log: wrapper preflight (excluded) + CLI start +
+        # banner lines that survive stripping + MCP error text
+        mcp_error = (
+            "MCP server failed: Unable to connect to server 'loom'\n"
+            "PluginToolManager: Failed to load 3 tools from MCP server\n"
+            "Session initialization incomplete - tools unavailable\n"
+        )
+        # This content exceeds LOW_OUTPUT_MIN_CHARS after cleaning
+        assert len(mcp_error) > LOW_OUTPUT_MIN_CHARS
+        log_text = f"# CLAUDE_CLI_START\n{mcp_error}"
+        assert len(log_text) < GHOST_SMALL_LOG_THRESHOLD_BYTES
+        log.write_text(log_text)
+
+        # Small MCP-failure log + short duration → ghost (size-based fallback)
+        assert _is_ghost_session(log, wall_clock_duration=18.0) is True
+
+    def test_size_based_fallback_requires_wall_clock_duration(
+        self, tmp_path: Path
+    ) -> None:
+        """Size-based fallback only fires when wall_clock_duration is provided.
+
+        Without wall_clock_duration, the function falls back to file timestamp
+        heuristics, which cannot trigger the size-based path.  This ensures
+        the new check doesn't change behavior for callers that don't pass
+        wall_clock_duration.
+        """
+        log = tmp_path / "session.log"
+        cli_content = "x" * (LOW_OUTPUT_MIN_CHARS + 50)
+        log.write_text(f"# CLAUDE_CLI_START\n{cli_content}\n")
+
+        # Without wall_clock_duration, meaningful content → not a ghost
+        # (falls through to timestamp heuristic, which sees ~0s duration
+        # for a freshly-created file — but that path only fires if cleaned
+        # content is < LOW_OUTPUT_MIN_CHARS, which it isn't here)
+        assert _is_ghost_session(log) is False
 
 
 class TestRunWorkerPhaseGhostSession:


### PR DESCRIPTION
## Summary

- Add `GHOST_SMALL_LOG_THRESHOLD_BYTES = 5KB` constant to `_is_ghost_session()` as a size-based fallback: sessions with raw log < 5KB AND wall-clock ≤ 30s are classified as ghost regardless of cleaned content length
- Reorder thinking stall check (exit 14) to come AFTER MCP failure check (exit 7) — MCP failure sessions show CLI startup UI that matches the thinking stall pattern, but should be retried via `ghost_retries`, not aborted
- Add 5 new `TestIsGhostSession` test cases covering the size-based fallback scenarios
- Fix existing `test_meaningful_output_long_duration_not_ghost` to use a large-enough log that the new check doesn't misclassify it

## Root Cause

The startup monitor kills Claude after detecting "MCP server failed" in the first 50 lines. The resulting log (~2.7KB) contains only wrapper preflight + CLI banner, but after ANSI/UI-chrome stripping, banner lines push cleaned content above `LOW_OUTPUT_MIN_CHARS` (100 chars). This caused the session to escape ghost detection and consume a real `stuck_retries` builder attempt instead of the separate `ghost_retries` budget.

Observed in issue #2784: 4 of 7 builder attempts were dead MCP-failure sessions (2.7KB logs, 15-20s runtime).

## Test Plan

- [x] All 17 `TestIsGhostSession` tests pass
- [x] New tests cover: small log + short duration → ghost, small log + long duration → not ghost, large log + short duration → not ghost, MCP error text in small log → ghost, missing wall_clock_duration → size check doesn't fire

Closes #2800