### PR TITLE
feat: Gitea branch protection and repository settings

### DIFF
--- a/scripts/install/forge-detect.sh
+++ b/scripts/install/forge-detect.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Detect forge type (GitHub or Gitea) from git remote URL
+#
+# Usage: source this file, then call detect_forge_and_repo
+#
+# Sets the following variables:
+#   FORGE_TYPE    - "github" or "gitea"
+#   FORGE_OWNER   - repository owner
+#   FORGE_REPO    - repository name
+#   FORGE_API_BASE - base URL for API calls (Gitea only)
+#   FORGE_TOKEN   - auth token for API calls (Gitea only)
+#
+# For Gitea, expects either $GITEA_TOKEN or $FORGE_TOKEN to be set.
+# The base URL is auto-detected from the remote URL.
+
+# Detect forge type and extract owner/repo from a git remote URL.
+#
+# Arguments:
+#   $1 - git remote URL (required)
+#
+# Returns 0 on success, 1 on failure.
+detect_forge_and_repo() {
+  local origin_url="${1:-}"
+
+  if [[ -z "$origin_url" ]]; then
+    echo "ERROR: origin URL is required" >&2
+    return 1
+  fi
+
+  FORGE_TYPE=""
+  FORGE_OWNER=""
+  FORGE_REPO=""
+  FORGE_API_BASE=""
+  FORGE_TOKEN=""
+
+  # Detect forge type from URL
+  if [[ "$origin_url" =~ github\.com ]]; then
+    FORGE_TYPE="github"
+  else
+    # For any non-GitHub URL, try to detect if it's a Gitea instance.
+    # We extract the host and probe the Gitea API endpoint.
+    local host=""
+    host=$(_extract_host "$origin_url")
+
+    if [[ -n "$host" ]]; then
+      # Check if this host responds to the Gitea API
+      local api_base="https://${host}/api/v1"
+      local token="${GITEA_TOKEN:-${FORGE_TOKEN:-}}"
+
+      if _probe_gitea_api "$api_base" "$token"; then
+        FORGE_TYPE="gitea"
+        FORGE_API_BASE="$api_base"
+        FORGE_TOKEN="$token"
+      else
+        # Try HTTP as fallback (some self-hosted instances)
+        api_base="http://${host}/api/v1"
+        if _probe_gitea_api "$api_base" "$token"; then
+          FORGE_TYPE="gitea"
+          FORGE_API_BASE="$api_base"
+          FORGE_TOKEN="$token"
+        fi
+      fi
+    fi
+
+    if [[ -z "$FORGE_TYPE" ]]; then
+      echo "ERROR: Could not detect forge type from URL: $origin_url" >&2
+      echo "For Gitea instances, ensure the server is reachable." >&2
+      return 1
+    fi
+  fi
+
+  # Extract owner/repo from URL (handles HTTPS and SSH for any host)
+  # HTTPS: https://host/owner/repo.git -> owner/repo
+  # SSH: git@host:owner/repo.git -> owner/repo
+  local repo_path=""
+  # Strip .git suffix first, then extract owner/repo
+  local cleaned_url
+  cleaned_url=$(echo "$origin_url" | sed -E 's/\.git$//')
+  repo_path=$(echo "$cleaned_url" | sed -E 's#^.*[:/]([^/]+/[^/]+)$#\1#')
+
+  if [[ ! "$repo_path" =~ ^[^/]+/[^/]+$ ]]; then
+    echo "ERROR: Could not extract valid owner/repo from URL: $origin_url" >&2
+    return 1
+  fi
+
+  FORGE_OWNER=$(echo "$repo_path" | cut -d'/' -f1)
+  FORGE_REPO=$(echo "$repo_path" | cut -d'/' -f2)
+
+  # For Gitea, validate that we have an auth token
+  if [[ "$FORGE_TYPE" == "gitea" && -z "$FORGE_TOKEN" ]]; then
+    echo "WARNING: No Gitea auth token found. Set GITEA_TOKEN or FORGE_TOKEN." >&2
+  fi
+
+  return 0
+}
+
+# Extract hostname (with optional port) from a git remote URL.
+# Handles HTTPS URLs, SSH URLs, and SCP-style URLs.
+_extract_host() {
+  local url="$1"
+
+  if [[ "$url" =~ ^https?:// ]]; then
+    # HTTPS: https://host:port/owner/repo.git
+    echo "$url" | sed -E 's#^https?://([^/]+)/.*#\1#'
+  elif [[ "$url" =~ ^ssh:// ]]; then
+    # SSH: ssh://git@host:port/owner/repo.git
+    echo "$url" | sed -E 's#^ssh://[^@]*@([^/]+)/.*#\1#'
+  elif [[ "$url" =~ ^git@ ]]; then
+    # SCP-style: git@host:owner/repo.git
+    echo "$url" | sed -E 's#^git@([^:]+):.*#\1#'
+  else
+    echo ""
+  fi
+}
+
+# Probe whether a URL responds like a Gitea API.
+# Returns 0 if it looks like Gitea, 1 otherwise.
+_probe_gitea_api() {
+  local api_base="$1"
+  local token="$2"
+
+  local auth_header=""
+  if [[ -n "$token" ]]; then
+    auth_header="Authorization: token $token"
+  fi
+
+  # Try the Gitea version endpoint — lightweight and always available
+  local response=""
+  if [[ -n "$auth_header" ]]; then
+    response=$(curl -s -m 5 -H "$auth_header" "${api_base}/version" 2>/dev/null || echo "")
+  else
+    response=$(curl -s -m 5 "${api_base}/version" 2>/dev/null || echo "")
+  fi
+
+  # Gitea returns {"version":"X.Y.Z"} from this endpoint
+  if echo "$response" | grep -q '"version"'; then
+    return 0
+  fi
+
+  return 1
+}
+
+# Make a Gitea API call using curl.
+#
+# Arguments:
+#   $1 - HTTP method (GET, POST, PATCH, PUT, DELETE)
+#   $2 - API path (e.g., /repos/owner/repo)
+#   $3 - JSON body (optional, for POST/PATCH/PUT)
+#
+# Requires FORGE_API_BASE and FORGE_TOKEN to be set.
+# Outputs the response body on stdout.
+# Returns the curl exit code.
+gitea_api() {
+  local method="$1"
+  local path="$2"
+  local body="${3:-}"
+
+  local url="${FORGE_API_BASE}${path}"
+  local -a curl_args=(
+    -s
+    -X "$method"
+    -H "Content-Type: application/json"
+    -w "\n%{http_code}"
+  )
+
+  if [[ -n "$FORGE_TOKEN" ]]; then
+    curl_args+=(-H "Authorization: token $FORGE_TOKEN")
+  fi
+
+  if [[ -n "$body" ]]; then
+    curl_args+=(-d "$body")
+  fi
+
+  curl "${curl_args[@]}" "$url"
+}

--- a/scripts/install/setup-branch-protection.sh
+++ b/scripts/install/setup-branch-protection.sh
@@ -1,25 +1,255 @@
 #!/usr/bin/env bash
-# Setup branch rulesets for Loom workflow
+# Setup branch protection for Loom workflow
+#
+# Supports both GitHub (rulesets API) and Gitea (branch protection API).
 #
 # Usage:
 #   ./scripts/install/setup-branch-protection.sh /path/to/target-repo [branch-name]
 #
-# Creates or updates a GitHub ruleset with recommended rules:
+# For GitHub, creates or updates a ruleset with recommended rules:
 #   - Prevent branch deletion and force pushes
 #   - Require linear history (squash merges only)
 #   - Require pull requests (0 approvals for solo dev/Loom workflows)
+#
+# For Gitea, creates or updates branch protection with equivalent settings:
+#   - Prevent force pushes
+#   - Require pull requests (0 approvals)
+#   - Dismiss stale approvals
+#   - Warns about features without Gitea equivalents (linear history, role-based bypass)
 
 set -euo pipefail
 
-# Source helper functions if available
+# Source helper functions
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-if [[ -f "${SCRIPT_DIR}/../install-loom.sh" ]]; then
-  # Define helper functions for consistent output
-  info() { echo -e "\033[0;34mℹ $*\033[0m"; }
-  success() { echo -e "\033[0;32m✓ $*\033[0m"; }
-  warning() { echo -e "\033[1;33m⚠ $*\033[0m"; }
-  error() { echo -e "\033[0;31m✗ $*\033[0m"; }
-fi
+
+# Define helper functions for consistent output
+info() { echo -e "\033[0;34mℹ $*\033[0m"; }
+success() { echo -e "\033[0;32m✓ $*\033[0m"; }
+warning() { echo -e "\033[1;33m⚠ $*\033[0m"; }
+error() { echo -e "\033[0;31m✗ $*\033[0m"; }
+
+# Source forge detection helper
+source "${SCRIPT_DIR}/forge-detect.sh"
+
+# --- GitHub branch protection (rulesets API) ---
+setup_github_branch_protection() {
+  local owner="$FORGE_OWNER"
+  local repo="$FORGE_REPO"
+  local ruleset_name="$RULESET_NAME"
+
+  # Check if user has admin permissions
+  local has_admin
+  has_admin=$(gh api "repos/${owner}/${repo}" --jq '.permissions.admin' 2>/dev/null || echo "false")
+  if [[ "$has_admin" != "true" ]]; then
+    warning "You may not have admin permissions to configure rulesets"
+    warning "Attempting anyway (may fail with permission error)..."
+  fi
+
+  # Ruleset payload
+  # bypass_actors: actor_id 5 = RepositoryRole/admin — allows repo admins to push
+  # directly to main without a PR (e.g. for hotfixes or initial setup).
+  local ruleset_payload='{
+    "name": "'"$ruleset_name"'",
+    "target": "branch",
+    "enforcement": "active",
+    "bypass_actors": [
+      {
+        "actor_id": 5,
+        "actor_type": "RepositoryRole",
+        "bypass_mode": "always"
+      }
+    ],
+    "conditions": {
+      "ref_name": {
+        "include": ["~DEFAULT_BRANCH"],
+        "exclude": []
+      }
+    },
+    "rules": [
+      {"type": "deletion"},
+      {"type": "non_fast_forward"},
+      {"type": "required_linear_history"},
+      {
+        "type": "pull_request",
+        "parameters": {
+          "required_approving_review_count": 0,
+          "dismiss_stale_reviews_on_push": true,
+          "require_code_owner_review": false,
+          "require_last_push_approval": false,
+          "required_review_thread_resolution": false,
+          "allowed_merge_methods": ["squash"]
+        }
+      }
+    ]
+  }'
+
+  # Check if a ruleset named "main" already exists
+  local existing_id
+  existing_id=$(gh api "repos/${owner}/${repo}/rulesets" --jq '.[] | select(.name == "'"$ruleset_name"'") | .id' 2>/dev/null || echo "")
+
+  local api_method api_url
+  if [[ -n "$existing_id" ]]; then
+    info "Found existing ruleset '${ruleset_name}' (ID: ${existing_id}), updating..."
+    api_method="PUT"
+    api_url="repos/${owner}/${repo}/rulesets/${existing_id}"
+  else
+    info "Creating new ruleset '${ruleset_name}'..."
+    api_method="POST"
+    api_url="repos/${owner}/${repo}/rulesets"
+  fi
+
+  if echo "$ruleset_payload" | gh api --method "$api_method" "$api_url" --input - > /dev/null 2>&1; then
+    success "Branch ruleset configured successfully"
+    echo ""
+    echo "Applied rules:"
+    echo "  - Prevent branch deletion"
+    echo "  - Prevent force pushes"
+    echo "  - Require linear history (squash merges only)"
+    echo "  - Require pull requests (0 approvals required)"
+    echo "  - Dismiss stale reviews on new commits"
+    echo "  - Admin bypass: repository admins can push directly without a PR"
+    echo ""
+    echo "Note: 0 approvals required supports solo development and Loom's label-based review system."
+    echo "Note: Admin bypass allows repo owners to push hotfixes directly to main when needed."
+    echo ""
+    info "To modify: GitHub Settings > Rules > Rulesets"
+    return 0
+  else
+    error "Failed to configure branch ruleset"
+    echo ""
+    echo "This can happen if:"
+    echo "  - You lack admin permissions on ${owner}/${repo}"
+    echo "  - GitHub API is unreachable"
+    echo ""
+    info "To configure manually:"
+    echo "  1. Go to: https://github.com/${owner}/${repo}/settings/rules"
+    echo "  2. Create a new ruleset for the default branch"
+    echo "  3. Enable: Prevent deletion, prevent force push"
+    echo "  4. Enable: Require linear history"
+    echo "  5. Enable: Require pull request (0 approvals)"
+    return 1
+  fi
+}
+
+# --- Gitea branch protection ---
+setup_gitea_branch_protection() {
+  local owner="$FORGE_OWNER"
+  local repo="$FORGE_REPO"
+
+  if [[ -z "$FORGE_TOKEN" ]]; then
+    error "Gitea API token required. Set GITEA_TOKEN or FORGE_TOKEN environment variable."
+    return 1
+  fi
+
+  # Check admin permissions via repo info
+  local repo_response http_code body
+  repo_response=$(gitea_api GET "/repos/${owner}/${repo}")
+  http_code=$(echo "$repo_response" | tail -1)
+  body=$(echo "$repo_response" | sed '$d')
+
+  if [[ "$http_code" != "200" ]]; then
+    warning "Could not verify permissions on ${owner}/${repo} (HTTP ${http_code})"
+    warning "Attempting branch protection setup anyway..."
+  fi
+
+  # Branch protection payload for Gitea
+  local protection_payload
+  protection_payload='{
+    "branch_name": "'"${BRANCH_NAME}"'",
+    "enable_push": true,
+    "enable_force_push": false,
+    "enable_force_push_allowlist": false,
+    "dismiss_stale_approvals": true,
+    "required_approvals": 0,
+    "block_on_rejected_reviews": false,
+    "block_admin_merge_override": false
+  }'
+
+  # Check if branch protection already exists
+  local existing_response existing_code
+  existing_response=$(gitea_api GET "/repos/${owner}/${repo}/branch_protections/${BRANCH_NAME}")
+  existing_code=$(echo "$existing_response" | tail -1)
+
+  if [[ "$existing_code" == "200" ]]; then
+    info "Found existing branch protection for '${BRANCH_NAME}', updating..."
+    local update_response update_code
+    update_response=$(gitea_api PATCH "/repos/${owner}/${repo}/branch_protections/${BRANCH_NAME}" "$protection_payload")
+    update_code=$(echo "$update_response" | tail -1)
+
+    if [[ "$update_code" == "200" ]]; then
+      _gitea_protection_success
+      return 0
+    else
+      _gitea_protection_failure "$owner" "$repo" "$update_code"
+      return 1
+    fi
+  else
+    info "Creating new branch protection for '${BRANCH_NAME}'..."
+    local create_response create_code
+    create_response=$(gitea_api POST "/repos/${owner}/${repo}/branch_protections" "$protection_payload")
+    create_code=$(echo "$create_response" | tail -1)
+
+    if [[ "$create_code" == "201" || "$create_code" == "200" ]]; then
+      _gitea_protection_success
+      return 0
+    else
+      _gitea_protection_failure "$owner" "$repo" "$create_code"
+      return 1
+    fi
+  fi
+}
+
+_gitea_protection_success() {
+  success "Branch protection configured successfully"
+  echo ""
+  echo "Applied rules:"
+  echo "  - Allow push (not force push)"
+  echo "  - Prevent force pushes"
+  echo "  - Require pull requests (0 approvals required)"
+  echo "  - Dismiss stale approvals on new commits"
+  echo "  - Admin merge override: allowed"
+  echo ""
+
+  # Graceful degradation warnings
+  warning "Gitea does not support 'required linear history' at the branch level."
+  echo "  Mitigation: squash-only merging is enforced via repository settings."
+  echo ""
+  warning "Gitea does not support role-based bypass actors (admin bypass)."
+  echo "  Mitigation: block_admin_merge_override is set to false, allowing admin overrides."
+  echo ""
+  warning "Gitea does not support per-branch merge method restrictions."
+  echo "  Mitigation: merge methods are configured at the repository level."
+  echo ""
+
+  echo "Note: 0 approvals required supports solo development and Loom's label-based review system."
+  echo ""
+  info "To modify: Gitea Settings > Branches > Branch Protection"
+}
+
+_gitea_protection_failure() {
+  local owner="$1"
+  local repo="$2"
+  local code="$3"
+
+  error "Failed to configure branch protection (HTTP ${code})"
+  echo ""
+  echo "This can happen if:"
+  echo "  - You lack admin permissions on ${owner}/${repo}"
+  echo "  - Gitea API is unreachable"
+  echo "  - The auth token is invalid or expired"
+  echo ""
+  info "To configure manually:"
+  echo "  1. Go to your Gitea repository settings"
+  echo "  2. Navigate to Branches > Branch Protection"
+  echo "  3. Add protection for '${BRANCH_NAME}'"
+  echo "  4. Disable force push"
+  echo "  5. Set required approvals to 0"
+  echo "  6. Enable 'Dismiss stale approvals'"
+}
+
+# ============================================================================
+# Main
+# ============================================================================
 
 TARGET_PATH="${1:-}"
 BRANCH_NAME="${2:-main}"
@@ -33,113 +263,29 @@ fi
 
 cd "$TARGET_PATH"
 
-# Detect the repository from origin remote (not upstream)
+# Detect the repository from origin remote
 ORIGIN_URL=$(git config --get remote.origin.url 2>/dev/null || echo "")
 if [[ -z "$ORIGIN_URL" ]]; then
-  error "Failed to get repository information. Is this a GitHub repository?"
+  error "Failed to get repository information from git remote."
   exit 1
 fi
 
-# Extract owner/repo from URL (handles both HTTPS and SSH)
-REPO_NAME=$(echo "$ORIGIN_URL" | sed -E 's#^.*(github\.com[/:])##; s/\.git$//')
-
-if [[ ! "$REPO_NAME" =~ ^[^/]+/[^/]+$ ]]; then
-  error "Could not extract valid repository from URL: $ORIGIN_URL"
+# Detect forge type and extract owner/repo
+if ! detect_forge_and_repo "$ORIGIN_URL"; then
+  error "Could not detect forge type. Is this a GitHub or Gitea repository?"
   exit 1
 fi
-
-OWNER=$(echo "$REPO_NAME" | cut -d'/' -f1)
-REPO=$(echo "$REPO_NAME" | cut -d'/' -f2)
 
 echo ""
-info "Configuring branch ruleset for: ${OWNER}/${REPO} (${BRANCH_NAME})"
+info "Detected forge: ${FORGE_TYPE}"
+info "Configuring branch protection for: ${FORGE_OWNER}/${FORGE_REPO} (${BRANCH_NAME})"
 
-# Check if user has admin permissions
-HAS_ADMIN=$(gh api "repos/${OWNER}/${REPO}" --jq '.permissions.admin' 2>/dev/null || echo "false")
-if [[ "$HAS_ADMIN" != "true" ]]; then
-  warning "You may not have admin permissions to configure rulesets"
-  warning "Attempting anyway (may fail with permission error)..."
-fi
-
-# Ruleset payload
-# bypass_actors: actor_id 5 = RepositoryRole/admin — allows repo admins to push
-# directly to main without a PR (e.g. for hotfixes or initial setup).
-RULESET_PAYLOAD='{
-  "name": "'"$RULESET_NAME"'",
-  "target": "branch",
-  "enforcement": "active",
-  "bypass_actors": [
-    {
-      "actor_id": 5,
-      "actor_type": "RepositoryRole",
-      "bypass_mode": "always"
-    }
-  ],
-  "conditions": {
-    "ref_name": {
-      "include": ["~DEFAULT_BRANCH"],
-      "exclude": []
-    }
-  },
-  "rules": [
-    {"type": "deletion"},
-    {"type": "non_fast_forward"},
-    {"type": "required_linear_history"},
-    {
-      "type": "pull_request",
-      "parameters": {
-        "required_approving_review_count": 0,
-        "dismiss_stale_reviews_on_push": true,
-        "require_code_owner_review": false,
-        "require_last_push_approval": false,
-        "required_review_thread_resolution": false,
-        "allowed_merge_methods": ["squash"]
-      }
-    }
-  ]
-}'
-
-# Check if a ruleset named "main" already exists
-EXISTING_ID=$(gh api "repos/${OWNER}/${REPO}/rulesets" --jq '.[] | select(.name == "'"$RULESET_NAME"'") | .id' 2>/dev/null || echo "")
-
-if [[ -n "$EXISTING_ID" ]]; then
-  info "Found existing ruleset '${RULESET_NAME}' (ID: ${EXISTING_ID}), updating..."
-  API_METHOD="PUT"
-  API_URL="repos/${OWNER}/${REPO}/rulesets/${EXISTING_ID}"
+# Dispatch to the appropriate forge handler
+if [[ "$FORGE_TYPE" == "github" ]]; then
+  setup_github_branch_protection
+elif [[ "$FORGE_TYPE" == "gitea" ]]; then
+  setup_gitea_branch_protection
 else
-  info "Creating new ruleset '${RULESET_NAME}'..."
-  API_METHOD="POST"
-  API_URL="repos/${OWNER}/${REPO}/rulesets"
-fi
-
-if echo "$RULESET_PAYLOAD" | gh api --method "$API_METHOD" "$API_URL" --input - > /dev/null 2>&1; then
-  success "Branch ruleset configured successfully"
-  echo ""
-  echo "Applied rules:"
-  echo "  - Prevent branch deletion"
-  echo "  - Prevent force pushes"
-  echo "  - Require linear history (squash merges only)"
-  echo "  - Require pull requests (0 approvals required)"
-  echo "  - Dismiss stale reviews on new commits"
-  echo "  - Admin bypass: repository admins can push directly without a PR"
-  echo ""
-  echo "Note: 0 approvals required supports solo development and Loom's label-based review system."
-  echo "Note: Admin bypass allows repo owners to push hotfixes directly to main when needed."
-  echo ""
-  info "To modify: GitHub Settings > Rules > Rulesets"
-  exit 0
-else
-  error "Failed to configure branch ruleset"
-  echo ""
-  echo "This can happen if:"
-  echo "  - You lack admin permissions on ${OWNER}/${REPO}"
-  echo "  - GitHub API is unreachable"
-  echo ""
-  info "To configure manually:"
-  echo "  1. Go to: https://github.com/${OWNER}/${REPO}/settings/rules"
-  echo "  2. Create a new ruleset for the default branch"
-  echo "  3. Enable: Prevent deletion, prevent force push"
-  echo "  4. Enable: Require linear history"
-  echo "  5. Enable: Require pull request (0 approvals)"
+  error "Unsupported forge type: ${FORGE_TYPE}"
   exit 1
 fi

--- a/scripts/install/setup-repository-settings.sh
+++ b/scripts/install/setup-repository-settings.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Setup repository settings for Loom workflow
 #
+# Supports both GitHub and Gitea forges.
+#
 # Usage:
 #   ./scripts/install/setup-repository-settings.sh /path/to/target-repo [--dry-run]
 #
@@ -8,19 +10,194 @@
 #   - Merge strategy (squash merge only)
 #   - Auto-delete head branches
 #   - Allow auto-merge
-#   - Suggest updating branches
+#   - Suggest updating branches (GitHub only; Gitea has no equivalent)
 
 set -euo pipefail
 
-# Source helper functions if available
+# Source helper functions
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-if [[ -f "${SCRIPT_DIR}/../install-loom.sh" ]]; then
-  # Define helper functions for consistent output
-  info() { echo -e "\033[0;34mℹ $*\033[0m"; }
-  success() { echo -e "\033[0;32m✓ $*\033[0m"; }
-  warning() { echo -e "\033[1;33m⚠ $*\033[0m"; }
-  error() { echo -e "\033[0;31m✗ $*\033[0m"; }
-fi
+
+# Define helper functions for consistent output
+info() { echo -e "\033[0;34mℹ $*\033[0m"; }
+success() { echo -e "\033[0;32m✓ $*\033[0m"; }
+warning() { echo -e "\033[1;33m⚠ $*\033[0m"; }
+error() { echo -e "\033[0;31m✗ $*\033[0m"; }
+
+# Source forge detection helper
+source "${SCRIPT_DIR}/forge-detect.sh"
+
+# --- GitHub repository settings ---
+setup_github_repo_settings() {
+  local owner="$FORGE_OWNER"
+  local repo="$FORGE_REPO"
+
+  # Check if user has admin permissions
+  local has_admin
+  has_admin=$(gh api "repos/${owner}/${repo}" --jq '.permissions.admin' 2>/dev/null || echo "false")
+  if [[ "$has_admin" != "true" ]]; then
+    warning "You may not have admin permissions to configure repository settings"
+    warning "Attempting anyway (may fail with permission error)..."
+  fi
+
+  # Define the settings to apply
+  local settings_json='{
+    "allow_merge_commit": false,
+    "allow_squash_merge": true,
+    "allow_rebase_merge": false,
+    "delete_branch_on_merge": true,
+    "allow_auto_merge": true,
+    "allow_update_branch": true
+  }'
+
+  # In dry-run mode, just display what would be changed
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo ""
+    info "DRY RUN - Would apply the following settings:"
+    echo ""
+    echo "  Repository: ${owner}/${repo}"
+    echo "  Forge: GitHub"
+    echo ""
+    echo "  Settings to be configured:"
+    echo "    allow_merge_commit: false (disabled)"
+    echo "    allow_squash_merge: true (default strategy - flattens PR to single commit)"
+    echo "    allow_rebase_merge: false (disabled)"
+    echo "    delete_branch_on_merge: true (auto-cleanup branches)"
+    echo "    allow_auto_merge: true (enables Champion auto-merge)"
+    echo "    allow_update_branch: true (suggest branch updates)"
+    echo ""
+    info "No changes made (dry-run mode)"
+    return 0
+  fi
+
+  # Apply repository settings using GitHub API
+  if echo "$settings_json" | gh api "repos/${owner}/${repo}" -X PATCH --input - > /dev/null 2>&1; then
+    success "Repository settings configured successfully"
+    echo ""
+    echo "Applied settings:"
+    echo "  - Allow merge commits: No (disabled)"
+    echo "  - Allow squash merging: Yes (default strategy - flattens PR to single commit)"
+    echo "  - Allow rebase merging: No (disabled)"
+    echo "  - Delete branches on merge: Yes (auto-cleanup)"
+    echo "  - Allow auto-merge: Yes (enables Champion workflow)"
+    echo "  - Suggest updating branches: Yes"
+    echo ""
+    info "To modify: GitHub Settings > General > Pull Requests"
+    return 0
+  else
+    error "Failed to configure repository settings"
+    echo ""
+    echo "This can happen if:"
+    echo "  - You lack admin permissions on ${owner}/${repo}"
+    echo "  - GitHub API is unreachable"
+    echo ""
+    info "To configure manually:"
+    echo "  1. Go to: https://github.com/${owner}/${repo}/settings"
+    echo "  2. Scroll to 'Pull Requests' section"
+    echo "  3. Configure merge options:"
+    echo "     - Disable: Allow merge commits"
+    echo "     - Enable: Allow squash merging"
+    echo "     - Disable: Allow rebase merging"
+    echo "     - Enable: Always suggest updating pull request branches"
+    echo "     - Enable: Automatically delete head branches"
+    echo "     - Enable: Allow auto-merge"
+    return 1
+  fi
+}
+
+# --- Gitea repository settings ---
+setup_gitea_repo_settings() {
+  local owner="$FORGE_OWNER"
+  local repo="$FORGE_REPO"
+
+  if [[ -z "$FORGE_TOKEN" ]]; then
+    error "Gitea API token required. Set GITEA_TOKEN or FORGE_TOKEN environment variable."
+    return 1
+  fi
+
+  # Gitea repo settings payload
+  # Note: default_merge_style enforces squash-only merging
+  local settings_json='{
+    "allow_merge_commits": false,
+    "allow_squash_merge": true,
+    "allow_rebase_merge": false,
+    "default_delete_branch_after_merge": true,
+    "default_merge_style": "squash"
+  }'
+
+  # In dry-run mode, just display what would be changed
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo ""
+    info "DRY RUN - Would apply the following settings:"
+    echo ""
+    echo "  Repository: ${owner}/${repo}"
+    echo "  Forge: Gitea"
+    echo ""
+    echo "  Settings to be configured:"
+    echo "    allow_merge_commits: false (disabled)"
+    echo "    allow_squash_merge: true (default strategy - flattens PR to single commit)"
+    echo "    allow_rebase_merge: false (disabled)"
+    echo "    default_delete_branch_after_merge: true (auto-cleanup branches)"
+    echo "    default_merge_style: squash (enforce squash-only merging)"
+    echo ""
+    warning "Gitea does not support 'allow_update_branch' (suggest branch updates)."
+    echo "  This is a cosmetic GitHub UI feature with low impact."
+    echo ""
+    warning "Gitea has limited auto-merge support via 'allow_merge_by_api'."
+    echo "  Loom's Champion role uses explicit merge API calls, so this is handled."
+    echo ""
+    info "No changes made (dry-run mode)"
+    return 0
+  fi
+
+  # Apply repository settings using Gitea API
+  local response http_code
+  response=$(gitea_api PATCH "/repos/${owner}/${repo}" "$settings_json")
+  http_code=$(echo "$response" | tail -1)
+
+  if [[ "$http_code" == "200" ]]; then
+    success "Repository settings configured successfully"
+    echo ""
+    echo "Applied settings:"
+    echo "  - Allow merge commits: No (disabled)"
+    echo "  - Allow squash merging: Yes (default strategy - flattens PR to single commit)"
+    echo "  - Allow rebase merging: No (disabled)"
+    echo "  - Delete branches on merge: Yes (auto-cleanup)"
+    echo "  - Default merge style: squash (enforces squash-only merging)"
+    echo ""
+
+    # Graceful degradation warnings
+    warning "Gitea does not support 'allow_update_branch' (suggest branch updates)."
+    echo "  This is a cosmetic GitHub UI feature with low impact."
+    echo ""
+    warning "Gitea has limited auto-merge support."
+    echo "  Loom's Champion role uses explicit merge API calls, so this is handled."
+    echo ""
+
+    info "To modify: Gitea Settings > Repository"
+    return 0
+  else
+    error "Failed to configure repository settings (HTTP ${http_code})"
+    echo ""
+    echo "This can happen if:"
+    echo "  - You lack admin permissions on ${owner}/${repo}"
+    echo "  - Gitea API is unreachable"
+    echo "  - The auth token is invalid or expired"
+    echo ""
+    info "To configure manually:"
+    echo "  1. Go to your Gitea repository settings"
+    echo "  2. Under 'Repository', configure merge options:"
+    echo "     - Disable: Allow merge commits"
+    echo "     - Enable: Allow squash merging"
+    echo "     - Disable: Allow rebase merging"
+    echo "     - Enable: Automatically delete head branches"
+    echo "     - Set default merge style to: squash"
+    return 1
+  fi
+}
+
+# ============================================================================
+# Main
+# ============================================================================
 
 # Parse arguments
 TARGET_PATH=""
