### PR TITLE
feat(model): Phase 3a — per-model observability (spawn, daemon, checkpoint, metrics)

### DIFF
--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -690,6 +690,7 @@ Apply exactly one of the three branches below, based on the PR's current label:
 - Expected exit states:
   - **Approve** → PR labeled `loom:pr` by Judge. If a closing-issue checkpoint is in scope, write `judge-done`:
     ```bash
+    # Append --model <resolved> when you passed a model param to the judge subagent (#3482).
     ./.loom/scripts/sweep-checkpoint.sh write N judge-done --task-id "sweep-$$" --pr-number P
     ```
     Continue to **C2 (Merge)** for this PR.
@@ -703,9 +704,9 @@ If the PR entered the wave already labeled `loom:changes-requested` (e.g., from 
 - Dispatch `loom-doctor` as a **single subagent Task** from this orchestrator session. Do **NOT** invoke `/shepherd` or `/doctor` slash-commands as subagents — see "CRITICAL: One level deep".
 - **Model escalation (#3481)**: Mode C inherits the issue-side rule unchanged — this Doctor is dispatched because of a `loom:changes-requested` rejection, so resolve its model per "Model escalation on Judge rejection" in the Execution Model: pass `ladder[1]` from `sweep.escalation` (default ladder: `opus`) via the Task tool's `model` parameter, **unless** a tier-1/tier-2 pin applies (pins win) or escalation is disabled (`[]`/`false`).
 - Doctor addresses the judge feedback, commits the fixes, pushes, and re-labels the PR `loom:review-requested`.
-- If a closing-issue checkpoint is in scope, write `doctor-done` (with the attempt counter) **before** the follow-up Judge:
+- If a closing-issue checkpoint is in scope, write `doctor-done` (with the attempt counter and the model the Doctor actually ran on — escalated or pinned, #3482) **before** the follow-up Judge:
   ```bash
-  ./.loom/scripts/sweep-checkpoint.sh write N doctor-done --task-id "sweep-$$" --pr-number P --attempt 2
+  ./.loom/scripts/sweep-checkpoint.sh write N doctor-done --task-id "sweep-$$" --pr-number P --attempt 2 --model <doctor-model>
   ```
 - Re-dispatch `loom-judge` for the PR (now `loom:review-requested` again).
 - Expected exit states:
@@ -771,8 +772,9 @@ See `.claude/commands/loom/shepherd-lifecycle.md` for the canonical phase-by-pha
 Sweep persists a per-issue phase checkpoint after each successful lifecycle phase so that a killed-and-relaunched sweep can pick up where it left off. The checkpoint is the **only** state required to resume — worktree preservation is handled by `worktree.sh`'s idempotency (re-running for an existing worktree is a no-op).
 
 - **Checkpoint file**: `.loom/sweep-checkpoint/issue-<N>.json` (gitignored).
-- **Schema**: `{phase: "<curator-done|builder-done|judge-done|doctor-done|merge-done>", task_id, timestamp, pr_number?}`.
-- **Helper**: `.loom/scripts/sweep-checkpoint.sh {write|read|phase|exists|delete|list}` — wraps the read/write/delete operations with atomic writes (`.tmp` + `mv`) and validates the phase enum.
+- **Schema**: `{phase: "<curator-done|builder-done|judge-done|doctor-done|merge-done>", task_id, timestamp, pr_number?, attempt?, model?}`.
+- **Helper**: `.loom/scripts/sweep-checkpoint.sh {write|read|phase|attempt|model|exists|delete|list}` — wraps the read/write/delete operations with atomic writes (`.tmp` + `mv`) and validates the phase enum.
+- **Model field (#3482, Phase 3a observability)**: when you resolved a model for the phase's subagent (i.e., you actually passed a `model` param to the Task tool — any tier above session default), record it on the checkpoint write with `--model <resolved>` (alias or pinned ID). When the subagent inherited the session default (tier 4, no `model` param passed), omit `--model` entirely. This is observability-only bookkeeping for per-model metrics — readers MUST tolerate checkpoints without the field (legacy checkpoints predate it; absence means default/unknown), and the field never feeds back into model selection or escalation decisions.
 - **Write timing**: After the *successful completion* of each lifecycle phase below. Never write a checkpoint speculatively before the phase finishes — a kill mid-phase must resume at the start of that phase.
 - **Read timing**: At the start of per-issue pre-flight (step 1) for every issue in the candidate list, before any worktree or label mutation for that issue.
 - **Delete timing**: On `merge-done` (step 7) and on stale-checkpoint detection (step 1).
@@ -847,6 +849,7 @@ For each surviving issue `N` in the wave:
 - If the issue already has `loom:curated` or `loom:issue`, skip the curator skill invocation but still write the checkpoint below (so future sweep runs can skip the redundant label probe).
 - **On successful completion** (curator ran, or curator-skip-because-already-curated), write the checkpoint:
   ```bash
+  # Append --model <resolved> when you passed a model param to the curator subagent (#3482).
   ./.loom/scripts/sweep-checkpoint.sh write N curator-done --task-id "sweep-$$"
   ```
 
@@ -888,6 +891,7 @@ Each builder is responsible for:
 
 **On successful PR creation**, write the `builder-done` checkpoint for that issue (record the PR number):
 ```bash
+# Append --model <resolved> when you passed a model param to the builder subagent (#3482).
 ./.loom/scripts/sweep-checkpoint.sh write N builder-done --task-id "sweep-$$" --pr-number <PR>
 ```
 
@@ -920,6 +924,7 @@ for pr in wave_prs:
 - Expected exit states per PR:
   - **Approve** → PR labeled `loom:pr`. Write the `judge-done` checkpoint for this issue (carrying the PR number), then continue to Merge (step 7) for this PR, then advance to the next PR in the wave.
     ```bash
+    # Append --model <resolved> when you passed a model param to the judge subagent (#3482).
     ./.loom/scripts/sweep-checkpoint.sh write N judge-done --task-id "sweep-$$" --pr-number <PR>
     ```
   - **Request changes** → PR labeled `loom:changes-requested`. Continue to Doctor (step 6) **inline for this PR**, then re-judge, then merge or block. Do **not** write a `judge-done` checkpoint here — the PR is not yet approved, and a resume after a kill should re-enter Doctor, not skip Judge.
@@ -933,9 +938,9 @@ If Judge requests changes on PR `#X` mid-wave, run a **single inline Doctor→Ju
 - Load and follow the instructions in `.claude/commands/loom/doctor.md` for PR `#X`.
 - **Model escalation (#3481)**: this Doctor is dispatched because of a Judge rejection, so resolve its model per "Model escalation on Judge rejection" in the Execution Model — pass `ladder[1]` from `sweep.escalation` (default ladder: `opus`) via the Task tool's `model` parameter, **unless** a tier-1/tier-2 pin applies (pins win) or escalation is disabled (`[]`/`false`).
 - Doctor addresses the judge's feedback, commits the fixes, and pushes.
-- **On successful Doctor completion**, write the `doctor-done` checkpoint for the issue (carrying the PR number and the attempt counter) **before** re-invoking Judge:
+- **On successful Doctor completion**, write the `doctor-done` checkpoint for the issue (carrying the PR number, the attempt counter, and the model the Doctor actually ran on — escalated or pinned, #3482) **before** re-invoking Judge:
   ```bash
-  ./.loom/scripts/sweep-checkpoint.sh write N doctor-done --task-id "sweep-$$" --pr-number <PR> --attempt 2
+  ./.loom/scripts/sweep-checkpoint.sh write N doctor-done --task-id "sweep-$$" --pr-number <PR> --attempt 2 --model <doctor-model>
   ```
   This way, if sweep is killed between Doctor and the follow-up Judge, the resume run will see `doctor-done` and re-enter at the Judge phase (step 5), not redo the Doctor work.
 - On completion, re-label the PR from `loom:changes-requested` back to `loom:review-requested` and **re-run the Judge phase** (step 5) for this PR.

--- a/defaults/scripts/agent-metrics.sh
+++ b/defaults/scripts/agent-metrics.sh
@@ -9,10 +9,13 @@
 # Usage:
 #   agent-metrics.sh [--role ROLE] [--period PERIOD] [--format FORMAT]
 #   agent-metrics.sh summary
-#   agent-metrics.sh effectiveness [--role ROLE]
-#   agent-metrics.sh costs [--issue NUMBER]
+#   agent-metrics.sh effectiveness [--role ROLE] [--by-model]
+#   agent-metrics.sh costs [--issue NUMBER] [--by-model]
 #   agent-metrics.sh velocity
 #   agent-metrics.sh --help
+#
+# --by-model (#3482, Phase 3a) adds a per-model dimension to the
+# effectiveness/costs output; NULL/absent model values render as 'default'.
 
 set -euo pipefail
 

--- a/defaults/scripts/spawn-claude.sh
+++ b/defaults/scripts/spawn-claude.sh
@@ -112,25 +112,46 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# --- Model selection (issue #3477, Phase 1) ---
+# --- Model selection (issue #3477, Phase 1; observability #3482, Phase 3a) ---
 # Precedence: explicit `--model` in the passthrough args > LOOM_MODEL env >
 # nothing (session/CLI default — no --model flag emitted at all).
-if [[ -n "${LOOM_MODEL:-}" ]]; then
-    _has_model_arg=false
-    for _arg in ${PASSTHROUGH_ARGS[@]+"${PASSTHROUGH_ARGS[@]}"}; do
-        case "$_arg" in
-            --model|--model=*)
-                _has_model_arg=true
-                break
-                ;;
-        esac
-    done
-    if [[ "$_has_model_arg" == "false" ]]; then
-        PASSTHROUGH_ARGS+=(--model "$LOOM_MODEL")
-        log_info "spawn-claude: using model '$LOOM_MODEL' (from LOOM_MODEL)"
-    else
+#
+# Observability (#3482): exactly ONE structured `spawn-claude: model=<value>`
+# line is emitted on every spawn, covering all three precedence cases —
+# including `model=default` when nothing is configured. The line is
+# stderr-only and changes NO spawn behavior; downstream log scrapers key on
+# the `model=` token.
+_explicit_model=""
+_has_model_arg=false
+_prev_was_model_flag=false
+for _arg in ${PASSTHROUGH_ARGS[@]+"${PASSTHROUGH_ARGS[@]}"}; do
+    if [[ "$_prev_was_model_flag" == "true" ]]; then
+        _explicit_model="$_arg"
+        _prev_was_model_flag=false
+        continue
+    fi
+    case "$_arg" in
+        --model)
+            _has_model_arg=true
+            _prev_was_model_flag=true
+            ;;
+        --model=*)
+            _has_model_arg=true
+            _explicit_model="${_arg#--model=}"
+            ;;
+    esac
+done
+
+if [[ "$_has_model_arg" == "true" ]]; then
+    if [[ -n "${LOOM_MODEL:-}" ]]; then
         log_info "spawn-claude: explicit --model in args wins over LOOM_MODEL='$LOOM_MODEL'"
     fi
+    log_info "spawn-claude: model=${_explicit_model:-default} (from --model arg)"
+elif [[ -n "${LOOM_MODEL:-}" ]]; then
+    PASSTHROUGH_ARGS+=(--model "$LOOM_MODEL")
+    log_info "spawn-claude: model=$LOOM_MODEL (from LOOM_MODEL)"
+else
+    log_info "spawn-claude: model=default"
 fi
 
 # --- Locate loom_tools package source ---

--- a/defaults/scripts/sweep-checkpoint.sh
+++ b/defaults/scripts/sweep-checkpoint.sh
@@ -16,7 +16,8 @@
 #     "task_id": "<task identifier, e.g. sweep PID>",
 #     "timestamp": "<ISO 8601 UTC>",
 #     "pr_number": <int or null>,
-#     "attempt": <int, optional - omitted when not provided; absent means attempt 1>
+#     "attempt": <int, optional - omitted when not provided; absent means attempt 1>,
+#     "model": "<string, optional - omitted when not provided; absent means default/unknown>"
 #   }
 #
 # The "attempt" field (#3481) is forward-compat bookkeeping for model
@@ -25,6 +26,13 @@
 # without the field (legacy checkpoints predate it) and treat absence as
 # attempt 1. The v1 escalation decision derives from the
 # loom:changes-requested label/phase, not this counter.
+#
+# The "model" field (#3482, Phase 3a observability) records the model the
+# orchestrator resolved for the phase's subagent (alias like "sonnet"/"opus"
+# or a pinned ID like "claude-sonnet-4-6"). Observability only — it never
+# feeds back into model selection. Readers MUST tolerate checkpoints without
+# the field (legacy checkpoints predate it) and treat absence as
+# default/unknown.
 #
 # Phases are recorded *after* successful completion of the corresponding
 # lifecycle phase, so "curator-done" means the curator phase succeeded for
@@ -36,11 +44,12 @@
 # by this helper, and the next sweep entry will clean it up with a warning.
 #
 # Usage:
-#   sweep-checkpoint.sh write <issue> <phase> [--task-id ID] [--pr-number N] [--attempt N]
+#   sweep-checkpoint.sh write <issue> <phase> [--task-id ID] [--pr-number N] [--attempt N] [--model M]
 #   sweep-checkpoint.sh read <issue>
 #   sweep-checkpoint.sh delete <issue>
 #   sweep-checkpoint.sh phase <issue>          # Print phase string only (or empty)
 #   sweep-checkpoint.sh attempt <issue>        # Print attempt number (empty if absent = attempt 1)
+#   sweep-checkpoint.sh model <issue>          # Print model string (empty if absent = default/unknown)
 #   sweep-checkpoint.sh exists <issue>         # Exit 0 if checkpoint exists, 1 otherwise
 #   sweep-checkpoint.sh list                   # List all checkpoint issue numbers
 #
@@ -55,7 +64,7 @@ set -euo pipefail
 VALID_PHASES=(curator-done builder-done judge-done doctor-done merge-done)
 
 usage() {
-    sed -n '3,46p' "$0" | sed 's/^# \{0,1\}//'
+    sed -n '3,55p' "$0" | sed 's/^# \{0,1\}//'
     exit 1
 }
 
@@ -104,12 +113,13 @@ cmd_write() {
     validate_issue "$issue"
     validate_phase "$phase"
 
-    local task_id="" pr_number="null" attempt=""
+    local task_id="" pr_number="null" attempt="" model=""
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --task-id) task_id="${2:-}"; shift 2 ;;
             --pr-number) pr_number="${2:-null}"; shift 2 ;;
             --attempt) attempt="${2:-}"; shift 2 ;;
+            --model) model="${2:-}"; shift 2 ;;
             *) echo "ERROR: unknown flag '$1'" >&2; exit 1 ;;
         esac
     done
