### PR TITLE
fix(install): replace removed loom-shepherd sentinel with loom-status

### DIFF
--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -1049,7 +1049,7 @@ fi
 echo ""
 
 # Set up Python tools (loom-tools package)
-# This creates a virtual environment in loom-tools/.venv and installs loom-shepherd, etc.
+# This creates a virtual environment in loom-tools/.venv and installs loom-status, loom-clean, etc.
 info "Setting up Python tools..."
 if [[ -x "$LOOM_ROOT/scripts/install/setup-python-tools.sh" ]]; then
   if "$LOOM_ROOT/scripts/install/setup-python-tools.sh" --loom-root "$LOOM_ROOT"; then
@@ -1057,11 +1057,11 @@ if [[ -x "$LOOM_ROOT/scripts/install/setup-python-tools.sh" ]]; then
   else
     warning "Python tools setup failed (non-fatal for installation)"
     info "Run manually: $LOOM_ROOT/scripts/install/setup-python-tools.sh --loom-root $LOOM_ROOT"
-    info "Without Python tools, /shepherd and some scripts will not work."
+    info "Without Python tools, loom-status and some scripts will not work."
   fi
 else
   warning "Python setup script not found"
-  info "Python tools (loom-shepherd, etc.) may not be available."
+  info "Python tools (loom-status, loom-clean, etc.) may not be available."
 fi
 
 # Store Loom source repository path for wrapper scripts

--- a/scripts/install/setup-python-tools.sh
+++ b/scripts/install/setup-python-tools.sh
@@ -109,11 +109,15 @@ if [[ ! -f "$LOOM_TOOLS/pyproject.toml" ]]; then
 fi
 
 VENV_PATH="$LOOM_TOOLS/.venv"
-LOOM_SHEPHERD="$VENV_PATH/bin/loom-shepherd"
+# Sentinel binary used to detect a complete installation. Must be a command
+# defined in loom-tools/pyproject.toml [project.scripts]. loom-status is stable
+# (core status command) and its --help short-circuits with sys.exit(0) before
+# any forge queries, so the runtime verify step below works offline.
+LOOM_SENTINEL="$VENV_PATH/bin/loom-status"
 
 # Check-only mode
 if [[ "$CHECK_ONLY" == "true" ]]; then
-  if [[ -x "$LOOM_SHEPHERD" ]]; then
+  if [[ -x "$LOOM_SENTINEL" ]]; then
     success "loom-tools is installed and ready"
     exit 0
   else
@@ -122,7 +126,7 @@ if [[ "$CHECK_ONLY" == "true" ]]; then
 fi
 
 # Check if already installed (unless --force)
-if [[ "$FORCE" != "true" ]] && [[ -x "$LOOM_SHEPHERD" ]]; then
+if [[ "$FORCE" != "true" ]] && [[ -x "$LOOM_SENTINEL" ]]; then
   success "loom-tools already installed"
   exit 0
 fi
@@ -168,13 +172,13 @@ info "Installing loom-tools..."
 "$VENV_PATH/bin/pip" install -e "$LOOM_TOOLS" --quiet || error "Failed to install loom-tools"
 
 # Verify installation
-if [[ ! -x "$LOOM_SHEPHERD" ]]; then
-  error "Installation verification failed: loom-shepherd not found"
+if [[ ! -x "$LOOM_SENTINEL" ]]; then
+  error "Installation verification failed: loom-status not found"
 fi
 
 # Test that it runs
-if ! "$LOOM_SHEPHERD" --help &>/dev/null; then
-  error "Installation verification failed: loom-shepherd cannot run"
+if ! "$LOOM_SENTINEL" --help &>/dev/null; then
+  error "Installation verification failed: loom-status cannot run"
 fi
 
 success "loom-tools installed successfully"


### PR DESCRIPTION
Closes #3520

## Problem

`scripts/install/setup-python-tools.sh` used the removed `loom-shepherd` binary as its installation sentinel (existence check, idempotency skip, and post-install verification). The `loom-shepherd` entry point was removed from `loom-tools/pyproject.toml`, so:

- `--check` always exited 1 (even with a working venv)
- the "already installed" fast-path never fired
- post-install verification hard-errored via `error()` (exit 1) even on a fully successful editable install

## Change

- Repoint the sentinel at **`loom-status`** (confirmed present in `[project.scripts]` at `loom-tools/pyproject.toml:35`). Its `main()` handles `--help` by printing help and `sys.exit(0)` before any forge queries, so the runtime verify step works offline — preserving the existing verify semantics exactly.
- Rename `LOOM_SHEPHERD` -> `LOOM_SENTINEL` for clarity and add an explanatory comment. Updates all five sites plus the two verify error-message strings.
- Cosmetic: update stale `loom-shepherd` / `/shepherd` references in `scripts/install-loom.sh` user-facing strings (lines 1052, 1060, 1064) to current command vocabulary. No functional change.

## Verification

Smoke-tested against the worktree (venv lives in gitignored `loom-tools/.venv`):

- `--check` with no venv -> exit 1 (correct)
- `--force` install -> ends with `loom-tools installed successfully`, exit 0
- second run without `--force` -> `loom-tools already installed` fast-path, exit 0
- `--check` post-install -> exit 0
- `loom-tools/.venv/bin/loom-status --help` -> exit 0 (offline)
- `grep -n loom-shepherd scripts/install/setup-python-tools.sh` -> no matches
- `bash -n` syntax check on both scripts -> OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)