### PR TITLE
feat(install): content-gated cleanup of retired release.md stray (#3572)

### DIFF
--- a/defaults/.loom-internal.list
+++ b/defaults/.loom-internal.list
@@ -21,8 +21,19 @@
 # Issue #3563: the `/loom:release` skill (`.claude/commands/loom/release.md`)
 # was retired in favor of `/repo:release` from
 # https://github.com/rjwalters/repo. Loom no longer ships a release skill, so
-# there is no internal-list entry for it. Consumers that received the
-# generalized skill during the #3495 window (when it briefly shipped) keep a
-# harmless stray copy; it is not re-installed and can be deleted by hand.
+# there is no internal-list entry for it.
+#
+# Issue #3572: consumers that received the generalized skill during the #3495
+# window (when it briefly shipped) carried a stray copy on disk. That stray is
+# now ACTIVELY REMOVED on the next `install-loom.sh` update by the content-gated
+# retired-file cleanup block (search "Retired-file cleanup" in
+# scripts/install-loom.sh). The removal is gated on a frozen sha256 allowlist of
+# every shipped release.md version, so an unmodified copy is deleted while a
+# consumer-customized copy (hash matches none) is preserved with an
+# informational log line. release.md's only placeholder is the runtime
+# {{workspace}} token (not install-time substituted), so shipped bytes are
+# identical across consumers and the hash gate is exact. The generic stale-file
+# sweep still skips it by design (the #3492 ownership intersection preserves
+# non-owned paths); the explicit cleanup is what removes it.
 # Releases are driven by `/repo:release`, which honors `scripts/version.sh` as
 # its first-priority version tool — see the root CLAUDE.md "Releasing" section.

--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -1247,6 +1247,130 @@ if (( ${#STALE_FILES[@]} > 0 )); then
 fi
 # --- End stale-file sweep ---
 
+# --- Retired-file cleanup (content-gated) ---
+# A handful of files Loom once shipped were later RETIRED outright (deleted
+# upstream, not renamed). The generic stale-file sweep above deliberately will
+# NOT remove them:
+#   * The #3492 ownership-boundary intersection preserves any stale-manifest
+#     entry that is no longer in the current defaults/ ownership set — a
+#     retired path is by definition not owned, so it lands in
+#     PRESERVED_NOT_OWNED and is never git-rm'd. That defense-in-depth is
+#     correct (it protects consumer-authored files captured by pre-#3450
+#     over-broad manifests) and must stay.
+#   * A retired file that was never in the previous manifest at all is never
+#     even a sweep candidate.
+# So a retired file lingers on disk in every consumer that installed before the
+# retirement. This block removes such strays narrowly and safely.
+#
+# Gate: a frozen allowlist of (retired path -> sha256 of every version Loom
+# ever shipped at that path). A file is removed ONLY when it exists AND its
+# content hash matches a shipped digest — i.e. it is byte-identical to
+# something Loom shipped and therefore unmodified. A consumer who customized
+# the file (hash matches none) is left untouched with an informational line.
+# Absent -> no-op. Idempotent by construction (once removed, the existence
+# check is false on every subsequent run).
+#
+# Issue #3572: retire the stray `.claude/commands/loom/release.md` left behind
+# by #3563 (which deleted the shipped `/loom:release` skill but deliberately
+# did not sweep existing consumer copies). release.md's only placeholder is the
+# Claude-Code *runtime* token {{workspace}} — it is NOT install-time
+# substituted (see substitute_template_variables in
+# loom-daemon/src/init/templates.rs), so the shipped bytes are identical across
+# all consumers and a content-hash gate is exact. The digest set is frozen:
+# release.md will never ship again, so no maintenance burden accrues.
+_loom_sha256() {
+  # Portable sha256 -> bare hex digest (shasum on macOS, sha256sum on Linux).
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" 2>/dev/null | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" 2>/dev/null | awk '{print $1}'
+  else
+    echo ""
+  fi
+}
+
+# Frozen retired-file allowlist. One "<relative-path> <sha256>" row per shipped
+# version; multiple rows per path enumerate every version. Comment (#) and
+# blank lines are ignored. Append-only — never remove a historical digest.
+LOOM_RETIRED_FILES=$(cat <<'RETIRED'
+# .claude/commands/loom/release.md — every version shipped in the #3495 -> #3563
+# window (retired by #3563 / PR #3571). Any match is unmodified Loom content.
+.claude/commands/loom/release.md 11aef217942f45bd03d90a24e5efae9209041cb59f09c888df4dc7e8208910dd
+.claude/commands/loom/release.md 0df6c20846c98850413243362c80dea2fd01330c8d97033ef5f7c3989578fe8c
+.claude/commands/loom/release.md c45841f8da42d1bda20bc180c8a93d14242238d9a2c1d9f5a1bdac32b5e9e556
+.claude/commands/loom/release.md d91e198e977ad7799f44fa1a6827c9836bca6d31c9357ed92fc400a3c88381de
+.claude/commands/loom/release.md 0d7030dd14f32f6f382a6430cd04e5f0475825d567aaed7570b73a4c43128ad1
+.claude/commands/loom/release.md 4a077ed25cb44add0afbc4d6bda23cb372f5f3c4c2ef23b7a24b586e66e4f3e7
+.claude/commands/loom/release.md 5f9930dc72a263866122b18018a64b8fed4bd53ef623d0eef27ed1e31fa0502f
+.claude/commands/loom/release.md b7fae9d13d2bfaee3bde514cabe44ac70b6551351a9e49357ede00f82c17cf35
+.claude/commands/loom/release.md f6523d9be058e40397f0ce30c08a8f2b60e9b38adae04bd7c919e0cc840acfec
+.claude/commands/loom/release.md 29a845f7f8912545d23832551753304df6e72dd4a9c8082c2d8ada1f09f449e1
+.claude/commands/loom/release.md 795c1df1d3f3706ba448482b037a0c9e4eb6272a719adb2688b9ddfc91ab4de6
+RETIRED
+)
+
+RETIRED_REMOVE=()
+RETIRED_PRESERVE=()
+# Unique retired paths (a path may have several allowed digests).
+RETIRED_PATHS=$(printf '%s\n' "$LOOM_RETIRED_FILES" \
+  | awk 'NF>=2 && $1 !~ /^#/ {print $1}' | sort -u)
+while IFS= read -r retired_path; do
+  [[ -n "$retired_path" ]] || continue
+  [[ -f "$TARGET_PATH/$retired_path" ]] || continue
+  file_hash=$(_loom_sha256 "$TARGET_PATH/$retired_path")
+  hash_matched=false
+  if [[ -n "$file_hash" ]]; then
+    while read -r allow_path allow_hash; do
+      [[ -n "$allow_path" && "${allow_path:0:1}" != "#" ]] || continue
+      if [[ "$allow_path" == "$retired_path" && "$allow_hash" == "$file_hash" ]]; then
+        hash_matched=true
+        break
+      fi
+    done <<< "$LOOM_RETIRED_FILES"
+  fi
+  if [[ "$hash_matched" == "true" ]]; then
+    RETIRED_REMOVE+=("$retired_path")
+  else
+    RETIRED_PRESERVE+=("$retired_path")
+  fi
+done <<< "$RETIRED_PATHS"
+
+# Preserved: retired path present, but content matches no shipped version.
+if (( ${#RETIRED_PRESERVE[@]} > 0 )); then
+  for f in "${RETIRED_PRESERVE[@]}"; do
+    info "preserving ${f} (retired by Loom, but on-disk content matches no shipped version — likely consumer-customized; leaving in place)"
+  done
+fi
+
+# Removed: retired path present with unmodified, shipped-identical content.
+if (( ${#RETIRED_REMOVE[@]} > 0 )); then
+  echo ""
+  info "Retired Loom files still present (deleted upstream, unmodified copy on disk):"
+  for f in "${RETIRED_REMOVE[@]}"; do
+    echo "    - $f"
+  done
+  echo ""
+  PROCEED_RETIRED=true
+  if [[ "$NON_INTERACTIVE" != "true" ]] && [[ "$FORCE_OVERWRITE" != "true" ]]; then
+    read -r -p "Remove these ${#RETIRED_REMOVE[@]} retired file(s)? [y/N] " CONFIRM_RETIRED
+    [[ "$CONFIRM_RETIRED" =~ ^[Yy]$ ]] || PROCEED_RETIRED=false
+  fi
+  if [[ "$PROCEED_RETIRED" == "true" ]]; then
+    RETIRED_DELETED=0
+    for f in "${RETIRED_REMOVE[@]}"; do
+      if git rm --quiet --force "$f" 2>/dev/null; then
+        (( RETIRED_DELETED++ )) || true
+      else
+        warning "Could not remove retired file: $f (may have been removed already or is untracked)"
+      fi
+    done
+    success "Removed $RETIRED_DELETED retired Loom file(s)"
+  else
+    info "Skipping retired file removal (user declined)"
+  fi
+fi
+# --- End retired-file cleanup ---
+
 cat > .loom/install-metadata.json <<METADATA
 {
   "loom_version": "${LOOM_VERSION}",

--- a/scripts/test-installer.sh
+++ b/scripts/test-installer.sh
@@ -1293,6 +1293,163 @@ echo ""
 
 
 # ==========================================================================
+# Section 5b: Retired-File Cleanup (#3572)
+# ==========================================================================
+# Exercises the content-gated retired-file cleanup block in install-loom.sh
+# (the "Retired-file cleanup (content-gated)" block after the stale-file
+# sweep). A file on the frozen retired-file allowlist is git-rm'd ONLY when its
+# on-disk content hashes to a shipped digest (unmodified); a consumer-modified
+# copy is preserved; an absent file is a no-op. The gate logic is mirrored
+# inline here (like find_stale_files above) so it can be verified without
+# invoking the full installer, plus a drift guard that asserts the real
+# allowlist in install-loom.sh still carries the digests this mirror expects.
+
+# Mirror of install-loom.sh's LOOM_RETIRED_FILES allowlist (#3572). Keep in
+# sync with install-loom.sh — assert_retired_allowlist_in_sync guards drift.
+RETIRED_ALLOWLIST_MIRROR=$(cat <<'RETIRED'
+.claude/commands/loom/release.md 11aef217942f45bd03d90a24e5efae9209041cb59f09c888df4dc7e8208910dd
+.claude/commands/loom/release.md 0df6c20846c98850413243362c80dea2fd01330c8d97033ef5f7c3989578fe8c
+.claude/commands/loom/release.md c45841f8da42d1bda20bc180c8a93d14242238d9a2c1d9f5a1bdac32b5e9e556
+.claude/commands/loom/release.md d91e198e977ad7799f44fa1a6827c9836bca6d31c9357ed92fc400a3c88381de
+.claude/commands/loom/release.md 0d7030dd14f32f6f382a6430cd04e5f0475825d567aaed7570b73a4c43128ad1
+.claude/commands/loom/release.md 4a077ed25cb44add0afbc4d6bda23cb372f5f3c4c2ef23b7a24b586e66e4f3e7
+.claude/commands/loom/release.md 5f9930dc72a263866122b18018a64b8fed4bd53ef623d0eef27ed1e31fa0502f
+.claude/commands/loom/release.md b7fae9d13d2bfaee3bde514cabe44ac70b6551351a9e49357ede00f82c17cf35
+.claude/commands/loom/release.md f6523d9be058e40397f0ce30c08a8f2b60e9b38adae04bd7c919e0cc840acfec
+.claude/commands/loom/release.md 29a845f7f8912545d23832551753304df6e72dd4a9c8082c2d8ada1f09f449e1
+.claude/commands/loom/release.md 795c1df1d3f3706ba448482b037a0c9e4eb6272a719adb2688b9ddfc91ab4de6
+RETIRED
+)
+
+# The git blob sha of the last release.md version Loom shipped (parent of the
+# #3571 deletion). Immutable + content-addressed; its sha256 is the first row
+# of the mirror above. Used to reconstruct real shipped bytes at test time.
+RETIRED_LAST_SHIPPED_BLOB="b1dac86f43dbe159b1a617b31010cdaab7b88bc5"
+RETIRED_RELEASE_PATH=".claude/commands/loom/release.md"
+
+_test_sha256() { shasum -a 256 "$1" 2>/dev/null | awk '{print $1}'; }
+
+# Mirror of the install-loom.sh gate: prints REMOVE / PRESERVE / NONE for the
+# retired path under repo $1.
+retired_decision() {
+  local repo="$1" rp="$RETIRED_RELEASE_PATH"
+  [[ -f "$repo/$rp" ]] || { echo "NONE"; return 0; }
+  local fh; fh="$(_test_sha256 "$repo/$rp")"
+  local matched=false ap ah
+  if [[ -n "$fh" ]]; then
+    while read -r ap ah; do
+      [[ -n "$ap" && "${ap:0:1}" != "#" ]] || continue
+      if [[ "$ap" == "$rp" && "$ah" == "$fh" ]]; then matched=true; break; fi
+    done <<< "$RETIRED_ALLOWLIST_MIRROR"
+  fi
+  if [[ "$matched" == "true" ]]; then echo "REMOVE"; else echo "PRESERVE"; fi
+}
+
+# Drift guard: every digest in the test mirror must be present in the real
+# install-loom.sh allowlist (and vice-versa for the release.md rows).
+assert_retired_allowlist_in_sync() {
+  local ok=true ap ah
+  while read -r ap ah; do
+    [[ -n "$ap" && "${ap:0:1}" != "#" ]] || continue
+    if ! grep -qF "$ap $ah" "$SCRIPT_DIR/install-loom.sh"; then
+      ok=false
+      warn "mirror digest missing from install-loom.sh: $ap $ah"
+    fi
+  done <<< "$RETIRED_ALLOWLIST_MIRROR"
+  if [[ "$ok" == "true" ]]; then
+    pass "Retired-file allowlist in test mirror matches install-loom.sh"
+  else
+    fail "Retired-file allowlist drifted between test mirror and install-loom.sh"
+  fi
+}
+
+echo "--- Section 5b: Retired-File Cleanup (#3572) ---"
+echo ""
+
+# Test 44a: an unmodified (hash-matching) retired file is removed on update.
+echo "Test 44a: Unmodified retired release.md is removed"
+RETIRED_REMOVE_REPO="$TEST_DIR/retired-remove-test"
+create_temp_repo "$RETIRED_REMOVE_REPO"
+mkdir -p "$RETIRED_REMOVE_REPO/$(dirname "$RETIRED_RELEASE_PATH")"
+if git -C "$LOOM_ROOT" cat-file -e "$RETIRED_LAST_SHIPPED_BLOB" 2>/dev/null; then
+  git -C "$LOOM_ROOT" cat-file blob "$RETIRED_LAST_SHIPPED_BLOB" \
+    > "$RETIRED_REMOVE_REPO/$RETIRED_RELEASE_PATH"
+  git -C "$RETIRED_REMOVE_REPO" add "$RETIRED_RELEASE_PATH"
+  git -C "$RETIRED_REMOVE_REPO" commit -m "Add shipped release.md" --quiet
+
+  # The reconstructed bytes must hash to the head of the allowlist — this is
+  # the real linkage between "what Loom shipped" and "what the gate removes".
+  SHIPPED_HASH="$(_test_sha256 "$RETIRED_REMOVE_REPO/$RETIRED_RELEASE_PATH")"
+  if grep -qF "$RETIRED_RELEASE_PATH $SHIPPED_HASH" "$SCRIPT_DIR/install-loom.sh"; then
+    pass "Reconstructed shipped release.md hash is in install-loom.sh allowlist"
+  else
+    fail "Shipped release.md hash ($SHIPPED_HASH) absent from install-loom.sh allowlist"
+  fi
+
+  if [[ "$(retired_decision "$RETIRED_REMOVE_REPO")" == "REMOVE" ]]; then
+    pass "Unmodified release.md gated for removal"
+  else
+    fail "Unmodified release.md not gated for removal"
+  fi
+  # Apply the sweep (mirrors install-loom.sh git-rm step) and verify removal.
+  git -C "$RETIRED_REMOVE_REPO" rm --quiet --force "$RETIRED_RELEASE_PATH" 2>/dev/null || true
+  if [[ ! -f "$RETIRED_REMOVE_REPO/$RETIRED_RELEASE_PATH" ]]; then
+    pass "Unmodified release.md removed from working tree"
+  else
+    fail "Unmodified release.md still present after cleanup"
+  fi
+
+  # Test 44d: idempotency — a second run with the file already gone is a no-op.
+  echo ""
+  echo "Test 44d: Cleanup is idempotent (second run is a no-op)"
+  if [[ "$(retired_decision "$RETIRED_REMOVE_REPO")" == "NONE" ]]; then
+    pass "Second cleanup run is a no-op (file already absent)"
+  else
+    fail "Second cleanup run did not treat absent file as no-op"
+  fi
+else
+  warn "Skipping Test 44a/44d: shipped release.md blob $RETIRED_LAST_SHIPPED_BLOB unreachable (shallow clone?)"
+fi
+echo ""
+
+# Test 44b: a consumer-modified retired file (hash matches none) is preserved.
+echo "Test 44b: Consumer-modified release.md is preserved"
+RETIRED_KEEP_REPO="$TEST_DIR/retired-keep-test"
+create_temp_repo "$RETIRED_KEEP_REPO"
+mkdir -p "$RETIRED_KEEP_REPO/$(dirname "$RETIRED_RELEASE_PATH")"
+printf '# my customized release skill\nlocal edits here\n' \
+  > "$RETIRED_KEEP_REPO/$RETIRED_RELEASE_PATH"
+git -C "$RETIRED_KEEP_REPO" add "$RETIRED_RELEASE_PATH"
+git -C "$RETIRED_KEEP_REPO" commit -m "Add customized release.md" --quiet
+if [[ "$(retired_decision "$RETIRED_KEEP_REPO")" == "PRESERVE" ]]; then
+  pass "Consumer-modified release.md gated for preservation"
+else
+  fail "Consumer-modified release.md not preserved (hash matched allowlist unexpectedly)"
+fi
+if [[ -f "$RETIRED_KEEP_REPO/$RETIRED_RELEASE_PATH" ]]; then
+  pass "Consumer-modified release.md left on disk"
+else
+  fail "Consumer-modified release.md was removed (should be preserved)"
+fi
+echo ""
+
+# Test 44c: absent retired file is a no-op (no error, no removal).
+echo "Test 44c: Absent release.md is a no-op"
+RETIRED_ABSENT_REPO="$TEST_DIR/retired-absent-test"
+create_temp_repo "$RETIRED_ABSENT_REPO"
+if [[ "$(retired_decision "$RETIRED_ABSENT_REPO")" == "NONE" ]]; then
+  pass "Absent release.md yields no cleanup action"
+else
+  fail "Absent release.md did not yield a no-op"
+fi
+echo ""
+
+# Drift guard: the test mirror's digests must match install-loom.sh.
+assert_retired_allowlist_in_sync
+echo ""
+
+
+# ==========================================================================
 # Section 8: Flag Rejection Tests (#3423 acceptance criteria)
 # ==========================================================================
 # The unknown-flag guard in install-loom.sh (lines ~120-124) fires before any


### PR DESCRIPTION
Closes #3572

## Summary

Pre-#3563 consumers still carry `.claude/commands/loom/release.md` on disk, materializing a dead `/loom:release` command. This adds a **one-time, narrow, idempotent** cleanup to the installer so an unmodified stray is removed on the next `install-loom.sh` update, while a consumer-customized copy is preserved.

## Mechanism

A new **retired-file cleanup block** in `scripts/install-loom.sh`, placed immediately after the `--- End stale-file sweep ---` marker (mirroring the removed #3495 migration block's placement). It is gated on a **frozen sha256 allowlist** of every `release.md` version Loom shipped in the #3495 → #3563 window:

- File exists AND content hash ∈ allowlist → `git rm --quiet --force` (same removal primitive + prompt / `--yes` / `--force` semantics as the stale-file sweep).
- File exists but hash matches none → treated as consumer-customized, **left in place** with an informational line (mirrors the `PRESERVED_NOT_OWNED` style).
- Absent → no-op. Idempotent by construction.

**Why a content-hash gate is exact:** `release.md`'s only placeholder is the Claude-Code *runtime* token `{{workspace}}`, which is NOT in the install-time substitution set (`substitute_template_variables`). Shipped bytes are therefore byte-identical across all consumers. The allowlist is frozen — `release.md` will never ship again.

**Why the generic sweep does not already do this:** the #3492 ownership-boundary intersection preserves any stale-manifest path no longer in the current `defaults/` ownership set. A retired file is not owned, so it is preserved by design. That defense-in-depth is correct and unchanged; the explicit cleanup is what removes the stray.

## Scope decision

**install-loom.sh only.** Quick Install / routine `loom-daemon init` (Rust) bypass this sweep entirely — a matching daemon-side retired-file cleanup (`loom-daemon/src/init/`) is intentionally **deferred to a follow-up** to keep this change narrow and reviewable, per the curator's recommendation (A).

## Files

- `scripts/install-loom.sh` — retired-file cleanup block + portable `_loom_sha256` helper.
- `defaults/.loom-internal.list` — #3563 note updated: the stray is now **actively removed on update** (content-gated), not "deleted by hand".
- `scripts/test-installer.sh` — new **Section 5b** mirroring the Section 5 pattern.

## Test results

`bash scripts/test-installer.sh` → **111 passed, 0 failed**. New Section 5b:

- 44a: unmodified (hash-matching) `release.md` reconstructed from git history is gated for removal and git-rm'd; its hash is asserted present in the real `install-loom.sh` allowlist (verifies the shipped-bytes ↔ gate linkage).
- 44b: consumer-modified `release.md` is preserved on disk.
- 44c: absent `release.md` is a no-op.
- 44d: idempotency — a second run with the file already gone is a no-op.
- Drift guard: every digest in the test mirror is present in `install-loom.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)