### PR TITLE
fix(worktree): detect default branch instead of hardcoding origin/main (#3549)

### DIFF
--- a/defaults/scripts/lib/default-branch.sh
+++ b/defaults/scripts/lib/default-branch.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# default-branch.sh — Resolve a repository's default branch name.
+#
+# Source this file (do not exec). Defines a single function:
+#
+#   loom_default_branch [remote] -> echoes the default branch name (e.g. "main"
+#                                   or "master"); returns non-zero on failure.
+#
+# Motivation (#3549): the worktree helpers historically hardcoded the base
+# branch as the literal string `main` / `origin/main`. On a repo whose default
+# branch is `master` (or any non-`main` name) every git call that references
+# `origin/main` fails with `fatal: invalid reference: origin/main`, aborting
+# worktree creation. This helper centralizes offline-first default-branch
+# detection so both worktree.sh and pr-worktree.sh work regardless of the
+# repo's default branch name.
+#
+# Detection order (first match wins) — offline-first, HARD-FAIL:
+#
+#   1. LOOM_DEFAULT_BRANCH env var         — explicit escape hatch / test seam.
+#   2. git symbolic-ref --short            — the offline, no-network source of
+#      refs/remotes/<remote>/HEAD            truth. Present in normal clones;
+#                                            `git remote set-head <remote> -a`
+#                                            populates it.
+#   3. git ls-remote --symref <remote> HEAD — network fallback when origin/HEAD
+#                                            is unset locally (fresh clones
+#                                            sometimes lack it).
+#   4. Local probe                          — check refs/remotes/<remote>/main
+#                                            then refs/remotes/<remote>/master,
+#                                            pick whichever exists.
+#   5. Hard error (return 1 + remediation)  — NEVER silently default to `main`.
+#      A silent wrong default reintroduces the exact class of bug this helper
+#      exists to fix (an empty or wrong branch on a master-default repo).
+#
+# Design notes:
+#   - `git symbolic-ref` is preferred over `gh repo view --json defaultBranchRef`
+#     because Loom is forge-agnostic (it supports Gitea too), needs no network,
+#     and needs no `gh` auth. A forge-API tier could be added later but must not
+#     be the primary detector.
+#   - The helper runs git against the current working directory. Callers that
+#     need a specific repo context should `cd` there (or run git -C) before
+#     calling, or resolve the branch once at the top of the script while cwd is
+#     the main workspace.
+#   - No side effects at source time; pure function, mirrors lib/worktree-root.sh.
+
+# loom_default_branch [remote]
+#
+# Echoes the resolved default branch name on stdout. Returns 0 on success,
+# 1 when the branch cannot be determined (with a remediation hint on stderr).
+loom_default_branch() {
+    local remote="${1:-origin}"
+
+    # 1. Env var override — highest priority (escape hatch + test seam).
+    if [[ -n "${LOOM_DEFAULT_BRANCH:-}" ]]; then
+        echo "$LOOM_DEFAULT_BRANCH"
+        return 0
+    fi
+
+    # 2. Local symbolic ref for the remote's HEAD — offline, no network.
+    #    Returns e.g. "origin/main"; strip the "<remote>/" prefix.
+    local sref
+    sref=$(git symbolic-ref --short "refs/remotes/$remote/HEAD" 2>/dev/null || true)
+    if [[ -n "$sref" ]]; then
+        echo "${sref#"$remote"/}"
+        return 0
+    fi
+
+    # 3. Network fallback: ask the remote for its HEAD symref.
+    #    Output line looks like: "ref: refs/heads/main\tHEAD"; strip the prefix.
+    local lsref
+    lsref=$(git ls-remote --symref "$remote" HEAD 2>/dev/null \
+        | awk '/^ref:/ { print $2; exit }' || true)
+    if [[ -n "$lsref" ]]; then
+        echo "${lsref#refs/heads/}"
+        return 0
+    fi
+
+    # 4. Local probe: prefer main, then master, whichever ref exists.
+    local candidate
+    for candidate in main master; do
+        if git show-ref --verify --quiet "refs/remotes/$remote/$candidate" 2>/dev/null; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+
+    # 5. Hard fail — do NOT default to main.
+    echo "loom_default_branch: could not determine the default branch for remote '$remote'." >&2
+    echo "  Fix: run 'git remote set-head $remote -a' to populate refs/remotes/$remote/HEAD," >&2
+    echo "  or set LOOM_DEFAULT_BRANCH to the branch name explicitly." >&2
+    return 1
+}

--- a/defaults/scripts/pr-worktree.sh
+++ b/defaults/scripts/pr-worktree.sh
@@ -85,6 +85,16 @@ REPO_ROOT=$(cd "$(dirname "$GIT_COMMON_DIR")" && pwd)
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/worktree-root.sh"
 WORKTREE_ROOT_DIR="$(loom_worktree_root "$REPO_ROOT")"
 
+# Shared default-branch resolver (#3549). Detects the repo's default branch so
+# the PR worktree bases on origin/<default> rather than a hardcoded origin/main
+# (which fails on master-default repos). Resolve against the main repo context.
+# shellcheck source=lib/default-branch.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/default-branch.sh"
+if ! DEFAULT_BRANCH="$(cd "$REPO_ROOT" && loom_default_branch)"; then
+    print_error "Could not determine the default branch. Set LOOM_DEFAULT_BRANCH or run: git remote set-head origin -a"
+    exit 1
+fi
+
 WORKTREE_PATH="$WORKTREE_ROOT_DIR/pr-$PR_NUMBER"
 
 # If the worktree already exists, treat it as reusable. The doctor may
@@ -110,18 +120,18 @@ fi
 print_info "Creating PR worktree for PR #$PR_NUMBER..."
 print_info "  Path: $WORKTREE_PATH"
 
-# Create the worktree on a detached HEAD of origin/main, then run
+# Create the worktree on a detached HEAD of origin/<default-branch>, then run
 # `gh pr checkout` from inside it. This avoids ever touching the
 # orchestrator's main worktree HEAD.
 mkdir -p "$WORKTREE_ROOT_DIR"
 
-# Fetch origin/main so we have something to base the worktree on.
-git -C "$REPO_ROOT" fetch origin main >/dev/null 2>&1 || \
-    print_warning "Could not fetch origin/main (continuing)"
+# Fetch origin/<default-branch> so we have something to base the worktree on.
+git -C "$REPO_ROOT" fetch origin "$DEFAULT_BRANCH" >/dev/null 2>&1 || \
+    print_warning "Could not fetch origin/$DEFAULT_BRANCH (continuing)"
 
 # Use --detach so we don't create a stale branch ref. `gh pr checkout` will
 # switch to the PR's branch once we cd into the worktree.
-if ! git -C "$REPO_ROOT" worktree add --detach "$WORKTREE_PATH" origin/main 2>/dev/null; then
+if ! git -C "$REPO_ROOT" worktree add --detach "$WORKTREE_PATH" "origin/$DEFAULT_BRANCH" 2>/dev/null; then
     print_error "Failed to create worktree at $WORKTREE_PATH"
     exit 1
 fi

--- a/defaults/scripts/tests/test-default-branch.sh
+++ b/defaults/scripts/tests/test-default-branch.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# test-default-branch.sh — Tests for default-branch detection (#3549)
+#
+# Verifies defaults/scripts/lib/default-branch.sh :: loom_default_branch and its
+# integration into worktree.sh, which historically hardcoded `origin/main` and
+# broke on repos whose default branch is `master`.
+#
+# Coverage:
+#   1. LOOM_DEFAULT_BRANCH env override wins over everything.
+#   2. git symbolic-ref detection on a main-default repo -> "main".
+#   3. git symbolic-ref detection on a master-default repo -> "master".
+#   4. ls-remote --symref fallback when refs/remotes/origin/HEAD is unset.
+#   5. Local probe fallback (origin/HEAD unset AND remote unreachable) -> main/master.
+#   6. Hard-fail (non-zero, remediation on stderr) when undetectable — never a
+#      silent `main` default.
+#   7. Integration: worktree.sh creates a worktree on a master-default repo
+#      (branch based on origin/master, .loom-managed sentinel present).
+#
+# Pattern follows test-worktree-root-override.sh: throwaway bare origin + repo
+# in a mktemp dir, copy worktree.sh + lib/, run.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+WORKTREE_SH="$SCRIPTS_DIR/worktree.sh"
+DEFAULT_BRANCH_LIB="$SCRIPTS_DIR/lib/default-branch.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1)); echo -e "  ${RED}FAIL${NC}: $1"; }
+
+assert_eq() {
+    if [[ "$1" == "$2" ]]; then pass "$3"; else fail "$3 (expected '$2', got '$1')"; fi
+}
+assert_file() {
+    if [[ -f "$1" ]]; then pass "$2"; else fail "$2 (expected file: $1)"; fi
+}
+
+# Build a throwaway repo with a bare origin whose default branch is $2.
+# Echoes the working-tree path.
+setup_repo() {
+    local name="${1:-myrepo}"
+    local branch="${2:-main}"
+    local tmp
+    tmp=$(mktemp -d /tmp/loom-defbranch.XXXXXX)
+    git init -q -b "$branch" "$tmp/origin.git" --bare
+    git init -q -b "$branch" "$tmp/$name"
+    (
+        cd "$tmp/$name"
+        git config user.email t@t
+        git config user.name t
+        git commit --allow-empty -q -m init
+        git remote add origin "$tmp/origin.git"
+        git push -q origin "$branch"
+        # Populate refs/remotes/origin/HEAD (as a normal clone would have).
+        git remote set-head origin -a >/dev/null 2>&1 || true
+        mkdir -p .loom/scripts/lib .loom/hooks
+        cp "$WORKTREE_SH" .loom/scripts/worktree.sh
+        if [[ -d "$SCRIPTS_DIR/lib" ]]; then
+            cp -R "$SCRIPTS_DIR"/lib/* .loom/scripts/lib/ 2>/dev/null || true
+        fi
+        chmod +x .loom/scripts/worktree.sh
+    )
+    echo "$tmp/$name"
+}
+
+cleanup_repo() {
+    local repo="$1"
+    [[ -z "$repo" ]] && return 0
+    rm -rf "$(dirname "$repo")"
+}
+
+# shellcheck source=../lib/default-branch.sh
+source "$DEFAULT_BRANCH_LIB"
+
+# --- Test 1: env override wins ---
+echo "Test 1: LOOM_DEFAULT_BRANCH env override"
+REPO=$(setup_repo envrepo master)
+(
+    cd "$REPO"
+    # Even though this repo is master-default, the env override must win.
+    r=$(LOOM_DEFAULT_BRANCH="develop" loom_default_branch)
+    [[ "$r" == "develop" ]] && echo OK || echo "GOT:$r"
+) | grep -q OK && pass "env override returns 'develop'" || fail "env override ignored"
+cleanup_repo "$REPO"
+
+# --- Test 2: symbolic-ref on a main-default repo ---
+echo ""
+echo "Test 2: symbolic-ref detection (main-default repo)"
+REPO=$(setup_repo mainrepo main)
+r=$(cd "$REPO" && unset LOOM_DEFAULT_BRANCH; loom_default_branch)
+assert_eq "$r" "main" "main-default repo resolves to 'main'"
+cleanup_repo "$REPO"
+
+# --- Test 3: symbolic-ref on a master-default repo ---
+echo ""
+echo "Test 3: symbolic-ref detection (master-default repo)"
+REPO=$(setup_repo masterrepo master)
+r=$(cd "$REPO" && unset LOOM_DEFAULT_BRANCH; loom_default_branch)
+assert_eq "$r" "master" "master-default repo resolves to 'master'"
+cleanup_repo "$REPO"
+
+# --- Test 4: ls-remote --symref fallback when origin/HEAD is unset ---
+echo ""
+echo "Test 4: ls-remote --symref fallback (origin/HEAD unset)"
+REPO=$(setup_repo lsremoterepo master)
+(
+    cd "$REPO"
+    # Remove the local symbolic ref so tier 2 misses and tier 3 (ls-remote) fires.
+    git symbolic-ref -d refs/remotes/origin/HEAD >/dev/null 2>&1 || true
+)
+r=$(cd "$REPO" && unset LOOM_DEFAULT_BRANCH; loom_default_branch)
+assert_eq "$r" "master" "ls-remote fallback resolves master when origin/HEAD unset"
+cleanup_repo "$REPO"
+
+# --- Test 5: local probe fallback (origin/HEAD unset AND remote unreachable) ---
+echo ""
+echo "Test 5: local probe fallback (no origin/HEAD, remote gone)"
+REPO=$(setup_repo proberepo master)
+(
+    cd "$REPO"
+    git symbolic-ref -d refs/remotes/origin/HEAD >/dev/null 2>&1 || true
+    # Point origin at a dead path so ls-remote fails; the remote-tracking ref
+    # refs/remotes/origin/master still exists locally for the probe tier.
+    git remote set-url origin /nonexistent/loom-dead-remote.git
+)
+r=$(cd "$REPO" && unset LOOM_DEFAULT_BRANCH; loom_default_branch)
+assert_eq "$r" "master" "local probe resolves master via refs/remotes/origin/master"
+cleanup_repo "$REPO"
+
+# --- Test 6: hard-fail when undetectable (no silent main default) ---
+echo ""
+echo "Test 6: hard-fail when the default branch cannot be determined"
+HARD=$(mktemp -d /tmp/loom-defbranch-hard.XXXXXX)
+(
+    cd "$HARD"
+    git init -q "$HARD/repo"
+    cd "$HARD/repo"
+    git config user.email t@t
+    git config user.name t
+    # No remote at all: no origin/HEAD, no ls-remote, no refs/remotes/origin/*.
+    git remote add origin /nonexistent/loom-dead.git
+)
+if (cd "$HARD/repo" && unset LOOM_DEFAULT_BRANCH; loom_default_branch >/dev/null 2>&1); then
+    fail "hard-fail case unexpectedly succeeded (silent default?)"
+else
+    pass "returns non-zero when default branch is undetectable"
+fi
+# Remediation hint must reach stderr. Capture stderr into a var first so
+# pipefail doesn't fold loom_default_branch's intentional exit-1 into a grep
+# pipeline (which would mask a matching hint).
+hint_stderr=$(cd "$HARD/repo" && unset LOOM_DEFAULT_BRANCH; loom_default_branch 2>&1 >/dev/null || true)
+if grep -q "LOOM_DEFAULT_BRANCH" <<<"$hint_stderr"; then
+    pass "hard-fail emits a remediation hint on stderr"
+else
+    fail "hard-fail did not emit remediation hint"
+fi
+rm -rf "$HARD"
+
+# --- Test 7: integration — worktree.sh on a master-default repo ---
+echo ""
+echo "Test 7: worktree.sh creates a worktree on a master-default repo"
+REPO=$(setup_repo wtmaster master)
+(
+    cd "$REPO"
+    unset LOOM_DEFAULT_BRANCH
+    ./.loom/scripts/worktree.sh 700 >/tmp/defbranch-wt.$$ 2>&1 || {
+        echo "worktree.sh failed (see below):"; cat /tmp/defbranch-wt.$$
+    }
+)
+if [[ -d "$REPO/.loom/worktrees/issue-700" ]]; then
+    pass "worktree created on master-default repo"
+else
+    fail "worktree NOT created on master-default repo"
+fi
+assert_file "$REPO/.loom/worktrees/issue-700/.loom-managed" "worktree carries .loom-managed sentinel"
+# The feature branch must be based on origin/master's tip.
+if [[ -d "$REPO/.loom/worktrees/issue-700" ]]; then
+    base=$(git -C "$REPO" rev-parse origin/master 2>/dev/null)
+    head=$(git -C "$REPO/.loom/worktrees/issue-700" rev-parse HEAD 2>/dev/null)
+    assert_eq "$head" "$base" "feature branch based on origin/master tip"
+fi
+rm -f "/tmp/defbranch-wt.$$"
+cleanup_repo "$REPO"
+
+# --- Summary ---
+echo ""
+echo "Tests run: $TESTS_RUN, Passed: $TESTS_PASSED, Failed: $TESTS_FAILED"
+[[ $TESTS_FAILED -eq 0 ]] || exit 1

--- a/defaults/scripts/worktree.sh
+++ b/defaults/scripts/worktree.sh
@@ -34,6 +34,12 @@ LOOM_WORKTREE_ALWAYS_INCLUDE_DEFAULT=(.claude .loom .githooks scripts)
 # shellcheck source=lib/worktree-root.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/worktree-root.sh"
 
+# Shared default-branch resolver (env var / symbolic-ref / ls-remote / probe).
+# Sourced so worktree base operations work on repos whose default branch is not
+# `main` (e.g. `master`) without hardcoding `origin/main` everywhere (#3549).
+# shellcheck source=lib/default-branch.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/default-branch.sh"
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -373,20 +379,22 @@ log_worktree_size() {
     fi
 }
 
-# Function to fetch latest changes from origin/main
-# Uses fetch-only approach to avoid conflicts with worktrees that have main checked out
+# Function to fetch latest changes from the default branch
+# Uses fetch-only approach to avoid conflicts with worktrees that have the
+# default branch checked out. Relies on the global DEFAULT_BRANCH (resolved via
+# loom_default_branch before this is called).
 fetch_latest_main() {
     if [[ "$JSON_OUTPUT" != "true" ]]; then
-        print_info "Fetching latest changes from origin/main..."
+        print_info "Fetching latest changes from origin/$DEFAULT_BRANCH..."
     fi
 
-    if git fetch origin main 2>/dev/null; then
+    if git fetch origin "$DEFAULT_BRANCH" 2>/dev/null; then
         if [[ "$JSON_OUTPUT" != "true" ]]; then
-            print_success "Fetched latest origin/main"
+            print_success "Fetched latest origin/$DEFAULT_BRANCH"
         fi
     else
         if [[ "$JSON_OUTPUT" != "true" ]]; then
-            print_warning "Could not fetch origin/main (continuing with local state)"
+            print_warning "Could not fetch origin/$DEFAULT_BRANCH (continuing with local state)"
         fi
     fi
 }
@@ -785,8 +793,21 @@ if [[ -n "$PRUNE_OUTPUT" ]]; then
     fi
 fi
 
-# Fetch latest changes from origin/main before creating the worktree
-# Uses fetch-only to avoid conflicts with worktrees that have main checked out
+# Resolve the repo's default branch once (cwd is now the main workspace, so
+# git symbolic-ref sees refs/remotes/origin/HEAD). Hard-fail rather than proceed
+# with an empty/wrong branch — an empty `origin/` refspec is worse than the
+# original bug (#3549).
+if ! DEFAULT_BRANCH="$(loom_default_branch)"; then
+    if [[ "$JSON_OUTPUT" == "true" ]]; then
+        echo '{"success": false, "error": "Could not determine the default branch (see stderr; set LOOM_DEFAULT_BRANCH or run: git remote set-head origin -a)"}' >&3
+    else
+        print_error "Could not determine the default branch. Set LOOM_DEFAULT_BRANCH or run: git remote set-head origin -a"
+    fi
+    exit 1
+fi
+
+# Fetch latest changes from origin/$DEFAULT_BRANCH before creating the worktree
+# Uses fetch-only to avoid conflicts with worktrees that have it checked out
 fetch_latest_main
 
 # Determine branch name
@@ -863,8 +884,8 @@ if [[ -d "$WORKTREE_PATH" ]]; then
     # Check if it's registered with git
     if git worktree list | grep -q "$WORKTREE_PATH"; then
         # Check if worktree is stale: no commits ahead of main and behind main
-        local_commits_ahead=$(git -C "$WORKTREE_PATH" rev-list --count "origin/main..HEAD" 2>/dev/null) || local_commits_ahead="0"
-        local_commits_behind=$(git -C "$WORKTREE_PATH" rev-list --count "HEAD..origin/main" 2>/dev/null) || local_commits_behind="0"
+        local_commits_ahead=$(git -C "$WORKTREE_PATH" rev-list --count "origin/$DEFAULT_BRANCH..HEAD" 2>/dev/null) || local_commits_ahead="0"
+        local_commits_behind=$(git -C "$WORKTREE_PATH" rev-list --count "HEAD..origin/$DEFAULT_BRANCH" 2>/dev/null) || local_commits_behind="0"
         local_uncommitted=$(git -C "$WORKTREE_PATH" status --porcelain 2>/dev/null) || local_uncommitted=""
 
         if [[ "$local_commits_ahead" -gt 0 || -n "$local_uncommitted" ]]; then
@@ -887,18 +908,18 @@ if [[ -d "$WORKTREE_PATH" ]]; then
             # Stale worktree: no commits ahead, no uncommitted changes
             # Reset in place instead of removing (avoids CWD corruption)
             if [[ "$JSON_OUTPUT" != "true" ]]; then
-                print_warning "Stale worktree detected (0 commits ahead, $local_commits_behind behind main, no uncommitted changes)"
-                print_info "Resetting worktree in place to origin/main..."
+                print_warning "Stale worktree detected (0 commits ahead, $local_commits_behind behind $DEFAULT_BRANCH, no uncommitted changes)"
+                print_info "Resetting worktree in place to origin/$DEFAULT_BRANCH..."
             fi
 
             # Back-fill/refresh the Loom sentinel on both reset outcomes: the
             # worktree remains usable either way, so keep it cleanup-eligible
             # (#3548).
             write_loom_sentinel "$WORKTREE_PATH"
-            if git -C "$WORKTREE_PATH" fetch origin main 2>/dev/null && \
-               git -C "$WORKTREE_PATH" reset --hard origin/main 2>/dev/null; then
+            if git -C "$WORKTREE_PATH" fetch origin "$DEFAULT_BRANCH" 2>/dev/null && \
+               git -C "$WORKTREE_PATH" reset --hard "origin/$DEFAULT_BRANCH" 2>/dev/null; then
                 if [[ "$JSON_OUTPUT" != "true" ]]; then
-                    print_success "Stale worktree reset to origin/main"
+                    print_success "Stale worktree reset to origin/$DEFAULT_BRANCH"
                     echo ""
                     print_info "To use this worktree: cd $WORKTREE_PATH"
                 fi
@@ -933,11 +954,11 @@ if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
 
     CREATE_ARGS=("$WORKTREE_PATH" "$BRANCH_NAME")
 else
-    # Create new branch from main
+    # Create new branch from the default branch
     if [[ "$JSON_OUTPUT" != "true" ]]; then
-        print_info "Creating new branch from main"
+        print_info "Creating new branch from $DEFAULT_BRANCH"
     fi
-    CREATE_ARGS=("$WORKTREE_PATH" "-b" "$BRANCH_NAME" "origin/main")
+    CREATE_ARGS=("$WORKTREE_PATH" "-b" "$BRANCH_NAME" "origin/$DEFAULT_BRANCH")
 fi
 
 # In sparse mode, defer file materialization until after we configure the cone.
@@ -987,8 +1008,8 @@ _handle_feature_branch_in_main_worktree() {
             echo ""
             echo "  The branch is in use elsewhere. To free it, find the worktree with:"
             echo "    git worktree list"
-            echo "  Then switch that worktree to main:"
-            echo "    cd <worktree-path> && git checkout main"
+            echo "  Then switch that worktree to $DEFAULT_BRANCH:"
+            echo "    cd <worktree-path> && git checkout $DEFAULT_BRANCH"
         fi
         return 0  # Handled (with human-readable message), no retry possible
     fi
@@ -1011,7 +1032,7 @@ _handle_feature_branch_in_main_worktree() {
             echo "  Branch is already checked out at: $conflict_path"
             echo ""
             echo "  To fix:"
-            echo "    cd $conflict_path && git checkout main"
+            echo "    cd $conflict_path && git checkout $DEFAULT_BRANCH"
         fi
         return 0  # Handled (with error message), no retry
     fi
@@ -1030,28 +1051,29 @@ _handle_feature_branch_in_main_worktree() {
             echo "  To fix manually:"
             echo "    cd $abs_conflict"
             echo "    git stash  # or commit your changes"
-            echo "    git checkout main"
+            echo "    git checkout $DEFAULT_BRANCH"
             echo "  Then rerun: ./.loom/scripts/worktree.sh $ISSUE_NUMBER"
         fi
         return 0  # Handled (with error message), no retry
     fi
 
-    # Main workspace is clean — auto-switch to main and signal caller to retry
+    # Main workspace is clean — auto-switch to the default branch and signal
+    # caller to retry.
     if [[ "$JSON_OUTPUT" != "true" ]]; then
         print_warning "Branch '$branch' is checked out in the main worktree."
-        print_info "Main worktree is clean — auto-switching to main branch..."
+        print_info "Main worktree is clean — auto-switching to $DEFAULT_BRANCH branch..."
     fi
 
-    if git -C "$abs_conflict" checkout main 2>/dev/null; then
+    if git -C "$abs_conflict" checkout "$DEFAULT_BRANCH" 2>/dev/null; then
         if [[ "$JSON_OUTPUT" != "true" ]]; then
-            print_success "Main worktree switched to main branch"
+            print_success "Main worktree switched to $DEFAULT_BRANCH branch"
         fi
         return 2  # Signal: auto-recovered, caller should retry
     else
         if [[ "$JSON_OUTPUT" != "true" ]]; then
-            print_error "Failed to switch main worktree to main branch."
+            print_error "Failed to switch main worktree to $DEFAULT_BRANCH branch."
             echo "  To fix manually:"
-            echo "    cd $abs_conflict && git checkout main"
+            echo "    cd $abs_conflict && git checkout $DEFAULT_BRANCH"
             echo "  Then rerun: ./.loom/scripts/worktree.sh $ISSUE_NUMBER"
         fi
         return 0  # Handled (with error message), no retry


### PR DESCRIPTION
Closes #3549

## Problem

Both worktree helpers hardcoded the base branch as the literal string `main` / `origin/main`. On a repo whose default branch is `master` (or any non-`main` name), every git call referencing `origin/main` failed with `fatal: invalid reference: origin/main`, so worktree creation aborted. No default-branch detection existed in Loom's shell layer.

## Fix

New helper `defaults/scripts/lib/default-branch.sh` exposing `loom_default_branch [remote]` with an offline-first, hard-fail detection order:

1. `LOOM_DEFAULT_BRANCH` env override (escape hatch / test seam)
2. `git symbolic-ref --short refs/remotes/<remote>/HEAD` (offline, no network, forge-agnostic)
3. `git ls-remote --symref <remote> HEAD` (network fallback when origin/HEAD unset)
4. Local probe of `refs/remotes/<remote>/main` then `/master`
5. Hard error with remediation hint — **never** a silent `main` default

`git symbolic-ref` is preferred over `gh repo view` so detection works on Gitea too and needs no network or `gh` auth.

Both scripts resolve the branch once near the top and substitute at every load-bearing site:

- `worktree.sh`: fetch, rev-list stale-check (ahead/behind), stale reset, new-branch base, checkout auto-recovery. Cosmetic remediation hints interpolate the resolved branch too.
- `pr-worktree.sh`: fetch + `worktree add --detach origin/<branch>`.

Callers hard-fail with a clear error rather than proceeding with an empty `origin/` refspec.

## Tests

New `defaults/scripts/tests/test-default-branch.sh` (10 assertions, all pass):
env override, symbolic-ref on main + master repos, ls-remote fallback, local probe fallback, hard-fail (non-zero + stderr remediation hint), and an end-to-end `worktree.sh` run on a master-default repo (branch based on `origin/master`, sentinel present).

Existing worktree tests (root-override 18, sentinel 10, pr-isolation 22, concurrency 6) still pass. `shellcheck --severity=warning` clean across all of `defaults/scripts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)