### PR TITLE
fix: detect completed support roles by checking Claude process liveness

### DIFF
--- a/loom-tools/src/loom_tools/agent_spawn.py
+++ b/loom-tools/src/loom_tools/agent_spawn.py
@@ -218,6 +218,32 @@ def capture_tmux_output(name: str, lines: int = 200) -> str:
     return ""
 
 
+def is_session_active(name: str) -> bool:
+    """Check if a tmux session exists AND the Claude process is still running.
+
+    Returns True only when both conditions hold.  When the session exists but
+    Claude has exited (leaving only an idle shell), returns False.  When the
+    session does not exist at all, also returns False.
+
+    This is the correct check for determining whether a support role is still
+    working — ``session_exists()`` alone cannot distinguish a live agent from
+    a finished one whose shell lingers in the tmux pane.
+    """
+    session_name = f"{SESSION_PREFIX}{name}"
+    try:
+        result = _tmux("has-session", "-t", session_name)
+        if result.returncode != 0:
+            return False
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return False
+
+    # Session exists — check for a live Claude process
+    shell_pid = _get_pane_pid(session_name)
+    if not shell_pid:
+        return False
+    return _is_claude_running(shell_pid)
+
+
 def kill_stuck_session(name: str) -> None:
     """Kill a stuck session with graceful then forced shutdown."""
     session_name = f"{SESSION_PREFIX}{name}"

--- a/loom-tools/src/loom_tools/daemon_v2/actions/support_roles.py
+++ b/loom-tools/src/loom_tools/daemon_v2/actions/support_roles.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from loom_tools.agent_spawn import spawn_agent, session_exists, kill_stuck_session
+from loom_tools.agent_spawn import (
+    is_session_active,
+    kill_stuck_session,
+    session_exists,
+    spawn_agent,
+)
 from loom_tools.common.logging import log_info, log_success, log_warning
 from loom_tools.common.time_utils import now_utc
 from loom_tools.daemon_v2.actions.completions import CompletionEntry
@@ -178,12 +183,18 @@ def spawn_roles_from_actions(ctx: DaemonContext) -> int:
 
 
 def reclaim_completed_support_roles(ctx: DaemonContext) -> list[CompletionEntry]:
-    """Detect support roles whose tmux sessions have exited and mark them idle.
+    """Detect support roles whose Claude process has finished and mark them idle.
 
     Iterates over all support roles with status ``"running"`` and checks
