### PR TITLE
docs: document --permission-mode bypassPermissions silently disabling hooks

### DIFF
--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -43,6 +43,8 @@ Additional options for `install-loom.sh`:
 
 **Never use `gh pr merge`** — Always use `./.loom/scripts/merge-pr.sh <PR_NUMBER>` instead. The `gh pr merge` command attempts a local checkout which fails in worktrees. The merge script uses the GitHub API directly. A PreToolUse hook enforces this.
 
+**`--permission-mode bypassPermissions` silently disables PreToolUse hooks** — If you invoke Claude Code with `--permission-mode bypassPermissions`, ALL PreToolUse hooks (including `guard-destructive.sh`) are skipped entirely and will not fire. Loom agents use `--dangerously-skip-permissions` instead, which runs Claude in non-interactive mode while still firing hooks. If you have a shell alias like `alias claude="claude --permission-mode bypassPermissions"`, your interactive sessions will have no hook protection. Use `--dangerously-skip-permissions` for automation that requires hooks to run.
+
 ## Three-Layer Architecture
 
 Loom uses a three-layer orchestration architecture for scalable automation:

--- a/defaults/hooks/guard-destructive.sh
+++ b/defaults/hooks/guard-destructive.sh
@@ -4,6 +4,16 @@
 # Claude Code PreToolUse hook that intercepts Bash commands before execution.
 # Receives JSON on stdin with tool_input.command and cwd fields.
 #
+# IMPORTANT: This hook only fires when Claude Code is invoked with:
+#   --dangerously-skip-permissions  ← hooks FIRE (used by Loom agents)
+#
+# It does NOT fire with:
+#   --permission-mode bypassPermissions  ← hooks SKIPPED entirely
+#
+# If you have a shell alias like 'alias claude="claude --permission-mode bypassPermissions"',
+# this safety hook will be silently disabled in interactive sessions.
+# Use --dangerously-skip-permissions instead for automation that needs hooks.
+#
 # Decisions:
 #   - Block (deny): Dangerous commands that should never run
 #   - Ask: Commands that need human confirmation


### PR DESCRIPTION
## Summary
Adds documentation explaining that `--permission-mode bypassPermissions` silently disables ALL PreToolUse hooks (including `guard-destructive.sh`), while `--dangerously-skip-permissions` (used by Loom agents) still fires hooks normally. This addresses confusion when hooks appear to not be working.

## Changes
- `defaults/hooks/guard-destructive.sh`: Added prominent IMPORTANT comment at lines 7-15 explaining the behavioral difference between the two flags
- `defaults/CLAUDE.md`: Added warning to Critical Rules section about `--permission-mode bypassPermissions` silently disabling hooks
- `.loom/docs/troubleshooting.md`: Added "Hooks not firing" section with symptom, diagnosis steps, flag comparison table, and fix instructions

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `guard-destructive.sh` has comment explaining it only fires with `--dangerously-skip-permissions` | ✅ | Comment added at lines 7-15 of the file |
| `defaults/CLAUDE.md` warns about `--permission-mode bypassPermissions` disabling hooks | ✅ | Warning added to Critical Rules section |
| `.loom/docs/troubleshooting.md` has "Hooks not firing" section with diagnosis steps | ✅ | Section added with symptom, diagnosis, fix table, and example |
| Documentation only — no behavior change | ✅ | Only `.md` and `.sh` comment changes, no code logic changed |
| User can find root cause via troubleshooting docs | ✅ | Troubleshooting entry covers symptom recognition, diagnosis commands, and fix |

## Test Plan
- Read `defaults/hooks/guard-destructive.sh` — IMPORTANT comment visible near top describing flag behavior difference
- Read `defaults/CLAUDE.md` Critical Rules — warning about `bypassPermissions` disabling hooks present
- Read `.loom/docs/troubleshooting.md` — "Hooks not firing" section with diagnosis table present at top of Common Issues

Closes #2977