### PR TITLE
fix: add comprehensive failure counter reset mechanism

### DIFF
--- a/defaults/scripts/reset-failures.sh
+++ b/defaults/scripts/reset-failures.sh
@@ -208,7 +208,7 @@ reset_all() {
     # 1. Clear issue-failures.json
     if [[ -f "$ISSUE_FAILURES" ]]; then
         cleared=$(jq '.entries | length' "$ISSUE_FAILURES" 2>/dev/null || echo "0")
-        echo '{"entries": {}, "updated_at": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"}' > "$ISSUE_FAILURES"
+        echo '{"entries": {}, "updated_at": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}' > "$ISSUE_FAILURES"
     fi
 
     # 2. Clear daemon-state.json failure fields
@@ -291,7 +291,7 @@ fi
 
 if [[ "$ALL_MODE" == "true" ]]; then
     if [[ "$SIGNAL_MODE" == "true" ]]; then
-        send_signal '{"action": "reset_failures", "all": true, "created_at": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"}'
+        send_signal '{"action": "reset_failures", "all": true, "created_at": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}'
     else
         reset_all
     fi
@@ -300,7 +300,7 @@ fi
 
 if [[ -n "$ISSUE_NUM" ]]; then
     if [[ "$SIGNAL_MODE" == "true" ]]; then
-        send_signal '{"action": "reset_failures", "issue": '"$ISSUE_NUM"', "created_at": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"}'
+        send_signal '{"action": "reset_failures", "issue": '"$ISSUE_NUM"', "created_at": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}'
     else
         reset_issue "$ISSUE_NUM"
     fi

--- a/defaults/scripts/reset-failures.sh
+++ b/defaults/scripts/reset-failures.sh
@@ -1,0 +1,312 @@
+#!/bin/bash
+# reset-failures.sh - Reset failure counters for issues
+#
+# Clears failure state from ALL three tracking locations:
+#   1. .loom/issue-failures.json  (persistent cross-session failure log)
+#   2. daemon-state.json blocked_issue_retries  (per-issue retry metadata)
+#   3. daemon-state.json recent_failures  (sliding window for systematic failure detection)
+#
+# Usage:
+#   reset-failures.sh <issue-number>     # Reset failures for a specific issue
+#   reset-failures.sh --all              # Reset all failure counters
+#   reset-failures.sh --signal <issue>   # Send reset signal to running daemon
+#   reset-failures.sh --signal --all     # Send reset-all signal to running daemon
+#   reset-failures.sh --list             # List current failure entries
+#   reset-failures.sh --help             # Show help
+#
+# When the daemon is running, use --signal to send an IPC signal so the
+# daemon's in-memory state is also updated. Without --signal, only the
+# on-disk files are modified (the daemon will pick up changes on next restart).
+
+set -euo pipefail
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Find the repository root
+find_repo_root() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.git" ]] || [[ -f "$dir/.git" ]]; then
+            if [[ -f "$dir/.git" ]]; then
+                local gitdir
+                gitdir=$(sed 's/^gitdir: //' "$dir/.git")
+                local main_repo
+                main_repo=$(dirname "$(dirname "$(dirname "$gitdir")")")
+                if [[ -d "$main_repo/.loom" ]]; then
+                    echo "$main_repo"
+                    return 0
+                fi
+            fi
+            if [[ -d "$dir/.loom" ]]; then
+                echo "$dir"
+                return 0
+            fi
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo "Error: Not in a git repository with .loom directory" >&2
+    return 1
+}
+
+REPO_ROOT=$(find_repo_root)
+LOOM_DIR="$REPO_ROOT/.loom"
+DAEMON_STATE="$LOOM_DIR/daemon-state.json"
+ISSUE_FAILURES="$LOOM_DIR/issue-failures.json"
+SIGNALS_DIR="$LOOM_DIR/signals"
+
+show_help() {
+    cat <<EOF
+${BLUE}reset-failures.sh - Reset failure counters for issues${NC}
+
+${YELLOW}USAGE:${NC}
+    reset-failures.sh <issue-number>       Reset failures for one issue
+    reset-failures.sh --all                Reset all failure counters
+    reset-failures.sh --signal <issue>     Send reset signal to running daemon
+    reset-failures.sh --signal --all       Send reset-all signal to running daemon
+    reset-failures.sh --list               List current failure entries
+    reset-failures.sh --help               Show this help
+
+${YELLOW}DESCRIPTION:${NC}
+    Failure state is tracked in three locations:
+      1. .loom/issue-failures.json        Persistent cross-session failure log
+      2. daemon-state.json                blocked_issue_retries (retry metadata)
+      3. daemon-state.json                recent_failures (systematic failure window)
+
+    This script clears ALL three locations atomically.
+
+${YELLOW}EXAMPLES:${NC}
+    # Reset failures for issue #42
+    reset-failures.sh 42
+
+    # Reset all failures
+    reset-failures.sh --all
+
+    # Reset via daemon signal (updates in-memory state too)
+    reset-failures.sh --signal 42
+
+    # List current failures
+    reset-failures.sh --list
+
+${YELLOW}NOTES:${NC}
+    Without --signal, only on-disk files are modified. If the daemon is
+    running, its in-memory state will be stale until the next restart.
+    Use --signal when the daemon is running to update both disk and memory.
+EOF
+}
+
+# List current failure entries
+list_failures() {
+    local has_data=false
+
+    echo -e "${BLUE}Failure tracking state:${NC}"
+    echo ""
+
+    # 1. Persistent failure log
+    if [[ -f "$ISSUE_FAILURES" ]]; then
+        local count
+        count=$(jq '.entries | length' "$ISSUE_FAILURES" 2>/dev/null || echo "0")
+        if [[ "$count" -gt 0 ]]; then
+            has_data=true
+            echo -e "  ${YELLOW}issue-failures.json${NC} ($count entries):"
+            jq -r '.entries | to_entries[] | "    #\(.key): \(.value.total_failures) failures (\(.value.error_class), phase=\(.value.phase))"' \
+                "$ISSUE_FAILURES" 2>/dev/null || true
+            echo ""
+        fi
+    fi
+
+    # 2. Daemon state blocked_issue_retries
+    if [[ -f "$DAEMON_STATE" ]]; then
+        local retry_count
+        retry_count=$(jq '.blocked_issue_retries | length' "$DAEMON_STATE" 2>/dev/null || echo "0")
+        if [[ "$retry_count" -gt 0 ]]; then
+            has_data=true
+            echo -e "  ${YELLOW}daemon-state.json blocked_issue_retries${NC} ($retry_count entries):"
+            jq -r '.blocked_issue_retries | to_entries[] | "    #\(.key): retries=\(.value.retry_count // 0), exhausted=\(.value.retry_exhausted // false), class=\(.value.error_class // "unknown")"' \
+                "$DAEMON_STATE" 2>/dev/null || true
+            echo ""
+        fi
+
+        # 3. Recent failures
+        local recent_count
+        recent_count=$(jq '.recent_failures | length' "$DAEMON_STATE" 2>/dev/null || echo "0")
+        if [[ "$recent_count" -gt 0 ]]; then
+            has_data=true
+            echo -e "  ${YELLOW}daemon-state.json recent_failures${NC} ($recent_count entries):"
+            jq -r '.recent_failures[-5:][] | "    #\(.issue): \(.error_class) (phase=\(.phase), at=\(.timestamp))"' \
+                "$DAEMON_STATE" 2>/dev/null || true
+            if [[ "$recent_count" -gt 5 ]]; then
+                echo "    ... and $((recent_count - 5)) more"
+            fi
+            echo ""
+        fi
+
+        # 4. Systematic failure
+        local sf_active
+        sf_active=$(jq -r '.systematic_failure.active // false' "$DAEMON_STATE" 2>/dev/null || echo "false")
+        if [[ "$sf_active" == "true" ]]; then
+            has_data=true
+            local pattern
+            pattern=$(jq -r '.systematic_failure.pattern // "unknown"' "$DAEMON_STATE" 2>/dev/null)
+            echo -e "  ${RED}Systematic failure ACTIVE${NC}: pattern=$pattern"
+            echo ""
+        fi
+    fi
+
+    if [[ "$has_data" == "false" ]]; then
+        echo -e "  ${GREEN}No failure entries found${NC}"
+    fi
+}
+
+# Reset failures for a specific issue (on-disk only)
+reset_issue() {
+    local issue_num="$1"
+    local cleared=0
+
+    # 1. Clear from issue-failures.json
+    if [[ -f "$ISSUE_FAILURES" ]]; then
+        local before
+        before=$(jq '.entries | length' "$ISSUE_FAILURES" 2>/dev/null || echo "0")
+        temp_file=$(mktemp)
+        if jq --arg key "$issue_num" 'del(.entries[$key])' "$ISSUE_FAILURES" > "$temp_file" 2>/dev/null; then
+            mv "$temp_file" "$ISSUE_FAILURES"
+            local after
+            after=$(jq '.entries | length' "$ISSUE_FAILURES" 2>/dev/null || echo "0")
+            cleared=$((before - after))
+        else
+            rm -f "$temp_file"
+        fi
+    fi
+
+    # 2. Clear from daemon-state.json
+    if [[ -f "$DAEMON_STATE" ]]; then
+        temp_file=$(mktemp)
+        if jq --arg key "$issue_num" --argjson inum "$issue_num" '
+            del(.blocked_issue_retries[$key]) |
+            .recent_failures = [.recent_failures[] | select(.issue != $inum)] |
+            .needs_human_input = [(.needs_human_input // [])[] | select(.type != "exhausted_retry" or .issue != $inum)]
+        ' "$DAEMON_STATE" > "$temp_file" 2>/dev/null; then
+            mv "$temp_file" "$DAEMON_STATE"
+        else
+            rm -f "$temp_file"
+        fi
+    fi
+
+    echo -e "${GREEN}✓ Reset failure tracking for issue #${issue_num}${NC}"
+    echo -e "  Cleared ${cleared} entry(ies) from issue-failures.json"
+    echo -e "  Cleared blocked_issue_retries and recent_failures entries from daemon-state.json"
+}
+
+# Reset all failures (on-disk only)
+reset_all() {
+    local cleared=0
+
+    # 1. Clear issue-failures.json
+    if [[ -f "$ISSUE_FAILURES" ]]; then
+        cleared=$(jq '.entries | length' "$ISSUE_FAILURES" 2>/dev/null || echo "0")
+        echo '{"entries": {}, "updated_at": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"}' > "$ISSUE_FAILURES"
+    fi
+
+    # 2. Clear daemon-state.json failure fields
+    if [[ -f "$DAEMON_STATE" ]]; then
+        temp_file=$(mktemp)
+        if jq '
+            .blocked_issue_retries = {} |
+            .recent_failures = [] |
+            .systematic_failure = {} |
+            .needs_human_input = [(.needs_human_input // [])[] | select(.type != "exhausted_retry")]
+        ' "$DAEMON_STATE" > "$temp_file" 2>/dev/null; then
+            mv "$temp_file" "$DAEMON_STATE"
+        else
+            rm -f "$temp_file"
+        fi
+    fi
+
+    echo -e "${GREEN}✓ Reset ALL failure tracking${NC}"
+    echo -e "  Cleared ${cleared} entry(ies) from issue-failures.json"
+    echo -e "  Cleared blocked_issue_retries, recent_failures, and systematic_failure from daemon-state.json"
+}
+
+# Send reset signal to running daemon
+send_signal() {
+    local payload="$1"
+
+    mkdir -p "$SIGNALS_DIR"
+    local ts
+    ts=$(date +%s%N | cut -c1-13)
+    local rand
+    rand=$(head -c 4 /dev/urandom | od -An -tx1 | tr -d ' \n')
+    local signal_file="$SIGNALS_DIR/cmd-${ts}-${rand}.json"
+
+    echo "$payload" > "$signal_file"
+    echo -e "${GREEN}✓ Reset signal sent to daemon${NC}"
+    echo -e "  Signal file: $signal_file"
+    echo -e "  The daemon will process this on its next poll cycle"
+}
+
+# Main
+SIGNAL_MODE=false
+ALL_MODE=false
+LIST_MODE=false
+ISSUE_NUM=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --help|-h)
+            show_help
+            exit 0
+            ;;
+        --list|-l)
+            LIST_MODE=true
+            shift
+            ;;
+        --signal|-s)
+            SIGNAL_MODE=true
+            shift
+            ;;
+        --all|-a)
+            ALL_MODE=true
+            shift
+            ;;
+        [0-9]*)
+            ISSUE_NUM="$1"
+            shift
+            ;;
+        *)
+            echo -e "${RED}Error: Unknown option '$1'${NC}" >&2
+            echo "Run 'reset-failures.sh --help' for usage" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ "$LIST_MODE" == "true" ]]; then
+    list_failures
+    exit 0
+fi
+
+if [[ "$ALL_MODE" == "true" ]]; then
+    if [[ "$SIGNAL_MODE" == "true" ]]; then
+        send_signal '{"action": "reset_failures", "all": true, "created_at": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"}'
+    else
+        reset_all
+    fi
+    exit 0
+fi
+
+if [[ -n "$ISSUE_NUM" ]]; then
+    if [[ "$SIGNAL_MODE" == "true" ]]; then
+        send_signal '{"action": "reset_failures", "issue": '"$ISSUE_NUM"', "created_at": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"}'
+    else
+        reset_issue "$ISSUE_NUM"
+    fi
+    exit 0
+fi
+
+echo -e "${RED}Error: Specify an issue number or --all${NC}" >&2
+echo "Run 'reset-failures.sh --help' for usage" >&2
+exit 1

