### PR TITLE
fix: kill idle support role tmux sessions to prevent memory accumulation

### DIFF
--- a/loom-tools/src/loom_tools/daemon_v2/actions/support_roles.py
+++ b/loom-tools/src/loom_tools/daemon_v2/actions/support_roles.py
@@ -206,6 +206,11 @@ def reclaim_completed_support_roles(ctx: DaemonContext) -> list[CompletionEntry]
     In the second case the lingering tmux session is killed so it does not
     block future spawns.
 
+    After processing running roles, also cleans up any tmux sessions that
+    linger for roles already marked ``"idle"`` (belt-and-suspenders cleanup
+    in case a prior ``kill_stuck_session`` call failed silently).
+    See issue #3136.
+
     Returns a list of ``CompletionEntry`` objects for completed roles.
     """
     if ctx.state is None:
@@ -241,4 +246,69 @@ def reclaim_completed_support_roles(ctx: DaemonContext) -> list[CompletionEntry]
             )
         )
 
+    # Belt-and-suspenders: kill tmux sessions for roles already marked idle.
+    # This catches sessions that survived a prior kill attempt (e.g., if
+    # kill_stuck_session failed silently or the daemon crashed between
+    # detection and cleanup).  See issue #3136.
+    cleanup_idle_support_sessions(ctx)
+
     return completed
+
+
+def cleanup_idle_support_sessions(ctx: DaemonContext) -> int:
+    """Kill tmux sessions that linger for support roles marked ``"idle"``.
+
+    When a support role completes, the daemon marks it idle and attempts to
+    kill the tmux session.  If that kill fails (silently swallowed error,
+    daemon crash, etc.), the session persists indefinitely because
+    subsequent iterations skip non-``"running"`` roles.
+
+    This function acts as a safety net: it checks every idle (or absent)
+    support role for a lingering tmux session and kills it.  It is cheap
+    to call (just ``tmux has-session`` per role) and safe to run every
+    iteration.
+
+    Returns the number of sessions cleaned up.
+    """
+    if ctx.state is None:
+        return 0
+
+    cleaned = 0
+
+    for role_name in SUPPORT_ROLES:
+        entry = ctx.state.support_roles.get(role_name)
+        # Only clean up roles that are NOT running — running roles are
+        # handled by reclaim_completed_support_roles above.
+        if entry and entry.status == "running":
+            continue
+
+        if session_exists(role_name):
+            # Session exists for a role that is idle (or has no state entry).
+            # Check if Claude is actually running (defensive — shouldn't happen
+            # for an idle role, but avoid killing a legitimately active session
+            # whose state entry was lost).
+            if is_session_active(role_name):
+                log_warning(
+                    f"Support role {role_name} has active Claude process "
+                    f"but state is '{entry.status if entry else 'missing'}' "
+                    f"— skipping cleanup (state inconsistency)"
+                )
+                continue
+
+            log_info(
+                f"Cleaning up lingering tmux session for idle support role "
+                f"{role_name}"
+            )
+            kill_stuck_session(role_name)
+            cleaned += 1
+
+            # Also clear the tmux_session field in state if present
+            if entry and entry.tmux_session:
+                entry.tmux_session = None
+
+    if cleaned > 0:
+        log_success(
+            f"Cleaned up {cleaned} lingering idle support role session(s)"
+        )
+
+    return cleaned

--- a/loom-tools/src/loom_tools/daemon_v2/loop.py
+++ b/loom-tools/src/loom_tools/daemon_v2/loop.py
@@ -31,6 +31,7 @@ from loom_tools.daemon_v2.signals import (
 )
 from loom_tools.daemon_cleanup import handle_daemon_shutdown, handle_daemon_startup, load_config
 from loom_tools.daemon_v2.actions.shepherds import spawn_shepherds
+from loom_tools.daemon_v2.actions.support_roles import cleanup_idle_support_sessions
 
 
 def run(ctx: DaemonContext) -> int:
@@ -234,6 +235,7 @@ def _responsive_sleep(
     - Check for stop signal (exit early if found)
     - Poll CommandPoller for new signal commands
     - Run fast-path shepherd assignment when idle slots + cached ready issues exist
+    - Clean up lingering idle support role tmux sessions (see issue #3136)
     - Keep the daemon responsive without busy-waiting
     """
     elapsed = 0
