### PR TITLE
feat: token rotation wrapper + selection algorithm (#3235)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -617,6 +617,55 @@ Loom provides a unified MCP server (`mcp-loom`) for programmatic control. See th
 mcp__loom__get_agent_metrics --command summary --period week
 ```
 
+## Token Rotation (Multi-Account Claude Code)
+
+For Pro/Max plans, Loom supports rotating between multiple Claude Code OAuth tokens. This spreads load across accounts and recovers automatically when a single token hits its weekly limit.
+
+### Setup
+
+1. Add account credentials to `.env` at the workspace root:
+   ```env
+   ACCOUNT_KEY_1=sk-ant-oat01-...
+   ACCOUNT_TOKEN_FILE_1=robb-personal.token
+   ACCOUNT_KEY_2=sk-ant-oat01-...
+   ACCOUNT_TOKEN_FILE_2=robb-work.token
+   ```
+2. Run `loom-tokens bootstrap` to materialize per-account `.token` files into `.loom/tokens/` (mode 0600, parent dir 0700). See issue #3234.
+3. Spawn agents through `.loom/scripts/spawn-claude.sh` instead of invoking `claude` directly. The wrapper selects a token using a 3-tier algorithm (ranking → allowlist → random), exports `CLAUDE_CODE_OAUTH_TOKEN`, then `exec`s `claude` (or pass `--use-wrapper` to layer on top of `claude-wrapper.sh` for retry behavior).
+
+### Selection algorithm (`loom_tools.tokens.select`)
+
+Three tiers, falling through to the next when the current tier yields nothing:
+
+1. **Ranking** — `.loom/tokens/.ranking` (pipe-delimited `name|status`, refreshed every <10 min). Picks the first non-`exhausted`/non-`blocked` token.
+2. **Allowlist** — `.loom/tokens/.allowlist` (one name per line). Random pick from allowed accounts.
+3. **Random** — uniform pick from all `*.token` files.
+
+Tokens marked bad in `.loom/tokens/.bad_tokens` are skipped at every tier.
+
+### Bad-token tracking (`loom_tools.tokens.bad_tokens`)
+
+When a token returns `TOKEN_EXPIRED` or `TOKEN_EXHAUSTED`, callers append an entry to `.loom/tokens/.bad_tokens`. Writes are guarded with a `mkdir`-based lock (POSIX-atomic, macOS-compatible — `flock` is **not** used because it isn't available on stock macOS). Reads use word-boundary regex so `agent-1` and `agent-10` don't collide.
+
+### Error classification (`.loom/scripts/lib/classify-error.sh`)
+
+The `classify_error <output> <exit_code>` function returns one of `SUCCESS`, `TIMEOUT`, `CWD_DELETED`, `TOKEN_EXPIRED`, `TOKEN_EXHAUSTED`, `RECOVERABLE`. Critical fix from #3233: exit code is checked **before** output substring matching — clean exits (`exit_code == 0`) always return `SUCCESS` regardless of stdout content. The previous lean-genius implementation returned `RECOVERABLE` for clean exits whose stdout contained substrings like `500` or `rate limit`.
+
+### Worktree handling
+
+When invoked from a worktree, `spawn-claude.sh` resolves the canonical repo root via `git rev-parse --git-common-dir` and locates `.loom/tokens/` there — never in the worktree's path. This avoids each worktree maintaining its own bad-tokens list.
+
+### Hard-fail on missing pool
+
+`spawn-claude.sh` exits `78` (`EX_CONFIG`) with a message instructing the user to run `loom-tokens bootstrap` when `.loom/tokens/` is absent or all tokens are bad. It does **not** silently fall back to keychain — that path belongs in `loom-daemon` (#3236), and only when token rotation has not been configured at all.
+
+### Tests
+
+```bash
+PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/tokens/ -v
+bash .loom/scripts/tests/test-spawn-claude.sh
+```
+
 ## Forge Authentication
 
 ### GitHub

--- a/defaults/scripts/lib/classify-error.sh
+++ b/defaults/scripts/lib/classify-error.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# classify-error.sh — Classify a (output, exit_code) pair into an error category.
+#
+# Source this file (do not exec). Defines a single function:
+#
+#   classify_error <output> <exit_code> -> echoes one of:
+#       SUCCESS         — exit 0 (regardless of output content)
+#       TIMEOUT         — exit 124/137 (productive cycle, not a failure)
+#       CWD_DELETED     — working directory was removed
+#       TOKEN_EXPIRED   — 401 / OAuth token expired (skip this token)
+#       TOKEN_EXHAUSTED — quota/weekly limit hit (rotate)
+#       RECOVERABLE     — transient (rate limit, 5xx, network, etc.)
+#       FATAL           — non-recoverable (currently never returned;
+#                         reserved for future explicit FATAL signals)
+#
+# Design — exit-code-first ordering:
+#   The original lean-genius implementation grepped output BEFORE checking
+#   the exit code, which caused false positives on clean exits whose stdout
+#   legitimately contained substrings like "500" or "rate limit" (issue
+#   #3233). This rewrite checks the exit code first and only inspects output
+#   for genuine failures (exit_code != 0).
+#
+# Test vectors live in `.loom/scripts/tests/test-spawn-claude.sh`.
+
+# shellcheck disable=SC2120  # OK that callers pass the args; we don't default.
+
+classify_error() {
+    local output="$1"
+    local exit_code="$2"
+
+    # 1. Timeout from the `timeout(1)` command — productive cycle, not error
+    if [[ "$exit_code" -eq 124 || "$exit_code" -eq 137 ]]; then
+        echo "TIMEOUT"
+        return
+    fi
+
+    # 2. Exit-code-first: a clean exit is SUCCESS regardless of output content.
+    #    This is the critical fix for #3233 — the previous implementation
+    #    returned RECOVERABLE for clean exits whose stdout contained "500",
+    #    "rate limit", or "No messages returned".
+    if [[ "$exit_code" -eq 0 ]]; then
+        echo "SUCCESS"
+        return
+    fi
+
+    # --- Below here, exit_code != 0 (genuine failure). Inspect output. ---
+
+    # Working directory deleted (worktree cleaned up while CLI ran)
+    if echo "$output" | grep -qi "current working directory was deleted"; then
+        echo "CWD_DELETED"
+        return
+    fi
+
+    # Token expired (401 auth error) — this specific token is bad
+    if echo "$output" | grep -qiE "401[^a-z]*authentication_error|OAuth token has expired|token has expired"; then
+        echo "TOKEN_EXPIRED"
+        return
+    fi
+
+    # Token exhausted (quota used up) — rotate to a different token
+    if echo "$output" | grep -qiE "hit your (limit|weekly limit)|hit.your.limit"; then
+        echo "TOKEN_EXHAUSTED"
+        return
+    fi
+
+    # Rate limit (429) — transient, retry with backoff
+    if echo "$output" | grep -qiE "rate.limit|too.many.requests|429"; then
+        echo "RECOVERABLE"
+        return
+    fi
+
+    # Server errors (5xx) — transient
+    if echo "$output" | grep -qiE "500|502|503|504|internal.server.error|service.unavailable"; then
+        echo "RECOVERABLE"
+        return
+    fi
+
+    # Network errors — transient
+    if echo "$output" | grep -qiE "ECONNREFUSED|ETIMEDOUT|network.error"; then
+        echo "RECOVERABLE"
+        return
+    fi
+
+    # "No messages returned" — transient API issue (only if exit_code != 0)
+    if echo "$output" | grep -q "No messages returned"; then
+        echo "RECOVERABLE"
+        return
+    fi
+
+    # Catch-all: unknown non-zero exit, treat as recoverable in daemon mode
+    echo "RECOVERABLE"
+}
+
+# Convenience predicate matching legacy callers in claude-wrapper.sh.
+is_recoverable_error() {
+    local classification
+    classification=$(classify_error "$1" "$2")
+    [[ "$classification" != "FATAL" && "$classification" != "SUCCESS" ]]
+}

--- a/defaults/scripts/spawn-claude.sh
+++ b/defaults/scripts/spawn-claude.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# spawn-claude.sh - Token-rotating launcher for Claude Code.
+#
+# This script is a thin layer that:
+#   1. Selects a Claude Code OAuth token from .loom/tokens/ via
+#      `python3 -m loom_tools.tokens.select`.
+#   2. Exports CLAUDE_CODE_OAUTH_TOKEN.
+#   3. exec's the underlying CLI (`claude` by default, or
+#      `claude-wrapper.sh` if --use-wrapper is passed for retry behavior).
+#
+# It does NOT replace the existing 1700-LOC `.loom/scripts/claude-wrapper.sh`,
+# which provides retry, backoff, auth-cache, and error classification.
+# Use `claude-wrapper.sh` directly when you need that behavior; use this
+# script when you want pure token rotation in front of either `claude` or
+# the wrapper.
+#
+# Behavior on missing tokens:
+#   When `.loom/tokens/` is absent, empty, or all tokens are bad, this script
+#   exits 78 (EX_CONFIG) with a message instructing the user to run
+#   `loom-tokens bootstrap`. It does NOT silently fall back to keychain.
+#
+# Worktree handling:
+#   When invoked from a git worktree, the script resolves the canonical repo
+#   root via `git rev-parse --git-common-dir` and looks up `.loom/tokens/`
+#   there — never in the worktree's path.
+#
+# Usage:
+#   .loom/scripts/spawn-claude.sh -p "your prompt"
+#   .loom/scripts/spawn-claude.sh --use-wrapper --prompt "..." --log /tmp/log
+#
+# Env vars:
+#   LOOM_WORKSPACE         Override repo root detection.
+#   LOOM_SPAWN_NO_EXPORT   If set, skip selection (caller already exported a
+#                          token). Useful for testing the dispatch path.
+#   LOOM_PYTHON            Override the python interpreter (default: python3).
+
+set -euo pipefail
+
+# --- Logging helpers (match loom convention) ---
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info() { echo -e "${BLUE}[$(date -u '+%Y-%m-%dT%H:%M:%SZ')]${NC} $*" >&2; }
+log_warn() { echo -e "${YELLOW}[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] WARN${NC} $*" >&2; }
+log_error() { echo -e "${RED}[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] ERROR${NC} $*" >&2; }
+
+# --- Repo root resolution (handles worktrees) ---
+# If LOOM_WORKSPACE is set, trust it. Otherwise:
+#   1. Try `git rev-parse --git-common-dir` to find the canonical .git dir
+#      (works inside main checkouts and worktrees alike).
+#   2. The parent of `.git` (or of the common dir if it's not literally .git)
+#      is the canonical repo root.
+#   3. Fallback: walk up from the script's directory.
+_resolve_workspace() {
+    if [[ -n "${LOOM_WORKSPACE:-}" ]]; then
+        printf '%s\n' "$LOOM_WORKSPACE"
+        return
+    fi
+
+    local git_common_dir
+    if git_common_dir="$(git rev-parse --git-common-dir 2>/dev/null)"; then
+        # `git rev-parse --git-common-dir` may return a relative path inside
+        # a worktree — convert to absolute, then take parent.
+        if [[ ! "$git_common_dir" = /* ]]; then
+            git_common_dir="$(cd "$git_common_dir" && pwd)"
+        fi
+        # If common-dir basename is `.git`, parent is repo root.
+        # Otherwise (linked worktree case), it's the literal main `.git/`
+        # directory — its parent is still the canonical main checkout.
+        printf '%s\n' "$(dirname "$git_common_dir")"
+        return
+    fi
+
+    # Fallback: relative to this script
+    cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd
+}
+
+WORKSPACE="$(_resolve_workspace)"
+PYTHON="${LOOM_PYTHON:-python3}"
+
+# --- Argument parsing ---
+USE_WRAPPER=false
+PASSTHROUGH_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --use-wrapper)
+            USE_WRAPPER=true
+            shift
+            ;;
+        --help|-h)
+            sed -n '2,/^set -euo/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//' \
+                | head -n -1
+            exit 0
+            ;;
+        --)
+            shift
+            PASSTHROUGH_ARGS+=("$@")
+            break
+            ;;
+        *)
+            PASSTHROUGH_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+# --- Locate loom_tools package source ---
+# Search order:
+#   1. $LOOM_PACKAGE_PATH (env override).
+#   2. Script-relative: .loom/scripts/spawn-claude.sh -> ../../loom-tools/src
+#      (matches the loom repo layout regardless of WORKSPACE override).
+#   3. $WORKSPACE/loom-tools/src.
+_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_script_relative_pkg="$(cd "$_script_dir/../../loom-tools/src" 2>/dev/null && pwd || echo "")"
+PACKAGE_PATH="${LOOM_PACKAGE_PATH:-$_script_relative_pkg}"
+if [[ -z "$PACKAGE_PATH" || ! -d "$PACKAGE_PATH/loom_tools/tokens" ]]; then
+    PACKAGE_PATH="${WORKSPACE}/loom-tools/src"
+fi
+
+# --- Token selection ---
+if [[ -z "${LOOM_SPAWN_NO_EXPORT:-}" && -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
+    # Capture stdout (JSON) and stderr (errors) separately so log output
+    # does not contaminate the JSON we feed to python -c.
+    _selection_stderr_file="$(mktemp)"
+    _selection_json=""
+    if ! _selection_json="$(
+        PYTHONPATH="${PACKAGE_PATH}${PYTHONPATH:+:$PYTHONPATH}" \
+        "$PYTHON" -m loom_tools.tokens.select --workspace "$WORKSPACE" --json \
+        2>"$_selection_stderr_file"
+    )"; then
+        log_error "Token selection failed:"
+        cat "$_selection_stderr_file" >&2 || true
+        rm -f "$_selection_stderr_file"
+        log_error "Run 'loom-tokens bootstrap' to populate .loom/tokens/, or"
+        log_error "set CLAUDE_CODE_OAUTH_TOKEN explicitly to bypass selection."
+        exit 78  # EX_CONFIG
+    fi
+    rm -f "$_selection_stderr_file"
+
+    # Parse JSON without jq (jq isn't guaranteed to be installed).
+    _token=$(
+        printf '%s' "$_selection_json" \
+        | "$PYTHON" -c 'import json,sys; print(json.load(sys.stdin)["key"])'
+    )
+    _name=$(
+        printf '%s' "$_selection_json" \
+        | "$PYTHON" -c 'import json,sys; print(json.load(sys.stdin)["name"])'
+    )
+    _mode=$(
+        printf '%s' "$_selection_json" \
+        | "$PYTHON" -c 'import json,sys; print(json.load(sys.stdin)["mode"])'
+    )
+
+    if [[ -z "$_token" ]]; then
+        log_error "Token selection returned empty key for account '$_name'."
+        exit 78
+    fi
+
+    export CLAUDE_CODE_OAUTH_TOKEN="$_token"
+    log_info "spawn-claude: using OAuth account '$_name' (mode=$_mode)"
+fi
+
+# --- Dispatch ---
+if [[ "$USE_WRAPPER" == "true" ]]; then
+    _wrapper="${WORKSPACE}/.loom/scripts/claude-wrapper.sh"
+    if [[ ! -x "$_wrapper" ]]; then
+        log_error "Cannot find executable claude-wrapper.sh at $_wrapper"
+        exit 1
+    fi
+    exec "$_wrapper" "${PASSTHROUGH_ARGS[@]}"
+fi
+
+# Default: exec the `claude` CLI directly.
+if ! command -v claude >/dev/null 2>&1; then
+    log_error "'claude' command not found in PATH."
+    log_error "Install Claude Code or pass --use-wrapper to invoke claude-wrapper.sh."
+    exit 127
+fi
+exec claude "${PASSTHROUGH_ARGS[@]}"

--- a/defaults/scripts/tests/test-spawn-claude.sh
+++ b/defaults/scripts/tests/test-spawn-claude.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# test-spawn-claude.sh — Tests for spawn-claude.sh and classify_error.
+#
+# Style matches test-forge-helpers.sh — plain bash, hand-rolled assertions.
+# Bats is NOT used in this repository.
+#
+# Usage:
+#   ./.loom/scripts/tests/test-spawn-claude.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPTS_DIR/../.." && pwd)"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_eq() {
+    local expected="$1"
+    local actual="$2"
+    local msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Expected: '$expected'"
+        echo "    Actual:   '$actual'"
+    fi
+}
+
+assert_contains() {
+    local needle="$1"
+    local haystack="$2"
+    local msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$haystack" == *"$needle"* ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Expected substring: '$needle'"
+        echo "    In: '$haystack'"
+    fi
+}
+
+# ============================================================
+# Section 1: classify_error test vectors (curator's 18 vectors)
+# ============================================================
+
+echo "Testing classify_error..."
+# Source the library
+# shellcheck source=../lib/classify-error.sh
+source "$SCRIPTS_DIR/lib/classify-error.sh"
+
+# Vector #1: clean exit with "500" in output → SUCCESS (regression #3233)
+result=$(classify_error "successfully merged PR #500 with status 200" 0)
+assert_eq "SUCCESS" "$result" "exit=0 output containing '500' is SUCCESS (#3233 regression)"
+
+# Vector #2: clean exit with "rate limit" substring → SUCCESS (regression #3233)
+result=$(classify_error "rate limit headers indicate 4500 remaining" 0)
+assert_eq "SUCCESS" "$result" "exit=0 with 'rate limit' substring is SUCCESS (#3233 regression)"
+
+# Vector #3: clean exit, "No messages returned" → SUCCESS (regression #3233)
+result=$(classify_error "No messages returned in this cycle, exiting" 0)
+assert_eq "SUCCESS" "$result" "exit=0 with 'No messages returned' is SUCCESS (#3233 regression)"
+
+# Vector #4: defensive — clean exit even with "500 Internal Server Error"
+result=$(classify_error "Internal Server Error 500" 0)
+assert_eq "SUCCESS" "$result" "exit=0 with '500 Internal Server Error' is SUCCESS"
+
+# Vector #5: clean exit, empty output
+result=$(classify_error "" 0)
+assert_eq "SUCCESS" "$result" "exit=0 empty output is SUCCESS"
+
+# Vector #6: timeout exit 124 → TIMEOUT
+result=$(classify_error "anything" 124)
+assert_eq "TIMEOUT" "$result" "exit=124 is TIMEOUT"
+
+# Vector #7: SIGKILL exit 137 → TIMEOUT
+result=$(classify_error "anything" 137)
+assert_eq "TIMEOUT" "$result" "exit=137 is TIMEOUT"
+
+# Vector #8: 401 expired → TOKEN_EXPIRED
+result=$(classify_error "OAuth token has expired" 1)
+assert_eq "TOKEN_EXPIRED" "$result" "OAuth token expired -> TOKEN_EXPIRED"
+
+# Vector #9: 401 authentication_error → TOKEN_EXPIRED
+result=$(classify_error "401 authentication_error" 1)
+assert_eq "TOKEN_EXPIRED" "$result" "401 authentication_error -> TOKEN_EXPIRED"
+
+# Vector #10: hit your limit → TOKEN_EXHAUSTED
+result=$(classify_error "You've hit your limit" 1)
+assert_eq "TOKEN_EXHAUSTED" "$result" "hit your limit -> TOKEN_EXHAUSTED"
+
+# Vector #11: weekly limit → TOKEN_EXHAUSTED
+result=$(classify_error "hit your weekly limit" 1)
+assert_eq "TOKEN_EXHAUSTED" "$result" "weekly limit -> TOKEN_EXHAUSTED"
+
+# Vector #12: 429 → RECOVERABLE
+result=$(classify_error "429 Too Many Requests" 1)
+assert_eq "RECOVERABLE" "$result" "429 -> RECOVERABLE"
+
+# Vector #13: 500 (with non-zero exit) → RECOVERABLE
+result=$(classify_error "500 Internal Server Error" 1)
+assert_eq "RECOVERABLE" "$result" "500 + exit=1 -> RECOVERABLE"
+
+# Vector #14: 503 → RECOVERABLE
+result=$(classify_error "503 Service Unavailable" 1)
+assert_eq "RECOVERABLE" "$result" "503 -> RECOVERABLE"
+
+# Vector #15: ECONNREFUSED → RECOVERABLE
+result=$(classify_error "ECONNREFUSED" 1)
+assert_eq "RECOVERABLE" "$result" "ECONNREFUSED -> RECOVERABLE"
+
+# Vector #16: No messages returned + exit=1 → RECOVERABLE (only when failed)
+result=$(classify_error "No messages returned" 1)
+assert_eq "RECOVERABLE" "$result" "'No messages' + exit=1 -> RECOVERABLE"
+
+# Vector #17: cwd deleted → CWD_DELETED
+result=$(classify_error "current working directory was deleted" 1)
+assert_eq "CWD_DELETED" "$result" "cwd deleted -> CWD_DELETED"
+
+# Vector #18: catch-all unknown failure → RECOVERABLE
+result=$(classify_error "" 2)
+assert_eq "RECOVERABLE" "$result" "unknown exit=2 -> RECOVERABLE"
+
+# ============================================================
+# Section 2: spawn-claude.sh dispatch (with stub `claude`)
+# ============================================================
+
+echo ""
+echo "Testing spawn-claude.sh dispatch..."
+
+# Set up a fake workspace
+TEST_WS="$(mktemp -d)"
+trap 'rm -rf "$TEST_WS"' EXIT
+
+mkdir -p "$TEST_WS/.loom/tokens"
+chmod 700 "$TEST_WS/.loom/tokens"
+echo -n "fake-token-alpha" > "$TEST_WS/.loom/tokens/alpha.token"
+chmod 600 "$TEST_WS/.loom/tokens/alpha.token"
+
+# Stub `claude` binary
+STUB_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_WS" "$STUB_DIR"' EXIT
+cat > "$STUB_DIR/claude" <<'STUB'
+#!/usr/bin/env bash
+echo "stub-claude got token=${CLAUDE_CODE_OAUTH_TOKEN}"
+echo "stub-claude args=$*"
+exit 0
+STUB
+chmod +x "$STUB_DIR/claude"
+
+# Test: spawn-claude selects the only token and exec's the stub
+output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
+    "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
+assert_contains "stub-claude got token=fake-token-alpha" "$output" \
+    "spawn-claude exports selected token to claude"
+assert_contains "stub-claude args=-p ping" "$output" \
+    "spawn-claude passes args through to claude"
+assert_contains "OAuth account 'alpha'" "$output" \
+    "spawn-claude logs the chosen account"
+
+# Test: explicit CLAUDE_CODE_OAUTH_TOKEN bypasses selection
+output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
+    CLAUDE_CODE_OAUTH_TOKEN="caller-supplied" \
+    "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
+assert_contains "stub-claude got token=caller-supplied" "$output" \
+    "explicit CLAUDE_CODE_OAUTH_TOKEN is preserved"
+
+# Test: missing tokens dir → exit 78 with helpful message
+EMPTY_WS="$(mktemp -d)"
+output=$(LOOM_WORKSPACE="$EMPTY_WS" PATH="$STUB_DIR:$PATH" \
+    "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
+exit_code=$?
+assert_contains "loom-tokens bootstrap" "$output" \
+    "empty pool error mentions 'loom-tokens bootstrap'"
+rm -rf "$EMPTY_WS"
+
+# Test that spawn-claude.sh exits 78 on missing tokens
+set +e
+LOOM_WORKSPACE="$(mktemp -d)" PATH="$STUB_DIR:$PATH" \
+    "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" >/dev/null 2>&1
+exit_code=$?
+set -e
+assert_eq "78" "$exit_code" "missing tokens exits 78 (EX_CONFIG)"
+
+# ============================================================
+# Summary
+# ============================================================
+
+echo ""
+echo "==================================="
+echo "Tests run:    $TESTS_RUN"
+echo -e "Tests passed: ${GREEN}$TESTS_PASSED${NC}"
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    echo -e "Tests failed: ${RED}$TESTS_FAILED${NC}"
+    exit 1
+fi
+echo "All tests passed."

--- a/defaults/scripts/tests/test-spawn-claude.sh
+++ b/defaults/scripts/tests/test-spawn-claude.sh
@@ -11,7 +11,6 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-REPO_ROOT="$(cd "$SCRIPTS_DIR/../.." && pwd)"
 
 # Colors
 RED='\033[0;31m'

--- a/loom-tools/src/loom_tools/tokens/__init__.py
+++ b/loom-tools/src/loom_tools/tokens/__init__.py
@@ -1,17 +1,49 @@
-"""Multi-account OAuth token pool management for Claude Code rotation.
+"""Multi-account OAuth token pool for Claude Code rotation.
 
-This subpackage handles bootstrapping the on-disk token pool at
-``.loom/tokens/`` from numbered ``ACCOUNT_*_N`` triples in ``.env``.
+This subpackage handles two responsibilities:
 
-The token pool is consumed by external rotation logic (see
-``scripts/agents/claude-wrapper.sh`` in the lean-genius reference). This
-module's sole responsibility is the bootstrap step: turn ``.env`` entries
-into per-account ``.token`` files (mode ``0600``) plus an ``index.json``
-manifest with sha256 fingerprints (no secret material).
+1. **Bootstrap** (``loom_tools.tokens.bootstrap``) — turn numbered
+   ``ACCOUNT_*_N`` triples in ``.env`` into per-account ``.token`` files
+   under ``.loom/tokens/`` (mode 0600), plus an ``index.json`` manifest
+   with sha256 fingerprints (no secret material).
+
+2. **Selection / bad-token tracking** (``loom_tools.tokens.select`` and
+   ``loom_tools.tokens.bad_tokens``) — runtime token rotation. The
+   selection algorithm picks a token using a 3-tier strategy
+   (ranking -> allowlist -> random), skipping tokens marked bad in
+   ``.bad_tokens``. Bad-token writes use ``mkdir``-based atomic locking
+   (POSIX, macOS-compatible — ``flock`` is not used).
+
+This module is import-safe: no I/O at import time. The daemon, shell
+wrappers (``defaults/scripts/spawn-claude.sh``), and tests all import it
+from concurrent processes.
+
+Public API:
+    bootstrap_tokens(...)              -- materialize .env -> .token files
+    select_token(workspace_path) -> SelectedToken
+    mark_bad(workspace_path, name, reason)
+    is_bad(workspace_path, name) -> bool
+    cleanup_bad_tokens(workspace_path, max_age_seconds)
 """
 
 from __future__ import annotations
 
+from loom_tools.tokens.bad_tokens import cleanup_bad_tokens, is_bad, mark_bad
 from loom_tools.tokens.bootstrap import bootstrap_tokens
+from loom_tools.tokens.select import (
+    EmptyTokenPoolError,
+    SelectedToken,
+    TokenSelectionError,
+    select_token,
+)
 
-__all__ = ["bootstrap_tokens"]
+__all__ = [
+    "EmptyTokenPoolError",
+    "SelectedToken",
+    "TokenSelectionError",
+    "bootstrap_tokens",
+    "cleanup_bad_tokens",
+    "is_bad",
+    "mark_bad",
+    "select_token",
+]

--- a/loom-tools/src/loom_tools/tokens/bad_tokens.py
+++ b/loom-tools/src/loom_tools/tokens/bad_tokens.py
@@ -1,0 +1,202 @@
+"""Bad-token tracking with mkdir-based locking.
+
+Tokens that fail with TOKEN_EXPIRED, TOKEN_EXHAUSTED, or otherwise prove
+unusable are appended to ``.loom/tokens/.bad_tokens``. Subsequent selection
+calls skip these tokens.
+
+The file is shared across concurrent bash and Python writers. We coordinate
+with a sibling ``.bad_tokens.lock`` directory, created via ``mkdir`` (POSIX
+atomic). ``flock`` is intentionally not used because it is unavailable on
+stock macOS.
+
+File format (one entry per line):
+    <ISO8601 UTC timestamp> <token_name> <reason words...>
+
+Reads use a word-boundary regex so ``agent-1`` and ``agent-10`` do not
+collide.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Lock parameters
+_LOCK_TIMEOUT_SECONDS = 5.0
+_LOCK_POLL_INTERVAL = 0.1
+_STALE_LOCK_THRESHOLD_SECONDS = 30.0
+
+
+class _MkdirLock:
+    """Context manager wrapping a directory-as-lock.
+
+    Acquires by creating ``lock_path``. Times out after _LOCK_TIMEOUT_SECONDS.
+    Cleans up stale locks (older than _STALE_LOCK_THRESHOLD_SECONDS) before
+    giving up.
+
+    Always releases the lock on ``__exit__`` (via rmdir). If the lock was
+    never acquired (timeout), ``__exit__`` is a no-op.
+    """
+
+    def __init__(self, lock_path: Path):
+        self._lock_path = lock_path
+        self._acquired = False
+
+    def __enter__(self) -> "_MkdirLock":
+        deadline = time.monotonic() + _LOCK_TIMEOUT_SECONDS
+        while time.monotonic() < deadline:
+            try:
+                self._lock_path.mkdir(parents=False, exist_ok=False)
+                self._acquired = True
+                return self
+            except FileExistsError:
+                # Stale-lock cleanup
+                try:
+                    age = time.time() - self._lock_path.stat().st_mtime
+                    if age > _STALE_LOCK_THRESHOLD_SECONDS:
+                        try:
+                            self._lock_path.rmdir()
+                        except OSError:
+                            pass
+                except FileNotFoundError:
+                    # Lock vanished between checks; loop and retry mkdir
+                    continue
+                time.sleep(_LOCK_POLL_INTERVAL)
+        raise TimeoutError(
+            f"Could not acquire bad_tokens lock at {self._lock_path} "
+            f"within {_LOCK_TIMEOUT_SECONDS}s"
+        )
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        if self._acquired:
+            try:
+                self._lock_path.rmdir()
+            except OSError:
+                # Lock already gone — log-friendly silent
+                pass
+
+
+def _bad_tokens_path(tokens_dir: Path) -> Path:
+    return tokens_dir / ".bad_tokens"
+
+
+def _lock_path(tokens_dir: Path) -> Path:
+    return tokens_dir / ".bad_tokens.lock"
+
+
+def _name_pattern(token_name: str) -> re.Pattern[str]:
+    """Word-boundary regex: matches the token name as a discrete token.
+
+    The bad_tokens file format is whitespace-separated, so the field
+    boundary is whitespace (or start/end of line).
+    """
+    return re.compile(
+        r"(^|\s)" + re.escape(token_name) + r"(\s|$)",
+        re.MULTILINE,
+    )
+
+
+def mark_bad(workspace_path: Path | str, token_name: str, reason: str) -> None:
+    """Append a bad-token entry atomically.
+
+    Args:
+        workspace_path: Repo root containing ``.loom/tokens/``.
+        token_name: Token name (basename of the .token file, no extension).
+        reason: Free-form reason string. Newlines are replaced with spaces.
+
+    Raises:
+        TimeoutError: If the lock cannot be acquired in time.
+        FileNotFoundError: If ``.loom/tokens/`` does not exist.
+    """
+    workspace_path = Path(workspace_path)
+    tokens_dir = workspace_path / ".loom" / "tokens"
+    if not tokens_dir.is_dir():
+        raise FileNotFoundError(f"Tokens dir does not exist: {tokens_dir}")
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    safe_reason = reason.replace("\n", " ").replace("\r", " ").strip()
+    line = f"{timestamp} {token_name} {safe_reason}\n"
+
+    with _MkdirLock(_lock_path(tokens_dir)):
+        with open(_bad_tokens_path(tokens_dir), "a", encoding="utf-8") as fh:
+            fh.write(line)
+
+
+def is_bad(workspace_path: Path | str, token_name: str) -> bool:
+    """Return True if ``token_name`` appears in the bad_tokens file.
+
+    Uses a word-boundary regex so ``agent-1`` does not match ``agent-10``.
+    Reads are unsynchronized — readers see a consistent file because writers
+    only ever append whole lines.
+
+    Args:
+        workspace_path: Repo root.
+        token_name: Token basename to look up.
+    """
+    workspace_path = Path(workspace_path)
+    bad_file = _bad_tokens_path(workspace_path / ".loom" / "tokens")
+    if not bad_file.is_file():
+        return False
+    try:
+        text = bad_file.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    return bool(_name_pattern(token_name).search(text))
+
+
+def cleanup_bad_tokens(
+    workspace_path: Path | str,
+    max_age_seconds: int = 6 * 3600,
+) -> int:
+    """Drop bad_tokens entries older than ``max_age_seconds``.
+
+    Args:
+        workspace_path: Repo root.
+        max_age_seconds: Cutoff age in seconds (default 6 hours).
+
+    Returns:
+        Number of entries retained after pruning.
+    """
+    workspace_path = Path(workspace_path)
+    tokens_dir = workspace_path / ".loom" / "tokens"
+    bad_file = _bad_tokens_path(tokens_dir)
+    if not bad_file.is_file():
+        return 0
+
+    cutoff_dt = datetime.now(timezone.utc).timestamp() - max_age_seconds
+    kept: list[str] = []
+
+    with _MkdirLock(_lock_path(tokens_dir)):
+        try:
+            lines = bad_file.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            return 0
+        for line in lines:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            ts_str = stripped.split(" ", 1)[0]
+            try:
+                # Accept the canonical UTC format we write.
+                ts_dt = datetime.strptime(ts_str, "%Y-%m-%dT%H:%M:%SZ").replace(
+                    tzinfo=timezone.utc,
+                )
+                ts_epoch = ts_dt.timestamp()
+            except ValueError:
+                # Malformed line — keep it so we don't silently lose data.
+                kept.append(line)
+                continue
+            if ts_epoch >= cutoff_dt:
+                kept.append(line)
+
+        # Atomic replacement: write to temp file then rename
+        tmp = bad_file.with_suffix(bad_file.suffix + ".tmp")
+        if kept:
+            tmp.write_text("\n".join(kept) + "\n", encoding="utf-8")
+        else:
+            tmp.write_text("", encoding="utf-8")
+        tmp.replace(bad_file)
+
+    return len(kept)

--- a/loom-tools/src/loom_tools/tokens/select.py
+++ b/loom-tools/src/loom_tools/tokens/select.py
@@ -1,0 +1,326 @@
+"""Token selection algorithm — 3-tier priority.
+
+Selection order:
+    1. Ranking file (.ranking, <10 min old): pick first non-exhausted
+       account, skipping bad tokens.
+    2. Allowlist file (.allowlist): random pick from allowed accounts.
+    3. Random pick from all .token files.
+
+In all tiers, tokens marked bad (via bad_tokens.is_bad) are skipped.
+
+This module is import-safe: no I/O occurs at import time. Both the daemon
+(via ``import``) and the bash wrapper (via ``python3 -m``) call
+``select_token`` from concurrent processes.
+
+Worktree handling: when invoked from a worktree, callers should pass the
+canonical repo root (i.e. ``git rev-parse --show-toplevel`` of the main
+checkout, not the worktree). The bash wrapper uses
+``git rev-parse --git-common-dir`` to derive this.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from loom_tools.tokens.bad_tokens import is_bad
+
+# Ranking file is considered fresh for this many seconds.
+_RANKING_FRESH_SECONDS = 600  # 10 min
+
+# Exit code when no token is available (matches sysexits.h EX_CONFIG)
+EX_CONFIG = 78
+
+
+class TokenSelectionError(Exception):
+    """Base class for token selection failures."""
+
+
+class EmptyTokenPoolError(TokenSelectionError):
+    """No tokens available — bootstrap has not been run, or all are bad."""
+
+
+@dataclass(frozen=True)
+class SelectedToken:
+    """A token chosen by ``select_token``."""
+
+    name: str  # basename without .token extension
+    file: Path  # absolute path to .token file
+    key: str  # token contents (whitespace-stripped)
+    mode: str  # "ranked" | "allowlist" | "random"
+
+
+def _read_token_file(token_path: Path) -> str:
+    """Read a .token file, stripping all whitespace defensively."""
+    raw = token_path.read_text(encoding="utf-8", errors="strict")
+    return "".join(raw.split())
+
+
+def _file_age_seconds(path: Path) -> float | None:
+    """Return file age in seconds, or None if file missing."""
+    try:
+        return time.time() - path.stat().st_mtime
+    except FileNotFoundError:
+        return None
+
+
+def _list_token_files(tokens_dir: Path) -> list[Path]:
+    """Return all .token files sorted by name (deterministic ordering)."""
+    return sorted(tokens_dir.glob("*.token"))
+
+
+def _strip_comment(line: str) -> str:
+    """Drop ``#`` comments and trim whitespace."""
+    line = line.split("#", 1)[0]
+    return line.strip()
+
+
+def _read_ranking(ranking_file: Path) -> Iterable[tuple[str, str]]:
+    """Yield (name, status) pairs from the ranking file.
+
+    Format: ``name|status`` per line. Lines starting with ``#`` are skipped.
+    Malformed lines are skipped. ``status`` defaults to empty string.
+    """
+    try:
+        for raw in ranking_file.read_text(encoding="utf-8").splitlines():
+            stripped = _strip_comment(raw)
+            if not stripped:
+                continue
+            parts = stripped.split("|", 1)
+            name = parts[0].strip()
+            status = parts[1].strip() if len(parts) > 1 else ""
+            if name:
+                yield name, status
+    except OSError:
+        return
+
+
+def _read_allowlist(allowlist_file: Path) -> list[str]:
+    """Return list of token names in the allowlist (no .token extension)."""
+    out: list[str] = []
+    try:
+        for raw in allowlist_file.read_text(encoding="utf-8").splitlines():
+            stripped = _strip_comment(raw)
+            if stripped:
+                out.append(stripped)
+    except OSError:
+        pass
+    return out
+
+
+def _try_ranking(
+    tokens_dir: Path,
+    ranking_file: Path,
+    workspace_path: Path,
+    rng: random.Random,
+) -> SelectedToken | None:
+    """Strategy 1: read .ranking, return first non-exhausted/non-blocked entry."""
+    age = _file_age_seconds(ranking_file)
+    if age is None or age >= _RANKING_FRESH_SECONDS:
+        return None
+    for name, status in _read_ranking(ranking_file):
+        if status in ("exhausted", "blocked"):
+            continue
+        token_file = tokens_dir / f"{name}.token"
+        if not token_file.is_file():
+            continue
+        if is_bad(workspace_path, name):
+            continue
+        try:
+            key = _read_token_file(token_file)
+        except OSError:
+            continue
+        if not key:
+            continue
+        return SelectedToken(name=name, file=token_file, key=key, mode="ranked")
+    return None
+
+
+def _try_allowlist(
+    tokens_dir: Path,
+    allowlist_file: Path,
+    workspace_path: Path,
+    rng: random.Random,
+) -> SelectedToken | None:
+    """Strategy 2: random pick from allowlist."""
+    if not allowlist_file.is_file():
+        return None
+    names = _read_allowlist(allowlist_file)
+    eligible: list[Path] = []
+    for name in names:
+        token_file = tokens_dir / f"{name}.token"
+        if token_file.is_file() and not is_bad(workspace_path, name):
+            eligible.append(token_file)
+    if not eligible:
+        return None
+    rng.shuffle(eligible)
+    for token_file in eligible:
+        try:
+            key = _read_token_file(token_file)
+        except OSError:
+            continue
+        if not key:
+            continue
+        return SelectedToken(
+            name=token_file.stem,
+            file=token_file,
+            key=key,
+            mode="allowlist",
+        )
+    return None
+
+
+def _try_random(
+    tokens_dir: Path,
+    workspace_path: Path,
+    rng: random.Random,
+) -> SelectedToken | None:
+    """Strategy 3: random pick from all tokens."""
+    candidates = [
+        p for p in _list_token_files(tokens_dir) if not is_bad(workspace_path, p.stem)
+    ]
+    if not candidates:
+        return None
+    rng.shuffle(candidates)
+    for token_file in candidates:
+        try:
+            key = _read_token_file(token_file)
+        except OSError:
+            continue
+        if not key:
+            continue
+        return SelectedToken(
+            name=token_file.stem,
+            file=token_file,
+            key=key,
+            mode="random",
+        )
+    return None
+
+
+def select_token(
+    workspace_path: Path | str,
+    *,
+    rng: random.Random | None = None,
+) -> SelectedToken:
+    """Select an OAuth token using the 3-tier algorithm.
+
+    Args:
+        workspace_path: Repo root containing ``.loom/tokens/``. When called
+            from a worktree, pass the canonical (main checkout) root, not
+            the worktree path.
+        rng: Optional random.Random instance for deterministic testing.
+            Defaults to a module-level Random seeded from os.urandom.
+
+    Returns:
+        SelectedToken with name, absolute file path, key, and selection mode.
+
+    Raises:
+        EmptyTokenPoolError: When ``.loom/tokens/`` is missing, contains no
+            ``.token`` files, or every token is marked bad.
+            The bash wrapper hard-fails (exit 78) and prompts the user to
+            run ``loom-tokens bootstrap`` — never silently falls back.
+    """
+    workspace_path = Path(workspace_path)
+    tokens_dir = workspace_path / ".loom" / "tokens"
+
+    if not tokens_dir.is_dir():
+        raise EmptyTokenPoolError(
+            f"Token directory does not exist: {tokens_dir}. "
+            f"Run `loom-tokens bootstrap` to populate it.",
+        )
+
+    all_tokens = _list_token_files(tokens_dir)
+    if not all_tokens:
+        raise EmptyTokenPoolError(
+            f"No .token files in {tokens_dir}. Run `loom-tokens bootstrap`.",
+        )
+
+    if rng is None:
+        rng = random.Random(os.urandom(16))
+
+    ranking_file = tokens_dir / ".ranking"
+    allowlist_file = tokens_dir / ".allowlist"
+
+    selected = _try_ranking(tokens_dir, ranking_file, workspace_path, rng)
+    if selected is not None:
+        return selected
+
+    selected = _try_allowlist(tokens_dir, allowlist_file, workspace_path, rng)
+    if selected is not None:
+        return selected
+
+    selected = _try_random(tokens_dir, workspace_path, rng)
+    if selected is not None:
+        return selected
+
+    raise EmptyTokenPoolError(
+        f"All {len(all_tokens)} tokens in {tokens_dir} are marked bad or empty. "
+        f"Inspect .bad_tokens or run `loom-tokens bootstrap --force`.",
+    )
+
+
+def _main(argv: list[str] | None = None) -> int:
+    """CLI entry: emit the selected token as JSON or shell-export lines.
+
+    The bash wrapper invokes us via ``python3 -m loom_tools.tokens.select``
+    and parses the JSON form. ``--export`` is provided for convenience
+    debugging.
+    """
+    parser = argparse.ArgumentParser(
+        prog="python -m loom_tools.tokens.select",
+        description="Select a Claude Code OAuth token from .loom/tokens/.",
+    )
+    parser.add_argument(
+        "--workspace",
+        required=True,
+        help="Repo root containing .loom/tokens/.",
+    )
+    fmt = parser.add_mutually_exclusive_group()
+    fmt.add_argument("--json", action="store_true", help="Emit JSON (default).")
+    fmt.add_argument(
+        "--export",
+        action="store_true",
+        help="Emit shell `export CLAUDE_CODE_OAUTH_TOKEN=...` lines.",
+    )
+    parser.add_argument(
+        "--no-key",
+        action="store_true",
+        help="Omit the secret key from output (for safe inspection).",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        sel = select_token(args.workspace)
+    except EmptyTokenPoolError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return EX_CONFIG
+
+    if args.export:
+        if args.no_key:
+            print(f"# selected={sel.name} mode={sel.mode} file={sel.file}")
+        else:
+            print(f"export CLAUDE_CODE_OAUTH_TOKEN={sel.key!r}")
+            print(f"# selected={sel.name} mode={sel.mode} file={sel.file}")
+        return 0
+
+    payload = {
+        "name": sel.name,
+        "file": str(sel.file),
+        "mode": sel.mode,
+    }
+    if not args.no_key:
+        payload["key"] = sel.key
+    print(json.dumps(payload))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/loom-tools/tests/tokens/test_bad_tokens.py
+++ b/loom-tools/tests/tokens/test_bad_tokens.py
@@ -1,0 +1,164 @@
+"""Tests for loom_tools.tokens.bad_tokens."""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import time
+from pathlib import Path
+
+import pytest
+
+from loom_tools.tokens import bad_tokens
+from loom_tools.tokens.bad_tokens import (
+    cleanup_bad_tokens,
+    is_bad,
+    mark_bad,
+)
+
+
+def _make_tokens_dir(tmp_path: Path) -> Path:
+    d = tmp_path / ".loom" / "tokens"
+    d.mkdir(parents=True)
+    return tmp_path
+
+
+def test_mark_then_is_bad(tmp_path):
+    workspace = _make_tokens_dir(tmp_path)
+    assert is_bad(workspace, "agent-1") is False
+    mark_bad(workspace, "agent-1", "OAuth expired")
+    assert is_bad(workspace, "agent-1") is True
+
+
+def test_word_boundary_does_not_collide(tmp_path):
+    """`agent-1` should not match `agent-10` (regression for substring bug)."""
+    workspace = _make_tokens_dir(tmp_path)
+    mark_bad(workspace, "agent-10", "exhausted")
+    # The bad-tokens file mentions agent-10; agent-1 must not match.
+    assert is_bad(workspace, "agent-10") is True
+    assert is_bad(workspace, "agent-1") is False
+
+
+def test_multiple_entries_for_same_token(tmp_path):
+    workspace = _make_tokens_dir(tmp_path)
+    mark_bad(workspace, "agent-1", "first")
+    mark_bad(workspace, "agent-1", "second")
+    bad_file = workspace / ".loom" / "tokens" / ".bad_tokens"
+    contents = bad_file.read_text()
+    assert contents.count("agent-1") == 2
+    assert "first" in contents
+    assert "second" in contents
+
+
+def test_reason_with_newlines_collapsed(tmp_path):
+    workspace = _make_tokens_dir(tmp_path)
+    mark_bad(workspace, "agent-1", "line one\nline two\rline three")
+    bad_file = workspace / ".loom" / "tokens" / ".bad_tokens"
+    contents = bad_file.read_text()
+    # Each appended record must be exactly one line — no embedded newlines
+    assert contents.count("\n") == 1
+    assert "line one" in contents
+    assert "line two" in contents
+
+
+def test_missing_tokens_dir_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        mark_bad(tmp_path, "agent-1", "no dir")
+
+
+def test_is_bad_when_file_absent_returns_false(tmp_path):
+    workspace = _make_tokens_dir(tmp_path)
+    assert is_bad(workspace, "anything") is False
+
+
+def test_cleanup_drops_old_entries(tmp_path):
+    workspace = _make_tokens_dir(tmp_path)
+    bad_file = workspace / ".loom" / "tokens" / ".bad_tokens"
+    bad_file.write_text(
+        "1999-01-01T00:00:00Z very-old expired\n"
+        "2099-01-01T00:00:00Z very-new exhausted\n",
+        encoding="utf-8",
+    )
+    kept = cleanup_bad_tokens(workspace, max_age_seconds=60)
+    assert kept == 1
+    contents = bad_file.read_text()
+    assert "very-old" not in contents
+    assert "very-new" in contents
+
+
+def test_cleanup_keeps_malformed_lines(tmp_path):
+    """Defensively retain lines we can't parse rather than silently delete."""
+    workspace = _make_tokens_dir(tmp_path)
+    bad_file = workspace / ".loom" / "tokens" / ".bad_tokens"
+    bad_file.write_text(
+        "garbage line with no timestamp\n"
+        "2099-01-01T00:00:00Z fresh ok\n",
+        encoding="utf-8",
+    )
+    cleanup_bad_tokens(workspace, max_age_seconds=60)
+    contents = bad_file.read_text()
+    assert "garbage" in contents
+    assert "fresh" in contents
+
+
+# ---------- locking ----------
+
+
+def _writer(workspace_str: str, name: str, count: int) -> None:
+    """Append `count` entries from a child process."""
+    for i in range(count):
+        mark_bad(workspace_str, name, f"reason-{i}")
+
+
+def test_concurrent_writers_no_loss(tmp_path):
+    """Spawn N processes, each writes K entries, verify N*K lines exist."""
+    workspace = _make_tokens_dir(tmp_path)
+    n_writers = 4
+    per_writer = 8
+    procs = []
+    for i in range(n_writers):
+        p = mp.Process(target=_writer, args=(str(workspace), f"agent-{i}", per_writer))
+        p.start()
+        procs.append(p)
+    for p in procs:
+        p.join(timeout=15)
+        assert p.exitcode == 0, f"writer {p.pid} crashed"
+
+    bad_file = workspace / ".loom" / "tokens" / ".bad_tokens"
+    lines = bad_file.read_text().splitlines()
+    # All lines should be well-formed (no interleaved bytes)
+    assert len(lines) == n_writers * per_writer
+    for line in lines:
+        # Each line is "TS NAME reason-N"
+        parts = line.split()
+        assert len(parts) >= 3, f"malformed line: {line!r}"
+        assert parts[1].startswith("agent-")
+        assert parts[2].startswith("reason-")
+
+
+def test_lock_released_on_exception(tmp_path):
+    """If mark_bad's body throws, the lock must still release."""
+    workspace = _make_tokens_dir(tmp_path)
+    # Block the lock dir — first acquisition should succeed.
+    mark_bad(workspace, "x", "first")
+    # The lock should not be held after mark_bad returns.
+    lock_path = workspace / ".loom" / "tokens" / ".bad_tokens.lock"
+    assert not lock_path.exists()
+    # Second call must succeed too.
+    mark_bad(workspace, "y", "second")
+    assert is_bad(workspace, "y")
+
+
+def test_stale_lock_cleaned_up(tmp_path, monkeypatch):
+    """A lock dir older than the stale threshold should be removed."""
+    workspace = _make_tokens_dir(tmp_path)
+    lock_path = workspace / ".loom" / "tokens" / ".bad_tokens.lock"
+    lock_path.mkdir()
+    # Backdate by 60 seconds (well past 30s stale threshold)
+    old = time.time() - 60
+    import os
+
+    os.utime(lock_path, (old, old))
+
+    # Now mark_bad should clean up the stale lock and proceed
+    mark_bad(workspace, "stale-test", "ok")
+    assert is_bad(workspace, "stale-test")

--- a/loom-tools/tests/tokens/test_select.py
+++ b/loom-tools/tests/tokens/test_select.py
@@ -1,0 +1,318 @@
+"""Tests for loom_tools.tokens.select."""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from loom_tools.tokens.select import (
+    EX_CONFIG,
+    EmptyTokenPoolError,
+    SelectedToken,
+    select_token,
+)
+
+
+# ---------- helpers ----------
+
+
+def _make_workspace(tmp_path: Path, accounts: dict[str, str]) -> Path:
+    """Materialize a fake .loom/tokens/ with the given {name: key} accounts.
+
+    Returns the workspace root.
+    """
+    tokens_dir = tmp_path / ".loom" / "tokens"
+    tokens_dir.mkdir(parents=True)
+    tokens_dir.chmod(0o700)
+    for name, key in accounts.items():
+        f = tokens_dir / f"{name}.token"
+        f.write_text(key, encoding="utf-8")
+        f.chmod(0o600)
+    return tmp_path
+
+
+def _write_ranking(workspace: Path, lines: list[str]) -> None:
+    rfile = workspace / ".loom" / "tokens" / ".ranking"
+    rfile.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    # Ensure mtime is fresh
+    now = time.time()
+    os.utime(rfile, (now, now))
+
+
+def _write_allowlist(workspace: Path, names: list[str]) -> None:
+    f = workspace / ".loom" / "tokens" / ".allowlist"
+    f.write_text("\n".join(names) + "\n", encoding="utf-8")
+
+
+# ---------- import-safety ----------
+
+
+def test_module_import_has_no_side_effects(tmp_path):
+    """Re-importing the module in a subprocess with no .loom/tokens must succeed."""
+    code = (
+        "import loom_tools.tokens.select as s; "
+        "import loom_tools.tokens.bad_tokens as b; "
+        "print('OK')"
+    )
+    # Locate the package source for this checkout (handles worktrees where
+    # the system-installed loom_tools points at a different path that may
+    # not yet have the tokens submodule).
+    pkg_root = Path(__file__).resolve().parents[2] / "src"
+    env = os.environ.copy()
+    existing_pp = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = (
+        f"{pkg_root}{os.pathsep}{existing_pp}" if existing_pp else str(pkg_root)
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+        check=False,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+# ---------- empty pool errors ----------
+
+
+def test_missing_tokens_dir_raises(tmp_path):
+    with pytest.raises(EmptyTokenPoolError, match="does not exist"):
+        select_token(tmp_path)
+
+
+def test_empty_tokens_dir_raises(tmp_path):
+    (tmp_path / ".loom" / "tokens").mkdir(parents=True)
+    with pytest.raises(EmptyTokenPoolError, match="No .token files"):
+        select_token(tmp_path)
+
+
+def test_all_tokens_bad_raises(tmp_path):
+    workspace = _make_workspace(tmp_path, {"a": "key-a", "b": "key-b"})
+    bad_file = workspace / ".loom" / "tokens" / ".bad_tokens"
+    bad_file.write_text(
+        "2026-01-01T00:00:00Z a expired\n2026-01-01T00:00:00Z b expired\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(EmptyTokenPoolError, match="marked bad"):
+        select_token(workspace)
+
+
+# ---------- random tier ----------
+
+
+def test_random_pick_returns_valid_token(tmp_path):
+    workspace = _make_workspace(tmp_path, {"alpha": "key-alpha", "beta": "key-beta"})
+    sel = select_token(workspace, rng=random.Random(42))
+    assert isinstance(sel, SelectedToken)
+    assert sel.name in ("alpha", "beta")
+    assert sel.key in ("key-alpha", "key-beta")
+    assert sel.mode == "random"
+    assert sel.file.is_file()
+
+
+def test_random_skips_bad_token(tmp_path):
+    workspace = _make_workspace(
+        tmp_path, {"good": "key-good", "rotten": "key-rotten"},
+    )
+    bad_file = workspace / ".loom" / "tokens" / ".bad_tokens"
+    bad_file.write_text("2026-01-01T00:00:00Z rotten expired\n", encoding="utf-8")
+    sel = select_token(workspace, rng=random.Random(0))
+    assert sel.name == "good"
+    assert sel.key == "key-good"
+
+
+def test_random_strips_whitespace(tmp_path):
+    workspace = _make_workspace(tmp_path, {"trim": "  key-trimmed\n\n"})
+    sel = select_token(workspace)
+    assert sel.key == "key-trimmed"
+
+
+# ---------- allowlist tier ----------
+
+
+def test_allowlist_only_picks_allowed(tmp_path):
+    workspace = _make_workspace(
+        tmp_path, {"alpha": "key-a", "beta": "key-b", "gamma": "key-c"},
+    )
+    _write_allowlist(workspace, ["beta"])
+    for _ in range(20):
+        sel = select_token(workspace)
+        assert sel.name == "beta"
+        assert sel.mode == "allowlist"
+
+
+def test_allowlist_skips_bad(tmp_path):
+    workspace = _make_workspace(tmp_path, {"a": "ka", "b": "kb"})
+    _write_allowlist(workspace, ["a", "b"])
+    bad_file = workspace / ".loom" / "tokens" / ".bad_tokens"
+    bad_file.write_text("2026-01-01T00:00:00Z a expired\n", encoding="utf-8")
+    sel = select_token(workspace)
+    assert sel.name == "b"
+    assert sel.mode == "allowlist"
+
+
+def test_allowlist_with_comments(tmp_path):
+    workspace = _make_workspace(tmp_path, {"a": "ka", "b": "kb"})
+    _write_allowlist(workspace, ["# header", "a", ""])
+    sel = select_token(workspace)
+    assert sel.name == "a"
+
+
+def test_allowlist_with_no_existing_tokens_falls_through_to_random(tmp_path):
+    workspace = _make_workspace(tmp_path, {"present": "kp"})
+    _write_allowlist(workspace, ["missing-account"])
+    sel = select_token(workspace)
+    # Should fall through to random tier since allowlist has no eligible files
+    assert sel.name == "present"
+    assert sel.mode == "random"
+
+
+# ---------- ranking tier ----------
+
+
+def test_ranking_picks_first_unblocked(tmp_path):
+    workspace = _make_workspace(tmp_path, {"a": "ka", "b": "kb", "c": "kc"})
+    _write_ranking(workspace, ["a|exhausted", "b|", "c|"])
+    sel = select_token(workspace)
+    assert sel.name == "b"
+    assert sel.mode == "ranked"
+
+
+def test_ranking_skips_blocked_status(tmp_path):
+    workspace = _make_workspace(tmp_path, {"a": "ka", "b": "kb"})
+    _write_ranking(workspace, ["a|blocked", "b|"])
+    sel = select_token(workspace)
+    assert sel.name == "b"
+
+
+def test_ranking_skips_bad_token(tmp_path):
+    workspace = _make_workspace(tmp_path, {"a": "ka", "b": "kb"})
+    _write_ranking(workspace, ["a|", "b|"])
+    bad_file = workspace / ".loom" / "tokens" / ".bad_tokens"
+    bad_file.write_text("2026-01-01T00:00:00Z a expired\n", encoding="utf-8")
+    sel = select_token(workspace)
+    assert sel.name == "b"
+
+
+def test_stale_ranking_falls_through_to_random(tmp_path):
+    workspace = _make_workspace(tmp_path, {"a": "ka", "b": "kb"})
+    rfile = workspace / ".loom" / "tokens" / ".ranking"
+    rfile.write_text("a|\nb|\n", encoding="utf-8")
+    # Backdate by 11 minutes — past the 10-min freshness window
+    old = time.time() - (11 * 60)
+    os.utime(rfile, (old, old))
+    sel = select_token(workspace)
+    # Tier 1 declined; tier 3 selected something
+    assert sel.mode == "random"
+
+
+def test_ranking_with_comments_and_blank_lines(tmp_path):
+    workspace = _make_workspace(tmp_path, {"a": "ka", "b": "kb"})
+    _write_ranking(
+        workspace,
+        ["# header comment", "", "a|exhausted", "b|"],
+    )
+    sel = select_token(workspace)
+    assert sel.name == "b"
+
+
+def test_ranking_falls_through_when_all_exhausted(tmp_path):
+    workspace = _make_workspace(tmp_path, {"a": "ka", "b": "kb"})
+    _write_ranking(workspace, ["a|exhausted", "b|exhausted"])
+    sel = select_token(workspace)
+    # Falls through past tier 1 (all exhausted), past tier 2 (no allowlist),
+    # to tier 3 (random).
+    assert sel.mode == "random"
+
+
+# ---------- CLI ----------
+
+
+def test_cli_json_output(tmp_path):
+    workspace = _make_workspace(tmp_path, {"only": "key-only"})
+    pkg_root = Path(__file__).resolve().parents[2] / "src"
+    env = os.environ.copy()
+    existing_pp = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = (
+        f"{pkg_root}{os.pathsep}{existing_pp}" if existing_pp else str(pkg_root)
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loom_tools.tokens.select",
+            "--workspace",
+            str(workspace),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["name"] == "only"
+    assert payload["key"] == "key-only"
+    assert payload["mode"] == "random"
+    assert payload["file"].endswith("only.token")
+
+
+def _cli_env() -> dict[str, str]:
+    pkg_root = Path(__file__).resolve().parents[2] / "src"
+    env = os.environ.copy()
+    existing_pp = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = (
+        f"{pkg_root}{os.pathsep}{existing_pp}" if existing_pp else str(pkg_root)
+    )
+    return env
+
+
+def test_cli_no_key_omits_secret(tmp_path):
+    workspace = _make_workspace(tmp_path, {"only": "key-only"})
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loom_tools.tokens.select",
+            "--workspace",
+            str(workspace),
+            "--json",
+            "--no-key",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=_cli_env(),
+    )
+    payload = json.loads(result.stdout)
+    assert "key" not in payload
+    assert payload["name"] == "only"
+
+
+def test_cli_empty_pool_exits_78(tmp_path):
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loom_tools.tokens.select",
+            "--workspace",
+            str(tmp_path),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_cli_env(),
+    )
+    assert result.returncode == EX_CONFIG
+    assert "loom-tokens bootstrap" in result.stderr


### PR DESCRIPTION
## Summary

Adds `spawn-claude.sh` wrapper + Python selection library implementing multi-account OAuth token rotation for Claude Code, ported from lean-genius.

Three meaningful corrections vs the upstream port:
- **`classify_error` is exit-code-first** — clean exits return `SUCCESS` regardless of stdout content (fixes #3233's false-RECOVERABLE bug where stdout substrings like `500` or `rate limit` misclassified successful runs).
- **`.bad_tokens` locking uses `mkdir`-based atomic locks**, not `flock` (which is unavailable on stock macOS). Matches existing `claude-wrapper.sh:524-557` pattern.
- **`is_bad` uses word-boundary regex** so `agent-1` doesn't match `agent-10`.

## Files

- `defaults/scripts/spawn-claude.sh` — selects token, exports `CLAUDE_CODE_OAUTH_TOKEN`, execs `claude` (or `claude-wrapper.sh` with `--use-wrapper`).
- `defaults/scripts/lib/classify-error.sh` — sourceable, exit-code-first error classification.
- `loom-tools/src/loom_tools/tokens/select.py` — 3-tier selection (ranking -> allowlist -> random); import-safe; CLI emits JSON. Exits 78 (EX_CONFIG) on empty pool.
- `loom-tools/src/loom_tools/tokens/bad_tokens.py` — `mkdir`-locked append, word-boundary read, periodic cleanup.
- 31 Python tests + 24 shell tests (no bats — plain bash, matches `test-forge-helpers.sh`).
- CLAUDE.md doc section.

## Hard-fail policy

When `.loom/tokens/` is absent or all tokens are bad, the wrapper exits 78 with a `loom-tokens bootstrap` instruction. It does **not** silently fall back to keychain.

## Dependencies

Depends on #3234 (`loom-tokens bootstrap`) for `.env -> .token` materialization. No code-level import — only docs reference it.

## Test plan

- [x] 31/31 Python tests pass: `PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/tokens/ -v`
- [x] 24/24 shell tests pass: `bash .loom/scripts/tests/test-spawn-claude.sh`
- [x] All 18 curator-provided `classify_error` test vectors pass.
- [x] Concurrent writer test (4 procs x 8 entries) produces 32 well-formed lines.
- [x] Stale lock cleanup test verifies dead locks (>30s) are reclaimed.

Closes #3235