### PR TITLE
feat(merge-pr.sh): Gitea support for UNSTABLE-fallback

### DIFF
--- a/defaults/scripts/lib/forge-helpers.sh
+++ b/defaults/scripts/lib/forge-helpers.sh
@@ -656,24 +656,88 @@ forge_get_pr_reviews() {
 #   checks" means every failing check is informational, which is the case the
 #   UNSTABLE-fallback wants to unblock.
 #
-# Gitea: TODO (#3486). The Gitea branch-protection API has different semantics
-#   for status checks — branch protection rules carry a `status_check_contexts`
-#   array on `GET /repos/{owner}/{repo}/branch_protections/{name}`, but its
-#   "required" semantics need a separate verification before we'd want to
-#   short-circuit the safety net. For v0.10.0 we return a sentinel ("__GITEA_TODO__")
-#   so the merge-pr.sh fallback fails-closed (treats EVERY failing check as
-#   required, leaving the existing UNSTABLE refusal intact). This matches the
-#   issue's "Forge-specific notes" guidance.
+# Gitea: GET /api/v1/repos/{owner}/{repo}/branch_protections/{name}. Gitea's
+#   branch-protection rule carries both `enable_status_check` (boolean toggle)
+#   and `status_check_contexts` (array of context patterns). The contexts are
+#   only enforced when `enable_status_check` is true — when it's false, the
+#   contexts list is informational and we emit empty output (every failing
+#   check is then treated as informational, same as the GitHub "no rule" path).
+#
+#   Distinguishing 404 (no protection rule, emit empty → fallback fires) from
+#   5xx / network error (emit empty + nonzero exit → caller fails closed) is
+#   important: the issue explicitly requires fail-closed semantics on lookup
+#   failure. `gitea_api` collapses both 4xx and 5xx into exit 1, so this
+#   function uses a direct curl invocation that captures the HTTP code and
+#   branches on it explicitly.
+#
+#   Unknown forge types fall through to a fail-closed nonzero exit, leaving
+#   the caller's existing UNSTABLE refusal intact.
 forge_get_required_status_check_contexts() {
   local nwo="$1"
   local branch="$2"
   local gh_cmd="${3:-gh}"
 
   if [[ "$FORGE_TYPE" == "gitea" ]]; then
-    # TODO(#3486): implement Gitea support. For now emit a sentinel that the
-    # merge-pr.sh caller treats as "all required" so the fallback short-circuits.
-    echo "__GITEA_TODO__"
+    forge_split_nwo "$nwo"
+
+    # Sanity-check Gitea config before issuing the request. Missing URL or
+    # token is treated as fail-closed (nonzero exit, empty stdout) so the
+    # caller preserves the UNSTABLE refusal.
+    if [[ -z "$_GITEA_BASE_URL" ]] || [[ -z "$_GITEA_TOKEN" ]]; then
+      return 1
+    fi
+    if ! _gitea_validate_basic_auth; then
+      return 1
+    fi
+
+    local url="${_GITEA_BASE_URL}/api/v1/repos/${FORGE_OWNER}/${FORGE_REPO}/branch_protections/${branch}"
+    local response
+    if [[ -n "$_GITEA_USERNAME" ]]; then
+      response=$(curl -s -w "\n%{http_code}" \
+        -X GET \
+        -u "${_GITEA_USERNAME}:${_GITEA_TOKEN}" \
+        -H "Accept: application/json" \
+        "$url" 2>/dev/null) || return 1
+    else
+      response=$(curl -s -w "\n%{http_code}" \
+        -X GET \
+        -H "Authorization: token $_GITEA_TOKEN" \
+        -H "Accept: application/json" \
+        "$url" 2>/dev/null) || return 1
+    fi
+
+    local http_code body
+    http_code=$(echo "$response" | tail -1)
+    body=$(echo "$response" | sed '$d')
+
+    # 404: no branch protection rule exists. Mirror GitHub's "no rule means no
+    # required" behavior — emit empty, exit 0 so the fallback fires.
+    if [[ "$http_code" == "404" ]]; then
+      return 0
+    fi
+
+    # 5xx / network failure / auth error / anything else non-2xx: fail closed.
+    # Empty stdout, nonzero exit; the caller will preserve the UNSTABLE refusal.
+    if [[ "$http_code" -lt 200 ]] || [[ "$http_code" -ge 300 ]]; then
+      return 1
+    fi
+
+    # 2xx: parse `enable_status_check` and `status_check_contexts`. When the
+    # toggle is off, contexts are not enforced — emit empty. Otherwise emit
+    # each context on its own line. A missing/null array also yields empty.
+    echo "$body" | jq -r '
+      if (.enable_status_check // false) then
+        (.status_check_contexts // []) | .[]
+      else
+        empty
+      end
+    ' 2>/dev/null || return 1
     return 0
+  fi
+
+  if [[ "$FORGE_TYPE" != "github" ]]; then
+    # Unknown forge — fail closed so the caller preserves the UNSTABLE refusal.
+    return 1
   fi
 
   forge_split_nwo "$nwo"

--- a/defaults/scripts/merge-pr.sh
+++ b/defaults/scripts/merge-pr.sh
@@ -380,16 +380,18 @@ if [[ "$AUTO_MERGE" == "true" ]]; then
 
       # Required contexts on the merge-target branch. Empty output means there
       # is no branch protection rule (or no required checks configured), so
-      # every failing check is informational. The Gitea variant returns a
-      # sentinel ("__GITEA_TODO__") which we treat as "all required" — that
-      # short-circuits the fallback and preserves the existing refusal until
-      # Gitea support is implemented (TODO in forge-helpers.sh, #3486).
-      _UNSTABLE_REQUIRED="$(forge_get_required_status_check_contexts "$REPO_NWO" "$_UNSTABLE_BASE_REF" "$GH" 2>/dev/null || true)"
-
-      if echo "$_UNSTABLE_REQUIRED" | grep -qx "__GITEA_TODO__"; then
-        warning "UNSTABLE-fallback is GitHub-only in v0.10.0; preserving refusal for Gitea (see #3486)"
+      # every failing check is informational. A nonzero exit from the helper
+      # signals a lookup failure (e.g. Gitea 5xx, network error, missing token,
+      # or an unknown forge) — fail closed and preserve the UNSTABLE refusal.
+      _UNSTABLE_REQUIRED=""
+      _UNSTABLE_LOOKUP_RC=0
+      _UNSTABLE_REQUIRED="$(forge_get_required_status_check_contexts "$REPO_NWO" "$_UNSTABLE_BASE_REF" "$GH" 2>/dev/null)" || _UNSTABLE_LOOKUP_RC=$?
+      if [[ "$_UNSTABLE_LOOKUP_RC" -ne 0 ]]; then
+        warning "Failed to resolve required status checks for $_UNSTABLE_BASE_REF (rc=$_UNSTABLE_LOOKUP_RC); preserving UNSTABLE refusal"
+        unset _UNSTABLE_LOOKUP_RC
         error "Failed to enable auto-merge for PR #$PR_NUMBER: $AUTO_MERGE_OUTPUT"
       fi
+      unset _UNSTABLE_LOOKUP_RC
 
       # Compute set difference: failing_checks \ required_contexts.
       # `comm -23 <failing> <required>` lists lines unique to failing.

--- a/defaults/scripts/tests/test-merge-pr-unstable-fallback.sh
+++ b/defaults/scripts/tests/test-merge-pr-unstable-fallback.sh
@@ -8,12 +8,21 @@
 # only when every failing check on the PR is OUTSIDE branch protection's
 # requiredStatusCheckContexts.
 #
-# This test exercises two surfaces:
+# This test exercises three surfaces:
 #   1. `forge_get_required_status_check_contexts` (GitHub) returns the
 #      newline-separated context list emitted by the GraphQL query, with the
 #      branchProtectionRule shape stubbed via a PATH-shimmed `gh`. Empty list
 #      and missing-rule paths both yield empty stdout.
-#   2. The set-difference policy that gates the fallback in merge-pr.sh:
+#   2. `forge_get_required_status_check_contexts` (Gitea, #3488) returns the
+#      newline-separated context list parsed from
+#      `GET /api/v1/repos/{owner}/{repo}/branch_protections/{branch}`, with
+#      `curl` PATH-shimmed to mock the Gitea API. Covers:
+#        - all-informational (enable_status_check=true, contexts populated)
+#        - at-least-one-required (preserved by the merge-pr.sh callsite)
+#        - 404 (missing branch protection → empty → fallback fires)
+#        - enable_status_check=false → empty (contexts informational only)
+#        - 5xx (fail-closed: nonzero exit, empty stdout)
+#   3. The set-difference policy that gates the fallback in merge-pr.sh:
 #      - All failing checks informational → fallback fires.
 #      - At least one failing check required → fallback does NOT fire.
 #   We test the policy by replicating the same `comm -23` / `comm -12` shape
@@ -132,7 +141,7 @@ echo "Code Ownership" > "$STUB_DIR/required-checks-single.txt"
 result=$(forge_get_required_status_check_contexts "owner/repo" "single" "$STUB_DIR/gh" | tr '\n' '|' | sed 's/|$//')
 assert_eq "Code Ownership" "$result" "GitHub: single required context returned correctly"
 
-# --- Test the set-difference policy (Gitea sentinel & GitHub) ---
+# --- Test the set-difference policy ---
 # These replicate the comm/sort/diff logic used inside merge-pr.sh so that the
 # decision can be exercised in isolation. If the inline script implementation
 # drifts away from this shape, this test starts failing.
@@ -141,18 +150,15 @@ echo "Testing set-difference policy (failing_checks \\ required_contexts)..."
 
 # Helper: returns "fire" if the fallback should fire (all failing are
 # informational), "preserve" if at least one failing is required (or there are
-# no failing checks at all, or the Gitea sentinel is present).
+# no failing checks at all). Note: in production code, a nonzero exit from
+# `forge_get_required_status_check_contexts` short-circuits to "preserve" at
+# the merge-pr.sh callsite (fail-closed on lookup failure); this helper exists
+# only for the happy-path set-difference shape.
 _policy_decision() {
     local failing="$1"
     local required="$2"
 
     if [[ -z "$failing" ]]; then
-        echo "preserve"
-        return
-    fi
-
-    # Gitea sentinel — fail-closed for v0.10.0.
-    if echo "$required" | grep -qx "__GITEA_TODO__"; then
         echo "preserve"
         return
     fi
@@ -208,19 +214,197 @@ required=$'Code Ownership'
 result=$(_policy_decision "$failing" "$required")
 assert_eq "preserve" "$result" "Empty failing set -> fallback preserves refusal"
 
-# Branch B.4: Gitea sentinel present -> fallback does NOT fire.
-failing=$'Informational A'
-required=$'__GITEA_TODO__'
-result=$(_policy_decision "$failing" "$required")
-assert_eq "preserve" "$result" "Gitea sentinel -> fallback preserves refusal (fail-closed)"
-
-# --- Test Gitea variant returns sentinel ---
+# --- Test forge_get_required_status_check_contexts (Gitea path, #3488) ---
+# The Gitea branch calls curl directly against
+#   GET ${_GITEA_BASE_URL}/api/v1/repos/${owner}/${repo}/branch_protections/${branch}
+# We PATH-shim curl so it returns canned JSON + HTTP status codes keyed on the
+# branch name extracted from the URL path. This mirrors the GitHub stub shape
+# but keys on URL path instead of argv args.
 echo ""
-echo "Testing forge_get_required_status_check_contexts (Gitea returns sentinel)..."
+echo "Testing forge_get_required_status_check_contexts (Gitea stub, #3488)..."
+
 # shellcheck disable=SC2034
-FORGE_TYPE="gitea"  # consumed by the sourced helper to pick the Gitea branch
-result=$(forge_get_required_status_check_contexts "owner/repo" "main" "$STUB_DIR/gh" | tr '\n' '|' | sed 's/|$//')
-assert_eq "__GITEA_TODO__" "$result" "Gitea: returns '__GITEA_TODO__' sentinel (TODO #3486)"
+FORGE_TYPE="gitea"
+# Provide the Gitea config the helper expects (token + URL). These are read
+# by the helper directly from the _GITEA_* globals set by _load_gitea_config.
+# We set them inline to avoid a config-file fixture.
+_GITEA_BASE_URL="https://gitea.example.com"
+_GITEA_TOKEN="fake-token-for-test"
+_GITEA_USERNAME=""
+
+# Stub curl that recognizes the Gitea branch_protections endpoint and pulls
+# canned responses + HTTP codes from $STUB_DIR keyed on the branch name.
+# Response files:
+#   $STUB_DIR/gitea-branch-protection-<branch>.json  - response body
+#   $STUB_DIR/gitea-branch-protection-<branch>.code  - HTTP status code
+# If the .code file is absent, the stub returns 200 with the body.
+# If the .json file is absent, the stub returns 404 with empty body.
+cat > "$STUB_DIR/curl" <<'STUB'
+#!/usr/bin/env bash
+# Stub curl used by test-merge-pr-unstable-fallback.sh (Gitea path).
+STUB_DIR_FROM_ENV="${LOOM_TEST_STUB_DIR:-}"
+if [[ -z "$STUB_DIR_FROM_ENV" ]]; then
+  echo "stub curl: LOOM_TEST_STUB_DIR not set" >&2
+  exit 2
+fi
+
+# The helper invokes curl with -w "\n%{http_code}" so we must emit body + newline + code.
+# Extract the URL (last positional arg) and find the branch_protections/<branch> path.
+url=""
+for a in "$@"; do
+  case "$a" in
+    https://*|http://*) url="$a" ;;
+  esac
+done
+
+if [[ -z "$url" ]]; then
+  exit 0
+fi
+
+# Pull the branch from the URL path
+branch=""
+if [[ "$url" =~ branch_protections/([^/?]+) ]]; then
+  branch="${BASH_REMATCH[1]}"
+fi
+
+if [[ -z "$branch" ]]; then
+  printf '\n404\n'
+  exit 0
+fi
+
+body_file="$STUB_DIR_FROM_ENV/gitea-branch-protection-$branch.json"
+code_file="$STUB_DIR_FROM_ENV/gitea-branch-protection-$branch.code"
+
+if [[ -f "$code_file" ]]; then
+  code=$(cat "$code_file")
+else
+  if [[ -f "$body_file" ]]; then
+    code="200"
+  else
+    code="404"
+  fi
+fi
+
+if [[ -f "$body_file" ]]; then
+  cat "$body_file"
+fi
+printf '\n%s\n' "$code"
+exit 0
+STUB
+chmod +x "$STUB_DIR/curl"
+
+# Save original PATH and prepend STUB_DIR so curl is shimmed.
+_ORIG_PATH="$PATH"
+export PATH="$STUB_DIR:$PATH"
+
+# Subtest G.1: enable_status_check=true with two required contexts.
+cat > "$STUB_DIR/gitea-branch-protection-main.json" <<'EOF'
+{
+  "branch_name": "main",
+  "enable_status_check": true,
+  "status_check_contexts": ["Code Ownership", "Required Build"]
+}
+EOF
+result=$(forge_get_required_status_check_contexts "owner/repo" "main" 2>/dev/null | tr '\n' '|' | sed 's/|$//')
+rc=$?
+assert_eq "Code Ownership|Required Build" "$result" "Gitea: two required contexts returned newline-separated"
+assert_eq "0" "$rc" "Gitea: success exit code on 200"
+
+# Subtest G.2: enable_status_check=true with empty contexts list -> empty.
+cat > "$STUB_DIR/gitea-branch-protection-no-contexts.json" <<'EOF'
+{
+  "branch_name": "no-contexts",
+  "enable_status_check": true,
+  "status_check_contexts": []
+}
+EOF
+result=$(forge_get_required_status_check_contexts "owner/repo" "no-contexts" 2>/dev/null | tr '\n' '|' | sed 's/|$//')
+rc=$?
+assert_eq "" "$result" "Gitea: enable_status_check=true with empty contexts yields empty output"
+assert_eq "0" "$rc" "Gitea: success exit code on empty contexts"
+
+# Subtest G.3: enable_status_check=false with populated contexts -> empty.
+# (Contexts are informational only when the toggle is off; fallback should fire.)
+cat > "$STUB_DIR/gitea-branch-protection-toggle-off.json" <<'EOF'
+{
+  "branch_name": "toggle-off",
+  "enable_status_check": false,
+  "status_check_contexts": ["Code Ownership", "Required Build"]
+}
+EOF
+result=$(forge_get_required_status_check_contexts "owner/repo" "toggle-off" 2>/dev/null | tr '\n' '|' | sed 's/|$//')
+rc=$?
+assert_eq "" "$result" "Gitea: enable_status_check=false yields empty output (contexts informational)"
+assert_eq "0" "$rc" "Gitea: success exit code when toggle is off"
+
+# Subtest G.4: 404 (no branch protection) -> empty, exit 0 (fallback fires).
+# We achieve 404 by not providing a .json file for this branch.
+result=$(forge_get_required_status_check_contexts "owner/repo" "missing-protection" 2>/dev/null | tr '\n' '|' | sed 's/|$//')
+rc=$?
+assert_eq "" "$result" "Gitea: 404 missing branch protection yields empty output"
+assert_eq "0" "$rc" "Gitea: 404 returns success exit code (mirrors GitHub no-rule path)"
+
+# Subtest G.5: 500 (server error) -> empty, nonzero exit (fail-closed).
+echo "500" > "$STUB_DIR/gitea-branch-protection-server-error.code"
+echo '{"message":"internal server error"}' > "$STUB_DIR/gitea-branch-protection-server-error.json"
+rc=0
+result=$(forge_get_required_status_check_contexts "owner/repo" "server-error" 2>/dev/null | tr '\n' '|' | sed 's/|$//') || rc=$?
+assert_eq "" "$result" "Gitea: 500 yields empty stdout (fail-closed)"
+if [[ "$rc" -ne 0 ]]; then
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: Gitea: 500 returns nonzero exit code (fail-closed)"
+else
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: Gitea: 500 should return nonzero (got $rc)"
+fi
+
+# Subtest G.6: 401 (auth error) -> empty, nonzero exit (fail-closed).
+echo "401" > "$STUB_DIR/gitea-branch-protection-auth-fail.code"
+echo '{"message":"unauthorized"}' > "$STUB_DIR/gitea-branch-protection-auth-fail.json"
+rc=0
+result=$(forge_get_required_status_check_contexts "owner/repo" "auth-fail" 2>/dev/null | tr '\n' '|' | sed 's/|$//') || rc=$?
+assert_eq "" "$result" "Gitea: 401 yields empty stdout (fail-closed)"
+if [[ "$rc" -ne 0 ]]; then
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: Gitea: 401 returns nonzero exit code (fail-closed)"
+else
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: Gitea: 401 should return nonzero (got $rc)"
+fi
+
+# Subtest G.7: missing token (config error) -> fail-closed, nonzero exit.
+_SAVED_TOKEN="$_GITEA_TOKEN"
+_GITEA_TOKEN=""
+rc=0
+result=$(forge_get_required_status_check_contexts "owner/repo" "main" 2>/dev/null | tr '\n' '|' | sed 's/|$//') || rc=$?
+assert_eq "" "$result" "Gitea: missing token yields empty stdout (fail-closed)"
+if [[ "$rc" -ne 0 ]]; then
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: Gitea: missing token returns nonzero (fail-closed)"
+else
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: Gitea: missing token should return nonzero (got $rc)"
+fi
+_GITEA_TOKEN="$_SAVED_TOKEN"
+
+# Subtest G.8: end-to-end policy — all-informational on Gitea (fallback fires).
+# Use the empty-contexts response to simulate "no required checks".
+failing=$'Some Informational Check'
+required="$(forge_get_required_status_check_contexts "owner/repo" "no-contexts" 2>/dev/null)"
+result=$(_policy_decision "$failing" "$required")
+assert_eq "fire" "$result" "Gitea: all-informational with empty contexts -> fallback fires"
+
+# Subtest G.9: end-to-end policy — at-least-one-required on Gitea (preserved).
+failing=$'Code Ownership\nSome Informational Check'
+required="$(forge_get_required_status_check_contexts "owner/repo" "main" 2>/dev/null)"
+result=$(_policy_decision "$failing" "$required")
+assert_eq "preserve" "$result" "Gitea: at-least-one-required -> fallback preserves refusal"
+
+# Restore PATH so subsequent tests don't see the stubbed curl.
+export PATH="$_ORIG_PATH"
+# Switch back to github for any remaining tests that may rely on it.
+# shellcheck disable=SC2034  # consumed by sourced helpers via FORGE_TYPE global
+FORGE_TYPE="github"
 
 # --- Test that the unstable-status-substring matcher in merge-pr.sh is robust ---
 # The merge-pr.sh fallback matches on the substring "is in unstable status"


### PR DESCRIPTION
Closes #3488

## Summary

Replaces the `__GITEA_TODO__` sentinel in `forge_get_required_status_check_contexts` (sibling of #3486 / #3487) with a real Gitea implementation. Gitea consumers now benefit from the UNSTABLE-fallback path that lets `merge-pr.sh --auto` demote to immediate-merge when every failing check is non-required.

The Gitea branch queries `GET /api/v1/repos/{owner}/{repo}/branch_protections/{branch}` and parses both `enable_status_check` (boolean toggle) and `status_check_contexts` (pattern list). When the toggle is off, contexts are treated as informational only and the function emits empty output — same as GitHub's "no rule" path.

A direct `curl` call (rather than the `gitea_api` helper) is used so we can inspect the HTTP status code explicitly. `gitea_api` collapses 404 and 5xx into the same exit-1 path, which would prevent distinguishing "missing branch protection rule" (treat as empty → fallback fires) from "transient lookup failure" (fail-closed → preserve UNSTABLE refusal).

### Behavior

| Scenario | Stdout | Exit | Caller behavior |
|----------|--------|------|-----------------|
| 200 + enable_status_check=true + contexts | newline-separated contexts | 0 | normal set-diff |
| 200 + enable_status_check=true + empty/null contexts | empty | 0 | fallback fires |
| 200 + enable_status_check=false | empty | 0 | fallback fires (contexts informational only) |
| 404 (missing branch protection) | empty | 0 | fallback fires (mirrors GitHub no-rule) |
| 5xx / 4xx (other) / network / missing token | empty | nonzero | preserves UNSTABLE refusal (fail-closed) |
| Unknown forge | empty | nonzero | fail-closed |

The `merge-pr.sh` caller's `__GITEA_TODO__` short-circuit is removed. The caller now captures the helper's exit code and falls through to the existing UNSTABLE refusal on nonzero, preserving fail-closed semantics on lookup failure.

## Affected files

- `defaults/scripts/lib/forge-helpers.sh` — `forge_get_required_status_check_contexts` Gitea branch implemented; sentinel removed; unknown-forge default is fail-closed.
- `defaults/scripts/merge-pr.sh` — sentinel-check block removed; helper exit code now drives fail-closed behavior.
- `defaults/scripts/tests/test-merge-pr-unstable-fallback.sh` — 14 new Gitea variants added (all-informational, at-least-one-required, 404, enable_status_check=false, 500, 401, missing-token, plus end-to-end policy probes). PATH-shimmed `curl` keys on URL path `branch_protections/<branch>` mirroring the existing GitHub stub shape.

## Test plan

- [x] `bash defaults/scripts/tests/test-merge-pr-unstable-fallback.sh` — 28/28 passed (14 existing GitHub + 14 new Gitea)
- [x] `bash defaults/scripts/tests/test-forge-helpers.sh` — 34/34 passed (no regression)
- [x] `bash defaults/scripts/tests/test-merge-pr-help.sh` — 15/15 passed (no regression)
- [x] `shellcheck defaults/scripts/lib/forge-helpers.sh defaults/scripts/merge-pr.sh defaults/scripts/tests/test-merge-pr-unstable-fallback.sh` — only pre-existing SC2015/SC2016 warnings remain; no new warnings introduced

## Related

- #3486 — parent issue (GitHub-only Option A landed)
- #3487 — PR that shipped the GitHub branch and added the `__GITEA_TODO__` sentinel
- #3371 — CLEAN-fallback precedent

🤖 Generated with [Claude Code](https://claude.com/claude-code)