### PR TITLE
fix: update dirty-main warning to show --force/--merge instead of just --merge

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/cli.py
+++ b/loom-tools/src/loom_tools/shepherd/cli.py
@@ -2484,7 +2484,7 @@ def main(argv: list[str] | None = None) -> int:
     # This prevents confusion when tests pass in main but fail in worktrees
     # (or vice versa) due to uncommitted local changes.
     allow_dirty_reason = (
-        "implied by --merge" if dirty_implied_by_force else "--allow-dirty-main specified"
+        "implied by --force/--merge" if dirty_implied_by_force else "--allow-dirty-main specified"
     )
     if not _check_main_repo_clean(repo_root, args.allow_dirty_main, allow_dirty_reason):
         return ShepherdExitCode.NEEDS_INTERVENTION


### PR DESCRIPTION
## Summary
Updates the dirty-main warning message to accurately reflect that either `--force` or `--merge` can imply `--allow-dirty-main`, not just `--merge`.

## Changes
- Change warning reason from `"implied by --merge"` to `"implied by --force/--merge"` in `shepherd/cli.py`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Warning shows `--force/--merge` when force mode implies dirty-main | ✅ | Changed the string at line 2487 in cli.py |
| Matches the comment `# --force / --merge implies --allow-dirty-main` | ✅ | The new message is consistent with the existing code comment |

## Test Plan
- Change is a one-line string update; verified the diff is correct
- The condition logic (`dirty_implied_by_force`) is unchanged — only the display string is updated

Closes #2901