### PR TITLE
feat: implement Gitea CI status integration with ForgeClient protocol

### DIFF
--- a/loom-tools/src/loom_tools/common/forge.py
+++ b/loom-tools/src/loom_tools/common/forge.py
@@ -451,6 +451,14 @@ class ForgeClient(Protocol):
         """Get CI status for the latest runs on the default branch."""
         ...
 
+    def get_commit_ci_status(self, sha: str) -> ForgeCIStatus:
+        """Get CI status for a specific commit SHA.
+
+        Returns aggregated CI status from all status checks and/or
+        workflow runs associated with the given commit.
+        """
+        ...
+
     # --- Repository metadata ---
 
     def get_repo_nwo(self) -> str | None:

--- a/loom-tools/src/loom_tools/common/gitea.py
+++ b/loom-tools/src/loom_tools/common/gitea.py
@@ -600,36 +600,43 @@ class GiteaForge:
     # CI status
     # ------------------------------------------------------------------
 
-    def get_default_branch_ci_status(self) -> ForgeCIStatus:
-        """Get CI status for the latest commit on the default branch."""
-        rp = self._repo_path()
-        default_branch = self.get_repo_default_branch()
-        if not rp or not default_branch:
-            return ForgeCIStatus(
-                status="unknown", message="Cannot determine repo or default branch",
-            )
+    # Gitea commit status values -> Loom internal status
+    _STATUS_MAP_FAILURE = frozenset({"failure", "error"})
+    _STATUS_MAP_PENDING = frozenset({"pending", "warning"})
+    _STATUS_MAP_SUCCESS = frozenset({"success"})
 
-        resp = self._request(
-            "GET", f"{rp}/commits/{default_branch}/statuses",
-        )
-        if resp is None:
-            return ForgeCIStatus(
-                status="unknown", message="Failed to fetch CI statuses",
-            )
+    # Gitea Actions run conclusion -> Loom internal status
+    _ACTIONS_FAILURE = frozenset({"failure", "cancelled"})
+    _ACTIONS_PENDING_STATUSES = frozenset({"queued", "waiting", "running", "in_progress"})
 
-        try:
-            statuses = resp.json()
-        except ValueError:
-            return ForgeCIStatus(
-                status="unknown", message="Invalid CI status response",
-            )
+    def _classify_gitea_status(self, status: str) -> str:
+        """Map a Gitea status value to Loom internal status.
 
-        if not isinstance(statuses, list) or not statuses:
+        Returns ``"success"``, ``"failure"``, or ``"pending"``.
+        """
+        s = status.lower()
+        if s in self._STATUS_MAP_FAILURE:
+            return "failure"
+        if s in self._STATUS_MAP_PENDING:
+            return "pending"
+        if s in self._STATUS_MAP_SUCCESS:
+            return "success"
+        return "pending"  # unknown values treated as pending
+
+    def _aggregate_commit_statuses(
+        self, statuses: list[dict[str, Any]],
+    ) -> ForgeCIStatus:
+        """Aggregate a list of Gitea commit status objects.
+
+        Groups by ``context`` (keeping only the latest per context),
+        then derives the worst-case overall status.
+        """
+        if not statuses:
             return ForgeCIStatus(
                 status="unknown", message="No CI statuses found",
             )
 
-        # Aggregate: group by context (workflow name), take latest
+        # Group by context, keep latest (first in list = most recent)
         latest_by_context: dict[str, dict[str, Any]] = {}
         for s in statuses:
             if not isinstance(s, dict):
@@ -639,10 +646,13 @@ class GiteaForge:
                 latest_by_context[ctx] = s
 
         failed_runs: list[str] = []
+        has_pending = False
         for ctx, s in latest_by_context.items():
-            state = s.get("status", "").lower()
-            if state in ("failure", "error"):
+            classified = self._classify_gitea_status(s.get("status", ""))
+            if classified == "failure":
                 failed_runs.append(ctx)
+            elif classified == "pending":
+                has_pending = True
 
         total = len(latest_by_context)
         if failed_runs:
@@ -653,11 +663,183 @@ class GiteaForge:
                 message=f"CI failing: {len(failed_runs)} check(s) failed",
             )
 
+        if has_pending:
+            return ForgeCIStatus(
+                status="passing",
+                total_runs=total,
+                message="CI passing (some checks pending)",
+            )
+
         return ForgeCIStatus(
             status="passing",
             total_runs=total,
             message="CI passing",
         )
