### PR TITLE
feat(status): port loom-status to spawn-loop-state.json + forge (with daemon-state.json fallback) (#3390)

### DIFF
--- a/loom-tools/src/loom_tools/common/paths.py
+++ b/loom-tools/src/loom_tools/common/paths.py
@@ -35,6 +35,7 @@ class LoomPaths:
 
     # State file names
     DAEMON_STATE_FILE = "daemon-state.json"
+    SPAWN_LOOP_STATE_FILE = "spawn-loop-state.json"
     HEALTH_METRICS_FILE = "health-metrics.json"
     ALERTS_FILE = "alerts.json"
     STUCK_HISTORY_FILE = "stuck-history.json"
@@ -119,6 +120,11 @@ class LoomPaths:
     def daemon_state_file(self) -> Path:
         """Path to .loom/daemon-state.json."""
         return self.loom_dir / self.DAEMON_STATE_FILE
+
+    @property
+    def spawn_loop_state_file(self) -> Path:
+        """Path to .loom/spawn-loop-state.json (Phase 1, #3374)."""
+        return self.loom_dir / self.SPAWN_LOOP_STATE_FILE
 
     @property
     def health_metrics_file(self) -> Path:

--- a/loom-tools/src/loom_tools/common/state.py
+++ b/loom-tools/src/loom_tools/common/state.py
@@ -18,6 +18,7 @@ from loom_tools.models.baseline_health import BaselineHealth
 from loom_tools.models.daemon_state import DaemonState
 from loom_tools.models.health import AlertsFile, HealthMetrics
 from loom_tools.models.progress import ShepherdProgress
+from loom_tools.models.spawn_loop_state import SpawnLoopState
 from loom_tools.models.stuck import StuckHistory
 
 
@@ -144,6 +145,27 @@ def read_daemon_state(repo_root: pathlib.Path) -> DaemonState:
     if isinstance(data, list):
         return DaemonState()
     return DaemonState.from_dict(data)
+
+
+def read_spawn_loop_state(repo_root: pathlib.Path) -> SpawnLoopState:
+    """Load ``.loom/spawn-loop-state.json`` into a :class:`SpawnLoopState`.
+
+    Returns a :class:`SpawnLoopState` with ``present=False`` when the file
+    is missing — callers (e.g. ``loom-status``) use this to fall back to
+    ``.loom/daemon-state.json`` for back-compat (Phase 3 port, #3390).
+
+    Phase 3.4 (#3401) trims the daemon-state fallback once all 3.1.x ports
+    have landed.
+    """
+    paths = LoomPaths(repo_root)
+    if not paths.spawn_loop_state_file.exists():
+        return SpawnLoopState.absent()
+    data = read_json_file(paths.spawn_loop_state_file)
+    if not isinstance(data, dict):
+        # File exists but malformed — still mark as present so the caller
+        # knows the spawn loop is at least configured; just return empty.
+        return SpawnLoopState(present=True)
+    return SpawnLoopState.from_dict(data)
 
 
 def read_progress_files(repo_root: pathlib.Path) -> list[ShepherdProgress]:

--- a/loom-tools/src/loom_tools/models/spawn_loop_state.py
+++ b/loom-tools/src/loom_tools/models/spawn_loop_state.py
@@ -1,0 +1,100 @@
+"""Model for ``.loom/spawn-loop-state.json`` (Phase 1, #3374).
+
+The spawn loop writes a minimal state file with the following shape::
+
+    {
+      "started_at": "2026-06-02T16:12:19Z",
+      "running": [
+        {
+          "issue": 42,
+          "pid": 12345,
+          "started_at": "2026-06-02T16:15:00Z",
+          "token": "robb-personal"
+        },
+        ...
+      ]
+    }
+
+There are intentionally *no* shepherd-pool slot identifiers, no support-role
+status, no pipeline state, no warnings, and no completed-issue history — the
+spawn loop tracks only the bare minimum needed to reap dead children and
+respect MAX_PARALLEL. Anything richer comes from the forge (`gh issue list`,
+`gh pr list`).
+
+This module is part of the Phase 3 port (epic #3372, tracker #3378) and is
+read by ``loom-status`` and other operator CLIs as they migrate off
+``.loom/daemon-state.json``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class SpawnLoopTask:
+    """A single sweep child tracked by the spawn loop."""
+
+    issue: int
+    pid: int
+    started_at: str | None = None
+    token: str | None = None
+    # The spawn loop does not currently write a heartbeat field, but reserving
+    # the slot makes future schema additions (e.g., per-task heartbeat from
+    # ``checkpoint.sh``) backwards compatible. ``loom-stuck-detection`` (a
+    # sibling port) will likely populate this.
+    last_heartbeat: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SpawnLoopTask:
+        # ``issue`` and ``pid`` are required by the spawn loop; if missing we
+        # synthesize sentinel values rather than crash. The CLI will simply
+        # display them as ``?`` / ``0``.
+        return cls(
+            issue=int(data.get("issue") or 0),
+            pid=int(data.get("pid") or 0),
+            started_at=data.get("started_at"),
+            token=data.get("token"),
+            last_heartbeat=data.get("last_heartbeat"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {"issue": self.issue, "pid": self.pid}
+        for k in ("started_at", "token", "last_heartbeat"):
+            v = getattr(self, k)
+            if v is not None:
+                d[k] = v
+        return d
+
+
+@dataclass
+class SpawnLoopState:
+    """Parsed contents of ``.loom/spawn-loop-state.json``.
+
+    ``present`` is True when the file existed and parsed successfully.
+    Callers use this to decide whether to fall back to ``daemon-state.json``.
+    """
+
+    started_at: str | None = None
+    running: list[SpawnLoopTask] = field(default_factory=list)
+    present: bool = False
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SpawnLoopState:
+        running_raw = data.get("running") or []
+        tasks: list[SpawnLoopTask] = []
+        if isinstance(running_raw, list):
+            for item in running_raw:
+                if isinstance(item, dict):
+                    tasks.append(SpawnLoopTask.from_dict(item))
+        return cls(
+            started_at=data.get("started_at"),
+            running=tasks,
+            present=True,
+        )
+
+    @classmethod
+    def absent(cls) -> SpawnLoopState:
+        """Sentinel for "no spawn-loop-state file on disk." """
+        return cls(present=False)

--- a/loom-tools/src/loom_tools/status.py
+++ b/loom-tools/src/loom_tools/status.py
@@ -4,6 +4,12 @@ Replaces the former ``loom-status.sh`` (814 LOC) with a Python module that
 reuses ``snapshot.build_snapshot()`` for data collection and provides
 colored terminal formatting.
 
+Phase 3 port (#3390, epic #3372): primary live-state source is now
+``.loom/spawn-loop-state.json`` (Phase 1, #3374) plus forge queries.
+``.loom/daemon-state.json`` is retained as a fallback so the CLI keeps
+working against workspaces still running the legacy Python daemon brain.
+The fallback is removed in Phase 3.4 (#3401).
+
 Usage::
 
     loom-status              # colored terminal output
@@ -21,9 +27,14 @@ from datetime import datetime, timezone
 from typing import Any, Sequence
 
 from loom_tools.common.repo import find_repo_root
-from loom_tools.common.state import read_daemon_state, read_json_file
+from loom_tools.common.state import (
+    read_daemon_state,
+    read_json_file,
+    read_spawn_loop_state,
+)
 from loom_tools.common.time_utils import parse_iso_timestamp
 from loom_tools.models.daemon_state import DaemonState
+from loom_tools.models.spawn_loop_state import SpawnLoopState, SpawnLoopTask
 from loom_tools.snapshot import build_snapshot
 
 # ---------------------------------------------------------------------------
@@ -169,12 +180,43 @@ def render_daemon_status(
     c: _Colors,
     *,
     _now: datetime | None = None,
+    spawn_loop_state: SpawnLoopState | None = None,
 ) -> list[str]:
-    """Render daemon status section."""
-    lines: list[str] = []
-    stop_file = repo_root / ".loom" / "stop-daemon"
+    """Render orchestrator status section.
 
-    if stop_file.exists():
+    When *spawn_loop_state* is provided and ``present=True``, the spawn
+    loop is treated as the active orchestrator (label "Spawn Loop") and
+    daemon-state fields are ignored. Otherwise this falls back to the
+    legacy daemon-state-derived display.
+    """
+    lines: list[str] = []
+    stop_daemon = repo_root / ".loom" / "stop-daemon"
+    stop_loop = repo_root / ".loom" / "stop-spawn-loop"
+    loop_pidfile = repo_root / ".loom" / "spawn-loop.pid"
+
+    # Spawn-loop primary path: explicit running detection via pidfile + state.
+    if spawn_loop_state is not None and spawn_loop_state.present:
+        loop_alive = loop_pidfile.exists()
+        if stop_loop.exists():
+            status = f"{c.yellow}Stopping{c.reset}"
+        elif loop_alive:
+            status = f"{c.green}Running{c.reset}"
+        else:
+            status = f"{c.red}Stopped{c.reset}"
+
+        uptime = (
+            format_uptime(spawn_loop_state.started_at, _now=_now)
+            if loop_alive and spawn_loop_state.started_at
+            else "n/a"
+        )
+
+        lines.append(f"  {c.bold}Spawn Loop:{c.reset} {status}")
+        lines.append(f"  {c.bold}Uptime:{c.reset} {uptime}")
+        lines.append(f"  {c.bold}Tracked Tasks:{c.reset} {len(spawn_loop_state.running)}")
+        return lines
+
+    # Legacy daemon-state fallback.
+    if stop_daemon.exists():
         status = f"{c.yellow}Stopping{c.reset}"
     elif daemon_state.running:
         status = f"{c.green}Running{c.reset}"
@@ -187,6 +229,46 @@ def render_daemon_status(
     lines.append(f"  {c.bold}Daemon:{c.reset} {status}")
     lines.append(f"  {c.bold}Uptime:{c.reset} {uptime}")
     lines.append(f"  {c.bold}Last Poll:{c.reset} {last_poll}")
+
+    return lines
+
+
+def render_spawn_loop_tasks(
+    spawn_loop_state: SpawnLoopState,
+    c: _Colors,
+    *,
+    _now: datetime | None = None,
+) -> list[str]:
+    """Render spawn-loop in-flight task rows (replacement for render_shepherds).
+
+    Each spawn-loop child is a ``claude -p "/loom:sweep N"`` invocation with
+    its own OAuth token. We have far less per-task state than the daemon
+    brain emitted (no phases, no judge retries, no PR number), so the row
+    is intentionally minimal: ``issue``, ``pid``, ``uptime``, ``token``.
+    """
+    lines = [f"  {c.bold}In-Flight Tasks:{c.reset}"]
+
+    if not spawn_loop_state.running:
+        lines.append(f"    {c.gray}No tasks running (spawn loop idle){c.reset}")
+        return lines
+
+    lines.append(f"    {c.cyan}{len(spawn_loop_state.running)} task(s) running{c.reset}")
+    lines.append("")
+
+    for task in sorted(spawn_loop_state.running, key=lambda t: t.issue):
+        uptime = (
+            format_uptime(task.started_at, _now=_now)
+            if task.started_at
+            else "unknown"
+        )
+        token_part = f" [token: {task.token}]" if task.token and task.token != "unknown" else ""
+        heartbeat_part = ""
+        if task.last_heartbeat:
+            heartbeat_part = f" [heartbeat: {time_ago(task.last_heartbeat, _now=_now)}]"
+        lines.append(
+            f"    {c.green}sweep-{task.issue}:{c.reset} Issue #{task.issue} "
+            f"pid={task.pid} ({uptime}){token_part}{heartbeat_part}"
+        )
 
     return lines
 
@@ -521,10 +603,21 @@ def output_formatted(
     *,
     use_color: bool = True,
     _now: datetime | None = None,
+    spawn_loop_state: SpawnLoopState | None = None,
 ) -> str:
-    """Render full formatted status display."""
+    """Render full formatted status display.
+
+    When *spawn_loop_state* is supplied with ``present=True``, the spawn loop
+    is treated as the primary source for live-task and orchestrator status;
+    daemon-state-derived sections (support roles, session stats, pipeline,
+    warnings) are suppressed because the spawn loop does not populate them.
+    Forge-derived sections (system state, layer-3 actions, stuck detection)
+    render the same way in both modes.
+    """
     c = _Colors(use_color=use_color)
     lines: list[str] = []
+
+    spawn_loop_primary = spawn_loop_state is not None and spawn_loop_state.present
 
     lines.append("")
     lines.append(f"{c.bold}{c.cyan}======================================================================={c.reset}")
@@ -532,19 +625,30 @@ def output_formatted(
     lines.append(f"{c.bold}{c.cyan}======================================================================={c.reset}")
     lines.append("")
 
-    lines.extend(render_daemon_status(daemon_state, repo_root, c, _now=_now))
+    lines.extend(render_daemon_status(
+        daemon_state, repo_root, c, _now=_now,
+        spawn_loop_state=spawn_loop_state,
+    ))
     lines.append("")
     lines.extend(render_system_state(snapshot, c))
     lines.append("")
-    lines.extend(render_shepherds(daemon_state, c, _now=_now))
-    lines.append("")
-    lines.extend(render_support_roles(daemon_state, c, _now=_now))
-    lines.append("")
-    lines.extend(render_session_stats(daemon_state, c))
-    lines.append("")
-    lines.extend(render_pipeline_status(daemon_state, c, _now=_now))
-    lines.append("")
-    lines.extend(render_warnings(daemon_state, c))
+    if spawn_loop_primary:
+        # Spawn loop only tracks in-flight sweep children — no shepherd pool,
+        # no support roles, no pipeline blocked-list, no warnings ring.
+        # Operators get forge-derived pipeline counts via render_system_state
+        # above; per-task detail comes from render_spawn_loop_tasks.
+        assert spawn_loop_state is not None  # for type checkers
+        lines.extend(render_spawn_loop_tasks(spawn_loop_state, c, _now=_now))
+    else:
+        lines.extend(render_shepherds(daemon_state, c, _now=_now))
+        lines.append("")
+        lines.extend(render_support_roles(daemon_state, c, _now=_now))
+        lines.append("")
+        lines.extend(render_session_stats(daemon_state, c))
+        lines.append("")
+        lines.extend(render_pipeline_status(daemon_state, c, _now=_now))
+        lines.append("")
+        lines.extend(render_warnings(daemon_state, c))
     lines.append("")
     lines.extend(render_stuck_detection(repo_root, c))
     lines.append("")
@@ -566,8 +670,15 @@ def render_agents_table(
     repo_root: pathlib.Path,
     *,
     _now: datetime | None = None,
+    spawn_loop_state: SpawnLoopState | None = None,
 ) -> None:
-    """Render a rich table of all active agents directly to stdout."""
+    """Render a rich table of all active agents directly to stdout.
+
+    When *spawn_loop_state* has ``present=True``, the table is populated from
+    spawn-loop tasks (``task_id`` is the issue number, "Phase" is "sweep").
+    Otherwise the table is populated from daemon-state shepherds and support
+    roles — the legacy path.
+    """
     from rich.console import Console
     from rich.table import Table
     import rich.box
@@ -580,6 +691,34 @@ def render_agents_table(
     table.add_column("Phase")
     table.add_column("Runtime")
     table.add_column("Last Heartbeat")
+
+    # Spawn-loop primary path.
+    if spawn_loop_state is not None and spawn_loop_state.present:
+        for task in sorted(spawn_loop_state.running, key=lambda t: t.issue):
+            status_markup = "[green]running[/green]"
+            runtime_str = (
+                format_uptime(task.started_at, _now=_now)
+                if task.started_at
+                else "-"
+            )
+            heartbeat_str = (
+                time_ago(task.last_heartbeat, _now=_now)
+                if task.last_heartbeat
+                else "-"
+            )
+            table.add_row(
+                f"sweep-{task.issue}",
+                status_markup,
+                f"#{task.issue}",
+                "sweep",
+                runtime_str,
+                heartbeat_str,
+            )
+        if not spawn_loop_state.running:
+            # Add a placeholder so the table renders something meaningful.
+            table.add_row("(spawn-loop)", "[dim]idle[/dim]", "-", "-", "-", "-")
+        console.print(table)
+        return
 
     for sid in sorted(daemon_state.shepherds):
         entry = daemon_state.shepherds[sid]
@@ -652,14 +791,50 @@ def output_fast(
     repo_root: pathlib.Path,
     *,
     _now: datetime | None = None,
+    spawn_loop_state: SpawnLoopState | None = None,
 ) -> None:
-    """Print a fast agent status table (no gh queries)."""
+    """Print a fast agent status table (no gh queries).
+
+    When *spawn_loop_state* has ``present=True``, the header reflects the
+    spawn loop (orchestrator name "Spawn Loop", PID from ``.loom/spawn-loop.pid``
+    if present) and the table is populated from spawn-loop tasks. Otherwise
+    the legacy daemon-state path is used.
+    """
     from rich.console import Console
 
     console = Console()
-    stop_file = repo_root / ".loom" / "stop-daemon"
+    stop_daemon = repo_root / ".loom" / "stop-daemon"
+    stop_loop = repo_root / ".loom" / "stop-spawn-loop"
+    loop_pidfile = repo_root / ".loom" / "spawn-loop.pid"
 
-    if stop_file.exists():
+    if spawn_loop_state is not None and spawn_loop_state.present:
+        loop_alive = loop_pidfile.exists()
+        if stop_loop.exists():
+            loop_status = "[yellow]Stopping[/yellow]"
+        elif loop_alive:
+            loop_status = "[green]Running[/green]"
+        else:
+            loop_status = "[red]Stopped[/red]"
+
+        uptime = (
+            format_uptime(spawn_loop_state.started_at, _now=_now)
+            if loop_alive and spawn_loop_state.started_at
+            else "n/a"
+        )
+        pid_str = "unknown"
+        if loop_pidfile.exists():
+            try:
+                pid_str = loop_pidfile.read_text().strip() or "unknown"
+            except OSError:
+                pass
+
+        console.print(f"Spawn Loop: {loop_status}  |  Uptime: {uptime}  |  PID: {pid_str}")
+        console.print()
+        render_agents_table(daemon_state, repo_root, _now=_now, spawn_loop_state=spawn_loop_state)
+        return
+
+    # Legacy daemon-state path.
+    if stop_daemon.exists():
         daemon_status = "[yellow]Stopping[/yellow]"
     elif daemon_state.running:
         daemon_status = "[green]Running[/green]"
@@ -738,13 +913,18 @@ EXAMPLES:
     loom-status --json | jq '.computed'
 
 FILES:
-    .loom/daemon-state.json     Daemon state file
-    .loom/stop-daemon           Shutdown signal file
+    .loom/spawn-loop-state.json  Spawn loop state (primary, #3374)
+    .loom/spawn-loop.pid         Spawn loop process ID
+    .loom/stop-spawn-loop        Spawn loop shutdown signal
+    .loom/daemon-state.json      Legacy daemon state (fallback, removed in 3.4)
+    .loom/stop-daemon            Legacy daemon shutdown signal
 
 RELATED COMMANDS:
-    /loom                       Run the daemon (Layer 2)
+    /loom                       Run the daemon (Layer 2, legacy)
+    ./.loom/scripts/spawn-loop.sh start    Run the spawn loop (Phase 1)
     /loom status                Equivalent to this script
-    touch .loom/stop-daemon     Signal graceful shutdown
+    touch .loom/stop-spawn-loop  Signal graceful spawn-loop shutdown
+    touch .loom/stop-daemon      Signal graceful daemon shutdown
 """
 
 
@@ -774,7 +954,8 @@ def main(argv: Sequence[str] | None = None) -> None:
     if fast_mode:
         repo_root = find_repo_root()
         daemon_state = read_daemon_state(repo_root)
-        output_fast(daemon_state, repo_root)
+        spawn_loop_state = read_spawn_loop_state(repo_root)
+        output_fast(daemon_state, repo_root, spawn_loop_state=spawn_loop_state)
         return
 
     # Build snapshot (includes parallel gh queries)
@@ -785,8 +966,13 @@ def main(argv: Sequence[str] | None = None) -> None:
     else:
         repo_root = find_repo_root()
         daemon_state = read_daemon_state(repo_root)
+        spawn_loop_state = read_spawn_loop_state(repo_root)
         colored = _use_color()
-        print(output_formatted(snapshot, daemon_state, repo_root, use_color=colored))
+        print(output_formatted(
+            snapshot, daemon_state, repo_root,
+            use_color=colored,
+            spawn_loop_state=spawn_loop_state,
+        ))
 
 
 if __name__ == "__main__":

--- a/loom-tools/tests/test_status.py
+++ b/loom-tools/tests/test_status.py
@@ -15,6 +15,7 @@ from loom_tools.models.daemon_state import (
     SupportRoleEntry,
     Warning,
 )
+from loom_tools.models.spawn_loop_state import SpawnLoopState, SpawnLoopTask
 from loom_tools.status import (
     _Colors,
     format_seconds,
@@ -29,6 +30,7 @@ from loom_tools.status import (
     render_pipeline_status,
     render_session_stats,
     render_shepherds,
+    render_spawn_loop_tasks,
     render_stuck_detection,
     render_support_roles,
     render_system_state,
@@ -892,3 +894,352 @@ class TestFastMode:
         assert exc_info.value.code == 1
         captured = capsys.readouterr()
         assert "mutually exclusive" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Spawn-loop primary path (Phase 3.1.1 port, #3390)
+# ---------------------------------------------------------------------------
+
+
+class TestSpawnLoopPath:
+    """When .loom/spawn-loop-state.json is present, the spawn loop is treated
+    as the primary live-state source; daemon-state-derived sections are
+    suppressed in the output. See issue #3390."""
+
+    def test_render_daemon_status_spawn_loop_running(self, tmp_path):
+        """Spawn loop with live pidfile renders Running + Spawn Loop label."""
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir(parents=True)
+        (loom_dir / "spawn-loop.pid").write_text("12345\n")
+        sls = SpawnLoopState(
+            started_at="2026-01-30T16:00:00Z",
+            running=[],
+            present=True,
+        )
+        ds = DaemonState()  # Empty daemon state — should be ignored.
+        lines = render_daemon_status(ds, tmp_path, NC, _now=NOW, spawn_loop_state=sls)
+        combined = "\n".join(lines)
+        assert "Spawn Loop:" in combined
+        assert "Running" in combined
+        assert "Daemon:" not in combined
+        assert "2h 0m" in combined  # 16:00 -> 18:00
+        assert "Tracked Tasks: 0" in combined
+
+    def test_render_daemon_status_spawn_loop_stopped(self, tmp_path):
+        """Spawn loop present but pidfile missing renders Stopped."""
+        sls = SpawnLoopState(
+            started_at="2026-01-30T16:00:00Z",
+            running=[],
+            present=True,
+        )
+        ds = DaemonState()
+        lines = render_daemon_status(ds, tmp_path, NC, _now=NOW, spawn_loop_state=sls)
+        combined = "\n".join(lines)
+        assert "Spawn Loop:" in combined
+        assert "Stopped" in combined
+
+    def test_render_daemon_status_spawn_loop_stopping(self, tmp_path):
+        """Spawn loop with stop-spawn-loop signal renders Stopping."""
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir(parents=True)
+        (loom_dir / "spawn-loop.pid").write_text("12345\n")
+        (loom_dir / "stop-spawn-loop").touch()
+        sls = SpawnLoopState(
+            started_at="2026-01-30T16:00:00Z",
+            running=[],
+            present=True,
+        )
+        ds = DaemonState()
+        lines = render_daemon_status(ds, tmp_path, NC, _now=NOW, spawn_loop_state=sls)
+        combined = "\n".join(lines)
+        assert "Stopping" in combined
+
+    def test_render_daemon_status_absent_falls_back_to_daemon(self, tmp_path):
+        """Absent spawn-loop-state file falls back to daemon-state path."""
+        sls = SpawnLoopState.absent()
+        ds = DaemonState(running=True, started_at="2026-01-30T16:00:00Z")
+        lines = render_daemon_status(ds, tmp_path, NC, _now=NOW, spawn_loop_state=sls)
+        combined = "\n".join(lines)
+        assert "Daemon:" in combined
+        assert "Spawn Loop:" not in combined
+        assert "Running" in combined
+
+    def test_render_spawn_loop_tasks_empty(self):
+        sls = SpawnLoopState(started_at="2026-01-30T16:00:00Z", running=[], present=True)
+        lines = render_spawn_loop_tasks(sls, NC, _now=NOW)
+        combined = "\n".join(lines)
+        assert "No tasks running" in combined
+
+    def test_render_spawn_loop_tasks_with_running(self):
+        sls = SpawnLoopState(
+            started_at="2026-01-30T16:00:00Z",
+            running=[
+                SpawnLoopTask(
+                    issue=42, pid=999,
+                    started_at="2026-01-30T17:00:00Z",
+                    token="robb-personal",
+                ),
+                SpawnLoopTask(
+                    issue=100, pid=1001,
+                    started_at="2026-01-30T17:30:00Z",
+                    token=None,
+                ),
+            ],
+            present=True,
+        )
+        lines = render_spawn_loop_tasks(sls, NC, _now=NOW)
+        combined = "\n".join(lines)
+        assert "2 task(s) running" in combined
+        assert "sweep-42:" in combined
+        assert "Issue #42" in combined
+        assert "pid=999" in combined
+        assert "[token: robb-personal]" in combined
+        assert "sweep-100:" in combined
+        # No token printed for the second task.
+        # Use a precise per-row check rather than scanning whole string.
+        sweep_100_line = next(l for l in lines if "sweep-100:" in l)
+        assert "[token:" not in sweep_100_line
+
+    def test_render_spawn_loop_tasks_with_heartbeat(self):
+        sls = SpawnLoopState(
+            running=[
+                SpawnLoopTask(
+                    issue=7, pid=1,
+                    started_at="2026-01-30T17:00:00Z",
+                    last_heartbeat="2026-01-30T17:55:00Z",
+                ),
+            ],
+            present=True,
+        )
+        lines = render_spawn_loop_tasks(sls, NC, _now=NOW)
+        combined = "\n".join(lines)
+        assert "[heartbeat: 5m ago]" in combined
+
+    def test_output_formatted_spawn_loop_suppresses_legacy_sections(self, tmp_path):
+        """When spawn loop is present, support-role and pipeline sections
+        derived from daemon-state are not rendered."""
+        sls = SpawnLoopState(
+            started_at="2026-01-30T16:00:00Z",
+            running=[SpawnLoopTask(issue=42, pid=999, started_at="2026-01-30T17:00:00Z")],
+            present=True,
+        )
+        # Daemon state has data that would normally render — we expect it
+        # to be suppressed because the spawn loop took over.
+        ds = DaemonState(
+            running=True,
+            shepherds={
+                "shepherd-1": ShepherdEntry(status="working", issue=99),
+            },
+            support_roles={
+                "guide": SupportRoleEntry(status="running"),
+            },
+            warnings=[Warning(time="2026-01-30T17:00:00Z", severity="warning", message="test")],
+        )
+        snapshot = {
+            "computed": {
+                "total_ready": 5, "total_building": 1,
+                "prs_awaiting_review": 0, "prs_ready_to_merge": 0,
+            },
+            "proposals": {"architect": [], "hermit": [], "curated": []},
+        }
+        result = output_formatted(
+            snapshot, ds, tmp_path, use_color=False, _now=NOW,
+            spawn_loop_state=sls,
+        )
+        # System state (forge-derived) still renders.
+        assert "Ready issues" in result
+        # Spawn-loop-task section renders the spawn-loop entry.
+        assert "sweep-42:" in result
+        assert "Issue #42" in result
+        # Daemon-state shepherd #99 is NOT shown (suppressed).
+        assert "Issue #99" not in result
+        # Support role section header is not present.
+        assert "Support Roles:" not in result
+        # Session statistics header is not present.
+        assert "Session Statistics:" not in result
+        # Pipeline-status header is not present.
+        assert "Pipeline Status:" not in result
+        # Warnings section header is not present.
+        assert "Recent Warnings:" not in result
+        # Spawn-loop label IS present.
+        assert "Spawn Loop:" in result
+
+    def test_output_formatted_spawn_loop_absent_uses_daemon_path(self, tmp_path):
+        """No spawn-loop-state — output looks like the legacy daemon-state
+        format (regression guard for the fallback)."""
+        ds = DaemonState(
+            running=True,
+            started_at="2026-01-30T16:00:00Z",
+            shepherds={"shepherd-1": ShepherdEntry(status="idle")},
+            support_roles={"guide": SupportRoleEntry(status="idle")},
+        )
+        snapshot = {
+            "computed": {
+                "total_ready": 0, "total_building": 0,
+                "prs_awaiting_review": 0, "prs_ready_to_merge": 0,
+            },
+            "proposals": {"architect": [], "hermit": [], "curated": []},
+        }
+        result = output_formatted(
+            snapshot, ds, tmp_path, use_color=False, _now=NOW,
+            spawn_loop_state=SpawnLoopState.absent(),
+        )
+        assert "Daemon:" in result
+        assert "Spawn Loop:" not in result
+        assert "Support Roles:" in result
+        assert "Session Statistics:" in result
+        assert "Pipeline Status:" in result
+
+    def test_render_agents_table_spawn_loop(self, tmp_path, capsys):
+        sls = SpawnLoopState(
+            running=[
+                SpawnLoopTask(
+                    issue=42, pid=999,
+                    started_at="2026-01-30T17:00:00Z",
+                ),
+            ],
+            present=True,
+        )
+        ds = DaemonState()  # ignored
+        render_agents_table(ds, tmp_path, _now=NOW, spawn_loop_state=sls)
+        out = capsys.readouterr().out
+        assert "sweep-42" in out
+        assert "#42" in out
+        assert "sweep" in out  # phase column
+        assert "running" in out
+
+    def test_render_agents_table_spawn_loop_empty(self, tmp_path, capsys):
+        """Empty spawn loop still renders a placeholder row."""
+        sls = SpawnLoopState(running=[], present=True)
+        ds = DaemonState()
+        render_agents_table(ds, tmp_path, _now=NOW, spawn_loop_state=sls)
+        out = capsys.readouterr().out
+        assert "spawn-loop" in out
+        assert "idle" in out
+
+    def test_output_fast_spawn_loop_running(self, tmp_path, capsys):
+        """Fast mode with live spawn loop shows Spawn Loop header + PID."""
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir(parents=True)
+        (loom_dir / "spawn-loop.pid").write_text("54321\n")
+        sls = SpawnLoopState(
+            started_at="2026-01-30T16:00:00Z",
+            running=[SpawnLoopTask(issue=42, pid=999, started_at="2026-01-30T17:00:00Z")],
+            present=True,
+        )
+        ds = DaemonState()
+        output_fast(ds, tmp_path, _now=NOW, spawn_loop_state=sls)
+        out = capsys.readouterr().out
+        assert "Spawn Loop:" in out
+        assert "Running" in out
+        assert "54321" in out
+        assert "sweep-42" in out
+
+    def test_output_fast_spawn_loop_absent_uses_daemon(self, tmp_path, capsys):
+        """Fast mode falls back to daemon-state when spawn-loop absent."""
+        ds = DaemonState(running=True, started_at="2026-01-30T16:00:00Z", daemon_pid=9999)
+        (tmp_path / ".loom").mkdir(parents=True, exist_ok=True)
+        output_fast(ds, tmp_path, _now=NOW, spawn_loop_state=SpawnLoopState.absent())
+        out = capsys.readouterr().out
+        assert "Daemon:" in out
+        assert "Spawn Loop:" not in out
+        assert "9999" in out
+
+    def test_main_spawn_loop_present_no_gh_in_fast_mode(self, tmp_path, monkeypatch, capsys):
+        """main(["--fast"]) reads spawn-loop-state.json and renders without gh."""
+        import subprocess
+
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir(parents=True)
+        (loom_dir / "spawn-loop.pid").write_text("99\n")
+        (loom_dir / "spawn-loop-state.json").write_text(json.dumps({
+            "started_at": "2026-01-30T16:00:00Z",
+            "running": [
+                {
+                    "issue": 42, "pid": 999,
+                    "started_at": "2026-01-30T17:00:00Z",
+                    "token": "robb-personal",
+                },
+            ],
+        }))
+        # No daemon-state file on disk.
+        monkeypatch.setattr("loom_tools.status.find_repo_root", lambda: tmp_path)
+
+        original_run = subprocess.run
+        gh_calls: list[list[str]] = []
+
+        def patched_run(cmd, *args, **kwargs):
+            if isinstance(cmd, (list, tuple)) and cmd and "gh" in str(cmd[0]):
+                gh_calls.append(list(cmd))
+            return original_run(cmd, *args, **kwargs)
+
+        monkeypatch.setattr(subprocess, "run", patched_run)
+
+        main(["--fast"])
+        out = capsys.readouterr().out
+        assert "Spawn Loop:" in out
+        assert "Running" in out
+        assert "sweep-42" in out
+        assert gh_calls == []
+
+
+# ---------------------------------------------------------------------------
+# read_spawn_loop_state (state.py reader)
+# ---------------------------------------------------------------------------
+
+
+class TestReadSpawnLoopState:
+    """Verify the state reader handles present/absent/malformed cases."""
+
+    def test_absent_when_file_missing(self, tmp_path):
+        from loom_tools.common.state import read_spawn_loop_state
+
+        result = read_spawn_loop_state(tmp_path)
+        assert result.present is False
+        assert result.running == []
+
+    def test_present_with_running_tasks(self, tmp_path):
+        from loom_tools.common.state import read_spawn_loop_state
+
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir(parents=True)
+        (loom_dir / "spawn-loop-state.json").write_text(json.dumps({
+            "started_at": "2026-01-30T16:00:00Z",
+            "running": [
+                {"issue": 42, "pid": 100, "started_at": "2026-01-30T17:00:00Z", "token": "tok-a"},
+                {"issue": 99, "pid": 200, "started_at": "2026-01-30T17:30:00Z"},
+            ],
+        }))
+        result = read_spawn_loop_state(tmp_path)
+        assert result.present is True
+        assert result.started_at == "2026-01-30T16:00:00Z"
+        assert len(result.running) == 2
+        assert result.running[0].issue == 42
+        assert result.running[0].pid == 100
+        assert result.running[0].token == "tok-a"
+        assert result.running[1].issue == 99
+        assert result.running[1].token is None
+
+    def test_present_but_empty_running(self, tmp_path):
+        from loom_tools.common.state import read_spawn_loop_state
+
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir(parents=True)
+        (loom_dir / "spawn-loop-state.json").write_text(json.dumps({
+            "started_at": "2026-01-30T16:00:00Z",
+            "running": [],
+        }))
+        result = read_spawn_loop_state(tmp_path)
+        assert result.present is True
+        assert result.running == []
+
+    def test_malformed_json_still_present(self, tmp_path):
+        from loom_tools.common.state import read_spawn_loop_state
+
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir(parents=True)
+        (loom_dir / "spawn-loop-state.json").write_text("this is not json")
+        result = read_spawn_loop_state(tmp_path)
+        # File exists -> present=True, even though parse failed
+        assert result.present is True
+        assert result.running == []


### PR DESCRIPTION
Closes #3390
Refs epic #3372, tracker #3378, downstream #3401 (fallback trim).

## Summary

Phase 3.1.1 of the shepherd/daemon deprecation epic. Adds a primary read
path against `.loom/spawn-loop-state.json` (Phase 1, #3374) while retaining
the existing `.loom/daemon-state.json` read path as a fallback so the CLI
keeps working against workspaces still running the legacy Python daemon
brain. Phase 3.4 (#3401) will trim the fallback once all 3.1.x ports land.

- New `SpawnLoopState` / `SpawnLoopTask` models matching the spawn loop's
  on-disk shape (`{started_at, running:[{issue,pid,started_at,token,...}]}`).
- New `read_spawn_loop_state()` reader + `LoomPaths.spawn_loop_state_file`.
- `status.py` dispatches on `spawn_loop_state.present`: when True, the
  header reads "Spawn Loop:" (PID from `.loom/spawn-loop.pid`, shutdown
  signal from `.loom/stop-spawn-loop`), in-flight tasks render from
  `spawn-loop-state.json::running[]`, and daemon-state-derived sections
  are suppressed. Otherwise the existing daemon-state path runs verbatim.

## What stays daemon-state-derived (for fallback) vs what moved

| Section | Spawn-loop primary | Daemon-state fallback |
|---------|-------------------|------------------------|
| Orchestrator header | `spawn-loop.pid` + `spawn-loop-state.json::started_at` + `stop-spawn-loop` signal | `daemon_state.running` + `started_at` + `stop-daemon` signal |
| In-flight tasks | `spawn-loop-state.json::running[]` (issue, pid, token, optional heartbeat) | `daemon_state.shepherds[]` (full shepherd-N pool, phases, idle reasons) |
| Pipeline counts (`System State`) | forge via `gh_parallel_queries` (unchanged) | same |
| Support roles | **suppressed** — spawn loop does not run support roles (those move to GH Actions, #3375) | `daemon_state.support_roles[]` |
| Session Statistics (`iteration`, `completed_issues`, `total_prs_merged`) | **suppressed** — spawn loop does not track them; per AC option (b), dropped from human-facing output (justified: the daemon brain that computed these is gone in Phase 3.2; a follow-up `loom-agent-metrics` port (Phase 3.1.5) can resurface them from `activity.db` if needed) | `daemon_state.iteration` + `completed_issues` + `total_prs_merged` |
| Pipeline Status (blocked items) | **suppressed** — `pipeline_state` is daemon-brain-internal; blocked issue surfacing moves to `loom-backlog` port (Phase 3.1.2) | `daemon_state.pipeline_state.blocked` |
| Recent Warnings | **suppressed** — `warnings` ring is daemon-brain-internal | `daemon_state.warnings[]` |
| Stuck Detection | `.loom/interventions/` + `.loom/stuck-config.json` (unchanged) | same |
| Layer 3 Actions | forge proposal counts + filesystem signals (unchanged) | same |

## Acceptance Criteria

- [x] `loom-status` works against a workspace running only the spawn loop (verified via `TestSpawnLoopPath::test_main_spawn_loop_present_no_gh_in_fast_mode` and the AFTER sample below).
- [x] `loom-status` still works against a workspace running the Python daemon (the fallback path is unchanged; all 73 original `test_status.py` cases pass).
- [x] Lifetime totals — explicitly dropped from spawn-loop output with justification in the table above.
- [x] Pipeline counts sourced from forge (no change to `System State` section shape).
- [x] Shepherd-liveness rows replaced by spawn-loop task rows (`sweep-N: Issue #N pid=… [token: …]`).
- [x] Before/after sample output for both scenarios (see below).
- [x] Existing tests in `test_status.py` pass (no trimming needed — fallback path is intact).
- [x] No changes to `snapshot.py` (snapshot split is Phase 3.2).

## Before / after CLI output

### BEFORE — `loom-status` against `.loom/daemon-state.json` (legacy fallback path)

```
=======================================================================
  LOOM SYSTEM STATUS (read-only)
=======================================================================

  Daemon: Running
  Uptime: 2h 0m
  Last Poll: 5m ago

  System State:
    Ready issues (loom:issue): 4
    Building (loom:building): 2
    Curated (awaiting approval): 1
    Proposals pending: 1 (arch: 1, hermit: 0)
    PRs pending review: 1
    PRs ready to merge: 0

  Shepherds:
    1/2 active

    shepherd-1: Issue #3390 (1h 0m) [phase: builder]
    shepherd-2: idle  - no ready issues

  Support Roles:
    Architect: idle (last: never)
    Hermit: idle (last: never)
    Guide: running
    Champion: idle (last: 10m ago)

  Session Statistics:
    Iteration: 42
    Issues completed: 3
    PRs merged: 3

  Pipeline Status:
    No blocked items

  Recent Warnings:
    No warnings

  Stuck Detection:
    Status: All agents healthy
    Config: Using defaults (idle=10m, working=30m, mode=escalate)

  Layer 3 Actions Available:
    ...
=======================================================================
```

### AFTER — `loom-status` against `.loom/spawn-loop-state.json` + forge (primary path)

```
=======================================================================
  LOOM SYSTEM STATUS (read-only)
=======================================================================

  Spawn Loop: Running
  Uptime: 2h 0m
  Tracked Tasks: 2

  System State:
    Ready issues (loom:issue): 4
    Building (loom:building): 2
    Curated (awaiting approval): 1
    Proposals pending: 1 (arch: 1, hermit: 0)
    PRs pending review: 1
    PRs ready to merge: 0

  In-Flight Tasks:
    2 task(s) running

    sweep-3390: Issue #3390 pid=12345 (1h 0m) [token: robb-personal]
    sweep-3401: Issue #3401 pid=12346 (30m) [token: robb-work]

  Stuck Detection:
    Status: All agents healthy
    Config: Using defaults (idle=10m, working=30m, mode=escalate)

  Layer 3 Actions Available:
    ...
=======================================================================
```

The forge-derived `System State`, `Stuck Detection`, and `Layer 3 Actions`
sections render identically in both modes — only the orchestrator-derived
sections diverge.

## Out of scope

- Splitting `snapshot.py` into `forge_snapshot.py` + retired half (that is Phase 3.2).
- Deleting `daemon-state.json` read code (that is Phase 3.4, #3401, blocked by all 3.1.x ports).
- Renaming the CLI.
- Resurrecting `iteration` / `completed_issues` / `total_prs_merged` on the spawn-loop path (revisit during Phase 3.1.5 `loom-agent-metrics` port if needed).

## Test plan

- [x] `PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/test_status.py -v` — 91 tests pass (73 existing + 18 new).
- [x] `PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/test_paths.py -v` — 38 tests pass.
- [x] New `TestSpawnLoopPath` class: 13 tests covering the primary path (orchestrator header, in-flight tasks, suppressed sections, fast mode, main entry).
- [x] New `TestReadSpawnLoopState` class: 4 tests covering absent / present-with-data / present-but-empty / malformed-JSON.
- [x] Manual smoke: ran generation script in PR description against in-memory fixtures to produce the BEFORE/AFTER samples above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)