### PR TITLE
fix: harden install verification to prevent lib/ regressions

### DIFF
--- a/loom-daemon/src/init/mod.rs
+++ b/loom-daemon/src/init/mod.rs
@@ -185,6 +185,12 @@ fn copy_single_file(
 }
 
 /// Sync a managed directory: clean stale files on reinstall, then copy fresh from defaults.
+///
+/// After copying, this function performs a fail-fast assertion that every file
+/// (including those in subdirectories) present in `defaults/<dir_name>/` exists
+/// in the destination. This guards against silent omissions like the regression
+/// reported in issue #3220, where `scripts/lib/forge-helpers.sh` was missing
+/// from installs even though `lib/loom-tools.sh` was verified by name.
 fn sync_managed_dir(
     defaults: &Path,
     loom_path: &Path,
@@ -202,8 +208,58 @@ fn sync_managed_dir(
         }
         copy_dir_with_report(&src, &dst, &report_prefix, report)
             .map_err(|e| format!("Failed to copy {dir_name} directory: {e}"))?;
+
+        // Fail-fast: ensure every source file (including subdirectories) reached
+        // the destination. This catches bugs in copy_dir_with_report and
+        // unexpected filesystem failures (permission denied on a subdir, etc.)
+        // before they propagate to a broken install.
+        let missing = find_missing_files(&src, &dst);
+        if !missing.is_empty() {
+            return Err(format!(
+                "Sync of {dir_name} directory completed but {} file(s) are missing from \
+                 destination (likely a copy bug or filesystem error): {}",
+                missing.len(),
+                missing.join(", ")
+            ));
+        }
     }
     Ok(())
+}
+
+/// Recursively find files present in `src` but missing from `dst`.
+///
+/// Returns relative paths (from `src`) for each missing file. Used as a
+/// post-copy assertion to detect partial copies. Subdirectories are walked
+/// recursively so that nested files (e.g., `scripts/lib/*.sh`) are checked.
+fn find_missing_files(src: &Path, dst: &Path) -> Vec<String> {
+    let mut missing = Vec::new();
+    collect_missing_files(src, dst, "", &mut missing);
+    missing
+}
+
+fn collect_missing_files(src: &Path, dst: &Path, prefix: &str, out: &mut Vec<String>) {
+    let Ok(entries) = std::fs::read_dir(src) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        let file_name = entry.file_name();
+        let file_name_str = file_name.to_string_lossy();
+        let rel_path = if prefix.is_empty() {
+            file_name_str.to_string()
+        } else {
+            format!("{prefix}/{file_name_str}")
+        };
+        let src_child = entry.path();
+        let dst_child = dst.join(&file_name);
+        if file_type.is_dir() {
+            collect_missing_files(&src_child, &dst_child, &rel_path, out);
+        } else if !dst_child.exists() {
+            out.push(rel_path);
+        }
+    }
 }
 
 /// Ensure all `.sh` files in a directory (and subdirectories) are executable.
@@ -884,5 +940,67 @@ mod tests {
             "lib/loom-tools.sh should be executable, mode: {:o}",
             perms.mode()
         );
+    }
+
+    #[test]
+    fn test_find_missing_files_empty_when_all_present() {
+        // Regression test for issue #3220: the post-copy assertion in
+        // sync_managed_dir uses find_missing_files to detect partial copies.
+        let temp_dir = TempDir::new().unwrap();
+        let src = temp_dir.path().join("src");
+        let dst = temp_dir.path().join("dst");
+
+        fs::create_dir_all(src.join("lib")).unwrap();
+        fs::create_dir_all(dst.join("lib")).unwrap();
+        fs::write(src.join("a.sh"), "a").unwrap();
+        fs::write(dst.join("a.sh"), "a").unwrap();
+        fs::write(src.join("lib").join("b.sh"), "b").unwrap();
+        fs::write(dst.join("lib").join("b.sh"), "b").unwrap();
+
+        let missing = find_missing_files(&src, &dst);
+        assert!(missing.is_empty(), "Expected no missing files, got: {missing:?}");
+    }
+
+    #[test]
+    fn test_find_missing_files_detects_missing_subdirectory_file() {
+        // Specifically verifies the issue #3220 scenario: a file in a
+        // subdirectory (e.g., scripts/lib/forge-helpers.sh) is missing
+        // from the destination.
+        let temp_dir = TempDir::new().unwrap();
+        let src = temp_dir.path().join("src");
+        let dst = temp_dir.path().join("dst");
+
+        fs::create_dir_all(src.join("lib")).unwrap();
+        fs::create_dir_all(dst.join("lib")).unwrap();
+        fs::write(src.join("a.sh"), "a").unwrap();
+        fs::write(dst.join("a.sh"), "a").unwrap();
+        fs::write(src.join("lib").join("loom-tools.sh"), "tools").unwrap();
+        fs::write(dst.join("lib").join("loom-tools.sh"), "tools").unwrap();
+        // Source has forge-helpers.sh but destination does NOT — this is
+        // the exact failure mode from issue #3220.
+        fs::write(src.join("lib").join("forge-helpers.sh"), "helpers").unwrap();
+
+        let missing = find_missing_files(&src, &dst);
+        assert_eq!(missing.len(), 1, "Expected 1 missing file, got: {missing:?}");
+        assert_eq!(missing[0], "lib/forge-helpers.sh");
+    }
+
+    #[test]
+    fn test_find_missing_files_detects_entire_missing_subdir() {
+        // If a whole subdirectory is missing, every file under it should be reported.
+        let temp_dir = TempDir::new().unwrap();
+        let src = temp_dir.path().join("src");
+        let dst = temp_dir.path().join("dst");
+
+        fs::create_dir_all(src.join("lib")).unwrap();
+        fs::create_dir_all(&dst).unwrap();
+        fs::write(src.join("lib").join("a.sh"), "a").unwrap();
+        fs::write(src.join("lib").join("b.sh"), "b").unwrap();
+
+        let missing = find_missing_files(&src, &dst);
+        assert_eq!(missing.len(), 2, "Expected 2 missing files, got: {missing:?}");
+        let mut sorted = missing;
+        sorted.sort();
+        assert_eq!(sorted, vec!["lib/a.sh".to_string(), "lib/b.sh".to_string()]);
     }
 }

