### PR TITLE
docs(builder): warn about downstream build-time perf caps

### DIFF
--- a/defaults/.claude/commands/loom/builder.md
+++ b/defaults/.claude/commands/loom/builder.md
@@ -549,6 +549,20 @@ cargo fmt            # Format code
 
 `cargo check` is fast (seconds) and catches the most common errors. Don't rely solely on `pnpm check:ci` at PR time — by then, a failed build wastes the entire implementation cycle.
 
+### Build-time performance
+
+If your change adds or modifies code called from the project's build pipeline (`pnpm build`, `cargo build`, equivalent), **time it before pushing**. A green local build is not the same as a green deploy: downstream deploy scripts often wrap the build in a `timeout` command, and code that scales with the consumer project's dataset (N items) can silently bust that budget.
+
+**Concrete precedent**: in `rjwalters/lean-genius`, `scripts/deploy/sync-and-deploy.sh` (line 570) wraps the build in `timeout --kill-after=30 20m pnpm build` — a hard 20-minute cap. A PR that spawned one `git log` subprocess per gallery listing (~2435 listings) added several minutes to `pnpm build` and pushed total build time past the cap, killing the deploy mid-`vite` transform. Local `pnpm build` passed (no cap); the regression was invisible until deploy.
+
+Before opening a PR that touches build-time code:
+- Measure actual build time against actual N (not the count quoted in the issue).
+- **Sanity-check magnitude claims in the issue body against repo state.** If the issue says "~300 items" and the repo has 2000+, an N-subprocess design will not fit. Re-derive N from `find`, `git ls-files`, or whatever the build actually iterates over.
+- Leave headroom for growth — if you're at 80% of the cap today, the next contributor's data import will tip you over.
+- If the design is fundamentally N-bound, **profile, batch, or cache** before pushing (e.g., one `git log` invocation for all paths instead of N invocations).
+
+If no downstream cap is documented, ask in the PR description rather than assuming there is none.
+
 ## Guidelines
 
 - **Pick the right work**: Choose issues labeled `loom:issue` (human-approved) that match your capabilities


### PR DESCRIPTION
## Summary

Adds a "Build-time performance" subsection to `builder.md` warning builders about hard time caps imposed by downstream deploy pipelines. Documents a concrete incident from `rjwalters/lean-genius` where a builder unknowingly blew past a 20-minute `pnpm build` cap.

## Changes

- Added a new `### Build-time performance` subsection after the existing "Build Verification During Implementation" section in `defaults/.claude/commands/loom/builder.md` (the canonical builder skill; the in-repo `.claude/commands/loom/builder.md`, `defaults/roles/builder.md`, and `.loom/roles/builder.md` all resolve to this file via symlink, so a single edit propagates everywhere).
- The new subsection covers: timing build-pipeline code before push, the lean-genius `scripts/deploy/sync-and-deploy.sh` 20m cap as concrete precedent, sanity-checking magnitude claims in the issue body against repo state, growth headroom, and the profile/batch/cache escape hatch for fundamentally N-bound designs.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Builders surfacing N-iteration build-time code measure it against actual N and the project's deploy-script cap | Yes | New subsection explicitly instructs both steps with the lean-genius cap as a concrete example. |
| Cited incident is accurate (lean-genius PR #20849, sync-and-deploy.sh line 570, 20m cap, ~2435 listings) | Yes | All numbers transcribed from the issue body verbatim. |
| Sanity-check guidance (issue said "~300", repo had 2000+) is included | Yes | Listed as a bullet under "Before opening a PR that touches build-time code". |
| Concise (2-3 paragraphs at most) | Yes | One opening paragraph, one incident paragraph, one bulleted checklist, one trailing line — fits the surrounding voice. |
| `judge.md` is **not** touched (sibling issue #3344 in wave 2) | Yes | Diff is single-file: `defaults/.claude/commands/loom/builder.md`. |

## Test Plan

- [x] `git diff --stat` shows only the canonical builder.md modified.
- [x] Verified all four resolved paths (`.claude/commands/loom/builder.md`, `defaults/.claude/commands/loom/builder.md`, `defaults/roles/builder.md`, `.loom/roles/builder.md`) contain the new "Build-time performance" header via `grep -c`.
- [x] Subsection reads cleanly in context: ends the "Build Verification" run-out, leads naturally into "## Guidelines".
- [x] No code changes, no test changes — docs-only.

Closes #3343