### PR TITLE
fix: classify worktree branch-conflict as infrastructure failure

### DIFF
--- a/loom-tools/src/loom_tools/common/issue_failures.py
+++ b/loom-tools/src/loom_tools/common/issue_failures.py
@@ -48,13 +48,14 @@ ERROR_CLASS_BLOCK_THRESHOLDS: dict[str, int] = {
 }
 
 # Infrastructure error classes that should NOT count toward auto-blocking.
-# These represent environment/platform failures (MCP server down, auth timeout),
-# not problems with the issue itself.  Blocking an issue for infrastructure
-# failures is counterproductive — the issue would succeed once infrastructure
-# recovers.  See issue #2772.
+# These represent environment/platform failures (MCP server down, auth timeout,
+# worktree branch conflicts), not problems with the issue itself.  Blocking an
+# issue for infrastructure failures is counterproductive — the issue would
+# succeed once infrastructure recovers.  See issue #2772, #2918.
 INFRASTRUCTURE_ERROR_CLASSES: frozenset[str] = frozenset({
     "auth_infrastructure_failure",
     "mcp_infrastructure_failure",
+    "worktree_conflict",
 })
 
 # Backoff schedule: attempt -> iterations to skip

--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -435,11 +435,20 @@ class BuilderPhase:
                 msg = "failed to create worktree"
                 if detail:
                     msg = f"{msg}: {detail}"
+                # Detect worktree branch conflicts: when the branch is already
+                # checked out in another worktree git raises a "already used by
+                # worktree" fatal error.  This is an infrastructure failure
+                # (git state, not issue quality) and must NOT count toward the
+                # systematic failure counter.  See issue #2918.
+                is_conflict = "already used by worktree" in detail
                 return PhaseResult(
                     status=PhaseStatus.FAILED,
                     message=msg,
                     phase_name="builder",
-                    data={"error_detail": detail},
+                    data={
+                        "error_detail": detail,
+                        "worktree_conflict": is_conflict,
+                    },
                 )
 
         # Create marker to prevent premature cleanup


### PR DESCRIPTION
## Summary

When `worktree.sh` fails because the feature branch is already checked out in another worktree, the shepherd was incorrectly classifying this infrastructure failure as `builder_unknown_failure`, which incremented the systematic failure counter. After 3 such failures, the issue was moved to `loom:blocked`.

## Changes

- **builder.py**: Detects "already used by worktree" in the `CalledProcessError` output from `worktree.sh` and sets `worktree_conflict=True` in the `PhaseResult.data` dict
- **cli.py**: Routes the `worktree_conflict` data flag to `SYSTEMIC_FAILURE` exit code; updates `_record_fallback_failure` to emit the distinct `worktree_conflict` error class (not `auth_infrastructure_failure`); adds actionable recovery guidance (`loom-clean --force` / `git worktree prune`) in the GitHub comment posted on failure
- **issue_failures.py**: Adds `worktree_conflict` to `INFRASTRUCTURE_ERROR_CLASSES` so it is excluded from systematic failure detection and never triggers auto-blocking
- **tests**: 5 new tests covering the detection, error class emission, and systematic failure exclusion

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Worktree conflict does not increment systematic failure counter | ✅ | `worktree_conflict` added to `INFRASTRUCTURE_ERROR_CLASSES`; verified by `test_worktree_conflict_not_counted` |
| Distinct `worktree_conflict` error class emitted | ✅ | `_record_fallback_failure` uses `worktree_conflict` class when `abandonment_info` has `worktree_conflict=True`; verified by `test_records_worktree_conflict_class` |
| Actionable recovery guidance in GitHub comment | ✅ | `_post_fallback_failure_comment` now includes `loom-clean --force` / `git worktree prune` advice for `worktree_conflict` failures |
| Existing auth/API infrastructure failures unaffected | ✅ | `isinstance(dict)` guard prevents MagicMock false-positives; verified by `test_records_auth_failure_class` still passing |

## Test Plan

- Ran `test_systematic_failure.py`, `test_issue_failures.py`, and `test_cli.py::TestRecordFallbackFailure`: 88 passed
- Ran full suite: 3598 passed, 16 pre-existing failures in unrelated doctor tests (reproducible on main)

Closes #2918