### PR TITLE
feat(mcp-loom): Phase C — sweep monitoring + subscription tools (#3455)

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -1,95 +1,297 @@
 # Loom Daemon Reference
 
-> **⚠️ Stop-gap — daemon backend in flight (epic #3449, stop-gap #3451)**
->
-> The "preserved, re-implemented" claim below describes the v0.10.0 target state. As of v0.9.1, `./.loom/scripts/daemon.sh` does **not** exist on `origin/main` — it was deleted in #3432 and is being rebuilt in epic #3449 (~4-6 weeks). Until that rebuild lands, all `./.loom/scripts/daemon.sh start|stop|status` commands in this page will fail with "no such file or directory". Use `./.loom/scripts/spawn-loop.sh` (headless) or `/loom:sweep <issue>` instead.
+> **Status: ACTIVE (v0.10.0).** This page describes the Rust `loom-daemon`
+> binary and its MCP-facing surface — the dispatch + pub/sub + monitoring
+> tools delivered by epic #3449 (Phases A through C). The legacy Python
+> `loom-daemon` brain (`loom_tools/daemon_v2/`) and the `/shepherd`
+> orchestrator were deleted in the v0.10.0 deprecation epic (#3372). The
+> shell-level `./.loom/scripts/daemon.sh` tmux session launcher (when
+> rebuilt under epic #3449's later phases) wraps this same daemon binary.
 
-> **Status: PRESERVED, RE-IMPLEMENTED in v0.10.0.** The Python `loom-daemon`
-> brain (`loom_tools/daemon_v2/`) and the `/shepherd` orchestrator are
-> deleted in v0.10.0 as part of the shepherd/daemon-brain deprecation epic
-> (#3372). **The shell-level daemon surface — `./.loom/scripts/daemon.sh` +
-> tmux session runner + per-pane OAuth token rotation — is preserved.**
-> The user-facing API is unchanged; only the internals are different.
->
-> The historical contents of this page — `ISSUE_THRESHOLD` /
-> `MAX_SHEPHERDS` tuning tables, the `daemon-state.json` schema,
-> session-rotation procedures, shepherd pool sizing, etc. — described a
-> Python brain that no longer exists. Those tunables are gone.
+## What the daemon is
 
-## What daemon mode is in v0.10.0
+`loom-daemon` is a Rust process that exposes a Unix-socket IPC surface
+(framed JSON, line-delimited) and a paired `mcp-loom` MCP server which
+maps each IPC request 1:1 to an MCP tool. The daemon is **the
+coordination point** for:
 
-`./.loom/scripts/daemon.sh start` opens a tmux session whose panes each
-run a fresh Claude Code session via `spawn-claude.sh` (one rotated OAuth
-token per pane). This is the **"daemon-managed tmux sessions that launch
-Loom agents as separate Claude Code sessions"** execution surface. It is
-the long-running, multi-account-rotated counterpart to `/loom:sweep`'s
-in-session subagent dispatch.
+- **Dispatching** `/loom:sweep` children with multi-account OAuth token
+  rotation (via `defaults/scripts/spawn-claude.sh`).
+- **Tracking** running sweeps in an in-memory registry (no on-disk state
+  file — the forge is the source of truth for queue state).
+- **Publishing** sweep-lifecycle events on an in-memory pub/sub bus, and
+  **subscribing** external monitors to topic-filtered streams.
+- **Cancelling** in-flight sweeps with SIGTERM → grace → SIGKILL.
+- **Reaping** dead PIDs (every 30s) to maintain registry liveness and
+  emit `sweep.issue.*.exited` / `sweep.issue.*.crashed` events.
 
-| Surface | Process model | Token model | Best for |
-|---------|---------------|-------------|----------|
-| `/loom:sweep` (subagent dispatch) | Single process, multiple subagents | Single OAuth token (parent's) | Operator-driven batches, ≤ hours of runtime |
-| `./.loom/scripts/daemon.sh` (tmux) | Multiple processes (one per pane + sweep child) | Rotated per process via `spawn-claude.sh` | Multi-day autonomous operation across multiple accounts |
+It is **not** a work generator. It does not poll the forge for ready
+issues, it does not maintain a `shepherd-N` pool, and it does not run
+support roles on cron. Those responsibilities live in `spawn-loop.sh`
+(`./.loom/scripts/spawn-loop.sh`) and the GitHub Actions cron workflows
+(`.github/workflows/loom-*.yml`).
 
-Both surfaces are first-class. Pick by runtime expectations. See
-[`docs/migration/v0.10.0-shepherd-deprecation.md`](../../docs/migration/v0.10.0-shepherd-deprecation.md)
-for the migration narrative.
+## Architecture (Phases A-C)
 
-## What is removed in v0.10.0
+```
+┌────────────────────────────────────────────────────────────────┐
+│                      MCP clients (Claude Code)                 │
+│  - dispatch_sweep, list_sweeps                          (A)    │
+│  - publish_event, subscribe_to_events                   (B)    │
+│  - get_sweep_status, tail_sweep_log, cancel_sweep       (C)    │
+│  - tail_event_bus                                       (C)    │
+└────────────────────────────────────────────────────────────────┘
+                              │ stdio JSON-RPC
+                              ▼
+┌────────────────────────────────────────────────────────────────┐
+│                    mcp-loom (TypeScript)                       │
+│  - Validates args, normalizes payloads, formats output         │
+│  - One MCP tool per IPC Request variant                        │
+└────────────────────────────────────────────────────────────────┘
+                              │ Unix socket, line-delimited JSON
+                              ▼
+┌────────────────────────────────────────────────────────────────┐
+│                    loom-daemon (Rust)                          │
+│  ┌──────────────────┐  ┌──────────────────┐  ┌──────────────┐  │
+│  │ SweepRegistry    │  │ EventBus         │  │ ReaperTask   │  │
+│  │ (BTreeMap)       │  │ (broadcast chan) │  │ (30s tick)   │  │
+│  └──────────────────┘  └──────────────────┘  └──────────────┘  │
+│                              │                                  │
+│                              ▼                                  │
+│                    fork+exec /loom:sweep N                      │
+│                    via spawn-claude.sh                          │
+└────────────────────────────────────────────────────────────────┘
+                              │ detached child
+                              ▼
+                       /loom:sweep <issue>
+                       (Claude Code session)
+```
 
-If you were relying on these, you have a migration:
+## IPC surface (Request/Response variants)
 
-| Removed | Replacement | Where |
-|---------|-------------|-------|
-| Python `loom-daemon` CLI entry point | `./.loom/scripts/daemon.sh start` (re-implemented) | This page |
-| `/shepherd <issue>` slash command | `/loom:sweep <issue>` | `.claude/commands/loom/sweep.md` |
-| `loom-shepherd` Python CLI | `claude -p "/loom:sweep <N>" --dangerously-skip-permissions` | Same skill, headless invocation |
-| `.loom/daemon-state.json` | `.loom/spawn-loop-state.json` (smaller schema) | Written by `spawn-loop.sh`; see [`spawn-loop.sh status`](../../.loom/scripts/spawn-loop.sh) |
-| `.loom/progress/shepherd-*.json` heartbeats | `.loom/sweep-checkpoint/issue-<N>.json` (#3373) | Written by `/loom:sweep` |
-| `loom-validate-state` | Presence check on `.loom/spawn-loop-state.json` | Use `[[ -f .loom/spawn-loop-state.json ]]` |
-| Support-role daemons running inside the Python brain | GitHub Actions cron workflows | `.github/workflows/loom-*.yml` (#3375) |
+The wire protocol is line-delimited JSON. Each `Request` is one line; the
+daemon responds with one line per request — except `SubscribeEvents`,
+which holds the connection open and streams one `EventStream` frame per
+event. Connection framing matches the existing terminal-management IPC
+surface; no new transport is introduced.
 
-For the per-CLI breaking changes and field-level diff, see
-[`docs/migration/v0.10.0-shepherd-deprecation.md § Per-CLI breaking
-changes`](../../docs/migration/v0.10.0-shepherd-deprecation.md#per-cli-breaking-changes).
+Source of truth: [`loom-daemon/src/types.rs`](../../loom-daemon/src/types.rs).
 
-For the engineering inventory that drove the deletion decisions (which
-consumers retire, which port, which are unchanged), see
-[`docs/migration/daemon-state-consumers.md`](../../docs/migration/daemon-state-consumers.md).
+| Request | MCP tool | Response | Phase |
+|---------|----------|----------|-------|
+| `DispatchSweep`     | `dispatch_sweep`       | `SweepDispatched`   | A (#3452) |
+| `ListSweeps`        | `list_sweeps`          | `SweepList`         | A (#3452) |
+| `PublishEvent`      | `publish_event`        | `EventPublished`    | B (#3453) |
+| `SubscribeEvents`   | `subscribe_to_events`, `tail_event_bus` | `EventStream` (stream) | B (#3453) |
+| `GetSweepStatus`    | `get_sweep_status`     | `SweepStatus`       | C (#3455) |
+| `TailSweepLog`      | `tail_sweep_log`       | `SweepLogTail`      | C (#3455) |
+| `CancelSweep`       | `cancel_sweep`         | `SweepCancelled`    | C (#3455) |
 
-## Why this file is intentionally minimal
+## Event taxonomy (frozen for v0.10.0)
 
-The legacy schema and tuning advice on this page were a pre-Phase-3
-reference for a multi-process Python daemon that polled the forge, scaled
-a `shepherd-N` pool, ran work-generation triggers (Architect/Hermit), and
-maintained a JSON state file as the canonical source of truth. **None of
-that exists post-v0.10.0.** The shell-level daemon mode that survives is
-deliberately thinner:
+The bus accepts arbitrary topic strings, but the documented taxonomy is
+the contract subscribers should rely on. **New topics require a follow-up
+issue** — the v0.10.0 set is intentionally frozen.
 
-- The daemon **does not** generate work — Architect and Hermit cadence is
-  out of scope for v0.10.0 and tracked under follow-up #3381.
-- The daemon **does not maintain a shepherd-N pool**. Each ready issue
-  detaches its own `claude -p "/loom:sweep N"` child via the spawn loop;
-  concurrency is bounded by `MAX_PARALLEL` only.
-- The daemon **does not track `pipeline_state`, `warnings`,
-  `completed_issues`, `total_prs_merged`, or `last_*_trigger`**. The forge
-  is the source of truth for pipeline state; failure counters live in
-  `.loom/tokens/.failure_counts` (token-rotation only).
-- Support roles run as **cron-driven** GitHub Actions workflows, not as
-  long-running daemon-managed processes (though operators can opt to run
-  them in tmux panes — see the migration guide). There is no
-  `JUDGE_INTERVAL` / `CHAMPION_INTERVAL` / etc. to tune from a daemon
-  config.
+| Topic | Publisher | Payload |
+|-------|-----------|---------|
+| `sweep.issue.{N}.phase`   | Sweep child via `publish_event` | `{phase, pr_number?}` |
+| `sweep.issue.{N}.blocker` | Sweep child                     | `{reason, label_added}` |
+| `sweep.issue.{N}.exited`  | Daemon reaper (or `cancel_sweep`) | `{exit_code, duration_sec}` |
+| `sweep.issue.{N}.crashed` | Daemon reaper                   | `{checkpoint_phase}` |
+| `sweep.global.dispatch`   | Daemon                          | `{sweep_id, kind}` |
+| `sweep.global.completed`  | Daemon                          | `{sweep_id, outcome}` |
 
-Re-creating a "compatibility-shape" `daemon-state.json` from the spawn
-loop was considered and rejected — see the rationale in
-`docs/migration/daemon-state-consumers.md` §"Conclusion: what Phase 3
-deletes vs preserves".
+In addition, the bus internally emits:
 
-## Rust `loom-daemon` (unrelated, still supported)
+- `sweep.system.topic_lag` — synthetic event when a subscription falls
+  behind the publisher past the bus capacity. Mirrors tokio's `Lagged`
+  semantics; carries `{skipped: usize}`.
 
-This page is about the **shell-level Loom daemon mode** + the deleted
-**Python** `loom-daemon` CLI. The **Rust** binary at `loom-daemon/`
-(Tauri-side IPC daemon, tmux session manager) is a different component
-and is unaffected by Phase 3. Its source lives in `loom-daemon/src/`, its
-tests in `loom-daemon/tests/`, and its release artifacts ship with the
-rest of the Tauri quickstart.
+Topic matching is **segment-aligned prefix** (`sweep.issue` matches
+`sweep.issue.123.phase` but not `sweep.issuetype.foo`). See
+[`event_bus::topic_matches`](../../loom-daemon/src/event_bus.rs) for the
+authoritative routing rule.
+
+## MCP tool reference
+
+All tools live in `mcp-loom/src/tools/sweeps.ts`. Each tool name maps
+1:1 to an IPC `Request` variant.
+
+### `dispatch_sweep` (Phase A)
+
+Spawn a `/loom:sweep` child via the daemon's registry. The daemon shells
+out to `defaults/scripts/spawn-claude.sh` for token rotation and detaches
+the child. Returns the `sweep_id`, child PID, token-account name, and
+per-sweep log path.
+
+Inputs:
+- `kind` (required) — `{"Issue": <N>}` or `{"PrSet": [<N>, ...]}`. Phase
+  A only fully implements `Issue`; `PrSet` is rejected by the registry.
+- `idempotency_key` (optional) — dedup key. Running sweeps with the same
+  key return the existing `sweep_id` without spawning a new child.
+
+### `list_sweeps` (Phase A)
+
+Return all tracked sweeps, optionally filtered by lifecycle state.
+Terminal entries are garbage-collected ~1h after the transition.
+
+Inputs:
+- `state_filter` (optional) — one of `Pending`, `Running`, `Exited`,
+  `Crashed`.
+
+### `publish_event` (Phase B)
+
+Publish a JSON event onto the in-memory bus. Operator override / test
+escape hatch — production publishes happen via the sweep skill, not this
+tool.
+
+Inputs:
+- `topic` (required) — should follow the frozen taxonomy.
+- `payload` (required) — opaque JSON.
+
+### `subscribe_to_events` (Phase C)
+
+Open a long-lived subscription to the event bus, filtered by topic
+prefix. Frames arrive as line-delimited JSON matching
+`Response::EventStream { events: [Event] }`. The MCP layer caps each
+subscription with a `duration` window so a single tool call returns
+deterministically.
+
+Inputs:
+- `topics` (optional) — array of topic prefixes; empty = all events.
+- `duration` (optional, default `30s`) — `<N>s`/`<N>m`/`<N>h` window.
+- `max_events` (optional) — upper bound on frames returned.
+
+### `get_sweep_status` (Phase C)
+
+Return the `SweepInfo` for a single sweep plus up to N recent events
+observed on its topics (default 10). The bus is in-memory and transient
+— recent-events collection is a best-effort short subscribe window
+(~200ms), not a replay log.
+
+Inputs:
+- `sweep_id` (required).
+- `recent_events` (optional, default 10) — set to 0 to skip the
+  subscribe window.
+
+### `tail_sweep_log` (Phase C)
+
+Read the last N lines of a sweep's per-sweep log file
+(`.loom/logs/sweep-issue-<N>.log`). The log path is resolved from the
+registry entry.
+
+Inputs:
+- `sweep_id` (required).
+- `lines` (optional, default 100).
+
+### `cancel_sweep` (Phase C)
+
+SIGTERM → wait `grace` seconds → SIGKILL the sweep's child PID.
+Transitions the registry entry from `Running` to `Exited{code: None,
+at: now}` and releases the per-issue lock. Idempotent: cancelling an
+already-terminal sweep returns success with `was_running: false`.
+
+Inputs:
+- `sweep_id` (required).
+- `grace` (optional, default 30) — seconds between SIGTERM and SIGKILL.
+
+### `tail_event_bus` (Phase C)
+
+Debug-oriented fire-hose subscription that streams ALL events on the bus
+regardless of topic. Added per curator risk note D — multi-child
+interactions are qualitatively harder to debug than hermetic children.
+
+Inputs:
+- `since` (optional, default `10m`) — `<N>s`/`<N>m`/`<N>h` streaming
+  window. **Note**: the bus is transient — `since` is a streaming
+  duration, not a backward-looking replay filter.
+- `max_events` (optional) — upper bound on frames returned.
+
+## In-memory registry layout
+
+The sweep registry (`loom-daemon/src/sweep_registry.rs`) holds a
+`BTreeMap<SweepId, SweepInfo>` keyed by stable IDs of the form
+`sweep-issue-<N>-<unix-secs>` or `sweep-prs-<n1>-<n2>-...-<unix-secs>`.
+`SweepInfo` carries:
+
+- `sweep_id`, `kind` (`Issue(N)` or `PrSet(Vec<u32>)`), `pid`,
+  `token_name`, `log_path`.
+- `idempotency_key` (optional), `started_at`.
+- `state` — one of `Pending`, `Running`, `Exited{code, at}`,
+  `Crashed{at}`.
+- `latest_phase` (optional) — most-recent phase advertised via
+  checkpoint.
+- `pr_number` (optional, reserved).
+
+The wire shape is pinned by `sweep_info_schema_snapshot` in
+`sweep_registry.rs` — a change to the JSON shape requires deliberate
+test update.
+
+## Reaper task
+
+The reaper (`sweep_registry::spawn_reaper_task`) ticks every 30 seconds
+(env-overridable via `LOOM_SWEEP_REAPER_INTERVAL_SECS`). Each tick:
+
+1. Snapshots live `Running`/`Pending` entries.
+2. Tests each PID via `kill(pid, 0)`.
+3. On dead PID:
+   - If a sweep checkpoint exists at
+     `.loom/sweep-checkpoint/issue-<N>.json`, marks the entry `Crashed`
+     and flips the forge label `loom:building` → `loom:issue` so the
+     next dispatch resumes from the checkpointed phase.
+   - Otherwise marks the entry `Exited{code: None}`.
+   - Emits `sweep.issue.{N}.exited` or `sweep.issue.{N}.crashed`, plus
+     a global `sweep.global.completed` event.
+4. Garbage-collects terminal entries older than the retention window
+   (default 1 hour).
+
+## Locks and lifecycle
+
+Each dispatched sweep acquires a directory lock under
+`.loom/locks/issue-<N>/` via `mkdir` (POSIX-atomic). The lock dir
+contains an `owner.json` with the dispatching daemon PID and the sweep
+ID. The reaper releases the lock when a child dies; `cancel_sweep`
+releases it explicitly. On daemon startup, `SweepRegistry::reconstruct`
+admits live-lock owners back into the registry and drops stale locks
+whose owner PID is dead.
+
+## What this page does NOT describe
+
+The legacy schema and tuning advice that historically lived here — the
+Python `daemon-state.json` schema, `MAX_SHEPHERDS`/`ISSUE_THRESHOLD`
+tunables, work-generation cooldowns, `shepherd-N` pool sizing — described
+a Python brain that no longer exists. **None of that exists post-v0.10.0.**
+
+- The daemon **does not** generate work. Architect and Hermit cadence
+  is out of scope and tracked under follow-up #3381.
+- The daemon **does not maintain a shepherd-N pool**. Each issue
+  detaches its own `claude -p "/loom:sweep N"` child; concurrency
+  bounds live in `spawn-loop.sh` (`MAX_PARALLEL`) or are operator-set
+  via separate `dispatch_sweep` MCP calls.
+- The daemon **does not track** `pipeline_state`, `warnings`,
+  `completed_issues`, or `last_*_trigger`. The forge is the source of
+  truth for pipeline state.
+- Support roles run as **cron-driven GitHub Actions workflows**, not as
+  long-running daemon-managed processes. There is no `JUDGE_INTERVAL`
+  or `CHAMPION_INTERVAL` to tune from daemon config.
+
+The decision to delete rather than re-implement the legacy state file
+is documented in `docs/migration/daemon-state-consumers.md` §"Conclusion:
+what Phase 3 deletes vs preserves".
+
+## Related resources
+
+- **Architecture epic**: [#3449](https://github.com/rjwalters/loom/issues/3449)
+  (rebuild of the daemon backend).
+- **Phase A** (dispatch surface): #3452 / PR #3459.
+- **Phase B** (event bus): #3453 / PR #3460.
+- **Phase C** (monitoring + subscription tools): #3455.
+- **Migration guide**:
+  [`docs/migration/v0.10.0-shepherd-deprecation.md`](../../docs/migration/v0.10.0-shepherd-deprecation.md).
+- **Source**:
+  - [`loom-daemon/src/types.rs`](../../loom-daemon/src/types.rs) — IPC types.
+  - [`loom-daemon/src/sweep_registry.rs`](../../loom-daemon/src/sweep_registry.rs) — registry + reaper.
+  - [`loom-daemon/src/event_bus.rs`](../../loom-daemon/src/event_bus.rs) — pub/sub bus.
+  - [`loom-daemon/src/ipc.rs`](../../loom-daemon/src/ipc.rs) — request dispatcher.
+  - [`mcp-loom/src/tools/sweeps.ts`](../../mcp-loom/src/tools/sweeps.ts) — MCP tool definitions.

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -794,6 +794,53 @@ fn handle_request(
         }
 
         // ====================================================================
+        // Sweep Monitoring Handlers (Issue #3455 — Phase C of #3449)
+        // ====================================================================
+        Request::GetSweepStatus { sweep_id } => {
+            let sr = sweep_registry
+                .lock()
+                .expect("Sweep registry mutex poisoned");
+            let info = sr.get_status(&sweep_id);
+            Response::SweepStatus { info }
+        }
+
+        Request::TailSweepLog { sweep_id, lines } => {
+            let sr = sweep_registry
+                .lock()
+                .expect("Sweep registry mutex poisoned");
+            match sr.tail_log(&sweep_id, lines) {
+                Ok((log_path, lines)) => Response::SweepLogTail {
+                    sweep_id,
+                    lines,
+                    log_path,
+                },
+                Err(e) => Response::Error {
+                    message: format!("tail_sweep_log failed: {e}"),
+                },
+            }
+        }
+
+        Request::CancelSweep {
+            sweep_id,
+            grace_secs,
+        } => {
+            let mut sr = sweep_registry
+                .lock()
+                .expect("Sweep registry mutex poisoned");
+            match sr.cancel(&sweep_id, std::time::Duration::from_secs(grace_secs)) {
+                Ok(outcome) => Response::SweepCancelled {
+                    sweep_id: outcome.sweep_id,
+                    pid: outcome.pid,
+                    sigkill_sent: outcome.sigkill_sent,
+                    was_running: outcome.was_running,
+                },
+                Err(e) => Response::Error {
+                    message: format!("cancel_sweep failed: {e}"),
+                },
+            }
+        }
+
+        // ====================================================================
         // Event Bus Handlers (Issue #3453 — Phase B of #3449)
         // ====================================================================
         Request::PublishEvent { topic, payload } => {
@@ -835,7 +882,7 @@ fn handle_request(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::panic)]
+#[allow(clippy::unwrap_used, clippy::panic, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::activity::ActivityDb;
@@ -1164,6 +1211,118 @@ exit 0
                 assert_eq!(payload, serde_json::json!({"phase": "builder"}));
             }
             other => panic!("Expected Generic event, got: {other:?}"),
+        }
+    }
+
+    // ===== Sweep monitoring IPC handlers (Issue #3455, Phase C) =====
+
+    #[test]
+    fn test_handle_request_get_sweep_status_missing() {
+        let (tm, db, _, bus) = setup_test_context();
+        let (sr, _dir, _rec) = setup_sweep_registry_in_tempdir();
+        let response = handle_request(
+            Request::GetSweepStatus {
+                sweep_id: "no-such-sweep".to_string(),
+            },
+            &tm,
+            &db,
+            &sr,
+            &bus,
+        );
+        match response {
+            Response::SweepStatus { info } => assert!(info.is_none()),
+            other => panic!("Expected SweepStatus, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_handle_request_tail_sweep_log_missing_sweep_returns_error() {
+        let (tm, db, _, bus) = setup_test_context();
+        let (sr, _dir, _rec) = setup_sweep_registry_in_tempdir();
+        let response = handle_request(
+            Request::TailSweepLog {
+                sweep_id: "no-such-sweep".to_string(),
+                lines: 10,
+            },
+            &tm,
+            &db,
+            &sr,
+            &bus,
+        );
+        match response {
+            Response::Error { message } => {
+                assert!(
+                    message.contains("unknown sweep_id"),
+                    "expected unknown sweep_id; got: {message}"
+                );
+            }
+            other => panic!("Expected Error, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_handle_request_cancel_sweep_unknown_returns_error() {
+        let (tm, db, _, bus) = setup_test_context();
+        let (sr, _dir, _rec) = setup_sweep_registry_in_tempdir();
+        let response = handle_request(
+            Request::CancelSweep {
+                sweep_id: "no-such-sweep".to_string(),
+                grace_secs: 1,
+            },
+            &tm,
+            &db,
+            &sr,
+            &bus,
+        );
+        match response {
+            Response::Error { message } => {
+                assert!(
+                    message.contains("unknown sweep_id"),
+                    "expected unknown sweep_id; got: {message}"
+                );
+            }
+            other => panic!("Expected Error, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_handle_request_get_sweep_status_returns_existing() {
+        let (tm, db, _, bus) = setup_test_context();
+        let (sr, _dir, _rec) = setup_sweep_registry_in_tempdir();
+
+        // Dispatch a sweep to get a real entry in the registry.
+        let dispatched = handle_request(
+            Request::DispatchSweep {
+                kind: SweepKind::Issue(444),
+                idempotency_key: None,
+            },
+            &tm,
+            &db,
+            &sr,
+            &bus,
+        );
+        let sweep_id = match dispatched {
+            Response::SweepDispatched { sweep_id, .. } => sweep_id,
+            other => panic!("Expected SweepDispatched, got: {other:?}"),
+        };
+
+        let response = handle_request(
+            Request::GetSweepStatus {
+                sweep_id: sweep_id.clone(),
+            },
+            &tm,
+            &db,
+            &sr,
+            &bus,
+        );
+        match response {
+            Response::SweepStatus { info } => {
+                let info = info.expect("status should be Some");
+                assert_eq!(info.sweep_id, sweep_id);
+                assert!(matches!(info.kind, SweepKind::Issue(444)));
+            }
+            other => panic!("Expected SweepStatus, got: {other:?}"),
         }
     }
 

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -550,6 +550,133 @@ impl SweepRegistry {
     }
 
     // ------------------------------------------------------------------------
+    // Cancellation + status accessors (Issue #3455, Phase C)
+    // ------------------------------------------------------------------------
+
+    /// Return the `SweepInfo` for the given sweep ID, cloned (so callers
+    /// can release the registry lock immediately). Phase C exposes this
+    /// as the `get_sweep_status` MCP tool.
+    #[must_use]
+    pub fn get_status(&self, sweep_id: &str) -> Option<SweepInfo> {
+        self.entries.get(sweep_id).cloned()
+    }
+
+    /// Cancel a running sweep.
+    ///
+    /// Sends SIGTERM, waits up to `grace` for the child to exit (polled
+    /// via `kill(pid, 0)`), then SIGKILL if still alive. On any path the
+    /// registry entry is transitioned to `Exited{code: None, at: now}`
+    /// and the per-issue lock is released. Emits the same lifecycle
+    /// events the reaper would emit on a clean exit
+    /// (`sweep.issue.{N}.exited` + `sweep.global.completed`).
+    ///
+    /// Returns [`CancelOutcome`] describing what actually happened. Calls
+    /// against unknown sweep IDs return `Err`. Calls against already-
+    /// terminal sweeps return `Ok` with `was_running = false` — cancel
+    /// is idempotent so monitor-tool retries don't surface as errors.
+    pub fn cancel(&mut self, sweep_id: &str, grace: Duration) -> Result<CancelOutcome> {
+        let (pid, kind, was_running, started_at) = {
+            let info = self
+                .entries
+                .get(sweep_id)
+                .ok_or_else(|| anyhow!("unknown sweep_id: {sweep_id}"))?;
+            let alive = matches!(info.state, SweepState::Running | SweepState::Pending);
+            (info.pid, info.kind.clone(), alive, info.started_at)
+        };
+
+        if !was_running {
+            // Already terminal — nothing to signal. Return success so
+            // duplicate cancel-from-monitor requests stay idempotent.
+            return Ok(CancelOutcome {
+                sweep_id: sweep_id.to_string(),
+                pid,
+                sigkill_sent: false,
+                was_running: false,
+            });
+        }
+
+        // Step 1: SIGTERM (signal 15). We send via `kill(2)` directly
+        // rather than spawning `kill(1)` so the path is identical on
+        // macOS + Linux and we don't depend on `PATH`.
+        let term_sent = send_signal(pid, 15);
+        if !term_sent {
+            log::warn!(
+                "cancel_sweep: SIGTERM to pid {pid} for sweep {sweep_id} failed \
+                 (process may already be dead)"
+            );
+        }
+
+        // Step 2: poll for exit up to the grace window. We poll every
+        // 100ms (matches the spawn-loop's shutdown-grace polling
+        // cadence). The poll loop is a blocking sleep — acceptable for
+        // an IPC handler since cancel is a low-frequency operator action.
+        let poll_interval = Duration::from_millis(100);
+        let deadline = std::time::Instant::now() + grace;
+        let mut exited_within_grace = !is_pid_alive(pid);
+        while !exited_within_grace && std::time::Instant::now() < deadline {
+            std::thread::sleep(poll_interval);
+            exited_within_grace = !is_pid_alive(pid);
+        }
+
+        // Step 3: SIGKILL if still alive.
+        let sigkill_sent = if exited_within_grace {
+            false
+        } else {
+            let killed = send_signal(pid, 9);
+            if !killed {
+                log::warn!("cancel_sweep: SIGKILL to pid {pid} also failed");
+            }
+            true
+        };
+
+        // Step 4: transition state, release lock, emit events.
+        let now = Utc::now();
+        let duration_sec = (now - started_at).num_seconds();
+        if let Some(info) = self.entries.get_mut(sweep_id) {
+            info.state = SweepState::Exited {
+                code: None,
+                at: now,
+            };
+        }
+        if let SweepKind::Issue(issue) = &kind {
+            let _ = self.release_lock(*issue);
+            self.emit_event(Event::SweepExited {
+                issue: *issue,
+                exit_code: None,
+                duration_sec,
+            });
+        }
+        self.emit_event(Event::SweepGlobalCompleted {
+            sweep_id: sweep_id.to_string(),
+            outcome: SweepOutcome::Exited,
+        });
+
+        Ok(CancelOutcome {
+            sweep_id: sweep_id.to_string(),
+            pid,
+            sigkill_sent,
+            was_running: true,
+        })
+    }
+
+    /// Read the last `lines` lines from a sweep's log file.
+    ///
+    /// Resolves the log path from the registry entry (so callers don't
+    /// have to know the workspace-relative naming convention). Returns
+    /// the absolute log path alongside the tail so the MCP layer can
+    /// surface it.
+    pub fn tail_log(&self, sweep_id: &str, lines: usize) -> Result<(PathBuf, Vec<String>)> {
+        let info = self
+            .entries
+            .get(sweep_id)
+            .ok_or_else(|| anyhow!("unknown sweep_id: {sweep_id}"))?;
+        let log_path = info.log_path.clone();
+        let tail = tail_lines(&log_path, lines)
+            .with_context(|| format!("failed to tail {}", log_path.display()))?;
+        Ok((log_path, tail))
+    }
+
+    // ------------------------------------------------------------------------
     // Reaper
     // ------------------------------------------------------------------------
 
@@ -837,6 +964,19 @@ pub struct DispatchOutcome {
     pub was_new: bool,
 }
 
+/// Result of a `cancel` call (Issue #3455, Phase C).
+#[derive(Debug, Clone)]
+pub struct CancelOutcome {
+    pub sweep_id: SweepId,
+    pub pid: u32,
+    /// `true` when the child did not exit within the grace window and
+    /// a SIGKILL was issued.
+    pub sigkill_sent: bool,
+    /// `true` when the sweep was in `Running`/`Pending` state at the
+    /// moment of the call; `false` when it was already terminal.
+    pub was_running: bool,
+}
+
 /// Generate a stable sweep ID for the given kind. Format follows the
 /// spawn-loop log naming convention so operators can correlate.
 #[must_use]
@@ -950,12 +1090,55 @@ fn read_checkpoint_phase(path: &Path) -> Option<String> {
         .map(ToString::to_string)
 }
 
+/// Send a signal to a PID. Returns `true` on success (signal queued or
+/// process already absent and the caller can treat that as "done"). PID
+/// 0 is rejected to avoid the POSIX broadcast-to-group semantics.
+#[cfg(unix)]
+fn send_signal(pid: u32, sig: i32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    let Ok(pid_t): Result<i32, _> = pid.try_into() else {
+        return false;
+    };
+    libc_kill(pid_t, sig) == 0
+}
+
+#[cfg(not(unix))]
+fn send_signal(_pid: u32, _sig: i32) -> bool {
+    // Non-unix platforms are not supported; return false so the cancel
+    // path surfaces a "kill failed" log but still transitions state.
+    false
+}
+
+/// Read the last `n` lines of a file. Returns an empty vec when the
+/// file is empty; returns an error when the file does not exist (so the
+/// caller can distinguish "no log yet" from "log gone").
+///
+/// Implementation is a simple full-read + split — sweep logs are
+/// bounded by the lifetime of a sweep (~tens of minutes typical) and
+/// the buffering overhead is dwarfed by the IPC round-trip. If sweep
+/// logs grow to GB-scale in a future release, swap this for a reverse
+/// reader.
+fn tail_lines(path: &Path, n: usize) -> Result<Vec<String>> {
+    let contents = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    if n == 0 {
+        return Ok(Vec::new());
+    }
+    let mut out: Vec<String> = contents.lines().map(ToString::to_string).collect();
+    if out.len() > n {
+        out = out.split_off(out.len() - n);
+    }
+    Ok(out)
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::panic)]
+#[allow(clippy::unwrap_used, clippy::panic, clippy::expect_used)]
 mod tests {
     use super::*;
     use serial_test::serial;
@@ -1577,5 +1760,298 @@ exit 0
                 "details": {"at": "2026-06-05T10:05:00Z"}
             })
         );
+    }
+
+    // ========================================================================
+    // Phase C tests (Issue #3455)
+    // ========================================================================
+
+    #[test]
+    fn get_status_returns_clone_or_none() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+
+        assert!(registry.get_status("missing").is_none());
+
+        let sweep_id = "sweep-status-test".to_string();
+        registry.entries.insert(
+            sweep_id.clone(),
+            SweepInfo {
+                sweep_id: sweep_id.clone(),
+                kind: SweepKind::Issue(42),
+                pid: 1234,
+                token_name: "agent-1.token".into(),
+                log_path: registry.compute_log_path(42),
+                idempotency_key: None,
+                started_at: Utc::now(),
+                state: SweepState::Running,
+                latest_phase: Some("builder".into()),
+                pr_number: None,
+            },
+        );
+
+        let info = registry.get_status(&sweep_id).expect("status should exist");
+        assert_eq!(info.pid, 1234);
+        assert!(matches!(info.kind, SweepKind::Issue(42)));
+        assert!(matches!(info.state, SweepState::Running));
+    }
+
+    #[test]
+    fn tail_log_returns_last_n_lines() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+
+        let log_path = registry.compute_log_path(99);
+        std::fs::create_dir_all(log_path.parent().unwrap()).unwrap();
+        let body = (1..=20)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(&log_path, body).unwrap();
+
+        let sweep_id = "sweep-tail-test".to_string();
+        registry.entries.insert(
+            sweep_id.clone(),
+            SweepInfo {
+                sweep_id: sweep_id.clone(),
+                kind: SweepKind::Issue(99),
+                pid: 1,
+                token_name: "unknown".into(),
+                log_path: log_path.clone(),
+                idempotency_key: None,
+                started_at: Utc::now(),
+                state: SweepState::Running,
+                latest_phase: None,
+                pr_number: None,
+            },
+        );
+
+        let (path, tail) = registry.tail_log(&sweep_id, 5).unwrap();
+        assert_eq!(path, log_path);
+        assert_eq!(tail.len(), 5);
+        assert_eq!(tail[0], "line 16");
+        assert_eq!(tail[4], "line 20");
+
+        // Requesting more lines than the file has should yield the whole file.
+        let (_path, tail) = registry.tail_log(&sweep_id, 1000).unwrap();
+        assert_eq!(tail.len(), 20);
+
+        // Zero is honored (returns empty vec).
+        let (_path, tail) = registry.tail_log(&sweep_id, 0).unwrap();
+        assert!(tail.is_empty());
+    }
+
+    #[test]
+    fn tail_log_rejects_unknown_sweep() {
+        let dir = tempdir().unwrap();
+        let (registry, _record_log) = fixture_registry(dir.path());
+        let err = registry.tail_log("nope", 10).unwrap_err();
+        assert!(err.to_string().contains("unknown sweep_id"));
+    }
+
+    #[test]
+    fn cancel_unknown_sweep_returns_error() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+        let err = registry
+            .cancel("does-not-exist", Duration::from_millis(50))
+            .unwrap_err();
+        assert!(err.to_string().contains("unknown sweep_id"));
+    }
+
+    #[test]
+    fn cancel_on_already_terminal_is_idempotent_noop() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+
+        let sweep_id = "sweep-already-exited".to_string();
+        registry.entries.insert(
+            sweep_id.clone(),
+            SweepInfo {
+                sweep_id: sweep_id.clone(),
+                kind: SweepKind::Issue(11),
+                pid: 1,
+                token_name: "unknown".into(),
+                log_path: registry.compute_log_path(11),
+                idempotency_key: None,
+                started_at: Utc::now(),
+                state: SweepState::Exited {
+                    code: Some(0),
+                    at: Utc::now(),
+                },
+                latest_phase: None,
+                pr_number: None,
+            },
+        );
+
+        let outcome = registry
+            .cancel(&sweep_id, Duration::from_millis(50))
+            .unwrap();
+        assert!(!outcome.was_running);
+        assert!(!outcome.sigkill_sent);
+        // State should remain Exited (not flipped to Exited{None, now}).
+        let info = registry.get(&sweep_id).unwrap();
+        if let SweepState::Exited { code, .. } = &info.state {
+            assert_eq!(*code, Some(0));
+        } else {
+            panic!("state should remain Exited");
+        }
+    }
+
+    #[test]
+    fn cancel_dead_pid_transitions_to_exited_without_sigkill() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+
+        let sweep_id = "sweep-dead-pid".to_string();
+        registry.entries.insert(
+            sweep_id.clone(),
+            SweepInfo {
+                sweep_id: sweep_id.clone(),
+                kind: SweepKind::Issue(22),
+                pid: 2_147_483_640, // ~i32::MAX, almost certainly dead
+                token_name: "unknown".into(),
+                log_path: registry.compute_log_path(22),
+                idempotency_key: None,
+                started_at: Utc::now(),
+                state: SweepState::Running,
+                latest_phase: None,
+                pr_number: None,
+            },
+        );
+
+        let outcome = registry
+            .cancel(&sweep_id, Duration::from_millis(200))
+            .unwrap();
+        assert!(outcome.was_running);
+        // SIGTERM to a dead pid is a no-op success; the poll loop sees
+        // pid dead immediately and never escalates to SIGKILL.
+        assert!(!outcome.sigkill_sent);
+        let info = registry.get(&sweep_id).unwrap();
+        assert!(matches!(info.state, SweepState::Exited { .. }));
+    }
+
+    /// AC #3: SIGTERM -> grace -> SIGKILL against a fixture child that
+    /// ignores SIGTERM. Spawns `bash -c 'trap "" TERM; sleep 5'`, asks
+    /// the registry to cancel with a short grace, and asserts that the
+    /// registry transitioned + sigkill_sent=true. We then `wait()` on the
+    /// `Child` handle to reap the zombie before asserting liveness.
+    #[test]
+    fn cancel_escalates_to_sigkill_when_child_ignores_sigterm() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+
+        // Spawn a real child that traps SIGTERM and sleeps for 30s.
+        // We need a real PID so SIGTERM/SIGKILL paths are exercised end
+        // to end. We keep the Child handle so we can `wait()` after the
+        // cancel — without that, SIGKILL leaves the child as a zombie
+        // and `kill(pid, 0)` still returns success (the PID is still in
+        // the process table).
+        let mut child = Command::new("bash")
+            .arg("-c")
+            .arg("trap '' TERM; sleep 30")
+            .spawn()
+            .expect("spawn fixture child");
+        let pid = child.id();
+
+        // Give bash a moment to install the trap before we try to TERM it.
+        std::thread::sleep(Duration::from_millis(100));
+
+        let sweep_id = "sweep-trap-term".to_string();
+        registry.entries.insert(
+            sweep_id.clone(),
+            SweepInfo {
+                sweep_id: sweep_id.clone(),
+                kind: SweepKind::Issue(77),
+                pid,
+                token_name: "unknown".into(),
+                log_path: registry.compute_log_path(77),
+                idempotency_key: None,
+                started_at: Utc::now(),
+                state: SweepState::Running,
+                latest_phase: None,
+                pr_number: None,
+            },
+        );
+
+        // Use a short grace — long enough for SIGTERM to be delivered to
+        // a healthy bash (~200ms), short enough to keep the test fast.
+        let outcome = registry
+            .cancel(&sweep_id, Duration::from_millis(500))
+            .expect("cancel should succeed");
+        assert!(outcome.was_running);
+        assert!(
+            outcome.sigkill_sent,
+            "trap '' TERM child should have survived SIGTERM and escalated to SIGKILL"
+        );
+
+        // Reap the zombie so the PID is truly gone from the process table.
+        let exit_status = child.wait().expect("wait on cancelled child");
+        // Exit status: killed by SIGKILL means no clean exit code on Unix;
+        // `success()` should be false. We don't assert specifics — the
+        // platform's signal-vs-exit-code reporting varies.
+        assert!(!exit_status.success(), "child should not have exited cleanly after SIGKILL");
+
+        let info = registry.get(&sweep_id).unwrap();
+        assert!(matches!(info.state, SweepState::Exited { .. }));
+    }
+
+    #[test]
+    fn cancel_emits_exited_and_completed_events() {
+        // Bus emission path: cancel a dead-pid sweep and confirm we
+        // see sweep.issue.{N}.exited + sweep.global.completed.
+        use crate::event_bus::EventBus;
+
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+        let bus = Arc::new(EventBus::new());
+        registry.set_event_bus(bus.clone());
+        let mut sub = bus.subscribe::<[&str; 0], &str>([]);
+
+        let sweep_id = "sweep-cancel-event".to_string();
+        registry.entries.insert(
+            sweep_id.clone(),
+            SweepInfo {
+                sweep_id: sweep_id.clone(),
+                kind: SweepKind::Issue(88),
+                pid: 2_147_483_640,
+                token_name: "unknown".into(),
+                log_path: registry.compute_log_path(88),
+                idempotency_key: None,
+                started_at: Utc::now(),
+                state: SweepState::Running,
+                latest_phase: None,
+                pr_number: None,
+            },
+        );
+
+        registry
+            .cancel(&sweep_id, Duration::from_millis(100))
+            .unwrap();
+
+        // Drain two events synchronously (cancel emits inline).
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let mut saw_exited = false;
+            let mut saw_completed = false;
+            for _ in 0..2 {
+                match sub.recv().await.unwrap() {
+                    Event::SweepExited { issue, .. } => {
+                        assert_eq!(issue, 88);
+                        saw_exited = true;
+                    }
+                    Event::SweepGlobalCompleted { outcome, .. } => {
+                        assert_eq!(outcome, SweepOutcome::Exited);
+                        saw_completed = true;
+                    }
+                    other => panic!("unexpected event: {other:?}"),
+                }
+            }
+            assert!(saw_exited);
+            assert!(saw_completed);
+        });
     }
 }

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -173,6 +173,33 @@ pub enum Request {
     SubscribeEvents {
         topics: Vec<String>,
     },
+    // ========================================================================
+    // Sweep Monitoring Requests (Issue #3455 — Phase C of #3449)
+    // ========================================================================
+    /// Return the `SweepInfo` for a given sweep ID. The daemon does NOT
+    /// include the recent event log here — recent events are filtered
+    /// client-side via a separate `SubscribeEvents` call. Phase C exposes
+    /// this as `get_sweep_status` in the MCP layer.
+    GetSweepStatus {
+        sweep_id: SweepId,
+    },
+    /// Read the last `lines` lines from a sweep's per-sweep log file.
+    /// Resolved relative to the registry's workspace root. Used by the
+    /// `tail_sweep_log` MCP tool.
+    TailSweepLog {
+        sweep_id: SweepId,
+        lines: usize,
+    },
+    /// Cancel a running sweep: send SIGTERM, wait the grace window, then
+    /// SIGKILL if still alive. Transitions the registry entry from
+    /// `Running` -> `Exited{code: None, at: now}` and releases the lock.
+    CancelSweep {
+        sweep_id: SweepId,
+        /// Seconds to wait between SIGTERM and SIGKILL. Defaults are
+        /// chosen by the MCP layer; the daemon honours whatever value
+        /// arrives in the request.
+        grace_secs: u64,
+    },
     Shutdown,
 }
 
@@ -260,6 +287,37 @@ pub enum Response {
     /// allowance for future batching without a wire-protocol change.
     EventStream {
         events: Vec<Event>,
+    },
+    // ========================================================================
+    // Sweep Monitoring Responses (Issue #3455 — Phase C of #3449)
+    // ========================================================================
+    /// Result of a `GetSweepStatus` request.
+    ///
+    /// `info` is `None` when no sweep with the requested ID is tracked.
+    SweepStatus {
+        info: Option<SweepInfo>,
+    },
+    /// Result of a `TailSweepLog` request.
+    ///
+    /// `lines` carries the requested tail (most-recent last). Missing
+    /// log files are reported via `Response::Error` instead of an empty
+    /// vec, so callers can distinguish "no entries yet" from "log gone".
+    SweepLogTail {
+        sweep_id: SweepId,
+        lines: Vec<String>,
+        /// Path actually read; useful for surfacing in operator output.
+        log_path: PathBuf,
+    },
+    /// Result of a `CancelSweep` request.
+    ///
+    /// `was_running` is `false` when the sweep was already terminal at
+    /// the moment of the cancel call (no-op success — the registry
+    /// state is unchanged).
+    SweepCancelled {
+        sweep_id: SweepId,
+        pid: u32,
+        sigkill_sent: bool,
+        was_running: bool,
     },
     /// Legacy error response (deprecated, use `StructuredError` for new code)
     /// Kept for backwards compatibility with existing frontends

--- a/mcp-loom/src/shared/daemon.ts
+++ b/mcp-loom/src/shared/daemon.ts
@@ -8,6 +8,43 @@ import { Socket } from "node:net";
 import { SOCKET_PATH } from "./config.js";
 
 /**
+ * Options for the streaming subscribe path (Issue #3455, Phase C).
+ */
+export interface StreamSubscribeOptions {
+  /**
+   * Optional duration after which the subscription closes automatically.
+   * Used by `tail_event_bus --since <duration>` to cap the streaming
+   * window. When undefined the connection stays open until the daemon
+   * closes it or `abort()` is called.
+   */
+  durationMs?: number;
+  /**
+   * Optional per-line callback invoked once per JSON frame from the
+   * daemon. Each frame is a `Response::EventStream { events: [...] }`
+   * payload. Implementations should treat the JSON as opaque and let
+   * the caller decode.
+   */
+  onLine?: (line: string) => void;
+  /**
+   * Maximum number of frames to collect before resolving. When set,
+   * acts as an upper bound on the returned array.
+   */
+  maxLines?: number;
+}
+
+/**
+ * Result of a streaming subscribe call.
+ */
+export interface StreamSubscribeResult {
+  /** Line-delimited JSON frames the daemon emitted during the window. */
+  lines: string[];
+  /** True when the duration window elapsed; false when the daemon closed first. */
+  closedByTimeout: boolean;
+  /** Total time the connection stayed open (ms). */
+  elapsedMs: number;
+}
+
+/**
  * Send a request to the Loom daemon and get the response
  *
  * Uses Unix domain socket to communicate with the running daemon.
@@ -42,6 +79,103 @@ export async function sendDaemonRequest(request: unknown): Promise<unknown> {
     socket.connect(SOCKET_PATH, () => {
       socket.write(JSON.stringify(request));
       socket.write("\n");
+    });
+  });
+}
+
+/**
+ * Send a streaming request (e.g. `SubscribeEvents`) and collect frames
+ * until the duration window elapses, the line cap is hit, or the daemon
+ * closes the connection.
+ *
+ * The daemon writes line-delimited JSON frames; this helper buffers
+ * partial reads and emits one entry per newline.
+ *
+ * Used by Phase C's `subscribe_to_events` and `tail_event_bus` tools.
+ */
+export async function sendDaemonStreamRequest(
+  request: unknown,
+  options: StreamSubscribeOptions = {}
+): Promise<StreamSubscribeResult> {
+  return new Promise((resolve, reject) => {
+    const socket = new Socket();
+    const lines: string[] = [];
+    let buffer = "";
+    let closedByTimeout = false;
+    let timer: NodeJS.Timeout | null = null;
+    const startedAt = Date.now();
+
+    const finish = () => {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      if (!socket.destroyed) {
+        socket.end();
+        socket.destroy();
+      }
+      resolve({
+        lines,
+        closedByTimeout,
+        elapsedMs: Date.now() - startedAt,
+      });
+    };
+
+    const consumeLine = (line: string) => {
+      const trimmed = line.trim();
+      if (trimmed.length === 0) return;
+      lines.push(trimmed);
+      if (options.onLine) {
+        try {
+          options.onLine(trimmed);
+        } catch {
+          // Swallow user-callback errors — they shouldn't tear down
+          // the stream collection path.
+        }
+      }
+      if (options.maxLines !== undefined && lines.length >= options.maxLines) {
+        finish();
+      }
+    };
+
+    socket.on("data", (data) => {
+      buffer += data.toString();
+      let nl = buffer.indexOf("\n");
+      while (nl !== -1) {
+        const line = buffer.slice(0, nl);
+        buffer = buffer.slice(nl + 1);
+        consumeLine(line);
+        nl = buffer.indexOf("\n");
+      }
+    });
+
+    socket.on("end", () => {
+      // Flush any trailing partial line.
+      if (buffer.length > 0) {
+        consumeLine(buffer);
+        buffer = "";
+      }
+      finish();
+    });
+
+    socket.on("close", () => {
+      finish();
+    });
+
+    socket.on("error", (error) => {
+      if (timer) clearTimeout(timer);
+      reject(new Error(`Failed to stream from Loom daemon at ${SOCKET_PATH}: ${error.message}`));
+    });
+
+    socket.connect(SOCKET_PATH, () => {
+      socket.write(JSON.stringify(request));
+      socket.write("\n");
+      if (options.durationMs !== undefined && options.durationMs > 0) {
+        timer = setTimeout(() => {
+          closedByTimeout = true;
+          finish();
+        }, options.durationMs);
+      }
     });
   });
 }

--- a/mcp-loom/src/tools/sweeps.ts
+++ b/mcp-loom/src/tools/sweeps.ts
@@ -1,24 +1,26 @@
 /**
- * Sweep tools for Loom MCP server (Issue #3452 — Phase A of #3449).
+ * Sweep tools for Loom MCP server.
  *
- * Exposes two tools for interacting with the loom-daemon's sweep registry:
+ * Phase A (Issue #3452) shipped `dispatch_sweep` + `list_sweeps`.
+ * Phase B (Issue #3453) shipped the event bus IPC surface (consumed below).
+ * Phase C (Issue #3455) adds the monitoring + subscription tools:
  *
- *   - `dispatch_sweep`  Spawn a `/loom:sweep` child via the daemon's
- *                       in-memory registry. The daemon shells out to
- *                       `defaults/scripts/spawn-claude.sh` for token rotation
- *                       and detaches the child; tracking is purely in-memory
- *                       (no daemon-side state file is written).
- *   - `list_sweeps`     Query tracked sweeps, optionally filtered by state.
- *
- * Remaining monitoring tools (`get_sweep_status`, `tail_sweep_log`,
- * `cancel_sweep`, pub/sub bus) come in Phase C — out of scope for this PR.
+ *   - `dispatch_sweep`      Spawn a `/loom:sweep` child via the daemon.
+ *   - `list_sweeps`         Query tracked sweeps, optionally filtered.
+ *   - `get_sweep_status`    Fetch a single SweepInfo + N recent events.
+ *   - `tail_sweep_log`      Read last N lines from a sweep's log file.
+ *   - `subscribe_to_events` Long-lived stream filtered by topic prefix.
+ *   - `publish_event`       Operator override / test escape hatch.
+ *   - `cancel_sweep`        SIGTERM -> grace -> SIGKILL; transitions to Exited.
+ *   - `tail_event_bus`      Debug fire-hose subscription with --since window.
  *
  * @see loom-daemon/src/types.rs — Request/Response variants.
  * @see loom-daemon/src/sweep_registry.rs — backend implementation.
+ * @see loom-daemon/src/event_bus.rs — pub/sub bus + topic taxonomy.
  */
 
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
-import { sendDaemonRequest } from "../shared/daemon.js";
+import { sendDaemonRequest, sendDaemonStreamRequest } from "../shared/daemon.js";
 
 // ============================================================================
 // Wire types
@@ -99,9 +101,47 @@ interface StructuredErrorResponse {
   payload: { message?: string };
 }
 
+interface SweepStatusResponse {
+  type: "SweepStatus";
+  payload: {
+    info: SweepInfo | null;
+  };
+}
+
+interface SweepLogTailResponse {
+  type: "SweepLogTail";
+  payload: {
+    sweep_id: string;
+    lines: string[];
+    log_path: string;
+  };
+}
+
+interface SweepCancelledResponse {
+  type: "SweepCancelled";
+  payload: {
+    sweep_id: string;
+    pid: number;
+    sigkill_sent: boolean;
+    was_running: boolean;
+  };
+}
+
+interface EventPublishedResponse {
+  type: "EventPublished";
+  payload: {
+    topic: string;
+    receivers: number;
+  };
+}
+
 type DaemonResponse =
   | DispatchResponse
   | ListResponse
+  | SweepStatusResponse
+  | SweepLogTailResponse
+  | SweepCancelledResponse
+  | EventPublishedResponse
   | ErrorResponse
   | StructuredErrorResponse
   | { type: string; payload?: unknown };
@@ -138,6 +178,38 @@ function buildStateFilter(stateArg: unknown): SweepState | null {
     return { state: "Crashed", details: {} };
   }
   return { state: stateArg };
+}
+
+/**
+ * Parse a duration string of the form `<N>s`, `<N>m`, or `<N>h` (case-
+ * insensitive). Returns the duration in milliseconds, or `null` for any
+ * invalid input. Used by `tail_event_bus --since`.
+ *
+ * Examples:
+ *   "10m" -> 600000
+ *   "1h"  -> 3600000
+ *   "30s" -> 30000
+ *   "10"  -> null (no unit)
+ *   "1d"  -> null (unsupported unit; days not in scope)
+ */
+export function parseDuration(input: string): number | null {
+  const trimmed = input.trim();
+  if (trimmed.length < 2) return null;
+  const match = trimmed.match(/^(\d+)([smhSMH])$/);
+  if (!match) return null;
+  const value = parseInt(match[1], 10);
+  if (!Number.isFinite(value) || value <= 0) return null;
+  const unit = match[2].toLowerCase();
+  switch (unit) {
+    case "s":
+      return value * 1000;
+    case "m":
+      return value * 60 * 1000;
+    case "h":
+      return value * 60 * 60 * 1000;
+    default:
+      return null;
+  }
 }
 
 // ============================================================================
@@ -192,6 +264,120 @@ async function listSweeps(args: {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Phase C: monitoring + subscription helpers (Issue #3455)
+// ---------------------------------------------------------------------------
+
+async function getSweepStatus(args: {
+  sweep_id: string;
+}): Promise<{ success: true; info: SweepInfo | null } | { success: false; error: string }> {
+  try {
+    const response = (await sendDaemonRequest({
+      type: "GetSweepStatus",
+      payload: { sweep_id: args.sweep_id },
+    })) as DaemonResponse;
+
+    if (response.type === "SweepStatus") {
+      return { success: true, info: (response as SweepStatusResponse).payload.info };
+    }
+    const err = extractError(response);
+    return { success: false, error: err ?? `Unexpected response: ${response.type}` };
+  } catch (error) {
+    return { success: false, error: `Error fetching sweep status: ${error}` };
+  }
+}
+
+async function tailSweepLog(args: {
+  sweep_id: string;
+  lines: number;
+}): Promise<
+  | { success: true; payload: SweepLogTailResponse["payload"] }
+  | { success: false; error: string }
+> {
+  try {
+    const response = (await sendDaemonRequest({
+      type: "TailSweepLog",
+      payload: { sweep_id: args.sweep_id, lines: args.lines },
+    })) as DaemonResponse;
+
+    if (response.type === "SweepLogTail") {
+      return { success: true, payload: (response as SweepLogTailResponse).payload };
+    }
+    const err = extractError(response);
+    return { success: false, error: err ?? `Unexpected response: ${response.type}` };
+  } catch (error) {
+    return { success: false, error: `Error tailing sweep log: ${error}` };
+  }
+}
+
+async function cancelSweep(args: {
+  sweep_id: string;
+  grace_secs: number;
+}): Promise<
+  | { success: true; payload: SweepCancelledResponse["payload"] }
+  | { success: false; error: string }
+> {
+  try {
+    const response = (await sendDaemonRequest({
+      type: "CancelSweep",
+      payload: { sweep_id: args.sweep_id, grace_secs: args.grace_secs },
+    })) as DaemonResponse;
+
+    if (response.type === "SweepCancelled") {
+      return { success: true, payload: (response as SweepCancelledResponse).payload };
+    }
+    const err = extractError(response);
+    return { success: false, error: err ?? `Unexpected response: ${response.type}` };
+  } catch (error) {
+    return { success: false, error: `Error cancelling sweep: ${error}` };
+  }
+}
+
+async function publishEvent(args: {
+  topic: string;
+  payload: unknown;
+}): Promise<
+  | { success: true; payload: EventPublishedResponse["payload"] }
+  | { success: false; error: string }
+> {
+  try {
+    const response = (await sendDaemonRequest({
+      type: "PublishEvent",
+      payload: { topic: args.topic, payload: args.payload },
+    })) as DaemonResponse;
+
+    if (response.type === "EventPublished") {
+      return { success: true, payload: (response as EventPublishedResponse).payload };
+    }
+    const err = extractError(response);
+    return { success: false, error: err ?? `Unexpected response: ${response.type}` };
+  } catch (error) {
+    return { success: false, error: `Error publishing event: ${error}` };
+  }
+}
+
+async function streamEvents(args: {
+  topics: string[];
+  durationMs?: number;
+  maxLines?: number;
+}): Promise<{ success: true; lines: string[]; closedByTimeout: boolean; elapsedMs: number } | { success: false; error: string }> {
+  try {
+    const result = await sendDaemonStreamRequest(
+      {
+        type: "SubscribeEvents",
+        payload: { topics: args.topics },
+      },
+      {
+        durationMs: args.durationMs,
+        maxLines: args.maxLines,
+      }
+    );
+    return { success: true, ...result };
+  } catch (error) {
+    return { success: false, error: `Error streaming events: ${error}` };
+  }
+}
+
 // ============================================================================
 // Tool definitions
 // ============================================================================
@@ -199,10 +385,8 @@ async function listSweeps(args: {
 /**
  * Sweep tool definitions exposed by the MCP server.
  *
- * Only two tools ship in Phase A. The remaining monitoring tools
- * (`get_sweep_status`, `tail_sweep_log`, `cancel_sweep`,
- * `subscribe_to_events`, `publish_event`) are reserved for Phase C of
- * epic #3449.
+ * Phase A shipped `dispatch_sweep` + `list_sweeps`. Phase C (Issue #3455)
+ * adds the six monitoring + subscription tools that follow.
  */
 export const sweepTools: Tool[] = [
   {
@@ -265,6 +449,180 @@ export const sweepTools: Tool[] = [
           enum: ["Pending", "Running", "Exited", "Crashed"],
           description:
             "Optional lifecycle state filter. Omit to list all tracked sweeps.",
+        },
+      },
+    },
+  },
+  {
+    name: "get_sweep_status",
+    description:
+      "Return the `SweepInfo` for a single sweep, plus optionally the N " +
+      "most-recent events observed on the in-memory event bus for that " +
+      "sweep's topics. Recent events are collected via a short subscribe " +
+      "window (default ~200ms); set `recent_events` to 0 to skip that step " +
+      "and return only the SweepInfo. Returns an error if the sweep ID is " +
+      "unknown to the registry.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sweep_id: {
+          type: "string",
+          description: "The sweep ID returned by `dispatch_sweep`.",
+        },
+        recent_events: {
+          type: "number",
+          description:
+            "Maximum number of recent events to surface alongside the " +
+            "SweepInfo. Defaults to 10. The bus is in-memory and transient " +
+            "— this is a best-effort recent-history sample, not a replay log.",
+        },
+      },
+      required: ["sweep_id"],
+    },
+  },
+  {
+    name: "tail_sweep_log",
+    description:
+      "Read the last N lines of a sweep's per-sweep log file " +
+      "(`.loom/logs/sweep-issue-<N>.log`). The log path is resolved from " +
+      "the registry entry — callers don't need to know the workspace layout. " +
+      "Returns an error if the sweep ID is unknown or the log file is " +
+      "missing on disk.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sweep_id: {
+          type: "string",
+          description: "The sweep ID returned by `dispatch_sweep`.",
+        },
+        lines: {
+          type: "number",
+          description: "Number of trailing lines to return. Defaults to 100.",
+        },
+      },
+      required: ["sweep_id"],
+    },
+  },
+  {
+    name: "subscribe_to_events",
+    description:
+      "Open a long-lived subscription to the loom-daemon's in-memory event " +
+      "bus, filtered by topic prefix. Events arrive as line-delimited JSON " +
+      "frames matching the `Response::EventStream { events: [Event] }` shape " +
+      "from `loom-daemon/src/types.rs`. Topic matching is segment-aligned " +
+      "prefix match (`sweep.issue` matches `sweep.issue.123.phase` but not " +
+      "`sweep.issuetype.foo`). The MCP layer caps each subscription with a " +
+      "`duration` window so a single tool call returns deterministically; " +
+      "set a longer duration for continuous monitoring scenarios. The bus " +
+      "taxonomy is frozen for v0.10.0 (see `.loom/docs/daemon-reference.md`).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        topics: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Topic prefixes to subscribe to. Pass an empty array (or omit) " +
+            "to receive all events — equivalent to `tail_event_bus` but " +
+            "without the time-window default.",
+        },
+        duration: {
+          type: "string",
+          description:
+            "How long to keep the subscription open. Accepts `<N>s`, `<N>m`, " +
+            "or `<N>h` (case-insensitive). Defaults to `30s`. Set a longer " +
+            "window for continuous monitoring.",
+        },
+        max_events: {
+          type: "number",
+          description:
+            "Optional upper bound on the number of frames returned. The " +
+            "subscription closes once either bound (duration or count) is " +
+            "reached, whichever comes first.",
+        },
+      },
+    },
+  },
+  {
+    name: "publish_event",
+    description:
+      "Publish a JSON event onto the loom-daemon's in-memory bus. Operator " +
+      "override and testing escape hatch — production publishes happen via " +
+      "the sweep skill, not this tool. Returns the number of receivers the " +
+      "event routed to. `topic` should follow the frozen taxonomy " +
+      "(`sweep.issue.{N}.phase` etc.); the bus accepts arbitrary topic " +
+      "strings, but downstream consumers only subscribe to documented topics.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        topic: {
+          type: "string",
+          description:
+            "Topic string. See `.loom/docs/daemon-reference.md` for the " +
+            "frozen taxonomy.",
+        },
+        payload: {
+          description:
+            "Opaque JSON payload. Per-topic schemas are documented in " +
+            "`defaults/.claude/commands/loom/sweep.md`.",
+        },
+      },
+      required: ["topic", "payload"],
+    },
+  },
+  {
+    name: "cancel_sweep",
+    description:
+      "Cancel a running sweep. Sends SIGTERM to the child PID, waits the " +
+      "grace window (default 30 seconds), then escalates to SIGKILL if the " +
+      "child is still alive. Transitions the registry entry from `Running` " +
+      "to `Exited{code: None, at: <now>}` regardless of which signal " +
+      "delivered the kill, and releases the per-issue lock. Idempotent: " +
+      "calling against an already-terminal sweep returns success with " +
+      "`was_running: false`.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sweep_id: {
+          type: "string",
+          description: "The sweep ID returned by `dispatch_sweep`.",
+        },
+        grace: {
+          type: "number",
+          description:
+            "Seconds between SIGTERM and SIGKILL. Defaults to 30. A value " +
+            "of 0 escalates to SIGKILL immediately after the first poll " +
+            "iteration (~100ms).",
+        },
+      },
+      required: ["sweep_id"],
+    },
+  },
+  {
+    name: "tail_event_bus",
+    description:
+      "Debug-oriented fire-hose subscription that streams ALL events on " +
+      "the bus regardless of topic (added per curator risk note D — " +
+      "multi-child interactions are qualitatively harder to debug than " +
+      "hermetic children). `--since` accepts `<N>s`, `<N>m`, or `<N>h` and " +
+      "caps how long the subscription stays open (the bus is in-memory and " +
+      "transient — `--since` is a streaming window, not a backward-looking " +
+      "replay filter). For topic-filtered streams, use `subscribe_to_events`.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        since: {
+          type: "string",
+          description:
+            "Streaming window duration. Accepts `<N>s`, `<N>m`, or `<N>h`. " +
+            "Defaults to `10m`.",
+        },
+        max_events: {
+          type: "number",
+          description:
+            "Optional upper bound on the number of frames returned. The " +
+            "subscription closes once either bound (duration or count) is " +
+            "reached, whichever comes first.",
         },
       },
     },
