### PR TITLE
feat(installer): sweep stale files from previous install on upgrade

### DIFF
--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -1094,6 +1094,51 @@ done < <(find \
   -print0 | sort -z)
 INSTALLED_FILES_JSON="${INSTALLED_FILES_JSON}]"
 
+# --- Stale-file sweep (upgrade path) ---
+# Compare the previous install's file list (from install-metadata.json) against
+# the new set. Files present in the old set but not the new set are orphans from
+# upstream renames/deletions and must be removed so they don't accumulate.
+# Only files the installer originally wrote are candidates — operator-added files
+# are never in PREV_INSTALLED_FILES, so they are safe by construction.
+STALE_FILES=()
+if [[ -f "$TARGET_PATH/.loom/install-metadata.json" ]] && command -v jq >/dev/null 2>&1; then
+  while IFS= read -r prev_file; do
+    [[ -n "$prev_file" ]] || continue
+    # Is this file still in the new installed set?
+    if ! echo "$INSTALLED_FILES_JSON" | grep -qF "\"${prev_file}\""; then
+      STALE_FILES+=("$prev_file")
+    fi
+  done < <(jq -r '.installed_files[]' "$TARGET_PATH/.loom/install-metadata.json")
+fi
+
+if (( ${#STALE_FILES[@]} > 0 )); then
+  echo ""
+  info "Stale files from previous Loom install (removed or renamed upstream):"
+  for f in "${STALE_FILES[@]}"; do
+    echo "    - $f"
+  done
+  echo ""
+  PROCEED_DELETE=true
+  if [[ "$NON_INTERACTIVE" != "true" ]] && [[ "$FORCE_OVERWRITE" != "true" ]]; then
+    read -r -p "Remove these ${#STALE_FILES[@]} stale file(s)? [y/N] " CONFIRM_DELETE
+    [[ "$CONFIRM_DELETE" =~ ^[Yy]$ ]] || PROCEED_DELETE=false
+  fi
+  if [[ "$PROCEED_DELETE" == "true" ]]; then
+    DELETED_COUNT=0
+    for f in "${STALE_FILES[@]}"; do
+      if git rm --quiet --force "$f" 2>/dev/null; then
+        (( DELETED_COUNT++ )) || true
+      else
+        warning "Could not remove stale file: $f (may have been removed already)"
+      fi
+    done
+    success "Removed $DELETED_COUNT stale file(s) from previous Loom version"
+  else
+    info "Skipping stale file removal (user declined)"
+  fi
+fi
+# --- End stale-file sweep ---
+
 cat > .loom/install-metadata.json <<METADATA
 {
   "loom_version": "${LOOM_VERSION}",


### PR DESCRIPTION
## Summary

The Loom installer copies files from `defaults/` to the target repo but never deletes files that were removed or renamed between releases. This causes orphaned files to accumulate in downstream installs (e.g., `daemon-cleanup.sh` remained after the v0.9.1 rename to `loom-cleanup.sh`). This PR adds a stale-file sweep that deletes the difference on upgrade.

## Changes

- In `scripts/install-loom.sh`, insert a stale-file sweep block between `INSTALLED_FILES_JSON` computation and writing the new `install-metadata.json`
- The sweep reads `installed_files` from the previous `$TARGET_PATH/.loom/install-metadata.json` (main checkout, not the worktree), diffs against the new file set, and `git rm`s each orphan so the removal lands in the install PR commit
- Interactive confirmation is shown in interactive mode; auto-proceeds when `NON_INTERACTIVE=true` or `FORCE_OVERWRITE=true`
- On fresh installs (no prior metadata file) or when `jq` is absent, the sweep is skipped entirely
- Operator-added files in `.loom/` are safe by construction — they are never listed in `installed_files`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Reads `installed_files` from previous `install-metadata.json` if present | Done | Block guarded by `[[ -f "$TARGET_PATH/.loom/install-metadata.json" ]]` |
| Computes set diff: previous minus current = stale | Done | `grep -qF "\"${prev_file}\""` against `$INSTALLED_FILES_JSON` |
| Deletes stale files via `git rm` (so deletion lands in PR commit) | Done | `git rm --quiet --force "$f"` inside sweep loop |
| Fresh install (no metadata file) produces no diff and no deletion | Done | Outer `if` guard skips entire sweep |
| Operator-added file in `.loom/` not deleted | Done | Only files from previous `installed_files` are candidates |
| Interactive confirmation unless `--yes`/`--force` | Done | `[[ "$NON_INTERACTIVE" != "true" ]] && [[ "$FORCE_OVERWRITE" != "true" ]]` check before prompt |
| Bash syntax valid | Done | `bash -n scripts/install-loom.sh` exits 0 |

## Test Plan

- Fresh install path: no `install-metadata.json` -> `STALE_FILES` stays empty -> no deletion, no prompt
- Upgrade with renamed file: previous metadata lists `scripts/daemon-cleanup.sh`, new install does not write it -> sweep detects it, prompts (interactive) or deletes (non-interactive/force)
- Operator-added file: file in `.loom/custom/` not in previous `installed_files` -> not a candidate, never deleted

Closes #3422