### PR TITLE
fix(ci): add rustfmt/clippy components to rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.96.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

Fixes the permanent `backend-lint-and-check` CI failure on main caused by `cargo fmt --all -- --check` erroring with:

```
error: 'cargo-fmt' is not installed for the toolchain '1.96.0-aarch64-unknown-linux-gnu'
```

## Root Cause

`.github/workflows/ci.yml` uses `dtolnay/rust-toolchain@stable`, which would normally install `rustfmt` + `clippy` with the stable channel. However, `rust-toolchain.toml` overrides the channel to `1.96.0`, and rustup auto-installs that pinned channel without the required components because they weren't declared in the toolchain file. The action's component preference is silently bypassed by the channel override.

## Fix

Add `components = ["rustfmt", "clippy"]` to `rust-toolchain.toml` so rustup installs the required tooling alongside the pinned channel.

```diff
 [toolchain]
 channel = "1.96.0"
+components = ["rustfmt", "clippy"]
```

## Test Plan

- [ ] CI `backend-lint-and-check` job passes on this PR (verifies both `cargo fmt --all -- --check` and `cargo clippy ...` run successfully against the 1.96.0 toolchain)

Closes #3445

🤖 Generated with [Claude Code](https://claude.com/claude-code)