### PR TITLE
fix: installer preserves project-specific files during upgrade

### DIFF
--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -708,16 +708,48 @@ echo "$LOOM_ROOT" > "$TARGET_PATH/.loom/loom-source-path"
 success "Loom source path recorded"
 
 # Store installation metadata (commit hash moved here from CLAUDE.md for idempotency)
+# Also record the list of installed files so the uninstaller knows exactly what to remove.
+# This prevents the uninstaller from using heuristics and accidentally touching project files.
 info "Recording installation metadata..."
+
+# Collect all installed files (relative paths from repo root)
+INSTALLED_FILES_JSON="["
+FIRST_FILE=true
+while IFS= read -r -d '' file; do
+  rel_path="${file#./}"
+  # Skip runtime artifacts that are gitignored
+  case "$rel_path" in
+    .loom/state.json|.loom/daemon-state.json|.loom/loom-source-path|.loom/install-metadata.json|.loom/manifest.json)
+      continue
+      ;;
+  esac
+  if [[ "$FIRST_FILE" == "true" ]]; then
+    FIRST_FILE=false
+  else
+    INSTALLED_FILES_JSON="${INSTALLED_FILES_JSON},"
+  fi
+  INSTALLED_FILES_JSON="${INSTALLED_FILES_JSON}\"${rel_path}\""
+done < <(find . -type f \
+  -not -path './.git/*' \
+  -not -path './.loom/worktrees/*' \
+  -not -path './.loom/progress/*' \
+  -not -path './.loom/logs/*' \
+  -not -name '*.log' \
+  -not -name '*.sock' \
+  -not -name '.DS_Store' \
+  -print0 | sort -z)
+INSTALLED_FILES_JSON="${INSTALLED_FILES_JSON}]"
+
 cat > .loom/install-metadata.json <<METADATA
 {
   "loom_version": "${LOOM_VERSION}",
   "loom_commit": "${LOOM_COMMIT}",
   "install_date": "$(date +%Y-%m-%d)",
-  "loom_source": "${LOOM_ROOT}"
+  "loom_source": "${LOOM_ROOT}",
+  "installed_files": ${INSTALLED_FILES_JSON}
 }
 METADATA
-success "Installation metadata recorded"
+success "Installation metadata recorded ($(echo "$INSTALLED_FILES_JSON" | grep -o '"' | wc -l | awk '{print $1/2}') files tracked)"
 echo ""
 
 # Verify expected files were created

--- a/scripts/test-installer.sh
+++ b/scripts/test-installer.sh
@@ -148,13 +148,40 @@ simulate_loom_install() {
 .loom/.daemon.*
 GITIGNORE_EOF
 
-  # Create install metadata
-  cat > "$target/.loom/install-metadata.json" << 'META_EOF'
+  # Build installed_files manifest by collecting all files we just installed
+  local installed_files_json="["
+  local first_file=true
+  while IFS= read -r -d '' file; do
+    local rel_path="${file#$target/}"
+    # Skip runtime artifacts and metadata
+    case "$rel_path" in
+      .loom/install-metadata.json|.loom/state.json|.loom/daemon-state.json|.loom/loom-source-path|.loom/manifest.json)
+        continue
+        ;;
+    esac
+    if [[ "$first_file" == "true" ]]; then
+      first_file=false
+    else
+      installed_files_json="${installed_files_json},"
+    fi
+    installed_files_json="${installed_files_json}\"${rel_path}\""
+  done < <(find "$target" -type f \
+    -not -path "$target/.git/*" \
+    -not -path "$target/.loom/worktrees/*" \
+    -not -name '.DS_Store' \
+    -not -name '*.log' \
+    -not -name '*.sock' \
+    -print0 | sort -z)
+  installed_files_json="${installed_files_json}]"
+
+  # Create install metadata with installed_files manifest
+  cat > "$target/.loom/install-metadata.json" <<META_EOF
 {
   "loom_version": "0.0.0-test",
   "loom_commit": "test",
   "install_date": "2026-01-01",
-  "loom_source": "/tmp/test-loom"
+  "loom_source": "/tmp/test-loom",
+  "installed_files": ${installed_files_json}
 }
 META_EOF
 
@@ -653,6 +680,122 @@ if [[ -f "$MIXED_REPO/CLAUDE.md" ]]; then
   fi
 else
   fail "Mixed CLAUDE.md: entire file was removed (should preserve user content)"