@@ -123,11 +133,20 @@ cmd_write() {
         echo "ERROR: --attempt must be a positive integer >= 1 (got: '$attempt')" >&2
         exit 1
     fi
+    # Model values are aliases (sonnet/opus/haiku) or pinned IDs
+    # (claude-sonnet-4-6). Restrict the charset so the value embeds safely
+    # in the hand-rolled JSON below (no quotes/backslashes/control chars).
+    if [[ -n "$model" && ! "$model" =~ ^[A-Za-z0-9._-]+$ ]]; then
+        echo "ERROR: --model must match [A-Za-z0-9._-]+ (got: '$model')" >&2
+        exit 1
+    fi
 
-    # Optional field: omitted entirely when --attempt is not provided so
-    # legacy readers (and diffs against old checkpoints) stay clean.
+    # Optional fields: omitted entirely when not provided so legacy readers
+    # (and diffs against old checkpoints) stay clean.
     local attempt_json=""
     [[ -n "$attempt" ]] && attempt_json=$',\n  "attempt": '"$attempt"
+    local model_json=""
+    [[ -n "$model" ]] && model_json=$',\n  "model": "'"$model"'"'
 
     ensure_dir
     local target tmp
@@ -139,7 +158,7 @@ cmd_write() {
   "phase": "$phase",
   "task_id": "$task_id",
   "timestamp": "$(iso_now)",
-  "pr_number": $pr_number$attempt_json
+  "pr_number": $pr_number$attempt_json$model_json
 }
 EOF
 
@@ -178,6 +197,17 @@ cmd_attempt() {
     sed -n 's/.*"attempt"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$target" | head -n1
 }
 
+cmd_model() {
+    local issue="${1:-}"
+    validate_issue "$issue"
+    local target
+    target="$(checkpoint_file "$issue")"
+    [[ ! -f "$target" ]] && return 0
+    # Empty output means the field is absent (legacy checkpoint) =
+    # default/unknown model. Mirrors cmd_attempt semantics (#3482).
+    sed -n 's/.*"model"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$target" | head -n1
+}
+
 cmd_exists() {
     local issue="${1:-}"
     validate_issue "$issue"
@@ -212,6 +242,7 @@ main() {
         read)    cmd_read "$@" ;;
         phase)   cmd_phase "$@" ;;
         attempt) cmd_attempt "$@" ;;
