### PR TITLE
feat: add 3 missing daemon startup cleanup steps

### DIFF
--- a/loom-tools/src/loom_tools/daemon_cleanup.py
+++ b/loom-tools/src/loom_tools/daemon_cleanup.py
@@ -26,7 +26,7 @@ import time
 from dataclasses import dataclass
 from typing import Any
 
-from loom_tools.agent_spawn import kill_stuck_session, session_exists
+from loom_tools.agent_spawn import TMUX_SOCKET, kill_stuck_session, session_exists
 from loom_tools.common.config import env_bool, env_int
 from loom_tools.common.logging import log_error, log_info, log_success, log_warning
 from loom_tools.common.repo import find_repo_root
@@ -651,11 +651,131 @@ def handle_shepherd_complete(
     log_success(f"Shepherd complete cleanup finished for issue #{issue_number}")
 
 
+def _tmux_run(*args: str) -> subprocess.CompletedProcess[str]:
+    """Run a tmux command on the loom socket (local helper)."""
+    cmd = ["tmux", "-L", TMUX_SOCKET, *args]
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+
+
+def _kill_orphaned_tmux_sessions(
+    *,
+    dry_run: bool = False,
+) -> None:
+    """Kill all orphaned loom tmux sessions from a previous daemon run.
+
+    Lists all sessions on the ``loom`` tmux socket and kills every one.
+    This is safe at startup because no sessions from the *current* daemon
+    have been created yet.
+    """
+    try:
+        result = _tmux_run("list-sessions", "-F", "#{session_name}")
+        if result.returncode != 0 or not result.stdout.strip():
+            log_info("No orphaned tmux sessions found")
+            return
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        log_info("tmux not available, skipping orphaned session cleanup")
+        return
+
+    sessions = [s.strip() for s in result.stdout.strip().splitlines() if s.strip()]
+    if not sessions:
+        log_info("No orphaned tmux sessions found")
+        return
+
+    log_info(f"Found {len(sessions)} orphaned tmux session(s) to clean up")
+    killed = 0
+    for session_name in sessions:
+        if dry_run:
+            log_info(f"[DRY-RUN] Would kill orphaned session: {session_name}")
+        else:
+            try:
+                _tmux_run("kill-session", "-t", session_name)
+                log_info(f"Killed orphaned session: {session_name}")
+                killed += 1
+            except (subprocess.TimeoutExpired, FileNotFoundError):
+                log_warning(f"Failed to kill session: {session_name}")
+
+    if not dry_run and killed > 0:
+        log_success(f"Killed {killed} orphaned tmux session(s)")
+
+
+def _ensure_shepherd_config_dirs(
+    repo_root: pathlib.Path,
+    max_shepherds: int,
+    *,
+    dry_run: bool = False,
+) -> None:
+    """Ensure config directories and lock files exist for all shepherd slots.
+
+    Creates ``.loom/claude-config/shepherd-N/`` directories and an empty
+    ``.claude.json.lock`` file in each one.  This prevents crashes at spawn
+    time when a shepherd tries to acquire a lock file that doesn't exist
+    (see issue #3097).
+    """
+    config_base = repo_root / ".loom" / "claude-config"
+
+    created = 0
+    for i in range(1, max_shepherds + 1):
+        agent_name = f"shepherd-{i}"
+        config_dir = config_base / agent_name
+        lock_file = config_dir / ".claude.json.lock"
+
+        if dry_run:
+            if not config_dir.is_dir():
+                log_info(f"[DRY-RUN] Would create config dir: {config_dir}")
+            if not lock_file.exists():
+                log_info(f"[DRY-RUN] Would create lock file: {lock_file}")
+            continue
+
+        if not config_dir.is_dir():
+            config_dir.mkdir(parents=True, exist_ok=True)
+            log_info(f"Created config dir: {config_dir}")
+            created += 1
+
+        if not lock_file.exists():
+            lock_file.touch()
+            log_info(f"Created lock file: {lock_file}")
+
+    if not dry_run:
+        log_info(
+            f"Ensured config dirs for {max_shepherds} shepherd slot(s) "
+            f"({created} new)"
+        )
+
+
+def _reset_failure_counters(
+    repo_root: pathlib.Path,
+    *,
+    dry_run: bool = False,
+) -> None:
+    """Reset the persistent issue failure log to empty.
+
+    Called when the daemon starts with ``--fresh`` to give all previously
+    failed issues a clean slate.
+    """
+    from loom_tools.common.paths import LoomPaths
+
+    paths = LoomPaths(repo_root)
+    fpath = paths.issue_failures_file
+
+    if not fpath.is_file():
+        log_info("No issue-failures.json to reset")
+        return
+
+    if dry_run:
+        log_info(f"[DRY-RUN] Would reset {fpath}")
+        return
+
+    write_json_file(fpath, {"entries": {}, "updated_at": now_utc().strftime("%Y-%m-%dT%H:%M:%SZ")})
+    log_success("Reset issue failure counters (--fresh)")
+
+
 def handle_daemon_startup(
     repo_root: pathlib.Path,
     config: CleanupConfig,
     *,
     dry_run: bool = False,
+    fresh: bool = False,
+    max_shepherds: int = 10,
 ) -> None:
     """Cleanup stale artifacts from a previous daemon session.
 
@@ -679,7 +799,12 @@ def handle_daemon_startup(
     log_info("Reverting stale labels from previous daemon...")
     _revert_shepherd_labels(state_path, dry_run=dry_run)
 
-    # 0c. Clean up expired file-based claims from previous session
+    # 0c. Kill any remaining orphaned tmux sessions on the loom socket.
+    #     This catches sessions missed by state-based termination above.
+    log_info("Killing orphaned tmux sessions...")
+    _kill_orphaned_tmux_sessions(dry_run=dry_run)
+
+    # 0d. Clean up expired file-based claims from previous session
     log_info("Cleaning up expired claims...")
     if not dry_run:
         from loom_tools.claim import cleanup_claims
@@ -688,7 +813,17 @@ def handle_daemon_startup(
     else:
         log_info("[DRY-RUN] Would clean up expired claims")
 
-    # 1. Orphaned shepherd recovery — run in background to avoid blocking startup.
+    # 2. Ensure config directories and lock files exist for all shepherd slots.
+    #    Missing lock files cause crashes at spawn time (see #3097).
+    log_info("Ensuring shepherd config directories...")
+    _ensure_shepherd_config_dirs(repo_root, max_shepherds, dry_run=dry_run)
+
+    # 3. Optionally reset failure counters when starting fresh.
+    if fresh:
+        log_info("Resetting failure counters (--fresh)...")
+        _reset_failure_counters(repo_root, dry_run=dry_run)
+
+    # 4. Orphaned shepherd recovery — run in background to avoid blocking startup.
     #    With many orphans (e.g. 60+), sequential GitHub API calls previously
     #    delayed iteration 1 by 2-3 minutes.  Running in a daemon thread lets
     #    the daemon process signals and start iterations immediately while
@@ -702,12 +837,12 @@ def handle_daemon_startup(
         run_background=not dry_run,
     )
 
-    # 2. Archive orphaned task outputs
+    # 5. Archive orphaned task outputs
     if config.archive_logs:
         log_info("Archiving orphaned task outputs...")
         _run_archive_logs(repo_root, dry_run=dry_run)
 
-    # 3. Process pending cleanups from previous session
+    # 6. Process pending cleanups from previous session
     if state_path.exists():
         data = read_json_file(state_path)
         if isinstance(data, dict):
@@ -726,11 +861,11 @@ def handle_daemon_startup(
                     data["cleanup"] = cleanup
                     write_json_file(state_path, data)
 
-    # 4. Clean stale worktrees
+    # 7. Clean stale worktrees
     log_info("Cleaning stale worktrees...")
     _run_loom_clean(repo_root, dry_run=dry_run)
 
-    # 5. Prune old archives
+    # 8. Prune old archives
     log_info("Pruning old archives...")
     _run_archive_logs(
         repo_root,
@@ -739,7 +874,7 @@ def handle_daemon_startup(
         retention_days=config.retention_days,
     )
 
-    # 6. Cleanup stale progress files (with startup-specific limits)
+    # 9. Cleanup stale progress files (with startup-specific limits)
     cleanup_stale_progress_files(
         repo_root,
         config.progress_stale_hours,
@@ -748,7 +883,7 @@ def handle_daemon_startup(
         timeout_seconds=config.startup_cleanup_timeout,
     )
 
-    # 7. Discard stale unprocessed signal files from previous session
+    # 10. Discard stale unprocessed signal files from previous session
     log_info(
         f"Discarding stale signal files (older than {config.signal_stale_hours}h)..."
     )
@@ -1114,6 +1249,9 @@ Examples:
   # On daemon startup
   loom-daemon-cleanup daemon-startup
 
+  # On daemon startup with fresh failure counters
+  loom-daemon-cleanup daemon-startup --fresh
+
   # Preview periodic cleanup
   loom-daemon-cleanup periodic --dry-run
 """,
@@ -1141,6 +1279,18 @@ Examples:
         "--dry-run",
         action="store_true",
         help="Show what would be cleaned without making changes",
+    )
+    parser.add_argument(
+        "--fresh",
+        action="store_true",
+        help="Reset failure counters on daemon-startup (clean slate for retries)",
+    )
+    parser.add_argument(
+        "--max-shepherds",
+        type=int,
+        default=10,
+        metavar="N",
+        help="Number of shepherd config dirs to ensure (default: 10)",
     )
 
     args = parser.parse_args(argv)
