### PR TITLE
fix: remove hardcoded model from agent definitions to inherit parent model

### DIFF
--- a/defaults/.claude/agents/loom-architect.md
+++ b/defaults/.claude/agents/loom-architect.md
@@ -2,7 +2,6 @@
 name: loom-architect
 description: Loom Architect - System design specialist that scans the codebase for improvement opportunities and creates comprehensive architectural proposals with loom:architect label.
 tools: Read, Glob, Grep, Bash
-model: opus
 ---
 
 You are the Loom Architect (System Design Specialist) for the {{workspace}} repository.

--- a/defaults/.claude/agents/loom-auditor.md
+++ b/defaults/.claude/agents/loom-auditor.md
@@ -2,7 +2,6 @@
 name: loom-auditor
 description: Loom Auditor - Verification specialist that validates claims made by other agents by building and testing software at runtime. Checks PRs with loom:pr label and verifies they work as described.
 tools: Read, Glob, Grep, Bash
-model: sonnet
 ---
 
 You are the Loom Auditor (Runtime Verification Specialist) for the {{workspace}} repository.

--- a/defaults/.claude/agents/loom-builder.md
+++ b/defaults/.claude/agents/loom-builder.md
@@ -2,7 +2,6 @@
 name: loom-builder
 description: Loom Builder - Development worker that implements issues labeled loom:issue. Use when implementing features, fixing bugs, writing tests, or creating PRs for approved issues.
 tools: Read, Glob, Grep, Bash, Write, Edit, Task
-model: opus
 ---
 
 You are the Loom Builder (Development Worker) for the {{workspace}} repository.

--- a/defaults/.claude/agents/loom-champion.md
+++ b/defaults/.claude/agents/loom-champion.md
@@ -2,7 +2,6 @@
 name: loom-champion
 description: Loom Champion - Human avatar that promotes quality issues to approved status AND auto-merges Judge-approved PRs meeting safety criteria. Use for final approval decisions.
 tools: Read, Glob, Grep, Bash
-model: sonnet
 ---
 
 You are the Loom Champion for the {{workspace}} repository.

--- a/defaults/.claude/agents/loom-curator.md
+++ b/defaults/.claude/agents/loom-curator.md
@@ -2,7 +2,6 @@
 name: loom-curator
 description: Loom Curator - Issue enhancement specialist that enriches unlabeled issues with technical details, acceptance criteria, and implementation guidance, then marks them as loom:curated.
 tools: Read, Glob, Grep, Bash
-model: sonnet
 ---
 
 You are the Loom Curator (Issue Enhancement Specialist) for the {{workspace}} repository.

--- a/defaults/.claude/agents/loom-daemon.md
+++ b/defaults/.claude/agents/loom-daemon.md
@@ -2,7 +2,6 @@
 name: loom-daemon
 description: Loom Daemon - Layer 2 system orchestrator that monitors system state, generates work by triggering Architect/Hermit, and scales shepherd pool based on demand. Use for fully autonomous development.
 tools: Read, Glob, Grep, Bash, Task
-model: sonnet
 ---
 
 You are the Loom Daemon (Layer 2 System Orchestrator) for the {{workspace}} repository.

--- a/defaults/.claude/agents/loom-doctor.md
+++ b/defaults/.claude/agents/loom-doctor.md
@@ -2,7 +2,6 @@
 name: loom-doctor
 description: Loom Doctor - PR fixer that addresses review feedback on PRs labeled loom:changes-requested, resolves merge conflicts, and fixes bugs. Returns PRs to review-ready state.
 tools: Read, Glob, Grep, Bash, Write, Edit
-model: sonnet
 ---
 
 You are the Loom Doctor (PR Fixer) for the {{workspace}} repository.

--- a/defaults/.claude/agents/loom-guide.md
+++ b/defaults/.claude/agents/loom-guide.md
@@ -2,7 +2,6 @@
 name: loom-guide
 description: Loom Guide - Issue triage specialist that continuously prioritizes loom:issue issues by managing loom:urgent labels to reflect current top priorities.
 tools: Read, Glob, Grep, Bash
-model: sonnet
 ---
 
 You are the Loom Guide (Triage Specialist) for the {{workspace}} repository.

--- a/defaults/.claude/agents/loom-hermit.md
+++ b/defaults/.claude/agents/loom-hermit.md
@@ -2,7 +2,6 @@
 name: loom-hermit
 description: Loom Hermit - Simplification specialist that identifies and proposes removal of unnecessary complexity, bloat, dead code, and over-engineering. Creates proposals with loom:hermit label.
 tools: Read, Glob, Grep, Bash
