### PR TITLE
feat: respect issue dependency chains when scheduling shepherds

### DIFF
--- a/loom-tools/src/loom_tools/daemon_v2/actions/dependencies.py
+++ b/loom-tools/src/loom_tools/daemon_v2/actions/dependencies.py
@@ -1,0 +1,100 @@
+"""Issue dependency parsing and filtering.
+
+Parses ``## Dependencies`` sections from GitHub issue bodies to determine
+which issues have unmet dependencies.  Used by :func:`spawn_shepherds` to
+avoid scheduling issues whose prerequisites are still open.
+
+Supported formats inside the ``## Dependencies`` section::
+
+    - #10
+    - #13, #14
+    - Depends on #10
+    - Requires #10 and #13
+    - #10 (scaffold) must be completed first
+
+The parser extracts all ``#N`` references found between the Dependencies
+heading and the next ``##`` heading (or end of body).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from loom_tools.common.logging import log_info
+
+# Regex to extract the ## Dependencies section content.
+# Matches from "## Dependencies" to the next "##" heading or end of string.
+_DEPS_SECTION_RE = re.compile(
+    r"##\s+Dependencies\s*\n(.*?)(?=\n##\s|\Z)",
+    re.DOTALL | re.IGNORECASE,
+)
+
+# Regex to find issue references (#N) within the dependencies section.
+_ISSUE_REF_RE = re.compile(r"#(\d+)")
+
+
+def parse_dependencies(body: str | None) -> set[int]:
+    """Extract dependency issue numbers from an issue body.
+
+    Looks for a ``## Dependencies`` section and returns the set of
+    referenced issue numbers.  Returns an empty set if there is no
+    Dependencies section or the body is empty/None.
+    """
+    if not body:
+        return set()
+
+    match = _DEPS_SECTION_RE.search(body)
+    if not match:
+        return set()
+
+    section_text = match.group(1)
+    return {int(m.group(1)) for m in _ISSUE_REF_RE.finditer(section_text)}
+
+
+def filter_issues_by_dependencies(
+    ready_issues: list[dict[str, Any]],
+    all_open_issue_numbers: set[int],
+) -> list[dict[str, Any]]:
+    """Filter out issues whose dependencies are not yet closed.
+
+    Args:
+        ready_issues: Issues with ``loom:issue`` label from the snapshot.
+            Each dict must have ``number`` and ``body`` keys.
+        all_open_issue_numbers: Set of all open issue numbers in the
+            pipeline (ready + building + blocked).  A dependency is
+            considered *unmet* if its number appears in this set (i.e.
+            the issue is still open).
+
+    Returns:
+        The subset of *ready_issues* whose dependencies are all closed
+        (not present in *all_open_issue_numbers*), preserving order.
+    """
+    schedulable: list[dict[str, Any]] = []
+    skipped: list[tuple[int, set[int]]] = []
+
+    for issue in ready_issues:
+        issue_num = issue.get("number")
+        body = issue.get("body") or ""
+        deps = parse_dependencies(body)
+
+        if not deps:
+            # No dependencies declared -- always schedulable
+            schedulable.append(issue)
+            continue
+
+        # A dependency is unmet if it is still open
+        unmet = deps & all_open_issue_numbers
+        if unmet:
+            skipped.append((issue_num, unmet))
+        else:
+            schedulable.append(issue)
+
+    if skipped:
+        for issue_num, unmet in skipped:
+            refs = ", ".join(f"#{n}" for n in sorted(unmet))
+            log_info(
+                f"Skipping issue #{issue_num}: unmet dependencies ({refs})"
+            )
+
+    return schedulable

--- a/loom-tools/src/loom_tools/daemon_v2/actions/shepherds.py
+++ b/loom-tools/src/loom_tools/daemon_v2/actions/shepherds.py
@@ -14,6 +14,7 @@ from loom_tools.agent_spawn import (
 )
 from loom_tools.claim import claim_issue, release_claim
 from loom_tools.common.github import gh_run
+from loom_tools.daemon_v2.actions.dependencies import filter_issues_by_dependencies
 from loom_tools.common.issue_failures import (
     INFRASTRUCTURE_ERROR_CLASSES,
     get_failure_entry,
@@ -36,8 +37,31 @@ STARTUP_GRACE_PERIOD = 120  # 2 minutes
 NO_PROGRESS_GRACE_PERIOD = 300  # 5 minutes
 
 
+def _collect_open_issue_numbers(ctx: DaemonContext) -> set[int]:
+    """Collect all open issue numbers from the snapshot pipeline.
+
+    Includes issues in ready, building, and blocked states so that
+    dependency checks can determine whether a prerequisite is still open.
+    """
+    if ctx.snapshot is None:
+        return set()
+
+    pipeline = ctx.snapshot.get("pipeline", {})
+    nums: set[int] = set()
+    for key in ("ready_issues", "building_issues", "blocked_issues"):
+        for item in pipeline.get(key, []):
+            n = item.get("number")
+            if n is not None:
+                nums.add(n)
+    return nums
+
+
 def spawn_shepherds(ctx: DaemonContext) -> int:
     """Spawn shepherds for ready issues.
