### PR TITLE
fix: add fallback repo detection via git remote URL parsing

### DIFF
--- a/defaults/scripts/agent-wait-bg.sh
+++ b/defaults/scripts/agent-wait-bg.sh
@@ -44,6 +44,17 @@ else
     GH="gh"
 fi
 
+# Auto-detect owner/repo with fallback for worktree contexts
+detect_repo_nwo() {
+  local nwo
+  nwo="$($GH repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)" && [[ -n "$nwo" ]] && echo "$nwo" && return 0
+  nwo="$(cd "$REPO_ROOT" && git remote get-url origin 2>/dev/null | sed -E 's|\.git$||; s|.*[:/]([^/]+/[^/]+)$|\1|')" && [[ -n "$nwo" ]] && echo "$nwo" && return 0
+  return 1
+}
+
+# Cache repo NWO to avoid repeated detection
+REPO_NWO="$(detect_repo_nwo)" || REPO_NWO=""
+
 # tmux configuration (must match agent-spawn.sh)
 TMUX_SOCKET="loom"
 SESSION_PREFIX="loom-"
@@ -279,7 +290,7 @@ check_signals() {
     # Check per-issue abort label
     if [ -n "$issue" ]; then
         local labels
-        labels=$($GH issue view "$issue" --repo "$($GH repo view --json nameWithOwner --jq '.nameWithOwner')" --json labels --jq '.labels[].name' 2>/dev/null || true)
+        labels=$($GH issue view "$issue" ${REPO_NWO:+--repo "$REPO_NWO"} --json labels --jq '.labels[].name' 2>/dev/null || true)
         if echo "$labels" | grep -q "loom:abort"; then
             log_warn "Abort signal detected for issue #${issue}"
             return 0

--- a/defaults/scripts/merge-pr.sh
+++ b/defaults/scripts/merge-pr.sh
@@ -64,8 +64,20 @@ else
     GH="gh"
 fi
 
-# Auto-detect owner/repo from git remote
-REPO_NWO="$($GH repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)" || \
+# Auto-detect owner/repo with fallback for worktree contexts
+# Primary: gh repo view (uses GitHub API, most reliable when authenticated)
+# Fallback: parse git remote URL (local operation, works when gh fails in worktrees)
+detect_repo_nwo() {
+  local nwo
+  # Try gh repo view first (works in most cases)
+  nwo="$($GH repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)" && [[ -n "$nwo" ]] && echo "$nwo" && return 0
+  # Fallback: parse origin remote URL from the main repo root
+  # Handles both HTTPS (https://github.com/owner/repo.git) and SSH (git@github.com:owner/repo.git)
+  nwo="$(cd "$REPO_ROOT" && git remote get-url origin 2>/dev/null | sed -E 's|\.git$||; s|.*[:/]([^/]+/[^/]+)$|\1|')" && [[ -n "$nwo" ]] && echo "$nwo" && return 0
+  return 1
+}
+
+REPO_NWO="$(detect_repo_nwo)" || \
   error "Could not determine repository. Is 'gh' authenticated?"
 
 # Parse arguments

--- a/defaults/scripts/test-plan-metrics.sh
+++ b/defaults/scripts/test-plan-metrics.sh
@@ -58,9 +58,13 @@ LIMIT=50
 REPO_SLUG=""
 
 # Cache repo slug to avoid repeated API calls
+# Uses gh repo view with fallback to git remote URL parsing for worktree contexts
 get_repo_slug() {
     if [[ -z "$REPO_SLUG" ]]; then
         REPO_SLUG=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || echo "")
+        if [[ -z "$REPO_SLUG" ]]; then
+            REPO_SLUG=$(git remote get-url origin 2>/dev/null | sed -E 's|\.git$||; s|.*[:/]([^/]+/[^/]+)$|\1|' || echo "")
+        fi
     fi
     echo "$REPO_SLUG"
 }


### PR DESCRIPTION
## Summary
Adds a two-step fallback for repository owner/repo detection in `merge-pr.sh` and hardens the same pattern in two other scripts. When `gh repo view` fails in worktree contexts, the scripts now fall back to parsing the git remote URL locally.

## Changes
- **`defaults/scripts/merge-pr.sh`** (primary fix): Extracted `detect_repo_nwo()` function with `gh repo view` as primary and `git remote get-url origin` parsing as fallback. Error only fires if both methods fail.
- **`defaults/scripts/agent-wait-bg.sh`** (hardening): Added same `detect_repo_nwo()` function and cached `REPO_NWO` variable. Updated `check_signals()` to use cached value instead of inline `gh repo view` call.
- **`defaults/scripts/test-plan-metrics.sh`** (hardening): Added fallback to `get_repo_slug()` that parses git remote URL when `gh repo view` returns empty.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| merge-pr.sh uses two-step fallback: gh repo view first, then git remote get-url origin parsing | Pass | `detect_repo_nwo()` function tries `gh repo view`, then falls back to `git remote get-url origin` parsing via `cd "$REPO_ROOT"` |
| Fallback correctly parses both HTTPS and SSH remote URLs | Pass | Tested sed pattern `s\|\.git$\|\|; s\|.*[:/]([^/]+/[^/]+)$\|\1\|` against HTTPS with/without .git, SSH with/without .git, and repos with dots in names |
| Running merge-pr.sh from worktree succeeds when gh repo view fails | Pass | Fallback uses `cd "$REPO_ROOT" && git remote get-url origin` which is a local operation independent of gh auth |
| Error message only appears if BOTH detection methods fail | Pass | `detect_repo_nwo` returns 1 only when both methods fail; the `\|\|` chain on the caller triggers the error |
| Existing behavior unchanged when gh repo view succeeds | Pass | Primary path (`gh repo view`) is tried first and short-circuits on success |

## Test Plan
- Verified all three scripts pass `bash -n` syntax check
- Tested sed regex against HTTPS with .git, HTTPS without .git, SSH with .git, SSH without .git, and repo names containing dots
- Verified `git remote get-url origin` works from inside the worktree directory
- Reviewed diff to confirm no out-of-scope changes

Closes #3072