### PR TITLE
feat(install): detect active loom session in target and refuse without override

### DIFF
--- a/defaults/scripts/tests/test-install-active-session.sh
+++ b/defaults/scripts/tests/test-install-active-session.sh
@@ -1,0 +1,378 @@
+#!/usr/bin/env bash
+# test-install-active-session.sh — Unit tests for scripts/install/check-active-session.sh
+#
+# Exercises each indicator individually (positive + negative), the
+# multi-indicator output, and the --allow-active-session flag matrix on
+# install-loom.sh.
+#
+# Per indicator (from issue #3331):
+#   1. Daemon PID file: .loom/daemon-loop.pid + alive PID
+#   2. Recent active state: .loom/daemon-state.json running=true + mtime <5min
+#   3. In-flight builder: .loom/worktrees/issue-N with mtime <5min
+#
+# Usage:
+#   ./defaults/scripts/tests/test-install-active-session.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# defaults/scripts/tests → defaults/scripts → defaults → repo root
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+CHECK_SCRIPT="$REPO_ROOT/scripts/install/check-active-session.sh"
+INSTALL_SCRIPT="$REPO_ROOT/scripts/install-loom.sh"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() {
+  TESTS_RUN=$((TESTS_RUN + 1))
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+  echo -e "  ${GREEN}PASS${NC}: $1"
+}
+
+fail() {
+  TESTS_RUN=$((TESTS_RUN + 1))
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+  echo -e "  ${RED}FAIL${NC}: $1"
+  if [[ -n "${2:-}" ]]; then
+    echo "    Detail: $2"
+  fi
+}
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local msg="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    pass "$msg"
+  else
+    fail "$msg" "expected='$expected' actual='$actual'"
+  fi
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local msg="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    pass "$msg"
+  else
+    fail "$msg" "needle='$needle' not found in output"
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local msg="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    pass "$msg"
+  else
+    fail "$msg" "unwanted needle='$needle' present in output"
+  fi
+}
+
+# Each test creates a fresh tmp dir and reuses it via $TARGET.
+TARGET=""
+new_target() {
+  TARGET=$(mktemp -d "/tmp/loom-active-session-test.XXXXXX")
+  mkdir -p "$TARGET/.loom"
+}
+
+cleanup_target() {
+  if [[ -n "$TARGET" && -d "$TARGET" ]]; then
+    rm -rf "$TARGET"
+  fi
+  TARGET=""
+}
+
+trap '[[ -n "$TARGET" ]] && rm -rf "$TARGET"' EXIT
+
+# Portable mtime backdating: set a file's mtime to ($EPOCH - $seconds_ago).
+# Uses `touch -d @timestamp` on GNU (Linux) and `touch -t YYYYMMDDhhmm.ss` on BSD/macOS.
+backdate() {
+  local path="$1"
+  local seconds_ago="$2"
+  local target_epoch
+  target_epoch=$(( $(date +%s) - seconds_ago ))
+
+  if touch -d "@$target_epoch" "$path" 2>/dev/null; then
+    return 0
+  fi
+  # BSD touch (macOS): -t [[CC]YY]MMDDhhmm[.SS]
+  local stamp
+  stamp=$(date -r "$target_epoch" +%Y%m%d%H%M.%S 2>/dev/null || true)
+  if [[ -n "$stamp" ]]; then
+    touch -t "$stamp" "$path"
+  else
+    echo "ERROR: cannot backdate $path" >&2
+    return 1
+  fi
+}
+
+# Run the check-active-session helper and capture exit code + stderr.
+run_check() {
+  local target="$1"
+  local stderr_file
+  stderr_file=$(mktemp)
+  local exit_code=0
+  "$CHECK_SCRIPT" "$target" 2>"$stderr_file" || exit_code=$?
+  CHECK_STDERR=$(cat "$stderr_file")
+  rm -f "$stderr_file"
+  CHECK_EXIT=$exit_code
+}
+
+# ───────────────────────────────────────────────────────────────────────────
+# Preconditions
+# ───────────────────────────────────────────────────────────────────────────
+if [[ ! -x "$CHECK_SCRIPT" ]]; then
+  echo "ERROR: check script not executable: $CHECK_SCRIPT" >&2
+  exit 1
+fi
+
+if [[ ! -x "$INSTALL_SCRIPT" ]]; then
+  echo "ERROR: install script not executable: $INSTALL_SCRIPT" >&2
+  exit 1
+fi
+
+# ───────────────────────────────────────────────────────────────────────────
+# Test 1: No .loom/ at all → silent, exit 0 (first-time install)
+# ───────────────────────────────────────────────────────────────────────────
+echo "Test 1: missing .loom/ directory exits 0 silently"
+TARGET=$(mktemp -d "/tmp/loom-active-session-test.XXXXXX")
+run_check "$TARGET"
+assert_eq "0" "$CHECK_EXIT" "no .loom/ → exit 0"
+assert_eq "" "$CHECK_STDERR" "no .loom/ → silent stderr"
+cleanup_target
+
+# ───────────────────────────────────────────────────────────────────────────
+# Test 2: empty .loom/ → silent, exit 0 (happy path)
+# ───────────────────────────────────────────────────────────────────────────
+echo "Test 2: empty .loom/ directory exits 0 silently"
+new_target
+run_check "$TARGET"
+assert_eq "0" "$CHECK_EXIT" "empty .loom/ → exit 0"
+assert_eq "" "$CHECK_STDERR" "empty .loom/ → silent stderr"
+cleanup_target
+
+# ───────────────────────────────────────────────────────────────────────────
+# Test 3: Indicator 1 positive — live PID file
+# ───────────────────────────────────────────────────────────────────────────
+echo "Test 3: live daemon PID file fires indicator 1"
+new_target
+# $$ is this shell's PID — guaranteed alive
+echo "$$" > "$TARGET/.loom/daemon-loop.pid"
+run_check "$TARGET"
+assert_eq "1" "$CHECK_EXIT" "live PID → exit 1"
+assert_contains "$CHECK_STDERR" "Daemon PID file present" "live PID → indicator 1 message"
+assert_contains "$CHECK_STDERR" "PID $$ alive" "live PID → exact PID reported"
+cleanup_target
+
+# ───────────────────────────────────────────────────────────────────────────
+# Test 4: Indicator 1 negative — stale PID file
+# ───────────────────────────────────────────────────────────────────────────
+echo "Test 4: stale PID file does NOT fire indicator 1"
+new_target
+# 2^22 = 4194304: very unlikely to exist; macOS PIDs max out lower than this
+echo "4194303" > "$TARGET/.loom/daemon-loop.pid"
+# Verify the PID really is dead before asserting
+if kill -0 4194303 2>/dev/null || ps -p 4194303 >/dev/null 2>&1; then
+  echo "  SKIP: PID 4194303 unexpectedly exists on this host; cannot test stale PID negative"
+else
+  run_check "$TARGET"
+  assert_eq "0" "$CHECK_EXIT" "stale PID → exit 0"
+  assert_not_contains "$CHECK_STDERR" "Daemon PID file present" "stale PID → no indicator 1"
+fi
+cleanup_target
+
+# ───────────────────────────────────────────────────────────────────────────
+# Test 5: Indicator 1 negative — non-numeric PID content
+# ───────────────────────────────────────────────────────────────────────────
+echo "Test 5: garbage PID file content does NOT fire indicator 1"
+new_target
+echo "not-a-pid" > "$TARGET/.loom/daemon-loop.pid"
+run_check "$TARGET"
+assert_eq "0" "$CHECK_EXIT" "garbage PID → exit 0"
+cleanup_target
+
+# ───────────────────────────────────────────────────────────────────────────
+# Test 6: Indicator 2 positive — running=true + fresh mtime
+# ───────────────────────────────────────────────────────────────────────────
+echo "Test 6: running=true + fresh state fires indicator 2"
+new_target
+cat > "$TARGET/.loom/daemon-state.json" <<'JSON'
+{
+  "running": true,
+  "iteration": 42
+}
+JSON
+run_check "$TARGET"
+assert_eq "1" "$CHECK_EXIT" "fresh running=true state → exit 1"
+assert_contains "$CHECK_STDERR" "Active daemon state" "fresh running=true → indicator 2 message"
+cleanup_target
+
+# ───────────────────────────────────────────────────────────────────────────
+# Test 7: Indicator 2 negative — running=true but stale mtime
+# ───────────────────────────────────────────────────────────────────────────
+echo "Test 7: running=true but stale mtime does NOT fire indicator 2"
+new_target
+cat > "$TARGET/.loom/daemon-state.json" <<'JSON'
+{
+  "running": true,
+  "iteration": 42
+}
+JSON
+# Backdate to 1 hour ago (well beyond 5 minutes)
+backdate "$TARGET/.loom/daemon-state.json" 3600
+run_check "$TARGET"
+assert_eq "0" "$CHECK_EXIT" "stale running=true → exit 0"
+assert_not_contains "$CHECK_STDERR" "Active daemon state" "stale running=true → no indicator 2"
+cleanup_target
+
+# ───────────────────────────────────────────────────────────────────────────
+# Test 8: Indicator 2 negative — running=false + fresh mtime
+# ───────────────────────────────────────────────────────────────────────────
+echo "Test 8: running=false + fresh state does NOT fire indicator 2"
+new_target
+cat > "$TARGET/.loom/daemon-state.json" <<'JSON'
+{
+  "running": false,
+  "iteration": 42
+}
+JSON
+run_check "$TARGET"
+assert_eq "0" "$CHECK_EXIT" "running=false fresh → exit 0"
+assert_not_contains "$CHECK_STDERR" "Active daemon state" "running=false → no indicator 2"
+cleanup_target
+
+# ───────────────────────────────────────────────────────────────────────────
+# Test 9: Indicator 3 positive — fresh issue worktree dir
+# ───────────────────────────────────────────────────────────────────────────
+echo "Test 9: fresh issue worktree fires indicator 3"
+new_target
+mkdir -p "$TARGET/.loom/worktrees/issue-42"
+run_check "$TARGET"
+assert_eq "1" "$CHECK_EXIT" "fresh worktree → exit 1"
+assert_contains "$CHECK_STDERR" "In-flight builder worktrees" "fresh worktree → indicator 3 message"
+assert_contains "$CHECK_STDERR" "issue-42" "fresh worktree → name reported"
+cleanup_target
+
+# ───────────────────────────────────────────────────────────────────────────
+# Test 10: Indicator 3 negative — stale worktree
+# ───────────────────────────────────────────────────────────────────────────
+echo "Test 10: stale issue worktree does NOT fire indicator 3"
+new_target
+mkdir -p "$TARGET/.loom/worktrees/issue-99"
+backdate "$TARGET/.loom/worktrees/issue-99" 3600
+run_check "$TARGET"
+assert_eq "0" "$CHECK_EXIT" "stale worktree → exit 0"
+assert_not_contains "$CHECK_STDERR" "In-flight builder worktrees" "stale worktree → no indicator 3"
+cleanup_target
+
+# ───────────────────────────────────────────────────────────────────────────
+# Test 11: Indicator 3 negative — worktrees/ directory empty
+# ───────────────────────────────────────────────────────────────────────────
+echo "Test 11: empty worktrees/ directory does NOT fire indicator 3"
+new_target
+mkdir -p "$TARGET/.loom/worktrees"
+run_check "$TARGET"
+assert_eq "0" "$CHECK_EXIT" "empty worktrees/ → exit 0"
+cleanup_target
+
+# ───────────────────────────────────────────────────────────────────────────
+# Test 12: Indicator 3 negative — non-matching subdirectory (e.g. terminal-1)
+# ───────────────────────────────────────────────────────────────────────────
+echo "Test 12: non-issue worktree (terminal-1) does NOT fire indicator 3"
+new_target
+mkdir -p "$TARGET/.loom/worktrees/terminal-1"
+run_check "$TARGET"
+assert_eq "0" "$CHECK_EXIT" "terminal-1 worktree → exit 0"
+cleanup_target
+
+# ───────────────────────────────────────────────────────────────────────────
+# Test 13: Multi-indicator — all three positive, all three reported
+# ───────────────────────────────────────────────────────────────────────────
+echo "Test 13: all three indicators fire and are all reported"
+new_target
+echo "$$" > "$TARGET/.loom/daemon-loop.pid"
+cat > "$TARGET/.loom/daemon-state.json" <<'JSON'
+{
+  "running": true,
+  "iteration": 7
+}
+JSON
+mkdir -p "$TARGET/.loom/worktrees/issue-42"
+mkdir -p "$TARGET/.loom/worktrees/issue-43"
+run_check "$TARGET"
+assert_eq "1" "$CHECK_EXIT" "all 3 → exit 1"
+assert_contains "$CHECK_STDERR" "Daemon PID file present" "multi → indicator 1 reported"
+assert_contains "$CHECK_STDERR" "Active daemon state" "multi → indicator 2 reported"
+assert_contains "$CHECK_STDERR" "In-flight builder worktrees" "multi → indicator 3 reported"
+assert_contains "$CHECK_STDERR" "Reason:" "multi → trailing reason present"
+cleanup_target
+
+# ───────────────────────────────────────────────────────────────────────────
+# Test 14: install-loom.sh --help documents --allow-active-session
+# ───────────────────────────────────────────────────────────────────────────
+echo "Test 14: install-loom.sh --help documents the new flag"
+set +e
+HELP_OUTPUT=$("$INSTALL_SCRIPT" --help 2>&1)
+HELP_EXIT=$?
+set -e
+assert_eq "0" "$HELP_EXIT" "install-loom.sh --help → exit 0"
+assert_contains "$HELP_OUTPUT" "--allow-active-session" "--help mentions --allow-active-session"
+assert_contains "$HELP_OUTPUT" "does NOT bypass active-session" \
+  "--help notes that --force does NOT bypass the guard"
+
+# ───────────────────────────────────────────────────────────────────────────
+# Test 15: install-loom.sh --allow-active-session is parsed without error
+# ───────────────────────────────────────────────────────────────────────────
+# We exercise the argument parser without performing a full install. The
+# easiest hermetic way to do this is to pass --help alongside --allow-active-session:
+# the parser must accept the flag before the help branch runs.
+echo "Test 15: install-loom.sh accepts --allow-active-session in argv"
+set +e
+FLAG_OUTPUT=$("$INSTALL_SCRIPT" --allow-active-session --help 2>&1)
+FLAG_EXIT=$?
+set -e
+assert_eq "0" "$FLAG_EXIT" "install-loom.sh --allow-active-session --help → exit 0"
+assert_contains "$FLAG_OUTPUT" "Usage:" "flag combo prints usage (parser accepted flag)"
+
+# ───────────────────────────────────────────────────────────────────────────
+# Test 16: usage error — no target path
+# ───────────────────────────────────────────────────────────────────────────
+echo "Test 16: check-active-session.sh with no args → exit 2"
+set +e
+USAGE_OUTPUT=$("$CHECK_SCRIPT" 2>&1)
+USAGE_EXIT=$?
+set -e
+assert_eq "2" "$USAGE_EXIT" "no args → exit 2"
+assert_contains "$USAGE_OUTPUT" "Usage:" "no args → usage line emitted"
+
+# ───────────────────────────────────────────────────────────────────────────
+# Test 17: usage error — nonexistent target path
+# ───────────────────────────────────────────────────────────────────────────
+echo "Test 17: check-active-session.sh with nonexistent target → exit 2"
+set +e
+NX_OUTPUT=$("$CHECK_SCRIPT" "/this/path/does/not/exist/xyzzy-$RANDOM" 2>&1)
+NX_EXIT=$?
+set -e
+assert_eq "2" "$NX_EXIT" "nonexistent target → exit 2"
+assert_contains "$NX_OUTPUT" "does not exist" "nonexistent target → diagnostic message"
+
+# ───────────────────────────────────────────────────────────────────────────
+# Summary
+# ───────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Tests run: $TESTS_RUN, Passed: $TESTS_PASSED, Failed: $TESTS_FAILED"
+
+if (( TESTS_FAILED > 0 )); then
+  exit 1
+fi
+exit 0