@@ -267,6 +269,15 @@ def _responsive_sleep(
             # the next full iteration. This eliminates poll_interval latency when
             # a shepherd completes and ready issues are already queued.
             _fast_path_assign(ctx)
+
+            # Clean up lingering tmux sessions for idle support roles.
+            # This catches sessions that survived the kill attempt during
+            # reclaim_completed_support_roles (e.g., kill_stuck_session
+            # failed silently).  Running during sleep ticks ensures cleanup
+            # happens within seconds rather than waiting for the next full
+            # iteration.  See issue #3136.
+            if ctx.state is not None:
+                cleanup_idle_support_sessions(ctx)
         except (KeyboardInterrupt, SystemExit):
             raise
         except Exception as e:

--- a/loom-tools/tests/test_support_role_reclaim.py
+++ b/loom-tools/tests/test_support_role_reclaim.py
@@ -12,7 +12,10 @@ from unittest import mock
 import pytest
 
 from loom_tools.daemon_v2.actions.completions import CompletionEntry
-from loom_tools.daemon_v2.actions.support_roles import reclaim_completed_support_roles
+from loom_tools.daemon_v2.actions.support_roles import (
+    cleanup_idle_support_sessions,
+    reclaim_completed_support_roles,
+)
 from loom_tools.daemon_v2.config import DaemonConfig
 from loom_tools.daemon_v2.context import DaemonContext
 from loom_tools.daemon_v2.iteration import _reclaim_completed_support_roles
@@ -87,9 +90,18 @@ class TestReclaimCompletedSupportRoles:
             },
         )
 
-        with mock.patch(
-            "loom_tools.daemon_v2.actions.support_roles.is_session_active",
-            return_value=True,
+        with (
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.is_session_active",
+                return_value=True,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.session_exists",
+                return_value=False,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.kill_stuck_session",
+            ),
         ):
             completed = reclaim_completed_support_roles(ctx)
 
@@ -108,6 +120,10 @@ class TestReclaimCompletedSupportRoles:
             },
         )
 
