### PR TITLE
fix: make issue failure threshold configurable and exempt dependency blocks

### DIFF
--- a/loom-tools/src/loom_tools/common/issue_failures.py
+++ b/loom-tools/src/loom_tools/common/issue_failures.py
@@ -27,6 +27,7 @@ File format::
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -37,8 +38,13 @@ from loom_tools.common.state import read_json_file, write_json_file
 
 logger = logging.getLogger(__name__)
 
-# After this many total failures, auto-block the issue (default for most error classes)
-MAX_FAILURES_BEFORE_BLOCK = 5
+# After this many total failures, auto-block the issue (default for most error classes).
+# Override with LOOM_ISSUE_FAILURE_THRESHOLD env var for repos where early failures
+# are expected (e.g., greenfield projects with dependency chains).  See issue #3101.
+_DEFAULT_FAILURE_THRESHOLD = 5
+MAX_FAILURES_BEFORE_BLOCK = int(
+    os.environ.get("LOOM_ISSUE_FAILURE_THRESHOLD", str(_DEFAULT_FAILURE_THRESHOLD))
+)
 
 # Per-error-class block thresholds (lower = block sooner)
 # Budget exhaustion means the issue is too complex for a single session;
@@ -49,11 +55,13 @@ ERROR_CLASS_BLOCK_THRESHOLDS: dict[str, int] = {
 
 # Infrastructure error classes that should NOT count toward auto-blocking.
 # These represent environment/platform failures (MCP server down, auth timeout,
-# worktree branch conflicts), not problems with the issue itself.  Blocking an
-# issue for infrastructure failures is counterproductive — the issue would
-# succeed once infrastructure recovers.  See issue #2772, #2918.
+# worktree branch conflicts) or dependency ordering issues, not problems with
+# the issue itself.  Blocking an issue for infrastructure failures is
+# counterproductive — the issue would succeed once infrastructure recovers.
+# See issue #2772, #2918, #3101.
 INFRASTRUCTURE_ERROR_CLASSES: frozenset[str] = frozenset({
     "auth_infrastructure_failure",
+    "dependency_blocked",
     "mcp_infrastructure_failure",
     "worktree_conflict",
 })

--- a/loom-tools/tests/test_issue_failures.py
+++ b/loom-tools/tests/test_issue_failures.py
@@ -11,6 +11,7 @@ from loom_tools.common.issue_failures import (
     BACKOFF_BASE,
     INFRASTRUCTURE_ERROR_CLASSES,
     MAX_FAILURES_BEFORE_BLOCK,
+    _DEFAULT_FAILURE_THRESHOLD,
     IssueFailureEntry,
     IssueFailureLog,
     get_failure_entry,
@@ -81,6 +82,15 @@ class TestIssueFailureEntry:
             assert entry.should_auto_block is False, (
                 f"{error_class} should not auto-block"
             )
+
+    def test_dependency_blocked_never_auto_blocks(self) -> None:
+        """dependency_blocked is an infrastructure error and should never auto-block."""
+        assert "dependency_blocked" in INFRASTRUCTURE_ERROR_CLASSES
+        entry = IssueFailureEntry(
+            total_failures=MAX_FAILURES_BEFORE_BLOCK + 10,
+            error_class="dependency_blocked",
+        )
+        assert entry.should_auto_block is False
 
     def test_non_infrastructure_error_still_auto_blocks(self) -> None:
         """Non-infrastructure failures still auto-block at threshold."""
@@ -414,3 +424,33 @@ class TestIntegration:
         # Issue 42 should be in backoff, 99 should pass
         assert len(result) == 1
         assert result[0]["number"] == 99
+
+
+# ── Configurable threshold ────────────────────────────────────
+
+
+class TestConfigurableThreshold:
+    def test_default_threshold_value(self) -> None:
+        """Default threshold is 5 when env var is not set."""
+        assert _DEFAULT_FAILURE_THRESHOLD == 5
+
+    def test_env_var_overrides_threshold(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """LOOM_ISSUE_FAILURE_THRESHOLD env var overrides the default."""
+        monkeypatch.setenv("LOOM_ISSUE_FAILURE_THRESHOLD", "10")
+        # Re-import to pick up the env var change
+        import importlib
+
+        import loom_tools.common.issue_failures as mod
+
+        importlib.reload(mod)
+        try:
+            assert mod.MAX_FAILURES_BEFORE_BLOCK == 10
+        finally:
+            # Restore original value
+            monkeypatch.delenv("LOOM_ISSUE_FAILURE_THRESHOLD", raising=False)
+            importlib.reload(mod)
+
+    def test_entry_uses_module_level_threshold(self) -> None:
+        """IssueFailureEntry.block_threshold falls back to MAX_FAILURES_BEFORE_BLOCK."""
+        entry = IssueFailureEntry(total_failures=1, error_class="builder_stuck")
+        assert entry.block_threshold == MAX_FAILURES_BEFORE_BLOCK


### PR DESCRIPTION
## Summary

- Add `LOOM_ISSUE_FAILURE_THRESHOLD` env var to override the default failure threshold (5) before auto-blocking issues. Greenfield projects with dependency chains can set a higher value (e.g., `LOOM_ISSUE_FAILURE_THRESHOLD=10`) to avoid premature blocking.
- Add `dependency_blocked` to `INFRASTRUCTURE_ERROR_CLASSES` so dependency-related failures never count toward auto-blocking, since those issues will succeed once the dependency is resolved.
- Add tests for the configurable threshold (including env var override via module reload) and for the new `dependency_blocked` infrastructure error class.

## Test plan

- [x] All 43 tests in `test_issue_failures.py` pass
- [x] All 40 tests in `test_budget_exhaustion.py` pass (no regressions)
- [ ] Verify `LOOM_ISSUE_FAILURE_THRESHOLD=10 ./.loom/scripts/daemon.sh start` uses the higher threshold in a live daemon

Closes #3101

🤖 Generated with [Claude Code](https://claude.com/claude-code)