### PR TITLE
fix: write fallback settings.json when copy fails in agent config setup

### DIFF
--- a/loom-daemon/src/terminal.rs
+++ b/loom-daemon/src/terminal.rs
@@ -277,8 +277,26 @@ mod claude_config {
         let settings_dst = config_dir.join("settings.json");
         if !settings_dst.exists() {
             let settings_src = home_claude.join("settings.json");
-            if settings_src.exists() {
-                copy_settings_without_plugins(&settings_src, &settings_dst);
+            let copied = if settings_src.exists() {
+                copy_settings_without_plugins(&settings_src, &settings_dst)
+            } else {
+                false
+            };
+            if !copied && !settings_dst.exists() {
+                // The copy failed or source was missing.  Write a minimal
+                // fallback so Claude Code never falls back to the global
+                // ~/.claude/settings.json which may contain enabledPlugins.
+                // See issue #3065.
+                if settings_src.is_file() {
+                    log::warn!(
+                        "Failed to copy settings.json from {} — writing minimal \
+                         fallback to prevent enabledPlugins leak",
+                        settings_src.display()
+                    );
+                }
+                if let Err(e) = fs::write(&settings_dst, "{}\n") {
+                    log::warn!("Failed to write fallback settings.json: {e}");
+                }
             }
         }
 
@@ -666,6 +684,33 @@ mod claude_config {
 
             let dst = tmp.path().join("out.json");
             assert!(!copy_settings_without_plugins(&src, &dst));
+        }
+
+        #[test]
+        fn test_setup_creates_fallback_settings_when_source_missing() {
+            // When ~/.claude/settings.json doesn't exist, a minimal fallback
+            // should still be written to prevent Claude Code from falling back
+            // to the global settings file with enabledPlugins (#3065).
+            let tmp = tempfile::tempdir().unwrap();
+            let repo_root = tmp.path();
+            fs::create_dir_all(repo_root.join(".loom")).unwrap();
+
+            let result = setup_agent_config_dir("terminal-fallback-settings", repo_root);
+            assert!(result.is_some());
+            let config_dir = result.unwrap();
+
+            let settings = config_dir.join("settings.json");
+            assert!(
+                settings.exists(),
+                "Fallback settings.json should be created even when source is missing"
+            );
+
+            let data: serde_json::Value =
+                serde_json::from_str(&fs::read_to_string(&settings).unwrap()).unwrap();
+            assert!(
+                data.get("enabledPlugins").is_none(),
+                "enabledPlugins must not be present in fallback"
+            );
         }
     }
 }

--- a/loom-tools/src/loom_tools/common/claude_config.py
+++ b/loom-tools/src/loom_tools/common/claude_config.py
@@ -318,6 +318,17 @@ def validate_agent_config_dir(agent_name: str, repo_root: Path) -> bool:
         )
         return False
 
+    # settings.json must exist — without it, Claude Code falls back to the
+    # global ~/.claude/settings.json which may contain enabledPlugins,
+    # causing ghost sessions (issue #3065).
+    settings_file = config_dir / "settings.json"
+    if not settings_file.is_file():
+        log.debug(
+            "Agent config dir validation failed for %s: settings.json is missing",
+            agent_name,
+        )
+        return False
+
     # All mutable directories must exist.
     for dirname in _MUTABLE_DIRS:
         if not (config_dir / dirname).is_dir():
@@ -364,7 +375,19 @@ def setup_agent_config_dir(agent_name: str, repo_root: Path) -> Path:
     # mode and cause ghost sessions.  All other settings are preserved.
     settings_dst = config_dir / "settings.json"
     if not settings_dst.exists():
-        _copy_settings_without_plugins(home_claude / "settings.json", settings_dst)
+        copied = _copy_settings_without_plugins(home_claude / "settings.json", settings_dst)
+        if not copied and not settings_dst.exists():
+            # The copy failed or source was missing.  Write a minimal
+            # fallback so Claude Code never falls back to the global
+            # ~/.claude/settings.json which may contain enabledPlugins.
+            # See issue #3065.
+            if (home_claude / "settings.json").is_file():
+                log.warning(
+                    "Failed to copy settings.json from %s — writing minimal "
+                    "fallback to prevent enabledPlugins leak",
+                    home_claude / "settings.json",
+                )
+            settings_dst.write_text("{}\n")
 
     # Symlink Claude Code state file (onboarding completion, theme, etc.).
     # The state file lives at ~/.claude.json (or ~/.claude/.config.json),

--- a/loom-tools/tests/test_claude_config.py
+++ b/loom-tools/tests/test_claude_config.py
@@ -156,6 +156,49 @@ class TestSetupAgentConfigDir:
         assert dst.is_symlink(), ".claude.json should be symlinked"
         assert dst.resolve() == preferred.resolve()
 
