### PR TITLE
fix: surface auth hint in thinking stall failure messages

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/base.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/base.py
@@ -2222,6 +2222,19 @@ def run_phase_with_retry(
                 )
                 time.sleep(backoff)
                 continue
+            # Retry budget exhausted.  Multiple consecutive thinking stalls can
+            # indicate expired authentication: when auth is expired, the builder
+            # subprocess shows the interactive welcome TUI (producing thinking
+            # output without tool calls) rather than an explicit auth failure.
+            # The auth pre-flight is skipped for shepherd subprocesses to avoid
+            # config-lock deadlock, so expired auth goes undetected until here.
+            # See issue #2893.
+            log_warning(
+                f"Thinking stall retry budget exhausted after "
+                f"{thinking_stall_retries + 1} consecutive stall(s). "
+                f"If authentication recently expired, this may be masking an "
+                f"auth failure — run 'claude auth status' to verify."
+            )
             return 14
 
         # --- Pre-retry approval check (judge phase only) ---

--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -765,7 +765,10 @@ class BuilderPhase:
                 status=PhaseStatus.FAILED,
                 message=(
                     "builder thinking stall: extended thinking output "
-                    "with zero tool calls detected (retry budget exhausted)"
+                    "with zero tool calls detected (retry budget exhausted). "
+                    "Note: expired authentication can appear as a thinking stall "
+                    "because the auth pre-flight is skipped for shepherd subprocesses "
+                    "— verify with: claude auth status"
                 ),
                 phase_name="builder",
                 data={


### PR DESCRIPTION
## Summary
When authentication expires during a shepherd run, the builder subprocess skips the auth pre-flight check (to avoid a config-lock deadlock with the parent session). The expired auth session shows the interactive welcome TUI, which produces thinking output with zero tool calls — indistinguishable from a genuine thinking stall (exit code 14). This masked the real cause from operators.

## Changes
- In `run_phase_with_retry` (base.py): After exhausting the thinking stall retry budget, log a warning explaining that expired auth can appear as a thinking stall and suggesting `claude auth status` verification
- In `BuilderPhase.run` (builder.py): Add the same auth hint to the `PhaseResult.message` that gets reported back to GitHub issue comments

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Thinking stall failure message surfaces auth hint | ✅ | Message now includes "Note: expired authentication can appear as a thinking stall — verify with: claude auth status" |
| Warning logged when retry budget exhausted | ✅ | `log_warning` call added in `run_phase_with_retry` before `return 14` |
| All existing thinking stall tests pass | ✅ | `python3 -m pytest loom-tools/tests/shepherd/test_phases.py -k thinking_stall` — 11 passed |

## Test Plan
- Ran `python3 -m pytest loom-tools/tests/shepherd/test_phases.py -k thinking_stall` — all 11 tests pass
- Both `test_thinking_stall_returns_failed_with_snippet` and `test_thinking_stall_non_retryable_on_second_consecutive` pass with the updated message text

Closes #2893