### PR TITLE
fix(loom-daemon): retire daemon-brain .gitignore patterns in post_init (#3402)

### DIFF
--- a/loom-daemon/src/init/post_init.rs
+++ b/loom-daemon/src/init/post_init.rs
@@ -109,21 +109,22 @@ pub fn update_gitignore(workspace_path: &Path) -> Result<(), String> {
 
     // Ephemeral/runtime files that should be ignored.
     // Keep in sync with the Loom source repo's .gitignore (lines 36–78).
+    //
+    // Phase 3.5 (#3402, epic #3372): removed patterns for retired daemon-brain
+    // state files (`daemon-state.json`, archived `[0-9][0-9]-daemon-state.json`,
+    // `progress/`, `stuck-history.json`, `alerts.json`, `health-metrics.json`)
+    // and added `spawn-loop-state.json` for the Phase 1 spawn loop (#3374).
     let ephemeral_patterns = [
         ".loom-in-use",
         ".loom-checkpoint",
         ".loom/.daemon.pid",
         ".loom/.daemon.log",
         ".loom/daemon.sock",
-        ".loom/daemon-state.json",
         ".loom/daemon-loop.pid",
         ".loom/daemon-metrics.json",
         ".loom/loom-source-path",
-        ".loom/[0-9][0-9]-daemon-state.json",
-        ".loom/stuck-history.json",
-        ".loom/alerts.json",
+        ".loom/spawn-loop-state.json",
         ".loom/issue-failures.json",
-        ".loom/health-metrics.json",
         ".loom/interventions/",
         ".loom/worktrees/",
         ".loom/state.json",
@@ -132,7 +133,6 @@ pub fn update_gitignore(workspace_path: &Path) -> Result<(), String> {
         ".loom/claims/",
         ".loom/signals/",
         ".loom/status/",
-        ".loom/progress/",
         ".loom/retry-state/",
         ".loom/diagnostics/",
         ".loom/guide-docs-state.json",
@@ -244,17 +244,23 @@ mod tests {
         // Spot-check key runtime patterns
         assert!(contents.contains(".loom-in-use"));
         assert!(contents.contains(".loom-checkpoint"));
-        assert!(contents.contains(".loom/daemon-state.json"));
+        assert!(contents.contains(".loom/spawn-loop-state.json"));
         assert!(contents.contains(".loom/worktrees/"));
-        assert!(contents.contains(".loom/progress/"));
         assert!(contents.contains(".loom/*.log"));
         assert!(contents.contains(".loom/logs/"));
         assert!(contents.contains(".loom/daemon-metrics.json"));
-        assert!(contents.contains(".loom/[0-9][0-9]-daemon-state.json"));
         assert!(contents.contains(".loom/activity.db"));
         assert!(contents.contains(".loom/issue-failures.json"));
         assert!(contents.contains(".loom/usage-cache.json"));
         assert!(contents.contains("# Loom runtime state"));
+
+        // Retired daemon-brain patterns must NOT be emitted (Phase 3.5, #3402)
+        assert!(!contents.contains(".loom/daemon-state.json"));
+        assert!(!contents.contains(".loom/[0-9][0-9]-daemon-state.json"));
+        assert!(!contents.contains(".loom/progress/"));
+        assert!(!contents.contains(".loom/stuck-history.json"));
+        assert!(!contents.contains(".loom/alerts.json"));
+        assert!(!contents.contains(".loom/health-metrics.json"));
 
         // config.json must NOT be gitignored
         assert!(!contents.contains(".loom/config.json"));
@@ -280,8 +286,8 @@ mod tests {
         assert_eq!(contents.matches(".loom/worktrees/").count(), 1);
         // New patterns added
         assert!(contents.contains(".loom-in-use"));
-        assert!(contents.contains(".loom/daemon-state.json"));
-        assert!(contents.contains(".loom/progress/"));
+        assert!(contents.contains(".loom/spawn-loop-state.json"));
+        assert!(contents.contains(".loom/daemon-metrics.json"));
         assert!(contents.contains(".loom/activity.db"));
     }
 
@@ -294,7 +300,7 @@ mod tests {
 
         let contents = fs::read_to_string(tmp.path().join(".gitignore")).unwrap();
 
-        assert_eq!(contents.matches(".loom/daemon-state.json").count(), 1);
+        assert_eq!(contents.matches(".loom/spawn-loop-state.json").count(), 1);
         assert_eq!(contents.matches(".loom-in-use").count(), 1);
         assert_eq!(contents.matches(".loom/worktrees/").count(), 1);
     }
@@ -315,15 +321,11 @@ mod tests {
             ".loom/.daemon.pid",
             ".loom/.daemon.log",
             ".loom/daemon.sock",
-            ".loom/daemon-state.json",
             ".loom/daemon-loop.pid",
             ".loom/daemon-metrics.json",
             ".loom/loom-source-path",
-            ".loom/[0-9][0-9]-daemon-state.json",
-            ".loom/stuck-history.json",
-            ".loom/alerts.json",
+            ".loom/spawn-loop-state.json",
             ".loom/issue-failures.json",
-            ".loom/health-metrics.json",
             ".loom/interventions/",
             ".loom/worktrees/",
             ".loom/state.json",
@@ -332,7 +334,6 @@ mod tests {
             ".loom/claims/",
             ".loom/signals/",
             ".loom/status/",
-            ".loom/progress/",
             ".loom/retry-state/",
             ".loom/diagnostics/",
             ".loom/guide-docs-state.json",
@@ -351,6 +352,22 @@ mod tests {
             assert!(
                 contents.contains(pattern),
                 "Missing pattern in generated .gitignore: {pattern}"
+            );
+        }
+
+        // Retired patterns (Phase 3.5, #3402) must no longer appear
+        let retired = [
+            ".loom/daemon-state.json",
+            ".loom/[0-9][0-9]-daemon-state.json",
+            ".loom/progress/",
+            ".loom/stuck-history.json",
+            ".loom/alerts.json",
+            ".loom/health-metrics.json",
+        ];
+        for pattern in &retired {
+            assert!(
+                !contents.contains(pattern),
+                "Retired pattern should not be in generated .gitignore: {pattern}"
             );
         }
     }
@@ -499,7 +516,7 @@ mod tests {
         );
 
         // Specific ephemeral patterns should be added instead
-        assert!(contents.contains(".loom/daemon-state.json"));
+        assert!(contents.contains(".loom/spawn-loop-state.json"));
         assert!(contents.contains(".loom/state.json"));
         assert!(contents.contains(".loom/worktrees/"));
 


### PR DESCRIPTION
Closes #3402

Parent: epic #3372 (shepherd/daemon deprecation), tracker #3378 (Phase 3 meta).
Authoritative source: `docs/migration/daemon-state-consumers.md` §Category 5 + §"Recommended Phase 3 PR sequencing" PR 3.5.

## What changed

`loom-daemon/src/init/post_init.rs` (Rust binary that writes a target repo's `.gitignore` during `loom-daemon init`):

**Removed** patterns — these state files are produced only by the Python daemon brain (`loom-tools/src/loom_tools/daemon_v2/`) which Phase 3 deletes:

- `.loom/daemon-state.json`
- `.loom/[0-9][0-9]-daemon-state.json` (rotated session archives)
- `.loom/progress/` (shepherd milestone files)
- `.loom/stuck-history.json`
- `.loom/alerts.json`
- `.loom/health-metrics.json`

**Added** pattern:

- `.loom/spawn-loop-state.json` — runtime state file for the Phase 1 spawn loop (#3374).

## Test updates

Five test assertion sites flagged in the architect's Phase 2c walk-through (lines 247, 249, 253, 283, 284, 297, 318, 322, 335, 502) were updated. Additionally, `covers_all_source_repo_gitignore_patterns` now negatively asserts the retired patterns are absent, and `creates_gitignore_with_all_patterns_when_none_exists` has six new `!contents.contains(...)` regression guards.

## Before/after `.gitignore` diff (fresh init)

```diff
 .loom-in-use
 .loom-checkpoint
 .loom/.daemon.pid
 .loom/.daemon.log
 .loom/daemon.sock
-.loom/daemon-state.json
 .loom/daemon-loop.pid
 .loom/daemon-metrics.json
 .loom/loom-source-path
-.loom/[0-9][0-9]-daemon-state.json
-.loom/stuck-history.json
-.loom/alerts.json
+.loom/spawn-loop-state.json
 .loom/issue-failures.json
-.loom/health-metrics.json
 .loom/interventions/
 .loom/worktrees/
 .loom/state.json
 .loom/mcp-command.json
 .loom/activity.db
 .loom/claims/
 .loom/signals/
 .loom/status/
-.loom/progress/
 .loom/retry-state/
 ...
```

## Acceptance criteria

- [x] Removed the six retired patterns.
- [x] Added `.loom/spawn-loop-state.json`.
- [x] Updated all unit-test assertion sites in the same module.
- [x] Added negative-assertion regression guards so future drift is caught.
- [x] No changes outside `loom-daemon/src/init/post_init.rs`.
- [x] No `Cargo.toml` version bumps.
- [x] No new GitHub labels.

## Test status

`cargo test -p loom-daemon init::post_init` is currently blocked **on `main` as well** by a pre-existing dependency issue: PR #3368 (`cd271ba9 build(deps): bump the all-dependencies group`) bumped `rusqlite -> 0.40` which transitively pulls `libsqlite3-sys 0.38.0`, and that crate uses the unstable `cfg_select!` feature (stable Rust 1.92 rejects it with E0658). This is **unrelated to this PR** — every `cargo check` in the workspace hits the same error before any of the touched source is even compiled.

Source-level validation performed instead:

- Standalone `rustc --edition 2024 --emit=metadata --crate-type lib src/init/post_init.rs` compiles cleanly (exit 0) — confirms syntactic + type validity of the edits.
- A fresh clone of `main` (`f3aec96e`, pre-bump) builds and runs the post_init tests successfully (13 passed), which is the baseline this PR preserves modulo the assertion updates.

Suggested follow-up (out of scope here): a separate PR pinning `libsqlite3-sys = "=0.37.0"` in the workspace or moving to a Rust toolchain that ships the `cfg_select!` feature stably.