+
+    def _fetch_actions_runs(self, rp: str, ref: str) -> list[dict[str, Any]] | None:
+        """Fetch Gitea Actions workflow runs for a branch/ref.
+
+        Returns ``None`` if the Actions API is unavailable (404) or
+        on any error, enabling callers to fall back to commit statuses only.
+
+        Only available on Gitea 1.19+.
+        """
+        resp = self._request(
+            "GET",
+            f"{rp}/actions/runs",
+            params={"branch": ref, "limit": 10},
+        )
+        if resp is None:
+            return None
+
+        try:
+            data = resp.json()
+        except ValueError:
+            return None
+
+        # Gitea Actions API returns {"workflow_runs": [...]} or just [...]
+        if isinstance(data, dict):
+            runs = data.get("workflow_runs", [])
+        elif isinstance(data, list):
+            runs = data
+        else:
+            return None
+
+        if not isinstance(runs, list):
+            return None
+
+        return runs
+
+    def _aggregate_actions_runs(
+        self, runs: list[dict[str, Any]],
+    ) -> ForgeCIStatus:
+        """Aggregate Gitea Actions workflow runs into a ForgeCIStatus.
+
+        Groups by workflow name, keeps only the latest run per workflow.
+        """
+        if not runs:
+            return ForgeCIStatus(
+                status="unknown", message="No Actions runs found",
+            )
+
+        latest_by_name: dict[str, dict[str, Any]] = {}
+        for run in runs:
+            if not isinstance(run, dict):
+                continue
+            name = run.get("name", "Unknown")
+            if name not in latest_by_name:
+                latest_by_name[name] = run
+
+        failed_runs: list[str] = []
+        for name, run in latest_by_name.items():
+            status = run.get("status", "").lower()
+            conclusion = run.get("conclusion", "").lower()
+
+            # If not completed, skip (pending)
+            if status in self._ACTIONS_PENDING_STATUSES:
+                continue
+
+            if conclusion in self._ACTIONS_FAILURE:
+                failed_runs.append(name)
+
+        total = len(latest_by_name)
+        if failed_runs:
+            return ForgeCIStatus(
+                status="failing",
+                failed_runs=failed_runs,
+                total_runs=total,
+                message=f"CI failing: {len(failed_runs)} workflow(s) failed",
+            )
+
+        return ForgeCIStatus(
+            status="passing",
+            total_runs=total,
+            message="CI passing",
+        )
+
+    def _merge_ci_results(
+        self,
+        commit_result: ForgeCIStatus,
+        actions_result: ForgeCIStatus | None,
+    ) -> ForgeCIStatus:
+        """Merge commit status and Actions run results.
+
+        If both sources are available, combines them. If either source
+        reports failure, the merged result is failing.
+        """
+        if actions_result is None or actions_result.status == "unknown":
+            return commit_result
+        if commit_result.status == "unknown":
+            return actions_result
+
+        # Merge: combine failed runs and total counts
+        all_failed = list(set(commit_result.failed_runs + actions_result.failed_runs))
+        total = commit_result.total_runs + actions_result.total_runs
+
+        if all_failed:
+            return ForgeCIStatus(
+                status="failing",
+                failed_runs=all_failed,
+                total_runs=total,
+                message=f"CI failing: {len(all_failed)} check(s) failed",
+            )
+
+        return ForgeCIStatus(
+            status="passing",
+            total_runs=total,
+            message="CI passing",
+        )
+
+    def get_default_branch_ci_status(self) -> ForgeCIStatus:
+        """Get CI status for the latest commit on the default branch.
+
+        Queries both commit statuses and Gitea Actions runs (if available).
+        Gitea Actions API (1.19+) is feature-detected via 404 fallback.
+        """
+        default_branch = self.get_repo_default_branch()
+        if not default_branch:
+            return ForgeCIStatus(
+                status="unknown", message="Cannot determine default branch",
+            )
+        return self.get_commit_ci_status(default_branch)
+
+    def get_commit_ci_status(self, sha: str) -> ForgeCIStatus:
+        """Get CI status for a specific commit or ref.
+
+        Queries both commit statuses and Gitea Actions runs (if available),
+        then merges the results. Handles Gitea version differences by
+        gracefully falling back when Actions API returns 404.
+        """
+        rp = self._repo_path()
+        if not rp:
+            return ForgeCIStatus(
+                status="unknown", message="Cannot determine repository",
+            )
+
+        # 1. Fetch commit statuses (available in all Gitea versions)
+        resp = self._request(
+            "GET", f"{rp}/commits/{sha}/statuses",
+        )
+
+        commit_statuses: list[dict[str, Any]] = []
+        if resp is not None:
+            try:
+                data = resp.json()
+                if isinstance(data, list):
+                    commit_statuses = data
+            except ValueError:
+                pass
+
+        commit_result = self._aggregate_commit_statuses(commit_statuses)
+
+        # 2. Try Gitea Actions runs (1.19+, graceful 404 fallback)
+        actions_runs = self._fetch_actions_runs(rp, sha)
+        actions_result: ForgeCIStatus | None = None
+        if actions_runs is not None:
+            actions_result = self._aggregate_actions_runs(actions_runs)
+
+        # 3. Merge both results
+        return self._merge_ci_results(commit_result, actions_result)
 
     # ------------------------------------------------------------------
     # Repository metadata

