### PR TITLE
feat: arch: curator should run as always-on background role, decoupled from shepherd pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -484,6 +484,7 @@ Archived sessions include a `session_summary` field with final statistics:
 | terminal-champion | champion.md | Auto-merge (always running) |
 | terminal-doctor | doctor.md | PR conflict resolution (always running) |
 | terminal-auditor | auditor.md | Main branch validation (always running) |
+| terminal-curator | curator.md | Issue enrichment background role (always running) |
 
 ### Custom Roles
 

--- a/loom-tools/src/loom_tools/daemon_v2/actions/support_roles.py
+++ b/loom-tools/src/loom_tools/daemon_v2/actions/support_roles.py
@@ -23,6 +23,7 @@ SUPPORT_ROLES = {
     "judge": "judge",
     "architect": "architect",
     "hermit": "hermit",
+    "curator": "curator",
 }
 
 
@@ -167,6 +168,10 @@ def spawn_roles_from_actions(ctx: DaemonContext) -> int:
 
     if "trigger_hermit" in actions:
         if spawn_support_role(ctx, "hermit"):
+            spawned += 1
+
+    if "trigger_curator" in actions:
+        if spawn_support_role(ctx, "curator"):
             spawned += 1
 
     return spawned

--- a/loom-tools/src/loom_tools/daemon_v2/config.py
+++ b/loom-tools/src/loom_tools/daemon_v2/config.py
@@ -21,6 +21,7 @@ DEFAULT_CHAMPION_INTERVAL = 600  # seconds
 DEFAULT_DOCTOR_INTERVAL = 300  # seconds
 DEFAULT_AUDITOR_INTERVAL = 600  # seconds
 DEFAULT_JUDGE_INTERVAL = 300  # seconds
+DEFAULT_CURATOR_INTERVAL = 300  # seconds
 DEFAULT_STARTUP_GRACE_PERIOD = 120  # seconds before early warning
 DEFAULT_NO_PROGRESS_GRACE_PERIOD = 300  # seconds before hard reclaim
 DEFAULT_STALL_DIAGNOSTIC_THRESHOLD = 3  # consecutive stalled iterations
@@ -60,6 +61,7 @@ class DaemonConfig:
     doctor_interval: int = DEFAULT_DOCTOR_INTERVAL
     auditor_interval: int = DEFAULT_AUDITOR_INTERVAL
     judge_interval: int = DEFAULT_JUDGE_INTERVAL
+    curator_interval: int = DEFAULT_CURATOR_INTERVAL
 
     # Shepherd startup detection thresholds
     startup_grace_period: int = DEFAULT_STARTUP_GRACE_PERIOD
@@ -104,6 +106,7 @@ class DaemonConfig:
             doctor_interval=env_int("LOOM_DOCTOR_INTERVAL", DEFAULT_DOCTOR_INTERVAL),
             auditor_interval=env_int("LOOM_AUDITOR_INTERVAL", DEFAULT_AUDITOR_INTERVAL),
             judge_interval=env_int("LOOM_JUDGE_INTERVAL", DEFAULT_JUDGE_INTERVAL),
+            curator_interval=env_int("LOOM_CURATOR_INTERVAL", DEFAULT_CURATOR_INTERVAL),
             stall_diagnostic_threshold=env_int(
                 "LOOM_STALL_DIAGNOSTIC_THRESHOLD", DEFAULT_STALL_DIAGNOSTIC_THRESHOLD
             ),


### PR DESCRIPTION
Closes #3045

> **Note:** This PR was created automatically via the builder recovery path. The builder produced changes but exited before creating a PR. Reviewers should examine the diff carefully.

## Changes

```
CLAUDE.md                                          |  1 +
 .../loom_tools/daemon_v2/actions/support_roles.py  |  5 ++++
 loom-tools/src/loom_tools/daemon_v2/config.py      |  3 ++
 loom-tools/src/loom_tools/snapshot.py              | 34 ++++++++++++++++++++--
 loom-tools/tests/test_snapshot.py                  | 32 +++++++++++++++++---
 5 files changed, 68 insertions(+), 7 deletions(-)
```

## Commits

- `d3886520 feat: arch: curator should run as always-on background role, decoupled from shepherd pipeline`

## Test plan

- [ ] Review diff carefully (recovery-created PR)
- [ ] Verify changes match issue requirements
- [ ] Run tests locally if needed