### PR TITLE
docs(phase-3.7): architecture narrative rewrites + add ADR 0009

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This repository uses **Loom** for AI-powered development orchestration.
 
 ## What is Loom?
 
-Loom is a CLI + daemon for AI-powered development orchestration. It coordinates AI development workers using git worktrees and a forge (GitHub or Gitea) as the coordination layer. It supports both manual coordination (Manual Orchestration Mode) and continuous autonomous orchestration (Daemon Mode).
+Loom is a CLI tool for AI-powered development orchestration. It coordinates AI development workers using git worktrees and a forge (GitHub or Gitea) as the coordination layer. It supports manual coordination (Manual Orchestration Mode) and continuous autonomous orchestration via the spawn loop + GitHub Actions cron schedules.
 
 **Loom Repository**: https://github.com/rjwalters/loom
 
@@ -87,9 +87,9 @@ Sweep also has a **PR-set mode (Mode C, #3384)** that drives Judge / Doctor → 
 
 Checkpoints (#3373) under `.loom/sweep-checkpoint/issue-<N>.json` survive crashes — restarting `/loom:sweep N` resumes from the last completed phase.
 
-### 3. Spawn-Loop Mode (Phase 1, opt-in)
+### 3. Spawn-Loop Mode (opt-in)
 
-A minimal alternative to the full daemon for multi-account `/loom:sweep` launching (#3374, Phase 1 of the shepherd/daemon deprecation epic #3372). Polls `loom:issue`, atomically claims ready issues, and detaches `claude -p "/loom:sweep N"` per issue — each spawn picks its own OAuth token via `spawn-claude.sh`. No work generation, no support-role triggers, no pool-slot bookkeeping.
+A minimal multi-account `/loom:sweep` launcher (#3374). Polls `loom:issue`, atomically claims ready issues, and detaches `claude -p "/loom:sweep N"` per issue — each spawn picks its own OAuth token via `spawn-claude.sh`. No work generation, no support-role triggers, no pool-slot bookkeeping.
 
 > **Note**: `/loom:sweep` also supports a **PR-set mode** (Mode C, #3384) via `--prs <pr-number-list>` or NL phrases like "all open `loom:pr`" — drives Judge / Doctor → Judge / Merge from an existing open-PR set without re-running Curator or Builder. The spawn loop is issue-keyed and does not invoke PR-set mode; operators use it directly via `claude -p "/loom:sweep --prs ..."`.
 
@@ -101,9 +101,9 @@ LOOM_USE_SPAWN_LOOP=1 ./.loom/scripts/spawn-loop.sh start  # opt-in gate is requ
 
 State lives in `.loom/spawn-loop-state.json`, logs in `.loom/logs/spawn-loop.log`, claim locks under `.loom/locks/issue-<N>/`. Crashed children whose checkpoints (#3373) survive are re-queued on the next tick. If `daemon-loop.pid` is alive, the loop warns and proceeds (both will compete for `loom:issue` items — pick one). Overrides: `MAX_PARALLEL=3`, `POLL_INTERVAL=30`, `SHUTDOWN_GRACE_SEC=300`.
 
-### 4. Scheduled Support Roles (Phase 2a, opt-in)
+### 4. Scheduled Support Roles (opt-in)
 
-GitHub Actions workflows under `.github/workflows/loom-*.yml` provide a daemon-free way to run the periodic support roles (Champion, Curator, Judge, Auditor, Guide) on cron schedules that match the daemon's historical intervals (Phase 2a of #3372, see #3375). Each workflow checks out the repo, installs the Claude CLI, and runs `claude -p "/<role>" --dangerously-skip-permissions` for one tick of work — no Loom-side state file, no long-running process.
+GitHub Actions workflows under `.github/workflows/loom-*.yml` run the periodic support roles (Champion, Curator, Judge, Auditor, Guide) on cron schedules (#3375). Each workflow checks out the repo, installs the Claude CLI, and runs `claude -p "/<role>" --dangerously-skip-permissions` for one tick of work — no Loom-side state file, no long-running process.
 
 | Workflow | Role | Schedule (commented) |
 |----------|------|----------------------|
@@ -119,7 +119,7 @@ GitHub Actions workflows under `.github/workflows/loom-*.yml` provide a daemon-f
 2. Uncomment the `schedule:` / `- cron:` lines in each `.github/workflows/loom-*.yml` you want to enable.
 3. Optionally trigger a run via `workflow_dispatch` (the Actions UI's "Run workflow" button) to smoke-test before the next scheduled tick.
 
-Architect and Hermit cadence (work-generation triggers) is intentionally out of scope here — see follow-up #3381 (Phase 2d). The schedule-driven model coexists with the daemon during Phase 2; Phase 3 removes the daemon brain entirely.
+Architect and Hermit cadence (work-generation triggers) is intentionally out of scope here — see follow-up #3381 (Phase 2d).
 
 ## Agent Roles
 
@@ -549,38 +549,30 @@ gh release create vX.Y.Z --title "vX.Y.Z" --notes "Release notes..."
 
 The script updates all 5 version-bearing files (`package.json`, `mcp-loom/package.json`, 2 `Cargo.toml` files (`loom-daemon`, `loom-api`), `CLAUDE.md`) plus `Cargo.lock`. The GitHub Actions release workflow (`.github/workflows/release.yml`) triggers on GitHub Release creation (`release: types: [created]`), NOT on tag push. You must create a GitHub Release via `gh release create` to trigger the build.
 
-## Migration: deprecations targeted for v0.10.0
+## Migration: v0.10.0 shepherd/daemon deprecation (completed)
 
-Loom is in the middle of an orchestration-architecture migration (epic #3372). In **v0.10.0** (the next planned minor release), the shepherd brain (`loom-tools/src/loom_tools/shepherd/`), the Python daemon brain (`loom-tools/src/loom_tools/daemon_v2/`), and the `/shepherd` slash command will be **deleted** in favour of a minimal spawn loop (#3374) + GitHub Actions workflows (#3375). **Daemon mode itself is preserved as a user-facing surface** — `./.loom/scripts/daemon.sh` continues to provide a tmux session container with multi-account token rotation, re-implemented around the spawn loop. The phased rollout is:
+The orchestration-architecture migration (epic #3372) is complete as of v0.10.0. The shepherd brain (`loom-tools/src/loom_tools/shepherd/`), the Python daemon brain (`loom-tools/src/loom_tools/daemon_v2/`), and the `/shepherd` slash command were deleted and replaced by the spawn loop (#3374) + GitHub Actions workflows (#3375). The shell-level daemon surface (`./.loom/scripts/daemon.sh`) is preserved, re-implemented as a tmux session launcher around the spawn loop. The completed phases:
 
-| Phase | Issue | What ships | Status |
+| Phase | Issue | What shipped | Status |
 |-------|-------|-----------|--------|
 | Phase 1 | #3374 | Minimal multi-account spawn loop (`./.loom/scripts/spawn-loop.sh`) | shipped |
 | Phase 2a | #3375 | GitHub Actions workflows for support roles | shipped (disabled by default) |
-| Phase 2b | #3376 | **Soft-deprecation warnings on deprecated entry points** | shipped |
-| Phase 3 | TBD | Deletion of shepherd brain, Python daemon brain, and `/shepherd` skill; re-implementation of `daemon.sh` around spawn loop + tmux | **v0.10.0** |
+| Phase 2b | #3376 | Soft-deprecation warnings on deprecated entry points | shipped |
+| Phase 3 | #3378 | Deletion of shepherd brain, Python daemon brain, `/shepherd` skill; `daemon.sh` re-implemented | shipped (v0.10.0) |
 | Phase 4 | #3382 | Coordinated downstream sphere-install migration | shipped |
 
 **v1.0.0 is intentionally unscheduled.** Loom remains pre-1.0 while the architecture settles.
 
-**Deprecated entry points (still functional, now warn on use):**
+**Removed entry points** (no longer present in v0.10.0+):
 
-| Deprecated | Replacement | Warning emitted from |
-|------------|-------------|----------------------|
-| `loom-daemon` (Python entry point) | `./.loom/scripts/daemon.sh` (preserved, re-implemented) OR `./.loom/scripts/spawn-loop.sh` (headless) + GitHub Actions schedules | `loom_tools.daemon_v2.cli.main()` |
-| `loom-shepherd` CLI / `/shepherd` invocations | `/loom:sweep <issue>` for the same lifecycle | `loom_tools.shepherd.cli.main()` |
-| `/shepherd` slash command (`defaults/.claude/commands/loom/shepherd.md`) | `/loom:sweep <issue>` | Markdown header instructs the LLM to emit the warning |
+| Removed | Replacement |
+|---------|-------------|
+| `loom-daemon` Python CLI | `./.loom/scripts/daemon.sh` (preserved) or `./.loom/scripts/spawn-loop.sh` (headless) + GitHub Actions schedules |
+| `loom-shepherd` CLI / `/shepherd` slash command | `/loom:sweep <issue>` for the same per-issue lifecycle |
 
-> **Note**: `./.loom/scripts/daemon.sh start` was listed as deprecated in 0.9.1 under the original plan that anticipated removing daemon mode entirely. **That plan was revised**: the shell-level daemon surface is preserved in v0.10.0. The warning attached to `daemon.sh start` in 0.9.1 will be withdrawn in v0.10.0. The Python `loom-daemon` CLI warning escalates to a genuine "command not found" error.
+Full migration narrative and per-CLI replacement table: [`docs/migration/v0.10.0-shepherd-deprecation.md`](docs/migration/v0.10.0-shepherd-deprecation.md).
 
-**Suppression**: set `LOOM_SUPPRESS_DEPRECATION=1` to silence the warnings emitted from Python and shell entry points. The `/shepherd` markdown skill warning always renders by design — operators should explicitly migrate, not silence. Sphere installs and other downstream automation that haven't migrated yet can use this env var to keep their logs clean during the deprecation window.
-
-**Helpers**: the warning text is centralized in two places so removal in Phase 3 is a single-PR sweep:
-
-- Python: `loom_tools.common.deprecation.warn_deprecated(component, replacement, ref="#3372")`
-- Shell: `source .loom/scripts/lib/deprecation.sh; warn_deprecated <component> <replacement> [ref]` — the bash helper is safe to source (no side effects).
-
-Full migration narrative: [`docs/migration/v0.10.0-shepherd-deprecation.md`](docs/migration/v0.10.0-shepherd-deprecation.md).
+See also: [ADR-0009](docs/adr/0009-shepherd-deprecation.md) — records the architectural decision to delete the shepherd and daemon Python brains.
 
 ## Resources
 

--- a/docs/adr/0009-shepherd-deprecation.md
+++ b/docs/adr/0009-shepherd-deprecation.md
@@ -1,0 +1,104 @@
+# ADR-0009: Deprecate and Delete Shepherd Brain and Python Daemon (Phase 3)
+
+## Status
+
+Accepted
+
+## Context
+
+Loom's original orchestration architecture concentrated intelligence in two Python packages:
+
+- **`loom_tools/shepherd/`** (~16.8k LOC): the per-issue orchestrator ("shepherd brain"). Each issue's lifecycle (Curator → Builder → Judge → Doctor → Merge) was managed by a long-running shepherd process that held lifecycle state in memory and wrote progress to `.loom/progress/shepherd-<id>.json`.
+
+- **`loom_tools/daemon_v2/`** (~4.7k LOC): the coordination daemon ("daemon brain"). A persistent Python process that polled the forge for `loom:issue` items, spawned shepherd children, ran periodic support roles (Judge, Curator, Champion, Auditor, Guide) in-process on a timer loop, and maintained a `daemon-state.json` file as its source of truth.
+
+This concentrated architecture created compounding problems:
+
+1. **Single point of failure**: if the daemon process crashed or got confused, all orchestration stopped. Recovery required manual intervention to clean up the daemon state file and restart.
+
+2. **Opaque internal state**: the daemon held significant state in memory and in `daemon-state.json`. Debugging required understanding the daemon's internal data model; the forge (GitHub labels, issue/PR state) was not sufficient to reconstruct what the daemon believed was happening.
+
+3. **Coupling**: the daemon owned the scheduling policy for all roles. Changing a role's cadence required daemon changes. Adding a new role required daemon registration. Worker roles were not independently runnable.
+
+4. **Process-level concurrency limits**: the daemon serialized role dispatching through a single Python event loop. Shepherd children ran as subprocesses but were tracked by the daemon, creating a dependency between child lifecycle and daemon health.
+
+5. **Maintenance burden**: ~21k LOC of Python orchestration code that had to be kept consistent with the role markdown files, the forge API, and the Claude CLI invocation patterns. The code duplicated coordination logic that could be expressed entirely through forge labels and standard shell scripts.
+
+The shepherd/daemon deprecation was proposed in #3317, refined and tracked as epic #3372, and implemented in a phased sequence documented in `docs/migration/daemon-state-consumers.md`.
+
+## Decision
+
+Delete `loom_tools/shepherd/`, `loom_tools/daemon_v2/`, the `/shepherd` slash command, and all related shell scripts and skill files. Replace the orchestration responsibilities with three daemon-free mechanisms:
+
+**1. Per-issue lifecycle: `/loom:sweep <issue>`**
+
+A Claude Code slash command that runs the full Curator → Builder → Judge → Doctor → Merge pipeline for one issue as a single-session process. State is checkpointed to `.loom/sweep-checkpoint/issue-<N>.json` for crash recovery. No persistent process. No daemon state file. The forge is the source of truth.
+
+**2. Multi-issue claiming: `./.loom/scripts/spawn-loop.sh`**
+
+A minimal shell script that polls `loom:issue`, atomically claims ready issues using a `mkdir`-based lock, and detaches one `claude -p "/loom:sweep N"` child per issue. Concurrency is bounded by `MAX_PARALLEL`. The spawn loop has no work-generation logic, no support-role triggers, and no pipeline state beyond a list of currently-running PIDs.
+
+**3. Periodic support roles: `.github/workflows/loom-*.yml`**
+
+GitHub Actions workflows that run the periodic support roles (Judge, Curator, Champion, Auditor, Guide) on cron schedules as fresh `claude -p "/<role>"` invocations. No Loom-side state file. No long-running process. Each tick is independent and idempotent.
+
+The shell-level daemon surface (`./.loom/scripts/daemon.sh`) is preserved as a user-facing convenience wrapper that launches the spawn loop + GitHub Actions cron + token-rotated tmux panes. The Python `loom-daemon` CLI entry point is removed.
+
+### Phase sequencing (PRs 3.1.1–3.7)
+
+The deletion was staged to minimize risk and allow incremental validation:
+
+| PR | What was deleted |
+|----|-----------------|
+| 3.1.1–3.1.9 | Nine targeted shepherd/daemon subsystem removals |
+| 3.2 | Python daemon brain (`daemon_v2/`) deletion |
+| 3.3 | Shepherd brain (`shepherd/`) deletion |
+| 3.4 | `daemon-state.json` fallback paths from ported CLIs |
+| 3.5 | Remaining `/shepherd` skill file and related shell scripts |
+| 3.6 | Mechanical docs search-and-replace (guides, quickstarts) |
+| 3.7 | Architecture narrative rewrites + this ADR (final Phase 3 PR) |
+
+## Consequences
+
+### Positive
+
+- **Simpler architecture**: ~21k LOC of Python orchestration deleted. The coordination logic is now ~500 lines of shell script plus forge labels.
+- **Transparent state**: all orchestration state is visible in the forge (labels, issue/PR status, comments). No hidden daemon state to debug.
+- **Independent evolution**: worker roles, sweep lifecycle, spawn loop, and GH Actions schedules can change independently. Adding a new role is a markdown file + optional GH Actions workflow.
+- **Fault tolerance**: a crashed sweep child restarts from its checkpoint; other sweeps are unaffected; the spawn loop re-queues on the next tick.
+- **No persistent process required**: operators can run Loom without a long-lived daemon. Single-issue sweeps (`/loom:sweep <N>`) work without the spawn loop; the spawn loop works without GH Actions workflows; GH Actions workflows work without the spawn loop.
+- **Multi-account scalability**: each `/loom:sweep` child picks its own OAuth token via `spawn-claude.sh`. Token rotation is handled at spawn time, not inside a shared daemon process.
+
+### Negative
+
+- **Breaking change for downstream automation**: any script or sphere install that invokes `loom-shepherd`, `loom-daemon` (Python CLI), or the `/shepherd` slash command must migrate to `/loom:sweep`. A migration guide is provided at `docs/migration/v0.10.0-shepherd-deprecation.md`.
+- **No preserve-compat shim**: unlike some deprecation paths, no compatibility shim was provided for the deleted Python entry points. The per-CLI replacement table in the migration guide covers all known invocation patterns.
+- **Architect/Hermit cadence**: the daemon's work-generation triggers (Architect and Hermit on a timer) are not yet replicated in GH Actions workflows. This is tracked as follow-up #3381 (Phase 2d). Until that ships, Architect and Hermit require manual invocation.
+
+## Alternatives Considered
+
+**Preserve the daemon brain, add the spawn loop alongside it**
+
+Rejected: running both the daemon brain and the spawn loop creates a split-brain scenario where two coordinators compete for `loom:issue` items. The daemon's internal state would drift from the forge state managed by sweep checkpoints. Complexity would increase, not decrease.
+
+**Rewrite the daemon brain in a more maintainable language (Rust, TypeScript)**
+
+Rejected: the core problem was not the Python implementation but the architectural pattern of a persistent stateful coordinator. Rewriting in another language would preserve the fragility and opacity. The shell + forge-as-state approach solves the root cause.
+
+**Keep the shepherd brain, replace only the daemon brain**
+
+Considered during Phase 1 scoping. Rejected: the shepherd brain (~16.8k LOC) and daemon brain (~4.7k LOC) were tightly coupled. The shepherd's per-issue state management duplicated what sweep checkpoints provide more simply. Keeping shepherd would have required maintaining the per-issue state protocol alongside the sweep protocol.
+
+**Gradual migration with a compatibility shim**
+
+The soft-deprecation warnings (Phase 2b, #3376) provided a warning window. A full compat shim was considered but rejected: the two orchestration models (daemon-state-centric vs forge-state-centric) are architecturally incompatible, not just interface-incompatible. A shim would mislead operators into thinking the old behavior was preserved when the internal model had fundamentally changed.
+
+## References
+
+- Original proposal: #3317 (closed — superseded by #3372)
+- Refining epic: #3372 (shepherd/daemon deprecation)
+- Phase 3 meta tracker: #3378
+- Phase inventory and rationale: `docs/migration/daemon-state-consumers.md`
+- Migration guide: `docs/migration/v0.10.0-shepherd-deprecation.md`
+- Related ADRs: [ADR-0008: tmux + Rust Daemon Architecture](0008-tmux-daemon-architecture.md) (Rust daemon preserved; Python brain deleted)
+- Related ADRs: [ADR-0006: Label-Based Workflow Coordination](0006-label-based-workflow-coordination.md) (forge-as-state-machine, foundational to this decision)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -43,6 +43,13 @@ An Architecture Decision Record captures an important architectural decision mad
   - **Summary**: Use GitHub labels as state machine for agent workflow coordination
   - **Key Decision**: Leverage GitHub labels over database, message queue, or file-based queue
 
+### Orchestration Architecture
+
+- [ADR-0009: Deprecate and Delete Shepherd Brain and Python Daemon (Phase 3)](0009-shepherd-deprecation.md)
+  - **Status**: Accepted
+  - **Summary**: Delete `loom_tools/shepherd/` (~16.8k LOC) and `loom_tools/daemon_v2/` (~4.7k LOC); replace with spawn loop + GitHub Actions cron + `/loom:sweep`
+  - **Key Decision**: Forge-as-state-machine + stateless components over persistent Python orchestration brain
+
 ## Creating a New ADR
 
 When making a significant architectural decision:

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -225,7 +225,7 @@ Hermit creates ──→ loom:hermit ──→ (human approves) ──→ loom:i
 ## Autonomous Operation
 
 Agents can run autonomously at configured intervals using either:
-1. **Daemon Mode**: `loom-daemon` manages support roles and shepherds on a schedule
+1. **Spawn loop + GitHub Actions cron**: `./.loom/scripts/spawn-loop.sh` claims `loom:issue` items and spawns `/loom:sweep` children; `.github/workflows/loom-*.yml` run periodic support roles on cron schedules
 2. **Manual Orchestration Mode**: Multiple Claude Code terminals with periodic commands
 
 ### Autonomous Agents

--- a/docs/philosophy/loom-intelligence.md
+++ b/docs/philosophy/loom-intelligence.md
@@ -1,597 +1,106 @@
-# Loom Intelligence: The Learning IDE
+# Loom Intelligence: Emergent Coordination
 
-*A vision for transforming agent activity data into continuous learning*
-
----
-
-## Vision
-
-Loom is not just a tool for running AI agents - it's a **learning system that gets smarter over time**. By analyzing agent activity, codebase evolution, and resource consumption, we can answer questions that fundamentally improve how software is built:
-
-- Which approaches actually work?
-- What's the true cost of different strategies?
-- How do we get faster and better over time?
-- Can the system teach itself what patterns succeed?
-
-This document defines the **product vision** for transforming raw agent data into actionable intelligence.
+*How a composition of simple, stateless components produces intelligent development behavior*
 
 ---
 
-## The Strategic Questions
+## The Core Insight
 
-These are the questions that, once answered, transform Loom from "AI terminals" into "a learning IDE":
+Loom's "intelligence" does not live in a single brain. There is no central planner, no persistent daemon loop that holds state and makes decisions. Instead, intelligence emerges from the composition of four simple, independently-replaceable layers:
 
-### 🎯 Agent Effectiveness
+```
+GitHub Actions cron schedules   — periodic support roles (Judge, Curator, Champion…)
+           +
+  spawn-loop.sh                  — atomic issue claiming + /loom:sweep dispatch
+           +
+  /loom:sweep <issue>            — single-issue lifecycle (Curator → Builder → Judge → Doctor → Merge)
+           +
+  Worker Roles                   — focused task executors (Builder, Judge, Doctor…)
+```
 
-**Which agents/roles are most effective?**
-- Success rate by agent role (Builder, Judge, Architect, etc.)
-- Time-to-completion by role
-- Quality metrics (tests passing, PR approval rate, rework frequency)
-- Specialization patterns (which roles excel at which task types?)
+The forge (GitHub or Gitea) is the shared state and coordination layer. Labels are the state machine. No component needs to talk to another component directly — they all read and write the same forge API.
 
-**Which prompts lead to the best outcomes?**
-- Correlation: prompt patterns → PR merge speed
-- Correlation: prompt patterns → test pass rates
-- Correlation: prompt patterns → human approval rates
-- Anti-patterns: prompts that consistently fail or require rework
-
-**How many prompts does it take?**
-- Prompts per feature (is it trending down over time?)
-- Prompts per bug fix
-- Prompts per PR
-- Iteration depth (how many tries before success?)
-
-### 💰 Resource Efficiency
-
-**What's the true cost of development?**
-- Token consumption per feature
-- API costs per PR
-- Cost per line of code
-- Cost per issue resolved
-- Budget burn rate and runway
-
-**Which approaches are cost-effective?**
-- Manual vs autonomous mode efficiency
-- Long-form prompts vs iterative dialog
-- Different models (Sonnet vs Opus) for different tasks
-- Role specialization ROI
-
-### 📈 Velocity & Trends
-
-**Are we getting faster?**
-- Issue resolution time (trending?)
-- PR cycle time (claim → merge)
-- Time in each workflow state
-- Velocity by week/month
-
-**What's our actual throughput?**
-- Features shipped per week
-- Bugs fixed per week
-- Lines of code per day
-- Issues opened vs closed rate
-
-### 🔍 Quality & Patterns
-
-**What correlates with quality?**
-- Test coverage vs PR approval rate
-- Prompt length vs success rate
-- Review cycles vs final merge
-- Time spent vs quality outcome
-
-**What patterns predict failure?**
-- Warning signs before failed builds
-- Patterns in stuck PRs
-- Common causes of rework
-- When to switch agent roles
-
-### 🧠 Learning & Improvement
-
-**Can the system improve itself?**
-- Identify successful prompt templates automatically
-- Suggest better prompts based on historical success
-- Detect when an agent is stuck (intervention signal)
-- Auto-tune autonomous intervals based on effectiveness
-- Recommend role assignments based on task type
+This is the architecture that replaced the Python daemon brain (`loom_tools/daemon_v2/`) and the shepherd orchestrator (`loom_tools/shepherd/`) in v0.10.0. See [ADR-0009](../adr/0009-shepherd-deprecation.md) for the decision record.
 
 ---
 
-## Product Features (User-Facing)
+## How Intelligence Emerges
 
-### Feature 1: Agent Dashboard
-**"Show me what's happening"**
+### Layer 1: Worker Roles (Task Execution)
 
-```
-┌─────────────────────────────────────────────┐
-│  Loom Intelligence Dashboard                │
-├─────────────────────────────────────────────┤
-│                                             │
-│  📊 Today's Activity                        │
-│  ├─ 6 active agents                         │
-│  ├─ 47 prompts sent                         │
-│  ├─ 3 features shipped                      │
-│  ├─ $12.47 spent                            │
-│  └─ 38k tokens used                         │
-│                                             │
-│  🎯 Agent Performance                       │
-│  ├─ Builder: 85% success (27/32 prompts)   │
-│  ├─ Judge: 100% success (10/10 reviews)    │
-│  └─ Architect: 60% approved (3/5 proposals)│
-│                                             │
-│  📈 This Week vs Last Week                  │
-│  ├─ Features: 12 (+3) ↗                    │
-│  ├─ Cycle time: 4.2hrs (-0.8hrs) ↘         │
-│  └─ Cost/feature: $42 (-$8) ↘              │
-│                                             │
-└─────────────────────────────────────────────┘
-```
+Each worker role — Builder, Judge, Curator, Doctor, Architect, Hermit, Champion, Guide, Auditor — is a focused prompt that performs one kind of work. Workers are stateless: they read the forge, do work, write back to the forge, and exit.
 
-### Feature 2: Prompt Library
-**"Learn from what worked"**
+Workers don't coordinate with each other. Coordination is entirely mediated by labels.
 
-- Browse successful prompts by category
-- Filter by agent role, success rate, task type
-- "Save as template" for reuse
-- Auto-suggest similar successful prompts
-- Show success metrics per template
+**Intelligence at this layer**: domain expertise encoded in role prompts. A Builder knows how to claim an issue, create a worktree, implement a feature, write tests, and open a PR. A Judge knows how to evaluate code quality. Neither needs to know the other exists.
 
-```
-Top Builder Prompts (Last 30 Days)
+### Layer 2: /loom:sweep (Single-Issue Lifecycle)
 
-1. "Find loom:issue, create worktree, implement"
-   ✅ 92% success | ⚡ 3.2hrs avg | 💰 $4.20 avg
-   Used: 23 times | Last: 2 hours ago
-   [Use This Template]
+`/loom:sweep <issue>` runs the full Curator → Builder → Judge → Doctor → Merge pipeline for one issue. It dispatches each phase to the appropriate worker role in sequence, checks the forge state between phases, and handles failures (Doctor fixes, re-Judge after Doctor, etc.).
 
-2. "Review PR #X, address all feedback"
-   ✅ 88% success | ⚡ 1.8hrs avg | 💰 $2.10 avg
-   Used: 15 times | Last: 1 day ago
-   [Use This Template]
-```
+Sweep is also stateless between issues. Its only persistent state is a checkpoint file (`.loom/sweep-checkpoint/issue-<N>.json`) that allows crash recovery within a single issue's lifecycle.
 
-### Feature 3: Cost Analytics
-**"Where's the money going?"**
+**Intelligence at this layer**: lifecycle orchestration. Sweep knows the correct order of operations, when to involve Doctor, and when to call Merge. This is the "workflow" layer — not a brain, but a well-defined protocol.
 
-- Real-time budget tracking
-- Cost breakdown by agent, task, time period
-- Projections and runway calculations
-- Cost-effectiveness comparisons
-- Alerts when approaching budget limits
+### Layer 3: Spawn Loop (Multi-Issue Claiming)
 
-```
-Monthly Budget: $500 | Used: $347 (69%)
+`./.loom/scripts/spawn-loop.sh` polls the forge for `loom:issue` items, atomically claims ready issues (using a `mkdir`-based lock to prevent double-claiming), and detaches one `claude -p "/loom:sweep N"` child per issue. Concurrency is bounded by `MAX_PARALLEL` (default 3).
 
-Cost Breakdown:
-├─ Builder role: $245 (71%)
-├─ Judge role: $52 (15%)
-├─ Architect: $38 (11%)
-└─ Other: $12 (3%)
+The spawn loop has no work-generation logic, no support-role triggers, no pipeline state. It is intentionally minimal. Its state file (`.loom/spawn-loop-state.json`) tracks only currently-running children — the forge is the source of truth for everything else.
 
-Most Expensive Feature: "Multi-workspace support"
-├─ 127 prompts over 3 days
-├─ $87 total cost
-└─ ⚠️ Above average - may need prompt optimization
+**Intelligence at this layer**: parallelism and resource management. The spawn loop turns a FIFO queue of approved issues into concurrent, isolated, self-contained sweeps. Multi-account token rotation (`spawn-claude.sh`) distributes load across Claude OAuth accounts.
 
-Runway: 12 days at current burn rate
-```
+### Layer 4: GitHub Actions Cron (Periodic Support Roles)
 
-### Feature 4: Learning Insights
-**"Make me smarter"**
+`.github/workflows/loom-*.yml` run the periodic support roles — Judge (5 min), Curator (5 min), Champion (10 min), Auditor (10 min), Guide (15 min) — on cron schedules as fresh `claude -p "/<role>"` invocations. No Loom-side state file. No long-running process. Each tick is independent.
 
-- Weekly intelligence reports
-- Pattern detection and recommendations
-- "Did you know?" insights
-- Performance trends and predictions
-- Anomaly detection
-
-```
-💡 Weekly Insights
-
-✨ Best Pattern This Week
-"Starting with tests" increased success rate by 34%
-→ Consider test-first for new features
-
-⚠️ Warning Sign Detected
-3 PRs stuck in review for >48hrs
-→ Possible reviewer bottleneck or unclear specs
-
-📈 Improvement Detected
-Average prompts-per-feature down from 8.2 to 6.4
-→ Prompt quality improving! Keep it up.
-
-🎯 Recommendation
-Architect proposals have 85% rejection rate on Fridays
-→ Consider scheduling brainstorming for Monday/Tuesday
-```
-
-### Feature 5: Playback & Replay
-**"Show me what happened"**
-
-- Timeline visualization of agent activity
-- Replay prompt sequences for a feature/bug
-- See the full context of a task
-- Compare successful vs failed attempts
-- Share/export task histories
-
-```
-Feature #42: "Add dark mode toggle"
-Timeline: 2024-10-18 to 2024-10-20 (2.3 days)
-
-├─ [Builder-1] 2:15 PM - Create worktree
-│  ⚡ 15 seconds | ✅ Success
-├─ [Builder-1] 2:16 PM - Implement toggle component
-│  ⚡ 4.2 min | ✅ Success | 47 lines changed
-├─ [Builder-1] 2:23 PM - Run tests
-│  ⚡ 23 seconds | ❌ Failed (3 tests)
-├─ [Doctor-1] 2:25 PM - Fix failing tests
-│  ⚡ 3.1 min | ✅ Success | 12 lines changed
-├─ [Builder-1] 2:31 PM - Create PR
-│  ⚡ 18 seconds | ✅ Success
-├─ [Judge-2] 4:42 PM - Review PR
-│  ⚡ 2.1 min | 🔄 Request changes (CSS issues)
-├─ [Doctor-1] 10:05 AM - Address review feedback
-│  ⚡ 5.3 min | ✅ Success | 8 lines changed
-└─ [Judge-2] 10:47 AM - Approve PR
-   ⚡ 1.2 min | ✅ Approved
-
-Total: 7 prompts | 16.2 active minutes | $4.35 cost
-Outcome: ✅ Merged in 2.3 days
-```
-
-### Feature 6: Comparative Analysis
-**"What's working better?"**
-
-- A/B test different approaches
-- Compare agent configurations
-- Benchmark against historical baseline
-- Model comparison (Sonnet vs Opus)
-- Role effectiveness comparisons
-
-```
-Experiment: Manual vs Autonomous Builder Mode
-Duration: 2 weeks | Sample: 20 features each
-
-┌─────────────────────┬─────────────┬──────────────┐
-│ Metric              │ Manual      │ Autonomous   │
-├─────────────────────┼─────────────┼──────────────┤
-│ Avg Time to PR      │ 3.2 hours   │ 4.8 hours    │
-│ Success Rate        │ 95%         │ 78%          │
-│ Cost per Feature    │ $8.20       │ $6.10        │
-│ Human Intervention  │ High        │ Low          │
-│ Test Pass Rate      │ 92%         │ 84%          │
-└─────────────────────┴─────────────┴──────────────┘
-
-Recommendation: Use manual mode for critical features,
-autonomous for routine tasks and maintenance.
-```
+**Intelligence at this layer**: continuous maintenance. Even when no human is present, the forge state is kept healthy: new issues get curated, open PRs get reviewed, approved PRs get merged, and stale items get flagged.
 
 ---
 
-## Data Requirements
+## The Forge as Shared Brain
 
-To answer these questions, we need to collect and correlate:
+The forge (GitHub or Gitea) is not just a code host — it is the external memory that makes all of this work without a central coordinator:
 
-### Already Tracking (Issue #174 ✅)
-- Terminal inputs (prompts)
-- Terminal outputs (results)
-- Timestamps
-- Agent roles
-- Workspace/branch context
+- **Issues** record approved work items with full context (curator notes, acceptance criteria)
+- **Labels** encode the workflow state machine (`loom:issue` → `loom:building` → PR → `loom:pr` → merged)
+- **Pull Requests** record completed work, review feedback, and merge decisions
+- **Comments** preserve institutional memory — why a decision was made, what was tried
 
-### Need to Add
-
-**GitHub Correlation:**
-- Link prompts → specific commits
-- Link prompts → specific PRs
-- Link prompts → specific issues
-- Track label transitions with timestamps
-- Track PR review cycles (requested → changes → approved)
-
-**Codebase Metrics:**
-- Lines added/removed per prompt
-- Files changed per prompt
-- Test coverage deltas
-- Build/test pass rates
-- Commit frequency
-
-**Resource Tracking:**
-- LLM API tokens per prompt
-- Model used (Sonnet, Opus, etc.)
-- Cost calculations
-- Session duration
-- Idle vs active time
-
-**Quality Metrics:**
-- Test pass/fail outcomes
-- Lint/format check results
-- PR approval/rejection
-- Time in review
-- Rework frequency
-
-**Derived Metrics:**
-- Success rate (by role, by prompt pattern, by time of day)
-- Cost efficiency (tokens per feature, cost per PR)
-- Velocity trends (features per week, cycle time)
-- Prompt effectiveness scores
+Every component reads from and writes to this shared state. No component needs to ask another "what is the current state?" — it just queries the forge. This is why the system is resilient to crashes, restarts, and multi-account concurrency: the forge is always consistent.
 
 ---
 
-## Database Schema Extensions
+## Why This Architecture is Smarter Than a Central Brain
 
-Building on #174's foundation:
+The previous architecture concentrated intelligence in a Python daemon brain (`daemon_v2/`) and shepherd orchestrator (`shepherd/`). That concentration created fragility:
 
-```sql
--- Link prompts to codebase changes
-CREATE TABLE prompt_changes (
-  id INTEGER PRIMARY KEY,
-  input_id INTEGER REFERENCES agent_inputs(id),
-  commit_hash TEXT,
-  files_changed INTEGER,
-  lines_added INTEGER,
-  lines_removed INTEGER,
-  tests_added INTEGER,
-  tests_modified INTEGER
-);
+- **Single point of failure**: if the daemon crashed or got confused, everything stopped
+- **Opaque state**: the daemon's internal state was hard to inspect and debug
+- **Coupling**: changing the daemon affected all workflows; changing a worker role required daemon updates
+- **Scalability limits**: the daemon serialized work through a single Python process
 
--- Link prompts to GitHub entities
-CREATE TABLE prompt_github (
-  id INTEGER PRIMARY KEY,
-  input_id INTEGER REFERENCES agent_inputs(id),
-  issue_number INTEGER,
-  pr_number INTEGER,
-  label_before TEXT,
-  label_after TEXT,
-  event_type TEXT -- 'issue_created', 'pr_created', 'pr_merged', etc.
-);
+The emergent architecture distributes intelligence:
 
--- Track resource consumption
-CREATE TABLE resource_usage (
-  id INTEGER PRIMARY KEY,
-  input_id INTEGER REFERENCES agent_inputs(id),
-  model TEXT NOT NULL,
-  tokens_input INTEGER,
-  tokens_output INTEGER,
-  cost_usd REAL,
-  duration_seconds INTEGER
-);
-
--- Track quality outcomes
-CREATE TABLE quality_metrics (
-  id INTEGER PRIMARY KEY,
-  input_id INTEGER REFERENCES agent_inputs(id),
-  tests_passed INTEGER,
-  tests_failed INTEGER,
-  lint_errors INTEGER,
-  format_errors INTEGER,
-  pr_approved BOOLEAN,
-  pr_changes_requested BOOLEAN,
-  human_rating INTEGER -- 1-5 stars, optional
-);
-
--- Materialized views for fast queries
-CREATE VIEW agent_effectiveness AS
-SELECT
-  agent_role,
-  COUNT(*) as total_prompts,
-  SUM(CASE WHEN q.tests_passed > 0 THEN 1 ELSE 0 END) as successful_prompts,
-  AVG(r.cost_usd) as avg_cost,
-  AVG(r.duration_seconds) as avg_duration
-FROM agent_inputs i
-LEFT JOIN quality_metrics q ON i.id = q.input_id
-LEFT JOIN resource_usage r ON i.id = r.input_id
-GROUP BY agent_role;
-```
+- **Fault tolerance**: a crashed sweep child restarts from its checkpoint; the spawn loop re-queues it on the next tick; other sweeps are unaffected
+- **Transparent state**: all state is visible in the forge — labels, comments, PR status; nothing is hidden in memory
+- **Independent evolution**: worker roles, sweep, spawn loop, and GH Actions workflows can change independently
+- **Horizontal scalability**: parallel sweeps run as separate processes; multi-account token rotation distributes load
 
 ---
 
-## Technical Architecture
+## The Learning Dimension
 
-### Data Collection Points
+The forge accumulates a rich history of every issue's lifecycle: curator notes, builder approaches, judge feedback, doctor fixes, merge decisions. This history is machine-readable.
 
-**1. Daemon (`loom-daemon`):**
-- Hook `send_input` → record prompts ✅ (already done)
-- Hook output polling → record results ✅ (already done)
-- Add: Capture git diff after each prompt
-- Add: Track LLM API metadata (tokens, model, cost)
-- Add: Measure session timing
+Future Loom intelligence layers can analyze this history to:
 
-**2. Frontend (`src/lib/`):**
-- Track UI events (user actions)
-- Capture human ratings/feedback
-- Record manual interventions
-- Log agent state transitions
+- Identify which prompt patterns correlate with faster PR approval
+- Detect common failure modes (builds that break after certain file patterns change)
+- Recommend issue decompositions based on historical cycle time
+- Surface agent effectiveness metrics (see `./.loom/scripts/agent-metrics.sh`)
 
-**3. GitHub Integration:**
-- Webhook listener for PR/issue events
-- Correlate events with active terminals
-- Track label transitions
-- Measure PR cycle times
-
-**4. CI/CD Integration:**
-- Report test results back to database
-- Track build success/failure
-- Capture lint/format check results
-- Link to originating prompts
-
-### Analytics Engine
-
-**Query Layer:**
-- SQL views for common metrics
-- Caching for expensive aggregations
-- Real-time vs batch processing
-- Export to CSV/JSON
-
-**Intelligence Layer:**
-- Pattern detection algorithms
-- Anomaly detection
-- Success prediction models
-- Prompt template extraction
-- Recommendation engine
-
----
-
-## Privacy & Ethics
-
-### Sensitive Data Handling
-
-**What could be sensitive:**
-- Code that reveals business logic
-- API keys/secrets in outputs
-- Personal information in comments
-- Proprietary algorithms
-
-**Mitigations:**
-- Local-only by default (`.loom/activity.db` never leaves machine)
-- Regex-based redaction for known secret patterns
-- Opt-in for any external sharing/export
-- Sanitization tools before export
-- Clear documentation of what's tracked
-
-### User Control
-
-- **Opt-out capability:** Disable tracking per workspace
-- **Granular controls:** Choose what to track (inputs only? outputs too?)
-- **Data retention:** Auto-delete after N days (configurable)
-- **Export/delete:** User owns all data, can export or purge anytime
-
-### Ethical Considerations
-
-**Transparency:**
-- Document exactly what's tracked
-- Make data inspection easy (SQLite browser, UI)
-- No hidden metrics or tracking
-
-**Consent:**
-- Installation process explains tracking
-- Checkbox during setup (not buried in TOS)
-- Easy to disable post-installation
-
-**Security:**
-- Database encrypted at rest (optional)
-- No phone-home by default
-- External APIs require explicit opt-in
-
----
-
-## Implementation Roadmap
-
-### Phase 1: Foundation (Current)
-- ✅ Basic input/output tracking (#174 complete)
-- 🔄 Terminal activity visualization (#177 in progress)
-- 📋 Enhanced installation (#442)
-- 📋 Offline mode (#443)
-
-### Phase 2: Correlation & Context
-- Link prompts to git commits
-- Link prompts to GitHub issues/PRs
-- Track test outcomes
-- Capture resource usage (tokens, cost)
-- Basic success metrics
-
-### Phase 3: Intelligence & Learning
-- Prompt pattern extraction
-- Success correlation analysis
-- Cost analytics
-- Velocity tracking
-- Simple recommendations
-
-### Phase 4: Advanced Analytics
-- Predictive models (success prediction)
-- Automated prompt optimization
-- A/B testing framework
-- Comparative analysis tools
-- External API for data access
-
-### Phase 5: Autonomous Learning
-- Agents read their own metrics
-- Self-tuning based on effectiveness
-- Auto-generated prompt templates
-- Intervention detection (when to ask human)
-- Continuous improvement loops
-
----
-
-## Success Criteria
-
-We'll know this is working when:
-
-### Short-term (6 months)
-- [ ] Can answer: "Which agent role is most cost-effective?"
-- [ ] Can answer: "What's my average cost per feature?"
-- [ ] Can export all activity data for analysis
-- [ ] Dashboard shows real-time agent status
-- [ ] Prompt library has >20 successful templates
-
-### Medium-term (12 months)
-- [ ] System suggests better prompts based on history
-- [ ] Can predict which tasks will succeed/fail
-- [ ] Cost per feature trending down 30%
-- [ ] Prompts per feature trending down 20%
-- [ ] Automated weekly intelligence reports
-
-### Long-term (24 months)
-- [ ] Agents autonomously improve their prompts
-- [ ] System detects when agent is stuck and intervenes
-- [ ] External researchers using Loom data for AI research
-- [ ] Community sharing successful prompt patterns
-- [ ] Loom becomes demonstrably faster/cheaper over time
-
----
-
-## Related Work
-
-### Existing Research
-- **OpenAI's agent benchmarking** - SWE-bench, HumanEval
-- **Devin AI** - Agent development environment
-- **Cursor analytics** - Code completion effectiveness
-- **GitHub Copilot metrics** - Acceptance rates, productivity
-
-### What Makes Loom Different
-- **Multi-agent orchestration** vs single-agent coding
-- **Full workflow tracking** vs just code completion
-- **Learning system** vs static tool
-- **Role specialization** vs general-purpose agent
-- **Local-first privacy** vs cloud telemetry
-
----
-
-## Open Questions
-
-1. **Model integration:** Should we use an LLM to analyze the data?
-   - Could Claude analyze its own effectiveness
-   - Generate insights automatically
-   - Suggest prompt improvements
-
-2. **Community features:** Should successful patterns be shareable?
-   - Public prompt library (opt-in)
-   - Anonymized benchmarks
-   - Best practices from aggregate data
-
-3. **Pricing model:** How does this affect Loom's business model?
-   - Free tier with basic analytics
-   - Pro tier with advanced intelligence
-   - Enterprise with custom models
-
-4. **Research opportunities:** Can this data advance AI research?
-   - Study how agents learn and improve
-   - Identify bottlenecks in AI coding
-   - Publish anonymized findings
-
-5. **Competitive advantage:** Is this data a moat?
-   - More usage → better insights → better tool → more usage
-   - Network effects from community patterns
-   - Proprietary prompt optimization
-
----
-
-## The North Star
-
-This vision can be summarized in a single principle:
-
-> **Loom should be an IDE that learns.**
-
-Every prompt is training data. Every success teaches the system. Every failure makes it smarter. Over time, Loom doesn't just help you write code—it helps you write code *better*.
-
-The foundation is already in place (#174). Now we build the intelligence layer.
+The key difference from the daemon era: this analysis layer reads from the forge, not from a proprietary daemon state file. Any tool that can query the GitHub/Gitea API can participate. The intelligence is not locked in Loom's process.
 
 ---
 
@@ -601,23 +110,16 @@ From [working-with-ai.md](working-with-ai.md):
 
 > "To get humans out of the debug loop, you need to create a surface that AI agents can read directly."
 
-Loom Intelligence IS that machine-readable surface. When agents can:
-- Read their own effectiveness metrics
-- Learn which patterns succeed
-- Self-correct based on outcomes
-- Continuously improve their prompts
+The forge IS that surface. Labels, issues, and PRs are machine-readable coordination primitives. Agents don't need a special protocol or a shared daemon — they read the same forge that humans read.
 
-We achieve the transformation described in our philosophy:
+> "Software development is transitioning from: 'Can I write this code fast enough?' To: 'Can I specify what I actually want clearly enough?'"
 
-> Software development is transitioning from: "Can I write this code fast enough?" To: "Can I specify what I actually want clearly enough?"
-
-Intelligence closes the loop. Agents not only execute—they learn, adapt, and improve. The craft evolves from writing code to orchestrating an ever-improving system.
+Loom's architecture embodies this: the work of specifying (Curator, Architect), building (Builder), and reviewing (Judge, Doctor) is distributed across specialized roles. The coordination overhead is handled by the forge's state machine. Human judgment enters at the right moments — proposal approval, merge decisions, blocked-issue triage — without requiring humans to manage the pipeline mechanics.
 
 ---
 
 **See Also:**
-- [Agent Archetypes](agent-archetypes.md) - The roles that generate the data
-- [Working with AI](working-with-ai.md) - The philosophy that demands this vision
-- [Issue #444](https://github.com/rjwalters/loom/issues/444) - Implementation tracking
-- [Issue #174](https://github.com/rjwalters/loom/issues/174) - Database foundation
-- [Issue #177](https://github.com/rjwalters/loom/issues/177) - Activity visualization
+- [Agent Archetypes](agent-archetypes.md) — the roles that compose this architecture
+- [ADR-0009: Deprecate and Delete Shepherd Brain and Python Daemon](../adr/0009-shepherd-deprecation.md) — the architectural decision record
+- [Working with AI](working-with-ai.md) — the philosophy that motivates this design
+- [CLAUDE.md](../../CLAUDE.md) — operational guide for running Loom


### PR DESCRIPTION
## Summary

Final Phase 3 PR in the shepherd/daemon deprecation epic (#3372). Phases 3.2 (daemon_v2 deletion), 3.3 (shepherd deletion), and 3.4 (daemon-state fallback path removal) are already merged. This PR is the narrative pass: rewrite documentation to match the post-Phase-3 reality.

The split between 3.6 (mechanical search-and-replace across guides/quickstarts) and 3.7 (this PR, narrative rewrites) was intentional — mechanical replacements are low-risk and can ship independently; architectural narrative rewrites require understanding the new architecture and are more contentious. Per `docs/migration/daemon-state-consumers.md` §"Recommended Phase 3 PR sequencing": ship narrative last.

## Changes

- **`CLAUDE.md`**: Updated "What is Loom?" to remove "Daemon Mode" framing; rewrote Migration section from future-tense ("will be deleted") to past-tense ("were deleted, Phase 3 complete"); trimmed Phase 2a/2d labels from section headings; replaced the forward-looking deprecated-entry-points table with a concise "Removed entry points" table; dropped two now-false forward-looking sentences about Phase 3.

- **`docs/philosophy/loom-intelligence.md`**: Full rewrite. The previous document framed Loom's intelligence around a daemon brain iteration loop and aspirational "Learning IDE" dashboards. The rewrite describes intelligence as emergent from composition: GitHub Actions cron schedules (periodic support roles) + spawn loop (multi-issue claiming) + `/loom:sweep` (single-issue lifecycle) + worker roles (task execution). The forge is the shared brain. Retains the "learning dimension" section to show how the forge's accumulated history enables future analytics without requiring a proprietary daemon state file.

- **`docs/agents.md`**: Updated "Autonomous Operation" section to reference spawn loop + GH Actions cron instead of "Daemon Mode: `loom-daemon` manages support roles and shepherds on a schedule."

- **`docs/adr/0009-shepherd-deprecation.md`**: New ADR recording the Phase 3 deletion decision. Cites original proposal #3317, refining epic #3372, Phase 3 meta tracker #3378, phase sequencing PRs 3.1.1–3.7, `docs/migration/daemon-state-consumers.md`, and the migration guide. Documents context (why centralized Python orchestration was problematic), decision (what was deleted and what replaced it), consequences (positive and negative), and alternatives considered (preserve daemon, rewrite in Rust, keep shepherd, compat shim).

- **`docs/adr/README.md`**: Added ADR-0009 to the index under new "Orchestration Architecture" category.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| New ADR exists at `docs/adr/0009-shepherd-deprecation.md` | Done | File created; numbered 0009 (next after 0008) |
| `CLAUDE.md` architecture diagram and prose accurate | Done | Diagram was already updated by Phase 3.6; prose updated in this PR |
| `docs/philosophy/loom-intelligence.md` no longer relies on deleted daemon brain | Done | Full rewrite removes all daemon-brain-as-central-intelligence framing |
| PR body explains 3.6 vs 3.7 split and confirms 3.6 merged | Done | See Summary above |
| No code changes — pure markdown | Done | `git diff --stat` shows only .md files |
| No new GitHub labels created | Done | No label operations |

## Test Plan

- All files are markdown; no build or test step required.
- Verify ADR is reachable: `docs/adr/0009-shepherd-deprecation.md`
- Verify ADR README index entry: `docs/adr/README.md` under "Orchestration Architecture"
- Verify CLAUDE.md Migration section says "completed" not "targeted for v0.10.0"
- Verify `docs/philosophy/loom-intelligence.md` does not mention "daemon brain" as active component

Closes #3405