### PR TITLE
feat: make commands/github.rs forge-agnostic via loom-forge CLI

### DIFF
--- a/loom-tools/src/loom_tools/forge_cli.py
+++ b/loom-tools/src/loom_tools/forge_cli.py
@@ -22,6 +22,7 @@ Shell scripts replace ``gh issue/pr`` calls with ``loom-forge`` equivalents:
     loom-forge issue comment 42 --body "Recovery message"
     loom-forge issue create --title "..." --body "..." --label "..."
     loom-forge pr list --state open --json number,headRefName,body,labels
+    loom-forge pr edit 123 --remove-label "loom:reviewing" --add-label "loom:review-requested"
     loom-forge auth status
 
 For GitHub: dispatches to ``gh`` CLI (identical behavior).
@@ -298,6 +299,20 @@ def _cmd_pr_list(forge: ForgeClient, args: list[str]) -> int:
     return 0
 
 
+def _cmd_pr_edit(forge: ForgeClient, args: list[str]) -> int:
+    """Handle: loom-forge pr edit <number> [--add-label X]... [--remove-label X]..."""
+    if not args:
+        print("Error: PR number required", file=sys.stderr)
+        return 1
+
+    number = int(args.pop(0))
+    add_labels = _pop_all_flags(args, "--add-label")
+    remove_labels = _pop_all_flags(args, "--remove-label")
+
+    success = forge.transition_labels("pr", number, add=add_labels, remove=remove_labels)
+    return 0 if success else 1
+
+
 def _cmd_auth_status(forge: ForgeClient, args: list[str]) -> int:
     """Handle: loom-forge auth status
 
@@ -345,6 +360,7 @@ _ISSUE_COMMANDS = {
 
 _PR_COMMANDS = {
     "list": _cmd_pr_list,
+    "edit": _cmd_pr_edit,
 }
 
 _TOP_COMMANDS = {
@@ -363,7 +379,7 @@ def _print_usage() -> None:
         "\n"
         "Entities:\n"
         "  issue    Issue operations (list, view, edit, comment, create)\n"
-        "  pr       Pull request operations (list)\n"
+        "  pr       Pull request operations (list, edit)\n"
         "  auth     Authentication (status)\n"
         "\n"
         "Examples:\n"
@@ -373,6 +389,7 @@ def _print_usage() -> None:
         "  loom-forge issue comment 42 --body 'Recovery message'\n"
         "  loom-forge issue create --title 'Title' --body 'Body' --label bug\n"
         "  loom-forge pr list --state open --json number,headRefName,body,labels\n"
+        "  loom-forge pr edit 123 --remove-label loom:reviewing --add-label loom:review-requested\n"
         "  loom-forge auth status\n",
         file=sys.stderr,
     )

--- a/loom-tools/tests/test_forge_cli.py
+++ b/loom-tools/tests/test_forge_cli.py
@@ -389,6 +389,32 @@ class TestMainPrList:
         assert output[0]["headRefName"] == "feature/issue-1"
 
 
+class TestMainPrEdit:
+    """Tests for 'loom-forge pr edit'."""
+
+    def test_pr_edit_labels(self) -> None:
+        forge = FakeForge()
+        with mock.patch("loom_tools.forge_cli.get_forge", return_value=forge):
+            rc = main([
+                "pr", "edit", "10",
+                "--remove-label", "loom:reviewing",
+                "--add-label", "loom:review-requested",
+            ])
+        assert rc == 0
+        assert len(forge.label_ops) == 1
+        entity, num, add, remove = forge.label_ops[0]
+        assert entity == "pr"
+        assert num == 10
+        assert add == ["loom:review-requested"]
+        assert remove == ["loom:reviewing"]
+
+    def test_pr_edit_no_number(self) -> None:
+        forge = FakeForge()
+        with mock.patch("loom_tools.forge_cli.get_forge", return_value=forge):
+            rc = main(["pr", "edit"])
+        assert rc == 1
+
+
 class TestMainAuthStatus:
     """Tests for 'loom-forge auth status'."""
 

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -2,12 +2,7 @@ use std::process::Command;
 
 /// Helper structs for JSON parsing
 #[derive(serde::Deserialize)]
-struct GhLabel {
-    name: String,
-}
-
-#[derive(serde::Deserialize)]
-struct GhIssue {
+struct ForgeEntity {
     number: u32,
 }
 
@@ -32,72 +27,9 @@ pub fn check_github_remote() -> Result<bool, String> {
     Ok(remotes.contains("github.com"))
 }
 
-#[tauri::command]
-pub fn check_label_exists(name: &str) -> Result<bool, String> {
-    let output = Command::new("gh")
-        .args(["label", "list", "--json", "name"])
-        .output()
-        .map_err(|e| format!("Failed to run gh label list: {e}"))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("gh label list failed: {stderr}"));
-    }
-
-    // Parse JSON in Rust instead of using jq to prevent injection
-    let labels: Vec<GhLabel> = serde_json::from_slice(&output.stdout)
-        .map_err(|e| format!("Failed to parse label JSON: {e}"))?;
-
-    Ok(labels.iter().any(|l| l.name == name))
-}
-
-#[tauri::command]
-pub fn create_github_label(name: &str, description: &str, color: &str) -> Result<(), String> {
-    let output = Command::new("gh")
-        .args([
-            "label",
-            "create",
-            name,
-            "--description",
-            description,
-            "--color",
-            color,
-        ])
-        .output()
-        .map_err(|e| format!("Failed to run gh label create: {e}"))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("gh label create failed: {stderr}"));
-    }
-
-    Ok(())
-}
-
-#[tauri::command]
-pub fn update_github_label(name: &str, description: &str, color: &str) -> Result<(), String> {
-    let output = Command::new("gh")
-        .args([
-            "label",
-            "create",
-            name,
-            "--description",
-            description,
-            "--color",
-            color,
-            "--force",
-        ])
-        .output()
-        .map_err(|e| format!("Failed to run gh label create --force: {e}"))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("gh label update failed: {stderr}"));
-    }
-
-    Ok(())
-}
-
+/// Reset label state machine by transitioning deprecated labels on open PRs.
+///
+/// Dispatches through `loom-forge` CLI for forge-agnostic support (GitHub and Gitea).
 #[tauri::command]
 pub fn reset_github_labels() -> Result<LabelResetResult, String> {
     let mut result = LabelResetResult {
@@ -105,61 +37,9 @@ pub fn reset_github_labels() -> Result<LabelResetResult, String> {
         errors: Vec::new(),
     };
 
-    // Step 1: Migration cleanup - Remove deprecated loom:in-progress label
-    //
-    // MIGRATION CODE: This handles cleanup of the deprecated `loom:in-progress` label.
-    // Background: loom:in-progress was deprecated in favor of role-specific labels
-    // (loom:building, loom:curating, loom:reviewing, loom:treating) in PR #808 (Dec 2025).
-    //
-    // This code can be removed after March 2026 when all installations have migrated.
-    // See: Issue #791 (deprecation request), PR #808 (implementation), Issue #903 (this review)
-    let issues_output = Command::new("gh")
-        .args([
-            "issue",
-            "list",
-            "--label",
-            "loom:in-progress",
-            "--state",
-            "open",
-            "--json",
-            "number",
-        ])
-        .output()
-        .map_err(|e| format!("Failed to list issues: {e}"))?;
-
-    if issues_output.status.success() {
-        // Parse JSON in Rust instead of using jq to prevent injection
-        let issues: Vec<GhIssue> = serde_json::from_slice(&issues_output.stdout)
-            .map_err(|e| format!("Failed to parse issue JSON: {e}"))?;
-
-        for issue in issues {
-            let issue_num = issue.number.to_string();
-
-            let remove_output = Command::new("gh")
-                .args([
-                    "issue",
-                    "edit",
-                    &issue_num,
-                    "--remove-label",
-                    "loom:in-progress",
-                ])
-                .output()
-                .map_err(|e| format!("Failed to remove label: {e}"))?;
-
-            if remove_output.status.success() {
-                result.issues_cleaned += 1;
-            } else {
-                let error = format!(
-                    "Failed to remove loom:in-progress from issue {issue_num}: {}",
-                    String::from_utf8_lossy(&remove_output.stderr)
-                );
-                result.errors.push(error);
-            }
-        }
-    }
-
-    // Step 2: Replace loom:reviewing with loom:review-requested on all open PRs
-    let prs_output = Command::new("gh")
+    // Replace loom:reviewing with loom:review-requested on all open PRs.
+    // Uses loom-forge CLI for forge-agnostic dispatch.
+    let prs_output = Command::new("loom-forge")
         .args([
             "pr",
             "list",
@@ -171,16 +51,16 @@ pub fn reset_github_labels() -> Result<LabelResetResult, String> {
             "number",
         ])
         .output()
-        .map_err(|e| format!("Failed to list PRs: {e}"))?;
+        .map_err(|e| format!("Failed to list PRs via loom-forge: {e}"))?;
 
     if prs_output.status.success() {
-        let prs: Vec<GhIssue> = serde_json::from_slice(&prs_output.stdout)
+        let prs: Vec<ForgeEntity> = serde_json::from_slice(&prs_output.stdout)
             .map_err(|e| format!("Failed to parse PR JSON: {e}"))?;
 
         for pr in prs {
             let pr_num = pr.number.to_string();
 
-            let edit_output = Command::new("gh")
+            let edit_output = Command::new("loom-forge")
                 .args([
                     "pr",
                     "edit",
@@ -191,7 +71,7 @@ pub fn reset_github_labels() -> Result<LabelResetResult, String> {
                     "loom:review-requested",
                 ])
                 .output()
-                .map_err(|e| format!("Failed to edit PR: {e}"))?;
+                .map_err(|e| format!("Failed to edit PR via loom-forge: {e}"))?;
 
             if edit_output.status.success() {
                 result.issues_cleaned += 1;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -235,11 +235,8 @@ fn main() {
             write_file,
             append_to_console_log,
             append_to_input_log,
-            // GitHub commands
+            // GitHub/forge commands
             check_github_remote,
-            check_label_exists,
-            create_github_label,
-            update_github_label,
             reset_github_labels,
             // Project commands
             create_local_project,


### PR DESCRIPTION
## Summary

Closes #3160

- Remove 4 dead-code Tauri commands (`check_label_exists`, `create_github_label`, `update_github_label`) and their `main.rs` registrations -- no frontend callers existed
- Remove expired `loom:in-progress` migration code from `reset_github_labels` (deadline was March 2026, it is now April 2026)
- Migrate `reset_github_labels` to dispatch through `loom-forge` CLI instead of `gh` directly, enabling both GitHub and Gitea forge support
- Add `pr edit` subcommand to `loom-forge` CLI with `--add-label`/`--remove-label` support for label transitions on pull requests
- Keep `check_github_remote` untouched (issue #3159 is handling that separately)

## Files Changed

| File | Change |
|------|--------|
| `src-tauri/src/commands/github.rs` | Remove dead code, expired migration, use `loom-forge` |
| `src-tauri/src/main.rs` | Remove 3 dead command registrations |
| `loom-tools/src/loom_tools/forge_cli.py` | Add `pr edit` subcommand |
| `loom-tools/tests/test_forge_cli.py` | Add tests for `pr edit` |

## Test plan

- [x] `cargo check -p app` passes (Rust compilation verified)
- [x] `cargo test -p loom-daemon` passes
- [x] `pytest tests/test_forge_cli.py` -- all 32 tests pass (including 2 new `pr edit` tests)
- [ ] Verify `reset_github_labels` works end-to-end with `loom-forge` installed
- [ ] Verify no frontend breakage (`workspace-reset.ts` still calls `reset_github_labels` unchanged)