### PR TITLE
fix(merge-pr): add --worktree-path override + porcelain warn-only fallback (#3364)

### DIFF
--- a/defaults/scripts/merge-pr.sh
+++ b/defaults/scripts/merge-pr.sh
@@ -11,6 +11,11 @@
 # Options:
 #   --no-cleanup-worktree  Skip local worktree cleanup after merge
 #   --cleanup-worktree     (no-op, worktree cleanup is now the default)
+#   --worktree-path <dir>  Explicit worktree path to clean up (bypasses
+#                          .loom-managed sentinel guard — caller asserts
+#                          responsibility). Also deletes the matching local
+#                          branch via `git branch -d` (refuses on unmerged
+#                          commits — Git's own safety check).
 #   --dry-run              Show what would happen without merging
 #   --auto                 Enable auto-merge instead of immediate merge
 #
@@ -22,6 +27,13 @@
 # .loom-managed sentinel written by worktree.sh). Worktrees lacking the
 # sentinel are treated as user-owned and never removed. Set
 # LOOM_PRESERVE_WORKTREE=1 to disable cleanup unconditionally for a session.
+#
+# Override: pass --worktree-path <dir> to opt into removing a non-Loom
+# worktree (the sentinel guard is bypassed only when this flag is supplied).
+# Discovery: if neither the default issue-N nor pr-N worktree exists, the
+# script walks `git worktree list --porcelain` looking for a worktree whose
+# branch matches the merged PR's head branch. It emits a hint (not an
+# auto-remove) so the operator can re-run with --worktree-path.
 #
 # Exit codes:
 #   0 = merged (or auto-merge enabled)
@@ -57,6 +69,12 @@ Supports both GitHub and Gitea forges. Forge detection is automatic
 Options:
   --no-cleanup-worktree  Skip local worktree cleanup after merge
   --cleanup-worktree     (no-op, worktree cleanup is now the default)
+  --worktree-path <dir>  Explicit worktree path to clean up. Bypasses the
+                         .loom-managed sentinel guard (caller asserts
+                         responsibility — this is the documented opt-in
+                         for removing non-Loom worktrees). Also deletes
+                         the matching local branch via 'git branch -d'
+                         (Git refuses on unmerged commits).
   --dry-run              Show what would happen without merging
   --auto                 Enable auto-merge instead of immediate merge
   -h, --help             Show this help and exit
@@ -68,8 +86,27 @@ have their CWD inside the worktree).
 Cleanup is restricted to Loom-managed worktrees (those under
 .loom/worktrees/issue-N that contain a .loom-managed sentinel file written
 by worktree.sh). User-provisioned worktrees at other paths are never
-removed. Set LOOM_PRESERVE_WORKTREE=1 to disable cleanup unconditionally
-for a session.
+removed by the default code path. Set LOOM_PRESERVE_WORKTREE=1 to disable
+cleanup unconditionally for a session.
+
+When --worktree-path <dir> is passed explicitly, the operator is taking
+responsibility for the cleanup decision: the sentinel guard is bypassed
+for that one path. The path is validated against 'git worktree list'
+and rejected if it is not a worktree of this repository.
+
+Discovery fallback: if neither .loom/worktrees/issue-N/ nor
+.loom/worktrees/pr-<PR_NUMBER>/ exists, the script walks
+'git worktree list --porcelain' looking for a worktree whose branch
+matches the merged PR head branch. It NEVER auto-removes a discovered
+user-owned worktree; it only logs the path and suggests re-running with
+--worktree-path <found-path>.
+
+Precedence (highest wins):
+  1. LOOM_PRESERVE_WORKTREE=1     (always skip cleanup)
+  2. --no-cleanup-worktree        (always skip cleanup; warns if combined
+                                  with --worktree-path)
+  3. --worktree-path <dir>        (explicit path; bypasses sentinel)
+  4. default: .loom/worktrees/issue-N or pr-N + sentinel guard
 
 Exit codes:
   0 = merged (or auto-merge enabled, or --help)
