### PR TITLE
feat: write full Loom guide to .loom/CLAUDE.md, inject short pointer into root CLAUDE.md

### DIFF
--- a/scripts/uninstall-loom.sh
+++ b/scripts/uninstall-loom.sh
@@ -782,6 +782,13 @@ if [[ -f "$WORKTREE_ABS/CLAUDE.md" ]]; then
   fi
 fi
 
+# Handle .loom/CLAUDE.md - remove the full Loom guide written by install
+if [[ -f "$WORKTREE_ABS/.loom/CLAUDE.md" ]]; then
+  rm -f "$WORKTREE_ABS/.loom/CLAUDE.md"
+  REMOVED_LIST+=(".loom/CLAUDE.md")
+  success ".loom/CLAUDE.md removed"
+fi
+
 # Handle .gitignore - remove Loom-specific patterns
 if [[ -f "$WORKTREE_ABS/.gitignore" ]]; then
   info "Removing Loom patterns from .gitignore..."


### PR DESCRIPTION
## Summary

On install, write the full Loom guide (with template substitution) to `.loom/CLAUDE.md` in the target repo. Inject only a one-line pointer into the root `CLAUDE.md` between the existing Loom section markers. This eliminates 537+ lines of Loom documentation from root `CLAUDE.md`, preserving context budget for non-Loom sessions. Claude Code auto-discovers `.loom/CLAUDE.md` when agents work in `.loom/worktrees/issue-N/` via ancestor directory traversal — no agent configuration changes needed.

## Changes

- `loom-daemon/src/init/scaffolding.rs`: Changed CLAUDE.md handling to write full guide to `<workspace>/.loom/CLAUDE.md` and inject only the short `LOOM_ROOT_POINTER` constant into root `CLAUDE.md`. Added `LOOM_ROOT_POINTER` constant. Updated existing tests. Added 3 new tests: `test_loom_claude_md_written_to_loom_dir`, `test_root_claude_md_contains_only_pointer`, `test_loom_claude_md_updated_on_reinstall`
- `scripts/uninstall-loom.sh`: Remove `.loom/CLAUDE.md` during uninstall in addition to the Loom section from root `CLAUDE.md`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Root CLAUDE.md contains only the short pointer after fresh install | ✅ | `test_root_claude_md_contains_only_pointer` and `test_claude_md_preservation_new_install` assert `LOOM_ROOT_POINTER` in root and absence of full guide content |
| `.loom/CLAUDE.md` exists after fresh install with full guide | ✅ | `test_loom_claude_md_written_to_loom_dir` asserts full guide content written to `.loom/CLAUDE.md` |
| Reinstall/upgrade replaces old full content in root with short pointer | ✅ | `test_claude_md_preservation_update_loom_section_only` verifies old content replaced with pointer via marker detection |
| `.loom/CLAUDE.md` updated on reinstall | ✅ | `test_loom_claude_md_updated_on_reinstall` verifies overwrite with latest template content |
| Uninstall removes `.loom/CLAUDE.md` | ✅ | Added explicit removal block in `uninstall-loom.sh` with tracking in `REMOVED_LIST` |
| Template variable substitution works in `.loom/CLAUDE.md` | ✅ | Full `substitute_template_variables()` applied before writing to `.loom/CLAUDE.md` |
| Agents in worktrees auto-discover `.loom/CLAUDE.md` | ✅ | No code change needed — Claude Code ancestor directory traversal handles this |
| Sessions not in a Loom worktree only see short pointer | ✅ | Root CLAUDE.md only contains the 1-line pointer (verified by tests) |

## Test Plan

All 13 unit tests in `init::scaffolding` pass, including 3 new tests specifically for the new behavior. Ran:
- `cargo check` — clean
- `cargo clippy` — clean (fixed `if_not_else` warning)
- `cargo test init::scaffolding` — 13/13 passed
- `cargo test` — all tests passed

Closes #2992