### PR TITLE
feat(merge-pr.sh): add --help / -h flag

### DIFF
--- a/defaults/scripts/merge-pr.sh
+++ b/defaults/scripts/merge-pr.sh
@@ -36,6 +36,56 @@ info() { echo -e "${BLUE}$*${NC}"; }
 success() { echo -e "${GREEN}$*${NC}"; }
 warning() { echo -e "${YELLOW}$*${NC}"; }
 
+# Function to show help
+show_help() {
+    cat << EOF
+Loom PR Merge - Worktree-safe merge using forge API (GitHub or Gitea)
+
+Usage: ./.loom/scripts/merge-pr.sh <pr-number> [options]
+
+Merges a PR via the forge API (not 'gh pr merge') to avoid
+"already used by worktree" errors when merging from inside a worktree.
+
+Supports both GitHub and Gitea forges. Forge detection is automatic
+(see forge-helpers.sh for details).
+
+Options:
+  --no-cleanup-worktree  Skip local worktree cleanup after merge
+  --cleanup-worktree     (no-op, worktree cleanup is now the default)
+  --dry-run              Show what would happen without merging
+  --auto                 Enable auto-merge instead of immediate merge
+  -h, --help             Show this help and exit
+
+By default, the local worktree is cleaned up after a successful merge.
+Pass --no-cleanup-worktree to skip this (e.g., when other terminals may
+have their CWD inside the worktree).
+
+Exit codes:
+  0 = merged (or auto-merge enabled, or --help)
+  1 = failed
+
+Examples:
+  ./.loom/scripts/merge-pr.sh 123
+    Merges PR #123 (squash), deletes remote branch, cleans up worktree
+
+  ./.loom/scripts/merge-pr.sh 123 --dry-run
+    Shows what would happen without merging
+
+  ./.loom/scripts/merge-pr.sh 123 --auto
+    Enables auto-merge instead of merging immediately
+
+  ./.loom/scripts/merge-pr.sh 123 --no-cleanup-worktree
+    Merges PR but leaves the local worktree in place
+EOF
+}
+
+# Early help check — runs before any git/forge initialization so --help works
+# in any directory and without forge authentication.
+if [[ $# -gt 0 ]] && { [[ "$1" == "--help" ]] || [[ "$1" == "-h" ]]; }; then
+    show_help
+    exit 0
+fi
+
 # Find the main repository root (works from worktrees too)
 # When run from a worktree, git rev-parse --show-toplevel returns the worktree path,
 # not the main repository. This function navigates via the gitdir to find the actual root.

--- a/defaults/scripts/tests/test-merge-pr-help.sh
+++ b/defaults/scripts/tests/test-merge-pr-help.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# test-merge-pr-help.sh - Unit tests for the --help / -h flag on merge-pr.sh
+#
+# Verifies that merge-pr.sh prints usage and exits 0 when --help or -h is
+# passed, without any network or git side effects (no forge_detect, no
+# find_main_repo_root). Runs from /tmp to confirm early-exit before git
+# initialization.
+#
+# Usage:
+#   ./.loom/scripts/tests/test-merge-pr-help.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MERGE_PR="$(cd "$SCRIPT_DIR/.." && pwd)/merge-pr.sh"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_eq() {
+    local expected="$1"
+    local actual="$2"
+    local msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Expected: '$expected'"
+        echo "    Actual:   '$actual'"
+    fi
+}
+
+assert_contains() {
+    local haystack="$1"
+    local needle="$2"
+    local msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$haystack" == *"$needle"* ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Looking for: '$needle'"
+        echo "    In output:   '$haystack'"
+    fi
+}
+
+if [[ ! -x "$MERGE_PR" ]]; then
+    echo "ERROR: $MERGE_PR is not executable" >&2
+    exit 1
+fi
+
+# --- Test: --help exits 0 with usage ---
+echo "Testing merge-pr.sh --help..."
+
+set +e
+HELP_OUTPUT=$("$MERGE_PR" --help 2>&1)
+HELP_EXIT=$?
+set -e
+
+assert_eq "0" "$HELP_EXIT" "--help exits 0"
+assert_contains "$HELP_OUTPUT" "Usage:" "--help output contains 'Usage:'"
+assert_contains "$HELP_OUTPUT" "--auto" "--help output mentions --auto"
+assert_contains "$HELP_OUTPUT" "--dry-run" "--help output mentions --dry-run"
+assert_contains "$HELP_OUTPUT" "--no-cleanup-worktree" "--help output mentions --no-cleanup-worktree"
+assert_contains "$HELP_OUTPUT" "-h, --help" "--help output documents -h/--help"
+
+# --- Test: -h exits 0 with same usage ---
+echo ""
+echo "Testing merge-pr.sh -h..."
+
+set +e
+SHORT_OUTPUT=$("$MERGE_PR" -h 2>&1)
+SHORT_EXIT=$?
+set -e
+
+assert_eq "0" "$SHORT_EXIT" "-h exits 0"
+assert_eq "$HELP_OUTPUT" "$SHORT_OUTPUT" "-h produces identical output to --help"
+
+# --- Test: --help works outside a git repo (early exit before find_main_repo_root) ---
+echo ""
+echo "Testing merge-pr.sh --help from outside a git repo..."
+
+TMP_DIR=$(mktemp -d /tmp/loom-merge-pr-help-test.XXXXXX)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+set +e
+NONGIT_OUTPUT=$(cd "$TMP_DIR" && "$MERGE_PR" --help 2>&1)
+NONGIT_EXIT=$?
+set -e
+
+assert_eq "0" "$NONGIT_EXIT" "--help exits 0 outside a git repo"
+assert_contains "$NONGIT_OUTPUT" "Usage:" "--help works without git context"
+
+# --- Test: --help with extra args still exits 0 ---
+echo ""
+echo "Testing merge-pr.sh --help with extra args..."
+
+set +e
+EXTRA_OUTPUT=$("$MERGE_PR" --help 999 2>&1)
+EXTRA_EXIT=$?
+set -e
+
+assert_eq "0" "$EXTRA_EXIT" "--help with extra args exits 0"
+assert_contains "$EXTRA_OUTPUT" "Usage:" "--help with extra args prints usage"
+
+# --- Summary ---
+echo ""
+echo "Tests run: $TESTS_RUN, Passed: $TESTS_PASSED, Failed: $TESTS_FAILED"
+
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Add `--help` / `-h` to `merge-pr.sh`, matching the `worktree.sh` style (dedicated `show_help()` function, early-exit before any initialization)
- Help check fires before `find_main_repo_root` and `forge_detect`, so it works outside a git repo and without forge auth
- New test `.loom/scripts/tests/test-merge-pr-help.sh` (12 assertions, all passing)

## Test plan
- [x] `./.loom/scripts/merge-pr.sh --help` exits 0 with usage
- [x] `./.loom/scripts/merge-pr.sh -h` exits 0 with identical output
- [x] `--help` works from outside a git repo (verified via `/tmp`)
- [x] `--help 999` (extra args) still exits 0 with usage
- [x] Existing `--auto` / `--dry-run` / `--no-cleanup-worktree` flows unchanged
- [x] No-args invocation still errors (`Usage: merge-pr.sh <pr-number> ...`)
- [x] Unknown flags still rejected (`Error: Unknown option: --unknown-flag`)
- [x] `bash .loom/scripts/tests/test-merge-pr-help.sh` passes (12/12)

Closes #3290