### PR TITLE
docs: document batch orchestration pattern for merge mode

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -122,7 +122,7 @@ Merge mode:    Curator → loom:curated → [Champion auto-promotes] → loom:is
 ```
 
 When `--merge` is active:
-1. **Champion auto-promotes** all `loom:curated` issues to `loom:issue` using its 8-criterion quality evaluation (scope, clarity, feasibility, etc.) as a substitute for human review
+1. **Champion auto-promotes** all `loom:curated` issues to `loom:issue` using a simplified quality check (problem statement, at least one acceptance criterion, no `loom:blocked`) as a substitute for human review
 2. **Shepherds skip Gate 1** (the human approval check), proceeding directly from curation to building
 3. **Shepherds auto-merge** PRs after Judge approval (skip the manual merge gate)
 4. All auto-promoted items are marked with `[force-mode]` in their audit trail for traceability

--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -110,6 +110,42 @@ LOOM_ISSUE_STRATEGY=lifo /loom
 LOOM_ISSUE_STRATEGY=priority /loom
 ```
 
+## Batch Orchestration (Merge Mode)
+
+In the default issue lifecycle, a human must manually promote `loom:curated` issues to `loom:issue` before Builders can claim them. This human gate ensures oversight but becomes a bottleneck during high-throughput batch sessions.
+
+**Merge mode** (`--merge`) solves this by automating the approval gate:
+
+```
+Normal mode:   Curator → loom:curated → [human promotes] → loom:issue → Builder claims
+Merge mode:    Curator → loom:curated → [Champion auto-promotes] → loom:issue → Builder claims
+```
+
+When `--merge` is active:
+1. **Champion auto-promotes** all `loom:curated` issues to `loom:issue` using its 8-criterion quality evaluation (scope, clarity, feasibility, etc.) as a substitute for human review
+2. **Shepherds skip Gate 1** (the human approval check), proceeding directly from curation to building
+3. **Shepherds auto-merge** PRs after Judge approval (skip the manual merge gate)
+4. All auto-promoted items are marked with `[force-mode]` in their audit trail for traceability
+
+**Why no `loom:approved` label?** The `loom:issue` label already means "approved for work" (see `.github/labels.yml`). In normal mode, a human adds it; in merge mode, Champion adds it. The same label serves both cases, keeping the state machine simple. Adding a separate `loom:approved` label would require updating every agent that currently checks for `loom:issue` and would complicate the already-working workflow with no functional benefit.
+
+**Starting a batch session:**
+
+```bash
+# Start daemon with merge mode (implies --auto-build)
+./.loom/scripts/daemon.sh start --auto-build
+/loom --merge
+
+# Or combine in one step
+LOOM_FORCE_MODE=true ./.loom/scripts/daemon.sh start --auto-build
+```
+
+**Safety guarantees in merge mode:**
+- Judge review is never skipped (GitHub API prevents self-review, so label-based review always runs)
+- `loom:blocked` issues are respected (not auto-promoted)
+- Force-push and other destructive operations remain blocked
+- All actions are auditable via `[force-mode]` markers
+
 ## Daemon State File
 
 The daemon state file (`.loom/daemon-state.json`) provides comprehensive information for debugging, crash recovery, and system observability.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,8 @@ Launch the Loom desktop application for automated orchestration:
 
 **Merge Mode** enables: auto-promotion of proposals, auto-merge after Judge approval, audit trail with `[force-mode]` markers, safety guardrails still apply. Merge mode does **not** skip the Judge phase (code review always runs due to GitHub's self-review API restriction). Merge mode implies `--auto-build`.
 
+**Batch Orchestration Pattern**: In normal mode, the `loom:curated` -> `loom:issue` transition requires a human to promote the issue (the human approval gate). In batch/high-throughput sessions, use `--merge` mode to have Champion auto-promote `loom:curated` issues to `loom:issue`, replacing the manual gate with Champion's automated quality evaluation. No separate `loom:approved` label is needed -- `--merge` makes the existing lifecycle fully automatic.
+
 **Graceful shutdown**: `./.loom/scripts/daemon.sh stop` (or `touch .loom/stop-daemon`)
 
 ## Agent Roles

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -228,6 +228,17 @@ When running with `--merge`, the daemon enables aggressive autonomous developmen
 
 **Merge mode does NOT skip code review.** The Judge phase always runs, even in merge mode. This is because GitHub's API prevents self-approval of PRs (`gh pr review --approve` fails when the same user created the PR). Loom's label-based review system (`loom:review-requested` -> `loom:pr`) works around this restriction and functions identically in both normal and merge modes. Merge mode's value is auto-promotion and auto-merge, not review bypass.
 
+**Batch Orchestration Pattern**:
+
+In normal mode, the issue lifecycle requires a human gate: Curator adds `loom:curated`, then a human promotes to `loom:issue` before a Builder can claim it. This ensures human oversight of what gets built.
+
+In batch/high-throughput sessions (e.g., processing a large backlog), this human gate becomes a bottleneck. The `--merge` flag solves this by having the Champion role automatically promote `loom:curated` issues to `loom:issue`, replacing the human approval step with Champion's automated quality evaluation (8 criteria including scope, clarity, and feasibility). There is no need for a separate `loom:approved` label -- `--merge` mode makes the existing `loom:curated` -> `loom:issue` transition automatic.
+
+```
+Normal mode:   Curator → loom:curated → [human promotes] → loom:issue → Builder
+Merge mode:    Curator → loom:curated → [Champion auto-promotes] → loom:issue → Builder
+```
+
 **Example daemon workflow**:
 ```
 Daemon Loop:

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -232,7 +232,7 @@ When running with `--merge`, the daemon enables aggressive autonomous developmen
 
 In normal mode, the issue lifecycle requires a human gate: Curator adds `loom:curated`, then a human promotes to `loom:issue` before a Builder can claim it. This ensures human oversight of what gets built.
 
-In batch/high-throughput sessions (e.g., processing a large backlog), this human gate becomes a bottleneck. The `--merge` flag solves this by having the Champion role automatically promote `loom:curated` issues to `loom:issue`, replacing the human approval step with Champion's automated quality evaluation (8 criteria including scope, clarity, and feasibility). There is no need for a separate `loom:approved` label -- `--merge` mode makes the existing `loom:curated` -> `loom:issue` transition automatic.
+In batch/high-throughput sessions (e.g., processing a large backlog), this human gate becomes a bottleneck. The `--merge` flag solves this by having the Champion role automatically promote `loom:curated` issues to `loom:issue`, replacing the human approval step with Champion's simplified force-mode quality check (problem statement, at least one acceptance criterion, no `loom:blocked`). There is no need for a separate `loom:approved` label -- `--merge` mode makes the existing `loom:curated` -> `loom:issue` transition automatic.
 
 ```
 Normal mode:   Curator → loom:curated → [human promotes] → loom:issue → Builder


### PR DESCRIPTION
## Summary
Adds documentation explaining how `--merge` mode serves as the batch orchestration mechanism, bridging the `loom:curated` -> `loom:issue` gap without needing a separate `loom:approved` label.

## Changes
- **`defaults/CLAUDE.md`**: Added "Batch Orchestration Pattern" subsection under Merge Mode with a visual flow diagram showing normal vs merge mode issue lifecycle
- **`CLAUDE.md`** (installed repo root): Added a concise batch orchestration paragraph to the Daemon Mode section
- **`.loom/docs/daemon-reference.md`**: Added a full "Batch Orchestration (Merge Mode)" section covering the automated approval gate, rationale for not adding `loom:approved`, startup instructions, and safety guarantees

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Batch orchestration pattern is clearly documented | ✅ | Added to all 3 affected files with visual flow diagrams |
| `--merge` mode explained as the batch curation-to-building mechanism | ✅ | Each section explicitly ties `--merge` to Champion auto-promotion of `loom:curated` issues |
| No new labels introduced | ✅ | Documentation explains why `loom:approved` is unnecessary, respecting label policy |
| Non-merge-mode still requires human approval | ✅ | All sections explicitly contrast normal mode (human gate) vs merge mode (Champion auto-promote) |

## Test Plan
- Documentation-only change -- no code affected
- Verified pre-existing Rust build error in `loom-daemon/src/terminal.rs` is unrelated (present on base branch)
- Reviewed all 3 files for accuracy against existing `--merge` behavior documented in `defaults/CLAUDE.md` lines 219-229

Closes #3080