@@ -1170,7 +1320,13 @@ Examples:
                 repo_root, issue_number, config, dry_run=args.dry_run
             )
         elif args.event == "daemon-startup":
-            handle_daemon_startup(repo_root, config, dry_run=args.dry_run)
+            handle_daemon_startup(
+                repo_root,
+                config,
+                dry_run=args.dry_run,
+                fresh=args.fresh,
+                max_shepherds=args.max_shepherds,
+            )
         elif args.event == "daemon-shutdown":
             handle_daemon_shutdown(repo_root, config, dry_run=args.dry_run)
         elif args.event == "periodic":

--- a/loom-tools/src/loom_tools/daemon_v2/cli.py
+++ b/loom-tools/src/loom_tools/daemon_v2/cli.py
@@ -151,6 +151,7 @@ Examples:
     loom-daemon --force         # Force mode (auto-promote, auto-merge, auto-build)
     loom-daemon -t 180          # Run for 3 hours then gracefully stop
     loom-daemon --merge -t 60   # Merge mode for 1 hour
+    loom-daemon --fresh         # Reset failure counters on startup
     loom-daemon --status        # Check if daemon is running
     loom-daemon --health        # Show daemon health
 """,
@@ -175,6 +176,11 @@ Examples:
         "--merge", "-m",
         action="store_true",
         help="Alias for --force (for CLI parity with /loom --merge)",
+    )
+    parser.add_argument(
+        "--fresh",
+        action="store_true",
+        help="Reset failure counters on startup (clean slate for all previously failed issues)",
     )
     parser.add_argument(
         "--debug", "-d",
@@ -224,6 +230,7 @@ Examples:
         force_mode=force_mode,
         auto_build=auto_build,
         no_auto_build=no_auto_build,
+        fresh=args.fresh,
         debug_mode=args.debug,
         timeout_min=args.timeout_min,
     )

--- a/loom-tools/src/loom_tools/daemon_v2/config.py
+++ b/loom-tools/src/loom_tools/daemon_v2/config.py
@@ -42,6 +42,7 @@ class DaemonConfig:
     iteration_timeout: int = DEFAULT_ITERATION_TIMEOUT
     force_mode: bool = False
     auto_build: bool = True
+    fresh: bool = False
     debug_mode: bool = False
     timeout_min: int = 0  # 0 = no timeout
 
@@ -82,6 +83,7 @@ class DaemonConfig:
         force_mode: bool = False,
         auto_build: bool = False,
         no_auto_build: bool = False,
+        fresh: bool = False,
         debug_mode: bool = False,
         timeout_min: int = 0,
     ) -> DaemonConfig:
@@ -91,6 +93,7 @@ class DaemonConfig:
             force_mode: Enable force mode (auto-promote, auto-merge)
             auto_build: Enable automatic shepherd spawning (kept for backward compat, now default)
             no_auto_build: Explicitly disable automatic shepherd spawning
+            fresh: Reset failure counters on startup (clean slate)
             debug_mode: Enable debug logging
             timeout_min: Stop daemon after N minutes (0 = no timeout)
         """
