### PR TITLE
fix: scope install metadata find to Loom-owned dirs only

### DIFF
--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -729,14 +729,16 @@ while IFS= read -r -d '' file; do
     INSTALLED_FILES_JSON="${INSTALLED_FILES_JSON},"
   fi
   INSTALLED_FILES_JSON="${INSTALLED_FILES_JSON}\"${rel_path}\""
-done < <(find . -type f \
-  -not -path './.git/*' \
+done < <(find \
+  .loom .claude .codex .github .githooks CLAUDE.md .gitignore \
+  -maxdepth 20 -type f \
   -not -path './.loom/worktrees/*' \
   -not -path './.loom/progress/*' \
   -not -path './.loom/logs/*' \
   -not -name '*.log' \
   -not -name '*.sock' \
   -not -name '.DS_Store' \
+  2>/dev/null \
   -print0 | sort -z)
 INSTALLED_FILES_JSON="${INSTALLED_FILES_JSON}]"
 

--- a/scripts/test-installer.sh
+++ b/scripts/test-installer.sh
@@ -165,12 +165,15 @@ GITIGNORE_EOF
       installed_files_json="${installed_files_json},"
     fi
     installed_files_json="${installed_files_json}\"${rel_path}\""
-  done < <(find "$target" -type f \
-    -not -path "$target/.git/*" \
+  done < <(find \
+    "$target/.loom" "$target/.claude" "$target/.codex" "$target/.github" \
+    "$target/.githooks" "$target/CLAUDE.md" "$target/.gitignore" \
+    -maxdepth 20 -type f \
     -not -path "$target/.loom/worktrees/*" \
     -not -name '.DS_Store' \
     -not -name '*.log' \
     -not -name '*.sock' \
+    2>/dev/null \
     -print0 | sort -z)
   installed_files_json="${installed_files_json}]"
 


### PR DESCRIPTION
## Summary

Fixes `install-loom.sh` hanging on large repos during metadata recording by scoping the `find` command to only Loom-owned directories instead of scanning the entire repository tree.

## Changes

- **`scripts/install-loom.sh`** (lines 732-742): Replaced `find . -type f` with targeted `find .loom .claude .codex .github .githooks CLAUDE.md .gitignore` — limits scanning to Loom-owned paths, typically a few hundred files instead of tens of thousands.
- **`scripts/test-installer.sh`** (lines 168-177): Applied the matching fix using `$target`-prefixed paths for the test harness.

Both now use `2>/dev/null` to silently skip optional paths (e.g., `.codex`, `.githooks`) that may not exist in every repo.

## Test Results

All 48 tests pass in `scripts/test-installer.sh`.

Closes #3189