### PR TITLE
fix: delete own progress file on shepherd exit

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/cli.py
+++ b/loom-tools/src/loom_tools/shepherd/cli.py
@@ -17,7 +17,7 @@ from loom_tools.common.git import (
     parse_porcelain_path,
 )
 from loom_tools.common.logging import log_error, log_info, log_success, log_warning
-from loom_tools.common.paths import NamingConventions
+from loom_tools.common.paths import LoomPaths, NamingConventions
 from loom_tools.common.repo import find_repo_root
 from loom_tools.shepherd.config import ExecutionMode, Phase, QualityGates, ShepherdConfig
 from loom_tools.shepherd.context import ShepherdContext
@@ -2213,6 +2213,13 @@ def main(argv: list[str] | None = None) -> int:
         _remove_worktree_marker(ctx)
         # Always release the file-based claim on exit
         release_claim(repo_root, config.issue, agent_id)
+        # Delete our own progress file.  The daemon handles this via
+        # handle_shepherd_complete(), but manual /shepherd runs never
+        # trigger that path, so files accumulate indefinitely.
+        try:
+            LoomPaths(repo_root).progress_file(config.task_id).unlink(missing_ok=True)
+        except OSError:
+            pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes #2813

Manual `/shepherd` runs leave progress files in `.loom/progress/` that never get cleaned up because the daemon's `handle_shepherd_complete()` cleanup path is never triggered. Files accumulated to 126+ stale entries.

**Fix**: Add a `finally` block in `cli.py:main()` to delete the shepherd's own progress file on any exit — success, failure, or exception. The daemon still handles cleanup via `handle_shepherd_complete()` when running autonomously; this adds the missing path for manual runs.

The existing startup cleanup (`_cleanup_old_progress_files`) only removes files older than 24 hours — it won't catch files from the same day. This fix ensures each shepherd cleans up after itself immediately on exit.

## Changes

- `loom-tools/src/loom_tools/shepherd/cli.py`: Import `LoomPaths`, add progress file cleanup to `main()` `finally` block

## Test plan

- [ ] All 42 existing `test_context.py` tests pass ✓
- [ ] Run `/shepherd <issue>` manually and verify no progress file remains after completion
- [ ] Verify daemon-mode behavior unchanged (daemon still calls `handle_shepherd_complete`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)