--- a/loom-tools/src/loom_tools/common/github.py
+++ b/loom-tools/src/loom_tools/common/github.py
@@ -563,6 +563,77 @@ class GitHubForge:
             message=raw.get("message", ""),
         )
 
+    def get_commit_ci_status(self, sha: str) -> ForgeCIStatus:
+        """Get CI status for a specific commit SHA.
+
+        Uses the GitHub Check Runs API and combined commit status API.
+        """
+        nwo = self.get_repo_nwo()
+        if not nwo:
+            return ForgeCIStatus(
+                status="unknown", message="Cannot determine repository",
+            )
+
+        failed_runs: list[str] = []
+        total_checks = 0
+
+        # 1. Check Runs API (GitHub Actions results)
+        check_result = gh_api_rest(
+            f"repos/{nwo}/commits/{sha}/check-runs", cwd=self._cwd,
+        )
+        if check_result.returncode == 0 and check_result.stdout.strip():
+            data = safe_parse_json(check_result.stdout)
+            if isinstance(data, dict):
+                check_runs = data.get("check_runs", [])
+                if isinstance(check_runs, list):
+                    for cr in check_runs:
+                        if not isinstance(cr, dict):
+                            continue
+                        total_checks += 1
+                        conclusion = (cr.get("conclusion") or "").lower()
+                        if conclusion in (
+                            "failure", "timed_out", "cancelled", "action_required",
+                        ):
+                            failed_runs.append(cr.get("name", "Unknown"))
+
+        # 2. Combined commit status API (older commit statuses)
+        status_result = gh_api_rest(
+            f"repos/{nwo}/commits/{sha}/status", cwd=self._cwd,
+        )
+        if status_result.returncode == 0 and status_result.stdout.strip():
+            data = safe_parse_json(status_result.stdout)
+            if isinstance(data, dict):
+                statuses = data.get("statuses", [])
+                if isinstance(statuses, list):
+                    for s in statuses:
+                        if not isinstance(s, dict):
+                            continue
+                        total_checks += 1
+                        state = (s.get("state") or "").lower()
+                        if state in ("failure", "error"):
+                            ctx = s.get("context", "Unknown")
+                            failed_runs.append(ctx)
+
+        if total_checks == 0:
+            return ForgeCIStatus(
+                status="unknown",
+                message=f"No CI checks found for {sha[:8]}",
+            )
+
+        if failed_runs:
+            return ForgeCIStatus(
+                status="failing",
+                failed_runs=failed_runs,
+                total_runs=total_checks,
+                message=f"CI failing: {len(failed_runs)} check(s) failed for {sha[:8]}",
+            )
+
+        return ForgeCIStatus(
+            status="passing",
+            total_runs=total_checks,
+            message=f"CI passing for {sha[:8]}",
+        )
+
     # --- Repository metadata (ForgeClient) ---
 
     def get_repo_nwo(self) -> str | None:

--- a/loom-tools/src/loom_tools/snapshot.py
+++ b/loom-tools/src/loom_tools/snapshot.py
@@ -28,6 +28,7 @@ from typing import Any, Sequence
 
 import shutil
 
+from loom_tools.common.forge import get_forge
 from loom_tools.common.github import gh_parallel_queries, gh_get_default_branch_ci_status
 from loom_tools.common.issue_failures import load_failure_log, IssueFailureLog
 from loom_tools.common.logging import log_info, log_warning
