### PR TITLE
fix: harden hermit stateless ceremony heuristic against dispatch-table false positives

### DIFF
--- a/defaults/.claude/commands/loom/hermit-patterns.md
+++ b/defaults/.claude/commands/loom/hermit-patterns.md
@@ -449,22 +449,40 @@ for root, dirs, files in os.walk('.'):
                 for n in ast.walk(node)
             )
             if has_self_assign:
-                continue
-            # Skip dispatch-table classes: no self.x= but uses self.method() calls
+                continue  # Has instance state -- not a stateless ceremony
+            # Exclusion 1: Internal method dispatch (self.method() calls)
             has_self_method_call = any(
                 isinstance(n, ast.Call) and
-                isinstance(n.func, ast.Attribute) and
-                isinstance(n.func.value, ast.Name) and n.func.value.id == 'self'
+                isinstance(getattr(n, 'func', None), ast.Attribute) and
+                isinstance(getattr(n.func, 'value', None), ast.Name) and
+                n.func.value.id == 'self'
                 for n in ast.walk(node)
             )
             if has_self_method_call:
-                continue
-            # Large classes (10+ methods) may use class as namespace intentionally
-            method_count = sum(1 for n in node.body if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)))
+                continue  # Uses internal dispatch -- likely a namespace
+            # Exclusion 2: Method count threshold (10+ methods = namespace)
+            method_count = sum(
+                1 for n in ast.walk(node)
+                if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+            )
             if method_count >= 10:
-                print(f'{path}:{node.lineno}: {node.name} (no instance state, {method_count} methods — large class, verify namespace use before converting)')
-            else:
-                print(f'{path}:{node.lineno}: {node.name} (no instance state)')
+                continue  # Too many methods to practically convert
+            # Exclusion 3: Dispatch-table pattern (self.method refs inside dict/list/set)
+            has_dispatch_table = False
+            for n in ast.walk(node):
+                if not isinstance(n, (ast.Dict, ast.List, ast.Set)):
+                    continue
+                for val in ast.walk(n):
+                    if (isinstance(val, ast.Attribute) and
+                        isinstance(getattr(val, 'value', None), ast.Name) and
+                        val.value.id == 'self'):
+                        has_dispatch_table = True
+                        break
+                if has_dispatch_table:
+                    break
+            if has_dispatch_table:
+                continue  # Builds dispatch table from self.method references
+            print(f'{path}:{node.lineno}: {node.name} (no instance state)')
 "
 
 # TypeScript: classes with no 'this.' property assignments

--- a/defaults/.claude/commands/loom/hermit.md
+++ b/defaults/.claude/commands/loom/hermit.md
@@ -145,6 +145,11 @@ Classes where `__init__` is `pass`/empty/missing AND no methods assign to `self.
 
 Current hermit flags "one-method classes" but not "zero-state classes." A class with multiple methods passes the one-method heuristic even when it has no instance state.
 
+**Exclusion criteria** -- the following patterns are NOT stateless ceremony and must be skipped:
+- **Internal method dispatch**: Classes where methods call `self.other_method()` are using the class for method organization/dispatch, not state. These are intentional namespace designs.
+- **Large method count (10+)**: Classes with 10 or more methods are using the class as a namespace. Suggesting conversion to 10+ module-level functions is impractical and noisy.
+- **Dispatch-table pattern**: Classes that build dicts/lists of `self.method` references (e.g., `{"key": self.handle_create, ...}`) are intentional dispatch tables.
+
 ```bash
 # Find Python classes with no instance state (excludes dispatch-table classes)
 python3 -c "
@@ -167,22 +172,40 @@ for root, dirs, files in os.walk('.'):
                 for n in ast.walk(node)
             )
             if has_self_assign:
-                continue
-            # Skip dispatch-table classes: no self.x= but uses self.method() calls
+                continue  # Has instance state -- not a stateless ceremony
+            # Exclusion 1: Internal method dispatch (self.method() calls)
             has_self_method_call = any(
                 isinstance(n, ast.Call) and
-                isinstance(n.func, ast.Attribute) and
-                isinstance(n.func.value, ast.Name) and n.func.value.id == 'self'
+                isinstance(getattr(n, 'func', None), ast.Attribute) and
+                isinstance(getattr(n.func, 'value', None), ast.Name) and
+                n.func.value.id == 'self'
                 for n in ast.walk(node)
             )
             if has_self_method_call:
