### PR TITLE
refactor(backlog): port loom-backlog to issue-failures.json only (#3391)

### DIFF
--- a/loom-tools/src/loom_tools/backlog.py
+++ b/loom-tools/src/loom_tools/backlog.py
@@ -1,13 +1,28 @@
-"""Backlog management utilities for the Loom daemon.
+"""Backlog management utilities for the Loom backlog of failed issues.
 
 Provides tools for bulk-triaging blocked issues, applying the tiered retry
-policy retroactively, and escalating permanently-stuck issues to the human
-input queue.
+policy retroactively, and escalating permanently-stuck issues to a
+human-review queue.
+
+**Source of truth.** Reads exclusively from ``.loom/issue-failures.json``
+(the durable cross-session failure log) — the ephemeral
+``.loom/daemon-state.json::blocked_issue_retries`` read path that this
+module used previously has been removed as part of the Phase 3
+shepherd/daemon deprecation (epic #3372, tracker #3378). Unlike sibling
+Phase 3.1.x CLI ports, this consumer does **not** keep a fallback to
+``daemon-state.json``.
+
+**Escalation persistence.** Without ``daemon-state.json::needs_human_input``
+to coordinate against, escalated issues are marked on the forge instead
+via the existing ``loom:blocked`` label. The label acts as the
+deduplication signal — re-running ``prune`` will skip issues that already
+carry ``loom:blocked``. The optional ``--comment`` flag still posts a
+human-readable comment alongside the label.
 
 Usage::
 
-    loom-backlog prune [--dry-run] [--comment]   # triage blocked backlog
-    loom-backlog list                             # list blocked issues with policy info
+    loom-backlog list                            # list blocked issues with policy info
+    loom-backlog prune [--dry-run] [--comment]   # triage and escalate exhausted backlog
 """
 
 from __future__ import annotations
@@ -15,16 +30,143 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Sequence
 
 from loom_tools.common.github import gh_run
+from loom_tools.common.issue_failures import IssueFailureEntry, load_failure_log
 from loom_tools.common.logging import log_info, log_warning
 from loom_tools.common.repo import find_repo_root
-from loom_tools.common.state import read_daemon_state, write_json_file
 from loom_tools.common.time_utils import now_utc
-from loom_tools.models.daemon_state import BlockedIssueRetry
-from loom_tools.snapshot import get_retry_policy
+
+
+# ---------------------------------------------------------------------------
+# Tiered retry policy by error class
+#
+# Inlined here (copied from the historical ``snapshot.get_retry_policy``)
+# so that ``loom-backlog`` has no runtime dependency on ``snapshot.py``,
+# which is slated for deletion in Phase 3.2. Keep this table in sync with
+# any other consumer that may still reference ``_ERROR_CLASS_POLICIES``
+# until the daemon brain is removed.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    """Per-error-class retry configuration.
+
+    Attributes:
+        cooldown: Fixed cooldown in seconds between retry attempts (no
+            exponential backoff).
+        max_retries: Maximum number of retry attempts before escalating.
+        escalate: Whether to add to the human-review queue when the retry
+            budget is exhausted.
+    """
+
+    cooldown: int
+    max_retries: int
+    escalate: bool
+
+
+# Transient errors: short cooldown, more retries, no escalation.
+# Structural errors: longer cooldown, fewer retries, then escalate.
+_ERROR_CLASS_POLICIES: dict[str, RetryPolicy] = {
+    # Transient: short cooldown, auto-retry (no human escalation)
+    "mcp_infrastructure_failure": RetryPolicy(cooldown=1800, max_retries=5, escalate=False),
+    "shepherd_failure": RetryPolicy(cooldown=1800, max_retries=5, escalate=False),
+    # Medium: 2h cooldown, max 3 retries, then escalate
+    "builder_unknown_failure": RetryPolicy(cooldown=7200, max_retries=3, escalate=True),
+    "builder_no_pr": RetryPolicy(cooldown=7200, max_retries=3, escalate=True),
+    # Structural: 6h cooldown, max 2 retries, then escalate
+    "builder_test_failure": RetryPolicy(cooldown=21600, max_retries=2, escalate=True),
+    "judge_exhausted": RetryPolicy(cooldown=21600, max_retries=2, escalate=True),
+    # Doctor failures: immediate human escalation, no auto-retry
+    "doctor_exhausted": RetryPolicy(cooldown=0, max_retries=0, escalate=True),
+    "doctor_no_progress": RetryPolicy(cooldown=0, max_retries=0, escalate=True),
+}
+
+# Safe default for unknown error classes (mirrors the historical
+# ``snapshot.get_retry_policy`` fallback for a ``None`` ``SnapshotConfig``).
+_DEFAULT_POLICY = RetryPolicy(cooldown=1800, max_retries=3, escalate=True)
+
+
+def get_retry_policy(error_class: str) -> RetryPolicy:
+    """Return the retry policy for *error_class*.
+
+    Known error classes use fixed per-class policies; unknown classes fall
+    back to ``_DEFAULT_POLICY``.
+    """
+    return _ERROR_CLASS_POLICIES.get(error_class, _DEFAULT_POLICY)
+
+
+# ---------------------------------------------------------------------------
+# Forge helpers
+# ---------------------------------------------------------------------------
+
+
+_ESCALATION_LABEL = "loom:blocked"
+
+
+def _fetch_escalated_issue_numbers() -> set[int]:
+    """Return the set of issue numbers already carrying the escalation label.
+
+    Uses a single ``gh issue list`` call so we do not pay one API round-trip
+    per issue. Returns an empty set on any failure (callers fall back to
+    "assume not yet escalated" semantics so the operator can still escalate).
+    """
+    try:
+        result = gh_run(
+            [
+                "issue",
+                "list",
+                "--label",
+                _ESCALATION_LABEL,
+                "--state",
+                "all",
+                "--limit",
+                "1000",
+                "--json",
+                "number",
+            ],
+            check=False,
+        )
+    except Exception:
+        log_warning(f"Failed to list issues with label '{_ESCALATION_LABEL}'")
+        return set()
+
+    if getattr(result, "returncode", 1) != 0:
+        return set()
+
+    try:
+        payload = json.loads(result.stdout or "[]")
+    except (json.JSONDecodeError, AttributeError):
+        return set()
+
+    return {int(item["number"]) for item in payload if "number" in item}
+
+
+def _apply_escalation_label(issue_num: int) -> bool:
+    """Idempotently apply the escalation label to *issue_num*.
+
+    Returns ``True`` on success, ``False`` otherwise. ``gh issue edit
+    --add-label`` is itself idempotent (no-op if the label is already
+    present), so we do not need to recheck.
+    """
+    try:
+        result = gh_run(
+            ["issue", "edit", str(issue_num), "--add-label", _ESCALATION_LABEL],
+            check=False,
+        )
+    except Exception:
+        log_warning(f"Failed to apply '{_ESCALATION_LABEL}' to issue #{issue_num}")
+        return False
+    return getattr(result, "returncode", 1) == 0
+
+
+# ---------------------------------------------------------------------------
+# Table rendering
+# ---------------------------------------------------------------------------
 
 
 def _print_table(rows: list[dict], columns: list[str]) -> None:
@@ -44,19 +186,37 @@ def _print_table(rows: list[dict], columns: list[str]) -> None:
         print("  ".join(str(row.get(col, "")).ljust(widths[col]) for col in columns))
 
 
-def _build_entry_row(issue_key: str, entry: BlockedIssueRetry) -> dict:
-    """Build a display row for a blocked issue entry."""
+def _build_entry_row(
+    issue_key: str,
+    entry: IssueFailureEntry,
+    escalated_numbers: set[int],
+) -> dict:
+    """Build a display row for an ``issue-failures.json`` entry.
+
+    ``escalated_numbers`` is the set of issue numbers already carrying
+    the escalation label on the forge; entries in this set are reported
+    as ``escalated``.
+    """
     policy = get_retry_policy(entry.error_class)
-    retries_left = max(0, policy.max_retries - entry.retry_count)
+    retries_left = max(0, policy.max_retries - entry.total_failures)
     cooldown_h = policy.cooldown // 3600
-    cooldown_str = f"{cooldown_h}h" if cooldown_h > 0 else (f"{policy.cooldown // 60}m" if policy.cooldown > 0 else "0")
-    status = "escalated" if entry.escalated_to_human else (
-        "exhausted" if (entry.retry_exhausted or entry.retry_count >= policy.max_retries) else "retryable"
+    cooldown_str = (
+        f"{cooldown_h}h"
+        if cooldown_h > 0
+        else (f"{policy.cooldown // 60}m" if policy.cooldown > 0 else "0")
     )
+    exhausted = entry.total_failures >= policy.max_retries
+    is_escalated = entry.issue in escalated_numbers
+    if is_escalated:
+        status = "escalated"
+    elif exhausted:
+        status = "exhausted"
+    else:
+        status = "retryable"
     return {
         "issue": f"#{issue_key}",
         "error_class": entry.error_class,
-        "retry_count": entry.retry_count,
+        "retry_count": entry.total_failures,
         "max_retries": policy.max_retries,
         "retries_left": retries_left,
         "cooldown": cooldown_str,
@@ -65,36 +225,61 @@ def _build_entry_row(issue_key: str, entry: BlockedIssueRetry) -> dict:
     }
 
 
-def cmd_list(repo_root: Path) -> int:
-    """List all blocked issues with their tiered retry policy info."""
-    loom_dir = repo_root / ".loom"
-    state_file = loom_dir / "daemon-state.json"
+# ---------------------------------------------------------------------------
+# Subcommands
+# ---------------------------------------------------------------------------
 
-    if not state_file.exists():
-        print("No daemon-state.json found.")
+
+def _load_entries(repo_root: Path) -> dict[str, IssueFailureEntry]:
+    """Load issue-failures entries with decay-on-main-advance disabled.
+
+    The CLI is meant to be a read-mostly tool; suppress the natural decay
+    side effect (which rewrites the file) by passing ``_main_sha=None``.
+    """
+    log = load_failure_log(repo_root, _main_sha=None)
+    return log.entries
+
+
+def cmd_list(repo_root: Path) -> int:
+    """List all tracked failure entries with their tiered retry policy info."""
+    failures_file = repo_root / ".loom" / "issue-failures.json"
+
+    if not failures_file.exists():
+        print("No issue-failures.json found.")
         return 1
 
-    state = read_daemon_state(repo_root)
-    retries = state.blocked_issue_retries
+    entries = _load_entries(repo_root)
 
-    if not retries:
-        print("No blocked issues in daemon state.")
+    if not entries:
+        print("No tracked issue failures.")
         return 0
 
-    rows = []
-    for issue_key, entry in sorted(retries.items(), key=lambda x: int(x[0])):
-        rows.append(_build_entry_row(issue_key, entry))
+    escalated_numbers = _fetch_escalated_issue_numbers()
 
-    # Summary stats
+    rows = []
+    for issue_key, entry in sorted(entries.items(), key=lambda x: int(x[0])):
+        rows.append(_build_entry_row(issue_key, entry, escalated_numbers))
+
     total = len(rows)
     escalated = sum(1 for r in rows if r["status"] == "escalated")
     exhausted = sum(1 for r in rows if r["status"] == "exhausted")
     retryable = sum(1 for r in rows if r["status"] == "retryable")
 
-    print(f"Blocked issues: {total} total  ({retryable} retryable, {exhausted} exhausted, {escalated} escalated)")
+    print(
+        f"Tracked issue failures: {total} total  "
+        f"({retryable} retryable, {exhausted} exhausted, {escalated} escalated)"
+    )
     print()
 
-    columns = ["issue", "error_class", "retry_count", "max_retries", "cooldown", "escalate", "status"]
+    columns = [
+        "issue",
+        "error_class",
+        "retry_count",
+        "max_retries",
+        "cooldown",
+        "escalate",
+        "status",
+    ]
     _print_table(rows, columns)
     return 0
 
@@ -105,45 +290,49 @@ def cmd_prune(
     dry_run: bool = False,
     add_comment: bool = False,
 ) -> int:
-    """Apply tiered retry policy retroactively to all blocked issues.
+    """Apply tiered retry policy retroactively to all tracked failures.
 
-    Issues that have exceeded their per-class retry budget will be:
-    - Marked ``escalated_to_human=True`` in daemon state
-    - Added to ``needs_human_input``
-    - Optionally commented on GitHub (with ``--comment``)
+    Issues that have exceeded their per-class retry budget and whose error
+    class has ``escalate=True`` will be:
 
-    Pass ``--dry-run`` to preview changes without modifying daemon state.
+    - Labelled with ``loom:blocked`` on the forge (idempotent).
+    - Optionally commented on (with ``--comment``).
+
+    Pass ``--dry-run`` to preview without touching the forge.
+
+    The ``loom:blocked`` label acts as the deduplication signal: issues
+    that already carry the label are reported as "already escalated" and
+    not re-touched.
     """
-    loom_dir = repo_root / ".loom"
-    state_file = loom_dir / "daemon-state.json"
+    failures_file = repo_root / ".loom" / "issue-failures.json"
 
-    if not state_file.exists():
-        print("No daemon-state.json found.")
+    if not failures_file.exists():
+        print("No issue-failures.json found.")
         return 1
 
-    state = read_daemon_state(repo_root)
-    retries = state.blocked_issue_retries
+    entries = _load_entries(repo_root)
 
-    if not retries:
-        print("No blocked issues in daemon state.")
+    if not entries:
+        print("No tracked issue failures.")
         return 0
 
+    escalated_numbers = _fetch_escalated_issue_numbers()
     timestamp = now_utc().strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    # Categorise issues by action needed
-    to_escalate: list[tuple[str, BlockedIssueRetry, str]] = []  # (key, entry, reason)
+    # Categorise entries by action needed.
+    to_escalate: list[tuple[str, IssueFailureEntry, str]] = []
     already_escalated: list[str] = []
     still_retryable: list[str] = []
     transient_exhausted: list[str] = []
 
-    for issue_key, entry in sorted(retries.items(), key=lambda x: int(x[0])):
+    for issue_key, entry in sorted(entries.items(), key=lambda x: int(x[0])):
         policy = get_retry_policy(entry.error_class)
 
-        if entry.escalated_to_human:
+        if entry.issue in escalated_numbers:
             already_escalated.append(issue_key)
             continue
 
-        exhausted = entry.retry_exhausted or entry.retry_count >= policy.max_retries
+        exhausted = entry.total_failures >= policy.max_retries
         if exhausted:
             if policy.escalate:
                 reason = (
@@ -157,12 +346,15 @@ def cmd_prune(
         else:
             still_retryable.append(issue_key)
 
-    # Print summary
+    # Summary
     print(f"Backlog prune summary ({timestamp}):")
-    print(f"  Total blocked issues:     {len(retries)}")
-    print(f"  Already escalated:        {len(already_escalated)}")
+    print(f"  Total tracked failures:   {len(entries)}")
+    print(f"  Already escalated:        {len(already_escalated)}  (carrying '{_ESCALATION_LABEL}')")
     print(f"  To escalate (this run):   {len(to_escalate)}")
-    print(f"  Transient exhausted:      {len(transient_exhausted)} (no escalation, error class non-critical)")
+    print(
+        f"  Transient exhausted:      {len(transient_exhausted)} "
+        f"(no escalation, error class non-critical)"
+    )
     print(f"  Still retryable:          {len(still_retryable)}")
     print()
 
@@ -172,7 +364,10 @@ def cmd_prune(
 
     print("Issues to escalate:")
     for issue_key, entry, reason in to_escalate:
-        print(f"  #{issue_key}  {entry.error_class} (retry_count={entry.retry_count})  {reason}")
+        print(
+            f"  #{issue_key}  {entry.error_class} "
+            f"(retry_count={entry.total_failures})  {reason}"
+        )
 
     if dry_run:
         print("\n[dry-run] No changes made.")
@@ -180,41 +375,24 @@ def cmd_prune(
 
     print()
 
-    # Apply escalations
     escalated_count = 0
     for issue_key, entry, reason in to_escalate:
         issue_num = int(issue_key)
 
-        # Mark escalated in state
-        entry.escalated_to_human = True
+        if not _apply_escalation_label(issue_num):
+            log_warning(f"Skipping issue #{issue_num}: failed to apply escalation label")
+            continue
 
-        # Add to needs_human_input
-        human_entry = {
-            "type": "exhausted_retry",
-            "issue": issue_num,
-            "error_class": entry.error_class,
-            "retry_count": entry.retry_count,
-            "reason": reason,
-            "escalated_at": timestamp,
-        }
-        already_present = any(
-            e.get("type") == "exhausted_retry" and e.get("issue") == issue_num
-            for e in state.needs_human_input
-        )
-        if not already_present:
-            state.needs_human_input.append(human_entry)
-
-        # Optionally add GitHub comment
         if add_comment:
             comment = (
                 f"**Blocked Issue: Human Review Required (backlog prune)**\n\n"
                 f"This issue has exceeded its automatic retry budget and was identified "
                 f"during a backlog triage run.\n\n"
                 f"**Error class**: `{entry.error_class}`\n"
-                f"**Retry attempts**: {entry.retry_count}\n"
+                f"**Retry attempts**: {entry.total_failures}\n"
                 f"**Reason**: {reason}\n\n"
                 f"Please review this issue and either:\n"
-                f"- Fix the underlying problem and remove the `loom:blocked` label to re-queue it, or\n"
+                f"- Fix the underlying problem and remove the `{_ESCALATION_LABEL}` label to re-queue it, or\n"
                 f"- Close the issue if it is no longer valid\n\n"
                 f"---\n"
                 f"*Escalated by `loom-backlog prune` at {timestamp}*"
@@ -230,10 +408,9 @@ def cmd_prune(
 
         escalated_count += 1
 
-    # Save updated state
-    write_json_file(state_file, state.to_dict())
-
-    print(f"Escalated {escalated_count} issue(s) to needs_human_input in daemon state.")
+    print(
+        f"Escalated {escalated_count} issue(s) via '{_ESCALATION_LABEL}' label."
+    )
     if add_comment:
         print("GitHub comments added.")
     else:
@@ -246,28 +423,29 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Entry point for the loom-backlog command."""
     parser = argparse.ArgumentParser(
         prog="loom-backlog",
-        description="Backlog management for the Loom daemon",
+        description=(
+            "Backlog management for tracked issue failures "
+            "(reads .loom/issue-failures.json)"
+        ),
     )
     subparsers = parser.add_subparsers(dest="command", help="Subcommand")
 
-    # list subcommand
     subparsers.add_parser(
         "list",
-        help="List blocked issues with tiered retry policy info",
+        help="List tracked failures with tiered retry policy info",
     )
 
-    # prune subcommand
     prune_parser = subparsers.add_parser(
         "prune",
         help=(
-            "Apply tiered retry policy retroactively; escalate exhausted issues "
-            "to the human input queue"
+            "Apply tiered retry policy retroactively; label exhausted issues "
+            "with 'loom:blocked' for human review"
         ),
     )
     prune_parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Preview changes without modifying daemon state",
+        help="Preview changes without touching the forge",
     )
     prune_parser.add_argument(
         "--comment",

--- a/loom-tools/tests/test_backlog.py
+++ b/loom-tools/tests/test_backlog.py
@@ -1,67 +1,159 @@
-"""Tests for the loom-backlog command."""
+"""Tests for the loom-backlog command (issue-failures.json port).
+
+After Phase 3.1.2 (#3391), ``loom-backlog`` reads exclusively from
+``.loom/issue-failures.json`` and uses the ``loom:blocked`` label as the
+escalation deduplication signal. These tests exercise that contract:
+
+- No fixture writes ``daemon-state.json`` — its absence is the point.
+- The forge ``gh issue list --label loom:blocked`` call is patched out
+  so tests do not require network access.
+"""
 
 from __future__ import annotations
 
 import json
 import pathlib
+from typing import Any
 from unittest import mock
 
 import pytest
 
-from loom_tools.backlog import cmd_list, cmd_prune, main
-from loom_tools.models.daemon_state import BlockedIssueRetry, DaemonState
+from loom_tools.backlog import cmd_list, cmd_prune, get_retry_policy, main
 
 
-def _write_state(loom_dir: pathlib.Path, blocked_retries: dict) -> None:
-    """Write a minimal daemon-state.json with the given blocked_issue_retries."""
-    state = {
-        "running": False,
-        "blocked_issue_retries": blocked_retries,
-        "needs_human_input": [],
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _write_failures(
+    loom_dir: pathlib.Path,
+    entries: dict[str, dict],
+) -> None:
+    """Write a minimal ``issue-failures.json`` with the given entries."""
+    payload = {
+        "entries": entries,
+        "updated_at": "2026-06-02T12:00:00Z",
     }
     loom_dir.mkdir(parents=True, exist_ok=True)
-    (loom_dir / "daemon-state.json").write_text(json.dumps(state))
+    (loom_dir / "issue-failures.json").write_text(json.dumps(payload))
+
+
+def _failure_entry(
+    issue: int,
+    *,
+    total_failures: int,
+    error_class: str,
+    phase: str = "builder",
+    details: str = "",
+) -> dict[str, Any]:
+    """Build a single ``IssueFailureEntry``-shaped dict."""
+    return {
+        "issue": issue,
+        "total_failures": total_failures,
+        "error_class": error_class,
+        "phase": phase,
+        "details": details,
+        "first_failure_at": "2026-01-20T10:00:00Z",
+        "last_failure_at": "2026-01-22T10:00:00Z",
+    }
+
+
+def _patch_escalated(monkeypatch: pytest.MonkeyPatch, numbers: set[int]) -> mock.MagicMock:
+    """Patch ``gh issue list --label loom:blocked`` to return *numbers*.
+
+    Returns the underlying ``gh_run`` mock so tests can assert on
+    follow-up calls (label apply, comment).
+    """
+    payload = json.dumps([{"number": n} for n in sorted(numbers)])
+    list_result = mock.MagicMock(returncode=0, stdout=payload)
+    edit_result = mock.MagicMock(returncode=0, stdout="")
+    comment_result = mock.MagicMock(returncode=0, stdout="")
+
+    def fake_gh(cmd, **kwargs):  # noqa: ANN001 - test helper
+        if len(cmd) >= 2 and cmd[0] == "issue":
+            if cmd[1] == "list":
+                return list_result
+            if cmd[1] == "edit":
+                return edit_result
+            if cmd[1] == "comment":
+                return comment_result
+        return mock.MagicMock(returncode=0, stdout="")
+
+    m = mock.MagicMock(side_effect=fake_gh)
+    monkeypatch.setattr("loom_tools.backlog.gh_run", m)
+    return m
+
+
+# ---------------------------------------------------------------------------
+# get_retry_policy()
+# ---------------------------------------------------------------------------
+
+
+class TestRetryPolicy:
+    def test_known_class_uses_table(self) -> None:
+        p = get_retry_policy("builder_test_failure")
+        assert p.max_retries == 2
+        assert p.cooldown == 21600
+        assert p.escalate is True
+
+    def test_transient_class_does_not_escalate(self) -> None:
+        p = get_retry_policy("mcp_infrastructure_failure")
+        assert p.escalate is False
+
+    def test_doctor_class_immediate_escalation(self) -> None:
+        p = get_retry_policy("doctor_exhausted")
+        assert p.max_retries == 0
+        assert p.escalate is True
+
+    def test_unknown_class_uses_default(self) -> None:
+        p = get_retry_policy("totally_unknown_class")
+        assert p.max_retries == 3
+        assert p.cooldown == 1800
+        assert p.escalate is True
+
+
+# ---------------------------------------------------------------------------
+# cmd_list()
+# ---------------------------------------------------------------------------
 
 
 class TestCmdList:
-    def test_no_state_file(self, tmp_path: pathlib.Path, capsys) -> None:
-        repo = tmp_path / "repo"
-        repo.mkdir()
-        (repo / ".git").mkdir()
-        (repo / ".loom").mkdir()
-
-        with mock.patch("loom_tools.backlog.find_repo_root", return_value=repo):
-            result = cmd_list(repo)
-
-        assert result == 1
-
-    def test_empty_retries(self, tmp_path: pathlib.Path, capsys) -> None:
+    def test_no_failures_file(
+        self, tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         loom_dir = tmp_path / ".loom"
-        _write_state(loom_dir, {})
+        loom_dir.mkdir()
+        result = cmd_list(tmp_path)
+        out = capsys.readouterr().out
+        assert result == 1
+        assert "No issue-failures.json" in out
+
+    def test_empty_entries(
+        self,
+        tmp_path: pathlib.Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _write_failures(tmp_path / ".loom", {})
+        _patch_escalated(monkeypatch, set())
 
         result = cmd_list(tmp_path)
         out = capsys.readouterr().out
         assert result == 0
-        assert "No blocked issues" in out
+        assert "No tracked issue failures" in out
 
-    def test_lists_blocked_issues(self, tmp_path: pathlib.Path, capsys) -> None:
-        loom_dir = tmp_path / ".loom"
-        _write_state(loom_dir, {
-            "42": {
-                "retry_count": 2,
-                "error_class": "builder_test_failure",
-                "retry_exhausted": False,
-                "last_blocked_phase": "builder",
-                "last_blocked_details": "",
-            },
-            "99": {
-                "retry_count": 1,
-                "error_class": "mcp_infrastructure_failure",
-                "retry_exhausted": False,
-                "last_blocked_phase": "builder",
-                "last_blocked_details": "",
-            },
+    def test_lists_tracked_failures(
+        self,
+        tmp_path: pathlib.Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _write_failures(tmp_path / ".loom", {
+            "42": _failure_entry(42, total_failures=2, error_class="builder_test_failure"),
+            "99": _failure_entry(99, total_failures=1, error_class="mcp_infrastructure_failure"),
         })
+        _patch_escalated(monkeypatch, set())
 
         result = cmd_list(tmp_path)
         out = capsys.readouterr().out
@@ -70,140 +162,247 @@ class TestCmdList:
         assert "#99" in out
         assert "builder_test_failure" in out
         assert "mcp_infrastructure_failure" in out
+        # #42: 2 failures vs max_retries=2 -> exhausted
+        # #99: 1 failure vs max_retries=5 -> retryable
+        assert "exhausted" in out
+        assert "retryable" in out
+
+    def test_escalated_label_overrides_exhausted(
+        self,
+        tmp_path: pathlib.Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _write_failures(tmp_path / ".loom", {
+            "42": _failure_entry(42, total_failures=5, error_class="builder_test_failure"),
+        })
+        _patch_escalated(monkeypatch, {42})
+
+        result = cmd_list(tmp_path)
+        out = capsys.readouterr().out
+        assert result == 0
+        assert "escalated" in out
+
+    def test_does_not_read_daemon_state(
+        self,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The ported CLI must not pull data from daemon-state.json at all."""
+        loom_dir = tmp_path / ".loom"
+        _write_failures(loom_dir, {
+            "42": _failure_entry(42, total_failures=2, error_class="builder_test_failure"),
+        })
+        # Write a daemon-state.json that, if read, would yield different data.
+        (loom_dir / "daemon-state.json").write_text(json.dumps({
+            "running": True,
+            "blocked_issue_retries": {
+                "9999": {
+                    "retry_count": 99,
+                    "error_class": "builder_unknown_failure",
+                    "retry_exhausted": True,
+                    "escalated_to_human": False,
+                    "last_blocked_phase": "builder",
+                    "last_blocked_details": "",
+                },
+            },
+            "needs_human_input": [],
+        }))
+        _patch_escalated(monkeypatch, set())
+
+        import io
+        buf = io.StringIO()
+        with mock.patch("sys.stdout", buf):
+            result = cmd_list(tmp_path)
+        out = buf.getvalue()
+
+        assert result == 0
+        assert "#42" in out
+        assert "#9999" not in out
+
+
+# ---------------------------------------------------------------------------
+# cmd_prune()
+# ---------------------------------------------------------------------------
 
 
 class TestCmdPrune:
-    def test_dry_run_makes_no_changes(self, tmp_path: pathlib.Path, capsys) -> None:
-        loom_dir = tmp_path / ".loom"
-        _write_state(loom_dir, {
-            "42": {
-                "retry_count": 2,
-                "error_class": "builder_test_failure",
-                "retry_exhausted": False,
-                "escalated_to_human": False,
-                "last_blocked_phase": "builder",
-                "last_blocked_details": "",
-            },
+    def test_no_failures_file(
+        self, tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        (tmp_path / ".loom").mkdir()
+        result = cmd_prune(tmp_path, dry_run=False, add_comment=False)
+        out = capsys.readouterr().out
+        assert result == 1
+        assert "No issue-failures.json" in out
+
+    def test_dry_run_makes_no_mutations(
+        self,
+        tmp_path: pathlib.Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _write_failures(tmp_path / ".loom", {
+            "42": _failure_entry(42, total_failures=2, error_class="builder_test_failure"),
         })
+        m = _patch_escalated(monkeypatch, set())
 
         result = cmd_prune(tmp_path, dry_run=True, add_comment=False)
         out = capsys.readouterr().out
         assert result == 0
         assert "dry-run" in out
 
-        # State should be unchanged
-        state = json.loads((loom_dir / "daemon-state.json").read_text())
-        entry = state["blocked_issue_retries"]["42"]
-        assert entry.get("escalated_to_human", False) is False
+        # Only the read-side 'issue list' query should have happened.
+        invoked_subcommands = [call.args[0][1] for call in m.call_args_list]
+        assert invoked_subcommands == ["list"]
 
-    def test_prune_escalates_exhausted_issue(self, tmp_path: pathlib.Path, capsys) -> None:
-        loom_dir = tmp_path / ".loom"
-        _write_state(loom_dir, {
-            "42": {
-                "retry_count": 2,
-                "error_class": "builder_test_failure",
-                "retry_exhausted": False,
-                "escalated_to_human": False,
-                "last_blocked_phase": "builder",
-                "last_blocked_details": "",
-            },
-        })
-
-        result = cmd_prune(tmp_path, dry_run=False, add_comment=False)
-        assert result == 0
-
-        state = json.loads((loom_dir / "daemon-state.json").read_text())
-        entry = state["blocked_issue_retries"]["42"]
-        assert entry.get("escalated_to_human") is True
-        assert len(state["needs_human_input"]) == 1
-        assert state["needs_human_input"][0]["issue"] == 42
-
-    def test_prune_skips_already_escalated(self, tmp_path: pathlib.Path, capsys) -> None:
-        loom_dir = tmp_path / ".loom"
-        _write_state(loom_dir, {
-            "42": {
-                "retry_count": 2,
-                "error_class": "builder_test_failure",
-                "retry_exhausted": False,
-                "escalated_to_human": True,  # already escalated
-                "last_blocked_phase": "builder",
-                "last_blocked_details": "",
-            },
-        })
-
-        result = cmd_prune(tmp_path, dry_run=False, add_comment=False)
-        out = capsys.readouterr().out
-        assert result == 0
-        assert "Nothing to escalate" in out
-
-    def test_prune_does_not_escalate_transient_errors(self, tmp_path: pathlib.Path, capsys) -> None:
-        """mcp_infrastructure_failure exhausted but escalate=False → no escalation."""
-        loom_dir = tmp_path / ".loom"
-        _write_state(loom_dir, {
-            "200": {
-                "retry_count": 5,
-                "error_class": "mcp_infrastructure_failure",
-                "retry_exhausted": False,
-                "escalated_to_human": False,
-                "last_blocked_phase": "builder",
-                "last_blocked_details": "",
-            },
-        })
-
-        result = cmd_prune(tmp_path, dry_run=False, add_comment=False)
-        out = capsys.readouterr().out
-        assert result == 0
-        assert "Nothing to escalate" in out
-
-        state = json.loads((loom_dir / "daemon-state.json").read_text())
-        assert len(state["needs_human_input"]) == 0
-
-    @mock.patch("loom_tools.backlog.gh_run")
-    def test_prune_with_comment(
-        self, mock_gh: mock.MagicMock, tmp_path: pathlib.Path, capsys
+    def test_prune_escalates_exhausted_issue(
+        self,
+        tmp_path: pathlib.Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        loom_dir = tmp_path / ".loom"
-        _write_state(loom_dir, {
-            "42": {
-                "retry_count": 3,
-                "error_class": "builder_unknown_failure",
-                "retry_exhausted": False,
-                "escalated_to_human": False,
-                "last_blocked_phase": "builder",
-                "last_blocked_details": "",
-            },
+        _write_failures(tmp_path / ".loom", {
+            "42": _failure_entry(42, total_failures=2, error_class="builder_test_failure"),
         })
-        mock_gh.return_value = mock.MagicMock(returncode=0)
+        m = _patch_escalated(monkeypatch, set())
+
+        result = cmd_prune(tmp_path, dry_run=False, add_comment=False)
+        out = capsys.readouterr().out
+        assert result == 0
+        assert "Escalated 1 issue" in out
+
+        label_calls = [
+            call for call in m.call_args_list
+            if call.args[0][:2] == ["issue", "edit"]
+        ]
+        assert len(label_calls) == 1
+        assert "loom:blocked" in label_calls[0].args[0]
+        assert "42" in label_calls[0].args[0]
+
+    def test_prune_skips_already_escalated(
+        self,
+        tmp_path: pathlib.Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _write_failures(tmp_path / ".loom", {
+            "42": _failure_entry(42, total_failures=2, error_class="builder_test_failure"),
+        })
+        m = _patch_escalated(monkeypatch, {42})
+
+        result = cmd_prune(tmp_path, dry_run=False, add_comment=False)
+        out = capsys.readouterr().out
+        assert result == 0
+        assert "Nothing to escalate" in out
+        edit_calls = [
+            call for call in m.call_args_list
+            if call.args[0][:2] == ["issue", "edit"]
+        ]
+        assert edit_calls == []
+
+    def test_prune_does_not_escalate_transient_errors(
+        self,
+        tmp_path: pathlib.Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """mcp_infrastructure_failure exhausted but escalate=False -> no escalation."""
+        _write_failures(tmp_path / ".loom", {
+            "200": _failure_entry(200, total_failures=5, error_class="mcp_infrastructure_failure"),
+        })
+        m = _patch_escalated(monkeypatch, set())
+
+        result = cmd_prune(tmp_path, dry_run=False, add_comment=False)
+        out = capsys.readouterr().out
+        assert result == 0
+        assert "Nothing to escalate" in out
+        edit_calls = [
+            call for call in m.call_args_list
+            if call.args[0][:2] == ["issue", "edit"]
+        ]
+        assert edit_calls == []
+
+    def test_prune_with_comment_posts_comment(
+        self,
+        tmp_path: pathlib.Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _write_failures(tmp_path / ".loom", {
+            "42": _failure_entry(42, total_failures=3, error_class="builder_unknown_failure"),
+        })
+        m = _patch_escalated(monkeypatch, set())
 
         result = cmd_prune(tmp_path, dry_run=False, add_comment=True)
         assert result == 0
 
-        # Verify gh comment was called
-        mock_gh.assert_called_once()
-        call_args = mock_gh.call_args[0][0]
-        assert "comment" in call_args
-        assert "42" in call_args
+        comment_calls = [
+            call for call in m.call_args_list
+            if call.args[0][:2] == ["issue", "comment"]
+        ]
+        assert len(comment_calls) == 1
+        assert "42" in comment_calls[0].args[0]
 
-    def test_doctor_exhausted_immediate_escalation(self, tmp_path: pathlib.Path, capsys) -> None:
-        """doctor_exhausted with 0 retries is immediately escalated."""
-        loom_dir = tmp_path / ".loom"
-        _write_state(loom_dir, {
-            "300": {
-                "retry_count": 0,
-                "error_class": "doctor_exhausted",
-                "retry_exhausted": False,
-                "escalated_to_human": False,
-                "last_blocked_phase": "doctor",
-                "last_blocked_details": "",
-            },
+    def test_doctor_exhausted_immediate_escalation(
+        self,
+        tmp_path: pathlib.Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """doctor_exhausted with 0 retries is immediately escalated (max_retries=0)."""
+        _write_failures(tmp_path / ".loom", {
+            "300": _failure_entry(300, total_failures=0, error_class="doctor_exhausted"),
         })
+        m = _patch_escalated(monkeypatch, set())
 
         result = cmd_prune(tmp_path, dry_run=False, add_comment=False)
         assert result == 0
 
-        state = json.loads((loom_dir / "daemon-state.json").read_text())
-        assert state["blocked_issue_retries"]["300"].get("escalated_to_human") is True
-        assert len(state["needs_human_input"]) == 1
+        edit_calls = [
+            call for call in m.call_args_list
+            if call.args[0][:2] == ["issue", "edit"]
+        ]
+        assert len(edit_calls) == 1
+        assert "300" in edit_calls[0].args[0]
+
+    def test_prune_does_not_read_daemon_state(
+        self,
+        tmp_path: pathlib.Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        loom_dir = tmp_path / ".loom"
+        _write_failures(loom_dir, {})
+        # Write a daemon-state.json that, if read, would queue an escalation.
+        (loom_dir / "daemon-state.json").write_text(json.dumps({
+            "running": True,
+            "blocked_issue_retries": {
+                "9999": {
+                    "retry_count": 99,
+                    "error_class": "builder_unknown_failure",
+                    "retry_exhausted": True,
+                    "escalated_to_human": False,
+                    "last_blocked_phase": "builder",
+                    "last_blocked_details": "",
+                },
+            },
+            "needs_human_input": [],
+        }))
+        m = _patch_escalated(monkeypatch, set())
+
+        result = cmd_prune(tmp_path, dry_run=False, add_comment=False)
+        assert result == 0
+        edit_calls = [
+            call for call in m.call_args_list
+            if call.args[0][:2] == ["issue", "edit"]
+        ]
+        assert edit_calls == []
+
+
+# ---------------------------------------------------------------------------
+# main()
+# ---------------------------------------------------------------------------
 
 
 class TestMain:


### PR DESCRIPTION
Closes #3391

Part of Phase 3 of the shepherd/daemon deprecation: epic **#3372**, tracker **#3378** (Category 3 of `docs/migration/daemon-state-consumers.md`).

## Summary

Migrates the `loom-backlog` CLI off the ephemeral `.loom/daemon-state.json::blocked_issue_retries` read path and onto the durable `.loom/issue-failures.json` log that survives Phase 3.

**Distinct from sibling Phase 3.1.x PRs:** this PR drops the `daemon-state.json` read path **entirely** — there is no fallback. `issue-failures.json` is already cross-session durable, so a fallback would only serve to mask drift between the two stores while the daemon is still alive. The architect doc calls this out explicitly:

> `loom-backlog` — port to `issue-failures.json` only (already cross-session).
> — `docs/migration/daemon-state-consumers.md`, Category 3 row

## Changes

- **`loom-tools/src/loom_tools/backlog.py`**
  - Replaces `read_daemon_state()` + `snapshot.get_retry_policy()` with `load_failure_log()` + an inlined `RetryPolicy` table (copied verbatim from `snapshot.py` so backlog has zero runtime dependency on `snapshot.py`, satisfying AC #6).
  - Escalation now uses the existing `loom:blocked` GitHub label as the deduplication signal. A single `gh issue list --label loom:blocked --state all` call replaces the in-state `escalated_to_human` flag. **No new labels introduced** (per the project's "never create new labels" policy).
  - `cmd_list` output: same columns (`issue`, `error_class`, `retry_count`, `max_retries`, `cooldown`, `escalate`, `status`); header text changed from "Blocked issues:" to "Tracked issue failures:" to reflect the new source of truth.
  - `cmd_prune` output: same summary structure, same `--dry-run`/`--comment` semantics; "Already escalated" now means "carrying `loom:blocked`".
  - `_load_entries` passes `_main_sha=None` to `load_failure_log` so the CLI does not trigger the auto-decay-rewrite side effect on read.

- **`loom-tools/tests/test_backlog.py`**
  - Rewritten to fixture `.loom/issue-failures.json` directly (no `daemon-state.json` writes) and mock the forge label-list call.
  - Added two regression tests (`test_does_not_read_daemon_state` in both `TestCmdList` and `TestCmdPrune`) that drop a misleading `daemon-state.json` alongside an empty/minimal `issue-failures.json` and assert the CLI **ignores** the daemon-state contents. These will catch any future change that accidentally reintroduces a fallback read.
  - 19 backlog tests pass; 2 unrelated snapshot tests matching `-k backlog` also still pass.

## Before / after CLI output

Run on the live `.loom/issue-failures.json` (162 entries) and `.loom/daemon-state.json` (same workspace).

### `loom-backlog list`

**Before** (read from `daemon-state.json::blocked_issue_retries`):
```
Blocked issues: 162 total  (109 retryable, 53 exhausted, 0 escalated)

issue  error_class                 retry_count  max_retries  cooldown  escalate  status
-----  --------------------------  -----------  -----------  --------  --------  ---------
#2194  judge_exhausted             1            2            6h        yes       retryable
#2243  shepherd_failure            2            5            30m       no        retryable
#2248  judge_exhausted             3            2            6h        yes       exhausted
...
```

**After** (read from `issue-failures.json`):
```
Tracked issue failures: 162 total  (111 retryable, 51 exhausted, 0 escalated)

issue  error_class                 retry_count  max_retries  cooldown  escalate  status
-----  --------------------------  -----------  -----------  --------  --------  ---------
#2194  judge_exhausted             1            2            6h        yes       retryable
#2243  shepherd_failure            2            5            30m       no        retryable
#2248  judge_exhausted             3            2            6h        yes       exhausted
...
```

Note the 109→111 retryable / 53→51 exhausted delta — that is real drift between the two stores (`daemon-state.json` carried two stale `judge_mcp_failure` entries that never made it into the durable log). The new behavior matches the durable record, which is the correct post-Phase-3 source of truth.

### `loom-backlog prune --dry-run`

**Before**:
```
Backlog prune summary (2026-06-03T01:09:20Z):
  Total blocked issues:     162
  Already escalated:        0
  To escalate (this run):   38
  Transient exhausted:      15 (no escalation, error class non-critical)
  Still retryable:          109

Issues to escalate:
  #2248  judge_exhausted (retry_count=3)  Exceeded 2 retries for judge_exhausted
  #2270  judge_exhausted (retry_count=2)  Exceeded 2 retries for judge_exhausted
  ...
```

**After**:
```
Backlog prune summary (2026-06-03T01:13:52Z):
  Total tracked failures:   162
  Already escalated:        0  (carrying 'loom:blocked')
  To escalate (this run):   36
  Transient exhausted:      15 (no escalation, error class non-critical)
  Still retryable:          111

Issues to escalate:
  #2248  judge_exhausted (retry_count=3)  Exceeded 2 retries for judge_exhausted
  #2270  judge_exhausted (retry_count=2)  Exceeded 2 retries for judge_exhausted
  ...
```

### `loom-backlog --help`

**After**:
```
usage: loom-backlog [-h] {list,prune} ...

Backlog management for tracked issue failures (reads .loom/issue-failures.json)

positional arguments:
  {list,prune}  Subcommand
    list        List tracked failures with tiered retry policy info
    prune       Apply tiered retry policy retroactively; label exhausted
                issues with 'loom:blocked' for human review
```

## Acceptance criteria

- [x] `loom-backlog` works against a workspace with no Python daemon present.
- [x] All retry-policy logic now reads only `issue-failures.json` (no `daemon-state.json` references in `backlog.py` after this PR — verified via `grep`; only docstring/comment mentions remain).
- [x] Existing CLI output shape preserved (table columns identical; summary structure preserved with cosmetic label tweaks).
- [x] PR body includes before/after sample output (`list`, `prune --dry-run`, `--help`).
- [x] `loom-tools/tests/test_backlog.py` passes (19/19 tests, plus 2 unrelated snapshot tests captured by `-k backlog`).
- [x] No new dependency on `snapshot.py` introduced (the `RetryPolicy` table is inlined locally).

## Out of scope

- Changing the `issue-failures.json` schema.
- Deleting `loom-tools/src/loom_tools/common/snapshot.py` — that is Phase 3.2.

## Test plan

- [x] `PYTHONPATH=loom-tools/src:$PYTHONPATH python3 -m pytest loom-tools/tests/ -v -k backlog` — 21 passed, 0 failed
- [x] Live CLI smoke test: `python3 -m loom_tools.backlog list` and `prune --dry-run` against the real workspace (162 entries) renders correctly.
- [ ] Smoke-test `prune` (non-dry-run) on a throwaway workspace to verify the label-apply path. (Skipped here to avoid mutating the live forge; covered by the unit test `test_prune_escalates_exhausted_issue`.)