### PR TITLE
fix: check-duplicate.sh falls back to gh when loom-forge is broken

### DIFF
--- a/defaults/scripts/check-duplicate.sh
+++ b/defaults/scripts/check-duplicate.sh
@@ -30,9 +30,14 @@
 set -euo pipefail
 
 # Use loom-forge for forge-agnostic issue/PR operations (supports GitHub + Gitea)
-if command -v loom-forge &>/dev/null; then
+# Validate loom-forge actually works (not just on PATH) — editable pip installs
+# can leave a broken binary after worktree cleanup (see issue #3205)
+if command -v loom-forge &>/dev/null && loom-forge --version &>/dev/null; then
     FORGE="loom-forge"
 else
+    if command -v loom-forge &>/dev/null; then
+        echo "WARNING: loom-forge is on PATH but non-functional, falling back to gh" >&2
+    fi
     FORGE="gh"
 fi
 


### PR DESCRIPTION
## Summary

- Makes `check-duplicate.sh` resilient when `loom-forge` is on PATH but non-functional (e.g., broken editable pip install pointing to a deleted worktree)
- Validates `loom-forge --version` before selecting it as the forge CLI; falls back to `gh` with a warning if validation fails
- No behavior change when `loom-forge` is working correctly or absent from PATH

Closes #3205

## Test plan

- [ ] Verify script works normally when `loom-forge` is not installed (falls back to `gh`)
- [ ] Verify script works normally when `loom-forge` is installed and functional
- [ ] Verify script falls back to `gh` with warning when `loom-forge` binary exists but crashes on import