### PR TITLE
fix(spawn): emit namespaced /loom:<role> form for Claude Code 2.1+

### DIFF
--- a/defaults/.claude/README.md
+++ b/defaults/.claude/README.md
@@ -205,9 +205,11 @@ The agent definition wires the correct system prompt, tool allowlist, and model 
 
 ```python
 # Legacy fallback - role selection happens via the slash command in the prompt.
+# Note: Claude Code 2.1+ requires the namespaced `/loom:<role>` form for
+# subdirectory commands (`.claude/commands/loom/<role>.md`). See issue #3345.
 result = Task(
     description="Builder phase for issue #123",
-    prompt="/builder 123",
+    prompt="/loom:builder 123",
     subagent_type="general-purpose",
     run_in_background=False
 )

--- a/defaults/.loom/bin/loom
+++ b/defaults/.loom/bin/loom
@@ -190,7 +190,7 @@ EXAMPLES:
     ./.loom/bin/loom status                 Show current state
     ./.loom/bin/loom status --json          Machine-readable status
     ./.loom/bin/loom attach shepherd-1      Connect to agent terminal
-    ./.loom/bin/loom send shepherd-1 "/shepherd 123"  Send command to agent
+    ./.loom/bin/loom send shepherd-1 "/loom:shepherd 123"  Send command to agent
     ./.loom/bin/loom stop                   Graceful shutdown
     ./.loom/bin/loom stop --force           Force kill all sessions
     ./.loom/bin/loom stop shepherd-1        Stop single agent

--- a/defaults/config/skill-routes.json
+++ b/defaults/config/skill-routes.json
@@ -1,55 +1,55 @@
 {
   "version": 1,
-  "description": "Default skill routing table for Loom agent suggestions. Routes are evaluated top-to-bottom, first match wins. Place specific patterns before general ones.",
+  "description": "Default skill routing table for Loom agent suggestions. Routes are evaluated top-to-bottom, first match wins. Place specific patterns before general ones. Agent invocations use the namespaced `/loom:<role>` form required by Claude Code 2.1+ (subdirectory commands at `.claude/commands/loom/<role>.md` resolve via `namespace:command` syntax — see issue #3345).",
   "routes": [
     {
       "pattern": "shepherd|orchestrate|lifecycle|end.to.end",
-      "agent": "/shepherd",
+      "agent": "/loom:shepherd",
       "description": "Full issue lifecycle orchestration"
     },
     {
       "pattern": "architect|design|proposal|system design|rfc",
-      "agent": "/architect",
+      "agent": "/loom:architect",
       "description": "System design and architecture"
     },
     {
       "pattern": "review|\\bPR\\b|pull request|code review",
-      "agent": "/judge",
+      "agent": "/loom:judge",
       "description": "Code review"
     },
     {
       "pattern": "fix|bug|broken|changes.requested|merge.conflict",
-      "agent": "/doctor",
+      "agent": "/loom:doctor",
       "description": "Bug fixes and PR feedback"
     },
     {
       "pattern": "simplify|refactor|clean.?up|dead.?code|complexity",
-      "agent": "/hermit",
+      "agent": "/loom:hermit",
       "description": "Simplification opportunities"
     },
     {
       "pattern": "build|implement|feature|develop|code",
-      "agent": "/builder",
+      "agent": "/loom:builder",
       "description": "Implement features and fixes"
     },
     {
       "pattern": "curate|triage|issue|enhance|enrich",
-      "agent": "/curator",
+      "agent": "/loom:curator",
       "description": "Issue enrichment"
     },
     {
       "pattern": "prioriti[zs]e|backlog|roadmap",
-      "agent": "/guide",
+      "agent": "/loom:guide",
       "description": "Backlog triage"
     },
     {
       "pattern": "audit|validate|check.?build",
-      "agent": "/auditor",
+      "agent": "/loom:auditor",
       "description": "Build validation"
     },
     {
       "pattern": "loom|daemon|auto.?build",
-      "agent": "/loom",
+      "agent": "/loom:loom",
       "description": "System daemon orchestration"
     }
   ]

--- a/defaults/scripts/agent-wait-bg.sh
+++ b/defaults/scripts/agent-wait-bg.sh
@@ -440,10 +440,13 @@ check_stuck_at_prompt() {
         return 1  # Can't determine, session may be gone
     fi
 
-    # Check for role slash command visible at the prompt line
-    # Pattern: ❯ followed by a role command like /builder, /judge, /curator, /doctor, /shepherd
+    # Check for role slash command visible at the prompt line.
+    # Pattern: ❯ followed by either:
+    #   - legacy bare form (`/builder`, `/judge`, ...), or
+    #   - namespaced form (`/loom:builder`, `/loom:judge`, ...) required by
+    #     Claude Code 2.1+ — see issue #3345.
     local command_at_prompt=false
-    if echo "$pane_content" | grep -qE '❯[[:space:]]*/?(builder|judge|curator|doctor|shepherd)'; then
+    if echo "$pane_content" | grep -qE '❯[[:space:]]*/?(loom:)?(builder|judge|curator|doctor|shepherd)'; then
         command_at_prompt=true
     fi
 
@@ -1140,11 +1143,14 @@ main() {
                     prompt_stuck_recovery_attempted=true
                     prompt_stuck_recovery_time=$now
 
-                    # Extract the likely role command from the session name for retry
+                    # Extract the likely role command from the session name for retry.
+                    # Uses the namespaced `/loom:<role>` form required by Claude Code 2.1+
+                    # (subdirectory commands at `.claude/commands/loom/<role>.md` are
+                    # resolved via `namespace:command` syntax — see issue #3345).
                     local role_cmd=""
                     if [[ "$name" == builder-issue-* ]]; then
                         local issue_num="${name#builder-issue-}"
-                        role_cmd="/builder ${issue_num}"
+                        role_cmd="/loom:builder ${issue_num}"
                     elif [[ "$name" == judge-* ]] || [[ "$name" == curator-* ]] || [[ "$name" == doctor-* ]]; then
                         # For other roles, we can't easily reconstruct the command
                         # Enter nudge is still attempted

--- a/defaults/scripts/claude-wrapper.sh
+++ b/defaults/scripts/claude-wrapper.sh
@@ -1290,10 +1290,12 @@ run_with_retry() {
         # Run claude with all arguments passed to wrapper
         # Three execution modes for Claude CLI:
         #
-        # 1. Slash command prompt detected (e.g., "/judge 2434"):
+        # 1. Slash command prompt detected (e.g., "/loom:judge 2434"):
         #    Use --print mode for reliable one-shot execution.  Interactive mode
         #    (script -q) can be blocked by onboarding/promotional dialogs that
         #    require user interaction before the prompt is processed. (Issue #2438)
+        #    Note: Claude Code 2.1+ uses `/loom:<role>` for subdirectory commands;
+        #    detection below works for any slash-prefixed argument (see #3345).
         #
         # 2. No prompt, TTY available (autonomous agents):
         #    Use macOS `script` to preserve TTY so Claude CLI sees isatty(stdout) = true.
@@ -1317,7 +1319,7 @@ run_with_retry() {
         if [[ -n "${TMPDIR:-}" ]]; then
             export TMPDIR
         fi
-        # Detect slash command prompt in arguments (e.g., "/judge 2434").
+        # Detect slash command prompt in arguments (e.g., "/loom:judge 2434").
         # On-demand workers spawned by the shepherd receive a slash command
         # as a positional prompt argument.  This flag is used for log-capture
         # heuristics (fallback append when pipe-pane misses output).
@@ -1325,7 +1327,9 @@ run_with_retry() {
         # --print treats "/role" as a skill-definition print (exits with 0s
         # duration, no actual work).  Interactive mode (script -q) is safe
         # because CLAUDE_CONFIG_DIR isolation ensures onboarding is complete.
-        # Regression from #2537, fixed in #2608.
+        # Regression from #2537, fixed in #2608.  Detection matches any
+        # slash-prefixed argument so both bare and namespaced forms work
+        # (see #3345 for the Claude Code 2.1+ namespacing requirement).
         _has_slash_cmd=false
         for _arg in "$@"; do
             case "$_arg" in

--- a/defaults/scripts/cli/loom-help.sh
+++ b/defaults/scripts/cli/loom-help.sh
@@ -93,7 +93,7 @@ ${YELLOW}QUICK START:${NC}
     ./.loom/bin/loom attach shepherd-1
 
     ${GRAY}# Send a command to an agent${NC}
-    ./.loom/bin/loom send shepherd-1 "/shepherd 123"
+    ./.loom/bin/loom send shepherd-1 "/loom:shepherd 123"
 
     ${GRAY}# View logs${NC}
     ./.loom/bin/loom logs shepherd-1
@@ -109,7 +109,7 @@ ${YELLOW}EXAMPLES:${NC}
     ./.loom/bin/loom health                 Run diagnostic health check
     ./.loom/bin/loom health --json          Machine-readable health report
     ./.loom/bin/loom attach shepherd-1      Connect to agent terminal
-    ./.loom/bin/loom send shepherd-1 "/shepherd 123"  Send command to agent
+    ./.loom/bin/loom send shepherd-1 "/loom:shepherd 123"  Send command to agent
     ./.loom/bin/loom stop                   Graceful shutdown
     ./.loom/bin/loom stop --force           Force kill all sessions
     ./.loom/bin/loom stop shepherd-1        Stop single agent

--- a/defaults/scripts/cli/loom-send.sh
+++ b/defaults/scripts/cli/loom-send.sh
@@ -7,10 +7,10 @@
 #   loom send --help                     Show help
 #
 # Examples:
-#   loom send shepherd-1 "/shepherd 123"
-#   loom send shepherd-1 "/shepherd 123 --merge"
-#   loom send terminal-2 "/builder 456"
-#   loom send champion "/champion"
+#   loom send shepherd-1 "/loom:shepherd 123"
+#   loom send shepherd-1 "/loom:shepherd 123 --merge"
+#   loom send terminal-2 "/loom:builder 456"
+#   loom send champion "/loom:champion"
 #
 # Notes:
 #   - Commands are sent with a trailing newline (Enter key)
@@ -83,10 +83,10 @@ ${YELLOW}OPTIONS:${NC}
     --json            Output result as JSON
 
 ${YELLOW}EXAMPLES:${NC}
-    loom send shepherd-1 "/shepherd 123"
-    loom send shepherd-1 "/shepherd 123 --merge"
-    loom send terminal-2 "/builder 456"
-    loom send champion "/champion"
+    loom send shepherd-1 "/loom:shepherd 123"
+    loom send shepherd-1 "/loom:shepherd 123 --merge"
+    loom send terminal-2 "/loom:builder 456"
+    loom send champion "/loom:champion"
 
 ${YELLOW}SESSION NAMING:${NC}
     Loom uses tmux sessions with the naming pattern:

--- a/defaults/scripts/enable-skill-routing.sh
+++ b/defaults/scripts/enable-skill-routing.sh
@@ -78,21 +78,24 @@ if [[ -n "$DEFAULT_CONFIG" ]]; then
     echo "Skill routing enabled (copied default routes from Loom source)"
 else
     # Inline minimal default if Loom source not available
+    # Agent paths use the namespaced `/loom:<role>` form required by Claude Code 2.1+
+    # (subdirectory commands at `.claude/commands/loom/<role>.md` resolve via
+    # `namespace:command` syntax — see issue #3345).
     cat > "$CONFIG_FILE" <<'ROUTES'
 {
   "version": 1,
   "description": "Skill routing table for Loom agent suggestions.",
   "routes": [
-    { "pattern": "shepherd|orchestrate|lifecycle|end.to.end", "agent": "/shepherd", "description": "Full issue lifecycle orchestration" },
-    { "pattern": "architect|design|proposal|system design|rfc", "agent": "/architect", "description": "System design and architecture" },
-    { "pattern": "review|\\bPR\\b|pull request|code review", "agent": "/judge", "description": "Code review" },
-    { "pattern": "fix|bug|broken|changes.requested|merge.conflict", "agent": "/doctor", "description": "Bug fixes and PR feedback" },
-    { "pattern": "simplify|refactor|clean.?up|dead.?code|complexity", "agent": "/hermit", "description": "Simplification opportunities" },
-    { "pattern": "build|implement|feature|develop|code", "agent": "/builder", "description": "Implement features and fixes" },
-    { "pattern": "curate|triage|issue|enhance|enrich", "agent": "/curator", "description": "Issue enrichment" },
-    { "pattern": "prioriti[zs]e|backlog|roadmap", "agent": "/guide", "description": "Backlog triage" },
-    { "pattern": "audit|validate|check.?build", "agent": "/auditor", "description": "Build validation" },
-    { "pattern": "loom|daemon|auto.?build", "agent": "/loom", "description": "System daemon orchestration" }
+    { "pattern": "shepherd|orchestrate|lifecycle|end.to.end", "agent": "/loom:shepherd", "description": "Full issue lifecycle orchestration" },
+    { "pattern": "architect|design|proposal|system design|rfc", "agent": "/loom:architect", "description": "System design and architecture" },
+    { "pattern": "review|\\bPR\\b|pull request|code review", "agent": "/loom:judge", "description": "Code review" },
+    { "pattern": "fix|bug|broken|changes.requested|merge.conflict", "agent": "/loom:doctor", "description": "Bug fixes and PR feedback" },
+    { "pattern": "simplify|refactor|clean.?up|dead.?code|complexity", "agent": "/loom:hermit", "description": "Simplification opportunities" },
+    { "pattern": "build|implement|feature|develop|code", "agent": "/loom:builder", "description": "Implement features and fixes" },
+    { "pattern": "curate|triage|issue|enhance|enrich", "agent": "/loom:curator", "description": "Issue enrichment" },
+    { "pattern": "prioriti[zs]e|backlog|roadmap", "agent": "/loom:guide", "description": "Backlog triage" },
+    { "pattern": "audit|validate|check.?build", "agent": "/loom:auditor", "description": "Build validation" },
+    { "pattern": "loom|daemon|auto.?build", "agent": "/loom:loom", "description": "System daemon orchestration" }
   ]
 }
 ROUTES

--- a/loom-tools/src/loom_tools/agent_monitor.py
+++ b/loom-tools/src/loom_tools/agent_monitor.py
@@ -485,9 +485,14 @@ class AgentMonitor:
         if not pane_content:
             return False
 
-        # Check for role slash command visible at the prompt line
+        # Check for role slash command visible at the prompt line.
+        # Matches both legacy bare form (`/builder`) and namespaced form
+        # (`/loom:builder`) required by Claude Code 2.1+ — see issue #3345.
         command_at_prompt = bool(
-            re.search(r"❯\s*/?(builder|judge|curator|doctor|shepherd)", pane_content)
+            re.search(
+                r"❯\s*/?(loom:)?(builder|judge|curator|doctor|shepherd)",
+                pane_content,
+            )
         )
 
         # Check for processing indicators
@@ -496,11 +501,16 @@ class AgentMonitor:
         return command_at_prompt and not processing
 
     def _extract_role_command(self) -> str:
-        """Extract the likely role command from the session name for retry."""
+        """Extract the likely role command from the session name for retry.
+
+        Returns the namespaced `/loom:<role>` form expected by Claude Code 2.1+,
+        which resolves subdirectory commands (under `.claude/commands/loom/`)
+        using `namespace:command` syntax. See issue #3345.
+        """
         name = self.config.name
         if name.startswith("builder-issue-"):
             issue_num = name[len("builder-issue-"):]
-            return f"/builder {issue_num}"
+            return f"/loom:builder {issue_num}"
         return ""
 
     def _attempt_prompt_stuck_recovery(self, role_cmd: str) -> bool:

--- a/loom-tools/src/loom_tools/agent_spawn.py
+++ b/loom-tools/src/loom_tools/agent_spawn.py
@@ -716,8 +716,13 @@ def spawn_agent(
             "LOOM_WORKTREE_PATH", str(working_dir),
         )
 
-    # Build the role slash command
-    role_cmd = f"/{role}"
+    # Build the role slash command.
+    # Note: role definitions live under `.claude/commands/loom/<role>.md` since
+    # #3176, and Claude Code 2.1+ resolves subdirectory commands using the
+    # `namespace:command` form (e.g., `/loom:builder`).  Emitting the bare
+    # `/<role>` form here would fail with "Unknown command" on Claude Code 2.1+
+    # — see issue #3345.
+    role_cmd = f"/loom:{role}"
     if args:
         role_cmd = f"{role_cmd} {args}"
 

--- a/loom-tools/src/loom_tools/daemon.py
+++ b/loom-tools/src/loom_tools/daemon.py
@@ -1,7 +1,9 @@
 """Loom Daemon Loop - Python implementation for robust continuous operation.
 
 This module implements the daemon loop that orchestrates Loom iterations,
-delegating iteration work to Claude via the /loom iterate command.
+delegating iteration work to Claude via the /loom:loom iterate command.
+(The `/loom:loom` form is required by Claude Code 2.1+ because the role
+file lives at `.claude/commands/loom/loom.md`; see issue #3345.)
 
 Features:
     - Deterministic loop behavior (no LLM interpretation variability)
@@ -380,8 +382,11 @@ class DaemonLoop:
         """Run a single daemon iteration via Claude CLI."""
         start_time = time.time()
 
-        # Build the command
-        cmd_parts = ["/loom", "iterate"]
+        # Build the command.
+        # The daemon role file lives at `.claude/commands/loom/loom.md` since #3176,
+        # so Claude Code 2.1+ resolves it via the namespaced `/loom:loom` form
+        # (subdirectory commands use `namespace:command` syntax — see issue #3345).
+        cmd_parts = ["/loom:loom", "iterate"]
         if self.config.force_mode:
             cmd_parts.append("--force")
         if self.config.debug_mode:

--- a/loom-tools/src/loom_tools/daemon_v2/actions/shepherds.py
+++ b/loom-tools/src/loom_tools/daemon_v2/actions/shepherds.py
@@ -516,7 +516,7 @@ def force_reclaim_stale_shepherds(ctx: DaemonContext) -> int:
                 severity="warning",
                 message=(
                     f"Shepherd for issue #{issue} exhausted retries due to {actual_error_class}. "
-                    f"Fix the underlying issue, then re-run: /shepherd {issue} -m"
+                    f"Fix the underlying issue, then re-run: /loom:shepherd {issue} -m"
                 ),
                 context={
                     "issue": issue,

--- a/loom-tools/src/loom_tools/shepherd/phases/base.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/base.py
@@ -332,8 +332,9 @@ _UI_CHROME_LINE_PATTERNS = [
     re.compile(r"resets\s+\w+\s+\d"),
     # Shell prompt capture: "user@host dir % "
     re.compile(r"^\w+@\w+\s+\S+\s+%\s*$"),
-    # Skill/command echo: "/builder 2055"
-    re.compile(r"^/\w+\s+\d+\s*$"),
+    # Skill/command echo: "/builder 2055" (legacy) or "/loom:builder 2055"
+    # (namespaced form required by Claude Code 2.1+, see issue #3345).
+    re.compile(r"^/[\w:]+\s+\d+\s*$"),
     # Spinner status line: "· Photosynthesizing…"
     re.compile(r"^·\s"),
 ]

--- a/loom-tools/tests/daemon_v2/test_shepherd_stall_recovery.py
+++ b/loom-tools/tests/daemon_v2/test_shepherd_stall_recovery.py
@@ -73,7 +73,8 @@ class TestStallRecoveryWarnings:
         assert w.severity == "warning"
         assert w.acknowledged is False
         assert "42" in w.message
-        assert "/shepherd 42 -m" in w.message
+        # Namespaced form required by Claude Code 2.1+ (see issue #3345).
+        assert "/loom:shepherd 42 -m" in w.message
         assert w.context["issue"] == 42
         assert w.context["shepherd"] == "shepherd-1"
         assert w.context["requires_role"] == "shepherd"
@@ -297,7 +298,8 @@ class TestStallRecoveryWarnings:
         force_reclaim_stale_shepherds(ctx)
 
         assert len(ctx.state.warnings) == 1
-        assert "/shepherd 123 -m" in ctx.state.warnings[0].message
+        # Namespaced form required by Claude Code 2.1+ (see issue #3345).
+        assert "/loom:shepherd 123 -m" in ctx.state.warnings[0].message
 
     def test_warning_has_correct_timestamp(
         self, _mock_session, _mock_kill, _mock_record, _mock_unclaim, _mock_release,

--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -17591,6 +17591,18 @@ class TestStripUiChrome:
         assert "/builder" not in result
         assert "real output" in result
 
+    def test_strips_namespaced_command_echo(self) -> None:
+        """Claude Code 2.1+ echoes commands in `/namespace:command` form.
+
+        Regression for issue #3345: the chrome regex must strip both the
+        bare-form echo (`/builder 2055`) and the namespaced echo
+        (`/loom:builder 2055`).
+        """
+        text = "/loom:builder 2055\nreal output\n"
+        result = _strip_ui_chrome(text)
+        assert "/loom:builder" not in result
+        assert "real output" in result
+
     def test_strips_block_art_lines(self) -> None:
         text = "▐▛███▜▌\n▝▜█████▛▘\nreal output\n"
         result = _strip_ui_chrome(text)

--- a/loom-tools/tests/test_agent_monitor.py
+++ b/loom-tools/tests/test_agent_monitor.py
@@ -187,7 +187,8 @@ class TestAgentMonitor:
             "loom_tools.agent_monitor.find_repo_root", return_value=temp_repo
         ):
             monitor = AgentMonitor(config)
-            assert monitor._extract_role_command() == "/builder 42"
+            # Namespaced form required by Claude Code 2.1+ (see issue #3345).
+            assert monitor._extract_role_command() == "/loom:builder 42"
 
     def test_extract_role_command_other(self, temp_repo: pathlib.Path) -> None:
         config = MonitorConfig(name="judge-123")

--- a/loom-tools/tests/test_daemon.py
+++ b/loom-tools/tests/test_daemon.py
@@ -540,27 +540,31 @@ class TestOrchestrationDelegation:
         """Verify iteration command format matches bash.
 
         Bash (lines 607-613):
-        - ITERATE_CMD="/loom iterate"
+        - ITERATE_CMD="/loom:loom iterate"
         - if [[ -n "$FORCE_FLAG" ]]; then
         -     ITERATE_CMD="$ITERATE_CMD $FORCE_FLAG"
         - fi
         - if [[ -n "$DEBUG_FLAG" ]]; then
         -     ITERATE_CMD="$ITERATE_CMD $DEBUG_FLAG"
         - fi
+
+        Note: the namespaced `/loom:loom` form is required by Claude Code 2.1+
+        (subdirectory commands at `.claude/commands/loom/loom.md` use
+        `namespace:command` syntax — see issue #3345).
         """
         from loom_tools.daemon import DaemonConfig
 
         # Python builds the same command (lines 332-338)
         config = DaemonConfig(force_mode=True, debug_mode=True)
 
-        cmd_parts = ["/loom", "iterate"]
+        cmd_parts = ["/loom:loom", "iterate"]
         if config.force_mode:
             cmd_parts.append("--force")
         if config.debug_mode:
             cmd_parts.append("--debug")
 
         iterate_cmd = " ".join(cmd_parts)
-        assert iterate_cmd == "/loom iterate --force --debug"
+        assert iterate_cmd == "/loom:loom iterate --force --debug"
 
     def test_shepherd_scaling_delegated_to_iterate(self) -> None:
         """Document that shepherd scaling is delegated to /loom iterate.


### PR DESCRIPTION
## Summary

After #3176 moved Loom commands into `.claude/commands/loom/`, Claude Code 2.1+ resolves them via the `namespace:command` syntax (`/loom:builder`, `/loom:shepherd`, etc.). Several spawn and recovery paths were still emitting the bare `/<role>` form, causing "Unknown command" failures on the first iteration of every freshly spawned agent.

Closes #3345

## Spawn-side patches (the three sites the reporter hit)

- `loom-tools/src/loom_tools/agent_spawn.py:720` — primary role-command construction (`role_cmd = f"/loom:{role}"`).
- `loom-tools/src/loom_tools/agent_monitor.py:503` — stuck-prompt recovery.
- `defaults/scripts/agent-wait-bg.sh:1147` — background-recovery dispatch.

Note: the reporter referenced `defaults/.loom/scripts/agent-wait-bg.sh` but the file actually lives at `defaults/scripts/agent-wait-bg.sh`. It is copied to `.loom/scripts/agent-wait-bg.sh` at install time.

## Additional sites patched

The fix is mechanical and atomic — sibling sites were patched in the same commit rather than filed as follow-up issues:

- `loom-tools/src/loom_tools/daemon.py:384` — `/loom iterate` dispatch becomes `/loom:loom iterate` since `loom.md` also lives in the subdirectory (`.claude/commands/loom/loom.md`).
- `loom-tools/src/loom_tools/daemon_v2/actions/shepherds.py:519` — user-facing stall-recovery warning instructs `/loom:shepherd <N> -m` so that operators following the message succeed on Claude Code 2.1+.
- `defaults/config/skill-routes.json` + `defaults/scripts/enable-skill-routing.sh` — the skill router suggestions emit namespaced agent paths, so Loom's own agents and human users following the suggestions hit the correct form.
- `defaults/.loom/bin/loom` + `defaults/scripts/cli/loom-help.sh` + `defaults/scripts/cli/loom-send.sh` + `defaults/.claude/README.md` — user-facing help text and examples.

## Detection-side regex updates

Three regexes were detecting the bare-form `/<role>` and would have missed namespaced echoes. Updated to accept both:

- `loom-tools/src/loom_tools/agent_monitor.py:490` — `_is_stuck_at_prompt` detector.
- `defaults/scripts/agent-wait-bg.sh:446` — `_is_stuck_at_prompt` detector (bash).
- `loom-tools/src/loom_tools/shepherd/phases/base.py:336` — `_strip_ui_chrome` echo-line regex.

## Tests

- Updated assertions in `test_agent_monitor.py`, `test_daemon.py`, `test_shepherd_stall_recovery.py` to expect the namespaced form.
- Added regression test `test_strips_namespaced_command_echo` in `test_phases.py` for the chrome-stripping regex.

## Verification

The verification command from the issue body returns zero matches:

```
$ git grep -nE 'f"/\{role\}"|"/builder \$\{issue_num' loom-tools/ defaults/
(no output)
```

## Test plan

- [x] `pytest loom-tools/tests/test_agent_monitor.py` — 47 passed
- [x] `pytest loom-tools/tests/test_daemon.py` — 44 passed
- [x] `pytest loom-tools/tests/daemon_v2/test_shepherd_stall_recovery.py` — 10 passed
- [x] `pytest loom-tools/tests/shepherd/test_phases.py::TestStripUiChrome` — 18 passed (including new namespaced echo test)
- [x] `pytest loom-tools/tests/test_agent_spawn.py` — 63 passed (1 pre-existing failure unrelated to this fix: `TestValidateRole::test_role_in_claude_commands` still expects the pre-#3176 layout)
- [ ] Smoke test on Claude Code 2.1+: spawn a builder/shepherd via Loom and verify the first iteration runs the role rather than failing with "Unknown command"

🤖 Generated with [Claude Code](https://claude.com/claude-code)