### PR TITLE
feat: add forge detection and selection configuration

### DIFF
--- a/loom-tools/src/loom_tools/common/forge.py
+++ b/loom-tools/src/loom_tools/common/forge.py
@@ -1,20 +1,188 @@
-"""Forge-agnostic protocol for issue tracker and code forge operations.
+"""Forge-agnostic protocol and detection for issue tracker and code forge operations.
 
-Defines the ``ForgeClient`` protocol that abstracts all forge operations
-(issues, PRs, labels, CI, comments, etc.) behind a single interface.
-Both ``GitHubForge`` and ``GiteaForge`` will implement this protocol.
+This module provides:
 
-This module is the foundation of the forge-agnostic abstraction layer.
-It defines only the interface and data types -- no implementation.
+1. **ForgeClient protocol** -- abstracts all forge operations (issues, PRs, labels,
+   CI, comments, etc.) behind a single interface. Both ``GitHubForge`` and
+   ``GiteaForge`` will implement this protocol.
+
+2. **Forge detection** -- determines which forge backend to use via a 4-step
+   resolution order:
+   a. ``LOOM_FORGE_TYPE`` env var (``"github"`` | ``"gitea"``)
+   b. ``.loom/config.json`` ``forge.type`` field (if not ``"auto"``)
+   c. Auto-detect from git remote origin URL host
+   d. Default to ``ForgeType.GITHUB`` (backward compatible)
 """
 
 from __future__ import annotations
 
+import enum
+import logging
+import os
+import re
+import subprocess
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Literal, Protocol, Sequence, runtime_checkable
 
+from loom_tools.common.state import read_json_file
 
 EntityType = Literal["issue", "pr"]
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Forge type enum and detection
+# ---------------------------------------------------------------------------
+
+
+class ForgeType(enum.Enum):
+    """Supported forge backends."""
+
+    GITHUB = "github"
+    GITEA = "gitea"
+
+
+def _parse_host(url: str) -> str | None:
+    """Extract hostname from a git remote URL.
+
+    Supports both SSH and HTTPS formats:
+
+    - SSH: ``git@gitea.example.com:owner/repo.git`` -> ``gitea.example.com``
+    - HTTPS: ``https://gitea.example.com/owner/repo`` -> ``gitea.example.com``
+
+    Returns ``None`` if the URL cannot be parsed.
+    """
+    # SSH format: git@host:owner/repo.git
+    ssh_match = re.match(r"git@([^:]+):", url)
+    if ssh_match:
+        return ssh_match.group(1)
+
+    # HTTPS format: https://host/owner/repo.git
+    https_match = re.match(r"https?://([^/]+)/", url)
+    if https_match:
+        return https_match.group(1)
+
+    return None
+
+
+def _get_remote_url(cwd: Path | None = None) -> str | None:
+    """Get the git remote origin URL.
+
+    Returns ``None`` if the URL cannot be determined.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            cwd=cwd,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            return None
+        return result.stdout.strip()
+    except OSError:
+        return None
+
+
+def _detect_from_host(host: str, forge_config: dict[str, Any] | None = None) -> ForgeType:
+    """Determine forge type from a hostname.
+
+    Rules:
+    - ``github.com`` -> :attr:`ForgeType.GITHUB`
+    - Host matches configured Gitea URL -> :attr:`ForgeType.GITEA`
+    - Everything else -> :attr:`ForgeType.GITHUB` (safe default)
+    """
+    if host == "github.com":
+        return ForgeType.GITHUB
+
+    # Check if host matches the configured Gitea URL
+    if forge_config:
+        gitea_config = forge_config.get("gitea", {})
+        if isinstance(gitea_config, dict):
+            gitea_url = gitea_config.get("url", "")
+            if gitea_url:
+                # Extract host from the configured Gitea URL
+                gitea_url_match = re.match(r"https?://([^/]+)", gitea_url)
+                if gitea_url_match and gitea_url_match.group(1) == host:
+                    return ForgeType.GITEA
+
+    # Default to GitHub for unknown hosts (backward compatible)
+    return ForgeType.GITHUB
+
+
+def get_forge_config(cwd: Path | None = None) -> dict[str, Any]:
+    """Read the ``forge`` section from ``.loom/config.json``.
+
+    Returns an empty dict if the config file is missing or has no
+    ``forge`` key.
+
+    Args:
+        cwd: Working directory to find ``.loom/config.json``. Defaults
+            to the current directory.
+    """
+    config_dir = (cwd or Path.cwd()) / ".loom"
+    config_file = config_dir / "config.json"
+
+    data = read_json_file(config_file)
+    if not isinstance(data, dict):
+        return {}
+
+    forge = data.get("forge", {})
+    return forge if isinstance(forge, dict) else {}
+
+
+def detect_forge(cwd: Path | None = None) -> ForgeType:
+    """Detect the forge type for the current repository.
+
+    Resolution order:
+
+    1. ``LOOM_FORGE_TYPE`` env var (``"github"`` | ``"gitea"``)
+    2. ``.loom/config.json`` ``forge.type`` field (if not ``"auto"``)
+    3. Auto-detect from git remote origin URL host
+    4. Default to :attr:`ForgeType.GITHUB` (backward compatible)
+
+    Args:
+        cwd: Working directory for git operations and config lookup.
+            Defaults to the current directory.
+
+    Returns:
+        The detected :class:`ForgeType`.
+    """
+    # 1. Environment variable override (highest priority)
+    env_val = os.environ.get("LOOM_FORGE_TYPE", "").lower().strip()
+    if env_val:
+        try:
+            return ForgeType(env_val)
+        except ValueError:
+            logger.warning(
+                "Invalid LOOM_FORGE_TYPE=%r, continuing with other detection methods",
+                env_val,
+            )
+
+    # 2. Config file override
+    forge_config = get_forge_config(cwd)
+    config_type = forge_config.get("type", "auto")
+    if isinstance(config_type, str) and config_type.lower() not in ("auto", ""):
+        try:
+            return ForgeType(config_type.lower())
+        except ValueError:
+            logger.warning(
+                "Invalid forge.type=%r in config, continuing with auto-detection",
+                config_type,
+            )
+
+    # 3. Auto-detect from git remote URL
+    remote_url = _get_remote_url(cwd)
+    if remote_url:
+        host = _parse_host(remote_url)
+        if host:
+            return _detect_from_host(host, forge_config)
+
+    # 4. Default to GitHub (backward compatible)
+    return ForgeType.GITHUB
 
 
 # ---------------------------------------------------------------------------

