### PR TITLE
feat(release): generalize loom:release skill for downstream repos

### DIFF
--- a/defaults/.claude/commands/loom/release.md
+++ b/defaults/.claude/commands/loom/release.md
@@ -1,36 +1,48 @@
 # Release Manager
 
-You are preparing a release of **Loom** from the {{workspace}} repository.
+You are preparing a release of **{{workspace}}** from the {{workspace}} repository.
 
 ## Overview
 
 This skill guides a careful, interactive release process. Every release must:
-1. Verify CI is green on main
+1. Verify the main branch is in a release-ready state (CI green or clean-main if CI is absent)
 2. Analyze what changed since the last release
 3. Help the user decide the correct semver bump
 4. Draft and refine the CHANGELOG entry
-5. Update version across all 7 version-bearing files
+5. Update version across every version-bearing file (discovered from `./scripts/version.sh list`)
 6. Commit, tag, and (with confirmation) push
-7. Create a GitHub Release to trigger the build workflow
+7. If a release workflow is configured, create a GitHub Release to trigger it
 
 **Do not rush. Each phase requires user confirmation before proceeding.**
 
+**Project-specific customization**: this skill is generic. If your project needs release-time reminders (e.g., "remember to bump the protocol version when the API changes"), drop a `release.md` file in `.loom/context/topics/` — the methodology-injection hook will inject it on every invocation. Do NOT fork this skill.
+
 ## Phase 1: Pre-flight Checks
 
-Before starting, verify the release is safe to cut:
+Before starting, verify the release is safe to cut. The exact CI gate depends on whether the repo has any GitHub Actions workflows configured.
 
 ```bash
-# Check CI status on main
-gh run list --branch main --limit 5 --json name,conclusion --jq '.[] | "\(.name): \(.conclusion)"'
+# Detect whether CI workflows exist. The CI gate degrades gracefully
+# when none are present (greenfield repos without CI yet). Uses `find`
+# rather than `compgen -G` so the check works under both bash and zsh.
+if [ -d ".github/workflows" ] && [ -n "$(find .github/workflows -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \) 2>/dev/null | head -1)" ]; then
+  echo "CI workflows detected; checking run status on main..."
+  gh run list --branch main --limit 5 --json name,conclusion --jq '.[] | "\(.name): \(.conclusion)"'
+else
+  echo "No CI workflows detected; using git status + open-PR check as the clean-main gate"
+fi
 
 # Check for open PRs that might need to land first
 gh pr list --state open --json number,title --jq '.[] | "#\(.number) \(.title)"'
 
-# Check for uncommitted changes
+# Check for uncommitted changes (always required)
 git status
 ```
 
-Present findings to the user. If CI is failing, stop and fix first. If there are open PRs, ask if they should land before the release.
+Present findings to the user:
+- If CI exists and is failing, stop and fix first.
+- If CI is absent, treat clean `git status` + zero blocking open PRs as the gate.
+- If there are open PRs, ask if they should land before the release.
 
 ## Phase 2: Gather Changes
 
@@ -58,38 +70,72 @@ If there are zero commits since the last tag, stop and tell the user there's not
 
 ## Phase 3: Semver Decision
 
-Present a semver analysis. Reference https://semver.org:
+Present a semver analysis. Reference https://semver.org. The categories below are generic — apply them to whatever public surface your project exposes (libraries, CLIs, protocols, file formats, etc.).
 
 ### Breaking Changes (MAJOR bump)
 Scan for:
-- Removed or renamed public API functions/types
-- Changed ForgeClient protocol methods
-- Changed CLI command flags/behavior
-- Changed MCP tool interfaces
-- Removed or renamed daemon commands
-- Changed config file format
+- Removed or renamed public API functions, types, or modules
+- Changed function signatures or return types in exported surfaces
+- Removed or renamed CLI commands, subcommands, or flags
+- Changed CLI command behavior in a way that breaks scripted callers
+- Changed wire-protocol / plugin-interface / IPC contracts
+- Changed configuration file format in a non-backward-compatible way
+- Removed or renamed environment variables that callers set
 
 ### New Capabilities (MINOR bump)
-- New forge support (e.g., Gitea, GitLab)
-- New CLI commands (`loom-forge`, `loom-auto-merge`)
-- New agent roles or orchestration features
-- New MCP tools
-- New configuration options
+- New public API surface (functions, types, modules)
+- New CLI commands, subcommands, or flags (additive, backward-compatible)
+- New configuration options (with sensible defaults preserving old behavior)
+- New optional plugin / protocol / IPC capabilities
+- New roles, agents, or orchestration features
 
 ### Bug Fixes / Internal (PATCH bump)
