### PR TITLE
chore(spawn-loop): Phase E — deprecate spawn-loop.sh with stderr warning, rewrite doc-fiction (#3456)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This repository uses **Loom** for AI-powered development orchestration.
 
 ## What is Loom?
 
-Loom is a CLI tool for AI-powered development orchestration. It coordinates AI development workers using git worktrees and a forge (GitHub or Gitea) as the coordination layer. It supports manual coordination (Manual Orchestration Mode) and continuous autonomous orchestration via the spawn loop + GitHub Actions cron schedules.
+Loom is a CLI + daemon for AI-powered development orchestration. It coordinates AI development workers using git worktrees and a forge (GitHub or Gitea) as the coordination layer. It supports manual coordination (Manual Orchestration Mode), continuous autonomous orchestration via the Rust `loom-daemon` binary (MCP-level dispatch + pub/sub + monitoring), and GitHub Actions cron schedules for periodic support roles.
 
 **Loom Repository**: https://github.com/rjwalters/loom
 
@@ -24,8 +24,9 @@ Loom decomposes development into three coordination tiers, with the forge (GitHu
                               │ observes/intervenes
                               ▼
 ┌─────────────────────────────────────────────────────────────────┐
-│              Tier 2: Spawn loop + GitHub Actions cron           │
-│  spawn-loop.sh — claims ready issues, spawns sweep children     │
+│              Tier 2: loom-daemon + GitHub Actions cron          │
+│  loom-daemon (Rust) — MCP dispatch_sweep, list_sweeps,          │
+│    get_sweep_status, cancel_sweep, event bus (pub/sub)          │
 │  .github/workflows/loom-*.yml — periodic support roles          │
 └─────────────────────────────────────────────────────────────────┘
                               │ spawns/triggers
@@ -47,12 +48,12 @@ Loom decomposes development into three coordination tiers, with the forge (GitHu
 | Tier | Entry point | Purpose | Mode |
 |------|-------------|---------|------|
 | Tier 3 | Human | Oversight — approve proposals, handle edge cases | Observer |
-| Tier 2 | `./.loom/scripts/spawn-loop.sh` + GH Actions cron | Multi-issue batch + scheduled support roles | Continuous / cron |
+| Tier 2 | `loom-daemon` (MCP) + GH Actions cron | Multi-issue dispatch + scheduled support roles | Continuous / cron |
 | Tier 1 | `/loom:sweep <issue>` | Single-issue lifecycle (Curator → Merge) | Per-issue |
 | Tier 0 | `/builder`, `/judge`, etc. | Task execution — single focused work units | Per-task |
 
-**Use `/loom:sweep <issue>`** when you have a specific issue to implement (interactively or from a script).
-**Use `LOOM_USE_SPAWN_LOOP=1 ./.loom/scripts/spawn-loop.sh start`** for multi-issue autonomous batches.
+**Use `/loom:sweep <issue>`** when you have a specific issue to implement (interactively or from a script). The skill probes for a running `loom-daemon` + multi-account token pool (Stage -1) and delegates dispatch when both are available; otherwise it falls through to in-process subagent dispatch.
+**Use `mcp__loom__dispatch_sweep`** from a Claude Code session to enqueue work directly against the running `loom-daemon` for autonomous multi-account batches.
 **Enable the GitHub Actions cron workflows** under `.github/workflows/loom-*.yml` for periodic Champion / Curator / Judge / Auditor / Guide ticks.
 
 ## Usage Modes
@@ -87,19 +88,32 @@ Sweep also has a **PR-set mode (Mode C, #3384)** that drives Judge / Doctor → 
 
 Checkpoints (#3373) under `.loom/sweep-checkpoint/issue-<N>.json` survive crashes — restarting `/loom:sweep N` resumes from the last completed phase.
 
-### 3. Spawn-Loop Mode (opt-in)
+### 3. Daemon Mode (`loom-daemon` + MCP tools)
 
-A minimal multi-account `/loom:sweep` launcher (#3374). Polls `loom:issue`, atomically claims ready issues, and detaches `claude -p "/loom:sweep N"` per issue — each spawn picks its own OAuth token via `spawn-claude.sh`. No work generation, no support-role triggers, no pool-slot bookkeeping.
+The Rust `loom-daemon` binary is the Tier 2 dispatch backend. It exposes a Unix-socket IPC surface and a paired `mcp-loom` MCP server which maps each IPC request 1:1 to an MCP tool. An operator running `/loom:sweep` in a Claude Code session — or any MCP client — interacts with the daemon via:
 
-> **Note**: `/loom:sweep` also supports a **PR-set mode** (Mode C, #3384) via `--prs <pr-number-list>` or NL phrases like "all open `loom:pr`" — drives Judge / Doctor → Judge / Merge from an existing open-PR set without re-running Curator or Builder. The spawn loop is issue-keyed and does not invoke PR-set mode; operators use it directly via `claude -p "/loom:sweep --prs ..."`.
+| MCP tool | Purpose | Phase |
+|----------|---------|-------|
+| `mcp__loom__dispatch_sweep` | Dispatch a sweep for an issue (multi-account token rotation via `spawn-claude.sh`) | A (#3452) |
+| `mcp__loom__list_sweeps` | Enumerate running sweeps in the in-memory registry | A (#3452) |
+| `mcp__loom__publish_event` | Publish a sweep-lifecycle event on the in-memory bus | B (#3453) |
+| `mcp__loom__subscribe_to_events` | Stream topic-filtered events to a subscriber | B (#3453) |
+| `mcp__loom__get_sweep_status` | Inspect a running sweep's state | C (#3455) |
+| `mcp__loom__tail_sweep_log` | Tail the per-sweep log file | C (#3455) |
+| `mcp__loom__cancel_sweep` | Cancel a running sweep (SIGTERM → grace → SIGKILL) | C (#3455) |
+| `mcp__loom__tail_event_bus` | Tail the event bus without subscribing to a topic | C (#3455) |
 
-```bash
-LOOM_USE_SPAWN_LOOP=1 ./.loom/scripts/spawn-loop.sh start  # opt-in gate is required
-./.loom/scripts/spawn-loop.sh status
-./.loom/scripts/spawn-loop.sh stop                          # or: touch .loom/stop-spawn-loop
-```
+**Event taxonomy (frozen for v0.10.0)**: `sweep.issue.{N}.phase`, `sweep.issue.{N}.blocker`, `sweep.issue.{N}.exited`, `sweep.issue.{N}.crashed`, `sweep.global.dispatch`, `sweep.global.completed`. New topics require a follow-up issue.
 
-State lives in `.loom/spawn-loop-state.json`, logs in `.loom/logs/spawn-loop.log`, claim locks under `.loom/locks/issue-<N>/`. Crashed children whose checkpoints (#3373) survive are re-queued on the next tick. If `daemon-loop.pid` is alive, the loop warns and proceeds (both will compete for `loom:issue` items — pick one). Overrides: `MAX_PARALLEL=3`, `POLL_INTERVAL=30`, `SHUTDOWN_GRACE_SEC=300`.
+**`/loom:sweep` backend detection (Stage -1, Phase D #3454)**: the skill probes whether the daemon is reachable (a Ping over the IPC socket with a 500ms timeout) AND whether a multi-account token pool exists (`.loom/tokens/` contains ≥ 2 `ACCOUNT_KEY_*` entries). **Strict AND** — either probe failing falls through to in-process subagent dispatch (the existing Mode A/B/C lifecycle). Mode C (`--prs`) always uses subagent dispatch; the daemon does not handle PR-set dispatch in v0.10.0. The `--no-daemon` flag forces subagent dispatch unconditionally.
+
+The daemon itself is **not** a work generator. It does not poll the forge for `loom:issue` items; it does not maintain a `shepherd-N` pool; it does not drive support roles on cron. Those responsibilities live in `mcp__loom__dispatch_sweep` (operator-driven enqueue) and the GitHub Actions cron workflows.
+
+For full surface documentation — IPC request/response variants, event-bus internals, registry behaviour, reaper semantics — see [`.loom/docs/daemon-reference.md`](.loom/docs/daemon-reference.md).
+
+> **Note**: `/loom:sweep` also supports a **PR-set mode** (Mode C, #3384) via `--prs <pr-number-list>` or NL phrases like "all open `loom:pr`" — drives Judge / Doctor → Judge / Merge from an existing open-PR set without re-running Curator or Builder. Mode C always uses subagent dispatch (see Stage -1 above).
+
+> **Legacy spawn loop**: `defaults/scripts/spawn-loop.sh` (Phase 1, #3374) is deprecated and emits a stderr warning on every invocation referencing #3449. It will be deleted in v0.11.0. Use `mcp__loom__dispatch_sweep` against `loom-daemon` instead. See [`docs/migration/v0.10.0-shepherd-deprecation.md`](docs/migration/v0.10.0-shepherd-deprecation.md).
 
 ### 4. Scheduled Support Roles (opt-in)
 
@@ -140,11 +154,7 @@ Architect and Hermit cadence (work-generation triggers) is intentionally out of 
 
 Full role definitions: `.loom/roles/*.md`.
 
-> **Stop-gap — daemon backend in flight (v0.10.0 rebuild, epic #3449)**
->
-> `./.loom/scripts/daemon.sh` does not exist on `origin/main` as of v0.9.1; the dispatcher was deleted in #3432 and is being rebuilt in epic #3449 (~4-6 weeks, scheduled for v0.10.0). The text below describes the intended target state. Until Phase A through E of #3449 land, daemon operator commands (`./.loom/scripts/daemon.sh start|stop|status`) will fail with "no such file or directory". Use `./.loom/scripts/spawn-loop.sh` for headless multi-issue dispatch in the interim. Tracker: #3451 (this stop-gap), #3449 (rebuild epic).
-
-> **Note**: the historical `shepherd.md` (single-issue orchestrator) role file was removed in v0.10.0 along with the `/shepherd` slash command — see [the migration guide](docs/migration/v0.10.0-shepherd-deprecation.md). Its orchestration responsibilities moved to `/loom:sweep` (Tier 1) and the spawn loop + GH Actions cron (Tier 2). The `loom.md` role file is preserved and documents the daemon-mode operator surface (`./.loom/scripts/daemon.sh` + tmux + token-rotated separate Claude Code sessions — see stop-gap warning above re: in-flight rebuild #3449); the Python brain it historically referenced (`loom_tools/daemon_v2/`) is removed in v0.10.0, but the shell-level daemon surface stays. The worker-role markdown files above are unchanged.
+> **Note**: the historical `shepherd.md` (single-issue orchestrator) role file was removed in v0.10.0 along with the `/shepherd` slash command — see [the migration guide](docs/migration/v0.10.0-shepherd-deprecation.md). Its orchestration responsibilities moved to `/loom:sweep` (Tier 1) and the `loom-daemon` + GH Actions cron (Tier 2). The `loom.md` role file is preserved and documents the daemon-mode operator surface: a Claude Code session that observes the running `loom-daemon` via MCP tools (`mcp__loom__list_sweeps`, `mcp__loom__get_sweep_status`, `mcp__loom__subscribe_to_events`) and dispatches new work via `mcp__loom__dispatch_sweep`. The historical Python brain (`loom_tools/daemon_v2/`) is gone; the MCP-level surface is the supported coordination point. The worker-role markdown files above are unchanged.
 
 ## Label-Based Workflow
 
@@ -292,47 +302,17 @@ Configuration stored in `.loom/config.json` (committed to git for team sharing):
 }
 ```
 
-### Spawn-Loop Configuration
+### Daemon Configuration (Tier 2)
 
-> **Stop-gap — daemon backend in flight (v0.10.0 rebuild, epic #3449)**
->
-> The paragraph below claims `./.loom/scripts/daemon.sh` is "preserved and re-implemented" — but the file does not exist on `origin/main` as of v0.9.1 (deleted in #3432). The rebuild is tracked in epic #3449 (~4-6 weeks). Until that lands, the only working multi-issue dispatch backend is `./.loom/scripts/spawn-loop.sh` (headless) or the GitHub Actions cron workflows. The daemon prose stays here as a forward-looking pointer at the target state.
+The Rust `loom-daemon` binary is the load-bearing Tier 2 dispatch backend. It is a single long-lived process that holds the sweep registry, the event bus, and the reaper task in memory — there is no on-disk state file the operator needs to touch. See [`.loom/docs/daemon-reference.md`](.loom/docs/daemon-reference.md) for the full surface and [`docs/migration/v0.10.0-shepherd-deprecation.md`](docs/migration/v0.10.0-shepherd-deprecation.md) for the migration narrative away from the legacy Python brain.
 
-The spawn loop replaces the historical Python daemon brain. The shell-level daemon surface (`./.loom/scripts/daemon.sh`) is preserved and re-implemented around the spawn loop + GitHub Actions cron + token-rotated tmux panes (see [`.loom/docs/daemon-reference.md`](.loom/docs/daemon-reference.md)). For the full migration narrative, see [`docs/migration/v0.10.0-shepherd-deprecation.md`](docs/migration/v0.10.0-shepherd-deprecation.md).
+**Per-sweep logs** live at `.loom/logs/sweep-issue-<N>.log` and are tailable via `mcp__loom__tail_sweep_log`.
 
-**State file** (`.loom/spawn-loop-state.json`, gitignored):
-
-```json
-{
-  "started_at": "2026-06-04T10:00:00Z",
-  "running": [
-    {
-      "issue": 123,
-      "pid": 49281,
-      "started_at": "2026-06-04T10:15:00Z",
-      "token": "agent-3.token"
-    }
-  ]
-}
-```
-
-That's the entire schema. Pipeline state, warnings, completed-issue history, and work-generation cooldowns are not tracked here — the forge is the source of truth for queue state, and the spawn loop is intentionally minimal (see `docs/migration/daemon-state-consumers.md` for the design rationale).
-
-**Tunables (env)**:
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `MAX_PARALLEL` | 3 | Maximum concurrent `/loom:sweep` children |
-| `POLL_INTERVAL` | 30 | Seconds between `loom:issue` polls |
-| `SHUTDOWN_GRACE_SEC` | 300 | Seconds to wait for in-flight children at shutdown |
-| `LOOM_USE_SPAWN_LOOP` | (unset) | Opt-in gate, required to start the loop |
-| `LOOM_REPO` | (auto) | Override remote auto-detection (`owner/repo`) |
-
-**Sweep checkpoints** (`.loom/sweep-checkpoint/issue-<N>.json`, gitignored):
-
-When a sweep child crashes mid-flight, the checkpoint records the last completed phase. On the next spawn the sweep skill resumes from that phase. The exact schema is owned by the sweep skill (#3373) and is not part of the spawn loop's public surface.
+**Sweep checkpoints** (`.loom/sweep-checkpoint/issue-<N>.json`, gitignored): when a sweep child crashes mid-flight, the checkpoint records the last completed phase. On the next dispatch the sweep skill resumes from that phase. The exact schema is owned by the sweep skill (#3373).
 
 **Scheduled support roles** run as separate GitHub Actions cron jobs — see `.github/workflows/loom-*.yml`. They have no persistent state on the Loom side; each tick is a fresh `claude -p "/<role>" --dangerously-skip-permissions` invocation.
+
+> **Legacy spawn-loop state**: the v0.9.x state file `.loom/spawn-loop-state.json` is still written by the deprecated `spawn-loop.sh` (scheduled for deletion in v0.11.0). The daemon does not consume it. Operators who need to observe running sweeps should call `mcp__loom__list_sweeps` against the daemon instead.
 
 ### Custom Roles
 
@@ -417,7 +397,7 @@ Cron example (probe every 10 minutes):
 See `.loom/docs/troubleshooting.md` for detailed troubleshooting including:
 - Cleaning up stale worktrees and branches
 - Stuck agent detection and intervention
-- Spawn-loop troubleshooting
+- Daemon troubleshooting (registry, event bus, reaper)
 - Common issues and solutions
 
 **Quick fixes**:
@@ -426,7 +406,7 @@ See `.loom/docs/troubleshooting.md` for detailed troubleshooting including:
 loom-clean --force                       # Clean stale worktrees/branches
 ./.loom/scripts/stale-building-check.sh --recover  # Recover stuck issues
 gh label sync --file .github/labels.yml  # Re-sync labels (GitHub only)
-touch .loom/stop-spawn-loop              # Graceful spawn-loop shutdown
+# Cancel a running sweep: mcp__loom__cancel_sweep --sweep_id <id>
 ```
 
 ## MCP Hooks
@@ -557,21 +537,22 @@ gh release create vX.Y.Z --title "vX.Y.Z" --notes "Release notes..."
 
 The script updates all 5 version-bearing files (`package.json`, `mcp-loom/package.json`, 2 `Cargo.toml` files (`loom-daemon`, `loom-api`), `CLAUDE.md`) plus `Cargo.lock`. The GitHub Actions release workflow (`.github/workflows/release.yml`) triggers on GitHub Release creation (`release: types: [created]`), NOT on tag push. You must create a GitHub Release via `gh release create` to trigger the build.
 
-## Migration: v0.10.0 shepherd/daemon deprecation (completed)
+## Migration: v0.10.0 shepherd/daemon deprecation (in progress)
 
-> **Stop-gap — daemon "preserved" claim is currently aspirational (epic #3449, stop-gap #3451)**
->
-> The next paragraph says the shell-level daemon surface "is preserved, re-implemented as a tmux session launcher around the spawn loop". On `origin/main` as of v0.9.1, `./.loom/scripts/daemon.sh` does **not** exist — it was deleted in #3432 and is being rebuilt in epic #3449 over an estimated 4-6 weeks for v0.10.0. The shepherd/Python-daemon-brain deletions are real and shipped; the daemon-shell rebuild is in flight. Until #3449 ships, use `./.loom/scripts/spawn-loop.sh` (headless) or GitHub Actions cron workflows.
-
-The orchestration-architecture migration (epic #3372) is complete as of v0.10.0. The shepherd brain (`loom-tools/src/loom_tools/shepherd/`), the Python daemon brain (`loom-tools/src/loom_tools/daemon_v2/`), and the `/shepherd` slash command were deleted and replaced by the spawn loop (#3374) + GitHub Actions workflows (#3375). The shell-level daemon surface (`./.loom/scripts/daemon.sh`) is preserved, re-implemented as a tmux session launcher around the spawn loop. The completed phases:
+The orchestration-architecture migration (epic #3372) deleted the shepherd brain (`loom-tools/src/loom_tools/shepherd/`), the Python daemon brain (`loom-tools/src/loom_tools/daemon_v2/`), and the `/shepherd` slash command. The replacement is a two-surface architecture: `/loom:sweep` for in-session subagent dispatch (Tier 1) and the Rust `loom-daemon` binary for multi-account MCP-level dispatch (Tier 2). Epic #3449 rebuilt the daemon surface in phases A–D, all shipped on main. The completed phases:
 
 | Phase | Issue | What shipped | Status |
 |-------|-------|-----------|--------|
-| Phase 1 | #3374 | Minimal multi-account spawn loop (`./.loom/scripts/spawn-loop.sh`) | shipped |
+| Phase 1 | #3374 | Minimal multi-account spawn loop (legacy — deprecated in Phase E of #3449) | shipped, deprecated |
 | Phase 2a | #3375 | GitHub Actions workflows for support roles | shipped (disabled by default) |
 | Phase 2b | #3376 | Soft-deprecation warnings on deprecated entry points | shipped |
-| Phase 3 | #3378 | Deletion of shepherd brain, Python daemon brain, `/shepherd` skill; `daemon.sh` re-implemented | partial (deletions shipped; daemon.sh re-implementation in flight under epic #3449) |
+| Phase 3 | #3378 | Deletion of shepherd brain, Python daemon brain, `/shepherd` skill | shipped |
 | Phase 4 | #3382 | Coordinated downstream sphere-install migration | shipped |
+| #3449 Phase A | #3452 | `loom-daemon`: `dispatch_sweep`, `list_sweeps`, sweep registry, reaper task | shipped |
+| #3449 Phase B | #3453 | `loom-daemon`: event bus (tokio broadcast), 6 frozen topics, `publish_event`, `subscribe_to_events` IPC | shipped |
+| #3449 Phase C | #3455 | MCP tools: `get_sweep_status`, `tail_sweep_log`, `subscribe_to_events`, `publish_event`, `cancel_sweep`, `tail_event_bus`; daemon-reference.md rewrite | shipped |
+| #3449 Phase D | #3454 | `/loom:sweep` Stage -1 backend detection (strict-AND daemon + pool probe) | shipped |
+| #3449 Phase E | #3456 | `spawn-loop.sh` deprecation warning + doc-fiction rewrite | this PR |
 
 **v1.0.0 is intentionally unscheduled.** Loom remains pre-1.0 while the architecture settles.
 
@@ -579,8 +560,9 @@ The orchestration-architecture migration (epic #3372) is complete as of v0.10.0.
 
 | Removed | Replacement |
 |---------|-------------|
-| `loom-daemon` Python CLI | `./.loom/scripts/daemon.sh` (rebuild in flight, epic #3449 — use `./.loom/scripts/spawn-loop.sh` headless until then) + GitHub Actions schedules |
+| `loom-daemon` Python CLI | Rust `loom-daemon` binary + `mcp__loom__dispatch_sweep` (+ GitHub Actions for support roles) |
 | `loom-shepherd` CLI / `/shepherd` slash command | `/loom:sweep <issue>` for the same per-issue lifecycle |
+| `defaults/scripts/spawn-loop.sh` (deprecation phase, deletion in v0.11.0) | `mcp__loom__dispatch_sweep` against `loom-daemon` |
 
 Full migration narrative and per-CLI replacement table: [`docs/migration/v0.10.0-shepherd-deprecation.md`](docs/migration/v0.10.0-shepherd-deprecation.md).
 

--- a/defaults/.claude/agents/loom-shepherd.md
+++ b/defaults/.claude/agents/loom-shepherd.md
@@ -6,8 +6,8 @@ tools: Read, Glob, Grep, Bash, Task
 
 > ⚠️  DEPRECATED: The `loom-shepherd` subagent is scheduled for removal in the
 >     next major release (Phase 3 of epic #3372). Use `/loom:sweep <issue>` for
->     the same single-issue lifecycle, or enable `LOOM_USE_SPAWN_LOOP=1` +
->     `./.loom/scripts/spawn-loop.sh` for multi-account batches. See #3372 for
+>     the same single-issue lifecycle, or use `mcp__loom__dispatch_sweep`
+>     against `loom-daemon` for multi-account autonomous batches. See #3372 for
 >     the migration plan and #3382 for the sphere downstream coordination
 >     tracker. No behavior change during the soft-deprecation window — the
 >     subagent still works.

--- a/defaults/.claude/commands/loom/loom.md
+++ b/defaults/.claude/commands/loom/loom.md
@@ -1,16 +1,6 @@
 # Loom Daemon
 
-> **⚠️ Stop-gap warning — entire role file describes a target state not yet shipped (epic #3449, stop-gap #3451)**
->
-> **This role file describes the operator surface of a daemon backend that does not currently exist on `origin/main`.** The dispatcher `./.loom/scripts/daemon.sh` was deleted in #3432 and is being rebuilt in epic #3449 (~4-6 weeks, scheduled for v0.10.0). Until Phases A-E of #3449 land:
->
-> - All `./.loom/scripts/daemon.sh start|stop|status|restart` commands in this file will fail with "no such file or directory".
-> - The `.loom/daemon-state.json` and `.loom/daemon-loop.pid` files this skill expects to read will not exist (no producer is running).
-> - The signals directory (`.loom/signals/`) this skill writes to has no consumer.
->
-> **Operators reading this file in v0.9.x**: invoking `/loom` will not do useful work — there is no daemon process to observe or signal. Use `./.loom/scripts/spawn-loop.sh start` (headless multi-issue dispatch) or `/loom:sweep <issue>` (per-issue lifecycle) instead. The full doc rewrite is Phase E of #3449; this stop-gap (#3451) only warns. Tracker links: #3449 (rebuild epic), #3451 (this stop-gap), #3432 (the deletion).
-
-You are the Layer 2 Loom Daemon orchestrator in the {{workspace}} repository. This skill operates as a **signal-writer and observer** — you coordinate the daemon process through JSON signals and state observation. You NEVER spawn daemon or shepherd processes directly via Bash.
+You are the Layer 2 Loom Daemon orchestrator in the {{workspace}} repository. The `loom-daemon` is a Rust binary that exposes an MCP-level dispatch + monitoring + pub/sub surface; you coordinate it via MCP tools, not by spawning shell processes directly.
 
 ## Arguments
 
@@ -26,15 +16,19 @@ IF arguments start with "help":
     -> EXIT after displaying help
 
 ELSE IF arguments contain "status":
-    -> Read .loom/daemon-state.json and display current state
+    -> Call mcp__loom__list_sweeps and display registry state
     -> EXIT after displaying status
 
 ELSE IF arguments contain "health":
-    -> Read .loom/daemon-state.json and display health summary
+    -> Call mcp__loom__list_sweeps + observe event-bus health via
+       mcp__loom__tail_event_bus (short tail) and display summary
     -> EXIT after displaying health
 
 ELSE IF arguments contain "stop":
-    -> Write stop signal to .loom/signals/
+    -> Iterate mcp__loom__list_sweeps and call mcp__loom__cancel_sweep
+       on each. Inform the operator the daemon process itself remains
+       running (cancellation drains in-flight sweeps; the daemon is a
+       long-lived process they control via their service manager).
     -> EXIT
 
 ELSE:
@@ -60,82 +54,49 @@ If the user is starting an overnight run, they should heed the warning before wa
 
 ## Daemon Detection
 
-Before observing, check whether the daemon is running:
+Before observing or dispatching, verify the daemon is reachable. Use `mcp__loom__list_sweeps` as the probe — it returns a (possibly empty) registry on a healthy daemon, and fails fast if the IPC socket is missing or the process is dead.
 
-```bash
-cat .loom/daemon-loop.pid 2>/dev/null
+```
+Call: mcp__loom__list_sweeps
 ```
 
-If the PID file exists, verify the process is alive:
-
-```bash
-PID=$(cat .loom/daemon-loop.pid 2>/dev/null)
-kill -0 "$PID" 2>/dev/null && echo "RUNNING" || echo "STALE"
-```
-
-### If Daemon is NOT Running
+### If the call fails (daemon unreachable)
 
 Display this message and EXIT:
 
 ```
-The Loom daemon is not running.
+The Loom daemon is not running (mcp__loom__list_sweeps returned no
+response).
 
-Start it from a terminal OUTSIDE Claude Code:
+The daemon is a long-lived Rust process. Start it from a terminal
+OUTSIDE Claude Code via your service manager of choice (systemd, launchd,
+foreman, or just `loom-daemon` in a background shell).
 
-  ./.loom/scripts/daemon.sh start                      # Auto-build mode (default)
-  ./.loom/scripts/daemon.sh start --no-auto-build      # Support-only (no auto-spawn)
-  ./.loom/scripts/daemon.sh start --timeout-min 120    # Auto-stop after 2 hours
+While the daemon is down, in-process orchestration still works:
 
-Then run /loom again to begin observing and orchestrating.
+  /loom:sweep <issue>       # Single-issue lifecycle, in-session
+                            # (subagent dispatch, single OAuth token)
 
-Why run outside Claude Code?
-  Shepherds start as daemon children (not Claude Code descendants),
-  avoiding the nested Claude Code spawning restriction.
+Stage -1 of /loom:sweep auto-detects the daemon — when the daemon comes
+back up AND a multi-account token pool is configured (.loom/tokens/),
+new /loom:sweep invocations will delegate dispatch to the daemon
+automatically.
 ```
 
-### If Daemon IS Running
+### If the call succeeds (daemon reachable)
 
-Read `.loom/daemon-state.json` and check `orchestration_active`.
+Proceed to the Observer / Dispatch Loop below.
 
-**If `orchestration_active` is `false` (standby mode)**:
+## Observer / Dispatch Loop
 
-The daemon is waiting for an explicit signal to begin autonomous work. Send a `start_orchestration` signal:
-
-```
-Mode mapping:
-  /loom           → mode: "default"
-  /loom --merge   → mode: "force"
-  /loom --force   → mode: "force"
-```
-
-Write the signal file using the Write tool (not Bash):
-
-```
-.loom/signals/cmd-{YYYYMMDD-HHMMSS}-{random4hex}.json
-```
-
-Payload:
-```json
-{"action": "start_orchestration", "mode": "<default|force>"}
-```
-
-Inform the user: `→ Activating orchestration (mode=<mode>)...`
-
-Then wait ~3 seconds and verify `orchestration_active` is now `true` in the state file before proceeding to the Observer Loop.
-
-**If `orchestration_active` is `true`**:
-
-Proceed directly to the Observer Loop below.
-
-## Observer Loop
-
-When the daemon is running, you are an intelligent observer and signal-writer.
+When the daemon is running, you coordinate work via MCP tools.
 
 **Each iteration:**
 
-1. **Read current state** using the Read tool:
-   - `.loom/daemon-state.json` — shepherd status, pipeline counts, warnings
-   - `.loom/daemon.log` — recent daemon activity
+1. **Read current state** by calling the daemon's MCP tools:
+   - `mcp__loom__list_sweeps` — currently-dispatched sweeps with PIDs and started_at
+   - `mcp__loom__get_sweep_status <sweep_id>` — per-sweep phase, blockers, last activity
+   - `mcp__loom__tail_event_bus` (short tail) — recent lifecycle events for context
 
 2. **Assess pipeline** using read-only gh commands:
    ```bash
@@ -144,93 +105,91 @@ When the daemon is running, you are an intelligent observer and signal-writer.
    gh pr list --label="loom:review-requested" --json number,title --limit=20
    ```
 
-3. **Signal the daemon** by writing JSON command files to `.loom/signals/`:
-   ```bash
-   SIGNAL=".loom/signals/cmd-$(date +%Y%m%d-%H%M%S)-$(openssl rand -hex 4).json"
-   echo '{"action": "spawn_shepherd", "issue": 42, "mode": "default"}' > "$SIGNAL"
-   # The daemon picks this up within 2 seconds.
+3. **Dispatch new sweeps** via MCP:
+   ```
+   For each ready loom:issue not already in the daemon registry:
+     mcp__loom__dispatch_sweep --issue <N>
+   ```
+   The daemon picks an OAuth token from the pool (`spawn-claude.sh` rotation), fork+execs `claude -p "/loom:sweep N"`, and registers the child PID in the in-memory `SweepRegistry`. Token rotation only happens at this process-spawn boundary.
+
+4. **Monitor lifecycle events** (optional, for live debugging or stuck-sweep detection):
+   ```
+   mcp__loom__subscribe_to_events --topic "sweep.issue.*"
+   ```
+   The frozen v0.10.0 topic taxonomy is:
+   - `sweep.issue.{N}.phase`     — phase transitions (curator → builder → judge → doctor → merge)
+   - `sweep.issue.{N}.blocker`   — a sweep added a `loom:blocked` or `loom:operator-only` label
+   - `sweep.issue.{N}.exited`    — clean exit (with `exit_code` and `duration_sec`)
+   - `sweep.issue.{N}.crashed`   — non-zero exit / OOM (with `exit_code` and `duration_sec`)
+   - `sweep.global.dispatch`     — daemon accepted a new `dispatch_sweep` request
+   - `sweep.global.completed`    — sweep completed (terminal state, post-reaper)
+
+5. **Cancel stuck sweeps** as needed:
+   ```
+   mcp__loom__cancel_sweep --sweep_id <id>
+   ```
+   This sends SIGTERM, waits the configured grace window, then SIGKILL. The `.loom/sweep-checkpoint/issue-<N>.json` checkpoint survives the cancellation; the next `dispatch_sweep` for that issue resumes from the last completed phase.
+
+6. **Tail per-sweep logs** if you need to inspect output:
+   ```
+   mcp__loom__tail_sweep_log --issue <N> --lines 200
+   ```
+   Or use the bare-event-bus view:
+   ```
+   mcp__loom__tail_event_bus --lines 50
    ```
 
-4. **Wait and observe**: Use the Read tool or MCP tools to monitor state.
-
-5. **Repeat** at appropriate intervals.
-
-### Signal Protocol
-
-Write JSON files named `cmd-{YYYYMMDD-HHMMSS}-{random}.json` to `.loom/signals/`:
-
-| Action | Payload | Description |
-|--------|---------|-------------|
-| `start_orchestration` | `{"action": "start_orchestration", "mode": "default\|force"}` | Activate autonomous orchestration loop |
-| `spawn_shepherd` | `{"action": "spawn_shepherd", "issue": N, "mode": "default\|force"}` | Start shepherd for issue N |
-| `stop` | `{"action": "stop"}` | Graceful daemon shutdown |
-| `set_max_shepherds` | `{"action": "set_max_shepherds", "count": N}` | Adjust shepherd pool size |
-| `pause_shepherd` | `{"action": "pause_shepherd", "shepherd_id": "shepherd-1"}` | Pause a shepherd slot |
-| `resume_shepherd` | `{"action": "resume_shepherd", "shepherd_id": "shepherd-1"}` | Resume a paused shepherd slot |
-
-**Force/merge mode**: Use `"mode": "force"` in `spawn_shepherd` to enable auto-promote + auto-merge behavior.
+7. **Sleep ~30 seconds**, then repeat.
 
 ### Orchestration Logic
 
 **Normal autonomous operation:**
-1. Count `loom:issue` issues available for work
-2. Check active shepherds in `daemon-state.json`
-3. If issues are available and shepherd slots are idle: signal `spawn_shepherd`
-4. If pipeline is empty (no issues, no proposals): assess whether Architect/Hermit should run
-5. Monitor for blocked issues, stuck shepherds, or unmerged approved PRs
-6. Sleep 30 seconds (checks signals and ready-issue assignment every 2 seconds), then repeat
+1. Count `loom:issue` items in the forge
+2. Check active sweeps via `mcp__loom__list_sweeps`
+3. If issues are available and the daemon is not at capacity (operator-defined; the daemon itself does not enforce a hard limit), dispatch new sweeps
+4. If pipeline is empty (no issues, no proposals), prompt the operator to consider triggering Architect/Hermit manually — work-generation cadence is tracked under #3381 and is **not** dispatched by the daemon
+5. Monitor `sweep.issue.*.blocker` events for sweeps that added a blocker label; surface these to the operator
+6. Monitor `sweep.issue.*.crashed` events for non-zero exits; consider re-dispatch (the checkpoint preserves progress)
 
 **Force/merge mode** (`/loom --merge` or `/loom --force`):
-- Same as normal, but pass `"mode": "force"` in all `spawn_shepherd` signals
-- This instructs shepherds to auto-promote curated issues and auto-merge approved PRs
+- Same as normal, but pass `--force` to `mcp__loom__dispatch_sweep` so the dispatched sweep auto-merges approved PRs (Mode B semantics — see `/loom:sweep` skill)
 
-### Observing with MCP Tools
+### Multi-account scaling
 
-Use MCP tools to monitor live state:
+The daemon is the **only** path that gives autonomous orchestration multi-account OAuth token rotation:
+- Each `mcp__loom__dispatch_sweep` call fork+execs a fresh `claude -p "/loom:sweep N"` child
+- `spawn-claude.sh` selects a token from `.loom/tokens/.ranking` (or the allowlist, or random fallback) and exports `CLAUDE_CODE_OAUTH_TOKEN` before exec
+- Multiple sweeps can run concurrently under different tokens, spreading load across accounts
 
-```
-mcp__loom__get_heartbeat          # Check if Loom app is active
-mcp__loom__list_terminals         # List running terminal sessions
-mcp__loom__get_ui_state           # Full engine + terminal status
-```
-
-Use the Read tool for file-based state:
-```
-Read: .loom/daemon-state.json     # Shepherd assignments, pipeline state, warnings
-Read: .loom/daemon.log            # Daemon process log
-Glob: .loom/signals/*.json        # Count pending signals in queue
-```
+In-session subagent dispatch (`/loom:sweep` with Stage -1 falling through to subagent path) inherits the parent's single OAuth token — fine for short batches, fatal for multi-day runs. The daemon path exists precisely to break that limit.
 
 ## Commands Quick Reference
 
 | Command | Description |
 |---------|-------------|
-| `/loom` | Check daemon, start observing/orchestrating |
-| `/loom --merge` | Same, but signal shepherds with force mode |
+| `/loom` | Check daemon, start observing/dispatching |
+| `/loom --merge` | Same, but dispatched sweeps use `--force` (auto-merge) |
 | `/loom --force` | Alias for --merge |
-| `/loom status` | Read and display daemon-state.json |
-| `/loom health` | Display daemon health summary |
-| `/loom stop` | Signal daemon to stop gracefully |
+| `/loom status` | Call `mcp__loom__list_sweeps` and display |
+| `/loom health` | Display daemon health summary (registry + recent events) |
+| `/loom stop` | Cancel all in-flight sweeps via `mcp__loom__cancel_sweep`; daemon process itself stays alive |
 | `/loom help` | Show comprehensive help guide |
 | `/loom help <topic>` | Show help for a specific topic |
 
-## Stopping the Daemon
+## Cancelling sweeps and stopping the daemon
 
-**Via IPC signal** (preferred, daemon processes within 2 seconds):
-```bash
-echo '{"action": "stop"}' > ".loom/signals/cmd-$(date +%Y%m%d-%H%M%S)-stop.json"
+**Cancel individual sweeps** (preferred):
+```
+mcp__loom__cancel_sweep --sweep_id <id>
 ```
 
-**Via stop file** (classic approach):
-```bash
-touch .loom/stop-daemon
+**Cancel all in-flight sweeps**:
+```
+For each sweep returned by mcp__loom__list_sweeps:
+  mcp__loom__cancel_sweep --sweep_id <sweep_id>
 ```
 
-**Via stop script** (from a shell outside Claude Code):
-```bash
-./.loom/scripts/daemon.sh stop            # Graceful (waits for exit)
-./.loom/scripts/daemon.sh stop --force   # Immediate SIGTERM
-```
+**Stop the daemon process itself** is out of scope for this skill — the daemon is a long-lived service that the operator manages outside Claude Code (via their init system, foreman, or shell-level process management).
 
 ---
 
@@ -248,8 +207,8 @@ List these when showing the full help or when the sub-topic is unrecognized:
 /loom help roles        - All available agent roles
 /loom help commands     - Slash command reference
 /loom help workflow     - Label-based workflow overview
-/loom help daemon       - Daemon mode and configuration
-/loom help shepherd     - Single-issue orchestration
+/loom help daemon       - Daemon mode and MCP-tool reference
+/loom help sweep        - Single-issue orchestration
 /loom help worktrees    - Git worktree workflow
 /loom help labels       - Label state machine reference
 /loom help troubleshoot - Common issues and fixes
@@ -276,24 +235,25 @@ Loom orchestrates AI-powered development using GitHub issues, labels, and git wo
 /curator
 ```
 
-**Try it now - Autonomous Mode (daemon manages everything):**
-
-```bash
-# Step 1: Start the daemon from a terminal OUTSIDE Claude Code
-./.loom/scripts/daemon.sh start
-
-# Step 2: In Claude Code, observe and orchestrate
-/loom --merge
-
-# Check daemon health anytime
-/loom health
-```
-
-**Try it now - Single Issue (shepherd handles the full lifecycle):**
+**Try it now - Single Issue (sweep handles the full lifecycle):**
 
 ```bash
 # Orchestrate one issue from curation through merge
-/shepherd 123 --merge
+/loom:sweep 123 --merge
+```
+
+**Try it now - Daemon Mode (multi-account autonomous dispatch):**
+
+```
+# Step 1: Ensure loom-daemon is running (outside Claude Code, via your
+# service manager). Verify via:
+#   mcp__loom__list_sweeps
+#
+# Step 2: In Claude Code, observe and dispatch:
+#   /loom --merge
+#
+# /loom uses MCP tools to enumerate the registry, dispatch new sweeps,
+# subscribe to lifecycle events, and cancel stuck work.
 ```
 
 **Key concepts:**
@@ -301,6 +261,7 @@ Loom orchestrates AI-powered development using GitHub issues, labels, and git wo
 - Each role manages specific label transitions
 - Agents coordinate through labels, not direct communication
 - Work happens in git worktrees (`.loom/worktrees/issue-N`)
+- Multi-account token rotation only works at process-spawn boundaries — that is the architectural reason daemon mode exists alongside in-session subagent dispatch
 
 ---
 
@@ -314,13 +275,13 @@ Loom has three layers of roles:
 
 | Command | Role | What it does |
 |---------|------|-------------|
-| `/loom` | Daemon | Observes daemon state, writes signals to coordinate shepherds and work generation. |
+| `/loom` | Daemon | Observes the `loom-daemon` registry via MCP tools, dispatches sweeps via `mcp__loom__dispatch_sweep`, and monitors lifecycle events via the pub/sub bus. |
 
 **Layer 1 - Issue Orchestration:**
 
 | Command | Role | What it does |
 |---------|------|-------------|
-| `/shepherd <N>` | Shepherd | Orchestrates a single issue through its full lifecycle: Curator -> Builder -> Judge -> Doctor -> Merge. |
+| `/loom:sweep <N>` | Sweep | Orchestrates a single issue through its full lifecycle: Curator -> Builder -> Judge -> Doctor -> Merge. Stage -1 auto-detects a running daemon + multi-account pool and delegates dispatch when both are available. |
 
 **Layer 0 - Task Execution (Worker Roles):**
 
@@ -344,34 +305,35 @@ Loom has three layers of roles:
 
 **Slash Command Reference**
 
-**Daemon commands:**
+**Daemon-observer commands:**
 ```
-/loom                          Check daemon, start observing/orchestrating
-/loom --merge                  Observe in merge mode (signals use force mode)
-/loom status                   Read and display daemon-state.json
+/loom                          Check daemon, start observing/dispatching
+/loom --merge                  Observe + dispatch in merge mode (force flag)
+/loom status                   List current sweep registry
 /loom health                   Show daemon health summary
-/loom stop                     Signal daemon to stop gracefully
+/loom stop                     Cancel all in-flight sweeps
 /loom help                     Show this help guide
 /loom help <topic>             Show help for a specific topic
 ```
 
-**Starting the daemon (run OUTSIDE Claude Code):**
+**Daemon MCP tools (callable from any Claude Code session):**
 ```
-./.loom/scripts/daemon.sh start                   Start daemon (auto-build, default)
-./.loom/scripts/daemon.sh start --no-auto-build   Support-only (no auto-spawn)
-./.loom/scripts/daemon.sh start -t 180            Run for 3 hours then stop
-./.loom/scripts/daemon.sh status                  Check if daemon is running
-./.loom/scripts/daemon.sh stop                    Stop gracefully (waits for exit)
-./.loom/scripts/daemon.sh stop --force            Stop immediately (SIGTERM)
-./.loom/scripts/daemon.sh restart                 Stop + start
-./.loom/scripts/daemon.sh restart --no-auto-build  Restart in support-only mode
+mcp__loom__dispatch_sweep      Dispatch a sweep for an issue
+mcp__loom__list_sweeps         Enumerate the in-memory sweep registry
+mcp__loom__get_sweep_status    Inspect a single sweep's state
+mcp__loom__cancel_sweep        SIGTERM -> grace -> SIGKILL
+mcp__loom__tail_sweep_log      Tail .loom/logs/sweep-issue-<N>.log
+mcp__loom__publish_event       Publish a sweep-lifecycle event
+mcp__loom__subscribe_to_events Topic-filtered event stream
+mcp__loom__tail_event_bus      Untopiced event tail
 ```
 
-**Shepherd commands:**
+**Sweep commands:**
 ```
-/shepherd 123                  Orchestrate issue #123 (stop after PR approval)
-/shepherd 123 --merge          Full automation including auto-merge
-/shepherd 123 --to curated     Stop after curation phase
+/loom:sweep 123                Orchestrate issue #123 (stop after PR approval)
+/loom:sweep 123 --merge        Full automation including auto-merge
+/loom:sweep --prs 456 789      Mode C — PR-set back half (judge / doctor / merge)
+/loom:sweep 123 --no-daemon    Force in-session subagent dispatch
 ```
 
 **Worker commands (with optional issue/PR number):**
@@ -439,74 +401,86 @@ Agents coordinate exclusively through GitHub labels. Here is how an issue flows 
 
 **Daemon Mode**
 
-The daemon is the Layer 2 orchestrator that runs continuously as a standalone background process. It spawns shepherds as direct subprocesses, so shepherds are children of the daemon — not descendants of any Claude Code session.
+The Layer-2 daemon is the Rust binary `loom-daemon`. It exposes a Unix-socket IPC surface and a paired `mcp-loom` MCP server which maps each IPC request 1:1 to an MCP tool. The daemon is the coordination point for multi-account dispatch, monitoring, and lifecycle eventing.
 
 **Architecture:**
 ```
-init/launchd → loom-daemon → loom-shepherd.sh → claude /builder
+init/launchd → loom-daemon  ──MCP──→  Claude Code session (this skill)
+                  │
+                  ├── SweepRegistry (in-memory BTreeMap of dispatched sweeps)
+                  ├── EventBus (tokio broadcast channel, 6 frozen topics)
+                  └── ReaperTask (30-second tick, sweeps dead PIDs,
+                                   emits sweep.issue.*.exited / .crashed)
+                  │
+                  ▼
+        fork+exec /loom:sweep N via spawn-claude.sh (token rotation)
 ```
 
-This avoids nested Claude Code spawning restrictions.
+The daemon does **not** poll the forge, **does not** maintain a `shepherd-N` pool, and **does not** drive cron-scheduled support roles. Those responsibilities live in the operator's `mcp__loom__dispatch_sweep` calls (this skill, or the `/loom:sweep` skill via Stage -1 delegation) and the GitHub Actions cron workflows under `.github/workflows/loom-*.yml`.
 
-**Starting the daemon (from a shell outside Claude Code):**
-```bash
-./.loom/scripts/daemon.sh start                    # Start daemon
-./.loom/scripts/daemon.sh start -t 120             # Start daemon, stop after 2 hours
+**Starting the daemon**:
+```
+Run `loom-daemon` from a terminal outside Claude Code, via your service
+manager of choice (systemd unit, launchd plist, foreman, or just a
+background shell). The daemon binds a Unix socket and serves IPC over it
+until stopped.
 ```
 
-**Observing from Claude Code (`/loom`):**
+**Observing and dispatching from Claude Code (`/loom`)**:
 ```
-/loom                  Check daemon, observe state, write signals
-/loom --merge          Same, but signal shepherds with force mode
-/loom status           Read daemon-state.json and display
-```
-
-**Signal queue** (`.loom/signals/`):
-- `/loom` writes JSON command files here
-- The daemon polls and processes them within 2 seconds
-- Commands: `spawn_shepherd`, `stop`, `set_max_shepherds`, `pause_shepherd`, `resume_shepherd`
-
-**What the daemon does each iteration:**
-1. Polls `.loom/signals/` for IPC commands from `/loom`
-2. Captures system snapshot (issues, PRs, labels)
-3. Checks for completed shepherds
-4. Spawns new shepherds for ready `loom:issue` issues
-5. Triggers Architect/Hermit when backlog is low
-6. Sleeps until next iteration (default: 30 seconds, checks signals and assigns ready issues every 2 seconds)
-
-**Stopping the daemon:**
-```bash
-./.loom/scripts/daemon.sh stop                   # Graceful (waits for exit)
-./.loom/scripts/daemon.sh stop --force           # Immediate SIGTERM
-touch .loom/stop-daemon                          # Via file signal (equivalent)
+/loom                  Check daemon (probe via mcp__loom__list_sweeps),
+                       then observe registry + event bus and dispatch
+                       new sweeps for ready loom:issue items
+/loom --merge          Same, but dispatched sweeps run in --force mode
+                       (auto-merge approved PRs)
+/loom status           mcp__loom__list_sweeps + format the result
 ```
 
-**Configuration (environment variables):**
+**MCP tool reference**:
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `LOOM_POLL_INTERVAL` | 30 | Seconds between full iterations |
-| `LOOM_MAX_SHEPHERDS` | 10 | Max concurrent shepherds |
-| `LOOM_ISSUE_THRESHOLD` | 3 | Trigger work generation below this count |
-| `LOOM_ARCHITECT_COOLDOWN` | 1800 | Seconds between architect triggers |
-| `LOOM_HERMIT_COOLDOWN` | 1800 | Seconds between hermit triggers |
-| `LOOM_ISSUE_STRATEGY` | fifo | Issue selection: fifo, lifo, or priority |
+| Tool | Purpose |
+|------|---------|
+| `mcp__loom__dispatch_sweep` | Dispatch a sweep for an issue (returns sweep ID) |
+| `mcp__loom__list_sweeps` | Enumerate registry entries |
+| `mcp__loom__get_sweep_status` | Inspect a single sweep's state |
+| `mcp__loom__cancel_sweep` | SIGTERM -> grace -> SIGKILL |
+| `mcp__loom__tail_sweep_log` | Tail per-issue log file |
+| `mcp__loom__publish_event` | Publish a lifecycle event |
+| `mcp__loom__subscribe_to_events` | Topic-filtered event stream |
+| `mcp__loom__tail_event_bus` | Untopiced bus tail |
 
-**Merge mode** auto-promotes proposals and auto-merges PRs after Judge approval. It does NOT skip code review - the Judge always runs.
+**Event taxonomy** (frozen for v0.10.0 — new topics require a follow-up issue):
+
+| Topic | Publisher | Payload |
+|-------|-----------|---------|
+| `sweep.issue.{N}.phase` | Sweep child via `publish_event` | `{phase, pr_number?}` |
+| `sweep.issue.{N}.blocker` | Sweep child | `{reason, label_added}` |
+| `sweep.issue.{N}.exited` | Daemon reaper or `cancel_sweep` | `{exit_code, duration_sec}` |
+| `sweep.issue.{N}.crashed` | Daemon reaper | `{exit_code, duration_sec}` |
+| `sweep.global.dispatch` | Daemon | `{sweep_id, issue}` |
+| `sweep.global.completed` | Daemon reaper | `{sweep_id, issue, terminal_state}` |
+
+**Stopping the daemon** is out of scope for this skill — manage the daemon process via your service manager.
+
+**Merge mode** auto-merges PRs after Judge approval. It does NOT skip code review — the Judge phase still runs inside the dispatched sweep.
+
+**Full reference**: see `.loom/docs/daemon-reference.md` for the wire protocol, IPC request/response variants, registry internals, and reaper semantics.
 
 ---
 
-### Sub-topic: shepherd
+### Sub-topic: sweep
 
-**Shepherd - Single-Issue Orchestration**
+**Sweep - Single-Issue Orchestration**
 
-The shepherd (`/shepherd <issue>`) orchestrates one issue through its complete lifecycle.
+The sweep skill (`/loom:sweep <issue>`) orchestrates one issue through its complete lifecycle.
 
 **Usage:**
-```bash
-/shepherd 123            # Stop after PR is approved
-/shepherd 123 --merge    # Full automation including auto-merge
-/shepherd 123 --to curated  # Stop after curation
+```text
+/loom:sweep 123                    # Run the full lifecycle for issue 123
+/loom:sweep 123 --merge            # Full automation including auto-merge
+/loom:sweep --prs 456 789          # Mode C — PR-set back half
+/loom:sweep 123 --no-daemon        # Force in-session subagent dispatch
+                                    # (skip Stage -1 daemon delegation)
 ```
 
 **Lifecycle phases:**
@@ -518,7 +492,17 @@ The shepherd (`/shepherd <issue>`) orchestrates one issue through its complete l
 5. Merge phase     - Auto-merge the approved PR (with --merge)
 ```
 
-The shepherd tracks progress via milestones in `.loom/progress/` and writes checkpoints for crash recovery.
+**Stage -1: Backend detection** (Phase D of #3449):
+
+Before running phase 1, the sweep skill probes:
+1. Is `loom-daemon` reachable? (Ping over IPC, 500ms timeout)
+2. Does a multi-account token pool exist? (`.loom/tokens/` has ≥ 2 `ACCOUNT_KEY_*` entries)
+
+**Strict AND** — if either probe fails, fall through to in-process subagent dispatch (the existing Mode A/B/C lifecycle, no behaviour change for solo-token operators). If both succeed AND the mode is not C AND `--no-daemon` is not set, the skill calls `mcp__loom__dispatch_sweep` and exits.
+
+Mode C (`--prs`) always uses subagent dispatch; the daemon does not handle PR-set dispatch in v0.10.0.
+
+The skill tracks progress via checkpoints in `.loom/sweep-checkpoint/issue-<N>.json` for crash recovery.
 
 ---
 
@@ -564,7 +548,7 @@ loom-clean --deep       # Also remove build artifacts
 | `loom:issue` | Approved and ready for work | Champion/Human |
 | `loom:building` | Builder is implementing | Builder |
 | `loom:blocked` | Work is blocked | Builder |
-| `loom:operator-only` | Requires human action; sweep/shepherd skip | Human |
+| `loom:operator-only` | Requires human action; sweep skip | Human |
 | `loom:urgent` | Critical priority | Guide/Human |
 
 **Workflow labels (PR lifecycle):**
@@ -595,9 +579,9 @@ loom-clean --deep       # Also remove build artifacts
 ./.loom/scripts/stale-building-check.sh --recover
 ```
 
-**Orphaned shepherds after daemon crash:**
+**Orphaned sweeps after daemon crash:**
 ```bash
-./.loom/scripts/recover-orphaned-shepherds.sh --recover
+loom-orphan-recovery --recover
 ```
 
 **Labels out of sync:**
@@ -610,21 +594,25 @@ gh label sync --file .github/labels.yml
 loom-clean --force
 ```
 
-**Daemon won't start (stale PID):**
-```bash
-rm -f .loom/daemon-loop.pid
-./.loom/scripts/daemon.sh start
+**Daemon unreachable:**
+Verify the binary is running outside Claude Code (via your service manager).
+The MCP probe `mcp__loom__list_sweeps` will fail immediately if the IPC
+socket is missing.
+
+**Cancel a stuck sweep:**
+```
+mcp__loom__cancel_sweep --sweep_id <id>
 ```
 
-**Stop daemon gracefully:**
-```bash
-./.loom/scripts/daemon.sh stop
+**Inspect a sweep's log:**
+```
+mcp__loom__tail_sweep_log --issue <N> --lines 200
 ```
 
-**Check daemon status:**
-```bash
-/loom status
-./.loom/scripts/daemon.sh status
+**Subscribe to events for live debugging:**
+```
+mcp__loom__subscribe_to_events --topic "sweep.issue.<N>.*"
+mcp__loom__tail_event_bus
 ```
 
 **Merge PRs from worktrees (never use `gh pr merge`):**
@@ -633,6 +621,6 @@ rm -f .loom/daemon-loop.pid
 ```
 
 **Reference documentation:**
-- Daemon details: `/loom-reference`
-- Shepherd lifecycle: `/shepherd-lifecycle`
+- Daemon details: `.loom/docs/daemon-reference.md`
+- Sweep lifecycle: `defaults/.claude/commands/loom/sweep.md`
 - Full troubleshooting: `.loom/docs/troubleshooting.md`

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -7,7 +7,7 @@ This repository uses **Loom** for AI-powered development orchestration.
 
 ## What is Loom?
 
-Loom is a CLI + daemon for AI-powered development orchestration. It coordinates AI development workers using git worktrees and a forge (GitHub or Gitea) as the coordination layer. It supports manual coordination (Manual Orchestration Mode) and continuous autonomous orchestration via a minimal spawn loop plus GitHub Actions cron workflows for support roles.
+Loom is a CLI + daemon for AI-powered development orchestration. It coordinates AI development workers using git worktrees and a forge (GitHub or Gitea) as the coordination layer. It supports manual coordination (Manual Orchestration Mode), continuous autonomous orchestration via the Rust `loom-daemon` binary (MCP-level dispatch + pub/sub + monitoring), and GitHub Actions cron schedules for periodic support roles.
 
 **Loom Repository**: https://github.com/rjwalters/loom
 
@@ -64,10 +64,12 @@ Loom decomposes development into three coordination tiers, with the forge (GitHu
                               │ observes/intervenes
                               ▼
 ┌─────────────────────────────────────────────────────────────────┐
-│             Tier 2: Spawn loop + GitHub Actions cron            │
-│  ./.loom/scripts/spawn-loop.sh                                  │
-│   - Claims ready `loom:issue` items, detaches per-issue sweep   │
-│   - Multi-account token rotation per spawn                      │
+│            Tier 2: loom-daemon + GitHub Actions cron            │
+│  loom-daemon (Rust binary, MCP-level surface)                   │
+│   - dispatch_sweep / list_sweeps (sweep registry)               │
+│   - subscribe_to_events / publish_event (event bus)             │
+│   - get_sweep_status / cancel_sweep / tail_sweep_log            │
+│   - Multi-account token rotation per dispatch                   │
 │  .github/workflows/loom-*.yml                                   │
 │   - Cron-driven Champion / Curator / Judge / Auditor / Guide    │
 └─────────────────────────────────────────────────────────────────┘
@@ -97,7 +99,7 @@ Loom decomposes development into three coordination tiers, with the forge (GitHu
 | Tier | Entry point | Purpose | Mode |
 |------|-------------|---------|------|
 | Tier 3 | Human | Oversight — approve proposals, handle edge cases | Observer |
-| Tier 2 | `./.loom/scripts/spawn-loop.sh` + GH Actions cron | Multi-issue batch + scheduled support roles | Continuous / cron |
+| Tier 2 | `loom-daemon` (MCP) + GH Actions cron | Multi-issue dispatch + scheduled support roles | Continuous / cron |
 | Tier 1 | `/loom:sweep <issue>` | Issue lifecycle from creation to merge | Per-issue |
 | Tier 0 | `/builder`, `/judge`, etc. | Task execution — single focused work units | Per-task |
 
@@ -109,10 +111,10 @@ Loom decomposes development into three coordination tiers, with the forge (GitHu
 - Intervene for blocked issues or stuck agents
 - Provide strategic direction on what to build
 
-**Tier 2 (Spawn loop + GH Actions cron)**:
-- The spawn loop polls `loom:issue` and spawns `/loom:sweep` children, one per ready issue, up to `MAX_PARALLEL` (default 3)
-- The GitHub Actions workflows under `.github/workflows/loom-*.yml` run periodic support roles (Champion, Curator, Judge, Auditor, Guide) on cron schedules
-- Architect / Hermit cadence (work generation) is currently manual — tracked under follow-up #3381
+**Tier 2 (`loom-daemon` + GH Actions cron)**:
+- The Rust `loom-daemon` binary exposes MCP tools for dispatching `/loom:sweep` children with multi-account OAuth token rotation (`mcp__loom__dispatch_sweep`), tracking running sweeps (`mcp__loom__list_sweeps`, `mcp__loom__get_sweep_status`), pub/sub eventing on a frozen 6-topic taxonomy (`mcp__loom__publish_event`, `mcp__loom__subscribe_to_events`), and cancellation (`mcp__loom__cancel_sweep`). State is in-memory only — the forge is the source of truth for queue state.
+- The GitHub Actions workflows under `.github/workflows/loom-*.yml` run periodic support roles (Champion, Curator, Judge, Auditor, Guide) on cron schedules.
+- Architect / Hermit cadence (work generation) is currently manual — tracked under follow-up #3381.
 
 **Tier 1 (`/loom:sweep`)**:
 - Fully autonomous once spawned
@@ -126,10 +128,11 @@ Loom decomposes development into three coordination tiers, with the forge (GitHu
 - You want to orchestrate one issue through its full lifecycle
 - Running manual orchestration mode
 
-**Use the spawn loop** (`LOOM_USE_SPAWN_LOOP=1 ./.loom/scripts/spawn-loop.sh start`) when:
-- You want autonomous multi-issue batch processing
-- Multiple ready issues need to be claimed in parallel
-- Running production-scale orchestration with multi-account token rotation
+**Use `mcp__loom__dispatch_sweep`** (against a running `loom-daemon`) when:
+- You want autonomous multi-issue dispatch with multi-account token rotation
+- Multiple sweeps need to run in parallel under daemon supervision
+- You need to monitor sweep lifecycle events (pub/sub) or cancel in-flight sweeps
+- Running production-scale orchestration where the daemon's reaper task and in-memory registry are the source of truth for "what is currently dispatched"
 
 ## Usage Modes
 
@@ -187,32 +190,39 @@ claude -p "/loom:sweep 123" --dangerously-skip-permissions
 
 Checkpoints (#3373) under `.loom/sweep-checkpoint/issue-<N>.json` survive crashes — restarting `/loom:sweep N` resumes from the last completed phase.
 
-### 3. Spawn-Loop Mode (Phase 1, opt-in)
+### 3. Daemon Mode (`loom-daemon` + MCP tools)
 
-A minimal alternative to the full daemon for multi-account `/loom:sweep` launching (#3374, Phase 1 of the shepherd/daemon deprecation epic #3372). Polls `loom:issue`, atomically claims ready issues (label flip + `mkdir`-based file lock under `.loom/locks/issue-<N>/`), and detaches `claude -p "/loom:sweep N"` per issue — each spawn picks its own OAuth token via `spawn-claude.sh`. No work generation, no support-role triggers, no shepherd-N pool-slot bookkeeping.
+The Rust `loom-daemon` binary is the Tier 2 dispatch backend. It is a single long-lived process exposing a Unix-socket IPC surface and a paired `mcp-loom` MCP server. Each IPC `Request` variant maps 1:1 to an MCP tool, so any MCP client — most commonly a Claude Code session running `/loom:sweep` — can dispatch sweeps, observe registry state, subscribe to lifecycle events, and cancel in-flight work.
 
-```bash
-# Opt-in gate is required (protects existing daemon users from accidental dual-orchestration)
-LOOM_USE_SPAWN_LOOP=1 ./.loom/scripts/spawn-loop.sh start
+**MCP surface** (Phases A–C of epic #3449, all shipped):
 
-./.loom/scripts/spawn-loop.sh status
-./.loom/scripts/spawn-loop.sh stop          # or: touch .loom/stop-spawn-loop
-```
+| MCP tool | Purpose | Phase |
+|----------|---------|-------|
+| `mcp__loom__dispatch_sweep` | Dispatch a sweep for an issue (token rotation via `spawn-claude.sh`) | A (#3452) |
+| `mcp__loom__list_sweeps` | Enumerate running sweeps in the in-memory registry | A (#3452) |
+| `mcp__loom__publish_event` | Publish a sweep-lifecycle event on the in-memory bus | B (#3453) |
+| `mcp__loom__subscribe_to_events` | Stream topic-filtered events to a subscriber | B (#3453) |
+| `mcp__loom__get_sweep_status` | Inspect a running sweep's state (PID, phase, started_at) | C (#3455) |
+| `mcp__loom__tail_sweep_log` | Tail `.loom/logs/sweep-issue-<N>.log` | C (#3455) |
+| `mcp__loom__cancel_sweep` | Cancel a running sweep (SIGTERM → grace → SIGKILL) | C (#3455) |
+| `mcp__loom__tail_event_bus` | Tail the event bus without subscribing to a topic | C (#3455) |
+
+**Event taxonomy (frozen for v0.10.0)**: `sweep.issue.{N}.phase`, `sweep.issue.{N}.blocker`, `sweep.issue.{N}.exited`, `sweep.issue.{N}.crashed`, `sweep.global.dispatch`, `sweep.global.completed`. New topics require a follow-up issue — the v0.10.0 set is intentionally frozen.
+
+**`/loom:sweep` backend detection (Stage -1, Phase D #3454)**: the skill probes whether the daemon is reachable (a Ping over the IPC socket with a 500ms timeout) AND whether a multi-account token pool exists (`.loom/tokens/` contains ≥ 2 `ACCOUNT_KEY_*` entries). **Strict AND** — either probe failing falls through to in-process subagent dispatch (the existing Mode A/B/C lifecycle, no behaviour change for solo-token operators). Mode C (`--prs`) always uses subagent dispatch; the daemon does not handle PR-set dispatch in v0.10.0. The `--no-daemon` flag forces subagent dispatch unconditionally.
+
+**Per-sweep state on disk**:
 
 | File | Purpose |
 |------|---------|
-| `.loom/spawn-loop.pid` | Loop PID (gitignored) |
-| `.loom/spawn-loop-state.json` | `{started_at, running:[{issue, pid, started_at, token}]}` (gitignored) |
-| `.loom/logs/spawn-loop.log` | Timestamped spawn/exit/error entries |
-| `.loom/logs/sweep-issue-<N>.log` | Per-issue child output |
-| `.loom/locks/issue-<N>/` | Atomic claim lock dir (gitignored) |
-| `.loom/stop-spawn-loop` | Touch to request graceful shutdown |
+| `.loom/logs/sweep-issue-<N>.log` | Per-issue child output (tailable via `mcp__loom__tail_sweep_log`) |
+| `.loom/sweep-checkpoint/issue-<N>.json` | Crash-resume checkpoint (#3373); the sweep skill reads it on entry and skips already-completed phases |
 
-**Crash recovery**: if a child dies while a `.loom/sweep-checkpoint/issue-<N>.json` exists, the loop flips the issue back to `loom:issue` so the next tick re-spawns; the sweep skill itself (#3373) reads the checkpoint on entry and skips already-completed phases.
+The daemon **does not** poll the forge for ready issues, **does not** maintain a `shepherd-N` pool, and **does not** drive support roles on cron. Those responsibilities live in `mcp__loom__dispatch_sweep` (operator-driven enqueue) and the GitHub Actions cron workflows (periodic support roles).
 
-**Coexistence with daemon mode**: the `daemon.sh` shell wrapper is **preserved** in v0.10.0 (the Python `loom-daemon` brain it historically called is removed; the shell launcher is re-implemented around the spawn loop and tmux). The spawn loop and `daemon.sh` are two ways to run the same Tier-2 orchestration — the spawn loop is the headless minimal driver, while `daemon.sh` adds a tmux multi-pane container with per-pane OAuth token rotation. If both are running, they will race for `loom:issue` items; pick one in practice.
+For the full surface — IPC request/response variants, event-bus internals, registry behaviour, reaper semantics — see [`.loom/docs/daemon-reference.md`](.loom/docs/daemon-reference.md).
 
-**Tunables (env)**: `MAX_PARALLEL=3`, `POLL_INTERVAL=30`, `SHUTDOWN_GRACE_SEC=300`, `LOOM_REPO=owner/repo` (override remote auto-detection).
+> **Legacy spawn loop deprecated**: `defaults/scripts/spawn-loop.sh` (Phase 1, #3374) is deprecated as of Phase E of #3449. It emits a stderr warning on every `start` / `status` / `stop` invocation and will be deleted in v0.11.0. Use `mcp__loom__dispatch_sweep` against `loom-daemon` instead. Suppress the warning with `LOOM_SUPPRESS_DEPRECATION=1` while you migrate. See [the migration guide](../docs/migration/v0.10.0-shepherd-deprecation.md).
 
 ### Scheduled Support Roles (Phase 2a, opt-in)
 
@@ -232,7 +242,7 @@ GitHub Actions workflows under `.github/workflows/loom-*.yml` provide a daemon-f
 2. Uncomment the `schedule:` / `- cron:` lines in each `.github/workflows/loom-*.yml` you want to enable.
 3. Optionally trigger a run via `workflow_dispatch` (the Actions UI's "Run workflow" button) to smoke-test before the next scheduled tick.
 
-Architect and Hermit cadence (work-generation triggers) is intentionally out of scope here — see follow-up #3381. Post-v0.10.0, the schedule-driven cron workflows are the recommended path for support roles since the Python daemon brain is removed. Operators who want support roles co-located with the issue-work pane can still run them in tmux via `./.loom/scripts/daemon.sh` (each pane gets its own rotated OAuth token, unlike the GH Actions workflows which use a single API key) — **but note: `./.loom/scripts/daemon.sh` is currently absent on `origin/main` (deleted in #3432, rebuild in flight under epic #3449, ~4-6 weeks); until that lands, use the GH Actions workflows or `./.loom/scripts/spawn-loop.sh`.**
+Architect and Hermit cadence (work-generation triggers) is intentionally out of scope here — see follow-up #3381. Post-v0.10.0, the schedule-driven cron workflows are the recommended path for support roles since the Python daemon brain is removed. Operators who want multi-account-rotated dispatch (rather than the single-CI-token GH Actions surface) should use `mcp__loom__dispatch_sweep` against `loom-daemon` from a Claude Code session — each dispatched sweep picks a fresh OAuth token via `spawn-claude.sh`.
 
 ## Agent Roles
 
@@ -306,11 +316,7 @@ Full role definitions with detailed guidelines are available in:
 - `.loom/roles/guide.md` - Issue triage and prioritization
 - `.loom/roles/auditor.md` - Main branch validation
 
-> **Stop-gap — daemon backend in flight (v0.10.0 rebuild, epic #3449)**
->
-> `./.loom/scripts/daemon.sh` does not exist on `origin/main` as of v0.9.1; the dispatcher was deleted in #3432 and is being rebuilt in epic #3449 (~4-6 weeks, scheduled for v0.10.0). The note below describes the intended target state. Until Phase A through E of #3449 land, daemon operator commands (`./.loom/scripts/daemon.sh start|stop|status`) will fail with "no such file or directory". Use `./.loom/scripts/spawn-loop.sh` for headless multi-issue dispatch in the interim. Tracker: #3451 (this stop-gap), #3449 (rebuild epic).
-
-> **Note**: the historical `shepherd.md` (single-issue orchestrator) role file was removed in v0.10.0 along with the `/shepherd` slash command — see [the migration guide](../docs/migration/v0.10.0-shepherd-deprecation.md). Its orchestration responsibilities moved to `/loom:sweep` (Tier 1) and the spawn loop + GH Actions cron (Tier 2). The `loom.md` role file is preserved and documents the daemon-mode operator surface (`./.loom/scripts/daemon.sh` + tmux + token-rotated separate Claude Code sessions — see stop-gap warning above re: in-flight rebuild #3449); the Python brain it historically referenced (`loom_tools/daemon_v2/`) is removed in v0.10.0, but the shell-level daemon surface stays. The worker-role markdown files above are unchanged.
+> **Note**: the historical `shepherd.md` (single-issue orchestrator) role file was removed in v0.10.0 along with the `/shepherd` slash command — see [the migration guide](../docs/migration/v0.10.0-shepherd-deprecation.md). Its orchestration responsibilities moved to `/loom:sweep` (Tier 1) and the `loom-daemon` + GH Actions cron (Tier 2). The `loom.md` role file is preserved and documents the daemon-mode operator surface: a Claude Code session that observes the running `loom-daemon` via MCP tools (`mcp__loom__list_sweeps`, `mcp__loom__get_sweep_status`, `mcp__loom__subscribe_to_events`) and dispatches new work via `mcp__loom__dispatch_sweep`. The historical Python brain (`loom_tools/daemon_v2/`) is gone; the MCP-level surface is the supported coordination point. The worker-role markdown files above are unchanged.
 
 ## Label-Based Workflow
 
@@ -617,47 +623,41 @@ An optional deterministic gate runs after the builder agent exits but before PR 
 
 Repos without a `buildGate` block see zero behavior change. See `.loom/docs/build-gate.md` for the full schema and failure semantics.
 
-### Spawn-Loop Configuration (Tier 2)
+### Daemon Configuration (Tier 2)
 
-> **Stop-gap — daemon backend in flight (v0.10.0 rebuild, epic #3449)**
->
-> The paragraph below claims `./.loom/scripts/daemon.sh` "now wraps the spawn loop with tmux + per-pane token rotation". On `origin/main` as of v0.9.1, that file does not exist (deleted in #3432, rebuild in flight under epic #3449, ~4-6 weeks). Until the rebuild lands, the only working multi-issue dispatch backend is `./.loom/scripts/spawn-loop.sh` (headless) or the GitHub Actions cron workflows.
+The Rust `loom-daemon` binary is the load-bearing Tier 2 dispatch backend. It is a single long-lived process that holds the sweep registry, the event bus, and the reaper task in memory — there is no on-disk state file the operator needs to touch. The forge is the source of truth for queue state; the daemon's in-memory registry tracks only currently-dispatched sweeps.
 
-The spawn loop replaces the historical Python daemon brain. Its surface is intentionally narrow — there are no work-generation triggers, no pool-slot bookkeeping, and no state-file-based pipeline tracking. The shell-level daemon surface (`./.loom/scripts/daemon.sh`) is preserved and now wraps the spawn loop with tmux + per-pane token rotation. See [`.loom/docs/daemon-reference.md`](.loom/docs/daemon-reference.md) and [the migration guide](../docs/migration/v0.10.0-shepherd-deprecation.md) for details.
+**Process model**: the daemon runs as a detached background process. Each `mcp__loom__dispatch_sweep` request fork+execs a fresh `claude -p "/loom:sweep N"` child via `defaults/scripts/spawn-claude.sh`, picking an OAuth token from the `.loom/tokens/` pool (token rotation only works at process-spawn boundaries; the daemon never holds the token itself). The reaper task ticks every 30 seconds, sweeping dead PIDs out of the registry and emitting `sweep.issue.{N}.exited` / `sweep.issue.{N}.crashed` events.
 
-**Tunables (env)**:
+**MCP tools available** (each maps 1:1 to a daemon IPC `Request` variant):
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `MAX_PARALLEL` | 3 | Maximum concurrent `/loom:sweep` children |
-| `POLL_INTERVAL` | 30 | Seconds between `loom:issue` polls |
-| `SHUTDOWN_GRACE_SEC` | 300 | Seconds to wait for in-flight children at shutdown |
-| `LOOM_USE_SPAWN_LOOP` | (unset) | Opt-in gate, required to start the loop |
-| `LOOM_REPO` | (auto) | Override remote auto-detection (`owner/repo`) |
+| MCP tool | Description |
+|----------|-------------|
+| `mcp__loom__dispatch_sweep` | Dispatch a sweep for an issue (returns a sweep ID) |
+| `mcp__loom__list_sweeps` | Enumerate registry entries |
+| `mcp__loom__get_sweep_status` | Inspect a single sweep's state |
+| `mcp__loom__cancel_sweep` | SIGTERM → grace → SIGKILL a running sweep |
+| `mcp__loom__tail_sweep_log` | Tail `.loom/logs/sweep-issue-<N>.log` |
+| `mcp__loom__publish_event` | Publish a sweep-lifecycle event |
+| `mcp__loom__subscribe_to_events` | Topic-filtered event stream |
+| `mcp__loom__tail_event_bus` | Untopiced event tail |
 
-**State file** (`.loom/spawn-loop-state.json`, gitignored):
+See [`.loom/docs/daemon-reference.md`](.loom/docs/daemon-reference.md) for the wire protocol, the frozen 6-topic event taxonomy, and the registry/reaper semantics.
 
-```json
-{
-  "started_at": "2026-06-04T10:00:00Z",
-  "running": [
-    {
-      "issue": 123,
-      "pid": 49281,
-      "started_at": "2026-06-04T10:15:00Z",
-      "token": "agent-3.token"
-    }
-  ]
-}
-```
+**Per-sweep state on disk**:
 
-That's the entire schema. Pipeline state, warnings, completed-issue history, and work-generation cooldowns are not tracked — the forge is the source of truth for queue state, and the spawn loop is intentionally minimal.
+| File | Purpose |
+|------|---------|
+| `.loom/logs/sweep-issue-<N>.log` | Per-issue child output (tailable via `mcp__loom__tail_sweep_log`) |
+| `.loom/sweep-checkpoint/issue-<N>.json` | Crash-resume checkpoint (#3373); sweep skill reads it on entry |
 
-**Issue selection** is FIFO within the `loom:issue` queue, with the `loom:urgent` label taking precedence (urgent-first, then oldest-first). The pre-v0.10.0 `LOOM_ISSUE_STRATEGY` env var (with `lifo` / `priority` alternatives) no longer applies; the strategy lives inside the spawn loop and is not currently configurable.
+**Issue selection** is operator-driven via `mcp__loom__dispatch_sweep` — the daemon does not autonomously claim items from the `loom:issue` queue. (The `/loom:sweep` skill is the typical caller; Stage -1 backend detection picks an issue and dispatches it when both daemon and pool probes succeed.)
 
-**Sweep checkpoints** (`.loom/sweep-checkpoint/issue-<N>.json`, gitignored) — the per-issue checkpoint format is owned by the sweep skill (#3373). When a sweep child crashes, the spawn loop flips the issue back to `loom:issue` so the next tick re-spawns; the sweep skill itself reads the checkpoint on entry and skips already-completed phases.
+**Sweep checkpoints** (`.loom/sweep-checkpoint/issue-<N>.json`, gitignored) — the per-issue checkpoint format is owned by the sweep skill (#3373). When a sweep child crashes, the next dispatch reads the checkpoint and skips already-completed phases.
 
 **Scheduled support roles** run as separate GitHub Actions cron jobs under `.github/workflows/loom-*.yml`. They have no persistent state on the Loom side; each tick is a fresh `claude -p "/<role>" --dangerously-skip-permissions` invocation.
+
+> **Legacy spawn-loop state**: the v0.9.x state file `.loom/spawn-loop-state.json` is still written by the deprecated `spawn-loop.sh` (scheduled for deletion in v0.11.0). The daemon does not consume it. Operators who need to observe running sweeps should call `mcp__loom__list_sweeps` against the daemon instead.
 
 ### Model Selection Strategy
 
@@ -989,7 +989,7 @@ cp -r defaults/hooks/example-context/* .loom/context/
 
 **Overnight / long-running orchestration: keep the host awake (#3350)**:
 
-`/loom:sweep` and the spawn loop automatically run `./.loom/scripts/check-host-sleep.sh` at startup and warn when the host can sleep. This is **advisory only** — Loom never blocks on it. Heed the warning before walking away from a long run.
+`/loom:sweep` automatically runs `./.loom/scripts/check-host-sleep.sh` at startup and warns when the host can sleep. This is **advisory only** — Loom never blocks on it. Heed the warning before walking away from a long run.
 
 - **macOS:** user-idle sleep assertions (Amphetamine, `caffeinate -dimsu`, etc.) do **not** reliably defeat Maintenance Sleep on Apple Silicon. Use `sudo pmset -c sleep 0` for AC-only sleep disable, or flip your sleep manager's "allow system sleep when display is off" toggle to OFF. Restore with `sudo pmset -c sleep 1` afterwards.
 - **systemd Linux:** wrap the session in `systemd-inhibit --what=idle:sleep --who=loom --why=loom -- <cmd>`. This is reliable.
@@ -1114,9 +1114,9 @@ When an agent crashes or is cancelled while building, issues can get stuck in `l
 - Issues without PRs older than threshold are flagged/recovered
 - Issues with stale PRs are flagged but not auto-recovered (need manual review)
 
-**Orphaned task recovery (spawn-loop crashes)**:
+**Orphaned task recovery (daemon dispatch crashes)**:
 
-When the spawn loop crashes or is terminated abruptly, sweep children may be left with stale `.loom/locks/issue-<N>/` lock directories or stale entries in `.loom/spawn-loop-state.json`. `loom-orphan-recovery` (the ported successor to the historical `recover-orphaned-shepherds.sh`) handles this:
+When a dispatched sweep child crashes abruptly and the daemon's reaper hasn't yet caught up, sweep state may diverge briefly from forge state. `loom-orphan-recovery` (the ported successor to the historical `recover-orphaned-shepherds.sh`) reconciles this:
 
 ```bash
 # Check for orphaned tasks (dry run)
@@ -1130,22 +1130,20 @@ loom-orphan-recovery --json
 ```
 
 **What it detects** (post-v0.10.0):
-- Stale pids in `.loom/spawn-loop-state.json` (tasks whose process no longer exists)
-- `loom:building` issues with no live task in the spawn loop
+- Dead PIDs still listed by `mcp__loom__list_sweeps`
+- `loom:building` issues with no live sweep in the daemon registry
 - Stale lock dirs at `.loom/locks/issue-<N>/` for closed/merged issues
 
 **What it recovers**:
-- Removes stale entries from `.loom/spawn-loop-state.json`
 - Returns orphaned issues from `loom:building` to `loom:issue`
 - Adds recovery comments to affected issues
 - Removes stale lock dirs
 
-**Automatic recovery on spawn-loop startup**:
-The spawn loop runs orphan recovery at startup. This ensures it starts with a clean claim set after a crash.
+The daemon's 30-second reaper task usually catches this autonomously; `loom-orphan-recovery` is the manual cross-check.
 
 ### Stuck Agent Detection
 
-`loom-stuck-detection` checks for stuck sweep children using `.loom/spawn-loop-state.json` task pids and `.loom/sweep-checkpoint/issue-<N>.json` checkpoint timestamps.
+`loom-stuck-detection` checks for stuck sweep children by combining the daemon registry (via `mcp__loom__list_sweeps`) with `.loom/sweep-checkpoint/issue-<N>.json` checkpoint timestamps.
 
 **Check for stuck agents**:
 ```bash
@@ -1164,49 +1162,34 @@ loom-stuck-detection check-issue 123
 | Indicator | Default Threshold | Description |
 |-----------|-------------------|-------------|
 | `stale_heartbeat` | 5 minutes | No checkpoint update for extended time |
-| `dead_pid` | (instant) | PID in spawn-loop-state.json is no longer alive |
+| `dead_pid` | (instant) | PID in daemon registry is no longer alive |
 | `error_spike` | 5 errors | Multiple errors in `.loom/logs/sweep-issue-N.log` |
 
 The pre-v0.10.0 indicators `no_progress`, `extended_work`, and `looping` are no longer tractable post-deletion of `.loom/progress/` — see [the migration guide § Per-CLI breaking changes](../docs/migration/v0.10.0-shepherd-deprecation.md#per-cli-breaking-changes) for the diff.
 
-### Spawn-Loop Troubleshooting
+### Daemon Troubleshooting
 
-**Check spawn-loop state**:
+**Inspect the daemon registry**:
 ```bash
-# Status summary (human-readable)
-./.loom/scripts/spawn-loop.sh status
+# From a Claude Code session: list all currently-dispatched sweeps
+# mcp__loom__list_sweeps
 
-# Or read the state file directly
-cat .loom/spawn-loop-state.json | jq
+# Or inspect a single sweep
+# mcp__loom__get_sweep_status --sweep_id <id>
 
-# Check if loop is running
-test -f .loom/spawn-loop.pid && ps -p "$(cat .loom/spawn-loop.pid)" -o pid,etime,command
-
-# List active sweep children
-jq '.running[] | {issue, pid, started_at}' .loom/spawn-loop-state.json
+# Tail per-sweep output
+# mcp__loom__tail_sweep_log --issue 123
 ```
 
-**Graceful shutdown**:
+**Cancel a stuck sweep**:
 ```bash
-# Signal the spawn loop to stop accepting new work and drain in-flight children
-./.loom/scripts/spawn-loop.sh stop
-# or, equivalently:
-touch .loom/stop-spawn-loop
+# From a Claude Code session
+# mcp__loom__cancel_sweep --sweep_id <id>
+# Sends SIGTERM, waits the configured grace window, then SIGKILL.
+# The checkpoint survives so the next dispatch resumes from the last phase.
 ```
 
-The loop honors `SHUTDOWN_GRACE_SEC` (default 300s) before SIGKILL'ing any remaining sweep children.
-
-**Force stop** (use with caution):
-```bash
-# Remove stop signal if it was set but never picked up
-rm -f .loom/stop-spawn-loop
-
-# Hard-kill the loop process
-test -f .loom/spawn-loop.pid && kill -9 "$(cat .loom/spawn-loop.pid)" || true
-rm -f .loom/spawn-loop.pid
-```
-
-**Stuck sweep child**:
+**Stuck sweep child** (without using MCP tools):
 
 A sweep child whose pid is alive but whose `.loom/sweep-checkpoint/issue-<N>.json` mtime is stale is likely stuck. Recovery:
 
@@ -1217,17 +1200,22 @@ ls -la .loom/sweep-checkpoint/issue-123.json
 # Look at the child's log for errors
 tail -200 .loom/logs/sweep-issue-123.log
 
-# Kill the stuck pid; the loop will detect the dead pid on the next tick
-# and release the claim (the checkpoint survives, so the issue will resume
-# from its last completed phase the next time the loop spawns it).
-jq '.running[] | select(.issue==123) | .pid' .loom/spawn-loop-state.json | xargs -I{} kill {}
+# Kill the stuck pid; the daemon reaper will detect it within 30 seconds and
+# emit a `sweep.issue.123.crashed` event. The checkpoint survives so the next
+# `mcp__loom__dispatch_sweep` resumes from the last completed phase.
 ```
+
+**Subscribe to sweep events for live debugging**:
+```bash
+# mcp__loom__subscribe_to_events --topic "sweep.issue.123.*"
+# mcp__loom__tail_event_bus
+```
+
+See [`.loom/docs/daemon-reference.md`](.loom/docs/daemon-reference.md) for the full event taxonomy and IPC surface.
 
 **Work generation (Architect / Hermit) not running**:
 
-**This is by design post-v0.10.0.** The spawn loop does not generate work — Architect and Hermit cadence is tracked under follow-up #3381. If you need new work generated automatically, run Architect/Hermit on a cron via the Phase 2a GitHub Actions pattern (`.github/workflows/loom-*.yml`); the existing five shipped workflows cover Champion / Curator / Judge / Auditor / Guide, but Architect and Hermit cron workflows are not yet shipped.
-
-For now, trigger them manually when the queue is empty:
+**This is by design post-v0.10.0.** Neither the daemon nor the GH Actions cron generates work for Architect / Hermit — that cadence is tracked under follow-up #3381. For now, trigger them manually when the queue is empty:
 
 ```bash
 claude -p "/architect" --dangerously-skip-permissions
@@ -1500,51 +1488,43 @@ Or run the setup script to generate `.mcp.json` automatically:
 ./scripts/setup-mcp.sh
 ```
 
-## Migration: deprecations targeted for v0.10.0
+## Migration: v0.10.0 shepherd/daemon deprecation
 
-> **Stop-gap — daemon "preserved" claim is currently aspirational (epic #3449, stop-gap #3451)**
->
-> The next paragraph says daemon mode "is preserved as a user-facing surface" and that `./.loom/scripts/daemon.sh` "continues to provide a tmux session container". On `origin/main` as of v0.9.1, `./.loom/scripts/daemon.sh` does **not** exist — it was deleted in #3432 and is being rebuilt in epic #3449 over an estimated 4-6 weeks for v0.10.0. The shepherd/Python-daemon-brain deletions are real and shipped; the daemon-shell rebuild is in flight. Until #3449 ships, use `./.loom/scripts/spawn-loop.sh` (headless) or GitHub Actions cron workflows.
+Loom's orchestration architecture migration (epic #3372) deleted the shepherd brain (`loom-tools/src/loom_tools/shepherd/`), the Python daemon brain (`loom-tools/src/loom_tools/daemon_v2/`), and the `/shepherd` slash command. Epic #3449 then rebuilt the **daemon surface as a Rust binary** (`loom-daemon`) that exposes MCP tools for dispatch, monitoring, and pub/sub eventing — phases A through D have all shipped on main; phase E (this work) deprecates the v0.9.x `defaults/scripts/spawn-loop.sh` interim implementation.
 
-Loom is in the middle of an orchestration-architecture migration (epic #3372). In **v0.10.0** (the next planned minor release), the shepherd brain (`loom-tools/src/loom_tools/shepherd/`), the Python daemon brain (`loom-tools/src/loom_tools/daemon_v2/`), and the `/shepherd` slash command will be **deleted** in favour of a minimal spawn loop (#3374) + GitHub Actions workflows (#3375). **Daemon mode itself is preserved as a user-facing surface** — `./.loom/scripts/daemon.sh` continues to provide a tmux session container with multi-account token rotation, re-implemented around the spawn loop. The phased rollout is:
-
-| Phase | Issue | What ships | Status |
+| Phase | Issue | What shipped | Status |
 |-------|-------|-----------|--------|
-| Phase 1 | #3374 | Minimal multi-account spawn loop (`./.loom/scripts/spawn-loop.sh`) | shipped |
-| Phase 2a | #3375 | GitHub Actions workflows for support roles (Champion, Curator, Judge, Auditor, Guide) | shipped (workflows disabled by default) |
-| Phase 2b | #3376 | **Soft-deprecation warnings on deprecated entry points** | shipped |
-| Phase 3 | TBD | Deletion of shepherd brain, Python daemon brain, and `/shepherd` skill; re-implementation of `daemon.sh` around spawn loop + tmux | **v0.10.0** |
-| Phase 4 | #3382 | Coordinated downstream sphere-install migration (deprecation banners in installed templates + this migration section) | shipped |
+| Phase 1 | #3374 | Minimal multi-account spawn loop (`spawn-loop.sh`) | shipped (deprecated in Phase E) |
+| Phase 2a | #3375 | GitHub Actions workflows for support roles | shipped (disabled by default) |
+| Phase 2b | #3376 | Soft-deprecation warnings on deprecated entry points | shipped |
+| Phase 3 | #3378 | Deletion of shepherd brain, Python daemon brain, `/shepherd` skill | shipped |
+| Phase 4 | #3382 | Coordinated downstream sphere-install migration | shipped |
+| #3449 Phase A | #3452 | `loom-daemon`: `dispatch_sweep`, `list_sweeps`, in-memory registry, reaper task | shipped |
+| #3449 Phase B | #3453 | `loom-daemon`: event bus (tokio broadcast), 6 frozen topics, `publish_event` / `subscribe_to_events` IPC | shipped |
+| #3449 Phase C | #3455 | MCP tools: `get_sweep_status`, `tail_sweep_log`, `subscribe_to_events`, `publish_event`, `cancel_sweep`, `tail_event_bus`; `.loom/docs/daemon-reference.md` rewrite | shipped |
+| #3449 Phase D | #3454 | `/loom:sweep` Stage -1 backend detection (strict-AND daemon + pool probe) | shipped |
+| #3449 Phase E | #3456 | `spawn-loop.sh` deprecation warning + operator-doc rewrite | this PR |
 
-**v1.0.0 is intentionally unscheduled.** Loom remains pre-1.0 while the architecture settles. The migration guide filename
-`docs/migration/v0.10.0-shepherd-deprecation.md` is named for the release that will ship the deletions.
+**v1.0.0 is intentionally unscheduled.** Loom remains pre-1.0 while the architecture settles. The migration guide filename `docs/migration/v0.10.0-shepherd-deprecation.md` is named for the release that ships the deletions.
 
-**Deprecated entry points (still functional, now warn on use):**
+**Removed entry points** (no longer present in v0.10.0+):
 
-| Deprecated | Replacement | Warning emitted from |
-|------------|-------------|----------------------|
-| `loom-daemon` (Python entry point) | `./.loom/scripts/daemon.sh` (preserved, re-implemented) OR `./.loom/scripts/spawn-loop.sh` (headless) + GitHub Actions schedules | `loom_tools.daemon_v2.cli.main()` |
-| `loom-shepherd` CLI / `/shepherd` invocations | `/loom:sweep <issue>` for the same lifecycle | `loom_tools.shepherd.cli.main()` |
-| `/shepherd` slash command (`defaults/.claude/commands/loom/shepherd.md`) | `/loom:sweep <issue>` | Markdown header instructs the LLM to emit the warning |
+| Removed | Replacement |
+|---------|-------------|
+| `loom-daemon` (Python entry point) | Rust `loom-daemon` binary + `mcp__loom__dispatch_sweep` + GitHub Actions schedules |
+| `loom-shepherd` CLI / `/shepherd` slash command | `/loom:sweep <issue>` for the same per-issue lifecycle |
 
-> **Note**: `./.loom/scripts/daemon.sh` was listed as deprecated in 0.9.1 under the original plan that anticipated removing daemon mode entirely. **That plan was revised**: the shell-level daemon surface is preserved in v0.10.0. The warning attached to `daemon.sh start` in 0.9.1 will be withdrawn in v0.10.0. The Python `loom-daemon` CLI warning escalates to a genuine "command not found" error.
+**Deprecated entry points (still functional in v0.10.x, removed in v0.11.0)**:
 
-**Suppression**: set `LOOM_SUPPRESS_DEPRECATION=1` to silence the warnings emitted from Python and shell entry points. The `/shepherd` markdown skill warning always renders by design — operators should explicitly migrate, not silence. Sphere installs and other downstream automation that haven't migrated yet can use this env var to keep their logs clean during the deprecation window.
+| Deprecated | Replacement | Warning |
+|------------|-------------|---------|
+| `defaults/scripts/spawn-loop.sh` | `mcp__loom__dispatch_sweep` against `loom-daemon` | Stderr banner on every invocation (Phase E of #3449); suppressible with `LOOM_SUPPRESS_DEPRECATION=1` |
 
-**Helpers**: the warning text is centralized in two places so removal in Phase 3 is a single-PR sweep:
+## Migrating off shepherd / spawn-loop (downstream consumers)
 
-- Python: `loom_tools.common.deprecation.warn_deprecated(component, replacement, ref="#3372")`
-- Shell: `source .loom/scripts/lib/deprecation.sh; warn_deprecated <component> <replacement> [ref]` — the bash helper is safe to source (no side effects).
+If you installed Loom via `scripts/install-loom.sh` (or `install.sh`), the shepherd brain and Python daemon brain are already gone; the spawn-loop deprecation in this phase is your final migration step before v0.11.0 deletes it.
 
-## Migrating off shepherd (downstream consumers, Phase 4 of #3372)
-
-> **Stop-gap reminder — daemon "preserved" claim is currently aspirational (epic #3449, stop-gap #3451)**
->
-> The references to `./.loom/scripts/daemon.sh` below describe the intended v0.10.0 target state. As of v0.9.1, that file does **not** exist on `origin/main` (deleted in #3432, rebuild in flight under epic #3449, ~4-6 weeks). Until that lands, downstream consumers should treat the "daemon.sh preserved" prose as forward-looking and use `./.loom/scripts/spawn-loop.sh` (headless) or GitHub Actions cron workflows.
-
-If you installed Loom via `scripts/install-loom.sh` (or `install.sh`), the shepherd brain (`loom-tools/src/loom_tools/shepherd/`), the Python daemon brain (`loom-tools/src/loom_tools/daemon_v2/`), and the `/shepherd` slash command are scheduled for **deletion in v0.10.0** (Phase 3 of epic #3372, tracked as part of #3382). **The user-facing daemon mode surface — `./.loom/scripts/daemon.sh` + tmux + token rotation — is preserved**, just re-implemented around the spawn loop. This section is the migration guide for downstream consumers; it complements the upstream phase table in the section above.
-
-### What you can still rely on (post-v0.10.0)
+### What you can still rely on (v0.10.0)
 
 These surfaces are **not** going away and are the supported replacements:
 
@@ -1552,8 +1532,8 @@ These surfaces are **not** going away and are the supported replacements:
 |------------|-------------|-------|
 | Single-issue lifecycle (curator → builder → judge → doctor → merge) | `/loom:sweep <issue>` | `.claude/commands/loom/sweep.md` |
 | PR-side back half (judge / doctor → judge / merge for an existing open PR set) | `/loom:sweep --prs <pr-number-list>` (Mode C, #3384) | `.claude/commands/loom/sweep.md` |
-| **Daemon-managed tmux session with per-pane token rotation** | `./.loom/scripts/daemon.sh start` | **Preserved**, re-implemented around spawn loop |
-| Multi-issue / multi-account batch orchestration (headless) | `LOOM_USE_SPAWN_LOOP=1 ./.loom/scripts/spawn-loop.sh` | Phase 1, #3374 |
+| **Multi-account dispatch with monitoring and pub/sub** | `mcp__loom__dispatch_sweep`, `mcp__loom__list_sweeps`, `mcp__loom__get_sweep_status`, `mcp__loom__subscribe_to_events`, `mcp__loom__cancel_sweep`, `mcp__loom__tail_sweep_log`, `mcp__loom__publish_event`, `mcp__loom__tail_event_bus` | `loom-daemon` (Rust binary) + `mcp-loom` MCP server |
+| `/loom:sweep` backend detection | Stage -1 strict-AND probe (daemon reachable AND multi-account pool present) | `.claude/commands/loom/sweep.md` Stage -1 |
 | Periodic support roles (Champion, Curator, Judge, Auditor, Guide) | GitHub Actions cron workflows | `.github/workflows/loom-*.yml`, Phase 2a, #3375 |
 | Per-task multi-account token rotation | `./.loom/scripts/spawn-claude.sh` + `.loom/tokens/` | Unchanged |
 | Label-based coordination (`loom:issue` → `loom:building` → `loom:pr` → merged) | Unchanged | `.github/labels.yml` |
@@ -1562,47 +1542,27 @@ These surfaces are **not** going away and are the supported replacements:
 
 ### What is being deprecated (and what to do)
 
-| Deprecated surface | Soft-deprecated since | What to do |
-|--------------------|----------------------|------------|
-| `loom-daemon` Python CLI | Phase 2b (#3376) | Replace direct calls with `./.loom/scripts/daemon.sh start` (preserved, re-implemented) for the tmux multi-account surface, or `./.loom/scripts/spawn-loop.sh` for the headless minimal surface. |
-| `loom-shepherd` Python CLI | Phase 2b (#3376) | Replace shell invocations with `claude -p "/loom:sweep <N>" --dangerously-skip-permissions`. The lifecycle phases are identical; checkpointing (#3373) is preserved. |
-| `/shepherd` slash command | Phase 2b (#3376) | Use `/loom:sweep <issue>` instead. Both run Curator → Builder → Judge → Doctor → Merge; the sweep skill is the maintained path. |
-| `loom-shepherd` subagent (`.claude/agents/loom-shepherd.md`) | Phase 4 (this section, #3382) | Stop dispatching to it from custom slash commands or hooks. The agent file will be removed in v0.10.0 along with the role definition it points at (`.loom/roles/shepherd.md`). The `loom-daemon` subagent is preserved and now documents the shell-level daemon surface. |
-| `.loom/daemon-state.json` and `.loom/progress/shepherd-*.json` consumers | Will be silent after v0.10.0 | The producers are being deleted (the Python brain wrote them). The per-consumer disposition table lives in `docs/migration/daemon-state-consumers.md` (PR #3389) — read it before writing new code that depends on either file. Most operator CLIs are slated to port to `.loom/spawn-loop-state.json` + forge queries; a few retire entirely. |
+| Deprecated surface | Status | What to do |
+|--------------------|--------|------------|
+| `defaults/scripts/spawn-loop.sh` | Deprecated in v0.10.x (Phase E of #3449), deletion in v0.11.0 | Migrate to `mcp__loom__dispatch_sweep` against `loom-daemon`. The script still works through v0.10.x but emits a stderr warning on every `start` / `status` / `stop` invocation. Suppress with `LOOM_SUPPRESS_DEPRECATION=1` if you need the noise gone during migration. |
+| `loom-shepherd` Python CLI (already removed in v0.10.0) | Removed | Replace shell invocations with `claude -p "/loom:sweep <N>" --dangerously-skip-permissions`. The lifecycle phases are identical; checkpointing (#3373) is preserved. |
+| `/shepherd` slash command (already removed in v0.10.0) | Removed | Use `/loom:sweep <issue>` instead. |
+| `loom-shepherd` subagent (already removed in v0.10.0) | Removed | Stop dispatching to it from custom slash commands or hooks. |
+| `.loom/daemon-state.json` and `.loom/progress/shepherd-*.json` consumers | Producers removed | Replace reads with `mcp__loom__list_sweeps` / `mcp__loom__get_sweep_status` against the daemon, plus forge queries. See `docs/migration/daemon-state-consumers.md` for the per-consumer disposition. |
 
-### Three migration paths for downstream consumers
+**Suppression**: set `LOOM_SUPPRESS_DEPRECATION=1` to silence the deprecation warnings emitted from the deprecated shell entry points. Sphere installs and other downstream automation mid-migration can use this env var to keep their logs clean during the v0.10.x → v0.11.0 window.
 
-You have three valid choices for handling v0.10.0. None of them require you to migrate before Phase 3 ships — they just determine what happens on your next `install-loom.sh` run.
+**Helpers**: the warning text is centralized in two places so removal in v0.11.0 is a single-PR sweep:
 
-**(a) Migrate now (recommended for active deployments).** Switch to `/loom:sweep` + spawn loop + GitHub Actions workflows on your main branch before Phase 3 ships. If you had `./.loom/scripts/daemon.sh start` in your automation, no operator-side change is needed — the API is preserved; only the internals change. Your `install-loom.sh` run after Phase 3 lands will cleanly install the new defaults with no manual cleanup.
-
-**(b) Defer migration (acceptable for downstream timelines).** Coordinate with the Loom maintainer to time Phase 3's merge with a migration window that suits your release schedule. The mechanic is a comment thread on #3382. Soft-deprecation warnings (Phase 2b) will continue rendering in your logs during the deferral; use `LOOM_SUPPRESS_DEPRECATION=1` to silence the Python/shell variants if needed (the `/shepherd` markdown skill warning always renders).
-
-**(c) Pin to a pre-Phase-3 Loom version (acceptable, but opts you out of upgrades).** Stop running `install-loom.sh` against your repo, or pin `loom` to a specific tag in your install scripts. This is a valid operator choice — it simply means you stop receiving Loom upgrades until you choose to migrate. The installer is idempotent and will not overwrite your pinned files on a no-op invocation, but rerunning it after pinning intentionally to a new Loom version will replace them.
-
-### Why this matters for the installed `defaults/` tree
-
-When Phase 3 ships in v0.10.0, the next time you run `scripts/install-loom.sh` (or `install.sh`) against your repo, these files will **disappear from `defaults/`** and therefore from your repo's `.claude/agents/` and `.claude/commands/loom/`:
-
-- `defaults/.claude/agents/loom-shepherd.md`
-- `defaults/.claude/commands/loom/shepherd.md`
-- `defaults/.claude/commands/loom/shepherd-lifecycle.md`
-- `defaults/roles/shepherd.md`
-
-These are **preserved**:
-
-- `defaults/.claude/agents/loom-daemon.md` (retitled to document the shell-level daemon surface)
-- `defaults/roles/loom.md` (likewise)
-- `./.loom/scripts/daemon.sh` (re-implemented around spawn loop + tmux + token rotation)
-
-If you have custom slash commands, hooks, or scripts that reference any of the **deleted** paths, the next install will quietly stop installing them. The deprecation banners on the template files (added in Phase 4, this issue) exist so you see the warning on your **very next** install — well before Phase 3 actually removes them.
+- Shell: `defaults/scripts/spawn-loop.sh::_deprecation_warn()` — fires on every `start` / `status` / `stop` subcommand.
 
 ### Coordination and questions
 
-- **Upstream tracker**: #3382 ("Phase 4: sphere downstream coordination tracker"). Open a comment there if you need to coordinate timing, request a deferral window, or report a missing migration path.
-- **Consumer inventory + disposition table**: `docs/migration/daemon-state-consumers.md` (PR #3389) — read this if you have code that imports from `loom_tools.daemon_v2` or `loom_tools.shepherd`, or reads `.loom/daemon-state.json` or `.loom/progress/`.
-- **Migration guide**: `docs/migration/v0.10.0-shepherd-deprecation.md`.
-- **Phase 2d follow-up**: Architect/Hermit work-generation cadence after the Python brain is removed — tracked in #3381.
+- **Daemon-rebuild epic**: #3449 (Phases A–E shipped; Phase F is the dedicated daemon-rebuild migration guide).
+- **Original shepherd-deprecation epic**: #3372.
+- **Consumer inventory + disposition table**: `docs/migration/daemon-state-consumers.md` — read this if you have code that imports from `loom_tools.daemon_v2` or `loom_tools.shepherd`, or reads `.loom/daemon-state.json` or `.loom/progress/`.
+- **Full migration guide**: [`docs/migration/v0.10.0-shepherd-deprecation.md`](../docs/migration/v0.10.0-shepherd-deprecation.md).
+- **Architect/Hermit cadence (work generation)** after the Python brain is removed — tracked in #3381.
 
 ## Resources
 

--- a/defaults/scripts/spawn-loop.sh
+++ b/defaults/scripts/spawn-loop.sh
@@ -83,6 +83,61 @@
 
 set -euo pipefail
 
+# ─── Deprecation warning (Phase E of #3449, deletion deferred to v0.11.0) ────
+#
+# `spawn-loop.sh` is the historical multi-account dispatcher (Phase 1 of the
+# shepherd/daemon deprecation epic #3372). It has been superseded by the Rust
+# `loom-daemon` binary, which now provides the load-bearing multi-account
+# dispatch surface via MCP tools (Phases A–D of epic #3449, all shipped on
+# main):
+#
+#   - `mcp__loom__dispatch_sweep`   (Phase A) — dispatch a sweep for an issue
+#   - `mcp__loom__list_sweeps`      (Phase A) — observe running sweeps
+#   - `mcp__loom__subscribe_to_events`, `mcp__loom__publish_event`,
+#     `mcp__loom__get_sweep_status`, `mcp__loom__tail_sweep_log`,
+#     `mcp__loom__cancel_sweep`, `mcp__loom__tail_event_bus`
+#                                   (Phases B / C)
+#   - `/loom:sweep` Stage -1 backend detection auto-routes to the daemon when
+#     it is reachable AND a multi-account token pool exists (Phase D).
+#
+# This script is retained through v0.10.x for downstream forks mid-migration
+# (per curator risk note C on #3456). It will be DELETED in v0.11.0. The
+# warning fires on every `start` / `status` / `stop` invocation; the script
+# still works as before.
+#
+# Migration hint (one-liner): use `mcp__loom__dispatch_sweep` from a Claude
+# Code session to enqueue work against the running `loom-daemon`. See
+# `docs/migration/v0.10.0-shepherd-deprecation.md` for the full guide; the
+# dedicated daemon-rebuild migration guide is filed under Phase F of #3449.
+#
+# Suppression: set `LOOM_SUPPRESS_DEPRECATION=1` to silence this warning if
+# you are intentionally keeping `spawn-loop.sh` in your automation during the
+# v0.10.x → v0.11.0 window.
+_deprecation_warn() {
+    if [[ "${LOOM_SUPPRESS_DEPRECATION:-}" == "1" ]]; then
+        return 0
+    fi
+    cat >&2 <<'WARN'
+─────────────────────────────────────────────────────────────────────────────
+DEPRECATION WARNING (#3449 Phase E): defaults/scripts/spawn-loop.sh
+
+This script is deprecated and scheduled for DELETION in v0.11.0. The
+multi-account dispatch surface has moved to the Rust `loom-daemon` binary
+and its MCP tools.
+
+  Migration: use `mcp__loom__dispatch_sweep` from a Claude Code session, or
+             let `/loom:sweep <issue>` auto-detect the daemon (Stage -1
+             backend probe — see defaults/.claude/commands/loom/sweep.md).
+
+  See docs/migration/v0.10.0-shepherd-deprecation.md for the full migration
+  guide. A dedicated daemon-rebuild migration guide will land under Phase F
+  of epic #3449.
+
+  Silence this warning by exporting LOOM_SUPPRESS_DEPRECATION=1.
+─────────────────────────────────────────────────────────────────────────────
+WARN
+}
+
 # ─── Path resolution ────────────────────────────────────────────────────────
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Resolve repo root via git common-dir to handle invocation from worktrees.
@@ -529,6 +584,7 @@ run_loop() {
 
 # ─── Commands ───────────────────────────────────────────────────────────────
 cmd_start() {
+    _deprecation_warn
     if [[ "${LOOM_USE_SPAWN_LOOP:-}" != "1" ]]; then
         cat >&2 <<EOF
 spawn-loop is opt-in. Set LOOM_USE_SPAWN_LOOP=1 to start:
@@ -561,6 +617,7 @@ EOF
 }
 
 cmd_stop() {
+    _deprecation_warn
     if [[ ! -f "$PIDFILE" ]]; then
         echo "spawn-loop not running"
         return 0
@@ -588,6 +645,7 @@ cmd_stop() {
 }
 
 cmd_status() {
+    _deprecation_warn
     if [[ ! -f "$PIDFILE" ]]; then
         echo "spawn-loop: not running"
         return 1

--- a/defaults/scripts/tests/test-spawn-loop.sh
+++ b/defaults/scripts/tests/test-spawn-loop.sh
@@ -275,6 +275,49 @@ assert_contains "LOOM_USE_SPAWN_LOOP" "$help_output" "usage documents opt-in env
 assert_contains "MAX_PARALLEL" "$help_output" "usage documents MAX_PARALLEL override"
 assert_contains "POLL_INTERVAL" "$help_output" "usage documents POLL_INTERVAL override"
 
+# ─── Section 9: deprecation warning (Phase E of #3449) ──────────────────────
+echo ""
+echo "Testing deprecation warning fires on subcommand invocations..."
+
+# Stop the spawn-loop running in our hermetic temp dir before checking warnings
+# (status uses cmd_status which calls _deprecation_warn before the not-running
+# check). The script exits with 1 from cmd_status when not running, so we
+# tolerate that and just inspect stderr.
+set +e
+status_stderr="$( "$SPAWN_LOOP" status 2>&1 1>/dev/null )"
+set -e
+assert_contains "DEPRECATION WARNING" "$status_stderr" "status emits deprecation banner on stderr"
+assert_contains "#3449" "$status_stderr" "deprecation warning references epic #3449"
+assert_contains "v0.11.0" "$status_stderr" "deprecation warning names v0.11.0 removal target"
+assert_contains "mcp__loom__dispatch_sweep" "$status_stderr" "deprecation warning includes Phase A migration hint"
+
+# Stop also fires the warning.
+set +e
+stop_stderr="$( "$SPAWN_LOOP" stop 2>&1 1>/dev/null )"
+set -e
+assert_contains "DEPRECATION WARNING" "$stop_stderr" "stop emits deprecation banner on stderr"
+
+# Start fires the warning too (even when blocked by the opt-in gate).
+set +e
+start_stderr="$( "$SPAWN_LOOP" start 2>&1 1>/dev/null )"
+set -e
+assert_contains "DEPRECATION WARNING" "$start_stderr" "start emits deprecation banner on stderr"
+
+# LOOM_SUPPRESS_DEPRECATION=1 silences it.
+set +e
+suppressed_stderr="$( LOOM_SUPPRESS_DEPRECATION=1 "$SPAWN_LOOP" status 2>&1 1>/dev/null )"
+set -e
+if [[ "$suppressed_stderr" == *"DEPRECATION WARNING"* ]]; then
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: LOOM_SUPPRESS_DEPRECATION=1 silences the warning"
+    echo "    Got stderr: '$suppressed_stderr'"
+else
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: LOOM_SUPPRESS_DEPRECATION=1 silences the warning"
+fi
+
 # ─── Summary ────────────────────────────────────────────────────────────────
 echo ""
 echo "─────────────────────────────────────────"

--- a/docs/migration/v0.10.0-shepherd-deprecation.md
+++ b/docs/migration/v0.10.0-shepherd-deprecation.md
@@ -1,10 +1,16 @@
 # v0.10.0 Migration Guide — shepherd deprecation
 
-> **⚠️ Stop-gap notice — daemon "preserved" claim is currently aspirational (epic #3449, stop-gap #3451)**
+> **Reconciliation notice — daemon "preserved" claim updated post-Phase E (epic #3449)**
 >
-> Throughout this guide, the prose says daemon mode is "preserved" via `./.loom/scripts/daemon.sh`, re-implemented around the spawn loop + tmux. **As of v0.9.1, `./.loom/scripts/daemon.sh` does not exist on `origin/main`** — the dispatcher was deleted in #3432 and is being rebuilt in epic #3449 (~4-6 weeks, scheduled for v0.10.0). The shepherd brain and the Python daemon brain deletions described below are real and shipped; the daemon-shell rebuild is in flight.
+> The original v0.10.0 narrative said daemon mode is "preserved" via a re-implemented `./.loom/scripts/daemon.sh` tmux launcher. **That tmux shell wrapper was never rebuilt.** Instead, epic #3449 preserved daemon mode at the **MCP-tool level**: the Rust `loom-daemon` binary now exposes `mcp__loom__dispatch_sweep` and the surrounding monitoring + pub/sub surface, which any Claude Code session can drive via MCP. The user-facing API the original narrative promised (`daemon.sh start|stop|status`) has been replaced by a different, also-preserved, also-supported user-facing API:
 >
-> Until #3449 ships, every operator invocation of `./.loom/scripts/daemon.sh {start,stop,status}` referenced in this guide will fail with "no such file or directory". Use `./.loom/scripts/spawn-loop.sh` (headless, multi-issue) or the GitHub Actions cron workflows in the interim. The full doc rewrite is Phase E of #3449; this stop-gap (#3451) inserts only this warning.
+> - `mcp__loom__dispatch_sweep` (Phase A, #3452) — enqueue a sweep
+> - `mcp__loom__list_sweeps` / `get_sweep_status` (Phases A / C) — observe registry
+> - `mcp__loom__subscribe_to_events` / `tail_event_bus` / `publish_event` (Phases B / C) — pub/sub bus with 6 frozen topics
+> - `mcp__loom__cancel_sweep` / `tail_sweep_log` (Phase C) — control + inspect
+> - `/loom:sweep` Stage -1 strict-AND backend detection (Phase D, #3454) — daemon reachable AND multi-account pool present → delegate dispatch, otherwise fall through to in-process subagent dispatch
+>
+> The v0.9.x spawn loop (`./.loom/scripts/spawn-loop.sh`) was the interim implementation while the Rust daemon was rebuilt. It is **deprecated as of Phase E of #3449** and emits a stderr warning on every invocation. Deletion is deferred to v0.11.0. Use `mcp__loom__dispatch_sweep` against `loom-daemon` for new automation. The sections below describe the v0.10.0 architecture as it actually shipped; references to "`daemon.sh`" should be read as "the MCP-tool surface that replaces `daemon.sh`".
 
 > **Audience**: anyone with an installed copy of Loom (via `install.sh` /
 > `scripts/install-loom.sh`) who has been running the Python `loom-shepherd`
@@ -200,29 +206,56 @@ These look related to the shepherd/daemon removal but are intentionally
 preserved. They are the load-bearing pieces of the v0.10.0 architecture.
 Do not delete them manually.
 
-### Daemon-mode shell surface
+### Daemon-mode MCP surface (preserved, what actually shipped)
 
-- **`./.loom/scripts/daemon.sh`** — the tmux session launcher.
-  `daemon.sh start` opens a tmux session, `daemon.sh stop` tears it down,
-  `daemon.sh status` reports running panes. The same operator API
-  pre-v0.10.0 had. The internals are re-implemented: instead of starting
-  the Python `loom-daemon` brain in a tmux pane, `daemon.sh` now drives
-  the spawn loop and (optionally) per-role `claude -p "/loom:<role>"`
-  panes that each get their own rotated OAuth token. This is the
-  "daemon-managed tmux sessions that launch loom agents as separate
-  Claude Code sessions" execution surface.
+- **`loom-daemon`** — the Rust binary. A single long-lived process exposing
+  Unix-socket IPC and a paired `mcp-loom` MCP server. Manages the in-memory
+  sweep registry, the tokio-broadcast event bus, and a 30-second reaper
+  task. **This is the v0.10.0 daemon.** The "preserved daemon mode"
+  promise the original v0.10.0 narrative made is fulfilled here: not as a
+  shell `daemon.sh` wrapper, but as MCP-tool dispatch surface that any
+  Claude Code session can drive.
+- **`mcp__loom__dispatch_sweep`** (Phase A, #3452) — enqueue a sweep for
+  an issue. Token rotation happens at this process-spawn boundary via
+  `spawn-claude.sh`.
+- **`mcp__loom__list_sweeps`** (Phase A) and
+  **`mcp__loom__get_sweep_status`** (Phase C, #3455) — observe the
+  in-memory registry.
+- **`mcp__loom__subscribe_to_events`** (Phase B, #3453),
+  **`mcp__loom__publish_event`** (Phase B),
+  **`mcp__loom__tail_event_bus`** (Phase C) — the pub/sub bus on six
+  frozen topics (`sweep.issue.{N}.{phase,blocker,exited,crashed}`,
+  `sweep.global.{dispatch,completed}`). New topics require a follow-up
+  issue.
+- **`mcp__loom__cancel_sweep`** (Phase C) and
+  **`mcp__loom__tail_sweep_log`** (Phase C) — control and inspect.
+- **`/loom:sweep` Stage -1 backend detection** (Phase D, #3454) — strict-AND
+  probe of daemon reachable AND multi-account pool present. Either
+  missing → fall through to in-process subagent dispatch (no behaviour
+  change for solo-token operators).
 - **`./.loom/scripts/spawn-claude.sh`** — the per-spawn token-rotation
   wrapper. Selects a token from the pool, exports
   `CLAUDE_CODE_OAUTH_TOKEN`, then `exec`s `claude`. Every separate Claude
-  Code session launched by `daemon.sh` or `spawn-loop.sh` goes through
-  this wrapper.
-- **`./.loom/scripts/spawn-loop.sh`** — the minimal multi-account spawn
-  loop. Used directly by operators for batch sweeps, and called from
-  inside `daemon.sh` for the issue-work pane.
+  Code session launched by `loom-daemon` (via `dispatch_sweep`) goes
+  through this wrapper.
 - `.loom/tokens/` and everything under it — the token pool, ranking,
   allowlist, bad-tokens log. The whole `loom-tokens bootstrap / check /
   pin / unpin / unblock` operator surface stays. This is the foundation
   of multi-account rotation.
+
+### Deprecated (still functional in v0.10.x, removed in v0.11.0)
+
+- **`./.loom/scripts/spawn-loop.sh`** — the v0.9.x interim multi-account
+  spawn loop (#3374). Phase E of #3449 (this work) deprecates it:
+  - Every `start` / `status` / `stop` invocation emits a stderr warning
+    referencing #3449 and the v0.11.0 removal target.
+  - The migration hint is `mcp__loom__dispatch_sweep`.
+  - Suppress with `LOOM_SUPPRESS_DEPRECATION=1` if you need clean logs
+    during migration.
+  - The script remains functional through the v0.10.x cycle so downstream
+    forks (sphere etc.) have one minor release of runway per curator
+    risk note C on #3456.
+  - **DELETION**: v0.11.0.
 
 ### Daemon-mode subagent surface
 
@@ -255,83 +288,136 @@ Do not delete them manually.
 
 ## How daemon mode works in v0.10.0
 
-`./.loom/scripts/daemon.sh start` opens a tmux session named `loom`
-containing one or more panes, each running a fresh Claude Code session
-launched via `spawn-claude.sh` (so each gets its own rotated OAuth token).
-The typical layout:
+The Rust `loom-daemon` binary runs as a long-lived background process,
+managed by the operator's service manager of choice (systemd, launchd,
+foreman, or a background shell). It does not poll the forge for ready
+issues — operators (or `/loom:sweep` Stage -1 delegation) dispatch sweeps
+explicitly via MCP.
 
-- **Issue pane**: runs the spawn loop
-  (`LOOM_USE_SPAWN_LOOP=1 ./.loom/scripts/spawn-loop.sh start` inline, or
-  re-spawned in its own pane). The spawn loop polls `loom:issue`, claims
-  ready issues atomically via `.loom/locks/issue-<N>/`, and detaches
-  `claude -p "/loom:sweep N"` children — each child is itself a fresh
-  Claude Code session with its own rotated OAuth token.
-- **Support-role panes** (optional): one pane per always-on role
-  (Champion, Doctor, Auditor) running `claude -p "/loom:<role>"` on a
-  loop. Token rotation applies because each iteration is a fresh process.
-  This is operator preference — the GitHub Actions cron workflows are the
-  recommended alternative for periodic support roles. The tmux-pane
-  approach makes sense when you want the role to run continuously on your
-  own machine with multi-account rotation; the cron approach makes sense
-  when you want it to run server-side on a single CI token.
+**Process model:**
 
-`./.loom/scripts/daemon.sh stop` (or `touch .loom/stop-daemon`) terminates
-all panes gracefully; the spawn loop honors `SHUTDOWN_GRACE_SEC` for
-in-flight sweep children.
+```
+init/launchd → loom-daemon  ──MCP──→  Claude Code session
+                  │                    (using /loom or /loom:sweep)
+                  ├── SweepRegistry (in-memory BTreeMap)
+                  ├── EventBus (tokio broadcast, 6 frozen topics)
+                  └── ReaperTask (30s tick — emits .exited / .crashed)
+                  │
+                  ▼
+        On dispatch_sweep:
+        fork+exec /loom:sweep N via spawn-claude.sh
+        (token rotation at this process-spawn boundary)
+```
+
+**Dispatch flow:**
+
+1. Operator (or `/loom:sweep` Stage -1) calls `mcp__loom__dispatch_sweep --issue N`.
+2. The daemon picks a token from `.loom/tokens/.ranking` (or allowlist, or random) and fork+execs `claude -p "/loom:sweep N"` via `spawn-claude.sh`.
+3. The child PID is registered in the in-memory `SweepRegistry`; a `sweep.global.dispatch` event is emitted.
+4. The sweep child runs the lifecycle (Curator → Builder → Judge → Doctor → Merge), publishing `sweep.issue.{N}.phase` events as it advances.
+5. On clean exit, the reaper (or the child itself) emits `sweep.issue.{N}.exited`; on non-zero exit, `sweep.issue.{N}.crashed`.
+6. Operator (or any MCP client) can observe via `list_sweeps`, `get_sweep_status`, `subscribe_to_events`, `tail_sweep_log`, `tail_event_bus`.
+
+**Support roles** (Champion, Curator, Judge, Auditor, Guide) run on cron via GitHub Actions workflows under `.github/workflows/loom-*.yml`. They are **not** dispatched by the daemon — the daemon is purely a sweep-dispatch + monitoring surface.
 
 **Architectural framing**:
 
 | Surface | Process model | Token model | Best for |
 |---------|---------------|-------------|----------|
-| Subagent dispatch (`/loom:sweep` in one session) | Single process, multiple subagents | Single OAuth token (parent's) | Operator-driven batches, ≤ hours of runtime |
-| Tmux-launched separate sessions (`daemon.sh`) | Multiple processes (one per pane + one per sweep child) | Rotated per process via `spawn-claude.sh` | Multi-day autonomous operation, multi-account rotation |
+| Subagent dispatch (`/loom:sweep` in one session) | Single process, multiple subagents | Single OAuth token (parent's) | Operator-driven batches, ≤ hours of runtime, single-account operators |
+| Daemon dispatch (`mcp__loom__dispatch_sweep` against `loom-daemon`) | Multiple processes (one per sweep child) | Rotated per process via `spawn-claude.sh` | Multi-day autonomous operation, multi-account rotation |
 
 Both surfaces are first-class. Choose by runtime expectations:
-- For an operator running a few-hour batch from their workstation:
-  `/loom:sweep` is faster, simpler, no tmux setup needed.
-- For a multi-day autonomous run rotating across multiple Claude Pro/Max
-  accounts: `daemon.sh start` is the answer.
+- For an operator running a few-hour batch from their workstation with a single Claude account: `/loom:sweep` is faster, simpler, no daemon setup needed.
+- For a multi-day autonomous run rotating across multiple Claude Pro/Max accounts: `mcp__loom__dispatch_sweep` against `loom-daemon` is the answer. `/loom:sweep` Stage -1 will auto-detect the daemon + pool and delegate dispatch transparently.
 
 The architectural reason both exist: Claude Code subagents inherit the
 parent's `CLAUDE_CODE_OAUTH_TOKEN`, so multi-account rotation only happens
 at process-spawn boundaries. The subagent surface optimizes for fast
-iteration within one token's budget; the tmux surface optimizes for
+iteration within one token's budget; the daemon surface optimizes for
 spreading load across many tokens over long time horizons.
 
 ## How to enable the replacements
 
-### Spawn-loop mode (an alternative to `./.loom/scripts/daemon.sh start`)
+### Daemon mode (multi-account autonomous dispatch)
 
-The spawn loop is the **headless** multi-account orchestrator. It runs in
-the foreground or detached, without tmux. Use it when you want a minimal
-multi-issue batch driver and don't need the daemon's multi-pane surface.
-
-The spawn loop is **opt-in via env var** to protect existing daemon users
-from accidental dual-orchestration:
+The Rust `loom-daemon` binary is the supported multi-account orchestrator
+for v0.10.0+. Start it from a terminal outside Claude Code via your
+service manager of choice (systemd unit, launchd plist, foreman, or just
+a background shell):
 
 ```bash
-# One-time opt-in gate (required in 0.9.x; remains required in v0.10.0)
-export LOOM_USE_SPAWN_LOOP=1
-
-# Start the loop. It detaches as a background process.
-./.loom/scripts/spawn-loop.sh start
-
-# Status / stop
-./.loom/scripts/spawn-loop.sh status
-./.loom/scripts/spawn-loop.sh stop      # or: touch .loom/stop-spawn-loop
+# In a background shell, or under your service manager:
+loom-daemon
 ```
 
-If you want the daemon's tmux-session surface (visibility into separate
-panes, manual intervention possible, support roles co-located), keep
-calling `./.loom/scripts/daemon.sh start` — it now drives the spawn loop
-internally. See [How daemon mode works in v0.10.0](#how-daemon-mode-works-in-v0100).
+The daemon binds a Unix socket and serves IPC over it until stopped.
 
-State is written to `.loom/spawn-loop-state.json`. Logs go to
-`.loom/logs/spawn-loop.log` (loop-level) and
-`.loom/logs/sweep-issue-<N>.log` (per-child). Atomic claim locks live under
-`.loom/locks/issue-<N>/`.
+From a Claude Code session, drive it via MCP tools:
 
-Tunables (env):
+```
+# Dispatch a sweep for one issue
+mcp__loom__dispatch_sweep --issue 123
+
+# List currently-dispatched sweeps
+mcp__loom__list_sweeps
+
+# Inspect a single sweep
+mcp__loom__get_sweep_status --sweep_id <id>
+
+# Subscribe to lifecycle events
+mcp__loom__subscribe_to_events --topic "sweep.issue.*"
+
+# Cancel a stuck sweep
+mcp__loom__cancel_sweep --sweep_id <id>
+
+# Tail a sweep's log
+mcp__loom__tail_sweep_log --issue 123 --lines 200
+```
+
+The `/loom` skill (`defaults/.claude/commands/loom/loom.md`) wraps these
+into an observer/dispatcher loop that polls the forge, dispatches ready
+issues, and surfaces blockers + crashes to the operator.
+
+The daemon **does not** generate work (no Architect / Hermit triggers),
+**does not** maintain a `shepherd-N` pool, and **does not** drive support
+roles. Each `mcp__loom__dispatch_sweep` request runs its own self-contained
+`claude -p "/loom:sweep N"` child with its own rotated OAuth token. If you
+need work generation, see the Phase 2d follow-up (#3381). Periodic support
+roles run via the GitHub Actions cron workflows under
+`.github/workflows/loom-*.yml`.
+
+For the full wire protocol, IPC request/response variants, registry and
+reaper semantics, and event taxonomy, see [`.loom/docs/daemon-reference.md`](../../.loom/docs/daemon-reference.md).
+
+### Spawn-loop mode (deprecated — removed in v0.11.0)
+
+The v0.9.x interim `defaults/scripts/spawn-loop.sh` is deprecated as of
+Phase E of #3449. It is still functional through v0.10.x for downstream
+forks mid-migration, but emits a stderr warning on every invocation and
+will be **deleted in v0.11.0**.
+
+```bash
+# Still works through v0.10.x; emits deprecation warning on each call
+LOOM_USE_SPAWN_LOOP=1 ./.loom/scripts/spawn-loop.sh start
+
+./.loom/scripts/spawn-loop.sh status
+./.loom/scripts/spawn-loop.sh stop      # or: touch .loom/stop-spawn-loop
+
+# Silence the warning during migration
+export LOOM_SUPPRESS_DEPRECATION=1
+```
+
+**Migrate to `mcp__loom__dispatch_sweep` against `loom-daemon`** before
+v0.11.0 ships.
+
+State is still written to `.loom/spawn-loop-state.json` during the v0.10.x
+deprecation window. Logs go to `.loom/logs/spawn-loop.log` (loop-level)
+and `.loom/logs/sweep-issue-<N>.log` (per-child). The daemon does **not**
+consume these files; if you need to observe running sweeps from outside
+the spawn loop, call `mcp__loom__list_sweeps` against the daemon instead.
+
+Tunables (env) — unchanged during the deprecation window:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -339,12 +425,7 @@ Tunables (env):
 | `POLL_INTERVAL` | 30 | Seconds between `loom:issue` polls |
 | `SHUTDOWN_GRACE_SEC` | 300 | Seconds to wait for in-flight children at shutdown |
 | `LOOM_REPO` | (auto) | Override remote auto-detection (`owner/repo`) |
-
-The spawn loop **does not** generate work (no Architect / Hermit triggers),
-**does not** maintain a `shepherd-N` pool, and **does not** drive support
-roles. Each ready issue runs its own self-contained `claude -p
-"/loom:sweep N"` child. If you need work generation, see the Phase 2d
-follow-up (#3381).
+| `LOOM_SUPPRESS_DEPRECATION` | (unset) | Set to `1` to silence the Phase E deprecation warning |
 
 ### Scheduled support roles (replaces always-running Champion / Curator / Judge / Auditor / Guide)
 

--- a/loom-daemon/tests/spawn_loop_deprecation_doc_lint.rs
+++ b/loom-daemon/tests/spawn_loop_deprecation_doc_lint.rs
@@ -1,0 +1,185 @@
+//! Doc-lint test for Phase E of epic #3449 (issue #3456).
+//!
+//! Phase E deprecates `defaults/scripts/spawn-loop.sh` and rewrites the
+//! operator-facing documentation to describe the actual Phase A-D
+//! `loom-daemon` MCP surface instead of the v0.9.x stop-gap warnings.
+//!
+//! This test grep-checks the operator-facing markdown files at compile
+//! time so that:
+//!
+//! - The legacy strings `LOOM_USE_SPAWN_LOOP` and `spawn-loop.sh start`
+//!   do not appear in operator-facing docs outside the migration guide.
+//! - The deprecation warning string is present in `spawn-loop.sh`.
+//! - The migration narrative actually mentions the Phase A-D MCP surface
+//!   (`mcp__loom__dispatch_sweep`, `mcp__loom__list_sweeps`).
+//!
+//! The migration guide (`docs/migration/v0.10.0-shepherd-deprecation.md`)
+//! is **exempt** from the legacy-string ban — it is the historical
+//! record and must be allowed to discuss the deprecated surface during
+//! the v0.10.x window.
+//!
+//! Companion tests:
+//! - `sweep_md_doc_lint.rs` (Phase B, #3453)
+//! - `sweep_md_stage_minus_one_doc_lint.rs` (Phase D, #3454)
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::fs;
+use std::path::PathBuf;
+
+/// Operator-facing files where the legacy spawn-loop strings must NOT
+/// appear. The migration guide is intentionally absent from this list.
+const BANNED_LEGACY_FILES: &[&str] = &[
+    "../CLAUDE.md",
+    "../defaults/CLAUDE.md",
+    "../defaults/.claude/commands/loom/loom.md",
+    "../defaults/.claude/commands/loom/sweep.md",
+];
+
+/// Strings that must not appear in any of the operator-facing files
+/// above. They MAY appear in the migration guide (out-of-list).
+const BANNED_LEGACY_STRINGS: &[&str] = &["LOOM_USE_SPAWN_LOOP", "spawn-loop.sh start"];
+
+/// Files that MUST contain the deprecation warning machinery.
+const DEPRECATION_WARNING_FILE: &str = "../defaults/scripts/spawn-loop.sh";
+
+/// Strings that must be present in the deprecation warning.
+const REQUIRED_DEPRECATION_STRINGS: &[&str] = &[
+    "_deprecation_warn",
+    "DEPRECATION WARNING",
+    "#3449",
+    "v0.11.0",
+    "mcp__loom__dispatch_sweep",
+    "LOOM_SUPPRESS_DEPRECATION",
+];
+
+/// Migration guide must mention the Phase A-D MCP surface so downstream
+/// readers can find the replacement.
+const MIGRATION_GUIDE_FILE: &str = "../docs/migration/v0.10.0-shepherd-deprecation.md";
+
+const REQUIRED_MIGRATION_STRINGS: &[&str] = &[
+    "mcp__loom__dispatch_sweep",
+    "mcp__loom__list_sweeps",
+    "loom-daemon",
+];
+
+fn read_file(rel_path: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(rel_path);
+    fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!("file not found at {} (CWD-relative path: {}): {e}", path.display(), rel_path,);
+    })
+}
+
+/// AC #3: operator-facing CLAUDE.md must not reference `LOOM_USE_SPAWN_LOOP`
+/// or `spawn-loop.sh start` as the recommended path.
+///
+/// Banned strings may appear in the migration guide — see the per-file
+/// loop below for the explicit allowlist.
+#[test]
+fn operator_docs_do_not_reference_legacy_spawn_loop_strings() {
+    let mut failures: Vec<String> = Vec::new();
+
+    for file in BANNED_LEGACY_FILES {
+        let content = read_file(file);
+        for banned in BANNED_LEGACY_STRINGS {
+            if content.contains(banned) {
+                failures.push(format!(
+                    "  - `{banned}` found in {file}; this string is banned in \
+                     operator-facing docs (allowed only in the migration guide)"
+                ));
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "Phase E of #3449 (issue #3456) requires that operator-facing docs \
+         do not reference the deprecated spawn-loop surface. Move the \
+         offending references to the migration guide \
+         (docs/migration/v0.10.0-shepherd-deprecation.md), or replace them \
+         with `mcp__loom__dispatch_sweep` against `loom-daemon`.\n\nFailures:\n{}",
+        failures.join("\n"),
+    );
+}
+
+/// AC #1 / #2: `defaults/scripts/spawn-loop.sh` must contain the deprecation
+/// warning machinery referencing #3449, v0.11.0, and the
+/// `mcp__loom__dispatch_sweep` migration hint, with `LOOM_SUPPRESS_DEPRECATION`
+/// as the documented suppression env var.
+#[test]
+fn spawn_loop_sh_contains_deprecation_warning_machinery() {
+    let content = read_file(DEPRECATION_WARNING_FILE);
+    let mut missing: Vec<&str> = Vec::new();
+
+    for required in REQUIRED_DEPRECATION_STRINGS {
+        if !content.contains(required) {
+            missing.push(required);
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "defaults/scripts/spawn-loop.sh is missing the following required \
+         deprecation-warning strings (Phase E of #3449):\n  {}\n\n\
+         The warning must reference epic #3449, name the v0.11.0 removal \
+         target, point at `mcp__loom__dispatch_sweep` as the replacement, \
+         and document `LOOM_SUPPRESS_DEPRECATION=1` as the suppression \
+         env var.",
+        missing.join("\n  "),
+    );
+}
+
+/// AC #4: the migration guide must reference the Phase A-D MCP surface
+/// (`mcp__loom__dispatch_sweep`, `mcp__loom__list_sweeps`, `loom-daemon`)
+/// so downstream consumers can find the replacement for the deprecated
+/// spawn loop.
+#[test]
+fn migration_guide_references_phase_a_through_d_surface() {
+    let content = read_file(MIGRATION_GUIDE_FILE);
+    let mut missing: Vec<&str> = Vec::new();
+
+    for required in REQUIRED_MIGRATION_STRINGS {
+        if !content.contains(required) {
+            missing.push(required);
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "docs/migration/v0.10.0-shepherd-deprecation.md is missing the \
+         following required references to the Phase A-D MCP surface:\n  {}\n\n\
+         Phase E of #3449 requires the migration narrative point downstream \
+         readers at the actual replacement (the Rust `loom-daemon` binary \
+         and its MCP-tool surface).",
+        missing.join("\n  "),
+    );
+}
+
+/// Sanity check: the migration guide IS allowed to mention
+/// `LOOM_USE_SPAWN_LOOP` and `spawn-loop.sh start` — verify it actually
+/// does, so the "the migration guide is exempt" carve-out is doing real
+/// work (and someone can't silently drop the legacy references from the
+/// guide without us noticing).
+#[test]
+fn migration_guide_retains_legacy_references_for_continuity() {
+    let content = read_file(MIGRATION_GUIDE_FILE);
+
+    // The migration guide is allowed to reference the deprecated surface;
+    // we expect at least one banned-elsewhere string to appear here so
+    // the carve-out has teeth.
+    let mentions_legacy = BANNED_LEGACY_STRINGS
+        .iter()
+        .any(|banned| content.contains(banned));
+
+    assert!(
+        mentions_legacy,
+        "Expected the migration guide \
+         (docs/migration/v0.10.0-shepherd-deprecation.md) to retain at \
+         least one reference to the deprecated spawn-loop surface \
+         (e.g., `LOOM_USE_SPAWN_LOOP` or `spawn-loop.sh start`) for \
+         historical continuity. If you intentionally removed all such \
+         references, also remove the carve-out from the \
+         `operator_docs_do_not_reference_legacy_spawn_loop_strings` test \
+         above so the doc-lint stays consistent.",
+    );
+}


### PR DESCRIPTION
Closes #3456. Phase E of epic #3449.

## Summary

- **Deprecate `defaults/scripts/spawn-loop.sh`** (per curator risk note C on #3456): adds `_deprecation_warn()` near the top of the script that emits a multi-line stderr banner on every `start` / `status` / `stop` invocation. The banner references epic #3449, names the v0.11.0 removal target, and points operators at `mcp__loom__dispatch_sweep` + `docs/migration/v0.10.0-shepherd-deprecation.md`. Suppressible via `LOOM_SUPPRESS_DEPRECATION=1`. **Deletion is deferred to v0.11.0** so downstream forks (sphere etc.) have one minor release of runway.
- **Rewrite the #3451 stop-gap doc-fiction** in `CLAUDE.md`, `defaults/CLAUDE.md`, and `defaults/.claude/commands/loom/loom.md` (the role file that `defaults/roles/loom.md` symlinks to). The stop-gap warnings said "daemon.sh doesn't exist yet on main"; Phase E supersedes them with accurate descriptions of the Phase A–D `loom-daemon` MCP surface that actually shipped:
  - `mcp__loom__dispatch_sweep` / `list_sweeps` (Phase A, #3452)
  - `mcp__loom__subscribe_to_events` / `publish_event` + 6 frozen topics (Phase B, #3453)
  - `mcp__loom__get_sweep_status` / `tail_sweep_log` / `cancel_sweep` / `tail_event_bus` (Phase C, #3455)
  - `/loom:sweep` Stage -1 strict-AND backend detection (Phase D, #3454)
- **Reconcile `docs/migration/v0.10.0-shepherd-deprecation.md`** to retroactively make its "daemon preserved" claim true. The original narrative promised a tmux `daemon.sh` wrapper; what shipped is the MCP-tool surface. Updated "What is preserved", "How daemon mode works in v0.10.0", and "How to enable the replacements" to reflect the actual Phase A–D architecture; spawn-loop is demoted to a deprecated subsection.
- **Add doc-lint test** `loom-daemon/tests/spawn_loop_deprecation_doc_lint.rs` following the Phase B / Phase D pattern. Four assertions: banned strings absent from operator-facing docs, deprecation warning machinery present in `spawn-loop.sh`, migration guide names the Phase A–D MCP surface, migration guide retains legacy references (carve-out sanity check).

## Acceptance criteria

| AC | Status | Note |
|----|--------|------|
| 1. `spawn-loop.sh` not deleted; gains stderr deprecation warning referencing #3449 and v0.11.0 | pass | `_deprecation_warn()` added; called from `cmd_start`, `cmd_status`, `cmd_stop`. Script remains functional. |
| 2. Warning includes one-line migration hint pointing at `mcp__loom__dispatch_sweep` + v0.10.0 migration guide | pass | "Migration:" line in the banner names `mcp__loom__dispatch_sweep` and links the v0.10.0 migration guide; calls out Phase F as the home for the dedicated daemon-rebuild guide. |
| 3. `CLAUDE.md` and `defaults/CLAUDE.md` no longer reference `LOOM_USE_SPAWN_LOOP` or `spawn-loop.sh start`; grep doc-lint enforces this | pass | Verified by `operator_docs_do_not_reference_legacy_spawn_loop_strings` in the new doc-lint test; migration guide is the documented exception. |
| 4. Migration guide updated to reflect the rebuild | pass | "Daemon-mode MCP surface (preserved, what actually shipped)" section enumerates Phases A–D; "How daemon mode works in v0.10.0" rewritten to describe the actual long-lived Rust daemon + fork+exec dispatch model. |

## Test results

```
bash defaults/scripts/tests/test-spawn-loop.sh    # 34/34 pass (8 new for deprecation)
cargo test -p loom-daemon --test spawn_loop_deprecation_doc_lint    # 4/4 pass
cargo test -p loom-daemon --test sweep_md_doc_lint                  # 4/4 pass (Phase B regression)
cargo test -p loom-daemon --test sweep_md_stage_minus_one_doc_lint  # 9/9 pass (Phase D regression)
cargo test -p loom-daemon --lib                                     # 336/336 pass
shellcheck defaults/scripts/spawn-loop.sh                           # clean
cargo clippy --package loom-daemon --package loom-api -- -D warnings ... # clean
```

## Manual smoke test of the warning

```
$ bash defaults/scripts/spawn-loop.sh status
─────────────────────────────────────────────────────────────────────────────
DEPRECATION WARNING (#3449 Phase E): defaults/scripts/spawn-loop.sh

This script is deprecated and scheduled for DELETION in v0.11.0. The
multi-account dispatch surface has moved to the Rust loom-daemon binary
and its MCP tools.

  Migration: use mcp__loom__dispatch_sweep from a Claude Code session, or
             let /loom:sweep <issue> auto-detect the daemon (Stage -1
             backend probe — see defaults/.claude/commands/loom/sweep.md).

  See docs/migration/v0.10.0-shepherd-deprecation.md for the full migration
  guide. A dedicated daemon-rebuild migration guide will land under Phase F
  of epic #3449.

  Silence this warning by exporting LOOM_SUPPRESS_DEPRECATION=1.
─────────────────────────────────────────────────────────────────────────────
spawn-loop: not running
```

Suppression check:
```
$ LOOM_SUPPRESS_DEPRECATION=1 bash defaults/scripts/spawn-loop.sh status
spawn-loop: not running
```

## Scope decisions

- **`defaults/scripts/start-daemon.sh` and `defaults/scripts/stop-daemon.sh`**: audited but left untouched. Both are thin `exec "$SCRIPT_DIR/daemon.sh" ...` wrappers around a `daemon.sh` that has not existed on main since #3432. They are pre-existing broken stubs; their state is the same after this PR as before it. The issue spec was explicit: "Don't aggressively add new scripts" and "The deliverable is doc rewrites, not a new wrapper." Repairing these stubs is out of scope; it belongs in a follow-up if anyone still calls them in automation. The migration guide already calls out that `daemon.sh` is gone.
- **`defaults/.claude/agents/loom-shepherd.md`**: small touch-up to the deprecated-subagent header. It used to recommend `LOOM_USE_SPAWN_LOOP=1 + spawn-loop.sh` for multi-account batches; that recommendation itself is now deprecated by this PR. Updated to recommend `mcp__loom__dispatch_sweep` against `loom-daemon`. The subagent file is itself scheduled for deletion in a future cycle.

## Test plan

- [x] `test-spawn-loop.sh` covers the warning firing on `start`/`status`/`stop` and `LOOM_SUPPRESS_DEPRECATION=1` silencing it
- [x] `spawn_loop_deprecation_doc_lint.rs` enforces the doc invariants programmatically
- [x] Phase B (#3453) and Phase D (#3454) doc-lints still pass — no regression in those contracts
- [x] `cargo test -p loom-daemon --lib` still passes 336 tests
- [x] `cargo clippy` with CI's `-D warnings` flag is clean
- [x] `shellcheck` clean on `spawn-loop.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)