### PR TITLE
fix: mock _is_in_worktree in test instead of relying on chdir

### DIFF
--- a/loom-tools/tests/test_worktree.py
+++ b/loom-tools/tests/test_worktree.py
@@ -115,16 +115,13 @@ class TestCLI:
         captured = capsys.readouterr()
         assert "does not exist" in captured.err.lower() or "error" in captured.err.lower()
 
-    def test_cli_check_not_in_worktree(self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
-        # Create a simple git repo
-        (tmp_path / ".git").mkdir()
-        monkeypatch.chdir(tmp_path)
-
-        result = main(["--check"])
+    def test_cli_check_not_in_worktree(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """--check reports 'not in a worktree' when _is_in_worktree returns False."""
+        with patch("loom_tools.worktree._is_in_worktree", return_value=False):
+            result = main(["--check"])
         captured = capsys.readouterr()
-
-        # Should indicate not in a worktree
-        assert result == 1 or "not" in captured.out.lower()
+        assert result == 1
+        assert "not" in captured.out.lower()
 
 
 class TestDocumentedBehaviorDifferences:


### PR DESCRIPTION
## Summary
Fix environment-dependent test by mocking `_is_in_worktree` instead of relying on `monkeypatch.chdir` + fake `.git` directory.

## Changes
- Replace fragile `tmp_path`/`monkeypatch.chdir`/fake `.git` setup in `test_cli_check_not_in_worktree` with a direct mock of `_is_in_worktree`
- Tighten assertions: check `result == 1` and `"not" in captured.out.lower()` separately instead of a weak `or` condition
- Remove unused `tmp_path`, `monkeypatch` parameters from the test signature

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Test passes from repo root | ✅ | `pytest loom-tools/tests/test_worktree.py::TestCLI::test_cli_check_not_in_worktree -v` passes |
| Full test suite passes | ✅ | All 21 tests in `test_worktree.py` pass |
| Test passes from within a worktree | ✅ | Ran from `.loom/worktrees/issue-3037` successfully |

## Test Plan
```
PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/test_worktree.py -v
# 21 passed
```

Closes #3037