### PR TITLE
fix: daemon accounts for actionable PRs in health status and work detection

### DIFF
--- a/loom-tools/src/loom_tools/daemon_v2/iteration.py
+++ b/loom-tools/src/loom_tools/daemon_v2/iteration.py
@@ -140,6 +140,16 @@ def run_iteration(ctx: DaemonContext) -> IterationResult:
             )
     completions.extend(support_completions)
 
+    # 4c. Patch demand-based actions after support role reclaim.
+    #     The snapshot (step 1) computed recommended_actions before support
+    #     role reclaim happened. If a support role was "running" at snapshot
+    #     time but just completed, demand-based triggers (spawn_judge_demand,
+    #     spawn_doctor_demand, spawn_champion_demand) may be missing.
+    #     Patch them in so roles are re-spawned immediately rather than
+    #     waiting until the next iteration.
+    if support_completions and ctx.snapshot is not None and ctx.state is not None:
+        _patch_demand_actions_after_reclaim(ctx, support_completions)
+
     # 5. Get recommended actions
     actions = ctx.get_recommended_actions()
     if ctx.config.debug_mode:
@@ -278,6 +288,61 @@ def _reclaim_completed_support_roles(
     return completed
 
 
+def _patch_demand_actions_after_reclaim(
+    ctx: DaemonContext,
+    reclaimed: list,
+) -> None:
+    """Patch demand-based actions into snapshot after support role reclaim.
+
+    When a support role completes (tmux session exits) *after* the snapshot
+    was built, the snapshot's recommended_actions won't include demand
+    triggers for that role because it was "running" at snapshot time.  This
+    function checks the current PR counts from the snapshot and injects
+    the appropriate demand action so the role is re-spawned immediately.
+    """
+    if ctx.snapshot is None or ctx.state is None:
+        return
+
+    computed = ctx.snapshot.get("computed", {})
+    actions: list[str] = computed.get("recommended_actions", [])
+
+    reclaimed_roles = {c.name for c in reclaimed}
+
+    # Champion: PRs ready to merge
+    if "champion" in reclaimed_roles:
+        merge_count = computed.get("prs_ready_to_merge", 0)
+        champion_entry = ctx.state.support_roles.get("champion")
+        champion_status = champion_entry.status if champion_entry else "idle"
+        if merge_count > 0 and champion_status != "running" and "spawn_champion_demand" not in actions:
+            actions.append("spawn_champion_demand")
+            computed["champion_demand"] = True
+            log_info(f"Patched spawn_champion_demand: {merge_count} PR(s) ready to merge")
+
+    # Judge: PRs awaiting review
+    if "judge" in reclaimed_roles:
+        review_count = computed.get("prs_awaiting_review", 0)
+        judge_entry = ctx.state.support_roles.get("judge")
+        judge_status = judge_entry.status if judge_entry else "idle"
+        if review_count > 0 and judge_status != "running" and "spawn_judge_demand" not in actions and "spawn_judge_targeted" not in actions:
+            actions.append("spawn_judge_demand")
+            computed["judge_demand"] = True
+            log_info(f"Patched spawn_judge_demand: {review_count} PR(s) awaiting review")
+
+    # Doctor: PRs needing fixes
+    if "doctor" in reclaimed_roles:
+        changes_count = computed.get("prs_needing_fixes", 0)
+        doctor_entry = ctx.state.support_roles.get("doctor")
+        doctor_status = doctor_entry.status if doctor_entry else "idle"
+        if changes_count > 0 and doctor_status != "running" and "spawn_doctor_demand" not in actions and "spawn_doctor_targeted" not in actions:
+            actions.append("spawn_doctor_demand")
+            computed["doctor_demand"] = True
+            log_info(f"Patched spawn_doctor_demand: {changes_count} PR(s) needing fixes")
+
+    # Remove "wait" if we added demand actions
+    if any(a.startswith("spawn_") for a in actions) and "wait" in actions:
+        actions.remove("wait")
+
+
 def _save_daemon_state(ctx: DaemonContext) -> None:
     """Save the current daemon state to disk."""
     if ctx.state is None:
@@ -302,6 +367,14 @@ def _build_summary(ctx: DaemonContext, result: IterationResult) -> str:
         f"blocked={computed.get('total_blocked', 0)}",
         f"shepherds={computed.get('active_shepherds', 0)}/{ctx.config.max_shepherds}",
     ]
