### PR TITLE
feat: honor LOOM_WORKTREE_ROOT in loom-tools Python GC/CLI surface

### DIFF
--- a/loom-tools/src/loom_tools/clean.py
+++ b/loom-tools/src/loom_tools/clean.py
@@ -1464,11 +1464,18 @@ def evaluate_aggressive_candidate(
             return DECISION_KEEP, "active_shepherd"
 
     # 4) Sentinel / canonical-path check.
-    worktrees_dir = (resolved_repo / ".loom" / "worktrees").resolve()
+    #    Two-way gate (mirrors worktree_root.rs::is_worktree_path and
+    #    agent-destroy.sh): a worktree counts as "under loom" if it resolves
+    #    under the override-aware worktree root OR contains the historical
+    #    `.loom/worktrees` substring. The substring branch preserves default +
+    #    mixed-setup detection when an override was configured after worktrees
+    #    were already created under the default base.
+    worktrees_dir = LoomPaths(resolved_repo).worktrees_dir.resolve()
     try:
         is_under_loom = (
             resolved_wt == worktrees_dir
             or worktrees_dir in resolved_wt.parents
+            or ".loom/worktrees" in str(resolved_wt)
         )
     except Exception:
         is_under_loom = False

--- a/loom-tools/src/loom_tools/common/paths.py
+++ b/loom-tools/src/loom_tools/common/paths.py
@@ -8,8 +8,150 @@ This module provides a single source of truth for:
 
 from __future__ import annotations
 
+import os
 import re
+import warnings
 from pathlib import Path
+
+
+def _namespaced(override: str, repo_root: Path) -> Path:
+    """Namespace an absolute override root by the repo basename.
+
+    Mirrors bash ``${override%/}/<repo-basename>``: strip trailing slash(es)
+    from the override, then join the repo's basename. If ``repo_root`` has no
+    final component (e.g. ``/``), fall back to the trimmed override alone.
+
+    Args:
+        override: An absolute override path (validated by the caller).
+        repo_root: The repository root whose basename provides the namespace.
+
+    Returns:
+        ``<override-without-trailing-slash>/<repo-basename>``.
+    """
+    trimmed = override.rstrip("/")
+    base = Path(trimmed)
+    name = repo_root.name
+    if name:
+        return base / name
+    return base
+
+
+def _resolve_worktree_root(repo_root: Path) -> Path:
+    """Resolve the worktree base directory, honoring overrides.
+
+    Resolution precedence (first match wins), mirroring
+    ``defaults/scripts/lib/worktree-root.sh`` (``loom_worktree_root``) and
+    ``loom-daemon/src/worktree_root.rs`` (``worktree_root``):
+
+    1. ``LOOM_WORKTREE_ROOT`` env var          — highest priority
+    2. ``.loom/config.json`` -> ``worktree.root`` — soft-fail JSON read
+    3. ``${repo_root}/.loom/worktrees``         — default, UNCHANGED behavior
+
+    When an override (env var or config key) is set, the returned path is
+    namespaced by repo basename so multiple workspaces can share one external
+    volume without colliding (``${override}/<repo-basename>``).
+
+    A relative override (env var or config key) is rejected with a warning and
+    the function falls back to the default — matching the bash stderr warning
+    and Rust ``log::warn!`` behavior, not a hard error. An external worktree
+    root must be absolute so cleanup/GC comparison sites (which compare
+    absolute paths) match.
+
+    With neither override set, the return value is byte-for-byte identical to
+    the historical hardcoded ``${repo_root}/.loom/worktrees`` path.
+
+    This helper never creates directories; callers ``mkdir -p`` as needed.
+
+    Args:
+        repo_root: The absolute repository root path.
+
+    Returns:
+        The absolute worktree base directory.
+    """
+    default = repo_root / LoomPaths.LOOM_DIR / LoomPaths.WORKTREES_DIR
+
+    # 1. Env var override — highest priority.
+    env_root = os.environ.get("LOOM_WORKTREE_ROOT")
+    if env_root:
+        if Path(env_root).is_absolute():
+            return _namespaced(env_root, repo_root)
+        warnings.warn(
+            "LOOM_WORKTREE_ROOT must be an absolute path "
+            f"(got: '{env_root}'); falling back to default",
+            stacklevel=2,
+        )
+        return default
+
+    # 2. Config key override — .loom/config.json -> worktree.root.
+    cfg_root = _read_config_worktree_root(repo_root)
+    if cfg_root:
+        if Path(cfg_root).is_absolute():
+            return _namespaced(cfg_root, repo_root)
+        warnings.warn(
+            "worktree.root in .loom/config.json must be an absolute path "
+            f"(got: '{cfg_root}'); falling back to default",
+            stacklevel=2,
+        )
+        return default
+
+    # 3. Default — unchanged historical behavior.
+    return default
+
+
+def _read_config_worktree_root(repo_root: Path) -> str | None:
+    """Read ``.loom/config.json`` -> ``worktree.root``, soft-failing to ``None``.
+
+    Missing file, parse error, missing key, or a non-string/empty value all
+    resolve to ``None`` (never a hard error), mirroring the soft-fail read in
+    the bash/Rust ports.
+
+    Args:
+        repo_root: The absolute repository root path.
+
+    Returns:
+        The configured worktree root string, or ``None`` when unset/invalid.
+    """
+    # Imported lazily to avoid a module-level import cycle
+    # (common.state imports from common.paths).
+    from loom_tools.common.state import read_json_file
+
+    config_path = repo_root / LoomPaths.LOOM_DIR / LoomPaths.CONFIG_FILE
+    data = read_json_file(config_path, default={})
+    if not isinstance(data, dict):
+        return None
+    worktree = data.get("worktree")
+    if not isinstance(worktree, dict):
+        return None
+    root = worktree.get("root")
+    if isinstance(root, str) and root:
+        return root
+    return None
+
+
+def is_worktree_path(path: Path, repo_root: Path) -> bool:
+    """Whether ``path`` is a Loom-managed worktree eligible for GC.
+
+    Two-way match mirroring ``loom-daemon/src/worktree_root.rs::is_worktree_path``
+    and ``defaults/scripts/agent-destroy.sh``: a path counts if it lives under
+    the resolved worktree root for ``repo_root`` (override-aware) OR contains the
+    historical ``.loom/worktrees`` substring. The substring branch preserves
+    default-path detection unchanged and covers mixed setups where an override
+    was configured after worktrees were already created under the default base.
+
+    Args:
+        path: The candidate worktree path (should be resolved by the caller).
+        repo_root: The absolute repository root path.
+
+    Returns:
+        True if ``path`` is under the resolved root or matches the legacy
+        substring, False otherwise.
+    """
+    root = LoomPaths(repo_root).worktrees_dir
+    try:
+        under_root = path == root or root in path.parents
+    except Exception:
+        under_root = False
+    return under_root or ".loom/worktrees" in str(path)
 
 
 class LoomPaths:
@@ -65,8 +207,16 @@ class LoomPaths:
 
     @property
     def worktrees_dir(self) -> Path:
-        """Path to .loom/worktrees directory."""
-        return self.loom_dir / self.WORKTREES_DIR
+        """Path to the worktree base directory.
+
+        Honors an overridden worktree root (``LOOM_WORKTREE_ROOT`` env var, then
+        ``.loom/config.json`` -> ``worktree.root``), namespaced by repo basename,
+        falling back to ``.loom/worktrees`` when no override is set. See
+        :func:`_resolve_worktree_root` for the full precedence chain. Resolved at
+        call time (matching the bash/Rust ports), so env/config changes between
+        ``LoomPaths()`` construction and property access are always picked up.
+        """
+        return _resolve_worktree_root(self.repo_root)
 
     @property
     def logs_dir(self) -> Path:

--- a/loom-tools/src/loom_tools/daemon_cleanup.py
+++ b/loom-tools/src/loom_tools/daemon_cleanup.py
@@ -576,8 +576,10 @@ def handle_shepherd_complete(
         log_info(f"Archiving logs for issue #{issue_number}...")
         _run_archive_logs(repo_root, dry_run=dry_run)
 
-    # Clean up worktree
-    worktree_path = repo_root / ".loom" / "worktrees" / f"issue-{issue_number}"
+    # Clean up worktree (override-aware via LoomPaths).
+    from loom_tools.common.paths import LoomPaths
+
+    worktree_path = LoomPaths(repo_root).worktree_path(issue_number)
     if worktree_path.is_dir():
         log_info(f"Cleaning worktree for issue #{issue_number}...")
         _run_loom_clean(repo_root, dry_run=dry_run, grace_period=config.grace_period)

--- a/loom-tools/src/loom_tools/orphan_recovery.py
+++ b/loom-tools/src/loom_tools/orphan_recovery.py
@@ -416,7 +416,9 @@ def _cleanup_stale_worktree(repo_root: pathlib.Path, issue: int) -> bool:
 
     Returns True if cleanup was performed, False otherwise.
     """
-    worktree_path = repo_root / ".loom" / "worktrees" / f"issue-{issue}"
+    from loom_tools.common.paths import LoomPaths
+
+    worktree_path = LoomPaths(repo_root).worktree_path(issue)
     if not worktree_path.is_dir():
         return False
 

--- a/loom-tools/src/loom_tools/worktree.py
+++ b/loom-tools/src/loom_tools/worktree.py
@@ -489,8 +489,17 @@ def create_worktree(
     else:
         branch_name = f"feature/issue-{issue_number}"
 
-    # Worktree path
-    worktree_path = pathlib.Path(".loom/worktrees") / f"issue-{issue_number}"
+    # Worktree path (override-aware via LoomPaths).
+    #
+    # Resolve the repo root explicitly rather than relying on cwd: in the
+    # in-worktree branch above we os.chdir'd to the main workspace, but in the
+    # non-worktree branch cwd is only implicitly the repo root. _get_main_workspace
+    # works from any cwd (parent of the git common dir); fall back to cwd if it
+    # cannot be determined. LoomPaths then honors LOOM_WORKTREE_ROOT / config.
+    from loom_tools.common.paths import LoomPaths
+
+    repo_root = _get_main_workspace() or pathlib.Path.cwd().resolve()
+    worktree_path = LoomPaths(repo_root).worktree_path(issue_number)
 
     # Check if worktree already exists
     if worktree_path.exists():

--- a/loom-tools/tests/test_clean.py
+++ b/loom-tools/tests/test_clean.py
@@ -319,3 +319,132 @@ class TestGhPinnedToRepoRoot:
         assert captured_cwd == [repo_root], (
             f"expected gh_run cwd={repo_root!r}, got {captured_cwd!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Two-way is_under_loom gate in evaluate_aggressive_candidate (issue #3537)
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateAggressiveCandidateGate:
+    """Cover the two-way ``is_under_loom`` gate in
+    :func:`evaluate_aggressive_candidate`.
+
+    Mirrors ``worktree_root.rs``'s ``gate_matches_default_path_worktree`` /
+    ``gate_matches_override_path_worktree`` /
+    ``gate_matches_default_substring_even_with_override_set`` /
+    ``gate_rejects_unrelated_path``.
+
+    Worktrees are built with ``branch=None`` so the earlier PR / active-shepherd
+    branches are skipped and evaluation falls straight through to the gate at
+    step 4. "Under loom" worktrees carry a ``.loom-managed`` sentinel so they
+    pass the sentinel check and continue to the ``force`` fallback
+    (``force_override_unreachable``, a REMOVE decision); an unrelated path is
+    rejected at the gate with ``user_owned`` (a KEEP decision). The two decisions
+    are the observable proof that the gate accepted vs. rejected the path.
+    """
+
+    def _worktree_info(self, path: pathlib.Path):
+        from loom_tools.clean import WorktreeInfo
+
+        return WorktreeInfo(path=path, head=None, branch=None)
+
+    def _make_managed(self, path: pathlib.Path) -> None:
+        from loom_tools.clean import LOOM_MANAGED_SENTINEL
+
+        path.mkdir(parents=True, exist_ok=True)
+        (path / LOOM_MANAGED_SENTINEL).write_text("")
+
+    def test_gate_accepts_default_path_worktree(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A worktree under the default .loom/worktrees base is Loom-managed."""
+        from loom_tools.clean import DECISION_REMOVE, evaluate_aggressive_candidate
+
+        monkeypatch.delenv("LOOM_WORKTREE_ROOT", raising=False)
+        repo_root = tmp_path / "my-repo"
+        repo_root.mkdir()
+        wt_path = repo_root / ".loom" / "worktrees" / "issue-42"
+        self._make_managed(wt_path)
+
+        decision, _reason = evaluate_aggressive_candidate(
+            self._worktree_info(wt_path),
+            repo_root,
+            active_shepherd_issues=set(),
+            min_age_seconds=0,
+            force=True,
+        )
+        # Accepted by the gate → proceeds past user_owned to the force fallback.
+        assert decision == DECISION_REMOVE
+
+    def test_gate_accepts_override_path_worktree(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A worktree under the override root is Loom-managed (override-aware)."""
+        from loom_tools.clean import DECISION_REMOVE, evaluate_aggressive_candidate
+
+        override = tmp_path / "ext"
+        monkeypatch.setenv("LOOM_WORKTREE_ROOT", str(override))
+        repo_root = tmp_path / "my-repo"
+        repo_root.mkdir()
+        # Override root is namespaced by repo basename: <override>/my-repo/issue-7
+        wt_path = override / "my-repo" / "issue-7"
+        self._make_managed(wt_path)
+
+        decision, _reason = evaluate_aggressive_candidate(
+            self._worktree_info(wt_path),
+            repo_root,
+            active_shepherd_issues=set(),
+            min_age_seconds=0,
+            force=True,
+        )
+        assert decision == DECISION_REMOVE
+
+    def test_gate_accepts_default_substring_with_override_set(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Mixed setup: override configured, but a worktree still lives under the
+        historical .loom/worktrees base — the substring branch must still match."""
+        from loom_tools.clean import DECISION_REMOVE, evaluate_aggressive_candidate
+
+        override = tmp_path / "ext"
+        monkeypatch.setenv("LOOM_WORKTREE_ROOT", str(override))
+        repo_root = tmp_path / "my-repo"
+        repo_root.mkdir()
+        wt_path = repo_root / ".loom" / "worktrees" / "issue-99"
+        self._make_managed(wt_path)
+
+        decision, _reason = evaluate_aggressive_candidate(
+            self._worktree_info(wt_path),
+            repo_root,
+            active_shepherd_issues=set(),
+            min_age_seconds=0,
+            force=True,
+        )
+        assert decision == DECISION_REMOVE
+
+    def test_gate_rejects_unrelated_path(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A worktree at an unrelated path is not Loom-managed → user_owned."""
+        from loom_tools.clean import (
+            DECISION_KEEP,
+            evaluate_aggressive_candidate,
+        )
+
+        override = tmp_path / "ext"
+        monkeypatch.setenv("LOOM_WORKTREE_ROOT", str(override))
+        repo_root = tmp_path / "my-repo"
+        repo_root.mkdir()
+        wt_path = tmp_path / "some" / "other" / "place" / "issue-42"
+        self._make_managed(wt_path)
+
+        decision, reason = evaluate_aggressive_candidate(
+            self._worktree_info(wt_path),
+            repo_root,
+            active_shepherd_issues=set(),
+            min_age_seconds=0,
+            force=True,
+        )
+        assert decision == DECISION_KEEP
+        assert reason == "user_owned"

--- a/loom-tools/tests/test_paths.py
+++ b/loom-tools/tests/test_paths.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
 
-from loom_tools.common.paths import LoomPaths, NamingConventions
+from loom_tools.common.paths import LoomPaths, NamingConventions, is_worktree_path
 
 
 class TestLoomPaths:
@@ -22,8 +23,11 @@ class TestLoomPaths:
         paths = LoomPaths(tmp_path)
         assert paths.scripts_dir == tmp_path / ".loom" / "scripts"
 
-    def test_worktrees_dir(self, tmp_path: Path) -> None:
-        """Test worktrees_dir property."""
+    def test_worktrees_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test worktrees_dir property (default, no override)."""
+        monkeypatch.delenv("LOOM_WORKTREE_ROOT", raising=False)
         paths = LoomPaths(tmp_path)
         assert paths.worktrees_dir == tmp_path / ".loom" / "worktrees"
 
@@ -62,8 +66,11 @@ class TestLoomPaths:
         paths = LoomPaths(tmp_path)
         assert paths.stop_shepherds_file == tmp_path / ".loom" / "stop-shepherds"
 
-    def test_worktree_path(self, tmp_path: Path) -> None:
-        """Test worktree_path method."""
+    def test_worktree_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test worktree_path method (default, no override)."""
+        monkeypatch.delenv("LOOM_WORKTREE_ROOT", raising=False)
         paths = LoomPaths(tmp_path)
         assert paths.worktree_path(42) == tmp_path / ".loom" / "worktrees" / "issue-42"
         assert paths.worktree_path(123) == tmp_path / ".loom" / "worktrees" / "issue-123"
@@ -72,6 +79,181 @@ class TestLoomPaths:
         """Test builder_log_file method."""
         paths = LoomPaths(tmp_path)
         assert paths.builder_log_file(42) == tmp_path / ".loom" / "logs" / "loom-builder-issue-42.log"
+
+
+class TestWorktreeRootResolution:
+    """Tests for the override-aware worktree-root resolver.
+
+    Mirrors the non-gate cases in loom-daemon/src/worktree_root.rs's test module
+    and the bash loom_worktree_root() precedence. pytest's monkeypatch fixture
+    isolates env vars per test, so no manual save/restore is needed.
+    """
+
+    def _repo(self, tmp_path: Path) -> Path:
+        """Create and return a repo root with a fixed basename under tmp_path."""
+        repo_root = tmp_path / "my-repo"
+        repo_root.mkdir()
+        return repo_root
+
+    def _write_config(self, repo_root: Path, body: dict) -> None:
+        loom_dir = repo_root / ".loom"
+        loom_dir.mkdir(exist_ok=True)
+        (loom_dir / "config.json").write_text(json.dumps(body))
+
+    def test_default_when_no_override(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No override → byte-for-byte default path."""
+        monkeypatch.delenv("LOOM_WORKTREE_ROOT", raising=False)
+        repo_root = self._repo(tmp_path)
+        paths = LoomPaths(repo_root)
+        assert paths.worktrees_dir == repo_root / ".loom" / "worktrees"
+        assert (
+            paths.worktree_path(42)
+            == repo_root / ".loom" / "worktrees" / "issue-42"
+        )
+
+    def test_env_override_namespaces_by_basename(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Absolute env override is namespaced by repo basename."""
+        monkeypatch.setenv("LOOM_WORKTREE_ROOT", "/Volumes/Stripe")
+        repo_root = self._repo(tmp_path)
+        assert LoomPaths(repo_root).worktrees_dir == Path("/Volumes/Stripe/my-repo")
+        assert (
+            LoomPaths(repo_root).worktree_path(7)
+            == Path("/Volumes/Stripe/my-repo/issue-7")
+        )
+
+    def test_env_override_strips_trailing_slash(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A trailing slash on the env override is stripped before namespacing."""
+        monkeypatch.setenv("LOOM_WORKTREE_ROOT", "/Volumes/Stripe/")
+        repo_root = self._repo(tmp_path)
+        assert LoomPaths(repo_root).worktrees_dir == Path("/Volumes/Stripe/my-repo")
+
+    def test_config_override_namespaces_by_basename(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Absolute config override is namespaced by repo basename."""
+        monkeypatch.delenv("LOOM_WORKTREE_ROOT", raising=False)
+        repo_root = self._repo(tmp_path)
+        self._write_config(repo_root, {"worktree": {"root": "/Volumes/Ext"}})
+        assert LoomPaths(repo_root).worktrees_dir == Path("/Volumes/Ext/my-repo")
+
+    def test_env_beats_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Env var takes precedence over the config key when both are set."""
+        monkeypatch.setenv("LOOM_WORKTREE_ROOT", "/Volumes/Env")
+        repo_root = self._repo(tmp_path)
+        self._write_config(repo_root, {"worktree": {"root": "/Volumes/Config"}})
+        assert LoomPaths(repo_root).worktrees_dir == Path("/Volumes/Env/my-repo")
+
+    def test_relative_env_override_falls_back_to_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A relative env override warns and falls back to the default path."""
+        monkeypatch.setenv("LOOM_WORKTREE_ROOT", "relative/path")
+        repo_root = self._repo(tmp_path)
+        with pytest.warns(UserWarning, match="must be an absolute path"):
+            got = LoomPaths(repo_root).worktrees_dir
+        assert got == repo_root / ".loom" / "worktrees"
+
+    def test_relative_config_override_falls_back_to_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A relative config override warns and falls back to the default path."""
+        monkeypatch.delenv("LOOM_WORKTREE_ROOT", raising=False)
+        repo_root = self._repo(tmp_path)
+        self._write_config(repo_root, {"worktree": {"root": "relative/path"}})
+        with pytest.warns(UserWarning, match="must be an absolute path"):
+            got = LoomPaths(repo_root).worktrees_dir
+        assert got == repo_root / ".loom" / "worktrees"
+
+    def test_empty_env_override_falls_through_to_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An empty env var is treated as unset (falls through to default)."""
+        monkeypatch.setenv("LOOM_WORKTREE_ROOT", "")
+        repo_root = self._repo(tmp_path)
+        assert LoomPaths(repo_root).worktrees_dir == repo_root / ".loom" / "worktrees"
+
+    def test_missing_config_key_uses_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A config file without worktree.root uses the default."""
+        monkeypatch.delenv("LOOM_WORKTREE_ROOT", raising=False)
+        repo_root = self._repo(tmp_path)
+        self._write_config(repo_root, {"terminals": []})
+        assert LoomPaths(repo_root).worktrees_dir == repo_root / ".loom" / "worktrees"
+
+    def test_malformed_config_uses_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A malformed config file soft-fails to the default (no crash)."""
+        monkeypatch.delenv("LOOM_WORKTREE_ROOT", raising=False)
+        repo_root = self._repo(tmp_path)
+        loom_dir = repo_root / ".loom"
+        loom_dir.mkdir(exist_ok=True)
+        (loom_dir / "config.json").write_text("{not valid json")
+        assert LoomPaths(repo_root).worktrees_dir == repo_root / ".loom" / "worktrees"
+
+    def test_missing_config_file_uses_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No config file at all soft-fails to the default."""
+        monkeypatch.delenv("LOOM_WORKTREE_ROOT", raising=False)
+        repo_root = self._repo(tmp_path)
+        assert LoomPaths(repo_root).worktrees_dir == repo_root / ".loom" / "worktrees"
+
+
+class TestIsWorktreePath:
+    """Tests for the two-way is_worktree_path gate.
+
+    Mirrors worktree_root.rs::gate_* cases: default-path match, override-path
+    match, mixed-setup substring match with an override configured, and rejection
+    of unrelated paths.
+    """
+
+    def _repo(self, tmp_path: Path) -> Path:
+        repo_root = tmp_path / "my-repo"
+        repo_root.mkdir()
+        return repo_root
+
+    def test_gate_matches_default_path_worktree(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("LOOM_WORKTREE_ROOT", raising=False)
+        repo_root = self._repo(tmp_path)
+        wt = repo_root / ".loom" / "worktrees" / "issue-42"
+        assert is_worktree_path(wt, repo_root)
+
+    def test_gate_matches_override_path_worktree(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("LOOM_WORKTREE_ROOT", "/Volumes/Stripe")
+        repo_root = self._repo(tmp_path)
+        wt = Path("/Volumes/Stripe/my-repo/issue-42")
+        assert is_worktree_path(wt, repo_root)
+
+    def test_gate_matches_default_substring_even_with_override_set(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Mixed setup: override configured, worktree still under default base."""
+        monkeypatch.setenv("LOOM_WORKTREE_ROOT", "/Volumes/Stripe")
+        repo_root = self._repo(tmp_path)
+        wt = repo_root / ".loom" / "worktrees" / "issue-99"
+        assert is_worktree_path(wt, repo_root)
+
+    def test_gate_rejects_unrelated_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("LOOM_WORKTREE_ROOT", "/Volumes/Stripe")
+        repo_root = self._repo(tmp_path)
+        unrelated = Path("/some/other/place/issue-42")
+        assert not is_worktree_path(unrelated, repo_root)
 
 
 class TestNamingConventions:


### PR DESCRIPTION
## Summary

Third and final surface of the configurable worktree-root feature (parent #3530; bash PR #3538, Rust PR #3539 already merged). Extends the Python `loom-tools` GC/CLI paths to honor an overridden worktree root so `loom-clean --aggressive`, `loom-worktree`, and the daemon-cleanup / orphan-recovery paths all act on the resolved root instead of the hardcoded `.loom/worktrees`.

`LoomPaths.worktrees_dir` is now the single override-aware extension point, mirroring the bash `loom_worktree_root()` and Rust `worktree_root()` ports exactly. Default installs (no override) see zero behavior change.

## Changes

- **`common/paths.py`**: new `_resolve_worktree_root()` (env `LOOM_WORKTREE_ROOT` > `.loom/config.json` `worktree.root` > default), `_namespaced()` (repo-basename namespacing, trailing-slash strip), `_read_config_worktree_root()` (soft-fail JSON read via `read_json_file`), and `is_worktree_path()` (two-way gate). `worktrees_dir` now resolves at call time. Relative overrides `warnings.warn` and fall back to default.
- **`clean.py`** `evaluate_aggressive_candidate`: `is_under_loom` gate is now two-way — path counts if under the override-aware `LoomPaths(repo_root).worktrees_dir` OR contains the legacy `.loom/worktrees` substring (fixes the override-root worktree misclassified as `user_owned`).
- **`worktree.py`**: resolve repo root via `_get_main_workspace()` (cwd-independent) and route through `LoomPaths(repo_root).worktree_path()`.
- **`daemon_cleanup.py`**, **`orphan_recovery.py`**: route their direct `repo_root/.loom/worktrees/issue-N` construction through `LoomPaths(repo_root).worktree_path()`.
- **Tests**: net-new `TestWorktreeRootResolution` (11 cases) + `TestIsWorktreePath` (4) in `test_paths.py`; net-new `TestEvaluateAggressiveCandidateGate` (4) in `test_clean.py`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Precedence env > config > default | done | `test_env_beats_config`, `test_config_override_*`, `test_default_when_no_override` |
| Absolute overrides namespaced by repo basename | done | `test_env_override_namespaces_by_basename`, `test_config_override_namespaces_by_basename` |
| Relative override → warn + fallback | done | `test_relative_env_override_falls_back_to_default`, `test_relative_config_*` (assert `pytest.warns`) |
| Env beats config | done | `test_env_beats_config` |
| No override → byte-for-byte default | done | existing `test_worktrees_dir` / `test_worktree_path` unmodified assertions still pass |
| Two-way `is_under_loom` gate | done | `TestEvaluateAggressiveCandidateGate` (default/override/mixed-substring accept; unrelated → `user_owned`) |
| Route worktree.py / daemon_cleanup.py / orphan_recovery.py through LoomPaths | done | code diff; all modules import cleanly |
| New pytest coverage (resolver + gate) | done | 19 net-new cases |
| Existing test_paths/test_clean/test_worktree pass unmodified | done | full targeted run green |

## Test Plan

- `PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/test_paths.py loom-tools/tests/test_clean.py loom-tools/tests/test_worktree.py -v` → **71 passed**
- Full suite: `pytest loom-tools/tests/ -q` → **1711 passed, 65 skipped, 3 failed**. The 3 failures (`test_logging::test_log_output_visible_non_interactively`, `test_forge_cli::test_version_flag`, `test_agent_spawn::test_role_in_claude_commands`) are pre-existing environmental failures (editable-install / PATH-dependent subprocess), reproduce on origin/main, and are unrelated to this change.
- `ruff check` on all touched files is clean (pre-existing ruff findings in `daemon_cleanup.py`/`orphan_recovery.py` are in untouched lines and left in place per scope discipline).
- Manual: verified resolver returns `<override>/<basename>/issue-N` for absolute env override, default for relative override, and `is_worktree_path` two-way gate accepts override + mixed-default paths and rejects unrelated paths.

Closes #3537