### PR TITLE
fix: per-phase stall detection timeouts for Judge/Doctor phases

### DIFF
--- a/loom-tools/src/loom_tools/daemon_v2/actions/shepherds.py
+++ b/loom-tools/src/loom_tools/daemon_v2/actions/shepherds.py
@@ -393,6 +393,10 @@ def force_reclaim_stale_shepherds(ctx: DaemonContext) -> int:
         if entry.status != "working":
             continue
 
+        # Sync last_phase from progress data so stall decisions use the
+        # most recent phase even if the daemon state hasn't been refreshed.
+        _sync_phase_from_progress(ctx, entry)
+
         is_stale = False
 
         # Compute spawn age once — used by both Check 1 and Check 3.
@@ -552,11 +556,14 @@ def _check_no_progress_file(
 ) -> bool:
     """Check if a working shepherd has no progress file past the grace period.
 
-    Implements two-tier detection:
+    Implements two-tier detection with **phase-aware** timeouts:
       Tier 1 (startup_grace_period, default 300s): Log a warning, capture tmux
         output snapshot, and set ``startup_warning_at`` but do NOT reclaim.
-      Tier 2 (no_progress_grace_period, default 600s): Save diagnostic output
-        to ``.loom/logs/`` and return True to trigger reclaim.
+      Tier 2 (phase-dependent grace): Save diagnostic output to
+        ``.loom/logs/`` and return True to trigger reclaim.  The hard reclaim
+        threshold adapts to the shepherd's current phase: judge/doctor/champion
+        phases get 900s (15 min) while builder/curator/started get 600s (10 min).
+        See ``DaemonConfig.phase_grace_periods`` for the full mapping.
 
     Returns True if the shepherd should be considered stale (Tier 2).
     """