@@ -343,7 +344,15 @@ def collect_pipeline_data(
     if ci_health_check_enabled:
         workflows_dir = repo_root / ".github" / "workflows"
         if workflows_dir.is_dir() and any(workflows_dir.iterdir()):
-            ci_status = gh_get_default_branch_ci_status()
+            # Use forge-agnostic CI status (works for both GitHub and Gitea)
+            forge = get_forge()
+            forge_ci = forge.get_default_branch_ci_status()
+            ci_status = {
+                "status": forge_ci.status,
+                "failed_runs": forge_ci.failed_runs,
+                "total_runs": forge_ci.total_runs,
+                "message": forge_ci.message,
+            }
         else:
             ci_status = {"status": "no_ci", "message": "No CI workflows configured (.github/workflows/ not found)"}
 

--- a/loom-tools/tests/test_forge.py
+++ b/loom-tools/tests/test_forge.py
@@ -260,6 +260,9 @@ class MockForgeClient:
     def get_default_branch_ci_status(self) -> ForgeCIStatus:
         return ForgeCIStatus(status="passing")
 
+    def get_commit_ci_status(self, sha: str) -> ForgeCIStatus:
+        return ForgeCIStatus(status="passing")
+
     # --- Repository metadata ---
 
     def get_repo_nwo(self) -> str | None:

--- a/loom-tools/tests/test_gitea.py
+++ b/loom-tools/tests/test_gitea.py
@@ -534,22 +534,25 @@ class TestStateNormalization:
 
 
 class TestCIStatus:
-    """Tests for get_default_branch_ci_status()."""
+    """Tests for get_default_branch_ci_status() and get_commit_ci_status()."""
 
     def test_passing(self) -> None:
         forge = _make_forge()
-        # First call: get repo info (default branch), second: statuses
+        # First call: get repo info (default branch), second: commit statuses,
+        # third: actions runs (404 = not available)
         repo_resp = _mock_response(json_data={"default_branch": "main"})
         statuses_resp = _mock_response(json_data=[
             {"context": "ci/test", "status": "success"},
             {"context": "ci/lint", "status": "success"},
         ])
-        with mock.patch.object(forge._session, "request", side_effect=[repo_resp, statuses_resp]):
+        actions_resp = _mock_response(404)  # Actions API not available
+        with mock.patch.object(forge._session, "request", side_effect=[repo_resp, statuses_resp, actions_resp]):
             result = forge.get_default_branch_ci_status()
 
         assert isinstance(result, ForgeCIStatus)
         assert result.status == "passing"
         assert result.failed_runs == []
+        assert result.total_runs == 2
 
     def test_failing(self) -> None:
         forge = _make_forge()
@@ -558,10 +561,256 @@ class TestCIStatus:
             {"context": "ci/test", "status": "failure"},
             {"context": "ci/lint", "status": "success"},
         ]
-        with mock.patch.object(forge._session, "request", return_value=_mock_response(json_data=statuses)):
+        actions_resp = _mock_response(404)
+        with mock.patch.object(forge._session, "request", side_effect=[
+            _mock_response(json_data=statuses),
+            actions_resp,
+        ]):
             result = forge.get_default_branch_ci_status()
         assert result.status == "failing"
         assert "ci/test" in result.failed_runs
