### PR TITLE
fix(merge): stop passing gh-cached --no-cache flag to plain gh (#3547)

### DIFF
--- a/defaults/hooks/guard-destructive.sh
+++ b/defaults/hooks/guard-destructive.sh
@@ -308,7 +308,19 @@ done
 # =============================================================================
 
 if echo "$COMMAND" | grep -qE 'gh\s+pr\s+merge'; then
-    deny "Use ./.loom/scripts/merge-pr.sh <PR_NUMBER> instead of 'gh pr merge'. The script merges via the GitHub API without local checkout, which avoids worktree errors."
+    # Resolve the merge-pr.sh path for the current repo context. Prefer an
+    # in-repo installed copy (./.loom/scripts/merge-pr.sh); fall back to the
+    # loom-checkout copy under defaults/scripts/ (via $LOOM_HOME) when the repo
+    # runs scripts directly from the checkout rather than an installed copy.
+    MERGE_SCRIPT="./.loom/scripts/merge-pr.sh"
+    if [[ -n "$REPO_ROOT" ]] && [[ ! -x "$REPO_ROOT/.loom/scripts/merge-pr.sh" ]]; then
+        if [[ -n "${LOOM_HOME:-}" ]] && [[ -x "$LOOM_HOME/defaults/scripts/merge-pr.sh" ]]; then
+            MERGE_SCRIPT="$LOOM_HOME/defaults/scripts/merge-pr.sh"
+        elif [[ -x "$REPO_ROOT/defaults/scripts/merge-pr.sh" ]]; then
+            MERGE_SCRIPT="$REPO_ROOT/defaults/scripts/merge-pr.sh"
+        fi
+    fi
+    deny "Use $MERGE_SCRIPT <PR_NUMBER> instead of 'gh pr merge'. The script merges via the GitHub API without local checkout, which avoids worktree errors."
 fi
 
 # =============================================================================

--- a/defaults/scripts/lib/forge-helpers.sh
+++ b/defaults/scripts/lib/forge-helpers.sh
@@ -323,7 +323,16 @@ forge_get_pr_nocache() {
   if [[ "$FORGE_TYPE" == "gitea" ]]; then
     # Gitea has no caching layer like gh-cached
     forge_get_pr "$nwo" "$pr_number"
+  elif [[ "$(basename "$gh_cmd")" == "gh" ]]; then
+    # Plain `gh` has no --no-cache flag (it's a gh-cached wrapper flag). Plain
+    # `gh api` is already uncached, so calling it without --no-cache preserves
+    # the no-cache intent. Passing --no-cache to plain gh fails on the unknown
+    # flag, and with 2>/dev/null the error is swallowed and callers substitute
+    # '{}', silently breaking merge verification and race-condition rechecks
+    # whenever gh-cached is absent (issue #3547).
+    "$gh_cmd" api "repos/$nwo/pulls/$pr_number" 2>/dev/null
   else
+    # gh-cached wrapper: --no-cache bypasses its cache layer as intended.
     "$gh_cmd" --no-cache api "repos/$nwo/pulls/$pr_number" 2>/dev/null
   fi
 }

--- a/defaults/scripts/merge-pr.sh
+++ b/defaults/scripts/merge-pr.sh
@@ -534,7 +534,15 @@ done
 VERIFY_JSON=$(forge_get_pr_nocache "$REPO_NWO" "$PR_NUMBER" "$GH" 2>/dev/null || echo '{}')
 VERIFY_MERGED=$(echo "$VERIFY_JSON" | jq -r '.merged // false')
 if [[ "$VERIFY_MERGED" != "true" ]]; then
-  error "Merge API call returned but PR #$PR_NUMBER is not merged"
+  # Defense-in-depth: a transient API error (empty/{} response) must not turn a
+  # successful merge into a hard failure. Retry the verify once before failing
+  # (issue #3547).
+  sleep 2
+  VERIFY_JSON=$(forge_get_pr_nocache "$REPO_NWO" "$PR_NUMBER" "$GH" 2>/dev/null || echo '{}')
+  VERIFY_MERGED=$(echo "$VERIFY_JSON" | jq -r '.merged // false')
+  if [[ "$VERIFY_MERGED" != "true" ]]; then
+    error "Merge API call returned but PR #$PR_NUMBER is not merged"
+  fi
 fi
 
 success "PR #$PR_NUMBER merged successfully"

--- a/defaults/scripts/tests/test-forge-helpers.sh
+++ b/defaults/scripts/tests/test-forge-helpers.sh
@@ -199,6 +199,67 @@ assert_eq "123 456" "$result" "GitHub path delegates to gh pr view --json closin
 
 rm -rf "$STUB_DIR"
 
+# --- Test forge_get_pr_nocache does not pass --no-cache to plain gh (issue #3547) ---
+# Regression: `--no-cache` is a gh-cached WRAPPER flag, not a real `gh` flag.
+# When gh-cached is absent and the plain `gh` fallback is used, passing
+# --no-cache made `gh api` fail on the unknown flag; the error was swallowed by
+# 2>/dev/null and callers substituted '{}', silently breaking merge verification
+# and race-condition rechecks. forge_get_pr_nocache must therefore NOT pass
+# --no-cache when the command basename is plain `gh` (plain `gh api` is already
+# uncached), while still passing it for the gh-cached wrapper.
+echo ""
+echo "Testing forge_get_pr_nocache --no-cache handling (issue #3547)..."
+
+NC_STUB_DIR=$(mktemp -d)
+
+# Stub named exactly `gh`: emits valid PR JSON for `api ...`, but exits non-zero
+# (as real gh does) if the unknown `--no-cache` flag is present. This proves the
+# helper reaches the api call cleanly only when --no-cache is omitted.
+cat > "$NC_STUB_DIR/gh" <<'STUB'
+#!/usr/bin/env bash
+for a in "$@"; do
+  if [[ "$a" == "--no-cache" ]]; then
+    echo "unknown flag: --no-cache" >&2
+    exit 1
+  fi
+done
+if [[ "$1" == "api" ]]; then
+  printf '{"merged":true,"state":"closed"}\n'
+  exit 0
+fi
+exit 1
+STUB
+chmod +x "$NC_STUB_DIR/gh"
+
+# Stub named `gh-cached`: REQUIRES --no-cache to be present (proves the wrapper
+# still receives the cache-bypass flag). Emits valid JSON when it is.
+cat > "$NC_STUB_DIR/gh-cached" <<'STUB'
+#!/usr/bin/env bash
+has_no_cache=0
+for a in "$@"; do
+  [[ "$a" == "--no-cache" ]] && has_no_cache=1
+done
+if [[ "$has_no_cache" -ne 1 ]]; then
+  echo "expected --no-cache" >&2
+  exit 1
+fi
+printf '{"merged":true,"state":"closed"}\n'
+exit 0
+STUB
+chmod +x "$NC_STUB_DIR/gh-cached"
+
+FORGE_TYPE="github"
+
+# Plain-gh path: helper must omit --no-cache and return real JSON.
+nc_result=$(forge_get_pr_nocache "owner/repo" "123" "$NC_STUB_DIR/gh" 2>/dev/null | jq -r '.merged' 2>/dev/null || echo "")
+assert_eq "true" "$nc_result" "forge_get_pr_nocache with plain gh omits --no-cache and returns real JSON"
+
+# gh-cached path: helper must still pass --no-cache to the wrapper.
+nc_cached_result=$(forge_get_pr_nocache "owner/repo" "123" "$NC_STUB_DIR/gh-cached" 2>/dev/null | jq -r '.merged' 2>/dev/null || echo "")
+assert_eq "true" "$nc_cached_result" "forge_get_pr_nocache with gh-cached wrapper still passes --no-cache"
+
+rm -rf "$NC_STUB_DIR"
+
 # --- Test gitea_api auth-mode selection (issue #3297) ---
 # Use a `curl` shim on PATH that records its argv and returns a fake 200.
 echo ""


### PR DESCRIPTION
Closes #3547

## Problem

`forge_get_pr_nocache` in `defaults/scripts/lib/forge-helpers.sh` unconditionally passed `--no-cache`, which is a `gh-cached` **wrapper** flag, not a real `gh` flag. When `gh-cached` is absent (the common downstream case), `merge-pr.sh` falls back to `GH="gh"`, and `gh --no-cache api ...` fails on the unknown flag. The error is swallowed by `2>/dev/null`, callers substitute `{}`, and `jq -r '.merged // false'` yields `false`. The post-merge verify then hard-errors "PR not merged" even though the merge succeeded. The same helper silently disabled the race-condition / HTTP-405 recovery rechecks.

## Fix

- **`forge-helpers.sh`** (primary): only pass `--no-cache` when `$gh_cmd` basename is not plain `gh`. Plain `gh api` is already uncached, so the no-cache intent is fully preserved.
- **`merge-pr.sh`** (defense-in-depth): retry the post-merge verify once on empty/`{}` before declaring failure, so a transient API error can't turn a successful merge into a hard failure.
- **`guard-destructive.sh`** (paper cut): resolve the `merge-pr.sh` path in the `gh pr merge` deny message dynamically — prefer an in-repo `./.loom/scripts/merge-pr.sh`, else fall back to the loom-checkout `defaults/scripts/merge-pr.sh` (via `$LOOM_HOME` or `$REPO_ROOT`).
- **`test-forge-helpers.sh`**: regression tests asserting plain-`gh` invocation omits `--no-cache` (and returns real JSON) while the `gh-cached` wrapper still receives it.

## Testing

- `bash defaults/scripts/tests/test-forge-helpers.sh` — 36/36 pass (2 new)
- `bash defaults/scripts/tests/test-merge-pr-unstable-fallback.sh` — 28/28 pass
- `bash defaults/scripts/tests/test-merge-pr-help.sh` — 15/15 pass
- `bash -n` syntax check on both modified shell scripts
- Manual smoke test of `guard-destructive.sh` deny path confirms it still denies `gh pr merge` and resolves the correct script path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)