### PR TITLE
docs(builder): enforce absolute-path discipline + add check-main-clean.sh backstop

### DIFF
--- a/defaults/.claude/commands/loom/builder-worktree.md
+++ b/defaults/.claude/commands/loom/builder-worktree.md
@@ -41,22 +41,49 @@ gh issue edit 84 --remove-label "loom:issue" --add-label "loom:building"
 # -> Creates: .loom/worktrees/issue-84
 # -> Branch: feature/issue-84
 
-# 3. Change to worktree directory
-cd .loom/worktrees/issue-84
+# 3. Capture the worktree ABSOLUTE path ONCE (see warning below)
+WORKTREE_ABS="$(cd .loom/worktrees/issue-84 && pwd)"
+# -> e.g. /Users/you/repo/.loom/worktrees/issue-84
 
-# 4. Do your work (implement, test, commit)
+# 4. Do your work using ABSOLUTE paths (implement, test, commit)
+#    - Write/Edit: pass "$WORKTREE_ABS/<file>"
+#    - Bash:       git -C "$WORKTREE_ABS" ...  OR  cd "$WORKTREE_ABS" && <cmd>
 # ... work work work ...
 
-# 5. Push and create PR from worktree
-git push -u origin feature/issue-84
+# 5. Push and create PR from the worktree
+git -C "$WORKTREE_ABS" push -u origin feature/issue-84
 gh pr create --label "loom:review-requested"
 
