### PR TITLE
fix(release): install both Apple targets explicitly before build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,11 @@ jobs:
           workspaces: |
             .
 
+      - name: Ensure both Apple targets installed
+        run: |
+          rustup target add aarch64-apple-darwin
+          rustup target add x86_64-apple-darwin
+
       - name: Build daemon (ARM64)
         run: |
           cargo build --package loom-daemon --release --target aarch64-apple-darwin


### PR DESCRIPTION
## Summary

The release workflow has failed twice in a row (v0.10.0 and v0.10.1) at the same place: the x86_64 daemon build errors with `E0463: can't find crate for 'core'`, hinting the x86_64-apple-darwin target isn't installed at build time.

The setup step uses `dtolnay/rust-toolchain@stable` with `targets: aarch64-apple-darwin,x86_64-apple-darwin`, which should install both. The ARM64 build succeeds, so the toolchain itself is fine — the most plausible explanation is that the subsequent `Swatinem/rust-cache@v2` step restores cache state that clobbers the x86_64 target install.

Adding an explicit `rustup target add` step after the cache step pins both targets back in place before either build runs.

## Test plan

- [ ] CI green on this PR (no functional surface beyond the workflow file; nothing to test here).
- [ ] After merge: redeploy v0.10.1 (delete + recreate the tag + GitHub Release) and confirm the `release.yml` workflow succeeds end-to-end and uploads both `loom-daemon-{aarch64,x86_64}-apple-darwin` artifacts to the release.