### PR TITLE
feat: add forge-agnostic shell script helpers for GitHub/Gitea support

### DIFF
--- a/defaults/scripts/check-ci-status.sh
+++ b/defaults/scripts/check-ci-status.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
-# check-ci-status.sh - Check GitHub Actions CI status for the latest main branch commit
+# check-ci-status.sh - Check CI status for the latest main branch commit
+#
+# Supports both GitHub and Gitea forges. Forge detection is automatic.
+# - GitHub: uses Check Runs API + commit status API
+# - Gitea: uses commit status API only (mapped to check-run shape)
 #
 # Usage:
 #   ./check-ci-status.sh [--commit SHA]
@@ -18,6 +22,7 @@
 #
 # Environment Variables:
 #   LOOM_CI_TIMEOUT - Timeout for API calls in seconds (default: 10)
+#   LOOM_FORGE_TYPE - Override forge detection ("github" or "gitea")
 #
 # Examples:
 #   ./check-ci-status.sh                    # Check HEAD status
@@ -33,6 +38,9 @@ set -euo pipefail
 # --- Configuration ---
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Source forge helpers for multi-forge support
+source "$SCRIPT_DIR/lib/forge-helpers.sh"
 
 # --- Color Output ---
 RED='\033[0;31m'
@@ -80,17 +88,27 @@ while [[ $# -gt 0 ]]; do
 done
 
 # --- Validation ---
-if ! command -v gh &>/dev/null; then
-    echo "Error: GitHub CLI (gh) is required but not installed" >&2
-    exit 3
-fi
-
 if ! command -v jq &>/dev/null; then
     echo "Error: jq is required but not installed" >&2
     exit 3
 fi
 
 cd "$WORKSPACE_ROOT"
+
+# Detect forge type
+forge_detect
+
+# For GitHub, we need the gh CLI
+if [[ "$FORGE_TYPE" == "github" ]] && ! command -v gh &>/dev/null; then
+    echo "Error: GitHub CLI (gh) is required but not installed" >&2
+    exit 3
+fi
+
+# Get repo NWO for forge API calls
+REPO_NWO="$(forge_get_repo_nwo)" || {
+    echo "Error: Could not determine repository" >&2
+    exit 3
+}
 
 # --- Get Commit SHA ---
 if [[ -z "$COMMIT" ]]; then
@@ -105,41 +123,21 @@ fi
 SHORT_SHA="${COMMIT:0:7}"
 
 # --- Fetch CI Status ---
-# Use GitHub CLI to get combined check status
-# This combines both status API and check runs API
+# Uses forge helpers to get combined check status from either GitHub or Gitea
 
 get_ci_status() {
     local commit="$1"
 
-    # Get check runs (GitHub Actions workflow runs)
+    # Get check runs (GitHub Actions / Gitea CI statuses mapped to check-run shape)
     local check_runs
-    check_runs=$(gh api "repos/{owner}/{repo}/commits/$commit/check-runs" \
-        --header "Accept: application/vnd.github+json" \
-        --jq '{
-            total_count: .total_count,
-            check_runs: [.check_runs[] | {
-                name: .name,
-                status: .status,
-                conclusion: .conclusion,
-                html_url: .html_url
-            }]
-        }' 2>/dev/null) || {
-        echo "Error: Failed to fetch check runs from GitHub API" >&2
+    check_runs=$(forge_get_check_runs "$REPO_NWO" "$commit") || {
+        echo "Error: Failed to fetch check runs from forge API" >&2
         return 1
     }
 
-    # Get combined status (commit status API - older checks)
+    # Get combined status (commit status API)
     local combined_status
-    combined_status=$(gh api "repos/{owner}/{repo}/commits/$commit/status" \
-        --header "Accept: application/vnd.github+json" \
-        --jq '{
-            state: .state,
-            statuses: [.statuses[] | {
-                context: .context,
-                state: .state,
-                target_url: .target_url
-            }]
-        }' 2>/dev/null) || {
+    combined_status=$(forge_get_commit_status "$REPO_NWO" "$commit") || {
         # Not critical if this fails - check runs are more important
         combined_status='{"state": "unknown", "statuses": []}'
     }

--- a/defaults/scripts/lib/forge-helpers.sh
+++ b/defaults/scripts/lib/forge-helpers.sh
@@ -1,0 +1,540 @@
+#!/usr/bin/env bash
+# forge-helpers.sh - Forge-agnostic helpers for shell scripts
+#
+# Provides forge detection and API dispatch functions that allow
+# Loom's shell scripts to work with both GitHub and Gitea.
+#
+# Usage:
+#   source "$(dirname "${BASH_SOURCE[0]}")/lib/forge-helpers.sh"
+#   forge_detect   # sets FORGE_TYPE to "github" or "gitea"
+#
+# Environment Variables:
+#   LOOM_FORGE_TYPE  - Override forge detection ("github" or "gitea")
+#   GITEA_TOKEN      - API token for Gitea authentication
+#   GITEA_URL        - Base URL for Gitea instance (e.g. "https://gitea.example.com")
+#
+# Forge detection priority:
+#   1. LOOM_FORGE_TYPE env var
+#   2. .loom/config.json forge.type (if not "auto")
+#   3. Auto-detect from git remote origin URL
+#   4. Default to "github"
+
+set -euo pipefail
+
+# --- Forge Detection ---
+
+# Global forge state (set by forge_detect)
+FORGE_TYPE=""
+_GITEA_BASE_URL=""
+_GITEA_TOKEN=""
+
+# Detect forge type from environment, config, or remote URL.
+# Sets FORGE_TYPE to "github" or "gitea".
+# For Gitea, also sets _GITEA_BASE_URL and _GITEA_TOKEN.
+forge_detect() {
+  # Already detected
+  if [[ -n "$FORGE_TYPE" ]]; then
+    return 0
+  fi
+
+  # 1. Environment variable override
+  local env_val="${LOOM_FORGE_TYPE:-}"
+  if [[ -n "$env_val" ]]; then
+    local env_lower
+    env_lower=$(echo "$env_val" | tr '[:upper:]' '[:lower:]')
+    case "$env_lower" in
+      github) FORGE_TYPE="github"; return 0 ;;
+      gitea)  FORGE_TYPE="gitea"; _load_gitea_config; return 0 ;;
+    esac
+  fi
+
+  # 2. Config file
+  local config_file
+  if [[ -n "${REPO_ROOT:-}" ]]; then
+    config_file="$REPO_ROOT/.loom/config.json"
+  elif [[ -n "${WORKSPACE_ROOT:-}" ]]; then
+    config_file="$WORKSPACE_ROOT/.loom/config.json"
+  else
+    config_file=".loom/config.json"
+  fi
+
+  if [[ -f "$config_file" ]] && command -v jq &>/dev/null; then
+    local config_type
+    config_type=$(jq -r '.forge.type // "auto"' "$config_file" 2>/dev/null || echo "auto")
+    local config_lower
+    config_lower=$(echo "$config_type" | tr '[:upper:]' '[:lower:]')
+    case "$config_lower" in
+      github) FORGE_TYPE="github"; return 0 ;;
+      gitea)  FORGE_TYPE="gitea"; _load_gitea_config; return 0 ;;
+    esac
+  fi
+
+  # 3. Auto-detect from git remote URL
+  local remote_url
+  remote_url=$(git remote get-url origin 2>/dev/null || echo "")
+  if [[ -n "$remote_url" ]]; then
+    local host
+    host=$(_extract_host "$remote_url")
+    if [[ "$host" == "github.com" ]]; then
+      FORGE_TYPE="github"
+      return 0
+    fi
+    # Check if host matches configured Gitea URL
+    if [[ -f "$config_file" ]] && command -v jq &>/dev/null; then
+      local gitea_url
+      gitea_url=$(jq -r '.forge.gitea.url // ""' "$config_file" 2>/dev/null || echo "")
+      if [[ -n "$gitea_url" ]]; then
+        local gitea_host
+        gitea_host=$(_extract_host "$gitea_url")
+        if [[ "$host" == "$gitea_host" ]]; then
+          FORGE_TYPE="gitea"
+          _load_gitea_config
+          return 0
+        fi
+      fi
+    fi
+  fi
+
+  # 4. Default to GitHub
+  FORGE_TYPE="github"
+}
+
+# Extract hostname from a URL (SSH or HTTPS)
+_extract_host() {
+  local url="$1"
+  # SSH: git@host:owner/repo.git
+  if [[ "$url" =~ ^git@([^:]+): ]]; then
+    echo "${BASH_REMATCH[1]}"
+    return
+  fi
+  # HTTPS: https://host/...
+  if [[ "$url" =~ ^https?://([^/]+) ]]; then
+    echo "${BASH_REMATCH[1]}"
+    return
+  fi
+  echo ""
+}
+
+# Load Gitea configuration (URL and token)
+_load_gitea_config() {
+  # Token: env var first, then config
+  _GITEA_TOKEN="${GITEA_TOKEN:-}"
+
+  # URL: env var first, then config
+  _GITEA_BASE_URL="${GITEA_URL:-}"
+
+  local config_file
+  if [[ -n "${REPO_ROOT:-}" ]]; then
+    config_file="$REPO_ROOT/.loom/config.json"
+  elif [[ -n "${WORKSPACE_ROOT:-}" ]]; then
+    config_file="$WORKSPACE_ROOT/.loom/config.json"
+  else
+    config_file=".loom/config.json"
+  fi
+
+  if [[ -f "$config_file" ]] && command -v jq &>/dev/null; then
+    if [[ -z "$_GITEA_TOKEN" ]]; then
+      _GITEA_TOKEN=$(jq -r '.forge.gitea.token // ""' "$config_file" 2>/dev/null || echo "")
+    fi
+    if [[ -z "$_GITEA_BASE_URL" ]]; then
+      _GITEA_BASE_URL=$(jq -r '.forge.gitea.url // ""' "$config_file" 2>/dev/null || echo "")
+    fi
+  fi
+
+  _GITEA_BASE_URL="${_GITEA_BASE_URL%/}"  # strip trailing slash
+}
+
+# --- Gitea API Helper ---
+
+# Make a Gitea API request using curl.
+# Usage: gitea_api METHOD path [curl-args...]
+# Returns: response body on stdout, exit code 0 on 2xx, 1 on error
+gitea_api() {
+  local method="$1"
+  local path="$2"
+  shift 2
+
+  if [[ -z "$_GITEA_BASE_URL" ]]; then
+    echo "Error: Gitea base URL not configured" >&2
+    return 1
+  fi
+  if [[ -z "$_GITEA_TOKEN" ]]; then
+    echo "Error: Gitea token not configured" >&2
+    return 1
+  fi
+
+  local url="${_GITEA_BASE_URL}/api/v1/${path#/}"
+  local http_code
+  local response
+
+  response=$(curl -s -w "\n%{http_code}" \
+    -X "$method" \
+    -H "Authorization: token $_GITEA_TOKEN" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json" \
+    "$@" \
+    "$url" 2>/dev/null)
+
+  http_code=$(echo "$response" | tail -1)
+  local body
+  body=$(echo "$response" | sed '$d')
+
+  if [[ "$http_code" -ge 200 && "$http_code" -lt 300 ]]; then
+    echo "$body"
+    return 0
+  else
+    echo "$body" >&2
+    return 1
+  fi
+}
+
+# --- Owner/Repo Helpers ---
+
+# Extract owner and repo from NWO (name-with-owner) string.
+# Usage: forge_split_nwo "owner/repo"
+# Outputs: sets FORGE_OWNER and FORGE_REPO
+forge_split_nwo() {
+  local nwo="$1"
+  FORGE_OWNER="${nwo%%/*}"
+  FORGE_REPO="${nwo#*/}"
+}
+
+# --- Forge-Dispatched Operations ---
+
+# Merge a PR via the forge API.
+# Usage: forge_merge_pr NWO PR_NUMBER
+# GitHub: PUT /repos/{nwo}/pulls/{n}/merge with merge_method=squash
+# Gitea: POST /repos/{owner}/{repo}/pulls/{n}/merge with Do=squash
+forge_merge_pr() {
+  local nwo="$1"
+  local pr_number="$2"
+
+  if [[ "$FORGE_TYPE" == "gitea" ]]; then
+    forge_split_nwo "$nwo"
+    gitea_api POST "repos/$FORGE_OWNER/$FORGE_REPO/pulls/$pr_number/merge" \
+      -d '{"Do":"squash","delete_branch_after_merge":false}'
+  else
+    gh api "repos/$nwo/pulls/$pr_number/merge" \
+      -X PUT \
+      -f merge_method=squash 2>&1
+  fi
+}
+
+# Update a PR branch (rebase on base branch).
+# Usage: forge_update_branch NWO PR_NUMBER
+# GitHub: PUT /repos/{nwo}/pulls/{n}/update-branch
+# Gitea: POST /repos/{owner}/{repo}/pulls/{n}/update
+forge_update_branch() {
+  local nwo="$1"
+  local pr_number="$2"
+
+  if [[ "$FORGE_TYPE" == "gitea" ]]; then
+    forge_split_nwo "$nwo"
+    gitea_api POST "repos/$FORGE_OWNER/$FORGE_REPO/pulls/$pr_number/update"
+  else
+    gh api "repos/$nwo/pulls/$pr_number/update-branch" -X PUT 2>&1
+  fi
+}
+
+# Get PR details.
+# Usage: forge_get_pr NWO PR_NUMBER
+# Returns JSON with .state, .merged, .head.ref, .title, .mergeable
+forge_get_pr() {
+  local nwo="$1"
+  local pr_number="$2"
+  local gh_cmd="${3:-gh}"
+
+  if [[ "$FORGE_TYPE" == "gitea" ]]; then
+    forge_split_nwo "$nwo"
+    gitea_api GET "repos/$FORGE_OWNER/$FORGE_REPO/pulls/$pr_number"
+  else
+    "$gh_cmd" api "repos/$nwo/pulls/$pr_number" 2>/dev/null
+  fi
+}
+
+# Get PR details without cache (for race-condition rechecks).
+# Usage: forge_get_pr_nocache NWO PR_NUMBER
+forge_get_pr_nocache() {
+  local nwo="$1"
+  local pr_number="$2"
+  local gh_cmd="${3:-gh}"
+
+  if [[ "$FORGE_TYPE" == "gitea" ]]; then
+    # Gitea has no caching layer like gh-cached
+    forge_get_pr "$nwo" "$pr_number"
+  else
+    "$gh_cmd" --no-cache api "repos/$nwo/pulls/$pr_number" 2>/dev/null
+  fi
+}
+
+# Check if repo auto-deletes branches on merge.
+# Usage: forge_check_auto_delete NWO
+# Returns: "true" or "false" on stdout
+forge_check_auto_delete() {
+  local nwo="$1"
+  local gh_cmd="${2:-gh}"
+
+  if [[ "$FORGE_TYPE" == "gitea" ]]; then
+    forge_split_nwo "$nwo"
+    local repo_json
+    repo_json=$(gitea_api GET "repos/$FORGE_OWNER/$FORGE_REPO" 2>/dev/null) || {
+      echo "false"
+      return
+    }
+    echo "$repo_json" | jq -r '.default_delete_branch_after_merge // false'
+  else
+    "$gh_cmd" api "repos/$nwo" --jq '.delete_branch_on_merge' 2>/dev/null || echo "false"
+  fi
+}
+
+# Delete a remote branch.
+# Usage: forge_delete_branch NWO BRANCH_NAME
+# GitHub: DELETE /repos/{nwo}/git/refs/heads/{branch}
+# Gitea: DELETE /repos/{owner}/{repo}/branches/{branch}
+forge_delete_branch() {
+  local nwo="$1"
+  local branch="$2"
+
+  if [[ "$FORGE_TYPE" == "gitea" ]]; then
+    forge_split_nwo "$nwo"
+    gitea_api DELETE "repos/$FORGE_OWNER/$FORGE_REPO/branches/$branch" 2>/dev/null
+  else
+    gh api "repos/$nwo/git/refs/heads/$branch" -X DELETE 2>/dev/null
+  fi
+}
+
+# Enable auto-merge on a PR.
+# Usage: forge_auto_merge NWO PR_NUMBER
+# GitHub: gh pr merge --auto --squash --delete-branch
+# Gitea: POST /repos/{owner}/{repo}/pulls/{n}/merge with merge_when_checks_succeed
+forge_auto_merge() {
+  local nwo="$1"
+  local pr_number="$2"
+
+  if [[ "$FORGE_TYPE" == "gitea" ]]; then
+    forge_split_nwo "$nwo"
+    gitea_api POST "repos/$FORGE_OWNER/$FORGE_REPO/pulls/$pr_number/merge" \
+      -d '{"Do":"squash","merge_when_checks_succeed":true,"delete_branch_after_merge":true}'
+  else
+    gh pr merge "$pr_number" --auto --squash --delete-branch 2>/dev/null
+  fi
+}
+
+# --- CI Status Helpers ---
+
+# Get CI check runs for a commit.
+# Usage: forge_get_check_runs NWO COMMIT_SHA
+# GitHub: GET /repos/{nwo}/commits/{sha}/check-runs
+# Gitea: GET /repos/{owner}/{repo}/commits/{sha}/statuses (mapped to check-run shape)
+forge_get_check_runs() {
+  local nwo="$1"
+  local commit="$2"
+
+  if [[ "$FORGE_TYPE" == "gitea" ]]; then
+    forge_split_nwo "$nwo"
+    local statuses
+    statuses=$(gitea_api GET "repos/$FORGE_OWNER/$FORGE_REPO/commits/$commit/statuses" 2>/dev/null) || {
+      echo '{"total_count":0,"check_runs":[]}'
+      return 1
+    }
+
+    # Map Gitea commit statuses to GitHub check-run shape.
+    # Gitea status field: pending, success, error, failure, warning
+    # GitHub check run: status=completed/queued/in_progress, conclusion=success/failure/...
+    echo "$statuses" | jq '{
+      total_count: (. | length),
+      check_runs: [.[] | {
+        name: .context,
+        status: (if .status == "pending" then "queued"
+                 else "completed" end),
+        conclusion: (if .status == "success" then "success"
+                     elif .status == "failure" then "failure"
+                     elif .status == "error" then "failure"
+                     elif .status == "warning" then "neutral"
+                     elif .status == "pending" then null
+                     else null end),
+        html_url: .target_url
+      }]
+    }'
+  else
+    gh api "repos/$nwo/commits/$commit/check-runs" \
+      --header "Accept: application/vnd.github+json" \
+      --jq '{
+        total_count: .total_count,
+        check_runs: [.check_runs[] | {
+          name: .name,
+          status: .status,
+          conclusion: .conclusion,
+          html_url: .html_url
+        }]
+      }' 2>/dev/null
+  fi
+}
+
+# Get combined commit status.
+# Usage: forge_get_commit_status NWO COMMIT_SHA
+# Both forges support GET /repos/{nwo}/commits/{sha}/status
+forge_get_commit_status() {
+  local nwo="$1"
+  local commit="$2"
+
+  if [[ "$FORGE_TYPE" == "gitea" ]]; then
+    forge_split_nwo "$nwo"
+    local status_json
+    status_json=$(gitea_api GET "repos/$FORGE_OWNER/$FORGE_REPO/commits/$commit/status" 2>/dev/null) || {
+      echo '{"state": "unknown", "statuses": []}'
+      return 0
+    }
+    # Map Gitea's "warning" state to "pending" for compatibility
+    echo "$status_json" | jq '{
+      state: (if .state == "warning" then "pending" else .state end),
+      statuses: [(.statuses // [])[] | {
+        context: .context,
+        state: .state,
+        target_url: .target_url
+      }]
+    }'
+  else
+    gh api "repos/$nwo/commits/$commit/status" \
+      --header "Accept: application/vnd.github+json" \
+      --jq '{
+        state: .state,
+        statuses: [.statuses[] | {
+          context: .context,
+          state: .state,
+          target_url: .target_url
+        }]
+      }' 2>/dev/null
+  fi
+}
+
+# --- PR Listing Helpers ---
+
+# List merged PRs.
+# Usage: forge_list_merged_prs NWO LIMIT [DATE_FILTER]
+# GitHub: gh pr list --state merged
+# Gitea: GET /repos/{owner}/{repo}/pulls?state=closed + client-side merge filter
+forge_list_merged_prs() {
+  local nwo="$1"
+  local limit="$2"
+  local date_filter="${3:-}"
+
+  if [[ "$FORGE_TYPE" == "gitea" ]]; then
+    forge_split_nwo "$nwo"
+    local page=1
+    local per_page=50
+    local collected=0
+    local results="[]"
+
+    while [[ $collected -lt $limit ]]; do
+      local batch
+      batch=$(gitea_api GET "repos/$FORGE_OWNER/$FORGE_REPO/pulls?state=closed&sort=updated&limit=$per_page&page=$page" 2>/dev/null) || break
+
+      local batch_len
+      batch_len=$(echo "$batch" | jq 'length')
+      [[ "$batch_len" -eq 0 ]] && break
+
+      # Filter to merged PRs and optionally by date
+      local filtered
+      if [[ -n "$date_filter" ]]; then
+        filtered=$(echo "$batch" | jq --arg df "$date_filter" '[.[] | select(.merged == true and .merged_at != null and .merged_at >= $df) | {number: .number, mergedAt: .merged_at}]')
+      else
+        filtered=$(echo "$batch" | jq '[.[] | select(.merged == true) | {number: .number, mergedAt: .merged_at}]')
+      fi
+
+      local filtered_len
+      filtered_len=$(echo "$filtered" | jq 'length')
+      results=$(echo "$results" "$filtered" | jq -s '.[0] + .[1]')
+      collected=$(echo "$results" | jq 'length')
+
+      # If we got a full page, there may be more
+      [[ "$batch_len" -lt "$per_page" ]] && break
+      page=$((page + 1))
+
+      # Rate limiting protection for Gitea
+      sleep 0.2
+    done
+
+    # Trim to limit and output just the numbers
+    echo "$results" | jq -r ".[:$limit] | .[].number"
+  else
+    if [[ -n "$date_filter" ]]; then
+      gh pr list --state merged --limit "$limit" --json number,mergedAt \
+        --jq '[.[] | select(.mergedAt >= "'"$date_filter"'")] | .[].number' 2>/dev/null || echo ""
+    else
+      gh pr list --state merged --limit "$limit" --json number --jq '.[].number' 2>/dev/null || echo ""
+    fi
+  fi
+}
+
+# Get PR body.
+# Usage: forge_get_pr_body NWO PR_NUMBER
+forge_get_pr_body() {
+  local nwo="$1"
+  local pr_number="$2"
+
+  if [[ "$FORGE_TYPE" == "gitea" ]]; then
+    forge_split_nwo "$nwo"
+    gitea_api GET "repos/$FORGE_OWNER/$FORGE_REPO/pulls/$pr_number" 2>/dev/null | jq -r '.body // ""'
+  else
+    gh pr view "$pr_number" --json body --jq '.body // ""' 2>/dev/null || echo ""
+  fi
+}
+
+# Get PR comments.
+# Usage: forge_get_pr_comments NWO PR_NUMBER
+# GitHub: gh pr view --comments
+# Gitea: GET /repos/{owner}/{repo}/issues/{n}/comments (PRs use issue comment API)
+forge_get_pr_comments() {
+  local nwo="$1"
+  local pr_number="$2"
+
+  if [[ "$FORGE_TYPE" == "gitea" ]]; then
+    forge_split_nwo "$nwo"
+    gitea_api GET "repos/$FORGE_OWNER/$FORGE_REPO/issues/$pr_number/comments" 2>/dev/null | \
+      jq -r '.[].body // empty'
+  else
+    gh pr view "$pr_number" --comments --json comments --jq '.comments[].body' 2>/dev/null || echo ""
+  fi
+}
+
+# Get PR reviews.
+# Usage: forge_get_pr_reviews NWO PR_NUMBER
+# Both forges: GET /repos/{nwo}/pulls/{n}/reviews
+forge_get_pr_reviews() {
+  local nwo="$1"
+  local pr_number="$2"
+
+  if [[ "$FORGE_TYPE" == "gitea" ]]; then
+    forge_split_nwo "$nwo"
+    gitea_api GET "repos/$FORGE_OWNER/$FORGE_REPO/pulls/$pr_number/reviews" 2>/dev/null | \
+      jq -r '.[].body // empty'
+  else
+    gh api "repos/$nwo/pulls/$pr_number/reviews" --jq '.[].body // empty' 2>/dev/null || echo ""
+  fi
+}
+
+# Get repo NWO (name with owner).
+# Usage: forge_get_repo_nwo [GH_CMD]
+# Returns "owner/repo" on stdout.
+forge_get_repo_nwo() {
+  local gh_cmd="${1:-gh}"
+  local nwo
+
+  if [[ "$FORGE_TYPE" == "gitea" ]]; then
+    # Parse from git remote URL
+    local remote_url
+    remote_url=$(git remote get-url origin 2>/dev/null || echo "")
+    if [[ -n "$remote_url" ]]; then
+      nwo=$(echo "$remote_url" | sed -E 's|\.git$||; s|.*[:/]([^/]+/[^/]+)$|\1|')
+      echo "$nwo"
+      return 0
+    fi
+    return 1
+  else
+    # GitHub: try gh repo view, fallback to git remote
+    nwo=$("$gh_cmd" repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null) && [[ -n "$nwo" ]] && echo "$nwo" && return 0
+    nwo=$(git remote get-url origin 2>/dev/null | sed -E 's|\.git$||; s|.*[:/]([^/]+/[^/]+)$|\1|') && [[ -n "$nwo" ]] && echo "$nwo" && return 0
+    return 1
+  fi
+}