-                continue
-            # Large classes (10+ methods) may use class as namespace intentionally
-            method_count = sum(1 for n in node.body if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)))
+                continue  # Uses internal dispatch -- likely a namespace
+            # Exclusion 2: Method count threshold (10+ methods = namespace)
+            method_count = sum(
+                1 for n in ast.walk(node)
+                if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+            )
             if method_count >= 10:
-                print(f'{path}:{node.lineno}: {node.name} (no instance state, {method_count} methods — large class, verify namespace use before converting)')
-            else:
-                print(f'{path}:{node.lineno}: {node.name} (no instance state)')
+                continue  # Too many methods to practically convert
+            # Exclusion 3: Dispatch-table pattern (self.method refs inside dict/list/set)
+            has_dispatch_table = False
+            for n in ast.walk(node):
+                if not isinstance(n, (ast.Dict, ast.List, ast.Set)):
+                    continue
+                for val in ast.walk(n):
+                    if (isinstance(val, ast.Attribute) and
+                        isinstance(getattr(val, 'value', None), ast.Name) and
+                        val.value.id == 'self'):
+                        has_dispatch_table = True
+                        break
+                if has_dispatch_table:
+                    break
+            if has_dispatch_table:
+                continue  # Builds dispatch table from self.method references
+            print(f'{path}:{node.lineno}: {node.name} (no instance state)')
 "
 
 # TypeScript: classes with no property assignments

--- a/tests/hermit/fixtures/dispatch_dict_pattern.py
+++ b/tests/hermit/fixtures/dispatch_dict_pattern.py
@@ -1,0 +1,18 @@
+# Fixture: Class using dict of self._method references -- should NOT be flagged
+# This is a dispatch-table pattern detected by exclusion 3
+class EventProcessor:
+    def get_handlers(self):
+        return {
+            "click": self._handle_click,
+            "hover": self._handle_hover,
+            "scroll": self._handle_scroll,
+        }
+
+    def _handle_click(self, event):
+        return "clicked"
+
+    def _handle_hover(self, event):
+        return "hovered"
+
+    def _handle_scroll(self, event):
+        return "scrolled"

--- a/tests/hermit/fixtures/dispatch_table.py
+++ b/tests/hermit/fixtures/dispatch_table.py
@@ -1,0 +1,27 @@
+# Fixture: Dispatch-table class -- should NOT be flagged as stateless ceremony
+# This class uses self.method() calls for internal dispatch and has no state.
+class CommandRouter:
+    """Routes commands to handler methods."""
+
+    def route(self, command, args):
+        handler = {
+            "create": self.handle_create,
+            "update": self.handle_update,
+            "delete": self.handle_delete,
+            "list": self.handle_list,
+        }.get(command)
+        if not handler:
+            raise ValueError(f"Unknown command: {command}")
+        return handler(args)
+
+    def handle_create(self, args):
+        return {"action": "create", "args": args}
+
+    def handle_update(self, args):
+        return {"action": "update", "args": args}
+
+    def handle_delete(self, args):
+        return {"action": "delete", "args": args}
+
+    def handle_list(self, args):
+        return {"action": "list", "args": args}

--- a/tests/hermit/fixtures/genuine_stateless.py
+++ b/tests/hermit/fixtures/genuine_stateless.py
@@ -1,0 +1,10 @@
+# Fixture: Genuinely stateless class -- SHOULD be flagged
+class PatternAdapter:
+    def __init__(self):
+        pass
+
+    def adapt(self, patterns):
+        return [p.upper() for p in patterns]
+
+    def validate(self, pattern):
+        return len(pattern) > 0

--- a/tests/hermit/fixtures/large_namespace.py
+++ b/tests/hermit/fixtures/large_namespace.py
@@ -1,0 +1,13 @@
+# Fixture: Large namespace class (10+ methods) -- should NOT be flagged
+class MathUtils:
+    def add(self, a, b): return a + b
+    def subtract(self, a, b): return a - b
+    def multiply(self, a, b): return a * b
+    def divide(self, a, b): return a / b
+    def modulo(self, a, b): return a % b
+    def power(self, a, b): return a ** b
+    def floor_div(self, a, b): return a // b
+    def negate(self, a): return -a
+    def absolute(self, a): return abs(a)
+    def maximum(self, a, b): return max(a, b)
+    def minimum(self, a, b): return min(a, b)