+
+    def test_error_status_treated_as_failure(self) -> None:
+        """Gitea 'error' status maps to failure."""
+        forge = _make_forge()
+        forge._default_branch_cache = "main"
+        statuses = [{"context": "ci/deploy", "status": "error"}]
+        with mock.patch.object(forge._session, "request", side_effect=[
+            _mock_response(json_data=statuses),
+            _mock_response(404),
+        ]):
+            result = forge.get_default_branch_ci_status()
+        assert result.status == "failing"
+        assert "ci/deploy" in result.failed_runs
+
+    def test_warning_status_treated_as_pending(self) -> None:
+        """Gitea 'warning' status maps to pending (not failure)."""
+        forge = _make_forge()
+        forge._default_branch_cache = "main"
+        statuses = [{"context": "ci/check", "status": "warning"}]
+        with mock.patch.object(forge._session, "request", side_effect=[
+            _mock_response(json_data=statuses),
+            _mock_response(404),
+        ]):
+            result = forge.get_default_branch_ci_status()
+        assert result.status == "passing"
+        assert result.failed_runs == []
+        assert "pending" in result.message.lower()
+
+    def test_pending_status(self) -> None:
+        """Gitea 'pending' status is not treated as failure."""
+        forge = _make_forge()
+        forge._default_branch_cache = "main"
+        statuses = [
+            {"context": "ci/test", "status": "pending"},
+            {"context": "ci/lint", "status": "success"},
+        ]
+        with mock.patch.object(forge._session, "request", side_effect=[
+            _mock_response(json_data=statuses),
+            _mock_response(404),
+        ]):
+            result = forge.get_default_branch_ci_status()
+        assert result.status == "passing"
+        assert result.failed_runs == []
+
+    def test_empty_statuses_returns_unknown(self) -> None:
+        """Empty status list returns unknown."""
+        forge = _make_forge()
+        forge._default_branch_cache = "main"
+        with mock.patch.object(forge._session, "request", side_effect=[
+            _mock_response(json_data=[]),
+            _mock_response(404),
+        ]):
+            result = forge.get_default_branch_ci_status()
+        assert result.status == "unknown"
+
+    def test_no_ci_configured(self) -> None:
+        """API error on status fetch returns unknown."""
+        forge = _make_forge()
+        forge._default_branch_cache = "main"
+        with mock.patch.object(forge._session, "request", side_effect=[
+            _mock_response(json_data=[]),  # empty statuses
+            _mock_response(404),  # no actions
+        ]):
+            result = forge.get_default_branch_ci_status()
+        assert result.status == "unknown"
+
+    def test_latest_status_per_context(self) -> None:
+        """Only the latest status per context is used."""
+        forge = _make_forge()
+        forge._default_branch_cache = "main"
+        # First in list is latest; ci/test succeeded after previous failure
+        statuses = [
+            {"context": "ci/test", "status": "success"},
+            {"context": "ci/test", "status": "failure"},  # older, ignored
+        ]
+        with mock.patch.object(forge._session, "request", side_effect=[
+            _mock_response(json_data=statuses),
+            _mock_response(404),
+        ]):
+            result = forge.get_default_branch_ci_status()
+        assert result.status == "passing"
+        assert result.total_runs == 1
+
+    def test_cannot_determine_default_branch(self) -> None:
+        """Returns unknown when default branch cannot be determined."""
+        forge = _make_forge()
+        with mock.patch.object(forge._session, "request", return_value=_mock_response(500)):
+            result = forge.get_default_branch_ci_status()
+        assert result.status == "unknown"
+
+
+class TestCIStatusActionsRuns:
+    """Tests for Gitea Actions runs integration."""
+
+    def test_actions_runs_passing(self) -> None:
+        """Actions runs that pass contribute to passing status."""
+        forge = _make_forge()
+        forge._default_branch_cache = "main"
+        statuses = []  # No commit statuses
+        actions = {"workflow_runs": [
+            {"name": "CI", "status": "completed", "conclusion": "success"},
+            {"name": "Lint", "status": "completed", "conclusion": "success"},
+        ]}
+        with mock.patch.object(forge._session, "request", side_effect=[
+            _mock_response(json_data=statuses),
+            _mock_response(json_data=actions),
+        ]):
+            result = forge.get_default_branch_ci_status()
+        assert result.status == "passing"
+        assert result.total_runs == 2
+
+    def test_actions_runs_failing(self) -> None:
+        """Failed Actions runs are reported as failures."""
+        forge = _make_forge()
+        forge._default_branch_cache = "main"
+        statuses = []
+        actions = {"workflow_runs": [
+            {"name": "CI", "status": "completed", "conclusion": "failure"},
+            {"name": "Lint", "status": "completed", "conclusion": "success"},
+        ]}
+        with mock.patch.object(forge._session, "request", side_effect=[
+            _mock_response(json_data=statuses),
+            _mock_response(json_data=actions),
+        ]):
+            result = forge.get_default_branch_ci_status()
+        assert result.status == "failing"
+        assert "CI" in result.failed_runs
+
+    def test_actions_cancelled_treated_as_failure(self) -> None:
+        """Cancelled Actions runs are treated as failures."""
+        forge = _make_forge()
+        forge._default_branch_cache = "main"
+        actions = {"workflow_runs": [
+            {"name": "Deploy", "status": "completed", "conclusion": "cancelled"},
+        ]}
+        with mock.patch.object(forge._session, "request", side_effect=[
+            _mock_response(json_data=[]),
+            _mock_response(json_data=actions),
+        ]):
+            result = forge.get_default_branch_ci_status()
+        assert result.status == "failing"
+        assert "Deploy" in result.failed_runs
+
+    def test_actions_in_progress_not_counted(self) -> None:
+        """In-progress Actions runs are not counted as failures."""
+        forge = _make_forge()
+        forge._default_branch_cache = "main"
+        actions = {"workflow_runs": [
+            {"name": "CI", "status": "running", "conclusion": ""},
+        ]}
+        with mock.patch.object(forge._session, "request", side_effect=[
+            _mock_response(json_data=[]),
+            _mock_response(json_data=actions),
+        ]):
+            result = forge.get_default_branch_ci_status()
+        assert result.status == "passing"
+
+    def test_actions_api_404_fallback(self) -> None:
+        """When Actions API returns 404, falls back to commit statuses only."""
+        forge = _make_forge()
+        forge._default_branch_cache = "main"
+        statuses = [{"context": "ci/test", "status": "success"}]
+        with mock.patch.object(forge._session, "request", side_effect=[
+            _mock_response(json_data=statuses),
+            _mock_response(404),  # Actions API not available
+        ]):
+            result = forge.get_default_branch_ci_status()
+        assert result.status == "passing"
+        assert result.total_runs == 1
+
+    def test_merge_commit_statuses_and_actions(self) -> None:
+        """Both commit statuses and Actions runs are merged."""
+        forge = _make_forge()
+        forge._default_branch_cache = "main"
+        statuses = [{"context": "external/check", "status": "success"}]
+        actions = {"workflow_runs": [
+            {"name": "CI", "status": "completed", "conclusion": "success"},
+        ]}
+        with mock.patch.object(forge._session, "request", side_effect=[
+            _mock_response(json_data=statuses),
+            _mock_response(json_data=actions),
+        ]):
+            result = forge.get_default_branch_ci_status()
+        assert result.status == "passing"
+        assert result.total_runs == 2  # 1 commit status + 1 actions run
+
+    def test_merge_with_failure_from_either_source(self) -> None:
+        """Failure from either source results in overall failure."""
+        forge = _make_forge()
+        forge._default_branch_cache = "main"
+        statuses = [{"context": "external/check", "status": "failure"}]
+        actions = {"workflow_runs": [
+            {"name": "CI", "status": "completed", "conclusion": "success"},
+        ]}
+        with mock.patch.object(forge._session, "request", side_effect=[
+            _mock_response(json_data=statuses),
+            _mock_response(json_data=actions),
+        ]):
+            result = forge.get_default_branch_ci_status()
+        assert result.status == "failing"
+        assert "external/check" in result.failed_runs
+
+    def test_actions_list_format(self) -> None:
+        """Handle Gitea Actions API returning a plain list instead of dict."""
+        forge = _make_forge()
+        forge._default_branch_cache = "main"
+        actions_list = [
+            {"name": "CI", "status": "completed", "conclusion": "success"},
+        ]
+        with mock.patch.object(forge._session, "request", side_effect=[
+            _mock_response(json_data=[]),
+            _mock_response(json_data=actions_list),
+        ]):
+            result = forge.get_default_branch_ci_status()
+        assert result.status == "passing"
+
+
+class TestGetCommitCIStatus:
+    """Tests for get_commit_ci_status() with specific SHA."""
+
+    def test_commit_status_for_sha(self) -> None:
+        """get_commit_ci_status queries the correct SHA."""
+        forge = _make_forge()
+        statuses = [{"context": "ci/test", "status": "success"}]
+        with mock.patch.object(forge._session, "request", side_effect=[
+            _mock_response(json_data=statuses),
+            _mock_response(404),
+        ]) as mock_req:
+            result = forge.get_commit_ci_status("abc123")
+
+        assert result.status == "passing"
+        # Verify the SHA was used in the URL
+        first_call_url = mock_req.call_args_list[0][1].get("url", "") or mock_req.call_args_list[0][0][1]
+        assert "abc123" in str(first_call_url) or "abc123" in str(mock_req.call_args_list[0])
+
+    def test_commit_status_no_repo(self) -> None:
+        """Returns unknown when repo cannot be determined."""
+        forge = _make_forge()
+        forge._nwo_cache = None
+        with mock.patch.object(forge, "get_repo_nwo", return_value=None):
+            result = forge.get_commit_ci_status("abc123")
+        assert result.status == "unknown"
 
 
 # ===========================================================================