--- a/loom-tools/tests/test_forge.py
+++ b/loom-tools/tests/test_forge.py
@@ -1,8 +1,19 @@
-"""Tests for the ForgeClient protocol and forge-neutral data types."""
+"""Tests for loom_tools.common.forge module.
+
+Tests cover both the ForgeClient protocol / data types and the forge
+detection / configuration logic.
+"""
 
 from __future__ import annotations
 
+import json
+import os
+import subprocess
+from pathlib import Path
 from typing import Any, Sequence
+from unittest import mock
+
+import pytest
 
 from loom_tools.common.forge import (
     EntityType,
@@ -11,12 +22,18 @@ from loom_tools.common.forge import (
     ForgeIssue,
     ForgeLabel,
     ForgePullRequest,
+    ForgeType,
+    _detect_from_host,
+    _get_remote_url,
+    _parse_host,
+    detect_forge,
+    get_forge_config,
 )
 
 
-# ---------------------------------------------------------------------------
+# ===========================================================================
 # Dataclass construction tests
-# ---------------------------------------------------------------------------
+# ===========================================================================
 
 
 class TestForgeIssue:
@@ -128,9 +145,9 @@ class TestForgeCIStatus:
         assert b.failed_runs == []
 
 
-# ---------------------------------------------------------------------------
+# ===========================================================================
 # Protocol compliance tests
-# ---------------------------------------------------------------------------
+# ===========================================================================
 
 
 class MockForgeClient:
@@ -416,9 +433,9 @@ class TestProtocolNonCompliance:
         assert not isinstance(Partial(), ForgeClient)
 
 
-# ---------------------------------------------------------------------------
+# ===========================================================================
 # Edge case tests
-# ---------------------------------------------------------------------------
+# ===========================================================================
 
 
 class TestEdgeCases:
@@ -446,3 +463,365 @@ class TestEdgeCases:
         assert val == "issue"
         val = "pr"
         assert val == "pr"
+
+
+# ===========================================================================
+# Forge detection tests
+# ===========================================================================
+
+
+# ---------------------------------------------------------------------------
+# _parse_host
+# ---------------------------------------------------------------------------
+
+
+class TestParseHost:
+    """Tests for _parse_host URL parsing."""
+
+    def test_ssh_github(self) -> None:
+        assert _parse_host("git@github.com:owner/repo.git") == "github.com"
+
+    def test_ssh_gitea(self) -> None:
+        assert _parse_host("git@gitea.example.com:owner/repo.git") == "gitea.example.com"
+
+    def test_ssh_without_git_suffix(self) -> None:
+        assert _parse_host("git@github.com:owner/repo") == "github.com"
+
+    def test_https_github(self) -> None:
+        assert _parse_host("https://github.com/owner/repo.git") == "github.com"
+
+    def test_https_gitea(self) -> None:
+        assert _parse_host("https://gitea.example.com/owner/repo.git") == "gitea.example.com"
+
+    def test_https_without_git_suffix(self) -> None:
+        assert _parse_host("https://github.com/owner/repo") == "github.com"
+
+    def test_http_url(self) -> None:
+        assert _parse_host("http://github.com/owner/repo.git") == "github.com"
+
+    def test_custom_ssh_host(self) -> None:
+        assert _parse_host("git@git.mycompany.com:org/project.git") == "git.mycompany.com"
+
+    def test_invalid_url(self) -> None:
+        assert _parse_host("not-a-url") is None
+
+    def test_empty_string(self) -> None:
+        assert _parse_host("") is None
+
+    def test_ssh_with_port_style(self) -> None:
+        # Some SSH configs use host:path format
+        assert _parse_host("git@gitea.local:owner/repo.git") == "gitea.local"
+
+
+# ---------------------------------------------------------------------------
+# _detect_from_host
+# ---------------------------------------------------------------------------
+
+
+class TestDetectFromHost:
+    """Tests for _detect_from_host hostname matching."""
+
+    def test_github_com(self) -> None:
+        assert _detect_from_host("github.com") == ForgeType.GITHUB
+
+    def test_unknown_host_defaults_github(self) -> None:
+        assert _detect_from_host("unknown.example.com") == ForgeType.GITHUB
+
+    def test_gitea_via_config_url(self) -> None:
+        config = {"gitea": {"url": "https://gitea.example.com"}}
+        assert _detect_from_host("gitea.example.com", config) == ForgeType.GITEA
+
+    def test_gitea_config_url_mismatch(self) -> None:
+        config = {"gitea": {"url": "https://gitea.example.com"}}
+        assert _detect_from_host("other.example.com", config) == ForgeType.GITHUB
+
+    def test_no_forge_config(self) -> None:
+        assert _detect_from_host("gitea.example.com", None) == ForgeType.GITHUB
+
+    def test_empty_forge_config(self) -> None:
+        assert _detect_from_host("gitea.example.com", {}) == ForgeType.GITHUB
+
+    def test_gitea_config_without_url(self) -> None:
+        config = {"gitea": {}}
+        assert _detect_from_host("gitea.example.com", config) == ForgeType.GITHUB
+
+    def test_gitea_config_url_with_path(self) -> None:
+        config = {"gitea": {"url": "https://gitea.example.com/prefix"}}
+        assert _detect_from_host("gitea.example.com", config) == ForgeType.GITEA
+
+
+# ---------------------------------------------------------------------------
+# get_forge_config
+# ---------------------------------------------------------------------------
+
+
+class TestGetForgeConfig:
+    """Tests for get_forge_config config loading."""
+
+    def test_config_with_forge_section(self, tmp_path: Path) -> None:
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir()
+        config = {
+            "version": "2",
+            "forge": {
+                "type": "gitea",
+                "gitea": {"url": "https://gitea.example.com"},
+            },
+            "terminals": [],
+        }
+        (loom_dir / "config.json").write_text(json.dumps(config))
+        result = get_forge_config(tmp_path)
+        assert result == {"type": "gitea", "gitea": {"url": "https://gitea.example.com"}}
+
+    def test_config_without_forge_section(self, tmp_path: Path) -> None:
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir()
+        config = {"version": "2", "terminals": []}
+        (loom_dir / "config.json").write_text(json.dumps(config))
+        result = get_forge_config(tmp_path)
+        assert result == {}
+
+    def test_missing_config_file(self, tmp_path: Path) -> None:
+        result = get_forge_config(tmp_path)
+        assert result == {}
+
+    def test_invalid_json(self, tmp_path: Path) -> None:
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir()
+        (loom_dir / "config.json").write_text("not json")
+        result = get_forge_config(tmp_path)
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# detect_forge
+# ---------------------------------------------------------------------------
+
+
+class TestDetectForge:
+    """Tests for detect_forge end-to-end detection."""
+
+    def test_env_var_github(self) -> None:
+        with mock.patch.dict(os.environ, {"LOOM_FORGE_TYPE": "github"}):
+            assert detect_forge() == ForgeType.GITHUB
+
+    def test_env_var_gitea(self) -> None:
+        with mock.patch.dict(os.environ, {"LOOM_FORGE_TYPE": "gitea"}):
+            assert detect_forge() == ForgeType.GITEA
+
+    def test_env_var_case_insensitive(self) -> None:
+        with mock.patch.dict(os.environ, {"LOOM_FORGE_TYPE": "GITHUB"}):
+            assert detect_forge() == ForgeType.GITHUB
+
+    def test_env_var_with_whitespace(self) -> None:
+        with mock.patch.dict(os.environ, {"LOOM_FORGE_TYPE": " gitea "}):
+            assert detect_forge() == ForgeType.GITEA
+
+    def test_env_var_invalid_falls_through(self, tmp_path: Path) -> None:
+        """Invalid env var falls through to next detection method."""
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir()
+        config = {"version": "2", "forge": {"type": "gitea"}, "terminals": []}
+        (loom_dir / "config.json").write_text(json.dumps(config))
+        with mock.patch.dict(os.environ, {"LOOM_FORGE_TYPE": "invalid"}):
+            assert detect_forge(tmp_path) == ForgeType.GITEA
+
+    def test_config_override_gitea(self, tmp_path: Path) -> None:
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir()
+        config = {"version": "2", "forge": {"type": "gitea"}, "terminals": []}
+        (loom_dir / "config.json").write_text(json.dumps(config))
+        with mock.patch.dict(os.environ, {}, clear=True):
+            # Ensure no env var set
+            os.environ.pop("LOOM_FORGE_TYPE", None)
+            assert detect_forge(tmp_path) == ForgeType.GITEA
+
+    def test_config_auto_falls_through(self, tmp_path: Path) -> None:
+        """Config type 'auto' falls through to URL detection."""
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir()
+        config = {"version": "2", "forge": {"type": "auto"}, "terminals": []}
+        (loom_dir / "config.json").write_text(json.dumps(config))
+
+        mock_result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="https://github.com/owner/repo.git\n"
+        )
+        with (
+            mock.patch.dict(os.environ, {}, clear=True),
+            mock.patch("loom_tools.common.forge.subprocess.run", return_value=mock_result),
+        ):
+            os.environ.pop("LOOM_FORGE_TYPE", None)
+            assert detect_forge(tmp_path) == ForgeType.GITHUB
+
+    def test_auto_detect_github_ssh(self) -> None:
+        mock_result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="git@github.com:owner/repo.git\n"
+        )
+        with (
+            mock.patch.dict(os.environ, {}, clear=True),
+            mock.patch("loom_tools.common.forge.subprocess.run", return_value=mock_result),
+        ):
+            os.environ.pop("LOOM_FORGE_TYPE", None)
+            assert detect_forge() == ForgeType.GITHUB
+
+    def test_auto_detect_github_https(self) -> None:
+        mock_result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="https://github.com/owner/repo.git\n"
+        )
+        with (
+            mock.patch.dict(os.environ, {}, clear=True),
+            mock.patch("loom_tools.common.forge.subprocess.run", return_value=mock_result),
+        ):
+            os.environ.pop("LOOM_FORGE_TYPE", None)
+            assert detect_forge() == ForgeType.GITHUB
+
+    def test_auto_detect_gitea_via_config_url(self, tmp_path: Path) -> None:
+        """Gitea detected via matching config URL."""
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir()
+        config = {
+            "version": "2",
+            "forge": {
+                "type": "auto",
+                "gitea": {"url": "https://gitea.mycompany.com"},
+            },
+            "terminals": [],
+        }
+        (loom_dir / "config.json").write_text(json.dumps(config))
+
+        mock_result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="git@gitea.mycompany.com:team/project.git\n"
+        )
+        with (
+            mock.patch.dict(os.environ, {}, clear=True),
+            mock.patch("loom_tools.common.forge.subprocess.run", return_value=mock_result),
+        ):
+            os.environ.pop("LOOM_FORGE_TYPE", None)
+            assert detect_forge(tmp_path) == ForgeType.GITEA
+
+    def test_default_github_no_remote(self) -> None:
+        """Default to GitHub when no remote URL is available."""
+        mock_result = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="fatal: not a git repository"
+        )
+        with (
+            mock.patch.dict(os.environ, {}, clear=True),
+            mock.patch("loom_tools.common.forge.subprocess.run", return_value=mock_result),
+        ):
+            os.environ.pop("LOOM_FORGE_TYPE", None)
+            assert detect_forge() == ForgeType.GITHUB
+
+    def test_default_github_no_config_no_env(self) -> None:
+        """Default to GitHub when nothing is configured."""
+        mock_result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="https://github.com/owner/repo.git\n"
+        )
+        with (
+            mock.patch.dict(os.environ, {}, clear=True),
+            mock.patch("loom_tools.common.forge.subprocess.run", return_value=mock_result),
+        ):
+            os.environ.pop("LOOM_FORGE_TYPE", None)
+            assert detect_forge() == ForgeType.GITHUB
+
+    def test_env_var_takes_priority_over_config(self, tmp_path: Path) -> None:
+        """Env var overrides config file."""
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir()
+        config = {"version": "2", "forge": {"type": "gitea"}, "terminals": []}
+        (loom_dir / "config.json").write_text(json.dumps(config))
+        with mock.patch.dict(os.environ, {"LOOM_FORGE_TYPE": "github"}):
+            assert detect_forge(tmp_path) == ForgeType.GITHUB
+
+    def test_config_takes_priority_over_url(self, tmp_path: Path) -> None:
+        """Config type overrides URL detection."""
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir()
+        config = {"version": "2", "forge": {"type": "gitea"}, "terminals": []}
+        (loom_dir / "config.json").write_text(json.dumps(config))
+
+        # Even though URL points to github.com, config says gitea
+        mock_result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="https://github.com/owner/repo.git\n"
+        )
+        with (
+            mock.patch.dict(os.environ, {}, clear=True),
+            mock.patch("loom_tools.common.forge.subprocess.run", return_value=mock_result),
+        ):
+            os.environ.pop("LOOM_FORGE_TYPE", None)
+            assert detect_forge(tmp_path) == ForgeType.GITEA
+
+    def test_backward_compatible_no_forge_config(self, tmp_path: Path) -> None:
+        """Existing repos without forge config default to GitHub."""
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir()
+        config = {"version": "2", "terminals": []}
+        (loom_dir / "config.json").write_text(json.dumps(config))
+
+        mock_result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="https://github.com/owner/repo.git\n"
+        )
+        with (
+            mock.patch.dict(os.environ, {}, clear=True),
+            mock.patch("loom_tools.common.forge.subprocess.run", return_value=mock_result),
+        ):
+            os.environ.pop("LOOM_FORGE_TYPE", None)
+            assert detect_forge(tmp_path) == ForgeType.GITHUB
+
+
+# ---------------------------------------------------------------------------
+# _get_remote_url
+# ---------------------------------------------------------------------------
+
+
+class TestGetRemoteUrl:
+    """Tests for _get_remote_url subprocess handling."""
+
+    def test_success(self) -> None:
+        mock_result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="https://github.com/owner/repo.git\n"
+        )
+        with mock.patch("loom_tools.common.forge.subprocess.run", return_value=mock_result):
+            assert _get_remote_url() == "https://github.com/owner/repo.git"
+
+    def test_failure(self) -> None:
+        mock_result = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="fatal: not a git repository"
+        )
+        with mock.patch("loom_tools.common.forge.subprocess.run", return_value=mock_result):
+            assert _get_remote_url() is None
+
+    def test_empty_stdout(self) -> None:
+        mock_result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="\n"
+        )
+        with mock.patch("loom_tools.common.forge.subprocess.run", return_value=mock_result):
+            assert _get_remote_url() is None
+
+    def test_os_error(self) -> None:
+        with mock.patch(
+            "loom_tools.common.forge.subprocess.run", side_effect=OSError("not found")
+        ):
+            assert _get_remote_url() is None
+
+
+# ---------------------------------------------------------------------------
+# ForgeType enum
+# ---------------------------------------------------------------------------
+
+
+class TestForgeType:
+    """Tests for ForgeType enum values."""
+
+    def test_github_value(self) -> None:
+        assert ForgeType.GITHUB.value == "github"
+
+    def test_gitea_value(self) -> None:
+        assert ForgeType.GITEA.value == "gitea"
+
+    def test_from_string(self) -> None:
+        assert ForgeType("github") == ForgeType.GITHUB
+        assert ForgeType("gitea") == ForgeType.GITEA
+
+    def test_invalid_value(self) -> None:
+        with pytest.raises(ValueError):
+            ForgeType("gitlab")

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -41,6 +41,21 @@ export interface TerminalConfig {
 }
 
 /**
+ * Forge configuration for selecting the git hosting backend.
+ */
+export interface ForgeConfig {
+  /** Forge type: "auto" (detect from remote URL), "github", or "gitea" */
+  type?: "auto" | "github" | "gitea";
+  /** Gitea-specific settings */
+  gitea?: {
+    /** Base URL of the Gitea instance */
+    url: string;
+    /** Name of env var holding the Gitea API token (default: "GITEA_TOKEN") */
+    api_token_env?: string;
+  };
+}
+
+/**
  * Root configuration structure for Loom workspace.
  * Stored in .loom/config.json and committed to version control.
  */
