### PR TITLE
fix(release): guard Phase 1.5 _all_tags loop against empty elements

### DIFF
--- a/defaults/.claude/commands/loom/release.md
+++ b/defaults/.claude/commands/loom/release.md
@@ -62,6 +62,7 @@ else
   # Use a portable read loop (avoids `mapfile`, which is bash 4+ only).
   _all_tags=()
   while IFS= read -r _t; do
+    [ -n "$_t" ] || continue   # defensive: skip empty lines from process substitution
     _all_tags+=("$_t")
   done < <(git tag --sort=-v:refname)
   _limit=$RECENT_TAG_COUNT


### PR DESCRIPTION
## Summary

Adds a single-line defensive guard to the Phase 1.5 CHANGELOG completeness gate read loop in `defaults/.claude/commands/loom/release.md`:

```diff
   _all_tags=()
   while IFS= read -r _t; do
+    [ -n "$_t" ] || continue   # defensive: skip empty lines from process substitution
     _all_tags+=("$_t")
   done < <(git tag --sort=-v:refname)
```

Fixes the phantom `MISSING entries: (?, 1 commits)` line that the v0.10.3 release flow surfaced when running on bash 3.2 (macOS default). The bug is timing-sensitive at the `< <(...)` process-substitution boundary; the guard removes the failure mode regardless of whether the subshell happens to emit a trailing empty element.

Per the curator's note in #3501, this is **Option 1** (guard at array population) — preferred over Option 2 (guard at consumption) because it keeps the consumer loop clean and the array invariant is "only real tag names".

## Test plan

Smoke-tested both directions on bash 3.2 (`GNU bash 3.2.57(1)-release arm64-apple-darwin25`) by extracting the gate logic into a standalone script and running against the current repo:

- [x] **Current loom repo at v0.10.3** (all 5 recent tags have CHANGELOG entries): script prints `OK — all 5 recent tags have CHANGELOG entries` and exits 0. No phantom missing entry.
- [x] **Synthesized CHANGELOG with `## [0.10.2]` block deleted**: script correctly reports `MISSING entries: v0.10.2 (2026-06-15, 5 commits)` and exits 2. Real gap still detected.
- [x] **Diff scope confirmed**: single-line change to `defaults/.claude/commands/loom/release.md`. `.claude/commands/loom/release.md` left untouched (install-script's job to regenerate from the `defaults/` template).

## Out of scope

- Regenerating `.claude/commands/loom/release.md` — that's the install script's responsibility.
- Any wider Phase 1.5 refactoring — the issue's "Out of scope" section explicitly excludes that.
- Bash version check — the skill targets bash 3.2+ uniformly; not changing.

Closes #3501

🤖 Generated with [Claude Code](https://claude.com/claude-code)