### PR TITLE
docs(migration): record LOOM-EXTENSION-POINT release seams audit finding (#3573)

### DIFF
--- a/docs/migration/v0.10.0-shepherd-deprecation.md
+++ b/docs/migration/v0.10.0-shepherd-deprecation.md
@@ -664,6 +664,43 @@ warnings are **withdrawn** for `./.loom/scripts/daemon.sh` (the shell-level
 surface is preserved). The Python `loom-daemon` CLI is genuinely removed,
 so its warning escalates to an actual "command not found" error.
 
+## `/loom:release` extension-point seams audit (#3573)
+
+The retirement of the `/loom:release` skill (#3563, in favor of the
+general-purpose `/repo:release` from `rjwalters/repo`) deleted
+`defaults/.claude/commands/loom/release.md` and its example topic file
+`defaults/hooks/example-context/topics/release.md`. Both carried five
+`<!-- LOOM-EXTENSION-POINT: <name> -->` HTML-comment markers (added by #3506
+/ proposal #3503): `pre-changelog-style`, `pre-push`, `post-push`,
+`pre-github-release`, `post-summary`. This audit records whether anything
+depended on them before they can be re-litigated.
+
+**Finding — were the release seams used loom-internally? No.** The seams were
+a *prose-composition convention*, not a runtime mechanism. Nothing in Loom
+parsed the markers. The actual delivery vehicle is the generic
+`defaults/hooks/methodology-inject.sh` `UserPromptSubmit` hook, which injects
+any `.loom/context/topics/<name>.md` file whose name/pattern matches the
+prompt — it has no knowledge of release phases or seam names, and #3563 left
+it **untouched and intact**. The only two files that ever referenced the
+seams were `release.md` and its own example topic, and #3563 removed them
+together. Grepping `origin/main` after the merge confirms the sole surviving
+mention of `LOOM-EXTENSION-POINT` is the historical `CHANGELOG.md` entry
+(intentionally preserved as history); no code, script, or other doc reads the
+markers. So no loom-internal machinery lost a dependency.
+
+**Consumer guidance (the "if used" path).** A downstream consumer who authored
+a `.loom/context/topics/release.md` targeting one of the named seams still has
+the generic injection hook — their topic file continues to be injected on
+matching prompts. What they lose is the Loom-shipped skill that defined the
+named seam boundaries to compose against. Such consumers should move
+release-time customization into their own repo's release command
+(`/repo:release` from `rjwalters/repo`) or their own `CLAUDE.md`, rather than
+relying on a Loom-defined seam. **Non-goal:** Loom will not re-add `release.md`
+or a runtime injection hook to `/repo:release` — the repo is general-by-design
+(see #3563 non-goals).
+
+Provenance: seam origin #3503 / #3506; retirement #3563; this audit #3573.
+
 ## Coordination, questions, and follow-ups
 
 - **Upstream epic**: #3372 (shepherd/daemon deprecation).


### PR DESCRIPTION
## Summary

Audit follow-up to #3563 (retire `/loom:release`). Records the definitive finding for #3573 in `docs/migration/v0.10.0-shepherd-deprecation.md`.

**Finding (yes/no on loom-internal use): NO.** The five `LOOM-EXTENSION-POINT` release seams (`pre-changelog-style`, `pre-push`, `post-push`, `pre-github-release`, `post-summary`, added by #3506/#3503) were a prose-composition convention, not a runtime mechanism. Nothing in Loom parsed the markers. The delivery vehicle is the generic `defaults/hooks/methodology-inject.sh` `UserPromptSubmit` hook, which is untouched by #3563 and survives intact.

**Evidence (verified in this worktree off current `origin/main`):**
- `release.md` and its example topic (`defaults/hooks/example-context/topics/release.md`) are both already deleted by #3563 (merged as #3571).
- The only two files that ever referenced the seams were those two — removed together.
- Post-merge grep: the sole surviving `LOOM-EXTENSION-POINT` mention is the historical `CHANGELOG.md` entry (intentional history). No code/script/doc reads the markers.
- `methodology-inject.sh` is generic topic injection (matches `.loom/context/topics/<name>.md` by name/pattern) with no release/seam-specific logic; intact.

**Consumer guidance** and the general-by-design **non-goal** (no re-added `release.md` / runtime hook) are recorded in the note.

Closes #3573

🤖 Generated with [Claude Code](https://claude.com/claude-code)