+        model)   cmd_model "$@" ;;
         exists)  cmd_exists "$@" ;;
         delete)  cmd_delete "$@" ;;
         list)    cmd_list "$@" ;;

--- a/defaults/scripts/tests/test-spawn-claude.sh
+++ b/defaults/scripts/tests/test-spawn-claude.sh
@@ -215,6 +215,8 @@ output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
     "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
 assert_contains "stub-claude args=-p ping --model claude-sonnet-4-6" "$output" \
     "LOOM_MODEL env injects --model into claude args"
+assert_contains "spawn-claude: model=claude-sonnet-4-6 (from LOOM_MODEL)" "$output" \
+    "structured model log line emitted for LOOM_MODEL case (#3482)"
 
 # Case 1: explicit --model arg wins over LOOM_MODEL env
 output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
@@ -222,6 +224,8 @@ output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
     "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" --model claude-opus-4-8 2>&1 || true)
 assert_contains "stub-claude args=-p ping --model claude-opus-4-8" "$output" \
     "explicit --model arg wins over LOOM_MODEL env"
+assert_contains "spawn-claude: model=claude-opus-4-8 (from --model arg)" "$output" \
+    "structured model log line emitted for explicit --model arg case (#3482)"
 TESTS_RUN=$((TESTS_RUN + 1))
 if [[ "$output" != *"claude-sonnet-4-6"* ]] || [[ "$output" == *"wins over LOOM_MODEL"* ]]; then
     TESTS_PASSED=$((TESTS_PASSED + 1))
@@ -238,6 +242,8 @@ output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
     "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" --model=claude-opus-4-8 2>&1 || true)
 assert_contains "stub-claude args=-p ping --model=claude-opus-4-8" "$output" \
     "--model=value form wins over LOOM_MODEL env"
+assert_contains "spawn-claude: model=claude-opus-4-8 (from --model arg)" "$output" \
+    "structured model log line emitted for --model=value form (#3482)"
 TESTS_RUN=$((TESTS_RUN + 1))
 if [[ "$output" != *"--model claude-sonnet-4-6"* ]]; then
     TESTS_PASSED=$((TESTS_PASSED + 1))
@@ -260,6 +266,8 @@ else
     echo -e "  ${RED}FAIL${NC}: no LOOM_MODEL + no --model arg emits NO --model (session default preserved)"
     echo "    In: '$output'"
 fi
+assert_contains "spawn-claude: model=default" "$output" \
+    "structured model=default log line emitted when nothing configured (#3482)"
 
 # Empty LOOM_MODEL is treated as unset — no --model emitted
 output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
@@ -274,6 +282,8 @@ else
     echo -e "  ${RED}FAIL${NC}: empty LOOM_MODEL emits NO --model"
     echo "    In: '$output'"
 fi
+assert_contains "spawn-claude: model=default" "$output" \
+    "structured model=default log line emitted for empty LOOM_MODEL (#3482)"
 
 # ============================================================
 # Summary

--- a/defaults/scripts/tests/test-sweep-checkpoint.sh
+++ b/defaults/scripts/tests/test-sweep-checkpoint.sh
@@ -208,6 +208,77 @@ fi
 out=$("$CHECKPOINT" attempt 50)
 assert_eq "attempt cleared after attempt-less rewrite" "" "$out"
 