@@ -51,6 +66,8 @@ export interface LoomConfig {
   terminals: TerminalConfig[];
   /** Offline mode flag - when true, skips Claude Code agent launch and uses simple status echoes */
   offlineMode?: boolean;
+  /** Forge backend configuration (defaults to GitHub when absent) */
+  forge?: ForgeConfig;
 }
 
 /**

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -61,6 +61,31 @@ export type InputRequestFromSchema = z.infer<typeof InputRequestSchema>;
 // ============================================================================
 
 /**
+ * Gitea-specific forge configuration
+ */
+export const GiteaConfigSchema = z.object({
+  /** Base URL of the Gitea instance */
+  url: z.string().url(),
+  /** Name of env var holding the Gitea API token (default: "GITEA_TOKEN") */
+  api_token_env: z.string().default("GITEA_TOKEN"),
+});
+
+export type GiteaConfigFromSchema = z.infer<typeof GiteaConfigSchema>;
+
+/**
+ * Forge configuration for selecting the git hosting backend.
+ * Optional field in LoomConfig — repos without it default to GitHub.
+ */
+export const ForgeConfigSchema = z.object({
+  /** Forge type: "auto" (detect from remote URL), "github", or "gitea" */
+  type: z.enum(["auto", "github", "gitea"]).default("auto"),
+  /** Gitea-specific settings (required when type is "gitea" or auto-detecting a Gitea host) */
+  gitea: GiteaConfigSchema.optional(),
+});
+
+export type ForgeConfigFromSchema = z.infer<typeof ForgeConfigSchema>;
+
+/**
  * Role configuration schema for agent settings
  */
 export const RoleConfigSchema = z.record(z.string(), z.unknown());
