### PR TITLE
fix(uninstall): avoid SIGPIPE in Clean Directories step

### DIFF
--- a/scripts/uninstall-loom.sh
+++ b/scripts/uninstall-loom.sh
@@ -1072,7 +1072,9 @@ for dir in "${REMOVE_DIRS[@]}"; do
   dir_path="$WORKTREE_ABS/$dir"
   if [[ -d "$dir_path" ]]; then
     # Check if directory is empty (or only contains .DS_Store)
-    remaining=$(find "$dir_path" -type f -not -name '.DS_Store' 2>/dev/null | head -1)
+    # `-print -quit` (instead of piping to `head -1`) avoids SIGPIPE on `find`,
+    # which under `set -o pipefail` would trip the EXIT trap and abort the script.
+    remaining=$(find "$dir_path" -type f -not -name '.DS_Store' -print -quit 2>/dev/null)
     if [[ -z "$remaining" ]]; then
       rm -rf "$dir_path"
       REMOVED_LIST+=("$dir/ (empty directory)")


### PR DESCRIPTION
## Summary

The uninstaller's Step 7 ("Clean Directories") can abort under `set -o pipefail` because of a `find ... | head -1` pipe that races against SIGPIPE. When this happens during a reinstall (where uninstall runs first), the script leaves the target repo with `.loom/`, `.claude/agents/`, `.claude/commands/` deleted but no reinstall attempted — a broken state that requires manual recovery (e.g., \`git restore .\`).

Repro: any target repo with non-Loom content under `.claude/` (e.g. `settings.local.json`, untracked worktrees) hits this when the loop reaches `.claude` in `REMOVE_DIRS` after the Loom-managed subdirs have already been removed.

Trace from a real failure:
\`\`\`
✓ Removed empty directory: .claude/agents

⚠ Warning: Uninstall failed at step: Clean Directories
✗ Error: Uninstall did not complete. See above for details.
✗ Error: Uninstall failed - aborting reinstall
\`\`\`

## Fix

Replace `find ... 2>/dev/null | head -1` with `find ... -print -quit 2>/dev/null`. `-print -quit` makes `find` exit cleanly after the first match — same semantics, no pipe, no SIGPIPE.

\`\`\`diff
- remaining=\$(find \"\$dir_path\" -type f -not -name '.DS_Store' 2>/dev/null | head -1)
+ remaining=\$(find \"\$dir_path\" -type f -not -name '.DS_Store' -print -quit 2>/dev/null)
\`\`\`

Single occurrence in the codebase (confirmed via grep).

## Test plan
- [x] \`bash -n scripts/uninstall-loom.sh\` (syntax check passes)
- [x] Confirmed isolated repro matches the expected semantics (returns first matching path or empty string)
- [ ] End-to-end: re-run \`install.sh --full\` against a real target with non-Loom \`.claude/\` content

## Context

Originally hit while upgrading a Lean formalization project (lean-genius) from Loom 0.7.1 to 0.8.1. The project has \`.claude/settings.local.json\` and a stray \`.claude/worktrees/\` from prior agent work, both of which trip the bug.