### PR TITLE
feat(install): guard against non-main source and stale target on install

### DIFF
--- a/defaults/scripts/tests/test-install-source-guard.sh
+++ b/defaults/scripts/tests/test-install-source-guard.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# test-install-source-guard.sh - Unit tests for the source-state guard
+# in scripts/install-loom.sh (issue #3327).
+#
+# The guard (check_source_state) runs after argv parsing and helper
+# definitions. It refuses to install from a Loom source checkout that is:
+#   - on a non-main branch, OR
+#   - in detached HEAD that does NOT resolve to an exact-match tag, OR
+#   - behind origin/main
+# ...unless --allow-non-main-source is passed (info + continue), or the
+# operator confirms an interactive prompt with 'y'. Detached HEAD on an
+# exact-match tag is treated as clean (info-only, no warning gate).
+#
+# Test strategy: extract the check_source_state() function from
+# install-loom.sh via awk, source it into a small harness that stubs the
+# color helpers and read prompt, then exercise it against temp git repos
+# built with `git init`. We do NOT run the full installer — the guard is
+# pure (only touches the source repo).
+#
+# Usage:
+#   bash defaults/scripts/tests/test-install-source-guard.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+INSTALL_SCRIPT="$REPO_ROOT/scripts/install-loom.sh"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_contains() {
+    local haystack="$1"
+    local needle="$2"
+    local msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$haystack" == *"$needle"* ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Looking for: '$needle'"
+        echo "    In output:"
+        echo "$haystack" | sed 's/^/      /'
+    fi
+}
+
+assert_zero_exit() {
+    local actual="$1"
+    local msg="$2"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$actual" -eq 0 ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg (exit=$actual)"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg (expected 0, got $actual)"
+    fi
+}
+
+assert_nonzero_exit() {
+    local actual="$1"
+    local msg="$2"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$actual" -ne 0 ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg (exit=$actual)"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg (expected non-zero, got $actual)"
+    fi
+}
+
+if [[ ! -f "$INSTALL_SCRIPT" ]]; then
+    echo "ERROR: $INSTALL_SCRIPT not found" >&2
+    exit 1
+fi
+
+# Build a runnable harness once: extract the check_source_state function
+# (and only that function) so the test exercises the production code path.
+HARNESS_FILE=$(mktemp /tmp/loom-source-guard-harness.XXXXXX.sh)
+trap 'rm -f "$HARNESS_FILE"' EXIT
+
+# Extract the function body. Markers: the `check_source_state()` declaration
+# line down through its closing `}` at column 0.
+FUNC_BLOCK=$(awk '
+    /^check_source_state\(\) \{$/ { capture=1 }
+    capture { print }
+    capture && /^\}$/ { exit }
+' "$INSTALL_SCRIPT")
+
+if [[ -z "$FUNC_BLOCK" ]]; then
+    echo "ERROR: could not extract check_source_state() from $INSTALL_SCRIPT" >&2
+    exit 1
+fi
+
+cat >"$HARNESS_FILE" <<'PROLOGUE'
+#!/usr/bin/env bash
+set -uo pipefail
+# Stub helpers so the extracted function runs standalone.
+RED=''; GREEN=''; BLUE=''; YELLOW=''; CYAN=''; NC=''
+error()   { echo "Error: $*" >&2; exit 1; }
+info()    { echo "INFO: $*"; }
+success() { echo "OK: $*"; }
+warning() { echo "WARN: $*" >&2; }
+PROLOGUE
+
+printf '%s\n' "$FUNC_BLOCK" >>"$HARNESS_FILE"
+
+# Append the dispatcher: read env vars and call the function.
+cat >>"$HARNESS_FILE" <<'EPILOGUE'
+check_source_state
+echo "__POST__=ok"
+EPILOGUE
+
+# Helper: run the harness with a synthesized git repo as LOOM_ROOT.
+# Args:
+#   $1: setup function name (creates the temp repo, leaves CWD inside it)
+#   $2: ALLOW_NON_MAIN_SOURCE (true|false)
+#   $3: NON_INTERACTIVE (true|false)
+#   $4: stdin input (passed to read -p prompt)
+run_guard() {
+    local setup_fn="$1"
+    local allow="$2"
+    local non_interactive="$3"
+    local stdin_in="$4"
+    local tmp
+    tmp=$(mktemp -d /tmp/loom-source-guard-test.XXXXXX)
+    (
+        cd "$tmp" || exit 1
+        # shellcheck disable=SC2086,SC2317
+        "$setup_fn" "$tmp"
+        # Run harness with LOOM_ROOT pointing at the temp repo. Use printf to
+        # feed stdin (for interactive prompt cases).
+        ALLOW_NON_MAIN_SOURCE="$allow" \
+        NON_INTERACTIVE="$non_interactive" \
+        LOOM_ROOT="$tmp" \
+            bash "$HARNESS_FILE" <<<"$stdin_in" 2>&1
+        echo "__EXIT__=$?"
+    )
+    rm -rf "$tmp"
+}
+
+# Setup helpers — each leaves CWD inside the temp repo with the desired state.
+
+setup_main_clean() {
+    local dir="$1"
+    git -C "$dir" init -q -b main .
+    git -C "$dir" config user.email "test@example.com"
+    git -C "$dir" config user.name "Test"
+    : > "$dir/README.md"
+    git -C "$dir" add README.md
+    git -C "$dir" commit -q -m "initial"
+}
+
+setup_feature_branch() {
+    local dir="$1"
+    setup_main_clean "$dir"
+    git -C "$dir" checkout -q -b feature/whatever
+    : > "$dir/feature.txt"
+    git -C "$dir" add feature.txt
+    git -C "$dir" commit -q -m "feature work"
+}
+
+setup_detached_on_tag() {
+    local dir="$1"
+    setup_main_clean "$dir"
+    git -C "$dir" tag v0.8.0
+    # Detach HEAD onto the tag (older git versions don't accept tag refs
+    # directly in --detach; resolve to SHA first).
+    local sha
+    sha=$(git -C "$dir" rev-parse v0.8.0)
+    git -C "$dir" checkout -q --detach "$sha"
+    # Re-create the tag annotation context by ensuring HEAD points at the
+    # tagged SHA. `git describe --exact-match --tags` should now match.
+}
+
+setup_detached_no_tag() {
+    local dir="$1"
+    setup_main_clean "$dir"
+    # Make a second commit, then detach at the first (which has no tag).
+    local first
+    first=$(git -C "$dir" rev-parse HEAD)
+    : > "$dir/extra.txt"
+    git -C "$dir" add extra.txt
+    git -C "$dir" commit -q -m "second"
+    git -C "$dir" checkout -q --detach "$first"
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: source on main, clean (no origin) — should pass silently.
+# ---------------------------------------------------------------------------
+echo "Case 1: clean main, no origin -> pass without warning"
+OUTPUT=$(run_guard setup_main_clean false false "")
+EXIT_CODE=$(printf '%s' "$OUTPUT" | grep -oE '__EXIT__=[0-9]+' | tail -1 | cut -d= -f2)
+assert_zero_exit "$EXIT_CODE" "Case 1: exits zero"
+# Must NOT contain the warning gate
+if [[ "$OUTPUT" == *"is not on a clean main"* ]]; then
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: Case 1: should not warn on clean main"
+    echo "    Output: $OUTPUT"
+else
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: Case 1: no warning emitted"
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# Case 2: source on feature branch, --yes (non-interactive), no allow flag
+#         -> refuses with actionable error mentioning the override flag.
+# ---------------------------------------------------------------------------
+echo "Case 2: feature branch + --yes (no override) -> refuses"
+OUTPUT=$(run_guard setup_feature_branch false true "")
+EXIT_CODE=$(printf '%s' "$OUTPUT" | grep -oE '__EXIT__=[0-9]+' | tail -1 | cut -d= -f2)
+assert_nonzero_exit "$EXIT_CODE" "Case 2: refuses install"
+assert_contains "$OUTPUT" "feature/whatever" "Case 2: shows branch name"
+assert_contains "$OUTPUT" "--allow-non-main-source" "Case 2: hints at override flag"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Case 3: source on feature branch + --allow-non-main-source -> proceeds.
+# ---------------------------------------------------------------------------
+echo "Case 3: feature branch + --allow-non-main-source -> proceeds"
+OUTPUT=$(run_guard setup_feature_branch true true "")
+EXIT_CODE=$(printf '%s' "$OUTPUT" | grep -oE '__EXIT__=[0-9]+' | tail -1 | cut -d= -f2)
+assert_zero_exit "$EXIT_CODE" "Case 3: continues with override"
+assert_contains "$OUTPUT" "Continuing anyway" "Case 3: announces override"
+assert_contains "$OUTPUT" "__POST__=ok" "Case 3: function returned normally"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Case 4: detached HEAD on a v* tag, no override, --yes -> passes (tagged
+#         release exemption: detached on an exact-match tag is treated as a
+#         clean snapshot).
+# ---------------------------------------------------------------------------
+echo "Case 4: detached HEAD on v0.8.0 tag -> passes (tagged release)"
+OUTPUT=$(run_guard setup_detached_on_tag false true "")
+EXIT_CODE=$(printf '%s' "$OUTPUT" | grep -oE '__EXIT__=[0-9]+' | tail -1 | cut -d= -f2)
+assert_zero_exit "$EXIT_CODE" "Case 4: tagged detached HEAD passes"
+assert_contains "$OUTPUT" "v0.8.0" "Case 4: announces tag"
+assert_contains "$OUTPUT" "__POST__=ok" "Case 4: function returned normally"
+# Must NOT contain the "not on a clean main" warning
+if [[ "$OUTPUT" == *"is not on a clean main"* ]]; then
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: Case 4: should not warn for tagged release"
+    echo "    Output: $OUTPUT"
+else
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: Case 4: no warning gate for tagged release"
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# Case 5 (bonus): detached HEAD with NO matching tag, --yes, no override
+#         -> refuses (this is the arbitrary detached-HEAD case, which we
+#         treat as non-main since the operator may be at an old commit).
+# ---------------------------------------------------------------------------
+echo "Case 5: detached HEAD with no matching tag + --yes -> refuses"
+OUTPUT=$(run_guard setup_detached_no_tag false true "")
+EXIT_CODE=$(printf '%s' "$OUTPUT" | grep -oE '__EXIT__=[0-9]+' | tail -1 | cut -d= -f2)
+assert_nonzero_exit "$EXIT_CODE" "Case 5: untagged detached HEAD refused"
+assert_contains "$OUTPUT" "detached HEAD" "Case 5: mentions detached HEAD"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo "================================================================"
+echo "Tests run:    $TESTS_RUN"
+echo -e "Tests passed: ${GREEN}$TESTS_PASSED${NC}"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+    echo -e "Tests failed: ${RED}$TESTS_FAILED${NC}"
+    exit 1
+fi
+echo "================================================================"
+echo "All tests passed."

--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -12,6 +12,9 @@
 #     ./scripts/install-loom.sh /path/to/target-repo
 #
 #   What this script does:
+#     0. Validates source/target checkout state (warns or refuses if either is
+#        on a non-main branch or behind origin/main; override with
+#        --allow-non-main-source / --allow-stale-target)
 #     1. Validates target repository (must be a Git repo)
 #     2. Creates installation worktree (.loom/worktrees/loom-install-vX.Y.Z)
 #     3. Initializes Loom configuration (copies defaults to .loom/)
@@ -36,6 +39,8 @@ NON_INTERACTIVE=false
 FORCE_OVERWRITE=false
 CLEAN_FIRST=false
 DOGFOOD_MODE=""  # "" (auto-detect), "true" (forced), "false" (forced off)
+ALLOW_NON_MAIN_SOURCE=false
+ALLOW_STALE_TARGET=false
 TARGET_PATH=""
 
 while [[ $# -gt 0 ]]; do
@@ -60,17 +65,29 @@ while [[ $# -gt 0 ]]; do
       DOGFOOD_MODE="false"
       shift
       ;;
+    --allow-non-main-source)
+      ALLOW_NON_MAIN_SOURCE=true
+      shift
+      ;;
+    --allow-stale-target)
+      ALLOW_STALE_TARGET=true
+      shift
+      ;;
     -h|--help)
       echo "Usage: $0 [OPTIONS] /path/to/target-repo"
       echo ""
       echo "Options:"
-      echo "  -y, --yes        Non-interactive mode"
-      echo "  -f, --force      Force overwrite existing files and enable auto-merge"
-      echo "  --clean          Run uninstall first, then fresh install (combines both operations)"
-      echo "  --dogfood        Force dogfood mode: symlink .claude/agents -> ../defaults/.claude/agents"
-      echo "                   (auto-detected when installing into the Loom source repo itself)"
-      echo "  --no-dogfood     Disable dogfood mode even when installing into the Loom source repo"
-      echo "  -h, --help       Show this help message"
+      echo "  -y, --yes                  Non-interactive mode"
+      echo "  -f, --force                Force overwrite existing files and enable auto-merge"
+      echo "  --clean                    Run uninstall first, then fresh install (combines both operations)"
+      echo "  --dogfood                  Force dogfood mode: symlink .claude/agents -> ../defaults/.claude/agents"
+      echo "                             (auto-detected when installing into the Loom source repo itself)"
+      echo "  --no-dogfood               Disable dogfood mode even when installing into the Loom source repo"
+      echo "  --allow-non-main-source    Proceed even if the Loom source checkout is not on a clean main"
+      echo "                             (non-main branch, detached HEAD, or behind origin/main)"
+      echo "  --allow-stale-target       Proceed even if the target checkout is not on a clean main"
+      echo "                             (non-main branch or behind origin/main); ignored in dogfood mode"
+      echo "  -h, --help                 Show this help message"
       exit 0
       ;;
     *)
@@ -110,6 +127,76 @@ warning() {
 
 header() {
   echo -e "${CYAN}$*${NC}"
+}
+
+# Check the state of the Loom *source* checkout (the directory that contains
+# this script). We refuse to install from a feature branch, a stale main, or
+# an arbitrary detached HEAD unless the operator explicitly opts in. Detached
+# HEAD on a `v*` tag is treated as a clean tagged release (still emits a mild
+# warning so the operator knows they're not on a moving branch). Staleness is
+# best-effort: we never run `git fetch` here — the operator is responsible for
+# refreshing `origin/main` if they want the staleness check to be accurate.
+check_source_state() {
+  local branch tag_match=""
+  branch=$(git -C "$LOOM_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+
+  # Tagged-release exemption: detached HEAD that resolves to a v* tag is OK.
+  if [[ "$branch" == "HEAD" ]]; then
+    tag_match=$(git -C "$LOOM_ROOT" describe --exact-match --tags HEAD 2>/dev/null || true)
+  fi
+
+  local stale=""
+  # Best-effort: only check upstream if origin/main exists locally. If there
+  # is no origin remote at all, or origin/main has never been fetched, we
+  # skip the staleness check silently rather than erroring — the operator
+  # has not opted into upstream tracking.
+  if git -C "$LOOM_ROOT" rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
+    local behind
+    behind=$(git -C "$LOOM_ROOT" rev-list --count HEAD..origin/main 2>/dev/null || echo 0)
+    if [[ "$behind" -gt 0 ]]; then
+      stale="local is $behind commit(s) behind origin/main (run 'git -C $LOOM_ROOT fetch && git -C $LOOM_ROOT pull' to refresh)"
+    fi
+  fi
+
+  # Tagged release on a clean snapshot is fine — just announce it.
+  if [[ "$branch" == "HEAD" ]] && [[ -n "$tag_match" ]] && [[ -z "$stale" ]]; then
+    info "Loom source is at tagged release: $tag_match (detached HEAD)"
+    return 0
+  fi
+
+  # Clean main, up to date — nothing to say.
+  if [[ "$branch" == "main" ]] && [[ -z "$stale" ]]; then
+    return 0
+  fi
+
+  warning "Loom source checkout is not on a clean main:"
+  if [[ "$branch" != "main" ]]; then
+    if [[ "$branch" == "HEAD" ]] && [[ -n "$tag_match" ]]; then
+      echo "    detached HEAD on tag: $tag_match (no branch)"
+    elif [[ "$branch" == "HEAD" ]]; then
+      echo "    detached HEAD (no branch, no matching tag)"
+    else
+      echo "    branch: $branch (expected: main)"
+    fi
+  fi
+  [[ -n "$stale" ]] && echo "    $stale"
+  echo "  Source path: $LOOM_ROOT"
+
+  if [[ "$ALLOW_NON_MAIN_SOURCE" == "true" ]]; then
+    info "Continuing anyway (--allow-non-main-source)"
+    return 0
+  fi
+
+  if [[ "$NON_INTERACTIVE" == "true" ]]; then
+    error "Refusing to install from non-main / stale source in --yes mode. Pass --allow-non-main-source to override."
+  fi
+
+  local reply=""
+  read -r -p "Proceed with this source checkout anyway? [y/N] " -n 1 reply
+  echo ""
+  if [[ ! "$reply" =~ ^[Yy]$ ]]; then
+    error "Aborted by user. Switch to main and pull, or pass --allow-non-main-source."
+  fi
 }
 
 # Cleanup function called on error
@@ -166,6 +253,12 @@ fi
 
 # Export for sub-scripts
 export NON_INTERACTIVE
+
+# Source-state guard (#3327): before doing any heavy work, verify that the
+# Loom source checkout is on a clean main. Refuse / prompt / continue based
+# on flags + interactive vs. --yes mode. Runs after NON_INTERACTIVE finalization
+# so the refusal logic sees the effective value (including TTY auto-detect).
+check_source_state
 
 # Resolve target to absolute path (git repository root, not worktree)
 TARGET_PATH="$(cd "$TARGET_PATH" 2>/dev/null && pwd)" || \
@@ -552,6 +645,7 @@ echo ""
 export LOOM_VERSION
 export LOOM_COMMIT
 export LOOM_ROOT
+export ALLOW_STALE_TARGET
 
 # Export FORCE_AUTO_MERGE for create-pr.sh
 # When --force is passed, also enable auto-merge on the installation PR

--- a/scripts/install/validate-target.sh
+++ b/scripts/install/validate-target.sh
@@ -104,6 +104,47 @@ if [[ -n "$(git status --porcelain)" ]]; then
   echo -e "${YELLOW}  Installation will create a worktree, so this is safe to proceed.${NC}"
 fi
 
+# Target-state guard (#3327): warn/refuse if the target checkout is on a
+# non-main branch or is behind origin/main. Dogfood exemption: when the
+# target IS the Loom source repo (TARGET_PATH == LOOM_ROOT) the source-state
+# check already covered this; don't double-warn.
+#
+# Environment inputs (exported by install-loom.sh parent):
+#   ALLOW_STALE_TARGET=true|false  - operator override
+#   NON_INTERACTIVE=true|false     - refuse vs. prompt
+#   LOOM_ROOT                      - canonical Loom source path
+ALLOW_STALE_TARGET="${ALLOW_STALE_TARGET:-false}"
+NON_INTERACTIVE="${NON_INTERACTIVE:-false}"
+if [[ "${LOOM_ROOT:-}" != "$TARGET_PATH" ]]; then
+  target_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+  target_stale=""
+  if git rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
+    target_behind=$(git rev-list --count HEAD..origin/main 2>/dev/null || echo 0)
+    if [[ "$target_behind" -gt 0 ]]; then
+      target_stale="local is $target_behind commit(s) behind origin/main (run 'git fetch && git pull' to refresh)"
+    fi
+  fi
+
+  if [[ "$target_branch" != "main" ]] || [[ -n "$target_stale" ]]; then
+    echo -e "${YELLOW}⚠ Warning: Target checkout is not on a clean main:${NC}"
+    [[ "$target_branch" != "main" ]] && echo "    branch: $target_branch (expected: main)"
+    [[ -n "$target_stale" ]]         && echo "    $target_stale"
+    echo "  Target path: $TARGET_PATH"
+
+    if [[ "$ALLOW_STALE_TARGET" == "true" ]]; then
+      info "Continuing anyway (--allow-stale-target)"
+    elif [[ "$NON_INTERACTIVE" == "true" ]]; then
+      error "Refusing to install into non-main / stale target in --yes mode. Pass --allow-stale-target to override."
+    else
+      read -r -p "Proceed with this target checkout anyway? [y/N] " -n 1 reply
+      echo ""
+      if [[ ! "$reply" =~ ^[Yy]$ ]]; then
+        error "Aborted by user. Switch the target to main and pull, or pass --allow-stale-target."
+      fi
+    fi
+  fi
+fi
+
 success "Validation complete"
 echo ""
 echo "Target repository: $REPO_NAME"


### PR DESCRIPTION
## Summary

Adds two install-time safety guards (#3327) so `scripts/install-loom.sh` no longer silently installs from an inconsistent Loom source checkout or into a stale target repo. Closes the gap discovered during the v0.8.0 deployment to `strata-fdtd` (target on the wrong branch) and `geode-fem` (concern about installing from a feature branch).

## Changes

- **`scripts/install-loom.sh`**
  - New `--allow-non-main-source` flag and `check_source_state()` helper. The guard runs right after non-interactive mode is finalized (line ~258), before any heavy work. It compares `git rev-parse --abbrev-ref HEAD` to `main`, runs a best-effort `HEAD..origin/main` count when `origin/main` is locally known, and (in `--yes` mode) refuses with a hint about the override flag.
  - Detached HEAD that resolves via `git describe --exact-match --tags` is treated as a clean tagged release — info-only, no gate.
  - New `--allow-stale-target` flag (exported as env for the sub-script).
  - Header docstring + `--help` updated.
- **`scripts/install/validate-target.sh`**
  - Extends the existing dirty-tree warning with the same branch + `HEAD..origin/main` check, gated by `ALLOW_STALE_TARGET` / `NON_INTERACTIVE` env vars.
  - **Dogfood exemption**: when `TARGET_PATH == LOOM_ROOT`, the target check is skipped entirely (source check already covered it).
- **`defaults/scripts/tests/test-install-source-guard.sh`** (new, +236 lines)
  - Extracts `check_source_state()` via `awk`, runs it against `git init`-built temp repos with stubbed color helpers. Exercises 5 cases / 14 assertions: clean main, feature-branch refusal, override flag, tagged-release exemption, untagged-detached refusal. **14/14 pass.**

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|---|---|---|
| Detect source-checkout state mismatches and warn/refuse | Yes | `check_source_state()` + test cases 2 & 5 |
| Detect target-checkout state mismatches and warn/refuse | Yes | `validate-target.sh` lines 107-145 |
| Interactive: warn+prompt; `--yes`: refuse unless opt-out | Yes | `read -r -p` interactive branch; `--yes` refuses with hint (test case 2) |
| No regression on happy path (main + up-to-date) | Yes | Test case 1: zero exit, no warning emitted |
| Dogfood mode (`pwd == LOOM_ROOT`) skips target check | Yes | `if [[ "${LOOM_ROOT:-}" != "$TARGET_PATH" ]]` guard in `validate-target.sh` |

## Test Plan

- [x] `bash -n scripts/install-loom.sh` (syntax OK)
- [x] `bash -n scripts/install/validate-target.sh` (syntax OK)
- [x] `bash defaults/scripts/tests/test-install-source-guard.sh` — 14/14 pass
- [x] `find defaults/scripts -type f -name "*.sh" -print0 | xargs -0 shellcheck --severity=warning --format=gcc` — clean
- [x] `./scripts/install-loom.sh --help` lists both new flags with one-line descriptions
- [ ] Manual smoke: install from a feature branch into a fresh target with `--yes` — verifies refusal hint
- [ ] Manual smoke: install with `--allow-non-main-source --yes` — verifies bypass

## Edge Cases Handled

- Missing `origin/main` ref (fresh clone, no fetch): branch check still runs; staleness silently skipped — no error.
- Detached HEAD on a `v*` tag: treated as clean tagged release (info-only).
- Detached HEAD without a matching tag: treated like a non-main branch (refused without override).
- Worktree-aware: `LOOM_ROOT` is the script's own path so it resolves correctly from any worktree.

## Out of Scope

- Auto-fetching `origin/main` (issue explicitly leaves `fetch` to the operator).
- Comparing against the last released tag vs. `origin/main` head (separate feature).
- Touching `uninstall-loom.sh` (different lifecycle).

Closes #3327