### PR TITLE
fix: tag rate-limit pre-check PhaseResult with api_rate_limited flag

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/cli.py
+++ b/loom-tools/src/loom_tools/shepherd/cli.py
@@ -2251,6 +2251,16 @@ def _post_fallback_failure_comment(ctx: ShepherdContext, exit_code: int) -> None
                 "Wait for the usage or plan limit to reset, or re-authenticate "
                 "with a different plan before retrying."
             )
+        elif failure_data.get("api_rate_limited"):
+            failure_mode = (
+                "API rate limit pre-check — usage exceeded configured threshold "
+                "before builder was started"
+            )
+            safe_to_retry = True
+            advice = (
+                "The issue has been returned to `loom:issue`. "
+                "Retry after the rate limit resets (usually a few minutes)."
+            )
         else:
             # Generic builder failure (MCP failure, low-output, etc.)
             failure_mode = message or "unexpected failure"

--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -363,6 +363,7 @@ class BuilderPhase:
                 status=PhaseStatus.FAILED,
                 message=f"API rate limit exceeded (threshold: {ctx.config.rate_limit_threshold}%)",
                 phase_name="builder",
+                data={"api_rate_limited": True},
             )
 
         # Report phase entry

--- a/loom-tools/tests/shepherd/test_cli.py
+++ b/loom-tools/tests/shepherd/test_cli.py
@@ -4393,6 +4393,38 @@ class TestPostFallbackFailureComment:
         assert "usage/plan limit" in body
 
     @patch("subprocess.run")
+    def test_abandonment_info_api_rate_limited(self, mock_run: MagicMock) -> None:
+        """When abandonment_info has api_rate_limited, posts pre-check rate-limit comment.
+
+        Covers the path where _is_rate_limited() fires before builder startup
+        (issue #2906).  The PhaseResult now carries data={"api_rate_limited": True}
+        which propagates into abandonment_info["failure_data"].
+        """
+        ctx = MagicMock()
+        ctx.config.issue = 42
+        ctx.config.task_id = "pqr1234"
+        ctx.repo_root = Path("/fake/repo")
+        ctx.abandonment_info = {
+            "phase": "builder",
+            "exit_code": 1,
+            "failure_data": {
+                "api_rate_limited": True,
+            },
+            "message": "API rate limit exceeded (threshold: 99%)",
+            "task_id": "pqr1234",
+        }
+
+        _post_fallback_failure_comment(ctx, ShepherdExitCode.BUILDER_FAILED)
+
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        body_idx = cmd.index("--body") + 1
+        body = cmd[body_idx]
+        assert "Shepherd abandoned issue" in body
+        assert "API rate limit pre-check" in body
+        assert "Retry after the rate limit resets" in body
+
+    @patch("subprocess.run")
     def test_abandonment_info_generic_failure(self, mock_run: MagicMock) -> None:
         """When abandonment_info has no specific flag, uses message as failure mode."""
         ctx = MagicMock()

--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -1328,6 +1328,34 @@ class TestBuilderPhase:
         assert mock_context.pr_number == 302
         mock_cleanup.assert_not_called()
 
+    def test_rate_limit_precheck_sets_api_rate_limited_flag(
+        self, mock_context: MagicMock
+    ) -> None:
+        """Pre-flight rate-limit check returns data with api_rate_limited=True.
+
+        When _is_rate_limited() fires before builder startup, the returned
+        PhaseResult must carry data={"api_rate_limited": True} so that the
+        orchestrator's abandonment_info records a recognisable flag and
+        _post_fallback_failure_comment generates a specific comment instead of
+        the generic "unexpected failure" fallback.  See issue #2906.
+        """
+        mock_context.check_shutdown.return_value = False
+        mock_context.config.rate_limit_threshold = 99
+
+        builder = BuilderPhase()
+
+        with (
+            patch(
+                "loom_tools.shepherd.phases.builder.get_pr_for_issue", return_value=None
+            ),
+            patch.object(builder, "_is_rate_limited", return_value=True),
+        ):
+            result = builder.run(mock_context)
+
+        assert result.status == PhaseStatus.FAILED
+        assert result.data.get("api_rate_limited") is True
+        assert "rate limit" in result.message.lower()
+
 
 class TestBuilderCountCommitsAheadOfMain:
     """Unit tests for BuilderPhase._count_commits_ahead_of_main."""


### PR DESCRIPTION
## Summary

When `BuilderPhase._is_rate_limited()` fires before the builder subprocess
starts, the returned `PhaseResult` had an empty `data` dict. This caused
`_post_fallback_failure_comment` to fall through to the generic
"unexpected failure" message instead of generating a specific rate-limit
diagnostic comment on the GitHub issue.

## Changes

- `builder.py`: Add `data={"api_rate_limited": True}` to the rate-limit pre-check `PhaseResult` so the flag propagates into `ctx.abandonment_info["failure_data"]`
- `cli.py`: Add `elif failure_data.get("api_rate_limited")` branch in `_post_fallback_failure_comment` to emit a specific "API rate limit pre-check" comment with retry advice
- `test_phases.py`: Add `test_rate_limit_precheck_sets_api_rate_limited_flag` to verify the builder phase sets the flag
- `test_cli.py`: Add `test_abandonment_info_api_rate_limited` to verify the comment generator produces the specific message

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Early-exit rate-limit path posts diagnostic comment | ✅ | `api_rate_limited` flag in PhaseResult.data propagates to abandonment_info and triggers specific comment |
| Comment is specific (not generic "unexpected failure") | ✅ | New `elif failure_data.get("api_rate_limited")` branch generates "API rate limit pre-check" message |
| Safe-to-retry advice is correct (retry after reset) | ✅ | `safe_to_retry = True`, advice says "Retry after the rate limit resets" |
| Existing failure mode paths unaffected | ✅ | All 185 existing test_cli.py tests pass |
| New flag tested at phase level | ✅ | `test_rate_limit_precheck_sets_api_rate_limited_flag` passes |

## Test Plan

```
PYTHONPATH=loom-tools/src:$PYTHONPATH python3 -m pytest \
  loom-tools/tests/shepherd/test_cli.py::TestPostFallbackFailureComment \
  loom-tools/tests/shepherd/test_phases.py::TestBuilderPhase \
  -v
```

All tests pass (25 builder phase, 10 fallback comment).

Closes #2906