### PR TITLE
docs(roles): add partial-increment carve-out so family/epic PRs don't auto-close

### DIFF
--- a/defaults/.claude/agents/loom-builder.md
+++ b/defaults/.claude/agents/loom-builder.md
@@ -16,7 +16,7 @@ Follow the complete role definition in `.loom/roles/builder.md` for:
 - Pre-implementation review of recent main changes
 - Checking dependencies before claiming
 - Scope management and decomposition criteria
-- PR creation with `loom:review-requested` and "Closes #N" syntax
+- PR creation with `loom:review-requested` and `Closes #N` syntax (or `Part of #N` for a partial increment of a family/epic issue)
 - Handling pre-existing lint/build failures
 
 Never abandon claimed work - always create a PR, decompose into sub-issues, or mark as blocked.

--- a/defaults/.claude/commands/loom/builder-pr.md
+++ b/defaults/.claude/commands/loom/builder-pr.md
@@ -126,7 +126,7 @@ Closes #N
 EOF
 ```
 
-Replace `#N` with the actual issue number. Write this BEFORE running `pnpm check:ci` or any test suite.
+Replace `#N` with the actual issue number. Write this BEFORE running `pnpm check:ci` or any test suite. Use `Part of #N` instead of `Closes #N` when this PR is a **partial increment** of a family/epic issue (see "Partial increments" below).
 
 ### When to Update It
 
@@ -526,12 +526,16 @@ These patterns are **WRONG** — the shepherd will reject PRs with titles matchi
 
 ## Creating Pull Requests: Label and Auto-Close Requirements
 
-> **CRITICAL**: PRs MUST include `Closes #N` (or `Fixes #N` / `Resolves #N`) in the body.
-> This is required for:
+> **CRITICAL**: PRs MUST include an issue reference in the body — either a closing keyword
+> (`Closes #N` / `Fixes #N` / `Resolves #N`) for a full implementation, or a non-closing
+> reference (`Part of #N` / `Contributes to #N`) for a declared **partial increment** of a
+> family/epic issue (see "Partial increments" below).
+> A closing keyword is required for:
 > 1. GitHub to auto-close the issue when the PR merges
 > 2. **Shepherd orchestration to detect your PR during phase validation**
 >
-> Without this keyword, shepherd phase validation cannot find your PR and will report false failures.
+> A partial-increment PR intentionally omits the closing keyword so the family/epic issue
+> stays open — it still references the issue with `Part of #N` so the PR is discoverable.
 
 ### PR Label Rules
 
@@ -613,13 +617,26 @@ GitHub's auto-close feature only works with specific keywords at the start of a 
 
 **Any other phrasing will NOT trigger auto-close.**
 
+### Partial increments (family/epic issues)
+
+The auto-close guidance above assumes one issue → one PR → close. Some issues track a **family** of work (labeled `loom:epic` / `loom:epic-phase`, or whose body explicitly scopes a family such as "~346 conformance failures across N files") and are intentionally landed in slices. For a PR that implements only a subset — with tracked work remaining after it merges — use a **non-closing** reference instead:
+
+```markdown
+Part of #123
+Contributes to #123
+```
+
+`Part of #N` references the issue (keeping the PR discoverable) but does NOT trigger auto-close, so the family/epic issue survives the merge. Only the **final increment** that completes the family uses `Closes #N`.
+
+**Both the PR body and the commit message must carry the same reference.** This repo squash-merges, and GitHub harvests closing keywords from the squash commit message as well as the PR body — a stray `Closes #N` in the commit body will auto-close the family issue even when the PR body says `Part of #N`. When in doubt on a `loom:epic` issue, prefer `Part of #N`.
+
 ### PR Creation Checklist
 
 When creating a PR, verify:
 
 1. **PR title uses conventional commit format** - e.g., `fix: descriptive summary` (see "PR Titles" above)
 2. **Acceptance criteria verified** - Each criterion from issue explicitly checked (see "Acceptance Criteria Verification" above)