-- Bug fixes that don't change API
-- Performance improvements
-- Internal refactoring
+- Bug fixes that don't change any public API
+- Performance improvements with identical observable behavior
+- Internal refactoring not visible to consumers
 - Documentation updates
-- Dependency bumps
+- Dependency bumps (unless they change observable behavior)
 
 Present your recommendation and **ask the user to confirm or override**. Do not proceed until confirmed.
 
 ## Phase 4: Draft CHANGELOG
 
-Draft a CHANGELOG entry following the existing format in `CHANGELOG.md`. Study existing entries to match style.
+If `CHANGELOG.md` exists at the repo root, draft a new entry following its existing format. Study existing entries to match style.
 
-Key formatting rules:
+```bash
+# Check whether a CHANGELOG.md exists
+if [ -f CHANGELOG.md ]; then
+  echo "CHANGELOG.md found — drafting a new entry below ## [Unreleased]"
+  head -50 CHANGELOG.md
+else
+  echo "No CHANGELOG.md found — offering to bootstrap one"
+fi
+```
+
+If `CHANGELOG.md` is **absent** (e.g., a young repo that hasn't created one yet), ask the user: "No CHANGELOG.md found at the repo root. Create one with the standard 'Keep a Changelog' template? [Y/n]". If yes, write:
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [X.Y.Z] - YYYY-MM-DD
+
+### Summary
+<one-paragraph release theme>
+
+### Added
+- ...
+```
+
+If the user declines bootstrap, skip the CHANGELOG update and proceed with version bump only.
+
+Key formatting rules (when `CHANGELOG.md` exists or has just been bootstrapped):
 - Use `## [X.Y.Z] - YYYY-MM-DD` header with today's date
 - Start with a `### Summary` paragraph describing the release theme
 - Group changes under `### Added`, `### Changed`, `### Fixed`, `### Removed`, `### Renamed` as appropriate
@@ -103,14 +149,20 @@ Present the draft and ask for revisions. Iterate until approved.
 
 Once the user approves:
 
-1. **Update CHANGELOG.md**: Insert the new entry below `## [Unreleased]`
-2. **Bump version**: Run `./scripts/version.sh bump <level> --tag`
-   - This updates all 5 files: `package.json`, `mcp-loom/package.json`, 2 `Cargo.toml` files (`loom-daemon`, `loom-api`), `CLAUDE.md`
-   - Plus `Cargo.lock`
-   - Creates the commit and tag automatically
-3. **Verify**: `./scripts/version.sh check`
+1. **Update CHANGELOG.md** (if it exists): Insert the new entry below `## [Unreleased]`.
+2. **Discover the version-bearing files** so the user knows what will change:
+   ```bash
+   ./scripts/version.sh list
+   ```
+   This emits the canonical list, one path per line, straight from the script's source-of-truth array.
+3. **Bump version**: Run `./scripts/version.sh bump <level> --tag`
+   - This updates every file emitted by `./scripts/version.sh list`.
+   - Any derived artifacts the script updates as a side effect (e.g., a lockfile via `cargo update` or `npm install`) are handled by the script itself.
+   - The script creates the commit and tag automatically.
+4. **Verify**: `./scripts/version.sh check`
 
-Note: The version bump script creates the commit, so commit the CHANGELOG first:
+Note: the version bump script creates the commit. To keep the CHANGELOG bump and the version bump together in a single tagged commit, commit the CHANGELOG first and then move the tag forward after the version bump:
+
 ```bash
 git add CHANGELOG.md
 git commit -m "docs: add X.Y.Z changelog entry"
@@ -130,22 +182,27 @@ After final confirmation:
    git push origin main --tags
    ```
 
-2. **Create GitHub Release** (this triggers the build workflow):
+2. **Create GitHub Release**:
    ```bash
    gh release create vX.Y.Z --title "vX.Y.Z" --notes-file - <<< "$(changelog excerpt)"
    ```
    Use the CHANGELOG entry as the release notes.
 
-3. **Verify build triggered**:
+3. **Build workflow trigger** (only when a release workflow is configured):
    ```bash
-   gh run list --workflow=release.yml --limit 1
+   if ls .github/workflows/release.yml 2>/dev/null; then
+     echo "release.yml detected — the GitHub Release will trigger the build workflow."
+     gh run list --workflow=release.yml --limit 1
+   else
+     echo "No release.yml workflow detected — the GitHub Release will not trigger any build."
+   fi
    ```
 
 **Do not push or create the release without explicit user confirmation.**
 
 ## Phase 7: Post-Release Summary
 
-Present a summary:
+Present a summary. Tailor the build-workflow line based on whether a release workflow was detected in Phase 6:
 
 ```
 ## Release Complete
@@ -154,17 +211,15 @@ Present a summary:
 - Commit: <sha>
 - Tag: vX.Y.Z
 - GitHub Release: created
-- Build workflow: [triggered / status]
+- Build workflow: [triggered / N/A — no release workflow configured]
 - CHANGELOG: updated with N items
-- Version files: 5 files + Cargo.lock updated
+- Version files updated: $(./scripts/version.sh list | wc -l | tr -d ' ') files (see `./scripts/version.sh list`)
 ```
 
 ## Important Notes
 
-- **Version script**: `scripts/version.sh` is the single source of truth for version management. Never manually edit version numbers.
-- **5 version-bearing files**: `package.json`, `mcp-loom/package.json`, `loom-daemon/Cargo.toml`, `loom-api/Cargo.toml`, `CLAUDE.md`
-- **Release workflow trigger**: The build workflow (`.github/workflows/release.yml`) triggers on GitHub Release creation (`release: types: [created]`), NOT on tag push. You must create a GitHub Release via `gh release create`.
-- **Conventional commits**: This project uses conventional commit prefixes (`feat:`, `fix:`, `chore:`, etc.).
-- **Build output**: The release workflow builds `loom-daemon` binaries (Apple Silicon + Intel) and attaches them to the GitHub Release.
-- **CLAUDE.md update**: The version script updates the `**Loom Version**` line in CLAUDE.md automatically.
-- **Branch protection**: Direct pushes to main will show a ruleset bypass warning — this is expected for release commits.
+- **Version script**: `scripts/version.sh` is the single source of truth for version management. Never manually edit version numbers — let the script update every tracked file plus any derived artifacts.
+- **Discover, don't hardcode**: the set of version-bearing files is discovered at release time via `./scripts/version.sh list`. Do not bake a count or path list into prose; the script is authoritative.
+- **Release workflow trigger** (when applicable): if `.github/workflows/release.yml` exists, it typically triggers on GitHub Release creation (`release: types: [created]`), NOT on tag push. In that case you must create a GitHub Release via `gh release create` to trigger the build. If no release workflow is configured, the tag push alone completes the release and no build artifacts are produced.
+- **Conventional commits**: many projects (including this one if it uses `feat:` / `fix:` / `chore:` prefixes) use conventional commits to drive the semver decision. Use the prefix breakdown from Phase 2 as input to Phase 3.
+- **Branch protection**: direct pushes to main from a release flow may show a ruleset bypass warning — this is expected for release commits when the project's policy allows admin bypass for tagged releases. If your project doesn't allow that, run the release through a PR instead.

--- a/defaults/.loom-internal.list
+++ b/defaults/.loom-internal.list
@@ -17,5 +17,12 @@
 # a stray `/loom:*` skill or auxiliary file.
 #
 # Tracked under issue #3464.
-
-.claude/commands/loom/release.md
+#
+# Issue #3495: `.claude/commands/loom/release.md` was previously listed
+# here when the skill was Loom-specific (it hardcoded the Loom project
+# name, version-file count, and Loom-only semver examples). The skill is
+# now generalized — it discovers everything via `./scripts/version.sh
+# list` and uses `{{workspace}}` for the project name — so it ships to
+# every downstream repo. The installer migration step in
+# `scripts/install-loom.sh` handles consumers that had a hand-customized
+# fork by snapshotting before init and prompting before replacing.

--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -913,6 +913,21 @@ info "loom-daemon binary: $DAEMON_VERSION"
 
 # Run loom-daemon init in the worktree
 cd "$TARGET_PATH/$WORKTREE_PATH"
+
+# Issue #3495: snapshot any pre-existing .claude/commands/loom/release.md
+# before `loom-daemon init` overwrites it. The generalized skill replaces
+# the historical Loom-internal one — but consumers (e.g. anvil) may have
+# hand-customized their fork. We restore the snapshot below the stale-file
+# sweep if the operator declines the migration. RELEASE_MD_SNAPSHOT stays
+# empty when there's no pre-existing file (greenfield install) or when no
+# customization is detectable.
+RELEASE_MD_REL=".claude/commands/loom/release.md"
+RELEASE_MD_SNAPSHOT=""
+if [[ -f "$RELEASE_MD_REL" ]]; then
+  RELEASE_MD_SNAPSHOT="$(mktemp)"
+  cp "$RELEASE_MD_REL" "$RELEASE_MD_SNAPSHOT"
+fi
+
 # Use --force to overwrite existing installation when requested (--force or --clean flags)
 # Otherwise, use merge mode to preserve custom project roles/commands
 # Use --defaults to point to Loom's defaults directory
@@ -1183,6 +1198,65 @@ if (( ${#STALE_FILES[@]} > 0 )); then
   fi
 fi
 # --- End stale-file sweep ---
+
+# --- Customized release.md migration (#3495) ---
+# Detect a pre-init customized .claude/commands/loom/release.md and offer to
+# preserve it. The skill was previously Loom-internal (kept out of consumer
+# trees via .loom-internal.list) so anvil and similar repos hand-forked it.
+# As of #3495 the canonical defaults/ version is generic and SHIPS to every
+# consumer. This step compares the pre-init snapshot against the canonical
+# and, on mismatch, prompts the operator before letting the freshly-copied
+# canonical version stand.
+#
+# Defaults:
+#   - Interactive: prompt [y/N/d=show diff], default N (preserve customization)
+#   - --yes (NON_INTERACTIVE): preserve silently
+#   - --force (FORCE_OVERWRITE): replace silently with a warning
+#   - Idempotent: if snapshot matches canonical (no customization), no-op
+if [[ -n "${RELEASE_MD_SNAPSHOT:-}" ]] && [[ -f "$RELEASE_MD_SNAPSHOT" ]]; then
+  CANONICAL_RELEASE_MD="$LOOM_ROOT/defaults/$RELEASE_MD_REL"
+  if [[ -f "$CANONICAL_RELEASE_MD" ]] && ! cmp -s "$RELEASE_MD_SNAPSHOT" "$CANONICAL_RELEASE_MD"; then
+    # Customization detected (pre-init disk content differs from canonical).
+    PRESERVE_RELEASE_MD=true
+    if [[ "$FORCE_OVERWRITE" == "true" ]]; then
+      PRESERVE_RELEASE_MD=false
+      warning "Replaced customized release.md with generalized version (--force)"
+    elif [[ "$NON_INTERACTIVE" == "true" ]]; then
+      info "Preserved customized release.md (--yes default; pass --force to replace)"
+    else
+      echo ""
+      info "Customized release.md detected. The generalized Loom version now"
+      info "ships out of the box and should work for any project."
+      while true; do
+        read -r -p "Replace customized release.md with the generalized version? [y/N/d=show diff] " CONFIRM_RELEASE_MD
+        case "$CONFIRM_RELEASE_MD" in
+          y|Y)
+            PRESERVE_RELEASE_MD=false
+            break
+            ;;
+          d|D)
+            echo ""
+            diff -u "$RELEASE_MD_SNAPSHOT" "$CANONICAL_RELEASE_MD" || true
+            echo ""
+            ;;
+          n|N|"")
+            break
+            ;;
+          *)
+            echo "Please answer y, N, or d."
+            ;;
+        esac
+      done
+    fi
+    if [[ "$PRESERVE_RELEASE_MD" == "true" ]]; then
+      cp "$RELEASE_MD_SNAPSHOT" "$RELEASE_MD_REL"
+      info "Preserved customized release.md (re-run with --force to replace next time)"
+    fi
+  fi
+  rm -f "$RELEASE_MD_SNAPSHOT"
+  RELEASE_MD_SNAPSHOT=""
+fi
+# --- End customized release.md migration ---
 
 cat > .loom/install-metadata.json <<METADATA
 {

--- a/scripts/test-installer.sh
+++ b/scripts/test-installer.sh
@@ -1758,11 +1758,14 @@ else
       pass "All defaults/.loom-internal.list entries absent from consumer tree"
     fi
 
-    # AC1: specifically pin .claude/commands/loom/release.md as absent.
-    if [[ -e "$INTERNAL_REPO/.claude/commands/loom/release.md" ]]; then
-      fail "AC1: .claude/commands/loom/release.md must not be installed to consumers"
+    # Issue #3495: release.md is now generalized and SHIPS to consumers
+    # (it discovers version files via `./scripts/version.sh list` and uses
+    # `{{workspace}}` for the project name). Pin its presence so a future
+    # regression that re-adds it to .loom-internal.list fails this test.
+    if [[ -f "$INTERNAL_REPO/.claude/commands/loom/release.md" ]]; then
+      pass "#3495: generalized .claude/commands/loom/release.md ships to consumers"
     else
-      pass "AC1: .claude/commands/loom/release.md is absent from consumer install"
+      fail "#3495: .claude/commands/loom/release.md missing from consumer install"
     fi
 
     # The siblings must continue to ship — pin three representative skills.
@@ -1986,6 +1989,209 @@ if echo "$UNINSTALL_OUTPUT" | grep -qF "preserving $CONSUMER_COMMAND"; then
   pass "Warning emitted for preserved consumer command path"
 else
   fail "No 'preserving' warning emitted for $CONSUMER_COMMAND"
+fi
+echo ""
+
+
+# ==========================================================================
+# Section 11: Customized release.md migration (#3495)
+# ==========================================================================
+# These tests exercise the migration logic that install-loom.sh runs around
+# the loom-daemon init step: snapshot any pre-existing
+# `.claude/commands/loom/release.md`, then after init compare the snapshot
+# against the canonical defaults/ version and restore-vs-overwrite based on
+# operator flags. The block is self-contained in install-loom.sh (it uses
+# only NON_INTERACTIVE / FORCE_OVERWRITE and the snapshot path) so we
+# replay the exact shell shape here against controlled fixtures.
+
+# Helper: run the migration logic with a given pre-init disk content and
+# the given (NON_INTERACTIVE, FORCE_OVERWRITE) combination. Echoes the
+# post-migration on-disk content so the caller can assert.
+#
+# Args:
+#   $1  pre-init disk content for .claude/commands/loom/release.md
+#       (empty string means "no pre-existing file")
+#   $2  canonical defaults content (what daemon init writes after snapshot)
+#   $3  NON_INTERACTIVE  (true|false)
+#   $4  FORCE_OVERWRITE  (true|false)
+#   $5  interactive input fed via stdin (only consulted when both flags are false)
+#
+# Returns the final on-disk content via stdout.
+run_release_md_migration() {
+  local pre_init_content="$1"
+  local canonical_content="$2"
+  local non_interactive="$3"
+  local force_overwrite="$4"
+  local interactive_input="$5"
+
+  local sandbox
+  sandbox="$(mktemp -d)"
+  local loom_root_fake="$sandbox/loom-root"
+  local target="$sandbox/target"
+
+  mkdir -p "$loom_root_fake/defaults/.claude/commands/loom"
+  mkdir -p "$target/.claude/commands/loom"
+  printf '%s' "$canonical_content" > "$loom_root_fake/defaults/.claude/commands/loom/release.md"
+
+  # Replicate the "snapshot before init" step from install-loom.sh.
+  local RELEASE_MD_REL=".claude/commands/loom/release.md"
+  local RELEASE_MD_SNAPSHOT=""
+  if [[ -n "$pre_init_content" ]]; then
+    printf '%s' "$pre_init_content" > "$target/$RELEASE_MD_REL"
+    RELEASE_MD_SNAPSHOT="$(mktemp)"
+    cp "$target/$RELEASE_MD_REL" "$RELEASE_MD_SNAPSHOT"
+  fi
+
+  # Simulate loom-daemon init's overwrite-with-canonical behavior.
+  cp "$loom_root_fake/defaults/$RELEASE_MD_REL" "$target/$RELEASE_MD_REL"
+
+  # Inline the migration block from install-loom.sh against the local
+  # sandbox. The block must read identically — if it diverges from the
+  # installer, the test stops being a regression gate.
+  local NON_INTERACTIVE="$non_interactive"
+  local FORCE_OVERWRITE="$force_overwrite"
+  local LOOM_ROOT="$loom_root_fake"
+  (
+    cd "$target"
+    if [[ -n "${RELEASE_MD_SNAPSHOT:-}" ]] && [[ -f "$RELEASE_MD_SNAPSHOT" ]]; then
+      CANONICAL_RELEASE_MD="$LOOM_ROOT/defaults/$RELEASE_MD_REL"
+      if [[ -f "$CANONICAL_RELEASE_MD" ]] && ! cmp -s "$RELEASE_MD_SNAPSHOT" "$CANONICAL_RELEASE_MD"; then
+        PRESERVE_RELEASE_MD=true
+        if [[ "$FORCE_OVERWRITE" == "true" ]]; then
+          PRESERVE_RELEASE_MD=false
+        elif [[ "$NON_INTERACTIVE" == "true" ]]; then
+          : # preserve silently
+        else
+          # Interactive: consume the canned answer from stdin.
+          while read -r CONFIRM_RELEASE_MD; do
+            case "$CONFIRM_RELEASE_MD" in
+              y|Y) PRESERVE_RELEASE_MD=false; break ;;
+              n|N|"") break ;;
+              d|D) continue ;;
+              *) continue ;;
+            esac
+          done
+        fi
+        if [[ "$PRESERVE_RELEASE_MD" == "true" ]]; then
+          cp "$RELEASE_MD_SNAPSHOT" "$RELEASE_MD_REL"
+        fi
+      fi
+      rm -f "$RELEASE_MD_SNAPSHOT"
+    fi
+  ) <<< "$interactive_input" >/dev/null 2>&1
+
+  cat "$target/$RELEASE_MD_REL"
+  rm -rf "$sandbox"
+}
+
+echo "--- Section 11: Customized release.md migration (#3495) ---"
+echo ""
+
+CUSTOM_RELEASE="# Custom Anvil release\nThis was forked."
+CANONICAL_RELEASE="# Release Manager\nYou are preparing a release of **{{workspace}}**."
+
+# Test 55: --yes (NON_INTERACTIVE) preserves customization silently
+echo "Test 55: --yes preserves customized release.md silently"
+RESULT_55=$(run_release_md_migration "$CUSTOM_RELEASE" "$CANONICAL_RELEASE" "true" "false" "")
+if [[ "$RESULT_55" == "$(printf '%s' "$CUSTOM_RELEASE")" ]]; then
+  pass "--yes mode preserved customized release.md"
+else
+  fail "--yes mode should have preserved customization; got: $RESULT_55"
+fi
+
+# Test 56: --force replaces with canonical
+echo "Test 56: --force replaces customized release.md with canonical"
+RESULT_56=$(run_release_md_migration "$CUSTOM_RELEASE" "$CANONICAL_RELEASE" "false" "true" "")
+if [[ "$RESULT_56" == "$(printf '%s' "$CANONICAL_RELEASE")" ]]; then
+  pass "--force replaced customized release.md with canonical"
+else
+  fail "--force should have replaced with canonical; got: $RESULT_56"
+fi
+
+# Test 57: interactive default (empty/N) preserves customization
+echo "Test 57: Interactive default (N) preserves customization"
+RESULT_57=$(run_release_md_migration "$CUSTOM_RELEASE" "$CANONICAL_RELEASE" "false" "false" "")
+if [[ "$RESULT_57" == "$(printf '%s' "$CUSTOM_RELEASE")" ]]; then
+  pass "Interactive default (N) preserved customization"
+else
+  fail "Interactive default should preserve; got: $RESULT_57"
+fi
+
+# Test 58: interactive y replaces with canonical
+echo "Test 58: Interactive 'y' replaces customization with canonical"
+RESULT_58=$(run_release_md_migration "$CUSTOM_RELEASE" "$CANONICAL_RELEASE" "false" "false" "y")
+if [[ "$RESULT_58" == "$(printf '%s' "$CANONICAL_RELEASE")" ]]; then
+  pass "Interactive 'y' replaced customization with canonical"
+else
+  fail "Interactive 'y' should replace with canonical; got: $RESULT_58"
+fi
+
+# Test 59: idempotency — when pre-init matches canonical, no detection
+echo "Test 59: Identical pre-init and canonical → no migration prompt path"
+RESULT_59=$(run_release_md_migration "$CANONICAL_RELEASE" "$CANONICAL_RELEASE" "false" "false" "")
+if [[ "$RESULT_59" == "$(printf '%s' "$CANONICAL_RELEASE")" ]]; then
+  pass "Identical content → canonical kept (no detection path triggered)"
+else
+  fail "Identical content should be no-op; got: $RESULT_59"
+fi
+
+# Test 60: fresh install (no pre-existing) — canonical is kept
+echo "Test 60: Fresh install (no pre-existing release.md) keeps canonical"
+RESULT_60=$(run_release_md_migration "" "$CANONICAL_RELEASE" "false" "false" "")
+if [[ "$RESULT_60" == "$(printf '%s' "$CANONICAL_RELEASE")" ]]; then
+  pass "Fresh install keeps canonical (no snapshot path)"
+else
+  fail "Fresh install should keep canonical; got: $RESULT_60"
+fi
+
+# Test 61: the release.md skill discovers files via ./scripts/version.sh list
+echo "Test 61: release.md skill discovers version files via './scripts/version.sh list'"
+RELEASE_MD_SHIPPED="$LOOM_ROOT/defaults/.claude/commands/loom/release.md"
+if [[ -f "$RELEASE_MD_SHIPPED" ]]; then
+  if grep -q '\./scripts/version\.sh list' "$RELEASE_MD_SHIPPED"; then
+    pass "release.md uses './scripts/version.sh list' for discovery"
+  else
+    fail "release.md does not invoke './scripts/version.sh list'"
+  fi
+  if grep -q '{{workspace}}' "$RELEASE_MD_SHIPPED"; then
+    pass "release.md uses {{workspace}} for project name"
+  else
+    fail "release.md missing {{workspace}} for project name"
+  fi
+  # The Loom-specific bullets should no longer be present in the generic skill.
+  if ! grep -qE 'ForgeClient|loom-daemon binaries' "$RELEASE_MD_SHIPPED"; then
+    pass "release.md does not name Loom-specific symbols (ForgeClient, loom-daemon binaries)"
+  else
+    fail "release.md still references Loom-specific symbols"
+  fi
+else
+  fail "release.md skill not present at $RELEASE_MD_SHIPPED"
+fi
+
+# Test 62: ./scripts/version.sh list emits the expected 5 entries
+echo "Test 62: 'scripts/version.sh list' emits the 5 version-bearing files"
+LIST_OUTPUT="$("$LOOM_ROOT/scripts/version.sh" list)"
+EXPECTED_LIST="package.json
+mcp-loom/package.json
+loom-daemon/Cargo.toml
+loom-api/Cargo.toml
+CLAUDE.md"
+if [[ "$LIST_OUTPUT" == "$EXPECTED_LIST" ]]; then
+  pass "'version.sh list' emits the 5 expected files"
+else
+  fail "'version.sh list' output diverged from expectation"
+  echo "  Expected:"
+  echo "$EXPECTED_LIST" | sed 's/^/    /'
+  echo "  Got:"
+  echo "$LIST_OUTPUT" | sed 's/^/    /'
+fi
+
+# Test 63: ./scripts/version.sh check still works after the list addition
+echo "Test 63: 'scripts/version.sh check' still works (regression)"
+if "$LOOM_ROOT/scripts/version.sh" check >/dev/null 2>&1; then
+  pass "'version.sh check' still works alongside the new 'list' subcommand"
+else
+  fail "'version.sh check' regressed after adding 'list'"
 fi
 echo ""
 

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -3,6 +3,7 @@
 #
 # Usage:
 #   ./scripts/version.sh                  # Show current version
