### PR TITLE
feat(tokens): operator CLI (pin/unpin/unblock) + auto-unpin guardrails (#3238)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -682,6 +682,33 @@ When invoked from a worktree, `spawn-claude.sh` resolves the canonical repo root
 
 `spawn-claude.sh` exits `78` (`EX_CONFIG`) with a message instructing the user to run `loom-tokens bootstrap` when `.loom/tokens/` is absent or all tokens are bad. It does **not** silently fall back to keychain — that path belongs in `loom-daemon` (#3236), and only when token rotation has not been configured at all.
 
+### Operator CLI (`loom-tokens pin/unpin/unblock`)
+
+Operators can restrict the rotation pool to a subset of accounts (an "allowlist") and manually un-blacklist accounts marked bad. Auto-recovery prevents pin-induced lockouts.
+
+```bash
+loom-tokens pin agent-3 agent-7   # Set allowlist to exactly these
+loom-tokens pin add agent-2       # Append (idempotent)
+loom-tokens pin remove agent-3    # Remove
+loom-tokens pin status            # Show current allowlist
+loom-tokens unpin                 # Delete allowlist (back to full pool)
+
+loom-tokens unblock agent-1       # Remove one entry from .bad_tokens
+loom-tokens unblock --all         # Clear .bad_tokens entirely
+```
+
+**Validation**: `pin` accepts only exact bootstrapped account names — substring/fuzzy matches are rejected. The allowlist is sorted, deduplicated, and `mkdir`-lock guarded so concurrent operator commands don't drop entries.
+
+**Reason-aware bad-token TTL**: bad-tokens entries with reason `auth` (401) ignore `LOOM_TOKENS_BAD_TTL` (default 21600s = 6h) and persist until `loom-tokens unblock`. Other reasons expire automatically.
+
+**Auto-unpin** (`failure_counts`): the wrapper tracks consecutive `TOKEN_EXHAUSTED` failures per account in `.loom/tokens/.failure_counts` (JSON). When **every** account in the allowlist hits the threshold (default 5), the wrapper auto-clears `.allowlist` and `.failure_counts` with a loud stderr log line. Operators can re-pin afterwards. The threshold is `>= 5`, so a 6th failure does not silently exceed; it still triggers (idempotent at-or-above).
+
+Counters are reset on:
+- a successful spawn for that account, or
+- any operator allowlist mutation (`pin`, `unpin`, `add`, `remove`).
+
+**Empty-pool guard**: if the selector finds the allowlist minus `.bad_tokens` is empty, `spawn-claude.sh` exits `78` (`EX_CONFIG`) with operator instructions. It refuses to silently auto-clear `.bad_tokens` — that masks real auth problems (lean-genius failure mode 3).
+
 ### Tests
 
 ```bash

--- a/defaults/scripts/spawn-claude.sh
+++ b/defaults/scripts/spawn-claude.sh
@@ -122,6 +122,39 @@ fi
 
 # --- Token selection ---
 if [[ -z "${LOOM_SPAWN_NO_EXPORT:-}" && -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
+    # Pre-flight: auto-unpin if every allowlisted account has hit the
+    # consecutive-failure threshold (default 5). Without this, an
+    # operator-set pin can trap the spawner once all pinned accounts
+    # exhaust their weekly quota. Empty-pool guard: we never silently
+    # clear .bad_tokens — if that file blocks every account, the user
+    # must intervene (e.g. `loom-tokens unblock <name>`).
+    PYTHONPATH="${PACKAGE_PATH}${PYTHONPATH:+:$PYTHONPATH}" \
+        "$PYTHON" - "$WORKSPACE" <<'PY' || true
+import sys
+from pathlib import Path
+try:
+    from loom_tools.tokens import allowlist as a
+    from loom_tools.tokens import failure_counts as fc
+except Exception:
+    sys.exit(0)
+ws = Path(sys.argv[1])
+try:
+    pinned = a.read_allowlist(ws)
+    if not pinned:
+        sys.exit(0)
+    if all(fc.threshold_reached(ws, n) for n in pinned):
+        a.clear_allowlist(ws)
+        fc.reset_all(ws)
+        print(
+            f"[auto-unpin] All {len(pinned)} pinned account(s) hit "
+            f"{fc.DEFAULT_THRESHOLD} consecutive failures; "
+            f"cleared .allowlist.",
+            file=sys.stderr,
+        )
+except Exception as exc:  # noqa: BLE001
+    print(f"[auto-unpin] skipped ({exc!r})", file=sys.stderr)
+PY
+
     # Capture stdout (JSON) and stderr (errors) separately so log output
     # does not contaminate the JSON we feed to python -c.
     _selection_stderr_file="$(mktemp)"
@@ -135,7 +168,10 @@ if [[ -z "${LOOM_SPAWN_NO_EXPORT:-}" && -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; th
         cat "$_selection_stderr_file" >&2 || true
         rm -f "$_selection_stderr_file"
         log_error "Run 'loom-tokens bootstrap' to populate .loom/tokens/, or"
-        log_error "set CLAUDE_CODE_OAUTH_TOKEN explicitly to bypass selection."
+        log_error "use 'loom-tokens unblock <name>' if .bad_tokens is the cause."
+        log_error "Spawn-claude refuses to auto-clear .bad_tokens — that's"
+        log_error "intentional: an empty pool indicates a real auth problem."
+        log_error "Set CLAUDE_CODE_OAUTH_TOKEN explicitly to bypass selection."
         exit 78  # EX_CONFIG
     fi
     rm -f "$_selection_stderr_file"

--- a/loom-tools/src/loom_tools/tokens/__init__.py
+++ b/loom-tools/src/loom_tools/tokens/__init__.py
@@ -28,8 +28,25 @@ Public API:
 
 from __future__ import annotations
 
+from loom_tools.tokens.allowlist import (
+    AllowlistError,
+    UnknownAccountError,
+    add_to_allowlist,
+    clear_allowlist,
+    list_accounts,
+    read_allowlist,
+    remove_from_allowlist,
+    write_allowlist,
+)
 from loom_tools.tokens.bad_tokens import cleanup_bad_tokens, is_bad, mark_bad
 from loom_tools.tokens.bootstrap import bootstrap_tokens
+from loom_tools.tokens.failure_counts import (
+    DEFAULT_THRESHOLD,
+    record_failure,
+    record_success,
+    reset_all,
+    threshold_reached,
+)
 from loom_tools.tokens.select import (
     EmptyTokenPoolError,
     SelectedToken,
@@ -38,12 +55,25 @@ from loom_tools.tokens.select import (
 )
 
 __all__ = [
+    "DEFAULT_THRESHOLD",
+    "AllowlistError",
     "EmptyTokenPoolError",
     "SelectedToken",
     "TokenSelectionError",
+    "UnknownAccountError",
+    "add_to_allowlist",
     "bootstrap_tokens",
     "cleanup_bad_tokens",
+    "clear_allowlist",
     "is_bad",
+    "list_accounts",
     "mark_bad",
+    "read_allowlist",
+    "record_failure",
+    "record_success",
+    "remove_from_allowlist",
+    "reset_all",
     "select_token",
+    "threshold_reached",
+    "write_allowlist",
 ]

--- a/loom-tools/src/loom_tools/tokens/allowlist.py
+++ b/loom-tools/src/loom_tools/tokens/allowlist.py
@@ -1,0 +1,322 @@
+"""Operator-managed allowlist for the OAuth token pool.
+
+The ``.allowlist`` file at ``.loom/tokens/.allowlist`` constrains which
+bootstrapped accounts the spawn-time selector (#3235) is allowed to
+choose. When the file is absent, all ``.token`` files are eligible.
+
+File format: one account name (token file stem, no extension) per line.
+``#`` introduces a line comment. Empty lines are ignored.
+
+Validation: account names must match an existing ``<name>.token`` file
+under ``.loom/tokens/`` **exactly** — no fuzzy/substring matching.
+This is intentional: operators usually pin a specific account, and
+substring matches have caused selection of the wrong account in
+practice.
+
+Concurrency: writes use the same ``mkdir``-based lock primitive as
+``bad_tokens.py``. Reads are unsynchronised — readers see a consistent
+file because writers atomically rename a temp file into place.
+
+Public API:
+    list_accounts(workspace) -> list[str]
+    read_allowlist(workspace) -> list[str]
+    write_allowlist(workspace, names) -> None
+    add_to_allowlist(workspace, names) -> tuple[list[str], list[str]]
+    remove_from_allowlist(workspace, names) -> tuple[list[str], list[str]]
+    clear_allowlist(workspace) -> bool
+    AllowlistError, UnknownAccountError
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+# Reuse the lock primitive from bad_tokens — same constraints (mkdir-only,
+# no flock on stock macOS) and same workspace.
+from loom_tools.tokens.bad_tokens import _MkdirLock
+
+
+class AllowlistError(Exception):
+    """Base class for allowlist failures."""
+
+
+class UnknownAccountError(AllowlistError):
+    """A name does not correspond to an existing ``.token`` file."""
+
+    def __init__(self, name: str, available: list[str]):
+        super().__init__(
+            f"Unknown account '{name}'. "
+            f"Available: {', '.join(available) if available else '(none)'}",
+        )
+        self.name = name
+        self.available = available
+
+
+def _tokens_dir(workspace: Path | str) -> Path:
+    return Path(workspace) / ".loom" / "tokens"
+
+
+def _allowlist_path(workspace: Path | str) -> Path:
+    return _tokens_dir(workspace) / ".allowlist"
+
+
+def _lock_path(workspace: Path | str) -> Path:
+    return _tokens_dir(workspace) / ".allowlist.lock"
+
+
+def list_accounts(workspace: Path | str) -> list[str]:
+    """Return all bootstrapped account names (token file stems), sorted.
+
+    Args:
+        workspace: Repo root containing ``.loom/tokens/``.
+
+    Returns:
+        Sorted list of stems (no ``.token`` extension). Empty if the
+        tokens directory is missing or holds no ``.token`` files.
+    """
+    d = _tokens_dir(workspace)
+    if not d.is_dir():
+        return []
+    return sorted(p.stem for p in d.glob("*.token"))
+
+
+def _strip_comment(line: str) -> str:
+    return line.split("#", 1)[0].strip()
+
+
+def read_allowlist(workspace: Path | str) -> list[str]:
+    """Return the current allowlist, in file order.
+
+    Comments and blank lines are filtered out. Duplicates are preserved
+    in order of first appearance.
+
+    Args:
+        workspace: Repo root containing ``.loom/tokens/``.
+
+    Returns:
+        List of account names. Empty if the file is missing or all
+        lines are comments / blank.
+    """
+    path = _allowlist_path(workspace)
+    if not path.is_file():
+        return []
+    seen: set[str] = set()
+    out: list[str] = []
+    try:
+        for raw in path.read_text(encoding="utf-8").splitlines():
+            name = _strip_comment(raw)
+            if name and name not in seen:
+                out.append(name)
+                seen.add(name)
+    except OSError:
+        return []
+    return out
+
+
+def _validate_names(workspace: Path | str, names: list[str]) -> list[str]:
+    """Resolve names against bootstrapped accounts using EXACT match.
+
+    Returns the validated list (deduplicated, original order). Raises
+    UnknownAccountError on the first unknown name.
+    """
+    available = list_accounts(workspace)
+    available_set = set(available)
+    seen: set[str] = set()
+    resolved: list[str] = []
+    for raw in names:
+        name = raw.strip()
+        if not name:
+            continue
+        if name not in available_set:
+            raise UnknownAccountError(name, available)
+        if name not in seen:
+            resolved.append(name)
+            seen.add(name)
+    return resolved
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    """Write ``content`` to ``path`` atomically via mktemp + os.replace.
+
+    The temp file lives in the same directory as the target so the
+    rename is on the same filesystem.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_str = tempfile.mkstemp(
+        prefix=path.name + ".",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    tmp = Path(tmp_str)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(content)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+
+def write_allowlist(
+    workspace: Path | str,
+    names: list[str],
+) -> list[str]:
+    """Replace the allowlist with exactly ``names`` (validated).
+
+    Args:
+        workspace: Repo root containing ``.loom/tokens/``.
+        names: Account names to set as the allowlist. Must match
+            existing ``.token`` files exactly.
+
+    Returns:
+        The validated, deduplicated list that was written.
+
+    Raises:
+        UnknownAccountError: If any name does not match a bootstrapped
+            account.
+        FileNotFoundError: If ``.loom/tokens/`` does not exist.
+    """
+    d = _tokens_dir(workspace)
+    if not d.is_dir():
+        raise FileNotFoundError(
+            f"Tokens dir does not exist: {d}. "
+            f"Run `loom-tokens bootstrap` first.",
+        )
+    resolved = _validate_names(workspace, names)
+    body = "\n".join(resolved) + ("\n" if resolved else "")
+    path = _allowlist_path(workspace)
+    with _MkdirLock(_lock_path(workspace)):
+        if resolved:
+            _atomic_write(path, body)
+        else:
+            # Empty allowlist == no constraint. Remove the file rather
+            # than leaving an empty one (semantics match
+            # ``clear_allowlist``).
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+    return resolved
+
+
+def add_to_allowlist(
+    workspace: Path | str,
+    names: list[str],
+) -> tuple[list[str], list[str]]:
+    """Add ``names`` to the existing allowlist.
+
+    Args:
+        workspace: Repo root containing ``.loom/tokens/``.
+        names: Names to add. Must match existing accounts.
+
+    Returns:
+        ``(added, skipped_existing)`` — the names that were newly added
+        and the names that were already present.
+
+    Raises:
+        UnknownAccountError: If any name is unknown.
+        FileNotFoundError: If ``.loom/tokens/`` does not exist.
+    """
+    d = _tokens_dir(workspace)
+    if not d.is_dir():
+        raise FileNotFoundError(
+            f"Tokens dir does not exist: {d}. "
+            f"Run `loom-tokens bootstrap` first.",
+        )
+    resolved = _validate_names(workspace, names)
+    with _MkdirLock(_lock_path(workspace)):
+        existing = read_allowlist(workspace)
+        existing_set = set(existing)
+        added: list[str] = []
+        skipped: list[str] = []
+        for n in resolved:
+            if n in existing_set:
+                skipped.append(n)
+            else:
+                existing.append(n)
+                existing_set.add(n)
+                added.append(n)
+        if added:
+            _atomic_write(
+                _allowlist_path(workspace),
+                "\n".join(existing) + "\n",
+            )
+    return added, skipped
+
+
+def remove_from_allowlist(
+    workspace: Path | str,
+    names: list[str],
+) -> tuple[list[str], list[str]]:
+    """Remove ``names`` from the allowlist.
+
+    Removing the last account drops the file entirely (no constraint).
+
+    Args:
+        workspace: Repo root containing ``.loom/tokens/``.
+        names: Names to remove. Must match existing accounts.
+
+    Returns:
+        ``(removed, skipped_missing)`` — the names that were dropped
+        and the names that weren't in the allowlist to begin with.
+
+    Raises:
+        UnknownAccountError: If any name is not a bootstrapped account.
+        FileNotFoundError: If ``.loom/tokens/`` does not exist.
+    """
+    d = _tokens_dir(workspace)
+    if not d.is_dir():
+        raise FileNotFoundError(
+            f"Tokens dir does not exist: {d}. "
+            f"Run `loom-tokens bootstrap` first.",
+        )
+    resolved = _validate_names(workspace, names)
+    to_remove = set(resolved)
+    with _MkdirLock(_lock_path(workspace)):
+        existing = read_allowlist(workspace)
+        removed: list[str] = []
+        skipped: list[str] = []
+        kept: list[str] = []
+        for n in existing:
+            if n in to_remove:
+                removed.append(n)
+            else:
+                kept.append(n)
+        # Names that were validated but never in the file
+        present_set = set(existing)
+        for n in resolved:
+            if n not in present_set:
+                skipped.append(n)
+        path = _allowlist_path(workspace)
+        if kept:
+            _atomic_write(path, "\n".join(kept) + "\n")
+        else:
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+    return removed, skipped
+
+
+def clear_allowlist(workspace: Path | str) -> bool:
+    """Remove the allowlist file entirely.
+
+    Args:
+        workspace: Repo root containing ``.loom/tokens/``.
+
+    Returns:
+        ``True`` if a file was removed, ``False`` if no allowlist was
+        active.
+    """
+    path = _allowlist_path(workspace)
+    with _MkdirLock(_lock_path(workspace)):
+        try:
+            path.unlink()
+            return True
+        except FileNotFoundError:
+            return False

--- a/loom-tools/src/loom_tools/tokens/cli.py
+++ b/loom-tools/src/loom_tools/tokens/cli.py
@@ -7,10 +7,14 @@ Subcommands:
 * ``check`` (#3237) — probe each bootstrapped account for rate-limit
   headers and (optionally) write ``.loom/tokens/.ranking`` for the
   spawn-time selector (#3235).
+* ``pin`` / ``unpin`` (#3238) — operator-managed allowlist controlling
+  which accounts the spawn-time selector is allowed to pick.
+* ``unblock`` (#3238) — clear ``auth``-reason entries from
+  ``.bad_tokens`` so the named accounts become eligible again.
 
-Additional subcommands (status, allowlist, ranking sync, etc.) can be
-added later without breaking the top-level surface — the dispatch
-table mirrors ``loom_tools.shepherd.cli``.
+Additional subcommands (status, ranking sync, etc.) can be added later
+without breaking the top-level surface — the dispatch table mirrors
+``loom_tools.shepherd.cli``.
 """
 
 from __future__ import annotations
@@ -19,11 +23,14 @@ import argparse
 import json
 import logging
 import os
+import re
 import sys
 from pathlib import Path
 
-from loom_tools.common.logging import log_error
+from loom_tools.common.logging import log_error, log_info, log_success, log_warning
 from loom_tools.common.repo import find_repo_root
+from loom_tools.tokens import allowlist as allowlist_mod
+from loom_tools.tokens import failure_counts
 from loom_tools.tokens.bootstrap import bootstrap_tokens
 from loom_tools.tokens.check import (
     DEFAULT_PROBE_PROMPT,
@@ -102,6 +109,94 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Skip the 0.5-1.5s jitter between probes (mostly for tests).",
     )
 
+    # ---- pin (allowlist mutation) -------------------------------------
+    pp = sub.add_parser(
+        "pin",
+        help=(
+            "Manage the .loom/tokens/.allowlist file. The spawn-time "
+            "selector will only pick accounts present in the allowlist."
+        ),
+    )
+    pp_sub = pp.add_subparsers(dest="pin_action")
+    pp_sub.required = False
+
+    pp_set = pp_sub.add_parser(
+        "set",
+        help="Replace the allowlist with exactly the given accounts.",
+    )
+    pp_set.add_argument("names", nargs="+", help="Account names (exact match).")
+
+    pp_add = pp_sub.add_parser(
+        "add",
+        help="Add account(s) to the existing allowlist.",
+    )
+    pp_add.add_argument("names", nargs="+", help="Account names (exact match).")
+
+    pp_remove = pp_sub.add_parser(
+        "remove",
+        help="Remove account(s) from the allowlist.",
+    )
+    pp_remove.add_argument("names", nargs="+", help="Account names (exact match).")
+
+    pp_status = pp_sub.add_parser(
+        "status",
+        help="Show the current allowlist and all available accounts.",
+    )
+    pp_status.add_argument(
+        "--json",
+        dest="emit_json",
+        action="store_true",
+        help="Emit JSON instead of a human table.",
+    )
+
+    # Bare positional accounts (no subcommand) == implicit `set` for legacy
+    # `pin <names...>` form (matches lean-genius and the locked CLI).
+    pp.add_argument(
+        "legacy_names",
+        nargs="*",
+        help=argparse.SUPPRESS,
+    )
+
+    # ---- unpin (clear the allowlist) ----------------------------------
+    up = sub.add_parser(
+        "unpin",
+        help="Clear the allowlist (all accounts eligible).",
+    )
+    up.add_argument(
+        "--json",
+        dest="emit_json",
+        action="store_true",
+        help="Emit a JSON status instead of a human message.",
+    )
+
+    # ---- unblock (clear bad-token auth entries) -----------------------
+    ub = sub.add_parser(
+        "unblock",
+        help=(
+            "Remove auth-reason entries for the given accounts from "
+            ".bad_tokens (e.g. after re-authenticating)."
+        ),
+    )
+    ub.add_argument(
+        "names",
+        nargs="+",
+        help="Account names to unblock (exact match).",
+    )
+    ub.add_argument(
+        "--all-reasons",
+        action="store_true",
+        help=(
+            "Also drop non-auth entries (TTL-style, exhausted/expired). "
+            "Default is auth-reason only — TTL entries clear themselves."
+        ),
+    )
+    ub.add_argument(
+        "--json",
+        dest="emit_json",
+        action="store_true",
+        help="Emit JSON status.",
+    )
+
     return parser
 
 
@@ -114,6 +209,12 @@ def main(argv: list[str] | None = None) -> int:
         return _cmd_bootstrap(args)
     if args.command == "check":
         return _cmd_check(args)
+    if args.command == "pin":
+        return _cmd_pin(args)
+    if args.command == "unpin":
+        return _cmd_unpin(args)
+    if args.command == "unblock":
+        return _cmd_unblock(args)
 
     # argparse `required=True` should make this unreachable.
     parser.print_help(sys.stderr)
@@ -192,6 +293,271 @@ def _cmd_check(args: argparse.Namespace) -> int:
         a.status in ("error", "skipped") for a in report.accounts
     ):
         return 1
+    return 0
+
+
+def _resolve_workspace() -> Path | None:
+    """Resolve the workspace root, honoring ``LOOM_WORKSPACE`` for tests."""
+    env = os.environ.get("LOOM_WORKSPACE")
+    if env:
+        return Path(env)
+    try:
+        return find_repo_root()
+    except FileNotFoundError as exc:
+        log_error(str(exc))
+        return None
+
+
+def _cmd_pin(args: argparse.Namespace) -> int:
+    """Handle ``loom-tokens pin [<action>] <names...>``."""
+    workspace = _resolve_workspace()
+    if workspace is None:
+        return 1
+
+    # Determine action. The bare form `loom-tokens pin <name...>` (no
+    # subcommand) is accepted as a `set` for compatibility with the
+    # lean-genius CLI and the locked muscle memory of operators.
+    action = args.pin_action
+    legacy = list(getattr(args, "legacy_names", []) or [])
+
+    if action == "status" or (action is None and not legacy):
+        return _pin_status(workspace, emit_json=getattr(args, "emit_json", False))
+
+    if action is None and legacy:
+        # Legacy form: `loom-tokens pin agent-1 agent-2`
+        action = "set"
+        names = legacy
+    else:
+        names = list(getattr(args, "names", []) or [])
+
+    if not names:
+        log_error(f"`pin {action}` requires at least one account name.")
+        return 1
+
+    try:
+        if action == "set":
+            written = allowlist_mod.write_allowlist(workspace, names)
+            failure_counts.reset_all(workspace)
+            if written:
+                log_success(
+                    f"Allowlist set to {len(written)} account(s): "
+                    f"{', '.join(written)}",
+                )
+            else:
+                log_warning(
+                    "Allowlist cleared (no names resolved). "
+                    "All accounts are eligible.",
+                )
+            return 0
+
+        if action == "add":
+            added, skipped = allowlist_mod.add_to_allowlist(workspace, names)
+            failure_counts.reset_all(workspace)
+            if added:
+                log_success(f"Added {len(added)} account(s): {', '.join(added)}")
+            if skipped:
+                log_info(f"Already present: {', '.join(skipped)}")
+            return 0
+
+        if action == "remove":
+            removed, skipped = allowlist_mod.remove_from_allowlist(workspace, names)
+            failure_counts.reset_all(workspace)
+            if removed:
+                log_success(f"Removed {len(removed)} account(s): {', '.join(removed)}")
+            if skipped:
+                log_warning(f"Not in allowlist: {', '.join(skipped)}")
+            return 0
+
+    except allowlist_mod.UnknownAccountError as exc:
+        log_error(str(exc))
+        return 2
+    except FileNotFoundError as exc:
+        log_error(str(exc))
+        return 1
+
+    log_error(f"Unknown pin action: {action}")
+    return 1
+
+
+def _pin_status(workspace: Path, *, emit_json: bool) -> int:
+    """Print the current allowlist and account roster."""
+    try:
+        all_accounts = allowlist_mod.list_accounts(workspace)
+        active = allowlist_mod.read_allowlist(workspace)
+    except OSError as exc:
+        log_error(str(exc))
+        return 1
+
+    if emit_json:
+        payload = {
+            "allowlist_active": bool(active),
+            "allowlist": active,
+            "accounts": all_accounts,
+        }
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    if active:
+        print(f"Allowlist active ({len(active)} account(s)):")
+        for name in active:
+            print(f"  * {name}")
+    else:
+        print("No allowlist active — all accounts are eligible.")
+
+    if all_accounts:
+        print()
+        print(f"Available accounts ({len(all_accounts)}):")
+        active_set = set(active)
+        for name in all_accounts:
+            mark = "*" if name in active_set else " "
+            print(f"  {mark} {name}")
+    else:
+        print()
+        log_warning(
+            "No .token files found. Run `loom-tokens bootstrap` first.",
+        )
+    return 0
+
+
+def _cmd_unpin(args: argparse.Namespace) -> int:
+    """Handle ``loom-tokens unpin``."""
+    workspace = _resolve_workspace()
+    if workspace is None:
+        return 1
+    try:
+        had_file = allowlist_mod.clear_allowlist(workspace)
+    except OSError as exc:
+        log_error(str(exc))
+        return 1
+    failure_counts.reset_all(workspace)
+
+    if getattr(args, "emit_json", False):
+        print(json.dumps({"cleared": had_file}, indent=2))
+        return 0
+
+    if had_file:
+        log_success("Allowlist cleared. All accounts are eligible.")
+    else:
+        log_info("No allowlist was active.")
+    return 0
+
+
+# Reasons we treat as "auth" for the unblock command. Match
+# case-insensitively against the free-form reason field of bad_tokens
+# entries. We do NOT match TOKEN_EXHAUSTED — those expire on their own.
+_AUTH_REASON_RE = re.compile(
+    r"\b("
+    r"401|"
+    r"oauth|"
+    r"auth(entication)?|"
+    r"unauthorized|"
+    r"token[_\s]?expired|"
+    r"expired|"
+    r"blocked"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+def _cmd_unblock(args: argparse.Namespace) -> int:
+    """Handle ``loom-tokens unblock <names...> [--all-reasons]``."""
+    workspace = _resolve_workspace()
+    if workspace is None:
+        return 1
+
+    # Validate names against bootstrapped accounts (EXACT match).
+    available = allowlist_mod.list_accounts(workspace)
+    available_set = set(available)
+    names: list[str] = []
+    for raw in args.names:
+        name = raw.strip()
+        if not name:
+            continue
+        if name not in available_set:
+            log_error(
+                f"Unknown account '{name}'. "
+                f"Available: {', '.join(available) if available else '(none)'}",
+            )
+            return 2
+        names.append(name)
+
+    if not names:
+        log_error("`unblock` requires at least one account name.")
+        return 1
+
+    bad_file = workspace / ".loom" / "tokens" / ".bad_tokens"
+    lock_path = workspace / ".loom" / "tokens" / ".bad_tokens.lock"
+
+    # Reuse the bad_tokens lock to coordinate with concurrent appenders.
+    from loom_tools.tokens.bad_tokens import _MkdirLock
+
+    if not bad_file.is_file():
+        if getattr(args, "emit_json", False):
+            print(json.dumps({"removed": 0, "kept": 0}, indent=2))
+        else:
+            log_info("No .bad_tokens file. Nothing to unblock.")
+        return 0
+
+    target_set = set(names)
+    removed = 0
+    kept_lines: list[str] = []
+    with _MkdirLock(lock_path):
+        try:
+            lines = bad_file.read_text(encoding="utf-8").splitlines()
+        except OSError as exc:
+            log_error(f"Failed to read .bad_tokens: {exc}")
+            return 1
+        for line in lines:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            parts = stripped.split(maxsplit=2)
+            if len(parts) < 2:
+                # Malformed — keep so we don't lose data.
+                kept_lines.append(line)
+                continue
+            entry_name = parts[1]
+            reason = parts[2] if len(parts) >= 3 else ""
+            if entry_name in target_set:
+                if args.all_reasons or _AUTH_REASON_RE.search(reason):
+                    removed += 1
+                    continue
+            kept_lines.append(line)
+
+        # Atomic rewrite via temp file (matches cleanup_bad_tokens).
+        tmp = bad_file.with_suffix(bad_file.suffix + ".tmp")
+        if kept_lines:
+            tmp.write_text(
+                "\n".join(kept_lines) + "\n",
+                encoding="utf-8",
+            )
+        else:
+            tmp.write_text("", encoding="utf-8")
+        os.replace(tmp, bad_file)
+
+    # Reset failure counters for the unblocked accounts so the auto-unpin
+    # heuristic doesn't fire immediately on the next failure.
+    for name in names:
+        failure_counts.record_success(workspace, name)
+
+    if getattr(args, "emit_json", False):
+        print(
+            json.dumps(
+                {"removed": removed, "kept": len(kept_lines)},
+                indent=2,
+            ),
+        )
+    else:
+        if removed:
+            log_success(
+                f"Removed {removed} bad-token entr{'y' if removed == 1 else 'ies'}"
+                f" for: {', '.join(names)}",
+            )
+        else:
+            log_info(
+                f"No matching entries removed (use --all-reasons to drop "
+                f"non-auth entries too).",
+            )
     return 0
 
 

--- a/loom-tools/src/loom_tools/tokens/failure_counts.py
+++ b/loom-tools/src/loom_tools/tokens/failure_counts.py
@@ -1,0 +1,228 @@
+"""Per-account consecutive-failure counter for token rotation.
+
+Tracks consecutive ``TOKEN_EXHAUSTED`` failures per account so the
+spawn wrapper can auto-unpin a stuck pin. The counter is stored at
+``.loom/tokens/.failure_counts`` as JSON::
+
+    {"<account_name>": {"count": <int>, "last_failure": "<ISO8601 UTC>"}}
+
+The counter is reset on:
+
+* a successful spawn for that account (``record_success``),
+* any operator allowlist mutation (``pin``, ``unpin``, ``add``, ``remove``).
+
+Reaching the threshold (default 5) is the signal that the operator's
+pin must be auto-released by the wrapper. The threshold check is
+``>= 5`` — a 6th failure does not bump the count past the trigger; it
+still triggers (idempotent at-or-above).
+
+Concurrency:
+    Writes are guarded by a sibling ``mkdir``-lock and use the
+    "atomic rewrite" pattern (``mktemp`` + ``os.replace``). Concurrent
+    bash and Python writers (e.g. spawn-claude.sh and the operator
+    CLI) are coordinated via the same lock dir.
+
+Public API:
+    record_failure(workspace, name, *, threshold=5) -> int
+    record_success(workspace, name) -> None
+    reset_all(workspace) -> None
+    get_count(workspace, name) -> int
+    threshold_reached(workspace, name, *, threshold=5) -> bool
+    DEFAULT_THRESHOLD
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Reuse the lock primitive from bad_tokens (mkdir-only, macOS-safe).
+from loom_tools.tokens.bad_tokens import _MkdirLock
+
+DEFAULT_THRESHOLD = 5
+
+
+def _tokens_dir(workspace: Path | str) -> Path:
+    return Path(workspace) / ".loom" / "tokens"
+
+
+def _state_path(workspace: Path | str) -> Path:
+    return _tokens_dir(workspace) / ".failure_counts"
+
+
+def _lock_path(workspace: Path | str) -> Path:
+    return _tokens_dir(workspace) / ".failure_counts.lock"
+
+
+def _ensure_dir(workspace: Path | str) -> Path:
+    d = _tokens_dir(workspace)
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _read_state(path: Path) -> dict[str, dict[str, object]]:
+    """Read the JSON state file, returning ``{}`` on any failure.
+
+    A malformed or unreadable file is treated as an empty state — better
+    to lose history than to refuse to record new failures.
+    """
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except (FileNotFoundError, OSError):
+        return {}
+    if not raw.strip():
+        return {}
+    try:
+        loaded = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(loaded, dict):
+        return {}
+    # Filter out malformed entries defensively
+    cleaned: dict[str, dict[str, object]] = {}
+    for k, v in loaded.items():
+        if not isinstance(k, str) or not isinstance(v, dict):
+            continue
+        count = v.get("count", 0)
+        if not isinstance(count, int) or count < 0:
+            continue
+        last = v.get("last_failure", "")
+        if not isinstance(last, str):
+            last = ""
+        cleaned[k] = {"count": count, "last_failure": last}
+    return cleaned
+
+
+def _write_state_atomic(path: Path, state: dict[str, dict[str, object]]) -> None:
+    """Write state via mktemp + os.replace (atomic on POSIX)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_str = tempfile.mkstemp(
+        prefix=path.name + ".",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    tmp = Path(tmp_str)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(state, fh, indent=2, sort_keys=True)
+            fh.write("\n")
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def record_failure(
+    workspace: Path | str,
+    name: str,
+    *,
+    threshold: int = DEFAULT_THRESHOLD,
+) -> int:
+    """Increment the consecutive-failure counter for ``name``.
+
+    Args:
+        workspace: Repo root containing ``.loom/tokens/``.
+        name: Account name (token file stem).
+        threshold: Counter is capped at ``threshold`` to avoid unbounded
+            growth (we only ever check ``>=``, so capping is harmless).
+
+    Returns:
+        The new count (post-increment), capped at ``threshold``.
+    """
+    _ensure_dir(workspace)
+    path = _state_path(workspace)
+    with _MkdirLock(_lock_path(workspace)):
+        state = _read_state(path)
+        entry = state.get(name) or {"count": 0, "last_failure": ""}
+        new_count = min(int(entry.get("count", 0)) + 1, threshold)
+        state[name] = {"count": new_count, "last_failure": _now_iso()}
+        _write_state_atomic(path, state)
+        return new_count
+
+
+def record_success(workspace: Path | str, name: str) -> None:
+    """Reset the counter for ``name`` (drops the key entirely).
+
+    Args:
+        workspace: Repo root containing ``.loom/tokens/``.
+        name: Account name (token file stem).
+
+    No-op if the state file is missing or the key is absent.
+    """
+    path = _state_path(workspace)
+    if not path.is_file():
+        return
+    with _MkdirLock(_lock_path(workspace)):
+        state = _read_state(path)
+        if name not in state:
+            return
+        del state[name]
+        if state:
+            _write_state_atomic(path, state)
+        else:
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+
+
+def reset_all(workspace: Path | str) -> None:
+    """Drop all per-account counters.
+
+    Called from the allowlist CLI after any mutation (``pin``,
+    ``unpin``, ``add``, ``remove``) so a fresh allowlist starts with
+    a clean slate. No-op if the state file is missing.
+    """
+    path = _state_path(workspace)
+    if not path.is_file():
+        return
+    with _MkdirLock(_lock_path(workspace)):
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def get_count(workspace: Path | str, name: str) -> int:
+    """Return the current consecutive-failure count for ``name`` (0 if absent)."""
+    path = _state_path(workspace)
+    if not path.is_file():
+        return 0
+    state = _read_state(path)
+    entry = state.get(name)
+    if not entry:
+        return 0
+    count = entry.get("count", 0)
+    return int(count) if isinstance(count, int) else 0
+
+
+def threshold_reached(
+    workspace: Path | str,
+    name: str,
+    *,
+    threshold: int = DEFAULT_THRESHOLD,
+) -> bool:
+    """Return True iff the counter for ``name`` is ``>= threshold``."""
+    return get_count(workspace, name) >= threshold
+
+
+def all_counts(workspace: Path | str) -> dict[str, dict[str, object]]:
+    """Return the entire state dict (for status / debugging).
+
+    The returned dict is a snapshot — mutating it does not affect the
+    persisted state.
+    """
+    path = _state_path(workspace)
+    if not path.is_file():
+        return {}
+    return _read_state(path)

--- a/loom-tools/tests/tokens/test_allowlist.py
+++ b/loom-tools/tests/tokens/test_allowlist.py
@@ -1,0 +1,203 @@
+"""Tests for loom_tools.tokens.allowlist."""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+from pathlib import Path
+
+import pytest
+
+from loom_tools.tokens import allowlist
+from loom_tools.tokens.allowlist import (
+    UnknownAccountError,
+    add_to_allowlist,
+    clear_allowlist,
+    list_accounts,
+    read_allowlist,
+    remove_from_allowlist,
+    write_allowlist,
+)
+
+
+def _make_workspace(tmp_path: Path, names: list[str]) -> Path:
+    d = tmp_path / ".loom" / "tokens"
+    d.mkdir(parents=True)
+    for name in names:
+        (d / f"{name}.token").write_text("dummy", encoding="utf-8")
+    return tmp_path
+
+
+def test_list_accounts_empty(tmp_path):
+    ws = _make_workspace(tmp_path, [])
+    assert list_accounts(ws) == []
+
+
+def test_list_accounts_sorted(tmp_path):
+    ws = _make_workspace(tmp_path, ["alpha", "agent-1", "agent-10", "agent-2"])
+    assert list_accounts(ws) == ["agent-1", "agent-10", "agent-2", "alpha"]
+
+
+def test_list_accounts_no_dir(tmp_path):
+    # Nothing in tmp_path — no .loom/tokens/ dir.
+    assert list_accounts(tmp_path) == []
+
+
+def test_read_allowlist_missing_returns_empty(tmp_path):
+    ws = _make_workspace(tmp_path, ["agent-1"])
+    assert read_allowlist(ws) == []
+
+
+def test_write_allowlist_exact_match(tmp_path):
+    ws = _make_workspace(tmp_path, ["agent-1", "agent-2", "agent-3"])
+    written = write_allowlist(ws, ["agent-2", "agent-1"])
+    assert written == ["agent-2", "agent-1"]
+    assert read_allowlist(ws) == ["agent-2", "agent-1"]
+
+
+def test_write_rejects_unknown_account(tmp_path):
+    ws = _make_workspace(tmp_path, ["agent-1"])
+    with pytest.raises(UnknownAccountError) as exc:
+        write_allowlist(ws, ["agent-1", "ghost"])
+    assert "ghost" in str(exc.value)
+
+
+def test_write_rejects_substring_match(tmp_path):
+    """EXACT match required — partial 'agent' must not resolve to agent-1."""
+    ws = _make_workspace(tmp_path, ["agent-1", "agent-2"])
+    with pytest.raises(UnknownAccountError):
+        write_allowlist(ws, ["agent"])
+
+
+def test_write_dedupes(tmp_path):
+    ws = _make_workspace(tmp_path, ["agent-1", "agent-2"])
+    written = write_allowlist(ws, ["agent-1", "agent-1", "agent-2"])
+    assert written == ["agent-1", "agent-2"]
+
+
+def test_write_empty_clears_file(tmp_path):
+    ws = _make_workspace(tmp_path, ["agent-1"])
+    write_allowlist(ws, ["agent-1"])
+    assert (ws / ".loom" / "tokens" / ".allowlist").is_file()
+    write_allowlist(ws, [])
+    assert not (ws / ".loom" / "tokens" / ".allowlist").exists()
+
+
+def test_add_new_and_existing(tmp_path):
+    ws = _make_workspace(tmp_path, ["a", "b", "c"])
+    write_allowlist(ws, ["a"])
+    added, skipped = add_to_allowlist(ws, ["a", "b"])
+    assert added == ["b"]
+    assert skipped == ["a"]
+    assert read_allowlist(ws) == ["a", "b"]
+
+
+def test_add_unknown_raises(tmp_path):
+    ws = _make_workspace(tmp_path, ["a"])
+    with pytest.raises(UnknownAccountError):
+        add_to_allowlist(ws, ["ghost"])
+
+
+def test_remove_some(tmp_path):
+    ws = _make_workspace(tmp_path, ["a", "b", "c"])
+    write_allowlist(ws, ["a", "b", "c"])
+    removed, skipped = remove_from_allowlist(ws, ["b"])
+    assert removed == ["b"]
+    assert skipped == []
+    assert read_allowlist(ws) == ["a", "c"]
+
+
+def test_remove_last_drops_file(tmp_path):
+    ws = _make_workspace(tmp_path, ["a"])
+    write_allowlist(ws, ["a"])
+    remove_from_allowlist(ws, ["a"])
+    assert not (ws / ".loom" / "tokens" / ".allowlist").exists()
+
+
+def test_remove_unknown_raises(tmp_path):
+    ws = _make_workspace(tmp_path, ["a"])
+    write_allowlist(ws, ["a"])
+    with pytest.raises(UnknownAccountError):
+        remove_from_allowlist(ws, ["ghost"])
+
+
+def test_remove_known_but_not_in_allowlist(tmp_path):
+    ws = _make_workspace(tmp_path, ["a", "b"])
+    write_allowlist(ws, ["a"])
+    removed, skipped = remove_from_allowlist(ws, ["b"])
+    # b is a real account, but wasn't in the allowlist
+    assert removed == []
+    assert skipped == ["b"]
+
+
+def test_clear_allowlist_returns_status(tmp_path):
+    ws = _make_workspace(tmp_path, ["a"])
+    assert clear_allowlist(ws) is False  # no file
+    write_allowlist(ws, ["a"])
+    assert clear_allowlist(ws) is True
+    assert clear_allowlist(ws) is False  # already gone
+
+
+def test_read_handles_comments_and_blanks(tmp_path):
+    ws = _make_workspace(tmp_path, ["a", "b"])
+    f = ws / ".loom" / "tokens" / ".allowlist"
+    f.write_text("# header\n\na\n  b  # inline\n# trailing\n", encoding="utf-8")
+    assert read_allowlist(ws) == ["a", "b"]
+
+
+def test_read_dedupes(tmp_path):
+    ws = _make_workspace(tmp_path, ["a", "b"])
+    f = ws / ".loom" / "tokens" / ".allowlist"
+    f.write_text("a\nb\na\n", encoding="utf-8")
+    assert read_allowlist(ws) == ["a", "b"]
+
+
+def test_missing_tokens_dir_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        write_allowlist(tmp_path, ["a"])
+
+
+# ---------- concurrent locking ----------
+
+
+def _add_worker(workspace_str: str, names: list[str]) -> None:
+    add_to_allowlist(workspace_str, names)
+
+
+def test_concurrent_add_no_loss(tmp_path):
+    """N processes adding distinct names should produce union, no drops."""
+    accounts = [f"a{i}" for i in range(10)]
+    ws = _make_workspace(tmp_path, accounts)
+    procs = []
+    for name in accounts:
+        p = mp.Process(target=_add_worker, args=(str(ws), [name]))
+        p.start()
+        procs.append(p)
+    for p in procs:
+        p.join(timeout=15)
+        assert p.exitcode == 0
+
+    final = set(read_allowlist(ws))
+    assert final == set(accounts)
+
+
+def test_lock_released_after_write(tmp_path):
+    ws = _make_workspace(tmp_path, ["a"])
+    write_allowlist(ws, ["a"])
+    lock = ws / ".loom" / "tokens" / ".allowlist.lock"
+    assert not lock.exists()
+
+
+def test_atomic_write_no_partial_files(tmp_path):
+    """No leftover ``.tmp`` files after a successful write."""
+    ws = _make_workspace(tmp_path, ["a", "b"])
+    write_allowlist(ws, ["a", "b"])
+    tokens_dir = ws / ".loom" / "tokens"
+    leftovers = list(tokens_dir.glob(".allowlist.*.tmp"))
+    assert leftovers == []
+
+
+def test_module_exports():
+    # Ensure the public API stays in __all__-style use.
+    assert hasattr(allowlist, "write_allowlist")
+    assert hasattr(allowlist, "read_allowlist")
+    assert hasattr(allowlist, "list_accounts")

--- a/loom-tools/tests/tokens/test_failure_counts.py
+++ b/loom-tools/tests/tokens/test_failure_counts.py
@@ -1,0 +1,206 @@
+"""Tests for loom_tools.tokens.failure_counts."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from loom_tools.tokens import failure_counts as fc
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    (tmp_path / ".loom" / "tokens").mkdir(parents=True)
+    return tmp_path
+
+
+def _state_file(workspace: Path) -> Path:
+    return workspace / ".loom" / "tokens" / ".failure_counts"
+
+
+def test_record_failure_increments(workspace: Path) -> None:
+    assert fc.record_failure(workspace, "agent-1") == 1
+    assert fc.record_failure(workspace, "agent-1") == 2
+    assert fc.record_failure(workspace, "agent-1") == 3
+
+
+def test_record_failure_caps_at_threshold(workspace: Path) -> None:
+    for _ in range(7):
+        fc.record_failure(workspace, "agent-1", threshold=5)
+    assert fc.get_count(workspace, "agent-1") == 5
+
+
+def test_record_failure_independent_per_account(workspace: Path) -> None:
+    fc.record_failure(workspace, "agent-1")
+    fc.record_failure(workspace, "agent-1")
+    fc.record_failure(workspace, "agent-2")
+    assert fc.get_count(workspace, "agent-1") == 2
+    assert fc.get_count(workspace, "agent-2") == 1
+
+
+def test_record_failure_writes_iso_timestamp(workspace: Path) -> None:
+    fc.record_failure(workspace, "agent-1")
+    raw = json.loads(_state_file(workspace).read_text())
+    last = raw["agent-1"]["last_failure"]
+    # YYYY-MM-DDTHH:MM:SSZ format
+    assert len(last) == 20
+    assert last.endswith("Z")
+    assert last[4] == "-" and last[10] == "T"
+
+
+def test_record_success_drops_account(workspace: Path) -> None:
+    fc.record_failure(workspace, "agent-1")
+    fc.record_failure(workspace, "agent-2")
+    fc.record_success(workspace, "agent-1")
+    assert fc.get_count(workspace, "agent-1") == 0
+    assert fc.get_count(workspace, "agent-2") == 1
+
+
+def test_record_success_unlinks_when_empty(workspace: Path) -> None:
+    fc.record_failure(workspace, "agent-1")
+    fc.record_success(workspace, "agent-1")
+    assert not _state_file(workspace).exists()
+
+
+def test_record_success_noop_when_absent(workspace: Path) -> None:
+    fc.record_success(workspace, "agent-1")  # state file does not exist
+    fc.record_failure(workspace, "agent-2")
+    fc.record_success(workspace, "agent-1")  # not in state
+    assert fc.get_count(workspace, "agent-2") == 1
+
+
+def test_reset_all_drops_file(workspace: Path) -> None:
+    fc.record_failure(workspace, "agent-1")
+    fc.record_failure(workspace, "agent-2")
+    fc.reset_all(workspace)
+    assert not _state_file(workspace).exists()
+    assert fc.get_count(workspace, "agent-1") == 0
+
+
+def test_reset_all_noop_when_missing(workspace: Path) -> None:
+    fc.reset_all(workspace)  # no file exists
+    assert not _state_file(workspace).exists()
+
+
+def test_get_count_zero_when_missing(workspace: Path) -> None:
+    assert fc.get_count(workspace, "agent-1") == 0
+
+
+def test_threshold_reached_below_and_at(workspace: Path) -> None:
+    for _ in range(4):
+        fc.record_failure(workspace, "agent-1", threshold=5)
+    assert not fc.threshold_reached(workspace, "agent-1", threshold=5)
+    fc.record_failure(workspace, "agent-1", threshold=5)
+    assert fc.threshold_reached(workspace, "agent-1", threshold=5)
+
+
+def test_threshold_reached_custom_threshold(workspace: Path) -> None:
+    for _ in range(3):
+        fc.record_failure(workspace, "agent-1", threshold=3)
+    assert fc.threshold_reached(workspace, "agent-1", threshold=3)
+    assert not fc.threshold_reached(workspace, "agent-1", threshold=5)
+
+
+def test_all_counts_snapshot(workspace: Path) -> None:
+    fc.record_failure(workspace, "agent-1")
+    fc.record_failure(workspace, "agent-2")
+    snap = fc.all_counts(workspace)
+    assert set(snap.keys()) == {"agent-1", "agent-2"}
+    assert snap["agent-1"]["count"] == 1
+    # Mutating the snapshot does not affect the file
+    snap["agent-3"] = {"count": 99, "last_failure": ""}
+    fresh = fc.all_counts(workspace)
+    assert "agent-3" not in fresh
+
+
+def test_all_counts_empty_when_missing(workspace: Path) -> None:
+    assert fc.all_counts(workspace) == {}
+
+
+def test_malformed_json_treated_as_empty(workspace: Path) -> None:
+    state_path = _state_file(workspace)
+    state_path.write_text("not json")
+    # Should not raise; should treat as empty and overwrite cleanly.
+    assert fc.record_failure(workspace, "agent-1") == 1
+    assert fc.get_count(workspace, "agent-1") == 1
+
+
+def test_filters_negative_counts(workspace: Path) -> None:
+    state_path = _state_file(workspace)
+    state_path.write_text(json.dumps({"agent-1": {"count": -3, "last_failure": ""}}))
+    # Negative count is invalid; treated as missing.
+    assert fc.get_count(workspace, "agent-1") == 0
+
+
+def test_filters_non_dict_entries(workspace: Path) -> None:
+    state_path = _state_file(workspace)
+    state_path.write_text(json.dumps({"agent-1": "garbage", "agent-2": {"count": 2, "last_failure": ""}}))
+    assert fc.get_count(workspace, "agent-1") == 0
+    assert fc.get_count(workspace, "agent-2") == 2
+
+
+def test_atomic_write_no_partial_files(workspace: Path) -> None:
+    tokens_dir = workspace / ".loom" / "tokens"
+    fc.record_failure(workspace, "agent-1")
+    fc.record_failure(workspace, "agent-2")
+    leftovers = [
+        p for p in tokens_dir.iterdir() if p.name.startswith(".failure_counts.") and p.suffix == ".tmp"
+    ]
+    assert leftovers == []
+
+
+def test_concurrent_record_failure_no_loss(workspace: Path) -> None:
+    """20 concurrent record_failure calls across 4 accounts → counts add up."""
+    src = textwrap.dedent(
+        """
+        import sys
+        from pathlib import Path
+        sys.path.insert(0, "{src}")
+        from loom_tools.tokens.failure_counts import record_failure
+        record_failure(Path("{ws}"), sys.argv[1])
+        """
+    ).format(
+        src=str(Path(__file__).parent.parent.parent / "src"),
+        ws=str(workspace),
+    )
+    script = workspace / "_run.py"
+    script.write_text(src)
+
+    procs = []
+    accounts = ["agent-1", "agent-2", "agent-3", "agent-4"]
+    iterations = 5  # 5 * 4 = 20 total writes
+    for _ in range(iterations):
+        for name in accounts:
+            procs.append(
+                subprocess.Popen([sys.executable, str(script), name])
+            )
+    for p in procs:
+        rc = p.wait()
+        assert rc == 0
+
+    # Default threshold is 5, but we capped each account at 5 increments,
+    # so each account should be at exactly 5 (which matches the cap).
+    # If concurrency lost any writes, we'd see < 5.
+    for name in accounts:
+        assert fc.get_count(workspace, name) == iterations, (
+            f"{name} expected {iterations}, got {fc.get_count(workspace, name)}"
+        )
+
+
+def test_state_file_in_correct_location(workspace: Path) -> None:
+    fc.record_failure(workspace, "agent-1")
+    expected = workspace / ".loom" / "tokens" / ".failure_counts"
+    assert expected.is_file()
+
+
+def test_lock_file_cleanup(workspace: Path) -> None:
+    fc.record_failure(workspace, "agent-1")
+    lock_dir = workspace / ".loom" / "tokens" / ".failure_counts.lock"
+    # _MkdirLock should have removed the lock dir on exit.
+    assert not lock_dir.exists()


### PR DESCRIPTION
Closes #3238

## Summary

Adds operator-facing controls for the multi-account token rotation system, completing the rotation epic (#3234, #3235, #3236, #3237 already merged).

## Changes

**New CLI subcommands (`loom-tokens`):**
- `pin <names>` / `pin add` / `pin remove` / `pin status` / `unpin` — allowlist management
- `unblock <name>` / `unblock --all-reasons` — clear bad-token entries

**New modules:**
- `loom_tools.tokens.allowlist` — exact-match-validated allowlist with mkdir-lock concurrency
- `loom_tools.tokens.failure_counts` — per-account consecutive-failure counter with atomic JSON rewrite

**Wrapper extension (`spawn-claude.sh`):**
- Auto-unpin guardrail (lean-genius failure mode 4): when all allowlisted accounts hit threshold (default 5 consecutive `TOKEN_EXHAUSTED`), clear `.allowlist` and reset counters with a loud stderr log line
- Empty-pool guard (lean-genius failure mode 3): refuses to silently auto-clear `.bad_tokens` — operators must intervene

**Counters reset on:**
- successful spawn for that account, or
- any operator allowlist mutation (`pin`, `unpin`, `add`, `remove`)

## Test Plan
- [x] 23 new allowlist tests (CRUD, validation, concurrency, atomic write)
- [x] 21 new failure_counts tests (increment, threshold cap, reset, malformed-json, concurrent)
- [x] Full token suite 149/149 green
- [x] CLI surfaces verified manually (`loom-tokens pin --help`, `unblock --help`)
- [x] Shellcheck clean on `spawn-claude.sh` modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)