### PR TITLE
fix(epic): provision loom:epic labels in install bundle and skill preflight

### DIFF
--- a/defaults/.claude/commands/loom/epic.md
+++ b/defaults/.claude/commands/loom/epic.md
@@ -161,6 +161,25 @@ MILESTONE=$(grep -i "milestone" README.md 2>/dev/null | head -1)
 ./.loom/scripts/check-duplicate.sh "Epic: [Title]" "[brief description]"
 ```
 
+### Ensure Epic Labels Exist (Preflight)
+
+Epic creation depends on the `loom:epic` and `loom:epic-phase` labels, which may not yet exist in the target repository (e.g., if the install bundle predates these labels, or if a user manually deleted them). Run this idempotent preflight before any `gh issue create` call below. The `|| true` suffix keeps the skill working for users who lack `label:write` permission -- in that case, the subsequent `gh issue create --label` calls will fail cleanly with a clear "label not found" error rather than the skill silently dropping the epic.
+
+```bash
+# Idempotent: gh label create exits non-zero if the label already exists,
+# which we explicitly ignore. Failures from missing permissions are also
+# tolerated -- the issue-create step below will surface the real error.
+gh label create 'loom:epic' \
+  --color '7C3AED' \
+  --description 'Multi-phase epic proposal (decomposes into implementation issues)' \
+  2>/dev/null || true
+
+gh label create 'loom:epic-phase' \
+  --color '8B5CF6' \
+  --description 'Issue is part of an epic phase (references parent epic)' \
+  2>/dev/null || true
+```
+
 ### Create the Epic
 
 ```bash

--- a/defaults/.github/labels.yml
+++ b/defaults/.github/labels.yml
@@ -69,6 +69,15 @@
   description: Critical/blocking issue requiring immediate attention
   color: "DC2626"  # red-600
 
+# Epic Labels
+- name: loom:epic
+  description: Multi-phase epic proposal (decomposes into implementation issues)
+  color: "7C3AED"  # violet-600 - distinguishes from regular proposals
+
+- name: loom:epic-phase
+  description: Issue is part of an epic phase (references parent epic)
+  color: "8B5CF6"  # violet-500 - lighter variant for child issues
+
 # Tier Labels (Goal Alignment)
 - name: tier:goal-advancing
   description: Directly implements a milestone deliverable or unblocks goal work


### PR DESCRIPTION
Closes #3254

## Summary

The `/epic` skill hardcodes `--label "loom:epic"` and `--label "loom:epic-phase"` in its `gh issue create` calls. These labels exist in the Loom source repo's `.github/labels.yml`, but were missing from `defaults/.github/labels.yml` (the install bundle). As a result, `sync-labels.sh` never provisioned them in target repos, and `/epic` would silently abort with `could not add label: 'loom:epic' not found`.

Two-part fix (Option B from issue curation):

1. **Install bundle** -- Add `loom:epic` (color `7C3AED`) and `loom:epic-phase` (color `8B5CF6`) entries to `defaults/.github/labels.yml`, mirroring the source repo definitions. New installs and re-runs of `sync-labels.sh` now provision them automatically.

2. **Skill self-heal** -- Add a preflight section to `defaults/.claude/commands/loom/epic.md` (immediately after Duplicate Check, before Create the Epic). Runs `gh label create ... 2>/dev/null || true` for both labels. Idempotent on existing labels; tolerant of missing `label:write` permission (subsequent `gh issue create` will surface the real error rather than the skill silently dropping the epic).

## Test plan

- [x] `defaults/.github/labels.yml` parses as valid YAML and includes both new label entries
- [x] Label colors and descriptions match `.github/labels.yml` (source of truth)
- [ ] Manual: fresh install into a clean repo; `gh label list | grep epic` shows both labels
- [ ] Manual: delete labels in a Loom-installed repo, run `/epic`; preflight recreates them and epic creation succeeds