### PR TITLE
fix(init): regression-guard .loom/docs/ + embed commit/build time in loom-daemon --version (#3470)

### DIFF
--- a/loom-daemon/build.rs
+++ b/loom-daemon/build.rs
@@ -1,0 +1,71 @@
+//! Build script: capture git commit + build timestamp for `--version`.
+//!
+//! Motivated by issue #3470 (and the broader #3287 Option D recommendation):
+//! when a consumer install fails with a "MISSING: <file>" error from the
+//! post-install metadata verification, the most common proximate cause is a
+//! stale `target/release/loom-daemon` binary built from a source tree that
+//! predates the fix for that missing file. Today `loom-daemon --version`
+//! emits only `loom-daemon 0.10.0`, which is identical across rebuilds of
+//! the same crate version — operators cannot tell at a glance whether the
+//! binary on disk matches `HEAD`.
+//!
+//! This script embeds the short HEAD hash and an ISO-8601 build timestamp
+//! into the binary via `cargo:rustc-env`. They are surfaced in `main.rs`
+//! via `env!("LOOM_DAEMON_GIT_COMMIT")` / `env!("LOOM_DAEMON_BUILD_TIME")`
+//! and folded into the clap `--version` long string.
+//!
+//! Both fall back to a placeholder when the build host lacks `git` (e.g.,
+//! building from a tarball release) or `date` — we never want missing
+//! tooling to break the build. The fallback is loud enough to be obvious
+//! in operator output (e.g., `loom-daemon 0.10.0 (commit unknown)`).
+
+use std::process::Command;
+
+fn main() {
+    // Re-run if `git` HEAD moves or the index changes. This is best-effort:
+    // if `.git` is absent (release tarball), we skip and use the fallback.
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+    println!("cargo:rerun-if-changed=../.git/index");
+    // Always re-run when build.rs itself changes.
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let commit = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|out| {
+            if out.status.success() {
+                String::from_utf8(out.stdout)
+                    .ok()
+                    .map(|s| s.trim().to_string())
+            } else {
+                None
+            }
+        })
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=LOOM_DAEMON_GIT_COMMIT={commit}");
+
+    // Build timestamp in ISO-8601 UTC. We use `date -u +%FT%TZ` for
+    // portability across macOS and Linux without pulling chrono into the
+    // build-script dependency graph (build scripts compile separately and
+    // the extra dep noticeably slows clean builds).
+    let timestamp = Command::new("date")
+        .args(["-u", "+%Y-%m-%dT%H:%M:%SZ"])
+        .output()
+        .ok()
+        .and_then(|out| {
+            if out.status.success() {
+                String::from_utf8(out.stdout)
+                    .ok()
+                    .map(|s| s.trim().to_string())
+            } else {
+                None
+            }
+        })
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=LOOM_DAEMON_BUILD_TIME={timestamp}");
+}

--- a/loom-daemon/src/init/mod.rs
+++ b/loom-daemon/src/init/mod.rs
@@ -1013,6 +1013,152 @@ mod tests {
     }
 
     #[test]
