### PR TITLE
feat(daemon): honor LOOM_WORKTREE_ROOT in loom-daemon terminal-destroy GC

### DIFF
--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -24,6 +24,7 @@ pub mod role_validation;
 pub mod sweep_registry;
 pub mod terminal;
 pub mod types;
+pub mod worktree_root;
 
 use std::collections::HashSet;
 use std::fs;

--- a/loom-daemon/src/terminal.rs
+++ b/loom-daemon/src/terminal.rs
@@ -986,6 +986,21 @@ impl TerminalManager {
             .or_else(|| std::env::var("LOOM_WORKSPACE").ok().map(PathBuf::from))
     }
 
+    /// Derive the repository root by walking up from a worktree path.
+    ///
+    /// Distinct from `find_repo_root` above (which starts from a tmux session's
+    /// `working_dir` / `LOOM_WORKSPACE`): this walks a *worktree* path
+    /// (e.g. `/repo/.loom/worktrees/issue-42` or `/Volumes/Ext/repo/issue-42`)
+    /// looking for the ancestor that contains both `.loom/` and `.git`, i.e. the
+    /// main workspace. Used by `destroy_terminal()` both to gate override-aware
+    /// worktree GC and to run `git worktree remove` from the repo root.
+    fn find_repo_root_from_worktree(worktree_path: &Path) -> Option<PathBuf> {
+        worktree_path
+            .ancestors()
+            .find(|p| p.join(".loom").is_dir() && p.join(".git").exists())
+            .map(Path::to_path_buf)
+    }
+
     /// Set up per-agent `CLAUDE_CONFIG_DIR` isolation for a tmux session.
     ///
     /// Creates an isolated config directory and sets `CLAUDE_CONFIG_DIR` and `TMPDIR`