-3. PR description uses "Closes #X" syntax (not "Issue #X" or "Addresses #X")
+3. PR description references the issue: `Closes #X` for a full implementation, or `Part of #X` for a declared partial increment (not "Issue #X" or "Addresses #X") — same reference in the commit message
 4. Issue number is correct
 5. PR has `loom:review-requested` label
 6. All CI checks pass (`pnpm check:ci` locally)
@@ -656,7 +673,7 @@ EOF
 ```
 
 **Remember**:
-- Put "Closes #123" on its own line in the PR description
+- Put "Closes #123" (or "Part of #123" for a partial increment) on its own line in the PR description, and use the same reference in the commit message
 - Include the acceptance criteria verification table showing each criterion was checked
 
 ## Handling Pre-existing Lint/Build Failures

--- a/defaults/.claude/commands/loom/builder.md
+++ b/defaults/.claude/commands/loom/builder.md
@@ -808,6 +808,22 @@ git diff   # Read the actual changes
 
 **The PR title and commit message MUST describe what the code change does, not reference the issue.** See builder-pr.md for the full rules, anti-patterns, and examples.
 
+### Closing vs Partial Increments (family/epic issues)
+
+Before writing the closing reference, decide whether this PR **fully** resolves the issue or is only a **partial increment** of a larger tracked body of work:
+
+- **Full implementation (default)** — this PR resolves the whole issue. Use `Closes #N`.
+- **Partial increment** — this PR lands a coherent but incomplete slice of a larger issue, and tracked work remains after it merges. Use `Part of #N` (or `Contributes to #N`) instead — this references the issue WITHOUT auto-closing it.
+
+Use the non-closing reference (`Part of #N`) when ANY of these hold:
+- The issue carries the `loom:epic` label (or `loom:epic-phase`) — a family/epic issue that must stay open until its final increment lands.
+- The issue body explicitly scopes a *family* of work (e.g. "~346 conformance failures across N files") and this PR implements only a subset.
+- Your own scope notes say tracked work remains after this PR — you are decomposing a large issue into slices and this is not the last slice.
+
+**Apply the same reference to BOTH the PR body AND the commit message.** This repository squash-merges, and GitHub harvests closing keywords from the squash commit message as well as the PR body — so a stray `Closes #N` in the commit body will auto-close the family issue even if the PR body says `Part of #N`. Derive the commit message and PR body together (see the diff-review step above) and keep the reference consistent across both.
+
+Only the **final increment** that completes the family should use `Closes #N`. When in doubt on an `loom:epic` issue, prefer `Part of #N` — a human can always close the issue manually, but silently dropping tracked work on an accidental auto-close is far more costly to recover.
+
 **REQUIRED: Use the structured PR body template below.** Do NOT create PRs with just `Closes #N` — the body must include Summary, Changes, and Acceptance Criteria sections.
 
 ```bash
@@ -838,11 +854,13 @@ EOF
 )"
 ```
 
+> Replace `Closes #<issue-number>` with `Part of #<issue-number>` when this PR is a **partial increment** of a family/epic issue (see "Closing vs Partial Increments" above) — and make the same substitution in your commit message.
+
 **PR title** must use conventional commit format: `fix:`, `feat:`, `refactor:`, `docs:`, `chore:`, etc.
 
 **After creation:**
 - Never touch PR labels after creation
-- Use "Closes #N" syntax (not "Issue #N" or "Addresses #N") for auto-close
+- For a full implementation, use "Closes #N" syntax (not "Issue #N" or "Addresses #N") for auto-close; for a declared partial increment, use "Part of #N" (see "Closing vs Partial Increments" above)
 - PRs are merged by Champion using `./.loom/scripts/merge-pr.sh` -- never use `gh pr merge`
 
 ## Working Style
