### PR TITLE
feat(sweep): add loom:operator-only label + pre-flight skip

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -93,6 +93,10 @@
   description: Signal to abort shepherd for this issue (returns to loom:issue)
   color: "F97316"  # orange-500 - warning/signal color
 
+- name: loom:operator-only
+  description: "Issue requires human action outside the automation (credentials, infra rotations, manual deploys, hardware access). Sweep/shepherd skip in pre-flight; curator may still enrich. Applied by: humans or any agent that recognizes the constraint."
+  color: "F97316"  # orange-500 - operator-action signal (matches loom:abort)
+
 # Epic Labels
 - name: loom:epic
   description: Multi-phase epic proposal (decomposes into implementation issues)

--- a/defaults/.claude/commands/loom/champion-issue-promo.md
+++ b/defaults/.claude/commands/loom/champion-issue-promo.md
@@ -332,6 +332,7 @@ This proposal has been auto-promoted in force mode. The daemon is configured for
 
 Even in force mode, do NOT auto-promote if:
 - Issue has `loom:blocked` label
+- Issue has `loom:operator-only` label (requires human action outside automation — credentials, infra rotations, manual deploys, hardware access; sweep/shepherd will skip these in pre-flight, so promoting to `loom:issue` would only stall the queue)
 - Issue title contains "DISCUSSION" or "RFC" (requires human input)
 - Issue mentions breaking changes without migration plan
 - Issue references external dependencies that need coordination

--- a/defaults/.claude/commands/loom/loom.md
+++ b/defaults/.claude/commands/loom/loom.md
@@ -554,6 +554,7 @@ loom-clean --deep       # Also remove build artifacts
 | `loom:issue` | Approved and ready for work | Champion/Human |
 | `loom:building` | Builder is implementing | Builder |
 | `loom:blocked` | Work is blocked | Builder |
+| `loom:operator-only` | Requires human action; sweep/shepherd skip | Human |
 | `loom:urgent` | Critical priority | Guide/Human |
 
 **Workflow labels (PR lifecycle):**

--- a/defaults/.claude/commands/loom/shepherd.md
+++ b/defaults/.claude/commands/loom/shepherd.md
@@ -87,10 +87,10 @@ If found, skip to Step 5 (monitor the existing shepherd using its `task_id`).
 
 ### Step 3: Verify Issue is Open
 
-Before writing the spawn signal, check that the issue is still open:
+Before writing the spawn signal, check that the issue is still open and not flagged operator-only:
 
 ```bash
-gh issue view <N> --json state --jq '.state'
+gh issue view <N> --json state,labels --jq '{state: .state, labels: [.labels[].name]}'
 ```
 
 **If the issue is CLOSED**, display this message and EXIT:
@@ -106,7 +106,22 @@ To proceed, reopen the issue first:
 Then run /shepherd <N> again.
 ```
 
-**If the issue is OPEN**, proceed to Step 4.
+**If the issue has `loom:operator-only`**, display this message and EXIT (regardless of `--merge`):
+
+```
+Issue #<N> is labeled loom:operator-only.
+
+This issue requires human action outside the automation (credentials,
+infrastructure rotations, manual deploys, hardware access). A shepherd
+cannot make progress on it. If you believe the label is incorrect,
+remove it first:
+
+  gh issue edit <N> --remove-label "loom:operator-only"
+
+Then run /shepherd <N> again.
+```
+
+**If the issue is OPEN and not operator-only**, proceed to Step 4.
 
 ### Step 4: Write Spawn Signal
 

--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -247,6 +247,7 @@ For each issue `N` in the wave, before any role skill is invoked:
    - If the issue is closed, skip it (log a warning). It does NOT contribute to this wave.
    - If the issue already has `loom:building`, skip it — another shepherd or builder is working on it. Log a warning. Does NOT contribute to this wave.
    - If the issue has `loom:blocked`, skip it. Log a warning. Does NOT contribute to this wave.
+   - If the issue has `loom:operator-only`, skip it — requires human action outside automation (credentials, infra rotations, manual deploys, hardware access). Log a warning with reason "operator-only". Does NOT contribute to this wave. **Checked before the existing-PR probe** so operator-only issues aren't probed at all.
    - **Existing-PR probe (#3359).** If `linked_prs` is non-empty, probe each linked PR for its state and labels:
      ```bash
      gh pr view <pr_url> --json state,labels --jq '{state, labels: [.labels[].name]}'
