### PR TITLE
fix(doctor): isolate external-fork PRs in pr-<N> worktrees

### DIFF
--- a/defaults/.claude/commands/loom/doctor.md
+++ b/defaults/.claude/commands/loom/doctor.md
@@ -17,6 +17,43 @@ You help PRs move toward merge by:
 
 **Important**: After fixing issues, you signal completion by transitioning `loom:changes-requested` → `loom:review-requested`. This completes the feedback cycle and hands the PR back to the Reviewer.
 
+## CRITICAL: PR Branch Isolation (Always Use a Worktree)
+
+**Never run `gh pr checkout <N>` in the orchestrator's main worktree.** Doing so switches the orchestrator's `HEAD` to the PR branch and can leave behind untracked files from the PR when you switch back — see issue #3358 for a concrete incident.
+
+Pick the right worktree path before any `gh pr checkout` mutation:
+
+- **Loom-issue PRs** — branch matches the strict pattern `^feature/issue-([0-9]+)$`:
+  ```bash
+  ./.loom/scripts/worktree.sh <ISSUE_NUMBER>
+  cd .loom/worktrees/issue-<ISSUE_NUMBER>
+  gh pr checkout <PR_NUMBER>   # safe: already inside the issue worktree
+  ```
+
+- **External-fork or ad-hoc PRs** — any other branch shape (e.g., `fix/foo-bar`, `release-1`, `jperla:fix/claude-code-2.1-compat`):
+  ```bash
+  ./.loom/scripts/pr-worktree.sh <PR_NUMBER>
+  cd .loom/worktrees/pr-<PR_NUMBER>
+  # pr-worktree.sh already ran `gh pr checkout` inside the worktree
+  ```
+
+The branch-name heuristic to choose between them:
+
+```bash
+PR_BRANCH=$(gh pr view <PR_NUMBER> --json headRefName --jq '.headRefName')
+if [[ "$PR_BRANCH" =~ ^feature/issue-([0-9]+)$ ]]; then
+  ISSUE_NUM="${BASH_REMATCH[1]}"
+  ./.loom/scripts/worktree.sh "$ISSUE_NUM"
+  cd ".loom/worktrees/issue-$ISSUE_NUM"
+  gh pr checkout <PR_NUMBER>
+else
+  ./.loom/scripts/pr-worktree.sh <PR_NUMBER>
+  cd ".loom/worktrees/pr-<PR_NUMBER>"
+fi
+```
+
+Both worktree paths get a `.loom-managed` sentinel and are auto-cleaned by `merge-pr.sh` on merge.
+
 ## CRITICAL: Scope Discipline
 
 **Only modify files that contain the failing test or the code under test. Do not refactor or improve code outside the scope of the failure you are fixing.**
@@ -253,7 +290,18 @@ if [ "$PRIORITY_1" -eq 0 ] && [ "$PRIORITY_2" -eq 0 ]; then
 
   if [ -n "$UNLABELED_PR" ]; then
     echo "Checking health of unlabeled PR #$UNLABELED_PR"
-    gh pr checkout $UNLABELED_PR
+
+    # Route through the right worktree (see "PR Branch Isolation" above)
+    PR_BRANCH=$(gh pr view "$UNLABELED_PR" --json headRefName --jq '.headRefName')
+    if [[ "$PR_BRANCH" =~ ^feature/issue-([0-9]+)$ ]]; then
+      ISSUE_NUM="${BASH_REMATCH[1]}"
+      ./.loom/scripts/worktree.sh "$ISSUE_NUM" >/dev/null
+      cd ".loom/worktrees/issue-$ISSUE_NUM"
+      gh pr checkout "$UNLABELED_PR"
+    else
+      ./.loom/scripts/pr-worktree.sh "$UNLABELED_PR" >/dev/null
+      cd ".loom/worktrees/pr-$UNLABELED_PR"
+    fi
 
     # Check for merge conflicts
     if git merge-tree origin/main | grep -q "^+<<<<<<<"; then
@@ -325,8 +373,17 @@ When the user explicitly instructs you to work on a specific PR by number:
 gh pr edit 588 --add-label "loom:treating"
 gh pr comment 588 --body "Addressing issues on this PR per user request"
 
