### PR TITLE
docs: add /loom:help command describing the installed Loom commands

### DIFF
--- a/defaults/.claude/README.md
+++ b/defaults/.claude/README.md
@@ -110,6 +110,7 @@ The `commands/` directory contains slash commands that define Loom roles. Each c
 | `/doctor` | Doctor | Addresses PR feedback and resolves conflicts |
 | `/guide` | Guide | Triages issues and applies `loom:urgent` to top 3 |
 | `/champion` | Champion | Auto-merges approved PRs with `loom:pr` label |
+| `/loom:help` | Help | Read-only overview of the installed `/loom:*` commands; `/loom:help <command>` describes one |
 | `/loom help` | Help | Comprehensive help guide with sub-topics (roles, workflow, commands, etc.) |
 
 ### How Slash Commands Work

--- a/defaults/.claude/commands/loom/help.md
+++ b/defaults/.claude/commands/loom/help.md
@@ -1,0 +1,116 @@
+# Loom Help
+
+You are a read-only help guide for the Loom command surface installed in the {{workspace}} repository. Your job is to orient the user: explain which `/loom:*` commands are available, what each is for, and where to start.
+
+**Arguments**: `$ARGUMENTS`
+
+## CRITICAL: Strictly Read-Only
+
+This command **describes** Loom commands — it never runs them, and it never mutates anything.
+
+- **Do NOT** run any other `/loom:*` command, spawn subagents, or invoke role workflows.
+- **Do NOT** edit files, create branches, open PRs, or change any labels.
+- **Do NOT** call `gh issue edit`, `gh pr create`, `worktree.sh`, `merge-pr.sh`, or any state-changing tooling.
+- The **only** shell you may run is a read-only `ls` (and equivalent read-only inspection) of `.claude/commands/loom/` for the drift cross-check described below.
+
+If the user asks you to *do* something (e.g. "build issue 42"), do not do it — tell them the command that does it (`/loom:builder 42` or `/loom:sweep 42`) and let them invoke it.
+
+## Mode Selection
+
+Parse `$ARGUMENTS`:
+
+- **Empty** → run **Overview mode** (grouped list of all user-facing commands).
+- **A single command name** (e.g. `builder`, `/builder`, `loom:sweep`, `sweep`) → run **Detail mode** for that command.
+- **`--help`, `help`, or anything you can't map** → run Overview mode and note how to ask about a specific command (`/loom:help <command>`).
+
+Normalize a requested name by stripping a leading `/`, a leading `loom:` namespace, and any trailing `.md`.
+
+---
+
+## Overview Mode (`/loom:help`)
+
+Print a one-screen, grouped overview of the **primary, user-facing** Loom commands. Use the curated list below as the source of truth for grouping and descriptions — it is deliberately hand-maintained so that reference sub-docs and deprecated stubs never leak into the listing.
+
+Present it grouped like this (keep descriptions terse, one line each):
+
+### Lifecycle / orchestration
+| Command | What it does |
+|---------|--------------|
+| `/loom:sweep <issue>` | Run one issue through the full lifecycle (Curator → Builder → Judge → Doctor → Merge). Also `--prs` for a PR set. |
+| `/loom:loom` | Operate the Layer 2 `loom-daemon` — dispatch, monitor, and cancel sweeps via MCP tools. |
+
+### Worker roles
+| Command | What it does |
+|---------|--------------|
+| `/loom:builder [issue]` | Implement a `loom:issue`, then open a PR for review. |
+| `/loom:judge [pr]` | Review a `loom:review-requested` PR; approve or request changes. |
+| `/loom:curator [issue]` | Enrich an issue with detail and acceptance criteria; mark `loom:curated`. |
+| `/loom:champion` | Promote quality proposals to `loom:issue` and auto-merge safe `loom:pr` PRs. |
+| `/loom:doctor [pr]` | Address PR feedback, fix bugs, resolve merge conflicts. |
+| `/loom:guide` | Triage the backlog; apply `loom:urgent` to the top priorities. |
+| `/loom:architect` | Analyze the codebase and file architectural proposals (`loom:architect`). |
+| `/loom:hermit` | Find bloat and file simplification proposals (`loom:hermit`). |
+| `/loom:auditor` | Build and run `main` to verify it actually works; file bugs on failure. |
+| `/loom:driver` | Plain shell environment with no assumed role, for ad-hoc tasks. |
+
+### Project / meta
+| Command | What it does |
+|---------|--------------|
+| `/loom:imagine <idea>` | Bootstrap a new Loom-powered project from a natural-language description. |
+| `/loom:epic <goal>` | Break a large goal into a phased epic with implementation issues. |
+| `/loom:release` | Guide a full versioned release of this project. |
+| `/loom:bump <level>` | Bump the version + tag for a generic (non-Loom) project. |
+| `/loom:help [command]` | This command — describe the Loom command surface. |
+
+After the tables, close with a short **where to start**:
+
+- **Just want work done on an issue?** `/loom:sweep <issue>` runs the whole lifecycle for you.
+- **Prefer hands-on control?** Drive individual roles: `/loom:builder`, then `/loom:judge`, then merge.
+- **Want details on one command?** `/loom:help <command>` (e.g. `/loom:help sweep`).
+- **Update Loom itself:** re-run the installer from the Loom source repo (`./install.sh /path/to/this/repo`); see `CLAUDE.md` for the current version and release notes.
+
+### Drift cross-check (runtime)
+
+After printing the overview, do a lightweight accuracy check against what is actually installed:
+
+1. List the installed command files: `ls .claude/commands/loom/*.md` (read-only). If that path is missing, try `ls defaults/.claude/commands/loom/*.md` (this repo keeps the canonical source there and symlinks `.claude/commands`).
+2. Reduce each result to its base name without `.md`.
+3. **Exclude** the known reference sub-docs and deprecated stubs — these are internal building blocks, not invocable entry points, and must never appear in the listing:
+   - anything ending in `-patterns` or `-reference` (e.g. `architect-patterns`, `architect-reference`, `champion-reference`, `hermit-patterns`, `loom-reference`)
+   - the builder sub-docs: `builder-pr`, `builder-worktree`, `builder-complexity`
+   - the champion helper docs: `champion-common`, `champion-epic`, `champion-issue-promo`, `champion-pr-merge` (any `champion-*` other than `champion` itself)
+   - the deprecated stubs: `loom-iteration`, `loom-parent`
+4. Compare the surviving set against the curated command names above.
+   - If an installed primary command is **missing** from the curated list, warn: `Note: /loom:<name> is installed here but not described above — this help text may be out of date (please report).`
+   - If a curated command is **not** installed here, note it as possibly-not-installed rather than dropping it silently: `Note: /loom:<name> is described above but not found in this install.`
+   - If everything matches, you may add a single line: `(Command list verified against this install.)`
+
+Keep the warnings brief — they are a safety net for version/partial-install drift, not the main event.
+
+---
+
+## Detail Mode (`/loom:help <command>`)
+
+The user asked about one command. Resolve `<command>` to a file at `.claude/commands/loom/<name>.md` (fall back to `defaults/.claude/commands/loom/<name>.md`).
+
+**If the name resolves to a reference sub-doc or deprecated stub** (matches the exclude rules above — `*-patterns`, `*-reference`, `builder-pr/-worktree/-complexity`, a `champion-*` helper, `loom-iteration`, `loom-parent`): explain that it is an internal reference file, not a user-invocable command, and point at its parent command (e.g. `builder-pr` → `/loom:builder`). Do not summarize it as if it were a command.
+
+**If the file does not exist**: say so plainly, list the closest matches from the curated command names, and suggest `/loom:help` (no args) for the full list. Do not guess or fabricate behavior.
+
+**If the file exists and is a real command**: read it and produce a concise summary:
+
+1. **Purpose** — one line (derive from the `# Title` heading and opening paragraph).
+2. **What it does** — 2–4 bullets of the main workflow.
+3. **What it will NOT do without confirmation** — destructive or state-changing actions the command guards (merges, label mutations, force operations). If the command is itself read-only, say so.
+4. **Example** — one concrete invocation, e.g. `/loom:sweep 123` or `/loom:builder 42`.
+
+Keep it to a screen. Quote the file rather than inventing behavior; if the file is ambiguous, say what you can support and stop.
+
+---
+
+## Style Notes
+
+- Match the terse, scannable tone of the other Loom command files.
+- Prefer tables and short bullets over prose.
+- Never invent commands, flags, or behavior that isn't in the curated list or the command file you read.
+- Everything you output is documentation. You take no action on the repository.