@@ -571,7 +578,8 @@ def _check_no_progress_file(
         return False
 
     startup_grace = ctx.config.startup_grace_period
-    hard_reclaim_grace = ctx.config.no_progress_grace_period
+    # Use phase-aware grace period for the hard reclaim threshold.
+    hard_reclaim_grace = ctx.config.get_phase_grace_period(entry.last_phase)
 
     if spawn_age < startup_grace:
         return False
@@ -590,7 +598,8 @@ def _check_no_progress_file(
             entry.startup_warning_at = now.strftime("%Y-%m-%dT%H:%M:%SZ")
             log_warning(
                 f"STALL-T1: {name} has no progress file after {spawn_age}s "
-                f"(task_id={entry.task_id}, issue=#{entry.issue}) — monitoring"
+                f"(task_id={entry.task_id}, issue=#{entry.issue}, "
+                f"phase={entry.last_phase}, grace={hard_reclaim_grace}s) — monitoring"
             )
             # Capture a tmux output snapshot for debugging
             if session_exists(name):
@@ -605,7 +614,8 @@ def _check_no_progress_file(
     # Tier 2: Hard reclaim
     log_warning(
         f"STALL-T2: {name} has no progress file after {spawn_age}s "
-        f"(task_id={entry.task_id}, issue=#{entry.issue}) — reclaiming"
+        f"(task_id={entry.task_id}, issue=#{entry.issue}, "
+        f"phase={entry.last_phase}, grace={hard_reclaim_grace}s) — reclaiming"
     )
     _save_diagnostic_output(ctx, name)
     return True
@@ -631,6 +641,34 @@ def _has_progress_data(ctx: DaemonContext, entry: ShepherdEntry) -> bool:
         prog.get("issue") == entry.issue
         for prog in shepherd_progress
     )
+
+
+def _sync_phase_from_progress(
+    ctx: DaemonContext,
+    entry: ShepherdEntry,
+) -> None:
+    """Sync ``entry.last_phase`` from snapshot progress data.
+
+    If the snapshot contains a progress entry for this shepherd's issue with a
+    ``current_phase`` value, update ``entry.last_phase`` so that downstream
+    stall-detection logic can use accurate phase-aware timeouts.
+    """
+    if ctx.snapshot is None or entry.issue is None:
+        return
+
+    shepherd_progress = (
+        ctx.snapshot.get("shepherds", {}).get("progress", [])
+    )
+    for prog in shepherd_progress:
+        # Match by task_id first, then fall back to issue number
+        if (
+            (entry.task_id and prog.get("task_id") == entry.task_id)
+            or prog.get("issue") == entry.issue
+        ):
+            phase = prog.get("current_phase")
+            if phase:
+                entry.last_phase = phase
+            return
 
 
 def _save_diagnostic_output(ctx: DaemonContext, name: str) -> None:

--- a/loom-tools/src/loom_tools/daemon_v2/config.py
+++ b/loom-tools/src/loom_tools/daemon_v2/config.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from loom_tools.common.config import env_bool, env_int
 
@@ -28,6 +28,20 @@ DEFAULT_SPAWN_STAGGER_DELAY = 3  # seconds between shepherd spawns
 DEFAULT_STALL_DIAGNOSTIC_THRESHOLD = 3  # consecutive stalled iterations
 DEFAULT_STALL_RECOVERY_THRESHOLD = 5
 DEFAULT_STALL_RESTART_THRESHOLD = 10
+
+# Per-phase no-progress grace periods (seconds).
+# Phases like judge and doctor involve waiting for external agents and
+# legitimately take much longer than the builder phase.  The default
+# ``no_progress_grace_period`` (600s) is used as fallback for unknown phases.
+DEFAULT_PHASE_GRACE_PERIODS: dict[str, int] = {
+    "started": 600,     # Initial startup: 10 min
+    "curator": 600,     # Curation: 10 min
+    "builder": 600,     # Building: 10 min
+    "judge": 900,       # Judge review cycles: 15 min
+    "doctor": 900,      # Doctor fix cycles: 15 min
+    "champion": 900,    # Champion merge: 15 min
+    "merge": 600,       # Merge operations: 10 min
+}
 
 
 @dataclass
@@ -69,6 +83,13 @@ class DaemonConfig:
     startup_grace_period: int = DEFAULT_STARTUP_GRACE_PERIOD
     no_progress_grace_period: int = DEFAULT_NO_PROGRESS_GRACE_PERIOD
     spawn_stagger_delay: int = DEFAULT_SPAWN_STAGGER_DELAY
+    # Per-phase grace periods for no-progress detection.
+    # When a shepherd's current phase is known (from progress files),
+    # this dict overrides no_progress_grace_period with a phase-specific
+    # timeout.  Unknown phases fall back to no_progress_grace_period.
+    phase_grace_periods: dict[str, int] = field(
+        default_factory=lambda: dict(DEFAULT_PHASE_GRACE_PERIODS)
+    )
 
     # Stall escalation thresholds
     stall_diagnostic_threshold: int = DEFAULT_STALL_DIAGNOSTIC_THRESHOLD
@@ -134,6 +155,16 @@ class DaemonConfig:
                 "LOOM_STALL_RESTART_THRESHOLD", DEFAULT_STALL_RESTART_THRESHOLD
             ),
         )
+
+    def get_phase_grace_period(self, phase: str | None) -> int:
+        """Return the no-progress grace period for *phase*.
+
+        Uses ``phase_grace_periods`` when a matching entry exists; falls back
+        to the flat ``no_progress_grace_period`` for unknown or ``None`` phases.
+        """
+        if phase and phase in self.phase_grace_periods:
+            return self.phase_grace_periods[phase]
+        return self.no_progress_grace_period
 
     def mode_display(self) -> str:
         """Return a display string for the current mode."""

--- a/loom-tools/tests/daemon_v2/test_no_progress_detection.py
+++ b/loom-tools/tests/daemon_v2/test_no_progress_detection.py
@@ -23,6 +23,7 @@ from loom_tools.daemon_v2.actions.shepherds import (
     STARTUP_GRACE_PERIOD,
     _check_no_progress_file,
     _save_diagnostic_output,
+    _sync_phase_from_progress,
     force_reclaim_stale_shepherds,
 )
 from loom_tools.daemon_v2.config import DaemonConfig
@@ -712,3 +713,416 @@ class TestTmuxSessionGracePeriod:
 
         assert reclaimed == 0
         assert ctx.state.shepherds["shepherd-1"].status == "working"
