### PR TITLE
fix: detect and auto-recover when feature branch is checked out in main worktree

### DIFF
--- a/loom-tools/uv.lock
+++ b/loom-tools/uv.lock
@@ -45,6 +45,9 @@ wheels = [
 name = "loom-tools"
 version = "0.1.0"
 source = { editable = "." }
+dependencies = [
+    { name = "rich" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -53,11 +56,33 @@ dev = [
 ]
 
 [package.metadata]
+requires-dist = [{ name = "rich", specifier = ">=13.0" }]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=9.0" },
     { name = "pytest-asyncio", specifier = ">=0.24" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -117,6 +142,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

When `git worktree add` fails with `fatal: 'feature/issue-N' is already used by worktree at '<path>'`, both `worktree.sh` and `worktree.py` now detect this specific error and attempt recovery rather than silently failing with a generic error message.

## Changes

- **`defaults/scripts/worktree.sh`**: Added `_handle_feature_branch_in_main_worktree()` helper and `_try_worktree_add()` wrapper that capture stderr separately, detect the conflict pattern, and either auto-recover (main workspace clean) or emit actionable guidance (dirty or non-main conflict)
- **`loom-tools/src/loom_tools/worktree.py`**: Added `_handle_feature_branch_in_main_worktree()` Python equivalent with the same logic, integrated into `create_worktree()` after failed `git worktree add`
- **`loom-tools/tests/test_worktree.py`**: Added `TestHandleFeatureBranchInMainWorktree` test class with 5 unit tests covering all code paths

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Detect "is already used by worktree at" error | Done | Pattern matched in both bash (`grep -q`) and Python (`in` string check) |
| Auto-recover when main worktree is clean | Done | `git -C <main-path> checkout main` then retry; tested via mock in Python |
| Emit clear actionable error when main has uncommitted changes | Done | Error message includes `git stash` and `git checkout main` instructions |
| Handle case where conflict is not in main worktree | Done | Emits `cd <conflict-path> && git checkout main` guidance |
| All tests pass | Done | 21/21 tests pass in `test_worktree.py` |

## Test Plan

- Ran `python3 -m pytest loom-tools/tests/test_worktree.py -v` — 21 tests passed
- Ran `bash -n .loom/scripts/worktree.sh` — syntax check passed
- Pre-existing test failure (`test_exit_code_11_returns_failed_with_degraded_flag`) confirmed on main branch, unrelated to this change

Closes #2924