### PR TITLE
fix: replace head -n -1 with sed $d in daemon script --help handlers

### DIFF
--- a/defaults/scripts/start-daemon.sh
+++ b/defaults/scripts/start-daemon.sh
@@ -49,7 +49,7 @@ while [[ $# -gt 0 ]]; do
         --status)        STATUS_ONLY=true;;
         --stop)          STOP_ONLY=true;;
         --help|-h)
-            sed -n '/^# Usage:/,/^[^#]/p' "$0" | head -n -1 | sed 's/^# \?//'
+            sed -n '/^# Usage:/,/^[^#]/p' "$0" | sed '$d' | sed 's/^# \?//'
             exit 0
             ;;
         *)               ARGS+=("$1");;

--- a/defaults/scripts/stop-daemon.sh
+++ b/defaults/scripts/stop-daemon.sh
@@ -34,7 +34,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         --force)  FORCE=true;;
         --help|-h)
-            sed -n '/^# Usage:/,/^[^#]/p' "$0" | head -n -1 | sed 's/^# \?//'
+            sed -n '/^# Usage:/,/^[^#]/p' "$0" | sed '$d' | sed 's/^# \?//'
             exit 0
             ;;
         *)  echo "Unknown option: $1" >&2; exit 1;;


### PR DESCRIPTION
## Summary

Replaces `head -n -1` with `sed '$d'` in the `--help` flag handlers for `start-daemon.sh` and `stop-daemon.sh`. GNU `head` supports negative line counts (`-n -1` means "all but last line"), but macOS BSD `head` does not, causing `--help` to fail on macOS with `head: illegal line count -- -1`.

`sed '$d'` is the POSIX-portable equivalent — it deletes the last line of input and works identically on both macOS BSD sed and GNU sed.

## Changes

- `defaults/scripts/start-daemon.sh` line 52: Replace `| head -n -1 |` with `| sed '$d' |`
- `defaults/scripts/stop-daemon.sh` line 37: Replace `| head -n -1 |` with `| sed '$d' |`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `start-daemon.sh --help` works on macOS without error | ✅ | Manually ran `bash defaults/scripts/start-daemon.sh --help` on macOS — prints usage cleanly, exits with code 0, no `head: illegal line count` error |
| `stop-daemon.sh --help` works on macOS without error | ✅ | Manually ran `bash defaults/scripts/stop-daemon.sh --help` on macOS — prints usage cleanly, exits with code 0 |
| POSIX-portable fix (`sed '$d'` not GNU-specific) | ✅ | `sed '$d'` is POSIX-standard and works on both BSD sed (macOS) and GNU sed (Linux) |
| Help block still terminates correctly | ✅ | Last blank/comment line stripped, no extra blank line printed in output |

## Test Plan

- Manually verified both scripts produce correct `--help` output on macOS (darwin 25.3.0)
- No automated test harness exists for these shell scripts per curator notes

Closes #2963