### PR TITLE
fix(claude-config): expose project commands to per-agent CLAUDE_CONFIG_DIR

### DIFF
--- a/loom-daemon/src/terminal.rs
+++ b/loom-daemon/src/terminal.rs
@@ -42,6 +42,13 @@ mod claude_config {
         "tmp",
     ];
 
+    /// Project-scoped subdirectories of `<repo_root>/.claude/` that must be
+    /// visible inside `CLAUDE_CONFIG_DIR` for Claude Code 2.1+ to resolve
+    /// namespaced slash commands (`/loom:<role>`) and skill routing.
+    ///
+    /// Must match the Python `_PROJECT_CLAUDE_LINKS` list.  See issue #3346.
+    const PROJECT_CLAUDE_LINKS: &[&str] = &["commands", "agents"];
+
     /// Create an isolated `CLAUDE_CONFIG_DIR` for a terminal.
     ///
     /// Creates `.loom/claude-config/{agent_name}/` with symlinks to shared
@@ -243,6 +250,83 @@ mod claude_config {
         }
     }
 
+    /// Refresh symlinks from `CLAUDE_CONFIG_DIR/<name>` to
+    /// `<repo>/.claude/<name>` for each entry in `PROJECT_CLAUDE_LINKS`.
+    ///
+    /// This is what makes the per-agent `CLAUDE_CONFIG_DIR` resolve
+    /// project-defined namespaced slash commands such as `/loom:shepherd`
+    /// (issue #3346).
+    ///
+    /// Behaviour:
+    ///   - Source missing  → skip silently (nothing to link).
+    ///   - Destination missing  → create the symlink.
+    ///   - Destination is a symlink to the correct target  → no-op.
+    ///   - Destination is a symlink to a different path (e.g. moved worktree)
+    ///     → replace it.
+    ///   - Destination is a regular file or directory  → leave alone (warn).
+    fn link_project_claude_dirs(repo_root: &Path, config_dir: &Path) {
+        let project_claude = repo_root.join(".claude");
+        for name in PROJECT_CLAUDE_LINKS {
+            let src = project_claude.join(name);
+            if !src.exists() {
+                // No project-side dir to link — harmless for repos that
+                // haven't installed Loom's command tree.
+                continue;
+            }
+            // Use the canonical absolute path so the link survives `cd`/cwd
+            // changes and is unambiguous when inspected with `ls -l`.
+            let src_abs = match fs::canonicalize(&src) {
+                Ok(p) => p,
+                Err(e) => {
+                    log::debug!(
+                        "Could not canonicalize project link source {}: {e}",
+                        src.display()
+                    );
+                    continue;
+                }
+            };
+
+            let dst = config_dir.join(name);
+            let dst_meta = fs::symlink_metadata(&dst);
+            match dst_meta {
+                Ok(meta) if meta.file_type().is_symlink() => {
+                    // Already a symlink — check whether it points at the
+                    // correct target.  Resolve via canonicalize so we
+                    // compare absolute paths.
+                    if let Ok(cur) = fs::canonicalize(&dst) {
+                        if cur == src_abs {
+                            continue;
+                        }
+                    }
+                    // Wrong target (or unreadable) — refresh.
+                    if let Err(e) = fs::remove_file(&dst) {
+                        log::debug!("Could not unlink stale symlink {}: {e}", dst.display());
+                        continue;
+                    }
+                }
+                Ok(_) => {
+                    // Non-symlink directory or file present — don't destroy
+                    // it.  Warn and skip; commands won't resolve via this
+                    // config dir, but we won't lose user data.
+                    log::warn!(
+                        "Skipping project-claude link for {name}: {} exists and is not a symlink",
+                        dst.display()
+                    );
+                    continue;
+                }
+                Err(_) => {
+                    // Doesn't exist — fall through to create.
+                }
+            }
+
+            if let Err(e) = std::os::unix::fs::symlink(&src_abs, &dst) {
+                log::warn!("Failed to symlink {} -> {}: {e}", dst.display(), src_abs.display());
+            } else {
+                log::debug!("Linked {} -> {}", dst.display(), src_abs.display());
+            }
+        }
+    }
+
     pub fn setup_agent_config_dir(agent_name: &str, repo_root: &Path) -> Option<PathBuf> {
         let config_dir = repo_root
             .join(".loom")
@@ -335,6 +419,14 @@ mod claude_config {
                 log::debug!("Failed to create mutable dir {}: {e}", dir.display());
             }
         }