@@ -95,6 +120,8 @@ export const LoomConfigSchema = z.object({
   terminals: z.array(TerminalConfigSchema),
   /** Offline mode flag */
   offlineMode: z.boolean().optional(),
+  /** Forge backend configuration (defaults to GitHub when absent) */
+  forge: ForgeConfigSchema.optional(),
 });
 
 export type LoomConfigFromSchema = z.infer<typeof LoomConfigSchema>;
@@ -107,6 +134,7 @@ export const RawLoomConfigSchema = z.object({
   terminals: z.array(z.record(z.string(), z.unknown())).optional(),
   agents: z.array(z.record(z.string(), z.unknown())).optional(),
   offlineMode: z.boolean().optional(),
+  forge: z.record(z.string(), z.unknown()).optional(),
 });
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Adds forge detection and selection configuration so Loom can determine which forge backend (GitHub or Gitea) to use for a repository.

- **New file**: `loom-tools/src/loom_tools/common/forge.py` — `ForgeType` enum, `detect_forge()` with 4-step resolution order (env var `LOOM_FORGE_TYPE` -> config `forge.type` -> git remote URL host -> default GitHub), `_parse_host()` for extracting hostnames from SSH/HTTPS remote URLs, `get_forge_config()` for reading the forge section from `.loom/config.json`
- **New file**: `loom-tools/tests/test_forge.py` — 46 tests covering all detection paths (GitHub SSH/HTTPS, Gitea via config URL, config override, env var override, default fallback, invalid inputs, priority ordering)
- **Modified**: `src/lib/schemas.ts` — Added `ForgeConfigSchema`, `GiteaConfigSchema` Zod schemas; added optional `forge` field to `LoomConfigSchema` and `RawLoomConfigSchema`
- **Modified**: `src/lib/config.ts` — Added `ForgeConfig` interface; added optional `forge` field to `LoomConfig` interface

Backward compatible: repos with no `forge` config default to GitHub. No version bump needed since the field is optional.

Closes #3135

## Test plan

- [x] All 46 new forge tests pass
- [x] All 75 existing github.py tests pass (no regressions)
- [x] All 111 config/paths/state tests pass
- [x] TypeScript compiles (only pre-existing CSS import warnings remain)