### PR TITLE
fix(deps): upgrade crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
Fixes the Security Scan (cargo audit) failure on main.

RUSTSEC-2026-0204: invalid pointer dereference in `fmt::Pointer` impl for `Atomic`/`Shared` in crossbeam-epoch 0.9.18. Upgraded to 0.9.20 via `cargo update crossbeam-epoch`.

Verified locally: `cargo check --workspace` and `cargo audit --deny warnings` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)