+# --- Optional model field (#3482, Phase 3a per-model observability) ---
+
+# 24. write with --model round-trips through read and model
+assert "write doctor-done with --model" "$CHECKPOINT" write 60 doctor-done --task-id t --pr-number 321 --attempt 2 --model claude-opus-4-8
+out=$("$CHECKPOINT" read 60)
+if echo "$out" | grep -q '"model": "claude-opus-4-8"'; then
+    echo "PASS: model persisted as string in JSON"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: model missing or wrong: $out" >&2
+    FAIL=$((FAIL + 1))
+fi
+out=$("$CHECKPOINT" model 60)
+assert_eq "model command reads back claude-opus-4-8" "claude-opus-4-8" "$out"
+
+# 25. pr_number and attempt still intact alongside model
+out=$("$CHECKPOINT" read 60)
+if echo "$out" | grep -q '"pr_number": 321' && echo "$out" | grep -q '"attempt": 2'; then
+    echo "PASS: pr_number and attempt coexist with model"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: pr_number/attempt lost when model present: $out" >&2
+    FAIL=$((FAIL + 1))
+fi
+
+# 26. Backward compat: write WITHOUT --model omits the field entirely
+"$CHECKPOINT" write 61 builder-done --task-id t >/dev/null
+out=$("$CHECKPOINT" read 61)
+if echo "$out" | grep -q '"model"'; then
+    echo "FAIL: model field should be omitted when not provided: $out" >&2
+    FAIL=$((FAIL + 1))
+else
+    echo "PASS: model field omitted when not provided"
+    PASS=$((PASS + 1))
+fi
+
+# 27. Legacy checkpoint (no model field): model prints empty, exit 0
+out=$("$CHECKPOINT" model 61)
+assert_eq "model is empty on legacy checkpoint (= default/unknown)" "" "$out"
+assert_exit "model on legacy checkpoint exits 0" 0 "$CHECKPOINT" model 61
+
+# 28. Legacy checkpoint read path unaffected (phase still resolves)
+out=$("$CHECKPOINT" phase 61)
+assert_eq "phase still reads on model-less checkpoint" "builder-done" "$out"
+
+# 29. model on missing checkpoint: empty output, exit 0 (mirrors phase/attempt)
+out=$("$CHECKPOINT" model 9999)
+assert_eq "model is empty when no checkpoint" "" "$out"
+assert_exit "model on missing checkpoint exits 0" 0 "$CHECKPOINT" model 9999
+
+# 30. Invalid --model values rejected with exit 1 (JSON-unsafe charset)
+assert_exit "model with quote exits 1" 1 "$CHECKPOINT" write 62 doctor-done --model 'op"us'
+assert_exit "model with space exits 1" 1 "$CHECKPOINT" write 62 doctor-done --model 'op us'
+if "$CHECKPOINT" exists 62 >/dev/null 2>&1; then
+    echo "FAIL: rejected --model write should not create a checkpoint" >&2
+    FAIL=$((FAIL + 1))
+else
+    echo "PASS: rejected --model write leaves no checkpoint behind"
+    PASS=$((PASS + 1))
+fi
+
+# 31. Alias model values accepted (sonnet/opus/haiku)
+assert "alias model 'sonnet' accepted" "$CHECKPOINT" write 63 judge-done --model sonnet
+out=$("$CHECKPOINT" model 63)
+assert_eq "alias model reads back" "sonnet" "$out"
+
+# 32. Overwrite a model-bearing checkpoint without --model drops the field
+"$CHECKPOINT" write 60 doctor-done --task-id t >/dev/null
+out=$("$CHECKPOINT" model 60)
+assert_eq "model cleared after model-less rewrite" "" "$out"
+
 echo
 echo "Results: $PASS passed, $FAIL failed"
 [[ $FAIL -eq 0 ]] || exit 1

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -333,7 +333,11 @@ impl SweepRegistry {
             .spawn_child(issue_number, &log_path, &sweep_id, model)
             .context("failed to spawn sweep child")?;
 
-        // 6. Record the entry.
+        // 6. Record the entry. The model is carried on the registry entry
+        //    (#3482, Phase 3a observability) so `list_sweeps` /
+        //    `get_sweep_status` can report which model a sweep runs. Empty
+        //    strings are normalized to None, matching the spawn-side rule
+        //    that `--model ""` is never emitted.
         let info = SweepInfo {
             sweep_id: sweep_id.clone(),
             kind: kind.clone(),
@@ -345,6 +349,7 @@ impl SweepRegistry {
             state: SweepState::Running,
             latest_phase: None,
             pr_number: None,
+            model: model.filter(|m| !m.is_empty()).map(String::from),
         };
         self.entries.insert(sweep_id.clone(), info);
 
@@ -909,6 +914,9 @@ impl SweepRegistry {
                         state: SweepState::Running,
                         latest_phase: None,
                         pr_number: None,
+                        // Lock owner.json does not record the model; the
+                        // dispatching daemon instance is gone (#3482).
+                        model: None,
                     },
                 );
                 admitted += 1;
@@ -958,6 +966,7 @@ impl SweepRegistry {
                         state: SweepState::Crashed { at: Utc::now() },
                         latest_phase: phase,
                         pr_number: None,
+                        model: None, // not recoverable from a checkpoint-only entry
                     },
                 );
                 admitted += 1;
@@ -1276,6 +1285,8 @@ exit 0
             !recorded.contains("--model"),
             "model=None must not emit --model; got: {recorded}"
         );
+        // #3482: model=None dispatches record no model on the entry.
+        assert_eq!(registry.get(&outcome.sweep_id).unwrap().model, None);
 
         // The lock dir should exist while Running.
         let lock = dir.path().join(".loom").join("locks").join("issue-42");
@@ -1304,6 +1315,13 @@ exit 0
             recorded.contains("argv: -p /loom:sweep 43 --model claude-sonnet-4-6"),
             "expected --model in argv; got: {recorded}"
         );
+        // #3482 (Phase 3a): the dispatch model is carried on the registry
+        // entry so list_sweeps / get_sweep_status report it.
+        assert_eq!(
+            registry.get(&outcome.sweep_id).unwrap().model.as_deref(),
+            Some("claude-sonnet-4-6"),
+            "dispatch model must be recorded on the SweepInfo entry"
+        );
     }
 
     /// Issue #3477: an empty-string model is treated as unset — `--model ""`
@@ -1328,6 +1346,12 @@ exit 0
         assert!(
             !recorded.contains("--model"),
             "empty model must not emit --model; got: {recorded}"
+        );
+        // #3482: empty-string model normalizes to None on the entry too.
+        assert_eq!(
+            registry.get(&outcome.sweep_id).unwrap().model,
+            None,
+            "empty model must be recorded as None on the SweepInfo entry"
         );
     }
 
@@ -1442,6 +1466,7 @@ exit 0
                 state: SweepState::Running,
                 latest_phase: None,
                 pr_number: None,
+                model: None,
             },
         );
 
@@ -1511,6 +1536,7 @@ exit 0
                 state: SweepState::Running,
                 latest_phase: None,
                 pr_number: None,
+                model: None,
             },
         );
 
@@ -1562,6 +1588,7 @@ exit 0
                 state: SweepState::Running,
                 latest_phase: None,
                 pr_number: None,
+                model: None,
             },
         );
 
@@ -1595,6 +1622,7 @@ exit 0
                 state: SweepState::Running,
                 latest_phase: None,
                 pr_number: None,
+                model: None,
             },
         );
 
@@ -1791,6 +1819,7 @@ exit 0
             state: SweepState::Running,
             latest_phase: Some("builder".to_string()),
             pr_number: Some(456),
+            model: Some("claude-sonnet-4-6".to_string()),
         };
         let json = serde_json::to_value(vec![info]).unwrap();
         let expected = serde_json::json!([{
@@ -1804,10 +1833,32 @@ exit 0
             "state": {"state": "Running"},
             "latest_phase": "builder",
             "pr_number": 456,
+            "model": "claude-sonnet-4-6",
         }]);
         assert_eq!(
             json, expected,
             "SweepInfo wire schema drifted — update the snapshot intentionally if this is desired"
+        );
+
+        // model=None is omitted from the wire (skip_serializing_if), and
+        // pre-#3482 JSON without the field deserializes to model=None —
+        // the backward-compat half of the schema pin.
+        let legacy_json = serde_json::json!({
+            "sweep_id": "sweep-issue-43-1700000000",
+            "kind": {"type": "Issue", "value": 43},
+            "pid": 1,
+            "token_name": "unknown",
+            "log_path": ".loom/logs/sweep-issue-43.log",
+            "started_at": "2026-06-05T10:00:00Z",
+            "state": {"state": "Running"},
+        });
+        let legacy: SweepInfo =
+            serde_json::from_value(legacy_json).expect("legacy SweepInfo without model must parse");
+        assert_eq!(legacy.model, None);
+        let reserialized = serde_json::to_value(&legacy).unwrap();
+        assert!(
+            reserialized.get("model").is_none(),
+            "model=None must be omitted from serialized SweepInfo"
         );
 
         // Also pin the variant shapes for Exited and Crashed.
