### PR TITLE
chore(claim): remove dead DEFAULT_HEARTBEAT_STALE_THRESHOLD constant (#3441)

### DIFF
--- a/loom-tools/src/loom_tools/claim.py
+++ b/loom-tools/src/loom_tools/claim.py
@@ -30,11 +30,6 @@ from loom_tools.common.state import read_json_file, write_json_file
 # Default TTL: 30 minutes
 DEFAULT_TTL = 1800
 
-# Default heartbeat staleness threshold: 5 minutes (300 seconds)
-DEFAULT_HEARTBEAT_STALE_THRESHOLD = int(
-    os.environ.get("LOOM_HEARTBEAT_STALE_THRESHOLD", "300")
-)
-
 # Threshold for claims without progress files: 10 minutes (600 seconds)
 NO_PROGRESS_FILE_THRESHOLD = 600
 


### PR DESCRIPTION
Closes #3441

## Summary

Removes the dead `DEFAULT_HEARTBEAT_STALE_THRESHOLD` constant and its `os.environ.get("LOOM_HEARTBEAT_STALE_THRESHOLD", ...)` env-var read from `loom-tools/src/loom_tools/claim.py`. The constant had zero references after PR #3440 removed the shepherd-progress branch in `_is_claim_abandoned()` (its sole consumer).

## What changed

- `loom-tools/src/loom_tools/claim.py`: deleted the 4-line constant definition + 1-line comment (5 LOC total). No other edits.

## What did NOT change (deliberately)

- `loom-tools/src/loom_tools/orphan_recovery.py`: contains an identically-named but separate module-scoped constant (`DEFAULT_HEARTBEAT_STALE_THRESHOLD = 300` at line 53) with 3 real consumers (lines 53, 144, 332). Untouched.
- `import os` in `claim.py`: retained — still consumed by `os.getpid()` (line 102 post-edit).
- `LOOM_HEARTBEAT_STALE_THRESHOLD` env-var contract: still consumed independently by `completions.py:41` and `orphan_recovery.py:138`.

## Verification

```
$ git grep -n DEFAULT_HEARTBEAT_STALE_THRESHOLD loom-tools/src/loom_tools/claim.py
(no matches)

$ git grep -n DEFAULT_HEARTBEAT_STALE_THRESHOLD loom-tools/src/loom_tools/orphan_recovery.py
loom-tools/src/loom_tools/orphan_recovery.py:53:DEFAULT_HEARTBEAT_STALE_THRESHOLD = 300
loom-tools/src/loom_tools/orphan_recovery.py:144:    return DEFAULT_HEARTBEAT_STALE_THRESHOLD
loom-tools/src/loom_tools/orphan_recovery.py:332:    heartbeat_threshold: int = DEFAULT_HEARTBEAT_STALE_THRESHOLD,
```

Net LOC diff: -5 lines, +0 lines.

## Test plan

- [x] `pytest loom-tools/tests/test_claim.py -v` -> 48 passed
- [x] `pytest loom-tools/tests/` -> 1677 passed, 65 skipped, 1 pre-existing failure (`test_agent_spawn.py::TestValidateRole::test_role_in_claude_commands`) that reproduces on `origin/main` and is unrelated to this change
- [x] Confirmed `import os` retained and still used by `os.getpid()`
- [x] Confirmed `orphan_recovery.py` constant untouched (3 references intact)