### PR TITLE
refactor: rename PromptGitHubEvent types to forge-neutral names

### DIFF
--- a/loom-daemon/src/activity/db.rs
+++ b/loom-daemon/src/activity/db.rs
@@ -7,7 +7,7 @@
 //! - [`super::claims`]: Issue claim registry
 //! - [`super::cost_analytics`]: Budget and cost analysis
 //! - [`super::metrics`]: Task metrics and productivity
-//! - [`super::prompts`]: Prompt tracking (git changes, GitHub events)
+//! - [`super::prompts`]: Prompt tracking (git changes, forge events)
 //! - [`super::quality`]: Quality metrics (tests, PR reviews, rework)
 
 use anyhow::Result;
@@ -18,7 +18,7 @@ use std::path::PathBuf;
 use super::models::{
     ActivityEntry, AgentInput, AgentMetric, AgentOutput, BudgetConfig, BudgetPeriod, BudgetStatus,
     ClaimResult, ClaimType, CostByIssue, CostByPr, CostByRole, CostSummary, InputContext,
-    InputType, IssueClaim, PrReworkStats, ProductivitySummary, PromptChanges, PromptGitHubEvent,
+    InputType, IssueClaim, PrReworkStats, ProductivitySummary, PromptChanges, PromptForgeEvent,
     PromptSuccessStats, QualityMetrics, RunwayProjection, TokenUsage,
 };
 use super::schema::init_schema;