-model: sonnet
 ---
 
 You are the Loom Hermit (Simplification Specialist) for the {{workspace}} repository.

--- a/defaults/.claude/agents/loom-judge.md
+++ b/defaults/.claude/agents/loom-judge.md
@@ -2,7 +2,6 @@
 name: loom-judge
 description: Loom Judge - Code review specialist that reviews PRs labeled loom:review-requested. Use when reviewing pull requests for code quality, security, and best practices.
 tools: Read, Glob, Grep, Bash
-model: opus
 ---
 
 You are the Loom Judge (Code Review Specialist) for the {{workspace}} repository.

--- a/defaults/.claude/agents/loom-shepherd.md
+++ b/defaults/.claude/agents/loom-shepherd.md
@@ -2,7 +2,6 @@
 name: loom-shepherd
 description: Loom Shepherd - Single-issue lifecycle orchestrator that coordinates other role agents through the full development cycle from creation to merged PR. Use when orchestrating issue #N through Curator -> Builder -> Judge -> Doctor -> Merge phases.
 tools: Read, Glob, Grep, Bash, Task
-model: sonnet
 ---
 
 You are the Loom Shepherd for the {{workspace}} repository.

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -811,9 +811,11 @@ The daemon state file provides comprehensive information for debugging, crash re
 
 ### Model Selection Strategy
 
-Loom uses different AI models optimized for each role's task complexity. Model preferences are defined in each role's JSON metadata file via the `suggestedModel` field.
+Loom subagents inherit the model of the parent conversation. Agent definitions do not specify a `model:` field in their frontmatter, so the model used depends on how the parent session was launched. This avoids per-model quota bucket exhaustion where a hardcoded model assignment causes rate limit failures even when other model quotas are available.
 
-**Model assignments by role**:
+Model preferences for the Tauri App (terminal configuration) are defined in each role's JSON metadata file via the `suggestedModel` field. These are used by the Loom desktop application when launching terminals, not by Claude Code subagent routing.
+
+**Suggested models by role** (for Tauri App terminal configuration):
 
 | Role | Model | Rationale |
 |------|-------|-----------|

--- a/defaults/roles/shepherd.json
+++ b/defaults/roles/shepherd.json
@@ -1,7 +1,7 @@
 {
   "name": "Shepherd",
   "description": "Thin wrapper that invokes loom-shepherd.sh for deterministic issue orchestration (Curator → Builder → Judge → Merge)",
-  "suggestedModel": "haiku",
+  "suggestedModel": "sonnet",
   "defaultInterval": 0,
   "defaultIntervalPrompt": "",
   "autonomousRecommended": false,


### PR DESCRIPTION
## Summary
Remove hardcoded `model:` frontmatter from all 11 agent definition files so subagents inherit the parent conversation's model. This prevents per-model quota bucket exhaustion where a pinned model hits rate limits even when other model quotas are available. Also reconciles the shepherd role JSON discrepancy (haiku -> sonnet).

## Changes
- Removed `model: opus` from loom-architect, loom-builder, loom-judge agent definitions
- Removed `model: sonnet` from loom-auditor, loom-champion, loom-curator, loom-daemon, loom-doctor, loom-guide, loom-hermit, loom-shepherd agent definitions
- Updated `defaults/roles/shepherd.json` to change `suggestedModel` from `haiku` to `sonnet` (reconciling discrepancy with agent definition)
- Updated Model Selection Strategy section in `defaults/CLAUDE.md` to document that subagents inherit the parent model, and clarified that `suggestedModel` in role JSON is for Tauri App terminal configuration only

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| All `model:` lines removed from agent frontmatter (11 files) | PASS | Verified via `head -6` on all 11 files, no `model:` line present |
| `suggestedModel` values in role JSON remain unchanged | PASS | Only shepherd.json changed (intentional reconciliation); all others untouched |
| Shepherd role JSON discrepancy reconciled (haiku -> sonnet) | PASS | `defaults/roles/shepherd.json` now reads `"suggestedModel": "sonnet"` |
| CLAUDE.md Model Selection Strategy updated | PASS | Section now documents inheritance behavior and clarifies suggestedModel purpose |
| Agent definitions without `model:` correctly inherit parent model | PASS | Claude Code agent frontmatter without `model:` field inherits parent model by design |

## Test Plan
- Lint check passes (pnpm lint: 0 errors)
- Python test suite: 3838 passed, 13 pre-existing failures (unrelated shepherd phase test mocking issues)
- Manual verification: All 11 agent files have frontmatter without `model:` line
- Rust build failure in worktree is pre-existing (passes on main) due to stale cargo cache

Closes #3079