@@ -393,6 +751,315 @@ export async function handleSweepTool(
         {
           type: "text",
           text: `=== List Sweeps (${result.sweeps.length}) ===\n\n${lines}`,
+        },
+      ];
+    }
+
+    // ----- Phase C: monitoring + subscription tools -----
+
+    case "get_sweep_status": {
+      const sweepId = typeof args?.sweep_id === "string" ? args.sweep_id : "";
+      if (!sweepId) {
+        return [
+          {
+            type: "text",
+            text: "=== Get Sweep Status ===\n\nFailed\n\nError: `sweep_id` is required.",
+          },
+        ];
+      }
+      const recentEventsArg = args?.recent_events;
+      const recentEvents =
+        typeof recentEventsArg === "number" && Number.isFinite(recentEventsArg)
+          ? Math.max(0, Math.floor(recentEventsArg))
+          : 10;
+
+      const statusResult = await getSweepStatus({ sweep_id: sweepId });
+      if (!statusResult.success) {
+        return [
+          {
+            type: "text",
+            text: `=== Get Sweep Status ===\n\nFailed\n\n${statusResult.error}`,
+          },
+        ];
+      }
+      if (!statusResult.info) {
+        return [
+          {
+            type: "text",
+            text: `=== Get Sweep Status ===\n\nNo sweep with ID: ${sweepId}`,
+          },
+        ];
+      }
+
+      // Surface the SweepInfo as a structured JSON block plus a short
+      // human summary. Then attempt a short subscribe window for
+      // recent events — best-effort, never fails the whole tool.
+      const info = statusResult.info;
+      const sections: string[] = [
+        `=== Get Sweep Status: ${info.sweep_id} ===`,
+        "",
+        formatSweepLine(info),
+        "",
+        "Raw SweepInfo:",
+        "```json",
+        JSON.stringify(info, null, 2),
+        "```",
+      ];
+
+      if (recentEvents > 0) {
+        const topicPrefix =
+          info.kind.type === "Issue" ? `sweep.issue.${info.kind.value}` : "sweep";
+        const stream = await streamEvents({
+          topics: [topicPrefix],
+          durationMs: 200,
+          maxLines: recentEvents,
+        });
+        if (stream.success) {
+          if (stream.lines.length === 0) {
+            sections.push("", `Recent events (last ${recentEvents}, prefix=${topicPrefix}): none observed in 200ms window.`);
+          } else {
+            sections.push(
+              "",
+              `Recent events (${stream.lines.length}, prefix=${topicPrefix}):`,
+              "```",
+              ...stream.lines,
+              "```",
+            );
+          }
+        } else {
+          sections.push("", `Recent events: subscribe failed (${stream.error}).`);
+        }
+      }
+
+      return [{ type: "text", text: sections.join("\n") }];
+    }
+
+    case "tail_sweep_log": {
+      const sweepId = typeof args?.sweep_id === "string" ? args.sweep_id : "";
+      if (!sweepId) {
+        return [
+          {
+            type: "text",
+            text: "=== Tail Sweep Log ===\n\nFailed\n\nError: `sweep_id` is required.",
+          },
+        ];
+      }
+      const linesArg = args?.lines;
+      const lines =
+        typeof linesArg === "number" && Number.isFinite(linesArg)
+          ? Math.max(0, Math.floor(linesArg))
+          : 100;
+
+      const result = await tailSweepLog({ sweep_id: sweepId, lines });
+      if (!result.success) {
+        return [
+          {
+            type: "text",
+            text: `=== Tail Sweep Log ===\n\nFailed\n\n${result.error}`,
+          },
+        ];
+      }
+      const { log_path, lines: tail } = result.payload;
+      const body =
+        tail.length === 0
+          ? "(log is empty)"
+          : tail.join("\n");
+      return [
+        {
+          type: "text",
+          text: `=== Tail Sweep Log: ${sweepId} ===\n\nLog: ${log_path}\nLines: ${tail.length}\n\n${body}`,
+        },
+      ];
+    }
+
+    case "subscribe_to_events": {
+      const topicsArg = args?.topics;
+      const topics = Array.isArray(topicsArg)
+        ? topicsArg.filter((t): t is string => typeof t === "string")
+        : [];
+      const durationArg = args?.duration;
+      let durationMs = 30000;
+      if (typeof durationArg === "string" && durationArg.length > 0) {
+        const parsed = parseDuration(durationArg);
+        if (parsed === null) {
+          return [
+            {
+              type: "text",
+              text:
+                "=== Subscribe To Events ===\n\nFailed\n\nError: invalid `duration` " +
+                `'${durationArg}'. Use formats like '30s', '10m', or '1h'.`,
+            },
+          ];
+        }
+        durationMs = parsed;
+      }
+      const maxLinesArg = args?.max_events;
+      const maxLines =
+        typeof maxLinesArg === "number" && Number.isFinite(maxLinesArg) && maxLinesArg > 0
+          ? Math.floor(maxLinesArg)
+          : undefined;
+
+      const result = await streamEvents({ topics, durationMs, maxLines });
+      if (!result.success) {
+        return [
+          {
+            type: "text",
+            text: `=== Subscribe To Events ===\n\nFailed\n\n${result.error}`,
+          },
+        ];
+      }
+      const summary = [
+        `Topics:           ${topics.length === 0 ? "(all)" : topics.join(", ")}`,
+        `Frames received:  ${result.lines.length}`,
+        `Elapsed:          ${result.elapsedMs}ms`,
+        `Closed by:        ${result.closedByTimeout ? "duration window" : "daemon / max"}`,
+      ].join("\n");
+      const body =
+        result.lines.length === 0
+          ? "(no events observed)"
+          : result.lines.join("\n");
+      return [
+        {
+          type: "text",
+          text: `=== Subscribe To Events ===\n\n${summary}\n\nFrames:\n${body}`,
+        },
+      ];
+    }
+
+    case "publish_event": {
+      const topic = typeof args?.topic === "string" ? args.topic : "";
+      if (!topic) {
+        return [
+          {
+            type: "text",
+            text: "=== Publish Event ===\n\nFailed\n\nError: `topic` is required.",
+          },
+        ];
+      }
+      if (!("payload" in (args ?? {}))) {
+        return [
+          {
+            type: "text",
+            text: "=== Publish Event ===\n\nFailed\n\nError: `payload` is required (use {} for empty).",
+          },
+        ];
+      }
+      const payload = (args as { payload: unknown }).payload;
+
+      const result = await publishEvent({ topic, payload });
+      if (!result.success) {
+        return [
+          {
+            type: "text",
+            text: `=== Publish Event ===\n\nFailed\n\n${result.error}`,
+          },
+        ];
+      }
+      return [
+        {
+          type: "text",
+          text:
+            `=== Publish Event ===\n\nSuccess\n\nTopic:      ${result.payload.topic}\n` +
+            `Receivers:  ${result.payload.receivers}`,
+        },
+      ];
+    }
+
+    case "cancel_sweep": {
+      const sweepId = typeof args?.sweep_id === "string" ? args.sweep_id : "";
+      if (!sweepId) {
+        return [
+          {
+            type: "text",
+            text: "=== Cancel Sweep ===\n\nFailed\n\nError: `sweep_id` is required.",
+          },
+        ];
+      }
+      const graceArg = args?.grace;
+      const graceSecs =
+        typeof graceArg === "number" && Number.isFinite(graceArg) && graceArg >= 0
+          ? Math.floor(graceArg)
+          : 30;
+
+      const result = await cancelSweep({ sweep_id: sweepId, grace_secs: graceSecs });
+      if (!result.success) {
+        return [
+          {
+            type: "text",
+            text: `=== Cancel Sweep ===\n\nFailed\n\n${result.error}`,
+          },
+        ];
+      }
+      const { pid, sigkill_sent, was_running } = result.payload;
+      const lines = [
+        `Sweep ID:      ${result.payload.sweep_id}`,
+        `PID:           ${pid}`,
+        `Was running:   ${was_running}`,
+        `SIGKILL sent:  ${sigkill_sent}`,
+        `Grace:         ${graceSecs}s`,
+      ].join("\n");
+      const summary = was_running
+        ? sigkill_sent
+          ? "Child survived SIGTERM; escalated to SIGKILL."
+          : "Child terminated within grace window."
+        : "Already terminal; no signal sent (idempotent success).";
+      return [
+        {
+          type: "text",
+          text: `=== Cancel Sweep ===\n\n${summary}\n\n${lines}`,
+        },
+      ];
+    }
+
+    case "tail_event_bus": {
+      const sinceArg = args?.since;
+      let durationMs = 10 * 60 * 1000; // default: 10m
+      if (typeof sinceArg === "string" && sinceArg.length > 0) {
+        const parsed = parseDuration(sinceArg);
+        if (parsed === null) {
+          return [
+            {
+              type: "text",
+              text:
+                "=== Tail Event Bus ===\n\nFailed\n\nError: invalid `since` " +
+                `'${sinceArg}'. Use formats like '30s', '10m', or '1h'.`,
+            },
+          ];
+        }
+        durationMs = parsed;
+      }
+      const maxLinesArg = args?.max_events;
+      const maxLines =
+        typeof maxLinesArg === "number" && Number.isFinite(maxLinesArg) && maxLinesArg > 0
+          ? Math.floor(maxLinesArg)
+          : undefined;
+
+      // tail_event_bus subscribes to ALL topics (empty filter) — its
+      // only knob over subscribe_to_events is the catch-all default
+      // and the operator-friendly `--since` window naming.
+      const result = await streamEvents({ topics: [], durationMs, maxLines });
+      if (!result.success) {
+        return [
+          {
+            type: "text",
+            text: `=== Tail Event Bus ===\n\nFailed\n\n${result.error}`,
+          },
+        ];
+      }
+      const summary = [
+        `Window:           ${typeof sinceArg === "string" ? sinceArg : "10m (default)"}`,
+        `Frames received:  ${result.lines.length}`,
+        `Elapsed:          ${result.elapsedMs}ms`,
+        `Closed by:        ${result.closedByTimeout ? "since window" : "daemon / max"}`,
+      ].join("\n");
+      const body =
+        result.lines.length === 0
+          ? "(no events observed)"
+          : result.lines.join("\n");
+      return [
+        {
+          type: "text",
+          text: `=== Tail Event Bus ===\n\n${summary}\n\nFrames:\n${body}`,
         },
       ];
     }