@@ -87,6 +124,10 @@ Examples:
 
   ./.loom/scripts/merge-pr.sh 123 --no-cleanup-worktree
     Merges PR but leaves the local worktree in place
+
+  ./.loom/scripts/merge-pr.sh 123 --worktree-path ../adhoc-wt
+    Merges PR #123 and removes the worktree at ../adhoc-wt plus its
+    matching local branch (bypasses the .loom-managed sentinel guard).
 EOF
 }
 
@@ -148,11 +189,22 @@ PR_NUMBER=""
 CLEANUP_WORKTREE=true
 DRY_RUN=false
 AUTO_MERGE=false
+WORKTREE_PATH_OVERRIDE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --cleanup-worktree) shift ;;  # no-op, cleanup is now the default
     --no-cleanup-worktree) CLEANUP_WORKTREE=false; shift ;;
+    --worktree-path)
+      [[ $# -lt 2 ]] && error "--worktree-path requires a value"
+      WORKTREE_PATH_OVERRIDE="$2"
+      shift 2
+      ;;
+    --worktree-path=*)
+      WORKTREE_PATH_OVERRIDE="${1#--worktree-path=}"
+      [[ -z "$WORKTREE_PATH_OVERRIDE" ]] && error "--worktree-path= requires a value"
+      shift
+      ;;
     --dry-run) DRY_RUN=true; shift ;;
     --auto) AUTO_MERGE=true; shift ;;
     -*)  error "Unknown option: $1" ;;
@@ -167,8 +219,34 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-[[ -z "$PR_NUMBER" ]] && error "Usage: merge-pr.sh <pr-number> [--no-cleanup-worktree] [--dry-run] [--auto]"
+[[ -z "$PR_NUMBER" ]] && error "Usage: merge-pr.sh <pr-number> [--no-cleanup-worktree] [--worktree-path <dir>] [--dry-run] [--auto]"
 [[ "$PR_NUMBER" =~ ^[0-9]+$ ]] || error "PR number must be numeric: $PR_NUMBER"
+
+# Validate --worktree-path early (before any network calls) so bad input
+# fails fast. The path must be a real directory and must appear in the
+# repository's worktree list. We resolve to an absolute path via cd so
+# downstream comparisons against the porcelain output work cleanly.
+if [[ -n "$WORKTREE_PATH_OVERRIDE" ]]; then
+  if [[ ! -d "$WORKTREE_PATH_OVERRIDE" ]]; then
+    error "--worktree-path does not exist or is not a directory: $WORKTREE_PATH_OVERRIDE"
+  fi
+  _WT_ABS="$(cd "$WORKTREE_PATH_OVERRIDE" 2>/dev/null && pwd -P)" || \
+    error "--worktree-path could not be resolved: $WORKTREE_PATH_OVERRIDE"
+  # Verify the path is actually a worktree of this repo. `git worktree list`
+  # prints absolute paths in column 1; awk on $1 is robust to trailing
+  # metadata columns. We compare against the resolved absolute path.
+  if ! git -C "$REPO_ROOT" worktree list --porcelain 2>/dev/null | \
+       awk -v p="$_WT_ABS" '/^worktree / { if ($2 == p) { found=1; exit } } END { exit !found }'; then
+    error "--worktree-path is not a registered worktree of this repository: $WORKTREE_PATH_OVERRIDE (resolved: $_WT_ABS)"
+  fi
+  WORKTREE_PATH_OVERRIDE="$_WT_ABS"
+  unset _WT_ABS
+
+  # Warn if combined with --no-cleanup-worktree (no-op wins).
+  if [[ "$CLEANUP_WORKTREE" == "false" ]]; then
+    warning "--worktree-path was supplied but --no-cleanup-worktree wins; no cleanup will occur"
+  fi
+fi
 
 # Fetch PR state
 PR_JSON=$(forge_get_pr "$REPO_NWO" "$PR_NUMBER" "$GH") || \
@@ -404,15 +482,80 @@ fi
 # Branch-to-issue regex is the strict `^feature/issue-([0-9]+)$` pattern so
 # branches like `release-1` or `fix-bug-42` correctly classify as PR-style
 # (not issue-style) and clean up the right worktree.
