### PR TITLE
fix: classify thinking stall exhaustion as builder_thinking_stall error class

### DIFF
--- a/loom-tools/tests/shepherd/test_cli.py
+++ b/loom-tools/tests/shepherd/test_cli.py
@@ -4449,6 +4449,60 @@ class TestRecordFallbackFailure:
     @patch("loom_tools.shepherd.cli.get_pr_for_issue", return_value=None)
     @patch("loom_tools.common.systematic_failure.detect_systematic_failure", return_value=None)
     @patch("loom_tools.common.systematic_failure.record_blocked_reason")
+    def test_records_thinking_stall_class(
+        self,
+        mock_record: MagicMock,
+        mock_detect: MagicMock,
+        mock_get_pr: MagicMock,
+    ) -> None:
+        """Should record builder_thinking_stall when abandonment_info has thinking_stall flag (issue #2921)."""
+        ctx = MagicMock()
+        ctx.config.issue = 42
+        ctx.repo_root = Path("/fake/repo")
+        ctx.abandonment_info = {
+            "phase": "builder",
+            "failure_data": {"thinking_stall": True, "exit_code": 1},
+            "message": "builder thinking stall: extended thinking output with zero tool calls detected",
+        }
+
+        _record_fallback_failure(ctx, ShepherdExitCode.BUILDER_FAILED)
+
+        mock_record.assert_called_once_with(
+            Path("/fake/repo"),
+            42,
+            error_class="builder_thinking_stall",
+            phase="builder",
+            details=(
+                "Builder thinking stall retry budget exhausted — extended thinking "
+                "output with zero tool calls detected (fallback cleanup)"
+            ),
+        )
+        mock_detect.assert_called_once_with(Path("/fake/repo"))
+
+    @patch("loom_tools.shepherd.cli.get_pr_for_issue", return_value=None)
+    @patch("loom_tools.common.systematic_failure.detect_systematic_failure", return_value=None)
+    @patch("loom_tools.common.systematic_failure.record_blocked_reason")
+    def test_thinking_stall_without_abandonment_info_falls_through_to_unknown(
+        self,
+        mock_record: MagicMock,
+        mock_detect: MagicMock,
+        mock_get_pr: MagicMock,
+    ) -> None:
+        """Should fall through to builder_unknown_failure when no abandonment_info set."""
+        ctx = MagicMock()
+        ctx.config.issue = 42
+        ctx.repo_root = Path("/fake/repo")
+        ctx.abandonment_info = None
+        ctx.last_postmortem = None
+
+        _record_fallback_failure(ctx, ShepherdExitCode.BUILDER_FAILED)
+
+        call_args = mock_record.call_args
+        assert call_args.kwargs.get("error_class") == "builder_unknown_failure"
+
+    @patch("loom_tools.shepherd.cli.get_pr_for_issue", return_value=None)
+    @patch("loom_tools.common.systematic_failure.detect_systematic_failure", return_value=None)
+    @patch("loom_tools.common.systematic_failure.record_blocked_reason")
     def test_records_unknown_failure_class(
         self,
         mock_record: MagicMock,
@@ -4460,6 +4514,7 @@ class TestRecordFallbackFailure:
         ctx.config.issue = 42
         ctx.repo_root = Path("/fake/repo")
         ctx.last_postmortem = None
+        ctx.abandonment_info = None
 
         _record_fallback_failure(ctx, ShepherdExitCode.BUILDER_FAILED)
 
@@ -4485,6 +4540,7 @@ class TestRecordFallbackFailure:
         ctx = MagicMock()
         ctx.config.issue = 42
         ctx.repo_root = Path("/fake/repo")
+        ctx.abandonment_info = None
         ctx.last_postmortem = {
             "summary": "CLI started but produced zero output; wall: 5s; exit(wait=1)",
         }
@@ -4539,6 +4595,7 @@ class TestRecordFallbackFailure:
         ctx = MagicMock()
         ctx.config.issue = 42
         ctx.repo_root = tmp_path
+        ctx.abandonment_info = None
 
         _record_fallback_failure(ctx, ShepherdExitCode.BUILDER_FAILED)
 
@@ -4569,6 +4626,7 @@ class TestRecordFallbackFailure:
         ctx = MagicMock()
         ctx.config.issue = 42
         ctx.repo_root = tmp_path
+        ctx.abandonment_info = None
         ctx.last_postmortem = None
 
         _record_fallback_failure(ctx, ShepherdExitCode.BUILDER_FAILED)


### PR DESCRIPTION
## Summary

When builder thinking stall retry budget is exhausted, the failure was incorrectly classified as `builder_unknown_failure` in the systematic failure tracker, making it indistinguishable from genuine unknown failures. This PR adds a specific `builder_thinking_stall` error class for this condition.

## Changes

- In `_record_fallback_failure` in `cli.py`: added an `elif` branch that checks `ctx.abandonment_info` for the `thinking_stall` flag (set by the builder phase when thinking stall retry budget is exhausted) and assigns `error_class="builder_thinking_stall"` with a tailored details message
- In `test_cli.py`: added two new tests for the thinking stall classification and fixed four existing tests that used bare `MagicMock()` for `ctx` (which would accidentally match the new branch since `MagicMock().abandonment_info` is truthy)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Thinking stall exhaustion classified as `builder_thinking_stall`, not `builder_unknown_failure` | Done | New test `test_records_thinking_stall_class` verifies `error_class="builder_thinking_stall"` when `abandonment_info` has `thinking_stall: True` |
| Operators can distinguish thinking stall from genuine unknown failures | Done | Separate error class in `issue-failures.json` and daemon state |
| Recovery guidance is tailored | Done | Details message specifies "thinking stall retry budget exhausted" (not generic "failed without specific handler") |
| No regression to existing error class tests | Done | All 12 `TestRecordFallbackFailure` tests pass; all 186 `test_cli.py` tests pass |

## Test Plan

```
PYTHONPATH=loom-tools/src:$PYTHONPATH python3 -m pytest loom-tools/tests/shepherd/test_cli.py::TestRecordFallbackFailure -v
# 12 passed
PYTHONPATH=loom-tools/src:$PYTHONPATH python3 -m pytest loom-tools/tests/shepherd/test_cli.py -q
# 186 passed
```

Closes #2921