### PR TITLE
fix(guard): narrow cloud ASK to mutating verbs, add cloudCli toggle, downgrade ec2-terminate to ask

### DIFF
--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -908,7 +908,7 @@ Loom ships with built-in guard hooks (`guard-destructive.sh` for dangerous Bash 
 
 `guard-destructive.sh` blocks SQL DDL/DML patterns — `DROP DATABASE`, `DROP TABLE`, `DROP SCHEMA`, `TRUNCATE TABLE`, and `DELETE FROM` without a `WHERE` clause. For most repos this is a useful safety net, but for a project that is **itself a database engine** (e.g. a SQLite-compatible engine running a SQL conformance suite) those statements are the product's own dev/test vocabulary and the guard is a category error — the match is a case-insensitive substring, so it even fires when the words appear in a comment or a `--description` label.
 
-Such repos can opt out of the SQL guard while keeping every other guard (`rm -rf /`, force-push to `main`, `gh repo delete`, `aws ec2 terminate`, `aws s3 rb`, etc.) fully active.
+Such repos can opt out of the SQL guard while keeping every other guard (`rm -rf /`, force-push to `main`, `gh repo delete`, `aws s3 rb`, `aws iam delete`, etc.) fully active.
 
 The SQL guard is **on by default**. It is resolved in this order (highest precedence first):
 
@@ -936,6 +936,42 @@ LOOM_GUARD_SQL=0 vibesql -c "DROP TABLE t"
 
 # Force the SQL guard on for one command even when the repo opts out
 LOOM_GUARD_SQL=1 psql -c "DROP TABLE users"
+```
+
+### Cloud CLI Guard Opt-Out (`guards.cloudCli` / `LOOM_GUARD_CLOUD`)
+
+`guard-destructive.sh` asks for confirmation on **mutating** cloud/container CLI calls — `aws ec2 run-instances`/`create-*`/`stop-instances`/`start-instances`/`terminate-instances`, `aws s3 rm`/`rb`/`cp`/`mv`/`sync`, other mutating `aws <service> <verb>` forms, and `docker rm`/`rmi`/`stop`/`kill`/`restart`. Read-only calls (`aws ec2 describe-instances`, `aws s3 ls`, `aws lambda list-functions`, `docker ps`, `docker logs`, etc.) are **not** prompted. For a repo whose *purpose* is managing cloud infrastructure (launch/stop/terminate dev VMs, build/tear-down containers), even the mutating asks are workflow friction rather than a safety win.
+
+Such repos can opt out of the cloud/docker ASK category while keeping every other guard active — including the genuinely catastrophic cloud denies (`aws s3 rm ... --recursive`, `aws s3 rb`, `aws iam delete-*`, `aws cloudformation delete-stack`, `docker system prune`), which are **never** gated by this toggle and stay hard denies even with the cloud guard off.
+
+The cloud guard is **on by default**. It is resolved in this order (highest precedence first):
+
+1. **`LOOM_GUARD_CLOUD` env var** — `0`/`false`/`no` disables the cloud/docker ASK category; `1`/`true`/`yes` forces it on. Overrides the config value.
+2. **`.loom/config.json`** — `guards.cloudCli` (default `true` when absent). Set it to `false` to disable:
+   ```json
+   {
+     "guards": {
+       "cloudCli": false
+     }
+   }
+   ```
+3. **Default** — `true` (guard on).
+
+The config read is best-effort: a missing, empty, or malformed `.loom/config.json` falls through to guard-ON and never causes the hook to exit non-zero. Only the cloud/docker ASK patterns are affected — disabling the cloud guard does not weaken the catastrophic cloud denies or any other guard.
+
+Note: `aws ec2 terminate-instances` is an **ask** (not a hard deny) so a legitimate VM-teardown workflow is possible; with `guards.cloudCli:false` / `LOOM_GUARD_CLOUD=0` it passes through without prompting.
+
+**Examples**:
+
+```bash
+# Tear down a dev VM without a prompt for a single command
+LOOM_GUARD_CLOUD=0 aws ec2 terminate-instances --instance-ids i-1234
+
+# Persist the opt-out for a cloud-management repo
+#   .loom/config.json  ->  { "guards": { "cloudCli": false } }
+
+# Force the cloud guard on for one command even when the repo opts out
+LOOM_GUARD_CLOUD=1 aws ec2 terminate-instances --instance-ids i-1234
 ```
 
 ### Protecting Read-Only Directories

--- a/defaults/hooks/guard-destructive.sh
+++ b/defaults/hooks/guard-destructive.sh
@@ -618,7 +618,8 @@ done
 # comment-stripped command): only mutating subcommands match, never read-only
 # describe*/get*/list*/ls. So `aws ec2 describe-instances`, `aws s3 ls`, and
 # `aws lambda list-functions` no longer prompt, while `run-instances`,
-# `create-*`, `terminate-instances`, `stop-instances`, etc. still ask.
+# `create-*`, `terminate-instances`, `stop-instances`, `lambda invoke`,
+# `lambda publish*`, `sns publish`, etc. still ask.
 #
 # The docker entries already name only mutating verbs (rm/rmi/stop/kill/restart)
 # and never match read-only `docker ps`/`docker logs`, so they are unchanged —
@@ -628,9 +629,17 @@ CLOUD_ASK_PATTERNS=(
     # aws mutating subcommands (verb-anchored). The service list covers the
     # common infra-mutating namespaces; the verb list is the mutating vocabulary
     # (never describe*/get*/list*/ls). terminate lands here — an ask, not a deny.
-    'aws (ec2|lambda|s3api|rds|iam|autoscaling|cloudformation|eks|ecs|elb|elbv2|route53|dynamodb|sns|sqs) (run|create|delete|terminate|stop|start|modify|update|put|reboot|authorize|revoke|attach|detach|associate|disassociate|register|deregister|enable|disable|add|remove|set|import|restore|reset|cancel|scale)'
-    # aws s3 (high-level) mutating verbs. `ls` is intentionally excluded.
-    'aws s3 (rm|rb|cp|mv|sync)'
+    # invoke/publish are mutating (lambda invoke runs arbitrary code with side
+    # effects; lambda publish-version / publish-layer-version and sns publish
+    # mutate state) — there is no read-only `aws <svc> invoke|publish`, so they
+    # cannot introduce describe/get/list false-positives. copy (ec2
+    # copy-image/copy-snapshot) and assign (ec2 assign-*-addresses) are likewise
+    # mutating-only. All were caught by the pre-#3593 bare `aws ec2|lambda`
+    # prefixes and must stay asks (#3595).
+    'aws (ec2|lambda|s3api|rds|iam|autoscaling|cloudformation|eks|ecs|elb|elbv2|route53|dynamodb|sns|sqs) (run|create|delete|terminate|stop|start|modify|update|put|reboot|authorize|revoke|attach|detach|associate|disassociate|register|deregister|enable|disable|add|remove|set|import|restore|reset|cancel|scale|invoke|publish|copy|assign)'
+    # aws s3 (high-level) mutating verbs. `ls` is intentionally excluded. `mb`
+    # (make-bucket) is mutating and was caught by the old bare `aws s3` prefix.
+    'aws s3 (rm|rb|cp|mv|sync|mb)'
 
     # Docker operations (already mutating-verb only; does not match docker ps/logs)
     'docker rm'

--- a/defaults/hooks/guard-destructive.sh
+++ b/defaults/hooks/guard-destructive.sh
@@ -117,6 +117,49 @@ sql_guard_enabled() {
     [[ "$_SQL_GUARD_CACHE" == "true" ]]
 }
 
+# =============================================================================
+# Cloud CLI guard toggle — default ON.
+#
+# The cloud/docker ASK patterns (mutating aws ec2/lambda/s3/... subcommands and
+# docker rm/rmi/stop/kill/restart) prompt for confirmation on every match. For a
+# repo whose *purpose* is managing cloud infrastructure (launch/stop/terminate
+# dev VMs, build/tear-down containers), that friction is a category error — the
+# mutating calls are the product's own dev/test vocabulary. Such repos opt out;
+# everyone else keeps the guard on. The genuinely catastrophic aws/docker denies
+# in ALWAYS_BLOCK_PATTERNS are NOT gated by this toggle and stay active.
+#
+# Resolution order (highest precedence first):
+#   1. LOOM_GUARD_CLOUD env var (0/false/no disables, 1/true/yes forces on)
+#   2. .loom/config.json  ->  guards.cloudCli  (default true when absent)
+#   3. Default: true (guard on)
+#
+# Mirrors sql_guard_enabled() exactly: cached in _CLOUD_GUARD_CACHE, invoked
+# LAZILY only after a cloud pattern has already matched so the jq config read
+# never touches the hot path for non-cloud commands. The config read is
+# best-effort: any parse failure falls through to guard-ON.
+# =============================================================================
+_CLOUD_GUARD_CACHE=""
+cloud_guard_enabled() {
+    if [[ -z "$_CLOUD_GUARD_CACHE" ]]; then
+        local enabled=true
+        if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/config.json" ]]; then
+            # jq // is alternative-on-null, not default-on-missing, so use
+            # if/then/else to treat only an explicit `false` as disabled (a
+            # missing guards.cloudCli key stays on). On malformed JSON jq exits
+            # non-zero and the `||` fallback restores the guard-ON default.
+            enabled=$(jq -r 'if .guards.cloudCli == false then "false" else "true" end' "$REPO_ROOT/.loom/config.json" 2>/dev/null) || enabled=true
+            [[ -n "$enabled" ]] || enabled=true
+        fi
+        # Env override wins over config.
+        case "${LOOM_GUARD_CLOUD:-}" in
+            0|false|no)  enabled=false ;;
+            1|true|yes)  enabled=true ;;
+        esac
+        _CLOUD_GUARD_CACHE="$enabled"
+    fi
+    [[ "$_CLOUD_GUARD_CACHE" == "true" ]]
+}
+
 # Helper: output a deny decision and exit
 deny() {
     local reason="$1"
@@ -203,9 +246,14 @@ ALWAYS_BLOCK_PATTERNS=(
     # matches "h·az·ard … delete" across unrelated prose tokens (#3584) — so they
     # are handled by the segment-parsed lifecycle/cloud check further below, NOT
     # here.
+    # NOTE: `aws ec2 terminate` is deliberately NOT in this raw catastrophic
+    # scan. For a repo whose job is standing up and tearing down dev VMs the
+    # teardown path (`terminate-instances`) is a first-class workflow, so it is
+    # downgraded to an ask via the toggle-gated CLOUD_ASK_PATTERNS below (and
+    # fully bypassed when LOOM_GUARD_CLOUD=0 / guards.cloudCli:false). The other
+    # aws forms here stay ungated — they remain a hard safety floor (#3593).
     'aws s3 rm.*--recursive'
     'aws s3 rb'
-    'aws ec2 terminate'
     'aws iam delete'
     'aws cloudformation delete-stack'
 
@@ -526,17 +574,9 @@ ASK_PATTERNS=(
     'gh release delete'
     'gh label delete'
 
-    # Cloud CLI operations
-    'aws s3'
-    'aws ec2'
-    'aws lambda'
-
-    # Docker operations
-    'docker rm'
-    'docker rmi'
-    'docker stop'
-    'docker kill'
-    'docker restart'
+    # NOTE: cloud CLI (aws) + docker ASK patterns are NOT in this ungated array.
+    # They live in CLOUD_ASK_PATTERNS below, gated by cloud_guard_enabled() so
+    # cloud-dev repos can opt down (LOOM_GUARD_CLOUD=0 / guards.cloudCli:false).
 
     # Service management
     'systemctl restart'
@@ -562,6 +602,46 @@ ASK_PATTERNS=(
 
 for pattern in "${ASK_PATTERNS[@]}"; do
     if echo "$COMMAND_NO_COMMENT" | grep -qE "$pattern"; then
+        ask "Command requires confirmation: $COMMAND"
+    fi
+done
+
+# =============================================================================
+# CLOUD CLI ASK patterns — gated by the cloud CLI guard toggle
+#
+# Kept separate from ASK_PATTERNS so cloud-dev repos can opt out
+# (guards.cloudCli:false / LOOM_GUARD_CLOUD=0). cloud_guard_enabled() is
+# consulted only AFTER a cloud pattern matches, so the config read stays off the
+# hot path for non-cloud commands (mirrors the SQL DDL block above).
+#
+# The aws entries are VERB-ANCHORED (case-sensitive ERE against the
+# comment-stripped command): only mutating subcommands match, never read-only
+# describe*/get*/list*/ls. So `aws ec2 describe-instances`, `aws s3 ls`, and
+# `aws lambda list-functions` no longer prompt, while `run-instances`,
+# `create-*`, `terminate-instances`, `stop-instances`, etc. still ask.
+#
+# The docker entries already name only mutating verbs (rm/rmi/stop/kill/restart)
+# and never match read-only `docker ps`/`docker logs`, so they are unchanged —
+# they only move under this toggle.
+# =============================================================================
+CLOUD_ASK_PATTERNS=(
+    # aws mutating subcommands (verb-anchored). The service list covers the
+    # common infra-mutating namespaces; the verb list is the mutating vocabulary
+    # (never describe*/get*/list*/ls). terminate lands here — an ask, not a deny.
+    'aws (ec2|lambda|s3api|rds|iam|autoscaling|cloudformation|eks|ecs|elb|elbv2|route53|dynamodb|sns|sqs) (run|create|delete|terminate|stop|start|modify|update|put|reboot|authorize|revoke|attach|detach|associate|disassociate|register|deregister|enable|disable|add|remove|set|import|restore|reset|cancel|scale)'
+    # aws s3 (high-level) mutating verbs. `ls` is intentionally excluded.
+    'aws s3 (rm|rb|cp|mv|sync)'
+
+    # Docker operations (already mutating-verb only; does not match docker ps/logs)
+    'docker rm'
+    'docker rmi'
+    'docker stop'
+    'docker kill'
+    'docker restart'
+)
+
+for pattern in "${CLOUD_ASK_PATTERNS[@]}"; do
+    if echo "$COMMAND_NO_COMMENT" | grep -qE "$pattern" && cloud_guard_enabled; then
         ask "Command requires confirmation: $COMMAND"
     fi
 done

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -707,6 +707,29 @@ assert_ask "Cloud: aws s3 cp (mutating) asks" \
     "aws s3 cp ./file s3://my-bucket/file"
 assert_ask "Cloud: aws lambda delete-function asks" \
     "aws lambda delete-function --function-name f"
+# --- #3595: invoke/publish/copy/assign/mb restored to the mutating verb list ---
+# aws lambda invoke executes arbitrary Lambda code with side effects; it is
+# neither read-only nor a catastrophic deny, so the pre-#3595 verb-narrowing
+# silently un-gated it. Restore the ask (toggle on).
+assert_ask "Cloud: aws lambda invoke asks (toggle on, #3595)" \
+    "aws lambda invoke --function-name f out.json"
+assert_ask "Cloud: aws lambda publish-version asks (#3595)" \
+    "aws lambda publish-version --function-name f"
+assert_ask "Cloud: aws lambda publish-layer-version asks (#3595)" \
+    "aws lambda publish-layer-version --layer-name l --zip-file fileb://l.zip"
+assert_ask "Cloud: aws sns publish asks (#3595)" \
+    "aws sns publish --topic-arn arn:aws:sns:us-east-1:1:t --message hi"
+assert_ask "Cloud: aws ec2 copy-image asks (#3595)" \
+    "aws ec2 copy-image --source-image-id ami-123 --source-region us-east-1 --name copy"
+assert_ask "Cloud: aws ec2 assign-private-ip-addresses asks (#3595)" \
+    "aws ec2 assign-private-ip-addresses --network-interface-id eni-123 --secondary-private-ip-address-count 1"
+assert_ask "Cloud: aws s3 mb (make-bucket) asks (#3595)" \
+    "aws s3 mb s3://my-new-bucket"
+# invoke/publish must NOT re-broaden into read-only false-positives.
+assert_allow "Cloud: aws lambda get-function is read-only (allow, #3595)" \
+    "aws lambda get-function --function-name f"
+assert_allow "Cloud: aws sns list-topics is read-only (allow, #3595)" \
+    "aws sns list-topics"
 
 # --- Docker verbs unchanged: mutating asks, read-only allowed (toggle on) ---
 assert_ask "Cloud: docker rm still asks" \
@@ -730,6 +753,8 @@ assert_allow "Cloud config-off: aws ec2 terminate-instances allowed" \
     "aws ec2 terminate-instances --instance-ids i-1234" "$CLOUD_OFF_REPO"
 assert_allow "Cloud config-off: aws ec2 run-instances allowed" \
     "aws ec2 run-instances --image-id ami-123" "$CLOUD_OFF_REPO"
+assert_allow "Cloud config-off: aws lambda invoke allowed (#3595)" \
+    "aws lambda invoke --function-name f out.json" "$CLOUD_OFF_REPO"
 assert_allow "Cloud config-off: docker rm allowed" \
     "docker rm my-container" "$CLOUD_OFF_REPO"
 
@@ -744,6 +769,8 @@ assert_ask "Cloud config-on: docker rm still asks" \
 # --- Env override: LOOM_GUARD_CLOUD=0 bypasses even when config says true ---
 assert_allow_env "LOOM_GUARD_CLOUD=0 overrides config-on: aws ec2 terminate allowed" \
     "LOOM_GUARD_CLOUD=0" "aws ec2 terminate-instances --instance-ids i-1234" "$CLOUD_ON_REPO"
+assert_allow_env "LOOM_GUARD_CLOUD=0: aws lambda invoke allowed (#3595)" \
+    "LOOM_GUARD_CLOUD=0" "aws lambda invoke --function-name f out.json" "$CLOUD_ON_REPO"
 assert_allow_env "LOOM_GUARD_CLOUD=0: docker rm allowed" \
     "LOOM_GUARD_CLOUD=0" "docker rm my-container" "$CLOUD_ON_REPO"
 

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -132,6 +132,24 @@ assert_allow_env() {
     fi
 }
 
+# Assert ask with an env assignment + cwd (repo root).
+assert_ask_env() {
+    local description="$1"; local env_kv="$2"; local cmd="$3"; local cwd="${4:-$REPO_ROOT}"
+    TOTAL=$((TOTAL + 1))
+    local output
+    output=$(run_guard_env "$env_kv" "$cmd" "$cwd") || true
+    if echo "$output" | jq -e '.hookSpecificOutput.permissionDecision == "ask"' >/dev/null 2>&1; then
+        PASS=$((PASS + 1))
+        echo -e "  ${GREEN}PASS${NC}: $description"
+    else
+        FAIL=$((FAIL + 1))
+        echo -e "  ${RED}FAIL${NC}: $description"
+        echo -e "       Command: $cmd (env: ${env_kv:-none}, cwd: $cwd)"
+        echo -e "       Expected: ask"
+        echo -e "       Got: $output"
+    fi
+}
+
 # Assert the guard denies a command when inside a worktree
 assert_deny_in_worktree() {
     local description="$1"
@@ -303,7 +321,9 @@ assert_deny "Block aws s3 rm recursive" \
 assert_deny "Block aws s3 rb" \
     "aws s3 rb s3://my-bucket --force"
 
-assert_deny "Block aws ec2 terminate" \
+# aws ec2 terminate-instances is no longer an ALWAYS_BLOCK deny (#3593) — it is
+# a toggle-gated ask (see the cloud-toggle section below).
+assert_ask "Ask (not deny) for aws ec2 terminate-instances (#3593)" \
     "aws ec2 terminate-instances --instance-ids i-1234"
 
 assert_deny "Block gcloud delete" \
@@ -423,7 +443,8 @@ assert_ask "Ask for gh issue close" \
 assert_ask "Ask for gh release delete" \
     "gh release delete v1.0"
 
-assert_ask "Ask for aws s3 ls" \
+# aws s3 ls is read-only — verb-narrowed cloud ASK patterns no longer prompt (#3593).
+assert_allow "Allow aws s3 ls (read-only, #3593)" \
     "aws s3 ls"
 
 assert_ask "Ask for docker rm" \
@@ -625,7 +646,9 @@ assert_deny "SQL config-off: force-push to main still blocked" \
     "git push --force origin main" "$SQL_OFF_REPO"
 assert_deny "SQL config-off: gh repo delete still blocked" \
     "gh repo delete myrepo --yes" "$SQL_OFF_REPO"
-assert_deny "SQL config-off: aws ec2 terminate still blocked" \
+# aws ec2 terminate-instances is no longer an ALWAYS_BLOCK deny (#3593); with the
+# SQL guard off (cloud guard still on) it is a toggle-gated ask.
+assert_ask "SQL config-off: aws ec2 terminate-instances now asks (#3593)" \
     "aws ec2 terminate-instances --instance-ids i-1234" "$SQL_OFF_REPO"
 assert_deny "SQL config-off: aws s3 rb still blocked" \
     "aws s3 rb s3://my-bucket --force" "$SQL_OFF_REPO"
@@ -649,6 +672,108 @@ assert_deny_env "LOOM_GUARD_SQL=0: rm -rf / still blocked" \
 # Clean up temp repos created above.
 for _sql_dir in "$SQL_OFF_REPO" "$SQL_ON_REPO" "$SQL_ABSENT_REPO" "$SQL_BAD_REPO"; do
     [[ -n "$_sql_dir" && "$_sql_dir" != "/" && -d "$_sql_dir/.loom" ]] && rm -rf "$_sql_dir"
+done
+
+echo ""
+
+# =========================================================================
+echo -e "${YELLOW}--- Cloud CLI opt-out + verb-narrowing (guards.cloudCli / LOOM_GUARD_CLOUD) (#3593) ---${NC}"
+# =========================================================================
+
+# --- Verb-narrowing: read-only aws calls no longer prompt (default guard on) ---
+assert_allow "Cloud: aws ec2 describe-instances is read-only (allow)" \
+    "aws ec2 describe-instances"
+assert_allow "Cloud: aws ec2 describe-images is read-only (allow)" \
+    "aws ec2 describe-images --owners self"
+assert_allow "Cloud: aws s3 ls is read-only (allow)" \
+    "aws s3 ls s3://my-bucket"
+assert_allow "Cloud: aws lambda list-functions is read-only (allow)" \
+    "aws lambda list-functions"
+assert_allow "Cloud: aws ec2 get-console-output is read-only (allow)" \
+    "aws ec2 get-console-output --instance-id i-1234"
+
+# --- Verb-narrowing: mutating aws subcommands still ask (default guard on) ---
+assert_ask "Cloud: aws ec2 run-instances asks" \
+    "aws ec2 run-instances --image-id ami-123 --count 1"
+assert_ask "Cloud: aws ec2 create-volume asks" \
+    "aws ec2 create-volume --size 10 --availability-zone us-east-1a"
+assert_ask "Cloud: aws ec2 stop-instances asks" \
+    "aws ec2 stop-instances --instance-ids i-1234"
+assert_ask "Cloud: aws ec2 start-instances asks" \
+    "aws ec2 start-instances --instance-ids i-1234"
+assert_ask "Cloud: aws ec2 terminate-instances asks (toggle on)" \
+    "aws ec2 terminate-instances --instance-ids i-1234"
+assert_ask "Cloud: aws s3 cp (mutating) asks" \
+    "aws s3 cp ./file s3://my-bucket/file"
+assert_ask "Cloud: aws lambda delete-function asks" \
+    "aws lambda delete-function --function-name f"
+
+# --- Docker verbs unchanged: mutating asks, read-only allowed (toggle on) ---
+assert_ask "Cloud: docker rm still asks" \
+    "docker rm my-container"
+assert_ask "Cloud: docker stop still asks" \
+    "docker stop my-container"
+assert_allow "Cloud: docker ps still allowed (read-only)" \
+    "docker ps -a"
+assert_allow "Cloud: docker logs still allowed (read-only)" \
+    "docker logs my-container"
+
+# Repos toggling the cloud guard via .loom/config.json (reuse make_sql_repo — it
+# just writes arbitrary config JSON).
+CLOUD_OFF_REPO=$(make_sql_repo '{"guards":{"cloudCli":false}}')
+CLOUD_ON_REPO=$(make_sql_repo '{"guards":{"cloudCli":true}}')
+CLOUD_ABSENT_REPO=$(make_sql_repo '{"champion":{"auto_merge_max_lines":200}}')
+CLOUD_BAD_REPO=$(make_sql_repo '{ not valid json ')
+
+# --- Config opt-out: guards.cloudCli:false fully bypasses cloud/docker ASK ---
+assert_allow "Cloud config-off: aws ec2 terminate-instances allowed" \
+    "aws ec2 terminate-instances --instance-ids i-1234" "$CLOUD_OFF_REPO"
+assert_allow "Cloud config-off: aws ec2 run-instances allowed" \
+    "aws ec2 run-instances --image-id ami-123" "$CLOUD_OFF_REPO"
+assert_allow "Cloud config-off: docker rm allowed" \
+    "docker rm my-container" "$CLOUD_OFF_REPO"
+
+# --- Default-on (absent/malformed config) still asks on mutating cloud calls ---
+assert_ask "Cloud config-absent: aws ec2 terminate-instances still asks" \
+    "aws ec2 terminate-instances --instance-ids i-1234" "$CLOUD_ABSENT_REPO"
+assert_ask "Cloud malformed-config: aws ec2 run-instances still asks" \
+    "aws ec2 run-instances --image-id ami-123" "$CLOUD_BAD_REPO"
+assert_ask "Cloud config-on: docker rm still asks" \
+    "docker rm my-container" "$CLOUD_ON_REPO"
+
+# --- Env override: LOOM_GUARD_CLOUD=0 bypasses even when config says true ---
+assert_allow_env "LOOM_GUARD_CLOUD=0 overrides config-on: aws ec2 terminate allowed" \
+    "LOOM_GUARD_CLOUD=0" "aws ec2 terminate-instances --instance-ids i-1234" "$CLOUD_ON_REPO"
+assert_allow_env "LOOM_GUARD_CLOUD=0: docker rm allowed" \
+    "LOOM_GUARD_CLOUD=0" "docker rm my-container" "$CLOUD_ON_REPO"
+
+# --- Env override: LOOM_GUARD_CLOUD=1 forces on even when config says false ---
+assert_ask_env "LOOM_GUARD_CLOUD=1 overrides config-off: aws ec2 terminate asks" \
+    "LOOM_GUARD_CLOUD=1" "aws ec2 terminate-instances --instance-ids i-1234" "$CLOUD_OFF_REPO"
+assert_ask_env "LOOM_GUARD_CLOUD=1 overrides config-off: docker rm asks" \
+    "LOOM_GUARD_CLOUD=1" "docker rm my-container" "$CLOUD_OFF_REPO"
+
+# --- Catastrophic denies are NOT gated by the cloud toggle (stay hard denies) ---
+assert_deny_env "Cloud toggle off does NOT weaken: aws s3 rb still denied" \
+    "LOOM_GUARD_CLOUD=0" "aws s3 rb s3://prod-bucket --force" "$CLOUD_OFF_REPO"
+assert_deny_env "Cloud toggle off does NOT weaken: aws s3 rm --recursive still denied" \
+    "LOOM_GUARD_CLOUD=0" "aws s3 rm s3://prod-bucket/data --recursive" "$CLOUD_OFF_REPO"
+assert_deny_env "Cloud toggle off does NOT weaken: aws iam delete-user still denied" \
+    "LOOM_GUARD_CLOUD=0" "aws iam delete-user --user-name bob" "$CLOUD_OFF_REPO"
+assert_deny_env "Cloud toggle off does NOT weaken: aws cloudformation delete-stack still denied" \
+    "LOOM_GUARD_CLOUD=0" "aws cloudformation delete-stack --stack-name prod" "$CLOUD_OFF_REPO"
+assert_deny_env "Cloud toggle off does NOT weaken: docker system prune still denied" \
+    "LOOM_GUARD_CLOUD=0" "docker system prune -af" "$CLOUD_OFF_REPO"
+
+# --- Cloud toggle off must NOT weaken non-cloud guards ---
+assert_deny_env "Cloud config-off: rm -rf / still blocked" \
+    "LOOM_GUARD_CLOUD=0" "rm -rf /" "$CLOUD_OFF_REPO"
+assert_deny_env "Cloud config-off: force-push to main still blocked" \
+    "LOOM_GUARD_CLOUD=0" "git push --force origin main" "$CLOUD_OFF_REPO"
+
+# Clean up cloud temp repos.
+for _cloud_dir in "$CLOUD_OFF_REPO" "$CLOUD_ON_REPO" "$CLOUD_ABSENT_REPO" "$CLOUD_BAD_REPO"; do
+    [[ -n "$_cloud_dir" && "$_cloud_dir" != "/" && -d "$_cloud_dir/.loom" ]] && rm -rf "$_cloud_dir"
 done
 
 echo ""
@@ -832,8 +957,9 @@ assert_deny "Regression: gh repo delete after && still denied" \
 assert_deny "Regression: sudo gh repo archive still denied" \
     "sudo gh repo archive acme/widgets"
 
-# Cloud infra destruction.
-assert_deny "Regression: aws ec2 terminate still denied" \
+# Cloud infra destruction. `aws ec2 terminate-instances` is now a toggle-gated
+# ask, not a deny (#3593); the genuinely catastrophic aws forms still deny.
+assert_ask "Regression: aws ec2 terminate-instances now asks not denies (#3593)" \
     "aws ec2 terminate-instances --instance-ids i-1234"
 assert_deny "Regression: aws s3 rb still denied" \
     "aws s3 rb s3://prod-bucket --force"


### PR DESCRIPTION
Closes #3593

## Summary

`defaults/hooks/guard-destructive.sh` over-fired for cloud-dev repos. Three source-verified fixes:

1. **Verb-narrowed the cloud ASK patterns.** The bare `aws s3` / `aws ec2` / `aws lambda` prefixes in `ASK_PATTERNS` matched read-only calls, so `aws ec2 describe-instances`, `aws s3 ls`, `aws lambda list-functions`, etc. all prompted. Replaced with verb-anchored ERE forms that match only mutating subcommands (`run`/`create`/`delete`/`terminate`/`stop`/`start`/`modify`/`put`/…) and never `describe*`/`get*`/`list*`/`ls`. Docker patterns (`docker rm/rmi/stop/kill/restart`) were already mutating-verb-only and are unchanged (they only moved under the toggle).

2. **Added `cloud_guard_enabled()`** mirroring `sql_guard_enabled()` exactly — reads `LOOM_GUARD_CLOUD` env + `guards.cloudCli` in `.loom/config.json`, default-on, resolution order env > config > default, invoked lazily only after a cloud pattern matches (config read stays off the hot path). The aws + docker ASK entries were split into a separate `CLOUD_ASK_PATTERNS` array gated on this toggle; the non-cloud ASK patterns stay ungated.

3. **Downgraded `aws ec2 terminate` from deny to ask.** Removed `'aws ec2 terminate'` from `ALWAYS_BLOCK_PATTERNS`; `terminate-instances` is now caught by the verb-narrowed, toggle-gated `CLOUD_ASK_PATTERNS` as an ask (and fully bypassed when the cloud guard is off). All genuinely catastrophic denies (`aws s3 rm --recursive`, `aws s3 rb`, `aws iam delete`, `aws cloudformation delete-stack`, `docker system prune`) stay **ungated** hard denies.

Docs: added a parallel **Cloud CLI Guard Opt-Out** section to `defaults/CLAUDE.md` and corrected a stale `aws ec2 terminate` reference in the SQL section.

## How verified

- `bash -n` clean on both the hook and the test file.
- `shellcheck -S error` clean on both files (the one pre-existing SC2016 info on the `$HOME` regex literal is unchanged/intentional).
- `bash tests/hooks/test-guard-destructive.sh`: **216/217 pass**. Flipped the 5 flagged assertions (read-only aws → allow; `terminate-instances` → ask not deny; SQL-config-off terminate → ask; run-instances still asks; regression terminate → ask) and added ~35 new cloud assertions covering every acceptance criterion (read-only allow, mutating ask, terminate ask with toggle on, `LOOM_GUARD_CLOUD=0` / `guards.cloudCli:false` bypass, `LOOM_GUARD_CLOUD=1` override, catastrophic-deny-not-gated, docker verbs still ask, `docker ps`/`logs` allowed).
- The **only** failing assertion is the 200ms perf threshold (measured ~211ms). Confirmed this is an environmental flake, not a regression: the pristine `origin/main` guard measures **239–261ms** on the same host while this branch measures **204–223ms** (`git status` never touches the new lazy `cloud_guard_enabled()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)