### PR TITLE
fix: set LC_ALL=C on tr invocations that process TUI output

### DIFF
--- a/defaults/scripts/claude-wrapper.sh
+++ b/defaults/scripts/claude-wrapper.sh
@@ -123,11 +123,11 @@ _pipe_pane_captured_content() {
     local _pp_temp="$1" _pp_log="$2" _pp_growth="$3"
     [[ $_pp_growth -le 0 ]] && return 1
     local _pp_log_norm
-    _pp_log_norm=$(tail -n "$_pp_growth" "$_pp_log" 2>/dev/null | tr -cd '[:alnum:]' | head -c 5000)
+    _pp_log_norm=$(tail -n "$_pp_growth" "$_pp_log" 2>/dev/null | LC_ALL=C tr -cd '[:alnum:]' | head -c 5000)
     [[ ${#_pp_log_norm} -lt 10 ]] && return 1
     local _pp_probe
     while IFS= read -r _pp_probe; do
-        _pp_probe=$(tr -cd '[:alnum:]' <<< "$_pp_probe")
+        _pp_probe=$(LC_ALL=C tr -cd '[:alnum:]' <<< "$_pp_probe")
         [[ ${#_pp_probe} -lt 12 ]] && continue
         [[ "$_pp_log_norm" == *"$_pp_probe"* ]] && return 0
     done < <(grep -v '^[[:space:]]*$' "$_pp_temp" 2>/dev/null | grep -v '^#' | tail -20 | head -5)
@@ -797,7 +797,7 @@ start_output_monitor() {
                 # non-alphanumeric chars to handle TUI garbling, then match
                 # the distinctive prompt text.
                 local normalized
-                normalized=$(echo "${tail_content}" | tr -cd '[:alnum:]')
+                normalized=$(echo "${tail_content}" | LC_ALL=C tr -cd '[:alnum:]')
                 if echo "${normalized}" | grep -qi "Stopandwaitforlimittoreset" 2>/dev/null; then
                     log_warn "Output monitor: CLI usage/plan limit prompt detected — killing claude"
                     echo "# RATE_LIMIT_ABORT" >&2
@@ -898,7 +898,7 @@ start_startup_monitor() {
             # Check for CLI usage/plan limit prompt in early output.
             # The limit prompt often appears within seconds of startup.
             local head_normalized
-            head_normalized=$(echo "${head_content}" | tr -cd '[:alnum:]')
+            head_normalized=$(echo "${head_content}" | LC_ALL=C tr -cd '[:alnum:]')
             if echo "${head_normalized}" | grep -qi "Stopandwaitforlimittoreset" 2>/dev/null; then
                 log_warn "Startup monitor: CLI usage/plan limit prompt detected — killing claude"
                 echo "# RATE_LIMIT_ABORT" >&2


### PR DESCRIPTION
## Summary

Fixes `tr: Illegal byte sequence` errors in shepherd log capture pipelines by prefixing each `tr -cd '[:alnum:]'` call in `claude-wrapper.sh` with `LC_ALL=C`. This causes `tr` to treat input as raw bytes rather than multi-byte UTF-8 characters, silently skipping non-ASCII bytes instead of erroring when Claude CLI emits TUI escape sequences with non-ASCII bytes.

## Changes

- `defaults/scripts/claude-wrapper.sh`: Add `LC_ALL=C` prefix to all 4 `tr -cd '[:alnum:]'` invocations:
  - `_pipe_pane_captured_content()` - log norm pipeline
  - `_pipe_pane_captured_content()` - probe normalization
  - `start_output_monitor()` - tail content normalization
  - `start_startup_monitor()` - head content normalization

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `tr: Illegal byte sequence` errors eliminated | ✅ | LC_ALL=C causes tr to treat input as raw bytes, bypassing multi-byte UTF-8 parsing |
| Non-ASCII bytes silently skipped (not errored) | ✅ | LC_ALL=C's byte mode skips non-ASCII rather than raising errors |
| All tr invocations in the log pipeline updated | ✅ | All 4 occurrences in claude-wrapper.sh updated (diff confirms 4 changes) |

## Test Plan

The fix addresses the root cause: `tr` with a UTF-8 locale errors on non-ASCII bytes. `LC_ALL=C` switches to byte mode. Verified by inspecting the 4 changed lines match the pattern `LC_ALL=C tr -cd '[:alnum:]'`.

Closes #2806