-# 6. Return to main workspace
-cd ../..  # Back to workspace root
-
-# 7. Worktree cleanup is automatic - DO NOT manually delete worktrees
+# 6. Worktree cleanup is automatic - DO NOT manually delete worktrees
 # Worktrees are cleaned up automatically when PRs merge or by loom-clean
 ```
+
+### CRITICAL: `cd` Does NOT Persist Across Tool Calls
+
+**The harness resets your working directory between tool calls.** A `cd
+.loom/worktrees/issue-N` in one Bash call does **not** carry over to the next
+Write, Edit, or Bash call — the next call starts back at the main repo root.
+If you rely on a persisted `cd` and then use a repo-relative path, your file
+operation lands in the **main worktree** instead of your issue worktree,
+silently contaminating main (#3513, recurrence of #2802).
+
+**Do this instead:**
+
+1. Capture the worktree's absolute path **once**, right after creating it:
+   ```bash
+   WORKTREE_ABS="$(cd .loom/worktrees/issue-N && pwd)"
+   ```
+2. Use absolute paths for **every** file-mutating operation thereafter:
+   - **Write / Edit tools** — pass the full path `"$WORKTREE_ABS/path/to/file"`.
+     These tools have no cwd; the path you give is the path written.
+   - **Bash** — either re-assert `cd "$WORKTREE_ABS" &&` at the **start of each
+     file-mutating invocation**, or use `git -C "$WORKTREE_ABS" ...` and
+     absolute paths. Never assume an earlier `cd` is still in effect.
+3. Before committing, verify your changes are in the worktree and main is clean:
+   ```bash
+   git -C "$WORKTREE_ABS" status        # changes should be HERE
+   ./.loom/scripts/check-main-clean.sh  # backstop: exits 3 if main is dirty
+   ```
 
 ### Collision Detection
 

--- a/defaults/.claude/commands/loom/builder.md
+++ b/defaults/.claude/commands/loom/builder.md
@@ -262,12 +262,54 @@ After claiming an issue, **before writing any code**, verify you are in the corr
 # 1. Create the worktree (if not already created)
 ./.loom/scripts/worktree.sh <issue-number>
 
-# 2. Change to the worktree directory
-cd .loom/worktrees/issue-<issue-number>
+# 2. Capture the worktree's ABSOLUTE path ONCE — do not rely on cwd persisting
+WORKTREE_ABS="$(cd .loom/worktrees/issue-<issue-number> && pwd)"
+echo "$WORKTREE_ABS"  # MUST end in /.loom/worktrees/issue-<number>
 
-# 3. Verify your location
-pwd  # MUST show: .loom/worktrees/issue-<number>
-git branch  # MUST show: feature/issue-<number>
+# 3. Verify the worktree's branch (works from anywhere via -C)
+git -C "$WORKTREE_ABS" branch --show-current  # MUST show: feature/issue-<number>
+```
+
+### CRITICAL: Absolute-Path Discipline (cwd does NOT persist across tool calls)
+
+**The harness resets your working directory between tool calls.** A `cd` into
+the worktree in one Bash call does **not** carry over to the next Write, Edit,
+or Bash call. If you use repo-relative paths after a cwd reset, your file
+operations resolve against the **main repo root** and silently contaminate the
+main worktree instead of your issue worktree. This is the exact failure this
+section exists to prevent (#3513, a recurrence of #2802).
+
+**The rule:** capture the worktree absolute path **once**, immediately after
+creating the worktree, and use absolute paths for **every** subsequent
+file-mutating operation. Shell variables do not survive across tool calls, so
+re-derive the literal absolute path and embed it directly in each call:
+
+```bash
+WORKTREE_ABS="$(cd .loom/worktrees/issue-<N> && pwd)"
+# e.g. /Users/you/repo/.loom/worktrees/issue-<N>
+```
+
+| Operation | WRONG (relative — lands in main after a cwd reset) | RIGHT (absolute — always lands in the worktree) |
+|-----------|-----------------------------------------------------|--------------------------------------------------|
+| Write tool | `src/foo.ts` | `<WORKTREE_ABS>/src/foo.ts` |
+| Edit tool | `src/foo.ts` | `<WORKTREE_ABS>/src/foo.ts` |
+| Bash file write | `echo x > src/foo.ts` | `echo x > "<WORKTREE_ABS>/src/foo.ts"` |
+| Bash git op | `git status` (cwd unknown) | `git -C "<WORKTREE_ABS>" status` |
+| Bash build | `cargo check` (cwd unknown) | `cd "<WORKTREE_ABS>" && cargo check` |
+
+- **Write / Edit tools**: always pass the **full absolute path** under the
+  worktree. These tools have no working directory of their own — the path you
+  give them is exactly the path that is written.
+- **Bash file mutations**: either prefix each invocation with
+  `cd "<WORKTREE_ABS>" &&`, or use absolute paths / `git -C "<WORKTREE_ABS>"`.
+  Never assume a prior `cd` is still in effect.
+
+**Before committing**, confirm your changes landed in the worktree and NOT in
+main:
+
+```bash
+git -C "<WORKTREE_ABS>" status        # your changes should appear HERE
+./.loom/scripts/check-main-clean.sh   # exits 3 if you contaminated main (#3513)
 ```
 
 **If your working directory does NOT contain `.loom/worktrees/issue-`:**
@@ -289,8 +331,9 @@ Working directly on main causes:
 
 Before writing any code, confirm ALL of these:
 - [ ] Worktree exists at `.loom/worktrees/issue-<N>`
-- [ ] Current directory is inside the worktree (not repo root)
-- [ ] Branch is `feature/issue-<N>` (not `main`)
+- [ ] Captured the worktree ABSOLUTE path once (`WORKTREE_ABS="$(cd .loom/worktrees/issue-<N> && pwd)"`)
+- [ ] Branch is `feature/issue-<N>` (not `main`) — `git -C "$WORKTREE_ABS" branch --show-current`
+- [ ] Will use absolute paths under `$WORKTREE_ABS` for every Write/Edit/Bash file operation (cwd does NOT persist across tool calls)
 - [ ] Issue is claimed with `loom:building` label
 
 **If any of these fail, STOP and fix the setup before proceeding.**

--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -889,6 +889,14 @@ Each builder is responsible for:
 
 **Await all builders in the wave** before proceeding to Judge. Collect each builder's PR number (or failure marker).
 
+**Backstop: verify the main worktree is clean after the builders return (#3513).** A builder subagent runs without `LOOM_WORKTREE_PATH` injected, so the `guard-worktree-paths.sh` hook does not fire on this path. If a builder used repo-relative paths after a cwd reset, it may have written to the **main** worktree instead of its issue worktree. After the wave's builders return and before advancing any PR to Judge, run:
+
+```bash
+./.loom/scripts/check-main-clean.sh   # exit 3 ⇒ main is dirty (builder contamination)
+```
+
+If it exits `3`, the main worktree carries uncommitted changes a builder left behind. Surface this loudly in the wave summary and do not advance the wave to Judge until the contamination is investigated and the stray changes reverted. This is a backstop only — the builder guidance (capture the absolute worktree path once, use absolute paths everywhere) is the primary defense.
+
 **On successful PR creation**, write the `builder-done` checkpoint for that issue (record the PR number):
 ```bash
 # Append --model <resolved> when you passed a model param to the builder subagent (#3482).

--- a/defaults/scripts/check-main-clean.sh
+++ b/defaults/scripts/check-main-clean.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# check-main-clean.sh - Backstop guard: fail if the MAIN worktree is dirty.
+#
+# Detects the #2802 / #3513 failure mode where a Builder agent's cwd resets
+# between tool calls and a repo-relative Write/Edit/Bash file operation lands
+# in the MAIN repository working tree instead of the issue worktree under
+# .loom/worktrees/issue-N. The builder guidance (builder.md / builder-worktree.md)
+# is the primary defense (capture the absolute worktree path once, use absolute
+# paths everywhere). This script is the BACKSTOP: run it after the builder phase
+# and before opening a PR. If the main worktree has uncommitted changes, the
+# builder has contaminated main and the sweep should abort.
+#
+# It resolves the MAIN worktree from anywhere — including from inside an issue
+# worktree — via `git rev-parse --git-common-dir`, so it works whether invoked
+# from the repo root or from a worktree.
+#
+# Usage:
+#   ./.loom/scripts/check-main-clean.sh            # check main worktree, exit 3 if dirty
+#   ./.loom/scripts/check-main-clean.sh --help     # show usage
+#
+# Exit codes:
+#   0 - Main worktree is clean (no uncommitted changes).
+#   2 - Usage error or could not resolve the main worktree (not a git repo).
+#   3 - Main worktree is DIRTY: uncommitted changes detected (the contamination
+#       this guard exists to catch).
+#
+# Notes:
+#   - "Dirty" means `git status --porcelain` on the MAIN worktree returns any
+#     output: staged, unstaged, or untracked files all count. A builder working
+#     correctly in its own worktree leaves the main worktree pristine.
+#   - Issue worktrees live under <main>/.loom/worktrees/ which is gitignored, so
+#     their existence does NOT make the main worktree dirty.
+
+set -euo pipefail
+
+EXIT_OK=0
+EXIT_USAGE=2
+EXIT_MAIN_DIRTY=3
+
+usage() {
+    sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+case "${1:-}" in
+    -h|--help)
+        usage
+        exit "$EXIT_OK"
+        ;;
+    "")
+        ;;
+    *)
+        echo "check-main-clean.sh: unknown argument: $1" >&2
+        echo "Run with --help for usage." >&2
+        exit "$EXIT_USAGE"
+        ;;
+esac
+
+# Resolve the canonical git common dir, then the main worktree root (its parent).
+# This works from the repo root AND from inside any worktree.
+common_dir=$(git rev-parse --git-common-dir 2>/dev/null || true)
+if [[ -z "$common_dir" ]]; then
+    echo "check-main-clean.sh: not inside a git repository" >&2
+    exit "$EXIT_USAGE"
+fi
+
+# git-common-dir may be relative; resolve to an absolute path.
+abs_common=$(cd "$common_dir" 2>/dev/null && pwd) || abs_common="$common_dir"
+main_root=$(dirname "$abs_common")
+
+if [[ ! -d "$main_root" ]]; then
+    echo "check-main-clean.sh: could not resolve main worktree root from '$common_dir'" >&2
+    exit "$EXIT_USAGE"
+fi
+
+status=$(git -C "$main_root" status --porcelain 2>/dev/null || true)
+
+if [[ -n "$status" ]]; then
+    echo "ERROR: MAIN worktree is dirty (uncommitted changes detected)." >&2
+    echo "       Main worktree: $main_root" >&2
+    echo "" >&2
+    echo "       This usually means a builder wrote to the main repo instead of" >&2
+    echo "       its issue worktree (cwd reset between tool calls — see #3513/#2802)." >&2
+    echo "       Builders MUST capture the absolute worktree path once and use" >&2
+    echo "       absolute paths for every Write/Edit/Bash file operation." >&2
+    echo "" >&2
+    echo "       Offending changes:" >&2
+    while IFS= read -r line; do
+        echo "         $line" >&2
+    done <<< "$status"
+    exit "$EXIT_MAIN_DIRTY"
+fi
+
+echo "check-main-clean.sh: main worktree is clean ($main_root)"
+exit "$EXIT_OK"

--- a/defaults/scripts/tests/test-check-main-clean.sh
+++ b/defaults/scripts/tests/test-check-main-clean.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# test-check-main-clean.sh - Smoke tests for check-main-clean.sh
+#
+# Exercises the main-worktree contamination backstop (#3513). Each test runs
+# against a throwaway temp git repo so the result is deterministic and
+# independent of the host repo's pre-existing untracked files.
+#
+# Verified behavior:
+#   - exit 0 when the main worktree is clean
+#   - exit 0 when only a gitignored issue worktree exists under .loom/worktrees/
+#   - exit 3 when the main worktree has a stray untracked file
+#   - exit 3 when the main worktree has a staged change
+#   - exit 3 even when invoked from INSIDE a worktree (resolves main correctly)
+#   - exit 0 from inside a worktree when main is clean
+#   - exit 0 / coherent output for --help
+#   - exit 2 for an unknown argument
+#
+# Usage:
+#   ./.loom/scripts/tests/test-check-main-clean.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPERS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$HELPERS_DIR/check-main-clean.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: $1"
+}
+
+fail() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: $1"
+}
+
+# Run the script, capture its exit code into a global.
+run_rc() {
+    ( "$@" ) >/dev/null 2>&1
+    RC=$?
+}
+
+# Create a throwaway git repo with one commit and a gitignored worktree dir.
+make_repo() {
+    local dir
+    dir=$(mktemp -d)
+    git -C "$dir" init -q
+    git -C "$dir" config user.email t@t.t
+    git -C "$dir" config user.name test
+    printf '.loom/worktrees/\n' > "$dir/.gitignore"
+    git -C "$dir" add .gitignore
+    git -C "$dir" commit -q -m init
+    echo "$dir"
+}
+
+# -------- Test 1: script exists and is executable --------
+echo "Test 1: script exists and is executable"
+if [[ -x "$SCRIPT" ]]; then
+    pass "check-main-clean.sh is executable"
+else
+    fail "check-main-clean.sh is missing or not executable: $SCRIPT"
+    echo "FAILED: $TESTS_FAILED/$TESTS_RUN"
+    exit 1
+fi
+
+# -------- Test 2: clean main exits 0 --------
+echo "Test 2: clean main worktree exits 0"
+REPO=$(make_repo)
+( cd "$REPO" && run_rc "$SCRIPT" ) && true
+( cd "$REPO" && "$SCRIPT" >/dev/null 2>&1 ); RC=$?
+if [[ "$RC" -eq 0 ]]; then pass "exit 0 on clean main"; else fail "expected 0, got $RC"; fi
+
+# -------- Test 3: gitignored issue worktree present is still clean --------
+echo "Test 3: gitignored .loom/worktrees/ does not count as dirty"
+mkdir -p "$REPO/.loom/worktrees/issue-1"
+echo "scratch" > "$REPO/.loom/worktrees/issue-1/foo.txt"
+( cd "$REPO" && "$SCRIPT" >/dev/null 2>&1 ); RC=$?
+if [[ "$RC" -eq 0 ]]; then pass "exit 0 with gitignored worktree files"; else fail "expected 0, got $RC"; fi
+
+# -------- Test 4: stray untracked file makes main dirty (exit 3) --------
+echo "Test 4: stray untracked file in main exits 3"
+echo "stray" > "$REPO/stray.txt"
+( cd "$REPO" && "$SCRIPT" >/dev/null 2>&1 ); RC=$?
+if [[ "$RC" -eq 3 ]]; then pass "exit 3 on untracked stray file"; else fail "expected 3, got $RC"; fi
+rm -f "$REPO/stray.txt"
+
+# -------- Test 5: staged change makes main dirty (exit 3) --------
+echo "Test 5: staged change in main exits 3"
+echo "content" > "$REPO/tracked.txt"
+git -C "$REPO" add tracked.txt
+( cd "$REPO" && "$SCRIPT" >/dev/null 2>&1 ); RC=$?
+if [[ "$RC" -eq 3 ]]; then pass "exit 3 on staged change"; else fail "expected 3, got $RC"; fi
+git -C "$REPO" reset -q HEAD tracked.txt
+rm -f "$REPO/tracked.txt"
+
+# -------- Test 6: invoked from inside a worktree, main dirty -> exit 3 --------
+echo "Test 6: detects dirty main from inside a worktree"
+git -C "$REPO" worktree add -q .loom/worktrees/issue-99 -b feature/issue-99 2>/dev/null
+echo "stray2" > "$REPO/stray2.txt"
+( cd "$REPO/.loom/worktrees/issue-99" && "$SCRIPT" >/dev/null 2>&1 ); RC=$?
+if [[ "$RC" -eq 3 ]]; then pass "exit 3 from worktree when main dirty"; else fail "expected 3, got $RC"; fi
+
+# -------- Test 7: clean main from inside a worktree -> exit 0 --------
+echo "Test 7: clean main from inside a worktree exits 0"
+rm -f "$REPO/stray2.txt"
+( cd "$REPO/.loom/worktrees/issue-99" && "$SCRIPT" >/dev/null 2>&1 ); RC=$?
+if [[ "$RC" -eq 0 ]]; then pass "exit 0 from worktree when main clean"; else fail "expected 0, got $RC"; fi
+
+# -------- Test 8: --help exits 0 and prints usage --------
+echo "Test 8: --help exits 0 with usage output"
+out=$("$SCRIPT" --help 2>&1); RC=$?
+if [[ "$RC" -eq 0 && "$out" == *"check-main-clean.sh"* ]]; then
+    pass "--help prints usage and exits 0"
+else
+    fail "--help: expected 0 + usage text, got rc=$RC"
+fi
+
+# -------- Test 9: unknown argument exits 2 --------
+echo "Test 9: unknown argument exits 2"
+"$SCRIPT" --bogus >/dev/null 2>&1; RC=$?
+if [[ "$RC" -eq 2 ]]; then pass "exit 2 on unknown argument"; else fail "expected 2, got $RC"; fi
+
+# Cleanup
+git -C "$REPO" worktree remove --force .loom/worktrees/issue-99 2>/dev/null || true
+rm -rf "$REPO"
+
+# -------- Summary --------
+echo ""
+if [[ "$TESTS_FAILED" -eq 0 ]]; then
+    echo -e "${GREEN}All $TESTS_PASSED/$TESTS_RUN tests passed${NC}"
+    exit 0
+else
+    echo -e "${RED}FAILED: $TESTS_FAILED/$TESTS_RUN tests failed${NC}"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

A Builder agent's working directory does **not** persist across tool calls — the harness resets cwd between calls. A builder using repo-relative paths after a cwd reset writes to the **main** repo working tree instead of its `.loom/worktrees/issue-N` worktree, silently contaminating main (#3513, a recurrence of #2802). The `/loom:sweep` subagent dispatch path is unprotected because `LOOM_WORKTREE_PATH` is never injected into the subagent's environment, so the `guard-worktree-paths.sh` PreToolUse hook is a dead no-op there.

This PR hardens the builder guidance to mandate absolute-path discipline and adds a deterministic backstop guard that fails loudly when the main worktree is contaminated.

## Changes

- **`defaults/.claude/commands/loom/builder.md`** — new "CRITICAL: Absolute-Path Discipline (cwd does NOT persist across tool calls)" subsection: capture the worktree absolute path once (`WORKTREE_ABS="$(cd .loom/worktrees/issue-N && pwd)"`) and use absolute paths for every Write/Edit/Bash file operation (with a WRONG-vs-RIGHT table). Updated Pre-Work Validation to capture the absolute path, and added two checklist items.
- **`defaults/.claude/commands/loom/builder-worktree.md`** — explicit "`cd` Does NOT Persist Across Tool Calls" section explaining the harness cwd reset and the main-contamination failure mode; the workflow example now captures `WORKTREE_ABS` once and uses `git -C "$WORKTREE_ABS"`.
- **`defaults/scripts/check-main-clean.sh`** (new, executable) — backstop guard. Resolves the MAIN worktree from anywhere (including from inside a worktree) via `git rev-parse --git-common-dir`, runs `git status --porcelain` on it, and exits `3` (`EXIT_MAIN_DIRTY`) if dirty, `0` if clean, `2` on usage error. Gitignored issue worktrees under `.loom/worktrees/` do not count as dirty. `set -euo pipefail`, usage header, `--help`. shellcheck-clean.
- **`defaults/scripts/tests/test-check-main-clean.sh`** (new, executable) — 9 deterministic smoke tests against throwaway temp repos: clean/dirty/staged states, gitignored-worktree-is-clean, invocation from inside a worktree, `--help`, and bad-arg exit codes.
- **`defaults/.claude/commands/loom/sweep.md`** — calls the backstop after the wave's builders return and before advancing any PR to Judge; documents that the subagent path lacks `LOOM_WORKTREE_PATH` protection.

> Note: `.claude/commands` and `.loom/scripts` are symlinks into `defaults/`; editing the `defaults/` sources is the source of truth and updates both views.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `builder.md` states: capture absolute worktree path once, use absolute paths for all Write/Edit/Bash ops | ✅ | New "Absolute-Path Discipline" section + WRONG/RIGHT table + checklist items (builder.md lines ~273–337) |
| `builder-worktree.md` notes `cd` does NOT persist across tool calls; use absolute paths or re-assert `cd` | ✅ | New "`cd` Does NOT Persist Across Tool Calls" section (builder-worktree.md line ~61) |
| `check-main-clean.sh` exits 3 when main dirty, 0 when clean | ✅ | Smoke-tested both states; 9/9 tests pass |
| Script is executable, follows script conventions (`set -euo pipefail`, usage comment) | ✅ | `git ls-files -s` shows mode 100755; shellcheck clean |
| Builder run produces zero uncommitted changes in main | ✅ | This PR was built with the discipline it documents — main worktree at repo root has zero stray changes (only pre-existing untracked `e2e/`, `src-tauri/`, `test-results/`) |
| A cwd reset mid-build does not cause edits outside the issue worktree | ✅ | All Write/Edit/Bash ops used the absolute path `/.../.loom/worktrees/issue-3513/...`; verified via `git -C "$WORKTREE_ABS" status` |

## Test Plan

- `bash defaults/scripts/tests/test-check-main-clean.sh` → all 9/9 pass (clean=0, gitignored-worktree=0, untracked=3, staged=3, dirty-from-worktree=3, clean-from-worktree=0, --help=0, bad-arg=2).
- `shellcheck` on both new scripts → clean.
- Confirmed the main worktree at the repo root has no stray changes introduced by this build.

Closes #3513