### PR TITLE
refactor: shepherd skill becomes signal-writer + observer

### DIFF
--- a/defaults/.claude/commands/shepherd-lifecycle.md
+++ b/defaults/.claude/commands/shepherd-lifecycle.md
@@ -1,5 +1,13 @@
 # Shepherd Lifecycle Reference
 
+> **Note**: This document describes what the **Python shepherd** (`loom-shepherd.sh` /
+> `loom_tools.shepherd.cli`) does once it is running. The Python shepherd is spawned by
+> the standalone daemon as a direct subprocess — it is **not** invoked by the
+> `/shepherd` Claude Code skill directly. The `/shepherd` skill writes a
+> `spawn_shepherd` signal to `.loom/signals/` and then observes progress via
+> `.loom/progress/` and `daemon-state.json`. See `shepherd.md` for the skill's
+> signal-writer + observer pattern.
+
 This document contains detailed workflow implementation for the Shepherd role. For core role definition, principles, and phase flow overview, see `shepherd.md`.
 
 ## Label State Machine

--- a/defaults/.claude/commands/shepherd.md
+++ b/defaults/.claude/commands/shepherd.md
@@ -1,6 +1,6 @@
 # Shepherd
 
-Orchestrate issue lifecycle via the shell-based shepherd script.
+Orchestrate a single issue through its full lifecycle as a **signal-writer and observer** — you coordinate the shepherd process through JSON signals and state observation. You NEVER spawn shepherd or worker processes directly via Bash.
 
 ## Arguments
 
@@ -33,17 +33,127 @@ Parse the issue number and any flags from the arguments.
 
 ## Execution
 
-Invoke the shepherd wrapper with all provided arguments:
+### Step 1: Daemon Detection
+
+Check whether the standalone daemon is running:
 
 ```bash
-./.loom/scripts/loom-shepherd.sh $ARGUMENTS
+PID=$(cat .loom/daemon-loop.pid 2>/dev/null)
+kill -0 "$PID" 2>/dev/null && echo "RUNNING" || echo "NOT RUNNING"
 ```
 
-Run this command now. Report the exit status when complete.
+**If the daemon is NOT running**, display this message and EXIT:
+
+```
+The Loom daemon is not running.
+
+Start it from a terminal OUTSIDE Claude Code:
+
+  ./.loom/scripts/start-daemon.sh                     # Normal mode
+  ./.loom/scripts/start-daemon.sh --merge             # Force/merge mode
+
+Then run /shepherd <issue> again.
+
+Why run outside Claude Code?
+  Shepherd and worker sessions start as daemon children (not Claude Code
+  descendants), avoiding the nested Claude Code spawning restriction.
+```
+
+**If the daemon IS running**, proceed to Step 2.
+
+### Step 2: Check for Existing Shepherd
+
+Before writing a new signal, check whether this issue is already being shepherded.
+Read `.loom/daemon-state.json` and look for a shepherd slot with `issue == <N>` and `status == "working"`.
+
+If found, skip to Step 4 (monitor the existing shepherd using its `task_id`).
+
+### Step 3: Write Spawn Signal
+
+Use the **Write tool** (not Bash) to create a signal file at:
+
+```
+.loom/signals/cmd-{YYYYMMDD-HHMMSS}-{random4hex}.json
+```
+
+Payload format:
+
+```json
+{
+  "action": "spawn_shepherd",
+  "issue": <N>,
+  "mode": "<default|force>",
+  "flags": []
+}
+```
+
+**Argument mapping:**
+
+| Argument | Signal field |
+|----------|-------------|
+| (none) | `"mode": "default"` |
+| `--merge` or `-m` | `"mode": "force"` |
+| `--to <phase>` | `"flags": ["--to", "<phase>"]` |
+| `--task-id <id>` | `"flags": ["--task-id", "<id>"]` |
+| `--force` / `-f` | `"mode": "force"` (deprecated alias) |
+
+Example for `/shepherd 123 --merge`:
+```json
+{"action": "spawn_shepherd", "issue": 123, "mode": "force", "flags": []}
+```
+
+Example for `/shepherd 123 --to curated`:
+```json
+{"action": "spawn_shepherd", "issue": 123, "mode": "default", "flags": ["--to", "curated"]}
+```
+
+The daemon polls `.loom/signals/` every 2 seconds and processes commands atomically.
+
+### Step 4: Confirm Daemon Pickup
+
+After writing the signal, read `.loom/daemon-state.json` every ~5 seconds until a shepherd slot shows `issue == <N>` with a `task_id`. This confirms the daemon received and processed the signal.
+
+**If no pickup after 30 seconds**: Check whether the signal file still exists in `.loom/signals/` — if present, the daemon hasn't processed it yet (may be busy or stopped). Report to the user and suggest checking daemon status with `.loom/scripts/start-daemon.sh --status`.
+
+### Step 5: Monitor Progress
+
+Once the `task_id` is known, read `.loom/progress/shepherd-{task_id}.json` every 10–15 seconds. Report milestone events to the user as they arrive:
+
+| Milestone event | Message to show user |
+|----------------|---------------------|
+| `phase_entered: curator` | `→ Curator phase: enhancing issue...` |
+| `phase_entered: builder` | `→ Builder phase: implementing...` |
+| `worktree_created` | `  Worktree created` |
+| `first_commit` | `  First commit made` |
+| `pr_created` | `→ PR #M created` |
+| `phase_entered: judge` | `→ Judge phase: reviewing PR...` |
+| `phase_entered: doctor` | `→ Doctor phase: addressing feedback...` |
+| `completed` | `✅ Shepherd complete` |
+| `error` | `❌ Error: <message>` |
+
+You can also use `mcp__loom__get_terminal_output` with the shepherd's terminal ID (from `daemon-state.json`) to show live output on request.
+
+### Step 6: Stuck Detection and Intervention
+
+If `heartbeat_age_seconds > 120` in the progress file (or `heartbeat_stale: true`):
+
+1. Inform the user: "⚠️ Worker appears stuck (no heartbeat for Xs)"
+2. Use `mcp__loom__send_terminal_input` to send a gentle nudge to the worker terminal
+3. Wait 30s — if still no heartbeat, escalate to the user for manual intervention
+
+### Step 7: Report Outcome
+
+When the progress file shows `status: completed` or `status: error`, summarize the result:
+
+- **Completed**: PR number, merge status, total duration
+- **Error**: Phase where it failed, error message, suggested recovery steps
+- **Blocked**: Label state, reason, what human action is needed
 
 ## Reference Documentation
 
 For detailed orchestration workflow, phase definitions, and troubleshooting:
 - **Lifecycle details**: `.claude/commands/shepherd-lifecycle.md`
