### PR TITLE
feat: make auto-build the default daemon startup mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,8 +73,8 @@ Launch the Loom desktop application for automated orchestration:
 ### 3. Daemon Mode (Layer 2)
 
 ```bash
-./.loom/scripts/daemon.sh start              # support roles only (default)
-./.loom/scripts/daemon.sh start --auto-build # also auto-spawn shepherds from queue
+./.loom/scripts/daemon.sh start                  # auto-build enabled (default)
+./.loom/scripts/daemon.sh start --no-auto-build  # support roles only
 ```
 
 ```bash
@@ -82,9 +82,9 @@ Launch the Loom desktop application for automated orchestration:
 /loom --merge   # Aggressive autonomous development
 ```
 
-**Default mode** (no flags): Daemon manages support roles only — judge, champion, doctor, auditor, curator, guide. Keeps the pipeline flowing for work humans have already initiated via `/shepherd <N>`. Does NOT auto-spawn shepherds.
+**Default mode** (no flags): Daemon manages support roles (judge, champion, doctor, auditor, curator, guide) AND auto-spawns shepherds from the `loom:issue` queue. Once orchestration is activated via `/loom`, issues are picked up and built automatically.
 
-**Auto-build mode** (`--auto-build` or `-a` flag): Also auto-picks issues from `loom:issue` queue and spawns shepherds. For fully autonomous runs where human intent is "build everything in the queue."
+**Support-only mode** (`--no-auto-build` flag): Daemon manages support roles only. Shepherds are NOT auto-spawned. Use `/shepherd <N>` to shepherd specific issues manually. The `--auto-build` / `-a` flag is retained for backward compatibility but is now a no-op (already the default).
 
 **Merge Mode** enables: auto-promotion of proposals, auto-merge after Judge approval, audit trail with `[force-mode]` markers, safety guardrails still apply. Merge mode does **not** skip the Judge phase (code review always runs due to GitHub's self-review API restriction). Merge mode implies `--auto-build`.
 

--- a/defaults/.claude/commands/loom.md
+++ b/defaults/.claude/commands/loom.md
@@ -55,8 +55,8 @@ The Loom daemon is not running.
 
 Start it from a terminal OUTSIDE Claude Code:
 
-  ./.loom/scripts/daemon.sh start                      # Support-only mode (default)
-  ./.loom/scripts/daemon.sh start --auto-build         # Also auto-spawn shepherds
+  ./.loom/scripts/daemon.sh start                      # Auto-build mode (default)
+  ./.loom/scripts/daemon.sh start --no-auto-build      # Support-only (no auto-spawn)
   ./.loom/scripts/daemon.sh start --timeout-min 120    # Auto-stop after 2 hours
 
 Then run /loom again to begin observing and orchestrating.
@@ -330,14 +330,14 @@ Loom has three layers of roles:
 
 **Starting the daemon (run OUTSIDE Claude Code):**
 ```
-./.loom/scripts/daemon.sh start                   Start daemon (support-only)
-./.loom/scripts/daemon.sh start --auto-build      Also auto-spawn shepherds
+./.loom/scripts/daemon.sh start                   Start daemon (auto-build, default)
+./.loom/scripts/daemon.sh start --no-auto-build   Support-only (no auto-spawn)
 ./.loom/scripts/daemon.sh start -t 180            Run for 3 hours then stop
 ./.loom/scripts/daemon.sh status                  Check if daemon is running
 ./.loom/scripts/daemon.sh stop                    Stop gracefully (waits for exit)
 ./.loom/scripts/daemon.sh stop --force            Stop immediately (SIGTERM)
 ./.loom/scripts/daemon.sh restart                 Stop + start
-./.loom/scripts/daemon.sh restart --auto-build    Restart with auto-build
+./.loom/scripts/daemon.sh restart --no-auto-build  Restart in support-only mode
 ```
 
 **Shepherd commands:**

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -192,11 +192,11 @@ Launch the Loom desktop application for automated orchestration with visual term
 Run the Loom daemon for fully autonomous system orchestration.
 
 ```bash
-# Start daemon in support-only mode (default — no auto-shepherd-spawning)
+# Start daemon with auto-build (default — auto-spawns shepherds from queue)
 ./.loom/scripts/daemon.sh start
 
-# Start daemon with auto-build enabled (also spawns shepherds from queue)
-./.loom/scripts/daemon.sh start --auto-build
+# Start daemon in support-only mode (no auto-shepherd-spawning)
+./.loom/scripts/daemon.sh start --no-auto-build
 
 # Activate orchestration from Claude Code (daemon must already be running)
 /loom
@@ -204,14 +204,14 @@ Run the Loom daemon for fully autonomous system orchestration.
 # Start with merge mode for aggressive autonomous development
 /loom --merge
 
-# In support-only mode, the daemon will:
+# By default, the daemon will:
 # 1. Monitor system state every 60 seconds
 # 2. Trigger Architect/Hermit when backlog is low
 # 3. Ensure Guide, Champion, Doctor, Auditor, Judge, Curator keep running
-# 4. NOT auto-spawn shepherds (use /shepherd <N> for specific issues)
+# 4. Auto-spawn shepherds for ready loom:issue issues
 
-# With --auto-build, also:
-# 3. Spawn shepherds for ready issues automatically
+# With --no-auto-build, shepherds are NOT auto-spawned
+# (use /shepherd <N> to shepherd specific issues manually)
 ```
 
 **Dual Daemon Prevention**: `/loom` uses session ID tracking to prevent multiple daemon instances from running simultaneously. If a second daemon is started, it will detect the conflict and refuse to start. The `daemon_session_id` field in `daemon-state.json` (format: `timestamp-PID`) enables each daemon to verify it still owns the state file before writing updates. This prevents state corruption when Claude Code sessions are auto-continued.

--- a/defaults/scripts/daemon.sh
+++ b/defaults/scripts/daemon.sh
@@ -20,7 +20,8 @@
 #   status             Print daemon status and exit
 #
 # Start options:
-#   --auto-build, -a   Enable automatic shepherd spawning from loom:issue queue
+#   --no-auto-build    Disable automatic shepherd spawning (support-only mode)
+#   --auto-build, -a   (default behavior, kept for backward compatibility)
 #   --timeout-min N    Stop daemon after N minutes (0 = no timeout)
 #   --debug, -d        Enable debug logging
 #
@@ -32,11 +33,11 @@
 #   --help, -h         Show this help
 #
 # Modes:
-#   (no flags)         Support-only: judge, champion, doctor, auditor, curator,
+#   (no flags)         Auto-build (default): support roles + auto-spawn shepherds
+#                      from loom:issue queue. Use /loom --merge for force mode.
+#   --no-auto-build    Support-only: judge, champion, doctor, auditor, curator,
 #                      guide run autonomously. Shepherds NOT auto-spawned.
 #                      Use /shepherd <N> to shepherd specific issues manually.
-#   --auto-build       Also auto-spawn shepherds from loom:issue queue.
-#                      Use /loom --merge in Claude Code for force mode on top.
 #
 # After starting, the /loom Claude Code skill detects the running daemon
 # via .loom/daemon-loop.pid and operates as a signal-writer + observer.
@@ -44,13 +45,13 @@
 # the daemon from within Claude Code without spawning subprocesses.
 #
 # Examples:
-#   ./.loom/scripts/daemon.sh start                # Start in support-only mode
-#   ./.loom/scripts/daemon.sh up --auto-build      # Start with auto-build
-#   ./.loom/scripts/daemon.sh stop                 # Graceful shutdown
-#   ./.loom/scripts/daemon.sh down --force         # Immediate SIGTERM
-#   ./.loom/scripts/daemon.sh restart              # Stop + start
-#   ./.loom/scripts/daemon.sh restart --auto-build # Stop + start with auto-build
-#   ./.loom/scripts/daemon.sh status               # Check if running
+#   ./.loom/scripts/daemon.sh start                    # Start with auto-build (default)
+#   ./.loom/scripts/daemon.sh start --no-auto-build    # Support-only mode
+#   ./.loom/scripts/daemon.sh stop                     # Graceful shutdown
+#   ./.loom/scripts/daemon.sh down --force             # Immediate SIGTERM
+#   ./.loom/scripts/daemon.sh restart                  # Stop + start
+#   ./.loom/scripts/daemon.sh restart --no-auto-build  # Stop + start support-only
+#   ./.loom/scripts/daemon.sh status                   # Check if running
 
 set -euo pipefail
 
@@ -267,8 +268,8 @@ cmd_start() {
     echo "  /loom"
     echo "  /loom --merge   # force mode: auto-promote + auto-merge"
     echo ""
-    echo "To enable automatic shepherd spawning, restart with --auto-build:"
-    echo "  $0 restart --auto-build"
+    echo "To disable auto-build (support-only mode), restart with --no-auto-build:"
+    echo "  $0 restart --no-auto-build"
 }
 
 # ── Command: restart ─────────────────────────────────────────────────────────

--- a/loom-tools/src/loom_tools/daemon_v2/cli.py
+++ b/loom-tools/src/loom_tools/daemon_v2/cli.py
@@ -133,7 +133,7 @@ Environment Variables:
     LOOM_POLL_INTERVAL          Seconds between iterations (default: 120)
     LOOM_MAX_SHEPHERDS          Maximum concurrent shepherds (default: 10)
     LOOM_ISSUE_THRESHOLD        Trigger work generation when issues < this (default: 3)
-    LOOM_AUTO_BUILD             Enable shepherd auto-spawning (default: false)
+    LOOM_AUTO_BUILD             Enable shepherd auto-spawning (default: true)
     LOOM_ARCHITECT_COOLDOWN     Seconds between architect triggers (default: 1800)
     LOOM_HERMIT_COOLDOWN        Seconds between hermit triggers (default: 1800)
     LOOM_GUIDE_INTERVAL         Guide respawn interval (default: 900)
@@ -146,8 +146,8 @@ To stop the daemon gracefully:
     touch .loom/stop-daemon
 
 Examples:
-    loom-daemon                 # Start in support-only mode (no auto-spawn)
-    loom-daemon --auto-build    # Auto-spawn shepherds from loom:issue queue
+    loom-daemon                 # Start with auto-build (default)
+    loom-daemon --no-auto-build # Support-only mode (no auto-spawn)
     loom-daemon --force         # Force mode (auto-promote, auto-merge, auto-build)
     loom-daemon -t 180          # Run for 3 hours then gracefully stop
     loom-daemon --merge -t 60   # Merge mode for 1 hour
@@ -159,7 +159,12 @@ Examples:
     parser.add_argument(
         "--auto-build", "-a",
         action="store_true",
-        help="Enable automatic shepherd spawning from loom:issue queue",
+        help="Enable automatic shepherd spawning (default behavior, kept for backward compatibility)",
+    )
+    parser.add_argument(
+        "--no-auto-build",
+        action="store_true",
+        help="Disable automatic shepherd spawning (support-only mode)",
     )
     parser.add_argument(
         "--force", "-f",
@@ -214,9 +219,11 @@ Examples:
     # Create config (--merge is alias for --force; --force/--merge imply --auto-build)
     force_mode = args.force or args.merge
     auto_build = getattr(args, "auto_build", False)
+    no_auto_build = getattr(args, "no_auto_build", False)
     config = DaemonConfig.from_env(
         force_mode=force_mode,
         auto_build=auto_build,
+        no_auto_build=no_auto_build,
         debug_mode=args.debug,
         timeout_min=args.timeout_min,
     )

--- a/loom-tools/src/loom_tools/daemon_v2/config.py
+++ b/loom-tools/src/loom_tools/daemon_v2/config.py
@@ -40,7 +40,7 @@ class DaemonConfig:
     poll_interval: int = DEFAULT_POLL_INTERVAL
     iteration_timeout: int = DEFAULT_ITERATION_TIMEOUT
     force_mode: bool = False
-    auto_build: bool = False
+    auto_build: bool = True
     debug_mode: bool = False
     timeout_min: int = 0  # 0 = no timeout
 
@@ -79,6 +79,7 @@ class DaemonConfig:
         *,
         force_mode: bool = False,
         auto_build: bool = False,
+        no_auto_build: bool = False,
         debug_mode: bool = False,
         timeout_min: int = 0,
     ) -> DaemonConfig:
@@ -86,13 +87,19 @@ class DaemonConfig:
 
         Args:
             force_mode: Enable force mode (auto-promote, auto-merge)
-            auto_build: Enable automatic shepherd spawning from loom:issue queue
+            auto_build: Enable automatic shepherd spawning (kept for backward compat, now default)
+            no_auto_build: Explicitly disable automatic shepherd spawning
             debug_mode: Enable debug logging
             timeout_min: Stop daemon after N minutes (0 = no timeout)
         """
         resolved_force = force_mode or env_bool("LOOM_FORCE_MODE", False)
-        # --merge/--force implies --auto-build; also check LOOM_AUTO_BUILD env var
-        resolved_auto_build = auto_build or resolved_force or env_bool("LOOM_AUTO_BUILD", False)
+        # Auto-build is ON by default. Disabled only by explicit --no-auto-build flag
+        # or LOOM_AUTO_BUILD=false env var. --force/--merge always implies auto-build.
+        if no_auto_build and not resolved_force:
+            resolved_auto_build = False
+        else:
+            env_auto_build = env_bool("LOOM_AUTO_BUILD", True)
+            resolved_auto_build = env_auto_build or auto_build or resolved_force
         return cls(
             poll_interval=env_int("LOOM_POLL_INTERVAL", DEFAULT_POLL_INTERVAL),
             iteration_timeout=env_int("LOOM_ITERATION_TIMEOUT", DEFAULT_ITERATION_TIMEOUT),

--- a/loom-tools/tests/daemon_v2/test_auto_build_gate.py
+++ b/loom-tools/tests/daemon_v2/test_auto_build_gate.py
@@ -1,7 +1,8 @@
 """Tests for the auto_build gate in daemon iteration.
 
-When auto_build=False (the new default), spawn_shepherds must NOT be called
-even when the snapshot recommends it and shepherd slots are available.
+When auto_build=False (explicit opt-out via --no-auto-build), spawn_shepherds
+must NOT be called even when the snapshot recommends it and shepherd slots are
+available.
 """
 
 from __future__ import annotations

--- a/loom-tools/tests/daemon_v2/test_config.py
+++ b/loom-tools/tests/daemon_v2/test_config.py
@@ -18,7 +18,7 @@ class TestDaemonConfig:
         assert config.max_shepherds == 10
         assert config.issue_threshold == 3
         assert config.force_mode is False
-        assert config.auto_build is False
+        assert config.auto_build is True
         assert config.debug_mode is False
 
     def test_from_env_defaults(self):
@@ -65,11 +65,30 @@ class TestDaemonConfig:
             config = DaemonConfig.from_env()
             assert config.auto_build is True
 
-    def test_from_env_auto_build_false_by_default(self):
-        """Test auto_build is False by default (no env var)."""
+    def test_from_env_auto_build_true_by_default(self):
+        """Test auto_build is True by default (no env var)."""
         with patch.dict(os.environ, {}, clear=True):
             config = DaemonConfig.from_env()
+            assert config.auto_build is True
+
+    def test_no_auto_build_flag(self):
+        """Test --no-auto-build disables auto_build."""
+        with patch.dict(os.environ, {}, clear=True):
+            config = DaemonConfig.from_env(no_auto_build=True)
             assert config.auto_build is False
+
+    def test_no_auto_build_env_var_false(self):
+        """Test LOOM_AUTO_BUILD=false disables auto_build."""
+        with patch.dict(os.environ, {"LOOM_AUTO_BUILD": "false"}, clear=True):
+            config = DaemonConfig.from_env()
+            assert config.auto_build is False
+
+    def test_force_mode_overrides_no_auto_build(self):
+        """Test that force_mode=True overrides no_auto_build."""
+        with patch.dict(os.environ, {}, clear=True):
+            config = DaemonConfig.from_env(force_mode=True, no_auto_build=True)
+            assert config.force_mode is True
+            assert config.auto_build is True
 
     def test_force_mode_implies_auto_build(self):
         """Test that force_mode=True implies auto_build=True."""
@@ -84,13 +103,18 @@ class TestDaemonConfig:
             assert config.force_mode is True
             assert config.auto_build is True
 
-    def test_mode_display_support_only(self):
-        """Test mode display for default mode (no auto_build, no force)."""
+    def test_mode_display_default_is_auto_build(self):
+        """Test mode display for default mode is Auto-build."""
         config = DaemonConfig()
+        assert config.mode_display() == "Auto-build"
+
+    def test_mode_display_support_only(self):
+        """Test mode display for explicit support-only mode (auto_build=False)."""
+        config = DaemonConfig(auto_build=False)
         assert config.mode_display() == "Support-only"
 
     def test_mode_display_auto_build(self):
-        """Test mode display for auto-build mode."""
+        """Test mode display for explicit auto-build mode."""
         config = DaemonConfig(auto_build=True)
         assert config.mode_display() == "Auto-build"
 
@@ -100,8 +124,13 @@ class TestDaemonConfig:
         assert config.mode_display() == "Force"
 
     def test_mode_display_debug(self):
-        """Test mode display for debug mode."""
+        """Test mode display for debug mode (with default auto_build=True)."""
         config = DaemonConfig(debug_mode=True)
+        assert config.mode_display() == "Auto-build + Debug"
+
+    def test_mode_display_debug_support_only(self):
+        """Test mode display for debug + support-only mode."""
+        config = DaemonConfig(auto_build=False, debug_mode=True)
         assert config.mode_display() == "Debug"
 
     def test_mode_display_force_debug(self):


### PR DESCRIPTION
## Summary
Inverts the daemon default so that `daemon.sh start` enables auto-build (shepherd spawning from `loom:issue` queue) by default. Adds `--no-auto-build` flag for explicit support-only mode. The daemon still requires `/loom` activation before starting any work.

## Changes
- `DaemonConfig.auto_build` defaults to `True` instead of `False`
- `DaemonConfig.from_env()` accepts `no_auto_build` parameter; `LOOM_AUTO_BUILD` env var defaults to `true` when unset
- CLI: added `--no-auto-build` flag; `--auto-build`/`-a` retained for backward compat (now a no-op)
- `daemon.sh` (both `.loom/scripts/` and `defaults/scripts/`): updated comments, modes description, and startup banner message
- `mode_display()` returns "Auto-build" by default instead of "Support-only"
- All daemon_v2 tests updated to reflect new defaults (21 config tests, 2 gate tests)
- Documentation updated in CLAUDE.md, defaults/CLAUDE.md, and defaults/.claude/commands/loom.md

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `daemon.sh start` enables auto-build by default | PASS | `DaemonConfig.auto_build` defaults to `True`; verified via `test_default_values` and `test_from_env_auto_build_true_by_default` |
| New `--no-auto-build` flag disables shepherd spawning | PASS | Added to CLI and config; verified via `test_no_auto_build_flag` |
| `--auto-build` / `-a` retained for backward compat | PASS | Flag kept in argparse with updated help text |
| `DaemonConfig.auto_build` defaults to `True` | PASS | Changed on line 43 of config.py; `test_default_values` asserts `True` |
| `LOOM_AUTO_BUILD` env var defaults to `true` | PASS | `env_bool("LOOM_AUTO_BUILD", True)` in `from_env()`; `test_no_auto_build_env_var_false` confirms explicit `false` still works |
| `--force`/`--merge` continues to imply auto-build | PASS | `test_force_mode_implies_auto_build` and `test_force_mode_overrides_no_auto_build` both pass |
| Startup banner updated | PASS | Changed "To enable automatic shepherd spawning" to "To disable auto-build" |
| All documentation updated | PASS | CLAUDE.md, defaults/CLAUDE.md, defaults/.claude/commands/loom.md all updated |
| All tests updated | PASS | 209 daemon_v2 tests pass (21 config, 2 gate, 186 others) |
| `mode_display()` returns "Auto-build" by default | PASS | `test_mode_display_default_is_auto_build` verifies this |

## Test Plan
- `PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/daemon_v2/test_config.py -v` -- 21 passed
- `PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/daemon_v2/test_auto_build_gate.py -v` -- 2 passed
- `PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/daemon_v2/ -v` -- 209 passed (full daemon test suite)

Closes #3064