### PR TITLE
chore(shellcheck): remove unused GH and filtered_len vars

### DIFF
--- a/defaults/scripts/lib/forge-helpers.sh
+++ b/defaults/scripts/lib/forge-helpers.sh
@@ -454,9 +454,6 @@ forge_list_merged_prs() {
         filtered=$(echo "$batch" | jq '[.[] | select(.merged == true) | {number: .number, mergedAt: .merged_at}]')
       fi
 
-      # shellcheck disable=SC2034
-      local filtered_len
-      filtered_len=$(echo "$filtered" | jq 'length')
       results=$(echo "$results" "$filtered" | jq -s '.[0] + .[1]')
       collected=$(echo "$results" | jq 'length')
 

--- a/defaults/scripts/stale-building-check.sh
+++ b/defaults/scripts/stale-building-check.sh
@@ -27,19 +27,10 @@
 set -euo pipefail
 
 # Use loom-forge for forge-agnostic issue/PR operations (supports GitHub + Gitea).
-# Falls back to gh-cached or gh for any commands not covered by loom-forge.
-_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if command -v loom-forge &>/dev/null; then
     FORGE="loom-forge"
 else
     FORGE="gh"
-fi
-# shellcheck disable=SC2034
-GH_CACHED="$_SCRIPT_DIR/gh-cached"
-if [[ -x "$GH_CACHED" ]] && "$GH_CACHED" --version &>/dev/null; then
-    GH="$GH_CACHED"
-else
-    GH="gh"
 fi
 
 # Configuration


### PR DESCRIPTION
Closes #3285.

## Summary

Shell Script Linting workflow has been red on main due to two genuine SC2034 (unused variable) warnings. Both variables were assigned but never read.

## Changes

- `defaults/scripts/stale-building-check.sh` — Remove `GH`/`GH_CACHED` block. These were assigned to wrap gh calls, but the script only ever uses `$FORGE` (loom-forge or gh).
- `defaults/scripts/lib/forge-helpers.sh` — Remove `filtered_len` declaration and assignment. Computed via `jq 'length'` but never read; the loop's count uses `$collected`.

Both `# shellcheck disable=SC2034` directives masking the warnings are removed along with the dead code.

## Verification

Matches the CI command exactly:
```
find defaults/scripts -type f -name "*.sh" -print0 | \
  xargs -0 shellcheck --severity=warning --format=gcc
# Exit: 0
```

## Test plan

- [x] Shellcheck passes locally with `--severity=warning`
- [x] No behavior change (variables were unused)
- [ ] Shell Script Linting CI passes on this PR