### PR TITLE
feat: auto-decay failure counters when main branch advances

### DIFF
--- a/loom-tools/src/loom_tools/common/issue_failures.py
+++ b/loom-tools/src/loom_tools/common/issue_failures.py
@@ -20,14 +20,21 @@ File format::
                 "last_success_at": null
             }
         },
-        "updated_at": "2026-01-22T14:30:00Z"
+        "updated_at": "2026-01-22T14:30:00Z",
+        "last_known_main_sha": "abc123..."
     }
+
+**Commit-based decay**: When the main branch advances (new commits land),
+failure counters are automatically halved. This ensures that transient
+failures caused by missing infrastructure or stale state don't permanently
+block issues after the underlying conditions change. See issue #3112.
 """
 
 from __future__ import annotations
 
 import logging
 import os
+import subprocess
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -70,9 +77,37 @@ INFRASTRUCTURE_ERROR_CLASSES: frozenset[str] = frozenset({
 # 1st failure: 0, 2nd: 2, 3rd: 4, 4th: 8, 5th: auto-block
 BACKOFF_BASE = 2
 
+# Sentinel for _main_sha parameter — distinguishes "auto-detect" from "None"
+_SENTINEL: Any = object()
+
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def get_main_branch_sha(repo_root: Path) -> str | None:
+    """Get the current SHA of the main branch (origin/main).
+
+    Uses ``git rev-parse`` to resolve ``origin/main``. Falls back to ``main``
+    if the remote ref is unavailable. Returns ``None`` on any error so that
+    callers can gracefully skip the decay check.
+    """
+    for ref in ("origin/main", "main"):
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", ref],
+                capture_output=True,
+                text=True,
+                cwd=repo_root,
+                timeout=5,
+            )
+            if result.returncode == 0:
+                sha = result.stdout.strip()
+                if sha:
+                    return sha
+        except Exception:
+            continue
+    return None
 
 
 @dataclass
@@ -155,6 +190,7 @@ class IssueFailureLog:
 
     entries: dict[str, IssueFailureEntry] = field(default_factory=dict)
     updated_at: str | None = None
+    last_known_main_sha: str | None = None
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> IssueFailureLog:
@@ -166,19 +202,89 @@ class IssueFailureLog:
         return cls(
             entries=entries,
             updated_at=data.get("updated_at"),
+            last_known_main_sha=data.get("last_known_main_sha"),
         )
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        d: dict[str, Any] = {
             "entries": {k: v.to_dict() for k, v in self.entries.items()},
             "updated_at": self.updated_at,
         }
+        if self.last_known_main_sha is not None:
+            d["last_known_main_sha"] = self.last_known_main_sha
+        return d
 
 
-def load_failure_log(repo_root: Path) -> IssueFailureLog:
+def _decay_on_main_advance(
+    log: IssueFailureLog,
+    current_sha: str,
+) -> bool:
+    """Decay failure counters if the main branch has advanced.
+
+    When new commits land on main, the conditions that caused failures may
+    no longer apply (e.g., missing infrastructure got deployed, stale state
+    was cleaned up). Halving failure counts gives issues another chance while
+    still preserving some history for genuinely broken issues.
+
+    Entries whose count drops to zero are removed entirely.
+
+    Returns True if the log was modified.
+    """
+    if log.last_known_main_sha is None:
+        # First time tracking — record SHA without decaying
+        log.last_known_main_sha = current_sha
+        return False
+
+    if log.last_known_main_sha == current_sha:
+        return False
+
+    # Main has advanced — decay all failure counters
+    old_sha = log.last_known_main_sha
+
+    if not log.entries:
+        log.last_known_main_sha = current_sha
+        return False
+
+    to_remove: list[str] = []
+    for key, entry in log.entries.items():
+        entry.total_failures = entry.total_failures // 2
+        if entry.total_failures == 0:
+            to_remove.append(key)
+
+    for key in to_remove:
+        del log.entries[key]
+
+    log.last_known_main_sha = current_sha
+
+    removed_count = len(to_remove)
+    remaining_count = len(log.entries)
+    logger.info(
+        "Main branch advanced (%s -> %s): decayed failure counters "
+        "(removed=%d, remaining=%d)",
+        old_sha[:8] if old_sha else "?",
+        current_sha[:8],
+        removed_count,
+        remaining_count,
+    )
+    return True
+
+
+def load_failure_log(
+    repo_root: Path,
+    *,
+    _main_sha: str | None = _SENTINEL,
+) -> IssueFailureLog:
     """Load the persistent failure log from disk.
 