--- a/tests/hermit/fixtures/self_method_and_state.py
+++ b/tests/hermit/fixtures/self_method_and_state.py
@@ -1,0 +1,13 @@
+# Fixture: Class with both self.method() calls AND self.x = (has state)
+# Should NOT be flagged -- existing behavior, just verify no regression
+class Processor:
+    def __init__(self):
+        self.results = []
+
+    def process(self, data):
+        result = self.transform(data)
+        self.results.append(result)
+        return result
+
+    def transform(self, data):
+        return data.upper()

--- a/tests/hermit/fixtures/stateful_class.py
+++ b/tests/hermit/fixtures/stateful_class.py
@@ -1,0 +1,10 @@
+# Fixture: Class with state -- should NOT be flagged (existing behavior)
+class Counter:
+    def __init__(self):
+        self.count = 0
+
+    def increment(self):
+        self.count += 1
+
+    def get(self):
+        return self.count

--- a/tests/hermit/test-stateless-ceremony.sh
+++ b/tests/hermit/test-stateless-ceremony.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Test suite for the stateless ceremony heuristic in hermit.md / hermit-patterns.md
+#
+# Usage: ./tests/hermit/test-stateless-ceremony.sh
+#
+# Runs the AST-based detection script against fixture Python files and verifies
+# that dispatch-table classes, large-namespace classes, and other false-positive
+# patterns are correctly excluded while genuinely stateless classes are still flagged.
+#
+# Exit code 0 = all tests pass, 1 = failures detected.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FIXTURES="$SCRIPT_DIR/fixtures"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+# Colors (if terminal supports them)
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# Run the AST detection script against a single directory
+run_detector() {
+    local target_dir="$1"
+    python3 -c "
+import ast, sys, os
+for root, dirs, files in os.walk('${target_dir}'):
+    dirs[:] = [d for d in dirs if not d.startswith('.') and d != 'node_modules']
+    for f in files:
+        if not f.endswith('.py'): continue
+        path = os.path.join(root, f)
+        try:
+            tree = ast.parse(open(path).read())
+        except: continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef): continue
+            has_self_assign = any(
+                isinstance(n, ast.Assign) and
+                any(isinstance(t, ast.Attribute) and
+                    isinstance(t.value, ast.Name) and t.value.id == 'self'
+                    for t in n.targets)
+                for n in ast.walk(node)
+            )
+            if has_self_assign:
+                continue
+            has_self_method_call = any(
+                isinstance(n, ast.Call) and
+                isinstance(getattr(n, 'func', None), ast.Attribute) and
+                isinstance(getattr(n.func, 'value', None), ast.Name) and
+                n.func.value.id == 'self'
+                for n in ast.walk(node)
+            )
+            if has_self_method_call:
+                continue
+            method_count = sum(
+                1 for n in ast.walk(node)
+                if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+            )
+            if method_count >= 10:
+                continue
+            has_dispatch_table = False
+            for n in ast.walk(node):
+                if not isinstance(n, (ast.Dict, ast.List, ast.Set)):
+                    continue
+                for val in ast.walk(n):
+                    if (isinstance(val, ast.Attribute) and
+                        isinstance(getattr(val, 'value', None), ast.Name) and
+                        val.value.id == 'self'):
+                        has_dispatch_table = True
+                        break
+                if has_dispatch_table:
+                    break
+            if has_dispatch_table:
+                continue
+            print(f'{path}:{node.lineno}: {node.name} (no instance state)')
+" 2>&1
+}
+
+# Assert that a class name appears in detector output (should be flagged)
+assert_flagged() {
+    local fixture="$1"
+    local class_name="$2"
+    local description="$3"
+    TOTAL=$((TOTAL + 1))
+
+    local output
+    output=$(run_detector "$FIXTURES")
+
+    if echo "$output" | grep -q "$class_name"; then
+        PASS=$((PASS + 1))
+        printf "${GREEN}PASS${NC}: %s\n" "$description"
+    else
+        FAIL=$((FAIL + 1))
+        printf "${RED}FAIL${NC}: %s\n" "$description"
+        printf "  Expected class '%s' to be flagged but it was not.\n" "$class_name"
+        printf "  Detector output:\n%s\n" "$output"
+    fi
+}
+
+# Assert that a class name does NOT appear in detector output (should be excluded)
+assert_not_flagged() {
+    local fixture="$1"
+    local class_name="$2"
+    local description="$3"
+    TOTAL=$((TOTAL + 1))
+
+    local output
+    output=$(run_detector "$FIXTURES")
+
+    if echo "$output" | grep -q "$class_name"; then
+        FAIL=$((FAIL + 1))
+        printf "${RED}FAIL${NC}: %s\n" "$description"
+        printf "  Expected class '%s' to NOT be flagged but it was.\n" "$class_name"
+        printf "  Detector output:\n%s\n" "$output"
+    else
+        PASS=$((PASS + 1))
+        printf "${GREEN}PASS${NC}: %s\n" "$description"
+    fi
+}
+
+echo "=== Hermit Stateless Ceremony Heuristic Tests ==="
+echo ""
+
+# Test 1: Genuinely stateless class SHOULD be flagged
+assert_flagged "genuine_stateless.py" "PatternAdapter" \
+    "Genuinely stateless class (no self.x=, no self.method() calls, <10 methods) is flagged"
+
+# Test 2: Dispatch-table class with self.method() calls should NOT be flagged (Exclusion 1)
+assert_not_flagged "dispatch_table.py" "CommandRouter" \
+    "Dispatch-table class with self.method() calls is excluded (Exclusion 1: internal dispatch)"
+
+# Test 3: Large namespace class (10+ methods) should NOT be flagged (Exclusion 2)
+assert_not_flagged "large_namespace.py" "MathUtils" \
+    "Large namespace class with 11 methods is excluded (Exclusion 2: method count >= 10)"
+
+# Test 4: Dispatch-table pattern with dict of self._method refs should NOT be flagged (Exclusion 3)
+assert_not_flagged "dispatch_dict_pattern.py" "EventProcessor" \
+    "Class with dict of self._method references is excluded (Exclusion 3: dispatch-table pattern)"
+
+# Test 5: Stateful class should NOT be flagged (existing behavior, no regression)
+assert_not_flagged "stateful_class.py" "Counter" \
+    "Stateful class (self.count = 0) is not flagged (regression check)"
+
+# Test 6: Class with both state and self.method() calls should NOT be flagged (regression)
+assert_not_flagged "self_method_and_state.py" "Processor" \
+    "Class with state AND self.method() calls is not flagged (regression check)"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed, $TOTAL total ==="
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Adds three exclusion criteria to the hermit's stateless ceremony detection heuristic to prevent false positives on dispatch-table classes, large namespace classes, and classes that use self.method references in dicts/lists.

## Changes

- Added exclusion criteria documentation to hermit.md describing the three patterns that should be skipped
- Changed method count >= 10 from a soft warning to a hard skip (exclusion 2)
- Added exclusion 3: detects `self.method` references inside dict/list/set literals to identify intentional dispatch-table designs
- Used `getattr()` for safer attribute access in AST node checks (exclusion 1)
- Updated hermit-patterns.md detection script to match hermit.md
- Added test suite (`tests/hermit/test-stateless-ceremony.sh`) with 6 fixture-based test cases covering all exclusion criteria and regression checks

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Internal method dispatch exclusion | Pass | Test "Dispatch-table class with self.method() calls is excluded" passes |
| Method count threshold (10+) skips class | Pass | Test "Large namespace class with 11 methods is excluded" passes |
| Dispatch-table dict pattern exclusion | Pass | Test "Class with dict of self._method references is excluded" passes |
| Genuinely stateless class still flagged | Pass | Test "Genuinely stateless class is flagged" passes |
| No regression on stateful classes | Pass | Tests for Counter and Processor classes pass |

## Test Plan

```bash
./tests/hermit/test-stateless-ceremony.sh
# Result: 6 passed, 0 failed, 6 total
```

Closes #3198