### PR TITLE
refactor(agent-metrics): drop daemon-state.json fallback (activity.db only)

### DIFF
--- a/loom-tools/src/loom_tools/agent_metrics.py
+++ b/loom-tools/src/loom_tools/agent_metrics.py
@@ -1,8 +1,11 @@
 """Agent performance metrics for self-aware agents.
 
 Enables agents to query their own effectiveness, costs, and velocity.
-Reads from the activity database (~/.loom/activity.db) when available,
-falling back to daemon-state.json and GitHub API.
+Reads exclusively from the activity database (``~/.loom/activity.db``).
+
+If the activity database is missing, the CLI emits a clear error and
+exits non-zero (see Phase 3.1.5 / #3394: the legacy ``daemon-state.json``
+fallback has been removed in preparation for full daemon retirement).
 
 Commands:
     summary         Overall metrics summary (default)
@@ -12,7 +15,7 @@ Commands:
 
 Exit codes:
     0 - Success
-    1 - Error
+    1 - Error (including activity database not available)
 """
 
 from __future__ import annotations
@@ -23,13 +26,11 @@ import os
 import pathlib
 import sqlite3
 import sys
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
-from loom_tools.common.github import gh_run
-from loom_tools.common.logging import log_error, log_warning
+from loom_tools.common.logging import log_error
 from loom_tools.common.repo import find_repo_root
-from loom_tools.common.state import read_daemon_state
 
 # ANSI color codes for direct stdout formatting.
 # Logging helpers write to stderr; metrics output goes to stdout.
@@ -158,46 +159,6 @@ class VelocityRow:
         }
 
 
-@dataclass
-class FallbackSummary:
-    """Limited metrics when the activity DB is unavailable."""
-
-    completed_issues: int = 0
-    total_prs_merged: int = 0
-    open_issues: int = 0
-    open_prs: int = 0
-    note: str = "Limited data - activity database not available"
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "completed_issues": self.completed_issues,
-            "total_prs_merged": self.total_prs_merged,
-            "open_issues": self.open_issues,
-            "open_prs": self.open_prs,
-            "note": self.note,
-        }
-
-
-@dataclass
-class FallbackVelocity:
-    """Limited velocity when the activity DB is unavailable."""
-
-    completed_issues: int = 0
-    prs_merged: int = 0
-    session_started: str = ""
-    note: str = "Velocity from daemon state (limited data)"
-
-    def to_dict(self) -> dict[str, Any]:
-        d: dict[str, Any] = {
-            "completed_issues": self.completed_issues,
-            "prs_merged": self.prs_merged,
-            "note": self.note,
-        }
-        if self.session_started:
-            d["session_started"] = self.session_started
-        return d
-
-
 # ---------------------------------------------------------------------------
 # SQL helpers
 # ---------------------------------------------------------------------------
@@ -297,43 +258,6 @@ def get_summary(
         issues_count=row.get("issues_count", 0) or 0,
         prs_count=row.get("prs_count", 0) or 0,
         success_rate=sr or 0.0,
-    )
-
-
-def get_summary_fallback(repo_root: pathlib.Path) -> FallbackSummary:
-    """Get limited summary metrics from daemon state and GitHub."""
-    state = read_daemon_state(repo_root)
-
-    completed = len(state.completed_issues) if state.completed_issues else 0
-    prs_merged = state.total_prs_merged or 0
-
-    open_issues = 0
-    open_prs = 0
-    try:
-        result = gh_run(
-            ["issue", "list", "--state", "open", "--json", "number", "--jq", "length"],
-            check=False,
-        )
-        if result.returncode == 0 and result.stdout.strip():
-            open_issues = int(result.stdout.strip())
-    except Exception:
-        pass
-
-    try:
-        result = gh_run(
-            ["pr", "list", "--state", "open", "--json", "number", "--jq", "length"],
-            check=False,
-        )
-        if result.returncode == 0 and result.stdout.strip():
-            open_prs = int(result.stdout.strip())
-    except Exception:
-        pass
-
-    return FallbackSummary(
-        completed_issues=completed,
-        total_prs_merged=prs_merged,
-        open_issues=open_issues,
-        open_prs=open_prs,
     )
 
 
