### PR TITLE
docs(judge): block on build-time regressions that eat deploy budget

### DIFF
--- a/defaults/.claude/commands/loom/judge.md
+++ b/defaults/.claude/commands/loom/judge.md
@@ -1092,6 +1092,16 @@ This saves significant time and reduces coordination overhead for issues that ta
 - Are non-obvious decisions explained?
 - Is the changelog updated?
 
+### Performance
+
+**Build-time perf is load-bearing, not advisory.** Downstream deploy scripts often hard-cap `pnpm build` / `cargo build` with `timeout` (e.g., `rjwalters/lean-genius`'s `scripts/deploy/sync-and-deploy.sh` line 570 wraps the build in `timeout --kill-after=30 20m pnpm build` — a 20-minute cap). When a PR adds work to the build pipeline that scales with the project's dataset (N items, N subprocesses, N file reads):
+
+1. **Estimate the added time against actual N**, not the count the issue body quoted. Re-derive N from `find`, `git ls-files`, or whatever the code iterates over — the issue may have undercounted.
+2. **If the regression is a meaningful fraction of the deploy cap, treat it as blocking, not a non-blocking note.** A regression that consumes ~25% of the budget headroom is already a problem; "we have time today" is not a defense when the dataset grows.
+3. **A passing local build is not a passing deploy.** `pnpm build` on the dev box has no cap; the deploy script does. If the PR adds N-bound work and the project has a documented build-time cap, the regression must be measured before approving.
+
+The lesson from `rjwalters/lean-genius` PR #20849: a Judge approved with a non-blocking note ("~2435 git log subprocess spawns adds several minutes to build time") — that framing was wrong. The added time pushed total build past the 20-minute cap, killing the production deploy mid-`vite` transform. A "several minutes added" note in a Judge review can translate directly into a failed deploy. When you spot N-bound build-pipeline code, **measure it or block on it** — do not file it as a follow-up.
+
 ### Test Plan Execution
 
 When a PR includes a "## Test Plan" section in its description, the Judge should extract and execute the automatable steps.


### PR DESCRIPTION
## Summary

Adds a `### Performance` subsection under `## Evaluation Focus Areas` in `judge.md` warning Judges to treat build-time regressions against the deploy cap as **blocking**, not non-blocking notes. Sibling to PR #3351 (merged) which added a `### Build-time performance` subsection to `builder.md`; together they form the builder-side ("measure before pushing") and judge-side ("block on it, don't file a follow-up") of the same lesson.

## Changes

- Added one new subsection (`### Performance`) to `defaults/.claude/commands/loom/judge.md`, between `### Documentation` and `### Test Plan Execution`. The other three resolved paths (`.claude/commands/loom/judge.md`, `defaults/roles/judge.md`, `.loom/roles/judge.md`) all resolve to this same file via the `.claude/commands -> ../defaults/.claude/commands` symlink + the per-`roles/` symlinks, so a single edit propagates everywhere (verified via `grep -c` on all four paths — all return `1`).
- The new subsection:
  - Opens with **"Build-time perf is load-bearing, not advisory"** (verbatim from the issue body).
  - Cites the lean-genius `scripts/deploy/sync-and-deploy.sh` line 570 `timeout --kill-after=30 20m pnpm build` cap as concrete precedent.
  - Gives three numbered checks: (1) re-derive N from repo state, (2) treat ~25%+ of deploy headroom as blocking, (3) a passing local build is not a passing deploy.
  - Closes with the lean-genius PR #20849 incident as the cautionary tale, and the imperative: **"measure it or block on it"** — do not file as follow-up.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Judges check build-time regressions against the deploy cap before deciding blocking vs non-blocking | Yes | New subsection explicitly instructs ` Estimate against actual N` and `If meaningful fraction of cap, treat as blocking`. |
| Builders get a clear signal that build perf is a first-class acceptance criterion | Yes — already covered by sibling PR #3351 | PR #3351 added the builder.md sibling subsection; this PR completes the pair. |
| Cited incident is accurate (lean-genius PR #20849, sync-and-deploy.sh line 570, 20m cap, ~2435 listings) | Yes | All numbers transcribed from the issue body verbatim. |
| Complementary to PR #3351, not duplicative | Yes | Builder.md framing is "time it before pushing"; judge.md framing is "treat it as blocking, not non-blocking" — different decisions for different roles. |
| Concise (2-3 paragraphs at most) | Yes | One header sentence + 3 numbered points + one closing paragraph (lesson) — fits the voice of sibling subsections (`Correctness`, `Design`, `Readability`, `Testing`, `Documentation`). |
| `builder.md` is **not** touched | Yes | Diff is single-file: `defaults/.claude/commands/loom/judge.md`. |

## Test Plan

- [x] `git diff --stat` shows only the canonical judge.md modified (10 insertions).
- [x] Verified all four resolved paths contain "Build-time perf is load-bearing" via `grep -c` (all return 1).
- [x] Subsection reads cleanly in context: slots between `### Documentation` and `### Test Plan Execution`, voice matches surrounding evaluation-criteria subsections.
- [x] No code changes, no test changes — docs-only.

Closes #3344