### PR TITLE
fix: prevent builders from creating PRs from stale/failed work

### DIFF
--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -533,60 +533,77 @@ class BuilderPhase:
         if ctx.worktree_path and ctx.worktree_path.is_dir():
             prior_commits = self._count_commits_ahead_of_main(ctx.worktree_path)
             if prior_commits > 0:
-                log_info(
-                    f"Prior work found ({prior_commits} commit(s) since main). "
-                    f"Resuming from checkpoint — skipping builder invocation."
+                # Guard: check if the feature branch already has a closed/merged
+                # PR — this means a previous attempt was rejected and we should
+                # NOT resubmit the same stale work.  Reset the worktree and let
+                # the builder start fresh.  See issue #3106.
+                closed_pr = self._has_closed_pr_for_branch(
+                    ctx.config.issue, ctx.repo_root
                 )
-                ctx.report_milestone(
-                    "checkpoint_loaded",
-                    stage="committed",
-                    recovery_path=str(ctx.worktree_path),
-                    skip_stages=["builder"],
-                )
-                diag = self._gather_diagnostics(ctx)
-                recovery = self._recover_from_existing_worktree(ctx, diag, exit_code=0)
-                if recovery is not None:
-                    return recovery
+                if closed_pr is not None:
+                    log_warning(
+                        f"Prior work from rejected PR #{closed_pr} detected "
+                        f"for issue #{ctx.config.issue} — resetting worktree "
+                        f"to start fresh instead of resubmitting stale work"
+                    )
+                    self._reset_stale_worktree(ctx)
+                    # Don't return — fall through to normal builder invocation
+                    # so a fresh builder can start from scratch.
+                else:
+                    log_info(
+                        f"Prior work found ({prior_commits} commit(s) since main). "
+                        f"Resuming from checkpoint — skipping builder invocation."
+                    )
+                    ctx.report_milestone(
+                        "checkpoint_loaded",
+                        stage="committed",
+                        recovery_path=str(ctx.worktree_path),
+                        skip_stages=["builder"],
+                    )
+                    diag = self._gather_diagnostics(ctx)
+                    recovery = self._recover_from_existing_worktree(ctx, diag, exit_code=0)
+                    if recovery is not None:
+                        return recovery
 
-                # recovery returned None — determine why before returning FAILED.
-                # Case: workflow already complete (PR created + review label added).
-                # This happens when the shepherd crashes after the builder finishes
-                # but before advancing to the judge phase.  On restart, the builder
-                # phase runs again, detects prior commits, but recovery has nothing
-                # to do because the workflow is already done.  Return SUCCESS so the
-                # shepherd advances to the judge phase instead of cycling.
-                if diag.get("pr_number") is not None and diag.get(
-                    "pr_has_review_label", False
-                ):
-                    ctx.pr_number = diag["pr_number"]
+                    # recovery returned None — determine why before returning FAILED.
+                    # Case: workflow already complete (PR created + review label added).
+                    # This happens when the shepherd crashes after the builder finishes
+                    # but before advancing to the judge phase.  On restart, the builder
+                    # phase runs again, detects prior commits, but recovery has nothing
+                    # to do because the workflow is already done.  Return SUCCESS so the
+                    # shepherd advances to the judge phase instead of cycling.
+                    if diag.get("pr_number") is not None and diag.get(
+                        "pr_has_review_label", False
+                    ):
+                        ctx.pr_number = diag["pr_number"]
+                        return PhaseResult(
+                            status=PhaseStatus.SUCCESS,
+                            message=(
+                                f"builder phase complete - PR #{diag['pr_number']} "
+                                f"already exists with review label "
+                                f"(prior checkpoint detected)"
+                            ),
+                            phase_name="builder",
+                            data={
+                                "pr_number": diag["pr_number"],
+                                "recovered_from_checkpoint": True,
+                            },
+                        )
+
+                    log_warning(
+                        f"Prior checkpoint recovery failed for issue #{ctx.config.issue} "
+                        f"— recovery could not complete push/PR workflow"
+                    )
                     return PhaseResult(
-                        status=PhaseStatus.SUCCESS,
+                        status=PhaseStatus.FAILED,
                         message=(
-                            f"builder phase complete - PR #{diag['pr_number']} "
-                            f"already exists with review label "
-                            f"(prior checkpoint detected)"
+                            f"prior checkpoint recovery failed: worktree has "
+                            f"{prior_commits} commit(s) ahead of main but "
+                            f"could not complete push/PR workflow"
                         ),
                         phase_name="builder",
-                        data={
-                            "pr_number": diag["pr_number"],
-                            "recovered_from_checkpoint": True,
-                        },
+                        data={"prior_commits": prior_commits},
                     )
-
-                log_warning(
-                    f"Prior checkpoint recovery failed for issue #{ctx.config.issue} "
-                    f"— recovery could not complete push/PR workflow"
-                )
-                return PhaseResult(
-                    status=PhaseStatus.FAILED,
-                    message=(
-                        f"prior checkpoint recovery failed: worktree has "
-                        f"{prior_commits} commit(s) ahead of main but "
-                        f"could not complete push/PR workflow"
-                    ),
-                    phase_name="builder",
-                    data={"prior_commits": prior_commits},
-                )
 
         # Snapshot main's dirty state before spawning the builder so we can
         # distinguish pre-existing dirt from actual worktree escapes later.
@@ -3898,6 +3915,11 @@ class BuilderPhase:
             ls_res.returncode == 0 and ls_res.stdout.strip()
         )
 
