### PR TITLE
fix(installer): snapshot pre-install state to avoid false dirty-tree alarms

### DIFF
--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -137,6 +137,17 @@ export NON_INTERACTIVE
 TARGET_PATH="$(cd "$TARGET_PATH" 2>/dev/null && pwd)" || \
   error "Target path does not exist: $TARGET_PATH"
 
+# Snapshot the pre-install working tree state. The post-install verification
+# (near the end of this script) compares against this snapshot so that the
+# user's pre-existing dirty state is not incorrectly flagged as "unstaged
+# changes after installation". Without this snapshot, the installer would
+# recommend destructive cleanup commands (git restore --staged . && git
+# checkout -- .) that destroy the user's uncommitted work.
+PRE_INSTALL_STATUS=""
+if git -C "$TARGET_PATH" rev-parse --git-dir >/dev/null 2>&1; then
+  PRE_INSTALL_STATUS=$(git -C "$TARGET_PATH" status --porcelain 2>/dev/null || true)
+fi
+
 # Check if target is a git repository - offer to initialize if not
 if ! git -C "$TARGET_PATH" rev-parse --git-dir >/dev/null 2>&1; then
   if [[ "$NON_INTERACTIVE" == "true" ]]; then
@@ -1015,38 +1026,51 @@ success "Pull request created"
 echo ""
 
 # ============================================================================
-# Post-Install Verification: Ensure main working tree is clean
+# Post-Install Verification: Detect changes introduced by the installer
 # ============================================================================
+# We compare the current `git status --porcelain` against the snapshot taken
+# at install start (PRE_INSTALL_STATUS). Only entries that did not exist in
+# the pre-install snapshot are reported as install residue. Pre-existing
+# dirty state in the user's working tree was already acknowledged earlier
+# (validate-target.sh); we must not flag it again here, and we must never
+# recommend destructive cleanup that would discard the user's work.
 CURRENT_STEP="Verify Working Tree"
 header "Verifying main working directory..."
 echo ""
 
 cd "$TARGET_PATH"
-VERIFY_CLEAN=true
 
-# Check for staged changes
-if ! git diff --staged --quiet 2>/dev/null; then
-  VERIFY_CLEAN=false
-  warning "Main working directory has staged changes after installation"
+POST_INSTALL_STATUS=$(git status --porcelain 2>/dev/null || true)
+
+# Compute install-introduced entries: lines present after install but not
+# before. We use line-level set difference via grep -F -v -x against the
+# pre-install snapshot. Empty snapshot is handled by treating all current
+# entries as new (which is correct).
+if [[ -z "$POST_INSTALL_STATUS" ]]; then
+  INSTALL_RESIDUE=""
+elif [[ -z "$PRE_INSTALL_STATUS" ]]; then
+  INSTALL_RESIDUE="$POST_INSTALL_STATUS"
+else
+  INSTALL_RESIDUE=$(printf '%s\n' "$POST_INSTALL_STATUS" \
+    | grep -F -x -v -f <(printf '%s\n' "$PRE_INSTALL_STATUS") \
+    || true)
 fi
 
-# Check for unstaged changes
-if ! git diff --quiet 2>/dev/null; then
-  VERIFY_CLEAN=false
-  warning "Main working directory has unstaged changes after installation"
-fi
-
-if [[ "$VERIFY_CLEAN" == "true" ]]; then
-  success "Main working directory is clean"
+if [[ -z "$INSTALL_RESIDUE" ]]; then
+  success "Main working directory is clean (relative to pre-install state)"
 else
   echo ""
-  warning "Unexpected changes detected in main working directory:"
-  git status --short 2>/dev/null || true
+  warning "Installer left changes in the main working directory:"
+  printf '%s\n' "$INSTALL_RESIDUE"
   echo ""
-  warning "To clean up manually:"
+  warning "These paths appear new since the installer started. Inspect them"
+  warning "before cleaning up — do not blindly discard, as some may overlap"
+  warning "with your own in-progress work."
+  echo ""
+  warning "To inspect:"
   warning "  cd $TARGET_PATH"
-  warning "  git restore --staged ."
-  warning "  git checkout -- ."
+  warning "  git status"
+  warning "  git diff <path>"
 fi
 
 echo ""

--- a/scripts/test-installer.sh
+++ b/scripts/test-installer.sh
@@ -799,6 +799,85 @@ echo ""
 
 
 # ==========================================================================
