### PR TITLE
feat(sweep): resource-gated automatic wave-size default (#3566)

### DIFF
--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -111,14 +111,14 @@ Combine flags as needed. Always pass `--state open` explicitly (Mode C operates 
 
 ### Optional flags
 
-- **`--builders-per-wave N`** — dispatch up to `N` builders in parallel per wave. Default `1` (fully sequential, matching the MVP behaviour). `N` must be an integer `>= 1`. Honoured in Modes A and B (issue-side); **silently ignored in Mode C** (PR-set mode has no Builder phase — see Mode C validation rules above). Flag tokens are stripped before classification.
+- **`--builders-per-wave N`** — dispatch up to `N` builders in parallel per wave. When **omitted**, the wave size is `auto` — resolved at Stage -1 from the chosen backend and scratch-volume disk headroom (see "Resolve auto wave size"): the daemon detached-process path targets up to 10 concurrent sweeps, while the in-session subagent path stays at the #3289-safe ceiling of 3. When **present**, `N` must be an integer `>= 1` and the explicit value overrides auto entirely (operator wins). Honoured in Modes A and B (issue-side); **silently ignored in Mode C** (PR-set mode has no Builder phase — see Mode C validation rules above). Flag tokens are stripped before classification.
 - **`--dry-run`** — print the planned candidate list (with wave grouping) and EXIT without performing any mutation. Recognized as a bare flag token (no value). May appear anywhere in `$ARGUMENTS`. Default is off. Honoured in **all three** modes — stripped before classification along with other flags. Mode C dry-run prints the PR-set plan (per-PR routing) instead of the issue-set plan.
 - **`--prs`** — switch into Mode C (PR-set mode). Recognized as a bare flag token (no value). May appear anywhere in `$ARGUMENTS`. Default is off. When present, non-flag tokens are interpreted as **PR numbers** (numeric tokens) or as a **PR-list description** (NL tokens). When absent, an NL trigger phrase listed in the Mode C section can still select Mode C. See "Mode C" above for full semantics.
 - **`--no-daemon`** — force in-process subagent dispatch even when the daemon is running with a multi-account token pool. Recognized as a bare flag token (no value). May appear anywhere in `$ARGUMENTS`. Default is off. When present, **Stage -1 (Backend detection) skips the `PROBE_DAEMON` step entirely** and the skill always falls through to the existing Mode A/B/C subagent dispatch path. Honoured in **all three** modes — stripped before classification along with other flags. Use this when you want the predictable single-process behaviour even though daemon dispatch is available (e.g., debugging, demoing the subagent path, or running under a token configuration that you don't want shared with daemon-spawned sweeps). See "Stage -1: Backend detection" below.
 
 ### Validation rules
 
-- Recognize `--dry-run`, `--prs`, `--no-daemon`, and `--builders-per-wave N` as flag tokens anywhere in `$ARGUMENTS`, strip them from the candidate list before validation, and store them as flags / parameters (`DRY_RUN=true|false`, `PRS_MODE=true|false`, `NO_DAEMON=true|false`, `BUILDERS_PER_WAVE=N`).
+- Recognize `--dry-run`, `--prs`, `--no-daemon`, and `--builders-per-wave N` as flag tokens anywhere in `$ARGUMENTS`, strip them from the candidate list before validation, and store them as flags / parameters (`DRY_RUN=true|false`, `PRS_MODE=true|false`, `NO_DAEMON=true|false`, `BUILDERS_PER_WAVE=N`). When `--builders-per-wave` is **absent**, set the sentinel `BUILDERS_PER_WAVE=auto` (not `1`) — Stage -1 resolves the concrete wave size from the backend + disk headroom. An explicit integer is stored verbatim and overrides auto.
 - At least one candidate (numeric token or NL description) must be supplied. If `$ARGUMENTS` (after stripping flag tokens) is empty, display:
   ```
   Usage: /sweep <issue-number> [<issue-number> ...] [--builders-per-wave N] [--dry-run] [--no-daemon]
@@ -151,6 +151,7 @@ Combine flags as needed. Always pass `--state open` explicitly (Mode C operates 
   - If the description is ambiguous between issues and PRs (e.g., `loom:review-requested` is PR-only but the description omits "PRs" / "pull requests"), ask the user to clarify before proceeding. Do not guess.
   - If `--builders-per-wave N` was supplied, print a one-line note that the flag has no effect in Mode C and proceed without it (Mode C waves are size-1; see Mode C section).
 - **`--builders-per-wave N` validation:**
+  - **Absent flag → `auto`.** When the operator did not pass `--builders-per-wave`, `BUILDERS_PER_WAVE=auto`; skip the integer validation below and resolve the concrete size at Stage -1 ("Resolve auto wave size"). The rules below apply **only** when an explicit value was passed — an explicit integer always overrides auto and is validated verbatim as before.
   - Parse `N` as an integer. Reject non-integer values with a clear error and EXIT.
   - Reject `N < 1` (including `0` and negative values) with: `Error: --builders-per-wave must be >= 1 (got: <N>)` and EXIT. Do **not** silently default to `1`.
   - If `N > 3`, print a warning and continue: `WARNING: --builders-per-wave=<N> is unvalidated. N<=3 is recommended; N>=4 may exhaust context or hit rate limits. Proceeding at your own risk.`
@@ -164,12 +165,13 @@ Combine flags as needed. Always pass `--state open` explicitly (Mode C operates 
 
 | `N` | Status |
 |-----|--------|
-| `1` | Default. Fully sequential (MVP-compatible). |
-| `2` | **Recommended** starting point for parallel waves. |
-| `3` | Tested and validated. Fine for routine use. |
-| `>= 4` | Unvalidated. Warns at parse time. Operator discretion. |
+| `auto` | **Default** (flag omitted). Resolved at Stage -1 from the backend + scratch-volume disk headroom: daemon detached-process path targets up to 10; in-session subagent path caps at 3. Clamped by candidate count and disk, floor 1. See "Resolve auto wave size". |
+| `1` | Fully sequential (MVP-compatible). Explicit override of `auto`. |
+| `2` | **Recommended** explicit starting point for parallel subagent waves. |
+| `3` | Tested and validated. The #3289-safe ceiling for the **subagent** path. |
+| `>= 4` | Unvalidated **for the subagent path**. Warns at parse time. Operator discretion. |
 
-The cap is **soft** — there is no hard upper bound. The warning is the only guard.
+The subagent-path cap is **soft** — there is no hard upper bound and the warning is the only guard. It is capped at 3 because the subagent path dispatches builders one level deep and is bounded by the #3289 nested-dispatch stall (see "CRITICAL: One level deep"). High parallelism toward 10 is reached **only** via the daemon detached-process path (`mcp__loom__dispatch_sweep`), where each sweep is an isolated OS process — not a nested subagent — so #3289 does not apply. Never raise the subagent number toward 10; route through the daemon instead.
 
 ## Examples
 
@@ -274,7 +276,7 @@ The cap is **soft** — there is no hard upper bound. The warning is the only gu
 
 `/sweep` processes the candidate list in **waves**:
 
-- **Mode A/B (issue-set)**: the candidate list is partitioned into waves of up to `N = --builders-per-wave` issues (default `1`). Issues are picked into waves in order. Within a wave, builders are dispatched in parallel; across waves, processing is sequential. Each wave fully settles (all builders → per-PR Judge → optional Doctor → merge) before the next wave starts.
+- **Mode A/B (issue-set)**: the candidate list is partitioned into waves of up to `N = --builders-per-wave` issues, where an omitted flag resolves to the Stage -1 auto wave size (see "Resolve auto wave size" — up to 10 on the daemon path, capped at 3 on the subagent path, disk-clamped). Issues are picked into waves in order. Within a wave, builders are dispatched in parallel; across waves, processing is sequential. Each wave fully settles (all builders → per-PR Judge → optional Doctor → merge) before the next wave starts.
 - **Mode C (PR-set)**: the candidate list is processed in **size-1 waves** (one PR per wave). `--builders-per-wave` is ignored because there is no Builder phase. Each PR is routed per its current label (Judge / Doctor→Judge / Merge — see "PR-set Wave Lifecycle" below) and fully settles before the next PR is touched. Sequential per-PR processing matches the load-bearing #3289 sequencing rule and parallels the issue-side "per-PR Judge is sequential within a wave" policy.
 
 ### CRITICAL: One level deep — never spawn `/shepherd` as a subagent
@@ -428,6 +430,49 @@ A single-token configuration (`TOKEN_FILE_COUNT == 1` and `ENV_KEY_COUNT <= 1`) 
 
 > **Why >= 2 and not >= 1?** A pool of one is not a pool — it is a single token, and rotation requires alternatives. The daemon's dispatch advantage (per-sweep token selection, weekly-quota recovery) only materializes once two-or-more accounts are configured. Single-token operators see no degradation in the subagent path; this preserves the existing solo-token experience.
 
+### Resolve auto wave size (when `BUILDERS_PER_WAVE = auto`)
+
+Run this **after `DECIDE` is known** (both probes done) and **before** taking the daemon-dispatch or subagent-fallthrough branch below. If `BUILDERS_PER_WAVE` is a concrete integer (the operator passed `--builders-per-wave N`), **skip this entire block** — the explicit value wins and flows into the wave-partition consumers unchanged. Mode C also never reaches this block: Mode C is size-1 and ignores `--builders-per-wave` (the `DECIDE` precedence already routed it to the subagent path).
+
+The disk math lives in a small sourceable helper so it is deterministic and unit-tested (`defaults/scripts/lib/disk-headroom.sh`, tested by `defaults/scripts/tests/test-disk-headroom.sh`). The skill sources it and calls two functions; it does not do the arithmetic inline:
+
+```bash
+source ./.loom/scripts/lib/disk-headroom.sh
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+FREE_GB="$(loom_worktree_root_free_gb "$REPO_ROOT")"   # df's the RESOLVED worktree root (scratch volume), not the repo drive
+```
+
+Then resolve by branch (`CAND` = number of surviving candidate issues):
+
+```bash
+if [[ "$DECIDE" == use_daemon ]]; then
+    # Detached-process path: each sweep is its own OS process with its own
+    # rotated token. NOT nested subagents, so #3289 does not apply — scale to 10.
+    MECH=daemon;   MECHANISM="daemon detached-process"
+else  # use_subagent (no daemon, single-token pool, --no-daemon, or Mode C)
+    # In-session Task subagents, one level deep. Bounded by #3289 — cap 3.
+    MECH=subagent; MECHANISM="in-session subagent"
+fi
+# The helper prints two lines: size on line 1, reason token on line 2.
+mapfile -t _WS < <(loom_wave_size_from_disk "$MECH" "$CAND" "$FREE_GB")
+WAVE_SIZE="${_WS[0]}"; REASON="${_WS[1]}"
+```
+
+`loom_wave_size_from_disk` prints two lines — the clamped size `K = min(target, floor(free_gb / LOOM_PER_WORKTREE_GB), CAND)` with a floor of 1 (never 0, even on a full disk) on line 1, and a machine reason token (`target` / `candidates` / `disk` / `floor`) on line 2. `LOOM_PER_WORKTREE_GB` defaults to a conservative 2 GB and is env-overridable for large-repo operators. The target is **10** for the daemon path and **3** for the subagent path.
+
+**Emit a one-line reason** so the operator understands any reduction. Map the reason token to a human sentence, adding the backend-specific context:
+
+| `DECIDE` / reason | One-line log |
+|-------------------|--------------|
+| `use_daemon`, `target` | `wave size 10, mechanism=daemon: daemon + multi-account pool → detached-process path (target 10)` |
+| `use_subagent`, `target`, daemon not reachable | `wave size 3, mechanism=subagent: daemon not reachable → subagent path (cap 3)` |
+| `use_subagent`, `target`, no pool | `wave size 3, mechanism=subagent: single-token pool → subagent path (cap 3)` |
+| any, `candidates` | `wave size K, mechanism=<m>: reduced to K (only K candidate issues)` |
+| any, `disk` | `wave size K, mechanism=<m>: reduced to K (only <FREE_GB> GB free on <worktree-root>)` |
+| any, `floor` | `wave size 1, mechanism=<m>: reduced to 1 (only <FREE_GB> GB free on <worktree-root>)` |
+
+The resolved `WAVE_SIZE` replaces `--builders-per-wave` everywhere the wave-partition consumers below reference it. On the **daemon path** `WAVE_SIZE` is the concurrency **target** the operator should expect (and that `--dry-run` reports) — the daemon runs each candidate as an independent detached process, so it is not a hard in-session partition. On the **subagent path** `WAVE_SIZE` is the literal wave partition size feeding the `min(...)` dispatch expression in the Wave Lifecycle. In both cases, **never raise the subagent number toward 10** — that is the #3289 line the daemon path exists to route around.
+
 ### The daemon-dispatch path (when `DECIDE = use_daemon`)
 
 When `DECIDE` lands on `use_daemon`, the skill **dispatches each candidate issue** to the daemon and **exits sub-2-second**. There is no in-session orchestration after dispatch — operators monitor with `mcp__loom__list_sweeps` (Phase A) or the richer Phase C tools once they land.
@@ -488,9 +533,11 @@ These are the AC #3 and AC #4 contracts, written for the operator.
 # Expected:
 #   1. Stage -1 runs: PROBE_MODE=A, PROBE_DAEMON or PROBE_POOL is false.
 #   2. DECIDE = use_subagent.
-#   3. Skill continues to "0. Dry-run gate" → "Wave Lifecycle" → ... exactly as today.
-#   4. Issue 123 runs Curator→Builder→Judge→Doctor→Merge in-session.
-#   5. Issue 456 runs the same way in the next wave (default --builders-per-wave=1).
+#   3. Skill continues to "0. Dry-run gate" → "Resolve auto wave size" → "Wave Lifecycle".
+#   4. Auto wave size resolves to the subagent path (cap 3, disk-clamped): both
+#      issues land in one wave of 2 (or fewer if the scratch volume is tight).
+#   5. Each issue runs Curator→Builder→Judge→Doctor→Merge in-session.
+#      (Pass an explicit --builders-per-wave 1 to force the old fully-sequential behaviour.)
 #   6. Skill exits when both issues have settled (potentially many minutes).
 ```
 
@@ -541,7 +588,7 @@ If `--dry-run` was supplied, **this stage runs before any mutation** and EXITs a
    ```
    This is a `gh issue view` read — it does not mutate anything. (If `gh` is unauthenticated or the issue is unreachable, log the error against that candidate and continue surveying the rest.)
 
-2. **Compute wave partition.** Partition the candidate list into waves of size `--builders-per-wave` (default `1`), preserving input order. Record `(issue, wave_index, total_waves)` for each candidate. Apply the same silent-clamp and pre-flight-skip rules that the live path uses (closed / `loom:building` / `loom:blocked` issues are tagged as "would skip" in the plan but still appear in the output for transparency).
+2. **Compute wave partition.** Partition the candidate list into waves of size `--builders-per-wave`, or the Stage -1 resolved auto wave size when the flag was omitted (see "Resolve auto wave size"), preserving input order. Record `(issue, wave_index, total_waves)` for each candidate. Apply the same silent-clamp and pre-flight-skip rules that the live path uses (closed / `loom:building` / `loom:blocked` issues are tagged as "would skip" in the plan but still appear in the output for transparency).
 
 3. **Print the plan.** Emit a table or block per the issue-set format below.
 
@@ -550,7 +597,8 @@ If `--dry-run` was supplied, **this stage runs before any mutation** and EXITs a
 **Issue-set output spec** (Modes A and B; minimum useful — do **not** add token-pool selection or agent dispatch internals):
 
 ```
-/sweep --dry-run plan: M candidate(s) across W wave(s) (--builders-per-wave=N)
+/sweep --dry-run plan: M candidate(s) across W wave(s) (wave size 10, auto; mechanism=daemon detached-process)
+  Wave sizing: daemon + multi-account pool → detached-process path (target 10)
 
   Wave 1:
     #123  "Add foo widget"                labels: loom:issue                    → would build
@@ -564,6 +612,8 @@ If `--dry-run` was supplied, **this stage runs before any mutation** and EXITs a
 Total: 3 would-build, 1 would-route-to-judge, 1 would-merge, 1 would-skip. No issues were modified.
 ```
 
+When `--builders-per-wave` was passed explicitly, the header shows the number without `auto` and the "Wave sizing" line reads `explicit --builders-per-wave=N` (no mechanism/disk reason). A disk- or candidate-clamped auto run reads e.g. `(wave size 3, auto; mechanism=in-session subagent)` with `Wave sizing: reduced to 3 (only 6 GB free on /Volumes/scratch/loom)`.
+
 **Per-candidate fields (required):**
 - Issue number
 - Title (truncated reasonably if very long)
@@ -571,7 +621,7 @@ Total: 3 would-build, 1 would-route-to-judge, 1 would-merge, 1 would-skip. No is
 - Planned action (`would build`, `would curate, build`, `would skip (<reason>)`, `would route to Judge (existing PR #X in flight)`, `would merge (existing PR #X already loom:pr)`)
 - Wave assignment (shown via the `Wave N:` group header)
 
-**Footer (required):** total candidates, total waves, count of `would-build` vs `would-skip`, and an explicit confirmation that nothing was modified.
+**Header/footer (required):** the header states the resolved wave size (and whether it is `auto` or explicit), the chosen **mechanism** (`daemon detached-process` vs `in-session subagent`), and — on the second line — the one-line **gating reason** from "Resolve auto wave size". The footer states total candidates, total waves, count of `would-build` vs `would-skip`, and an explicit confirmation that nothing was modified. (Dry-run resolves the auto wave size via the same Stage -1 helper but performs no dispatch — it prints the plan and EXITs.)
 
 ### Procedure — Mode C (PR-set)
 
@@ -877,7 +927,7 @@ If `CHECKPOINT_PHASE` is `judge-done` or `doctor-done`, see the corresponding sk
 
 For issues without `builder-done`-or-later checkpoints, proceed with the normal Builder dispatch:
 
-Dispatch up to `min(--builders-per-wave, surviving-candidates-in-wave-needing-builder)` `loom-builder` subagents **in a single tool-call block** from this orchestrator session. **Do NOT invoke `/shepherd` as a subagent here** — see the "One level deep" rule in Execution Model above.
+Dispatch up to `min(resolved-wave-size, surviving-candidates-in-wave-needing-builder)` `loom-builder` subagents **in a single tool-call block** from this orchestrator session, where `resolved-wave-size` is the explicit `--builders-per-wave` value or, when the flag was omitted, the Stage -1 auto wave size ("Resolve auto wave size"). Note this Wave Lifecycle is the **subagent** path, so the auto size here is capped at 3 (#3289-safe) — the daemon path never runs this section (it dispatches detached processes and exits at Stage -1). **Do NOT invoke `/shepherd` as a subagent here** — see the "One level deep" rule in Execution Model above.
 
 Each builder is responsible for:
 
@@ -1008,7 +1058,7 @@ Stop processing and print the summary when any of these conditions hold:
 - The user interrupts (Ctrl-C or explicit stop).
 - An unrecoverable error occurs (e.g., `gh` is not authenticated, repository state is broken). Log the error and exit.
 
-This skill does **not** implement disk-pressure checks, max-waves caps, or doctor-cycle global limits — those are deferred (see Limitations).
+This skill does **not** implement a disk-pressure *stop* condition (aborting an in-flight sweep when the disk fills), max-waves caps, or doctor-cycle global limits — those are deferred (see Limitations). It **does** apply a disk-headroom *gate* when resolving the auto wave size at Stage -1 (see "Resolve auto wave size"): the scratch-volume free space clamps the initial wave size down, but does not stop a running sweep.
 
 ## Host Sleep Readiness (#3350)
 
@@ -1066,7 +1116,7 @@ The full `/sweep` design in #3298 includes many features that are intentionally 
 
 | Feature | Status | Notes |
 |---------|--------|-------|
-| Parallel waves (`--builders-per-wave N`) | **Implemented (#3316)** | Soft cap at N=3 (warns above). One level deep — no `/shepherd` subagent. Issue-side only; ignored in Mode C. |
+| Parallel waves (`--builders-per-wave N`) | **Implemented (#3316, auto default #3566)** | Omitted flag resolves to an auto wave size at Stage -1 (#3566): up to 10 on the daemon detached-process path, capped at 3 on the in-session subagent path. The N=3 soft cap is **subagent-path-specific** (the #3289 nested-dispatch ceiling — warns above on explicit override); the daemon path scales to 10 because each sweep is an isolated process, not a nested subagent. One level deep — no `/shepherd` subagent. Issue-side only; ignored in Mode C. |
 | Natural-language selectors (label/author/title/time-window filters via NL description) | **Implemented (#3318)** | Mode B in Arguments. Out-of-band queries (body/diff inspection, file-touch filters) still trigger clarification. |
 | `--dry-run` | **Implemented (#3319, extended in #3384)** | Prints the candidate plan (with wave grouping) and exits without mutating labels, worktrees, or PRs. Issue-set (Modes A/B) and PR-set (Mode C) output formats. |
 | Existing-PR detection in pre-flight | **Implemented (#3359)** | Pre-flight probes `closedByPullRequestsReferences`; routes existing open linked PRs to Judge (or Merge if already `loom:pr`) instead of dispatching a duplicate Builder. Multi-PR ambiguity skips with a log. |
@@ -1079,7 +1129,8 @@ The full `/sweep` design in #3298 includes many features that are intentionally 
 | `--include-blocked` (unblock pass) | Deferred | Currently `/sweep` skips `loom:blocked` issues outright. |
 | `--curator-also` (parallel curators on `loom:triage`) | Deferred | Parallel triage is a separate orchestration question. |
 | Config-driven defaults (`.loom/config.json` keys `sweep.*`) | Deferred | No knobs to configure yet. |
-| Disk-pressure stop condition | Deferred | Wave sequencing limits disk usage; revisit if waves grow large. |
+| Disk-pressure *gate* on auto wave size | **Implemented (#3566)** | Stage -1 resolves the auto wave size against free space on the **worktree-root filesystem** (via `loom_worktree_root`, so it measures the dedicated scratch volume when `LOOM_WORKTREE_ROOT` / `worktree.root` is set — #3539/#3541), clamping the target down and logging the reason. `LOOM_PER_WORKTREE_GB` (default 2) is the per-worktree estimate. |
+| Disk-pressure *stop* condition (abort a running sweep on low disk) | Deferred | Only the initial auto wave size is gated (above); no mid-sweep abort. Wave sequencing limits disk usage; revisit if waves grow large. |
 | Doctor-cycle counting across PRs | Deferred | Single Doctor→Judge cycle limit per PR is enforced inline. |
 | Parallel Judges within a wave | Deferred | Sequential per-PR Judge today; needs benchmarking before parallelizing. Mode C is also strictly sequential per PR (size-1 waves). |
 | Parallel PRs in Mode C | Deferred | Mode C uses size-1 waves. Multi-PR-per-wave is feasible (one judge per PR in parallel) but inherits the same #3289 risk that gated parallel issue-side Judges. |

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -190,6 +190,8 @@ claude -p "/loom:sweep 123" --dangerously-skip-permissions
 
 Checkpoints (#3373) under `.loom/sweep-checkpoint/issue-<N>.json` survive crashes — restarting `/loom:sweep N` resumes from the last completed phase.
 
+**Wave parallelism default (#3566)**: when `--builders-per-wave` is omitted, `/loom:sweep` auto-resolves the wave size at Stage -1 from the chosen backend and scratch-volume disk headroom — the daemon detached-process path (isolated OS processes, not nested subagents) targets up to **10**, while the in-session subagent path stays at the **#3289-safe cap of 3**. The disk gate measures the **worktree-root filesystem** (`LOOM_WORKTREE_ROOT` / `worktree.root`, #3539/#3541), so a dedicated scratch volume rarely binds. Passing an explicit `--builders-per-wave N` overrides auto. `--dry-run` prints the resolved size, mechanism, and gating reason. See `.claude/commands/loom/sweep.md` → "Resolve auto wave size".
+
 ### 3. Daemon Mode (`loom-daemon` + MCP tools)
 
 The Rust `loom-daemon` binary is the Tier 2 dispatch backend. It is a single long-lived process exposing a Unix-socket IPC surface and a paired `mcp-loom` MCP server. Each IPC `Request` variant maps 1:1 to an MCP tool, so any MCP client — most commonly a Claude Code session running `/loom:sweep` — can dispatch sweeps, observe registry state, subscribe to lifecycle events, and cancel in-flight work.

--- a/defaults/scripts/lib/disk-headroom.sh
+++ b/defaults/scripts/lib/disk-headroom.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# disk-headroom.sh — Resource-gated wave-size math for /loom:sweep (#3566).
+#
+# Source this file (do not exec). It defines two functions used by the sweep
+# skill's Stage -1 "Resolve auto wave size" step:
+#
+#   loom_worktree_root_free_gb <repo_root>
+#       Resolve the worktree-root filesystem (via loom_worktree_root) and echo
+#       the integer free space on THAT volume in GB. This is the dedicated
+#       scratch volume when LOOM_WORKTREE_ROOT / worktree.root is set (#3539,
+#       #3541) — NOT the repo's own drive.
+#
+#   loom_wave_size_from_disk <mechanism> <candidate_count> <free_gb>
+#       Pure integer arithmetic (no I/O). Given the chosen parallelism
+#       mechanism, the number of candidate issues, and the free GB on the
+#       scratch volume, echo the clamped wave size on line 1 and a machine
+#       reason token on line 2. Deterministic and trivially unit-testable.
+#
+# Two mechanisms, two targets (see #3566, #3289):
+#   - daemon   → detached-process path (mcp__loom__dispatch_sweep). Each sweep
+#                is its own OS process with its own rotated token, so the #3289
+#                nested-subagent stall does not apply. Scales toward N=10.
+#   - subagent → in-session Task subagents, one level deep. Bounded by the
+#                #3289 stream-pump stall; the validated ceiling is 3. NEVER
+#                raise this cap toward 10 — route high parallelism through the
+#                daemon path instead.
+#
+# Constants (all overridable via env for large-repo / tuning cases):
+#   LOOM_PER_WORKTREE_GB   default 2   Conservative per-worktree disk estimate.
+#                                      A fixed estimate keeps the math pure and
+#                                      testable; runtime footprint measurement
+#                                      is intentionally out of scope for v1.
+#   LOOM_DAEMON_WAVE_TARGET  default 10  Concurrency target for the daemon path.
+#   LOOM_SUBAGENT_WAVE_CAP   default 3   #3289-safe ceiling for the subagent path.
+#
+# Reason tokens emitted on line 2 of loom_wave_size_from_disk (which constraint
+# bound the result):
+#   target      — result equals the mechanism target; nothing reduced it.
+#   candidates  — reduced by the candidate count (fewer issues than the target).
+#   disk        — reduced by scratch-volume disk headroom.
+#   floor       — the math produced < 1 (e.g. a nearly full disk); floored to 1.
+
+# Resolve worktree-root.sh relative to this file so sourcing works from any cwd.
+_LOOM_DISK_HEADROOM_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./worktree-root.sh
+source "$_LOOM_DISK_HEADROOM_LIB_DIR/worktree-root.sh"
+
+# loom_worktree_root_free_gb <repo_root>
+#
+# Echoes the integer free space (GB) on the filesystem that hosts the resolved
+# worktree root. The worktree-root leaf (e.g. ${root}/<repo>/issue-N) usually
+# does not exist yet, so this walks up to the nearest existing ancestor before
+# calling df — df on a non-existent path errors. df -Pk forces the portable
+# POSIX 512-independent 1024-byte-block output (macOS df differs from GNU df;
+# -P pins the single-line-per-fs columnar format, -k pins 1K blocks), and the
+# 4th column of the data row is "Available" in 1K blocks.
+loom_worktree_root_free_gb() {
+    local repo_root="$1"
+    if [[ -z "$repo_root" ]]; then
+        echo "loom_worktree_root_free_gb: repo_root argument required" >&2
+        echo "0"
+        return 0
+    fi
+
+    local wt_root
+    wt_root="$(loom_worktree_root "$repo_root")"
+
+    # Walk up to the nearest existing ancestor (read-only; never mkdir).
+    local probe="$wt_root"
+    while [[ -n "$probe" && "$probe" != "/" && ! -e "$probe" ]]; do
+        probe="$(dirname "$probe")"
+    done
+
+    local avail_k
+    avail_k="$(df -Pk "$probe" 2>/dev/null | awk 'NR==2 {print $4}')"
+    if [[ -z "$avail_k" || ! "$avail_k" =~ ^[0-9]+$ ]]; then
+        # df failed or produced an unexpected shape — report 0 free so the
+        # caller floors to a single worktree rather than crashing.
+        echo "0"
+        return 0
+    fi
+
+    # 1K blocks -> GB (integer floor).
+    echo "$(( avail_k / 1024 / 1024 ))"
+}
+
+# loom_wave_size_from_disk <mechanism> <candidate_count> <free_gb>
+#
+# Pure integer arithmetic. Echoes two lines:
+#   line 1: the clamped wave size K = min(target, floor(free_gb/PER), candidates), floor 1
+#   line 2: a reason token (target|candidates|disk|floor)
+# where target is 10 for mechanism=daemon and 3 for mechanism=subagent.
+loom_wave_size_from_disk() {
+    local mechanism="$1" candidate_count="$2" free_gb="$3"
+
+    local per="${LOOM_PER_WORKTREE_GB:-2}"
+    local daemon_target="${LOOM_DAEMON_WAVE_TARGET:-10}"
+    local subagent_cap="${LOOM_SUBAGENT_WAVE_CAP:-3}"
+
+    # Validate integer inputs (defensive — the pure math must not silently
+    # coerce garbage into a plausible-looking wave size).
+    local n
+    for n in "$candidate_count" "$free_gb" "$per" "$daemon_target" "$subagent_cap"; do
+        if [[ ! "$n" =~ ^[0-9]+$ ]]; then
+            echo "loom_wave_size_from_disk: non-integer input '$n'" >&2
+            return 2
+        fi
+    done
+    if (( per < 1 )); then
+        echo "loom_wave_size_from_disk: LOOM_PER_WORKTREE_GB must be >= 1 (got $per)" >&2
+        return 2
+    fi
+
+    local target
+    case "$mechanism" in
+        daemon)   target="$daemon_target" ;;
+        subagent) target="$subagent_cap" ;;
+        *)
+            echo "loom_wave_size_from_disk: unknown mechanism '$mechanism' (expected 'daemon' or 'subagent')" >&2
+            return 2
+            ;;
+    esac
+
+    local max_by_disk=$(( free_gb / per ))
+
+    # Start at the mechanism target and reduce by each binding constraint.
+    # Precedence when constraints tie: candidates before disk before floor, so
+    # a strictly-smaller disk headroom wins the reason, and a hard floor wins
+    # over everything.
+    local k="$target" reason="target"
+    if (( candidate_count < k )); then
+        k="$candidate_count"
+        reason="candidates"
+    fi
+    if (( max_by_disk < k )); then
+        k="$max_by_disk"
+        reason="disk"
+    fi
+    if (( k < 1 )); then
+        k=1
+        reason="floor"
+    fi
+
+    echo "$k"
+    echo "$reason"
+}

--- a/defaults/scripts/tests/test-disk-headroom.sh
+++ b/defaults/scripts/tests/test-disk-headroom.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# test-disk-headroom.sh — Tests for the resource-gated wave-size helper (#3566)
+#
+# Covers defaults/scripts/lib/disk-headroom.sh:
+#
+#   1. loom_wave_size_from_disk — pure integer clamping across the whole matrix
+#      (daemon vs subagent target, disk-bound, target-bound, candidate-bound,
+#      floor-of-1), plus the reason token and env-tunable PER_WORKTREE_GB.
+#   2. loom_worktree_root_free_gb — GB conversion with a stubbed df on PATH.
+#   3. loom_worktree_root_free_gb — with LOOM_WORKTREE_ROOT pointed at a scratch
+#      tmpdir, proves the helper df's the RESOLVED worktree root (the scratch
+#      volume), not the repo drive. Regression guard for the core #3566 AC.
+#
+# Pattern follows test-worktree-root-override.sh: throwaway dirs in mktemp, a
+# df stub on PATH, assert-style harness.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+DISK_HEADROOM_LIB="$SCRIPTS_DIR/lib/disk-headroom.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1)); echo -e "  ${RED}FAIL${NC}: $1"; }
+
+assert_eq() {
+    if [[ "$1" == "$2" ]]; then pass "$3"; else fail "$3 (expected '$2', got '$1')"; fi
+}
+
+# shellcheck source=../lib/disk-headroom.sh
+source "$DISK_HEADROOM_LIB"
+
+# Convenience: run loom_wave_size_from_disk and capture "size|reason".
+wave() {
+    local out size reason
+    out="$(loom_wave_size_from_disk "$@")"
+    size="$(printf '%s\n' "$out" | sed -n '1p')"
+    reason="$(printf '%s\n' "$out" | sed -n '2p')"
+    echo "${size}|${reason}"
+}
+
+# --- Test 1: pure wave-size math (daemon target = 10) ---
+echo "Test 1: loom_wave_size_from_disk daemon path (target 10)"
+
+# Plentiful disk, plenty of candidates -> target-bound at 10.
+assert_eq "$(wave daemon 20 100)" "10|target" "daemon: plentiful disk + candidates -> 10 (target)"
+
+# Candidate-bound: only 3 issues, disk and target both higher.
+assert_eq "$(wave daemon 3 100)" "3|candidates" "daemon: 3 candidates clamps to 3 (candidates)"
+
+# Disk-bound: free=6 GB, per=2 -> max_by_disk=3, below target and candidates.
+assert_eq "$(wave daemon 10 6)" "3|disk" "daemon: 6GB free (per 2) clamps to 3 (disk)"
+
+# Floor-of-1: nearly full disk (free=1, per=2 -> 0) never returns 0.
+assert_eq "$(wave daemon 10 1)" "1|floor" "daemon: 1GB free floors to 1 (floor)"
+
+# --- Test 2: pure wave-size math (subagent cap = 3) ---
+echo ""
+echo "Test 2: loom_wave_size_from_disk subagent path (cap 3)"
+
+# Plentiful disk + candidates -> capped at 3 (the #3289-safe ceiling).
+assert_eq "$(wave subagent 20 100)" "3|target" "subagent: plentiful -> 3 (cap, NOT 10)"
+
+# Candidate-bound: 2 issues -> 2.
+assert_eq "$(wave subagent 2 100)" "2|candidates" "subagent: 2 candidates clamps to 2"
+
+# Disk-bound below the cap: free=2, per=2 -> 1.
+assert_eq "$(wave subagent 10 2)" "1|disk" "subagent: 2GB free (per 2) clamps to 1 (disk)"
+
+# Floor: free=0 -> 1.
+assert_eq "$(wave subagent 10 0)" "1|floor" "subagent: 0GB free floors to 1"
+
+# --- Test 3: PER_WORKTREE_GB env override ---
+echo ""
+echo "Test 3: LOOM_PER_WORKTREE_GB env override changes the disk clamp"
+
+# With per=5, free=100 -> max_by_disk=20 -> daemon target 10 still wins.
+assert_eq "$(LOOM_PER_WORKTREE_GB=5 wave daemon 15 100)" "10|target" "per=5, 100GB -> 10 (target)"
+# With per=25, free=100 -> max_by_disk=4 -> disk-bound at 4.
+assert_eq "$(LOOM_PER_WORKTREE_GB=25 wave daemon 15 100)" "4|disk" "per=25, 100GB -> 4 (disk)"
+
+# --- Test 4: unknown mechanism is rejected ---
+echo ""
+echo "Test 4: unknown mechanism errors (non-zero exit)"
+if loom_wave_size_from_disk bogus 5 100 >/dev/null 2>&1; then
+    fail "unknown mechanism should return non-zero"
+else
+    pass "unknown mechanism returns non-zero"
+fi
+
+# --- Test 5: loom_worktree_root_free_gb GB conversion via stubbed df ---
+echo ""
+echo "Test 5: loom_worktree_root_free_gb converts df 1K blocks to GB"
+STUBDIR=$(mktemp -d /tmp/loom-dh-stub.XXXXXX)
+ARGLOG="$STUBDIR/df-args.log"
+# Stub df: record the path argument, emit a POSIX -Pk table with a fixed
+# Available column. 20971520 1K-blocks = 20 GB.
+cat > "$STUBDIR/df" <<EOF
+#!/usr/bin/env bash
+# Record the last (path) argument for the regression assertion.
+for a in "\$@"; do :; done
+echo "\$a" >> "$ARGLOG"
+echo "Filesystem     1024-blocks      Used Available Capacity Mounted on"
+echo "/dev/stub         52428800  31457280  20971520      60% /stub"
+EOF
+chmod +x "$STUBDIR/df"
+
+REPO=$(mktemp -d /tmp/loom-dh-repo.XXXXXX)
+# No override: worktree root resolves to $REPO/.loom/worktrees (walks up to $REPO).
+gb=$(PATH="$STUBDIR:$PATH" loom_worktree_root_free_gb "$REPO")
+assert_eq "$gb" "20" "df 20971520 1K-blocks converts to 20 GB"
+
+# --- Test 6: measures the RESOLVED worktree root (scratch volume) ---
+echo ""
+echo "Test 6: LOOM_WORKTREE_ROOT override -> df targets the scratch volume, not the repo drive"
+: > "$ARGLOG"
+SCRATCH=$(mktemp -d /tmp/loom-dh-scratch.XXXXXX)
+# Materialize the namespaced leaf so df receives the exact worktree root.
+mkdir -p "$SCRATCH/$(basename "$REPO")"
+gb=$(PATH="$STUBDIR:$PATH" LOOM_WORKTREE_ROOT="$SCRATCH" loom_worktree_root_free_gb "$REPO")
+assert_eq "$gb" "20" "override path still converts df output to 20 GB"
+
+DF_PATH=$(tail -n 1 "$ARGLOG")
+assert_eq "$DF_PATH" "$SCRATCH/$(basename "$REPO")" "df measured the resolved scratch worktree root"
+# Regression guard: it must NOT have measured the repo drive.
+if [[ "$DF_PATH" == "$REPO"* ]]; then
+    fail "df measured the repo drive ($DF_PATH) instead of the scratch volume"
+else
+    pass "df did not measure the repo drive (scratch volume used)"
+fi
+
+rm -rf "$STUBDIR" "$REPO" "$SCRATCH"
+
+# --- Summary ---
+echo ""
+echo "Tests run: $TESTS_RUN, Passed: $TESTS_PASSED, Failed: $TESTS_FAILED"
+[[ $TESTS_FAILED -eq 0 ]] || exit 1


### PR DESCRIPTION
Closes #3566

## Summary

Replaces `/loom:sweep`'s hardcoded `--builders-per-wave` default of `1` with an `auto` sentinel resolved at Stage -1 from the chosen backend and scratch-volume disk headroom. Only warns/reduces when genuinely constrained; explicit `--builders-per-wave N` still overrides.

## Two mechanisms (not conflated)

- **daemon + multi-account pool** → detached-process path (`mcp__loom__dispatch_sweep`). Each sweep is its own OS process with its own rotated token — **not** nested subagents, so the #3289 stall does not apply. Targets up to **N=10**.
- **no daemon / single-token / `--no-daemon` / Mode C** → in-session subagent path, one level deep. Bounded by #3289; stays at the validated ceiling of **3**.

Both clamped by candidate count and by free space on the **worktree-root filesystem** (resolved via `loom_worktree_root`, so it measures the dedicated scratch volume from #3539/#3541 — not the repo drive), floor of 1. **The subagent cap is never raised toward 10** — high parallelism is routed through the daemon path.

## New helper (the unit-testable seam)

`defaults/scripts/lib/disk-headroom.sh` (sourceable, not exec):
- `loom_worktree_root_free_gb <repo_root>` — resolves the worktree root, walks up to the nearest existing ancestor, `df -Pk`s it (portable across macOS/GNU), echoes integer free GB.
- `loom_wave_size_from_disk <mechanism> <candidate_count> <free_gb>` — pure integer arithmetic. Returns `min(target, floor(free_gb/PER_WORKTREE_GB), candidate_count)` (floor 1) on line 1 and a reason token (`target`/`candidates`/`disk`/`floor`) on line 2. Targets: daemon 10, subagent 3.

Constants: `LOOM_PER_WORKTREE_GB` (default **2** GB), `LOOM_DAEMON_WAVE_TARGET` (10), `LOOM_SUBAGENT_WAVE_CAP` (3) — all env-overridable.

## Skill doc changes (`defaults/.claude/commands/loom/sweep.md`)

- Absent flag → `BUILDERS_PER_WAVE=auto` sentinel; explicit-integer validation kept verbatim.
- New Stage -1 "Resolve auto wave size" subsection (algorithm + reason table), after `DECIDE`, before daemon/subagent branch; Mode C never reaches it.
- Three wave-partition consumers (Execution Model A/B, dry-run gate, Wave Lifecycle `min(...)`) now reference the resolved size.
- `--dry-run` output prints resolved size + mechanism + gating reason.
- Wave-size guidance table gains an `auto` row; the `<=3` soft-cap reframed as subagent-path-specific.
- Limitations rows updated (disk gate now implemented; soft-cap subagent-specific); stale "does not implement disk-pressure checks" line corrected.
- #3289 "One level deep" prose left intact and cross-referenced.

Plus a one-line pointer in `defaults/CLAUDE.md`.

## Tests

`defaults/scripts/tests/test-disk-headroom.sh` — 15 assertions covering the daemon/subagent × target/candidate/disk/floor matrix, `LOOM_PER_WORKTREE_GB` override, unknown-mechanism rejection, GB conversion via a stubbed `df`, and a regression guard proving the resolved scratch volume is measured (not the repo drive). All pass; shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)