+
+        // Symlink project's `.claude/commands` and `.claude/agents` into
+        // the per-agent `CLAUDE_CONFIG_DIR` so Claude Code 2.1+ can resolve
+        // namespaced slash commands like `/loom:shepherd`.  Without these
+        // links the config dir is a bare directory and Claude Code falls
+        // back to "Unknown command" even when `.claude/commands/loom/
+        // <role>.md` exists in the project.  See issue #3346.
+        link_project_claude_dirs(repo_root, &config_dir);
 
         // Clone macOS Keychain credentials to the per-config-dir service name.
         clone_keychain_credentials(&config_dir);
@@ -711,6 +803,130 @@ mod claude_config {
                 data.get("enabledPlugins").is_none(),
                 "enabledPlugins must not be present in fallback"
             );
+        }
+
+        #[test]
+        fn test_project_claude_links_constant_includes_commands_and_agents() {
+            // Constant must include the two directories Claude Code 2.1+
+            // consults when resolving namespaced slash commands.
+            // See issue #3346.
+            assert!(PROJECT_CLAUDE_LINKS.contains(&"commands"));
+            assert!(PROJECT_CLAUDE_LINKS.contains(&"agents"));
+        }
+
+        #[test]
+        fn test_setup_links_project_commands_when_present() {
+            // When `<repo>/.claude/commands` exists, the config dir must
+            // contain a symlink to it so `/loom:shepherd` resolves.
+            // See issue #3346.
+            let tmp = tempfile::tempdir().unwrap();
+            let repo_root = tmp.path();
+            fs::create_dir_all(repo_root.join(".loom")).unwrap();
+
+            let project_commands = repo_root.join(".claude").join("commands").join("loom");
+            fs::create_dir_all(&project_commands).unwrap();
+            fs::write(project_commands.join("shepherd.md"), "# shepherd\n").unwrap();
+
+            let config_dir = setup_agent_config_dir("shepherd-1", repo_root).unwrap();
+            let dst = config_dir.join("commands");
+            let meta = fs::symlink_metadata(&dst).unwrap();
+            assert!(meta.file_type().is_symlink(), "config_dir/commands must be a symlink");
+
+            // Canonicalize both sides for a stable comparison
+            // (tempdir paths on macOS go through /private symlinks).
+            let expected = fs::canonicalize(repo_root.join(".claude").join("commands")).unwrap();
+            let actual = fs::canonicalize(&dst).unwrap();
+            assert_eq!(actual, expected);
+
+            // The role file is reachable through the link.
+            assert!(dst.join("loom").join("shepherd.md").is_file());
+        }
+
+        #[test]
+        fn test_setup_skips_project_link_when_dir_missing() {
+            // Repos without `.claude/commands` get no link and no error.
+            let tmp = tempfile::tempdir().unwrap();
+            let repo_root = tmp.path();
+            fs::create_dir_all(repo_root.join(".loom")).unwrap();
+
+            let config_dir = setup_agent_config_dir("shepherd-2", repo_root).unwrap();
+            assert!(!config_dir.join("commands").exists());
+            assert!(!config_dir.join("agents").exists());
+        }
+
+        #[test]
+        fn test_setup_refreshes_stale_project_link() {
+            // If the config dir already has a symlink pointing at the wrong
+            // target, setup must replace it with the correct one.
+            let tmp = tempfile::tempdir().unwrap();
+            let repo_root = tmp.path();
+            fs::create_dir_all(repo_root.join(".loom")).unwrap();
+
+            let project_commands = repo_root.join(".claude").join("commands");
+            fs::create_dir_all(&project_commands).unwrap();
+
+            let config_dir = repo_root
+                .join(".loom")
+                .join("claude-config")
+                .join("shepherd-3");
+            fs::create_dir_all(&config_dir).unwrap();
+
+            // Pre-create a wrong-target symlink.
+            let wrong = repo_root.join("wrong-target");
+            fs::create_dir_all(&wrong).unwrap();
+            std::os::unix::fs::symlink(&wrong, config_dir.join("commands")).unwrap();
+
+            let _ = setup_agent_config_dir("shepherd-3", repo_root).unwrap();
+
+            let expected = fs::canonicalize(&project_commands).unwrap();
+            let actual = fs::canonicalize(config_dir.join("commands")).unwrap();
+            assert_eq!(actual, expected);
+        }
+
+        #[test]
+        fn test_setup_preserves_non_symlink_directory() {
+            // If `commands/` is a real directory (operator placed content
+            // there), we must not destroy it.
+            let tmp = tempfile::tempdir().unwrap();
+            let repo_root = tmp.path();
+            fs::create_dir_all(repo_root.join(".loom")).unwrap();
+
+            let project_commands = repo_root.join(".claude").join("commands");
+            fs::create_dir_all(&project_commands).unwrap();
+
+            let config_dir = repo_root
+                .join(".loom")
+                .join("claude-config")
+                .join("shepherd-4");
+            fs::create_dir_all(&config_dir).unwrap();
+            let plain = config_dir.join("commands");
+            fs::create_dir_all(&plain).unwrap();
+            fs::write(plain.join("user-file.md"), "user content\n").unwrap();
+
+            let _ = setup_agent_config_dir("shepherd-4", repo_root).unwrap();
+
+            // Still a plain dir; user content preserved.
+            let meta = fs::symlink_metadata(&plain).unwrap();
+            assert!(!meta.file_type().is_symlink());
+            assert!(plain.join("user-file.md").is_file());
+        }
+
+        #[test]
+        fn test_link_helper_idempotent() {
+            // Calling setup twice with the same project paths is a no-op.
+            let tmp = tempfile::tempdir().unwrap();
+            let repo_root = tmp.path();
+            fs::create_dir_all(repo_root.join(".loom")).unwrap();
+
+            let project_commands = repo_root.join(".claude").join("commands");
+            fs::create_dir_all(&project_commands).unwrap();
+
+            let first = setup_agent_config_dir("shepherd-5", repo_root).unwrap();
+            let first_target = fs::canonicalize(first.join("commands")).unwrap();
+
+            let _ = setup_agent_config_dir("shepherd-5", repo_root).unwrap();
+            let second_target = fs::canonicalize(first.join("commands")).unwrap();
+            assert_eq!(first_target, second_target);
         }
     }
 }