+        def mock_exists(name: str) -> bool:
+            # Only the architect session lingers
+            return name == "architect"
+
         with (
             mock.patch(
                 "loom_tools.daemon_v2.actions.support_roles.is_session_active",
@@ -115,7 +131,7 @@ class TestReclaimCompletedSupportRoles:
             ),
             mock.patch(
                 "loom_tools.daemon_v2.actions.support_roles.session_exists",
-                return_value=True,  # But tmux session still exists
+                side_effect=mock_exists,
             ),
             mock.patch(
                 "loom_tools.daemon_v2.actions.support_roles.kill_stuck_session",
@@ -129,8 +145,8 @@ class TestReclaimCompletedSupportRoles:
         # Stale shell-only session should be killed
         mock_kill.assert_called_once_with("architect")
 
-    def test_idle_roles_skipped(self, tmp_path: pathlib.Path) -> None:
-        """Idle roles should not be checked or reclaimed."""
+    def test_idle_roles_not_reclaimed_as_completions(self, tmp_path: pathlib.Path) -> None:
+        """Idle roles should not produce CompletionEntry objects."""
         ctx = _make_ctx(
             tmp_path,
             support_roles={
@@ -141,13 +157,22 @@ class TestReclaimCompletedSupportRoles:
             },
         )
 
-        with mock.patch(
-            "loom_tools.daemon_v2.actions.support_roles.is_session_active",
-        ) as mock_active:
+        with (
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.is_session_active",
+                return_value=False,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.session_exists",
+                return_value=False,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.kill_stuck_session",
+            ),
+        ):
             completed = reclaim_completed_support_roles(ctx)
 
         assert len(completed) == 0
-        mock_active.assert_not_called()
 
     def test_multiple_roles_mixed_states(self, tmp_path: pathlib.Path) -> None:
         """Multiple roles: only running ones without active Claude are reclaimed."""
@@ -178,7 +203,8 @@ class TestReclaimCompletedSupportRoles:
             return name == "champion"
 
         def mock_exists(name: str) -> bool:
-            # judge session gone, doctor session still there (shell-only)
+            # judge session gone, doctor session still there (shell-only),
+            # all other roles have no lingering sessions
             return name == "doctor"
 
         with (
@@ -199,7 +225,8 @@ class TestReclaimCompletedSupportRoles:
         assert len(completed) == 2
         names = {c.name for c in completed}
         assert names == {"judge", "doctor"}
-        # Only doctor's stale session should be killed (judge was already gone)
+        # Only doctor's stale session should be killed (judge was already gone,
+        # no other roles have lingering sessions per mock_exists)
         mock_kill.assert_called_once_with("doctor")
 
     def test_no_state_returns_empty(self, tmp_path: pathlib.Path) -> None:
@@ -249,8 +276,8 @@ class TestHandleCompletionIntegration:
 class TestIterationWrapperFunction:
     """Tests for _reclaim_completed_support_roles in iteration.py."""
 
-    def test_no_running_roles_skips_check(self, tmp_path: pathlib.Path) -> None:
-        """When no roles are running, is_session_active is never called."""
+    def test_no_running_roles_skips_reclaim(self, tmp_path: pathlib.Path) -> None:
+        """When no roles are running, no CompletionEntry objects are produced."""
         ctx = _make_ctx(
             tmp_path,
             support_roles={
@@ -259,13 +286,22 @@ class TestIterationWrapperFunction:
             },
         )
 
-        with mock.patch(
-            "loom_tools.daemon_v2.actions.support_roles.is_session_active",
-        ) as mock_active:
+        with (
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.is_session_active",
+                return_value=False,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.session_exists",
+                return_value=False,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.kill_stuck_session",
+            ),
+        ):
             result = _reclaim_completed_support_roles(ctx)
 
         assert result == []
-        mock_active.assert_not_called()
 
     def test_running_role_triggers_check(self, tmp_path: pathlib.Path) -> None:
         """When a role is running, the check detects inactive Claude process."""
@@ -396,3 +432,180 @@ class TestRunIterationWithSupportRoleReclaim:
         assert state.support_roles["judge"].tmux_session is None
         # Completion should be counted
         assert result.completions_handled == 1
+
+
+class TestCleanupIdleSupportSessions:
+    """Tests for cleanup_idle_support_sessions (belt-and-suspenders cleanup).
+
+    This function catches tmux sessions that linger for roles already marked
+    idle — e.g., when kill_stuck_session failed silently on a prior iteration.
+    See issue #3136.
+    """
+
+    def test_idle_role_with_lingering_session_is_killed(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """An idle role whose tmux session still exists should have it killed."""
+        ctx = _make_ctx(
+            tmp_path,
+            support_roles={
+                "guide": SupportRoleEntry(
+                    status="idle",
+                    tmux_session="loom-guide",
+                    last_completed="2026-01-30T09:00:00Z",
+                ),
+            },
+        )
+
+        with (
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.session_exists",
+                return_value=True,  # Session still exists for idle role
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.is_session_active",
+                return_value=False,  # But Claude is not running
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.kill_stuck_session",
+            ) as mock_kill,
+        ):
+            cleaned = cleanup_idle_support_sessions(ctx)
+
+        assert cleaned >= 1
+        mock_kill.assert_any_call("guide")
+        # tmux_session field should be cleared
+        assert ctx.state.support_roles["guide"].tmux_session is None
+
+    def test_idle_role_without_session_is_noop(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """An idle role with no lingering tmux session needs no cleanup."""
+        ctx = _make_ctx(
+            tmp_path,
+            support_roles={
+                "guide": SupportRoleEntry(
+                    status="idle",
+                    last_completed="2026-01-30T09:00:00Z",
+                ),
+            },
+        )
+
+        with (
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.session_exists",
+                return_value=False,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.kill_stuck_session",
+            ) as mock_kill,
+        ):
+            cleaned = cleanup_idle_support_sessions(ctx)
+
+        assert cleaned == 0
+        mock_kill.assert_not_called()
+
+    def test_running_role_skipped(self, tmp_path: pathlib.Path) -> None:
+        """Running roles should NOT be cleaned up by this function."""
+        ctx = _make_ctx(
+            tmp_path,
+            support_roles={
+                "champion": SupportRoleEntry(
+                    status="running",
+                    tmux_session="loom-champion",
+                    started="2026-01-30T10:00:00Z",
+                ),
+            },
+        )
+
+        with (
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.session_exists",
+                return_value=False,  # No lingering sessions
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.kill_stuck_session",
+            ) as mock_kill,
+        ):
+            cleaned = cleanup_idle_support_sessions(ctx)
+
+        assert cleaned == 0
+        mock_kill.assert_not_called()
+
+    def test_active_claude_on_idle_role_not_killed(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """If an idle role somehow has an active Claude process, don't kill it.
+
+        This is a state inconsistency (idle status but Claude running), so
+        the function should log a warning and skip the kill.
+        """
+        ctx = _make_ctx(
+            tmp_path,
+            support_roles={
+                "judge": SupportRoleEntry(
+                    status="idle",
+                    tmux_session="loom-judge",
+                    last_completed="2026-01-30T09:00:00Z",
+                ),
+            },
+        )
+
+        def mock_exists(name: str) -> bool:
+            return name == "judge"
+
+        with (
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.session_exists",
+                side_effect=mock_exists,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.is_session_active",
+                return_value=True,  # Claude still running despite idle status
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.kill_stuck_session",
+            ) as mock_kill,
+        ):
+            cleaned = cleanup_idle_support_sessions(ctx)
+
+        assert cleaned == 0
+        mock_kill.assert_not_called()
+
+    def test_role_with_no_state_entry_cleaned(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """A role not in daemon state but with a lingering session gets cleaned."""
+        ctx = _make_ctx(
+            tmp_path,
+            support_roles={},  # No entries at all
+        )
+
+        def mock_exists(name: str) -> bool:
+            return name == "architect"
+
+        with (
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.session_exists",
+                side_effect=mock_exists,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.is_session_active",
+                return_value=False,
+            ),
+            mock.patch(
+                "loom_tools.daemon_v2.actions.support_roles.kill_stuck_session",
+            ) as mock_kill,
+        ):
+            cleaned = cleanup_idle_support_sessions(ctx)
+
+        assert cleaned == 1
+        mock_kill.assert_called_once_with("architect")
+
+    def test_none_state_returns_zero(self, tmp_path: pathlib.Path) -> None:
+        """When ctx.state is None, returns 0."""
+        ctx = _make_ctx(tmp_path)
+        ctx.state = None
+
+        cleaned = cleanup_idle_support_sessions(ctx)
+        assert cleaned == 0


