### PR TITLE
fix(install): make .gitignore install/uninstall round-trip byte-idempotent (#3590)

### DIFF
--- a/loom-daemon/src/init/post_init.rs
+++ b/loom-daemon/src/init/post_init.rs
@@ -63,6 +63,81 @@ pub fn find_overbroad_loom_patterns(workspace_path: &Path) -> Vec<String> {
     found
 }
 
+/// Sentinel that opens the Loom-managed `.gitignore` block.
+///
+/// The managed block is delimited by [`GITIGNORE_BEGIN_MARKER`] and
+/// [`GITIGNORE_END_MARKER`] so that both `update_gitignore` (add/refresh) and
+/// `scripts/uninstall-loom.sh` (remove) operate on a single, self-locating,
+/// contiguous region. This mirrors the `<!-- BEGIN/END LOOM ORCHESTRATION -->`
+/// convention already used for CLAUDE.md. See issue #3590.
+pub const GITIGNORE_BEGIN_MARKER: &str = "# >>> loom-managed (do not edit) >>>";
+
+/// Sentinel that closes the Loom-managed `.gitignore` block.
+pub const GITIGNORE_END_MARKER: &str = "# <<< loom-managed <<<";
+
+/// Human-readable header emitted inside the managed block. Pre-#3590 installs
+/// wrote this same line as a bare (markerless) header; detecting it lets us
+/// migrate those installs to the marked form in place.
+const GITIGNORE_BLOCK_HEADER: &str = "# Loom runtime state (don't commit these)";
+
+/// Ephemeral/runtime files that should be ignored — the single source of truth
+/// for the Loom-managed `.gitignore` block.
+///
+/// Keep in sync with the Loom source repo's `.gitignore`.
+///
+/// Phase 3.5 (#3402, epic #3372): removed patterns for retired daemon-brain
+/// state files (`daemon-state.json`, archived `[0-9][0-9]-daemon-state.json`,
+/// `progress/`, `stuck-history.json`, `alerts.json`, `health-metrics.json`)
+/// and added `spawn-loop-state.json` for the Phase 1 spawn loop (#3374).
+pub const EPHEMERAL_PATTERNS: &[&str] = &[
+    ".loom-in-use",
+    ".loom-checkpoint",
+    ".loom/.daemon.pid",
+    ".loom/.daemon.log",
+    ".loom/daemon.sock",
+    ".loom/daemon-loop.pid",
+    ".loom/daemon-metrics.json",
+    ".loom/loom-source-path",
+    ".loom/spawn-loop-state.json",
+    ".loom/issue-failures.json",
+    ".loom/interventions/",
+    ".loom/worktrees/",
+    ".loom/state.json",
+    ".loom/mcp-command.json",
+    ".loom/activity.db",
+    ".loom/claims/",
+    ".loom/signals/",
+    ".loom/status/",
+    ".loom/retry-state/",
+    ".loom/diagnostics/",
+    ".loom/guide-docs-state.json",
+    ".loom/metrics_state.json",
+    ".loom/manifest.json",
+    ".loom/stuck-config.json",
+    ".loom/metrics/",
+    ".loom/usage-cache.json",
+    ".loom/claude-config/",
+    ".loom/*.log",
+    ".loom/*.sock",
+    ".loom/logs/",
+];
+
+/// Build the Loom-managed `.gitignore` block (marker lines + header + patterns),
+/// with no leading or trailing newline. Callers add surrounding newlines.
+fn managed_gitignore_block() -> String {
+    let mut block = String::new();
+    block.push_str(GITIGNORE_BEGIN_MARKER);
+    block.push('\n');
+    block.push_str(GITIGNORE_BLOCK_HEADER);
+    block.push('\n');
+    for pattern in EPHEMERAL_PATTERNS {
+        block.push_str(pattern);
+        block.push('\n');
+    }
+    block.push_str(GITIGNORE_END_MARKER);
+    block
+}
+
 /// Generate installation manifest by running verify-install.sh
 ///
 /// Attempts to run `.loom/scripts/verify-install.sh generate --quiet` to create
@@ -106,122 +181,70 @@ pub fn generate_manifest(workspace_path: &Path) {
 /// Creates .gitignore if it doesn't exist.
 pub fn update_gitignore(workspace_path: &Path) -> Result<(), String> {
     let gitignore_path = workspace_path.join(".gitignore");
+    let block = managed_gitignore_block();
 
-    // Ephemeral/runtime files that should be ignored.
-    // Keep in sync with the Loom source repo's .gitignore (lines 36–78).
-    //
-    // Phase 3.5 (#3402, epic #3372): removed patterns for retired daemon-brain
-    // state files (`daemon-state.json`, archived `[0-9][0-9]-daemon-state.json`,
-    // `progress/`, `stuck-history.json`, `alerts.json`, `health-metrics.json`)
-    // and added `spawn-loop-state.json` for the Phase 1 spawn loop (#3374).
-    let ephemeral_patterns = [
-        ".loom-in-use",
-        ".loom-checkpoint",
-        ".loom/.daemon.pid",
-        ".loom/.daemon.log",
-        ".loom/daemon.sock",
-        ".loom/daemon-loop.pid",
-        ".loom/daemon-metrics.json",
-        ".loom/loom-source-path",
-        ".loom/spawn-loop-state.json",
-        ".loom/issue-failures.json",
-        ".loom/interventions/",
-        ".loom/worktrees/",
-        ".loom/state.json",
-        ".loom/mcp-command.json",
-        ".loom/activity.db",
-        ".loom/claims/",
-        ".loom/signals/",
-        ".loom/status/",
-        ".loom/retry-state/",
-        ".loom/diagnostics/",
-        ".loom/guide-docs-state.json",
-        ".loom/metrics_state.json",
-        ".loom/manifest.json",
-        ".loom/stuck-config.json",
-        ".loom/metrics/",
-        ".loom/usage-cache.json",
-        ".loom/claude-config/",
-        ".loom/*.log",
-        ".loom/*.sock",
-        ".loom/logs/",
-    ];
-
-    // Legacy patterns that should be removed during migration.
-    // These overly broad patterns block config.json from being tracked.
-    let legacy_patterns_to_remove = [".loom/*.json", ".loom/config.json"];
-
-    if gitignore_path.exists() {
-        let contents = fs::read_to_string(&gitignore_path)
-            .map_err(|e| format!("Failed to read .gitignore: {e}"))?;
-
-        let mut new_contents = contents.clone();
-        let mut modified = false;
-
-        // Remove legacy patterns that block config.json from being tracked.
-        // Older installs and /imagine used `.loom/*.json` which is too broad.
-        for legacy in &legacy_patterns_to_remove {
-            // Remove lines that exactly match the legacy pattern (with optional trailing whitespace)
-            let filtered: Vec<&str> = new_contents
-                .lines()
-                .filter(|line| line.trim() != *legacy)
-                .collect();
-            let joined = filtered.join("\n");
-            // Preserve trailing newline
-            let joined = if new_contents.ends_with('\n') && !joined.ends_with('\n') {
-                format!("{joined}\n")
-            } else {
-                joined
-            };
-            if joined != new_contents {
-                new_contents = joined;
-                modified = true;
-            }
-        }
-
-        // Also remove negation patterns that were paired with the legacy *.json glob
-        let negation_legacy = "!.loom/roles/*.json";
-        let filtered: Vec<&str> = new_contents
-            .lines()
-            .filter(|line| line.trim() != negation_legacy)
-            .collect();
-        let joined = filtered.join("\n");
-        let joined = if new_contents.ends_with('\n') && !joined.ends_with('\n') {
-            format!("{joined}\n")
-        } else {
-            joined
-        };
-        if joined != new_contents {
-            new_contents = joined;
-            modified = true;
-        }
-
-        // Add ephemeral patterns if not present
-        for pattern in &ephemeral_patterns {
-            if !new_contents.contains(pattern) {
-                if !new_contents.ends_with('\n') {
-                    new_contents.push('\n');
-                }
-                new_contents.push_str(pattern);
-                new_contents.push('\n');
-                modified = true;
-            }
-        }
-
-        // Write back if we made changes
-        if modified {
-            fs::write(&gitignore_path, new_contents)
-                .map_err(|e| format!("Failed to write .gitignore: {e}"))?;
-        }
-    } else {
-        // Create .gitignore with ephemeral patterns
-        let mut loom_entries = String::from("# Loom runtime state (don't commit these)\n");
-        for pattern in &ephemeral_patterns {
-            loom_entries.push_str(pattern);
-            loom_entries.push('\n');
-        }
-        fs::write(&gitignore_path, loom_entries)
+    // Create a fresh .gitignore containing only the managed block.
+    if !gitignore_path.exists() {
+        fs::write(&gitignore_path, format!("{block}\n"))
             .map_err(|e| format!("Failed to create .gitignore: {e}"))?;
+        return Ok(());
+    }
+
+    let contents = fs::read_to_string(&gitignore_path)
+        .map_err(|e| format!("Failed to read .gitignore: {e}"))?;
+
+    // Split on '\n'. When the file ends with '\n', the trailing element is an
+    // empty string; joining back with '\n' reproduces the original bytes
+    // exactly, so line-vector edits are byte-preserving for untouched regions.
+    let mut lines: Vec<String> = contents.split('\n').map(str::to_string).collect();
+
+    // Remove legacy over-broad patterns that block config.json from being
+    // tracked (older installs and /imagine used `.loom/*.json`), plus the
+    // negation that was paired with that glob.
+    let legacy_overbroad = [".loom/*.json", ".loom/config.json", "!.loom/roles/*.json"];
+    lines.retain(|line| !legacy_overbroad.contains(&line.trim()));
+
+    let begin = lines
+        .iter()
+        .position(|l| l.trim() == GITIGNORE_BEGIN_MARKER);
+    let end = lines.iter().position(|l| l.trim() == GITIGNORE_END_MARKER);
+
+    let block_lines: Vec<String> = block.split('\n').map(str::to_string).collect();
+
+    match (begin, end) {
+        (Some(b), Some(e)) if b <= e => {
+            // Marked block already present: refresh it in place (patterns may
+            // have changed between versions) without moving it.
+            lines.splice(b..=e, block_lines.iter().cloned());
+        }
+        _ => {
+            // No marked block. Migrate any legacy markerless block by dropping
+            // the old header and any bare ephemeral pattern lines, then append
+            // the marked block at EOF (the one-time create-at-EOF path).
+            lines.retain(|line| {
+                let t = line.trim();
+                t != GITIGNORE_BLOCK_HEADER && !EPHEMERAL_PATTERNS.contains(&t)
+            });
+            // Drop exactly one trailing empty element (the file's final '\n')
+            // so the block is appended directly after the existing content with
+            // no spurious blank line. This makes the append the exact inverse of
+            // uninstall's marker-span deletion, so an install -> uninstall ->
+            // install round-trip is byte-identical (issue #3590).
+            if lines.last().is_some_and(String::is_empty) {
+                lines.pop();
+            }
+            for bl in &block_lines {
+                lines.push(bl.clone());
+            }
+            // Re-add exactly one trailing empty element => single trailing '\n'.
+            lines.push(String::new());
+        }
+    }
+
+    let new_contents = lines.join("\n");
+    if new_contents != contents {
+        fs::write(&gitignore_path, &new_contents)
+            .map_err(|e| format!("Failed to write .gitignore: {e}"))?;
     }
 
     Ok(())
@@ -522,5 +545,142 @@ mod tests {
 
         // Non-Loom content preserved
         assert!(contents.contains("node_modules/"));
+    }
+
+    /// Mimic `scripts/uninstall-loom.sh`'s marker-span deletion: drop every
+    /// line from the BEGIN marker through the END marker (inclusive).
+    fn remove_managed_block(contents: &str) -> String {
+        let mut out: Vec<&str> = Vec::new();
+        let mut in_block = false;
+        for line in contents.split('\n') {
+            if line.trim() == GITIGNORE_BEGIN_MARKER {
+                in_block = true;
+                continue;
+            }
+            if in_block {
+                if line.trim() == GITIGNORE_END_MARKER {
+                    in_block = false;
+                }
+                continue;
+            }
+            out.push(line);
+        }
+        out.join("\n")
+    }
+
+    #[test]
+    fn create_wraps_patterns_in_markers() {
+        let tmp = TempDir::new().unwrap();
+        update_gitignore(tmp.path()).unwrap();
+        let contents = fs::read_to_string(tmp.path().join(".gitignore")).unwrap();
+
+        assert!(contents.contains(GITIGNORE_BEGIN_MARKER), "missing BEGIN marker");
+        assert!(contents.contains(GITIGNORE_END_MARKER), "missing END marker");
+        // BEGIN must precede END, and each appears exactly once.
+        assert_eq!(contents.matches(GITIGNORE_BEGIN_MARKER).count(), 1);
+        assert_eq!(contents.matches(GITIGNORE_END_MARKER).count(), 1);
+        let b = contents.find(GITIGNORE_BEGIN_MARKER).unwrap();
+        let e = contents.find(GITIGNORE_END_MARKER).unwrap();
+        assert!(b < e, "BEGIN marker must precede END marker");
+        // Patterns live inside the block.
+        assert!(contents.contains(".loom/worktrees/"));
+    }
+
+    #[test]
+    fn in_place_update_does_not_move_or_duplicate_block() {
+        let tmp = TempDir::new().unwrap();
+        let gitignore = tmp.path().join(".gitignore");
+
+        // User content that already carries a marked block, followed by more
+        // user content AFTER the block (so an EOF re-append would reorder it).
+        fs::write(
+            &gitignore,
+            format!(
+                "node_modules/\n{block}\n# trailing user content\ndist/\n",
+                block = managed_gitignore_block()
+            ),
+        )
+        .unwrap();
+
+        update_gitignore(tmp.path()).unwrap();
+        let contents = fs::read_to_string(&gitignore).unwrap();
+
+        // Exactly one block, refreshed in place.
+        assert_eq!(contents.matches(GITIGNORE_BEGIN_MARKER).count(), 1);
+        assert_eq!(contents.matches(GITIGNORE_END_MARKER).count(), 1);
+        // Content after the block is untouched and still after the block.
+        let end_pos = contents.find(GITIGNORE_END_MARKER).unwrap();
+        let trailing_pos = contents.find("# trailing user content").unwrap();
+        assert!(trailing_pos > end_pos, "trailing user content must not move");
+        assert!(contents.contains("node_modules/"));
+        assert!(contents.contains("dist/"));
+    }
+
+    #[test]
+    fn roundtrip_is_byte_identical() {
+        // install -> uninstall -> install on a committed, customized .gitignore
+        // (whose Loom block is exactly what install produces) must be a no-op at
+        // the byte level. This is the core acceptance criterion of issue #3590.
+        let tmp = TempDir::new().unwrap();
+        let gitignore = tmp.path().join(".gitignore");
+
+        // A realistic consumer .gitignore.
+        fs::write(&gitignore, "# consumer rules\nnode_modules/\n__pycache__/\n.venv/\n*.log\n")
+            .unwrap();
+
+        // First install writes the managed block.
+        update_gitignore(tmp.path()).unwrap();
+        let after_install = fs::read_to_string(&gitignore).unwrap();
+        assert!(after_install.contains(GITIGNORE_BEGIN_MARKER));
+
+        // Simulate `uninstall-loom.sh` removing the marked span, then reinstall.
+        let after_uninstall = remove_managed_block(&after_install);
+        fs::write(&gitignore, &after_uninstall).unwrap();
+        update_gitignore(tmp.path()).unwrap();
+        let after_reinstall = fs::read_to_string(&gitignore).unwrap();
+
+        assert_eq!(
+            after_install, after_reinstall,
+            "install -> uninstall -> install must be byte-identical"
+        );
+
+        // And uninstall fully removes the Loom block (no residual patterns).
+        assert!(!after_uninstall.contains(GITIGNORE_BEGIN_MARKER));
+        assert!(!after_uninstall.contains(GITIGNORE_END_MARKER));
+        assert!(!after_uninstall.contains(".loom/worktrees/"));
+        assert!(!after_uninstall.contains("# Loom runtime state"));
+        // User content survives the uninstall verbatim.
+        assert_eq!(
+            after_uninstall,
+            "# consumer rules\nnode_modules/\n__pycache__/\n.venv/\n*.log\n"
+        );
+    }
+
+    #[test]
+    fn migrates_legacy_markerless_block_in_place() {
+        let tmp = TempDir::new().unwrap();
+        let gitignore = tmp.path().join(".gitignore");
+
+        // Pre-#3590 install: bare header + bare patterns, no markers.
+        fs::write(
+            &gitignore,
+            "node_modules/\n# Loom runtime state (don't commit these)\n\
+             .loom/state.json\n.loom/worktrees/\n.loom/*.log\n",
+        )
+        .unwrap();
+
+        update_gitignore(tmp.path()).unwrap();
+        let contents = fs::read_to_string(&gitignore).unwrap();
+
+        // Migrated to the marked form.
+        assert_eq!(contents.matches(GITIGNORE_BEGIN_MARKER).count(), 1);
+        assert_eq!(contents.matches(GITIGNORE_END_MARKER).count(), 1);
+        // No duplicate bare patterns outside the block.
+        assert_eq!(contents.matches(".loom/state.json").count(), 1);
+        assert_eq!(contents.matches(".loom/worktrees/").count(), 1);
+        // Now idempotent: a second run is a no-op.
+        update_gitignore(tmp.path()).unwrap();
+        let again = fs::read_to_string(&gitignore).unwrap();
+        assert_eq!(contents, again, "post-migration update must be idempotent");
     }
 }

--- a/scripts/test-install-quick-gitignore-stash.sh
+++ b/scripts/test-install-quick-gitignore-stash.sh
@@ -207,6 +207,79 @@ else
 fi
 echo ""
 
+# --------------------------------------------------------------------------
+# Scenario 6 (issue #3590): install -> uninstall -> install on a repo with a
+# committed, customized .gitignore is byte-identical, and uninstall removes the
+# entire Loom-managed block (marker-delimited). This asserts the round-trip is
+# reversible at the byte level — the root cause #3589 only worked around.
+#
+# FAILS against pre-#3590 code: uninstall stripped a drifted 4-pattern subset +
+# reflowed blank lines, and init re-appended at EOF, so the block moved and
+# ~26 patterns were left behind.
+# --------------------------------------------------------------------------
+UNINSTALL_SCRIPT="$LOOM_ROOT/scripts/uninstall-loom.sh"
+R6="$TEST_DIR/roundtrip-byte-identical"
+git init -q "$R6"
+git -C "$R6" config user.email test@example.com
+git -C "$R6" config user.name "Test User"
+# A customized consumer .gitignore with intentional spacing and no Loom content.
+printf '# consumer rules\nnode_modules/\ntarget/\n\n*.log\ndist/\n' >"$R6/.gitignore"
+echo "hello" >"$R6/README.md"
+git -C "$R6" add -A
+git -C "$R6" commit -qm "init"
+# First install writes the marked Loom block; commit it as the baseline.
+"$INSTALL_SCRIPT" -y --quick "$R6" >/dev/null 2>&1
+git -C "$R6" add -A
+git -C "$R6" commit -qm "loom install" >/dev/null 2>&1
+cp "$R6/.gitignore" "$TEST_DIR/gi-baseline"
+
+# Sanity: the marked block exists after install.
+if grep -qxF "# >>> loom-managed (do not edit) >>>" "$R6/.gitignore" && \
+   grep -qxF "# <<< loom-managed <<<" "$R6/.gitignore"; then
+  pass "install writes a marker-delimited Loom block"
+else
+  fail "install did not write marker-delimited Loom block (#3590)"
+fi
+
+# install -> uninstall -> install (a second --quick reinstall runs uninstall+init
+# internally). With no user edits it must be a byte-for-byte no-op.
+"$INSTALL_SCRIPT" -y --quick "$R6" >/dev/null 2>&1
+if diff -q "$TEST_DIR/gi-baseline" "$R6/.gitignore" >/dev/null; then
+  pass ".gitignore is byte-identical after install -> uninstall -> install (#3590)"
+else
+  fail ".gitignore changed across the round-trip (not byte-stable — #3590)"
+  diff "$TEST_DIR/gi-baseline" "$R6/.gitignore" || true
+fi
+if git -C "$R6" diff --exit-code -- .gitignore >/dev/null 2>&1; then
+  pass "git diff shows no .gitignore movement after round-trip"
+else
+  fail "git diff shows .gitignore movement after round-trip (#3590)"
+fi
+
+# Uninstall alone must remove the ENTIRE Loom block (markers + all patterns),
+# leaving the user's consumer content (and its blank line) verbatim.
+"$UNINSTALL_SCRIPT" --yes --local "$R6" >/dev/null 2>&1 || true
+if [[ -f "$R6/.gitignore" ]]; then
+  if grep -q "loom-managed" "$R6/.gitignore" 2>/dev/null || \
+     grep -qxF ".loom/worktrees/" "$R6/.gitignore" 2>/dev/null || \
+     grep -qxF ".loom/logs/" "$R6/.gitignore" 2>/dev/null || \
+     grep -q "# Loom runtime state" "$R6/.gitignore" 2>/dev/null; then
+    fail "uninstall left residual Loom patterns in .gitignore (#3590)"
+  else
+    pass "uninstall removed the entire Loom-managed block (no residue)"
+  fi
+  if diff -q <(printf '# consumer rules\nnode_modules/\ntarget/\n\n*.log\ndist/\n') \
+       "$R6/.gitignore" >/dev/null; then
+    pass "uninstall preserved consumer content + spacing verbatim"
+  else
+    fail "uninstall mutated consumer content/spacing outside the block (#3590)"
+    diff <(printf '# consumer rules\nnode_modules/\ntarget/\n\n*.log\ndist/\n') "$R6/.gitignore" || true
+  fi
+else
+  fail "uninstall hard-deleted a .gitignore that still had consumer content (#3590)"
+fi
+echo ""
+
 echo "======================================"
 echo "Test Summary"
 echo "======================================"

--- a/scripts/uninstall-loom.sh
+++ b/scripts/uninstall-loom.sh
@@ -1005,41 +1005,88 @@ if [[ -f "$WORKTREE_ABS/.loom/CLAUDE.md" ]]; then
   success ".loom/CLAUDE.md removed"
 fi
 
-# Handle .gitignore - remove Loom-specific patterns
+# Handle .gitignore - remove the Loom-managed block
+#
+# Issue #3590: the Loom-managed region is delimited by sentinel markers written
+# by `update_gitignore` (loom-daemon/src/init/post_init.rs). Deleting the whole
+# marked span in one pass is the single source of truth — it removes every Loom
+# pattern (not a drifted 4-item subset) and never reflows user spacing outside
+# the block, so an install -> uninstall -> install round-trip is byte-stable.
+# The markers mirror the `<!-- BEGIN/END LOOM ORCHESTRATION -->` convention used
+# for CLAUDE.md above.
 if [[ -f "$WORKTREE_ABS/.gitignore" ]]; then
   info "Removing Loom patterns from .gitignore..."
 
   GITIGNORE="$WORKTREE_ABS/.gitignore"
 
-  # Loom-specific patterns to remove (exact matches)
-  LOOM_PATTERNS=(
-    ".loom/state.json"
-    ".loom/worktrees/"
-    ".loom/*.log"
-    ".loom/*.sock"
-    "# Loom - AI Development Orchestration"
-  )
+  # Keep these in sync with post_init.rs (GITIGNORE_BEGIN_MARKER / END_MARKER).
+  GITIGNORE_BEGIN_MARKER="# >>> loom-managed (do not edit) >>>"
+  GITIGNORE_END_MARKER="# <<< loom-managed <<<"
 
   MODIFIED=false
-  for pattern in "${LOOM_PATTERNS[@]}"; do
-    if grep -qF "$pattern" "$GITIGNORE" 2>/dev/null; then
-      # Remove the exact line
-      grep -vF "$pattern" "$GITIGNORE" > "${GITIGNORE}.tmp" || true
-      mv "${GITIGNORE}.tmp" "$GITIGNORE"
-      MODIFIED=true
-    fi
-  done
+
+  if grep -qxF "$GITIGNORE_BEGIN_MARKER" "$GITIGNORE" 2>/dev/null && \
+     grep -qxF "$GITIGNORE_END_MARKER" "$GITIGNORE" 2>/dev/null; then
+    # Marker-delimited block: delete BEGIN..END inclusive in a single pass.
+    # Exact-line matching (awk `$0==`) needs no regex escaping and leaves every
+    # other line — including user blank lines — byte-for-byte untouched.
+    awk -v b="$GITIGNORE_BEGIN_MARKER" -v e="$GITIGNORE_END_MARKER" '
+      $0 == b { inblock = 1; next }
+      inblock { if ($0 == e) inblock = 0; next }
+      { print }
+    ' "$GITIGNORE" > "${GITIGNORE}.tmp" && mv "${GITIGNORE}.tmp" "$GITIGNORE"
+    MODIFIED=true
+  else
+    # Backward-compat: legacy markerless installs (pre-#3590) wrote a header
+    # plus bare patterns. Remove the known headers and the full authoritative
+    # pattern set by exact whole-line match. This enumerated list exists ONLY
+    # for these legacy files; the marker path above is the source of truth for
+    # current installs. Blank lines are left as-is (no whole-file reflow).
+    LOOM_LEGACY_LINES=(
+      "# Loom runtime state (don't commit these)"
+      "# Loom - AI Development Orchestration"
+      ".loom-in-use"
+      ".loom-checkpoint"
+      ".loom/.daemon.pid"
+      ".loom/.daemon.log"
+      ".loom/daemon.sock"
+      ".loom/daemon-loop.pid"
+      ".loom/daemon-metrics.json"
+      ".loom/loom-source-path"
+      ".loom/spawn-loop-state.json"
+      ".loom/issue-failures.json"
+      ".loom/interventions/"
+      ".loom/worktrees/"
+      ".loom/state.json"
+      ".loom/mcp-command.json"
+      ".loom/activity.db"
+      ".loom/claims/"
+      ".loom/signals/"
+      ".loom/status/"
+      ".loom/retry-state/"
+      ".loom/diagnostics/"
+      ".loom/guide-docs-state.json"
+      ".loom/metrics_state.json"
+      ".loom/manifest.json"
+      ".loom/stuck-config.json"
+      ".loom/metrics/"
+      ".loom/usage-cache.json"
+      ".loom/claude-config/"
+      ".loom/*.log"
+      ".loom/*.sock"
+      ".loom/logs/"
+    )
+    for pattern in "${LOOM_LEGACY_LINES[@]}"; do
+      if grep -qxF "$pattern" "$GITIGNORE" 2>/dev/null; then
+        grep -vxF "$pattern" "$GITIGNORE" > "${GITIGNORE}.tmp" || true
+        mv "${GITIGNORE}.tmp" "$GITIGNORE"
+        MODIFIED=true
+      fi
+    done
+  fi
 
   if [[ "$MODIFIED" == "true" ]]; then
-    # Clean up consecutive blank lines left by removal
-    awk 'NF || prev_blank++ < 1 { print; if (NF) prev_blank=0 }' "$GITIGNORE" > "${GITIGNORE}.tmp"
-    mv "${GITIGNORE}.tmp" "$GITIGNORE"
-
-    # Remove trailing blank lines (awk equivalent, consistent with the
-    # consecutive-blank-line trim immediately above).
-    awk 'NF || prev_blank++ < 1 { print; if (NF) prev_blank=0 }' "$GITIGNORE" > "${GITIGNORE}.tmp" && mv "${GITIGNORE}.tmp" "$GITIGNORE"
-
-    # If file is now empty, remove it
+    # If file is now empty (or only whitespace), remove it
     if [[ ! -s "$GITIGNORE" ]] || ! grep -q '[^[:space:]]' "$GITIGNORE" 2>/dev/null; then
       rm -f "$GITIGNORE"
       REMOVED_LIST+=(".gitignore")


### PR DESCRIPTION
Closes #3590

## Problem

The install/uninstall `.gitignore` round-trip was non-idempotent (root cause behind #3588, only worked around by #3589):

1. **Pattern-list drift** — `uninstall-loom.sh` hardcoded only 4 patterns + a stale header, while `post_init.rs::update_gitignore` wrote ~30 patterns. Uninstall left ~26 patterns + the header behind.
2. **Whole-file reflow + EOF re-append** — uninstall's two `awk` passes collapsed blank lines across the entire file, and init always re-appended at EOF, so the block moved every uninstall -> install cycle.

## Fix (marker-delimited managed block)

Wrap the Loom `.gitignore` region in sentinels (mirroring the `<!-- BEGIN/END LOOM ORCHESTRATION -->` convention used for CLAUDE.md):

```
# >>> loom-managed (do not edit) >>>
# Loom runtime state (don't commit these)
<~30 runtime patterns>
# <<< loom-managed <<<
```

- **`post_init.rs`**: `update_gitignore` refreshes the marked block **in place** (never moves it); appends at EOF only when no block exists; migrates legacy markerless blocks to the marked form. Pattern list hoisted to a module-level `EPHEMERAL_PATTERNS` const (single source of truth). Line ops split/join on `\n` so untouched regions stay byte-exact.
- **`uninstall-loom.sh`**: deletes the whole marked span in one exact-match `awk` pass; drops the drifted 4-item list and both whole-file blank-line reflow passes. A legacy fallback still removes the old headers + full pattern set for pre-marker installs.

The #3589 reset-to-HEAD stash workaround in `install.sh` is left untouched and still passes its suite; it can be simplified in a later pass now that the round-trip is byte-stable.

## Verification

- `cargo test --lib post_init` — 17 pass, incl. new tests: marker wrapping, in-place update (no move/duplicate), legacy migration idempotency, and a byte-identical install/uninstall/install round-trip.
- `cargo build --release` + `cargo clippy --lib` — clean for changed code (only a pre-existing unrelated pedantic warning in a forge file remains).
- `bash -n scripts/uninstall-loom.sh` — OK.
- `scripts/test-installer.sh` — 111 pass (Test 18 + legacy Test 48 gitignore paths green).
- `scripts/test-install-quick-gitignore-stash.sh` — 16 pass (5 new #3590 checks). **Verified the new round-trip scenario FAILS against pre-change code** (byte movement + ~26 residual patterns after uninstall) and passes after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)