### PR TITLE
feat(worktree): opt-in configurable worktree root (LOOM_WORKTREE_ROOT)

### DIFF
--- a/defaults/scripts/agent-destroy.sh
+++ b/defaults/scripts/agent-destroy.sh
@@ -21,6 +21,10 @@ SESSION_PREFIX="loom-"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=kill-session-tree.sh
 source "$SCRIPT_DIR/kill-session-tree.sh"
+# Shared worktree-root resolver (#3530). Terminal-destroy cleanup must
+# recognize worktrees at an overridden root, not just under .loom/worktrees.
+# shellcheck source=lib/worktree-root.sh
+source "$SCRIPT_DIR/lib/worktree-root.sh"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -128,8 +132,18 @@ main() {
         else
             local repo_root
             if repo_root=$(find_repo_root); then
+                # Resolve the configured worktree root (#3530) so an overridden
+                # base (e.g. an external volume) is recognized as a Loom
+                # worktree here; without an override this is
+                # "$repo_root/.loom/worktrees". We accept a match against either
+                # the resolved root OR the historical .loom/worktrees substring
+                # so mixed setups (an override configured after worktrees were
+                # created under the default) still GC correctly.
+                local wt_root_dir
+                wt_root_dir="$(loom_worktree_root "$repo_root")"
                 # Only clean if it's actually a worktree (not the main repo)
-                if [[ "$worktree_path" != "$repo_root" ]] && [[ "$worktree_path" == *".loom/worktrees/"* ]]; then
+                if [[ "$worktree_path" != "$repo_root" ]] && \
+                   { [[ "$worktree_path" == "$wt_root_dir/"* ]] || [[ "$worktree_path" == *".loom/worktrees/"* ]]; }; then
                     if [[ ! -f "$worktree_path/.loom-managed" ]]; then
                         log_warn "Worktree at $worktree_path lacks .loom-managed sentinel — refusing to remove (user-owned)"
                     else

--- a/defaults/scripts/lib/worktree-root.sh
+++ b/defaults/scripts/lib/worktree-root.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# worktree-root.sh — Resolve the base directory that holds Loom worktrees.
+#
+# Source this file (do not exec). Defines a single function:
+#
+#   loom_worktree_root <repo_root> -> echoes the absolute worktree base dir
+#
+# Resolution precedence (first match wins), all opt-in:
+#
+#   1. LOOM_WORKTREE_ROOT env var          — highest priority
+#   2. .loom/config.json → worktree.root   — jq-guarded, same namespace as
+#                                            worktree.linkPaths (#3534)
+#   3. ${repo_root}/.loom/worktrees        — default, UNCHANGED behavior
+#
+# When an override (env var or config key) is set, the returned path is
+# namespaced by repo basename so multiple workspaces can share one external
+# volume without colliding:
+#
+#     ${override%/}/<repo-basename>
+#
+# Callers then append `issue-<N>` / `pr-<N>` as before. With neither override
+# set, the function returns `${repo_root}/.loom/worktrees` verbatim — the
+# result is byte-for-byte identical to the historical hardcoded path, so
+# default installations (including the sandboxed macOS app, see ADR-0004) see
+# zero behavior change.
+#
+# Design notes:
+#   - The env-var branch imitates other Loom env overrides (e.g.
+#     LOOM_WORKTREE_ALWAYS_INCLUDE) and always wins over config.
+#   - The config read reuses the exact guard pattern worktree.sh uses for
+#     worktree.linkPaths: only attempt jq when it exists AND the config file
+#     is present, and fall through softly (missing jq / missing key / malformed
+#     JSON → default) so a broken config never breaks worktree creation.
+#   - A RELATIVE override is rejected with a stderr warning and the function
+#     falls back to the default. An external worktree root must be absolute so
+#     that cleanup/GC comparison sites (which resolve absolute paths) match.
+#   - Repo namespacing uses `basename "$repo_root"`. Two repos whose basenames
+#     collide under the same override root would share a namespace; that is a
+#     documented v1 limitation (see the issue), not a bug this helper guards.
+#   - This helper never creates directories; callers `mkdir -p` the parent as
+#     needed (git worktree add creates only the leaf).
+
+# loom_worktree_root <repo_root>
+#
+# Echoes the absolute worktree base directory. `repo_root` must be an absolute
+# path to the main workspace (the parent of the git common dir).
+loom_worktree_root() {
+    local repo_root="$1"
+
+    # 1. Env var override — highest priority.
+    if [[ -n "${LOOM_WORKTREE_ROOT:-}" ]]; then
+        if [[ "$LOOM_WORKTREE_ROOT" == /* ]]; then
+            echo "${LOOM_WORKTREE_ROOT%/}/$(basename "$repo_root")"
+            return 0
+        fi
+        echo "loom_worktree_root: LOOM_WORKTREE_ROOT must be an absolute path (got: '$LOOM_WORKTREE_ROOT'); falling back to default" >&2
+        echo "$repo_root/.loom/worktrees"
+        return 0
+    fi
+
+    # 2. Config key override — .loom/config.json → worktree.root.
+    #    Same jq guard pattern as worktree.linkPaths (worktree.sh).
+    local config_file="$repo_root/.loom/config.json"
+    if command -v jq >/dev/null 2>&1 && [[ -f "$config_file" ]]; then
+        local cfg_root
+        cfg_root=$(jq -r '.worktree.root? // empty' "$config_file" 2>/dev/null)
+        if [[ -n "$cfg_root" ]]; then
+            if [[ "$cfg_root" == /* ]]; then
+                echo "${cfg_root%/}/$(basename "$repo_root")"
+                return 0
+            fi
+            echo "loom_worktree_root: worktree.root in .loom/config.json must be an absolute path (got: '$cfg_root'); falling back to default" >&2
+            echo "$repo_root/.loom/worktrees"
+            return 0
+        fi
+    fi
+
+    # 3. Default — unchanged historical behavior.
+    echo "$repo_root/.loom/worktrees"
+}

--- a/defaults/scripts/merge-pr.sh
+++ b/defaults/scripts/merge-pr.sh
@@ -169,6 +169,10 @@ REPO_ROOT="$(find_main_repo_root)" || \
 # Source forge helpers for multi-forge support
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib/forge-helpers.sh"
+# Shared worktree-root resolver (#3530) — cleanup must discover worktrees at an
+# overridden root, not just the default .loom/worktrees.
+# shellcheck source=lib/worktree-root.sh
+source "$SCRIPT_DIR/lib/worktree-root.sh"
 forge_detect
 
 # Use gh-cached for read-only queries to reduce API calls (see issue #1609)
@@ -692,14 +696,17 @@ if [[ "$CLEANUP_WORKTREE" == "true" ]]; then
   else
     # Strict pattern: only `feature/issue-<N>` matches. Trailing-number
     # heuristics would misclassify branches like `release-1`.
+    # Resolve the worktree base through the shared helper so an overridden
+    # root (#3530) is discovered here; defaults to $REPO_ROOT/.loom/worktrees.
+    WT_ROOT_DIR="$(loom_worktree_root "$REPO_ROOT")"
     DEFAULT_WT_PATH=""
     if [[ "$PR_BRANCH" =~ ^feature/issue-([0-9]+)$ ]]; then
       ISSUE_NUM="${BASH_REMATCH[1]}"
-      DEFAULT_WT_PATH="$REPO_ROOT/.loom/worktrees/issue-$ISSUE_NUM"
+      DEFAULT_WT_PATH="$WT_ROOT_DIR/issue-$ISSUE_NUM"
     else
       # External-fork / ad-hoc branch — the doctor would have used a
       # `pr-<PR_NUMBER>` worktree if any.
-      DEFAULT_WT_PATH="$REPO_ROOT/.loom/worktrees/pr-$PR_NUMBER"
+      DEFAULT_WT_PATH="$WT_ROOT_DIR/pr-$PR_NUMBER"
     fi
     if [[ -d "$DEFAULT_WT_PATH" ]]; then
       _remove_loom_worktree "$DEFAULT_WT_PATH"

--- a/defaults/scripts/pr-worktree.sh
+++ b/defaults/scripts/pr-worktree.sh
@@ -78,7 +78,14 @@ GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null) || {
 }
 REPO_ROOT=$(cd "$(dirname "$GIT_COMMON_DIR")" && pwd)
 
-WORKTREE_PATH="$REPO_ROOT/.loom/worktrees/pr-$PR_NUMBER"
+# Shared worktree-root resolver (#3530). Redirects the worktree base to an
+# external volume when LOOM_WORKTREE_ROOT / worktree.root is configured;
+# otherwise returns "$REPO_ROOT/.loom/worktrees" unchanged.
+# shellcheck source=lib/worktree-root.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/worktree-root.sh"
+WORKTREE_ROOT_DIR="$(loom_worktree_root "$REPO_ROOT")"
+
+WORKTREE_PATH="$WORKTREE_ROOT_DIR/pr-$PR_NUMBER"
 
 # If the worktree already exists, treat it as reusable. The doctor may
 # re-enter for the same PR across multiple iterations.
@@ -106,7 +113,7 @@ print_info "  Path: $WORKTREE_PATH"
 # Create the worktree on a detached HEAD of origin/main, then run
 # `gh pr checkout` from inside it. This avoids ever touching the
 # orchestrator's main worktree HEAD.
-mkdir -p "$REPO_ROOT/.loom/worktrees"
+mkdir -p "$WORKTREE_ROOT_DIR"
 
 # Fetch origin/main so we have something to base the worktree on.
 git -C "$REPO_ROOT" fetch origin main >/dev/null 2>&1 || \

--- a/defaults/scripts/tests/test-worktree-root-override.sh
+++ b/defaults/scripts/tests/test-worktree-root-override.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# test-worktree-root-override.sh — Tests for configurable worktree root (#3530)
+#
+# Verifies the opt-in LOOM_WORKTREE_ROOT / .loom/config.json worktree.root
+# override implemented via defaults/scripts/lib/worktree-root.sh and wired into
+# worktree.sh, pr-worktree.sh, merge-pr.sh, and agent-destroy.sh.
+#
+# Coverage:
+#   1. Default (no override): worktree lands under $repo/.loom/worktrees,
+#      byte-for-byte identical to historical behavior.
+#   2. Env-var override: worktree is created at
+#      ${LOOM_WORKTREE_ROOT}/<repo-basename>/issue-<N>, registered with git,
+#      and carries the .loom-managed sentinel. The default .loom/worktrees dir
+#      is never created.
+#   3. Config-key override (.loom/config.json → worktree.root) with the env var
+#      unset produces the same namespaced path.
+#   4. Env var beats config when both are set.
+#   5. agent-destroy.sh GC-detection recognizes an overridden-root worktree
+#      (the substring-only check would have skipped it) — the regression this
+#      issue must not reintroduce.
+#   6. _worktree_locks_dir() resolves via git-common-dir regardless of the
+#      worktree root override (locks stay in the main repo).
+#   7. loom_worktree_root() unit behavior: relative override is rejected with a
+#      warning and falls back to the default.
+#
+# Pattern follows test-worktree-sentinel.sh / test-worktree-nested-symlinks.sh:
+# throwaway bare origin + repo in a mktemp dir, copy worktree.sh + lib/, run.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+WORKTREE_SH="$SCRIPTS_DIR/worktree.sh"
+AGENT_DESTROY_SH="$SCRIPTS_DIR/agent-destroy.sh"
+WORKTREE_ROOT_LIB="$SCRIPTS_DIR/lib/worktree-root.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1)); echo -e "  ${RED}FAIL${NC}: $1"; }
+
+assert_dir() {
+    if [[ -d "$1" ]]; then pass "$2"; else fail "$2 (expected dir: $1)"; fi
+}
+assert_no_dir() {
+    if [[ ! -d "$1" ]]; then pass "$2"; else fail "$2 (unexpected dir present: $1)"; fi
+}
+assert_file() {
+    if [[ -f "$1" ]]; then pass "$2"; else fail "$2 (expected file: $1)"; fi
+}
+assert_eq() {
+    if [[ "$1" == "$2" ]]; then pass "$3"; else fail "$3 (expected '$2', got '$1')"; fi
+}
+
+# Build a throwaway repo named `<basename>` with an origin/main ref and the
+# minimal .loom layout worktree.sh needs. Echoes the working-tree path.
+# The repo basename is meaningful — the override namespacing keys off it — so
+# the caller passes a stable name.
+setup_repo() {
+    local name="${1:-myrepo}"
+    local tmp
+    tmp=$(mktemp -d /tmp/loom-wtroot.XXXXXX)
+    git init -q -b main "$tmp/origin.git" --bare
+    git init -q -b main "$tmp/$name"
+    (
+        cd "$tmp/$name"
+        git config user.email t@t
+        git config user.name t
+        git commit --allow-empty -q -m init
+        git remote add origin "$tmp/origin.git"
+        git push -q origin main
+        mkdir -p .loom/scripts/lib .loom/hooks
+        cp "$WORKTREE_SH" .loom/scripts/worktree.sh
+        if [[ -d "$SCRIPTS_DIR/lib" ]]; then
+            cp -R "$SCRIPTS_DIR"/lib/* .loom/scripts/lib/ 2>/dev/null || true
+        fi
+        chmod +x .loom/scripts/worktree.sh
+    )
+    echo "$tmp/$name"
+}
+
+cleanup_repo() {
+    local repo="$1"
+    [[ -z "$repo" ]] && return 0
+    rm -rf "$(dirname "$repo")"
+}
+
+# --- Test 1: default (no override) — worktree under .loom/worktrees ---
+echo "Test 1: default behavior unchanged (no override)"
+REPO=$(setup_repo defrepo)
+(
+    cd "$REPO"
+    unset LOOM_WORKTREE_ROOT
+    ./.loom/scripts/worktree.sh 100 >/tmp/wtroot-default.$$ 2>&1 || {
+        echo "worktree.sh failed (see /tmp/wtroot-default.$$)"; cat /tmp/wtroot-default.$$
+    }
+)
+assert_dir "$REPO/.loom/worktrees/issue-100" "default worktree created under .loom/worktrees"
+assert_file "$REPO/.loom/worktrees/issue-100/.loom-managed" "default worktree carries .loom-managed sentinel"
+cleanup_repo "$REPO"
+
+# --- Test 2: env-var override ---
+echo ""
+echo "Test 2: LOOM_WORKTREE_ROOT env override → namespaced external path"
+REPO=$(setup_repo envrepo)
+EXT=$(mktemp -d /tmp/loom-ext.XXXXXX)
+(
+    cd "$REPO"
+    LOOM_WORKTREE_ROOT="$EXT" ./.loom/scripts/worktree.sh 200 >/tmp/wtroot-env.$$ 2>&1 || {
+        echo "worktree.sh failed (see /tmp/wtroot-env.$$)"; cat /tmp/wtroot-env.$$
+    }
+)
+assert_dir "$EXT/envrepo/issue-200" "env-override worktree created at \${root}/<repo>/issue-N"
+assert_file "$EXT/envrepo/issue-200/.loom-managed" "env-override worktree carries .loom-managed sentinel"
+assert_no_dir "$REPO/.loom/worktrees/issue-200" "default .loom/worktrees not used when override set"
+# git must have registered the worktree at the external path.
+if git -C "$REPO" worktree list --porcelain 2>/dev/null | grep -qF "$EXT/envrepo/issue-200"; then
+    pass "env-override worktree registered with git worktree list"
+else
+    fail "env-override worktree not registered with git"
+fi
+rm -rf "$EXT"
+cleanup_repo "$REPO"
+
+# --- Test 3: config-key override ---
+echo ""
+echo "Test 3: .loom/config.json worktree.root override (env var unset)"
+REPO=$(setup_repo cfgrepo)
+CFGEXT=$(mktemp -d /tmp/loom-cfgext.XXXXXX)
+(
+    cd "$REPO"
+    unset LOOM_WORKTREE_ROOT
+    printf '{ "worktree": { "root": "%s" } }\n' "$CFGEXT" > .loom/config.json
+    ./.loom/scripts/worktree.sh 300 >/tmp/wtroot-cfg.$$ 2>&1 || {
+        echo "worktree.sh failed (see /tmp/wtroot-cfg.$$)"; cat /tmp/wtroot-cfg.$$
+    }
+)
+assert_dir "$CFGEXT/cfgrepo/issue-300" "config-override worktree created at configured root"
+assert_no_dir "$REPO/.loom/worktrees/issue-300" "default .loom/worktrees not used with config override"
+rm -rf "$CFGEXT"
+cleanup_repo "$REPO"
+
+# --- Test 4: env beats config ---
+echo ""
+echo "Test 4: env var takes precedence over config key"
+REPO=$(setup_repo bothrepo)
+CFGEXT=$(mktemp -d /tmp/loom-both-cfg.XXXXXX)
+ENVEXT=$(mktemp -d /tmp/loom-both-env.XXXXXX)
+(
+    cd "$REPO"
+    printf '{ "worktree": { "root": "%s" } }\n' "$CFGEXT" > .loom/config.json
+    LOOM_WORKTREE_ROOT="$ENVEXT" ./.loom/scripts/worktree.sh 400 >/tmp/wtroot-both.$$ 2>&1 || {
+        echo "worktree.sh failed (see /tmp/wtroot-both.$$)"; cat /tmp/wtroot-both.$$
+    }
+)
+assert_dir "$ENVEXT/bothrepo/issue-400" "env-var root wins when both set"
+assert_no_dir "$CFGEXT/bothrepo/issue-400" "config root ignored when env var also set"
+rm -rf "$CFGEXT" "$ENVEXT"
+cleanup_repo "$REPO"
+
+# --- Test 5: agent-destroy.sh GC recognizes overridden root ---
+echo ""
+echo "Test 5: agent-destroy.sh GC-detection accepts an overridden-root worktree"
+# We exercise the decision predicate directly by sourcing the same helper the
+# script uses and replicating the load-bearing condition from agent-destroy.sh:
+#   worktree_path != repo_root AND
+#   ( worktree_path starts with resolved-root/ OR contains .loom/worktrees/ )
+# The regression this guards: an overridden root outside .loom/worktrees must
+# still be recognized as a Loom-managed worktree (not skipped as user-owned).
+# shellcheck source=../lib/worktree-root.sh
+source "$WORKTREE_ROOT_LIB"
+
+gc_recognizes() {
+    # $1 repo_root, $2 worktree_path
+    local repo_root="$1" worktree_path="$2" wt_root_dir
+    wt_root_dir="$(loom_worktree_root "$repo_root")"
+    if [[ "$worktree_path" != "$repo_root" ]] && \
+       { [[ "$worktree_path" == "$wt_root_dir/"* ]] || [[ "$worktree_path" == *".loom/worktrees/"* ]]; }; then
+        echo "recognized"
+    else
+        echo "skipped"
+    fi
+}
+
+# Default root: recognized via both the resolved-root and the substring branch.
+unset LOOM_WORKTREE_ROOT
+r=$(gc_recognizes "/Users/foo/repo" "/Users/foo/repo/.loom/worktrees/issue-9")
+assert_eq "$r" "recognized" "default-root worktree recognized by GC predicate"
+
+# Overridden root outside .loom/worktrees: recognized only because the resolved
+# root now matches (the old substring-only check would have skipped it).
+r=$(LOOM_WORKTREE_ROOT="/Volumes/Stripe" gc_recognizes "/Users/foo/repo" "/Volumes/Stripe/repo/issue-9")
+assert_eq "$r" "recognized" "overridden-root worktree recognized by GC predicate (regression #3530)"
+
+# Sanity: an unrelated path outside both is still skipped (user-owned).
+r=$(LOOM_WORKTREE_ROOT="/Volumes/Stripe" gc_recognizes "/Users/foo/repo" "/Users/foo/somewhere-else")
+assert_eq "$r" "skipped" "unrelated path is not recognized (stays user-owned)"
+
+# The wiring is present in the real script (guards against silent unwiring).
+# shellcheck disable=SC2016  # literal '$repo_root' is intentional in the grep pattern
+if grep -q 'loom_worktree_root "\$repo_root"' "$AGENT_DESTROY_SH"; then
+    pass "agent-destroy.sh sources and calls loom_worktree_root for GC detection"
+else
+    fail "agent-destroy.sh no longer routes GC detection through loom_worktree_root"
+fi
+
+# --- Test 6: locks stay in main repo regardless of override ---
+echo ""
+echo "Test 6: _worktree_locks_dir() independent of worktree root override"
+REPO=$(setup_repo lockrepo)
+EXT=$(mktemp -d /tmp/loom-lock-ext.XXXXXX)
+(
+    cd "$REPO"
+    LOOM_WORKTREE_ROOT="$EXT" ./.loom/scripts/worktree.sh 500 >/tmp/wtroot-lock.$$ 2>&1 || {
+        echo "worktree.sh failed (see /tmp/wtroot-lock.$$)"; cat /tmp/wtroot-lock.$$
+    }
+)
+# The lock dir (.loom/locks) lives in the MAIN repo, never at the override root.
+# worktree.sh removes the lock on exit, but the parent .loom/locks dir persists.
+if [[ -d "$REPO/.loom/locks" ]]; then
+    pass "lock namespace (.loom/locks) resides in the main repo, not the override root"
+else
+    # Lock dir may be pruned; assert the override root has NO locks dir instead.
+    if [[ ! -d "$EXT/lockrepo/.loom/locks" ]] && [[ ! -d "$EXT/.loom/locks" ]]; then
+        pass "no lock namespace created under the override root"
+    else
+        fail "lock namespace leaked into the override root"
+    fi
+fi
+rm -rf "$EXT"
+cleanup_repo "$REPO"
+
+# --- Test 7: relative override rejected with warning → default fallback ---
+echo ""
+echo "Test 7: relative override is rejected and falls back to default"
+unset LOOM_WORKTREE_ROOT
+r=$(LOOM_WORKTREE_ROOT="rel/dir" loom_worktree_root "/Users/foo/repo" 2>/dev/null)
+assert_eq "$r" "/Users/foo/repo/.loom/worktrees" "relative env override falls back to default path"
+if LOOM_WORKTREE_ROOT="rel/dir" loom_worktree_root "/Users/foo/repo" 2>&1 >/dev/null | grep -q "must be an absolute path"; then
+    pass "relative env override emits an absolute-path warning to stderr"
+else
+    fail "relative env override did not warn"
+fi
+# Config relative override likewise falls back.
+CFGREPO=$(mktemp -d /tmp/loom-relcfg.XXXXXX)
+mkdir -p "$CFGREPO/.loom"
+printf '{ "worktree": { "root": "also/relative" } }\n' > "$CFGREPO/.loom/config.json"
+r=$(loom_worktree_root "$CFGREPO" 2>/dev/null)
+assert_eq "$r" "$CFGREPO/.loom/worktrees" "relative config override falls back to default path"
+rm -rf "$CFGREPO"
+
+# --- Summary ---
+echo ""
+echo "Tests run: $TESTS_RUN, Passed: $TESTS_PASSED, Failed: $TESTS_FAILED"
+[[ $TESTS_FAILED -eq 0 ]] || exit 1

--- a/defaults/scripts/worktree.sh
+++ b/defaults/scripts/worktree.sh
@@ -27,6 +27,13 @@ set -e
 # separated paths).
 LOOM_WORKTREE_ALWAYS_INCLUDE_DEFAULT=(.claude .loom .githooks scripts)
 
+# Shared worktree-root resolver (env var / config key / default). Sourced so
+# the worktree base can be redirected to an external volume (#3530). With no
+# override configured, loom_worktree_root returns the historical
+# ${repo_root}/.loom/worktrees path unchanged.
+# shellcheck source=lib/worktree-root.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/worktree-root.sh"
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -219,7 +226,13 @@ cleanup_partial_worktree_state() {
     done
 
     # 2. Orphan worktree dir (exists but git doesn't know about it).
-    local wt_path=".loom/worktrees/issue-$issue"
+    #    Resolve the base through loom_worktree_root so an overridden root
+    #    (#3530) has its orphan debris cleaned too. The repo root is the parent
+    #    of the git common dir (works whether or not cwd is the main workspace).
+    local repo_root
+    repo_root=$(cd "$(dirname "$git_common")" 2>/dev/null && pwd) || repo_root="$(pwd)"
+    local wt_path
+    wt_path="$(loom_worktree_root "$repo_root")/issue-$issue"
     if [[ -d "$wt_path" ]]; then
         # `git worktree list --porcelain` emits absolute paths on the
         # `worktree ` line; compare against the resolved absolute path.
@@ -726,8 +739,17 @@ else
     BRANCH_NAME="feature/issue-$ISSUE_NUMBER"
 fi
 
-# Worktree path
-WORKTREE_PATH=".loom/worktrees/issue-$ISSUE_NUMBER"
+# Worktree path. At this point cwd is the main workspace root (the script
+# auto-navigates out of any worktree above), so REPO_ROOT is the current dir.
+# loom_worktree_root returns an absolute base; when no override is configured
+# it is "$REPO_ROOT/.loom/worktrees" — identical to the historical relative
+# ".loom/worktrees" resolved against this same cwd.
+WORKTREE_REPO_ROOT="$(pwd)"
+WORKTREE_ROOT_DIR="$(loom_worktree_root "$WORKTREE_REPO_ROOT")"
+# Ensure the base dir exists. `git worktree add` creates only the leaf, so an
+# external override root (e.g. /Volumes/Stripe/<repo>) needs its parents made.
+mkdir -p "$WORKTREE_ROOT_DIR" 2>/dev/null || true
+WORKTREE_PATH="$WORKTREE_ROOT_DIR/issue-$ISSUE_NUMBER"
 
 # Check if worktree already exists
 if [[ -d "$WORKTREE_PATH" ]]; then

--- a/docs/adr/0004-worktree-paths-inside-workspace.md
+++ b/docs/adr/0004-worktree-paths-inside-workspace.md
@@ -45,9 +45,9 @@ This path is:
 
 ### Negative
 
-- **Disk space in workspace**: Worktrees consume space inside the repository
+- **Disk space in workspace**: Worktrees consume space inside the repository. _(Amended 2026-07 by #3530: CLI/daemon users can now opt in to an external worktree root — e.g. a dedicated volume — via `LOOM_WORKTREE_ROOT` / `worktree.root`. See the Amendment below. The default remains in-workspace.)_
 - **Longer paths**: Nested inside `.loom/worktrees/` adds path length
-- **Not user-configurable**: Users can't choose worktree location
+- **Not user-configurable**: Users can't choose worktree location. _(Amended 2026-07 by #3530: the worktree root is now opt-in configurable for CLI/daemon users; the sandboxed-app default is unchanged. See the Amendment below.)_
 - **Potential confusion**: Users might not expect files in `.loom/` directory
 
 ## Alternatives Considered
@@ -78,11 +78,21 @@ This path is:
 
 ### 4. User-Configurable Path
 
-**Rejected because**:
+**Originally rejected because**:
 - Complexity in UI and configuration
 - Sandbox restrictions still apply
 - Most users won't care about location
 - Harder to guarantee cleanup
+
+_**Partially revisited 2026-07 by #3530.**_ The original rejection stands for the
+default and for the sandboxed macOS app. But CLI/daemon operators running many
+parallel agents against large repos hit real disk-pressure limits (disk-full
+incidents that corrupt in-flight work), and a dedicated external volume is a
+legitimate answer. The concerns above are addressed narrowly: the override is
+**opt-in** (no UI surface — an env var / config key), sandbox restrictions are
+sidestepped because sandboxed users simply don't set it, and cleanup is
+preserved because every worktree-GC site resolves through the same helper (so
+overridden worktrees are still garbage-collected). See the Amendment below.
 
 ## Implementation Details
 
@@ -119,3 +129,43 @@ git worktree add ../loom-issue-84 -b feature/issue-84 main
 - Related: ADR-0008 (tmux + Daemon Architecture)
 - `.gitignore` line 34: `.loom/worktrees/` exclusion
 - macOS Sandbox: https://developer.apple.com/library/archive/documentation/Security/Conceptual/AppSandboxDesignGuide/
+
+## Amendment (2026-07, #3530): opt-in configurable worktree root
+
+The core decision above — **worktrees default to `${workspacePath}/.loom/worktrees/`** — is unchanged. The sandboxed macOS app and every zero-config install behave exactly as before. This amendment records an **opt-in override** for CLI/daemon operators who need worktrees on a different volume.
+
+### Motivation
+
+Operators running many concurrent agents against a large repo can exhaust the workspace's disk. Worktrees under `.loom/worktrees/` are the dominant consumer, and disk-full incidents block git operations mid-task and corrupt in-flight work. A dedicated high-bandwidth external volume (e.g. an NVMe RAID) is a legitimate host for agent worktrees, but the historical hardcoded path offered no way to point at it. Symlinking `.loom/worktrees` was tried and is fragile — cleanup/GC sites compare resolved absolute paths that no longer match, and tooling that recreates the directory silently reverts the redirect.
+
+### What changed
+
+A single shared resolver, `loom_worktree_root()` in [`defaults/scripts/lib/worktree-root.sh`](../../defaults/scripts/lib/worktree-root.sh), resolves the worktree base with this precedence (first match wins):
+
+1. **`LOOM_WORKTREE_ROOT`** environment variable
+2. **`.loom/config.json` → `worktree.root`** (same key namespace as `worktree.linkPaths` from #3534; read via the same jq-guarded pattern)
+3. **`${repo_root}/.loom/worktrees`** — the unchanged default
+
+When an override is set, the base is namespaced by repo basename to avoid collisions when multiple workspaces share one volume:
+
+```
+${LOOM_WORKTREE_ROOT%/}/<repo-basename>/issue-<N>   (and pr-<N>)
+```
+
+The resolver is wired into the bash worktree lifecycle — construction sites (`worktree.sh`, `pr-worktree.sh`), cleanup discovery (`merge-pr.sh`), and the terminal-destroy GC-detection site (`agent-destroy.sh`, which now checks the resolved root instead of a hardcoded `.loom/worktrees/` substring so overridden worktrees are still garbage-collected).
+
+### What did NOT change
+
+- **Default behavior** is byte-for-byte identical when neither override is set.
+- **`.loom-managed` sentinel** semantics — written inside the worktree dir wherever it lives; ownership is unaffected.
+- **Locks** — `_worktree_locks_dir()` still resolves via the git common dir, so lock state stays in the main repo regardless of the worktree root.
+- **Sandboxed-app default** — the macOS app does not set the override; the sandbox rationale in the original decision is intact.
+
+### Constraints and known limitations
+
+- The override must be an **absolute path**; a relative value is rejected with a warning and falls back to the default.
+- Two repos with the **same basename** cloned under the same override root would share a namespace — a documented v1 limitation, not guarded.
+
+### Scope of the #3530 implementation
+
+The initial change covers the **bash-script + `.loom/config.json` surface only**. The Rust daemon comparison site (`loom-daemon/src/terminal.rs`, the `contains(".loom/worktrees")` GC check) and the Python `loom-tools` GC/CLI surface (`clean.py`, `common/paths.py`, `daemon_cleanup.py`, `orphan_recovery.py`, `worktree.py`) resolve the worktree path independently and are tracked as separate follow-up issues. Until those land, an overridden root is fully honored by the manual/CLI/`/loom:sweep` bash workflow but not yet by daemon-driven Rust cleanup or `loom-clean --aggressive`.


### PR DESCRIPTION
## Summary

Adds an **opt-in** override of the Loom worktree root so CLI/daemon operators can place agent worktrees on a separate volume (e.g. a dedicated NVMe RAID) instead of the workspace disk. With no override configured, behavior is **byte-for-byte identical** to today. Scope is the **bash-script + `.loom/config.json` surface only** per curation (#3530); the Rust daemon and Python `loom-tools` GC surfaces are documented follow-ups (#3536, #3537).

## Changes

- **New shared resolver** `defaults/scripts/lib/worktree-root.sh` — `loom_worktree_root <repo_root>` resolves the worktree base with precedence:
  1. `LOOM_WORKTREE_ROOT` env var
  2. `.loom/config.json` → `worktree.root` (same namespace as `worktree.linkPaths` #3534, same jq-guarded read pattern)
  3. `${repo_root}/.loom/worktrees` (unchanged default)

  When overridden, the base is namespaced by repo basename: `${root}/<repo-basename>/issue-<N>` (and `pr-<N>`). Relative overrides are rejected with a warning and fall back to the default.
- **`worktree.sh`** — main `WORKTREE_PATH` construction and the `cleanup_partial_worktree_state` orphan-dir path route through the helper; `mkdir -p` the (possibly external) base before `git worktree add`.
- **`pr-worktree.sh`** — `pr-<N>` path + base `mkdir` route through the helper.
- **`merge-pr.sh`** — default-discovery `DEFAULT_WT_PATH` construction routes through the helper.
- **`agent-destroy.sh`** — GC-detection now checks the resolved root (falling back to the historical `.loom/worktrees/` substring), so terminal-destroy cleanup removes overridden-root worktrees instead of skipping them as user-owned. **This is the regression the issue explicitly must not reintroduce.**
- **ADR-0004** — appended an Amendment section; annotated the stale "Not user-configurable" / "Disk space in workspace" negative bullets and the "User-Configurable Path — Rejected" alternative. Sandboxed-app default rationale preserved.
- **New test** `defaults/scripts/tests/test-worktree-root-override.sh` (18 assertions).

Unchanged (verified): `.loom-managed` sentinel semantics; `_worktree_locks_dir()` (still resolves via git-common-dir, so locks stay in the main repo).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `LOOM_WORKTREE_ROOT` redirects worktree creation to `${root}/<repo>/issue-N` across `worktree.sh`, `pr-worktree.sh` | ✅ | Test 2; manual end-to-end (worktree created + registered with git + sentinel) |
| `.loom/config.json` `worktree.root` key, same jq guard; env beats config | ✅ | Tests 3 + 4 |
| Default `.loom/worktrees/issue-N` unchanged when no override | ✅ | Test 1 + three regression tests pass |
| `merge-pr.sh` cleanup resolves via the helper (default-discovery + sentinel) | ✅ | `DEFAULT_WT_PATH` routed through `loom_worktree_root`; sentinel guard unchanged |
| `agent-destroy.sh` GC-detection checks resolved root | ✅ | Test 5 (predicate + wiring grep); recognizes `/Volumes/…/repo/issue-N` |
| Automated test exercises override end-to-end (create + cleanup, root outside repo) | ✅ | `test-worktree-root-override.sh` (18 assertions) |
| `_worktree_locks_dir()` unchanged | ✅ | Test 6 + code untouched |
| ADR-0004 amended (not replaced) | ✅ | Amendment section + annotated stale bullets/alternative |
| Follow-up issues filed (Rust, Python) | ✅ | #3536, #3537 filed and cross-linked on #3530 |

## Test Plan

- `test-worktree-root-override.sh`: **18/18 pass** (default, env override, config override, env-beats-config, GC-detection, lock independence, relative-override rejection).
- Regression (no default-behavior change): `test-worktree-sentinel.sh` 10/10, `test-worktree-concurrency.sh` 6/6, `test-worktree-nested-symlinks.sh` 11/11.
- Manual: `LOOM_WORKTREE_ROOT=/tmp/… worktree.sh <N>` → worktree at `${root}/<repo>/issue-N`, registered in `git worktree list`, `.loom-managed` present, default `.loom/worktrees` never created; config-key path and env-beats-config confirmed.
- `shellcheck -x` clean on all touched files (2 pre-existing warnings in untouched regions of `worktree.sh`/`merge-pr.sh` remain).
- Composes with #3534 (nested node_modules / linkPaths) — `linkPaths` sources come from the main workspace regardless of worktree root; nested-symlinks test passes against the override wiring.

## Documented follow-up surfaces (out of scope here)

- **#3536** — Rust daemon: `loom-daemon/src/terminal.rs` `contains(".loom/worktrees")` GC-comparison site.
- **#3537** — Python `loom-tools`: `clean.py`, `common/paths.py`, `daemon_cleanup.py`, `orphan_recovery.py`, `worktree.py`.

Until those land, an overridden root is honored by the manual/CLI/`/loom:sweep` bash workflow but not yet by daemon-driven Rust cleanup or `loom-clean --aggressive`.

Closes #3530