+fi
+echo ""
+
+
+# ==========================================================================
+# Section 7: Project-Specific Files in .loom/ Subdirectories
+# ==========================================================================
+echo "--- Section 7: Project-Specific Files in .loom/ ---"
+echo ""
+
+# Test 33: Project-specific directories in .loom/ survive uninstall
+echo "Test 33: Project dirs in .loom/ survive uninstall (manifest-based)"
+PROJECT_REPO="$TEST_DIR/project-dirs-test"
+create_temp_repo "$PROJECT_REPO"
+simulate_loom_install "$PROJECT_REPO"
+
+# Create project-specific directories and files inside .loom/
+# These simulate real-world usage (e.g., sphere's claims/, diagnostics/)
+mkdir -p "$PROJECT_REPO/.loom/claims"
+echo '{"claim": "test"}' > "$PROJECT_REPO/.loom/claims/claim-1.json"
+mkdir -p "$PROJECT_REPO/.loom/diagnostics"
+echo "diagnostic data" > "$PROJECT_REPO/.loom/diagnostics/report.txt"
+mkdir -p "$PROJECT_REPO/.loom/methodology-cache"
+echo "cached data" > "$PROJECT_REPO/.loom/methodology-cache/cache.json"
+mkdir -p "$PROJECT_REPO/.loom/tests"
+echo "test config" > "$PROJECT_REPO/.loom/tests/test-config.json"
+
+# Also create project-specific hooks in .claude/hooks/
+mkdir -p "$PROJECT_REPO/.claude/hooks"
+echo '#!/bin/bash' > "$PROJECT_REPO/.claude/hooks/guard-pdk-files.sh"
+echo '#!/bin/bash' > "$PROJECT_REPO/.claude/hooks/skill-router.sh"
+
+# And project-specific agents
+mkdir -p "$PROJECT_REPO/.claude/agents"
+echo "# AMS Architect" > "$PROJECT_REPO/.claude/agents/ams-architect.md"
+echo "# Layout Place" > "$PROJECT_REPO/.claude/agents/layout-place.md"
+
+git -C "$PROJECT_REPO" add -A
+git -C "$PROJECT_REPO" commit -m "Add project-specific files" --quiet
+
+# Run uninstall (non-interactive, non-clean)
+"$UNINSTALL_SCRIPT" --yes --local "$PROJECT_REPO" > /dev/null 2>&1 || true
+
+# Verify project-specific directories and files survived
+if [[ -f "$PROJECT_REPO/.loom/claims/claim-1.json" ]]; then
+  pass "Project dir .loom/claims/ preserved after uninstall"
+else
+  fail "Project dir .loom/claims/ was removed by uninstall"
+fi
+
+if [[ -f "$PROJECT_REPO/.loom/diagnostics/report.txt" ]]; then
+  pass "Project dir .loom/diagnostics/ preserved after uninstall"
+else
+  fail "Project dir .loom/diagnostics/ was removed by uninstall"
+fi
+
+if [[ -f "$PROJECT_REPO/.loom/methodology-cache/cache.json" ]]; then
+  pass "Project dir .loom/methodology-cache/ preserved after uninstall"
+else
+  fail "Project dir .loom/methodology-cache/ was removed by uninstall"
+fi
+
+if [[ -f "$PROJECT_REPO/.loom/tests/test-config.json" ]]; then
+  pass "Project dir .loom/tests/ preserved after uninstall"
+else
+  fail "Project dir .loom/tests/ was removed by uninstall"
+fi
+
+# Verify project-specific hooks survived
+if [[ -f "$PROJECT_REPO/.claude/hooks/guard-pdk-files.sh" ]]; then
+  pass "Project hook .claude/hooks/guard-pdk-files.sh preserved"
+else
+  fail "Project hook .claude/hooks/guard-pdk-files.sh was removed"
+fi
+
+if [[ -f "$PROJECT_REPO/.claude/hooks/skill-router.sh" ]]; then
+  pass "Project hook .claude/hooks/skill-router.sh preserved"
+else
+  fail "Project hook .claude/hooks/skill-router.sh was removed"
+fi
+
+# Verify project-specific agents survived
+if [[ -f "$PROJECT_REPO/.claude/agents/ams-architect.md" ]]; then
+  pass "Project agent .claude/agents/ams-architect.md preserved"
+else
+  fail "Project agent .claude/agents/ams-architect.md was removed"
+fi
+
+# Verify Loom files WERE removed
+if [[ ! -d "$PROJECT_REPO/.loom/roles" ]] || [[ $(find "$PROJECT_REPO/.loom/roles" -type f 2>/dev/null | wc -l | tr -d ' ') -eq 0 ]]; then
+  pass "Loom roles were correctly removed"
+else
+  fail "Loom roles were not removed"
+fi
+
+if [[ ! -d "$PROJECT_REPO/.loom/scripts" ]] || [[ $(find "$PROJECT_REPO/.loom/scripts" -type f 2>/dev/null | wc -l | tr -d ' ') -eq 0 ]]; then
+  pass "Loom scripts were correctly removed"
+else
+  fail "Loom scripts were not removed"
+fi
+
+# Test 34: No "Preserved directory" noise (uninstall output check)
+echo "Test 34: No 'Preserved directory' noise in uninstall output"
+NOISE_REPO="$TEST_DIR/noise-test"
+create_temp_repo "$NOISE_REPO"
+simulate_loom_install "$NOISE_REPO"
+mkdir -p "$NOISE_REPO/.loom/project-data"
+echo "data" > "$NOISE_REPO/.loom/project-data/info.txt"
+git -C "$NOISE_REPO" add -A
+git -C "$NOISE_REPO" commit -m "Add project data" --quiet
+
+UNINSTALL_OUTPUT=$("$UNINSTALL_SCRIPT" --yes --local "$NOISE_REPO" 2>&1 || true)
+if echo "$UNINSTALL_OUTPUT" | grep -q "Preserved directory"; then
+  fail "Uninstall output contains 'Preserved directory' noise"
+else
+  pass "No 'Preserved directory' noise in uninstall output"
 fi
 echo ""
 