+#   ./scripts/version.sh list             # List version-bearing files (one per line)
 #   ./scripts/version.sh check            # Verify all files are in sync
 #   ./scripts/version.sh bump patch       # 0.4.1 → 0.4.2
 #   ./scripts/version.sh bump minor       # 0.4.1 → 0.5.0
@@ -163,6 +164,15 @@ case "${1:-}" in
   ""|show)
     echo "$(get_version)"
     ;;
+  list)
+    # Emit the VERSION_FILES array, one entry per line.
+    # Used by the /loom:release skill to discover version-bearing files
+    # without hardcoding the count or names in skill prose. Cargo.lock is
+    # intentionally excluded — it's a derived artifact updated by
+    # `cargo update` as a side effect of the bump, not a directly-edited
+    # version source.
+    printf '%s\n' "${VERSION_FILES[@]}"
+    ;;
   check)
     check_versions
     ;;
@@ -186,7 +196,7 @@ case "${1:-}" in
     fi
     ;;
   *)
-    echo "Usage: $0 [show|check|bump <major|minor|patch> [--tag]|set <version> [--tag]]"
+    echo "Usage: $0 [show|list|check|bump <major|minor|patch> [--tag]|set <version> [--tag]]"
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary

Generalize the `/loom:release` skill so downstream repositories that install Loom get a working release flow out of the box, without having to fork and customize the skill. Loom itself continues to use the same skill via dogfooding.

