### PR TITLE
feat(skills): warn at startup when host can sleep during /sweep, /loom, /shepherd

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 3347
-# Branch: feature/issue-3347
+# Issue: 3350
+# Branch: feature/issue-3350
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,15 @@ Curator → Builder → Judge → Doctor (if needed) → Merge
 2. Enhance issue with technical details
 3. Mark curated: `gh issue edit 42 --add-label "loom:curated"`
 
+### Overnight / long-running orchestration: keep the host awake (#3350)
+
+`/sweep`, `/loom`, and `/shepherd` automatically run `./.loom/scripts/check-host-sleep.sh` at startup and warn when the host can sleep. This is **advisory only** — Loom never blocks on it. Heed the warning before walking away from a long run.
+
+- **macOS:** user-idle sleep assertions (Amphetamine, `caffeinate -dimsu`, etc.) do **not** reliably defeat Maintenance Sleep on Apple Silicon. Use `sudo pmset -c sleep 0` for AC-only sleep disable, or flip your sleep manager's "allow system sleep when display is off" toggle to OFF.
+- **systemd Linux:** wrap the session in `systemd-inhibit --what=idle:sleep --who=loom --why=loom -- <cmd>`.
+
+Manual invocation: `./.loom/scripts/check-host-sleep.sh` (or `--quiet` for stderr-only output).
+
 ## Configuration
 
 ### Workspace Configuration

--- a/defaults/.claude/commands/loom/loom.md
+++ b/defaults/.claude/commands/loom/loom.md
@@ -28,8 +28,25 @@ ELSE IF arguments contain "stop":
     -> EXIT
 
 ELSE:
