### PR TITLE
fix: eliminate auth cache lock contention across all agent spawns

### DIFF
--- a/defaults/scripts/claude-wrapper.sh
+++ b/defaults/scripts/claude-wrapper.sh
@@ -42,11 +42,17 @@ API_ERROR_IDLE_TIMEOUT="${LOOM_API_ERROR_IDLE_TIMEOUT:-60}"
 
 # Auth cache configuration
 # Short-TTL file cache to prevent concurrent `claude auth status` calls
-# from overwhelming the auth endpoint when multiple agents start simultaneously
-AUTH_CACHE_TTL="${LOOM_AUTH_CACHE_TTL:-120}"  # seconds
+# from overwhelming the auth endpoint when multiple agents start simultaneously.
+# 300s is safe because auth tokens have much longer lifetimes; if auth was valid
+# 5 minutes ago it is still valid now.  See issue #3109.
+AUTH_CACHE_TTL="${LOOM_AUTH_CACHE_TTL:-300}"  # seconds (was 120, raised to reduce contention)
 # Max time a single auth check cycle can take: 15s timeout × 3 retries + backoff (2+5+10) ≈ 62s
 AUTH_CACHE_STALE_LOCK_THRESHOLD="${LOOM_AUTH_CACHE_STALE_LOCK_THRESHOLD:-90}"  # seconds
-AUTH_CACHE_LOCK_WAIT="${LOOM_AUTH_CACHE_LOCK_WAIT:-60}"  # seconds
+AUTH_CACHE_LOCK_WAIT="${LOOM_AUTH_CACHE_LOCK_WAIT:-10}"  # seconds (was 60, reduced to fail fast)
+# Extended TTL for lock-contention fallback: when the lock is held AND the cache
+# is expired but younger than this threshold, use the stale cached result instead
+# of blocking.  Prevents the cascading 60s-per-agent delay pattern.  See #3109.
+AUTH_CACHE_GRACE_TTL="${LOOM_AUTH_CACHE_GRACE_TTL:-600}"  # seconds
 
 # Startup health monitor configuration
 # How long (seconds) to watch early output for MCP/plugin failures