--- a/defaults/scripts/retry-blocked-issues.sh
+++ b/defaults/scripts/retry-blocked-issues.sh
@@ -218,6 +218,17 @@ $(if [[ $new_retry_count -ge $MAX_RETRY_COUNT ]]; then echo "**Warning**: This i
 ---
 *Automated by Loom daemon retry system*" >/dev/null 2>&1
 
+        # Clear persistent failure log entry so daemon doesn't re-block on startup
+        ISSUE_FAILURES_FILE="$REPO_ROOT/.loom/issue-failures.json"
+        if [[ -f "$ISSUE_FAILURES_FILE" ]]; then
+            temp_file=$(mktemp)
+            if jq --arg key "$issue_num" 'del(.entries[$key])' "$ISSUE_FAILURES_FILE" > "$temp_file" 2>/dev/null; then
+                mv "$temp_file" "$ISSUE_FAILURES_FILE"
+            else
+                rm -f "$temp_file"
+            fi
+        fi
+
         # Update retry metadata in daemon-state.json
         if [[ -f "$DAEMON_STATE_FILE" ]]; then
             local_retry_exhausted="false"

--- a/loom-tools/src/loom_tools/common/issue_failures.py
+++ b/loom-tools/src/loom_tools/common/issue_failures.py
@@ -258,6 +258,84 @@ def get_failure_entry(repo_root: Path, issue: int) -> IssueFailureEntry | None:
     return log.entries.get(str(issue))
 
 
+def reset_failures(repo_root: Path, issue: int | None = None) -> int:
+    """Reset all failure tracking for a specific issue or all issues.
+
+    Clears failure state from all three locations:
+    1. ``.loom/issue-failures.json`` (persistent cross-session failure log)
+    2. ``daemon-state.json`` ``blocked_issue_retries`` (per-issue retry metadata)
+    3. ``daemon-state.json`` ``recent_failures`` (sliding window)
+
+    When *issue* is ``None``, all failure state is cleared.
+
+    Returns the number of entries cleared from the persistent failure log.
+    """
+    paths = LoomPaths(repo_root)
+    cleared = 0
+
+    # 1. Clear persistent failure log
+    log = load_failure_log(repo_root)
+    if issue is not None:
+        issue_key = str(issue)
+        if issue_key in log.entries:
+            del log.entries[issue_key]
+            cleared = 1
+    else:
+        cleared = len(log.entries)
+        log.entries.clear()
+    save_failure_log(repo_root, log)
+
+    # 2. Clear daemon-state.json fields
+    state_file = paths.daemon_state_file
+    if state_file.is_file():
+        try:
+            data = read_json_file(state_file)
+            if isinstance(data, dict):
+                if issue is not None:
+                    issue_key = str(issue)
+                    # Clear blocked_issue_retries for this issue
+                    retries: dict = data.get("blocked_issue_retries", {})
+                    retries.pop(issue_key, None)
+
+                    # Remove from recent_failures
+                    failures: list[dict] = data.get("recent_failures", [])
+                    data["recent_failures"] = [
+                        f for f in failures if f.get("issue") != issue
+                    ]
+
+                    # Remove from needs_human_input
+                    human: list[dict] = data.get("needs_human_input", [])
+                    data["needs_human_input"] = [
+                        h for h in human
+                        if not (
+                            h.get("type") == "exhausted_retry"
+                            and h.get("issue") == issue
+                        )
+                    ]
+                else:
+                    # Clear all failure state
+                    data["blocked_issue_retries"] = {}
+                    data["recent_failures"] = []
+                    data["systematic_failure"] = {}
+                    data["needs_human_input"] = [
+                        h for h in data.get("needs_human_input", [])
+                        if h.get("type") != "exhausted_retry"
+                    ]
+
+                write_json_file(state_file, data)
+        except Exception:
+            logger.warning(
+                "Failed to clear daemon-state.json failure fields"
+            )
+
+    if issue is not None:
+        logger.info("Reset all failure tracking for issue #%d", issue)
+    else:
+        logger.info("Reset all failure tracking (%d entries cleared)", cleared)
+
+    return cleared
+
+
 def merge_into_daemon_state(
     repo_root: Path,
     blocked_issue_retries: dict[str, Any],

--- a/loom-tools/src/loom_tools/daemon_v2/command_poller.py
+++ b/loom-tools/src/loom_tools/daemon_v2/command_poller.py
@@ -42,6 +42,8 @@ Available actions:
 +----------------------+---------------------------------------+
 | set_max_shepherds    | count (int)                           |
 +----------------------+---------------------------------------+
+| reset_failures       | issue (int) OR all (bool)             |
++----------------------+---------------------------------------+
 
 Note: ``start_orchestration`` must be sent by the /loom skill before the
 daemon will run its autonomous iteration loop. Until received, the daemon

--- a/loom-tools/src/loom_tools/daemon_v2/loop.py
+++ b/loom-tools/src/loom_tools/daemon_v2/loop.py
@@ -12,7 +12,7 @@ import time
 from typing import Any
 
 from loom_tools.common.github import gh_issue_view
-from loom_tools.common.issue_failures import load_failure_log, merge_into_daemon_state
+from loom_tools.common.issue_failures import load_failure_log, merge_into_daemon_state, reset_failures
 from loom_tools.common.logging import log_error, log_info, log_success, log_warning
 from loom_tools.common.state import read_daemon_state, read_json_file, write_json_file
 from loom_tools.common.time_utils import now_utc
@@ -288,6 +288,9 @@ def _process_commands(
                 "orchestration activated"
             )
             _update_orchestration_active(ctx)
+
+        elif action == "reset_failures":
+            _handle_reset_failures(ctx, cmd)
 
         else:
             log_warning(f"Signal: unknown action={action!r}, skipping")
@@ -582,6 +585,65 @@ def _resume_shepherd(ctx: DaemonContext, shepherd_id: str) -> None:
             log_warning(f"resume_shepherd: could not remove stop file: {exc}")
     else:
         log_warning(f"resume_shepherd: {shepherd_id} has no issue assigned")
+
+
+def _handle_reset_failures(ctx: DaemonContext, cmd: dict) -> None:
+    """Handle a reset_failures signal command.
+
+    Clears all three failure tracking locations (issue-failures.json,
+    blocked_issue_retries, recent_failures) for a specific issue or
+    all issues.
+
+    Signal payload:
+        {"action": "reset_failures", "issue": 42}    # reset one issue
+        {"action": "reset_failures", "all": true}     # reset all issues
+    """
+    issue = cmd.get("issue")
+    reset_all = cmd.get("all", False)
+
+    if issue is not None:
+        cleared = reset_failures(ctx.repo_root, issue=int(issue))
+        # Also update in-memory daemon state if loaded
+        if ctx.state is not None:
+            issue_key = str(issue)
+            ctx.state.blocked_issue_retries.pop(issue_key, None)
+            ctx.state.recent_failures = [
+                f for f in ctx.state.recent_failures
+                if f.issue != int(issue)
+            ]
+            ctx.state.needs_human_input = [
+                h for h in ctx.state.needs_human_input
+                if not (
+                    h.get("type") == "exhausted_retry"
+                    and h.get("issue") == int(issue)
+                )
+            ]
+        log_success(
+            f"Signal: reset_failures issue=#{issue} — "
+            f"cleared {cleared} persistent entry(ies)"
+        )
+    elif reset_all:
+        cleared = reset_failures(ctx.repo_root, issue=None)
+        # Also update in-memory daemon state if loaded
+        if ctx.state is not None:
+            ctx.state.blocked_issue_retries.clear()
+            ctx.state.recent_failures.clear()
+            ctx.state.systematic_failure.active = False
+            ctx.state.systematic_failure.pattern = ""
+            ctx.state.systematic_failure.count = 0
+            ctx.state.systematic_failure.probe_count = 0
+            ctx.state.needs_human_input = [
+                h for h in ctx.state.needs_human_input
+                if h.get("type") != "exhausted_retry"
+            ]
+        log_success(
+            f"Signal: reset_failures all=true — "
+            f"cleared {cleared} persistent entry(ies)"
+        )
+    else:
+        log_warning(
+            "Signal: reset_failures requires 'issue' (int) or 'all' (true), skipping"
+        )
 
 
 def _write_state(ctx: DaemonContext) -> None:

--- a/loom-tools/tests/test_reset_failures.py
+++ b/loom-tools/tests/test_reset_failures.py
@@ -1,0 +1,238 @@
+"""Tests for the reset_failures function in loom_tools.common.issue_failures."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+from loom_tools.common.issue_failures import (
+    load_failure_log,
+    record_failure,
+    reset_failures,
+)
+
+
+@pytest.fixture
+def repo(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Create a minimal repo with .loom directory and daemon-state.json."""
+    (tmp_path / ".git").mkdir()
+    loom_dir = tmp_path / ".loom"
+    loom_dir.mkdir()
+    return tmp_path
+
+
+def _write_daemon_state(repo: pathlib.Path, data: dict) -> None:
+    (repo / ".loom" / "daemon-state.json").write_text(json.dumps(data))
+
+
+def _read_daemon_state(repo: pathlib.Path) -> dict:
+    return json.loads((repo / ".loom" / "daemon-state.json").read_text())
+
+
+def _read_failures(repo: pathlib.Path) -> dict:
+    return json.loads((repo / ".loom" / "issue-failures.json").read_text())
+
+
+# ── reset_failures for a single issue ─────────────────────────
+
+
+class TestResetSingleIssue:
+    def test_clears_persistent_failure_log_entry(self, repo: pathlib.Path) -> None:
+        record_failure(repo, 42, error_class="builder_stuck", phase="builder")
+        record_failure(repo, 99, error_class="judge_stuck", phase="judge")
+
+        cleared = reset_failures(repo, issue=42)
+
+        assert cleared == 1
+        log = load_failure_log(repo)
+        assert "42" not in log.entries
+        assert "99" in log.entries
+
+    def test_clears_blocked_issue_retries(self, repo: pathlib.Path) -> None:
+        _write_daemon_state(repo, {
+            "blocked_issue_retries": {
+                "42": {"retry_count": 3, "retry_exhausted": True, "error_class": "builder_stuck"},
+                "99": {"retry_count": 1, "retry_exhausted": False, "error_class": "judge_stuck"},
+            },
+            "recent_failures": [],
+        })
+
+        reset_failures(repo, issue=42)
+
+        state = _read_daemon_state(repo)
+        assert "42" not in state["blocked_issue_retries"]
+        assert "99" in state["blocked_issue_retries"]
+
+    def test_clears_recent_failures(self, repo: pathlib.Path) -> None:
+        _write_daemon_state(repo, {
+            "blocked_issue_retries": {},
+            "recent_failures": [
+                {"issue": 42, "error_class": "builder_stuck", "phase": "builder", "timestamp": "2026-01-01T00:00:00Z"},
+                {"issue": 99, "error_class": "judge_stuck", "phase": "judge", "timestamp": "2026-01-02T00:00:00Z"},
+                {"issue": 42, "error_class": "builder_stuck", "phase": "builder", "timestamp": "2026-01-03T00:00:00Z"},
+            ],
+        })
+
+        reset_failures(repo, issue=42)
+
+        state = _read_daemon_state(repo)
+        assert len(state["recent_failures"]) == 1
+        assert state["recent_failures"][0]["issue"] == 99
+
+    def test_clears_needs_human_input(self, repo: pathlib.Path) -> None:
+        _write_daemon_state(repo, {
+            "blocked_issue_retries": {},
+            "recent_failures": [],
+            "needs_human_input": [
+                {"type": "exhausted_retry", "issue": 42, "error_class": "builder_stuck"},
+                {"type": "exhausted_retry", "issue": 99, "error_class": "judge_stuck"},
+                {"type": "other", "reason": "manual request"},
+            ],
+        })
+
+        reset_failures(repo, issue=42)
+
+        state = _read_daemon_state(repo)
+        assert len(state["needs_human_input"]) == 2
+        issues = [h.get("issue") for h in state["needs_human_input"]]
+        assert 42 not in issues
+
+    def test_returns_zero_for_unknown_issue(self, repo: pathlib.Path) -> None:
+        record_failure(repo, 42, error_class="builder_stuck")
+        cleared = reset_failures(repo, issue=999)
+        assert cleared == 0
+
+    def test_works_without_daemon_state(self, repo: pathlib.Path) -> None:
+        """Should work even when daemon-state.json doesn't exist."""
+        record_failure(repo, 42, error_class="builder_stuck")
+
+        cleared = reset_failures(repo, issue=42)
+
+        assert cleared == 1
+        log = load_failure_log(repo)
+        assert "42" not in log.entries
+
+
+# ── reset_failures for all issues ─────────────────────────────
+
+
+class TestResetAllIssues:
+    def test_clears_all_persistent_entries(self, repo: pathlib.Path) -> None:
+        record_failure(repo, 42, error_class="builder_stuck")
+        record_failure(repo, 99, error_class="judge_stuck")
+        record_failure(repo, 100, error_class="doctor_exhausted")
+
+        cleared = reset_failures(repo, issue=None)
+
+        assert cleared == 3
+        log = load_failure_log(repo)
+        assert log.entries == {}
+
+    def test_clears_all_daemon_state_fields(self, repo: pathlib.Path) -> None:
+        _write_daemon_state(repo, {
+            "blocked_issue_retries": {
+                "42": {"retry_count": 3, "retry_exhausted": True},
+                "99": {"retry_count": 1, "retry_exhausted": False},
+            },
+            "recent_failures": [
+                {"issue": 42, "error_class": "builder_stuck"},
+                {"issue": 99, "error_class": "judge_stuck"},
+            ],
+            "systematic_failure": {
+                "active": True,
+                "pattern": "builder_stuck",
+                "count": 3,
+            },
+            "needs_human_input": [
+                {"type": "exhausted_retry", "issue": 42},
+                {"type": "other", "reason": "manual"},
+            ],
+            "running": True,
+            "iteration": 10,
+        })
+
+        reset_failures(repo, issue=None)
+
+        state = _read_daemon_state(repo)
+        assert state["blocked_issue_retries"] == {}
+        assert state["recent_failures"] == []
+        assert state["systematic_failure"] == {}
+        # Non-exhausted_retry entries should be preserved
+        assert len(state["needs_human_input"]) == 1
+        assert state["needs_human_input"][0]["type"] == "other"
+        # Other state fields should be untouched
+        assert state["running"] is True
+        assert state["iteration"] == 10
+
+    def test_returns_zero_when_no_entries(self, repo: pathlib.Path) -> None:
+        cleared = reset_failures(repo, issue=None)
+        assert cleared == 0
+
+    def test_works_without_daemon_state(self, repo: pathlib.Path) -> None:
+        record_failure(repo, 42, error_class="builder_stuck")
+
+        cleared = reset_failures(repo, issue=None)
+
+        assert cleared == 1
+        log = load_failure_log(repo)
+        assert log.entries == {}
+
+
+# ── Integration: reset then retry ─────────────────────────────
+
+
+class TestResetThenRetry:
+    def test_issue_passes_backoff_filter_after_reset(self, repo: pathlib.Path) -> None:
+        """After reset, the issue should pass the backoff filter immediately."""
+        from loom_tools.snapshot import filter_issues_by_failure_backoff
+
+        # Record enough failures to trigger backoff
+        for _ in range(4):
+            record_failure(repo, 42, error_class="builder_stuck")
+
+        # Verify issue is in backoff
+        log = load_failure_log(repo)
+        issues = [{"number": 42}]
+        result = filter_issues_by_failure_backoff(issues, log, current_iteration=1)
+        assert len(result) == 0  # Should be blocked/in backoff
+
+        # Reset failures
+        reset_failures(repo, issue=42)
+
+        # Verify issue now passes filter
+        log = load_failure_log(repo)
+        result = filter_issues_by_failure_backoff(issues, log, current_iteration=1)
+        assert len(result) == 1
+        assert result[0]["number"] == 42
+
+    def test_full_lifecycle_reset_all(self, repo: pathlib.Path) -> None:
+        """Reset all -> verify clean state -> record new failure -> works."""
+        record_failure(repo, 42, error_class="builder_stuck")
+        record_failure(repo, 99, error_class="judge_stuck")
+
+        _write_daemon_state(repo, {
+            "blocked_issue_retries": {
+                "42": {"retry_count": 5, "retry_exhausted": True},
+            },
+            "recent_failures": [
+                {"issue": 42, "error_class": "builder_stuck"},
+            ],
+            "systematic_failure": {"active": True, "pattern": "builder_stuck"},
+        })
+
+        # Reset all
+        reset_failures(repo, issue=None)
+
+        # Verify clean state
+        log = load_failure_log(repo)
+        assert log.entries == {}
+        state = _read_daemon_state(repo)
+        assert state["blocked_issue_retries"] == {}
+        assert state["recent_failures"] == []
+        assert state["systematic_failure"] == {}
+
+        # Record new failure - should work as fresh
+        entry = record_failure(repo, 42, error_class="new_error")
+        assert entry.total_failures == 1

--- a/loom-tools/tests/test_reset_failures_signal.py
+++ b/loom-tools/tests/test_reset_failures_signal.py
@@ -1,0 +1,169 @@
+"""Tests for reset_failures signal handling in daemon loop."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+from unittest import mock
+
+import pytest
+
+from loom_tools.common.issue_failures import record_failure
+from loom_tools.daemon_v2.config import DaemonConfig
+from loom_tools.daemon_v2.context import DaemonContext
+from loom_tools.daemon_v2.loop import _handle_reset_failures
+from loom_tools.models.daemon_state import (
+    BlockedIssueRetry,
+    DaemonState,
+    RecentFailure,
+    SystematicFailure,
+)
+
+
+@pytest.fixture
+def repo(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Create a minimal repo with .loom directory."""
+    (tmp_path / ".git").mkdir()
+    loom_dir = tmp_path / ".loom"
+    loom_dir.mkdir()
+    return tmp_path
+
+
+def _make_ctx(
+    repo: pathlib.Path,
+    blocked_retries: dict[str, BlockedIssueRetry] | None = None,
+    recent_failures: list[RecentFailure] | None = None,
+) -> DaemonContext:
+    config = DaemonConfig()
+    ctx = DaemonContext(config=config, repo_root=repo)
+    ctx.state = DaemonState(
+        blocked_issue_retries=blocked_retries or {},
+        recent_failures=recent_failures or [],
+        systematic_failure=SystematicFailure(
+            active=True, pattern="builder_stuck", count=3
+        ),
+        needs_human_input=[
+            {"type": "exhausted_retry", "issue": 42, "error_class": "builder_stuck"},
+            {"type": "other", "reason": "manual"},
+        ],
+    )
+    return ctx
+
+
+class TestResetFailuresSignalSingleIssue:
+    def test_clears_in_memory_state(self, repo: pathlib.Path) -> None:
+        ctx = _make_ctx(
+            repo,
+            blocked_retries={
+                "42": BlockedIssueRetry(retry_count=3, retry_exhausted=True),
+                "99": BlockedIssueRetry(retry_count=1),
+            },
+            recent_failures=[
+                RecentFailure(issue=42, error_class="builder_stuck"),
+                RecentFailure(issue=99, error_class="judge_stuck"),
+                RecentFailure(issue=42, error_class="builder_stuck"),
+            ],
+        )
+
+        cmd = {"action": "reset_failures", "issue": 42}
+        _handle_reset_failures(ctx, cmd)
+
+        # In-memory state should be updated
+        assert "42" not in ctx.state.blocked_issue_retries
+        assert "99" in ctx.state.blocked_issue_retries
+        assert len(ctx.state.recent_failures) == 1
+        assert ctx.state.recent_failures[0].issue == 99
+        # needs_human_input should have removed issue 42 escalation
+        assert len(ctx.state.needs_human_input) == 1
+        assert ctx.state.needs_human_input[0]["type"] == "other"
+
+    def test_clears_persistent_log(self, repo: pathlib.Path) -> None:
+        record_failure(repo, 42, error_class="builder_stuck")
+        record_failure(repo, 99, error_class="judge_stuck")
+
+        # Need daemon-state.json for the handler
+        (repo / ".loom" / "daemon-state.json").write_text(json.dumps({
+            "blocked_issue_retries": {},
+            "recent_failures": [],
+        }))
+
+        ctx = _make_ctx(repo)
+        cmd = {"action": "reset_failures", "issue": 42}
+        _handle_reset_failures(ctx, cmd)
+
+        from loom_tools.common.issue_failures import load_failure_log
+        log = load_failure_log(repo)
+        assert "42" not in log.entries
+        assert "99" in log.entries
+
+
+class TestResetFailuresSignalAll:
+    def test_clears_all_in_memory_state(self, repo: pathlib.Path) -> None:
+        ctx = _make_ctx(
+            repo,
+            blocked_retries={
+                "42": BlockedIssueRetry(retry_count=3),
+                "99": BlockedIssueRetry(retry_count=1),
+            },
+            recent_failures=[
+                RecentFailure(issue=42, error_class="builder_stuck"),
+                RecentFailure(issue=99, error_class="judge_stuck"),
+            ],
+        )
+
+        cmd = {"action": "reset_failures", "all": True}
+        _handle_reset_failures(ctx, cmd)
+
+        assert ctx.state.blocked_issue_retries == {}
+        assert ctx.state.recent_failures == []
+        assert ctx.state.systematic_failure.active is False
+        assert ctx.state.systematic_failure.pattern == ""
+        assert ctx.state.systematic_failure.count == 0
+        # Non-exhausted_retry human input should survive
+        assert len(ctx.state.needs_human_input) == 1
+        assert ctx.state.needs_human_input[0]["type"] == "other"
+
+    def test_clears_all_persistent_entries(self, repo: pathlib.Path) -> None:
+        record_failure(repo, 42, error_class="builder_stuck")
+        record_failure(repo, 99, error_class="judge_stuck")
+
+        (repo / ".loom" / "daemon-state.json").write_text(json.dumps({
+            "blocked_issue_retries": {},
+            "recent_failures": [],
+        }))
+
+        ctx = _make_ctx(repo)
+        cmd = {"action": "reset_failures", "all": True}
+        _handle_reset_failures(ctx, cmd)
+
+        from loom_tools.common.issue_failures import load_failure_log
+        log = load_failure_log(repo)
+        assert log.entries == {}
+
+
+class TestResetFailuresSignalInvalid:
+    def test_warns_on_missing_params(self, repo: pathlib.Path) -> None:
+        ctx = _make_ctx(repo)
+        cmd = {"action": "reset_failures"}  # Missing both issue and all
+        # Should not raise, just log a warning
+        _handle_reset_failures(ctx, cmd)
+        # State should be unchanged
+        assert len(ctx.state.needs_human_input) == 2
+
+    def test_issue_as_string_is_converted(self, repo: pathlib.Path) -> None:
+        """Issue number passed as string should still work."""
+        record_failure(repo, 42, error_class="builder_stuck")
+        (repo / ".loom" / "daemon-state.json").write_text(json.dumps({
+            "blocked_issue_retries": {"42": {"retry_count": 1}},
+            "recent_failures": [{"issue": 42, "error_class": "builder_stuck"}],
+        }))
+
+        ctx = _make_ctx(
+            repo,
+            blocked_retries={"42": BlockedIssueRetry(retry_count=1)},
+            recent_failures=[RecentFailure(issue=42, error_class="builder_stuck")],
+        )
+        cmd = {"action": "reset_failures", "issue": "42"}  # String, not int
+        _handle_reset_failures(ctx, cmd)
+
+        assert "42" not in ctx.state.blocked_issue_retries


### PR DESCRIPTION
## Summary

- Add `reset_failures()` Python function that atomically clears all three failure tracking locations: `issue-failures.json`, `blocked_issue_retries`, and `recent_failures`
- Add `reset_failures` daemon signal action so failures can be reset while the daemon is running (updates both disk and in-memory state)
- Create `reset-failures.sh` shell script for human use with `--list`, `--signal`, and `--all` options
- Fix `retry-blocked-issues.sh --execute` to also clear the persistent failure log so the daemon doesn't re-block issues on next startup

## Test plan

- [x] 18 new unit tests for `reset_failures()` function (single issue, all issues, integration with backoff filter)
- [x] 18 new unit tests for daemon signal handler (in-memory state update, persistent log clearing, invalid input handling)
- [x] All 104 existing failure-related tests pass with zero regressions
- [x] Full test suite: 3875 passed (13 pre-existing failures unrelated to this change)

Closes #3100