### PR TITLE
feat(model): Phase 1 model-selection plumbing + static per-role mapping

### DIFF
--- a/.github/workflows/loom-auditor.yml
+++ b/.github/workflows/loom-auditor.yml
@@ -35,4 +35,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: claude -p "/auditor" --dangerously-skip-permissions
+        # Pinned model ID per the role mapping (issue #3477, Phase 1): cron
+        # support roles are predictable, cost-sensitive load, so they pin an
+        # exact ID rather than an alias. Bump deliberately on lineup changes.
+        run: claude -p "/auditor" --model claude-sonnet-4-6 --dangerously-skip-permissions

--- a/.github/workflows/loom-champion.yml
+++ b/.github/workflows/loom-champion.yml
@@ -35,4 +35,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: claude -p "/champion" --dangerously-skip-permissions
+        # Pinned model ID per the role mapping (issue #3477, Phase 1): cron
+        # support roles are predictable, cost-sensitive load, so they pin an
+        # exact ID rather than an alias. Bump deliberately on lineup changes.
+        run: claude -p "/champion" --model claude-sonnet-4-6 --dangerously-skip-permissions

--- a/.github/workflows/loom-curator.yml
+++ b/.github/workflows/loom-curator.yml
@@ -36,4 +36,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: claude -p "/curator" --dangerously-skip-permissions
+        # Pinned model ID per the role mapping (issue #3477, Phase 1): cron
+        # support roles are predictable, cost-sensitive load, so they pin an
+        # exact ID rather than an alias. Bump deliberately on lineup changes.
+        run: claude -p "/curator" --model claude-sonnet-4-6 --dangerously-skip-permissions

--- a/.github/workflows/loom-guide.yml
+++ b/.github/workflows/loom-guide.yml
@@ -35,4 +35,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: claude -p "/guide" --dangerously-skip-permissions
+        # Pinned model ID per the role mapping (issue #3477, Phase 1): cron
+        # support roles are predictable, cost-sensitive load, so they pin an
+        # exact ID rather than an alias. Bump deliberately on lineup changes.
+        run: claude -p "/guide" --model claude-sonnet-4-6 --dangerously-skip-permissions

--- a/.github/workflows/loom-judge.yml
+++ b/.github/workflows/loom-judge.yml
@@ -36,4 +36,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: claude -p "/judge" --dangerously-skip-permissions
+        # Pinned model ID per the role mapping (issue #3477, Phase 1): cron
+        # support roles are predictable, cost-sensitive load, so they pin an
+        # exact ID rather than an alias. Bump deliberately on lineup changes.
+        run: claude -p "/judge" --model claude-opus-4-8 --dangerously-skip-permissions

--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -130,6 +130,12 @@ Inputs:
   A only fully implements `Issue`; `PrSet` is rejected by the registry.
 - `idempotency_key` (optional) — dedup key. Running sweeps with the same
   key return the existing `sweep_id` without spawning a new child.
