### PR TITLE
fix: return SUCCESS when PR with loom:review-requested exists during validation loop

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -990,6 +990,30 @@ class BuilderPhase:
 
             # Check if this is incomplete work that could be completed
             if not self._has_incomplete_work(diag):
+                # Check if workflow is already complete (PR with correct label).
+                # This catches the API propagation race where validate_phase()
+                # returns False (PR not yet visible) but _gather_diagnostics()
+                # finds it moments later after the API propagates.
+                # See issue #2961.
+                if diag.get("pr_number") is not None and diag.get(
+                    "pr_has_review_label", False
+                ):
+                    pr = diag["pr_number"]
+                    ctx.pr_number = pr
+                    ctx.report_milestone("pr_created", pr_number=pr)
+                    return PhaseResult(
+                        status=PhaseStatus.SUCCESS,
+                        message=(
+                            f"builder phase complete - PR #{pr} exists with "
+                            f"loom:review-requested (API propagation delay resolved)"
+                        ),
+                        phase_name="builder",
+                        data={
+                            "pr_number": pr,
+                            "api_propagation_race": True,
+                        },
+                    )
+
                 # Check if this is the "no changes needed" pattern
                 if self._is_no_changes_needed(diag):
                     log_info(


### PR DESCRIPTION
## Summary

Fixes the API propagation race in the builder phase validation loop where a successfully-created PR causes `PhaseStatus.FAILED` due to a brief GitHub API propagation delay.

**Root cause**: After `_direct_completion()` creates a PR and returns `True`, the validation loop re-enters and calls `validate_phase()`. Due to GitHub API propagation delay, `validate_phase()` may not find the PR immediately (returns `False`). The loop then calls `_gather_diagnostics()` which finds the PR moments later (propagation complete). `_has_incomplete_work()` correctly returns `False` (workflow done), but the code fell through to `PhaseStatus.FAILED` instead of `SUCCESS`.

**Fix**: Before the `FAILED` fallthrough in the `not _has_incomplete_work` branch, add a check: if `pr_number` is set and `pr_has_review_label` is `True`, return `PhaseStatus.SUCCESS` with an `api_propagation_race` marker.

This is analogous to the existing recovery patterns for exit codes 11, 13, and 14 (which also check for an existing PR before failing).

Closes #2961