### PR TITLE
build: add rust-toolchain.toml pinning Rust 1.96.0 (fixes cfg_select! breakage)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,9 @@ Run `pnpm check:ci` before pushing. This runs the full CI suite locally (linting
 
 If you want to explore the codebase or run Loom locally:
 
-**Prerequisites**: Node.js 20+, pnpm, Rust (stable), tmux, Git, GitHub CLI (`gh`)
+**Prerequisites**: Node.js 20+, pnpm, Rust 1.96.0 or newer (see `rust-toolchain.toml`), tmux, Git, GitHub CLI (`gh`)
+
+> **Minimum Supported Rust Version (MSRV)**: Rust 1.96.0. The `loom-daemon` crate depends on `rusqlite` → `libsqlite3-sys`, which uses `cfg_select!` (stabilised in Rust 1.96). Building with an older stable toolchain will fail. Run `rustup update stable` or `rustup install 1.96.0` if needed. The `rust-toolchain.toml` at the repo root pins the toolchain automatically when you use `rustup`.
 
 ```bash
 git clone https://github.com/rjwalters/loom.git

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.96.0"


### PR DESCRIPTION
## Summary

Operators on Rust stable < 1.96 hit a hard build failure during `loom-daemon init` because `libsqlite3-sys 0.38.0` uses `cfg_select!`, which was unstable before Rust 1.96. This PR adds a `rust-toolchain.toml` at the repo root pinning to `1.96.0`, so `rustup` auto-installs a compatible toolchain on first use and the install blocker is gone.

## Changes

- Add `rust-toolchain.toml` at the repo root with `channel = "1.96.0"` (Option 1 from the issue)
- Update `CONTRIBUTING.md` prerequisites line and add an MSRV callout block documenting Rust 1.96.0 as the minimum and explaining why (`cfg_select!` stabilisation)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `rust-toolchain.toml` lives at the repo root and is committed | Done | File created at repo root on `feature/issue-3424` |
| CONTRIBUTING.md / README documents the MSRV | Done | Prerequisites line updated + MSRV note block added to Development Setup section |
| CI matches chosen MSRV (`dtolnay/rust-toolchain` respects `rust-toolchain.toml`) | Done | No CI changes needed — `dtolnay/rust-toolchain@stable` already reads `rust-toolchain.toml` automatically |

## Test Plan

- `rust-toolchain.toml` is present at repo root with correct content
- CONTRIBUTING.md Development Setup section now states "Rust 1.96.0 or newer" and includes MSRV rationale
- No other files changed (scope-checked via `git diff --stat`)

Closes #3424