@@ -460,17 +384,6 @@ def get_velocity(db_path: pathlib.Path) -> list[VelocityRow]:
     ]
 
 
-def get_velocity_fallback(repo_root: pathlib.Path) -> FallbackVelocity:
-    """Get limited velocity from daemon state."""
-    state = read_daemon_state(repo_root)
-
-    return FallbackVelocity(
-        completed_issues=len(state.completed_issues) if state.completed_issues else 0,
-        prs_merged=state.total_prs_merged or 0,
-        session_started=state.started_at or "",
-    )
-
-
 # ---------------------------------------------------------------------------
 # Text formatters
 # ---------------------------------------------------------------------------
@@ -504,23 +417,6 @@ def format_summary_text(m: SummaryMetrics, period: str) -> str:
     return "\n".join(lines)
 
 
-def format_summary_fallback_text(m: FallbackSummary) -> str:
-    """Format fallback summary for human display."""
-    lines = [
-        "",
-        _c(_BLUE, "Agent Performance Summary") + " (daemon state)",
-        _c(_GRAY, "\u2500" * 40),
-        f"  Completed Issues: {m.completed_issues}",
-        f"  PRs Merged:       {m.total_prs_merged}",
-        f"  Open Issues:      {m.open_issues}",
-        f"  Open PRs:         {m.open_prs}",
-        "",
-        _c(_YELLOW, "Note: Activity database not available. Enable tracking for detailed metrics."),
-        "",
-    ]
-    return "\n".join(lines)
-
-
 def format_effectiveness_text(rows: list[EffectivenessRow], period: str) -> str:
     """Format effectiveness table for human display."""
     lines = [
@@ -541,11 +437,6 @@ def format_effectiveness_text(rows: list[EffectivenessRow], period: str) -> str:
     return "\n".join(lines)
 
 
-def format_effectiveness_unavailable_text() -> str:
-    """Format message when effectiveness data is unavailable."""
-    return _c(_YELLOW, "Activity database not available. Enable tracking for effectiveness metrics.")
-
-
 def format_costs_text(rows: list[CostRow]) -> str:
     """Format cost table for human display."""
     lines = [
@@ -562,11 +453,6 @@ def format_costs_text(rows: list[CostRow]) -> str:
         )
     lines.append("")
     return "\n".join(lines)
-
-
-def format_costs_unavailable_text() -> str:
-    """Format message when cost data is unavailable."""
-    return _c(_YELLOW, "Activity database not available. Enable tracking for cost metrics.")
 
 
 def format_velocity_text(rows: list[VelocityRow]) -> str:
@@ -587,24 +473,13 @@ def format_velocity_text(rows: list[VelocityRow]) -> str:
     return "\n".join(lines)
 
 
-def format_velocity_fallback_text(m: FallbackVelocity) -> str:
-    """Format fallback velocity for human display."""
-    lines = [
-        "",
-        _c(_BLUE, "Development Velocity") + " (daemon state)",
-        _c(_GRAY, "\u2500" * 40),
-        f"  Issues Completed: {m.completed_issues}",
-        f"  PRs Merged:       {m.prs_merged}",
-    ]
-    if m.session_started:
-        lines.append(f"  Session Started:  {m.session_started}")
-    lines.append("")
-    return "\n".join(lines)
-
-
-def format_velocity_unavailable_text() -> str:
-    """Format message when no velocity data is available."""
-    return _c(_YELLOW, "No velocity data available.")
+def format_db_unavailable_text(db_path: pathlib.Path) -> str:
+    """Format error message when the activity database is missing."""
+    return _c(
+        _RED,
+        f"Error: activity database not found at {db_path}. "
+        "Set LOOM_ACTIVITY_DB or enable agent activity tracking.",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -684,23 +559,44 @@ Examples:
         return 1
 
     try:
-        repo_root = find_repo_root()
+        # Anchor to a git repo so the CLI behaves consistently with the
+        # other loom-tools entry points; the activity database itself lives
+        # under ``~/.loom`` (overridable via LOOM_ACTIVITY_DB), not in the
+        # repo, but failing fast outside a repo matches operator expectations.
+        find_repo_root()
     except FileNotFoundError:
         log_error("Not in a git repository with .loom directory")
         return 1
 
     db_path = _get_activity_db_path()
-    db_available = db_path.is_file()
+    if not db_path.is_file():
+        # No more daemon-state.json fallback (#3394). The activity DB is
+        # the single source of truth for metrics; surface a clear error so
+        # operators know what to configure rather than silently returning
+        # empty/stale state.
+        if args.output_format == "json":
+            print(
+                json.dumps(
+                    {
+                        "error": "Activity database not available",
+                        "db_path": str(db_path),
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            print(format_db_unavailable_text(db_path))
+        return 1
 
     try:
         if args.command == "summary":
-            return _cmd_summary(db_available, db_path, repo_root, args)
+            return _cmd_summary(db_path, args)
         elif args.command == "effectiveness":
-            return _cmd_effectiveness(db_available, db_path, args)
+            return _cmd_effectiveness(db_path, args)
         elif args.command == "costs":
-            return _cmd_costs(db_available, db_path, args)
+            return _cmd_costs(db_path, args)
         elif args.command == "velocity":
-            return _cmd_velocity(db_available, db_path, repo_root, args)
+            return _cmd_velocity(db_path, args)
     except Exception as e:
         log_error(f"Failed to get metrics: {e}")
         return 1
@@ -708,39 +604,16 @@ Examples:
     return 0
 
 
-def _cmd_summary(
-    db_available: bool,
-    db_path: pathlib.Path,
-    repo_root: pathlib.Path,
-    args: argparse.Namespace,
-) -> int:
-    if db_available:
-        metrics = get_summary(db_path, args.role, args.period)
-        if args.output_format == "json":
-            print(json.dumps(metrics.to_dict(), indent=2))
-        else:
-            print(format_summary_text(metrics, args.period))
+def _cmd_summary(db_path: pathlib.Path, args: argparse.Namespace) -> int:
+    metrics = get_summary(db_path, args.role, args.period)
+    if args.output_format == "json":
+        print(json.dumps(metrics.to_dict(), indent=2))
     else:
-        fb = get_summary_fallback(repo_root)
-        if args.output_format == "json":
-            print(json.dumps(fb.to_dict(), indent=2))
-        else:
-            print(format_summary_fallback_text(fb))
+        print(format_summary_text(metrics, args.period))
     return 0
 
 
-def _cmd_effectiveness(
-    db_available: bool,
-    db_path: pathlib.Path,
-    args: argparse.Namespace,
-) -> int:
-    if not db_available:
-        if args.output_format == "json":
-            print(json.dumps({"error": "Activity database not available", "roles": []}))
-        else:
-            print(format_effectiveness_unavailable_text())
-        return 0
-
+def _cmd_effectiveness(db_path: pathlib.Path, args: argparse.Namespace) -> int:
     rows = get_effectiveness(db_path, args.role, args.period)
     if args.output_format == "json":
         print(json.dumps([r.to_dict() for r in rows], indent=2))
@@ -749,18 +622,7 @@ def _cmd_effectiveness(
     return 0
 
 
-def _cmd_costs(
-    db_available: bool,
-    db_path: pathlib.Path,
-    args: argparse.Namespace,
-) -> int:
-    if not db_available:
-        if args.output_format == "json":
-            print(json.dumps({"error": "Activity database not available", "costs": []}))
-        else:
-            print(format_costs_unavailable_text())
-        return 0
-
+def _cmd_costs(db_path: pathlib.Path, args: argparse.Namespace) -> int:
     rows = get_costs(db_path, args.issue)
     if args.output_format == "json":
         print(json.dumps([r.to_dict() for r in rows], indent=2))
@@ -769,30 +631,12 @@ def _cmd_costs(
     return 0
 
 
-def _cmd_velocity(
-    db_available: bool,
-    db_path: pathlib.Path,
-    repo_root: pathlib.Path,
-    args: argparse.Namespace,
-) -> int:
-    if db_available:
-        rows = get_velocity(db_path)
-        if args.output_format == "json":
-            print(json.dumps([r.to_dict() for r in rows], indent=2))
-        else:
-            print(format_velocity_text(rows))
+def _cmd_velocity(db_path: pathlib.Path, args: argparse.Namespace) -> int:
+    rows = get_velocity(db_path)
+    if args.output_format == "json":
+        print(json.dumps([r.to_dict() for r in rows], indent=2))
     else:
-        fb = get_velocity_fallback(repo_root)
-        if fb.completed_issues or fb.prs_merged:
-            if args.output_format == "json":
-                print(json.dumps(fb.to_dict(), indent=2))
-            else:
-                print(format_velocity_fallback_text(fb))
-        else:
-            if args.output_format == "json":
-                print(json.dumps({"error": "No velocity data available"}))
-            else:
-                print(format_velocity_unavailable_text())
+        print(format_velocity_text(rows))
     return 0
 
 

--- a/loom-tools/tests/test_agent_metrics.py
+++ b/loom-tools/tests/test_agent_metrics.py
@@ -12,24 +12,19 @@ import pytest
 from loom_tools.agent_metrics import (
     CostRow,
     EffectivenessRow,
-    FallbackSummary,
-    FallbackVelocity,
     SummaryMetrics,
     VelocityRow,
     _get_period_filter,
     _get_role_filter,
     format_costs_text,
+    format_db_unavailable_text,
     format_effectiveness_text,
-    format_summary_fallback_text,
     format_summary_text,
-    format_velocity_fallback_text,
     format_velocity_text,
     get_costs,
     get_effectiveness,
     get_summary,
-    get_summary_fallback,
     get_velocity,
-    get_velocity_fallback,
     main,
 )
 
@@ -329,74 +324,18 @@ class TestVelocity:
 
 
 # ---------------------------------------------------------------------------
-# Fallback path tests
+# Missing-database error path tests (Phase 3.1.5 / #3394 — no fallback)
 # ---------------------------------------------------------------------------
 
 
-class TestFallbackSummary:
-    """Tests for the fallback summary when DB is unavailable."""
+class TestMissingDatabase:
+    """Tests for the explicit error path when activity.db is missing."""
 
-    def test_fallback_with_daemon_state(self, mock_repo: pathlib.Path) -> None:
-        # Write a daemon state file
-        state_file = mock_repo / ".loom" / "daemon-state.json"
-        state_file.write_text(
-            json.dumps(
-                {
-                    "completed_issues": [100, 101, 102],
-                    "total_prs_merged": 3,
-                }
-            )
-        )
-
-        with mock.patch("loom_tools.agent_metrics.find_repo_root", return_value=mock_repo):
-            with mock.patch("loom_tools.agent_metrics.gh_run") as mock_gh:
-                # Mock gh issue list and pr list
-                mock_gh.side_effect = [
-                    mock.Mock(returncode=0, stdout="5"),
-                    mock.Mock(returncode=0, stdout="2"),
-                ]
-                fb = get_summary_fallback(mock_repo)
-
-        assert fb.completed_issues == 3
-        assert fb.total_prs_merged == 3
-        assert fb.open_issues == 5
-        assert fb.open_prs == 2
-        assert "not available" in fb.note
-
-    def test_fallback_no_daemon_state(self, mock_repo: pathlib.Path) -> None:
-        with mock.patch("loom_tools.agent_metrics.find_repo_root", return_value=mock_repo):
-            with mock.patch("loom_tools.agent_metrics.gh_run") as mock_gh:
-                mock_gh.side_effect = [
-                    mock.Mock(returncode=0, stdout="0"),
-                    mock.Mock(returncode=0, stdout="0"),
-                ]
-                fb = get_summary_fallback(mock_repo)
-
-        assert fb.completed_issues == 0
-        assert fb.total_prs_merged == 0
-
-
-class TestFallbackVelocity:
-    """Tests for the fallback velocity when DB is unavailable."""
-
-    def test_fallback_with_daemon_state(self, mock_repo: pathlib.Path) -> None:
-        state_file = mock_repo / ".loom" / "daemon-state.json"
-        state_file.write_text(
-            json.dumps(
-                {
-                    "started_at": "2026-01-23T10:00:00Z",
-                    "completed_issues": [1, 2, 3],
-                    "total_prs_merged": 2,
-                }
-            )
-        )
-
-        with mock.patch("loom_tools.agent_metrics.find_repo_root", return_value=mock_repo):
-            fb = get_velocity_fallback(mock_repo)
-
-        assert fb.completed_issues == 3
-        assert fb.prs_merged == 2
-        assert fb.session_started == "2026-01-23T10:00:00Z"
+    def test_format_db_unavailable_mentions_path(self, tmp_path: pathlib.Path) -> None:
+        missing = tmp_path / "no-such.db"
+        msg = format_db_unavailable_text(missing)
+        assert "not found" in msg
+        assert str(missing) in msg
 
 
 # ---------------------------------------------------------------------------
@@ -423,13 +362,6 @@ class TestTextFormatting:
         assert "50K" in output
         assert "$1.5000" in output
         assert "85.0%" in output
-
-    def test_summary_fallback_text(self) -> None:
-        fb = FallbackSummary(completed_issues=5, total_prs_merged=3, open_issues=10, open_prs=2)
-        output = format_summary_fallback_text(fb)
-        assert "daemon state" in output
-        assert "5" in output
-        assert "not available" in output
 
     def test_effectiveness_text_table(self) -> None:
         rows = [
@@ -471,16 +403,6 @@ class TestTextFormatting:
         assert "2026-W04" in output
         assert "20" in output
 
-    def test_velocity_fallback_text(self) -> None:
-        fb = FallbackVelocity(
-            completed_issues=5, prs_merged=3, session_started="2026-01-23T10:00:00Z"
-        )
-        output = format_velocity_fallback_text(fb)
-        assert "daemon state" in output
-        assert "5" in output
-        assert "2026-01-23T10:00:00Z" in output
-
-
 # ---------------------------------------------------------------------------
 # JSON formatting tests
 # ---------------------------------------------------------------------------
@@ -518,14 +440,6 @@ class TestJsonFormatting:
         output = json.dumps([r.to_dict() for r in rows], indent=2)
         parsed = json.loads(output)
         assert isinstance(parsed, list)
-
-    def test_fallback_summary_json_valid(self) -> None:
-        fb = FallbackSummary(completed_issues=5, total_prs_merged=3, open_issues=10, open_prs=2)
-        output = json.dumps(fb.to_dict(), indent=2)
-        parsed = json.loads(output)
-        assert "note" in parsed
-        assert parsed["completed_issues"] == 5
-
 
 # ---------------------------------------------------------------------------
 # ANSI color tests
@@ -602,16 +516,41 @@ class TestCLI:
                 rc = main(["velocity", "--format", "json"])
         assert rc == 0
 
-    def test_fallback_when_no_db(self, mock_repo: pathlib.Path, tmp_path: pathlib.Path) -> None:
+    def test_errors_when_no_db_json(
+        self,
+        mock_repo: pathlib.Path,
+        tmp_path: pathlib.Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Missing activity DB returns rc=1 with a JSON error payload (#3394)."""
         nonexistent = tmp_path / "no-such-file.db"
         with mock.patch("loom_tools.agent_metrics.find_repo_root", return_value=mock_repo):
             with mock.patch(
                 "loom_tools.agent_metrics._get_activity_db_path", return_value=nonexistent
             ):
-                with mock.patch("loom_tools.agent_metrics.gh_run") as mock_gh:
-                    mock_gh.return_value = mock.Mock(returncode=0, stdout="0")
-                    rc = main(["summary", "--format", "json"])
-        assert rc == 0
+                rc = main(["summary", "--format", "json"])
+        assert rc == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["error"] == "Activity database not available"
+        assert payload["db_path"] == str(nonexistent)
+
+    def test_errors_when_no_db_text(
+        self,
+        mock_repo: pathlib.Path,
+        tmp_path: pathlib.Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Missing activity DB returns rc=1 with a human-readable error (#3394)."""
+        nonexistent = tmp_path / "no-such-file.db"
+        with mock.patch("loom_tools.agent_metrics.find_repo_root", return_value=mock_repo):
+            with mock.patch(
+                "loom_tools.agent_metrics._get_activity_db_path", return_value=nonexistent
+            ):
+                rc = main(["summary"])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "not found" in out
+        assert str(nonexistent) in out
 
     def test_role_filter_cli(self, activity_db: pathlib.Path, mock_repo: pathlib.Path) -> None:
         with mock.patch("loom_tools.agent_metrics.find_repo_root", return_value=mock_repo):


### PR DESCRIPTION
Closes #3394
Refs epic #3372, tracker #3378

## Rationale

`loom-agent-metrics` previously preferred `~/.loom/activity.db` but fell back to `daemon-state.json` for `completed_issues` and `total_prs_merged` whenever the DB was missing. Per the Phase 3 migration plan (`docs/migration/daemon-state-consumers.md` Category 3 row), the fallback path is the only daemon-state read in this CLI and the activity DB already has the full event history needed for `summary`, `effectiveness`, `costs`, and `velocity` — the fallback exposed a partial, lifetime-only view that drifted from the DB.

This PR is the smallest of the nine Phase 3.1.x CLI ports: a pure removal that unblocks Phase 3.2 (deleting `daemon-state.json` entirely).

## Changes

- `loom-tools/src/loom_tools/agent_metrics.py`
  - Removed `FallbackSummary`, `FallbackVelocity` dataclasses.
  - Removed `get_summary_fallback()`, `get_velocity_fallback()` (the only callers of `read_daemon_state` + `gh_run` in this module).
  - Removed `format_summary_fallback_text`, `format_velocity_fallback_text`, and the now-dead `format_*_unavailable_text` helpers.
  - Added `format_db_unavailable_text(db_path)` and made `main()` exit `1` with a clear error when `activity.db` is missing (text or JSON, matching `--format`).
  - Collapsed `_cmd_*` helpers (no longer need to branch on `db_available`).
  - Dropped unused imports: `gh_run`, `log_warning`, `field`, `read_daemon_state`.
- `loom-tools/tests/test_agent_metrics.py` — per the migration plan's "trim, don't delete" instruction:
  - Removed `TestFallbackSummary`, `TestFallbackVelocity`, `test_summary_fallback_text`, `test_velocity_fallback_text`, `test_fallback_summary_json_valid`.
  - Replaced `test_fallback_when_no_db` with `test_errors_when_no_db_json` (expects rc=1 + structured error payload) and `test_errors_when_no_db_text` (expects rc=1 + human-readable message).
  - Added `TestMissingDatabase::test_format_db_unavailable_mentions_path`.

Diffstat: +93 / -310 (net -217). The estimate in the issue was +5/-60; the larger negative is because the now-dead per-command `_unavailable_text` formatters and their conditional branches also came out cleanly.

## Behaviour change (intentional, narrow)

| Scenario | Before | After |
|---|---|---|
| `activity.db` present | DB-derived metrics, rc=0 | **DB-derived metrics, rc=0 (unchanged)** |
| `activity.db` missing, `--format text` | "(daemon state)" partial summary, rc=0 | "Error: activity database not found at ..." rc=1 |
| `activity.db` missing, `--format json` | Daemon-state JSON object, rc=0 | `{"error": "Activity database not available", "db_path": "..."}` rc=1 |

For users whose `activity.db` exists (the default for any operator who has run `loom-daemon` or the spawn loop), output is identical to before.

## Sample output (after)

```text
$ LOOM_ACTIVITY_DB=/tmp/no-such-file.db loom-agent-metrics --role builder --period week
Error: activity database not found at /tmp/no-such-file.db. Set LOOM_ACTIVITY_DB or enable agent activity tracking.
$ echo $?
1

$ LOOM_ACTIVITY_DB=/tmp/no-such-file.db loom-agent-metrics --format json
{
  "error": "Activity database not available",
  "db_path": "/tmp/no-such-file.db"
}
$ echo $?
1
```

Before (on `main` with no DB), the same invocations exited 0 with a `FallbackSummary` payload like `{"completed_issues": 0, "total_prs_merged": 0, "open_issues": ..., "open_prs": ..., "note": "Limited data - activity database not available"}`.

## Tests

```bash
PYTHONPATH=loom-tools/src:$PYTHONPATH python3 -m pytest loom-tools/tests/ -v -k metric
# 69 passed, 4603 deselected in 3.26s
```

## Out of scope

- Touching other Phase 3.1.x CLIs (#3392, #3393 etc.) — siblings own those.
- Editing `defaults/scripts/spawn-loop.sh` — sibling PRs touch it.
- Deleting `daemon-state.json` itself — that's Phase 3.2.
- Updating `docs/migration/daemon-state-consumers.md` (its row still accurately describes the plan; status updates are part of the Phase 3 docs sweep PR 3.6).