### PR TITLE
fix(workflows): remove broken push trigger from label-external-issues template

### DIFF
--- a/defaults/optional/github-workflows/label-external-issues.yml
+++ b/defaults/optional/github-workflows/label-external-issues.yml
@@ -3,27 +3,13 @@ name: Label external issues
 on:
   issues:
     types: [opened]
-  push:
-    paths:
-      - '.github/workflows/label-external-issues.yml'
 
 permissions:
   issues: write
   contents: read
 
 jobs:
-  # Guard job to prevent workflow failure on push events
-  # GitHub Actions marks runs as failed when no jobs execute, so this ensures
-  # at least one job runs. Using explicit true condition for clarity.
-  validate:
-    if: ${{ true }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Workflow syntax valid
-        run: echo "Workflow file validated successfully"
-
   label_external:
-    if: ${{ github.event_name == 'issues' }}
     runs-on: ubuntu-latest
     steps:
       - name: Check if author is a collaborator


### PR DESCRIPTION
Closes #3255

## Summary

The Loom-installed workflow template `defaults/optional/github-workflows/label-external-issues.yml` ships a `push:` trigger that produces ~50 false-positive failed-CI emails per day on repos with active branch creation. Every new branch push fires a run that completes with `conclusion=failure` because the intended guard job never executes.

## Root Cause

Two compounding bugs:

1. **`paths:` filter does not exclude first-push of a new branch.** GitHub treats the initial push of a branch as adding every file at the branch tip, so the workflow fires on every `feature/*`, `research/*`, `issue-*` branch creation. Loom autonomous agents create dozens of these per day.

2. **The `validate` guard job never runs.** It was intended to ensure at least one job executes on push events so the run isn't marked failed-due-to-zero-jobs, but in practice `gh api .../jobs` returns `[]` and `conclusion=failure`. GitHub then notifies the repository owner.

## Changes

Per the curation comment's recommended fix:

- Remove `push:` trigger from `on:` block
- Remove the `validate` guard job entirely (no dead guard job)
- Remove `if: github.event_name == 'issues'` from `label_external` (unconditional, since `issues.opened` is now the only trigger)

The workflow's only useful path -- labeling external issues at open time -- is unchanged.

## Test Plan

- [x] Verified diff matches the curation proposal exactly
- [x] YAML parses (note: PyYAML/actionlint both fail on the pre-existing embedded JS template literal; this is unchanged from main and GitHub Actions' parser handles it fine in production)
- [ ] Manual install verification (out of scope -- template ships to user repos)

## Note on Validation Tools

Both `python3 -c "import yaml"` and `actionlint` fail to parse this file on **main** as well as in this PR, due to the embedded multi-line JavaScript template literal (lines starting at column 1 inside a `|` block scalar). GitHub Actions' YAML parser is more lenient and handles it correctly in production. My changes do not touch the script block, only the `on:` and `jobs:` keys, so the parser behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)