+# Look up the branch attached to a worktree via porcelain. Prints the branch
+# short-name (without refs/heads/ prefix) on stdout. Returns 0 with empty
+# output for detached / bare worktrees (no branch line in the stanza).
+_worktree_branch_for() {
+  local target="$1" target_abs
+  target_abs="$(cd "$target" 2>/dev/null && pwd -P)" || target_abs="$target"
+  git -C "$REPO_ROOT" worktree list --porcelain 2>/dev/null | \
+    awk -v p="$target_abs" '
+      /^worktree / { wt=$2; br=""; next }
+      /^branch /   { br=$2 }
+      /^$/         { if (wt == p && br != "") { sub(/^refs\/heads\//, "", br); print br; exit } }
+      END          { if (wt == p && br != "") { sub(/^refs\/heads\//, "", br); print br } }
+    '
+}
+
+# Walk porcelain output for a worktree whose branch matches the given branch
+# short-name. Prints the worktree absolute path or nothing. Skips detached /
+# bare entries (they have no `branch refs/heads/...` line).
+_find_worktree_by_branch() {
+  local want_branch="$1"
+  git -C "$REPO_ROOT" worktree list --porcelain 2>/dev/null | \
+    awk -v want="refs/heads/${want_branch}" '
+      /^worktree / { wt=$2; br=""; next }
+      /^branch /   { br=$2 }
+      /^$/         { if (br == want) { print wt; exit } }
+      END          { if (br == want) { print wt } }
+    '
+}
+
+# Delete the matching local branch. Uses `git branch -d` (not -D) so unmerged
+# commits abort the delete — that's the right safety net. Never fails the
+# cleanup pipeline; warns on errors.
+_maybe_delete_local_branch() {
+  local branch="$1"
+  if [[ -z "$branch" ]]; then
+    return 0
+  fi
+  if ! git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/$branch"; then
+    info "Local branch '$branch' does not exist — skipping branch delete"
+    return 0
+  fi
+  if git -C "$REPO_ROOT" branch -d "$branch" 2>/dev/null; then
+    success "Local branch '$branch' deleted"
+  else
+    warning "Could not delete local branch '$branch' (may have unmerged commits — use 'git branch -D' if intentional)"
+  fi
+}
+
+# _remove_loom_worktree <path> [allow_unmanaged]
+#
+# When allow_unmanaged is "true" (only set by the --worktree-path code path),
+# the .loom-managed sentinel check is skipped — the caller has taken explicit
+# responsibility for the cleanup decision. The default (no second arg, or
+# "false") preserves the original sentinel guard.
 _remove_loom_worktree() {
   local worktree_path="$1"
+  local allow_unmanaged="${2:-false}"
   if [[ ! -d "$worktree_path" ]]; then
     info "No worktree found at $worktree_path"
     return 0
   fi
-  if [[ ! -f "$worktree_path/.loom-managed" ]]; then
+  if [[ "$allow_unmanaged" != "true" ]] && [[ ! -f "$worktree_path/.loom-managed" ]]; then
     warning "Worktree at $worktree_path lacks .loom-managed sentinel — refusing to remove (user-owned)"
     return 0
+  fi
+  if [[ "$allow_unmanaged" == "true" ]] && [[ ! -f "$worktree_path/.loom-managed" ]]; then
+    info "Bypassing sentinel guard (--worktree-path explicit opt-in for $worktree_path)"
+  fi
+  # Record the attached branch BEFORE removing the worktree (the porcelain
+  # entry vanishes once the worktree is gone). Only relevant when allow_unmanaged
+  # — the default issue/pr path already has the branch encoded in PR_BRANCH.
+  local attached_branch=""
+  if [[ "$allow_unmanaged" == "true" ]]; then
+    attached_branch="$(_worktree_branch_for "$worktree_path")"
   fi
   # If our shell is inside the worktree we're removing, hop out first.
   local current_dir worktree_real in_worktree=false
@@ -431,6 +574,12 @@ _remove_loom_worktree() {
       warning "Run this command to fix:"
       echo "  cd $REPO_ROOT"
     fi
+    # For the explicit-override path, also tidy up the attached local branch.
+    # We defer this to AFTER `git worktree remove` succeeds so the worktree's
+    # checkout lock is released first.
+    if [[ "$allow_unmanaged" == "true" ]] && [[ -n "$attached_branch" ]]; then
+      _maybe_delete_local_branch "$attached_branch"
+    fi
   else
     warning "Could not remove worktree at $worktree_path"
   fi
@@ -439,16 +588,49 @@ _remove_loom_worktree() {
 if [[ "$CLEANUP_WORKTREE" == "true" ]]; then
   if [[ "${LOOM_PRESERVE_WORKTREE:-0}" == "1" ]]; then
     info "Worktree cleanup skipped (LOOM_PRESERVE_WORKTREE=1)"
+  elif [[ -n "$WORKTREE_PATH_OVERRIDE" ]]; then
+    # Explicit operator opt-in: bypass the sentinel guard for THIS path only.
+    # The path was already validated at parse time (exists + is a registered
+    # worktree of this repo). _remove_loom_worktree will also delete the
+    # matching local branch via `git branch -d` (refuses on unmerged commits).
+    info "Cleanup target overridden by --worktree-path: $WORKTREE_PATH_OVERRIDE"
+    _remove_loom_worktree "$WORKTREE_PATH_OVERRIDE" "true"
   else
     # Strict pattern: only `feature/issue-<N>` matches. Trailing-number
     # heuristics would misclassify branches like `release-1`.
+    DEFAULT_WT_PATH=""
     if [[ "$PR_BRANCH" =~ ^feature/issue-([0-9]+)$ ]]; then
       ISSUE_NUM="${BASH_REMATCH[1]}"
-      _remove_loom_worktree "$REPO_ROOT/.loom/worktrees/issue-$ISSUE_NUM"
+      DEFAULT_WT_PATH="$REPO_ROOT/.loom/worktrees/issue-$ISSUE_NUM"
     else
       # External-fork / ad-hoc branch — the doctor would have used a
       # `pr-<PR_NUMBER>` worktree if any.
-      _remove_loom_worktree "$REPO_ROOT/.loom/worktrees/pr-$PR_NUMBER"
+      DEFAULT_WT_PATH="$REPO_ROOT/.loom/worktrees/pr-$PR_NUMBER"
+    fi
+    if [[ -d "$DEFAULT_WT_PATH" ]]; then
+      _remove_loom_worktree "$DEFAULT_WT_PATH"
+    else
+      # Discovery fallback (warn-only): the Loom-convention path is missing,
+      # so walk porcelain looking for any worktree tracking $PR_BRANCH. We
+      # never auto-remove a discovered worktree — that would violate the
+      # ownership model from #3334. Instead we surface the path so the
+      # operator can re-run with --worktree-path.
+      DISCOVERED_WT="$(_find_worktree_by_branch "$PR_BRANCH")"
+      if [[ -n "$DISCOVERED_WT" ]]; then
+        if [[ -f "$DISCOVERED_WT/.loom-managed" ]]; then
+          # Rare case: Loom-managed worktree at a non-standard path. The
+          # sentinel says it's safe to remove, so do so.
+          info "Discovered Loom-managed worktree at non-standard path: $DISCOVERED_WT"
+          _remove_loom_worktree "$DISCOVERED_WT"
+        else
+          warning "Discovered worktree for branch '$PR_BRANCH' at: $DISCOVERED_WT"
+          warning "Worktree lacks .loom-managed sentinel — not removing (user-owned)."
+          warning "To clean it up, re-run with: --worktree-path '$DISCOVERED_WT'"
+          warning "Or manually: git worktree remove '$DISCOVERED_WT'"
+        fi
+      else
+        info "No worktree found at $DEFAULT_WT_PATH (and none tracking '$PR_BRANCH' in 'git worktree list')"
+      fi
     fi
   fi
 fi

--- a/defaults/scripts/tests/test-merge-pr-help.sh
+++ b/defaults/scripts/tests/test-merge-pr-help.sh
@@ -74,6 +74,10 @@ assert_contains "$HELP_OUTPUT" "--auto" "--help output mentions --auto"
 assert_contains "$HELP_OUTPUT" "--dry-run" "--help output mentions --dry-run"
 assert_contains "$HELP_OUTPUT" "--no-cleanup-worktree" "--help output mentions --no-cleanup-worktree"
 assert_contains "$HELP_OUTPUT" "-h, --help" "--help output documents -h/--help"
+# Issue #3364: --worktree-path override flag for non-Loom worktrees
+assert_contains "$HELP_OUTPUT" "--worktree-path" "--help output mentions --worktree-path (#3364)"
+assert_contains "$HELP_OUTPUT" "sentinel guard" "--help explains the sentinel-guard bypass semantics"
+assert_contains "$HELP_OUTPUT" "--worktree-path ../adhoc-wt" "--help shows a --worktree-path example"
 
 # --- Test: -h exits 0 with same usage ---
 echo ""

--- a/defaults/scripts/tests/test-merge-pr-worktree-path.sh
+++ b/defaults/scripts/tests/test-merge-pr-worktree-path.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+# test-merge-pr-worktree-path.sh - Tests for the --worktree-path flag (#3364)
+#
+# Verifies:
+#   1. --worktree-path appears in --help output (composition with help test).
+#   2. CLI rejects bad input early: missing value, nonexistent path,
+#      registered-worktree validation.
+#   3. The script's source contains the bypass-sentinel logic and the
+#      porcelain discovery fallback (static grep checks — full integration
+#      requires a live forge).
+#   4. Inline simulation of the cleanup decision tree:
+#      - LOOM_PRESERVE_WORKTREE=1 wins
+#      - --no-cleanup-worktree wins over --worktree-path
+#      - --worktree-path bypasses sentinel on the explicit path
+#      - default path keeps sentinel guard
+#      - discovery fallback emits hint without removing
+#
+# This is the companion to test-merge-pr-help.sh. The help test verifies
+# the documentation surface; this test verifies the implementation surface.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+MERGE_PR="$SCRIPTS_DIR/merge-pr.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1)); echo -e "  ${RED}FAIL${NC}: $1"; }
+
+assert_grep() {
+    local pattern="$1" file="$2" msg="$3"
+    if grep -qE "$pattern" "$file"; then pass "$msg"; else fail "$msg (pattern: $pattern)"; fi
+}
+
+[[ -x "$MERGE_PR" ]] || { echo "ERROR: $MERGE_PR not executable" >&2; exit 1; }
+
+# --- Test 1: CLI parsing rejects bad input early ---
+echo "Test 1: CLI rejects bad --worktree-path input"
+
+# Missing value
+set +e
+out=$("$MERGE_PR" 1 --worktree-path 2>&1)
+rc=$?
+set -e
+if [[ $rc -ne 0 ]] && [[ "$out" == *"--worktree-path requires a value"* ]]; then
+    pass "missing value for --worktree-path errors with rc!=0 and clear message"
+else
+    fail "missing value: expected nonzero exit + message; got rc=$rc, out='$out'"
+fi
+
+# Nonexistent path
+set +e
+out=$("$MERGE_PR" --worktree-path /nonexistent-loom-test-path 1 2>&1)
+rc=$?
+set -e
+if [[ $rc -ne 0 ]] && [[ "$out" == *"does not exist"* ]]; then
+    pass "nonexistent --worktree-path errors with rc!=0 and clear message"
+else
+    fail "nonexistent path: expected nonzero exit + message; got rc=$rc, out='$out'"
+fi
+
+# Path exists but is not a registered worktree of this repo
+set +e
+out=$("$MERGE_PR" --worktree-path /tmp 1 2>&1)
+rc=$?
+set -e
+if [[ $rc -ne 0 ]] && [[ "$out" == *"not a registered worktree"* ]]; then
+    pass "unregistered --worktree-path errors with rc!=0 and clear message"
+else
+    fail "unregistered path: expected nonzero exit + message; got rc=$rc, out='$out'"
+fi
+
+# --- Test 2: Source contains the expected logic surface ---
+echo ""
+echo "Test 2: merge-pr.sh source contains the new logic blocks"
+
+assert_grep "WORKTREE_PATH_OVERRIDE=" "$MERGE_PR" \
+    "merge-pr.sh declares WORKTREE_PATH_OVERRIDE state variable"
+assert_grep "_find_worktree_by_branch" "$MERGE_PR" \
+    "merge-pr.sh defines the porcelain branch-search helper"
+assert_grep "_worktree_branch_for" "$MERGE_PR" \
+    "merge-pr.sh defines the worktree-to-branch lookup helper"
+assert_grep "_maybe_delete_local_branch" "$MERGE_PR" \
+    "merge-pr.sh defines the safe local-branch delete helper"
+assert_grep "git branch -d" "$MERGE_PR" \
+    "merge-pr.sh uses git branch -d (safe delete, not -D)"
+assert_grep "allow_unmanaged" "$MERGE_PR" \
+    "_remove_loom_worktree takes allow_unmanaged second arg"
+assert_grep "Bypassing sentinel guard" "$MERGE_PR" \
+    "explicit --worktree-path logs the sentinel-bypass action"
+assert_grep "Discovered worktree for branch" "$MERGE_PR" \
+    "discovery fallback emits a hint about the discovered path"
+assert_grep "re-run with: --worktree-path" "$MERGE_PR" \
+    "discovery fallback suggests --worktree-path in the hint"
+
+# --- Test 3: Precedence — --no-cleanup-worktree warns when combined ---
+echo ""
+echo "Test 3: --no-cleanup-worktree wins over --worktree-path"
+
+# This requires a registered worktree path. Use the script's own repo root
+# (the worktree this test is running inside).
+SELF_WT="$(cd "$SCRIPT_DIR/../../.." && pwd -P)"
+# Resolve the worktree's actual recorded path via porcelain — git's worktree
+# list uses the canonical recorded path which may differ from $PWD if there
+# are symlinks.
+ACTUAL_WT="$(cd "$SELF_WT" && git rev-parse --show-toplevel 2>/dev/null || echo "")"
+
+if [[ -n "$ACTUAL_WT" ]] && git -C "$ACTUAL_WT" worktree list --porcelain 2>/dev/null | \
+   awk -v p="$ACTUAL_WT" '/^worktree / { if ($2 == p) { found=1; exit } } END { exit !found }'; then
+    # We're in a worktree; we can use ACTUAL_WT as a valid --worktree-path value.
+    # Run with --dry-run so the merge itself short-circuits (we only want to see
+    # the validation + warning).
+    set +e
+    out=$("$MERGE_PR" --no-cleanup-worktree --worktree-path "$ACTUAL_WT" 1 --dry-run 2>&1)
+    rc=$?
+    set -e
+    if [[ "$out" == *"--no-cleanup-worktree wins"* ]]; then
+        pass "combining --no-cleanup-worktree + --worktree-path warns"
+    else
+        fail "expected '--no-cleanup-worktree wins' warning; got: $out"
+    fi
+else
+    echo "  SKIP: not running inside a registered worktree, skipping precedence test"
+fi
+
+# --- Test 4: Inline simulation of the cleanup decision tree ---
+echo ""
+echo "Test 4: cleanup decision tree (inline simulation)"
+
+# Replicate the decision shape from merge-pr.sh's cleanup driver so we can
+# exercise every branch without a live forge round-trip.
+simulate_cleanup() {
+    # Args:
+    #   $1 preserve            ("0" / "1")        # LOOM_PRESERVE_WORKTREE
+    #   $2 cleanup             ("true" / "false") # --no-cleanup-worktree => false
+    #   $3 override            (string or "")     # --worktree-path value
+    #   $4 default_exists      ("true" / "false") # whether .loom/worktrees/issue-N exists
+    #   $5 override_has_sentinel ("true" / "false") # does override path have .loom-managed
+    #   $6 discovered          (string or "")     # discovered worktree path
+    #   $7 discovered_has_sentinel ("true" / "false")
+    local preserve="$1" cleanup="$2" override="$3" default_exists="$4" \
+          override_has_sentinel="$5" discovered="$6" discovered_has_sentinel="$7"
+
+    if [[ "$cleanup" != "true" ]]; then
+        echo "skip:no-cleanup"; return 0
+    fi
+    if [[ "$preserve" == "1" ]]; then
+        echo "skip:env"; return 0
+    fi
+    if [[ -n "$override" ]]; then
+        # --worktree-path bypasses sentinel
+        if [[ "$override_has_sentinel" == "true" ]]; then
+            echo "remove:override-managed"
+        else
+            echo "remove:override-bypass-sentinel"
+        fi
+        return 0
+    fi
+    if [[ "$default_exists" == "true" ]]; then
+        echo "remove:default"
+        return 0
+    fi
+    # Fallback discovery
+    if [[ -n "$discovered" ]]; then
+        if [[ "$discovered_has_sentinel" == "true" ]]; then
+            echo "remove:discovered-managed"
+        else
+            echo "warn:discovered-user-owned"
+        fi
+        return 0
+    fi
+    echo "skip:nothing-to-do"
+}
+
+# Args: preserve cleanup override default_exists override_has_sentinel discovered discovered_has_sentinel
+
+# Case A: LOOM_PRESERVE_WORKTREE=1 wins over everything
+result=$(simulate_cleanup 1 true "/path/x" false true "" false)
+if [[ "$result" == "skip:env" ]]; then
+    pass "case A: LOOM_PRESERVE_WORKTREE=1 short-circuits everything"
+else
+    fail "case A: expected 'skip:env', got '$result'"
+fi
+
+# Case B: --no-cleanup-worktree wins (cleanup=false)
+result=$(simulate_cleanup 0 false "/path/x" false true "" false)
+if [[ "$result" == "skip:no-cleanup" ]]; then
+    pass "case B: --no-cleanup-worktree short-circuits even with override"
+else
+    fail "case B: expected 'skip:no-cleanup', got '$result'"
+fi
+
+# Case C: --worktree-path bypasses sentinel (no sentinel on override path)
+result=$(simulate_cleanup 0 true "/path/x" true false "" false)
+if [[ "$result" == "remove:override-bypass-sentinel" ]]; then
+    pass "case C: --worktree-path bypasses sentinel for non-Loom worktree"
+else
+    fail "case C: expected 'remove:override-bypass-sentinel', got '$result'"
+fi
+
+# Case D: --worktree-path on Loom-managed worktree — still removes
+result=$(simulate_cleanup 0 true "/path/x" true true "" false)
+if [[ "$result" == "remove:override-managed" ]]; then
+    pass "case D: --worktree-path also removes Loom-managed worktrees"
+else
+    fail "case D: expected 'remove:override-managed', got '$result'"
+fi
+
+# Case E: default path exists — remove via sentinel-guarded path
+result=$(simulate_cleanup 0 true "" true false "" false)
+if [[ "$result" == "remove:default" ]]; then
+    pass "case E: default Loom-convention path used when present"
+else
+    fail "case E: expected 'remove:default', got '$result'"
+fi
+
+# Case F: default missing, discovered worktree has sentinel — remove
+result=$(simulate_cleanup 0 true "" false false "/found" true)
+if [[ "$result" == "remove:discovered-managed" ]]; then
+    pass "case F: discovery removes Loom-managed worktree at non-standard path"
+else
+    fail "case F: expected 'remove:discovered-managed', got '$result'"
+fi
+
+# Case G: default missing, discovered worktree LACKS sentinel — warn-only
+result=$(simulate_cleanup 0 true "" false false "/found" false)
+if [[ "$result" == "warn:discovered-user-owned" ]]; then
+    pass "case G: discovery warns but does NOT remove user-owned worktree"
+else
+    fail "case G: expected 'warn:discovered-user-owned', got '$result'"
+fi
+
+# Case H: nothing found anywhere — quiet success
+result=$(simulate_cleanup 0 true "" false false "" false)
+if [[ "$result" == "skip:nothing-to-do" ]]; then
+    pass "case H: nothing-found is a quiet no-op"
+else
+    fail "case H: expected 'skip:nothing-to-do', got '$result'"
+fi
+
+# --- Summary ---
+echo ""
+echo "Tests run: $TESTS_RUN, Passed: $TESTS_PASSED, Failed: $TESTS_FAILED"
+[[ $TESTS_FAILED -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

Closes #3364

Adds a documented escape hatch for non-Loom worktrees plus a discovery hint when the default Loom-convention path is missing. Implements the hybrid (A + B) approach recommended by the curator.

**Option A (primary fix): `--worktree-path <dir>` flag.** Operators can now point `merge-pr.sh` at any registered worktree of the repo. The `.loom-managed` sentinel guard is bypassed **only** when this flag is explicitly supplied — the caller is taking responsibility. The CLI validates the path exists and is a registered worktree (via `git worktree list --porcelain`), rejecting bad input early. After removing the worktree, the matching local branch is also deleted via `git branch -d` (Git's safety check refuses unmerged commits).

**Option B (secondary discovery aid): warn-only porcelain fallback.** When neither `.loom/worktrees/issue-N` nor `.loom/worktrees/pr-N` exists, the script walks `git worktree list --porcelain` for a worktree tracking the PR's head branch. If found with a sentinel, it removes it; without a sentinel, it logs the discovered path and suggests re-running with `--worktree-path`. Never auto-removes user-owned worktrees (the #3334 sentinel guard remains intact for this path).

## Precedence (highest wins)

1. `LOOM_PRESERVE_WORKTREE=1`
2. `--no-cleanup-worktree` (warns if combined with `--worktree-path`)
3. `--worktree-path <dir>`
4. Default: `.loom/worktrees/issue-N` or `pr-N` + sentinel guard

Default behavior is unchanged for the today's-Loom convention.

## Files

- `defaults/scripts/merge-pr.sh` — flag parsing, validation, sentinel-bypass logic, porcelain helpers (`_worktree_branch_for`, `_find_worktree_by_branch`), safe branch-delete helper (`_maybe_delete_local_branch`), discovery fallback. `--help` text expanded with the new flag, precedence table, and an example.
- `defaults/scripts/tests/test-merge-pr-help.sh` — three new assertions covering `--worktree-path` in the help output and example.
- `defaults/scripts/tests/test-merge-pr-worktree-path.sh` — new dedicated test file: 21 assertions covering CLI validation (missing value / nonexistent / unregistered path), source-surface invariants, `--no-cleanup-worktree` precedence warning, and an 8-case inline simulation of the cleanup decision tree.

## Test plan

- [x] `./defaults/scripts/tests/test-merge-pr-help.sh` — 15/15 pass
- [x] `./defaults/scripts/tests/test-merge-pr-worktree-path.sh` — 21/21 pass (new)
- [x] `./defaults/scripts/tests/test-pr-worktree-isolation.sh` — 22/22 pass (regression)
- [x] `./defaults/scripts/tests/test-worktree-sentinel.sh` — 10/10 pass (regression — sentinel guard still in place for the default path)
- [x] `bash -n defaults/scripts/merge-pr.sh` — clean
- [x] `shellcheck -S warning` on `merge-pr.sh` and both test files — clean
- [x] Manual: `./defaults/scripts/merge-pr.sh --help` shows the new flag with example
- [x] Manual: `./defaults/scripts/merge-pr.sh --worktree-path /nonexistent 1` errors with clear message
- [x] Manual: `./defaults/scripts/merge-pr.sh --worktree-path /tmp 1` errors (not a registered worktree)
- [x] Manual: `./defaults/scripts/merge-pr.sh 1 --worktree-path` errors with "requires a value"
- [ ] Live end-to-end with a real PR (requires merge — defer to operator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)