### PR TITLE
fix: add pre-claim closed-issue check in shepherd main()

### DIFF
--- a/loom-tools/tests/shepherd/test_cli.py
+++ b/loom-tools/tests/shepherd/test_cli.py
@@ -363,6 +363,7 @@ class TestMain:
              patch("loom_tools.shepherd.cli.ShepherdContext"), \
              patch("loom_tools.shepherd.cli.find_repo_root", return_value=Path("/fake/repo")), \
              patch("loom_tools.shepherd.cli._auto_navigate_out_of_worktree"), \
+             patch("loom_tools.common.github.gh_issue_view", return_value={"state": "OPEN"}), \
              patch("loom_tools.claim.claim_issue", return_value=0), \
              patch("loom_tools.claim.release_claim"):
             result = main(["42"])
@@ -374,6 +375,7 @@ class TestMain:
              patch("loom_tools.shepherd.cli.ShepherdContext"), \
              patch("loom_tools.shepherd.cli.find_repo_root", return_value=Path("/fake/repo")), \
              patch("loom_tools.shepherd.cli._auto_navigate_out_of_worktree"), \
+             patch("loom_tools.common.github.gh_issue_view", return_value={"state": "OPEN"}), \
              patch("loom_tools.claim.claim_issue", return_value=0), \
              patch("loom_tools.claim.release_claim"):
             result = main(["42"])
@@ -394,6 +396,7 @@ class TestMain:
              patch("loom_tools.shepherd.cli.ShepherdContext", side_effect=track_context), \
              patch("loom_tools.shepherd.cli.find_repo_root", return_value=Path("/fake/repo")), \
              patch("loom_tools.shepherd.cli._auto_navigate_out_of_worktree", side_effect=track_navigate), \
+             patch("loom_tools.common.github.gh_issue_view", return_value={"state": "OPEN"}), \
              patch("loom_tools.claim.claim_issue", return_value=0), \
              patch("loom_tools.claim.release_claim"):
             main(["42"])
@@ -416,6 +419,7 @@ class TestMain:
              patch("loom_tools.shepherd.cli.find_repo_root", return_value=Path("/fake/repo")), \
              patch("loom_tools.shepherd.cli._auto_navigate_out_of_worktree"), \
              patch("loom_tools.shepherd.cli.get_uncommitted_files", return_value=["M file.py"]), \
+             patch("loom_tools.common.github.gh_issue_view", return_value={"state": "OPEN"}), \
              patch("loom_tools.claim.claim_issue", return_value=0), \
              patch("loom_tools.claim.release_claim"):
             result = main(["42", "--allow-dirty-main"])
@@ -428,10 +432,23 @@ class TestMain:
              patch("loom_tools.shepherd.cli.find_repo_root", return_value=Path("/fake/repo")), \
              patch("loom_tools.shepherd.cli._auto_navigate_out_of_worktree"), \
              patch("loom_tools.shepherd.cli.get_uncommitted_files", return_value=[]), \
+             patch("loom_tools.common.github.gh_issue_view", return_value={"state": "OPEN"}), \
              patch("loom_tools.claim.claim_issue", return_value=0), \
              patch("loom_tools.claim.release_claim"):
             result = main(["42"])
             assert result == 0
+
+    def test_closed_issue_skips_without_claiming(self) -> None:
+        """main should return SKIPPED and not call claim_issue when issue is already closed."""
+        mock_claim = MagicMock(return_value=0)
+        with patch("loom_tools.shepherd.cli.find_repo_root", return_value=Path("/fake/repo")), \
+             patch("loom_tools.shepherd.cli._auto_navigate_out_of_worktree"), \
+             patch("loom_tools.common.github.gh_issue_view", return_value={"state": "CLOSED"}), \
+             patch("loom_tools.claim.claim_issue", mock_claim), \
+             patch("loom_tools.claim.release_claim"):
+            result = main(["42"])
+            assert result == ShepherdExitCode.SKIPPED
+            mock_claim.assert_not_called()
 
 
 class TestIsLoomRuntime:
@@ -3954,6 +3971,7 @@ class TestMainCleanupIntegration:
              patch("loom_tools.shepherd.cli.find_repo_root", return_value=Path("/fake/repo")), \
              patch("loom_tools.shepherd.cli._auto_navigate_out_of_worktree"), \
              patch("loom_tools.shepherd.cli._cleanup_labels_on_failure") as mock_cleanup, \
+             patch("loom_tools.common.github.gh_issue_view", return_value={"state": "OPEN"}), \
              patch("loom_tools.claim.claim_issue", return_value=0), \
              patch("loom_tools.claim.release_claim"):
             ctx = MockCtx.return_value
@@ -3968,6 +3986,7 @@ class TestMainCleanupIntegration:
              patch("loom_tools.shepherd.cli.find_repo_root", return_value=Path("/fake/repo")), \
              patch("loom_tools.shepherd.cli._auto_navigate_out_of_worktree"), \
              patch("loom_tools.shepherd.cli._cleanup_labels_on_failure") as mock_cleanup, \
+             patch("loom_tools.common.github.gh_issue_view", return_value={"state": "OPEN"}), \
              patch("loom_tools.claim.claim_issue", return_value=0), \
              patch("loom_tools.claim.release_claim"):
             result = main(["42"])
@@ -3981,6 +4000,7 @@ class TestMainCleanupIntegration:
              patch("loom_tools.shepherd.cli.find_repo_root", return_value=Path("/fake/repo")), \
              patch("loom_tools.shepherd.cli._auto_navigate_out_of_worktree"), \
              patch("loom_tools.shepherd.cli._cleanup_labels_on_failure") as mock_cleanup, \
+             patch("loom_tools.common.github.gh_issue_view", return_value={"state": "OPEN"}), \
              patch("loom_tools.claim.claim_issue", return_value=0), \
              patch("loom_tools.claim.release_claim"):
             ctx = MockCtx.return_value


### PR DESCRIPTION
## Summary
Adds a pre-claim validation in shepherd `main()` that checks if the target issue is already closed before calling `claim_issue()`. This avoids the unnecessary claim/release cycle for closed issues.

## Changes
- Added `gh_issue_view()` call in `main()` before `claim_issue()` to check issue state
- Returns `ShepherdExitCode.SKIPPED` immediately if issue is not open
- Added `test_closed_issue_skips_without_claiming` test verifying `claim_issue` is never called for closed issues
- Patched existing tests to mock the new `gh_issue_view` call with `{"state": "OPEN"}`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Shepherd does not call claim_issue() when issue is already closed | ✅ | New test asserts `mock_claim.assert_not_called()` when state is CLOSED |
| IssueClosedError / closed-state check in orchestrate() remains as safety net | ✅ | No changes to `orchestrate()` — existing validate_issue() is untouched |
| Shepherd returns ShepherdExitCode.SKIPPED for closed issues | ✅ | New test asserts `result == ShepherdExitCode.SKIPPED` |
| No regression in existing shepherd tests | ✅ | All 162 shepherd CLI tests pass |

## Test Plan
- `python3 -m pytest loom-tools/tests/shepherd/test_cli.py -x -q` — 162 passed
- Full loom-tools test suite: 1087 passed, 1 pre-existing failure in unrelated test

Closes #2830