### PR TITLE
fix(install): exclude Loom-internal skills from consumer install (#3464)

### DIFF
--- a/defaults/.loom-internal.list
+++ b/defaults/.loom-internal.list
@@ -1,0 +1,21 @@
+# Loom-internal files — paths relative to defaults/ that the installer
+# MUST NOT copy into consumer repositories. Loom's own source checkout
+# still resolves these files via the working tree (they continue to live
+# under defaults/), but `loom-daemon init` and the install-side helpers
+# skip them when materializing a consumer repo.
+#
+# Format: one defaults-relative path per line. Lines starting with "#"
+# and blank lines are ignored. Trailing whitespace is stripped.
+#
+# Skip rules are exact-string matches against the defaults-relative path
+# (e.g. ".claude/commands/loom/release.md"). No globbing.
+#
+# Both install (loom-daemon/src/init/scaffolding.rs::setup_repository_scaffolding)
+# and uninstall (scripts/install/manifest.sh::_emit_installed_files_manifest)
+# consume this file. Keep additions narrow — every entry is a piece of
+# Loom-internal tooling that downstream consumers would otherwise see as
+# a stray `/loom:*` skill or auxiliary file.
+#
+# Tracked under issue #3464.
+
+.claude/commands/loom/release.md

--- a/loom-daemon/src/init/file_ops.rs
+++ b/loom-daemon/src/init/file_ops.rs
@@ -83,6 +83,31 @@ pub fn copy_dir_with_report(
     prefix: &str,
     report: &mut InitReport,
 ) -> io::Result<()> {
+    copy_dir_with_report_filtered(src, dst, prefix, report, &|_| false)
+}
+
+/// Copy directory recursively with reporting, honoring a skip predicate.
+///
+/// Identical to [`copy_dir_with_report`] but consults `skip` for every file
+/// (paths are passed as the same defaults-relative path that callers see in
+/// `report.added` — i.e. `prefix/<file_name>` with `/` separators).
+///
+/// `skip` is called with a defaults-relative-style path string. Returning
+/// `true` causes the file to be omitted from the copy and from the report.
+/// Directories are walked unconditionally — the skip predicate decides per
+/// file, so a single skipped file inside a copied directory works as
+/// expected.
+///
+/// Used by `setup_repository_scaffolding` to keep Loom-internal skills
+/// (e.g. `.claude/commands/loom/release.md`, see issue #3464) out of
+/// consumer-installed `.claude/` trees.
+pub fn copy_dir_with_report_filtered(
+    src: &Path,
+    dst: &Path,
+    prefix: &str,
+    report: &mut InitReport,
+    skip: &dyn Fn(&str) -> bool,
+) -> io::Result<()> {
     fs::create_dir_all(dst)?;
 
     for entry in fs::read_dir(src)? {
@@ -94,8 +119,11 @@ pub fn copy_dir_with_report(
         let rel_path = format!("{}/{}", prefix, file_name.to_string_lossy());
 
         if file_type.is_dir() {
-            copy_dir_with_report(&src_path, &dst_path, &rel_path, report)?;
+            copy_dir_with_report_filtered(&src_path, &dst_path, &rel_path, report, skip)?;
         } else {
+            if skip(&rel_path) {
+                continue;
+            }
             let existed = dst_path.exists();
             fs::copy(&src_path, &dst_path)?;
             if existed {
@@ -209,6 +237,27 @@ pub fn force_merge_dir_with_report(
     prefix: &str,
     report: &mut InitReport,
 ) -> io::Result<()> {
+    force_merge_dir_with_report_filtered(src, dst, prefix, report, &|_| false)
+}
+
+/// Force-merge directory recursively with reporting, honoring a skip predicate.
+///
+/// Identical to [`force_merge_dir_with_report`] but consults `skip` for every
+/// file. Skipped source files are NOT copied and NOT reported as added /
+/// updated; if such a file already exists in the destination it is left in
+/// place (we do not delete user-resolved local copies — the consumer install
+/// path either never created the file in the first place, or it predates the
+/// skip rule).
+///
+/// See [`copy_dir_with_report_filtered`] for predicate semantics. Used by
+/// `setup_repository_scaffolding` for the `.claude/` reinstall path.
+pub fn force_merge_dir_with_report_filtered(
+    src: &Path,
+    dst: &Path,
+    prefix: &str,
+    report: &mut InitReport,
+    skip: &dyn Fn(&str) -> bool,
+) -> io::Result<()> {
     fs::create_dir_all(dst)?;
 
     // Collect files in source for comparison
@@ -242,8 +291,11 @@ pub fn force_merge_dir_with_report(
         let rel_path = format!("{}/{}", prefix, file_name.to_string_lossy());
 
         if file_type.is_dir() {
-            force_merge_dir_with_report(&src_path, &dst_path, &rel_path, report)?;
+            force_merge_dir_with_report_filtered(&src_path, &dst_path, &rel_path, report, skip)?;
         } else {
+            if skip(&rel_path) {
+                continue;
+            }
             let existed = dst_path.exists();
             // Always copy from source (overwrite if exists)
             fs::copy(&src_path, &dst_path)?;
@@ -560,6 +612,112 @@ mod tests {
             "Template-substituted files should not produce verification failures, got: {:?}",
             report.verification_failures
         );
+    }
+
+    #[test]
+    fn test_copy_dir_with_report_filtered_skips_matching_files() {
+        // Issue #3464: the skip predicate must drop matching files from
+        // both the copy and the report. The path passed to the predicate
+        // is the same rel_path used in report.added (prefix-joined).
+        let temp_dir = TempDir::new().unwrap();
+        let src = temp_dir.path().join("src");
+        let dst = temp_dir.path().join("dst");
+
+        // Mirror the real .claude/commands/loom/ shape that motivates the
+        // skip rule: a deeply nested file we want excluded sits next to
+        // files that must continue to ship.
+        fs::create_dir_all(src.join("commands").join("loom")).unwrap();
+        fs::write(src.join("commands").join("loom").join("builder.md"), "ship me").unwrap();
+        fs::write(src.join("commands").join("loom").join("judge.md"), "ship me").unwrap();
+        fs::write(src.join("commands").join("loom").join("release.md"), "loom-internal").unwrap();
+
+        let mut report = super::super::InitReport::default();
+        copy_dir_with_report_filtered(&src, &dst, ".claude", &mut report, &|p| {
+            p == ".claude/commands/loom/release.md"
+        })
+        .unwrap();
+
+        // release.md must NOT exist in the destination tree.
+        assert!(
+            !dst.join("commands")
+                .join("loom")
+                .join("release.md")
+                .exists(),
+            "skipped file must not be copied"
+        );
+        // builder.md and judge.md must exist (skip predicate is narrow).
+        assert!(dst
+            .join("commands")
+            .join("loom")
+            .join("builder.md")
+            .exists());
+        assert!(dst.join("commands").join("loom").join("judge.md").exists());
+
+        // Report bookkeeping: skipped file is not in `added`, but the
+        // siblings are.
+        assert!(report
+            .added
+            .contains(&".claude/commands/loom/builder.md".to_string()));
+        assert!(report
+            .added
+            .contains(&".claude/commands/loom/judge.md".to_string()));
+        assert!(!report
+            .added
+            .contains(&".claude/commands/loom/release.md".to_string()));
+    }
+
+    #[test]
+    fn test_force_merge_dir_with_report_filtered_skips_matching_files() {
+        // Issue #3464: reinstall path must also honor the skip predicate.
+        // We additionally pin the "skipped file is not reported as
+        // updated/added even when a stale copy exists in dst" behavior —
+        // existing local files are left as-is, not deleted.
+        let temp_dir = TempDir::new().unwrap();
+        let src = temp_dir.path().join("src");
+        let dst = temp_dir.path().join("dst");
+
+        fs::create_dir_all(src.join("commands").join("loom")).unwrap();
+        fs::write(src.join("commands").join("loom").join("builder.md"), "v2").unwrap();
+        fs::write(src.join("commands").join("loom").join("release.md"), "v2-internal").unwrap();
+
+        // Simulate a pre-existing (pre-skip-rule) install of release.md.
+        fs::create_dir_all(dst.join("commands").join("loom")).unwrap();
+        fs::write(dst.join("commands").join("loom").join("release.md"), "stale local copy")
+            .unwrap();
+        // And a custom command not in defaults — must be preserved.
+        fs::write(dst.join("commands").join("my-custom.md"), "mine").unwrap();
+
+        let mut report = super::super::InitReport::default();
+        force_merge_dir_with_report_filtered(&src, &dst, ".claude", &mut report, &|p| {
+            p == ".claude/commands/loom/release.md"
+        })
+        .unwrap();
+
+        // builder.md was updated from src.
+        let installed_builder =
+            fs::read_to_string(dst.join("commands").join("loom").join("builder.md")).unwrap();
+        assert_eq!(installed_builder, "v2");
+        assert!(report
+            .added
+            .contains(&".claude/commands/loom/builder.md".to_string()));
+
+        // release.md: the stale local copy is LEFT IN PLACE (we do not
+        // delete; install/uninstall ownership is decoupled). What matters
+        // for the leakage fix is that we did not write the v2 source over
+        // it AND did not report it as added/updated.
+        let stale =
+            fs::read_to_string(dst.join("commands").join("loom").join("release.md")).unwrap();
+        assert_eq!(stale, "stale local copy");
+        assert!(!report
+            .added
+            .iter()
+            .chain(report.updated.iter())
+            .any(|p| p == ".claude/commands/loom/release.md"));
+
+        // Custom command preserved (existing behavior).
+        assert!(report
+            .preserved
+            .contains(&".claude/commands/my-custom.md".to_string()));
     }
 
     #[test]

--- a/loom-daemon/src/init/scaffolding.rs
+++ b/loom-daemon/src/init/scaffolding.rs
@@ -2,15 +2,25 @@
 //!
 //! Sets up CLAUDE.md, .claude/, .codex/, and .github/ directories.
 
+use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 
 use serde_json::Value;
 
-use super::file_ops::{copy_dir_with_report, force_merge_dir_with_report, merge_dir_with_report};
+use super::file_ops::{
+    copy_dir_with_report, copy_dir_with_report_filtered, force_merge_dir_with_report,
+    force_merge_dir_with_report_filtered, merge_dir_with_report,
+};
 use super::git::extract_repo_info;
 use super::templates::{assert_no_placeholders, substitute_template_variables, LoomMetadata};
 use super::InitReport;
+
+/// Name of the skip-list file under `defaults/` that lists Loom-internal
+/// paths the installer must not ship to consumer repositories.
+///
+/// See [`load_internal_skip_list`] for the file format. Issue #3464.
+pub const INTERNAL_SKIP_LIST_NAME: &str = ".loom-internal.list";
 
 /// Prefix used to identify Loom-owned hooks in settings.json.
 /// Hooks with commands starting with this prefix are managed by Loom.
@@ -101,6 +111,40 @@ fn is_legacy_loom_managed_root(existing_content: &str) -> bool {
     LEGACY_LOOM_SIGNATURES
         .iter()
         .any(|sig| existing_content.contains(sig))
+}
+
+/// Load the Loom-internal skip list from `<defaults>/.loom-internal.list`.
+///
+/// Returns a set of defaults-relative path strings (e.g.
+/// `".claude/commands/loom/release.md"`) that the installer must NOT copy
+/// into consumer repositories.
+///
+/// File format:
+/// - One defaults-relative path per line.
+/// - Lines starting with `#` are comments and ignored.
+/// - Blank lines are ignored.
+/// - Leading/trailing whitespace on each entry is stripped.
+/// - Paths are matched exactly against the defaults-relative path the
+///   copy helpers see (e.g. `.claude/commands/loom/release.md`). No
+///   globbing.
+///
+/// Missing or unreadable files yield an empty set — the install path is
+/// expected to function unchanged for repos that ship without a skip
+/// list. Issue #3464.
+pub fn load_internal_skip_list(defaults_path: &Path) -> HashSet<String> {
+    let mut set = HashSet::new();
+    let path = defaults_path.join(INTERNAL_SKIP_LIST_NAME);
+    let Ok(contents) = fs::read_to_string(&path) else {
+        return set;
+    };
+    for raw_line in contents.lines() {
+        let line = raw_line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        set.insert(line.to_string());
+    }
+    set
 }
 
 /// Read and parse an existing settings.json file, returning None if missing or invalid.
@@ -560,6 +604,14 @@ pub fn setup_repository_scaffolding(
     //
     // Special handling for settings.json: deep-merge hooks and permissions
     // instead of overwriting, so project-specific hooks are preserved.
+    //
+    // Issue #3464: skip files listed in `defaults/.loom-internal.list` so
+    // Loom-internal skills (e.g. `.claude/commands/loom/release.md`) are not
+    // shipped to consumer repositories. The skip list is loaded once and the
+    // closure does a HashSet lookup per file. An empty list (or missing file)
+    // is a no-op.
+    let skip_list = load_internal_skip_list(defaults_path);
+    let skip_predicate = |rel_path: &str| -> bool { skip_list.contains(rel_path) };
     let claude_src = defaults_path.join(".claude");
     let claude_dst = workspace_path.join(".claude");
     if claude_src.exists() {
@@ -569,12 +621,24 @@ pub fn setup_repository_scaffolding(
         if claude_dst.exists() {
             // Reinstall: always force-merge to update default commands
             // Custom commands (files not in defaults) are preserved
-            force_merge_dir_with_report(&claude_src, &claude_dst, ".claude", report)
-                .map_err(|e| format!("Failed to force-merge .claude directory: {e}"))?;
+            force_merge_dir_with_report_filtered(
+                &claude_src,
+                &claude_dst,
+                ".claude",
+                report,
+                &skip_predicate,
+            )
+            .map_err(|e| format!("Failed to force-merge .claude directory: {e}"))?;
         } else {
             // Fresh install: copy all
-            copy_dir_with_report(&claude_src, &claude_dst, ".claude", report)
-                .map_err(|e| format!("Failed to copy .claude directory: {e}"))?;
+            copy_dir_with_report_filtered(
+                &claude_src,
+                &claude_dst,
+                ".claude",
+                report,
+                &skip_predicate,
+            )
+            .map_err(|e| format!("Failed to copy .claude directory: {e}"))?;
         }
 
         // If there was an existing settings.json, merge Loom's defaults into it
@@ -663,6 +727,146 @@ mod tests {
         assert!(wrapped.starts_with(LOOM_SECTION_START));
         assert!(wrapped.ends_with(LOOM_SECTION_END));
         assert!(wrapped.contains("Loom content here"));
+    }
+
+    #[test]
+    fn test_load_internal_skip_list_missing_file() {
+        // Missing skip-list file yields an empty set so existing repos that
+        // ship without one keep their current behavior.
+        let temp_dir = TempDir::new().unwrap();
+        let set = load_internal_skip_list(temp_dir.path());
+        assert!(set.is_empty());
+    }
+
+    #[test]
+    fn test_load_internal_skip_list_parses_entries() {
+        // Issue #3464: confirm comment lines, blank lines, and surrounding
+        // whitespace are handled correctly so the file is operator-editable
+        // without surprise behavior.
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(
+            temp_dir.path().join(INTERNAL_SKIP_LIST_NAME),
+            "# Loom-internal files\n\
+             \n\
+             .claude/commands/loom/release.md\n\
+             \n\
+             # second-section comment\n\
+             .claude/commands/loom/some-other.md  \n",
+        )
+        .unwrap();
+
+        let set = load_internal_skip_list(temp_dir.path());
+        assert_eq!(set.len(), 2);
+        assert!(set.contains(".claude/commands/loom/release.md"));
+        assert!(set.contains(".claude/commands/loom/some-other.md"));
+    }
+
+    #[test]
+    fn test_setup_repository_scaffolding_skips_internal_files() {
+        // End-to-end coverage of issue #3464: when defaults/.loom-internal.list
+        // lists a path under .claude/, the installer must skip it on both
+        // fresh install and reinstall, while sibling commands continue to
+        // ship.
+        let temp_dir = TempDir::new().unwrap();
+        let workspace = temp_dir.path();
+        let defaults = temp_dir.path().join("defaults");
+
+        fs::create_dir(workspace.join(".git")).unwrap();
+        fs::create_dir_all(defaults.join(".claude").join("commands").join("loom")).unwrap();
+
+        fs::write(
+            defaults
+                .join(".claude")
+                .join("commands")
+                .join("loom")
+                .join("builder.md"),
+            "builder command",
+        )
+        .unwrap();
+        fs::write(
+            defaults
+                .join(".claude")
+                .join("commands")
+                .join("loom")
+                .join("judge.md"),
+            "judge command",
+        )
+        .unwrap();
+        fs::write(
+            defaults
+                .join(".claude")
+                .join("commands")
+                .join("loom")
+                .join("release.md"),
+            "loom-internal release skill",
+        )
+        .unwrap();
+
+        // Skip-list excludes release.md.
+        fs::write(
+            defaults.join(INTERNAL_SKIP_LIST_NAME),
+            "# header\n.claude/commands/loom/release.md\n",
+        )
+        .unwrap();
+
+        let mut report = InitReport::default();
+        setup_repository_scaffolding(workspace, &defaults, false, &mut report).unwrap();
+
+        // release.md must NOT be in the consumer's installed tree.
+        assert!(
+            !workspace
+                .join(".claude")
+                .join("commands")
+                .join("loom")
+                .join("release.md")
+                .exists(),
+            "issue #3464: .claude/commands/loom/release.md must be skipped on install"
+        );
+        // The siblings must still be installed verbatim.
+        assert!(workspace
+            .join(".claude")
+            .join("commands")
+            .join("loom")
+            .join("builder.md")
+            .exists());
+        assert!(workspace
+            .join(".claude")
+            .join("commands")
+            .join("loom")
+            .join("judge.md")
+            .exists());
+
+        // Reinstall: same outcome, plus a stale local copy (if one exists)
+        // is left in place rather than being overwritten or deleted.
+        fs::write(
+            workspace
+                .join(".claude")
+                .join("commands")
+                .join("loom")
+                .join("release.md"),
+            "stale local copy",
+        )
+        .unwrap();
+        let mut report2 = InitReport::default();
+        setup_repository_scaffolding(workspace, &defaults, true, &mut report2).unwrap();
+        let local = fs::read_to_string(
+            workspace
+                .join(".claude")
+                .join("commands")
+                .join("loom")
+                .join("release.md"),
+        )
+        .unwrap();
+        assert_eq!(
+            local, "stale local copy",
+            "skip rule must leave pre-existing local copies untouched"
+        );
+        // And the report must not list release.md as added/updated.
+        assert!(!report2
+            .added
+            .iter()
+            .chain(report2.updated.iter())
+            .any(|p| p == ".claude/commands/loom/release.md"));
     }
 
     #[test]

--- a/scripts/install/manifest.sh
+++ b/scripts/install/manifest.sh
@@ -26,6 +26,27 @@
 # below enumerates defaults/ instead — files Loom never shipped are not in
 # the manifest, so the uninstaller can't accidentally delete them.
 
+# Read the Loom-internal skip list at `<defaults>/.loom-internal.list` and
+# emit one defaults-relative path per line on stdout (comments, blank
+# lines, and surrounding whitespace stripped). Missing file → no output.
+#
+# This mirrors `loom_daemon::init::scaffolding::load_internal_skip_list` so
+# both surfaces consult the same declarative source. See issue #3464.
+_read_loom_internal_skip_list() {
+  local defaults_dir="$1"
+  local list_file="$defaults_dir/.loom-internal.list"
+  [[ -r "$list_file" ]] || return 0
+  # Strip comments and blanks; trim surrounding whitespace from each entry.
+  awk '
+    {
+      sub(/^[[:space:]]+/, "")
+      sub(/[[:space:]]+$/, "")
+      if ($0 == "" || $0 ~ /^#/) next
+      print
+    }
+  ' "$list_file"
+}
+
 # Print the installed-files manifest as a JSON array.
 #
 # Skip rules (mirror install-side behavior):
@@ -34,6 +55,9 @@
 #   - defaults/hooks/example-context/** → example methodology content
 #   - defaults/hooks/*.template     → templates, not installed verbatim
 #   - defaults/package.json         → only installed if target lacks one
+#   - any entry in defaults/.loom-internal.list (issue #3464) — Loom-
+#     internal files (e.g. .claude/commands/loom/release.md) that the
+#     Rust installer also skips at copy time
 #
 # Path translations (defaults-relative → target-relative):
 #   .loom-README.md       → .loom/README.md
@@ -62,6 +86,12 @@ _emit_installed_files_manifest() {
     return 0
   fi
 
+  # Issue #3464: load the declarative Loom-internal skip list once and stash
+  # it in a newline-delimited string. We use grep -Fx for the per-file check
+  # below so additions to the list don't require any code change here.
+  local internal_skip_paths
+  internal_skip_paths="$(_read_loom_internal_skip_list "$defaults_dir")"
+
   local json="["
   local first=true
   local rel_path target_path
@@ -82,6 +112,12 @@ _emit_installed_files_manifest() {
   while IFS= read -r -d '' file; do
     rel_path="${file#"${defaults_dir}"/}"
 
+    # The skip list itself is metadata about Loom's install boundary; it
+    # is not a shipped file.
+    if [[ "$rel_path" == ".loom-internal.list" ]]; then
+      continue
+    fi
+
     # Skip rules — files Loom does NOT install verbatim into the target.
     case "$rel_path" in
       README.md)
@@ -97,6 +133,15 @@ _emit_installed_files_manifest() {
         continue
         ;;
     esac
+
+    # Issue #3464: drop Loom-internal files declared in
+    # defaults/.loom-internal.list. Exact-match against the
+    # defaults-relative path; behavior mirrors the Rust installer's
+    # `load_internal_skip_list` + `_filtered` copy variants.
+    if [[ -n "$internal_skip_paths" ]] \
+        && printf '%s\n' "$internal_skip_paths" | grep -Fxq -- "$rel_path"; then
+      continue
+    fi
 
     # Translate defaults-relative → target-relative.
     case "$rel_path" in

--- a/scripts/test-installer.sh
+++ b/scripts/test-installer.sh
@@ -1579,6 +1579,72 @@ fi
 echo ""
 
 
+# Test 52: Loom-internal skills are not shipped to consumer repos (#3464)
+# After `loom-daemon init` against a fresh consumer repo, the entries
+# listed in defaults/.loom-internal.list must NOT exist in the consumer
+# tree, while sibling commands (builder, judge, curator) must exist.
+#
+# This test runs the real `loom-daemon init` (the same call install.sh
+# makes) rather than `simulate_loom_install`, because the leakage fix
+# lives inside `loom-daemon::init::scaffolding::setup_repository_scaffolding`
+# and the simulator's `cp -r .claude` does not exercise the skip path.
+echo "Test 52: Loom-internal skills excluded from consumer install (#3464)"
+DAEMON_BIN_52="$LOOM_ROOT/target/release/loom-daemon"
+SKIP_LIST_FILE="$LOOM_ROOT/defaults/.loom-internal.list"
+if [[ ! -x "$DAEMON_BIN_52" ]]; then
+  warn "Skipping Test 52 — loom-daemon release binary not built at $DAEMON_BIN_52"
+elif [[ ! -f "$SKIP_LIST_FILE" ]]; then
+  fail "defaults/.loom-internal.list is missing — the skip mechanism requires this file"
+else
+  INTERNAL_REPO="$TEST_DIR/internal-skip-test"
+  create_temp_repo "$INTERNAL_REPO"
+
+  # `loom-daemon init` builds a real consumer install in INTERNAL_REPO.
+  # Suppress stdout — we only care about side effects on the filesystem.
+  if "$DAEMON_BIN_52" init --defaults "$LOOM_ROOT/defaults" "$INTERNAL_REPO" >/dev/null 2>&1; then
+    # Each listed defaults-relative path must NOT exist in the consumer.
+    skip_violations=0
+    while IFS= read -r skip_rel; do
+      # Strip comments and blank lines (mirror the skip-list reader).
+      skip_rel="${skip_rel%%#*}"
+      # shellcheck disable=SC2295
+      skip_rel="${skip_rel#"${skip_rel%%[![:space:]]*}"}"
+      skip_rel="${skip_rel%"${skip_rel##*[![:space:]]}"}"
+      [[ -z "$skip_rel" ]] && continue
+      if [[ -e "$INTERNAL_REPO/$skip_rel" ]]; then
+        fail "Loom-internal file leaked to consumer: $skip_rel"
+        skip_violations=$((skip_violations + 1))
+      fi
+    done < "$SKIP_LIST_FILE"
+    if [[ "$skip_violations" -eq 0 ]]; then
+      pass "All defaults/.loom-internal.list entries absent from consumer tree"
+    fi
+
+    # AC1: specifically pin .claude/commands/loom/release.md as absent.
+    if [[ -e "$INTERNAL_REPO/.claude/commands/loom/release.md" ]]; then
+      fail "AC1: .claude/commands/loom/release.md must not be installed to consumers"
+    else
+      pass "AC1: .claude/commands/loom/release.md is absent from consumer install"
+    fi
+
+    # The siblings must continue to ship — pin three representative skills.
+    sibling_ok=true
+    for sibling in builder.md judge.md curator.md; do
+      if [[ ! -f "$INTERNAL_REPO/.claude/commands/loom/$sibling" ]]; then
+        fail "Consumer install missing .claude/commands/loom/$sibling"
+        sibling_ok=false
+      fi
+    done
+    if $sibling_ok; then
+      pass "Consumer install includes builder.md, judge.md, curator.md (skip-list is narrow)"
+    fi
+  else
+    fail "loom-daemon init failed against fresh consumer repo $INTERNAL_REPO"
+  fi
+fi
+echo ""
+
+
 # ==========================================================================
 # Summary
 # ==========================================================================


### PR DESCRIPTION
Closes #3464

## Summary

Loom's installer (`scripts/install-loom.sh` → `loom-daemon init`) was copying `defaults/.claude/commands/loom/release.md` verbatim into every consumer repository. That file is Loom-internal — it hardcodes Loom's 5-file version matrix and `./scripts/version.sh` invocation — so any downstream consumer that tried `/loom:release` would either hit "file not found" or, worse, mangle their own version-bearing files.

This PR introduces a declarative skip mechanism (Mechanism A in the Curator's analysis: https://github.com/rjwalters/loom/issues/3464#issuecomment-4635711223) so the install and uninstall surfaces share a single ownership-boundary file. The first entry is `release.md`. Future Loom-internal skills can land on the same list.

## Mechanism

- New file: `defaults/.loom-internal.list` — one defaults-relative path per line. Comments (`#`) and blanks are ignored. The first entry is `.claude/commands/loom/release.md`.
- New Rust API: `copy_dir_with_report_filtered` and `force_merge_dir_with_report_filtered` accept a `&dyn Fn(&str) -> bool` skip predicate. The existing helpers are now thin wrappers (`|_| false`) — zero behavior change for everything except `.claude/`.
- `setup_repository_scaffolding` (loom-daemon) loads `.loom-internal.list` once via `load_internal_skip_list` and passes the predicate to the `.claude/` copy path (both fresh-install and reinstall branches).
- `scripts/install/manifest.sh` (the uninstall manifest helper) reads the same file and drops matching entries from the JSON array it emits.

The skip list itself (`.loom-internal.list`) is also excluded from the manifest — it's metadata about Loom's install boundary, not a shipped file.

## Why Mechanism A, not Mechanism B

Mechanism B would have relocated `release.md` outside `defaults/`. That option would have needed special handling for Loom's own dogfood symlink at `.claude/commands -> ../defaults/.claude/commands` (#3311) and would not have generalized to future internal skills. Mechanism A keeps the ownership boundary declarative in one place.

## Dogfood mode

No changes needed. Loom's own `.claude/commands` is a symlink to `../defaults/.claude/commands` (mode `120000` in git). Since `release.md` continues to live in `defaults/.claude/commands/loom/`, the in-repo `/loom:release` skill still resolves through the symlink. The skip rule only fires when the install path is **writing** files into a consumer's `.claude/` — which doesn't happen for Loom itself in dogfood mode (where the directory is symlinked, not copied).

## Smoke test (real `loom-daemon init` against a fresh fixture)

```
=== release.md (should not exist) ===
ls: .../tmp.dMnWkjII0l/.claude/commands/loom/release.md: No such file or directory
=== builder.md (should exist) ===
-rw-r--r--  ... .claude/commands/loom/builder.md
=== judge.md (should exist) ===
-rw-r--r--  ... .claude/commands/loom/judge.md
=== curator.md (should exist) ===
-rw-r--r--  ... .claude/commands/loom/curator.md
=== loom dir count ===
      28
```

## Acceptance criteria

| AC | Status | Notes |
|----|--------|-------|
| AC1 — no `/loom:release` in consumer install | pass | smoke test above + Test 52 pins it; 28 loom commands ship vs 29 pre-PR |
| AC2 — Loom's own `/loom:release` still works | pass | symlink at `.claude/commands -> ../defaults/.claude/commands` resolves through to the still-present `defaults/.claude/commands/loom/release.md` |
| AC3 — skip list unified install/uninstall | pass | both `scaffolding.rs::load_internal_skip_list` and `manifest.sh::_read_loom_internal_skip_list` read `defaults/.loom-internal.list` |
| AC4 — regression test in `test-installer.sh` Section 9 | pass | Test 52: 3 sub-assertions (all skip-list entries absent; AC1 specifically; siblings present) |
| AC5 — no regression on PR #3461's narrowed manifest | pass | Test 51 still passes; full test suite 82/82 |

## Out of scope (deferred to follow-up)

Per the Curator's analysis, the broader scope — designing a generic version-bump skill that works in non-Loom repos by autodetecting `package.json` / `Cargo.toml` / `pyproject.toml` / `VERSION=` shapes — is **deferred to a follow-up issue**. This PR is purely the leakage fix. `scripts/version.sh` and `defaults/.claude/commands/loom/release.md` are unchanged.

## Test plan

- [x] `cargo test -p loom-daemon --lib` — 341 passed (3 new init/scaffolding tests)
- [x] `cargo test -p loom-daemon scaffolding` — covered
- [x] `bash scripts/test-installer.sh` — 82 passed (was 79; +3 from Test 52 sub-assertions)
- [x] `cargo clippy --package loom-daemon --package loom-api -- -D warnings ...` (CI mode) — clean
- [x] `shellcheck scripts/install/manifest.sh` — clean
- [x] Smoke test: real `loom-daemon init` against a fresh git repo confirms release.md absent, siblings present

🤖 Generated with [Claude Code](https://claude.com/claude-code)