### PR TITLE
fix(validate_phase): replace stale loom-shepherd.sh references with /loom:sweep

### DIFF
--- a/loom-tools/src/loom_tools/clean.py
+++ b/loom-tools/src/loom_tools/clean.py
@@ -677,7 +677,7 @@ def clean_branches(
 def _list_loom_tmux_sessions() -> list[str]:
     """List all tmux sessions on the loom socket.
 
-    Returns session names (e.g. ``["loom-shepherd-1", "loom-champion"]``).
+    Returns session names (e.g. ``["loom-champion", "loom-builder-1"]``).
     """
     try:
         result = subprocess.run(

--- a/loom-tools/src/loom_tools/validate_phase.py
+++ b/loom-tools/src/loom_tools/validate_phase.py
@@ -499,13 +499,13 @@ git worktree remove .loom/worktrees/issue-{issue} --force 2>/dev/null || true
 git branch -D feature/issue-{issue} 2>/dev/null || true
 # Reset labels and retry
 gh issue edit {issue} --remove-label loom:blocked --add-label loom:issue
-./.loom/scripts/loom-shepherd.sh {issue} --merge
+claude -p "/loom:sweep {issue}" --dangerously-skip-permissions
 ```
 
 **Option B: Retry preserving worktree** (if worktree may have partial work)
 ```bash
 gh issue edit {issue} --remove-label loom:blocked --add-label loom:issue
-./.loom/scripts/loom-shepherd.sh {issue} --merge
+claude -p "/loom:sweep {issue}" --dangerously-skip-permissions
 ```
 
 **Option C: Complete manually**


### PR DESCRIPTION
## Summary

- Replace two stale `.loom/scripts/loom-shepherd.sh {issue} --merge` references in `validate_phase.py` `BuilderDiagnostics.to_markdown()` recovery guidance (Options A and B) with `claude -p "/loom:sweep {issue}" --dangerously-skip-permissions`
- Update stale docstring in `clean.py` `_list_loom_tmux_sessions()` that referenced `loom-shepherd-1` as an example session name, replacing it with current role names (`loom-champion`, `loom-builder-1`)

`grep -r 'loom-shepherd' loom-tools/src/` now returns zero hits (excluding `loom_tools.egg-info/`).

## Test plan

- [x] `PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/test_validate_phase.py loom-tools/tests/test_cleanup.py -q` — 126 passed
- [x] Full suite `loom-tools/tests/` (excluding pre-existing unrelated failure in `test_agent_spawn.py::TestValidateRole::test_role_in_claude_commands`) — 1608 passed, 65 skipped

Closes #3436

🤖 Generated with [Claude Code](https://claude.com/claude-code)