### PR TITLE
docs(roles): add curator/architect playbook entries for multi-phase sweeps

### DIFF
--- a/defaults/.claude/commands/loom/architect.md
+++ b/defaults/.claude/commands/loom/architect.md
@@ -253,6 +253,7 @@ gh issue edit <number> --add-label "loom:epic"
 - **Be practical**: Consider implementation effort and risk
 - **Be patient**: Wait for approval before work begins
 - **Focus on architecture**: Leave implementation details to worker agents
+- **Mark enumerations as non-exhaustive**: When listing specific callers/sites/files in an issue body, label the list as "starting point — curator must verify" rather than asserting completeness. LLM enumeration of "find all X" is reliably under-inclusive.
 
 ---
 

--- a/defaults/.claude/commands/loom/curator.md
+++ b/defaults/.claude/commands/loom/curator.md
@@ -145,6 +145,13 @@ gh issue list --label="loom:issue" --state=open --json number,title,labels,updat
   "#\(.number) (updated \(.updatedAt)): \(.title)"'
 ```
 
+### Multi-phase sweep dependency check
+
+> **Multi-phase sweep dependency check.** If the issue you're curating is part of an epic/phase chain (`loom:epic-phase` label, or body references a sibling phase that may have just merged):
+> 1. Run `git fetch origin main` before reading any file.
+> 2. Read dependency files from `origin/main` directly (`git show origin/main:path/to/file`) rather than the local checkout, which may pre-date sibling merges in the same /sweep session.
+> 3. If your verification finds that "Phase N didn't deliver X", explicitly check whether X is on `origin/main` before filing it as a blocker.
+
 ### Priority 2: Unlabeled Issues (Fallback)
 
 If no Priority 1 issues exist, find unlabeled issues:
@@ -300,6 +307,10 @@ The Builder's complexity-assessment path (`defaults/.claude/commands/loom/builde
 - Document implementation options and trade-offs
 - Add planning details (architecture, dependencies, risks)
 - Assess and add `loom:urgent` label if issue is time-sensitive or critical
+
+### Verify enumerations
+
+> **Verify enumerations.** If the issue body lists specific callers, files, sites, or line numbers, treat the enumeration as a *starting point*, not authoritative. Run a comprehensive `git ls-files <pattern> | xargs grep -nE '<pattern>'` to verify completeness. Report any additions in your curator comment so the builder gets the correct scope.
 
 ### Process-Improvement Issues
 


### PR DESCRIPTION
## Summary

Pure docs-only PR. Three additions across two role files, each using the verbatim text from issue #3365's "Suggested addition" blocks:

- **`defaults/.claude/commands/loom/curator.md`** — new `### Multi-phase sweep dependency check` subsection under `## Finding Work` (sibling of `### Re-curating Approved Issues`). Tells curators to `git fetch origin main` and read dependency files from `origin/main` directly (`git show origin/main:path/to/file`) before filing blockers in multi-phase `/sweep` sessions where sibling phases may have just merged.
- **`defaults/.claude/commands/loom/curator.md`** — new `### Verify enumerations` subsection under `## Curation Activities` (between `### Enhancement` and `### Process-Improvement Issues`). Tells curators to treat issue-body enumerations (callers, files, sites, line numbers) as starting points and verify completeness via `git ls-files <pattern> | xargs grep -nE '<pattern>'`.
- **`defaults/.claude/commands/loom/architect.md`** — new `**Mark enumerations as non-exhaustive**` bullet under `## Guidelines`. Tells architects to label specific enumerations as "starting point — curator must verify" rather than asserting completeness, since LLM "find all X" is reliably under-inclusive.

Both patterns surfaced repeatedly during a `/sweep` of a 7-phase epic in a downstream consumer repo (sphere #8798) — neither pattern is sphere-specific; both generalize to any multi-phase Loom epic and any architect-authored issue with caller enumerations.

The `defaults/.claude/commands/loom/architect-patterns.md` stretch goal flagged by the curator is intentionally skipped to keep the PR surgical.

## Test plan

No automated tests for docs-only changes; the test plan is heading-grep + diff-stat sanity checks:

- [x] `git diff --stat` shows only the two role files with `12 insertions(+)` and no deletions (pure additions diff).
- [x] `grep -n '^### ' defaults/.claude/commands/loom/curator.md` shows the new `Multi-phase sweep dependency check` (line 148) and `Verify enumerations` (line 311) headings nested correctly under their parent `##` sections, with no existing headings missing or reordered.
- [x] `grep -nE '^- \*\*' defaults/.claude/commands/loom/architect.md | grep -i enumer` returns the new `Mark enumerations as non-exhaustive` bullet (line 256) under `## Guidelines`.
- [x] Suggested text is used verbatim from the issue body's `> blockquote` blocks — no paraphrasing.
- [ ] Markdown renders cleanly in the GitHub PR preview (no broken lists, no orphaned headings, no unclosed code fences).

Closes #3365

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>