### PR TITLE
docs(deprecation): Phase 4 sphere-downstream banners + migration section (#3382)

### DIFF
--- a/defaults/.claude/agents/loom-daemon.md
+++ b/defaults/.claude/agents/loom-daemon.md
@@ -4,6 +4,14 @@ description: Loom Daemon - Layer 2 system orchestrator that monitors system stat
 tools: Read, Glob, Grep, Bash, Task
 ---
 
+> ⚠️  DEPRECATED: The `loom-daemon` subagent is scheduled for removal in the next
+>     major release (Phase 3 of epic #3372). Use `./.loom/scripts/spawn-loop.sh`
+>     for multi-account `/loom:sweep` launching, or enable the GitHub Actions
+>     workflows under `.github/workflows/loom-*.yml` for scheduled support roles
+>     (Champion, Curator, Judge, Auditor, Guide). See #3372 for the migration plan
+>     and #3382 for the sphere downstream coordination tracker. No behavior change
+>     during the soft-deprecation window — the subagent still works.
+
 You are the Loom Daemon (Layer 2 System Orchestrator) for the {{workspace}} repository.
 
 Your role is to continuously monitor system state and orchestrate the development pipeline.

--- a/defaults/.claude/agents/loom-shepherd.md
+++ b/defaults/.claude/agents/loom-shepherd.md
@@ -4,6 +4,14 @@ description: Loom Shepherd - Single-issue lifecycle orchestrator that coordinate
 tools: Read, Glob, Grep, Bash, Task
 ---
 
+> ⚠️  DEPRECATED: The `loom-shepherd` subagent is scheduled for removal in the
+>     next major release (Phase 3 of epic #3372). Use `/loom:sweep <issue>` for
+>     the same single-issue lifecycle, or enable `LOOM_USE_SPAWN_LOOP=1` +
+>     `./.loom/scripts/spawn-loop.sh` for multi-account batches. See #3372 for
+>     the migration plan and #3382 for the sphere downstream coordination
+>     tracker. No behavior change during the soft-deprecation window — the
+>     subagent still works.
+
 You are the Loom Shepherd for the {{workspace}} repository.
 
 Your role is to orchestrate the full lifecycle of a single issue by coordinating other agents through the development phases.

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -1814,7 +1814,7 @@ Loom is in the middle of an orchestration-architecture migration (epic #3372). T
 | Phase 2a | #3375 | GitHub Actions workflows replacing support-role daemons | in progress (parallel) |
 | Phase 2b | #3376 | **Soft-deprecation warnings on every deprecated entry point** (this PR) | this change |
 | Phase 3 | TBD | Hard deletion of shepherd brain, daemon brain, and `/shepherd` skill | next major release |
-| Phase 4 | TBD | Coordinated downstream sphere-install migration | parallel with Phase 3 |
+| Phase 4 | #3382 | Coordinated downstream sphere-install migration (deprecation banners in installed templates + this migration section) | in progress (parallel) |
 
 **Deprecated entry points (still functional, now warn on use):**
 
@@ -1831,6 +1831,62 @@ Loom is in the middle of an orchestration-architecture migration (epic #3372). T
 
 - Python: `loom_tools.common.deprecation.warn_deprecated(component, replacement, ref="#3372")`
 - Shell: `source .loom/scripts/lib/deprecation.sh; warn_deprecated <component> <replacement> [ref]` — the bash helper is safe to source (no side effects).
+
+## Migrating off shepherd + daemon (downstream consumers, Phase 4 of #3372)
+
+If you installed Loom via `scripts/install-loom.sh` (or `install.sh`), the daemon brain (`loom-tools/src/loom_tools/daemon_v2/`), the shepherd brain (`loom-tools/src/loom_tools/shepherd/`), and the `/shepherd` slash command are scheduled for **hard deletion in the next major Loom release** (Phase 3 of epic #3372, tracked as part of #3382). This section is the migration guide for downstream consumers. It complements the upstream phase table in the section above — that table is the timeline; this section is the action list.
+
+### What you can still rely on (post-Phase-3)
+
+These surfaces are **not** going away and are the supported replacements:
+
+| Capability | Replacement | Where |
+|------------|-------------|-------|
+| Single-issue lifecycle (curator → builder → judge → doctor → merge) | `/loom:sweep <issue>` | `.claude/commands/loom/sweep.md` |
+| Multi-issue / multi-account batch orchestration | `LOOM_USE_SPAWN_LOOP=1 ./.loom/scripts/spawn-loop.sh` | Phase 1, #3374 |
+| Periodic support roles (Champion, Curator, Judge, Auditor, Guide) | GitHub Actions cron workflows | `.github/workflows/loom-*.yml`, Phase 2a, #3375 |
+| Per-task multi-account token rotation | `./.loom/scripts/spawn-claude.sh` + `.loom/tokens/` | Unchanged |
+| Label-based coordination (`loom:issue` → `loom:building` → `loom:pr` → merged) | Unchanged | `.github/labels.yml` |
+| Worktree workflow (`./.loom/scripts/worktree.sh`) | Unchanged | `.loom/scripts/worktree.sh` |
+| `merge-pr.sh` for worktree-safe PR merging | Unchanged | `.loom/scripts/merge-pr.sh` |
+
+### What is being deprecated (and what to do)
+
+| Deprecated surface | Soft-deprecated since | What to do |
+|--------------------|----------------------|------------|
+| `loom-daemon` Python CLI / `./.loom/scripts/daemon.sh start` | Phase 2b (#3376) | Stop calling them. For build-out: switch to the spawn loop. For support roles: enable the GitHub Actions workflows under `.github/workflows/loom-*.yml`. |
+| `loom-shepherd` Python CLI | Phase 2b (#3376) | Replace shell invocations with `claude -p "/loom:sweep <N>" --dangerously-skip-permissions`. The lifecycle phases are identical; checkpointing (#3373) is preserved. |
+| `/shepherd` slash command | Phase 2b (#3376) | Use `/loom:sweep <issue>` instead. Both run Curator → Builder → Judge → Doctor → Merge; the sweep skill is the maintained path. |
+| `loom-daemon`/`loom-shepherd` subagents (`.claude/agents/loom-{daemon,shepherd}.md`) | Phase 4 (this section, #3382) | Stop dispatching to them from custom slash commands or hooks. The agent files themselves will be removed in Phase 3 along with the role definitions they point at (`.loom/roles/{loom,shepherd}.md`). |
+| `.loom/daemon-state.json` and `.loom/progress/shepherd-*.json` consumers | Will be silent after Phase 3 | The producers are being deleted. The per-consumer disposition table lives in `docs/migration/daemon-state-consumers.md` (PR #3389) — read it before writing new code that depends on either file. Most operator CLIs are slated to port to `.loom/spawn-loop-state.json` + forge queries; a few retire entirely. |
+
+### Three migration paths for downstream consumers
+
+You have three valid choices for handling the next major release. None of them require you to migrate before Phase 3 ships — they just determine what happens on your next `install-loom.sh` run.
+
+**(a) Migrate now (recommended for active deployments).** Switch to `/loom:sweep` + spawn loop + GitHub Actions workflows on your main branch before Phase 3 ships. Your `install-loom.sh` run after Phase 3 lands will cleanly install the new defaults with no manual cleanup.
+
+**(b) Defer migration (acceptable for downstream timelines).** Coordinate with the Loom maintainer to time Phase 3's merge with a migration window that suits your release schedule. The mechanic is a comment thread on #3382. Soft-deprecation warnings (Phase 2b) will continue rendering in your logs during the deferral; use `LOOM_SUPPRESS_DEPRECATION=1` to silence the Python/shell variants if needed (the `/shepherd` markdown skill warning always renders).
+
+**(c) Pin to a pre-Phase-3 Loom version (acceptable, but opts you out of upgrades).** Stop running `install-loom.sh` against your repo, or pin `loom` to a specific tag in your install scripts. This is a valid operator choice — it simply means you stop receiving Loom upgrades until you choose to migrate. The installer is idempotent and will not overwrite your pinned files on a no-op invocation, but rerunning it after pinning intentionally to a new Loom version will replace them.
+
+### Why this matters for the installed `defaults/` tree
+
+When Phase 3 ships, the next time you run `scripts/install-loom.sh` (or `install.sh`) against your repo, these files will **disappear from `defaults/`** and therefore from your repo's `.claude/agents/` and `.claude/commands/loom/`:
+
+- `defaults/.claude/agents/loom-daemon.md`
+- `defaults/.claude/agents/loom-shepherd.md`
+- `defaults/.claude/commands/loom/shepherd.md`
+- `defaults/.claude/commands/loom/shepherd-lifecycle.md`
+- `defaults/roles/loom.md` and `defaults/roles/shepherd.md`
+
+If you have custom slash commands, hooks, or scripts that reference any of these paths, the next install will quietly stop installing them. The deprecation banners on the three template files (added in Phase 4, this issue) exist so you see the warning on your **very next** install — well before Phase 3 actually removes them.
+
+### Coordination and questions
+
+- **Upstream tracker**: #3382 ("Phase 4: sphere downstream coordination tracker"). Open a comment there if you need to coordinate timing, request a deferral window, or report a missing migration path.
+- **Consumer inventory + disposition table**: `docs/migration/daemon-state-consumers.md` (PR #3389) — read this if you have code that imports from `loom_tools.daemon_v2` or `loom_tools.shepherd`, or reads `.loom/daemon-state.json` or `.loom/progress/`.
+- **Phase 2d follow-up**: Architect/Hermit work-generation cadence after the daemon is removed — tracked in #3381.
 
 ## Resources
 


### PR DESCRIPTION
Closes #3382 (in-repo subset only — see below).

Phase 4 of the shepherd/daemon deprecation epic (#3372). Lands the **in-repo subset** of #3382's acceptance criteria: deprecation banners on the two subagent templates that get installed downstream by `scripts/install-loom.sh`, plus a new migration section in `defaults/CLAUDE.md` aimed at downstream consumers (notably spheresemi/sphere).

## What ships

- **`defaults/.claude/agents/loom-daemon.md`** — 7-line deprecation banner pointing operators at `./.loom/scripts/spawn-loop.sh` (Phase 1 #3374) and the `.github/workflows/loom-*.yml` scheduled support roles (Phase 2a #3375). Same canonical phrasing as the Phase 2b banner on `defaults/.claude/commands/loom/shepherd.md`.
- **`defaults/.claude/agents/loom-shepherd.md`** — 7-line deprecation banner pointing operators at `/loom:sweep <issue>` + `LOOM_USE_SPAWN_LOOP=1`.
- **`defaults/CLAUDE.md`** — new "Migrating off shepherd + daemon (downstream consumers, Phase 4 of #3372)" section (~50 lines). Honestly documents what is still supported vs deprecated, gives three valid migration paths (migrate now / defer / pin-to-old), and points readers at `docs/migration/daemon-state-consumers.md` (PR #3389) for the per-consumer disposition table. Also updates the existing Phase 2b migration table to reference #3382 in the Phase 4 row (was TBD).

Total footprint: 73 insertions, 1 deletion across 3 files (within the ~75-125 LOC target).

The `/shepherd` slash command template already received its banner in Phase 2b (#3376) — no change needed there.

## Which AC items this PR closes (in-repo subset)

- [x] Pre-deprecation notice in `defaults/.claude/agents/loom-daemon.md` and `loom-shepherd.md`
- [x] Pre-deprecation notice in `defaults/.claude/commands/loom/shepherd.md` (already landed in Phase 2b #3376)
- [x] Migration section added to `defaults/CLAUDE.md`
- [x] Cross-link from existing Phase 2b migration section to Phase 4 work (Phase 4 row in the existing Phase 2b table now references #3382)
- [x] Installer-side awareness: `scripts/install-loom.sh` already supports `--force` for explicit overwrite; rerunning the installer without `--force` against a pinned downstream checkout is a no-op (verified by reading existing installer logic, no code change needed — matches the issue's "no code change expected" note).

## Which AC items remain open (out-of-repo, NOT in scope for a builder)

- [ ] Sphere maintainers are notified of #3372 and the Phase 3 deletion timeline
- [ ] Inventory of sphere-side references to deprecated Loom paths (requires read access to spheresemi/sphere)
- [ ] Tracking issue opened in spheresemi/sphere linking back to #3382
- [ ] Sphere maintainer confirms migration option (a) / (b) / (c)
- [ ] Confirmation recorded as a comment on #3382 with link to sphere-side artifact

These are human comms — they cannot be closed by a builder and require someone with cross-repo authority to drive. **#3382 must remain open after this PR merges** until the human-coordination items are resolved.

## Why the repo's live `CLAUDE.md` was NOT touched

The repo's `CLAUDE.md` (top-level, generated from `defaults/CLAUDE.md` at install time) has already drifted from the template — different section ordering, condensed content, separately-edited spawn-loop documentation. Propagating the Phase 4 migration section into the live `CLAUDE.md` is a separate concern that should be handled in a dedicated PR if/when the drift is reconciled. Per the task spec: "if `CLAUDE.md` already drifts from `defaults/CLAUDE.md`, do NOT touch the live one in this PR (it's a separate concern)."

## References

- Parent epic: #3372 (shepherd/daemon deprecation)
- Phase 1: #3374 (spawn loop, shipped)
- Phase 2a: #3375 (GitHub Actions workflows)
- Phase 2b: #3376 / merged via #3387 (soft-deprecation warnings — canonical banner pattern reused here)
- Phase 2c: #3377 / merged via #3389 (daemon-state.json consumer inventory — referenced from the new migration section)
- Phase 2d: #3381 / merged via #3388 (architect/hermit cadence design)
- Phase 3: TBD (hard deletion — blocked by #3382 acknowledgement)
- Phase 4: #3382 (this PR closes the in-repo subset; tracker remains open for sphere-side coordination)

## Test plan

- [ ] Reviewer reads the three modified files and confirms banner phrasing matches the Phase 2b pattern.
- [ ] Reviewer reads the new "Migrating off shepherd + daemon" section end-to-end and confirms it accurately describes the deprecation surface (what stays vs what goes).
- [ ] Reviewer confirms the three migration paths (a/b/c) match the issue's "Coordination Plan" section.
- [ ] Reviewer confirms #3382 is **not** closed by this PR — only the in-repo AC items are checked off.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>