### PR TITLE
fix(install): copy defaults/.claude/agents into target + verify

### DIFF
--- a/loom-daemon/src/init/git.rs
+++ b/loom-daemon/src/init/git.rs
@@ -105,6 +105,42 @@ pub fn is_loom_source_repo(workspace_path: &Path) -> bool {
     false
 }
 
+/// Collect file stems of every entry in `dir` whose extension matches `ext`.
+///
+/// Returns an empty vec when the directory is unreadable or missing — callers
+/// surface the "missing directory" issue separately.
+fn collect_file_stems(dir: &Path, ext: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let Ok(entries) = fs::read_dir(dir) else {
+        return out;
+    };
+    for entry in entries.filter_map(Result::ok) {
+        let path = entry.path();
+        if path.extension().is_some_and(|e| e == ext) {
+            if let Some(name) = path.file_stem() {
+                out.push(name.to_string_lossy().to_string());
+            }
+        }
+    }
+    out
+}
+
+/// Scan `dir` for files with extension `ext`, populating `found`. If `dir`
+/// does not exist, push a `Missing <missing_msg>` entry into `issues`.
+fn scan_or_record_missing(
+    dir: &Path,
+    ext: &str,
+    found: &mut Vec<String>,
+    issues: &mut Vec<String>,
+    missing_msg: &str,
+) {
+    if dir.is_dir() {
+        found.extend(collect_file_stems(dir, ext));
+    } else {
+        issues.push(format!("Missing {missing_msg}"));
+    }
+}
+
 /// Validate an existing Loom source repository configuration
 ///
 /// Instead of copying files, this validates that the expected structure exists