--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -38,6 +38,7 @@ set -euo pipefail
 NON_INTERACTIVE=false
 FORCE_OVERWRITE=false
 CLEAN_FIRST=false
+ALLOW_ACTIVE_SESSION=false
 DOGFOOD_MODE=""  # "" (auto-detect), "true" (forced), "false" (forced off)
 ALLOW_NON_MAIN_SOURCE=false
 ALLOW_STALE_TARGET=false
@@ -55,6 +56,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --clean)
       CLEAN_FIRST=true
+      shift
+      ;;
+    --allow-active-session)
+      ALLOW_ACTIVE_SESSION=true
       shift
       ;;
     --dogfood)
@@ -79,7 +84,12 @@ while [[ $# -gt 0 ]]; do
       echo "Options:"
       echo "  -y, --yes                  Non-interactive mode"
       echo "  -f, --force                Force overwrite existing files and enable auto-merge"
+      echo "                             (does NOT bypass active-session detection)"
       echo "  --clean                    Run uninstall first, then fresh install (combines both operations)"
+      echo "  --allow-active-session     Proceed even if a live Loom session is detected in"
+      echo "                             the target (daemon running, recent state file, or"
+      echo "                             active issue worktrees). Required to override the"
+      echo "                             pre-flight active-session guard."
       echo "  --dogfood                  Force dogfood mode: symlink .claude/agents -> ../defaults/.claude/agents"
       echo "                             (auto-detected when installing into the Loom source repo itself)"
       echo "  --no-dogfood               Disable dogfood mode even when installing into the Loom source repo"
@@ -414,6 +424,43 @@ if [[ -n "$MAIN_WORKTREE" ]] && [[ "$TARGET_PATH" != "$MAIN_WORKTREE" ]]; then
   warning "Target path is inside a worktree: $TARGET_PATH"
   info "Resolving to main repository root: $MAIN_WORKTREE"
   TARGET_PATH="$MAIN_WORKTREE"
+fi
+
+# ============================================================================
+# PRE-FLIGHT: Active Loom session detection (issue #3331)
+# ============================================================================
+# Refuse to install on top of a live Loom session unless the operator passes
+# --allow-active-session. This guards against installing while a daemon is
+# running or builders are actively in-flight (state corruption, lost work).
+#
+# Indicators (any one triggers detection):
+#   1. .loom/daemon-loop.pid exists AND PID is alive (kill -0 / ps -p check)
+#   2. .loom/daemon-state.json has "running": true AND was updated within the
+#      last 5 minutes
+#   3. Any .loom/worktrees/issue-N directory with mtime activity in the last
+#      5 minutes (in-flight builder)
+#
+# --force does NOT imply --allow-active-session by design: --force is for
+# overwriting files, not for racing with live processes. The operator must
+# opt in to both independently.
+ACTIVE_SESSION_CHECK="$LOOM_ROOT/scripts/install/check-active-session.sh"
+if [[ -x "$ACTIVE_SESSION_CHECK" ]]; then
+  if ! "$ACTIVE_SESSION_CHECK" "$TARGET_PATH"; then
+    if [[ "$ALLOW_ACTIVE_SESSION" == "true" ]]; then
+      warning "Continuing despite active session (--allow-active-session was passed)"
+      echo ""
+    else
+      echo "" >&2
+      error "Refusing to install: an active Loom session was detected in the target.
+
+To proceed:
+  • Stop the running daemon:   cd '$TARGET_PATH' && ./.loom/scripts/daemon.sh stop
+  • Wait for in-flight builders to finish, OR
+  • Pass --allow-active-session to override this guard (use with caution).
+
+Note: --force does NOT bypass this check; --allow-active-session must be set explicitly."
+    fi
+  fi
 fi
 
 # Dogfood mode detection (issue #3311):

--- a/scripts/install/check-active-session.sh
+++ b/scripts/install/check-active-session.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# check-active-session.sh — Detect an active Loom session in a target repository
+#
+# Usage:
+#   check-active-session.sh <target-path>
+#
+# Exit codes:
+#   0 — No active session detected (or target has no .loom/ directory)
+#   1 — Active session detected (one or more indicators fired)
+#   2 — Invalid usage (missing or unreadable target)
+#
+# Indicators (any one triggers detection):
+#   1. Live daemon: .loom/daemon-loop.pid exists AND kill -0 <pid> succeeds.
+#      kill -0 returns EPERM on cross-user PIDs — we treat that as live (fail
+#      closed). Stale PID files alone are not a hit.
+#   2. Recent active state: .loom/daemon-state.json has "running": true AND
+#      file mtime is within the last 5 minutes (300 seconds).
+#   3. In-flight builders: any .loom/worktrees/issue-N directory with mtime
+#      activity within the last 5 minutes.
+#
+# When any indicator fires, each is reported on its own line on stderr, then a
+# trailing reason summary line. The script is silent on the happy path.
+#
+# POSIX/macOS notes:
+#   - We use POSIX stat invocations with both BSD (-f) and GNU (-c) syntaxes
+#     and a portable arithmetic comparison against `date +%s`. We do not rely
+#     on `find -mmin`, which behaves identically on macOS and Linux but is
+#     awkward to use with single-file lookups.
+#   - jq is preferred for reading daemon-state.json; we degrade to a grep
+#     fallback when jq is unavailable.
+
+set -euo pipefail
+
+TARGET_PATH="${1:-}"
+
+if [[ -z "$TARGET_PATH" ]]; then
+  echo "Usage: $0 <target-path>" >&2
+  exit 2
+fi
+
+if [[ ! -d "$TARGET_PATH" ]]; then
+  echo "Error: target path does not exist or is not a directory: $TARGET_PATH" >&2
+  exit 2
+fi
+
+LOOM_DIR="$TARGET_PATH/.loom"
+THRESHOLD_SECONDS=300
+
+# Short-circuit when there is no .loom/ at all (first-time install).
+if [[ ! -d "$LOOM_DIR" ]]; then
+  exit 0
+fi
+
+# Portable mtime-in-epoch-seconds reader. Echoes the mtime on stdout, or
+# nothing (and a non-zero exit) when the file doesn't exist.
+_file_mtime_epoch() {
+  local path="$1"
+  if [[ ! -e "$path" ]]; then
+    return 1
+  fi
+  # BSD stat (macOS)
+  if stat -f '%m' "$path" 2>/dev/null; then
+    return 0
+  fi
+  # GNU stat (Linux)
+  if stat -c '%Y' "$path" 2>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
+# Returns 0 if the file mtime is within THRESHOLD_SECONDS of now.
+_file_is_recent() {
+  local path="$1"
+  local mtime now
+  mtime=$(_file_mtime_epoch "$path" 2>/dev/null) || return 1
+  now=$(date +%s)
+  local age=$((now - mtime))
+  if (( age < 0 )); then
+    # Clock skew — treat as recent (fail closed).
+    return 0
+  fi
+  if (( age <= THRESHOLD_SECONDS )); then
+    return 0
+  fi
+  return 1
+}
+
+# Indicator accumulator. We print one line per fired indicator so the operator
+# can see exactly what tripped the check without re-running anything.
+INDICATORS=()
+DETECTED=0
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Indicator 1: Live daemon (daemon-loop.pid + alive PID)
+# ─────────────────────────────────────────────────────────────────────────────
+PIDFILE="$LOOM_DIR/daemon-loop.pid"
+if [[ -f "$PIDFILE" ]]; then
+  PID_CONTENT=""
+  # Read PID file safely (avoid hangs on weird content).
+  PID_CONTENT=$(head -c 64 "$PIDFILE" 2>/dev/null | tr -d '[:space:]' || true)
+  if [[ "$PID_CONTENT" =~ ^[0-9]+$ ]]; then
+    # kill -0 returns:
+    #   0  → process exists and we may signal it
+    #   1+ → either no process or EPERM (cross-user PID)
+    # We can't distinguish EPERM from ESRCH in pure bash. Use `ps -p` to break
+    # the tie: if the process exists in the process table we treat it as live.
+    if kill -0 "$PID_CONTENT" 2>/dev/null; then
+      INDICATORS+=("Daemon PID file present: .loom/daemon-loop.pid (PID $PID_CONTENT alive)")
+      DETECTED=1
+    elif ps -p "$PID_CONTENT" >/dev/null 2>&1; then
+      # Cross-user PID — fail closed.
+      INDICATORS+=("Daemon PID file present: .loom/daemon-loop.pid (PID $PID_CONTENT alive, different user)")
+      DETECTED=1
+    fi
+  fi
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Indicator 2: Recently-active daemon state file with running=true
+# ─────────────────────────────────────────────────────────────────────────────
+STATE_FILE="$LOOM_DIR/daemon-state.json"
+if [[ -f "$STATE_FILE" ]]; then
+  RUNNING=""
+  if command -v jq >/dev/null 2>&1; then
+    RUNNING=$(jq -r '.running // empty' "$STATE_FILE" 2>/dev/null || true)
+  else
+    # Grep fallback — match "running": true (allow whitespace, ignore commas).
+    if grep -Eq '"running"[[:space:]]*:[[:space:]]*true' "$STATE_FILE" 2>/dev/null; then
+      RUNNING="true"
+    fi
+  fi
+
+  if [[ "$RUNNING" == "true" ]] && _file_is_recent "$STATE_FILE"; then
+    INDICATORS+=("Active daemon state: .loom/daemon-state.json has running=true and was updated within the last 5 minutes")
+    DETECTED=1
+  fi
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Indicator 3: In-flight issue worktrees (.loom/worktrees/issue-N) with recent activity
+# ─────────────────────────────────────────────────────────────────────────────
+WORKTREES_DIR="$LOOM_DIR/worktrees"
+if [[ -d "$WORKTREES_DIR" ]]; then
+  ACTIVE_WORKTREE_COUNT=0
+  ACTIVE_WORKTREE_NAMES=()
+  # Iterate only directories matching issue-N.
+  # Using a glob is portable; null when no matches.
+  shopt -s nullglob
+  for wt in "$WORKTREES_DIR"/issue-*; do
+    if [[ -d "$wt" ]]; then
+      if _file_is_recent "$wt"; then
+        ACTIVE_WORKTREE_COUNT=$((ACTIVE_WORKTREE_COUNT + 1))
+        ACTIVE_WORKTREE_NAMES+=("$(basename "$wt")")
+      fi
+    fi
+  done
+  shopt -u nullglob
+
+  if (( ACTIVE_WORKTREE_COUNT > 0 )); then
+    # Cap the list in the message to avoid wall-of-text for large pools.
+    if (( ACTIVE_WORKTREE_COUNT <= 5 )); then
+      INDICATORS+=("In-flight builder worktrees ($ACTIVE_WORKTREE_COUNT): ${ACTIVE_WORKTREE_NAMES[*]}")
+    else
+      FIRST_FIVE="${ACTIVE_WORKTREE_NAMES[*]:0:5}"
+      INDICATORS+=("In-flight builder worktrees ($ACTIVE_WORKTREE_COUNT): $FIRST_FIVE …")
+    fi
+    DETECTED=1
+  fi
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Output
+# ─────────────────────────────────────────────────────────────────────────────
+if (( DETECTED == 1 )); then
+  {
+    echo "Active Loom session detected in target: $TARGET_PATH"
+    for line in "${INDICATORS[@]}"; do
+      echo "  - $line"
+    done
+    echo "Reason: installing into a live system risks state corruption (concurrent worktree mutations, daemon races, lost work)."
+  } >&2
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Adds a pre-flight guard to `scripts/install-loom.sh` that refuses to install into a target when an active Loom session is detected — preventing state corruption from daemon races, lost worktree mutations, and stomping on in-flight builders. The new `--allow-active-session` flag is the explicit opt-in override; `--force` does **not** bypass this guard.

The detection logic lives in a new factored helper `scripts/install/check-active-session.sh` (exit 0 = no session, exit 1 = detected, exit 2 = usage), invoked from the installer immediately after worktree-root resolution and before any mutation (including `--clean`).

## Changes

- **New helper** `scripts/install/check-active-session.sh` — silent on happy path, prints each fired indicator individually plus a reason summary when any indicator trips.
- **Three indicators** (any triggers detection):
  1. `.loom/daemon-loop.pid` exists AND PID is alive (`kill -0`, with `ps -p` fallback so cross-user EPERM is treated as live — fail closed).
  2. `.loom/daemon-state.json` has `"running": true` AND was modified within the last 5 minutes (jq preferred, grep fallback).
  3. Any `.loom/worktrees/issue-N` directory with mtime activity within the last 5 minutes (in-flight builder).
- **Installer integration** (`scripts/install-loom.sh`):
  - New `--allow-active-session` flag in the argument parser.
  - Helper invoked after worktree-root resolution (line 329-334 area) and **before** `--clean` runs, the dogfood block, dependency check, or any other mutation.
  - On detection without the flag: actionable error listing remediation steps and an explicit note that `--force` does NOT bypass this guard.
  - With the flag: prints the indicator list as audit trail and continues.
  - `--help` updated to document the new flag and the `--force` semantics.
- **New test** `defaults/scripts/tests/test-install-active-session.sh` — 37 assertions covering each indicator (positive + negative), multi-indicator output, garbage / non-numeric PID content, non-matching subdirectories (e.g., `terminal-1`), usage errors, and the install-loom.sh argument-parser surface for the new flag.

Portability: uses `stat -f` (BSD/macOS) with `-c` (GNU) fallback for mtime, `touch -d @epoch` with `touch -t` fallback for backdating in tests. No reliance on `find -mmin` for single-file lookups.

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|---|---|---|
| New helper `scripts/install/check-active-session.sh` | ✅ | File created, executable, exit codes 0/1/2 |
| Indicator 1 — alive daemon PID | ✅ | Test 3 (positive PID `\$\$`), Test 4 (stale negative), Test 5 (garbage negative) |
| Indicator 2 — `running:true` + recent mtime | ✅ | Test 6 (positive), Test 7 (stale negative), Test 8 (running=false negative) |
| Indicator 3 — recent issue worktree | ✅ | Test 9 (positive), Test 10 (stale negative), Test 11/12 (empty/terminal-* negative) |
| Each indicator printed individually | ✅ | Test 13 — all three fire and all reported, plus reason summary |
| Helper sourced from installer after worktree-root resolution | ✅ | `scripts/install-loom.sh` line ~336, invokes `\$LOOM_ROOT/scripts/install/check-active-session.sh` |
| `--allow-active-session` flag added | ✅ | Argv parser updated; Test 15 confirms it is accepted |
| `--force` does NOT imply override | ✅ | Code path checks `ALLOW_ACTIVE_SESSION` only; `--help` text explicit; Test 14 |
| `--help` documents new flag | ✅ | Test 14 |
| macOS / POSIX portable | ✅ | Dual `stat` syntax + `touch -d @` / `touch -t` fallback in tests |
| `kill -0` cross-user EPERM = fail closed | ✅ | Helper has explicit `ps -p` fallback branch |
| First-time install (no `.loom/`) | ✅ | Test 1 — silent exit 0 |
| Quiescent state silent | ✅ | Test 2 — silent exit 0 on empty `.loom/` |
| Shellcheck clean (`--severity=warning`) on new files | ✅ | `shellcheck scripts/install/check-active-session.sh defaults/scripts/tests/test-install-active-session.sh` → clean |
| `bash -n` syntax check | ✅ | All three files parse |

## Test Plan

- [x] `bash -n scripts/install-loom.sh scripts/install/check-active-session.sh defaults/scripts/tests/test-install-active-session.sh`
- [x] `bash defaults/scripts/tests/test-install-active-session.sh` — 37/37 passing
- [x] `find defaults/scripts -type f -name "*.sh" -print0 | xargs -0 shellcheck --severity=warning --format=gcc` — clean
- [x] `shellcheck scripts/install/check-active-session.sh` — clean
- [x] Smoke test against a synthetic target with a live PID — fires correctly with exit 1 and indicator message
- [x] `install-loom.sh --help` and `install-loom.sh --allow-active-session --help` both exit 0 and print usage

Closes #3331