### PR TITLE
fix(worktree): serialize concurrent invocations + cleanup partial state (#3380)

### DIFF
--- a/defaults/scripts/tests/test-worktree-concurrency.sh
+++ b/defaults/scripts/tests/test-worktree-concurrency.sh
@@ -18,7 +18,6 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-REPO_ROOT="$(cd "$SCRIPTS_DIR/../.." && pwd)"
 
 WORKTREE_SH="$SCRIPTS_DIR/worktree.sh"
 

--- a/defaults/scripts/tests/test-worktree-concurrency.sh
+++ b/defaults/scripts/tests/test-worktree-concurrency.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# test-worktree-concurrency.sh — Tests for worktree.sh concurrency lock + partial-state cleanup (#3380)
+#
+# Verifies the fix for "worktree.sh chronic hangs on concurrent invocations":
+#   - Parallel invocations against different issues serialize cleanly and finish quickly.
+#   - Parallel invocations against the same issue produce no partial state.
+#   - Stale `.git/worktrees/issue-N/index.lock` files are recovered automatically.
+#   - Half-created `.loom/worktrees/issue-N/` dirs (not registered with git) are removed
+#     and recreated, instead of erroring out with the "Directory exists but is not a
+#     registered worktree" path.
+#   - A stale lock dir from a dead PID is recovered (not stranded).
+#   - On lock-acquisition timeout, --json emits the documented error schema.
+#
+# Pattern follows test-worktree-sentinel.sh: throw-away bare origin + clone in a
+# mktemp dir, copy worktree.sh + lib/, exercise behaviors.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPTS_DIR/../.." && pwd)"
+
+WORKTREE_SH="$SCRIPTS_DIR/worktree.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Counter file persists across subshells (each test runs in `(...)`).
+COUNTER_FILE=$(mktemp /tmp/loom-wt-concur-counts.XXXXXX)
+echo "0 0 0" > "$COUNTER_FILE"
+trap 'rm -f "$COUNTER_FILE"' EXIT
+
+bump() {
+    local kind="$1"
+    local run pass fail
+    read -r run pass fail < "$COUNTER_FILE"
+    run=$((run + 1))
+    if [[ "$kind" == "pass" ]]; then pass=$((pass + 1)); else fail=$((fail + 1)); fi
+    echo "$run $pass $fail" > "$COUNTER_FILE"
+}
+
+pass() { bump pass; echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { bump fail; echo -e "  ${RED}FAIL${NC}: $1"; }
+
+# Setup a throw-away repo for one test. Echoes the path of the repo working tree.
+setup_repo() {
+    local tmp
+    tmp=$(mktemp -d /tmp/loom-worktree-concur.XXXXXX)
+    git init -q -b main "$tmp/origin.git" --bare
+    git init -q -b main "$tmp/repo"
+    (
+        cd "$tmp/repo"
+        git config user.email t@t
+        git config user.name t
+        git commit --allow-empty -q -m init
+        git remote add origin "$tmp/origin.git"
+        git push -q origin main
+        # Mirror the .loom layout worktree.sh expects to find.
+        mkdir -p .loom/scripts/lib .loom/hooks
+        cp "$WORKTREE_SH" .loom/scripts/worktree.sh
+        if [[ -d "$SCRIPTS_DIR/lib" ]]; then
+            cp -R "$SCRIPTS_DIR"/lib/* .loom/scripts/lib/ 2>/dev/null || true
+        fi
+        chmod +x .loom/scripts/worktree.sh
+    )
+    echo "$tmp/repo"
+}
+
+cleanup_repo() {
+    local repo="$1"
+    [[ -z "$repo" ]] && return 0
+    # The parent of the repo is the mktemp dir; remove the whole thing.
+    rm -rf "$(dirname "$repo")"
+}
+
+# --- Test 1: three concurrent invocations on different issues complete fast ---
+echo "Test 1: three concurrent invocations (different issues) complete within 60s"
+REPO=$(setup_repo)
+(
+    cd "$REPO"
+    # Launch three invocations in parallel; the outer `timeout 60` enforces the
+    # acceptance criterion. We swallow stdout but preserve exit codes via wait.
+    set +e
+    timeout 60 bash -c '
+        ./.loom/scripts/worktree.sh 90 >/tmp/wt-90.$$ 2>&1 &
+        p90=$!
+        ./.loom/scripts/worktree.sh 91 >/tmp/wt-91.$$ 2>&1 &
+        p91=$!
+        ./.loom/scripts/worktree.sh 92 >/tmp/wt-92.$$ 2>&1 &
+        p92=$!
+        wait $p90; r90=$?
+        wait $p91; r91=$?
+        wait $p92; r92=$?
+        if [[ $r90 -ne 0 || $r91 -ne 0 || $r92 -ne 0 ]]; then
+            echo "--- worktree.sh 90 output (rc=$r90) ---" >&2
+            cat /tmp/wt-90.$$ >&2 2>/dev/null || true
+            echo "--- worktree.sh 91 output (rc=$r91) ---" >&2
+            cat /tmp/wt-91.$$ >&2 2>/dev/null || true
+            echo "--- worktree.sh 92 output (rc=$r92) ---" >&2
+            cat /tmp/wt-92.$$ >&2 2>/dev/null || true
+        fi
+        rm -f /tmp/wt-9[0-2].$$
+        [[ $r90 -eq 0 && $r91 -eq 0 && $r92 -eq 0 ]]
+    '
+    rc=$?
+    set -e
+    if [[ $rc -eq 0 ]]; then
+        if [[ -f .loom/worktrees/issue-90/.loom-managed \
+           && -f .loom/worktrees/issue-91/.loom-managed \
+           && -f .loom/worktrees/issue-92/.loom-managed ]]; then
+            pass "three concurrent invocations (issues 90/91/92) all succeed within 60s"
+        else
+            fail "all three exited 0 but at least one .loom-managed sentinel is missing"
+        fi
+    else
+        fail "concurrent invocation timed out or one of three children failed (rc=$rc)"
+    fi
+)
+cleanup_repo "$REPO"
+
+# --- Test 2: stale .git/worktrees/issue-N/index.lock is recovered ---
+echo ""
+echo "Test 2: stale index.lock under .git/worktrees/issue-N/ is recovered"
+REPO=$(setup_repo)
+(
+    cd "$REPO"
+    mkdir -p .git/worktrees/issue-93
+    : > .git/worktrees/issue-93/index.lock
+    if ./.loom/scripts/worktree.sh 93 >/tmp/wt-93.$$ 2>&1; then
+        if [[ ! -e .git/worktrees/issue-93/index.lock ]]; then
+            pass "stale index.lock is removed and worktree created normally"
+        else
+            fail "worktree.sh exited 0 but stale index.lock still present"
+        fi
+    else
+        fail "worktree.sh failed in the presence of a stale index.lock (see /tmp/wt-93.$$)"
+    fi
+    rm -f /tmp/wt-93.$$
+)
+cleanup_repo "$REPO"
+
+# --- Test 3: half-created .loom/worktrees/issue-N/ (unregistered) is recovered ---
+echo ""
+echo "Test 3: half-created .loom/worktrees/issue-N/ dir is recovered"
+REPO=$(setup_repo)
+(
+    cd "$REPO"
+    mkdir -p .loom/worktrees/issue-94
+    # Deliberately make this dir NOT registered with git — it's a shell.
+    : > .loom/worktrees/issue-94/leftover-file
+    if ./.loom/scripts/worktree.sh 94 >/tmp/wt-94.$$ 2>&1; then
+        if [[ -f .loom/worktrees/issue-94/.loom-managed ]]; then
+            pass "half-created dir is removed and worktree recreated with sentinel"
+        else
+            fail "worktree.sh exited 0 but .loom-managed sentinel missing — likely fell into idempotent branch"
+        fi
+    else
+        fail "worktree.sh failed to recover from half-created dir (see /tmp/wt-94.$$)"
+    fi
+    rm -f /tmp/wt-94.$$
+)
+cleanup_repo "$REPO"
+
+# --- Test 4: stale lock dir owned by a dead PID is recovered ---
+echo ""
+echo "Test 4: stale .loom/locks/worktree-N/ owned by dead PID is recovered"
+REPO=$(setup_repo)
+(
+    cd "$REPO"
+    # Find a guaranteed-dead PID by spawning + reaping a short-lived child.
+    bash -c 'exit 0' &
+    DEAD_PID=$!
+    wait $DEAD_PID 2>/dev/null || true
+    # Tiny safety: keep retrying until a non-existent PID is found.
+    while kill -0 "$DEAD_PID" 2>/dev/null; do
+        bash -c 'exit 0' &
+        DEAD_PID=$!
+        wait $DEAD_PID 2>/dev/null || true
+    done
+
+    # Lock is repo-global at .loom/locks/worktree-add/ — stage it there.
+    mkdir -p .loom/locks/worktree-add
+    cat > .loom/locks/worktree-add/owner.json <<EOF
+{
+  "issue": 95,
+  "owner_pid": $DEAD_PID,
+  "script": "worktree.sh",
+  "acquired_at": "1970-01-01T00:00:00Z"
+}
+EOF
+
+    if ./.loom/scripts/worktree.sh 95 >/tmp/wt-95.$$ 2>&1; then
+        if [[ -f .loom/worktrees/issue-95/.loom-managed ]]; then
+            pass "stale lock from dead PID $DEAD_PID is broken; worktree created"
+        else
+            fail "worktree.sh exited 0 but .loom-managed sentinel missing"
+        fi
+    else
+        fail "worktree.sh failed to recover from stale lock (see /tmp/wt-95.$$)"
+    fi
+    rm -f /tmp/wt-95.$$
+)
+cleanup_repo "$REPO"
+
+# --- Test 5: concurrent invocations on the SAME issue serialize cleanly ---
+echo ""
+echo "Test 5: two concurrent invocations on the same issue serialize cleanly"
+REPO=$(setup_repo)
+(
+    cd "$REPO"
+    set +e
+    timeout 60 bash -c '
+        ./.loom/scripts/worktree.sh 96 >/tmp/wt-96a.$$ 2>&1 &
+        a=$!
+        ./.loom/scripts/worktree.sh 96 >/tmp/wt-96b.$$ 2>&1 &
+        b=$!
+        wait $a; ra=$?
+        wait $b; rb=$?
+        rm -f /tmp/wt-96a.$$ /tmp/wt-96b.$$
+        [[ $ra -eq 0 && $rb -eq 0 ]]
+    '
+    rc=$?
+    set -e
+    if [[ $rc -eq 0 ]]; then
+        if [[ -f .loom/worktrees/issue-96/.loom-managed ]]; then
+            # Lock dir should be empty at the end of both runs (lock is
+            # repo-global at .loom/locks/worktree-add/, see worktree.sh).
+            if [[ ! -d .loom/locks/worktree-add ]]; then
+                pass "same-issue concurrent invocations both exit 0; lock dir cleaned up"
+            else
+                fail "both exited 0 but lock dir still present: .loom/locks/worktree-add"
+            fi
+        else
+            fail "both exited 0 but .loom-managed sentinel missing"
+        fi
+    else
+        fail "concurrent same-issue invocations did not both succeed (rc=$rc)"
+    fi
+)
+cleanup_repo "$REPO"
+
+# --- Test 6: lock-timeout failure emits documented --json error schema ---
+echo ""
+echo "Test 6: lock-timeout --json error includes 'worktree-lock-timeout' and holderPid"
+REPO=$(setup_repo)
+(
+    cd "$REPO"
+    # Stage a lock owned by a definitely-live PID (this shell) so it can't be
+    # cleared as stale. Force the timeout to 1s so we don't actually wait.
+    # Lock is repo-global; stage it at the global path.
+    mkdir -p .loom/locks/worktree-add
+    cat > .loom/locks/worktree-add/owner.json <<EOF
+{
+  "issue": 97,
+  "owner_pid": $$,
+  "script": "worktree.sh",
+  "acquired_at": "1970-01-01T00:00:00Z"
+}
+EOF
+    set +e
+    OUT=$(LOOM_WORKTREE_LOCK_TIMEOUT=1 LOOM_WORKTREE_LOCK_POLL_INTERVAL=1 \
+        ./.loom/scripts/worktree.sh --json 97 2>&1)
+    rc=$?
+    set -e
+    if [[ $rc -ne 0 ]] && echo "$OUT" | grep -q 'worktree-lock-timeout' && echo "$OUT" | grep -q "\"holderPid\": \"$$\""; then
+        pass "lock-timeout error JSON includes 'worktree-lock-timeout' and holder PID $$"
+    else
+        fail "lock-timeout JSON output missing expected fields (rc=$rc, output: $OUT)"
+    fi
+    # Cleanup the synthetic lock we created.
+    rm -rf .loom/locks/worktree-add
+)
+cleanup_repo "$REPO"
+
+# --- Summary ---
+read -r TESTS_RUN TESTS_PASSED TESTS_FAILED < "$COUNTER_FILE"
+echo ""
+echo "Tests run: $TESTS_RUN, Passed: $TESTS_PASSED, Failed: $TESTS_FAILED"
+[[ $TESTS_FAILED -eq 0 ]] || exit 1

--- a/defaults/scripts/worktree.sh
+++ b/defaults/scripts/worktree.sh
@@ -436,7 +436,7 @@ Safety Features:
   ✓ Symlinks .mcp.json from main (MCP config visible in worktrees)
   ✓ Runs project-specific hooks after creation
   ✓ Stashes/restores local changes during pull
-  ✓ Per-issue lock serializes concurrent invocations (issue #3380)
+  ✓ Repo-global lock serializes concurrent invocations (issue #3380)
   ✓ Recovers from stale .git/worktrees/issue-N/index.lock files
   ✓ Recovers from half-created .loom/worktrees/issue-N/ dirs
 

--- a/defaults/scripts/worktree.sh
+++ b/defaults/scripts/worktree.sh
@@ -52,6 +52,202 @@ print_warning() {
 }
 
 # --------------------------------------------------------------------------
+# Concurrency lock (issue #3380)
+# --------------------------------------------------------------------------
+#
+# `git worktree add` is not safe to run concurrently against the same repo —
+# parallel invocations contend on the per-worktree administrative dir
+# (`.git/worktrees/issue-N/`) and on git's repo-global locks. The observed
+# failure mode in busy shepherd sessions is multi-minute hangs (10-20 min)
+# while a peer process holds an `index.lock` it will never release.
+#
+# We use the same POSIX-atomic `mkdir`-based primitive as spawn-loop.sh
+# (`.loom/scripts/spawn-loop.sh:236-260`) — `flock` is not available on stock
+# macOS, so `mkdir` is the only portable atomic file-system operation we can
+# rely on.
+#
+# Lock scope is **repo-global** (`.loom/locks/worktree-add/`). The original
+# per-issue design was tried first but failed under concurrent invocations
+# with different issue numbers: `git worktree add` mutates the repo-global
+# `.git/config.lock` (writing the new branch's upstream configuration), and
+# concurrent processes race with the diagnostic:
+#
+#   error: could not lock config file .git/config: File exists
+#   error: unable to write upstream branch configuration
+#
+# A repo-global lock serializes the entire `git worktree add` call so this
+# race cannot happen. The cost — two builders on different issues no longer
+# parallelize through the helper — is acceptable because (a) `git worktree
+# add` itself is short relative to the rest of an issue's lifecycle, and
+# (b) parallel hangs that hold an `index.lock` for 10-20 minutes are the
+# very problem this PR fixes.
+#
+# The lock path uses the same name (`worktree-<id>/`) the per-issue version
+# used so its layout matches `.loom/locks/issue-<N>/` (spawn-loop). The "id"
+# here is the constant string "add"; per-issue accounting still lives in the
+# `owner.json` body for debugging visibility.
+#
+# Tunables (env vars, documented in show_help):
+#   LOOM_WORKTREE_LOCK_TIMEOUT       — seconds to wait (default 600 = 10min,
+#                                      sized to cover worst-case cold-clone
+#                                      submodule init on heavy repos)
+#   LOOM_WORKTREE_LOCK_POLL_INTERVAL — seconds between poll attempts (default 2)
+
+LOOM_WORKTREE_LOCK_TIMEOUT="${LOOM_WORKTREE_LOCK_TIMEOUT:-600}"
+LOOM_WORKTREE_LOCK_POLL_INTERVAL="${LOOM_WORKTREE_LOCK_POLL_INTERVAL:-2}"
+
+# Resolve the locks directory to the canonical git common dir so worktrees
+# and the main workspace all share the same lock namespace. Falls back to the
+# current dir for the rare case where we're not yet inside a repo (tests).
+_worktree_locks_dir() {
+    local common
+    common=$(git rev-parse --git-common-dir 2>/dev/null || true)
+    if [[ -n "$common" ]]; then
+        # git-common-dir may be returned as a relative path; resolve it.
+        local abs_common
+        abs_common=$(cd "$common" 2>/dev/null && pwd) || abs_common="$common"
+        echo "$(dirname "$abs_common")/.loom/locks"
+    else
+        echo ".loom/locks"
+    fi
+}
+
+_worktree_lock_path() {
+    # The argument is the issue number — accepted for owner-metadata logging
+    # only. The lock itself is repo-global; see the design note above.
+    echo "$(_worktree_locks_dir)/worktree-add"
+}
+
+# Returns 0 if lock acquired, non-zero otherwise. Sets WORKTREE_LOCK_HOLDER_PID
+# on timeout failure so the caller can include it in error output.
+WORKTREE_LOCK_HOLDER_PID=""
+
+acquire_worktree_lock() {
+    local issue="$1"
+    local lock
+    lock="$(_worktree_lock_path "$issue")"
+    local locks_dir
+    locks_dir="$(_worktree_locks_dir)"
+
+    mkdir -p "$locks_dir" 2>/dev/null || true
+
+    local deadline=$(( $(date +%s) + LOOM_WORKTREE_LOCK_TIMEOUT ))
+    local stale_retry_done=0
+
+    while true; do
+        if mkdir "$lock" 2>/dev/null; then
+            # Lock acquired; record owner metadata for debugging.
+            cat > "$lock/owner.json" <<EOF
+{
+  "issue": $issue,
+  "owner_pid": $$,
+  "script": "worktree.sh",
+  "acquired_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+            return 0
+        fi
+
+        # Lock exists. Check whether the owner is still alive; if not, clear
+        # it once and retry (mirrors spawn-loop's stale-lock recovery).
+        local owner_pid=""
+        if [[ -f "$lock/owner.json" ]]; then
+            owner_pid=$(awk -F'[ ,]+' '/owner_pid/ {gsub(/[^0-9]/,"",$3); print $3; exit}' "$lock/owner.json" 2>/dev/null)
+        fi
+
+        if [[ -n "$owner_pid" ]] && [[ "$stale_retry_done" -eq 0 ]] && ! kill -0 "$owner_pid" 2>/dev/null; then
+            if [[ "$JSON_OUTPUT" != "true" ]]; then
+                print_warning "Stale worktree lock from dead PID $owner_pid — cleaning up"
+            fi
+            rm -rf "$lock" 2>/dev/null || true
+            stale_retry_done=1
+            continue
+        fi
+
+        if [[ $(date +%s) -ge $deadline ]]; then
+            WORKTREE_LOCK_HOLDER_PID="$owner_pid"
+            return 1
+        fi
+
+        sleep "$LOOM_WORKTREE_LOCK_POLL_INTERVAL"
+    done
+}
+
+release_worktree_lock() {
+    local issue="$1"
+    [[ -z "$issue" ]] && return 0
+    local lock
+    lock="$(_worktree_lock_path "$issue")"
+    [[ -d "$lock" ]] || return 0
+    rm -rf "$lock" 2>/dev/null || true
+}
+
+# cleanup_partial_worktree_state <issue>
+#
+# Removes the residue of a crashed `git worktree add`:
+#   - `.git/worktrees/issue-<N>/{index,HEAD,gitdir}.lock` — file-level locks
+#     that git would normally hold for the duration of an add operation and
+#     release on success/failure. A SIGKILL'd or stuck process leaves them
+#     behind, where they block every subsequent operation against the same
+#     administrative dir.
+#   - `.loom/worktrees/issue-<N>/` — a half-created worktree dir that was
+#     never registered with git (verified via `git worktree list --porcelain`).
+#
+# **Sentinel contract** (#3334): a dir that IS registered with git is NEVER
+# removed by this helper, regardless of `.loom-managed` presence. The sentinel
+# governs cleanup-on-merge; this helper governs cleanup-on-crash-recovery, and
+# the dividing line is "registered with git or not". An unregistered dir is by
+# definition a shell from a killed add — the sentinel is written *after* a
+# successful add (worktree.sh:761), so a half-created dir never has one.
+cleanup_partial_worktree_state() {
+    local issue="$1"
+    local git_common
+    git_common=$(git rev-parse --git-common-dir 2>/dev/null) || return 0
+
+    local admin_dir="$git_common/worktrees/issue-$issue"
+    local cleaned=0
+
+    # 1. Per-worktree file locks.
+    local lf
+    for lf in index.lock HEAD.lock gitdir.lock; do
+        if [[ -f "$admin_dir/$lf" ]]; then
+            rm -f "$admin_dir/$lf" 2>/dev/null && cleaned=1
+            if [[ "$JSON_OUTPUT" != "true" ]]; then
+                print_warning "Cleaned stale $lf at $admin_dir/$lf"
+            fi
+        fi
+    done
+
+    # 2. Orphan worktree dir (exists but git doesn't know about it).
+    local wt_path=".loom/worktrees/issue-$issue"
+    if [[ -d "$wt_path" ]]; then
+        # `git worktree list --porcelain` emits absolute paths on the
+        # `worktree ` line; compare against the resolved absolute path.
+        local abs_wt
+        abs_wt=$(cd "$wt_path" 2>/dev/null && pwd) || abs_wt=""
+        local registered=0
+        if [[ -n "$abs_wt" ]]; then
+            if git worktree list --porcelain 2>/dev/null \
+                | awk '/^worktree / {print $2}' \
+                | grep -Fxq "$abs_wt"; then
+                registered=1
+            fi
+        fi
+        if [[ $registered -eq 0 ]]; then
+            if [[ "$JSON_OUTPUT" != "true" ]]; then
+                print_warning "Removing orphan worktree dir (not registered with git): $wt_path"
+            fi
+            rm -rf "$wt_path" 2>/dev/null && cleaned=1
+        fi
+    fi
+
+    # 3. Prune now that the orphan administrative dir is locally consistent.
+    if [[ $cleaned -eq 1 ]]; then
+        git worktree prune 2>/dev/null || true
+    fi
+}
+
+# --------------------------------------------------------------------------
 # Sparse-checkout helpers
 # --------------------------------------------------------------------------
 #
@@ -240,6 +436,18 @@ Safety Features:
   ✓ Symlinks .mcp.json from main (MCP config visible in worktrees)
   ✓ Runs project-specific hooks after creation
   ✓ Stashes/restores local changes during pull
+  ✓ Per-issue lock serializes concurrent invocations (issue #3380)
+  ✓ Recovers from stale .git/worktrees/issue-N/index.lock files
+  ✓ Recovers from half-created .loom/worktrees/issue-N/ dirs
+
+Environment Variables:
+  LOOM_WORKTREE_ALWAYS_INCLUDE      Extra sparse-mode safety paths (space-sep)
+  LOOM_SUBMODULE_TIMEOUT            Per-submodule init timeout (default 300s)
+  LOOM_WORKTREE_LOCK_TIMEOUT        Lock acquisition timeout in seconds
+                                    (default 600 — sized to cover worst-case
+                                    cold-clone submodule init)
+  LOOM_WORKTREE_LOCK_POLL_INTERVAL  Lock poll interval in seconds (default 2)
+  LOOM_PRESERVE_WORKTREE            Disable cleanup-on-merge for all worktrees
 
 Project-Specific Hooks:
   Create .loom/hooks/post-worktree.sh to run custom setup after worktree creation.
@@ -435,6 +643,39 @@ if check_if_in_worktree; then
         echo ""
     fi
 fi
+
+# ─── Concurrency lock (issue #3380) ─────────────────────────────────────────
+# Serialize concurrent invocations against the same issue. The lock dir
+# lives under the canonical git common dir so worktrees and the main
+# workspace agree on the lock namespace.
+#
+# Pre-cleanup runs *before* the lock so a crashed prior run's debris (which
+# would otherwise prevent us from making progress under the lock) is cleared
+# regardless of whether we ultimately acquire the lock.
+cleanup_partial_worktree_state "$ISSUE_NUMBER" || true
+
+if ! acquire_worktree_lock "$ISSUE_NUMBER"; then
+    if [[ "$JSON_OUTPUT" == "true" ]]; then
+        echo '{"success": false, "error": "worktree-lock-timeout", "issueNumber": '"$ISSUE_NUMBER"', "holderPid": "'"${WORKTREE_LOCK_HOLDER_PID:-}"'", "timeoutSeconds": '"$LOOM_WORKTREE_LOCK_TIMEOUT"'}'
+    else
+        print_error "Timed out waiting for worktree lock after ${LOOM_WORKTREE_LOCK_TIMEOUT}s"
+        if [[ -n "${WORKTREE_LOCK_HOLDER_PID:-}" ]]; then
+            echo "  Lock holder PID: $WORKTREE_LOCK_HOLDER_PID"
+        fi
+        echo "  Lock dir: $(_worktree_lock_path "$ISSUE_NUMBER")"
+        echo ""
+        echo "  If the holder is dead, remove the lock dir manually:"
+        echo "    rm -rf '$(_worktree_lock_path "$ISSUE_NUMBER")'"
+    fi
+    exit 1
+fi
+
+# Release the lock on any exit path (success, failure, signal).
+trap 'release_worktree_lock "$ISSUE_NUMBER"' EXIT INT TERM
+
+# Re-run cleanup under the lock so a crashed concurrent peer (one that died
+# between our pre-cleanup and our lock acquisition) is still handled.
+cleanup_partial_worktree_state "$ISSUE_NUMBER" || true
 
 # Prune orphaned worktree references before any worktree operations
 # This cleans up stale references when worktree directories were deleted externally (e.g., rm -rf)


### PR DESCRIPTION
## Summary

Adds a repo-global mkdir-based lock around the body of `worktree.sh` (from `git worktree prune` onward) plus a `cleanup_partial_worktree_state` helper that recovers from crashed prior runs. Combined, these eliminate the chronic 10-20 minute hangs reported in #3380.

- **Lock**: `.loom/locks/worktree-add/` — repo-global, mkdir-atomic (POSIX/macOS-portable; no `flock`). Owner metadata in `owner.json` for debugging.
- **Cleanup helper**: removes stale `.git/worktrees/issue-N/{index,HEAD,gitdir}.lock` files and orphan `.loom/worktrees/issue-N/` dirs that aren't registered with `git worktree list --porcelain`.
- **Sentinel contract preserved**: a dir registered with git is never removed by cleanup, regardless of `.loom-managed` presence. Existing `test-worktree-sentinel.sh` continues to pass.

### Why repo-global instead of per-issue

Per-issue locks were tried first but proved insufficient: concurrent `git worktree add` invocations against distinct issue numbers race on the repo-global `.git/config.lock` ("error: could not lock config file .git/config: File exists"). A repo-global lock serializes the entire `git worktree add` call so this cannot happen. The design note in the source documents this rationale.

### Config knobs (documented in `worktree.sh --help`)

- `LOOM_WORKTREE_LOCK_TIMEOUT` — default 600s (sized for cold-clone submodule init on heavy repos)
- `LOOM_WORKTREE_LOCK_POLL_INTERVAL` — default 2s
- `LOOM_PRESERVE_WORKTREE` — unchanged (governs cleanup-on-merge only; not honored at creation by design)

### Out of scope (deferred by curator)

- Proposal 1: generic `git worktree add` timeout wrapper.
- Proposal 2: `--no-submodules` flag.

If hangs persist under the lock these become worth doing; for now the minimal lock+cleanup pair is the smallest change that demonstrably fixes the chronic-hang loop.

## Test plan

- [x] `bash .loom/scripts/tests/test-worktree-concurrency.sh` (new, 6 cases): three concurrent invocations on different issues finish <60s; stale `index.lock` recovered; orphan worktree dir recovered; stale lock from dead PID broken; same-issue concurrency serializes cleanly; `--json` lock-timeout error schema validated.
- [x] `bash .loom/scripts/tests/test-worktree-sentinel.sh` (regression): 10/10 PASS.
- [x] `bash .loom/scripts/tests/test-pr-worktree-isolation.sh` (caller regression): 22/22 PASS.
- [x] `bash .loom/scripts/tests/test-merge-pr-worktree-path.sh` + `test-merge-pr-help.sh` (caller regression): 21/21 + 15/15 PASS.
- [x] `bash -n` syntax check on `worktree.sh`, `pr-worktree.sh`, `merge-pr.sh`, new test.

Closes #3380

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>