### PR TITLE
feat: shepherd comments on GitHub issue when abandoning due to non-retryable failure

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/context.py
+++ b/loom-tools/src/loom_tools/shepherd/context.py
@@ -61,6 +61,11 @@ class ShepherdContext:
     # (set by run_worker_phase on non-zero exit).  See issue #2766.
     last_postmortem: dict[str, Any] | None = field(default=None, init=False)
 
+    # Abandonment details for non-retryable failures (set by orchestrator when
+    # a specific failure mode is detected).  Used by _post_fallback_failure_comment
+    # to generate a more informative GitHub comment.  See issue #2839.
+    abandonment_info: dict[str, Any] | None = field(default=None, init=False)
+
     # Preflight baseline status (set by orchestrator after preflight phase).
     # "healthy" means baseline tests pass and builder can skip re-running them.
     preflight_baseline_status: str | None = field(default=None, init=False)


### PR DESCRIPTION
## Summary

- Adds `abandonment_info` field to `ShepherdContext` to capture specific failure details when the orchestrator encounters a non-retryable builder failure
- Sets `ctx.abandonment_info` before returning non-retryable exit codes (thinking stall, planning stall, auth failure, rate limit abort, generic failure)
- Enhances `_post_fallback_failure_comment` to use `abandonment_info` when available, generating a detailed GitHub comment with phase, failure mode, task ID, log file path, and retry guidance
- Fixes 3 existing tests broken by MagicMock auto-creating `abandonment_info` as truthy
- Adds 5 new tests covering each failure mode in the `abandonment_info` path

## Test plan

- [x] All 174 existing `test_cli.py` tests pass
- [x] 3 previously failing `TestPostFallbackFailureComment` tests now pass (fixed by adding `ctx.abandonment_info = None`)
- [x] 5 new tests for `abandonment_info` path: thinking_stall, planning_stall, auth_failure, rate_limit_abort, generic_failure

Closes #2839

🤖 Generated with [Claude Code](https://claude.com/claude-code)