-- **Wrapper script**: `.loom/scripts/loom-shepherd.sh` (routes to Python)
-- **Python implementation**: `loom-tools/src/loom_tools/shepherd/`
+- **Daemon startup**: `.loom/scripts/start-daemon.sh --help`
+- **Daemon status**: `.loom/scripts/start-daemon.sh --status`
+- **Signal protocol**: `loom-tools/src/loom_tools/daemon_v2/command_poller.py`
+- **Python shepherd**: `loom-tools/src/loom_tools/shepherd/`


### PR DESCRIPTION
## Summary

Refactors the `/shepherd` Claude Code skill to use the signal-writer + observer pattern established by PR #2956 (daemon IPC infrastructure). The skill no longer spawns subprocesses directly — it writes a JSON signal file and then observes progress via daemon state files and MCP tools.

## Changes

- **`defaults/.claude/commands/shepherd.md`**: Complete rewrite of the `## Execution` section from a single Bash subprocess call to a 7-step signal-writer + observer pattern:
  1. Daemon detection via `.loom/daemon-loop.pid`
  2. Check `daemon-state.json` for existing shepherd on this issue
  3. Write `spawn_shepherd` signal to `.loom/signals/` using the Write tool (not Bash)
  4. Poll `daemon-state.json` every ~5s to confirm daemon pickup
  5. Monitor `.loom/progress/shepherd-{task_id}.json` for milestone events
  6. Stuck detection via `heartbeat_age_seconds > 120` + nudge via `mcp__loom__send_terminal_input`
  7. Report outcome summary (completed/error/blocked)

- **`defaults/.claude/commands/shepherd-lifecycle.md`**: Added clarifying note explaining that the lifecycle doc describes the Python shepherd process (spawned by the daemon as a direct subprocess), not the `/shepherd` Claude Code skill.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `/shepherd` uses Write tool for signals, not Bash subprocess | ✅ | Step 3 explicitly uses Write tool; no `loom-shepherd.sh` call anywhere in the new execution section |
| Daemon detection gate (exit with instructions if not running) | ✅ | Step 1 checks `.loom/daemon-loop.pid` and shows startup instructions if missing |
| Signal payload matches `command_poller.py` format | ✅ | `{"action": "spawn_shepherd", "issue": N, "mode": "default\|force", "flags": [...]}` matches `_spawn_shepherd_from_signal()` in `loop.py` |
| Argument mapping: `--merge`/`-m` → `mode: "force"`, `--to` → `flags` | ✅ | Argument mapping table and examples in Step 3 |
| Daemon pickup confirmation (poll `daemon-state.json`) | ✅ | Step 4 polls every ~5s with 30s timeout |
| Progress monitoring via `.loom/progress/` | ✅ | Step 5 documents all milestone events with user-facing messages |
| Stuck detection via heartbeat | ✅ | Step 6 checks `heartbeat_age_seconds > 120` |
| Existing shepherd detected — skip to monitor | ✅ | Step 2 checks `daemon-state.json` for `issue == N` and `status == "working"` |
| Deprecated flag support (`--force`, `-f`, `--force-merge`, `--wait`) | ✅ | Supported Options table includes deprecated aliases |

## Test Plan

- [ ] Manual: Start daemon (`./loom/scripts/start-daemon.sh`), run `/shepherd <issue>`, verify signal file appears in `.loom/signals/` then disappears (daemon consumed it)
- [ ] Manual: Run `/shepherd <issue>` with daemon NOT running — verify exit with startup instructions
- [ ] Manual: Run `/shepherd <issue> --merge` — verify `mode: "force"` in signal payload
- [ ] Manual: Run `/shepherd <issue> --to curated` — verify `flags: ["--to", "curated"]` in signal payload
- [ ] Manual: Run `/shepherd <issue>` when daemon already working on that issue — verify skip to Step 4 (monitor existing)

Closes #2950