### PR TITLE
fix(install): prefix hook commands with ${CLAUDE_PROJECT_DIR}

### DIFF
--- a/defaults/.claude/settings.json
+++ b/defaults/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".loom/hooks/guard-destructive.sh"
+            "command": "${CLAUDE_PROJECT_DIR}/.loom/hooks/guard-destructive.sh"
           }
         ]
       }
@@ -17,11 +17,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".loom/hooks/skill-router.sh"
+            "command": "${CLAUDE_PROJECT_DIR}/.loom/hooks/skill-router.sh"
           },
           {
             "type": "command",
-            "command": ".loom/hooks/methodology-inject.sh"
+            "command": "${CLAUDE_PROJECT_DIR}/.loom/hooks/methodology-inject.sh"
           }
         ]
       }

--- a/loom-daemon/src/init/scaffolding.rs
+++ b/loom-daemon/src/init/scaffolding.rs
@@ -14,8 +14,23 @@ use super::InitReport;
 
 /// Prefix used to identify Loom-owned hooks in settings.json.
 /// Hooks with commands starting with this prefix are managed by Loom.
+///
+/// Hooks are written with `${CLAUDE_PROJECT_DIR}/` prefix so that Claude Code
+/// expands them at hook-invocation time to the project root, ensuring the
+/// commands resolve regardless of the agent's current working directory.
 #[allow(dead_code)]
-pub const LOOM_HOOK_PREFIX: &str = ".loom/hooks/";
+pub const LOOM_HOOK_PREFIX: &str = "${CLAUDE_PROJECT_DIR}/.loom/hooks/";
+
+/// Legacy prefix for hooks installed before the `${CLAUDE_PROJECT_DIR}` migration.
+/// Used during merge/remove operations to detect and migrate stale entries.
+#[allow(dead_code)]
+pub const LEGACY_LOOM_HOOK_PREFIX: &str = ".loom/hooks/";
+
+/// Returns true if a command string belongs to Loom (matches new or legacy prefix).
+#[allow(dead_code)]
+fn is_loom_hook_command(cmd: &str) -> bool {
+    cmd.starts_with(LOOM_HOOK_PREFIX) || cmd.starts_with(LEGACY_LOOM_HOOK_PREFIX)
+}
 
 /// Loom section markers for CLAUDE.md content preservation
 pub const LOOM_SECTION_START: &str = "<!-- BEGIN LOOM ORCHESTRATION -->";
@@ -126,6 +141,10 @@ fn merge_hooks(
 }
 
 /// Merge hook commands within a single matcher entry, deduplicating by command path.
