### PR TITLE
feat(guard): per-project opt-out for SQL DDL/DML blocking (#3552)

### DIFF
--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -902,6 +902,40 @@ If setup fails, it's usually due to:
 
 Loom ships with built-in guard hooks (`guard-destructive.sh` for dangerous Bash commands). You can add project-specific guards to protect read-only directories from accidental edits.
 
+### SQL DDL/DML Guard Opt-Out (`guards.sqlDdl` / `LOOM_GUARD_SQL`)
+
+`guard-destructive.sh` blocks SQL DDL/DML patterns — `DROP DATABASE`, `DROP TABLE`, `DROP SCHEMA`, `TRUNCATE TABLE`, and `DELETE FROM` without a `WHERE` clause. For most repos this is a useful safety net, but for a project that is **itself a database engine** (e.g. a SQLite-compatible engine running a SQL conformance suite) those statements are the product's own dev/test vocabulary and the guard is a category error — the match is a case-insensitive substring, so it even fires when the words appear in a comment or a `--description` label.
+
+Such repos can opt out of the SQL guard while keeping every other guard (`rm -rf /`, force-push to `main`, `gh repo delete`, `aws ec2 terminate`, `aws s3 rb`, etc.) fully active.
+
+The SQL guard is **on by default**. It is resolved in this order (highest precedence first):
+
+1. **`LOOM_GUARD_SQL` env var** — `0`/`false`/`no` disables the SQL guard; `1`/`true`/`yes` forces it on. Overrides the config value.
+2. **`.loom/config.json`** — `guards.sqlDdl` (default `true` when absent). Set it to `false` to disable:
+   ```json
+   {
+     "guards": {
+       "sqlDdl": false
+     }
+   }
+   ```
+3. **Default** — `true` (guard on).
+
+The config read is best-effort: a missing, empty, or malformed `.loom/config.json` falls through to guard-ON and never causes the hook to exit non-zero. Only the SQL DDL/DML blocks are affected — disabling the SQL guard does not weaken any other guard.
+
+**Examples**:
+
+```bash
+# Disable the SQL guard for a single command (e.g. a one-off dev query)
+LOOM_GUARD_SQL=0 vibesql -c "DROP TABLE t"
+
+# Persist the opt-out for the whole repo
+#   .loom/config.json  ->  { "guards": { "sqlDdl": false } }
+
+# Force the SQL guard on for one command even when the repo opts out
+LOOM_GUARD_SQL=1 psql -c "DROP TABLE users"
+```
+
 ### Protecting Read-Only Directories
 
 Many projects have directories that should never be modified by agents (vendor code, generated files, external SDKs, process design kits). Loom provides a template hook for this.

--- a/defaults/hooks/guard-destructive.sh
+++ b/defaults/hooks/guard-destructive.sh
@@ -74,6 +74,49 @@ elif [[ -n "$CWD" ]]; then
     log_hook_error "cwd does not exist: $CWD — skipping repo root resolution"
 fi
 
+# =============================================================================
+# SQL DDL/DML guard toggle — default ON.
+#
+# The SQL DDL/DML blocks (DROP DATABASE/TABLE/SCHEMA, TRUNCATE TABLE, and
+# DELETE FROM without WHERE) are a category error for repos that are themselves
+# database engines, where those statements are the product's own dev/test
+# vocabulary. Such repos opt out; everyone else keeps the guard on.
+#
+# Resolution order (highest precedence first):
+#   1. LOOM_GUARD_SQL env var (0/false/no disables, 1/true/yes forces on)
+#   2. .loom/config.json  ->  guards.sqlDdl  (default true when absent)
+#   3. Default: true (guard on)
+#
+# The resolution runs LAZILY — sql_guard_enabled() is only invoked once a
+# command has already matched a SQL DDL/DML pattern, so the jq config read never
+# touches the hot path for the ~99% of commands that are not SQL. The result is
+# cached so a command matching multiple SQL patterns pays for at most one read.
+#
+# The config read is best-effort: any parse failure falls through to guard-ON
+# and never trips the ERR trap or produces a non-zero exit.
+# =============================================================================
+_SQL_GUARD_CACHE=""
+sql_guard_enabled() {
+    if [[ -z "$_SQL_GUARD_CACHE" ]]; then
+        local enabled=true
+        if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/config.json" ]]; then
+            # jq // is alternative-on-null, not default-on-missing, so use
+            # if/then/else to treat only an explicit `false` as disabled (a
+            # missing guards.sqlDdl key stays on). On malformed JSON jq exits
+            # non-zero and the `||` fallback restores the guard-ON default.
+            enabled=$(jq -r 'if .guards.sqlDdl == false then "false" else "true" end' "$REPO_ROOT/.loom/config.json" 2>/dev/null) || enabled=true
+            [[ -n "$enabled" ]] || enabled=true
+        fi
+        # Env override wins over config.
+        case "${LOOM_GUARD_SQL:-}" in
+            0|false|no)  enabled=false ;;
+            1|true|yes)  enabled=true ;;
+        esac
+        _SQL_GUARD_CACHE="$enabled"
+    fi
+    [[ "$_SQL_GUARD_CACHE" == "true" ]]
+}
+
 # Helper: output a deny decision and exit
 deny() {
     local reason="$1"
@@ -164,12 +207,6 @@ ALWAYS_BLOCK_PATTERNS=(
     'poweroff'
     'init 0'
     'init 6'
-
-    # Database destruction
-    'DROP DATABASE'
-    'DROP TABLE'
-    'DROP SCHEMA'
-    'TRUNCATE TABLE'
 )
 
 for pattern in "${ALWAYS_BLOCK_PATTERNS[@]}"; do
@@ -177,6 +214,21 @@ for pattern in "${ALWAYS_BLOCK_PATTERNS[@]}"; do
         deny "BLOCKED: Command matches dangerous pattern: $pattern"
     fi
 done
+
+# =============================================================================
+# DATABASE DESTRUCTION - Gated by the SQL DDL/DML guard toggle
+#
+# Kept separate from ALWAYS_BLOCK_PATTERNS so DB-engine repos can opt out
+# (guards.sqlDdl:false / LOOM_GUARD_SQL=0). A single alternation grep matches
+# all four DDL statements in one pass (cheaper than a per-pattern loop), and
+# sql_guard_enabled() is consulted only after a match, so the config read stays
+# off the hot path.
+# =============================================================================
+SQL_DDL_PATTERN='DROP DATABASE|DROP TABLE|DROP SCHEMA|TRUNCATE TABLE'
+if echo "$COMMAND" | grep -qiE "$SQL_DDL_PATTERN" && sql_guard_enabled; then
+    matched=$(echo "$COMMAND" | grep -oiE "$SQL_DDL_PATTERN" | head -1)
+    deny "BLOCKED: Command matches dangerous pattern: ${matched:-SQL DDL statement}"
+fi
 
 # =============================================================================
 # rm -rf SCOPE CHECK - Block rm with recursive/force flags outside repo
@@ -245,9 +297,13 @@ fi
 # DELETE without WHERE - Database safety
 # =============================================================================
 
+# Gated by the SQL DDL/DML guard toggle. DB-engine repos opt out via
+# guards.sqlDdl:false or LOOM_GUARD_SQL=0. sql_guard_enabled() is consulted only
+# after the DELETE-FROM-without-WHERE match, keeping the config read off the hot
+# path for non-SQL commands.
 if echo "$COMMAND" | grep -qiE 'DELETE\s+FROM\s+' && \
    ! echo "$COMMAND" | grep -qiE 'WHERE\s+'; then
-    deny "BLOCKED: DELETE FROM without WHERE clause"
+    sql_guard_enabled && deny "BLOCKED: DELETE FROM without WHERE clause"
 fi
 
 # =============================================================================

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -1,16 +1,20 @@
 #!/usr/bin/env bash
-# Test suite for .loom/hooks/guard-destructive.sh
+# Test suite for defaults/hooks/guard-destructive.sh
 #
 # Usage: ./tests/hooks/test-guard-destructive.sh
 #
 # Tests the PreToolUse guard hook against various command patterns.
 # Exit code 0 = all tests pass, 1 = failures detected.
+#
+# The guard under test is the canonical source at defaults/hooks/ (the
+# version-controlled source of truth), NOT the gitignored .loom/hooks/ install
+# artifact — so the suite validates exactly what ships.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-GUARD="$REPO_ROOT/.loom/hooks/guard-destructive.sh"
+GUARD="$REPO_ROOT/defaults/hooks/guard-destructive.sh"
 
 PASS=0
 FAIL=0
@@ -55,6 +59,77 @@ run_guard_in_worktree() {
     exit_code=${exit_code:-0}
     echo "$output"
     return $exit_code
+}
+
+# --- SQL opt-out helpers (guards.sqlDdl / LOOM_GUARD_SQL) ---
+
+# Create a throwaway git repo whose .loom/config.json holds the given JSON.
+# Echoes the repo path (which becomes the guard's cwd / resolved REPO_ROOT).
+# NB: callers invoke this via command substitution (a subshell), so this must
+# not try to record state in the parent — cleanup is done by path at the end.
+make_sql_repo() {
+    local config_json="$1"
+    local dir
+    dir=$(mktemp -d 2>/dev/null)
+    git -C "$dir" init -q >/dev/null 2>&1
+    mkdir -p "$dir/.loom"
+    printf '%s' "$config_json" > "$dir/.loom/config.json"
+    echo "$dir"
+}
+
+# Run the guard with an optional env assignment (e.g. "LOOM_GUARD_SQL=0").
+run_guard_env() {
+    local env_kv="$1"
+    local cmd="$2"
+    local cwd="${3:-$REPO_ROOT}"
+    local output
+    local exit_code=0
+    if [[ -n "$env_kv" ]]; then
+        output=$(make_input "$cmd" "$cwd" | env "$env_kv" "$GUARD" 2>&1) || exit_code=$?
+    else
+        output=$(make_input "$cmd" "$cwd" | "$GUARD" 2>&1) || exit_code=$?
+    fi
+    echo "$output"
+    return $exit_code
+}
+
+# Assert deny with an env assignment + cwd (repo root).
+assert_deny_env() {
+    local description="$1"; local env_kv="$2"; local cmd="$3"; local cwd="${4:-$REPO_ROOT}"
+    TOTAL=$((TOTAL + 1))
+    local output
+    output=$(run_guard_env "$env_kv" "$cmd" "$cwd") || true
+    if echo "$output" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' >/dev/null 2>&1; then
+        PASS=$((PASS + 1))
+        echo -e "  ${GREEN}PASS${NC}: $description"
+    else
+        FAIL=$((FAIL + 1))
+        echo -e "  ${RED}FAIL${NC}: $description"
+        echo -e "       Command: $cmd (env: ${env_kv:-none}, cwd: $cwd)"
+        echo -e "       Expected: deny"
+        echo -e "       Got: $output"
+    fi
+}
+
+# Assert allow (exit 0, no decision) with an env assignment + cwd.
+assert_allow_env() {
+    local description="$1"; local env_kv="$2"; local cmd="$3"; local cwd="${4:-$REPO_ROOT}"
+    TOTAL=$((TOTAL + 1))
+    local output
+    local exit_code=0
+    output=$(run_guard_env "$env_kv" "$cmd" "$cwd") || exit_code=$?
+    if [[ $exit_code -eq 0 ]] && \
+       ! echo "$output" | jq -e '.hookSpecificOutput.permissionDecision' >/dev/null 2>&1; then
+        PASS=$((PASS + 1))
+        echo -e "  ${GREEN}PASS${NC}: $description"
+    else
+        FAIL=$((FAIL + 1))
+        echo -e "  ${RED}FAIL${NC}: $description"
+        echo -e "       Command: $cmd (env: ${env_kv:-none}, cwd: $cwd)"
+        echo -e "       Expected: allow (exit 0, no decision)"
+        echo -e "       Exit code: $exit_code"
+        echo -e "       Got: $output"
+    fi
 }
 
 # Assert the guard denies a command when inside a worktree
@@ -485,6 +560,90 @@ assert_allow "Allow pip install -e outside worktree" \
 
 assert_allow "Allow pip install -e ./loom-tools outside worktree" \
     "pip install -e ./loom-tools"
+
+echo ""
+
+# =========================================================================
+echo -e "${YELLOW}--- SQL DDL/DML opt-out (guards.sqlDdl / LOOM_GUARD_SQL) ---${NC}"
+# =========================================================================
+
+# Repo with the SQL guard explicitly disabled via .loom/config.json.
+SQL_OFF_REPO=$(make_sql_repo '{"guards":{"sqlDdl":false}}')
+# Repo with the SQL guard explicitly enabled via .loom/config.json.
+SQL_ON_REPO=$(make_sql_repo '{"guards":{"sqlDdl":true}}')
+# Repo whose config has no guards key at all — must default to guard ON.
+SQL_ABSENT_REPO=$(make_sql_repo '{"champion":{"auto_merge_max_lines":200}}')
+# Repo with malformed config — must fall through to guard ON.
+SQL_BAD_REPO=$(make_sql_repo '{ this is not valid json ')
+
+# --- Non-regression: guard ON by default still blocks all five SQL cases ---
+assert_deny "SQL default-on: block DROP DATABASE (config guards absent)" \
+    "psql -c 'DROP DATABASE mydb;'" "$SQL_ABSENT_REPO"
+assert_deny "SQL default-on: block DROP TABLE (config guards absent)" \
+    "mysql -e 'DROP TABLE users;'" "$SQL_ABSENT_REPO"
+assert_deny "SQL default-on: block DROP SCHEMA (config guards absent)" \
+    "psql -c 'DROP SCHEMA public CASCADE;'" "$SQL_ABSENT_REPO"
+assert_deny "SQL default-on: block TRUNCATE TABLE (config guards absent)" \
+    "psql -c 'TRUNCATE TABLE users;'" "$SQL_ABSENT_REPO"
+assert_deny "SQL default-on: block DELETE FROM without WHERE (config guards absent)" \
+    "psql -c 'DELETE FROM users;'" "$SQL_ABSENT_REPO"
+
+# --- Non-regression: explicit guards.sqlDdl:true still blocks ---
+assert_deny "SQL config-on: block DROP TABLE" \
+    "mysql -e 'DROP TABLE users;'" "$SQL_ON_REPO"
+assert_deny "SQL config-on: block DELETE FROM without WHERE" \
+    "psql -c 'DELETE FROM users;'" "$SQL_ON_REPO"
+
+# --- Non-regression: malformed config falls through to guard ON ---
+assert_deny "SQL malformed-config: block DROP TABLE (fall through to on)" \
+    "mysql -e 'DROP TABLE users;'" "$SQL_BAD_REPO"
+assert_deny "SQL malformed-config: block DELETE FROM without WHERE" \
+    "psql -c 'DELETE FROM users;'" "$SQL_BAD_REPO"
+
+# --- Opt-out via config: all five SQL cases pass through as allow ---
+assert_allow "SQL config-off: allow DROP DATABASE" \
+    "psql -c 'DROP DATABASE mydb;'" "$SQL_OFF_REPO"
+assert_allow "SQL config-off: allow DROP TABLE" \
+    "mysql -e 'DROP TABLE users;'" "$SQL_OFF_REPO"
+assert_allow "SQL config-off: allow DROP SCHEMA" \
+    "psql -c 'DROP SCHEMA public CASCADE;'" "$SQL_OFF_REPO"
+assert_allow "SQL config-off: allow TRUNCATE TABLE" \
+    "psql -c 'TRUNCATE TABLE users;'" "$SQL_OFF_REPO"
+assert_allow "SQL config-off: allow DELETE FROM without WHERE" \
+    "psql -c 'DELETE FROM users;'" "$SQL_OFF_REPO"
+
+# --- Opt-out must NOT weaken non-SQL guards ---
+assert_deny "SQL config-off: rm -rf / still blocked" \
+    "rm -rf /" "$SQL_OFF_REPO"
+assert_deny "SQL config-off: force-push to main still blocked" \
+    "git push --force origin main" "$SQL_OFF_REPO"
+assert_deny "SQL config-off: gh repo delete still blocked" \
+    "gh repo delete myrepo --yes" "$SQL_OFF_REPO"
+assert_deny "SQL config-off: aws ec2 terminate still blocked" \
+    "aws ec2 terminate-instances --instance-ids i-1234" "$SQL_OFF_REPO"
+assert_deny "SQL config-off: aws s3 rb still blocked" \
+    "aws s3 rb s3://my-bucket --force" "$SQL_OFF_REPO"
+
+# --- Env override: LOOM_GUARD_SQL=0 disables even when config says true ---
+assert_allow_env "LOOM_GUARD_SQL=0 overrides config-on: allow DROP TABLE" \
+    "LOOM_GUARD_SQL=0" "mysql -e 'DROP TABLE users;'" "$SQL_ON_REPO"
+assert_allow_env "LOOM_GUARD_SQL=0 overrides config-on: allow DELETE FROM without WHERE" \
+    "LOOM_GUARD_SQL=0" "psql -c 'DELETE FROM users;'" "$SQL_ON_REPO"
+
+# --- Env override: LOOM_GUARD_SQL=1 forces on even when config says false ---
+assert_deny_env "LOOM_GUARD_SQL=1 overrides config-off: block DROP TABLE" \
+    "LOOM_GUARD_SQL=1" "mysql -e 'DROP TABLE users;'" "$SQL_OFF_REPO"
+assert_deny_env "LOOM_GUARD_SQL=1 overrides config-off: block DELETE FROM without WHERE" \
+    "LOOM_GUARD_SQL=1" "psql -c 'DELETE FROM users;'" "$SQL_OFF_REPO"
+
+# --- Env override: LOOM_GUARD_SQL=0 still doesn't weaken non-SQL guards ---
+assert_deny_env "LOOM_GUARD_SQL=0: rm -rf / still blocked" \
+    "LOOM_GUARD_SQL=0" "rm -rf /" "$SQL_ON_REPO"
+
+# Clean up temp repos created above.
+for _sql_dir in "$SQL_OFF_REPO" "$SQL_ON_REPO" "$SQL_ABSENT_REPO" "$SQL_BAD_REPO"; do
+    [[ -n "$_sql_dir" && "$_sql_dir" != "/" && -d "$_sql_dir/.loom" ]] && rm -rf "$_sql_dir"
+done
 
 echo ""
 


### PR DESCRIPTION
Closes #3552

## Summary

`guard-destructive.sh` hard-blocks SQL DDL/DML patterns (`DROP DATABASE`, `DROP TABLE`, `DROP SCHEMA`, `TRUNCATE TABLE`, and `DELETE FROM` without `WHERE`). For a repo that is **itself a database engine**, those statements are the product's own dev/test vocabulary — and because the match is a case-insensitive substring, the guard even fires on comments and `--description` label text. This adds a per-project opt-out.

## Design

A single boolean gate, **default ON** (safe for the ~99% of repos that are not DB engines). Resolution order (highest precedence first):

1. `LOOM_GUARD_SQL` env var — `0`/`false`/`no` disables, `1`/`true`/`yes` forces on
2. `.loom/config.json` → `guards.sqlDdl` (default `true` when absent)
3. Default `true`

- Config read is best-effort via `jq` (`if/then/else` so a missing key stays on; malformed/empty JSON falls through to guard-ON). Preserves the never-exit-nonzero / ERR-trap contract.
- Resolution is **lazy + cached**: `sql_guard_enabled()` is only consulted after a command matches a SQL pattern, so the `jq` read never touches the hot path for non-SQL commands. The four DDL statements now match via a single alternation grep (hot-path cost is neutral vs the pre-change guard).
- Both SQL blocks are gated (the four `ALWAYS_BLOCK` DDL entries and the standalone `DELETE FROM`-without-`WHERE` block). **Only** the SQL blocks — every other guard (`rm -rf /`, force-push to `main`, `gh repo delete`, `aws ec2 terminate`, `aws s3 rb`, …) is unaffected.

Scope is limited to the SQL opt-out; the AWS-`ASK` and `git checkout .` items from the issue body are deliberately left for a separate follow-up.

## Files changed

- `defaults/hooks/guard-destructive.sh` — lazy `sql_guard_enabled()` gate; split DB patterns out of `ALWAYS_BLOCK_PATTERNS`; gate the `DELETE FROM` block.
- `tests/hooks/test-guard-destructive.sh` — point the harness at the canonical `defaults/hooks/` source (was the gitignored `.loom/hooks/` install artifact, which was stale) and add 24 opt-out / env-override / malformed-config / non-regression cases.
- `defaults/CLAUDE.md` — document `guards.sqlDdl` + `LOOM_GUARD_SQL` under "Custom Guard Hooks".

## Tests

`bash tests/hooks/test-guard-destructive.sh` — 116/117 functional assertions pass, including all 24 new SQL opt-out cases. The single failure is the environmental performance check (200ms threshold): under load the pristine `main` guard also benchmarks 210-230ms, and this change is performance-neutral vs pristine on the non-SQL hot path.