### PR TITLE
feat: auto-detect CI presence to avoid false ci_failing warnings

### DIFF
--- a/loom-tools/src/loom_tools/snapshot.py
+++ b/loom-tools/src/loom_tools/snapshot.py
@@ -338,10 +338,14 @@ def collect_pipeline_data(
     # Run usage check separately (it's a script, not a gh query)
     usage = _collect_usage(repo_root)
 
-    # Run CI health check if enabled
+    # Run CI health check if enabled and CI workflows exist
     ci_status: dict[str, Any] = {"status": "unknown", "message": "CI health check disabled"}
     if ci_health_check_enabled:
-        ci_status = gh_get_default_branch_ci_status()
+        workflows_dir = repo_root / ".github" / "workflows"
+        if workflows_dir.is_dir() and any(workflows_dir.iterdir()):
+            ci_status = gh_get_default_branch_ci_status()
+        else:
+            ci_status = {"status": "no_ci", "message": "No CI workflows configured (.github/workflows/ not found)"}
 
     return {
         "ready_issues": results[0],
@@ -1421,6 +1425,7 @@ def compute_health(
         })
 
     # ci_failing - CI is broken on the default branch
+    # Skip when status is "no_ci" (no workflows configured) to avoid false warnings
     if ci_status and ci_status.get("status") == "failing":
         failed_runs = ci_status.get("failed_runs", [])
         warnings.append({
@@ -1891,7 +1896,7 @@ ENVIRONMENT VARIABLES:
     LOOM_SYSTEMATIC_FAILURE_THRESHOLD  Consecutive failures to suppress (default: 3)
     LOOM_SYSTEMATIC_FAILURE_COOLDOWN   Seconds before first probe attempt (default: 1800)
     LOOM_SYSTEMATIC_FAILURE_MAX_PROBES Maximum probe attempts (default: 3)
-    LOOM_CI_HEALTH_CHECK               Enable CI status monitoring (default: true)
+    LOOM_CI_HEALTH_CHECK               Enable CI status monitoring (default: true, auto-disabled when no .github/workflows/ found)
 """
 
 

--- a/loom-tools/tests/test_snapshot.py
+++ b/loom-tools/tests/test_snapshot.py
@@ -29,6 +29,7 @@ from loom_tools.snapshot import (
     TmuxPool,
     _CURATED_SKIP_LABELS,
     build_snapshot,
+    collect_pipeline_data,
     compute_health,
     compute_pipeline_health,
     compute_recommended_actions,
@@ -1256,6 +1257,66 @@ class TestPipelineHealthTieredPolicy:
 
 
 # ---------------------------------------------------------------------------
+# CI auto-detection in collect_pipeline_data
+# ---------------------------------------------------------------------------
+
+
+class TestCollectPipelineDataCiAutoDetect:
+    """Tests for CI auto-detection in collect_pipeline_data."""
+
+    def test_no_workflows_dir_returns_no_ci(self, tmp_path: pathlib.Path) -> None:
+        """When .github/workflows/ doesn't exist, ci_status should be no_ci."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        # No .github/workflows/ directory at all
+        with mock.patch("loom_tools.snapshot.gh_parallel_queries") as mock_queries, \
+             mock.patch("loom_tools.snapshot._collect_usage", return_value={}):
+            mock_queries.return_value = [[] for _ in range(10)]
+            result = collect_pipeline_data(repo, ci_health_check_enabled=True)
+        assert result["ci_status"]["status"] == "no_ci"
+        assert "not found" in result["ci_status"]["message"]
+
+    def test_empty_workflows_dir_returns_no_ci(self, tmp_path: pathlib.Path) -> None:
+        """When .github/workflows/ exists but is empty, ci_status should be no_ci."""
+        repo = tmp_path / "repo"
+        (repo / ".github" / "workflows").mkdir(parents=True)
+        with mock.patch("loom_tools.snapshot.gh_parallel_queries") as mock_queries, \
+             mock.patch("loom_tools.snapshot._collect_usage", return_value={}):
+            mock_queries.return_value = [[] for _ in range(10)]
+            result = collect_pipeline_data(repo, ci_health_check_enabled=True)
+        assert result["ci_status"]["status"] == "no_ci"
+
+    def test_workflows_present_calls_gh(self, tmp_path: pathlib.Path) -> None:
+        """When .github/workflows/ has files, gh_get_default_branch_ci_status is called."""
+        repo = tmp_path / "repo"
+        wf_dir = repo / ".github" / "workflows"
+        wf_dir.mkdir(parents=True)
+        (wf_dir / "ci.yml").write_text("name: CI\n")
+        with mock.patch("loom_tools.snapshot.gh_parallel_queries") as mock_queries, \
+             mock.patch("loom_tools.snapshot._collect_usage", return_value={}), \
+             mock.patch("loom_tools.snapshot.gh_get_default_branch_ci_status") as mock_ci:
+            mock_queries.return_value = [[] for _ in range(10)]
+            mock_ci.return_value = {"status": "passing", "failed_runs": [], "total_runs": 1, "message": "CI passing"}
+            result = collect_pipeline_data(repo, ci_health_check_enabled=True)
+        mock_ci.assert_called_once()
+        assert result["ci_status"]["status"] == "passing"
+
+    def test_ci_disabled_skips_detection(self, tmp_path: pathlib.Path) -> None:
+        """When ci_health_check_enabled=False, skip detection entirely."""
+        repo = tmp_path / "repo"
+        wf_dir = repo / ".github" / "workflows"
+        wf_dir.mkdir(parents=True)
+        (wf_dir / "ci.yml").write_text("name: CI\n")
+        with mock.patch("loom_tools.snapshot.gh_parallel_queries") as mock_queries, \
+             mock.patch("loom_tools.snapshot._collect_usage", return_value={}), \
+             mock.patch("loom_tools.snapshot.gh_get_default_branch_ci_status") as mock_ci:
+            mock_queries.return_value = [[] for _ in range(10)]
+            result = collect_pipeline_data(repo, ci_health_check_enabled=False)
+        mock_ci.assert_not_called()
+        assert result["ci_status"]["status"] == "unknown"
+
+
+# ---------------------------------------------------------------------------
 # Health warnings
 # ---------------------------------------------------------------------------
 
@@ -1393,6 +1454,29 @@ class TestHealth:
         )
         assert status == "healthy"
         assert not any(w["code"] == "ci_failing" for w in warnings)
+
+    def test_ci_no_ci_status_healthy(self) -> None:
+        """no_ci status (no workflows configured) does not generate a warning."""
+        status, warnings = compute_health(
+            ready_count=1, building_count=0, blocked_count=0,
+            total_proposals=0, stale_heartbeat_count=0, orphaned_count=0,
+            usage_healthy=True, session_percent=50.0,
+            ci_status={"status": "no_ci", "message": "No CI workflows configured"},
+        )
+        assert status == "healthy"
+        assert not any(w["code"] == "ci_failing" for w in warnings)
+
+    def test_ci_no_ci_does_not_degrade_health(self) -> None:
+        """Repos without CI should stay healthy, not degraded."""
+        status, warnings = compute_health(
+            ready_count=0, building_count=0, blocked_count=0,
+            total_proposals=0, stale_heartbeat_count=0, orphaned_count=0,
+            usage_healthy=True, session_percent=50.0,
+            ci_status={"status": "no_ci", "message": "No CI workflows configured"},
+        )
+        # The only warning should be no_work_available (info), not ci_failing
+        ci_warns = [w for w in warnings if w["code"] == "ci_failing"]
+        assert len(ci_warns) == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #3105

## Summary

- Auto-detects CI presence by checking for `.github/workflows/` directory before querying GitHub API for CI status
- Repos without CI workflows now return `"no_ci"` status instead of making unnecessary `gh run list` API calls
- The `"no_ci"` status does not generate any health warning, keeping health status `"healthy"` for repos without CI

## Changes

**`loom-tools/src/loom_tools/snapshot.py`**:
- `collect_pipeline_data()`: checks for `.github/workflows/` directory existence and non-emptiness before calling `gh_get_default_branch_ci_status()`; returns `{"status": "no_ci", ...}` when no workflows found
- Updated env var help text to note auto-detection behavior

**`loom-tools/tests/test_snapshot.py`**:
- Added `TestCollectPipelineDataCiAutoDetect` class with 4 tests: no workflows dir, empty workflows dir, workflows present, CI disabled
- Added 2 tests in `TestHealth`: `no_ci` status stays healthy, `no_ci` doesn't degrade health

## Test plan

- [x] All 11 CI-related tests pass
- [x] All 286 tests in affected test files pass (test_snapshot.py, test_github.py, test_stall_escalation.py)
- [ ] Manual verification: run `loom-tools snapshot` in a repo without `.github/workflows/` and confirm health is `healthy`