### PR TITLE
fix: block cd-to-main-repo worktree escapes in guard-destructive hook

### DIFF
--- a/defaults/.claude/commands/builder.md
+++ b/defaults/.claude/commands/builder.md
@@ -284,6 +284,29 @@ Before writing any code, confirm ALL of these:
 
 **If any of these fail, STOP and fix the setup before proceeding.**
 
+### Working with gh CLI from a Worktree
+
+**You do NOT need to `cd` to the main repo to use `gh` or `.loom/scripts/` commands.**
+
+These all work from within your worktree:
+- `gh issue view <N>` — no cd needed
+- `gh pr list` — no cd needed
+- `./.loom/scripts/checkpoint.sh write ...` — no cd needed
+
+❌ **WRONG** (causes worktree escape):
+```bash
+cd /Users/rwalters/GitHub/loom && gh issue view 123
+cd {{workspace}} && gh pr list
+```
+
+✅ **CORRECT** (stay in worktree):
+```bash
+gh issue view 123   # Works from worktree
+./.loom/scripts/checkpoint.sh write --stage planning --issue 123
+```
+
+**A PreToolUse hook blocks `cd` commands to the main repo from worktrees.**
+
 ## Progress Checkpoints
 
 **CRITICAL: Write checkpoints at every stage to enable recovery.** Without checkpoints, the shepherd cannot reliably distinguish "builder made real progress but crashed" from "builder never started meaningful work." While the shepherd can now detect some cases of uncommitted work via log analysis and file counts, checkpoints remain the primary and most reliable signal for recovery. Always write them — skipping checkpoints risks your completed work being retried from scratch instead of recovered.


### PR DESCRIPTION
## Summary

- Adds a new guard section to `.loom/hooks/guard-destructive.sh` that detects and blocks `cd` commands targeting the main repo when `LOOM_WORKTREE_PATH` is set (builder is in a worktree)
- Adds "Working with gh CLI from a Worktree" documentation to `defaults/.claude/commands/builder.md` explaining that `gh`, `git`, and `.loom/scripts/` work from within a worktree — no `cd` to main repo needed
- Root cause of #2893: builders ran `cd /path/to/main/repo && gh issue view ...`, which changed CWD for all subsequent Bash commands, causing file writes to land in main instead of the worktree

## How the guard works

- Only active when `LOOM_WORKTREE_PATH` is set
- Extracts the first absolute `cd` target from the command (handles `cd /x`, `cmd && cd /x`, etc.)
- Blocks if target is under `REPO_ROOT` but NOT under `WORKTREE_PATH`
- Allows `cd /tmp` and other paths outside the repo
- Allows `cd` within the worktree itself

## Test plan

- [x] `cd /repo && gh issue view 2893` → BLOCKED
- [x] `cd /repo/loom-tools` → BLOCKED
- [x] `cd /tmp && echo test` → allowed
- [x] `cd /repo/.loom/worktrees/issue-N` → allowed
- [x] `gh issue view 2893` (no cd) → allowed
- [x] No `LOOM_WORKTREE_PATH` set → always allowed

Closes #2893

🤖 Generated with [Claude Code](https://claude.com/claude-code)