### PR TITLE
fix: set LC_ALL=C on tr invocations that process TUI output

### DIFF
--- a/defaults/scripts/claude-wrapper.sh
+++ b/defaults/scripts/claude-wrapper.sh
@@ -123,11 +123,11 @@ _pipe_pane_captured_content() {
     local _pp_temp="$1" _pp_log="$2" _pp_growth="$3"
     [[ $_pp_growth -le 0 ]] && return 1
     local _pp_log_norm
-    _pp_log_norm=$(tail -n "$_pp_growth" "$_pp_log" 2>/dev/null | tr -cd '[:alnum:]' | head -c 5000)
+    _pp_log_norm=$(tail -n "$_pp_growth" "$_pp_log" 2>/dev/null | LC_ALL=C tr -cd '[:alnum:]' | head -c 5000)
     [[ ${#_pp_log_norm} -lt 10 ]] && return 1
     local _pp_probe
     while IFS= read -r _pp_probe; do
-        _pp_probe=$(tr -cd '[:alnum:]' <<< "$_pp_probe")
+        _pp_probe=$(LC_ALL=C tr -cd '[:alnum:]' <<< "$_pp_probe")
         [[ ${#_pp_probe} -lt 12 ]] && continue
         [[ "$_pp_log_norm" == *"$_pp_probe"* ]] && return 0
     done < <(grep -v '^[[:space:]]*$' "$_pp_temp" 2>/dev/null | grep -v '^#' | tail -20 | head -5)
@@ -797,7 +797,7 @@ start_output_monitor() {
                 # non-alphanumeric chars to handle TUI garbling, then match
                 # the distinctive prompt text.
                 local normalized
-                normalized=$(echo "${tail_content}" | tr -cd '[:alnum:]')
+                normalized=$(echo "${tail_content}" | LC_ALL=C tr -cd '[:alnum:]')
                 if echo "${normalized}" | grep -qi "Stopandwaitforlimittoreset" 2>/dev/null; then
                     log_warn "Output monitor: CLI usage/plan limit prompt detected — killing claude"
                     echo "# RATE_LIMIT_ABORT" >&2
@@ -898,7 +898,7 @@ start_startup_monitor() {
             # Check for CLI usage/plan limit prompt in early output.
             # The limit prompt often appears within seconds of startup.
             local head_normalized
-            head_normalized=$(echo "${head_content}" | tr -cd '[:alnum:]')
+            head_normalized=$(echo "${head_content}" | LC_ALL=C tr -cd '[:alnum:]')
             if echo "${head_normalized}" | grep -qi "Stopandwaitforlimittoreset" 2>/dev/null; then
                 log_warn "Startup monitor: CLI usage/plan limit prompt detected — killing claude"
                 echo "# RATE_LIMIT_ABORT" >&2


### PR DESCRIPTION
## Summary
The `tr` command emits `tr: Illegal byte sequence` errors when processing the non-UTF-8 bytes that Claude CLI's TUI renderer emits. This adds noise to agent logs and causes `tr` to exit with code 1, potentially corrupting results in the output normalization pipeline.

## Changes
- Prefix all four `tr -cd '[:alnum:]'` calls in `claude-wrapper.sh` with `LC_ALL=C` so `tr` treats input as raw bytes and silently skips non-ASCII bytes instead of erroring

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `tr: Illegal byte sequence` errors eliminated | ✅ | `printf '\x80hello' \| LC_ALL=C tr -cd '[:alnum:]'` exits 0 and returns `hello`; without `LC_ALL=C` exits 1 with the error |
| All four `tr -cd` call sites fixed | ✅ | `grep -n 'LC_ALL=C tr' defaults/scripts/claude-wrapper.sh` shows lines 126, 130, 800, 901 |
| No functional change to normalization logic | ✅ | `LC_ALL=C` only changes how `tr` interprets multi-byte sequences; ASCII alphanumeric filtering is identical |

## Test Plan
Verified locally:
- `printf '\x80\x81\x82hello\x83world' | LC_ALL=C tr -cd '[:alnum:]'` → outputs `helloworld`, exit 0
- `printf '\x80\x81\x82hello\x83world' | tr -cd '[:alnum:]'` → `tr: Illegal byte sequence`, exit 1 (original bug reproduced)

Closes #2806