### PR TITLE
perf: reduce daemon poll interval from 120s to 30s and add fast-path assignment

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -10,7 +10,7 @@ Detailed configuration and state management for the Loom daemon (Layer 2).
 | `MAX_PROPOSALS` | 5 | Maximum pending proposal issues |
 | `MAX_SHEPHERDS` | 10 | Maximum concurrent shepherd processes |
 | `ISSUES_PER_SHEPHERD` | 2 | Scale factor: target = ready_issues / ISSUES_PER_SHEPHERD |
-| `POLL_INTERVAL` | 60 | Seconds between daemon loop iterations |
+| `POLL_INTERVAL` | 30 | Seconds between full daemon loop iterations |
 | `ISSUE_STRATEGY` | fifo | Issue selection strategy (see below) |
 | `ARCHITECT_COOLDOWN` | 1800 | Seconds between Architect role triggers (30 min) |
 | `HERMIT_COOLDOWN` | 1800 | Seconds between Hermit role triggers (30 min) |

--- a/defaults/.claude/commands/loom.md
+++ b/defaults/.claude/commands/loom.md
@@ -120,7 +120,7 @@ Write JSON files named `cmd-{YYYYMMDD-HHMMSS}-{random}.json` to `.loom/signals/`
 3. If issues are available and shepherd slots are idle: signal `spawn_shepherd`
 4. If pipeline is empty (no issues, no proposals): assess whether Architect/Hermit should run
 5. Monitor for blocked issues, stuck shepherds, or unmerged approved PRs
-6. Sleep 60–120 seconds, then repeat
+6. Sleep 30 seconds (checks signals and ready-issue assignment every 2 seconds), then repeat
 
 **Force/merge mode** (`/loom --merge` or `/loom --force`):
 - Same as normal, but pass `"mode": "force"` in all `spawn_shepherd` signals
@@ -415,7 +415,7 @@ This avoids nested Claude Code spawning restrictions.
 3. Checks for completed shepherds
 4. Spawns new shepherds for ready `loom:issue` issues
 5. Triggers Architect/Hermit when backlog is low
