### PR TITLE
fix: clear stale checkpoint before thinking stall retry

### DIFF
--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -19670,6 +19670,129 @@ class TestRunPhaseWithRetryThinkingStall:
         sleep_calls = [c.args[0] for c in mock_sleep.call_args_list]
         assert sleep_calls == list(THINKING_STALL_BACKOFF_SECONDS)
 
+    def test_thinking_stall_clears_checkpoint_before_retry(
+        self, mock_context: MagicMock, tmp_path: Path
+    ) -> None:
+        """A thinking stall retry should delete the worktree checkpoint file.
+
+        The stalled builder writes `.loom-checkpoint` at stage=planning before
+        it stalls.  Without cleanup, the retry builder reads the stale checkpoint,
+        concludes planning is already in progress, skips re-initialisation, finds
+        nothing meaningful to do, and exits with code 0 — consuming a failure
+        budget slot.  The fix deletes the checkpoint before sleeping so the retry
+        builder starts fresh.  See issue #2914.
+        """
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        checkpoint_file = worktree / ".loom-checkpoint"
+        checkpoint_file.write_text('{"stage": "planning"}')
+
+        call_count = 0
+
+        def mock_run_worker(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return 14 if call_count == 1 else 0
+
+        with (
+            patch(
+                "loom_tools.shepherd.phases.base.run_worker_phase",
+                side_effect=mock_run_worker,
+            ),
+            patch("time.sleep"),
+        ):
+            exit_code = run_phase_with_retry(
+                mock_context,
+                role="builder",
+                name="builder-issue-42",
+                timeout=600,
+                max_retries=2,
+                phase="builder",
+                worktree=worktree,
+            )
+
+        assert exit_code == 0
+        assert call_count == 2
+        # Checkpoint must be removed before the retry was spawned
+        assert not checkpoint_file.exists(), (
+            ".loom-checkpoint was not deleted before the thinking stall retry"
+        )
+
+    def test_thinking_stall_no_worktree_does_not_error(
+        self, mock_context: MagicMock
+    ) -> None:
+        """A thinking stall retry with no worktree should not raise an error.
+
+        When worktree=None (e.g., judge/curator phases), the checkpoint cleanup
+        is skipped gracefully.  See issue #2914.
+        """
+        call_count = 0
+
+        def mock_run_worker(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return 14 if call_count == 1 else 0
+
+        with (
+            patch(
+                "loom_tools.shepherd.phases.base.run_worker_phase",
+                side_effect=mock_run_worker,
+            ),
+            patch("time.sleep"),
+        ):
+            exit_code = run_phase_with_retry(
+                mock_context,
+                role="judge",
+                name="judge-issue-42",
+                timeout=600,
+                max_retries=2,
+                phase="judge",
+                worktree=None,
+            )
+
+        assert exit_code == 0
+        assert call_count == 2
+
+    def test_thinking_stall_missing_checkpoint_does_not_error(
+        self, mock_context: MagicMock, tmp_path: Path
+    ) -> None:
+        """A thinking stall retry when no checkpoint file exists should not raise.
+
+        If the stalled builder never wrote a checkpoint (e.g., it stalled before
+        starting planning), unlink(missing_ok=True) should silently succeed.
+        See issue #2914.
+        """
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        # No checkpoint file created — worktree is empty
+
+        call_count = 0
+
+        def mock_run_worker(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return 14 if call_count == 1 else 0
+
+        with (
+            patch(
+                "loom_tools.shepherd.phases.base.run_worker_phase",
+                side_effect=mock_run_worker,
+            ),
+            patch("time.sleep"),
+        ):
+            exit_code = run_phase_with_retry(
+                mock_context,
+                role="builder",
+                name="builder-issue-42",
+                timeout=600,
+                max_retries=2,
+                phase="builder",
+                worktree=worktree,
+            )
+
+        assert exit_code == 0
+        assert call_count == 2
+
 
 class TestExtractTestFilePaths:
     """Test BuilderPhase._extract_test_file_paths."""


### PR DESCRIPTION
## Summary

When a builder session exits with code 14 (thinking stall), `run_phase_with_retry` sleeps and spawns a retry in the same worktree. The stalled builder had already written `.loom-checkpoint` at `stage=planning`. The retry builder reads this stale checkpoint, skips re-initialisation, finds nothing meaningful to do, and exits immediately with code 0 — consuming a failure budget slot without doing real work.

## Changes

- In `run_phase_with_retry` (base.py): before sleeping and continuing the retry loop on exit code 14, delete `worktree / ".loom-checkpoint"` using `unlink(missing_ok=True)`. When `worktree=None` (judge/curator phases with no worktree), the cleanup is skipped entirely.
- In `test_phases.py`: added three tests to `TestRunPhaseWithRetryThinkingStall`:
  - `test_thinking_stall_clears_checkpoint_before_retry` — verifies the checkpoint file is deleted before the retry
  - `test_thinking_stall_no_worktree_does_not_error` — verifies graceful no-op when `worktree=None`
  - `test_thinking_stall_missing_checkpoint_does_not_error` — verifies no error when checkpoint file is absent

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| After a thinking stall, the `.loom-checkpoint` file is removed before the retry is spawned | ✅ | `test_thinking_stall_clears_checkpoint_before_retry` creates the file, calls `run_phase_with_retry` with a stall+success sequence, and asserts `checkpoint_file.exists()` is False |
| The retry builder session starts fresh (no stale stage seen in diagnostics) | ✅ | Covered by the above test — with the checkpoint removed, the retry builder sees no existing checkpoint |
| A unit test for `run_phase_with_retry` verifies the checkpoint is cleared between a stall and its retry | ✅ | Three tests added to `TestRunPhaseWithRetryThinkingStall` covering the happy path, None worktree, and missing file edge cases |

## Test Plan

```
PYTHONPATH=loom-tools/src:$PYTHONPATH python3 -m pytest loom-tools/tests/shepherd/test_phases.py::TestRunPhaseWithRetryThinkingStall -v
# All 7 tests pass (4 pre-existing + 3 new)

PYTHONPATH=loom-tools/src:$PYTHONPATH python3 -m pytest loom-tools/tests/shepherd/test_phases.py -k "ThinkingStall or thinking_stall" -v
# All 20 thinking stall tests pass
```

Closes #2914