@@ -47,98 +224,29 @@ fi
 
 cd "$TARGET_PATH"
 
-# Detect the repository from origin remote (not upstream)
+# Detect the repository from origin remote
 ORIGIN_URL=$(git config --get remote.origin.url 2>/dev/null || echo "")
 if [[ -z "$ORIGIN_URL" ]]; then
-  error "Failed to get repository information. Is this a GitHub repository?"
+  error "Failed to get repository information from git remote."
   exit 1
 fi
 
-# Extract owner/repo from URL (handles both HTTPS and SSH)
-# HTTPS: https://github.com/owner/repo.git -> owner/repo
-# SSH: git@github.com:owner/repo.git -> owner/repo
-REPO_NAME=$(echo "$ORIGIN_URL" | sed -E 's#^.*(github\.com[/:])##; s/\.git$//')
-
-if [[ ! "$REPO_NAME" =~ ^[^/]+/[^/]+$ ]]; then
-  error "Could not extract valid repository from URL: $ORIGIN_URL"
+# Detect forge type and extract owner/repo
+if ! detect_forge_and_repo "$ORIGIN_URL"; then
+  error "Could not detect forge type. Is this a GitHub or Gitea repository?"
   exit 1
 fi
-
-OWNER=$(echo "$REPO_NAME" | cut -d'/' -f1)
-REPO=$(echo "$REPO_NAME" | cut -d'/' -f2)
 
 echo ""
