### PR TITLE
feat: add loom-tokens bootstrap for multi-account OAuth pool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,19 @@ WORKSPACE_PATH=/Users/yourname/projects/loom
 # Generate at: https://github.com/settings/tokens
 # Scopes needed: repo, read:org
 GITHUB_TOKEN=ghp_...
+
+# Optional: Multi-account OAuth token pool for Claude Code rotation
+#
+# Each account is defined as a numbered triple:
+#   ACCOUNT_EMAIL_N        - Account email (used in the token pool manifest).
+#   ACCOUNT_KEY_N          - The OAuth token (e.g. sk-ant-oat01-...).
+#   ACCOUNT_TOKEN_FILE_N   - Filename to write under .loom/tokens/ (must end in .token).
+#
+# Numbering does not need to be contiguous (gaps are allowed). Run
+# `loom-tokens bootstrap` to materialize these into .loom/tokens/<file>.token
+# (mode 0600) plus an index.json manifest. Re-run is idempotent; pass --force
+# to overwrite drifted on-disk tokens.
+#
+# ACCOUNT_EMAIL_1=user1@example.com
+# ACCOUNT_KEY_1=sk-ant-oat01-...
+# ACCOUNT_TOKEN_FILE_1=user1.token

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ Thumbs.db
 .loom/metrics/
 .loom/usage-cache.json
 .loom/claude-config/
+.loom/tokens/
 
 # Loom workspace config (DO commit for team sharing)
 # - config.json: Persistent terminal configurations (roles, themes, intervals)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -562,7 +562,27 @@ Configure merge settings during installation or manually:
 
 Settings applied: squash merge only (no merge commits/rebase), delete branches on merge, auto-merge enabled.
 
-## Troubleshooting
+### Multi-Account Token Pool
+
+For environments that rotate among multiple Claude OAuth accounts, Loom can bootstrap a per-account token pool at `.loom/tokens/` from numbered triples in `.env`:
+
+```env
+ACCOUNT_EMAIL_1=user1@example.com
+ACCOUNT_KEY_1=sk-ant-oat01-...
+ACCOUNT_TOKEN_FILE_1=user1.token
+```
+
+Run `loom-tokens bootstrap` to materialize the pool:
+
+```bash
+loom-tokens bootstrap            # Idempotent — only writes new/missing tokens.
+loom-tokens bootstrap --dry-run  # Preview without writing.
+loom-tokens bootstrap --force    # Overwrite on-disk tokens that have drifted from .env.
+```
+
+Each account becomes `.loom/tokens/<file>.token` (mode `0600`). An `index.json` manifest is written alongside with sha256 fingerprints (8 chars) for drift detection — **no secret material is stored in the manifest**. Numbering gaps are allowed; partial triples are skipped with a warning.
+
+`.loom/tokens/` is gitignored. The pool is consumed by external rotation logic (e.g. a `claude-wrapper.sh` that picks the least-used token); only the bootstrap step is provided here.
 
 See `.loom/docs/troubleshooting.md` for detailed troubleshooting including:
 - Cleaning up stale worktrees and branches

--- a/loom-tools/pyproject.toml
+++ b/loom-tools/pyproject.toml
@@ -44,6 +44,7 @@ loom-usage = "loom_tools.common.usage:main"
 loom-backlog = "loom_tools.backlog:main"
 loom-forge = "loom_tools.forge_cli:cli_main"
 loom-auto-merge = "loom_tools.auto_merge:main"
+loom-tokens = "loom_tools.tokens.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/loom-tools/src/loom_tools/tokens/__init__.py
+++ b/loom-tools/src/loom_tools/tokens/__init__.py
@@ -1,0 +1,17 @@
+"""Multi-account OAuth token pool management for Claude Code rotation.
+
+This subpackage handles bootstrapping the on-disk token pool at
+``.loom/tokens/`` from numbered ``ACCOUNT_*_N`` triples in ``.env``.
+
+The token pool is consumed by external rotation logic (see
+``scripts/agents/claude-wrapper.sh`` in the lean-genius reference). This
+module's sole responsibility is the bootstrap step: turn ``.env`` entries
+into per-account ``.token`` files (mode ``0600``) plus an ``index.json``
+manifest with sha256 fingerprints (no secret material).
+"""
+
+from __future__ import annotations
+
+from loom_tools.tokens.bootstrap import bootstrap_tokens
+
+__all__ = ["bootstrap_tokens"]