-    whether their tmux session is still alive.  When a session is gone the
-    role is considered complete and a :class:`CompletionEntry` is returned
-    so the caller can feed it through :func:`handle_completion`.
+    whether the Claude process inside their tmux session is still active.
+    A role is considered complete when:
+
+    - The tmux session no longer exists at all, OR
+    - The tmux session exists but the Claude process has exited (the shell
+      is sitting at an idle prompt).
+
+    In the second case the lingering tmux session is killed so it does not
+    block future spawns.
 
     Returns a list of ``CompletionEntry`` objects for completed roles.
     """
@@ -196,13 +207,22 @@ def reclaim_completed_support_roles(ctx: DaemonContext) -> list[CompletionEntry]
         if entry.status != "running":
             continue
 
-        # Check if the tmux session is still alive
-        if session_exists(role_name):
+        # Check if the tmux session has a live Claude process
+        if is_session_active(role_name):
             continue
 
-        log_info(
-            f"Support role {role_name} tmux session exited — marking as completed"
-        )
+        # Session is either gone or Claude has exited.
+        # If the tmux session still exists (shell-only), kill it.
+        if session_exists(role_name):
+            log_info(
+                f"Support role {role_name} Claude process exited "
+                f"(tmux session still open) — killing stale session"
+            )
+            kill_stuck_session(role_name)
+        else:
+            log_info(
+                f"Support role {role_name} tmux session exited — marking as completed"
+            )
 
         completed.append(
             CompletionEntry(

--- a/loom-tools/tests/test_agent_spawn.py
+++ b/loom-tools/tests/test_agent_spawn.py
@@ -18,6 +18,7 @@ from loom_tools.agent_spawn import (
     check_claude_cli,
     check_stop_signals,
     check_tmux,
+    is_session_active,
     kill_stuck_session,
     run,
     session_exists,
@@ -237,6 +238,58 @@ class TestSessionIsAlive:
             args=[], returncode=1, stdout=""
         )
         assert session_is_alive("test") is False
+
+
+class TestIsSessionActive:
+    """Tests for is_session_active (session exists AND Claude running)."""
+
+    @patch("loom_tools.agent_spawn._is_claude_running", return_value=True)
+    @patch("loom_tools.agent_spawn._get_pane_pid", return_value="12345")
+    @patch("loom_tools.agent_spawn._tmux")
+    def test_active_when_session_and_claude_running(
+        self,
+        mock_tmux: MagicMock,
+        _mock_pid: MagicMock,
+        _mock_running: MagicMock,
+    ) -> None:
+        mock_tmux.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=""
+        )
+        assert is_session_active("test") is True
+
+    @patch("loom_tools.agent_spawn._tmux")
+    def test_not_active_when_session_missing(self, mock_tmux: MagicMock) -> None:
+        mock_tmux.return_value = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout=""
+        )
+        assert is_session_active("test") is False
+
+    @patch("loom_tools.agent_spawn._is_claude_running", return_value=False)
+    @patch("loom_tools.agent_spawn._get_pane_pid", return_value="12345")
+    @patch("loom_tools.agent_spawn._tmux")
+    def test_not_active_when_claude_exited(
+        self,
+        mock_tmux: MagicMock,
+        _mock_pid: MagicMock,
+        _mock_running: MagicMock,
+    ) -> None:
+        """Session exists but Claude has exited (shell-only) -- should return False."""
+        mock_tmux.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=""
+        )
+        assert is_session_active("test") is False
+
+    @patch("loom_tools.agent_spawn._get_pane_pid", return_value=None)
+    @patch("loom_tools.agent_spawn._tmux")
+    def test_not_active_when_no_shell_pid(
+        self,
+        mock_tmux: MagicMock,
+        _mock_pid: MagicMock,
+    ) -> None:
+        mock_tmux.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=""
+        )
+        assert is_session_active("test") is False
 
 
 class TestSessionIsStuck:

--- a/loom-tools/tests/test_support_role_reclaim.py
+++ b/loom-tools/tests/test_support_role_reclaim.py
@@ -53,18 +53,29 @@ class TestReclaimCompletedSupportRoles:
             },
         )
 
-        with mock.patch(
-            "loom_tools.daemon_v2.actions.support_roles.session_exists",
-            return_value=False,
+        with (
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.is_session_active",
+                return_value=False,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.session_exists",
+                return_value=False,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.kill_stuck_session",
+            ) as mock_kill,
         ):
             completed = reclaim_completed_support_roles(ctx)
 
         assert len(completed) == 1
         assert completed[0].type == "support_role"
         assert completed[0].name == "judge"
+        # Session was already gone — no need to kill
+        mock_kill.assert_not_called()
 
     def test_alive_session_not_reclaimed(self, tmp_path: pathlib.Path) -> None:
-        """A running role with a live tmux session should NOT be reclaimed."""
+        """A running role with a live Claude process should NOT be reclaimed."""
         ctx = _make_ctx(
             tmp_path,
             support_roles={
@@ -77,12 +88,46 @@ class TestReclaimCompletedSupportRoles:
         )
 
         with mock.patch(
-            "loom_tools.daemon_v2.actions.support_roles.session_exists",
+            "loom_tools.daemon_v2.actions.support_roles.is_session_active",
             return_value=True,
         ):
             completed = reclaim_completed_support_roles(ctx)
 
         assert len(completed) == 0
+
+    def test_session_exists_but_claude_exited(self, tmp_path: pathlib.Path) -> None:
+        """A session with no Claude process (shell-only) should be reclaimed and killed."""
+        ctx = _make_ctx(
+            tmp_path,
+            support_roles={
+                "architect": SupportRoleEntry(
+                    status="running",
+                    tmux_session="loom-architect",
+                    started="2026-01-30T10:00:00Z",
+                ),
+            },
+        )
+
+        with (
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.is_session_active",
+                return_value=False,  # Claude not running
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.session_exists",
+                return_value=True,  # But tmux session still exists
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.kill_stuck_session",
+            ) as mock_kill,
+        ):
+            completed = reclaim_completed_support_roles(ctx)
+
+        assert len(completed) == 1
+        assert completed[0].type == "support_role"
+        assert completed[0].name == "architect"
+        # Stale shell-only session should be killed
+        mock_kill.assert_called_once_with("architect")
 
     def test_idle_roles_skipped(self, tmp_path: pathlib.Path) -> None:
         """Idle roles should not be checked or reclaimed."""
@@ -97,15 +142,15 @@ class TestReclaimCompletedSupportRoles:
         )
 
         with mock.patch(
-            "loom_tools.daemon_v2.actions.support_roles.session_exists",
-        ) as mock_exists:
+            "loom_tools.daemon_v2.actions.support_roles.is_session_active",
+        ) as mock_active:
             completed = reclaim_completed_support_roles(ctx)
 
         assert len(completed) == 0
-        mock_exists.assert_not_called()
+        mock_active.assert_not_called()
 
     def test_multiple_roles_mixed_states(self, tmp_path: pathlib.Path) -> None:
-        """Multiple roles: only running ones with dead sessions are reclaimed."""
+        """Multiple roles: only running ones without active Claude are reclaimed."""
         ctx = _make_ctx(
             tmp_path,
             support_roles={
@@ -128,19 +173,34 @@ class TestReclaimCompletedSupportRoles:
             },
         )
 
-        def mock_session_exists(name: str) -> bool:
-            # judge dead, champion alive, doctor dead
+        def mock_is_active(name: str) -> bool:
+            # champion is active, judge and doctor are not
             return name == "champion"
 
-        with mock.patch(
-            "loom_tools.daemon_v2.actions.support_roles.session_exists",
-            side_effect=mock_session_exists,
+        def mock_exists(name: str) -> bool:
+            # judge session gone, doctor session still there (shell-only)
+            return name == "doctor"
+
+        with (
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.is_session_active",
+                side_effect=mock_is_active,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.session_exists",
+                side_effect=mock_exists,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.kill_stuck_session",
+            ) as mock_kill,
         ):
             completed = reclaim_completed_support_roles(ctx)
 
         assert len(completed) == 2
         names = {c.name for c in completed}
         assert names == {"judge", "doctor"}
+        # Only doctor's stale session should be killed (judge was already gone)
+        mock_kill.assert_called_once_with("doctor")
 
     def test_no_state_returns_empty(self, tmp_path: pathlib.Path) -> None:
         """When ctx.state is None, returns empty list."""
@@ -190,7 +250,7 @@ class TestIterationWrapperFunction:
     """Tests for _reclaim_completed_support_roles in iteration.py."""
 
     def test_no_running_roles_skips_check(self, tmp_path: pathlib.Path) -> None:
-        """When no roles are running, session_exists is never called."""
+        """When no roles are running, is_session_active is never called."""
         ctx = _make_ctx(
             tmp_path,
             support_roles={
@@ -200,15 +260,15 @@ class TestIterationWrapperFunction:
         )
 
         with mock.patch(
-            "loom_tools.daemon_v2.actions.support_roles.session_exists",
-        ) as mock_exists:
+            "loom_tools.daemon_v2.actions.support_roles.is_session_active",
+        ) as mock_active:
             result = _reclaim_completed_support_roles(ctx)
 
         assert result == []
-        mock_exists.assert_not_called()
+        mock_active.assert_not_called()
 
     def test_running_role_triggers_check(self, tmp_path: pathlib.Path) -> None:
-        """When a role is running, the check runs and detects dead session."""
+        """When a role is running, the check detects inactive Claude process."""
         ctx = _make_ctx(
             tmp_path,
             support_roles={
@@ -220,9 +280,18 @@ class TestIterationWrapperFunction:
             },
         )
 
-        with mock.patch(
-            "loom_tools.daemon_v2.actions.support_roles.session_exists",
-            return_value=False,
+        with (
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.is_session_active",
+                return_value=False,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.session_exists",
+                return_value=False,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.kill_stuck_session",
+            ),
         ):
             result = _reclaim_completed_support_roles(ctx)
 
@@ -306,8 +375,15 @@ class TestRunIterationWithSupportRoleReclaim:
             ),
             mock.patch("loom_tools.daemon_v2.iteration.write_json_file"),
             mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.is_session_active",
+                return_value=False,
+            ),
+            mock.patch(
                 "loom_tools.daemon_v2.actions.support_roles.session_exists",
                 return_value=False,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.kill_stuck_session",
             ),
         ):
             from loom_tools.daemon_v2.iteration import run_iteration


### PR DESCRIPTION
Closes #3108

## Summary

- Added `is_session_active()` function to `agent_spawn.py` that checks both tmux session existence AND whether the Claude process is still running inside it
- Updated `reclaim_completed_support_roles()` to use `is_session_active()` instead of just `session_exists()`, so roles are properly reclaimed when Claude exits but the shell lingers
- Stale shell-only tmux sessions are now killed automatically when detected during reclaim
- Added comprehensive tests for the new function and updated all existing support role reclaim tests

## Root cause

`session_exists()` uses `tmux has-session` which returns true as long as the tmux session exists -- even if Claude has exited and only the idle shell prompt remains. This caused support roles to stay stuck as "running" in daemon state indefinitely, preventing new instances from being spawned.

## Test plan

- [x] `TestIsSessionActive` -- 4 new unit tests for the `is_session_active()` function covering all combinations (session+Claude active, session missing, Claude exited, no shell PID)
- [x] `TestReclaimCompletedSupportRoles::test_session_exists_but_claude_exited` -- new test for the exact bug scenario (shell-only session gets reclaimed and killed)
- [x] All existing support role reclaim tests updated and passing (12 tests)
- [x] Full test suite: 3858 passed (13 pre-existing failures unrelated to this change)