--- a/loom-tools/src/loom_tools/common/claude_config.py
+++ b/loom-tools/src/loom_tools/common/claude_config.py
@@ -53,6 +53,23 @@ _MUTABLE_DIRS = [
     "tmp",
 ]
 
+# Project-scoped subdirectories of <repo_root>/.claude/ that must be visible
+# inside ``CLAUDE_CONFIG_DIR`` for Claude Code 2.1+ to resolve namespaced
+# slash commands (e.g., ``/loom:shepherd``) and skill routing.
+#
+# Without these symlinks, the per-agent ``CLAUDE_CONFIG_DIR`` is a bare
+# directory with no view of the project's slash-command tree, so Claude Code
+# replies "Unknown command: /loom:<role>" even when ``.claude/commands/loom/
+# <role>.md`` exists in the project.  See issue #3346.
+#
+# The symlinks point at the project's ``.claude/<name>`` directory (absolute
+# path).  They are refreshed on every ``setup_agent_config_dir`` call so a
+# moved/recreated worktree always sees the current project paths.
+_PROJECT_CLAUDE_LINKS = [
+    "commands",
+    "agents",
+]
+
 
 def _copy_settings_without_plugins(src: Path, dst: Path) -> bool:
     """Copy settings.json stripping the ``enabledPlugins`` key.
@@ -339,7 +356,88 @@ def validate_agent_config_dir(agent_name: str, repo_root: Path) -> bool:
             )
             return False
 
+    # Project-claude links must be present and resolvable whenever the
+    # project itself has the corresponding directory.  A missing or dangling
+    # symlink here causes Claude Code 2.1+ to fail with "Unknown command:
+    # /loom:<role>".  See issue #3346.
+    project_claude = repo_root / ".claude"
+    for name in _PROJECT_CLAUDE_LINKS:
+        src = project_claude / name
+        if not src.exists():
+            # Project doesn't have this dir — nothing to link, nothing to
+            # validate.  Don't fail validation just because the workspace
+            # hasn't installed Loom's command tree.
+            continue
+        dst = config_dir / name
+        if not dst.exists():
+            log.debug(
+                "Agent config dir validation failed for %s: project link "
+                "'%s' is missing or dangling",
+                agent_name,
+                name,
+            )
+            return False
+
     return True
+
+
+def _link_project_claude_dirs(repo_root: Path, config_dir: Path) -> None:
+    """Refresh symlinks from ``CLAUDE_CONFIG_DIR/<name>`` to ``<repo>/.claude/<name>``.
+
+    For each entry in ``_PROJECT_CLAUDE_LINKS`` (e.g. ``commands``, ``agents``),
+    ensure ``config_dir/<name>`` is a symlink pointing at the absolute project
+    path ``repo_root/.claude/<name>``.  This is what makes the per-agent
+    ``CLAUDE_CONFIG_DIR`` resolve project-defined namespaced slash commands
+    such as ``/loom:shepherd`` (issue #3346).
+
+    Behaviour:
+      - Source missing  → skip silently (nothing to link).
+      - Destination missing  → create the symlink.
+      - Destination is a symlink to the correct target  → no-op.
+      - Destination is a symlink to a *different* path (e.g. moved worktree)
+        → replace it (unlink + symlink).
+      - Destination is a regular file or directory  → leave it alone and
+        warn; we do not destroy user-created content.
+    """
+    project_claude = repo_root / ".claude"
+    for name in _PROJECT_CLAUDE_LINKS:
+        src = (project_claude / name).resolve() if (project_claude / name).exists() else None
+        if src is None:
+            # No project-side dir to link — skip.  This is the case for repos
+            # that haven't installed Loom's command tree, and is harmless.
+            continue
+
+        dst = config_dir / name
+        if dst.is_symlink():
+            try:
+                current_target = dst.resolve()
+            except OSError:
+                current_target = None
+            if current_target == src:
+                continue
+            # Wrong target (e.g., moved worktree) — refresh.
+            try:
+                dst.unlink()
+            except OSError as exc:
+                log.debug("Could not unlink stale symlink %s: %s", dst, exc)
+                continue
+        elif dst.exists():
+            # Non-symlink directory or file is present.  Don't destroy it —
+            # the agent (or operator) may have intentionally placed content
+            # there.  Warn once and move on; project commands won't resolve
+            # via this config dir, but we won't lose user data.
+            log.warning(
+                "Skipping project-claude link for %s: %s exists and is not a symlink",
+                name,
+                dst,
+            )
+            continue
+
+        try:
+            dst.symlink_to(src)
+            log.debug("Linked %s -> %s", dst, src)
+        except OSError as exc:
+            log.warning("Failed to symlink %s -> %s: %s", dst, src, exc)
 
 
 def setup_agent_config_dir(agent_name: str, repo_root: Path) -> Path:
@@ -414,6 +512,19 @@ def setup_agent_config_dir(agent_name: str, repo_root: Path) -> Path:
     # Create mutable directories
     for dirname in _MUTABLE_DIRS:
         (config_dir / dirname).mkdir(exist_ok=True)
+
+    # Symlink project's ``.claude/commands`` and ``.claude/agents`` into the
+    # per-agent ``CLAUDE_CONFIG_DIR`` so Claude Code 2.1+ can resolve
+    # namespaced slash commands like ``/loom:shepherd``.  Without this, the
+    # config dir is a bare directory and Claude Code falls back to "Unknown
+    # command" even when ``.claude/commands/loom/<role>.md`` exists in the
+    # project.  See issue #3346.
+    #
+    # We refresh these links every call (idempotent): if the link exists and
+    # already points at the correct project path, do nothing; if it exists
+    # but points elsewhere (e.g., a moved worktree), replace it; if missing,
+    # create it.
+    _link_project_claude_dirs(repo_root, config_dir)
 
     # Clone macOS Keychain credentials to the per-config-dir service name.
     # Claude Code v2.1.42+ hashes the config dir path into the keychain

--- a/loom-tools/tests/test_claude_config.py
+++ b/loom-tools/tests/test_claude_config.py
@@ -9,10 +9,12 @@ from unittest import mock
 import pytest
 
 from loom_tools.common.claude_config import (
+    _PROJECT_CLAUDE_LINKS,
     _SHARED_CONFIG_FILES,
     _copy_settings_without_plugins,
     _ensure_onboarding_complete,
     _keychain_service_name,
+    _link_project_claude_dirs,
     _resolve_state_file,
     cleanup_agent_config_dir,
     cleanup_all_agent_config_dirs,
@@ -220,6 +222,163 @@ class TestSetupAgentConfigDir:
         assert data["theme"] == "dark"
         assert data["effortCalloutDismissed"] is True
         assert data["opusProMigrationComplete"] is True
+
+
+class TestLinkProjectClaudeDirs:
+    """Tests for the project-claude link logic (issue #3346).
+
+    The per-agent ``CLAUDE_CONFIG_DIR`` must expose the project's
+    ``.claude/commands`` and ``.claude/agents`` so Claude Code 2.1+ can
+    resolve namespaced slash commands like ``/loom:shepherd``.
+    """
+
+    def test_constant_has_commands_and_agents(self) -> None:
+        """The link list must include the directories Claude Code consults."""
+        assert "commands" in _PROJECT_CLAUDE_LINKS
+        assert "agents" in _PROJECT_CLAUDE_LINKS
+
+    def test_creates_symlinks_to_project_claude_dirs(
+        self, mock_repo: pathlib.Path
+    ) -> None:
+        """When ``<repo>/.claude/commands`` exists it must be linked into the
+        agent config dir as a symlink pointing at the project path."""
+        project_commands = mock_repo / ".claude" / "commands" / "loom"
+        project_commands.mkdir(parents=True)
+        (project_commands / "shepherd.md").write_text("# shepherd role\n")
+
+        config_dir = setup_agent_config_dir("shepherd-1", mock_repo)
+        dst = config_dir / "commands"
+        assert dst.is_symlink(), "commands/ should be a symlink"
+        assert dst.resolve() == (mock_repo / ".claude" / "commands").resolve()
+        # The role file is reachable via the link.
+        assert (dst / "loom" / "shepherd.md").is_file()
+
+    def test_skips_when_project_dir_missing(self, mock_repo: pathlib.Path) -> None:
+        """Repos without ``.claude/commands`` get no link and no error."""
+        config_dir = setup_agent_config_dir("shepherd-1", mock_repo)
+        assert not (config_dir / "commands").exists()
+        assert not (config_dir / "agents").exists()
+
+    def test_links_agents_dir_when_present(self, mock_repo: pathlib.Path) -> None:
+        agents = mock_repo / ".claude" / "agents"
+        agents.mkdir(parents=True)
+        (agents / "loom-shepherd.md").write_text("# agent\n")
+
+        config_dir = setup_agent_config_dir("shepherd-1", mock_repo)
+        dst = config_dir / "agents"
+        assert dst.is_symlink()
+        assert dst.resolve() == agents.resolve()
+
+    def test_idempotent_keeps_existing_correct_link(
+        self, mock_repo: pathlib.Path
+    ) -> None:
+        """Re-running setup with the same project paths must be a no-op."""
+        commands = mock_repo / ".claude" / "commands"
+        commands.mkdir(parents=True)
+
+        setup_agent_config_dir("shepherd-1", mock_repo)
+        config_dir = mock_repo / ".loom" / "claude-config" / "shepherd-1"
+        first_target = (config_dir / "commands").resolve()
+
+        # Run again; link must still be present and point at the same place.
+        setup_agent_config_dir("shepherd-1", mock_repo)
+        assert (config_dir / "commands").is_symlink()
+        assert (config_dir / "commands").resolve() == first_target
+
+    def test_refreshes_stale_symlink(self, mock_repo: pathlib.Path) -> None:
+        """If the link points at a stale path, setup must replace it."""
+        commands = mock_repo / ".claude" / "commands"
+        commands.mkdir(parents=True)
+
+        config_dir = mock_repo / ".loom" / "claude-config" / "shepherd-1"
+        config_dir.mkdir(parents=True)
+
+        # Pre-create a wrong-target symlink.
+        wrong = mock_repo / "wrong-target"
+        wrong.mkdir()
+        (config_dir / "commands").symlink_to(wrong)
+
+        setup_agent_config_dir("shepherd-1", mock_repo)
+
+        assert (config_dir / "commands").is_symlink()
+        assert (config_dir / "commands").resolve() == commands.resolve()
+
+    def test_preserves_existing_non_symlink_directory(
+        self, mock_repo: pathlib.Path
+    ) -> None:
+        """If ``commands/`` already exists as a real directory (e.g. operator
+        placed content there), we must not destroy it."""
+        commands = mock_repo / ".claude" / "commands"
+        commands.mkdir(parents=True)
+
+        config_dir = mock_repo / ".loom" / "claude-config" / "shepherd-1"
+        config_dir.mkdir(parents=True)
+        # Operator-placed plain directory.
+        plain = config_dir / "commands"
+        plain.mkdir()
+        (plain / "user-file.md").write_text("# user content\n")
+
+        setup_agent_config_dir("shepherd-1", mock_repo)
+
+        # Plain dir preserved; not converted to symlink.
+        assert plain.is_dir() and not plain.is_symlink()
+        assert (plain / "user-file.md").is_file()
+
+    def test_link_helper_called_directly(self, mock_repo: pathlib.Path) -> None:
+        """The helper itself must be safe to call without a full setup."""
+        commands = mock_repo / ".claude" / "commands"
+        commands.mkdir(parents=True)
+
+        config_dir = mock_repo / "agent-conf"
+        config_dir.mkdir()
+
+        _link_project_claude_dirs(mock_repo, config_dir)
+
+        assert (config_dir / "commands").is_symlink()
+        assert (config_dir / "commands").resolve() == commands.resolve()
+
+    def test_validate_fails_when_project_link_missing(
+        self, mock_repo: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If the project has ``.claude/commands`` but the agent's link is
+        missing, validation must fail so the dir gets rebuilt."""
+        commands = mock_repo / ".claude" / "commands"
+        commands.mkdir(parents=True)
+
+        fake_home = mock_repo / "fake-home"
+        fake_home.mkdir()
+        (fake_home / ".claude").mkdir()
+        (fake_home / ".claude.json").write_text(
+            '{"hasCompletedOnboarding":true,"theme":"dark",'
+            '"effortCalloutDismissed":true,"opusProMigrationComplete":true}'
+        )
+        monkeypatch.setattr(pathlib.Path, "home", staticmethod(lambda: fake_home))
+
+        setup_agent_config_dir("shepherd-1", mock_repo)
+        config_dir = mock_repo / ".loom" / "claude-config" / "shepherd-1"
+        assert validate_agent_config_dir("shepherd-1", mock_repo) is True
+
+        # Break the link.
+        (config_dir / "commands").unlink()
+        assert validate_agent_config_dir("shepherd-1", mock_repo) is False
+
+    def test_validate_tolerates_missing_project_dir(
+        self, mock_repo: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If the project itself doesn't have ``.claude/commands``, the link
+        is not required and validation must still pass."""
+        # No project .claude/commands created.
+        fake_home = mock_repo / "fake-home"
+        fake_home.mkdir()
+        (fake_home / ".claude").mkdir()
+        (fake_home / ".claude.json").write_text(
+            '{"hasCompletedOnboarding":true,"theme":"dark",'
+            '"effortCalloutDismissed":true,"opusProMigrationComplete":true}'
+        )
+        monkeypatch.setattr(pathlib.Path, "home", staticmethod(lambda: fake_home))
+
+        setup_agent_config_dir("shepherd-1", mock_repo)
+        assert validate_agent_config_dir("shepherd-1", mock_repo) is True
 
 
 class TestEnsureOnboardingComplete:


### PR DESCRIPTION
## Summary

- Symlink ``<repo>/.claude/commands`` and ``<repo>/.claude/agents`` into every per-agent ``CLAUDE_CONFIG_DIR`` so Claude Code 2.1+ can resolve ``/loom:shepherd`` (and every other namespaced slash command) from the agent's isolated config dir.
- Mirrored in both the Python (``loom_tools.common.claude_config``) and Rust (``loom-daemon/src/terminal.rs``) implementations so the daemon and the spawn CLI behave identically.
- Validation now requires the project link when the project has the corresponding directory, so any pre-existing bare config dirs get rebuilt on next spawn.

This is the gating bug for fully-autonomous ``/loom`` mode on Claude Code 2.1+: every prior change (#3176 moved commands under ``.claude/commands/loom/``, #3345 made spawn emit ``/loom:<role>``) was correct, but the bare ``.loom/claude-config/shepherd-N/`` had no view of those commands and Claude Code replied ``Unknown command: /loom:shepherd``.

Closes #3346

## Test plan

- [x] ``pytest loom-tools/tests/test_claude_config.py`` — 60/60 pass (10 new tests for create / skip / refresh / preserve / idempotent / validate)
- [x] ``cargo test -p loom-daemon --lib`` — 287/287 pass (6 new Rust tests covering the same cases)
- [x] Traced the post-fix layout of ``.loom/claude-config/shepherd-1/`` — ``commands`` and ``agents`` are symlinks resolving to the project paths and ``commands/loom/shepherd.md`` is reachable.
- [x] Verified the fix doesn't regress the existing support-role setup (judge, champion, doctor, guide, auditor all use the same code path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)