### PR DESCRIPTION
## Summary

Phase C of epic #3449 — adds the remaining monitoring MCP tools on top
of Phase A's dispatch surface + Phase B's event bus. Closes #3455.

Six new MCP tools:

- `get_sweep_status` — returns `SweepInfo` plus the N most-recent
  events (default 10, configurable, set to 0 to skip).
- `tail_sweep_log` — reads last N lines from
  `.loom/logs/sweep-issue-<N>.log` (default 100).
- `subscribe_to_events` — long-lived MCP stream filtered by topic
  prefix; capped by `duration` (default 30s) and optional `max_events`.
- `publish_event` — operator override / testing escape hatch.
- `cancel_sweep` — SIGTERM → grace (default 30s) → SIGKILL; transitions
  `Running` → `Exited{None, now}`, releases the lock, emits
  `sweep.issue.{N}.exited` + `sweep.global.completed`.
- `tail_event_bus --since 10m` — debug fire-hose subscription to all
  topics (per curator risk note D).

Plus a full rewrite of `.loom/docs/daemon-reference.md` (it currently
references the deleted Python daemon brain per the #3389 audit).

Builds on PR #3459 (Phase A) and PR #3460 (Phase B) — both already on
main. No refactors of Phase A/B APIs; all extensions are additive.

## Acceptance criteria

| AC | Status | Note |
|----|--------|------|
| 1 — `get_sweep_status` returns SweepInfo + N recent events | Pass | Recent events collected via short subscribe window (~200ms) on the issue's topic prefix; configurable via `recent_events` (default 10, 0 disables). |
| 2 — `subscribe_to_events` streams JSON until disconnect | Pass | Reuses Phase B's `handle_client` streaming path; MCP layer caps each tool call with `duration` (default 30s) so a single call returns deterministically. Bus closes earlier than the duration if the daemon drops. |
| 3 — `cancel_sweep --grace 30` SIGTERM → grace → SIGKILL | Pass | Verified by `cancel_escalates_to_sigkill_when_child_ignores_sigterm` test — spawns `bash -c 'trap "" TERM; sleep 30'`, calls cancel with 500ms grace, asserts `sigkill_sent=true` and the child is reaped after `wait()`. |
| 4 — daemon-reference.md rewritten for Phase A-C | Pass | Removed all Python daemon brain references; added IPC/Response table, event taxonomy, per-tool reference, registry layout, reaper lifecycle, explicit "what this page does NOT describe" section. |
| 5 — `tail_event_bus --since 10m` exists | Pass | Subscribes to all topics (empty filter, per Phase B's catch-all design). `--since` parses `<N>s`/`<N>m`/`<N>h` (case-insensitive); invalid formats are rejected with a clear error. Default 10m. |

## Test plan

- [x] `cd loom-daemon && cargo test --lib` — **336 passed, 0 failed**.
- [x] `cargo clippy --package loom-daemon --package loom-api -- -D warnings ...` — **clean** (matches CI `.github/workflows/ci.yml:57`).
- [x] `cd mcp-loom && npm run typecheck` — **clean**.
- [x] `cd mcp-loom && npm run build` — **clean** (esbuild bundle).
- [x] 12 new tests added across `sweep_registry` (8) and `ipc` (4).

## Design decisions

- **`cancel_sweep` timing**: polls `kill(pid, 0)` every 100ms (matches
  the spawn-loop's shutdown-grace cadence). Uses `kill(2)` directly so
  behavior is identical on macOS + Linux without depending on PATH.
  Idempotent on already-terminal sweeps (returns `was_running: false`).
- **`tail_event_bus --since` parsing**: streaming duration, not a
  backward-looking replay filter. The bus is in-memory and transient
  — there is no event log to replay. Docstring + tool description call
  this out explicitly.
- **`get_sweep_status` recent events**: collected via a ~200ms
  subscribe window on the sweep's topic prefix. Best-effort sample of
  in-flight bus traffic, not a replay log. Setting `recent_events: 0`
  skips the subscribe entirely.
- **Streaming transport**: added `sendDaemonStreamRequest` to
  `shared/daemon.ts` that buffers partial reads, splits on newlines,
  and supports duration + frame caps. The single-shot
  `sendDaemonRequest` remains unchanged.
- **`daemon-reference.md` rewrite scope**: full rewrite. The legacy
  page described a Python brain that no longer exists; I kept the
  "what this page does NOT describe" section to point at the
  work-generation deletions and the cron-driven support-role model
  (with cross-refs to `docs/migration/daemon-state-consumers.md`).
- **No new topics**: Phase B froze the six topics for v0.10.0. The
  `tail_event_bus` tool subscribes to ALL of them via the empty-filter
  catch-all path that Phase B's bus already exposes.

## File-level changes (LOC)

| File | Lines | Notes |
|------|-------|-------|
| `loom-daemon/src/types.rs` | +58 | 3 new Request variants + 3 new Response variants. |
| `loom-daemon/src/sweep_registry.rs` | +480 | `cancel`, `get_status`, `tail_log`, `CancelOutcome`, `send_signal`, `tail_lines`, 8 new tests. |
| `loom-daemon/src/ipc.rs` | +160 | 3 new handlers + 4 new tests. |
| `mcp-loom/src/shared/daemon.ts` | +134 | `sendDaemonStreamRequest` streaming variant. |
| `mcp-loom/src/tools/sweeps.ts` | +700 | 6 new tool defs + handlers + `parseDuration` helper. |
| `.loom/docs/daemon-reference.md` | +295/-93 | Full rewrite for Phase A-C surface. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)