+
+    # Add PR counts when there are actionable PRs
+    prs_review = computed.get("prs_awaiting_review", 0)
+    prs_fixes = computed.get("prs_needing_fixes", 0)
+    prs_merge = computed.get("prs_ready_to_merge", 0)
+    total_prs = prs_review + prs_fixes + prs_merge
+    if total_prs > 0:
+        parts.append(f"prs={prs_review}r/{prs_fixes}f/{prs_merge}m")
 
     # Add spawned counts if any
     if result.shepherds_spawned > 0:

--- a/loom-tools/src/loom_tools/snapshot.py
+++ b/loom-tools/src/loom_tools/snapshot.py
@@ -1339,12 +1339,18 @@ def compute_health(
     curated_count: int = 0,
     architect_count: int = 0,
     hermit_count: int = 0,
+    review_count: int = 0,
+    changes_count: int = 0,
+    merge_count: int = 0,
 ) -> tuple[str, list[dict[str, str]]]:
     """Compute health status and warnings.
 
     Returns ``(health_status, health_warnings)``.
     """
     warnings: list[dict[str, str]] = []
+
+    # Total actionable PR work (PRs needing review, fixes, or merging)
+    actionable_pr_count = review_count + changes_count + merge_count
 
     # contradictory_labels — entities with mutually exclusive labels
     if contradictory_labels:
@@ -1358,8 +1364,8 @@ def compute_health(
                 "message": f"{entity_type} #{number} has contradictory labels: {labels}",
             })
 
