### PR TITLE
feat: update installation scripts and docs for multi-forge support

### DIFF
--- a/.loom/docs/forge-authentication.md
+++ b/.loom/docs/forge-authentication.md
@@ -1,0 +1,144 @@
+# Forge Authentication Guide
+
+Loom supports multiple forge platforms for issue tracking, PR management, and label coordination. This guide covers authentication setup for each supported forge.
+
+## Supported Forges
+
+| Forge | Detection | CLI Tool | Auth Method |
+|-------|-----------|----------|-------------|
+| GitHub | `github.com` in remote URL | `gh` CLI | `gh auth login` or `GH_TOKEN` |
+| Gitea | Auto-detected via API probe | Loom scripts (direct API) | `GITEA_TOKEN` or `FORGE_TOKEN` |
+
+Forge type is auto-detected from your git remote URL. GitHub is detected by hostname; any non-GitHub remote is probed for the Gitea API version endpoint.
+
+## GitHub Authentication
+
+See [github-authentication.md](github-authentication.md) for the full GitHub authentication guide, including:
+- Fine-grained PAT creation
+- Required token permissions per role
+- Verification and troubleshooting
+
+**Quick start:**
+```bash
+export GH_TOKEN=github_pat_xxx
+gh auth status
+```
+
+## Gitea Authentication
+
+### Quick Start
+
+```bash
+# 1. Create an API token on your Gitea instance
+#    Go to: <your-gitea-instance>/user/settings/applications
+#    Create a token with repository read/write permissions
+
+# 2. Export it before running Loom
+export GITEA_TOKEN=your_gitea_api_token
+
+# 3. Verify (optional)
+curl -s -H "Authorization: token $GITEA_TOKEN" \
+  https://your-gitea-instance/api/v1/user | jq .login
+```
+
+### Required Token Permissions
+
+Gitea API tokens need the following scopes (if your Gitea version supports scoped tokens):
+
+| Scope | Used By | Purpose |
+|-------|---------|---------|
+| `repo` | All roles | Repository access (issues, PRs, labels, contents) |
+| `issue` | Builder, Curator, Champion, Shepherd | Issue creation, editing, label management |
+| `package` | (optional) | Not required by Loom |
+
+For Gitea instances without scoped tokens, a standard API token grants full access to repositories the user can reach.
+
+### Creating an API Token
+
+1. Log in to your Gitea instance
+2. Go to **Settings** > **Applications** (URL: `<instance>/user/settings/applications`)
+3. Under **Manage Access Tokens**, enter a token name (e.g., `loom-orchestration`)
+4. Select appropriate scopes if available (at minimum: repository read/write)
+5. Click **Generate Token**
+6. Copy the token immediately -- it will not be shown again
+
+### Using the Token
+
+Set the token as an environment variable before running Loom:
+
+```bash
+# Option A: Export in current session
+export GITEA_TOKEN=your_token_here
+
+# Option B: Use FORGE_TOKEN (generic, works for any forge)
+export FORGE_TOKEN=your_token_here
+
+# Option C: Add to shell profile (~/.zshrc, ~/.bashrc)
+export GITEA_TOKEN=your_token_here
+
+# Option D: Use a .env file (not committed)
+source .env  # where .env contains: export GITEA_TOKEN=your_token_here
+```
+
+When using Tauri App Mode, set the variable before launching the app so all spawned terminals inherit it.
+
+### Verifying Authentication
+
+```bash
+# Check user identity
+curl -s -H "Authorization: token $GITEA_TOKEN" \
+  https://your-instance/api/v1/user | jq '.login'
+
+# Check repository access
+curl -s -H "Authorization: token $GITEA_TOKEN" \
+  https://your-instance/api/v1/repos/owner/repo | jq '.full_name'
+
+# Check issue access
+curl -s -H "Authorization: token $GITEA_TOKEN" \
+  https://your-instance/api/v1/repos/owner/repo/issues?limit=1 | jq '.[0].title'
+```
+
+### Gitea Instance URL
+
+Loom auto-detects the Gitea API URL from your git remote. For HTTPS remotes like `https://gitea.example.com/owner/repo.git`, the API base URL is `https://gitea.example.com/api/v1`.
+
+If auto-detection fails (e.g., non-standard ports or paths), you can configure the API URL in `.loom/config.json`:
+
+```json
+{
+  "forge": {
+    "type": "gitea",
+    "gitea": {
+      "api_url": "https://gitea.example.com/api/v1",
+      "known_hosts": ["gitea.example.com"]
+    }
+  }
+}
+```
+
+## Troubleshooting
+
+### Forge not detected
+
+- Ensure your git remote URL is set: `git remote -v`
+- For Gitea, ensure the instance is reachable (Loom probes the `/api/v1/version` endpoint)
+- Try setting the forge type explicitly in `.loom/config.json`
+
+### Gitea token not being picked up
+
+- Confirm `echo $GITEA_TOKEN` shows the token value
+- The variable must be **exported**, not just set: `export GITEA_TOKEN=...`
+- `FORGE_TOKEN` is checked as a fallback if `GITEA_TOKEN` is not set
+
+### Permission errors (401 / 403)
+
+- Verify the token has not expired
+- Check that the token has sufficient scopes for the operation
+- Ensure the token belongs to a user with access to the target repository
+
+## Security Notes
+
+- **Never commit tokens** to the repository. Add `.env` to `.gitignore` if using an env file.
+- Use the minimum permissions required.
+- Rotate tokens periodically.
+- For Gitea self-hosted instances, ensure HTTPS is configured for API communication.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This repository uses **Loom** for AI-powered development orchestration.
 
 ## What is Loom?
 
-Loom is a multi-terminal desktop application for macOS that orchestrates AI-powered development workers using git worktrees and GitHub as the coordination layer. It enables both automated orchestration (Tauri App Mode) and manual coordination (Manual Orchestration Mode).
+Loom is a multi-terminal desktop application for macOS that orchestrates AI-powered development workers using git worktrees and a forge (GitHub or Gitea) as the coordination layer. It enables both automated orchestration (Tauri App Mode) and manual coordination (Manual Orchestration Mode).
 
 **Loom Repository**: https://github.com/rjwalters/loom
 
@@ -566,7 +566,7 @@ See `.loom/docs/troubleshooting.md` for detailed troubleshooting including:
 loom-clean --force                       # Clean stale worktrees/branches
 ./.loom/scripts/stale-building-check.sh --recover  # Recover stuck issues
 ./.loom/scripts/recover-orphaned-shepherds.sh --recover  # Recover orphaned shepherds after crash
-gh label sync --file .github/labels.yml  # Re-sync labels
+gh label sync --file .github/labels.yml  # Re-sync labels (GitHub only)
 touch .loom/stop-daemon                  # Graceful daemon shutdown
 ```
 
@@ -587,11 +587,19 @@ Loom provides a unified MCP server (`mcp-loom`) for programmatic control. See th
 mcp__loom__get_agent_metrics --command summary --period week
 ```
 
-## GitHub Authentication
+## Forge Authentication
+
+### GitHub
 
 Loom uses the `gh` CLI for all GitHub operations. By default it uses the credential from `gh auth login`, which has access to all repositories. To scope access to a single repository, create a fine-grained PAT and set `export GH_TOKEN=github_pat_xxx` before running Loom.
 
 See `.loom/docs/github-authentication.md` for the detailed setup guide, required token permissions per role, and troubleshooting.
+
+### Gitea
+
+For Gitea repositories, Loom uses the Gitea API with token authentication. Set `GITEA_TOKEN` or `FORGE_TOKEN` environment variable with an API token created at `<your-gitea-instance>/user/settings/applications`. The token needs repository read/write permissions (issues, pull requests, labels).
+
+See `.loom/docs/forge-authentication.md` for the complete authentication guide covering both GitHub and Gitea.
 
 ## Releasing
 
