### PR TITLE
feat: add forge-agnostic auto-merge with poll-and-merge for Gitea

### DIFF
--- a/defaults/scripts/merge-pr.sh
+++ b/defaults/scripts/merge-pr.sh
@@ -139,6 +139,17 @@ if [[ "$AUTO_MERGE" == "true" ]]; then
     info "[dry-run] Would enable auto-merge for PR #$PR_NUMBER"
     exit 0
   fi
+  # Prefer loom-auto-merge CLI (forge-agnostic, with poll-and-merge for Gitea)
+  if command -v loom-auto-merge &>/dev/null; then
+    info "Using loom-auto-merge (forge-agnostic auto-merge)"
+    if loom-auto-merge "$PR_NUMBER" --method squash; then
+      success "Auto-merge completed for PR #$PR_NUMBER"
+      exit 0
+    else
+      error "Failed to auto-merge PR #$PR_NUMBER"
+    fi
+  fi
+  # Fallback: shell-based forge_auto_merge
   if forge_auto_merge "$REPO_NWO" "$PR_NUMBER" 2>/dev/null; then
     success "Auto-merge enabled for PR #$PR_NUMBER"
     exit 0

--- a/loom-tools/pyproject.toml
+++ b/loom-tools/pyproject.toml
@@ -43,6 +43,7 @@ loom-test-failure-analysis = "loom_tools.test_failure_analysis:main"
 loom-usage = "loom_tools.common.usage:main"
 loom-backlog = "loom_tools.backlog:main"
 loom-forge = "loom_tools.forge_cli:cli_main"