--- a/loom-tools/tests/test_github.py
+++ b/loom-tools/tests/test_github.py
@@ -1097,6 +1097,114 @@ class TestGitHubForgeCIStatus:
         assert result.status == "passing"
         assert result.total_runs == 1
 
+    def test_get_commit_ci_status_passing(self) -> None:
+        """get_commit_ci_status returns passing when all checks pass."""
+        check_runs_data = json.dumps({
+            "check_runs": [
+                {"name": "CI", "conclusion": "success"},
+                {"name": "Lint", "conclusion": "success"},
+            ],
+        })
+        status_data = json.dumps({
+            "statuses": [
+                {"context": "coverage", "state": "success"},
+            ],
+        })
+        forge = GitHubForge()
+        with mock.patch("loom_tools.common.github.subprocess.run") as mock_run:
+            mock_run.return_value = mock.Mock(
+                returncode=0, stdout="git@github.com:owner/repo.git\n",
+            )
+            _reset_nwo_cache()
+            with mock.patch("loom_tools.common.github.gh_run") as mock_gh:
+                mock_gh.side_effect = [
+                    mock.Mock(returncode=0, stdout=check_runs_data, stderr=""),
+                    mock.Mock(returncode=0, stdout=status_data, stderr=""),
+                ]
+                result = forge.get_commit_ci_status("abc123def")
+        _reset_nwo_cache()
+
+        assert isinstance(result, ForgeCIStatus)
+        assert result.status == "passing"
+        assert result.total_runs == 3
+        assert result.failed_runs == []
+
+    def test_get_commit_ci_status_failing(self) -> None:
+        """get_commit_ci_status returns failing when a check fails."""
+        check_runs_data = json.dumps({
+            "check_runs": [
+                {"name": "CI", "conclusion": "failure"},
+                {"name": "Lint", "conclusion": "success"},
+            ],
+        })
+        status_data = json.dumps({"statuses": []})
+        forge = GitHubForge()
+        with mock.patch("loom_tools.common.github.subprocess.run") as mock_run:
+            mock_run.return_value = mock.Mock(
+                returncode=0, stdout="git@github.com:owner/repo.git\n",
+            )
+            _reset_nwo_cache()
+            with mock.patch("loom_tools.common.github.gh_run") as mock_gh:
+                mock_gh.side_effect = [
+                    mock.Mock(returncode=0, stdout=check_runs_data, stderr=""),
+                    mock.Mock(returncode=0, stdout=status_data, stderr=""),
+                ]
+                result = forge.get_commit_ci_status("abc123def")
+        _reset_nwo_cache()
+
+        assert result.status == "failing"
+        assert "CI" in result.failed_runs
+
+    def test_get_commit_ci_status_no_checks(self) -> None:
+        """get_commit_ci_status returns unknown when no checks found."""
+        forge = GitHubForge()
+        with mock.patch("loom_tools.common.github.subprocess.run") as mock_run:
+            mock_run.return_value = mock.Mock(
+                returncode=0, stdout="git@github.com:owner/repo.git\n",
+            )
+            _reset_nwo_cache()
+            with mock.patch("loom_tools.common.github.gh_run") as mock_gh:
+                mock_gh.side_effect = [
+                    mock.Mock(returncode=0, stdout=json.dumps({"check_runs": []}), stderr=""),
+                    mock.Mock(returncode=0, stdout=json.dumps({"statuses": []}), stderr=""),
+                ]
+                result = forge.get_commit_ci_status("abc123def")
+        _reset_nwo_cache()
+
+        assert result.status == "unknown"
+
+    def test_get_commit_ci_status_commit_status_error(self) -> None:
+        """Commit status 'error' state is treated as failure."""
+        forge = GitHubForge()
+        with mock.patch("loom_tools.common.github.subprocess.run") as mock_run:
+            mock_run.return_value = mock.Mock(
+                returncode=0, stdout="git@github.com:owner/repo.git\n",
+            )
+            _reset_nwo_cache()
+            with mock.patch("loom_tools.common.github.gh_run") as mock_gh:
+                mock_gh.side_effect = [
+                    mock.Mock(returncode=0, stdout=json.dumps({"check_runs": []}), stderr=""),
+                    mock.Mock(returncode=0, stdout=json.dumps({
+                        "statuses": [{"context": "deploy", "state": "error"}],
+                    }), stderr=""),
+                ]
+                result = forge.get_commit_ci_status("abc123def")
+        _reset_nwo_cache()
+
+        assert result.status == "failing"
+        assert "deploy" in result.failed_runs
+
+    def test_get_commit_ci_status_no_nwo(self) -> None:
+        """Returns unknown when repo NWO cannot be determined."""
+        forge = GitHubForge()
+        _reset_nwo_cache()
+        with mock.patch("loom_tools.common.github.subprocess.run") as mock_run:
+            mock_run.return_value = mock.Mock(returncode=1, stdout="")
+            result = forge.get_commit_ci_status("abc123")
+        _reset_nwo_cache()
+
+        assert result.status == "unknown"
+
 
 # ---------------------------------------------------------------------------
 # GitHubForge — repo metadata

