### PR TITLE
feat: add tiered retry strategy with per-error-class cooldowns and backlog prune command

### DIFF
--- a/loom-tools/pyproject.toml
+++ b/loom-tools/pyproject.toml
@@ -40,6 +40,7 @@ loom-checkpoint = "loom_tools.checkpoints:main"
 loom-daemon = "loom_tools.daemon_v2.cli:main"
 loom-test-failure-analysis = "loom_tools.test_failure_analysis:main"
 loom-usage = "loom_tools.common.usage:main"
+loom-backlog = "loom_tools.backlog:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/loom-tools/src/loom_tools/backlog.py
+++ b/loom-tools/src/loom_tools/backlog.py
@@ -1,0 +1,300 @@
+"""Backlog management utilities for the Loom daemon.
+
+Provides tools for bulk-triaging blocked issues, applying the tiered retry
+policy retroactively, and escalating permanently-stuck issues to the human
+input queue.
+
+Usage::
+
+    loom-backlog prune [--dry-run] [--comment]   # triage blocked backlog
+    loom-backlog list                             # list blocked issues with policy info
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+from loom_tools.common.github import gh_run
+from loom_tools.common.logging import log_info, log_warning
+from loom_tools.common.repo import find_repo_root
+from loom_tools.common.state import read_daemon_state, write_json_file
+from loom_tools.common.time_utils import now_utc
+from loom_tools.models.daemon_state import BlockedIssueRetry
+from loom_tools.snapshot import get_retry_policy
+
+
+def _print_table(rows: list[dict], columns: list[str]) -> None:
+    """Print a simple ASCII table."""
+    if not rows:
+        return
+    widths = {col: len(col) for col in columns}
+    for row in rows:
+        for col in columns:
+            widths[col] = max(widths[col], len(str(row.get(col, ""))))
+
+    header = "  ".join(col.ljust(widths[col]) for col in columns)
+    separator = "  ".join("-" * widths[col] for col in columns)
+    print(header)
+    print(separator)
+    for row in rows:
+        print("  ".join(str(row.get(col, "")).ljust(widths[col]) for col in columns))
+
+
+def _build_entry_row(issue_key: str, entry: BlockedIssueRetry) -> dict:
+    """Build a display row for a blocked issue entry."""
+    policy = get_retry_policy(entry.error_class)
+    retries_left = max(0, policy.max_retries - entry.retry_count)
+    cooldown_h = policy.cooldown // 3600
+    cooldown_str = f"{cooldown_h}h" if cooldown_h > 0 else (f"{policy.cooldown // 60}m" if policy.cooldown > 0 else "0")
+    status = "escalated" if entry.escalated_to_human else (
+        "exhausted" if (entry.retry_exhausted or entry.retry_count >= policy.max_retries) else "retryable"
+    )
+    return {
+        "issue": f"#{issue_key}",
+        "error_class": entry.error_class,
+        "retry_count": entry.retry_count,
+        "max_retries": policy.max_retries,
+        "retries_left": retries_left,
+        "cooldown": cooldown_str,
+        "escalate": "yes" if policy.escalate else "no",
+        "status": status,
+    }
+
+
+def cmd_list(repo_root: Path) -> int:
+    """List all blocked issues with their tiered retry policy info."""
+    loom_dir = repo_root / ".loom"
+    state_file = loom_dir / "daemon-state.json"
+
+    if not state_file.exists():
+        print("No daemon-state.json found.")
+        return 1
+
+    state = read_daemon_state(repo_root)
+    retries = state.blocked_issue_retries
+
+    if not retries:
+        print("No blocked issues in daemon state.")
+        return 0
+
+    rows = []
+    for issue_key, entry in sorted(retries.items(), key=lambda x: int(x[0])):
+        rows.append(_build_entry_row(issue_key, entry))
+
+    # Summary stats
+    total = len(rows)
+    escalated = sum(1 for r in rows if r["status"] == "escalated")
+    exhausted = sum(1 for r in rows if r["status"] == "exhausted")
+    retryable = sum(1 for r in rows if r["status"] == "retryable")
+
+    print(f"Blocked issues: {total} total  ({retryable} retryable, {exhausted} exhausted, {escalated} escalated)")
+    print()
+
+    columns = ["issue", "error_class", "retry_count", "max_retries", "cooldown", "escalate", "status"]
+    _print_table(rows, columns)
+    return 0
+
+
+def cmd_prune(
+    repo_root: Path,
+    *,
+    dry_run: bool = False,
+    add_comment: bool = False,
+) -> int:
+    """Apply tiered retry policy retroactively to all blocked issues.
+
+    Issues that have exceeded their per-class retry budget will be:
+    - Marked ``escalated_to_human=True`` in daemon state
+    - Added to ``needs_human_input``
+    - Optionally commented on GitHub (with ``--comment``)
+
+    Pass ``--dry-run`` to preview changes without modifying daemon state.
+    """
+    loom_dir = repo_root / ".loom"
+    state_file = loom_dir / "daemon-state.json"
+
+    if not state_file.exists():
+        print("No daemon-state.json found.")
+        return 1
+
+    state = read_daemon_state(repo_root)
+    retries = state.blocked_issue_retries
+
+    if not retries:
+        print("No blocked issues in daemon state.")
+        return 0
+
+    timestamp = now_utc().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # Categorise issues by action needed
+    to_escalate: list[tuple[str, BlockedIssueRetry, str]] = []  # (key, entry, reason)
+    already_escalated: list[str] = []
+    still_retryable: list[str] = []
+    transient_exhausted: list[str] = []
+
+    for issue_key, entry in sorted(retries.items(), key=lambda x: int(x[0])):
+        policy = get_retry_policy(entry.error_class)
+
+        if entry.escalated_to_human:
+            already_escalated.append(issue_key)
+            continue
+
+        exhausted = entry.retry_exhausted or entry.retry_count >= policy.max_retries
+        if exhausted:
+            if policy.escalate:
+                reason = (
+                    f"Exceeded {policy.max_retries} retries for {entry.error_class}"
+                    if policy.max_retries > 0
+                    else f"Error class {entry.error_class} requires immediate human review"
+                )
+                to_escalate.append((issue_key, entry, reason))
+            else:
+                transient_exhausted.append(issue_key)
+        else:
+            still_retryable.append(issue_key)
+
+    # Print summary
+    print(f"Backlog prune summary ({timestamp}):")
+    print(f"  Total blocked issues:     {len(retries)}")
+    print(f"  Already escalated:        {len(already_escalated)}")
+    print(f"  To escalate (this run):   {len(to_escalate)}")
+    print(f"  Transient exhausted:      {len(transient_exhausted)} (no escalation, error class non-critical)")
+    print(f"  Still retryable:          {len(still_retryable)}")
+    print()
+
+    if not to_escalate:
+        print("Nothing to escalate.")
+        return 0
+
+    print("Issues to escalate:")
+    for issue_key, entry, reason in to_escalate:
+        print(f"  #{issue_key}  {entry.error_class} (retry_count={entry.retry_count})  {reason}")
+
+    if dry_run:
+        print("\n[dry-run] No changes made.")
+        return 0
+
+    print()
+
+    # Apply escalations
+    escalated_count = 0
+    for issue_key, entry, reason in to_escalate:
+        issue_num = int(issue_key)
+
+        # Mark escalated in state
+        entry.escalated_to_human = True
+
+        # Add to needs_human_input
+        human_entry = {
+            "type": "exhausted_retry",
+            "issue": issue_num,
+            "error_class": entry.error_class,
+            "retry_count": entry.retry_count,
+            "reason": reason,
+            "escalated_at": timestamp,
+        }
+        already_present = any(
+            e.get("type") == "exhausted_retry" and e.get("issue") == issue_num
+            for e in state.needs_human_input
+        )
+        if not already_present:
+            state.needs_human_input.append(human_entry)
+
+        # Optionally add GitHub comment
+        if add_comment:
+            comment = (
+                f"**Blocked Issue: Human Review Required (backlog prune)**\n\n"
+                f"This issue has exceeded its automatic retry budget and was identified "
+                f"during a backlog triage run.\n\n"
+                f"**Error class**: `{entry.error_class}`\n"
+                f"**Retry attempts**: {entry.retry_count}\n"
+                f"**Reason**: {reason}\n\n"
+                f"Please review this issue and either:\n"
+                f"- Fix the underlying problem and remove the `loom:blocked` label to re-queue it, or\n"
+                f"- Close the issue if it is no longer valid\n\n"
+                f"---\n"
+                f"*Escalated by `loom-backlog prune` at {timestamp}*"
+            )
+            try:
+                gh_run(
+                    ["issue", "comment", str(issue_num), "--body", comment],
+                    check=False,
+                )
+                log_info(f"Commented on issue #{issue_num}")
+            except Exception:
+                log_warning(f"Failed to comment on issue #{issue_num}")
+
+        escalated_count += 1
+
+    # Save updated state
+    write_json_file(state_file, state.to_dict())
+
+    print(f"Escalated {escalated_count} issue(s) to needs_human_input in daemon state.")
+    if add_comment:
+        print("GitHub comments added.")
+    else:
+        print("(Use --comment to also post GitHub comments.)")
+
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point for the loom-backlog command."""
+    parser = argparse.ArgumentParser(
+        prog="loom-backlog",
+        description="Backlog management for the Loom daemon",
+    )
+    subparsers = parser.add_subparsers(dest="command", help="Subcommand")
+
+    # list subcommand
+    subparsers.add_parser(
+        "list",
+        help="List blocked issues with tiered retry policy info",
+    )
+
+    # prune subcommand
+    prune_parser = subparsers.add_parser(
+        "prune",
+        help=(
+            "Apply tiered retry policy retroactively; escalate exhausted issues "
+            "to the human input queue"
+        ),
+    )
+    prune_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview changes without modifying daemon state",
+    )
+    prune_parser.add_argument(
+        "--comment",
+        action="store_true",
+        help="Also post GitHub comments on escalated issues",
+    )
+
+    args = parser.parse_args(argv)
+
+    if not args.command:
+        parser.print_help()
+        return 1
+
+    try:
+        repo_root = find_repo_root()
+    except FileNotFoundError:
+        print("Error: not in a git repository with .loom directory", file=sys.stderr)
+        return 1
+
+    if args.command == "list":
+        return cmd_list(repo_root)
+    elif args.command == "prune":
+        return cmd_prune(repo_root, dry_run=args.dry_run, add_comment=args.comment)
+    else:
+        parser.print_help()
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/loom-tools/src/loom_tools/models/daemon_state.py
+++ b/loom-tools/src/loom_tools/models/daemon_state.py
@@ -234,6 +234,9 @@ class BlockedIssueRetry:
     last_blocked_at: str | None = None
     last_blocked_phase: str = ""
     last_blocked_details: str = ""
