### PR TITLE
fix: add loom:blocked to uncurated skip labels in snapshot

### DIFF
--- a/loom-tools/src/loom_tools/snapshot.py
+++ b/loom-tools/src/loom_tools/snapshot.py
@@ -274,7 +274,8 @@ _ISSUE_FIELDS = ["number", "title", "labels", "createdAt"]
 # Labels that indicate an issue has been processed or claimed — used to identify
 # issues that still need curator attention.
 _CURATED_SKIP_LABELS = frozenset({
-    "loom:curated", "loom:curating", "loom:issue", "loom:building", "external",
+    "loom:curated", "loom:curating", "loom:issue", "loom:building", "loom:blocked",
+    "external",
 })
 _PR_FIELDS = ["number", "title", "labels", "headRefName"]
 


### PR DESCRIPTION
## Summary
Adds `loom:blocked` to `_CURATED_SKIP_LABELS` in `snapshot.py` so blocked issues are excluded from the uncurated count. Without this fix, blocked issues inflate the uncurated count and can trigger unnecessary curator spawns.

## Changes
- Added `"loom:blocked"` to the `_CURATED_SKIP_LABELS` frozenset in `snapshot.py`
- Added `TestCuratedSkipLabels` test class with 3 tests verifying the skip set contents and filtering behavior

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `loom:blocked` in skip labels set | ✅ | Added to frozenset, verified by `test_blocked_label_is_in_skip_set` |
| Blocked issues excluded from uncurated list | ✅ | Verified by `test_blocked_issue_excluded_from_uncurated` |
| Edge case: issue with only `loom:blocked` label excluded | ✅ | Test constructs issue with only `loom:blocked` and confirms exclusion |

## Test Plan
- All 164 snapshot tests pass (`uv run pytest tests/test_snapshot.py`)
- 3 new tests specifically validate the fix

Closes #3050