### PR TITLE
feat: bug: stale unprocessed signal files accumulate in .loom/signals/

### DIFF
--- a/loom-tools/src/loom_tools/daemon_v2/command_poller.py
+++ b/loom-tools/src/loom_tools/daemon_v2/command_poller.py
@@ -15,8 +15,15 @@ Signal payload format::
         "action": "spawn_shepherd",
         "issue": 42,
         "mode": "default",
-        "flags": []
+        "flags": [],
+        "created_at": "2026-02-23T19:25:00Z",
+        "ttl_seconds": 3600
     }
+
+The ``created_at`` and ``ttl_seconds`` fields are optional but recommended.
+Signals older than ``ttl_seconds`` are discarded. If ``ttl_seconds`` is
+absent, ``max_age_seconds`` (set at construction time, default 1 hour) is
+used as a fallback age limit based on the file's modification time.
 
 Available actions:
 
@@ -46,10 +53,17 @@ without activating full loom orchestration.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import pathlib
 import time
+from datetime import datetime, timezone
 from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Default maximum age for signal files (1 hour). Overridable via env var.
+_DEFAULT_MAX_AGE_SECONDS = int(os.environ.get("LOOM_SIGNAL_MAX_AGE_SECONDS", "3600"))
 
 
 class CommandPoller:
@@ -58,11 +72,57 @@ class CommandPoller:
     Thread-safety note: poll() is safe to call from a single thread.
     Each file is unlinked immediately after being read, so concurrent
     daemon instances will not double-consume the same command.
+
+    Args:
+        workspace: Repository root directory.
+        max_age_seconds: Discard signal files older than this many seconds
+            (based on file mtime). Use 0 or None to disable age filtering.
+            Defaults to ``LOOM_SIGNAL_MAX_AGE_SECONDS`` env var (1 hour).
     """
 
-    def __init__(self, workspace: pathlib.Path) -> None:
+    def __init__(
+        self,
+        workspace: pathlib.Path,
+        max_age_seconds: int | None = _DEFAULT_MAX_AGE_SECONDS,
+    ) -> None:
         self.signals_dir = workspace / ".loom" / "signals"
         self.signals_dir.mkdir(parents=True, exist_ok=True)
+        self.max_age_seconds = max_age_seconds or 0
+
+    def _is_expired(self, signal_file: pathlib.Path, data: dict[str, Any]) -> bool:
+        """Return True if this signal should be discarded as stale.
+
+        Checks ``created_at`` + ``ttl_seconds`` from the payload first.
+        Falls back to file mtime vs ``self.max_age_seconds`` if the payload
+        fields are absent.
+        """
+        now = time.time()
+
+        # Payload-based TTL check (authoritative when present and parseable)
+        created_at_str = data.get("created_at")
+        ttl_seconds = data.get("ttl_seconds")
+        if created_at_str and ttl_seconds is not None:
+            try:
+                created_dt = datetime.fromisoformat(
+                    created_at_str.replace("Z", "+00:00")
+                )
+                age = now - created_dt.replace(tzinfo=timezone.utc).timestamp()
+                # Payload TTL is authoritative: return its verdict without
+                # falling through to the mtime check.
+                return age > ttl_seconds
+            except (ValueError, TypeError):
+                pass  # Malformed timestamp; fall through to mtime check
+
+        # Fallback: file mtime check
+        if self.max_age_seconds > 0:
+            try:
+                file_age = now - signal_file.stat().st_mtime
+                if file_age > self.max_age_seconds:
+                    return True
+            except OSError:
+                pass
+
+        return False
 
     def poll(self) -> list[dict[str, Any]]:
         """Atomically consume and return all pending signal commands.
@@ -70,7 +130,9 @@ class CommandPoller:
         Reads all ``*.json`` files from the signals directory in sorted
         (alphabetical/timestamp) order. Each file is deleted immediately
         after being read. Corrupt or unreadable files are skipped with
-        a warning and also deleted to prevent re-processing.
+        a warning and also deleted to prevent re-processing. Stale files
+        (older than ``max_age_seconds`` or expired per payload TTL) are
+        discarded with a warning.
 
         Returns a list of command dicts (possibly empty).
         """
@@ -86,6 +148,19 @@ class CommandPoller:
                 data = json.loads(signal_file.read_text())
             except (OSError, json.JSONDecodeError):
                 # Corrupt or unreadable — delete to prevent re-processing
+                try:
+                    signal_file.unlink(missing_ok=True)
+                except OSError:
+                    pass
+                continue
+
+            # Check staleness before consuming
+            if isinstance(data, dict) and self._is_expired(signal_file, data):
+                logger.warning(
+                    "Discarding stale signal file %s (action=%s)",
+                    signal_file.name,
+                    data.get("action", "unknown"),
+                )
                 try:
                     signal_file.unlink(missing_ok=True)
                 except OSError:


### PR DESCRIPTION
Closes #3034

> **Note:** Builder completed changes but exited before creating a PR. PR created via direct completion.

## Changes

```
loom-tools/src/loom_tools/daemon_cleanup.py        |  66 +++++++++
 .../src/loom_tools/daemon_v2/command_poller.py     |  81 ++++++++++-
 loom-tools/tests/daemon/test_command_poller.py     | 162 +++++++++++++++++++++
 loom-tools/tests/test_daemon_cleanup.py            | 126 ++++++++++++++++
 4 files changed, 432 insertions(+), 3 deletions(-)
```

## Commits

- `808ec038 [prior-run-checkpoint] stale work from previous builder attempt`

## Test plan

- [ ] Verify changes match issue requirements
- [ ] Confirm tests pass