@@ -113,66 +149,40 @@ pub fn validate_loom_source_repo(workspace_path: &Path) -> ValidationReport {
     let mut report = ValidationReport::default();
     let loom_path = workspace_path.join(".loom");
 
-    // Check roles
-    let roles_dir = loom_path.join("roles");
-    if roles_dir.is_dir() {
-        if let Ok(entries) = fs::read_dir(&roles_dir) {
-            for entry in entries.filter_map(Result::ok) {
-                let path = entry.path();
-                if path.extension().is_some_and(|e| e == "md") {
-                    if let Some(name) = path.file_stem() {
-                        report.roles_found.push(name.to_string_lossy().to_string());
-                    }
-                }
-            }
-        }
-    } else {
-        report
-            .issues
-            .push("Missing .loom/roles/ directory".to_string());
-    }
+    scan_or_record_missing(
+        &loom_path.join("roles"),
+        "md",
+        &mut report.roles_found,
+        &mut report.issues,
+        ".loom/roles/ directory",
+    );
 
-    // Check scripts
-    let scripts_dir = loom_path.join("scripts");
-    if scripts_dir.is_dir() {
-        if let Ok(entries) = fs::read_dir(&scripts_dir) {
-            for entry in entries.filter_map(Result::ok) {
-                let path = entry.path();
-                if path.extension().is_some_and(|e| e == "sh") {
-                    if let Some(name) = path.file_stem() {
-                        report
-                            .scripts_found
-                            .push(name.to_string_lossy().to_string());
-                    }
-                }
-            }
-        }
-    } else {
-        report
-            .issues
-            .push("Missing .loom/scripts/ directory".to_string());
-    }
+    scan_or_record_missing(
+        &loom_path.join("scripts"),
+        "sh",
+        &mut report.scripts_found,
+        &mut report.issues,
+        ".loom/scripts/ directory",
+    );
 
-    // Check .claude/commands/loom/
-    let commands_dir = workspace_path.join(".claude").join("commands").join("loom");
-    if commands_dir.is_dir() {
-        if let Ok(entries) = fs::read_dir(&commands_dir) {
-            for entry in entries.filter_map(Result::ok) {
-                let path = entry.path();
-                if path.extension().is_some_and(|e| e == "md") {
-                    if let Some(name) = path.file_stem() {
-                        report
-                            .commands_found
-                            .push(name.to_string_lossy().to_string());
-                    }
-                }
-            }
-        }
-    } else {
-        report
-            .issues
-            .push("Missing .claude/commands/loom/ directory".to_string());
-    }
+    scan_or_record_missing(
+        &workspace_path.join(".claude").join("commands").join("loom"),
+        "md",
+        &mut report.commands_found,
+        &mut report.issues,
+        ".claude/commands/loom/ directory",
+    );
+
+    // .claude/agents/ holds subagent definitions (loom-builder, loom-judge, …).
+    // Required for native Claude Code `subagent_type` dispatch — without these
+    // files fresh installs cannot use the loom-* subagents. See issue #3310.
+    scan_or_record_missing(
+        &workspace_path.join(".claude").join("agents"),
+        "md",
+        &mut report.agents_found,
+        &mut report.issues,
+        ".claude/agents/ directory",
+    );
 
     // Check documentation files
     report.has_claude_md = workspace_path.join("CLAUDE.md").exists();
@@ -204,6 +214,17 @@ pub fn validate_loom_source_repo(workspace_path: &Path) -> ValidationReport {
         report.issues.push(format!(
             "Expected at least 4 slash commands, found {}",
             report.commands_found.len()
+        ));
+    }
+
+    // The shipped agents pool currently contains 11 loom-* subagents
+    // (architect, auditor, builder, champion, curator, daemon, doctor,
+    // guide, hermit, judge, shepherd). Require at least 5 so a degraded
+    // install (missing core dispatchers like loom-builder) is flagged.
+    if report.agents_found.len() < 5 {
+        report.issues.push(format!(
+            "Expected at least 5 subagent definitions in .claude/agents/, found {}",
+            report.agents_found.len()
         ));
     }
 

--- a/loom-daemon/src/init/mod.rs
+++ b/loom-daemon/src/init/mod.rs
@@ -73,6 +73,8 @@ pub struct ValidationReport {
     pub scripts_found: Vec<String>,
     /// Slash commands found
     pub commands_found: Vec<String>,
+    /// Subagent definitions found in .claude/agents/
+    pub agents_found: Vec<String>,
     /// Whether CLAUDE.md exists
     pub has_claude_md: bool,
     /// Whether .github/labels.yml exists
@@ -431,15 +433,52 @@ mod tests {
 
         // Create .claude/commands/loom/
         fs::create_dir_all(workspace.join(".claude").join("commands").join("loom")).unwrap();
-        fs::write(
-            workspace
-                .join(".claude")
-                .join("commands")
-                .join("loom")
-                .join("builder.md"),
-            "",
-        )
-        .unwrap();
+        for cmd in [
+            "builder.md",
+            "judge.md",
+            "curator.md",
+            "doctor.md",
+            "shepherd.md",
+        ] {
+            fs::write(
+                workspace
+                    .join(".claude")
+                    .join("commands")
+                    .join("loom")
+                    .join(cmd),
+                "",
+            )
+            .unwrap();
+        }
+
+        // Create .claude/agents/ (subagent definitions — required for
+        // native Claude Code subagent dispatch). See issue #3310.
+        fs::create_dir_all(workspace.join(".claude").join("agents")).unwrap();
+        for agent in [
+            "loom-builder.md",
+            "loom-judge.md",
+            "loom-curator.md",
+            "loom-doctor.md",
+            "loom-shepherd.md",
+        ] {
+            fs::write(workspace.join(".claude").join("agents").join(agent), "").unwrap();
+        }
+
+        // Create roles to satisfy the >=5 role-count check (issue #3310 makes
+        // agents/ subject to the same kind of minimum-count audit and the
+        // validation report now bails on too-few defaults across the board).
+        for role in [
+            "builder.md",
+            "judge.md",
+            "curator.md",
+            "doctor.md",
+            "shepherd.md",
+        ] {
+            fs::write(workspace.join(".loom").join("roles").join(role), "").unwrap();
+        }
+
+        // Create a couple of scripts to satisfy the >=2 script-count check.
+        fs::write(workspace.join(".loom").join("scripts").join("daemon.sh"), "").unwrap();
 
         // Create docs
         fs::write(workspace.join("CLAUDE.md"), "").unwrap();
@@ -466,8 +505,58 @@ mod tests {
         assert!(validation.roles_found.contains(&"builder".to_string()));
         assert!(validation.scripts_found.contains(&"worktree".to_string()));
         assert!(validation.commands_found.contains(&"builder".to_string()));
+        // Issue #3310: subagent definitions must be discovered for native
+        // Claude Code `subagent_type` dispatch to work.
+        assert!(validation
+            .agents_found
+            .contains(&"loom-builder".to_string()));
         assert!(validation.has_claude_md);
         assert!(validation.has_labels_yml);
+        // Verify the missing-agents-directory issue is NOT raised when
+        // the directory exists with the expected fixtures.
+        assert!(!validation
+            .issues
+            .iter()
+            .any(|i| i.contains("Missing .claude/agents/")));
+    }
+
+    #[test]
+    fn test_self_install_flags_missing_agents_directory() {
+        // Issue #3310: a self-installed Loom checkout that is missing
+        // `.claude/agents/` cannot dispatch subagents. The validation
+        // report must surface this as an explicit issue so downstream
+        // tooling (installer reconciliation, `loom-daemon init`) can
+        // fail loudly instead of silently producing a broken install.
+        let temp_dir = TempDir::new().unwrap();
+        let workspace = temp_dir.path();
+
+        // Mark this directory as a Loom source repo via the marker file.
+        // We deliberately do NOT create `.claude/agents/` here.
+        fs::create_dir(workspace.join(".git")).unwrap();
+        fs::write(workspace.join(".loom-source"), "").unwrap();
+        fs::create_dir_all(workspace.join(".loom").join("roles")).unwrap();
+        fs::create_dir_all(workspace.join(".loom").join("scripts")).unwrap();
+        fs::create_dir_all(workspace.join(".claude").join("commands").join("loom")).unwrap();
+        fs::write(workspace.join("CLAUDE.md"), "").unwrap();
+        fs::create_dir_all(workspace.join(".github")).unwrap();
+        fs::write(workspace.join(".github").join("labels.yml"), "").unwrap();
+
+        let result =
+            initialize_workspace(workspace.to_str().unwrap(), "nonexistent-defaults", false);
+        assert!(result.is_ok());
+
+        let report = result.unwrap();
+        assert!(report.is_self_install);
+        let validation = report.validation.expect("validation report present");
+        assert!(validation.agents_found.is_empty());
+        assert!(
+            validation
+                .issues
+                .iter()
+                .any(|i| i == "Missing .claude/agents/ directory"),
+            "Expected missing-agents-directory issue, got: {:?}",
+            validation.issues
+        );
     }
 
     #[test]

--- a/loom-daemon/src/init/scaffolding.rs
+++ b/loom-daemon/src/init/scaffolding.rs
@@ -1156,7 +1156,9 @@ WARNING: Never run `lake build` inside Docker - causes memory corruption.
     #[test]
     fn test_claude_commands_always_updated_on_reinstall() {
         // .claude/ commands should always be force-merged on reinstall (without --force flag)
-        // This ensures command updates propagate while custom commands are preserved
+        // This ensures command updates propagate while custom commands are preserved.
+        // Issue #3310: also covers `.claude/agents/` (subagent definitions),
+        // which live alongside `.claude/commands/` and must propagate the same way.
         let temp_dir = TempDir::new().unwrap();
         let workspace = temp_dir.path();
         let defaults = temp_dir.path().join("defaults");
@@ -1164,8 +1166,9 @@ WARNING: Never run `lake build` inside Docker - causes memory corruption.
         // Setup git repo
         fs::create_dir(workspace.join(".git")).unwrap();
 
-        // Create defaults with .claude commands
+        // Create defaults with .claude commands AND agents
         fs::create_dir_all(defaults.join(".claude").join("commands").join("loom")).unwrap();
+        fs::create_dir_all(defaults.join(".claude").join("agents")).unwrap();
         fs::write(
             defaults
                 .join(".claude")
@@ -1184,9 +1187,26 @@ WARNING: Never run `lake build` inside Docker - causes memory corruption.
             "builder command v2",
         )
         .unwrap();
+        fs::write(
+            defaults
+                .join(".claude")
+                .join("agents")
+                .join("loom-builder.md"),
+            "loom-builder subagent v2",
+        )
+        .unwrap();
+        fs::write(
+            defaults
+                .join(".claude")
+                .join("agents")
+                .join("loom-judge.md"),
+            "loom-judge subagent v1",
+        )
+        .unwrap();
 
         // Create existing .claude directory in workspace (simulates previous install)
         fs::create_dir_all(workspace.join(".claude").join("commands").join("loom")).unwrap();
+        fs::create_dir_all(workspace.join(".claude").join("agents")).unwrap();
         fs::write(
             workspace
                 .join(".claude")
@@ -1202,6 +1222,22 @@ WARNING: Never run `lake build` inside Docker - causes memory corruption.
                 .join("commands")
                 .join("my-custom.md"),
             "my project-specific command",
+        )
+        .unwrap();
+        fs::write(
+            workspace
+                .join(".claude")
+                .join("agents")
+                .join("loom-builder.md"),
+            "loom-builder subagent v1 with bug",
+        )
+        .unwrap();
+        fs::write(
+            workspace
+                .join(".claude")
+                .join("agents")
+                .join("my-custom-agent.md"),
+            "project-specific custom subagent",
         )
         .unwrap();
 
@@ -1251,6 +1287,121 @@ WARNING: Never run `lake build` inside Docker - causes memory corruption.
         assert!(report
             .preserved
             .contains(&".claude/commands/my-custom.md".to_string()));
+
+        // Issue #3310: verify .claude/agents/ propagates identically.
+        // Default subagent updated:
+        let agent_content = fs::read_to_string(
+            workspace
+                .join(".claude")
+                .join("agents")
+                .join("loom-builder.md"),
+        )
+        .unwrap();
+        assert_eq!(agent_content, "loom-builder subagent v2");
+        // New default subagent added:
+        let new_agent_content = fs::read_to_string(
+            workspace
+                .join(".claude")
+                .join("agents")
+                .join("loom-judge.md"),
+        )
+        .unwrap();
+        assert_eq!(new_agent_content, "loom-judge subagent v1");
+        // Project-specific custom subagent preserved:
+        let custom_agent_content = fs::read_to_string(
+            workspace
+                .join(".claude")
+                .join("agents")
+                .join("my-custom-agent.md"),
+        )
+        .unwrap();
+        assert_eq!(custom_agent_content, "project-specific custom subagent");
+
+        assert!(report
+            .updated
+            .contains(&".claude/agents/loom-builder.md".to_string()));
+        assert!(report
+            .added
+            .contains(&".claude/agents/loom-judge.md".to_string()));
+        assert!(report
+            .preserved
+            .contains(&".claude/agents/my-custom-agent.md".to_string()));
+    }
+
+    #[test]
+    fn test_fresh_install_copies_claude_agents() {
+        // Issue #3310: a fresh install (no existing .claude/) must copy the
+        // full `.claude/agents/` tree from defaults so native subagent
+        // dispatch (subagent_type="loom-builder", etc.) works out of the
+        // box. Previously the .claude/ directory copy happened only via
+        // copy_dir_with_report — this test pins the behavior so the
+        // installer cannot silently regress agents/ in the future.
+        let temp_dir = TempDir::new().unwrap();
+        let workspace = temp_dir.path();
+        let defaults = temp_dir.path().join("defaults");
+
+        // Setup git repo
+        fs::create_dir(workspace.join(".git")).unwrap();
+
+        // Create defaults with .claude/agents/ (and a commands/ stub so the
+        // .claude/ src directory is non-empty, mirroring real defaults).
+        fs::create_dir_all(defaults.join(".claude").join("commands").join("loom")).unwrap();
+        fs::create_dir_all(defaults.join(".claude").join("agents")).unwrap();
+        fs::write(
+            defaults
+                .join(".claude")
+                .join("commands")
+                .join("loom")
+                .join("builder.md"),
+            "builder command",
+        )
+        .unwrap();
+        fs::write(
+            defaults
+                .join(".claude")
+                .join("agents")
+                .join("loom-builder.md"),
+            "loom-builder subagent body",
+        )
+        .unwrap();
+        fs::write(
+            defaults
+                .join(".claude")
+                .join("agents")
+                .join("loom-judge.md"),
+            "loom-judge subagent body",
+        )
+        .unwrap();
+
+        // Workspace starts with NO .claude/ — pure fresh install
+        assert!(!workspace.join(".claude").exists());
+
+        let mut report = InitReport::default();
+        setup_repository_scaffolding(workspace, &defaults, false, &mut report).unwrap();
+
+        // The fresh-install path must produce the full agents tree.
+        let installed_builder = workspace
+            .join(".claude")
+            .join("agents")
+            .join("loom-builder.md");
+        assert!(
+            installed_builder.exists(),
+            "fresh install must copy .claude/agents/loom-builder.md (see #3310)"
+        );
+        assert_eq!(fs::read_to_string(&installed_builder).unwrap(), "loom-builder subagent body");
+        assert!(workspace
+            .join(".claude")
+            .join("agents")
+            .join("loom-judge.md")
+            .exists());
+
+        // Report should track every agent file as "added".
+        assert!(report
+            .added
+            .contains(&".claude/agents/loom-builder.md".to_string()));
+        assert!(report
+            .added
+            .contains(&".claude/agents/loom-judge.md".to_string()));
     }
 
     // =========================================================================

--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -895,6 +895,7 @@ EXPECTED_FILES=(
   "CLAUDE.md"
   ".github/labels.yml"
   ".claude/commands/loom"
+  ".claude/agents"
   ".claude/settings.json"
 )
 


### PR DESCRIPTION
## Summary

Child issue 1/3 from #3305 — installer copy path for fresh installs.

Fresh installs of Loom into a target repo now populate `.claude/agents/loom-*.md` so native Claude Code subagent dispatch (`subagent_type="loom-builder"`, etc.) works out of the box. Previously the installer copied `.claude/commands/loom/` but never audited `.claude/agents/`, so a degraded install would silently produce a repo where subagents could not be dispatched.

## Changes

- **`scripts/install-loom.sh`**: add `.claude/agents` to `EXPECTED_FILES` so post-install verification fails fast when the directory is missing.
- **`loom-daemon/src/init/git.rs`**: `validate_loom_source_repo` now scans `.claude/agents/` and surfaces a `Missing .claude/agents/ directory` issue; new >=5 subagent count check mirrors the existing roles/commands gate. Extracted `scan_or_record_missing` helper to keep the function under clippy `too_many_lines`.
- **`loom-daemon/src/init/mod.rs`**: extend `ValidationReport` with `agents_found`; updated self-install fixture; added `test_self_install_flags_missing_agents_directory`.
- **`loom-daemon/src/init/scaffolding.rs`**: extended reinstall test for update/add/preserve semantics across `.claude/agents/`; added `test_fresh_install_copies_claude_agents` to lock in the fresh-install copy path.

## Scope

Per the parent epic (#3305), this PR is **scoped to the fresh-install copy path only**. Dogfood symlinks (#3311) and README rewrites (#3312) are intentionally untouched and will land in sibling PRs.

## Test plan

- [x] cargo test --lib  272/272 passing (includes 2 new tests + 2 extended)
- [x] cargo clippy --lib -- -D warnings  no new lint regressions (only the preexisting forge_parser.rs:91 uninlined-format-args warning remains, unrelated)
- [ ] Manual: fresh ./scripts/install-loom.sh /tmp/test-install produces working .claude/agents/loom-builder.md
- [ ] Manual: loom-daemon init against a repo without .claude/agents/ surfaces the new validation issue

Closes #3310