### PR TITLE
fix(installer): reject unknown flags in install-loom.sh (--quick silently ignored)

### DIFF
--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -118,6 +118,12 @@ while [[ $# -gt 0 ]]; do
       exit 0
       ;;
     *)
+      if [[ "$1" == -* ]]; then
+        echo "Error: unknown flag: $1" >&2
+        echo "       (--quick and --full belong to ./install.sh, not scripts/install-loom.sh)" >&2
+        echo "Use --help for usage." >&2
+        exit 1
+      fi
       TARGET_PATH="$1"
       shift
       ;;


### PR DESCRIPTION
## Summary

- Adds a flag-detection guard in the `*)` catch-all of `scripts/install-loom.sh`'s argument-parsing loop
- Any argument starting with `-` now produces a clear error instead of being silently consumed as `TARGET_PATH`
- Error message explicitly names `--quick`/`--full` as `install.sh`-only flags to make the footgun obvious

## Changes

`scripts/install-loom.sh` lines ~120-125: the `*)` catch-all now checks `if [[ "$1" == -* ]]` before assigning `TARGET_PATH`, emits an actionable error to stderr, and exits 1.

## Test plan

- [ ] `./scripts/install-loom.sh --quick /some/path` now prints `Error: unknown flag: --quick` and exits non-zero instead of treating `--quick` as the target path
- [ ] `./scripts/install-loom.sh --full /some/path` similarly errors out
- [ ] `./scripts/install-loom.sh /some/path` (no flags) still works correctly
- [ ] `./scripts/install-loom.sh --help` still prints usage and exits 0

Closes #3423

🤖 Generated with [Claude Code](https://claude.com/claude-code)