### PR TITLE
chore(deps): bump anyhow to 1.0.103 (RUSTSEC-2026-0190)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "atomic-waker"


### PR DESCRIPTION
## Summary

Bumps `anyhow` 1.0.102 → 1.0.103 to clear **RUSTSEC-2026-0190** (unsoundness in `Error::downcast_mut()`), which is currently failing the Security Scan (`cargo audit --deny warnings`) on `main`.

- Lockfile-only change — `anyhow` is a caret (`"1.0"`) workspace dependency, so no `Cargo.toml` edit is required.
- Verified locally: `cargo audit --deny warnings` now exits 0; `cargo check --workspace` passes.

Unblocks the 0.10.5 release (main CI was red on Security Scan).