### PR TITLE
fix: prevent false-positive thinking stall detection and symlink destruction

### DIFF
--- a/loom-tools/src/loom_tools/log_filter.py
+++ b/loom-tools/src/loom_tools/log_filter.py
@@ -37,10 +37,17 @@ _CONTROL_CHARS = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
 # Claude Code TUI noise patterns (used in deep/file cleaning mode)
 # ---------------------------------------------------------------------------
 
-# Spinner characters used by the Claude Code TUI
-SPINNERS = set("\u2736\u273b\u273d\u2733\u2722\u23fa\u00b7")  # ✶✻✽✳✢⏺·
+# Spinner characters used by the Claude Code TUI thinking animation.
+# NOTE: ⏺ (U+23FA) is intentionally excluded — it is the tool call marker
+# used by _is_thinking_stall_session() to detect productive sessions.
+# Stripping ⏺ would cause false-positive thinking stall detection.
+# See issue #2835.
+SPINNERS = set("\u2736\u273b\u273d\u2733\u2722\u00b7")  # ✶✻✽✳✢·
 
-# Animation words displayed during thinking/processing
+# Animation words displayed during thinking/processing.
+# Covers multiple Claude Code versions — newer versions (v2.1.40+) use
+# words like "Frosting", "Befuddling", "Moseying", etc. that were not
+# present in older versions.  See issue #2835.
 ANIMATION_WORDS = {
     "Nucleating", "Pollinating", "Shimmying", "Transmuting",
     "Crunching", "Pondering", "Germinating", "Synthesizing",
@@ -53,12 +60,21 @@ ANIMATION_WORDS = {
     "Interpolating", "Meditating", "Originating", "Philosophizing",
     "Reflecting", "Simulating", "Triangulating", "Unbundling",
     "Visualizing", "Crunched",
+    # Newer animation words observed in Claude Code v2.1.40+ (issue #2835)
+    "Befuddling", "Frosting", "Moseying", "Sashaying", "Waltzing",
+    "Ambling", "Beguiling", "Brooding", "Bumbling", "Dawdling",
+    "Dithering", "Floundering", "Fretting", "Fumbling", "Gallivanting",
+    "Humming", "Idling", "Lollygagging", "Meandering", "Milling",
+    "Mulling", "Noodling", "Perambulating", "Perusing", "Pondering",
+    "Pottering", "Puttering", "Rambling", "Ruminating", "Sifting",
+    "Stewing", "Tinkering", "Toiling", "Wandering", "Whirring",
 }
 
-# Build animation regex: optional spinner + animation word + optional ellipsis/timing
+# Build animation regex: optional spinner + animation word + optional ellipsis/timing.
+# ⏺ is excluded from the spinner prefix class — see SPINNERS note above.
 _anim_pattern = "|".join(re.escape(w) for w in sorted(ANIMATION_WORDS))
 _ANIMATION_RE = re.compile(
-    "^[✶✻✽✳✢⏺·\\s]*("
+    "^[✶✻✽✳✢·\\s]*("
     + _anim_pattern
     + ")…?"
     "(\\s*\\(.*\\))?\\s*$"


### PR DESCRIPTION
## Summary

- **Fix ⏺ in SPINNERS (issue #2835 root cause)**: `⏺` (U+23FA) was incorrectly included in the `SPINNERS` set. `_strip_leading_spinners` removed the tool-call marker from log lines, so `_is_thinking_stall_session` found zero `⏺` markers and declared thinking stalls even when the agent was actively making tool calls.
- **Fix symlink destruction in `_ensure_onboarding_complete`**: When `~/.claude.json` contains `"theme": null` (JSON null), `bool(None) = False` triggered the merge path which called `state_path.unlink()` on the symlink and replaced it with a minimal standalone file. Subsequent agent sessions lost full user state. Now writes merged data to the symlink target instead.
- **Fix startup monitor checking wrong debug log path**: The monitor checked `${CLAUDE_CONFIG_DIR}/debug/latest` but Claude Code always writes debug logs to `~/.claude/debug/latest` regardless of `CLAUDE_CONFIG_DIR`. The per-agent `debug/` directory was always empty, so MCP-connected checks never fired.
- **Add 30+ new animation words** observed in Claude Code v2.1.40+ (`Frosting`, `Befuddling`, `Moseying`, etc.) that were missing from `ANIMATION_WORDS`, causing log noise to pass through filters.

## Test plan

- [x] `test_log_filter.py`: 109 tests pass, new `TestToolCallMarker` class with 8 regression tests added
- [x] `test_claude_config.py`: 38 tests pass, new `test_symlink_target_updated_not_destroyed_when_theme_null` regression test added
- [x] All 147 tests pass after rebase on main

Closes #2835

🤖 Generated with [Claude Code](https://claude.com/claude-code)