### PR TITLE
fix: add runtime verification probe to gh-cached selection

### DIFF
--- a/defaults/scripts/agent-wait-bg.sh
+++ b/defaults/scripts/agent-wait-bg.sh
@@ -37,8 +37,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 # Use gh-cached for read-only queries to reduce API calls (see issue #1609)
+# Verify the Python interpreter works too — a broken runtime (e.g. unaccepted
+# Xcode license) would make every subsequent gh call fail with a misleading error.
 GH_CACHED="$REPO_ROOT/.loom/scripts/gh-cached"
-if [[ -x "$GH_CACHED" ]]; then
+if [[ -x "$GH_CACHED" ]] && "$GH_CACHED" --version &>/dev/null; then
     GH="$GH_CACHED"
 else
     GH="gh"

--- a/defaults/scripts/merge-pr.sh
+++ b/defaults/scripts/merge-pr.sh
@@ -57,8 +57,10 @@ REPO_ROOT="$(find_main_repo_root)" || \
   error "Not in a git repository"
 
 # Use gh-cached for read-only queries to reduce API calls (see issue #1609)
+# Verify the Python interpreter works too — a broken runtime (e.g. unaccepted
+# Xcode license) would make every subsequent gh call fail with a misleading error.
 GH_CACHED="$REPO_ROOT/.loom/scripts/gh-cached"
-if [[ -x "$GH_CACHED" ]]; then
+if [[ -x "$GH_CACHED" ]] && "$GH_CACHED" --version &>/dev/null; then
     GH="$GH_CACHED"
 else
     GH="gh"

--- a/defaults/scripts/stale-building-check.sh
+++ b/defaults/scripts/stale-building-check.sh
@@ -27,9 +27,11 @@
 set -euo pipefail
 
 # Use gh-cached for read-only queries to reduce API calls (see issue #1609)
+# Verify the Python interpreter works too — a broken runtime (e.g. unaccepted
+# Xcode license) would make every subsequent gh call fail with a misleading error.
 _SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GH_CACHED="$_SCRIPT_DIR/gh-cached"
-if [[ -x "$GH_CACHED" ]]; then
+if [[ -x "$GH_CACHED" ]] && "$GH_CACHED" --version &>/dev/null; then
     GH="$GH_CACHED"
 else
     GH="gh"

--- a/loom-tools/src/loom_tools/common/github.py
+++ b/loom-tools/src/loom_tools/common/github.py
@@ -155,9 +155,24 @@ def _is_rate_limited(result: subprocess.CompletedProcess[str]) -> bool:
 
 
 def _gh_cmd() -> str:
-    """Return ``gh-cached`` if available, otherwise ``gh``."""
+    """Return ``gh-cached`` if available and functional, otherwise ``gh``.
+
+    Beyond checking PATH availability, we probe with ``--version`` to catch
+    broken Python runtimes (e.g. unaccepted Xcode license, missing interpreter).
+    The probe is lightweight -- ``gh-cached --version`` delegates to
+    ``gh --version`` with no API calls and no cache interaction.
+    """
     if shutil.which("gh-cached"):
-        return "gh-cached"
+        try:
+            subprocess.run(
+                ["gh-cached", "--version"],
+                capture_output=True,
+                timeout=5,
+                check=True,
+            )
+            return "gh-cached"
+        except (subprocess.SubprocessError, OSError):
+            pass
     return "gh"
 
 

--- a/loom-tools/src/loom_tools/validate_phase.py
+++ b/loom-tools/src/loom_tools/validate_phase.py
@@ -104,10 +104,25 @@ def _find_repo_root(start: Path | None = None) -> Path:
 
 
 def _gh_cmd(repo_root: Path) -> str:
-    """Return ``gh-cached`` when available, else plain ``gh``."""
+    """Return ``gh-cached`` when available and functional, else plain ``gh``.
+
+    Beyond checking the executable bit, we probe with ``--version`` to catch
+    broken Python runtimes (e.g. unaccepted Xcode license, missing interpreter).
+    The probe is lightweight -- ``gh-cached --version`` delegates to
+    ``gh --version`` with no API calls and no cache interaction.
+    """
     cached = repo_root / ".loom" / "scripts" / "gh-cached"
     if cached.is_file() and cached.stat().st_mode & 0o111:
-        return str(cached)
+        try:
+            subprocess.run(
+                [str(cached), "--version"],
+                capture_output=True,
+                timeout=5,
+                check=True,
+            )
+            return str(cached)
+        except (subprocess.SubprocessError, OSError):
+            pass
     return "gh"
 
 