+loom-auto-merge = "loom_tools.auto_merge:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/loom-tools/src/loom_tools/auto_merge.py
+++ b/loom-tools/src/loom_tools/auto_merge.py
@@ -1,0 +1,98 @@
+"""CLI entry point for forge-agnostic auto-merge.
+
+Enables auto-merge for a PR using the appropriate forge backend:
+- GitHub: delegates to ``gh pr merge --auto`` (server-side queue)
+- Gitea: polls CI status and merges when checks pass
+
+Usage::
+
+    loom-auto-merge <pr-number> [--method squash] [--poll-interval 30] [--timeout 600]
+
+Environment variables::
+
+    LOOM_AUTO_MERGE_POLL_INTERVAL  - Poll interval in seconds (default: 30)
+    LOOM_AUTO_MERGE_TIMEOUT        - Timeout in seconds (default: 600)
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+logger = logging.getLogger(__name__)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for ``loom-auto-merge``."""
+    parser = argparse.ArgumentParser(
+        prog="loom-auto-merge",
+        description="Enable auto-merge for a PR (forge-agnostic)",
+    )
+    parser.add_argument(
+        "pr_number",
+        type=int,
+        help="Pull request number",
+    )
+    parser.add_argument(
+        "--method",
+        default="squash",
+        choices=["squash", "merge", "rebase"],
+        help="Merge method (default: squash)",
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=int,
+        default=int(os.environ.get("LOOM_AUTO_MERGE_POLL_INTERVAL", "30")),
+        help="Seconds between CI status polls (default: 30, env: LOOM_AUTO_MERGE_POLL_INTERVAL)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=int(os.environ.get("LOOM_AUTO_MERGE_TIMEOUT", "600")),
+        help="Max seconds to wait for CI (default: 600, env: LOOM_AUTO_MERGE_TIMEOUT)",
+    )
+    parser.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        help="Enable verbose logging",
+    )
+
+    args = parser.parse_args(argv)
+
+    # Configure logging
+    level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(levelname)s: %(message)s",
+        stream=sys.stderr,
+    )
+
+    from loom_tools.common.forge import get_forge
+
+    forge = get_forge(cached=False)
+
+    logger.info(
+        "Auto-merge PR #%d via %s (method=%s, poll=%ds, timeout=%ds)",
+        args.pr_number, forge.forge_type, args.method,
+        args.poll_interval, args.timeout,
+    )
+
+    success = forge.auto_merge_pull_request(
+        args.pr_number,
+        method=args.method,
+        poll_interval=args.poll_interval,
+        timeout=args.timeout,
+    )
+
+    if success:
+        print(f"Auto-merge {'enabled' if forge.forge_type == 'github' else 'completed'} for PR #{args.pr_number}")
+        return 0
+    else:
+        print(f"Failed to auto-merge PR #{args.pr_number}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/loom-tools/src/loom_tools/common/cached_forge.py
+++ b/loom-tools/src/loom_tools/common/cached_forge.py
@@ -591,6 +591,22 @@ class CachedForgeClient:
             self._invalidate("merge_pull_request", entity_id=str(number))
         return result
 
+    def auto_merge_pull_request(
+        self,
+        number: int,
+        method: str = "squash",
+        poll_interval: int = 30,
+        timeout: int = 600,
+    ) -> bool:
+        # Mutations bypass cache; invalidate PR entries on success.
+        result = self._inner.auto_merge_pull_request(
+            number, method=method,
+            poll_interval=poll_interval, timeout=timeout,
+        )
+        if result:
+            self._invalidate("auto_merge_pull_request", entity_id=str(number))
+        return result
+
     def comment_on_pull_request(self, number: int, body: str) -> bool:
         result = self._inner.comment_on_pull_request(number, body)
         if result:
@@ -651,6 +667,15 @@ class CachedForgeClient:
             return cached
         result = self._inner.get_default_branch_ci_status()
         self._put_cached("get_default_branch_ci_status", ar, result)
+        return result
+
+    def get_commit_ci_status(self, sha: str) -> ForgeCIStatus:
+        ar = self._args_repr(sha)
+        cached = self._get_cached("get_commit_ci_status", ar)
+        if cached is not _MISSING:
+            return cached
+        result = self._inner.get_commit_ci_status(sha)
+        self._put_cached("get_commit_ci_status", ar, result)
         return result
 
     # --- Repository metadata (cached, long TTL) ---

--- a/loom-tools/src/loom_tools/common/forge.py
+++ b/loom-tools/src/loom_tools/common/forge.py
@@ -399,6 +399,35 @@ class ForgeClient(Protocol):
         """
         ...
 
+    def auto_merge_pull_request(
+        self,
+        number: int,
+        method: str = "squash",
+        poll_interval: int = 30,
+        timeout: int = 600,
+    ) -> bool:
+        """Enable auto-merge or poll-and-merge for a pull request.
+
+        For forges with native auto-merge support (e.g. GitHub), this
+        enables auto-merge and returns immediately. For forges without
+        native support (e.g. Gitea), this polls CI status and merges
+        when checks pass.
+
+        Parameters
+        ----------
+        number:
+            PR number.
+        method:
+            Merge method (``"squash"``, ``"merge"``, ``"rebase"``).
+        poll_interval:
+            Seconds between CI status polls (Gitea only).
+        timeout:
+            Maximum seconds to wait for CI before giving up (Gitea only).
+
+        Returns ``True`` if the PR was merged or auto-merge was enabled.
+        """
+        ...
+
     def comment_on_pull_request(self, number: int, body: str) -> bool:
         """Add a comment to a pull request. Returns ``True`` on success."""
         ...

--- a/loom-tools/src/loom_tools/common/gitea.py
+++ b/loom-tools/src/loom_tools/common/gitea.py
@@ -600,6 +600,148 @@ class GiteaForge:
         resp = self._request("POST", f"{rp}/pulls/{number}/merge", json=payload)
         return resp is not None
 
+    def auto_merge_pull_request(
+        self,
+        number: int,
+        method: str = "squash",
+        poll_interval: int = 30,
+        timeout: int = 600,
+    ) -> bool:
+        """Poll CI status and merge when checks pass.
+
+        Gitea has no native auto-merge queue, so this polls the CI
+        status of the PR's head commit and merges once all checks
+        are green. If no CI checks are found, merges immediately
+        (assumes no branch protection requires checks).
+
+        Parameters
+        ----------
+        number:
+            PR number.
+        method:
+            Merge method (``"squash"``, ``"merge"``, ``"rebase"``).
+        poll_interval:
+            Seconds between CI status polls.
+        timeout:
+            Maximum seconds to wait for CI before giving up.
+        """
+        rp = self._repo_path()
+        if not rp:
+            return False
+
+        # Get PR to extract head SHA
+        resp = self._request("GET", f"{rp}/pulls/{number}")
+        if resp is None:
+            logger.error("Cannot fetch PR #%d for auto-merge", number)
+            return False
+        try:
+            pr_data = resp.json()
+        except ValueError:
+            logger.error("Invalid JSON from PR #%d", number)
+            return False
+        if not isinstance(pr_data, dict):
+            return False
+
+        # Check if already merged
+        if pr_data.get("merged") is True:
+            logger.info("PR #%d is already merged", number)
+            return True
+
+        head_info = pr_data.get("head", {})
+        head_sha = head_info.get("sha") if isinstance(head_info, dict) else None
+        if not head_sha:
+            logger.warning(
+                "Cannot determine head SHA for PR #%d, attempting immediate merge",
+                number,
+            )
+            return self.merge_pull_request(number, method=method)
+
+        logger.info(
+            "Starting poll-and-merge for PR #%d (sha=%s, interval=%ds, timeout=%ds)",
+            number, head_sha[:8], poll_interval, timeout,
+        )
+
+        elapsed = 0
+        while elapsed < timeout:
+            ci_result = self._get_raw_ci_state(head_sha)
+
+            if ci_result == "passing":
+                logger.info("CI passing for PR #%d, merging", number)
+                return self.merge_pull_request(number, method=method)
+
+            if ci_result == "failing":
+                logger.warning("CI failing for PR #%d", number)
+                return False
+
+            if ci_result == "no_checks":
+                logger.info(
+                    "No CI checks found for PR #%d, merging immediately",
+                    number,
+                )
+                return self.merge_pull_request(number, method=method)
+
+            # CI pending — wait and retry
+            logger.info(
+                "CI pending for PR #%d, waiting %ds... (%d/%ds elapsed)",
+                number, poll_interval, elapsed, timeout,
+            )
+            time.sleep(poll_interval)
+            elapsed += poll_interval
+
+        logger.warning(
+            "Timeout waiting for CI on PR #%d after %ds", number, timeout,
+        )
+        return False
+
+    def _get_raw_ci_state(self, sha: str) -> str:
+        """Query raw CI state for a commit, distinguishing pending from passing.
+
+        Returns one of: ``"passing"``, ``"failing"``, ``"pending"``,
+        ``"no_checks"``.
+
+        Unlike ``get_commit_ci_status()`` which treats pending as passing
+        (optimistic for dashboard display), this method distinguishes
+        pending checks so the auto-merge poll loop can wait for completion.
+        """
+        rp = self._repo_path()
+        if not rp:
+            return "no_checks"
+
+        # Fetch commit statuses
+        resp = self._request("GET", f"{rp}/commits/{sha}/statuses")
+        statuses: list[dict[str, Any]] = []
+        if resp is not None:
+            try:
+                data = resp.json()
+                if isinstance(data, list):
+                    statuses = data
+            except ValueError:
+                pass
+
+        # Group by context, take latest
+        latest_by_context: dict[str, str] = {}
+        for s in statuses:
+            if not isinstance(s, dict):
+                continue
+            ctx = s.get("context", "unknown")
+            if ctx not in latest_by_context:
+                latest_by_context[ctx] = self._classify_gitea_status(
+                    s.get("status", ""),
+                )
+
+        if not latest_by_context:
+            return "no_checks"
+
+        has_failure = any(v == "failure" for v in latest_by_context.values())
+        if has_failure:
+            return "failing"
+
+        has_pending = any(v == "pending" for v in latest_by_context.values())
+        if has_pending:
+            return "pending"
+
+        return "passing"
+
     def comment_on_pull_request(self, number: int, body: str) -> bool:
         """Add a comment to a pull request (shares issue comment API)."""
         rp = self._repo_path()

--- a/loom-tools/src/loom_tools/common/github.py
+++ b/loom-tools/src/loom_tools/common/github.py
@@ -496,6 +496,34 @@ class GitHubForge:
         result = gh_run(args, check=False, cwd=self._cwd)
         return result.returncode == 0
 
+    def auto_merge_pull_request(
+        self,
+        number: int,
+        method: str = "squash",
+        poll_interval: int = 30,
+        timeout: int = 600,
+    ) -> bool:
+        """Enable GitHub's native auto-merge for a PR.
+
+        Delegates to ``gh pr merge --auto`` which queues the merge
+        until all required checks pass. The ``poll_interval`` and
+        ``timeout`` parameters are ignored (GitHub handles polling
+        server-side).
+        """
+        args = [
+            "pr", "merge", str(number),
+            "--auto", f"--{method}", "--delete-branch",
+        ]
+        result = gh_run(args, check=False, cwd=self._cwd)
+        if result.returncode == 0:
+            logger.info("Auto-merge enabled for PR #%d (GitHub)", number)
+            return True
+        logger.warning(
+            "Failed to enable auto-merge for PR #%d: %s",
+            number, (result.stderr or result.stdout or "").strip(),
+        )
+        return False
+
     def comment_on_pull_request(self, number: int, body: str) -> bool:
         """Add a comment to a pull request."""
         result = gh_run(

--- a/loom-tools/tests/test_forge.py
+++ b/loom-tools/tests/test_forge.py
@@ -226,6 +226,15 @@ class MockForgeClient:
     ) -> bool:
         return True
 
+    def auto_merge_pull_request(
+        self,
+        number: int,
+        method: str = "squash",
+        poll_interval: int = 30,
+        timeout: int = 600,
+    ) -> bool:
+        return True
+
     def comment_on_pull_request(self, number: int, body: str) -> bool:
         return True
 

--- a/loom-tools/tests/test_gitea.py
+++ b/loom-tools/tests/test_gitea.py
@@ -1226,3 +1226,215 @@ class TestGetForgeFactory:
             forge = get_forge()
 
         assert forge.forge_type == "github"
+
+
+# ===========================================================================
+# Auto-merge (poll-and-merge)
+# ===========================================================================
+
+
+class TestAutoMergePullRequest:
+    """Tests for GiteaForge.auto_merge_pull_request() poll-and-merge."""
+
+    def _pr_response(
+        self,
+        number: int = 42,
+        merged: bool = False,
+        head_sha: str = "abc123def456",
+    ) -> mock.MagicMock:
+        """Create a mock PR API response."""
+        return _mock_response(json_data={
+            "number": number,
+            "state": "open",
+            "title": "Test PR",
+            "html_url": f"https://gitea.example.com/owner/repo/pulls/{number}",
+            "labels": [],
+            "merged": merged,
+            "head": {"sha": head_sha, "ref": "feature/test"},
+        })
+
+    def _ci_passing(self) -> mock.MagicMock:
+        """CI statuses response with all passing."""
+        return _mock_response(json_data=[
+            {"context": "ci/build", "status": "success", "state": "success"},
+        ])
+
+    def _ci_failing(self) -> mock.MagicMock:
+        """CI statuses response with a failure."""
+        return _mock_response(json_data=[
+            {"context": "ci/build", "status": "failure", "state": "failure"},
+        ])
+
+    def _ci_pending(self) -> mock.MagicMock:
+        """CI statuses response with pending check."""
+        return _mock_response(json_data=[
+            {"context": "ci/build", "status": "pending", "state": "pending"},
+        ])
+
+    def _no_ci(self) -> mock.MagicMock:
+        """CI statuses response with no checks."""
+        return _mock_response(json_data=[])
+
+    def _merge_success(self) -> mock.MagicMock:
+        """Successful merge response."""
+        return _mock_response(json_data={"sha": "merged123"})
+
+    def test_passing_ci_merges_immediately(self) -> None:
+        """When CI is passing, should merge right away."""
+        forge = _make_forge()
+
+        responses = [
+            self._pr_response(),       # GET pulls/42 (fetch PR)
+            self._ci_passing(),        # GET commits/{sha}/statuses
+            self._merge_success(),     # POST pulls/42/merge
+        ]
+
+        with mock.patch.object(
+            forge._session, "request", side_effect=responses,
+        ):
+            result = forge.auto_merge_pull_request(42, poll_interval=1, timeout=5)
+
+        assert result is True
+
+    def test_failing_ci_returns_false(self) -> None:
+        """When CI fails, should return False without merging."""
+        forge = _make_forge()
+
+        responses = [
+            self._pr_response(),   # GET pulls/42
+            self._ci_failing(),    # GET commits/{sha}/statuses
+        ]
+
+        with mock.patch.object(
+            forge._session, "request", side_effect=responses,
+        ):
+            result = forge.auto_merge_pull_request(42, poll_interval=1, timeout=5)
+
+        assert result is False
+
+    def test_no_ci_merges_immediately(self) -> None:
+        """When no CI checks exist, should merge immediately."""
+        forge = _make_forge()
+
+        responses = [
+            self._pr_response(),       # GET pulls/42
+            self._no_ci(),             # GET commits/{sha}/statuses (empty)
+            self._merge_success(),     # POST pulls/42/merge
+        ]
+
+        with mock.patch.object(
+            forge._session, "request", side_effect=responses,
+        ):
+            result = forge.auto_merge_pull_request(42, poll_interval=1, timeout=5)
+
+        assert result is True
+
+    def test_already_merged_returns_true(self) -> None:
+        """When PR is already merged, should return True."""
+        forge = _make_forge()
+
+        responses = [
+            self._pr_response(merged=True),  # GET pulls/42 (merged=True)
+        ]
+
+        with mock.patch.object(
+            forge._session, "request", side_effect=responses,
+        ):
+            result = forge.auto_merge_pull_request(42)
+
+        assert result is True
+
+    def test_pending_then_passing_polls_and_merges(self) -> None:
+        """When CI is pending then passes, should poll and merge."""
+        forge = _make_forge()
+
+        responses = [
+            self._pr_response(),       # GET pulls/42
+            self._ci_pending(),        # poll 1: GET commits/{sha}/statuses (pending)
+            self._ci_passing(),        # poll 2: GET commits/{sha}/statuses (passing)
+            self._merge_success(),     # POST pulls/42/merge
+        ]
+
+        with (
+            mock.patch.object(forge._session, "request", side_effect=responses),
+            mock.patch("loom_tools.common.gitea.time.sleep") as mock_sleep,
+        ):
+            result = forge.auto_merge_pull_request(42, poll_interval=10, timeout=60)
+
+        assert result is True
+        mock_sleep.assert_called_once_with(10)
+
+    def test_timeout_returns_false(self) -> None:
+        """When CI stays pending past timeout, should return False."""
+        forge = _make_forge()
+
+        responses = [
+            self._pr_response(),   # GET pulls/42
+            self._ci_pending(),    # poll 1: statuses
+            self._ci_pending(),    # poll 2: statuses
+        ]
+
+        with (
+            mock.patch.object(forge._session, "request", side_effect=responses),
+            mock.patch("loom_tools.common.gitea.time.sleep"),
+        ):
+            result = forge.auto_merge_pull_request(42, poll_interval=5, timeout=10)
+
+        assert result is False
+
+    def test_pr_fetch_failure_returns_false(self) -> None:
+        """When PR cannot be fetched, should return False."""
+        forge = _make_forge()
+
+        with mock.patch.object(
+            forge._session, "request", return_value=_mock_response(404),
+        ):
+            result = forge.auto_merge_pull_request(999)
+
+        assert result is False
+
+    def test_no_head_sha_falls_back_to_direct_merge(self) -> None:
+        """When PR has no head SHA, should attempt direct merge."""
+        forge = _make_forge()
+
+        pr_no_head = _mock_response(json_data={
+            "number": 42,
+            "state": "open",
+            "title": "Test PR",
+            "html_url": "https://gitea.example.com/owner/repo/pulls/42",
+            "labels": [],
+            "merged": False,
+            "head": {},  # no sha
+        })
+
+        responses = [
+            pr_no_head,            # GET pulls/42 (no head SHA)
+            self._merge_success(), # POST pulls/42/merge (direct)
+        ]
+
+        with mock.patch.object(
+            forge._session, "request", side_effect=responses,
+        ):
+            result = forge.auto_merge_pull_request(42)
+
+        assert result is True
+
+    def test_configurable_poll_interval(self) -> None:
+        """Verify poll_interval and timeout parameters are respected."""
+        forge = _make_forge()
+
+        responses = [
+            self._pr_response(),
+            self._ci_pending(),
+            self._ci_passing(),
+            self._merge_success(),
+        ]
+
+        with (
+            mock.patch.object(forge._session, "request", side_effect=responses),
+            mock.patch("loom_tools.common.gitea.time.sleep") as mock_sleep,
+        ):
+            forge.auto_merge_pull_request(42, poll_interval=15, timeout=120)
+
+        # Should sleep for 15 seconds (the configured interval)
+        mock_sleep.assert_called_once_with(15)

--- a/loom-tools/tests/test_github.py
+++ b/loom-tools/tests/test_github.py
@@ -1009,6 +1009,32 @@ class TestGitHubForgePullRequests:
         assert "merge" in call_args
         assert "--squash" in call_args
 
+    def test_auto_merge_pull_request_success(self) -> None:
+        """auto_merge_pull_request delegates to gh pr merge --auto."""
+        forge = GitHubForge()
+        with mock.patch("loom_tools.common.github.gh_run") as mock_gh:
+            mock_gh.return_value = mock.Mock(returncode=0, stdout="", stderr="")
+            result = forge.auto_merge_pull_request(10, method="squash")
+
+        assert result is True
+        call_args = mock_gh.call_args[0][0]
+        assert "pr" in call_args
+        assert "merge" in call_args
+        assert "--auto" in call_args
+        assert "--squash" in call_args
+        assert "--delete-branch" in call_args
+
+    def test_auto_merge_pull_request_failure(self) -> None:
+        """auto_merge_pull_request returns False on gh failure."""
+        forge = GitHubForge()
+        with mock.patch("loom_tools.common.github.gh_run") as mock_gh:
+            mock_gh.return_value = mock.Mock(
+                returncode=1, stdout="", stderr="auto-merge not available",
+            )
+            result = forge.auto_merge_pull_request(10)
+
+        assert result is False
+
     def test_get_pull_request_reviews(self) -> None:
         """get_pull_request_reviews returns review list."""
         review_data = {


### PR DESCRIPTION
Closes #3170

## Summary

- Add `auto_merge_pull_request()` to the `ForgeClient` protocol
- **GitHubForge**: delegates to `gh pr merge --auto` (server-side queue)
- **GiteaForge**: implements poll-and-merge loop — queries CI status on PR head commit, waits for checks to pass, then merges
- Add `_get_raw_ci_state()` helper that distinguishes pending from passing (unlike `get_commit_ci_status()` which is optimistic for dashboards)
- Add `get_commit_ci_status()` delegation in `CachedForgeClient`
- Add `loom-auto-merge` CLI entry point for shell script integration
- Update `merge-pr.sh` to prefer `loom-auto-merge` when available, with fallback to existing `forge_auto_merge` shell helper
- Configurable poll interval (`LOOM_AUTO_MERGE_POLL_INTERVAL`, default 30s) and timeout (`LOOM_AUTO_MERGE_TIMEOUT`, default 600s)

## Test plan

- [x] 9 new tests for `GiteaForge.auto_merge_pull_request()` covering: passing CI, failing CI, no CI, already merged, pending-then-passing poll, timeout, PR fetch failure, missing head SHA fallback, configurable poll interval
- [x] 2 new tests for `GitHubForge.auto_merge_pull_request()` covering success and failure
- [x] Updated `MockForgeClient` in test_forge.py for protocol compliance
- [x] All 284 forge-related tests pass