-info "Configuring repository settings for: ${OWNER}/${REPO}"
+info "Detected forge: ${FORGE_TYPE}"
+info "Configuring repository settings for: ${FORGE_OWNER}/${FORGE_REPO}"
 
-# Check if user has admin permissions
-HAS_ADMIN=$(gh api "repos/${OWNER}/${REPO}" --jq '.permissions.admin' 2>/dev/null || echo "false")
-if [[ "$HAS_ADMIN" != "true" ]]; then
-  warning "You may not have admin permissions to configure repository settings"
-  warning "Attempting anyway (may fail with permission error)..."
-fi
-
-# Define the settings to apply
-SETTINGS_JSON='{
-  "allow_merge_commit": false,
-  "allow_squash_merge": true,
-  "allow_rebase_merge": false,
-  "delete_branch_on_merge": true,
-  "allow_auto_merge": true,
-  "allow_update_branch": true
-}'
-
-# In dry-run mode, just display what would be changed
-if [[ "$DRY_RUN" == "true" ]]; then
-  echo ""
-  info "DRY RUN - Would apply the following settings:"
-  echo ""
-  echo "  Repository: ${OWNER}/${REPO}"
-  echo ""
-  echo "  Settings to be configured:"
-  echo "    allow_merge_commit: false (disabled)"
-  echo "    allow_squash_merge: true (default strategy - flattens PR to single commit)"
-  echo "    allow_rebase_merge: false (disabled)"
-  echo "    delete_branch_on_merge: true (auto-cleanup branches)"
-  echo "    allow_auto_merge: true (enables Champion auto-merge)"
-  echo "    allow_update_branch: true (suggest branch updates)"
-  echo ""
-  info "No changes made (dry-run mode)"
-  exit 0
-fi
-
-# Apply repository settings using GitHub API
-if gh api "repos/${OWNER}/${REPO}" -X PATCH --input - > /dev/null 2>&1 <<EOF
-${SETTINGS_JSON}
-EOF
-then
-  success "Repository settings configured successfully"
-  echo ""
-  echo "Applied settings:"
-  echo "  - Allow merge commits: No (disabled)"
-  echo "  - Allow squash merging: Yes (default strategy - flattens PR to single commit)"
-  echo "  - Allow rebase merging: No (disabled)"
-  echo "  - Delete branches on merge: Yes (auto-cleanup)"
-  echo "  - Allow auto-merge: Yes (enables Champion workflow)"
-  echo "  - Suggest updating branches: Yes"
-  echo ""
-  info "To modify: GitHub Settings > General > Pull Requests"
-  exit 0
+# Dispatch to the appropriate forge handler
+if [[ "$FORGE_TYPE" == "github" ]]; then
+  setup_github_repo_settings
+elif [[ "$FORGE_TYPE" == "gitea" ]]; then
+  setup_gitea_repo_settings
 else
