### PR TITLE
feat(skill): Phase D — /loom:sweep backend detection + daemon delegation (#3454)

### DIFF
--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -10,7 +10,7 @@ Process an explicit list of issues — **or an explicit/NL-described set of open
 
 **Arguments**: $ARGUMENTS
 
-`$ARGUMENTS` is interpreted in one of **three modes**, chosen by inspection of the non-flag tokens and the presence of a `--prs` flag. Before classifying, **strip all recognized flag tokens** (`--builders-per-wave N`, `--dry-run`, `--prs`) from the token list — flags are honoured in their respective modes.
+`$ARGUMENTS` is interpreted in one of **three modes**, chosen by inspection of the non-flag tokens and the presence of a `--prs` flag. Before classifying, **strip all recognized flag tokens** (`--builders-per-wave N`, `--dry-run`, `--prs`, `--no-daemon`) from the token list — flags are honoured in their respective modes.
 
 **Mode selection summary** (full rules below):
 
@@ -96,7 +96,7 @@ Combine flags as needed. Always pass `--state open` explicitly (Mode C operates 
 
 **Mode C validation rules:**
 
-- `--prs` strips from the token list before classification, exactly like `--builders-per-wave N` and `--dry-run`.
+- `--prs` strips from the token list before classification, exactly like `--builders-per-wave N`, `--dry-run`, and `--no-daemon`.
 - Numeric tokens (after stripping `--prs`): same `^#?\d+$` regex as Mode A. Strip leading `#`, parse as positive integers, deduplicate (preserve first-seen order). Reject any token that fails to parse, with a clear error citing the offending token, and EXIT.
 - NL tokens (after stripping `--prs`): translate to one or more `gh pr list` invocations per the guide above. Run the command, deduplicate the resulting PR list, and **display the candidate set to the user before spawning any agents**. Await confirmation. If the user declines, EXIT cleanly.
 - **`--builders-per-wave N` is silently ignored in Mode C**. The Builder phase is skipped wholesale for PR-set mode; per-PR Judge is sequential within a wave (matching the existing issue-side wave policy). If the user passes both `--prs` and `--builders-per-wave N`, print a one-line note that the flag has no effect in Mode C and proceed without it. Mode C waves are size-1 by default — one PR settles fully (Judge → optional Doctor → optional Merge) before the next PR is touched. This may relax in a future issue; today it preserves the load-bearing #3289 sequencing rule.
@@ -114,19 +114,20 @@ Combine flags as needed. Always pass `--state open` explicitly (Mode C operates 
 - **`--builders-per-wave N`** — dispatch up to `N` builders in parallel per wave. Default `1` (fully sequential, matching the MVP behaviour). `N` must be an integer `>= 1`. Honoured in Modes A and B (issue-side); **silently ignored in Mode C** (PR-set mode has no Builder phase — see Mode C validation rules above). Flag tokens are stripped before classification.
 - **`--dry-run`** — print the planned candidate list (with wave grouping) and EXIT without performing any mutation. Recognized as a bare flag token (no value). May appear anywhere in `$ARGUMENTS`. Default is off. Honoured in **all three** modes — stripped before classification along with other flags. Mode C dry-run prints the PR-set plan (per-PR routing) instead of the issue-set plan.
 - **`--prs`** — switch into Mode C (PR-set mode). Recognized as a bare flag token (no value). May appear anywhere in `$ARGUMENTS`. Default is off. When present, non-flag tokens are interpreted as **PR numbers** (numeric tokens) or as a **PR-list description** (NL tokens). When absent, an NL trigger phrase listed in the Mode C section can still select Mode C. See "Mode C" above for full semantics.
+- **`--no-daemon`** — force in-process subagent dispatch even when the daemon is running with a multi-account token pool. Recognized as a bare flag token (no value). May appear anywhere in `$ARGUMENTS`. Default is off. When present, **Stage -1 (Backend detection) skips the `PROBE_DAEMON` step entirely** and the skill always falls through to the existing Mode A/B/C subagent dispatch path. Honoured in **all three** modes — stripped before classification along with other flags. Use this when you want the predictable single-process behaviour even though daemon dispatch is available (e.g., debugging, demoing the subagent path, or running under a token configuration that you don't want shared with daemon-spawned sweeps). See "Stage -1: Backend detection" below.
 
 ### Validation rules
 
-- Recognize `--dry-run`, `--prs`, and `--builders-per-wave N` as flag tokens anywhere in `$ARGUMENTS`, strip them from the candidate list before validation, and store them as flags / parameters (`DRY_RUN=true|false`, `PRS_MODE=true|false`, `BUILDERS_PER_WAVE=N`).
+- Recognize `--dry-run`, `--prs`, `--no-daemon`, and `--builders-per-wave N` as flag tokens anywhere in `$ARGUMENTS`, strip them from the candidate list before validation, and store them as flags / parameters (`DRY_RUN=true|false`, `PRS_MODE=true|false`, `NO_DAEMON=true|false`, `BUILDERS_PER_WAVE=N`).
 - At least one candidate (numeric token or NL description) must be supplied. If `$ARGUMENTS` (after stripping flag tokens) is empty, display:
   ```
-  Usage: /sweep <issue-number> [<issue-number> ...] [--builders-per-wave N] [--dry-run]
-         /sweep <natural-language description>     [--builders-per-wave N] [--dry-run]
+  Usage: /sweep <issue-number> [<issue-number> ...] [--builders-per-wave N] [--dry-run] [--no-daemon]
+         /sweep <natural-language description>     [--builders-per-wave N] [--dry-run] [--no-daemon]
          /sweep --prs <pr-number> [<pr-number> ...] [--dry-run]
          /sweep --prs <natural-language PR description> [--dry-run]
          /sweep <natural-language PR description>       [--dry-run]   # PR NL triggers select Mode C
 
-  See #3298 and #3384 for the full design.
+  See #3298, #3384, and #3454 for the full design.
   ```
   and EXIT.
 - **Mode-selection precedence** (apply in order):
@@ -154,6 +155,10 @@ Combine flags as needed. Always pass `--state open` explicitly (Mode C operates 
   - Reject `N < 1` (including `0` and negative values) with: `Error: --builders-per-wave must be >= 1 (got: <N>)` and EXIT. Do **not** silently default to `1`.
   - If `N > 3`, print a warning and continue: `WARNING: --builders-per-wave=<N> is unvalidated. N<=3 is recommended; N>=4 may exhaust context or hit rate limits. Proceeding at your own risk.`
   - If `N` exceeds the number of candidates at any wave, **silently clamp** to the candidate count for that wave. Do not warn, do not stall.
+- **`--no-daemon` validation:**
+  - Bare flag, no value. If a value is supplied (`--no-daemon=true`, `--no-daemon something`), treat the `=value` form as an error and EXIT (`Error: --no-daemon takes no value`). The standalone-token form is the only accepted spelling.
+  - Honoured in all three modes (A, B, C). The flag is a no-op in Mode C (Mode C is always subagent-side — see Stage -1's `DECIDE` precedence below) but is accepted without error so operators can pass it unconditionally from scripts.
+  - When `NO_DAEMON=true`, Stage -1 short-circuits to the subagent path **before** issuing the daemon Ping probe. No daemon-state files are read or written, and no `mcp__loom__*` calls are made for backend probing.
 
 **Wave-size guidance:**
 
@@ -179,6 +184,7 @@ The cap is **soft** — there is no hard upper bound. The warning is the only gu
 /sweep 1 2 --builders-per-wave 5              # Silently clamps to 2 (candidate count)
 /sweep 123 456 789 --dry-run                  # Print plan and EXIT without mutating
 /sweep 1 2 3 4 5 --dry-run --builders-per-wave 2  # Preview with wave grouping
+/sweep 123 456 --no-daemon                    # Force in-process subagent dispatch even when daemon is up (#3454)
 ```
 
 ### Mode B — Natural-language description
@@ -284,6 +290,196 @@ If a future maintainer is tempted to "simplify" by replacing the wave-loop with 
 ### Other constraints
 
 - **Do NOT write to `.loom/daemon-state.json`.** That file is owned by the standalone daemon. `/sweep` runs independently and must not race with the daemon on shepherd-slot bookkeeping. Reading `daemon-state.json` for situational awareness is fine; writing is not.
+
+## Stage -1: Backend detection (Phase D of #3449)
+
+Before **any** other stage — including the dry-run gate and all wave lifecycles — decide whether to **delegate dispatch to the in-process loom-daemon** or **fall through to the existing in-process subagent dispatch**. This stage is prose for the LLM running this skill; it does not run a separate binary. Implementation is small, side-effect-free probes followed by a single routing decision.
+
+This stage exists because Phase A of epic #3449 (#3452) shipped `mcp__loom__dispatch_sweep`, an MCP tool that queues a sweep on the daemon's spawn queue and returns immediately. When the daemon is reachable **and** a multi-account token pool is configured, dispatching to the daemon means each sweep runs in its own detached process with its own rotated OAuth token — load is balanced across accounts, and the orchestrator session exits sub-2-second after dispatch. When either precondition is missing, today's Mode A/B/C subagent path is the right choice — it works on a solo token, it doesn't depend on a running daemon, and it is the verified behaviour for the v0.9.x line.
+
+The contract is **strict AND between two preconditions**, with an explicit Mode C short-circuit and an explicit `--no-daemon` opt-out. There is **no implicit auto-start** of the daemon if the pool exists but the daemon is down; there is **no implicit "use daemon if reachable even without a pool"** branch. Either probe failing → subagent fallthrough.
+
+### Decision tree (the contract)
+
+```text
+PROBE_MODE:
+  If --prs flag present OR any PR-side NL trigger detected → Mode C (subagent always)
+
+PROBE_DAEMON:
+  Ping ~/.loom/loom-daemon.sock with 500ms timeout. Pong → reachable.
+
+PROBE_POOL:
+  Count *.token files in .loom/tokens/ OR ACCOUNT_KEY_* lines in .env. Pool exists if count >= 2.
+
+DECIDE:
+  if Mode C: use_subagent()
+  elif --no-daemon: use_subagent()
+  elif PROBE_DAEMON AND PROBE_POOL: use_daemon()
+  else: use_subagent()
+```
+
+The precedence is deliberate:
+
+1. **Mode C → subagent** (always, regardless of daemon/pool state). The daemon's dispatch surface is **issue-keyed only** in v0.10.0 (`mcp__loom__dispatch_sweep --kind '{"Issue":N}'`); PR-set dispatch is an explicit non-goal of the parent epic and is not on the v0.10.0 roadmap. PR-set sweeps therefore route to the existing in-process subagent path, which already supports Mode C end-to-end.
+2. **`--no-daemon` → subagent** (operator opt-out, after Mode C but before any probes). When this flag is present, do not even attempt the `PROBE_DAEMON` Ping — saves a 500ms ceiling and produces predictable behaviour for debug/demo/scripted runs.
+3. **`PROBE_DAEMON ∧ PROBE_POOL → daemon`** (the only way to land on the daemon path). **Strict AND**: both probes must succeed. Either missing → fallthrough.
+4. **Else → subagent** (the universal fallthrough, equivalent to v0.9.x behaviour).
+
+### The three probes
+
+#### PROBE_MODE — mode classification (already done)
+
+Mode classification happens in the existing "Mode-selection precedence" rules above (Arguments → Validation rules). By the time Stage -1 runs, the skill knows whether it is in Mode A, B, or C. **If the mode is C, the decision is already made — go straight to the subagent path** (the "Stage 0: Dry-run gate" section below, then "PR-set Wave Lifecycle"). Do not run the daemon or pool probes for Mode C.
+
+#### PROBE_DAEMON — is the loom-daemon reachable?
+
+The daemon listens on `~/.loom/loom-daemon.sock` (a Unix-domain socket). A reachability probe is a cheap `mcp__loom__list_sweeps` invocation — the daemon answers with the current sweep list (which may be an empty array if the daemon is up but no sweeps are queued). Either a successful response **or** an empty-list response is a "pong" — the daemon is reachable.
+
+Use a **500ms timeout** on this probe. The MCP layer accepts a timeout parameter; do not raise it. The 500ms ceiling covers two failure modes simultaneously:
+
+- **No daemon running.** The Unix socket file does not exist, or the connection refused immediately. The MCP call returns an error in well under 500ms; treat as `PROBE_DAEMON = false`.
+- **Stale socket.** The socket file exists but no process is listening (e.g., the daemon crashed without cleanup). The connection hangs until the OS times out — that's the 500ms guard. Timeout → treat as `PROBE_DAEMON = false`. **Do not retry, do not auto-clean the stale socket, do not auto-start the daemon.** Those behaviours belong in operator tools, not in this skill.
+
+A successful response (any well-formed `EventStream`/sweep-list payload, including the empty case) → `PROBE_DAEMON = true`.
+
+```text
+PROBE_DAEMON pseudocode (LLM-directed):
+
+  if NO_DAEMON:
+      PROBE_DAEMON = false   # short-circuit; do not even issue the call
+  else:
+      try:
+          response = mcp__loom__list_sweeps(timeout_ms=500)
+          PROBE_DAEMON = true        # any structured response = reachable
+      except timeout, connection_error, no_such_tool:
+          PROBE_DAEMON = false
+```
+
+The `no_such_tool` case covers older Loom installs without Phase A's MCP additions — treat as "daemon not reachable" and fall through. Do not try to detect the daemon by other means (no `ps` parsing, no PID file reads — the socket probe is the authoritative reachability test).
+
+#### PROBE_POOL — does a multi-account token pool exist?
+
+A pool exists if **either** of these is true (logical OR, both checked):
+
+1. **Materialized pool**: `.loom/tokens/*.token` contains **two or more** files. The bootstrap step (`loom-tokens bootstrap`) writes one `*.token` file per `ACCOUNT_KEY_*` triple in `.env`; a count `>= 2` means at least two distinct accounts are available for rotation.
+2. **Configured pool**: `.env` at the workspace root contains **two or more** `ACCOUNT_KEY_*` lines. This catches the case where the operator has configured multiple accounts but hasn't yet run `loom-tokens bootstrap` — the daemon's spawn-time selector can still pick a token, and the pool will be materialized on demand.
+
+Both checks are cheap, local, and side-effect-free:
+
+```bash
+TOKEN_FILE_COUNT=$(ls .loom/tokens/*.token 2>/dev/null | wc -l | tr -d ' ')
+ENV_KEY_COUNT=$(grep -c '^ACCOUNT_KEY_' .env 2>/dev/null || echo 0)
+if (( TOKEN_FILE_COUNT >= 2 )) || (( ENV_KEY_COUNT >= 2 )); then
+  PROBE_POOL=true
+else
+  PROBE_POOL=false
+fi
+```
+
+A single-token configuration (`TOKEN_FILE_COUNT == 1` and `ENV_KEY_COUNT <= 1`) is **not** a pool — the daemon dispatch path needs at least two accounts to make rotation meaningful, and a single-token operator gets no benefit from delegating to the daemon. Fall through to the subagent path in that case.
+
+> **Why >= 2 and not >= 1?** A pool of one is not a pool — it is a single token, and rotation requires alternatives. The daemon's dispatch advantage (per-sweep token selection, weekly-quota recovery) only materializes once two-or-more accounts are configured. Single-token operators see no degradation in the subagent path; this preserves the existing solo-token experience.
+
+### The daemon-dispatch path (when `DECIDE = use_daemon`)
+
+When `DECIDE` lands on `use_daemon`, the skill **dispatches each candidate issue** to the daemon and **exits sub-2-second**. There is no in-session orchestration after dispatch — operators monitor with `mcp__loom__list_sweeps` (Phase A) or the richer Phase C tools once they land.
+
+For each candidate issue `N` in the candidate set:
+
+```text
+mcp__loom__dispatch_sweep(kind={"Issue": N})
+```
+
+The daemon enqueues the sweep, returns a sweep ID, and the skill logs the dispatch (`Dispatched sweep <sweep-id> for issue #N to daemon`). The daemon's spawn-time logic picks an OAuth token from the rotation pool, detaches a `claude -p "/loom:sweep N"` child, and runs the sweep in that child's session — completely independent of this orchestrator session.
+
+**The skill does NOT subscribe to events.** Phase B's pub/sub bus is consumed by long-running monitors and the spawn loop, not by the skill itself. The skill is fire-and-forget: dispatch, log, exit.
+
+**Mode C is excluded.** Mode C uses `--prs` (or NL triggers); the daemon does not handle PR-set dispatch in v0.10.0. If `PROBE_MODE` returned Mode C, this branch is unreachable — the `DECIDE` precedence sends Mode C to subagent before this branch is evaluated.
+
+**Exit immediately after the last `mcp__loom__dispatch_sweep` returns.** Do **not** run the dry-run gate, the issue-side wave lifecycle, or any of the "0." through "8." stages below — those are subagent-path-only and would double-orchestrate. The skill's job in the daemon path is dispatch and exit; the daemon-side child runs the full Curator → Builder → Judge → Doctor → Merge lifecycle in its own session.
+
+**Dry-run interaction:** when `--dry-run` is passed alongside the daemon path, **the dry-run gate (Stage 0) still runs and the skill EXITs without dispatching**. Dry-run is a read-only contract independent of backend choice; it prints the candidate plan and exits without mutation regardless of whether the daemon would have been used. This is intentional — operators previewing a sweep should see the plan before any backend dispatches.
+
+### The subagent fallthrough (when `DECIDE = use_subagent`)
+
+Otherwise — `DECIDE` is `use_subagent` for **any** of the reasons above (Mode C, `--no-daemon`, daemon unreachable, no pool, or any probe error) — **continue to "0. Dry-run gate" below and run the existing Mode A/B/C lifecycle in-process exactly as today**. This is the v0.9.x behaviour, unchanged. The skill prose from "0. Dry-run gate" onward is the canonical subagent path.
+
+No behaviour change for solo-token operators: their `PROBE_POOL` returns `false`, the `DECIDE` lands on `use_subagent`, and the rest of the skill runs as it always has.
+
+### Smoke tests (documented expectations)
+
+These are the AC #3 and AC #4 contracts, written for the operator.
+
+**Daemon-on + multi-account pool (AC #3):**
+
+```bash
+# Preconditions:
+#   - loom-daemon is running (`pgrep loom-daemon` matches, ~/.loom/loom-daemon.sock exists)
+#   - At least 2 accounts in .env / .loom/tokens/
+
+/loom:sweep 123 456
+
+# Expected:
+#   1. Stage -1 runs: PROBE_MODE=A, PROBE_DAEMON=true, PROBE_POOL=true.
+#   2. DECIDE = use_daemon.
+#   3. Skill calls mcp__loom__dispatch_sweep for issue 123 → logs sweep ID.
+#   4. Skill calls mcp__loom__dispatch_sweep for issue 456 → logs sweep ID.
+#   5. Skill exits in < 2 seconds.
+#   6. Daemon runs the two sweeps independently in detached processes.
+#   7. Operator monitors progress via mcp__loom__list_sweeps or Phase C tools.
+```
+
+**Daemon-off OR single-token (AC #4):**
+
+```bash
+# Preconditions:
+#   - Either loom-daemon is not running, OR .env has < 2 ACCOUNT_KEY_* lines.
+
+/loom:sweep 123 456
+
+# Expected:
+#   1. Stage -1 runs: PROBE_MODE=A, PROBE_DAEMON or PROBE_POOL is false.
+#   2. DECIDE = use_subagent.
+#   3. Skill continues to "0. Dry-run gate" → "Wave Lifecycle" → ... exactly as today.
+#   4. Issue 123 runs Curator→Builder→Judge→Doctor→Merge in-session.
+#   5. Issue 456 runs the same way in the next wave (default --builders-per-wave=1).
+#   6. Skill exits when both issues have settled (potentially many minutes).
+```
+
+**`--no-daemon` opt-out:**
+
+```bash
+# Preconditions: any. The flag forces the subagent path.
+
+/loom:sweep 123 456 --no-daemon
+
+# Expected:
+#   1. Stage -1 sees NO_DAEMON=true → PROBE_DAEMON skipped entirely.
+#   2. DECIDE = use_subagent.
+#   3. Skill continues to "0. Dry-run gate" → "Wave Lifecycle" → ... exactly as today.
+```
+
+**Mode C (PR-set):**
+
+```bash
+# Preconditions: any. Mode C short-circuits Stage -1's daemon path.
+
+/loom:sweep --prs 200 201
+
+# Expected:
+#   1. PROBE_MODE = C (because --prs is present).
+#   2. DECIDE = use_subagent (regardless of daemon/pool state).
+#   3. Skill continues to "0. Dry-run gate" → "PR-set Wave Lifecycle" → ... exactly as today.
+```
+
+### What Stage -1 does NOT do
+
+- **Does not auto-start the daemon** if the pool exists but the daemon is unreachable. Auto-start is operator policy, not skill policy.
+- **Does not write `~/.loom/loom-daemon.sock` cleanup** for stale sockets. Stale-socket cleanup belongs to the daemon's own startup logic and to operator tools.
+- **Does not subscribe to the Phase B event bus.** Subscription is consumed by long-running monitors and the spawn loop, not by this skill. Phase D is dispatch-only.
+- **Does not retry probe failures.** Either probe returns within 500ms (or its natural latency) and is treated as authoritative; no retry, no backoff.
+- **Does not mutate any forge state** during the probes. `mcp__loom__list_sweeps` and the local pool checks are read-only. Even in the daemon path, mutation happens inside the daemon-side child sweep, not in this orchestrator session.
+- **Does not log to `.loom/daemon-state.json` or any daemon-owned state file.** Read-only access is fine for situational awareness; writes are forbidden (same constraint as the existing "Daemon Coexistence" section).
 
 ## 0. Dry-run gate (if `--dry-run`)
 
@@ -814,6 +1010,7 @@ The full `/sweep` design in #3298 includes many features that are intentionally 
 | `loom:operator-only` enforcement | **Implemented (#3360)** | Pre-flight skips issues with `loom:operator-only` (human action required: credentials, infra, hardware). Champion `--merge` mode also refuses to auto-promote them. |
 | Checkpoint/resume after kill | **Implemented (#3373)** | Per-issue phase checkpoint at `.loom/sweep-checkpoint/issue-<N>.json`. Sweep reads on entry and skips completed phases. No mid-builder recovery — kill during Builder resumes at builder start, worktree preserved by `worktree.sh` idempotency. Mode C reuses the helper keyed by the PR's closing-issue number (`closingIssuesReferences`); PRs without a `Closes #N` reference run without checkpointing. |
 | PR-set mode (`--prs` flag and PR NL triggers; Judge/Doctor/Merge from current PR label) | **Implemented (#3384)** | Mode C. Skips Curator, Approval gate, Builder. Size-1 waves. `--builders-per-wave` ignored. Reuses issue-keyed checkpoint via `closingIssuesReferences`. |
+| Daemon backend detection (Stage -1) | **Implemented (#3454)** | Strict-AND between daemon reachability and multi-account pool. Mode C and `--no-daemon` short-circuit to subagent. No implicit auto-start. Dispatch-only — Phase D does not subscribe to the event bus. See "Stage -1: Backend detection". |
 | `--max-waves` cap | Deferred | Operator-level brake on long sweeps. |
 | `--paused-merge` / `--no-judge` | Deferred | Merge-mode variants for trusted batches. |
 | `--include-blocked` (unblock pass) | Deferred | Currently `/sweep` skips `loom:blocked` issues outright. |
@@ -942,3 +1139,6 @@ These are deferred to Phase C (#3454) and Phase D follow-ups — do **not** impl
 - **PR-set mode (Mode C) design**: issue #3384
 - **Parallel-shepherd stall hazard**: issue #3289
 - **Checkpoint/resume design**: issue #3373 (Phase 0 of #3372 shepherd/daemon deprecation epic)
+- **Daemon backend detection (Stage -1)**: issue #3454 (Phase D of #3449 daemon rebuild epic)
+- **Daemon dispatch MCP tool (`mcp__loom__dispatch_sweep`)**: issue #3452 (Phase A of #3449)
+- **Daemon event bus (Phase B)**: issue #3453 (Phase B of #3449)

--- a/loom-daemon/tests/sweep_md_stage_minus_one_doc_lint.rs
+++ b/loom-daemon/tests/sweep_md_stage_minus_one_doc_lint.rs
@@ -1,0 +1,233 @@
+//! Doc-lint test for "Stage -1: Backend detection" in
+//! `defaults/.claude/commands/loom/sweep.md` (Issue #3454, Phase D of
+//! epic #3449).
+//!
+//! Phase D adds a new "Stage -1: Backend detection" stage to the sweep
+//! skill markdown. The new stage probes whether the loom-daemon is
+//! reachable AND whether a multi-account token pool exists; if both
+//! preconditions hold and the mode is not C, it dispatches each
+//! candidate issue to the daemon via `mcp__loom__dispatch_sweep`
+//! (Phase A) and exits. Otherwise it falls through to today's
+//! in-process subagent dispatch (Modes A/B/C unchanged).
+//!
+//! This test grep-checks the markdown file at compile time so that:
+//!
+//! - The new section header is present (AC #1).
+//! - The decision-tree probes (`PROBE_MODE`, `PROBE_DAEMON`,
+//!   `PROBE_POOL`, `DECIDE`) are all documented (AC #1 — the contract
+//!   text is unambiguous).
+//! - The strict-AND precedence between daemon-reachable and
+//!   pool-exists is documented (AC #1 — no implicit auto-start
+//!   behavior).
+//! - The `--no-daemon` opt-out flag is documented in the optional-flags
+//!   section AND the new stage section (AC #2).
+//! - The 500ms timeout for the daemon Ping probe is documented (AC #2
+//!   — the implicit-fallback semantics).
+//!
+//! If the markdown structure intentionally changes (e.g. a follow-up
+//! issue revises the decision tree), update this test together with the
+//! markdown so the doc-lint stays in sync with the contract.
+//!
+//! Companion test: `sweep_md_doc_lint.rs` (Phase B, #3453).
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::fs;
+use std::path::PathBuf;
+
+const SWEEP_MD_RELATIVE: &str = "../defaults/.claude/commands/loom/sweep.md";
+
+fn read_sweep_md() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(SWEEP_MD_RELATIVE);
+    fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!(
+            "sweep.md not found at {} (CWD-relative path: {}): {e}",
+            path.display(),
+            SWEEP_MD_RELATIVE,
+        );
+    })
+}
+
+/// AC #1: assert the `## Stage -1: Backend detection` section header
+/// is present.
+#[test]
+fn sweep_md_has_stage_minus_one_section() {
+    let content = read_sweep_md();
+    assert!(
+        content.contains("## Stage -1: Backend detection"),
+        "expected `## Stage -1: Backend detection` section in sweep.md — \
+         the Phase D backend-detection stage is required by #3454 AC #1"
+    );
+}
+
+/// AC #1: assert all four probe / decision identifiers are present.
+/// These are the exact strings from the decision tree pseudocode the
+/// issue body specifies — renames flag drift between the spec and the
+/// markdown.
+#[test]
+fn sweep_md_decision_tree_documents_all_probes() {
+    let content = read_sweep_md();
+    let required_identifiers: &[&str] = &["PROBE_MODE", "PROBE_DAEMON", "PROBE_POOL", "DECIDE"];
+    for id in required_identifiers {
+        assert!(
+            content.contains(id),
+            "sweep.md is missing decision-tree identifier `{id}` — \
+             #3454 AC #1 requires the full decision tree be documented \
+             (PROBE_MODE / PROBE_DAEMON / PROBE_POOL / DECIDE)"
+        );
+    }
+}
+
+/// AC #1: assert the strict-AND precedence between daemon-reachable
+/// and pool-exists is documented. The contract is "either missing →
+/// subagent fallback" — this catches accidental relaxations to "OR"
+/// or "auto-start daemon if pool exists".
+#[test]
+fn sweep_md_documents_strict_and_precedence() {
+    let content = read_sweep_md();
+
+    // The literal decision-tree precedence string from the issue body.
+    assert!(
+        content.contains("PROBE_DAEMON AND PROBE_POOL"),
+        "sweep.md is missing the literal `PROBE_DAEMON AND PROBE_POOL` \
+         conjunction — #3454 AC #1 requires strict-AND precedence \
+         (no implicit auto-start, no `OR` fallback to daemon-without-pool)"
+    );
+
+    // The prose explanation that either probe failing → subagent.
+    // Allow any of several equivalent phrasings to survive editorial
+    // changes, but require at least one.
+    let strict_and_phrases: &[&str] = &[
+        "Strict AND",
+        "strict AND",
+        "Either missing → subagent",
+        "either missing → subagent",
+        "Either probe failing → subagent",
+    ];
+    let found = strict_and_phrases
+        .iter()
+        .any(|phrase| content.contains(phrase));
+    assert!(
+        found,
+        "sweep.md is missing prose that documents the strict-AND \
+         contract (e.g., `Strict AND`, `Either missing → subagent`) — \
+         #3454 AC #1 requires the contract be unambiguous"
+    );
+}
+
+/// AC #1: assert the Mode C short-circuit is documented. Mode C must
+/// route to subagent **before** any daemon/pool probe — the daemon
+/// does not handle PR-set dispatch in v0.10.0.
+#[test]
+fn sweep_md_documents_mode_c_short_circuit() {
+    let content = read_sweep_md();
+    assert!(
+        content.contains("if Mode C: use_subagent()"),
+        "sweep.md is missing the literal `if Mode C: use_subagent()` \
+         line from the decision tree — Mode C must short-circuit to \
+         subagent before evaluating PROBE_DAEMON / PROBE_POOL (#3454 AC #1)"
+    );
+}
+
+/// AC #2: assert the `--no-daemon` flag is documented in both the
+/// optional-flags section AND the new stage section.
+#[test]
+fn sweep_md_documents_no_daemon_flag() {
+    let content = read_sweep_md();
+
+    // The flag itself must appear at least three times: once in the
+    // optional-flags list, once in the validation rules, and at least
+    // once in the new stage section (and the decision tree). Three is
+    // a lower bound; the real count is higher.
+    let occurrences = content.matches("--no-daemon").count();
+    assert!(
+        occurrences >= 3,
+        "sweep.md mentions `--no-daemon` only {occurrences} time(s); \
+         #3454 AC #2 requires the flag be documented in the \
+         optional-flags section, the validation rules, and the new \
+         Stage -1 section (lower bound: 3 occurrences)"
+    );
+
+    // The decision-tree line must mention --no-daemon as a short-circuit
+    // ahead of the daemon probe.
+    assert!(
+        content.contains("elif --no-daemon: use_subagent()")
+            || content.contains("elif NO_DAEMON: use_subagent()")
+            || (content.contains("--no-daemon") && content.contains("PROBE_DAEMON skipped")),
+        "sweep.md does not document `--no-daemon` as a Stage -1 \
+         short-circuit ahead of the daemon probe — #3454 AC #2 \
+         requires both the explicit opt-out flag AND the implicit \
+         fallback"
+    );
+}
+
+/// AC #2: assert the 500ms timeout on the daemon Ping probe is
+/// documented. This is the "implicit fallback" semantic — a stale
+/// socket or hung daemon is treated as unavailable after 500ms.
+#[test]
+fn sweep_md_documents_500ms_daemon_probe_timeout() {
+    let content = read_sweep_md();
+    assert!(
+        content.contains("500ms"),
+        "sweep.md is missing the `500ms` daemon probe timeout — \
+         #3454 AC #2 requires the implicit fallback (timeout = \
+         daemon unavailable) be documented"
+    );
+}
+
+/// AC #3 & AC #4: assert smoke-test recipes for both backend paths
+/// are documented in the new section. The daemon-on path expects
+/// sub-2-second exit; the daemon-off path falls through to the
+/// existing in-process lifecycle.
+#[test]
+fn sweep_md_documents_smoke_test_recipes() {
+    let content = read_sweep_md();
+
+    // Sub-2-second exit expectation (AC #3 documented expectation).
+    assert!(
+        content.contains("< 2 seconds")
+            || content.contains("sub-2-second")
+            || content.contains("Sub-2-second"),
+        "sweep.md is missing the sub-2-second exit expectation for the \
+         daemon path — #3454 AC #3 requires this be documented"
+    );
+
+    // Daemon-off / single-token fallthrough (AC #4).
+    assert!(
+        content.contains("PROBE_POOL")
+            && (content.contains("single-token")
+                || content.contains("solo-token")
+                || content.contains("< 2 ACCOUNT_KEY_")),
+        "sweep.md is missing the daemon-off / single-token \
+         fallthrough recipe — #3454 AC #4 requires the no-behavior-\
+         change-for-solo-token-operators contract be documented"
+    );
+}
+
+/// AC #1 / #3: assert the dispatch tool (`mcp__loom__dispatch_sweep`,
+/// Phase A) is named as the daemon-path entry point. This anchors the
+/// Phase D documentation to the actual Phase A wire protocol.
+#[test]
+fn sweep_md_references_dispatch_sweep_mcp_tool() {
+    let content = read_sweep_md();
+    assert!(
+        content.contains("mcp__loom__dispatch_sweep"),
+        "sweep.md is missing the `mcp__loom__dispatch_sweep` MCP tool \
+         reference — #3454 requires the daemon dispatch path consume \
+         Phase A's tool (#3452)"
+    );
+}
+
+/// AC #1: assert the Limitations table records the Stage -1 row as
+/// Implemented (#3454). This is the operator-visible status flip that
+/// signals Phase D shipped.
+#[test]
+fn sweep_md_limitations_table_records_stage_minus_one_implemented() {
+    let content = read_sweep_md();
+    assert!(
+        content.contains("Daemon backend detection") && content.contains("Implemented (#3454)"),
+        "sweep.md Limitations table is missing the `Daemon backend \
+         detection | Implemented (#3454)` row — #3454 AC #1 requires \
+         the operator-visible status flip"
+    );
+}


### PR DESCRIPTION
## Summary

Adds **Stage -1: Backend detection** to `defaults/.claude/commands/loom/sweep.md` (Phase D of epic #3449). The new stage is prose for the LLM running the skill: probe whether the loom-daemon is reachable AND whether a multi-account token pool exists; if both hold and the mode is not C, dispatch each candidate issue to the daemon via `mcp__loom__dispatch_sweep` (Phase A, #3452) and exit sub-2-second. Otherwise fall through to today's in-process Mode A/B/C lifecycle unchanged — solo-token operators see no behaviour change.

### Decision tree (the contract)

```text
PROBE_MODE:
  If --prs flag present OR any PR-side NL trigger detected → Mode C (subagent always)

PROBE_DAEMON:
  Ping ~/.loom/loom-daemon.sock with 500ms timeout. Pong → reachable.

PROBE_POOL:
  Count *.token files in .loom/tokens/ OR ACCOUNT_KEY_* lines in .env. Pool exists if count >= 2.

DECIDE:
  if Mode C: use_subagent()
  elif --no-daemon: use_subagent()
  elif PROBE_DAEMON AND PROBE_POOL: use_daemon()
  else: use_subagent()
```

### Highlights

- **Strict AND** between daemon-reachable and pool-exists. No implicit auto-start, no "daemon if reachable even without pool" branch.
- **`--no-daemon` opt-out flag** — short-circuits to subagent before any probe. Added to optional flags, validation rules, and the decision tree.
- **500ms timeout** on the daemon Ping probe (`mcp__loom__list_sweeps` as a cheap reachability test). Timeout → daemon unavailable.
- **Mode C stays subagent-only** — daemon PR-set dispatch is an explicit non-goal of the parent epic. Mode C short-circuits before evaluating PROBE_DAEMON / PROBE_POOL.
- **Dispatch-only** — the skill does NOT subscribe to the Phase B (#3453) event bus. Operators monitor via `mcp__loom__list_sweeps` or Phase C tools.
- **Dry-run interaction**: when `--dry-run` is passed alongside the daemon path, the dry-run gate still runs and the skill EXITs without dispatching. Dry-run is a read-only contract independent of backend choice.

### Files changed

- `defaults/.claude/commands/loom/sweep.md` (+206 / -6) — adds Stage -1 section before "0. Dry-run gate"; adds `--no-daemon` to optional flags, validation rules, flag-stripping prose, and examples; updates Limitations table; adds reference links.
- `loom-daemon/tests/sweep_md_stage_minus_one_doc_lint.rs` (new, ~230 lines) — doc-lint test asserting the section header, all four decision-tree identifiers (PROBE_MODE / PROBE_DAEMON / PROBE_POOL / DECIDE), strict-AND precedence, Mode C short-circuit, `--no-daemon` flag occurrences, 500ms timeout, smoke-test recipes for both paths, the `mcp__loom__dispatch_sweep` reference, and the Limitations-table row. Modeled on Phase B's `sweep_md_doc_lint.rs` (#3453, PR #3460).

### Design note

Stage -1 sits **above Stage 0 (dry-run gate)** in the lifecycle but **routes Mode C to subagent before evaluating any probes**. This preserves dry-run as a read-only contract on both backend paths: `/loom:sweep 123 --dry-run` with daemon-up still prints the plan and exits without dispatching. The alternative (running the dry-run gate before Stage -1) would have produced the same observable behaviour for dry-run but would have made the daemon-path exit story muddier in the daemon-path fast case.

## Acceptance criteria

- **AC #1** — Decision tree explicit with `PROBE_MODE C → subagent`, else `PROBE_DAEMON ∧ PROBE_POOL → daemon`, else `subagent`; doc-lint test asserts it is unambiguous. **PASS** — the literal pseudocode block is present, strict-AND text is explicit, and the new doc-lint test pins all of it.
- **AC #2** — Explicit `--no-daemon` opt-out flag AND implicit fallback (`PROBE_DAEMON` timeout → daemon unavailable). **PASS** — `--no-daemon` added in three places (optional flags, validation rules, decision tree); 500ms timeout documented in PROBE_DAEMON pseudocode.
- **AC #3** — Smoke-test recipe with daemon + multi-account pool that documents sub-2-second exit. **PASS** — "Daemon-on + multi-account pool" recipe under "Smoke tests (documented expectations)" sets the `< 2 seconds` expectation and describes the dispatch-and-exit flow.
- **AC #4** — Without daemon, same command runs sequentially in-process — no behaviour change for solo-token operators. **PASS** — "Daemon-off OR single-token" recipe documents the fallthrough; "The subagent fallthrough" subsection states "No behaviour change for solo-token operators".

## Test plan

- [x] `cargo test -p loom-daemon --test sweep_md_stage_minus_one_doc_lint` — 9 / 9 pass
- [x] `cargo test -p loom-daemon --test sweep_md_doc_lint` — 4 / 4 pass (Phase B doc-lint unaffected)
- [x] `cargo test -p loom-daemon --lib` — 324 / 324 pass (no library changes)
- [x] Manual reading of the new section against the issue body — decision tree matches verbatim, three probes spelled out with concrete commands, --no-daemon documented in all three required spots, smoke-test recipes for both paths, Limitations table updated

Closes #3454
Part of epic #3449

Generated with Claude Code