Closes #3495

## What changed

- **`scripts/version.sh`**: new `list` subcommand emits the `VERSION_FILES` array entries one per line. This is the canonical discovery mechanism the skill consumes — no more hardcoded prose count (the previous skill said "7" in one place and "5" in three others).
- **`defaults/.claude/commands/loom/release.md`**: rewritten as a generic skill.
  - Project name uses `{{workspace}}` (already-supported templating); no new template variables.
  - Version files discovered via `./scripts/version.sh list` in bash blocks; the count is no longer mentioned in prose.
  - Phase 1 CI gate uses `find .github/workflows -type f \( -name '*.yml' -o -name '*.yaml' \)` (portable across bash/zsh) and prints `"No CI workflows detected; using git status + open-PR check as the clean-main gate"` when absent.
  - Phase 6 only mentions the release-workflow trigger when `.github/workflows/release.yml` exists; otherwise prints `"No release.yml workflow detected — the GitHub Release will not trigger any build."`
  - Semver examples are project-agnostic (no `ForgeClient`, MCP, daemon references). The "Loom self-release notes" question is resolved by pointing users at `.loom/context/topics/release.md` for project-specific reminders.
  - Phase 4 detects missing `CHANGELOG.md` and offers to bootstrap one with the standard "Keep a Changelog" template.
