### PR TITLE
fix: correct systematic failure comment to reflect global detection scope

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/cli.py
+++ b/loom-tools/src/loom_tools/shepherd/cli.py
@@ -2255,10 +2255,10 @@ def _record_fallback_failure(ctx: ShepherdContext, exit_code: int) -> None:
                 [
                     "gh", "issue", "comment", str(ctx.config.issue),
                     "--body",
-                    f"**Systematic failure detected** — this issue has failed "
-                    f"**{sf.count}** consecutive times with the same error "
-                    f"pattern (`{sf.pattern}`). It has been moved to "
-                    f"`loom:blocked` to prevent further automated attempts.\n\n"
+                    f"**Systematic failure detected** — the builder has hit "
+                    f"the same error pattern (`{sf.pattern}`) **{sf.count}** "
+                    f"times in a row across recent issues. This issue was "
+                    f"blocked as a precaution.\n\n"
                     f"### Recovery\n\n"
                     f"Investigate the failure pattern and either fix the "
                     f"underlying issue or add more guidance to the issue "


### PR DESCRIPTION
## Summary

The systematic failure comment posted on blocked issues incorrectly stated "this issue has failed N consecutive times" when the detection is actually based on a global sliding window across all recent issues. This misleads operators into thinking a specific issue is problematic when the actual problem may be system-wide.

## Changes

- Updated the `_record_fallback_failure()` comment in `cli.py` to accurately describe that the failure pattern was detected globally across recent issues, not just for the blocked issue itself

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Comment no longer says "this issue has failed N times" when detection is global | ✅ | Changed to "the builder has hit the same error pattern N times in a row across recent issues" |
| Comment explains this issue was blocked as a precaution | ✅ | Added "This issue was blocked as a precaution." |
| Recovery instructions remain intact | ✅ | Recovery section unchanged |

## Test Plan

- All 50 systematic failure tests pass (`python3 -m pytest tests/ -q -k "systematic"`)
- The one unrelated pre-existing test failure (`TestDoctorPhaseExitCode5`) also fails on main and is not related to this change

Closes #2858