-6. Sleeps until next iteration (default: 120 seconds, checks signals every 2 seconds)
+6. Sleeps until next iteration (default: 30 seconds, checks signals and assigns ready issues every 2 seconds)
 
 **Stopping the daemon:**
 ```bash
@@ -428,7 +428,7 @@ touch .loom/stop-daemon                          # Via file signal
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `LOOM_POLL_INTERVAL` | 120 | Seconds between iterations |
+| `LOOM_POLL_INTERVAL` | 30 | Seconds between full iterations |
 | `LOOM_MAX_SHEPHERDS` | 10 | Max concurrent shepherds |
 | `LOOM_ISSUE_THRESHOLD` | 3 | Trigger work generation below this count |
 | `LOOM_ARCHITECT_COOLDOWN` | 1800 | Seconds between architect triggers |

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -615,7 +615,7 @@ The Loom daemon uses these configuration parameters:
 | `MAX_PROPOSALS` | 5 | Maximum pending proposal issues |
 | `MAX_SHEPHERDS` | 10 | Maximum concurrent shepherd processes |
 | `ISSUES_PER_SHEPHERD` | 2 | Scale factor: target = ready_issues / ISSUES_PER_SHEPHERD |
-| `POLL_INTERVAL` | 60 | Seconds between daemon loop iterations |
+| `POLL_INTERVAL` | 30 | Seconds between full daemon loop iterations |
 | `ISSUE_STRATEGY` | fifo | Issue selection strategy (see below) |
 | `SHELL_SHEPHERDS` | false | Use shell-based shepherds instead of LLM-based |
 

--- a/loom-tools/src/loom_tools/daemon_v2/config.py
+++ b/loom-tools/src/loom_tools/daemon_v2/config.py
@@ -9,7 +9,7 @@ from loom_tools.common.config import env_bool, env_int
 
 
 # Configuration defaults (same as existing daemon.py and snapshot.py)
-DEFAULT_POLL_INTERVAL = 120  # seconds
+DEFAULT_POLL_INTERVAL = 30  # seconds
 DEFAULT_ITERATION_TIMEOUT = 300  # seconds
 DEFAULT_MAX_SHEPHERDS = 10
 DEFAULT_ISSUE_THRESHOLD = 3

--- a/loom-tools/tests/daemon_v2/test_config.py
+++ b/loom-tools/tests/daemon_v2/test_config.py
@@ -14,7 +14,7 @@ class TestDaemonConfig:
     def test_default_values(self):
         """Test that defaults are sensible."""
         config = DaemonConfig()
-        assert config.poll_interval == 120
+        assert config.poll_interval == 30
         assert config.max_shepherds == 10
         assert config.issue_threshold == 3
         assert config.force_mode is False
@@ -24,7 +24,7 @@ class TestDaemonConfig:
         """Test loading from environment with defaults."""
         with patch.dict(os.environ, {}, clear=True):
             config = DaemonConfig.from_env()
-            assert config.poll_interval == 120
+            assert config.poll_interval == 30
             assert config.max_shepherds == 10
 
     def test_from_env_with_overrides(self):

--- a/loom-tools/tests/daemon_v2/test_fast_path_assign.py
+++ b/loom-tools/tests/daemon_v2/test_fast_path_assign.py
@@ -1,0 +1,171 @@
+"""Tests for fast-path shepherd assignment during sleep ticks.
+
+The fast-path assigns ready issues to idle shepherd slots during responsive-sleep
+ticks without waiting for the next full iteration. This reduces shepherd idle time
+from up to poll_interval seconds to at most tick seconds (default 2s).
+"""
+
+from __future__ import annotations
+
+import pathlib
+from unittest import mock
+
+import pytest
+
+from loom_tools.daemon_v2.config import DaemonConfig
+from loom_tools.daemon_v2.context import DaemonContext
+from loom_tools.daemon_v2.loop import _fast_path_assign
+from loom_tools.models.daemon_state import DaemonState, ShepherdEntry
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ctx(
+    tmp_path: pathlib.Path,
+    *,
+    max_shepherds: int = 3,
+) -> DaemonContext:
+    """Return a DaemonContext with minimal state for unit tests."""
+    config = DaemonConfig(max_shepherds=max_shepherds)
+    ctx = DaemonContext(config=config, repo_root=tmp_path)
+    ctx.state = DaemonState()
+    return ctx
+
+
+def _snapshot_with_ready_issues(issue_numbers: list[int]) -> dict:
+    """Build a minimal snapshot dict with the given ready issues."""
+    ready_issues = [{"number": n, "title": f"Issue #{n}"} for n in issue_numbers]
+    return {
+        "pipeline": {"ready_issues": ready_issues},
+        "computed": {
+            "available_shepherd_slots": len(ready_issues),
+            "total_ready": len(ready_issues),
+            "recommended_actions": ["spawn_shepherds"] if ready_issues else [],
+        },
+    }
+
+
+def _snapshot_empty() -> dict:
+    """Build a minimal snapshot with no ready issues."""
+    return {
+        "pipeline": {"ready_issues": []},
+        "computed": {
+            "available_shepherd_slots": 0,
+            "total_ready": 0,
+            "recommended_actions": [],
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests: fast-path no-ops
+# ---------------------------------------------------------------------------
+
+
+class TestFastPathAssignNoOps:
+    """_fast_path_assign should be a no-op when conditions are not met."""
+
+    def test_noop_when_no_state(self, tmp_path: pathlib.Path) -> None:
+        """No state — must not raise, must not spawn."""
+        ctx = _make_ctx(tmp_path)
+        ctx.state = None
+        ctx.snapshot = _snapshot_with_ready_issues([42])
+
+        with mock.patch("loom_tools.daemon_v2.loop.spawn_shepherds") as mock_spawn:
+            _fast_path_assign(ctx)
+            mock_spawn.assert_not_called()
+
+    def test_noop_when_no_snapshot(self, tmp_path: pathlib.Path) -> None:
+        """No snapshot — must not raise, must not spawn."""
+        ctx = _make_ctx(tmp_path)
+        ctx.snapshot = None
+
+        with mock.patch("loom_tools.daemon_v2.loop.spawn_shepherds") as mock_spawn:
+            _fast_path_assign(ctx)
+            mock_spawn.assert_not_called()
+
+    def test_noop_when_no_ready_issues_in_snapshot(self, tmp_path: pathlib.Path) -> None:
+        """Empty ready issues list — no spawn should occur."""
+        ctx = _make_ctx(tmp_path)
+        ctx.snapshot = _snapshot_empty()
+
+        with mock.patch("loom_tools.daemon_v2.loop.spawn_shepherds") as mock_spawn:
+            _fast_path_assign(ctx)
+            mock_spawn.assert_not_called()
+
+    def test_noop_when_all_slots_working(self, tmp_path: pathlib.Path) -> None:
+        """All shepherd slots occupied — no spawn should occur."""
+        ctx = _make_ctx(tmp_path, max_shepherds=2)
+        ctx.state.shepherds["shepherd-1"] = ShepherdEntry(status="working", issue=10)
+        ctx.state.shepherds["shepherd-2"] = ShepherdEntry(status="working", issue=20)
+        ctx.snapshot = _snapshot_with_ready_issues([42])
+
+        with mock.patch("loom_tools.daemon_v2.loop.spawn_shepherds") as mock_spawn:
+            _fast_path_assign(ctx)
+            mock_spawn.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests: fast-path triggers spawn
+# ---------------------------------------------------------------------------
+
+
+class TestFastPathAssignTriggers:
+    """_fast_path_assign should call spawn_shepherds when conditions are met."""
+
+    def test_triggers_when_idle_slot_exists(self, tmp_path: pathlib.Path) -> None:
+        """Idle shepherd slot + ready issues should trigger spawn_shepherds."""
+        ctx = _make_ctx(tmp_path, max_shepherds=2)
+        ctx.state.shepherds["shepherd-1"] = ShepherdEntry(status="idle")
+        ctx.snapshot = _snapshot_with_ready_issues([42])
+
+        with mock.patch("loom_tools.daemon_v2.loop.spawn_shepherds", return_value=1) as mock_spawn:
+            with mock.patch("loom_tools.daemon_v2.loop._write_state"):
+                _fast_path_assign(ctx)
+                mock_spawn.assert_called_once_with(ctx)
+
+    def test_triggers_when_new_slot_can_be_created(self, tmp_path: pathlib.Path) -> None:
+        """No existing shepherds + ready issues should trigger spawn (new slot)."""
+        ctx = _make_ctx(tmp_path, max_shepherds=3)
+        # No shepherd entries at all — slots can be created up to max_shepherds
+        ctx.snapshot = _snapshot_with_ready_issues([42])
+
+        with mock.patch("loom_tools.daemon_v2.loop.spawn_shepherds", return_value=1) as mock_spawn:
+            with mock.patch("loom_tools.daemon_v2.loop._write_state"):
+                _fast_path_assign(ctx)
+                mock_spawn.assert_called_once_with(ctx)
+
+    def test_triggers_with_mixed_shepherd_states(self, tmp_path: pathlib.Path) -> None:
+        """One working, one idle shepherd — fast-path should trigger for idle."""
+        ctx = _make_ctx(tmp_path, max_shepherds=2)
+        ctx.state.shepherds["shepherd-1"] = ShepherdEntry(status="working", issue=10)
+        ctx.state.shepherds["shepherd-2"] = ShepherdEntry(status="idle")
+        ctx.snapshot = _snapshot_with_ready_issues([99])
+
+        with mock.patch("loom_tools.daemon_v2.loop.spawn_shepherds", return_value=1) as mock_spawn:
+            with mock.patch("loom_tools.daemon_v2.loop._write_state"):
+                _fast_path_assign(ctx)
+                mock_spawn.assert_called_once_with(ctx)
+
+    def test_writes_state_after_successful_spawn(self, tmp_path: pathlib.Path) -> None:
+        """State should be persisted after a successful fast-path spawn."""
+        ctx = _make_ctx(tmp_path)
+        ctx.snapshot = _snapshot_with_ready_issues([42])
+
+        with mock.patch("loom_tools.daemon_v2.loop.spawn_shepherds", return_value=1):
+            with mock.patch("loom_tools.daemon_v2.loop._write_state") as mock_write:
+                _fast_path_assign(ctx)
+                mock_write.assert_called_once_with(ctx)
+
+    def test_no_state_write_when_spawn_returns_zero(self, tmp_path: pathlib.Path) -> None:
+        """State should NOT be written if spawn_shepherds returns 0."""
+        ctx = _make_ctx(tmp_path)
+        ctx.snapshot = _snapshot_with_ready_issues([42])
+
+        with mock.patch("loom_tools.daemon_v2.loop.spawn_shepherds", return_value=0):
+            with mock.patch("loom_tools.daemon_v2.loop._write_state") as mock_write:
+                _fast_path_assign(ctx)
+                mock_write.assert_not_called()


### PR DESCRIPTION
## Summary

Reduces worst-case shepherd idle latency from 120s to ~2s by combining a lower default poll interval with a fast-path assignment mechanism during responsive-sleep ticks.

## Changes

- Reduced `DEFAULT_POLL_INTERVAL` from 120s to 30s in `config.py`
- Added `_fast_path_assign()` to `loop.py`: called every 2s during sleep ticks, checks for idle shepherd slots + cached ready issues in the last snapshot, and spawns immediately without waiting for the next full iteration
- Updated `test_config.py` to reflect the new 30s default
- Added `test_fast_path_assign.py` with 9 unit tests covering no-op conditions and trigger conditions
- Updated documentation in `loom.md`, `daemon-reference.md`, and `CLAUDE.md` to reflect the new default

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Poll interval reduced (Option A) | ✅ | `DEFAULT_POLL_INTERVAL = 30` in `config.py`; test asserts 30s |
| Fast-path assignment during sleep (Option B) | ✅ | `_fast_path_assign()` called every 2s tick in `_responsive_sleep` |
| No GitHub API call during fast-path | ✅ | Uses cached `ctx.snapshot` and `ctx.state` directly |
| No spurious spawns when no idle slots | ✅ | Guarded by `has_idle_slot` check before calling `spawn_shepherds` |
| No spurious spawns when no ready issues | ✅ | Guarded by `ready_issues = ctx.get_ready_issues()` check |
| Tests pass | ✅ | 181/181 daemon_v2 tests pass |
| Documentation updated | ✅ | Three docs updated to reflect 30s default |

## Test Plan

- `uv run pytest loom-tools/tests/daemon_v2/ -q` → 181 passed
- Pre-existing failures in `shepherd/test_phases.py`, `test_degraded_session_detection.py`, and `test_recovery_stats.py` are unrelated to this change (verified on main branch)

Closes #3040