- **`defaults/.loom-internal.list`**: remove `release.md` from the skip list. The generic skill now ships to every consumer via `loom-daemon init`. The previous Loom-internal carve-out is documented in a header comment for the next person who wonders why it was there.
- **`scripts/install-loom.sh`**: add a customized-release.md migration step.
  - Before `loom-daemon init` (line 915), snapshot any pre-existing `.claude/commands/loom/release.md` into a tempfile.
  - After the stale-file sweep (~line 1185), compare the snapshot against `defaults/.claude/commands/loom/release.md`.
  - On mismatch: interactive prompts `[y/N/d=show diff]` with default N (preserve customization). `--yes` (NON_INTERACTIVE) preserves silently. `--force` (FORCE_OVERWRITE) replaces silently with a warning. Idempotent — identical snapshot/canonical is a no-op.
- **`scripts/test-installer.sh`**: invert Test 52's release.md AC1 assertion (the skill now ships), plus new Section 11 (Tests 55-63) covering the migration semantics across all four operator-flag combinations, plus pinning that the generic skill contents are correct (uses `{{workspace}}`, calls `./scripts/version.sh list`, no Loom-specific symbols).

## Verification

- `bash scripts/test-installer.sh` → **109 passed, 0 failed** (including the 9 new tests in Section 11).
- `cargo test --package loom-daemon --lib --release init::scaffolding` → **36 passed, 0 failed** (the `.loom-internal.list` change does not affect these tests because they construct synthetic skip lists in temp dirs).
- `cargo test --package loom-daemon --lib --release init::file_ops` → **9 passed, 0 failed**.
- Dry-run of the new release skill against this repo, Phases 1-3:
  - CI detection: `CI workflows detected; checking run status on main...` (correct).
  - `./scripts/version.sh` → `0.10.1`.
  - `./scripts/version.sh list` → 5 lines: `package.json`, `mcp-loom/package.json`, `loom-daemon/Cargo.toml`, `loom-api/Cargo.toml`, `CLAUDE.md`. **Matches** the historical 5-file expectation; `Cargo.lock` correctly excluded (it's a derived artifact updated by `cargo update`).

## Caveats

- The `compgen -G` glob test originally in the skill is bash-only — replaced with a portable `find` invocation that works under both bash and zsh. Tested both.
- The bump.md skill (already shipped under a separate generic name) is left in place. The two have different scopes; consolidating them is a follow-up question if needed.
- Anvil's forked `release.md` at `../anvil/.claude/commands/loom/release.md` is not touched by this PR (out of repo). The acceptance criterion only requires that it CAN be deleted after this lands; anvil maintainers will handle the actual deletion in a follow-up anvil PR.

## Test plan

- [x] `bash scripts/test-installer.sh` passes
- [x] `cargo test --package loom-daemon --lib --release init` passes
- [x] `./scripts/version.sh list` emits 5 lines matching the expected file set
- [x] `./scripts/version.sh check` still works (regression)
- [x] `./scripts/version.sh` (default `show`) still works (regression)
- [x] Phase 1 CI detection works under both bash and zsh
- [x] Phase 6 `release.yml` detection works (`ls .github/workflows/release.yml`)
- [x] release.md ships under `loom-daemon init` (Test 52 inversion)
- [x] Migration step preserves customization under `--yes` (Test 55)
- [x] Migration step replaces under `--force` (Test 56)
- [x] Migration step prompts interactively, default N preserves (Tests 57, 58)
- [x] Migration step is idempotent on identical content (Test 59)
- [x] Fresh install (no pre-existing) leaves canonical in place (Test 60)

🤖 Generated with [Claude Code](https://claude.com/claude-code)