### PR TITLE
feat: pass structured judge feedback context to doctor phase

### DIFF
--- a/defaults/.claude/commands/doctor.md
+++ b/defaults/.claude/commands/doctor.md
@@ -174,11 +174,35 @@ If none of the patterns above match clearly:
 
 ### Standard PR Fix Mode
 
-If a number is provided without `--test-fix` (e.g., `/doctor 123`):
+If a number is provided without `--test-fix` (e.g., `/doctor 123` or `/doctor 123 --context /path/to/context.json`):
 1. Treat that number as the target **PR** to fix
 2. **Skip** the "Finding Work" section entirely
 3. Claim the PR: `gh pr edit <number> --add-label "loom:treating"`
-4. Proceed directly to fixing that PR
+4. **Read the context file first** if `--context <path>` is provided (see below)
+5. Proceed directly to fixing that PR
+
+**Structured judge feedback context** (when `--context <path>` is provided):
+
+When invoked by the Shepherd after a judge rejection, a context file is written to help you understand exactly what the judge found wrong. **Read it before reading PR comments** — it provides a concise, structured view of the judge's feedback:
+
+```bash
+cat <path>
+```
+
+The context file (`.loom-judge-feedback.json`) contains:
+- `pr_number`: The PR being fixed
+- `issue`: The issue number
+- `context_type`: Always `"judge_feedback"` for this mode
+- `judge_comments`: List of the judge's most recent comments, each with:
+  - `body`: The full comment text (look for specific file paths, line numbers, and what to change)
+  - `author`: Who wrote the comment
+  - `created_at`: When the comment was posted
+
+**How to use the context:**
+1. Read `judge_comments` to understand what the judge requested
+2. Identify specific files and lines mentioned in the feedback
+3. Make the targeted fix before doing anything else
+4. Use `gh pr view <pr> --comments` for additional context if the structured feedback is insufficient
 
 If no argument is provided, use the normal "Finding Work" workflow below.
 

--- a/loom-tools/tests/shepherd/test_doctor_phase.py
+++ b/loom-tools/tests/shepherd/test_doctor_phase.py
@@ -183,7 +183,127 @@ class TestFullDoctorRunUnchanged:
                 return_value=DoctorDiagnostics(commits_made=0),
             ):
                 with patch.object(phase, "validate", return_value=True):
-                    phase.run(mock_context)
+                    with patch.object(
+                        phase, "_write_judge_feedback_context", return_value=None
+                    ):
+                        phase.run(mock_context)
 
         _, kwargs = mock_run.call_args
         assert kwargs["timeout"] == 3600
