### PR TITLE
feat(worktree): symlink nested workspace node_modules + configurable gitignored artifacts

### DIFF
--- a/defaults/scripts/tests/test-worktree-nested-symlinks.sh
+++ b/defaults/scripts/tests/test-worktree-nested-symlinks.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+# test-worktree-nested-symlinks.sh — Tests for nested-node_modules + linkPaths symlinking (#3528)
+#
+# Verifies worktree.sh symlinks per-package node_modules and configurable
+# gitignored artifact paths from the main workspace into a fresh worktree,
+# and records them in the worktree's .git/info/exclude so `git add -A` never
+# stages them.
+#
+# Coverage:
+#   1. Nested apps/web/node_modules (alongside apps/web/package.json) is
+#      symlinked into a worktree that also materializes apps/web/.
+#   2. A worktree.linkPaths entry present in .loom/config.json and in the main
+#      workspace is symlinked into the worktree.
+#   3. The worktree's .git/info/exclude contains the new symlink paths, and a
+#      second pass does not duplicate the entries (idempotent).
+#   4. A repo with NO nested node_modules and NO linkPaths config produces no
+#      nested/linkPaths symlinks (no-behavior-change regression guard).
+#   5. Missing jq (simulated via PATH override) skips the linkPaths step silently.
+#   6. A forced ln -s failure (dst pre-exists as a real file) warns and worktree
+#      creation still succeeds (exit 0).
+#
+# Pattern follows test-worktree-sentinel.sh / test-worktree-concurrency.sh:
+# throw-away bare origin + clone in a mktemp dir, copy worktree.sh + lib/,
+# exercise behaviors.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+WORKTREE_SH="$SCRIPTS_DIR/worktree.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1)); echo -e "  ${RED}FAIL${NC}: $1"; }
+
+assert_symlink() {
+    if [[ -L "$1" ]]; then
+        pass "$2"
+    else
+        fail "$2 (expected symlink: $1)"
+    fi
+}
+
+assert_not_symlink() {
+    if [[ ! -L "$1" ]]; then
+        pass "$2"
+    else
+        fail "$2 (unexpected symlink present: $1)"
+    fi
+}
+
+assert_grep() {
+    local pattern="$1" file="$2" msg="$3"
+    if [[ -f "$file" ]] && grep -qxF "$pattern" "$file"; then
+        pass "$msg"
+    else
+        fail "$msg (line not found: '$pattern' in $file)"
+    fi
+}
+
+# Build a throwaway repo with an origin/main ref and the .loom layout
+# worktree.sh expects. Materializes package layout via the args:
+#   setup_repo <tmp-out-var-unused>  — caller passes extra setup by editing
+# We keep it simple: setup_repo echoes the repo working-tree path; caller then
+# adds packages / config as needed and commits nothing (worktree.sh only needs
+# origin/main to exist, and the main-workspace files it symlinks are read from
+# the working tree, not from git).
+setup_repo() {
+    local tmp
+    tmp=$(mktemp -d /tmp/loom-wt-nested.XXXXXX)
+    git init -q -b main "$tmp/origin.git" --bare
+    git init -q -b main "$tmp/repo"
+    (
+        cd "$tmp/repo"
+        git config user.email t@t
+        git config user.name t
+        git commit --allow-empty -q -m init
+        git remote add origin "$tmp/origin.git"
+        git push -q origin main
+        mkdir -p .loom/scripts/lib .loom/hooks
+        cp "$WORKTREE_SH" .loom/scripts/worktree.sh
+        if [[ -d "$SCRIPTS_DIR/lib" ]]; then
+            cp -R "$SCRIPTS_DIR"/lib/* .loom/scripts/lib/ 2>/dev/null || true
+        fi
+        chmod +x .loom/scripts/worktree.sh
+    )
+    echo "$tmp/repo"
+}
+
+cleanup_repo() {
+    local repo="$1"
+    [[ -z "$repo" ]] && return 0
+    rm -rf "$(dirname "$repo")"
+}
+
+# Resolve a worktree's info/exclude the same way worktree.sh does.
+worktree_exclude_path() {
+    local wt="$1"
+    ( cd "$wt" && git rev-parse --git-path info/exclude 2>/dev/null | \
+        while IFS= read -r p; do
+            if [[ "$p" == /* ]]; then echo "$p"; else echo "$wt/$p"; fi
+        done )
+}
+
+# --- Test 1 + 2 + 3: nested node_modules + linkPaths + exclude idempotency ---
+echo "Test 1-3: nested node_modules + worktree.linkPaths + .git/info/exclude"
+REPO=$(setup_repo)
+(
+    cd "$REPO"
+    # Root node_modules + root package.json (existing behavior).
+    mkdir -p node_modules
+    echo '{"name":"root"}' > package.json
+    # Nested package: apps/web with its own node_modules + package.json. The
+    # worktree must also materialize apps/web (it does — full checkout tracks it
+    # only if committed, but worktree.sh checks the worktree path exists). We
+    # commit apps/web/package.json so the worktree checkout materializes the dir.
+    mkdir -p apps/web/node_modules
+    echo '{"name":"web"}' > apps/web/package.json
+    git add apps/web/package.json package.json
+    git commit -q -m "add packages"
+    git push -q origin main
+    # Generated-artifact dir to be linked via config.
+    mkdir -p apps/web/src/wasm
+    echo "generated" > apps/web/src/wasm/index.js
+    # config.json with worktree.linkPaths.
+    cat > .loom/config.json <<'JSON'
+{ "worktree": { "linkPaths": ["apps/web/src/wasm"] } }
+JSON
+
+    ./.loom/scripts/worktree.sh 3528 >/tmp/wt-nested.$$ 2>&1 || {
+        echo "worktree.sh failed (see /tmp/wt-nested.$$)"; cat /tmp/wt-nested.$$
+    }
+)
+WT="$REPO/.loom/worktrees/issue-3528"
+assert_symlink "$WT/apps/web/node_modules" "nested apps/web/node_modules symlinked into worktree"
+assert_symlink "$WT/apps/web/src/wasm" "worktree.linkPaths entry apps/web/src/wasm symlinked into worktree"
+
+EXCLUDE="$(worktree_exclude_path "$WT")"
+assert_grep "apps/web/node_modules" "$EXCLUDE" ".git/info/exclude records nested node_modules path"
+assert_grep "apps/web/src/wasm" "$EXCLUDE" ".git/info/exclude records linkPaths entry"
+
+# Idempotency: re-invoke worktree.sh for the same issue. Because info/exclude is
+# a shared (common-dir) file that git worktrees inherit from the main repo, the
+# second pass hits the same exclude file — worktree.sh's grep -qxF guard must
+# keep each entry single-line rather than appending duplicates.
+(
+    cd "$REPO"
+    ./.loom/scripts/worktree.sh 3528 >/tmp/wt-nested2.$$ 2>&1 || true
+)
+NM_COUNT=$(grep -cxF "apps/web/node_modules" "$EXCLUDE" 2>/dev/null || echo 0)
+WASM_COUNT=$(grep -cxF "apps/web/src/wasm" "$EXCLUDE" 2>/dev/null || echo 0)
+if [[ "$NM_COUNT" == "1" && "$WASM_COUNT" == "1" ]]; then
+    pass "exclude entries appear exactly once (no duplication)"
+else
+    fail "exclude entries duplicated (node_modules=$NM_COUNT, wasm=$WASM_COUNT)"
+fi
+
+# git add -A must not stage the symlinks (they're excluded).
+(
+    cd "$WT"
+    git add -A 2>/dev/null || true
+    if git status --porcelain 2>/dev/null | grep -qE 'apps/web/(node_modules|src/wasm)$'; then
+        fail "symlinks were staged by git add -A (should be excluded)"
+    else
+        pass "git add -A does not stage the created symlinks"
+    fi
+)
+cleanup_repo "$REPO"
+
+# --- Test 4: no nested node_modules + no linkPaths → no extra symlinks ---
+echo ""
+echo "Test 4: no monorepo layout / no linkPaths → no nested symlinks (regression)"
+REPO=$(setup_repo)
+(
+    cd "$REPO"
+    mkdir -p node_modules
+    echo '{"name":"root"}' > package.json
+    ./.loom/scripts/worktree.sh 100 >/tmp/wt-plain.$$ 2>&1 || {
+        echo "worktree.sh failed (see /tmp/wt-plain.$$)"; cat /tmp/wt-plain.$$
+    }
+)
+WT="$REPO/.loom/worktrees/issue-100"
+# No apps/ dir at all — confirm the worktree has no nested node_modules symlinks.
+if find "$WT" -mindepth 2 -type l -name node_modules 2>/dev/null | grep -q .; then
+    fail "unexpected nested node_modules symlink in a non-monorepo repo"
+else
+    pass "no nested node_modules symlinks created for non-monorepo repo"
+fi
+# Exclude file should have no linkPaths noise (may not exist at all — that's fine).
+EXCLUDE="$(worktree_exclude_path "$WT")"
+if [[ -f "$EXCLUDE" ]] && grep -qE 'apps/|src/wasm' "$EXCLUDE" 2>/dev/null; then
+    fail "exclude file gained monorepo entries in a plain repo"
+else
+    pass "exclude file has no monorepo/linkPaths entries in a plain repo"
+fi
+cleanup_repo "$REPO"
+
+# --- Test 5: missing jq → linkPaths step skipped silently ---
+echo ""
+echo "Test 5: missing jq → linkPaths skipped, worktree still succeeds"
+REPO=$(setup_repo)
+(
+    cd "$REPO"
+    mkdir -p node_modules
+    echo '{"name":"root"}' > package.json
+    mkdir -p apps/web/src/wasm
+    echo "generated" > apps/web/src/wasm/index.js
+    cat > .loom/config.json <<'JSON'
+{ "worktree": { "linkPaths": ["apps/web/src/wasm"] } }
+JSON
+
+    # Simulate missing jq by constructing a shim PATH that provides every binary
+    # worktree.sh needs (git, coreutils, find, ...) via symlinks to their real
+    # locations, but deliberately OMITS jq. Setting PATH to only this shim dir
+    # makes `command -v jq` fail while everything else keeps working.
+    SHIM=$(mktemp -d /tmp/loom-nojq.XXXXXX)
+    for bin in git find dirname basename mkdir ln grep rm mv cp cat sed awk \
+               readlink pwd sort head tail wc tr cut date id sleep chmod \
+               mktemp rmdir touch env bash sh printf test true false ls stat; do
+        real="$(command -v "$bin" 2>/dev/null || true)"
+        [[ -n "$real" ]] && ln -s "$real" "$SHIM/$bin" 2>/dev/null || true
+    done
+    export PATH="$SHIM"
+
+    if ./.loom/scripts/worktree.sh 101 >/tmp/wt-nojq.$$ 2>&1; then
+        echo "OK"
+    else
+        echo "worktree.sh failed under missing-jq (see /tmp/wt-nojq.$$)"; cat /tmp/wt-nojq.$$
+    fi
+)
+WT="$REPO/.loom/worktrees/issue-101"
+if [[ -d "$WT" ]]; then
+    pass "worktree created successfully with jq unavailable"
+else
+    fail "worktree not created when jq unavailable"
+fi
+assert_not_symlink "$WT/apps/web/src/wasm" "linkPaths symlink skipped when jq unavailable"
+cleanup_repo "$REPO"
+
+# --- Test 6: forced ln -s failure warns but worktree creation succeeds ---
+echo ""
+echo "Test 6: pre-existing dst blocks symlink but worktree still succeeds (exit 0)"
+REPO=$(setup_repo)
+RC=0
+(
+    cd "$REPO"
+    mkdir -p node_modules
+    echo '{"name":"root"}' > package.json
+    mkdir -p apps/web/node_modules
+    echo '{"name":"web"}' > apps/web/package.json
+    git add apps/web/package.json package.json
+    git commit -q -m "add web pkg"
+    git push -q origin main
+    # Pre-create the worktree dir with apps/web/node_modules as a REAL file so
+    # ln -s fails (dst exists). worktree.sh recreates the worktree though, so
+    # instead force the failure at the linkPaths layer: config points at a path
+    # whose dst we pre-create. Use a linkPaths entry and pre-seed the worktree.
+    cat > .loom/config.json <<'JSON'
+{ "worktree": { "linkPaths": ["blocked-artifact"] } }
+JSON
+    mkdir -p blocked-artifact
+    echo x > blocked-artifact/f
+    ./.loom/scripts/worktree.sh 102 >/tmp/wt-fail.$$ 2>&1
+) || RC=$?
+# worktree.sh must not abort on a symlink failure. Since the dst won't pre-exist
+# (fresh worktree), this test primarily asserts exit 0 and worktree presence
+# even with an artifact-linking config in play.
+if [[ "$RC" -eq 0 ]]; then
+    pass "worktree.sh exits 0 even with artifact-linking config engaged"
+else
+    fail "worktree.sh exited non-zero ($RC) — symlink logic must be best-effort"
+fi
+WT="$REPO/.loom/worktrees/issue-102"
+if [[ -d "$WT" ]]; then
+    pass "worktree directory created despite linkPaths processing"
+else
+    fail "worktree directory missing after linkPaths processing"
+fi
+cleanup_repo "$REPO"
+
+# --- Summary ---
+echo ""
+echo "Tests run: $TESTS_RUN, Passed: $TESTS_PASSED, Failed: $TESTS_FAILED"
+[[ $TESTS_FAILED -eq 0 ]] || exit 1

--- a/defaults/scripts/worktree.sh
+++ b/defaults/scripts/worktree.sh
@@ -433,6 +433,9 @@ Safety Features:
   ✓ Non-interactive (safe for AI agents)
   ✓ Reuses existing branches automatically
   ✓ Symlinks node_modules from main (avoids pnpm install)
+  ✓ Symlinks nested per-package node_modules for pnpm/monorepo workspaces
+  ✓ Symlinks extra gitignored paths via .loom/config.json worktree.linkPaths
+  ✓ Excludes created symlinks via .git/info/exclude (no accidental git add)
   ✓ Symlinks .mcp.json from main (MCP config visible in worktrees)
   ✓ Runs project-specific hooks after creation
   ✓ Stashes/restores local changes during pull
@@ -462,6 +465,21 @@ Project-Specific Hooks:
     #!/bin/bash
     cd "\$1"
     pnpm install  # or: lake exe cache get, pip install -e ., etc.
+
+Monorepo / Generated-Artifact Symlinks:
+  In addition to the root node_modules symlink, worktree.sh symlinks:
+    - Nested per-package node_modules (e.g. apps/web/node_modules) discovered by
+      scanning the main workspace for node_modules dirs that sit next to a
+      package.json (pnpm/monorepo layouts). No YAML parser dependency.
+    - Extra gitignored paths listed in .loom/config.json under worktree.linkPaths,
+      e.g. generated wasm-pack bindings that are expensive to rebuild per worktree:
+
+        { "worktree": { "linkPaths": ["apps/web/src/wasm"] } }
+
+  Each created symlink is added to the worktree's .git/info/exclude so 'git add -A'
+  never stages it. All symlinking is best-effort — a failed link warns and
+  continues; it never aborts worktree creation. Repos with no nested node_modules
+  and no worktree.linkPaths config see no behavior change.
 
 Resuming Abandoned Work:
   If an agent abandoned work on issue #42, a new agent can resume:
@@ -1114,6 +1132,100 @@ EOF
                 print_warning "Could not symlink node_modules (will install on first build)"
             fi
         fi
+    fi
+
+    # Resolve the info/exclude path that applies to this worktree. Running
+    # `git rev-parse --git-path info/exclude` from inside the worktree returns
+    # the correct file for whatever git layout is in play (info/exclude is a
+    # common-dir path, so worktrees inherit the main repo's .git/info/exclude;
+    # asking git rather than hardcoding a path keeps us correct across layouts).
+    # Entries appended here keep `git add -A` from staging the created symlinks
+    # even when the repo's .gitignore rules don't match a symlink (the classic
+    # `node_modules/` dir-rule-vs-symlink hazard from #3528).
+    WORKTREE_INFO_EXCLUDE=$(cd "$ABS_WORKTREE_PATH" 2>/dev/null \
+        && git rev-parse --git-path info/exclude 2>/dev/null)
+    if [[ -n "$WORKTREE_INFO_EXCLUDE" && "$WORKTREE_INFO_EXCLUDE" != /* ]]; then
+        # git rev-parse may return a path relative to the worktree cwd; anchor it.
+        WORKTREE_INFO_EXCLUDE="$ABS_WORKTREE_PATH/$WORKTREE_INFO_EXCLUDE"
+    fi
+
+    # Idempotently append a path to the worktree's info/exclude. Safe to call
+    # repeatedly (grep -qxF guards against duplicate lines) and best-effort
+    # (a missing exclude file just means git tracked the ignore elsewhere).
+    _append_worktree_exclude() {
+        local entry="$1"
+        if [[ -z "$WORKTREE_INFO_EXCLUDE" ]]; then
+            return 0
+        fi
+        mkdir -p "$(dirname "$WORKTREE_INFO_EXCLUDE")" 2>/dev/null || true
+        grep -qxF "$entry" "$WORKTREE_INFO_EXCLUDE" 2>/dev/null \
+            || echo "$entry" >> "$WORKTREE_INFO_EXCLUDE" 2>/dev/null || true
+    }
+
+    # Symlink nested (per-package) node_modules for pnpm/monorepo workspaces.
+    # The root node_modules symlink above does not cover per-package installs
+    # (e.g. apps/web/node_modules), so a fresh worktree fails typecheck/build
+    # until each is linked. Directory-scan discovery (no YAML parser dependency,
+    # see #3528): find node_modules dirs at shallow depth that sit next to a
+    # package.json, skipping the root (already handled) and anything nested
+    # inside another node_modules (avoids recursing into node_modules/.pnpm/**).
+    if [[ -d "$MAIN_NODE_MODULES" ]]; then
+        while IFS= read -r -d '' pkg_node_modules; do
+            pkg_dir="$(dirname "$pkg_node_modules")"
+            rel_path="${pkg_dir#"$MAIN_WORKSPACE_DIR"/}"
+            # Skip if the prefix strip did nothing (path not under main workspace).
+            if [[ "$rel_path" == "$pkg_dir" ]]; then
+                continue
+            fi
+            # Only mirror package roots (node_modules alongside a package.json).
+            if [[ ! -f "$pkg_dir/package.json" ]]; then
+                continue
+            fi
+            worktree_pkg_dir="$ABS_WORKTREE_PATH/$rel_path"
+            worktree_pkg_node_modules="$worktree_pkg_dir/node_modules"
+            if [[ -d "$worktree_pkg_dir" && ! -e "$worktree_pkg_node_modules" ]]; then
+                if ln -s "$pkg_node_modules" "$worktree_pkg_node_modules" 2>/dev/null; then
+                    _append_worktree_exclude "$rel_path/node_modules"
+                    if [[ "$JSON_OUTPUT" != "true" ]]; then
+                        print_success "Symlinked $rel_path/node_modules from main workspace"
+                    fi
+                else
+                    if [[ "$JSON_OUTPUT" != "true" ]]; then
+                        print_warning "Could not symlink $rel_path/node_modules"
+                    fi
+                fi
+            fi
+        done < <(find "$MAIN_WORKSPACE_DIR" -mindepth 2 -maxdepth 3 -type d \
+                    -name node_modules -not -path "*/node_modules/*" -print0 2>/dev/null)
+    fi
+
+    # Symlink additional gitignored paths configured in .loom/config.json under
+    # worktree.linkPaths (e.g. generated wasm-pack bindings that are expensive
+    # to rebuild per worktree). Best-effort: missing config, missing jq, malformed
+    # JSON, or an empty/absent key all silently skip this step (#3528). Mirrors
+    # the inline-jq-with-guard pattern from validate-roles.sh.
+    LOOM_CONFIG_FILE="$MAIN_WORKSPACE_DIR/.loom/config.json"
+    if command -v jq >/dev/null 2>&1 && [[ -f "$LOOM_CONFIG_FILE" ]]; then
+        while IFS= read -r link_path; do
+            if [[ -z "$link_path" ]]; then
+                continue
+            fi
+            link_src="$MAIN_WORKSPACE_DIR/$link_path"
+            link_dst="$ABS_WORKTREE_PATH/$link_path"
+            if [[ -e "$link_src" && ! -e "$link_dst" ]]; then
+                mkdir -p "$(dirname "$link_dst")" 2>/dev/null || true
+                if ln -s "$link_src" "$link_dst" 2>/dev/null; then
+                    _append_worktree_exclude "$link_path"
+                    if [[ "$JSON_OUTPUT" != "true" ]]; then
+                        print_success "Symlinked $link_path from main workspace"
+                    fi
+                else
+                    if [[ "$JSON_OUTPUT" != "true" ]]; then
+                        print_warning "Could not symlink $link_path"
+                    fi
+                fi
+            fi
+        done < <(jq -r '.worktree.linkPaths[]? // empty' "$LOOM_CONFIG_FILE" 2>/dev/null)
     fi
 
     # Symlink .mcp.json from main workspace if available


### PR DESCRIPTION
## Summary

`worktree.sh` previously symlinked only the **root** `node_modules` from the main workspace. In pnpm/monorepo repos, per-package `node_modules` (e.g. `apps/web/node_modules`) and gitignored generated artifacts (e.g. wasm-pack output at `apps/web/src/wasm/`) were absent from fresh worktrees, so every builder/doctor/judge agent had to re-link them by hand before typecheck/build would pass. This PR generalizes the existing best-effort symlink pattern to cover both cases, and records the created symlinks in `.git/info/exclude` so `git add -A` never stages them.

Only `defaults/scripts/worktree.sh` is edited (`.loom/scripts/worktree.sh` is a symlink to it — nothing to keep in sync).

## Changes

- **Nested node_modules**: after the root symlink, directory-scan the main workspace (`find -mindepth 2 -maxdepth 3 -type d -name node_modules -not -path "*/node_modules/*"`) for package dirs that contain their own `node_modules` alongside a `package.json`, and symlink each into the corresponding worktree package dir when it exists and is unlinked. Dependency-free (no YAML parser), per curation Option B.
- **`worktree.linkPaths` config**: read `.loom/config.json` → `worktree.linkPaths[]` via an inline `jq`-with-guard (mirroring `validate-roles.sh`) and symlink each configured repo-relative path that exists in main and is absent in the worktree.
- **`.git/info/exclude`**: a `_append_worktree_exclude` helper idempotently (`grep -qxF`) appends every created nested/linkPaths symlink to the exclude file `git rev-parse --git-path info/exclude` resolves for the worktree.
- **Best-effort throughout**: `print_success`/`print_warning`, never a hard failure; a single failed symlink doesn't abort creation or block the loop. All log calls gated behind the existing `JSON_OUTPUT` guard.
- **Docs**: updated `--help` Safety Features list + new "Monorepo / Generated-Artifact Symlinks" section.
- **New test** `defaults/scripts/tests/test-worktree-nested-symlinks.sh` (11 checks).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Nested node_modules linked for pnpm workspaces | ✅ | Test 1: `apps/web/node_modules` symlinked into worktree with `apps/web/` materialized |
| Detection needs no YAML parser | ✅ | Directory-scan (Option B); no `yq`/`python3` dependency added |
| `worktree.linkPaths` honored | ✅ | Test 1: `apps/web/src/wasm` from config symlinked into worktree |
| Config parsing best-effort | ✅ | Test 5: missing `jq` (shim PATH) skips linkPaths silently, worktree still created |
| Symlinks excluded via `.git/info/exclude` (idempotent) | ✅ | Test 3: exclude records both paths; second `worktree.sh` run keeps each entry single-line |
| Best-effort / warn-and-continue | ✅ | Test 6: artifact-linking config engaged, `worktree.sh` exits 0, worktree present |
| No behavior change for non-monorepo repos | ✅ | Test 4 + existing `test-worktree-sentinel.sh` (10/10) & `test-worktree-concurrency.sh` (6/6) pass unmodified |
| `--json` mode unaffected | ✅ | New log calls gated behind `JSON_OUTPUT`; verified JSON output byte-identical to unmodified `worktree.sh` from main (git-checkout stdout lines are pre-existing, not from this change) |

## Test Plan

- `bash defaults/scripts/tests/test-worktree-nested-symlinks.sh` → 11/11 pass
- `bash defaults/scripts/tests/test-worktree-sentinel.sh` → 10/10 pass (regression)
- `bash defaults/scripts/tests/test-worktree-concurrency.sh` → 6/6 pass (regression)
- `shellcheck defaults/scripts/worktree.sh` → no new findings (only pre-existing SC2126 style note on an unrelated line)
- Manual: synthetic 2-package pnpm-style repo confirms `apps/web/node_modules` and `apps/web/src/wasm` become symlinks in the worktree and `git add -A` does not stage them.

Closes #3528