--- a/loom-tools/tests/test_snapshot.py
+++ b/loom-tools/tests/test_snapshot.py
@@ -1286,19 +1286,25 @@ class TestCollectPipelineDataCiAutoDetect:
             result = collect_pipeline_data(repo, ci_health_check_enabled=True)
         assert result["ci_status"]["status"] == "no_ci"
 
-    def test_workflows_present_calls_gh(self, tmp_path: pathlib.Path) -> None:
-        """When .github/workflows/ has files, gh_get_default_branch_ci_status is called."""
+    def test_workflows_present_calls_forge(self, tmp_path: pathlib.Path) -> None:
+        """When .github/workflows/ has files, forge.get_default_branch_ci_status is called."""
+        from loom_tools.common.forge import ForgeCIStatus
+
         repo = tmp_path / "repo"
         wf_dir = repo / ".github" / "workflows"
         wf_dir.mkdir(parents=True)
         (wf_dir / "ci.yml").write_text("name: CI\n")
+
+        mock_forge = mock.MagicMock()
+        mock_forge.get_default_branch_ci_status.return_value = ForgeCIStatus(
+            status="passing", failed_runs=[], total_runs=1, message="CI passing",
+        )
         with mock.patch("loom_tools.snapshot.gh_parallel_queries") as mock_queries, \
              mock.patch("loom_tools.snapshot._collect_usage", return_value={}), \
