### PR TITLE
fix(install): decouple loom-daemon build from pnpm preflight

### DIFF
--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -23,7 +23,7 @@
 #     - Target must be a Git repository with a remote
 #     - For GitHub: GitHub CLI (gh) must be authenticated
 #     - For Gitea: GITEA_TOKEN or FORGE_TOKEN environment variable must be set
-#     - loom-daemon binary must be built (pnpm daemon:build)
+#     - loom-daemon binary must be buildable (cargo build --package loom-daemon --release)
 #
 #   After installation:
 #     - Merge the generated PR in the target repository
@@ -438,7 +438,7 @@ else
   MISSING_DEPS+=("node")
 fi
 
-# Check for pnpm (needed to build daemon)
+# Check for pnpm (used by the JS workspace; no longer required for the daemon build)
 if command -v pnpm &> /dev/null; then
   success "pnpm: $(pnpm --version)"
 else
@@ -683,7 +683,13 @@ echo ""
 # Cargo's incremental compilation makes this fast (~1-2s) when nothing changed
 info "Building loom-daemon..."
 cd "$LOOM_ROOT"
-pnpm daemon:build || error "Failed to build loom-daemon"
+# Inlined from package.json `daemon:build` script to decouple from pnpm preflight (issue #3252).
+# The daemon is pure Rust; invoking via pnpm forced lockfile/workspace/build-script validation
+# of the loom source checkout, causing unrelated JS-toolchain drift to abort installation.
+cargo build --package loom-daemon --release || error "Failed to build loom-daemon"
+# Copy to architecture-specific name (Tauri sidecar convention)
+rm -f target/release/loom-daemon-aarch64-apple-darwin
+cp target/release/loom-daemon target/release/loom-daemon-aarch64-apple-darwin
 
 success "loom-daemon binary ready"
 


### PR DESCRIPTION
## Summary

Replaces `pnpm daemon:build` in `scripts/install-loom.sh` with the inlined cargo invocation it wraps. The daemon is pure Rust, but routing through pnpm forced lockfile / workspace / build-script approval validation against the loom source checkout — any unrelated JS-toolchain drift (e.g. unapproved esbuild build scripts) would abort installation with `ERR_PNPM_IGNORED_BUILDS`, misleadingly pointing at the daemon build.

## Changes

- `scripts/install-loom.sh:686` — replaced `pnpm daemon:build` with the equivalent `cargo build --package loom-daemon --release && rm -f ... && cp ...` sequence (matches `package.json` `daemon:build` exactly).
- `scripts/install-loom.sh:26` — header comment updated to reference cargo, not pnpm.
- `scripts/install-loom.sh:441` — preflight comment updated; pnpm check retained for the JS workspace but no longer claims to be a daemon-build precondition.

Cargo preflight at lines 448-453 already guarantees cargo is available, so no preflight changes are required.

## Test plan

- [x] `bash -n scripts/install-loom.sh` syntax check passes
- [x] `shellcheck scripts/install-loom.sh` introduces no new warnings (existing SC2086/SC2227/SC2295 unchanged)
- [x] Visual diff confirms inlined commands match `package.json` `daemon:build` script verbatim
- [ ] Manual verification: run installer from a checkout with dirty `pnpm-workspace.yaml` — daemon build should now succeed
- [ ] Manual verification: cargo failure path surfaces a cargo error, not a pnpm/esbuild error

Closes #3252