### PR TITLE
fix: replace bash 4+ syntax with bash 3.2-compatible alternatives

### DIFF
--- a/defaults/scripts/cli/loom-scale.sh
+++ b/defaults/scripts/cli/loom-scale.sh
@@ -169,23 +169,20 @@ show_status() {
         return 0
     fi
 
-    # Count by role pattern
-    declare -A role_counts
+    # Count by role pattern (bash 3.2-compatible: no associative arrays)
+    # Extract role names, sort and count with uniq -c, then display
+    local role_summary
+    role_summary=$(echo "$sessions" \
+        | sed 's/^loom-//' \
+        | sed 's/-[0-9]*$//' \
+        | sort \
+        | uniq -c)
 
-    while read -r session; do
-        if [[ -n "$session" ]]; then
-            # Extract role name (e.g., loom-shepherd-1 -> shepherd)
-            local role
-            role=$(echo "$session" | sed 's/^loom-//' | sed 's/-[0-9]*$//')
-            role_counts["$role"]=$((${role_counts["$role"]:-0} + 1))
+    while read -r count role; do
+        if [[ -n "$role" ]]; then
+            echo -e "  ${CYAN}$role:${NC} $count"
         fi
-    done <<< "$sessions"
-
-    # Display counts
-    for role in "${!role_counts[@]}"; do
-        local count="${role_counts[$role]}"
-        echo -e "  ${CYAN}$role:${NC} $count"
-    done
+    done <<< "$role_summary"
 
     echo ""
     echo -e "${GRAY}Total: $(echo "$sessions" | wc -l | tr -d ' ') session(s)${NC}"

--- a/scripts/install/validate-target.sh
+++ b/scripts/install/validate-target.sh
@@ -95,7 +95,8 @@ elif [[ "$FORGE_TYPE" == "gitea" ]]; then
   success "Gitea API access verified"
 fi
 
-success "${FORGE_TYPE^} repository: $REPO_NAME"
+FORGE_TYPE_DISPLAY=$(printf '%s' "$FORGE_TYPE" | awk '{print toupper(substr($0,1,1)) tolower(substr($0,2))}')
+success "$FORGE_TYPE_DISPLAY repository: $REPO_NAME"
 
 # Check git status - warn if dirty
 if [[ -n "$(git status --porcelain)" ]]; then


### PR DESCRIPTION
## Summary

Fixes two bash 4+ syntax issues that cause failures on macOS (bash 3.2):

- **`scripts/install/validate-target.sh` line 98**: Replace `${FORGE_TYPE^}` (bash 4+ case modification) with a POSIX-compatible `printf | awk` approach that capitalizes the first letter and lowercases the rest. This was breaking the installer on macOS.

- **`defaults/scripts/cli/loom-scale.sh` line 173**: Replace `declare -A role_counts` (bash 4+ associative arrays) with a `sort | uniq -c` pipeline. The `loom scale --status` command was failing on macOS with the default bash.

## Changes

Both files now use only bash 3.2-compatible syntax:
- Case modification: `awk '{print toupper(substr($0,1,1)) tolower(substr($0,2))}'`
- Role counting: `sort | uniq -c` pipeline with `while read -r count role` parsing

## Test Plan

- [ ] Run `./scripts/install-loom.sh /tmp/test-repo` on macOS with `/bin/bash --version` showing 3.x — should display "Github repository: ..." without error
- [ ] Run `loom scale --status` on macOS — should display role counts without error
- [ ] Verify both fixes work with `bash --version` ≥ 4 as well (forward compatibility)

Closes #3190

🤖 Generated with [Claude Code](https://claude.com/claude-code)