### PR TITLE
fix(install): scope reinstall stash guard to Loom-owned paths (#3597)

### DIFF
--- a/defaults/scripts/tests/test-install-stash-scope.sh
+++ b/defaults/scripts/tests/test-install-stash-scope.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# test-install-stash-scope.sh — regression tests for the reinstall stash guard
+# scoping (issue #3597).
+#
+# The `--quick` reinstall (install.sh) and `--clean` install (install-loom.sh)
+# guards used to run an unscoped `git stash push`, sweeping sibling installers'
+# uncommitted tracked changes into the stash and leaving a half-old/half-new
+# hybrid tree. The fix scopes the stash to the intersection of the dirty set
+# with Loom's ownership set (manifest paths + .gitignore) via
+# scripts/install/stash-scope.sh::_emit_loom_owned_dirty_paths.
+#
+# Strategy: source the real helper against a temp git repo seeded with both a
+# Loom-owned file and a sibling (non-Loom) file, dirty both, and assert:
+#   1. the helper lists ONLY the Loom-owned dirty path,
+#   2. a pathspec-scoped `git stash push` leaves the sibling change untouched
+#      in the working tree and absent from the stash,
+#   3. a tree dirty with ONLY sibling changes yields no owned-dirty paths
+#      (callers skip the stash entirely).
+#
+# Usage:
+#   bash defaults/scripts/tests/test-install-stash-scope.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# In the source checkout this file lives at defaults/scripts/tests/; the repo
+# root is three levels up. When shipped into a consumer at
+# .loom/scripts/tests/, the same climb lands on the consumer root — but this
+# test is a source-checkout artifact and expects the real scripts/install/.
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+STASH_SCOPE="$REPO_ROOT/scripts/install/stash-scope.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_PASSED=$((TESTS_PASSED + 1)); TESTS_RUN=$((TESTS_RUN + 1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() {
+  TESTS_FAILED=$((TESTS_FAILED + 1)); TESTS_RUN=$((TESTS_RUN + 1))
+  echo -e "  ${RED}FAIL${NC}: $1"
+  [[ -n "${2:-}" ]] && echo "$2" | sed 's/^/      /'
+}
+
+assert_eq() {
+  local expected="$1" actual="$2" msg="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    pass "$msg"
+  else
+    fail "$msg" "expected: [$expected]
+  actual: [$actual]"
+  fi
+}
+
+if [[ ! -f "$STASH_SCOPE" ]]; then
+  echo "ERROR: $STASH_SCOPE not found" >&2
+  exit 1
+fi
+
+# shellcheck source=/dev/null
+source "$STASH_SCOPE"
+
+# A real Loom-owned path (present in the defaults/ manifest) and a sibling path
+# Loom never ships. .loom/roles/builder.md is a stable manifest entry.
+OWNED_PATH=".loom/roles/builder.md"
+SIBLING_PATH=".anvil/install-metadata.json"
+
+# Sanity: confirm the chosen owned path is actually in the ownership set, so
+# the test fails loudly if the manifest layout changes rather than silently
+# passing on an empty set.
+OWNERSHIP="$(_emit_loom_ownership_paths "$REPO_ROOT" "$REPO_ROOT")"
+if ! printf '%s\n' "$OWNERSHIP" | grep -qxF "$OWNED_PATH"; then
+  echo "ERROR: expected $OWNED_PATH in the Loom ownership set (manifest drift?)" >&2
+  exit 1
+fi
+if printf '%s\n' "$OWNERSHIP" | grep -qxF "$SIBLING_PATH"; then
+  echo "ERROR: sibling path $SIBLING_PATH unexpectedly in ownership set" >&2
+  exit 1
+fi
+
+# Build a throwaway git repo that mirrors a consumer tree: a committed
+# Loom-owned file plus a committed sibling-installer file.
+TMP_REPO="$(mktemp -d "${TMPDIR:-/tmp}/loom-stash-scope.XXXXXX")"
+trap 'rm -rf "$TMP_REPO"' EXIT
+
+git -C "$TMP_REPO" init -q
+git -C "$TMP_REPO" config user.email test@example.com
+git -C "$TMP_REPO" config user.name "Test"
+
+mkdir -p "$TMP_REPO/$(dirname "$OWNED_PATH")" "$TMP_REPO/$(dirname "$SIBLING_PATH")"
+printf 'loom original\n' > "$TMP_REPO/$OWNED_PATH"
+printf '{"version":"old"}\n' > "$TMP_REPO/$SIBLING_PATH"
+git -C "$TMP_REPO" add -A
+git -C "$TMP_REPO" commit -qm "seed"
+
+echo "== Test 1: mixed-dirty tree — only the Loom-owned path is selected =="
+printf 'loom modified\n' > "$TMP_REPO/$OWNED_PATH"
+printf '{"version":"new"}\n' > "$TMP_REPO/$SIBLING_PATH"
+
+SELECTED="$(_emit_loom_owned_dirty_paths "$REPO_ROOT" "$TMP_REPO")"
+assert_eq "$OWNED_PATH" "$SELECTED" "helper selects only the Loom-owned dirty path"
+
+echo "== Test 2: scoped stash leaves the sibling change in the working tree =="
+# Reproduce the caller's pathspec array + stash push.
+OWNED_DIRTY=()
+while IFS= read -r p; do [[ -n "$p" ]] && OWNED_DIRTY+=("$p"); done \
+  < <(_emit_loom_owned_dirty_paths "$REPO_ROOT" "$TMP_REPO")
+
+git -C "$TMP_REPO" stash push -m "loom-install: test" -- "${OWNED_DIRTY[@]}" >/dev/null 2>&1
+
+# Sibling file must still carry its uncommitted modification.
+SIBLING_CONTENT="$(cat "$TMP_REPO/$SIBLING_PATH")"
+assert_eq '{"version":"new"}' "$SIBLING_CONTENT" "sibling change survives in working tree after stash"
+
+# Loom-owned file must have been reverted to HEAD by the stash.
+OWNED_CONTENT="$(cat "$TMP_REPO/$OWNED_PATH")"
+assert_eq "loom original" "$OWNED_CONTENT" "Loom-owned change was stashed (reverted to HEAD)"
+
+# The stash must not carry the sibling path.
+STASH_FILES="$(git -C "$TMP_REPO" stash show --name-only 'stash@{0}' 2>/dev/null)"
+if printf '%s\n' "$STASH_FILES" | grep -qxF "$SIBLING_PATH"; then
+  fail "sibling path absent from stash" "stash contained: $STASH_FILES"
+else
+  pass "sibling path absent from stash"
+fi
+if printf '%s\n' "$STASH_FILES" | grep -qxF "$OWNED_PATH"; then
+  pass "Loom-owned path present in stash"
+else
+  fail "Loom-owned path present in stash" "stash contained: $STASH_FILES"
+fi
+
+# Pop restores the Loom-owned change cleanly.
+git -C "$TMP_REPO" stash pop >/dev/null 2>&1
+assert_eq "loom modified" "$(cat "$TMP_REPO/$OWNED_PATH")" "stash pop restores the Loom-owned change"
+
+echo "== Test 3: sibling-only dirty tree yields no owned-dirty paths (no stash) =="
+git -C "$TMP_REPO" checkout -- . 2>/dev/null || true
+git -C "$TMP_REPO" stash clear 2>/dev/null || true
+printf '{"version":"newer"}\n' > "$TMP_REPO/$SIBLING_PATH"
+
+SELECTED_SIBLING_ONLY="$(_emit_loom_owned_dirty_paths "$REPO_ROOT" "$TMP_REPO")"
+assert_eq "" "$SELECTED_SIBLING_ONLY" "sibling-only dirty tree produces no owned-dirty paths"
+
+echo ""
+echo "Ran $TESTS_RUN test(s): $TESTS_PASSED passed, $TESTS_FAILED failed"
+[[ $TESTS_FAILED -eq 0 ]]

