### PR TITLE
fix: make in-place sed edits portable, run installer CI on ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,8 +87,8 @@ jobs:
     name: Installer Integration Tests
     needs: changes
     if: always() && (github.event_name == 'push' || needs.changes.outputs.scripts == 'true')
-    # macOS runner required: uninstall-loom.sh uses sed -i '' (macOS syntax)
-    runs-on: macos-latest
+    # Portable across GNU/BSD sed (temp-file + mv idiom) — runs on ubuntu (#3515)
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - name: Run installer tests

--- a/scripts/uninstall-loom.sh
+++ b/scripts/uninstall-loom.sh
@@ -935,11 +935,14 @@ if [[ -f "$WORKTREE_ABS/CLAUDE.md" ]]; then
     # Remove only the Loom section (between markers, inclusive)
     info "Removing Loom section from CLAUDE.md (marker-based)..."
 
-    # Use sed to remove everything between markers (inclusive)
-    sed -i '' '/<!-- BEGIN LOOM ORCHESTRATION -->/,/<!-- END LOOM ORCHESTRATION -->/d' "$CLAUDE_MD"
+    # Use sed to remove everything between markers (inclusive).
+    # Portable in-place: pipe through a temp file and mv, avoiding the BSD vs
+    # GNU `sed -i` syntax divergence (matches the house idiom in version.sh).
+    sed '/<!-- BEGIN LOOM ORCHESTRATION -->/,/<!-- END LOOM ORCHESTRATION -->/d' "$CLAUDE_MD" > "${CLAUDE_MD}.tmp" && mv "${CLAUDE_MD}.tmp" "$CLAUDE_MD"
 
-    # Clean up any trailing blank lines
-    sed -i '' -e :a -e '/^\n*$/{$d;N;ba' -e '}' "$CLAUDE_MD"
+    # Clean up any trailing blank lines (awk equivalent of the old sed
+    # blank-trim, consistent with the .gitignore handling below).
+    awk 'NF || prev_blank++ < 1 { print; if (NF) prev_blank=0 }' "$CLAUDE_MD" > "${CLAUDE_MD}.tmp" && mv "${CLAUDE_MD}.tmp" "$CLAUDE_MD"
 
     # If file is now empty or only whitespace, remove it
     if [[ ! -s "$CLAUDE_MD" ]] || ! grep -q '[^[:space:]]' "$CLAUDE_MD" 2>/dev/null; then
@@ -1032,8 +1035,9 @@ if [[ -f "$WORKTREE_ABS/.gitignore" ]]; then
     awk 'NF || prev_blank++ < 1 { print; if (NF) prev_blank=0 }' "$GITIGNORE" > "${GITIGNORE}.tmp"
     mv "${GITIGNORE}.tmp" "$GITIGNORE"
 
-    # Remove trailing blank lines
-    sed -i '' -e :a -e '/^\n*$/{$d;N;ba' -e '}' "$GITIGNORE"
+    # Remove trailing blank lines (awk equivalent, consistent with the
+    # consecutive-blank-line trim immediately above).
+    awk 'NF || prev_blank++ < 1 { print; if (NF) prev_blank=0 }' "$GITIGNORE" > "${GITIGNORE}.tmp" && mv "${GITIGNORE}.tmp" "$GITIGNORE"
 
     # If file is now empty, remove it
     if [[ ! -s "$GITIGNORE" ]] || ! grep -q '[^[:space:]]' "$GITIGNORE" 2>/dev/null; then

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -128,8 +128,9 @@ set_version() {
     echo "  Updated $file"
   done
 
-  # CLAUDE.md
-  sed -i '' "s/\*\*Loom Version\*\*: .*/\*\*Loom Version\*\*: $new_version/" "$REPO_ROOT/CLAUDE.md"
+  # CLAUDE.md — portable in-place edit via temp file + mv (matches the
+  # Cargo.toml idiom above; avoids BSD vs GNU `sed -i` divergence).
+  sed "s/\*\*Loom Version\*\*: .*/\*\*Loom Version\*\*: $new_version/" "$REPO_ROOT/CLAUDE.md" > "$REPO_ROOT/CLAUDE.md.tmp" && mv "$REPO_ROOT/CLAUDE.md.tmp" "$REPO_ROOT/CLAUDE.md"
   echo "  Updated CLAUDE.md"
 
   # Cargo.lock


### PR DESCRIPTION
## Summary

The `installer-tests` CI job was pinned to `macos-latest` because `uninstall-loom.sh` and `version.sh` used unconditional BSD `sed -i ''`, which fails on GNU/Linux (`''` is read as an empty in-place script and the expression is read as a filename). The macOS pin masked that uninstall/version were effectively macOS-only, while costing ~50-70 min of queue time per run (UNSTABLE mergeState that breaks `merge-pr.sh --auto`).

This PR makes the four in-place-edit call sites portable using the repo's existing house idiom (temp-file + `mv`, and the `awk` blank-line trim already present in `uninstall-loom.sh`), then switches the CI job to `ubuntu-latest`. No new helper is introduced (Option A, per curator).

## Changes

- `scripts/uninstall-loom.sh`:
  - Marker-range deletion of the Loom block in `CLAUDE.md` → `sed ... > tmp && mv`.
  - Trailing-blank-line trim of `CLAUDE.md` → reuse the `awk 'NF || prev_blank++ < 1 ...'` one-liner already used in this file.
  - Trailing-blank-line trim of `.gitignore` → same `awk` replacement (consistent with the consecutive-blank trim immediately above it).
- `scripts/version.sh`:
  - CLAUDE.md version-line rewrite → `sed ... > tmp && mv`, matching the `Cargo.toml` idiom directly above. The `s///` expression is unchanged; only the in-place mechanism changed.
- `.github/workflows/ci.yml`:
  - `installer-tests` job `runs-on: macos-latest` → `ubuntu-latest`; stale "macOS runner required" comment replaced.

No matrix leg added (explicitly out of scope).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| No remaining unconditional `sed -i ''` in `scripts/` | ✅ | `grep -rn "sed -i ''" scripts/` returns empty |
| `test-installer.sh` passes (incl. CLAUDE.md Tests 20/25/31/32, .gitignore Test 48) | ✅ | Ran locally on macOS: 109 passed, 0 failed |
| `version.sh` rewrites the CLAUDE.md version line | ✅ | Dry-ran the new `sed ... > tmp && mv` against a temp copy → version line rewritten correctly; did NOT bump the repo |
| CI installer job no longer on macOS critical path | ✅ | `installer-tests` now `runs-on: ubuntu-latest` |

## Test Plan

- `grep -rn "sed -i ''" scripts/` → empty.
- `bash scripts/test-installer.sh` → `Passed: 109, Failed: 0` (validates the portable form still works on BSD sed locally; the CI switch validates Linux).
- `shellcheck scripts/uninstall-loom.sh scripts/version.sh` → only pre-existing warnings on unrelated lines; the changed lines are clean.

Closes #3515