### PR TITLE
fix(installer): rm -rf worktree dir after git worktree remove in cleanup paths

### DIFF
--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -237,6 +237,8 @@ cleanup_on_error() {
       info "Cleaning up worktree: ${WORKTREE_PATH}..."
       cd "$TARGET_PATH" 2>/dev/null || true
       git worktree remove "${WORKTREE_PATH}" --force 2>/dev/null || true
+      git worktree prune 2>/dev/null || true
+      rm -rf "${TARGET_PATH}/${WORKTREE_PATH}"
       if [[ -n "${BRANCH_NAME:-}" ]]; then
         git branch -D "${BRANCH_NAME}" 2>/dev/null || true
 
@@ -1439,6 +1441,8 @@ if [[ "$PR_URL_RAW" == *"NO_CHANGES_NEEDED"* ]]; then
   # Remove the worktree
   cd "$TARGET_PATH"
   git worktree remove "${WORKTREE_PATH}" --force 2>/dev/null || true
+  git worktree prune 2>/dev/null || true
+  rm -rf "${TARGET_PATH}/${WORKTREE_PATH}"
   git branch -D "${BRANCH_NAME}" 2>/dev/null || true
 
   # Restore any staged changes left by --clean uninstall


### PR DESCRIPTION
## Summary

`cleanup_on_error()` and the NO-CHANGES-NEEDED path in `scripts/install-loom.sh` both called `git worktree remove --force` but omitted a follow-up `rm -rf`, leaving orphaned `.loom/worktrees/loom-install-v<VERSION>/` directories on disk when the worktree directory was non-empty (e.g. a partial/failed checkout).

Changes:
- In `cleanup_on_error()` (~line 239): add `git worktree prune` and `rm -rf "${TARGET_PATH}/${WORKTREE_PATH}"` after the `git worktree remove` call.
- In the NO-CHANGES-NEEDED path (~line 1443): same two lines added after the existing `git worktree remove` call.

`WORKTREE_PATH` is validated at line ~861 with a `^\.loom/worktrees/` guard, so `rm -rf` is safe.

## Test plan

- [ ] Simulate a failed install at a post-worktree-creation step; verify `ls .loom/worktrees/` shows no `loom-install-*` entries afterward.
- [ ] Run `git worktree list` after a failed install; verify no orphan entries remain.
- [ ] Run a clean install (no changes needed); verify the worktree directory is fully removed.

Closes #3425

🤖 Generated with [Claude Code](https://claude.com/claude-code)