@@ -870,7 +888,7 @@ When claiming:
 
 When creating PR:
 - [ ] Add `loom:review-requested` (at creation only)
-- [ ] PR body uses "Closes #N" syntax
+- [ ] PR body uses `Closes #N` (full implementation) or `Part of #N` (partial increment of a family/epic issue) — same reference in the commit message
 
 After PR creation:
 - [ ] STOP - do not touch any PR labels

--- a/defaults/.claude/commands/loom/guide.md
+++ b/defaults/.claude/commands/loom/guide.md
@@ -354,12 +354,21 @@ gh issue view NUMBER --json state
 
 **If issue is still open after PR merged:**
 1. Check if PR body used correct syntax (`Closes #X`)
-2. If missing keyword, manually close the issue with explanation
-3. Leave comment documenting what happened
+2. **Exclude intentional partial increments first** — if the merged PR body contains a non-closing reference (`Part of #X` / `Contributes to #X`), or the still-open issue is labeled `loom:epic` / `loom:epic-phase`, the issue is **supposed** to stay open across increments. This is NOT an orphan — do NOT close it and do NOT flag it as a process failure.
+3. If genuinely missing keyword (a full-implementation PR that used sloppy syntax), manually close the issue with explanation
+4. Leave comment documenting what happened
+
+```bash
+# Guard: skip closure if this is a deliberate partial increment
+gh pr view <pr-number> --json body -q .body | grep -Eiq 'part of #|contributes to #' && echo "PARTIAL — leave issue open"
+gh issue view <issue-number> --json labels -q '.labels[].name' | grep -Eqx 'loom:epic|loom:epic-phase' && echo "EPIC/family — leave issue open"
+```
 
 **3. Close Orphaned Issues**
 
-When you find a completed issue that stayed open:
+> **Only close TRUE orphans.** A `loom:epic` / `loom:epic-phase` issue, or an issue whose merged PR referenced it with `Part of #N` / `Contributes to #N`, is intentionally kept open until its final increment lands — it is not orphaned. Never close it as "completed but missing keyword".
+
+When you find a completed issue that stayed open (and the partial-increment exclusion above does not apply):
 
 ```bash
 # Close the issue

--- a/defaults/.claude/commands/loom/judge.md
+++ b/defaults/.claude/commands/loom/judge.md
@@ -803,10 +803,28 @@ gh pr view <number> --json body
 
 # Check for magic keywords
 # ✅ Look for: "Closes #X", "Fixes #X", or "Resolves #X"
+# ⏸️ Intentional non-closing (partial increment): "Part of #X", "Contributes to #X" — see exception below
 # ❌ Not acceptable: "Issue #X", "Addresses #X", "Related to #X"
 ```
 
-**If PR description is missing "Closes #X" syntax:**
+**EXCEPTION — intentional partial increments (family/epic issues).** Before treating a missing closing keyword as a defect, check whether the non-closing reference is **deliberate**:
+
+```bash
+# Does the PR body already reference the issue with a non-closing keyword?
+gh pr view <number> --json body -q .body | grep -Eiq 'part of #|contributes to #'
+
+# Or is the referenced issue a family/epic that must stay open across increments?
+gh issue view <issue-number> --json labels -q '.labels[].name' | grep -qx 'loom:epic'   # also check loom:epic-phase
+```
+
+If EITHER is true, the PR is a **partial increment** of a larger tracked body of work (a family/epic issue landed in slices). The absence of `Closes #N` is intentional — the issue must survive the merge so the remaining tracked work isn't dropped. In this case:
+
+- Do NOT flag the missing closing keyword.
+- Do NOT insert or rewrite a closing keyword (skip the auto-fix in "Minor PR Description Fixes" below).
+- Verify the non-closing reference (`Part of #N` / `Contributes to #N`) is present so the PR stays discoverable; if it references the issue only as bare "Issue #N", ask the Builder to change it to `Part of #N` (do not "fix" it to `Closes #N`).
+- Evaluate the code on its own merits and approve/reject normally.
+
+**If PR description is missing "Closes #X" syntax (and the partial-increment exception above does NOT apply):**
 
 1. **Comment with the issue immediately** - don't evaluate further until fixed
 2. **Explain the problem** in your comment:
@@ -847,7 +865,7 @@ EOF
 
 **Approval checklist must include:**
 
-- ✅ PR description uses "Closes #X" (or "Fixes #X" / "Resolves #X")
+- ✅ PR description uses "Closes #X" (or "Fixes #X" / "Resolves #X") — OR "Part of #X" / "Contributes to #X" for an intentional partial increment of a family/epic issue
 - ✅ Issue number is correct and matches the work done
 - ✅ Code quality meets standards (see sections below)
 - ✅ Tests are adequate
@@ -860,6 +878,8 @@ EOF
 **Before requesting changes for missing auto-close syntax, try to fix it directly.**
 
 For minor documentation issues in PR descriptions (not code), Judges are empowered to make direct edits rather than blocking approval. This speeds up the evaluation process while maintaining code quality standards.
+
+> **STOP — do not auto-fix intentional partial increments.** If the partial-increment exception above applies (the PR body already says `Part of #N` / `Contributes to #N`, or the referenced issue carries `loom:epic` / `loom:epic-phase`), the missing closing keyword is deliberate. Do NOT append `Closes #N` and do NOT rewrite the reference — doing so would auto-close a family/epic issue and silently drop its remaining tracked work. The auto-fix steps below apply ONLY to genuinely sloppy references (e.g. a plain one-issue-one-PR that wrote "Issue #N" instead of "Closes #N").
 
 ### When to Edit PR Descriptions Directly
 
@@ -879,7 +899,7 @@ For minor documentation issues in PR descriptions (not code), Judges are empower
 
 ### How to Edit PR Descriptions
 
-**Step 1: Check if there's a related issue**
+**Step 1: Check if there's a related issue (and that this isn't an intentional partial increment)**
 
 ```bash
 # Search for issues related to the PR
@@ -887,6 +907,10 @@ gh issue list --search "keyword from PR title"
 
 # View the PR to confirm issue number
 gh pr view <number>
+
+# Guard: skip the auto-fix entirely if this is a deliberate partial increment
+gh pr view <number> --json body -q .body | grep -Eiq 'part of #|contributes to #' && echo "PARTIAL — do not add Closes"
+gh issue view <issue-number> --json labels -q '.labels[].name' | grep -qx 'loom:epic' && echo "EPIC — do not add Closes"
 ```
 
 **Step 2: Edit the PR description**
@@ -919,9 +943,10 @@ EOF
 ### Important Guidelines
 
 1. **Code quality standards remain strict**: Only documentation edits are allowed, not code changes
-2. **Document your edits**: Always mention in your evaluation that you edited the PR description
-3. **Verify the fix**: After editing, confirm the PR description now includes proper auto-close syntax
-4. **When in doubt, request changes**: If you're unsure which issue to reference, ask the Builder to clarify
+2. **Never override an intentional partial increment**: If the PR uses `Part of #N` / `Contributes to #N`, or the referenced issue is `loom:epic` / `loom:epic-phase`, leave the reference as-is — do not "fix" it into a closing keyword
+3. **Document your edits**: Always mention in your evaluation that you edited the PR description
+4. **Verify the fix**: After editing, confirm the PR description now includes proper auto-close syntax
+5. **When in doubt, request changes**: If you're unsure which issue to reference, ask the Builder to clarify
 
 ### Example Workflow
 
@@ -930,11 +955,13 @@ EOF
 gh pr view 42 --json body
 # → Body says "Issue #123" instead of "Closes #123"
 
-# 2. Verify this is the correct issue
+# 2. Verify this is the correct issue AND not an intentional partial increment
 gh issue view 123
 # → Confirmed: issue matches PR work
