### PR TITLE
docs(curator): forbid pre-curating decomposed sub-issues

### DIFF
--- a/defaults/.claude/commands/loom/curator.md
+++ b/defaults/.claude/commands/loom/curator.md
@@ -224,6 +224,42 @@ Issue #99: "fix the crash bug"
 3. **Human Control**: Only humans decide what gets implemented (`loom:issue`)
 4. **Clear Standards**: `loom:curated` means enhanced, `loom:issue` means approved for work
 
+## Decomposing Oversized Issues
+
+If, during curation, you determine an issue is too large to be a single Builder PR (>6 hours, >8 files, or >400 LOC) and must be split into sub-issues:
+
+1. **Create each sub-issue with `loom:triage` only.** Do NOT apply `loom:curated`, even if your decomposition includes curator-quality detail (acceptance criteria, file references, scope guards).
+2. **Do NOT apply `loom:issue`** — only humans add `loom:issue`. This rule is unchanged for sub-issues (see "NEVER add `loom:issue`" below).
+3. **Update the parent issue's body or add a comment** with a "Decomposed sub-issues" section linking each child.
+4. **Do not close the parent during curation** — flag for human review (Curator never closes issues; see "Never Close Issues" below).
+5. **Do not self-curate your own sub-issues in the same session.** A separate Curator pass (could be the same human-role agent in a later session, or a different agent) must independently review each sub-issue before it can earn `loom:curated`.
+
+### Why this matters
+
+A dedicated Curator pass after decomposition catches:
+- Acceptance-criteria gaps the decomposer didn't surface
+- file:line citations that drift between decomposer-read time and builder-run time
+- Sub-issue dependencies the decomposer missed
+- Scope-guard sharpening (LOC limits, out-of-scope footnotes)
+
+When skipped, the Builder hits these issues at implementation time — usually as a scope-guard trigger or a Doctor cycle — which is far more expensive than catching at curate time.
+
+**Scope note**: This two-pass rule applies *only* to sub-issues created during decomposition. Single-issue curation remains one pass — enhance and mark `loom:curated` in the same session as today.
+
+### Example
+
+```bash
+# WRONG: decomposer-curates in one pass
+gh issue create --title "Sub-issue A" --label "loom:curated"  # FORBIDDEN
+
+# RIGHT: decomposer creates at triage, leaves for separate curator pass
+gh issue create --title "Sub-issue A" --label "loom:triage"
+```
+
+### Related: Builder decomposition
+
+The Builder's complexity-assessment path (`defaults/.claude/commands/loom/builder-complexity.md`) currently labels decomposed sub-issues with `loom:issue` directly, skipping both human approval *and* Curator review. That parallel defect is **out of scope for this rule** and should be tracked in a separate follow-up issue; the Curator rule above stands on its own.
+
 ## Curation Activities
 
 ### Enhancement


### PR DESCRIPTION
Closes #3266

## Summary

Adds a new "Decomposing Oversized Issues" H2 section to `.loom/roles/curator.md` (canonical source: `defaults/.claude/commands/loom/curator.md`) that:

- Forbids applying `loom:curated` to sub-issues created during decomposition — they must be born at `loom:triage` only.
- Forbids the decomposer from self-curating their own children in the same session; a separate Curator pass is required before `loom:curated`.
- Reaffirms the existing rules: only humans add `loom:issue`, and Curators never close issues.
- Cross-references the parallel defect in `builder-complexity.md` line 40 as an out-of-scope follow-up.

This closes the structural gap that lets a single agent collapse decomposer review and dedicated Curator review into one pass, which the reporter observed in `spheresemi/sphere` #7264 → #7649-#7652. Also resolves the overlapping issue #3253 (same failure mode, different repro).

## Affected files

- `defaults/.claude/commands/loom/curator.md` (+36 lines, doc-only)

The repo's `.loom/roles/curator.md` is a symlink to this canonical source; both views reflect the change.

## Test plan

- [x] Section placed between "Triage" decision tree and "Curation Activities" (per curation guidance)
- [x] `grep -ni "decompos\\|sub-issue\\|split" .loom/roles/curator.md` returns matches in the new section
- [x] Section explicitly forbids `loom:curated` on sub-issues
- [x] Section directs decomposer to use `loom:triage`
- [x] "Do not self-curate your own sub-issues in the same session" verbatim
- [x] Reaffirms "only humans add `loom:issue`" (no regression on the human-approval gate)
- [x] Reaffirms "Curator never closes issues" (no regression)
- [x] Cross-reference to `builder-complexity.md` parallel defect noted as out-of-scope follow-up
- [x] No other files modified; no code changes
- [x] Single-issue curation flow explicitly unchanged via a "Scope note"