### PR TITLE
fix: add --version flag to loom-forge CLI

### DIFF
--- a/loom-tools/src/loom_tools/forge_cli.py
+++ b/loom-tools/src/loom_tools/forge_cli.py
@@ -399,6 +399,12 @@ def main(argv: list[str] | None = None) -> int:
     """Entry point for the ``loom-forge`` CLI."""
     args = list(argv if argv is not None else sys.argv[1:])
 
+    if args and args[0] == "--version":
+        from importlib.metadata import version
+
+        print(f"loom-forge {version('loom-tools')}")
+        return 0
+
     if not args or args[0] in ("-h", "--help"):
         _print_usage()
         return 0 if args and args[0] in ("-h", "--help") else 1

--- a/loom-tools/tests/test_forge_cli.py
+++ b/loom-tools/tests/test_forge_cli.py
@@ -438,6 +438,12 @@ class TestMainHelp:
         rc = main(["--help"])
         assert rc == 0
 
+    def test_version_flag(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = main(["--version"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert out.startswith("loom-forge ")
+
     def test_unknown_entity(self) -> None:
         rc = main(["unknown", "list"])
         assert rc == 1


### PR DESCRIPTION
## Summary
Add `--version` flag support to the `loom-forge` CLI so that health checks in shell scripts work correctly when loom-forge is installed and functional.

## Changes
- Add `--version` flag handling in `forge_cli.py:main()` before entity dispatch, using `importlib.metadata.version()` for dynamic version resolution
- Add test for `--version` flag in `test_forge_cli.py`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `loom-forge --version` prints version and exits 0 | ✅ | Outputs `loom-forge 0.1.0`, returns 0 |
| `check-duplicate.sh` health check passes | ✅ | The `loom-forge --version &>/dev/null` probe now succeeds |
| No spurious "non-functional" warning | ✅ | Warning only appeared because `--version` returned error |
| Existing commands work unchanged | ✅ | All 33 tests pass |

## Test Plan
- All 33 existing tests pass plus 1 new test for `--version`
- Manual verification: `loom-forge --version` → `loom-forge 0.1.0`

Closes #3210