@@ -621,6 +629,7 @@ The script updates all 7 version-bearing files (`package.json`, `mcp-loom/packag
 - **Troubleshooting**: `.loom/docs/troubleshooting.md`
 - **Daemon Reference**: `.loom/docs/daemon-reference.md`
 - **GitHub Authentication**: `.loom/docs/github-authentication.md`
+- **Forge Authentication** (GitHub + Gitea): `.loom/docs/forge-authentication.md`
 - **Scripts**: `.loom/scripts/`
 
 ---

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@
 [![GitHub Release](https://img.shields.io/github/v/release/rjwalters/loom?include_prereleases)](https://github.com/rjwalters/loom/releases)
 [![Lines of Code](https://raw.githubusercontent.com/rjwalters/loom/ghloc/.ghloc/badge.svg)](https://github.com/rjwalters/loom)
 
-**AI-powered development orchestration using GitHub as the coordination layer.**
+**AI-powered development orchestration using your forge as the coordination layer.**
 
-Loom spawns AI agents that claim issues, implement features, review PRs, and merge code—all coordinated through GitHub labels. Your only job: write issues, review PRs, merge what you like.
+Loom spawns AI agents that claim issues, implement features, review PRs, and merge code -- all coordinated through labels. Your only job: write issues, review PRs, merge what you like.
+
+**Supported Forges**: GitHub (full support) | Gitea (supported via forge abstraction layer)
 
 ## Quick Start
 

--- a/defaults/.loom/CLAUDE.md
+++ b/defaults/.loom/CLAUDE.md
@@ -7,9 +7,11 @@ This repository uses **Loom** for AI-powered development orchestration.
 
 ## What is Loom?
 
-Loom is a multi-terminal desktop application for macOS that orchestrates AI-powered development workers using git worktrees and GitHub as the coordination layer. It enables both automated orchestration (Tauri App Mode) and manual coordination (Manual Orchestration Mode).
+Loom is a multi-terminal desktop application for macOS that orchestrates AI-powered development workers using git worktrees and a forge (GitHub or Gitea) as the coordination layer. It enables both automated orchestration (Tauri App Mode) and manual coordination (Manual Orchestration Mode).
 
 **Loom Repository**: https://github.com/rjwalters/loom
+
+> **Forge note**: The `gh` commands shown below are for GitHub. For Gitea repositories, Loom scripts handle API calls internally. The label-based workflow is identical regardless of forge.
 
 ## Usage Modes
 

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -7,9 +7,11 @@ This repository uses **Loom** for AI-powered development orchestration.
 
 ## What is Loom?
 
-Loom is a multi-terminal desktop application for macOS that orchestrates AI-powered development workers using git worktrees and GitHub as the coordination layer. It enables both automated orchestration (Tauri App Mode) and manual coordination (Manual Orchestration Mode).
+Loom is a multi-terminal desktop application for macOS that orchestrates AI-powered development workers using git worktrees and a forge (GitHub or Gitea) as the coordination layer. It enables both automated orchestration (Tauri App Mode) and manual coordination (Manual Orchestration Mode).
 
 **Loom Repository**: https://github.com/rjwalters/loom
+
+**Supported Forges**: GitHub (full support), Gitea (supported via forge abstraction layer). Forge type is auto-detected from your git remote URL. For Gitea, set `GITEA_TOKEN` or `FORGE_TOKEN` with an API token from your instance's `/user/settings/applications` page.
 
 ## Installing Loom
 
@@ -41,7 +43,9 @@ Additional options for `install-loom.sh`:
 
 ## Critical Rules
 
-**Never use `gh pr merge`** — Always use `./.loom/scripts/merge-pr.sh <PR_NUMBER>` instead. The `gh pr merge` command attempts a local checkout which fails in worktrees. The merge script uses the GitHub API directly. A PreToolUse hook enforces this.
+**Never use `gh pr merge`** — Always use `./.loom/scripts/merge-pr.sh <PR_NUMBER>` instead. The `gh pr merge` command attempts a local checkout which fails in worktrees. The merge script uses the forge API directly. A PreToolUse hook enforces this.
+
+**Forge CLI note** — The `gh` commands shown throughout this document are for GitHub repositories. For Gitea repositories, Loom's scripts handle forge API calls internally; agents do not need to call `gh` directly. The label-based workflow is the same regardless of forge.
 
 **`--permission-mode bypassPermissions` silently disables PreToolUse hooks** — If you invoke Claude Code with `--permission-mode bypassPermissions`, ALL PreToolUse hooks (including `guard-destructive.sh`) are skipped entirely and will not fire. Loom agents use `--dangerously-skip-permissions` instead, which runs Claude in non-interactive mode while still firing hooks. If you have a shell alias like `alias claude="claude --permission-mode bypassPermissions"`, your interactive sessions will have no hook protection. Use `--dangerously-skip-permissions` for automation that requires hooks to run.
 
@@ -368,7 +372,7 @@ Full role definitions with detailed guidelines are available in:
 
 ## Label-Based Workflow
 
-Agents coordinate work through GitHub labels. This enables autonomous operation without direct communication.
+Agents coordinate work through forge labels (GitHub or Gitea). This enables autonomous operation without direct communication.
 
 ### Label Flow
 
@@ -1099,8 +1103,11 @@ git worktree prune
 
 **Labels out of sync**:
 ```bash
-# Re-sync labels from configuration
+# Re-sync labels from configuration (GitHub)
 gh label sync --file .github/labels.yml
+
+# Or use the Loom sync script (works with both GitHub and Gitea)
+./scripts/install/sync-labels.sh .
 ```
 
 **Terminal won't start (Tauri App)**:

--- a/defaults/config.json
+++ b/defaults/config.json
@@ -1,6 +1,13 @@
 {
   "version": "2",
   "offlineMode": false,
+  "forge": {
+    "type": "auto",
+    "gitea": {
+      "api_url": null,
+      "known_hosts": []
+    }
+  },
   "health_monitoring": {
     "enabled": true,
     "collect_interval_minutes": 5,

--- a/install.sh
+++ b/install.sh
@@ -160,9 +160,10 @@ while [[ "${1:-}" == -* ]]; do
   esac
 done
 
-# Early validation for --full: requires gh CLI
+# Early validation for --full: requires gh CLI (for GitHub repos)
+# Gitea repos use the API directly and don't need gh CLI
 if [[ "$INSTALL_TYPE" == "2" ]] && ! command -v gh &> /dev/null; then
-  error "Full Install requires GitHub CLI (gh)\n       Install: brew install gh\n       Or use --quick for installation without GitHub integration"
+  warning "GitHub CLI (gh) not found. Required for GitHub repos.\n       Install: brew install gh\n       For Gitea repos, set GITEA_TOKEN instead.\n       Or use --quick for installation without forge integration"
 fi
 
 # Get target path from argument or prompt
@@ -268,9 +269,10 @@ GITIGNORE
   success "Initial commit created"
   echo ""
 
-  # Offer GitHub repository creation
+  # Offer remote repository creation
   if command -v gh &> /dev/null; then
     echo "Would you like to create a GitHub repository for this project?"
+    echo "(For Gitea, create the repository manually and add the remote)"
     echo ""
     read -r -p "Create GitHub repository? [y/N] " -n 1 CREATE_REPO
     echo ""
@@ -304,16 +306,17 @@ GITIGNORE
 
       info "Creating GitHub repository: $REPO_NAME..."
       if gh repo create "$REPO_NAME" $VISIBILITY_FLAG --source="$TARGET_PATH" --push; then
-        success "GitHub repository created and pushed"
+        success "Repository created and pushed"
       else
-        warning "Failed to create GitHub repository. Continuing with local git only."
+        warning "Failed to create repository. Continuing with local git only."
         info "You can create the repository later with: gh repo create"
       fi
       echo ""
     fi
   else
-    info "GitHub CLI (gh) not found - skipping GitHub repository creation"
-    info "Install with: brew install gh"
+    info "GitHub CLI (gh) not found - skipping remote repository creation"
+    info "For GitHub: install gh CLI (brew install gh)"
+    info "For Gitea: create the repo manually and run: git remote add origin <url>"
     echo ""
   fi
 fi
@@ -362,12 +365,13 @@ else
   INSTALL_INSTRUCTIONS="${INSTALL_INSTRUCTIONS}\n  • Rust/Cargo: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
 fi
 
-# Check for GitHub CLI (optional but needed for Full Install)
+# Check for GitHub CLI (optional, needed for Full Install with GitHub repos)
 if command -v gh &> /dev/null; then
   success "gh: $(gh --version | head -1)"
 else
-  warning "gh (GitHub CLI) not found - Full Install will not be available"
+  warning "gh (GitHub CLI) not found - needed for Full Install with GitHub repos"
   info "  Install with: brew install gh"
+  info "  For Gitea repos, gh is not required (set GITEA_TOKEN instead)"
 fi
 
 echo ""
@@ -629,30 +633,52 @@ case "$METHOD" in
     info "Running Full Install with Workflow..."
     echo ""
 
-    # Check prerequisites
-    if ! command -v gh &> /dev/null; then
-      error "GitHub CLI (gh) is required for full installation\n       Install: brew install gh"
+    # Detect forge type from remote URL
+    cd "$TARGET_PATH"
+    _ORIGIN_URL=$(git config --get remote.origin.url 2>/dev/null || echo "")
+    _DETECTED_FORGE="github"
+    if [[ -n "$_ORIGIN_URL" ]] && [[ ! "$_ORIGIN_URL" =~ github\.com ]]; then
+      _DETECTED_FORGE="gitea"
     fi
 
-    # Check GitHub authentication
-    if ! gh auth status &> /dev/null; then
-      warning "GitHub CLI is not authenticated"
-      info "Please authenticate with GitHub:"
-      echo ""
-      gh auth login || error "GitHub authentication failed"
-      echo ""
-    fi
+    # Check prerequisites based on detected forge
+    if [[ "$_DETECTED_FORGE" == "github" ]]; then
+      if ! command -v gh &> /dev/null; then
+        error "GitHub CLI (gh) is required for GitHub repos\n       Install: brew install gh\n       For Gitea repos, set GITEA_TOKEN instead"
+      fi
 
-    success "GitHub CLI is authenticated"
+      # Check GitHub authentication
+      if ! gh auth status &> /dev/null; then
+        warning "GitHub CLI is not authenticated"
+        info "Please authenticate with GitHub:"
+        echo ""
+        gh auth login || error "GitHub authentication failed"
+        echo ""
+      fi
+      success "GitHub CLI is authenticated"
+    else
+      # Gitea forge
+      if [[ -z "${GITEA_TOKEN:-${FORGE_TOKEN:-}}" ]]; then
+        warning "Gitea detected but no API token found"
+        info "Set GITEA_TOKEN or FORGE_TOKEN environment variable"
+        info "Create a token at: <your-gitea-instance>/user/settings/applications"
+      else
+        success "Gitea API token configured"
+      fi
+    fi
     echo ""
 
     # Show repository info
-    cd "$TARGET_PATH"
-    REPO_INFO=$(gh repo view --json nameWithOwner,description 2>/dev/null || echo "{}")
-    REPO_NAME=$(echo "$REPO_INFO" | jq -r '.nameWithOwner // "unknown"' 2>/dev/null || echo "unknown")
+    REPO_NAME="unknown"
+    if [[ "$_DETECTED_FORGE" == "github" ]]; then
+      REPO_INFO=$(gh repo view --json nameWithOwner,description 2>/dev/null || echo "{}")
+      REPO_NAME=$(echo "$REPO_INFO" | jq -r '.nameWithOwner // "unknown"' 2>/dev/null || echo "unknown")
+    elif [[ -n "$_ORIGIN_URL" ]]; then
+      REPO_NAME=$(echo "$_ORIGIN_URL" | sed -E 's/\.git$//; s#^.*[:/]([^/]+/[^/]+)$#\1#' || echo "unknown")
+    fi
 
     if [[ "$REPO_NAME" != "unknown" ]]; then
-      info "Target repository: $REPO_NAME"
+      info "Target repository: $REPO_NAME (${_DETECTED_FORGE})"
     else
       warning "Could not detect remote repository. This may be a local-only repo."
       read -r -p "Continue anyway? [y/N] " -n 1 CONTINUE_LOCAL

--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -15,13 +15,14 @@
 #     1. Validates target repository (must be a Git repo)
 #     2. Creates installation worktree (.loom/worktrees/loom-installation)
 #     3. Initializes Loom configuration (copies defaults to .loom/)
-#     4. Syncs GitHub labels for Loom workflow
+#     4. Syncs workflow labels (GitHub or Gitea)
 #     5. Configures branch rulesets (interactive mode only)
 #     6. Creates pull request with loom:review-requested label
 #
 #   Requirements:
-#     - Target must be a Git repository
-#     - GitHub CLI (gh) must be authenticated
+#     - Target must be a Git repository with a remote
+#     - For GitHub: GitHub CLI (gh) must be authenticated
+#     - For Gitea: GITEA_TOKEN or FORGE_TOKEN environment variable must be set
 #     - loom-daemon binary must be built (pnpm daemon:build)
 #
 #   After installation:
@@ -146,19 +147,19 @@ if ! git -C "$TARGET_PATH" rev-parse --git-dir >/dev/null 2>&1; then
   echo ""
   warning "$TARGET_PATH is not a git repository."
   echo ""
-  echo "Would you like to initialize git and set up GitHub?"
+  echo "Would you like to initialize git and set up a remote repository?"
   echo ""
   echo "This will:"
   echo "  1. Run 'git init' in the directory"
   echo "  2. Create a sensible .gitignore file"
   echo "  3. Create an initial commit"
-  echo "  4. Create a GitHub repository and set up remote (required for Full Install)"
+  echo "  4. Create a remote repository and set up the origin (required for Full Install)"
   echo ""
-  read -r -p "Initialize git and GitHub? [y/N] " -n 1 INIT_GIT
+  read -r -p "Initialize git and remote? [y/N] " -n 1 INIT_GIT
   echo ""
 
   if [[ ! $INIT_GIT =~ ^[Yy]$ ]]; then
-    error "Full Install requires a git repository with GitHub remote.\n       Run 'git init' and 'gh repo create' manually, or use Quick Install."
+    error "Full Install requires a git repository with a remote.\n       Run 'git init' and set up a remote manually, or use Quick Install."
   fi
 
   # Initialize git
@@ -217,41 +218,51 @@ GITIGNORE
   success "Initial commit created"
   echo ""
 
-  # GitHub repository creation is required for Full Install
-  info "Full Install requires a GitHub repository."
+  # Remote repository creation is required for Full Install
+  info "Full Install requires a remote repository (GitHub or Gitea)."
   echo ""
 
-  # Check GitHub authentication
-  if ! gh auth status &> /dev/null; then
-    warning "GitHub CLI is not authenticated"
-    info "Please authenticate with GitHub:"
+  # Check if gh CLI is available (needed for GitHub repo creation)
+  if command -v gh &> /dev/null; then
+    # Check GitHub authentication
+    if ! gh auth status &> /dev/null; then
+      warning "GitHub CLI is not authenticated"
+      info "Please authenticate with GitHub:"
+      echo ""
+      gh auth login || error "GitHub authentication failed"
+      echo ""
+    fi
+
+    # Prompt for repository visibility
+    echo "Repository visibility:"
+    echo "  1. Private (default)"
+    echo "  2. Public"
+    read -r -p "Choose visibility [1/2]: " -n 1 VISIBILITY
     echo ""
-    gh auth login || error "GitHub authentication failed"
-    echo ""
-  fi
 
-  # Prompt for repository visibility
-  echo "Repository visibility:"
-  echo "  1. Private (default)"
-  echo "  2. Public"
-  read -r -p "Choose visibility [1/2]: " -n 1 VISIBILITY
-  echo ""
+    VISIBILITY_FLAG="--private"
+    if [[ "$VISIBILITY" == "2" ]]; then
+      VISIBILITY_FLAG="--public"
+    fi
 
-  VISIBILITY_FLAG="--private"
-  if [[ "$VISIBILITY" == "2" ]]; then
-    VISIBILITY_FLAG="--public"
-  fi
+    # Get directory name for repo name suggestion
+    DIR_NAME=$(basename "$TARGET_PATH")
+    read -r -p "Repository name [$DIR_NAME]: " REPO_NAME
+    REPO_NAME="${REPO_NAME:-$DIR_NAME}"
 
-  # Get directory name for repo name suggestion
-  DIR_NAME=$(basename "$TARGET_PATH")
-  read -r -p "Repository name [$DIR_NAME]: " REPO_NAME
-  REPO_NAME="${REPO_NAME:-$DIR_NAME}"
-
-  info "Creating GitHub repository: $REPO_NAME..."
-  if gh repo create "$REPO_NAME" $VISIBILITY_FLAG --source="$TARGET_PATH" --push; then
-    success "GitHub repository created and pushed"
+    info "Creating GitHub repository: $REPO_NAME..."
+    if gh repo create "$REPO_NAME" $VISIBILITY_FLAG --source="$TARGET_PATH" --push; then
+      success "GitHub repository created and pushed"
+    else
+      error "Failed to create repository. Cannot proceed with Full Install."
+    fi
   else
-    error "Failed to create GitHub repository. Cannot proceed with Full Install."
+    warning "GitHub CLI (gh) not available."
+    info "For GitHub repos: install gh CLI (brew install gh)"
+    info "For Gitea repos: create the repository manually and add the remote:"
+    echo "  git remote add origin https://your-gitea-instance/owner/repo.git"
+    echo "  git push -u origin main"
+    error "Cannot auto-create repository without gh CLI. Set up the remote manually and re-run."
   fi
   echo ""
 fi
@@ -514,7 +525,9 @@ if [[ "$FORCE_OVERWRITE" != "true" ]] && [[ "$CLEAN_FIRST" != "true" ]]; then
   fi
 
   # Check 2: Is there already an open installation PR?
-  REPO_NWOPATH=$(git -C "$TARGET_PATH" config --get remote.origin.url 2>/dev/null | sed -E 's#^.*(github\.com[/:])##; s/\.git$//' || true)
+  # Extract owner/repo from URL (handles GitHub, Gitea, and other forges)
+  _ORIGIN_URL=$(git -C "$TARGET_PATH" config --get remote.origin.url 2>/dev/null || true)
+  REPO_NWOPATH=$(echo "$_ORIGIN_URL" | sed -E 's/\.git$//; s#^.*[:/]([^/]+/[^/]+)$#\1#' || true)
   if [[ -n "$REPO_NWOPATH" ]] && [[ "$REPO_NWOPATH" =~ ^[^/]+/[^/]+$ ]]; then
     EXISTING_INSTALL_PR=$(gh pr list -R "$REPO_NWOPATH" --state open --search "Install Loom" --json url,headRefName --jq '
       [.[] | select(.headRefName | startswith("feature/loom-installation"))][0].url' 2>/dev/null || true)
@@ -760,7 +773,7 @@ echo ""
 # STEP 4: Sync GitHub Labels
 # ============================================================================
 CURRENT_STEP="Sync Labels"
-header "Step 4: Syncing GitHub Labels"
+header "Step 4: Syncing Workflow Labels"
 echo ""
 
 if [[ ! -x "$LOOM_ROOT/scripts/install/sync-labels.sh" ]]; then
@@ -818,7 +831,7 @@ else
     else
       echo ""
       warning "Failed to configure branch ruleset (may require admin permissions)"
-      info "You can configure manually via GitHub Settings > Rules > Rulesets"
+      info "You can configure manually via your forge's Settings > Branch Protection"
     fi
   else
     info "Skipping branch ruleset setup"
@@ -932,9 +945,9 @@ PR_URL=$(echo "$LAST_OUTPUT_LINE" | cut -d'|' -f1)
 MERGE_STATUS=$(echo "$LAST_OUTPUT_LINE" | cut -d'|' -f2)
 
 # Validate PR URL - also try to extract from the raw output if parsing failed
-if [[ ! "$PR_URL" =~ ^https://github\.com/ ]]; then
-  # Fallback: try to extract URL from anywhere in the output
-  PR_URL=$(echo "$PR_URL_RAW" | grep -oE 'https://github\.com/[^[:space:]|]+/pull/[0-9]+' | head -1 | tr -d '[:space:]')
+if [[ ! "$PR_URL" =~ ^https:// ]]; then
+  # Fallback: try to extract URL from anywhere in the output (GitHub or Gitea)
+  PR_URL=$(echo "$PR_URL_RAW" | grep -oE 'https://[^[:space:]|]+/(pull|pulls)/[0-9]+' | head -1 | tr -d '[:space:]')
 fi
 
 if [[ ! "$PR_URL" =~ ^https:// ]]; then

--- a/scripts/install/check-workflow-scope.sh
+++ b/scripts/install/check-workflow-scope.sh
@@ -1,21 +1,39 @@
 #!/usr/bin/env bash
 # Check if GitHub CLI has workflow scope for modifying workflow files
 #
+# For Gitea forges, this check is not applicable and always returns success.
+#
 # Returns:
-#   0 - workflow scope is available
+#   0 - workflow scope is available (or not applicable for Gitea)
 #   1 - workflow scope is NOT available
 #   2 - error checking scope
 
 set -euo pipefail
 
-# Get auth status and check for workflow scope
+# Source forge detection helper if available
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -f "${SCRIPT_DIR}/forge-detect.sh" ]]; then
+  source "${SCRIPT_DIR}/forge-detect.sh"
+
+  # Try to detect forge from current directory's git remote
+  ORIGIN_URL=$(git config --get remote.origin.url 2>/dev/null || echo "")
+  if [[ -n "$ORIGIN_URL" ]]; then
+    if detect_forge_and_repo "$ORIGIN_URL" 2>/dev/null; then
+      if [[ "$FORGE_TYPE" == "gitea" ]]; then
+        # Workflow scope check is not applicable for Gitea
+        exit 0
+      fi
+    fi
+  fi
+fi
+
+# GitHub: check for workflow scope
 AUTH_OUTPUT=$(gh auth status 2>&1) || {
   echo "Error: GitHub CLI is not authenticated" >&2
   exit 2
 }
 
 # Check if the workflow scope is listed
-# gh auth status shows scopes like: Token scopes: 'gist', 'read:org', 'repo', 'workflow'
 if echo "$AUTH_OUTPUT" | grep -qE "workflow"; then
   exit 0
 else

--- a/scripts/install/create-pr.sh
+++ b/scripts/install/create-pr.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Create pull request for Loom installation or uninstallation
 #
+# Supports both GitHub (via gh CLI) and Gitea (via API).
+#
 # Environment variables:
 #   LOOM_VERSION       - Loom version string (default: "unknown")
 #   LOOM_COMMIT        - Loom commit hash (default: "unknown")
@@ -16,6 +18,10 @@ BASE_BRANCH="${2:-}"
 LOOM_VERSION="${LOOM_VERSION:-unknown}"
 LOOM_COMMIT="${LOOM_COMMIT:-unknown}"
 FORCE_AUTO_MERGE="${FORCE_AUTO_MERGE:-false}"
+
+# Source forge detection helper
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/forge-detect.sh"
 
 # ANSI color codes
 RED='\033[0;31m'
@@ -48,22 +54,18 @@ fi
 cd "$WORKTREE_PATH"
 
 # Detect the target repository from git remote
-# This ensures we use the fork instead of upstream when both exist
 ORIGIN_URL=$(git config --get remote.origin.url 2>/dev/null || echo "")
 if [[ -z "$ORIGIN_URL" ]]; then
   error "Could not determine repository from git remote"
 fi
 
-# Extract owner/repo from URL (handles both HTTPS and SSH)
-# HTTPS: https://github.com/owner/repo.git -> owner/repo
-# SSH: git@github.com:owner/repo.git -> owner/repo
-REPO=$(echo "$ORIGIN_URL" | sed -E 's#^.*(github\.com[/:])##; s/\.git$//')
-
-if [[ ! "$REPO" =~ ^[^/]+/[^/]+$ ]]; then
-  error "Could not extract valid repository from URL: $ORIGIN_URL"
+# Detect forge type and extract owner/repo
+if ! detect_forge_and_repo "$ORIGIN_URL"; then
+  error "Could not detect forge type from URL: $ORIGIN_URL"
 fi
 
-info "Target repository: $REPO"
+REPO="${FORGE_OWNER}/${FORGE_REPO}"
+info "Target repository: $REPO (${FORGE_TYPE})"
 
 # Get current branch
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
@@ -77,7 +79,6 @@ git add -A
 if git diff --staged --quiet; then
   info "No changes to commit - Loom is already installed"
   info "Skipping commit and PR creation"
-  # Exit successfully with a special marker that the caller can detect
   echo "NO_CHANGES_NEEDED"
   exit 0
 fi
@@ -87,7 +88,7 @@ if [[ -z "${COMMIT_MSG:-}" ]]; then
   COMMIT_MSG=$(cat <<EOF
 Install Loom ${LOOM_VERSION} orchestration framework
 
-Adds Loom configuration and GitHub workflow integration:
+Adds Loom configuration and workflow integration:
 - .loom/ directory with configuration and scripts
 - .claude/commands/ slash commands for roles (/builder, /judge, etc.)
 - .claude/settings.json tool permissions
@@ -107,14 +108,13 @@ success "Changes committed"
 info "Pushing branch: $BRANCH_NAME"
 
 # Push branch (use --force in case branch exists remotely from previous failed installation)
-# Redirect output to stderr so it doesn't interfere with PR URL capture
 PUSH_OUTPUT=""
 PUSH_EXIT_CODE=0
 PUSH_OUTPUT=$(git push -u origin "$BRANCH_NAME" --force 2>&1) || PUSH_EXIT_CODE=$?
 
 if [[ $PUSH_EXIT_CODE -ne 0 ]]; then
-  # Check if the error is due to missing workflow scope
-  if echo "$PUSH_OUTPUT" | grep -q "refusing to allow.*workflow"; then
+  # Check if the error is due to missing workflow scope (GitHub-specific)
+  if [[ "$FORGE_TYPE" == "github" ]] && echo "$PUSH_OUTPUT" | grep -q "refusing to allow.*workflow"; then
     echo "" >&2
     echo -e "${YELLOW}⚠ GitHub rejected push: missing 'workflow' scope${NC}" >&2
     echo "" >&2
@@ -126,10 +126,7 @@ if [[ $PUSH_EXIT_CODE -ne 0 ]]; then
     WORKFLOW_FILES=$(git diff --name-only HEAD~1 HEAD 2>/dev/null | grep "^\.github/workflows/" || true)
 
     if [[ -n "$WORKFLOW_FILES" ]]; then
-      # Unstage workflow files and amend the commit
       git reset HEAD~1 --soft >&2
-
-      # Re-add everything except workflows
       git add -A >&2
       for wf in $WORKFLOW_FILES; do
         if [[ -f "$wf" ]]; then
@@ -138,11 +135,10 @@ if [[ $PUSH_EXIT_CODE -ne 0 ]]; then
         fi
       done
 
-      # Amend commit message to note skipped workflows
       COMMIT_MSG_NO_WORKFLOW=$(cat <<EOF
 Install Loom ${LOOM_VERSION} orchestration framework
 
-Adds Loom configuration and GitHub workflow integration:
+Adds Loom configuration and workflow integration:
 - .loom/ directory with configuration and scripts
 - .claude/ MCP servers and prompts
 - .github/ labels (workflows skipped - requires 'workflow' scope)
@@ -157,7 +153,6 @@ EOF
 )
       git commit -m "$COMMIT_MSG_NO_WORKFLOW" >&2
 
-      # Retry push
       git push -u origin "$BRANCH_NAME" --force >&2 || {
         error "Failed to push even without workflow files"
       }
@@ -182,12 +177,10 @@ EOF
 
       success "Branch pushed (without workflows)"
     else
-      # No workflow files found, but still failed - re-raise the error
       echo "$PUSH_OUTPUT" >&2
       error "Failed to push branch: $BRANCH_NAME"
     fi
   else
-    # Different error - show output and fail
     echo "$PUSH_OUTPUT" >&2
     error "Failed to push branch: $BRANCH_NAME"
   fi
@@ -209,13 +202,13 @@ This PR adds Loom orchestration framework to the repository.
 
 ## What's Included
 
-- ✅ \`.loom/\` - Configuration, roles, and scripts
-- ✅ \`.claude/commands/\` - Slash commands for roles (/builder, /judge, /curator, etc.)
-- ✅ \`.claude/settings.json\` - Claude Code tool permissions
-- ✅ \`.github/\` - Labels and workflows
-- ✅ \`CLAUDE.md\` - Documentation with Loom reference
+- \`.loom/\` - Configuration, roles, and scripts
+- \`.claude/commands/\` - Slash commands for roles (/builder, /judge, etc.)
+- \`.claude/settings.json\` - Claude Code tool permissions
+- \`.github/\` - Labels and workflows
+- \`CLAUDE.md\` - Documentation with Loom reference
 
-## GitHub Labels
+## Labels
 
 Synced Loom workflow labels via \`.github/labels.yml\`
 
@@ -228,7 +221,7 @@ After merging:
 See \`CLAUDE.md\` for complete usage details.
 
 ---
-🤖 Generated by [Loom](https://github.com/rjwalters/loom) installation
+Generated by [Loom](https://github.com/rjwalters/loom) installation
 EOF
   )
 fi
@@ -238,54 +231,111 @@ if [[ -z "${PR_TITLE:-}" ]]; then
   PR_TITLE="Install Loom ${LOOM_VERSION}"
 fi
 
-# Create pull request and capture the URL
-# Redirect stderr to stdout to capture the full output, then extract the URL
-# Use || to prevent set -e from exiting before we can report the error
-GH_PR_EXIT=0
-GH_PR_OUTPUT=$(gh pr create \
-  -R "$REPO" \
-  --base "$BASE_BRANCH" \
-  --title "$PR_TITLE" \
-  --body "$PR_BODY" \
-  --label "loom:pr" 2>&1) || GH_PR_EXIT=$?
+# ============================================================================
+# Create PR - forge-specific
+# ============================================================================
 
-if [[ $GH_PR_EXIT -ne 0 ]]; then
-  # Check if a PR already exists for this branch
-  if echo "$GH_PR_OUTPUT" | grep -qi "already exists"; then
-    warning "A pull request already exists for this branch"
-    info "Looking up existing PR..."
+PR_URL=""
 
-    # Find the existing PR URL
-    EXISTING_PR=$(gh pr list -R "$REPO" --head "$BRANCH_NAME" --base "$BASE_BRANCH" --json url --jq '.[0].url' 2>/dev/null || true)
+if [[ "$FORGE_TYPE" == "github" ]]; then
+  # Create PR via GitHub CLI
+  GH_PR_EXIT=0
+  GH_PR_OUTPUT=$(gh pr create \
+    -R "$REPO" \
+    --base "$BASE_BRANCH" \
+    --title "$PR_TITLE" \
+    --body "$PR_BODY" \
+    --label "loom:pr" 2>&1) || GH_PR_EXIT=$?
 
-    if [[ -n "$EXISTING_PR" ]]; then
-      success "Found existing PR: $EXISTING_PR"
-      PR_URL="$EXISTING_PR"
+  if [[ $GH_PR_EXIT -ne 0 ]]; then
+    if echo "$GH_PR_OUTPUT" | grep -qi "already exists"; then
+      warning "A pull request already exists for this branch"
+      info "Looking up existing PR..."
+
+      EXISTING_PR=$(gh pr list -R "$REPO" --head "$BRANCH_NAME" --base "$BASE_BRANCH" --json url --jq '.[0].url' 2>/dev/null || true)
+
+      if [[ -n "$EXISTING_PR" ]]; then
+        success "Found existing PR: $EXISTING_PR"
+        PR_URL="$EXISTING_PR"
+      else
+        echo "Error: PR already exists but could not find its URL" >&2
+        echo "gh output was:" >&2
+        echo "$GH_PR_OUTPUT" >&2
+        exit 1
+      fi
     else
-      echo "Error: PR already exists but could not find its URL" >&2
+      echo "Error: Failed to create pull request" >&2
       echo "gh output was:" >&2
       echo "$GH_PR_OUTPUT" >&2
       exit 1
     fi
   else
-    echo "Error: Failed to create pull request" >&2
-    echo "gh output was:" >&2
-    echo "$GH_PR_OUTPUT" >&2
-    exit 1
-  fi
-else
-  # Extract URL from output (gh CLI outputs the PR URL as the last line)
-  PR_URL=$(echo "$GH_PR_OUTPUT" | grep -oE 'https://github\.com/[^[:space:]]+/pull/[0-9]+' | head -1 | tr -d '[:space:]')
+    PR_URL=$(echo "$GH_PR_OUTPUT" | grep -oE 'https://[^[:space:]]+/pull/[0-9]+' | head -1 | tr -d '[:space:]')
 
-  # Validate the URL
-  if [[ -z "$PR_URL" ]] || [[ ! "$PR_URL" =~ ^https://github\.com/[^[:space:]]+/pull/[0-9]+$ ]]; then
-    echo "Error: Failed to create PR or invalid URL returned" >&2
-    echo "gh output was:" >&2
-    echo "$GH_PR_OUTPUT" >&2
-    exit 1
+    if [[ -z "$PR_URL" ]]; then
+      echo "Error: Failed to create PR or invalid URL returned" >&2
+      echo "gh output was:" >&2
+      echo "$GH_PR_OUTPUT" >&2
+      exit 1
+    fi
+
+    success "Pull request created: $PR_URL"
   fi
 
-  success "Pull request created: $PR_URL"
+elif [[ "$FORGE_TYPE" == "gitea" ]]; then
+  # Create PR via Gitea API
+  if [[ -z "$FORGE_TOKEN" ]]; then
+    error "Gitea API token required to create pull request. Set GITEA_TOKEN or FORGE_TOKEN."
+  fi
+
+  PR_PAYLOAD=$(cat <<EOJSON
+{
+  "title": $(echo "$PR_TITLE" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read().strip()))'),
+  "body": $(echo "$PR_BODY" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read().strip()))'),
+  "head": "$BRANCH_NAME",
+  "base": "$BASE_BRANCH",
+  "labels": []
+}
+EOJSON
+  )
+
+  GITEA_RESPONSE=$(gitea_api POST "/repos/${FORGE_OWNER}/${FORGE_REPO}/pulls" "$PR_PAYLOAD")
+  GITEA_HTTP_CODE=$(echo "$GITEA_RESPONSE" | tail -1)
+  GITEA_BODY=$(echo "$GITEA_RESPONSE" | sed '$d')
+
+  if [[ "$GITEA_HTTP_CODE" == "201" ]]; then
+    PR_URL=$(echo "$GITEA_BODY" | python3 -c 'import json,sys; data=json.load(sys.stdin); print(data.get("html_url",""))' 2>/dev/null || echo "")
+    PR_NUMBER=$(echo "$GITEA_BODY" | python3 -c 'import json,sys; data=json.load(sys.stdin); print(data.get("number",""))' 2>/dev/null || echo "")
+
+    if [[ -n "$PR_URL" ]]; then
+      success "Pull request created: $PR_URL"
+
+      # Try to add loom:pr label
+      if [[ -n "$PR_NUMBER" ]]; then
+        gitea_api POST "/repos/${FORGE_OWNER}/${FORGE_REPO}/issues/${PR_NUMBER}/labels" '{"labels":["loom:pr"]}' > /dev/null 2>&1 || true
+      fi
+    else
+      warning "PR created but could not extract URL from response"
+      PR_URL="unknown"
+    fi
+
+  elif [[ "$GITEA_HTTP_CODE" == "409" ]]; then
+    warning "A pull request already exists for this branch"
+    # Try to find existing PR
+    EXISTING_RESPONSE=$(gitea_api GET "/repos/${FORGE_OWNER}/${FORGE_REPO}/pulls?state=open&head=${FORGE_OWNER}:${BRANCH_NAME}&base=${BASE_BRANCH}")
+    EXISTING_BODY=$(echo "$EXISTING_RESPONSE" | sed '$d')
+    PR_URL=$(echo "$EXISTING_BODY" | python3 -c 'import json,sys; data=json.load(sys.stdin); print(data[0].get("html_url","") if data else "")' 2>/dev/null || echo "")
+
+    if [[ -n "$PR_URL" ]]; then
+      success "Found existing PR: $PR_URL"
+    else
+      error "PR already exists but could not find its URL"
+    fi
+  else
+    echo "Error: Failed to create pull request (HTTP $GITEA_HTTP_CODE)" >&2
+    echo "Response: $GITEA_BODY" >&2
+    exit 1
+  fi
 fi
 
 # ============================================================================
@@ -296,21 +346,39 @@ MERGE_STATUS="manual"
 if [[ "$FORCE_AUTO_MERGE" == "true" ]]; then
   info "Force mode: Attempting to merge PR..."
 
-  # First try immediate squash merge (works when no review requirements or 0 approvals)
-  # Note: We use --squash because Loom's repository settings disable merge commits
-  if gh pr merge "$PR_URL" --squash --delete-branch 2>/dev/null; then
-    success "PR merged successfully"
-    MERGE_STATUS="merged"
-  else
-    # If immediate merge fails, try enabling auto-merge
-    info "Immediate merge not available (ruleset may require reviews)"
-    if gh pr merge "$PR_URL" --auto --squash --delete-branch 2>/dev/null; then
-      success "Auto-merge enabled - PR will merge once requirements are met"
-      MERGE_STATUS="auto"
+  if [[ "$FORGE_TYPE" == "github" ]]; then
+    if gh pr merge "$PR_URL" --squash --delete-branch 2>/dev/null; then
+      success "PR merged successfully"
+      MERGE_STATUS="merged"
     else
-      warning "Could not merge or enable auto-merge - manual merge required"
-      warning "This may be because auto-merge is not enabled on the repository"
-      info "To enable: GitHub Settings > General > Allow auto-merge"
+      info "Immediate merge not available (ruleset may require reviews)"
+      if gh pr merge "$PR_URL" --auto --squash --delete-branch 2>/dev/null; then
+        success "Auto-merge enabled - PR will merge once requirements are met"
+        MERGE_STATUS="auto"
+      else
+        warning "Could not merge or enable auto-merge - manual merge required"
+        warning "This may be because auto-merge is not enabled on the repository"
+        info "To enable: GitHub Settings > General > Allow auto-merge"
+        MERGE_STATUS="manual"
+      fi
+    fi
+
+  elif [[ "$FORGE_TYPE" == "gitea" ]]; then
+    # Extract PR number for Gitea merge
+    GITEA_PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$' || echo "")
+    if [[ -n "$GITEA_PR_NUMBER" ]]; then
+      MERGE_RESPONSE=$(gitea_api POST "/repos/${FORGE_OWNER}/${FORGE_REPO}/pulls/${GITEA_PR_NUMBER}/merge" '{"Do":"squash","delete_branch_after_merge":true}')
+      MERGE_CODE=$(echo "$MERGE_RESPONSE" | tail -1)
+
+      if [[ "$MERGE_CODE" == "200" || "$MERGE_CODE" == "204" ]]; then
+        success "PR merged successfully"
+        MERGE_STATUS="merged"
+      else
+        warning "Could not merge PR - manual merge required (HTTP $MERGE_CODE)"
+        MERGE_STATUS="manual"
+      fi
+    else
+      warning "Could not extract PR number for merge"
       MERGE_STATUS="manual"
     fi
   fi
@@ -319,7 +387,5 @@ else
 fi
 
 # Output the PR URL and merge status (stdout, so it can be captured by caller)
-# Format: PR_URL|MERGE_STATUS
-# Use exec to ensure we're writing directly to FD 1 without any buffering issues
-exec 1>&1  # Ensure FD 1 is stdout
+exec 1>&1
 printf "%s|%s" "$PR_URL" "$MERGE_STATUS"

--- a/scripts/install/sync-labels.sh
+++ b/scripts/install/sync-labels.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
-# Sync GitHub labels from .github/labels.yml
+# Sync workflow labels from .github/labels.yml
+#
+# Supports both GitHub (via gh CLI) and Gitea (via API).
 
 set -euo pipefail
 
 WORKTREE_PATH="${1:-.}"
+
+# Source forge detection helper
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/forge-detect.sh"
 
 # ANSI color codes
 RED='\033[0;31m'
@@ -32,22 +38,18 @@ warning() {
 cd "$WORKTREE_PATH"
 
 # Detect the target repository from git remote
-# This ensures we use the fork instead of upstream when both exist
 ORIGIN_URL=$(git config --get remote.origin.url 2>/dev/null || echo "")
 if [[ -z "$ORIGIN_URL" ]]; then
   error "Could not determine repository from git remote"
 fi
 
-# Extract owner/repo from URL (handles both HTTPS and SSH)
-# HTTPS: https://github.com/owner/repo.git -> owner/repo
-# SSH: git@github.com:owner/repo.git -> owner/repo
-REPO=$(echo "$ORIGIN_URL" | sed -E 's#^.*(github\.com[/:])##; s/\.git$//')
-
-if [[ ! "$REPO" =~ ^[^/]+/[^/]+$ ]]; then
-  error "Could not extract valid repository from URL: $ORIGIN_URL"
+# Detect forge type and extract owner/repo
+if ! detect_forge_and_repo "$ORIGIN_URL"; then
+  error "Could not detect forge type from URL: $ORIGIN_URL"
 fi
 
-info "Target repository: $REPO"
+REPO="${FORGE_OWNER}/${FORGE_REPO}"
+info "Target repository: $REPO (${FORGE_TYPE})"
 
 LABELS_FILE=".github/labels.yml"
 
@@ -57,9 +59,141 @@ if [[ ! -f "$LABELS_FILE" ]]; then
   exit 0
 fi
 
-info "Syncing GitHub labels from $LABELS_FILE..."
+info "Syncing workflow labels from $LABELS_FILE..."
 
-# Remove default GitHub labels that clutter issue tracking
+# ============================================================================
+# GitHub label operations
+# ============================================================================
+
+github_delete_label() {
+  local label="$1"
+  if output=$(gh label delete "$label" -R "$REPO" --yes 2>&1); then
+    info "Deleted default label: $label"
+  elif ! echo "$output" | grep -qi "not found\|404"; then
+    warning "Could not delete label '$label': $output"
+  fi
+}
+
+github_sync_label() {
+  local name="$1" description="$2" color="$3"
+
+  if gh label list -R "$REPO" --json name --jq '.[].name' 2>&1 | grep -q "^${name}$" 2>/dev/null; then
+    if output=$(gh label edit "$name" -R "$REPO" --description "$description" --color "$color" 2>&1); then
+      info "Updated label: $name"
+    else
+      warning "Failed to update label: $name"
+      echo "$output" >&2
+    fi
+  else
+    if output=$(gh label create "$name" -R "$REPO" --description "$description" --color "$color" 2>&1); then
+      info "Created label: $name"
+    else
+      if echo "$output" | grep -q "already exists"; then
+        if update_output=$(gh label edit "$name" -R "$REPO" --description "$description" --color "$color" 2>&1); then
+          info "Updated label: $name"
+        else
+          warning "Failed to update label: $name"
+          echo "$update_output" >&2
+        fi
+      else
+        warning "Failed to create label: $name"
+        echo "$output" >&2
+      fi
+    fi
+  fi
+}
+
+# ============================================================================
+# Gitea label operations
+# ============================================================================
+
+gitea_delete_label() {
+  local label="$1"
+
+  # Find label ID by name
+  local response body http_code label_id
+  response=$(gitea_api GET "/repos/${FORGE_OWNER}/${FORGE_REPO}/labels")
+  http_code=$(echo "$response" | tail -1)
+  body=$(echo "$response" | sed '$d')
+
+  if [[ "$http_code" != "200" ]]; then
+    warning "Could not list labels to delete '$label'"
+    return
+  fi
+
+  label_id=$(echo "$body" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for l in data:
+    if l['name'] == '$label':
+        print(l['id'])
+        break
+" 2>/dev/null || echo "")
+
+  if [[ -n "$label_id" ]]; then
+    local del_response del_code
+    del_response=$(gitea_api DELETE "/repos/${FORGE_OWNER}/${FORGE_REPO}/labels/${label_id}")
+    del_code=$(echo "$del_response" | tail -1)
+    if [[ "$del_code" == "204" ]]; then
+      info "Deleted default label: $label"
+    else
+      warning "Could not delete label '$label' (HTTP $del_code)"
+    fi
+  fi
+}
+
+gitea_sync_label() {
+  local name="$1" description="$2" color="$3"
+
+  # Check if label exists
+  local response body http_code label_id
+  response=$(gitea_api GET "/repos/${FORGE_OWNER}/${FORGE_REPO}/labels")
+  http_code=$(echo "$response" | tail -1)
+  body=$(echo "$response" | sed '$d')
+
+  label_id=""
+  if [[ "$http_code" == "200" ]]; then
+    label_id=$(echo "$body" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for l in data:
+    if l['name'] == $(python3 -c "import json; print(json.dumps('$name'))"):
+        print(l['id'])
+        break
+" 2>/dev/null || echo "")
+  fi
+
+  local payload
+  payload="{\"name\":$(echo "$name" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read().strip()))'),\"description\":$(echo "$description" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read().strip()))'),\"color\":\"#${color}\"}"
+
+  if [[ -n "$label_id" ]]; then
+    # Update existing label
+    local update_response update_code
+    update_response=$(gitea_api PATCH "/repos/${FORGE_OWNER}/${FORGE_REPO}/labels/${label_id}" "$payload")
+    update_code=$(echo "$update_response" | tail -1)
+    if [[ "$update_code" == "200" ]]; then
+      info "Updated label: $name"
+    else
+      warning "Failed to update label: $name (HTTP $update_code)"
+    fi
+  else
+    # Create new label
+    local create_response create_code
+    create_response=$(gitea_api POST "/repos/${FORGE_OWNER}/${FORGE_REPO}/labels" "$payload")
+    create_code=$(echo "$create_response" | tail -1)
+    if [[ "$create_code" == "201" ]]; then
+      info "Created label: $name"
+    else
+      warning "Failed to create label: $name (HTTP $create_code)"
+    fi
+  fi
+}
+
+# ============================================================================
+# Main sync logic
+# ============================================================================
+
+# Remove default labels that clutter issue tracking
 DEFAULT_LABELS=(
   "bug"
   "documentation"
@@ -72,37 +206,30 @@ DEFAULT_LABELS=(
   "wontfix"
 )
 
-info "Removing default GitHub labels..."
+info "Removing default labels..."
 for label in "${DEFAULT_LABELS[@]}"; do
-  if output=$(gh label delete "$label" -R "$REPO" --yes 2>&1); then
-    info "Deleted default label: $label"
-  elif ! echo "$output" | grep -qi "not found\|404"; then
-    # Only warn if it failed for a reason other than "not found" or 404
-    warning "Could not delete label '$label': $output"
+  if [[ "$FORGE_TYPE" == "github" ]]; then
+    github_delete_label "$label"
+  elif [[ "$FORGE_TYPE" == "gitea" ]]; then
+    gitea_delete_label "$label"
   fi
 done
 
 # Sync Loom workflow labels
-# This will:
-# - Create missing labels
-# - Update existing labels with new descriptions/colors
 info "Syncing Loom workflow labels..."
 
-# Parse YAML file and sync labels
-# YAML format: - name: label-name\n  description: desc\n  color: "HEXCODE"
 label_count=0
 while IFS= read -u 3 -r line; do
-  # Extract label name
   if [[ "$line" =~ ^-\ name:\ (.+)$ ]]; then
     name="${BASH_REMATCH[1]}"
-    # Read next two lines for description and color
     read -u 3 -r desc_line
     read -u 3 -r color_line
 
-    # Extract description and color
+    description=""
+    color=""
+
     if [[ "$desc_line" =~ description:\ (.+)$ ]]; then
       description="${BASH_REMATCH[1]}"
-      # Remove quotes if present
       description="${description//\"/}"
     fi
 
@@ -110,35 +237,10 @@ while IFS= read -u 3 -r line; do
       color="${BASH_REMATCH[1]}"
     fi
 
-    # Try to create or update the label
-    # Use gh label list to check existence, suppressing grep's stderr only
-    if gh label list -R "$REPO" --json name --jq '.[].name' 2>&1 | grep -q "^${name}$" 2>/dev/null; then
-      # Label exists, update it
-      if output=$(gh label edit "$name" -R "$REPO" --description "$description" --color "$color" 2>&1); then
-        info "Updated label: $name"
-      else
-        warning "Failed to update label: $name"
-        echo "$output" >&2
-      fi
-    else
-      # Label doesn't exist, create it
-      if output=$(gh label create "$name" -R "$REPO" --description "$description" --color "$color" 2>&1); then
-        info "Created label: $name"
-      else
-        # Check if it failed because the label already exists
-        if echo "$output" | grep -q "already exists"; then
-          info "Label '$name' already exists, attempting update instead..."
-          if update_output=$(gh label edit "$name" -R "$REPO" --description "$description" --color "$color" 2>&1); then
-            info "Updated label: $name"
-          else
-            warning "Failed to update label: $name"
-            echo "$update_output" >&2
-          fi
-        else
-          warning "Failed to create label: $name"
-          echo "$output" >&2
-        fi
-      fi
+    if [[ "$FORGE_TYPE" == "github" ]]; then
+      github_sync_label "$name" "$description" "$color"
+    elif [[ "$FORGE_TYPE" == "gitea" ]]; then
+      gitea_sync_label "$name" "$description" "$color"
     fi
 
     ((label_count++)) || true

--- a/scripts/install/validate-target.sh
+++ b/scripts/install/validate-target.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
 # Validate target repository for Loom installation
+#
+# Supports both GitHub and Gitea repositories.
+# For GitHub: requires gh CLI and authentication.
+# For Gitea: requires GITEA_TOKEN or FORGE_TOKEN environment variable.
 
 set -euo pipefail
 
 TARGET_PATH="${1:-.}"
+
+# Source forge detection helper
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/forge-detect.sh"
 
 # ANSI color codes
 RED='\033[0;31m'
@@ -36,42 +44,58 @@ if [[ ! -d "$TARGET_PATH/.git" ]]; then
 fi
 success "Git repository detected"
 
-# Check if gh CLI is available
-if ! command -v gh &> /dev/null; then
-  error "GitHub CLI (gh) is not installed. Install from: https://cli.github.com/"
-fi
-success "GitHub CLI (gh) available"
-
-# Check if gh is authenticated
-if ! gh auth status &> /dev/null; then
-  error "GitHub CLI is not authenticated. Run: gh auth login"
-fi
-success "GitHub CLI authenticated"
-
 # Check if we can determine the remote repository
 cd "$TARGET_PATH"
 
 # Detect the repository from origin remote (not upstream)
 ORIGIN_URL=$(git config --get remote.origin.url 2>/dev/null || echo "")
 if [[ -z "$ORIGIN_URL" ]]; then
-  error "Unable to determine GitHub repository. Ensure origin remote is set."
+  error "Unable to determine remote repository. Ensure origin remote is set."
 fi
 
-# Extract owner/repo from URL (handles both HTTPS and SSH)
-# HTTPS: https://github.com/owner/repo.git -> owner/repo
-# SSH: git@github.com:owner/repo.git -> owner/repo
-REPO_NAME=$(echo "$ORIGIN_URL" | sed -E 's#^.*(github\.com[/:])##; s/\.git$//')
-
-if [[ ! "$REPO_NAME" =~ ^[^/]+/[^/]+$ ]]; then
-  error "Could not extract valid repository from URL: $ORIGIN_URL"
+# Detect forge type and extract owner/repo
+if ! detect_forge_and_repo "$ORIGIN_URL"; then
+  error "Could not detect forge type from URL: $ORIGIN_URL"
 fi
 
-# Verify gh can access this repository
-if ! gh repo view "$REPO_NAME" &> /dev/null; then
-  error "Unable to access GitHub repository: $REPO_NAME. Check your gh authentication."
+REPO_NAME="${FORGE_OWNER}/${FORGE_REPO}"
+
+# Forge-specific validation
+if [[ "$FORGE_TYPE" == "github" ]]; then
+  # Check if gh CLI is available
+  if ! command -v gh &> /dev/null; then
+    error "GitHub CLI (gh) is not installed. Install from: https://cli.github.com/"
+  fi
+  success "GitHub CLI (gh) available"
+
+  # Check if gh is authenticated
+  if ! gh auth status &> /dev/null; then
+    error "GitHub CLI is not authenticated. Run: gh auth login"
+  fi
+  success "GitHub CLI authenticated"
+
+  # Verify gh can access this repository
+  if ! gh repo view "$REPO_NAME" &> /dev/null; then
+    error "Unable to access repository: $REPO_NAME. Check your gh authentication."
+  fi
+
+elif [[ "$FORGE_TYPE" == "gitea" ]]; then
+  # Validate Gitea token
+  if [[ -z "$FORGE_TOKEN" ]]; then
+    error "Gitea API token required. Set GITEA_TOKEN or FORGE_TOKEN environment variable.\n       Create a token at: <your-gitea-instance>/user/settings/applications"
+  fi
+  success "Gitea API token configured"
+
+  # Verify API access to the repository
+  local_response=$(gitea_api GET "/repos/${FORGE_OWNER}/${FORGE_REPO}")
+  local_code=$(echo "$local_response" | tail -1)
+  if [[ "$local_code" != "200" ]]; then
+    error "Unable to access Gitea repository: $REPO_NAME (HTTP $local_code). Check your API token and URL."
+  fi
+  success "Gitea API access verified"
 fi
 
-success "GitHub repository: $REPO_NAME"
+success "${FORGE_TYPE^} repository: $REPO_NAME"
 
 # Check git status - warn if dirty
 if [[ -n "$(git status --porcelain)" ]]; then
@@ -83,3 +107,4 @@ success "Validation complete"
 echo ""
 echo "Target repository: $REPO_NAME"
 echo "Target path: $TARGET_PATH"
+echo "Forge type: $FORGE_TYPE"


### PR DESCRIPTION
## Summary

Updates installation scripts and documentation for multi-forge (GitHub + Gitea) support:

- **validate-target.sh**: Uses forge-detect.sh for forge-agnostic validation (gh CLI for GitHub, API token for Gitea)
- **create-pr.sh**: Creates PRs via gh CLI (GitHub) or Gitea API, with forge-specific merge support
- **sync-labels.sh**: Syncs labels via gh CLI (GitHub) or Gitea API (create/update/delete)
- **check-workflow-scope.sh**: No-ops for Gitea (workflow scope is GitHub-only)
- **defaults/config.json**: Adds `forge` configuration section
- **install.sh / install-loom.sh**: Forge-aware messaging and validation
- **CLAUDE.md templates**: Multi-forge context and notes throughout
- **README.md**: Adds Supported Forges line
- **forge-authentication.md**: New docs covering Gitea token setup

Closes #3157