### PR TITLE
feat: extract shared keyword PR search into a reusable helper in builder.py

### DIFF
--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -11663,7 +11663,7 @@ class TestBuilderDirectCompletion:
             # branch-name check: no PR found; keyword "Closes" search: PR found
             mock_run.side_effect = [
                 MagicMock(returncode=0, stdout="", stderr=""),   # --head check: empty
-                MagicMock(returncode=0, stdout="888\n", stderr=""),  # Closes keyword: PR 888
+                MagicMock(returncode=0, stdout='{"number": 888, "labels": []}\n', stderr=""),  # Closes keyword: PR 888
             ]
             result = builder._direct_completion(mock_context, diag)
 
@@ -11708,7 +11708,7 @@ class TestBuilderDirectCompletion:
             mock_run.side_effect = [
                 MagicMock(returncode=0, stdout="", stderr=""),   # --head check: empty
                 MagicMock(returncode=0, stdout="", stderr=""),   # Closes keyword: empty
-                MagicMock(returncode=0, stdout="777\n", stderr=""),  # Fixes keyword: PR 777
+                MagicMock(returncode=0, stdout='{"number": 777, "labels": []}\n', stderr=""),  # Fixes keyword: PR 777
             ]
             result = builder._direct_completion(mock_context, diag)
 


### PR DESCRIPTION
Closes #3024

> **Note:** Builder completed changes but exited before creating a PR. PR created via direct completion.

## Changes

```
.../src/loom_tools/shepherd/phases/builder.py      | 127 +++++++++++----------
 loom-tools/tests/shepherd/test_phases.py           |   4 +-
 2 files changed, 68 insertions(+), 63 deletions(-)
```

## Commits

- `9e637109 [prior-run-checkpoint] stale work from previous builder attempt`

## Test plan

- [ ] Verify changes match issue requirements
- [ ] Confirm tests pass