### PR TITLE
fix(install): reconcile index on --quick reinstall + scope uninstall staging (#3545)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -563,6 +563,28 @@ elif [[ -d "$TARGET_PATH/.loom" ]]; then
     info "Non-interactive mode: proceeding with reinstall"
   fi
 
+  # Issue #3545: for a --quick reinstall, guard uncommitted user changes across
+  # the uninstall→reinstall cycle (mirrors the stash guard in the sibling
+  # scripts/install-loom.sh --clean path). The uninstall runs `git add` in the
+  # target tree and the reinstall reconciles the index afterwards; stashing
+  # first keeps a user's pre-existing staged/working changes from being caught
+  # up in either step. The non-quick reinstall delegates to install-loom.sh,
+  # which performs its own guarding, so it is intentionally left unstashed here.
+  REINSTALL_STASHED_USER_CHANGES=false
+  if [[ "$INSTALL_TYPE" == "1" ]]; then
+    if ! git -C "$TARGET_PATH" diff --quiet 2>/dev/null || \
+       ! git -C "$TARGET_PATH" diff --staged --quiet 2>/dev/null; then
+      info "Stashing uncommitted user changes before reinstall..."
+      if git -C "$TARGET_PATH" stash push -m "loom-install: preserving user changes before --quick reinstall" 2>/dev/null; then
+        REINSTALL_STASHED_USER_CHANGES=true
+        success "User changes stashed"
+      else
+        warning "Failed to stash user changes - continuing without stash"
+        warning "Uncommitted changes may appear alongside the reinstall diff"
+      fi
+    fi
+  fi
+
   # Uninstall existing installation (local mode, no separate PR)
   info "Uninstalling existing Loom installation..."
   "$LOOM_ROOT/scripts/uninstall-loom.sh" --yes --local "$TARGET_PATH" || \
@@ -598,6 +620,29 @@ elif [[ -d "$TARGET_PATH/.loom" ]]; then
     # Emit skill-routes.json, install-metadata.json, loom-source-path (#3502).
     finalize_quick_install "$LOOM_ROOT" "$TARGET_PATH"
     verify_install "$TARGET_PATH"
+
+    # Issue #3545: reconcile the git index after the uninstall→reinstall cycle.
+    # The chained uninstall staged the deletion of every prior Loom file (now
+    # scoped to Loom-managed paths — see scripts/uninstall-loom.sh), then
+    # `loom-daemon init --force` rewrote those files to disk WITHOUT touching
+    # the index. Left as-is, `git status` shows ~150 paired staged-`D` /
+    # untracked-`??` entries instead of the real version-upgrade diff. Unstage
+    # the uninstall's staged deletions so the working tree reflects only the
+    # actual old→new file changes.
+    info "Reconciling git index after reinstall..."
+    git -C "$TARGET_PATH" restore --staged . 2>/dev/null || \
+      git -C "$TARGET_PATH" reset -q HEAD -- . 2>/dev/null || true
+
+    # Restore any user changes stashed before the uninstall (see above).
+    if [[ "$REINSTALL_STASHED_USER_CHANGES" == "true" ]]; then
+      info "Restoring stashed user changes..."
+      if git -C "$TARGET_PATH" stash pop 2>/dev/null; then
+        success "User changes restored"
+      else
+        warning "Failed to restore stashed user changes automatically"
+        warning "Run 'git stash pop' in $TARGET_PATH to recover your changes"
+      fi
+    fi
 
     echo ""
     success "Quick reinstallation complete!"

--- a/scripts/test-installer.sh
+++ b/scripts/test-installer.sh
@@ -2197,6 +2197,57 @@ echo ""
 
 
 # ==========================================================================
+# Section 12: Local-mode uninstall staging scope (#3545)
+# ==========================================================================
+
+# Test 64: Local-mode uninstall stages ONLY Loom-managed paths, never
+# unrelated user changes. Regression guard for #3545: the old bare
+# `git add -A` in Step 8 (local mode) swept in any pending user work —
+# an in-progress edit or an embedded worktree — which the install.sh
+# --quick reinstall path would then fold into its commit guidance.
+echo "Test 64: Local uninstall stages only Loom paths, not user changes (#3545)"
+SCOPE_REPO="$TEST_DIR/scoped-staging-test"
+create_temp_repo "$SCOPE_REPO"
+simulate_loom_install "$SCOPE_REPO"
+
+# Commit a baseline that includes a tracked user file alongside the Loom install.
+mkdir -p "$SCOPE_REPO/src"
+echo "original" > "$SCOPE_REPO/src/app.txt"
+git -C "$SCOPE_REPO" add -A
+git -C "$SCOPE_REPO" commit -m "loom install + user file" --quiet
+
+# Dirty the tree the way a user mid-edit would: modify a tracked file and drop
+# an untracked file (mimics the .claude/worktrees/agent-*/ near-miss in #3545).
+echo "user edit" >> "$SCOPE_REPO/src/app.txt"
+mkdir -p "$SCOPE_REPO/user-junk"
+echo "scratch" > "$SCOPE_REPO/user-junk/notes.txt"
+
+"$UNINSTALL_SCRIPT" --yes --local "$SCOPE_REPO" > /dev/null 2>&1 || true
+
+# The untracked user file must remain untracked/unstaged (?? in porcelain).
+if git -C "$SCOPE_REPO" status --porcelain -- user-junk/notes.txt | grep -q '^??'; then
+  pass "Untracked user file left unstaged by local uninstall (#3545)"
+else
+  fail "Untracked user file was staged by local uninstall (bare 'git add -A' regression, #3545)"
+fi
+
+# The modified tracked user file must remain a working-tree modification ( M).
+if git -C "$SCOPE_REPO" status --porcelain -- src/app.txt | grep -q '^ M'; then
+  pass "Modified tracked user file left unstaged by local uninstall (#3545)"
+else
+  fail "Modified tracked user file was staged by local uninstall (#3545)"
+fi
+
+# Loom file deletions MUST still be staged — that is the uninstall's job.
+if git -C "$SCOPE_REPO" diff --staged --name-only | grep -q '^\.loom/'; then
+  pass "Loom file deletions staged by local uninstall (scoped staging still works)"
+else
+  fail "Loom file deletions were not staged by local uninstall (#3545 over-scoped)"
+fi
+echo ""
+
+
+# ==========================================================================
 # Summary
 # ==========================================================================
 echo "======================================"

--- a/scripts/uninstall-loom.sh
+++ b/scripts/uninstall-loom.sh
@@ -1187,7 +1187,27 @@ if [[ "$LOCAL_MODE" == "true" ]]; then
   echo ""
 
   cd "$TARGET_PATH"
-  git add -A
+
+  # Issue #3545: stage ONLY the paths this uninstall actually touched — never a
+  # bare `git add -A`. A bare `git add -A` stages every pending change in the
+  # tree, sweeping unrelated user work (in-progress edits, an embedded
+  # `.claude/worktrees/agent-*/`, etc.) into the index alongside the Loom
+  # deletions. The `install.sh --quick` reinstall path then prints generic
+  # `git add -A && git commit` guidance that would commit those user files.
+  # Scope staging to the Loom-managed paths that were removed / smart-edited so
+  # user files are never staged.
+  STAGE_PATHS=(
+    ${REMOVE_FILES[@]+"${REMOVE_FILES[@]}"}
+    ${REMOVE_UNKNOWN_FILES[@]+"${REMOVE_UNKNOWN_FILES[@]}"}
+    ${SMART_REMOVE_FILES[@]+"${SMART_REMOVE_FILES[@]}"}
+    ".loom/CLAUDE.md"
+  )
+  for _stage_path in ${STAGE_PATHS[@]+"${STAGE_PATHS[@]}"}; do
+    # `-A` stages deletions and modifications alike; per-path invocation with
+    # `|| true` tolerates pathspecs that never matched (e.g. an untracked file
+    # that was removed, or a smart-remove target that did not exist).
+    git add -A -- "$_stage_path" 2>/dev/null || true
+  done
 
   if git diff --staged --quiet; then
     info "No changes detected - Loom files may have already been removed"


### PR DESCRIPTION
Closes #3545

## Problem

The `install.sh --quick` **reinstall** path chained three operations with no index reconciliation between them:

1. `uninstall-loom.sh --yes --local` ran a bare `git add -A`, staging the deletion of every prior Loom file **and** sweeping in any pre-existing untracked/dirty user path (the `.claude/worktrees/agent-*/` near-miss in the report).
2. `loom-daemon init --force` rewrote the Loom files **to disk only** — the index was never touched.

Net: ~150 paired staged-`D`/untracked-`??` entries plus whatever user files the bare `git add -A` staged, followed by generic `git add -A && git commit` guidance that would commit the lot.

The sibling full-install `--clean` path in `scripts/install-loom.sh` already solves this (stash guard + `git restore --staged .`). This PR ports/adapts those guards and fixes the over-broad staging at the source.

## Changes

- **`install.sh`** (--quick reinstall block): stash uncommitted user changes before the uninstall, then after `loom-daemon init` + finalize/verify run `git restore --staged .` (drops the uninstall's staged deletions so `git status` reflects only the real version-upgrade content diff), then `git stash pop`. Scoped to the `--quick` branch; the non-quick branch already delegates to `install-loom.sh`'s own guarding. The scoped `git clean` from the reference impl is intentionally **not** ported — quick installs into the target tree directly, so cleaning would delete the freshly installed files.
- **`scripts/uninstall-loom.sh`** (local-mode Step 8): replace the bare `git add -A` with staging scoped to the paths the uninstall actually touched (`REMOVE_FILES`, `REMOVE_UNKNOWN_FILES`, `SMART_REMOVE_FILES`, `.loom/CLAUDE.md`). Per-path `git add -A -- "$p" || true` tolerates pathspecs that never matched. Unrelated user files are never staged.
- **`scripts/test-installer.sh`**: Test 64 asserts local-mode uninstall stages only Loom paths and leaves untracked/modified user files untouched, while still staging Loom deletions.

## Verification

- `shellcheck` + `bash -n` clean on both scripts (no new warnings on added lines).
- Full `scripts/test-installer.sh` suite: **112 passed / 0 failed** (Test 64 new).
- End-to-end simulation of the uninstall→init→reconcile sequence: **before** reconcile 3 stale staged `D` + untracked `??` pairs (bug shape); **after** reconcile 0 staged deletions, only a clean ` M` version-upgrade diff, with a planted untracked file (`??`) and a tracked in-progress edit both preserved by the stash guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)