### PR TITLE
fix(merge-pr): fall through to immediate merge when PR is CLEAN

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,7 @@ gh pr create --label "loom:review-requested"
 
 ```bash
 ./.loom/scripts/merge-pr.sh <PR_NUMBER>         # Standard merge with worktree cleanup
-./.loom/scripts/merge-pr.sh <PR_NUMBER> --auto   # Auto-confirm (for automation)
+./.loom/scripts/merge-pr.sh <PR_NUMBER> --auto   # Enable auto-merge instead of immediate merge (queues until checks pass; on CLEAN PRs falls back to immediate merge)
 ./.loom/scripts/merge-pr.sh <PR_NUMBER> --dry-run # Preview without merging
 ```
 

--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -357,7 +357,7 @@ Use the dedicated merge script (CLAUDE.md "Merging PRs" mandate — never `gh pr
 ./.loom/scripts/merge-pr.sh <PR_NUMBER> --auto
 ```
 
-The script merges via the forge API and cleans up the worktree.
+The script merges via the forge API and cleans up the worktree. `--auto` enables GitHub's server-side auto-merge queue (queues the merge until required checks pass); on PRs that are already in `CLEAN` state (fast CI), the script transparently falls back to an immediate merge — see #3371.
 
 ### 8. Wave settled → advance to next wave
 

--- a/defaults/scripts/merge-pr.sh
+++ b/defaults/scripts/merge-pr.sh
@@ -333,6 +333,18 @@ if [[ "$AUTO_MERGE" == "true" ]]; then
       fi
     fi
 
+    # PR is already CLEAN — GitHub's enablePullRequestAutoMerge mutation rejects
+    # this state with "Pull request Pull request is in clean status" (the
+    # doubled-word prefix is from GitHub's GraphQL error formatter). Match on
+    # the unique substring to stay robust against future normalization. Fall
+    # through to the synchronous-merge path below instead of erroring. See #3371.
+    if echo "$AUTO_MERGE_OUTPUT" | grep -q "is in clean status"; then
+      info "PR #$PR_NUMBER is already CLEAN; falling back to immediate merge"
+      AUTO_MERGE=false      # let the synchronous-merge block at ~line 364 run
+      AUTO_MERGE_OK=true    # bypass the post-loop "after N attempts" guard
+      break
+    fi
+
     # Other auto-merge errors — fail immediately (no retry would help)
     error "Failed to enable auto-merge for PR #$PR_NUMBER: $AUTO_MERGE_OUTPUT"
   done
@@ -341,22 +353,27 @@ if [[ "$AUTO_MERGE" == "true" ]]; then
     error "Failed to enable auto-merge for PR #$PR_NUMBER after $MAX_MERGE_RETRIES attempts"
   fi
 
-  success "Auto-merge enabled for PR #$PR_NUMBER"
+  # If the CLEAN-status fall-through fired above, AUTO_MERGE has been flipped
+  # to false. Skip the "Auto-merge enabled" success message and the post-auto
+  # state poll — let the synchronous-merge block at ~line 376 take over.
+  if [[ "$AUTO_MERGE" == "true" ]]; then
+    success "Auto-merge enabled for PR #$PR_NUMBER"
 
-  # Check whether the server-side merge has already completed. GitHub
-  # auto-merge queues until checks pass, so on most PRs this is still
-  # false right after enabling. If merged, fall through to the shared
-  # cleanup block below. Otherwise skip cleanup — loom-clean will
-  # handle the stale worktree later.
-  POST_AUTO_JSON=$(forge_get_pr_nocache "$REPO_NWO" "$PR_NUMBER" "$GH" 2>/dev/null || echo '{}')
-  POST_AUTO_MERGED=$(echo "$POST_AUTO_JSON" | jq -r '.merged // false')
-  if [[ "$POST_AUTO_MERGED" != "true" ]]; then
-    info "Auto-merge queued (server-side merge pending checks); skipping local cleanup"
-    info "Run loom-clean later to remove the worktree once GitHub completes the merge"
-    exit 0
+    # Check whether the server-side merge has already completed. GitHub
+    # auto-merge queues until checks pass, so on most PRs this is still
+    # false right after enabling. If merged, fall through to the shared
+    # cleanup block below. Otherwise skip cleanup — loom-clean will
+    # handle the stale worktree later.
+    POST_AUTO_JSON=$(forge_get_pr_nocache "$REPO_NWO" "$PR_NUMBER" "$GH" 2>/dev/null || echo '{}')
+    POST_AUTO_MERGED=$(echo "$POST_AUTO_JSON" | jq -r '.merged // false')
+    if [[ "$POST_AUTO_MERGED" != "true" ]]; then
+      info "Auto-merge queued (server-side merge pending checks); skipping local cleanup"
+      info "Run loom-clean later to remove the worktree once GitHub completes the merge"
+      exit 0
+    fi
+    info "PR #$PR_NUMBER already merged server-side; running cleanup"
+    # Fall through to the shared cleanup block (branch deletion + worktree).
   fi
-  info "PR #$PR_NUMBER already merged server-side; running cleanup"
-  # Fall through to the shared cleanup block (branch deletion + worktree).
 fi
 
 # Synchronous-merge path. Skipped when --auto already succeeded server-side


### PR DESCRIPTION
## Summary

`merge-pr.sh --auto` failed with GraphQL `UNPROCESSABLE: "Pull request Pull request is in clean status"` when the PR had already reached `mergeStateStatus: CLEAN` by the time the script ran. This bit fast-CI PRs (docs-only, small Python edits) where the PR became mergeable between PR creation and the merge call. GitHub's `enablePullRequestAutoMerge` mutation rejects already-CLEAN PRs because there is nothing to queue.

This PR detects that specific error in the auto-merge retry loop and falls through to the synchronous-merge path — matching the spirit of `--auto`: "merge as soon as possible," even when "as soon as possible" is right now.

## Changes

- **`defaults/scripts/merge-pr.sh`** (symlinked from `.loom/scripts/merge-pr.sh`):
  - Add a fall-through branch in the auto-merge retry loop matching the substring `"is in clean status"` (robust against future GitHub normalization of the doubled-word prefix).
  - On fall-through, set `AUTO_MERGE=false` (routes to the synchronous-merge block at ~line 376) AND `AUTO_MERGE_OK=true` (bypasses the post-loop "after N attempts" guard at line 353).
  - Gate the post-loop "Auto-merge enabled" success message and the POST_AUTO_MERGED state poll on `AUTO_MERGE == "true"`, so the CLEAN fall-through proceeds directly to the synchronous block instead of hitting the misleading "queued, skipping cleanup; exit 0" branch.
  - Logs `info "PR #N is already CLEAN; falling back to immediate merge"` on fall-through so the path is visible in script output.

- **`CLAUDE.md`** line 173: correct the `--auto` comment from "Auto-confirm (for automation)" — the script has no `read -p` prompt — to "Enable auto-merge instead of immediate merge (queues until checks pass; on CLEAN PRs falls back to immediate merge)".

- **`defaults/.claude/commands/loom/sweep.md`** step 7: add a sentence clarifying that `--auto` is now safe on CLEAN PRs (transparent fall-through).

## Logic trace

**CLEAN PR with `--auto`:** enter auto-merge block -> loom-auto-merge fails with "...is in clean status" -> match fires, set `AUTO_MERGE=false`, `AUTO_MERGE_OK=true`, `break` -> post-loop guard passes -> AUTO_MERGE-gated block skipped -> outer `if AUTO_MERGE == "true"` block exits -> synchronous-merge block (`if AUTO_MERGE != "true"`) runs -> PR merged immediately.

**Non-CLEAN PR with `--auto`:** unchanged. loom-auto-merge succeeds, AUTO_MERGE stays true, "Auto-merge enabled" message + POST_AUTO check run as before.

**CLEAN PR without `--auto`:** unchanged. Auto-merge block skipped entirely.

**`--auto --dry-run`:** unchanged. Exits at line 289 with `[dry-run] Would enable auto-merge`.

## Per-AC mapping (curator's 6 criteria)

- [x] `merge-pr.sh --auto` on a CLEAN PR merges with an info-level log line. Implemented: `info "PR #$PR_NUMBER is already CLEAN; falling back to immediate merge"` before `AUTO_MERGE=false; AUTO_MERGE_OK=true; break`.
- [x] `merge-pr.sh --auto` on a not-yet-clean PR still enables server-side auto-merge. Existing behavior preserved — substring match does not fire, control flows through the existing success path.
- [x] Substring match works for both `loom-auto-merge` and `forge_auto_merge` paths. Both shell-wrap `AUTO_MERGE_OUTPUT=$(... 2>&1)` so the GraphQL error appears in the captured output in either path.
- [x] `merge-pr.sh --auto --dry-run` on a CLEAN PR still prints `[dry-run] Would enable auto-merge`. The dry-run guard at line 288 short-circuits before the retry loop is reached.
- [x] `CLAUDE.md` line 173 (`--auto` comment) corrected. The `defaults/CLAUDE.md` mirror does not contain the mislabeled comment, so no mirror update was needed.
- [x] `sweep.md` step 7 reviewed — kept `--auto` as the default (now safe), added explanatory sentence.

## Scope guardrails honored

- Single-file script change. No refactor of the retry loop structure.
- No changes to `forge_auto_merge` in `forge-helpers.sh`.
- No changes to `loom-auto-merge` Python CLI (called out as follow-up in the issue thread).
- No new label, env var, or flag.
- `--no-cleanup-worktree`, `--dry-run`, `LOOM_PRESERVE_WORKTREE` behavior preserved — the synchronous path is reached unmodified.

## Test plan

- [x] `bash -n` syntax check on `merge-pr.sh` passes.
- [x] `shellcheck` reports only a pre-existing SC2015 warning (unrelated to this change).
- [x] `bash .loom/scripts/tests/test-merge-pr-help.sh` passes (15/15) — `--help` output and `--auto` mention unchanged.
- [ ] Manual smoke test #1: docs-only PR, wait for CLEAN, `merge-pr.sh <N> --auto` -> expect "falling back to immediate merge" info line then immediate merge.
- [ ] Manual smoke test #2: code PR with slower CI, `merge-pr.sh <N> --auto` -> expect existing "Auto-merge enabled" path and "queued, skipping cleanup" exit.
- [ ] Manual smoke test #3: CLEAN PR, `merge-pr.sh <N> --auto --dry-run` -> expect "[dry-run] Would enable auto-merge" and exit 0 (no GraphQL call).

Closes #3371