### PR TITLE
fix: fall back to GitHub mergeable check when rebase phase has no worktree

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/rebase.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/rebase.py
@@ -82,6 +82,15 @@ class RebasePhase(BasePhase):
             return self.shutdown("shutdown signal detected")
 
         if ctx.worktree_path is None or not ctx.worktree_path.is_dir():
+            if ctx.pr_number and _is_pr_mergeable(ctx.pr_number, str(ctx.repo_root)):
+                log_info(
+                    f"No worktree available but PR #{ctx.pr_number} is CLEAN on GitHub"
+                    f" — skipping rebase"
+                )
+                return self.success(
+                    "no worktree available but PR is mergeable on GitHub",
+                    {"reason": "github_mergeable_fallback"},
+                )
             return self.failed(
                 "no worktree path available for rebase",
                 {"reason": "no_worktree"},


### PR DESCRIPTION
## Summary

The rebase phase was failing hard (`self.failed(...)`) when `ctx.worktree_path` is `None` or missing, without applying the same `_is_pr_mergeable()` fallback that already exists for local rebase failures. This caused shepherds that restart without a worktree (e.g. after force-mode cleanup or cross-process PR creation) to fail even when GitHub reports the PR as `CLEAN`.

## Changes

- `loom-tools/src/loom_tools/shepherd/phases/rebase.py`: When no worktree is available, check `_is_pr_mergeable()` before returning `self.failed(...)`. Return `self.success(...)` with `reason: github_mergeable_fallback` if GitHub reports `MERGEABLE/CLEAN`, consistent with the existing local-rebase-failure fallback (lines 124–138).
- `loom-tools/tests/shepherd/test_rebase.py`: Update the two existing no-worktree failure tests to mock `_is_pr_mergeable` returning `False` (reflecting the new code path), and add three new tests:
  - `test_no_worktree_but_pr_is_clean_on_github_succeeds` — worktree_path is None, PR is CLEAN → SUCCESS
  - `test_nonexistent_worktree_but_pr_is_clean_on_github_succeeds` — worktree dir missing, PR is CLEAN → SUCCESS
  - `test_no_worktree_no_pr_number_fails_without_github_check` — no worktree and no PR number → FAILED, `_is_pr_mergeable` not called

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Rebase phase skips gracefully when no worktree but PR is CLEAN | ✅ | New code path: `_is_pr_mergeable()` fallback added at lines 85–93; `test_no_worktree_but_pr_is_clean_on_github_succeeds` passes |
| Hard failure still returned when no worktree and PR is not CLEAN | ✅ | `self.failed(...)` at line 94 still reached when `_is_pr_mergeable()` returns False; existing tests updated and passing |
| No GitHub check when no PR number | ✅ | Guard `if ctx.pr_number and ...` prevents call when pr_number is None; `test_no_worktree_no_pr_number_fails_without_github_check` passes |
| Consistent with existing local-rebase-failure fallback pattern | ✅ | Same `_is_pr_mergeable()` function, same `github_mergeable_fallback` reason, same log message pattern |
| All 31 rebase tests pass | ✅ | `python3 -m pytest loom-tools/tests/shepherd/test_rebase.py -v` → 31 passed |

## Test Plan

```
PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/shepherd/test_rebase.py -v
# → 31 passed (28 original + 3 new)
```

Closes #2910