-# Check out and fix
-gh pr checkout 588
+# Check out and fix — always inside a dedicated worktree (see "PR Branch Isolation")
+PR_BRANCH=$(gh pr view 588 --json headRefName --jq '.headRefName')
+if [[ "$PR_BRANCH" =~ ^feature/issue-([0-9]+)$ ]]; then
+  ISSUE_NUM="${BASH_REMATCH[1]}"
+  ./.loom/scripts/worktree.sh "$ISSUE_NUM"
+  cd ".loom/worktrees/issue-$ISSUE_NUM"
+  gh pr checkout 588
+else
+  ./.loom/scripts/pr-worktree.sh 588
+  cd ".loom/worktrees/pr-588"
+fi
 # ... address feedback, resolve conflicts ...
 
 # Complete normally
@@ -355,7 +412,7 @@ gh pr edit 588 --remove-label "loom:treating" --add-label "loom:review-requested
    ```
 3. **Check PR details**: `gh pr view <number>` - look for "Changes requested" reviews or conflicts
 4. **Read feedback**: Understand what the reviewer is asking for
-5. **Check out PR branch**: `gh pr checkout <number>`
+5. **Check out PR branch in a dedicated worktree** (see "PR Branch Isolation" above): use `./.loom/scripts/worktree.sh <ISSUE_NUM>` for `feature/issue-<N>` branches or `./.loom/scripts/pr-worktree.sh <PR_NUMBER>` for external/ad-hoc branches, then `cd` into the worktree before running `gh pr checkout`.
 6. **CRITICAL: Assess ALL CI failures FIRST** (see "CI Assessment" section below):
    - Run `gh pr checks <number>` to identify ALL failing checks
    - Fetch logs for each failing check
@@ -635,8 +692,17 @@ gh pr edit 42 --add-label "loom:treating"
 # View PR details and review status
 gh pr view 42
 
-# Check out the PR branch
-gh pr checkout 42
+# Check out the PR branch in a dedicated worktree (see "PR Branch Isolation")
+PR_BRANCH=$(gh pr view 42 --json headRefName --jq '.headRefName')
+if [[ "$PR_BRANCH" =~ ^feature/issue-([0-9]+)$ ]]; then
+  ISSUE_NUM="${BASH_REMATCH[1]}"
+  ./.loom/scripts/worktree.sh "$ISSUE_NUM"
+  cd ".loom/worktrees/issue-$ISSUE_NUM"
+  gh pr checkout 42
+else
+  ./.loom/scripts/pr-worktree.sh 42
+  cd ".loom/worktrees/pr-42"
+fi
 
 # See what reviewer said
 gh pr view 42 --comments
@@ -780,7 +846,7 @@ If review requests major architectural changes:
 
 ## Notes
 
-- **Work in PR branches**: You don't need worktrees - check out the PR branch directly with `gh pr checkout <number>`
+- **Always work in a dedicated worktree** (see "PR Branch Isolation" above): use the issue worktree for `feature/issue-<N>` branches or `pr-worktree.sh` for external/ad-hoc branches. Never run `gh pr checkout` in the orchestrator's main worktree.
 - **Find work by label**: Look for `loom:changes-requested` (amber badges) to find PRs needing fixes
 - **Signal completion**: After fixing, transition `loom:changes-requested` → `loom:review-requested` to hand back to Reviewer
 - **Be proactive**: Check all open PRs regularly - conflicts can appear even on unlabeled PRs

--- a/defaults/scripts/merge-pr.sh
+++ b/defaults/scripts/merge-pr.sh
@@ -392,48 +392,63 @@ fi
 # Cleanup worktree if requested.
 #
 # Ownership model (see issue #3334): Loom owns worktrees it created under
-# .loom/worktrees/ (marked with a .loom-managed sentinel file by worktree.sh).
-# Any worktree lacking the sentinel is treated as user-owned and is never
-# removed by this script. Operators can also set LOOM_PRESERVE_WORKTREE=1 to
-# skip cleanup unconditionally.
+# .loom/worktrees/ (marked with a .loom-managed sentinel file by worktree.sh
+# or pr-worktree.sh). Any worktree lacking the sentinel is treated as
+# user-owned and is never removed by this script. Operators can also set
+# LOOM_PRESERVE_WORKTREE=1 to skip cleanup unconditionally.
+#
+# Two worktree-path conventions are recognized:
+#   - .loom/worktrees/issue-<N>/  (Loom-issue branches: feature/issue-<N>)
+#   - .loom/worktrees/pr-<N>/     (external-fork / ad-hoc branches; #3358)
+#
+# Branch-to-issue regex is the strict `^feature/issue-([0-9]+)$` pattern so
+# branches like `release-1` or `fix-bug-42` correctly classify as PR-style
+# (not issue-style) and clean up the right worktree.
+_remove_loom_worktree() {
+  local worktree_path="$1"
+  if [[ ! -d "$worktree_path" ]]; then
+    info "No worktree found at $worktree_path"
+    return 0
+  fi
+  if [[ ! -f "$worktree_path/.loom-managed" ]]; then
+    warning "Worktree at $worktree_path lacks .loom-managed sentinel — refusing to remove (user-owned)"
+    return 0
+  fi
+  # If our shell is inside the worktree we're removing, hop out first.
+  local current_dir worktree_real in_worktree=false
+  current_dir="$(pwd -P 2>/dev/null || pwd)"
+  worktree_real="$(cd "$worktree_path" 2>/dev/null && pwd -P || echo "$worktree_path")"
+  if [[ "$current_dir" == "$worktree_real"* ]]; then
+    in_worktree=true
+    cd "$REPO_ROOT"
+  fi
+  info "Removing worktree: $worktree_path"
+  if git -C "$REPO_ROOT" worktree remove "$worktree_path" --force 2>/dev/null; then
+    success "Worktree removed"
+    if [[ "$in_worktree" == "true" ]]; then
+      echo ""
+      warning "Your shell's working directory was inside the removed worktree."
+      warning "Run this command to fix:"
+      echo "  cd $REPO_ROOT"
+    fi
+  else
+    warning "Could not remove worktree at $worktree_path"
+  fi
+}
+
 if [[ "$CLEANUP_WORKTREE" == "true" ]]; then
   if [[ "${LOOM_PRESERVE_WORKTREE:-0}" == "1" ]]; then
     info "Worktree cleanup skipped (LOOM_PRESERVE_WORKTREE=1)"
   else
-    # Extract issue number from branch name (feature/issue-N pattern)
-    ISSUE_NUM=$(echo "$PR_BRANCH" | grep -oE '[0-9]+$' || true)
-    if [[ -n "$ISSUE_NUM" ]]; then
-      WORKTREE_PATH="$REPO_ROOT/.loom/worktrees/issue-$ISSUE_NUM"
-      if [[ -d "$WORKTREE_PATH" ]]; then
-        if [[ ! -f "$WORKTREE_PATH/.loom-managed" ]]; then
-          warning "Worktree at $WORKTREE_PATH lacks .loom-managed sentinel — refusing to remove (user-owned)"
-        else
-          # Check if we're currently inside the worktree being removed
-          CURRENT_DIR="$(pwd -P 2>/dev/null || pwd)"
-          WORKTREE_REAL="$(cd "$WORKTREE_PATH" 2>/dev/null && pwd -P || echo "$WORKTREE_PATH")"
-          IN_WORKTREE=false
-          if [[ "$CURRENT_DIR" == "$WORKTREE_REAL"* ]]; then
-            IN_WORKTREE=true
-            cd "$REPO_ROOT"
-          fi
-          info "Removing worktree: $WORKTREE_PATH"
-          if git -C "$REPO_ROOT" worktree remove "$WORKTREE_PATH" --force 2>/dev/null; then
-            success "Worktree removed"
-            if [[ "$IN_WORKTREE" == "true" ]]; then
-              echo ""
-              warning "Your shell's working directory was inside the removed worktree."
-              warning "Run this command to fix:"
-              echo "  cd $REPO_ROOT"
-            fi
-          else
-            warning "Could not remove worktree at $WORKTREE_PATH"
-          fi
-        fi
-      else
-        info "No worktree found at $WORKTREE_PATH"
-      fi
+    # Strict pattern: only `feature/issue-<N>` matches. Trailing-number
+    # heuristics would misclassify branches like `release-1`.
+    if [[ "$PR_BRANCH" =~ ^feature/issue-([0-9]+)$ ]]; then
+      ISSUE_NUM="${BASH_REMATCH[1]}"
+      _remove_loom_worktree "$REPO_ROOT/.loom/worktrees/issue-$ISSUE_NUM"
     else
-      warning "Could not determine issue number from branch '$PR_BRANCH' for worktree cleanup"
+      # External-fork / ad-hoc branch — the doctor would have used a
+      # `pr-<PR_NUMBER>` worktree if any.
+      _remove_loom_worktree "$REPO_ROOT/.loom/worktrees/pr-$PR_NUMBER"
     fi
   fi
 fi

--- a/defaults/scripts/pr-worktree.sh
+++ b/defaults/scripts/pr-worktree.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Loom PR Worktree Helper - Create a dedicated worktree for an external-fork
+# or ad-hoc PR branch.
+#
+# Usage:
+#   ./.loom/scripts/pr-worktree.sh <PR_NUMBER>
+#
+# This helper is for PRs whose branch does NOT match `feature/issue-<N>`,
+# typically:
+#   - External-fork PRs (e.g., jperla/loom:fix/claude-code-2.1-compat)
+#   - Ad-hoc branch names that don't include a Loom issue number
+#
+# For Loom-issue PRs whose branch IS `feature/issue-<N>`, use:
+#   ./.loom/scripts/worktree.sh <ISSUE_NUMBER>
+#
+# What it does:
+#   1. Fetches the PR's branch into a local tracking branch via `gh pr checkout`
+#      INSIDE the new worktree (not in the orchestrator's main worktree)
+#   2. Creates .loom/worktrees/pr-<PR_NUMBER>/ on a placeholder branch first,
+#      then runs `gh pr checkout` from inside it so the PR branch is only
+#      ever checked out in the dedicated worktree
+#   3. Writes a `.loom-managed` sentinel so merge-pr.sh / loom-clean will
+#      remove the worktree on PR merge
+#
+# Exit codes:
+#   0 = success (worktree exists at the expected path)
+#   1 = failure (error printed)
+#   2 = invalid arguments
+
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+print_error() { echo -e "${RED}ERROR: $1${NC}" >&2; }
+print_success() { echo -e "${GREEN}✓ $1${NC}"; }
+print_info() { echo -e "${BLUE}ℹ $1${NC}"; }
+print_warning() { echo -e "${YELLOW}⚠ $1${NC}"; }
+
+show_help() {
+    cat <<'EOF'
+Loom PR Worktree Helper
+
+Usage: ./.loom/scripts/pr-worktree.sh <PR_NUMBER>
+
+Creates an isolated worktree at .loom/worktrees/pr-<PR_NUMBER>/ for a PR
+whose branch doesn't fit the `feature/issue-<N>` convention (typically
+external-fork PRs). The PR's branch is checked out inside the worktree —
+never in the orchestrator's main worktree.
+
+For Loom-issue PRs (branch = feature/issue-<N>), use worktree.sh instead.
+
+Exit codes:
+  0 = worktree ready at .loom/worktrees/pr-<PR_NUMBER>/
+  1 = failure
+  2 = invalid arguments
+EOF
+}
+
+if [[ $# -eq 0 ]] || [[ "$1" == "--help" ]] || [[ "$1" == "-h" ]]; then
+    show_help
+    [[ $# -eq 0 ]] && exit 2 || exit 0
+fi
+
+PR_NUMBER="$1"
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+    print_error "PR number must be numeric (got: '$PR_NUMBER')"
+    exit 2
+fi
+
+# Resolve the main repo root even when invoked from a worktree.
+GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null) || {
+    print_error "Not in a git repository"
+    exit 1
+}
+REPO_ROOT=$(cd "$(dirname "$GIT_COMMON_DIR")" && pwd)
+
+WORKTREE_PATH="$REPO_ROOT/.loom/worktrees/pr-$PR_NUMBER"
+
+# If the worktree already exists, treat it as reusable. The doctor may
+# re-enter for the same PR across multiple iterations.
+if [[ -d "$WORKTREE_PATH" ]]; then
+    if git -C "$REPO_ROOT" worktree list | grep -q "$WORKTREE_PATH"; then
+        print_info "PR worktree already exists at $WORKTREE_PATH (reusing)"
+        # Refresh the PR branch in case upstream pushed new commits.
+        if (cd "$WORKTREE_PATH" && gh pr checkout "$PR_NUMBER" --force >/dev/null 2>&1); then
+            print_success "Refreshed PR branch in existing worktree"
+        else
+            print_warning "Could not refresh PR branch (continuing with existing checkout)"
+        fi
+        echo "$WORKTREE_PATH"
+        exit 0
+    else
+        print_error "Directory exists but is not a registered worktree: $WORKTREE_PATH"
+        print_info "Remove it and retry: rm -rf '$WORKTREE_PATH'"
+        exit 1
+    fi
+fi
+
+print_info "Creating PR worktree for PR #$PR_NUMBER..."
+print_info "  Path: $WORKTREE_PATH"
+
+# Create the worktree on a detached HEAD of origin/main, then run
+# `gh pr checkout` from inside it. This avoids ever touching the
+# orchestrator's main worktree HEAD.
+mkdir -p "$REPO_ROOT/.loom/worktrees"
+
+# Fetch origin/main so we have something to base the worktree on.
+git -C "$REPO_ROOT" fetch origin main >/dev/null 2>&1 || \
+    print_warning "Could not fetch origin/main (continuing)"
+
+# Use --detach so we don't create a stale branch ref. `gh pr checkout` will
+# switch to the PR's branch once we cd into the worktree.
+if ! git -C "$REPO_ROOT" worktree add --detach "$WORKTREE_PATH" origin/main 2>/dev/null; then
+    print_error "Failed to create worktree at $WORKTREE_PATH"
+    exit 1
+fi
+
+# Write the sentinel BEFORE any PR mutation so merge-pr.sh / loom-clean
+# recognize it as Loom-managed even if `gh pr checkout` fails midway.
+# Mirrors the heredoc shape used by worktree.sh:761-768 but records the PR
+# number instead of the issue number.
+cat > "$WORKTREE_PATH/.loom-managed" <<EOF
+# Loom-managed worktree marker
+# Created by .loom/scripts/pr-worktree.sh
+# PR: $PR_NUMBER
+# Removing this file makes Loom treat the worktree as user-owned and refuse
+# to clean it up automatically.
+EOF
+
+# Now check out the PR branch from inside the new worktree.
+if ! (cd "$WORKTREE_PATH" && gh pr checkout "$PR_NUMBER" --force >/dev/null 2>&1); then
+    print_error "Failed to run 'gh pr checkout $PR_NUMBER' in $WORKTREE_PATH"
+    print_info "The worktree was created but the PR branch is not checked out."
+    print_info "You can retry: cd '$WORKTREE_PATH' && gh pr checkout $PR_NUMBER"
+    exit 1
+fi
+
+# Symlink .mcp.json so MCP servers work in the PR worktree (same pattern
+# as worktree.sh).
+if [[ -f "$REPO_ROOT/.mcp.json" && ! -e "$WORKTREE_PATH/.mcp.json" ]]; then
+    ln -s "$REPO_ROOT/.mcp.json" "$WORKTREE_PATH/.mcp.json" 2>/dev/null || true
+fi
+
+print_success "PR worktree ready at $WORKTREE_PATH"
+echo "$WORKTREE_PATH"

--- a/defaults/scripts/tests/test-pr-worktree-isolation.sh
+++ b/defaults/scripts/tests/test-pr-worktree-isolation.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# test-pr-worktree-isolation.sh - Regression test for issue #3358
+#
+# Verifies that:
+#   1. pr-worktree.sh creates a worktree at .loom/worktrees/pr-<N>/ with the
+#      .loom-managed sentinel (PR-mode entry).
+#   2. The orchestrator's main worktree HEAD is unchanged after a simulated
+#      doctor pass that targets an external-fork-style PR branch (`fix/foo-bar`).
+#   3. merge-pr.sh's regex tightening correctly classifies branch shapes:
+#      - `feature/issue-42` -> issue-style (clean up issue-42 worktree)
+#      - `release-1`        -> PR-style (clean up pr-<N> worktree)
+#      - `fix/foo-bar`      -> PR-style
+#      - `feature/issue-42-fix` (extra suffix) -> PR-style (strict regex)
+#   4. doctor.md (defaults/) documents the branch-isolation requirement.
+#
+# This is a static / simulation test — we do not exercise the real `gh pr
+# checkout` round-trip because that would require a live forge. The
+# correctness of the regex and worktree-path selection is what we care about.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPTS_DIR/../.." && pwd)"
+
+PR_WORKTREE_SH="$SCRIPTS_DIR/pr-worktree.sh"
+MERGE_PR_SH="$SCRIPTS_DIR/merge-pr.sh"
+DOCTOR_MD="$REPO_ROOT/defaults/.claude/commands/loom/doctor.md"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1)); echo -e "  ${RED}FAIL${NC}: $1"; }
+
+assert_grep() {
+    local pattern="$1" file="$2" msg="$3"
+    if grep -qE "$pattern" "$file"; then pass "$msg"; else fail "$msg (pattern: $pattern)"; fi
+}
+
+# --- Test 1: pr-worktree.sh exists and has the sentinel write block ---
+echo "Test 1: pr-worktree.sh ships sentinel write logic"
+if [[ -x "$PR_WORKTREE_SH" ]]; then
+    pass "pr-worktree.sh exists and is executable"
+else
+    fail "pr-worktree.sh missing or not executable at $PR_WORKTREE_SH"
+fi
+assert_grep "Loom-managed worktree marker" "$PR_WORKTREE_SH" \
+    "pr-worktree.sh writes the sentinel marker"
+assert_grep "# PR: " "$PR_WORKTREE_SH" \
+    "pr-worktree.sh records PR number in sentinel (mirrors worktree.sh issue convention)"
+assert_grep "worktrees/pr-" "$PR_WORKTREE_SH" \
+    "pr-worktree.sh uses .loom/worktrees/pr-<N>/ convention"
+
+# --- Test 2: merge-pr.sh uses strict regex and recognizes pr-<N> path ---
+echo ""
+echo "Test 2: merge-pr.sh uses strict branch regex + pr-<N> cleanup"
+assert_grep '\^feature/issue-\(\[0-9\]\+\)\$' "$MERGE_PR_SH" \
+    "merge-pr.sh uses strict ^feature/issue-([0-9]+)$ regex (tightened from trailing-digit heuristic)"
+assert_grep "worktrees/pr-" "$MERGE_PR_SH" \
+    "merge-pr.sh cleans up .loom/worktrees/pr-<N>/ path"
+# Confirm the loose trailing-digit heuristic is gone
+if grep -q "grep -oE '\[0-9\]+\$'" "$MERGE_PR_SH"; then
+    fail "merge-pr.sh still uses the loose trailing-digit regex (should be tightened)"
+else
+    pass "loose trailing-digit regex no longer present in merge-pr.sh"
+fi
+
+# --- Test 3: doctor.md documents PR Branch Isolation ---
+echo ""
+echo "Test 3: doctor.md documents the worktree-isolation rule"
+assert_grep "PR Branch Isolation" "$DOCTOR_MD" \
+    "doctor.md has a 'PR Branch Isolation' section"
+assert_grep "pr-worktree\.sh" "$DOCTOR_MD" \
+    "doctor.md references pr-worktree.sh helper"
+assert_grep "\^feature/issue-" "$DOCTOR_MD" \
+    "doctor.md documents the feature/issue-<N> regex heuristic"
+
+# --- Test 4: branch-to-worktree classification (in-script regex simulation) ---
+echo ""
+echo "Test 4: branch classification regex (simulated)"
+
+classify_branch() {
+    local branch="$1"
+    if [[ "$branch" =~ ^feature/issue-([0-9]+)$ ]]; then
+        echo "issue:${BASH_REMATCH[1]}"
+    else
+        echo "pr"
+    fi
+}
+
+assert_classify() {
+    local branch="$1" expected="$2"
+    local got
+    got=$(classify_branch "$branch")
+    if [[ "$got" == "$expected" ]]; then
+        pass "branch '$branch' -> $expected"
+    else
+        fail "branch '$branch' expected '$expected', got '$got'"
+    fi
+}
+
+assert_classify "feature/issue-42"      "issue:42"
+assert_classify "feature/issue-3358"    "issue:3358"
+assert_classify "fix/foo-bar"           "pr"
+assert_classify "release-1"             "pr"            # tightening fix: no longer matches issue style
+assert_classify "fix-bug-42"            "pr"            # tightening fix: no longer matches issue style
+assert_classify "feature/issue-42-fix"  "pr"            # extra suffix -> not strict match
+assert_classify "jperla/fix-thing"      "pr"
+assert_classify "main"                  "pr"
+
+# --- Test 5: simulated doctor pass leaves orchestrator HEAD unchanged ---
+echo ""
+echo "Test 5: doctor pass on 'fix/foo-bar' does not move orchestrator HEAD"
+
+TMP=$(mktemp -d /tmp/loom-pr-iso-test.XXXXXX)
+trap 'rm -rf "$TMP"; cd "$REPO_ROOT" 2>/dev/null || true' EXIT
+
+# Build a tiny throwaway repo so we exercise real git commands without
+# touching the real workspace. We simulate the doctor's worktree-creation
+# step only — we don't call `gh pr checkout` since there is no live forge.
+git init -q -b main "$TMP/origin.git" --bare
+git init -q -b main "$TMP/repo"
+cd "$TMP/repo"
+git config user.email t@t
+git config user.name t
+git commit --allow-empty -q -m init
+git remote add origin "$TMP/origin.git"
+git push -q origin main
+
+ORCH_HEAD_BEFORE=$(git rev-parse HEAD)
+ORCH_BRANCH_BEFORE=$(git rev-parse --abbrev-ref HEAD)
+
+# Simulate what the corrected doctor flow does for an external-fork PR
+# whose branch is `fix/foo-bar`: create a `pr-<N>` worktree from origin/main
+# and "check out" a synthetic PR branch INSIDE that worktree. We don't have a
+# real PR, so we substitute a fake branch ref pointing at origin/main and
+# check it out inside the dedicated worktree.
+PR_NUM=999
+PR_BRANCH="fix/foo-bar"
+git update-ref "refs/heads/$PR_BRANCH" HEAD
+git worktree add --detach ".loom/worktrees/pr-$PR_NUM" origin/main >/dev/null 2>&1
+
+# Write a sentinel mirroring pr-worktree.sh
+mkdir -p ".loom/worktrees/pr-$PR_NUM"
+cat > ".loom/worktrees/pr-$PR_NUM/.loom-managed" <<EOF
+# Loom-managed worktree marker
+# PR: $PR_NUM
+EOF
+
+# Now "check out" the PR branch from INSIDE the worktree.
+(cd ".loom/worktrees/pr-$PR_NUM" && git checkout "$PR_BRANCH" >/dev/null 2>&1)
+
+ORCH_HEAD_AFTER=$(git rev-parse HEAD)
+ORCH_BRANCH_AFTER=$(git rev-parse --abbrev-ref HEAD)
+
+if [[ "$ORCH_HEAD_BEFORE" == "$ORCH_HEAD_AFTER" ]]; then
+    pass "orchestrator HEAD SHA unchanged after PR-worktree checkout"
+else
+    fail "orchestrator HEAD moved: $ORCH_HEAD_BEFORE -> $ORCH_HEAD_AFTER"
+fi
+if [[ "$ORCH_BRANCH_BEFORE" == "$ORCH_BRANCH_AFTER" ]]; then
+    pass "orchestrator branch unchanged ($ORCH_BRANCH_BEFORE)"
+else
+    fail "orchestrator branch moved: $ORCH_BRANCH_BEFORE -> $ORCH_BRANCH_AFTER"
+fi
+
+# Verify the worktree got the fork branch checked out
+WT_BRANCH=$(git -C ".loom/worktrees/pr-$PR_NUM" rev-parse --abbrev-ref HEAD)
+if [[ "$WT_BRANCH" == "$PR_BRANCH" ]]; then
+    pass "PR worktree HEAD is on '$PR_BRANCH'"
+else
+    fail "PR worktree HEAD expected '$PR_BRANCH', got '$WT_BRANCH'"
+fi
+
+# Verify sentinel exists in the pr-<N> worktree
+if [[ -f ".loom/worktrees/pr-$PR_NUM/.loom-managed" ]]; then
+    pass "pr-$PR_NUM worktree has .loom-managed sentinel"
+else
+    fail "pr-$PR_NUM worktree missing .loom-managed sentinel"
+fi
+
+cd "$REPO_ROOT"
+
+# --- Summary ---
+echo ""
+echo "Tests run: $TESTS_RUN, Passed: $TESTS_PASSED, Failed: $TESTS_FAILED"
+[[ $TESTS_FAILED -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

When `/loom:doctor` (or any subagent) ran on an external-fork PR — i.e., a PR whose branch did not match `feature/issue-<N>` — it had no dedicated worktree path to use and fell through to `gh pr checkout <N>` in the orchestrator's main worktree. That switched the orchestrator's `HEAD` off `main` and could leave behind untracked files from the PR (concrete v0.9.0 incident: jperla's #3348 left `src-tauri/` orphans behind).

This PR makes the doctor route every PR through an isolated worktree before any `gh pr checkout` mutation:

- New helper `defaults/scripts/pr-worktree.sh` creates `.loom/worktrees/pr-<PR_NUMBER>/` (with `.loom-managed` sentinel — `# PR: <N>` mirroring the worktree.sh `# Issue: <N>` convention) and runs `gh pr checkout` from inside the worktree so the orchestrator HEAD never moves.
- `defaults/.claude/commands/loom/doctor.md` documents the branch-name heuristic and updates every `gh pr checkout` invocation site (unlabeled-PR fallback, explicit-user-instruction example, standard PR-fix flow, "Example Commands" block, and the "Notes" section) to dispatch through the right helper.
- `defaults/scripts/merge-pr.sh` tightens the branch-to-issue regex from the loose `[0-9]+$` heuristic (which incorrectly matched `release-1`, `fix-bug-42`, etc.) to the strict `^feature/issue-([0-9]+)$` pattern, and adds a parallel cleanup path for `.loom/worktrees/pr-<N>/`.
- `defaults/scripts/tests/test-pr-worktree-isolation.sh` is a regression test covering branch classification, sentinel placement, the strict-regex tightening, and the load-bearing invariant: after a simulated doctor pass on `fix/foo-bar`, the orchestrator's CWD HEAD/branch is unchanged.

`.claude/commands/` is a symlink to `defaults/.claude/commands/` in this repo so the doctor.md update propagates without a separate copy.

Closes #3358

## Test plan

- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` passes (14 + 10 doc tests)
- [x] `bash .loom/scripts/tests/test-pr-worktree-isolation.sh` — 22/22 pass (new regression test)
- [x] `bash .loom/scripts/tests/test-worktree-sentinel.sh` — 10/10 pass (unchanged ownership-model contract)
- [x] `bash .loom/scripts/tests/test-merge-pr-help.sh` — 12/12 pass (no regression in `--help` surface)
- [x] All 9 shell test suites green
- [x] doctor pass on `feature/issue-N` branch → uses `.loom/worktrees/issue-N/` (regression preserved)
- [x] doctor pass on `fix/foo-bar` branch → uses `.loom/worktrees/pr-<N>/` (new)
- [x] merge-pr.sh cleans up both worktree forms
- [x] `release-1`, `fix-bug-42`, `feature/issue-42-fix` correctly classify as PR-style (regex tightening)

🤖 Generated with [Claude Code](https://claude.com/claude-code)