### PR TITLE
ci: add rust-toolchain.toml to backend paths-filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
               - 'loom-api/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
+              - 'rust-toolchain.toml'
               - '.github/workflows/ci.yml'
             mcp:
               - 'mcp-loom/**'


### PR DESCRIPTION
## Summary

- Adds `rust-toolchain.toml` to the `backend` paths-filter in `.github/workflows/ci.yml`
- Without this, a PR that only changes the toolchain pin silently skips all Rust CI jobs

## Change

One line added to the `backend` filter in the `dorny/paths-filter` step, after `Cargo.lock` and before `.github/workflows/ci.yml`.

## Test plan

- [ ] Verify the paths-filter YAML is valid (no syntax errors)
- [ ] Confirm a future PR touching only `rust-toolchain.toml` triggers the `backend-lint-and-check` and related Rust jobs

Closes #3428