+    Automatically checks if the main branch has advanced since the last save,
+    and if so, halves all failure counters (commit-based decay). Entries that
+    decay to zero are removed.
+
     Returns an empty log if the file is missing or corrupt.
+
+    Args:
+        repo_root: Repository root path.
+        _main_sha: Override for testing. Use the sentinel default to auto-detect.
     """
     paths = LoomPaths(repo_root)
     fpath = paths.issue_failures_file
@@ -189,17 +295,41 @@ def load_failure_log(repo_root: Path) -> IssueFailureLog:
     try:
         data = read_json_file(fpath)
         if isinstance(data, dict):
-            return IssueFailureLog.from_dict(data)
+            log = IssueFailureLog.from_dict(data)
+        else:
+            return IssueFailureLog()
     except Exception:
         logger.warning("Corrupt issue-failures.json, starting fresh")
+        return IssueFailureLog()
 
-    return IssueFailureLog()
+    # Check for main branch advance and decay if needed
+    if _main_sha is _SENTINEL:
+        current_sha = get_main_branch_sha(repo_root)
+    else:
+        current_sha = _main_sha
+
+    if current_sha is not None and log.entries:
+        modified = _decay_on_main_advance(log, current_sha)
+        if modified:
+            save_failure_log(repo_root, log)
+
+    return log
 
 
 def save_failure_log(repo_root: Path, log: IssueFailureLog) -> None:
-    """Save the persistent failure log to disk."""
+    """Save the persistent failure log to disk.
+
+    Also records the current main branch SHA so we can detect advances
+    on the next load.
+    """
     paths = LoomPaths(repo_root)
     log.updated_at = _now_iso()
+
+    # Update the main SHA on save so the next load can compare
+    current_sha = get_main_branch_sha(repo_root)
+    if current_sha is not None:
+        log.last_known_main_sha = current_sha
+
     write_json_file(paths.issue_failures_file, log.to_dict())
 
 

--- a/loom-tools/tests/test_issue_failures.py
+++ b/loom-tools/tests/test_issue_failures.py
@@ -14,6 +14,7 @@ from loom_tools.common.issue_failures import (
     _DEFAULT_FAILURE_THRESHOLD,
     IssueFailureEntry,
     IssueFailureLog,
+    _decay_on_main_advance,
     get_failure_entry,
     load_failure_log,
     merge_into_daemon_state,
@@ -454,3 +455,271 @@ class TestConfigurableThreshold:
         """IssueFailureEntry.block_threshold falls back to MAX_FAILURES_BEFORE_BLOCK."""
         entry = IssueFailureEntry(total_failures=1, error_class="builder_stuck")
         assert entry.block_threshold == MAX_FAILURES_BEFORE_BLOCK
+
+
+# ── Commit-based decay ────────────────────────────────────────
+
+
+class TestDecayOnMainAdvance:
+    """Tests for failure counter decay when main branch advances (issue #3112)."""
+
+    def test_no_decay_when_sha_unchanged(self) -> None:
+        """No decay when main SHA has not changed."""
+        log = IssueFailureLog(
+            entries={"42": IssueFailureEntry(issue=42, total_failures=4)},
+            last_known_main_sha="aaa111",
+        )
+        modified = _decay_on_main_advance(log, "aaa111")
+        assert modified is False
+        assert log.entries["42"].total_failures == 4
+
+    def test_no_decay_when_sha_first_seen(self) -> None:
+        """First time seeing a SHA — record it, don't decay."""
+        log = IssueFailureLog(
+            entries={"42": IssueFailureEntry(issue=42, total_failures=4)},
+            last_known_main_sha=None,
+        )
+        modified = _decay_on_main_advance(log, "aaa111")
+        assert modified is False
+        assert log.entries["42"].total_failures == 4
+        assert log.last_known_main_sha == "aaa111"
+
+    def test_decay_halves_failure_count(self) -> None:
+        """When main advances, failure counts are halved."""
+        log = IssueFailureLog(
+            entries={"42": IssueFailureEntry(issue=42, total_failures=4)},
+            last_known_main_sha="aaa111",
+        )
+        modified = _decay_on_main_advance(log, "bbb222")
+        assert modified is True
+        assert log.entries["42"].total_failures == 2
+        assert log.last_known_main_sha == "bbb222"
+
+    def test_decay_removes_zero_entries(self) -> None:
+        """Entries that decay to zero are removed."""
+        log = IssueFailureLog(
+            entries={"42": IssueFailureEntry(issue=42, total_failures=1)},
+            last_known_main_sha="aaa111",
+        )
+        modified = _decay_on_main_advance(log, "bbb222")
+        assert modified is True
+        assert "42" not in log.entries
+
+    def test_decay_mixed_entries(self) -> None:
+        """Some entries removed, others reduced."""
+        log = IssueFailureLog(
+            entries={
+                "42": IssueFailureEntry(issue=42, total_failures=1),  # -> 0, removed
+                "99": IssueFailureEntry(issue=99, total_failures=6),  # -> 3, kept
+                "77": IssueFailureEntry(issue=77, total_failures=2),  # -> 1, kept
+            },
+            last_known_main_sha="aaa111",
+        )
+        modified = _decay_on_main_advance(log, "bbb222")
+        assert modified is True
+        assert "42" not in log.entries
+        assert log.entries["99"].total_failures == 3
+        assert log.entries["77"].total_failures == 1
+
+    def test_decay_unblocks_previously_blocked_issue(self) -> None:
+        """An issue at the block threshold is unblocked after decay."""
+        entry = IssueFailureEntry(
+            issue=42,
+            total_failures=MAX_FAILURES_BEFORE_BLOCK,
+            error_class="builder_stuck",
+        )
+        assert entry.should_auto_block is True
+
+        log = IssueFailureLog(
+            entries={"42": entry},
+            last_known_main_sha="aaa111",
+        )
+        _decay_on_main_advance(log, "bbb222")
+
+        # 5 // 2 = 2, which is below the block threshold
+        assert log.entries["42"].total_failures == MAX_FAILURES_BEFORE_BLOCK // 2
+        assert log.entries["42"].should_auto_block is False
+
+    def test_no_decay_when_entries_empty(self) -> None:
+        """No modification when there are no failure entries."""
+        log = IssueFailureLog(
+            entries={},
+            last_known_main_sha="aaa111",
+        )
+        modified = _decay_on_main_advance(log, "bbb222")
+        assert modified is False
+        assert log.last_known_main_sha == "bbb222"
+
+    def test_successive_decays(self) -> None:
+        """Multiple main advances progressively decay failures."""
+        log = IssueFailureLog(
+            entries={"42": IssueFailureEntry(issue=42, total_failures=8)},
+            last_known_main_sha="sha1",
+        )
+
+        # First advance: 8 -> 4
+        _decay_on_main_advance(log, "sha2")
+        assert log.entries["42"].total_failures == 4
+
+        # Second advance: 4 -> 2
+        _decay_on_main_advance(log, "sha3")
+        assert log.entries["42"].total_failures == 2
+
+        # Third advance: 2 -> 1
+        _decay_on_main_advance(log, "sha4")
+        assert log.entries["42"].total_failures == 1
+
+        # Fourth advance: 1 -> 0, removed
+        _decay_on_main_advance(log, "sha5")
+        assert "42" not in log.entries
+
+
+class TestLoadWithDecay:
+    """Tests for load_failure_log with commit-based decay via _main_sha."""
+
+    def test_load_triggers_decay_on_sha_change(self, repo: pathlib.Path) -> None:
+        """Loading with a new SHA triggers decay and saves."""
+        # Write initial state with known SHA
+        _write_failures(repo, {
+            "entries": {
+                "42": {
+                    "issue": 42,
+                    "total_failures": 4,
+                    "error_class": "builder_stuck",
+                    "phase": "builder",
+                }
+            },
+            "updated_at": "2026-01-01T00:00:00Z",
+            "last_known_main_sha": "old_sha",
+        })
+
+        log = load_failure_log(repo, _main_sha="new_sha")
+        assert log.entries["42"].total_failures == 2  # 4 // 2
+
+        # Verify it was persisted
+        data = _read_failures(repo)
+        assert data["entries"]["42"]["total_failures"] == 2
+        assert data["last_known_main_sha"] == "new_sha"
+
+    def test_load_no_decay_when_sha_same(self, repo: pathlib.Path) -> None:
+        """Loading with the same SHA does not trigger decay."""
+        _write_failures(repo, {
+            "entries": {
+                "42": {
+                    "issue": 42,
+                    "total_failures": 4,
+                    "error_class": "builder_stuck",
+                    "phase": "builder",
+                }
+            },
+            "updated_at": "2026-01-01T00:00:00Z",
+            "last_known_main_sha": "same_sha",
+        })
+
+        log = load_failure_log(repo, _main_sha="same_sha")
+        assert log.entries["42"].total_failures == 4
+
+    def test_load_no_decay_when_sha_none(self, repo: pathlib.Path) -> None:
+        """Loading with SHA=None (git unavailable) skips decay."""
+        _write_failures(repo, {
+            "entries": {
+                "42": {
+                    "issue": 42,
+                    "total_failures": 4,
+                    "error_class": "builder_stuck",
+                    "phase": "builder",
+                }
+            },
+            "updated_at": "2026-01-01T00:00:00Z",
+            "last_known_main_sha": "old_sha",
+        })
+
+        log = load_failure_log(repo, _main_sha=None)
+        assert log.entries["42"].total_failures == 4
+
+    def test_load_decay_removes_entries_at_one(self, repo: pathlib.Path) -> None:
+        """Entries with 1 failure are removed on decay (1 // 2 == 0)."""
+        _write_failures(repo, {
+            "entries": {
+                "42": {
+                    "issue": 42,
+                    "total_failures": 1,
+                    "error_class": "builder_stuck",
+                    "phase": "builder",
+                }
+            },
+            "updated_at": "2026-01-01T00:00:00Z",
+            "last_known_main_sha": "old_sha",
+        })
+
+        log = load_failure_log(repo, _main_sha="new_sha")
+        assert "42" not in log.entries
+
+    def test_load_decay_then_filter_unblocks_issue(self, repo: pathlib.Path) -> None:
+        """After decay, previously blocked issues pass the backoff filter."""
+        _write_failures(repo, {
+            "entries": {
+                "42": {
+                    "issue": 42,
+                    "total_failures": MAX_FAILURES_BEFORE_BLOCK,
+                    "error_class": "builder_stuck",
+                    "phase": "builder",
+                }
+            },
+            "updated_at": "2026-01-01T00:00:00Z",
+            "last_known_main_sha": "old_sha",
+        })
+
+        # Before decay: issue is blocked
+        log_before = load_failure_log(repo, _main_sha="old_sha")
+        issues = [{"number": 42}]
+        result = filter_issues_by_failure_backoff(issues, log_before, current_iteration=1)
+        assert len(result) == 0  # Blocked
+
+        # After main advances: issue is unblocked
+        log_after = load_failure_log(repo, _main_sha="new_sha")
+        result = filter_issues_by_failure_backoff(issues, log_after, current_iteration=3)
+        assert len(result) == 1  # Unblocked (2 failures, backoff=2, iter 3 % 3 == 0)
+
+
+class TestIssueFailureLogSerialization:
+    """Tests for last_known_main_sha serialization."""
+
+    def test_round_trip_with_sha(self) -> None:
+        log = IssueFailureLog(
+            entries={},
+            updated_at="2026-01-01T00:00:00Z",
+            last_known_main_sha="abc123def456",
+        )
+        data = log.to_dict()
+        assert data["last_known_main_sha"] == "abc123def456"
+
+        restored = IssueFailureLog.from_dict(data)
+        assert restored.last_known_main_sha == "abc123def456"
+
+    def test_round_trip_without_sha(self) -> None:
+        log = IssueFailureLog(
+            entries={},
+            updated_at="2026-01-01T00:00:00Z",
+        )
+        data = log.to_dict()
+        assert "last_known_main_sha" not in data
+
+        restored = IssueFailureLog.from_dict(data)
+        assert restored.last_known_main_sha is None
+
+    def test_backward_compatible_load(self) -> None:
+        """Old files without last_known_main_sha field load correctly."""
+        data = {
+            "entries": {
+                "42": {
+                    "issue": 42,
+                    "total_failures": 3,
+                    "error_class": "builder_stuck",
+                }
+            },
+            "updated_at": "2026-01-01T00:00:00Z",
+        }
+        log = IssueFailureLog.from_dict(data)
+        assert log.last_known_main_sha is None
+        assert log.entries["42"].total_failures == 3


### PR DESCRIPTION
Closes #3112

## Summary

- Adds commit-based decay to `issue_failures.py`: when the main branch advances (new SHA detected), all failure counters are automatically halved. Entries that decay to zero are removed.
- Tracks `last_known_main_sha` in `issue-failures.json` to detect when main has new commits.
- Decay happens transparently at load time via `load_failure_log()`, so all callers (snapshot, daemon loop, merge) automatically benefit.
- Fully backward compatible: old files without `last_known_main_sha` work correctly (first load records the SHA without decaying).

## Test plan

- [x] 16 new tests covering decay logic, load-time integration, serialization, and backward compatibility
- [x] All 55 issue_failures tests pass (39 existing + 16 new)
- [x] All 138 related module tests pass (issue_failures + systematic_failure + budget_exhaustion)
- [x] Full test suite passes (13 pre-existing failures in unrelated shepherd tests)
- [ ] Verify in production that failure counters decay when PRs merge to main