### PR TITLE
feat: increase builder thinking stall timeout to 360s for complex tasks

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/config.py
+++ b/loom-tools/src/loom_tools/shepherd/config.py
@@ -189,6 +189,14 @@ class ShepherdConfig:
         default_factory=lambda: env_int("LOOM_ESCAPE_MAX_RETRIES", 1)
     )
 
+    # Thinking stall timeouts (seconds) - configurable per phase
+    # Builder tasks require longer thinking windows than judge/curator tasks
+    # because they involve reading multiple files and designing implementations.
+    # See issue #2853.
+    builder_thinking_stall_timeout: int = field(
+        default_factory=lambda: env_int("LOOM_BUILDER_THINKING_STALL_TIMEOUT", 360)
+    )
+
     # Rate limiting
     rate_limit_threshold: int = field(
         default_factory=lambda: env_int("LOOM_RATE_LIMIT_THRESHOLD", 99)

--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -427,6 +427,7 @@ class BuilderPhase:
             worktree=ctx.worktree_path,
             args=str(ctx.config.issue),
             planning_timeout=ctx.config.planning_timeout,
+            thinking_stall_timeout=ctx.config.builder_thinking_stall_timeout,
         )
 
         if exit_code == 3:
@@ -714,6 +715,7 @@ class BuilderPhase:
                 worktree=ctx.worktree_path,
                 args=str(ctx.config.issue),
                 planning_timeout=ctx.config.planning_timeout,
+                thinking_stall_timeout=ctx.config.builder_thinking_stall_timeout,
             )
 
             # Handle fatal exit codes from retry (shutdown, stuck, etc.)


### PR DESCRIPTION
Closes #2853

## Problem

The 180s thinking stall threshold was too aggressive for builder tasks that legitimately require extended reasoning — reading multiple files, designing integrations, writing tests — before making the first tool call. This caused premature kills and consumed retry budgets on false-positive stalls.

## Changes

- **`config.py`**: Add `builder_thinking_stall_timeout` (default 360s, configurable via `LOOM_BUILDER_THINKING_STALL_TIMEOUT`)
- **`base.py`**: Thread `thinking_stall_timeout` parameter through `run_worker_phase` and `run_phase_with_retry` (defaults to `THINKING_STALL_TIMEOUT` = 180s for all other phases)
- **`builder.py`**: Pass `ctx.config.builder_thinking_stall_timeout` at both builder phase call sites

## Approach

Implements **Option A** from the issue (phase-specific thresholds). The 180s default is preserved for judge/curator/other phases; only the builder gets the extended 360s window.

## Test plan

- Builder sessions with extended thinking (>180s, <360s before first tool call) will no longer be killed prematurely
- Non-builder phases retain the 180s threshold unchanged
- `LOOM_BUILDER_THINKING_STALL_TIMEOUT` env var allows further tuning without code changes