@@ -107,6 +110,7 @@ class DaemonConfig:
             iteration_timeout=env_int("LOOM_ITERATION_TIMEOUT", DEFAULT_ITERATION_TIMEOUT),
             force_mode=resolved_force,
             auto_build=resolved_auto_build,
+            fresh=fresh,
             debug_mode=debug_mode or env_bool("LOOM_DEBUG_MODE", False),
             timeout_min=timeout_min or env_int("LOOM_TIMEOUT_MIN", 0),
             max_shepherds=env_int("LOOM_MAX_SHEPHERDS", DEFAULT_MAX_SHEPHERDS),

--- a/loom-tools/src/loom_tools/daemon_v2/loop.py
+++ b/loom-tools/src/loom_tools/daemon_v2/loop.py
@@ -67,7 +67,12 @@ def run(ctx: DaemonContext) -> int:
         #    previous daemon state to find orphaned sessions and stale labels.
         log_info("Running startup cleanup (crash recovery)...")
         cleanup_config = load_config()
-        handle_daemon_startup(ctx.repo_root, cleanup_config)
+        handle_daemon_startup(
+            ctx.repo_root,
+            cleanup_config,
+            fresh=ctx.config.fresh,
+            max_shepherds=ctx.config.max_shepherds,
+        )
 
         # 6. Rotate existing state file (after crash recovery has read it)
         _rotate_state_file(ctx)

