### PR TITLE
feat(loom-daemon): Phase B — pub/sub event bus + sweep-child publishing (#3453)

### DIFF
--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -833,6 +833,101 @@ The full `/sweep` design in #3298 includes many features that are intentionally 
 
 For the full design discussion (including the open questions raised by the curator), see issue #3298.
 
+## Daemon event bus (Phase B of #3449 — #3453)
+
+When the in-process **loom-daemon** is running, the sweep child **must** publish phase-transition events onto the daemon's in-memory pub/sub bus so monitoring tools, the spawn loop, and any subscribed MCP layer can react in real time. This is the **wire-protocol contract** the skill exposes to the daemon (and via the daemon to the rest of Loom).
+
+The bus is an in-process `tokio::sync::broadcast::channel<Event>` with a default capacity of **1024** events. It is **not** NATS/ZeroMQ — it lives only inside the running daemon and is gone the moment the daemon exits. Subscribers route by **topic prefix** (segment-aligned — `sweep.issue` matches `sweep.issue.123.phase` but not `sweep.issuetype.foo`). Slow subscribers receive a synthetic `topic_lag` event when they fall behind, then resume at the current channel head (pass-through, no silent drops; matches tokio's `Receiver::Lagged` semantics).
+
+### When to publish
+
+Publish a `sweep.issue.{N}.phase` event **immediately after the sweep skill commits a phase transition** — i.e. once the phase is durable in the forge (label flipped, comment posted, checkpoint written via `sweep-checkpoint.sh`). Do not publish before the side effects have landed; downstream subscribers treat the event as the authoritative signal that the phase is complete.
+
+Publish a `sweep.issue.{N}.blocker` event when the skill chooses to mark the issue with a Loom-recognized blocker label (e.g., `loom:blocked`, `loom:operator-only`) and exits the lifecycle without proceeding to the next phase.
+
+The daemon publishes `sweep.issue.{N}.exited`, `sweep.issue.{N}.crashed`, `sweep.global.dispatch`, and `sweep.global.completed` itself — the sweep child does **not** publish those.
+
+### Topic taxonomy (frozen for v0.10.0)
+
+The following six topics are the **entire** event vocabulary for v0.10.0. New topics require a follow-up issue — do not invent topics outside this table.
+
+| Topic | Publisher | Payload (JSON) |
+|-------|-----------|----------------|
+| `sweep.issue.{N}.phase` | Sweep child via `PublishEvent` | `{"phase": "<phase-name>", "pr_number": <int or null>}` |
+| `sweep.issue.{N}.blocker` | Sweep child | `{"reason": "<short-text>", "label_added": "<label>"}` |
+| `sweep.issue.{N}.exited` | Daemon reaper | `{"exit_code": <int or null>, "duration_sec": <int>}` |
+| `sweep.issue.{N}.crashed` | Daemon reaper | `{"checkpoint_phase": "<phase-name or null>"}` |
+| `sweep.global.dispatch` | Daemon | `{"sweep_id": "<id>", "kind": {"type": "Issue", "value": <N>}}` |
+| `sweep.global.completed` | Daemon | `{"sweep_id": "<id>", "outcome": "exited" | "crashed"}` |
+
+`{N}` is the issue number (a positive integer). Phase names match the sweep-checkpoint schema (#3373): `curator`, `builder`, `judge`, `doctor`, `merge`, etc.
+
+### How to publish — IPC contract
+
+The daemon exposes a `Request::PublishEvent { topic, payload }` variant over its line-delimited JSON Unix-socket framing (the same socket used for `DispatchSweep`, `ListSweeps`, etc. — see `loom-daemon/src/ipc.rs`). One request → one `Response::EventPublished { topic, receivers }` ack frame.
+
+**Sample wire frame** — sweep child advertises that it just finished the builder phase and opened PR #501:
+
+```json
+{"type": "PublishEvent", "payload": {"topic": "sweep.issue.123.phase", "payload": {"phase": "builder", "pr_number": 501}}}
+```
+
+The daemon responds with:
+
+```json
+{"type": "EventPublished", "payload": {"topic": "sweep.issue.123.phase", "receivers": 2}}
+```
+
+If no subscribers are listening, `receivers` is `0` and the event is dropped. **This is not an error condition** — the sweep child treats `receivers: 0` as "best-effort delivery, nobody home" and continues. Do not retry; the event is fire-and-forget.
+
+### Sample payloads for the six initial topics
+
+The following six samples are the authoritative reference for the payload schema of each frozen topic.
+
+```json
+{"type": "PublishEvent", "payload": {"topic": "sweep.issue.123.phase", "payload": {"phase": "curator", "pr_number": null}}}
+{"type": "PublishEvent", "payload": {"topic": "sweep.issue.123.phase", "payload": {"phase": "builder", "pr_number": 501}}}
+{"type": "PublishEvent", "payload": {"topic": "sweep.issue.123.phase", "payload": {"phase": "judge", "pr_number": 501}}}
+{"type": "PublishEvent", "payload": {"topic": "sweep.issue.123.phase", "payload": {"phase": "merge", "pr_number": 501}}}
+{"type": "PublishEvent", "payload": {"topic": "sweep.issue.123.blocker", "payload": {"reason": "missing credentials", "label_added": "loom:operator-only"}}}
+{"type": "PublishEvent", "payload": {"topic": "sweep.issue.456.blocker", "payload": {"reason": "dependent on #999", "label_added": "loom:blocked"}}}
+```
+
+The daemon-side events (these are **emitted by the daemon**, not by the sweep child — included here as the contract for subscribers):
+
+```json
+{"type": "EventStream", "payload": {"events": [{"type": "SweepExited", "issue": 123, "exit_code": 0, "duration_sec": 1842}]}}
+{"type": "EventStream", "payload": {"events": [{"type": "SweepCrashed", "issue": 456, "checkpoint_phase": "judge"}]}}
+{"type": "EventStream", "payload": {"events": [{"type": "SweepGlobalDispatch", "sweep_id": "sweep-issue-789-1717599600", "kind": {"type": "Issue", "value": 789}}]}}
+{"type": "EventStream", "payload": {"events": [{"type": "SweepGlobalCompleted", "sweep_id": "sweep-issue-123-1717599600", "outcome": "exited"}]}}
+```
+
+### Subscription (for tooling, not the sweep child)
+
+Long-running monitors subscribe with a single `Request::SubscribeEvents { topics }` frame and receive a stream of `Response::EventStream { events }` frames on the same open connection. Topic matching is prefix-aligned: `["sweep.issue.123"]` matches every event for issue 123; `["sweep.global"]` matches the two global topics; `[]` (empty list) matches everything on the bus.
+
+```json
+{"type": "SubscribeEvents", "payload": {"topics": ["sweep.issue.123", "sweep.global.completed"]}}
+```
+
+The sweep child itself does **not** subscribe — it only publishes. Subscription is consumed by the spawn loop, the operator-facing monitoring tools slated for Phase C (#3454), and any custom MCP-bridged tool an operator wires up.
+
+### Failure modes (publisher side)
+
+- **Daemon not running**: the Unix-socket connect fails. The sweep child must treat this as a soft error and continue without publishing — Loom is designed to run without the daemon. Log a single `debug` line and proceed.
+- **Daemon running but no subscribers**: `Response::EventPublished { receivers: 0 }`. Fire-and-forget; continue.
+- **Bus capacity exhausted on the subscriber side**: the slow subscriber sees a `topic_lag` event; **the publisher is unaffected** and never blocks. The bus is bounded but tokio's broadcast channel has pass-through overflow on the receiver, not the sender.
+
+### Out-of-scope for Phase B
+
+These are deferred to Phase C (#3454) and Phase D follow-ups — do **not** implement them in the sweep skill:
+
+- Operator-facing MCP tools (`get_sweep_status`, `subscribe_to_events`, `tail_event_bus`) — Phase C.
+- New topics beyond the six listed — frozen for v0.10.0 per epic #3449; file a follow-up issue if you "need" one.
+- Distributed bus / cross-daemon coordination — explicit non-goal (single broker, in-process).
+- Persistent event log or replay — explicit non-goal (transient bus).
+- Consumer groups / durable subscriptions — explicit non-goal.
+
 ## Reference Documentation
 
 - **Shepherd lifecycle**: `.claude/commands/loom/shepherd-lifecycle.md` — canonical per-issue lifecycle.

--- a/loom-daemon/src/event_bus.rs
+++ b/loom-daemon/src/event_bus.rs
@@ -1,0 +1,600 @@
+//! In-memory pub/sub event bus for the loom-daemon
+//! (Issue #3453, Phase B of epic #3449).
+//!
+//! # Overview
+//!
+//! This module provides a lightweight in-process pub/sub bus that
+//! coordinates sweep-lifecycle events between the daemon, the reaper task,
+//! and external subscribers (the MCP layer, monitoring tools, etc.).
+//!
+//! The bus is **NOT** NATS/ZeroMQ. It is a thin wrapper around
+//! [`tokio::sync::broadcast`] with:
+//!
+//! - A bounded channel (default capacity 1,024 — see [`DEFAULT_CAPACITY`]).
+//! - Prefix-match topic routing (`sweep.issue.*` matches
+//!   `sweep.issue.123.phase`).
+//! - Pass-through overflow semantics — slow subscribers receive a
+//!   [`Event::TopicLag`] sentinel and continue from the current channel
+//!   position. Matches tokio's `Receiver::Lagged` overflow behaviour.
+//!
+//! # Topic taxonomy (frozen for v0.10.0)
+//!
+//! | Topic | Publisher | Payload |
+//! |-------|-----------|---------|
+//! | `sweep.issue.{N}.phase`   | Sweep child via `PublishEvent` | `{phase, pr_number?}` |
+//! | `sweep.issue.{N}.blocker` | Sweep child | `{reason, label_added}` |
+//! | `sweep.issue.{N}.exited`  | Daemon reaper | `{exit_code, duration_sec}` |
+//! | `sweep.issue.{N}.crashed` | Daemon reaper | `{checkpoint_phase}` |
+//! | `sweep.global.dispatch`   | Daemon | `{sweep_id, kind}` |
+//! | `sweep.global.completed`  | Daemon | `{sweep_id, outcome}` |
+//!
+//! New topics require a follow-up issue — the taxonomy is intentionally
+//! pinned. The bus accepts arbitrary topic strings (`publish` does not
+//! reject unknown topics) so the publisher side stays open for future
+//! extension, but the documented taxonomy is the contract subscribers
+//! should rely on for v0.10.0.
+
+use crate::types::Event;
+
+use std::collections::HashSet;
+use tokio::sync::broadcast;
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/// Default broadcast channel capacity. Matches the curator's frozen
+/// architectural default (`1024`).
+pub const DEFAULT_CAPACITY: usize = 1024;
+
+// ============================================================================
+// Event bus
+// ============================================================================
+
+/// In-memory pub/sub event bus.
+///
+/// Cloning the bus is **not** the way to add subscribers — call
+/// [`EventBus::subscribe`] instead. Wrap the bus in an `Arc` if you need
+/// to share it across tasks (the daemon's main wiring does so).
+#[derive(Debug)]
+pub struct EventBus {
+    tx: broadcast::Sender<Event>,
+    capacity: usize,
+}
+
+impl EventBus {
+    /// Construct a new bus with the default capacity (1024).
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_CAPACITY)
+    }
+
+    /// Construct a new bus with an explicit channel capacity.
+    #[must_use]
+    pub fn with_capacity(capacity: usize) -> Self {
+        let (tx, _rx) = broadcast::channel(capacity);
+        Self { tx, capacity }
+    }
+
+    /// Channel capacity as configured at construction.
+    #[must_use]
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Number of currently active subscribers (excludes the internal
+    /// sender). Exposed for tests/metrics.
+    #[must_use]
+    pub fn receiver_count(&self) -> usize {
+        self.tx.receiver_count()
+    }
+
+    /// Publish an event to the bus.
+    ///
+    /// Returns `Ok(receiver_count)` on success or `Err(0)` when no
+    /// receivers are active (matches the underlying `broadcast::Sender::send`
+    /// convention but using `usize` directly so callers don't need to
+    /// import tokio types).
+    pub fn publish(&self, event: Event) -> Result<usize, PublishError> {
+        match self.tx.send(event) {
+            Ok(n) => Ok(n),
+            Err(_) => Err(PublishError::NoSubscribers),
+        }
+    }
+
+    /// Convenience helper: build a `Generic` event and publish it.
+    pub fn publish_generic(
+        &self,
+        topic: impl Into<String>,
+        payload: serde_json::Value,
+    ) -> Result<usize, PublishError> {
+        self.publish(Event::Generic {
+            topic: topic.into(),
+            payload,
+        })
+    }
+
+    /// Subscribe to a set of topic prefixes.
+    ///
+    /// The returned [`Subscription`] wraps a `tokio::sync::broadcast::Receiver`
+    /// with a topic-filter applied at receive time. Pass an empty slice
+    /// to receive **all** events on the bus (useful for debugging and
+    /// the operator-facing `tail_event_bus` MCP tool slated for Phase C).
+    ///
+    /// Topic matching is **prefix match**, not glob:
+    ///
+    /// - `sweep.issue.123` matches `sweep.issue.123.phase`
+    /// - `sweep.issue` matches `sweep.issue.123.phase`, `sweep.issue.456.exited`, etc.
+    /// - `sweep` matches every event whose topic starts with `sweep`
+    /// - Empty string matches everything (treated identically to an empty filter set)
+    #[must_use]
+    pub fn subscribe<I, S>(&self, topics: I) -> Subscription
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let topics: HashSet<String> = topics.into_iter().map(Into::into).collect();
+        let receive_all = topics.is_empty() || topics.contains("");
+        Subscription {
+            rx: self.tx.subscribe(),
+            topics,
+            receive_all,
+        }
+    }
+}
+
+impl Default for EventBus {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ============================================================================
+// Publish errors
+// ============================================================================
+
+/// Error type returned by [`EventBus::publish`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PublishError {
+    /// No active subscribers — the event was dropped. This is *not* an
+    /// error condition for fire-and-forget callers; the daemon-side
+    /// publish sites log at `debug` level and continue.
+    NoSubscribers,
+}
+
+impl std::fmt::Display for PublishError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoSubscribers => write!(f, "no active subscribers"),
+        }
+    }
+}
+
+impl std::error::Error for PublishError {}
+
+// ============================================================================
+// Subscription
+// ============================================================================
+
+/// A topic-filtered subscription on the event bus.
+///
+/// Wraps a `tokio::sync::broadcast::Receiver` and filters events by
+/// topic prefix at receive time. The subscription's overflow behaviour
+/// matches the underlying broadcast channel: when the receiver lags
+/// behind the publisher beyond the channel's capacity, [`recv`] returns
+/// a synthetic [`Event::TopicLag`] event and resumes from the current
+/// channel head (the operator-visible signal that some events were
+/// missed, matching tokio's `Lagged` semantics).
+///
+/// [`recv`]: Subscription::recv
+#[derive(Debug)]
+pub struct Subscription {
+    rx: broadcast::Receiver<Event>,
+    topics: HashSet<String>,
+    /// When true, the filter is a no-op and every event is delivered.
+    receive_all: bool,
+}
+
+impl Subscription {
+    /// Receive the next event matching this subscription's topics.
+    ///
+    /// Returns:
+    ///
+    /// - `Ok(event)` — a normal event or a synthetic [`Event::TopicLag`].
+    /// - `Err(RecvError::Closed)` — the bus has been dropped.
+    ///
+    /// Internally this loops past non-matching events; only events whose
+    /// topic prefix-matches one of this subscription's filters (or all
+    /// events, when the filter set is empty) are returned to the caller.
+    pub async fn recv(&mut self) -> Result<Event, RecvError> {
+        loop {
+            match self.rx.recv().await {
+                Ok(event) => {
+                    if self.matches(&event) {
+                        return Ok(event);
+                    }
+                    // Otherwise loop and consume the next event.
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    return Err(RecvError::Closed);
+                }
+                Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                    // Slow-subscriber overflow. Emit a topic_lag sentinel
+                    // so the subscriber gets a clear signal that some
+                    // events were dropped — pass-through, don't silently
+                    // skip. Matches tokio's broadcast Lagged semantics.
+                    return Ok(Event::TopicLag { skipped });
+                }
+            }
+        }
+    }
+
+    /// Try to receive a single event without blocking. Returns
+    /// `Err(RecvError::Empty)` when no events are available. Useful for
+    /// tests and polling-style consumers.
+    pub fn try_recv(&mut self) -> Result<Event, RecvError> {
+        loop {
+            match self.rx.try_recv() {
+                Ok(event) => {
+                    if self.matches(&event) {
+                        return Ok(event);
+                    }
+                }
+                Err(broadcast::error::TryRecvError::Empty) => return Err(RecvError::Empty),
+                Err(broadcast::error::TryRecvError::Closed) => return Err(RecvError::Closed),
+                Err(broadcast::error::TryRecvError::Lagged(skipped)) => {
+                    return Ok(Event::TopicLag { skipped });
+                }
+            }
+        }
+    }
+
+    /// Returns the current topic filter set (read-only). Empty means
+    /// "receive all events".
+    #[must_use]
+    pub fn topics(&self) -> &HashSet<String> {
+        &self.topics
+    }
+
+    /// Topic-prefix match against the subscription's filter set.
+    ///
+    /// Returns `true` when the event's topic starts with at least one of
+    /// the configured topic-prefix strings. The empty prefix and empty
+    /// filter set both match every topic.
+    fn matches(&self, event: &Event) -> bool {
+        if self.receive_all {
+            return true;
+        }
+        let topic = event.topic();
+        self.topics
+            .iter()
+            .any(|prefix| topic_matches(&topic, prefix))
+    }
+}
+
+/// Errors returned by [`Subscription::recv`] and [`Subscription::try_recv`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecvError {
+    /// The bus has been dropped — no further events will arrive.
+    Closed,
+    /// `try_recv` only: no event is currently buffered.
+    Empty,
+}
+
+impl std::fmt::Display for RecvError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Closed => write!(f, "event bus closed"),
+            Self::Empty => write!(f, "no events available"),
+        }
+    }
+}
+
+impl std::error::Error for RecvError {}
+
+// ============================================================================
+// Topic-prefix matching helper
+// ============================================================================
+
+/// Prefix-match `topic` against `prefix`.
+///
+/// Returns true when:
+///
+/// - `prefix` is empty (matches everything), OR
+/// - `topic == prefix` (exact match), OR
+/// - `topic.starts_with(format!("{prefix}."))` — segment-aligned prefix.
+///
+/// The segment-alignment rule prevents `sweep.iss` from matching
+/// `sweep.issue.123` (which would be a glob-style match but not the
+/// intended dot-segmented prefix). Operators specifying prefixes like
+/// `sweep.issue` get all `sweep.issue.*` events without accidentally
+/// including a hypothetical `sweep.issuetype.foo` event.
+#[must_use]
+pub fn topic_matches(topic: &str, prefix: &str) -> bool {
+    if prefix.is_empty() {
+        return true;
+    }
+    if topic == prefix {
+        return true;
+    }
+    // Segment-aligned: topic must continue with a '.' after the prefix.
+    if let Some(rest) = topic.strip_prefix(prefix) {
+        return rest.starts_with('.');
+    }
+    false
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use crate::types::{Event, SweepKind};
+    use serde_json::json;
+
+    fn phase_event(issue: u32, phase: &str) -> Event {
+        Event::SweepPhase {
+            issue,
+            phase: phase.to_string(),
+            pr_number: None,
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Topic-prefix matching
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn topic_matches_empty_prefix_matches_all() {
+        assert!(topic_matches("anything.at.all", ""));
+        assert!(topic_matches("", ""));
+    }
+
+    #[test]
+    fn topic_matches_exact_match() {
+        assert!(topic_matches("sweep.issue.123.phase", "sweep.issue.123.phase"));
+    }
+
+    #[test]
+    fn topic_matches_segment_prefix() {
+        // sweep.issue prefix should match sweep.issue.123.phase
+        assert!(topic_matches("sweep.issue.123.phase", "sweep.issue"));
+        // sweep prefix should match anything under sweep.*
+        assert!(topic_matches("sweep.global.dispatch", "sweep"));
+        assert!(topic_matches("sweep.issue.42.exited", "sweep"));
+    }
+
+    #[test]
+    fn topic_matches_rejects_non_segment_prefix() {
+        // 'sweep.iss' should NOT match 'sweep.issue.123' — the prefix is
+        // not segment-aligned. This guards against accidental matches on
+        // half-word prefixes.
+        assert!(!topic_matches("sweep.issue.123", "sweep.iss"));
+        // A prefix that is a different sibling segment doesn't match.
+        assert!(!topic_matches("sweep.global.dispatch", "sweep.issue"));
+    }
+
+    #[test]
+    fn topic_matches_rejects_unrelated() {
+        assert!(!topic_matches("sweep.issue.123.phase", "other.topic"));
+    }
+
+    // ------------------------------------------------------------------
+    // EventBus construction
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn bus_default_capacity_is_1024() {
+        let bus = EventBus::new();
+        assert_eq!(bus.capacity(), DEFAULT_CAPACITY);
+        assert_eq!(bus.capacity(), 1024);
+    }
+
+    #[test]
+    fn bus_custom_capacity() {
+        let bus = EventBus::with_capacity(64);
+        assert_eq!(bus.capacity(), 64);
+    }
+
+    #[test]
+    fn bus_receiver_count_tracks_subscriptions() {
+        let bus = EventBus::new();
+        assert_eq!(bus.receiver_count(), 0);
+        let _sub_a = bus.subscribe::<[&str; 0], &str>([]);
+        assert_eq!(bus.receiver_count(), 1);
+        let _sub_b = bus.subscribe(["sweep.issue"]);
+        assert_eq!(bus.receiver_count(), 2);
+        drop(_sub_a);
+        assert_eq!(bus.receiver_count(), 1);
+    }
+
+    // ------------------------------------------------------------------
+    // Publish/subscribe routing
+    // ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn publish_routes_to_matching_subscriber() {
+        let bus = EventBus::new();
+        let mut sub = bus.subscribe(["sweep.issue.123"]);
+        let _ignored = bus.publish(phase_event(123, "builder")).unwrap();
+
+        let event = sub.recv().await.unwrap();
+        match event {
+            Event::SweepPhase {
+                issue,
+                phase,
+                pr_number: _,
+            } => {
+                assert_eq!(issue, 123);
+                assert_eq!(phase, "builder");
+            }
+            other => panic!("expected SweepPhase, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn publish_filters_non_matching_topics() {
+        let bus = EventBus::new();
+        let mut sub = bus.subscribe(["sweep.issue.999"]);
+
+        // Two events: 123 should be filtered out, 999 should arrive.
+        let _ = bus.publish(phase_event(123, "builder"));
+        let _ = bus.publish(phase_event(999, "judge"));
+
+        let event = sub.recv().await.unwrap();
+        match event {
+            Event::SweepPhase { issue, .. } => assert_eq!(issue, 999),
+            other => panic!("expected SweepPhase for 999, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_topic_set_receives_all() {
+        let bus = EventBus::new();
+        let mut sub = bus.subscribe::<[&str; 0], &str>([]);
+
+        let _ = bus.publish(phase_event(1, "builder"));
+        let _ = bus.publish_generic(
+            "sweep.global.dispatch",
+            json!({"sweep_id": "abc", "kind": "Issue(7)"}),
+        );
+
+        let first = sub.recv().await.unwrap();
+        let second = sub.recv().await.unwrap();
+        match (first, second) {
+            (Event::SweepPhase { .. }, Event::Generic { .. })
+            | (Event::Generic { .. }, Event::SweepPhase { .. }) => {}
+            other => panic!("unexpected event pair: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn segment_prefix_matches_all_under_namespace() {
+        let bus = EventBus::new();
+        // Subscribe to all sweep.issue.* events
+        let mut sub = bus.subscribe(["sweep.issue"]);
+
+        let _ = bus.publish(phase_event(42, "builder"));
+        let _ = bus.publish(Event::SweepExited {
+            issue: 42,
+            exit_code: Some(0),
+            duration_sec: 12,
+        });
+        let _ = bus.publish_generic("sweep.global.dispatch", json!({"sweep_id": "x"}));
+
+        // Should receive both sweep.issue events but NOT the global one.
+        let e1 = sub.recv().await.unwrap();
+        assert!(e1.topic().starts_with("sweep.issue."));
+        let e2 = sub.recv().await.unwrap();
+        assert!(e2.topic().starts_with("sweep.issue."));
+
+        // try_recv must now return Empty (the global event was filtered).
+        let empty = sub.try_recv();
+        assert!(matches!(empty, Err(RecvError::Empty)));
+    }
+
+    #[tokio::test]
+    async fn publish_with_no_subscribers_returns_error() {
+        let bus = EventBus::new();
+        let result = bus.publish(phase_event(1, "builder"));
+        assert!(matches!(result, Err(PublishError::NoSubscribers)));
+    }
+
+    // ------------------------------------------------------------------
+    // Slow-subscriber overflow -> topic_lag
+    // ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn slow_subscriber_receives_topic_lag_on_overflow() {
+        // Tiny bus (capacity 4) so we can overflow it cheaply.
+        let bus = EventBus::with_capacity(4);
+        let mut sub = bus.subscribe::<[&str; 0], &str>([]);
+
+        // Publish far more events than the channel can hold without
+        // letting `sub` consume — this guarantees a Lagged condition.
+        for i in 0..20 {
+            let _ =
+                bus.publish_generic(format!("sweep.issue.{i}.phase"), json!({"phase": "builder"}));
+        }
+
+        // The first recv() should surface a TopicLag sentinel because
+        // the receiver is so far behind the publisher.
+        let event = sub.recv().await.unwrap();
+        match event {
+            Event::TopicLag { skipped } => {
+                assert!(skipped > 0, "topic_lag should report skipped > 0");
+            }
+            other => panic!("expected TopicLag, got: {other:?}"),
+        }
+
+        // After the lag signal, the subscription should resume at the
+        // current channel head; the next recv() returns a normal event
+        // (one of the post-overflow events still in the buffer).
+        let next = sub.recv().await.unwrap();
+        match next {
+            Event::Generic { topic, .. } => {
+                assert!(topic.starts_with("sweep.issue."));
+            }
+            other => panic!("expected Generic post-lag event, got: {other:?}"),
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Topic-router HashMap behavior (multiple subscribers, different filters)
+    // ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn multiple_subscribers_with_distinct_filters() {
+        let bus = EventBus::new();
+        // Subscriber A watches only one issue.
+        let mut sub_a = bus.subscribe(["sweep.issue.111"]);
+        // Subscriber B watches global events.
+        let mut sub_b = bus.subscribe(["sweep.global"]);
+        // Subscriber C watches everything sweep.*.
+        let mut sub_c = bus.subscribe(["sweep"]);
+
+        let _ = bus.publish(phase_event(111, "builder"));
+        let _ = bus.publish_generic("sweep.global.dispatch", json!({"sweep_id": "abc"}));
+        let _ = bus.publish(phase_event(222, "judge"));
+
+        // A: only issue 111
+        let a1 = sub_a.recv().await.unwrap();
+        match a1 {
+            Event::SweepPhase { issue, .. } => assert_eq!(issue, 111),
+            other => panic!("sub_a expected SweepPhase(111), got: {other:?}"),
+        }
+        assert!(matches!(sub_a.try_recv(), Err(RecvError::Empty)));
+
+        // B: only the global dispatch
+        let b1 = sub_b.recv().await.unwrap();
+        match b1 {
+            Event::Generic { topic, .. } => assert_eq!(topic, "sweep.global.dispatch"),
+            other => panic!("sub_b expected Generic sweep.global.dispatch, got: {other:?}"),
+        }
+        assert!(matches!(sub_b.try_recv(), Err(RecvError::Empty)));
+
+        // C: all three events
+        for _ in 0..3 {
+            let _ = sub_c.recv().await.unwrap();
+        }
+        assert!(matches!(sub_c.try_recv(), Err(RecvError::Empty)));
+    }
+
+    // ------------------------------------------------------------------
+    // Event helper coverage
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn sweep_kind_helper_produces_expected_topic_for_dispatch() {
+        // The Event::SweepGlobalDispatch helper must produce
+        // `sweep.global.dispatch` regardless of SweepKind contents.
+        let ev = Event::SweepGlobalDispatch {
+            sweep_id: "sweep-issue-42-1".to_string(),
+            kind: SweepKind::Issue(42),
+        };
+        assert_eq!(ev.topic(), "sweep.global.dispatch");
+    }
+}

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -1,11 +1,12 @@
 use crate::activity::{ActivityDb, AgentInput, AgentOutput, InputContext, InputType};
 use crate::errors::DaemonError;
+use crate::event_bus::EventBus;
 use crate::forge_parser::parse_forge_events;
 use crate::git_parser;
 use crate::git_utils;
 use crate::sweep_registry::SweepRegistry;
 use crate::terminal::TerminalManager;
-use crate::types::{Request, Response};
+use crate::types::{Event, Request, Response};
 use anyhow::Result;
 use chrono::Utc;
 use std::path::PathBuf;
@@ -43,6 +44,7 @@ pub struct IpcServer {
     terminal_manager: Arc<Mutex<TerminalManager>>,
     activity_db: Arc<Mutex<ActivityDb>>,
     sweep_registry: Arc<Mutex<SweepRegistry>>,
+    event_bus: Arc<EventBus>,
 }
 
 impl IpcServer {
@@ -51,12 +53,14 @@ impl IpcServer {
         terminal_manager: Arc<Mutex<TerminalManager>>,
         activity_db: Arc<Mutex<ActivityDb>>,
         sweep_registry: Arc<Mutex<SweepRegistry>>,
+        event_bus: Arc<EventBus>,
     ) -> Self {
         Self {
             socket_path,
             terminal_manager,
             activity_db,
             sweep_registry,
+            event_bus,
         }
     }
 
@@ -73,8 +77,9 @@ impl IpcServer {
                     let tm = self.terminal_manager.clone();
                     let db = self.activity_db.clone();
                     let sr = self.sweep_registry.clone();
+                    let bus = self.event_bus.clone();
                     tokio::spawn(async move {
-                        if let Err(e) = handle_client(stream, tm, db, sr).await {
+                        if let Err(e) = handle_client(stream, tm, db, sr, bus).await {
                             log::error!("Client error: {e}");
                         }
                     });
@@ -92,6 +97,7 @@ async fn handle_client(
     terminal_manager: Arc<Mutex<TerminalManager>>,
     activity_db: Arc<Mutex<ActivityDb>>,
     sweep_registry: Arc<Mutex<SweepRegistry>>,
+    event_bus: Arc<EventBus>,
 ) -> Result<()> {
     let (reader, mut writer) = stream.into_split();
     let mut lines = BufReader::new(reader).lines();
@@ -100,13 +106,77 @@ async fn handle_client(
         let request: Request = serde_json::from_str(&line)?;
         log::debug!("Request: {request:?}");
 
-        let response = handle_request(request, &terminal_manager, &activity_db, &sweep_registry);
+        // SubscribeEvents is the only structurally-different request: it
+        // returns a stream of `EventStream` frames on the same connection
+        // rather than a single response. Once a client subscribes, the
+        // connection is dedicated to the stream until the client closes
+        // it (or the bus drops).
+        if let Request::SubscribeEvents { topics } = request {
+            stream_events(&event_bus, &mut writer, topics).await?;
+            // After streaming ends (client disconnect or bus closed) the
+            // connection has no more useful state — exit the loop.
+            break;
+        }
+
+        let response =
+            handle_request(request, &terminal_manager, &activity_db, &sweep_registry, &event_bus);
 
         let response_json = serde_json::to_string(&response)?;
         writer.write_all(response_json.as_bytes()).await?;
         writer.write_all(b"\n").await?;
     }
 
+    Ok(())
+}
+
+/// Stream events from the bus to `writer` as long as the bus is alive
+/// and the client connection is open.
+///
+/// This is the streaming-response path used by `Request::SubscribeEvents`.
+/// Each event is encoded as a single `Response::EventStream { events }`
+/// frame containing exactly one event (the `events: Vec<Event>` shape
+/// gives us room to batch in a future revision without a protocol break).
+///
+/// Termination: the loop ends when either
+///
+/// - the bus is dropped (`Subscription::recv` returns `Closed`), or
+/// - `writer.write_all` returns an error (the client closed the socket).
+async fn stream_events(
+    bus: &Arc<EventBus>,
+    writer: &mut tokio::net::unix::OwnedWriteHalf,
+    topics: Vec<String>,
+) -> Result<()> {
+    use crate::event_bus::RecvError;
+
+    let mut subscription = bus.subscribe(topics);
+
+    loop {
+        match subscription.recv().await {
+            Ok(event) => {
+                let frame = Response::EventStream {
+                    events: vec![event],
+                };
+                let frame_json = serde_json::to_string(&frame)?;
+                if writer.write_all(frame_json.as_bytes()).await.is_err() {
+                    // Client disconnected — gracefully exit.
+                    break;
+                }
+                if writer.write_all(b"\n").await.is_err() {
+                    break;
+                }
+            }
+            Err(RecvError::Closed) => {
+                log::debug!("event stream: bus closed, ending subscription");
+                break;
+            }
+            Err(RecvError::Empty) => {
+                // recv() should never return Empty (it blocks); but if
+                // the underlying receiver ever changes semantics, just
+                // yield and try again.
+                tokio::task::yield_now().await;
+            }
+        }
+    }
     Ok(())
 }
 
@@ -119,6 +189,7 @@ fn handle_request(
     terminal_manager: &Arc<Mutex<TerminalManager>>,
     activity_db: &Arc<Mutex<ActivityDb>>,
     sweep_registry: &Arc<Mutex<SweepRegistry>>,
+    event_bus: &Arc<EventBus>,
 ) -> Response {
     match request {
         Request::Ping => Response::Pong,
@@ -722,6 +793,40 @@ fn handle_request(
             Response::SweepList { sweeps }
         }
 
+        // ====================================================================
+        // Event Bus Handlers (Issue #3453 — Phase B of #3449)
+        // ====================================================================
+        Request::PublishEvent { topic, payload } => {
+            // Generic publish path used by sweep children — the topic is
+            // the canonical name (e.g., "sweep.issue.123.phase") and the
+            // payload is opaque JSON. See `defaults/.claude/commands/loom/
+            // sweep.md` for the per-topic payload schema.
+            let event = Event::Generic {
+                topic: topic.clone(),
+                payload,
+            };
+            match event_bus.publish(event) {
+                Ok(receivers) => Response::EventPublished { topic, receivers },
+                Err(_) => Response::EventPublished {
+                    topic,
+                    receivers: 0,
+                },
+            }
+        }
+
+        Request::SubscribeEvents { .. } => {
+            // SubscribeEvents is intercepted in `handle_client` before it
+            // reaches this dispatcher because it requires a streaming
+            // response (not a single Response frame). If this branch is
+            // ever reached, the IPC server's handle_client logic is bugged
+            // — fail loud so it doesn't silently mis-route.
+            Response::Error {
+                message: "internal: SubscribeEvents must be handled by stream_events, not \
+                          handle_request"
+                    .to_string(),
+            }
+        }
+
         Request::Shutdown => {
             log::info!("Shutdown requested");
             std::process::exit(0);
@@ -738,8 +843,12 @@ mod tests {
     use crate::types::{SweepKind, SweepState};
     use tempfile::tempdir;
 
-    fn setup_test_context(
-    ) -> (Arc<Mutex<TerminalManager>>, Arc<Mutex<ActivityDb>>, Arc<Mutex<SweepRegistry>>) {
+    fn setup_test_context() -> (
+        Arc<Mutex<TerminalManager>>,
+        Arc<Mutex<ActivityDb>>,
+        Arc<Mutex<SweepRegistry>>,
+        Arc<EventBus>,
+    ) {
         let tm = Arc::new(Mutex::new(TerminalManager::new()));
         let dir = tempdir().unwrap();
         let db_path = dir.path().join("test_activity.db");
@@ -747,18 +856,21 @@ mod tests {
         let db = Arc::new(Mutex::new(db));
         let mut sr_config = SweepRegistryConfig::new(dir.path().to_path_buf());
         sr_config.skip_label_flip = true;
-        let sr = Arc::new(Mutex::new(SweepRegistry::new(sr_config)));
+        let bus = Arc::new(EventBus::new());
+        let mut registry = SweepRegistry::new(sr_config);
+        registry.set_event_bus(bus.clone());
+        let sr = Arc::new(Mutex::new(registry));
         // Keep dir alive so the temp directory isn't deleted
         std::mem::forget(dir);
-        (tm, db, sr)
+        (tm, db, sr, bus)
     }
 
     // ===== Ping/Pong =====
 
     #[test]
     fn test_handle_request_ping() {
-        let (tm, db, sr) = setup_test_context();
-        let response = handle_request(Request::Ping, &tm, &db, &sr);
+        let (tm, db, sr, bus) = setup_test_context();
+        let response = handle_request(Request::Ping, &tm, &db, &sr, &bus);
         assert!(matches!(response, Response::Pong));
     }
 
@@ -766,10 +878,10 @@ mod tests {
 
     #[test]
     fn test_handle_request_list_terminals_empty() {
-        let (tm, db, sr) = setup_test_context();
+        let (tm, db, sr, bus) = setup_test_context();
         // Set LOOM_NO_RESTORE to prevent tmux restore attempts
         std::env::set_var("LOOM_NO_RESTORE", "1");
-        let response = handle_request(Request::ListTerminals, &tm, &db, &sr);
+        let response = handle_request(Request::ListTerminals, &tm, &db, &sr, &bus);
         std::env::remove_var("LOOM_NO_RESTORE");
         match response {
             Response::TerminalList { terminals } => {
@@ -783,7 +895,7 @@ mod tests {
 
     #[test]
     fn test_handle_request_get_current_commit_nonexistent_dir() {
-        let (tm, db, sr) = setup_test_context();
+        let (tm, db, sr, bus) = setup_test_context();
         let response = handle_request(
             Request::GetCurrentCommit {
                 working_dir: "/nonexistent/path".to_string(),
@@ -791,6 +903,7 @@ mod tests {
             &tm,
             &db,
             &sr,
+            &bus,
         );
         match response {
             Response::CurrentCommit { commit } => {
@@ -804,7 +917,7 @@ mod tests {
 
     #[test]
     fn test_handle_request_get_terminal_activity_empty() {
-        let (tm, db, sr) = setup_test_context();
+        let (tm, db, sr, bus) = setup_test_context();
         let response = handle_request(
             Request::GetTerminalActivity {
                 id: "nonexistent".to_string(),
@@ -813,6 +926,7 @@ mod tests {
             &tm,
             &db,
             &sr,
+            &bus,
         );
         match response {
             Response::TerminalActivity { entries } => {
@@ -826,8 +940,8 @@ mod tests {
 
     #[test]
     fn test_handle_request_get_all_claims_empty() {
-        let (tm, db, sr) = setup_test_context();
-        let response = handle_request(Request::GetAllClaims, &tm, &db, &sr);
+        let (tm, db, sr, bus) = setup_test_context();
+        let response = handle_request(Request::GetAllClaims, &tm, &db, &sr, &bus);
         match response {
             Response::Claims(claims) => {
                 assert!(claims.is_empty());
@@ -840,7 +954,7 @@ mod tests {
 
     #[test]
     fn test_handle_request_get_claims_summary() {
-        let (tm, db, sr) = setup_test_context();
+        let (tm, db, sr, bus) = setup_test_context();
         let response = handle_request(
             Request::GetClaimsSummary {
                 stale_threshold_secs: Some(3600),
@@ -848,6 +962,7 @@ mod tests {
             &tm,
             &db,
             &sr,
+            &bus,
         );
         match response {
             Response::ClaimsSummary(summary) => {
@@ -861,7 +976,7 @@ mod tests {
 
     #[test]
     fn test_handle_request_capture_git_changes_no_repo() {
-        let (tm, db, sr) = setup_test_context();
+        let (tm, db, sr, bus) = setup_test_context();
         let response = handle_request(
             Request::CaptureGitChanges {
                 input_id: 1,
@@ -871,6 +986,7 @@ mod tests {
             &tm,
             &db,
             &sr,
+            &bus,
         );
         match response {
             Response::GitChangesCaptured {
@@ -933,9 +1049,10 @@ exit 0
 
     #[test]
     fn test_handle_request_list_sweeps_empty() {
-        let (tm, db, _) = setup_test_context();
+        let (tm, db, _, bus) = setup_test_context();
         let (sr, _dir, _rec) = setup_sweep_registry_in_tempdir();
-        let response = handle_request(Request::ListSweeps { state_filter: None }, &tm, &db, &sr);
+        let response =
+            handle_request(Request::ListSweeps { state_filter: None }, &tm, &db, &sr, &bus);
         match response {
             Response::SweepList { sweeps } => {
                 assert!(sweeps.is_empty());
@@ -947,7 +1064,7 @@ exit 0
     #[test]
     #[serial_test::serial]
     fn test_handle_request_dispatch_sweep_happy_path() {
-        let (tm, db, _) = setup_test_context();
+        let (tm, db, _, bus) = setup_test_context();
         let (sr, _dir, _rec) = setup_sweep_registry_in_tempdir();
 
         let response = handle_request(
@@ -958,6 +1075,7 @@ exit 0
             &tm,
             &db,
             &sr,
+            &bus,
         );
         match response {
             Response::SweepDispatched {
@@ -975,7 +1093,8 @@ exit 0
         }
 
         // Follow-up ListSweeps should see the new entry.
-        let response = handle_request(Request::ListSweeps { state_filter: None }, &tm, &db, &sr);
+        let response =
+            handle_request(Request::ListSweeps { state_filter: None }, &tm, &db, &sr, &bus);
         match response {
             Response::SweepList { sweeps } => {
                 assert_eq!(sweeps.len(), 1);
@@ -987,7 +1106,7 @@ exit 0
 
     #[test]
     fn test_handle_request_dispatch_sweep_rejects_prset_in_phase_a() {
-        let (tm, db, _) = setup_test_context();
+        let (tm, db, _, bus) = setup_test_context();
         let (sr, _dir, _rec) = setup_sweep_registry_in_tempdir();
 
         let response = handle_request(
@@ -998,6 +1117,7 @@ exit 0
             &tm,
             &db,
             &sr,
+            &bus,
         );
         match response {
             Response::Error { message } => {
@@ -1007,6 +1127,69 @@ exit 0
                 );
             }
             other => panic!("Expected Error, got: {other:?}"),
+        }
+    }
+
+    // ===== Event bus IPC handlers (Issue #3453, Phase B) =====
+
+    #[tokio::test]
+    async fn test_handle_request_publish_event_routes_to_subscribers() {
+        let (tm, db, sr, bus) = setup_test_context();
+        let mut sub = bus.subscribe::<[&str; 0], &str>([]);
+
+        let response = handle_request(
+            Request::PublishEvent {
+                topic: "sweep.issue.123.phase".to_string(),
+                payload: serde_json::json!({"phase": "builder"}),
+            },
+            &tm,
+            &db,
+            &sr,
+            &bus,
+        );
+
+        match response {
+            Response::EventPublished { topic, receivers } => {
+                assert_eq!(topic, "sweep.issue.123.phase");
+                assert!(receivers >= 1, "expected at least 1 receiver; got {receivers}");
+            }
+            other => panic!("Expected EventPublished, got: {other:?}"),
+        }
+
+        // Subscriber should now see the published event.
+        let ev = sub.recv().await.unwrap();
+        match ev {
+            Event::Generic { topic, payload } => {
+                assert_eq!(topic, "sweep.issue.123.phase");
+                assert_eq!(payload, serde_json::json!({"phase": "builder"}));
+            }
+            other => panic!("Expected Generic event, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_handle_request_subscribe_events_short_circuits_to_error() {
+        // SubscribeEvents must be handled by stream_events (not the
+        // dispatcher). If it ever reaches handle_request, the dispatcher
+        // returns an Error sentinel so the bug is visible.
+        let (tm, db, sr, bus) = setup_test_context();
+        let response = handle_request(
+            Request::SubscribeEvents {
+                topics: vec!["sweep".to_string()],
+            },
+            &tm,
+            &db,
+            &sr,
+            &bus,
+        );
+        match response {
+            Response::Error { message } => {
+                assert!(
+                    message.contains("SubscribeEvents must be handled by stream_events"),
+                    "expected internal-bug error message; got: {message}"
+                );
+            }
+            other => panic!("Expected Error sentinel, got: {other:?}"),
         }
     }
 }

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -12,6 +12,7 @@
 
 pub mod activity;
 pub mod errors;
+pub mod event_bus;
 pub mod forge_parser;
 pub mod git_parser;
 pub mod git_utils;

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -1,4 +1,5 @@
 use loom_daemon::activity::{self, ActivityDb, StatsQueries};
+use loom_daemon::event_bus::EventBus;
 use loom_daemon::health_monitor;
 use loom_daemon::ipc::IpcServer;
 use loom_daemon::metrics_collector;
@@ -205,7 +206,16 @@ async fn main() -> Result<()> {
         .or_else(|| std::env::current_dir().ok())
         .unwrap_or_else(|| std::path::PathBuf::from("."));
     let sweep_config = SweepRegistryConfig::new(sweep_workspace.clone());
-    let mut sweep = SweepRegistry::new(sweep_config);
+
+    // Phase B (#3453): construct the in-memory pub/sub event bus *before*
+    // the sweep registry so we can wire it in at construction time. The
+    // bus is shared between the registry (publisher for reaper + dispatch
+    // events) and the IPC server (publisher for `PublishEvent` requests
+    // from sweep children, plus consumer for `SubscribeEvents` streams).
+    let event_bus = Arc::new(EventBus::new());
+    log::info!("event_bus: started in-memory pub/sub (capacity={})", event_bus.capacity());
+
+    let mut sweep = SweepRegistry::with_event_bus(sweep_config, event_bus.clone());
     match sweep.reconstruct() {
         Ok(0) => log::debug!("sweep_registry: no sweeps to reconstruct"),
         Ok(n) => log::info!(
@@ -218,7 +228,7 @@ async fn main() -> Result<()> {
     let _reaper_handle = sweep_registry::spawn_reaper_task(sweep_registry.clone());
 
     // Start IPC server
-    let server = IpcServer::new(socket_path.clone(), tm, activity_db, sweep_registry);
+    let server = IpcServer::new(socket_path.clone(), tm, activity_db, sweep_registry, event_bus);
 
     // Setup signal handler for graceful shutdown
     let socket_path_clone = socket_path.clone();

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -37,7 +37,8 @@
 //! - Sweep checkpoints under `.loom/sweep-checkpoint/issue-<N>.json` (#3373).
 //! - Forge labels (`loom:issue` vs `loom:building`).
 
-use crate::types::{SweepId, SweepInfo, SweepKind, SweepState};
+use crate::event_bus::EventBus;
+use crate::types::{Event, SweepId, SweepInfo, SweepKind, SweepOutcome, SweepState};
 
 use anyhow::{anyhow, Context, Result};
 use chrono::Utc;
@@ -179,16 +180,50 @@ struct LockOwner {
 pub struct SweepRegistry {
     config: SweepRegistryConfig,
     entries: BTreeMap<SweepId, SweepInfo>,
+    /// Optional event bus for lifecycle events (Issue #3453, Phase B).
+    /// When `None`, the registry behaves identically to Phase A — bus
+    /// emission is best-effort and never blocks core dispatch/reaper
+    /// progress.
+    bus: Option<Arc<EventBus>>,
 }
 
 impl SweepRegistry {
-    /// Construct an empty registry.
+    /// Construct an empty registry without an event bus.
+    ///
+    /// Equivalent to Phase A's behavior. Use [`set_event_bus`](Self::set_event_bus)
+    /// or [`with_event_bus`](Self::with_event_bus) to attach a bus.
     #[must_use]
     pub fn new(config: SweepRegistryConfig) -> Self {
         Self {
             config,
             entries: BTreeMap::new(),
+            bus: None,
         }
+    }
+
+    /// Construct an empty registry with the given event bus pre-attached.
+    #[must_use]
+    pub fn with_event_bus(config: SweepRegistryConfig, bus: Arc<EventBus>) -> Self {
+        Self {
+            config,
+            entries: BTreeMap::new(),
+            bus: Some(bus),
+        }
+    }
+
+    /// Attach (or replace) the event bus used for lifecycle emission.
+    /// Additive setter — exposed so `main.rs` can construct the bus and
+    /// the registry separately, then wire them together at startup.
+    pub fn set_event_bus(&mut self, bus: Arc<EventBus>) {
+        self.bus = Some(bus);
+    }
+
+    /// Read-only accessor for the event bus, if any. Exposed so external
+    /// callers (IPC handlers) can publish directly via the same bus the
+    /// registry uses.
+    #[must_use]
+    pub fn event_bus(&self) -> Option<&Arc<EventBus>> {
+        self.bus.as_ref()
     }
 
     /// Returns a shared, mutex-guarded registry suitable for tokio tasks.
@@ -307,6 +342,14 @@ impl SweepRegistry {
         };
         self.entries.insert(sweep_id.clone(), info);
 
+        // 7. Emit `sweep.global.dispatch` (best-effort — never block
+        //    dispatch progress on the bus). If no subscribers are
+        //    listening, the bus returns NoSubscribers; log at debug.
+        self.emit_event(Event::SweepGlobalDispatch {
+            sweep_id: sweep_id.clone(),
+            kind: kind.clone(),
+        });
+
         Ok(DispatchOutcome {
             sweep_id,
             pid,
@@ -314,6 +357,20 @@ impl SweepRegistry {
             log_path,
             was_new: true,
         })
+    }
+
+    /// Internal helper: publish an event on the attached bus (if any).
+    /// Best-effort — logs a debug line if no subscribers are listening.
+    fn emit_event(&self, event: Event) {
+        if let Some(ref bus) = self.bus {
+            let topic = event.topic();
+            match bus.publish(event) {
+                Ok(n) => log::debug!("event_bus: published {topic} to {n} subscriber(s)"),
+                Err(_) => {
+                    log::debug!("event_bus: published {topic} (no subscribers)");
+                }
+            }
+        }
     }
 
     fn find_running_by_key(&self, key: &str) -> Option<&SweepInfo> {
@@ -501,17 +558,34 @@ impl SweepRegistry {
     /// and GCs entries older than the retention window.
     ///
     /// Returns the number of entries whose state changed.
+    ///
+    /// Emits the following events when an attached event bus is present
+    /// (Issue #3453, Phase B):
+    ///
+    /// - `sweep.issue.{N}.exited` on a clean-exit transition.
+    /// - `sweep.issue.{N}.crashed` on a checkpoint-present transition
+    ///   (which also re-arms the `loom:issue` label).
+    /// - `sweep.global.completed` on every terminal transition, regardless
+    ///   of which per-issue event also fired.
     pub fn reap_once(&mut self) -> usize {
         let mut changes = 0usize;
 
         // Snapshot keys + pids first so we can borrow mutably below.
-        let candidates: Vec<(SweepId, u32, SweepState, SweepKind)> = self
+        // Capture started_at so we can compute durations for Exited events.
+        let candidates: Vec<(SweepId, u32, SweepState, SweepKind, chrono::DateTime<Utc>)> = self
             .entries
             .iter()
-            .map(|(id, info)| (id.clone(), info.pid, info.state.clone(), info.kind.clone()))
+            .map(|(id, info)| {
+                (id.clone(), info.pid, info.state.clone(), info.kind.clone(), info.started_at)
+            })
             .collect();
 
-        for (sweep_id, pid, state, kind) in candidates {
+        // Buffer events to emit after we've finished mutating the
+        // registry — so we never call into the bus while holding the
+        // registry mutex's lifetime budget unnecessarily.
+        let mut events_to_emit: Vec<Event> = Vec::new();
+
+        for (sweep_id, pid, state, kind, started_at) in candidates {
             match state {
                 SweepState::Running | SweepState::Pending if !is_pid_alive(pid) => {
                     changes += 1;
@@ -519,6 +593,8 @@ impl SweepRegistry {
                         SweepKind::Issue(n) => Some(*n),
                         SweepKind::PrSet(_) => None,
                     };
+                    let now = Utc::now();
+                    let duration_sec = (now - started_at).num_seconds();
                     // Release lock and decide between Exited vs Crashed.
                     if let Some(issue) = issue {
                         let _ = self.release_lock(issue);
@@ -530,24 +606,64 @@ impl SweepRegistry {
                             if !self.config.skip_label_flip {
                                 let _ = self.restore_label_to_ready(issue);
                             }
+                            let checkpoint_phase = read_checkpoint_phase(&checkpoint);
                             if let Some(info) = self.entries.get_mut(&sweep_id) {
-                                info.state = SweepState::Crashed { at: Utc::now() };
+                                info.state = SweepState::Crashed { at: now };
+                                if info.latest_phase.is_none() {
+                                    info.latest_phase.clone_from(&checkpoint_phase);
+                                }
                             }
-                        } else if let Some(info) = self.entries.get_mut(&sweep_id) {
+                            events_to_emit.push(Event::SweepCrashed {
+                                issue,
+                                checkpoint_phase,
+                            });
+                            events_to_emit.push(Event::SweepGlobalCompleted {
+                                sweep_id: sweep_id.clone(),
+                                outcome: SweepOutcome::Crashed,
+                            });
+                        } else {
+                            if let Some(info) = self.entries.get_mut(&sweep_id) {
+                                info.state = SweepState::Exited {
+                                    code: None,
+                                    at: now,
+                                };
+                            }
+                            events_to_emit.push(Event::SweepExited {
+                                issue,
+                                exit_code: None,
+                                duration_sec,
+                            });
+                            events_to_emit.push(Event::SweepGlobalCompleted {
+                                sweep_id: sweep_id.clone(),
+                                outcome: SweepOutcome::Exited,
+                            });
+                        }
+                    } else {
+                        if let Some(info) = self.entries.get_mut(&sweep_id) {
                             info.state = SweepState::Exited {
                                 code: None,
-                                at: Utc::now(),
+                                at: now,
                             };
                         }
-                    } else if let Some(info) = self.entries.get_mut(&sweep_id) {
-                        info.state = SweepState::Exited {
-                            code: None,
-                            at: Utc::now(),
-                        };
+                        // PrSet sweeps don't have a single issue id, so we
+                        // only emit the global event. Per-issue events are
+                        // intentionally not emitted for PrSet (out of scope
+                        // for Phase A — see sweep_registry::dispatch).
+                        events_to_emit.push(Event::SweepGlobalCompleted {
+                            sweep_id: sweep_id.clone(),
+                            outcome: SweepOutcome::Exited,
+                        });
                     }
                 }
                 _ => {}
             }
+        }
+
+        // Drain the buffered events onto the bus. Each emission is
+        // best-effort and never propagates an error back into reaper
+        // progress.
+        for event in events_to_emit {
+            self.emit_event(event);
         }
 
         // GC: drop terminal entries past the retention window.
@@ -1030,6 +1146,140 @@ exit 0
 
         let all = registry.list(None);
         assert_eq!(all.len(), 1);
+    }
+
+    /// AC #2: reaper emits `sweep.issue.{N}.crashed` AND re-arms the
+    /// `loom:building` -> `loom:issue` label when a dead pid has a
+    /// checkpoint on disk. We don't actually invoke `gh` here (that's
+    /// covered by integration tests with `skip_label_flip = false`); we
+    /// assert the event payload and the registry state transition, which
+    /// is the contract Phase B exposes to subscribers.
+    #[tokio::test]
+    async fn reaper_emits_crashed_event_with_checkpoint_phase() {
+        use crate::event_bus::EventBus;
+
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+        let bus = Arc::new(EventBus::new());
+        registry.set_event_bus(bus.clone());
+        let mut sub = bus.subscribe::<[&str; 0], &str>([]);
+
+        let cp_dir = registry.config.checkpoint_dir();
+        std::fs::create_dir_all(&cp_dir).unwrap();
+        std::fs::write(cp_dir.join("issue-55.json"), r#"{"phase":"doctor","issue":55}"#).unwrap();
+
+        let sweep_id = "sweep-issue-55-test".to_string();
+        registry.entries.insert(
+            sweep_id.clone(),
+            SweepInfo {
+                sweep_id: sweep_id.clone(),
+                kind: SweepKind::Issue(55),
+                pid: 2_147_483_640,
+                token_name: "unknown".into(),
+                log_path: registry.compute_log_path(55),
+                idempotency_key: None,
+                started_at: Utc::now(),
+                state: SweepState::Running,
+                latest_phase: None,
+                pr_number: None,
+            },
+        );
+
+        let changed = registry.reap_once();
+        assert!(changed >= 1);
+
+        // Should observe: sweep.issue.55.crashed + sweep.global.completed
+        let mut saw_crashed = false;
+        let mut saw_completed = false;
+        for _ in 0..2 {
+            let ev = sub.recv().await.unwrap();
+            match ev {
+                Event::SweepCrashed {
+                    issue,
+                    checkpoint_phase,
+                } => {
+                    assert_eq!(issue, 55);
+                    assert_eq!(checkpoint_phase.as_deref(), Some("doctor"));
+                    saw_crashed = true;
+                }
+                Event::SweepGlobalCompleted {
+                    sweep_id: sid,
+                    outcome,
+                } => {
+                    assert_eq!(sid, sweep_id);
+                    assert_eq!(outcome, SweepOutcome::Crashed);
+                    saw_completed = true;
+                }
+                other => panic!("unexpected event: {other:?}"),
+            }
+        }
+        assert!(saw_crashed, "expected sweep.issue.55.crashed event");
+        assert!(saw_completed, "expected sweep.global.completed event");
+
+        // And the registry state should be Crashed (the label re-arm
+        // side-effect is suppressed because skip_label_flip is true in
+        // the fixture; the contract is the state transition + event
+        // emission, which together signal the re-arm has happened in
+        // production).
+        let info = registry.get(&sweep_id).unwrap();
+        assert!(matches!(info.state, SweepState::Crashed { .. }));
+    }
+
+    /// Clean-exit (no checkpoint) emits `sweep.issue.{N}.exited` plus
+    /// `sweep.global.completed{outcome=Exited}`.
+    #[tokio::test]
+    async fn reaper_emits_exited_event_for_clean_exit() {
+        use crate::event_bus::EventBus;
+
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+        let bus = Arc::new(EventBus::new());
+        registry.set_event_bus(bus.clone());
+        let mut sub = bus.subscribe::<[&str; 0], &str>([]);
+
+        let sweep_id = "sweep-issue-66-test".to_string();
+        registry.entries.insert(
+            sweep_id.clone(),
+            SweepInfo {
+                sweep_id: sweep_id.clone(),
+                kind: SweepKind::Issue(66),
+                pid: 2_147_483_640,
+                token_name: "unknown".into(),
+                log_path: registry.compute_log_path(66),
+                idempotency_key: None,
+                started_at: Utc::now() - chrono::Duration::seconds(10),
+                state: SweepState::Running,
+                latest_phase: None,
+                pr_number: None,
+            },
+        );
+
+        let changed = registry.reap_once();
+        assert!(changed >= 1);
+
+        let mut saw_exited = false;
+        let mut saw_completed = false;
+        for _ in 0..2 {
+            let ev = sub.recv().await.unwrap();
+            match ev {
+                Event::SweepExited {
+                    issue,
+                    duration_sec,
+                    ..
+                } => {
+                    assert_eq!(issue, 66);
+                    assert!(duration_sec >= 0);
+                    saw_exited = true;
+                }
+                Event::SweepGlobalCompleted { outcome, .. } => {
+                    assert_eq!(outcome, SweepOutcome::Exited);
+                    saw_completed = true;
+                }
+                other => panic!("unexpected event: {other:?}"),
+            }
+        }
+        assert!(saw_exited);
+        assert!(saw_completed);
     }
 
     #[test]

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -142,6 +142,37 @@ pub enum Request {
     ListSweeps {
         state_filter: Option<SweepState>,
     },
+    // ========================================================================
+    // Event Bus Requests (Issue #3453 — Phase B of #3449)
+    // ========================================================================
+    /// Publish a sweep-lifecycle event onto the in-memory bus.
+    ///
+    /// `topic` must follow the frozen taxonomy (`sweep.issue.{N}.phase`,
+    /// `sweep.issue.{N}.blocker`, `sweep.issue.{N}.exited`, etc.). The bus
+    /// itself accepts arbitrary topic strings, but downstream consumers
+    /// only subscribe to the documented topics.
+    ///
+    /// `payload` is opaque JSON — the schema is per-topic and documented
+    /// in `defaults/.claude/commands/loom/sweep.md`.
+    PublishEvent {
+        topic: String,
+        payload: serde_json::Value,
+    },
+    /// Subscribe to one or more topic prefixes on the event bus.
+    ///
+    /// This is a long-lived request: instead of returning a single
+    /// `Response`, the daemon streams `Response::EventStream { events }`
+    /// frames over the open connection as events arrive on the bus.
+    /// An empty `topics` vec subscribes to all events on the bus (useful
+    /// for the `tail_event_bus` debug tool slated for Phase C).
+    ///
+    /// Topic matching is **prefix match**, segment-aligned —
+    /// `sweep.issue` matches `sweep.issue.123.phase` but not
+    /// `sweep.issuetype.foo`. See `event_bus::topic_matches` for the
+    /// authoritative routing rule.
+    SubscribeEvents {
+        topics: Vec<String>,
+    },
     Shutdown,
 }
 
@@ -212,6 +243,23 @@ pub enum Response {
     /// Result of a `ListSweeps` request.
     SweepList {
         sweeps: Vec<SweepInfo>,
+    },
+    // ========================================================================
+    // Event Bus Responses (Issue #3453 — Phase B of #3449)
+    // ========================================================================
+    /// Acknowledgement frame returned by a successful `PublishEvent`.
+    /// Includes the receiver count so debug tooling can verify routing.
+    EventPublished {
+        topic: String,
+        receivers: usize,
+    },
+    /// A frame in the long-lived event stream returned by `SubscribeEvents`.
+    ///
+    /// Each frame may carry one or more events. The daemon sends one
+    /// frame per event in practice; the `events` vec is a structural
+    /// allowance for future batching without a wire-protocol change.
+    EventStream {
+        events: Vec<Event>,
     },
     /// Legacy error response (deprecated, use `StructuredError` for new code)
     /// Kept for backwards compatibility with existing frontends
@@ -336,4 +384,108 @@ pub struct SweepInfo {
     /// future phases (Phase A always sets this to `None`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pr_number: Option<i32>,
+}
+
+// ========================================================================
+// Event Bus Types (Issue #3453 — Phase B of #3449)
+// ========================================================================
+
+/// A sweep-lifecycle event published on the in-memory bus.
+///
+/// The enum is tagged on the `type` field; the topic each variant maps
+/// to is determined by [`Event::topic`]. Subscribers route by topic
+/// prefix (see `event_bus::topic_matches`).
+///
+/// The taxonomy below is **frozen for v0.10.0** — new topics require a
+/// follow-up issue per epic #3449.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum Event {
+    /// `sweep.issue.{N}.phase` — sweep child advanced a phase.
+    /// Payload published by the sweep skill via `PublishEvent`.
+    SweepPhase {
+        issue: u32,
+        phase: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pr_number: Option<i32>,
+    },
+    /// `sweep.issue.{N}.blocker` — sweep child encountered a blocker.
+    SweepBlocker {
+        issue: u32,
+        reason: String,
+        label_added: String,
+    },
+    /// `sweep.issue.{N}.exited` — reaper detected clean exit.
+    SweepExited {
+        issue: u32,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        exit_code: Option<i32>,
+        duration_sec: i64,
+    },
+    /// `sweep.issue.{N}.crashed` — reaper detected dead pid + checkpoint.
+    SweepCrashed {
+        issue: u32,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        checkpoint_phase: Option<String>,
+    },
+    /// `sweep.global.dispatch` — daemon dispatched a new sweep.
+    SweepGlobalDispatch { sweep_id: SweepId, kind: SweepKind },
+    /// `sweep.global.completed` — daemon reaper recorded sweep completion.
+    SweepGlobalCompleted {
+        sweep_id: SweepId,
+        outcome: SweepOutcome,
+    },
+    /// Synthetic event signalling that the subscription fell behind the
+    /// publisher. The number of events dropped is reported in `skipped`.
+    /// Matches `tokio::sync::broadcast::Receiver::Lagged` semantics.
+    TopicLag { skipped: u64 },
+    /// Generic event for forward compatibility — a topic + opaque payload.
+    /// Used by the `PublishEvent` IPC variant when the publisher does not
+    /// supply a strongly-typed event.
+    Generic {
+        topic: String,
+        payload: serde_json::Value,
+    },
+}
+
+impl Event {
+    /// Resolve the topic string for this event.
+    ///
+    /// Per-variant rules:
+    ///
+    /// | Variant | Topic |
+    /// |---------|-------|
+    /// | `SweepPhase {issue, ..}` | `sweep.issue.{issue}.phase` |
+    /// | `SweepBlocker {issue, ..}` | `sweep.issue.{issue}.blocker` |
+    /// | `SweepExited {issue, ..}` | `sweep.issue.{issue}.exited` |
+    /// | `SweepCrashed {issue, ..}` | `sweep.issue.{issue}.crashed` |
+    /// | `SweepGlobalDispatch {..}` | `sweep.global.dispatch` |
+    /// | `SweepGlobalCompleted {..}` | `sweep.global.completed` |
+    /// | `TopicLag {..}` | `sweep.system.topic_lag` |
+    /// | `Generic {topic, ..}` | the explicit topic string |
+    #[must_use]
+    pub fn topic(&self) -> String {
+        match self {
+            Self::SweepPhase { issue, .. } => format!("sweep.issue.{issue}.phase"),
+            Self::SweepBlocker { issue, .. } => format!("sweep.issue.{issue}.blocker"),
+            Self::SweepExited { issue, .. } => format!("sweep.issue.{issue}.exited"),
+            Self::SweepCrashed { issue, .. } => format!("sweep.issue.{issue}.crashed"),
+            Self::SweepGlobalDispatch { .. } => "sweep.global.dispatch".to_string(),
+            Self::SweepGlobalCompleted { .. } => "sweep.global.completed".to_string(),
+            Self::TopicLag { .. } => "sweep.system.topic_lag".to_string(),
+            Self::Generic { topic, .. } => topic.clone(),
+        }
+    }
+}
+
+/// Outcome of a completed sweep, used by `Event::SweepGlobalCompleted`.
+///
+/// `Exited` is the clean-exit path; `Crashed` is the dead-pid +
+/// checkpoint-present path that triggers a `loom:building` →
+/// `loom:issue` label re-arm on the reaper side.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SweepOutcome {
+    Exited,
+    Crashed,
 }

--- a/loom-daemon/tests/sweep_md_doc_lint.rs
+++ b/loom-daemon/tests/sweep_md_doc_lint.rs
@@ -1,0 +1,121 @@
+//! Doc-lint test for `defaults/.claude/commands/loom/sweep.md` (Issue #3453,
+//! AC #3).
+//!
+//! The sweep skill markdown documents the wire-protocol contract for the
+//! Phase B event bus — the six initial topics in the frozen taxonomy.
+//! This test grep-checks the markdown file at compile time so that:
+//!
+//! - Renames/refactors to the topic strings flag a CI failure.
+//! - Removing the section by accident also flags a CI failure.
+//! - The acceptance criteria for #3453 (AC #3) can be verified
+//!   programmatically.
+//!
+//! If the markdown structure intentionally changes (e.g. a follow-up issue
+//! adds a seventh topic), update this test together with the markdown so
+//! the doc-lint stays in sync with the contract.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::fs;
+use std::path::PathBuf;
+
+const SWEEP_MD_RELATIVE: &str = "../defaults/.claude/commands/loom/sweep.md";
+
+/// All six frozen topic strings from the Phase B taxonomy. The presence
+/// of each in `sweep.md` is part of the acceptance criteria for #3453.
+const REQUIRED_TOPICS: &[&str] = &[
+    "sweep.issue.{N}.phase",
+    "sweep.issue.{N}.blocker",
+    "sweep.issue.{N}.exited",
+    "sweep.issue.{N}.crashed",
+    "sweep.global.dispatch",
+    "sweep.global.completed",
+];
+
+fn read_sweep_md() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(SWEEP_MD_RELATIVE);
+    fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!(
+            "sweep.md not found at {} (CWD-relative path: {}): {e}",
+            path.display(),
+            SWEEP_MD_RELATIVE,
+        );
+    })
+}
+
+/// AC #3: assert the `## Daemon event bus` section is present.
+#[test]
+fn sweep_md_has_daemon_event_bus_section() {
+    let content = read_sweep_md();
+    assert!(
+        content.contains("## Daemon event bus"),
+        "expected `## Daemon event bus` section in sweep.md — the Phase B \
+         contract documentation is required by #3453 AC #3"
+    );
+}
+
+/// AC #3: assert all six initial topics are present in the markdown.
+///
+/// If a topic is renamed in Rust without updating sweep.md, this test
+/// catches the drift. If sweep.md is renamed without updating this
+/// test, the test panics with a missing-file message above.
+#[test]
+fn sweep_md_topic_taxonomy_table_lists_six_topics() {
+    let content = read_sweep_md();
+    for topic in REQUIRED_TOPICS {
+        assert!(
+            content.contains(topic),
+            "sweep.md is missing topic `{topic}` from the Phase B taxonomy; \
+             update sweep.md or this test if the change is intentional"
+        );
+    }
+}
+
+/// AC #3: assert the `PublishEvent` IPC contract is documented (i.e.,
+/// the markdown has the Request::PublishEvent wire-format reference).
+/// This catches accidental section removals during future refactors.
+#[test]
+fn sweep_md_documents_publish_event_ipc_contract() {
+    let content = read_sweep_md();
+    assert!(
+        content.contains("Request::PublishEvent"),
+        "sweep.md should reference `Request::PublishEvent` — the IPC contract \
+         is required by #3453 AC #3"
+    );
+    assert!(
+        content.contains("PublishEvent"),
+        "sweep.md should reference `PublishEvent` IPC variant"
+    );
+    assert!(
+        content.contains("SubscribeEvents"),
+        "sweep.md should reference `SubscribeEvents` IPC variant"
+    );
+}
+
+/// AC #3: assert at least one sample JSON payload for each topic type.
+/// Looks for the structural markers (the wire-frame examples), not
+/// every payload field — payload fields may evolve while the topic
+/// remains stable.
+#[test]
+fn sweep_md_includes_sample_wire_payloads() {
+    let content = read_sweep_md();
+
+    // At least one sample for each topic. We assert that the wire-frame
+    // example contains the topic string AND a JSON `"payload"` key —
+    // together this confirms a sample exists (not just a table entry).
+    let samples: &[&str] = &[
+        r#""topic": "sweep.issue.123.phase""#,
+        r#""topic": "sweep.issue.123.blocker""#,
+        r#""SweepExited""#,
+        r#""SweepCrashed""#,
+        r#""SweepGlobalDispatch""#,
+        r#""SweepGlobalCompleted""#,
+    ];
+    for sample in samples {
+        assert!(
+            content.contains(sample),
+            "sweep.md is missing a sample wire-frame for `{sample}` — \
+             #3453 AC #3 requires sample payloads for each topic"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Implements **Phase B of epic #3449** — an in-memory pub/sub event bus on `loom-daemon`, plus reaper-emitted lifecycle events and the wire-protocol contract for sweep-child phase publication. Builds directly on Phase A (#3459).

The bus is **NOT** NATS/ZeroMQ. It is a thin wrapper around `tokio::sync::broadcast::channel<Event>` (default capacity 1024) with segment-aligned topic-prefix routing, scoped to one daemon per workspace. Wire protocol reuses the existing line-delimited JSON Unix-socket framing in `loom-daemon/src/ipc.rs` (no new transport).

Closes #3453. Part of epic #3449 (Phase A: PR #3459).

## What ships

- `loom-daemon/src/event_bus.rs` — new `EventBus`, `Subscription`, prefix-match router, `TopicLag` overflow semantics. ~600 LOC + 16 unit tests.
- `loom-daemon/src/types.rs` — `Request::PublishEvent`, `Request::SubscribeEvents`, `Response::EventPublished`, `Response::EventStream`, `Event` enum (six topics + `TopicLag` + `Generic`), `SweepOutcome`.
- `loom-daemon/src/sweep_registry.rs` — registry holds an `Option<Arc<EventBus>>` (additive — `new()` is unchanged), reaper emits `sweep.issue.{N}.exited` / `sweep.issue.{N}.crashed` + `sweep.global.completed`, dispatch emits `sweep.global.dispatch`.
- `loom-daemon/src/ipc.rs` — `PublishEvent` returns one-shot `EventPublished` ack; `SubscribeEvents` is intercepted in `handle_client` and drives a long-lived `EventStream` frame loop until the client disconnects.
- `loom-daemon/src/main.rs` — daemon constructs the bus at startup and wires it into `SweepRegistry::with_event_bus` + `IpcServer::new`.
- `defaults/.claude/commands/loom/sweep.md` — new `## Daemon event bus` section: six-topic taxonomy table, when-to-publish guidance, sample wire frames for all six topics, subscription model, failure modes, out-of-scope list.
- `loom-daemon/tests/sweep_md_doc_lint.rs` — 4 grep-style doc-lint tests assert the section, topic strings, IPC contract, and sample payloads are present.

## Topic taxonomy (frozen for v0.10.0 per epic #3449)

| Topic | Publisher | Payload |
|-------|-----------|---------|
| sweep.issue.{N}.phase | Sweep child | {phase, pr_number?} |
| sweep.issue.{N}.blocker | Sweep child | {reason, label_added} |
| sweep.issue.{N}.exited | Daemon reaper | {exit_code, duration_sec} |
| sweep.issue.{N}.crashed | Daemon reaper | {checkpoint_phase} |
| sweep.global.dispatch | Daemon | {sweep_id, kind} |
| sweep.global.completed | Daemon | {sweep_id, outcome} |

## Architectural decisions matching curator review

- **Topic matching**: segment-aligned prefix (`sweep.issue` matches `sweep.issue.123.phase` but not `sweep.issuetype.foo`). Implemented in `event_bus::topic_matches`.
- **Subscription model**: long-lived MCP connection with initial subscribe payload; daemon streams `EventStream` frames until client disconnect or bus closure.
- **Backpressure**: bounded broadcast channel (1024 default). Slow subscribers receive a `Event::TopicLag { skipped }` sentinel and resume at the current channel head — pass-through, no silent drops. Matches `tokio::sync::broadcast::Receiver::Lagged`.

## Acceptance criteria — status

| AC | Status | Justification |
|----|--------|---------------|
| AC1: `cargo test -p loom-daemon event_bus` passes (channel capacity 1024 + topic router) | **PASS** | 16 unit tests covering bus_default_capacity_is_1024, prefix matching (5 tests), routing, multi-subscriber filtering, overflow, etc. |
| AC2: reaper emits sweep.issue.{N}.exited on dead pid + sweep.issue.{N}.crashed with loom:building -> loom:issue re-arm | **PASS** | reaper_emits_crashed_event_with_checkpoint_phase and reaper_emits_exited_event_for_clean_exit assert the events. Label re-arm path is unchanged from Phase A; the bus event is the new observable signal. |
| AC3: sweep.md documents PublishEvent IPC + topic taxonomy + sample payloads + doc-lint | **PASS** | New `## Daemon event bus` section in sweep.md + tests/sweep_md_doc_lint.rs (4 tests). |
| AC4: slow-subscriber overflow emits topic_lag matching tokio broadcast semantics | **PASS** | slow_subscriber_receives_topic_lag_on_overflow fills a capacity-4 channel with 20 events, asserts Event::TopicLag { skipped > 0 }, then asserts the next recv() resumes with a normal event. |

## Scope decisions

- **Subscription stream design**: kept the existing line-delimited JSON framing (no new transport). Request::SubscribeEvents is intercepted in handle_client before reaching handle_request because it needs to drive a long-lived response stream rather than a single-frame return. handle_request returns an internal-bug Error sentinel if it ever sees SubscribeEvents, so a routing regression fails loud.
- **Sweep registry API extension**: kept Phase A's SweepRegistry::new(config) signature unchanged — added with_event_bus(config, bus) and set_event_bus(bus) as additive opt-ins. Registries constructed without a bus behave identically to Phase A.
- **PrSet sweeps**: emit only sweep.global.dispatch / sweep.global.completed (no per-issue events). PrSet dispatch itself is still rejected in Phase A — the global events fire on reconstruction-then-reap of legacy PrSet entries if any exist.
- **No new topics, no new labels, no daemon-state writes** — per the issue constraints.

## Test commands run

- `cargo test -p loom-daemon --lib` — **324 passed, 0 failed** (up from 304 in Phase A, +20 new tests).
- `cargo test -p loom-daemon event_bus` — **16 passed, 0 failed**.
- `cargo test -p loom-daemon --test sweep_md_doc_lint` — **4 passed, 0 failed**.
- CI clippy command from .github/workflows/ci.yml:57 — **clean (exit 0)**.
- `cargo check --workspace --all-targets` — clean.
- `cargo fmt --all -- --check` — clean.
- Two integration tests in tests/integration_basic.rs / tests/integration_security.rs are pre-existing flaky daemon-startup tests (5s socket-create timeout race under parallel load) — pass on re-run, unrelated to Phase B.

## LOC by file

| File | Lines | Notes |
|------|-------|-------|
| loom-daemon/src/event_bus.rs | 600 (new) | ~390 production + 210 unit tests |
| loom-daemon/src/types.rs | +137 | Event enum, SweepOutcome, IPC variants |
| loom-daemon/src/sweep_registry.rs | +250 | bus integration + 2 reaper tests |
| loom-daemon/src/ipc.rs | +193 | stream_events + handle_request rewiring + tests |
| loom-daemon/src/main.rs | +14 | bus instantiation + wiring |
| loom-daemon/src/lib.rs | +1 | module declaration |
| loom-daemon/tests/sweep_md_doc_lint.rs | 121 (new) | 4 doc-lint tests |
| defaults/.claude/commands/loom/sweep.md | +95 | new `## Daemon event bus` section |

## Test plan

- [ ] CI green on Rust clippy + workspace check.
- [ ] CI green on `cargo test --workspace`.
- [ ] Manual: spin up loom-daemon, send a PublishEvent over the IPC socket, observe EventPublished ack frame.
- [ ] Manual: send a SubscribeEvents { topics: [] }, then send a DispatchSweep, observe EventStream frames for sweep.global.dispatch.
- [ ] Manual: kill a sweep child with a checkpoint present, observe EventStream { events: [{ type: SweepCrashed, ... }] } on the subscription.

🤖 Generated with [Claude Code](https://claude.com/claude-code)