### PR DESCRIPTION
## Summary

Adds a user-invocable `/loom:help` command so a user inside a consumer repo can learn the `/loom:*` surface without reading source. It is a read-only prompt-skill: `/loom:help` prints a curated, grouped overview of the user-facing commands, and `/loom:help <command>` summarizes a single command file.

## Changes

- **Create `defaults/.claude/commands/loom/help.md`** — the only required change. A read-only skill that:
  - Prints a grouped overview (Lifecycle/orchestration, Worker roles, Project/meta) with terse one-line descriptions plus a "where to start" pointer.
  - Supports `/loom:help <command>` detail mode (purpose, what it does, what it won't do without confirmation, one example) and handles unknown / reference-file names gracefully.
  - Runs a runtime `ls .claude/commands/loom/*.md` cross-check and warns when the curated list has drifted from what is actually installed.
  - Excludes reference sub-docs and deprecated stubs from any listing: `*-patterns`, `*-reference`, `builder-pr`, `builder-worktree`, `builder-complexity`, `champion-*` helpers, `loom-iteration`, `loom-parent`.
  - Is strictly read-only — never runs commands, edits files, or mutates labels.
- **Update `defaults/.claude/README.md`** — one-line pointer to `/loom:help` in the Available Commands table.

## How it installs

Slash commands are prompt-skills: `/loom:<name>` loads `.claude/commands/loom/<name>.md`. `loom-daemon/src/init/scaffolding.rs` copies the whole `.claude/commands/loom/` directory into consumer repos, so `help.md` ships automatically — **no installer or scaffolding change**, and it is **not** added to `defaults/.loom-internal.list` (it must ship). In this repo `.claude/commands` symlinks to `defaults/.claude/commands`, so the file resolves in-repo immediately.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `help.md` exists, `{{workspace}}`-templated, starts with `# Title` | Done | `head -1` → `# Loom Help`; uses `{{workspace}}` like siblings |
| `/loom:help` prints grouped one-screen overview + where-to-start + update pointer | Done | Overview mode with 3 grouped tables and closing pointers |
| Reference sub-docs / deprecated stubs excluded | Done | Explicit exclude rules for `*-patterns`, `*-reference`, `builder-*` sub-docs, `champion-*` helpers, `loom-iteration`, `loom-parent` |
| Runtime `ls` cross-check + drift warning | Done | Drift cross-check section instructs `ls .claude/commands/loom/*.md` and warns on mismatch |
| `/loom:help <command>` summarizes one file, handles unknown names | Done | Detail mode with graceful unknown / reference-file handling |
| Strictly read-only | Done | Dedicated read-only section; only permitted shell is read-only `ls` |
| NOT added to `.loom-internal.list` | Done | `grep help.md defaults/.loom-internal.list` → no entry |

## Test Plan

- Verified the new file resolves through the `.claude/commands` symlink (`ls -la .claude/commands/loom/help.md`).
- Confirmed `defaults/.loom-internal.list` has no `help.md` entry.
- Confirmed the main worktree stayed clean (`check-main-clean.sh`).
- Reviewed the rendered markdown for coherent, self-consistent instructions matching sibling command-file style.

Closes #3554