-    # pipeline_stalled
-    if ready_count == 0 and building_count == 0 and blocked_count > 0:
+    # pipeline_stalled — only when there are no actionable PRs either
+    if ready_count == 0 and building_count == 0 and blocked_count > 0 and actionable_pr_count == 0:
         warnings.append({
             "code": "pipeline_stalled",
             "level": "warning",
@@ -1391,12 +1397,27 @@ def compute_health(
             "message": f"Pipeline blocked on human input: {', '.join(parts)}",
         })
 
-    # no_work_available
-    if ready_count == 0 and building_count == 0 and blocked_count == 0 and total_proposals == 0:
+    # no_work_available — only when there are also no actionable PRs
+    if ready_count == 0 and building_count == 0 and blocked_count == 0 and total_proposals == 0 and actionable_pr_count == 0:
         warnings.append({
             "code": "no_work_available",
             "level": "info",
             "message": "No ready, building, blocked, or proposed issues — pipeline is empty",
+        })
+
+    # prs_in_progress — informational: no issue work but PRs need attention
+    if ready_count == 0 and building_count == 0 and blocked_count == 0 and total_proposals == 0 and actionable_pr_count > 0:
+        parts = []
+        if review_count > 0:
+            parts.append(f"{review_count} awaiting review")
+        if changes_count > 0:
+            parts.append(f"{changes_count} needing fixes")
+        if merge_count > 0:
+            parts.append(f"{merge_count} ready to merge")
+        warnings.append({
+            "code": "prs_in_progress",
+            "level": "info",
+            "message": f"No issue work, but {actionable_pr_count} PR(s) need attention: {', '.join(parts)}",
         })
 
     # stale_heartbeats
@@ -1716,6 +1737,9 @@ def build_snapshot(
         curated_count=curated_count,
         architect_count=architect_count,
         hermit_count=hermit_count,
+        review_count=review_count,
+        changes_count=changes_count,
+        merge_count=merge_count,
     )
 
     # 18. Build support_roles output (schema matches shell)

--- a/loom-tools/tests/test_iteration.py
+++ b/loom-tools/tests/test_iteration.py
@@ -11,8 +11,14 @@ from unittest import mock
 
 from loom_tools.daemon_v2.config import DaemonConfig
 from loom_tools.daemon_v2.context import DaemonContext
-from loom_tools.daemon_v2.iteration import _build_summary, run_iteration, IterationResult
-from loom_tools.models.daemon_state import DaemonState, ShepherdEntry
+from loom_tools.daemon_v2.iteration import (
+    _build_summary,
+    _patch_demand_actions_after_reclaim,
+    run_iteration,
+    IterationResult,
+)
+from loom_tools.daemon_v2.actions.completions import CompletionEntry
+from loom_tools.models.daemon_state import DaemonState, ShepherdEntry, SupportRoleEntry
 
 
 def _make_ctx(
@@ -273,3 +279,142 @@ class TestBuildSummaryHumanInput:
         result = IterationResult(status="success", summary="")
         summary = _build_summary(ctx, result)
         assert "human_input_needed" not in summary
+
+
+class TestBuildSummaryPRCounts:
+    """Tests for PR counts in _build_summary."""
+
+    def test_summary_includes_pr_counts_when_prs_exist(self, tmp_path: pathlib.Path) -> None:
+        """Summary shows PR counts when there are actionable PRs."""
+        ctx = _make_ctx(tmp_path)
+        ctx.snapshot["computed"]["prs_awaiting_review"] = 2
+        ctx.snapshot["computed"]["prs_needing_fixes"] = 1
+        ctx.snapshot["computed"]["prs_ready_to_merge"] = 3
+
+        result = IterationResult(status="success", summary="")
+        summary = _build_summary(ctx, result)
+        assert "prs=2r/1f/3m" in summary
+
+    def test_summary_omits_pr_counts_when_zero(self, tmp_path: pathlib.Path) -> None:
+        """Summary omits PR counts when no actionable PRs."""
+        ctx = _make_ctx(tmp_path)
+        ctx.snapshot["computed"]["prs_awaiting_review"] = 0
+        ctx.snapshot["computed"]["prs_needing_fixes"] = 0
+        ctx.snapshot["computed"]["prs_ready_to_merge"] = 0
+
+        result = IterationResult(status="success", summary="")
+        summary = _build_summary(ctx, result)
+        assert "prs=" not in summary
+
+    def test_summary_shows_pr_counts_with_only_review(self, tmp_path: pathlib.Path) -> None:
+        """Summary shows PR counts when only review-requested PRs exist."""
+        ctx = _make_ctx(tmp_path)
+        ctx.snapshot["computed"]["prs_awaiting_review"] = 1
+        ctx.snapshot["computed"]["prs_needing_fixes"] = 0
+        ctx.snapshot["computed"]["prs_ready_to_merge"] = 0
+
+        result = IterationResult(status="success", summary="")
+        summary = _build_summary(ctx, result)
+        assert "prs=1r/0f/0m" in summary
+
+
+class TestPatchDemandActionsAfterReclaim:
+    """Tests for _patch_demand_actions_after_reclaim."""
+
+    def test_patches_champion_demand_on_reclaim(self, tmp_path: pathlib.Path) -> None:
+        """When champion completes and PRs ready to merge, patches demand action."""
+        ctx = _make_ctx(tmp_path)
+        ctx.state.support_roles["champion"] = SupportRoleEntry(status="idle")
+        ctx.snapshot["computed"]["prs_ready_to_merge"] = 2
+        ctx.snapshot["computed"]["recommended_actions"] = ["wait"]
+
+        reclaimed = [CompletionEntry(type="support_role", name="champion")]
+        _patch_demand_actions_after_reclaim(ctx, reclaimed)
+
+        actions = ctx.snapshot["computed"]["recommended_actions"]
+        assert "spawn_champion_demand" in actions
+        assert ctx.snapshot["computed"]["champion_demand"] is True
+        assert "wait" not in actions
+
+    def test_patches_judge_demand_on_reclaim(self, tmp_path: pathlib.Path) -> None:
+        """When judge completes and PRs awaiting review, patches demand action."""
+        ctx = _make_ctx(tmp_path)
+        ctx.state.support_roles["judge"] = SupportRoleEntry(status="idle")
+        ctx.snapshot["computed"]["prs_awaiting_review"] = 1
+        ctx.snapshot["computed"]["recommended_actions"] = ["wait"]
+
+        reclaimed = [CompletionEntry(type="support_role", name="judge")]
+        _patch_demand_actions_after_reclaim(ctx, reclaimed)
+
+        actions = ctx.snapshot["computed"]["recommended_actions"]
+        assert "spawn_judge_demand" in actions
+        assert ctx.snapshot["computed"]["judge_demand"] is True
+
+    def test_patches_doctor_demand_on_reclaim(self, tmp_path: pathlib.Path) -> None:
+        """When doctor completes and PRs need fixes, patches demand action."""
+        ctx = _make_ctx(tmp_path)
+        ctx.state.support_roles["doctor"] = SupportRoleEntry(status="idle")
+        ctx.snapshot["computed"]["prs_needing_fixes"] = 1
+        ctx.snapshot["computed"]["recommended_actions"] = ["wait"]
+
+        reclaimed = [CompletionEntry(type="support_role", name="doctor")]
+        _patch_demand_actions_after_reclaim(ctx, reclaimed)
+
+        actions = ctx.snapshot["computed"]["recommended_actions"]
+        assert "spawn_doctor_demand" in actions
+        assert ctx.snapshot["computed"]["doctor_demand"] is True
+
+    def test_no_patch_when_no_pr_work(self, tmp_path: pathlib.Path) -> None:
+        """No patch when no PRs need attention for the reclaimed role."""
+        ctx = _make_ctx(tmp_path)
+        ctx.state.support_roles["champion"] = SupportRoleEntry(status="idle")
+        ctx.snapshot["computed"]["prs_ready_to_merge"] = 0
+        ctx.snapshot["computed"]["recommended_actions"] = ["wait"]
+
+        reclaimed = [CompletionEntry(type="support_role", name="champion")]
+        _patch_demand_actions_after_reclaim(ctx, reclaimed)
+
+        actions = ctx.snapshot["computed"]["recommended_actions"]
+        assert "spawn_champion_demand" not in actions
+        assert "wait" in actions
+
+    def test_no_patch_when_already_has_demand_action(self, tmp_path: pathlib.Path) -> None:
+        """No duplicate patch when demand action already exists."""
+        ctx = _make_ctx(tmp_path)
+        ctx.state.support_roles["judge"] = SupportRoleEntry(status="idle")
+        ctx.snapshot["computed"]["prs_awaiting_review"] = 1
+        ctx.snapshot["computed"]["recommended_actions"] = ["spawn_judge_demand"]
+
+        reclaimed = [CompletionEntry(type="support_role", name="judge")]
+        _patch_demand_actions_after_reclaim(ctx, reclaimed)
+
+        actions = ctx.snapshot["computed"]["recommended_actions"]
+        assert actions.count("spawn_judge_demand") == 1
+
+    def test_no_patch_when_targeted_action_exists(self, tmp_path: pathlib.Path) -> None:
+        """No patch when targeted demand action already exists."""
+        ctx = _make_ctx(tmp_path)
+        ctx.state.support_roles["judge"] = SupportRoleEntry(status="idle")
+        ctx.snapshot["computed"]["prs_awaiting_review"] = 1
+        ctx.snapshot["computed"]["recommended_actions"] = ["spawn_judge_targeted"]
+
+        reclaimed = [CompletionEntry(type="support_role", name="judge")]
+        _patch_demand_actions_after_reclaim(ctx, reclaimed)
+
+        actions = ctx.snapshot["computed"]["recommended_actions"]
+        assert "spawn_judge_demand" not in actions
+
+    def test_removes_wait_when_demand_added(self, tmp_path: pathlib.Path) -> None:
+        """Wait action removed when demand action is patched in."""
+        ctx = _make_ctx(tmp_path)
+        ctx.state.support_roles["champion"] = SupportRoleEntry(status="idle")
+        ctx.snapshot["computed"]["prs_ready_to_merge"] = 1
+        ctx.snapshot["computed"]["recommended_actions"] = ["check_stuck", "wait"]
+
+        reclaimed = [CompletionEntry(type="support_role", name="champion")]
+        _patch_demand_actions_after_reclaim(ctx, reclaimed)
+
+        actions = ctx.snapshot["computed"]["recommended_actions"]
+        assert "spawn_champion_demand" in actions
+        assert "wait" not in actions
+        assert "check_stuck" in actions  # other actions preserved

--- a/loom-tools/tests/test_snapshot.py
+++ b/loom-tools/tests/test_snapshot.py
@@ -1478,6 +1478,81 @@ class TestHealth:
         ci_warns = [w for w in warnings if w["code"] == "ci_failing"]
         assert len(ci_warns) == 0
 
+    def test_no_work_available_suppressed_when_prs_exist(self) -> None:
+        """no_work_available should NOT be emitted when PRs need attention."""
+        status, warnings = compute_health(
+            ready_count=0, building_count=0, blocked_count=0,
+            total_proposals=0, stale_heartbeat_count=0, orphaned_count=0,
+            usage_healthy=True, session_percent=50.0,
+            review_count=1,
+        )
+        assert not any(w["code"] == "no_work_available" for w in warnings)
+
+    def test_no_work_available_suppressed_when_merge_ready(self) -> None:
+        """no_work_available should NOT be emitted when PRs ready to merge."""
+        status, warnings = compute_health(
+            ready_count=0, building_count=0, blocked_count=0,
+            total_proposals=0, stale_heartbeat_count=0, orphaned_count=0,
+            usage_healthy=True, session_percent=50.0,
+            merge_count=2,
+        )
+        assert not any(w["code"] == "no_work_available" for w in warnings)
+
+    def test_no_work_available_suppressed_when_changes_requested(self) -> None:
+        """no_work_available should NOT be emitted when PRs need fixes."""
+        status, warnings = compute_health(
+            ready_count=0, building_count=0, blocked_count=0,
+            total_proposals=0, stale_heartbeat_count=0, orphaned_count=0,
+            usage_healthy=True, session_percent=50.0,
+            changes_count=1,
+        )
+        assert not any(w["code"] == "no_work_available" for w in warnings)
+
+    def test_prs_in_progress_shown_when_only_pr_work(self) -> None:
+        """prs_in_progress should be emitted when no issue work but PRs exist."""
+        status, warnings = compute_health(
+            ready_count=0, building_count=0, blocked_count=0,
+            total_proposals=0, stale_heartbeat_count=0, orphaned_count=0,
+            usage_healthy=True, session_percent=50.0,
+            review_count=1, merge_count=2,
+        )
+        pr_warns = [w for w in warnings if w["code"] == "prs_in_progress"]
+        assert len(pr_warns) == 1
+        assert "3 PR(s) need attention" in pr_warns[0]["message"]
+        assert "1 awaiting review" in pr_warns[0]["message"]
+        assert "2 ready to merge" in pr_warns[0]["message"]
+        assert status == "degraded"  # info-level only
+
+    def test_prs_in_progress_not_shown_when_issues_exist(self) -> None:
+        """prs_in_progress should NOT be emitted when issue work exists."""
+        status, warnings = compute_health(
+            ready_count=1, building_count=0, blocked_count=0,
+            total_proposals=0, stale_heartbeat_count=0, orphaned_count=0,
+            usage_healthy=True, session_percent=50.0,
+            review_count=1, merge_count=2,
+        )
+        assert not any(w["code"] == "prs_in_progress" for w in warnings)
+
+    def test_pipeline_stalled_suppressed_when_prs_actionable(self) -> None:
+        """pipeline_stalled should NOT be emitted when actionable PRs exist."""
+        status, warnings = compute_health(
+            ready_count=0, building_count=0, blocked_count=3,
+            total_proposals=0, stale_heartbeat_count=0, orphaned_count=0,
+            usage_healthy=True, session_percent=50.0,
+            merge_count=1,
+        )
+        assert not any(w["code"] == "pipeline_stalled" for w in warnings)
+
+    def test_pipeline_stalled_still_emitted_without_prs(self) -> None:
+        """pipeline_stalled should still be emitted when no actionable PRs."""
+        status, warnings = compute_health(
+            ready_count=0, building_count=0, blocked_count=3,
+            total_proposals=0, stale_heartbeat_count=0, orphaned_count=0,
+            usage_healthy=True, session_percent=50.0,
+            review_count=0, changes_count=0, merge_count=0,
+        )
+        assert any(w["code"] == "pipeline_stalled" for w in warnings)
+
 
 # ---------------------------------------------------------------------------
 # Tmux pool detection


### PR DESCRIPTION
Closes #3111

## Summary

- **Health warnings now account for PR work**: `no_work_available` and `pipeline_stalled` are no longer emitted when open PRs need merging, reviewing, or fixing. A new `prs_in_progress` info message shows actionable PR counts when no issue work exists.
- **Iteration summary shows PR counts**: The daemon log line now includes `prs=Xr/Yf/Zm` (review/fixes/merge) so operators can see PR activity at a glance.
- **Immediate re-spawn after support role completion**: When a support role (judge, doctor, champion) completes and PRs still need attention, demand-based spawn actions are patched into the snapshot immediately rather than waiting one iteration.

## Test plan

- [x] All 171 snapshot tests pass (7 new tests for health/PR behavior)
- [x] All 18 iteration tests pass (10 new tests for PR summary and demand patching)
- [x] All 209 daemon_v2 tests pass
- [x] Pre-existing test failures (13, all `/fake/repo` mock issues) confirmed unchanged