### PR TITLE
refactor: remove unused _make_result helper from TestGetPrForIssue

### DIFF
--- a/loom-tools/tests/shepherd/test_labels.py
+++ b/loom-tools/tests/shepherd/test_labels.py
@@ -362,16 +362,6 @@ class TestAtomicLabelTransitions:
 class TestGetPrForIssue:
     """Tests for get_pr_for_issue using closingIssuesReferences validation."""
 
-    def _make_result(self, returncode: int = 0, stdout: str = "") -> object:
-        """Create a mock subprocess result."""
-        result = object.__new__(object)
-        result.__class__ = type(
-            "Result",
-            (),
-            {"returncode": returncode, "stdout": stdout},
-        )
-        return result
-
     def _mock_run(self, outputs: list[tuple[int, str]]):  # type: ignore[return]
         """Return a mock that yields (returncode, stdout) pairs in sequence."""
         from unittest.mock import MagicMock


### PR DESCRIPTION
## Summary
Removes the `_make_result` helper method from `TestGetPrForIssue` in `loom-tools/tests/shepherd/test_labels.py`. The method was never called by any test — all mock construction uses `_mock_run` with `MagicMock` internally. It was a leftover from an earlier implementation approach.

## Changes
- Deleted `_make_result` method (10 lines) from `TestGetPrForIssue`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `_make_result` removed from `TestGetPrForIssue` | ✅ | Grep confirms no occurrences remain |
| All tests still pass | ✅ | `python3 -m pytest tests/shepherd/test_labels.py` — 41 passed |

## Test Plan
Ran `python3 -m pytest tests/shepherd/test_labels.py -x -q` — all 41 tests pass.

Closes #3023