+        # -- Closed/rejected PR (stale branch detection, issue #3106) --------
+        diag["closed_pr_for_branch"] = self._has_closed_pr_for_branch(
+            ctx.config.issue, ctx.repo_root
+        )
+
         # -- Existing PR -----------------------------------------------------
         branch_name_for_pr = NamingConventions.branch_name(ctx.config.issue)
         pr_res = subprocess.run(
@@ -4094,6 +4116,11 @@ class BuilderPhase:
             parts.append(
                 f"WARNING: commits reference wrong issue(s): "
                 f"{diag['wrong_issue_refs']}"
+            )
+        if diag.get("closed_pr_for_branch") is not None:
+            parts.append(
+                f"WARNING: stale branch — closed PR #{diag['closed_pr_for_branch']} "
+                f"exists for this branch"
             )
         parts.append(f"log={diag['log_file']}")
         diag["summary"] = "; ".join(parts)
@@ -4471,6 +4498,117 @@ class BuilderPhase:
 
         return steps
 
+    def _has_closed_pr_for_branch(
+        self, issue: int, repo_root: Path
+    ) -> int | None:
+        """Check if a closed/merged PR already exists for this issue's branch.
+
+        When a feature branch already has a closed (rejected) or merged PR,
+        creating a new PR from the same branch is likely to submit stale or
+        previously-rejected work.  The builder should start fresh instead.
+
+        Returns the PR number if a closed/merged PR exists, None otherwise.
+        See issue #3106.
+        """
+        branch = NamingConventions.branch_name(issue)
+        result = subprocess.run(
+            [
+                "gh", "pr", "list",
+                "--head", branch,
+                "--state", "closed",
+                "--json", "number",
+                "--jq", ".[0].number // empty",
+            ],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        pr_num_str = result.stdout.strip()
+        if pr_num_str:
+            try:
+                return int(pr_num_str)
+            except ValueError:
+                pass
+        return None
+
+    def _validate_build_before_pr(
+        self, ctx: ShepherdContext
+    ) -> tuple[bool, str]:
+        """Run a quick build/test validation before creating a PR.
+
+        Prevents submitting broken work that wastes Judge review cycles.
+        Runs the detected test command in the worktree and returns
+        (passed, message).
+
+        This is a lightweight pre-PR gate, not a full baseline comparison.
+        It only checks that the build/tests pass in the worktree.
+
+        Returns:
+            Tuple of (passed: bool, message: str).  When passed is False,
+            the message describes the failure.
+        See issue #3106.
+        """
+        wt = ctx.worktree_path
+        if not wt or not wt.is_dir():
+            # No worktree to validate — allow PR creation (the builder
+            # may have pushed from elsewhere).
+            return True, "no worktree to validate"
+
+        test_info = self._detect_test_command(wt)
+        if test_info is None:
+            # No test runner detected — allow PR creation.
+            return True, "no test runner detected"
+
+        test_cmd, display_name = test_info
+        log_info(
+            f"Pre-PR validation: running {display_name} in worktree "
+            f"for issue #{ctx.config.issue}"
+        )
+
+        try:
+            result = subprocess.run(
+                test_cmd,
+                cwd=str(wt),
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=300,  # 5 minute timeout for pre-PR validation
+            )
+        except subprocess.TimeoutExpired:
+            log_warning(
+                f"Pre-PR validation timed out after 300s for issue "
+                f"#{ctx.config.issue} — allowing PR creation"
+            )
+            return True, "validation timed out (allowing PR)"
+        except OSError as e:
+            log_warning(
+                f"Pre-PR validation could not run {display_name}: {e} "
+                f"— allowing PR creation"
+            )
+            return True, f"could not run {display_name}: {e}"
+
+        if result.returncode == 0:
+            log_info(
+                f"Pre-PR validation passed: {display_name} exited with 0"
+            )
+            return True, f"{display_name} passed"
+
+        # Extract tail of output for diagnostics
+        output_lines = (result.stdout or "").splitlines()
+        stderr_lines = (result.stderr or "").splitlines()
+        tail = (output_lines + stderr_lines)[-20:]
+        tail_str = "\n".join(tail)
+
+        log_warning(
+            f"Pre-PR validation failed: {display_name} exited with "
+            f"{result.returncode} for issue #{ctx.config.issue}\n"
+            f"Output tail:\n{tail_str}"
+        )
+        return False, (
+            f"{display_name} failed (exit code {result.returncode})"
+        )
+
     def _direct_completion(
         self, ctx: ShepherdContext, diag: dict[str, Any]
     ) -> bool:
@@ -4583,6 +4721,33 @@ class BuilderPhase:
                     existing_pr = str(kw_pr_num)
                 if existing_pr:
                     continue
+
+                # Guard: refuse to create PR when a closed/merged PR already
+                # exists for this branch.  This means the branch contains
+                # stale/rejected work from a prior attempt.  See issue #3106.
+                closed_pr = self._has_closed_pr_for_branch(
+                    ctx.config.issue, ctx.repo_root
+                )
+                if closed_pr is not None:
+                    log_warning(
+                        f"Direct completion: refusing to create PR for issue "
+                        f"#{ctx.config.issue} — closed/merged PR #{closed_pr} "
+                        f"already exists for branch {branch} (stale work)"
+                    )
+                    return False
+
+                # Guard: run build/test validation before creating a PR.
+                # This prevents submitting broken work that wastes Judge
+                # review cycles.  See issue #3106.
+                build_ok, build_msg = self._validate_build_before_pr(ctx)
+                if not build_ok:
+                    log_warning(
+                        f"Direct completion: refusing to create PR for issue "
+                        f"#{ctx.config.issue} — pre-PR validation failed: "
+                        f"{build_msg}"
+                    )
+                    return False
+
                 pr_body = self._build_direct_completion_pr_body(ctx)
                 result = subprocess.run(
                     [

--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -1450,6 +1450,7 @@ class TestBuilderCheckpointResume:
             patch.object(
                 builder, "_count_commits_ahead_of_main", return_value=3
             ),
+            patch.object(builder, "_has_closed_pr_for_branch", return_value=None),
             patch.object(builder, "_gather_diagnostics", return_value={}),
             patch.object(
                 builder,
@@ -1536,6 +1537,7 @@ class TestBuilderCheckpointResume:
             patch.object(
                 builder, "_count_commits_ahead_of_main", return_value=2
             ),
+            patch.object(builder, "_has_closed_pr_for_branch", return_value=None),
             patch.object(builder, "_gather_diagnostics", return_value=fake_diag),
             patch.object(
                 builder, "_recover_from_existing_worktree", return_value=None
@@ -1578,6 +1580,7 @@ class TestBuilderCheckpointResume:
             patch.object(
                 builder, "_count_commits_ahead_of_main", return_value=2
             ),
+            patch.object(builder, "_has_closed_pr_for_branch", return_value=None),
             patch.object(builder, "_gather_diagnostics", return_value=fake_diag),
             patch.object(
                 builder, "_recover_from_existing_worktree", return_value=None
@@ -1998,8 +2001,10 @@ class TestBuilderDiagnostics:
             diag = builder._gather_diagnostics(mock_context)
 
         assert diag["pr_number"] == 123
-        assert len(branch_lookup_called) == 1
-        # Keyword search should NOT be called when branch-name lookup succeeds
+        # Two branch-name lookups: one for open PRs, one for closed PRs
+        # (stale branch detection, issue #3106)
+        assert len(branch_lookup_called) == 2
+        # Keyword search should NOT be called when branch-name lookup finds a PR
         assert len(keyword_lookup_called) == 0, (
             "Keyword search should be skipped when branch-name lookup finds a PR"
         )
@@ -11384,6 +11389,8 @@ class TestBuilderDirectCompletion:
                 "_build_direct_completion_pr_body",
                 return_value="Closes #42\n\n## Changes\n```\nfile.py | 2 +-\n```\n\n## Test plan\n- [ ] Verify",
             ),
+            patch.object(builder, "_has_closed_pr_for_branch", return_value=None),
+            patch.object(builder, "_validate_build_before_pr", return_value=(True, "passed")),
             patch(
                 "loom_tools.shepherd.phases.builder.subprocess.run"
             ) as mock_run,
@@ -11465,6 +11472,8 @@ class TestBuilderDirectCompletion:
                 "_build_direct_completion_pr_body",
                 return_value="Closes #42\n\n## Test plan\n- [ ] Verify",
             ),
+            patch.object(builder, "_has_closed_pr_for_branch", return_value=None),
+            patch.object(builder, "_validate_build_before_pr", return_value=(True, "passed")),
             patch(
                 "loom_tools.shepherd.phases.builder.subprocess.run"
             ) as mock_run,
@@ -11530,6 +11539,8 @@ class TestBuilderDirectCompletion:
                 "_build_direct_completion_pr_body",
                 return_value="Closes #42\n\n## Changes\n```\nbuilder.py | 10 ++++\n```\n\n## Test plan\n- [ ] Verify",
             ),
+            patch.object(builder, "_has_closed_pr_for_branch", return_value=None),
+            patch.object(builder, "_validate_build_before_pr", return_value=(True, "passed")),
             patch(
                 "loom_tools.shepherd.phases.builder.subprocess.run"
             ) as mock_run,
@@ -11616,6 +11627,8 @@ class TestBuilderDirectCompletion:
                 "_build_direct_completion_pr_body",
                 return_value="Closes #42\n\n## Test plan\n- [ ] Verify",
             ),
+            patch.object(builder, "_has_closed_pr_for_branch", return_value=None),
+            patch.object(builder, "_validate_build_before_pr", return_value=(True, "passed")),
             patch(
                 "loom_tools.shepherd.phases.builder.subprocess.run"
             ) as mock_run,
@@ -11785,6 +11798,8 @@ class TestBuilderDirectCompletion:
                 "_build_direct_completion_pr_body",
                 return_value="Closes #42\n\n## Test plan\n- [ ] Verify",
             ),
+            patch.object(builder, "_has_closed_pr_for_branch", return_value=None),
+            patch.object(builder, "_validate_build_before_pr", return_value=(True, "passed")),
             patch(
                 "loom_tools.shepherd.phases.builder.subprocess.run"
             ) as mock_run,
@@ -11828,6 +11843,8 @@ class TestBuilderDirectCompletion:
                 "_build_direct_completion_pr_body",
                 return_value="Closes #99",
             ),
+            patch.object(builder, "_has_closed_pr_for_branch", return_value=None),
+            patch.object(builder, "_validate_build_before_pr", return_value=(True, "passed")),
             patch(
                 "loom_tools.shepherd.phases.builder.subprocess.run"
             ) as mock_run,
@@ -11871,6 +11888,8 @@ class TestBuilderDirectCompletion:
                 "_build_direct_completion_pr_body",
                 return_value="Closes #55",
             ),
