### PR TITLE
feat(release): add LOOM-EXTENSION-POINT seam markers (Option B, #3503)

### DIFF
--- a/defaults/.claude/commands/loom/release.md
+++ b/defaults/.claude/commands/loom/release.md
@@ -15,7 +15,7 @@ This skill guides a careful, interactive release process. Every release must:
 
 **Do not rush. Each phase requires user confirmation before proceeding.**
 
-**Project-specific customization**: this skill is generic. If your project needs release-time reminders (e.g., "remember to bump the protocol version when the API changes"), drop a `release.md` file in `.loom/context/topics/` — the methodology-injection hook will inject it on every invocation. Do NOT fork this skill.
+**Project-specific customization**: this skill is generic. If your project needs release-time reminders (e.g., "remember to bump the protocol version when the API changes"), drop a `release.md` file in `.loom/context/topics/` — the methodology-injection hook will inject it on every invocation. For procedural overrides that must execute at a specific phase boundary (e.g., "poll workflow X before creating the GitHub Release"), reference one of the named seams documented under [Operator extension points](#operator-extension-points) at the bottom of this skill. Do NOT fork this skill.
 
 ## Phase 1: Pre-flight Checks
 
@@ -43,6 +43,8 @@ Present findings to the user:
 - If CI exists and is failing, stop and fix first.
 - If CI is absent, treat clean `git status` + zero blocking open PRs as the gate.
 - If there are open PRs, ask if they should land before the release.
+
+<!-- LOOM-EXTENSION-POINT: pre-changelog-style -->
 
 ## Phase 1.5: CHANGELOG Completeness Gate
 
@@ -421,6 +423,8 @@ git tag -f vX.Y.Z
 
 Show the user the result and ask for final confirmation.
 
+<!-- LOOM-EXTENSION-POINT: pre-push -->
+
 ## Phase 6: Push and Release
 
 After final confirmation:
@@ -430,7 +434,10 @@ After final confirmation:
    git push origin main --tags
    ```
 
+<!-- LOOM-EXTENSION-POINT: post-push -->
+
 2. **Create GitHub Release**:
+   <!-- LOOM-EXTENSION-POINT: pre-github-release -->
    ```bash
    gh release create vX.Y.Z --title "vX.Y.Z" --notes-file - <<< "$(changelog excerpt)"
    ```
@@ -472,6 +479,45 @@ For the version-files line, report what the chosen tool actually modified:
 - `bumpversion`/`bump2version`: the `[bumpversion:file:*]` set from `.bumpversion.cfg` / `setup.cfg`
 - `poetry`: `pyproject.toml`
 - `npm`: `package.json` (+ `package-lock.json` if present)
+
+<!-- LOOM-EXTENSION-POINT: post-summary -->
+
+## `scripts/version.sh` interface
+
+When the skill detects `./scripts/version.sh` (Phase 2a), it dispatches the following subcommands. Projects that ship a custom `scripts/version.sh` from a pre-v0.10.3 install must implement these, or delete the script entirely and let detection fall through to the next supported tool (`cargo-release`, `bumpversion`, `poetry`, `npm`).
+
+| Subcommand | Purpose | Required by Phase |
+|---|---|---|
+| `./scripts/version.sh` | Print current version to stdout | 2b |
+| `./scripts/version.sh list` | List version-bearing files, one per line | 5 step 2 |
+| `./scripts/version.sh check` | Verify all version-bearing files agree | 5 step 4 |
+| `./scripts/version.sh bump <level> --tag` | Bump (`patch`/`minor`/`major`), commit, tag | 5 step 3 |
+| `./scripts/version.sh set <version> [--tag]` | Set explicit version, commit, optionally tag | (not used by skill; supported by Loom's bundled script for operator convenience) |
+
+The skill currently never invokes `set`, but it is documented here because the bundled `scripts/version.sh` ships with it and downstream `version.sh` forks should not silently drop it.
+
+## Operator extension points
+
+This skill exposes the following named seams (HTML-comment markers) that project-specific topic injections can target. Seam names are stable contracts — once published they will not be renamed; new seams may be added over time. Markers are HTML comments, so they do not render in the prose.
+
+| Seam | Location | Intended use |
+|---|---|---|
+| `pre-changelog-style` | Just before Phase 1.5 (CHANGELOG Completeness Gate) | Inject CHANGELOG-style overrides (e.g., themed-section grouping, Keep-a-Changelog opt-outs, project-specific entry conventions). |
+| `pre-push` | Just before Phase 6 (Push and Release) | Inject the project's irreversibility prompt or any final pre-push gate (e.g., "confirm you intend to push tag `vX.Y.Z` and trigger N downstream workflows"). |
+| `post-push` | Inside Phase 6, after the `git push origin main --tags` step and before the GitHub Release is created | Inject post-push procedural steps such as polling multiple registry/publish workflows for completion before continuing. |
+| `pre-github-release` | Inside Phase 6, immediately before `gh release create` | Inject pre-release-creation gates (e.g., "wait for both Crates and npm workflows to finish before creating the GitHub Release"). |
+| `post-summary` | After Phase 7 (Post-Release Summary) | Inject project-specific follow-up steps (e.g., "post release announcement", "ping #releases Slack channel", "open the next milestone"). |
+
+**How projects use these seams**: drop a `release.md` file in `.loom/context/topics/` (the existing methodology-injection mechanism) and reference the target seam name in prose. The agent reading the skill plus the injected topic file will compose them at runtime. Example topic snippet:
+
+```markdown
+At extension point `pre-github-release`: do NOT run `gh release create` until BOTH of the following workflows succeed:
+  - `.github/workflows/publish-crate.yml`
+  - `.github/workflows/publish-npm.yml`
+Poll with `gh run list --workflow=<file> --limit 1 --json conclusion` until both report `success`.
+```
+
+Projects that find injection insufficient (i.e. need to REPLACE a phase's content, not just inject alongside it) should file an issue requesting Option A (named phase-extension files) — see the architect notes on #3503.
 
 ## Important Notes
 

--- a/defaults/hooks/example-context/topics/release.md
+++ b/defaults/hooks/example-context/topics/release.md
@@ -1,0 +1,44 @@
+# Release Reminders (example)
+
+This file is injected when a prompt mentions release-related keywords (default
+pattern: filename "release"). Use it for project-specific reminders, conventions,
+and procedural overrides that must execute at the named seams in `/loom:release`.
+
+## Advisory reminders (any phase)
+
+- Bump the protocol version constant when the wire format changes.
+- Update the migration guide for any deletion-class change.
+- Verify the CI badge in README.md still points at the right branch.
+
+## Procedural overrides at named seams
+
+The `/loom:release` skill exposes named seams (HTML-comment markers) at
+well-chosen phase boundaries. To inject content at a specific seam, write the
+override in prose and reference the seam name. The agent reading the skill and
+this topic file will compose them at runtime.
+
+Available seams (see the "Operator extension points" section at the bottom of
+`/loom:release` for the authoritative list):
+
+- `pre-changelog-style` — before Phase 1.5 (CHANGELOG style overrides).
+- `pre-push` — before Phase 6 (irreversibility prompts, final gates).
+- `post-push` — inside Phase 6 after `git push --tags` (post-push polling).
+- `pre-github-release` — inside Phase 6 before `gh release create` (release
+  gating on external workflows).
+- `post-summary` — after Phase 7 (project-specific follow-ups).
+
+### Example: override CHANGELOG style at `pre-changelog-style`
+
+> At extension point `pre-changelog-style`: this project does NOT follow
+> Keep-a-Changelog "Added/Changed/Fixed/Removed" grouping. Instead, group
+> entries under thematic headers: "User-facing", "Internals", "Docs". Match
+> the existing CHANGELOG.md for examples.
+
+### Example: gate release on multiple workflows at `pre-github-release`
+
+> At extension point `pre-github-release`: do NOT run `gh release create` until
+> BOTH of the following workflows succeed for the just-pushed tag:
+>   - `.github/workflows/publish-crate.yml`
+>   - `.github/workflows/publish-npm.yml`
+> Poll with `gh run list --workflow=<file> --limit 1 --json conclusion` until
+> both report `success`. Time out after 15 minutes and ask the operator.


### PR DESCRIPTION
Closes #3503

## Summary

Implements the smallest concrete first step from the architect proposal in #3503: **Option B (skill seams)**. Annotates `defaults/.claude/commands/loom/release.md` with five named HTML-comment markers at well-chosen phase boundaries that project-side topics files can target for procedural overrides. Adds documentation, a `scripts/version.sh` interface contract section, and an example topics file.

## Why Option B (and not A or C)

The issue sketches three extension mechanisms:

- **Option A** — named phase-extension files (`.loom/context/release/phase-N-{pre,post,replace}.md`)
- **Option B** — skill seams with HTML-comment markers (this PR)
- **Option C** — formal `@override`/`@inject` directive blocks

Option B is the lowest-risk, smallest-blast-radius change of the three. It composes naturally with the existing topics-injection mechanism (no new methodology-hook contract, no new directive parser), it uses HTML comments so the markers render invisibly in the prose, and it decouples extension points from phase numbers (so a future Phase 4.5 insert doesn't silently invalidate every project's `phase-5-pre.md`).

The architect comment on the issue explicitly recommends Option B as the foundation, and notes that A and C can be layered on later if seams prove insufficient.

## Seams added

| Seam | Location | Maps to issue gap |
|---|---|---|
| `pre-changelog-style` | Just before Phase 1.5 | Gap 3 (CHANGELOG style override) |
| `pre-push` | Just before Phase 6 | Gap 4 (irreversibility prompt) |
| `post-push` | After `git push --tags`, before `gh release create` | Gap 1 (multi-workflow trigger gate) |
| `pre-github-release` | Immediately before `gh release create` | Gap 2 (ordering enforcement) |
| `post-summary` | After Phase 7 | (project-specific follow-ups) |

## Files changed

- `defaults/.claude/commands/loom/release.md` — adds five `<!-- LOOM-EXTENSION-POINT: <name> -->` markers (HTML comments; render invisibly), a new "Operator extension points" section documenting the seam contract, a new "scripts/version.sh interface" section documenting the subcommands the skill dispatches, and a one-line cross-reference in the existing "Project-specific customization" note. **No procedural content of the skill was changed** — only seam markers and new documentation sections were added.
- `defaults/hooks/example-context/topics/release.md` — example topics file showing how to write seam-targeted overrides (consistent with the existing `defaults/hooks/example-context/topics/security.md` precedent).

## Out of scope / deferred follow-ups

The issue's last section flagged that the `scripts/version.sh` interface contract (subcommands `bump`, `set`, `list`, `check`, `--tag`) was undocumented in the skill. This PR documents the interface contract inline so projects with pre-existing `version.sh` forks know what to support, but does **not** modify the host-repo `scripts/version.sh` itself.

If projects find seam-based injection insufficient (e.g., they need to REPLACE phase content, not just inject alongside it), the next concrete step is **Option A** — named phase-extension files with a `replace` semantic. That work is not filed as a separate GitHub issue per Loom label policy (#3503's existing thread is the right place to surface that need when it materializes).

**Option C** (formal `@override`/`@inject` directive blocks) is the heaviest of the three sketches and remains the lowest-priority deferral; it requires inventing a markdown DSL and shipping a directive parser, and there is no evidence yet that A wouldn't cover the remaining gaps.

## Test plan

- [ ] Markers are HTML comments — visually inspect rendered markdown to confirm they don't appear in the prose.
- [ ] The five seam names match between the markers, the "Operator extension points" section, and the example topics file.
- [ ] The example topics file at `defaults/hooks/example-context/topics/release.md` matches the convention set by the existing `security.md`/`security.pattern` example.
- [ ] The existing "Project-specific customization" callout in the skill overview correctly cross-references the new section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)