### PR TITLE
fix: queue spawn_shepherd signals when all shepherd slots are full

### DIFF
--- a/loom-tools/src/loom_tools/daemon_v2/context.py
+++ b/loom-tools/src/loom_tools/daemon_v2/context.py
@@ -33,6 +33,12 @@ class DaemonContext:
     snapshot: dict[str, Any] | None = None
     state: DaemonState | None = None
 
+    # Pending spawn queue: spawn_shepherd signals that could not be fulfilled
+    # immediately (no idle slot available) are held here and retried each
+    # iteration until a slot opens or the issue is cancelled.
+    # Each entry is a dict: {"issue": int, "mode": str, "flags": list[str]}
+    pending_spawns: list[dict] = field(default_factory=list)
+
     # File paths (computed from repo_root)
     _log_file: pathlib.Path | None = field(default=None, repr=False)
     _state_file: pathlib.Path | None = field(default=None, repr=False)

--- a/loom-tools/src/loom_tools/daemon_v2/loop.py
+++ b/loom-tools/src/loom_tools/daemon_v2/loop.py
@@ -119,6 +119,11 @@ def run(ctx: DaemonContext) -> int:
                 # Update signal_queue_depth in state file after processing
                 _update_signal_queue_depth(ctx, command_poller.queue_depth())
 
+            # Retry any pending spawn signals that were queued when all slots were full.
+            # Runs before each iteration so reclaimed slots are immediately reused.
+            if ctx.pending_spawns:
+                _retry_pending_spawns(ctx)
+
             # Run iteration
             log_info(f"Iteration {ctx.iteration}: Starting...")
             start_time = time.time()
