### PR TITLE
fix: auto-dispatch Doctor for merge-conflicted approved PRs

### DIFF
--- a/loom-tools/src/loom_tools/snapshot.py
+++ b/loom-tools/src/loom_tools/snapshot.py
@@ -701,12 +701,14 @@ def detect_orphaned_prs(
     daemon_state: DaemonState,
     review_requested: list[dict[str, Any]],
     changes_requested: list[dict[str, Any]],
+    merge_conflicted: list[dict[str, Any]] | None = None,
 ) -> list[OrphanedPR]:
     """Detect PRs needing attention that no active shepherd is tracking.
 
-    A PR is orphaned when it has ``loom:review-requested`` (needs judge) or
-    ``loom:changes-requested`` (needs doctor) but no working shepherd has it
-    as its ``pr_number``.
+    A PR is orphaned when it has ``loom:review-requested`` (needs judge),
+    ``loom:changes-requested`` (needs doctor), or ``loom:pr`` +
+    ``loom:merge-conflict`` (approved but blocked by conflicts, needs doctor)
+    but no working shepherd has it as its ``pr_number``.
 
     Returns orphaned PRs sorted by PR number ascending (FIFO).
     """
@@ -724,6 +726,12 @@ def detect_orphaned_prs(
             orphaned.append(OrphanedPR(pr_number=pr_num, needed_role="judge"))
 
     for pr in changes_requested:
+        pr_num = pr.get("number")
+        if pr_num is not None and pr_num not in tracked_prs:
+            orphaned.append(OrphanedPR(pr_number=pr_num, needed_role="doctor"))
+
+    # Approved PRs with merge conflicts need doctor attention (issue #3104)
+    for pr in merge_conflicted or []:
         pr_num = pr.get("number")
         if pr_num is not None and pr_num not in tracked_prs:
             orphaned.append(OrphanedPR(pr_number=pr_num, needed_role="doctor"))
@@ -1071,6 +1079,7 @@ def compute_recommended_actions(
     spinning_prs: list[SpinningPR] | None = None,
     curated_count: int = 0,
     uncurated_count: int = 0,
+    merge_conflict_count: int = 0,
 ) -> tuple[list[str], dict[str, Any]]:
     """Compute recommended actions and demand flags.
 
@@ -1136,7 +1145,7 @@ def compute_recommended_actions(
         demand["champion_demand"] = True
 
     doctor_status = support_roles.get("doctor", SupportRoleState()).status
-    if changes_count > 0 and doctor_status != "running":
+    if (changes_count > 0 or merge_conflict_count > 0) and doctor_status != "running":
         if doctor_targeted:
             actions.append("spawn_doctor_targeted")
             demand["doctor_targeted_prs"] = [o.pr_number for o in doctor_targeted]
@@ -1569,6 +1578,14 @@ def build_snapshot(
     changes_count = len(changes_requested)
     merge_count = len(ready_to_merge)
 
+    # Approved PRs (loom:pr) that also have loom:merge-conflict — these are
+    # blocking: approved but can't merge.  Derived from ready_to_merge since
+    # it already includes labels.  See issue #3104.
+    merge_conflicted = [
+        pr for pr in ready_to_merge if _has_label(pr, "loom:merge-conflict")
+    ]
+    merge_conflict_count = len(merge_conflicted)
+
     total_proposals = architect_count + hermit_count + curated_count
     total_in_flight = building_count + review_count + changes_count + merge_count
 
@@ -1615,7 +1632,7 @@ def build_snapshot(
     orphaned_count = len(orphaned)
 
     # 12. Orphaned PRs (PRs needing attention without an active shepherd)
-    orphaned_prs = detect_orphaned_prs(daemon_state, review_requested, changes_requested)
+    orphaned_prs = detect_orphaned_prs(daemon_state, review_requested, changes_requested, merge_conflicted)
 
     # 13. Pipeline health (retry/backoff classification)
     p_health = compute_pipeline_health(
@@ -1661,6 +1678,7 @@ def build_snapshot(
         spinning_prs=spinning_prs,
         curated_count=curated_count,
         uncurated_count=uncurated_count,
+        merge_conflict_count=merge_conflict_count,
     )
 
     # 16. Promotable proposals
@@ -1732,6 +1750,8 @@ def build_snapshot(
             "review_requested": review_requested,
             "changes_requested": changes_requested,
             "ready_to_merge": ready_to_merge,
+            "merge_conflicted": merge_conflicted,
+            "merge_conflict_count": merge_conflict_count,
             "orphaned": [o.to_dict() for o in orphaned_prs],
             "orphaned_count": len(orphaned_prs),
             "spinning": [s.to_dict() for s in spinning_prs],
@@ -1790,6 +1810,7 @@ def build_snapshot(
             "prs_awaiting_review": review_count,
             "prs_needing_fixes": changes_count,
             "prs_ready_to_merge": merge_count,
+            "prs_with_merge_conflicts": merge_conflict_count,
             "champion_demand": demand["champion_demand"],
             "doctor_demand": demand["doctor_demand"],
             "judge_demand": demand["judge_demand"],

--- a/loom-tools/tests/test_snapshot.py
+++ b/loom-tools/tests/test_snapshot.py
@@ -2207,3 +2207,146 @@ class TestCuratedSkipLabels:
             if not any(lbl["name"] in _CURATED_SKIP_LABELS for lbl in item.get("labels", []))
         ]
         assert [i["number"] for i in uncurated] == [2]
+
+
+# ---------------------------------------------------------------------------
+# Merge-conflicted approved PRs (issue #3104)
+# ---------------------------------------------------------------------------
+
+
+class TestDetectOrphanedPRs:
+    """Tests for detect_orphaned_prs including merge-conflicted approved PRs."""
+
+    def test_review_requested_orphaned(self) -> None:
+        """Review-requested PRs without a shepherd are orphaned (needs judge)."""
+        ds = DaemonState()
+        orphaned = detect_orphaned_prs(ds, [{"number": 10}], [])
+        assert len(orphaned) == 1
+        assert orphaned[0].pr_number == 10
+        assert orphaned[0].needed_role == "judge"
+
+    def test_changes_requested_orphaned(self) -> None:
+        """Changes-requested PRs without a shepherd are orphaned (needs doctor)."""
+        ds = DaemonState()
+        orphaned = detect_orphaned_prs(ds, [], [{"number": 20}])
+        assert len(orphaned) == 1
+        assert orphaned[0].pr_number == 20
+        assert orphaned[0].needed_role == "doctor"
+
+    def test_merge_conflicted_approved_pr_orphaned(self) -> None:
+        """Approved PRs with merge conflicts are orphaned (needs doctor)."""
+        ds = DaemonState()
+        merge_conflicted = [
+            {"number": 36, "labels": [{"name": "loom:pr"}, {"name": "loom:merge-conflict"}]}
+        ]
+        orphaned = detect_orphaned_prs(ds, [], [], merge_conflicted)
+        assert len(orphaned) == 1
+        assert orphaned[0].pr_number == 36
+        assert orphaned[0].needed_role == "doctor"
+
+    def test_merge_conflicted_tracked_by_shepherd_not_orphaned(self) -> None:
+        """Approved PRs with merge conflicts tracked by a shepherd are not orphaned."""
+        ds = DaemonState(shepherds={
+            "s-1": ShepherdEntry(status="working", pr_number=36),
+        })
+        merge_conflicted = [
+            {"number": 36, "labels": [{"name": "loom:pr"}, {"name": "loom:merge-conflict"}]}
+        ]
+        orphaned = detect_orphaned_prs(ds, [], [], merge_conflicted)
+        assert len(orphaned) == 0
+
+    def test_merge_conflicted_none_parameter(self) -> None:
+        """When merge_conflicted is None, no error occurs."""
+        ds = DaemonState()
+        orphaned = detect_orphaned_prs(ds, [], [], None)
+        assert len(orphaned) == 0
+
+    def test_merge_conflicted_default_parameter(self) -> None:
+        """When merge_conflicted is not passed, no error occurs (backward compat)."""
+        ds = DaemonState()
+        orphaned = detect_orphaned_prs(ds, [], [])
+        assert len(orphaned) == 0
+
+    def test_mixed_orphans_sorted_by_pr_number(self) -> None:
+        """Orphans from all three sources are sorted by PR number ascending."""
+        ds = DaemonState()
+        review_req = [{"number": 50}]
+        changes_req = [{"number": 30}]
+        merge_conf = [{"number": 10}]
+        orphaned = detect_orphaned_prs(ds, review_req, changes_req, merge_conf)
+        assert len(orphaned) == 3
+        assert [o.pr_number for o in orphaned] == [10, 30, 50]
+        assert orphaned[0].needed_role == "doctor"   # merge-conflict
+        assert orphaned[1].needed_role == "doctor"   # changes-requested
+        assert orphaned[2].needed_role == "judge"    # review-requested
+
+
+class TestMergeConflictDoctorDemand:
+    """Tests for doctor demand triggered by merge-conflicted approved PRs."""
+
+    def _base_kwargs(self) -> dict:
+        return {
+            "ready_count": 0,
+            "building_count": 0,
+            "blocked_count": 0,
+            "total_proposals": 0,
+            "architect_count": 0,
+            "hermit_count": 0,
+            "review_count": 0,
+            "changes_count": 0,
+            "merge_count": 0,
+            "available_shepherd_slots": 3,
+            "needs_work_generation": False,
+            "architect_cooldown_ok": True,
+            "hermit_cooldown_ok": True,
+            "support_roles": {r: SupportRoleState() for r in
+                              ("guide", "champion", "doctor", "auditor", "judge", "architect", "hermit", "curator")},
+            "orphaned_count": 0,
+            "invalid_task_id_count": 0,
+        }
+
+    def test_merge_conflicts_trigger_doctor_demand(self) -> None:
+        """merge_conflict_count > 0 should trigger spawn_doctor_demand."""
+        kw = self._base_kwargs()
+        kw["merge_conflict_count"] = 1
+        actions, demand = compute_recommended_actions(**kw)
+        assert "spawn_doctor_demand" in actions
+        assert demand["doctor_demand"] is True
+
+    def test_merge_conflicts_with_targeted_orphan(self) -> None:
+        """Merge-conflict orphan should trigger spawn_doctor_targeted."""
+        kw = self._base_kwargs()
+        kw["merge_conflict_count"] = 1
+        kw["orphaned_prs"] = [OrphanedPR(pr_number=36, needed_role="doctor")]
+        actions, demand = compute_recommended_actions(**kw)
+        assert "spawn_doctor_targeted" in actions
+        assert demand["doctor_targeted_prs"] == [36]
+        assert demand["doctor_demand"] is True
+
+    def test_no_merge_conflicts_no_extra_doctor_demand(self) -> None:
+        """When changes_count=0 and merge_conflict_count=0, no doctor demand."""
+        kw = self._base_kwargs()
+        actions, demand = compute_recommended_actions(**kw)
+        assert "spawn_doctor_demand" not in actions
+        assert "spawn_doctor_targeted" not in actions
+        assert demand["doctor_demand"] is False
+
+    def test_both_changes_and_merge_conflicts(self) -> None:
+        """Both changes_count and merge_conflict_count trigger doctor demand."""
+        kw = self._base_kwargs()
+        kw["changes_count"] = 1
+        kw["merge_conflict_count"] = 1
+        actions, demand = compute_recommended_actions(**kw)
+        assert "spawn_doctor_demand" in actions
+        assert demand["doctor_demand"] is True
+
+    def test_merge_conflicts_skip_when_doctor_running(self) -> None:
+        """Doctor demand should not fire if doctor is already running."""
+        kw = self._base_kwargs()
+        kw["merge_conflict_count"] = 1
+        doctor_state = SupportRoleState()
+        doctor_state.status = "running"
+        kw["support_roles"]["doctor"] = doctor_state
+        actions, demand = compute_recommended_actions(**kw)
+        assert "spawn_doctor_demand" not in actions
+        assert "spawn_doctor_targeted" not in actions


### PR DESCRIPTION
Closes #3104

## Summary

- Extends `detect_orphaned_prs()` to include approved PRs (`loom:pr`) that also have `loom:merge-conflict` as needing Doctor attention
- Adds `merge_conflict_count` to `compute_recommended_actions()` so Doctor demand fires when approved PRs have conflicts (not just when `loom:changes-requested` PRs exist)
- Derives merge-conflicted PRs from the existing `ready_to_merge` query (no extra API call) by filtering on the `loom:merge-conflict` label
- Exposes `merge_conflicted` and `merge_conflict_count` in the snapshot output for observability

## Test plan

- [x] 9 new tests covering orphaned PR detection with merge conflicts, Doctor demand triggering, backward compatibility, and edge cases
- [x] All 210 existing snapshot + rebase tests still pass
- [x] Full test suite passes (pre-existing failures in `test_degraded_session_detection` and `test_phases` unrelated)