### PR TITLE
feat: clear issue-specific failures at force-mode shepherd startup

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/cli.py
+++ b/loom-tools/src/loom_tools/shepherd/cli.py
@@ -415,6 +415,17 @@ def orchestrate(ctx: ShepherdContext) -> int:
         # Report started milestone
         ctx.report_milestone("started", issue=ctx.config.issue, mode=ctx.config.mode.value)
 
+        # ─── Force mode: clear prior failures for this issue ─────────────
+        if ctx.config.is_force_mode:
+            from loom_tools.common.systematic_failure import clear_failures_for_issue
+
+            cleared = clear_failures_for_issue(ctx.repo_root, ctx.config.issue)
+            if cleared > 0:
+                log_info(
+                    f"Force mode: cleared {cleared} prior failure(s) for issue "
+                    f"#{ctx.config.issue} — full retry window restored"
+                )
+
         # ─── PHASE 1: Curator ─────────────────────────────────────────────
         curator = CuratorPhase()
         skip, reason = curator.should_skip(ctx)


### PR DESCRIPTION
## Summary
When a shepherd starts in force mode, prior failure entries for the retried issue are now cleared from `recent_failures` and `blocked_issue_retries` is reset, giving the issue a full retry window instead of inheriting stale failures from prior runs.

## Changes
- Add `clear_failures_for_issue(repo_root, issue)` to `systematic_failure.py` — filters `recent_failures`, resets `blocked_issue_retries`, and re-evaluates `systematic_failure` state
- Call `clear_failures_for_issue()` in `orchestrate()` when `is_force_mode` is True, with INFO-level logging of cleared count
- Add 7 unit tests covering: target-only removal, retry reset, other-issue preservation, systematic failure re-evaluation, no-op edge cases

## Test Plan
All 34 tests in `test_systematic_failure.py` pass (7 new + 27 existing).

Closes #2822