### PR TITLE
fix(version): stage CHANGELOG.md in do_tag so it ships in the tagged release commit

### DIFF
--- a/defaults/.claude/commands/loom/release.md
+++ b/defaults/.claude/commands/loom/release.md
@@ -583,15 +583,7 @@ for p in packages:
    git tag --sort=-v:refname | head -1   # confirm the new tag exists
    ```
 
-Note: every tool in the dispatch above creates its own commit. To keep the CHANGELOG bump and the version bump together in a single tagged commit, commit the CHANGELOG first and then move the tag forward after the version bump:
-
-```bash
-git add CHANGELOG.md
-git commit -m "docs: add X.Y.Z changelog entry"
-# ...run the tool-specific bump above...
-# Move tag to include both commits
-git tag -f vX.Y.Z
-```
+Note: the generated `version.sh do_tag` stages `CHANGELOG.md` alongside the version-bearing files, so the changelog bump and the version bump land in the same tagged commit automatically — no separate commit or `git tag -f` choreography is needed. Simply promote `## [Unreleased]` → `## [X.Y.Z]` in `CHANGELOG.md` before invoking the bump.
 
 Show the user the result and ask for final confirmation.
 

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -151,6 +151,7 @@ do_tag() {
     git add package.json mcp-loom/package.json \
            loom-daemon/Cargo.toml loom-api/Cargo.toml \
            CLAUDE.md Cargo.lock
+    [ -f "CHANGELOG.md" ] && git add CHANGELOG.md
     git commit -m "chore: bump version to $version"
     git tag -a "v$version" -m "v$version"
   )


### PR DESCRIPTION
## Summary

`scripts/version.sh do_tag` staged the version-bearing files (`package.json`, `mcp-loom/package.json`, both `Cargo.toml`s, `CLAUDE.md`, `Cargo.lock`) but never `CHANGELOG.md`. Since the release flow promotes `## [Unreleased]` → `## [X.Y.Z]` in the same step, the changelog edit was left in the working tree and the tagged commit shipped without it. Loom papered over this in `release.md` with a commit-first-then-move-tag workaround; downstream repos that adopt the `version.sh` shape without that choreography ship release commits missing their changelog block (observed in anvil v0.7.1).

## Changes

- `scripts/version.sh`: add `[ -f "CHANGELOG.md" ] && git add CHANGELOG.md` inside `do_tag()`, immediately after the existing `git add`, matching the precedent in the `/loom:bump` generated-script template (`defaults/.claude/commands/loom/bump.md`). The `[ -f ... ] &&` guard no-ops cleanly in repos without a changelog.
- `defaults/.claude/commands/loom/release.md`: replace the now-obsolete "commit the CHANGELOG first and then move the tag forward" workaround note (and its `git tag -f` snippet) with a one-line note that `do_tag` now includes the changelog in the single tagged commit. Only the `defaults/` copy is edited — `.claude/commands/loom/release.md` resolves through a symlink to it (confirmed byte-identical).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `do_tag()` stages `CHANGELOG.md` when present, guarded as `[ -f "CHANGELOG.md" ] && git add CHANGELOG.md` | ✅ | Line added in `do_tag()` diff |
| New `git add` line added without reordering the existing staged-file list | ✅ | Diff is a single `+` line; existing `git add` block unchanged |
| `check_versions`, `bump_version`, `set_version`, `list`/`show`/`check` unchanged | ✅ | Diff touches only `do_tag`; `./scripts/version.sh` → `0.10.5` and `check` → all in sync |
| Workaround note in `release.md` (lines 586-594) simplified/removed | ✅ | Replaced with a single note; `git tag -f` snippet removed |
| No new GitHub label introduced | ✅ | n/a |

## Test Plan

- `shellcheck scripts/version.sh` — no new warnings; only the pre-existing SC2005 (now line 167, shifted +1 by the added line) remains, left untouched per scope guard.
- `./scripts/version.sh` → `0.10.5`; `./scripts/version.sh check` → all files in sync (unchanged code paths).
- Manual review confirms the added `git add` is inside the `do_tag` subshell (`cd "$REPO_ROOT"`), so the path resolves against the repo root; the `[ -f ]` guard no-ops when no changelog exists (matching the bump.md template).
- No automated test harness exists for `version.sh` (confirmed by curator); none added per scope guard.

Closes #3529