-    -> Proceed to Daemon Detection below
+    -> Proceed to Host Sleep Readiness, then Daemon Detection below
 ```
+
+## Host Sleep Readiness (#3350)
+
+`/loom` is intended for **long-running, often overnight** autonomous orchestration. If the host enters sleep / suspend mid-run, in-flight subagent sockets to `api.anthropic.com` are torn down and that work is lost (see #3350 for the incident that motivated this check).
+
+Before doing anything else (other than the help / status / stop early exits handled in Mode Selection above), run the host-sleep readiness check and surface its output to the user:
+
+```bash
+./.loom/scripts/check-host-sleep.sh
+```
+
+This is advisory-only. The script always exits `0` and **must not block** orchestration — proceed regardless of what it prints. It prints a platform-aware warning when the host is configured in a way that allows it to sleep:
+
+- **macOS:** user-idle sleep assertions (e.g. Amphetamine, `caffeinate -dimsu`) do **not** reliably defeat Maintenance Sleep. The reliable defenses are `sudo pmset -c sleep 0` or flipping the sleep manager's "allow system sleep when display is off" toggle to OFF.
+- **systemd Linux:** wrap the session in `systemd-inhibit --what=idle:sleep --who=loom --why=loom -- <cmd>`, which IS reliable.
+
+If the user is starting an overnight run, they should heed the warning before walking away.
 
 ## Daemon Detection
 

--- a/defaults/.claude/commands/loom/shepherd.md
+++ b/defaults/.claude/commands/loom/shepherd.md
@@ -33,6 +33,23 @@ Parse the issue number and any flags from the arguments.
 
 ## Execution
 
+### Step 0: Host Sleep Readiness (#3350)
+
+A shepherd lifecycle (curator → builder → judge → optional doctor → merge) can take 30–60 minutes or more, especially in `--merge` mode with conflict resolution. If the host enters sleep / suspend mid-run, in-flight subagent sockets to `api.anthropic.com` are torn down and that work is lost (see #3350 for the incident that motivated this check).
+
+Before spawning the shepherd, run the host-sleep readiness check and surface its output to the user:
+
+```bash
+./.loom/scripts/check-host-sleep.sh
+```
+
+This is advisory-only. The script always exits `0` and **must not block** the shepherd — proceed regardless of what it prints. It prints a platform-aware warning when the host is configured in a way that allows it to sleep:
+
+- **macOS:** user-idle sleep assertions (e.g. Amphetamine, `caffeinate -dimsu`) do **not** reliably defeat Maintenance Sleep. The reliable defenses are `sudo pmset -c sleep 0` or flipping the sleep manager's "allow system sleep when display is off" toggle to OFF.
+- **systemd Linux:** wrap the session in `systemd-inhibit --what=idle:sleep --who=loom --why=shepherd -- <cmd>`, which IS reliable.
+
+If you are about to walk away from a `--merge` run, heed the warning before doing so.
+
 ### Step 1: Daemon Detection
 
 Check whether the standalone daemon is running:

--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -363,6 +363,23 @@ Stop processing and print the summary when any of these conditions hold:
 
 This skill does **not** implement disk-pressure checks, max-waves caps, or doctor-cycle global limits — those are deferred (see Limitations).
 
+## Host Sleep Readiness (#3350)
+
+Long sweeps run for many minutes — sometimes hours overnight — and the host going to sleep mid-run tears down in-flight subagent sockets to `api.anthropic.com`, killing curator / builder / judge subagents and losing all their work (see #3350 for the incident report).
+
+**Before the first wave**, run the host-sleep readiness check and surface its output to the user:
+
+```bash
+./.loom/scripts/check-host-sleep.sh
+```
+
+This is advisory-only. The script always exits `0` and **must not block** the sweep — proceed regardless of what it prints. It prints a platform-aware warning to stderr when the host is configured in a way that allows it to sleep:
+
+- **macOS:** even with a user-idle sleep assertion (Amphetamine, `caffeinate -dimsu`, etc.), macOS Maintenance Sleep can still fire and tear down sockets. The reliable defenses are `sudo pmset -c sleep 0` or flipping your sleep manager's "allow system sleep when display is off" toggle to OFF.
+- **systemd Linux:** wrap the session in `systemd-inhibit --what=idle:sleep --who=loom --why=sweep -- <cmd>`, which IS reliable.
+
+If the user is running an overnight sweep, they should heed the warning before walking away.
+
 ## Daemon Coexistence
 
 `/sweep` does not require the daemon and does not interact with `.loom/daemon-state.json` for writes. If the daemon is running, `/sweep` and the daemon may both try to claim the same `loom:issue` label.

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -1174,6 +1174,20 @@ cp -r defaults/hooks/example-context/* .loom/context/
 
 ### Common Issues
 
+**Overnight / long-running orchestration: keep the host awake (#3350)**:
+
+`/sweep`, `/loom`, and `/shepherd` automatically run `./.loom/scripts/check-host-sleep.sh` at startup and warn when the host can sleep. This is **advisory only** — Loom never blocks on it. Heed the warning before walking away from a long run.
+
+- **macOS:** user-idle sleep assertions (Amphetamine, `caffeinate -dimsu`, etc.) do **not** reliably defeat Maintenance Sleep on Apple Silicon. Use `sudo pmset -c sleep 0` for AC-only sleep disable, or flip your sleep manager's "allow system sleep when display is off" toggle to OFF. Restore with `sudo pmset -c sleep 1` afterwards.
+- **systemd Linux:** wrap the session in `systemd-inhibit --what=idle:sleep --who=loom --why=loom -- <cmd>`. This is reliable.
+
+If you want to invoke the check manually:
+
+```bash
+./.loom/scripts/check-host-sleep.sh         # full warning (or success line)
+./.loom/scripts/check-host-sleep.sh --quiet # stderr warning only, no stdout line
+```
+
 **Merging PRs from worktrees**:
 
 Use `merge-pr.sh` instead of `gh pr merge` to avoid worktree checkout errors:

--- a/defaults/scripts/check-host-sleep.sh
+++ b/defaults/scripts/check-host-sleep.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# check-host-sleep.sh - Warn when the host may sleep during long-running orchestration.
+#
+# This is a NON-BLOCKING, advisory check. It prints a platform-aware warning
+# to stderr (and a brief one-liner to stdout) when the host is configured in a
+# way that could let it sleep mid-session, killing in-flight subagents (#3350).
+#
+# It is invoked at the start of /sweep, /loom, and /shepherd. It MUST NOT
+# block — even if detection fails, it returns 0 and orchestration proceeds.
+#
+# Usage:
+#   ./.loom/scripts/check-host-sleep.sh         # print warning (or nothing) and exit 0
+#   ./.loom/scripts/check-host-sleep.sh --quiet # suppress the stdout one-liner
+#   ./.loom/scripts/check-host-sleep.sh --help  # show usage
+#
+# Exit codes:
+#   0 - Always. This script is advisory; it never blocks Loom.
+#
+# Background: On 2026-05-28 an overnight /sweep lost two curator subagents at
+# the 33-minute mark when macOS entered Maintenance Sleep. The user had a
+# user-idle sleep assertion held (Amphetamine's PreventUserIdleSystemSleep),
+# but Maintenance Sleep (governed by powerd / DarkWake / Power Nap) is
+# independent of user-idle assertions and tore down the local TCP sockets to
+# api.anthropic.com. See issue #3350.
+#
+# IMPORTANT macOS caveat: `caffeinate -dimsu` does NOT reliably defeat
+# Maintenance Sleep on Apple Silicon. The only truly reliable defenses on
+# macOS are:
+#   - `sudo pmset -c sleep 0` (disable sleep on AC entirely), or
+#   - flip the sleep-manager's "allow system sleep when display is off" toggle
+#     to OFF (Amphetamine, Lungo, etc.).
+# We surface those as the recommended remediation, not `caffeinate`.
+
+set -uo pipefail  # NOTE: no -e — this script must never exit non-zero
+
+# ---------- output helpers ----------
+
+# Colors (only when stderr is a tty)
+if [[ -t 2 ]]; then
+    YELLOW='\033[1;33m'
+    RED='\033[1;31m'
+    GREEN='\033[1;32m'
+    BOLD='\033[1m'
+    NC='\033[0m'
+else
+    YELLOW=''
+    RED=''
+    GREEN=''
+    BOLD=''
+    NC=''
+fi
+
+QUIET=0
+for arg in "$@"; do
+    case "$arg" in
+        --quiet|-q)
+            QUIET=1
+            ;;
+        --help|-h)
+            sed -n '2,32p' "$0" | sed 's/^# //; s/^#//'
+            exit 0
+            ;;
+        *)
+            # Unknown args are ignored — this script must never fail.
+            ;;
+    esac
+done
+
+warn() {
+    # Print a multi-line warning block to stderr. Always returns 0.
+    printf '%b\n' "$*" >&2 || true
+}
+
+info_oneliner() {
+    # Print a single status line to stdout (suppressed by --quiet).
+    if [[ "$QUIET" -eq 0 ]]; then
+        printf '%b\n' "$*" || true
+    fi
+}
+
+# ---------- platform detection ----------
+
+PLATFORM="$(uname -s 2>/dev/null || echo unknown)"
+
+case "$PLATFORM" in
+    Darwin)
+        check_macos() {
+            # Find the AC-power sleep timeout from `pmset -g`. Format is
+            #   sleep                1 (sleep prevented by ...)
+            # The first numeric column is minutes. 0 = sleep disabled.
+            local pmset_out sleep_line sleep_minutes
+            if ! command -v pmset >/dev/null 2>&1; then
+                info_oneliner "${YELLOW}[sleep-check] pmset not found; cannot verify host sleep settings.${NC}"
+                return 0
+            fi
+
+            pmset_out="$(pmset -g 2>/dev/null || true)"
+            if [[ -z "$pmset_out" ]]; then
+                info_oneliner "${YELLOW}[sleep-check] pmset returned no output; skipping check.${NC}"
+                return 0
+            fi
+
+            # Extract the "sleep   <N>" line — leading whitespace, then "sleep".
+            sleep_line="$(printf '%s\n' "$pmset_out" | awk '/^[[:space:]]*sleep[[:space:]]+[0-9]+/ {print; exit}')"
+            if [[ -z "$sleep_line" ]]; then
+                info_oneliner "${YELLOW}[sleep-check] could not parse pmset sleep timeout; skipping.${NC}"
+                return 0
+            fi
+
+            sleep_minutes="$(printf '%s' "$sleep_line" | awk '{print $2}')"
+            if ! [[ "$sleep_minutes" =~ ^[0-9]+$ ]]; then
+                info_oneliner "${YELLOW}[sleep-check] unexpected pmset format; skipping.${NC}"
+                return 0
+            fi
+
+            if [[ "$sleep_minutes" -eq 0 ]]; then
+                info_oneliner "${GREEN}[sleep-check] macOS AC sleep is disabled (pmset sleep=0). Host should stay awake.${NC}"
+                return 0
+            fi
+
+            # AC sleep is non-zero → the host CAN sleep on AC power.
+            warn ""
+            warn "${YELLOW}${BOLD}========================================================================${NC}"
+            warn "${YELLOW}${BOLD}  WARNING: host may sleep during long-running orchestration (#3350)${NC}"
+            warn "${YELLOW}${BOLD}========================================================================${NC}"
+            warn "${YELLOW}macOS AC sleep timeout is ${sleep_minutes} minute(s) (pmset sleep=${sleep_minutes}).${NC}"
+            warn "${YELLOW}If the host sleeps mid-run, in-flight subagent sockets to${NC}"
+            warn "${YELLOW}api.anthropic.com will be torn down and that work will be lost.${NC}"
+            warn ""
+            warn "${BOLD}Important:${NC} ${RED}caffeinate -dimsu does NOT reliably defeat macOS"
+            warn "Maintenance Sleep on Apple Silicon.${NC} A user-idle assertion (the kind"
+            warn "Amphetamine and similar tools hold) was NOT enough to keep the host"
+            warn "awake during the 2026-05-28 incident that motivated this check."
+            warn ""
+            warn "${BOLD}Reliable defenses on macOS:${NC}"
+            warn "  - Disable AC sleep entirely (requires sudo, persistent):"
+            warn "      ${BOLD}sudo pmset -c sleep 0${NC}"
+            warn "  - Or, in your sleep manager (Amphetamine / Lungo / etc.), turn OFF"
+            warn "    \"allow system sleep when display is off\" before this run."
+            warn ""
+            warn "Restore the default afterwards with:"
+            warn "      ${BOLD}sudo pmset -c sleep 1${NC}  ${YELLOW}# or whatever value you prefer${NC}"
+            warn "${YELLOW}========================================================================${NC}"
+            warn ""
+
+            info_oneliner "${YELLOW}[sleep-check] WARNING: macOS AC sleep is enabled (sleep=${sleep_minutes}m). See stderr for details.${NC}"
+            return 0
+        }
+        check_macos
+        ;;
+
+    Linux)
+        check_linux() {
+            # Prefer systemd-inhibit if systemd is available.
+            if ! command -v systemctl >/dev/null 2>&1 || ! systemctl --version >/dev/null 2>&1; then
+                info_oneliner "${YELLOW}[sleep-check] Linux without systemd detected; cannot auto-verify sleep settings.${NC}"
+                info_oneliner "${YELLOW}[sleep-check] If this host can suspend, consider disabling suspend for this session.${NC}"
+                return 0
+            fi
+
+            if ! command -v systemd-inhibit >/dev/null 2>&1; then
+                info_oneliner "${YELLOW}[sleep-check] systemd-inhibit not found; cannot verify sleep inhibitors.${NC}"
+                return 0
+            fi
+
+            local inhibit_list
+            inhibit_list="$(systemd-inhibit --list 2>/dev/null || true)"
+
+            # Look for any active sleep/idle inhibitor. The exact column layout
+            # varies across systemd versions, so we just grep for the lock
+            # types of interest in the listing text.
+            if printf '%s' "$inhibit_list" | grep -Eq '(idle:sleep|sleep:idle|^[^:]*sleep)'; then
+                info_oneliner "${GREEN}[sleep-check] Linux: an idle/sleep inhibitor is active. Host should stay awake.${NC}"
+                return 0
+            fi
+
+            warn ""
+            warn "${YELLOW}${BOLD}========================================================================${NC}"
+            warn "${YELLOW}${BOLD}  WARNING: host may suspend during long-running orchestration (#3350)${NC}"
+            warn "${YELLOW}${BOLD}========================================================================${NC}"
+            warn "${YELLOW}No active idle/sleep inhibitor was found via systemd-inhibit --list.${NC}"
+            warn "${YELLOW}If the host suspends mid-run, in-flight subagent sockets to${NC}"
+            warn "${YELLOW}api.anthropic.com will be torn down and that work will be lost.${NC}"
+            warn ""
+            warn "${BOLD}Reliable defense on systemd Linux:${NC}"
+            warn "  Wrap this whole session in:"
+            warn "      ${BOLD}systemd-inhibit --what=idle:sleep --who=loom \\\\"
+            warn "          --why='loom orchestration' -- <your command>${NC}"
+            warn ""
+            warn "  Example:"
+            warn "      ${BOLD}systemd-inhibit --what=idle:sleep --who=loom --why=sweep -- \\\\"
+            warn "          claude /sweep …${NC}"
+            warn ""
+            warn "  Or temporarily mask the sleep targets for this session:"
+            warn "      ${BOLD}sudo systemctl mask sleep.target suspend.target \\\\"
+            warn "          hibernate.target hybrid-sleep.target${NC}"
+            warn "  (unmask afterwards with the same names)."
+            warn "${YELLOW}========================================================================${NC}"
+            warn ""
+
+            info_oneliner "${YELLOW}[sleep-check] WARNING: no systemd-inhibit lock detected. See stderr for details.${NC}"
+            return 0
+        }
+        check_linux
+        ;;
+
+    *)
+        info_oneliner "${YELLOW}[sleep-check] Host platform '${PLATFORM}' unknown for sleep detection. Verify the host won't suspend during this run.${NC}"
+        ;;
+esac
+
+# Always succeed — this script is advisory only.
+exit 0

--- a/defaults/scripts/tests/test-check-host-sleep.sh
+++ b/defaults/scripts/tests/test-check-host-sleep.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# test-check-host-sleep.sh - Smoke tests for check-host-sleep.sh
+#
+# This script exercises the host-sleep readiness check (#3350) against the
+# current host. It does NOT mock the platform — it just verifies the helper
+# behaves as designed:
+#   - always exits 0 (never blocks Loom)
+#   - prints something coherent on supported platforms
+#   - handles unknown platforms without crashing
+#   - respects --quiet (suppresses stdout one-liner but still warns on stderr)
+#   - handles --help
+#
+# Usage:
+#   ./.loom/scripts/tests/test-check-host-sleep.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPERS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$HELPERS_DIR/check-host-sleep.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: $1"
+}
+
+fail() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: $1"
+}
+
+# -------- Test 1: script exists and is executable --------
+echo "Test 1: script exists and is executable"
+if [[ -x "$SCRIPT" ]]; then
+    pass "check-host-sleep.sh is executable"
+else
+    fail "check-host-sleep.sh is missing or not executable: $SCRIPT"
+    echo "FAILED: $TESTS_FAILED/$TESTS_RUN"
+    exit 1
+fi
+
+# -------- Test 2: default invocation exits 0 --------
+echo "Test 2: default invocation always exits 0"
+"$SCRIPT" >/dev/null 2>&1
+rc=$?
+if [[ "$rc" -eq 0 ]]; then
+    pass "exit code is 0"
+else
+    fail "expected exit 0, got $rc"
+fi
+
+# -------- Test 3: --quiet exits 0 and suppresses stdout --------
+echo "Test 3: --quiet suppresses stdout"
+stdout_quiet="$("$SCRIPT" --quiet 2>/dev/null || true)"
+rc=$?
+if [[ "$rc" -eq 0 ]]; then
+    pass "--quiet exit code is 0"
+else
+    fail "--quiet exit code expected 0, got $rc"
+fi
+if [[ -z "$stdout_quiet" ]]; then
+    pass "--quiet produces no stdout"
+else
+    fail "--quiet produced stdout: $stdout_quiet"
+fi
+
+# -------- Test 4: default invocation prints SOMETHING (stdout or stderr) --------
+echo "Test 4: default invocation produces output"
+combined="$("$SCRIPT" 2>&1 || true)"
+if [[ -n "$combined" ]]; then
+    pass "produced output on supported platform"
+else
+    fail "produced no output at all (unexpected)"
+fi
+
+# -------- Test 5: --help works --------
+echo "Test 5: --help prints usage and exits 0"
+help_out="$("$SCRIPT" --help 2>&1 || true)"
+rc=$?
+if [[ "$rc" -eq 0 ]]; then
+    pass "--help exit code is 0"
+else
+    fail "--help exit expected 0, got $rc"
+fi
+if printf '%s' "$help_out" | grep -q -i "Usage"; then
+    pass "--help mentions Usage"
+else
+    fail "--help did not mention Usage. Got: $help_out"
+fi
+
+# -------- Test 6: unknown args do not break it --------
+echo "Test 6: unknown args do not break the script"
+"$SCRIPT" --some-nonsense-flag --another 99 >/dev/null 2>&1
+rc=$?
+if [[ "$rc" -eq 0 ]]; then
+    pass "unknown args tolerated; exit 0"
+else
+    fail "unknown args caused non-zero exit ($rc)"
+fi
+
+# -------- Test 7: platform-aware content on macOS / Linux --------
+echo "Test 7: platform-aware content (best-effort)"
+platform="$(uname -s 2>/dev/null || echo unknown)"
+combined="$("$SCRIPT" 2>&1 || true)"
+case "$platform" in
+    Darwin)
+        # Either we get a warning mentioning pmset/sleep, or a success-line
+        # confirming sleep is disabled. Both are acceptable.
+        if printf '%s' "$combined" | grep -qE "(pmset|sleep)"; then
+            pass "macOS output mentions pmset/sleep"
+        else
+            fail "macOS output missing pmset/sleep keywords. Got: $combined"
+        fi
+        ;;
+    Linux)
+        if printf '%s' "$combined" | grep -qiE "(systemd|sleep|suspend|inhibit)"; then
+            pass "Linux output mentions systemd-inhibit/sleep keywords"
+        else
+            fail "Linux output missing expected keywords. Got: $combined"
+        fi
+        ;;
+    *)
+        if printf '%s' "$combined" | grep -qi "unknown"; then
+            pass "unknown platform handled gracefully"
+        else
+            # Acceptable to be silent; at minimum the script exited 0.
+            pass "unknown platform produced no recognizable output (allowed)"
+        fi
+        ;;
+esac
+
+# -------- Summary --------
+echo ""
+echo "Results: $TESTS_PASSED/$TESTS_RUN passed"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+    echo -e "${RED}FAILED${NC}: $TESTS_FAILED test(s) failed"
+    exit 1
+fi
+echo -e "${GREEN}OK${NC}: all tests passed"
+exit 0


### PR DESCRIPTION
## Summary

Closes #3350.

Long-running orchestration (`/sweep` overnight, `/loom` autonomous, multi-issue `/shepherd --merge`) can lose all in-flight subagent work when the host enters macOS Maintenance Sleep or Linux suspend. The 2026-05-28 incident lost two curator subagents at the 33-minute mark despite a user-idle sleep assertion being held.

This implements **scope option 1 only** from #3350: a warn-only check at skill startup. No `--keep-awake` flag, no auto-inhibition — those are explicitly deferred per the issue body.

## What changed

- **New helper** `defaults/scripts/check-host-sleep.sh` — advisory, non-blocking. Always exits `0` (Loom proceeds regardless).
  - **macOS**: parses `pmset -g` for the AC sleep timeout. Warns if non-zero. Recommends `sudo pmset -c sleep 0` or the sleep manager's "allow system sleep when display is off → off" toggle. Explicitly does **not** recommend `caffeinate -dimsu`, because the incident proved user-idle assertions don't defeat Maintenance Sleep on Apple Silicon.
  - **systemd Linux**: checks `systemd-inhibit --list` for an active idle/sleep lock and recommends wrapping the session in `systemd-inhibit --what=idle:sleep --who=loom --why=loom -- <cmd>`, which IS reliable.
  - **Unknown platforms**: brief notice and continue.
  - Supports `--quiet` (suppresses the stdout one-liner; stderr warning still fires) and `--help`.
- **Skill integrations** (all three cross-reference #3350):
  - `defaults/.claude/commands/loom/sweep.md` — new "Host Sleep Readiness" section near the existing Daemon Coexistence warning.
  - `defaults/.claude/commands/loom/loom.md` — Mode Selection forwards through the check before Daemon Detection.
  - `defaults/.claude/commands/loom/shepherd.md` — new Step 0 before Daemon Detection.
- **Operator docs**: short note in `CLAUDE.md` and `defaults/CLAUDE.md` naming the real platform-specific defenses (`pmset -c sleep 0` on macOS, `systemd-inhibit` on Linux), not `caffeinate`.
- **Smoke test** `defaults/scripts/tests/test-check-host-sleep.sh` — verifies exit code, `--quiet`, `--help`, unknown args, and platform-aware content.

## Scope discipline

- Warn-only. No `--keep-awake` flag. No automatic `caffeinate` / `systemd-inhibit` calls.
- Script is non-blocking — always exits `0` even on detection failure.
- Honest about macOS: the warning does NOT promise `caffeinate -dimsu` will fix Maintenance Sleep, because the incident proved it doesn't.
- Touches only the three orchestration skills + helper + docs. No daemon changes, no unrelated subsystems.

## Test plan

- [x] `bash defaults/scripts/tests/test-check-host-sleep.sh` passes (9/9 on macOS)
- [x] `shellcheck defaults/scripts/check-host-sleep.sh defaults/scripts/tests/test-check-host-sleep.sh` clean
- [x] Running `./.loom/scripts/check-host-sleep.sh` on this Darwin host prints the expected pmset-based warning and exits `0`
- [x] Running with `--quiet` suppresses the stdout one-liner but still emits the stderr warning
- [x] Running with `--help` prints usage and exits `0`
- [ ] Smoke-tested on a systemd Linux host (deferred to reviewer; logic mirrors macOS branch)
- [ ] Verified `/sweep`, `/loom`, `/shepherd` skill prose change displays correctly when those skills are next invoked