+
+
+class TestJudgeFeedbackContext:
+    """Tests for _write_judge_feedback_context and its integration into run()."""
+
+    @patch("loom_tools.shepherd.phases.doctor.run_phase_with_retry")
+    def test_run_passes_context_flag_when_context_file_written(
+        self, mock_run: MagicMock, mock_context: MagicMock
+    ) -> None:
+        """When context file is written, run() should pass --context flag to doctor."""
+        mock_run.return_value = 0
+        context_path = Path("/fake/repo/.loom/worktrees/issue-42/.loom-judge-feedback.json")
+
+        phase = DoctorPhase()
+        with patch.object(phase, "_get_commit_count", return_value=0):
+            with patch.object(
+                phase,
+                "_diagnose_doctor_outcome",
+                return_value=DoctorDiagnostics(commits_made=0),
+            ):
+                with patch.object(phase, "validate", return_value=True):
+                    with patch.object(
+                        phase,
+                        "_write_judge_feedback_context",
+                        return_value=context_path,
+                    ):
+                        phase.run(mock_context)
+
+        _, kwargs = mock_run.call_args
+        assert kwargs["args"] == f"100 --context {context_path}"
+
+    @patch("loom_tools.shepherd.phases.doctor.run_phase_with_retry")
+    def test_run_passes_only_pr_number_when_no_context_file(
+        self, mock_run: MagicMock, mock_context: MagicMock
+    ) -> None:
+        """When context file cannot be written, run() should pass just the PR number."""
+        mock_run.return_value = 0
+
+        phase = DoctorPhase()
+        with patch.object(phase, "_get_commit_count", return_value=0):
+            with patch.object(
+                phase,
+                "_diagnose_doctor_outcome",
+                return_value=DoctorDiagnostics(commits_made=0),
+            ):
+                with patch.object(phase, "validate", return_value=True):
+                    with patch.object(
+                        phase, "_write_judge_feedback_context", return_value=None
+                    ):
+                        phase.run(mock_context)
+
+        _, kwargs = mock_run.call_args
+        assert kwargs["args"] == "100"
+
+    @patch("loom_tools.shepherd.phases.doctor.subprocess.run")
+    def test_write_judge_feedback_context_success(
+        self, mock_subprocess: MagicMock, mock_context: MagicMock, tmp_path: Path
+    ) -> None:
+        """_write_judge_feedback_context writes a JSON context file on success."""
+        import json
+
+        mock_context.worktree_path = tmp_path
+        mock_subprocess.return_value = MagicMock(
+            returncode=0,
+            stdout='[{"body": "Fix the exit code at line 42", "author": "judge-bot", "created_at": "2026-01-01T00:00:00Z"}]',
+        )
+
+        phase = DoctorPhase()
+        result = phase._write_judge_feedback_context(mock_context)
+
+        assert result is not None
+        assert result == tmp_path / ".loom-judge-feedback.json"
+        assert result.exists()
+
+        data = json.loads(result.read_text())
+        assert data["pr_number"] == 100
+        assert data["issue"] == 42
+        assert data["context_type"] == "judge_feedback"
+        assert len(data["judge_comments"]) == 1
+        assert data["judge_comments"][0]["body"] == "Fix the exit code at line 42"
+
+    @patch("loom_tools.shepherd.phases.doctor.subprocess.run")
+    def test_write_judge_feedback_context_returns_none_on_gh_failure(
+        self, mock_subprocess: MagicMock, mock_context: MagicMock, tmp_path: Path
+    ) -> None:
+        """_write_judge_feedback_context returns None when gh command fails."""
+        mock_context.worktree_path = tmp_path
+        mock_subprocess.return_value = MagicMock(returncode=1, stdout="")
+
+        phase = DoctorPhase()
+        result = phase._write_judge_feedback_context(mock_context)
+
+        assert result is None
+
+    @patch("loom_tools.shepherd.phases.doctor.subprocess.run")
+    def test_write_judge_feedback_context_returns_none_on_empty_comments(
+        self, mock_subprocess: MagicMock, mock_context: MagicMock, tmp_path: Path
+    ) -> None:
+        """_write_judge_feedback_context returns None when PR has no comments."""
+        mock_context.worktree_path = tmp_path
+        mock_subprocess.return_value = MagicMock(returncode=0, stdout="[]")
+
+        phase = DoctorPhase()
+        result = phase._write_judge_feedback_context(mock_context)
+
+        assert result is None
+
+    def test_write_judge_feedback_context_returns_none_when_no_worktree(
+        self, mock_context: MagicMock
+    ) -> None:
+        """_write_judge_feedback_context returns None when worktree_path is not set."""
+        mock_context.worktree_path = None
+
+        phase = DoctorPhase()
+        result = phase._write_judge_feedback_context(mock_context)
+
+        assert result is None


### PR DESCRIPTION
Closes #2807

## Summary

When the judge requests changes on a PR, the shepherd now extracts the judge's recent PR comments and writes them to a structured JSON context file (`.loom-judge-feedback.json`) in the issue worktree. This context file is passed to the doctor worker via a `--context` flag, mirroring the existing test-fix context pattern introduced in `run_test_fix()`.

The doctor role is updated to read and prioritize this structured context before scanning PR comments, giving it a precise view of what the judge found wrong (specific comment text, file paths, line numbers).

## Changes

- **`loom-tools/src/loom_tools/shepherd/phases/doctor.py`**: Added `_write_judge_feedback_context()` method that fetches the PR's 10 most recent comments via `gh pr view` and writes them to `.loom-judge-feedback.json`. Modified `run()` to call this method and pass `--context <path>` to the doctor worker when successful.
- **`defaults/.claude/commands/doctor.md`** (also `.loom/roles/doctor.md` via symlink): Updated "Standard PR Fix Mode" section to describe reading the `--context` file first when provided.
- **`loom-tools/tests/shepherd/test_doctor_phase.py`**: Added `TestJudgeFeedbackContext` class with 6 tests covering context file writing, error cases, and `run()` integration.

## Test plan

- [x] All 12 tests in `test_doctor_phase.py` pass
- [x] Context file gracefully degrades: returns `None` on `gh` failure, empty comments, or missing worktree path
- [x] Doctor falls back to just PR number when context file not available