--- a/defaults/scripts/merge-pr.sh
+++ b/defaults/scripts/merge-pr.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
-# Loom PR Merge - Worktree-safe merge using GitHub API
+# Loom PR Merge - Worktree-safe merge using forge API (GitHub or Gitea)
 # Usage: ./.loom/scripts/merge-pr.sh <pr-number> [options]
 #
-# Merges a PR via the GitHub API (not `gh pr merge`) to avoid
+# Merges a PR via the forge API (not `gh pr merge`) to avoid
 # "already used by worktree" errors when merging from inside a worktree.
+#
+# Supports both GitHub and Gitea forges. Forge detection is automatic
+# (see forge-helpers.sh for details).
 #
 # Options:
 #   --no-cleanup-worktree  Skip local worktree cleanup after merge
@@ -61,30 +64,22 @@ find_main_repo_root() {
 REPO_ROOT="$(find_main_repo_root)" || \
   error "Not in a git repository"
 
+# Source forge helpers for multi-forge support
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/forge-helpers.sh"
+forge_detect
+
 # Use gh-cached for read-only queries to reduce API calls (see issue #1609)
 # Verify the Python interpreter works too — a broken runtime (e.g. unaccepted
 # Xcode license) would make every subsequent gh call fail with a misleading error.
 GH_CACHED="$REPO_ROOT/.loom/scripts/gh-cached"
-if [[ -x "$GH_CACHED" ]] && "$GH_CACHED" --version &>/dev/null; then
+if [[ "$FORGE_TYPE" == "github" ]] && [[ -x "$GH_CACHED" ]] && "$GH_CACHED" --version &>/dev/null; then
     GH="$GH_CACHED"
 else
     GH="gh"
 fi
 
-# Auto-detect owner/repo with fallback for worktree contexts
-# Primary: gh repo view (uses GitHub API, most reliable when authenticated)
-# Fallback: parse git remote URL (local operation, works when gh fails in worktrees)
-detect_repo_nwo() {
-  local nwo
-  # Try gh repo view first (works in most cases)
-  nwo="$($GH repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)" && [[ -n "$nwo" ]] && echo "$nwo" && return 0
-  # Fallback: parse origin remote URL from the main repo root
-  # Handles both HTTPS (https://github.com/owner/repo.git) and SSH (git@github.com:owner/repo.git)
-  nwo="$(cd "$REPO_ROOT" && git remote get-url origin 2>/dev/null | sed -E 's|\.git$||; s|.*[:/]([^/]+/[^/]+)$|\1|')" && [[ -n "$nwo" ]] && echo "$nwo" && return 0
-  return 1
-}
-
-REPO_NWO="$(detect_repo_nwo)" || \
+REPO_NWO="$(forge_get_repo_nwo "$GH")" || \
   error "Could not determine repository. Is 'gh' authenticated?"
 
 # Parse arguments
@@ -115,7 +110,7 @@ done
 [[ "$PR_NUMBER" =~ ^[0-9]+$ ]] || error "PR number must be numeric: $PR_NUMBER"
 
 # Fetch PR state
-PR_JSON=$($GH api "repos/$REPO_NWO/pulls/$PR_NUMBER" 2>/dev/null) || \
+PR_JSON=$(forge_get_pr "$REPO_NWO" "$PR_NUMBER" "$GH") || \
   error "Could not fetch PR #$PR_NUMBER"
 
 PR_STATE=$(echo "$PR_JSON" | jq -r '.state')
@@ -144,8 +139,7 @@ if [[ "$AUTO_MERGE" == "true" ]]; then
     info "[dry-run] Would enable auto-merge for PR #$PR_NUMBER"
     exit 0
   fi
-  # Use gh CLI for auto-merge (API for this requires GraphQL)
-  if gh pr merge "$PR_NUMBER" --auto --squash --delete-branch 2>/dev/null; then
+  if forge_auto_merge "$REPO_NWO" "$PR_NUMBER" 2>/dev/null; then
     success "Auto-merge enabled for PR #$PR_NUMBER"
     exit 0
   else
@@ -169,13 +163,11 @@ MAX_MERGE_RETRIES=3
 MERGE_RETRY_DELAY=5
 
 for MERGE_ATTEMPT in $(seq 1 $MAX_MERGE_RETRIES); do
-  MERGE_RESPONSE=$(gh api "repos/$REPO_NWO/pulls/$PR_NUMBER/merge" \
-    -X PUT \
-    -f merge_method=squash \
-    2>&1) && break  # Success, exit loop
+  MERGE_RESPONSE=$(forge_merge_pr "$REPO_NWO" "$PR_NUMBER" 2>&1) && break  # Success, exit loop
 
   # Check if it merged despite error (race condition)
-  RECHECK=$($GH --no-cache api "repos/$REPO_NWO/pulls/$PR_NUMBER" --jq '.merged' 2>/dev/null || echo "false")
+  RECHECK_JSON=$(forge_get_pr_nocache "$REPO_NWO" "$PR_NUMBER" "$GH" 2>/dev/null || echo '{}')
+  RECHECK=$(echo "$RECHECK_JSON" | jq -r '.merged // false')
   if [[ "$RECHECK" == "true" ]]; then
     warning "Merge reported error but PR is merged (race condition)"
     break
@@ -186,7 +178,8 @@ for MERGE_ATTEMPT in $(seq 1 $MAX_MERGE_RETRIES); do
   if echo "$MERGE_RESPONSE" | grep -q "Merge already in progress"; then
     info "Merge already in progress (HTTP 405), waiting for completion..."
     sleep 5
-    RECHECK=$($GH --no-cache api "repos/$REPO_NWO/pulls/$PR_NUMBER" --jq '.merged' 2>/dev/null || echo "false")
+    RECHECK_JSON=$(forge_get_pr_nocache "$REPO_NWO" "$PR_NUMBER" "$GH" 2>/dev/null || echo '{}')
+    RECHECK=$(echo "$RECHECK_JSON" | jq -r '.merged // false')
     if [[ "$RECHECK" == "true" ]]; then
       success "PR #$PR_NUMBER merged (concurrent merge completed)"
       break
@@ -201,10 +194,8 @@ for MERGE_ATTEMPT in $(seq 1 $MAX_MERGE_RETRIES); do
     if [[ $MERGE_ATTEMPT -lt $MAX_MERGE_RETRIES ]]; then
       info "Branch is behind base branch, updating... (attempt $MERGE_ATTEMPT/$MAX_MERGE_RETRIES)"
 
-      # Update branch via GitHub API
-      UPDATE_RESPONSE=$(gh api "repos/$REPO_NWO/pulls/$PR_NUMBER/update-branch" \
-        -X PUT \
-        2>&1) || {
+      # Update branch via forge API
+      UPDATE_RESPONSE=$(forge_update_branch "$REPO_NWO" "$PR_NUMBER" 2>&1) || {
         warning "Failed to update branch: $UPDATE_RESPONSE"
         # Continue to retry merge anyway - update may have partially succeeded
       }
@@ -226,7 +217,8 @@ for MERGE_ATTEMPT in $(seq 1 $MAX_MERGE_RETRIES); do
 done
 
 # Verify merge
-VERIFY_MERGED=$($GH --no-cache api "repos/$REPO_NWO/pulls/$PR_NUMBER" --jq '.merged' 2>/dev/null || echo "false")
+VERIFY_JSON=$(forge_get_pr_nocache "$REPO_NWO" "$PR_NUMBER" "$GH" 2>/dev/null || echo '{}')
+VERIFY_MERGED=$(echo "$VERIFY_JSON" | jq -r '.merged // false')
 if [[ "$VERIFY_MERGED" != "true" ]]; then
   error "Merge API call returned but PR #$PR_NUMBER is not merged"
 fi
@@ -237,13 +229,13 @@ success "PR #$PR_NUMBER merged successfully"
 # Labels on closed/merged items are harmless — all agents filter by open state.
 # See: https://github.com/rjwalters/loom/issues/2838
 
-# Delete remote branch (skip if GitHub auto-deletes on merge)
-DELETE_BRANCH_ON_MERGE=$($GH api "repos/$REPO_NWO" --jq '.delete_branch_on_merge' 2>/dev/null || echo "false")
+# Delete remote branch (skip if forge auto-deletes on merge)
+DELETE_BRANCH_ON_MERGE=$(forge_check_auto_delete "$REPO_NWO" "$GH")
 if [[ "$DELETE_BRANCH_ON_MERGE" == "true" ]]; then
-  info "Skipping branch deletion (GitHub auto-delete is enabled)"
+  info "Skipping branch deletion (auto-delete is enabled)"
 else
   info "Deleting remote branch: $PR_BRANCH"
-  gh api "repos/$REPO_NWO/git/refs/heads/$PR_BRANCH" -X DELETE 2>/dev/null && \
+  forge_delete_branch "$REPO_NWO" "$PR_BRANCH" && \
     success "Branch '$PR_BRANCH' deleted" || \
     warning "Could not delete branch '$PR_BRANCH' (may already be deleted)"
 fi

--- a/defaults/scripts/test-plan-metrics.sh
+++ b/defaults/scripts/test-plan-metrics.sh
@@ -2,6 +2,8 @@
 
 # test-plan-metrics.sh - Test plan execution metrics from Judge PR reviews
 #
+# Supports both GitHub and Gitea forges. Forge detection is automatic.
+#
 # Extracts and aggregates test plan execution data from Judge review comments
 # on merged PRs. The Judge documents test execution using a structured format
 # with emoji markers (✅ executed, ⚠️ observation-only, ⏭️ skipped).
@@ -43,6 +45,12 @@
 
 set -euo pipefail
 
+# --- Configuration ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source forge helpers for multi-forge support
+source "$SCRIPT_DIR/lib/forge-helpers.sh"
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -58,13 +66,10 @@ LIMIT=50
 REPO_SLUG=""
 
 # Cache repo slug to avoid repeated API calls
-# Uses gh repo view with fallback to git remote URL parsing for worktree contexts
+# Uses forge-helpers for detection, with fallback to git remote URL parsing
 get_repo_slug() {
     if [[ -z "$REPO_SLUG" ]]; then
-        REPO_SLUG=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || echo "")
-        if [[ -z "$REPO_SLUG" ]]; then
-            REPO_SLUG=$(git remote get-url origin 2>/dev/null | sed -E 's|\.git$||; s|.*[:/]([^/]+/[^/]+)$|\1|' || echo "")
-        fi
+        REPO_SLUG=$(forge_get_repo_nwo 2>/dev/null || echo "")
     fi
     echo "$REPO_SLUG"
 }
@@ -109,7 +114,7 @@ ${YELLOW}METRICS${NC}
     - other (⏭️) - other skip reasons
 
 ${YELLOW}DATA SOURCE${NC}
-    Parses Judge review comments on merged PRs via GitHub API.
+    Parses Judge review comments on merged PRs via forge API (GitHub or Gitea).
     The Judge documents test execution using structured emoji markers:
       ✅ Executed    ⚠️ Observation-only    ⏭️ Skipped (long-running/external)
 EOF
@@ -141,12 +146,9 @@ get_date_filter() {
 # Fetch merged PRs for the period
 fetch_merged_prs() {
     local date_filter="$1"
-    if [[ -n "$date_filter" ]]; then
-        gh pr list --state merged --limit "$LIMIT" --json number,mergedAt \
-            --jq '[.[] | select(.mergedAt >= "'"$date_filter"'")] | .[].number' 2>/dev/null || echo ""
-    else
-        gh pr list --state merged --limit "$LIMIT" --json number --jq '.[].number' 2>/dev/null || echo ""
-    fi
+    local slug
+    slug=$(get_repo_slug)
+    forge_list_merged_prs "$slug" "$LIMIT" "$date_filter"
 }
 
 # Extract Judge review comment with Test Execution section from a PR
@@ -154,14 +156,16 @@ fetch_merged_prs() {
 # Handles both "## Test Execution" (heading) and "**Test Execution:**" (bold) formats.
 get_judge_test_execution() {
     local pr_number="$1"
+    local slug
+    slug=$(get_repo_slug)
     # Get all comments (issue comments + review comments) and find the most recent
     # one with a Test Execution section
     local comments
-    comments=$(gh pr view "$pr_number" --comments --json comments --jq '.comments[].body' 2>/dev/null || echo "")
+    comments=$(forge_get_pr_comments "$slug" "$pr_number")
 
     # Also check review bodies
     local reviews
-    reviews=$(gh api "repos/$(get_repo_slug)/pulls/${pr_number}/reviews" --jq '.[].body // empty' 2>/dev/null || echo "")
+    reviews=$(forge_get_pr_reviews "$slug" "$pr_number")
 
     # Combine and find the last one with Test Execution
     local all_bodies
@@ -196,7 +200,9 @@ pr_has_test_plan() {
     local pr_number="$1"
     local body="${2:-}"
     if [[ -z "$body" ]]; then
-        body=$(gh pr view "$pr_number" --json body --jq '.body // ""' 2>/dev/null || echo "")
+        local slug
+        slug=$(get_repo_slug)
+        body=$(forge_get_pr_body "$slug" "$pr_number")
     fi
     echo "$body" | grep -qi '## test plan' && return 0
     return 1
@@ -296,7 +302,9 @@ collect_metrics() {
 
         # Prefetch PR body to avoid redundant API calls
         local pr_body
-        pr_body=$(gh pr view "$pr_number" --json body --jq '.body // ""' 2>/dev/null || echo "")
+        local slug
+        slug=$(get_repo_slug)
+        pr_body=$(forge_get_pr_body "$slug" "$pr_number")
 
         # Get test execution section from Judge comments
         local test_section
@@ -517,6 +525,9 @@ case "$FORMAT" in
     text|json) ;;
     *) echo -e "${RED}Error: Invalid format '$FORMAT'. Use: text, json${NC}" >&2; exit 1 ;;
 esac
+
+# Detect forge type
+forge_detect
 
 # Run
 collect_metrics

--- a/defaults/scripts/tests/test-forge-helpers.sh
+++ b/defaults/scripts/tests/test-forge-helpers.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# test-forge-helpers.sh - Unit tests for forge-helpers.sh dispatch logic
+#
+# Tests forge detection, host extraction, and verifies that forge dispatch
+# functions route to the correct backend based on FORGE_TYPE.
+#
+# Usage:
+#   ./.loom/scripts/tests/test-forge-helpers.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPERS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_eq() {
+    local expected="$1"
+    local actual="$2"
+    local msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Expected: '$expected'"
+        echo "    Actual:   '$actual'"
+    fi
+}
+
+# --- Test _extract_host ---
+echo "Testing _extract_host..."
+
+# Need to source the library
+source "$HELPERS_DIR/lib/forge-helpers.sh"
+
+# Reset state for testing
+FORGE_TYPE=""
+
+result=$(_extract_host "git@github.com:owner/repo.git")
+assert_eq "github.com" "$result" "SSH GitHub URL"
+
+result=$(_extract_host "https://github.com/owner/repo.git")
+assert_eq "github.com" "$result" "HTTPS GitHub URL"
+
+result=$(_extract_host "git@gitea.example.com:owner/repo.git")
+assert_eq "gitea.example.com" "$result" "SSH Gitea URL"
+
+result=$(_extract_host "https://gitea.example.com/owner/repo")
+assert_eq "gitea.example.com" "$result" "HTTPS Gitea URL (no .git)"
+
+result=$(_extract_host "not-a-url")
+assert_eq "" "$result" "Invalid URL returns empty"
+
+# --- Test forge_detect with env var ---
+echo ""
+echo "Testing forge_detect with LOOM_FORGE_TYPE env var..."
+
+FORGE_TYPE=""
+LOOM_FORGE_TYPE="github" forge_detect
+assert_eq "github" "$FORGE_TYPE" "LOOM_FORGE_TYPE=github"
+
+FORGE_TYPE=""
+LOOM_FORGE_TYPE="gitea" forge_detect 2>/dev/null || true
+# Note: this may fail if no Gitea config, but FORGE_TYPE should still be set
+assert_eq "gitea" "$FORGE_TYPE" "LOOM_FORGE_TYPE=gitea"
+
+# --- Test forge_split_nwo ---
+echo ""
+echo "Testing forge_split_nwo..."
+
+forge_split_nwo "myowner/myrepo"
+assert_eq "myowner" "$FORGE_OWNER" "Split NWO owner"
+assert_eq "myrepo" "$FORGE_REPO" "Split NWO repo"
+
+forge_split_nwo "org/complex-repo-name"
+assert_eq "org" "$FORGE_OWNER" "Split NWO org owner"
+assert_eq "complex-repo-name" "$FORGE_REPO" "Split NWO complex repo"
+
+# --- Test forge detection defaults to github ---
+echo ""
+echo "Testing forge_detect defaults..."
+
+FORGE_TYPE=""
+# Unset LOOM_FORGE_TYPE to test auto-detection
+unset LOOM_FORGE_TYPE 2>/dev/null || true
+export LOOM_FORGE_TYPE=""
+forge_detect
+# In this repo (github.com remote), should detect as github
+assert_eq "github" "$FORGE_TYPE" "Auto-detect defaults to github for github.com remote"
+
+# --- Test forge_get_repo_nwo for github ---
+echo ""
+echo "Testing forge_get_repo_nwo..."
+
+FORGE_TYPE="github"
+result=$(forge_get_repo_nwo "gh" 2>/dev/null || echo "")
+# Should return non-empty for this repo
+if [[ -n "$result" ]]; then
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: forge_get_repo_nwo returns non-empty for GitHub ($result)"
+else
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: forge_get_repo_nwo returned empty"
+fi
+
+# --- Summary ---
+echo ""
+echo "────────────────────────────────"
+echo "Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed"
+
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #3147

## Summary

Adds a `forge-helpers.sh` shared library and updates the three high-complexity shell scripts (`merge-pr.sh`, `check-ci-status.sh`, `test-plan-metrics.sh`) to work with both GitHub and Gitea forges.

**Key design decisions:**
- **Bash helper library approach** (not Python rewrite) -- scripts are called from other bash scripts, so interface compatibility is maintained
- **GitHub behavior completely unchanged** -- forge helpers delegate to existing `gh` CLI/API calls when `FORGE_TYPE=github`
- **Gitea uses `curl`** against REST API v1 with token auth, since `gh` CLI is GitHub-only

**forge-helpers.sh** provides:
- Forge detection (env var > config > git remote URL > default to github)
- `gitea_api()` -- curl wrapper with auth and error handling
- Dispatch functions: `forge_merge_pr`, `forge_update_branch`, `forge_auto_merge`, `forge_delete_branch`, `forge_check_auto_delete`, `forge_get_check_runs`, `forge_get_commit_status`, `forge_list_merged_prs`, `forge_get_pr_body/comments/reviews`

**Script changes:**
- `merge-pr.sh`: 6 API calls migrated (squash merge PUT->POST, update-branch, branch deletion path, auto-merge, auto-delete field name)
- `check-ci-status.sh`: 2 API calls migrated (Gitea has no Check Runs API -- commit statuses are mapped to check-run shape)
- `test-plan-metrics.sh`: 5 API calls migrated (no `state=merged` in Gitea -- client-side filter, PR comments via issues endpoint, rate limiting for Gitea)

## Test plan
- [x] Unit tests for forge-helpers.sh pass (13/13)
- [x] Syntax check passes for all modified scripts
- [x] `check-ci-status.sh --quiet` works on GitHub (existing behavior)
- [x] `merge-pr.sh <merged-pr> --dry-run` works on GitHub (existing behavior)
- [ ] Gitea integration testing (requires Gitea Docker container)