### PR TITLE
fix: catch non-critical errors in daemon loop instead of crashing

### DIFF
--- a/loom-tools/src/loom_tools/daemon_v2/iteration.py
+++ b/loom-tools/src/loom_tools/daemon_v2/iteration.py
@@ -11,7 +11,11 @@ from loom_tools.common.logging import log_error, log_info, log_success, log_warn
 from loom_tools.common.state import read_daemon_state, write_json_file
 from loom_tools.common.time_utils import now_utc
 from loom_tools.models.daemon_state import SystematicFailure
-from loom_tools.daemon_v2.actions.completions import check_completions, handle_completion
+from loom_tools.daemon_v2.actions.completions import (
+    CompletionEntry,
+    check_completions,
+    handle_completion,
+)
 from loom_tools.daemon_v2.actions.proposals import promote_proposals
 from loom_tools.daemon_v2.actions.retry_blocked import (
     escalate_blocked_issues,
@@ -81,9 +85,22 @@ def run_iteration(ctx: DaemonContext) -> IterationResult:
     ctx.state.iteration = ctx.iteration
 
     # 3. Check completions
-    completions = check_completions(ctx)
+    #    Each completion is handled individually so a failure in one
+    #    (e.g. missing lock file during cleanup) does not skip the rest.
+    completions: list[CompletionEntry] = []
+    try:
+        completions = check_completions(ctx)
+    except Exception as e:
+        log_warning(f"Non-critical error checking completions: {e}")
+
     for completion in completions:
-        handle_completion(ctx, completion)
+        try:
+            handle_completion(ctx, completion)
+        except Exception as e:
+            log_warning(
+                f"Non-critical error handling completion for "
+                f"{completion.name}: {e}"
+            )
 
     # Recompute active shepherd count after completions modify ctx.state
     if completions and ctx.state is not None and ctx.snapshot is not None:
@@ -99,14 +116,28 @@ def run_iteration(ctx: DaemonContext) -> IterationResult:
     #    Detects shepherds with dead tmux sessions, stale heartbeats, or
     #    missing progress files. Runs before action planning so reclaimed
     #    slots are available for new spawns.
-    _reclaim_stale_shepherds(ctx)
+    try:
+        _reclaim_stale_shepherds(ctx)
+    except Exception as e:
+        log_warning(f"Non-critical error reclaiming stale shepherds: {e}")
 
     # 4b. Detect completed support roles (tmux session exited)
     #     Support roles have no progress files — we detect completion by
     #     checking whether their tmux session is still alive.
-    support_completions = _reclaim_completed_support_roles(ctx)
+    support_completions: list[CompletionEntry] = []
+    try:
+        support_completions = _reclaim_completed_support_roles(ctx)
+    except Exception as e:
+        log_warning(f"Non-critical error reclaiming support roles: {e}")
+
     for sc in support_completions:
-        handle_completion(ctx, sc)
+        try:
+            handle_completion(ctx, sc)
+        except Exception as e:
+            log_warning(
+                f"Non-critical error handling support role completion "
+                f"for {sc.name}: {e}"
+            )
     completions.extend(support_completions)
 
     # 5. Get recommended actions

--- a/loom-tools/src/loom_tools/daemon_v2/loop.py
+++ b/loom-tools/src/loom_tools/daemon_v2/loop.py
@@ -91,6 +91,9 @@ def run(ctx: DaemonContext) -> int:
             deadline = time.time() + ctx.config.timeout_min * 60
 
         # 12. Main loop
+        consecutive_errors = 0
+        MAX_CONSECUTIVE_ERRORS = 10  # Crash only after this many in a row
+
         while ctx.running:
             ctx.iteration += 1
 
@@ -112,41 +115,62 @@ def run(ctx: DaemonContext) -> int:
                 log_warning("Yielding to other daemon instance. Exiting.")
                 break
 
-            # Poll and process IPC commands from /loom skill BEFORE iteration.
-            # The /loom skill writes spawn_shepherd/stop/etc. signals here.
-            commands = command_poller.poll()
-            if commands:
-                log_info(f"Iteration {ctx.iteration}: Processing {len(commands)} signal command(s)")
-                _process_commands(ctx, commands, command_poller)
-                # Update signal_queue_depth in state file after processing
-                _update_signal_queue_depth(ctx, command_poller.queue_depth())
+            try:
+                # Poll and process IPC commands from /loom skill BEFORE iteration.
+                # The /loom skill writes spawn_shepherd/stop/etc. signals here.
+                commands = command_poller.poll()
+                if commands:
+                    log_info(f"Iteration {ctx.iteration}: Processing {len(commands)} signal command(s)")
+                    _process_commands(ctx, commands, command_poller)
+                    # Update signal_queue_depth in state file after processing
+                    _update_signal_queue_depth(ctx, command_poller.queue_depth())
 
-            # Retry any pending spawn signals that were queued when all slots were full.
-            # Runs before each iteration so reclaimed slots are immediately reused.
-            if ctx.pending_spawns:
-                _retry_pending_spawns(ctx)
+                # Retry any pending spawn signals that were queued when all slots were full.
+                # Runs before each iteration so reclaimed slots are immediately reused.
+                if ctx.pending_spawns:
+                    _retry_pending_spawns(ctx)
 
-            # Run iteration (only when orchestration is active — activated by /loom)
-            if ctx.orchestration_active:
-                log_info(f"Iteration {ctx.iteration}: Starting...")
-                start_time = time.time()
-                result = run_iteration(ctx)
-                duration = int(time.time() - start_time)
+                # Run iteration (only when orchestration is active — activated by /loom)
+                if ctx.orchestration_active:
+                    log_info(f"Iteration {ctx.iteration}: Starting...")
+                    start_time = time.time()
+                    result = run_iteration(ctx)
+                    duration = int(time.time() - start_time)
 
-                # Log result
-                log_info(f"Iteration {ctx.iteration}: {result.summary} ({duration}s)")
+                    # Log result
+                    log_info(f"Iteration {ctx.iteration}: {result.summary} ({duration}s)")
 
-                # Update metrics
-                _update_metrics(ctx, result.status, duration, result.summary)
+                    # Update metrics
+                    _update_metrics(ctx, result.status, duration, result.summary)
 
-                # Check for shutdown in result
-                if result.status == "shutdown" or "SHUTDOWN" in result.summary:
-                    break
-            else:
-                log_info(
-                    f"Iteration {ctx.iteration}: Standby — "
-                    "waiting for /loom to activate orchestration"
+                    # Check for shutdown in result
+                    if result.status == "shutdown" or "SHUTDOWN" in result.summary:
+                        break
+                else:
+                    log_info(
+                        f"Iteration {ctx.iteration}: Standby — "
+                        "waiting for /loom to activate orchestration"
+                    )
+
+                # Successful iteration — reset error counter
+                consecutive_errors = 0
+
+            except (KeyboardInterrupt, SystemExit):
+                # These are intentional exits — always re-raise
+                raise
+            except Exception as e:
+                consecutive_errors += 1
+                log_warning(
+                    f"Iteration {ctx.iteration}: Non-critical error "
+                    f"({consecutive_errors}/{MAX_CONSECUTIVE_ERRORS}): {e}"
                 )
+                if consecutive_errors >= MAX_CONSECUTIVE_ERRORS:
+                    log_error(
+                        f"Iteration {ctx.iteration}: "
+                        f"{MAX_CONSECUTIVE_ERRORS} consecutive errors — "
+                        f"treating as fatal"
+                    )
+                    raise
 
             # Check stop signal again before sleeping
             if check_stop_signal(ctx):
@@ -198,24 +222,31 @@ def _responsive_sleep(
             ctx.running = False
             break
 
-        # Process any IPC commands that arrived during the sleep tick
-        commands = command_poller.poll()
-        if commands:
-            log_info(f"Sleep-tick: processing {len(commands)} signal command(s)")
-            _process_commands(ctx, commands, command_poller)
-            _update_signal_queue_depth(ctx, command_poller.queue_depth())
+        # Process any IPC commands that arrived during the sleep tick.
+        # Wrapped in try/except so transient errors (e.g., missing lock
+        # files, stale state) don't crash the daemon during sleep.
+        try:
+            commands = command_poller.poll()
+            if commands:
+                log_info(f"Sleep-tick: processing {len(commands)} signal command(s)")
+                _process_commands(ctx, commands, command_poller)
+                _update_signal_queue_depth(ctx, command_poller.queue_depth())
 
-        # Retry pending spawns that were queued when all slots were full.
-        # Doing this during sleep ticks means a freed slot triggers a spawn
-        # within 2s rather than waiting for the next full iteration.
-        if ctx.pending_spawns:
-            _retry_pending_spawns(ctx)
+            # Retry pending spawns that were queued when all slots were full.
+            # Doing this during sleep ticks means a freed slot triggers a spawn
+            # within 2s rather than waiting for the next full iteration.
+            if ctx.pending_spawns:
+                _retry_pending_spawns(ctx)
 
-        # Fast-path assignment: if idle shepherd slots exist and the cached
-        # snapshot shows ready issues, spawn immediately without waiting for
-        # the next full iteration. This eliminates poll_interval latency when
-        # a shepherd completes and ready issues are already queued.
-        _fast_path_assign(ctx)
+            # Fast-path assignment: if idle shepherd slots exist and the cached
+            # snapshot shows ready issues, spawn immediately without waiting for
+            # the next full iteration. This eliminates poll_interval latency when
+            # a shepherd completes and ready issues are already queued.
+            _fast_path_assign(ctx)
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception as e:
+            log_warning(f"Sleep-tick: non-critical error (continuing): {e}")
 
 
 def _process_commands(

--- a/loom-tools/tests/daemon_v2/test_error_resilience.py
+++ b/loom-tools/tests/daemon_v2/test_error_resilience.py
@@ -1,0 +1,507 @@
+"""Tests for daemon error resilience (issue #3102).
+
+Verifies that the daemon catches non-critical errors (FileNotFoundError,
+PermissionError, etc.) in the main loop and iteration logic instead of
+crashing the entire daemon process.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from unittest import mock
+
+import pytest
+
+from loom_tools.daemon_v2.actions.completions import CompletionEntry
+from loom_tools.daemon_v2.config import DaemonConfig
+from loom_tools.daemon_v2.context import DaemonContext
+from loom_tools.daemon_v2.iteration import IterationResult, run_iteration
+from loom_tools.models.daemon_state import DaemonState, ShepherdEntry
+
+
+def _make_ctx(
+    tmp_path: pathlib.Path,
+    shepherds: dict[str, ShepherdEntry] | None = None,
+    max_shepherds: int = 3,
+) -> DaemonContext:
+    """Create a minimal DaemonContext for testing."""
+    config = DaemonConfig(max_shepherds=max_shepherds)
+    ctx = DaemonContext(config=config, repo_root=tmp_path)
+    ctx.iteration = 1
+    ctx.state = DaemonState(shepherds=shepherds or {})
+    ctx.snapshot = {
+        "computed": {
+            "active_shepherds": 0,
+            "available_shepherd_slots": max_shepherds,
+            "total_ready": 0,
+            "total_building": 0,
+            "total_blocked": 0,
+            "health_status": "healthy",
+            "health_warnings": [],
+            "recommended_actions": [],
+            "needs_human_input": [],
+        },
+        "shepherds": {"progress": []},
+        "prs": {"spinning": []},
+        "pipeline_health": {},
+    }
+    return ctx
+
+
+class TestIterationCompletionErrorResilience:
+    """Verify that errors in completion handling don't crash the iteration."""
+
+    def test_check_completions_error_returns_success(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """If check_completions raises, run_iteration still succeeds."""
+        ctx = _make_ctx(tmp_path)
+
+        # Create state file so _save_daemon_state works
+        state_file = tmp_path / ".loom" / "daemon-state.json"
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+        state_file.write_text("{}")
+
+        with (
+            mock.patch(
+                "loom_tools.daemon_v2.iteration.build_snapshot",
+                return_value=ctx.snapshot,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.iteration.read_daemon_state",
+                return_value=ctx.state,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.iteration.check_completions",
+                side_effect=FileNotFoundError(
+                    "[Errno 2] No such file or directory: '.loom/claude-config/shepherd-4/.claude.json.lock'"
+                ),
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.iteration.spawn_shepherds",
+                return_value=0,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.iteration.spawn_roles_from_actions",
+                return_value=0,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.iteration.force_reclaim_stale_shepherds",
+                return_value=0,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.iteration.reclaim_completed_support_roles",
+                return_value=[],
+            ),
+        ):
+            result = run_iteration(ctx)
+
+        # Should be success, not a crash
+        assert result.status == "success"
+        assert result.completions_handled == 0
+
+    def test_handle_completion_error_continues_to_next(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """If handle_completion raises for one entry, the rest still run."""
+        ctx = _make_ctx(
+            tmp_path,
+            shepherds={
+                "shepherd-1": ShepherdEntry(
+                    status="working", issue=100, task_id="aaa1111"
+                ),
+                "shepherd-2": ShepherdEntry(
+                    status="working", issue=200, task_id="bbb2222"
+                ),
+            },
+        )
+
+        state_file = tmp_path / ".loom" / "daemon-state.json"
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+        state_file.write_text("{}")
+
+        completion1 = CompletionEntry(
+            type="shepherd", name="shepherd-1", issue=100, task_id="aaa1111"
+        )
+        completion2 = CompletionEntry(
+            type="shepherd", name="shepherd-2", issue=200, task_id="bbb2222"
+        )
+
+        handle_call_count = 0
+
+        def mock_handle(ctx, completion):
+            nonlocal handle_call_count
+            handle_call_count += 1
+            if completion.name == "shepherd-1":
+                raise PermissionError("cannot remove lock file")
+
+        with (
+            mock.patch(
+                "loom_tools.daemon_v2.iteration.build_snapshot",
+                return_value=ctx.snapshot,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.iteration.read_daemon_state",
+                return_value=ctx.state,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.iteration.check_completions",
+                return_value=[completion1, completion2],
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.iteration.handle_completion",
+                side_effect=mock_handle,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.iteration.spawn_shepherds",
+                return_value=0,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.iteration.spawn_roles_from_actions",
+                return_value=0,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.iteration.force_reclaim_stale_shepherds",
+                return_value=0,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.iteration.reclaim_completed_support_roles",
+                return_value=[],
+            ),
+        ):
+            result = run_iteration(ctx)
+
+        # Both completions were attempted (2 calls), even though first raised
+        assert handle_call_count == 2
+        assert result.status == "success"
+
+    def test_stale_shepherd_reclaim_error_continues(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """If stale shepherd reclaim raises, iteration still succeeds."""
+        ctx = _make_ctx(tmp_path)
+
+        state_file = tmp_path / ".loom" / "daemon-state.json"
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+        state_file.write_text("{}")
+
+        with (
+            mock.patch(
+                "loom_tools.daemon_v2.iteration.build_snapshot",
+                return_value=ctx.snapshot,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.iteration.read_daemon_state",
+                return_value=ctx.state,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.iteration.check_completions",
+                return_value=[],
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.iteration.force_reclaim_stale_shepherds",
+                side_effect=OSError("disk I/O error"),
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.iteration.spawn_shepherds",
+                return_value=0,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.iteration.spawn_roles_from_actions",
+                return_value=0,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.iteration.reclaim_completed_support_roles",
+                return_value=[],
+            ),
+        ):
+            result = run_iteration(ctx)
+
+        assert result.status == "success"
+
+    def test_support_role_reclaim_error_continues(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """If support role reclaim raises, iteration still succeeds."""
+        ctx = _make_ctx(tmp_path)
+
+        state_file = tmp_path / ".loom" / "daemon-state.json"
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+        state_file.write_text("{}")
+
+        with (
+            mock.patch(
+                "loom_tools.daemon_v2.iteration.build_snapshot",
+                return_value=ctx.snapshot,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.iteration.read_daemon_state",
+                return_value=ctx.state,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.iteration.check_completions",
+                return_value=[],
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.iteration.force_reclaim_stale_shepherds",
+                return_value=0,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.iteration.spawn_shepherds",
+                return_value=0,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.iteration.spawn_roles_from_actions",
+                return_value=0,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.iteration.reclaim_completed_support_roles",
+                side_effect=FileNotFoundError("config dir missing"),
+            ),
+        ):
+            result = run_iteration(ctx)
+
+        assert result.status == "success"
+
+
+class TestMainLoopErrorResilience:
+    """Verify that the main loop catches non-critical errors."""
+
+    def test_single_iteration_error_does_not_crash(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """A single non-critical error should log a warning and continue."""
+        from loom_tools.daemon_v2.loop import run
+
+        config = DaemonConfig(poll_interval=1, timeout_min=0)
+        ctx = DaemonContext(config=config, repo_root=tmp_path)
+
+        # Create required dirs/files
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir(parents=True)
+        signals_dir = loom_dir / "signals"
+        signals_dir.mkdir()
+        pid_file = loom_dir / "daemon.pid"
+
+        iteration_count = 0
+
+        def mock_run_iteration(ctx):
+            nonlocal iteration_count
+            iteration_count += 1
+            if iteration_count == 1:
+                raise FileNotFoundError(
+                    ".loom/claude-config/shepherd-4/.claude.json.lock"
+                )
+            # Stop after second iteration
+            ctx.running = False
+            return IterationResult(status="success", summary="ok")
+
+        with (
+            mock.patch(
+                "loom_tools.daemon_v2.loop.check_existing_pid",
+                return_value=(False, None),
+            ),
+            mock.patch("loom_tools.daemon_v2.loop._run_preflight_checks", return_value=[]),
+            mock.patch("loom_tools.daemon_v2.loop.write_pid_file"),
+            mock.patch("loom_tools.daemon_v2.loop._rotate_state_file"),
+            mock.patch("loom_tools.daemon_v2.loop._init_state_file"),
+            mock.patch("loom_tools.daemon_v2.loop._init_metrics_file"),
+            mock.patch("loom_tools.daemon_v2.loop.clear_stop_signal"),
+            mock.patch("loom_tools.daemon_v2.loop._print_header"),
+            mock.patch("loom_tools.daemon_v2.loop.load_config"),
+            mock.patch("loom_tools.daemon_v2.loop.handle_daemon_startup"),
+            mock.patch("loom_tools.daemon_v2.loop.handle_daemon_shutdown"),
+            mock.patch("loom_tools.daemon_v2.loop.cleanup_on_exit"),
+            mock.patch("loom_tools.daemon_v2.loop.check_stop_signal", return_value=False),
+            mock.patch("loom_tools.daemon_v2.loop.check_session_conflict", return_value=False),
+            mock.patch("loom_tools.daemon_v2.loop.run_iteration", side_effect=mock_run_iteration),
+            mock.patch("loom_tools.daemon_v2.loop._update_metrics"),
+            mock.patch("loom_tools.daemon_v2.loop._responsive_sleep"),
+            mock.patch("loom_tools.daemon_v2.loop.CommandPoller") as mock_poller_cls,
+        ):
+            mock_poller = mock.MagicMock()
+            mock_poller.poll.return_value = []
+            mock_poller.queue_depth.return_value = 0
+            mock_poller_cls.return_value = mock_poller
+
+            ctx.orchestration_active = True
+
+            exit_code = run(ctx)
+
+        # Daemon should complete gracefully (exit code 0), not crash (exit code 1)
+        assert exit_code == 0
+        # Both iterations should have run
+        assert iteration_count == 2
+
+    def test_consecutive_errors_eventually_crash(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """10 consecutive non-critical errors should be treated as fatal."""
+        from loom_tools.daemon_v2.exit_codes import DaemonExitCode
+        from loom_tools.daemon_v2.loop import run
+
+        config = DaemonConfig(poll_interval=1, timeout_min=0)
+        ctx = DaemonContext(config=config, repo_root=tmp_path)
+
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir(parents=True)
+        signals_dir = loom_dir / "signals"
+        signals_dir.mkdir()
+
+        def mock_run_iteration(ctx):
+            raise FileNotFoundError("persistent failure")
+
+        with (
+            mock.patch(
+                "loom_tools.daemon_v2.loop.check_existing_pid",
+                return_value=(False, None),
+            ),
+            mock.patch("loom_tools.daemon_v2.loop._run_preflight_checks", return_value=[]),
+            mock.patch("loom_tools.daemon_v2.loop.write_pid_file"),
+            mock.patch("loom_tools.daemon_v2.loop._rotate_state_file"),
+            mock.patch("loom_tools.daemon_v2.loop._init_state_file"),
+            mock.patch("loom_tools.daemon_v2.loop._init_metrics_file"),
+            mock.patch("loom_tools.daemon_v2.loop.clear_stop_signal"),
+            mock.patch("loom_tools.daemon_v2.loop._print_header"),
+            mock.patch("loom_tools.daemon_v2.loop.load_config"),
+            mock.patch("loom_tools.daemon_v2.loop.handle_daemon_startup"),
+            mock.patch("loom_tools.daemon_v2.loop.handle_daemon_shutdown"),
+            mock.patch("loom_tools.daemon_v2.loop.cleanup_on_exit"),
+            mock.patch("loom_tools.daemon_v2.loop.check_stop_signal", return_value=False),
+            mock.patch("loom_tools.daemon_v2.loop.check_session_conflict", return_value=False),
+            mock.patch("loom_tools.daemon_v2.loop.run_iteration", side_effect=mock_run_iteration),
+            mock.patch("loom_tools.daemon_v2.loop._responsive_sleep"),
+            mock.patch("loom_tools.daemon_v2.loop.CommandPoller") as mock_poller_cls,
+        ):
+            mock_poller = mock.MagicMock()
+            mock_poller.poll.return_value = []
+            mock_poller.queue_depth.return_value = 0
+            mock_poller_cls.return_value = mock_poller
+
+            ctx.orchestration_active = True
+
+            exit_code = run(ctx)
+
+        # Should crash after MAX_CONSECUTIVE_ERRORS (10)
+        assert exit_code == DaemonExitCode.ERROR
+
+    def test_error_counter_resets_on_success(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """A successful iteration resets the consecutive error counter."""
+        from loom_tools.daemon_v2.loop import run
+
+        config = DaemonConfig(poll_interval=1, timeout_min=0)
+        ctx = DaemonContext(config=config, repo_root=tmp_path)
+
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir(parents=True)
+        signals_dir = loom_dir / "signals"
+        signals_dir.mkdir()
+
+        call_count = 0
+
+        def mock_run_iteration(ctx):
+            nonlocal call_count
+            call_count += 1
+            # First 5 calls fail, then succeed, then 5 more fail, then succeed
+            # This ensures the counter resets after success
+            if call_count <= 5:
+                raise FileNotFoundError("transient error")
+            if call_count == 6:
+                return IterationResult(status="success", summary="ok")
+            if call_count <= 11:
+                raise FileNotFoundError("transient error again")
+            # Stop after the 12th call
+            ctx.running = False
+            return IterationResult(status="success", summary="done")
+
+        with (
+            mock.patch(
+                "loom_tools.daemon_v2.loop.check_existing_pid",
+                return_value=(False, None),
+            ),
+            mock.patch("loom_tools.daemon_v2.loop._run_preflight_checks", return_value=[]),
+            mock.patch("loom_tools.daemon_v2.loop.write_pid_file"),
+            mock.patch("loom_tools.daemon_v2.loop._rotate_state_file"),
+            mock.patch("loom_tools.daemon_v2.loop._init_state_file"),
+            mock.patch("loom_tools.daemon_v2.loop._init_metrics_file"),
+            mock.patch("loom_tools.daemon_v2.loop.clear_stop_signal"),
+            mock.patch("loom_tools.daemon_v2.loop._print_header"),
+            mock.patch("loom_tools.daemon_v2.loop.load_config"),
+            mock.patch("loom_tools.daemon_v2.loop.handle_daemon_startup"),
+            mock.patch("loom_tools.daemon_v2.loop.handle_daemon_shutdown"),
+            mock.patch("loom_tools.daemon_v2.loop.cleanup_on_exit"),
+            mock.patch("loom_tools.daemon_v2.loop.check_stop_signal", return_value=False),
+            mock.patch("loom_tools.daemon_v2.loop.check_session_conflict", return_value=False),
+            mock.patch("loom_tools.daemon_v2.loop.run_iteration", side_effect=mock_run_iteration),
+            mock.patch("loom_tools.daemon_v2.loop._update_metrics"),
+            mock.patch("loom_tools.daemon_v2.loop._responsive_sleep"),
+            mock.patch("loom_tools.daemon_v2.loop.CommandPoller") as mock_poller_cls,
+        ):
+            mock_poller = mock.MagicMock()
+            mock_poller.poll.return_value = []
+            mock_poller.queue_depth.return_value = 0
+            mock_poller_cls.return_value = mock_poller
+
+            ctx.orchestration_active = True
+
+            exit_code = run(ctx)
+
+        # Should complete gracefully — the success at call 6 and 12 reset
+        # the error counter so we never hit the threshold of 10
+        assert exit_code == 0
+        assert call_count == 12
+
+    def test_keyboard_interrupt_propagates_through_loop(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """KeyboardInterrupt should propagate and not be silently caught."""
+        from loom_tools.daemon_v2.loop import run
+
+        config = DaemonConfig(poll_interval=1, timeout_min=0)
+        ctx = DaemonContext(config=config, repo_root=tmp_path)
+
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir(parents=True)
+        signals_dir = loom_dir / "signals"
+        signals_dir.mkdir()
+
+        def mock_run_iteration(ctx):
+            raise KeyboardInterrupt()
+
+        with (
+            mock.patch(
+                "loom_tools.daemon_v2.loop.check_existing_pid",
+                return_value=(False, None),
+            ),
+            mock.patch("loom_tools.daemon_v2.loop._run_preflight_checks", return_value=[]),
+            mock.patch("loom_tools.daemon_v2.loop.write_pid_file"),
+            mock.patch("loom_tools.daemon_v2.loop._rotate_state_file"),
+            mock.patch("loom_tools.daemon_v2.loop._init_state_file"),
+            mock.patch("loom_tools.daemon_v2.loop._init_metrics_file"),
+            mock.patch("loom_tools.daemon_v2.loop.clear_stop_signal"),
+            mock.patch("loom_tools.daemon_v2.loop._print_header"),
+            mock.patch("loom_tools.daemon_v2.loop.load_config"),
+            mock.patch("loom_tools.daemon_v2.loop.handle_daemon_startup"),
+            mock.patch("loom_tools.daemon_v2.loop.handle_daemon_shutdown"),
+            mock.patch("loom_tools.daemon_v2.loop.cleanup_on_exit"),
+            mock.patch("loom_tools.daemon_v2.loop.check_stop_signal", return_value=False),
+            mock.patch("loom_tools.daemon_v2.loop.check_session_conflict", return_value=False),
+            mock.patch("loom_tools.daemon_v2.loop.run_iteration", side_effect=mock_run_iteration),
+            mock.patch("loom_tools.daemon_v2.loop._responsive_sleep"),
+            mock.patch("loom_tools.daemon_v2.loop.CommandPoller") as mock_poller_cls,
+        ):
+            mock_poller = mock.MagicMock()
+            mock_poller.poll.return_value = []
+            mock_poller.queue_depth.return_value = 0
+            mock_poller_cls.return_value = mock_poller
+
+            ctx.orchestration_active = True
+
+            # KeyboardInterrupt inherits from BaseException, not Exception.
+            # The inner try/except (KeyboardInterrupt, SystemExit): raise
+            # re-raises it. The outer except Exception does NOT catch it.
+            # It propagates through finally and out to the caller.
+            with pytest.raises(KeyboardInterrupt):
+                run(ctx)


### PR DESCRIPTION
Closes #3102

## Summary

- Wrap the daemon main loop iteration body in try/except so transient OS errors (FileNotFoundError, PermissionError, etc.) log warnings instead of crashing the process
- Wrap individual completion handling, stale shepherd reclaim, and support role reclaim in iteration.py so a failure in one operation does not skip the rest
- Protect sleep-tick operations (IPC command processing, pending spawn retries, fast-path assignment) with the same resilience pattern
- Track consecutive errors with a threshold of 10 -- persistent failures are still treated as fatal to prevent infinite error loops
- KeyboardInterrupt and SystemExit are explicitly re-raised so intentional exits propagate normally

## Test plan

- [x] 8 new tests in `test_error_resilience.py` covering:
  - FileNotFoundError in check_completions does not crash iteration
  - PermissionError in handle_completion for one entry does not skip others
  - OSError in stale shepherd reclaim does not crash iteration
  - FileNotFoundError in support role reclaim does not crash iteration
  - Single iteration error logs warning and continues
  - 10 consecutive errors trigger fatal exit
  - Error counter resets after successful iteration
  - KeyboardInterrupt propagates through the loop
- [x] All 249 existing daemon_v2/iteration/completion tests pass with no regressions