### PR TITLE
fix(guard): segment-parse lifecycle/cloud-delete patterns to stop prose false-positives (#3584)

### DIFF
--- a/defaults/hooks/guard-destructive.sh
+++ b/defaults/hooks/guard-destructive.sh
@@ -197,29 +197,29 @@ ALWAYS_BLOCK_PATTERNS=(
     'wget .* \| .*sh'
     'wget .* -O- \| sh'
 
-    # Cloud infrastructure destruction
+    # Cloud infrastructure destruction. The aws forms below are specific
+    # multi-token phrases, so they stay in this raw substring scan. The az/gcloud
+    # CLIs, by contrast, need command-word anchoring — an unanchored `az.*delete`
+    # matches "h·az·ard … delete" across unrelated prose tokens (#3584) — so they
+    # are handled by the segment-parsed lifecycle/cloud check further below, NOT
+    # here.
     'aws s3 rm.*--recursive'
     'aws s3 rb'
     'aws ec2 terminate'
     'aws iam delete'
     'aws cloudformation delete-stack'
-    'gcloud.*delete'
-    'az.*delete'
-    'az group delete'
 
     # Docker mass destruction
     'docker system prune'
 
-    # System reboot/shutdown — command-position + trailing-boundary anchored so
-    # a flag name (e.g. --instance-initiated-shutdown-behavior) or the word in a
-    # comment/message ("this reboots the box") no longer trips them, while the
-    # bare command (optionally sudo-prefixed, or after a separator) still denies.
-    '(^|[;&|[:space:]])reboot([;&|[:space:]]|$)'
-    '(^|[;&|[:space:]])shutdown([;&|[:space:]]|$)'
-    '(^|[;&|[:space:]])halt([;&|[:space:]]|$)'
-    '(^|[;&|[:space:]])poweroff([;&|[:space:]]|$)'
-    '(^|[;&|[:space:]])init[[:space:]]+0([;&|[:space:]]|$)'
-    '(^|[;&|[:space:]])init[[:space:]]+6([;&|[:space:]]|$)'
+    # NOTE: system-lifecycle commands (halt/reboot/poweroff/shutdown/init 0/
+    # init 6) are deliberately NOT in this raw substring scan. Even the
+    # whitespace-inclusive boundary anchor they used to carry still fired inside
+    # ordinary prose ("...the box will halt", "...after a reboot event"), and a
+    # pure regex tweak can't separate `sudo halt` from `will halt` (both are
+    # "<word> halt"). They are handled by the segment-parsed check below, which
+    # denies only when a segment's *command word* is exactly the lifecycle word
+    # (#3584).
 )
 
 for pattern in "${ALWAYS_BLOCK_PATTERNS[@]}"; do
@@ -246,6 +246,69 @@ if [[ "$COMMAND" == *"#"* ]]; then
     COMMAND_NO_COMMENT=$(printf '%s\n' "$COMMAND" | sed -E 's/(^|[[:space:]])#.*$//')
 else
     COMMAND_NO_COMMENT="$COMMAND"
+fi
+
+# =============================================================================
+# SYSTEM-LIFECYCLE + CLOUD-CLI DELETE (segment-parsed, command-word anchored)
+#
+# The system-lifecycle commands (halt/reboot/poweroff/shutdown/init 0/init 6)
+# and the az/gcloud cloud-delete CLIs are far too common as ordinary prose,
+# identifiers, and flag names to scan as unanchored substrings — and even a
+# whitespace-inclusive boundary anchor still fired inside comments and commit
+# messages ("...the box will halt", "...after a reboot event"). A pure regex
+# tweak cannot separate `sudo halt` (a real command) from `will halt` (prose)
+# because both are "<word> halt".
+#
+# So we segment-parse instead, mirroring extract_rm_targets(): split the command
+# on ; | & && || and newline, strip a leading sudo/env wrapper from each segment,
+# and deny only when a segment's *command word* (first token) is exactly a
+# lifecycle word — or is `az`/`gcloud` with a `delete` subcommand token. This
+# distinguishes `sudo halt` (command word = halt) from `will halt` (command word
+# = echo/other) and from `--instance-initiated-shutdown-behavior` (not a command
+# word at all). The scan runs against COMMAND_NO_COMMENT so a lifecycle/cloud
+# word sitting in a trailing comment is already gone. The catastrophic
+# ALWAYS_BLOCK scan above still reads the raw string for the symbolic patterns
+# (rm -rf /, the fork bomb, curl|sh) that are not prose-prone (#3584).
+# =============================================================================
+lifecycle_or_cloud_reason() {
+    # Emit a deny reason (one per line) for every segment whose command word is a
+    # system-lifecycle command or an az/gcloud delete. Portable awk only.
+    printf '%s' "$1" | awk '
+    {
+        gsub(/&&|\|\||[;|&]/, "\n")
+        n = split($0, segs, "\n")
+        for (i = 1; i <= n; i++) {
+            seg = segs[i]
+            sub(/^[ \t]+/, "", seg)
+            sub(/^sudo[ \t]+/, "", seg)
+            sub(/^env[ \t]+/, "", seg)
+            sub(/^[ \t]+/, "", seg)
+            m = split(seg, toks, /[ \t]+/)
+            if (m == 0) continue
+            cmd = toks[1]
+            if (cmd == "halt" || cmd == "reboot" || cmd == "poweroff" || cmd == "shutdown") {
+                print "system lifecycle command: " cmd
+                continue
+            }
+            if (cmd == "init" && (toks[2] == "0" || toks[2] == "6")) {
+                print "system lifecycle command: init " toks[2]
+                continue
+            }
+            if (cmd == "az" || cmd == "gcloud") {
+                for (j = 2; j <= m; j++) {
+                    if (toks[j] == "delete") {
+                        print "cloud resource deletion: " cmd " delete"
+                        break
+                    }
+                }
+            }
+        }
+    }'
+}
+
+_LIFECYCLE_REASON=$(lifecycle_or_cloud_reason "$COMMAND_NO_COMMENT" | head -1)
+if [[ -n "$_LIFECYCLE_REASON" ]]; then
+    deny "BLOCKED: $_LIFECYCLE_REASON"
 fi
 
 # =============================================================================

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -713,6 +713,49 @@ assert_allow "Allow HOST=cat(...); ssh ... rm -rf remote-path (phantom class)" \
 echo ""
 
 # =========================================================================
+echo -e "${YELLOW}--- #3584: lifecycle/cloud words in prose no longer DENY ---${NC}"
+# =========================================================================
+
+# The ALWAYS_BLOCK lifecycle words (halt/reboot/poweroff/shutdown/init 0/init 6)
+# and the az/gcloud cloud-delete CLIs were unanchored (or anchored only to a
+# whitespace-inclusive boundary), so they DENIED on ordinary prose in comments,
+# commit messages, and flag names. Command-word segment parsing (#3584) fixes
+# this: they now deny ONLY when a segment's command word is exactly the word.
+
+# 1. `halt` inside a trailing comment must ALLOW (comment-stripped, and its
+#    command word is `echo`, not `halt`).
+assert_allow "Allow 'halt' in a trailing comment (#3584)" \
+    'echo "stopping" # stops billing then the box will halt'
+
+# 2. `reboot` inside a commit message must ALLOW (command word is `git`).
+assert_allow "Allow 'reboot' inside a commit message (#3584)" \
+    'git commit -m "recover cleanly after a reboot event"'
+
+# 3. `az`/`delete` as substrings of unrelated prose tokens (h·az·ard … delete)
+#    must ALLOW — the command word is `gh`, not `az`/`gcloud`.
+assert_allow "Allow 'hazard...delete' prose in a gh pr comment body (#3584)" \
+    'gh pr comment --body "the hazard here is a swallowed delete of a row"'
+
+# 4. `shutdown` inside a flag name must NOT deny. `aws ec2` is an ASK gate, so
+#    ASK is the acceptable outcome per the issue's Acceptance (never DENY).
+assert_ask "Ask (not deny) for 'shutdown' inside an aws ec2 flag name (#3584)" \
+    "aws ec2 run-instances --instance-initiated-shutdown-behavior stop"
+
+# Regression: the lifecycle/cloud words as STANDALONE commands still DENY.
+assert_deny "Regression (#3584): 'az group delete' as command word still denied" \
+    "az group delete my-rg --yes"
+assert_deny "Regression (#3584): 'gcloud ... delete' as command word still denied" \
+    "gcloud compute instances delete my-instance"
+assert_deny "Regression (#3584): standalone 'halt' still denied" \
+    "halt"
+assert_deny "Regression (#3584): 'sudo reboot' still denied" \
+    "sudo reboot"
+assert_deny "Regression (#3584): 'foo && reboot' still denied" \
+    "foo && reboot"
+
+echo ""
+
+# =========================================================================
 echo -e "${YELLOW}--- #3553 regression guard: catastrophic commands STILL deny ---${NC}"
 # =========================================================================
 


### PR DESCRIPTION
Closes #3584

## Problem

`defaults/hooks/guard-destructive.sh`'s `ALWAYS_BLOCK` catastrophic scan produced false-positive DENIES on ordinary prose/identifiers:

| Command (abridged) | Before | Why |
|---|---|---|
| `... # stops billing then the box will halt` | deny | `halt` in a trailing comment matched the whitespace-boundary anchor |
| `git commit -m "recover cleanly after a reboot event"` | deny | `reboot` in a commit message |
| `gh pr comment --body "the hazard here is a swallowed delete of a row"` | deny | unanchored `az.*delete` matched h·**az**·ard … **delete** |
| `aws ec2 run-instances --instance-initiated-shutdown-behavior stop` | ask | `shutdown` inside a flag name |

The lifecycle words were already anchored (PR #3564) but to `[;&|[:space:]]`, so whitespace-surrounded prose still matched. A pure regex tweak can't fix it: dropping `[:space:]` breaks the required `sudo halt`/`sudo reboot` DENY cases, since both `sudo halt` and `will halt` are `<word> halt`.

## Fix

Segment-parse instead, mirroring the existing `extract_rm_targets()`:

- Split the command on `;` `&&` `||` `|` and newline.
- Strip a leading `sudo`/`env` wrapper from each segment.
- Deny only when a segment's **command word** (first token) is exactly a lifecycle word (`halt`/`reboot`/`poweroff`/`shutdown`, or `init 0`/`init 6`) — or is `az`/`gcloud` with a `delete` subcommand token.
- Runs against `COMMAND_NO_COMMENT`, so a lifecycle/cloud word in a trailing comment is already gone.

The lifecycle patterns and `az.*delete`/`gcloud.*delete`/`az group delete` are removed from the raw `ALWAYS_BLOCK_PATTERNS` array. `rm -rf /`, the fork bomb, and `curl|sh` keep scanning the raw string (symbolic, not prose-prone); the `aws` multi-token phrases stay in the raw scan too.

## Source of truth

Only `defaults/hooks/guard-destructive.sh` is edited — the repo convention (and the test harness header) treat `defaults/hooks/` as canonical; the tracked `.loom/hooks/` copy is a stale install artifact that the prior fix #3564 also left untouched.

## Tests

`tests/hooks/test-guard-destructive.sh` gains the four documented false-positive cases (3 `assert_allow`, 1 `assert_ask` for the flag-name case) plus command-word regression cases (`az group delete`, `gcloud … delete`, standalone `halt`, `sudo reboot`, `foo && reboot`).

Full suite: **179/179 pass**, including the entire catastrophic regression set (`rm -rf /`, force-push to main, `gh repo delete`, `aws ec2 terminate`, `aws s3 rb`, `curl|sh`, fork bomb, lifecycle standalone commands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)