### PR TITLE
docs(shepherd): clarify loom:curated as persistent milestone

### DIFF
--- a/defaults/.claude/commands/loom/shepherd-lifecycle.md
+++ b/defaults/.claude/commands/loom/shepherd-lifecycle.md
@@ -23,7 +23,7 @@ This section documents the expected GitHub label states at each shepherd phase b
 |-------|-----------------|----------------------|
 | Curator | (none or `loom:curating`) | - |
 | Approval Gate | `loom:curated` | `loom:curating` |
-| Builder | `loom:issue` + `loom:building` | `loom:curated` (optional) |
+| Builder | `loom:issue` + `loom:building` | `loom:issue` (atomic swap to `loom:building`) |
 | Judge | Issue: `loom:building`, PR: `loom:review-requested` | `loom:issue` |
 | Doctor | Issue: `loom:building`, PR: `loom:changes-requested` | PR: `loom:review-requested` |
 | Merge Gate | Issue: `loom:building`, PR: `loom:pr` | PR: `loom:changes-requested` |
@@ -49,6 +49,15 @@ This section documents the expected GitHub label states at each shepherd phase b
 | Builder (other failure) | `loom:blocked` | - | See diagnostics comment |
 | Judge | `loom:blocked` | (unchanged) | Manual review required |
 | Doctor | `loom:blocked` | (unchanged) | Manual fix required |
+
+### Label Persistence
+
+**`loom:curated` is a persistent milestone marker, not a transient step label.** Once applied by the Curator, it remains on the issue through all subsequent phases (`loom:issue`, `loom:building`, `loom:blocked`) and is only removed during an intentional full lifecycle reset (see "Reset to retry from beginning" below). The atomic transitions at each phase swap `loom:issue` <-> `loom:building`; `loom:curated` is never swapped.
+
+This matches the ground-truth behavior in code:
+- `champion-issue-promo.md` explicitly preserves `loom:curated` when promoting `curated` -> `loom:issue`
+- `loom_tools.shepherd.phases.approval` and `loom_tools.shepherd.phases.builder` never touch `loom:curated`
+- `loom_tools.status` documents this preservation in user-facing output
 
 ### Label State Diagram
 
@@ -89,7 +98,8 @@ When manually continuing after a shepherd failure, ensure labels match the expec
 **Resume at Builder phase:**
 ```bash
 # Issue must have loom:issue AND loom:building
-gh issue edit <N> --remove-label "loom:blocked,loom:curated" --add-label "loom:issue,loom:building"
+# NOTE: loom:curated is preserved as a persistent milestone marker — do not strip it.
+gh issue edit <N> --remove-label "loom:blocked" --add-label "loom:issue,loom:building"
 ```
 
 **Resume at Judge phase:**
@@ -107,7 +117,8 @@ gh pr edit <PR> --remove-label "loom:review-requested" --add-label "loom:changes
 
 **Reset to retry from beginning:**
 ```bash
-# Clear all loom labels and start fresh
+# Full reset including re-curation (rare — only when intentionally restarting from curator phase).
+# Normally preserve loom:curated; this snippet is the one case where it is removed.
 gh issue edit <N> --remove-label "loom:blocked,loom:building,loom:issue,loom:curated,loom:curating"
 # Then run: /shepherd <N>
 ```


### PR DESCRIPTION
## Summary

- Resolve three internal contradictions in `.loom/roles/shepherd-lifecycle.md` (line 26, line 92, and surrounding prose) about whether `loom:curated` persists through approval/promotion.
- Adopt Option A (persistent milestone) — matches the ground-truth behavior already implemented in `champion-issue-promo.md`, `loom_tools.shepherd.phases.approval`/`builder`, and `loom_tools.status`.
- Add an explicit "Label Persistence" subsection so future readers cannot misinterpret the lifecycle.

## Changes

- Phase Entry table: Builder row no longer mentions `loom:curated` — it now describes the `loom:issue` -> `loom:building` atomic swap.
- New "Label Persistence" note explicitly states `loom:curated` is persistent and lists the code paths that confirm this.
- Resume-at-Builder snippet no longer strips `loom:curated`; added an inline NOTE explaining the policy.
- Reset-to-retry snippet kept (correct for intentional full reset) but with explanatory comment clarifying that this is the one case where `loom:curated` is removed.
- Code change scope: none (documentation-only per curator analysis).

## Test plan

- [x] `grep -n "loom:curated" .loom/roles/shepherd-lifecycle.md` — every reference is consistent with Option A (persistent milestone).
- [x] Cross-check against `defaults/.claude/commands/loom/champion-issue-promo.md` — preserves `loom:curated` on promotion (matches the doc now).
- [x] Phase Router code at lines 559-570 already treats `loom:curated` AND `loom:issue` as the "ready for builder" state — no longer contradicted by the prose.

Closes #3288