+    fn test_docs_subdirectory_copied_on_fresh_install() {
+        // Regression-guard for issue #3470: the `.loom/docs/` managed
+        // directory (containing static reference docs like
+        // `ci-integration.md` from issue #3333) must be copied during
+        // initialization. The line-169 `sync_managed_dir(..., "docs", ...)`
+        // call already exists on main — this test prevents the entry from
+        // silently being deleted or refactored away in the future, which
+        // would re-introduce the v0.10 field failure where consumers got
+        // `MISSING: .loom/docs/ci-integration.md` from the post-install
+        // metadata verification (the #3287 safety net).
+        let temp_dir = TempDir::new().unwrap();
+        let workspace = temp_dir.path();
+        let defaults = temp_dir.path().join("defaults");
+
+        fs::create_dir(workspace.join(".git")).unwrap();
+
+        // Create defaults mirroring the real shape, including `.loom/docs/`
+        // with the file that triggered the original failure.
+        fs::create_dir_all(defaults.join("roles")).unwrap();
+        fs::create_dir_all(defaults.join("docs")).unwrap();
+        fs::write(defaults.join("config.json"), "{}").unwrap();
+        fs::write(defaults.join("roles").join("builder.md"), "builder").unwrap();
+        fs::write(
+            defaults.join("docs").join("ci-integration.md"),
+            "# CI Integration\n\nStatic reference documentation.",
+        )
+        .unwrap();
+        // A second doc, to confirm we copy the whole directory and not
+        // just one named file.
+        fs::write(
+            defaults.join("docs").join("troubleshooting.md"),
+            "# Troubleshooting\n\nMore docs.",
+        )
+        .unwrap();
+
+        let result =
+            initialize_workspace(workspace.to_str().unwrap(), defaults.to_str().unwrap(), false);
+
+        assert!(result.is_ok(), "init failed: {:?}", result.err());
+        let report = result.unwrap();
+
+        // The `.loom/docs/` directory must exist on disk post-init.
+        let docs_dir = workspace.join(".loom").join("docs");
+        assert!(docs_dir.exists(), ".loom/docs/ directory should exist");
+        assert!(docs_dir.is_dir(), ".loom/docs/ should be a directory");
+
+        // The specific file the field failure flagged must be present.
+        let ci_md = docs_dir.join("ci-integration.md");
+        assert!(
+            ci_md.exists(),
+            ".loom/docs/ci-integration.md should exist (this is the file the \
+             v0.10 install regression reported as MISSING in issue #3470)"
+        );
+        let content = fs::read_to_string(&ci_md).unwrap();
+        assert_eq!(content, "# CI Integration\n\nStatic reference documentation.");
+
+        // The sibling doc must also be present (whole-directory copy).
+        let troubleshooting = docs_dir.join("troubleshooting.md");
+        assert!(troubleshooting.exists(), ".loom/docs/troubleshooting.md should exist");
+
+        // Report bookkeeping: both docs files should be tracked as added.
+        assert!(
+            report
+                .added
+                .contains(&".loom/docs/ci-integration.md".to_string()),
+            "Report should include docs/ci-integration.md, got: {:?}",
+            report.added
+        );
+        assert!(
+            report
+                .added
+                .contains(&".loom/docs/troubleshooting.md".to_string()),
+            "Report should include docs/troubleshooting.md, got: {:?}",
+            report.added
+        );
+
+        // No verification failures: the fail-fast assertion inside
+        // sync_managed_dir (the #3220/#3287 safety net) should be quiet,
+        // and the post-copy `verify_all_copied_files` walk over the docs
+        // dir should not produce any content mismatches.
+        assert!(
+            report.verification_failures.is_empty(),
+            "Expected no verification failures, got: {:?}",
+            report.verification_failures
+        );
+    }
+
+    #[test]
+    fn test_docs_subdirectory_restored_on_reinstall() {
+        // Reinstall analog of test_docs_subdirectory_copied_on_fresh_install:
+        // the docs dir must be cleaned and re-copied so stale files are
+        // removed and updated content lands. This pins the #3470 fix on
+        // the reinstall path (which is the path the field failure
+        // exercised — Studio was upgrading v0.9 -> v0.10).
+        let temp_dir = TempDir::new().unwrap();
+        let workspace = temp_dir.path();
+        let defaults = temp_dir.path().join("defaults");
+
+        fs::create_dir(workspace.join(".git")).unwrap();
+
+        // Defaults with updated docs.
+        fs::create_dir_all(defaults.join("roles")).unwrap();
+        fs::create_dir_all(defaults.join("docs")).unwrap();
+        fs::write(defaults.join("config.json"), "{}").unwrap();
+        fs::write(defaults.join("roles").join("builder.md"), "builder").unwrap();
+        fs::write(defaults.join("docs").join("ci-integration.md"), "# CI Integration v2").unwrap();
+
+        // Pre-existing install with stale content + a stale file.
+        fs::create_dir_all(workspace.join(".loom").join("docs")).unwrap();
+        fs::write(
+            workspace
+                .join(".loom")
+                .join("docs")
+                .join("ci-integration.md"),
+            "# CI Integration v1 (old)",
+        )
+        .unwrap();
+        fs::write(workspace.join(".loom").join("docs").join("obsolete-doc.md"), "stale").unwrap();
+
+        let result =
+            initialize_workspace(workspace.to_str().unwrap(), defaults.to_str().unwrap(), false);
+
+        assert!(result.is_ok(), "reinstall failed: {:?}", result.err());
+        let report = result.unwrap();
+
+        // Updated file has new content.
+        let ci_md = workspace
+            .join(".loom")
+            .join("docs")
+            .join("ci-integration.md");
+        let content = fs::read_to_string(&ci_md).unwrap();
+        assert_eq!(content, "# CI Integration v2");
+
+        // Stale file removed.
+        let obsolete = workspace.join(".loom").join("docs").join("obsolete-doc.md");
+        assert!(!obsolete.exists(), "Stale docs file should be removed on reinstall");
+        assert!(
+            report
+                .removed
+                .contains(&".loom/docs/obsolete-doc.md".to_string()),
+            "Report should list obsolete-doc.md as removed, got: {:?}",
+            report.removed
+        );
+    }
+
+    #[test]
     fn test_filter_preserved_from_verification_failures_removes_preserved() {
         // Files preserved by merge strategy must not appear as verification failures
         // (this is the regression case from issue #3218).

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -20,7 +20,21 @@ use std::sync::{Arc, Mutex};
 #[derive(Parser)]
 #[command(name = "loom-daemon")]
 #[command(about = "Loom daemon for AI-powered development orchestration", long_about = None)]
-#[command(version = env!("CARGO_PKG_VERSION"))]
+// Embed git commit + build timestamp alongside the crate version so
+// `--version` distinguishes rebuilds of the same release. Motivated by
+// issue #3470: stale daemon binaries are otherwise indistinguishable from
+// fresh ones and cause hard-to-diagnose install regressions (#3287 class).
+// `LOOM_DAEMON_GIT_COMMIT` and `LOOM_DAEMON_BUILD_TIME` are populated by
+// `build.rs`; both fall back to "unknown" when the build host lacks the
+// tooling, which is loud but harmless.
+#[command(version = concat!(
+    env!("CARGO_PKG_VERSION"),
+    " (commit ",
+    env!("LOOM_DAEMON_GIT_COMMIT"),
+    ", built ",
+    env!("LOOM_DAEMON_BUILD_TIME"),
+    ")"
+))]
 struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,


