### PR TITLE
fix: prevent CLAUDECODE leaking through tmux server inheritance

### DIFF
--- a/defaults/scripts/claude-wrapper.sh
+++ b/defaults/scripts/claude-wrapper.sh
@@ -1549,6 +1549,12 @@ main() {
             break
         fi
     done
+    if [[ "${SKIP_PERMISSIONS_MODE}" == "true" ]]; then
+        log_info "Skip-permissions mode: ON (--dangerously-skip-permissions detected)"
+    fi
+    if [[ -n "${CLAUDECODE:-}" ]]; then
+        log_warn "CLAUDECODE is set (value='${CLAUDECODE}') — nested session guard may trigger"
+    fi
 
     # Run pre-flight checks
     if ! run_preflight_checks; then

--- a/defaults/scripts/spawn-shell-shepherd.sh
+++ b/defaults/scripts/spawn-shell-shepherd.sh
@@ -289,6 +289,11 @@ tmux -L "$TMUX_SOCKET" set-environment -t "$FULL_SESSION_NAME" LOOM_WORKSPACE "$
 tmux -L "$TMUX_SOCKET" set-environment -t "$FULL_SESSION_NAME" LOOM_ROLE "shepherd-sh"
 tmux -L "$TMUX_SOCKET" set-environment -t "$FULL_SESSION_NAME" LOOM_ISSUE "$ISSUE"
 tmux -L "$TMUX_SOCKET" set-environment -t "$FULL_SESSION_NAME" LOOM_ON_DEMAND "true"
+# Clear CLAUDECODE to prevent nested session guard from blocking worker
+# sessions.  If the tmux server was started from a Claude Code session,
+# CLAUDECODE would leak into the shepherd and its worker subprocesses,
+# potentially triggering the nested-session guard.  See issue #3208.
+tmux -L "$TMUX_SOCKET" set-environment -t "$FULL_SESSION_NAME" CLAUDECODE ""
 
 # Send the shepherd command to the session
 tmux -L "$TMUX_SOCKET" send-keys -t "$FULL_SESSION_NAME" "$SHEPHERD_CMD" C-m

--- a/loom-tools/src/loom_tools/agent_spawn.py
+++ b/loom-tools/src/loom_tools/agent_spawn.py
@@ -621,8 +621,13 @@ def spawn_agent(
     _tmux("set-environment", "-t", session_name, "LOOM_TERMINAL_ID", name)
     _tmux("set-environment", "-t", session_name, "LOOM_WORKSPACE", str(working_dir))
     _tmux("set-environment", "-t", session_name, "LOOM_ROLE", role)
-    # Unset CLAUDECODE to prevent nested session guard from blocking subprocess
-    _tmux("set-environment", "-t", session_name, "-u", "CLAUDECODE")
+    # Clear CLAUDECODE to prevent nested session guard from blocking subprocess.
+    # Use explicit empty set instead of -u (unset): tmux's -u removes the
+    # session-level override, causing the session to INHERIT the variable from
+    # the tmux server environment.  If the server was started from a Claude Code
+    # session (which sets CLAUDECODE), -u allows it to leak through.  Setting to
+    # empty string explicitly overrides the server-level value.  See issue #3208.
+    _tmux("set-environment", "-t", session_name, "CLAUDECODE", "")
 
     # Propagate shepherd task ID so claude-wrapper.sh can skip auth pre-flight
     # check for shepherd subprocess sessions (see issue #2524).

--- a/loom-tools/tests/test_agent_spawn.py
+++ b/loom-tools/tests/test_agent_spawn.py
@@ -410,13 +410,18 @@ class TestRunValidation:
 
 
 class TestClaudeCodeEnvUnset:
-    """Test that CLAUDECODE env var is unset in tmux sessions (issue #2240)."""
+    """Test that CLAUDECODE env var is cleared in tmux sessions (issue #2240, #3208)."""
 
     @patch("loom_tools.agent_spawn._tmux")
-    def test_spawn_agent_unsets_claudecode(
+    def test_spawn_agent_clears_claudecode(
         self, mock_tmux: MagicMock, mock_repo: pathlib.Path
     ) -> None:
-        """spawn_agent must call set-environment -u CLAUDECODE on the tmux session."""
+        """spawn_agent must set CLAUDECODE to empty string on the tmux session.
+
+        Using set-environment with an explicit empty value (not -u) prevents
+        the session from inheriting CLAUDECODE from the tmux server
+        environment.  See issue #3208.
+        """
         from loom_tools.agent_spawn import spawn_agent
 
         # Create required role file and wrapper script
@@ -437,19 +442,23 @@ class TestClaudeCodeEnvUnset:
             repo_root=mock_repo,
         )
 
-        # Find the set-environment -u CLAUDECODE call
+        # Find the set-environment CLAUDECODE "" call (explicit empty, not -u)
         tmux_calls = [c.args for c in mock_tmux.call_args_list]
-        unset_calls = [
+        clear_calls = [
             c
             for c in tmux_calls
             if len(c) >= 4
             and c[0] == "set-environment"
-            and "-u" in c
             and "CLAUDECODE" in c
+            and "-u" not in c
         ]
-        assert len(unset_calls) == 1, (
-            f"Expected exactly one 'set-environment -u CLAUDECODE' call, "
-            f"got {len(unset_calls)}. All tmux calls: {tmux_calls}"
+        assert len(clear_calls) == 1, (
+            f"Expected exactly one 'set-environment -t ... CLAUDECODE \"\"' call, "
+            f"got {len(clear_calls)}. All tmux calls: {tmux_calls}"
+        )
+        # Verify the value is empty string (not some other value)
+        assert clear_calls[0][-1] == "", (
+            f"CLAUDECODE should be set to empty string, got: {clear_calls[0][-1]}"
         )
 
 


### PR DESCRIPTION
## Summary

- Fix CLAUDECODE environment variable leaking into agent tmux sessions when the tmux server was started from a Claude Code session, causing thinking stalls (output produced but zero tool calls)
- The root cause: `tmux set-environment -u` removes the session-level override, causing inheritance from the server environment instead of truly clearing it
- Fix applied at three defensive layers: `agent_spawn.py`, `spawn-shell-shepherd.sh`, and diagnostic logging in `claude-wrapper.sh`

## Changes

- **`loom-tools/src/loom_tools/agent_spawn.py`**: Changed from `set-environment -u CLAUDECODE` to `set-environment -t <session> CLAUDECODE ""` (explicit empty override instead of unset)
- **`defaults/scripts/spawn-shell-shepherd.sh`**: Added `CLAUDECODE=""` to tmux session environment setup
- **`defaults/scripts/claude-wrapper.sh`**: Added diagnostic logging for skip-permissions mode and CLAUDECODE presence
- **`loom-tools/tests/test_agent_spawn.py`**: Updated test to verify empty string set instead of `-u` unset

## Test Plan

- [x] `TestClaudeCodeEnvUnset::test_spawn_agent_clears_claudecode` passes (verifies explicit empty string set, no `-u` flag)
- [x] All other agent_spawn tests pass (1 pre-existing failure on main unrelated to this change)
- [ ] Manual verification: spawn a shell shepherd from a Claude Code session and confirm no thinking stalls

Closes #3208