### PR TITLE
fix: stagger agent spawns to avoid auth cache thundering herd

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -21,6 +21,7 @@ Detailed configuration and state management for the Loom daemon (Layer 2).
 | `DOCTOR_INTERVAL` | 300 | Seconds between Doctor role re-triggers (5 min) |
 | `AUDITOR_INTERVAL` | 600 | Seconds between Auditor role re-triggers (10 min) |
 | `JUDGE_INTERVAL` | 300 | Seconds between Judge role re-triggers (5 min) |
+| `SPAWN_STAGGER` | 3 | Seconds between shepherd spawns to avoid auth cache contention |
 
 ## Work Generation
 

--- a/loom-tools/src/loom_tools/daemon_v2/actions/shepherds.py
+++ b/loom-tools/src/loom_tools/daemon_v2/actions/shepherds.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pathlib
 import subprocess
+import time
 from typing import TYPE_CHECKING, Any
 
 from loom_tools.agent_spawn import (
@@ -59,10 +60,20 @@ def spawn_shepherds(ctx: DaemonContext) -> int:
     issues_to_spawn = ready_issues[:available_slots]
     spawned = 0
 
+    stagger_delay = ctx.config.spawn_stagger_delay
+
     for issue in issues_to_spawn:
         issue_num = issue.get("number")
         if issue_num is None:
             continue
+
+        # Stagger spawns to avoid auth cache thundering herd.
+        # Each shepherd runs a pre-flight `claude auth status` check that
+        # contends on a shared lock file; spacing spawns apart lets each
+        # agent complete its auth check before the next one starts.
+        if spawned > 0 and stagger_delay > 0:
+            log_info(f"Staggering spawn by {stagger_delay}s to avoid auth contention")
+            time.sleep(stagger_delay)
 
         # Find an idle shepherd slot
         shepherd_name = _find_idle_shepherd(ctx)

--- a/loom-tools/src/loom_tools/daemon_v2/config.py
+++ b/loom-tools/src/loom_tools/daemon_v2/config.py
@@ -24,6 +24,7 @@ DEFAULT_JUDGE_INTERVAL = 300  # seconds
 DEFAULT_CURATOR_INTERVAL = 300  # seconds
 DEFAULT_STARTUP_GRACE_PERIOD = 120  # seconds before early warning
 DEFAULT_NO_PROGRESS_GRACE_PERIOD = 300  # seconds before hard reclaim
+DEFAULT_SPAWN_STAGGER_DELAY = 3  # seconds between shepherd spawns
 DEFAULT_STALL_DIAGNOSTIC_THRESHOLD = 3  # consecutive stalled iterations
 DEFAULT_STALL_RECOVERY_THRESHOLD = 5
 DEFAULT_STALL_RESTART_THRESHOLD = 10
@@ -67,6 +68,7 @@ class DaemonConfig:
     # Shepherd startup detection thresholds
     startup_grace_period: int = DEFAULT_STARTUP_GRACE_PERIOD
     no_progress_grace_period: int = DEFAULT_NO_PROGRESS_GRACE_PERIOD
+    spawn_stagger_delay: int = DEFAULT_SPAWN_STAGGER_DELAY
 
     # Stall escalation thresholds
     stall_diagnostic_threshold: int = DEFAULT_STALL_DIAGNOSTIC_THRESHOLD
@@ -113,6 +115,7 @@ class DaemonConfig:
             max_proposals=env_int("LOOM_MAX_PROPOSALS", DEFAULT_MAX_PROPOSALS),
             startup_grace_period=env_int("LOOM_STARTUP_GRACE_PERIOD", DEFAULT_STARTUP_GRACE_PERIOD),
             no_progress_grace_period=env_int("LOOM_NO_PROGRESS_GRACE_PERIOD", DEFAULT_NO_PROGRESS_GRACE_PERIOD),
+            spawn_stagger_delay=env_int("LOOM_SPAWN_STAGGER", DEFAULT_SPAWN_STAGGER_DELAY),
             architect_cooldown=env_int("LOOM_ARCHITECT_COOLDOWN", DEFAULT_ARCHITECT_COOLDOWN),
             hermit_cooldown=env_int("LOOM_HERMIT_COOLDOWN", DEFAULT_HERMIT_COOLDOWN),
             guide_interval=env_int("LOOM_GUIDE_INTERVAL", DEFAULT_GUIDE_INTERVAL),

--- a/loom-tools/tests/daemon_v2/test_shepherd_spawn.py
+++ b/loom-tools/tests/daemon_v2/test_shepherd_spawn.py
@@ -7,7 +7,7 @@ from unittest import mock
 
 import pytest
 
-from loom_tools.daemon_v2.actions.shepherds import _spawn_single_shepherd
+from loom_tools.daemon_v2.actions.shepherds import _spawn_single_shepherd, spawn_shepherds
 from loom_tools.daemon_v2.config import DaemonConfig
 from loom_tools.daemon_v2.context import DaemonContext
 from loom_tools.models.daemon_state import DaemonState, ShepherdEntry
@@ -84,3 +84,130 @@ class TestSpawnSingleShepherd:
 
         args = mock_spawn.call_args.kwargs.get("args", "")
         assert "--allow-dirty-main" in args
+
+
+class TestSpawnStagger:
+    """Tests for stagger delay between shepherd spawns."""
+
+    def _make_multi_ctx(
+        self,
+        tmp_path: pathlib.Path,
+        *,
+        spawn_stagger_delay: int = 3,
+        max_shepherds: int = 5,
+    ) -> DaemonContext:
+        """Create a DaemonContext with multiple idle shepherd slots."""
+        config = DaemonConfig(
+            spawn_stagger_delay=spawn_stagger_delay,
+            max_shepherds=max_shepherds,
+        )
+        ctx = DaemonContext(config=config, repo_root=tmp_path)
+        ctx.state = DaemonState()
+        ctx.snapshot = {
+            "pipeline": {
+                "ready_issues": [
+                    {"number": 1, "title": "Issue 1"},
+                    {"number": 2, "title": "Issue 2"},
+                    {"number": 3, "title": "Issue 3"},
+                ],
+            },
+            "computed": {
+                "available_shepherd_slots": 3,
+                "active_shepherds": 0,
+            },
+            "shepherds": {"progress": []},
+        }
+        # Pre-create idle shepherd slots
+        for i in range(1, 4):
+            ctx.state.shepherds[f"shepherd-{i}"] = ShepherdEntry(status="idle")
+        return ctx
+
+    @mock.patch("loom_tools.daemon_v2.actions.shepherds.time.sleep")
+    @mock.patch("loom_tools.daemon_v2.actions.shepherds._spawn_single_shepherd")
+    def test_stagger_delay_between_spawns(
+        self, mock_spawn, mock_sleep, tmp_path: pathlib.Path
+    ) -> None:
+        """Sleep is called between successful spawns, not before the first."""
+        mock_spawn.return_value = True
+        ctx = self._make_multi_ctx(tmp_path, spawn_stagger_delay=5)
+
+        spawned = spawn_shepherds(ctx)
+
+        assert spawned == 3
+        # Sleep should be called before 2nd and 3rd spawn, not before the 1st
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_called_with(5)
+
+    @mock.patch("loom_tools.daemon_v2.actions.shepherds.time.sleep")
+    @mock.patch("loom_tools.daemon_v2.actions.shepherds._spawn_single_shepherd")
+    def test_no_stagger_when_delay_is_zero(
+        self, mock_spawn, mock_sleep, tmp_path: pathlib.Path
+    ) -> None:
+        """No sleep when LOOM_SPAWN_STAGGER=0."""
+        mock_spawn.return_value = True
+        ctx = self._make_multi_ctx(tmp_path, spawn_stagger_delay=0)
+
+        spawned = spawn_shepherds(ctx)
+
+        assert spawned == 3
+        mock_sleep.assert_not_called()
+
+    @mock.patch("loom_tools.daemon_v2.actions.shepherds.time.sleep")
+    @mock.patch("loom_tools.daemon_v2.actions.shepherds._spawn_single_shepherd")
+    def test_no_stagger_for_single_spawn(
+        self, mock_spawn, mock_sleep, tmp_path: pathlib.Path
+    ) -> None:
+        """No sleep when only one shepherd is spawned."""
+        mock_spawn.return_value = True
+        ctx = self._make_multi_ctx(tmp_path, spawn_stagger_delay=3)
+        # Only one ready issue
+        ctx.snapshot["pipeline"]["ready_issues"] = [{"number": 1, "title": "Issue 1"}]
+
+        spawned = spawn_shepherds(ctx)
+
+        assert spawned == 1
+        mock_sleep.assert_not_called()
+
+    @mock.patch("loom_tools.daemon_v2.actions.shepherds.time.sleep")
+    @mock.patch("loom_tools.daemon_v2.actions.shepherds._spawn_single_shepherd")
+    def test_stagger_default_is_3_seconds(
+        self, mock_spawn, mock_sleep, tmp_path: pathlib.Path
+    ) -> None:
+        """Default stagger delay should be 3 seconds."""
+        mock_spawn.return_value = True
+        # Use default config
+        config = DaemonConfig()
+        ctx = DaemonContext(config=config, repo_root=tmp_path)
+        ctx.state = DaemonState()
+        ctx.snapshot = {
+            "pipeline": {
+                "ready_issues": [
+                    {"number": 1, "title": "Issue 1"},
+                    {"number": 2, "title": "Issue 2"},
+                ],
+            },
+            "computed": {
+                "available_shepherd_slots": 2,
+                "active_shepherds": 0,
+            },
+            "shepherds": {"progress": []},
+        }
+        ctx.state.shepherds["shepherd-1"] = ShepherdEntry(status="idle")
+        ctx.state.shepherds["shepherd-2"] = ShepherdEntry(status="idle")
+
+        spawned = spawn_shepherds(ctx)
+
+        assert spawned == 2
+        assert mock_sleep.call_count == 1
+        mock_sleep.assert_called_with(3)
+
+    def test_config_from_env_reads_spawn_stagger(self) -> None:
+        """LOOM_SPAWN_STAGGER env var is read by DaemonConfig.from_env."""
+        with mock.patch.dict("os.environ", {"LOOM_SPAWN_STAGGER": "7"}):
+            config = DaemonConfig.from_env()
+        assert config.spawn_stagger_delay == 7
+
+    def test_config_default_spawn_stagger(self) -> None:
+        """Default spawn stagger delay is 3 seconds."""
+        config = DaemonConfig()
+        assert config.spawn_stagger_delay == 3


### PR DESCRIPTION
## Summary

When the daemon spawns multiple shepherds in a single iteration, all their `claude auth status` pre-flight checks contend on the same lock file, causing 60s timeout cascades. This adds a configurable stagger delay between spawns.

- Add `LOOM_SPAWN_STAGGER` env var (default 3s) to `DaemonConfig`
- Insert `time.sleep(stagger_delay)` between successive shepherd spawns in `spawn_shepherds()`
- Delay only applies between spawns (not before the first one), and is skipped when set to 0
- 6 new tests covering stagger behavior, zero-delay bypass, single-spawn no-op, default value, and env var loading

## Test plan

- [x] All 9 tests in `test_shepherd_spawn.py` pass (3 existing + 6 new)
- [x] Full test suite passes (660/660, 1 pre-existing failure unrelated to this change)
- [ ] Manual verification: start daemon with 5+ ready issues and observe staggered spawns in logs

Closes #3094