--- a/loom-tools/tests/test_github.py
+++ b/loom-tools/tests/test_github.py
@@ -11,6 +11,7 @@ import pytest
 
 from loom_tools.common.github import (
     ApiMode,
+    _gh_cmd,
     _is_rate_limited,
     _normalize_rest_entity,
     _normalize_rest_labels,
@@ -768,3 +769,59 @@ class TestGhPrListWrapper:
         mock_list.assert_called_once_with(
             "pr", labels=["ready"], state="open", fields=["url"]
         )
+
+
+# ---------------------------------------------------------------------------
+# _gh_cmd (runtime verification of gh-cached)
+# ---------------------------------------------------------------------------
+
+
+class TestGhCmd:
+    """Tests for _gh_cmd runtime verification of gh-cached."""
+
+    def test_returns_gh_cached_when_available_and_functional(self) -> None:
+        """gh-cached is used when found on PATH and --version succeeds."""
+        with mock.patch("loom_tools.common.github.shutil.which", return_value="/usr/local/bin/gh-cached"):
+            with mock.patch("loom_tools.common.github.subprocess.run") as mock_run:
+                mock_run.return_value = mock.Mock(returncode=0)
+                assert _gh_cmd() == "gh-cached"
+
+                # Verify --version probe was called
+                mock_run.assert_called_once_with(
+                    ["gh-cached", "--version"],
+                    capture_output=True,
+                    timeout=5,
+                    check=True,
+                )
+
+    def test_falls_back_to_gh_when_version_fails(self) -> None:
+        """Falls back to gh when gh-cached --version returns non-zero."""
+        with mock.patch("loom_tools.common.github.shutil.which", return_value="/usr/local/bin/gh-cached"):
+            with mock.patch(
+                "loom_tools.common.github.subprocess.run",
+                side_effect=subprocess.CalledProcessError(1, "gh-cached"),
+            ):
+                assert _gh_cmd() == "gh"
+
+    def test_falls_back_to_gh_when_version_times_out(self) -> None:
+        """Falls back to gh when gh-cached --version times out."""
+        with mock.patch("loom_tools.common.github.shutil.which", return_value="/usr/local/bin/gh-cached"):
+            with mock.patch(
+                "loom_tools.common.github.subprocess.run",
+                side_effect=subprocess.TimeoutExpired("gh-cached", 5),
+            ):
+                assert _gh_cmd() == "gh"
+
+    def test_falls_back_to_gh_when_os_error(self) -> None:
+        """Falls back to gh when gh-cached triggers an OSError (broken interpreter)."""
+        with mock.patch("loom_tools.common.github.shutil.which", return_value="/usr/local/bin/gh-cached"):
+            with mock.patch(
+                "loom_tools.common.github.subprocess.run",
+                side_effect=OSError("No such file or directory"),
+            ):
+                assert _gh_cmd() == "gh"
+
+    def test_falls_back_to_gh_when_not_on_path(self) -> None:
+        """Falls back to gh when gh-cached is not found on PATH."""
+        with mock.patch("loom_tools.common.github.shutil.which", return_value=None):
+            assert _gh_cmd() == "gh"

--- a/loom-tools/tests/test_validate_phase.py
+++ b/loom-tools/tests/test_validate_phase.py
@@ -22,6 +22,7 @@ from loom_tools.validate_phase import (
     _parse_args,
     _gather_builder_diagnostics,
     _build_recovery_pr_body,
+    _gh_cmd,
     _is_rate_limited_builder_exit,
     VALID_PHASES,
 )
@@ -1687,3 +1688,94 @@ class TestCLI:
         with pytest.raises(SystemExit) as exc:
             main(["curator", "42"])
         assert exc.value.code == 0  # recovered counts as success
+
+
+# ---------------------------------------------------------------------------
+# _gh_cmd (runtime verification of gh-cached)
+# ---------------------------------------------------------------------------
+
+
+class TestGhCmdValidatePhase:
+    """Tests for _gh_cmd runtime verification of gh-cached in validate_phase."""
+
+    def test_returns_gh_cached_when_available_and_functional(self, tmp_path: Path) -> None:
+        """gh-cached is used when the file is executable and --version succeeds."""
+        scripts_dir = tmp_path / ".loom" / "scripts"
+        scripts_dir.mkdir(parents=True)
+        cached = scripts_dir / "gh-cached"
+        cached.write_text("#!/bin/sh\ngh \"$@\"")
+        cached.chmod(0o755)
+
+        with patch("loom_tools.validate_phase.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            result = _gh_cmd(tmp_path)
+
+        assert result == str(cached)
+        mock_run.assert_called_once_with(
+            [str(cached), "--version"],
+            capture_output=True,
+            timeout=5,
+            check=True,
+        )
+
+    def test_falls_back_to_gh_when_version_fails(self, tmp_path: Path) -> None:
+        """Falls back to gh when gh-cached --version returns non-zero."""
+        scripts_dir = tmp_path / ".loom" / "scripts"
+        scripts_dir.mkdir(parents=True)
+        cached = scripts_dir / "gh-cached"
+        cached.write_text("#!/bin/sh\nexit 1")
+        cached.chmod(0o755)
+
+        with patch(
+            "loom_tools.validate_phase.subprocess.run",
+            side_effect=subprocess.CalledProcessError(1, str(cached)),
+        ):
+            result = _gh_cmd(tmp_path)
+
+        assert result == "gh"
+
+    def test_falls_back_to_gh_when_version_times_out(self, tmp_path: Path) -> None:
+        """Falls back to gh when gh-cached --version times out."""
+        scripts_dir = tmp_path / ".loom" / "scripts"
+        scripts_dir.mkdir(parents=True)
+        cached = scripts_dir / "gh-cached"
+        cached.write_text("#!/bin/sh\nsleep 999")
+        cached.chmod(0o755)
+
+        with patch(
+            "loom_tools.validate_phase.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(str(cached), 5),
+        ):
+            result = _gh_cmd(tmp_path)
+
+        assert result == "gh"
+
+    def test_falls_back_to_gh_when_os_error(self, tmp_path: Path) -> None:
+        """Falls back to gh on OSError (e.g., broken Python interpreter)."""
+        scripts_dir = tmp_path / ".loom" / "scripts"
+        scripts_dir.mkdir(parents=True)
+        cached = scripts_dir / "gh-cached"
+        cached.write_text("#!/bin/sh\nexit 0")
+        cached.chmod(0o755)
+
+        with patch(
+            "loom_tools.validate_phase.subprocess.run",
+            side_effect=OSError("No such file or directory"),
+        ):
+            result = _gh_cmd(tmp_path)
+
+        assert result == "gh"
+
+    def test_falls_back_to_gh_when_file_missing(self, tmp_path: Path) -> None:
+        """Falls back to gh when gh-cached does not exist."""
+        assert _gh_cmd(tmp_path) == "gh"
+
+    def test_falls_back_to_gh_when_not_executable(self, tmp_path: Path) -> None:
+        """Falls back to gh when gh-cached exists but is not executable."""
+        scripts_dir = tmp_path / ".loom" / "scripts"
+        scripts_dir.mkdir(parents=True)
+        cached = scripts_dir / "gh-cached"
+        cached.write_text("#!/bin/sh\ngh \"$@\"")
+        cached.chmod(0o644)  # Not executable
+
+        assert _gh_cmd(tmp_path) == "gh"


### PR DESCRIPTION
## Summary
When the Python runtime is broken (e.g., unaccepted Xcode license, missing interpreter, corrupted venv), scripts that select `gh-cached` based solely on the executable bit commit to using a non-functional wrapper, causing every subsequent `gh` call to fail with a misleading auth error. This PR adds a lightweight `--version` invocation probe that falls back to bare `gh` when the probe fails.

## Changes
- **Shell scripts** (`merge-pr.sh`, `agent-wait-bg.sh`, `stale-building-check.sh`): Added `&& "$GH_CACHED" --version &>/dev/null` to the existing `-x` check, suppressing any unexpected stderr output (e.g., Xcode license prompt)
- **Python module** (`github.py`): Added `subprocess.run(["gh-cached", "--version"], capture_output=True, timeout=5, check=True)` after the `shutil.which` check, catching `SubprocessError` and `OSError`
- **Python module** (`validate_phase.py`): Same probe pattern after the `is_file()` + executable-bit check
- **Tests** (`test_github.py`): 5 new tests covering functional, non-zero exit, timeout, OSError, and missing-from-PATH scenarios
- **Tests** (`test_validate_phase.py`): 6 new tests covering functional, non-zero exit, timeout, OSError, missing file, and non-executable scenarios

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Shell scripts add `--version` runtime probe | Done | All 3 scripts in `defaults/scripts/` updated with `&& "$GH_CACHED" --version &>/dev/null` |
| Python `github.py` adds subprocess probe | Done | `_gh_cmd()` now runs `subprocess.run(["gh-cached", "--version"], ...)` with 5s timeout |
| Python `validate_phase.py` adds subprocess probe | Done | `_gh_cmd(repo_root)` now runs `subprocess.run([str(cached), "--version"], ...)` with 5s timeout |
| Fallback to `gh` when probe fails | Done | All exception paths (CalledProcessError, TimeoutExpired, OSError) tested |
| Automated tests for broken gh-cached fallback | Done | 11 new test cases across both test files, all passing |
| `--version` probe is lightweight (no API calls) | Done | `gh-cached --version` delegates to `gh --version` with no cache/API interaction |
| `&>/dev/null` suppresses Xcode prompt in shell | Done | stderr/stdout redirected via `&>/dev/null` |
| 5-second timeout prevents hanging in Python | Done | `timeout=5` parameter set on both subprocess calls |

## Test Plan
- All 177 existing + new tests pass (`pytest test_github.py test_validate_phase.py` -- 75 + 102)
- Shell scripts pass `bash -n` syntax check
- Python files pass `py_compile` check

Closes #3076