### PR TITLE
docs: clarify label ownership in labels.yml and fix Issue Lifecycle diagram

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -5,11 +5,11 @@
 
 # Core Workflow States
 - name: loom:triage
-  description: New issue awaiting Curator enhancement
+  description: "New issue awaiting Curator enhancement. Applied by: humans or any agent filing a new issue (intake label)."
   color: "9CA3AF"  # gray-400 - neutral initial state
 
 - name: loom:issue
-  description: Approved for work by human (ready for Builder to claim)
+  description: "Approved for work by human (ready for Builder to claim). Applied by: humans only (or Champion in --merge mode)."
   color: "3B82F6"  # blue-500
 
 # DEPRECATED: loom:in-progress removed (use role-specific labels)
@@ -20,27 +20,27 @@
 
 # Role-Specific Workflow Labels
 - name: loom:building
-  description: Builder is implementing this issue
+  description: "Builder is implementing this issue. Applied by: Builder/Shepherd only (claim label)."
   color: "F59E0B"  # amber-500 - matches other in-progress states
 
 - name: loom:curating
-  description: Curator is enhancing this issue
+  description: "Curator is enhancing this issue. Applied by: Curator only (claim label)."
   color: "F59E0B"  # amber-500 - matches other in-progress states
 
 - name: loom:treating
-  description: Doctor is fixing this bug or addressing PR feedback
+  description: "Doctor is fixing this bug or addressing PR feedback. Applied by: Doctor only (claim label)."
   color: "F59E0B"  # amber-500 - matches other in-progress states
 
 - name: loom:reviewing
-  description: Judge is actively reviewing this PR
+  description: "Judge is actively reviewing this PR. Applied by: Judge only (claim label)."
   color: "F59E0B"  # amber-500 - matches other in-progress states
 
 - name: loom:review-requested
-  description: PR ready for Judge to review
+  description: "PR ready for Judge to review. Applied by: Builder when opening PR."
   color: "10B981"  # emerald-500
 
 - name: loom:changes-requested
-  description: "PR requires changes before re-review (Judge requested modifications)"
+  description: "PR requires changes before re-review (Judge requested modifications). Applied by: Judge."
   color: "F59E0B"  # amber-500 - matches other "action required" labels
 
 - name: loom:merge-conflict
@@ -56,20 +56,20 @@
   color: "DC2626"  # red-600 - indicates broken state
 
 - name: loom:pr
-  description: PR approved by Judge, ready for human to merge
+  description: "PR approved by Judge, ready for human to merge. Applied by: Judge."
   color: "3B82F6"  # blue-500
 
 # Agent Proposal Labels
 - name: loom:architect
-  description: Architect proposal awaiting user approval
+  description: "Architect proposal awaiting user approval. Applied by: Architect only."
   color: "9333EA"  # purple (violet-600)
 
 - name: loom:hermit
-  description: Hermit removal/simplification proposal awaiting user approval
+  description: "Hermit removal/simplification proposal awaiting user approval. Applied by: Hermit only."
   color: "9333EA"  # purple (violet-600)
 
 - name: loom:auditor
-  description: Bug discovered by Auditor during main branch validation
+  description: "Bug discovered by Auditor during main branch validation. Applied by: Auditor only."
   color: "d93f0b"  # red - indicates runtime/build issue
 
 - name: loom:auditor-capability-request
@@ -77,7 +77,7 @@
   color: "6366F1"  # indigo-500 - indicates meta/tooling request
 
 - name: loom:curated
-  description: "Curator-enriched. Additive marker; coexists with loom:issue (highest-quality state for Builders)"
+  description: "Curator-enriched, awaiting human approval. Additive marker; coexists with loom:issue (highest-quality state for Builders). Applied by: Curator only."
   color: "10B981"  # emerald-500
 
 # Status Labels

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,12 +126,13 @@ Agents coordinate through GitHub labels. See `.github/labels.yml` for full defin
 
 **Issue Lifecycle**:
 ```
-(created) → loom:issue → loom:building → (closed)
-           ↑ Curator      ↑ Builder
-
-(created) → loom:curating → loom:curated → loom:issue
-           ↑ Curator        ↑ Curator      ↑ Champion approves
+(created) → loom:triage → loom:curating → loom:curated → loom:issue → loom:building → (closed)
+           ↑ filer        ↑ Curator        ↑ Curator      ↑ human     ↑ Builder
+                                                          (or Champion
+                                                           in --merge mode)
 ```
+
+See `.github/labels.yml` for the authoritative `Applied by:` field on every label.
 
 **PR Lifecycle**:
 ```


### PR DESCRIPTION
Closes #3307

## Summary

- **`.github/labels.yml`** — extended 10 lifecycle label descriptions with an `Applied by:` clause so the YAML acts as the single source of truth for label ownership. Covers: `loom:triage`, `loom:issue`, `loom:building`, `loom:curating`, `loom:curated`, `loom:treating`, `loom:reviewing`, `loom:review-requested`, `loom:changes-requested`, `loom:pr`, `loom:architect`, `loom:hermit`, `loom:auditor`.
- **`CLAUDE.md` Issue Lifecycle diagram** — fixed two existing bugs:
  - Added the missing `loom:triage` intake state (previously omitted)
  - Corrected the `loom:issue` actor attribution from "Curator" to "human (or Champion in --merge mode)" — per `.loom/roles/curator.md`, the Curator does NOT apply `loom:issue`
- Added a one-line pointer from CLAUDE.md to `.github/labels.yml` as the authoritative `Applied by:` reference.

No new labels created, no role files touched (curator.md already documents its transitions; duplicating invites drift). YAML still parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`).

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/labels.yml'))"` → 25 labels)
- [x] Diagram correctness: `loom:triage` is the first state; `loom:issue` is attributed to human, not Curator
- [x] No new labels added (label count unchanged)
- [ ] Operator should run `gh label sync --file .github/labels.yml --repo rjwalters/loom` after merge to propagate the description updates (colors unchanged, only descriptions change)