### PR TITLE
fix: shorten loom:operator-only label description to fit GitHub 100-char cap

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -93,8 +93,13 @@
   description: Signal to abort shepherd for this issue (returns to loom:issue)
   color: "F97316"  # orange-500 - warning/signal color
 
+# loom:operator-only vs loom:blocked: operator-only = a human must act OUTSIDE
+# automation (credentials, infra, hardware) and sweep/shepherd skip it entirely;
+# blocked = waiting on a dependency but otherwise automatable. Keep the
+# description at/under GitHub's 100-char label-description limit so sync-labels.sh
+# can create it (a longer description fails with HTTP 422 and the label never syncs).
 - name: loom:operator-only
-  description: "Issue requires human action outside the automation (credentials, infra rotations, manual deploys, hardware access). Sweep/shepherd skip in pre-flight; curator may still enrich. Applied by: humans or any agent that recognizes the constraint."
+  description: "Requires human action outside automation (credentials, infra, hardware); sweep/shepherd skip"
   color: "F97316"  # orange-500 - operator-action signal (matches loom:abort)
 
 # Epic Labels

--- a/.loom/docs/troubleshooting.md
+++ b/.loom/docs/troubleshooting.md
@@ -102,6 +102,38 @@ git worktree prune
 gh label sync --file .github/labels.yml
 ```
 
+Label sync is a manual/install-time step (`./scripts/install/sync-labels.sh .`),
+not something CI re-applies when `.github/labels.yml` changes. If a label is
+defined in `labels.yml` but missing from the live repo, applying it fails with
+`failed to update 1 issue` (the standard `gh` error for "label does not exist").
+Run the sync script — or create the one label directly — to reconcile:
+
+```bash
+gh label list --search operator                      # empty => not provisioned
+gh label create "loom:operator-only" --color F97316 \
+  --description "Requires human action outside automation (credentials, infra, hardware); sweep/shepherd skip"
+```
+
+**GitHub caps label descriptions at 100 characters.** A `labels.yml` entry with a
+longer description fails to sync (HTTP 422 "description is too long") and the label
+silently never gets created. Keep descriptions at or under 100 chars.
+
+#### `loom:blocked` vs `loom:operator-only`
+
+These two status labels look similar but mean different things to the automation:
+
+- **`loom:blocked`** — work is *automatable* but currently waiting on a dependency
+  (another issue, an unmerged PR, missing context). The intent is "unblock it, then
+  a Builder can proceed."
+- **`loom:operator-only`** — work requires a *human to act outside automation
+  entirely* (rotating credentials, infra changes, hardware access, manual deploys).
+  Sweep/shepherd skip these in pre-flight rather than attempting them; a human must
+  do the work off-automation before the issue can proceed.
+
+Reaching for `loom:blocked` when you mean `loom:operator-only` conflates "waiting on
+a dependency" with "needs a human action," which muddies the daemon/sweep skip
+semantics. Use `loom:operator-only` for the human-must-act-off-automation case.
+
 ### Daemon won't start
 
 ```bash


### PR DESCRIPTION
## Summary

`loom:operator-only` was defined in `.github/labels.yml` (since PR #3362) but was **never provisioned as a live label** on `rjwalters/loom` — `gh label list --search operator` returned empty, and `gh issue edit <N> --add-label loom:operator-only` failed with "failed to update 1 issue". This PR provisions the live label and fixes the root cause that prevented it from ever syncing.

**Root cause (newly pinned down):** the `labels.yml` description was 240 chars, exceeding GitHub's hard **100-char label-description limit**. `sync-labels.sh` passes the description straight to `gh label create`, which rejects it with `HTTP 422 "description is too long"`. So even running the sync script would have failed for this one label — the template shipped a description that GitHub can never accept.

## Changes

- **Live repo action (the primary deliverable):** created `loom:operator-only` on `rjwalters/loom` via `gh label create` (color `F97316`, 92-char description). Verified present via `gh label list --search operator-only`.
- **`.github/labels.yml`:** shortened the `loom:operator-only` description from 240 → 92 chars (semantics preserved) so `sync-labels.sh` can actually create it; added a comment documenting the 100-char cap and the `loom:blocked` vs `loom:operator-only` distinction. The trimmed text matches the live label exactly, so a future sync is idempotent.
- **`.loom/docs/troubleshooting.md`:** expanded the "Labels out of sync" section with the manual-sync gap, the 100-char gotcha, and a `loom:blocked` vs `loom:operator-only` explainer.

## Acceptance Criteria Verification

| Criterion (from curation comment) | Status | Verification |
|-----------------------------------|--------|--------------|
| `loom:operator-only` exists as a live label on `rjwalters/loom`, color `F97316` | ✅ | `gh api repos/rjwalters/loom/labels/loom:operator-only` → name/color/description present; appears in `gh label list` |
| No incorrect change to `.github/labels.yml` (definition already present) | ✅ | Definition retained at same location; only description trimmed to satisfy GitHub's 100-char limit so it can sync (the reason it was never provisioned) |
| Optional doc note: `loom:blocked` vs `loom:operator-only` distinction | ✅ | Added to `.loom/docs/troubleshooting.md` and as a comment in `labels.yml` |

## Test Plan

- `gh label list --search operator-only` returns `loom:operator-only` (non-empty). ✅
- Live label description == `labels.yml` description (idempotent re-sync, no drift). ✅
- `python3 -c "import yaml; ..."` parses `labels.yml` (26 labels) and asserts the operator-only description ≤ 100 chars. ✅
- `./.loom/scripts/check-main-clean.sh` → exit 0 (no main contamination). ✅

Closes #3525