### PR TITLE
feat(skill): /loom:bump — generic version-bump + tag skill for consumer projects (#3468)

### DIFF
--- a/defaults/.claude/commands/loom/bump.md
+++ b/defaults/.claude/commands/loom/bump.md
@@ -1,0 +1,436 @@
+# Version Bump + Tag (generic)
+
+You are bumping the version of {{workspace}} — a **generic project**, not necessarily Loom itself.
+
+## When to use this skill
+
+- The operator wants to release a new version of **their project**.
+- This is the **generic counterpart** to `/loom:release` (which is Loom-internal and ships from a separate skill file that consumers never see).
+- Works for any project shape: an npm package, a Cargo crate, a Python package, a single-script shell project, an npm+cargo monorepo, etc.
+
+If the operator is releasing **Loom itself** (from a checkout of `rjwalters/loom`), they should use `/loom:release` instead — that skill is wired to Loom's specific 5-file + `Cargo.lock` layout and knows about the release-workflow trigger. `/loom:bump` is for everyone else.
+
+**Do not rush.** Each phase requires explicit confirmation before proceeding to the next.
+
+## Phase 1: Detect version sources
+
+Walk the current repository root **once** and record which version-bearing files exist. Look for these sources **in order** and remember every match — multiple shapes can coexist (e.g. an npm+cargo monorepo).
+
+### Detection order
+
+1. **`scripts/version.sh`** (top-level): if this file already exists from a prior `/loom:bump` run, **short-circuit** the detection. Skip directly to Phase 5 ("Invoke the generated script"). The script is the source of truth on subsequent runs — the operator may have edited it.
+
+2. **`package.json`** (top-level): an npm project. Read `.version` via `jq -r .version`.
+
+3. **`*/package.json`** (workspace packages): an npm workspace / monorepo. Glob the top-level for subdirectory `package.json` files and read `.version` from each. Common patterns: `packages/*/package.json`, `apps/*/package.json`, or simply `<name>/package.json` (Loom's `mcp-loom/package.json` shape).
+
+4. **`Cargo.toml`** (top-level + workspace members): a Cargo crate or workspace.
+   - If `[package].version` is present at top level, that's a single-crate project.
+   - If `[workspace].members` lists subdirectories, each member's `Cargo.toml` has its own `[package].version`.
+   - If `Cargo.lock` exists, it must be refreshed via `cargo update -w <member>` (or `cargo update -w` for all) after each `Cargo.toml` change so the lockfile stays in sync.
+
+5. **`pyproject.toml`**: a Python project. Read **`[project].version`** (PEP 621) OR **`[tool.poetry].version`** (Poetry style). These are mutually exclusive — never both.
+
+6. **`setup.py` / `setup.cfg`** (legacy Python): some older Python projects still use these. Look for `version=` in `setup.py` or `version = ` under `[metadata]` in `setup.cfg`.
+
+7. **Top-level shell script with `VERSION="X.Y.Z"` line**: a single-file shell-script project (the `rjwalters/clean` shape). Grep for `^VERSION="[0-9]+\.[0-9]+\.[0-9]+"` in top-level `*.sh` files. Common script names: `cleanup.sh`, `install.sh`, `setup.sh`, `<projectname>.sh`.
+
+8. **`CLAUDE.md` and `README.md`**: markdown projects that embed the version in human-readable docs. Look for the line `**Version**: X.Y.Z` (or `**Loom Version**: X.Y.Z` — Loom's own pattern). Use ripgrep / grep with the regex `^\*\*[A-Za-z ]*Version\*\*: [0-9]+\.[0-9]+\.[0-9]+`.
+
+### Cross-check
+
+If multiple sources are detected, they should agree on the current version. If they disagree, **surface the inconsistency to the operator and ask** before proceeding:
+
+```
+Detected version sources:
+  - package.json: 0.4.1
+  - Cargo.toml:   0.4.0  ← MISMATCH
+  - CLAUDE.md:    0.4.1
+
+Sources disagree on the current version. The most-common value is 0.4.1.
+Should I treat 0.4.1 as the current version and update Cargo.toml to match,
+or do you want to investigate first?
+```
+
+### No sources detected
+
+If **no** version-bearing files are found, stop and tell the operator:
+
+> No version sources detected in this project. Supported shapes are: `package.json`, `Cargo.toml`, `pyproject.toml`, `setup.py`/`setup.cfg`, top-level shell script with `VERSION="X.Y.Z"`, and `CLAUDE.md` / `README.md` with `**Version**: X.Y.Z`. If your project uses a different shape, add one of these conventions first.
+
+## Phase 2: Ensure `CHANGELOG.md` exists with `[Unreleased]`
+
+Look for `CHANGELOG.md` at the repository root.
+
+- **If present and contains `## [Unreleased]`**: continue.
+- **If present but missing `## [Unreleased]`**: ask the operator to add one, or offer to insert it just below the file header.
+- **If absent entirely**: offer to scaffold a minimal Keep-a-Changelog header. Ask first — do not write without confirmation.
+
+Suggested scaffold:
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+```
+
+## Phase 3: Compute the new version (semver bump)
+
+Ask the operator:
+
+> What level should I bump — `patch`, `minor`, or `major`? Or do you want to set an explicit version like `1.2.3`?
+
+Apply semver rules:
+
+- `patch`: `X.Y.Z` → `X.Y.(Z+1)`
+- `minor`: `X.Y.Z` → `X.(Y+1).0`
+- `major`: `X.Y.Z` → `(X+1).0.0`
+- explicit: `X.Y.Z` (validate format — three integers separated by dots)
+
+Show the operator the computed new version and ask for confirmation.
+
+## Phase 4: Draft the changelog entry
+
+This is a **human-in-the-loop** step. **Never auto-generate the changelog content from commits.** Open `CHANGELOG.md`, find the `## [Unreleased]` section, and:
+
+1. If the operator has already written content under `## [Unreleased]`, present it and ask whether to use it as-is or edit.
+2. If the section is empty, ask the operator to dictate the entry. Suggest the categories from Keep a Changelog: `### Added`, `### Changed`, `### Fixed`, `### Removed`, `### Deprecated`, `### Security`.
+
+Once approved, **promote** the `## [Unreleased]` heading to `## [X.Y.Z] - YYYY-MM-DD` (today's UTC date, ISO-8601). Insert a fresh empty `## [Unreleased]` section above the new one so the next release has a place to accumulate.
+
+Example transform:
+
+```diff
+-## [Unreleased]
++## [Unreleased]
++
++## [0.4.2] - 2026-06-05
+
+ ### Fixed
+ - Foo bug
+```
+
+## Phase 5: Generate (or update) `scripts/version.sh`
+
+### If `scripts/version.sh` already exists
+
+Invoke it directly:
+
+```bash
+./scripts/version.sh bump <level> --tag
+```
+
+The generated script is the source of truth — the operator may have customized it. **Do not silently overwrite** an existing `scripts/version.sh`. If you suspect drift (e.g. a new version-bearing file was added since the script was generated), offer a diff and ask before replacing.
+
+### If `scripts/version.sh` does NOT exist
+
+Generate one tailored to the detected sources. The template structure below mirrors Loom's own `scripts/version.sh` but **parameterized** for whatever shape was detected. Adapt the per-shape sections — emit only the readers/writers for files that actually exist in this project.
+
+#### Template (adapt to detected sources)
+
+```bash
+#!/usr/bin/env bash
+# version.sh - Manage version across all project packages
+# Generated by /loom:bump — safe to edit; subsequent /loom:bump runs reuse this script.
+#
+# Usage:
+#   ./scripts/version.sh                  # Show current version
+#   ./scripts/version.sh check            # Verify all files are in sync
+#   ./scripts/version.sh bump patch       # X.Y.Z → X.Y.(Z+1)
+#   ./scripts/version.sh bump minor       # X.Y.Z → X.(Y+1).0
+#   ./scripts/version.sh bump major       # X.Y.Z → (X+1).0.0
+#   ./scripts/version.sh set 1.2.3        # Set explicit version
+#   ./scripts/version.sh set 1.2.3 --tag  # Set + commit + tag
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# All files that contain the version string.
+# EDIT THIS LIST when you add or remove version-bearing files.
+VERSION_FILES=(
+  # "package.json"            # npm shape
+  # "mcp-loom/package.json"   # npm-workspace shape
+  # "loom-daemon/Cargo.toml"  # cargo-workspace shape
+  # "pyproject.toml"          # python shape
+  # "cleanup.sh"              # shell-VERSION shape (top-level)
+  # "CLAUDE.md"               # markdown-version shape
+  # "README.md"
+)
+
+# Pick the canonical source for `get_version` — usually the first
+# entry in VERSION_FILES, but parameterized so the project can choose.
+get_version() {
+  # Example for npm shape:
+  # jq -r '.version' "$REPO_ROOT/package.json"
+  echo "REPLACE_WITH_CANONICAL_SOURCE_READER"
+}
+
+get_version_from_file() {
+  local file="$1"
+  case "$file" in
+    *.json)
+      jq -r '.version' "$REPO_ROOT/$file"
+      ;;
+    *.toml)
+      # PEP 621: [project] version = "..."
+      # Poetry: [tool.poetry] version = "..."
+      # Cargo:  [package] version = "..."
+      grep -m1 '^version' "$REPO_ROOT/$file" | sed 's/version = "\(.*\)"/\1/'
+      ;;
+    *.sh)
+      # Top-level shell script with VERSION="X.Y.Z"
+      grep -m1 '^VERSION=' "$REPO_ROOT/$file" | sed 's/VERSION="\(.*\)"/\1/'
+      ;;
+    *.md)
+      grep -o '\*\*[A-Za-z ]*Version\*\*: [0-9]*\.[0-9]*\.[0-9]*' "$REPO_ROOT/$file" \
+        | grep -o '[0-9]*\.[0-9]*\.[0-9]*'
+      ;;
+  esac
+}
+
+check_versions() {
+  local expected
+  expected=$(get_version)
+  local all_match=true
+
+  for file in "${VERSION_FILES[@]}"; do
+    local actual
+    actual=$(get_version_from_file "$file")
+    if [ "$actual" != "$expected" ]; then
+      echo "MISMATCH  $file: $actual (expected $expected)"
+      all_match=false
+    else
+      echo "OK        $file: $actual"
+    fi
+  done
+
+  # If Cargo.lock is present, verify it agrees too.
+  if [ -f "$REPO_ROOT/Cargo.lock" ]; then
+    # The set of workspace members to check is project-specific — list them here.
+    # local lock_versions
+    # lock_versions=$(grep -A1 'name = "PROJECT-CRATE"' "$REPO_ROOT/Cargo.lock" \
+    #                 | grep '^version' | sed 's/version = "\(.*\)"/\1/' | sort -u)
+    : # remove this line and add real checks for Cargo.lock workspace crates
+  fi
+
+  if $all_match; then
+    echo ""
+    echo "All versions in sync: $expected"
+    return 0
+  else
+    echo ""
+    echo "Version mismatch detected. Run: $0 set $expected"
+    return 1
+  fi
+}
+
+bump_version() {
+  local current="$1"
+  local part="$2"
+
+  IFS='.' read -r major minor patch <<< "$current"
+
+  case "$part" in
+    major) echo "$((major + 1)).0.0" ;;
+    minor) echo "$major.$((minor + 1)).0" ;;
+    patch) echo "$major.$minor.$((patch + 1))" ;;
+    *) echo "Unknown bump type: $part (use major, minor, or patch)" >&2; exit 1 ;;
+  esac
+}
+
+set_version() {
+  local new_version="$1"
+
+  if ! [[ "$new_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Invalid version format: $new_version (expected X.Y.Z)" >&2
+    exit 1
+  fi
+
+  local old_version
+  old_version=$(get_version)
+
+  echo "Updating version: $old_version → $new_version"
+  echo ""
+
+  # ---- Per-shape writers — emit ONLY the sections that match the detected shapes. ----
+  #
+  # JSON files (npm / npm-workspace):
+  # for file in package.json mcp-loom/package.json; do
+  #   local tmp; tmp=$(mktemp)
+  #   jq --arg v "$new_version" '.version = $v' "$REPO_ROOT/$file" > "$tmp"
+  #   mv "$tmp" "$REPO_ROOT/$file"
+  #   echo "  Updated $file"
+  # done
+  #
+  # Cargo.toml files (cargo / cargo-workspace):
+  # for file in loom-daemon/Cargo.toml loom-api/Cargo.toml; do
+  #   awk -v ver="$new_version" '!done && /^version = "/ { print "version = \"" ver "\""; done=1; next } 1' \
+  #     "$REPO_ROOT/$file" > "$REPO_ROOT/$file.tmp" && mv "$REPO_ROOT/$file.tmp" "$REPO_ROOT/$file"
+  #   echo "  Updated $file"
+  # done
+  #
+  # pyproject.toml ([project].version OR [tool.poetry].version):
+  # awk -v ver="$new_version" '!done && /^version = "/ { print "version = \"" ver "\""; done=1; next } 1' \
+  #   "$REPO_ROOT/pyproject.toml" > "$REPO_ROOT/pyproject.toml.tmp" \
+  #   && mv "$REPO_ROOT/pyproject.toml.tmp" "$REPO_ROOT/pyproject.toml"
+  # echo "  Updated pyproject.toml"
+  #
+  # Top-level shell script with VERSION="X.Y.Z":
+  # sed -i '' "s/^VERSION=\".*\"/VERSION=\"$new_version\"/" "$REPO_ROOT/cleanup.sh"
+  # echo "  Updated cleanup.sh"
+  #
+  # Markdown (CLAUDE.md / README.md) with **Version**: X.Y.Z:
+  # sed -i '' "s/\*\*Version\*\*: .*/\*\*Version\*\*: $new_version/" "$REPO_ROOT/CLAUDE.md"
+  # echo "  Updated CLAUDE.md"
+  #
+  # Cargo.lock refresh (only if Cargo.toml(s) were updated):
+  # (cd "$REPO_ROOT" && cargo update -w 2>/dev/null) && echo "  Updated Cargo.lock"
+
+  echo ""
+  echo "Version set to $new_version"
+}
+
+do_tag() {
+  local version="$1"
+
+  echo ""
+  echo "Committing and tagging..."
+  (
+    cd "$REPO_ROOT"
+    # Stage every version-bearing file PLUS Cargo.lock (if it exists) and CHANGELOG.md.
+    # EDIT THIS LIST to match VERSION_FILES above.
+    git add "${VERSION_FILES[@]}"
+    [ -f "Cargo.lock" ] && git add Cargo.lock
+    [ -f "CHANGELOG.md" ] && git add CHANGELOG.md
+    git commit -m "chore: bump version to $version"
+    git tag -a "v$version" -m "v$version"
+  )
+  echo ""
+  echo "Created commit and tag v$version"
+  echo "Push with: git push origin HEAD --tags"
+}
+
+# --- Main ---
+
+case "${1:-}" in
+  ""|show)
+    echo "$(get_version)"
+    ;;
+  check)
+    check_versions
+    ;;
+  bump)
+    part="${2:-patch}"
+    current=$(get_version)
+    new_version=$(bump_version "$current" "$part")
+    set_version "$new_version"
+    if [ "${3:-}" = "--tag" ]; then
+      do_tag "$new_version"
+    fi
+    ;;
+  set)
+    if [ -z "${2:-}" ]; then
+      echo "Usage: $0 set <version> [--tag]" >&2
+      exit 1
+    fi
+    set_version "$2"
+    if [ "${3:-}" = "--tag" ]; then
+      do_tag "$2"
+    fi
+    ;;
+  *)
+    echo "Usage: $0 [show|check|bump <major|minor|patch> [--tag]|set <version> [--tag]]"
+    exit 1
+    ;;
+esac
+```
+
+Write the generated `scripts/version.sh` with the placeholder sections **filled in** for the detected shapes and the unused sections **removed** (don't ship commented-out templates to the operator's repo). Make the script executable: `chmod +x scripts/version.sh`. Show the operator the generated file before saving.
+
+## Phase 6: Run the bump + tag flow
+
+Once `scripts/version.sh` exists, invoke it:
+
+```bash
+./scripts/version.sh bump <level> --tag
+```
+
+This will:
+1. Update every file in `VERSION_FILES` to the new version.
+2. Refresh `Cargo.lock` (if present).
+3. Stage the changes plus `CHANGELOG.md`.
+4. Create a commit `chore: bump version to X.Y.Z`.
+5. Create an annotated tag `vX.Y.Z`.
+
+**Verify** the result before proceeding:
+
+```bash
+./scripts/version.sh check     # all versions in sync
+git log -1 --oneline           # commit message
+git tag --list 'v*' | tail -1  # new tag
+```
+
+Show the operator the diff and the new commit. Ask for final confirmation before Phase 7.
+
+## Phase 7: Push and `gh release create` (OPTIONAL)
+
+This phase is **explicitly gated**. Ask the operator:
+
+> Push to origin and create a GitHub Release? (y/N)
+
+Do NOT proceed without an explicit "yes".
+
+If confirmed:
+
+```bash
+git push origin HEAD
+git push origin "v$NEW_VERSION"
+```
+
+Then create the GitHub Release. Use the just-promoted changelog block as the release notes:
+
+```bash
+# Extract the most recent ## [X.Y.Z] - DATE block from CHANGELOG.md
+notes=$(awk '/^## \['"$NEW_VERSION"'\]/{flag=1; next} /^## \[/{flag=0} flag' CHANGELOG.md)
+
+gh release create "v$NEW_VERSION" \
+  --title "v$NEW_VERSION" \
+  --notes "$notes"
+```
+
+**Do NOT publish to package registries.** This skill does not run `npm publish`, `cargo publish`, `twine upload`, or any other registry push. Tag + GitHub Release only. If the operator wants registry publication, that's a separate manual step (or a CI workflow they configure on their own).
+
+If the project does not use GitHub (e.g. it's on Gitea or self-hosted), skip the `gh release create` step and just push the tag. The operator can create the release through their forge's UI.
+
+## Phase 8: Summary
+
+Present a final summary:
+
+```
+Release v$NEW_VERSION complete
+
+- Version: $NEW_VERSION
+- Commit:  <sha>
+- Tag:     v$NEW_VERSION
+- Files:   <list of updated files>
+- Pushed:  yes / no
+- Release: created / skipped
+```
+
+## Notes and constraints
+
+- **Do not auto-generate CHANGELOG content from commits.** The `## [Unreleased]` content comes from the operator. The skill only *promotes* the existing `[Unreleased]` heading to `[X.Y.Z] - DATE`.
+- **Do not publish to package registries.** Tag + GitHub Release only.
+- **Do not modify `/loom:release`.** That skill is Loom-internal and ships from a separate file consumers never see. `/loom:bump` is the generic counterpart.
+- **Do not overwrite an existing `scripts/version.sh` without confirmation.** The operator may have customized it; offer a diff first.
+- **`scripts/version.sh` is the source of truth on subsequent runs.** Phase 1's short-circuit step ensures the skill defers to the generated script after the first run.
+- **Multiple shapes can coexist.** An npm+cargo monorepo (Loom's own shape) needs updates across `package.json`, `Cargo.toml`, `Cargo.lock`, and possibly `CLAUDE.md`. Emit writers for every detected shape.
+- **The seven detection sources are**: `package.json`, `*/package.json` (workspace), `Cargo.toml` (+ workspace members + `Cargo.lock`), `pyproject.toml` (`[project]` or `[tool.poetry]`), `setup.py`/`setup.cfg` (legacy Python), top-level shell script with `VERSION="X.Y.Z"`, and `CLAUDE.md`/`README.md` with `**Version**: X.Y.Z`.
+- **Branch protection**: if the operator's repo enforces PR-only merges to `main`, a direct push of the bump commit will fail. In that case, push the bump commit to a feature branch and open a PR — the tag can be created after the PR merges.

--- a/loom-daemon/tests/bump_md_doc_lint.rs
+++ b/loom-daemon/tests/bump_md_doc_lint.rs
@@ -1,0 +1,254 @@
+//! Doc-lint test for `defaults/.claude/commands/loom/bump.md` (Issue #3468).
+//!
+//! The `/loom:bump` skill is the generic, consumer-facing counterpart to the
+//! Loom-internal `/loom:release` skill. It must ship to consumer repos (it is
+//! NOT in `defaults/.loom-internal.list`) and its prose must document a
+//! specific contract: seven detection sources, eight lifecycle phases, an
+//! explicit-confirmation gate on push + GitHub Release, and a parameterized
+//! `scripts/version.sh` template that subsequent runs reuse.
+//!
+//! This test grep-checks the markdown file at compile time so that:
+//!
+//! - Renames/refactors to the phase headings flag a CI failure.
+//! - Removing a detection source by accident also flags a CI failure.
+//! - The acceptance criteria for #3468 (AC #1 through AC #8) can be
+//!   verified programmatically.
+//!
+//! Companion tests: `sweep_md_doc_lint.rs` (Phase B, #3453),
+//! `sweep_md_stage_minus_one_doc_lint.rs` (Phase D, #3454).
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::fs;
+use std::path::PathBuf;
+
+const BUMP_MD_RELATIVE: &str = "../defaults/.claude/commands/loom/bump.md";
+
+fn read_bump_md() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(BUMP_MD_RELATIVE);
+    fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!(
+            "bump.md not found at {} (CWD-relative path: {}): {e}",
+            path.display(),
+            BUMP_MD_RELATIVE,
+        );
+    })
+}
+
+/// AC: skill file exists with the expected title.
+#[test]
+fn bump_md_exists_and_has_title() {
+    let content = read_bump_md();
+    assert!(
+        content.starts_with("# Version Bump + Tag"),
+        "expected `# Version Bump + Tag` title at top of bump.md — \
+         the skill must self-identify as the generic version-bump skill"
+    );
+}
+
+/// AC: the eight lifecycle phases must all be present as section headers.
+///
+/// Phase 1: Detect version sources
+/// Phase 2: Ensure CHANGELOG.md exists
+/// Phase 3: Compute the new version
+/// Phase 4: Draft the changelog entry
+/// Phase 5: Generate (or update) scripts/version.sh
+/// Phase 6: Run the bump + tag flow
+/// Phase 7: Push and gh release create (OPTIONAL)
+/// Phase 8: Summary
+#[test]
+fn bump_md_documents_all_eight_phases() {
+    let content = read_bump_md();
+    let required_phase_headers: &[&str] = &[
+        "## Phase 1: Detect version sources",
+        "## Phase 2: Ensure",
+        "## Phase 3: Compute the new version",
+        "## Phase 4: Draft the changelog entry",
+        "## Phase 5: Generate",
+        "## Phase 6: Run the bump",
+        "## Phase 7: Push and",
+        "## Phase 8: Summary",
+    ];
+    for header in required_phase_headers {
+        assert!(
+            content.contains(header),
+            "bump.md is missing required phase header `{header}` — \
+             #3468 acceptance criteria require eight lifecycle phases"
+        );
+    }
+}
+
+/// AC3, AC4, AC5: detection prose must mention all seven version-source
+/// shapes. The skill prose tells the runtime LLM which files to scan; if
+/// any source disappears from this list the contract is broken.
+#[test]
+fn bump_md_lists_seven_detection_sources() {
+    let content = read_bump_md();
+    // AC3: multi-file npm+cargo monorepo shape (Loom-style).
+    assert!(
+        content.contains("package.json"),
+        "bump.md must document `package.json` detection (AC3, npm shape)"
+    );
+    assert!(
+        content.contains("*/package.json"),
+        "bump.md must document `*/package.json` workspace-package detection \
+         (AC3, npm-workspace shape — used by Loom for mcp-loom/)"
+    );
+    assert!(
+        content.contains("Cargo.toml"),
+        "bump.md must document `Cargo.toml` detection (AC3, cargo shape)"
+    );
+    assert!(
+        content.contains("Cargo.lock"),
+        "bump.md must document `Cargo.lock` refresh requirement (AC3, cargo-workspace shape)"
+    );
+    // AC5: pyproject.toml shape.
+    assert!(
+        content.contains("pyproject.toml"),
+        "bump.md must document `pyproject.toml` detection (AC5, Python shape)"
+    );
+    assert!(
+        content.contains("[project].version") || content.contains("`[project].version`"),
+        "bump.md must document `[project].version` PEP-621 detection (AC5)"
+    );
+    assert!(
+        content.contains("[tool.poetry].version") || content.contains("`[tool.poetry].version`"),
+        "bump.md must document `[tool.poetry].version` Poetry detection (AC5)"
+    );
+    // AC4: rjwalters/clean shape — top-level shell script with VERSION="X.Y.Z".
+    assert!(
+        content.contains("VERSION=\"X.Y.Z\"") || content.contains(r#"VERSION="X.Y.Z""#),
+        "bump.md must document `VERSION=\"X.Y.Z\"` shell-script detection (AC4, rjwalters/clean shape)"
+    );
+    // Markdown version shape (CLAUDE.md / README.md).
+    assert!(
+        content.contains("**Version**: X.Y.Z") || content.contains("`**Version**: X.Y.Z`"),
+        "bump.md must document `**Version**: X.Y.Z` markdown detection (Loom CLAUDE.md shape)"
+    );
+    assert!(
+        content.contains("CLAUDE.md") && content.contains("README.md"),
+        "bump.md must reference both `CLAUDE.md` and `README.md` as scan targets"
+    );
+}
+
+/// AC6: the skill must ship a templated `scripts/version.sh` body. We
+/// assert the marker structural pieces of the template (function names,
+/// subcommand wiring) so a future refactor that drops the template by
+/// accident lights up CI.
+#[test]
+fn bump_md_includes_version_sh_template() {
+    let content = read_bump_md();
+    let required_template_markers: &[&str] = &[
+        "scripts/version.sh",
+        "VERSION_FILES=",
+        "get_version()",
+        "get_version_from_file()",
+        "check_versions()",
+        "bump_version()",
+        "set_version()",
+        "do_tag()",
+        // The subcommand surface mirrored from Loom's own scripts/version.sh.
+        "bump <major|minor|patch>",
+        "set <version>",
+        "--tag",
+    ];
+    for marker in required_template_markers {
+        assert!(
+            content.contains(marker),
+            "bump.md is missing template marker `{marker}` — \
+             #3468 AC6 requires a parameterized scripts/version.sh template"
+        );
+    }
+}
+
+/// AC7: CHANGELOG handling must ensure `## [Unreleased]` and offer to
+/// scaffold a Keep-a-Changelog header when CHANGELOG.md is absent.
+#[test]
+fn bump_md_documents_changelog_handling() {
+    let content = read_bump_md();
+    assert!(
+        content.contains("## [Unreleased]"),
+        "bump.md must reference the `## [Unreleased]` Keep-a-Changelog heading (AC7)"
+    );
+    assert!(
+        content.contains("Keep a Changelog") || content.contains("keepachangelog"),
+        "bump.md must reference Keep-a-Changelog convention (AC7)"
+    );
+    // The promotion transform: [Unreleased] -> [X.Y.Z] - YYYY-MM-DD.
+    assert!(
+        content.contains("YYYY-MM-DD"),
+        "bump.md must describe the `[Unreleased] -> [X.Y.Z] - YYYY-MM-DD` promotion (AC7)"
+    );
+}
+
+/// AC8: explicit-confirmation gate on push + GitHub Release.
+#[test]
+fn bump_md_gates_push_and_release_on_confirmation() {
+    let content = read_bump_md();
+    // The Phase 7 header must call itself OPTIONAL.
+    assert!(
+        content.contains("Phase 7") && content.contains("OPTIONAL"),
+        "bump.md Phase 7 must be marked OPTIONAL — #3468 AC8 requires an \
+         explicit confirmation gate before push + gh release create"
+    );
+    // The skill must invoke `gh release create` (or describe doing so).
+    assert!(
+        content.contains("gh release create"),
+        "bump.md must document `gh release create` as the GitHub Release step (AC8)"
+    );
+    // The skill must NOT publish to package registries — load-bearing
+    // safety guardrail per the issue's "out of scope" list.
+    assert!(
+        content.contains("npm publish") || content.contains("not run `npm publish`"),
+        "bump.md must explicitly disclaim registry publication (npm publish, cargo publish, twine upload)"
+    );
+}
+
+/// Acceptance check that the skill self-identifies as the generic
+/// counterpart to `/loom:release` (so consumers reading it understand
+/// when to reach for it vs. when `/loom:release` would apply).
+#[test]
+fn bump_md_distinguishes_itself_from_loom_release() {
+    let content = read_bump_md();
+    assert!(
+        content.contains("/loom:release"),
+        "bump.md must reference `/loom:release` so readers understand the \
+         relationship between the generic and the Loom-internal skill"
+    );
+    assert!(
+        content.contains("generic"),
+        "bump.md must describe itself as the generic counterpart"
+    );
+    assert!(
+        content.contains("Loom-internal") || content.contains("Loom itself"),
+        "bump.md must describe `/loom:release` as Loom-internal so consumers \
+         understand it is not shipped to them"
+    );
+}
+
+/// AC2 by transitive contract: the skill file must NOT be listed in
+/// `defaults/.loom-internal.list` (that would prevent it from shipping
+/// to consumers — the opposite of AC1).
+#[test]
+fn bump_md_is_not_in_loom_internal_skip_list() {
+    let skip_list_path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../defaults/.loom-internal.list");
+    let skip_list = fs::read_to_string(&skip_list_path).unwrap_or_else(|e| {
+        panic!("defaults/.loom-internal.list not found at {}: {e}", skip_list_path.display());
+    });
+    for line in skip_list.lines() {
+        // Strip comments and trim.
+        let entry = match line.split_once('#') {
+            Some((before, _)) => before.trim(),
+            None => line.trim(),
+        };
+        if entry.is_empty() {
+            continue;
+        }
+        assert_ne!(
+            entry, ".claude/commands/loom/bump.md",
+            "bump.md must NOT be on defaults/.loom-internal.list — it is the \
+             generic skill that ships to consumers. #3468 AC1 requires this."
+        );
+    }
+}

--- a/scripts/test-installer.sh
+++ b/scripts/test-installer.sh
@@ -1638,6 +1638,14 @@ else
     if $sibling_ok; then
       pass "Consumer install includes builder.md, judge.md, curator.md (skip-list is narrow)"
     fi
+
+    # #3468 AC1: the new generic /loom:bump skill must ship to consumers.
+    # (It is the public counterpart to the Loom-internal /loom:release skill.)
+    if [[ -f "$INTERNAL_REPO/.claude/commands/loom/bump.md" ]]; then
+      pass "AC1 (#3468): /loom:bump skill ships to consumers"
+    else
+      fail "AC1 (#3468): .claude/commands/loom/bump.md missing from consumer install"
+    fi
   else
     fail "loom-daemon init failed against fresh consumer repo $INTERNAL_REPO"
   fi


### PR DESCRIPTION
## Summary

- Add `defaults/.claude/commands/loom/bump.md` — a new generic version-bump skill (`/loom:bump`) that ships to consumer repos, the public counterpart to the Loom-internal `/loom:release` skill (which stays in `.loom-internal.list`).
- Add doc-lint test `loom-daemon/tests/bump_md_doc_lint.rs` (8 tests, all passing) that locks in the skill contract: 8 phases, 7 detection sources, parameterized `scripts/version.sh` template, CHANGELOG handling, explicit-confirmation push gate, distinction from `/loom:release`, and absence from `.loom-internal.list`.
- Extend Test 52 in `scripts/test-installer.sh` with a positive assertion that `bump.md` ships to consumers (alongside the existing assertions that `release.md` does not).

The skill is a markdown recipe for the runtime LLM. "Detection" happens at skill-execution time — the prose tells the LLM to scan for `package.json`, `*/package.json`, `Cargo.toml` (+ workspace members + `Cargo.lock`), `pyproject.toml` (both PEP-621 and Poetry shapes), `setup.py`/`setup.cfg`, top-level shell scripts matching `^VERSION="X.Y.Z"`, and `CLAUDE.md`/`README.md` matching `**Version**: X.Y.Z`.

**First run** generates a tailored `scripts/version.sh` mirroring Loom's own bump/set/check/show subcommand structure (template embedded in the skill). **Subsequent runs** short-circuit to the generated script — so the operator may safely customize it without the skill silently overwriting their edits.

**No changes to** `/loom:release`, `defaults/.loom-internal.list`, `scripts/version.sh` (Loom's own), or `loom-daemon/src/init/*`. The skip-list mechanism from #3464 / #3467 stays intact: `release.md` continues to be excluded from consumer installs; the new `bump.md` flows through naturally because it is NOT on the skip list.

## Per-AC status

| AC | Status | Notes |
|----|--------|-------|
| AC1 — `/loom:bump` ships to consumers | PASS | Smoke-test verified; Test 52 extended with new positive assertion |
| AC2 — `/loom:release` still works for Loom | PASS | `release.md` untouched; smoke-test confirms it still doesn't ship to consumers |
| AC3 — Detection for npm+cargo monorepo (Loom shape) | PASS | Phase 1 prose enumerates `package.json`, `*/package.json`, `Cargo.toml`, `Cargo.lock` |
| AC4 — Detection for shell `VERSION="X.Y.Z"` (rjwalters/clean shape) | PASS | Phase 1 includes the regex `^VERSION="[0-9]+\.[0-9]+\.[0-9]+"` |
| AC5 — Detection for `pyproject.toml` `[project].version` (and Poetry) | PASS | Phase 1 covers both PEP-621 and Poetry shapes |
| AC6 — First run generates project-tailored `scripts/version.sh` | PASS | Phase 5 ships a parameterized template; doc-lint asserts presence |
| AC7 — CHANGELOG handling with `## [Unreleased]` scaffold offer | PASS | Phase 2 + Phase 4 cover this; doc-lint asserts Keep-a-Changelog references |
| AC8 — Optional push + `gh release create` gated on explicit confirmation | PASS | Phase 7 marked OPTIONAL; explicit `(y/N)` prompt; no registry publication |

## Smoke-test output

After `bash install.sh --quick --yes "$FIXTURE"` into a fresh git repo:

```
Checking bump.md (must exist):
-rw-r--r--  1 rwalters  staff  17525 Jun  5 15:51 .../bump.md
Checking release.md (must NOT exist):
ls: .../release.md: No such file or directory
```

Both conditions hold: `bump.md` ships; `release.md` is still skipped by the skip-list mechanism.

## Test commands run

| Command | Result |
|---------|--------|
| `cargo test -p loom-daemon --test bump_md_doc_lint` | 8 passed, 0 failed |
| `cargo test -p loom-daemon --test sweep_md_doc_lint` (regression) | 4 passed, 0 failed |
| `cargo test -p loom-daemon --test sweep_md_stage_minus_one_doc_lint` (regression) | 9 passed, 0 failed |
| `cargo test -p loom-daemon --test spawn_loop_deprecation_doc_lint` (regression) | 4 passed, 0 failed |
| `cargo test -p loom-daemon --lib` | 341 passed, 0 failed |
| `bash scripts/test-installer.sh` | 83 passed, 0 failed (was 82 + new AC1 #3468 assertion) |
| `cargo clippy --package loom-daemon --package loom-api -- -D warnings <allows>` | clean |
| `shellcheck scripts/test-installer.sh` | no new warnings (pre-existing only) |

## LOC summary

| Change | Lines |
|--------|-------|
| `defaults/.claude/commands/loom/bump.md` (new skill) | 436 markdown |
| `loom-daemon/tests/bump_md_doc_lint.rs` (new doc-lint) | 254 Rust |
| `scripts/test-installer.sh` (Test 52 extension) | +8 bash |

## Scope decisions

- **`scripts/version.sh` template structure**: mirrored Loom's own 1:1 (function names `get_version`, `get_version_from_file`, `check_versions`, `bump_version`, `set_version`, `do_tag`; subcommand surface `bump|set|check|show`). Per-shape writer sections embedded as commented examples that the skill's runtime LLM substitutes in based on what detection found.
- **Detection scope**: covered all three reference shapes (Loom-style monorepo, rjwalters/clean shape, Python) plus `setup.py`/`setup.cfg` for legacy Python and `*/package.json` for general npm workspaces. Did not include Java/Maven, Go modules, etc. — out of scope per curator's "Out of scope" list.
- **CHANGELOG drafting**: kept human-in-the-loop. Skill explicitly disclaims auto-generation from commits ("Do NOT auto-generate CHANGELOG from commits" appears as a hard constraint in Phase 4 and the closing Notes).
- **Registry publication**: explicitly disclaimed. The skill text reads "Do NOT publish to package registries. ... Tag + GitHub Release only." (doc-lint asserts this).
- **`defaults/optional/version.sh.template`**: curator's note suggested optionally shipping a separate template file there. I chose to embed the template inside `bump.md` (in a fenced code block) rather than a sidecar file, because (a) the skill is the only consumer of the template, (b) the LLM needs to substitute placeholders at runtime anyway, (c) one fewer file keeps the install footprint smaller, and (d) the doc-lint asserts the template structure remains intact within the skill. If a future iteration wants a sidecar template that operators can edit independently of the skill, that is a follow-up.
- **No `scripts/test-loom-bump.sh` fixture tests**: the curator's AC5 ("Detection contract is testable in isolation") suggested either an inline shell helper inside the generated `version.sh` or a separate fixture test script. Since the detection runs in the LLM's head (the skill is prose), the contract is locked in via the Rust doc-lint that asserts each detection source is named in the markdown. A future PR can add fixture-driven tests once we see real consumer adoption patterns.

## Files

- New: `defaults/.claude/commands/loom/bump.md`
- New: `loom-daemon/tests/bump_md_doc_lint.rs`
- Modified: `scripts/test-installer.sh` (Test 52 +8 lines)

## References

Closes #3468
Builds on #3464 / #3467 (the skip-list mechanism that excludes `release.md` from consumer installs but lets `bump.md` flow through).

🤖 Generated with [Claude Code](https://claude.com/claude-code)