-             mock.patch("loom_tools.snapshot.gh_get_default_branch_ci_status") as mock_ci:
+             mock.patch("loom_tools.snapshot.get_forge", return_value=mock_forge):
             mock_queries.return_value = [[] for _ in range(10)]
-            mock_ci.return_value = {"status": "passing", "failed_runs": [], "total_runs": 1, "message": "CI passing"}
             result = collect_pipeline_data(repo, ci_health_check_enabled=True)
-        mock_ci.assert_called_once()
+        mock_forge.get_default_branch_ci_status.assert_called_once()
         assert result["ci_status"]["status"] == "passing"
 
     def test_ci_disabled_skips_detection(self, tmp_path: pathlib.Path) -> None:
@@ -1309,10 +1315,10 @@ class TestCollectPipelineDataCiAutoDetect:
         (wf_dir / "ci.yml").write_text("name: CI\n")
         with mock.patch("loom_tools.snapshot.gh_parallel_queries") as mock_queries, \
              mock.patch("loom_tools.snapshot._collect_usage", return_value={}), \
-             mock.patch("loom_tools.snapshot.gh_get_default_branch_ci_status") as mock_ci:
+             mock.patch("loom_tools.snapshot.get_forge") as mock_get_forge:
             mock_queries.return_value = [[] for _ in range(10)]
             result = collect_pipeline_data(repo, ci_health_check_enabled=False)
-        mock_ci.assert_not_called()
+        mock_get_forge.assert_not_called()
         assert result["ci_status"]["status"] == "unknown"
 
 


### PR DESCRIPTION
Closes #3148

## Summary
- Add `get_commit_ci_status(sha)` method to `ForgeClient` protocol and both implementations
- Enhance `GiteaForge` CI status to query both commit statuses AND Gitea Actions runs (1.19+) with graceful 404 fallback
- Implement client-side aggregation of Gitea commit statuses (latest per context, worst-case overall)
- Map Gitea-specific status values correctly: `warning` -> pending, `error` -> failure, `cancelled` -> failure
- Update `snapshot.py` to use forge-agnostic `forge.get_default_branch_ci_status()` instead of `gh_get_default_branch_ci_status()` directly
- `GitHubForge.get_commit_ci_status()` uses both Check Runs API and combined Status API

## Acceptance Criteria Checklist
- [x] `ForgeClient` protocol includes `get_default_branch_ci_status()` and `get_commit_ci_status(sha)` methods
- [x] `GiteaForge` implements both methods using Gitea REST API
- [x] Commit statuses are aggregated client-side (latest per context, worst-case overall)
- [x] Gitea Actions runs API is queried when available (1.19+); graceful 404 fallback to commit-status-only mode
- [x] Status values are mapped correctly (see mapping table in issue)
- [x] `GitHubForge` wraps existing logic behind the same protocol methods
- [x] `snapshot.py` calls forge-agnostic CI status method instead of `gh_get_default_branch_ci_status()` directly
- [x] Return format matches current contract: `{status, failed_runs, total_runs, message}`
- [x] Tests with mocked HTTP responses for both Gitea commit statuses and Actions runs
- [x] Tests for version fallback (Actions API unavailable)
- [x] Tests for empty/no CI configured scenarios

## Test plan
- [x] 70 Gitea tests pass (including 20 new CI status tests)
- [x] 103 GitHub tests pass (including 5 new commit CI status tests)
- [x] 275 forge + snapshot tests pass (updated mock expectations)
- [x] All 448 affected tests pass