--- a/loom-tools/tests/test_daemon_cleanup.py
+++ b/loom-tools/tests/test_daemon_cleanup.py
@@ -9,6 +9,9 @@ import time
 from unittest import mock
 
 from loom_tools.daemon_cleanup import (
+    _ensure_shepherd_config_dirs,
+    _kill_orphaned_tmux_sessions,
+    _reset_failure_counters,
     _revert_shepherd_labels,
     _run_orphan_recovery,
     _terminate_active_sessions,
@@ -573,7 +576,9 @@ class TestRunOrphanRecoveryBackground:
 
         config = load_config()
 
-        with mock.patch("loom_tools.daemon_cleanup._run_archive_logs"), \
+        with mock.patch("loom_tools.daemon_cleanup._kill_orphaned_tmux_sessions"), \
+             mock.patch("loom_tools.daemon_cleanup._ensure_shepherd_config_dirs"), \
+             mock.patch("loom_tools.daemon_cleanup._run_archive_logs"), \
              mock.patch("loom_tools.daemon_cleanup._run_loom_clean"), \
              mock.patch("loom_tools.daemon_cleanup.cleanup_stale_progress_files"), \
              mock.patch("loom_tools.orphan_recovery.run_orphan_recovery", side_effect=fake_recovery):
@@ -597,7 +602,9 @@ class TestRunOrphanRecoveryBackground:
 
         config = load_config()
 
-        with mock.patch("loom_tools.daemon_cleanup._run_archive_logs"), \
+        with mock.patch("loom_tools.daemon_cleanup._kill_orphaned_tmux_sessions"), \
+             mock.patch("loom_tools.daemon_cleanup._ensure_shepherd_config_dirs"), \
+             mock.patch("loom_tools.daemon_cleanup._run_archive_logs"), \
              mock.patch("loom_tools.daemon_cleanup._run_loom_clean"), \
              mock.patch("loom_tools.daemon_cleanup.cleanup_stale_progress_files"), \
              mock.patch("loom_tools.claim.cleanup_claims"), \
@@ -632,7 +639,9 @@ class TestRunOrphanRecoveryBackground:
         config = load_config()
 
         def run_startup():
-            with mock.patch("loom_tools.daemon_cleanup._run_archive_logs"), \
+            with mock.patch("loom_tools.daemon_cleanup._kill_orphaned_tmux_sessions"), \
+                 mock.patch("loom_tools.daemon_cleanup._ensure_shepherd_config_dirs"), \
+                 mock.patch("loom_tools.daemon_cleanup._run_archive_logs"), \
                  mock.patch("loom_tools.daemon_cleanup._run_loom_clean"), \
                  mock.patch("loom_tools.daemon_cleanup.cleanup_stale_progress_files"), \
                  mock.patch("loom_tools.claim.cleanup_claims"), \
@@ -754,7 +763,9 @@ class TestHandleDaemonStartupCleanupSignals:
         loom_dir.mkdir()
         config = load_config()
 
-        with mock.patch("loom_tools.daemon_cleanup._run_archive_logs"), \
+        with mock.patch("loom_tools.daemon_cleanup._kill_orphaned_tmux_sessions"), \
+             mock.patch("loom_tools.daemon_cleanup._ensure_shepherd_config_dirs"), \
+             mock.patch("loom_tools.daemon_cleanup._run_archive_logs"), \
              mock.patch("loom_tools.daemon_cleanup._run_loom_clean"), \
              mock.patch("loom_tools.daemon_cleanup.cleanup_stale_progress_files"), \
              mock.patch("loom_tools.daemon_cleanup.cleanup_stale_signal_files") as mock_cleanup, \
@@ -773,7 +784,9 @@ class TestHandleDaemonStartupCleanupSignals:
         loom_dir.mkdir()
         config = load_config()
 
-        with mock.patch("loom_tools.daemon_cleanup._run_archive_logs"), \
+        with mock.patch("loom_tools.daemon_cleanup._kill_orphaned_tmux_sessions"), \
+             mock.patch("loom_tools.daemon_cleanup._ensure_shepherd_config_dirs"), \
+             mock.patch("loom_tools.daemon_cleanup._run_archive_logs"), \
              mock.patch("loom_tools.daemon_cleanup._run_loom_clean"), \
              mock.patch("loom_tools.daemon_cleanup.cleanup_stale_progress_files"), \
              mock.patch("loom_tools.daemon_cleanup.cleanup_stale_signal_files") as mock_cleanup, \
@@ -811,6 +824,8 @@ class TestHandleDaemonStartupCrashRecovery:
         with mock.patch("loom_tools.daemon_cleanup.session_exists", return_value=True), \
              mock.patch("loom_tools.daemon_cleanup.kill_stuck_session") as m_kill, \
              mock.patch("loom_tools.common.github.gh_run"), \
+             mock.patch("loom_tools.daemon_cleanup._kill_orphaned_tmux_sessions"), \
+             mock.patch("loom_tools.daemon_cleanup._ensure_shepherd_config_dirs"), \
              mock.patch("loom_tools.daemon_cleanup._run_archive_logs"), \
              mock.patch("loom_tools.daemon_cleanup._run_loom_clean"), \
              mock.patch("loom_tools.daemon_cleanup.cleanup_stale_progress_files"), \
@@ -840,6 +855,8 @@ class TestHandleDaemonStartupCrashRecovery:
         with mock.patch("loom_tools.daemon_cleanup.session_exists", return_value=False), \
              mock.patch("loom_tools.daemon_cleanup.kill_stuck_session"), \
              mock.patch("loom_tools.common.github.gh_run") as m_gh, \
+             mock.patch("loom_tools.daemon_cleanup._kill_orphaned_tmux_sessions"), \
+             mock.patch("loom_tools.daemon_cleanup._ensure_shepherd_config_dirs"), \
              mock.patch("loom_tools.daemon_cleanup._run_archive_logs"), \
              mock.patch("loom_tools.daemon_cleanup._run_loom_clean"), \
              mock.patch("loom_tools.daemon_cleanup.cleanup_stale_progress_files"), \
@@ -886,6 +903,8 @@ class TestHandleDaemonStartupCrashRecovery:
 
         with mock.patch("loom_tools.daemon_cleanup._terminate_active_sessions", side_effect=track_terminate), \
              mock.patch("loom_tools.daemon_cleanup._revert_shepherd_labels", side_effect=track_revert), \
+             mock.patch("loom_tools.daemon_cleanup._kill_orphaned_tmux_sessions"), \
+             mock.patch("loom_tools.daemon_cleanup._ensure_shepherd_config_dirs"), \
              mock.patch("loom_tools.daemon_cleanup._run_orphan_recovery", side_effect=track_orphan_recovery), \
              mock.patch("loom_tools.daemon_cleanup._run_archive_logs"), \
              mock.patch("loom_tools.daemon_cleanup._run_loom_clean"), \
@@ -904,7 +923,9 @@ class TestHandleDaemonStartupCrashRecovery:
 
         config = load_config()
 
-        with mock.patch("loom_tools.daemon_cleanup._run_archive_logs"), \
+        with mock.patch("loom_tools.daemon_cleanup._kill_orphaned_tmux_sessions"), \
+             mock.patch("loom_tools.daemon_cleanup._ensure_shepherd_config_dirs"), \
+             mock.patch("loom_tools.daemon_cleanup._run_archive_logs"), \
              mock.patch("loom_tools.daemon_cleanup._run_loom_clean"), \
              mock.patch("loom_tools.daemon_cleanup.cleanup_stale_progress_files"), \
              mock.patch("loom_tools.daemon_cleanup.cleanup_stale_signal_files"), \
@@ -930,6 +951,8 @@ class TestHandleDaemonStartupCrashRecovery:
         with mock.patch("loom_tools.daemon_cleanup.session_exists") as m_exists, \
              mock.patch("loom_tools.daemon_cleanup.kill_stuck_session") as m_kill, \
              mock.patch("loom_tools.common.github.gh_run") as m_gh, \
+             mock.patch("loom_tools.daemon_cleanup._kill_orphaned_tmux_sessions"), \
+             mock.patch("loom_tools.daemon_cleanup._ensure_shepherd_config_dirs"), \
              mock.patch("loom_tools.daemon_cleanup._run_archive_logs"), \
              mock.patch("loom_tools.daemon_cleanup._run_loom_clean"), \
              mock.patch("loom_tools.daemon_cleanup.cleanup_stale_progress_files"), \
@@ -941,3 +964,293 @@ class TestHandleDaemonStartupCrashRecovery:
         # log but do not kill or call gh
         m_kill.assert_not_called()
         m_gh.assert_not_called()
+
+
+class TestKillOrphanedTmuxSessions:
+    """Tests for _kill_orphaned_tmux_sessions() called during daemon startup."""
+
+    def test_kills_all_sessions_on_loom_socket(self) -> None:
+        """All sessions on the loom socket should be killed at startup."""
+        fake_result = mock.MagicMock(
+            returncode=0, stdout="loom-shepherd-1\nloom-shepherd-2\nloom-champion\n"
+        )
+        with mock.patch("loom_tools.daemon_cleanup._tmux_run") as m_tmux:
+            m_tmux.return_value = fake_result
+            _kill_orphaned_tmux_sessions()
+
+        # First call is list-sessions, subsequent calls are kill-session
+        assert m_tmux.call_count == 4
+        m_tmux.assert_any_call("kill-session", "-t", "loom-shepherd-1")
+        m_tmux.assert_any_call("kill-session", "-t", "loom-shepherd-2")
+        m_tmux.assert_any_call("kill-session", "-t", "loom-champion")
+
+    def test_no_sessions_found(self) -> None:
+        """Should handle empty session list gracefully."""
+        fake_result = mock.MagicMock(returncode=1, stdout="")
+        with mock.patch("loom_tools.daemon_cleanup._tmux_run") as m_tmux:
+            m_tmux.return_value = fake_result
+            _kill_orphaned_tmux_sessions()
+
+        # Only the list-sessions call
+        m_tmux.assert_called_once()
+
+    def test_tmux_not_available(self) -> None:
+        """Should handle missing tmux gracefully."""
+        with mock.patch(
+            "loom_tools.daemon_cleanup._tmux_run",
+            side_effect=FileNotFoundError("tmux not found"),
+        ):
+            # Should not raise
+            _kill_orphaned_tmux_sessions()
+
+    def test_dry_run_does_not_kill(self) -> None:
+        """Dry run should list but not kill sessions."""
+        fake_result = mock.MagicMock(
+            returncode=0, stdout="loom-shepherd-1\nloom-champion\n"
+        )
+        with mock.patch("loom_tools.daemon_cleanup._tmux_run") as m_tmux:
+            m_tmux.return_value = fake_result
+            _kill_orphaned_tmux_sessions(dry_run=True)
+
+        # Only the list-sessions call, no kill calls
+        m_tmux.assert_called_once()
+
+    def test_timeout_during_kill_continues(self) -> None:
+        """Timeout killing one session should not prevent killing others."""
+        import subprocess as sp
+
+        fake_list = mock.MagicMock(
+            returncode=0, stdout="loom-shepherd-1\nloom-shepherd-2\n"
+        )
+
+        def side_effect(*args, **kwargs):
+            if args == ("list-sessions", "-F", "#{session_name}"):
+                return fake_list
+            if args == ("kill-session", "-t", "loom-shepherd-1"):
+                raise sp.TimeoutExpired(cmd="tmux", timeout=10)
+            return mock.MagicMock(returncode=0)
+
+        with mock.patch("loom_tools.daemon_cleanup._tmux_run", side_effect=side_effect):
+            _kill_orphaned_tmux_sessions()
+
+        # Should not raise despite timeout on first kill
+
+
+class TestEnsureShepherdConfigDirs:
+    """Tests for _ensure_shepherd_config_dirs()."""
+
+    def test_creates_dirs_and_lockfiles(self, tmp_path: pathlib.Path) -> None:
+        """Should create config dirs and lock files for each shepherd slot."""
+        (tmp_path / ".loom").mkdir()
+
+        _ensure_shepherd_config_dirs(tmp_path, max_shepherds=3)
+
+        for i in range(1, 4):
+            config_dir = tmp_path / ".loom" / "claude-config" / f"shepherd-{i}"
+            lock_file = config_dir / ".claude.json.lock"
+            assert config_dir.is_dir(), f"Config dir for shepherd-{i} should exist"
+            assert lock_file.exists(), f"Lock file for shepherd-{i} should exist"
+
+    def test_does_not_overwrite_existing(self, tmp_path: pathlib.Path) -> None:
+        """Should not overwrite existing lock files."""
+        (tmp_path / ".loom").mkdir()
+        config_dir = tmp_path / ".loom" / "claude-config" / "shepherd-1"
+        config_dir.mkdir(parents=True)
+        lock_file = config_dir / ".claude.json.lock"
+        lock_file.write_text("existing content")
+
+        _ensure_shepherd_config_dirs(tmp_path, max_shepherds=1)
+
+        assert lock_file.read_text() == "existing content"
+
+    def test_creates_missing_lockfile_in_existing_dir(self, tmp_path: pathlib.Path) -> None:
+        """Should create lock file even if config dir already exists."""
+        (tmp_path / ".loom").mkdir()
+        config_dir = tmp_path / ".loom" / "claude-config" / "shepherd-1"
+        config_dir.mkdir(parents=True)
+
+        _ensure_shepherd_config_dirs(tmp_path, max_shepherds=1)
+
+        lock_file = config_dir / ".claude.json.lock"
+        assert lock_file.exists()
+
+    def test_dry_run_does_not_create(self, tmp_path: pathlib.Path) -> None:
+        """Dry run should not create any directories or files."""
+        (tmp_path / ".loom").mkdir()
+
+        _ensure_shepherd_config_dirs(tmp_path, max_shepherds=3, dry_run=True)
+
+        config_base = tmp_path / ".loom" / "claude-config"
+        assert not config_base.exists()
+
+    def test_zero_shepherds(self, tmp_path: pathlib.Path) -> None:
+        """Should handle zero max_shepherds gracefully."""
+        (tmp_path / ".loom").mkdir()
+
+        _ensure_shepherd_config_dirs(tmp_path, max_shepherds=0)
+
+        config_base = tmp_path / ".loom" / "claude-config"
+        # No directories should be created
+        if config_base.exists():
+            assert list(config_base.iterdir()) == []
+
+
+class TestResetFailureCounters:
+    """Tests for _reset_failure_counters()."""
+
+    def test_resets_existing_file(self, tmp_path: pathlib.Path) -> None:
+        """Should replace failure log with empty entries."""
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir()
+        failures_file = loom_dir / "issue-failures.json"
+        failures_file.write_text(json.dumps({
+            "entries": {
+                "42": {"issue": 42, "total_failures": 3, "error_class": "builder_stuck"},
+                "99": {"issue": 99, "total_failures": 5, "error_class": "budget_exhausted"},
+            },
+            "updated_at": "2026-01-20T10:00:00Z",
+        }))
+
+        _reset_failure_counters(tmp_path)
+
+        data = json.loads(failures_file.read_text())
+        assert data["entries"] == {}
+        assert "updated_at" in data
+
+    def test_no_file_does_not_error(self, tmp_path: pathlib.Path) -> None:
+        """Should handle missing failure log gracefully."""
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir()
+
+        _reset_failure_counters(tmp_path)
+
+        failures_file = loom_dir / "issue-failures.json"
+        assert not failures_file.exists()
+
+    def test_dry_run_does_not_reset(self, tmp_path: pathlib.Path) -> None:
+        """Dry run should not modify the failure log."""
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir()
+        failures_file = loom_dir / "issue-failures.json"
+        original = json.dumps({
+            "entries": {"42": {"issue": 42, "total_failures": 3}},
+        })
+        failures_file.write_text(original)
+
+        _reset_failure_counters(tmp_path, dry_run=True)
+
+        assert failures_file.read_text() == original
+
+
+class TestHandleDaemonStartupNewSteps:
+    """Tests that handle_daemon_startup calls the three new cleanup steps."""
+
+    def test_startup_kills_orphaned_sessions(self, tmp_path: pathlib.Path) -> None:
+        """Startup should kill orphaned tmux sessions."""
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir()
+        config = load_config()
+
+        with mock.patch("loom_tools.daemon_cleanup._kill_orphaned_tmux_sessions") as m_kill, \
+             mock.patch("loom_tools.daemon_cleanup._ensure_shepherd_config_dirs"), \
+             mock.patch("loom_tools.daemon_cleanup._terminate_active_sessions"), \
+             mock.patch("loom_tools.daemon_cleanup._revert_shepherd_labels"), \
+             mock.patch("loom_tools.daemon_cleanup._run_archive_logs"), \
+             mock.patch("loom_tools.daemon_cleanup._run_loom_clean"), \
+             mock.patch("loom_tools.daemon_cleanup.cleanup_stale_progress_files"), \
+             mock.patch("loom_tools.daemon_cleanup.cleanup_stale_signal_files"), \
+             mock.patch("loom_tools.daemon_cleanup._run_orphan_recovery"):
+            handle_daemon_startup(tmp_path, config, dry_run=True)
+
+        m_kill.assert_called_once_with(dry_run=True)
+
+    def test_startup_ensures_config_dirs(self, tmp_path: pathlib.Path) -> None:
+        """Startup should ensure shepherd config directories exist."""
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir()
+        config = load_config()
+
+        with mock.patch("loom_tools.daemon_cleanup._kill_orphaned_tmux_sessions"), \
+             mock.patch("loom_tools.daemon_cleanup._ensure_shepherd_config_dirs") as m_ensure, \
+             mock.patch("loom_tools.daemon_cleanup._terminate_active_sessions"), \
+             mock.patch("loom_tools.daemon_cleanup._revert_shepherd_labels"), \
+             mock.patch("loom_tools.daemon_cleanup._run_archive_logs"), \
+             mock.patch("loom_tools.daemon_cleanup._run_loom_clean"), \
+             mock.patch("loom_tools.daemon_cleanup.cleanup_stale_progress_files"), \
+             mock.patch("loom_tools.daemon_cleanup.cleanup_stale_signal_files"), \
+             mock.patch("loom_tools.daemon_cleanup._run_orphan_recovery"):
+            handle_daemon_startup(tmp_path, config, max_shepherds=5, dry_run=True)
+
+        m_ensure.assert_called_once_with(tmp_path, 5, dry_run=True)
+
+    def test_startup_with_fresh_resets_failures(self, tmp_path: pathlib.Path) -> None:
+        """Startup with fresh=True should reset failure counters."""
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir()
+        config = load_config()
+
+        with mock.patch("loom_tools.daemon_cleanup._kill_orphaned_tmux_sessions"), \
+             mock.patch("loom_tools.daemon_cleanup._ensure_shepherd_config_dirs"), \
+             mock.patch("loom_tools.daemon_cleanup._terminate_active_sessions"), \
+             mock.patch("loom_tools.daemon_cleanup._revert_shepherd_labels"), \
+             mock.patch("loom_tools.daemon_cleanup._reset_failure_counters") as m_reset, \
+             mock.patch("loom_tools.daemon_cleanup._run_archive_logs"), \
+             mock.patch("loom_tools.daemon_cleanup._run_loom_clean"), \
+             mock.patch("loom_tools.daemon_cleanup.cleanup_stale_progress_files"), \
+             mock.patch("loom_tools.daemon_cleanup.cleanup_stale_signal_files"), \
+             mock.patch("loom_tools.daemon_cleanup._run_orphan_recovery"):
+            handle_daemon_startup(tmp_path, config, fresh=True, dry_run=True)
+
+        m_reset.assert_called_once_with(tmp_path, dry_run=True)
+
+    def test_startup_without_fresh_does_not_reset_failures(self, tmp_path: pathlib.Path) -> None:
+        """Startup without fresh=True should not reset failure counters."""
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir()
+        config = load_config()
+
+        with mock.patch("loom_tools.daemon_cleanup._kill_orphaned_tmux_sessions"), \
+             mock.patch("loom_tools.daemon_cleanup._ensure_shepherd_config_dirs"), \
+             mock.patch("loom_tools.daemon_cleanup._terminate_active_sessions"), \
+             mock.patch("loom_tools.daemon_cleanup._revert_shepherd_labels"), \
+             mock.patch("loom_tools.daemon_cleanup._reset_failure_counters") as m_reset, \
+             mock.patch("loom_tools.daemon_cleanup._run_archive_logs"), \
+             mock.patch("loom_tools.daemon_cleanup._run_loom_clean"), \
+             mock.patch("loom_tools.daemon_cleanup.cleanup_stale_progress_files"), \
+             mock.patch("loom_tools.daemon_cleanup.cleanup_stale_signal_files"), \
+             mock.patch("loom_tools.daemon_cleanup._run_orphan_recovery"):
+            handle_daemon_startup(tmp_path, config, dry_run=True)
+
+        m_reset.assert_not_called()
+
+    def test_startup_kills_sessions_before_other_cleanup(self, tmp_path: pathlib.Path) -> None:
+        """Tmux session killing should happen first (before claim cleanup, orphan recovery)."""
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir()
+        config = load_config()
+
+        call_order: list[str] = []
+
+        def track_kill(**kwargs):
+            call_order.append("kill_sessions")
+
+        def track_claims(repo_root):
+            call_order.append("cleanup_claims")
+
+        def track_orphan(repo_root, **kwargs):
+            call_order.append("orphan_recovery")
+
+        with mock.patch("loom_tools.daemon_cleanup._kill_orphaned_tmux_sessions", side_effect=track_kill), \
+             mock.patch("loom_tools.daemon_cleanup._ensure_shepherd_config_dirs"), \
+             mock.patch("loom_tools.daemon_cleanup._terminate_active_sessions"), \
+             mock.patch("loom_tools.daemon_cleanup._revert_shepherd_labels"), \
+             mock.patch("loom_tools.daemon_cleanup._run_archive_logs"), \
+             mock.patch("loom_tools.daemon_cleanup._run_loom_clean"), \
+             mock.patch("loom_tools.daemon_cleanup.cleanup_stale_progress_files"), \
+             mock.patch("loom_tools.daemon_cleanup.cleanup_stale_signal_files"), \
+             mock.patch("loom_tools.claim.cleanup_claims", side_effect=track_claims), \
+             mock.patch("loom_tools.daemon_cleanup._run_orphan_recovery", side_effect=track_orphan):
+            handle_daemon_startup(tmp_path, config)
+
+        assert call_order.index("kill_sessions") < call_order.index("cleanup_claims")
+        assert call_order.index("kill_sessions") < call_order.index("orphan_recovery")


### PR DESCRIPTION
Closes #3107

## Summary

- **Kill orphaned tmux sessions** (step 0): Lists all sessions on the `loom` tmux socket and kills every one before other cleanup runs. Safe at startup since no current-session agents exist yet.
- **Ensure shepherd config dirs** (step 2): Creates `.loom/claude-config/shepherd-N/` directories and `.claude.json.lock` files for all shepherd slots, preventing spawn-time crashes (related to #3097).
- **Reset failure counters** (step 3, opt-in): New `--fresh` flag on both `loom-daemon` CLI and `loom-daemon-cleanup daemon-startup` resets `issue-failures.json` to give previously failed issues a clean slate.

Existing startup steps renumbered from 0-7 to 0-10. All new steps include dry-run support.

## Test plan

- [x] 60 tests pass in `test_daemon_cleanup.py` (18 new + 42 existing)
- [x] Full Python test suite: 3856 passed (12 pre-existing failures unrelated)
- [x] Rust daemon tests: 14 passed
- [ ] Manual: `loom-daemon --fresh` starts with empty failure counters
- [ ] Manual: Daemon startup kills leftover tmux sessions from previous run

Generated with [Claude Code](https://claude.com/claude-code)