### PR DESCRIPTION
## Summary

Closes #3470.

- **Mandatory fix**: adds `test_docs_subdirectory_copied_on_fresh_install` and `test_docs_subdirectory_restored_on_reinstall` in `loom-daemon/src/init/mod.rs`, mirroring the existing `scripts/lib/` tests. These regression-guard the `.loom/docs/` symptom against future deletion or refactoring of the line-169 `sync_managed_dir(..., "docs", ...)` entry.
- **Optional observability (#3287 Option D)**: adds `loom-daemon/build.rs` that embeds the git short HEAD + ISO-8601 build timestamp into the binary, surfaced via `--version`. The install script already logs `loom-daemon --version` at install start (line 911 of `install-loom.sh`), so this automatically makes stale-binary diagnosis trivial.

## Root cause analysis

The issue's primary hypothesis ("`sync_managed_dir` has a hardcoded subdir list that omits docs") **does not match the code on origin/main**. Verified by reading `loom-daemon/src/init/mod.rs`:

- Line 169 already calls `sync_managed_dir(&defaults, &loom_path, "docs", is_reinstall, &mut report)?;` with a comment explicitly referencing #3333.
- Line 350 already includes `"docs"` in the `verify_all_copied_files` walk.
- `find_missing_files` (line 281) is fully recursive — tests `test_find_missing_files_detects_missing_subdirectory_file` (line 1205) and `test_find_missing_files_detects_entire_missing_subdir` (line 1229) prove subdirectory files are caught.
- `copy_dir_with_report` in `file_ops.rs` is also fully recursive.

The post-copy safety net (`find_missing_files`) is sound. I could not find a real bug in `sync_managed_dir` / `find_missing_files` / `collect_missing_files` that would let a missing destination file slip past the assertion at lines 263-271.

**The most plausible proximate cause of the field failure** is the #3287 Option D class: a stale `target/release/loom-daemon` binary that pre-dated the line-169 addition. `pnpm daemon:build` (or its inlined `cargo build --release` equivalent at line 902 of `install-loom.sh`) returned a binary cached from before the docs entry landed. The new `--version` commit/timestamp embedding makes this trivially diagnosable next time: the install log line `loom-daemon binary: loom-daemon 0.10.0 (commit <sha>, built <ts>)` will distinguish a binary built against the docs-aware commit from one built earlier.

I **could not reproduce** the field failure against a clean rebuild on this branch. The new tests pass; the existing `scripts/lib/` analogs continue to pass. If a future reproduction reveals a real soundness bug in the copy/verify path, that should be filed as a follow-up — the test infrastructure added here will detect it.

## Changes

- `loom-daemon/src/init/mod.rs` — two new tests: `test_docs_subdirectory_copied_on_fresh_install` (fresh install pins `.loom/docs/ci-integration.md` exists, report bookkeeping correct, no verification failures) and `test_docs_subdirectory_restored_on_reinstall` (reinstall pins stale-file cleanup + content update).
- `loom-daemon/build.rs` — new file. Runs `git rev-parse --short HEAD` and `date -u +%FT%TZ`, emits `LOOM_DAEMON_GIT_COMMIT` and `LOOM_DAEMON_BUILD_TIME` via `cargo:rustc-env`. Both fall back to `"unknown"` when the tooling is absent (release-tarball builds). No new build-script dependencies — `chrono` was deliberately not added to keep clean-build times short.
- `loom-daemon/src/main.rs` — updates `#[command(version = ...)]` to use `concat!` to fold the new env vars into the `--version` string. Output now reads e.g. `loom-daemon 0.10.0 (commit e241f3ce, built 2026-06-06T02:19:04Z)`.

## Test plan

- [x] `cargo test --lib init::` — all 82 init tests pass (was 80, added 2).
- [x] `cargo test --lib` — all 343 daemon library tests pass.
- [x] Manual: `cargo build --package loom-daemon --release && ./target/release/loom-daemon --version` prints `loom-daemon 0.10.0 (commit <sha>, built <iso8601>)`.
- [ ] Judge / human: run `./scripts/install-loom.sh --yes <target>` against a v0.9 install and confirm `.loom/docs/ci-integration.md` now lands cleanly with a fresh binary built from this branch.

### Pre-existing test note

One integration test (`test_destroy_terminal` in `tests/integration_basic.rs`) failed when run in the full suite but **passes when run in isolation**. The assertion `Should have no terminals after destroy` saw 6 leftover terminals — symptoms of cross-test state bleed from `test_list_terminals` / `test_create_terminal`. This is unrelated to the changes in this PR (which do not touch terminal management). Worth filing as a separate flaky-test issue.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>