### PR TITLE
Add 'Built with Loom' badge for downstream projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,16 @@ See [DEVELOPMENT.md](docs/guides/development.md) for complete guidelines.
 
 Creates a new GitHub repo with Loom pre-installed and initial roadmap.
 
+## Built with Loom
+
+If your project was built with Loom, you can add a badge to your README:
+
+[![Built with Loom](https://img.shields.io/badge/Built_with-Loom-blue?logo=github)](https://github.com/rjwalters/loom)
+
+```markdown
+[![Built with Loom](https://img.shields.io/badge/Built_with-Loom-blue?logo=github)](https://github.com/rjwalters/loom)
+```
+
 ## License
 
 MIT License © 2025 [Robb Walters](https://github.com/rjwalters)


### PR DESCRIPTION
## Summary

- Adds a "Built with Loom" section to README.md with a shields.io badge and copy-paste markdown snippet
- Uses a static shields.io badge (`Built_with-Loom-blue` with the GitHub logo) linking back to the Loom repository
- Enables downstream projects (like sokol-ts) to show Loom attribution in their READMEs

Closes #3137

## Test plan

- [ ] Verify the badge renders correctly on the README (shields.io URL)
- [ ] Verify the copy-paste markdown snippet produces the same badge when used in another repo
- [ ] Confirm the badge links to https://github.com/rjwalters/loom

🤖 Generated with [Claude Code](https://claude.com/claude-code)