--- a/install.sh
+++ b/install.sh
@@ -618,14 +618,32 @@ elif [[ -d "$TARGET_PATH/.loom" ]]; then
   # first keeps a user's pre-existing staged/working changes from being caught
   # up in either step. The non-quick reinstall delegates to install-loom.sh,
   # which performs its own guarding, so it is intentionally left unstashed here.
+  #
+  # Issue #3597: scope the stash to Loom-owned paths. The original unscoped
+  # `git stash push` swept sibling installers' uncommitted tracked changes
+  # (.anvil/*, .claude/skills/repo/*, non-Loom CLAUDE.md sections, …) into the
+  # stash and left a half-old/half-new hybrid tree. Restrict the stash to the
+  # dirty ∩ (Loom ownership set + .gitignore) intersection so sibling changes
+  # are never touched. Empty intersection → no stash at all.
   REINSTALL_STASHED_USER_CHANGES=false
   if [[ "$INSTALL_TYPE" == "1" ]]; then
-    if ! git -C "$TARGET_PATH" diff --quiet 2>/dev/null || \
-       ! git -C "$TARGET_PATH" diff --staged --quiet 2>/dev/null; then
-      info "Stashing uncommitted user changes before reinstall..."
-      if git -C "$TARGET_PATH" stash push -m "loom-install: preserving user changes before --quick reinstall" 2>/dev/null; then
+    # shellcheck source=scripts/install/stash-scope.sh
+    source "$LOOM_ROOT/scripts/install/stash-scope.sh"
+    REINSTALL_OWNED_DIRTY=()
+    while IFS= read -r _owned_path; do
+      [[ -n "$_owned_path" ]] && REINSTALL_OWNED_DIRTY+=("$_owned_path")
+    done < <(_emit_loom_owned_dirty_paths "$LOOM_ROOT" "$TARGET_PATH")
+
+    if [[ ${#REINSTALL_OWNED_DIRTY[@]} -gt 0 ]]; then
+      info "Stashing uncommitted Loom-owned changes before reinstall..."
+      if git -C "$TARGET_PATH" stash push \
+           -m "loom-install: preserving user changes before --quick reinstall" \
+           -- "${REINSTALL_OWNED_DIRTY[@]}" 2>/dev/null; then
         REINSTALL_STASHED_USER_CHANGES=true
-        success "User changes stashed"
+        REINSTALL_STASH_REF="$(git -C "$TARGET_PATH" stash list 2>/dev/null | head -1)"
+        success "Loom-owned changes stashed → ${REINSTALL_STASH_REF:-stash@{0}}"
+        info "  Stashed ${#REINSTALL_OWNED_DIRTY[@]} Loom-owned path(s): ${REINSTALL_OWNED_DIRTY[*]}"
+        info "  Recover manually with: git -C \"$TARGET_PATH\" stash pop"
       else
         warning "Failed to stash user changes - continuing without stash"
         warning "Uncommitted changes may appear alongside the reinstall diff"
@@ -677,9 +695,20 @@ elif [[ -d "$TARGET_PATH/.loom" ]]; then
     # untracked-`??` entries instead of the real version-upgrade diff. Unstage
     # the uninstall's staged deletions so the working tree reflects only the
     # actual old→new file changes.
+    #
+    # Issue #3597: scope the unstage to Loom-owned paths so user-staged
+    # non-Loom changes (sibling installers, unrelated work) stay staged. The
+    # uninstall only stages Loom-managed paths (#3450), so the dirty ∩
+    # ownership intersection is exactly the set of staged deletions to undo.
     info "Reconciling git index after reinstall..."
-    git -C "$TARGET_PATH" restore --staged . 2>/dev/null || \
-      git -C "$TARGET_PATH" reset -q HEAD -- . 2>/dev/null || true
+    RECONCILE_PATHS=()
+    while IFS= read -r _owned_path; do
+      [[ -n "$_owned_path" ]] && RECONCILE_PATHS+=("$_owned_path")
+    done < <(_emit_loom_owned_dirty_paths "$LOOM_ROOT" "$TARGET_PATH")
+    if [[ ${#RECONCILE_PATHS[@]} -gt 0 ]]; then
+      git -C "$TARGET_PATH" restore --staged -- "${RECONCILE_PATHS[@]}" 2>/dev/null || \
+        git -C "$TARGET_PATH" reset -q HEAD -- "${RECONCILE_PATHS[@]}" 2>/dev/null || true
+    fi
 
     # Restore any user changes stashed before the uninstall (see above).
     #

--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -527,15 +527,30 @@ if [[ "$CLEAN_FIRST" == "true" ]]; then
   if [[ -d "$TARGET_PATH/.loom" ]]; then
     # Preserve uncommitted user changes before uninstall
     # The uninstall --local mode runs 'git add -A' which would stage user changes
-    # along with uninstall deletions, and our cleanup would discard them
+    # along with uninstall deletions, and our cleanup would discard them.
+    #
+    # Issue #3597: scope the stash to Loom-owned paths. The original unscoped
+    # `git stash push` swept sibling installers' uncommitted tracked changes
+    # into the stash (and the cleanup's `git checkout -- .` would otherwise
+    # revert them outright). Restrict to dirty ∩ (Loom ownership set +
+    # .gitignore); empty intersection → no stash.
+    # shellcheck source=scripts/install/stash-scope.sh
+    source "$LOOM_ROOT/scripts/install/stash-scope.sh"
     STASHED_USER_CHANGES=false
-    if ! git -C "$TARGET_PATH" diff --quiet 2>/dev/null || \
-       ! git -C "$TARGET_PATH" diff --staged --quiet 2>/dev/null; then
-      warning "Working tree has uncommitted changes"
-      info "Stashing user changes to preserve them during clean install..."
-      if git -C "$TARGET_PATH" stash push -m "loom-install: preserving user changes before --clean" 2>/dev/null; then
+    CLEAN_OWNED_DIRTY=()
+    while IFS= read -r _owned_path; do
+      [[ -n "$_owned_path" ]] && CLEAN_OWNED_DIRTY+=("$_owned_path")
+    done < <(_emit_loom_owned_dirty_paths "$LOOM_ROOT" "$TARGET_PATH")
+    if [[ ${#CLEAN_OWNED_DIRTY[@]} -gt 0 ]]; then
+      warning "Working tree has uncommitted Loom-owned changes"
+      info "Stashing Loom-owned changes to preserve them during clean install..."
+      if git -C "$TARGET_PATH" stash push \
+           -m "loom-install: preserving user changes before --clean" \
+           -- "${CLEAN_OWNED_DIRTY[@]}" 2>/dev/null; then
         STASHED_USER_CHANGES=true
-        success "User changes stashed"
+        CLEAN_STASH_REF="$(git -C "$TARGET_PATH" stash list 2>/dev/null | head -1)"
+        success "Loom-owned changes stashed → ${CLEAN_STASH_REF:-stash@{0}}"
+        info "  Stashed ${#CLEAN_OWNED_DIRTY[@]} Loom-owned path(s): ${CLEAN_OWNED_DIRTY[*]}"
       else
         warning "Failed to stash changes - uncommitted changes may be lost during --clean install"
         warning "Consider committing your changes first, then retry"
@@ -568,14 +583,26 @@ if [[ "$CLEAN_FIRST" == "true" ]]; then
 
     CLEANUP_FAILED=false
 
-    if ! git -C "$TARGET_PATH" restore --staged . 2>/dev/null; then
-      warning "Failed to unstage changes from uninstall"
-      CLEANUP_FAILED=true
-    fi
+    # Issue #3597: scope the unstage/checkout to Loom-owned dirty paths so
+    # sibling installers' uncommitted tracked changes (which were NOT stashed
+    # above) are never reverted. The uninstall only stages Loom-managed paths
+    # (#3450), so this intersection is exactly the set of staged deletions to
+    # undo and restore.
+    CLEANUP_PATHS=()
+    while IFS= read -r _owned_path; do
+      [[ -n "$_owned_path" ]] && CLEANUP_PATHS+=("$_owned_path")
+    done < <(_emit_loom_owned_dirty_paths "$LOOM_ROOT" "$TARGET_PATH")
 
-    if ! git -C "$TARGET_PATH" checkout -- . 2>/dev/null; then
-      warning "Failed to restore files from uninstall"
-      CLEANUP_FAILED=true
+    if [[ ${#CLEANUP_PATHS[@]} -gt 0 ]]; then
+      if ! git -C "$TARGET_PATH" restore --staged -- "${CLEANUP_PATHS[@]}" 2>/dev/null; then
+        warning "Failed to unstage changes from uninstall"
+        CLEANUP_FAILED=true
+      fi
+
+      if ! git -C "$TARGET_PATH" checkout -- "${CLEANUP_PATHS[@]}" 2>/dev/null; then
+        warning "Failed to restore files from uninstall"
+        CLEANUP_FAILED=true
+      fi
     fi
 
     # Also clean any untracked files left by the uninstall process
@@ -583,9 +610,10 @@ if [[ "$CLEAN_FIRST" == "true" ]]; then
     # that may contain custom project-specific commands not installed by Loom
     git -C "$TARGET_PATH" clean -fd .loom/ .codex/ .github/labels.yml 2>/dev/null || true
 
-    # Verify the working tree is clean
-    if ! git -C "$TARGET_PATH" diff --quiet 2>/dev/null || \
-       ! git -C "$TARGET_PATH" diff --staged --quiet 2>/dev/null; then
+    # Verify no Loom-owned path is still dirty. Scoped to the ownership set so
+    # legitimately-preserved sibling changes don't trip a false "not clean"
+    # warning (issue #3597).
+    if [[ -n "$(_emit_loom_owned_dirty_paths "$LOOM_ROOT" "$TARGET_PATH")" ]]; then
       CLEANUP_FAILED=true
     fi
 
@@ -604,13 +632,24 @@ if [[ "$CLEAN_FIRST" == "true" ]]; then
     fi
 
     # Restore stashed user changes
+    #
+    # Issue #3597: surface pop conflicts instead of silencing them with
+    # `2>/dev/null`. A conflicting pop (e.g. a Loom-managed file `init` also
+    # rewrote) previously hid the conflict and stranded the stash silently.
     if [[ "$STASHED_USER_CHANGES" == "true" ]]; then
       info "Restoring stashed user changes..."
-      if git -C "$TARGET_PATH" stash pop 2>/dev/null; then
+      if CLEAN_POP_OUTPUT="$(git -C "$TARGET_PATH" stash pop 2>&1)"; then
         success "User changes restored"
       else
+        CLEAN_STASH_REF="$(git -C "$TARGET_PATH" stash list 2>/dev/null | head -1 | cut -d: -f1)"
+        [[ -z "$CLEAN_STASH_REF" ]] && CLEAN_STASH_REF="stash@{0}"
         warning "Failed to restore stashed user changes automatically"
-        warning "Run 'git stash pop' in $TARGET_PATH to recover your changes"
+        echo ""
+        echo "  git stash pop reported:"
+        printf '%s\n' "$CLEAN_POP_OUTPUT" | sed 's/^/    /'
+        echo ""
+        echo "  Your changes are preserved in the stash ($CLEAN_STASH_REF)."
+        echo "  Recover with: cd $TARGET_PATH && git stash pop"
       fi
     fi
 

--- a/scripts/install/stash-scope.sh
+++ b/scripts/install/stash-scope.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# scripts/install/stash-scope.sh — scope the reinstall stash/reconcile guard
+# to Loom-owned paths (issue #3597).
+#
+# Both install.sh (`--quick` reinstall) and scripts/install-loom.sh (`--clean`)
+# guard uncommitted user changes across the uninstall→reinstall cycle by
+# stashing them first. The original guards ran an unscoped `git stash push`
+# (no pathspec), which swept EVERY uncommitted tracked change in the tree —
+# including sibling installers' work (`.anvil/install-metadata.json`,
+# `.claude/skills/repo/install-metadata.json`, renamed-away `anvil:*` files,
+# non-Loom CLAUDE.md sections) — into the stash. Untracked files were not
+# stashed, leaving the reporter's half-old/half-new hybrid tree.
+#
+# This helper narrows the guard to paths Loom actually owns: the intersection
+# of the dirty set (unstaged ∪ staged changes) with Loom's ownership set
+# (`_emit_loom_ownership_set` from manifest.sh, plus `.gitignore`, which
+# `loom-daemon init` rewrites but which is not part of the defaults/ walk).
+#
+# Source with:
+#     source "$LOOM_ROOT/scripts/install/stash-scope.sh"
+#
+# Public functions:
+#   _emit_loom_ownership_paths <loom_root> <target>
+#       One target-relative path per line: Loom's manifest ownership set plus
+#       `.gitignore`. Missing manifest.sh → just `.gitignore` (loud caller
+#       fallback expected).
+#
+#   _emit_loom_owned_dirty_paths <loom_root> <target>
+#       One target-relative path per line: the dirty set (unstaged ∪ staged
+#       changes) intersected with the ownership set. Empty output means no
+#       Loom-owned path is dirty → callers skip the stash entirely.
+
+# Emit the Loom ownership set (manifest paths + .gitignore), one per line.
+_emit_loom_ownership_paths() {
+  local loom_root="$1"
+  local target="$2"
+  local ownership_set=""
+
+  if [[ -f "$loom_root/scripts/install/manifest.sh" ]]; then
+    # shellcheck source=/dev/null
+    source "$loom_root/scripts/install/manifest.sh"
+    ownership_set="$(LOOM_ROOT="$loom_root" TARGET_PATH="$target" \
+      _emit_loom_ownership_set 2>/dev/null)"
+  fi
+
+  # `.gitignore` is rewritten by `loom-daemon init` (update_gitignore in
+  # loom-daemon/src/init/post_init.rs) but is not enumerated by the defaults/
+  # walk, so add it explicitly.
+  printf '%s\n.gitignore\n' "$ownership_set" | awk 'NF'
+}
+
+# Emit dirty ∩ ownership-set, one target-relative path per line.
+_emit_loom_owned_dirty_paths() {
+  local loom_root="$1"
+  local target="$2"
+
+  # Dirty set: union of unstaged (working tree vs index) and staged
+  # (index vs HEAD) changes. Staged deletions appear here too, which is
+  # exactly what the reconcile step needs to unstage.
+  local dirty_set
+  dirty_set="$( { git -C "$target" diff --name-only 2>/dev/null; \
+                  git -C "$target" diff --staged --name-only 2>/dev/null; } \
+                | sort -u )"
+
+  [[ -z "$dirty_set" ]] && return 0
+
+  local ownership_set
+  ownership_set="$(_emit_loom_ownership_paths "$loom_root" "$target")"
+  [[ -z "$ownership_set" ]] && return 0
+
+  # Intersect: first pass loads the ownership set into a map, second pass
+  # prints dirty paths present in the map. Awk avoids a perl/python dep.
+  awk 'NR==FNR { if ($0 != "") owned[$0]=1; next } { if ($0 != "" && ($0 in owned)) print }' \
+    <(printf '%s\n' "$ownership_set") \
+    <(printf '%s\n' "$dirty_set") \
+    | sort -u
+}


### PR DESCRIPTION
## Summary

Fixes #3597 Part A: the `--quick` reinstall (`install.sh`) and `--clean` install (`scripts/install-loom.sh`) guards ran an **unscoped** `git stash push`, sweeping every uncommitted tracked change — including sibling installers' work (`.anvil/install-metadata.json`, `.claude/skills/repo/install-metadata.json`, renamed-away `anvil:*` files, non-Loom CLAUDE.md sections) — into a stash and reverting those files to HEAD. Untracked files survived, so the tree was left in a half-old/half-new hybrid state that looked superficially fine.

## Changes

- **New `scripts/install/stash-scope.sh`** — shared helper: `_emit_loom_ownership_paths` (manifest ownership set + `.gitignore`) and `_emit_loom_owned_dirty_paths` (dirty set ∩ ownership set). Empty intersection ⇒ callers skip the stash entirely.
- **`install.sh` `--quick` reinstall** — pathspec-scope the stash push and the reconcile unstage to Loom-owned dirty paths; print the stash ref loudly at creation (and it is already repeated in the pop-failure summary). The existing #3588 `.gitignore` pop-conflict machinery is retained.
- **`scripts/install-loom.sh` `--clean`** — same pathspec scoping for the stash **and** for the cleanup `restore --staged`/`checkout` (otherwise `git checkout -- .` would revert the now-unstashed sibling changes outright); the cleanliness check is scoped to Loom-owned paths; the previously `2>/dev/null`-silenced stash pop now surfaces the conflict and the stash ref.
- **New regression test `defaults/scripts/tests/test-install-stash-scope.sh`** — seeds a temp repo with a committed Loom-owned file and a sibling file, dirties both, and asserts the helper selects only the Loom path, the scoped stash leaves the sibling change untouched in the working tree and absent from the stash, and a sibling-only dirty tree produces no stash.

## Part B split

Per the curator's split recommendation, Part B (scope `verify-install.sh` manifest to Loom-owned files + hash only the CLAUDE.md marker block; `MANIFEST_VERSION` bump v1→v2 with migration handling) is an independently shippable manifest schema change and is filed as follow-up **#3600**. This PR still uses `Closes #3597` — the follow-up #3600 tracks the remaining Part B scope.

## Testing

- `defaults/scripts/tests/test-install-stash-scope.sh` — 7/7 pass (new)
- `defaults/scripts/tests/test-gitignore-guard.sh` — 18/18 pass (byte-idempotency #3588/#3590 stays green)
- `defaults/scripts/tests/test-install-pr-markers.sh` — 28/28 pass
- `scripts/test-installer.sh` — 111/111 pass (includes #3545 scoped-staging coverage)
- `shellcheck --severity=warning` clean on new/changed shell files; `bash -n` clean on all three scripts

## Notes for reviewers

- Kept the diff to `install.sh` minimal and confined to the stash-guard and reconcile blocks to reduce merge-conflict surface with the concurrent #3598 (config.json snapshot/restore) work.
- Per the issue's scope boundaries: no `-u`/`--include-untracked` added (untracked files already survive correctly — the fix is narrowing, not widening), and `loom-daemon init` / `uninstall-loom.sh` are untouched.

Closes #3597

🤖 Generated with [Claude Code](https://claude.com/claude-code)