### PR TITLE
feat(curator): verify Affected Files against origin/main before curating (#3418)

### DIFF
--- a/defaults/.claude/agents/loom-curator.md
+++ b/defaults/.claude/agents/loom-curator.md
@@ -19,4 +19,6 @@ Follow the complete role definition in `.loom/roles/curator.md` for:
 - Marking enhanced issues as `loom:curated`
 - NEVER adding `loom:issue` - only humans can approve work
 
+Before applying `loom:curated`, verify each path enumerated under `## Affected Files` exists on `origin/main` (curator runs in the user's working tree where uncommitted files are visible; builder runs in a worktree off `origin/main` where they are not). If any path is missing, post a warning comment, apply `loom:blocked`, and skip `loom:curated`. See `.claude/commands/loom/curator.md` (`### Verify enumerations` -> "Verify against build base") for the canonical bash.
+
 Quality issues get marked `loom:curated` immediately; incomplete issues get enhanced first.

--- a/defaults/.claude/commands/loom/curator.md
+++ b/defaults/.claude/commands/loom/curator.md
@@ -312,6 +312,43 @@ The Builder's complexity-assessment path (`defaults/.claude/commands/loom/builde
 
 > **Verify enumerations.** If the issue body lists specific callers, files, sites, or line numbers, treat the enumeration as a *starting point*, not authoritative. Run a comprehensive `git ls-files <pattern> | xargs grep -nE '<pattern>'` to verify completeness. Report any additions in your curator comment so the builder gets the correct scope.
 
+> **Verify against build base (origin/main).** The curator runs in the user's working tree (where uncommitted files are visible); the builder runs in a fresh worktree off `origin/main` (where they are not). If your "Affected Files" enumeration silently includes uncommitted paths, the builder will block on a broken setup. Before applying `loom:curated`, verify every path you enumerated under `## Affected Files` exists on the build base:
+>
+> ```bash
+> # Curator pre-flight: verify Affected Files exist on origin/main
+> git fetch origin --quiet
+>
+> # AFFECTED_FILES is the set of paths you enumerated under `## Affected Files`
+> MISSING=()
+> for path in "${AFFECTED_FILES[@]}"; do
+>   if ! git ls-tree -r origin/main --name-only | grep -qFx "$path"; then
+>     MISSING+=("$path")
+>   fi
+> done
+>
+> if (( ${#MISSING[@]} > 0 )); then
+>   # Surface in a warning comment + apply loom:blocked; do NOT apply loom:curated
+>   COMMENT="⚠️ **Curator pre-flight: uncommitted source files**
+>
+> The following files in the Affected Files enumeration are not on \`origin/main\`:
+> $(printf -- '- \`%s\`\n' "${MISSING[@]}")
+>
+> This will block the Builder, which dispatches into a fresh worktree off \`origin/main\`. Either:
+> - Commit + push these files first, then remove the \`loom:blocked\` label, OR
+> - Adjust the Affected Files section to scope down to committed-only changes."
+>   gh issue comment "$N" --body "$COMMENT"
+>   gh issue edit "$N" --add-label "loom:blocked"
+>   # Exit without further state changes — the next curator tick will re-evaluate.
+>   exit 0
+> fi
+> ```
+>
+> Implementation notes:
+> - Use `grep -qFx` (exact match) — not `grep -qF` — so `src/foo.ts` doesn't match `src/foo.ts.bak`.
+> - Run `git fetch origin --quiet` once at the top of the verification pass; do not refetch per file.
+> - If the issue has no `## Affected Files` section yet, this check is a no-op for this tick — add the section in the same pass and let the next curator tick run the verification.
+> - The `loom:blocked` label is the right escape hatch: it's already in the workflow, and is removed by the user (not by Loom) once the underlying files are committed and pushed.
+
 ### Process-Improvement Issues
 
 Issues about agent behavior or workflow failures need special curation to prevent superficial fixes (e.g., adding cross-references instead of structural changes). When curating these issues:


### PR DESCRIPTION
Closes #3418

## Summary

Adds a "Verify against build base (origin/main)" sub-step to the curator's existing `### Verify enumerations` section. Before applying `loom:curated`, the curator verifies each path enumerated under `## Affected Files` exists on `origin/main` via:

```bash
git fetch origin --quiet
git ls-tree -r origin/main --name-only | grep -qFx "$path"
```

If any path is missing, the curator posts a warning comment listing the missing paths, applies `loom:blocked`, and does NOT apply `loom:curated`. The next curator tick re-evaluates after the user commits and pushes.

## Rationale

The curator runs in the user's working tree (where uncommitted files are visible); the builder runs in a fresh worktree off `origin/main` (where they are not). When the curator silently enumerates uncommitted files, the builder dispatches into a broken setup and blocks expensively (worktree teardown + re-dispatch + re-curate). Surfacing the gap at curate time is the cheapest place to catch it.

## Files changed

- `defaults/.claude/commands/loom/curator.md` — full bash block + rationale + implementation notes inserted as a new blockquote inside `### Verify enumerations` (line 311 on origin/main).
- `defaults/.claude/agents/loom-curator.md` — one-line reminder pointing to the canonical curator.md for the bash details.
- `defaults/roles/curator.md` — already a symlink to `defaults/.claude/commands/loom/curator.md`, so it inherits the update automatically (the curator's enrichment listed all three files but only two underlying files exist).

Diff stat: 2 files changed, 39 insertions(+), 0 deletions(-).

## Out of scope

- Option B (sweep-side preflight) — broader coverage but heavier; if Option A proves insufficient, file as a follow-up.
- Option C (builder-side better diagnostic) — current builder behavior already blocks cleanly; polish only.

## Test plan

- [ ] Manually trigger a curator pass on an issue whose `## Affected Files` enumeration references a path not on `origin/main`. Confirm the curator posts the warning comment, applies `loom:blocked`, and does NOT apply `loom:curated`.
- [ ] Trigger a curator pass on an issue whose enumeration references only paths present on `origin/main`. Confirm normal `loom:curated` flow.
- [ ] Trigger a curator pass on an issue that has no `## Affected Files` section yet. Confirm the verification is a no-op (the curator adds the section on this pass; the next tick runs the verification).