+    # Set to True after the issue has been added to needs_human_input once,
+    # to prevent duplicate escalation comments on subsequent iterations.
+    escalated_to_human: bool = False
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> BlockedIssueRetry:
@@ -245,6 +248,7 @@ class BlockedIssueRetry:
             last_blocked_at=data.get("last_blocked_at"),
             last_blocked_phase=data.get("last_blocked_phase", ""),
             last_blocked_details=data.get("last_blocked_details", ""),
+            escalated_to_human=data.get("escalated_to_human", False),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -259,6 +263,8 @@ class BlockedIssueRetry:
             d["last_retry_at"] = self.last_retry_at
         if self.last_blocked_at is not None:
             d["last_blocked_at"] = self.last_blocked_at
+        if self.escalated_to_human:
+            d["escalated_to_human"] = True
         return d
 
 

--- a/loom-tools/tests/test_backlog.py
+++ b/loom-tools/tests/test_backlog.py
@@ -1,0 +1,216 @@
+"""Tests for the loom-backlog command."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+from unittest import mock
+
+import pytest
+
+from loom_tools.backlog import cmd_list, cmd_prune, main
+from loom_tools.models.daemon_state import BlockedIssueRetry, DaemonState
+
+
+def _write_state(loom_dir: pathlib.Path, blocked_retries: dict) -> None:
+    """Write a minimal daemon-state.json with the given blocked_issue_retries."""
+    state = {
+        "running": False,
+        "blocked_issue_retries": blocked_retries,
+        "needs_human_input": [],
+    }
+    loom_dir.mkdir(parents=True, exist_ok=True)
+    (loom_dir / "daemon-state.json").write_text(json.dumps(state))
+
+
+class TestCmdList:
+    def test_no_state_file(self, tmp_path: pathlib.Path, capsys) -> None:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        (repo / ".loom").mkdir()
+
+        with mock.patch("loom_tools.backlog.find_repo_root", return_value=repo):
+            result = cmd_list(repo)
+
+        assert result == 1
+
+    def test_empty_retries(self, tmp_path: pathlib.Path, capsys) -> None:
+        loom_dir = tmp_path / ".loom"
+        _write_state(loom_dir, {})
+
+        result = cmd_list(tmp_path)
+        out = capsys.readouterr().out
+        assert result == 0
+        assert "No blocked issues" in out
+
+    def test_lists_blocked_issues(self, tmp_path: pathlib.Path, capsys) -> None:
+        loom_dir = tmp_path / ".loom"
+        _write_state(loom_dir, {
+            "42": {
+                "retry_count": 2,
+                "error_class": "builder_test_failure",
+                "retry_exhausted": False,
+                "last_blocked_phase": "builder",
+                "last_blocked_details": "",
+            },
+            "99": {
+                "retry_count": 1,
+                "error_class": "mcp_infrastructure_failure",
+                "retry_exhausted": False,
+                "last_blocked_phase": "builder",
+                "last_blocked_details": "",
+            },
+        })
+
+        result = cmd_list(tmp_path)
+        out = capsys.readouterr().out
+        assert result == 0
+        assert "#42" in out
+        assert "#99" in out
+        assert "builder_test_failure" in out
+        assert "mcp_infrastructure_failure" in out
+
+
+class TestCmdPrune:
+    def test_dry_run_makes_no_changes(self, tmp_path: pathlib.Path, capsys) -> None:
+        loom_dir = tmp_path / ".loom"
+        _write_state(loom_dir, {
+            "42": {
+                "retry_count": 2,
+                "error_class": "builder_test_failure",
+                "retry_exhausted": False,
+                "escalated_to_human": False,
+                "last_blocked_phase": "builder",
+                "last_blocked_details": "",
+            },
+        })
+
+        result = cmd_prune(tmp_path, dry_run=True, add_comment=False)
+        out = capsys.readouterr().out
+        assert result == 0
+        assert "dry-run" in out
+
+        # State should be unchanged
+        state = json.loads((loom_dir / "daemon-state.json").read_text())
+        entry = state["blocked_issue_retries"]["42"]
+        assert entry.get("escalated_to_human", False) is False
+
+    def test_prune_escalates_exhausted_issue(self, tmp_path: pathlib.Path, capsys) -> None:
+        loom_dir = tmp_path / ".loom"
+        _write_state(loom_dir, {
+            "42": {
+                "retry_count": 2,
+                "error_class": "builder_test_failure",
+                "retry_exhausted": False,
+                "escalated_to_human": False,
+                "last_blocked_phase": "builder",
+                "last_blocked_details": "",
+            },
+        })
+
+        result = cmd_prune(tmp_path, dry_run=False, add_comment=False)
+        assert result == 0
+
+        state = json.loads((loom_dir / "daemon-state.json").read_text())
+        entry = state["blocked_issue_retries"]["42"]
+        assert entry.get("escalated_to_human") is True
+        assert len(state["needs_human_input"]) == 1
+        assert state["needs_human_input"][0]["issue"] == 42
+
+    def test_prune_skips_already_escalated(self, tmp_path: pathlib.Path, capsys) -> None:
+        loom_dir = tmp_path / ".loom"
+        _write_state(loom_dir, {
+            "42": {
+                "retry_count": 2,
+                "error_class": "builder_test_failure",
+                "retry_exhausted": False,
+                "escalated_to_human": True,  # already escalated
+                "last_blocked_phase": "builder",
+                "last_blocked_details": "",
+            },
+        })
+
+        result = cmd_prune(tmp_path, dry_run=False, add_comment=False)
+        out = capsys.readouterr().out
+        assert result == 0
+        assert "Nothing to escalate" in out
+
+    def test_prune_does_not_escalate_transient_errors(self, tmp_path: pathlib.Path, capsys) -> None:
+        """mcp_infrastructure_failure exhausted but escalate=False → no escalation."""
+        loom_dir = tmp_path / ".loom"
+        _write_state(loom_dir, {
+            "200": {
+                "retry_count": 5,
+                "error_class": "mcp_infrastructure_failure",
+                "retry_exhausted": False,
+                "escalated_to_human": False,
+                "last_blocked_phase": "builder",
+                "last_blocked_details": "",
+            },
+        })
+
+        result = cmd_prune(tmp_path, dry_run=False, add_comment=False)
+        out = capsys.readouterr().out
+        assert result == 0
+        assert "Nothing to escalate" in out
+
+        state = json.loads((loom_dir / "daemon-state.json").read_text())
+        assert len(state["needs_human_input"]) == 0
+
+    @mock.patch("loom_tools.backlog.gh_run")
+    def test_prune_with_comment(
+        self, mock_gh: mock.MagicMock, tmp_path: pathlib.Path, capsys
+    ) -> None:
+        loom_dir = tmp_path / ".loom"
+        _write_state(loom_dir, {
+            "42": {
+                "retry_count": 3,
+                "error_class": "builder_unknown_failure",
+                "retry_exhausted": False,
+                "escalated_to_human": False,
+                "last_blocked_phase": "builder",
+                "last_blocked_details": "",
+            },
+        })
+        mock_gh.return_value = mock.MagicMock(returncode=0)
+
+        result = cmd_prune(tmp_path, dry_run=False, add_comment=True)
+        assert result == 0
+
+        # Verify gh comment was called
+        mock_gh.assert_called_once()
+        call_args = mock_gh.call_args[0][0]
+        assert "comment" in call_args
+        assert "42" in call_args
+
+    def test_doctor_exhausted_immediate_escalation(self, tmp_path: pathlib.Path, capsys) -> None:
+        """doctor_exhausted with 0 retries is immediately escalated."""
+        loom_dir = tmp_path / ".loom"
+        _write_state(loom_dir, {
+            "300": {
+                "retry_count": 0,
+                "error_class": "doctor_exhausted",
+                "retry_exhausted": False,
+                "escalated_to_human": False,
+                "last_blocked_phase": "doctor",
+                "last_blocked_details": "",
+            },
+        })
+
+        result = cmd_prune(tmp_path, dry_run=False, add_comment=False)
+        assert result == 0
+
+        state = json.loads((loom_dir / "daemon-state.json").read_text())
+        assert state["blocked_issue_retries"]["300"].get("escalated_to_human") is True
+        assert len(state["needs_human_input"]) == 1
+
+
+class TestMain:
+    def test_no_subcommand_returns_1(self) -> None:
+        result = main([])
+        assert result == 1
+
+    def test_unknown_subcommand_raises_system_exit(self) -> None:
+        with pytest.raises(SystemExit):
+            main(["unknown"])


### PR DESCRIPTION
## Summary

Implements a tiered retry strategy for blocked issues that differentiates between transient failures (short cooldown, more retries) and structural failures (long cooldown, fewer retries, then human escalation). Replaces the previous single global retry policy that was burning shepherd capacity by re-attempting all 150 blocked issues indiscriminately.

## Changes

- **`snapshot.py`**: Add `RetryPolicy` dataclass and `_ERROR_CLASS_POLICIES` table with per-class settings. Update `compute_pipeline_health` to use per-class policies; add `escalation_needed` field for exhausted issues that need human review.
- **`daemon_v2/actions/retry_blocked.py`**: Add `escalate_blocked_issues` function that posts GitHub comments and marks issues as `escalated_to_human=True` to prevent duplicate escalations.
- **`daemon_v2/iteration.py`**: Integrate escalation into the daemon loop; persist escalated issues across iterations via `blocked_issue_retries`.
- **`models/daemon_state.py`**: Add `escalated_to_human` field to `BlockedIssueRetry` model.
- **`backlog.py`** (new): `loom-backlog list` shows all blocked issues with policy info; `loom-backlog prune [--dry-run] [--comment]` bulk-escalates exhausted issues.
- **`pyproject.toml`**: Register `loom-backlog` script entry point.
- **Tests**: 191 tests covering tiered policies, escalation, backlog prune/list commands.

**Tiered retry table:**

| Error Class | Cooldown | Max Retries | Escalate |
|-------------|----------|-------------|---------|
| `mcp_infrastructure_failure`, `shepherd_failure` | 30min | 5 | No |
| `builder_unknown_failure`, `builder_no_pr` | 2h | 3 | Yes |
| `builder_test_failure`, `judge_exhausted` | 6h | 2 | Yes |
| `doctor_exhausted`, `doctor_no_progress` | 0 | 0 | Yes (immediate) |
| unknown | global config | global config | Yes |

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Tiered retry by error class (short/medium/long cooldown) | Done | `_ERROR_CLASS_POLICIES` in snapshot.py with per-class `RetryPolicy` |
| No exponential backoff for known error classes | Done | `compute_pipeline_health` uses fixed cooldown for known classes |
| Human escalation queue (`needs_human_input[]`) | Done | `escalate_blocked_issues` populates daemon state + `escalated_to_human` prevents duplicates |
| `loom-backlog prune` command | Done | `backlog.py` with `--dry-run` and `--comment` options |
| `loom-backlog list` command | Done | Shows policy info, retry counts, status per blocked issue |
| Tests | Done | 191 tests pass across all new files |

## Test Plan

- `python3 -m pytest loom-tools/tests/test_retry_blocked.py loom-tools/tests/test_snapshot.py loom-tools/tests/test_backlog.py` — 191 pass
- Pre-existing test failures (`test_recovery_stats.py`, `test_phases.py`) are unrelated to this change and existed before this PR

Closes #3041