### PR TITLE
feat(tokens): add account health probe + ranking (loom-tokens check)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -584,6 +584,29 @@ Each account becomes `.loom/tokens/<file>.token` (mode `0600`). An `index.json` 
 
 `.loom/tokens/` is gitignored. The pool is consumed by external rotation logic (e.g. a `claude-wrapper.sh` that picks the least-used token); only the bootstrap step is provided here.
 
+#### Account health probe + ranking
+
+Once bootstrapped, `loom-tokens check` probes each account for current rate-limit headers and (optionally) writes a JSON ranking that the spawn-time selector can consume:
+
+```bash
+loom-tokens check                  # Probe + print human table
+loom-tokens check --ranking        # Probe + write .loom/tokens/.ranking atomically
+loom-tokens check --json           # Emit full JSON report to stdout
+./.loom/scripts/probe-tokens.sh    # Cron-friendly wrapper for periodic invocation
+```
+
+The probe sends a minimal `POST /v1/messages` request (1 input, 1 output token) and parses rate-limit response headers. The header parser matches by **suffix** (`-5h-utilization`, `-7d-utilization`, `-7d-reset`) so future renames of the `anthropic-ratelimit-tokens-*` prefix still work; the full header set is logged on the first probe of each run.
+
+Status assignment: `available` (utilizations < 95%), `exhausted` (`7d_utilization >= 0.95`), `rate_limited` (current 429), `blocked` (401 auth failure or token listed in `.bad_tokens`). Probe failures (network, timeout, 5xx) are logged and skipped — one bad account does not abort the run.
+
+OAuth tokens shaped `sk-ant-oat01-*` are sent with `Authorization: Bearer` + `anthropic-beta: oauth-2025-04-20`; plain API keys use `x-api-key`.
+
+Cron example (probe every 10 minutes):
+
+```cron
+*/10 * * * * cd /path/to/repo && ./.loom/scripts/probe-tokens.sh --ranking >> .loom/logs/probe-tokens.log 2>&1
+```
+
 See `.loom/docs/troubleshooting.md` for detailed troubleshooting including:
 - Cleaning up stale worktrees and branches
 - Stuck agent detection and intervention

--- a/defaults/scripts/probe-tokens.sh
+++ b/defaults/scripts/probe-tokens.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# probe-tokens.sh - Probe each bootstrapped OAuth account and write .ranking.
+#
+# Usage:
+#   ./.loom/scripts/probe-tokens.sh              # Probe + print human table
+#   ./.loom/scripts/probe-tokens.sh --ranking    # Probe + write .loom/tokens/.ranking
+#   ./.loom/scripts/probe-tokens.sh --json       # Probe + emit JSON to stdout
+#
+# Exit codes:
+#   0 - At least one account was probed (results may be mixed)
+#   1 - Every probe failed, or the tokens directory is missing
+#
+# Cron example (every 10 minutes):
+#   */10 * * * * cd /path/to/repo && ./.loom/scripts/probe-tokens.sh --ranking >> .loom/logs/probe-tokens.log 2>&1
+#
+# Thin wrapper around the loom-tokens Python CLI.  Modeled on
+# .loom/scripts/check-usage.sh — keeps the bash surface tiny so the real
+# logic lives in loom-tools.
+
+if command -v loom-tokens &>/dev/null; then
+    loom-tokens check "$@"
+    exit $?
+fi
+
+python3 -m loom_tools.cli.loom_tokens check "$@"

