### PR TITLE
feat(deprecation): soft-deprecate /shepherd + loom-daemon with stderr warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+
+- `loom-daemon`, the `loom-shepherd` CLI, and the `/shepherd` slash command are soft-deprecated ahead of removal in the next major release (epic #3372, this notice tracked in #3376). Each entry point now emits a one-shot `⚠️  DEPRECATED` block to stderr on invocation pointing at the replacement path: `./.loom/scripts/spawn-loop.sh` (Phase 1, #3374) + GitHub Actions schedules (Phase 2a, #3375) for autonomous orchestration, and `/loom:sweep <issue>` for single-issue lifecycle. **No behavior change** — the warned components continue to function identically during the soft-deprecation window. Suppress the warning in shell entry points (e.g. downstream installers that have not yet migrated) with `LOOM_SUPPRESS_DEPRECATION=1`; the markdown skill warning always renders by design. Two new helpers ship the warning message in both Python (`loom_tools.common.deprecation.warn_deprecated`) and shell (`.loom/scripts/lib/deprecation.sh`); the shell helper is safe to `source` without side effects. See the "Migration: deprecations announced for the next major release" section in CLAUDE.md for the full before/after table.
+
 ## [0.9.0] - 2026-05-28
 
 ### Summary

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -763,6 +763,34 @@ gh release create vX.Y.Z --title "vX.Y.Z" --notes "Release notes..."
 
 The script updates all 5 version-bearing files (`package.json`, `mcp-loom/package.json`, 2 `Cargo.toml` files (`loom-daemon`, `loom-api`), `CLAUDE.md`) plus `Cargo.lock`. The GitHub Actions release workflow (`.github/workflows/release.yml`) triggers on GitHub Release creation (`release: types: [created]`), NOT on tag push. You must create a GitHub Release via `gh release create` to trigger the build.
 
+## Migration: deprecations announced for the next major release
+
+Loom is in the middle of an orchestration-architecture migration (epic #3372). The shepherd brain (`loom-tools/src/loom_tools/shepherd/`), the daemon brain (`loom-tools/src/loom_tools/daemon_v2/`), and the `/shepherd` slash command will be **deleted in the next major release** in favour of a minimal spawn loop (#3374) + GitHub Actions workflows (#3375). The phased rollout is:
+
+| Phase | Issue | What ships | Status |
+|-------|-------|-----------|--------|
+| Phase 1 | #3374 | Minimal multi-account spawn loop (`./.loom/scripts/spawn-loop.sh`) | shipped |
+| Phase 2a | #3375 | GitHub Actions workflows replacing support-role daemons | in progress (parallel) |
+| Phase 2b | #3376 | **Soft-deprecation warnings on every deprecated entry point** (this PR) | this change |
+| Phase 3 | TBD | Hard deletion of shepherd brain, daemon brain, and `/shepherd` skill | next major release |
+| Phase 4 | TBD | Coordinated downstream sphere-install migration | parallel with Phase 3 |
+
+**Deprecated entry points (still functional, now warn on use):**
+
+| Deprecated | Replacement | Warning emitted from |
+|------------|-------------|----------------------|
+| `loom-daemon` (Python entry point) | `./.loom/scripts/spawn-loop.sh` (Phase 1) + GitHub Actions schedules (Phase 2a) | `loom_tools.daemon_v2.cli.main()` |
+| `./.loom/scripts/daemon.sh start` (shell wrapper) | Same as above | `cmd_start` in `daemon.sh`, via `lib/deprecation.sh` |
+| `loom-shepherd` CLI / `/shepherd` invocations | `/loom:sweep <issue>` for the same lifecycle | `loom_tools.shepherd.cli.main()` |
+| `/shepherd` slash command (`defaults/.claude/commands/loom/shepherd.md`) | `/loom:sweep <issue>` | Markdown header instructs the LLM to emit the warning |
+
+**Suppression**: set `LOOM_SUPPRESS_DEPRECATION=1` to silence the warnings emitted from Python and shell entry points. The `/shepherd` markdown skill warning always renders by design — operators should explicitly migrate, not silence. Sphere installs and other downstream automation that haven't migrated yet can use this env var to keep their logs clean during the deprecation window.
+
+**Helpers**: the warning text is centralized in two places so removal in Phase 3 is a single-PR sweep:
+
+- Python: `loom_tools.common.deprecation.warn_deprecated(component, replacement, ref="#3372")`
+- Shell: `source .loom/scripts/lib/deprecation.sh; warn_deprecated <component> <replacement> [ref]` — the bash helper is safe to source (no side effects).
+
 ## Resources
 
 - **Main Repository**: https://github.com/rjwalters/loom

--- a/defaults/.claude/commands/loom/shepherd.md
+++ b/defaults/.claude/commands/loom/shepherd.md
@@ -1,5 +1,21 @@
 # Shepherd
 
+## ⚠️ Deprecated
+
+**Before doing anything else, emit this notice to the user verbatim as the first line of your response:**
+
+> ⚠️  DEPRECATED: `/shepherd` is scheduled for removal in the next major release.
+>     Use `/loom:sweep <issue>` for the same lifecycle, or enable
+>     `LOOM_USE_SPAWN_LOOP=1` + `./.loom/scripts/spawn-loop.sh` for
+>     multi-account batches. See #3372.
+>     (Suppress this notice in shell entry points with `LOOM_SUPPRESS_DEPRECATION=1`;
+>     the markdown skill warning always renders — explicit operator awareness is
+>     the goal of the soft-deprecation window.)
+
+After printing the notice, continue with the lifecycle below. **No behavior change** — the skill still works during the deprecation window. This warning exists so operators have time to migrate to `/loom:sweep` and the spawn loop before Phase 3 deletes the shepherd brain (see epic #3372, this notice tracked in #3376).
+
+---
+
 Orchestrate a single issue through its full lifecycle as a **signal-writer and observer** — you coordinate the shepherd process through JSON signals and state observation. You NEVER spawn shepherd or worker processes directly via Bash.
 
 ## Arguments

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -1784,6 +1784,34 @@ Or run the setup script to generate `.mcp.json` automatically:
 ./scripts/setup-mcp.sh
 ```
 
+## Migration: deprecations announced for the next major release
+
+Loom is in the middle of an orchestration-architecture migration (epic #3372). The shepherd brain (`loom-tools/src/loom_tools/shepherd/`), the daemon brain (`loom-tools/src/loom_tools/daemon_v2/`), and the `/shepherd` slash command will be **deleted in the next major release** in favour of a minimal spawn loop (#3374) + GitHub Actions workflows (#3375). The phased rollout is:
+
+| Phase | Issue | What ships | Status |
+|-------|-------|-----------|--------|
+| Phase 1 | #3374 | Minimal multi-account spawn loop (`./.loom/scripts/spawn-loop.sh`) | shipped |
+| Phase 2a | #3375 | GitHub Actions workflows replacing support-role daemons | in progress (parallel) |
+| Phase 2b | #3376 | **Soft-deprecation warnings on every deprecated entry point** (this PR) | this change |
+| Phase 3 | TBD | Hard deletion of shepherd brain, daemon brain, and `/shepherd` skill | next major release |
+| Phase 4 | TBD | Coordinated downstream sphere-install migration | parallel with Phase 3 |
+
+**Deprecated entry points (still functional, now warn on use):**
+
+| Deprecated | Replacement | Warning emitted from |
+|------------|-------------|----------------------|
+| `loom-daemon` (Python entry point) | `./.loom/scripts/spawn-loop.sh` (Phase 1) + GitHub Actions schedules (Phase 2a) | `loom_tools.daemon_v2.cli.main()` |
+| `./.loom/scripts/daemon.sh start` (shell wrapper) | Same as above | `cmd_start` in `daemon.sh`, via `lib/deprecation.sh` |
+| `loom-shepherd` CLI / `/shepherd` invocations | `/loom:sweep <issue>` for the same lifecycle | `loom_tools.shepherd.cli.main()` |
+| `/shepherd` slash command (`defaults/.claude/commands/loom/shepherd.md`) | `/loom:sweep <issue>` | Markdown header instructs the LLM to emit the warning |
+
+**Suppression**: set `LOOM_SUPPRESS_DEPRECATION=1` to silence the warnings emitted from Python and shell entry points. The `/shepherd` markdown skill warning always renders by design — operators should explicitly migrate, not silence. Sphere installs and other downstream automation that haven't migrated yet can use this env var to keep their logs clean during the deprecation window.
+
+**Helpers**: the warning text is centralized in two places so removal in Phase 3 is a single-PR sweep:
+
+- Python: `loom_tools.common.deprecation.warn_deprecated(component, replacement, ref="#3372")`
+- Shell: `source .loom/scripts/lib/deprecation.sh; warn_deprecated <component> <replacement> [ref]` — the bash helper is safe to source (no side effects).
+
 ## Resources
 
 ### Loom Documentation

--- a/defaults/scripts/daemon.sh
+++ b/defaults/scripts/daemon.sh
@@ -61,6 +61,19 @@ PIDFILE="$REPO_ROOT/.loom/daemon-loop.pid"
 LOGFILE="$REPO_ROOT/.loom/daemon.log"
 STOP_SIGNAL="$REPO_ROOT/.loom/stop-daemon"
 
+# Source the soft-deprecation helper (issue #3376, epic #3372). Sourcing is
+# side-effect-free — only function definitions. We invoke warn_deprecated
+# from cmd_start so status/stop/restart introspection remains clean.
+# shellcheck source=lib/deprecation.sh
+if [[ -f "$SCRIPT_DIR/lib/deprecation.sh" ]]; then
+    # shellcheck disable=SC1091
+    source "$SCRIPT_DIR/lib/deprecation.sh"
+else
+    # Helper missing — define a stub so cmd_start does not fail. Older
+    # installs may not have the helper yet during the rollout window.
+    warn_deprecated() { :; }
+fi
+
 # ── Parse command ────────────────────────────────────────────────────────────
 COMMAND=""
 ARGS=()
@@ -203,6 +216,14 @@ cmd_stop() {
 
 # ── Command: start ───────────────────────────────────────────────────────────
 cmd_start() {
+    # Soft-deprecation warning (issue #3376, epic #3372). Suppressed by
+    # LOOM_SUPPRESS_DEPRECATION=1. The Python loom-daemon emits its own
+    # warning on startup; this one fires earlier so the message is visible
+    # even when the daemon fails before reaching its Python entry point.
+    warn_deprecated \
+        "loom-daemon (./.loom/scripts/daemon.sh start)" \
+        "./.loom/scripts/spawn-loop.sh (Phase 1, #3374) + GitHub Actions schedules (Phase 2a, #3375)"
+
     local pid
     if pid=$(daemon_pid); then
         echo "Daemon already running (PID $pid)"

--- a/defaults/scripts/lib/deprecation.sh
+++ b/defaults/scripts/lib/deprecation.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Soft-deprecation warning helper (issue #3376, epic #3372).
+#
+# Phase 2b of the shepherd/daemon deprecation epic. Source this file from
+# any shell entry point that wraps a deprecated component and call
+# warn_deprecated to print a one-shot stderr warning. Set
+# LOOM_SUPPRESS_DEPRECATION=1 in the environment to silence it.
+#
+# This file must be safe to source (no side effects at source time — only
+# function definitions). Calling warn_deprecated multiple times in a single
+# script is allowed; each call emits its own warning.
+#
+# Usage:
+#   # shellcheck source=.loom/scripts/lib/deprecation.sh
+#   source "$(dirname "${BASH_SOURCE[0]}")/lib/deprecation.sh"
+#   warn_deprecated "loom-daemon" "./.loom/scripts/spawn-loop.sh + GH Actions"
+
+# warn_deprecated <component> <replacement> [ref]
+#
+# Emits a multi-line ⚠️ DEPRECATED block to stderr. Returns 0 even when
+# suppressed; never errors. The third argument defaults to "#3372" (the
+# umbrella epic).
+warn_deprecated() {
+    # Respect the global suppression env var. Treat unset as "not suppressed".
+    if [[ "${LOOM_SUPPRESS_DEPRECATION:-}" == "1" ]]; then
+        return 0
+    fi
+
+    local component="${1:-<unspecified>}"
+    local replacement="${2:-<see #3372>}"
+    local ref="${3:-#3372}"
+
+    cat >&2 <<EOF
+⚠️  DEPRECATED: ${component} is scheduled for removal in the next major release.
+    Replacement: ${replacement}
+    See ${ref}.
+    Suppress with LOOM_SUPPRESS_DEPRECATION=1.
+EOF
+    return 0
+}

--- a/loom-tools/src/loom_tools/common/deprecation.py
+++ b/loom-tools/src/loom_tools/common/deprecation.py
@@ -1,0 +1,61 @@
+"""Soft-deprecation warning helper (issue #3376, epic #3372).
+
+Phase 2b of the shepherd/daemon deprecation epic emits warnings — but never
+errors — from entry points that are scheduled for removal in the next major
+release. The goal is to give downstream consumers (notably the sphere
+loom-install pipeline) a clear signal before Phase 3 deletes the code.
+
+Usage:
+
+    from loom_tools.common.deprecation import warn_deprecated
+
+    warn_deprecated(
+        "loom-daemon",
+        replacement="./.loom/scripts/spawn-loop.sh + GitHub Actions schedules",
+    )
+
+Set ``LOOM_SUPPRESS_DEPRECATION=1`` in the environment to silence the warning
+(useful for downstream installers that have not yet migrated and want a clean
+signal in their logs).
+
+This module is intentionally tiny and dependency-free so it can be imported
+at the top of any entry-point script without dragging in the rest of
+``loom_tools``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+__all__ = ["warn_deprecated"]
+
+
+def warn_deprecated(component: str, replacement: str, ref: str = "#3372") -> None:
+    """Emit a one-shot deprecation warning to stderr.
+
+    Args:
+        component: Human-readable name of the deprecated entry point
+            (e.g. ``"loom-daemon"``, ``"/shepherd skill"``).
+        replacement: One-line description of the replacement path the user
+            should migrate to (e.g. spawn-loop + workflows).
+        ref: GitHub issue or PR reference for the deprecation rationale.
+            Defaults to ``"#3372"`` (the umbrella epic).
+
+    Behaviour:
+        - Writes a multi-line ``⚠️  DEPRECATED`` block to ``sys.stderr``.
+        - Returns immediately and silently when ``LOOM_SUPPRESS_DEPRECATION=1``.
+        - Never raises — the warning must not break the deprecated component
+          during the soft-deprecation window.
+    """
+    if os.environ.get("LOOM_SUPPRESS_DEPRECATION") == "1":
+        return
+
+    print(
+        f"⚠️  DEPRECATED: {component} is scheduled for removal in the next major release.\n"
+        f"    Replacement: {replacement}\n"
+        f"    See {ref}.\n"
+        f"    Suppress with LOOM_SUPPRESS_DEPRECATION=1.\n",
+        file=sys.stderr,
+        flush=True,
+    )

--- a/loom-tools/src/loom_tools/daemon_v2/cli.py
+++ b/loom-tools/src/loom_tools/daemon_v2/cli.py
@@ -7,6 +7,7 @@ import os
 import sys
 from typing import Sequence
 
+from loom_tools.common.deprecation import warn_deprecated
 from loom_tools.common.logging import log_error, log_info, log_success
 from loom_tools.common.repo import find_repo_root
 from loom_tools.common.state import read_json_file
@@ -233,6 +234,19 @@ Examples:
         fresh=args.fresh,
         debug_mode=args.debug,
         timeout_min=args.timeout_min,
+    )
+
+    # Emit soft-deprecation warning before entering the run loop.
+    # Issue #3376, epic #3372: the daemon is scheduled for removal in the
+    # next major release. Warning is suppressible via LOOM_SUPPRESS_DEPRECATION=1.
+    # Skipped for --status / --health (already returned above) to keep
+    # introspection output clean.
+    warn_deprecated(
+        "loom-daemon",
+        replacement=(
+            "./.loom/scripts/spawn-loop.sh (Phase 1, #3374) "
+            "+ GitHub Actions schedules (Phase 2a, #3375)"
+        ),
     )
 
     # Create context and run

--- a/loom-tools/src/loom_tools/shepherd/cli.py
+++ b/loom-tools/src/loom_tools/shepherd/cli.py
@@ -11,6 +11,7 @@ import time
 from pathlib import Path
 
 from loom_tools.common.config import env_int
+from loom_tools.common.deprecation import warn_deprecated
 from loom_tools.common.git import (
     attempt_rebase,
     get_uncommitted_files,
@@ -2666,6 +2667,19 @@ def _record_fallback_failure(ctx: ShepherdContext, exit_code: int) -> None:
 
 def main(argv: list[str] | None = None) -> int:
     """Main entry point for loom-shepherd CLI."""
+    # Soft-deprecation warning (issue #3376, epic #3372). Emitted to stderr
+    # before any other output. Suppressed by LOOM_SUPPRESS_DEPRECATION=1
+    # (the daemon may set this when spawning shepherds as subprocesses to
+    # avoid log spam; manual invocations always see the warning).
+    warn_deprecated(
+        "/shepherd (loom-shepherd CLI)",
+        replacement=(
+            "/loom:sweep <issue> for the same lifecycle, or "
+            "LOOM_USE_SPAWN_LOOP=1 + ./.loom/scripts/spawn-loop.sh "
+            "for multi-account batches"
+        ),
+    )
+
     # Route shepherd output through stdout to eliminate Bash tool duplication.
     # Claude Code's Bash tool captures output via two mechanisms: PTY (which
     # includes stderr) and explicit stderr capture.  Both are shown in the

--- a/loom-tools/tests/common/test_deprecation.py
+++ b/loom-tools/tests/common/test_deprecation.py
@@ -1,0 +1,160 @@
+"""Tests for ``loom_tools.common.deprecation`` (issue #3376, epic #3372).
+
+The deprecation helper is intentionally tiny — these tests pin the contract
+so Phase 3 (deletion) cannot land without first updating the call sites:
+
+1. Calling ``warn_deprecated`` prints a multi-line block to stderr.
+2. The block contains the component name, the replacement description, and
+   the reference (defaulting to ``#3372``).
+3. ``LOOM_SUPPRESS_DEPRECATION=1`` silences the output entirely.
+4. Any other value (or unset) does NOT silence it.
+5. The function returns ``None`` and never raises.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+
+import pytest
+
+from loom_tools.common.deprecation import warn_deprecated
+
+
+# ---------------------------------------------------------------------------
+# Basic emission
+# ---------------------------------------------------------------------------
+
+
+def test_warn_deprecated_writes_to_stderr(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Output goes to stderr, not stdout."""
+    monkeypatch.delenv("LOOM_SUPPRESS_DEPRECATION", raising=False)
+
+    warn_deprecated("loom-daemon", "spawn-loop.sh + GH Actions")
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "DEPRECATED" in captured.err
+    assert "loom-daemon" in captured.err
+
+
+def test_warn_deprecated_contains_component_replacement_and_ref(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """All three required pieces of information appear in the warning."""
+    monkeypatch.delenv("LOOM_SUPPRESS_DEPRECATION", raising=False)
+
+    warn_deprecated(
+        "/shepherd skill",
+        replacement="/loom:sweep <issue>",
+        ref="#3372",
+    )
+
+    err = capsys.readouterr().err
+    assert "/shepherd skill" in err
+    assert "/loom:sweep <issue>" in err
+    assert "#3372" in err
+
+
+def test_warn_deprecated_default_ref_is_epic(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ``ref`` is omitted, the default points at the umbrella epic."""
+    monkeypatch.delenv("LOOM_SUPPRESS_DEPRECATION", raising=False)
+
+    warn_deprecated("some-component", "some-replacement")
+
+    assert "#3372" in capsys.readouterr().err
+
+
+def test_warn_deprecated_mentions_suppression_envvar(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Output documents the suppression env var so operators can find it.
+
+    Without this hint, the only way to discover ``LOOM_SUPPRESS_DEPRECATION``
+    is to grep the codebase — which downstream installers can't realistically
+    do.  Document it inline.
+    """
+    monkeypatch.delenv("LOOM_SUPPRESS_DEPRECATION", raising=False)
+
+    warn_deprecated("X", "Y")
+
+    assert "LOOM_SUPPRESS_DEPRECATION" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Suppression semantics
+# ---------------------------------------------------------------------------
+
+
+def test_warn_deprecated_suppressed_when_env_set(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``LOOM_SUPPRESS_DEPRECATION=1`` silences the warning."""
+    monkeypatch.setenv("LOOM_SUPPRESS_DEPRECATION", "1")
+
+    warn_deprecated("loom-daemon", "spawn-loop")
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert captured.out == ""
+
+
+def test_warn_deprecated_not_suppressed_by_other_values(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only the exact value ``"1"`` suppresses; other truthy strings do not.
+
+    This matches the bash helper's behaviour (``[[ "$VAR" == "1" ]]``) so
+    Python and shell call sites share a single mental model.
+    """
+    for value in ("", "0", "true", "yes", "on"):
+        monkeypatch.setenv("LOOM_SUPPRESS_DEPRECATION", value)
+        warn_deprecated("component", "replacement")
+        err = capsys.readouterr().err
+        assert "DEPRECATED" in err, (
+            f"LOOM_SUPPRESS_DEPRECATION={value!r} should NOT suppress the warning"
+        )
+
+
+def test_warn_deprecated_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Return value is always ``None`` — both emitting and suppressed paths."""
+    monkeypatch.delenv("LOOM_SUPPRESS_DEPRECATION", raising=False)
+    assert warn_deprecated("X", "Y") is None
+
+    monkeypatch.setenv("LOOM_SUPPRESS_DEPRECATION", "1")
+    assert warn_deprecated("X", "Y") is None
+
+
+# ---------------------------------------------------------------------------
+# Flush behaviour (regression guard)
+# ---------------------------------------------------------------------------
+
+
+def test_warn_deprecated_flushes_immediately(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Output reaches stderr immediately even when stderr is block-buffered.
+
+    Entry-point CLIs may invoke ``warn_deprecated`` and then immediately
+    redirect stderr (e.g. shepherd's ``sys.stderr = sys.stdout``); without
+    ``flush=True`` the warning could be lost.
+    """
+    monkeypatch.delenv("LOOM_SUPPRESS_DEPRECATION", raising=False)
+
+    buf = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", buf)
+
+    warn_deprecated("component", "replacement")
+
+    # The warning should already be in the buffer — no manual flush needed.
+    assert "DEPRECATED" in buf.getvalue()


### PR DESCRIPTION
Closes #3376

Phase 2b of the shepherd/daemon deprecation epic (#3372). Adds soft-deprecation warnings to every deprecated entry point pointing operators at the Phase 1 spawn loop (#3374) + Phase 2a GitHub Actions (#3375) replacements. **No behavior change** — execution continues normally after every warning. The intent is to give downstream consumers (notably sphere's loom-install) a clear signal during the soft-deprecation window before Phase 3 deletes the code.

## What ships

### New helpers (centralized warning text)

- **Python**: `loom_tools.common.deprecation.warn_deprecated(component, replacement, ref="#3372")` — dependency-free, writes a multi-line "⚠️ DEPRECATED" block to stderr, returns `None`, never raises.
- **Shell**: `.loom/scripts/lib/deprecation.sh` (mirrored in `defaults/scripts/lib/`) — sourceable bash helper exposing the same `warn_deprecated` function with identical message format. Safe to `source` (function definitions only, no side effects). `daemon.sh` sources it with a defensive stub fallback so older installs missing the helper don't fail.

### Entry points wired up

| Entry point | Warning emitted from |
|---|---|
| `loom-daemon` (Python) | `loom_tools.daemon_v2.cli.main()` — just before `run(ctx)`, after `--status`/`--health` early returns so introspection output stays clean |
| `./.loom/scripts/daemon.sh start` | `cmd_start` via `lib/deprecation.sh` — fires even if the Python daemon fails to start |
| `loom-shepherd` CLI | `loom_tools.shepherd.cli.main()` — before the `sys.stderr = sys.stdout` redirect so the message reaches real stderr |
| `/shepherd` slash command | Prepended `## ⚠️ Deprecated` section in `defaults/.claude/commands/loom/shepherd.md` (and `defaults/roles/shepherd.md` via symlink) — LLM emits the warning as the first line of its response |

### Suppression

Set `LOOM_SUPPRESS_DEPRECATION=1` to silence the Python and shell warnings. Only the exact value `"1"` suppresses (matches the bash helper's `[[ == "1" ]]` check); other truthy strings (`true`, `yes`, `on`, `0`, …) do NOT suppress. The `/shepherd` markdown skill warning ignores the env var **by design** — operators should explicitly migrate to `/loom:sweep`, not silence the prompt.

This is the lever sphere installs (and any other downstream automation that hasn't migrated yet) need to keep their logs clean during the deprecation window.

### Docs

- `CHANGELOG.md`: `Deprecated` entry under `[Unreleased]` citing #3372 + #3376.
- `CLAUDE.md` and `defaults/CLAUDE.md`: new **Migration: deprecations announced for the next major release** section with the phase table, deprecated-entry-point table, and helper API reference. **Additive** — does NOT remove or rewrite any existing daemon/shepherd documentation (that is Phase 3's job).

## Tests

8 unit tests in `loom-tools/tests/common/test_deprecation.py` pinning the contract:

- stderr emission (not stdout)
- component, replacement, and ref all appear in the warning text
- default `ref` is `#3372` (the umbrella epic)
- `LOOM_SUPPRESS_DEPRECATION=1` suppresses
- other env var values (`"true"`, `"0"`, `"yes"`, `"on"`, `""`) do NOT suppress
- returns `None` in both emitting and suppressed paths
- flushes immediately (regression guard for shepherd's `sys.stderr = sys.stdout` redirect)
- output mentions `LOOM_SUPPRESS_DEPRECATION` inline so operators can discover it

```
$ PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/common/test_deprecation.py -v
8 passed in 0.10s
```

Existing daemon and common tests still pass (318 tests). Pre-existing shepherd test failures in `test_phases.py` and `TestMarkJudgeExhausted` are unrelated to this change (reproduce on `main`).

## Out of scope (per the issue)

- No behavior change beyond stderr emission.
- No auto-redirect of `/shepherd` → `/loom:sweep` (operators should explicitly choose during the window).
- No CI failure when `loom-daemon` is invoked (warnings only — open question #2 in the issue).
- No deletion of existing daemon/shepherd documentation — that is Phase 3's responsibility.

## Coordination note

This PR ships alongside #3375 (Phase 2a GitHub Actions workflows). Both touch `CLAUDE.md`; this PR's edits are surgically scoped to a new "Migration" section so merge ordering with #3375 doesn't matter.

## Migration section preview

See the new **"Migration: deprecations announced for the next major release"** sections in `CLAUDE.md` and `defaults/CLAUDE.md` for the phase table and deprecated-entry-point reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)