### PR TITLE
docs: Phase F — v0.10.0 daemon-rebuild migration guide + release prep (#3457)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 This repository uses **Loom** for AI-powered development orchestration.
 
-**Loom Version**: 0.9.1
+**Loom Version**: 0.10.0
 **Installation Date**: 2026-04-21
 
 ## What is Loom?

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,7 +888,7 @@ checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "loom-api"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "loom-daemon"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/docs/adr/0010-daemon-rebuild.md
+++ b/docs/adr/0010-daemon-rebuild.md
@@ -1,0 +1,243 @@
+# ADR-0010: Rebuild Daemon Mode as Rust Binary with MCP-Tool Surface (v0.10.0)
+
+## Status
+
+Accepted
+
+Partially reverses [ADR-0009](0009-shepherd-deprecation.md). The
+shepherd brain and Python daemon brain remain deleted; daemon mode as
+a *user-facing capability* is rebuilt at a different architectural
+layer.
+
+## Context
+
+[ADR-0009](0009-shepherd-deprecation.md) deleted the Python shepherd
+brain (`loom_tools/shepherd/`), the Python daemon brain
+(`loom_tools/daemon_v2/`), the `/shepherd` slash command, and the
+related shell wrappers. The replacement was three daemon-free
+mechanisms: `/loom:sweep` for per-issue lifecycle (in-process subagent
+dispatch), `./.loom/scripts/spawn-loop.sh` for multi-issue claiming
+(shell script polling the forge), and `.github/workflows/loom-*.yml`
+for periodic support roles (cron-driven, no persistent process).
+
+That deletion was correct for the Python brains — they were ~21k LOC
+of fragile coordination code duplicating what forge labels expressed
+more simply. But the "no persistent process at all" stance turned out
+to be an overcorrection. Three operational realities pushed back:
+
+1. **Token rotation only works at process-spawn boundaries.** Claude
+   Code subagents inherit the parent session's `CLAUDE_CODE_OAUTH_TOKEN`.
+   For multi-day autonomous runs spreading load across multiple Pro/Max
+   accounts, every sweep child must be a separate `claude -p` process
+   with its own rotated token. The `/loom:sweep` skill (one Claude Code
+   session driving a subagent dispatch tree) cannot rotate tokens. A
+   separate dispatch surface is needed.
+
+2. **Operators want named dispatch and observability, not a polling
+   loop.** `spawn-loop.sh` (Phase 1 of epic #3372) reads the forge for
+   `loom:issue` items every 30 seconds and detaches one `claude -p
+   "/loom:sweep N"` child per ready issue. It works, but provides no
+   way to dispatch a specific issue on demand, no way to observe a
+   running sweep's lifecycle from outside the per-child log file, no
+   way to cancel a stuck child, and no way for sweep children to
+   coordinate with each other (e.g., Judge waiting on Builder's
+   `loom:review-requested` label flip without polling the forge).
+
+3. **The shell-level "preserved daemon mode" promised by ADR-0009 was
+   never built.** ADR-0009's "Decision" section said:
+   `./.loom/scripts/daemon.sh` "is preserved as a user-facing convenience
+   wrapper that launches the spawn loop + GitHub Actions cron +
+   token-rotated tmux panes." That `daemon.sh` wrapper does not exist
+   on `main`. The documentation referenced it through v0.9.x, but
+   `defaults/scripts/start-daemon.sh` and `stop-daemon.sh` were broken
+   stubs `exec`ing a script that was never written. The "preserved
+   daemon mode" promise was doc fiction.
+
+The Rust `loom-daemon` binary (~20k LOC, originally built for terminal
+lifecycle management per [ADR-0008](0008-tmux-daemon-architecture.md))
+already existed and was already running on operator machines. It owned
+the Unix socket IPC surface and the `mcp-loom` MCP server. Extending it
+with sweep dispatch, an event bus, and monitoring tools costs ~2,000–2,500
+LOC of net additions — not a new process, not a new persistent state
+file, just three new capabilities (named dispatch, inter-agent
+pub/sub, MCP-driven monitoring) layered onto the existing daemon.
+
+This rebuild was proposed in epic #3449 and implemented in six phases.
+
+## Decision
+
+Rebuild daemon mode at the **MCP-tool level** by extending the
+existing Rust `loom-daemon` binary with three new capabilities:
+
+**1. Named sweep dispatch (Phase A, #3459)**
+
+`mcp__loom__dispatch_sweep` enqueues a sweep for an issue. The daemon
+fork-execs `claude -p "/loom:sweep N"` via `defaults/scripts/spawn-claude.sh`
+(the existing token-rotation wrapper), registers the child pid in an
+in-memory `SweepRegistry`, and returns the `sweep_id` to the caller.
+`mcp__loom__list_sweeps` enumerates running sweeps. No forge polling
+— dispatch is operator-driven (or skill-delegated via Stage -1
+backend detection).
+
+**2. Inter-agent pub/sub event bus (Phase B, #3460)**
+
+`mcp__loom__publish_event` / `subscribe_to_events` provide a topic-routed
+event channel over `tokio::sync::broadcast`. Six topics are frozen for
+v0.10.0: `sweep.issue.{N}.phase`, `sweep.issue.{N}.blocker`,
+`sweep.issue.{N}.exited`, `sweep.issue.{N}.crashed`,
+`sweep.global.dispatch`, `sweep.global.completed`. Events are advisory
+— the forge (GitHub labels, issue/PR state) remains the authoritative
+source of coordination truth. Events accelerate inter-agent reaction
+time; they do not replace forge state.
+
+**3. MCP monitoring tools (Phase C, #3463)**
+
+`mcp__loom__get_sweep_status`, `tail_sweep_log`, `cancel_sweep`,
+`tail_event_bus` provide observability and control over running
+sweeps. `cancel_sweep` implements SIGTERM → grace → SIGKILL with a
+configurable grace window. `tail_event_bus` is a fire-hose view of all
+events regardless of topic, for post-hoc debugging (per the curator's
+risk note D on #3449).
+
+**Backend detection** (`/loom:sweep` Stage -1, Phase D, #3462) probes
+on every skill invocation whether the daemon is reachable AND a
+multi-account pool exists. **Strict AND** — either probe failing falls
+through to the existing in-process subagent dispatch path. This
+guarantees no behaviour change for solo-token operators while making
+the daemon path available to multi-account operators with zero
+configuration on the skill side.
+
+The v0.9.x spawn loop is **deprecated, not deleted** (Phase E, #3465).
+It emits a stderr warning on every invocation but remains functional
+through the v0.10.x cycle so downstream forks have one minor release of
+migration runway (per the curator's risk note C on #3449). Deletion is
+deferred to v0.11.0.
+
+The shell-level `daemon.sh` wrapper that ADR-0009 promised is **not
+rebuilt**. Operators run `loom-daemon` directly under their service
+manager of choice (systemd, launchd, foreman, or a background shell).
+The user-facing API is the MCP tools, not a shell command.
+
+## Consequences
+
+### Positive
+
+- **Multi-account dispatch is restored.** The rebuilt daemon supports
+  the long-running multi-account autonomous runs that motivated the
+  original v0.9.x spawn loop, with a cleaner operator surface (named
+  dispatch instead of forge polling).
+- **Inter-agent coordination becomes possible.** The pub/sub bus lets
+  Judge react to a Builder PR creation without polling the forge.
+  Reaction time drops from "next 5-minute cron tick" to sub-second.
+- **Operator observability improves.** `list_sweeps`,
+  `get_sweep_status`, `tail_sweep_log`, `tail_event_bus`, and
+  `subscribe_to_events` give a structured view of running sweeps that
+  the spawn loop could not provide (it only wrote a `pid` and
+  `started_at` to a state file).
+- **Cancellation is supported.** `cancel_sweep` is the first
+  first-class way to stop a stuck sweep without `pkill` or a manual
+  signal cascade.
+- **The doc-fiction gap is closed.** The Phase E rewrite of
+  `CLAUDE.md` / `defaults/CLAUDE.md` / `defaults/roles/loom.md`
+  removes references to the nonexistent `daemon.sh` and points to the
+  actual MCP-tool surface.
+- **No process count growth.** The capabilities are added to the
+  existing `loom-daemon` binary, not a new process. Operators who
+  already run `loom-daemon` for terminal management gain the sweep
+  surface for free.
+- **No on-disk daemon state file.** The sweep registry and event bus
+  live in-memory only. The forge remains the authoritative source of
+  coordination state. Restarting the daemon is safe — in-flight
+  sweeps survive (they are detached children) and re-register
+  themselves via the reaper on the first 30-second tick post-restart.
+
+### Negative
+
+- **Reputational risk: "didn't we just delete the daemon?"** The
+  curator's risk note B on #3449 addressed this; the framing this ADR
+  uses is: ADR-0009 deleted the *Python brain*, ADR-0010 adds three
+  *new capabilities* (named dispatch, pub/sub, MCP monitoring) the
+  prior brain never had. The architecture is genuinely different, not
+  a reversal. But the framing requires operator attention to land
+  correctly.
+- **Two dispatch surfaces.** Operators now have two valid ways to
+  drive a sweep: in-process subagent dispatch via `/loom:sweep`, and
+  multi-process daemon dispatch via `mcp__loom__dispatch_sweep`.
+  Stage -1 routes between them automatically, but operators reading
+  the docs see both paths and may need to think about which one applies.
+  The `/loom:sweep` skill (in either Mode A/B or daemon-delegated)
+  remains the recommended entry point for most workflows.
+- **LOC growth in the Rust daemon.** Phases A–C added ~2,000–2,500
+  LOC to `loom-daemon/src/`. The daemon was already ~20k LOC; the
+  growth is ~10–12%. Test coverage for the new modules
+  (`sweep_registry`, `event_bus`, MCP surface) is maintained at the
+  pre-rebuild bar.
+- **The Phase A "preserved daemon mode" promise from ADR-0009 is now
+  fulfilled at a different layer than originally claimed.** ADR-0009
+  said `daemon.sh start` would be the preserved API. ADR-0010 says
+  `mcp__loom__dispatch_sweep` is the preserved API. Operators who
+  scripted against the original (never-built) `daemon.sh` surface
+  must migrate to the MCP tools. This is documented in
+  [`docs/migration/v0.10.0-daemon-rebuild.md`](../migration/v0.10.0-daemon-rebuild.md).
+
+## Alternatives Considered
+
+**Restore the Python daemon brain (`loom_tools/daemon_v2/`)**
+
+Rejected. The Python brain's problems (single point of failure,
+opaque internal state, coupled scheduling, ~21k LOC maintenance
+burden) were architectural, not implementational. Restoring it would
+restore the problems ADR-0009 fixed. The MCP-tool surface on the Rust
+daemon avoids all five of ADR-0009's "Context" failure modes: no
+hidden state file (in-memory only), no scheduling policy in the daemon
+(operator-driven dispatch only), no role registration (the daemon does
+not know what `/curator` is), no event-loop serialization (`tokio`
+broadcast channels are concurrent), and ~10% of the LOC.
+
+**Keep daemon-free; build `spawn-loop.sh` v2 with named dispatch**
+
+Rejected. `spawn-loop.sh` is a polling loop — its primary mechanism is
+"every 30 seconds, scan the forge for `loom:issue` items." Adding
+named-dispatch on top requires either a second polling channel
+(operator-written request files in `.loom/dispatch-queue/`) or a
+network surface (Unix socket). Once you add the network surface, you
+have a daemon — at which point the question becomes "do we want the
+daemon to be 500 lines of shell or 2,000 lines of Rust?" The Rust
+daemon already exists for terminal management; extending it is cheaper
+than a parallel shell-daemon hybrid.
+
+**Build the shell-level `daemon.sh` wrapper ADR-0009 promised**
+
+Rejected. ADR-0009 said `daemon.sh` would "launch the spawn loop + GitHub
+Actions cron + token-rotated tmux panes." But: (a) GitHub Actions cron
+runs on GitHub's infrastructure, not via a local wrapper; (b)
+token-rotated tmux panes are an operator preference, not a Loom
+responsibility; and (c) `spawn-loop.sh` is being deprecated. The
+wrapper would have been a thin convenience layer over capabilities
+that mostly live elsewhere. The MCP surface is a more honest
+abstraction: it owns dispatch, observability, and lifecycle, with no
+pretence of also owning GH Actions schedules.
+
+**Defer the rebuild to v1.0.0**
+
+Rejected. The multi-account dispatch use case is the load-bearing
+operational pattern for autonomous overnight runs against the
+`loom:issue` queue. Deferring it would leave operators on
+`spawn-loop.sh` indefinitely while the docs continued to refer to a
+nonexistent `daemon.sh`. The doc-fiction gap (curator's risk note E on
+#3449) was already actively misleading operators. Closing the gap
+required either deleting the doc references entirely or building the
+backend they referred to. Building the backend was cheaper than
+reframing the entire "preserved daemon mode" narrative.
+
+## References
+
+- Original proposal: epic #3449 (daemon rebuild)
+- Phase issues: #3459 (A), #3460 (B), #3463 (C), #3462 (D), #3465 (E), #3457 (F — this ADR)
+- Stop-gap doc patch: #3458
+- Migration guide: [`docs/migration/v0.10.0-daemon-rebuild.md`](../migration/v0.10.0-daemon-rebuild.md)
+- Daemon surface reference: [`.loom/docs/daemon-reference.md`](../../.loom/docs/daemon-reference.md)
+- `/loom:sweep` skill (Stage -1 backend detection): [`defaults/.claude/commands/loom/sweep.md`](../../defaults/.claude/commands/loom/sweep.md)
+- Partially reversed: [ADR-0009: Shepherd Deprecation](0009-shepherd-deprecation.md)
+- Related: [ADR-0008: tmux + Rust Daemon Architecture](0008-tmux-daemon-architecture.md) (the daemon binary this ADR extends)
+- Related: [ADR-0006: Label-Based Workflow Coordination](0006-label-based-workflow-coordination.md) (forge-as-state-machine, foundational to both ADR-0009 and this one — the pub/sub bus does not displace forge labels as authoritative state)

--- a/docs/migration/v0.10.0-daemon-rebuild.md
+++ b/docs/migration/v0.10.0-daemon-rebuild.md
@@ -1,0 +1,354 @@
+# v0.10.0 Migration Guide — daemon rebuild
+
+> **Audience**: operators of v0.9.x Loom installations who run sweeps
+> via the v0.9.x spawn loop, solo-token operators running `/loom:sweep`
+> directly, and GitHub Actions cron operators of the periodic support
+> roles. This guide describes what changes (and what doesn't) when
+> upgrading to v0.10.0.
+>
+> **Status**: authoritative for the v0.10.0 release.
+>
+> **Pairs with**:
+> [`docs/migration/v0.10.0-shepherd-deprecation.md`](v0.10.0-shepherd-deprecation.md)
+> — the prior migration guide for the shepherd/daemon-Python-brain
+> deletion that v0.10.0 also ships. This guide covers the *rebuild* of
+> daemon mode at the MCP-tool level (epic #3449); the shepherd-deprecation
+> guide covers the *deletion* of the prior Python implementation (epic
+> #3372).
+
+## TL;DR
+
+**Two things change in v0.10.0 vs v0.9.x:**
+
+1. **Daemon mode comes back as a Rust binary with an MCP-tool surface.**
+   The Rust `loom-daemon` binary now exposes `mcp__loom__dispatch_sweep`
+   (plus seven sibling MCP tools and a frozen 6-topic event bus). Any
+   Claude Code session — or any MCP client — can drive multi-account
+   sweep dispatch through this surface. See
+   [What is new](#what-is-new) for the full list.
+
+2. **The v0.9.x spawn loop is deprecated.**
+   `./.loom/scripts/spawn-loop.sh` still works through v0.10.x but
+   emits a stderr warning on every invocation referencing #3449. It
+   will be **deleted in v0.11.0**. Migrate to
+   `mcp__loom__dispatch_sweep` against `loom-daemon`.
+
+**Two things do not change:**
+
+3. **Solo-token operators**: no-op. The strict-AND backend detection
+   in `/loom:sweep` Stage -1 means single-token configurations skip the
+   daemon and use the existing in-process subagent dispatch path —
+   exactly as in v0.9.x.
+
+4. **GitHub Actions cron operators**: no-op. The `.github/workflows/loom-*.yml`
+   workflows continue to run on cron with a single `CLAUDE_API_KEY`.
+   They are orthogonal to the daemon rebuild.
+
+If you fall into category 3 or 4 only, you can stop reading. If you
+operate the spawn loop or want the multi-account daemon dispatch, read
+on.
+
+## Phase rollout recap (epic #3449)
+
+The v0.10.0 daemon rebuild was staged into six phases under epic #3449:
+
+| Phase | Issue / PR | What shipped | Status |
+|-------|------------|--------------|--------|
+| Stop-gap | #3458 | Doc-fiction warnings (then rewritten in Phase E) | shipped |
+| Phase A | #3459 | `sweep_registry.rs`, `Request::DispatchSweep`, `mcp__loom__dispatch_sweep` + `list_sweeps` | shipped |
+| Phase B | #3460 | `event_bus.rs`, 6 frozen topics, `subscribe_to_events` IPC | shipped |
+| Phase C | #3463 | `cancel_sweep`, `get_sweep_status`, `tail_sweep_log`, `subscribe_to_events`, `publish_event`, `tail_event_bus`; full rewrite of `.loom/docs/daemon-reference.md` | shipped |
+| Phase D | #3462 | `defaults/.claude/commands/loom/sweep.md` Stage -1 backend detection (strict-AND probe) | shipped |
+| Phase E | #3465 | `spawn-loop.sh` deprecation warning (deletion deferred to v0.11.0); doc-fiction rewrite across `CLAUDE.md` / `defaults/CLAUDE.md` / `defaults/roles/loom.md`; reconciliation in the prior migration guide | shipped |
+| Phase F | this PR (#3457) | this migration guide; ADR-0010; version bump to 0.10.0 | shipped |
+
+The rebuild reverses part of ADR-0009 (which deleted the Python daemon
+brain in favour of a daemon-free architecture). The rationale and the
+explicit "this is genuinely different, not just re-adding what we
+removed" framing live in
+[`docs/adr/0010-daemon-rebuild.md`](../adr/0010-daemon-rebuild.md).
+
+## Operator personas
+
+### Spawn-loop operators
+
+**Symptom**: you have `LOOM_USE_SPAWN_LOOP=1 ./.loom/scripts/spawn-loop.sh start`
+in your automation, in a tmux pane, or in a systemd unit. The loop
+polls the forge for `loom:issue` items and detaches one
+`claude -p "/loom:sweep N"` child per ready issue.
+
+**v0.10.0 behaviour**: the script still works. Phase E (#3465) added
+a deprecation warning that fires on every `start` / `status` / `stop`
+invocation referencing #3449. The state file
+(`.loom/spawn-loop-state.json`), the lock directory
+(`.loom/locks/issue-<N>/`), and the per-child log files
+(`.loom/logs/sweep-issue-<N>.log`) all continue to be produced. Your
+existing observability (anything that scrapes those files) keeps
+working through the v0.10.x cycle.
+
+**Deletion target**: v0.11.0. Migrate before then.
+
+**Migration path** — pick one:
+
+**Option 1: drive the daemon from a Claude Code session (recommended for
+operator-attended runs)**
+
+Start the daemon once, in a background shell or under your service
+manager:
+
+```bash
+loom-daemon
+```
+
+(The binary is shipped under `loom-daemon/target/release/` — install
+via `cargo install --path loom-daemon` or your own packaging step.)
+
+Then, from a Claude Code session, enqueue sweeps via MCP:
+
+```text
+mcp__loom__dispatch_sweep --kind '{"Issue": 123}'
+mcp__loom__list_sweeps
+mcp__loom__get_sweep_status --sweep_id <id>
+```
+
+The daemon picks a rotated OAuth token from `.loom/tokens/` for each
+dispatched sweep child via `defaults/scripts/spawn-claude.sh`. Token
+rotation happens at the process-spawn boundary — same model as
+spawn-loop, just driven by named operator dispatch instead of a forge
+polling loop.
+
+**Option 2: let `/loom:sweep` Stage -1 auto-detect the daemon**
+
+If you previously typed `/loom:sweep 123` interactively while the
+spawn-loop ran in another window, you can now skip the spawn-loop
+entirely: just keep `loom-daemon` running. The
+[`defaults/.claude/commands/loom/sweep.md`](../../defaults/.claude/commands/loom/sweep.md)
+skill's Stage -1 (Phase D, #3462) probes whether the daemon is
+reachable AND a multi-account pool exists. On strict-AND, it delegates
+dispatch to the daemon and returns in under 2 seconds. Either probe
+failing falls through to the existing in-process subagent dispatch
+path.
+
+**Suppress the deprecation warning during migration:**
+
+```bash
+export LOOM_SUPPRESS_DEPRECATION=1
+```
+
+This silences the spawn-loop warning. Use it if you have a few weeks
+of staged migration ahead and the noise is unhelpful. Do not set it
+permanently — the warning is the only mechanism reminding you that
+v0.11.0 will delete the script.
+
+### Solo-token operators
+
+**Symptom**: you run `/loom:sweep <issue>` interactively from a
+Claude Code session. Your `.loom/tokens/` directory is empty, or
+contains a single token. You do not use the spawn loop. You do not
+have multi-account rotation configured.
+
+**v0.10.0 behaviour**: **no change**.
+
+The `/loom:sweep` Stage -1 backend detection requires **both** a
+reachable daemon AND a multi-account token pool to delegate dispatch.
+Either probe failing falls through to the existing Mode A/B/C
+subagent-dispatch lifecycle. Solo-token operators have no multi-account
+pool, so the `PROBE_POOL` step returns `false`, the `DECIDE` lands
+on `use_subagent`, and the rest of the skill runs as it always has.
+
+You do not need to do anything for v0.10.0. The skill works the same
+as in v0.9.x.
+
+If you later configure multi-account rotation (via `loom-tokens
+bootstrap` against multiple `ACCOUNT_KEY_N` entries in `.env`) AND start
+the daemon, Stage -1 will begin delegating to the daemon transparently.
+Until then, your solo-token flow is unchanged.
+
+### GitHub Actions cron operators
+
+**Symptom**: you have enabled one or more of the
+`.github/workflows/loom-*.yml` cron workflows (Champion, Curator,
+Judge, Auditor, Guide). The workflows run on schedules of 5–15 minutes,
+each invoking `claude -p "/<role>" --dangerously-skip-permissions` for
+one tick of work under a single `CLAUDE_API_KEY` secret.
+
+**v0.10.0 behaviour**: **no change**.
+
+The GitHub Actions cron path is orthogonal to the daemon rebuild. The
+workflows do not touch `loom-daemon`, do not use the MCP tools, and do
+not need a multi-account pool. Each tick is a fresh process invocation
+with a single API key — the simplest possible execution model.
+
+You do not need to do anything for v0.10.0. Continue running the
+workflows as configured.
+
+If you want to add daemon-driven sweep dispatch to your CI in the
+future, that is a separate (out-of-scope) operator decision, not a
+v0.10.0 migration step.
+
+## What is new
+
+The v0.10.0 daemon surface, end to end. For the IPC wire protocol,
+registry semantics, event taxonomy, and reaper behaviour, see
+[`.loom/docs/daemon-reference.md`](../../.loom/docs/daemon-reference.md)
+— this guide stays at the operator-surface level.
+
+### MCP tools (Phase A–C)
+
+| Tool | Phase | Purpose |
+|------|-------|---------|
+| `mcp__loom__dispatch_sweep` | A (#3459) | Enqueue a sweep for an issue. Token rotation happens at the process-spawn boundary via `spawn-claude.sh`. |
+| `mcp__loom__list_sweeps` | A (#3459) | Enumerate running sweeps in the in-memory registry. |
+| `mcp__loom__get_sweep_status` | C (#3463) | Inspect a single running sweep (registry entry + recent events). |
+| `mcp__loom__tail_sweep_log` | C (#3463) | Tail the per-sweep log file at `.loom/logs/sweep-issue-<N>.log`. |
+| `mcp__loom__cancel_sweep` | C (#3463) | Cancel a running sweep (SIGTERM → grace → SIGKILL). |
+| `mcp__loom__subscribe_to_events` | C (#3463) | Stream topic-filtered events to a subscriber. |
+| `mcp__loom__publish_event` | C (#3463) | Publish a sweep-lifecycle event on the in-memory bus (used by sweep children themselves). |
+| `mcp__loom__tail_event_bus` | C (#3463) | Tail the event bus without subscribing to a topic — a fire-hose view of all events for post-hoc investigation. |
+
+### Event taxonomy (Phase B, frozen for v0.10.0)
+
+Six topics. New topics require a follow-up issue.
+
+- `sweep.issue.{N}.phase` — phase transitions (Curator → Builder → Judge → Doctor → Merge)
+- `sweep.issue.{N}.blocker` — phase failures requiring human attention
+- `sweep.issue.{N}.exited` — clean child exit
+- `sweep.issue.{N}.crashed` — non-zero child exit
+- `sweep.global.dispatch` — `dispatch_sweep` accepted; sweep child started
+- `sweep.global.completed` — sweep finished (success, failure, or cancel) and was reaped
+
+### Backend detection (`/loom:sweep` Stage -1, Phase D)
+
+The `/loom:sweep` skill probes for the daemon and the multi-account pool
+on every invocation, before any other stage runs. Decision tree
+(simplified — see [`defaults/.claude/commands/loom/sweep.md`](../../defaults/.claude/commands/loom/sweep.md)
+"Stage -1: Backend detection" section for the authoritative version):
+
+1. **Mode C (`--prs`) → subagent.** Mode C is PR-set dispatch (Judge /
+   Doctor → Judge / Merge against an existing open-PR set). The daemon
+   does not handle PR-set dispatch in v0.10.0.
+2. **`--no-daemon` → subagent.** Operator opt-out flag. Skips both
+   probes, lands on subagent unconditionally. Use this for debug, demo,
+   or scripted runs where you want predictable single-process
+   behaviour.
+3. **`PROBE_DAEMON ∧ PROBE_POOL` (strict AND) → daemon.** Both probes
+   must succeed. `PROBE_DAEMON` is a Ping over the IPC socket with a
+   500ms timeout. `PROBE_POOL` checks `.loom/tokens/` for at least
+   two `ACCOUNT_KEY_*` entries.
+4. **Otherwise → subagent.** Either probe failing falls through to
+   the existing Mode A/B/C subagent dispatch path.
+
+The strict-AND design is what guarantees **no behaviour change for
+solo-token operators**. The probe is cheap (sub-millisecond when
+either condition is obviously false) and the fallthrough preserves the
+existing single-process lifecycle exactly.
+
+## What is gone
+
+Already shipped and not present in v0.10.0:
+
+- **Python daemon brain** (`loom-tools/src/loom_tools/daemon_v2/`) —
+  deleted in the prior shepherd-deprecation epic (#3372 / #3378).
+  Replaced by the Rust `loom-daemon` binary's MCP surface.
+- **Python shepherd brain** (`loom-tools/src/loom_tools/shepherd/`) —
+  deleted in the same epic. Replaced by the `/loom:sweep` Claude Code
+  skill.
+- **`/shepherd` slash command** — deleted in the same epic. Replaced
+  by `/loom:sweep <issue>`.
+- **`loom-daemon` Python entry point** — deleted in the same epic.
+  The Rust binary is the v0.10.0+ supported entry point.
+- **`loom-shepherd` Python entry point** — deleted in the same epic.
+  Replaced by `claude -p "/loom:sweep N" --dangerously-skip-permissions`.
+
+If your automation imports from `loom_tools.daemon_v2` or
+`loom_tools.shepherd`, or reads `.loom/daemon-state.json` or
+`.loom/progress/`, those calls broke in the prior epic. See
+[`docs/migration/v0.10.0-shepherd-deprecation.md`](v0.10.0-shepherd-deprecation.md)
+for the per-CLI replacement table and state-file migration narrative.
+
+## What is deprecated
+
+Still functional in v0.10.x, scheduled for deletion in v0.11.0:
+
+- **`./.loom/scripts/spawn-loop.sh`** — the v0.9.x interim
+  multi-account spawn loop (#3374). Every invocation now emits a
+  stderr warning referencing #3449. The script remains functional
+  through the entire v0.10.x cycle so downstream forks (sphere etc.)
+  have one minor release of runway per the curator's risk note C on
+  #3449.
+  - Migration target: `mcp__loom__dispatch_sweep` against
+    `loom-daemon`.
+  - Suppression: `export LOOM_SUPPRESS_DEPRECATION=1`.
+  - State file `.loom/spawn-loop-state.json` is still produced; logs
+    still go to `.loom/logs/spawn-loop.log` and
+    `.loom/logs/sweep-issue-<N>.log`.
+
+## Release prep checklist (operator)
+
+This checklist runs **after** this PR (#3457) merges and **before** the
+operator tags `v0.10.0-rc1`. Phase F ships the artifacts; the operator
+decides when the release goes out.
+
+- [ ] **File the sphere downstream coordination issue** per the #3382
+      coordination protocol. This tracks the rebuild's downstream
+      impact on sphere installs and any other forks that have not
+      migrated. The body should reference epic #3449, this migration
+      guide, and the v0.11.0 spawn-loop deletion target. The curator's
+      risk note C on #3449 recommended filing this in Phase A; if it
+      was filed earlier in the epic, this step is "confirm the tracker
+      is still active and link it from the rc1 release notes."
+- [ ] **Run a full self-sweep cycle end-to-end on the daemon backend.**
+      Start `loom-daemon`, ensure `.loom/tokens/` has ≥ 2
+      `ACCOUNT_KEY_*` entries materialized, pick a real `loom:issue`,
+      and run `/loom:sweep <N>` from a Claude Code session. Confirm
+      Stage -1 routes to the daemon (the skill returns in < 2 seconds
+      after `dispatch_sweep`), the sweep child runs Curator → Builder
+      → Judge → Doctor → Merge to completion, and the PR merges
+      without operator intervention. This is the validation that the
+      Phase A–E surface actually works end to end with a real account
+      pool and a real forge.
+- [ ] **Verify `./scripts/version.sh check` is green for 0.10.0.**
+      Phase F bumped the five version-bearing files (`package.json`,
+      `mcp-loom/package.json`, `loom-daemon/Cargo.toml`,
+      `loom-api/Cargo.toml`, `CLAUDE.md`) plus `Cargo.lock`. Re-run the
+      check on `main` after this PR merges as a smoke test before
+      tagging.
+- [ ] **Tag `v0.10.0-rc1`** when the prior three items pass. Use
+      `./scripts/version.sh set 0.10.0-rc1 --tag` (or another
+      release-candidate naming convention if the operator prefers).
+      The final `v0.10.0` tag is gated on at least one full week of
+      `loom:issue` queue exercise against rc1 with no operator
+      intervention.
+
+## Cross-references
+
+- [`docs/migration/v0.10.0-shepherd-deprecation.md`](v0.10.0-shepherd-deprecation.md)
+  — the prior migration guide for the shepherd/Python-daemon-brain
+  deletion (epic #3372). v0.10.0 ships both this rebuild and that
+  deletion.
+- [`docs/migration/daemon-state-consumers.md`](daemon-state-consumers.md)
+  — the read-side consumer inventory for `.loom/daemon-state.json`
+  and `.loom/progress/`. Required reading if you have downstream
+  scripts that consumed those files.
+- [`docs/adr/0009-shepherd-deprecation.md`](../adr/0009-shepherd-deprecation.md)
+  — the architectural decision to delete the Python brains.
+  Superseded in part by ADR-0010.
+- [`docs/adr/0010-daemon-rebuild.md`](../adr/0010-daemon-rebuild.md)
+  — the architectural decision to rebuild daemon mode at the Rust +
+  MCP level after the deletion was determined to have been an
+  overcorrection. Records the v0.10.0 reversal explicitly.
+- [`.loom/docs/daemon-reference.md`](../../.loom/docs/daemon-reference.md)
+  — the authoritative reference for the daemon surface (IPC wire
+  protocol, request/response variants, registry and reaper semantics,
+  event taxonomy). This migration guide stays operator-facing; the
+  daemon-reference stays implementor-facing.
+- [`defaults/.claude/commands/loom/sweep.md`](../../defaults/.claude/commands/loom/sweep.md)
+  — the `/loom:sweep` skill. Stage -1 backend detection is the
+  user-facing entry point to the daemon.
+- Epic #3449 — the parent proposal for the daemon rebuild.
+- Epic #3372 — the parent proposal for the Python-brain deletion that
+  preceded the rebuild.
+
+If you find a missing migration path or an unmigrated downstream that
+breaks on v0.10.0, please file an issue against `rjwalters/loom`
+referencing this guide.

--- a/loom-api/Cargo.toml
+++ b/loom-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loom-api"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 description = "External REST API for Loom analytics data access"
 

--- a/loom-daemon/Cargo.toml
+++ b/loom-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loom-daemon"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 
 [dependencies]

--- a/mcp-loom/package.json
+++ b/mcp-loom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loom/mcp",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Unified MCP server for Loom - combines logs, UI, and terminal tools",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loom",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "AI-powered development orchestration: a CLI + daemon that coordinates AI development workers using git worktrees and a forge (GitHub or Gitea) as the coordination layer.",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Closes #3457
Parent epic: #3449

## Summary

Phase F of epic #3449 — the v0.10.0 release prep capstone. Three coupled deliverables:

1. **Migration guide** — new `docs/migration/v0.10.0-daemon-rebuild.md` covers the three operator personas affected by the daemon rebuild (spawn-loop operators, solo-token operators, GH Actions cron operators).
2. **Successor ADR** — new `docs/adr/0010-daemon-rebuild.md` records the architectural decision to rebuild daemon mode at the Rust binary + MCP-tool layer, partially reversing ADR-0009.
3. **Version bump** — 0.9.1 → 0.10.0 via `./scripts/version.sh bump minor`. All 5 version-bearing files + Cargo.lock at 0.10.0.

## ADR strategy: Option A (successor)

Chose Option A (new `0010-daemon-rebuild.md`) over Option B (edit `0009-shepherd-deprecation.md` in place). Rationale:

- ADR-0009 was correct on its core decision — deleting the Python brains *was* the right call. That decision stands; the ~21k LOC of fragile coordination code is gone for good and should not come back.
- The reversal is narrower than the ADR-0009 framing suggests. ADR-0009's "Decision" promised a `daemon.sh start` shell-level surface that was never built; ADR-0010 fulfills the "preserved daemon mode" promise at a different architectural layer (MCP tools on the Rust binary) and explicitly calls out the doc-fiction gap.
- The successor pattern lets ADR-0009 stay "Accepted" (it shipped, the deletion is real) while ADR-0010 records the v0.10.0 reversal of the narrower "no persistent process at all" stance. Both ADRs are now operative — ADR-0009 for the deletion, ADR-0010 for the rebuild — and a future operator can read them in sequence to understand the full arc.

## Acceptance criteria status

| AC | Scope | Status |
|----|-------|--------|
| AC1: `docs/migration/v0.10.0-daemon-rebuild.md` covers all 3 personas | In scope | **PASS** — file exists; spawn-loop section documents both migration paths (drive daemon via MCP from Claude Code session; or `/loom:sweep` Stage -1 auto-detect), the deprecation timeline (warning in v0.10.0, deletion in v0.11.0), and the suppression env var. Solo-token and GH Actions sections explicitly call out "no-op" with the strict-AND rationale. |
| AC2: Sphere tracking issue filed per #3382 protocol | **OUT OF SCOPE** — cross-repo | Documented as release-blocker in the migration guide's release-prep checklist and below. Operator action required. |
| AC3: `./scripts/version.sh check` green for 0.10.0 | In scope | **PASS** — all 5 files + Cargo.lock at 0.10.0; output in test commands section. |
| AC4: Full self-sweep cycle on daemon backend | **OUT OF SCOPE** — operator action | Documented as release-blocker in the migration guide's release-prep checklist and below. Requires running `loom-daemon` with a multi-account pool. Not executable from a builder subagent. |

## Release-blockers (operator action AFTER merge, BEFORE tagging v0.10.0-rc1)

These are the two AC items intentionally out of scope for this PR per the issue body's "Phase F gets to rc1; the operator decides when the final tag drops" guidance.

- [ ] **AC2: File the sphere downstream coordination issue.** Cross-repo (sphere). Follow the #3382 coordination protocol. Body should reference epic #3449, this migration guide, and the v0.11.0 spawn-loop deletion target. The curator's risk note C on #3449 recommended filing this in Phase A; if it was filed earlier, confirm the tracker is still active and link it from the rc1 release notes.
- [ ] **AC4: Run a full self-sweep cycle end-to-end on the daemon backend.** Start `loom-daemon`, ensure `.loom/tokens/` has >= 2 `ACCOUNT_KEY_*` entries materialized, pick a real `loom:issue`, run `/loom:sweep <N>` from a Claude Code session. Confirm Stage -1 routes to the daemon (skill returns in < 2 seconds after `dispatch_sweep`), the sweep child runs Curator -> Builder -> Judge -> Doctor -> Merge to completion, and the PR merges without operator intervention.
- [ ] **Verify `./scripts/version.sh check` still green for 0.10.0 on `main` after this PR merges.**
- [ ] **Tag v0.10.0-rc1.** Operator decides timing; the final `v0.10.0` tag is gated on at least one full week of `loom:issue` queue exercise against rc1 with no operator intervention.

## What this PR does NOT do

Per the issue body's "OUT OF SCOPE" list:

- Does not tag v0.10.0-rc1 or v0.10.0.
- Does not file the sphere tracking issue.
- Does not run the self-sweep cycle (needs daemon + multi-account pool; operator action).
- Does not invent `daemon.sh start` or other non-existent entry points. The migration guide and ADR-0010 both reference the actual surface: `loom-daemon` binary + MCP tools + `/loom:sweep` Stage -1.
- No code changes beyond the mechanical version-bump edits to `Cargo.toml` / `package.json` / `Cargo.lock`.

## Commits in this PR

1. `docs: add v0.10.0 daemon-rebuild migration guide (#3457)` — 354 LOC new migration guide.
2. `docs(adr): add ADR-0010 daemon-rebuild successor (#3457)` — 243 LOC new ADR.
3. `chore: bump version to 0.10.0 (#3457)` — 7 LOC across 6 files; mechanical bump via `./scripts/version.sh bump minor` (no `--tag` — rc1 tagging is operator-deferred).

## Test plan

- [x] `./scripts/version.sh check` confirms all 5 files + Cargo.lock at 0.10.0
- [x] `cargo build --workspace` green
- [x] `cargo test -p loom-daemon --lib` green (336 passed; 0 failed)
- [x] `cargo clippy --package loom-daemon --package loom-api -- -D warnings ...` green with the standard Phase A–E allow-list
- [ ] Operator: verify `./scripts/version.sh check` still green on `main` post-merge
- [ ] Operator: AC2 sphere coordination tracking
- [ ] Operator: AC4 full self-sweep cycle validation on daemon backend