+
+
+# -----------------------------------------------------------------------
+# Phase-aware grace periods (issue #3103)
+# -----------------------------------------------------------------------
+
+
+class TestPhaseAwareGracePeriods:
+    """Tests for phase-aware no-progress grace periods.
+
+    Judge/Doctor/Champion phases get 900s (15 min) instead of the default
+    300s (5 min) because they involve waiting for external agents.
+    """
+
+    def test_judge_phase_not_reclaimed_at_600s(self, tmp_path: pathlib.Path) -> None:
+        """Shepherd in judge phase at 600s should NOT be reclaimed (grace=900s)."""
+        progress_dir = tmp_path / ".loom" / "progress"
+        progress_dir.mkdir(parents=True)
+
+        ctx = _make_ctx(
+            repo_root=tmp_path,
+            shepherds={
+                "shepherd-1": {
+                    "status": "working",
+                    "issue": 42,
+                    "task_id": "abc1234",
+                    "started": _ts(600),  # 600s — past 300s but within 900s judge grace
+                    "last_phase": "judge",
+                },
+            },
+        )
+        entry = ctx.state.shepherds["shepherd-1"]
+
+        with patch("loom_tools.daemon_v2.actions.shepherds.session_exists", return_value=True):
+            with patch("loom_tools.daemon_v2.actions.shepherds.capture_tmux_output", return_value="some output"):
+                result = _check_no_progress_file(ctx, "shepherd-1", entry)
+
+        assert result is False  # NOT reclaimed — within 900s judge grace
+
+    def test_doctor_phase_not_reclaimed_at_600s(self, tmp_path: pathlib.Path) -> None:
+        """Shepherd in doctor phase at 600s should NOT be reclaimed (grace=900s)."""
+        progress_dir = tmp_path / ".loom" / "progress"
+        progress_dir.mkdir(parents=True)
+
+        ctx = _make_ctx(
+            repo_root=tmp_path,
+            shepherds={
+                "shepherd-1": {
+                    "status": "working",
+                    "issue": 42,
+                    "task_id": "abc1234",
+                    "started": _ts(600),
+                    "last_phase": "doctor",
+                },
+            },
+        )
+        entry = ctx.state.shepherds["shepherd-1"]
+
+        with patch("loom_tools.daemon_v2.actions.shepherds.session_exists", return_value=True):
+            with patch("loom_tools.daemon_v2.actions.shepherds.capture_tmux_output", return_value="output"):
+                result = _check_no_progress_file(ctx, "shepherd-1", entry)
+
+        assert result is False
+
+    def test_champion_phase_not_reclaimed_at_600s(self, tmp_path: pathlib.Path) -> None:
+        """Shepherd in champion phase at 600s should NOT be reclaimed (grace=900s)."""
+        progress_dir = tmp_path / ".loom" / "progress"
+        progress_dir.mkdir(parents=True)
+
+        ctx = _make_ctx(
+            repo_root=tmp_path,
+            shepherds={
+                "shepherd-1": {
+                    "status": "working",
+                    "issue": 42,
+                    "task_id": "abc1234",
+                    "started": _ts(600),
+                    "last_phase": "champion",
+                },
+            },
+        )
+        entry = ctx.state.shepherds["shepherd-1"]
+
+        with patch("loom_tools.daemon_v2.actions.shepherds.session_exists", return_value=True):
+            with patch("loom_tools.daemon_v2.actions.shepherds.capture_tmux_output", return_value="output"):
+                result = _check_no_progress_file(ctx, "shepherd-1", entry)
+
+        assert result is False
+
+    def test_judge_phase_reclaimed_past_900s(self, tmp_path: pathlib.Path) -> None:
+        """Shepherd in judge phase past 900s SHOULD be reclaimed."""
+        progress_dir = tmp_path / ".loom" / "progress"
+        progress_dir.mkdir(parents=True)
+
+        ctx = _make_ctx(
+            repo_root=tmp_path,
+            shepherds={
+                "shepherd-1": {
+                    "status": "working",
+                    "issue": 42,
+                    "task_id": "abc1234",
+                    "started": _ts(910),  # Past 900s judge grace
+                    "last_phase": "judge",
+                },
+            },
+        )
+        entry = ctx.state.shepherds["shepherd-1"]
+
+        with patch("loom_tools.daemon_v2.actions.shepherds.capture_tmux_output", return_value=""):
+            result = _check_no_progress_file(ctx, "shepherd-1", entry)
+
+        assert result is True
+
+    def test_builder_phase_reclaimed_at_610s(self, tmp_path: pathlib.Path) -> None:
+        """Shepherd in builder phase at 610s SHOULD be reclaimed (grace=600s)."""
+        progress_dir = tmp_path / ".loom" / "progress"
+        progress_dir.mkdir(parents=True)
+
+        ctx = _make_ctx(
+            repo_root=tmp_path,
+            shepherds={
+                "shepherd-1": {
+                    "status": "working",
+                    "issue": 42,
+                    "task_id": "abc1234",
+                    "started": _ts(610),
+                    "last_phase": "builder",
+                },
+            },
+        )
+        entry = ctx.state.shepherds["shepherd-1"]
+
+        with patch("loom_tools.daemon_v2.actions.shepherds.capture_tmux_output", return_value=""):
+            result = _check_no_progress_file(ctx, "shepherd-1", entry)
+
+        assert result is True
+
+    def test_unknown_phase_uses_default_grace(self, tmp_path: pathlib.Path) -> None:
+        """Unknown phase falls back to default no_progress_grace_period (600s)."""
+        progress_dir = tmp_path / ".loom" / "progress"
+        progress_dir.mkdir(parents=True)
+
+        ctx = _make_ctx(
+            repo_root=tmp_path,
+            shepherds={
+                "shepherd-1": {
+                    "status": "working",
+                    "issue": 42,
+                    "task_id": "abc1234",
+                    "started": _ts(610),
+                    "last_phase": "some_unknown_phase",
+                },
+            },
+        )
+        entry = ctx.state.shepherds["shepherd-1"]
+
+        with patch("loom_tools.daemon_v2.actions.shepherds.capture_tmux_output", return_value=""):
+            result = _check_no_progress_file(ctx, "shepherd-1", entry)
+
+        assert result is True  # Falls back to 600s default
+
+    def test_none_phase_uses_default_grace(self, tmp_path: pathlib.Path) -> None:
+        """None phase falls back to default no_progress_grace_period (600s)."""
+        progress_dir = tmp_path / ".loom" / "progress"
+        progress_dir.mkdir(parents=True)
+
+        ctx = _make_ctx(
+            repo_root=tmp_path,
+            shepherds={
+                "shepherd-1": {
+                    "status": "working",
+                    "issue": 42,
+                    "task_id": "abc1234",
+                    "started": _ts(610),
+                    "last_phase": None,
+                },
+            },
+        )
+        entry = ctx.state.shepherds["shepherd-1"]
+
+        with patch("loom_tools.daemon_v2.actions.shepherds.capture_tmux_output", return_value=""):
+            result = _check_no_progress_file(ctx, "shepherd-1", entry)
+
+        assert result is True
+
+    def test_config_phase_grace_periods_customizable(self, tmp_path: pathlib.Path) -> None:
+        """Custom phase_grace_periods dict is respected."""
+        progress_dir = tmp_path / ".loom" / "progress"
+        progress_dir.mkdir(parents=True)
+
+        config = DaemonConfig(phase_grace_periods={"judge": 1800})  # 30 min
+        ctx = DaemonContext(
+            config=config,
+            repo_root=tmp_path,
+        )
+        ctx.snapshot = {
+            "computed": {"health_warnings": []},
+            "shepherds": {"progress": []},
+        }
+        state = DaemonState()
+        state.shepherds["shepherd-1"] = ShepherdEntry(
+            status="working",
+            issue=42,
+            task_id="abc1234",
+            started=_ts(1000),  # 1000s — past 900s default but within 1800s custom
+            last_phase="judge",
+        )
+        ctx.state = state
+
+        entry = ctx.state.shepherds["shepherd-1"]
+
+        with patch("loom_tools.daemon_v2.actions.shepherds.session_exists", return_value=True):
+            with patch("loom_tools.daemon_v2.actions.shepherds.capture_tmux_output", return_value=""):
+                result = _check_no_progress_file(ctx, "shepherd-1", entry)
+
+        assert result is False  # Within custom 1800s grace
+
+
+# -----------------------------------------------------------------------
+# _sync_phase_from_progress (issue #3103)
+# -----------------------------------------------------------------------
+
+
+class TestSyncPhaseFromProgress:
+    """Tests for syncing entry.last_phase from snapshot progress data."""
+
+    def test_syncs_phase_from_matching_task_id(self) -> None:
+        """Phase is updated when progress entry matches by task_id."""
+        ctx = _make_ctx(
+            shepherds={
+                "shepherd-1": {
+                    "status": "working",
+                    "issue": 42,
+                    "task_id": "abc1234",
+                    "last_phase": "started",
+                },
+            },
+            progress=[
+                {"task_id": "abc1234", "issue": 42, "current_phase": "judge"},
+            ],
+        )
+        entry = ctx.state.shepherds["shepherd-1"]
+        _sync_phase_from_progress(ctx, entry)
+        assert entry.last_phase == "judge"
+
+    def test_syncs_phase_from_matching_issue(self) -> None:
+        """Phase is updated when progress entry matches by issue number."""
+        ctx = _make_ctx(
+            shepherds={
+                "shepherd-1": {
+                    "status": "working",
+                    "issue": 42,
+                    "task_id": "different_id",
+                    "last_phase": "started",
+                },
+            },
+            progress=[
+                {"task_id": "other_task", "issue": 42, "current_phase": "doctor"},
+            ],
+        )
+        entry = ctx.state.shepherds["shepherd-1"]
+        _sync_phase_from_progress(ctx, entry)
+        assert entry.last_phase == "doctor"
+
+    def test_no_progress_preserves_existing_phase(self) -> None:
+        """No matching progress entry leaves last_phase unchanged."""
+        ctx = _make_ctx(
+            shepherds={
+                "shepherd-1": {
+                    "status": "working",
+                    "issue": 42,
+                    "task_id": "abc1234",
+                    "last_phase": "builder",
+                },
+            },
+            progress=[
+                {"task_id": "xxx", "issue": 99, "current_phase": "judge"},
+            ],
+        )
+        entry = ctx.state.shepherds["shepherd-1"]
+        _sync_phase_from_progress(ctx, entry)
+        assert entry.last_phase == "builder"
+
+    def test_empty_current_phase_preserves_existing(self) -> None:
+        """Progress entry with empty current_phase does not overwrite."""
+        ctx = _make_ctx(
+            shepherds={
+                "shepherd-1": {
+                    "status": "working",
+                    "issue": 42,
+                    "task_id": "abc1234",
+                    "last_phase": "builder",
+                },
+            },
+            progress=[
+                {"task_id": "abc1234", "issue": 42, "current_phase": ""},
+            ],
+        )
+        entry = ctx.state.shepherds["shepherd-1"]
+        _sync_phase_from_progress(ctx, entry)
+        assert entry.last_phase == "builder"
+
+    def test_none_issue_does_not_crash(self) -> None:
+        """Entry with no issue should not crash."""
+        ctx = _make_ctx(
+            shepherds={
+                "shepherd-1": {
+                    "status": "working",
+                    "issue": None,
+                    "task_id": "abc1234",
+                    "last_phase": "started",
+                },
+            },
+            progress=[
+                {"task_id": "abc1234", "issue": 42, "current_phase": "judge"},
+            ],
+        )
+        entry = ctx.state.shepherds["shepherd-1"]
+        _sync_phase_from_progress(ctx, entry)
+        assert entry.last_phase == "started"  # Unchanged — issue is None
+
+    def test_none_snapshot_does_not_crash(self) -> None:
+        """None snapshot should not crash."""
+        ctx = _make_ctx(
+            shepherds={
+                "shepherd-1": {
+                    "status": "working",
+                    "issue": 42,
+                    "task_id": "abc1234",
+                    "last_phase": "started",
+                },
+            },
+        )
+        ctx.snapshot = None
+        entry = ctx.state.shepherds["shepherd-1"]
+        _sync_phase_from_progress(ctx, entry)
+        assert entry.last_phase == "started"
+
+    def test_phase_sync_affects_grace_period_in_reclaim(self, tmp_path: pathlib.Path) -> None:
+        """Integration: progress showing 'judge' phase extends grace period for stall check."""
+        progress_dir = tmp_path / ".loom" / "progress"
+        progress_dir.mkdir(parents=True)
+
+        # Shepherd spawned 600s ago with last_phase="started" in daemon state,
+        # but progress file shows current_phase="judge".
+        # Without phase sync: 600s > 300s (started grace) -> reclaimed
+        # With phase sync: 600s < 900s (judge grace) -> NOT reclaimed
+        ctx = _make_ctx(
+            repo_root=tmp_path,
+            shepherds={
+                "shepherd-1": {
+                    "status": "working",
+                    "issue": 42,
+                    "task_id": "abc1234",
+                    "started": _ts(600),
+                    "last_phase": "started",  # Stale phase in daemon state
+                },
+            },
+            progress=[
+                {"task_id": "abc1234", "issue": 42, "current_phase": "judge"},
+            ],
+        )
+
+        @patch("loom_tools.agent_spawn._is_claude_running", return_value=True)
+        @patch("loom_tools.agent_spawn._get_pane_pid", return_value=12345)
+        @patch("loom_tools.daemon_v2.actions.shepherds.session_exists", return_value=True)
+        @patch("loom_tools.daemon_v2.actions.shepherds.capture_tmux_output", return_value="output")
+        def run_test(mock_capture, mock_session, mock_pid, mock_claude):
+            reclaimed = force_reclaim_stale_shepherds(ctx)
+            return reclaimed
+
+        reclaimed = run_test()
+        assert reclaimed == 0  # NOT reclaimed because phase synced to "judge"
+        assert ctx.state.shepherds["shepherd-1"].status == "working"
+        assert ctx.state.shepherds["shepherd-1"].last_phase == "judge"  # Phase was synced
+
+
+# -----------------------------------------------------------------------
+# DaemonConfig.get_phase_grace_period
+# -----------------------------------------------------------------------
+
+
+class TestGetPhaseGracePeriod:
+    """Tests for DaemonConfig.get_phase_grace_period helper."""
+
+    def test_known_phases(self) -> None:
+        cfg = DaemonConfig()
+        assert cfg.get_phase_grace_period("judge") == 900
+        assert cfg.get_phase_grace_period("doctor") == 900
+        assert cfg.get_phase_grace_period("champion") == 900
+        assert cfg.get_phase_grace_period("builder") == 600
+        assert cfg.get_phase_grace_period("curator") == 600
+        assert cfg.get_phase_grace_period("started") == 600
+        assert cfg.get_phase_grace_period("merge") == 600
+
+    def test_unknown_phase_fallback(self) -> None:
+        cfg = DaemonConfig()
+        assert cfg.get_phase_grace_period("unknown_phase") == cfg.no_progress_grace_period
+
+    def test_none_phase_fallback(self) -> None:
+        cfg = DaemonConfig()
+        assert cfg.get_phase_grace_period(None) == cfg.no_progress_grace_period
+
+    def test_empty_string_phase_fallback(self) -> None:
+        cfg = DaemonConfig()
+        assert cfg.get_phase_grace_period("") == cfg.no_progress_grace_period
+
+    def test_custom_phase_grace_periods(self) -> None:
+        cfg = DaemonConfig(phase_grace_periods={"judge": 1800, "builder": 600})
+        assert cfg.get_phase_grace_period("judge") == 1800
+        assert cfg.get_phase_grace_period("builder") == 600
+        # Unknown falls back to no_progress_grace_period
+        assert cfg.get_phase_grace_period("doctor") == 600


### PR DESCRIPTION
Closes #3103

## Summary
- Implements per-phase grace periods for stall detection: judge/doctor/champion phases get 900s (15 min) instead of the flat 300s (5 min), preventing the daemon from killing shepherds that are actively orchestrating review/fix cycles
- Syncs `entry.last_phase` from progress file data before stall checks so the daemon uses the most current phase, not the stale "started" value from spawn time
- Adds `DaemonConfig.phase_grace_periods` dict and `get_phase_grace_period()` helper, both configurable and with sane defaults

## Test plan
- [x] 20 new tests covering phase-aware grace periods, phase sync, config helper, and integration
- [x] All 50 no-progress detection tests pass (30 existing + 20 new)
- [x] All 229 daemon_v2 tests pass
- [x] Full suite: 3858 passed (12 pre-existing failures unrelated to this change)

Generated with [Claude Code](https://claude.com/claude-code)