### PR TITLE
fix: suppress 'Killed: 9 sleep' messages from output monitor cleanup

### DIFF
--- a/defaults/scripts/claude-wrapper.sh
+++ b/defaults/scripts/claude-wrapper.sh
@@ -773,11 +773,13 @@ start_output_monitor() {
     local monitor_pid_file="$2"
 
     (
+        trap 'exit 0' TERM INT
         local last_size=0
         local error_detected_at=0
 
         while true; do
-            sleep 5
+            sleep 5 &
+            wait $! || exit 0
 
             # Exit if output file is gone (session ended)
             if [[ ! -f "${output_file}" ]]; then
@@ -875,11 +877,13 @@ start_startup_monitor() {
     local monitor_pid_file="$2"
 
     (
+        trap 'exit 0' TERM INT
         local check_interval=2
         local elapsed=0
 
         while [[ "${elapsed}" -lt "${STARTUP_MONITOR_WINDOW}" ]]; do
-            sleep "${check_interval}"
+            sleep "${check_interval}" &
+            wait $! || exit 0
             elapsed=$((elapsed + check_interval))
 
             # Exit if output file is gone (session ended)
@@ -952,7 +956,8 @@ start_startup_monitor() {
                     fi
 
                     # Sleep AFTER checking so the first iteration is instant
-                    sleep "${poll_interval}"
+                    sleep "${poll_interval}" &
+                    wait $! || exit 0
                     grace_elapsed=$((grace_elapsed + poll_interval))
                 done
 


### PR DESCRIPTION
## Summary

- Add `trap 'exit 0' TERM INT` inside output monitor and startup monitor subshells so they exit cleanly when `stop_output_monitor` sends SIGTERM
- Change `sleep N` to `sleep N &; wait $! || exit 0` so signals are delivered immediately (bash's `wait` builtin is interruptible by trapped signals, unlike external `sleep`)
- Applied to all 3 sleep points: output monitor loop, startup monitor loop, and startup monitor grace period

Closes #2834

## Test plan

- [ ] Run a shepherd session and verify agent logs no longer contain `Killed: 9 sleep 5` during normal session completion
- [ ] Verify output monitor still terminates promptly when session ends (no 5-second delay)
- [ ] Verify API error detection still works (monitor correctly detects and acts on error patterns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)