### PR TITLE
fix: exempt force-mode failures from systematic failure detection

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/cli.py
+++ b/loom-tools/src/loom_tools/shepherd/cli.py
@@ -1454,6 +1454,7 @@ def _mark_builder_test_failure(ctx: ShepherdContext) -> None:
         error_class="builder_test_failure",
         phase="builder",
         details="Builder test verification failed",
+        force_mode=ctx.config.is_force_mode,
     )
     detect_systematic_failure(ctx.repo_root)
 
@@ -1534,6 +1535,7 @@ def _mark_doctor_exhausted(
         error_class=error_class,
         phase="doctor",
         details=details,
+        force_mode=ctx.config.is_force_mode,
     )
     detect_systematic_failure(ctx.repo_root)
 
@@ -1620,6 +1622,7 @@ def _mark_judge_exhausted(ctx: ShepherdContext, retries: int) -> None:
         error_class="judge_exhausted",
         phase="judge",
         details=f"judge failed after {retries} retry attempt(s)",
+        force_mode=ctx.config.is_force_mode,
     )
     detect_systematic_failure(ctx.repo_root)
 
@@ -1842,6 +1845,7 @@ def _mark_builder_no_pr(ctx: ShepherdContext) -> None:
         error_class="builder_no_pr",
         phase="builder",
         details="Builder phase completed but no PR was created",
+        force_mode=ctx.config.is_force_mode,
     )
     detect_systematic_failure(ctx.repo_root)
 
@@ -1994,6 +1998,7 @@ def _mark_baseline_blocked(ctx: ShepherdContext, result: "PhaseResult") -> None:
         error_class="baseline_failing",
         phase="preflight",
         details=result.message,
+        force_mode=ctx.config.is_force_mode,
     )
     detect_systematic_failure(ctx.repo_root)
 
@@ -2400,6 +2405,7 @@ def _record_fallback_failure(ctx: ShepherdContext, exit_code: int) -> None:
             error_class=error_class,
             phase="builder",
             details=details,
+            force_mode=ctx.config.is_force_mode,
         )
         sf = detect_systematic_failure(ctx.repo_root)
 

--- a/loom-tools/tests/shepherd/test_cli.py
+++ b/loom-tools/tests/shepherd/test_cli.py
@@ -7,7 +7,7 @@ import sys
 import time
 from io import StringIO
 from pathlib import Path
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import ANY, MagicMock, call, patch
 
 import pytest
 
@@ -2113,6 +2113,7 @@ class TestMarkJudgeExhausted:
             error_class="judge_exhausted",
             phase="judge",
             details="judge failed after 2 retry attempt(s)",
+            force_mode=ANY,
         )
 
     @patch("subprocess.run")
@@ -2205,6 +2206,7 @@ class TestMarkBuilderNoPr:
             error_class="builder_no_pr",
             phase="builder",
             details="Builder phase completed but no PR was created",
+            force_mode=ANY,
         )
 
     @patch("loom_tools.shepherd.cli._gather_no_pr_diagnostics")
@@ -4443,6 +4445,7 @@ class TestRecordFallbackFailure:
             error_class="auth_infrastructure_failure",
             phase="builder",
             details="Builder failed due to auth/API infrastructure issue (fallback cleanup)",
+            force_mode=ANY,
         )
         mock_detect.assert_called_once_with(Path("/fake/repo"))
 
@@ -4469,6 +4472,7 @@ class TestRecordFallbackFailure:
             error_class="builder_unknown_failure",
             phase="builder",
             details="Builder failed without specific handler (exit code 1, fallback cleanup)",
+            force_mode=ANY,
         )
         mock_detect.assert_called_once_with(Path("/fake/repo"))
 
@@ -4518,6 +4522,7 @@ class TestRecordFallbackFailure:
             error_class="builder_worktree_escape",
             phase="builder",
             details="Builder escaped worktree and modified main instead (fallback cleanup)",
+            force_mode=ANY,
         )
         mock_detect.assert_called_once_with(Path("/fake/repo"))
 
@@ -4548,6 +4553,7 @@ class TestRecordFallbackFailure:
             error_class="mcp_infrastructure_failure",
             phase="builder",
             details="Builder failed due to MCP server failure (exit code 1, fallback cleanup)",
+            force_mode=ANY,
         )
         mock_detect.assert_called_once_with(tmp_path)
 
@@ -4579,6 +4585,7 @@ class TestRecordFallbackFailure:
             error_class="builder_unknown_failure",
             phase="builder",
             details="Builder failed without specific handler (exit code 1, fallback cleanup)",
+            force_mode=ANY,
         )
 
     @patch("loom_tools.shepherd.cli.get_pr_for_issue", return_value=None)


### PR DESCRIPTION
## Summary

Running `/shepherd N -m` multiple times while debugging an issue rapidly exhausted the systematic failure budget (threshold=3), causing the issue to be re-blocked after just 3 force-mode invocations. Force-mode runs represent deliberate user retries and should not count against the failure budget.

## Changes

- Add `force_mode: bool = False` parameter to `record_blocked_reason` in `systematic_failure.py`
- Tag force-mode failure entries with `"force_mode": True` in `recent_failures`
- Filter force-mode entries (alongside infrastructure errors) in `detect_systematic_failure` and `clear_failures_for_issue`
- Pass `force_mode=ctx.config.is_force_mode` to all `record_blocked_reason` calls in `shepherd/cli.py`
- Update `test_cli.py` assertions to include `force_mode=ANY` for the new argument
- Add 7 new unit tests in `test_systematic_failure.py` covering the force-mode exemption

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Running `/shepherd N -m` 3 times does not trigger `loom:blocked` | ✅ | `test_force_mode_failures_not_counted`: 3 force-mode `record_blocked_reason` calls → `detect_systematic_failure` returns `None` |
| Systematic failure threshold still applies after force-mode grace | ✅ | `test_force_mode_followed_by_enough_normal_failures`: force-mode runs + 3 normal failures → detection fires |
| A unit test covers the force-mode exemption | ✅ | 7 new tests in `TestForceModeExemption` class |

## Test Plan

- All 41 tests in `test_systematic_failure.py` pass (7 new, 34 existing)
- All previously-passing tests in `test_cli.py` continue to pass
- Remaining 16 failures in `test_phases.py` / `test_degraded_session_detection.py` are pre-existing on `main` (verified by running on base branch without changes)

Closes #2897