### PR TITLE
feat(workflows): scheduled support-role workflows (Phase 2a, #3375)

### DIFF
--- a/.github/workflows/loom-auditor.yml
+++ b/.github/workflows/loom-auditor.yml
@@ -24,6 +24,9 @@ jobs:
   auditor:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Install Claude CLI

--- a/.github/workflows/loom-auditor.yml
+++ b/.github/workflows/loom-auditor.yml
@@ -1,0 +1,35 @@
+name: Loom Auditor
+
+# Periodic support role for the Loom orchestration system.
+#
+# Auditor validates the main branch build and runtime health, filing issues
+# (with the `loom:auditor` proposal label) when regressions are detected.
+#
+# Cadence: every 10 minutes (matches the daemon's historical interval).
+#
+# Disabled by default. To enable on your fork:
+#   1. Uncomment the `schedule:` block below.
+#   2. Add a `CLAUDE_API_KEY` secret to the repository
+#      (Settings -> Secrets and variables -> Actions).
+#
+# This is Phase 2a of the shepherd/daemon deprecation epic (#3372 / #3375).
+
+on:
+  # schedule:
+  #   # Uncomment and set CLAUDE_API_KEY secret to enable.
+  #   - cron: "*/10 * * * *"
+  workflow_dispatch:  # Allow manual runs for testing.
+
+jobs:
+  auditor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Claude CLI
+        run: npm install -g @anthropic-ai/claude-code
+      - name: Run auditor
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: claude -p "/auditor" --dangerously-skip-permissions

--- a/.github/workflows/loom-champion.yml
+++ b/.github/workflows/loom-champion.yml
@@ -1,0 +1,35 @@
+name: Loom Champion
+
+# Periodic support role for the Loom orchestration system.
+#
+# Champion evaluates proposals, promotes `loom:curated` issues to `loom:issue`
+# (in merge-mode operations), and auto-merges PRs that have passed Judge review.
+#
+# Cadence: every 10 minutes (matches the daemon's historical interval).
+#
+# Disabled by default. To enable on your fork:
+#   1. Uncomment the `schedule:` block below.
+#   2. Add a `CLAUDE_API_KEY` secret to the repository
+#      (Settings -> Secrets and variables -> Actions).
+#
+# This is Phase 2a of the shepherd/daemon deprecation epic (#3372 / #3375).
+
+on:
+  # schedule:
+  #   # Uncomment and set CLAUDE_API_KEY secret to enable.
+  #   - cron: "*/10 * * * *"
+  workflow_dispatch:  # Allow manual runs for testing.
+
+jobs:
+  champion:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Claude CLI
+        run: npm install -g @anthropic-ai/claude-code
+      - name: Run champion
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: claude -p "/champion" --dangerously-skip-permissions

--- a/.github/workflows/loom-champion.yml
+++ b/.github/workflows/loom-champion.yml
@@ -24,6 +24,9 @@ jobs:
   champion:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Install Claude CLI

--- a/.github/workflows/loom-curator.yml
+++ b/.github/workflows/loom-curator.yml
@@ -25,6 +25,9 @@ jobs:
   curator:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Install Claude CLI

--- a/.github/workflows/loom-curator.yml
+++ b/.github/workflows/loom-curator.yml
@@ -1,0 +1,36 @@
+name: Loom Curator
+
+# Periodic support role for the Loom orchestration system.
+#
+# Curator enriches new issues with technical details, acceptance criteria,
+# and scope guidance, moving them along the `loom:triage` -> `loom:curated`
+# pipeline.
+#
+# Cadence: every 5 minutes (matches the daemon's historical interval).
+#
+# Disabled by default. To enable on your fork:
+#   1. Uncomment the `schedule:` block below.
+#   2. Add a `CLAUDE_API_KEY` secret to the repository
+#      (Settings -> Secrets and variables -> Actions).
+#
+# This is Phase 2a of the shepherd/daemon deprecation epic (#3372 / #3375).
+
+on:
+  # schedule:
+  #   # Uncomment and set CLAUDE_API_KEY secret to enable.
+  #   - cron: "*/5 * * * *"
+  workflow_dispatch:  # Allow manual runs for testing.
+
+jobs:
+  curator:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Claude CLI
+        run: npm install -g @anthropic-ai/claude-code
+      - name: Run curator
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: claude -p "/curator" --dangerously-skip-permissions

--- a/.github/workflows/loom-guide.yml
+++ b/.github/workflows/loom-guide.yml
@@ -24,6 +24,9 @@ jobs:
   guide:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Install Claude CLI

--- a/.github/workflows/loom-guide.yml
+++ b/.github/workflows/loom-guide.yml
@@ -1,0 +1,35 @@
+name: Loom Guide
+
+# Periodic support role for the Loom orchestration system.
+#
+# Guide triages and prioritizes the backlog, ensuring the next batch of
+# `loom:issue` work is the highest-leverage work available.
+#
+# Cadence: every 15 minutes (matches the daemon's historical interval).
+#
+# Disabled by default. To enable on your fork:
+#   1. Uncomment the `schedule:` block below.
+#   2. Add a `CLAUDE_API_KEY` secret to the repository
+#      (Settings -> Secrets and variables -> Actions).
+#
+# This is Phase 2a of the shepherd/daemon deprecation epic (#3372 / #3375).
+
+on:
+  # schedule:
+  #   # Uncomment and set CLAUDE_API_KEY secret to enable.
+  #   - cron: "*/15 * * * *"
+  workflow_dispatch:  # Allow manual runs for testing.
+
+jobs:
+  guide:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Claude CLI
+        run: npm install -g @anthropic-ai/claude-code
+      - name: Run guide
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: claude -p "/guide" --dangerously-skip-permissions

--- a/.github/workflows/loom-judge.yml
+++ b/.github/workflows/loom-judge.yml
@@ -1,0 +1,36 @@
+name: Loom Judge
+
+# Periodic support role for the Loom orchestration system.
+#
+# Judge evaluates PRs labeled `loom:review-requested` and either approves
+# (moving them to `loom:pr`) or requests changes (moving them to
+# `loom:changes-requested`).
+#
+# Cadence: every 5 minutes (matches the daemon's historical interval).
+#
+# Disabled by default. To enable on your fork:
+#   1. Uncomment the `schedule:` block below.
+#   2. Add a `CLAUDE_API_KEY` secret to the repository
+#      (Settings -> Secrets and variables -> Actions).
+#
+# This is Phase 2a of the shepherd/daemon deprecation epic (#3372 / #3375).
+
+on:
+  # schedule:
+  #   # Uncomment and set CLAUDE_API_KEY secret to enable.
+  #   - cron: "*/5 * * * *"
+  workflow_dispatch:  # Allow manual runs for testing.
+
+jobs:
+  judge:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Claude CLI
+        run: npm install -g @anthropic-ai/claude-code
+      - name: Run judge
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: claude -p "/judge" --dangerously-skip-permissions

--- a/.github/workflows/loom-judge.yml
+++ b/.github/workflows/loom-judge.yml
@@ -25,6 +25,9 @@ jobs:
   judge:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Install Claude CLI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,26 @@ LOOM_USE_SPAWN_LOOP=1 ./.loom/scripts/spawn-loop.sh start  # opt-in gate is requ
 
 State lives in `.loom/spawn-loop-state.json`, logs in `.loom/logs/spawn-loop.log`, claim locks under `.loom/locks/issue-<N>/`. Crashed children whose checkpoints (#3373) survive are re-queued on the next tick. If `daemon-loop.pid` is alive, the loop warns and proceeds (both will compete for `loom:issue` items — pick one). Overrides: `MAX_PARALLEL=3`, `POLL_INTERVAL=30`, `SHUTDOWN_GRACE_SEC=300`.
 
+### 4. Scheduled Support Roles (Phase 2a, opt-in)
+
+GitHub Actions workflows under `.github/workflows/loom-*.yml` provide a daemon-free way to run the periodic support roles (Champion, Curator, Judge, Auditor, Guide) on cron schedules that match the daemon's historical intervals (Phase 2a of #3372, see #3375). Each workflow checks out the repo, installs the Claude CLI, and runs `claude -p "/<role>" --dangerously-skip-permissions` for one tick of work — no Loom-side state file, no long-running process.
+
+| Workflow | Role | Schedule (commented) |
+|----------|------|----------------------|
+| `loom-champion.yml` | `/champion` | `*/10 * * * *` |
+| `loom-curator.yml`  | `/curator`  | `*/5 * * * *`  |
+| `loom-judge.yml`    | `/judge`    | `*/5 * * * *`  |
+| `loom-auditor.yml`  | `/auditor`  | `*/10 * * * *` |
+| `loom-guide.yml`    | `/guide`    | `*/15 * * * *` |
+
+**Disabled by default.** Every shipped workflow has its `schedule:` block commented out so forks don't burn Actions minutes accidentally. To opt in on a fork:
+
+1. Add a `CLAUDE_API_KEY` repository secret (Settings -> Secrets and variables -> Actions). Workflows run on a single API key — token rotation is for per-task spawns only; scheduled support roles are predictable load that doesn't benefit from rotation.
+2. Uncomment the `schedule:` / `- cron:` lines in each `.github/workflows/loom-*.yml` you want to enable.
+3. Optionally trigger a run via `workflow_dispatch` (the Actions UI's "Run workflow" button) to smoke-test before the next scheduled tick.
+
+Architect and Hermit cadence (work-generation triggers) is intentionally out of scope here — see follow-up #3381 (Phase 2d). The schedule-driven model coexists with the daemon during Phase 2; Phase 3 removes the daemon brain entirely.
+
 ## Agent Roles
 
 ### Orchestration Roles

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -290,6 +290,26 @@ LOOM_USE_SPAWN_LOOP=1 ./.loom/scripts/spawn-loop.sh start
 
 **Tunables (env)**: `MAX_PARALLEL=3`, `POLL_INTERVAL=30`, `SHUTDOWN_GRACE_SEC=300`, `LOOM_REPO=owner/repo` (override remote auto-detection).
 
+### Scheduled Support Roles (Phase 2a, opt-in)
+
+GitHub Actions workflows under `.github/workflows/loom-*.yml` provide a daemon-free way to run the periodic support roles (Champion, Curator, Judge, Auditor, Guide) on cron schedules that match the daemon's historical intervals (Phase 2a of #3372, see #3375). Each workflow checks out the repo, installs the Claude CLI, and runs `claude -p "/<role>" --dangerously-skip-permissions` for one tick of work — no Loom-side state file, no long-running process.
+
+| Workflow | Role | Schedule (commented) |
+|----------|------|----------------------|
+| `loom-champion.yml` | `/champion` | `*/10 * * * *` |
+| `loom-curator.yml`  | `/curator`  | `*/5 * * * *`  |
+| `loom-judge.yml`    | `/judge`    | `*/5 * * * *`  |
+| `loom-auditor.yml`  | `/auditor`  | `*/10 * * * *` |
+| `loom-guide.yml`    | `/guide`    | `*/15 * * * *` |
+
+**Disabled by default.** Every shipped workflow has its `schedule:` block commented out so forks don't burn Actions minutes accidentally. To opt in on a fork:
+
+1. Add a `CLAUDE_API_KEY` repository secret (Settings -> Secrets and variables -> Actions). Workflows run on a single API key — token rotation is for per-task spawns only; scheduled support roles are predictable load that doesn't benefit from rotation.
+2. Uncomment the `schedule:` / `- cron:` lines in each `.github/workflows/loom-*.yml` you want to enable.
+3. Optionally trigger a run via `workflow_dispatch` (the Actions UI's "Run workflow" button) to smoke-test before the next scheduled tick.
+
+Architect and Hermit cadence (work-generation triggers) is intentionally out of scope here — see follow-up #3381 (Phase 2d). The schedule-driven model coexists with the daemon during Phase 2; Phase 3 removes the daemon brain entirely.
+
 ## Agent Roles
 
 Loom provides specialized roles for different development tasks. Each role follows specific guidelines and uses GitHub labels for coordination.


### PR DESCRIPTION
Closes #3375

## Summary

Phase 2a of the shepherd/daemon deprecation epic (#3372). Adds GitHub Actions workflows that run the five periodic support roles on cron schedules matching the daemon's historical intervals, so Phase 3 can drop the daemon brain without losing Champion/Curator/Judge/Auditor/Guide coverage.

One workflow per role (per Open Question #1 in the issue) for readability and per-role schedule clarity:

| File | Role | Schedule (commented out) |
|------|------|--------------------------|
| `.github/workflows/loom-champion.yml` | `/champion` | `*/10 * * * *` |
| `.github/workflows/loom-curator.yml`  | `/curator`  | `*/5 * * * *`  |
| `.github/workflows/loom-judge.yml`    | `/judge`    | `*/5 * * * *`  |
| `.github/workflows/loom-auditor.yml`  | `/auditor`  | `*/10 * * * *` |
| `.github/workflows/loom-guide.yml`    | `/guide`    | `*/15 * * * *` |

Each workflow checks out the repo, installs `@anthropic-ai/claude-code`, and runs `claude -p "/<role>" --dangerously-skip-permissions` once. `runs-on: ubuntu-latest`, `timeout-minutes: 10`. Auth via `ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_API_KEY }}` and `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` per the issue's sketch.

## Disabled by default (rationale)

Every shipped workflow has its `schedule:` block commented out. Reasons:

- Forks of this repo would otherwise burn Actions minutes on every fork the moment they pull main, even without an API key configured.
- The cron block is the only thing that needs flipping to opt in — the YAML still parses and `workflow_dispatch` remains available for smoke-testing.

## How to enable on a fork

1. Add a repository secret named `CLAUDE_API_KEY` (Settings -> Secrets and variables -> Actions).
2. In each `.github/workflows/loom-*.yml` you want to enable, uncomment the `schedule:` and `- cron:` lines.
3. (Optional) Smoke-test via the Actions UI's "Run workflow" button (`workflow_dispatch` is enabled in every file).

## Scope

Architect and Hermit cadence is intentionally out of scope here — see Phase 2d (#3381). No scheduler-swap (launchd/cron/systemd), no token rotation for support roles, no conditional triggering, no new labels.

Documentation is **additive** in `CLAUDE.md` and `defaults/CLAUDE.md` — the existing "daemon manages support roles" section is left intact for Phase 2b/3 to revise.

## Test plan

- [x] All five YAML files parse cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] `grep -E "^[[:space:]]*schedule:|^[[:space:]]*- cron:"` returns nothing for `loom-*.yml` (confirms disabled-by-default)
- [ ] Manual test per acceptance criteria: on a test fork, set `CLAUDE_API_KEY`, uncomment the Champion `schedule:` block, file a `loom:curated` issue, verify champion runs on the next 10-minute tick and promotes it. Operator-side smoke test — not covered by repo CI because we ship the workflows disabled.

## Coexistence

Both PRs in this wave (#3375 here, #3376 Phase 2b soft-deprecation) are additive and touch disjoint files: this PR only adds `.github/workflows/loom-*.yml` and appends documentation; #3376 modifies daemon role docs. Merge order does not matter.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>