@@ -1866,6 +1917,7 @@ exit 0
                 state: SweepState::Running,
                 latest_phase: Some("builder".into()),
                 pr_number: None,
+                model: None,
             },
         );
 
@@ -1902,6 +1954,7 @@ exit 0
                 state: SweepState::Running,
                 latest_phase: None,
                 pr_number: None,
+                model: None,
             },
         );
 
@@ -1960,6 +2013,7 @@ exit 0
                 },
                 latest_phase: None,
                 pr_number: None,
+                model: None,
             },
         );
 
@@ -1996,6 +2050,7 @@ exit 0
                 state: SweepState::Running,
                 latest_phase: None,
                 pr_number: None,
+                model: None,
             },
         );
 
@@ -2050,6 +2105,7 @@ exit 0
                 state: SweepState::Running,
                 latest_phase: None,
                 pr_number: None,
+                model: None,
             },
         );
 
@@ -2101,6 +2157,7 @@ exit 0
                 state: SweepState::Running,
                 latest_phase: None,
                 pr_number: None,
+                model: None,
             },
         );
 

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -453,6 +453,15 @@ pub struct SweepInfo {
     /// future phases (Phase A always sets this to `None`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pr_number: Option<i32>,
+    /// Model requested at dispatch time (issue #3482, Phase 3a
+    /// observability). Mirrors the `model` param of `DispatchSweep`:
+    /// `Some(value)` when an explicit non-empty model was supplied,
+    /// `None` otherwise — consumers should render `None` as "default"
+    /// (the child inherited the session/CLI default; no `--model` flag
+    /// was emitted). `#[serde(default)]` keeps pre-#3482 wire data and
+    /// clients compatible.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
 }
 
 // ========================================================================

--- a/loom-tools/src/loom_tools/agent_metrics.py
+++ b/loom-tools/src/loom_tools/agent_metrics.py
@@ -100,7 +100,13 @@ class SummaryMetrics:
 
 @dataclass
 class EffectivenessRow:
-    """Effectiveness metrics for a single role."""
+    """Effectiveness metrics for a single role (optionally per model).
+
+    ``model`` (#3482, Phase 3a) is populated only when grouping by model
+    (``--by-model``); NULL/absent model values in the DB render as
+    ``"default"``. When empty, the key is omitted from ``to_dict`` so the
+    pre-#3482 JSON shape is byte-identical for existing consumers.
+    """
 
     role: str = ""
     total_prompts: int = 0
@@ -108,9 +114,10 @@ class EffectivenessRow:
     success_rate: float = 0.0
     avg_cost: float = 0.0
     avg_duration_sec: float = 0.0
+    model: str = ""
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        d: dict[str, Any] = {
             "role": self.role,
             "total_prompts": self.total_prompts,
             "successful_prompts": self.successful_prompts,
@@ -118,24 +125,34 @@ class EffectivenessRow:
             "avg_cost": self.avg_cost,
             "avg_duration_sec": self.avg_duration_sec,
         }
+        if self.model:
+            d["model"] = self.model
+        return d
 
 
 @dataclass
 class CostRow:
-    """Cost breakdown for a single issue."""
+    """Cost breakdown for a single issue (optionally per model).
+
+    ``model`` semantics match :class:`EffectivenessRow` (#3482).
+    """
 
     issue_number: int = 0
     prompt_count: int = 0
     total_cost: float = 0.0
     total_tokens: int = 0
+    model: str = ""
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        d: dict[str, Any] = {
             "issue_number": self.issue_number,
             "prompt_count": self.prompt_count,
             "total_cost": self.total_cost,
             "total_tokens": self.total_tokens,
         }
+        if self.model:
+            d["model"] = self.model
+        return d
 
 
 @dataclass
@@ -197,6 +214,36 @@ def _query_db(db_path: pathlib.Path, sql: str) -> list[dict[str, Any]]:
         return [dict(row) for row in rows]
     finally:
         conn.close()
+
+
+def _db_has_model_column(db_path: pathlib.Path) -> bool:
+    """Return True when ``resource_usage.model`` exists in *db_path*.
+
+    Older activity databases predate the model column (and possibly the
+    ``resource_usage`` table itself); per-model grouping must degrade
+    gracefully rather than erroring on them (#3482).
+    """
+    conn = sqlite3.connect(str(db_path))
+    try:
+        rows = conn.execute("PRAGMA table_info(resource_usage)").fetchall()
+        return any(row[1] == "model" for row in rows)
+    except sqlite3.Error:
+        return False
+    finally:
+        conn.close()
+
+
+def _model_expr(db_path: pathlib.Path) -> str:
+    """SQL expression for the model dimension, NULL/absent-tolerant.
+
+    NULL and empty-string models render as ``'default'`` (rows recorded
+    before per-model attribution, or spawns that inherited the session/CLI
+    default). On schemas without the column, a literal ``'default'`` keeps
+    the query valid so old databases never break metrics (#3482).
+    """
+    if _db_has_model_column(db_path):
+        return "COALESCE(NULLIF(r.model, ''), 'default')"
+    return "'default'"
 
 
 # ---------------------------------------------------------------------------
@@ -264,16 +311,28 @@ def get_effectiveness(
     db_path: pathlib.Path,
     role: str,
     period: str,
+    by_model: bool = False,
 ) -> list[EffectivenessRow]:
-    """Get effectiveness metrics grouped by role."""
+    """Get effectiveness metrics grouped by role (and model when *by_model*).
+
+    With ``by_model=True`` (#3482, Phase 3a) each (role, model) pair gets
+    its own row, using the existing ``resource_usage.model`` column;
+    NULL/absent model values group under ``'default'``.
+    """
     role_filter = _get_role_filter(role)
     period_filter = _get_period_filter(period)
+    model_select = ""
+    model_group = ""
+    if by_model:
+        model_select = f"{_model_expr(db_path)} as model,"
+        model_group = f", {_model_expr(db_path)}"
 
     rows = _query_db(
         db_path,
         f"""
         SELECT
             COALESCE(i.agent_role, 'unknown') as role,
+            {model_select}
             COUNT(*) as total_prompts,
             SUM(
                 CASE WHEN q.tests_passed > 0
@@ -294,7 +353,7 @@ def get_effectiveness(
         LEFT JOIN quality_metrics q ON i.id = q.input_id
         LEFT JOIN resource_usage r ON i.id = r.input_id
         WHERE 1=1 {role_filter} {period_filter}
-        GROUP BY COALESCE(i.agent_role, 'unknown')
+        GROUP BY COALESCE(i.agent_role, 'unknown'){model_group}
         ORDER BY success_rate DESC
         """,
     )
@@ -307,6 +366,7 @@ def get_effectiveness(
             success_rate=r.get("success_rate", 0.0) or 0.0,
             avg_cost=r.get("avg_cost", 0.0) or 0.0,
             avg_duration_sec=r.get("avg_duration_sec", 0.0) or 0.0,
+            model=(r.get("model") or "default") if by_model else "",
         )
         for r in rows
     ]