+            patch.object(builder, "_has_closed_pr_for_branch", return_value=None),
+            patch.object(builder, "_validate_build_before_pr", return_value=(True, "passed")),
             patch(
                 "loom_tools.shepherd.phases.builder.subprocess.run"
             ) as mock_run,
@@ -11936,6 +11955,8 @@ class TestBuilderDirectCompletion:
                 "_build_direct_completion_pr_body",
                 return_value="Closes #42\n\n## Test plan\n- [ ] Verify",
             ),
+            patch.object(builder, "_has_closed_pr_for_branch", return_value=None),
+            patch.object(builder, "_validate_build_before_pr", return_value=(True, "passed")),
             patch(
                 "loom_tools.shepherd.phases.builder.subprocess.run"
             ) as mock_run,
@@ -11986,6 +12007,274 @@ class TestBuilderDirectCompletion:
         checkpoint = read_checkpoint(worktree)
         assert checkpoint is not None
         assert checkpoint.stage == "pushed"
+
+
+class TestBuilderHasClosedPrForBranch:
+    """Test _has_closed_pr_for_branch for stale branch detection.  See #3106."""
+
+    def test_returns_pr_number_when_closed_pr_exists(
+        self, mock_context: MagicMock
+    ) -> None:
+        """Should return the closed PR number when one exists."""
+        builder = BuilderPhase()
+
+        with patch(
+            "loom_tools.shepherd.phases.builder.subprocess.run"
+        ) as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="123\n", stderr=""
+            )
+            result = builder._has_closed_pr_for_branch(42, Path("/fake/repo"))
+
+        assert result == 123
+        call_args = mock_run.call_args[0][0]
+        assert call_args[:3] == ["gh", "pr", "list"]
+        assert "--head" in call_args
+        assert "feature/issue-42" in call_args
+        assert "--state" in call_args
+        state_idx = call_args.index("--state")
+        assert call_args[state_idx + 1] == "closed"
+
+    def test_returns_none_when_no_closed_pr(
+        self, mock_context: MagicMock
+    ) -> None:
+        """Should return None when no closed PR exists."""
+        builder = BuilderPhase()
+
+        with patch(
+            "loom_tools.shepherd.phases.builder.subprocess.run"
+        ) as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="", stderr=""
+            )
+            result = builder._has_closed_pr_for_branch(42, Path("/fake/repo"))
+
+        assert result is None
+
+    def test_returns_none_on_command_failure(
+        self, mock_context: MagicMock
+    ) -> None:
+        """Should return None when gh command fails."""
+        builder = BuilderPhase()
+
+        with patch(
+            "loom_tools.shepherd.phases.builder.subprocess.run"
+        ) as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=1, stdout="", stderr="error"
+            )
+            result = builder._has_closed_pr_for_branch(42, Path("/fake/repo"))
+
+        assert result is None
+
+    def test_returns_none_on_non_numeric_output(
+        self, mock_context: MagicMock
+    ) -> None:
+        """Should return None when output is not a valid number."""
+        builder = BuilderPhase()
+
+        with patch(
+            "loom_tools.shepherd.phases.builder.subprocess.run"
+        ) as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="not-a-number\n", stderr=""
+            )
+            result = builder._has_closed_pr_for_branch(42, Path("/fake/repo"))
+
+        assert result is None
+
+
+class TestBuilderValidateBuildBeforePr:
+    """Test _validate_build_before_pr for pre-PR validation.  See #3106."""
+
+    def test_passes_when_tests_succeed(
+        self, mock_context: MagicMock, tmp_path: Path
+    ) -> None:
+        """Should return (True, msg) when build/tests pass."""
+        builder = BuilderPhase()
+        worktree = tmp_path / "issue-42"
+        worktree.mkdir()
+        mock_context.worktree_path = worktree
+        mock_context.config = ShepherdConfig(issue=42)
+
+        with (
+            patch.object(
+                builder, "_detect_test_command",
+                return_value=(["pnpm", "test"], "pnpm test"),
+            ),
+            patch(
+                "loom_tools.shepherd.phases.builder.subprocess.run"
+            ) as mock_run,
+        ):
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="all tests pass\n", stderr=""
+            )
+            passed, msg = builder._validate_build_before_pr(mock_context)
+
+        assert passed is True
+        assert "passed" in msg
+
+    def test_fails_when_tests_fail(
+        self, mock_context: MagicMock, tmp_path: Path
+    ) -> None:
+        """Should return (False, msg) when build/tests fail."""
+        builder = BuilderPhase()
+        worktree = tmp_path / "issue-42"
+        worktree.mkdir()
+        mock_context.worktree_path = worktree
+        mock_context.config = ShepherdConfig(issue=42)
+
+        with (
+            patch.object(
+                builder, "_detect_test_command",
+                return_value=(["pnpm", "test"], "pnpm test"),
+            ),
+            patch(
+                "loom_tools.shepherd.phases.builder.subprocess.run"
+            ) as mock_run,
+        ):
+            mock_run.return_value = MagicMock(
+                returncode=1, stdout="FAIL: test_foo\n", stderr=""
+            )
+            passed, msg = builder._validate_build_before_pr(mock_context)
+
+        assert passed is False
+        assert "pnpm test" in msg
+        assert "exit code 1" in msg
+
+    def test_passes_when_no_test_runner(
+        self, mock_context: MagicMock, tmp_path: Path
+    ) -> None:
+        """Should return (True, msg) when no test runner is detected."""
+        builder = BuilderPhase()
+        worktree = tmp_path / "issue-42"
+        worktree.mkdir()
+        mock_context.worktree_path = worktree
+        mock_context.config = ShepherdConfig(issue=42)
+
+        with patch.object(builder, "_detect_test_command", return_value=None):
+            passed, msg = builder._validate_build_before_pr(mock_context)
+
+        assert passed is True
+        assert "no test runner" in msg
+
+    def test_passes_when_no_worktree(self, mock_context: MagicMock) -> None:
+        """Should return (True, msg) when no worktree exists."""
+        builder = BuilderPhase()
+        mock_context.worktree_path = None
+        mock_context.config = ShepherdConfig(issue=42)
+
+        passed, msg = builder._validate_build_before_pr(mock_context)
+
+        assert passed is True
+        assert "no worktree" in msg
+
+    def test_passes_on_timeout(
+        self, mock_context: MagicMock, tmp_path: Path
+    ) -> None:
+        """Should return (True, msg) when validation times out."""
+        builder = BuilderPhase()
+        worktree = tmp_path / "issue-42"
+        worktree.mkdir()
+        mock_context.worktree_path = worktree
+        mock_context.config = ShepherdConfig(issue=42)
+
+        with (
+            patch.object(
+                builder, "_detect_test_command",
+                return_value=(["pnpm", "test"], "pnpm test"),
+            ),
+            patch(
+                "loom_tools.shepherd.phases.builder.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(cmd="pnpm test", timeout=300),
+            ),
+        ):
+            passed, msg = builder._validate_build_before_pr(mock_context)
+
+        assert passed is True
+        assert "timed out" in msg
+
+
+class TestBuilderDirectCompletionStaleBranch:
+    """Test _direct_completion rejects stale branches.  See #3106."""
+
+    def test_refuses_pr_when_closed_pr_exists(
+        self, mock_context: MagicMock
+    ) -> None:
+        """Should refuse to create PR when a closed PR exists for the branch."""
+        builder = BuilderPhase()
+        mock_context.repo_root = Path("/fake/repo")
+        mock_context.config = ShepherdConfig(issue=42)
+        diag = {
+            "has_uncommitted_changes": False,
+            "commits_ahead": 2,
+            "remote_branch_exists": True,
+            "pr_number": None,
+            "pr_has_review_label": False,
+            "branch": "feature/issue-42",
+        }
+
+        with (
+            patch.object(builder, "_has_closed_pr_for_branch", return_value=99),
+            patch(
+                "loom_tools.shepherd.phases.builder.subprocess.run"
+            ) as mock_run,
+        ):
+            # Open-PR checks return empty (no open PR)
+            empty = MagicMock(returncode=0, stdout="", stderr="")
+            mock_run.side_effect = [
+                empty,  # gh pr list --head (no existing open PR)
+                empty,  # gh pr list --search "Closes #42"
+                empty,  # gh pr list --search "Fixes #42"
+                empty,  # gh pr list --search "Resolves #42"
+            ]
+            result = builder._direct_completion(mock_context, diag)
+
+        assert result is False
+        # gh pr create must NOT have been called
+        for call in mock_run.call_args_list:
+            assert call[0][0][:3] != ["gh", "pr", "create"]
+
+    def test_refuses_pr_when_build_fails(
+        self, mock_context: MagicMock
+    ) -> None:
+        """Should refuse to create PR when pre-PR build validation fails."""
+        builder = BuilderPhase()
+        mock_context.repo_root = Path("/fake/repo")
+        mock_context.config = ShepherdConfig(issue=42)
+        diag = {
+            "has_uncommitted_changes": False,
+            "commits_ahead": 2,
+            "remote_branch_exists": True,
+            "pr_number": None,
+            "pr_has_review_label": False,
+            "branch": "feature/issue-42",
+        }
+
+        with (
+            patch.object(builder, "_has_closed_pr_for_branch", return_value=None),
+            patch.object(
+                builder, "_validate_build_before_pr",
+                return_value=(False, "pnpm test failed (exit code 1)"),
+            ),
+            patch(
+                "loom_tools.shepherd.phases.builder.subprocess.run"
+            ) as mock_run,
+        ):
+            # Open-PR checks return empty (no open PR)
+            empty = MagicMock(returncode=0, stdout="", stderr="")
+            mock_run.side_effect = [
+                empty,  # gh pr list --head (no existing open PR)
+                empty,  # gh pr list --search "Closes #42"
+                empty,  # gh pr list --search "Fixes #42"
+                empty,  # gh pr list --search "Resolves #42"
+            ]
+            result = builder._direct_completion(mock_context, diag)
+
+        assert result is False
+        # gh pr create must NOT have been called
+        for call in mock_run.call_args_list:
+            assert call[0][0][:3] != ["gh", "pr", "create"]
 
 
 class TestBuildDirectCompletionPrBody:


### PR DESCRIPTION
Closes #3106

## Summary

- Add stale branch detection: before creating a PR, check if a closed/merged PR already exists for the feature branch (indicating previously rejected work). If detected, refuse to resubmit and reset the worktree for a fresh build.
- Add pre-PR build validation gate: run the project's test command before creating a PR in `_direct_completion` to catch broken builds before they waste Judge review cycles.
- Add `closed_pr_for_branch` to diagnostics and surface stale branch warnings in the diagnostic summary.
- Update checkpoint resume path to detect and reset stale branches from rejected PRs instead of blindly resubmitting.

## Test plan

- [x] `TestBuilderHasClosedPrForBranch` - 4 tests for stale branch detection (returns PR number, returns None variants)
- [x] `TestBuilderValidateBuildBeforePr` - 5 tests for pre-PR validation (passes, fails, no test runner, no worktree, timeout)
- [x] `TestBuilderDirectCompletionStaleBranch` - 2 tests for integration (refuses on closed PR, refuses on build failure)
- [x] All 478 existing Builder tests pass (no regressions)
- [x] Updated 10 existing tests to account for new validation steps