+- `model` (optional, issue #3477 Phase 1) — Claude model for the spawned
+  child, as an alias (`sonnet`, `opus`, `haiku`) or a pinned ID
+  (`claude-sonnet-4-6`). Forwarded as `--model <value>` on the
+  `spawn-claude.sh` argv. When omitted (or empty), NO `--model` flag is
+  emitted and the child inherits the session/CLI default. The field is
+  `#[serde(default)]` on the wire, so pre-#3477 clients remain compatible.
 
 ### `list_sweeps` (Phase A)
 

--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -287,6 +287,22 @@ Concretely, when this skill says "dispatch builders for the wave", that means: i
 
 If a future maintainer is tempted to "simplify" by replacing the wave-loop with parallel `/shepherd` calls: don't. Read #3289, then read this section again.
 
+### Model selection for subagent dispatch (issue #3477, Phase 1)
+
+Every role subagent dispatched by this skill (`loom-curator`, `loom-builder`, `loom-judge`, `loom-doctor`) gets its model resolved through a fixed precedence chain. Resolve once per role at dispatch time and pass the result via the Task tool's `model` parameter:
+
+1. **Explicit dispatch param** — a model explicitly requested by the operator for this sweep (e.g., an operator instruction in the invoking prompt).
+2. **Workspace override** — `.loom/config.json` → the `terminals[]` entry whose `roleConfig.roleFile` matches the role (e.g., `builder.md`) → its optional `roleConfig.model` field.
+3. **Role default** — `.loom/roles/<role>.json` → `suggestedModel` (ships as an alias: `sonnet`, `opus`, or `haiku`).
+4. **Session default** — if none of the above resolves (or resolves to an empty string), **omit the `model` parameter entirely** so the subagent inherits the parent session's model. Never pass `model: ""`.
+
+Rules:
+
+- Aliases (`sonnet`/`opus`/`haiku`) and pinned IDs (`claude-sonnet-4-6`) are both valid at every tier. Shipped role JSONs use aliases; workspaces that need determinism pin exact IDs in `roleConfig.model`.
+- A retry of the same role for the same issue (e.g., Builder re-dispatch after a mid-builder kill, or a second Judge pass after Doctor) **reuses the same resolved model**. Attempt-based escalation is strategy B of #3477 and explicitly out of scope here.
+- Resolution failures are soft: if a role JSON is missing or unparseable, fall through to the next tier silently. Model selection must never block a sweep.
+- The daemon path has its own equivalent: `mcp__loom__dispatch_sweep` accepts an optional `model` param which the daemon forwards to the spawned child as `claude --model <value>`. When delegating to the daemon (Stage -1 `use_daemon`), you MAY pass a resolved model; when omitted, the child inherits the spawning environment's default — the daemon emits no `--model` flag at all.
+
 ### Other constraints
 
 - **Do NOT write to `.loom/daemon-state.json`.** That file is owned by the standalone daemon. `/sweep` runs independently and must not race with the daemon on shepherd-slot bookkeeping. Reading `daemon-state.json` for situational awareness is fine; writing is not.

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -661,11 +661,16 @@ See [`.loom/docs/daemon-reference.md`](.loom/docs/daemon-reference.md) for the w
 
 ### Model Selection Strategy
 
-Loom subagents inherit the model of the parent conversation. Agent definitions do not specify a `model:` field in their frontmatter, so the model used depends on how the parent session was launched. This avoids per-model quota bucket exhaustion where a hardcoded model assignment causes rate limit failures even when other model quotas are available.
+Model selection is a first-class orchestration concern (issue #3477, Phase 1). Each worker's model is resolved through a fixed precedence chain — highest first:
 
-Each role ships JSON metadata with a `suggestedModel` field that records the historically-validated model for that role. The metadata is informational only — Claude Code subagent routing still inherits from the parent conversation.
+1. **Explicit dispatch param** — `mcp__loom__dispatch_sweep`'s optional `model` argument (daemon path), an explicit `--model` flag passed to `spawn-claude.sh` / `claude-wrapper.sh`, or an operator-requested model for an in-session sweep.
+2. **Workspace override** — `.loom/config.json` → `terminals[].roleConfig.model` (optional). Pin exact IDs here (e.g., `claude-sonnet-4-6`) when your workspace needs deterministic cost/behavior.
+3. **Role default** — `.loom/roles/<role>.json` → `suggestedModel` (ships as an alias). The `/loom:sweep` skill passes the resolved model to role subagents via the Task tool's `model` parameter.
+4. **Session default** — when nothing above resolves, NO `--model` flag (and no Task `model` param) is emitted at all, and the worker inherits the parent session/CLI default. This is the zero-config behavior: nothing configured means nothing changes.
 
-**Suggested models by role**:
+The spawn plumbing also honors a `LOOM_MODEL` environment variable (`spawn-claude.sh`, `claude-wrapper.sh`): it is injected as `--model <value>` unless an explicit `--model` is already present in the args. Retries inside `claude-wrapper.sh` always reuse the same model — re-consulting policy on retry (attempt-based escalation) is deliberately out of scope for Phase 1.
+
+**Suggested models by role** (`suggestedModel`, live as the role-default tier):
 
 | Role | Model | Rationale |
 |------|-------|-----------|
@@ -679,11 +684,32 @@ Each role ships JSON metadata with a `suggestedModel` field that records the his
 | Guide | `sonnet` | Triage is systematic |
 | Driver | `sonnet` | General-purpose default |
 
-**Valid model values**: `haiku`, `sonnet`, `opus`
+**Valid model values**: aliases (`haiku`, `sonnet`, `opus`) or pinned model IDs (e.g., `claude-sonnet-4-6`).
 
 - **haiku**: Fast, cheap - for simple status checks and monitoring
 - **sonnet**: Balanced - for structured tasks with clear criteria
 - **opus**: Most capable - for complex reasoning and implementation
+
+**Aliases vs pinned IDs**: shipped role JSONs use aliases so defaults stay sensible across model releases with zero maintenance. The GitHub Actions cron workflows (`.github/workflows/loom-*.yml`) are the exception — they pin exact IDs because scheduled support roles are predictable, cost-sensitive load and a stale pin is visible and cheap to bump in the consuming repo.
+
+**Workspace override example** (`.loom/config.json`):
+
+```json
+{
+  "terminals": [
+    {
+      "id": "terminal-1",
+      "name": "Builder",
+      "role": "claude-code-worker",
+      "roleConfig": {
+        "workerType": "claude",
+        "roleFile": "builder.md",
+        "model": "claude-sonnet-4-6"
+      }
+    }
+  ]
+}
+```
 
 ### Custom Roles
 

--- a/defaults/scripts/claude-wrapper.sh
+++ b/defaults/scripts/claude-wrapper.sh
@@ -27,6 +27,13 @@
 #   LOOM_AUTH_CACHE_TTL    - Auth cache TTL in seconds (default: 120)
 #   LOOM_AUTH_CACHE_STALE_LOCK_THRESHOLD - Stale lock cleanup threshold in seconds (default: 90)
 #   LOOM_AUTH_CACHE_LOCK_WAIT - Max time to wait for lock holder in seconds (default: 60)
+#   LOOM_MODEL             - Model to pass as `claude --model <value>` (issue
+#                            #3477). An explicit `--model` in the wrapper args
+#                            always wins. The flag is appended once before the
+#                            retry loop, so every retry attempt reuses the SAME
+#                            model (re-consulting policy on retry is strategy B
+#                            of #3477 and intentionally out of scope). When
+#                            neither is set, NO --model flag is emitted.
 
 set -euo pipefail
 
@@ -1582,6 +1589,30 @@ main() {
         log_info "Stop signal already present - exiting without starting"
         _write_exit_sidecar 0
         exit 0
+    fi
+
+    # Model selection (issue #3477, Phase 1).
+    # Precedence: explicit `--model` in args > LOOM_MODEL env > nothing
+    # (session/CLI default — no --model flag emitted at all). The flag is
+    # appended ONCE here, before run_with_retry, so all retry attempts
+    # invoke `claude "$@"` with the same model (retries never re-consult
+    # model policy — that is strategy B of #3477, out of scope).
+    local _has_model_arg=false
+    for arg in "$@"; do
+        case "$arg" in
+            --model|--model=*)
+                _has_model_arg=true
+                break
+                ;;
+        esac
+    done
+    if [[ -n "${LOOM_MODEL:-}" ]]; then
+        if [[ "${_has_model_arg}" == "false" ]]; then
+            set -- "$@" --model "${LOOM_MODEL}"
+            log_info "Model: ${LOOM_MODEL} (from LOOM_MODEL)"
+        else
+            log_info "Explicit --model in args wins over LOOM_MODEL='${LOOM_MODEL}'"
+        fi
     fi
 
     # Run Claude with retry logic

--- a/defaults/scripts/spawn-claude.sh
+++ b/defaults/scripts/spawn-claude.sh
@@ -33,6 +33,11 @@
 #   LOOM_SPAWN_NO_EXPORT   If set, skip selection (caller already exported a
 #                          token). Useful for testing the dispatch path.
 #   LOOM_PYTHON            Override the python interpreter (default: python3).
+#   LOOM_MODEL             Model to pass as `claude --model <value>` (issue
+#                          #3477). Lowest-priority tier: an explicit `--model`
+#                          in the passthrough args always wins. When neither
+#                          is set, NO --model flag is emitted and the session/
+#                          CLI default is preserved.
 
 set -euo pipefail
 
@@ -106,6 +111,27 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+# --- Model selection (issue #3477, Phase 1) ---
+# Precedence: explicit `--model` in the passthrough args > LOOM_MODEL env >
+# nothing (session/CLI default — no --model flag emitted at all).
+if [[ -n "${LOOM_MODEL:-}" ]]; then
+    _has_model_arg=false
+    for _arg in ${PASSTHROUGH_ARGS[@]+"${PASSTHROUGH_ARGS[@]}"}; do
+        case "$_arg" in
+            --model|--model=*)
+                _has_model_arg=true
+                break
+                ;;
+        esac
+    done
+    if [[ "$_has_model_arg" == "false" ]]; then
+        PASSTHROUGH_ARGS+=(--model "$LOOM_MODEL")
+        log_info "spawn-claude: using model '$LOOM_MODEL' (from LOOM_MODEL)"
+    else
+        log_info "spawn-claude: explicit --model in args wins over LOOM_MODEL='$LOOM_MODEL'"
+    fi
+fi
 
 # --- Locate loom_tools package source ---
 # Search order:

--- a/defaults/scripts/tests/test-spawn-claude.sh
+++ b/defaults/scripts/tests/test-spawn-claude.sh
@@ -196,6 +196,86 @@ set -e
 assert_eq "78" "$exit_code" "missing tokens exits 78 (EX_CONFIG)"
 
 # ============================================================
+# Section 3: model selection (issue #3477, Phase 1)
+#
+# Precedence chain at the spawn layer, all four observable cases:
+#   1. explicit --model arg beats LOOM_MODEL env
+#   2. --model=value form also beats LOOM_MODEL env
+#   3. LOOM_MODEL alone produces --model in the exec'd args
+#   4. no env + no arg produces NO --model at all (session default
+#      preserved — the zero-behavior-change acceptance criterion)
+# ============================================================
+
+echo ""
+echo "Testing spawn-claude.sh model selection (#3477)..."
+
+# Case 3: LOOM_MODEL env produces --model in args
+output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
+    LOOM_MODEL="claude-sonnet-4-6" \
+    "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
+assert_contains "stub-claude args=-p ping --model claude-sonnet-4-6" "$output" \
+    "LOOM_MODEL env injects --model into claude args"
+
+# Case 1: explicit --model arg wins over LOOM_MODEL env
+output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
+    LOOM_MODEL="claude-sonnet-4-6" \
+    "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" --model claude-opus-4-8 2>&1 || true)
+assert_contains "stub-claude args=-p ping --model claude-opus-4-8" "$output" \
+    "explicit --model arg wins over LOOM_MODEL env"
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ "$output" != *"claude-sonnet-4-6"* ]] || [[ "$output" == *"wins over LOOM_MODEL"* ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: LOOM_MODEL value is not injected when explicit --model present"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: LOOM_MODEL value is not injected when explicit --model present"
+    echo "    In: '$output'"
+fi
+
+# Case 2: --model=value form also suppresses LOOM_MODEL injection
+output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
+    LOOM_MODEL="claude-sonnet-4-6" \
+    "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" --model=claude-opus-4-8 2>&1 || true)
+assert_contains "stub-claude args=-p ping --model=claude-opus-4-8" "$output" \
+    "--model=value form wins over LOOM_MODEL env"
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ "$output" != *"--model claude-sonnet-4-6"* ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: --model=value suppresses LOOM_MODEL injection"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: --model=value suppresses LOOM_MODEL injection"
+    echo "    In: '$output'"
+fi
+
+# Case 4 (zero-behavior-change criterion): no env + no arg => no --model
+output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
+    "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ "$output" == *"stub-claude args=-p ping"* && "$output" != *"--model"* ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: no LOOM_MODEL + no --model arg emits NO --model (session default preserved)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: no LOOM_MODEL + no --model arg emits NO --model (session default preserved)"
+    echo "    In: '$output'"
+fi
+
+# Empty LOOM_MODEL is treated as unset — no --model emitted
+output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
+    LOOM_MODEL="" \
+    "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ "$output" == *"stub-claude args=-p ping"* && "$output" != *"--model"* ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: empty LOOM_MODEL emits NO --model"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: empty LOOM_MODEL emits NO --model"
+    echo "    In: '$output'"
+fi
+
+# ============================================================
 # Summary
 # ============================================================
 

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -768,11 +768,12 @@ fn handle_request(
         Request::DispatchSweep {
             kind,
             idempotency_key,
+            model,
         } => {
             let mut sr = sweep_registry
                 .lock()
                 .expect("Sweep registry mutex poisoned");
-            match sr.dispatch(&kind, idempotency_key) {
+            match sr.dispatch(&kind, idempotency_key, model.as_deref()) {
                 Ok(outcome) => Response::SweepDispatched {
                     sweep_id: outcome.sweep_id,
                     pid: outcome.pid,
@@ -1118,6 +1119,7 @@ exit 0
             Request::DispatchSweep {
                 kind: SweepKind::Issue(2024),
                 idempotency_key: None,
+                model: None,
             },
             &tm,
             &db,
@@ -1160,6 +1162,7 @@ exit 0
             Request::DispatchSweep {
                 kind: SweepKind::PrSet(vec![100, 200]),
                 idempotency_key: None,
+                model: None,
             },
             &tm,
             &db,
@@ -1174,6 +1177,67 @@ exit 0
                 );
             }
             other => panic!("Expected Error, got: {other:?}"),
+        }
+    }
+
+    // ===== DispatchSweep serde compat (Issue #3477, Phase 1) =====
+
+    /// A wire payload WITHOUT the `model` field (the pre-#3477 client shape)
+    /// must deserialize with `model == None` — `#[serde(default)]` keeps
+    /// existing clients compatible.
+    #[test]
+    fn test_dispatch_sweep_deserializes_without_model_field() {
+        let json = r#"{"type":"DispatchSweep","payload":{"kind":{"type":"Issue","value":42},"idempotency_key":null}}"#;
+        let request: Request = serde_json::from_str(json).expect("pre-#3477 payload must parse");
+        match request {
+            Request::DispatchSweep {
+                kind,
+                idempotency_key,
+                model,
+            } => {
+                assert!(matches!(kind, SweepKind::Issue(42)));
+                assert!(idempotency_key.is_none());
+                assert!(model.is_none(), "absent model field must default to None");
+            }
+            other => panic!("Expected DispatchSweep, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_dispatch_sweep_serde_round_trip_with_model() {
+        let request = Request::DispatchSweep {
+            kind: SweepKind::Issue(7),
+            idempotency_key: Some("key-B".to_string()),
+            model: Some("claude-sonnet-4-6".to_string()),
+        };
+        let json = serde_json::to_string(&request).expect("serialize");
+        let back: Request = serde_json::from_str(&json).expect("deserialize");
+        match back {
+            Request::DispatchSweep {
+                kind,
+                idempotency_key,
+                model,
+            } => {
+                assert!(matches!(kind, SweepKind::Issue(7)));
+                assert_eq!(idempotency_key.as_deref(), Some("key-B"));
+                assert_eq!(model.as_deref(), Some("claude-sonnet-4-6"));
+            }
+            other => panic!("Expected DispatchSweep, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_dispatch_sweep_serde_round_trip_without_model() {
+        let request = Request::DispatchSweep {
+            kind: SweepKind::Issue(8),
+            idempotency_key: None,
+            model: None,
+        };
+        let json = serde_json::to_string(&request).expect("serialize");
+        let back: Request = serde_json::from_str(&json).expect("deserialize");
+        match back {
+            Request::DispatchSweep { model, .. } => assert!(model.is_none()),
+            other => panic!("Expected DispatchSweep, got: {other:?}"),
         }
     }
 
@@ -1296,6 +1360,7 @@ exit 0
             Request::DispatchSweep {
                 kind: SweepKind::Issue(444),
                 idempotency_key: None,
+                model: None,
             },
             &tm,
             &db,

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -277,10 +277,16 @@ impl SweepRegistry {
     /// Dispatch a sweep. See module docs.
     ///
     /// On idempotency hit returns the existing entry with `was_new = false`.
+    ///
+    /// `model` (issue #3477): when `Some` and non-empty, the spawned child
+    /// receives `--model <value>` appended to the `spawn-claude.sh` argv.
+    /// When `None`, no `--model` flag is emitted at all — the session/CLI
+    /// default is preserved end-to-end.
     pub fn dispatch(
         &mut self,
         kind: &SweepKind,
         idempotency_key: Option<String>,
+        model: Option<&str>,
     ) -> Result<DispatchOutcome> {
         // 1. Idempotency dedup against Running entries.
         if let Some(ref key) = idempotency_key {
@@ -324,7 +330,7 @@ impl SweepRegistry {
         // 5. Compute the log path and spawn the child.
         let log_path = self.compute_log_path(issue_number);
         let (pid, token_name) = self
-            .spawn_child(issue_number, &log_path, &sweep_id)
+            .spawn_child(issue_number, &log_path, &sweep_id, model)
             .context("failed to spawn sweep child")?;
 
         // 6. Record the entry.
@@ -489,7 +495,13 @@ impl SweepRegistry {
             .join(format!("sweep-issue-{issue}.log"))
     }
 
-    fn spawn_child(&self, issue: u32, log_path: &Path, sweep_id: &str) -> Result<(u32, String)> {
+    fn spawn_child(
+        &self,
+        issue: u32,
+        log_path: &Path,
+        sweep_id: &str,
+        model: Option<&str>,
+    ) -> Result<(u32, String)> {
         let spawn_bin = self.config.resolve_spawn_bin()?;
 
         // Ensure log dir exists.
@@ -524,9 +536,17 @@ impl SweepRegistry {
 
         let prompt = format!("/loom:sweep {issue}");
         let mut cmd = Command::new(&spawn_bin);
-        cmd.arg("-p")
-            .arg(&prompt)
-            .env("LOOM_TERMINAL_ID", format!("daemon-{sweep_id}"))
+        cmd.arg("-p").arg(&prompt);
+        // Model selection (issue #3477, Phase 1): the dispatch-param tier of
+        // the precedence chain. Appended as an explicit `--model` arg (which
+        // beats any ambient LOOM_MODEL env inside spawn-claude.sh). Empty
+        // strings are treated as unset — `--model ""` must never be emitted.
+        if let Some(m) = model {
+            if !m.is_empty() {
+                cmd.arg("--model").arg(m);
+            }
+        }
+        cmd.env("LOOM_TERMINAL_ID", format!("daemon-{sweep_id}"))
             // Always pin LOOM_WORKSPACE to the registry's configured root so
             // spawn-claude.sh resolves `.loom/tokens/` from the same place
             // the daemon thinks the workspace is — never inheriting an
@@ -1217,7 +1237,7 @@ exit 0
         let (mut registry, record_log) = fixture_registry(dir.path());
 
         let outcome = registry
-            .dispatch(&SweepKind::Issue(42), None)
+            .dispatch(&SweepKind::Issue(42), None, None)
             .expect("dispatch should succeed");
 
         assert!(outcome.was_new);
@@ -1250,10 +1270,65 @@ exit 0
             recorded.contains("argv: -p /loom:sweep 42"),
             "expected argv in recorded log; got: {recorded}"
         );
+        // Issue #3477 zero-behavior-change criterion: with model=None the
+        // spawned command must NOT receive a --model flag at all.
+        assert!(
+            !recorded.contains("--model"),
+            "model=None must not emit --model; got: {recorded}"
+        );
 
         // The lock dir should exist while Running.
         let lock = dir.path().join(".loom").join("locks").join("issue-42");
         assert!(lock.exists(), "expected lock dir at {}", lock.display());
+    }
+
+    /// Issue #3477 (Phase 1): a `model` dispatch param threads through to
+    /// the spawn command as an explicit `--model <value>` argument.
+    #[test]
+    #[serial]
+    fn dispatch_with_model_appends_model_arg() {
+        let dir = tempdir().unwrap();
+        let (mut registry, record_log) = fixture_registry(dir.path());
+
+        let outcome = registry
+            .dispatch(&SweepKind::Issue(43), None, Some("claude-sonnet-4-6"))
+            .expect("dispatch should succeed");
+
+        let needle = format!("LOOM_TERMINAL_ID=daemon-{}", outcome.sweep_id);
+        assert!(
+            wait_for_contents(&record_log, &needle, 10000),
+            "fake spawn-claude.sh did not finish writing within 10s"
+        );
+        let recorded = std::fs::read_to_string(&record_log).unwrap();
+        assert!(
+            recorded.contains("argv: -p /loom:sweep 43 --model claude-sonnet-4-6"),
+            "expected --model in argv; got: {recorded}"
+        );
+    }
+
+    /// Issue #3477: an empty-string model is treated as unset — `--model ""`
+    /// must never be emitted (acceptance criterion: no flag at all, not an
+    /// empty flag).
+    #[test]
+    #[serial]
+    fn dispatch_with_empty_model_emits_no_model_flag() {
+        let dir = tempdir().unwrap();
+        let (mut registry, record_log) = fixture_registry(dir.path());
+
+        let outcome = registry
+            .dispatch(&SweepKind::Issue(44), None, Some(""))
+            .expect("dispatch should succeed");
+
+        let needle = format!("LOOM_TERMINAL_ID=daemon-{}", outcome.sweep_id);
+        assert!(
+            wait_for_contents(&record_log, &needle, 10000),
+            "fake spawn-claude.sh did not finish writing within 10s"
+        );
+        let recorded = std::fs::read_to_string(&record_log).unwrap();
+        assert!(
+            !recorded.contains("--model"),
+            "empty model must not emit --model; got: {recorded}"
+        );
     }
 
     #[test]
@@ -1262,10 +1337,10 @@ exit 0
         let dir = tempdir().unwrap();
         let (mut registry, _record_log) = fixture_registry(dir.path());
 
-        let first = registry.dispatch(&SweepKind::Issue(7), None);
+        let first = registry.dispatch(&SweepKind::Issue(7), None, None);
         assert!(first.is_ok());
 
-        let second = registry.dispatch(&SweepKind::Issue(7), None);
+        let second = registry.dispatch(&SweepKind::Issue(7), None, None);
         assert!(second.is_err(), "second dispatch for issue #7 should fail (lock collision)");
         let err = second.unwrap_err().to_string();
         assert!(err.contains("lock collision"), "expected lock collision error; got: {err}");
@@ -1278,7 +1353,7 @@ exit 0
         let (mut registry, _record_log) = fixture_registry(dir.path());
 
         let first = registry
-            .dispatch(&SweepKind::Issue(99), Some("key-A".to_string()))
+            .dispatch(&SweepKind::Issue(99), Some("key-A".to_string()), None)
             .unwrap();
         assert!(first.was_new);
 
@@ -1286,7 +1361,7 @@ exit 0
         // Issue #99 is the same kind, but we don't need a different issue —
         // the dedup is purely on the idempotency key.
         let second = registry
-            .dispatch(&SweepKind::Issue(99), Some("key-A".to_string()))
+            .dispatch(&SweepKind::Issue(99), Some("key-A".to_string()), None)
             .unwrap();
         assert!(!second.was_new);
         assert_eq!(first.sweep_id, second.sweep_id);
@@ -1297,7 +1372,7 @@ exit 0
         let dir = tempdir().unwrap();
         let (mut registry, _record_log) = fixture_registry(dir.path());
 
-        let outcome = registry.dispatch(&SweepKind::PrSet(vec![1, 2, 3]), None);
+        let outcome = registry.dispatch(&SweepKind::PrSet(vec![1, 2, 3]), None, None);
         assert!(outcome.is_err());
         assert!(outcome
             .unwrap_err()
@@ -1311,7 +1386,9 @@ exit 0
         let (mut registry, _record_log) = fixture_registry(dir.path());
 
         // Dispatch and then poke an entry into Exited state directly.
-        let outcome = registry.dispatch(&SweepKind::Issue(11), None).unwrap();
+        let outcome = registry
+            .dispatch(&SweepKind::Issue(11), None, None)
+            .unwrap();
         let entry = registry.entries.get_mut(&outcome.sweep_id).unwrap();
         entry.state = SweepState::Exited {
             code: Some(0),
@@ -1678,7 +1755,9 @@ exit 0
         config.skip_label_flip = true;
         let mut registry = SweepRegistry::new(config);
 
-        let outcome = registry.dispatch(&SweepKind::Issue(123), None).unwrap();
+        let outcome = registry
+            .dispatch(&SweepKind::Issue(123), None, None)
+            .unwrap();
         assert!(outcome.was_new);
 
         let needle = format!("CLAUDE_CODE_OAUTH_TOKEN={token_value}");

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -134,9 +134,20 @@ pub enum Request {
     /// If a `Running` sweep with the same key exists, the existing `sweep_id`
     /// is returned with no new spawn. If the matching sweep has `Exited` or
     /// `Crashed`, a new sweep is spawned.
+    ///
+    /// `model` (issue #3477, Phase 1) optionally selects the Claude model for
+    /// the spawned child. When `Some`, the daemon appends `--model <value>`
+    /// to the `spawn-claude.sh` invocation — the highest-precedence tier of
+    /// the model chain (explicit dispatch param, then workspace
+    /// `roleConfig.model`, then role `suggestedModel`, then session default).
+    /// When `None` (or absent on the wire — `#[serde(default)]` keeps
+    /// existing clients compatible), NO `--model` flag is emitted and the
+    /// session/CLI default is preserved.
     DispatchSweep {
         kind: SweepKind,
         idempotency_key: Option<String>,
+        #[serde(default)]
+        model: Option<String>,
     },
     /// List tracked sweeps, optionally filtered by state.
     ListSweeps {

--- a/mcp-loom/src/tools/sweeps.ts
+++ b/mcp-loom/src/tools/sweeps.ts
@@ -219,6 +219,7 @@ export function parseDuration(input: string): number | null {
 async function dispatchSweep(args: {
   kind: SweepKind;
   idempotency_key?: string;
+  model?: string;
 }): Promise<{ success: true; result: DispatchResponse["payload"] } | { success: false; error: string }> {
   try {
     const response = (await sendDaemonRequest({
@@ -226,6 +227,10 @@ async function dispatchSweep(args: {
       payload: {
         kind: args.kind,
         idempotency_key: args.idempotency_key ?? null,
+        // Issue #3477 (Phase 1): optional model override. `null` (the
+        // default) means the daemon emits NO --model flag and the spawned
+        // child inherits the session/CLI default.
+        model: args.model ?? null,
       },
     })) as DaemonResponse;
 
@@ -427,6 +432,17 @@ export const sweepTools: Tool[] = [
             "already exists, the existing sweep ID is returned with no new " +
             "spawn. Matches against `Exited`/`Crashed` entries are NOT deduped " +
             "(the dedup window is the lifetime of the Running entry).",
+        },
+        model: {
+          type: "string",
+          description:
+            "Optional Claude model for the spawned sweep child (issue #3477). " +
+            "Accepts an alias (`sonnet`, `opus`, `haiku`) or a pinned ID " +
+            "(`claude-sonnet-4-6`). This is the highest-precedence tier of " +
+            "the model chain: explicit dispatch param > workspace " +
+            "`roleConfig.model` > role `suggestedModel` > session default. " +
+            "Omit to preserve the session/CLI default (no --model flag is " +
+            "emitted at all).",
         },
       },
       required: ["kind"],
@@ -701,8 +717,14 @@ export async function handleSweepTool(
 
       const idempotencyKey =
         typeof args?.idempotency_key === "string" ? (args.idempotency_key as string) : undefined;
+      // Issue #3477: optional model override. Empty strings are treated as
+      // unset so the daemon never receives `--model ""`.
+      const model =
+        typeof args?.model === "string" && args.model.length > 0
+          ? (args.model as string)
+          : undefined;
 
-      const result = await dispatchSweep({ kind: normalized, idempotency_key: idempotencyKey });
+      const result = await dispatchSweep({ kind: normalized, idempotency_key: idempotencyKey, model });
       if (!result.success) {
         return [
           {


### PR DESCRIPTION
Closes #3477

Implements **Phase 1 only**, per the curator's scoping comment: model-selection plumbing + static per-role mapping. Strategies B (attempt escalation), C (smart routing), D (self-escalation), and account×model joint selection remain out of scope for follow-up issues.

## Precedence chain (documented in defaults/CLAUDE.md)

`explicit dispatch param > workspace roleConfig.model > role suggestedModel > session default`

## Changes

| Touchpoint | Change |
|---|---|
| `defaults/scripts/spawn-claude.sh` | `LOOM_MODEL` env injects `--model` into the passthrough args unless an explicit `--model`/`--model=` arg is already present (arg wins). Empty env treated as unset. |
| `defaults/scripts/claude-wrapper.sh` | Same injection, applied **once before the retry loop** — every retry attempt reuses the same model (re-consulting policy on retry is strategy B, out of scope). |
| `loom-daemon` (`types.rs`, `sweep_registry.rs`, `ipc.rs`) | `model: Option<String>` on `Request::DispatchSweep` with `#[serde(default)]` (pre-#3477 clients unaffected); threaded through `dispatch()` → `spawn_child()` as an explicit `--model` argv. Empty string treated as unset — `--model ""` is never emitted. |
| `mcp-loom/src/tools/sweeps.ts` | `dispatch_sweep` schema + wire payload gain optional `model`; empty strings filtered client-side. |
| `defaults/.claude/commands/loom/sweep.md` | New "Model selection for subagent dispatch" section: resolve per role via the chain, pass via Task tool `model` param, omit entirely when nothing resolves. Activates the previously-dead `suggestedModel` role metadata as the role-default tier. |
| `.github/workflows/loom-*.yml` (5) | Pinned IDs per role mapping: judge → `claude-opus-4-8`; champion/curator/auditor/guide → `claude-sonnet-4-6` (cron roles are predictable cost-sensitive load; pins live in the consuming repo). |
| `defaults/CLAUDE.md` | "informational only" suggestedModel note replaced with the live precedence chain + `roleConfig.model` workspace-override example. Role JSONs keep aliases per the curator's aliases-vs-pins position. |
| `.loom/docs/daemon-reference.md` | `dispatch_sweep` input docs updated. |

## Zero-behavior-change criterion

When no model is configured anywhere (no `LOOM_MODEL`, no `--model` arg, no dispatch param), **no `--model` flag is emitted at any layer** — session/CLI default preserved end-to-end. Covered by dedicated tests at the shell and Rust layers, including the empty-string guards.

Note: `defaults/config.json` intentionally does NOT ship an active `model` value — `roleConfig.model` is documented as an optional override so installed workspaces see no pinning by default.

## Tests

- `bash defaults/scripts/tests/test-spawn-claude.sh` — 31/31 pass (12 new assertions: LOOM_MODEL injection, explicit-arg-wins, `--model=` form, no-config-no-flag, empty-env-no-flag).
- `cargo test` (loom-daemon) — 351 lib tests + suites, all pass. New: serde round-trips with/without model, absent-field backward compat, spawn-argv `--model` threading, empty-model no-flag guard, model=None no-flag assertion in the happy path.
- `cargo fmt --check` clean; CI-flavored `cargo clippy` clean (a pre-existing `type_complexity` finding under `--all-targets` in `ipc.rs::setup_test_context` exists on main and is untouched).
- `npm run build` (mcp-loom) — typecheck + bundle pass.

## Mirror-file note

`.loom/scripts/spawn-claude.sh`, `.loom/scripts/claude-wrapper.sh`, `.loom/scripts/tests/test-spawn-claude.sh`, and `.claude/commands/loom/sweep.md` are hardlinks to the `defaults/` sources in this checkout (same inode) and are not git-tracked — they stay in sync automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)