### PR TITLE
fix: use pre-written PR body from builder to avoid boilerplate descriptions

### DIFF
--- a/defaults/.claude/commands/builder-pr.md
+++ b/defaults/.claude/commands/builder-pr.md
@@ -88,6 +88,52 @@ This review happens BEFORE creating your worktree:
 4. Create worktree
 5. Implement (using patterns learned from review)
 
+## Write PR Body Before Running Tests
+
+**CRITICAL**: Before running the test suite, write your PR description to `.loom/pr-body.md`.
+
+This ensures a high-quality PR description is preserved even if context runs out during testing. The shepherd uses this file when creating the PR automatically.
+
+### Why This Matters
+
+The builder commonly exhausts its context window during test verification. When this happens, the shepherd creates the PR automatically — but it can only generate a boilerplate description unless you've pre-written the body.
+
+### How to Write the PR Body
+
+After implementing your changes (but BEFORE running tests):
+
+```bash
+cat > .loom/pr-body.md << 'EOF'
+## Summary
+[1-2 sentences describing what this PR does and why]
+
+## Changes
+- [Key change 1 - what you changed and why]
+- [Key change 2]
+- [Key change 3]
+
+## Acceptance Criteria Verification
+
+| Criterion | Status | Verification |
+|-----------|--------|--------------|
+| [Criterion from issue] | ✅ | [How you verified it] |
+
+## Test Plan
+- [ ] [Test 1]
+- [ ] [Test 2]
+
+Closes #N
+EOF
+```
+
+Replace `#N` with the actual issue number. Write this BEFORE running `pnpm check:ci` or any test suite.
+
+### When to Update It
+
+If you discover additional changes during testing, update `.loom/pr-body.md` to reflect them before committing.
+
+---
+
 ## Test Output: Truncate for Token Efficiency
 
 **IMPORTANT**: When running tests, truncate verbose output to conserve tokens in long-running sessions.


### PR DESCRIPTION
## Summary

When the builder exhausts its context window during test verification (which happens 100% of the time per #2811), the shepherd's direct completion and recovery paths create the PR. Previously these paths generated boilerplate descriptions (diff stats + a note saying "recovery path created this PR").

This fix enables builders to write a structured PR body **before** running tests, preserving their intent even when context runs out during testing.

## Changes

- **`_build_direct_completion_pr_body()` in `builder.py`**: Checks for `.loom/pr-body.md` in the worktree before generating boilerplate. If the builder wrote this file, the shepherd uses it as-is (appending `Closes #N` if missing).

- **`_build_recovery_pr_body()` in `validate_phase.py`**: Same check, so both the direct completion and validate_phase recovery paths benefit from pre-written PR bodies.

- **`builder-pr.md`**: New **CRITICAL** instruction — write `.loom/pr-body.md` after implementing but BEFORE running tests. Includes the template with Summary/Changes/Acceptance Criteria/Test Plan sections.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| PR descriptions have Summary/Changes/Criteria structure | ✅ | Builder writes structured body pre-test; shepherd uses it |
| Works for both direct completion and recovery paths | ✅ | Both `_build_direct_completion_pr_body()` and `_build_recovery_pr_body()` check for `.loom/pr-body.md` |
| Backwards compatible (no file = falls back to existing behavior) | ✅ | File check is optional; existing code path runs when absent |
| Doesn't break existing tests | ✅ | 129 tests pass (test_validate_phase.py, test_checkpoints.py) |

## Test Plan

- [ ] Run `python3 -m pytest loom-tools/tests/test_validate_phase.py loom-tools/tests/test_checkpoints.py -v`
- [ ] Verify that when `.loom/pr-body.md` exists in a worktree, `_build_direct_completion_pr_body()` returns its contents
- [ ] Verify that when `.loom/pr-body.md` is absent, the fallback diff-stats body is generated as before

Closes #2811