### PR TITLE
refactor: remove unused monkeypatch parameter from test_matching_error_conflict_not_main_workspace

### DIFF
--- a/loom-tools/tests/test_worktree.py
+++ b/loom-tools/tests/test_worktree.py
@@ -259,7 +259,6 @@ class TestHandleFeatureBranchInMainWorktree:
         self,
         tmp_path: pathlib.Path,
         capsys: pytest.CaptureFixture[str],
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Error where conflict is NOT in the main workspace gets handled with guidance."""
         conflict_path = tmp_path / "some-other-worktree"


### PR DESCRIPTION
## Summary
Removes an unused `monkeypatch: pytest.MonkeyPatch` parameter from `test_matching_error_conflict_not_main_workspace` in `loom-tools/tests/test_worktree.py`. The test uses `unittest.mock.patch()` context manager directly, making the pytest `monkeypatch` fixture injection unnecessary and misleading to readers.

## Changes
- Remove unused `monkeypatch: pytest.MonkeyPatch` parameter from `TestHandleFeatureBranchInMainWorktree::test_matching_error_conflict_not_main_workspace`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Unused `monkeypatch` parameter removed from function signature | ✅ | Parameter deleted from `test_matching_error_conflict_not_main_workspace` |
| Test still passes | ✅ | Ran test with `PYTHONPATH=loom-tools/src python3 -m pytest ...::test_matching_error_conflict_not_main_workspace -v` → PASSED |

## Test Plan
Ran the specific test and confirmed it passes after removing the parameter:
```
loom-tools/tests/test_worktree.py::TestHandleFeatureBranchInMainWorktree::test_matching_error_conflict_not_main_workspace PASSED
```

Closes #3026