@@ -267,7 +268,7 @@ For each issue `N` in the wave, before any role skill is invoked:
    gh issue view N --json title,body
    ```
 
-> **Pre-flight skip rule.** If `K` of the wave's `N` candidates are skipped at pre-flight (closed, `loom:building`, `loom:blocked`, or multi-PR ambiguity), dispatch only `N - K` builders for this wave. Issues routed to Judge or Merge via the existing-PR rules consume a wave slot but skip the Builder dispatch. **Do not pull a candidate forward** from the next wave to backfill. Wave boundaries stay clean, and the next wave runs at its originally planned size.
+> **Pre-flight skip rule.** If `K` of the wave's `N` candidates are skipped at pre-flight (closed, `loom:building`, `loom:blocked`, `loom:operator-only`, or multi-PR ambiguity), dispatch only `N - K` builders for this wave. Issues routed to Judge or Merge via the existing-PR rules consume a wave slot but skip the Builder dispatch. **Do not pull a candidate forward** from the next wave to backfill. Wave boundaries stay clean, and the next wave runs at its originally planned size.
 
 ### 2. Curator phase (still per-issue, before the wave dispatch)
 
@@ -428,7 +429,7 @@ Per-issue, the pre-flight check (step 1) already detects `loom:building` and ski
 - **No `gh pr merge`.** Always use `./.loom/scripts/merge-pr.sh`.
 - **No daemon-state writes.** Read-only access to `daemon-state.json` for situational awareness.
 - **Read the issue body** (`gh issue view N --json body`) before briefing the builder. Don't rely on the title.
-- **Skip operator-only issues** (issues that require human action, such as releases or credential changes). Log and move on.
+- **Skip operator-only issues** (issues labeled `loom:operator-only` — see Wave Lifecycle step 1). Log and move on.
 
 ## Limitations (Deferred for Follow-up Issues)
 
@@ -440,6 +441,7 @@ The full `/sweep` design in #3298 includes many features that are intentionally 
 | Natural-language selectors (label/author/title/time-window filters via NL description) | **Implemented (#3318)** | Mode B in Arguments. Out-of-band queries (body/diff inspection, file-touch filters) still trigger clarification. |
 | `--dry-run` | **Implemented (#3319)** | Prints the candidate plan (with wave grouping) and exits without mutating labels, worktrees, or PRs. |
 | Existing-PR detection in pre-flight | **Implemented (#3359)** | Pre-flight probes `closedByPullRequestsReferences`; routes existing open linked PRs to Judge (or Merge if already `loom:pr`) instead of dispatching a duplicate Builder. Multi-PR ambiguity skips with a log. |
+| `loom:operator-only` enforcement | **Implemented (#3360)** | Pre-flight skips issues with `loom:operator-only` (human action required: credentials, infra, hardware). Champion `--merge` mode also refuses to auto-promote them. |
 | `--max-waves` cap | Deferred | Operator-level brake on long sweeps. |
 | `--paused-merge` / `--no-judge` | Deferred | Merge-mode variants for trusted batches. |
 | `--include-blocked` (unblock pass) | Deferred | Currently `/sweep` skips `loom:blocked` issues outright. |


### PR DESCRIPTION
## Summary
- Adds `loom:operator-only` label to `.github/labels.yml` (orange-500, groups with `loom:abort`).
- Sweep pre-flight (Wave Lifecycle step 1) now skips operator-only issues with a logged reason; Constraints prose now references the mechanism instead of an unenforced promise.
- Champion `--merge`-mode guard added so `loom:curated` + `loom:operator-only` issues are never silently auto-promoted into the build queue (the critical safety guard — without it the sweep skip is bypassed under `--merge`).
- `loom.md` labels table documents the new label between `loom:blocked` and `loom:urgent`.
- Defensive operator-only check added to `/shepherd` Step 3 so direct shepherd invocations exit cleanly instead of stalling.
- Curator intentionally unchanged — `/curator N` on an operator-only issue should still enrich the body; the constraint is "no builder claims it", not "no curation happens".

Note: `.claude/commands/loom/*.md` is hardlinked to `defaults/.claude/commands/loom/*.md` (same inodes), so a single edit updates both trees. Verified with `stat -f "%i %N"`.

Closes #3360

## Test plan
- [ ] `/sweep N` where `#N` has `loom:operator-only` → builder NOT dispatched; log shows skip with reason "operator-only".
- [ ] `/sweep N` where `#N` lacks the label → unchanged behavior.
- [ ] `/curator N` on a `loom:operator-only` issue still enriches the body (does not skip).
- [ ] Champion in `--merge` mode does NOT auto-promote `loom:curated` + `loom:operator-only` issues.
- [ ] `/shepherd N` on a `loom:operator-only` issue exits with the new message instead of writing a spawn signal.
- [ ] After `./scripts/install/sync-labels.sh .`, `gh label list | grep loom:operator-only` returns the new label (deferred to operator; not run as part of this PR).