-  error "Failed to configure repository settings"
-  echo ""
-  echo "This can happen if:"
-  echo "  - You lack admin permissions on ${OWNER}/${REPO}"
-  echo "  - GitHub API is unreachable"
-  echo ""
-  info "To configure manually:"
-  echo "  1. Go to: https://github.com/${OWNER}/${REPO}/settings"
-  echo "  2. Scroll to 'Pull Requests' section"
-  echo "  3. Configure merge options:"
-  echo "     - Disable: Allow merge commits"
-  echo "     - Enable: Allow squash merging"
-  echo "     - Disable: Allow rebase merging"
-  echo "     - Enable: Always suggest updating pull request branches"
-  echo "     - Enable: Automatically delete head branches"
-  echo "     - Enable: Allow auto-merge"
+  error "Unsupported forge type: ${FORGE_TYPE}"
   exit 1
 fi

--- a/tests/install/test-forge-detect.sh
+++ b/tests/install/test-forge-detect.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Test suite for scripts/install/forge-detect.sh
+#
+# Usage: ./tests/install/test-forge-detect.sh
+#
+# Tests forge detection logic and URL parsing. Mocks network calls
+# so no real API access is needed.
+#
+# Exit code 0 = all tests pass, 1 = failures detected.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+assert_eq() {
+  local desc="$1"
+  local expected="$2"
+  local actual="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "${RED}FAIL${NC}: $desc"
+    echo "  expected: '$expected'"
+    echo "  actual:   '$actual'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Source forge-detect (we'll test its helper functions directly)
+source "$REPO_ROOT/scripts/install/forge-detect.sh"
+
+# ============================================================================
+# Test _extract_host
+# ============================================================================
+echo ""
+echo "=== Testing _extract_host ==="
+
+assert_eq "HTTPS github.com" \
+  "github.com" \
+  "$(_extract_host "https://github.com/owner/repo.git")"
+
+assert_eq "SSH github.com" \
+  "github.com" \
+  "$(_extract_host "git@github.com:owner/repo.git")"
+
+assert_eq "HTTPS gitea self-hosted" \
+  "gitea.example.com" \
+  "$(_extract_host "https://gitea.example.com/owner/repo.git")"
+
+assert_eq "SSH gitea self-hosted" \
+  "gitea.example.com" \
+  "$(_extract_host "git@gitea.example.com:owner/repo.git")"
+
+assert_eq "HTTPS with port" \
+  "gitea.example.com:3000" \
+  "$(_extract_host "https://gitea.example.com:3000/owner/repo.git")"
+
+assert_eq "SSH protocol URL" \
+  "gitea.example.com" \
+  "$(_extract_host "ssh://git@gitea.example.com/owner/repo.git")"
+
+assert_eq "HTTPS no .git suffix" \
+  "github.com" \
+  "$(_extract_host "https://github.com/owner/repo")"
+
+# ============================================================================
+# Test detect_forge_and_repo - GitHub URLs
+# ============================================================================
+echo ""
+echo "=== Testing detect_forge_and_repo (GitHub) ==="
+
+detect_forge_and_repo "https://github.com/rjwalters/loom.git" 2>/dev/null
+assert_eq "GitHub HTTPS - forge type" "github" "$FORGE_TYPE"
+assert_eq "GitHub HTTPS - owner" "rjwalters" "$FORGE_OWNER"
+assert_eq "GitHub HTTPS - repo" "loom" "$FORGE_REPO"
+
+detect_forge_and_repo "git@github.com:rjwalters/loom.git" 2>/dev/null
+assert_eq "GitHub SSH - forge type" "github" "$FORGE_TYPE"
+assert_eq "GitHub SSH - owner" "rjwalters" "$FORGE_OWNER"
+assert_eq "GitHub SSH - repo" "loom" "$FORGE_REPO"
+
+detect_forge_and_repo "https://github.com/owner/repo" 2>/dev/null
+assert_eq "GitHub HTTPS no .git - forge type" "github" "$FORGE_TYPE"
+assert_eq "GitHub HTTPS no .git - owner" "owner" "$FORGE_OWNER"
+assert_eq "GitHub HTTPS no .git - repo" "repo" "$FORGE_REPO"
+
+# ============================================================================
+# Test detect_forge_and_repo - error cases
+# ============================================================================
+echo ""
+echo "=== Testing detect_forge_and_repo (error cases) ==="
+
+TOTAL=$((TOTAL + 1))
+if detect_forge_and_repo "" 2>/dev/null; then
+  echo -e "${RED}FAIL${NC}: Empty URL should fail"
+  FAIL=$((FAIL + 1))
+else
+  echo -e "${GREEN}PASS${NC}: Empty URL returns error"
+  PASS=$((PASS + 1))
+fi
+
+# Non-GitHub URL with unreachable host should fail
+TOTAL=$((TOTAL + 1))
+if detect_forge_and_repo "https://unreachable.invalid/owner/repo.git" 2>/dev/null; then
+  echo -e "${RED}FAIL${NC}: Unreachable host should fail"
+  FAIL=$((FAIL + 1))
+else
+  echo -e "${GREEN}PASS${NC}: Unreachable host returns error"
+  PASS=$((PASS + 1))
+fi
+
+# ============================================================================
+# Test gitea_api function structure (just verify it's callable)
+# ============================================================================
+echo ""
+echo "=== Testing gitea_api function ==="
+
+TOTAL=$((TOTAL + 1))
+if type gitea_api &>/dev/null; then
+  echo -e "${GREEN}PASS${NC}: gitea_api function is defined"
+  PASS=$((PASS + 1))
+else
+  echo -e "${RED}FAIL${NC}: gitea_api function is not defined"
+  FAIL=$((FAIL + 1))
+fi
+
+# ============================================================================
+# Summary
+# ============================================================================
+echo ""
+echo "=========================================="
+echo -e "Results: ${PASS} passed, ${FAIL} failed, ${TOTAL} total"
+echo "=========================================="
+
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Implements Gitea support for the installation scripts that configure branch protection and repository settings:

- **New `forge-detect.sh` helper** — shared forge detection from git remote URL, Gitea API probe, and `gitea_api()` curl wrapper
- **`setup-branch-protection.sh`** — dispatches to GitHub rulesets API or Gitea branch protection API based on detected forge
- **`setup-repository-settings.sh`** — dispatches to GitHub or Gitea repo settings API, including `default_merge_style: "squash"`
- **Graceful degradation** — features without Gitea equivalents (linear history, update branch, role-based bypass) emit clear warnings
- **Tests** — 19 unit tests for forge detection logic (URL parsing, host extraction, error cases)
- **No GitHub regression** — existing GitHub behavior is preserved exactly

Closes #3145

## Test plan

- [x] `bash -n` syntax check passes on all 3 scripts
- [x] `tests/install/test-forge-detect.sh` — 19/19 tests pass
- [ ] Manual: run `setup-branch-protection.sh` against a GitHub repo (existing behavior unchanged)
- [ ] Manual: run against a Gitea instance with `GITEA_TOKEN` set