--- a/scripts/uninstall-loom.sh
+++ b/scripts/uninstall-loom.sh
@@ -227,138 +227,310 @@ REMOVE_DIRS=()         # Directories to remove if empty after file removal
 UNKNOWN_FILES=()       # Files in Loom directories that don't match known patterns
 SMART_REMOVE_FILES=()  # Files needing smart removal (CLAUDE.md, .gitignore)
 
-# 1. Build manifest from defaults/ directory (if available)
-DEFAULTS_PATH="$LOOM_ROOT/defaults"
-KNOWN_DEFAULTS=()
+# Check if install-metadata.json has an installed_files manifest
+# If so, use it as the authoritative source instead of walking defaults/
+METADATA_FILE="$TARGET_PATH/.loom/install-metadata.json"
+USE_MANIFEST=false
 
-if [[ -d "$DEFAULTS_PATH" ]]; then
-  # Walk defaults/ to find all files that Loom installs
-  while IFS= read -r -d '' file; do
-    rel_path="${file#$DEFAULTS_PATH/}"
-
-    # Map defaults paths to target repo paths
-    case "$rel_path" in
-      # roles/ -> .loom/roles/
-      roles/*)
-        target_file=".loom/$rel_path"
-        ;;
-      # scripts/ -> .loom/scripts/
-      scripts/*)
-        target_file=".loom/$rel_path"
-        ;;
-      # config.json -> .loom/config.json
-      config.json)
-        target_file=".loom/config.json"
-        ;;
-      # package.json -> .loom/package.json (if installed there)
-      package.json)
-        target_file=".loom/package.json"
-        ;;
-      # .loom-README.md -> .loom/README.md
-      .loom-README.md)
-        target_file=".loom/README.md"
-        ;;
-      # README.md from defaults -> skip (this is Loom's own README)
-      README.md)
-        continue
-        ;;
-      # .loom/ files -> .loom/ (CLAUDE.md in .loom/)
-      .loom/*)
-        target_file="$rel_path"
-        ;;
-      # .DS_Store -> skip
-      .DS_Store)
-        continue
-        ;;
-      # All other files map directly (CLAUDE.md, .claude/*, .codex/*, .github/*)
-      *)
-        target_file="$rel_path"
-        ;;
-    esac
-
-    KNOWN_DEFAULTS+=("$target_file")
-
-    # Check if the file exists in target and add to removal list
-    # CLAUDE.md gets smart removal (step 6), not direct removal
-    # .claude/settings.json gets smart removal (selective Loom hook/permission removal)
-    if [[ "$target_file" == "CLAUDE.md" ]]; then
-      continue
-    fi
-    if [[ "$target_file" == ".claude/settings.json" ]]; then
-      continue
-    fi
-
-    if [[ -f "$TARGET_PATH/$target_file" ]]; then
-      REMOVE_FILES+=("$target_file")
-    fi
-  done < <(find -L "$DEFAULTS_PATH" -type f -print0 | sort -z)
-else
-  warning "Loom defaults/ directory not found at $DEFAULTS_PATH"
-  info "Using fallback pattern matching for file detection"
+if [[ -f "$METADATA_FILE" ]]; then
+  # Check if the metadata has the installed_files field
+  if grep -q '"installed_files"' "$METADATA_FILE" 2>/dev/null; then
+    USE_MANIFEST=true
+    info "Using installed file manifest from install-metadata.json"
+  fi
 fi
 
-# 2. Add generated role .md files (correspond to .json files)
-if [[ -d "$TARGET_PATH/.loom/roles" ]]; then
-  for json_file in "$TARGET_PATH/.loom/roles/"*.json; do
-    [[ -f "$json_file" ]] || continue
-    base_name=$(basename "$json_file" .json)
-    md_file=".loom/roles/${base_name}.md"
-    if [[ -f "$TARGET_PATH/$md_file" ]]; then
-      # Add if not already in the list
-      if ! printf '%s\n' ${REMOVE_FILES[@]+"${REMOVE_FILES[@]}"} | grep -q "^${md_file}$" 2>/dev/null; then
-        REMOVE_FILES+=("$md_file")
+if [[ "$USE_MANIFEST" == "true" ]]; then
+  # ── Manifest-based removal (new path) ──────────────────────────────────
+  # Parse installed_files array from JSON using lightweight shell tools.
+  # Handles both single-line and multi-line JSON array formats.
+  # Extract the array content, split on commas, strip quotes.
+  MANIFEST_CONTENT=$(cat "$METADATA_FILE" | tr '\n' ' ')
+  INSTALLED_LIST=$(echo "$MANIFEST_CONTENT" | grep -o '"installed_files"[[:space:]]*:[[:space:]]*\[.*\]' | sed 's/.*\[//;s/\]//' | tr ',' '\n')
+
+  while IFS= read -r file_path; do
+    # Trim whitespace and quotes
+    file_path=$(echo "$file_path" | sed 's/^[[:space:]]*"//;s/"[[:space:]]*$//')
+    [[ -z "$file_path" ]] && continue
+
+    # CLAUDE.md gets smart removal (step 6), not direct removal
+    # .claude/settings.json gets smart removal (selective Loom hook/permission removal)
+    if [[ "$file_path" == "CLAUDE.md" ]]; then
+      continue
+    fi
+    if [[ "$file_path" == ".claude/settings.json" ]]; then
+      continue
+    fi
+
+    if [[ -f "$TARGET_PATH/$file_path" ]]; then
+      REMOVE_FILES+=("$file_path")
+    fi
+  done <<< "$INSTALLED_LIST"
+
+  # Also add install-metadata.json itself to removal
+  REMOVE_FILES+=(".loom/install-metadata.json")
+
+  # Add runtime artifacts not tracked in the manifest
+  RUNTIME_ARTIFACTS=(
+    ".loom/state.json"
+    ".loom/daemon-state.json"
+    ".loom/stop-daemon"
+    ".loom/manifest.json"
+    ".loom/loom-source-path"
+    ".loom/metrics_state.json"
+    ".loom/stuck-config.json"
+    ".loom/activity.db"
+  )
+
+  for artifact in "${RUNTIME_ARTIFACTS[@]}"; do
+    if [[ -f "$TARGET_PATH/$artifact" ]]; then
+      if ! printf '%s\n' ${REMOVE_FILES[@]+"${REMOVE_FILES[@]}"} | grep -q "^${artifact}$" 2>/dev/null; then
+        REMOVE_FILES+=("$artifact")
       fi
     fi
   done
-fi
 
-# 3. Add runtime artifacts
-RUNTIME_ARTIFACTS=(
-  ".loom/state.json"
-  ".loom/daemon-state.json"
-  ".loom/config.json"
-  ".loom/stop-daemon"
-  ".loom/manifest.json"
-  ".loom/loom-source-path"
-  ".loom/metrics_state.json"
-  ".loom/stuck-config.json"
-  ".loom/activity.db"
-)
-
-for artifact in "${RUNTIME_ARTIFACTS[@]}"; do
-  if [[ -f "$TARGET_PATH/$artifact" ]]; then
-    if ! printf '%s\n' ${REMOVE_FILES[@]+"${REMOVE_FILES[@]}"} | grep -q "^${artifact}$" 2>/dev/null; then
-      REMOVE_FILES+=("$artifact")
+  # Add archived daemon state files
+  for f in "$TARGET_PATH/.loom/"*-daemon-state.json; do
+    [[ -f "$f" ]] || continue
+    rel_f="${f#$TARGET_PATH/}"
+    if ! printf '%s\n' ${REMOVE_FILES[@]+"${REMOVE_FILES[@]}"} | grep -q "^${rel_f}$" 2>/dev/null; then
+      REMOVE_FILES+=("$rel_f")
     fi
-  fi
-done
+  done
 
-# Add archived daemon state files
-for f in "$TARGET_PATH/.loom/"*-daemon-state.json; do
-  [[ -f "$f" ]] || continue
-  rel_f="${f#$TARGET_PATH/}"
-  if ! printf '%s\n' ${REMOVE_FILES[@]+"${REMOVE_FILES[@]}"} | grep -q "^${rel_f}$" 2>/dev/null; then
+  # Add log files
+  for f in "$TARGET_PATH/.loom/"*.log; do
+    [[ -f "$f" ]] || continue
+    rel_f="${f#$TARGET_PATH/}"
     REMOVE_FILES+=("$rel_f")
-  fi
-done
+  done
 
-# Add log files
-for f in "$TARGET_PATH/.loom/"*.log; do
-  [[ -f "$f" ]] || continue
-  rel_f="${f#$TARGET_PATH/}"
-  if ! printf '%s\n' ${REMOVE_FILES[@]+"${REMOVE_FILES[@]}"} | grep -q "^${rel_f}$" 2>/dev/null; then
+  # Add socket files
+  for f in "$TARGET_PATH/.loom/"*.sock; do
+    [[ -f "$f" ]] || continue
+    rel_f="${f#$TARGET_PATH/}"
     REMOVE_FILES+=("$rel_f")
-  fi
-done
+  done
 
-# Add socket files
-for f in "$TARGET_PATH/.loom/"*.sock; do
-  [[ -f "$f" ]] || continue
-  rel_f="${f#$TARGET_PATH/}"
-  if ! printf '%s\n' ${REMOVE_FILES[@]+"${REMOVE_FILES[@]}"} | grep -q "^${rel_f}$" 2>/dev/null; then
-    REMOVE_FILES+=("$rel_f")
+  # In --clean mode, also find and remove non-manifest files in Loom-owned directories.
+  # The manifest tells us what Loom installed, but --clean means "wipe everything Loom-owned".
+  # Shared directories (.claude/commands/, .claude/agents/) are still preserved.
+  if [[ "$CLEAN_MODE" == "true" ]]; then
+    LOOM_OWNED_DIRS=(".loom/roles" ".loom/scripts" ".loom/docs" ".loom/hooks")
+    for loom_dir in "${LOOM_OWNED_DIRS[@]}"; do
+      [[ -d "$TARGET_PATH/$loom_dir" ]] || continue
+      while IFS= read -r -d '' file; do
+        rel_file="${file#$TARGET_PATH/}"
+        # Check if already in removal list
+        is_listed=false
+        for listed in ${REMOVE_FILES[@]+"${REMOVE_FILES[@]}"}; do
+          if [[ "$rel_file" == "$listed" ]]; then
+            is_listed=true
+            break
+          fi
+        done
+        if [[ "$is_listed" == "false" ]]; then
+          REMOVE_FILES+=("$rel_file")
+        fi
+      done < <(find "$TARGET_PATH/$loom_dir" -type f -print0 2>/dev/null | sort -z)
+    done
   fi
-done
+
+else
+  # ── Heuristic-based removal (legacy path for pre-manifest installs) ────
+
+  # 1. Build manifest from defaults/ directory (if available)
+  DEFAULTS_PATH="$LOOM_ROOT/defaults"
+  KNOWN_DEFAULTS=()
+
+  if [[ -d "$DEFAULTS_PATH" ]]; then
+    # Walk defaults/ to find all files that Loom installs
+    while IFS= read -r -d '' file; do
+      rel_path="${file#$DEFAULTS_PATH/}"
+
+      # Map defaults paths to target repo paths
+      case "$rel_path" in
+        # roles/ -> .loom/roles/
+        roles/*)
+          target_file=".loom/$rel_path"
+          ;;
+        # scripts/ -> .loom/scripts/
+        scripts/*)
+          target_file=".loom/$rel_path"
+          ;;
+        # config.json -> .loom/config.json
+        config.json)
+          target_file=".loom/config.json"
+          ;;
+        # package.json -> .loom/package.json (if installed there)
+        package.json)
+          target_file=".loom/package.json"
+          ;;
+        # .loom-README.md -> .loom/README.md
+        .loom-README.md)
+          target_file=".loom/README.md"
+          ;;
+        # README.md from defaults -> skip (this is Loom's own README)
+        README.md)
+          continue
+          ;;
+        # .loom/ files -> .loom/ (CLAUDE.md in .loom/)
+        .loom/*)
+          target_file="$rel_path"
+          ;;
+        # .DS_Store -> skip
+        .DS_Store)
+          continue
+          ;;
+        # All other files map directly (CLAUDE.md, .claude/*, .codex/*, .github/*)
+        *)
+          target_file="$rel_path"
+          ;;
+      esac
+
+      KNOWN_DEFAULTS+=("$target_file")
+
+      # Check if the file exists in target and add to removal list
+      # CLAUDE.md gets smart removal (step 6), not direct removal
+      if [[ "$target_file" == "CLAUDE.md" ]]; then
+        continue
+      fi
+
+      if [[ -f "$TARGET_PATH/$target_file" ]]; then
+        REMOVE_FILES+=("$target_file")
+      fi
+    done < <(find -L "$DEFAULTS_PATH" -type f -print0 | sort -z)
+  else
+    warning "Loom defaults/ directory not found at $DEFAULTS_PATH"
+    info "Using fallback pattern matching for file detection"
+  fi
+
+  # 2. Add generated role .md files (correspond to .json files)
+  if [[ -d "$TARGET_PATH/.loom/roles" ]]; then
+    for json_file in "$TARGET_PATH/.loom/roles/"*.json; do
+      [[ -f "$json_file" ]] || continue
+      base_name=$(basename "$json_file" .json)
+      md_file=".loom/roles/${base_name}.md"
+      if [[ -f "$TARGET_PATH/$md_file" ]]; then
+        # Add if not already in the list
+        if ! printf '%s\n' ${REMOVE_FILES[@]+"${REMOVE_FILES[@]}"} | grep -q "^${md_file}$" 2>/dev/null; then
+          REMOVE_FILES+=("$md_file")
+        fi
+      fi
+    done
+  fi
+
+  # 3. Add runtime artifacts
+  RUNTIME_ARTIFACTS=(
+    ".loom/state.json"
+    ".loom/daemon-state.json"
+    ".loom/config.json"
+    ".loom/stop-daemon"
+    ".loom/manifest.json"
+    ".loom/loom-source-path"
+    ".loom/metrics_state.json"
+    ".loom/stuck-config.json"
+    ".loom/activity.db"
+    ".loom/install-metadata.json"
+  )
+
+  for artifact in "${RUNTIME_ARTIFACTS[@]}"; do
+    if [[ -f "$TARGET_PATH/$artifact" ]]; then
+      if ! printf '%s\n' ${REMOVE_FILES[@]+"${REMOVE_FILES[@]}"} | grep -q "^${artifact}$" 2>/dev/null; then
+        REMOVE_FILES+=("$artifact")
+      fi
+    fi
+  done
+
+  # Add archived daemon state files
+  for f in "$TARGET_PATH/.loom/"*-daemon-state.json; do
+    [[ -f "$f" ]] || continue
+    rel_f="${f#$TARGET_PATH/}"
+    if ! printf '%s\n' ${REMOVE_FILES[@]+"${REMOVE_FILES[@]}"} | grep -q "^${rel_f}$" 2>/dev/null; then
+      REMOVE_FILES+=("$rel_f")
+    fi
+  done
+
+  # Add log files
+  for f in "$TARGET_PATH/.loom/"*.log; do
+    [[ -f "$f" ]] || continue
+    rel_f="${f#$TARGET_PATH/}"
+    if ! printf '%s\n' ${REMOVE_FILES[@]+"${REMOVE_FILES[@]}"} | grep -q "^${rel_f}$" 2>/dev/null; then
+      REMOVE_FILES+=("$rel_f")
+    fi
+  done
+
+  # Add socket files
+  for f in "$TARGET_PATH/.loom/"*.sock; do
+    [[ -f "$f" ]] || continue
+    rel_f="${f#$TARGET_PATH/}"
+    if ! printf '%s\n' ${REMOVE_FILES[@]+"${REMOVE_FILES[@]}"} | grep -q "^${rel_f}$" 2>/dev/null; then
+      REMOVE_FILES+=("$rel_f")
+    fi
+  done
+
+  # 6. Detect unknown files in Loom-installed directories
+  # Only scan directories that the install process creates — NOT runtime dirs like worktrees/
+  LOOM_DIRS=(".loom/roles" ".loom/scripts" ".loom/docs" ".claude/commands" ".claude/agents")
+
+  # Claimed role name prefixes — any file in .loom/roles/ matching these prefixes
+  # is owned by Loom and should be removed during uninstall. This handles deprecated
+  # role files from older versions (e.g., builder-complexity.md, hermit-patterns.md)
+  # without needing to maintain an explicit list of deprecated filenames.
+  CLAIMED_ROLE_PREFIXES=(
+    architect auditor builder champion curator
+    doctor driver guide hermit judge
+    loom shepherd
+  )
+
+  for loom_dir in "${LOOM_DIRS[@]}"; do
+    if [[ ! -d "$TARGET_PATH/$loom_dir" ]]; then
+      continue
+    fi
+
+    while IFS= read -r -d '' file; do
+      rel_file="${file#$TARGET_PATH/}"
+
+      # Check if this file is in our removal list or known defaults
+      is_known=false
+      for known in ${REMOVE_FILES[@]+"${REMOVE_FILES[@]}"} ${KNOWN_DEFAULTS[@]+"${KNOWN_DEFAULTS[@]}"}; do
+        if [[ "$rel_file" == "$known" ]]; then
+          is_known=true
+          break
+        fi
+      done
+
+      # For .loom/roles/, also check claimed role name prefixes
+      # This catches deprecated role files from older Loom versions
+      if [[ "$is_known" == "false" ]] && [[ "$loom_dir" == ".loom/roles" ]]; then
+        base_name=$(basename "$rel_file")
+        for prefix in "${CLAIMED_ROLE_PREFIXES[@]}"; do
+          if [[ "$base_name" == "${prefix}"* ]]; then
+            is_known=true
+            # Add to removal list since it's a claimed Loom file
+            REMOVE_FILES+=("$rel_file")
+            break
+          fi
+        done
+      fi
+
+      if [[ "$is_known" == "false" ]]; then
+        UNKNOWN_FILES+=("$rel_file")
+      fi
+    done < <(find "$TARGET_PATH/$loom_dir" -type f -print0 2>/dev/null | sort -z)
+  done
+
+  # Also add the CLI wrapper if it exists (new location: .loom/bin/loom)
+  if [[ -f "$TARGET_PATH/.loom/bin/loom" ]] && [[ -x "$TARGET_PATH/.loom/bin/loom" ]]; then
+    REMOVE_FILES+=(".loom/bin/loom")
+  fi
+
+  # Backward compatibility: also check old location (repo root)
+  if [[ -f "$TARGET_PATH/loom" ]] && [[ -x "$TARGET_PATH/loom" ]]; then
+    REMOVE_FILES+=("loom")
+  fi
+fi
 
 # 4. Add runtime directories (worktrees, progress)
 RUNTIME_DIRS=(
@@ -382,66 +554,6 @@ if [[ -f "$TARGET_PATH/.claude/settings.json" ]]; then
   SMART_REMOVE_FILES+=(".claude/settings.json")
 fi
 
-# 6. Detect unknown files in Loom-installed directories
-# Only scan directories that the install process creates — NOT runtime dirs like worktrees/
-LOOM_DIRS=(".loom/roles" ".loom/scripts" ".loom/docs" ".claude/commands/loom" ".claude/agents")
-
-# Claimed role name prefixes — any file in .loom/roles/ matching these prefixes
-# is owned by Loom and should be removed during uninstall. This handles deprecated
-# role files from older versions (e.g., builder-complexity.md, hermit-patterns.md)
-# without needing to maintain an explicit list of deprecated filenames.
-CLAIMED_ROLE_PREFIXES=(
-  architect auditor builder champion curator
-  doctor driver guide hermit judge
-  loom shepherd
-)
-
-for loom_dir in "${LOOM_DIRS[@]}"; do
-  if [[ ! -d "$TARGET_PATH/$loom_dir" ]]; then
-    continue
-  fi
-
-  while IFS= read -r -d '' file; do
-    rel_file="${file#$TARGET_PATH/}"
-
-    # Check if this file is in our removal list or known defaults
-    is_known=false
-    for known in ${REMOVE_FILES[@]+"${REMOVE_FILES[@]}"} ${KNOWN_DEFAULTS[@]+"${KNOWN_DEFAULTS[@]}"}; do
-      if [[ "$rel_file" == "$known" ]]; then
-        is_known=true
-        break
-      fi
-    done
-
-    # For .loom/roles/, also check claimed role name prefixes
-    # This catches deprecated role files from older Loom versions
-    if [[ "$is_known" == "false" ]] && [[ "$loom_dir" == ".loom/roles" ]]; then
-      base_name=$(basename "$rel_file")
-      for prefix in "${CLAIMED_ROLE_PREFIXES[@]}"; do
-        if [[ "$base_name" == "${prefix}"* ]]; then
-          is_known=true
-          # Add to removal list since it's a claimed Loom file
-          REMOVE_FILES+=("$rel_file")
-          break
-        fi
-      done
-    fi
-
-    if [[ "$is_known" == "false" ]]; then
-      UNKNOWN_FILES+=("$rel_file")
-    fi
-  done < <(find "$TARGET_PATH/$loom_dir" -type f -print0 2>/dev/null | sort -z)
-done
-
-# Also add the CLI wrapper if it exists (new location: .loom/bin/loom)
-if [[ -f "$TARGET_PATH/.loom/bin/loom" ]] && [[ -x "$TARGET_PATH/.loom/bin/loom" ]]; then
-  REMOVE_FILES+=(".loom/bin/loom")
-fi
-
-# Backward compatibility: also check old location (repo root)
-if [[ -f "$TARGET_PATH/loom" ]] && [[ -x "$TARGET_PATH/loom" ]]; then
-  REMOVE_FILES+=("loom")
-fi
 
 # Track directories to check for emptiness after removal
 REMOVE_DIRS=(
@@ -450,6 +562,7 @@ REMOVE_DIRS=(
   ".loom/scripts"
   ".loom/scripts/cli"
   ".loom/docs"
+  ".loom/hooks"
   ".loom"
   ".claude/commands/loom"
   ".claude/commands"
@@ -947,9 +1060,8 @@ for dir in "${REMOVE_DIRS[@]}"; do
       rm -rf "$dir_path"
       REMOVED_LIST+=("$dir/ (empty directory)")
       success "Removed empty directory: $dir"
-    else
-      info "Preserved directory $dir (contains files)"
     fi
+    # Silently skip non-empty directories — they contain project-specific files
   fi
 done
 


### PR DESCRIPTION
## Summary

Fixes the installer/uninstaller to precisely track which files Loom owns, preventing uninstall from touching project-specific files in `.loom/` and other shared directories.

### Changes

**Installer (`scripts/install-loom.sh`)**:
- After installation, collects all installed file paths and records them in `install-metadata.json` under a new `installed_files` array field

**Uninstaller (`scripts/uninstall-loom.sh`)**:
- Checks for `installed_files` in `install-metadata.json`; when present, uses it as the authoritative removal list instead of walking `defaults/` and using heuristics
- Falls back to existing heuristic-based removal for pre-manifest installations (backward compatible)
- In `--clean` mode with manifest, also removes non-manifest files in Loom-owned directories (`.loom/roles`, `.loom/scripts`, etc.) while preserving shared directories
- Step 7 (Clean Directories) silently skips non-empty directories instead of logging "Preserved directory" noise

**Tests (`scripts/test-installer.sh`)**:
- `simulate_loom_install` now generates `installed_files` manifest matching real installer behavior
- New Section 7 with tests for project-specific files surviving uninstall (`.loom/claims/`, `.loom/diagnostics/`, `.claude/hooks/`, `.claude/agents/`)
- Tests verify no "Preserved directory" noise in output
- All 48 tests pass

Closes #3178