@@ -190,6 +195,12 @@ def _responsive_sleep(
             log_info(f"Sleep-tick: processing {len(commands)} signal command(s)")
             _process_commands(ctx, commands)
             _update_signal_queue_depth(ctx, command_poller.queue_depth())
+
+        # Retry pending spawns that were queued when all slots were full.
+        # Doing this during sleep ticks means a freed slot triggers a spawn
+        # within 2s rather than waiting for the next full iteration.
+        if ctx.pending_spawns:
+            _retry_pending_spawns(ctx)
 
 
 def _process_commands(ctx: DaemonContext, commands: list[dict]) -> None:
@@ -274,19 +285,29 @@ def _spawn_shepherd_from_signal(
 
     from loom_tools.models.daemon_state import ShepherdEntry
 
-    shepherd_script = ctx.repo_root / ".loom" / "scripts" / "loom-shepherd.sh"
-    if not shepherd_script.exists():
-        log_error(f"Signal spawn: loom-shepherd.sh not found at {shepherd_script}")
-        return
-
-    # Find or allocate a shepherd slot
+    # Check slot availability FIRST so we can queue for retry even when the
+    # shepherd script is missing (it will be present when the slot eventually
+    # opens in a healthy deployment, and the error will surface then).
     if ctx.state is None:
         log_warning("Signal spawn: no daemon state loaded, cannot track shepherd")
         return
 
     shepherd_name = _find_idle_shepherd_slot(ctx)
     if shepherd_name is None:
-        log_warning(f"Signal spawn: no idle shepherd slot available for issue #{issue}")
+        # No slot available — enqueue for retry on the next iteration or
+        # sleep-tick rather than silently dropping the signal.
+        pending = {"issue": issue, "mode": mode, "flags": flags}
+        if pending not in ctx.pending_spawns:
+            ctx.pending_spawns.append(pending)
+            log_warning(
+                f"Signal spawn: no idle shepherd slot available for issue #{issue} "
+                f"— queued for retry (pending={len(ctx.pending_spawns)})"
+            )
+        return
+
+    shepherd_script = ctx.repo_root / ".loom" / "scripts" / "loom-shepherd.sh"
+    if not shepherd_script.exists():
+        log_error(f"Signal spawn: loom-shepherd.sh not found at {shepherd_script}")
         return
 
     # Build command arguments
@@ -355,6 +376,46 @@ def _find_idle_shepherd_slot(ctx: DaemonContext) -> str | None:
         return new_name
 
     return None
+
+
+def _retry_pending_spawns(ctx: DaemonContext) -> None:
+    """Attempt to spawn shepherds from the pending queue.
+
+    Called at the start of each iteration and during responsive-sleep ticks.
+    Drains ``ctx.pending_spawns`` by attempting to fulfil each queued spawn
+    signal.  Entries that still cannot be fulfilled (slots still full) remain
+    in the queue for the next retry.
+
+    Algorithm:
+    1. Snapshot and clear the pending list (so _spawn_shepherd_from_signal
+       can re-queue items to ctx.pending_spawns without interfering).
+    2. For each snapshot item, attempt the spawn.
+       - Success: item is consumed.
+       - Failure (slot gone again): _spawn_shepherd_from_signal re-queues
+         the item into ctx.pending_spawns automatically.
+    3. Any items added to ctx.pending_spawns by step 2 are already there;
+       no further merging is needed.
+    """
+    if not ctx.pending_spawns:
+        return
+
+    # Take a snapshot and clear, so re-queuing by _spawn_shepherd_from_signal
+    # goes into a clean list.
+    to_retry = ctx.pending_spawns[:]
+    ctx.pending_spawns = []
+
+    log_info(f"Retrying {len(to_retry)} pending spawn(s)...")
+    for pending in to_retry:
+        issue = pending["issue"]
+        mode = pending["mode"]
+        flags = pending["flags"]
+        _spawn_shepherd_from_signal(ctx, issue, mode, flags)
+
+    if ctx.pending_spawns:
+        log_info(
+            f"Pending spawn queue: {len(ctx.pending_spawns)} spawn(s) still "
+            f"waiting for an idle shepherd slot"
+        )
 
 
 def _pause_shepherd(ctx: DaemonContext, shepherd_id: str) -> None:

--- a/loom-tools/tests/daemon_v2/test_pending_spawns.py
+++ b/loom-tools/tests/daemon_v2/test_pending_spawns.py
@@ -1,0 +1,269 @@
+"""Tests for spawn_shepherd pending queue behaviour.
+
+When all shepherd slots are full, a spawn_shepherd signal must NOT be silently
+dropped.  Instead it should be enqueued in ctx.pending_spawns and retried when
+a slot becomes available.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from unittest import mock
+
+import pytest
+
+from loom_tools.daemon_v2.config import DaemonConfig
+from loom_tools.daemon_v2.context import DaemonContext
+from loom_tools.daemon_v2.loop import (
+    _find_idle_shepherd_slot,
+    _process_commands,
+    _retry_pending_spawns,
+    _spawn_shepherd_from_signal,
+)
+from loom_tools.models.daemon_state import DaemonState, ShepherdEntry
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ctx(
+    tmp_path: pathlib.Path,
+    *,
+    max_shepherds: int = 2,
+) -> DaemonContext:
+    """Return a DaemonContext with minimal state for unit tests."""
+    config = DaemonConfig(max_shepherds=max_shepherds)
+    ctx = DaemonContext(config=config, repo_root=tmp_path)
+    ctx.state = DaemonState()
+    return ctx
+
+
+def _fill_slots(ctx: DaemonContext) -> None:
+    """Mark all shepherd slots as working so no idle slot is available."""
+    for i in range(ctx.config.max_shepherds):
+        name = f"shepherd-{i + 1}"
+        ctx.state.shepherds[name] = ShepherdEntry(status="working", issue=100 + i)
+
+
+def _free_one_slot(ctx: DaemonContext) -> None:
+    """Set the first working shepherd back to idle, freeing one slot."""
+    for name, entry in ctx.state.shepherds.items():
+        if entry.status == "working":
+            entry.status = "idle"
+            entry.issue = None
+            return
+
+
+# ---------------------------------------------------------------------------
+# Tests: _spawn_shepherd_from_signal enqueues instead of dropping
+# ---------------------------------------------------------------------------
+
+
+class TestSpawnShepherdFromSignalQueuesWhenFull:
+    """_spawn_shepherd_from_signal should enqueue pending spawns, not drop."""
+
+    def test_no_slot_enqueues_pending(self, tmp_path: pathlib.Path) -> None:
+        """When all slots are full the signal is added to pending_spawns."""
+        ctx = _make_ctx(tmp_path)
+        _fill_slots(ctx)
+        assert len(ctx.pending_spawns) == 0
+
+        _spawn_shepherd_from_signal(ctx, issue=42, mode="default", flags=[])
+
+        assert len(ctx.pending_spawns) == 1
+        assert ctx.pending_spawns[0] == {"issue": 42, "mode": "default", "flags": []}
+
+    def test_no_slot_does_not_duplicate_pending(self, tmp_path: pathlib.Path) -> None:
+        """Calling with the same issue multiple times should not duplicate entries."""
+        ctx = _make_ctx(tmp_path)
+        _fill_slots(ctx)
+
+        _spawn_shepherd_from_signal(ctx, issue=42, mode="default", flags=[])
+        _spawn_shepherd_from_signal(ctx, issue=42, mode="default", flags=[])
+
+        assert len(ctx.pending_spawns) == 1
+
+    def test_different_issues_both_enqueued(self, tmp_path: pathlib.Path) -> None:
+        """Two different issues with no slot should both be enqueued."""
+        ctx = _make_ctx(tmp_path)
+        _fill_slots(ctx)
+
+        _spawn_shepherd_from_signal(ctx, issue=10, mode="default", flags=[])
+        _spawn_shepherd_from_signal(ctx, issue=20, mode="default", flags=[])
+
+        issues = [p["issue"] for p in ctx.pending_spawns]
+        assert sorted(issues) == [10, 20]
+
+    @mock.patch("loom_tools.daemon_v2.loop.subprocess.Popen")
+    def test_slot_available_does_not_enqueue(
+        self, mock_popen: mock.MagicMock, tmp_path: pathlib.Path
+    ) -> None:
+        """When a slot IS available the signal is spawned, not enqueued."""
+        ctx = _make_ctx(tmp_path, max_shepherds=2)
+        # Only one working shepherd — one idle slot remains
+        ctx.state.shepherds["shepherd-1"] = ShepherdEntry(status="working", issue=100)
+
+        # Patch shepherd script existence check
+        shepherd_script = tmp_path / ".loom" / "scripts" / "loom-shepherd.sh"
+        shepherd_script.parent.mkdir(parents=True, exist_ok=True)
+        shepherd_script.touch()
+
+        proc_mock = mock.MagicMock()
+        proc_mock.pid = 12345
+        mock_popen.return_value = proc_mock
+
+        _spawn_shepherd_from_signal(ctx, issue=42, mode="default", flags=[])
+
+        # Nothing should be pending
+        assert len(ctx.pending_spawns) == 0
+        # Popen should have been called
+        assert mock_popen.called
+
+
+# ---------------------------------------------------------------------------
+# Tests: _retry_pending_spawns
+# ---------------------------------------------------------------------------
+
+
+class TestRetryPendingSpawns:
+    """_retry_pending_spawns should drain the queue when slots open up."""
+
+    def test_empty_queue_is_noop(self, tmp_path: pathlib.Path) -> None:
+        """Calling with an empty queue should not raise."""
+        ctx = _make_ctx(tmp_path)
+        ctx.pending_spawns = []
+        _retry_pending_spawns(ctx)  # must not raise
+        assert ctx.pending_spawns == []
+
+    @mock.patch("loom_tools.daemon_v2.loop.subprocess.Popen")
+    def test_retry_succeeds_when_slot_opens(
+        self, mock_popen: mock.MagicMock, tmp_path: pathlib.Path
+    ) -> None:
+        """Once a slot is freed, _retry_pending_spawns spawns the pending entry."""
+        ctx = _make_ctx(tmp_path, max_shepherds=1)
+        _fill_slots(ctx)
+
+        # Signal arrives when full — gets queued
+        _spawn_shepherd_from_signal(ctx, issue=42, mode="default", flags=[])
+        assert len(ctx.pending_spawns) == 1
+
+        # Free the slot
+        _free_one_slot(ctx)
+
+        # Set up shepherd script
+        shepherd_script = tmp_path / ".loom" / "scripts" / "loom-shepherd.sh"
+        shepherd_script.parent.mkdir(parents=True, exist_ok=True)
+        shepherd_script.touch()
+
+        proc_mock = mock.MagicMock()
+        proc_mock.pid = 99999
+        mock_popen.return_value = proc_mock
+
+        _retry_pending_spawns(ctx)
+
+        # Queue should be drained
+        assert ctx.pending_spawns == []
+        # Spawn should have been called
+        assert mock_popen.called
+
+    def test_retry_keeps_items_when_still_full(self, tmp_path: pathlib.Path) -> None:
+        """Items stay queued when all slots are still occupied after retry."""
+        ctx = _make_ctx(tmp_path, max_shepherds=1)
+        _fill_slots(ctx)
+
+        # Queue a pending spawn
+        ctx.pending_spawns = [{"issue": 42, "mode": "default", "flags": []}]
+
+        # Retry with still-full slots — nothing should be spawned
+        _retry_pending_spawns(ctx)
+
+        # Item should still be in the queue
+        assert len(ctx.pending_spawns) == 1
+        assert ctx.pending_spawns[0]["issue"] == 42
+
+    @mock.patch("loom_tools.daemon_v2.loop.subprocess.Popen")
+    def test_retry_only_drains_as_many_as_available_slots(
+        self, mock_popen: mock.MagicMock, tmp_path: pathlib.Path
+    ) -> None:
+        """Only as many pending spawns as available slots should be drained."""
+        ctx = _make_ctx(tmp_path, max_shepherds=2)
+        _fill_slots(ctx)
+
+        # Queue 3 pending spawns
+        ctx.pending_spawns = [
+            {"issue": 10, "mode": "default", "flags": []},
+            {"issue": 20, "mode": "default", "flags": []},
+            {"issue": 30, "mode": "default", "flags": []},
+        ]
+
+        # Free exactly one slot
+        _free_one_slot(ctx)
+
+        shepherd_script = tmp_path / ".loom" / "scripts" / "loom-shepherd.sh"
+        shepherd_script.parent.mkdir(parents=True, exist_ok=True)
+        shepherd_script.touch()
+
+        proc_mock = mock.MagicMock()
+        proc_mock.pid = 11111
+        mock_popen.return_value = proc_mock
+
+        _retry_pending_spawns(ctx)
+
+        # One spawned, two remain
+        assert len(ctx.pending_spawns) == 2
+        assert mock_popen.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: _process_commands integration — queuing path
+# ---------------------------------------------------------------------------
+
+
+class TestProcessCommandsQueuing:
+    """_process_commands should enqueue spawn_shepherd when all slots are full."""
+
+    def test_spawn_shepherd_queued_when_full(self, tmp_path: pathlib.Path) -> None:
+        """spawn_shepherd command is queued when no idle slot exists."""
+        ctx = _make_ctx(tmp_path)
+        _fill_slots(ctx)
+
+        commands = [{"action": "spawn_shepherd", "issue": 55, "mode": "default", "flags": []}]
+        _process_commands(ctx, commands)
+
+        assert any(p["issue"] == 55 for p in ctx.pending_spawns)
+
+    def test_spawn_shepherd_without_issue_not_queued(self, tmp_path: pathlib.Path) -> None:
+        """spawn_shepherd with no issue field should be skipped, not queued."""
+        ctx = _make_ctx(tmp_path)
+        _fill_slots(ctx)
+
+        commands = [{"action": "spawn_shepherd", "mode": "default"}]
+        _process_commands(ctx, commands)
+
+        assert ctx.pending_spawns == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: DaemonContext.pending_spawns field
+# ---------------------------------------------------------------------------
+
+
+class TestDaemonContextPendingSpawns:
+    """DaemonContext should have a pending_spawns field that defaults to []."""
+
+    def test_pending_spawns_default_empty(self, tmp_path: pathlib.Path) -> None:
+        config = DaemonConfig()
+        ctx = DaemonContext(config=config, repo_root=tmp_path)
+        assert ctx.pending_spawns == []
+
+    def test_pending_spawns_not_shared_between_instances(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """Each DaemonContext gets its own list (no mutable default sharing)."""
+        config = DaemonConfig()
+        ctx_a = DaemonContext(config=config, repo_root=tmp_path)
+        ctx_b = DaemonContext(config=config, repo_root=tmp_path)
+        ctx_a.pending_spawns.append({"issue": 1, "mode": "default", "flags": []})
+        assert ctx_b.pending_spawns == []


### PR DESCRIPTION
## Summary

When the daemon receives a `spawn_shepherd` signal but all shepherd slots are full, the signal was silently dropped after being consumed from disk. This meant the issue would never be picked up unless the signal file was manually re-written. This PR fixes the bug by implementing an in-memory pending spawn queue that retries dropped signals whenever a slot becomes available.

## Changes

- **`context.py`**: Added `pending_spawns: list[dict]` field to `DaemonContext` (defaults to `[]`; uses `field(default_factory=list)` to avoid mutable-default sharing)
- **`loop.py`**: Reordered the slot-availability check to run before the shepherd-script existence check in `_spawn_shepherd_from_signal()`, so the queue path is reachable even when the script is absent (e.g. in tests)
- **`loop.py`**: When no idle slot is found, the signal is enqueued in `ctx.pending_spawns` with a dedup guard instead of being silently dropped
- **`loop.py`**: Added `_retry_pending_spawns()` which snapshots the queue, clears it, then calls `_spawn_shepherd_from_signal()` for each entry; entries that still can't find a slot are re-queued automatically
- **`loop.py`**: `_retry_pending_spawns()` is called in two places: (1) at the start of each iteration before `run_iteration()`, and (2) inside `_responsive_sleep()` on every 2-second tick — so freed slots trigger a spawn within 2 seconds rather than waiting for the next full poll interval
- **`tests/daemon_v2/test_pending_spawns.py`**: 12 new unit tests covering enqueueing, dedup, multi-issue queuing, retry-succeeds-when-slot-opens, retry-keeps-items-when-still-full, partial drain (only as many as available slots), `_process_commands` integration path, and `DaemonContext.pending_spawns` field isolation

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Signal not silently dropped when slots full | ✅ | `test_no_slot_enqueues_pending` confirms signal added to `pending_spawns` |
| Pending spawn retried when slot opens | ✅ | `test_retry_succeeds_when_slot_opens` confirms `Popen` called after slot freed |
| Stays queued while still full | ✅ | `test_retry_keeps_items_when_still_full` confirms item persists |
| No duplicate entries for same issue | ✅ | `test_no_slot_does_not_duplicate_pending` confirms dedup guard |
| Multiple distinct issues all queued | ✅ | `test_different_issues_both_enqueued` confirms both queued |
| Only drains as many as available slots | ✅ | `test_retry_only_drains_as_many_as_available_slots` confirms 1 spawn with 1 slot |
| All 164 daemon_v2 tests pass | ✅ | Full test suite run confirms no regressions |

## Test Plan

- Ran `PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/daemon_v2/ -v` from the worktree — all 164 tests pass (12 new + 152 existing)

Closes #2970