+
+    Filters out issues whose ``## Dependencies`` reference open issues
+    before scheduling, so shepherds are not wasted on work that cannot
+    proceed yet.
 
     Returns the number of shepherds successfully spawned.
     """
@@ -53,6 +77,14 @@ def spawn_shepherds(ctx: DaemonContext) -> int:
 
     if not ready_issues:
         log_info("No ready issues to assign")
+        return 0
+
+    # Filter out issues with unmet dependencies
+    open_issues = _collect_open_issue_numbers(ctx)
+    ready_issues = filter_issues_by_dependencies(ready_issues, open_issues)
+
+    if not ready_issues:
+        log_info("No ready issues after dependency filtering")
         return 0
 
     # Limit to available slots

--- a/loom-tools/src/loom_tools/snapshot.py
+++ b/loom-tools/src/loom_tools/snapshot.py
@@ -269,7 +269,7 @@ def compute_support_role_state(
 # Pipeline data collection (parallel gh queries)
 # ---------------------------------------------------------------------------
 
-_ISSUE_FIELDS = ["number", "title", "labels", "createdAt"]
+_ISSUE_FIELDS = ["number", "title", "labels", "createdAt", "body"]
 
 # Labels that indicate an issue has been processed or claimed — used to identify
 # issues that still need curator attention.

--- a/loom-tools/tests/daemon_v2/test_dependencies.py
+++ b/loom-tools/tests/daemon_v2/test_dependencies.py
@@ -1,0 +1,242 @@
+"""Tests for issue dependency parsing and filtering."""
+
+from __future__ import annotations
+
+import pathlib
+from unittest import mock
+
+import pytest
+
+from loom_tools.daemon_v2.actions.dependencies import (
+    filter_issues_by_dependencies,
+    parse_dependencies,
+)
+
+
+class TestParseDependencies:
+    """Tests for parse_dependencies()."""
+
+    def test_no_body(self):
+        assert parse_dependencies(None) == set()
+        assert parse_dependencies("") == set()
+
+    def test_no_dependencies_section(self):
+        body = "## Summary\nThis is a feature request.\n## Details\nMore info."
+        assert parse_dependencies(body) == set()
+
+    def test_single_dependency(self):
+        body = "## Summary\nSome text.\n## Dependencies\n- #10\n## Details\nMore."
+        assert parse_dependencies(body) == {10}
+
+    def test_multiple_dependencies_separate_lines(self):
+        body = (
+            "## Summary\nSome text.\n"
+            "## Dependencies\n"
+            "- #10\n"
+            "- #13\n"
+            "- #14\n"
+            "## Details\nMore."
+        )
+        assert parse_dependencies(body) == {10, 13, 14}
+
+    def test_multiple_dependencies_same_line(self):
+        body = "## Dependencies\n- #10, #13, #14\n"
+        assert parse_dependencies(body) == {10, 13, 14}
+
+    def test_dependencies_with_descriptions(self):
+        body = (
+            "## Dependencies\n"
+            "- #10 (bootstrap/scaffold)\n"
+            "- #13 document management must be done first\n"
+        )
+        assert parse_dependencies(body) == {10, 13}
+
+    def test_prose_format(self):
+        body = "## Dependencies\nDepends on #10 and #13.\n"
+        assert parse_dependencies(body) == {10, 13}
+
+    def test_dependencies_at_end_of_body(self):
+        body = "## Summary\nText.\n## Dependencies\n- #42\n- #99"
+        assert parse_dependencies(body) == {42, 99}
+
+    def test_case_insensitive_heading(self):
+        body = "## dependencies\n- #5\n"
+        assert parse_dependencies(body) == {5}
+
+    def test_extra_whitespace_in_heading(self):
+        body = "##  Dependencies  \n- #7\n"
+        assert parse_dependencies(body) == {7}
+
+    def test_does_not_pick_up_refs_outside_section(self):
+        body = (
+            "## Summary\nRelated to #99.\n"
+            "## Dependencies\n- #10\n"
+            "## Notes\nSee also #50."
+        )
+        assert parse_dependencies(body) == {10}
+
+
+class TestFilterIssuesByDependencies:
+    """Tests for filter_issues_by_dependencies()."""
+
+    def _make_issue(self, num: int, body: str = "") -> dict:
+        return {"number": num, "title": f"Issue #{num}", "body": body}
+
+    def test_no_dependencies(self):
+        issues = [self._make_issue(1), self._make_issue(2)]
+        result = filter_issues_by_dependencies(issues, {1, 2, 3})
+        assert len(result) == 2
+
+    def test_all_deps_closed(self):
+        """Dependencies not in open set => issue is schedulable."""
+        issues = [
+            self._make_issue(5, "## Dependencies\n- #1\n- #2\n"),
+        ]
+        # open issues are 5, 6, 7 -- deps #1, #2 are closed
+        result = filter_issues_by_dependencies(issues, {5, 6, 7})
+        assert len(result) == 1
+        assert result[0]["number"] == 5
+
+    def test_unmet_dependency_filtered(self):
+        """Issue with open dependency should be filtered out."""
+        issues = [
+            self._make_issue(5, "## Dependencies\n- #3\n"),
+        ]
+        # #3 is still open
+        result = filter_issues_by_dependencies(issues, {3, 5})
+        assert len(result) == 0
+
+    def test_partial_deps_met(self):
+        """Issue with one met and one unmet dep should be filtered."""
+        issues = [
+            self._make_issue(5, "## Dependencies\n- #1\n- #3\n"),
+        ]
+        # #1 is closed, #3 is open
+        result = filter_issues_by_dependencies(issues, {3, 5})
+        assert len(result) == 0
+
+    def test_mixed_issues(self):
+        """Mix of issues with and without dependencies."""
+        issues = [
+            self._make_issue(1),  # no deps
+            self._make_issue(2, "## Dependencies\n- #50\n"),  # dep on closed #50
+            self._make_issue(3, "## Dependencies\n- #10\n"),  # dep on open #10
+            self._make_issue(4, "## Dependencies\n- #10\n- #20\n"),  # deps on open #10
+        ]
+        # #50 is NOT in open set (closed), #10 IS open
+        open_issues = {1, 2, 3, 4, 10}
+        result = filter_issues_by_dependencies(issues, open_issues)
+        assert [r["number"] for r in result] == [1, 2]
+
+    def test_preserves_order(self):
+        issues = [
+            self._make_issue(10),
+            self._make_issue(5),
+            self._make_issue(1),
+        ]
+        result = filter_issues_by_dependencies(issues, {1, 5, 10})
+        assert [r["number"] for r in result] == [10, 5, 1]
+
+    def test_self_reference_not_treated_as_dependency(self):
+        """An issue referencing itself in deps shouldn't block itself.
+
+        This tests the real behavior: the issue IS in the open set, so a
+        self-reference would block it.  Authors should avoid self-references.
+        But practically, parse_dependencies only extracts from the deps
+        section, and self-references there are a user error.
+        """
+        issues = [
+            self._make_issue(5, "## Dependencies\n- #5\n"),
+        ]
+        # #5 is itself open, so it IS in the open set => blocked
+        result = filter_issues_by_dependencies(issues, {5})
+        assert len(result) == 0
+
+    def test_empty_issues_list(self):
+        result = filter_issues_by_dependencies([], {1, 2, 3})
+        assert result == []
+
+    def test_empty_open_set(self):
+        """No open issues => all deps are met."""
+        issues = [
+            self._make_issue(1, "## Dependencies\n- #99\n"),
+        ]
+        result = filter_issues_by_dependencies(issues, set())
+        assert len(result) == 1
+
+
+class TestCollectOpenIssueNumbers:
+    """Tests for _collect_open_issue_numbers()."""
+
+    def test_collects_from_all_pipeline_keys(self):
+        from loom_tools.daemon_v2.actions.shepherds import _collect_open_issue_numbers
+        from loom_tools.daemon_v2.config import DaemonConfig
+        from loom_tools.daemon_v2.context import DaemonContext
+
+        ctx = DaemonContext(config=DaemonConfig(), repo_root=pathlib.Path("/tmp"))
+        ctx.snapshot = {
+            "pipeline": {
+                "ready_issues": [{"number": 1}, {"number": 2}],
+                "building_issues": [{"number": 3}],
+                "blocked_issues": [{"number": 4}],
+            },
+        }
+
+        result = _collect_open_issue_numbers(ctx)
+        assert result == {1, 2, 3, 4}
+
+    def test_empty_snapshot(self):
+        from loom_tools.daemon_v2.actions.shepherds import _collect_open_issue_numbers
+        from loom_tools.daemon_v2.config import DaemonConfig
+        from loom_tools.daemon_v2.context import DaemonContext
+
+        ctx = DaemonContext(config=DaemonConfig(), repo_root=pathlib.Path("/tmp"))
+        ctx.snapshot = None
+
+        result = _collect_open_issue_numbers(ctx)
+        assert result == set()
+
+
+class TestSpawnShepherdsWithDependencies:
+    """Integration tests for spawn_shepherds with dependency filtering."""
+
+    def test_skips_issues_with_unmet_deps(self):
+        """spawn_shepherds should not schedule issues with open dependencies."""
+        from loom_tools.daemon_v2.actions.shepherds import spawn_shepherds
+        from loom_tools.daemon_v2.config import DaemonConfig
+        from loom_tools.daemon_v2.context import DaemonContext
+        from loom_tools.models.daemon_state import DaemonState, ShepherdEntry
+
+        ctx = DaemonContext(config=DaemonConfig(), repo_root=pathlib.Path("/tmp"))
+        ctx.state = DaemonState()
+        ctx.state.shepherds["shepherd-1"] = ShepherdEntry(status="idle")
+
+        ctx.snapshot = {
+            "computed": {
+                "available_shepherd_slots": 3,
+            },
+            "pipeline": {
+                "ready_issues": [
+                    {"number": 10, "title": "Bootstrap", "body": ""},
+                    {"number": 13, "title": "Doc mgmt", "body": "## Dependencies\n- #10\n"},
+                    {"number": 14, "title": "Editor", "body": "## Dependencies\n- #13\n"},
+                ],
+                "building_issues": [],
+                "blocked_issues": [],
+            },
+        }
+
+        # All three are in ready state (open). #13 depends on #10, #14 depends on #13.
+        # Only #10 (no deps) should be schedulable.
+        with (
+            mock.patch(
+                "loom_tools.daemon_v2.actions.shepherds._spawn_single_shepherd",
+                return_value=True,
+            ) as mock_spawn,
+        ):
+            result = spawn_shepherds(ctx)
+
+        assert result == 1
+        mock_spawn.assert_called_once()
+        # The issue number passed should be 10 (the one with no deps)
+        assert mock_spawn.call_args[0][2] == 10


### PR DESCRIPTION
Closes #3095

## Summary

- Parses `## Dependencies` sections from issue bodies to extract `#N` references as dependency declarations
- Filters out issues with unmet (still-open) dependencies before scheduling shepherds in `spawn_shepherds()`
- Adds `body` field to snapshot issue queries so dependency data is available without extra API calls

## Changes

- **New**: `loom_tools/daemon_v2/actions/dependencies.py` -- `parse_dependencies()` extracts issue refs from `## Dependencies` sections; `filter_issues_by_dependencies()` filters issues whose deps are still open
- **Modified**: `loom_tools/daemon_v2/actions/shepherds.py` -- `spawn_shepherds()` now calls dependency filter before scheduling; added `_collect_open_issue_numbers()` helper
- **Modified**: `loom_tools/snapshot.py` -- Added `body` to `_ISSUE_FIELDS` so issue bodies are included in snapshot data
- **New**: `loom_tools/tests/daemon_v2/test_dependencies.py` -- 23 tests covering parsing, filtering, and integration with spawn logic

## Test plan

- [x] 23 new unit tests for dependency parsing and filtering
- [x] Integration test verifying `spawn_shepherds` skips issues with unmet deps
- [x] All 232 existing daemon_v2 tests pass
- [x] All 164 existing snapshot tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)