### PR TITLE
docs(release): clarify pre-changelog-style scope + augment-vs-replace seam convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.10.4] - 2026-06-16
+### Changed
+
+- **`/loom:release` seam-contract clarification** — documents the v0.10.4 Option B seam markers more precisely without renaming any existing seam or adding new ones. Two clarifications land in `defaults/.claude/commands/loom/release.md` and the example topics file at `defaults/hooks/example-context/topics/release.md`: (1) the `pre-changelog-style` row in the "Operator extension points" table now records its phase scope explicitly as **Phase 1.5 AND Phase 4** — a single marker placed before Phase 1.5 covers both phases by contract, so projects with non-default header patterns (e.g., `## Release notes — vX.Y.Z (YYYY-MM-DD)`) do not need a separate Phase 4 marker; (2) a new "Composition semantics: augment vs replace" subsection documents the prose-prefix convention that distinguishes augment overrides (`At extension point <seam>: <directive>`) from replace overrides (`At extension point <seam>, replacing default behavior: <directive>`), with worked examples and a "prefer augment unless structurally incompatible" guidance line. The example topics file is updated to demonstrate both prefixes (one augment for `pre-changelog-style` and `pre-push`, one replace for `pre-github-release`). No seam renames, no new markers, no breaking changes to existing topic files — the prose-prefix convention is purely additive, and topic files authored before the convention was documented are treated as augment by default. Defers the structural alternatives (option (b) — separate `pre-changelog-draft` marker, and the `replace-X` parallel seam family) to follow-up issues if the prose-level convention proves insufficient over a release cycle. (#3509)
 
 ### Summary
 

--- a/defaults/.claude/commands/loom/release.md
+++ b/defaults/.claude/commands/loom/release.md
@@ -674,13 +674,15 @@ The skill currently never invokes `set`, but it is documented here because the b
 
 This skill exposes the following named seams (HTML-comment markers) that project-specific topic injections can target. Seam names are stable contracts — once published they will not be renamed; new seams may be added over time. Markers are HTML comments, so they do not render in the prose.
 
-| Seam | Location | Intended use |
-|---|---|---|
-| `pre-changelog-style` | Just before Phase 1.5 (CHANGELOG Completeness Gate) | Inject CHANGELOG-style overrides (e.g., themed-section grouping, Keep-a-Changelog opt-outs, project-specific entry conventions). |
-| `pre-push` | Just before Phase 6 (Push and Release) | Inject the project's irreversibility prompt or any final pre-push gate (e.g., "confirm you intend to push tag `vX.Y.Z` and trigger N downstream workflows"). |
-| `post-push` | Inside Phase 6, after the `git push origin main --tags` step and before the GitHub Release is created | Inject post-push procedural steps such as polling multiple registry/publish workflows for completion before continuing. |
-| `pre-github-release` | Inside Phase 6, immediately before `gh release create` | Inject pre-release-creation gates (e.g., "wait for both Crates and npm workflows to finish before creating the GitHub Release"). |
-| `post-summary` | After Phase 7 (Post-Release Summary) | Inject project-specific follow-up steps (e.g., "post release announcement", "ping #releases Slack channel", "open the next milestone"). |
+| Seam | Marker location | Phase scope | Intended use |
+|---|---|---|---|
+| `pre-changelog-style` | Just before Phase 1.5 (CHANGELOG Completeness Gate) | **Phase 1.5 AND Phase 4** — content injected here is in scope for both Phase 1.5's gap-detection regex (`^## \[X.Y.Z\]`) and Phase 4's CHANGELOG drafting prose. The single marker placed before Phase 1.5 covers both phases by contract. | Inject CHANGELOG-style overrides (e.g., themed-section grouping, Keep-a-Changelog opt-outs, project-specific entry conventions, custom header patterns like `## Release notes — vX.Y.Z (YYYY-MM-DD)`). |
+| `pre-push` | Just before Phase 6 (Push and Release) | Phase 6 (pre-push) | Inject the project's irreversibility prompt or any final pre-push gate (e.g., "confirm you intend to push tag `vX.Y.Z` and trigger N downstream workflows"). |
+| `post-push` | Inside Phase 6, after the `git push origin main --tags` step and before the GitHub Release is created | Phase 6 (between push and GitHub Release creation) | Inject post-push procedural steps such as polling multiple registry/publish workflows for completion before continuing. |
+| `pre-github-release` | Inside Phase 6, immediately before `gh release create` | Phase 6 (immediately pre-release) | Inject pre-release-creation gates (e.g., "wait for both Crates and npm workflows to finish before creating the GitHub Release"). |
+| `post-summary` | After Phase 7 (Post-Release Summary) | Phase 7 (post-summary) | Inject project-specific follow-up steps (e.g., "post release announcement", "ping #releases Slack channel", "open the next milestone"). |
+
+**Note on `pre-changelog-style` dual-phase scope**: the seam name records the marker *location* (just before Phase 1.5), but the contract is that any injected content authored against this seam applies to both Phase 1.5 (the detection regex) and Phase 4 (the drafting prose). Projects whose CHANGELOG style still produces `## [X.Y.Z]` headers (the default Keep-a-Changelog shape) only need to influence Phase 4; projects with a non-default header pattern need both phases to honor the override, and the single marker covers them by contract. There is intentionally no separate `pre-changelog-draft` seam — the dual-phase contract avoids the API surface cost. If your project genuinely needs separate Phase 1.5 vs Phase 4 injection points, file an issue referencing this note so the design can be revisited with concrete evidence.
 
 **How projects use these seams**: drop a `release.md` file in `.loom/context/topics/` (the existing methodology-injection mechanism) and reference the target seam name in prose. The agent reading the skill plus the injected topic file will compose them at runtime. Example topic snippet:
 
@@ -691,7 +693,34 @@ At extension point `pre-github-release`: do NOT run `gh release create` until BO
 Poll with `gh run list --workflow=<file> --limit 1 --json conclusion` until both report `success`.
 ```
 
-Projects that find injection insufficient (i.e. need to REPLACE a phase's content, not just inject alongside it) should file an issue requesting Option A (named phase-extension files) — see the architect notes on #3503.
+### Composition semantics: augment vs replace (prose-prefix convention)
+
+The seam names (`pre-X`, `post-X`) describe *where* a topic-file override fires, not whether it composes additively with or overrides the skill's default behavior at that seam. The composition mode is signaled by the **prose prefix** the topic-file author writes when referencing the seam. The agent reading both files honors the prefix at runtime.
+
+| Prose prefix | Semantics | Composition rule |
+|---|---|---|
+| `At extension point <seam>: <directive>` | **Augment** (additive) | Run the default behavior at this seam AND the injected directive. The default is preserved; the override runs alongside it (typically before for `pre-X`, after for `post-X`). |
+| `At extension point <seam>, replacing default behavior: <directive>` | **Replace** (override) | The injected directive REPLACES whatever the default does at this seam. The default behavior at that seam does not run. |
+
+**Worked examples**:
+
+- *Augment example* — add a confirmation gate before the existing push, without removing it:
+
+  > At extension point `pre-push`: ask the operator to confirm the irreversibility of pushing tag `vX.Y.Z` before proceeding.
+
+  Phase 6 runs the confirmation first, then runs its default `git push origin main --tags` step.
+
+- *Replace example* — substitute a multi-workflow gate for the default "create the release immediately" behavior:
+
+  > At extension point `pre-github-release`, replacing default behavior: poll `.github/workflows/publish-crate.yml` and `.github/workflows/publish-npm.yml` until both succeed, THEN run `gh release create vX.Y.Z --title "vX.Y.Z" --notes-file -` with the CHANGELOG excerpt.
+
+  Phase 6's default `gh release create` does not run on its own; the topic-file directive owns the GitHub Release creation entirely.
+
+**When in doubt**: prefer the augment form. It is the safer default — the skill's existing behavior at the seam is preserved, and the override layers on top. Use the replace form only when the default behavior at the seam is incompatible with the project's release flow (the multi-workflow gate above is the canonical case: you cannot run `gh release create` immediately AND wait for upstream workflows; one must yield).
+
+**Compatibility note**: topic files authored before this convention was documented (i.e. without an explicit "replacing default behavior" prefix) are treated as augment by default. If such a file's directive is structurally incompatible with the augment reading (e.g., it says "do NOT run X" where X is the default at that seam), the agent should surface the ambiguity to the operator rather than guess.
+
+Projects that find injection insufficient (i.e. need to REPLACE a phase's content at scale, not just inject alongside or replace a single seam's default action) should file an issue requesting Option A (named phase-extension files) — see the architect notes on #3503.
 
 ## Important Notes
 

--- a/defaults/hooks/example-context/topics/release.md
+++ b/defaults/hooks/example-context/topics/release.md
@@ -20,25 +20,66 @@ this topic file will compose them at runtime.
 Available seams (see the "Operator extension points" section at the bottom of
 `/loom:release` for the authoritative list):
 
-- `pre-changelog-style` — before Phase 1.5 (CHANGELOG style overrides).
+- `pre-changelog-style` — before Phase 1.5 (CHANGELOG style overrides). Content
+  authored here is in scope for **both** Phase 1.5's detection regex and
+  Phase 4's drafting prose by contract.
 - `pre-push` — before Phase 6 (irreversibility prompts, final gates).
 - `post-push` — inside Phase 6 after `git push --tags` (post-push polling).
 - `pre-github-release` — inside Phase 6 before `gh release create` (release
   gating on external workflows).
 - `post-summary` — after Phase 7 (project-specific follow-ups).
 
-### Example: override CHANGELOG style at `pre-changelog-style`
+### Composition semantics: augment vs replace
+
+Each override below uses one of two prose prefixes to signal whether it adds
+to the skill's default behavior at the seam (augment) or substitutes for it
+(replace):
+
+- `At extension point <seam>: <directive>` — **augment**. The skill's default
+  at the seam still runs; the directive layers alongside it.
+- `At extension point <seam>, replacing default behavior: <directive>` —
+  **replace**. The directive substitutes for the default; the default does
+  not run.
+
+Prefer augment unless the project's flow is structurally incompatible with
+the default. See the "Operator extension points" section in `/loom:release`
+for the full convention.
+
+### Example (augment): override CHANGELOG style at `pre-changelog-style`
 
 > At extension point `pre-changelog-style`: this project does NOT follow
 > Keep-a-Changelog "Added/Changed/Fixed/Removed" grouping. Instead, group
 > entries under thematic headers: "User-facing", "Internals", "Docs". Match
-> the existing CHANGELOG.md for examples.
+> the existing CHANGELOG.md for examples. The thematic-header convention
+> applies to BOTH Phase 1.5 detection (headers still match `^## \[X.Y.Z\]`
+> for gap-finding) and Phase 4 drafting (use thematic sub-sections instead
+> of Keep-a-Changelog groups).
 