+    def test_settings_json_fallback_when_source_missing(
+        self, mock_repo: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When ~/.claude/settings.json doesn't exist, a minimal fallback
+        settings.json is written to prevent Claude Code from falling back
+        to the global settings file with enabledPlugins (#3065)."""
+        import json
+
+        fake_home = mock_repo / "fake-home"
+        fake_home.mkdir()
+        (fake_home / ".claude").mkdir()
+        # No settings.json in fake home
+        monkeypatch.setattr(pathlib.Path, "home", staticmethod(lambda: fake_home))
+
+        config_dir = setup_agent_config_dir("test-agent", mock_repo)
+        settings_dst = config_dir / "settings.json"
+        assert settings_dst.exists(), "Fallback settings.json should be created"
+        assert not settings_dst.is_symlink(), "settings.json should NOT be a symlink"
+        data = json.loads(settings_dst.read_text())
+        assert "enabledPlugins" not in data
+        assert data == {}
+
+    def test_settings_json_fallback_when_copy_fails(
+        self, mock_repo: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When _copy_settings_without_plugins fails (corrupt source), a minimal
+        fallback settings.json is written (#3065)."""
+        import json
+
+        fake_home = mock_repo / "fake-home"
+        fake_home.mkdir()
+        (fake_home / ".claude").mkdir()
+        # Write corrupt settings.json
+        (fake_home / ".claude" / "settings.json").write_text("not valid json{{{")
+        monkeypatch.setattr(pathlib.Path, "home", staticmethod(lambda: fake_home))
+
+        config_dir = setup_agent_config_dir("test-agent", mock_repo)
+        settings_dst = config_dir / "settings.json"
+        assert settings_dst.exists(), "Fallback settings.json should be created"
+        data = json.loads(settings_dst.read_text())
+        assert "enabledPlugins" not in data
+        assert data == {}
+
     def test_missing_state_file_writes_fallback(
         self, mock_repo: pathlib.Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -645,6 +688,32 @@ class TestValidateAgentConfigDir:
 
         # Validation must now pass
         assert validate_agent_config_dir("test-agent", mock_repo) is True
+
+
+    def test_returns_false_when_settings_json_missing(
+        self, mock_repo: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Missing settings.json means Claude Code could fall back to
+        global settings with enabledPlugins, causing ghost sessions (#3065)."""
+        fake_home = mock_repo / "fake-home"
+        fake_home.mkdir()
+        (fake_home / ".claude").mkdir()
+        state_file = fake_home / ".claude.json"
+        state_file.write_text(
+            '{"hasCompletedOnboarding":true,"theme":"dark",'
+            '"effortCalloutDismissed":true,"opusProMigrationComplete":true}'
+        )
+        monkeypatch.setattr(pathlib.Path, "home", staticmethod(lambda: fake_home))
+
+        setup_agent_config_dir("test-agent", mock_repo)
+
+        # Remove settings.json to simulate incomplete setup
+        config_dir = mock_repo / ".loom" / "claude-config" / "test-agent"
+        settings = config_dir / "settings.json"
+        if settings.exists():
+            settings.unlink()
+
+        assert validate_agent_config_dir("test-agent", mock_repo) is False
 
 
 class TestCleanupAllAgentConfigDirs:


### PR DESCRIPTION
## Summary
Write a minimal fallback `settings.json` (empty JSON object) when `_copy_settings_without_plugins()` fails or the source file is missing, preventing Claude Code from falling back to the global `~/.claude/settings.json` which may contain `enabledPlugins` that cause ghost sessions in headless mode.

## Changes
- **`claude_config.py`**: In `setup_agent_config_dir()`, check the return value of `_copy_settings_without_plugins()` and write `{}` as fallback when the copy fails. Log a warning when the source exists but the copy failed.
- **`claude_config.py`**: Add `settings.json` existence check to `validate_agent_config_dir()` so the validate-cleanup-recreate recovery flow detects missing `settings.json`.
- **`terminal.rs`**: Mirror the Python fallback logic in the Rust `setup_agent_config_dir()` — write `{}` when copy fails or source is missing.
- **`test_claude_config.py`**: Add 3 new test cases: fallback when source missing, fallback when copy fails (corrupt JSON), and validation failure when `settings.json` is missing.
- **`terminal.rs` (tests)**: Add Rust test for fallback `settings.json` creation when source is missing.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Fallback settings.json written when source missing | Pass | `test_settings_json_fallback_when_source_missing` passes |
| Fallback settings.json written when copy fails | Pass | `test_settings_json_fallback_when_copy_fails` passes |
| enabledPlugins not present in fallback | Pass | Both tests verify `enabledPlugins` not in output |
| validate_agent_config_dir rejects missing settings.json | Pass | `test_returns_false_when_settings_json_missing` passes |
| Warning logged on copy failure with existing source | Pass | Code review confirms `log.warning()` call |
| Rust parity | Pass | Same fallback logic added to terminal.rs |
| Existing tests still pass | Pass | All 48 Python tests pass |

## Test Plan
- All 48 Python tests pass (`pytest loom-tools/tests/test_claude_config.py -v`)
- Rust tests have a pre-existing build failure in `keychain_service_name()` from sha2 0.11.0 API change (unrelated to this PR, present on main worktree too after dependency bump)

Closes #3065