### PR TITLE
feat: arch: daemon auto-spawning shepherds should be opt-in (--auto-build), not default behavior

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,11 +73,20 @@ Launch the Loom desktop application for automated orchestration:
 ### 3. Daemon Mode (Layer 2)
 
 ```bash
+./.loom/scripts/start-daemon.sh              # support roles only (new default)
+./.loom/scripts/start-daemon.sh --auto-build # also auto-spawn shepherds from queue
+```
+
+```bash
 /loom           # Activate daemon orchestration (daemon must be started first)
 /loom --merge   # Aggressive autonomous development
 ```
 
-**Merge Mode** enables: auto-promotion of proposals, auto-merge after Judge approval, audit trail with `[force-mode]` markers, safety guardrails still apply. Merge mode does **not** skip the Judge phase (code review always runs due to GitHub's self-review API restriction).
+**Default mode** (no flags): Daemon manages support roles only — judge, champion, doctor, auditor, curator, guide. Keeps the pipeline flowing for work humans have already initiated via `/shepherd <N>`. Does NOT auto-spawn shepherds.
+
+**Auto-build mode** (`--auto-build` or `-a` flag): Also auto-picks issues from `loom:issue` queue and spawns shepherds. For fully autonomous runs where human intent is "build everything in the queue."
+
+**Merge Mode** enables: auto-promotion of proposals, auto-merge after Judge approval, audit trail with `[force-mode]` markers, safety guardrails still apply. Merge mode does **not** skip the Judge phase (code review always runs due to GitHub's self-review API restriction). Merge mode implies `--auto-build`.
 
 **Graceful shutdown**: `touch .loom/stop-daemon`
 

--- a/defaults/.claude/commands/loom.md
+++ b/defaults/.claude/commands/loom.md
@@ -55,7 +55,8 @@ The Loom daemon is not running.
 
 Start it from a terminal OUTSIDE Claude Code:
 
-  ./.loom/scripts/start-daemon.sh                     # Normal mode
+  ./.loom/scripts/start-daemon.sh                     # Support-only mode (default)
+  ./.loom/scripts/start-daemon.sh --auto-build        # Also auto-spawn shepherds
   ./.loom/scripts/start-daemon.sh --timeout-min 120   # Auto-stop after 2 hours
 
 Then run /loom again to begin observing and orchestrating.
@@ -330,7 +331,8 @@ Loom has three layers of roles:
 
 **Starting the daemon (run OUTSIDE Claude Code):**
 ```
-./.loom/scripts/start-daemon.sh                   Start daemon
+./.loom/scripts/start-daemon.sh                   Start daemon (support-only)
+./.loom/scripts/start-daemon.sh --auto-build      Also auto-spawn shepherds
 ./.loom/scripts/start-daemon.sh -t 180            Run for 3 hours then stop
 ./.loom/scripts/start-daemon.sh --status          Check if daemon is running
 ./.loom/scripts/stop-daemon.sh                    Stop gracefully

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -192,17 +192,26 @@ Launch the Loom desktop application for automated orchestration with visual term
 Run the Loom daemon for fully autonomous system orchestration.
 
 ```bash
-# Start the daemon (runs continuously)
+# Start daemon in support-only mode (default — no auto-shepherd-spawning)
+./.loom/scripts/start-daemon.sh
+
+# Start daemon with auto-build enabled (also spawns shepherds from queue)
+./.loom/scripts/start-daemon.sh --auto-build
+
+# Activate orchestration from Claude Code (daemon must already be running)
 /loom
 
 # Start with merge mode for aggressive autonomous development
 /loom --merge
 
-# The daemon will:
+# In support-only mode, the daemon will:
 # 1. Monitor system state every 60 seconds
 # 2. Trigger Architect/Hermit when backlog is low
-# 3. Spawn shepherds for ready issues
-# 4. Ensure Guide and Champion keep running
+# 3. Ensure Guide, Champion, Doctor, Auditor, Judge, Curator keep running
+# 4. NOT auto-spawn shepherds (use /shepherd <N> for specific issues)
+
+# With --auto-build, also:
+# 3. Spawn shepherds for ready issues automatically
 ```
 
 **Dual Daemon Prevention**: `/loom` uses session ID tracking to prevent multiple daemon instances from running simultaneously. If a second daemon is started, it will detect the conflict and refuse to start. The `daemon_session_id` field in `daemon-state.json` (format: `timestamp-PID`) enables each daemon to verify it still owns the state file before writing updates. This prevents state corruption when Claude Code sessions are auto-continued.

--- a/defaults/scripts/start-daemon.sh
+++ b/defaults/scripts/start-daemon.sh
@@ -14,11 +14,20 @@
 #   ./.loom/scripts/start-daemon.sh [OPTIONS]
 #
 # Options:
+#   --auto-build, -a    Enable automatic shepherd spawning from loom:issue queue
 #   --timeout-min N     Stop daemon after N minutes (0 = no timeout)
 #   --debug, -d         Enable debug logging
 #   --status            Print daemon status and exit
 #   --stop              Write stop signal and exit
 #   --help, -h          Show this help
+#
+# Modes:
+#   (no flags)          Support-only: judge, champion, doctor, auditor, curator,
+#                       guide run autonomously. Shepherds NOT auto-spawned.
+#                       Use /shepherd <N> to shepherd specific issues manually.
+#   --auto-build        Also auto-spawn shepherds from loom:issue queue.
+#                       Equivalent to current default behavior before this change.
+#                       Use /loom --merge in Claude Code for force mode on top.
 #
 # After starting, the /loom Claude Code skill detects the running daemon
 # via .loom/daemon-loop.pid and operates as a signal-writer + observer.
@@ -173,3 +182,7 @@ echo ""
 echo "Start /loom in Claude Code to begin orchestration:"
 echo "  /loom"
 echo "  /loom --merge   # force mode: auto-promote + auto-merge"
+echo ""
+echo "To enable automatic shepherd spawning, restart with --auto-build:"
+echo "  $SCRIPT_DIR/stop-daemon.sh"
+echo "  $SCRIPT_DIR/start-daemon.sh --auto-build"

--- a/loom-tools/src/loom_tools/daemon_v2/iteration.py
+++ b/loom-tools/src/loom_tools/daemon_v2/iteration.py
@@ -124,8 +124,8 @@ def run_iteration(ctx: DaemonContext) -> IterationResult:
     if "promote_proposals" in actions and ctx.config.force_mode:
         result.proposals_promoted = promote_proposals(ctx)
 
-    # Spawn shepherds
-    if "spawn_shepherds" in actions:
+    # Spawn shepherds (only when auto_build is enabled)
+    if "spawn_shepherds" in actions and ctx.config.auto_build:
         result.shepherds_spawned = spawn_shepherds(ctx)
 
     # Spawn support roles (handles all interval and demand triggers)

--- a/loom-tools/tests/daemon_v2/test_auto_build_gate.py
+++ b/loom-tools/tests/daemon_v2/test_auto_build_gate.py
@@ -1,0 +1,122 @@
+"""Tests for the auto_build gate in daemon iteration.
+
+When auto_build=False (the new default), spawn_shepherds must NOT be called
+even when the snapshot recommends it and shepherd slots are available.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from unittest import mock
+
+import pytest
+
+from loom_tools.daemon_v2.config import DaemonConfig
+from loom_tools.daemon_v2.context import DaemonContext
+from loom_tools.daemon_v2.iteration import run_iteration
+from loom_tools.models.daemon_state import DaemonState, ShepherdEntry
+
+
+def _make_ctx(
+    tmp_path: pathlib.Path,
+    *,
+    auto_build: bool,
+    force_mode: bool = False,
+) -> DaemonContext:
+    """Return a DaemonContext with minimal state for unit tests."""
+    config = DaemonConfig(auto_build=auto_build, force_mode=force_mode)
+    ctx = DaemonContext(config=config, repo_root=tmp_path)
+    ctx.state = DaemonState()
+    return ctx
+
+
+def _snapshot_with_spawn_shepherds_action() -> dict:
+    """Build a minimal snapshot that recommends spawn_shepherds."""
+    return {
+        "pipeline": {
+            "ready_issues": [{"number": 42, "title": "Test issue"}],
+        },
+        "prs": {"open": [], "spinning": []},
+        "shepherds": {"progress": []},
+        "pipeline_health": {"retryable_issues": [], "escalation_needed": []},
+        "computed": {
+            "total_ready": 1,
+            "total_building": 0,
+            "total_blocked": 0,
+            "active_shepherds": 0,
+            "available_shepherd_slots": 3,
+            "health_status": "healthy",
+            "health_warnings": [],
+            "needs_human_input": [],
+            "recommended_actions": ["spawn_shepherds"],
+        },
+        "support_roles": {},
+    }
+
+
+class TestAutoBuildGateInIteration:
+    """run_iteration must gate spawn_shepherds on config.auto_build."""
+
+    @mock.patch("loom_tools.daemon_v2.iteration.spawn_shepherds")
+    @mock.patch("loom_tools.daemon_v2.iteration.spawn_roles_from_actions", return_value=0)
+    @mock.patch("loom_tools.daemon_v2.iteration.check_completions", return_value=[])
+    @mock.patch("loom_tools.daemon_v2.iteration.reclaim_completed_support_roles", return_value=[])
+    @mock.patch("loom_tools.daemon_v2.iteration.force_reclaim_stale_shepherds", return_value=0)
+    @mock.patch("loom_tools.daemon_v2.iteration.read_daemon_state")
+    @mock.patch("loom_tools.daemon_v2.iteration.build_snapshot")
+    @mock.patch("loom_tools.daemon_v2.iteration._save_daemon_state")
+    def test_spawn_shepherds_not_called_when_auto_build_false(
+        self,
+        _mock_save,
+        mock_snapshot,
+        mock_read_state,
+        _mock_force_reclaim,
+        _mock_reclaim_support,
+        _mock_completions,
+        _mock_roles,
+        mock_spawn,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        """spawn_shepherds must NOT be called when auto_build=False."""
+        mock_snapshot.return_value = _snapshot_with_spawn_shepherds_action()
+        state = DaemonState()
+        mock_read_state.return_value = state
+
+        ctx = _make_ctx(tmp_path, auto_build=False)
+        ctx.state = state
+
+        run_iteration(ctx)
+
+        mock_spawn.assert_not_called()
+
+    @mock.patch("loom_tools.daemon_v2.iteration.spawn_shepherds", return_value=1)
+    @mock.patch("loom_tools.daemon_v2.iteration.spawn_roles_from_actions", return_value=0)
+    @mock.patch("loom_tools.daemon_v2.iteration.check_completions", return_value=[])
+    @mock.patch("loom_tools.daemon_v2.iteration.reclaim_completed_support_roles", return_value=[])
+    @mock.patch("loom_tools.daemon_v2.iteration.force_reclaim_stale_shepherds", return_value=0)
+    @mock.patch("loom_tools.daemon_v2.iteration.read_daemon_state")
+    @mock.patch("loom_tools.daemon_v2.iteration.build_snapshot")
+    @mock.patch("loom_tools.daemon_v2.iteration._save_daemon_state")
+    def test_spawn_shepherds_called_when_auto_build_true(
+        self,
+        _mock_save,
+        mock_snapshot,
+        mock_read_state,
+        _mock_force_reclaim,
+        _mock_reclaim_support,
+        _mock_completions,
+        _mock_roles,
+        mock_spawn,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        """spawn_shepherds must be called when auto_build=True and action recommended."""
+        mock_snapshot.return_value = _snapshot_with_spawn_shepherds_action()
+        state = DaemonState()
+        mock_read_state.return_value = state
+
+        ctx = _make_ctx(tmp_path, auto_build=True)
+        ctx.state = state
+
+        run_iteration(ctx)
+
+        mock_spawn.assert_called_once_with(ctx)

--- a/loom-tools/tests/daemon_v2/test_config.py
+++ b/loom-tools/tests/daemon_v2/test_config.py
@@ -18,6 +18,7 @@ class TestDaemonConfig:
         assert config.max_shepherds == 10
         assert config.issue_threshold == 3
         assert config.force_mode is False
+        assert config.auto_build is False
         assert config.debug_mode is False
 
     def test_from_env_defaults(self):
@@ -52,14 +53,50 @@ class TestDaemonConfig:
         config = DaemonConfig.from_env(debug_mode=True)
         assert config.debug_mode is True
 
-    def test_mode_display_normal(self):
-        """Test mode display for normal mode."""
+    def test_from_env_with_auto_build_flag(self):
+        """Test auto_build passed as argument."""
+        config = DaemonConfig.from_env(auto_build=True)
+        assert config.auto_build is True
+        assert config.force_mode is False
+
+    def test_from_env_auto_build_env_var(self):
+        """Test LOOM_AUTO_BUILD environment variable enables auto_build."""
+        with patch.dict(os.environ, {"LOOM_AUTO_BUILD": "true"}, clear=True):
+            config = DaemonConfig.from_env()
+            assert config.auto_build is True
+
+    def test_from_env_auto_build_false_by_default(self):
+        """Test auto_build is False by default (no env var)."""
+        with patch.dict(os.environ, {}, clear=True):
+            config = DaemonConfig.from_env()
+            assert config.auto_build is False
+
+    def test_force_mode_implies_auto_build(self):
+        """Test that force_mode=True implies auto_build=True."""
+        config = DaemonConfig.from_env(force_mode=True)
+        assert config.force_mode is True
+        assert config.auto_build is True
+
+    def test_merge_mode_implies_auto_build_via_env(self):
+        """Test LOOM_FORCE_MODE env var implies auto_build."""
+        with patch.dict(os.environ, {"LOOM_FORCE_MODE": "true"}, clear=True):
+            config = DaemonConfig.from_env()
+            assert config.force_mode is True
+            assert config.auto_build is True
+
+    def test_mode_display_support_only(self):
+        """Test mode display for default mode (no auto_build, no force)."""
         config = DaemonConfig()
-        assert config.mode_display() == "Normal"
+        assert config.mode_display() == "Support-only"
+
+    def test_mode_display_auto_build(self):
+        """Test mode display for auto-build mode."""
+        config = DaemonConfig(auto_build=True)
+        assert config.mode_display() == "Auto-build"
 
     def test_mode_display_force(self):
         """Test mode display for force mode."""
-        config = DaemonConfig(force_mode=True)
+        config = DaemonConfig(force_mode=True, auto_build=True)
         assert config.mode_display() == "Force"
 
     def test_mode_display_debug(self):
@@ -67,7 +104,12 @@ class TestDaemonConfig:
         config = DaemonConfig(debug_mode=True)
         assert config.mode_display() == "Debug"
 
-    def test_mode_display_both(self):
+    def test_mode_display_force_debug(self):
         """Test mode display for force + debug mode."""
-        config = DaemonConfig(force_mode=True, debug_mode=True)
+        config = DaemonConfig(force_mode=True, auto_build=True, debug_mode=True)
         assert config.mode_display() == "Force + Debug"
+
+    def test_mode_display_auto_build_debug(self):
+        """Test mode display for auto-build + debug mode."""
+        config = DaemonConfig(auto_build=True, debug_mode=True)
+        assert config.mode_display() == "Auto-build + Debug"


### PR DESCRIPTION
Closes #3044

> **Note:** This PR was created automatically via the builder recovery path. The builder produced changes but exited before creating a PR. Reviewers should examine the diff carefully.

## Changes

```
CLAUDE.md                                          |  11 +-
 defaults/.claude/commands/loom.md                  |   6 +-
 defaults/CLAUDE.md                                 |  17 ++-
 defaults/scripts/start-daemon.sh                   |  13 +++
 loom-tools/src/loom_tools/daemon_v2/cli.py         |  19 +++-
 loom-tools/src/loom_tools/daemon_v2/config.py      |  24 ++--
 loom-tools/src/loom_tools/daemon_v2/iteration.py   |   4 +-
 loom-tools/src/loom_tools/daemon_v2/loop.py        |  12 +-
 loom-tools/tests/daemon_v2/test_auto_build_gate.py | 122 +++++++++++++++++++++
 loom-tools/tests/daemon_v2/test_config.py          |  54 ++++++++-
 .../tests/daemon_v2/test_fast_path_assign.py       |  33 +++++-
 11 files changed, 286 insertions(+), 29 deletions(-)
```

## Commits

- `e25ad2fc feat: arch: daemon auto-spawning shepherds should be opt-in (--auto-build), not default behavior`

## Test plan

- [ ] Review diff carefully (recovery-created PR)
- [ ] Verify changes match issue requirements
- [ ] Run tests locally if needed