--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -807,11 +807,17 @@ success "Installation metadata recorded ($(echo "$INSTALLED_FILES_JSON" | grep -
 echo ""
 
 # Verify expected files were created
+# NOTE: lib/ entries are listed explicitly as a defensive belt-and-suspenders check.
+# The recursive verification block below catches any other missing files under
+# defaults/scripts/, but listing lib/ here ensures these specific helpers
+# (sourced by ~17 other scripts) cannot regress silently. See issue #3220.
 EXPECTED_FILES=(
   ".loom/config.json"
   ".loom/roles"
   ".loom/scripts/worktree.sh"
   ".loom/scripts/lib/loom-tools.sh"
+  ".loom/scripts/lib/forge-helpers.sh"
+  ".loom/scripts/lib/pipe-pane-cmd.sh"
   ".loom/hooks/guard-destructive.sh"
   ".loom/hooks/skill-router.sh"
   "CLAUDE.md"
@@ -830,9 +836,15 @@ done
 success "All Loom files installed"
 echo ""
 
-# Verify installed scripts match source defaults
+# Verify installed scripts match source defaults (recursive walk).
+# Missing files are now a HARD ERROR — the previous warning-only behavior
+# allowed regressions like #3220 (lib/forge-helpers.sh missing) to slip through.
+# Content mismatches remain warnings since template substitution and platform
+# differences (line endings, etc.) can cause false positives.
 info "Verifying scripts match source..."
-VERIFY_FAILURES=0
+VERIFY_MISSING=0
+VERIFY_MISMATCHES=0
+MISSING_SCRIPTS=()
 if [[ -d "$LOOM_ROOT/defaults/scripts" ]] && [[ -d ".loom/scripts" ]]; then
   while IFS= read -r -d '' src_file; do
     rel_path="${src_file#$LOOM_ROOT/defaults/scripts/}"
@@ -840,16 +852,23 @@ if [[ -d "$LOOM_ROOT/defaults/scripts" ]] && [[ -d ".loom/scripts" ]]; then
     if [[ -f "$dst_file" ]]; then
       if ! cmp -s "$src_file" "$dst_file"; then
         warning "Script mismatch: .loom/scripts/$rel_path differs from source"
-        VERIFY_FAILURES=$((VERIFY_FAILURES + 1))
+        VERIFY_MISMATCHES=$((VERIFY_MISMATCHES + 1))
       fi
     else
-      warning "Script missing: .loom/scripts/$rel_path not installed"
-      VERIFY_FAILURES=$((VERIFY_FAILURES + 1))
+      MISSING_SCRIPTS+=(".loom/scripts/$rel_path")
+      VERIFY_MISSING=$((VERIFY_MISSING + 1))
     fi
   done < <(find "$LOOM_ROOT/defaults/scripts" -type f -print0)
 fi
-if [[ $VERIFY_FAILURES -gt 0 ]]; then
-  warning "$VERIFY_FAILURES script(s) failed verification — see above"
+if [[ $VERIFY_MISSING -gt 0 ]]; then
+  echo "" >&2
+  for missing in "${MISSING_SCRIPTS[@]}"; do
+    echo "  MISSING: $missing" >&2
+  done
+  error "$VERIFY_MISSING script(s) missing from installation — install incomplete (see #3220)"
+fi
+if [[ $VERIFY_MISMATCHES -gt 0 ]]; then
+  warning "$VERIFY_MISMATCHES script(s) had content mismatches — see above"
 else
   success "All scripts verified (match source defaults)"
 fi

--- a/scripts/test-installer.sh
+++ b/scripts/test-installer.sh
@@ -349,6 +349,49 @@ else
   fail ".loom/scripts has only $SCRIPT_COUNT scripts (expected >5)"
 fi
 
+# Test 15b: .loom/scripts/lib/ subdirectory and its helpers (regression test for #3220)
+# These files are sourced by ~17 other scripts (merge-pr.sh, agent-spawn.sh, etc.)
+# and must always be present after a successful install.
+echo "Test 15b: Install creates .loom/scripts/lib/ with all required helpers"
+LIB_DIR="$INSTALL_REPO/.loom/scripts/lib"
+LIB_MISSING=0
+if [[ ! -d "$LIB_DIR" ]]; then
+  fail ".loom/scripts/lib/ directory missing (regression of #3220)"
+  LIB_MISSING=1
+else
+  for lib_file in loom-tools.sh forge-helpers.sh pipe-pane-cmd.sh; do
+    if [[ ! -f "$LIB_DIR/$lib_file" ]]; then
+      fail ".loom/scripts/lib/$lib_file missing (regression of #3220)"
+      LIB_MISSING=1
+    fi
+  done
+  if [[ $LIB_MISSING -eq 0 ]]; then
+    pass ".loom/scripts/lib/ contains all required helpers (loom-tools.sh, forge-helpers.sh, pipe-pane-cmd.sh)"
+  fi
+fi
+
+# Test 15c: every file in defaults/scripts/ exists in installed .loom/scripts/
+# This is a structural check that catches future regressions like #3220 where
+# new files added to defaults/scripts/ might not reach the install target.
+echo "Test 15c: All files in defaults/scripts/ are installed under .loom/scripts/"
+SCRIPTS_MISSING_COUNT=0
+SCRIPTS_MISSING_LIST=""
+if [[ -d "$DEFAULTS_DIR/scripts" ]]; then
+  while IFS= read -r -d '' src_file; do
+    rel_path="${src_file#$DEFAULTS_DIR/scripts/}"
+    dst_file="$INSTALL_REPO/.loom/scripts/$rel_path"
+    if [[ ! -f "$dst_file" ]]; then
+      SCRIPTS_MISSING_COUNT=$((SCRIPTS_MISSING_COUNT + 1))
+      SCRIPTS_MISSING_LIST="${SCRIPTS_MISSING_LIST}\n  - $rel_path"
+    fi
+  done < <(find "$DEFAULTS_DIR/scripts" -type f -print0)
+fi
+if [[ $SCRIPTS_MISSING_COUNT -eq 0 ]]; then
+  pass "All defaults/scripts/ files installed (recursive parity check)"
+else
+  fail "$SCRIPTS_MISSING_COUNT script(s) from defaults/scripts/ missing in install:$(printf '%b' "$SCRIPTS_MISSING_LIST")"
+fi
+
 # Test 16: .loom/hooks/guard-destructive.sh
 echo "Test 16: Install creates .loom/hooks/guard-destructive.sh"
 if [[ -f "$INSTALL_REPO/.loom/hooks/guard-destructive.sh" ]]; then


### PR DESCRIPTION
Closes #3220

## Summary

Three layers of defense to prevent `.loom/scripts/lib/` from going missing during install (a regression of #2392/PR #2471 reintroduced when `forge-helpers.sh` was added in #3155 without updating verification).

## Changes

### `loom-daemon/src/init/mod.rs` — Fail-fast post-copy assertion
- `sync_managed_dir` now recursively walks the source and asserts every file is present in the destination after `copy_dir_with_report`. Returns `Err(...)` listing missing paths if the copy was partial — catches bugs in the copy routine and unexpected filesystem errors before they propagate to a broken install.
- New helpers: `find_missing_files` / `collect_missing_files`.

### `scripts/install-loom.sh` — Belt-and-suspenders verify
- Added `lib/forge-helpers.sh` and `lib/pipe-pane-cmd.sh` to `EXPECTED_FILES` so a missing helper triggers an immediate hard error.
- Promoted the recursive `defaults/scripts/` parity check (lines 781-803) from a warning to a hard error when files are missing. Content mismatches remain warnings to avoid false positives from template substitution / line endings.
- Improved error output to list every missing script for easier debugging.

### `scripts/test-installer.sh` — End-to-end coverage
- Test 15b: explicit checks for all three required lib helpers (`loom-tools.sh`, `forge-helpers.sh`, `pipe-pane-cmd.sh`).
- Test 15c: structural recursive parity check that every file in `defaults/scripts/` reaches `.loom/scripts/`. Catches future regressions where new defaults files are added but not copied through.

### Rust tests
Three new unit tests covering `find_missing_files`:
- Empty case (everything present)
- Specific subdir-file regression matching the #3220 scenario
- Full-subdir missing

## Test plan

- [x] `cargo test --lib init::` — all 51 tests pass (3 new)
- [x] `bash scripts/test-installer.sh` — all 50 tests pass (3 new)
- [x] `bash -n scripts/install-loom.sh` — syntax valid
- [x] `cargo build --release` — builds clean
- [x] No new clippy warnings introduced