### PR TITLE
fix(clean): loom-clean silently skipped ~100% of stale branches due to 3 bugs

### DIFF
--- a/loom-tools/src/loom_tools/clean.py
+++ b/loom-tools/src/loom_tools/clean.py
@@ -48,6 +48,7 @@ class CleanupStats:
     skipped_editable: int = 0
     cleaned_branches: int = 0
     kept_branches: int = 0
+    errored_branches: int = 0
     killed_tmux: int = 0
     cleaned_config_dirs: int = 0
     errors: int = 0
@@ -609,16 +610,141 @@ def prune_orphaned_worktrees(
         log_warning(f"Error pruning worktrees: {e}")
 
 
+def _current_branch(repo_root: pathlib.Path) -> str | None:
+    """Return the currently checked-out branch name (or None if detached/error).
+
+    Used by :func:`clean_branches` to avoid deleting the branch the operator
+    is sitting on.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "symbolic-ref", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+            check=False,
+        )
+        if result.returncode != 0:
+            return None
+        name = result.stdout.strip()
+        return name or None
+    except Exception:
+        return None
+
+
+def _checked_out_branches(repo_root: pathlib.Path) -> set[str]:
+    """Return the set of branch names currently checked out by ANY worktree.
+
+    ``git branch -D`` refuses to delete a branch that's checked out in
+    another worktree, but it's nicer to surface that as a "protected"
+    rule rather than letting the delete fail noisily. Reads
+    ``git worktree list --porcelain`` and harvests every ``branch
+    refs/heads/<name>`` line.
+    """
+    checked_out: set[str] = set()
+    try:
+        result = subprocess.run(
+            ["git", "worktree", "list", "--porcelain"],
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+            check=False,
+        )
+        if result.returncode != 0:
+            return checked_out
+        prefix = "branch refs/heads/"
+        for line in result.stdout.splitlines():
+            line = line.rstrip("\n")
+            if line.startswith(prefix):
+                checked_out.add(line[len(prefix) :].strip())
+    except Exception:
+        pass
+    return checked_out
+
+
+def _default_branch(repo_root: pathlib.Path) -> str | None:
+    """Return the upstream default branch (e.g. ``main``) or None.
+
+    Reads ``refs/remotes/origin/HEAD`` which is set by ``git clone`` / by
+    ``git remote set-head origin --auto``. Falls back to None when the ref
+    isn't configured (older clones, custom remotes) — the caller treats
+    ``main`` as a hard-coded safe default in that case.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "symbolic-ref", "refs/remotes/origin/HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+            check=False,
+        )
+        if result.returncode != 0:
+            return None
+        # Output looks like "refs/remotes/origin/main" -> strip the prefix.
+        ref = result.stdout.strip()
+        prefix = "refs/remotes/origin/"
+        if ref.startswith(prefix):
+            return ref[len(prefix) :]
+        return None
+    except Exception:
+        return None
+
+
+def _remote_branch_exists(repo_root: pathlib.Path, branch: str) -> bool:
+    """Check whether ``refs/remotes/origin/<branch>`` exists locally.
+
+    Pure local probe — no network, no API. Used by :func:`clean_branches`
+    to detect branches whose remote tracking ref has been pruned (typically
+    after the upstream branch was deleted post-merge). Such branches are
+    "stale" regardless of their naming pattern.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "show-ref", "--verify", "--quiet", f"refs/remotes/origin/{branch}"],
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+            check=False,
+        )
+        return result.returncode == 0
+    except Exception:
+        # Fail closed: if we can't probe, claim the remote exists so we
+        # don't delete a branch on a transient git error.
+        return True
+
+
 def clean_branches(
     repo_root: pathlib.Path,
     stats: CleanupStats,
     dry_run: bool = False,
     force: bool = False,
 ) -> None:
-    """Clean up branches for closed issues."""
+    """Clean up local branches that are stale or for closed issues.
+
+    Two-pass strategy (see #3471 for the history — the previous single-pass
+    implementation silently skipped ~100% of stale branches because the
+    name filter only matched ``feature/issue-*``):
+
+    1. **Generic stale-detection pass.** For every local branch (except
+       the default branch and the currently-checked-out branch), check
+       whether ``refs/remotes/origin/<branch>`` still exists. If the
+       remote ref has been pruned (typical after upstream deletes the
+       branch post-merge), the branch is stale and is deleted. This pass
+       is pattern-agnostic — it catches ``pr-*``, ``fix/*``, ``feat/*``,
+       ``docs/*``, and bare-named branches that the old filter missed.
+
+    2. **Issue-state pass.** Branches that *do* still have a remote and
+       match the ``feature/issue-*`` naming convention are then probed
+       against the forge: if the corresponding issue is CLOSED, the
+       branch is deleted. This catches the "issue closed but PR still
+       open" edge case (rare, but worth keeping).
+    """
     try:
+        # Use --format to avoid the "* "/"+ " marker noise that ``git
+        # branch`` adds for the current/linked-worktree branches. Parsing
+        # those markers manually is fragile (see #3471 history).
         result = subprocess.run(
-            ["git", "branch"],
+            ["git", "branch", "--format=%(refname:short)"],
             capture_output=True,
             text=True,
             cwd=repo_root,
@@ -627,31 +753,89 @@ def clean_branches(
     except Exception:
         branches = []
 
-    feature_branches = []
+    normalized: list[str] = []
     for branch in branches:
-        branch = branch.strip().lstrip("* ")
-        if branch.startswith(NamingConventions.BRANCH_PREFIX):
-            feature_branches.append(branch)
+        branch = branch.strip()
+        if branch:
+            normalized.append(branch)
 
-    if not feature_branches:
-        log_success("No feature branches found")
+    if not normalized:
+        log_success("No local branches found")
         return
 
-    for branch in feature_branches:
-        # Extract issue number
+    # Branches we must never touch:
+    #   - the default branch (``origin/HEAD`` target),
+    #   - ``main`` as a hard fallback when the default isn't configured,
+    #   - the currently-checked-out branch (deleting your own checkout
+    #     is a bad time),
+    #   - any branch checked out in another worktree (git refuses to
+    #     delete those anyway; surfacing them as "protected" keeps the
+    #     log clean).
+    default = _default_branch(repo_root)
+    current = _current_branch(repo_root)
+    protected: set[str] = {"main"}
+    if default:
+        protected.add(default)
+    if current:
+        protected.add(current)
+    protected |= _checked_out_branches(repo_root)
+
+    # ------------------------------------------------------------------
+    # Pass 1: generic stale-detection via remote-ref existence probe.
+    # ------------------------------------------------------------------
+    issue_pass_candidates: list[str] = []
+    for branch in normalized:
+        if branch in protected:
+            continue
+
+        if not _remote_branch_exists(repo_root, branch):
+            # Remote ref is gone -> branch is stale (upstream deleted it,
+            # typically post-merge). Delete regardless of naming pattern.
+            print(f"  Stale (no origin/{branch}) - deleting {branch}")
+            if dry_run:
+                stats.cleaned_branches += 1
+                continue
+            try:
+                subprocess.run(
+                    ["git", "branch", "-D", branch],
+                    capture_output=True,
+                    text=True,
+                    cwd=repo_root,
+                    check=True,
+                )
+                stats.cleaned_branches += 1
+            except Exception:
+                stats.errors += 1
+        else:
+            # Remote still exists -> defer to issue-state pass below.
+            issue_pass_candidates.append(branch)
+
+    # ------------------------------------------------------------------
+    # Pass 2: issue-state probe for ``feature/issue-*`` branches whose
+    # remote still exists. Catches "issue closed but PR still open" cases.
+    # ------------------------------------------------------------------
+    for branch in issue_pass_candidates:
+        if not branch.startswith(NamingConventions.BRANCH_PREFIX):
+            continue
+
         issue_num = NamingConventions.issue_from_branch(branch)
         if issue_num is None:
             continue
 
-        # Check issue status
+        # Check issue status. Pin gh to the repo root so we don't
+        # accidentally inherit the cwd of an unrelated worktree (#3471).
         try:
             result = gh_run(
                 ["issue", "view", str(issue_num), "--json", "state", "--jq", ".state"],
                 check=False,
+                cwd=repo_root,
             )
-            status = result.stdout.strip() if result.returncode == 0 else "NOT_FOUND"
-        except Exception:
+            exit_code = result.returncode
+            status = result.stdout.strip() if exit_code == 0 else "NOT_FOUND"
+        except Exception as exc:
+            exit_code = -1
             status = "NOT_FOUND"
+            log_warning(f"  gh issue view raised for #{issue_num} ({branch}): {exc}")
 
         if status == "CLOSED":
             print(f"  Issue #{issue_num} CLOSED - deleting {branch}")
@@ -672,6 +856,15 @@ def clean_branches(
         elif status == "OPEN":
             print(f"  Issue #{issue_num} OPEN - keeping {branch}")
             stats.kept_branches += 1
+        else:
+            # Don't silently fall through. Surface the gh failure so the
+            # operator can investigate (auth, repo mismatch, network, etc.)
+            # and keep the branch (state is unknown — fail closed).
+            log_warning(
+                f"  Could not probe issue #{issue_num} for {branch}: "
+                f"gh exit code {exit_code}"
+            )
+            stats.errored_branches += 1
 
 
 def _list_loom_tmux_sessions() -> list[str]:
@@ -1542,12 +1735,14 @@ def print_summary(stats: CleanupStats, dry_run: bool = False, safe_mode: bool = 
         print(f"  Skipped (grace period): {stats.skipped_grace}")
         print(f"  Skipped (uncommitted): {stats.skipped_uncommitted}")
 
-    if stats.cleaned_branches > 0 or stats.kept_branches > 0:
+    if stats.cleaned_branches > 0 or stats.kept_branches > 0 or stats.errored_branches > 0:
         if dry_run:
             print(f"  Would delete: {stats.cleaned_branches} branch(es)")
         else:
             print(f"  Deleted: {stats.cleaned_branches} branch(es)")
         print(f"  Kept: {stats.kept_branches} branch(es)")
+        if stats.errored_branches > 0:
+            print(f"  Errored (gh probe failed): {stats.errored_branches} branch(es)")
 
     if stats.killed_tmux > 0:
         if dry_run:

--- a/loom-tools/tests/test_clean.py
+++ b/loom-tools/tests/test_clean.py
@@ -1,0 +1,321 @@
+"""Tests for ``loom_tools.clean.clean_branches``.
+
+These cover the three regressions diagnosed in issue #3471:
+
+1. **Pattern broadening** -- ``clean_branches`` must also delete branches
+   whose ``origin/<branch>`` ref no longer exists, regardless of naming
+   pattern (the old filter only matched ``feature/issue-*``).
+2. **gh pinned to repo root** -- ``gh issue view`` must be called with
+   ``cwd=repo_root`` so an unrelated worktree's cwd never leaks in.
+3. **Surface gh failures** -- when the ``gh`` probe fails, the branch is
+   counted under ``errored_branches`` and a warning is logged. The
+   branch must NOT be deleted (issue state is unknown -> fail closed).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+from unittest import mock
+
+import pytest
+
+from loom_tools.clean import CleanupStats, clean_branches
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_completed(stdout: str = "", returncode: int = 0) -> subprocess.CompletedProcess[str]:
+    """Build a ``CompletedProcess`` stub for ``subprocess.run`` patches."""
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr="")
+
+
+class _SubprocessRouter:
+    """Route ``subprocess.run`` calls through per-command handlers.
+
+    Tests register handlers keyed off a tuple of leading argv tokens
+    (e.g. ``("git", "branch")``). Unrecognized calls raise to surface
+    test gaps rather than silently passing.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[list[str], pathlib.Path | None]] = []
+        self.deleted_branches: list[str] = []
+        self._handlers: list[
+            tuple[tuple[str, ...], "callable[[list[str], pathlib.Path | None], subprocess.CompletedProcess[str]]"]
+        ] = []
+
+    def register(
+        self,
+        prefix: tuple[str, ...],
+        handler,
+    ) -> None:
+        self._handlers.append((prefix, handler))
+
+    def __call__(
+        self,
+        cmd: list[str],
+        *args,
+        **kwargs,
+    ) -> subprocess.CompletedProcess[str]:
+        cwd = kwargs.get("cwd")
+        self.calls.append((list(cmd), cwd))
+        # Track branch deletions for assertion convenience.
+        if (
+            len(cmd) >= 3
+            and cmd[0] == "git"
+            and cmd[1] == "branch"
+            and cmd[2] == "-D"
+        ):
+            self.deleted_branches.append(cmd[3])
+        for prefix, handler in self._handlers:
+            if tuple(cmd[: len(prefix)]) == prefix:
+                result = handler(cmd, cwd)
+                if kwargs.get("check") and result.returncode != 0:
+                    raise subprocess.CalledProcessError(result.returncode, cmd)
+                return result
+        raise AssertionError(f"Unexpected subprocess.run call: {cmd!r}")
+
+
+# ---------------------------------------------------------------------------
+# Regression: surface gh failures (Fix #3)
+# ---------------------------------------------------------------------------
+
+
+class TestGhFailureSurfaced:
+    """When ``gh issue view`` exits non-zero, we must:
+    - bump ``stats.errored_branches`` (not silently skip),
+    - emit a ``log_warning`` so the operator sees it,
+    - NOT delete the branch (state is unknown).
+    """
+
+    def test_gh_nonzero_exit_logs_warning_and_bumps_errored(
+        self,
+        tmp_path: pathlib.Path,
+        caplog: pytest.LogCaptureFixture,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        repo_root = tmp_path
+        router = _SubprocessRouter()
+
+        # `git branch` -> emit one feature/issue-1 branch whose origin ref
+        # exists (so we exercise the issue-state pass).
+        router.register(
+            ("git", "branch", "--format=%(refname:short)"),
+            lambda cmd, cwd: _make_completed(stdout="feature/issue-1\n"),
+        )
+        # Default-branch + current-branch probes -> emit something sane.
+        router.register(
+            ("git", "symbolic-ref", "--short", "HEAD"),
+            lambda cmd, cwd: _make_completed(stdout="main\n"),
+        )
+        router.register(
+            ("git", "symbolic-ref", "refs/remotes/origin/HEAD"),
+            lambda cmd, cwd: _make_completed(stdout="refs/remotes/origin/main\n"),
+        )
+        router.register(
+            ("git", "worktree", "list", "--porcelain"),
+            lambda cmd, cwd: _make_completed(stdout=""),
+        )
+        # `git show-ref --verify` -> remote exists (exit 0).
+        router.register(
+            ("git", "show-ref", "--verify"),
+            lambda cmd, cwd: _make_completed(returncode=0),
+        )
+
+        # Mock gh_run to return a non-zero exit (network failure, auth
+        # failure, repo mismatch, etc.). This is the regression bait --
+        # the old code silently fell through.
+        def fake_gh_run(args, *, check=False, cwd=None):  # noqa: ARG001
+            return _make_completed(stdout="", returncode=1)
+
+        with mock.patch("loom_tools.clean.subprocess.run", router), mock.patch(
+            "loom_tools.clean.gh_run", side_effect=fake_gh_run
+        ):
+            stats = CleanupStats()
+            # caplog only captures stdlib `logging`; the loom_tools log
+            # helpers print to stderr. Capture stderr too.
+            clean_branches(repo_root, stats, dry_run=False)
+
+        captured = capsys.readouterr()
+
+        # 1. errored counter bumped.
+        assert stats.errored_branches == 1, (
+            f"expected errored_branches=1, got {stats.errored_branches}"
+        )
+        # 2. branch NOT deleted (state unknown -> fail closed).
+        assert "feature/issue-1" not in router.deleted_branches
+        assert stats.cleaned_branches == 0
+        # 3. A warning was emitted to stderr that mentions the issue.
+        assert (
+            "#1" in captured.err and "feature/issue-1" in captured.err
+        ), f"expected warning mentioning #1 and the branch, got stderr: {captured.err!r}"
+
+
+# ---------------------------------------------------------------------------
+# Regression: pattern broadening via remote-ref check (Fix #1)
+# ---------------------------------------------------------------------------
+
+
+class TestStaleRemoteRefDetection:
+    """Branches whose ``origin/<branch>`` no longer exists are stale."""
+
+    def test_pr_branch_with_missing_remote_is_deleted(
+        self,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        repo_root = tmp_path
+        router = _SubprocessRouter()
+
+        router.register(
+            ("git", "branch", "--format=%(refname:short)"),
+            lambda cmd, cwd: _make_completed(stdout="pr-3472\nmain\n"),
+        )
+        router.register(
+            ("git", "symbolic-ref", "--short", "HEAD"),
+            lambda cmd, cwd: _make_completed(stdout="main\n"),
+        )
+        router.register(
+            ("git", "symbolic-ref", "refs/remotes/origin/HEAD"),
+            lambda cmd, cwd: _make_completed(stdout="refs/remotes/origin/main\n"),
+        )
+        router.register(
+            ("git", "worktree", "list", "--porcelain"),
+            lambda cmd, cwd: _make_completed(stdout=""),
+        )
+
+        # `git show-ref --verify refs/remotes/origin/<branch>`:
+        # - for `pr-3472` -> not found (exit 1, stale).
+        # - for `main` -> protected anyway, won't be probed.
+        def show_ref(cmd: list[str], cwd: pathlib.Path | None) -> subprocess.CompletedProcess[str]:
+            ref = cmd[-1]
+            if ref == "refs/remotes/origin/pr-3472":
+                return _make_completed(returncode=1)
+            return _make_completed(returncode=0)
+
+        router.register(("git", "show-ref", "--verify"), show_ref)
+
+        # `git branch -D pr-3472` -> success.
+        router.register(
+            ("git", "branch", "-D"),
+            lambda cmd, cwd: _make_completed(returncode=0),
+        )
+
+        # gh_run must NOT be called for the pattern-broadening pass since
+        # `pr-3472` doesn't match `feature/issue-*` AND its remote is
+        # already gone, so it's deleted in pass 1.
+        gh_run_calls = []
+
+        def fake_gh_run(args, *, check=False, cwd=None):
+            gh_run_calls.append((list(args), cwd))
+            return _make_completed(stdout="OPEN", returncode=0)
+
+        with mock.patch("loom_tools.clean.subprocess.run", router), mock.patch(
+            "loom_tools.clean.gh_run", side_effect=fake_gh_run
+        ):
+            stats = CleanupStats()
+            clean_branches(repo_root, stats, dry_run=False)
+
+        assert "pr-3472" in router.deleted_branches
+        assert "main" not in router.deleted_branches
+        assert stats.cleaned_branches == 1
+        # No gh call needed -- pass-1 catches it.
+        assert gh_run_calls == []
+
+    def test_main_and_current_branch_are_never_deleted(
+        self,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        """Even if the remote-ref probe fails, ``main`` and the current
+        branch must be preserved."""
+        repo_root = tmp_path
+        router = _SubprocessRouter()
+
+        router.register(
+            ("git", "branch", "--format=%(refname:short)"),
+            lambda cmd, cwd: _make_completed(stdout="feature/issue-3471\nmain\n"),
+        )
+        router.register(
+            ("git", "symbolic-ref", "--short", "HEAD"),
+            lambda cmd, cwd: _make_completed(stdout="feature/issue-3471\n"),
+        )
+        router.register(
+            ("git", "symbolic-ref", "refs/remotes/origin/HEAD"),
+            lambda cmd, cwd: _make_completed(stdout="refs/remotes/origin/main\n"),
+        )
+        router.register(
+            ("git", "worktree", "list", "--porcelain"),
+            lambda cmd, cwd: _make_completed(stdout=""),
+        )
+        # show-ref always says "not found" -- protected list must save us.
+        router.register(
+            ("git", "show-ref", "--verify"),
+            lambda cmd, cwd: _make_completed(returncode=1),
+        )
+
+        # `git branch -D` should never be reached.
+        router.register(
+            ("git", "branch", "-D"),
+            lambda cmd, cwd: _make_completed(returncode=0),
+        )
+
+        with mock.patch("loom_tools.clean.subprocess.run", router), mock.patch(
+            "loom_tools.clean.gh_run", side_effect=AssertionError("gh_run should not be called")
+        ):
+            stats = CleanupStats()
+            clean_branches(repo_root, stats, dry_run=False)
+
+        assert router.deleted_branches == [], (
+            f"expected no deletions, got {router.deleted_branches!r}"
+        )
+        assert stats.cleaned_branches == 0
+        assert stats.errored_branches == 0
+
+
+# ---------------------------------------------------------------------------
+# Regression: gh pinned to repo root (Fix #2)
+# ---------------------------------------------------------------------------
+
+
+class TestGhPinnedToRepoRoot:
+    """`gh issue view` must be invoked with ``cwd=repo_root``."""
+
+    def test_gh_called_with_repo_root_cwd(self, tmp_path: pathlib.Path) -> None:
+        repo_root = tmp_path
+        router = _SubprocessRouter()
+
+        router.register(
+            ("git", "branch", "--format=%(refname:short)"),
+            lambda cmd, cwd: _make_completed(stdout="feature/issue-42\n"),
+        )
+        router.register(
+            ("git", "symbolic-ref", "--short", "HEAD"),
+            lambda cmd, cwd: _make_completed(stdout="main\n"),
+        )
+        router.register(
+            ("git", "symbolic-ref", "refs/remotes/origin/HEAD"),
+            lambda cmd, cwd: _make_completed(stdout="refs/remotes/origin/main\n"),
+        )
+        router.register(
+            ("git", "show-ref", "--verify"),
+            lambda cmd, cwd: _make_completed(returncode=0),
+        )
+
+        captured_cwd: list[pathlib.Path | None] = []
+
+        def fake_gh_run(args, *, check=False, cwd=None):
+            captured_cwd.append(cwd)
+            return _make_completed(stdout="OPEN", returncode=0)
+
+        with mock.patch("loom_tools.clean.subprocess.run", router), mock.patch(
+            "loom_tools.clean.gh_run", side_effect=fake_gh_run
+        ):
+            stats = CleanupStats()
+            clean_branches(repo_root, stats, dry_run=False)
+
+        assert captured_cwd == [repo_root], (
+            f"expected gh_run cwd={repo_root!r}, got {captured_cwd!r}"
+        )


### PR DESCRIPTION
## Summary

`loom-clean --branches-only` was silently skipping the vast majority of stale local branches. Issue #3471 diagnosed three independent bugs in `loom_tools.clean.clean_branches` that compounded:

1. **Naming-pattern filter too narrow.** The pre-filter only matched `feature/issue-*`, so `pr-*`, `fix/*`, `feat/*`, `docs/*`, and bare-named branches were never even considered. This is by far the largest contributor — on a real repo the operator who filed this had ~109 stale branches that the old code never looked at.
2. **`gh` inherited an arbitrary `cwd`.** The `gh issue view` call did not pass `cwd=repo_root`, so an unrelated worktree's directory could leak in and bias which repo `gh` resolved against.
3. **Probe failures silently swallowed.** When `gh` exited non-zero, the code fell through with no print, no counter, no `log_warning`. Stats lacked an `errored_branches` field, so the operator had no signal that branches were left behind because of probe failure rather than legitimately-open issues.

## Three bugs addressed

* **Fix #1 — generic remote-existence pass.** Before the existing `feature/issue-*` flow, `clean_branches` now runs `git show-ref --verify refs/remotes/origin/<branch>` for every local branch. Missing remote ref means stale, so delete regardless of naming pattern. Cheap, pure-local, no forge calls. Catches every naming style.
* **Fix #2 — pin `gh` to `repo_root`.** The `gh_run([...issue, view...])` call now passes `cwd=repo_root`.
* **Fix #3 — surface `gh` failures.** Added `CleanupStats.errored_branches: int = 0`. Non-zero `gh` exits now log a `log_warning("Could not probe issue #N for <branch>: gh exit code X")` and bump that counter. The summary printer renders it. The branch is **not** deleted (state unknown — fail closed).

**Bonus robustness fix:** the old `git branch` parser stripped `* `/`+ ` markers fragilely with `.lstrip("* ")`, which left `+` markers (for branches checked out in another worktree) attached to branch names. Switched to `git branch --format=%(refname:short)` to get clean names, and the protected-branch set now includes every branch checked out by *any* worktree.

Protected branches that are never deleted: the default branch (`origin/HEAD` target), `main` (hard fallback), the currently-checked-out branch, and any branch checked out in another worktree.

## Test plan

- [x] Added `loom-tools/tests/test_clean.py` with four unit tests:
  - `TestGhFailureSurfaced::test_gh_nonzero_exit_logs_warning_and_bumps_errored` — exercises the silent-skip regression. Mocks `gh_run` to return exit 1, asserts `errored_branches > 0`, `cleaned_branches == 0`, and a warning was emitted to stderr mentioning the issue number and branch.
  - `TestStaleRemoteRefDetection::test_pr_branch_with_missing_remote_is_deleted` — covers the pattern-broadening fix: a `pr-3472` branch with no `origin/pr-3472` is deleted without any `gh` call.
  - `TestStaleRemoteRefDetection::test_main_and_current_branch_are_never_deleted` — protected list saves us even when `show-ref` says "missing" for everything.
  - `TestGhPinnedToRepoRoot::test_gh_called_with_repo_root_cwd` — captures the `cwd=` kwarg and asserts it equals `repo_root`.
- [x] All 4 new tests pass.
- [x] Pre-existing test suite: 1689 passed, 26 skipped. The one pre-existing failure (`test_role_in_claude_commands`) is unrelated to this change (verified on `main`).
- [x] Smoke test on the actual repo: `loom-clean --branches-only --dry-run` went from "Kept: 0 branch(es)" to identifying 8 stale `pr-*`/`feat/*` branches plus 1 errored gh probe. The currently-checked-out `feature/issue-3471` and the linked-worktree `pr-3472` were correctly preserved.

Closes #3471