### PR TITLE
fix: surface git exit-128 failures in judge diagnostics and use gh pr diff

### DIFF
--- a/defaults/.claude/commands/judge.md
+++ b/defaults/.claude/commands/judge.md
@@ -1099,8 +1099,14 @@ When running quality checks (step 7), use **scoped test execution** to run only 
 ### Step 1: Detect Changed Files
 
 ```bash
-# Get list of files changed in the PR relative to main
-CHANGED_FILES=$(git diff --name-only origin/main...HEAD)
+# Use gh API to list changed files — avoids local git dependency and
+# exit-128 errors when the branch is checked out in a worktree or when
+# concurrent builder operations hold a git lock. (issue #2828)
+CHANGED_FILES=$(gh pr diff $PR_NUMBER --name-only 2>/dev/null)
+if [ -z "$CHANGED_FILES" ]; then
+    echo "Warning: Could not detect changed files via gh pr diff — running full test suite"
+    # Fall through to full suite
+fi
 echo "$CHANGED_FILES"
 ```
 


### PR DESCRIPTION
## Summary

Fixes judge's silent recovery from git exit status 128 errors (issue #2828).

- **Root cause identified**: The `failed to run git: exit status 128` message appears in judge logs when:
  1. Claude Code's background git monitor encounters a lock from concurrent builder operations, or
  2. The judge's `git diff --name-only origin/main...HEAD` fails because the branch is already checked out in a worktree

- **Detection added**: `_gather_diagnostics` in `judge.py` now scans the full log for `failed to run git` / `exit status 128` patterns and surfaces a warning in the diagnostics summary if found, so the shepherd operator can see when a review may have been incomplete

- **Git dependency eliminated**: Replaced `git diff --name-only origin/main...HEAD` in judge.md's scoped test execution with `gh pr diff $PR_NUMBER --name-only` — API-based, works from any directory, no worktree conflicts

## Test plan

- [ ] `TestJudgeDiagnostics::test_detects_git_failure_in_log` — verifies detection and warning in summary
- [ ] `TestJudgeDiagnostics::test_no_git_failure_when_log_clean` — verifies clean logs don't false-positive

All 13 TestJudgeDiagnostics tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Closes #2828
