### PR TITLE
feat(model): Phase 2 — model escalation on Judge rejection (#3481)

### DIFF
--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -299,9 +299,41 @@ Every role subagent dispatched by this skill (`loom-curator`, `loom-builder`, `l
 Rules:
 
 - Aliases (`sonnet`/`opus`/`haiku`) and pinned IDs (`claude-sonnet-4-6`) are both valid at every tier. Shipped role JSONs use aliases; workspaces that need determinism pin exact IDs in `roleConfig.model`.
-- A retry of the same role for the same issue (e.g., Builder re-dispatch after a mid-builder kill, or a second Judge pass after Doctor) **reuses the same resolved model**. Attempt-based escalation is strategy B of #3477 and explicitly out of scope here.
+- A retry of the same role for the same issue (e.g., Builder re-dispatch after a mid-builder kill, or a second Judge pass after Doctor) **reuses the same resolved model**. Transport-level retries inside `claude-wrapper.sh` (token exhaustion, crashes, 5xx) likewise always keep the model — they are not quality signals and never trigger escalation.
+- **Exception — Judge-rejection escalation (issue #3481, Phase 2)**: a Doctor dispatched *because of* a `loom:changes-requested` transition escalates one rung up the capability ladder. See "Model escalation on Judge rejection" below.
 - Resolution failures are soft: if a role JSON is missing or unparseable, fall through to the next tier silently. Model selection must never block a sweep.
 - The daemon path has its own equivalent: `mcp__loom__dispatch_sweep` accepts an optional `model` param which the daemon forwards to the spawned child as `claude --model <value>`. When delegating to the daemon (Stage -1 `use_daemon`), you MAY pass a resolved model; when omitted, the child inherits the spawning environment's default — the daemon emits no `--model` flag at all.
+
+### Model escalation on Judge rejection (issue #3481, Phase 2)
+
+When the Judge requests changes and this orchestrator dispatches a Doctor for the rejected PR — the Doctor phase at issue-side step 6 and at Mode C step C1b — the Doctor's model escalates one rung up a capability ladder instead of resolving through tiers 3/4 of the precedence chain.
+
+**The ladder** lives in `.loom/config.json` under `sweep.escalation`:
+
+```json
+{
+  "sweep": {
+    "escalation": ["sonnet", "opus"]
+  }
+}
+```
+
+Three states:
+
+| `sweep.escalation` value | Behavior |
+|--------------------------|----------|
+| Key absent | Default ladder `["sonnet", "opus"]` applies |
+| `[]` or `false` | Escalation disabled — pure Phase 1 behavior; the rejection-triggered Doctor resolves through the unmodified precedence chain |
+| Non-empty array | As configured; rungs accept aliases or pinned IDs, same as every other tier |
+
+Rules:
+
+1. **Trigger**: escalation fires **only** on a real Judge rejection — the `loom:changes-requested` transition that routes into the Doctor phase. First attempts of every role (Curator, Builder, the first Judge pass) always use the unmodified Phase 1 precedence chain. `ladder[0]` never overrides anything — it documents what attempt 1 is *expected* to run on, it is not applied.
+2. **Precedence interaction**: the rejection-triggered Doctor resolves to `ladder[1]`, but only when its model would otherwise come from tier 3 (role `suggestedModel`) or tier 4 (session default). Tier 1 (explicit dispatch param) and tier 2 (`roleConfig.model` workspace pin) still win — pins are pins; operators who pinned want determinism.
+3. **Cap unchanged**: the single Doctor→Judge cycle cap still applies — escalation composes with the cap, it does not extend it. A second rejection blocks the PR; it does not dispatch a second Doctor. A configured third rung (e.g., a frontier model) is therefore **dormant** today: consume the ladder generically as `ladder[min(attempt - 1, len - 1)]` so a future cap raise activates deeper rungs without changes here, but only `ladder[1]` is reachable in v1.
+4. **Mode C inherits the rule** — C1b runs the identical Doctor phase under the identical cap, so the identical `ladder[1]` rule applies. No separate policy.
+5. **Resume safety**: the escalation decision derives from the `loom:changes-requested` label/phase, **not** from a stored counter — so a sweep killed between Doctor dispatch and the follow-up Judge resumes correctly: re-entry routes back through the Doctor/Judge phases per the checkpoint skip rules, and any re-dispatched rejection-triggered Doctor escalates again. The optional `attempt` field on the sweep checkpoint (`sweep-checkpoint.sh write N doctor-done ... --attempt 2`) is forward-compat bookkeeping for a future cap raise; readers treat an absent field as attempt 1.
+6. **The orchestrator decides, never the wrapper**: escalation is resolved here at Doctor-dispatch time. `claude-wrapper.sh` / `spawn-claude.sh` retries always keep their model (transport failures are not quality signals), and no wrapper change is involved.
 
 ### Other constraints
 
@@ -669,10 +701,11 @@ If the PR entered the wave already labeled `loom:changes-requested` (e.g., from 
 
 - Load and follow the instructions in `.claude/commands/loom/doctor.md` for this PR.
 - Dispatch `loom-doctor` as a **single subagent Task** from this orchestrator session. Do **NOT** invoke `/shepherd` or `/doctor` slash-commands as subagents — see "CRITICAL: One level deep".
+- **Model escalation (#3481)**: Mode C inherits the issue-side rule unchanged — this Doctor is dispatched because of a `loom:changes-requested` rejection, so resolve its model per "Model escalation on Judge rejection" in the Execution Model: pass `ladder[1]` from `sweep.escalation` (default ladder: `opus`) via the Task tool's `model` parameter, **unless** a tier-1/tier-2 pin applies (pins win) or escalation is disabled (`[]`/`false`).
 - Doctor addresses the judge feedback, commits the fixes, pushes, and re-labels the PR `loom:review-requested`.
-- If a closing-issue checkpoint is in scope, write `doctor-done` **before** the follow-up Judge:
+- If a closing-issue checkpoint is in scope, write `doctor-done` (with the attempt counter) **before** the follow-up Judge:
   ```bash
-  ./.loom/scripts/sweep-checkpoint.sh write N doctor-done --task-id "sweep-$$" --pr-number P
+  ./.loom/scripts/sweep-checkpoint.sh write N doctor-done --task-id "sweep-$$" --pr-number P --attempt 2
   ```
 - Re-dispatch `loom-judge` for the PR (now `loom:review-requested` again).
 - Expected exit states:
@@ -898,10 +931,11 @@ for pr in wave_prs:
 If Judge requests changes on PR `#X` mid-wave, run a **single inline Doctor→Judge cycle** for `#X` before moving to the next PR's Judge:
 
 - Load and follow the instructions in `.claude/commands/loom/doctor.md` for PR `#X`.
+- **Model escalation (#3481)**: this Doctor is dispatched because of a Judge rejection, so resolve its model per "Model escalation on Judge rejection" in the Execution Model — pass `ladder[1]` from `sweep.escalation` (default ladder: `opus`) via the Task tool's `model` parameter, **unless** a tier-1/tier-2 pin applies (pins win) or escalation is disabled (`[]`/`false`).
 - Doctor addresses the judge's feedback, commits the fixes, and pushes.
-- **On successful Doctor completion**, write the `doctor-done` checkpoint for the issue (carrying the PR number) **before** re-invoking Judge:
+- **On successful Doctor completion**, write the `doctor-done` checkpoint for the issue (carrying the PR number and the attempt counter) **before** re-invoking Judge:
   ```bash
-  ./.loom/scripts/sweep-checkpoint.sh write N doctor-done --task-id "sweep-$$" --pr-number <PR>
+  ./.loom/scripts/sweep-checkpoint.sh write N doctor-done --task-id "sweep-$$" --pr-number <PR> --attempt 2
   ```
   This way, if sweep is killed between Doctor and the follow-up Judge, the resume run will see `doctor-done` and re-enter at the Judge phase (step 5), not redo the Doctor work.
 - On completion, re-label the PR from `loom:changes-requested` back to `loom:review-requested` and **re-run the Judge phase** (step 5) for this PR.

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -668,7 +668,31 @@ Model selection is a first-class orchestration concern (issue #3477, Phase 1). E
 3. **Role default** — `.loom/roles/<role>.json` → `suggestedModel` (ships as an alias). The `/loom:sweep` skill passes the resolved model to role subagents via the Task tool's `model` parameter.
 4. **Session default** — when nothing above resolves, NO `--model` flag (and no Task `model` param) is emitted at all, and the worker inherits the parent session/CLI default. This is the zero-config behavior: nothing configured means nothing changes.
 
-The spawn plumbing also honors a `LOOM_MODEL` environment variable (`spawn-claude.sh`, `claude-wrapper.sh`): it is injected as `--model <value>` unless an explicit `--model` is already present in the args. Retries inside `claude-wrapper.sh` always reuse the same model — re-consulting policy on retry (attempt-based escalation) is deliberately out of scope for Phase 1.
+The spawn plumbing also honors a `LOOM_MODEL` environment variable (`spawn-claude.sh`, `claude-wrapper.sh`): it is injected as `--model <value>` unless an explicit `--model` is already present in the args. Retries inside `claude-wrapper.sh` always reuse the same model — transport-level failures (token exhaustion, crashes, 5xx) are not quality signals and never change the model.
+
+**Escalation on Judge rejection (`sweep.escalation`, Phase 2, issue #3481)**:
+
+The `/loom:sweep` orchestrator escalates one rung up a capability ladder when the Judge rejects a PR (`loom:changes-requested`) and a Doctor is dispatched to address the feedback. The escalation decision is made by the sweep orchestrator at Doctor-dispatch time — never by `claude-wrapper.sh` retries, never by worker self-assessment. Mode C (`--prs`) inherits the same rule for its Doctor phase (step C1b).
+
+The ladder is configured in `.loom/config.json`:
+
+```json
+{
+  "sweep": {
+    "escalation": ["sonnet", "opus"]
+  }
+}
+```
+
+| Value | Behavior |
+|-------|----------|
+| Key absent | Default ladder `["sonnet", "opus"]` applies |
+| `[]` or `false` | Escalation disabled entirely (pure Phase 1 behavior) |
+| Non-empty array | As configured; rungs accept aliases or pinned IDs |
+
+**Precedence interaction**: escalation replaces only tier 3 (`suggestedModel`) / tier 4 (session default) resolution for the rejection-triggered Doctor. Tier 1 (explicit dispatch param) and tier 2 (`roleConfig.model` workspace pin) always win — pins are never overridden. `ladder[0]` never overrides anything either: first attempts of every role use the unmodified precedence chain, and the ladder only fires on rejection (the rejection-triggered Doctor gets `ladder[1]`).
+
+**Cap interaction**: escalation composes with — and does not extend — the single Doctor→Judge cycle cap. A second Judge rejection blocks the PR rather than dispatching another Doctor, so a configured third rung (e.g., a frontier model) is dormant until a future issue raises the cap. The sweep checkpoint's optional `attempt` field (`sweep-checkpoint.sh write N doctor-done --attempt 2`) is forward-compat bookkeeping for that future; absent means attempt 1, and legacy checkpoints without the field read cleanly.
 
 **Suggested models by role** (`suggestedModel`, live as the role-default tier):
 

--- a/defaults/scripts/sweep-checkpoint.sh
+++ b/defaults/scripts/sweep-checkpoint.sh
@@ -15,8 +15,16 @@
 #     "phase": "<curator-done|builder-done|judge-done|doctor-done|merge-done>",
 #     "task_id": "<task identifier, e.g. sweep PID>",
 #     "timestamp": "<ISO 8601 UTC>",
-#     "pr_number": <int or null>
+#     "pr_number": <int or null>,
+#     "attempt": <int, optional - omitted when not provided; absent means attempt 1>
 #   }
+#
+# The "attempt" field (#3481) is forward-compat bookkeeping for model
+# escalation: attempt 1 is the first Builder pass, attempt 2 is the Doctor
+# dispatched after a Judge rejection. Readers MUST tolerate checkpoints
+# without the field (legacy checkpoints predate it) and treat absence as
+# attempt 1. The v1 escalation decision derives from the
+# loom:changes-requested label/phase, not this counter.
 #
 # Phases are recorded *after* successful completion of the corresponding
 # lifecycle phase, so "curator-done" means the curator phase succeeded for
@@ -28,10 +36,11 @@
 # by this helper, and the next sweep entry will clean it up with a warning.
 #
 # Usage:
-#   sweep-checkpoint.sh write <issue> <phase> [--task-id ID] [--pr-number N]
+#   sweep-checkpoint.sh write <issue> <phase> [--task-id ID] [--pr-number N] [--attempt N]
 #   sweep-checkpoint.sh read <issue>
 #   sweep-checkpoint.sh delete <issue>
 #   sweep-checkpoint.sh phase <issue>          # Print phase string only (or empty)
+#   sweep-checkpoint.sh attempt <issue>        # Print attempt number (empty if absent = attempt 1)
 #   sweep-checkpoint.sh exists <issue>         # Exit 0 if checkpoint exists, 1 otherwise
 #   sweep-checkpoint.sh list                   # List all checkpoint issue numbers
 #
@@ -46,7 +55,7 @@ set -euo pipefail
 VALID_PHASES=(curator-done builder-done judge-done doctor-done merge-done)
 
 usage() {
-    sed -n '3,38p' "$0" | sed 's/^# \{0,1\}//'
+    sed -n '3,46p' "$0" | sed 's/^# \{0,1\}//'
     exit 1
 }
 
@@ -95,11 +104,12 @@ cmd_write() {
     validate_issue "$issue"
     validate_phase "$phase"
 
-    local task_id="" pr_number="null"
+    local task_id="" pr_number="null" attempt=""
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --task-id) task_id="${2:-}"; shift 2 ;;
             --pr-number) pr_number="${2:-null}"; shift 2 ;;
+            --attempt) attempt="${2:-}"; shift 2 ;;
             *) echo "ERROR: unknown flag '$1'" >&2; exit 1 ;;
         esac
     done
@@ -109,6 +119,15 @@ cmd_write() {
         echo "ERROR: --pr-number must be a positive integer or 'null'" >&2
         exit 1
     fi
+    if [[ -n "$attempt" && ! "$attempt" =~ ^[1-9][0-9]*$ ]]; then
+        echo "ERROR: --attempt must be a positive integer >= 1 (got: '$attempt')" >&2
+        exit 1
+    fi
+
+    # Optional field: omitted entirely when --attempt is not provided so
+    # legacy readers (and diffs against old checkpoints) stay clean.
+    local attempt_json=""
+    [[ -n "$attempt" ]] && attempt_json=$',\n  "attempt": '"$attempt"
 
     ensure_dir
     local target tmp
@@ -120,7 +139,7 @@ cmd_write() {
   "phase": "$phase",
   "task_id": "$task_id",
   "timestamp": "$(iso_now)",
-  "pr_number": $pr_number
+  "pr_number": $pr_number$attempt_json
 }
 EOF
 
@@ -147,6 +166,16 @@ cmd_phase() {
     [[ ! -f "$target" ]] && return 0
     # Extract phase via grep+sed to avoid jq dependency.
     sed -n 's/.*"phase"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$target" | head -n1
+}
+
+cmd_attempt() {
+    local issue="${1:-}"
+    validate_issue "$issue"
+    local target
+    target="$(checkpoint_file "$issue")"
+    [[ ! -f "$target" ]] && return 0
+    # Empty output means the field is absent (legacy checkpoint) = attempt 1.
+    sed -n 's/.*"attempt"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$target" | head -n1
 }
 
 cmd_exists() {
@@ -182,6 +211,7 @@ main() {
         write)   cmd_write "$@" ;;
         read)    cmd_read "$@" ;;
         phase)   cmd_phase "$@" ;;
+        attempt) cmd_attempt "$@" ;;
         exists)  cmd_exists "$@" ;;
         delete)  cmd_delete "$@" ;;
         list)    cmd_list "$@" ;;

