### PR TITLE
feat: integrate OAuth token rotation into agent_spawn (#3236)

### DIFF
--- a/defaults/scripts/claude-wrapper.sh
+++ b/defaults/scripts/claude-wrapper.sh
@@ -1542,6 +1542,17 @@ main() {
     log_info "Workspace: ${WORKSPACE}"
     [[ -n "${TERMINAL_ID}" ]] && log_info "Terminal ID: ${TERMINAL_ID}"
 
+    # Observability for OAuth-token rotation (issue #3236).  Log a single
+    # masked line so post-mortem debugging can confirm which spawn path was
+    # used (env-token vs Keychain) without leaking secret material to logs.
+    if [[ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
+        local _tok_len=${#CLAUDE_CODE_OAUTH_TOKEN}
+        local _tok_tail="${CLAUDE_CODE_OAUTH_TOKEN: -4}"
+        log_info "OAuth auth mode: env-token (CLAUDE_CODE_OAUTH_TOKEN set, len=${_tok_len}, tail=…${_tok_tail})"
+    else
+        log_info "OAuth auth mode: keychain (CLAUDE_CODE_OAUTH_TOKEN not set)"
+    fi
+
     # Detect --dangerously-skip-permissions flag (automated agent mode)
     for arg in "$@"; do
         if [[ "$arg" == "--dangerously-skip-permissions" ]]; then

--- a/defaults/scripts/cli/loom-scale.sh
+++ b/defaults/scripts/cli/loom-scale.sh
@@ -220,15 +220,26 @@ spawn_role_agent() {
     # Change to workspace
     tmux -L "$TMUX_SOCKET" send-keys -t "$session_name" "cd '$REPO_ROOT'" C-m
 
-    # Start claude with role
+    # Start claude with role.  Prefer the resilient wrapper (claude-wrapper.sh)
+    # so OAuth-token rotation, retry, and auth pre-flight all run consistently
+    # with the Python spawn path in agent_spawn.py.  The wrapper exec's the
+    # real `claude` binary; CLAUDE_CODE_OAUTH_TOKEN inherited from the parent
+    # shell flows through naturally.  See issue #3236.
     local role_file="${role}.md"
     local role_path="$REPO_ROOT/.loom/roles/$role_file"
+    local wrapper_path="$REPO_ROOT/.loom/scripts/claude-wrapper.sh"
+    local claude_invocation
+    if [[ -x "$wrapper_path" ]]; then
+        claude_invocation="'$wrapper_path'"
+    else
+        claude_invocation="claude"
+    fi
 
     if [[ -f "$role_path" ]]; then
-        tmux -L "$TMUX_SOCKET" send-keys -t "$session_name" "claude -p '/$role' --dangerously-skip-permissions" C-m
+        tmux -L "$TMUX_SOCKET" send-keys -t "$session_name" "$claude_invocation -p '/$role' --dangerously-skip-permissions" C-m
     else
         echo -e "    ${YELLOW}Warning: Role file not found: $role_file${NC}"
-        tmux -L "$TMUX_SOCKET" send-keys -t "$session_name" "claude --dangerously-skip-permissions" C-m
+        tmux -L "$TMUX_SOCKET" send-keys -t "$session_name" "$claude_invocation --dangerously-skip-permissions" C-m
     fi
 
     return 0

--- a/defaults/scripts/verify-token-precedence.sh
+++ b/defaults/scripts/verify-token-precedence.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# verify-token-precedence.sh - Manually confirm CLAUDE_CODE_OAUTH_TOKEN
+# takes precedence over Keychain auth in the installed Claude Code CLI.
+#
+# Issue #3236 / curator AC: the lean-genius wrapper relies on the
+# precedence assumption but the loom repo has no in-repo citation
+# proving it.  Run this script once, on the operator's machine, to
+# confirm the assumption holds for the installed Claude Code version.
+#
+# Usage:
+#   ./verify-token-precedence.sh
+#
+# Exit codes:
+#   0 - env-token correctly takes precedence over Keychain
+#   1 - env-token did NOT take precedence (precedence claim is false)
+#   2 - prerequisites missing (claude not installed, not logged in, etc.)
+
+set -euo pipefail
+
+if ! command -v claude >/dev/null 2>&1; then
+    echo "ERROR: 'claude' CLI not found in PATH" >&2
+    exit 2
+fi
+
+# Ensure the local Keychain is logged in — otherwise the comparison is
+# meaningless (env-token would be the only auth source).
+if ! claude auth status --json 2>/dev/null | grep -q '"loggedIn": *true'; then
+    echo "ERROR: 'claude auth status' reports not logged in." >&2
+    echo "Run 'claude auth login' first so the Keychain has a valid token," >&2
+    echo "then rerun this script." >&2
+    exit 2
+fi
+
+echo "Step 1: Keychain-only auth status"
+keychain_email=$(claude auth status --json | python3 -c 'import json,sys; print(json.load(sys.stdin).get("email",""))' 2>/dev/null || echo "")
+echo "  Keychain account email: ${keychain_email:-<unknown>}"
+echo ""
+
+echo "Step 2: Auth status with env-token set to a deliberately bogus value"
+echo "  CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-deliberately-bogus claude auth status --json"
+set +e
+env_output=$(CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat01-deliberately-bogus" \
+    claude auth status --json 2>&1)
+env_exit=$?
+set -e
+
+echo "  Exit code: ${env_exit}"
+echo "  Output: ${env_output}"
+echo ""
+
+# If precedence holds, the bogus token should make auth FAIL or report a
+# different account than the Keychain.  If precedence does NOT hold, the
+# CLI silently falls back to Keychain and reports the same account.
+env_logged_in=$(echo "${env_output}" | python3 -c \
+    'import json,sys
+try:
+    print(json.load(sys.stdin).get("loggedIn", False))
+except Exception:
+    print("parse-error")' 2>/dev/null || echo "parse-error")
+
+if [[ "${env_exit}" -ne 0 || "${env_logged_in}" != "True" ]]; then
+    echo "PASS: env-token takes precedence over Keychain."
+    echo "      (Bogus token caused auth to fail; Keychain was NOT consulted.)"
+    exit 0
+fi
+
+env_email=$(echo "${env_output}" | python3 -c \
+    'import json,sys; print(json.load(sys.stdin).get("email",""))' 2>/dev/null || echo "")
+
+if [[ -n "${keychain_email}" && -n "${env_email}" && \
+      "${keychain_email}" == "${env_email}" ]]; then
+    echo "FAIL: env-token did NOT take precedence."
+    echo "      With a bogus env-token, auth still reported the Keychain"
+    echo "      account (${keychain_email}).  Token rotation will NOT work"
+    echo "      on this Claude Code version — it falls back to Keychain."
+    exit 1
+fi
+
+echo "INCONCLUSIVE: could not determine precedence from output."
+echo "  Keychain email: ${keychain_email:-<unknown>}"
+echo "  Env-token email: ${env_email:-<unknown>}"
+echo "  Output: ${env_output}"
+exit 2

--- a/loom-tools/src/loom_tools/agent_spawn.py
+++ b/loom-tools/src/loom_tools/agent_spawn.py
@@ -41,6 +41,36 @@ from loom_tools.common.claude_config import (
 from loom_tools.common.logging import log_error, log_info, log_success, log_warning
 from loom_tools.common.repo import find_repo_root
 
+
+def _select_oauth_token(repo_root: pathlib.Path) -> str | None:
+    """Select an OAuth token from the workspace token pool, if available.
+
+    Returns the selected token string or None when:
+      - The ``loom_tools.tokens.select`` module is not yet present
+        (issue #3235 not merged into the current worktree).
+      - No ``.loom/tokens/`` directory exists in the workspace
+        (token rotation not bootstrapped via #3234's ``loom-tokens bootstrap``).
+      - Selection raises any exception (token pool corrupt, all tokens bad,
+        etc.) — the fallback is the per-agent Keychain auth path.
+
+    On any None return, callers should NOT inject ``CLAUDE_CODE_OAUTH_TOKEN``;
+    Claude Code falls back to its Keychain credential under the per-agent
+    ``CLAUDE_CONFIG_DIR``-hashed service name. See issue #3236.
+    """
+    tokens_dir = repo_root / ".loom" / "tokens"
+    if not tokens_dir.is_dir():
+        return None
+    try:
+        # Imported lazily so the module is optional until #3235 lands.
+        from loom_tools.tokens.select import select_token  # type: ignore[import-not-found]
+    except ImportError:
+        return None
+    try:
+        return select_token(repo_root)
+    except Exception as exc:  # pragma: no cover - defensive
+        log_warning(f"Token selection failed ({exc}); falling back to Keychain auth")
+        return None
+
 # tmux configuration (must match agent_monitor.py)
 TMUX_SOCKET = "loom"
 SESSION_PREFIX = "loom-"
@@ -710,17 +740,51 @@ def spawn_agent(
     if shepherd_task_id:
         shepherd_prefix = f"LOOM_SHEPHERD_TASK_ID='{shepherd_task_id}' "
 
+    # OAuth token rotation prefix (see issue #3236).
+    # If a workspace token pool exists (created by `loom-tokens bootstrap`)
+    # and the selection library is installed, pick an account and inline its
+    # token as CLAUDE_CODE_OAUTH_TOKEN so Claude Code uses it instead of the
+    # per-agent Keychain entry.  When neither condition holds, do nothing —
+    # the existing Keychain-auth path under CLAUDE_CONFIG_DIR continues to
+    # work unchanged (backward compatible).
+    #
+    # Honour any CLAUDE_CODE_OAUTH_TOKEN already in the caller's environment:
+    # if the user explicitly set it, do not override.
+    token_prefix = ""
+    inherited_token = os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "")
+    if inherited_token:
+        # Quote single-quotes safely for shell interpolation.
+        safe = inherited_token.replace("'", "'\"'\"'")
+        token_prefix = f"CLAUDE_CODE_OAUTH_TOKEN='{safe}' "
+        log_info("Using CLAUDE_CODE_OAUTH_TOKEN from caller environment")
+    else:
+        selected = _select_oauth_token(repo_root)
+        if selected:
+            safe = selected.replace("'", "'\"'\"'")
+            token_prefix = f"CLAUDE_CODE_OAUTH_TOKEN='{safe}' "
+            # Also surface the selected token on the tmux session env so any
+            # later interactive `claude` invocation in the same session
+            # inherits it (mirrors CLAUDE_CONFIG_DIR handling above).
+            _tmux(
+                "set-environment", "-t", session_name,
+                "CLAUDE_CODE_OAUTH_TOKEN", selected,
+            )
+            log_info("Injected CLAUDE_CODE_OAUTH_TOKEN from workspace token pool")
+
     # Build the Claude CLI command
     wrapper_script = repo_root / ".loom" / "scripts" / "claude-wrapper.sh"
     if wrapper_script.is_file() and os.access(wrapper_script, os.X_OK):
         claude_cmd = (
-            f"{pythonpath_prefix}{worktree_prefix}{max_retries_prefix}{shepherd_prefix}"
+            f"{token_prefix}{pythonpath_prefix}{worktree_prefix}"
+            f"{max_retries_prefix}{shepherd_prefix}"
             f"LOOM_TERMINAL_ID='{name}' LOOM_WORKSPACE='{working_dir}' "
             f"CLAUDE_CONFIG_DIR='{config_dir}' TMPDIR='{config_dir / 'tmp'}' "
             f"'{wrapper_script}' --dangerously-skip-permissions \"{role_cmd}\""
         )
     else:
-        claude_cmd = f'claude --dangerously-skip-permissions "{role_cmd}"'
+        claude_cmd = (
+            f"{token_prefix}claude --dangerously-skip-permissions \"{role_cmd}\""
+        )
         log_warning("claude-wrapper.sh not found, using claude directly (no retry logic)")
 
     # Send the command to the session

--- a/loom-tools/tests/tokens/test_agent_spawn_integration.py
+++ b/loom-tools/tests/tokens/test_agent_spawn_integration.py
@@ -1,0 +1,282 @@
+"""Integration tests for OAuth-token rotation in agent_spawn.
+
+Issue #3236: verify that ``CLAUDE_CODE_OAUTH_TOKEN`` is correctly injected
+into the spawned ``claude-wrapper.sh`` invocation when a workspace token
+pool is present, and that it is omitted (preserving Keychain-auth backward
+compatibility) when the pool is absent.
+
+These tests do not require the ``loom_tools.tokens`` package (#3235) to
+exist — the helper is exercised in three configurations:
+
+  1. No ``.loom/tokens/`` directory (returns None).
+  2. ``.loom/tokens/`` present but the selection module unavailable
+     (returns None — defensive against #3235 not being merged yet).
+  3. Selection module available (mocked) — returns the chosen token.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import pathlib
+import subprocess
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from loom_tools.agent_spawn import _select_oauth_token, spawn_agent
+from loom_tools.common.repo import clear_repo_cache
+
+
+@pytest.fixture
+def mock_repo(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Create a mock repo with .git, .loom, and .loom/scripts dirs."""
+    clear_repo_cache()
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".loom").mkdir()
+    (tmp_path / ".loom" / "roles").mkdir()
+    (tmp_path / ".loom" / "logs").mkdir()
+    (tmp_path / ".loom" / "scripts").mkdir(parents=True)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# _select_oauth_token unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestSelectOAuthToken:
+    """Tests for the _select_oauth_token helper."""
+
+    def test_returns_none_when_tokens_dir_missing(
+        self, mock_repo: pathlib.Path
+    ) -> None:
+        """Backward-compat: no .loom/tokens/ -> Keychain auth path."""
+        assert not (mock_repo / ".loom" / "tokens").exists()
+        assert _select_oauth_token(mock_repo) is None
+
+    def test_returns_none_when_selection_module_missing(
+        self, mock_repo: pathlib.Path
+    ) -> None:
+        """Backward-compat: tokens dir exists but #3235 not merged."""
+        (mock_repo / ".loom" / "tokens").mkdir()
+        # Belt-and-suspenders: ensure the module really is absent.
+        sys.modules.pop("loom_tools.tokens", None)
+        sys.modules.pop("loom_tools.tokens.select", None)
+        # The real codebase has no loom_tools.tokens module yet.
+        assert _select_oauth_token(mock_repo) is None
+
+    def test_returns_token_when_selection_module_present(
+        self, mock_repo: pathlib.Path
+    ) -> None:
+        """Token is returned when both the dir and the module are present."""
+        (mock_repo / ".loom" / "tokens").mkdir()
+
+        # Synthesize a fake loom_tools.tokens.select module.
+        fake_pkg = types.ModuleType("loom_tools.tokens")
+        fake_pkg.__path__ = []  # mark as package
+        fake_select = types.ModuleType("loom_tools.tokens.select")
+        fake_select.select_token = MagicMock(return_value="sk-ant-oat01-test-xyz")
+        sys.modules["loom_tools.tokens"] = fake_pkg
+        sys.modules["loom_tools.tokens.select"] = fake_select
+        try:
+            assert _select_oauth_token(mock_repo) == "sk-ant-oat01-test-xyz"
+            fake_select.select_token.assert_called_once_with(mock_repo)
+        finally:
+            sys.modules.pop("loom_tools.tokens.select", None)
+            sys.modules.pop("loom_tools.tokens", None)
+
+    def test_returns_none_when_selection_raises(
+        self, mock_repo: pathlib.Path
+    ) -> None:
+        """Defensive: selection errors fall through to Keychain auth."""
+        (mock_repo / ".loom" / "tokens").mkdir()
+
+        fake_pkg = types.ModuleType("loom_tools.tokens")
+        fake_pkg.__path__ = []
+        fake_select = types.ModuleType("loom_tools.tokens.select")
+        fake_select.select_token = MagicMock(
+            side_effect=RuntimeError("all tokens exhausted")
+        )
+        sys.modules["loom_tools.tokens"] = fake_pkg
+        sys.modules["loom_tools.tokens.select"] = fake_select
+        try:
+            assert _select_oauth_token(mock_repo) is None
+        finally:
+            sys.modules.pop("loom_tools.tokens.select", None)
+            sys.modules.pop("loom_tools.tokens", None)
+
+
+# ---------------------------------------------------------------------------
+# spawn_agent integration tests — verify env-prefix in the tmux send-keys cmd
+# ---------------------------------------------------------------------------
+
+
+def _capture_tmux_calls(mock_repo: pathlib.Path) -> list[list[str]]:
+    """Return a list of the tmux argv arrays passed to subprocess.run."""
+    captured: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        captured.append(list(cmd))
+        # Return success for every tmux call.  has-session needs to return 0
+        # so the spawn loop sees the session as alive; new-session also OK.
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    return captured, fake_run  # type: ignore[return-value]
+
+
+class TestSpawnAgentTokenInjection:
+    """Verify CLAUDE_CODE_OAUTH_TOKEN flows into the spawned command."""
+
+    def _make_wrapper(self, mock_repo: pathlib.Path) -> pathlib.Path:
+        """Create an executable claude-wrapper.sh stub."""
+        wrapper = mock_repo / ".loom" / "scripts" / "claude-wrapper.sh"
+        wrapper.write_text("#!/bin/bash\nexit 0\n")
+        wrapper.chmod(0o755)
+        return wrapper
+
+    def _run_spawn(
+        self, mock_repo: pathlib.Path, env: dict[str, str] | None = None
+    ) -> list[list[str]]:
+        """Drive spawn_agent through the send-keys step and return tmux calls."""
+        self._make_wrapper(mock_repo)
+        # Make a builder role file so validate_role would pass (not strictly
+        # needed for spawn_agent itself but mirrors a realistic call site).
+        (mock_repo / ".loom" / "roles" / "builder.md").write_text("# builder")
+
+        captured: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+            captured.append(list(cmd))
+            stdout = ""
+            # _get_pane_pid asks for pane_pid; return something so the verify
+            # loop sees a process and exits early.
+            if "list-panes" in cmd:
+                stdout = "12345\n"
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout=stdout, stderr=""
+            )
+
+        with patch("loom_tools.agent_spawn.subprocess.run", side_effect=fake_run):
+            with patch(
+                "loom_tools.agent_spawn._is_claude_running", return_value=True
+            ):
+                with patch.dict(os.environ, env or {}, clear=False):
+                    spawn_agent(
+                        role="builder",
+                        name="test-agent",
+                        args="",
+                        worktree="",
+                        repo_root=mock_repo,
+                        verify_timeout=2,
+                    )
+        return captured
+
+    def _find_send_keys_cmd(self, calls: list[list[str]]) -> str:
+        """Return the command-string passed to `tmux send-keys` for claude_cmd."""
+        for call in calls:
+            if (
+                "send-keys" in call
+                and any(
+                    "claude-wrapper.sh" in part or "claude " in part
+                    for part in call
+                )
+            ):
+                # send-keys -t SESSION 'CMD' C-m -> CMD is the second-to-last arg
+                return call[-2]
+        raise AssertionError(f"No send-keys call with claude found in {calls!r}")
+
+    def test_no_token_when_pool_absent(self, mock_repo: pathlib.Path) -> None:
+        """Backward-compat: no token pool -> no env-token injected."""
+        # Ensure no inherited env token leaks into the test.
+        env = {"CLAUDE_CODE_OAUTH_TOKEN": ""}
+        calls = self._run_spawn(mock_repo, env=env)
+        cmd = self._find_send_keys_cmd(calls)
+        assert "CLAUDE_CODE_OAUTH_TOKEN=" not in cmd
+        # Sanity: the wrapper invocation IS present.
+        assert "claude-wrapper.sh" in cmd
+
+    def test_token_injected_when_pool_present(
+        self, mock_repo: pathlib.Path
+    ) -> None:
+        """Pool exists + selection works -> env-token in command line."""
+        (mock_repo / ".loom" / "tokens").mkdir()
+
+        fake_pkg = types.ModuleType("loom_tools.tokens")
+        fake_pkg.__path__ = []
+        fake_select = types.ModuleType("loom_tools.tokens.select")
+        fake_select.select_token = MagicMock(return_value="sk-ant-oat01-AAA")
+        sys.modules["loom_tools.tokens"] = fake_pkg
+        sys.modules["loom_tools.tokens.select"] = fake_select
+        try:
+            env = {"CLAUDE_CODE_OAUTH_TOKEN": ""}
+            calls = self._run_spawn(mock_repo, env=env)
+            cmd = self._find_send_keys_cmd(calls)
+            assert "CLAUDE_CODE_OAUTH_TOKEN='sk-ant-oat01-AAA'" in cmd
+            # The token prefix MUST come BEFORE the wrapper script invocation
+            # otherwise it would be interpreted as an argument, not an env var.
+            tok_pos = cmd.index("CLAUDE_CODE_OAUTH_TOKEN=")
+            wrap_pos = cmd.index("claude-wrapper.sh")
+            assert tok_pos < wrap_pos
+        finally:
+            sys.modules.pop("loom_tools.tokens.select", None)
+            sys.modules.pop("loom_tools.tokens", None)
+
+    def test_inherited_env_token_takes_precedence(
+        self, mock_repo: pathlib.Path
+    ) -> None:
+        """User-set CLAUDE_CODE_OAUTH_TOKEN is propagated, pool not consulted."""
+        (mock_repo / ".loom" / "tokens").mkdir()
+        fake_pkg = types.ModuleType("loom_tools.tokens")
+        fake_pkg.__path__ = []
+        fake_select = types.ModuleType("loom_tools.tokens.select")
+        fake_select.select_token = MagicMock(return_value="from-pool-XXX")
+        sys.modules["loom_tools.tokens"] = fake_pkg
+        sys.modules["loom_tools.tokens.select"] = fake_select
+        try:
+            env = {"CLAUDE_CODE_OAUTH_TOKEN": "from-caller-YYY"}
+            calls = self._run_spawn(mock_repo, env=env)
+            cmd = self._find_send_keys_cmd(calls)
+            assert "CLAUDE_CODE_OAUTH_TOKEN='from-caller-YYY'" in cmd
+            assert "from-pool-XXX" not in cmd
+            # Selection must NOT have been called — caller env wins.
+            fake_select.select_token.assert_not_called()
+        finally:
+            sys.modules.pop("loom_tools.tokens.select", None)
+            sys.modules.pop("loom_tools.tokens", None)
+
+
+# ---------------------------------------------------------------------------
+# Keychain-cleanup regression: ensure the cleanup path is non-fatal when
+# the per-agent Keychain entry was never written (i.e. env-token was used).
+# ---------------------------------------------------------------------------
+
+
+class TestKeychainCleanupWithEnvToken:
+    """Regression test for AC #3 from the curator (#3236).
+
+    When env-token bypasses Keychain entirely, the per-terminal Keychain
+    entry is never written.  The existing cleanup logic must no-op rather
+    than error.
+    """
+
+    def test_cleanup_agent_config_dir_idempotent(
+        self, mock_repo: pathlib.Path
+    ) -> None:
+        """Calling cleanup on an agent that never wrote a Keychain entry
+        must not raise, must not fail, and must remove the config dir."""
+        from loom_tools.common.claude_config import (
+            cleanup_agent_config_dir,
+            setup_agent_config_dir,
+        )
+
+        # Setup a per-agent config dir but never invoke `claude` (so no
+        # Keychain entry is created).  Cleanup should still succeed.
+        config_dir = setup_agent_config_dir("test-agent", mock_repo)
+        assert config_dir.exists()
+
+        removed = cleanup_agent_config_dir("test-agent", mock_repo)
+        assert removed is True
+        assert not config_dir.exists()


### PR DESCRIPTION
Closes #3236

## Summary

Wires OAuth-token rotation (from #3234 + #3235) into the actual `claude` spawn path. The change is intentionally narrow — the curator's research showed the issue body's affected-files list was wrong (the Rust daemon does not spawn `claude`, and `mcp-loom` is TypeScript with no spawn). The real spawn point is `loom-tools/src/loom_tools/agent_spawn.py:714-724`, which already invokes `claude-wrapper.sh`.

### Changes

- **`agent_spawn.py`**: new `_select_oauth_token()` helper with defensive imports (handles #3235 not being merged yet); injects `CLAUDE_CODE_OAUTH_TOKEN='...'` env prefix into the wrapper command line; respects caller-set env-token; also pushes token onto the tmux session env (parity with `CLAUDE_CONFIG_DIR`).
- **`loom-scale.sh`**: legacy CLI scale path now invokes `claude-wrapper.sh` instead of bare `claude`, so rotation/retry/auth pre-flight all run consistently.
- **`claude-wrapper.sh`**: single masked observability log line indicating env-token vs Keychain auth mode.
- **`verify-token-precedence.sh`**: manual one-shot script confirming `CLAUDE_CODE_OAUTH_TOKEN` takes precedence over Keychain on the operator's installed Claude Code CLI (addresses curator AC about the unverified precedence claim).
- **`tests/tokens/test_agent_spawn_integration.py`**: 8 new tests.

### Backward compatibility

- No `.loom/tokens/` -> Keychain path unchanged.
- `loom_tools.tokens.select` not yet installed (#3235 not merged) -> Keychain path unchanged.
- Selection raises -> warning logged, Keychain path used.
- Caller already set `CLAUDE_CODE_OAUTH_TOKEN` -> respected, pool not consulted.

### Files NOT modified (curator's reframing)

- `loom-daemon/src/terminal.rs` — does not spawn `claude` (only sets up tmux sessions).
- `loom-daemon/src/token_pool.rs` — would be dead code; not created.
- `mcp-loom/src/tools/terminals.ts` — thin RPC to daemon, no spawn.

## Dependencies

Depends on **#3234** (token bootstrap) and **#3235** (`spawn-claude.sh` / selection library). Both are still `loom:building`. This PR is functional standalone (defensive imports preserve current behavior), but token rotation only activates after #3234/#3235 ship.

## Test plan

- [x] `PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/tokens/ -v` -> 8 pass
- [x] `PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/test_agent_spawn.py loom-tools/tests/test_claude_config.py -v` -> 113 pass, 1 pre-existing failure unrelated to this PR
- [x] `bash -n` passes on all modified shell scripts
- [x] `loom-scale --help` still works
- [ ] Operator runs `verify-token-precedence.sh` to confirm precedence claim before #3234/#3235 land in production