@@ -1326,10 +1341,24 @@ impl TerminalManager {
         // Capture worktree info before killing the session.
         // We need to kill the tmux session FIRST to avoid leaving the shell's
         // CWD pointing at a deleted worktree path (see issue #2413).
-        let worktree_to_remove: Option<(String, PathBuf)> =
+        //
+        // The GC gate is override-aware (#3536): a worktree qualifies if it lives
+        // under the resolved worktree root (which honors LOOM_WORKTREE_ROOT /
+        // `.loom/config.json` → worktree.root) OR contains the historical
+        // `.loom/worktrees` substring. We derive `repo_root` from the worktree
+        // path *before* the gate so it's available both here and for the later
+        // `git worktree remove` invocation without duplicating the ancestor walk.
+        let worktree_to_remove: Option<(String, PathBuf, Option<PathBuf>)> =
             if let Some(ref worktree_path) = info.worktree_path {
                 let path = PathBuf::from(worktree_path);
-                if path.to_string_lossy().contains(".loom/worktrees") {
+                let repo_root = Self::find_repo_root_from_worktree(&path);
+                let is_worktree = match repo_root {
+                    Some(ref root) => crate::worktree_root::is_worktree_path(&path, root),
+                    // No repo root resolved (worktree already partly gone): fall
+                    // back to the historical substring check alone.
+                    None => path.to_string_lossy().contains(".loom/worktrees"),
+                };
+                if is_worktree {
                     let other_users = self
                         .terminals
                         .values()
@@ -1337,7 +1366,7 @@ impl TerminalManager {
                         .count();
 
                     if other_users == 0 {
-                        Some((worktree_path.clone(), path))
+                        Some((worktree_path.clone(), path, repo_root))
                     } else {
                         log::info!(
                             "Skipping worktree removal at {} ({} other terminal(s) still using it)",
@@ -1372,15 +1401,12 @@ impl TerminalManager {
 
         // Now that the tmux session is dead, safe to remove the worktree
         // without breaking any shell's working directory.
-        if let Some((worktree_path, path)) = worktree_to_remove {
+        if let Some((worktree_path, path, repo_root)) = worktree_to_remove {
             log::info!("Removing worktree at {} (no other terminals using it)", path.display());
 
-            // Derive repo root from worktree path (e.g., /repo/.loom/worktrees/issue-42 → /repo)
-            // Run git from repo root to avoid CWD-inside-worktree issues
-            let repo_root = path
-                .ancestors()
-                .find(|p| p.join(".loom").is_dir() && p.join(".git").exists())
-                .map(std::path::Path::to_path_buf);
+            // repo_root was resolved before the gate (via find_repo_root_from_worktree)
+            // and is reused here to run git from the repo root, avoiding
+            // CWD-inside-worktree issues.
 
             // First try to remove the worktree via git
             let mut cmd = Command::new("git");

--- a/loom-daemon/src/worktree_root.rs
+++ b/loom-daemon/src/worktree_root.rs
@@ -1,0 +1,343 @@
+//! Resolve the base directory that holds Loom worktrees.
+//!
+//! This is the Rust port of `defaults/scripts/lib/worktree-root.sh`
+//! (`loom_worktree_root`). It mirrors that helper's resolution precedence,
+//! repo-basename namespacing, and relative-override fallback **exactly** so the
+//! daemon's terminal-destroy GC recognizes worktrees on an overridden base
+//! (e.g. an external volume) the same way the bash tooling does (#3536, follow-up
+//! to #3530).
+//!
+//! Resolution precedence (first match wins), all opt-in:
+//!
+//! 1. `LOOM_WORKTREE_ROOT` env var          — highest priority
+//! 2. `.loom/config.json` → `worktree.root` — soft-fail serde_json read
+//! 3. `${repo_root}/.loom/worktrees`         — default, UNCHANGED behavior
+//!
+//! When an override (env var or config key) is set, the returned path is
+//! namespaced by repo basename so multiple workspaces can share one external
+//! volume without colliding (`${override}/<repo-basename>`).
+//!
+//! With neither override set, the function returns `${repo_root}/.loom/worktrees`
+//! verbatim — byte-for-byte identical to the historical hardcoded path, so
+//! default installations see zero behavior change.
+//!
+//! A RELATIVE override (env var or config key) is rejected with a warning log
+//! and the function falls back to the default (matching bash's
+//! stderr-warning-and-fallback behavior, not a hard error). An external worktree
+//! root must be absolute so that cleanup/GC comparison sites (which compare
+//! absolute paths) match.
+
+use std::path::{Path, PathBuf};
+
+/// Resolve the absolute worktree base directory for `repo_root`.
+///
+/// `repo_root` must be an absolute path to the main workspace (the parent of the
+/// git common dir). Callers append `issue-<N>` / `pr-<N>` as before.
+///
+/// Mirrors `loom_worktree_root` in `defaults/scripts/lib/worktree-root.sh`:
+/// env var > `.loom/config.json` `worktree.root` > `${repo_root}/.loom/worktrees`,
+/// with repo-basename namespacing on override and relative-override fallback.
+pub fn worktree_root(repo_root: &Path) -> PathBuf {
+    let default = || repo_root.join(".loom").join("worktrees");
+
+    // 1. Env var override — highest priority.
+    if let Ok(env_root) = std::env::var("LOOM_WORKTREE_ROOT") {
+        if !env_root.is_empty() {
+            if Path::new(&env_root).is_absolute() {
+                return namespaced(&env_root, repo_root);
+            }
+            log::warn!(
+                "LOOM_WORKTREE_ROOT must be an absolute path (got: '{env_root}'); falling back to default"
+            );
+            return default();
+        }
+    }
+
+    // 2. Config key override — .loom/config.json → worktree.root.
+    //    Soft-fail serde_json read, mirroring extract_configured_terminal_ids.
+    if let Some(cfg_root) = read_config_worktree_root(repo_root) {
+        if Path::new(&cfg_root).is_absolute() {
+            return namespaced(&cfg_root, repo_root);
+        }
+        log::warn!(
+            "worktree.root in .loom/config.json must be an absolute path (got: '{cfg_root}'); falling back to default"
+        );
+        return default();
+    }
+
+    // 3. Default — unchanged historical behavior.
+    default()
+}
+
+/// Namespace an absolute override root by the repo basename.
+///
+/// Mirrors bash `${override%/}/<repo-basename>`: strip a trailing slash from the
+/// override, then join the repo's basename. If `repo_root` has no final
+/// component (e.g. `/`), fall back to joining nothing extra.
+fn namespaced(override_root: &str, repo_root: &Path) -> PathBuf {
+    // Strip trailing slash(es) to match bash `${override%/}` (single trailing
+    // slash), but PathBuf::join already normalizes, so trim_end_matches keeps
+    // parity for the common cases.
+    let trimmed = override_root.trim_end_matches('/');
+    let base = PathBuf::from(trimmed);
+    match repo_root.file_name() {
+        Some(name) => base.join(name),
+        None => base,
+    }
+}
+
+/// Read `.loom/config.json` → `worktree.root`, soft-failing to `None`.
+///
+/// Follows the pattern in `crate::extract_configured_terminal_ids`: missing
+/// file, parse error, or missing key all resolve to `None` (never a hard error).
+fn read_config_worktree_root(repo_root: &Path) -> Option<String> {
+    let config_path = repo_root.join(".loom").join("config.json");
+
+    let config_str = match std::fs::read_to_string(&config_path) {
+        Ok(s) => s,
+        Err(e) => {
+            log::debug!("Could not read config at {}: {e}", config_path.display());
+            return None;
+        }
+    };
+
+    let config: serde_json::Value = match serde_json::from_str(&config_str) {
+        Ok(v) => v,
+        Err(e) => {
+            log::warn!("Could not parse config at {}: {e}", config_path.display());
+            return None;
+        }
+    };
+
+    let root = config.get("worktree")?.get("root")?.as_str()?;
+    if root.is_empty() {
+        return None;
+    }
+    Some(root.to_string())
+}
+
+/// Whether `path` is a Loom-managed worktree eligible for GC.
+///
+/// Two-way match mirroring `defaults/scripts/agent-destroy.sh`: a path counts if
+/// it lives under the resolved worktree root for `repo_root` (override-aware) OR
+/// contains the historical `.loom/worktrees` substring. The substring branch
+/// preserves default-path detection unchanged and covers mixed setups where an
+/// override was configured after worktrees were already created under the
+/// default base.
+pub fn is_worktree_path(path: &Path, repo_root: &Path) -> bool {
+    path.starts_with(worktree_root(repo_root)) || path.to_string_lossy().contains(".loom/worktrees")
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // std::env::set_var mutates process-global state; serialize env-touching
+    // tests so parallel execution doesn't race on LOOM_WORKTREE_ROOT.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Run `f` with LOOM_WORKTREE_ROOT set to `value` (or unset if None),
+    /// restoring the prior value afterward. Serialized via ENV_LOCK.
+    fn with_env<T>(value: Option<&str>, f: impl FnOnce() -> T) -> T {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let prev = std::env::var("LOOM_WORKTREE_ROOT").ok();
+        match value {
+            Some(v) => std::env::set_var("LOOM_WORKTREE_ROOT", v),
+            None => std::env::remove_var("LOOM_WORKTREE_ROOT"),
+        }
+        let result = f();
+        match prev {
+            Some(p) => std::env::set_var("LOOM_WORKTREE_ROOT", p),
+            None => std::env::remove_var("LOOM_WORKTREE_ROOT"),
+        }
+        result
+    }
+
+    fn write_config(dir: &Path, body: &str) {
+        let loom_dir = dir.join(".loom");
+        fs::create_dir_all(&loom_dir).unwrap();
+        fs::write(loom_dir.join("config.json"), body).unwrap();
+    }
+
+    use std::fs;
+
+    #[test]
+    fn default_when_no_override() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = tmp.path().join("my-repo");
+        fs::create_dir_all(&repo_root).unwrap();
+
+        with_env(None, || {
+            let got = worktree_root(&repo_root);
+            assert_eq!(got, repo_root.join(".loom").join("worktrees"));
+        });
+    }
+
+    #[test]
+    fn env_override_namespaces_by_basename() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = tmp.path().join("my-repo");
+        fs::create_dir_all(&repo_root).unwrap();
+
+        with_env(Some("/Volumes/Stripe"), || {
+            let got = worktree_root(&repo_root);
+            assert_eq!(got, PathBuf::from("/Volumes/Stripe/my-repo"));
+        });
+    }
+
+    #[test]
+    fn env_override_strips_trailing_slash() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = tmp.path().join("my-repo");
+        fs::create_dir_all(&repo_root).unwrap();
+
+        with_env(Some("/Volumes/Stripe/"), || {
+            let got = worktree_root(&repo_root);
+            assert_eq!(got, PathBuf::from("/Volumes/Stripe/my-repo"));
+        });
+    }
+
+    #[test]
+    fn config_override_namespaces_by_basename() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = tmp.path().join("my-repo");
+        fs::create_dir_all(&repo_root).unwrap();
+        write_config(&repo_root, r#"{"worktree": {"root": "/Volumes/Ext"}}"#);
+
+        with_env(None, || {
+            let got = worktree_root(&repo_root);
+            assert_eq!(got, PathBuf::from("/Volumes/Ext/my-repo"));
+        });
+    }
+
+    #[test]
+    fn env_beats_config() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = tmp.path().join("my-repo");
+        fs::create_dir_all(&repo_root).unwrap();
+        write_config(&repo_root, r#"{"worktree": {"root": "/Volumes/Config"}}"#);
+
+        with_env(Some("/Volumes/Env"), || {
+            let got = worktree_root(&repo_root);
+            assert_eq!(got, PathBuf::from("/Volumes/Env/my-repo"));
+        });
+    }
+
+    #[test]
+    fn relative_env_override_falls_back_to_default() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = tmp.path().join("my-repo");
+        fs::create_dir_all(&repo_root).unwrap();
+
+        with_env(Some("relative/path"), || {
+            let got = worktree_root(&repo_root);
+            assert_eq!(got, repo_root.join(".loom").join("worktrees"));
+        });
+    }
+
+    #[test]
+    fn relative_config_override_falls_back_to_default() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = tmp.path().join("my-repo");
+        fs::create_dir_all(&repo_root).unwrap();
+        write_config(&repo_root, r#"{"worktree": {"root": "relative/path"}}"#);
+
+        with_env(None, || {
+            let got = worktree_root(&repo_root);
+            assert_eq!(got, repo_root.join(".loom").join("worktrees"));
+        });
+    }
+
+    #[test]
+    fn empty_env_override_falls_back_to_config_then_default() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = tmp.path().join("my-repo");
+        fs::create_dir_all(&repo_root).unwrap();
+
+        // Empty env var is treated as unset → falls through to default here.
+        with_env(Some(""), || {
+            let got = worktree_root(&repo_root);
+            assert_eq!(got, repo_root.join(".loom").join("worktrees"));
+        });
+    }
+
+    #[test]
+    fn missing_config_key_uses_default() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = tmp.path().join("my-repo");
+        fs::create_dir_all(&repo_root).unwrap();
+        // Config exists but has no worktree.root key.
+        write_config(&repo_root, r#"{"terminals": []}"#);
+
+        with_env(None, || {
+            let got = worktree_root(&repo_root);
+            assert_eq!(got, repo_root.join(".loom").join("worktrees"));
+        });
+    }
+
+    #[test]
+    fn malformed_config_uses_default() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = tmp.path().join("my-repo");
+        fs::create_dir_all(&repo_root).unwrap();
+        write_config(&repo_root, "{not valid json");
+
+        with_env(None, || {
+            let got = worktree_root(&repo_root);
+            assert_eq!(got, repo_root.join(".loom").join("worktrees"));
+        });
+    }
+
+    #[test]
+    fn gate_matches_default_path_worktree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = tmp.path().join("my-repo");
+        fs::create_dir_all(&repo_root).unwrap();
+
+        with_env(None, || {
+            let wt = repo_root.join(".loom").join("worktrees").join("issue-42");
+            assert!(is_worktree_path(&wt, &repo_root));
+        });
+    }
+
+    #[test]
+    fn gate_matches_override_path_worktree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = tmp.path().join("my-repo");
+        fs::create_dir_all(&repo_root).unwrap();
+
+        with_env(Some("/Volumes/Stripe"), || {
+            let wt = PathBuf::from("/Volumes/Stripe/my-repo/issue-42");
+            assert!(is_worktree_path(&wt, &repo_root));
+        });
+    }
+
+    #[test]
+    fn gate_matches_default_substring_even_with_override_set() {
+        // Mixed setup: an override is configured, but a worktree still lives
+        // under the historical .loom/worktrees base. The substring fallback
+        // must still match it.
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = tmp.path().join("my-repo");
+        fs::create_dir_all(&repo_root).unwrap();
+
+        with_env(Some("/Volumes/Stripe"), || {
+            let wt = repo_root.join(".loom").join("worktrees").join("issue-99");
+            assert!(is_worktree_path(&wt, &repo_root));
+        });
+    }
+
+    #[test]
+    fn gate_rejects_unrelated_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = tmp.path().join("my-repo");
+        fs::create_dir_all(&repo_root).unwrap();
+
+        with_env(Some("/Volumes/Stripe"), || {
+            let unrelated = PathBuf::from("/some/other/place/issue-42");
+            assert!(!is_worktree_path(&unrelated, &repo_root));
+        });
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #3530 (configurable worktree root), which shipped the bash + `.loom/config.json` surface only. This PR ports the resolver to the **Rust daemon** so `loom-daemon`'s `destroy_terminal()` GC recognizes worktrees on an overridden base.

Previously the cleanup gate at `terminal.rs:1332` was a hardcoded substring check (`path.to_string_lossy().contains(".loom/worktrees")`). When `LOOM_WORKTREE_ROOT` (or `.loom/config.json` → `worktree.root`) redirects worktrees to an external volume (e.g. `/Volumes/Stripe/<repo>/issue-42`), the daemon silently skipped `git worktree remove`, leaking worktrees on the override volume.

## Changes

- **New module `loom-daemon/src/worktree_root.rs`** (registered in `lib.rs`):
  - `worktree_root(repo_root: &Path) -> PathBuf` mirrors `defaults/scripts/lib/worktree-root.sh`'s `loom_worktree_root` exactly: precedence env `LOOM_WORKTREE_ROOT` > `.loom/config.json` `worktree.root` > default `${repo_root}/.loom/worktrees`; on override, namespaced by repo basename (`${override}/<basename>`, trailing slash stripped); relative overrides fall back to default with a `log::warn!` (not a hard error). Config read is a soft-fail `serde_json::Value` parse following the `extract_configured_terminal_ids` pattern.
  - `is_worktree_path(path, repo_root) -> bool` implements the two-way GC match: `path.starts_with(worktree_root(repo_root))` OR the legacy `.loom/worktrees` substring (mixed-setup fallback, mirroring `agent-destroy.sh`).
- **`terminal.rs` `destroy_terminal()`**: `repo_root` is now derived *before* the gate via a new shared `find_repo_root_from_worktree()` helper (distinct from the existing `find_repo_root` that walks a tmux `working_dir`/`LOOM_WORKSPACE`), and reused for the later `git worktree remove` — no duplicated ancestor walk. The gate now calls `is_worktree_path()`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `worktree_root()` implements 3-tier precedence (env > config > default) | ✅ | `worktree_root.rs`; tests `env_beats_config`, `config_override_namespaces_by_basename`, `default_when_no_override` |
| Repo-basename namespacing `${override}/<basename>` (not `${override}/.loom/worktrees`) | ✅ | tests `env_override_namespaces_by_basename`, `env_override_strips_trailing_slash` |
| Relative overrides rejected → default + warning (not hard error) | ✅ | `log::warn!` + fallback; tests `relative_env_override_falls_back_to_default`, `relative_config_override_falls_back_to_default` |
| Gate uses `starts_with(resolved root)` OR `.contains(".loom/worktrees")` | ✅ | `is_worktree_path()`; tests `gate_matches_override_path_worktree`, `gate_matches_default_path_worktree` |
| `repo_root` resolved before gate via shared helper, no duplication | ✅ | `find_repo_root_from_worktree()` used at gate and reused for `git worktree remove` |
| Default behavior byte-for-byte unchanged | ✅ | default branch returns `${repo_root}/.loom/worktrees`; test `default_when_no_override`; full suite green |
| Unit tests cover precedence, namespacing, relative fallback (env+config), gate match default/override, gate reject unrelated | ✅ | 14 tests in `worktree_root.rs` incl. `gate_rejects_unrelated_path`, `gate_matches_default_substring_even_with_override_set` |

## Test Plan

- `cargo test --package loom-daemon` — all green (368 lib + integration + 14 new `worktree_root` unit tests + doctests). Env-var tests serialize `std::env::set_var` via a `Mutex` to avoid cross-test races.
- `cargo clippy --all-targets --all-features -- -D warnings` — no findings in `worktree_root.rs` / `terminal.rs` (pre-existing violations in unrelated files — `forge_parser.rs`, `event_bus.rs`, `init/*`, `ipc.rs` — were present before this branch and are out of scope).
- `cargo fmt` — clean.

Closes #3536