### PR TITLE
fix: skip systematic failure counter when PR already exists for issue

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/cli.py
+++ b/loom-tools/src/loom_tools/shepherd/cli.py
@@ -2221,8 +2221,6 @@ def _record_fallback_failure(ctx: ShepherdContext, exit_code: int) -> None:
         # completion teardown failed (e.g. thinking stall).  Counting this
         # against the issue would cause false-positive loom:blocked
         # escalations.  See issue #2854.
-        from loom_tools.shepherd.labels import get_pr_for_issue
-
         existing_pr = get_pr_for_issue(ctx.config.issue, repo_root=ctx.repo_root)
         if existing_pr is not None:
             log_info(


### PR DESCRIPTION
## Summary

- In `_handle_builder_failure_fallback()`, check for an existing open PR via `get_pr_for_issue()` before recording a systematic failure
- If a PR exists, log the skip and return early — no counter increment, no `loom:blocked` escalation
- Addresses false-positive `loom:blocked` escalations when the builder created a PR but exited with a non-zero code (e.g. thinking stall post-completion)

## Test plan

- [ ] All existing systematic failure tests pass (50 tests)
- [ ] Builder that creates a PR then stalls no longer triggers `loom:blocked`
- [ ] Builder that fails without creating a PR still triggers counter as before

Closes #2854

🤖 Generated with [Claude Code](https://claude.com/claude-code)