### PR TITLE
feat: add methodology injection framework for project-specific context

### DIFF
--- a/defaults/.claude/settings.json
+++ b/defaults/.claude/settings.json
@@ -18,6 +18,10 @@
           {
             "type": "command",
             "command": ".loom/hooks/skill-router.sh"
+          },
+          {
+            "type": "command",
+            "command": ".loom/hooks/methodology-inject.sh"
           }
         ]
       }

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -1080,7 +1080,97 @@ Many projects have directories that should never be modified by agents (vendor c
 
 **Template location**: `defaults/hooks/guard-readonly-dirs.sh.template`
 
+## Methodology Injection Framework
+
+Loom provides an opt-in methodology injection hook that automatically injects project-specific context into every agent session. This is useful for domain knowledge, coding conventions, design rules, or any context that agents need to do their job well.
+
+### Quick Start
+
+1. Create the context directory in your repository:
+   ```bash
+   mkdir -p .loom/context/roles .loom/context/topics
+   ```
+
+2. Add a universal context file (injected on every prompt):
+   ```bash
+   cat > .loom/context/universal.md << 'EOF'
+   # Project Rules
+   - Use TypeScript strict mode
+   - All functions must have JSDoc comments
+   - Run tests before creating PRs
+   EOF
+   ```
+
+3. The hook is already registered in `.claude/settings.json`. It activates automatically when `.loom/context/` exists and silently does nothing when the directory is absent.
+
+### Context File Structure
+
+```
+.loom/context/
+├── config.json              # Optional configuration
+├── universal.md             # Injected on every prompt
+├── roles/
+│   ├── builder.md           # Injected when LOOM_ROLE=builder
+│   ├── judge.md             # Injected when LOOM_ROLE=judge
+│   └── ...
+└── topics/
+    ├── security.md          # Injected when prompt matches "security"
+    ├── security.pattern     # Optional: custom regex pattern for matching
+    ├── database.md          # Injected when prompt matches "database"
+    └── ...
+```
+
+**Universal context** (`universal.md`): Always injected when the context directory exists. Use for project-wide rules and conventions.
+
+**Role context** (`roles/<role>.md`): Injected when the `LOOM_ROLE` environment variable matches the filename, or when a slash command (e.g., `/builder`) is detected in the prompt. Role names are case-insensitive.
+
+**Topic context** (`topics/<name>.md`): Injected when the prompt matches a keyword pattern. By default, the filename is used as the regex pattern (e.g., `security.md` matches prompts containing "security"). For custom patterns, create a sidecar `.pattern` file with a regex (e.g., `security.pattern` containing `security|auth|token|credential`).
+
+### Configuration
+
+Create `.loom/context/config.json` to customize behavior:
+
+```json
+{
+  "max_context_chars": 8000,
+  "enabled": true,
+  "inject_universal": true,
+  "inject_role": true,
+  "inject_topics": true
+}
+```
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `max_context_chars` | 8000 | Maximum total characters injected (prevents overwhelming the context window) |
+| `enabled` | true | Set to false to disable injection without removing files |
+| `inject_universal` | true | Whether to inject `universal.md` |
+| `inject_role` | true | Whether to inject role-specific context |
+| `inject_topics` | true | Whether to inject topic-matched context |
+
+### How It Works
+
+The `methodology-inject.sh` hook runs as a `UserPromptSubmit` hook alongside `skill-router.sh`. On each prompt:
+
+1. Checks for `.loom/context/` directory -- exits silently if absent
+2. Reads `universal.md` if present
+3. Detects the active role via `LOOM_ROLE` env var or prompt slash command
+4. Scans `topics/` files, matching prompt against filename or sidecar `.pattern` regex
+5. Concatenates matching content, capped at `max_context_chars`
+6. Returns the collected context as `additionalContext`
+
+The hook follows the same error-handling patterns as other Loom hooks: it never exits non-zero, logs errors to `.loom/logs/hook-errors.log`, and fails silently on any unexpected error.
+
+### Example Context Files
+
+Example context files are provided in `defaults/hooks/example-context/` to guide setup. Copy them to your `.loom/context/` directory and customize:
+
+```bash
+cp -r defaults/hooks/example-context/* .loom/context/
+```
+
 ## Troubleshooting
+
 
 ### Common Issues
 

--- a/defaults/hooks/example-context/roles/builder.md
+++ b/defaults/hooks/example-context/roles/builder.md
@@ -1,0 +1,9 @@
+# Builder Context
+
+Additional context injected when LOOM_ROLE=builder or the /builder command is used.
+
+## Example Content
+
+- Always run `pnpm test` before creating a PR
+- Keep PRs under 300 lines of diff when possible
+- Include JSDoc comments on exported functions

--- a/defaults/hooks/example-context/topics/security.md
+++ b/defaults/hooks/example-context/topics/security.md
@@ -1,0 +1,11 @@
+# Security Guidelines
+
+This file is injected when a prompt mentions security-related keywords.
+The default pattern matches the filename ("security"). For custom patterns,
+create a sidecar file (e.g., topics/security.pattern) containing a regex.
+
+## Example Content
+
+- Never log secrets or tokens
+- Use parameterized queries for all database access
+- Validate and sanitize all user input

--- a/defaults/hooks/example-context/topics/security.pattern
+++ b/defaults/hooks/example-context/topics/security.pattern
@@ -1,0 +1,1 @@
+security|auth|token|credential|password|secret|encrypt

--- a/defaults/hooks/example-context/universal.md
+++ b/defaults/hooks/example-context/universal.md
@@ -1,0 +1,11 @@
+# Project Context
+
+This file is injected into every agent session when `.loom/context/` exists.
+Use it for project-wide rules, conventions, and domain knowledge.
+
+## Example Content
+
+- **Language**: TypeScript with strict mode
+- **Framework**: React 18 with Server Components
+- **Testing**: Vitest for unit tests, Playwright for E2E
+- **Style**: Follow existing patterns; prefer composition over inheritance

--- a/defaults/hooks/methodology-inject.sh
+++ b/defaults/hooks/methodology-inject.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# methodology-inject.sh - UserPromptSubmit hook for project-specific context injection
+#
+# Claude Code UserPromptSubmit hook that injects domain-specific context from
+# .loom/context/ files into agent sessions as additionalContext.
+#
+# Receives JSON on stdin with { "prompt": "...", "session_id": "...", "cwd": "..." }
+#
+# Behavior:
+#   1. Check for .loom/context/ directory — exit silently if absent (opt-in)
+#   2. Always inject universal.md if it exists
+#   3. Inject roles/<LOOM_ROLE>.md if LOOM_ROLE env var is set
+#   4. Inject topics/<name>.md when prompt matches filename or sidecar .pattern file
+#   5. Cap total output at configurable max (default 8000 chars)
+#
+# Output format (Claude Code hooks spec):
+#   { "hookSpecificOutput": { "hookEventName": "UserPromptSubmit", "additionalContext": "..." } }
+#
+# Opt-in: Only activates when .loom/context/ directory exists.
+# If the directory is missing, the hook exits silently (no context injected).
+#
+# Error handling: This script MUST never exit with a non-zero code or produce
+# invalid output. Any internal error results in a silent exit 0.
+
+set -o pipefail
+
+# Determine main repo root via git-common-dir (works from worktrees)
+MAIN_ROOT="$(cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." 2>/dev/null && pwd)" || \
+MAIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." 2>/dev/null && pwd 2>/dev/null || echo ".")"
+
+HOOK_ERROR_LOG="${MAIN_ROOT}/.loom/logs/hook-errors.log"
+
+# Log a diagnostic error message (best-effort, never fails the script)
+log_hook_error() {
+    local msg="$1"
+    mkdir -p "$(dirname "$HOOK_ERROR_LOG")" 2>/dev/null || true
+    echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] [methodology-inject] $msg" >> "$HOOK_ERROR_LOG" 2>/dev/null || true
+}
+
+# Top-level error trap: on ANY unexpected error, exit silently
+trap 'log_hook_error "Unexpected error on line ${LINENO}: ${BASH_COMMAND:-unknown} (exit=$?)"; exit 0' ERR
+
+# Read stdin safely
+INPUT=$(cat 2>/dev/null) || INPUT=""
+
+# Verify jq is available
+if ! command -v jq &>/dev/null; then
+    log_hook_error "jq not found in PATH"
+    exit 0
+fi
+
+# Extract prompt
+PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty' 2>/dev/null) || PROMPT=""
+
+# If no prompt, nothing to do
+if [[ -z "$PROMPT" ]]; then
+    exit 0
+fi
+
+# Skip orchestrator pulse prompts (start with /self)
+if [[ "$PROMPT" == /self* ]]; then
+    exit 0
+fi
+
+# =============================================================================
+# OPT-IN CHECK
+# =============================================================================
+
+CONTEXT_DIR="${MAIN_ROOT}/.loom/context"
+
+# Exit silently if context directory does not exist
+if [[ ! -d "$CONTEXT_DIR" ]]; then
+    exit 0
+fi
+
+# =============================================================================
+# CONFIGURATION
+# =============================================================================
+
+CONFIG_FILE="${CONTEXT_DIR}/config.json"
+MAX_CONTEXT_CHARS=8000
+INJECT_UNIVERSAL=true
+INJECT_ROLE=true
+INJECT_TOPICS=true
+
+# Read config if it exists
+if [[ -f "$CONFIG_FILE" ]] && jq empty "$CONFIG_FILE" 2>/dev/null; then
+    # Check enabled flag (jq // is alternative-on-null, not default-on-missing,
+    # so we use if/then/else to handle explicit false correctly)
+    ENABLED=$(jq -r 'if .enabled == false then "false" else "true" end' "$CONFIG_FILE" 2>/dev/null) || ENABLED=true
+    if [[ "$ENABLED" == "false" ]]; then
+        exit 0
+    fi
+
+    MAX_CONTEXT_CHARS=$(jq -r '.max_context_chars // 8000' "$CONFIG_FILE" 2>/dev/null) || MAX_CONTEXT_CHARS=8000
+    INJECT_UNIVERSAL=$(jq -r 'if .inject_universal == false then "false" else "true" end' "$CONFIG_FILE" 2>/dev/null) || INJECT_UNIVERSAL=true
+    INJECT_ROLE=$(jq -r 'if .inject_role == false then "false" else "true" end' "$CONFIG_FILE" 2>/dev/null) || INJECT_ROLE=true
+    INJECT_TOPICS=$(jq -r 'if .inject_topics == false then "false" else "true" end' "$CONFIG_FILE" 2>/dev/null) || INJECT_TOPICS=true
+fi
+
+# =============================================================================
+# CONTEXT COLLECTION
+# =============================================================================
+
+COLLECTED_CONTEXT=""
+
+# Helper: append content with a separator, respecting max chars
+append_context() {
+    local label="$1"
+    local content="$2"
+
+    if [[ -z "$content" ]]; then
+        return
+    fi
+
+    local new_section
+    if [[ -n "$COLLECTED_CONTEXT" ]]; then
+        new_section=$'\n\n---\n\n'"[${label}]"$'\n'"${content}"
+    else
+        new_section="[${label}]"$'\n'"${content}"
+    fi
+
+    local current_len=${#COLLECTED_CONTEXT}
+    local new_len=${#new_section}
+
+    if (( current_len + new_len > MAX_CONTEXT_CHARS )); then
+        # Truncate to fit within budget
+        local remaining=$(( MAX_CONTEXT_CHARS - current_len ))
+        if (( remaining > 50 )); then
+            COLLECTED_CONTEXT="${COLLECTED_CONTEXT}${new_section:0:$remaining}... [truncated]"
+        fi
+        return
+    fi
+
+    COLLECTED_CONTEXT="${COLLECTED_CONTEXT}${new_section}"
+}
+
+# --- Universal context ---
+if [[ "$INJECT_UNIVERSAL" == "true" ]] && [[ -f "${CONTEXT_DIR}/universal.md" ]]; then
+    UNIVERSAL_CONTENT=$(cat "${CONTEXT_DIR}/universal.md" 2>/dev/null) || UNIVERSAL_CONTENT=""
+    append_context "Project Context" "$UNIVERSAL_CONTENT"
+fi
+
+# --- Role-specific context ---
+if [[ "$INJECT_ROLE" == "true" ]]; then
+    ROLE="${LOOM_ROLE:-}"
+
+    # Fallback: detect role from prompt preamble (slash commands)
+    if [[ -z "$ROLE" ]]; then
+        case "$PROMPT" in
+            /builder*) ROLE="builder" ;;
+            /judge*)   ROLE="judge" ;;
+            /curator*) ROLE="curator" ;;
+            /doctor*)  ROLE="doctor" ;;
+            /architect*) ROLE="architect" ;;
+            /hermit*)  ROLE="hermit" ;;
+            /champion*) ROLE="champion" ;;
+            /guide*)   ROLE="guide" ;;
+            /auditor*) ROLE="auditor" ;;
+            /shepherd*) ROLE="shepherd" ;;
+            /loom*)    ROLE="loom" ;;
+        esac
+    fi
+
+    if [[ -n "$ROLE" ]]; then
+        # Normalize to lowercase
+        ROLE_LOWER=$(echo "$ROLE" | tr '[:upper:]' '[:lower:]')
+        ROLE_FILE="${CONTEXT_DIR}/roles/${ROLE_LOWER}.md"
+
+        if [[ -f "$ROLE_FILE" ]]; then
+            ROLE_CONTENT=$(cat "$ROLE_FILE" 2>/dev/null) || ROLE_CONTENT=""
+            append_context "Role Context: ${ROLE_LOWER}" "$ROLE_CONTENT"
+        fi
+    fi
+fi
+
+# --- Topic-specific context ---
+if [[ "$INJECT_TOPICS" == "true" ]] && [[ -d "${CONTEXT_DIR}/topics" ]]; then
+    PROMPT_LOWER=$(echo "$PROMPT" | tr '[:upper:]' '[:lower:]')
+
+    for topic_file in "${CONTEXT_DIR}/topics/"*.md; do
+        # Skip if glob didn't match anything
+        [[ -f "$topic_file" ]] || continue
+
+        # Check if we've already hit the max
+        if (( ${#COLLECTED_CONTEXT} >= MAX_CONTEXT_CHARS )); then
+            break
+        fi
+
+        TOPIC_NAME=$(basename "$topic_file" .md)
+        PATTERN=""
+
+        # Check for sidecar .pattern file first
+        PATTERN_FILE="${CONTEXT_DIR}/topics/${TOPIC_NAME}.pattern"
+        if [[ -f "$PATTERN_FILE" ]]; then
+            PATTERN=$(cat "$PATTERN_FILE" 2>/dev/null) || PATTERN=""
+        fi
+
+        # Fall back to using filename as the regex pattern
+        if [[ -z "$PATTERN" ]]; then
+            PATTERN="$TOPIC_NAME"
+        fi
+
+        # Match pattern case-insensitively against prompt
+        if echo "$PROMPT_LOWER" | grep -qiE "$PATTERN" 2>/dev/null; then
+            TOPIC_CONTENT=$(cat "$topic_file" 2>/dev/null) || TOPIC_CONTENT=""
+            append_context "Topic: ${TOPIC_NAME}" "$TOPIC_CONTENT"
+        fi
+    done
+fi
+
+# =============================================================================
+# OUTPUT
+# =============================================================================
+
+# If no context was collected, exit silently
+if [[ -z "$COLLECTED_CONTEXT" ]]; then
+    exit 0
+fi
+
+# Output valid JSON
+jq -n --arg context "$COLLECTED_CONTEXT" '{
+    hookSpecificOutput: {
+        hookEventName: "UserPromptSubmit",
+        additionalContext: $context
+    }
+}' 2>/dev/null || {
+    log_hook_error "Failed to produce JSON output"
+    exit 0
+}
+
+exit 0


### PR DESCRIPTION
## Summary

Adds a `UserPromptSubmit` hook (`methodology-inject.sh`) that injects project-specific domain context into agent sessions from `.loom/context/` files.

- **Opt-in**: Hook is always registered in `settings.json` but silently exits if `.loom/context/` directory doesn't exist
- **Three context layers**: `universal.md` (always), `roles/<role>.md` (by LOOM_ROLE or slash command), `topics/<name>.md` (by prompt keyword match with optional sidecar `.pattern` regex)
- **Configurable**: `config.json` controls max chars (default 8000), enable/disable per layer
- **Safe**: Follows existing hook error-handling patterns (never exits non-zero, logs to hook-errors.log)
- **Documented**: New section in `defaults/CLAUDE.md` with quick start, structure reference, and configuration
- **Example files**: `defaults/hooks/example-context/` provides templates users can copy

Closes #3187