### PR TITLE
feat: implement GiteaForge class with ForgeClient protocol

### DIFF
--- a/loom-tools/pyproject.toml
+++ b/loom-tools/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
     "rich>=13.0",
+    "requests>=2.28",
 ]
 
 [project.scripts]

--- a/loom-tools/src/loom_tools/common/forge.py
+++ b/loom-tools/src/loom_tools/common/forge.py
@@ -491,3 +491,26 @@ class ForgeClient(Protocol):
         Returns the PR number, or ``None`` if no matching PR is found.
         """
         ...
+
+
+# ---------------------------------------------------------------------------
+# Factory function
+# ---------------------------------------------------------------------------
+
+
+def get_forge(cwd: Path | None = None) -> ForgeClient:
+    """Return a ``ForgeClient`` for the detected forge type.
+
+    Uses :func:`detect_forge` to determine which backend to instantiate.
+    Imports are lazy to avoid circular dependencies and so that
+    ``requests`` is only loaded when Gitea is actually used.
+    """
+    forge_type = detect_forge(cwd)
+    if forge_type == ForgeType.GITEA:
+        from loom_tools.common.gitea import GiteaForge
+
+        return GiteaForge(cwd=cwd)
+    # Default: GitHub
+    from loom_tools.common.github import GitHubForge
+
+    return GitHubForge(cwd=cwd)

--- a/loom-tools/src/loom_tools/common/gitea.py
+++ b/loom-tools/src/loom_tools/common/gitea.py
@@ -1,0 +1,765 @@
+"""Gitea implementation of the ``ForgeClient`` protocol.
+
+Uses Gitea's REST API v1 via ``requests.Session`` with token authentication.
+
+Authentication:
+- ``GITEA_TOKEN`` env var (primary)
+- ``.loom/config.json`` ``forge.gitea.token`` (fallback)
+
+Base URL is required and comes from ``.loom/config.json`` ``forge.gitea.url``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import subprocess
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any, Sequence
+
+import requests
+
+from loom_tools.common.forge import (
+    EntityType,
+    ForgeCIStatus,
+    ForgeIssue,
+    ForgePullRequest,
+    get_forge_config,
+)
+
+logger = logging.getLogger(__name__)
+
+# Default request timeout in seconds
+_DEFAULT_TIMEOUT = 30
+
+
+class GiteaForge:
+    """Gitea implementation of the ``ForgeClient`` protocol.
+
+    Wraps Gitea's REST API v1 behind the forge-agnostic interface.
+    Uses ``requests.Session`` with ``Authorization: token {value}`` headers.
+
+    Label operations require integer IDs. A lazy name-to-ID cache is
+    maintained and auto-populated on the first label operation.
+    """
+
+    def __init__(self, cwd: Path | None = None) -> None:
+        self._cwd = cwd
+        self._nwo_cache: str | None = None
+        self._label_cache: dict[str, int] | None = None
+        self._default_branch_cache: str | None = None
+
+        # Load config
+        forge_config = get_forge_config(cwd)
+        gitea_config = forge_config.get("gitea", {})
+        if not isinstance(gitea_config, dict):
+            gitea_config = {}
+
+        # Base URL (required)
+        self._base_url = gitea_config.get("url", "").rstrip("/")
+        if not self._base_url:
+            raise ValueError(
+                "Gitea base URL is required. Set forge.gitea.url in "
+                ".loom/config.json (e.g. \"https://gitea.example.com\")"
+            )
+
+        # API token: env var takes priority
+        token = os.environ.get("GITEA_TOKEN", "") or gitea_config.get("token", "")
+        if not token:
+            raise ValueError(
+                "Gitea API token is required. Set GITEA_TOKEN env var or "
+                "forge.gitea.token in .loom/config.json"
+            )
+
+        # Build session
+        self._session = requests.Session()
+        self._session.headers.update({
+            "Authorization": f"token {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        })
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _api_url(self, path: str) -> str:
+        """Build a full API URL from a relative path."""
+        return f"{self._base_url}/api/v1/{path.lstrip('/')}"
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: Any = None,
+        params: dict[str, Any] | None = None,
+    ) -> requests.Response | None:
+        """Make an API request, handling errors uniformly.
+
+        Returns the ``Response`` on success (2xx), or ``None`` on failure.
+        Logs appropriate messages for auth failures, network errors, etc.
+        """
+        url = self._api_url(path)
+        try:
+            resp = self._session.request(
+                method, url, json=json, params=params,
+                timeout=_DEFAULT_TIMEOUT,
+            )
+        except requests.ConnectionError:
+            logger.error("Connection error reaching Gitea at %s", url)
+            return None
+        except requests.Timeout:
+            logger.error("Request timed out: %s %s", method, url)
+            return None
+
+        if resp.status_code in (401, 403):
+            logger.error(
+                "Gitea auth failed (%d) for %s %s. "
+                "Check GITEA_TOKEN env var or forge.gitea.token config.",
+                resp.status_code, method, url,
+            )
+            return None
+
+        if resp.status_code >= 500:
+            logger.error(
+                "Gitea server error (%d) for %s %s", resp.status_code, method, url,
+            )
+            return None
+
+        if resp.status_code >= 400:
+            # 4xx (not auth) — return None silently (404 = not found, etc.)
+            logger.debug(
+                "Gitea %d for %s %s: %s",
+                resp.status_code, method, url, resp.text[:200],
+            )
+            return None
+
+        return resp
+
+    def _repo_path(self) -> str | None:
+        """Return ``repos/{owner}/{repo}`` prefix, or None."""
+        nwo = self.get_repo_nwo()
+        if not nwo:
+            return None
+        return f"repos/{nwo}"
+
+    # ------------------------------------------------------------------
+    # Label name → ID resolution
+    # ------------------------------------------------------------------
+
+    def _populate_label_cache(self) -> None:
+        """Fetch all repository labels and populate the name→ID cache."""
+        rp = self._repo_path()
+        if not rp:
+            self._label_cache = {}
+            return
+
+        resp = self._request("GET", f"{rp}/labels", params={"limit": 50})
+        if resp is None:
+            self._label_cache = {}
+            return
+
+        try:
+            labels = resp.json()
+        except ValueError:
+            self._label_cache = {}
+            return
+
+        if not isinstance(labels, list):
+            self._label_cache = {}
+            return
+
+        self._label_cache = {
+            label["name"]: label["id"]
+            for label in labels
+            if isinstance(label, dict) and "name" in label and "id" in label
+        }
+
+    def _resolve_label_ids(self, names: Sequence[str]) -> list[int]:
+        """Resolve label names to Gitea integer IDs, using cache.
+
+        Missing labels are silently skipped. If a label is not found,
+        the cache is invalidated once to allow for newly created labels.
+        """
+        if self._label_cache is None:
+            self._populate_label_cache()
+        assert self._label_cache is not None  # noqa: S101
+
+        ids: list[int] = []
+        missing: list[str] = []
+        for name in names:
+            lid = self._label_cache.get(name)
+            if lid is not None:
+                ids.append(lid)
+            else:
+                missing.append(name)
+
+        # Retry once if any labels were missing (cache may be stale)
+        if missing:
+            self._label_cache = None
+            self._populate_label_cache()
+            assert self._label_cache is not None  # noqa: S101
+            for name in missing:
+                lid = self._label_cache.get(name)
+                if lid is not None:
+                    ids.append(lid)
+                else:
+                    logger.warning("Gitea label %r not found in repository", name)
+
+        return ids
+
+    def _resolve_label_id(self, name: str) -> int | None:
+        """Resolve a single label name to its ID."""
+        ids = self._resolve_label_ids([name])
+        return ids[0] if ids else None
+
+    # ------------------------------------------------------------------
+    # State normalization
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _normalize_state(state: str, merged: bool = False) -> str:
+        """Normalize Gitea's lowercase states to uppercase.
+
+        Gitea returns ``"open"`` / ``"closed"``. For PRs with
+        ``merged=true``, we return ``"MERGED"``.
+        """
+        if merged:
+            return "MERGED"
+        return state.upper()
+
+    # ------------------------------------------------------------------
+    # Conversion helpers
+    # ------------------------------------------------------------------
+
+    def _to_forge_issue(self, data: dict[str, Any]) -> ForgeIssue:
+        """Convert a Gitea issue JSON object to ``ForgeIssue``."""
+        labels_data = data.get("labels", [])
+        label_names = [
+            lbl["name"] for lbl in labels_data
+            if isinstance(lbl, dict) and "name" in lbl
+        ]
+        return ForgeIssue(
+            number=data.get("number", 0),
+            state=self._normalize_state(data.get("state", "open")),
+            title=data.get("title", ""),
+            url=data.get("html_url", ""),
+            labels=label_names,
+            body=data.get("body"),
+        )
+
+    def _to_forge_pr(self, data: dict[str, Any]) -> ForgePullRequest:
+        """Convert a Gitea PR JSON object to ``ForgePullRequest``."""
+        labels_data = data.get("labels", [])
+        label_names = [
+            lbl["name"] for lbl in labels_data
+            if isinstance(lbl, dict) and "name" in lbl
+        ]
+        merged = data.get("merged", False) is True
+        head_info = data.get("head", {})
+        head_branch = (
+            head_info.get("ref") or head_info.get("label")
+            if isinstance(head_info, dict) else None
+        )
+        return ForgePullRequest(
+            number=data.get("number", 0),
+            state=self._normalize_state(data.get("state", "open"), merged=merged),
+            title=data.get("title", ""),
+            url=data.get("html_url", ""),
+            labels=label_names,
+            head_branch=head_branch,
+            body=data.get("body"),
+        )
+
+    # ------------------------------------------------------------------
+    # ForgeClient.forge_type
+    # ------------------------------------------------------------------
+
+    @property
+    def forge_type(self) -> str:
+        """Identifier for the forge backend."""
+        return "gitea"
+
+    # ------------------------------------------------------------------
+    # Issue operations
+    # ------------------------------------------------------------------
+
+    def get_issue(self, number: int) -> ForgeIssue | None:
+        """Fetch a single issue by number."""
+        rp = self._repo_path()
+        if not rp:
+            return None
+        resp = self._request("GET", f"{rp}/issues/{number}")
+        if resp is None:
+            return None
+        try:
+            data = resp.json()
+        except ValueError:
+            return None
+        if not isinstance(data, dict):
+            return None
+        # Gitea issues endpoint may include PRs — filter them out
+        if data.get("pull_request") is not None:
+            return None
+        return self._to_forge_issue(data)
+
+    def list_issues(
+        self,
+        *,
+        labels: Sequence[str] | None = None,
+        state: str = "open",
+        limit: int | None = None,
+    ) -> list[ForgeIssue]:
+        """List issues matching the given filters."""
+        rp = self._repo_path()
+        if not rp:
+            return []
+        params: dict[str, Any] = {
+            "type": "issues",  # exclude PRs
+            "state": state,
+        }
+        if labels:
+            params["labels"] = ",".join(labels)
+        if limit is not None:
+            params["limit"] = limit
+        resp = self._request("GET", f"{rp}/issues", params=params)
+        if resp is None:
+            return []
+        try:
+            items = resp.json()
+        except ValueError:
+            return []
+        if not isinstance(items, list):
+            return []
+        return [self._to_forge_issue(d) for d in items if isinstance(d, dict)]
+
+    def create_issue(
+        self,
+        title: str,
+        body: str,
+        labels: Sequence[str] | None = None,
+    ) -> ForgeIssue | None:
+        """Create a new issue."""
+        rp = self._repo_path()
+        if not rp:
+            return None
+        payload: dict[str, Any] = {"title": title, "body": body}
+        if labels:
+            label_ids = self._resolve_label_ids(labels)
+            if label_ids:
+                payload["labels"] = label_ids
+        resp = self._request("POST", f"{rp}/issues", json=payload)
+        if resp is None:
+            return None
+        try:
+            data = resp.json()
+        except ValueError:
+            return None
+        if not isinstance(data, dict):
+            return None
+        return self._to_forge_issue(data)
+
+    def close_issue(self, number: int) -> bool:
+        """Close an issue."""
+        rp = self._repo_path()
+        if not rp:
+            return False
+        resp = self._request("PATCH", f"{rp}/issues/{number}", json={"state": "closed"})
+        return resp is not None
+
+    def comment_on_issue(self, number: int, body: str) -> bool:
+        """Add a comment to an issue."""
+        rp = self._repo_path()
+        if not rp:
+            return False
+        resp = self._request(
+            "POST", f"{rp}/issues/{number}/comments", json={"body": body},
+        )
+        return resp is not None
+
+    # ------------------------------------------------------------------
+    # Pull request operations
+    # ------------------------------------------------------------------
+
+    def get_pull_request(self, number: int) -> ForgePullRequest | None:
+        """Fetch a single pull request by number."""
+        rp = self._repo_path()
+        if not rp:
+            return None
+        resp = self._request("GET", f"{rp}/pulls/{number}")
+        if resp is None:
+            return None
+        try:
+            data = resp.json()
+        except ValueError:
+            return None
+        if not isinstance(data, dict):
+            return None
+        return self._to_forge_pr(data)
+
+    def list_pull_requests(
+        self,
+        *,
+        labels: Sequence[str] | None = None,
+        state: str = "open",
+        head: str | None = None,
+        search: str | None = None,
+        limit: int | None = None,
+    ) -> list[ForgePullRequest]:
+        """List pull requests matching the given filters."""
+        if search:
+            logger.warning(
+                "Gitea does not support 'search' parameter for pull request listing; "
+                "ignoring search=%r", search,
+            )
+
+        rp = self._repo_path()
+        if not rp:
+            return []
+        params: dict[str, Any] = {"state": state}
+        if labels:
+            params["labels"] = ",".join(labels)
+        if limit is not None:
+            params["limit"] = limit
+        resp = self._request("GET", f"{rp}/pulls", params=params)
+        if resp is None:
+            return []
+        try:
+            items = resp.json()
+        except ValueError:
+            return []
+        if not isinstance(items, list):
+            return []
+
+        prs = [self._to_forge_pr(d) for d in items if isinstance(d, dict)]
+
+        # Client-side head branch filtering (Gitea API doesn't support it natively)
+        if head:
+            prs = [pr for pr in prs if pr.head_branch == head]
+
+        return prs
+
+    def create_pull_request(
+        self,
+        title: str,
+        body: str,
+        head: str,
+        base: str | None = None,
+        labels: Sequence[str] | None = None,
+    ) -> ForgePullRequest | None:
+        """Create a new pull request."""
+        rp = self._repo_path()
+        if not rp:
+            return None
+
+        if base is None:
+            base = self.get_repo_default_branch() or "main"
+
+        payload: dict[str, Any] = {
+            "title": title,
+            "body": body,
+            "head": head,
+            "base": base,
+        }
+        if labels:
+            label_ids = self._resolve_label_ids(labels)
+            if label_ids:
+                payload["labels"] = label_ids
+
+        resp = self._request("POST", f"{rp}/pulls", json=payload)
+        if resp is None:
+            return None
+        try:
+            data = resp.json()
+        except ValueError:
+            return None
+        if not isinstance(data, dict):
+            return None
+        return self._to_forge_pr(data)
+
+    def close_pull_request(
+        self, number: int, comment: str | None = None,
+    ) -> bool:
+        """Close a pull request, optionally leaving a comment."""
+        rp = self._repo_path()
+        if not rp:
+            return False
+        # Comment first (PRs share the issue comment API in Gitea)
+        if comment:
+            self._request(
+                "POST", f"{rp}/issues/{number}/comments", json={"body": comment},
+            )
+        resp = self._request(
+            "PATCH", f"{rp}/pulls/{number}", json={"state": "closed"},
+        )
+        return resp is not None
+
+    def merge_pull_request(
+        self, number: int, method: str = "squash",
+    ) -> bool:
+        """Merge a pull request."""
+        rp = self._repo_path()
+        if not rp:
+            return False
+        payload = {
+            "Do": method,
+            "delete_branch_after_merge": True,
+        }
+        resp = self._request("POST", f"{rp}/pulls/{number}/merge", json=payload)
+        return resp is not None
+
+    def comment_on_pull_request(self, number: int, body: str) -> bool:
+        """Add a comment to a pull request (shares issue comment API)."""
+        rp = self._repo_path()
+        if not rp:
+            return False
+        resp = self._request(
+            "POST", f"{rp}/issues/{number}/comments", json={"body": body},
+        )
+        return resp is not None
+
+    def get_pull_request_reviews(
+        self, number: int,
+    ) -> list[dict[str, Any]]:
+        """Fetch reviews for a pull request."""
+        rp = self._repo_path()
+        if not rp:
+            return []
+        resp = self._request("GET", f"{rp}/pulls/{number}/reviews")
+        if resp is None:
+            return []
+        try:
+            reviews = resp.json()
+        except ValueError:
+            return []
+        if not isinstance(reviews, list):
+            return []
+        # Normalize review state to uppercase
+        for review in reviews:
+            if isinstance(review, dict) and "state" in review:
+                review["state"] = review["state"].upper()
+        return reviews
+
+    # ------------------------------------------------------------------
+    # Label operations
+    # ------------------------------------------------------------------
+
+    def add_labels(
+        self, entity_type: EntityType, number: int, labels: Sequence[str],
+    ) -> bool:
+        """Add labels to an issue or PR (same endpoint in Gitea)."""
+        rp = self._repo_path()
+        if not rp:
+            return False
+        label_ids = self._resolve_label_ids(labels)
+        if not label_ids:
+            return False
+        resp = self._request(
+            "POST", f"{rp}/issues/{number}/labels", json={"labels": label_ids},
+        )
+        return resp is not None
+
+    def remove_labels(
+        self, entity_type: EntityType, number: int, labels: Sequence[str],
+    ) -> bool:
+        """Remove labels from an issue or PR (one call per label)."""
+        rp = self._repo_path()
+        if not rp:
+            return False
+        success = True
+        for name in labels:
+            lid = self._resolve_label_id(name)
+            if lid is None:
+                continue
+            resp = self._request("DELETE", f"{rp}/issues/{number}/labels/{lid}")
+            if resp is None:
+                success = False
+        return success
+
+    def transition_labels(
+        self,
+        entity_type: EntityType,
+        number: int,
+        add: Sequence[str] | None = None,
+        remove: Sequence[str] | None = None,
+    ) -> bool:
+        """Add and remove labels in sequence (no atomic API in Gitea)."""
+        success = True
+        if remove:
+            if not self.remove_labels(entity_type, number, remove):
+                success = False
+        if add:
+            if not self.add_labels(entity_type, number, add):
+                success = False
+        return success
+
+    # ------------------------------------------------------------------
+    # CI status
+    # ------------------------------------------------------------------
+
+    def get_default_branch_ci_status(self) -> ForgeCIStatus:
+        """Get CI status for the latest commit on the default branch."""
+        rp = self._repo_path()
+        default_branch = self.get_repo_default_branch()
+        if not rp or not default_branch:
+            return ForgeCIStatus(
+                status="unknown", message="Cannot determine repo or default branch",
+            )
+
+        resp = self._request(
+            "GET", f"{rp}/commits/{default_branch}/statuses",
+        )
+        if resp is None:
+            return ForgeCIStatus(
+                status="unknown", message="Failed to fetch CI statuses",
+            )
+
+        try:
+            statuses = resp.json()
+        except ValueError:
+            return ForgeCIStatus(
+                status="unknown", message="Invalid CI status response",
+            )
+
+        if not isinstance(statuses, list) or not statuses:
+            return ForgeCIStatus(
+                status="unknown", message="No CI statuses found",
+            )
+
+        # Aggregate: group by context (workflow name), take latest
+        latest_by_context: dict[str, dict[str, Any]] = {}
+        for s in statuses:
+            if not isinstance(s, dict):
+                continue
+            ctx = s.get("context", "unknown")
+            if ctx not in latest_by_context:
+                latest_by_context[ctx] = s
+
+        failed_runs: list[str] = []
+        for ctx, s in latest_by_context.items():
+            state = s.get("status", "").lower()
+            if state in ("failure", "error"):
+                failed_runs.append(ctx)
+
+        total = len(latest_by_context)
+        if failed_runs:
+            return ForgeCIStatus(
+                status="failing",
+                failed_runs=failed_runs,
+                total_runs=total,
+                message=f"CI failing: {len(failed_runs)} check(s) failed",
+            )
+
+        return ForgeCIStatus(
+            status="passing",
+            total_runs=total,
+            message="CI passing",
+        )
+
+    # ------------------------------------------------------------------
+    # Repository metadata
+    # ------------------------------------------------------------------
+
+    def get_repo_nwo(self) -> str | None:
+        """Return the ``owner/repo`` identifier, parsed from git remote."""
+        if self._nwo_cache is not None:
+            return self._nwo_cache
+
+        try:
+            result = subprocess.run(
+                ["git", "remote", "get-url", "origin"],
+                cwd=self._cwd,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            if result.returncode != 0 or not result.stdout.strip():
+                return None
+            nwo = self._parse_nwo(result.stdout.strip())
+            if nwo:
+                self._nwo_cache = nwo
+            return nwo
+        except OSError:
+            return None
+
+    @staticmethod
+    def _parse_nwo(url: str) -> str | None:
+        """Extract ``owner/repo`` from a git remote URL."""
+        # SSH: git@host:owner/repo.git
+        ssh_match = re.match(r"git@[^:]+:(.+?)(?:\.git)?$", url)
+        if ssh_match:
+            return ssh_match.group(1)
+        # HTTPS: https://host/owner/repo.git
+        https_match = re.match(r"https?://[^/]+/(.+?)(?:\.git)?$", url)
+        if https_match:
+            return https_match.group(1)
+        return None
+
+    def get_repo_default_branch(self) -> str | None:
+        """Return the default branch name from Gitea's repo API."""
+        if self._default_branch_cache is not None:
+            return self._default_branch_cache
+
+        rp = self._repo_path()
+        if not rp:
+            return None
+        resp = self._request("GET", rp)
+        if resp is None:
+            return None
+        try:
+            data = resp.json()
+        except ValueError:
+            return None
+        if isinstance(data, dict):
+            branch = data.get("default_branch")
+            if isinstance(branch, str):
+                self._default_branch_cache = branch
+                return branch
+        return None
+
+    # ------------------------------------------------------------------
+    # Batch operations
+    # ------------------------------------------------------------------
+
+    def get_issues_batch(
+        self, numbers: Sequence[int],
+    ) -> dict[int, ForgeIssue | None]:
+        """Fetch multiple issues concurrently."""
+        results: dict[int, ForgeIssue | None] = {}
+
+        def _fetch(num: int) -> tuple[int, ForgeIssue | None]:
+            return (num, self.get_issue(num))
+
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            futures = [pool.submit(_fetch, n) for n in numbers]
+            for f in futures:
+                num, issue = f.result()
+                results[num] = issue
+
+        return results
+
+    def find_pull_request_for_issue(
+        self, issue: int, state: str = "open",
+    ) -> int | None:
+        """Find a PR associated with a given issue.
+
+        Searches by branch naming convention first, then falls back to
+        body content matching.
+        """
+        # Try branch naming convention
+        prs = self.list_pull_requests(
+            head=f"feature/issue-{issue}", state=state,
+        )
+        if prs:
+            return prs[0].number
+
+        # Fall back: list PRs and search body for closing reference
+        all_prs = self.list_pull_requests(state=state, limit=50)
+        for pr in all_prs:
+            if pr.body and f"Closes #{issue}" in pr.body:
+                return pr.number
+
+        return None

--- a/loom-tools/tests/test_gitea.py
+++ b/loom-tools/tests/test_gitea.py
@@ -1,0 +1,739 @@
+"""Tests for loom_tools.common.gitea — GiteaForge implementation.
+
+All HTTP calls are mocked via ``requests.Session``. No real network
+requests are made.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+import pytest
+import requests
+
+from loom_tools.common.forge import (
+    ForgeCIStatus,
+    ForgeClient,
+    ForgeIssue,
+    ForgePullRequest,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_BASE_URL = "https://gitea.example.com"
+_TOKEN = "test-token-12345"
+
+# Minimal Gitea config
+_GITEA_CONFIG = {
+    "gitea": {
+        "url": _BASE_URL,
+        "token": _TOKEN,
+    },
+}
+
+
+def _mock_response(
+    status_code: int = 200,
+    json_data: Any = None,
+    text: str = "",
+) -> mock.MagicMock:
+    """Create a mock requests.Response."""
+    resp = mock.MagicMock(spec=requests.Response)
+    resp.status_code = status_code
+    resp.text = text or json.dumps(json_data) if json_data is not None else ""
+    if json_data is not None:
+        resp.json.return_value = json_data
+    else:
+        resp.json.side_effect = ValueError("No JSON")
+    return resp
+
+
+def _make_forge(
+    nwo: str = "owner/repo",
+    config: dict[str, Any] | None = None,
+    token_env: str | None = None,
+) -> Any:
+    """Create a GiteaForge with mocked config and git remote.
+
+    Pre-populates the NWO cache so tests don't need to mock subprocess.
+    """
+    from loom_tools.common.gitea import GiteaForge
+
+    env_patch = {}
+    if token_env is not None:
+        env_patch["GITEA_TOKEN"] = token_env
+
+    with (
+        mock.patch("loom_tools.common.gitea.get_forge_config", return_value=config or _GITEA_CONFIG),
+        mock.patch.dict(os.environ, env_patch, clear=False),
+    ):
+        forge = GiteaForge(cwd=Path("/tmp/test"))
+
+    # Pre-populate NWO cache to avoid subprocess calls in tests
+    forge._nwo_cache = nwo
+    return forge
+
+
+# ===========================================================================
+# Protocol compliance
+# ===========================================================================
+
+
+class TestProtocolCompliance:
+    """Verify GiteaForge satisfies the ForgeClient protocol."""
+
+    def test_isinstance_check(self) -> None:
+        forge = _make_forge()
+        assert isinstance(forge, ForgeClient)
+
+    def test_forge_type(self) -> None:
+        forge = _make_forge()
+        assert forge.forge_type == "gitea"
+
+
+# ===========================================================================
+# Constructor
+# ===========================================================================
+
+
+class TestConstructor:
+    """Constructor validation tests."""
+
+    def test_raises_without_base_url(self) -> None:
+        with (
+            mock.patch(
+                "loom_tools.common.gitea.get_forge_config",
+                return_value={"gitea": {"token": "tok"}},
+            ),
+            mock.patch.dict(os.environ, {}, clear=False),
+            pytest.raises(ValueError, match="base URL is required"),
+        ):
+            from loom_tools.common.gitea import GiteaForge
+            GiteaForge()
+
+    def test_raises_without_token(self) -> None:
+        with (
+            mock.patch(
+                "loom_tools.common.gitea.get_forge_config",
+                return_value={"gitea": {"url": _BASE_URL}},
+            ),
+            mock.patch.dict(os.environ, {"GITEA_TOKEN": ""}, clear=False),
+            pytest.raises(ValueError, match="API token is required"),
+        ):
+            from loom_tools.common.gitea import GiteaForge
+            GiteaForge()
+
+    def test_env_token_takes_priority(self) -> None:
+        forge = _make_forge(token_env="env-token")
+        assert forge._session.headers["Authorization"] == "token env-token"
+
+    def test_config_token_fallback(self) -> None:
+        forge = _make_forge()
+        assert forge._session.headers["Authorization"] == f"token {_TOKEN}"
+
+    def test_auth_header_format(self) -> None:
+        forge = _make_forge()
+        # Must be "token xxx", NOT "Bearer xxx"
+        auth = forge._session.headers["Authorization"]
+        assert auth.startswith("token ")
+        assert not auth.startswith("Bearer ")
+
+
+# ===========================================================================
+# Issue operations
+# ===========================================================================
+
+
+class TestGetIssue:
+    """Tests for get_issue()."""
+
+    def test_returns_forge_issue(self) -> None:
+        forge = _make_forge()
+        issue_data = {
+            "number": 42,
+            "state": "open",
+            "title": "Test issue",
+            "html_url": "https://gitea.example.com/owner/repo/issues/42",
+            "labels": [{"name": "bug", "id": 1}],
+            "body": "Some body",
+        }
+        with mock.patch.object(forge._session, "request", return_value=_mock_response(json_data=issue_data)):
+            result = forge.get_issue(42)
+
+        assert result is not None
+        assert isinstance(result, ForgeIssue)
+        assert result.number == 42
+        assert result.state == "OPEN"  # normalized to uppercase
+        assert result.title == "Test issue"
+        assert result.labels == ["bug"]
+
+    def test_returns_none_for_404(self) -> None:
+        forge = _make_forge()
+        with mock.patch.object(forge._session, "request", return_value=_mock_response(404)):
+            result = forge.get_issue(999)
+        assert result is None
+
+    def test_filters_out_pull_requests(self) -> None:
+        forge = _make_forge()
+        pr_as_issue = {
+            "number": 10,
+            "state": "open",
+            "title": "A PR",
+            "html_url": "https://gitea.example.com/owner/repo/issues/10",
+            "labels": [],
+            "pull_request": {"merged": False},
+        }
+        with mock.patch.object(forge._session, "request", return_value=_mock_response(json_data=pr_as_issue)):
+            result = forge.get_issue(10)
+        assert result is None
+
+
+class TestListIssues:
+    """Tests for list_issues()."""
+
+    def test_returns_list(self) -> None:
+        forge = _make_forge()
+        issues = [
+            {"number": 1, "state": "open", "title": "A", "html_url": "u1", "labels": []},
+            {"number": 2, "state": "closed", "title": "B", "html_url": "u2", "labels": []},
+        ]
+        with mock.patch.object(forge._session, "request", return_value=_mock_response(json_data=issues)):
+            result = forge.list_issues()
+        assert len(result) == 2
+        assert result[0].number == 1
+        assert result[1].state == "CLOSED"
+
+    def test_empty_on_error(self) -> None:
+        forge = _make_forge()
+        with mock.patch.object(forge._session, "request", return_value=_mock_response(500)):
+            result = forge.list_issues()
+        assert result == []
+
+    def test_passes_label_and_state_params(self) -> None:
+        forge = _make_forge()
+        with mock.patch.object(forge._session, "request", return_value=_mock_response(json_data=[])) as mock_req:
+            forge.list_issues(labels=["bug", "urgent"], state="closed", limit=10)
+
+        _, kwargs = mock_req.call_args
+        params = kwargs["params"]
+        assert params["labels"] == "bug,urgent"
+        assert params["state"] == "closed"
+        assert params["limit"] == 10
+        assert params["type"] == "issues"
+
+
+class TestCreateIssue:
+    """Tests for create_issue()."""
+
+    def test_creates_issue(self) -> None:
+        forge = _make_forge()
+        created = {
+            "number": 99,
+            "state": "open",
+            "title": "New",
+            "html_url": "u99",
+            "labels": [],
+        }
+        # Mock label cache population + create
+        responses = [
+            _mock_response(json_data=[{"name": "bug", "id": 5}]),  # label cache
+            _mock_response(json_data=created),  # create
+        ]
+        with mock.patch.object(forge._session, "request", side_effect=responses):
+            result = forge.create_issue("New", "body", labels=["bug"])
+        assert result is not None
+        assert result.number == 99
+
+    def test_returns_none_on_failure(self) -> None:
+        forge = _make_forge()
+        with mock.patch.object(forge._session, "request", return_value=_mock_response(500)):
+            result = forge.create_issue("Fail", "body")
+        assert result is None
+
+
+class TestCloseIssue:
+    """Tests for close_issue()."""
+
+    def test_success(self) -> None:
+        forge = _make_forge()
+        with mock.patch.object(forge._session, "request", return_value=_mock_response(json_data={"state": "closed"})):
+            assert forge.close_issue(42) is True
+
+    def test_failure(self) -> None:
+        forge = _make_forge()
+        with mock.patch.object(forge._session, "request", return_value=_mock_response(500)):
+            assert forge.close_issue(42) is False
+
+
+class TestCommentOnIssue:
+    """Tests for comment_on_issue()."""
+
+    def test_success(self) -> None:
+        forge = _make_forge()
+        with mock.patch.object(forge._session, "request", return_value=_mock_response(json_data={"id": 1})):
+            assert forge.comment_on_issue(42, "Hello") is True
+
+
+# ===========================================================================
+# Pull request operations
+# ===========================================================================
+
+
+class TestGetPullRequest:
+    """Tests for get_pull_request()."""
+
+    def test_returns_forge_pr(self) -> None:
+        forge = _make_forge()
+        pr_data = {
+            "number": 10,
+            "state": "open",
+            "title": "Fix bug",
+            "html_url": "https://gitea.example.com/owner/repo/pulls/10",
+            "labels": [{"name": "enhancement", "id": 2}],
+            "head": {"ref": "feature/fix", "label": "feature/fix"},
+            "body": "Closes #42",
+            "merged": False,
+        }
+        with mock.patch.object(forge._session, "request", return_value=_mock_response(json_data=pr_data)):
+            result = forge.get_pull_request(10)
+
+        assert result is not None
+        assert isinstance(result, ForgePullRequest)
+        assert result.number == 10
+        assert result.state == "OPEN"
+        assert result.head_branch == "feature/fix"
+        assert result.labels == ["enhancement"]
+
+    def test_merged_state(self) -> None:
+        forge = _make_forge()
+        pr_data = {
+            "number": 11,
+            "state": "closed",
+            "title": "Done",
+            "html_url": "u",
+            "labels": [],
+            "head": {"ref": "main"},
+            "merged": True,
+        }
+        with mock.patch.object(forge._session, "request", return_value=_mock_response(json_data=pr_data)):
+            result = forge.get_pull_request(11)
+        assert result is not None
+        assert result.state == "MERGED"
+
+    def test_returns_none_for_404(self) -> None:
+        forge = _make_forge()
+        with mock.patch.object(forge._session, "request", return_value=_mock_response(404)):
+            assert forge.get_pull_request(999) is None
+
+
+class TestListPullRequests:
+    """Tests for list_pull_requests()."""
+
+    def test_returns_list(self) -> None:
+        forge = _make_forge()
+        prs = [
+            {"number": 1, "state": "open", "title": "PR1", "html_url": "u", "labels": [],
+             "head": {"ref": "branch-1"}, "merged": False},
+        ]
+        with mock.patch.object(forge._session, "request", return_value=_mock_response(json_data=prs)):
+            result = forge.list_pull_requests()
+        assert len(result) == 1
+
+    def test_head_filter(self) -> None:
+        forge = _make_forge()
+        prs = [
+            {"number": 1, "state": "open", "title": "PR1", "html_url": "u", "labels": [],
+             "head": {"ref": "branch-a"}, "merged": False},
+            {"number": 2, "state": "open", "title": "PR2", "html_url": "u", "labels": [],
+             "head": {"ref": "branch-b"}, "merged": False},
+        ]
+        with mock.patch.object(forge._session, "request", return_value=_mock_response(json_data=prs)):
+            result = forge.list_pull_requests(head="branch-b")
+        assert len(result) == 1
+        assert result[0].number == 2
+
+    def test_search_param_warns(self) -> None:
+        forge = _make_forge()
+        with (
+            mock.patch.object(forge._session, "request", return_value=_mock_response(json_data=[])),
+            mock.patch("loom_tools.common.gitea.logger") as mock_logger,
+        ):
+            forge.list_pull_requests(search="some query")
+        mock_logger.warning.assert_called_once()
+        assert "search" in mock_logger.warning.call_args[0][0].lower()
+
+
+class TestMergePullRequest:
+    """Tests for merge_pull_request()."""
+
+    def test_squash_merge(self) -> None:
+        forge = _make_forge()
+        with mock.patch.object(forge._session, "request", return_value=_mock_response(json_data={})) as mock_req:
+            assert forge.merge_pull_request(10, "squash") is True
+
+        call_args = mock_req.call_args
+        assert call_args[1]["json"]["Do"] == "squash"
+        assert call_args[1]["json"]["delete_branch_after_merge"] is True
+
+    def test_failure(self) -> None:
+        forge = _make_forge()
+        with mock.patch.object(forge._session, "request", return_value=_mock_response(409)):
+            assert forge.merge_pull_request(10) is False
+
+
+class TestClosePullRequest:
+    """Tests for close_pull_request()."""
+
+    def test_close_with_comment(self) -> None:
+        forge = _make_forge()
+        with mock.patch.object(forge._session, "request", return_value=_mock_response(json_data={})) as mock_req:
+            assert forge.close_pull_request(10, comment="Closing") is True
+        # Should have made 2 calls: comment + close
+        assert mock_req.call_count == 2
+
+    def test_close_without_comment(self) -> None:
+        forge = _make_forge()
+        with mock.patch.object(forge._session, "request", return_value=_mock_response(json_data={})) as mock_req:
+            assert forge.close_pull_request(10) is True
+        assert mock_req.call_count == 1
+
+
+class TestGetPullRequestReviews:
+    """Tests for get_pull_request_reviews()."""
+
+    def test_returns_reviews_with_normalized_state(self) -> None:
+        forge = _make_forge()
+        reviews = [
+            {"state": "approved", "user": {"login": "reviewer"}},
+            {"state": "request_changes", "user": {"login": "other"}},
+        ]
+        with mock.patch.object(forge._session, "request", return_value=_mock_response(json_data=reviews)):
+            result = forge.get_pull_request_reviews(10)
+        assert len(result) == 2
+        assert result[0]["state"] == "APPROVED"
+        assert result[1]["state"] == "REQUEST_CHANGES"
+
+    def test_empty_on_error(self) -> None:
+        forge = _make_forge()
+        with mock.patch.object(forge._session, "request", return_value=_mock_response(500)):
+            assert forge.get_pull_request_reviews(10) == []
+
+
+# ===========================================================================
+# Label operations
+# ===========================================================================
+
+
+class TestLabelOperations:
+    """Tests for add_labels, remove_labels, transition_labels."""
+
+    def test_add_labels(self) -> None:
+        forge = _make_forge()
+        responses = [
+            _mock_response(json_data=[{"name": "bug", "id": 1}, {"name": "fix", "id": 2}]),  # cache
+            _mock_response(json_data=[{"name": "bug", "id": 1}]),  # add
+        ]
+        with mock.patch.object(forge._session, "request", side_effect=responses):
+            assert forge.add_labels("issue", 42, ["bug"]) is True
+
+    def test_remove_labels(self) -> None:
+        forge = _make_forge()
+        responses = [
+            _mock_response(json_data=[{"name": "bug", "id": 1}]),  # cache
+            _mock_response(json_data={}),  # remove
+        ]
+        with mock.patch.object(forge._session, "request", side_effect=responses):
+            assert forge.remove_labels("issue", 42, ["bug"]) is True
+
+    def test_transition_labels(self) -> None:
+        forge = _make_forge()
+        responses = [
+            _mock_response(json_data=[{"name": "old", "id": 1}, {"name": "new", "id": 2}]),  # cache for remove
+            _mock_response(json_data={}),  # remove "old"
+            _mock_response(json_data=[{"name": "old", "id": 1}, {"name": "new", "id": 2}]),  # cache for add (already populated but re-resolved)
+            _mock_response(json_data=[{"name": "new", "id": 2}]),  # add "new"
+        ]
+        # Pre-populate label cache to avoid extra requests
+        forge._label_cache = {"old": 1, "new": 2}
+        responses_simple = [
+            _mock_response(json_data={}),  # remove "old"
+            _mock_response(json_data=[{"name": "new", "id": 2}]),  # add "new"
+        ]
+        with mock.patch.object(forge._session, "request", side_effect=responses_simple):
+            assert forge.transition_labels("pr", 10, add=["new"], remove=["old"]) is True
+
+
+class TestLabelCache:
+    """Tests for label name→ID resolution cache."""
+
+    def test_lazy_population(self) -> None:
+        forge = _make_forge()
+        assert forge._label_cache is None
+
+        labels = [{"name": "bug", "id": 1}, {"name": "feat", "id": 2}]
+        with mock.patch.object(forge._session, "request", return_value=_mock_response(json_data=labels)):
+            ids = forge._resolve_label_ids(["bug", "feat"])
+
+        assert forge._label_cache is not None
+        assert ids == [1, 2]
+
+    def test_cache_invalidation_on_missing(self) -> None:
+        forge = _make_forge()
+        forge._label_cache = {"bug": 1}
+
+        # "new-label" not in cache -> triggers re-fetch
+        updated_labels = [{"name": "bug", "id": 1}, {"name": "new-label", "id": 3}]
+        with mock.patch.object(forge._session, "request", return_value=_mock_response(json_data=updated_labels)):
+            ids = forge._resolve_label_ids(["bug", "new-label"])
+
+        assert set(ids) == {1, 3}
+
+    def test_unknown_label_warns(self) -> None:
+        forge = _make_forge()
+        with (
+            mock.patch.object(forge._session, "request", return_value=_mock_response(json_data=[])),
+            mock.patch("loom_tools.common.gitea.logger") as mock_logger,
+        ):
+            ids = forge._resolve_label_ids(["nonexistent"])
+        assert ids == []
+        mock_logger.warning.assert_called()
+
+
+# ===========================================================================
+# State normalization
+# ===========================================================================
+
+
+class TestStateNormalization:
+    """Tests for state normalization (lowercase -> uppercase)."""
+
+    def test_open(self) -> None:
+        from loom_tools.common.gitea import GiteaForge
+        assert GiteaForge._normalize_state("open") == "OPEN"
+
+    def test_closed(self) -> None:
+        from loom_tools.common.gitea import GiteaForge
+        assert GiteaForge._normalize_state("closed") == "CLOSED"
+
+    def test_merged(self) -> None:
+        from loom_tools.common.gitea import GiteaForge
+        assert GiteaForge._normalize_state("closed", merged=True) == "MERGED"
+
+
+# ===========================================================================
+# CI status
+# ===========================================================================
+
+
+class TestCIStatus:
+    """Tests for get_default_branch_ci_status()."""
+
+    def test_passing(self) -> None:
+        forge = _make_forge()
+        # First call: get repo info (default branch), second: statuses
+        repo_resp = _mock_response(json_data={"default_branch": "main"})
+        statuses_resp = _mock_response(json_data=[
+            {"context": "ci/test", "status": "success"},
+            {"context": "ci/lint", "status": "success"},
+        ])
+        with mock.patch.object(forge._session, "request", side_effect=[repo_resp, statuses_resp]):
+            result = forge.get_default_branch_ci_status()
+
+        assert isinstance(result, ForgeCIStatus)
+        assert result.status == "passing"
+        assert result.failed_runs == []
+
+    def test_failing(self) -> None:
+        forge = _make_forge()
+        forge._default_branch_cache = "main"
+        statuses = [
+            {"context": "ci/test", "status": "failure"},
+            {"context": "ci/lint", "status": "success"},
+        ]
+        with mock.patch.object(forge._session, "request", return_value=_mock_response(json_data=statuses)):
+            result = forge.get_default_branch_ci_status()
+        assert result.status == "failing"
+        assert "ci/test" in result.failed_runs
+
+
+# ===========================================================================
+# Repository metadata
+# ===========================================================================
+
+
+class TestRepoMetadata:
+    """Tests for get_repo_nwo() and get_repo_default_branch()."""
+
+    def test_nwo_from_https(self) -> None:
+        forge = _make_forge(nwo="myorg/myrepo")
+        with mock.patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0,
+                stdout="https://gitea.example.com/myorg/myrepo.git\n",
+            )
+            assert forge.get_repo_nwo() == "myorg/myrepo"
+
+    def test_nwo_from_ssh(self) -> None:
+        forge = _make_forge()
+        with mock.patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0,
+                stdout="git@gitea.example.com:team/project.git\n",
+            )
+            # Clear cache
+            forge._nwo_cache = None
+            assert forge.get_repo_nwo() == "team/project"
+
+    def test_default_branch(self) -> None:
+        forge = _make_forge()
+        repo_data = {"default_branch": "develop"}
+        with mock.patch.object(forge._session, "request", return_value=_mock_response(json_data=repo_data)):
+            assert forge.get_repo_default_branch() == "develop"
+
+
+# ===========================================================================
+# Batch operations
+# ===========================================================================
+
+
+class TestBatchOperations:
+    """Tests for get_issues_batch() and find_pull_request_for_issue()."""
+
+    def test_get_issues_batch(self) -> None:
+        forge = _make_forge()
+        issue1 = {"number": 1, "state": "open", "title": "A", "html_url": "u1", "labels": []}
+        issue2 = {"number": 2, "state": "closed", "title": "B", "html_url": "u2", "labels": []}
+
+        def side_effect(method, url, **kwargs):
+            if "/issues/1" in url:
+                return _mock_response(json_data=issue1)
+            if "/issues/2" in url:
+                return _mock_response(json_data=issue2)
+            return _mock_response(404)
+
+        with mock.patch.object(forge._session, "request", side_effect=side_effect):
+            results = forge.get_issues_batch([1, 2, 999])
+
+        assert results[1] is not None
+        assert results[1].number == 1
+        assert results[2] is not None
+        assert results[999] is None
+
+    def test_find_pr_by_branch(self) -> None:
+        forge = _make_forge()
+        prs = [
+            {"number": 50, "state": "open", "title": "PR", "html_url": "u",
+             "labels": [], "head": {"ref": "feature/issue-42"}, "merged": False},
+        ]
+        with mock.patch.object(forge._session, "request", return_value=_mock_response(json_data=prs)):
+            result = forge.find_pull_request_for_issue(42)
+        assert result == 50
+
+    def test_find_pr_by_body(self) -> None:
+        forge = _make_forge()
+        # First call returns no match for branch, second returns all PRs
+        no_match_prs = [
+            {"number": 1, "state": "open", "title": "Other", "html_url": "u",
+             "labels": [], "head": {"ref": "other-branch"}, "merged": False},
+        ]
+        all_prs = [
+            {"number": 60, "state": "open", "title": "Fix", "html_url": "u",
+             "labels": [], "head": {"ref": "my-fix"}, "merged": False,
+             "body": "This PR Closes #42 and does stuff"},
+        ]
+        with mock.patch.object(forge._session, "request", side_effect=[
+            _mock_response(json_data=no_match_prs),  # head filter (client-side, no match)
+            _mock_response(json_data=all_prs),  # body search
+        ]):
+            result = forge.find_pull_request_for_issue(42)
+        assert result == 60
+
+
+# ===========================================================================
+# Error handling
+# ===========================================================================
+
+
+class TestErrorHandling:
+    """Tests for error paths."""
+
+    def test_auth_failure_logs_error(self) -> None:
+        forge = _make_forge()
+        with (
+            mock.patch.object(forge._session, "request", return_value=_mock_response(401)),
+            mock.patch("loom_tools.common.gitea.logger") as mock_logger,
+        ):
+            result = forge.get_issue(42)
+        assert result is None
+        mock_logger.error.assert_called()
+        assert "auth" in mock_logger.error.call_args[0][0].lower()
+
+    def test_connection_error(self) -> None:
+        forge = _make_forge()
+        with (
+            mock.patch.object(forge._session, "request", side_effect=requests.ConnectionError("down")),
+            mock.patch("loom_tools.common.gitea.logger") as mock_logger,
+        ):
+            result = forge.get_issue(42)
+        assert result is None
+        mock_logger.error.assert_called()
+
+    def test_timeout_error(self) -> None:
+        forge = _make_forge()
+        with (
+            mock.patch.object(forge._session, "request", side_effect=requests.Timeout("timeout")),
+            mock.patch("loom_tools.common.gitea.logger") as mock_logger,
+        ):
+            result = forge.get_issue(42)
+        assert result is None
+        mock_logger.error.assert_called()
+
+    def test_server_error_returns_none(self) -> None:
+        forge = _make_forge()
+        with mock.patch.object(forge._session, "request", return_value=_mock_response(500)):
+            assert forge.get_issue(42) is None
+            assert forge.list_issues() == []
+            assert forge.get_pull_request(10) is None
+
+
+# ===========================================================================
+# Factory function
+# ===========================================================================
+
+
+class TestGetForgeFactory:
+    """Tests for get_forge() in forge.py."""
+
+    def test_returns_gitea_forge(self) -> None:
+        from loom_tools.common.forge import get_forge
+
+        with (
+            mock.patch("loom_tools.common.forge.detect_forge") as mock_detect,
+            mock.patch(
+                "loom_tools.common.gitea.get_forge_config",
+                return_value=_GITEA_CONFIG,
+            ),
+            mock.patch.dict(os.environ, {"GITEA_TOKEN": "tok"}, clear=False),
+        ):
+            from loom_tools.common.forge import ForgeType
+            mock_detect.return_value = ForgeType.GITEA
+            forge = get_forge()
+
+        assert forge.forge_type == "gitea"
+
+    def test_returns_github_forge_by_default(self) -> None:
+        from loom_tools.common.forge import ForgeType, get_forge
+
+        with mock.patch("loom_tools.common.forge.detect_forge") as mock_detect:
+            mock_detect.return_value = ForgeType.GITHUB
+            forge = get_forge()
+
+        assert forge.forge_type == "github"


### PR DESCRIPTION
## Summary

Implements the `GiteaForge` class satisfying the `ForgeClient` protocol using Gitea's REST API v1 (Phase 2 of Epic #3131).

- **GiteaForge class** (`loom-tools/src/loom_tools/common/gitea.py`): All 18 ForgeClient methods implemented using `requests.Session` with `Authorization: token {value}` auth headers
- **Label name-to-ID cache**: Lazy-populated cache with automatic invalidation on cache miss, since Gitea's label API requires integer IDs
- **State normalization**: Gitea's lowercase states (`open`, `closed`) normalized to uppercase (`OPEN`, `CLOSED`), with `merged=true` mapped to `MERGED`
- **Factory function**: `get_forge()` added to `forge.py` with lazy imports to dispatch between `GitHubForge` and `GiteaForge` based on `detect_forge()`
- **Error handling**: Returns None/False/[] on errors (matching GitHubForge patterns), logs clear auth error messages for 401/403, handles connection and timeout errors
- **53 comprehensive tests** (`loom-tools/tests/test_gitea.py`): All endpoints mocked via `requests.Session`, covering protocol compliance, constructor validation, all CRUD operations, label caching, state normalization, CI status, batch operations, and error paths
- **Dependency**: Added `requests>=2.28` to `pyproject.toml`

Closes #3144

## Test plan

- [x] All 53 new tests pass (`python3 -m pytest tests/test_gitea.py`)
- [x] All 184 existing tests pass (`python3 -m pytest tests/test_forge.py tests/test_github.py`)
- [ ] Verify `isinstance(GiteaForge(), ForgeClient)` returns True (covered by test)
- [ ] Verify all 12 acceptance criteria from the issue are met