### PR DESCRIPTION
## Summary

- Adds `cleanup_idle_support_sessions()` as a belt-and-suspenders safety net that kills tmux sessions lingering for support roles already marked idle
- Calls the cleanup both during `reclaim_completed_support_roles()` (each iteration) and during responsive sleep ticks (every 2s) so dead sessions are caught within seconds
- Handles edge cases: state inconsistency (idle status but Claude still running), roles with no state entry but lingering sessions, and clearing the `tmux_session` field in state

## Problem

When support roles finish their work, the daemon marks them idle but the tmux session may survive if `kill_stuck_session` fails silently or the daemon crashes between detection and cleanup. Subsequent iterations skip non-"running" roles in `reclaim_completed_support_roles`, so the session lingers indefinitely consuming memory. With 8 support roles, this means 8 idle processes worth of memory pressure.

## Test plan

- [x] All 18 tests in `test_support_role_reclaim.py` pass (6 new tests for `cleanup_idle_support_sessions`)
- [x] All 266 tests in `daemon_v2/` pass
- [x] All 82 tests in `test_agent_spawn.py` pass
- [ ] Verify in production that idle support role tmux sessions are cleaned up within seconds of Claude exiting

Closes #3136

🤖 Generated with [Claude Code](https://claude.com/claude-code)