-### Example: gate release on multiple workflows at `pre-github-release`
+This is an augment because Phase 1.5's regex still applies to the standard
+`## [X.Y.Z]` header pattern — only Phase 4's grouping is project-specific.
 
-> At extension point `pre-github-release`: do NOT run `gh release create` until
-> BOTH of the following workflows succeed for the just-pushed tag:
+### Example (augment): add an irreversibility prompt at `pre-push`
+
+> At extension point `pre-push`: ask the operator to confirm the irreversibility
+> of pushing tag `vX.Y.Z` (this will trigger downstream publish workflows that
+> cannot be unwound). Proceed only after explicit confirmation.
+
+Phase 6 still runs its default `git push origin main --tags` after the
+confirmation — the prompt augments, it does not replace.
+
+### Example (replace): gate release on multiple workflows at `pre-github-release`
+
+> At extension point `pre-github-release`, replacing default behavior: do NOT
+> run `gh release create` immediately. Instead, poll BOTH of the following
+> workflows for the just-pushed tag until each reports `success`:
 >   - `.github/workflows/publish-crate.yml`
 >   - `.github/workflows/publish-npm.yml`
-> Poll with `gh run list --workflow=<file> --limit 1 --json conclusion` until
-> both report `success`. Time out after 15 minutes and ask the operator.
+> Poll with `gh run list --workflow=<file> --limit 1 --json conclusion`. Time
+> out after 15 minutes and ask the operator. Once both succeed, run
+> `gh release create vX.Y.Z --title "vX.Y.Z" --notes-file -` with the
+> CHANGELOG excerpt as the release notes.
+
+This is a replace because the default behavior at `pre-github-release` (run
+`gh release create` immediately) is structurally incompatible with the
+"wait for upstream workflows first" requirement — one must yield, and the
+directive owns the GitHub Release creation entirely.


