### PR TITLE
fix: retry thinking stalls once before classifying as permanent failure

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -552,8 +552,10 @@ class BuilderPhase:
 
         if exit_code == 14:
             # Thinking stall: builder produced output (spinner/thinking)
-            # but never made a tool call.  Not retryable — the same
-            # conditions will produce the same result.  See issue #2784.
+            # but never made a tool call.  Retry logic is handled upstream
+            # in run_phase_with_retry() (THINKING_STALL_MAX_RETRIES).  If
+            # we reach this point, the retry budget is exhausted.
+            # See issues #2784, #2823.
             log_path = self._get_log_path(ctx)
             thinking_snippet = _extract_thinking_snippet(log_path)
             snippet_suffix = (
@@ -571,7 +573,7 @@ class BuilderPhase:
                 status=PhaseStatus.FAILED,
                 message=(
                     "builder thinking stall: extended thinking output "
-                    "with zero tool calls detected (not retryable)"
+                    "with zero tool calls detected (retry budget exhausted)"
                 ),
                 phase_name="builder",
                 data={


### PR DESCRIPTION
## Summary

- Thinking stalls (exit code 14) were immediately non-retryable, causing issues to hit `loom:blocked` after a single occurrence
- Changed `run_phase_with_retry()` to allow one retry with 30s backoff before giving up
- Added `THINKING_STALL_MAX_RETRIES = 1` and `THINKING_STALL_BACKOFF_SECONDS = [30]` constants
- Updated `builder.py` comment to clarify that exit code 14 means the retry budget is exhausted

## Test plan

- [x] `test_thinking_stall_retries_once` — single stall retries and succeeds on second attempt
- [x] `test_thinking_stall_non_retryable_on_second_consecutive` — two stalls exhaust budget and return 14
- [x] `test_thinking_stall_counter_independent_of_ghost` — ghost and thinking stall budgets are independent
- [x] Existing `test_mcp_failure_checked_before_thinking_stall` still passes

Closes #2823

🤖 Generated with [Claude Code](https://claude.com/claude-code)