--- a/loom-tools/src/loom_tools/tokens/bootstrap.py
+++ b/loom-tools/src/loom_tools/tokens/bootstrap.py
@@ -1,0 +1,360 @@
+"""Bootstrap the multi-account OAuth token pool from ``.env``.
+
+Reads numbered ``ACCOUNT_EMAIL_N`` / ``ACCOUNT_KEY_N`` / ``ACCOUNT_TOKEN_FILE_N``
+triples and materializes them as per-account ``.token`` files inside
+``.loom/tokens/``. Writes an ``index.json`` manifest with sha256
+fingerprints (truncated to 8 chars) so drift between ``.env`` and on-disk
+state can be detected without storing secret material.
+
+Lean-genius reference: ``scripts/agents/claude-wrapper.sh:46-66``. The
+bootstrap behaviour mirrors that shell snippet (strip surrounding quotes
+and embedded newlines, mode ``0600`` per file) but uses
+``ACCOUNT_TOKEN_FILE_N`` for filenames instead of ``agent-N.token`` for
+readability.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+from loom_tools.common.logging import (
+    log_error,
+    log_info,
+    log_success,
+    log_warning,
+)
+from loom_tools.common.paths import LoomPaths
+
+# ``ACCOUNT_<FIELD>_<N>=<value>`` — N is 1+ digits, FIELD is one of the
+# triple keys we recognize. Anchored to start of line.
+_ENV_LINE_RE = re.compile(
+    r"^ACCOUNT_(EMAIL|KEY|TOKEN_FILE)_(\d+)\s*=\s*(.*)$"
+)
+
+# Filename safety: lowercase letters, digits, dot, dash, underscore. Must
+# end with .token (case-insensitive). Matches lean-genius conventions.
+_TOKEN_FILE_RE = re.compile(r"^[A-Za-z0-9._-]+\.token$")
+
+INDEX_VERSION = 1
+DIR_MODE = 0o700
+FILE_MODE = 0o600
+
+
+# ---------------------------------------------------------------------------
+# .env parsing
+# ---------------------------------------------------------------------------
+
+
+def _strip_value(raw: str) -> str:
+    """Strip surrounding quotes and embedded newlines from a value.
+
+    Mirrors the shell snippet ``printf '%s' "$val" | tr -d "'\"\n"`` from
+    lean-genius's ``claude-wrapper.sh:61``. Trailing comment after the
+    value (e.g. ``KEY=value # comment``) is *not* stripped: we treat the
+    whole RHS as opaque, only normalising whitespace and quotes.
+    """
+    s = raw.strip()
+    # Drop a single matching pair of surrounding quotes.
+    if len(s) >= 2 and s[0] == s[-1] and s[0] in ("'", '"'):
+        s = s[1:-1]
+    # Remove embedded newlines and stray quotes (matches `tr -d "'\"\n"`).
+    s = s.replace("\n", "").replace("\r", "")
+    s = s.replace("'", "").replace('"', "")
+    return s
+
+
+def parse_env_accounts(env_path: Path) -> dict[int, dict[str, str]]:
+    """Parse ``.env`` and return ``{N: {"email": ..., "key": ..., "file": ...}}``.
+
+    Lines that don't match the ``ACCOUNT_*_N=`` pattern are ignored
+    (this is not a general-purpose ``.env`` parser). Partial triples are
+    returned as-is so the caller can warn and skip them.
+
+    Args:
+        env_path: Path to the ``.env`` file (must exist).
+
+    Returns:
+        Mapping from account index ``N`` to a dict with keys ``email``,
+        ``key``, and ``file`` (any subset may be present).
+    """
+    accounts: dict[int, dict[str, str]] = {}
+    text = env_path.read_text(encoding="utf-8", errors="replace")
+    field_to_key = {"EMAIL": "email", "KEY": "key", "TOKEN_FILE": "file"}
+
+    for line in text.splitlines():
+        stripped = line.lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        m = _ENV_LINE_RE.match(stripped)
+        if not m:
+            continue
+        field, n_str, raw_value = m.group(1), m.group(2), m.group(3)
+        try:
+            n = int(n_str)
+        except ValueError:
+            continue
+        value = _strip_value(raw_value)
+        accounts.setdefault(n, {})[field_to_key[field]] = value
+
+    return accounts
+
+
+# ---------------------------------------------------------------------------
+# Fingerprinting + manifest
+# ---------------------------------------------------------------------------
+
+
+def fingerprint(secret: str) -> str:
+    """Return the first 8 hex chars of sha256(secret).
+
+    Used in ``index.json`` for drift detection. **Never** stores the
+    secret itself — only enough entropy to detect when ``.env`` and the
+    on-disk token diverge.
+    """
+    return hashlib.sha256(secret.encode("utf-8")).hexdigest()[:8]
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _name_from_file(filename: str) -> str:
+    """Strip the trailing ``.token`` suffix to derive a logical account name."""
+    if filename.lower().endswith(".token"):
+        return filename[: -len(".token")]
+    return filename
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+class BootstrapResult:
+    """Outcome of a single ``bootstrap_tokens()`` call."""
+
+    def __init__(self) -> None:
+        self.written: list[str] = []
+        self.unchanged: list[str] = []
+        self.drifted: list[str] = []
+        self.skipped: list[str] = []
+        self.dry_run: bool = False
+        self.tokens_dir: Path | None = None
+        self.index_path: Path | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "written": list(self.written),
+            "unchanged": list(self.unchanged),
+            "drifted": list(self.drifted),
+            "skipped": list(self.skipped),
+            "dry_run": self.dry_run,
+            "tokens_dir": str(self.tokens_dir) if self.tokens_dir else None,
+            "index_path": str(self.index_path) if self.index_path else None,
+        }
+
+
+def bootstrap_tokens(
+    repo_root: Path,
+    *,
+    env_path: Path | None = None,
+    force: bool = False,
+    dry_run: bool = False,
+) -> BootstrapResult:
+    """Bootstrap ``.loom/tokens/`` from ``.env`` triples.
+
+    Args:
+        repo_root: Repository root (must contain ``.loom/``).
+        env_path: Optional override for the ``.env`` file. Defaults to
+            ``repo_root / ".env"``.
+        force: When ``True``, overwrite existing token files even if
+            their contents match ``.env`` (rewrites mode and timestamp).
+            When ``False`` (default), files whose fingerprint matches
+            ``.env`` are left alone.
+        dry_run: When ``True``, no files are written; the result lists
+            what *would* change.
+
+    Returns:
+        :class:`BootstrapResult` summarising the operation.
+
+    Raises:
+        FileNotFoundError: If ``.env`` does not exist at ``env_path``.
+    """
+    paths = LoomPaths(repo_root)
+    tokens_dir = paths.loom_dir / "tokens"
+    index_path = tokens_dir / "index.json"
+    env_file = env_path if env_path is not None else (repo_root / ".env")
+
+    result = BootstrapResult()
+    result.dry_run = dry_run
+    result.tokens_dir = tokens_dir
+    result.index_path = index_path
+
+    if not env_file.is_file():
+        raise FileNotFoundError(f".env not found at {env_file}")
+
+    accounts = parse_env_accounts(env_file)
+    if not accounts:
+        log_warning(
+            f"No ACCOUNT_*_N entries found in {env_file}; nothing to bootstrap."
+        )
+        return result
+
+    # Validate triples and build the work list, in stable order by N.
+    valid: list[tuple[int, str, str, str]] = []  # (n, email, key, filename)
+    for n in sorted(accounts):
+        triple = accounts[n]
+        missing = [k for k in ("email", "key", "file") if not triple.get(k)]
+        if missing:
+            log_warning(
+                f"ACCOUNT_*_{n}: incomplete triple "
+                f"(missing: {', '.join(sorted(missing))}); skipping."
+            )
+            continue
+        filename = triple["file"]
+        if not _TOKEN_FILE_RE.match(filename) or "/" in filename or "\\" in filename:
+            log_warning(
+                f"ACCOUNT_TOKEN_FILE_{n}={filename!r}: unsafe filename; skipping."
+            )
+            continue
+        valid.append((n, triple["email"], triple["key"], filename))
+
+    if not valid:
+        log_warning(
+            f"No complete ACCOUNT_*_N triples in {env_file}; nothing to bootstrap."
+        )
+        return result
+
+    # Detect duplicate filenames (would otherwise clobber each other).
+    seen_files: dict[str, int] = {}
+    for n, _email, _key, filename in valid:
+        if filename in seen_files:
+            log_error(
+                f"Duplicate ACCOUNT_TOKEN_FILE: {filename!r} appears for "
+                f"both _{seen_files[filename]} and _{n}; aborting."
+            )
+            raise ValueError(f"duplicate token filename: {filename}")
+        seen_files[filename] = n
+
+    if not dry_run:
+        tokens_dir.mkdir(parents=True, exist_ok=True)
+        # Tighten directory mode (best-effort; ignore on FS without chmod).
+        try:
+            os.chmod(tokens_dir, DIR_MODE)
+        except OSError:
+            pass
+
+    manifest_accounts: list[dict[str, object]] = []
+    for n, email, key, filename in valid:
+        token_path = tokens_dir / filename
+        new_fp = fingerprint(key)
+
+        existing_fp: str | None = None
+        if token_path.exists():
+            try:
+                existing = token_path.read_text(encoding="utf-8")
+            except OSError as exc:
+                log_warning(f"Could not read {token_path}: {exc}; will rewrite.")
+                existing = None  # type: ignore[assignment]
+            if existing is not None:
+                existing_fp = fingerprint(existing.rstrip("\n"))
+
+        action: str
+        if existing_fp is None:
+            action = "written"
+        elif existing_fp == new_fp:
+            action = "unchanged" if not force else "written"
+        else:
+            action = "drifted"
+
+        if action == "drifted" and not force:
+            log_warning(
+                f"DRIFT: {filename} on disk does not match .env "
+                f"(disk fp={existing_fp}, env fp={new_fp}); "
+                f"re-run with --force to overwrite."
+            )
+            result.drifted.append(filename)
+            # Still record current on-disk fingerprint in manifest so
+            # operators can see it.
+            manifest_accounts.append(
+                {
+                    "env_index": n,
+                    "name": _name_from_file(filename),
+                    "email": email,
+                    "file": filename,
+                    "key_fingerprint": existing_fp,
+                    "drift": True,
+                    "env_fingerprint": new_fp,
+                }
+            )
+            continue
+
+        if action == "unchanged":
+            result.unchanged.append(filename)
+        else:
+            # written (new file or force-overwrite)
+            if not dry_run:
+                # Write atomically: temp file + rename.
+                tmp = token_path.with_suffix(token_path.suffix + ".tmp")
+                tmp.write_text(key, encoding="utf-8")
+                try:
+                    os.chmod(tmp, FILE_MODE)
+                except OSError:
+                    pass
+                os.replace(tmp, token_path)
+                # Re-apply mode in case `replace` reset it on some FS.
+                try:
+                    os.chmod(token_path, FILE_MODE)
+                except OSError:
+                    pass
+            result.written.append(filename)
+
+        manifest_accounts.append(
+            {
+                "env_index": n,
+                "name": _name_from_file(filename),
+                "email": email,
+                "file": filename,
+                "key_fingerprint": new_fp,
+            }
+        )
+
+    # Write the manifest.
+    manifest = {
+        "version": INDEX_VERSION,
+        "generated_at": _now_iso(),
+        "accounts": manifest_accounts,
+    }
+    if not dry_run:
+        # Confirm dir exists (e.g. dry_run was False but no files written).
+        tokens_dir.mkdir(parents=True, exist_ok=True)
+        index_tmp = index_path.with_suffix(index_path.suffix + ".tmp")
+        index_tmp.write_text(
+            json.dumps(manifest, indent=2, sort_keys=False) + "\n",
+            encoding="utf-8",
+        )
+        os.replace(index_tmp, index_path)
+
+    log_info(
+        f"bootstrap: written={len(result.written)} "
+        f"unchanged={len(result.unchanged)} "
+        f"drifted={len(result.drifted)} "
+        f"skipped={len(result.skipped)} "
+        f"(dry_run={dry_run})"
+    )
+    if result.drifted and not force:
+        log_warning(
+            f"{len(result.drifted)} token(s) drifted from .env; "
+            f"re-run with --force to overwrite on-disk values."
+        )
+    elif result.written and not dry_run:
+        log_success(
+            f"Bootstrapped {len(result.written)} token(s) into {tokens_dir}"
+        )
+
+    return result

--- a/loom-tools/src/loom_tools/tokens/cli.py
+++ b/loom-tools/src/loom_tools/tokens/cli.py
@@ -1,0 +1,104 @@
+"""CLI entry point for ``loom-tokens``.
+
+Currently exposes a single subcommand, ``bootstrap``, which materializes
+the ``.loom/tokens/`` pool from ``.env``. Additional subcommands (status,
+allowlist, ranking sync, etc.) can be added later without breaking the
+top-level surface — the dispatch table mirrors
+``loom_tools.shepherd.cli``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from loom_tools.common.logging import log_error
+from loom_tools.common.repo import find_repo_root
+from loom_tools.tokens.bootstrap import bootstrap_tokens
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="loom-tokens",
+        description="Manage the .loom/tokens/ OAuth pool for Claude Code rotation.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    bp = sub.add_parser(
+        "bootstrap",
+        help="Materialize .loom/tokens/ from ACCOUNT_*_N triples in .env.",
+    )
+    bp.add_argument(
+        "--env",
+        type=Path,
+        default=None,
+        help="Path to .env file (default: <repo-root>/.env).",
+    )
+    bp.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing token files even if their fingerprint matches.",
+    )
+    bp.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would change without writing any files.",
+    )
+    bp.add_argument(
+        "--json",
+        dest="emit_json",
+        action="store_true",
+        help="Emit a JSON summary on stdout (in addition to log lines).",
+    )
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for ``loom-tokens``."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "bootstrap":
+        return _cmd_bootstrap(args)
+
+    # argparse `required=True` should make this unreachable.
+    parser.print_help(sys.stderr)
+    return 1
+
+
+def _cmd_bootstrap(args: argparse.Namespace) -> int:
+    try:
+        repo_root = find_repo_root()
+    except FileNotFoundError as exc:
+        log_error(str(exc))
+        return 1
+
+    try:
+        result = bootstrap_tokens(
+            repo_root,
+            env_path=args.env,
+            force=args.force,
+            dry_run=args.dry_run,
+        )
+    except FileNotFoundError as exc:
+        log_error(str(exc))
+        return 1
+    except ValueError as exc:
+        log_error(str(exc))
+        return 1
+
+    if args.emit_json:
+        print(json.dumps(result.to_dict(), indent=2))
+
+    # Treat unresolved drift (without --force) as a non-zero exit so CI
+    # can detect divergence.
+    if result.drifted and not args.force:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/loom-tools/tests/tokens/test_bootstrap.py
+++ b/loom-tools/tests/tokens/test_bootstrap.py
@@ -1,0 +1,397 @@
+"""Tests for loom_tools.tokens.bootstrap."""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import sys
+
+import pytest
+
+from loom_tools.common.repo import clear_repo_cache
+from loom_tools.tokens.bootstrap import (
+    INDEX_VERSION,
+    BootstrapResult,
+    _strip_value,
+    bootstrap_tokens,
+    fingerprint,
+    parse_env_accounts,
+)
+from loom_tools.tokens.cli import main as cli_main
+
+
+@pytest.fixture
+def mock_repo(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Create a mock repo with .git and .loom directories."""
+    clear_repo_cache()
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".loom").mkdir()
+    return tmp_path
+
+
+def _write_env(repo: pathlib.Path, body: str) -> pathlib.Path:
+    env = repo / ".env"
+    env.write_text(body, encoding="utf-8")
+    return env
+
+
+# ---------------------------------------------------------------------------
+# parse_env_accounts / _strip_value
+# ---------------------------------------------------------------------------
+
+
+class TestStripValue:
+    def test_plain(self) -> None:
+        assert _strip_value("hello") == "hello"
+
+    def test_double_quoted(self) -> None:
+        assert _strip_value('"hello"') == "hello"
+
+    def test_single_quoted(self) -> None:
+        assert _strip_value("'hello'") == "hello"
+
+    def test_trims_whitespace(self) -> None:
+        assert _strip_value("  hello  ") == "hello"
+
+    def test_strips_embedded_newline(self) -> None:
+        # Mirrors lean-genius `tr -d "'\"\n"` behavior.
+        assert _strip_value("hel\nlo") == "hello"
+
+    def test_strips_embedded_quotes(self) -> None:
+        assert _strip_value('he"l"lo') == "hello"
+
+
+class TestParseEnv:
+    def test_complete_triple(self, mock_repo: pathlib.Path) -> None:
+        env = _write_env(
+            mock_repo,
+            "ACCOUNT_EMAIL_1=a@b.com\n"
+            "ACCOUNT_KEY_1=sk-ant-oat01-aaa\n"
+            "ACCOUNT_TOKEN_FILE_1=alice.token\n",
+        )
+        accounts = parse_env_accounts(env)
+        assert set(accounts) == {1}
+        assert accounts[1] == {
+            "email": "a@b.com",
+            "key": "sk-ant-oat01-aaa",
+            "file": "alice.token",
+        }
+
+    def test_multiple_accounts(self, mock_repo: pathlib.Path) -> None:
+        env = _write_env(
+            mock_repo,
+            "ACCOUNT_EMAIL_1=a@b.com\n"
+            "ACCOUNT_KEY_1=sk-1\n"
+            "ACCOUNT_TOKEN_FILE_1=a.token\n"
+            "ACCOUNT_EMAIL_2=c@d.com\n"
+            "ACCOUNT_KEY_2=sk-2\n"
+            "ACCOUNT_TOKEN_FILE_2=c.token\n",
+        )
+        accounts = parse_env_accounts(env)
+        assert set(accounts) == {1, 2}
+
+    def test_gap_in_numbering(self, mock_repo: pathlib.Path) -> None:
+        # Per AC: gaps must not error.
+        env = _write_env(
+            mock_repo,
+            "ACCOUNT_EMAIL_1=a@b.com\n"
+            "ACCOUNT_KEY_1=sk-1\n"
+            "ACCOUNT_TOKEN_FILE_1=a.token\n"
+            "ACCOUNT_EMAIL_3=c@d.com\n"
+            "ACCOUNT_KEY_3=sk-3\n"
+            "ACCOUNT_TOKEN_FILE_3=c.token\n",
+        )
+        accounts = parse_env_accounts(env)
+        assert set(accounts) == {1, 3}
+
+    def test_partial_triple_returned(self, mock_repo: pathlib.Path) -> None:
+        # Parser returns partial triples; bootstrap will warn and skip.
+        env = _write_env(mock_repo, "ACCOUNT_EMAIL_5=a@b.com\n")
+        accounts = parse_env_accounts(env)
+        assert accounts == {5: {"email": "a@b.com"}}
+
+    def test_ignores_unrelated_lines(self, mock_repo: pathlib.Path) -> None:
+        env = _write_env(
+            mock_repo,
+            "# comment\n"
+            "OTHER_VAR=xyz\n"
+            "ACCOUNT_EMAIL_1=a@b.com\n"
+            "ACCOUNT_KEY_1=sk-1\n"
+            "ACCOUNT_TOKEN_FILE_1=a.token\n",
+        )
+        accounts = parse_env_accounts(env)
+        assert set(accounts) == {1}
+
+    def test_quoted_values(self, mock_repo: pathlib.Path) -> None:
+        env = _write_env(
+            mock_repo,
+            'ACCOUNT_EMAIL_1="a@b.com"\n'
+            "ACCOUNT_KEY_1='sk-1'\n"
+            "ACCOUNT_TOKEN_FILE_1=a.token\n",
+        )
+        accounts = parse_env_accounts(env)
+        assert accounts[1]["email"] == "a@b.com"
+        assert accounts[1]["key"] == "sk-1"
+
+
+# ---------------------------------------------------------------------------
+# fingerprint
+# ---------------------------------------------------------------------------
+
+
+def test_fingerprint_is_8_hex_chars() -> None:
+    fp = fingerprint("sk-ant-oat01-something")
+    assert len(fp) == 8
+    assert all(c in "0123456789abcdef" for c in fp)
+
+
+def test_fingerprint_changes_on_drift() -> None:
+    assert fingerprint("a") != fingerprint("b")
+
+
+def test_fingerprint_stable() -> None:
+    assert fingerprint("same") == fingerprint("same")
+
+
+# ---------------------------------------------------------------------------
+# bootstrap_tokens
+# ---------------------------------------------------------------------------
+
+
+def _make_env(repo: pathlib.Path, n_accounts: int = 2) -> pathlib.Path:
+    lines = []
+    for i in range(1, n_accounts + 1):
+        lines.append(f"ACCOUNT_EMAIL_{i}=user{i}@example.com")
+        lines.append(f"ACCOUNT_KEY_{i}=sk-ant-oat01-key{i}")
+        lines.append(f"ACCOUNT_TOKEN_FILE_{i}=user{i}.token")
+    return _write_env(repo, "\n".join(lines) + "\n")
+
+
+class TestBootstrap:
+    def test_creates_token_files(self, mock_repo: pathlib.Path) -> None:
+        _make_env(mock_repo, 2)
+        result = bootstrap_tokens(mock_repo)
+        tokens_dir = mock_repo / ".loom" / "tokens"
+        assert (tokens_dir / "user1.token").read_text() == "sk-ant-oat01-key1"
+        assert (tokens_dir / "user2.token").read_text() == "sk-ant-oat01-key2"
+        assert sorted(result.written) == ["user1.token", "user2.token"]
+        assert result.unchanged == []
+        assert result.drifted == []
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX modes only")
+    def test_token_file_mode_0600(self, mock_repo: pathlib.Path) -> None:
+        _make_env(mock_repo, 1)
+        bootstrap_tokens(mock_repo)
+        token_path = mock_repo / ".loom" / "tokens" / "user1.token"
+        mode = os.stat(token_path).st_mode & 0o777
+        assert mode == 0o600
+
+    def test_writes_index_json(self, mock_repo: pathlib.Path) -> None:
+        _make_env(mock_repo, 2)
+        bootstrap_tokens(mock_repo)
+        idx_path = mock_repo / ".loom" / "tokens" / "index.json"
+        assert idx_path.exists()
+        idx = json.loads(idx_path.read_text())
+        assert idx["version"] == INDEX_VERSION
+        assert "generated_at" in idx
+        assert len(idx["accounts"]) == 2
+        # No secret material — only fingerprints.
+        for acct in idx["accounts"]:
+            assert "key" not in acct
+            assert "ACCOUNT_KEY" not in str(acct)
+            assert len(acct["key_fingerprint"]) == 8
+            assert acct["env_index"] in (1, 2)
+            assert acct["file"].endswith(".token")
+            assert "email" in acct
+            assert acct["name"] == acct["file"].removesuffix(".token")
+
+    def test_idempotent_unchanged(self, mock_repo: pathlib.Path) -> None:
+        _make_env(mock_repo, 2)
+        bootstrap_tokens(mock_repo)
+        result = bootstrap_tokens(mock_repo)
+        assert result.written == []
+        assert sorted(result.unchanged) == ["user1.token", "user2.token"]
+        assert result.drifted == []
+
+    def test_drift_detected_without_force(self, mock_repo: pathlib.Path) -> None:
+        _make_env(mock_repo, 1)
+        bootstrap_tokens(mock_repo)
+        token_path = mock_repo / ".loom" / "tokens" / "user1.token"
+        token_path.write_text("manually-edited", encoding="utf-8")
+
+        result = bootstrap_tokens(mock_repo)
+        assert result.drifted == ["user1.token"]
+        assert result.written == []
+        # Disk content is preserved when drift is detected w/o --force.
+        assert token_path.read_text() == "manually-edited"
+
+    def test_force_overwrites_drift(self, mock_repo: pathlib.Path) -> None:
+        _make_env(mock_repo, 1)
+        bootstrap_tokens(mock_repo)
+        token_path = mock_repo / ".loom" / "tokens" / "user1.token"
+        token_path.write_text("manually-edited", encoding="utf-8")
+
+        result = bootstrap_tokens(mock_repo, force=True)
+        assert result.drifted == []
+        assert result.written == ["user1.token"]
+        assert token_path.read_text() == "sk-ant-oat01-key1"
+
+    def test_dry_run_writes_nothing(self, mock_repo: pathlib.Path) -> None:
+        _make_env(mock_repo, 2)
+        result = bootstrap_tokens(mock_repo, dry_run=True)
+        tokens_dir = mock_repo / ".loom" / "tokens"
+        assert sorted(result.written) == ["user1.token", "user2.token"]
+        # Nothing materialized.
+        assert not tokens_dir.exists() or list(tokens_dir.iterdir()) == []
+
+    def test_partial_triple_skipped(self, mock_repo: pathlib.Path) -> None:
+        env_body = (
+            "ACCOUNT_EMAIL_1=a@b.com\n"
+            "ACCOUNT_KEY_1=sk-1\n"
+            "ACCOUNT_TOKEN_FILE_1=a.token\n"
+            # _2 is missing TOKEN_FILE
+            "ACCOUNT_EMAIL_2=c@d.com\n"
+            "ACCOUNT_KEY_2=sk-2\n"
+        )
+        _write_env(mock_repo, env_body)
+        result = bootstrap_tokens(mock_repo)
+        assert result.written == ["a.token"]
+        # _2 was silently dropped (with a warning).
+        tokens_dir = mock_repo / ".loom" / "tokens"
+        assert not (tokens_dir / "c@d.token").exists()
+
+    def test_unsafe_filename_skipped(self, mock_repo: pathlib.Path) -> None:
+        env_body = (
+            "ACCOUNT_EMAIL_1=a@b.com\n"
+            "ACCOUNT_KEY_1=sk-1\n"
+            "ACCOUNT_TOKEN_FILE_1=../escape.token\n"
+        )
+        _write_env(mock_repo, env_body)
+        result = bootstrap_tokens(mock_repo)
+        assert result.written == []
+
+    def test_duplicate_filenames_aborts(self, mock_repo: pathlib.Path) -> None:
+        env_body = (
+            "ACCOUNT_EMAIL_1=a@b.com\n"
+            "ACCOUNT_KEY_1=sk-1\n"
+            "ACCOUNT_TOKEN_FILE_1=same.token\n"
+            "ACCOUNT_EMAIL_2=c@d.com\n"
+            "ACCOUNT_KEY_2=sk-2\n"
+            "ACCOUNT_TOKEN_FILE_2=same.token\n"
+        )
+        _write_env(mock_repo, env_body)
+        with pytest.raises(ValueError, match="duplicate"):
+            bootstrap_tokens(mock_repo)
+
+    def test_missing_env_raises(self, mock_repo: pathlib.Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            bootstrap_tokens(mock_repo)
+
+    def test_no_accounts_returns_empty(self, mock_repo: pathlib.Path) -> None:
+        _write_env(mock_repo, "OTHER_VAR=xyz\n")
+        result = bootstrap_tokens(mock_repo)
+        assert result.written == []
+        assert result.unchanged == []
+        assert result.drifted == []
+
+    def test_index_records_drift_flag(self, mock_repo: pathlib.Path) -> None:
+        _make_env(mock_repo, 1)
+        bootstrap_tokens(mock_repo)
+        token_path = mock_repo / ".loom" / "tokens" / "user1.token"
+        token_path.write_text("manually-edited", encoding="utf-8")
+        bootstrap_tokens(mock_repo)
+        idx = json.loads(
+            (mock_repo / ".loom" / "tokens" / "index.json").read_text()
+        )
+        drifted_entry = idx["accounts"][0]
+        assert drifted_entry.get("drift") is True
+        assert "env_fingerprint" in drifted_entry
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+
+class TestCli:
+    def test_help_exits_zero(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with pytest.raises(SystemExit) as exc:
+            cli_main(["--help"])
+        assert exc.value.code == 0
+
+    def test_bootstrap_help_exits_zero(self) -> None:
+        with pytest.raises(SystemExit) as exc:
+            cli_main(["bootstrap", "--help"])
+        assert exc.value.code == 0
+
+    def test_bootstrap_dry_run_via_cli(
+        self,
+        mock_repo: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _make_env(mock_repo, 1)
+        monkeypatch.chdir(mock_repo)
+        rc = cli_main(["bootstrap", "--dry-run", "--json"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        payload = json.loads(out)
+        assert payload["dry_run"] is True
+        assert payload["written"] == ["user1.token"]
+
+    def test_bootstrap_drift_returns_2(
+        self,
+        mock_repo: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _make_env(mock_repo, 1)
+        monkeypatch.chdir(mock_repo)
+        cli_main(["bootstrap"])
+        # Tamper with disk to create drift.
+        token_path = mock_repo / ".loom" / "tokens" / "user1.token"
+        token_path.write_text("tampered", encoding="utf-8")
+        rc = cli_main(["bootstrap"])
+        assert rc == 2
+
+    def test_bootstrap_force_clears_drift(
+        self,
+        mock_repo: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _make_env(mock_repo, 1)
+        monkeypatch.chdir(mock_repo)
+        cli_main(["bootstrap"])
+        token_path = mock_repo / ".loom" / "tokens" / "user1.token"
+        token_path.write_text("tampered", encoding="utf-8")
+        rc = cli_main(["bootstrap", "--force"])
+        assert rc == 0
+        assert token_path.read_text() == "sk-ant-oat01-key1"
+
+    def test_missing_env_returns_1(
+        self,
+        mock_repo: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.chdir(mock_repo)
+        rc = cli_main(["bootstrap"])
+        assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# Result struct
+# ---------------------------------------------------------------------------
+
+
+def test_bootstrap_result_to_dict_roundtrip() -> None:
+    r = BootstrapResult()
+    r.written = ["a.token"]
+    r.unchanged = ["b.token"]
+    r.drifted = []
+    r.skipped = []
+    r.dry_run = True
+    d = r.to_dict()
+    # Ensure JSON-serializable.
+    assert json.dumps(d)
+    assert d["written"] == ["a.token"]
+    assert d["dry_run"] is True


### PR DESCRIPTION
Closes #3234

## Summary
Adds the `loom-tokens bootstrap` CLI that materializes `.loom/tokens/<file>.token` (mode 0600) plus an `index.json` manifest from numbered `ACCOUNT_EMAIL_N` / `ACCOUNT_KEY_N` / `ACCOUNT_TOKEN_FILE_N` triples in `.env`. The manifest stores sha256 fingerprints (8 chars) for drift detection -- no secret material is persisted in `index.json`.

## What ships
- `loom_tools/tokens/{__init__.py, bootstrap.py, cli.py}` -- new subpackage matching the `shepherd/cli.py` convention
- `loom-tokens` console script registered in `loom-tools/pyproject.toml`
- `.loom/tokens/` added to `.gitignore` (was missing)
- `.env.example` documents the multi-account triple format
- `CLAUDE.md` gains a `### Multi-Account Token Pool` subsection under `## Configuration`
- 35 unit tests in `loom-tools/tests/tokens/test_bootstrap.py`

## Behaviour
- Idempotent re-run (existing tokens whose fingerprint matches `.env` are left alone)
- `--force` overwrites drifted on-disk tokens
- `--dry-run` reports planned changes without writing
- Drift without `--force` exits `2` so CI can detect divergence
- Numbering gaps and partial triples are skipped with a warning (not errors)
- Unsafe filenames (path traversal, non-`.token` suffix) are rejected
- Duplicate filenames across triples abort with a clear error
- Atomic writes (tmp + rename) preserve mode 0600

## Test plan
- [x] PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/tokens/ -v -- 35/35 passing
- [x] pip install -e loom-tools/ in a clean venv; loom-tokens --help and loom-tokens bootstrap --help resolve correctly
- [x] End-to-end smoke: real .env produces .loom/tokens/alice.token (mode 0600), .loom/tokens/ (mode 0700), and index.json with no key material