### PR TITLE
feat(builder): post-build quality gate before opening PR

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 3330
-# Branch: feature/issue-3330
+# Issue: 3347
+# Branch: feature/issue-3347
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/.loom/docs/build-gate.md
+++ b/.loom/docs/build-gate.md
@@ -1,0 +1,121 @@
+# Post-Builder Quality Gate (`buildGate`)
+
+The post-builder quality gate is a deterministic, orchestrator-side check that runs **after the builder agent exits but before any PR is opened**. It short-circuits PR creation when the builder's work obviously isn't shippable, releases the issue claim, and lets the next builder re-attempt the issue.
+
+See issue [#3347](https://github.com/rjwalters/loom/issues/3347) for the original proposal.
+
+## Why a gate?
+
+Builder agents (Claude Code as well as external engines invoked by parallel swarms) occasionally ship PRs that should never have been opened:
+
+- broken builds,
+- commits containing only logfiles / scratch files,
+- no commits at all.
+
+Without a gate, the Judge phase has to catch every one of these post-hoc, which wastes review cycles and pollutes the queue. The gate moves that filter ~30s of CPU instead of a multi-minute Judge cycle, and on parallel-shepherd fleets the savings compound.
+
+## The three checks
+
+The gate runs three checks in order. Any failure short-circuits PR creation:
+
+1. **has-commits** — `git rev-list --count origin/main..HEAD > 0` in the worktree.
+2. **has-real-changes** — at least one changed file matches the configured `realChangeGlobs` (or the default scratch-exclusion list when no globs are configured).
+3. **build-passes** — the configured `buildGate.command` exits with code 0 inside the worktree.
+
+When all three pass the builder phase proceeds normally to PR creation. When any one fails the orchestrator:
+
+- Atomically releases the claim: `loom:building` -> `loom:issue`.
+- Logs an `error` milestone with `reason=build_failed_post_builder` and `check=<failed_check>`.
+- Cleans up the stale worktree.
+- Returns a `FAILED` `PhaseResult` so the shepherd does not progress to Judge.
+
+## Configuration
+
+The gate is **opt-in**. Repos with no `buildGate` block in `.loom/config.json` see zero behavior change — the gate returns immediately.
+
+```json
+{
+  "nextAgentNumber": 1,
+  "terminals": [],
+  "buildGate": {
+    "enabled": true,
+    "command": "cargo build --workspace",
+    "realChangeGlobs": ["*.rs", "*.toml", "Cargo.lock"],
+    "timeoutSeconds": 600
+  }
+}
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `true` when block is present | Set to `false` to disable the gate without removing the block. |
+| `command` | string | _(none)_ | Shell-style command run in the worktree (parsed with `shlex.split`). When omitted, the build check is skipped but the has-commits and has-real-changes checks still run. |
+| `realChangeGlobs` | array of strings | _(default exclusions)_ | Positive globs. A changed file must match at least one to count as "real." When omitted, every changed file counts unless it matches one of the default scratch exclusions: `.loom-*`, `*.log`, `.no-changes-needed`. |
+| `timeoutSeconds` | integer | `600` | Timeout for the `command` run. |
+
+## Examples
+
+### Rust workspace
+
+```json
+{
+  "buildGate": {
+    "command": "cargo build --workspace",
+    "realChangeGlobs": ["*.rs", "*.toml", "Cargo.lock"]
+  }
+}
+```
+
+### Python project with pytest
+
+```json
+{
+  "buildGate": {
+    "command": "python -m pytest -x",
+    "realChangeGlobs": ["*.py", "pyproject.toml"]
+  }
+}
+```
+
+### Node.js project
+
+```json
+{
+  "buildGate": {
+    "command": "pnpm check:ci",
+    "realChangeGlobs": ["*.ts", "*.tsx", "*.js", "package.json"],
+    "timeoutSeconds": 900
+  }
+}
+```
+
+### Disable without removing config
+
+```json
+{
+  "buildGate": {
+    "enabled": false,
+    "command": "cargo build"
+  }
+}
+```
+
+## Failure semantics
+
+A gate failure is **not** the same as a builder failure: the issue is automatically re-queued (`loom:issue`) and a future builder can take a fresh attempt. The `PhaseResult.data` block carries:
+
+```python
+{
+  "post_builder_gate_failed": True,
+  "gate_check": "has_commits" | "has_real_changes" | "build_passes",
+  "gate_detail": "<human-readable failure reason>",
+  "reason": "build_failed_post_builder",
+  "claim_released": True,
+}
+```
+
+These fields are available in shepherd state and milestone logs for postmortem analysis.
+
+## Why orchestrator-side?
+
+The gate intentionally lives in the shepherd's builder phase (`loom_tools/shepherd/phases/builder.py`), not in the builder *role* prompt. The point is deterministic enforcement independent of agent self-discipline: an agent that crashed, was rate-limited, or simply ignored its prompt should still not produce a PR.

--- a/defaults/.claude/commands/loom/builder.md
+++ b/defaults/.claude/commands/loom/builder.md
@@ -59,6 +59,18 @@ This role definition is split across multiple files for maintainability:
 | **builder-complexity.md** | Complexity assessment, issue decomposition, scope management |
 | **builder-pr.md** | PR creation, **acceptance criteria verification**, test output, quality requirements |
 
+## Post-Builder Quality Gate (optional, configured per-repo)
+
+If this repository configures a `buildGate` block in `.loom/config.json`, the shepherd orchestrator runs three deterministic checks **after you exit but before any PR is opened**:
+
+1. At least one commit ahead of `origin/main`.
+2. At least one changed file matches the configured `realChangeGlobs` (or default scratch exclusions).
+3. The configured build command exits 0 in the worktree.
+
+If any check fails the orchestrator releases the claim (`loom:building` -> `loom:issue`) and **no PR is opened**. The next builder retries from scratch.
+
+This is enforced by the orchestrator independent of your prompt — you cannot disable it from inside the agent session. In practice this means: commit real source changes, make sure the build passes before you exit, and don't rely on logfiles or scratch files being treated as "the implementation." See `.loom/docs/build-gate.md` for the full schema.
+
 ## Argument Handling
 
 Check for an argument passed via the slash command:

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -635,6 +635,23 @@ Configuration is stored in `.loom/config.json` (committed to git for team sharin
 
 The size limit can also be bypassed per-PR by adding the `loom:auto-merge-ok` label (applied by Judge or human to signal a large PR is safe to auto-merge). In force mode (`--merge`), the size limit is waived entirely.
 
+**Post-Builder Quality Gate (`buildGate`)**:
+
+An optional deterministic gate runs after the builder agent exits but before PR creation. When any of three checks fails (has-commits, has-real-changes, build-passes), the orchestrator releases the issue claim and no PR is opened. This is opt-in via `.loom/config.json`:
+
+```json
+{
+  "buildGate": {
+    "enabled": true,
+    "command": "cargo build --workspace",
+    "realChangeGlobs": ["*.rs", "*.toml", "Cargo.lock"],
+    "timeoutSeconds": 600
+  }
+}
+```
+
+Repos without a `buildGate` block see zero behavior change. See `.loom/docs/build-gate.md` for the full schema and failure semantics.
+
 ### Daemon Configuration (Layer 2)
 
 The Loom daemon uses these configuration parameters:

--- a/loom-tools/src/loom_tools/shepherd/phases/builder.py
+++ b/loom-tools/src/loom_tools/shepherd/phases/builder.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import fnmatch
 import json
 import logging
 import os
@@ -241,6 +242,20 @@ _BUILD_ARTIFACT_PATTERNS: list[str] = [
     "pnpm-lock.yaml",
     ".venv",
     NO_CHANGES_MARKER,
+]
+
+# Default timeout (seconds) for the post-builder quality gate build command.
+# Overridden by `buildGate.timeoutSeconds` in `.loom/config.json`.
+_BUILD_GATE_DEFAULT_TIMEOUT = 600
+
+# Patterns excluded by default when no `realChangeGlobs` is configured.
+# These are scratch/log artifacts that should never count as "real" changes.
+# A repo can override this list via `buildGate.realChangeGlobs` (positive
+# globs — files must match at least one).
+_BUILD_GATE_DEFAULT_EXCLUSIONS: list[str] = [
+    ".loom-*",
+    "*.log",
+    ".no-changes-needed",
 ]
 
 
@@ -1034,6 +1049,20 @@ class BuilderPhase:
         if escape is not None:
             # Retries exhausted, still escaping
             return escape
+
+        # Post-builder quality gate (issue #3347) — opt-in via
+        # `.loom/config.json` `buildGate` block.  Runs the three deterministic
+        # checks (commits-ahead, real-changes, build-passes) after the builder
+        # exits but BEFORE any PR creation step.  On failure the gate releases
+        # the loom:building claim so another builder can re-attempt the issue.
+        # Skip when validation already shows a PR exists (fast path) — the
+        # builder finished its workflow before this hook could run.
+        if not self.validate(ctx, quiet=True):
+            gate_result = self._run_post_builder_quality_gate(ctx)
+            if gate_result is not None:
+                # Gate failed — claim already released, no PR opened.
+                self._cleanup_stale_worktree(ctx)
+                return gate_result
 
         # Fast path: when the builder already completed its full git workflow
         # (PR with loom:review-requested exists), skip test verification to
@@ -4604,6 +4633,328 @@ class BuilderPhase:
         )
         return False, (
             f"{display_name} failed (exit code {result.returncode})"
+        )
+
+    # ------------------------------------------------------------------
+    # Post-builder quality gate (issue #3347)
+    # ------------------------------------------------------------------
+
+    def _load_build_gate_config(
+        self, ctx: ShepherdContext
+    ) -> dict[str, Any] | None:
+        """Load `.loom/config.json`'s `buildGate` block.
+
+        Returns the buildGate dict when present and ``enabled`` is not False;
+        otherwise ``None`` (gate disabled).  Backward-compatible: repos with
+        no buildGate config see zero behavior change.
+
+        Schema::
+
+            {
+              "buildGate": {
+                "enabled": true,                # default true if block present
+                "command": "cargo build",       # required to run build check
+                "realChangeGlobs": ["*.rs"],    # optional; positive globs
+                "timeoutSeconds": 600           # optional; default 600
+              }
+            }
+        """
+        config_path = ctx.repo_root / ".loom" / "config.json"
+        if not config_path.is_file():
+            return None
+        data = read_json_file(config_path)
+        if not isinstance(data, dict):
+            return None
+        gate = data.get("buildGate")
+        if not isinstance(gate, dict):
+            return None
+        if gate.get("enabled") is False:
+            return None
+        return gate
+
+    def _gate_check_has_commits(self, worktree: Path) -> tuple[bool, str]:
+        """Verify the worktree has at least one commit ahead of origin/main.
+
+        Returns ``(ok, message)``.  ``message`` describes the failure on
+        ``ok=False``.
+        """
+        count = self._count_commits_ahead_of_main(worktree)
+        if count == 0:
+            return False, "no commits ahead of origin/main"
+        return True, f"{count} commit(s) ahead of origin/main"
+
+    def _gate_check_has_real_changes(
+        self,
+        worktree: Path,
+        real_change_globs: list[str] | None,
+    ) -> tuple[bool, str]:
+        """Verify the worktree has at least one "real" source change.
+
+        When ``real_change_globs`` is provided, a file is "real" if its path
+        matches at least one positive glob.  When omitted, every changed file
+        is considered "real" unless it matches one of the default exclusions
+        (``.loom-*``, ``*.log``, etc.).
+
+        Returns ``(ok, message)``.  ``message`` lists the changed-file count
+        on success, or describes the failure on ``ok=False``.
+        """
+        result = subprocess.run(
+            ["git", "-C", str(worktree), "diff", "--name-only", "origin/main..HEAD"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            # Treat git errors as "no changes" rather than swallowing — let
+            # the caller decide.  But if git itself failed, we cannot validate
+            # so fail conservatively.
+            return False, (
+                f"git diff failed (exit {result.returncode}): "
+                f"{(result.stderr or '').strip()[:200]}"
+            )
+
+        changed_files = [
+            line for line in result.stdout.splitlines() if line.strip()
+        ]
+        if not changed_files:
+            return False, "no files changed vs origin/main"
+
+        if real_change_globs:
+            matched = [
+                f for f in changed_files
+                if any(fnmatch.fnmatch(f, g) for g in real_change_globs)
+            ]
+            if not matched:
+                return False, (
+                    f"no real source changes among {len(changed_files)} "
+                    f"changed file(s) (configured globs: "
+                    f"{', '.join(real_change_globs)})"
+                )
+            return True, (
+                f"{len(matched)}/{len(changed_files)} changed file(s) match "
+                f"realChangeGlobs"
+            )
+
+        # No globs configured — apply default exclusions
+        kept = [
+            f for f in changed_files
+            if not any(
+                fnmatch.fnmatch(f, p) or fnmatch.fnmatch(Path(f).name, p)
+                for p in _BUILD_GATE_DEFAULT_EXCLUSIONS
+            )
+        ]
+        if not kept:
+            return False, (
+                f"all {len(changed_files)} changed file(s) match scratch "
+                f"exclusion patterns ({', '.join(_BUILD_GATE_DEFAULT_EXCLUSIONS)})"
+            )
+        return True, f"{len(kept)} real-change file(s) detected"
+
+    def _gate_check_build_passes(
+        self,
+        worktree: Path,
+        command: str,
+        timeout: int,
+    ) -> tuple[bool, str]:
+        """Run the configured build command in the worktree.
+
+        Returns ``(ok, message)``.  On failure, the message includes the
+        exit code and a trailing snippet of stdout/stderr.
+        """
+        try:
+            argv = shlex.split(command)
+        except ValueError as exc:
+            return False, f"could not parse buildGate.command: {exc}"
+        if not argv:
+            return False, "buildGate.command is empty"
+
+        log_info(
+            f"Post-builder quality gate: running '{command}' "
+            f"(timeout={timeout}s)"
+        )
+        try:
+            result = subprocess.run(
+                argv,
+                cwd=str(worktree),
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired:
+            return False, (
+                f"build command '{command}' timed out after {timeout}s"
+            )
+        except (OSError, FileNotFoundError) as exc:
+            return False, (
+                f"could not execute build command '{command}': {exc}"
+            )
+
+        if result.returncode == 0:
+            return True, f"'{command}' passed"
+
+        out_tail = "\n".join(
+            ((result.stdout or "") + (result.stderr or "")).splitlines()[-20:]
+        )
+        return False, (
+            f"'{command}' exited with {result.returncode}\n"
+            f"output tail:\n{out_tail}"
+        )
+
+    def _run_post_builder_quality_gate(
+        self, ctx: ShepherdContext
+    ) -> PhaseResult | None:
+        """Deterministic post-builder quality gate (issue #3347).
+
+        Runs three orchestrator-side checks after the builder agent exits
+        but before any PR is created:
+
+        1. **has-commits**: worktree has at least one commit ahead of
+           ``origin/main``.
+        2. **has-real-changes**: changed files match the configured
+           ``realChangeGlobs`` (or default scratch exclusions).
+        3. **build-passes**: the configured ``buildGate.command`` exits 0.
+
+        On any failure: release the ``loom:building`` claim back to
+        ``loom:issue``, log an ``error`` milestone with
+        ``reason=build_failed_post_builder``, and return a ``FAILED``
+        ``PhaseResult`` so the caller short-circuits before PR creation.
+
+        Returns:
+            ``None`` when the gate is disabled, no worktree exists, or all
+            three checks pass.  A ``FAILED`` ``PhaseResult`` when any check
+            fails (and the claim has been released).
+        """
+        gate = self._load_build_gate_config(ctx)
+        if gate is None:
+            return None  # Gate disabled / unconfigured — no-op
+
+        worktree = ctx.worktree_path
+        if worktree is None or not worktree.is_dir():
+            # Can't run gate without a worktree; skip rather than fail.
+            log_info(
+                "Post-builder quality gate: no worktree present, skipping"
+            )
+            return None
+
+        # Validate config types
+        command = gate.get("command")
+        if command is not None and not isinstance(command, str):
+            log_warning(
+                "buildGate.command must be a string; ignoring quality gate"
+            )
+            return None
+        real_change_globs = gate.get("realChangeGlobs")
+        if real_change_globs is not None and not isinstance(real_change_globs, list):
+            log_warning(
+                "buildGate.realChangeGlobs must be a list; ignoring globs"
+            )
+            real_change_globs = None
+        timeout_value = gate.get("timeoutSeconds", _BUILD_GATE_DEFAULT_TIMEOUT)
+        try:
+            timeout = int(timeout_value)
+        except (TypeError, ValueError):
+            timeout = _BUILD_GATE_DEFAULT_TIMEOUT
+
+        log_info(
+            f"Post-builder quality gate enabled for issue "
+            f"#{ctx.config.issue}; running checks"
+        )
+
+        # 1. has-commits
+        ok, msg = self._gate_check_has_commits(worktree)
+        if not ok:
+            return self._fail_post_builder_gate(
+                ctx, check="has_commits", detail=msg
+            )
+
+        # 2. has-real-changes
+        ok, msg = self._gate_check_has_real_changes(
+            worktree,
+            real_change_globs if isinstance(real_change_globs, list) else None,
+        )
+        if not ok:
+            return self._fail_post_builder_gate(
+                ctx, check="has_real_changes", detail=msg
+            )
+
+        # 3. build-passes (only when a command is configured)
+        if command:
+            ok, msg = self._gate_check_build_passes(
+                worktree, command, timeout
+            )
+            if not ok:
+                return self._fail_post_builder_gate(
+                    ctx, check="build_passes", detail=msg
+                )
+        else:
+            log_info(
+                "Post-builder quality gate: no buildGate.command "
+                "configured, skipping build check"
+            )
+
+        log_success(
+            f"Post-builder quality gate passed for issue #{ctx.config.issue}"
+        )
+        return None
+
+    def _fail_post_builder_gate(
+        self,
+        ctx: ShepherdContext,
+        *,
+        check: str,
+        detail: str,
+    ) -> PhaseResult:
+        """Handle a post-builder gate failure: release claim, return FAILED.
+
+        Releases the ``loom:building`` claim back to ``loom:issue`` so the
+        next builder can re-attempt the issue, logs an ``error`` milestone
+        with ``reason=build_failed_post_builder``, and returns a ``FAILED``
+        ``PhaseResult``.  No PR is opened.
+        """
+        log_warning(
+            f"Post-builder quality gate FAILED for issue #{ctx.config.issue}: "
+            f"check={check} detail={detail}"
+        )
+
+        # Release the claim atomically: loom:building -> loom:issue
+        try:
+            transition_issue_labels(
+                ctx.config.issue,
+                add=["loom:issue"],
+                remove=["loom:building"],
+                repo_root=ctx.repo_root,
+            )
+            ctx.label_cache.invalidate_issue(ctx.config.issue)
+        except Exception as exc:  # pragma: no cover — best-effort cleanup
+            log_warning(
+                f"Failed to release claim for issue #{ctx.config.issue} "
+                f"after gate failure: {exc}"
+            )
+
+        # Milestone for observability
+        ctx.report_milestone(
+            "error",
+            error=(
+                f"post_builder_quality_gate_failed check={check} "
+                f"reason=build_failed_post_builder"
+            ),
+            will_retry=False,
+        )
+
+        return PhaseResult(
+            status=PhaseStatus.FAILED,
+            message=(
+                f"post-builder quality gate failed ({check}): {detail}"
+            ),
+            phase_name="builder",
+            data={
+                "post_builder_gate_failed": True,
+                "gate_check": check,
+                "gate_detail": detail,
+                "reason": "build_failed_post_builder",
+                "claim_released": True,
+            },
         )
 
     def _direct_completion(

--- a/loom-tools/tests/shepherd/test_phases.py
+++ b/loom-tools/tests/shepherd/test_phases.py
@@ -20357,3 +20357,499 @@ class TestRunPhaseWithRetryThinkingStallTimeoutThreading:
         mock_run_worker.assert_called_once()
         call_kwargs = mock_run_worker.call_args[1]
         assert call_kwargs["thinking_stall_timeout"] == 720
+
+
+# ----------------------------------------------------------------------
+# Post-builder quality gate (issue #3347)
+# ----------------------------------------------------------------------
+
+
+def _write_build_gate_config(repo_root: Path, gate: dict | None) -> None:
+    """Helper: write .loom/config.json with optional buildGate block."""
+    loom_dir = repo_root / ".loom"
+    loom_dir.mkdir(parents=True, exist_ok=True)
+    payload: dict = {"nextAgentNumber": 1, "terminals": []}
+    if gate is not None:
+        payload["buildGate"] = gate
+    (loom_dir / "config.json").write_text(json.dumps(payload))
+
+
+class TestLoadBuildGateConfig:
+    """Test _load_build_gate_config reads .loom/config.json correctly."""
+
+    def test_returns_none_when_config_missing(
+        self, mock_context: MagicMock, tmp_path: Path
+    ) -> None:
+        """No config file -> None (gate disabled)."""
+        builder = BuilderPhase()
+        mock_context.repo_root = tmp_path
+        assert builder._load_build_gate_config(mock_context) is None
+
+    def test_returns_none_when_buildgate_missing(
+        self, mock_context: MagicMock, tmp_path: Path
+    ) -> None:
+        """Config without buildGate block -> None."""
+        builder = BuilderPhase()
+        mock_context.repo_root = tmp_path
+        _write_build_gate_config(tmp_path, gate=None)
+        assert builder._load_build_gate_config(mock_context) is None
+
+    def test_returns_none_when_buildgate_disabled(
+        self, mock_context: MagicMock, tmp_path: Path
+    ) -> None:
+        """buildGate.enabled=false -> None (explicitly disabled)."""
+        builder = BuilderPhase()
+        mock_context.repo_root = tmp_path
+        _write_build_gate_config(
+            tmp_path,
+            gate={"enabled": False, "command": "cargo build"},
+        )
+        assert builder._load_build_gate_config(mock_context) is None
+
+    def test_returns_dict_when_enabled(
+        self, mock_context: MagicMock, tmp_path: Path
+    ) -> None:
+        """buildGate present and not disabled -> returns dict."""
+        builder = BuilderPhase()
+        mock_context.repo_root = tmp_path
+        _write_build_gate_config(
+            tmp_path,
+            gate={"command": "cargo build", "realChangeGlobs": ["*.rs"]},
+        )
+        result = builder._load_build_gate_config(mock_context)
+        assert result is not None
+        assert result["command"] == "cargo build"
+        assert result["realChangeGlobs"] == ["*.rs"]
+
+
+class TestGateCheckHasCommits:
+    """Test _gate_check_has_commits."""
+
+    def test_fails_when_zero_commits(self, tmp_path: Path) -> None:
+        builder = BuilderPhase()
+        with patch.object(
+            builder, "_count_commits_ahead_of_main", return_value=0
+        ):
+            ok, msg = builder._gate_check_has_commits(tmp_path)
+        assert ok is False
+        assert "no commits" in msg
+
+    def test_passes_when_one_or_more_commits(self, tmp_path: Path) -> None:
+        builder = BuilderPhase()
+        with patch.object(
+            builder, "_count_commits_ahead_of_main", return_value=3
+        ):
+            ok, msg = builder._gate_check_has_commits(tmp_path)
+        assert ok is True
+        assert "3 commit" in msg
+
+
+class TestGateCheckHasRealChanges:
+    """Test _gate_check_has_real_changes."""
+
+    def test_fails_when_no_files_changed(self, tmp_path: Path) -> None:
+        builder = BuilderPhase()
+        with patch(
+            "loom_tools.shepherd.phases.builder.subprocess.run",
+            return_value=MagicMock(returncode=0, stdout="", stderr=""),
+        ):
+            ok, msg = builder._gate_check_has_real_changes(tmp_path, None)
+        assert ok is False
+        assert "no files changed" in msg
+
+    def test_passes_when_glob_matches(self, tmp_path: Path) -> None:
+        builder = BuilderPhase()
+        with patch(
+            "loom_tools.shepherd.phases.builder.subprocess.run",
+            return_value=MagicMock(
+                returncode=0,
+                stdout="src/foo.rs\nREADME.md\n",
+                stderr="",
+            ),
+        ):
+            ok, msg = builder._gate_check_has_real_changes(tmp_path, ["*.rs"])
+        assert ok is True
+        assert "1/2" in msg
+
+    def test_fails_when_no_glob_matches(self, tmp_path: Path) -> None:
+        builder = BuilderPhase()
+        with patch(
+            "loom_tools.shepherd.phases.builder.subprocess.run",
+            return_value=MagicMock(
+                returncode=0,
+                stdout="logfile.log\nscratch.txt\n",
+                stderr="",
+            ),
+        ):
+            ok, msg = builder._gate_check_has_real_changes(tmp_path, ["*.rs"])
+        assert ok is False
+        assert "no real source changes" in msg
+
+    def test_passes_with_default_exclusions(self, tmp_path: Path) -> None:
+        """When no globs are configured, default exclusions filter scratch."""
+        builder = BuilderPhase()
+        with patch(
+            "loom_tools.shepherd.phases.builder.subprocess.run",
+            return_value=MagicMock(
+                returncode=0,
+                stdout="src/foo.py\n.loom-build.log\n",
+                stderr="",
+            ),
+        ):
+            ok, msg = builder._gate_check_has_real_changes(tmp_path, None)
+        assert ok is True
+        # src/foo.py kept, .loom-build.log excluded
+        assert "1 real-change" in msg
+
+    def test_fails_when_only_scratch_files(self, tmp_path: Path) -> None:
+        """Only scratch files -> gate fails even without configured globs."""
+        builder = BuilderPhase()
+        with patch(
+            "loom_tools.shepherd.phases.builder.subprocess.run",
+            return_value=MagicMock(
+                returncode=0,
+                stdout=".loom-build.log\nscratch.log\n",
+                stderr="",
+            ),
+        ):
+            ok, msg = builder._gate_check_has_real_changes(tmp_path, None)
+        assert ok is False
+        assert "scratch exclusion" in msg
+
+
+class TestGateCheckBuildPasses:
+    """Test _gate_check_build_passes."""
+
+    def test_passes_when_command_exits_zero(self, tmp_path: Path) -> None:
+        builder = BuilderPhase()
+        with patch(
+            "loom_tools.shepherd.phases.builder.subprocess.run",
+            return_value=MagicMock(returncode=0, stdout="", stderr=""),
+        ):
+            ok, msg = builder._gate_check_build_passes(
+                tmp_path, "cargo build", 60
+            )
+        assert ok is True
+        assert "passed" in msg
+
+    def test_fails_when_command_exits_nonzero(self, tmp_path: Path) -> None:
+        builder = BuilderPhase()
+        with patch(
+            "loom_tools.shepherd.phases.builder.subprocess.run",
+            return_value=MagicMock(
+                returncode=1,
+                stdout="error: compilation failed\n",
+                stderr="",
+            ),
+        ):
+            ok, msg = builder._gate_check_build_passes(
+                tmp_path, "cargo build", 60
+            )
+        assert ok is False
+        assert "exited with 1" in msg
+        assert "compilation failed" in msg
+
+    def test_fails_on_timeout(self, tmp_path: Path) -> None:
+        builder = BuilderPhase()
+        with patch(
+            "loom_tools.shepherd.phases.builder.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(
+                cmd="cargo build", timeout=5
+            ),
+        ):
+            ok, msg = builder._gate_check_build_passes(
+                tmp_path, "cargo build", 5
+            )
+        assert ok is False
+        assert "timed out" in msg
+
+    def test_fails_on_empty_command(self, tmp_path: Path) -> None:
+        builder = BuilderPhase()
+        ok, msg = builder._gate_check_build_passes(tmp_path, "", 60)
+        assert ok is False
+        assert "empty" in msg
+
+
+class TestRunPostBuilderQualityGate:
+    """End-to-end tests for _run_post_builder_quality_gate."""
+
+    def test_returns_none_when_gate_disabled(
+        self, mock_context: MagicMock, tmp_path: Path
+    ) -> None:
+        """No buildGate config -> None (gate skipped, builder proceeds to PR)."""
+        builder = BuilderPhase()
+        mock_context.repo_root = tmp_path
+        mock_context.worktree_path = tmp_path / "wt"
+        (tmp_path / "wt").mkdir()
+        assert builder._run_post_builder_quality_gate(mock_context) is None
+
+    def test_returns_none_when_gate_explicitly_disabled(
+        self, mock_context: MagicMock, tmp_path: Path
+    ) -> None:
+        """enabled=false -> None."""
+        builder = BuilderPhase()
+        mock_context.repo_root = tmp_path
+        mock_context.worktree_path = tmp_path / "wt"
+        (tmp_path / "wt").mkdir()
+        _write_build_gate_config(
+            tmp_path,
+            gate={"enabled": False, "command": "cargo build"},
+        )
+        assert builder._run_post_builder_quality_gate(mock_context) is None
+
+    def test_returns_none_when_no_worktree(
+        self, mock_context: MagicMock, tmp_path: Path
+    ) -> None:
+        """No worktree -> None (cannot run gate)."""
+        builder = BuilderPhase()
+        mock_context.repo_root = tmp_path
+        mock_context.worktree_path = None
+        _write_build_gate_config(
+            tmp_path,
+            gate={"command": "cargo build"},
+        )
+        assert builder._run_post_builder_quality_gate(mock_context) is None
+
+    def test_fails_when_no_commits(
+        self, mock_context: MagicMock, tmp_path: Path
+    ) -> None:
+        """has-commits check fails -> release claim, FAILED, no PR."""
+        builder = BuilderPhase()
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        mock_context.repo_root = tmp_path
+        mock_context.worktree_path = worktree
+        _write_build_gate_config(
+            tmp_path,
+            gate={"command": "cargo build", "realChangeGlobs": ["*.rs"]},
+        )
+
+        with (
+            patch.object(builder, "_count_commits_ahead_of_main", return_value=0),
+            patch(
+                "loom_tools.shepherd.phases.builder.transition_issue_labels"
+            ) as mock_trans,
+        ):
+            result = builder._run_post_builder_quality_gate(mock_context)
+
+        assert result is not None
+        assert result.status == PhaseStatus.FAILED
+        assert result.data["gate_check"] == "has_commits"
+        assert result.data["claim_released"] is True
+        assert result.data["reason"] == "build_failed_post_builder"
+        # Claim release: must call transition_issue_labels with
+        # add=loom:issue, remove=loom:building
+        mock_trans.assert_called_once()
+        kwargs = mock_trans.call_args.kwargs
+        assert kwargs["add"] == ["loom:issue"]
+        assert kwargs["remove"] == ["loom:building"]
+
+    def test_fails_when_no_real_changes(
+        self, mock_context: MagicMock, tmp_path: Path
+    ) -> None:
+        """has-real-changes check fails -> release claim, FAILED."""
+        builder = BuilderPhase()
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        mock_context.repo_root = tmp_path
+        mock_context.worktree_path = worktree
+        _write_build_gate_config(
+            tmp_path,
+            gate={"command": "cargo build", "realChangeGlobs": ["*.rs"]},
+        )
+
+        with (
+            patch.object(builder, "_count_commits_ahead_of_main", return_value=2),
+            patch(
+                "loom_tools.shepherd.phases.builder.subprocess.run"
+            ) as mock_run,
+            patch(
+                "loom_tools.shepherd.phases.builder.transition_issue_labels"
+            ) as mock_trans,
+        ):
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="docs/notes.md\nscratch.log\n",
+                stderr="",
+            )
+            result = builder._run_post_builder_quality_gate(mock_context)
+
+        assert result is not None
+        assert result.status == PhaseStatus.FAILED
+        assert result.data["gate_check"] == "has_real_changes"
+        # Build command must NOT have been invoked (we short-circuit on
+        # real-changes failure).
+        for call in mock_run.call_args_list:
+            assert call[0][0][:1] != ["cargo"]
+        mock_trans.assert_called_once()
+
+    def test_fails_when_build_fails(
+        self, mock_context: MagicMock, tmp_path: Path
+    ) -> None:
+        """build-passes check fails -> release claim, FAILED."""
+        builder = BuilderPhase()
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        mock_context.repo_root = tmp_path
+        mock_context.worktree_path = worktree
+        _write_build_gate_config(
+            tmp_path,
+            gate={"command": "cargo build", "realChangeGlobs": ["*.rs"]},
+        )
+
+        with (
+            patch.object(builder, "_count_commits_ahead_of_main", return_value=2),
+            patch.object(
+                builder, "_gate_check_has_real_changes",
+                return_value=(True, "1 real-change file(s) detected"),
+            ),
+            patch.object(
+                builder, "_gate_check_build_passes",
+                return_value=(False, "'cargo build' exited with 1"),
+            ),
+            patch(
+                "loom_tools.shepherd.phases.builder.transition_issue_labels"
+            ) as mock_trans,
+        ):
+            result = builder._run_post_builder_quality_gate(mock_context)
+
+        assert result is not None
+        assert result.status == PhaseStatus.FAILED
+        assert result.data["gate_check"] == "build_passes"
+        mock_trans.assert_called_once()
+
+    def test_passes_all_three_checks(
+        self, mock_context: MagicMock, tmp_path: Path
+    ) -> None:
+        """All checks pass -> None (builder proceeds to PR creation)."""
+        builder = BuilderPhase()
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        mock_context.repo_root = tmp_path
+        mock_context.worktree_path = worktree
+        _write_build_gate_config(
+            tmp_path,
+            gate={"command": "cargo build", "realChangeGlobs": ["*.rs"]},
+        )
+
+        with (
+            patch.object(builder, "_count_commits_ahead_of_main", return_value=2),
+            patch.object(
+                builder, "_gate_check_has_real_changes",
+                return_value=(True, "1/2 changed file(s) match"),
+            ),
+            patch.object(
+                builder, "_gate_check_build_passes",
+                return_value=(True, "'cargo build' passed"),
+            ),
+            patch(
+                "loom_tools.shepherd.phases.builder.transition_issue_labels"
+            ) as mock_trans,
+        ):
+            result = builder._run_post_builder_quality_gate(mock_context)
+
+        assert result is None
+        # Claim must NOT be released on a passing gate
+        mock_trans.assert_not_called()
+
+    def test_skips_build_check_when_no_command(
+        self, mock_context: MagicMock, tmp_path: Path
+    ) -> None:
+        """No buildGate.command -> only commits + real-changes checked."""
+        builder = BuilderPhase()
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        mock_context.repo_root = tmp_path
+        mock_context.worktree_path = worktree
+        _write_build_gate_config(
+            tmp_path,
+            gate={"realChangeGlobs": ["*.py"]},
+        )
+
+        with (
+            patch.object(builder, "_count_commits_ahead_of_main", return_value=1),
+            patch.object(
+                builder, "_gate_check_has_real_changes",
+                return_value=(True, "1/1 changed file(s) match"),
+            ),
+            patch.object(
+                builder, "_gate_check_build_passes"
+            ) as mock_build,
+        ):
+            result = builder._run_post_builder_quality_gate(mock_context)
+
+        assert result is None
+        mock_build.assert_not_called()
+
+
+class TestPostBuilderGateIntegration:
+    """Integration: ensure the gate fires inside BuilderPhase.run().
+
+    Lightweight smoke tests — we don't run the full builder pipeline,
+    we just verify the wiring at the validate/completion handoff.
+    """
+
+    def test_gate_invoked_after_builder_exit(
+        self, mock_context: MagicMock, tmp_path: Path
+    ) -> None:
+        """When the builder exits cleanly and no PR yet exists, the gate runs."""
+        builder = BuilderPhase()
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        mock_context.repo_root = tmp_path
+        mock_context.worktree_path = worktree
+        mock_context.config = ShepherdConfig(issue=42)
+        mock_context.check_shutdown = MagicMock(return_value=False)
+        mock_context.has_issue_label = MagicMock(return_value=True)
+        _write_build_gate_config(
+            tmp_path,
+            gate={"command": "cargo build", "realChangeGlobs": ["*.rs"]},
+        )
+
+        with (
+            # Skip preflight gates
+            patch.object(builder, "should_skip", return_value=(False, "")),
+            patch("loom_tools.shepherd.phases.builder.get_pr_for_issue", return_value=None),
+            patch.object(builder, "_run_quality_validation", return_value=None),
+            patch.object(builder, "_run_reproducibility_check", return_value=None),
+            patch.object(builder, "_is_stale_worktree", return_value=False),
+            patch.object(builder, "_commit_prior_uncommitted_work", return_value=False),
+            patch.object(builder, "_snapshot_main_dirty", return_value=set()),
+            patch.object(builder, "_count_commits_ahead_of_main", return_value=0),
+            patch.object(builder, "_detect_worktree_escape", return_value=None),
+            patch.object(builder, "_is_rate_limited", return_value=False),
+            patch.object(builder, "validate", return_value=False),
+            patch.object(builder, "_cleanup_stale_worktree"),
+            patch.object(
+                builder, "_run_post_builder_quality_gate"
+            ) as mock_gate,
+            patch(
+                "loom_tools.shepherd.phases.builder.run_phase_with_retry",
+                return_value=0,
+            ),
+            patch(
+                "loom_tools.shepherd.phases.builder.transition_issue_labels"
+            ),
+            patch(
+                "loom_tools.shepherd.phases.builder.subprocess.run",
+                return_value=MagicMock(returncode=0, stdout="", stderr=""),
+            ),
+        ):
+            mock_gate.return_value = PhaseResult(
+                status=PhaseStatus.FAILED,
+                message="post-builder quality gate failed (has_commits): no commits",
+                phase_name="builder",
+                data={
+                    "post_builder_gate_failed": True,
+                    "gate_check": "has_commits",
+                    "reason": "build_failed_post_builder",
+                    "claim_released": True,
+                },
+            )
+            result = builder.run(mock_context)
+
+        # Gate must have been invoked, and its FAILED result must propagate
+        mock_gate.assert_called_once()
+        assert result.status == PhaseStatus.FAILED
+        assert result.data["post_builder_gate_failed"] is True
+        assert result.data["reason"] == "build_failed_post_builder"


### PR DESCRIPTION
Closes #3347

## Summary

Adds an opt-in, deterministic, orchestrator-side quality gate that runs after the builder agent exits but **before any PR is created**. When any check fails the gate releases the `loom:building` claim back to `loom:issue` so another builder can re-attempt the issue without polluting the Judge queue.

## The three checks

1. **has-commits** — `git rev-list --count origin/main..HEAD > 0` in the worktree
2. **has-real-changes** — at least one changed file matches the configured `realChangeGlobs` (or the default scratch-exclusion list when no globs are configured)
3. **build-passes** — the configured `buildGate.command` exits with code 0 in the worktree

## Configuration (opt-in)

Repos with no `buildGate` block in `.loom/config.json` see zero behavior change. Schema:

```json
{
  "buildGate": {
    "enabled": true,
    "command": "cargo build --workspace",
    "realChangeGlobs": ["*.rs", "*.toml", "Cargo.lock"],
    "timeoutSeconds": 600
  }
}
```

| Key | Type | Default | Description |
|-----|------|---------|-------------|
| `enabled` | boolean | `true` (when block present) | Set to `false` to disable without removing the block |
| `command` | string | _(none)_ | Build command run in the worktree (parsed with `shlex.split`). Omit to skip the build check |
| `realChangeGlobs` | string[] | _(default exclusions)_ | Positive globs. When omitted, defaults exclude `.loom-*`, `*.log`, `.no-changes-needed` |
| `timeoutSeconds` | integer | `600` | Timeout for the build command |

## On failure

- Atomic label transition: `loom:building` -> `loom:issue` (claim released)
- Milestone: `error` with `reason=build_failed_post_builder` + `check=<failed_check>`
- Stale worktree cleaned up
- `PhaseResult.FAILED` with diagnostic fields (`gate_check`, `gate_detail`, `claim_released`)

## Files changed

- `loom-tools/src/loom_tools/shepherd/phases/builder.py` — gate implementation + integration point right after the worktree-escape retry succeeds (before the validate/completion loop)
- `loom-tools/tests/shepherd/test_phases.py` — 24 new unit tests across 6 classes
- `.loom/docs/build-gate.md` — new doc covering schema, examples, failure semantics
- `defaults/CLAUDE.md` — buildGate config snippet in the Configuration section
- `defaults/.claude/commands/loom/builder.md` — short note that builders should expect the gate

## Why orchestrator-side?

The whole point of the gate is deterministic enforcement *independent of agent self-discipline*. An agent that crashed, was rate-limited, or simply ignored its prompt should still not produce a PR. The gate lives in the shepherd's builder phase, never in the builder role prompt.

## Test plan

- [x] All 24 new gate tests pass
- [x] All 487 existing builder tests pass
- [x] Full loom-tools test suite: 21 pre-existing failures (doctor/agent-spawn tests broken on main), 4534 passed
- [ ] Smoke-test on a real shepherd invocation in a repo with `buildGate` configured
- [ ] Confirm `loom:building` -> `loom:issue` transition fires on simulated build failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)