+# → If the body already says "Part of #123"/"Contributes to #123", or issue 123 is
+#   labeled loom:epic/loom:epic-phase, STOP: the non-closing reference is deliberate.
 
-# 3. Fix the PR description
+# 3. Fix the PR description (only for genuinely sloppy references — never on a partial increment)
 gh pr view 42 --json body -q .body > /tmp/pr-body.txt
 sed -i '' 's/Issue #123/Closes #123/g' /tmp/pr-body.txt
 gh pr edit 42 --body-file /tmp/pr-body.txt


### PR DESCRIPTION
## Summary

The builder role docs presented `Closes #N` as unconditional, so a PR that lands only a coherent slice of a large family/epic issue would auto-close the entire issue on merge — silently dropping all remaining tracked work. The bug spanned three roles: the **builder** hardcoded the closing keyword, the **judge**'s auto-repair rewrote a deliberate `Part of #N` back into `Closes #N`, and the **guide** flagged intentionally-open family issues as orphans. This teaches all three roles to recognize and preserve intentional partial increments.

## Changes

- **`builder.md`** — new "Closing vs Partial Increments (family/epic issues)" decision rule: use `Part of #N` / `Contributes to #N` (not `Closes #N`) in **both** the PR body and the commit message when the issue is `loom:epic`/`loom:epic-phase`-labeled, explicitly family-scoped, or the builder's own scope notes say tracked work remains. Default stays `Closes #N`. Template comment, after-creation guidance, and label checklist updated. Squash-merge nuance (GitHub harvests keywords from the commit message too) called out.
- **`builder-pr.md`** — softened the `CRITICAL: PRs MUST include Closes #N` block to accept a declared partial-increment reference, added a "Partial increments" subsection, updated the PR-creation checklist and "Remember" list.
- **`judge.md`** — added a partial-increment EXCEPTION at the top of the issue-linking section and STOP-guards on the "Minor PR Description Fixes" auto-fix + sed rewrite: if the PR body already carries `Part of #N`/`Contributes to #N` or the referenced issue is `loom:epic`/`loom:epic-phase`, the non-closing reference is treated as intentional and never rewritten to a closing keyword.
- **`guide.md`** — the "completed but missing closing keyword" orphan detection now excludes merged PRs whose bodies contain `Part of #N`/`Contributes to #N` and issues labeled `loom:epic`/`loom:epic-phase`.
- **`loom-builder.md`** — one-line wording update.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| builder.md documents partial-increment case (PR body + commit msg), template + checklist updated | ✅ | New subsection + template note + checklist line |
| builder-pr.md no longer mandates `Closes #N` unconditionally; checklists accept `Part of #N` | ✅ | CRITICAL block softened, new subsection, checklist updated |
| judge.md auto-fix checks for intentional `Part of #N`/`Contributes to #N` or `loom:epic` before inserting/rewriting | ✅ | EXCEPTION block + STOP guards + guarded example |
| guide.md missing-keyword detection excludes intentional `Part of #N` PRs | ✅ | Exclusion guard + epic-label check |
| loom-builder.md + all four command copies updated and byte-identical to role-file counterparts | ✅ | `diff` shows IDENTICAL for all four (role files are git symlinks to the command copies) |
| No new GitHub labels created or referenced | ✅ | Only `loom:epic` / `loom:epic-phase` (both exist in `.github/labels.yml`) referenced |

## Test Plan

Docs-only change (no scripts touched):
- `diff defaults/roles/{builder,builder-pr,judge,guide}.md defaults/.claude/commands/loom/*.md` → all IDENTICAL (symlinks keep them in sync).
- `grep loom:` over the diff → only `loom:epic`, `loom:epic-phase`, `loom:review-requested`; no new labels.
- `grep "Part of #"` → present in all four role docs + the agent file.
- Existing shell/Python test suites unaffected.

Closes #3596