--- a/loom-tools/src/loom_tools/tokens/check.py
+++ b/loom-tools/src/loom_tools/tokens/check.py
@@ -1,0 +1,515 @@
+"""Account health probe + ranking for the agent token pool.
+
+Probes each bootstrapped OAuth account by sending a minimal Anthropic
+``POST /v1/messages`` request and parses rate-limit headers to derive
+session (5h) and weekly (7d) utilization plus the next 7d reset time.
+
+Resilient to header renames: matches by **suffix** (e.g.
+``-5h-utilization``, ``-7d-utilization``, ``-7d-reset``) so that any
+prefix change in the ``anthropic-ratelimit-*`` family still maps to
+our internal fields. The full header set is logged on the first run
+of the process for visibility.
+
+OAuth header format: tokens shaped ``sk-ant-oat01-*`` (Claude Code
+OAuth) require ``Authorization: Bearer <token>`` plus the
+``anthropic-beta: oauth-2025-04-20`` header. Plain ``sk-ant-api*`` API
+keys use ``x-api-key: <token>`` instead.  We auto-detect by token
+prefix (verified empirically: lean-genius's ``check-accounts.sh``
+sends ``x-api-key`` and that fails on ``oat01`` tokens with 401, but
+succeeds on plain API keys).
+
+Status assignment:
+
+* ``available`` — utilizations < 95 percent
+* ``exhausted`` — 7d_utilization >= 0.95
+* ``rate_limited`` — current 429 (transient, distinct from exhausted)
+* ``blocked`` — 401 auth failure or token listed in ``.bad_tokens``
+
+The CLI command writes ``.loom/tokens/.ranking`` atomically when
+``--ranking`` is passed (write-then-rename in the same directory so no
+partial file is ever visible mid-write).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import random
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages"
+ANTHROPIC_VERSION = "2023-06-01"
+ANTHROPIC_OAUTH_BETA = "oauth-2025-04-20"
+USER_AGENT = "loom-tokens/0.1 (claude-code-compatible)"
+DEFAULT_PROBE_MODEL = "claude-haiku-4-5-20251001"
+DEFAULT_PROBE_PROMPT = "hi"
+DEFAULT_TIMEOUT_SECONDS = 15
+EXHAUSTED_THRESHOLD = 0.95
+
+# Suffix patterns matched case-insensitively against header names. Keeping
+# these as suffixes (not full names) makes the parser resilient to any
+# rename of the ``anthropic-ratelimit-tokens-*`` prefix segment (for
+# example, a future ``anthropic-ratelimit-input-tokens-7d-utilization``
+# would still match ``-7d-utilization``).
+HEADER_SUFFIX_5H_UTIL = "-5h-utilization"
+HEADER_SUFFIX_7D_UTIL = "-7d-utilization"
+HEADER_SUFFIX_7D_RESET = "-7d-reset"
+HEADER_SUFFIX_5H_STATUS = "-5h-status"
+
+# Module-level "have we logged the full header set yet" flag. We log on the
+# first SUCCESSFUL probe so users can see which headers Anthropic is
+# actually sending without stamping the screen with stack traces from
+# error responses.
+_FIRST_RUN_HEADERS_LOGGED = False
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AccountResult:
+    """Per-account probe result."""
+
+    name: str
+    status: str  # available | exhausted | rate_limited | blocked | error | skipped
+    s5h_utilization: float | None = None
+    s7d_utilization: float | None = None
+    s7d_reset: str | None = None
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "name": self.name,
+            "status": self.status,
+            "5h_utilization": self.s5h_utilization,
+            "7d_utilization": self.s7d_utilization,
+            "7d_reset": self.s7d_reset,
+        }
+        if self.error:
+            out["error"] = self.error
+        return out
+
+
+@dataclass
+class ProbeReport:
+    """Aggregate probe report across all accounts."""
+
+    ranked_at: str
+    accounts: list[AccountResult] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ranked_at": self.ranked_at,
+            "accounts": [a.to_dict() for a in self.accounts],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Token discovery (ties into #3234's bootstrap output)
+# ---------------------------------------------------------------------------
+
+
+def discover_tokens(tokens_dir: Path) -> list[tuple[str, str]]:
+    """Return ``[(account_name, token), ...]`` for bootstrapped accounts.
+
+    Reads every ``*.token`` file in *tokens_dir* and skips entries listed
+    in ``.bad_tokens`` (one account name per line, ``#`` comments allowed).
+    Skipped accounts are returned with an empty token string so callers
+    can still emit them as ``status: blocked`` in the ranking — that way
+    #3235's selector knows not to attempt them.
+    """
+    if not tokens_dir.is_dir():
+        return []
+
+    bad: set[str] = set()
+    bad_file = tokens_dir / ".bad_tokens"
+    if bad_file.is_file():
+        for raw in bad_file.read_text().splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            bad.add(line)
+
+    tokens: list[tuple[str, str]] = []
+    for path in sorted(tokens_dir.glob("*.token")):
+        name = path.stem
+        if name in bad:
+            tokens.append((name, ""))  # signal: known-bad, do not probe
+            continue
+        try:
+            token = path.read_text().strip()
+        except OSError:
+            continue
+        if token:
+            tokens.append((name, token))
+    return tokens
+
+
+# ---------------------------------------------------------------------------
+# Header parsing
+# ---------------------------------------------------------------------------
+
+
+def _find_header_by_suffix(
+    headers: dict[str, str] | Any, suffix: str
+) -> str | None:
+    """Case-insensitive header lookup by suffix.
+
+    Iterates header names rather than indexing because we want pattern
+    matching on the name, not exact match. Works with both ``dict`` and
+    ``requests.structures.CaseInsensitiveDict`` (both expose ``.items()``).
+    """
+    suffix_lower = suffix.lower()
+    for name, value in headers.items():
+        if name.lower().endswith(suffix_lower):
+            return value
+    return None
+
+
+def _parse_float(raw: str | None) -> float | None:
+    if raw is None:
+        return None
+    try:
+        return float(raw.strip())
+    except (ValueError, AttributeError):
+        return None
+
+
+def _epoch_to_iso(raw: str | None) -> str | None:
+    """Convert an integer-seconds reset timestamp to ISO-8601 UTC.
+
+    The 7d-reset header is delivered as a unix timestamp (seconds since
+    epoch). Some providers serialise it as a float; normalise both. If
+    parsing fails we return the raw string so downstream code can still
+    inspect it.
+    """
+    if raw is None:
+        return None
+    raw = raw.strip()
+    if not raw:
+        return None
+    try:
+        ts = float(raw)
+    except ValueError:
+        return raw  # already ISO-8601 or unparseable — pass through
+    try:
+        return datetime.fromtimestamp(ts, tz=timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+    except (OverflowError, OSError, ValueError):
+        return raw
+
+
+def parse_rate_limit_headers(headers: dict[str, str] | Any) -> dict[str, Any]:
+    """Extract rate-limit fields from a response headers mapping.
+
+    Returns a dict with ``5h_utilization``, ``7d_utilization``,
+    ``7d_reset`` (ISO-8601), and ``5h_status``. Missing fields are
+    ``None``.
+    """
+    return {
+        "5h_utilization": _parse_float(
+            _find_header_by_suffix(headers, HEADER_SUFFIX_5H_UTIL)
+        ),
+        "7d_utilization": _parse_float(
+            _find_header_by_suffix(headers, HEADER_SUFFIX_7D_UTIL)
+        ),
+        "7d_reset": _epoch_to_iso(
+            _find_header_by_suffix(headers, HEADER_SUFFIX_7D_RESET)
+        ),
+        "5h_status": _find_header_by_suffix(headers, HEADER_SUFFIX_5H_STATUS),
+    }
+
+
+def _maybe_log_first_run_headers(headers: Any) -> None:
+    """Log the full header set on the first successful probe.
+
+    Idempotent across multiple calls in the same process. We log to
+    stderr (via ``logger.info``) so JSON-mode stdout output is not
+    polluted.
+    """
+    global _FIRST_RUN_HEADERS_LOGGED
+    if _FIRST_RUN_HEADERS_LOGGED:
+        return
+    _FIRST_RUN_HEADERS_LOGGED = True
+    try:
+        names = sorted(name for name, _ in headers.items())
+    except Exception:  # pragma: no cover — defensive
+        return
+    rl_names = [n for n in names if "ratelimit" in n.lower()]
+    logger.info("Anthropic API response header set (first probe of run):")
+    for n in names:
+        logger.info("  %s", n)
+    if rl_names:
+        logger.info("Rate-limit headers detected: %d", len(rl_names))
+
+
+# ---------------------------------------------------------------------------
+# HTTP probe
+# ---------------------------------------------------------------------------
+
+
+def _build_headers(token: str) -> dict[str, str]:
+    """Return the right header set for *token*.
+
+    OAuth tokens (``sk-ant-oat01-*``) use ``Authorization: Bearer`` plus
+    ``anthropic-beta``. API keys (``sk-ant-api*``) use ``x-api-key``.
+    The token-prefix sniff matches Anthropic's own convention; if it's
+    wrong for a given account, the result is a 401 and the account
+    ends up as ``blocked`` (which is the right behaviour: the token
+    can't be used).
+    """
+    base: dict[str, str] = {
+        "anthropic-version": ANTHROPIC_VERSION,
+        "content-type": "application/json",
+        "user-agent": USER_AGENT,
+    }
+    if token.startswith("sk-ant-oat"):
+        base["authorization"] = f"Bearer {token}"
+        base["anthropic-beta"] = ANTHROPIC_OAUTH_BETA
+    else:
+        # Plain API key (or unknown shape — fall through to x-api-key,
+        # which is the historical default).
+        base["x-api-key"] = token
+    return base
+
+
+def probe_account(
+    name: str,
+    token: str,
+    *,
+    model: str = DEFAULT_PROBE_MODEL,
+    probe_prompt: str = DEFAULT_PROBE_PROMPT,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    session: requests.Session | None = None,
+) -> AccountResult:
+    """Probe a single account, returning an AccountResult.
+
+    Probe failures (network errors, 5xx, timeout) are mapped to
+    ``status="error"`` with a description in ``error``; they DO NOT
+    raise. 401 -> blocked, 429 -> rate_limited.
+    """
+    if not token:
+        # known-bad token (in .bad_tokens) — surface for selector visibility
+        return AccountResult(name=name, status="blocked", error="bad_token_listed")
+
+    body = {
+        "model": model,
+        "max_tokens": 1,
+        "messages": [{"role": "user", "content": probe_prompt}],
+    }
+    headers = _build_headers(token)
+
+    sess = session or requests
+    try:
+        resp = sess.post(
+            ANTHROPIC_MESSAGES_URL,
+            headers=headers,
+            json=body,
+            timeout=timeout,
+        )
+    except requests.Timeout:
+        logger.warning("probe %s: timeout after %ss", name, timeout)
+        return AccountResult(name=name, status="error", error="timeout")
+    except requests.ConnectionError as exc:
+        logger.warning("probe %s: connection error: %s", name, exc)
+        return AccountResult(name=name, status="error", error=f"connection: {exc}")
+    except requests.RequestException as exc:
+        logger.warning("probe %s: request exception: %s", name, exc)
+        return AccountResult(name=name, status="error", error=str(exc))
+
+    code = resp.status_code
+
+    if code == 401:
+        return AccountResult(name=name, status="blocked", error="auth_401")
+
+    if code == 429:
+        # Even a 429 may include rate-limit headers; capture them.
+        parsed = parse_rate_limit_headers(resp.headers)
+        return AccountResult(
+            name=name,
+            status="rate_limited",
+            s5h_utilization=parsed["5h_utilization"],
+            s7d_utilization=parsed["7d_utilization"],
+            s7d_reset=parsed["7d_reset"],
+        )
+
+    if code >= 500:
+        logger.warning("probe %s: upstream %d", name, code)
+        return AccountResult(
+            name=name, status="error", error=f"http_{code}"
+        )
+
+    if code >= 400:
+        # 4xx other than 401/429 — probe payload was bad. Treat as error
+        # so the selector can still try the account, but log loudly.
+        logger.warning("probe %s: client error %d: %s", name, code, resp.text[:200])
+        return AccountResult(
+            name=name, status="error", error=f"http_{code}"
+        )
+
+    # 2xx — successful probe. Log header set on first run.
+    _maybe_log_first_run_headers(resp.headers)
+
+    parsed = parse_rate_limit_headers(resp.headers)
+    s7d_util = parsed["7d_utilization"]
+
+    if s7d_util is not None and s7d_util >= EXHAUSTED_THRESHOLD:
+        status = "exhausted"
+    else:
+        status = "available"
+
+    return AccountResult(
+        name=name,
+        status=status,
+        s5h_utilization=parsed["5h_utilization"],
+        s7d_utilization=parsed["7d_utilization"],
+        s7d_reset=parsed["7d_reset"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Ranking + atomic write
+# ---------------------------------------------------------------------------
+
+
+_STATUS_RANK = {
+    "available": 0,
+    "rate_limited": 1,
+    "exhausted": 2,
+    "blocked": 3,
+    "error": 4,
+    "skipped": 5,
+}
+
+
+def _sort_key(account: AccountResult) -> tuple[int, str]:
+    """Ranking sort: available first, then by 7d_reset ascending.
+
+    Accounts without a reset timestamp sort last within their status
+    bucket. ``error``/``skipped`` accounts stay at the bottom so they
+    are tried last, not first.
+    """
+    rank = _STATUS_RANK.get(account.status, 99)
+    reset = account.s7d_reset or "9999-12-31T23:59:59Z"
+    return (rank, reset)
+
+
+def build_report(results: Iterable[AccountResult]) -> ProbeReport:
+    """Build a sorted ProbeReport from probe results."""
+    ranked_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    sorted_results = sorted(results, key=_sort_key)
+    return ProbeReport(ranked_at=ranked_at, accounts=sorted_results)
+
+
+def write_ranking_atomic(report: ProbeReport, ranking_path: Path) -> None:
+    """Write *report* to *ranking_path* atomically.
+
+    Writes to ``<path>.tmp`` in the same directory (so the rename is on
+    the same filesystem and uses ``rename(2)``), then ``Path.replace``s
+    onto the target. This guarantees readers see either the old file or
+    the new file, never a partial.
+    """
+    ranking_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = ranking_path.with_suffix(ranking_path.suffix + ".tmp")
+    tmp.write_text(json.dumps(report.to_dict(), indent=2) + "\n")
+    tmp.replace(ranking_path)
+
+
+# ---------------------------------------------------------------------------
+# Run + report formatting
+# ---------------------------------------------------------------------------
+
+
+def run_check(
+    tokens_dir: Path,
+    *,
+    write_ranking: bool = False,
+    probe_prompt: str = DEFAULT_PROBE_PROMPT,
+    model: str = DEFAULT_PROBE_MODEL,
+    stagger: bool = True,
+    session: requests.Session | None = None,
+) -> ProbeReport:
+    """Probe all accounts and (optionally) write ``.ranking``.
+
+    Probes are issued sequentially with 0.5-1.5s jitter between them
+    (lean-genius pattern) when *stagger* is true. Tests can pass
+    ``stagger=False`` to skip the sleep.
+    """
+    pairs = discover_tokens(tokens_dir)
+    if not pairs:
+        logger.warning("no tokens found in %s", tokens_dir)
+
+    results: list[AccountResult] = []
+    for i, (name, token) in enumerate(pairs):
+        if i > 0 and stagger and token:
+            time.sleep(0.5 + random.random())
+        result = probe_account(
+            name,
+            token,
+            probe_prompt=probe_prompt,
+            model=model,
+            session=session,
+        )
+        results.append(result)
+
+    report = build_report(results)
+
+    if write_ranking:
+        ranking_path = tokens_dir / ".ranking"
+        write_ranking_atomic(report, ranking_path)
+        logger.info(
+            "wrote ranking to %s (%d accounts)",
+            ranking_path,
+            len(report.accounts),
+        )
+
+    return report
+
+
+def format_table(report: ProbeReport) -> str:
+    """Human-readable status table, sorted with best accounts first."""
+    lines: list[str] = []
+    lines.append(f"Token pool ranking (probed at {report.ranked_at})")
+    lines.append("=" * 78)
+    lines.append(
+        f"{'Account':<28} {'5h util':>9} {'7d util':>9} {'Status':<13} {'7d resets':<22}"
+    )
+    lines.append("-" * 78)
+    for a in report.accounts:
+        s5 = f"{a.s5h_utilization:.2f}" if a.s5h_utilization is not None else "-"
+        s7 = f"{a.s7d_utilization:.2f}" if a.s7d_utilization is not None else "-"
+        reset = a.s7d_reset or "-"
+        lines.append(
+            f"{a.name:<28} {s5:>9} {s7:>9} {a.status:<13} {reset:<22}"
+        )
+
+    counts: dict[str, int] = {}
+    for a in report.accounts:
+        counts[a.status] = counts.get(a.status, 0) + 1
+    summary = ", ".join(f"{n} {s}" for s, n in sorted(counts.items()))
+    lines.append("")
+    lines.append(f"Total {len(report.accounts)}: {summary}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI dispatch lives in ``loom_tools.tokens.cli`` (alongside the bootstrap
+# subcommand from #3234). This module exposes the building blocks
+# (``run_check``, ``format_table``, ``DEFAULT_PROBE_PROMPT``) that the
+# dispatcher composes.
+# ---------------------------------------------------------------------------

--- a/loom-tools/src/loom_tools/tokens/cli.py
+++ b/loom-tools/src/loom_tools/tokens/cli.py
@@ -1,22 +1,35 @@
 """CLI entry point for ``loom-tokens``.
 
-Currently exposes a single subcommand, ``bootstrap``, which materializes
-the ``.loom/tokens/`` pool from ``.env``. Additional subcommands (status,
-allowlist, ranking sync, etc.) can be added later without breaking the
-top-level surface — the dispatch table mirrors
-``loom_tools.shepherd.cli``.
+Subcommands:
+
+* ``bootstrap`` (#3234) — materialize ``.loom/tokens/`` from
+  ``ACCOUNT_*_N`` triples in ``.env``.
+* ``check`` (#3237) — probe each bootstrapped account for rate-limit
+  headers and (optionally) write ``.loom/tokens/.ranking`` for the
+  spawn-time selector (#3235).
+
+Additional subcommands (status, allowlist, ranking sync, etc.) can be
+added later without breaking the top-level surface — the dispatch
+table mirrors ``loom_tools.shepherd.cli``.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import logging
+import os
 import sys
 from pathlib import Path
 
 from loom_tools.common.logging import log_error
 from loom_tools.common.repo import find_repo_root
 from loom_tools.tokens.bootstrap import bootstrap_tokens
+from loom_tools.tokens.check import (
+    DEFAULT_PROBE_PROMPT,
+    format_table,
+    run_check,
+)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -53,6 +66,42 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Emit a JSON summary on stdout (in addition to log lines).",
     )
 
+    cp = sub.add_parser(
+        "check",
+        help=(
+            "Probe each bootstrapped account for rate-limit headers and "
+            "rank by available quota."
+        ),
+    )
+    cp.add_argument(
+        "--ranking",
+        action="store_true",
+        help=(
+            "Write .loom/tokens/.ranking atomically (consumed by the spawn "
+            "wrapper, #3235)."
+        ),
+    )
+    cp.add_argument(
+        "--probe-prompt",
+        type=str,
+        default=DEFAULT_PROBE_PROMPT,
+        help=(
+            f"Override the probe prompt (default {DEFAULT_PROBE_PROMPT!r}). "
+            "The probe always uses max_tokens=1 regardless of prompt."
+        ),
+    )
+    cp.add_argument(
+        "--json",
+        dest="emit_json",
+        action="store_true",
+        help="Emit the full report as JSON to stdout (instead of a human table).",
+    )
+    cp.add_argument(
+        "--no-stagger",
+        action="store_true",
+        help="Skip the 0.5-1.5s jitter between probes (mostly for tests).",
+    )
+
     return parser
 
 
@@ -63,6 +112,8 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "bootstrap":
         return _cmd_bootstrap(args)
+    if args.command == "check":
+        return _cmd_check(args)
 
     # argparse `required=True` should make this unreachable.
     parser.print_help(sys.stderr)
@@ -97,6 +148,50 @@ def _cmd_bootstrap(args: argparse.Namespace) -> int:
     # can detect divergence.
     if result.drifted and not args.force:
         return 2
+    return 0
+
+
+def _cmd_check(args: argparse.Namespace) -> int:
+    """Handle ``loom-tokens check``."""
+    # Configure logging on stderr so --json stdout output is clean.
+    if not logging.getLogger("loom_tools.tokens.check").handlers:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(levelname)s %(message)s",
+            stream=sys.stderr,
+        )
+
+    # Resolve tokens dir. Prefer LOOM_TOKENS_DIR for tests, else
+    # <repo-root>/.loom/tokens (matching where bootstrap writes).
+    env_dir = os.environ.get("LOOM_TOKENS_DIR")
+    if env_dir:
+        tokens_dir = Path(env_dir)
+    else:
+        try:
+            repo_root = find_repo_root()
+        except FileNotFoundError as exc:
+            log_error(str(exc))
+            return 1
+        tokens_dir = repo_root / ".loom" / "tokens"
+
+    report = run_check(
+        tokens_dir,
+        write_ranking=args.ranking,
+        probe_prompt=args.probe_prompt,
+        stagger=not args.no_stagger,
+    )
+
+    if args.emit_json:
+        json.dump(report.to_dict(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    else:
+        print(format_table(report))
+
+    # Exit 0 unless every probe failed (then 1 — selector has nothing usable)
+    if report.accounts and all(
+        a.status in ("error", "skipped") for a in report.accounts
+    ):
+        return 1
     return 0
 
 

--- a/loom-tools/tests/tokens/test_check.py
+++ b/loom-tools/tests/tokens/test_check.py
@@ -1,0 +1,393 @@
+"""Tests for loom_tools.tokens.check (issue #3237).
+
+Mocks Anthropic API responses with ``unittest.mock.patch`` rather than
+hitting the live API. Covers:
+
+* Header parsing (resilient suffix match, including renamed prefixes).
+* Status assignment for 200/401/429/5xx and timeouts.
+* Ranking sort + atomic write semantics.
+* ``.bad_tokens`` skip behavior surfaces ``status: blocked``.
+* OAuth header selection by token prefix.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from loom_tools.tokens import check as check_mod
+from loom_tools.tokens.check import (
+    AccountResult,
+    EXHAUSTED_THRESHOLD,
+    ProbeReport,
+    _build_headers,
+    _epoch_to_iso,
+    _find_header_by_suffix,
+    build_report,
+    discover_tokens,
+    parse_rate_limit_headers,
+    probe_account,
+    run_check,
+    write_ranking_atomic,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_response(
+    status_code: int = 200,
+    headers: dict[str, str] | None = None,
+    text: str = "",
+) -> MagicMock:
+    """Build a fake ``requests.Response``."""
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status_code
+    resp.headers = headers or {}
+    resp.text = text
+    return resp
+
+
+@pytest.fixture(autouse=True)
+def _reset_first_run_flag():
+    """Reset the module-level "have we logged headers yet" flag per-test."""
+    check_mod._FIRST_RUN_HEADERS_LOGGED = False
+    yield
+    check_mod._FIRST_RUN_HEADERS_LOGGED = False
+
+
+# ---------------------------------------------------------------------------
+# Header parser
+# ---------------------------------------------------------------------------
+
+
+class TestHeaderParser:
+    def test_suffix_match_canonical(self):
+        headers = {
+            "anthropic-ratelimit-tokens-5h-utilization": "0.42",
+            "anthropic-ratelimit-tokens-7d-utilization": "0.10",
+            "anthropic-ratelimit-tokens-7d-reset": "1762070400",
+        }
+        parsed = parse_rate_limit_headers(headers)
+        assert parsed["5h_utilization"] == pytest.approx(0.42)
+        assert parsed["7d_utilization"] == pytest.approx(0.10)
+        assert parsed["7d_reset"] == "2025-11-02T08:00:00Z"
+
+    def test_suffix_match_after_rename(self):
+        # Future rename: prefix becomes ``anthropic-ratelimit-input-tokens-*``.
+        # Suffix-only matching still picks it up.
+        headers = {
+            "anthropic-ratelimit-input-tokens-5h-utilization": "0.55",
+            "anthropic-ratelimit-input-tokens-7d-utilization": "0.91",
+            "anthropic-ratelimit-input-tokens-7d-reset": "1762070400",
+        }
+        parsed = parse_rate_limit_headers(headers)
+        assert parsed["5h_utilization"] == pytest.approx(0.55)
+        assert parsed["7d_utilization"] == pytest.approx(0.91)
+
+    def test_case_insensitive(self):
+        headers = {
+            "Anthropic-RateLimit-Tokens-5H-Utilization": "0.30",
+        }
+        assert parse_rate_limit_headers(headers)["5h_utilization"] == pytest.approx(
+            0.30
+        )
+
+    def test_missing_headers_return_none(self):
+        parsed = parse_rate_limit_headers({"x-request-id": "abc"})
+        assert parsed["5h_utilization"] is None
+        assert parsed["7d_utilization"] is None
+        assert parsed["7d_reset"] is None
+
+    def test_unparseable_float(self):
+        parsed = parse_rate_limit_headers(
+            {"anthropic-ratelimit-tokens-5h-utilization": "not-a-number"}
+        )
+        assert parsed["5h_utilization"] is None
+
+    def test_iso_reset_passthrough(self):
+        # If Anthropic ever sends ISO-8601 instead of epoch, pass through.
+        parsed = parse_rate_limit_headers(
+            {"anthropic-ratelimit-tokens-7d-reset": "2026-05-09T00:00:00Z"}
+        )
+        assert parsed["7d_reset"] == "2026-05-09T00:00:00Z"
+
+    def test_find_header_by_suffix_returns_none_when_absent(self):
+        assert _find_header_by_suffix({}, "-5h-utilization") is None
+
+    def test_epoch_zero(self):
+        # Edge case: explicit "0" reset (lean-genius treats as missing)
+        # Our parser converts to epoch 1970-01-01; downstream sort treats
+        # this as "very old" which is fine for ranking purposes.
+        result = _epoch_to_iso("0")
+        assert result == "1970-01-01T00:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# Auth header selection
+# ---------------------------------------------------------------------------
+
+
+class TestAuthHeaders:
+    def test_oauth_token_uses_bearer(self):
+        h = _build_headers("sk-ant-oat01-abc123")
+        assert h["authorization"] == "Bearer sk-ant-oat01-abc123"
+        assert "x-api-key" not in h
+        assert h["anthropic-beta"] == check_mod.ANTHROPIC_OAUTH_BETA
+
+    def test_api_key_uses_x_api_key(self):
+        h = _build_headers("sk-ant-api03-xyz")
+        assert h["x-api-key"] == "sk-ant-api03-xyz"
+        assert "authorization" not in h
+        assert "anthropic-beta" not in h
+
+
+# ---------------------------------------------------------------------------
+# Probe — status mapping
+# ---------------------------------------------------------------------------
+
+
+def _good_headers(s7d: float = 0.30, s5h: float = 0.10) -> dict[str, str]:
+    return {
+        "anthropic-ratelimit-tokens-5h-utilization": str(s5h),
+        "anthropic-ratelimit-tokens-7d-utilization": str(s7d),
+        "anthropic-ratelimit-tokens-7d-reset": "1762070400",
+    }
+
+
+class TestProbeStatuses:
+    def test_200_available(self):
+        with patch("requests.post", return_value=_mock_response(200, _good_headers())):
+            r = probe_account("agent-1", "sk-ant-oat01-x")
+        assert r.status == "available"
+        assert r.s7d_utilization == pytest.approx(0.30)
+        assert r.s7d_reset == "2025-11-02T08:00:00Z"
+
+    def test_200_exhausted_when_7d_high(self):
+        with patch(
+            "requests.post",
+            return_value=_mock_response(200, _good_headers(s7d=0.97)),
+        ):
+            r = probe_account("agent-1", "sk-ant-oat01-x")
+        assert r.status == "exhausted"
+
+    def test_200_at_threshold(self):
+        with patch(
+            "requests.post",
+            return_value=_mock_response(
+                200, _good_headers(s7d=EXHAUSTED_THRESHOLD)
+            ),
+        ):
+            r = probe_account("agent-1", "sk-ant-oat01-x")
+        assert r.status == "exhausted"
+
+    def test_401_blocked(self):
+        with patch("requests.post", return_value=_mock_response(401)):
+            r = probe_account("agent-1", "sk-ant-oat01-x")
+        assert r.status == "blocked"
+        assert r.error == "auth_401"
+
+    def test_429_rate_limited(self):
+        with patch(
+            "requests.post",
+            return_value=_mock_response(429, _good_headers(s7d=0.20)),
+        ):
+            r = probe_account("agent-1", "sk-ant-oat01-x")
+        assert r.status == "rate_limited"
+        # Rate-limit headers still captured even on 429.
+        assert r.s7d_utilization == pytest.approx(0.20)
+
+    def test_503_error_not_fatal(self):
+        with patch("requests.post", return_value=_mock_response(503)):
+            r = probe_account("agent-1", "sk-ant-oat01-x")
+        assert r.status == "error"
+        assert "503" in r.error
+
+    def test_timeout_not_fatal(self):
+        with patch("requests.post", side_effect=requests.Timeout()):
+            r = probe_account("agent-1", "sk-ant-oat01-x")
+        assert r.status == "error"
+        assert r.error == "timeout"
+
+    def test_connection_error_not_fatal(self):
+        with patch(
+            "requests.post", side_effect=requests.ConnectionError("dns failure")
+        ):
+            r = probe_account("agent-1", "sk-ant-oat01-x")
+        assert r.status == "error"
+        assert "connection" in r.error
+
+    def test_empty_token_returns_blocked(self):
+        # .bad_tokens-listed accounts arrive with empty token strings.
+        r = probe_account("agent-bad", "")
+        assert r.status == "blocked"
+        assert r.error == "bad_token_listed"
+
+
+# ---------------------------------------------------------------------------
+# Token discovery + .bad_tokens
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverTokens:
+    def test_lists_tokens(self, tmp_path: Path):
+        (tmp_path / "agent-1.token").write_text("sk-ant-oat01-aaa\n")
+        (tmp_path / "agent-2.token").write_text("sk-ant-oat01-bbb\n")
+        results = discover_tokens(tmp_path)
+        assert {n for n, _ in results} == {"agent-1", "agent-2"}
+        assert all(t.startswith("sk-ant-oat01-") for _, t in results)
+
+    def test_skips_bad_tokens(self, tmp_path: Path):
+        (tmp_path / "agent-1.token").write_text("sk-ant-oat01-aaa\n")
+        (tmp_path / "agent-2.token").write_text("sk-ant-oat01-bbb\n")
+        (tmp_path / ".bad_tokens").write_text(
+            "# comment line\nagent-2\n\n"  # blank line + comment ignored
+        )
+        results = discover_tokens(tmp_path)
+        names = {n for n, _ in results}
+        assert names == {"agent-1", "agent-2"}
+        # bad token is surfaced with empty string -> probe returns "blocked"
+        agent_2 = next(t for n, t in results if n == "agent-2")
+        assert agent_2 == ""
+
+    def test_missing_dir_returns_empty(self, tmp_path: Path):
+        assert discover_tokens(tmp_path / "does-not-exist") == []
+
+    def test_empty_token_file_skipped(self, tmp_path: Path):
+        (tmp_path / "agent-empty.token").write_text("\n")
+        (tmp_path / "agent-real.token").write_text("sk-ant-oat01-x\n")
+        results = discover_tokens(tmp_path)
+        assert {n for n, _ in results} == {"agent-real"}
+
+
+# ---------------------------------------------------------------------------
+# Ranking sort + atomic write
+# ---------------------------------------------------------------------------
+
+
+class TestRanking:
+    def test_sort_available_first_then_by_reset(self):
+        results = [
+            AccountResult(
+                "exhausted-1", "exhausted", s7d_reset="2026-05-09T00:00:00Z"
+            ),
+            AccountResult(
+                "fresh", "available", s7d_reset="2026-05-08T00:00:00Z"
+            ),
+            AccountResult(
+                "older", "available", s7d_reset="2026-05-05T00:00:00Z"
+            ),
+            AccountResult("blocked-1", "blocked"),
+            AccountResult("rl-1", "rate_limited", s7d_reset="2026-05-07T00:00:00Z"),
+        ]
+        report = build_report(results)
+        ordered = [a.name for a in report.accounts]
+        assert ordered == ["older", "fresh", "rl-1", "exhausted-1", "blocked-1"]
+
+    def test_atomic_write_creates_file(self, tmp_path: Path):
+        report = ProbeReport(
+            ranked_at="2026-05-03T00:00:00Z",
+            accounts=[AccountResult("a-1", "available")],
+        )
+        target = tmp_path / "tokens" / ".ranking"
+        write_ranking_atomic(report, target)
+        assert target.exists()
+        data = json.loads(target.read_text())
+        assert data["accounts"][0]["name"] == "a-1"
+        assert data["ranked_at"] == "2026-05-03T00:00:00Z"
+
+    def test_atomic_write_no_partial_file(self, tmp_path: Path):
+        # Verify that the temp file is renamed (no stray .tmp left behind on
+        # success). This is the visible side-effect of using Path.replace().
+        target = tmp_path / ".ranking"
+        report = ProbeReport(ranked_at="2026-05-03T00:00:00Z", accounts=[])
+        write_ranking_atomic(report, target)
+        assert target.exists()
+        assert not target.with_suffix(target.suffix + ".tmp").exists()
+
+    def test_atomic_write_overwrites_existing(self, tmp_path: Path):
+        target = tmp_path / ".ranking"
+        target.write_text("old contents")
+        report = ProbeReport(
+            ranked_at="2026-05-03T00:00:00Z",
+            accounts=[AccountResult("new", "available")],
+        )
+        write_ranking_atomic(report, target)
+        data = json.loads(target.read_text())
+        assert data["accounts"][0]["name"] == "new"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end run_check
+# ---------------------------------------------------------------------------
+
+
+class TestRunCheck:
+    def test_skipped_account_propagates_to_ranking(self, tmp_path: Path):
+        (tmp_path / "agent-1.token").write_text("sk-ant-oat01-good")
+        (tmp_path / "agent-bad.token").write_text("sk-ant-oat01-bad")
+        (tmp_path / ".bad_tokens").write_text("agent-bad\n")
+
+        with patch(
+            "requests.post",
+            return_value=_mock_response(200, _good_headers(s7d=0.20)),
+        ):
+            report = run_check(tmp_path, write_ranking=True, stagger=False)
+
+        names_status = {a.name: a.status for a in report.accounts}
+        assert names_status["agent-1"] == "available"
+        assert names_status["agent-bad"] == "blocked"
+
+        ranking = json.loads((tmp_path / ".ranking").read_text())
+        assert {a["name"] for a in ranking["accounts"]} == {"agent-1", "agent-bad"}
+
+    def test_one_failure_does_not_kill_run(self, tmp_path: Path):
+        # Tokens are probed in sorted-name order (a-good, z-bad).
+        (tmp_path / "a-good.token").write_text("sk-ant-oat01-good")
+        (tmp_path / "z-bad.token").write_text("sk-ant-oat01-times-out")
+
+        call_count = {"n": 0}
+
+        def fake_post(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return _mock_response(200, _good_headers())
+            raise requests.Timeout()
+
+        with patch("requests.post", side_effect=fake_post):
+            report = run_check(tmp_path, write_ranking=False, stagger=False)
+
+        statuses = {a.name: a.status for a in report.accounts}
+        assert statuses["a-good"] == "available"
+        assert statuses["z-bad"] == "error"
+
+    def test_first_run_logs_headers(self, tmp_path: Path, caplog):
+        (tmp_path / "a.token").write_text("sk-ant-oat01-a")
+        with patch(
+            "requests.post",
+            return_value=_mock_response(200, _good_headers()),
+        ):
+            with caplog.at_level("INFO", logger="loom_tools.tokens.check"):
+                run_check(tmp_path, write_ranking=False, stagger=False)
+        joined = "\n".join(rec.message for rec in caplog.records)
+        assert "header set" in joined
+        # Subsequent probes do not re-log
+        caplog.clear()
+        with patch(
+            "requests.post",
+            return_value=_mock_response(200, _good_headers()),
+        ):
+            with caplog.at_level("INFO", logger="loom_tools.tokens.check"):
+                run_check(tmp_path, write_ranking=False, stagger=False)
+        joined2 = "\n".join(rec.message for rec in caplog.records)
+        assert "header set" not in joined2
+
+    def test_empty_pool_returns_empty_report(self, tmp_path: Path):
+        report = run_check(tmp_path, write_ranking=False, stagger=False)
+        assert report.accounts == []


### PR DESCRIPTION
Closes #3237

## Summary

Implements the token rotation account health probe + ranking stage (#3237). New `loom-tokens check` CLI probes each bootstrapped OAuth account via a minimal Anthropic Messages request, parses rate-limit response headers, and atomically writes a JSON ranking that #3235's selector consumes.

## What's in the PR

- `loom-tools/src/loom_tools/tokens/check.py` - probe + parse + ranking logic
- `loom-tools/src/loom_tools/cli/loom_tokens.py` - hand-rolled subcommand dispatch (mirrors `forge_cli.py:398-446`)
- `loom-tools/pyproject.toml` - `loom-tokens` console script entry point
- `defaults/scripts/probe-tokens.sh` - cron-friendly wrapper modeled on `check-usage.sh`
- `loom-tools/tests/tokens/test_check.py` - 31 tests, all passing
- `CLAUDE.md` - new Multi-Account Token Rotation section

## Key design choices

- Header parser matches by suffix (`-5h-utilization`, `-7d-utilization`, `-7d-reset`, `-5h-status`) - survives prefix renames. Full header set logged on first probe.
- OAuth vs API key auth auto-detected by token prefix: `sk-ant-oat01-*` -> Bearer + anthropic-beta; plain keys -> x-api-key.
- Atomic write via `Path.replace()` (POSIX rename(2)); same-dir tmp avoids EXDEV.
- Probe failures (network/timeout/5xx) logged and skipped, not fatal. 401->blocked, 429->rate_limited, 7d_util>=0.95->exhausted, else available.
- `.bad_tokens` accounts surface as `status: blocked` so selector avoids them without an API call.

## Curator concerns addressed

- Pattern made explicit via `HEADER_SUFFIX_*` constants.
- `--probe-prompt` documented and tested.
- `.bad_tokens` skip behavior covered in tests.

## Dependencies

Independent of #3234 (bootstrap) and #3235 (selector). No expected merge conflicts.

## Test plan

- [x] Unit: header parsing including renamed prefix
- [x] Unit: 200/401/429/503/timeout/connection error -> correct status
- [x] Unit: ranking write is atomic
- [x] Unit: `.bad_tokens` -> blocked
- [x] Unit: empty pool returns empty report
- [x] Manual: end-to-end CLI run