### PR TITLE
fix(install): refuse install when .gitignore would shadow lib/*.sh

### DIFF
--- a/loom-daemon/src/activity/db.rs
+++ b/loom-daemon/src/activity/db.rs
@@ -94,7 +94,10 @@ impl ActivityDb {
             ",
         )?;
 
-        let inputs = stmt.query_map(params![terminal_id, limit], |row| {
+        // rusqlite 0.39 dropped the `ToSql` impl for `usize`; convert to i64 for SQLite.
+        // Saturate at i64::MAX on 64-bit platforms where `usize` can exceed i64.
+        let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
+        let inputs = stmt.query_map(params![terminal_id, limit_i64], |row| {
             let id: i64 = row.get(0)?;
             let terminal_id: String = row.get(1)?;
             let timestamp_str: String = row.get(2)?;
@@ -243,7 +246,10 @@ impl ActivityDb {
             ",
         )?;
 
-        let entries = stmt.query_map(params![terminal_id, limit], |row| {
+        // rusqlite 0.39 dropped the `ToSql` impl for `usize`; convert to i64 for SQLite.
+        // Saturate at i64::MAX on 64-bit platforms where `usize` can exceed i64.
+        let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
+        let entries = stmt.query_map(params![terminal_id, limit_i64], |row| {
             // Parse context JSON to extract git_branch
             let ctx_json: String = row.get(5)?;
             let ctx: InputContext = serde_json::from_str(&ctx_json).unwrap_or_default();

--- a/loom-daemon/src/init/mod.rs
+++ b/loom-daemon/src/init/mod.rs
@@ -32,7 +32,7 @@ use std::fs;
 use std::path::Path;
 
 use file_ops::{clean_managed_dir, copy_dir_with_report, verify_copied_files, TemplateContext};
-use post_init::{generate_manifest, update_gitignore};
+use post_init::{find_overbroad_loom_patterns, generate_manifest, update_gitignore};
 use scaffolding::setup_repository_scaffolding;
 
 // Re-export public types and functions
@@ -120,6 +120,22 @@ pub fn initialize_workspace(
 
     // Validate workspace is a git repository
     validate_git_repository(workspace_path)?;
+
+    // Check for over-broad gitignore patterns that would shadow installed Loom
+    // files (e.g., `.loom/scripts/lib/*.sh`). This catches the regression
+    // reported in issue #3287, where a target repo's `.gitignore` contained
+    // `.loom/` and caused the install worktree's lib files to never be
+    // committed to main. We fail fast here, before any file operations.
+    let bad_patterns = find_overbroad_loom_patterns(workspace);
+    if !bad_patterns.is_empty() {
+        return Err(format!(
+            "Refusing to install: .gitignore contains pattern(s) that would block \
+             installed Loom files from being committed (e.g., .loom/scripts/lib/*.sh). \
+             Remove or scope these patterns to specific runtime files before \
+             reinstalling. Offending patterns: {}",
+            bad_patterns.join(", ")
+        ));
+    }
 
     // Check for self-installation (Loom source repo)
     if is_loom_source_repo(workspace) {

--- a/loom-daemon/src/init/post_init.rs
+++ b/loom-daemon/src/init/post_init.rs
@@ -6,6 +6,63 @@ use std::fs;
 use std::path::Path;
 use std::process::Command;
 
+/// Gitignore patterns that would shadow installed Loom files like
+/// `.loom/scripts/lib/*.sh`. If a user's gitignore contains any of these, the
+/// installer must fail loudly: the files will exist on disk after install but
+/// will not be committed to the repo, producing a "successful" install that
+/// breaks on the next worktree (see issue #3287).
+///
+/// Note: `.loom/` is intentionally listed even though some users may *want*
+/// to ignore the entire `.loom/` directory. In that mode they should not be
+/// running `install-loom.sh` at all — the installer's job is to commit Loom
+/// files into the target repo. Hard-failing here surfaces that mismatch
+/// instead of producing a silently broken install.
+const OVERBROAD_LOOM_PATTERNS: &[&str] = &[
+    ".loom/",
+    ".loom",
+    ".loom/*",
+    ".loom/**",
+    ".loom/scripts/",
+    ".loom/scripts",
+    ".loom/scripts/*",
+    ".loom/scripts/**",
+    ".loom/scripts/lib/",
+    ".loom/scripts/lib",
+    ".loom/scripts/lib/*",
+    ".loom/scripts/lib/*.sh",
+];
+
+/// Scan `.gitignore` for patterns that would block installed Loom files
+/// (specifically `.loom/scripts/lib/*.sh`) from being committed.
+///
+/// Returns a sorted list of offending pattern lines (trimmed of whitespace).
+/// Empty result means the gitignore is safe.
+///
+/// This is the detection half of the issue #3287 fix. The installer treats a
+/// non-empty result as a hard error: the user must remove the broad pattern
+/// (or scope it more narrowly) before installation can proceed.
+pub fn find_overbroad_loom_patterns(workspace_path: &Path) -> Vec<String> {
+    let gitignore_path = workspace_path.join(".gitignore");
+    let Ok(contents) = fs::read_to_string(&gitignore_path) else {
+        return Vec::new();
+    };
+
+    let mut found: Vec<String> = Vec::new();
+    for raw_line in contents.lines() {
+        let line = raw_line.trim();
+        // Skip blanks, comments, and negation entries (a negation can't shadow files)
+        if line.is_empty() || line.starts_with('#') || line.starts_with('!') {
+            continue;
+        }
+        if OVERBROAD_LOOM_PATTERNS.contains(&line) {
+            found.push(line.to_string());
+        }
+    }
+    found.sort();
+    found.dedup();
+    found
+}
+
 /// Generate installation manifest by running verify-install.sh
 ///
 /// Attempts to run `.loom/scripts/verify-install.sh generate --quiet` to create
@@ -294,6 +351,119 @@ mod tests {
             assert!(
                 contents.contains(pattern),
                 "Missing pattern in generated .gitignore: {pattern}"
+            );
+        }
+    }
+
+    #[test]
+    fn find_overbroad_loom_patterns_empty_when_no_gitignore() {
+        let tmp = TempDir::new().unwrap();
+        let found = find_overbroad_loom_patterns(tmp.path());
+        assert!(
+            found.is_empty(),
+            "Expected empty result when .gitignore is absent, got {found:?}"
+        );
+    }
+
+    #[test]
+    fn find_overbroad_loom_patterns_detects_dot_loom_slash() {
+        // Issue #3287: a target repo with `.loom/` in .gitignore would have all
+        // installed Loom files (including `.loom/scripts/lib/*.sh`) silently
+        // dropped at commit time.
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join(".gitignore"), "node_modules/\n.loom/\nsome-other-pattern\n")
+            .unwrap();
+        let found = find_overbroad_loom_patterns(tmp.path());
+        assert_eq!(found, vec![".loom/".to_string()]);
+    }
+
+    #[test]
+    fn find_overbroad_loom_patterns_detects_dot_loom_scripts() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join(".gitignore"), ".loom/scripts/\n# comment\n").unwrap();
+        let found = find_overbroad_loom_patterns(tmp.path());
+        assert_eq!(found, vec![".loom/scripts/".to_string()]);
+    }
+
+    #[test]
+    fn find_overbroad_loom_patterns_detects_lib_specifically() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join(".gitignore"), ".loom/scripts/lib/*.sh\n").unwrap();
+        let found = find_overbroad_loom_patterns(tmp.path());
+        assert_eq!(found, vec![".loom/scripts/lib/*.sh".to_string()]);
+    }
+
+    #[test]
+    fn find_overbroad_loom_patterns_ignores_safe_runtime_patterns() {
+        // The patterns written by update_gitignore() are runtime-only and
+        // must not be flagged as over-broad.
+        let tmp = TempDir::new().unwrap();
+        update_gitignore(tmp.path()).unwrap();
+        let found = find_overbroad_loom_patterns(tmp.path());
+        assert!(found.is_empty(), "update_gitignore output should be safe, got: {found:?}");
+    }
+
+    #[test]
+    fn find_overbroad_loom_patterns_ignores_comments_and_negations() {
+        let tmp = TempDir::new().unwrap();
+        // Negations and comments mentioning `.loom/` must not be flagged
+        fs::write(
+            tmp.path().join(".gitignore"),
+            "# .loom/ — see docs\n!.loom/scripts/lib/\n.loom/worktrees/\n",
+        )
+        .unwrap();
+        let found = find_overbroad_loom_patterns(tmp.path());
+        assert!(found.is_empty(), "Expected no flags, got: {found:?}");
+    }
+
+    #[test]
+    fn find_overbroad_loom_patterns_dedups_and_sorts() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join(".gitignore"), ".loom/scripts/\n.loom/\n.loom/scripts/\n")
+            .unwrap();
+        let found = find_overbroad_loom_patterns(tmp.path());
+        assert_eq!(found, vec![".loom/".to_string(), ".loom/scripts/".to_string()]);
+    }
+
+    #[test]
+    fn initialize_workspace_rejects_overbroad_gitignore() {
+        // End-to-end: an install against a target with `.loom/` in .gitignore
+        // must fail with a clear error message (issue #3287). Without this
+        // check, files copy successfully on disk but never make it into the
+        // commit, producing a "successful" install that is silently broken.
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path();
+        let defaults = tmp.path().join("defaults");
+
+        fs::create_dir(workspace.join(".git")).unwrap();
+        fs::create_dir_all(defaults.join("roles")).unwrap();
+        fs::create_dir_all(defaults.join("scripts").join("lib")).unwrap();
+        fs::write(defaults.join("config.json"), "{}").unwrap();
+        fs::write(defaults.join("roles").join("builder.md"), "builder").unwrap();
+        fs::write(
+            defaults
+                .join("scripts")
+                .join("lib")
+                .join("forge-helpers.sh"),
+            "#!/bin/bash",
+        )
+        .unwrap();
+
+        // Hostile .gitignore: `.loom/` would prevent the lib files from ever
+        // being committed (the file copy would succeed, but git would silently
+        // drop them at commit time).
+        fs::write(workspace.join(".gitignore"), ".loom/\n").unwrap();
+
+        let result = crate::init::initialize_workspace(
+            workspace.to_str().unwrap(),
+            defaults.to_str().unwrap(),
+            false,
+        );
+        assert!(result.is_err(), "install should refuse hostile .gitignore but returned Ok");
+        if let Err(err) = result {
+            assert!(
+                err.contains(".loom/") && err.contains("Refusing to install"),
+                "error message should call out the offending pattern; got: {err}"
             );
         }
     }

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -18,6 +18,7 @@ use std::sync::{Arc, Mutex};
 #[derive(Parser)]
 #[command(name = "loom-daemon")]
 #[command(about = "Loom daemon for AI-powered development orchestration", long_about = None)]
+#[command(version = env!("CARGO_PKG_VERSION"))]
 struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,

--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -693,6 +693,11 @@ cp target/release/loom-daemon target/release/loom-daemon-aarch64-apple-darwin
 
 success "loom-daemon binary ready"
 
+# Log the daemon binary identity so a stale binary can be diagnosed
+# post-hoc when an install regression is reported (issue #3287).
+DAEMON_VERSION=$("$LOOM_ROOT/target/release/loom-daemon" --version 2>/dev/null || echo "(unknown)")
+info "loom-daemon binary: $DAEMON_VERSION"
+
 # Run loom-daemon init in the worktree
 cd "$TARGET_PATH/$WORKTREE_PATH"
 # Use --force to overwrite existing installation when requested (--force or --clean flags)
@@ -823,6 +828,55 @@ cat > .loom/install-metadata.json <<METADATA
 METADATA
 success "Installation metadata recorded ($(echo "$INSTALLED_FILES_JSON" | grep -o '"' | wc -l | awk '{print $1/2}') files tracked)"
 echo ""
+
+# Reconcile install-metadata.json against on-disk state.
+# Issue #3287: a metadata-vs-disk divergence is itself a hard error — regardless
+# of which step caused it (a stale daemon binary, a hostile gitignore, a copy
+# race, etc.). This is the cheapest single check that catches every variant.
+info "Verifying all metadata-listed files exist on disk..."
+MISSING_FROM_METADATA=()
+if command -v jq >/dev/null 2>&1; then
+  while IFS= read -r path; do
+    [[ -n "$path" ]] || continue
+    if [[ ! -e "$path" ]]; then
+      MISSING_FROM_METADATA+=("$path")
+    fi
+  done < <(jq -r '.installed_files[]' .loom/install-metadata.json)
+else
+  warning "jq not available — skipping metadata reconciliation check"
+fi
+if (( ${#MISSING_FROM_METADATA[@]} > 0 )); then
+  echo "" >&2
+  for f in "${MISSING_FROM_METADATA[@]}"; do
+    echo "  MISSING: $f" >&2
+  done
+  error "${#MISSING_FROM_METADATA[@]} file(s) in install-metadata.json are missing from disk — install incomplete (see #3287)"
+fi
+success "Metadata reconciliation passed (all listed files present)"
+echo ""
+
+# Verify no installed lib files are gitignored.
+# This catches the hostile-gitignore variant of issue #3287 *after* the
+# daemon's own check, providing belt-and-suspenders coverage for users on
+# stale daemon binaries that predate the in-daemon gitignore audit.
+if [[ -d ".loom/scripts/lib" ]]; then
+  info "Checking that installed lib/*.sh files are not gitignored..."
+  IGNORED_LIB_FILES=$(git check-ignore .loom/scripts/lib/*.sh 2>/dev/null || true)
+  if [[ -n "$IGNORED_LIB_FILES" ]]; then
+    echo "" >&2
+    echo "  The following lib files are matched by a .gitignore rule:" >&2
+    while IFS= read -r ignored_line; do
+      echo "    $ignored_line" >&2
+    done <<<"$IGNORED_LIB_FILES"
+    echo "" >&2
+    echo "  These files will be silently dropped on commit, breaking installs" >&2
+    echo "  in fresh clones and worktrees. Remove the offending pattern from" >&2
+    echo "  .gitignore (commonly '.loom/' or '.loom/scripts/') before retrying." >&2
+    error "Installed lib files are gitignored — install would produce a broken commit (see #3287)"
+  fi
+  success "lib/*.sh files are not gitignored"
+  echo ""
+fi
 
 # Verify expected files were created
 # NOTE: lib/ entries are listed explicitly as a defensive belt-and-suspenders check.


### PR DESCRIPTION
## Summary

Hard-fail installs that would silently drop `.loom/scripts/lib/*.sh` from the
target repo's commit, instead of producing a "successful" install that breaks
on the next worktree. Implements the defense-in-depth approach (Option A + B +
binary stamping) recommended by Curator on #3287.

## Changes

- **`loom-daemon/src/init/post_init.rs`**: New `find_overbroad_loom_patterns()`
  scans `.gitignore` for patterns that would shadow installed lib files
  (`.loom/`, `.loom/scripts/`, `.loom/scripts/lib/*.sh`, etc.). Negations and
  comments are correctly ignored.
- **`loom-daemon/src/init/mod.rs`**: `initialize_workspace()` now calls the
  scanner first and refuses to install (clear error message) when an
  over-broad pattern is present. Fails before any file operations.
- **`loom-daemon/src/main.rs`**: Add `--version` flag (clap auto-generates
  from `CARGO_PKG_VERSION`) so a stale binary can be diagnosed post-hoc.
- **`scripts/install-loom.sh`** (three new checks after `loom-daemon init`):
  1. Log `loom-daemon --version` before invoking init.
  2. **Metadata-vs-disk reconciliation** — iterate `installed_files[]` from
     `install-metadata.json` and hard-error on any path that doesn't exist on
     disk. Catches every divergence regardless of which step caused it.
  3. **`git check-ignore`** on `.loom/scripts/lib/*.sh` — fail with operator
     fix-it instructions if any installed lib file is gitignored.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Verification scope expanded (metadata vs. disk) | done | New loop in install-loom.sh iterating `.installed_files[]`; hard-errors on missing |
| Daemon binary identity logged | done | `info "loom-daemon binary: $DAEMON_VERSION"` before init |
| `.gitignore` audit (detect over-broad patterns) | done | `find_overbroad_loom_patterns()` + new test `initialize_workspace_rejects_overbroad_gitignore` |
| PR-time check (`git check-ignore .loom/scripts/lib/`) | done | New `git check-ignore` block in install-loom.sh, fails on any match |
| Reproducer landed | done | Rust test `initialize_workspace_rejects_overbroad_gitignore` builds a target with `.loom/` in .gitignore and asserts the install errors out |

## Test Plan

- [x] `cargo test` in `loom-daemon/` — 270 lib + 27 integration tests pass,
      including 7 new tests for the gitignore audit.
- [x] `bash scripts/test-installer.sh` — all 58 installer integration tests pass.
- [x] `shellcheck scripts/install-loom.sh` — no new warnings introduced.
- [x] `loom-daemon --version` — returns `loom-daemon 0.7.2`.
- [x] `cargo clippy --tests --lib` — no new warnings introduced (two
      pre-existing format-string warnings in `forge_parser.rs:91` and
      `scaffolding.rs:1575` are untouched).

Closes #3287