### PR TITLE
fix(guard): resolve command word past env NAME=value assignments in lifecycle guard

### DIFF
--- a/defaults/hooks/guard-destructive.sh
+++ b/defaults/hooks/guard-destructive.sh
@@ -281,7 +281,25 @@ lifecycle_or_cloud_reason() {
             seg = segs[i]
             sub(/^[ \t]+/, "", seg)
             sub(/^sudo[ \t]+/, "", seg)
-            sub(/^env[ \t]+/, "", seg)
+            # Strip a leading `env` wrapper, then loop-strip the env flags and
+            # NAME=value assignments a shell resolves past before the command
+            # word, so `env FOO=bar halt` resolves to command word `halt` (not
+            # `FOO=bar`) and still denies. `env -i FOO=bar halt` and `env -u
+            # NAME halt` likewise resolve to `halt`. A bare `env halt` (no
+            # assignment) is unaffected — the loop matches nothing and leaves
+            # `halt` as the command word. Portable awk only (no GNU/BSD-specific
+            # escapes), consistent with extract_rm_targets(). (#3586)
+            if (sub(/^env([ \t]+|$)/, "", seg)) {
+                sub(/^[ \t]+/, "", seg)
+                stripped = 1
+                while (stripped) {
+                    stripped = 0
+                    if (sub(/^-u[ \t]+[^ \t]+([ \t]+|$)/, "", seg)) { stripped = 1; continue }
+                    if (sub(/^-i([ \t]+|$)/, "", seg))              { stripped = 1; continue }
+                    if (sub(/^--([ \t]+|$)/, "", seg))              { break }
+                    if (sub(/^[A-Za-z_][A-Za-z0-9_]*=[^ \t]*([ \t]+|$)/, "", seg)) { stripped = 1; continue }
+                }
+            }
             sub(/^[ \t]+/, "", seg)
             m = split(seg, toks, /[ \t]+/)
             if (m == 0) continue

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -753,6 +753,21 @@ assert_deny "Regression (#3584): 'sudo reboot' still denied" \
 assert_deny "Regression (#3584): 'foo && reboot' still denied" \
     "foo && reboot"
 
+# #3586: `env` wrapper with NAME=value assignments / flags must resolve the
+# command word past the env prelude and still DENY. `env halt` (no assignment)
+# already worked; the assignment forms regressed under the #3585 command-word
+# anchoring because `toks[1]` was `FOO=bar` instead of `halt`.
+assert_deny "Regression (#3586): 'env halt' still denied" \
+    "env halt"
+assert_deny "Regression (#3586): 'env FOO=bar halt' resolves command word past assignment" \
+    "env FOO=bar halt"
+assert_deny "Regression (#3586): 'env FOO=bar BAZ=qux halt' skips multiple assignments" \
+    "env FOO=bar BAZ=qux halt"
+assert_deny "Regression (#3586): 'env -i FOO=bar halt' skips flag + assignment" \
+    "env -i FOO=bar halt"
+assert_deny "Regression (#3586): 'env -u NAME reboot' skips two-token -u flag" \
+    "env -u SOMEVAR reboot"
+
 echo ""
 
 # =========================================================================


### PR DESCRIPTION
## Summary

`defaults/hooks/guard-destructive.sh` — the `lifecycle_or_cloud_reason()` segment parser (added by #3585) stripped only a bare `env ` wrapper via `sub(/^env[ \t]+/, "", seg)` before taking the first whitespace token as the command word. For `env FOO=bar halt` the segment became `FOO=bar halt`, so the command word resolved to `FOO=bar` (not `halt`) and the command slipped past the lifecycle deny. `env halt` (no assignment) correctly denied. This was a narrow regression from the #3585 command-word anchoring.

## Changes

- `defaults/hooks/guard-destructive.sh`: in the `env`-strip step, after stripping a leading `env`, loop-strip leading env flags (`-i`, two-token `-u NAME`, `--`) and `NAME=value` environment assignments before taking the command word — mirroring how a shell/env resolves the command word past an env prelude. Portable awk only (BSD/POSIX), consistent with `extract_rm_targets()`. The fix lives entirely inside `lifecycle_or_cloud_reason()`; the catastrophic `ALWAYS_BLOCK` scan is untouched.
- `tests/hooks/test-guard-destructive.sh`: added five #3586 regression cases in the #3584 block covering `env halt`, `env FOO=bar halt`, multi-assignment, `env -i FOO=bar halt`, and the two-token `env -u NAME reboot` form.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `env FOO=bar halt` → DENY | ✅ | New assertion passes |
| `env -i FOO=bar halt` → DENY | ✅ | New assertion passes |
| Fix confined to `lifecycle_or_cloud_reason()`; ALWAYS_BLOCK untouched | ✅ | Diff only edits the env-strip step in that function |
| `env halt` still DENY (loop must not skip a bare command word) | ✅ | New assertion passes |
| `sudo halt`, standalone `halt`, `foo && reboot`, `sudo reboot` still DENY | ✅ | Existing #3584 regressions green |
| Four #3584 prose false-positive ALLOW/ASK cases still pass | ✅ | Existing assertions green |
| `az group delete` / `gcloud ... delete` command words still DENY | ✅ | Existing assertions green |
| Full suite passes | ✅ | 184/184 passed |

## Test Plan

`bash tests/hooks/test-guard-destructive.sh` → `Total: 184, Passed: 184, Failed: 0, ALL TESTS PASSED`. The test targets the canonical `defaults/hooks/guard-destructive.sh` source of truth (not the gitignored `.loom/hooks/` install artifact), matching the #3585 convention.

Closes #3586