### PR TITLE
refactor: move import re to top-level in worktree.py

### DIFF
--- a/loom-tools/src/loom_tools/worktree.py
+++ b/loom-tools/src/loom_tools/worktree.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import json
 import pathlib
+import re
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -356,8 +357,6 @@ def _handle_feature_branch_in_main_worktree(
 
     # Extract the conflicting worktree path from the error message.
     # Example: "fatal: 'feature/issue-2853' is already used by worktree at '/path'"
-    import re
-
     match = re.search(r"is already used by worktree at '([^']+)'", error_output)
     if not match:
         # Could not parse path — emit actionable guidance and fail.


### PR DESCRIPTION
## Summary
Moves `import re` from inside `_handle_feature_branch_in_main_worktree()` to the module-level import block in `worktree.py`, following standard Python conventions.

## Changes
- Added `import re` to the top-level import block (alphabetically between `pathlib` and `subprocess`)
- Removed the function-scoped `import re` statement from `_handle_feature_branch_in_main_worktree()`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `import re` moved to top-level import block | ✅ | Now at line 21, alphabetically ordered with other stdlib imports |
| No more function-scoped `import re` | ✅ | `grep "import re" worktree.py` shows only one occurrence at module level |
| Code still functions correctly | ✅ | 20/20 worktree tests pass (1 skipped due to environment: running inside a worktree) |
| Linter passes | ✅ | `ruff check` reports "All checks passed!" |

## Test Plan
- Ran `ruff check loom-tools/src/loom_tools/worktree.py` — no issues
- Ran `python3 -m pytest loom-tools/tests/test_worktree.py -k not test_cli_check_not_in_worktree` — 20 passed
- Confirmed only one `import re` at module level via grep

Closes #3025