### PR TITLE
fix(curator): add re-curation playbook + clarify loom:curated label

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -77,7 +77,7 @@
   color: "6366F1"  # indigo-500 - indicates meta/tooling request
 
 - name: loom:curated
-  description: Enhanced by Curator, awaiting human approval
+  description: "Curator-enriched. Additive marker; coexists with loom:issue (highest-quality state for Builders)"
   color: "10B981"  # emerald-500
 
 # Status Labels

--- a/defaults/.claude/commands/loom/curator.md
+++ b/defaults/.claude/commands/loom/curator.md
@@ -116,6 +116,35 @@ gh issue list --label="loom:issue" --state=open --json number,title,labels \
 
 **Why prioritize these**: Human already approved the concept, Curator adds technical detail before Builder starts.
 
+### Re-curating Approved Issues
+
+Use this playbook when refreshing an already-approved (`loom:issue`) issue against current `main` — e.g., stale file refs, dependent fixes have merged, or scope drift needs clarification.
+
+**Default behavior** (recommended unless the four questions below indicate otherwise):
+
+1. **Retain `loom:issue`** — Do not remove human approval for non-material updates.
+2. **Add `loom:curated`** — Signals "fresh enrichment against current main is available." `loom:curated` is *additive*, not exclusive; it coexists with `loom:issue`. Builders prioritize `loom:issue` + `loom:curated` over `loom:issue` alone, so re-curation has direct downstream impact on Builder selection.
+3. **Prefer body edits over comments for stale references** — Keep the body as the single source of truth for Builders. Use a dated curator comment summarizing what changed (e.g., "Refreshed file refs after #NNNN merged on YYYY-MM-DD").
+4. **For material scope changes** — When you rewrite the problem statement, re-narrow root cause, or change acceptance criteria materially, remove `loom:issue` and leave only `loom:curated`. This forces fresh human re-approval.
+
+**The four decision questions** (use these to deviate from the default):
+
+| Question | Default | Deviate when |
+|----------|---------|--------------|
+| Retain `loom:issue`? | Yes | Material scope or AC change |
+| (Re-)add `loom:curated`? | Always yes | Never skip |
+| Comment vs body edit? | Body edit + dated comment | Pure context/links → comment |
+| Substantive rewrite? | Drop `loom:issue`, keep `loom:curated` | Minor refresh → keep both |
+
+**Discovery query** — find approved issues that haven't been re-curated recently:
+
+```bash
+# Approved issues missing fresh curation
+gh issue list --label="loom:issue" --state=open --json number,title,labels,updatedAt \
+  --jq '.[] | select(([.labels[].name] | contains(["loom:curated"]) | not)) |
+  "#\(.number) (updated \(.updatedAt)): \(.title)"'
+```
+
 ### Priority 2: Unlabeled Issues (Fallback)
 
 If no Priority 1 issues exist, find unlabeled issues:

--- a/defaults/.github/labels.yml
+++ b/defaults/.github/labels.yml
@@ -57,7 +57,7 @@
   color: "9333EA"  # purple (violet-600)
 
 - name: loom:curated
-  description: Enhanced by Curator, awaiting human approval
+  description: "Curator-enriched. Additive marker; coexists with loom:issue (highest-quality state for Builders)"
   color: "10B981"  # emerald-500
 
 # Status Labels


### PR DESCRIPTION
Closes #3249

## Summary

Two coordinated documentation fixes to make the `loom:curated` label semantically clear and give curators an explicit playbook for refreshing already-approved issues against current `main`.

## Changes

- **`.github/labels.yml` + `defaults/.github/labels.yml`** — Reword the `loom:curated` description from `"Enhanced by Curator, awaiting human approval"` (implies pre-approval exclusive state) to `"Curator-enriched. Additive marker; coexists with loom:issue (highest-quality state for Builders)"` (96 chars, under GitHub's 100-char limit).
- **`defaults/.claude/commands/loom/curator.md`** (canonical target of the `.loom/roles/curator.md` and `defaults/roles/curator.md` symlinks) — Add a new **"Re-curating Approved Issues"** subsection after Priority 1, covering:
  - Default behavior (retain `loom:issue`, always re-add `loom:curated`, prefer body edits with dated comment).
  - The four decision questions in a table (retain `loom:issue`? re-add `loom:curated`? comment vs body? substantive rewrite?).
  - A copy-pasteable `gh issue list` discovery query for `loom:issue` issues missing `loom:curated`.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/labels.yml'))"` on both label files — both pass.
- [x] Description length verified at 96 chars (< 100 GitHub limit).
- [x] Symlink chain (`.loom/roles/curator.md` → `defaults/roles/curator.md` → `defaults/.claude/commands/loom/curator.md`) verified — single canonical edit covers all three reference paths.
- [x] Manual re-read of new subsection in context — four questions answered, defaults unambiguous, discovery query is copy-pasteable.