@@ -315,15 +375,26 @@ def get_effectiveness(
 def get_costs(
     db_path: pathlib.Path,
     issue_number: int | None,
+    by_model: bool = False,
 ) -> list[CostRow]:
-    """Get cost breakdown by issue."""
+    """Get cost breakdown by issue (and model when *by_model*).
+
+    With ``by_model=True`` (#3482, Phase 3a) each (issue, model) pair gets
+    its own row; NULL/absent model values group under ``'default'``.
+    """
     issue_filter = f"WHERE pg.issue_number = {issue_number}" if issue_number else ""
+    model_select = ""
+    model_group = ""
+    if by_model:
+        model_select = f"{_model_expr(db_path)} as model,"
+        model_group = f", {_model_expr(db_path)}"
 
     rows = _query_db(
         db_path,
         f"""
         SELECT
             pg.issue_number,
+            {model_select}
             COUNT(DISTINCT i.id) as prompt_count,
             ROUND(COALESCE(SUM(r.cost_usd), 0), 4) as total_cost,
             COALESCE(SUM(r.tokens_input + r.tokens_output), 0) as total_tokens
@@ -331,7 +402,7 @@ def get_costs(
         JOIN agent_inputs i ON pg.input_id = i.id
         LEFT JOIN resource_usage r ON i.id = r.input_id
         {issue_filter}
-        GROUP BY pg.issue_number
+        GROUP BY pg.issue_number{model_group}
         ORDER BY total_cost DESC
         LIMIT 20
         """,
@@ -343,6 +414,7 @@ def get_costs(
             prompt_count=r.get("prompt_count", 0) or 0,
             total_cost=r.get("total_cost", 0.0) or 0.0,
             total_tokens=r.get("total_tokens", 0) or 0,
+            model=(r.get("model") or "default") if by_model else "",
         )
         for r in rows
         if r.get("issue_number") is not None
@@ -417,19 +489,37 @@ def format_summary_text(m: SummaryMetrics, period: str) -> str:
 
 
 def format_effectiveness_text(rows: list[EffectivenessRow], period: str) -> str:
-    """Format effectiveness table for human display."""
+    """Format effectiveness table for human display.
+
+    A Model column is included when any row carries a model dimension
+    (``--by-model``, #3482).
+    """
+    with_model = any(r.model for r in rows)
+    if with_model:
+        header = (
+            f"{'Role':<12} {'Model':<22} {'Prompts':>10} {'Success':>10} "
+            f"{'Rate':>10} {'Avg Cost':>10} {'Avg Time':>10}"
+        )
+        width = 90
+    else:
+        header = (
+            f"{'Role':<12} {'Prompts':>10} {'Success':>10} "
+            f"{'Rate':>10} {'Avg Cost':>10} {'Avg Time':>10}"
+        )
+        width = 68
     lines = [
         "",
         _c(_BLUE, "Agent Effectiveness by Role") + f" ({period})",
-        _c(_GRAY, "\u2500" * 68),
-        f"{'Role':<12} {'Prompts':>10} {'Success':>10} {'Rate':>10} {'Avg Cost':>10} {'Avg Time':>10}",
-        _c(_GRAY, "\u2500" * 68),
+        _c(_GRAY, "\u2500" * width),
+        header,
+        _c(_GRAY, "\u2500" * width),
     ]
     for r in rows:
         rate_clr = _rate_color(r.success_rate)
         rate_str = _c(rate_clr, f"{r.success_rate:.1f}%")
+        model_col = f"{(r.model or 'default'):<22} " if with_model else ""
         lines.append(
-            f"{r.role:<12} {r.total_prompts:>10} {r.successful_prompts:>10} "
+            f"{r.role:<12} {model_col}{r.total_prompts:>10} {r.successful_prompts:>10} "
             f"{rate_str:>10} {'$' + f'{r.avg_cost:.4f}':>10} {f'{r.avg_duration_sec:.1f}s':>10}"
         )
     lines.append("")
@@ -437,17 +527,29 @@ def format_effectiveness_text(rows: list[EffectivenessRow], period: str) -> str:
 
 
 def format_costs_text(rows: list[CostRow]) -> str:
-    """Format cost table for human display."""
+    """Format cost table for human display.
+
+    A Model column is included when any row carries a model dimension
+    (``--by-model``, #3482).
+    """
+    with_model = any(r.model for r in rows)
+    if with_model:
+        header = f"{'Issue':<8} {'Model':<22} {'Prompts':>10} {'Cost':>12} {'Tokens':>12}"
+        width = 90
+    else:
+        header = f"{'Issue':<8} {'Prompts':>10} {'Cost':>12} {'Tokens':>12}"
+        width = 68
     lines = [
         "",
         _c(_BLUE, "Cost Breakdown by Issue"),
-        _c(_GRAY, "\u2500" * 68),
-        f"{'Issue':<8} {'Prompts':>10} {'Cost':>12} {'Tokens':>12}",
-        _c(_GRAY, "\u2500" * 68),
+        _c(_GRAY, "\u2500" * width),
+        header,
+        _c(_GRAY, "\u2500" * width),
     ]
     for r in rows:
+        model_col = f"{(r.model or 'default'):<22} " if with_model else ""
         lines.append(
-            f"{'#' + str(r.issue_number):<8} {r.prompt_count:>10} "
+            f"{'#' + str(r.issue_number):<8} {model_col}{r.prompt_count:>10} "
             f"{'$' + f'{r.total_cost:.4f}':>12} {r.total_tokens:>12}"
         )
     lines.append("")
@@ -503,6 +605,8 @@ Options:
   --period PERIOD       Time period: today, week, month, all (default: week)
   --format FORMAT       Output format: text, json (default: text)
   --issue NUMBER        Filter by issue number (costs command)
+  --by-model            Add a per-model dimension (effectiveness/costs commands);
+                        NULL/absent model values render as 'default' (#3482)
 
 Exit codes:
   0 - Success
@@ -512,7 +616,9 @@ Examples:
   loom-agent-metrics                           # Summary for this week
   loom-agent-metrics --role builder            # Builder metrics
   loom-agent-metrics effectiveness             # Effectiveness by role
+  loom-agent-metrics effectiveness --by-model  # Effectiveness by role x model
   loom-agent-metrics costs --issue 123         # Cost for issue #123
+  loom-agent-metrics costs --by-model          # Cost per issue x model
   loom-agent-metrics velocity --format json    # Velocity as JSON
 """,
     )
@@ -548,6 +654,15 @@ Examples:
         type=int,
         default=None,
         help="Filter by issue number (costs command)",
+    )
+    parser.add_argument(
+        "--by-model",
+        dest="by_model",
+        action="store_true",
+        help=(
+            "Add a per-model dimension to effectiveness/costs output; "
+            "NULL/absent model values render as 'default' (#3482)"
+        ),
     )
 
     args = parser.parse_args(argv)
@@ -612,7 +727,7 @@ def _cmd_summary(db_path: pathlib.Path, args: argparse.Namespace) -> int:
 
 
 def _cmd_effectiveness(db_path: pathlib.Path, args: argparse.Namespace) -> int:
-    rows = get_effectiveness(db_path, args.role, args.period)
+    rows = get_effectiveness(db_path, args.role, args.period, by_model=args.by_model)
     if args.output_format == "json":
         print(json.dumps([r.to_dict() for r in rows], indent=2))
     else:
@@ -621,7 +736,7 @@ def _cmd_effectiveness(db_path: pathlib.Path, args: argparse.Namespace) -> int:
 
 
 def _cmd_costs(db_path: pathlib.Path, args: argparse.Namespace) -> int:
-    rows = get_costs(db_path, args.issue)
+    rows = get_costs(db_path, args.issue, by_model=args.by_model)
     if args.output_format == "json":
         print(json.dumps([r.to_dict() for r in rows], indent=2))
     else:

--- a/loom-tools/tests/test_agent_metrics.py
+++ b/loom-tools/tests/test_agent_metrics.py
@@ -100,6 +100,73 @@ def activity_db(tmp_path: pathlib.Path) -> pathlib.Path:
 
 
 @pytest.fixture
+def model_db(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Activity DB whose resource_usage table HAS the model column (#3482).
+
+    Includes a NULL-model row and an empty-string-model row to exercise the
+    'absent model renders as default' acceptance criterion.
+    """
+    db_path = tmp_path / "model-activity.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(
+        """
+        CREATE TABLE agent_inputs (
+            id INTEGER PRIMARY KEY,
+            agent_role TEXT,
+            timestamp TEXT
+        );
+        CREATE TABLE resource_usage (
+            input_id INTEGER,
+            model TEXT,
+            tokens_input INTEGER,
+            tokens_output INTEGER,
+            cost_usd REAL,
+            duration_ms INTEGER
+        );
+        CREATE TABLE prompt_github (
+            input_id INTEGER,
+            issue_number INTEGER,
+            pr_number INTEGER,
+            event_type TEXT
+        );
+        CREATE TABLE quality_metrics (
+            input_id INTEGER,
+            tests_passed INTEGER,
+            tests_failed INTEGER
+        );
+
+        -- builder: two opus prompts, one sonnet prompt, one NULL-model prompt
+        INSERT INTO agent_inputs VALUES (1, 'builder', datetime('now', '-1 day'));
+        INSERT INTO agent_inputs VALUES (2, 'builder', datetime('now', '-1 day'));
+        INSERT INTO agent_inputs VALUES (3, 'builder', datetime('now', '-2 days'));
+        INSERT INTO agent_inputs VALUES (4, 'builder', datetime('now', '-2 days'));
+        -- judge: one empty-string-model prompt (treated as default)
+        INSERT INTO agent_inputs VALUES (5, 'judge', datetime('now', '-1 day'));
+
+        INSERT INTO resource_usage VALUES (1, 'claude-opus-4-8', 1000, 500, 0.10, 30000);
+        INSERT INTO resource_usage VALUES (2, 'claude-opus-4-8', 2000, 1000, 0.20, 40000);
+        INSERT INTO resource_usage VALUES (3, 'claude-sonnet-4-6', 500, 250, 0.02, 10000);
+        INSERT INTO resource_usage VALUES (4, NULL, 800, 400, 0.04, 15000);
+        INSERT INTO resource_usage VALUES (5, '', 600, 300, 0.03, 12000);
+
+        INSERT INTO prompt_github VALUES (1, 42, NULL, 'issue_work');
+        INSERT INTO prompt_github VALUES (2, 42, NULL, 'issue_work');
+        INSERT INTO prompt_github VALUES (3, 42, NULL, 'issue_work');
+        INSERT INTO prompt_github VALUES (4, 43, NULL, 'issue_work');
+        INSERT INTO prompt_github VALUES (5, NULL, 100, 'pr_review');
+
+        INSERT INTO quality_metrics VALUES (1, 5, 0);
+        INSERT INTO quality_metrics VALUES (2, 0, 2);
+        INSERT INTO quality_metrics VALUES (3, 3, 0);
+        INSERT INTO quality_metrics VALUES (4, 1, 0);
+        INSERT INTO quality_metrics VALUES (5, 2, 0);
+        """
+    )
+    conn.close()
+    return db_path
+
+
+@pytest.fixture
 def empty_db(tmp_path: pathlib.Path) -> pathlib.Path:
     """Create an empty activity database (tables exist but no rows)."""
     db_path = tmp_path / "empty.db"
@@ -296,6 +363,112 @@ class TestCosts:
     def test_empty_db(self, empty_db: pathlib.Path) -> None:
         rows = get_costs(empty_db, issue_number=None)
         assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# Per-model dimension tests (#3482, Phase 3a)
+# ---------------------------------------------------------------------------
+
+
+class TestByModel:
+    """Tests for the --by-model grouping dimension."""
+
+    def test_effectiveness_groups_by_role_and_model(self, model_db: pathlib.Path) -> None:
+        rows = get_effectiveness(model_db, role="", period="all", by_model=True)
+        pairs = {(r.role, r.model) for r in rows}
+        assert ("builder", "claude-opus-4-8") in pairs
+        assert ("builder", "claude-sonnet-4-6") in pairs
+        # NULL model groups under 'default'
+        assert ("builder", "default") in pairs
+        # Empty-string model also groups under 'default'
+        assert ("judge", "default") in pairs
+
+    def test_effectiveness_model_row_counts(self, model_db: pathlib.Path) -> None:
+        rows = get_effectiveness(model_db, role="builder", period="all", by_model=True)
+        by_model = {r.model: r for r in rows}
+        assert by_model["claude-opus-4-8"].total_prompts == 2
+        assert by_model["claude-sonnet-4-6"].total_prompts == 1
+        assert by_model["default"].total_prompts == 1
+
+    def test_effectiveness_without_by_model_unchanged(self, model_db: pathlib.Path) -> None:
+        """Default (no --by-model) output keeps the pre-#3482 shape."""
+        rows = get_effectiveness(model_db, role="", period="all")
+        assert all(r.model == "" for r in rows)
+        for r in rows:
+            assert "model" not in r.to_dict()
+
+    def test_effectiveness_json_includes_model_key(self, model_db: pathlib.Path) -> None:
+        rows = get_effectiveness(model_db, role="", period="all", by_model=True)
+        parsed = json.loads(json.dumps([r.to_dict() for r in rows]))
+        assert all("model" in r for r in parsed)
+
+    def test_costs_groups_by_issue_and_model(self, model_db: pathlib.Path) -> None:
+        rows = get_costs(model_db, issue_number=42, by_model=True)
+        models = {r.model for r in rows}
+        assert models == {"claude-opus-4-8", "claude-sonnet-4-6"}
+        assert all(r.issue_number == 42 for r in rows)
+
+    def test_costs_null_model_renders_default(self, model_db: pathlib.Path) -> None:
+        rows = get_costs(model_db, issue_number=43, by_model=True)
+        assert len(rows) == 1
+        assert rows[0].model == "default"
+
+    def test_costs_without_by_model_unchanged(self, model_db: pathlib.Path) -> None:
+        rows = get_costs(model_db, issue_number=None)
+        assert all(r.model == "" for r in rows)
+        for r in rows:
+            assert "model" not in r.to_dict()
+
+    def test_by_model_degrades_on_schema_without_model_column(
+        self, activity_db: pathlib.Path
+    ) -> None:
+        """Old DBs whose resource_usage lacks the model column must not break."""
+        rows = get_effectiveness(activity_db, role="", period="all", by_model=True)
+        assert len(rows) >= 1
+        assert all(r.model == "default" for r in rows)
+
+        cost_rows = get_costs(activity_db, issue_number=None, by_model=True)
+        assert len(cost_rows) >= 1
+        assert all(r.model == "default" for r in cost_rows)
+
+    def test_effectiveness_text_has_model_column(self, model_db: pathlib.Path) -> None:
+        rows = get_effectiveness(model_db, role="", period="all", by_model=True)
+        output = format_effectiveness_text(rows, "all")
+        assert "Model" in output
+        assert "claude-opus-4-8" in output
+        assert "default" in output
+
+    def test_effectiveness_text_no_model_column_by_default(
+        self, model_db: pathlib.Path
+    ) -> None:
+        rows = get_effectiveness(model_db, role="", period="all")
+        output = format_effectiveness_text(rows, "all")
+        assert "Model" not in output
+
+    def test_costs_text_has_model_column(self, model_db: pathlib.Path) -> None:
+        rows = get_costs(model_db, issue_number=None, by_model=True)
+        output = format_costs_text(rows)
+        assert "Model" in output
+
+    def test_cli_by_model_flag(self, model_db: pathlib.Path, mock_repo: pathlib.Path) -> None:
+        with mock.patch("loom_tools.agent_metrics.find_repo_root", return_value=mock_repo):
+            with mock.patch(
+                "loom_tools.agent_metrics._get_activity_db_path", return_value=model_db
+            ):
+                rc = main(
+                    ["effectiveness", "--by-model", "--format", "json", "--period", "all"]
+                )
+        assert rc == 0
+
+    def test_cli_costs_by_model_flag(
+        self, model_db: pathlib.Path, mock_repo: pathlib.Path
+    ) -> None:
+        with mock.patch("loom_tools.agent_metrics.find_repo_root", return_value=mock_repo):
+            with mock.patch(
+                "loom_tools.agent_metrics._get_activity_db_path", return_value=model_db
+            ):
+                rc = main(["costs", "--by-model", "--format", "json"])
+        assert rc == 0
 
 
 # ---------------------------------------------------------------------------

--- a/mcp-loom/src/tools/sweeps.ts
+++ b/mcp-loom/src/tools/sweeps.ts
@@ -71,6 +71,12 @@ export interface SweepInfo {
   state: SweepState;
   latest_phase?: string;
   pr_number?: number;
+  /**
+   * Model requested at dispatch (issue #3482, Phase 3a observability).
+   * Absent/undefined means no explicit model was supplied — the child
+   * inherited the session/CLI default; render as "default".
+   */
+  model?: string;
 }
 
 interface DispatchResponse {
@@ -661,6 +667,8 @@ function formatSweepLine(info: SweepInfo): string {
     `  PID:        ${info.pid}`,
     `  State:      ${stateLabel}`,
     `  Token:      ${info.token_name}`,
+    // Issue #3482 (Phase 3a): absent model renders as "default".
+    `  Model:      ${info.model ?? "default"}`,
     `  Log:        ${info.log_path}`,
     `  Started:    ${info.started_at}`,
   ];
@@ -737,6 +745,10 @@ export async function handleSweepTool(
         `Sweep ID:   ${result.result.sweep_id}`,
         `PID:        ${result.result.pid}`,
         `Token:      ${result.result.token_name}`,
+        // Issue #3482 (Phase 3a): echo the dispatched model so the spawn
+        // is attributable from the dispatch transcript alone. "default"
+        // means no --model flag was emitted (session/CLI default).
+        `Model:      ${model ?? "default"}`,
         `Log:        ${result.result.log_path}`,
       ].join("\n");
       return [


### PR DESCRIPTION
Closes #3482

Implements the curator-scoped **Phase 3a: per-model observability** only. Routing policy and account×model selection (Phase 3b) remain out of scope and should be filed as a new issue once per-model metrics accumulate.

## Summary

The model was plumbed everywhere but recorded almost nowhere. This PR records the selected model at every point where spawns/dispatches are logged, and adds a per-model dimension to metrics — **observability only, zero behavior change to model selection or spawning**.

- **`spawn-claude.sh`**: always emits exactly one structured `spawn-claude: model=<value>` stderr line — explicit `--model` arg (both `--model v` and `--model=v` forms), `LOOM_MODEL` env, and `model=default` when nothing is configured. Previously only the `LOOM_MODEL` case logged.
- **`loom-daemon`**: `SweepInfo` gains `model: Option<String>` (`#[serde(default)]` + omit-when-`None` — pre-#3482 wire data and clients keep working). Populated at dispatch (empty string normalized to `None`, matching the no-`--model ""` spawn rule); `None` on lock/checkpoint reconstruction. Schema snapshot test updated deliberately, plus a legacy-JSON round-trip pin.
- **`mcp-loom`**: `dispatch_sweep` / `list_sweeps` / `get_sweep_status` output now includes `Model: <value|default>`.
- **`sweep-checkpoint.sh`**: optional `--model` write field + `model` reader subcommand, mirroring the `--attempt` pattern from #3484 — charset-validated (`[A-Za-z0-9._-]+`, JSON-safe), omitted entirely when absent, legacy checkpoints read cleanly (absent = default/unknown).
- **`sweep.md`**: orchestrator instructed to record the resolved model on checkpoint writes (Doctor examples carry `--model <doctor-model>`; other phases note the optional flag).
- **`agent_metrics.py`** (+ `agent-metrics.sh` help text): new `--by-model` flag for `effectiveness` and `costs`, grouping on the existing `resource_usage.model` column. NULL/empty models render as `default`; schemas without the model column degrade gracefully to `default` (old DBs never break). Default (no flag) output is byte-identical to before — the `model` JSON key is only emitted under `--by-model`, so the MCP/stub interface stays stable.

## Acceptance criteria coverage

- [x] Model recorded at spawn time in all paths: spawn-claude log line (3 cases incl. `model=default`), `SweepInfo.model`, checkpoint `model` field
- [x] `list_sweeps` / `get_sweep_status` include the model (or `default`)
- [x] `agent-metrics.sh` can group/report by model; NULL renders as `default`
- [x] Zero behavior change to spawning — log lines, registry bookkeeping, and metrics queries only
- [x] Checkpoint readers tolerate legacy checkpoints without the field
- [x] Tests across all four surfaces (see below)

## Test plan

- [x] `bash defaults/scripts/tests/test-spawn-claude.sh` — 36/36 pass (5 new structured-log assertions)
- [x] `bash defaults/scripts/tests/test-sweep-checkpoint.sh` — 52/52 pass (9 new model-field cases incl. legacy/back-compat and charset rejection)
- [x] `cargo test` (loom-daemon) — 351 lib + integration tests pass; `cargo fmt --check` clean; CI-profile clippy clean
- [x] `pytest loom-tools/tests/test_agent_metrics.py` — 61/61 pass (13 new by-model tests incl. NULL/empty model → `default`, old-schema degradation, JSON-shape stability)
- [x] `npm run build` / `typecheck` (mcp-loom) — clean
- [x] shellcheck (CI profile, severity=warning) clean on all touched scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)