@@ -554,7 +560,12 @@ _auth_cache_unlock() {
 # Read cached auth output if it exists and is within TTL.
 # On success, echoes the cached auth JSON output and returns 0.
 # Returns 1 if cache is missing, corrupt, or expired.
+#
+# Optional argument: $1 = TTL override (defaults to AUTH_CACHE_TTL).
+# Callers can pass AUTH_CACHE_GRACE_TTL when willing to accept slightly stale
+# data to avoid lock contention.  See issue #3109.
 _auth_cache_read() {
+    local ttl="${1:-${AUTH_CACHE_TTL}}"
     local cache_file
     cache_file=$(_auth_cache_file)
 
@@ -571,7 +582,7 @@ _auth_cache_read() {
     local now
     now=$(date +%s)
     local age=$(( now - cache_time ))
-    if [[ "${age}" -gt "${AUTH_CACHE_TTL}" ]]; then
+    if [[ "${age}" -gt "${ttl}" ]]; then
         return 1
     fi
 
@@ -633,7 +644,22 @@ check_auth_status() {
     if _auth_cache_lock; then
         lock_acquired=true
     else
-        # Another process is refreshing — wait for it to finish, polling cache
+        # Another process is refreshing the cache.
+        # First, check if we have a recently-expired-but-still-trustworthy cached
+        # result (within AUTH_CACHE_GRACE_TTL).  Auth tokens have long lifetimes so
+        # a result from a few minutes ago is almost certainly still valid.  Using the
+        # grace TTL avoids the cascading delay pattern where N agents each wait 60s
+        # for the lock holder.  See issue #3109.
+        if cached_output=$(_auth_cache_read "${AUTH_CACHE_GRACE_TTL}"); then
+            local logged_in
+            logged_in=$(echo "${cached_output}" | python3 -c "import json,sys; print(json.load(sys.stdin).get('loggedIn', False))" 2>/dev/null || echo "")
+            if [[ "${logged_in}" == "True" ]]; then
+                log_info "Authentication check passed (grace-TTL cache, lock held by another process)"
+                return 0
+            fi
+        fi
+
+        # No usable grace cache — wait briefly for the lock holder to finish
         log_info "Auth cache lock held by another process, waiting up to ${AUTH_CACHE_LOCK_WAIT}s..."
         local wait_elapsed=0
         while [[ "${wait_elapsed}" -lt "${AUTH_CACHE_LOCK_WAIT}" ]]; do

--- a/loom-tools/src/loom_tools/daemon_v2/actions/support_roles.py
+++ b/loom-tools/src/loom_tools/daemon_v2/actions/support_roles.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING
 
 from loom_tools.agent_spawn import (
@@ -17,6 +18,11 @@ from loom_tools.models.daemon_state import SupportRoleEntry
 
 if TYPE_CHECKING:
     from loom_tools.daemon_v2.context import DaemonContext
+
+# Delay between consecutive support role spawns (seconds).
+# Prevents auth cache lock contention when multiple roles start simultaneously.
+# See issue #3109.
+SPAWN_STAGGER_DELAY = 3
 
 
 # Support roles and their corresponding slash commands
@@ -117,67 +123,71 @@ def _get_first_targeted_pr(ctx: DaemonContext, key: str) -> int | None:
 def spawn_roles_from_actions(ctx: DaemonContext) -> int:
     """Spawn support roles based on recommended actions from snapshot.
 
+    Staggers spawns by SPAWN_STAGGER_DELAY seconds between consecutive
+    successful spawns to prevent auth cache lock contention.  See issue #3109.
+
     Returns the number of roles spawned.
     """
     actions = ctx.get_recommended_actions()
     spawned = 0
 
+    def _spawn_with_stagger(role: str, **kwargs: object) -> bool:
+        """Spawn a role and stagger if this is not the first spawn."""
+        nonlocal spawned
+        if spawned > 0:
+            log_info(
+                f"Staggering {role} spawn by {SPAWN_STAGGER_DELAY}s "
+                f"to avoid auth cache contention"
+            )
+            time.sleep(SPAWN_STAGGER_DELAY)
+        if spawn_support_role(ctx, role, **kwargs):  # type: ignore[arg-type]
+            spawned += 1
+            return True
+        return False
+
     # Demand-based triggers (higher priority)
     # Targeted dispatch takes precedence: if orphaned PRs exist, the
     # snapshot generates ``spawn_*_targeted`` instead of ``spawn_*_demand``.
     if "spawn_champion_demand" in actions:
-        if spawn_support_role(ctx, "champion", demand=True):
-            spawned += 1
+        _spawn_with_stagger("champion", demand=True)
 
     if "spawn_doctor_targeted" in actions:
         pr = _get_first_targeted_pr(ctx, "doctor_targeted_prs")
-        if spawn_support_role(ctx, "doctor", demand=True, target_pr=pr):
-            spawned += 1
+        _spawn_with_stagger("doctor", demand=True, target_pr=pr)
     elif "spawn_doctor_demand" in actions:
-        if spawn_support_role(ctx, "doctor", demand=True):
-            spawned += 1
+        _spawn_with_stagger("doctor", demand=True)
 
     if "spawn_judge_targeted" in actions:
         pr = _get_first_targeted_pr(ctx, "judge_targeted_prs")
-        if spawn_support_role(ctx, "judge", demand=True, target_pr=pr):
-            spawned += 1
+        _spawn_with_stagger("judge", demand=True, target_pr=pr)
     elif "spawn_judge_demand" in actions:
-        if spawn_support_role(ctx, "judge", demand=True):
-            spawned += 1
+        _spawn_with_stagger("judge", demand=True)
 
     # Interval-based triggers
     if "trigger_guide" in actions:
-        if spawn_support_role(ctx, "guide"):
-            spawned += 1
+        _spawn_with_stagger("guide")
 
     if "trigger_champion" in actions and "spawn_champion_demand" not in actions:
-        if spawn_support_role(ctx, "champion"):
-            spawned += 1
+        _spawn_with_stagger("champion")
 
     if "trigger_doctor" in actions and "spawn_doctor_demand" not in actions and "spawn_doctor_targeted" not in actions:
-        if spawn_support_role(ctx, "doctor"):
-            spawned += 1
+        _spawn_with_stagger("doctor")
 
     if "trigger_auditor" in actions:
-        if spawn_support_role(ctx, "auditor"):
-            spawned += 1
+        _spawn_with_stagger("auditor")
 
     if "trigger_judge" in actions and "spawn_judge_demand" not in actions and "spawn_judge_targeted" not in actions:
-        if spawn_support_role(ctx, "judge"):
-            spawned += 1
+        _spawn_with_stagger("judge")
 
     # Work generation roles
     if "trigger_architect" in actions:
-        if spawn_support_role(ctx, "architect"):
-            spawned += 1
+        _spawn_with_stagger("architect")
 
     if "trigger_hermit" in actions:
-        if spawn_support_role(ctx, "hermit"):
-            spawned += 1
+        _spawn_with_stagger("hermit")
 
     if "trigger_curator" in actions:
-        if spawn_support_role(ctx, "curator"):
-            spawned += 1
+        _spawn_with_stagger("curator")
 
     return spawned
 

--- a/loom-tools/src/loom_tools/daemon_v2/loop.py
+++ b/loom-tools/src/loom_tools/daemon_v2/loop.py
@@ -82,16 +82,24 @@ def run(ctx: DaemonContext) -> int:
         # 9. Print startup header
         _print_header(ctx)
 
-        # 10. Initialize CommandPoller for signal-based IPC with /loom skill
+        # 10. Pre-warm the auth cache (issue #3109)
+        # Run a single `claude auth status` before spawning any agents so the
+        # shared file cache at /tmp/claude-auth-cache-*.json is populated.
+        # Without this, the first batch of spawned agents (shepherds + support
+        # roles) all contend on the auth cache lock simultaneously, each waiting
+        # up to 60s and wasting 90-120s per agent.
+        _prewarm_auth_cache(ctx)
+
+        # 11. Initialize CommandPoller for signal-based IPC with /loom skill
         command_poller = CommandPoller(ctx.repo_root)
         log_info(f"CommandPoller initialized: signals_dir={ctx.signals_dir}")
 
-        # 11. Compute deadline for timeout
+        # 12. Compute deadline for timeout
         deadline: float | None = None
         if ctx.config.timeout_min > 0:
             deadline = time.time() + ctx.config.timeout_min * 60
 
-        # 12. Main loop
+        # 13. Main loop
         consecutive_errors = 0
         MAX_CONSECUTIVE_ERRORS = 10  # Crash only after this many in a row
 
@@ -184,7 +192,7 @@ def run(ctx: DaemonContext) -> int:
             log_info(f"Sleeping {ctx.config.poll_interval}s until next iteration...")
             _responsive_sleep(ctx, command_poller, ctx.config.poll_interval)
 
-        # 11. Run shutdown cleanup
+        # 14. Run shutdown cleanup
         log_info("Running shutdown cleanup...")
         handle_daemon_shutdown(ctx.repo_root, cleanup_config)
 
@@ -1024,6 +1032,56 @@ def _update_metrics(ctx: DaemonContext, status: str, duration: int, summary: str
         data["average_iteration_seconds"] = sum(durations) // len(durations)
 
     write_json_file(ctx.metrics_file, data)
+
+
+def _prewarm_auth_cache(ctx: DaemonContext) -> None:
+    """Pre-warm the shared auth cache before spawning any agents.
+
+    Runs a single ``claude auth status --json`` call and writes the result to
+    the shared cache file at ``/tmp/claude-auth-cache-<uid>.json``.  This
+    ensures that all subsequently-spawned agents (shepherds and support roles)
+    find a fresh cache entry and skip the lock-contention path entirely.
+
+    Without pre-warming, the first N agents spawned after daemon start all try
+    to acquire the same file lock simultaneously, leading to cascading delays
+    of 60-120s per agent.  See issue #3109.
+
+    This is best-effort: if the auth check fails, agents will fall back to
+    their normal per-agent auth check (just with potential contention).
+    """
+    log_info("Pre-warming auth cache...")
+    try:
+        result = subprocess.run(
+            ["claude", "auth", "status", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            env={**os.environ, "CLAUDECODE": ""},  # Unset to avoid nested guard
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            # Write the cache file in the same format claude-wrapper.sh expects
+            import json as _json
+
+            uid = os.getuid()
+            cache_file = f"/tmp/claude-auth-cache-{uid}.json"
+            now = int(time.time())
+            cache_data = {
+                "time": now,
+                "exit_code": 0,
+                "output": result.stdout.strip(),
+            }
+            with open(cache_file, "w") as f:
+                _json.dump(cache_data, f)
+            log_success("Auth cache pre-warmed successfully")
+        else:
+            log_warning(
+                f"Auth cache pre-warm: claude auth status returned "
+                f"exit code {result.returncode}"
+            )
+    except subprocess.TimeoutExpired:
+        log_warning("Auth cache pre-warm: timed out after 15s (non-fatal)")
+    except Exception as e:
+        log_warning(f"Auth cache pre-warm failed (non-fatal): {e}")
 
 
 def _print_header(ctx: DaemonContext) -> None:

--- a/loom-tools/tests/test_auth_cache_contention.py
+++ b/loom-tools/tests/test_auth_cache_contention.py
@@ -1,0 +1,284 @@
+"""Tests for auth cache contention mitigation (issue #3109).
+
+Tests cover:
+1. Auth cache pre-warming in the daemon loop
+2. Staggered support role spawning
+3. Staggered shepherd spawning
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+from unittest import mock
+
+import pytest
+
+from loom_tools.daemon_v2.config import DaemonConfig
+from loom_tools.daemon_v2.context import DaemonContext
+from loom_tools.models.daemon_state import DaemonState, ShepherdEntry, SupportRoleEntry
+
+
+def _make_ctx(
+    tmp_path: pathlib.Path,
+    max_shepherds: int = 3,
+    auto_build: bool = True,
+) -> DaemonContext:
+    """Create a minimal DaemonContext for testing."""
+    config = DaemonConfig(max_shepherds=max_shepherds, auto_build=auto_build)
+    ctx = DaemonContext(config=config, repo_root=tmp_path)
+    ctx.state = DaemonState()
+    ctx.snapshot = {
+        "computed": {
+            "active_shepherds": 0,
+            "available_shepherd_slots": max_shepherds,
+            "total_ready": 0,
+            "total_building": 0,
+            "total_blocked": 0,
+            "health_status": "healthy",
+            "health_warnings": [],
+            "recommended_actions": [],
+        },
+    }
+    return ctx
+
+
+class TestPrewarmAuthCache:
+    """Tests for _prewarm_auth_cache."""
+
+    def test_prewarm_writes_cache_file_on_success(self, tmp_path: pathlib.Path) -> None:
+        """Pre-warm writes a valid cache file when auth succeeds."""
+        from loom_tools.daemon_v2.loop import _prewarm_auth_cache
+
+        ctx = _make_ctx(tmp_path)
+        auth_output = json.dumps({"loggedIn": True, "user": "test"})
+
+        with mock.patch("subprocess.run") as mock_run, \
+             mock.patch("os.getuid", return_value=12345):
+            mock_run.return_value = mock.Mock(
+                returncode=0,
+                stdout=auth_output,
+            )
+            _prewarm_auth_cache(ctx)
+
+        # Verify the cache file was written
+        cache_file = pathlib.Path("/tmp/claude-auth-cache-12345.json")
+        assert cache_file.exists()
+        data = json.loads(cache_file.read_text())
+        assert data["exit_code"] == 0
+        assert "loggedIn" in data["output"]
+        assert isinstance(data["time"], int)
+
+        # Clean up
+        cache_file.unlink(missing_ok=True)
+
+    def test_prewarm_handles_timeout_gracefully(self, tmp_path: pathlib.Path) -> None:
+        """Pre-warm does not raise on timeout (non-fatal)."""
+        import subprocess
+        from loom_tools.daemon_v2.loop import _prewarm_auth_cache
+
+        ctx = _make_ctx(tmp_path)
+
+        with mock.patch("subprocess.run", side_effect=subprocess.TimeoutExpired("claude", 15)):
+            # Should not raise
+            _prewarm_auth_cache(ctx)
+
+    def test_prewarm_handles_nonzero_exit(self, tmp_path: pathlib.Path) -> None:
+        """Pre-warm logs warning on non-zero exit code."""
+        from loom_tools.daemon_v2.loop import _prewarm_auth_cache
+
+        ctx = _make_ctx(tmp_path)
+
+        with mock.patch("subprocess.run") as mock_run:
+            mock_run.return_value = mock.Mock(returncode=1, stdout="")
+            # Should not raise
+            _prewarm_auth_cache(ctx)
+
+    def test_prewarm_handles_exception_gracefully(self, tmp_path: pathlib.Path) -> None:
+        """Pre-warm does not raise on unexpected exceptions."""
+        from loom_tools.daemon_v2.loop import _prewarm_auth_cache
+
+        ctx = _make_ctx(tmp_path)
+
+        with mock.patch("subprocess.run", side_effect=OSError("no such command")):
+            # Should not raise
+            _prewarm_auth_cache(ctx)
+
+
+class TestSupportRoleStagger:
+    """Tests for staggered support role spawning."""
+
+    def test_first_spawn_has_no_delay(self, tmp_path: pathlib.Path) -> None:
+        """The first role spawn should not sleep."""
+        from loom_tools.daemon_v2.actions.support_roles import spawn_roles_from_actions
+
+        ctx = _make_ctx(tmp_path)
+        ctx.snapshot["computed"]["recommended_actions"] = ["trigger_guide"]
+
+        with mock.patch(
+            "loom_tools.daemon_v2.actions.support_roles.spawn_support_role",
+            return_value=True,
+        ) as mock_spawn, mock.patch(
+            "loom_tools.daemon_v2.actions.support_roles.time.sleep"
+        ) as mock_sleep:
+            result = spawn_roles_from_actions(ctx)
+
+        assert result == 1
+        mock_spawn.assert_called_once()
+        mock_sleep.assert_not_called()
+
+    def test_second_spawn_has_stagger_delay(self, tmp_path: pathlib.Path) -> None:
+        """Second and subsequent role spawns should sleep between them."""
+        from loom_tools.daemon_v2.actions.support_roles import (
+            SPAWN_STAGGER_DELAY,
+            spawn_roles_from_actions,
+        )
+
+        ctx = _make_ctx(tmp_path)
+        ctx.snapshot["computed"]["recommended_actions"] = [
+            "trigger_guide",
+            "trigger_auditor",
+        ]
+
+        with mock.patch(
+            "loom_tools.daemon_v2.actions.support_roles.spawn_support_role",
+            return_value=True,
+        ), mock.patch(
+            "loom_tools.daemon_v2.actions.support_roles.time.sleep"
+        ) as mock_sleep:
+            result = spawn_roles_from_actions(ctx)
+
+        assert result == 2
+        # Exactly one sleep call (before the second spawn)
+        mock_sleep.assert_called_once_with(SPAWN_STAGGER_DELAY)
+
+    def test_failed_spawn_does_not_trigger_stagger(self, tmp_path: pathlib.Path) -> None:
+        """A failed spawn (returns False) does not increment counter or stagger."""
+        from loom_tools.daemon_v2.actions.support_roles import spawn_roles_from_actions
+
+        ctx = _make_ctx(tmp_path)
+        ctx.snapshot["computed"]["recommended_actions"] = [
+            "trigger_guide",
+            "trigger_auditor",
+        ]
+
+        # First call fails, second succeeds
+        with mock.patch(
+            "loom_tools.daemon_v2.actions.support_roles.spawn_support_role",
+            side_effect=[False, True],
+        ), mock.patch(
+            "loom_tools.daemon_v2.actions.support_roles.time.sleep"
+        ) as mock_sleep:
+            result = spawn_roles_from_actions(ctx)
+
+        assert result == 1
+        # No stagger since the first spawn failed (spawned count was 0 before second)
+        mock_sleep.assert_not_called()
+
+    def test_three_spawns_stagger_twice(self, tmp_path: pathlib.Path) -> None:
+        """Three successful spawns should stagger between each consecutive pair."""
+        from loom_tools.daemon_v2.actions.support_roles import (
+            SPAWN_STAGGER_DELAY,
+            spawn_roles_from_actions,
+        )
+
+        ctx = _make_ctx(tmp_path)
+        ctx.snapshot["computed"]["recommended_actions"] = [
+            "trigger_guide",
+            "trigger_auditor",
+            "trigger_architect",
+        ]
+
+        with mock.patch(
+            "loom_tools.daemon_v2.actions.support_roles.spawn_support_role",
+            return_value=True,
+        ), mock.patch(
+            "loom_tools.daemon_v2.actions.support_roles.time.sleep"
+        ) as mock_sleep:
+            result = spawn_roles_from_actions(ctx)
+
+        assert result == 3
+        assert mock_sleep.call_count == 2
+        for call in mock_sleep.call_args_list:
+            assert call == mock.call(SPAWN_STAGGER_DELAY)
+
+
+class TestShepherdSpawnStagger:
+    """Tests for staggered shepherd spawning."""
+
+    def test_single_shepherd_no_delay(self, tmp_path: pathlib.Path) -> None:
+        """Spawning a single shepherd should not sleep."""
+        from loom_tools.daemon_v2.actions.shepherds import spawn_shepherds
+
+        ctx = _make_ctx(tmp_path)
+        ctx.snapshot["computed"]["available_shepherd_slots"] = 3
+        ctx.snapshot["pipeline"] = {"ready_issues": [{"number": 42}]}
+        ctx.snapshot["computed"]["total_ready"] = 1
+        ctx.snapshot["computed"]["recommended_actions"] = ["spawn_shepherds"]
+
+        with mock.patch(
+            "loom_tools.daemon_v2.actions.shepherds._spawn_single_shepherd",
+            return_value=True,
+        ), mock.patch(
+            "loom_tools.daemon_v2.actions.shepherds.time.sleep"
+        ) as mock_sleep:
+            result = spawn_shepherds(ctx)
+
+        assert result == 1
+        mock_sleep.assert_not_called()
+
+    def test_multiple_shepherds_stagger(self, tmp_path: pathlib.Path) -> None:
+        """Spawning multiple shepherds should sleep between them."""
+        from loom_tools.daemon_v2.actions.shepherds import (
+            SHEPHERD_SPAWN_STAGGER_DELAY,
+            spawn_shepherds,
+        )
+
+        ctx = _make_ctx(tmp_path)
+        ctx.snapshot["computed"]["available_shepherd_slots"] = 3
+        ctx.snapshot["pipeline"] = {
+            "ready_issues": [{"number": 42}, {"number": 43}]
+        }
+        ctx.snapshot["computed"]["total_ready"] = 2
+        ctx.snapshot["computed"]["recommended_actions"] = ["spawn_shepherds"]
+
+        with mock.patch(
+            "loom_tools.daemon_v2.actions.shepherds._spawn_single_shepherd",
+            return_value=True,
+        ), mock.patch(
+            "loom_tools.daemon_v2.actions.shepherds._find_idle_shepherd",
+            side_effect=["shepherd-1", "shepherd-2"],
+        ), mock.patch(
+            "loom_tools.daemon_v2.actions.shepherds.time.sleep"
+        ) as mock_sleep:
+            result = spawn_shepherds(ctx)
+
+        assert result == 2
+        # Only one sleep (before the second spawn)
+        mock_sleep.assert_called_once_with(SHEPHERD_SPAWN_STAGGER_DELAY)
+
+    def test_failed_spawn_no_stagger(self, tmp_path: pathlib.Path) -> None:
+        """A failed spawn does not count toward stagger."""
+        from loom_tools.daemon_v2.actions.shepherds import spawn_shepherds
+
+        ctx = _make_ctx(tmp_path)
+        ctx.snapshot["computed"]["available_shepherd_slots"] = 3
+        ctx.snapshot["pipeline"] = {
+            "ready_issues": [{"number": 42}, {"number": 43}]
+        }
+        ctx.snapshot["computed"]["total_ready"] = 2
+
+        with mock.patch(
+            "loom_tools.daemon_v2.actions.shepherds._spawn_single_shepherd",
+            side_effect=[False, True],
+        ), mock.patch(
+            "loom_tools.daemon_v2.actions.shepherds._find_idle_shepherd",
+            side_effect=["shepherd-1", "shepherd-2"],
+        ), mock.patch(
+            "loom_tools.daemon_v2.actions.shepherds.time.sleep"
+        ) as mock_sleep:
+            result = spawn_shepherds(ctx)
+
+        assert result == 1
+        # No stagger: first spawn failed so spawned=0 when second runs
+        mock_sleep.assert_not_called()


### PR DESCRIPTION
Closes #3109

## Summary

- **Pre-warm auth cache at daemon startup**: `loop.py` runs a single `claude auth status` before spawning any agents, populating the shared cache file so all subsequent agents hit cache immediately instead of contending on the lock
- **Stagger all agent spawns**: 3-second delay between consecutive successful spawns in both `support_roles.py` and `shepherds.py`, preventing simultaneous lock contention
- **Improve claude-wrapper.sh cache behavior**: raised cache TTL from 120s to 300s, reduced lock wait from 60s to 10s (fail fast), added grace-TTL fallback (use recently-expired cache up to 600s old when lock is held)

## Test plan

- [x] 11 new tests in `test_auth_cache_contention.py` covering pre-warm, stagger for support roles, and stagger for shepherds
- [x] All 30 related tests pass (new + existing iteration + support role reclaim)
- [x] Full test suite passes (654 passed, 1 pre-existing failure unrelated to this change)
- [ ] Manual verification: start daemon with multiple shepherds and observe no auth lock contention in logs