### PR TITLE
docs(stop-gap): warn that ./.loom/scripts/daemon.sh is absent pending v0.10.0 rebuild (#3449)

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -1,5 +1,9 @@
 # Loom Daemon Reference
 
+> **⚠️ Stop-gap — daemon backend in flight (epic #3449, stop-gap #3451)**
+>
+> The "preserved, re-implemented" claim below describes the v0.10.0 target state. As of v0.9.1, `./.loom/scripts/daemon.sh` does **not** exist on `origin/main` — it was deleted in #3432 and is being rebuilt in epic #3449 (~4-6 weeks). Until that rebuild lands, all `./.loom/scripts/daemon.sh start|stop|status` commands in this page will fail with "no such file or directory". Use `./.loom/scripts/spawn-loop.sh` (headless) or `/loom:sweep <issue>` instead.
+
 > **Status: PRESERVED, RE-IMPLEMENTED in v0.10.0.** The Python `loom-daemon`
 > brain (`loom_tools/daemon_v2/`) and the `/shepherd` orchestrator are
 > deleted in v0.10.0 as part of the shepherd/daemon-brain deprecation epic

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,11 @@ Architect and Hermit cadence (work-generation triggers) is intentionally out of 
 
 Full role definitions: `.loom/roles/*.md`.
 
-> **Note**: the historical `shepherd.md` (single-issue orchestrator) role file was removed in v0.10.0 along with the `/shepherd` slash command — see [the migration guide](docs/migration/v0.10.0-shepherd-deprecation.md). Its orchestration responsibilities moved to `/loom:sweep` (Tier 1) and the spawn loop + GH Actions cron (Tier 2). The `loom.md` role file is preserved and documents the daemon-mode operator surface (`./.loom/scripts/daemon.sh` + tmux + token-rotated separate Claude Code sessions); the Python brain it historically referenced (`loom_tools/daemon_v2/`) is removed in v0.10.0, but the shell-level daemon surface stays. The worker-role markdown files above are unchanged.
+> **Stop-gap — daemon backend in flight (v0.10.0 rebuild, epic #3449)**
+>
+> `./.loom/scripts/daemon.sh` does not exist on `origin/main` as of v0.9.1; the dispatcher was deleted in #3432 and is being rebuilt in epic #3449 (~4-6 weeks, scheduled for v0.10.0). The text below describes the intended target state. Until Phase A through E of #3449 land, daemon operator commands (`./.loom/scripts/daemon.sh start|stop|status`) will fail with "no such file or directory". Use `./.loom/scripts/spawn-loop.sh` for headless multi-issue dispatch in the interim. Tracker: #3451 (this stop-gap), #3449 (rebuild epic).
+
+> **Note**: the historical `shepherd.md` (single-issue orchestrator) role file was removed in v0.10.0 along with the `/shepherd` slash command — see [the migration guide](docs/migration/v0.10.0-shepherd-deprecation.md). Its orchestration responsibilities moved to `/loom:sweep` (Tier 1) and the spawn loop + GH Actions cron (Tier 2). The `loom.md` role file is preserved and documents the daemon-mode operator surface (`./.loom/scripts/daemon.sh` + tmux + token-rotated separate Claude Code sessions — see stop-gap warning above re: in-flight rebuild #3449); the Python brain it historically referenced (`loom_tools/daemon_v2/`) is removed in v0.10.0, but the shell-level daemon surface stays. The worker-role markdown files above are unchanged.
 
 ## Label-Based Workflow
 
@@ -289,6 +293,10 @@ Configuration stored in `.loom/config.json` (committed to git for team sharing):
 ```
 
 ### Spawn-Loop Configuration
+
+> **Stop-gap — daemon backend in flight (v0.10.0 rebuild, epic #3449)**
+>
+> The paragraph below claims `./.loom/scripts/daemon.sh` is "preserved and re-implemented" — but the file does not exist on `origin/main` as of v0.9.1 (deleted in #3432). The rebuild is tracked in epic #3449 (~4-6 weeks). Until that lands, the only working multi-issue dispatch backend is `./.loom/scripts/spawn-loop.sh` (headless) or the GitHub Actions cron workflows. The daemon prose stays here as a forward-looking pointer at the target state.
 
 The spawn loop replaces the historical Python daemon brain. The shell-level daemon surface (`./.loom/scripts/daemon.sh`) is preserved and re-implemented around the spawn loop + GitHub Actions cron + token-rotated tmux panes (see [`.loom/docs/daemon-reference.md`](.loom/docs/daemon-reference.md)). For the full migration narrative, see [`docs/migration/v0.10.0-shepherd-deprecation.md`](docs/migration/v0.10.0-shepherd-deprecation.md).
 
@@ -551,6 +559,10 @@ The script updates all 5 version-bearing files (`package.json`, `mcp-loom/packag
 
 ## Migration: v0.10.0 shepherd/daemon deprecation (completed)
 
+> **Stop-gap — daemon "preserved" claim is currently aspirational (epic #3449, stop-gap #3451)**
+>
+> The next paragraph says the shell-level daemon surface "is preserved, re-implemented as a tmux session launcher around the spawn loop". On `origin/main` as of v0.9.1, `./.loom/scripts/daemon.sh` does **not** exist — it was deleted in #3432 and is being rebuilt in epic #3449 over an estimated 4-6 weeks for v0.10.0. The shepherd/Python-daemon-brain deletions are real and shipped; the daemon-shell rebuild is in flight. Until #3449 ships, use `./.loom/scripts/spawn-loop.sh` (headless) or GitHub Actions cron workflows.
+
 The orchestration-architecture migration (epic #3372) is complete as of v0.10.0. The shepherd brain (`loom-tools/src/loom_tools/shepherd/`), the Python daemon brain (`loom-tools/src/loom_tools/daemon_v2/`), and the `/shepherd` slash command were deleted and replaced by the spawn loop (#3374) + GitHub Actions workflows (#3375). The shell-level daemon surface (`./.loom/scripts/daemon.sh`) is preserved, re-implemented as a tmux session launcher around the spawn loop. The completed phases:
 
 | Phase | Issue | What shipped | Status |
@@ -558,7 +570,7 @@ The orchestration-architecture migration (epic #3372) is complete as of v0.10.0.
 | Phase 1 | #3374 | Minimal multi-account spawn loop (`./.loom/scripts/spawn-loop.sh`) | shipped |
 | Phase 2a | #3375 | GitHub Actions workflows for support roles | shipped (disabled by default) |
 | Phase 2b | #3376 | Soft-deprecation warnings on deprecated entry points | shipped |
-| Phase 3 | #3378 | Deletion of shepherd brain, Python daemon brain, `/shepherd` skill; `daemon.sh` re-implemented | shipped (v0.10.0) |
+| Phase 3 | #3378 | Deletion of shepherd brain, Python daemon brain, `/shepherd` skill; `daemon.sh` re-implemented | partial (deletions shipped; daemon.sh re-implementation in flight under epic #3449) |
 | Phase 4 | #3382 | Coordinated downstream sphere-install migration | shipped |
 
 **v1.0.0 is intentionally unscheduled.** Loom remains pre-1.0 while the architecture settles.
@@ -567,7 +579,7 @@ The orchestration-architecture migration (epic #3372) is complete as of v0.10.0.
 
 | Removed | Replacement |
 |---------|-------------|
-| `loom-daemon` Python CLI | `./.loom/scripts/daemon.sh` (preserved) or `./.loom/scripts/spawn-loop.sh` (headless) + GitHub Actions schedules |
+| `loom-daemon` Python CLI | `./.loom/scripts/daemon.sh` (rebuild in flight, epic #3449 — use `./.loom/scripts/spawn-loop.sh` headless until then) + GitHub Actions schedules |
 | `loom-shepherd` CLI / `/shepherd` slash command | `/loom:sweep <issue>` for the same per-issue lifecycle |
 
 Full migration narrative and per-CLI replacement table: [`docs/migration/v0.10.0-shepherd-deprecation.md`](docs/migration/v0.10.0-shepherd-deprecation.md).

--- a/defaults/.claude/commands/loom/loom.md
+++ b/defaults/.claude/commands/loom/loom.md
@@ -1,5 +1,15 @@
 # Loom Daemon
 
+> **⚠️ Stop-gap warning — entire role file describes a target state not yet shipped (epic #3449, stop-gap #3451)**
+>
+> **This role file describes the operator surface of a daemon backend that does not currently exist on `origin/main`.** The dispatcher `./.loom/scripts/daemon.sh` was deleted in #3432 and is being rebuilt in epic #3449 (~4-6 weeks, scheduled for v0.10.0). Until Phases A-E of #3449 land:
+>
+> - All `./.loom/scripts/daemon.sh start|stop|status|restart` commands in this file will fail with "no such file or directory".
+> - The `.loom/daemon-state.json` and `.loom/daemon-loop.pid` files this skill expects to read will not exist (no producer is running).
+> - The signals directory (`.loom/signals/`) this skill writes to has no consumer.
+>
+> **Operators reading this file in v0.9.x**: invoking `/loom` will not do useful work — there is no daemon process to observe or signal. Use `./.loom/scripts/spawn-loop.sh start` (headless multi-issue dispatch) or `/loom:sweep <issue>` (per-issue lifecycle) instead. The full doc rewrite is Phase E of #3449; this stop-gap (#3451) only warns. Tracker links: #3449 (rebuild epic), #3451 (this stop-gap), #3432 (the deletion).
+
 You are the Layer 2 Loom Daemon orchestrator in the {{workspace}} repository. This skill operates as a **signal-writer and observer** — you coordinate the daemon process through JSON signals and state observation. You NEVER spawn daemon or shepherd processes directly via Bash.
 
 ## Arguments

--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -770,6 +770,8 @@ If the user is running an overnight sweep, they should heed the warning before w
 
 ## Daemon Coexistence
 
+> **Stop-gap note (epic #3449, stop-gap #3451)**: `./.loom/scripts/daemon.sh` does not currently exist on `origin/main` (deleted in #3432, rebuild in flight under epic #3449). The PID-file check below is a defensive coexistence guard that fires only if a daemon process is already running — it's a no-op in v0.9.x. The `./.loom/scripts/daemon.sh stop` instruction in the warning text is forward-looking until the rebuild lands.
+
 `/sweep` does not require the daemon and does not interact with `.loom/daemon-state.json` for writes. If the daemon is running, `/sweep` and the daemon may both try to claim the same `loom:issue` label.
 
 **Coexistence behavior:** before the first wave, check whether the daemon is running. If it is, warn the user once at the start of the sweep:

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -232,7 +232,7 @@ GitHub Actions workflows under `.github/workflows/loom-*.yml` provide a daemon-f
 2. Uncomment the `schedule:` / `- cron:` lines in each `.github/workflows/loom-*.yml` you want to enable.
 3. Optionally trigger a run via `workflow_dispatch` (the Actions UI's "Run workflow" button) to smoke-test before the next scheduled tick.
 
-Architect and Hermit cadence (work-generation triggers) is intentionally out of scope here — see follow-up #3381. Post-v0.10.0, the schedule-driven cron workflows are the recommended path for support roles since the Python daemon brain is removed. Operators who want support roles co-located with the issue-work pane can still run them in tmux via `./.loom/scripts/daemon.sh` (each pane gets its own rotated OAuth token, unlike the GH Actions workflows which use a single API key).
+Architect and Hermit cadence (work-generation triggers) is intentionally out of scope here — see follow-up #3381. Post-v0.10.0, the schedule-driven cron workflows are the recommended path for support roles since the Python daemon brain is removed. Operators who want support roles co-located with the issue-work pane can still run them in tmux via `./.loom/scripts/daemon.sh` (each pane gets its own rotated OAuth token, unlike the GH Actions workflows which use a single API key) — **but note: `./.loom/scripts/daemon.sh` is currently absent on `origin/main` (deleted in #3432, rebuild in flight under epic #3449, ~4-6 weeks); until that lands, use the GH Actions workflows or `./.loom/scripts/spawn-loop.sh`.**
 
 ## Agent Roles
 
@@ -306,7 +306,11 @@ Full role definitions with detailed guidelines are available in:
 - `.loom/roles/guide.md` - Issue triage and prioritization
 - `.loom/roles/auditor.md` - Main branch validation
 
-> **Note**: the historical `shepherd.md` (single-issue orchestrator) role file was removed in v0.10.0 along with the `/shepherd` slash command — see [the migration guide](../docs/migration/v0.10.0-shepherd-deprecation.md). Its orchestration responsibilities moved to `/loom:sweep` (Tier 1) and the spawn loop + GH Actions cron (Tier 2). The `loom.md` role file is preserved and documents the daemon-mode operator surface (`./.loom/scripts/daemon.sh` + tmux + token-rotated separate Claude Code sessions); the Python brain it historically referenced (`loom_tools/daemon_v2/`) is removed in v0.10.0, but the shell-level daemon surface stays. The worker-role markdown files above are unchanged.
+> **Stop-gap — daemon backend in flight (v0.10.0 rebuild, epic #3449)**
+>
+> `./.loom/scripts/daemon.sh` does not exist on `origin/main` as of v0.9.1; the dispatcher was deleted in #3432 and is being rebuilt in epic #3449 (~4-6 weeks, scheduled for v0.10.0). The note below describes the intended target state. Until Phase A through E of #3449 land, daemon operator commands (`./.loom/scripts/daemon.sh start|stop|status`) will fail with "no such file or directory". Use `./.loom/scripts/spawn-loop.sh` for headless multi-issue dispatch in the interim. Tracker: #3451 (this stop-gap), #3449 (rebuild epic).
+
+> **Note**: the historical `shepherd.md` (single-issue orchestrator) role file was removed in v0.10.0 along with the `/shepherd` slash command — see [the migration guide](../docs/migration/v0.10.0-shepherd-deprecation.md). Its orchestration responsibilities moved to `/loom:sweep` (Tier 1) and the spawn loop + GH Actions cron (Tier 2). The `loom.md` role file is preserved and documents the daemon-mode operator surface (`./.loom/scripts/daemon.sh` + tmux + token-rotated separate Claude Code sessions — see stop-gap warning above re: in-flight rebuild #3449); the Python brain it historically referenced (`loom_tools/daemon_v2/`) is removed in v0.10.0, but the shell-level daemon surface stays. The worker-role markdown files above are unchanged.
 
 ## Label-Based Workflow
 
@@ -614,6 +618,10 @@ An optional deterministic gate runs after the builder agent exits but before PR 
 Repos without a `buildGate` block see zero behavior change. See `.loom/docs/build-gate.md` for the full schema and failure semantics.
 
 ### Spawn-Loop Configuration (Tier 2)
+
+> **Stop-gap — daemon backend in flight (v0.10.0 rebuild, epic #3449)**
+>
+> The paragraph below claims `./.loom/scripts/daemon.sh` "now wraps the spawn loop with tmux + per-pane token rotation". On `origin/main` as of v0.9.1, that file does not exist (deleted in #3432, rebuild in flight under epic #3449, ~4-6 weeks). Until the rebuild lands, the only working multi-issue dispatch backend is `./.loom/scripts/spawn-loop.sh` (headless) or the GitHub Actions cron workflows.
 
 The spawn loop replaces the historical Python daemon brain. Its surface is intentionally narrow — there are no work-generation triggers, no pool-slot bookkeeping, and no state-file-based pipeline tracking. The shell-level daemon surface (`./.loom/scripts/daemon.sh`) is preserved and now wraps the spawn loop with tmux + per-pane token rotation. See [`.loom/docs/daemon-reference.md`](.loom/docs/daemon-reference.md) and [the migration guide](../docs/migration/v0.10.0-shepherd-deprecation.md) for details.
 
@@ -1494,6 +1502,10 @@ Or run the setup script to generate `.mcp.json` automatically:
 
 ## Migration: deprecations targeted for v0.10.0
 
+> **Stop-gap — daemon "preserved" claim is currently aspirational (epic #3449, stop-gap #3451)**
+>
+> The next paragraph says daemon mode "is preserved as a user-facing surface" and that `./.loom/scripts/daemon.sh` "continues to provide a tmux session container". On `origin/main` as of v0.9.1, `./.loom/scripts/daemon.sh` does **not** exist — it was deleted in #3432 and is being rebuilt in epic #3449 over an estimated 4-6 weeks for v0.10.0. The shepherd/Python-daemon-brain deletions are real and shipped; the daemon-shell rebuild is in flight. Until #3449 ships, use `./.loom/scripts/spawn-loop.sh` (headless) or GitHub Actions cron workflows.
+
 Loom is in the middle of an orchestration-architecture migration (epic #3372). In **v0.10.0** (the next planned minor release), the shepherd brain (`loom-tools/src/loom_tools/shepherd/`), the Python daemon brain (`loom-tools/src/loom_tools/daemon_v2/`), and the `/shepherd` slash command will be **deleted** in favour of a minimal spawn loop (#3374) + GitHub Actions workflows (#3375). **Daemon mode itself is preserved as a user-facing surface** — `./.loom/scripts/daemon.sh` continues to provide a tmux session container with multi-account token rotation, re-implemented around the spawn loop. The phased rollout is:
 
 | Phase | Issue | What ships | Status |
@@ -1525,6 +1537,10 @@ Loom is in the middle of an orchestration-architecture migration (epic #3372). I
 - Shell: `source .loom/scripts/lib/deprecation.sh; warn_deprecated <component> <replacement> [ref]` — the bash helper is safe to source (no side effects).
 
 ## Migrating off shepherd (downstream consumers, Phase 4 of #3372)
+
+> **Stop-gap reminder — daemon "preserved" claim is currently aspirational (epic #3449, stop-gap #3451)**
+>
+> The references to `./.loom/scripts/daemon.sh` below describe the intended v0.10.0 target state. As of v0.9.1, that file does **not** exist on `origin/main` (deleted in #3432, rebuild in flight under epic #3449, ~4-6 weeks). Until that lands, downstream consumers should treat the "daemon.sh preserved" prose as forward-looking and use `./.loom/scripts/spawn-loop.sh` (headless) or GitHub Actions cron workflows.
 
 If you installed Loom via `scripts/install-loom.sh` (or `install.sh`), the shepherd brain (`loom-tools/src/loom_tools/shepherd/`), the Python daemon brain (`loom-tools/src/loom_tools/daemon_v2/`), and the `/shepherd` slash command are scheduled for **deletion in v0.10.0** (Phase 3 of epic #3372, tracked as part of #3382). **The user-facing daemon mode surface — `./.loom/scripts/daemon.sh` + tmux + token rotation — is preserved**, just re-implemented around the spawn loop. This section is the migration guide for downstream consumers; it complements the upstream phase table in the section above.
 

--- a/docs/migration/v0.10.0-shepherd-deprecation.md
+++ b/docs/migration/v0.10.0-shepherd-deprecation.md
@@ -1,5 +1,11 @@
 # v0.10.0 Migration Guide — shepherd deprecation
 
+> **⚠️ Stop-gap notice — daemon "preserved" claim is currently aspirational (epic #3449, stop-gap #3451)**
+>
+> Throughout this guide, the prose says daemon mode is "preserved" via `./.loom/scripts/daemon.sh`, re-implemented around the spawn loop + tmux. **As of v0.9.1, `./.loom/scripts/daemon.sh` does not exist on `origin/main`** — the dispatcher was deleted in #3432 and is being rebuilt in epic #3449 (~4-6 weeks, scheduled for v0.10.0). The shepherd brain and the Python daemon brain deletions described below are real and shipped; the daemon-shell rebuild is in flight.
+>
+> Until #3449 ships, every operator invocation of `./.loom/scripts/daemon.sh {start,stop,status}` referenced in this guide will fail with "no such file or directory". Use `./.loom/scripts/spawn-loop.sh` (headless, multi-issue) or the GitHub Actions cron workflows in the interim. The full doc rewrite is Phase E of #3449; this stop-gap (#3451) inserts only this warning.
+
 > **Audience**: anyone with an installed copy of Loom (via `install.sh` /
 > `scripts/install-loom.sh`) who has been running the Python `loom-shepherd`
 > CLI, the `/shepherd` Claude Code slash command, or the Python


### PR DESCRIPTION
## Summary

Stop-gap (#3451) ahead of the daemon-backend rebuild (epic #3449). Several docs claim `./.loom/scripts/daemon.sh` is "preserved" and re-implemented around the spawn loop + tmux. **That file does not exist on `origin/main` as of v0.9.1** — it was deleted in #3432 and is being rebuilt over an estimated 4-6 weeks under epic #3449 for v0.10.0. Until that ships, every operator who reads the docs and tries `./.loom/scripts/daemon.sh start` gets "no such file or directory".

This PR inserts visible stop-gap warning blocks into each affected section so the doc-fiction does not actively mislead operators during the rebuild window. **This is NOT the Phase E full doc rewrite** (which depends on the daemon actually shipping); it is the pre-Phase-A warning insertion only.

## What changed per file

- **`CLAUDE.md`** (top-level): three stop-gap warning blocks (Agent Roles note, Spawn-Loop Configuration, Migration section). Phase 3 table row downgraded to "partial — daemon.sh re-implementation in flight under #3449". Removed-entry-points table now points to #3449 instead of unqualified "preserved".
- **`defaults/CLAUDE.md`** (installer source, mirrors top-level): three stop-gap warning blocks at parallel sections; inline qualifier on the GH-Actions/tmux paragraph in the "Scheduled support roles" section.
- **`defaults/.claude/commands/loom/loom.md`** (target of the `defaults/roles/loom.md` symlink — the `/loom` skill role file): **file-level stop-gap warning at the top**. Stronger framing per the issue's acceptance-criterion 3 alternate: the entire skill describes a target state not yet shipped; invoking `/loom` in v0.9.x is a no-op because there is no daemon process to observe or signal.
- **`defaults/.claude/commands/loom/sweep.md`**: inline stop-gap note above the **Daemon Coexistence** PID-check block. The PID check itself is a defensive coexistence guard (no-op in v0.9.x); the warning clarifies why the `./.loom/scripts/daemon.sh stop` instruction in its echo text is forward-looking.
- **`docs/migration/v0.10.0-shepherd-deprecation.md`**: top-level stop-gap notice ahead of the existing Audience/Status block. Reframes the doc: the shepherd brain and Python daemon brain deletions described below ARE shipped; the daemon-shell rebuild ("preserved" claim) is in-flight under #3449.
- **`.loom/docs/daemon-reference.md`**: inserted stop-gap warning at the top of the canonical daemon reference. This file was not in the issue body's explicit 5-file list, but it is the most operator-facing of the additional grep hits and uses the same warning pattern as the in-scope files.

## Acceptance grep (criterion 5)

Per the issue:

```bash
grep -rn '\.loom/scripts/daemon\.sh' --include='*.md' --include='*.sh' \
  | grep -v -E '#3449|/migration/'
```

After this PR:

- Hits in the **5 in-scope files** (`CLAUDE.md`, `defaults/CLAUDE.md`, `defaults/.claude/commands/loom/loom.md`, `defaults/.claude/commands/loom/sweep.md`, and the migration guide via `/migration/` carve-out) are all inside sections that now carry a clearly-marked stop-gap warning block (Acceptance criteria 1, 2, 3, 4 satisfied — the warnings are visible at the top of each affected section, with cross-references to #3449 and #3451).
- Hits in **out-of-scope files** remain: `CHANGELOG.md` (historical changelog record — should not be retroactively edited), `loom.sh` (root wrapper script — code, not docs, hence out of scope per "docs only" constraint), `docs/agents.md`, `docs/adr/0009-shepherd-deprecation.md`, `docs/guides/quickstart-tutorial.md`, `defaults/.loom/CLAUDE.md`, `defaults/scripts/spawn-loop.sh`, `scripts/install-loom.sh`, `scripts/install/create-pr.sh`. These were not in the issue's bounded scope and would expand the patch significantly. **Recommendation**: file a follow-up issue if a stricter zero-residual-hits posture is desired; this PR meets the stated scope of #3451.

## Test plan

- [x] All edits are markdown-only; no code, no tests, no `.loom/scripts/daemon.sh` creation
- [x] Acceptance grep run; in-scope file hits are all qualified by a visible warning block
- [x] Each in-scope file reads coherently — warnings are inserted as block quotes above the existing prose, not as inline edits to the prose itself

Closes #3451
Refs #3449 (rebuild epic), #3432 (the deletion that triggered this stop-gap)

Generated with Claude Code (https://claude.com/claude-code)