### PR DESCRIPTION
## Summary

Two docs-only clarifications to the v0.10.4 Option B seam markers, both per the curator's lowest-blast-radius recommendations on #3509. No seam renames, no new markers, no breaking changes.

## Chosen options (Judge: please verify these trade-offs were honored)

**Friction 1 — option (c) chosen** (over option (a) rename and option (b) new `pre-changelog-draft` marker)
- Approach: clarify in the seam-table prose that `pre-changelog-style` content is in scope for both Phase 1.5 (detection) and Phase 4 (drafting) by contract.
- Trade-off: zero new API surface and zero rename; existing topic files (including vibesql's) stay compatible. Option (b) would have added a second marker at Phase 4 with cleaner separation but more API surface; rejected per the curator's "smallest blast radius" recommendation.
- Implementation: one-row clarification of `pre-changelog-style` in the "Operator extension points" table (added a new "Phase scope" column to make the dual-phase contract visible for ALL seams, not just this one), plus a short explanatory paragraph immediately under the table referencing the dual-phase contract and noting that the absence of a `pre-changelog-draft` seam is deliberate.

**Friction 2 — prose-prefix convention chosen** (over the parallel `replace-X` seam-rename family)
- Approach: document the convention that topic-file authors signal augment-vs-replace via prose prefix:
  - `At extension point <seam>: <directive>` -> augment (default behavior at the seam still runs)
  - `At extension point <seam>, replacing default behavior: <directive>` -> replace (default behavior at the seam does not run)
- Trade-off: purely additive; no seam renames; no new markers; existing topic files (including vibesql's existing `pre-changelog-style` and `pre-github-release` overrides) remain valid and are treated as augment by default. The structural alternative (parallel `replace-X` seam names like `replace-changelog-style`, `replace-github-release`) was rejected per the curator's recommendation as a follow-up if the prose convention proves insufficient over a release cycle.
- Implementation: new "Composition semantics: augment vs replace (prose-prefix convention)" subsection in `release.md` with a 2-row prefix table, worked augment and replace examples, "prefer augment unless structurally incompatible" guidance, and a backward-compatibility note for topic files predating the convention.

**Friction 3 — deferred (no work this PR)**
- The existing "Projects that find injection insufficient ... should file an issue requesting Option A" forward-looking paragraph remains in place. Lightly rephrased to acknowledge the augment/replace convention as the first line of defense before Option A becomes necessary; the deferral language is preserved verbatim.

## Files changed

- `defaults/.claude/commands/loom/release.md` — added "Phase scope" column + `pre-changelog-style` dual-phase note (Friction 1); new "Composition semantics: augment vs replace (prose-prefix convention)" subsection with prefix table, worked examples, fallback guidance, compatibility note (Friction 2); light rephrase of the existing Option A forward-looking paragraph (Friction 3, no semantic change).
- `defaults/hooks/example-context/topics/release.md` — added a "Composition semantics: augment vs replace" subsection summarizing the convention; relabeled existing examples as augment / replace and added a new augment example for `pre-push`; updated `pre-github-release` example to use the explicit `replacing default behavior` prefix as a worked replace example; updated the `pre-changelog-style` summary to mention the dual-phase scope.
- `CHANGELOG.md` — single `## [Unreleased]` entry under `### Changed` describing the docs-level seam-contract clarification.

## Constraints honored (acceptance criteria)

- [x] Friction 1 resolved via option (c) — `pre-changelog-style` phase scope is now explicit (Phase 1.5 AND Phase 4).
- [x] Friction 2 resolved via prose-prefix convention — augment vs replace documented in the "Operator extension points" section.
- [x] Friction 3 acknowledged — the existing forward-looking Option A note remains.
- [x] Example topics file updated to reflect the new convention (both augment and replace forms demonstrated).
- [x] No seam renames — the five existing names (`pre-changelog-style`, `pre-push`, `post-push`, `pre-github-release`, `post-summary`) are unchanged. `grep -n LOOM-EXTENSION-POINT` confirms all 5 markers at their pre-existing line positions (47 / 598 / 609 / 612 / 657).
- [x] No new HTML-comment markers added — pure prose changes only.
- [x] No fork-inducing changes — vibesql topics file at https://github.com/rjwalters/vibesql/blob/main/.loom/context/topics/release.md remains compatible by inspection (its `pre-changelog-style` and `pre-github-release` overrides will be read as augment by default; if it needs replace semantics for `pre-github-release` it can add the explicit `replacing default behavior` prefix as a follow-up, but the current behavior is preserved).
- [x] CHANGELOG `## [Unreleased]` entry added under `### Changed`.

## Diff size

`+89 / -17` lines across three files. Well within the curator's ~150-line scope guard.

## Test plan

- [x] Manual verification: re-read the "Operator extension points" section end-to-end and confirm the augment-vs-replace convention is unambiguous. An operator reading only the seam table + immediate prose can now write a `replace`-style override without consulting the skill source.
- [x] Manual verification: the `pre-changelog-style` row now explicitly names both Phase 1.5 and Phase 4 via the new "Phase scope" column plus the dual-phase note immediately under the table.
- [x] Manual verification: vibesql's topics file at https://github.com/rjwalters/vibesql/blob/main/.loom/context/topics/release.md was re-read against the new contract; its existing `At extension point pre-changelog-style:` and `At extension point pre-github-release:` prose still composes correctly (both read as augment under the new convention, which matches the pre-PR runtime behavior — no behavior change for existing topic files).
- [x] `grep -n LOOM-EXTENSION-POINT` confirms all 5 existing marker names are still present and unchanged.
- [x] No automated tests apply — release skill is markdown executed by an LLM agent, no unit tests cover it.

Closes #3509