### PR TITLE
fix(worktree): robust submodule init (recursive, longer timeout, preserve stderr)

### DIFF
--- a/defaults/scripts/worktree.sh
+++ b/defaults/scripts/worktree.sh
@@ -533,9 +533,20 @@ if _try_worktree_add; then
     fi
 
     # Initialize submodules with reference to main workspace (for object sharing)
-    # This is much faster than downloading from network and saves disk space
+    # This is much faster than downloading from network and saves disk space.
+    #
+    # Uses --recursive to handle nested submodules (a top-level submodule may
+    # itself declare submodules; without --recursive those remain empty and a
+    # builder sees a half-populated reference directory with no error).
+    # Timeout is generous (300s) because cold clones of large reference corpora
+    # without an object cache can legitimately exceed 30s. Override via
+    # LOOM_SUBMODULE_TIMEOUT.
+    # Stderr is preserved (not redirected to /dev/null) so the underlying git
+    # error is visible to whoever runs worktree.sh -- the previous "Some
+    # submodules failed to initialize" warning was a black box.
     MAIN_GIT_DIR=$(git rev-parse --git-common-dir 2>/dev/null)
     UNINIT_SUBMODULES=$(cd "$ABS_WORKTREE_PATH" && git submodule status 2>/dev/null | grep '^-' | wc -l | tr -d ' ')
+    SUBMODULE_TIMEOUT="${LOOM_SUBMODULE_TIMEOUT:-300}"
 
     if [[ "$UNINIT_SUBMODULES" -gt 0 ]]; then
         if [[ "$JSON_OUTPUT" != "true" ]]; then
@@ -550,12 +561,12 @@ if _try_worktree_add; then
 
             if [[ -d "$ref_path" ]]; then
                 # Use reference to share objects with main workspace (fast, no network)
-                if ! timeout 30 git submodule update --init --reference "$ref_path" -- "$submod_path" 2>/dev/null; then
+                if ! timeout "$SUBMODULE_TIMEOUT" git submodule update --init --recursive --reference "$ref_path" -- "$submod_path"; then
                     echo "SUBMODULE_FAILED" > /tmp/loom-submodule-status-$$
                 fi
             else
                 # No reference available, initialize normally (may need network)
-                if ! timeout 30 git submodule update --init -- "$submod_path" 2>/dev/null; then
+                if ! timeout "$SUBMODULE_TIMEOUT" git submodule update --init --recursive -- "$submod_path"; then
                     echo "SUBMODULE_FAILED" > /tmp/loom-submodule-status-$$
                 fi
             fi
@@ -566,6 +577,7 @@ if _try_worktree_add; then
             rm -f "/tmp/loom-submodule-status-$$"
             if [[ "$JSON_OUTPUT" != "true" ]]; then
                 print_warning "Some submodules failed to initialize (worktree still created)"
+                print_info "See stderr above for the underlying git error."
                 print_info "You may need to run: git submodule update --init --recursive"
             fi
         else


### PR DESCRIPTION
## Summary

Tier 1 fix for #3250 -- the worktree script's submodule init was unreliable and its failures invisible. Three concrete causes addressed:

- **Not recursive**: `git submodule update --init` only initialized top-level submodules, leaving nested submodules empty. A builder saw a half-populated reference directory with no error signal. Adds `--recursive`.
- **30s timeout too short**: Cold clones of large reference corpora without an object cache (SQLite TCL corpus, sqllogictest) routinely exceeded 30s. Raised to 300s with `LOOM_SUBMODULE_TIMEOUT` override.
- **Stderr swallowed**: Both `git submodule update` calls redirected stderr to `/dev/null`, leaving only a generic "Some submodules failed" warning. Stop swallowing; the underlying git error (network, missing reference, permission, lock) now surfaces in worktree creation output.

## Files changed

- `defaults/scripts/worktree.sh` -- the canonical source. `.loom/scripts/worktree.sh` is a hardlink to this file, so it updates automatically (and git sees only one tracked change).

## Tiers deferred

The curation proposes three tiers. This PR implements **Tier 1 only**. Tiers 2-3 (empty-but-registered detection, per-submodule status output, CLAUDE.md/builder.md guidance) are appropriate as separate follow-up issues.

## Coordination note

PR for #3256 (sparse cone-mode) is also touching `defaults/scripts/worktree.sh`, but in a different section of the file (sparse-checkout setup vs. submodule init around lines 535-579). No textual conflict expected; whichever lands second will rebase cleanly.

## Test plan

- [x] `bash -n` clean on `defaults/scripts/worktree.sh` and `.loom/scripts/worktree.sh`
- [x] `shellcheck` clean (no new warnings introduced; one pre-existing SC2126 style note unrelated to this change)
- [ ] Manual: re-run on a vibesql-shaped repo with nested submodules and confirm both the parent and nested submodule trees populate
- [ ] Manual: temporarily break a submodule URL and confirm the git stderr (not the bland summary) reaches the terminal
- [ ] Manual: `LOOM_SUBMODULE_TIMEOUT=5 ./.loom/scripts/worktree.sh N` on a slow submodule -- verify the timeout fires and the failure surfaces clearly

Closes #3250