### PR TITLE
chore(gitignore): ignore .claude/skills for co-install hygiene (#3578)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,19 @@ Thumbs.db
 # to the daemon's `update_gitignore` list in loom-daemon/src/init/post_init.rs.
 .claude/commands
 
+# Co-install hygiene (issue #3578, sibling of #3565):
+# Loom ships no skills of its own (`defaults/.claude/skills/` does not exist),
+# so `.claude/skills/` in the live tree is a pure destination for co-installed
+# tools that write `.claude/skills/<ns>/…` (e.g. `repo` writes
+# `.claude/skills/repo/SKILL.md`). Ignoring it keeps a foreign tool's files
+# from being accidentally staged into loom's tree by `git add -A`.
+# IMPORTANT: this ignore lives ONLY in loom's own committed .gitignore. It must
+# NOT be added to the daemon's `update_gitignore` list in
+# loom-daemon/src/init/post_init.rs, so consumer repos keep any skills they author TRACKED.
+# If loom ever ships its own skills, materialize/dogfood them like
+# `.claude/commands/loom/` (out of scope here).
+.claude/skills
+
 # Skill routing local overrides (untracked, user-specific)
 .loom/config/skill-routes.local.json
 .loom/*.log


### PR DESCRIPTION
Closes #3578

## Summary
Adds `.claude/skills` to loom's own committed `.gitignore`, mirroring the existing `.claude/commands` block (#3565). Loom ships no skills of its own (`defaults/.claude/skills/` does not exist, nothing tracked under `.claude/skills/`), so a blanket ignore is correct today and removes nothing.

Without this, a co-installed tool writing `.claude/skills/<ns>/…` (e.g. `repo` writes `.claude/skills/repo/SKILL.md`) lands as an untracked, non-ignored directory that `git add -A` would stage into loom's tree.

## Scope
- Edits **only** `.gitignore` — one comment block + one `.claude/skills` entry after the `.claude/commands` block.
- Does **not** touch `loom-daemon/src/init/post_init.rs` (`update_gitignore` / `ephemeral_patterns`), so consumer repos keep any skills they author tracked.
- Does not create `defaults/.claude/skills/`; removes no tracked files.

## Verification (in worktree)
- `git check-ignore .claude/skills/testns/foo.md` → path echoed (ignored)
- `git status --porcelain .claude/skills` → empty
- `git add -A --dry-run` → stages nothing under `.claude/skills/`
- `git diff --name-only` → only `.gitignore`