+# Section 35-38: Post-install verification snapshot diff (issue #3219)
+# ==========================================================================
+# These tests exercise the snapshot-comparison math used by install-loom.sh
+# to distinguish installer-introduced residue from the user's pre-existing
+# dirty working tree. The math is short enough to mirror inline; if it
+# drifts from install-loom.sh, both must be updated.
+
+# Helper: replicate the symmetric-difference logic from install-loom.sh
+diff_snapshot() {
+  local pre="$1"
+  local post="$2"
+  if [[ -z "$post" ]]; then
+    return 0
+  fi
+  if [[ -z "$pre" ]]; then
+    printf '%s' "$post"
+    return 0
+  fi
+  printf '%s\n' "$post" | grep -F -x -v -f <(printf '%s\n' "$pre") || true
+}
+
+echo "--- Section: Post-install verification snapshot diff (#3219) ---"
+echo ""
+
+# Test 35: empty pre, empty post -> empty diff (clean repo, clean after)
+echo "Test 35: Empty snapshot, empty post-state yields empty diff"
+RESULT=$(diff_snapshot "" "")
+if [[ -z "$RESULT" ]]; then
+  pass "Clean -> clean produces no residue"
+else
+  fail "Clean -> clean unexpectedly produced: $RESULT"
+fi
+echo ""
+
+# Test 36: pre-existing dirty state with no install changes -> empty diff
+echo "Test 36: Pre-existing dirty entries are filtered out of residue"
+PRE=' M README.md
+?? local-notes.txt'
+POST=' M README.md
+?? local-notes.txt'
+RESULT=$(diff_snapshot "$PRE" "$POST")
+if [[ -z "$RESULT" ]]; then
+  pass "User's pre-existing dirty state does not register as residue"
+else
+  fail "Pre-existing entries leaked into residue: $RESULT"
+fi
+echo ""
+
+# Test 37: genuine new install residue is detected
+echo "Test 37: New install-introduced entries surface in residue"
+PRE=' M README.md'
+POST=' M README.md
+ M .loom/config.json
+?? .loom/loom-source-path'
+RESULT=$(diff_snapshot "$PRE" "$POST")
+EXPECTED=' M .loom/config.json
+?? .loom/loom-source-path'
+if [[ "$RESULT" == "$EXPECTED" ]]; then
+  pass "Install-introduced entries appear in residue"
+else
+  fail "Residue mismatch. Got: [$RESULT] Expected: [$EXPECTED]"
+fi
+echo ""
+
+# Test 38: empty pre with non-empty post returns full post (initial-clean repo
+# that is dirty after install)
+echo "Test 38: Empty pre-snapshot returns full post-state as residue"
+POST=' M .loom/config.json
+?? .loom/loom-source-path'
+RESULT=$(diff_snapshot "" "$POST")
+if [[ "$RESULT" == "$POST" ]]; then
+  pass "Empty snapshot treats all post-entries as new"
+else
+  fail "Empty snapshot mishandled. Got: [$RESULT]"
+fi
+echo ""
+
+
+# ==========================================================================
 # Summary
 # ==========================================================================
 echo "======================================"


### PR DESCRIPTION
Closes #3219

## Summary

The post-install verification block in `scripts/install-loom.sh` compared the
working tree against an absolute "clean" baseline. If the user already had
uncommitted modifications before running the installer, those changes were
incorrectly flagged as "unstaged changes after installation" and the user was
advised to run:

```
git restore --staged .
git checkout -- .
```

which would silently destroy their pre-existing uncommitted work.

## Fix

1. Snapshot `git status --porcelain` immediately after `TARGET_PATH` is
   resolved (mirrors the stash-based protection already in the `--clean`
   path at lines 293-377).
2. At install end, compute the symmetric difference between current status
   and the snapshot. Only entries that did NOT exist pre-install are
   reported as installer residue.
3. When the diff is empty, emit a positive success message instead of any
   warning.
4. When residue is found, the cleanup hint is softened: instead of blanket
   `git restore`/`git checkout`, tell the user to inspect with `git status`
   and `git diff` before deciding.

## Tests

Added 4 regression tests to `scripts/test-installer.sh` covering the
snapshot-diff math in isolation (no installer execution required):

- Clean -> clean: no residue.
- Pre-existing dirty entries filtered out.
- Genuine new install entries surface.
- Empty pre-snapshot returns full post-state.

All 52 tests pass.