### PR TITLE
fix(merge-pr): make auto-merge worktree-safe, retry-aware, and clean up

### DIFF
--- a/defaults/scripts/lib/forge-helpers.sh
+++ b/defaults/scripts/lib/forge-helpers.sh
@@ -305,7 +305,9 @@ forge_delete_branch() {
 
 # Enable auto-merge on a PR.
 # Usage: forge_auto_merge NWO PR_NUMBER
-# GitHub: gh pr merge --auto --squash --delete-branch
+# GitHub: GraphQL enablePullRequestAutoMerge mutation (pure API, no
+#         working-tree dependency — `gh pr merge --auto` does a local
+#         checkout that collides with worktrees owning the head branch).
 # Gitea: POST /repos/{owner}/{repo}/pulls/{n}/merge with merge_when_checks_succeed
 forge_auto_merge() {
   local nwo="$1"
@@ -316,7 +318,17 @@ forge_auto_merge() {
     gitea_api POST "repos/$FORGE_OWNER/$FORGE_REPO/pulls/$pr_number/merge" \
       -d '{"Do":"squash","merge_when_checks_succeed":true,"delete_branch_after_merge":true}'
   else
-    gh pr merge "$pr_number" --auto --squash --delete-branch 2>/dev/null
+    # Resolve PR node_id (required by GraphQL mutation).
+    local node_id
+    node_id=$(gh api "repos/$nwo/pulls/$pr_number" --jq '.node_id' 2>/dev/null) || return 1
+    [[ -z "$node_id" ]] && return 1
+
+    local mutation='mutation($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) { enablePullRequestAutoMerge(input: {pullRequestId: $pullRequestId, mergeMethod: $mergeMethod}) { pullRequest { number autoMergeRequest { enabledAt } } } }'
+
+    gh api graphql \
+      -f "query=$mutation" \
+      -F "pullRequestId=$node_id" \
+      -F "mergeMethod=SQUASH" 2>/dev/null
   fi
 }
 

--- a/defaults/scripts/merge-pr.sh
+++ b/defaults/scripts/merge-pr.sh
@@ -134,29 +134,95 @@ info "Merging PR #$PR_NUMBER: $PR_TITLE"
 info "Branch: $PR_BRANCH"
 
 # Handle auto-merge mode
+#
+# The auto-merge path now mirrors the sync path's resilience patterns:
+#   - Retry on "Base branch was modified" with the same backoff loop.
+#   - Recheck PR state on failure (concurrent shepherd may have already
+#     merged it).
+#   - Fall through to the shared cleanup block (lines below) instead of
+#     exiting early. Cleanup is gated on `PR.merged == true`; if the
+#     server-side merge is still queued, we skip local cleanup and let
+#     loom-clean handle it.
+#
+# See issue #3279.
 if [[ "$AUTO_MERGE" == "true" ]]; then
   if [[ "$DRY_RUN" == "true" ]]; then
     info "[dry-run] Would enable auto-merge for PR #$PR_NUMBER"
     exit 0
   fi
-  # Prefer loom-auto-merge CLI (forge-agnostic, with poll-and-merge for Gitea)
-  if command -v loom-auto-merge &>/dev/null; then
-    info "Using loom-auto-merge (forge-agnostic auto-merge)"
-    if loom-auto-merge "$PR_NUMBER" --method squash; then
-      success "Auto-merge completed for PR #$PR_NUMBER"
-      exit 0
+
+  MAX_MERGE_RETRIES=3
+  MERGE_RETRY_DELAY=5
+  AUTO_MERGE_OK=false
+
+  for MERGE_ATTEMPT in $(seq 1 $MAX_MERGE_RETRIES); do
+    AUTO_MERGE_OUTPUT=""
+    # Prefer loom-auto-merge CLI (forge-agnostic, with poll-and-merge for Gitea)
+    if command -v loom-auto-merge &>/dev/null; then
+      [[ $MERGE_ATTEMPT -eq 1 ]] && info "Using loom-auto-merge (forge-agnostic auto-merge)"
+      if AUTO_MERGE_OUTPUT=$(loom-auto-merge "$PR_NUMBER" --method squash 2>&1); then
+        AUTO_MERGE_OK=true
+        break
+      fi
     else
-      error "Failed to auto-merge PR #$PR_NUMBER"
+      # Fallback: shell-based forge_auto_merge
+      if AUTO_MERGE_OUTPUT=$(forge_auto_merge "$REPO_NWO" "$PR_NUMBER" 2>&1); then
+        AUTO_MERGE_OK=true
+        break
+      fi
     fi
+
+    # Check if PR merged despite error (concurrent merge by another shepherd)
+    RECHECK_JSON=$(forge_get_pr_nocache "$REPO_NWO" "$PR_NUMBER" "$GH" 2>/dev/null || echo '{}')
+    RECHECK=$(echo "$RECHECK_JSON" | jq -r '.merged // false')
+    if [[ "$RECHECK" == "true" ]]; then
+      warning "Auto-merge reported error but PR is already merged (race condition)"
+      AUTO_MERGE_OK=true
+      break
+    fi
+
+    # Retry on stale-branch race ("Base branch was modified")
+    if echo "$AUTO_MERGE_OUTPUT" | grep -q "Base branch was modified"; then
+      if [[ $MERGE_ATTEMPT -lt $MAX_MERGE_RETRIES ]]; then
+        info "Branch is behind base branch, updating... (attempt $MERGE_ATTEMPT/$MAX_MERGE_RETRIES)"
+        forge_update_branch "$REPO_NWO" "$PR_NUMBER" 2>/dev/null || \
+          warning "Failed to update branch (continuing anyway)"
+        info "Waiting ${MERGE_RETRY_DELAY}s for branch to sync..."
+        sleep "$MERGE_RETRY_DELAY"
+        MERGE_RETRY_DELAY=$((MERGE_RETRY_DELAY * 2))
+        continue
+      fi
+    fi
+
+    # Other auto-merge errors — fail immediately (no retry would help)
+    error "Failed to enable auto-merge for PR #$PR_NUMBER: $AUTO_MERGE_OUTPUT"
+  done
+
+  if [[ "$AUTO_MERGE_OK" != "true" ]]; then
+    error "Failed to enable auto-merge for PR #$PR_NUMBER after $MAX_MERGE_RETRIES attempts"
   fi
-  # Fallback: shell-based forge_auto_merge
-  if forge_auto_merge "$REPO_NWO" "$PR_NUMBER" 2>/dev/null; then
-    success "Auto-merge enabled for PR #$PR_NUMBER"
+
+  success "Auto-merge enabled for PR #$PR_NUMBER"
+
+  # Check whether the server-side merge has already completed. GitHub
+  # auto-merge queues until checks pass, so on most PRs this is still
+  # false right after enabling. If merged, fall through to the shared
+  # cleanup block below. Otherwise skip cleanup — loom-clean will
+  # handle the stale worktree later.
+  POST_AUTO_JSON=$(forge_get_pr_nocache "$REPO_NWO" "$PR_NUMBER" "$GH" 2>/dev/null || echo '{}')
+  POST_AUTO_MERGED=$(echo "$POST_AUTO_JSON" | jq -r '.merged // false')
+  if [[ "$POST_AUTO_MERGED" != "true" ]]; then
+    info "Auto-merge queued (server-side merge pending checks); skipping local cleanup"
+    info "Run loom-clean later to remove the worktree once GitHub completes the merge"
     exit 0
-  else
-    error "Failed to enable auto-merge for PR #$PR_NUMBER"
   fi
+  info "PR #$PR_NUMBER already merged server-side; running cleanup"
+  # Fall through to the shared cleanup block (branch deletion + worktree).
 fi
+
+# Synchronous-merge path. Skipped when --auto already succeeded server-side
+# (in which case we fall through to the shared cleanup block below).
+if [[ "$AUTO_MERGE" != "true" ]]; then
 
 # Check mergeability
 if [[ "$PR_MERGEABLE" == "false" ]]; then
@@ -235,6 +301,8 @@ if [[ "$VERIFY_MERGED" != "true" ]]; then
 fi
 
 success "PR #$PR_NUMBER merged successfully"
+
+fi  # end synchronous-merge path (AUTO_MERGE != "true")
 
 # NOTE: Label cleanup on linked issues is intentionally skipped.
 # Labels on closed/merged items are harmless — all agents filter by open state.

--- a/loom-tools/src/loom_tools/common/github.py
+++ b/loom-tools/src/loom_tools/common/github.py
@@ -505,18 +505,73 @@ class GitHubForge:
     ) -> bool:
         """Enable GitHub's native auto-merge for a PR.
 
-        Delegates to ``gh pr merge --auto`` which queues the merge
-        until all required checks pass. The ``poll_interval`` and
-        ``timeout`` parameters are ignored (GitHub handles polling
-        server-side).
+        Uses the GraphQL ``enablePullRequestAutoMerge`` mutation instead
+        of ``gh pr merge --auto`` to avoid the working-tree checkout that
+        the CLI performs. The CLI variant fails with
+        ``'<branch>' is already used by worktree at ...`` when invoked
+        from inside a worktree whose branch matches the PR head. The
+        GraphQL mutation is a pure API call with no working-tree
+        dependency.
+
+        The ``poll_interval`` and ``timeout`` parameters are ignored
+        (GitHub handles polling server-side).
         """
-        args = [
-            "pr", "merge", str(number),
-            "--auto", f"--{method}", "--delete-branch",
-        ]
-        result = gh_run(args, check=False, cwd=self._cwd)
+        nwo = get_repo_nwo(self._cwd)
+        if not nwo:
+            logger.warning(
+                "Failed to enable auto-merge for PR #%d: could not "
+                "resolve repository NWO",
+                number,
+            )
+            return False
+
+        # Step 1: Look up the PR's GraphQL node_id (required by the
+        # mutation). REST returns `node_id` in the PR object.
+        owner, _, repo = nwo.partition("/")
+        node_id_result = gh_run(
+            [
+                "api",
+                f"repos/{owner}/{repo}/pulls/{number}",
+                "--jq", ".node_id",
+            ],
+            check=False, cwd=self._cwd,
+        )
+        if node_id_result.returncode != 0 or not node_id_result.stdout.strip():
+            logger.warning(
+                "Failed to enable auto-merge for PR #%d: "
+                "could not fetch node_id: %s",
+                number,
+                (node_id_result.stderr or node_id_result.stdout or "").strip(),
+            )
+            return False
+        node_id = node_id_result.stdout.strip()
+
+        # Step 2: Enable auto-merge via GraphQL.
+        # mergeMethod must be uppercase (SQUASH, MERGE, REBASE).
+        merge_method = method.upper()
+        mutation = (
+            "mutation($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {"
+            "  enablePullRequestAutoMerge(input: {"
+            "    pullRequestId: $pullRequestId,"
+            "    mergeMethod: $mergeMethod"
+            "  }) {"
+            "    pullRequest { number autoMergeRequest { enabledAt } }"
+            "  }"
+            "}"
+        )
+        result = gh_run(
+            [
+                "api", "graphql",
+                "-f", f"query={mutation}",
+                "-F", f"pullRequestId={node_id}",
+                "-F", f"mergeMethod={merge_method}",
+            ],
+            check=False, cwd=self._cwd,
+        )
         if result.returncode == 0:
-            logger.info("Auto-merge enabled for PR #%d (GitHub)", number)
+            logger.info(
+                "Auto-merge enabled for PR #%d (GitHub, GraphQL)", number,
+            )
             return True
         logger.warning(
             "Failed to enable auto-merge for PR #%d: %s",

--- a/loom-tools/tests/test_github.py
+++ b/loom-tools/tests/test_github.py
@@ -1010,30 +1010,104 @@ class TestGitHubForgePullRequests:
         assert "--squash" in call_args
 
     def test_auto_merge_pull_request_success(self) -> None:
-        """auto_merge_pull_request delegates to gh pr merge --auto."""
+        """auto_merge_pull_request uses GraphQL mutation (worktree-safe).
+
+        Per issue #3279: must NOT shell out to ``gh pr merge --auto``,
+        which performs a local checkout that collides with worktrees
+        owning the head branch. Instead it must call the GraphQL
+        ``enablePullRequestAutoMerge`` mutation (a pure API call).
+        """
         forge = GitHubForge()
-        with mock.patch("loom_tools.common.github.gh_run") as mock_gh:
-            mock_gh.return_value = mock.Mock(returncode=0, stdout="", stderr="")
+        # First gh_run: fetch node_id; second gh_run: GraphQL mutation.
+        node_id_result = mock.Mock(
+            returncode=0, stdout="PR_kwDOABC123\n", stderr="",
+        )
+        graphql_result = mock.Mock(
+            returncode=0,
+            stdout='{"data":{"enablePullRequestAutoMerge":{"pullRequest":{"number":10}}}}',
+            stderr="",
+        )
+        with mock.patch(
+            "loom_tools.common.github.gh_run",
+        ) as mock_gh, mock.patch(
+            "loom_tools.common.github.get_repo_nwo",
+            return_value="acme/widget",
+        ):
+            mock_gh.side_effect = [node_id_result, graphql_result]
             result = forge.auto_merge_pull_request(10, method="squash")
 
         assert result is True
-        call_args = mock_gh.call_args[0][0]
-        assert "pr" in call_args
-        assert "merge" in call_args
-        assert "--auto" in call_args
-        assert "--squash" in call_args
-        assert "--delete-branch" in call_args
+        # Verify the first call fetched the node_id via REST.
+        first_args = mock_gh.call_args_list[0][0][0]
+        assert first_args[0] == "api"
+        assert "repos/acme/widget/pulls/10" in first_args
+        # Verify the second call invoked GraphQL with the mutation.
+        second_args = mock_gh.call_args_list[1][0][0]
+        assert second_args[0] == "api"
+        assert second_args[1] == "graphql"
+        joined = " ".join(second_args)
+        assert "enablePullRequestAutoMerge" in joined
+        assert "pullRequestId=PR_kwDOABC123" in joined
+        assert "mergeMethod=SQUASH" in joined
+        # Critical regression guard: must NOT use `gh pr merge --auto`.
+        for call in mock_gh.call_args_list:
+            call_args = call[0][0]
+            if "pr" in call_args and "merge" in call_args:
+                assert "--auto" not in call_args, \
+                    "must not shell out to `gh pr merge --auto` (worktree-unsafe)"
 
     def test_auto_merge_pull_request_failure(self) -> None:
-        """auto_merge_pull_request returns False on gh failure."""
+        """auto_merge_pull_request returns False on GraphQL failure."""
         forge = GitHubForge()
-        with mock.patch("loom_tools.common.github.gh_run") as mock_gh:
-            mock_gh.return_value = mock.Mock(
-                returncode=1, stdout="", stderr="auto-merge not available",
-            )
+        node_id_result = mock.Mock(
+            returncode=0, stdout="PR_kwDOABC123\n", stderr="",
+        )
+        graphql_fail = mock.Mock(
+            returncode=1, stdout="",
+            stderr="auto-merge not available on this repository",
+        )
+        with mock.patch(
+            "loom_tools.common.github.gh_run",
+        ) as mock_gh, mock.patch(
+            "loom_tools.common.github.get_repo_nwo",
+            return_value="acme/widget",
+        ):
+            mock_gh.side_effect = [node_id_result, graphql_fail]
             result = forge.auto_merge_pull_request(10)
 
         assert result is False
+
+    def test_auto_merge_pull_request_no_node_id(self) -> None:
+        """auto_merge_pull_request returns False if node_id lookup fails."""
+        forge = GitHubForge()
+        node_id_fail = mock.Mock(returncode=1, stdout="", stderr="not found")
+        with mock.patch(
+            "loom_tools.common.github.gh_run",
+        ) as mock_gh, mock.patch(
+            "loom_tools.common.github.get_repo_nwo",
+            return_value="acme/widget",
+        ):
+            mock_gh.return_value = node_id_fail
+            result = forge.auto_merge_pull_request(10)
+
+        assert result is False
+        # Should not have called GraphQL after node_id lookup failed.
+        assert mock_gh.call_count == 1
+
+    def test_auto_merge_pull_request_no_nwo(self) -> None:
+        """auto_merge_pull_request returns False if repo NWO unresolved."""
+        forge = GitHubForge()
+        with mock.patch(
+            "loom_tools.common.github.gh_run",
+        ) as mock_gh, mock.patch(
+            "loom_tools.common.github.get_repo_nwo",
+            return_value=None,
+        ):
+            result = forge.auto_merge_pull_request(10)
+
+        assert result is False
+        # Should not have called gh at all.
+        assert mock_gh.call_count == 0
 
     def test_get_pull_request_reviews(self) -> None:
         """get_pull_request_reviews returns review list."""


### PR DESCRIPTION
Closes #3279

## Summary

Fixes 3 related bugs in `merge-pr.sh` / `loom-auto-merge` that surface during parallel shepherding from inside worktrees:

- **Bug 1 (worktree collision)**: Replace `gh pr merge --auto` with the GraphQL `enablePullRequestAutoMerge` mutation in both `GitHubForge.auto_merge_pull_request` (loom-tools) and `forge_auto_merge` (shell). The CLI variant performs a working-tree checkout that collides with worktrees owning the head branch.
- **Bug 2 (missing retry)**: Replicate the sync path's `Base branch was modified` retry loop with exponential backoff on the `--auto` path of `merge-pr.sh`.
- **Bug 3 (stale worktrees)**: Auto-merge path no longer `exit 0`s early; it falls through to the shared cleanup block when `PR.merged == true`. If GitHub still has the merge queued behind checks, log a deferred-cleanup hint so `loom-clean` can finish later.

## Test plan
- [x] `test_auto_merge_pull_request_success` updated to assert GraphQL is used and `gh pr merge --auto` is NOT invoked (regression guard).
- [x] New tests: `test_auto_merge_pull_request_no_node_id` and `_no_nwo` cover the new failure paths.
- [x] Existing `test_auto_merge_pull_request_failure` still passes with adjusted mocks.
- [x] `bash -n` clean on `merge-pr.sh` and `forge-helpers.sh`.
- [x] Full `test_github.py` + `test_forge.py` + `test_gitea.py` + `test_forge_cli.py` suites pass (319 tests).
- [x] `test-forge-helpers.sh` shell tests pass (27/27).
- [ ] Manual: merge this PR via `merge-pr.sh --auto` from inside a worktree to verify the fix on its own merge.

Note: this PR is fixing the very bugs that would otherwise affect its own merge. If the new code path misbehaves, a direct API call fallback is available.