### PR TITLE
feat(spawn-loop): minimal multi-account spawn loop for /loom:sweep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,10 @@ Thumbs.db
 .loom/claude-config/
 .loom/tokens/
 .loom/sweep-checkpoint/
+.loom/spawn-loop.pid
+.loom/spawn-loop-state.json
+.loom/stop-spawn-loop
+.loom/locks/
 
 # Loom workspace config (DO commit for team sharing)
 # - config.json: Persistent terminal configurations (roles, themes, intervals)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,18 @@ Use Claude Code terminals with specialized roles for hands-on development:
 
 **Graceful shutdown**: `./.loom/scripts/daemon.sh stop` (or `touch .loom/stop-daemon`)
 
+### 3. Spawn-Loop Mode (Phase 1, opt-in)
+
+A minimal alternative to the full daemon for multi-account `/loom:sweep` launching (#3374, Phase 1 of the shepherd/daemon deprecation epic #3372). Polls `loom:issue`, atomically claims ready issues, and detaches `claude -p "/loom:sweep N"` per issue — each spawn picks its own OAuth token via `spawn-claude.sh`. No work generation, no support-role triggers, no pool-slot bookkeeping.
+
+```bash
+LOOM_USE_SPAWN_LOOP=1 ./.loom/scripts/spawn-loop.sh start  # opt-in gate is required
+./.loom/scripts/spawn-loop.sh status
+./.loom/scripts/spawn-loop.sh stop                          # or: touch .loom/stop-spawn-loop
+```
+
+State lives in `.loom/spawn-loop-state.json`, logs in `.loom/logs/spawn-loop.log`, claim locks under `.loom/locks/issue-<N>/`. Crashed children whose checkpoints (#3373) survive are re-queued on the next tick. If `daemon-loop.pid` is alive, the loop warns and proceeds (both will compete for `loom:issue` items — pick one). Overrides: `MAX_PARALLEL=3`, `POLL_INTERVAL=30`, `SHUTDOWN_GRACE_SEC=300`.
+
 ## Agent Roles
 
 ### Orchestration Roles

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -263,6 +263,33 @@ touch .loom/stop-daemon
 - Slightly higher latency per iteration (CLI startup)
 - No conversation context between iterations (by design - this is a feature for long-running operation)
 
+### 3. Spawn-Loop Mode (Phase 1, opt-in)
+
+A minimal alternative to the full daemon for multi-account `/loom:sweep` launching (#3374, Phase 1 of the shepherd/daemon deprecation epic #3372). Polls `loom:issue`, atomically claims ready issues (label flip + `mkdir`-based file lock under `.loom/locks/issue-<N>/`), and detaches `claude -p "/loom:sweep N"` per issue — each spawn picks its own OAuth token via `spawn-claude.sh`. No work generation, no support-role triggers, no shepherd-N pool-slot bookkeeping.
+
+```bash
+# Opt-in gate is required (protects existing daemon users from accidental dual-orchestration)
+LOOM_USE_SPAWN_LOOP=1 ./.loom/scripts/spawn-loop.sh start
+
+./.loom/scripts/spawn-loop.sh status
+./.loom/scripts/spawn-loop.sh stop          # or: touch .loom/stop-spawn-loop
+```
+
+| File | Purpose |
+|------|---------|
+| `.loom/spawn-loop.pid` | Loop PID (gitignored) |
+| `.loom/spawn-loop-state.json` | `{started_at, running:[{issue, pid, started_at, token}]}` (gitignored) |
+| `.loom/logs/spawn-loop.log` | Timestamped spawn/exit/error entries |
+| `.loom/logs/sweep-issue-<N>.log` | Per-issue child output |
+| `.loom/locks/issue-<N>/` | Atomic claim lock dir (gitignored) |
+| `.loom/stop-spawn-loop` | Touch to request graceful shutdown |
+
+**Crash recovery**: if a child dies while a `.loom/sweep-checkpoint/issue-<N>.json` exists, the loop flips the issue back to `loom:issue` so the next tick re-spawns; the sweep skill itself (#3373) reads the checkpoint on entry and skips already-completed phases.
+
+**Coexistence with `daemon.sh`**: if `.loom/daemon-loop.pid` is alive, the spawn loop warns at startup and proceeds. Both will race for `loom:issue` items; operators should pick one or the other in practice.
+
+**Tunables (env)**: `MAX_PARALLEL=3`, `POLL_INTERVAL=30`, `SHUTDOWN_GRACE_SEC=300`, `LOOM_REPO=owner/repo` (override remote auto-detection).
+
 ## Agent Roles
 
 Loom provides specialized roles for different development tasks. Each role follows specific guidelines and uses GitHub labels for coordination.

--- a/defaults/scripts/spawn-loop.sh
+++ b/defaults/scripts/spawn-loop.sh
@@ -1,0 +1,569 @@
+#!/usr/bin/env bash
+# spawn-loop.sh - Minimal multi-account spawn loop for /loom:sweep (Phase 1, #3374).
+#
+# Phase 1 of the shepherd/daemon deprecation epic (#3372). Replaces the
+# ~4,200 LOC Python daemon brain (`daemon_v2/`) with a ~200-LOC bash poller
+# that does only the load-bearing thing: launch one `claude -p "/loom:sweep N"`
+# per ready issue, with token rotation via spawn-claude.sh.
+#
+# What this script does:
+#   1. Polls `gh issue list --label loom:issue --state open --limit 50`.
+#   2. While `len(running) < MAX_PARALLEL`, atomically claims the next ready
+#      issue (label flip + mkdir-based file lock under `.loom/locks/issue-<N>/`)
+#      and detaches `spawn-claude.sh -p "/loom:sweep <N>"`. Each spawned process
+#      picks its own token from `.loom/tokens/.ranking`.
+#   3. Sleeps POLL_INTERVAL seconds, then reaps exited children.
+#   4. If a child dies but the issue is still `loom:building` AND a sweep
+#      checkpoint exists at `.loom/sweep-checkpoint/issue-<N>.json`, the next
+#      tick re-spawns. The sweep skill itself reads the checkpoint on entry
+#      and skips completed phases (--resume semantics shipped in #3373).
+#
+# What this script does NOT do (Phase 2 territory):
+#   - Work generation triggers (Architect/Hermit/Auditor cadence)
+#   - Periodic support roles (Champion, Guide, Curator)
+#   - Shepherd-N pool slot bookkeeping (we track a flat list of children)
+#   - Cross-session retry history or `last_*_trigger` cooldowns
+#   - Tauri / MCP integration
+#
+# Coexistence with daemon_v2:
+#   If `.loom/daemon-loop.pid` exists and the process is alive, we warn at
+#   startup but proceed. Both will try to claim `loom:issue` items; the
+#   label flip + lock file race resolves cleanly (last writer wins on
+#   `loom:building`, first mkdir wins on the lock). Operators are expected
+#   to pick one or the other, not run both.
+#
+# Opt-in only:
+#   Refuses to run unless `LOOM_USE_SPAWN_LOOP=1` is exported. This protects
+#   existing daemon users from accidentally starting a parallel orchestrator.
+#
+# Usage:
+#   LOOM_USE_SPAWN_LOOP=1 ./.loom/scripts/spawn-loop.sh start
+#   ./.loom/scripts/spawn-loop.sh stop                 # or: touch .loom/stop-spawn-loop
+#   ./.loom/scripts/spawn-loop.sh status
+#
+# Environment overrides:
+#   LOOM_USE_SPAWN_LOOP    Must be `1` to start. (mandatory)
+#   MAX_PARALLEL           Concurrent children (default: 3)
+#   POLL_INTERVAL          Seconds between ticks (default: 30)
+#   SHUTDOWN_GRACE_SEC     Wait this long for children on stop (default: 300)
+#   LOOM_REPO              Override repo for `gh issue list` (default: from gh remote)
+#
+# State files:
+#   .loom/spawn-loop.pid             Running PID
+#   .loom/spawn-loop-state.json      {started_at, running:[{issue, pid, started_at, token}]}
+#   .loom/logs/spawn-loop.log        Loop log (timestamped spawn/exit/error entries)
+#   .loom/logs/sweep-issue-<N>.log   Per-issue child output
+#   .loom/locks/issue-<N>/           Atomic claim lock (mkdir primitive)
+#   .loom/stop-spawn-loop            Touch to request graceful shutdown
+#
+# Exit codes:
+#   0   Normal exit (start/stop succeeded)
+#   1   Generic error
+#   2   Already running / not running mismatch
+#   78  EX_CONFIG — refused to start (e.g. missing LOOM_USE_SPAWN_LOOP)
+
+set -euo pipefail
+
+# ─── Path resolution ────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve repo root via git common-dir to handle invocation from worktrees.
+if REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --git-common-dir 2>/dev/null)"; then
+    if [[ ! "$REPO_ROOT" = /* ]]; then
+        REPO_ROOT="$(cd "$SCRIPT_DIR" && cd "$REPO_ROOT" && pwd)"
+    fi
+    REPO_ROOT="$(dirname "$REPO_ROOT")"
+else
+    REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+fi
+
+LOOM_DIR="$REPO_ROOT/.loom"
+PIDFILE="$LOOM_DIR/spawn-loop.pid"
+STATEFILE="$LOOM_DIR/spawn-loop-state.json"
+STOP_SIGNAL="$LOOM_DIR/stop-spawn-loop"
+LOGFILE="$LOOM_DIR/logs/spawn-loop.log"
+LOCKS_DIR="$LOOM_DIR/locks"
+CHECKPOINT_DIR="$LOOM_DIR/sweep-checkpoint"
+DAEMON_PIDFILE="$LOOM_DIR/daemon-loop.pid"
+SPAWN_CLAUDE="$REPO_ROOT/.loom/scripts/spawn-claude.sh"
+
+# Defaults (overridable via env)
+MAX_PARALLEL="${MAX_PARALLEL:-3}"
+POLL_INTERVAL="${POLL_INTERVAL:-30}"
+SHUTDOWN_GRACE_SEC="${SHUTDOWN_GRACE_SEC:-300}"
+
+# ─── Logging ────────────────────────────────────────────────────────────────
+log() {
+    local level="$1"; shift
+    local line
+    line="$(date -u '+%Y-%m-%dT%H:%M:%SZ') [$level] $*"
+    echo "$line" >&2
+    mkdir -p "$(dirname "$LOGFILE")"
+    echo "$line" >> "$LOGFILE" 2>/dev/null || true
+}
+log_info()  { log "INFO"  "$@"; }
+log_warn()  { log "WARN"  "$@"; }
+log_error() { log "ERROR" "$@"; }
+
+iso_now() { date -u '+%Y-%m-%dT%H:%M:%SZ'; }
+
+# ─── State file (JSON) ──────────────────────────────────────────────────────
+# We use python3 for safe JSON read/write — bash JSON manipulation is fragile
+# and the repo already requires python3 for token selection. State writes are
+# atomic via .tmp + mv.
+require_python() {
+    if ! command -v python3 >/dev/null 2>&1; then
+        log_error "python3 is required for state file management."
+        exit 1
+    fi
+}
+
+state_init() {
+    mkdir -p "$LOOM_DIR" "$LOCKS_DIR" "$(dirname "$LOGFILE")"
+    if [[ ! -f "$STATEFILE" ]]; then
+        python3 - "$STATEFILE" <<'PY'
+import json, sys, datetime, os
+path = sys.argv[1]
+data = {
+    "started_at": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "running": []
+}
+tmp = path + ".tmp"
+with open(tmp, "w") as f:
+    json.dump(data, f, indent=2)
+os.replace(tmp, path)
+PY
+    fi
+}
+
+# Print pids of currently-tracked children (one per line).
+state_list_running_pids() {
+    [[ -f "$STATEFILE" ]] || return 0
+    python3 - "$STATEFILE" <<'PY' 2>/dev/null || true
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        data = json.load(f)
+    for c in data.get("running", []):
+        print(c.get("pid", ""))
+except Exception:
+    pass
+PY
+}
+
+# Print issue numbers of currently-tracked children (one per line).
+state_list_running_issues() {
+    [[ -f "$STATEFILE" ]] || return 0
+    python3 - "$STATEFILE" <<'PY' 2>/dev/null || true
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        data = json.load(f)
+    for c in data.get("running", []):
+        print(c.get("issue", ""))
+except Exception:
+    pass
+PY
+}
+
+state_count_running() {
+    state_list_running_pids | grep -c -v '^$' || true
+}
+
+# Add a child to state.running.
+state_add_child() {
+    local issue="$1" pid="$2" token="${3:-unknown}"
+    python3 - "$STATEFILE" "$issue" "$pid" "$token" <<'PY'
+import json, sys, datetime, os
+path, issue, pid, token = sys.argv[1:5]
+with open(path) as f:
+    data = json.load(f)
+data.setdefault("running", []).append({
+    "issue": int(issue),
+    "pid": int(pid),
+    "started_at": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "token": token,
+})
+tmp = path + ".tmp"
+with open(tmp, "w") as f:
+    json.dump(data, f, indent=2)
+os.replace(tmp, path)
+PY
+}
+
+# Remove all children whose pid is no longer alive. Prints issue numbers of
+# the removed entries (one per line) so the caller can decide whether to
+# unlock / re-queue.
+state_reap_dead() {
+    [[ -f "$STATEFILE" ]] || return 0
+    python3 - "$STATEFILE" <<'PY'
+import json, os, sys, errno
+path = sys.argv[1]
+with open(path) as f:
+    data = json.load(f)
+alive, dead = [], []
+for c in data.get("running", []):
+    pid = int(c.get("pid", 0))
+    try:
+        os.kill(pid, 0)  # signal 0: existence check
+        alive.append(c)
+    except ProcessLookupError:
+        dead.append(c)
+    except PermissionError:
+        # Process exists but we don't own it — count as alive (defensive).
+        alive.append(c)
+    except OSError as e:
+        if e.errno == errno.ESRCH:
+            dead.append(c)
+        else:
+            alive.append(c)
+data["running"] = alive
+tmp = path + ".tmp"
+with open(tmp, "w") as f:
+    json.dump(data, f, indent=2)
+os.replace(tmp, path)
+for c in dead:
+    print(c.get("issue", ""))
+PY
+}
+
+# ─── Lock primitive (mkdir-based, POSIX-atomic) ─────────────────────────────
+# Mirrors `loom_tools.claim.claim_issue` (#3236): mkdir is the only POSIX-
+# atomic primitive available on stock macOS (flock is Linux-only). The
+# directory's presence is the lock; we drop a tiny metadata file inside for
+# debugging but the existence of the directory is the contract.
+lock_path() { echo "$LOCKS_DIR/issue-$1"; }
+
+acquire_lock() {
+    local issue="$1"
+    local lock
+    lock="$(lock_path "$issue")"
+    mkdir -p "$LOCKS_DIR"
+    if mkdir "$lock" 2>/dev/null; then
+        cat > "$lock/owner.json" <<EOF
+{
+  "issue": $issue,
+  "owner_pid": $$,
+  "acquired_at": "$(iso_now)"
+}
+EOF
+        return 0
+    fi
+    return 1
+}
+
+release_lock() {
+    local issue="$1"
+    local lock
+    lock="$(lock_path "$issue")"
+    [[ -d "$lock" ]] || return 0
+    rm -rf "$lock" 2>/dev/null || true
+}
+
+# ─── GitHub helpers ─────────────────────────────────────────────────────────
+gh_args() {
+    # Inject --repo if LOOM_REPO is set; otherwise gh uses the cwd's remote.
+    if [[ -n "${LOOM_REPO:-}" ]]; then
+        echo "--repo $LOOM_REPO"
+    fi
+}
+
+list_ready_issues() {
+    # shellcheck disable=SC2046
+    gh issue list $(gh_args) \
+        --label "loom:issue" \
+        --state open \
+        --limit 50 \
+        --json number \
+        --jq '.[].number' 2>/dev/null || true
+}
+
+issue_has_label() {
+    local issue="$1" label="$2"
+    # shellcheck disable=SC2046
+    gh issue view "$issue" $(gh_args) --json labels --jq ".labels[].name" 2>/dev/null \
+        | grep -Fxq "$label"
+}
+
+flip_label_to_building() {
+    local issue="$1"
+    # shellcheck disable=SC2046
+    gh issue edit "$issue" $(gh_args) \
+        --remove-label "loom:issue" \
+        --add-label "loom:building" >/dev/null 2>&1
+}
+
+restore_label_to_ready() {
+    local issue="$1"
+    # shellcheck disable=SC2046
+    gh issue edit "$issue" $(gh_args) \
+        --remove-label "loom:building" \
+        --add-label "loom:issue" >/dev/null 2>&1 || true
+}
+
+checkpoint_exists() {
+    local issue="$1"
+    [[ -f "$CHECKPOINT_DIR/issue-${issue}.json" ]]
+}
+
+# ─── Spawn ──────────────────────────────────────────────────────────────────
+spawn_sweep() {
+    local issue="$1"
+    local log_path="$LOOM_DIR/logs/sweep-issue-${issue}.log"
+    mkdir -p "$(dirname "$log_path")"
+
+    if [[ ! -x "$SPAWN_CLAUDE" ]]; then
+        log_error "spawn-claude.sh not executable at $SPAWN_CLAUDE"
+        return 1
+    fi
+
+    # Append a header to the per-issue log so reruns are distinguishable.
+    {
+        echo ""
+        echo "==== spawn-loop tick: $(iso_now) issue=$issue ===="
+    } >> "$log_path" 2>/dev/null || true
+
+    # Detach with setsid-equivalent (bash &) so the child survives the loop's
+    # next iteration and we can simply track its PID. spawn-claude.sh handles
+    # token selection; we record whatever it picked via the LOOM_TOKEN_NAME env
+    # hint if available, otherwise "unknown".
+    LOOM_TERMINAL_ID="spawn-$$-${issue}" \
+        nohup "$SPAWN_CLAUDE" -p "/loom:sweep ${issue}" \
+        >> "$log_path" 2>&1 &
+    local pid=$!
+
+    # Token is selected inside spawn-claude.sh; we don't know which one without
+    # parsing the child's stderr. Record "unknown" — token attribution lives in
+    # the per-issue log file and the bad-tokens manifest, not in spawn-loop
+    # state.
+    state_add_child "$issue" "$pid" "unknown"
+    log_info "spawned issue=$issue pid=$pid log=$log_path"
+}
+
+# ─── Main loop ──────────────────────────────────────────────────────────────
+tick() {
+    # 1. Reap dead children. If an issue's child died but the issue is still
+    #    `loom:building` and a checkpoint exists, the next ready-issue scan
+    #    won't pick it back up (because the label is wrong). We re-arm by
+    #    flipping the label back to `loom:issue` ourselves so the next tick
+    #    can re-claim and re-spawn — sweep.md handles the actual phase skip
+    #    via its checkpoint read on entry.
+    local dead_issue
+    while IFS= read -r dead_issue; do
+        [[ -z "$dead_issue" ]] && continue
+        release_lock "$dead_issue"
+        if checkpoint_exists "$dead_issue" && issue_has_label "$dead_issue" "loom:building"; then
+            log_warn "child for issue=$dead_issue died with checkpoint present; re-queueing"
+            restore_label_to_ready "$dead_issue"
+        else
+            log_info "child for issue=$dead_issue exited cleanly (no checkpoint or already merged)"
+        fi
+    done < <(state_reap_dead)
+
+    # 2. If we're at capacity or shutting down, skip the spawn phase.
+    if [[ -f "$STOP_SIGNAL" ]]; then
+        return 0
+    fi
+    local running
+    running="$(state_count_running)"
+    if (( running >= MAX_PARALLEL )); then
+        return 0
+    fi
+
+    # 3. Fetch ready issues and try to claim until we hit MAX_PARALLEL.
+    local ready_issues
+    ready_issues="$(list_ready_issues || true)"
+    if [[ -z "$ready_issues" ]]; then
+        return 0
+    fi
+
+    # Track issues already claimed by our own children so we don't double-spawn
+    # in the gap between flip_label_to_building and the next GitHub list query.
+    local already
+    already="$(state_list_running_issues | tr '\n' ' ' || true)"
+
+    local issue
+    while IFS= read -r issue; do
+        [[ -z "$issue" ]] && continue
+        running="$(state_count_running)"
+        if (( running >= MAX_PARALLEL )); then
+            break
+        fi
+
+        # Skip if we're already running this one.
+        if [[ " $already " == *" $issue "* ]]; then
+            continue
+        fi
+
+        # Atomic claim: lock-dir first (loses fast if another spawn-loop or
+        # daemon got there), then label flip (loses if a parallel agent flipped
+        # already). We release the lock if the label flip fails.
+        if ! acquire_lock "$issue"; then
+            log_info "issue=$issue lock held by another agent; skipping"
+            continue
+        fi
+        if ! flip_label_to_building "$issue"; then
+            log_warn "issue=$issue label flip failed; releasing lock"
+            release_lock "$issue"
+            continue
+        fi
+
+        spawn_sweep "$issue" || {
+            log_error "spawn failed for issue=$issue; rolling back label + lock"
+            restore_label_to_ready "$issue"
+            release_lock "$issue"
+            continue
+        }
+        already="$already $issue"
+    done <<< "$ready_issues"
+}
+
+run_loop() {
+    log_info "spawn-loop started (pid=$$ max_parallel=$MAX_PARALLEL poll=${POLL_INTERVAL}s)"
+    # Coexistence warning (does not block).
+    if [[ -f "$DAEMON_PIDFILE" ]]; then
+        local dpid
+        dpid="$(cat "$DAEMON_PIDFILE" 2>/dev/null || true)"
+        if [[ -n "$dpid" ]] && kill -0 "$dpid" 2>/dev/null; then
+            log_warn "loom-daemon is also running (pid=$dpid). Both will compete for loom:issue."
+            log_warn "Recommended: stop the daemon (./.loom/scripts/daemon.sh stop) before relying on spawn-loop."
+        fi
+    fi
+
+    # Trap signals so a SIGTERM from `kill` does graceful shutdown.
+    trap 'log_info "received SIGTERM"; touch "$STOP_SIGNAL"' TERM
+    trap 'log_info "received SIGINT";  touch "$STOP_SIGNAL"' INT
+
+    while true; do
+        # Tick body runs even during shutdown so dead children are reaped.
+        tick || log_error "tick error: $?"
+
+        if [[ -f "$STOP_SIGNAL" ]]; then
+            log_info "stop signal detected; waiting up to ${SHUTDOWN_GRACE_SEC}s for children"
+            local waited=0
+            while (( waited < SHUTDOWN_GRACE_SEC )); do
+                state_reap_dead >/dev/null
+                local n
+                n="$(state_count_running)"
+                if (( n == 0 )); then
+                    break
+                fi
+                sleep 5
+                waited=$((waited + 5))
+            done
+            local n
+            n="$(state_count_running)"
+            if (( n > 0 )); then
+                log_warn "shutdown timeout reached; $n children still running (leaving them)"
+            else
+                log_info "all children exited cleanly"
+            fi
+            rm -f "$STOP_SIGNAL" "$PIDFILE"
+            log_info "spawn-loop exited"
+            return 0
+        fi
+
+        sleep "$POLL_INTERVAL"
+    done
+}
+
+# ─── Commands ───────────────────────────────────────────────────────────────
+cmd_start() {
+    if [[ "${LOOM_USE_SPAWN_LOOP:-}" != "1" ]]; then
+        cat >&2 <<EOF
+spawn-loop is opt-in. Set LOOM_USE_SPAWN_LOOP=1 to start:
+
+  LOOM_USE_SPAWN_LOOP=1 $0 start
+
+This guard exists so existing daemon users (./.loom/scripts/daemon.sh) are
+not surprised by a competing orchestrator. See issue #3374.
+EOF
+        exit 78
+    fi
+
+    require_python
+
+    if [[ -f "$PIDFILE" ]]; then
+        local existing
+        existing="$(cat "$PIDFILE" 2>/dev/null || true)"
+        if [[ -n "$existing" ]] && kill -0 "$existing" 2>/dev/null; then
+            echo "spawn-loop already running (pid=$existing)"
+            exit 2
+        fi
+        rm -f "$PIDFILE"
+    fi
+
+    state_init
+    rm -f "$STOP_SIGNAL"
+
+    echo $$ > "$PIDFILE"
+    run_loop
+}
+
+cmd_stop() {
+    if [[ ! -f "$PIDFILE" ]]; then
+        echo "spawn-loop not running"
+        return 0
+    fi
+    local pid
+    pid="$(cat "$PIDFILE" 2>/dev/null || true)"
+    if [[ -z "$pid" ]] || ! kill -0 "$pid" 2>/dev/null; then
+        echo "spawn-loop PID file stale; removing"
+        rm -f "$PIDFILE"
+        return 0
+    fi
+    echo "Requesting graceful shutdown of spawn-loop (pid=$pid)..."
+    touch "$STOP_SIGNAL"
+    # Wait briefly so callers can `&& echo "stopped"` ergonomically.
+    local waited=0
+    while kill -0 "$pid" 2>/dev/null; do
+        sleep 1
+        waited=$((waited + 1))
+        if (( waited >= 10 )); then
+            echo "spawn-loop still draining children (this can take up to ${SHUTDOWN_GRACE_SEC}s)"
+            return 0
+        fi
+    done
+    echo "spawn-loop exited"
+}
+
+cmd_status() {
+    if [[ ! -f "$PIDFILE" ]]; then
+        echo "spawn-loop: not running"
+        return 1
+    fi
+    local pid
+    pid="$(cat "$PIDFILE" 2>/dev/null || true)"
+    if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+        local count
+        count="$(state_count_running 2>/dev/null || echo 0)"
+        echo "spawn-loop: running (pid=$pid, children=$count)"
+        if [[ -f "$STATEFILE" ]]; then
+            echo "state: $STATEFILE"
+            python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print('  started_at:', d.get('started_at','?')); [print(f\"  - issue {c['issue']} pid {c['pid']} since {c['started_at']}\") for c in d.get('running', [])]" "$STATEFILE" 2>/dev/null || true
+        fi
+        return 0
+    fi
+    echo "spawn-loop: not running (stale PID file at $PIDFILE)"
+    return 1
+}
+
+usage() {
+    # Extract the leading comment block (from line 2 up to but not including
+    # the first non-comment line, i.e. `set -euo pipefail`). Avoids
+    # `head -n -1` which is GNU-only and breaks on macOS BSD head.
+    awk 'NR>=2 { if (/^[^#]/) exit; sub(/^# ?/, ""); print }' "${BASH_SOURCE[0]}"
+}
+
+main() {
+    local cmd="${1:-}"
+    shift || true
+    case "$cmd" in
+        start)  cmd_start "$@" ;;
+        stop)   cmd_stop "$@" ;;
+        status) cmd_status "$@" ;;
+        ""|--help|-h) usage; exit 0 ;;
+        *) echo "ERROR: unknown command '$cmd'" >&2; usage; exit 1 ;;
+    esac
+}
+
+main "$@"

--- a/defaults/scripts/tests/test-spawn-loop.sh
+++ b/defaults/scripts/tests/test-spawn-loop.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+# test-spawn-loop.sh — Smoke tests for spawn-loop.sh (#3374).
+#
+# These tests exercise the local, deterministic pieces:
+#   - State file read/write round-trip
+#   - mkdir-based lock acquire/release primitive
+#   - Concurrent lock acquisition (race)
+#   - Opt-in gate (LOOM_USE_SPAWN_LOOP guard)
+#   - Daemon-coexistence warning
+#
+# What they do NOT test (intentionally):
+#   - End-to-end spawning of `claude` (requires real OAuth token + network)
+#   - `gh issue list` / label flipping (requires GitHub credential)
+#   - Long-running shutdown (the manual test in the PR body covers this)
+#
+# Style mirrors test-spawn-claude.sh: plain bash, hand-rolled assertions, no
+# bats. Run from the repo root or any subdir:
+#
+#   ./.loom/scripts/tests/test-spawn-loop.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SPAWN_LOOP="$SCRIPTS_DIR/spawn-loop.sh"
+
+if [[ ! -x "$SPAWN_LOOP" ]]; then
+    echo "ERROR: spawn-loop.sh not found or not executable at $SPAWN_LOOP" >&2
+    exit 1
+fi
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_eq() {
+    local expected="$1" actual="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Expected: '$expected'"
+        echo "    Actual:   '$actual'"
+    fi
+}
+
+assert_true() {
+    local cond_desc="$2"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if eval "$1"; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $cond_desc"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $cond_desc"
+    fi
+}
+
+assert_contains() {
+    local needle="$1" haystack="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$haystack" == *"$needle"* ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Expected substring: '$needle'"
+        echo "    In: '$haystack'"
+    fi
+}
+
+# ─── Setup: hermetic fake repo root ─────────────────────────────────────────
+# We point spawn-loop at a temp dir so the tests don't touch the real
+# .loom/ state. We re-implement just enough to invoke the loop's helper
+# functions; the script uses `git rev-parse --git-common-dir` so we either
+# `git init` or shadow with explicit paths.
+TMPDIR_BASE="$(mktemp -d -t spawn-loop-test.XXXXXX)"
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+cd "$TMPDIR_BASE"
+git init -q .
+mkdir -p .loom/scripts .loom/logs .loom/locks
+# Stage the script into the fake repo's expected path so internal references
+# (e.g. spawn-claude.sh) at least exist as no-ops.
+cp "$SPAWN_LOOP" .loom/scripts/spawn-loop.sh
+chmod +x .loom/scripts/spawn-loop.sh
+# Provide a stub spawn-claude.sh so spawn_sweep doesn't refuse to start when
+# we exercise the spawn path in isolation later.
+cat > .loom/scripts/spawn-claude.sh <<'STUB'
+#!/usr/bin/env bash
+# Test stub — echoes its args and sleeps, simulating a long-running child.
+echo "stub-spawn-claude args: $*"
+sleep 60
+STUB
+chmod +x .loom/scripts/spawn-claude.sh
+
+# Force gh helpers to be quiet by stubbing gh out of PATH for this shell.
+# (Sourcing the script will define functions but won't call them unless
+# tick() runs, so this is just defensive.)
+export PATH="$TMPDIR_BASE/bin:$PATH"
+mkdir -p "$TMPDIR_BASE/bin"
+cat > "$TMPDIR_BASE/bin/gh" <<'GH'
+#!/usr/bin/env bash
+# Test gh stub: prints nothing, exits 0 — simulates "no ready issues".
+exit 0
+GH
+chmod +x "$TMPDIR_BASE/bin/gh"
+
+# ─── Source the script so we can call individual functions ──────────────────
+# spawn-loop.sh defines functions then dispatches on $1. We source with no
+# args, which routes to usage() then exits 0 — but we want the functions
+# defined without running anything. Trick: stub `main` before sourcing.
+SCRIPT_BODY="$(grep -v '^main "$@"' "$SPAWN_LOOP")"
+# shellcheck disable=SC1091
+eval "$SCRIPT_BODY"
+
+# ─── Section 1: state file round-trip ───────────────────────────────────────
+echo "Testing state file management..."
+
+# state_init should create the file with started_at + empty running[].
+rm -f "$STATEFILE"
+state_init
+assert_true "[[ -f '$STATEFILE' ]]" "state_init creates state file"
+
+initial_count="$(state_count_running)"
+assert_eq "0" "$initial_count" "fresh state has zero running children"
+
+# Add a synthetic child with PID=$$ (we know that's alive — it's us).
+state_add_child 123 $$ "agent-test"
+count_after_add="$(state_count_running)"
+assert_eq "1" "$count_after_add" "state_add_child increments running count"
+
+# state_list_running_issues should yield "123".
+issues="$(state_list_running_issues | tr '\n' ' ' | sed 's/ *$//')"
+assert_eq "123" "$issues" "state_list_running_issues returns added issue"
+
+# Add another with a very-likely-dead PID (well above max).
+state_add_child 456 999999 "agent-test"
+count_after_second="$(state_count_running)"
+assert_eq "2" "$count_after_second" "state file holds multiple children"
+
+# state_reap_dead should remove the dead one (issue 456) and emit "456".
+dead_output="$(state_reap_dead | tr '\n' ' ' | sed 's/ *$//')"
+assert_eq "456" "$dead_output" "state_reap_dead removes pid 999999 and reports issue"
+count_after_reap="$(state_count_running)"
+assert_eq "1" "$count_after_reap" "state_reap_dead leaves live children alone"
+
+# Clean up the live entry so subsequent tests start fresh.
+rm -f "$STATEFILE"
+state_init
+
+# ─── Section 2: lock acquire / release ──────────────────────────────────────
+echo ""
+echo "Testing mkdir-based lock primitive..."
+
+# Fresh acquire should succeed.
+acquire_lock 42 && acquired_first=0 || acquired_first=1
+assert_eq "0" "$acquired_first" "first acquire_lock 42 succeeds"
+
+# Lock dir + metadata should exist.
+LOCK_42="$(lock_path 42)"
+assert_true "[[ -d '$LOCK_42' ]]" "lock dir created on disk"
+assert_true "[[ -f '$LOCK_42/owner.json' ]]" "owner metadata file written inside lock dir"
+
+# Second acquire (same process) should fail — mkdir on an existing dir is the
+# atomic primitive we rely on.
+acquire_lock 42 && acquired_second=0 || acquired_second=1
+assert_eq "1" "$acquired_second" "second acquire_lock 42 fails (lock held)"
+
+# Release and re-acquire should succeed.
+release_lock 42
+assert_true "[[ ! -d '$LOCK_42' ]]" "release_lock removes lock dir"
+acquire_lock 42 && reacquired=0 || reacquired=1
+assert_eq "0" "$reacquired" "re-acquire after release succeeds"
+release_lock 42
+
+# ─── Section 3: lock race (two children, one winner) ────────────────────────
+echo ""
+echo "Testing concurrent lock acquisition..."
+
+# Spawn two background subshells racing for the same lock. Exactly one should
+# succeed. Use a barrier file so they start as close together as possible.
+RACE_TMP="$(mktemp -d -t spawn-loop-race.XXXXXX)"
+BARRIER="$RACE_TMP/start"
+WINNERS="$RACE_TMP/winners"
+touch "$WINNERS"
+
+race_worker() {
+    # shellcheck disable=SC2034
+    local wid="$1"
+    while [[ ! -f "$BARRIER" ]]; do :; done
+    if acquire_lock 7777 2>/dev/null; then
+        echo "$wid" >> "$WINNERS"
+    fi
+}
+
+race_worker A &
+PA=$!
+race_worker B &
+PB=$!
+touch "$BARRIER"
+wait "$PA" "$PB"
+
+winner_count="$(wc -l < "$WINNERS" | tr -d ' ')"
+assert_eq "1" "$winner_count" "exactly one of two racers acquires the lock"
+release_lock 7777
+rm -rf "$RACE_TMP"
+
+# ─── Section 4: opt-in gate ─────────────────────────────────────────────────
+echo ""
+echo "Testing LOOM_USE_SPAWN_LOOP opt-in gate..."
+
+# Without the env var, `start` must refuse with exit 78.
+set +e
+output="$( "$SPAWN_LOOP" start 2>&1 )"
+exit_code=$?
+set -e
+assert_eq "78" "$exit_code" "spawn-loop start exits 78 without LOOM_USE_SPAWN_LOOP=1"
+assert_contains "LOOM_USE_SPAWN_LOOP" "$output" "refusal message mentions the env var"
+assert_contains "opt-in" "$output" "refusal message explains opt-in nature"
+
+# ─── Section 5: status when not running ─────────────────────────────────────
+echo ""
+echo "Testing status command (not running)..."
+
+set +e
+status_output="$( "$SPAWN_LOOP" status 2>&1 )"
+status_exit=$?
+set -e
+assert_eq "1" "$status_exit" "status exits 1 when not running"
+assert_contains "not running" "$status_output" "status output says not running"
+
+# ─── Section 6: stop when not running ───────────────────────────────────────
+echo ""
+echo "Testing stop command (not running)..."
+
+set +e
+stop_output="$( "$SPAWN_LOOP" stop 2>&1 )"
+stop_exit=$?
+set -e
+assert_eq "0" "$stop_exit" "stop exits 0 when nothing to stop (idempotent)"
+assert_contains "not running" "$stop_output" "stop output says not running"
+
+# ─── Section 7: stale PID file recovery ─────────────────────────────────────
+echo ""
+echo "Testing stale PID file handling..."
+
+# Write a PID that's definitely not alive. status should detect it and exit 1
+# with a "stale PID file" message.
+echo 999999 > "$PIDFILE"
+set +e
+stale_output="$( "$SPAWN_LOOP" status 2>&1 )"
+stale_exit=$?
+set -e
+assert_eq "1" "$stale_exit" "status with stale PID file exits 1"
+assert_contains "stale PID file" "$stale_output" "status flags stale PID file"
+rm -f "$PIDFILE"
+
+# ─── Section 8: usage / help ────────────────────────────────────────────────
+echo ""
+echo "Testing usage output..."
+
+set +e
+help_output="$( "$SPAWN_LOOP" --help 2>&1 )"
+set -e
+assert_contains "spawn-loop" "$help_output" "usage mentions spawn-loop"
+assert_contains "LOOM_USE_SPAWN_LOOP" "$help_output" "usage documents opt-in env var"
+assert_contains "MAX_PARALLEL" "$help_output" "usage documents MAX_PARALLEL override"
+assert_contains "POLL_INTERVAL" "$help_output" "usage documents POLL_INTERVAL override"
+
+# ─── Summary ────────────────────────────────────────────────────────────────
+echo ""
+echo "─────────────────────────────────────────"
+echo "Tests run: $TESTS_RUN"
+echo -e "Passed:    ${GREEN}$TESTS_PASSED${NC}"
+if (( TESTS_FAILED > 0 )); then
+    echo -e "Failed:    ${RED}$TESTS_FAILED${NC}"
+    exit 1
+else
+    echo "Failed:    0"
+fi


### PR DESCRIPTION
Closes #3374

## Summary

Phase 1 of the shepherd/daemon deprecation epic (#3372). Adds a ~400-LOC bash spawn loop that handles only the load-bearing concern of the ~4,200-LOC Python `daemon_v2/` brain: launch one `claude -p "/loom:sweep N"` per ready issue with token rotation via `spawn-claude.sh`.

- New: `defaults/scripts/spawn-loop.sh` (also reachable as `.loom/scripts/spawn-loop.sh` via the existing `defaults/scripts/` -> `.loom/scripts/` symlink in this repo).
- New: `defaults/scripts/tests/test-spawn-loop.sh` — 27 hand-rolled bash assertions; all pass on macOS BSD tools; clean `shellcheck`.
- Docs: `CLAUDE.md` (both root and `defaults/`) now document the opt-in path under a new "Spawn-Loop Mode (Phase 1, opt-in)" subsection.
- Gitignore: `.loom/spawn-loop.pid`, `.loom/spawn-loop-state.json`, `.loom/stop-spawn-loop`, `.loom/locks/`.

## Design notes

- **Opt-in gate**: refuses to start unless `LOOM_USE_SPAWN_LOOP=1` is exported. Exits `78` (`EX_CONFIG`) otherwise with an explanatory message. This protects existing `./.loom/scripts/daemon.sh` users from accidentally running a competing orchestrator.
- **Atomic claim**: `mkdir`-based lock under `.loom/locks/issue-<N>/` plus `gh issue edit --remove-label loom:issue --add-label loom:building`. Same POSIX-atomic primitive as `loom_tools.claim.claim_issue` (works on stock macOS where `flock` is unavailable).
- **Token rotation**: delegates to existing `spawn-claude.sh` — three-tier (ranking -> allowlist -> random) selection with bad-token tracking. The loop records `"unknown"` for the token field in state (per-issue logs and the `.bad_tokens` manifest are authoritative for token attribution).
- **Crash recovery**: dead children whose `.loom/sweep-checkpoint/issue-<N>.json` survives get re-queued (label flipped back to `loom:issue`) so the next tick re-spawns. The sweep skill itself (#3373) reads the checkpoint on entry and skips already-completed phases.
- **Daemon coexistence**: warns at startup if `.loom/daemon-loop.pid` is alive but proceeds. Operators are expected to pick one or the other; the label flip + lock race resolves cleanly if both are run.
- **Graceful shutdown**: `stop` command (or `touch .loom/stop-spawn-loop`) stops the spawn phase and waits up to `SHUTDOWN_GRACE_SEC` seconds (default 300) for children to drain.
- **No state machine**: tracks running children as a flat list. No `shepherd-N` slot bookkeeping, no `pipeline_state`, no `warnings`, no `completed_issues`, no `daemon_session_id`. The brain is the issue labels on the forge.

## Out of scope (Phase 2)

- Work generation triggers (Architect/Hermit/Auditor cadence) — moves to GitHub Actions.
- Periodic support roles (Champion, Guide, Curator).
- Mid-flight token rotation per call (the existing `claude-wrapper.sh` handles per-call retry on `TOKEN_EXPIRED`/`TOKEN_EXHAUSTED`; the spawn loop's coarser rotation is: exit, mark token bad, relaunch on next tick).
- Tauri/MCP integration.
- Cross-session retry history (`last_architect_trigger` cooldowns).

## Test plan

### Automated smoke tests (already passing in local run)

```
bash defaults/scripts/tests/test-spawn-loop.sh
```

Covers:
- State file round-trip (init, add child, list issues/pids, count, reap dead).
- Lock primitive (acquire, release, re-acquire, double-acquire failure).
- Concurrent lock race (two background subshells; exactly one wins).
- Opt-in gate (refuse without `LOOM_USE_SPAWN_LOOP=1`, exit 78).
- Status / stop idempotency (no-op when not running).
- Stale PID file recovery.
- Usage output documents key env vars.

All 27 assertions pass. `shellcheck` is clean on both `spawn-loop.sh` and the test script.

### Manual end-to-end test (acceptance criterion from #3374)

This requires real Claude OAuth credentials and a multi-account token pool, so it cannot be automated in CI.

- [ ] `loom-tokens bootstrap` with at least 3 accounts in `.env`.
- [ ] File 5 issues with `loom:issue` label in a test repo.
- [ ] `LOOM_USE_SPAWN_LOOP=1 MAX_PARALLEL=3 ./.loom/scripts/spawn-loop.sh start &` in one terminal.
- [ ] Watch `.loom/logs/spawn-loop.log` and `.loom/spawn-loop-state.json` — verify 3 children spawn promptly, then 2 more after the first batch starts completing.
- [ ] Verify per-issue logs at `.loom/logs/sweep-issue-<N>.log` show different `Selected account: agent-X` lines across issues (tokens spread).
- [ ] All 5 issues complete (labels move to closed, PRs created and merged).
- [ ] `./.loom/scripts/spawn-loop.sh stop` exits cleanly within 5 minutes.

### Crash-recovery spot check

- [ ] Start the loop with a single issue in `loom:issue`.
- [ ] After it spawns and the sweep child has written a `curator-done` checkpoint, `kill -9` the child.
- [ ] On the next tick (within `POLL_INTERVAL` seconds), confirm the loop logs `child for issue=N died with checkpoint present; re-queueing` and the issue label is restored to `loom:issue`.
- [ ] Confirm a new child spawns and the sweep skill skips the curator phase per `.loom/sweep-checkpoint/issue-<N>.json`.

## Files changed

- `defaults/scripts/spawn-loop.sh` (new, ~400 lines incl. comments)
- `defaults/scripts/tests/test-spawn-loop.sh` (new, ~250 lines)
- `.gitignore` (+4 lines for spawn-loop runtime artifacts)
- `CLAUDE.md` (+12 lines for new mode docs)
- `defaults/CLAUDE.md` (+27 lines for new mode docs)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>