--- a/defaults/scripts/tests/test-sweep-checkpoint.sh
+++ b/defaults/scripts/tests/test-sweep-checkpoint.sh
@@ -141,6 +141,73 @@ for phase in curator-done builder-done judge-done doctor-done merge-done; do
     fi
 done
 
+# --- Optional attempt field (#3481, model escalation bookkeeping) ---
+
+# 16. write with --attempt round-trips through read and attempt
+assert "write doctor-done with --attempt 2" "$CHECKPOINT" write 50 doctor-done --task-id t --pr-number 123 --attempt 2
+out=$("$CHECKPOINT" read 50)
+if echo "$out" | grep -q '"attempt": 2'; then
+    echo "PASS: attempt persisted as integer in JSON"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: attempt missing or wrong: $out" >&2
+    FAIL=$((FAIL + 1))
+fi
+out=$("$CHECKPOINT" attempt 50)
+assert_eq "attempt command reads back 2" "2" "$out"
+
+# 17. pr_number still intact alongside attempt
+out=$("$CHECKPOINT" read 50)
+if echo "$out" | grep -q '"pr_number": 123'; then
+    echo "PASS: pr_number coexists with attempt"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: pr_number lost when attempt present: $out" >&2
+    FAIL=$((FAIL + 1))
+fi
+
+# 18. Backward compat: write WITHOUT --attempt omits the field entirely
+"$CHECKPOINT" write 51 builder-done --task-id t >/dev/null
+out=$("$CHECKPOINT" read 51)
+if echo "$out" | grep -q '"attempt"'; then
+    echo "FAIL: attempt field should be omitted when not provided: $out" >&2
+    FAIL=$((FAIL + 1))
+else
+    echo "PASS: attempt field omitted when not provided"
+    PASS=$((PASS + 1))
+fi
+
+# 19. Legacy checkpoint (no attempt field): attempt prints empty, exit 0
+out=$("$CHECKPOINT" attempt 51)
+assert_eq "attempt is empty on legacy checkpoint (= attempt 1)" "" "$out"
+assert_exit "attempt on legacy checkpoint exits 0" 0 "$CHECKPOINT" attempt 51
+
+# 20. Legacy checkpoint read path unaffected (phase still resolves)
+out=$("$CHECKPOINT" phase 51)
+assert_eq "phase still reads on attempt-less checkpoint" "builder-done" "$out"
+
+# 21. attempt on missing checkpoint: empty output, exit 0 (mirrors phase)
+out=$("$CHECKPOINT" attempt 9999)
+assert_eq "attempt is empty when no checkpoint" "" "$out"
+assert_exit "attempt on missing checkpoint exits 0" 0 "$CHECKPOINT" attempt 9999
+
+# 22. Invalid --attempt values rejected with exit 1
+assert_exit "non-numeric --attempt exits 1" 1 "$CHECKPOINT" write 52 doctor-done --attempt abc
+assert_exit "zero --attempt exits 1" 1 "$CHECKPOINT" write 52 doctor-done --attempt 0
+assert_exit "negative --attempt exits 1" 1 "$CHECKPOINT" write 52 doctor-done --attempt -1
+if "$CHECKPOINT" exists 52 >/dev/null 2>&1; then
+    echo "FAIL: rejected --attempt write should not create a checkpoint" >&2
+    FAIL=$((FAIL + 1))
+else
+    echo "PASS: rejected --attempt write leaves no checkpoint behind"
+    PASS=$((PASS + 1))
+fi
+
+# 23. Overwrite an attempt-bearing checkpoint without --attempt drops the field
+"$CHECKPOINT" write 50 doctor-done --task-id t >/dev/null
+out=$("$CHECKPOINT" attempt 50)
+assert_eq "attempt cleared after attempt-less rewrite" "" "$out"
+
 echo
 echo "Results: $PASS passed, $FAIL failed"
 [[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

Phase 2 of #3477 (Phase 1 merged in PR #3479). Implements the curator-settled design on #3481: deterministic model escalation up a capability ladder, fired **only** by a Judge rejection (`loom:changes-requested`), decided by the sweep orchestrator at Doctor-dispatch time.

- **`defaults/.claude/commands/loom/sweep.md`** — new "Model escalation on Judge rejection" section in the Execution Model: ladder configured in `.loom/config.json` under `sweep.escalation`; three states (absent → default `["sonnet", "opus"]`, `[]`/`false` → disabled, non-empty → as configured); escalation overrides only precedence tiers 3/4 — tier-1 dispatch params and tier-2 `roleConfig.model` pins always win; `ladder[0]` never overrides anything. The `ladder[1]` override is wired into the Doctor dispatch prose at issue-side step 6 **and** Mode C step C1b (Mode C inherits the identical rule). The single Doctor→Judge cycle cap is unchanged — escalation composes with it, so a configured third (frontier) rung is documented as dormant; the ladder is consumed generically (`ladder[min(attempt-1, len-1)]`) for a future cap raise.
- **`defaults/scripts/sweep-checkpoint.sh`** — optional `--attempt N` flag on `write` (field omitted from JSON when not provided), new `attempt <issue>` reader command (empty output = legacy checkpoint = attempt 1), validation rejecting non-numeric/zero/negative values. Forward-compat bookkeeping only: v1 escalation derives from the `loom:changes-requested` label/phase, so a kill between Doctor dispatch and the Judge re-run resumes with the escalated model via the existing skip rules.
- **`defaults/CLAUDE.md`** — `sweep.escalation` documented next to the Phase 1 precedence-chain section (key, default ladder, disable semantics, precedence + cap interaction).
- **No `claude-wrapper.sh` / `spawn-claude.sh` / Rust changes** — verified wrapper retries keep their model by construction (injection happens once before the retry loop, per Phase 1). Smart routing / account×model selection is out of scope (#3482).

Mirror note: `.loom/scripts/sweep-checkpoint.sh` and `.claude/commands/loom/sweep.md` are untracked hardlinks of the `defaults/` files (same inodes verified before and after editing) — they stay in sync automatically, matching how Phase 1 (PR #3479) handled it.

## Test plan

- [x] `bash defaults/scripts/tests/test-sweep-checkpoint.sh` — 36/36 pass (21 pre-existing + 15 new: `--attempt` round-trip via `read` and `attempt`, field omission when flag absent, legacy attempt-less checkpoint reads, missing-checkpoint behavior, invalid-value rejection with no checkpoint left behind, attempt cleared on attempt-less rewrite)
- [x] `bash -n` on `sweep-checkpoint.sh` and the test file
- [x] Hardlink mirrors verified in sync after edits

Closes #3481

🤖 Generated with [Claude Code](https://claude.com/claude-code)