### PR TITLE
fix: clarify systematic failure comment reflects global detection not per-issue count

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/cli.py
+++ b/loom-tools/src/loom_tools/shepherd/cli.py
@@ -2255,10 +2255,10 @@ def _record_fallback_failure(ctx: ShepherdContext, exit_code: int) -> None:
                 [
                     "gh", "issue", "comment", str(ctx.config.issue),
                     "--body",
-                    f"**Systematic failure detected** — this issue has failed "
-                    f"**{sf.count}** consecutive times with the same error "
-                    f"pattern (`{sf.pattern}`). It has been moved to "
-                    f"`loom:blocked` to prevent further automated attempts.\n\n"
+                    f"**Systematic failure detected** — the builder has hit "
+                    f"the same error pattern (`{sf.pattern}`) **{sf.count}** "
+                    f"times in a row across recent issues. This issue was "
+                    f"blocked as a precaution.\n\n"
                     f"### Recovery\n\n"
                     f"Investigate the failure pattern and either fix the "
                     f"underlying issue or add more guidance to the issue "


### PR DESCRIPTION
## Summary

- The systematic failure comment on blocked issues previously said "this issue has failed **N** consecutive times" — misleading because `detect_systematic_failure()` checks a **global** sliding window across recent issues, not per-issue counts
- Updated message to accurately state: "the builder has hit the same error pattern (`<pattern>`) **N** times in a row across recent issues. This issue was blocked as a precaution."
- Implements Option A from the issue (simpler message correction vs. per-issue tracking)

## Test plan

- [x] Existing `test_escalates_on_systematic_failure` and `test_no_escalation_when_no_systematic_failure` pass (assertions check for "Systematic failure detected", pattern name, and count — all still present in new message)

Closes #2858

🤖 Generated with [Claude Code](https://claude.com/claude-code)