### PR TITLE
fix: use versioned branch names for installer to avoid version-upgrade collisions

### DIFF
--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -37,7 +37,7 @@ This guide helps you diagnose and fix common issues in Loom.
    cd /path/to/target-repo
    git worktree list  # Find orphaned worktrees
    git worktree remove .loom/worktrees/issue-XXX --force
-   git branch -D feature/loom-installation-X
+   git branch -D feature/loom-install-vX.Y.Z
    gh issue close XXX --comment "Retrying installation"
 
    # Retry installation

--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -13,7 +13,7 @@
 #
 #   What this script does:
 #     1. Validates target repository (must be a Git repo)
-#     2. Creates installation worktree (.loom/worktrees/loom-installation)
+#     2. Creates installation worktree (.loom/worktrees/loom-install-vX.Y.Z)
 #     3. Initializes Loom configuration (copies defaults to .loom/)
 #     4. Syncs workflow labels (GitHub or Gitea)
 #     5. Configures branch rulesets (interactive mode only)
@@ -530,7 +530,7 @@ if [[ "$FORCE_OVERWRITE" != "true" ]] && [[ "$CLEAN_FIRST" != "true" ]]; then
   REPO_NWOPATH=$(echo "$_ORIGIN_URL" | sed -E 's/\.git$//; s#^.*[:/]([^/]+/[^/]+)$#\1#' || true)
   if [[ -n "$REPO_NWOPATH" ]] && [[ "$REPO_NWOPATH" =~ ^[^/]+/[^/]+$ ]]; then
     EXISTING_INSTALL_PR=$(gh pr list -R "$REPO_NWOPATH" --state open --search "Install Loom" --json url,headRefName --jq '
-      [.[] | select(.headRefName | startswith("feature/loom-installation"))][0].url' 2>/dev/null || true)
+      [.[] | select(.headRefName | startswith("feature/loom-install-"))][0].url' 2>/dev/null || true)
 
     if [[ -n "$EXISTING_INSTALL_PR" ]]; then
       warning "An open Loom installation PR already exists:"

--- a/scripts/install/create-worktree.sh
+++ b/scripts/install/create-worktree.sh
@@ -29,8 +29,8 @@ cd "$TARGET_PATH"
 # Ensure .loom/worktrees directory exists
 mkdir -p .loom/worktrees
 
-WORKTREE_PATH=".loom/worktrees/loom-installation"
-BASE_BRANCH_NAME="feature/loom-installation"
+WORKTREE_PATH=".loom/worktrees/loom-install-v${LOOM_VERSION}"
+BASE_BRANCH_NAME="feature/loom-install-v${LOOM_VERSION}"
 
 info "Creating worktree for Loom installation..."
 


### PR DESCRIPTION
## Summary

Fixes the branch name collision problem when upgrading Loom across versions. The installer previously always used `feature/loom-installation` as the branch name, causing issues when a second install of a newer version reused the same branch after the first PR was squash-merged.

## Changes

- **`scripts/install/create-worktree.sh`**: Changed `WORKTREE_PATH` and `BASE_BRANCH_NAME` to include `$LOOM_VERSION` (e.g., `feature/loom-install-v0.6.1`)
- **`scripts/install-loom.sh`**: Updated idempotency PR search prefix from `feature/loom-installation` to `feature/loom-install-` to match all versioned branches; updated comment to reflect new worktree path pattern
- **`docs/guides/troubleshooting.md`**: Updated example cleanup branch name to match new naming scheme

## Acceptance Criteria

- [x] Branch name includes Loom version (e.g., `feature/loom-install-v0.6.1`)
- [x] Consecutive upgrades create distinct branches and PRs
- [x] Old stale branches from previous installs don't interfere
- [x] Idempotency check still detects open installation PRs with new naming scheme (prefix match `feature/loom-install-`)
- [x] Suffix-fallback loop still works if same-version branch exists from a failed install

Closes #3196