+///
+/// Also strips legacy Loom hook entries (bare `.loom/hooks/...` paths from pre-3265
+/// installs) so that re-running install does not leave duplicate hook invocations
+/// alongside the new `${CLAUDE_PROJECT_DIR}/.loom/hooks/...` entries.
 fn merge_hook_commands(existing_entry: &mut Value, loom_entry: &Value) {
     let Some(existing_hooks) = existing_entry
         .get_mut("hooks")
@@ -137,6 +156,14 @@ fn merge_hook_commands(existing_entry: &mut Value, loom_entry: &Value) {
     let Some(loom_hooks) = loom_entry.get("hooks").and_then(|h| h.as_array()) else {
         return;
     };
+
+    // First, strip legacy bare-relative Loom hooks so they don't coexist with the
+    // new ${CLAUDE_PROJECT_DIR}-prefixed versions. We only strip the *legacy* prefix
+    // here -- new-prefix entries are kept and serve as the dedup signal below.
+    existing_hooks.retain(|h| {
+        let cmd = h.get("command").and_then(|c| c.as_str()).unwrap_or("");
+        !cmd.starts_with(LEGACY_LOOM_HOOK_PREFIX) || cmd.starts_with(LOOM_HOOK_PREFIX)
+    });
 
     // Collect existing command paths for dedup
     let existing_commands: std::collections::HashSet<String> = existing_hooks
@@ -189,7 +216,11 @@ fn merge_permissions(
 
 /// Remove Loom-owned hooks from a settings.json value.
 ///
-/// Loom hooks are identified by command paths starting with `.loom/hooks/`.
+/// Loom hooks are identified by command paths starting with either the new
+/// `${CLAUDE_PROJECT_DIR}/.loom/hooks/` prefix or the legacy `.loom/hooks/`
+/// prefix (pre-3265 installs). Both are stripped so uninstall is clean for
+/// users on any prior version.
+///
 /// After removal, empty matcher entries and empty hook type arrays are cleaned up.
 #[allow(dead_code)]
 pub fn remove_loom_hooks(settings: &mut Value) {
@@ -212,7 +243,7 @@ pub fn remove_loom_hooks(settings: &mut Value) {
             {
                 hook_arr.retain(|hook| {
                     let cmd = hook.get("command").and_then(|c| c.as_str()).unwrap_or("");
-                    !cmd.starts_with(LOOM_HOOK_PREFIX)
+                    !is_loom_hook_command(cmd)
                 });
             }
         }
@@ -1331,7 +1362,56 @@ WARNING: Never run `lake build` inside Docker - causes memory corruption.
 
     #[test]
     fn test_merge_settings_deduplicates_hooks() {
-        // When project already has the Loom hook, don't add it again
+        // When project already has the new-prefix Loom hook, don't add it again
+        let existing: serde_json::Value = serde_json::from_str(
+            r#"{
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [
+                        {"type": "command", "command": "${CLAUDE_PROJECT_DIR}/.loom/hooks/guard-destructive.sh"},
+                        {"type": "command", "command": ".claude/hooks/custom-bash-guard.sh"}
+                    ]
+                }]
+            }
+        }"#,
+        )
+        .unwrap();
+
+        let loom_defaults: serde_json::Value = serde_json::from_str(
+            r#"{
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{"type": "command", "command": "${CLAUDE_PROJECT_DIR}/.loom/hooks/guard-destructive.sh"}]
+                }]
+            }
+        }"#,
+        )
+        .unwrap();
+
+        let merged = merge_settings_json(&existing, &loom_defaults);
+
+        // Should not duplicate the Loom hook
+        let bash_hooks = &merged["hooks"]["PreToolUse"][0]["hooks"];
+        let hooks_arr = bash_hooks.as_array().unwrap();
+        assert_eq!(hooks_arr.len(), 2, "Should not duplicate existing Loom hook");
+
+        // Both hooks should still be present
+        let commands: Vec<&str> = hooks_arr
+            .iter()
+            .map(|h| h["command"].as_str().unwrap())
+            .collect();
+        assert!(commands.contains(&"${CLAUDE_PROJECT_DIR}/.loom/hooks/guard-destructive.sh"));
+        assert!(commands.contains(&".claude/hooks/custom-bash-guard.sh"));
+    }
+
+    #[test]
+    fn test_merge_settings_migrates_legacy_hooks() {
+        // Pre-3265 installs have bare-relative `.loom/hooks/...` entries.
+        // On re-install, the merge must strip the legacy entry and add the new
+        // `${CLAUDE_PROJECT_DIR}/.loom/hooks/...` entry so the result has no
+        // duplicate invocations.
         let existing: serde_json::Value = serde_json::from_str(
             r#"{
             "hooks": {
@@ -1352,7 +1432,7 @@ WARNING: Never run `lake build` inside Docker - causes memory corruption.
             "hooks": {
                 "PreToolUse": [{
                     "matcher": "Bash",
-                    "hooks": [{"type": "command", "command": ".loom/hooks/guard-destructive.sh"}]
+                    "hooks": [{"type": "command", "command": "${CLAUDE_PROJECT_DIR}/.loom/hooks/guard-destructive.sh"}]
                 }]
             }
         }"#,
@@ -1361,18 +1441,33 @@ WARNING: Never run `lake build` inside Docker - causes memory corruption.
 
         let merged = merge_settings_json(&existing, &loom_defaults);
 
-        // Should not duplicate the Loom hook
         let bash_hooks = &merged["hooks"]["PreToolUse"][0]["hooks"];
         let hooks_arr = bash_hooks.as_array().unwrap();
-        assert_eq!(hooks_arr.len(), 2, "Should not duplicate existing Loom hook");
 
-        // Both hooks should still be present
         let commands: Vec<&str> = hooks_arr
             .iter()
             .map(|h| h["command"].as_str().unwrap())
             .collect();
-        assert!(commands.contains(&".loom/hooks/guard-destructive.sh"));
+
+        // Legacy bare-relative entry must be stripped
+        assert!(
+            !commands.contains(&".loom/hooks/guard-destructive.sh"),
+            "Legacy bare-relative hook should be removed during merge"
+        );
+        // New prefix entry must be present
+        assert!(
+            commands.contains(&"${CLAUDE_PROJECT_DIR}/.loom/hooks/guard-destructive.sh"),
+            "New ${{CLAUDE_PROJECT_DIR}}-prefixed hook must be added"
+        );
+        // Custom project hook must be preserved
         assert!(commands.contains(&".claude/hooks/custom-bash-guard.sh"));
+
+        // Exactly 2 entries: new Loom hook + custom project hook (no duplicate)
+        assert_eq!(
+            hooks_arr.len(),
+            2,
+            "Should have exactly 2 hooks: new Loom hook + custom project hook"
+        );
     }
 
     #[test]

--- a/scripts/test-installer.sh
+++ b/scripts/test-installer.sh
@@ -323,6 +323,42 @@ else
   fail ".claude/settings.json missing"
 fi
 
+# Test 12b: Hook commands use ${CLAUDE_PROJECT_DIR} prefix (issue #3265)
+# Hooks must use ${CLAUDE_PROJECT_DIR}/.loom/hooks/... so they resolve regardless
+# of the agent's current working directory. Bare-relative paths fail when the
+# session cwd has moved into a subdirectory.
+echo "Test 12b: Hook commands use \${CLAUDE_PROJECT_DIR} prefix"
+SETTINGS_FILE="$INSTALL_REPO/.claude/settings.json"
+if [[ -f "$SETTINGS_FILE" ]] && command -v jq &> /dev/null; then
+  HOOK_PREFIX_FAIL=0
+  for hook_name in guard-destructive.sh skill-router.sh methodology-inject.sh; do
+    # Collect every command in the settings.json that ends with this hook script.
+    matches=$(jq -r --arg name "$hook_name" \
+      '[.. | objects | select(.command? != null) | .command | select(endswith($name))][]' \
+      "$SETTINGS_FILE" 2>/dev/null)
+    if [[ -z "$matches" ]]; then
+      fail "Hook command for $hook_name not found in settings.json"
+      HOOK_PREFIX_FAIL=1
+      continue
+    fi
+    while IFS= read -r cmd; do
+      [[ -z "$cmd" ]] && continue
+      # The literal string '${CLAUDE_PROJECT_DIR}' must appear at the start
+      # (not the expanded value -- the JSON stores the placeholder verbatim
+      # and Claude Code expands it at hook-invocation time).
+      if [[ "$cmd" != '${CLAUDE_PROJECT_DIR}/.loom/hooks/'* ]]; then
+        fail "Hook command does not use \${CLAUDE_PROJECT_DIR} prefix: $cmd"
+        HOOK_PREFIX_FAIL=1
+      fi
+    done <<< "$matches"
+  done
+  if [[ $HOOK_PREFIX_FAIL -eq 0 ]]; then
+    pass "All Loom hook commands use \${CLAUDE_PROJECT_DIR} prefix"
+  fi
+else
+  fail "Cannot verify hook command prefixes (settings.json or jq missing)"
+fi
+
 # Test 13: .github/labels.yml
 echo "Test 13: Install creates .github/labels.yml"
 if [[ -f "$INSTALL_REPO/.github/labels.yml" ]]; then

--- a/scripts/uninstall-loom.sh
+++ b/scripts/uninstall-loom.sh
@@ -973,7 +973,11 @@ if [[ -f "$WORKTREE_ABS/.claude/settings.json" ]]; then
     # and Loom permissions (exact matches from defaults)
 
     # Build jq filter to remove Loom hooks
-    # Step 1: Remove hooks with .loom/hooks/ command prefix
+    # Step 1: Remove hooks whose command starts with the new Loom prefix
+    #         (${CLAUDE_PROJECT_DIR}/.loom/hooks/) OR the legacy bare-relative
+    #         prefix (.loom/hooks/) from pre-3265 installs. Both must be
+    #         stripped so uninstall is clean regardless of when Loom was first
+    #         installed.
     # Step 2: Clean up empty matcher entries and hook types
     # Step 3: Remove Loom-specific permissions
     LOOM_PERMS=$(jq -r '.permissions.allow // [] | .[]' "$LOOM_DEFAULTS_SETTINGS" 2>/dev/null)
@@ -991,13 +995,26 @@ if [[ -f "$WORKTREE_ABS/.claude/settings.json" ]]; then
       fi
     done <<< "$LOOM_PERMS"
 
-    # Apply the combined jq transformation
-    jq --arg hook_prefix ".loom/hooks/" "
-      # Remove Loom hooks (commands starting with .loom/hooks/)
+    # Apply the combined jq transformation.
+    #
+    # Note: $hook_prefix is the new Loom prefix, which contains the literal
+    # string '${CLAUDE_PROJECT_DIR}'. We single-quote the value passed to
+    # --arg so bash does NOT expand the variable -- the shell's
+    # $CLAUDE_PROJECT_DIR is unset/empty in this context, and we need the
+    # literal string preserved so jq's startswith check matches the
+    # template-installed entries verbatim.
+    jq --arg hook_prefix '${CLAUDE_PROJECT_DIR}/.loom/hooks/' \
+       --arg legacy_hook_prefix '.loom/hooks/' "
+      # Remove Loom hooks (commands starting with either the new prefix or
+      # the legacy bare-relative prefix from pre-3265 installs)
       (if .hooks then
         .hooks |= with_entries(
           .value |= map(
-            .hooks |= map(select(.command | startswith(\$hook_prefix) | not))
+            .hooks |= map(select(
+              (.command | startswith(\$hook_prefix))
+              or (.command | startswith(\$legacy_hook_prefix))
+              | not
+            ))
           )
           | .value |= map(select(.hooks | length > 0))
         )


### PR DESCRIPTION
## Summary

Loom's installer registered Claude Code hooks with bare-relative paths like `.loom/hooks/skill-router.sh`. Hook subprocesses inherit the session's shell `cwd`, so as soon as an agent runs `cd subdir/...` during a long-lived session, all three hooks fail with `No such file or directory` errors. This silently disables `guard-destructive.sh` (PreToolUse safety) and breaks `methodology-inject.sh` / `skill-router.sh` on every prompt.

Prefixing each command with `${CLAUDE_PROJECT_DIR}/` lets Claude Code expand the variable shell-side to the repo root at hook-invocation time, resolving the script reliably regardless of cwd. The variable is stored verbatim in JSON; Claude Code does the expansion, not the installer.

The fix touches three coordinated locations (template, detection prefix in Rust, detection prefix in uninstaller) plus the installer test. A legacy-prefix migration path strips bare-relative entries during re-install so users upgrading from earlier versions do not accumulate duplicate hook invocations.

Closes #3265.
Also resolves #3251 (duplicate of #3265).

## Changes

- **`defaults/.claude/settings.json`** -- Prefix all three hook commands (`guard-destructive.sh`, `skill-router.sh`, `methodology-inject.sh`) with the literal string `${CLAUDE_PROJECT_DIR}/`.
- **`loom-daemon/src/init/scaffolding.rs`**:
  - Update `LOOM_HOOK_PREFIX` to `${CLAUDE_PROJECT_DIR}/.loom/hooks/`.
  - Add `LEGACY_LOOM_HOOK_PREFIX = ".loom/hooks/"` for back-compat detection.
  - `merge_hook_commands` now strips legacy bare-relative entries before dedup, so re-installing over a pre-3265 install produces exactly one hook entry per command rather than two.
  - `remove_loom_hooks` recognizes both prefixes so uninstall is clean for users on any prior version.
  - New unit test `test_merge_settings_migrates_legacy_hooks` covers the upgrade scenario explicitly.
- **`scripts/uninstall-loom.sh`** -- jq filter now strips both prefixes via a second `--arg legacy_hook_prefix`. The new `--arg hook_prefix` value is **single-quoted** so bash does not expand `$CLAUDE_PROJECT_DIR` (which is unset/empty in the uninstaller context); the literal placeholder must reach jq verbatim to match the template-installed entries.
- **`scripts/test-installer.sh`** -- New Test 12b asserts that all three installed hook commands begin with the literal `${CLAUDE_PROJECT_DIR}/.loom/hooks/` prefix.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `defaults/.claude/settings.json` contains all three hook commands prefixed with literal `${CLAUDE_PROJECT_DIR}/` | Done | `jq -r '.hooks.PreToolUse[0].hooks[0].command' defaults/.claude/settings.json` returns `${CLAUDE_PROJECT_DIR}/.loom/hooks/guard-destructive.sh`; same for both UserPromptSubmit hooks |
| `LOOM_HOOK_PREFIX` constant updated to new prefix | Done | scaffolding.rs L22 |
| Legacy detection preserved for clean uninstall on pre-3265 installs | Done | `LEGACY_LOOM_HOOK_PREFIX` + `is_loom_hook_command` helper; `test_remove_loom_hooks` still passes with legacy-prefix input |
| Uninstaller jq filter updated for new prefix, with no shell-quoting trap | Done | `--arg hook_prefix '${CLAUDE_PROJECT_DIR}/.loom/hooks/'` (single-quoted); verified with a standalone shell test that strips both new and legacy entries while preserving custom project hooks |
| Re-install over existing install does not produce duplicate hook entries | Done | `merge_hook_commands` strips legacy entries before dedup; `test_merge_settings_migrates_legacy_hooks` asserts exactly 2 hooks (new Loom + custom) after migrating an existing pre-3265 install |
| Installer test asserts new prefix | Done | Test 12b in `scripts/test-installer.sh` checks all three hook commands |

## Test Plan

- `cargo check -p loom-daemon` -- clean
- `cargo test -p loom-daemon --lib init::scaffolding` -- 23/23 pass (including the new `test_merge_settings_migrates_legacy_hooks`)
- Standalone shell test of the new jq filter with `CLAUDE_PROJECT_DIR` unset: strips both legacy and new-prefix entries, preserves custom hooks, cleans up empty matchers
- JSON validity of `defaults/.claude/settings.json` verified with `jq`