@@ -205,14 +205,14 @@ impl ActivityDb {
     // ========================================================================
 
     /// Record a prompt-GitHub correlation event.
-    pub fn record_prompt_github_event(&self, event: &PromptGitHubEvent) -> Result<i64> {
-        prompts::record_prompt_github_event(&self.conn, event)
+    pub fn record_prompt_forge_event(&self, event: &PromptForgeEvent) -> Result<i64> {
+        prompts::record_prompt_forge_event(&self.conn, event)
     }
 
     /// Get prompt-GitHub events for a specific input.
     #[allow(dead_code)]
-    pub fn get_prompt_github_events(&self, input_id: i64) -> Result<Vec<PromptGitHubEvent>> {
-        prompts::get_prompt_github_events(&self.conn, input_id)
+    pub fn get_prompt_forge_events(&self, input_id: i64) -> Result<Vec<PromptForgeEvent>> {
+        prompts::get_prompt_forge_events(&self.conn, input_id)
     }
 
     /// Get terminal activity history (inputs joined with outputs)
@@ -1225,8 +1225,8 @@ mod tests {
     }
 
     #[test]
-    fn test_record_prompt_github_event() -> Result<()> {
-        use super::super::models::PromptGitHubEventType;
+    fn test_record_prompt_forge_event() -> Result<()> {
+        use super::super::models::PromptForgeEventType;
 
         let temp_file = NamedTempFile::new()?;
         let db = ActivityDb::new(temp_file.path().to_path_buf())?;
@@ -1244,24 +1244,24 @@ mod tests {
         let input_id = db.record_input(&input)?;
 
         // Record a GitHub event linked to this input
-        let event = PromptGitHubEvent {
+        let event = PromptForgeEvent {
             id: None,
             input_id: Some(input_id),
             issue_number: Some(42),
             pr_number: None,
             label_before: None,
             label_after: Some(vec!["loom:building".to_string()]),
-            event_type: PromptGitHubEventType::LabelAdded,
+            event_type: PromptForgeEventType::LabelAdded,
         };
 
-        let event_id = db.record_prompt_github_event(&event)?;
+        let event_id = db.record_prompt_forge_event(&event)?;
         assert!(event_id > 0);
 
         // Retrieve the events
-        let events = db.get_prompt_github_events(input_id)?;
+        let events = db.get_prompt_forge_events(input_id)?;
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].issue_number, Some(42));
-        assert_eq!(events[0].event_type, PromptGitHubEventType::LabelAdded);
+        assert_eq!(events[0].event_type, PromptForgeEventType::LabelAdded);
         assert_eq!(events[0].label_after, Some(vec!["loom:building".to_string()]));
 
         Ok(())
@@ -1269,7 +1269,7 @@ mod tests {
 
     #[test]
     fn test_record_multiple_github_events() -> Result<()> {
-        use super::super::models::PromptGitHubEventType;
+        use super::super::models::PromptForgeEventType;
 
         let temp_file = NamedTempFile::new()?;
         let db = ActivityDb::new(temp_file.path().to_path_buf())?;
@@ -1287,35 +1287,35 @@ mod tests {
         let input_id = db.record_input(&input)?;
 
         // Record multiple events from the same input
-        let event1 = PromptGitHubEvent {
+        let event1 = PromptForgeEvent {
             id: None,
             input_id: Some(input_id),
             issue_number: None,
             pr_number: Some(123),
             label_before: None,
             label_after: None,
-            event_type: PromptGitHubEventType::PrCreated,
+            event_type: PromptForgeEventType::PrCreated,
         };
-        db.record_prompt_github_event(&event1)?;
+        db.record_prompt_forge_event(&event1)?;
 
-        let event2 = PromptGitHubEvent {
+        let event2 = PromptForgeEvent {
             id: None,
             input_id: Some(input_id),
             issue_number: None,
             pr_number: Some(123),
             label_before: None,
             label_after: Some(vec!["loom:review-requested".to_string()]),
-            event_type: PromptGitHubEventType::LabelAdded,
+            event_type: PromptForgeEventType::LabelAdded,
         };
-        db.record_prompt_github_event(&event2)?;
+        db.record_prompt_forge_event(&event2)?;
 
         // Retrieve all events for this input
-        let retrieved_events = db.get_prompt_github_events(input_id)?;
+        let retrieved_events = db.get_prompt_forge_events(input_id)?;
         assert_eq!(retrieved_events.len(), 2);
 
         let pr_created = retrieved_events
             .iter()
-            .find(|e| e.event_type == PromptGitHubEventType::PrCreated);
+            .find(|e| e.event_type == PromptForgeEventType::PrCreated);
         assert!(pr_created.is_some());
         if let Some(evt) = pr_created {
             assert_eq!(evt.pr_number, Some(123));
@@ -1323,7 +1323,7 @@ mod tests {
 
         let label_added = retrieved_events
             .iter()
-            .find(|e| e.event_type == PromptGitHubEventType::LabelAdded);
+            .find(|e| e.event_type == PromptForgeEventType::LabelAdded);
         assert!(label_added.is_some());
 
         Ok(())
@@ -1331,23 +1331,23 @@ mod tests {
 
     #[test]
     fn test_github_event_without_input_link() -> Result<()> {
-        use super::super::models::PromptGitHubEventType;
+        use super::super::models::PromptForgeEventType;
 
         let temp_file = NamedTempFile::new()?;
         let db = ActivityDb::new(temp_file.path().to_path_buf())?;
 
         // Record a GitHub event without linking to a specific input
-        let event = PromptGitHubEvent {
+        let event = PromptForgeEvent {
             id: None,
             input_id: None,
             issue_number: Some(100),
             pr_number: None,
             label_before: Some(vec!["loom:issue".to_string()]),
             label_after: Some(vec!["loom:building".to_string()]),
-            event_type: PromptGitHubEventType::LabelAdded,
+            event_type: PromptForgeEventType::LabelAdded,
         };
 
-        let event_id = db.record_prompt_github_event(&event)?;
+        let event_id = db.record_prompt_forge_event(&event)?;
         assert!(event_id > 0);
 
         Ok(())

--- a/loom-daemon/src/activity/mod.rs
+++ b/loom-daemon/src/activity/mod.rs
@@ -56,8 +56,8 @@ pub use models::{ActivityEntry, AgentInput, AgentOutput, InputContext, InputType
 // These types are available for future use but not currently imported elsewhere
 #[allow(unused_imports)]
 pub use models::{
-    AgentMetric, LintResults, PrReworkStats, ProductivitySummary, PromptChanges, PromptGitHubEvent,
-    PromptGitHubEventType, PromptSuccessStats, QualityMetrics, TestResults, TokenUsage,
+    AgentMetric, LintResults, PrReworkStats, ProductivitySummary, PromptChanges, PromptForgeEvent,
+    PromptForgeEventType, PromptSuccessStats, QualityMetrics, TestResults, TokenUsage,
 };
 
 // Cost analytics types (Issue #1064)

--- a/loom-daemon/src/activity/models.rs
+++ b/loom-daemon/src/activity/models.rs
@@ -169,10 +169,10 @@ pub struct PromptChanges {
     pub tests_modified: i32,
 }
 
-/// GitHub event types that can be parsed from terminal output
+/// Forge event types that can be parsed from terminal output
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum PromptGitHubEventType {
+pub enum PromptForgeEventType {
     IssueCreated,
     IssueClosed,
     PrCreated,
@@ -183,7 +183,7 @@ pub enum PromptGitHubEventType {
     ReviewSubmitted,
 }
 
-impl PromptGitHubEventType {
+impl PromptForgeEventType {
     pub fn as_str(&self) -> &str {
         match self {
             Self::IssueCreated => "issue_created",
@@ -212,9 +212,9 @@ impl PromptGitHubEventType {
     }
 }
 
-/// Prompt-GitHub correlation record for tracking which prompts triggered GitHub actions
+/// Prompt-forge correlation record for tracking which prompts triggered forge actions
 #[derive(Debug, Clone)]
-pub struct PromptGitHubEvent {
+pub struct PromptForgeEvent {
     #[allow(dead_code)]
     pub id: Option<i64>,
     pub input_id: Option<i64>,
@@ -222,7 +222,7 @@ pub struct PromptGitHubEvent {
     pub pr_number: Option<i32>,
     pub label_before: Option<Vec<String>>,
     pub label_after: Option<Vec<String>>,
-    pub event_type: PromptGitHubEventType,
+    pub event_type: PromptForgeEventType,
 }
 
 /// Test results parsed from terminal output

--- a/loom-daemon/src/activity/prompts.rs
+++ b/loom-daemon/src/activity/prompts.rs
@@ -1,12 +1,12 @@
-//! Prompt tracking: git changes and GitHub event correlation.
+//! Prompt tracking: git changes and forge event correlation.
 //!
 //! Extracted from `db.rs` — provides recording and querying of prompt-level
-//! tracking data including git changes per prompt and GitHub event correlation.
+//! tracking data including git changes per prompt and forge event correlation.
 
 use anyhow::Result;
 use rusqlite::{params, Connection};
 
-use super::models::{PromptChanges, PromptGitHubEvent, PromptGitHubEventType};
+use super::models::{PromptChanges, PromptForgeEvent, PromptForgeEventType};
 
 // ========================================================================
 // Prompt Changes (Git)
@@ -103,9 +103,9 @@ pub(super) fn get_terminal_changes_summary(
 ///
 /// Links a prompt (agent input) with a GitHub action it triggered,
 /// such as creating an issue, opening a PR, or changing labels.
-pub(super) fn record_prompt_github_event(
+pub(super) fn record_prompt_forge_event(
     conn: &Connection,
-    event: &PromptGitHubEvent,
+    event: &PromptForgeEvent,
 ) -> Result<i64> {
     let label_before_json = event
         .label_before
@@ -138,10 +138,10 @@ pub(super) fn record_prompt_github_event(
 }
 
 /// Get prompt-GitHub events for a specific input.
-pub(super) fn get_prompt_github_events(
+pub(super) fn get_prompt_forge_events(
     conn: &Connection,
     input_id: i64,
-) -> Result<Vec<PromptGitHubEvent>> {
+) -> Result<Vec<PromptForgeEvent>> {
     let mut stmt = conn.prepare(
         r"
         SELECT id, input_id, issue_number, pr_number, label_before, label_after, event_type
@@ -170,13 +170,13 @@ pub(super) fn get_prompt_github_events(
             .transpose()
             .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?;
 
-        let event_type = PromptGitHubEventType::from_str(&event_type_str).ok_or_else(|| {
+        let event_type = PromptForgeEventType::from_str(&event_type_str).ok_or_else(|| {
             rusqlite::Error::ToSqlConversionFailure(
                 format!("Invalid event_type: {event_type_str}").into(),
             )
         })?;
 
-        Ok(PromptGitHubEvent {
+        Ok(PromptForgeEvent {
             id: Some(id),
             input_id,
             issue_number,

--- a/loom-daemon/src/activity/schema.rs
+++ b/loom-daemon/src/activity/schema.rs
@@ -143,7 +143,8 @@ pub fn init_schema(conn: &Connection) -> Result<()> {
             -- NOTE: idx_token_usage_provider is created in migrate_token_usage_table()
             -- because the provider column may not exist in older databases.
 
-            -- GitHub events for correlating agent activity with GitHub actions
+            -- Forge events for correlating agent activity with forge actions
+            -- NOTE: table name kept as 'github_events' for migration compatibility
             CREATE TABLE IF NOT EXISTS github_events (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 activity_id INTEGER,
@@ -179,7 +180,8 @@ pub fn init_schema(conn: &Connection) -> Result<()> {
             CREATE INDEX IF NOT EXISTS idx_prompt_changes_input_id ON prompt_changes(input_id);
             CREATE INDEX IF NOT EXISTS idx_prompt_changes_after_commit ON prompt_changes(after_commit);
 
-            -- Prompt-GitHub correlation table for linking prompts to GitHub actions
+            -- Prompt-forge correlation table for linking prompts to forge actions
+            -- NOTE: table name kept as 'prompt_github' for migration compatibility
             CREATE TABLE IF NOT EXISTS prompt_github (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 input_id INTEGER REFERENCES agent_inputs(id),

--- a/loom-daemon/src/forge_parser.rs
+++ b/loom-daemon/src/forge_parser.rs
@@ -20,13 +20,13 @@
 //! // Returns: [ParsedForgeEvent { event_type: PrCreated, pr_number: Some(123), ... }]
 //! ```
 
-use crate::activity::{PromptGitHubEvent, PromptGitHubEventType};
+use crate::activity::{PromptForgeEvent, PromptForgeEventType};
 use regex::Regex;
 
 /// A parsed forge event from terminal output
 #[derive(Debug, Clone)]
 pub struct ParsedForgeEvent {
-    pub event_type: PromptGitHubEventType,
+    pub event_type: PromptForgeEventType,
     pub issue_number: Option<i32>,
     pub pr_number: Option<i32>,
     pub labels_added: Vec<String>,
@@ -34,8 +34,8 @@ pub struct ParsedForgeEvent {
 }
 
 impl ParsedForgeEvent {
-    /// Convert to a `PromptGitHubEvent` for database storage
-    pub fn to_prompt_forge_event(&self, input_id: Option<i64>) -> PromptGitHubEvent {
+    /// Convert to a `PromptForgeEvent` for database storage
+    pub fn to_prompt_forge_event(&self, input_id: Option<i64>) -> PromptForgeEvent {
         let (label_before, label_after) =
             if !self.labels_added.is_empty() || !self.labels_removed.is_empty() {
                 // For label changes, we track removed as "before" and added as "after"
@@ -55,7 +55,7 @@ impl ParsedForgeEvent {
                 (None, None)
             };
 
-        PromptGitHubEvent {
+        PromptForgeEvent {
             id: None,
             input_id,
             issue_number: self.issue_number,
@@ -95,14 +95,14 @@ pub fn parse_forge_events(output: &str, forge_host: &str) -> Vec<ParsedForgeEven
                 if let Ok(number) = number_match.as_str().parse::<i32>() {
                     let event = match type_match.as_str() {
                         "issues" => ParsedForgeEvent {
-                            event_type: PromptGitHubEventType::IssueCreated,
+                            event_type: PromptForgeEventType::IssueCreated,
                             issue_number: Some(number),
                             pr_number: None,
                             labels_added: Vec::new(),
                             labels_removed: Vec::new(),
                         },
                         "pull" | "pulls" => ParsedForgeEvent {
-                            event_type: PromptGitHubEventType::PrCreated,
+                            event_type: PromptForgeEventType::PrCreated,
                             issue_number: None,
                             pr_number: Some(number),
                             labels_added: Vec::new(),
@@ -124,7 +124,7 @@ pub fn parse_forge_events(output: &str, forge_host: &str) -> Vec<ParsedForgeEven
             if let Some(number_match) = cap.get(1) {
                 if let Ok(number) = number_match.as_str().parse::<i32>() {
                     events.push(ParsedForgeEvent {
-                        event_type: PromptGitHubEventType::PrMerged,
+                        event_type: PromptForgeEventType::PrMerged,
                         issue_number: None,
                         pr_number: Some(number),
                         labels_added: Vec::new(),
@@ -145,7 +145,7 @@ pub fn parse_forge_events(output: &str, forge_host: &str) -> Vec<ParsedForgeEven
             if let Some(number_match) = number {
                 if let Ok(number) = number_match.as_str().parse::<i32>() {
                     events.push(ParsedForgeEvent {
-                        event_type: PromptGitHubEventType::IssueClosed,
+                        event_type: PromptForgeEventType::IssueClosed,
                         issue_number: Some(number),
                         pr_number: None,
                         labels_added: Vec::new(),
@@ -163,7 +163,7 @@ pub fn parse_forge_events(output: &str, forge_host: &str) -> Vec<ParsedForgeEven
             if let Some(number_match) = cap.get(1) {
                 if let Ok(number) = number_match.as_str().parse::<i32>() {
                     events.push(ParsedForgeEvent {
-                        event_type: PromptGitHubEventType::PrClosed,
+                        event_type: PromptForgeEventType::PrClosed,
                         issue_number: None,
                         pr_number: Some(number),
                         labels_added: Vec::new(),
@@ -194,7 +194,7 @@ pub fn parse_forge_events(output: &str, forge_host: &str) -> Vec<ParsedForgeEven
                     let (issue_number, pr_number) = extract_issue_pr_from_context(output);
 
                     events.push(ParsedForgeEvent {
-                        event_type: PromptGitHubEventType::LabelAdded,
+                        event_type: PromptForgeEventType::LabelAdded,
                         issue_number,
                         pr_number,
                         labels_added: labels,
@@ -222,7 +222,7 @@ pub fn parse_forge_events(output: &str, forge_host: &str) -> Vec<ParsedForgeEven
                     let (issue_number, pr_number) = extract_issue_pr_from_context(output);
 
                     events.push(ParsedForgeEvent {
-                        event_type: PromptGitHubEventType::LabelRemoved,
+                        event_type: PromptForgeEventType::LabelRemoved,
                         issue_number,
                         pr_number,
                         labels_added: Vec::new(),
@@ -242,7 +242,7 @@ pub fn parse_forge_events(output: &str, forge_host: &str) -> Vec<ParsedForgeEven
             if let Some(number_match) = cap.get(2) {
                 if let Ok(number) = number_match.as_str().parse::<i32>() {
                     events.push(ParsedForgeEvent {
-                        event_type: PromptGitHubEventType::ReviewSubmitted,
+                        event_type: PromptForgeEventType::ReviewSubmitted,
                         issue_number: None,
                         pr_number: Some(number),
                         labels_added: Vec::new(),
@@ -295,7 +295,7 @@ mod tests {
         let output = "Creating issue...\nhttps://github.com/owner/repo/issues/42";
         let events = parse_forge_events(output, GITHUB_HOST);
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].event_type, PromptGitHubEventType::IssueCreated);
+        assert_eq!(events[0].event_type, PromptForgeEventType::IssueCreated);
         assert_eq!(events[0].issue_number, Some(42));
     }
 
@@ -304,7 +304,7 @@ mod tests {
         let output = "Creating pull request for feature/test into main in owner/repo\n\nhttps://github.com/owner/repo/pull/123";
         let events = parse_forge_events(output, GITHUB_HOST);
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].event_type, PromptGitHubEventType::PrCreated);
+        assert_eq!(events[0].event_type, PromptForgeEventType::PrCreated);
         assert_eq!(events[0].pr_number, Some(123));
     }
 
@@ -315,7 +315,7 @@ mod tests {
         assert!(!events.is_empty());
         let merge_event = events
             .iter()
-            .find(|e| e.event_type == PromptGitHubEventType::PrMerged);
+            .find(|e| e.event_type == PromptForgeEventType::PrMerged);
         assert!(merge_event.is_some());
         if let Some(evt) = merge_event {
             assert_eq!(evt.pr_number, Some(456));
@@ -327,7 +327,7 @@ mod tests {
         let output = "Closed issue #789";
         let events = parse_forge_events(output, GITHUB_HOST);
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].event_type, PromptGitHubEventType::IssueClosed);
+        assert_eq!(events[0].event_type, PromptForgeEventType::IssueClosed);
         assert_eq!(events[0].issue_number, Some(789));
     }
 
@@ -336,7 +336,7 @@ mod tests {
         let output = "gh issue edit 42 --add-label \"loom:building\"";
         let events = parse_forge_events(output, GITHUB_HOST);
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].event_type, PromptGitHubEventType::LabelAdded);
+        assert_eq!(events[0].event_type, PromptForgeEventType::LabelAdded);
         assert_eq!(events[0].labels_added, vec!["loom:building"]);
         assert_eq!(events[0].issue_number, Some(42));
     }
@@ -346,7 +346,7 @@ mod tests {
         let output = "gh issue edit 42 --remove-label loom:issue";
         let events = parse_forge_events(output, GITHUB_HOST);
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].event_type, PromptGitHubEventType::LabelRemoved);
+        assert_eq!(events[0].event_type, PromptForgeEventType::LabelRemoved);
         assert_eq!(events[0].labels_removed, vec!["loom:issue"]);
     }
 
@@ -355,7 +355,7 @@ mod tests {
         let output = "Approved pull request #123";
         let events = parse_forge_events(output, GITHUB_HOST);
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].event_type, PromptGitHubEventType::ReviewSubmitted);
+        assert_eq!(events[0].event_type, PromptForgeEventType::ReviewSubmitted);
         assert_eq!(events[0].pr_number, Some(123));
     }
 
@@ -367,10 +367,10 @@ mod tests {
 
         let remove_event = events
             .iter()
-            .find(|e| e.event_type == PromptGitHubEventType::LabelRemoved);
+            .find(|e| e.event_type == PromptForgeEventType::LabelRemoved);
         let add_event = events
             .iter()
-            .find(|e| e.event_type == PromptGitHubEventType::LabelAdded);
+            .find(|e| e.event_type == PromptForgeEventType::LabelAdded);
 
         assert!(remove_event.is_some());
         assert!(add_event.is_some());
@@ -392,7 +392,7 @@ mod tests {
     #[test]
     fn test_to_prompt_forge_event() {
         let parsed = ParsedForgeEvent {
-            event_type: PromptGitHubEventType::LabelAdded,
+            event_type: PromptForgeEventType::LabelAdded,
             issue_number: Some(42),
             pr_number: None,
             labels_added: vec!["loom:building".to_string()],
@@ -413,7 +413,7 @@ mod tests {
         let output = "Creating issue...\nhttps://gitea.example.com/owner/repo/issues/42";
         let events = parse_forge_events(output, GITEA_HOST);
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].event_type, PromptGitHubEventType::IssueCreated);
+        assert_eq!(events[0].event_type, PromptForgeEventType::IssueCreated);
         assert_eq!(events[0].issue_number, Some(42));
     }
 
@@ -423,7 +423,7 @@ mod tests {
         let output = "Creating pull request...\nhttps://gitea.example.com/owner/repo/pulls/99";
         let events = parse_forge_events(output, GITEA_HOST);
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].event_type, PromptGitHubEventType::PrCreated);
+        assert_eq!(events[0].event_type, PromptForgeEventType::PrCreated);
         assert_eq!(events[0].pr_number, Some(99));
     }
 
@@ -449,7 +449,7 @@ mod tests {
         let output = "https://github.com/owner/repo/pull/456";
         let events = parse_forge_events(output, GITHUB_HOST);
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].event_type, PromptGitHubEventType::PrCreated);
+        assert_eq!(events[0].event_type, PromptForgeEventType::PrCreated);
         assert_eq!(events[0].pr_number, Some(456));
     }
 }

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -263,11 +263,11 @@ fn handle_request(
                             let forge_events = parse_forge_events(&output_str, forge_host);
                             for parsed_event in forge_events {
                                 let prompt_event = parsed_event.to_prompt_forge_event(None);
-                                if let Err(e) = db.record_prompt_github_event(&prompt_event) {
-                                    log::warn!("Failed to record GitHub event: {e}");
+                                if let Err(e) = db.record_prompt_forge_event(&prompt_event) {
+                                    log::warn!("Failed to record forge event: {e}");
                                 } else {
                                     log::debug!(
-                                        "Recorded GitHub event: {:?} (issue: {:?}, pr: {:?})",
+                                        "Recorded forge event: {:?} (issue: {:?}, pr: {:?})",
                                         prompt_event.event_type,
                                         prompt_event.issue_number,
                                         prompt_event.pr_number

--- a/src-tauri/src/commands/activity/forge_events.rs
+++ b/src-tauri/src/commands/activity/forge_events.rs
@@ -27,15 +27,15 @@ pub fn log_github_event(
 }
 
 // ============================================================================
-// Prompt-GitHub Correlation (Phase 2: Correlation & Context)
+// Prompt-Forge Correlation (Phase 2: Correlation & Context)
 // ============================================================================
 
-/// GitHub event types for prompt correlation
-/// These map to specific GitHub CLI operations detected in terminal output
+/// Forge event types for prompt correlation
+/// These map to specific forge CLI operations detected in terminal output
 #[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
-pub enum PromptGitHubEventType {
+pub enum PromptForgeEventType {
     /// Issue was claimed (label changed to loom:building)
     IssueClaimed,
     /// New PR was created
@@ -60,7 +60,7 @@ pub enum PromptGitHubEventType {
     PrApproved,
 }
 
-impl std::fmt::Display for PromptGitHubEventType {
+impl std::fmt::Display for PromptForgeEventType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {
             Self::IssueClaimed => "issue_claimed",
@@ -79,10 +79,10 @@ impl std::fmt::Display for PromptGitHubEventType {
     }
 }
 
-/// Entry for prompt-GitHub correlation
+/// Entry for prompt-forge correlation
 #[allow(dead_code)]
 #[derive(Debug, Serialize, Deserialize)]
-pub struct PromptGitHubEntry {
+pub struct PromptForgeEntry {
     pub id: Option<i64>,
     pub activity_id: i64,
     pub issue_number: Option<i32>,
@@ -93,11 +93,11 @@ pub struct PromptGitHubEntry {
     pub event_time: String,
 }
 
-/// Log a prompt-GitHub correlation entry
+/// Log a prompt-forge correlation entry
 #[allow(dead_code)]
 #[tauri::command]
 #[allow(clippy::needless_pass_by_value)]
-pub fn log_prompt_github(
+pub fn log_prompt_forge(
     workspace_path: String,
     activity_id: i64,
     event_type: String,
@@ -122,18 +122,18 @@ pub fn log_prompt_github(
             event_type
         ],
     )
-    .map_err(|e| format!("Failed to log prompt-GitHub correlation: {e}"))?;
+    .map_err(|e| format!("Failed to log prompt-forge correlation: {e}"))?;
 
     Ok(conn.last_insert_rowid())
 }
 
-/// Query prompt-GitHub correlations for a specific issue
+/// Query prompt-forge correlations for a specific issue
 #[allow(dead_code)]
 #[tauri::command]
 pub fn get_prompts_for_issue(
     workspace_path: &str,
     issue_number: i32,
-) -> Result<Vec<PromptGitHubEntry>, String> {
+) -> Result<Vec<PromptForgeEntry>, String> {
     let conn =
         open_activity_db(workspace_path).map_err(|e| format!("Failed to open database: {e}"))?;
 
@@ -148,7 +148,7 @@ pub fn get_prompts_for_issue(
 
     let entries = stmt
         .query_map([issue_number], |row| {
-            Ok(PromptGitHubEntry {
+            Ok(PromptForgeEntry {
                 id: row.get(0)?,
                 activity_id: row.get(1)?,
                 issue_number: row.get(2)?,
@@ -159,20 +159,20 @@ pub fn get_prompts_for_issue(
                 event_time: row.get(7)?,
             })
         })
-        .map_err(|e| format!("Failed to query prompt-GitHub entries: {e}"))?
+        .map_err(|e| format!("Failed to query prompt-forge entries: {e}"))?
         .collect::<Result<Vec<_>, _>>()
         .map_err(|e| format!("Failed to collect entries: {e}"))?;
 
     Ok(entries)
 }
 
-/// Query prompt-GitHub correlations for a specific PR
+/// Query prompt-forge correlations for a specific PR
 #[allow(dead_code)]
 #[tauri::command]
 pub fn get_prompts_for_pr(
     workspace_path: &str,
     pr_number: i32,
-) -> Result<Vec<PromptGitHubEntry>, String> {
+) -> Result<Vec<PromptForgeEntry>, String> {
     let conn =
         open_activity_db(workspace_path).map_err(|e| format!("Failed to open database: {e}"))?;
 
@@ -187,7 +187,7 @@ pub fn get_prompts_for_pr(
 
     let entries = stmt
         .query_map([pr_number], |row| {
-            Ok(PromptGitHubEntry {
+            Ok(PromptForgeEntry {
                 id: row.get(0)?,
                 activity_id: row.get(1)?,
                 issue_number: row.get(2)?,
@@ -198,7 +198,7 @@ pub fn get_prompts_for_pr(
                 event_time: row.get(7)?,
             })
         })
-        .map_err(|e| format!("Failed to query prompt-GitHub entries: {e}"))?
+        .map_err(|e| format!("Failed to query prompt-forge entries: {e}"))?
         .collect::<Result<Vec<_>, _>>()
         .map_err(|e| format!("Failed to collect entries: {e}"))?;
 

--- a/src-tauri/src/commands/activity/mod.rs
+++ b/src-tauri/src/commands/activity/mod.rs
@@ -3,7 +3,7 @@
 mod budget;
 mod costs;
 mod db;
-mod github_events;
+mod forge_events;
 mod logging;
 mod metrics;
 mod patterns;
@@ -20,7 +20,7 @@ pub use budget::*;
 #[allow(unused_imports)]
 pub use costs::*;
 #[allow(unused_imports)]
-pub use github_events::*;
+pub use forge_events::*;
 #[allow(unused_imports)]
 pub use logging::*;
 #[allow(unused_imports)]

--- a/src/lib/activity-playback-modal.ts
+++ b/src/lib/activity-playback-modal.ts
@@ -442,11 +442,11 @@ async function queryTimelineEntriesFallback(
     limit: filter.limit ?? 100,
   });
 
-  // Get prompt-GitHub correlations if filtering by issue/PR
-  let githubEntries: RawPromptGitHubEntry[] = [];
+  // Get prompt-forge correlations if filtering by issue/PR
+  let forgeEntries: RawPromptForgeEntry[] = [];
   if (filter.issue_number) {
     try {
-      githubEntries = await invoke<RawPromptGitHubEntry[]>("get_prompts_for_issue", {
+      forgeEntries = await invoke<RawPromptForgeEntry[]>("get_prompts_for_issue", {
         workspacePath,
         issueNumber: filter.issue_number,
       });
@@ -455,7 +455,7 @@ async function queryTimelineEntriesFallback(
     }
   } else if (filter.pr_number) {
     try {
-      githubEntries = await invoke<RawPromptGitHubEntry[]>("get_prompts_for_pr", {
+      forgeEntries = await invoke<RawPromptForgeEntry[]>("get_prompts_for_pr", {
         workspacePath,
         prNumber: filter.pr_number,
       });
@@ -464,8 +464,8 @@ async function queryTimelineEntriesFallback(
     }
   }
 
-  // Create a map of activity IDs from GitHub entries for filtering
-  const activityIds = new Set(githubEntries.map((e) => e.activity_id));
+  // Create a map of activity IDs from forge entries for filtering
+  const activityIds = new Set(forgeEntries.map((e) => e.activity_id));
 
   // Transform and filter activities
   let entries: TimelineEntry[] = activities.map((a) => ({
@@ -523,7 +523,7 @@ interface RawActivityEntry {
   notes: string | null;
 }
 
-interface RawPromptGitHubEntry {
+interface RawPromptForgeEntry {
   id: number | null;
   activity_id: number;
   issue_number: number | null;


### PR DESCRIPTION
Closes #3169

## Summary

Renames all `PromptGitHub*` Rust types and functions to forge-neutral `PromptForge*` equivalents across 10 files. This is a pure mechanical rename with no behavior changes.

### Types renamed
- `PromptGitHubEvent` -> `PromptForgeEvent`
- `PromptGitHubEventType` -> `PromptForgeEventType` (both daemon and Tauri copies)
- `PromptGitHubEntry` -> `PromptForgeEntry`

### Functions renamed
- `record_prompt_github_event` -> `record_prompt_forge_event`
- `log_prompt_github` -> `log_prompt_forge`
- `get_prompt_github_events` -> `get_prompt_forge_events`

### File renamed
- `src-tauri/src/commands/activity/github_events.rs` -> `forge_events.rs`

### Intentionally unchanged
- SQL table names (`prompt_github`, `github_events`) kept for migration compatibility
- Comments added at schema definitions explaining the intentional mismatch