### PR TITLE
fix: clean up orphaned sessions and stale labels after daemon crash

### DIFF
--- a/loom-tools/src/loom_tools/clean.py
+++ b/loom-tools/src/loom_tools/clean.py
@@ -602,59 +602,159 @@ def clean_branches(
             stats.kept_branches += 1
 
 
+def _list_loom_tmux_sessions() -> list[str]:
+    """List all tmux sessions on the loom socket.
+
+    Returns session names (e.g. ``["loom-shepherd-1", "loom-champion"]``).
+    """
+    try:
+        result = subprocess.run(
+            ["tmux", "-L", "loom", "list-sessions", "-F", "#{session_name}"],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            return []
+        return [s.strip() for s in result.stdout.strip().split("\n") if s.strip()]
+    except (FileNotFoundError, Exception):
+        return []
+
+
 def clean_tmux_sessions(
     stats: CleanupStats,
     dry_run: bool = False,
 ) -> None:
-    """Clean up Loom tmux sessions."""
-    try:
-        result = subprocess.run(
-            ["tmux", "list-sessions"],
-            capture_output=True,
-            text=True,
-        )
+    """Clean up Loom tmux sessions on the loom socket."""
+    sessions = _list_loom_tmux_sessions()
 
-        if result.returncode != 0:
-            log_success("No Loom tmux sessions found")
-            return
-
-        sessions = []
-        for line in result.stdout.strip().split("\n"):
-            if line.startswith("loom-"):
-                session = line.split(":")[0]
-                sessions.append(session)
-
-        if not sessions:
-            log_success("No Loom tmux sessions found")
-            return
-
-        print("Found Loom tmux sessions:")
-        for session in sessions:
-            print(f"  - {session}")
-        print()
-
-        if dry_run:
-            log_info("Would kill these sessions")
-            stats.killed_tmux = len(sessions)
-        else:
-            for session in sessions:
-                try:
-                    subprocess.run(
-                        ["tmux", "kill-session", "-t", session],
-                        capture_output=True,
-                        text=True,
-                        check=True,
-                    )
-                    log_success(f"Killed: {session}")
-                    stats.killed_tmux += 1
-                except Exception:
-                    pass
-
-    except FileNotFoundError:
-        # tmux not installed
-        log_success("No Loom tmux sessions found (tmux not available)")
-    except Exception:
+    if not sessions:
         log_success("No Loom tmux sessions found")
+        return
+
+    print("Found Loom tmux sessions:")
+    for session in sessions:
+        print(f"  - {session}")
+    print()
+
+    if dry_run:
+        log_info("Would kill these sessions")
+        stats.killed_tmux = len(sessions)
+    else:
+        for session in sessions:
+            try:
+                subprocess.run(
+                    ["tmux", "-L", "loom", "kill-session", "-t", session],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                )
+                log_success(f"Killed: {session}")
+                stats.killed_tmux += 1
+            except Exception:
+                pass
+
+
+def clean_daemon_crash_state(
+    repo_root: pathlib.Path,
+    dry_run: bool = False,
+) -> None:
+    """Full daemon crash recovery: kill sessions, revert labels, clear state.
+
+    This is the one-shot manual cleanup invoked by ``loom-clean --daemon``
+    that performs everything the issue #3099 manual steps describe:
+
+    1. Kill all orphaned tmux sessions on the loom socket
+    2. Revert stale ``loom:building`` labels to ``loom:issue``
+    3. Clear stale claim files, progress files, and issue-failures.json
+    """
+    from loom_tools.daemon_cleanup import (
+        _revert_shepherd_labels,
+        _terminate_active_sessions,
+    )
+
+    state_path = repo_root / ".loom" / "daemon-state.json"
+
+    # 1. Kill all loom tmux sessions
+    print("Step 1: Kill orphaned tmux sessions")
+    stats = CleanupStats()
+    clean_tmux_sessions(stats, dry_run=dry_run)
+    print()
+
+    # 2. Terminate tracked sessions from daemon state and revert labels
+    print("Step 2: Terminate tracked sessions and revert stale labels")
+    _terminate_active_sessions(state_path, dry_run=dry_run)
+    _revert_shepherd_labels(state_path, dry_run=dry_run)
+    print()
+
+    # 3. Clear stale claim files
+    print("Step 3: Clear stale claims")
+    claims_dir = repo_root / ".loom" / "claims"
+    if claims_dir.is_dir():
+        claim_files = list(claims_dir.glob("*.json"))
+        if claim_files:
+            for claim_file in claim_files:
+                if dry_run:
+                    log_info(f"Would remove: {claim_file.name}")
+                else:
+                    claim_file.unlink(missing_ok=True)
+                    log_info(f"Removed: {claim_file.name}")
+        else:
+            log_success("No stale claim files")
+    else:
+        log_success("No claims directory")
+    print()
+
+    # 4. Clear stale progress files
+    print("Step 4: Clear stale progress files")
+    progress_dir = repo_root / ".loom" / "progress"
+    if progress_dir.is_dir():
+        progress_files = list(progress_dir.glob("*.json"))
+        if progress_files:
+            for pf in progress_files:
+                if dry_run:
+                    log_info(f"Would remove: {pf.name}")
+                else:
+                    pf.unlink(missing_ok=True)
+                    log_info(f"Removed: {pf.name}")
+        else:
+            log_success("No stale progress files")
+    else:
+        log_success("No progress directory")
+    print()
+
+    # 5. Reset issue-failures.json
+    print("Step 5: Reset issue-failures.json")
+    failures_file = repo_root / ".loom" / "issue-failures.json"
+    if failures_file.exists():
+        if dry_run:
+            log_info("Would reset: issue-failures.json")
+        else:
+            write_json_file(failures_file, {"entries": {}})
+            log_success("Reset issue-failures.json")
+    else:
+        log_success("No issue-failures.json to reset")
+    print()
+
+    # 6. Mark daemon state as not running
+    print("Step 6: Finalize daemon state")
+    if state_path.exists() and not dry_run:
+        data = read_json_file(state_path)
+        if isinstance(data, dict):
+            data["running"] = False
+            # Reset all shepherds to idle
+            shepherds = data.get("shepherds", {})
+            if isinstance(shepherds, dict):
+                for entry in shepherds.values():
+                    if isinstance(entry, dict):
+                        entry["status"] = "idle"
+                        entry["issue"] = None
+                        entry["task_id"] = None
+            write_json_file(state_path, data)
+            log_success("Daemon state finalized (running=false, shepherds reset)")
+    elif dry_run:
+        log_info("Would finalize daemon state")
+    else:
+        log_success("No daemon state to finalize")
 
 
 def clean_agent_config(
@@ -815,12 +915,20 @@ Safe mode (--safe):
   - Applies grace period after merge to avoid race conditions
   - Tracks cleanup state in daemon-state.json
 
+Daemon crash cleanup (--daemon):
+  - Kill all orphaned tmux sessions on the loom socket
+  - Revert stale loom:building labels to loom:issue
+  - Clear claims, progress files, and issue-failures.json
+  - Finalize daemon state (running=false, shepherds=idle)
+
 Examples:
   loom-clean                      # Interactive standard cleanup
   loom-clean --force              # Non-interactive cleanup (CI/automation)
   loom-clean --deep               # Include build artifacts
   loom-clean --safe               # Safe mode (MERGED PRs only)
   loom-clean --safe --force       # Safe mode, non-interactive
+  loom-clean --daemon             # Full daemon crash recovery
+  loom-clean --daemon --dry-run   # Preview daemon crash recovery
   loom-clean --worktrees-only     # Just worktrees
   loom-clean --branches-only      # Just branches
 """,
@@ -877,6 +985,11 @@ Examples:
         dest="tmux_only",
         help="Only clean tmux sessions (skip worktrees and branches)",
     )
+    parser.add_argument(
+        "--daemon",
+        action="store_true",
+        help="Daemon crash recovery: kill sessions, revert labels, clear state",
+    )
 
     args = parser.parse_args(argv)
 
@@ -885,6 +998,23 @@ Examples:
     except FileNotFoundError:
         log_error("Not in a git repository with .loom directory")
         return 1
+
+    # --daemon: full daemon crash recovery (separate workflow)
+    if args.daemon:
+        print()
+        print("========================================")
+        print("  Loom Daemon Crash Recovery")
+        if args.dry_run:
+            print("  (DRY RUN MODE)")
+        print("========================================")
+        print()
+        clean_daemon_crash_state(repo_root, dry_run=args.dry_run)
+        if args.dry_run:
+            log_warning("Dry run complete - no changes made")
+        else:
+            log_success("Daemon crash recovery complete!")
+        print()
+        return 0
 
     # Show banner
     print()

--- a/loom-tools/src/loom_tools/daemon_cleanup.py
+++ b/loom-tools/src/loom_tools/daemon_cleanup.py
@@ -657,12 +657,29 @@ def handle_daemon_startup(
     *,
     dry_run: bool = False,
 ) -> None:
-    """Cleanup stale artifacts from a previous daemon session."""
+    """Cleanup stale artifacts from a previous daemon session.
+
+    Steps 0a-0b run *before* the daemon state is rotated by the caller so
+    they can read the previous daemon state to discover which sessions were
+    active and which issues had ``loom:building`` labels.  This handles the
+    crash scenario where the previous daemon died without running shutdown
+    cleanup.
+    """
     log_info("Daemon Startup Cleanup")
 
     state_path = repo_root / ".loom" / "daemon-state.json"
 
-    # 0. Clean up expired file-based claims from previous session
+    # 0a. Kill orphaned tmux sessions left by a crashed previous daemon.
+    #     Must happen before state rotation so we can read previous state.
+    log_info("Cleaning up orphaned tmux sessions from previous daemon...")
+    _terminate_active_sessions(state_path, dry_run=dry_run)
+
+    # 0b. Revert stale loom:building labels for issues that were mid-build
+    #     when the previous daemon crashed.
+    log_info("Reverting stale labels from previous daemon...")
+    _revert_shepherd_labels(state_path, dry_run=dry_run)
+
+    # 0c. Clean up expired file-based claims from previous session
     log_info("Cleaning up expired claims...")
     if not dry_run:
         from loom_tools.claim import cleanup_claims

--- a/loom-tools/src/loom_tools/daemon_v2/loop.py
+++ b/loom-tools/src/loom_tools/daemon_v2/loop.py
@@ -63,23 +63,24 @@ def run(ctx: DaemonContext) -> int:
     signal.signal(signal.SIGTERM, signal_handler)
 
     try:
-        # 5. Rotate existing state file
+        # 5. Run crash recovery BEFORE rotating state, so we can read the
+        #    previous daemon state to find orphaned sessions and stale labels.
+        log_info("Running startup cleanup (crash recovery)...")
+        cleanup_config = load_config()
+        handle_daemon_startup(ctx.repo_root, cleanup_config)
+
+        # 6. Rotate existing state file (after crash recovery has read it)
         _rotate_state_file(ctx)
 
-        # 6. Initialize state and metrics files
+        # 7. Initialize state and metrics files
         _init_state_file(ctx)
         _init_metrics_file(ctx)
 
-        # 7. Clear any existing stop signal
+        # 8. Clear any existing stop signal
         clear_stop_signal(ctx)
 
-        # 8. Print startup header
+        # 9. Print startup header
         _print_header(ctx)
-
-        # 9. Run startup cleanup
-        log_info("Running startup cleanup...")
-        cleanup_config = load_config()
-        handle_daemon_startup(ctx.repo_root, cleanup_config)
 
         # 10. Initialize CommandPoller for signal-based IPC with /loom skill
         command_poller = CommandPoller(ctx.repo_root)
@@ -168,6 +169,16 @@ def run(ctx: DaemonContext) -> int:
 
     except Exception as e:
         log_error(f"Daemon error: {e}")
+
+        # Run crash cleanup: release labels and kill tmux sessions so the
+        # system doesn't appear busy when it is actually dead.
+        try:
+            log_warning("Running crash cleanup...")
+            crash_config = load_config()
+            handle_daemon_shutdown(ctx.repo_root, crash_config)
+        except Exception as cleanup_err:
+            log_error(f"Crash cleanup also failed: {cleanup_err}")
+
         return DaemonExitCode.ERROR
 
     finally:

--- a/loom-tools/tests/test_clean.py
+++ b/loom-tools/tests/test_clean.py
@@ -16,6 +16,7 @@ from loom_tools.clean import (
     check_grace_period,
     check_uncommitted_changes,
     clean_agent_config,
+    clean_daemon_crash_state,
     find_editable_pip_installs,
     main,
     print_summary,
@@ -584,4 +585,115 @@ class TestDocumentedDivergences:
         The implementations are equivalent but use different I/O mechanisms.
         """
         pass  # Behavior is equivalent
+
+
+class TestCleanDaemonCrashState:
+    """Tests for clean_daemon_crash_state (--daemon flag, issue #3099)."""
+
+    def test_cleans_claims_dir(self, mock_repo: pathlib.Path) -> None:
+        """Should remove all claim files."""
+        claims_dir = mock_repo / ".loom" / "claims"
+        claims_dir.mkdir(parents=True)
+        (claims_dir / "42.json").write_text('{"issue": 42}')
+        (claims_dir / "43.json").write_text('{"issue": 43}')
+
+        with patch("loom_tools.clean._list_loom_tmux_sessions", return_value=[]), \
+             patch("loom_tools.daemon_cleanup._terminate_active_sessions"), \
+             patch("loom_tools.daemon_cleanup._revert_shepherd_labels"):
+            clean_daemon_crash_state(mock_repo)
+
+        assert not list(claims_dir.glob("*.json"))
+
+    def test_cleans_progress_dir(self, mock_repo: pathlib.Path) -> None:
+        """Should remove all progress files."""
+        progress_dir = mock_repo / ".loom" / "progress"
+        progress_dir.mkdir(parents=True)
+        (progress_dir / "shepherd-abc.json").write_text('{"task_id": "abc"}')
+
+        with patch("loom_tools.clean._list_loom_tmux_sessions", return_value=[]), \
+             patch("loom_tools.daemon_cleanup._terminate_active_sessions"), \
+             patch("loom_tools.daemon_cleanup._revert_shepherd_labels"):
+            clean_daemon_crash_state(mock_repo)
+
+        assert not list(progress_dir.glob("*.json"))
+
+    def test_resets_issue_failures(self, mock_repo: pathlib.Path) -> None:
+        """Should reset issue-failures.json to empty entries."""
+        failures_file = mock_repo / ".loom" / "issue-failures.json"
+        failures_file.write_text('{"entries": {"42": {"count": 3}}}')
+
+        with patch("loom_tools.clean._list_loom_tmux_sessions", return_value=[]), \
+             patch("loom_tools.daemon_cleanup._terminate_active_sessions"), \
+             patch("loom_tools.daemon_cleanup._revert_shepherd_labels"):
+            clean_daemon_crash_state(mock_repo)
+
+        data = json.loads(failures_file.read_text())
+        assert data == {"entries": {}}
+
+    def test_finalizes_daemon_state(self, mock_repo: pathlib.Path) -> None:
+        """Should mark daemon state as not running and reset shepherds."""
+        state_path = mock_repo / ".loom" / "daemon-state.json"
+        state_path.write_text(json.dumps({
+            "running": True,
+            "shepherds": {
+                "shepherd-1": {"status": "working", "issue": 42, "task_id": "abc"},
+            },
+        }))
+
+        with patch("loom_tools.clean._list_loom_tmux_sessions", return_value=[]), \
+             patch("loom_tools.daemon_cleanup._terminate_active_sessions"), \
+             patch("loom_tools.daemon_cleanup._revert_shepherd_labels"):
+            clean_daemon_crash_state(mock_repo)
+
+        data = json.loads(state_path.read_text())
+        assert data["running"] is False
+        assert data["shepherds"]["shepherd-1"]["status"] == "idle"
+        assert data["shepherds"]["shepherd-1"]["issue"] is None
+        assert data["shepherds"]["shepherd-1"]["task_id"] is None
+
+    def test_dry_run_preserves_files(self, mock_repo: pathlib.Path) -> None:
+        """Dry run should not modify any files."""
+        claims_dir = mock_repo / ".loom" / "claims"
+        claims_dir.mkdir(parents=True)
+        claim_file = claims_dir / "42.json"
+        claim_file.write_text('{"issue": 42}')
+
+        progress_dir = mock_repo / ".loom" / "progress"
+        progress_dir.mkdir(parents=True)
+        progress_file = progress_dir / "shepherd-abc.json"
+        progress_file.write_text('{"task_id": "abc"}')
+
+        failures_file = mock_repo / ".loom" / "issue-failures.json"
+        failures_file.write_text('{"entries": {"42": {"count": 3}}}')
+
+        with patch("loom_tools.clean._list_loom_tmux_sessions", return_value=[]), \
+             patch("loom_tools.daemon_cleanup._terminate_active_sessions"), \
+             patch("loom_tools.daemon_cleanup._revert_shepherd_labels"):
+            clean_daemon_crash_state(mock_repo, dry_run=True)
+
+        assert claim_file.exists()
+        assert progress_file.exists()
+        assert json.loads(failures_file.read_text())["entries"]["42"]["count"] == 3
+
+
+class TestMainDaemonFlag:
+    """Tests for the --daemon CLI flag."""
+
+    def test_daemon_flag_runs_crash_recovery(self, mock_repo: pathlib.Path) -> None:
+        """--daemon should call clean_daemon_crash_state."""
+        with patch("loom_tools.clean.find_repo_root", return_value=mock_repo), \
+             patch("loom_tools.clean.clean_daemon_crash_state") as m_clean:
+            result = main(["--daemon"])
+
+        m_clean.assert_called_once_with(mock_repo, dry_run=False)
+        assert result == 0
+
+    def test_daemon_dry_run(self, mock_repo: pathlib.Path) -> None:
+        """--daemon --dry-run should pass dry_run=True."""
+        with patch("loom_tools.clean.find_repo_root", return_value=mock_repo), \
+             patch("loom_tools.clean.clean_daemon_crash_state") as m_clean:
+            result = main(["--daemon", "--dry-run"])
+
+        m_clean.assert_called_once_with(mock_repo, dry_run=True)
+        assert result == 0
 

--- a/loom-tools/tests/test_daemon_cleanup.py
+++ b/loom-tools/tests/test_daemon_cleanup.py
@@ -758,7 +758,9 @@ class TestHandleDaemonStartupCleanupSignals:
              mock.patch("loom_tools.daemon_cleanup._run_loom_clean"), \
              mock.patch("loom_tools.daemon_cleanup.cleanup_stale_progress_files"), \
              mock.patch("loom_tools.daemon_cleanup.cleanup_stale_signal_files") as mock_cleanup, \
-             mock.patch("loom_tools.daemon_cleanup._run_orphan_recovery"):
+             mock.patch("loom_tools.daemon_cleanup._run_orphan_recovery"), \
+             mock.patch("loom_tools.daemon_cleanup._terminate_active_sessions"), \
+             mock.patch("loom_tools.daemon_cleanup._revert_shepherd_labels"):
             handle_daemon_startup(tmp_path, config, dry_run=True)
 
         mock_cleanup.assert_called_once()
@@ -775,8 +777,167 @@ class TestHandleDaemonStartupCleanupSignals:
              mock.patch("loom_tools.daemon_cleanup._run_loom_clean"), \
              mock.patch("loom_tools.daemon_cleanup.cleanup_stale_progress_files"), \
              mock.patch("loom_tools.daemon_cleanup.cleanup_stale_signal_files") as mock_cleanup, \
-             mock.patch("loom_tools.daemon_cleanup._run_orphan_recovery"):
+             mock.patch("loom_tools.daemon_cleanup._run_orphan_recovery"), \
+             mock.patch("loom_tools.daemon_cleanup._terminate_active_sessions"), \
+             mock.patch("loom_tools.daemon_cleanup._revert_shepherd_labels"):
             handle_daemon_startup(tmp_path, config, dry_run=True)
 
         mock_cleanup.assert_called_once()
         assert mock_cleanup.call_args.kwargs.get("dry_run") is True
+
+
+class TestHandleDaemonStartupCrashRecovery:
+    """Tests that daemon startup cleans up after a crash (issue #3099)."""
+
+    def _write_state(self, state_path: pathlib.Path, data: dict) -> None:
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        state_path.write_text(json.dumps(data))
+
+    def test_startup_kills_orphaned_sessions(self, tmp_path: pathlib.Path) -> None:
+        """Startup should terminate tmux sessions left by a crashed daemon."""
+        state_path = tmp_path / ".loom" / "daemon-state.json"
+        self._write_state(state_path, {
+            "running": True,
+            "shepherds": {
+                "shepherd-1": {"status": "working", "issue": 42},
+            },
+            "support_roles": {
+                "champion": {"status": "running", "tmux_session": "loom-champion"},
+            },
+        })
+
+        config = load_config()
+
+        with mock.patch("loom_tools.daemon_cleanup.session_exists", return_value=True), \
+             mock.patch("loom_tools.daemon_cleanup.kill_stuck_session") as m_kill, \
+             mock.patch("loom_tools.common.github.gh_run"), \
+             mock.patch("loom_tools.daemon_cleanup._run_archive_logs"), \
+             mock.patch("loom_tools.daemon_cleanup._run_loom_clean"), \
+             mock.patch("loom_tools.daemon_cleanup.cleanup_stale_progress_files"), \
+             mock.patch("loom_tools.daemon_cleanup.cleanup_stale_signal_files"), \
+             mock.patch("loom_tools.daemon_cleanup._run_orphan_recovery"):
+            handle_daemon_startup(tmp_path, config)
+
+        # Both shepherd and support role sessions should be killed
+        assert m_kill.call_count == 2
+        m_kill.assert_any_call("shepherd-1")
+        m_kill.assert_any_call("champion")
+
+    def test_startup_reverts_stale_labels(self, tmp_path: pathlib.Path) -> None:
+        """Startup should revert loom:building labels from a crashed daemon."""
+        state_path = tmp_path / ".loom" / "daemon-state.json"
+        self._write_state(state_path, {
+            "running": True,
+            "shepherds": {
+                "shepherd-1": {"status": "working", "issue": 42},
+                "shepherd-2": {"status": "working", "issue": 43},
+            },
+            "support_roles": {},
+        })
+
+        config = load_config()
+
+        with mock.patch("loom_tools.daemon_cleanup.session_exists", return_value=False), \
+             mock.patch("loom_tools.daemon_cleanup.kill_stuck_session"), \
+             mock.patch("loom_tools.common.github.gh_run") as m_gh, \
+             mock.patch("loom_tools.daemon_cleanup._run_archive_logs"), \
+             mock.patch("loom_tools.daemon_cleanup._run_loom_clean"), \
+             mock.patch("loom_tools.daemon_cleanup.cleanup_stale_progress_files"), \
+             mock.patch("loom_tools.daemon_cleanup.cleanup_stale_signal_files"), \
+             mock.patch("loom_tools.daemon_cleanup._run_orphan_recovery"):
+            handle_daemon_startup(tmp_path, config)
+
+        # Both issues should have labels reverted
+        assert m_gh.call_count == 2
+        m_gh.assert_any_call([
+            "issue", "edit", "42",
+            "--remove-label", "loom:building",
+            "--add-label", "loom:issue",
+        ])
+        m_gh.assert_any_call([
+            "issue", "edit", "43",
+            "--remove-label", "loom:building",
+            "--add-label", "loom:issue",
+        ])
+
+    def test_startup_crash_recovery_order(self, tmp_path: pathlib.Path) -> None:
+        """Crash recovery should: terminate sessions, revert labels, THEN other cleanup."""
+        state_path = tmp_path / ".loom" / "daemon-state.json"
+        self._write_state(state_path, {
+            "running": True,
+            "shepherds": {
+                "shepherd-1": {"status": "working", "issue": 42},
+            },
+            "support_roles": {},
+        })
+
+        call_order: list[str] = []
+
+        def track_terminate(*a, **kw):
+            call_order.append("terminate_sessions")
+
+        def track_revert(*a, **kw):
+            call_order.append("revert_labels")
+
+        def track_orphan_recovery(*a, **kw):
+            call_order.append("orphan_recovery")
+
+        config = load_config()
+
+        with mock.patch("loom_tools.daemon_cleanup._terminate_active_sessions", side_effect=track_terminate), \
+             mock.patch("loom_tools.daemon_cleanup._revert_shepherd_labels", side_effect=track_revert), \
+             mock.patch("loom_tools.daemon_cleanup._run_orphan_recovery", side_effect=track_orphan_recovery), \
+             mock.patch("loom_tools.daemon_cleanup._run_archive_logs"), \
+             mock.patch("loom_tools.daemon_cleanup._run_loom_clean"), \
+             mock.patch("loom_tools.daemon_cleanup.cleanup_stale_progress_files"), \
+             mock.patch("loom_tools.daemon_cleanup.cleanup_stale_signal_files"):
+            handle_daemon_startup(tmp_path, config, dry_run=True)
+
+        # Session termination and label revert must happen before orphan recovery
+        assert call_order.index("terminate_sessions") < call_order.index("orphan_recovery")
+        assert call_order.index("revert_labels") < call_order.index("orphan_recovery")
+
+    def test_startup_with_no_previous_state(self, tmp_path: pathlib.Path) -> None:
+        """Startup without previous daemon state should not error."""
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir()
+
+        config = load_config()
+
+        with mock.patch("loom_tools.daemon_cleanup._run_archive_logs"), \
+             mock.patch("loom_tools.daemon_cleanup._run_loom_clean"), \
+             mock.patch("loom_tools.daemon_cleanup.cleanup_stale_progress_files"), \
+             mock.patch("loom_tools.daemon_cleanup.cleanup_stale_signal_files"), \
+             mock.patch("loom_tools.daemon_cleanup._run_orphan_recovery"):
+            # Should not raise
+            handle_daemon_startup(tmp_path, config, dry_run=True)
+
+    def test_startup_dry_run_does_not_kill_or_revert(self, tmp_path: pathlib.Path) -> None:
+        """Dry run startup should not kill sessions or call gh."""
+        state_path = tmp_path / ".loom" / "daemon-state.json"
+        self._write_state(state_path, {
+            "running": True,
+            "shepherds": {
+                "shepherd-1": {"status": "working", "issue": 42},
+            },
+            "support_roles": {
+                "champion": {"status": "running", "tmux_session": "loom-champion"},
+            },
+        })
+
+        config = load_config()
+
+        with mock.patch("loom_tools.daemon_cleanup.session_exists") as m_exists, \
+             mock.patch("loom_tools.daemon_cleanup.kill_stuck_session") as m_kill, \
+             mock.patch("loom_tools.common.github.gh_run") as m_gh, \
+             mock.patch("loom_tools.daemon_cleanup._run_archive_logs"), \
+             mock.patch("loom_tools.daemon_cleanup._run_loom_clean"), \
+             mock.patch("loom_tools.daemon_cleanup.cleanup_stale_progress_files"), \
+             mock.patch("loom_tools.daemon_cleanup.cleanup_stale_signal_files"), \
+             mock.patch("loom_tools.daemon_cleanup._run_orphan_recovery"):
+            handle_daemon_startup(tmp_path, config, dry_run=True)
+
+        # In dry_run mode, _terminate_active_sessions and _revert_shepherd_labels
+        # log but do not kill or call gh
+        m_kill.assert_not_called()
+        m_gh.assert_not_called()


### PR DESCRIPTION
Closes #3099

## Summary

- **Crash cleanup in daemon loop**: When the daemon crashes (unhandled exception), the `except` block now calls `handle_daemon_shutdown()` to kill tmux sessions and revert `loom:building` labels before exiting
- **Startup crash recovery**: `handle_daemon_startup()` now terminates orphaned tmux sessions and reverts stale labels from the previous daemon state *before* rotating it, so crash artifacts are cleaned up even if the daemon died without running shutdown cleanup
- **`loom-clean --daemon` flag**: One-shot manual crash recovery that kills all loom tmux sessions, reverts stale labels, clears claims/progress/failures, and finalizes daemon state
- **tmux socket fix**: `clean_tmux_sessions` now correctly uses the `loom` tmux socket (`-L loom`) instead of the default server

## Test plan

- [x] All 47 daemon_cleanup tests pass (5 new crash recovery tests)
- [x] All 51 clean tests pass (7 new tests for `--daemon` flag and `clean_daemon_crash_state`)
- [x] Pre-existing test failure on main confirmed unrelated (test_degraded_session_detection)
- [ ] Manual verification: start daemon, kill -9 it, verify next startup cleans up
- [ ] Manual verification: `loom-clean --daemon --dry-run` shows expected cleanup actions