### PR TITLE
docs: mandate merge-pr.sh for all PR merges

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,16 @@ gh pr create --label "loom:review-requested"
 - Never run `git worktree` directly (helper prevents nested worktrees)
 - Worktrees auto-removed when PRs merged
 
+### Merging PRs
+
+**Never use `gh pr merge`** -- always use `./.loom/scripts/merge-pr.sh <PR_NUMBER>` instead. The `gh pr merge` command attempts a local checkout which fails when the PR branch is linked to a worktree. The merge script merges via the forge API directly and handles worktree cleanup automatically.
+
+```bash
+./.loom/scripts/merge-pr.sh <PR_NUMBER>         # Standard merge with worktree cleanup
+./.loom/scripts/merge-pr.sh <PR_NUMBER> --auto   # Auto-confirm (for automation)
+./.loom/scripts/merge-pr.sh <PR_NUMBER> --dry-run # Preview without merging
+```
+
 ## Development Workflow
 
 ### Shepherd Lifecycle (MANDATORY)

--- a/defaults/.claude/commands/loom/builder.md
+++ b/defaults/.claude/commands/loom/builder.md
@@ -775,6 +775,7 @@ EOF
 **After creation:**
 - Never touch PR labels after creation
 - Use "Closes #N" syntax (not "Issue #N" or "Addresses #N") for auto-close
+- PRs are merged by Champion using `./.loom/scripts/merge-pr.sh` -- never use `gh pr merge`
 
 ## Working Style
 

--- a/defaults/.claude/commands/loom/champion.md
+++ b/defaults/.claude/commands/loom/champion.md
@@ -12,6 +12,8 @@ You are the human's avatar in the autonomous workflow - a trusted decision-maker
 
 **Key principle**: Conservative bias - when in doubt, do NOT act. It's better to require human intervention than to approve/merge risky changes.
 
+**Merging**: Always use `./.loom/scripts/merge-pr.sh <PR_NUMBER>` to merge PRs. Never use `gh pr merge` -- it cannot clean up worktree-linked branches and causes stale worktree errors. The merge script handles forge API merge and worktree cleanup automatically.
+
 ---
 
 ## Finding Work


### PR DESCRIPTION
## Summary
Update documentation and role definitions to mandate `.loom/scripts/merge-pr.sh` for merging PRs instead of `gh pr merge`, which fails when PR branches are linked to worktrees.

## Changes
- **CLAUDE.md**: Add "Merging PRs" section to Git Worktree Workflow with usage examples
- **champion.md**: Add merge-pr.sh mandate to role preamble
- **builder.md**: Add note in "After creation" section that PRs are merged via the script

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| CLAUDE.md has merge-pr.sh section | Done | Added under Git Worktree Workflow with command examples |
| Champion role references the script | Done | Added merge guidance after key principle |
| Builder role notes merges use the script | Done | Added to "After creation" bullet list |
| Other roles checked | Done | Doctor/shepherd don't call gh pr merge directly; they use merge-pr.sh via context files already |

## Test Plan
Documentation-only change. Verified no roles directly invoke `gh pr merge`.

Closes #3204