### PR TITLE
fix(verify-install): scope manifest to Loom-owned files, region-hash CLAUDE.md (#3600)

### DIFF
--- a/defaults/scripts/tests/test-verify-install-scope.sh
+++ b/defaults/scripts/tests/test-verify-install-scope.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+# test-verify-install-scope.sh - Regression tests for verify-install.sh manifest
+# scoping (issue #3600, Part B of #3597).
+#
+# verify-install.sh previously built its checksum manifest from a hard-coded
+# directory walk and hashed CLAUDE.md whole-file. In a multi-tool consumer repo
+# (Loom + a sibling installer such as Anvil + Repo Skills) that produced false
+# DRIFT:
+#
+#   1. `find .claude/agents -name '*.md'` captured sibling agent shims Loom
+#      never shipped (e.g. anvil-*.md).
+#   2. A whole-file CLAUDE.md hash flagged drift whenever a sibling installer
+#      edited CLAUDE.md *outside* Loom's <!-- BEGIN/END LOOM ORCHESTRATION -->
+#      marker block.
+#
+# The fix derives the tracked-file set from .loom/install-metadata.json
+# "installed_files" (Loom's ownership boundary) and hashes CLAUDE.md over its
+# Loom marker region only. It also bumps the manifest schema to v2, so a stale
+# v1 manifest reports "schema outdated" instead of false drift.
+#
+# Test strategy: seed a temp git repo with a hand-written install-metadata.json,
+# a CLAUDE.md with a Loom block plus sibling sections, a Loom agent, and a
+# sibling agent shim, then invoke the real script from the source checkout and
+# assert on the generated manifest and verify exit codes.
+#
+# Usage:
+#   bash .loom/scripts/tests/test-verify-install-scope.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+VERIFY_SCRIPT="$REPO_ROOT/defaults/scripts/verify-install.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_eq() {
+    local expected="$1" actual="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg (expected '$expected', got '$actual')"
+    fi
+}
+
+assert_not_contains() {
+    local haystack="$1" needle="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$haystack" != *"$needle"* ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg (found unexpected '$needle')"
+    fi
+}
+
+assert_contains() {
+    local haystack="$1" needle="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$haystack" == *"$needle"* ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg (missing '$needle')"
+        echo "$haystack" | sed 's/^/      /'
+    fi
+}
+
+if [[ ! -f "$VERIFY_SCRIPT" ]]; then
+    echo "ERROR: $VERIFY_SCRIPT not found" >&2
+    exit 1
+fi
+if ! command -v jq &>/dev/null; then
+    echo "SKIP: jq not available (required by verify-install.sh verify mode)" >&2
+    exit 0
+fi
+
+# Seed a temp git repo with a Loom install. Args set which optional bits exist.
+# Writes CLAUDE.md with a Loom marker block flanked by sibling sections, one
+# Loom agent, one sibling agent shim, settings.json, a user-edited config.json,
+# and an install-metadata.json listing only Loom-owned paths.
+seed_repo() {
+    local tmp
+    tmp=$(mktemp -d "${TMPDIR:-/tmp}/loom-vscope.XXXXXX")
+    (
+        cd "$tmp" || exit 1
+        git init -q .
+        git config user.email "test@example.com"
+        git config user.name "Test"
+        mkdir -p .loom .claude/agents
+
+        cat > CLAUDE.md <<'EOF'
+# Consumer Project
+
+Sibling intro section owned by another tool.
+
+<!-- BEGIN LOOM ORCHESTRATION -->
+## Loom
+Loom-managed content lives here.
+<!-- END LOOM ORCHESTRATION -->
+
+## Sibling Tail Section
+More sibling-owned content.
+EOF
+
+        echo "loom builder agent" > .claude/agents/loom-builder.md
+        echo "anvil sibling shim" > .claude/agents/anvil-foo.md
+        printf '{"schema":"loom"}\n' > .claude/settings.json
+        printf '{"nextAgentNumber":9,"user":"edited"}\n' > .loom/config.json
+
+        # install-metadata.json lists only Loom-owned paths; anvil-foo.md is
+        # deliberately absent (a sibling installer, not Loom, shipped it).
+        cat > .loom/install-metadata.json <<'EOF'
+{
+  "loom_version": "0.10.9",
+  "loom_commit": "deadbee",
+  "installed_files": [".claude/agents/loom-builder.md",".claude/settings.json","CLAUDE.md",".loom/config.json"]
+}
+EOF
+    )
+    echo "$tmp"
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: sibling agent shim never enters the manifest.
+# ---------------------------------------------------------------------------
+echo "Case 1: sibling agent shim excluded from manifest"
+REPO=$(seed_repo)
+( cd "$REPO" && bash "$VERIFY_SCRIPT" generate --quiet )
+MANIFEST=$(cat "$REPO/.loom/manifest.json")
+assert_not_contains "$MANIFEST" "anvil-foo.md" "Case 1: anvil-foo.md absent from .loom/manifest.json"
+assert_contains "$MANIFEST" "loom-builder.md" "Case 1: Loom agent present in manifest"
+assert_contains "$MANIFEST" '"version": 2' "Case 1: manifest schema is v2"
+# User-mutable config.json must not be tracked (false-drift guard).
+assert_not_contains "$MANIFEST" '".loom/config.json"' "Case 1: user config.json not tracked"
+rm -rf "$REPO"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Case 2: sibling CLAUDE.md edit outside markers is clean; inside is drift.
+# ---------------------------------------------------------------------------
+echo "Case 2: CLAUDE.md region-scoped hashing"
+REPO=$(seed_repo)
+( cd "$REPO" && bash "$VERIFY_SCRIPT" generate --quiet )
+
+# Edit OUTSIDE the Loom markers (both the intro and the tail sibling sections).
+cat > "$REPO/CLAUDE.md" <<'EOF'
+# Consumer Project
+
+Sibling intro section HEAVILY rewritten by another tool.
+
+<!-- BEGIN LOOM ORCHESTRATION -->
+## Loom
+Loom-managed content lives here.
+<!-- END LOOM ORCHESTRATION -->
+
+## Sibling Tail Section
+Even more sibling-owned content appended later, plus a new paragraph.
+EOF
+( cd "$REPO" && bash "$VERIFY_SCRIPT" verify --quiet )
+assert_eq "0" "$?" "Case 2a: edit outside Loom markers -> verify exit 0"
+
+# Edit INSIDE the Loom markers -> real drift.
+cat > "$REPO/CLAUDE.md" <<'EOF'
+# Consumer Project
+
+Sibling intro.
+
+<!-- BEGIN LOOM ORCHESTRATION -->
+## Loom
+Loom-managed content lives here — but TAMPERED inside the block.
+<!-- END LOOM ORCHESTRATION -->
+
+## Sibling Tail Section
+tail.
+EOF
+( cd "$REPO" && bash "$VERIFY_SCRIPT" verify --quiet )
+assert_eq "1" "$?" "Case 2b: edit inside Loom markers -> verify exit 1 (drift)"
+
+# Remove the Loom block entirely -> missing-markers drift.
+printf '# Consumer Project\n\nNo Loom block remains.\n' > "$REPO/CLAUDE.md"
+( cd "$REPO" && bash "$VERIFY_SCRIPT" verify --quiet )
+assert_eq "1" "$?" "Case 2c: removed Loom markers -> verify exit 1 (drift)"
+rm -rf "$REPO"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Case 3: a v1-schema manifest reports "schema outdated", not false drift.
+# ---------------------------------------------------------------------------
+echo "Case 3: outdated v1 manifest schema"
+REPO=$(seed_repo)
+( cd "$REPO" && bash "$VERIFY_SCRIPT" generate --quiet )
+# Downgrade the recorded schema version to 1 in place.
+sed 's/"version": 2/"version": 1/' "$REPO/.loom/manifest.json" > "$REPO/.loom/manifest.json.tmp"
+mv "$REPO/.loom/manifest.json.tmp" "$REPO/.loom/manifest.json"
+
+HUMAN_OUT=$( cd "$REPO" && bash "$VERIFY_SCRIPT" verify 2>&1 )
+HUMAN_EXIT=$?
+assert_eq "5" "$HUMAN_EXIT" "Case 3a: v1 manifest -> verify exit 5 (schema outdated, not 1)"
+assert_contains "$HUMAN_OUT" "schema outdated" "Case 3b: human message says schema outdated"
+assert_not_contains "$HUMAN_OUT" "DRIFT DETECTED" "Case 3c: no per-file drift reported for v1"
+
+JSON_OUT=$( cd "$REPO" && bash "$VERIFY_SCRIPT" verify --json 2>&1 )
+assert_contains "$JSON_OUT" "manifest_schema_outdated" "Case 3d: json error is manifest_schema_outdated"
+
+# Auto (no-arg) mode self-heals a v1 manifest by regenerating it.
+( cd "$REPO" && bash "$VERIFY_SCRIPT" >/dev/null 2>&1 )
+assert_eq "0" "$?" "Case 3e: auto mode regenerates v1 manifest (exit 0)"
+REGEN=$(cat "$REPO/.loom/manifest.json")
+assert_contains "$REGEN" '"version": 2' "Case 3f: auto mode rewrote manifest to v2"
+rm -rf "$REPO"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Case 4: no install-metadata.json -> warned legacy directory-walk fallback.
+# ---------------------------------------------------------------------------
+echo "Case 4: legacy fallback when metadata absent"
+FBTMP=$(mktemp -d "${TMPDIR:-/tmp}/loom-vscope-fb.XXXXXX")
+(
+    cd "$FBTMP" || exit 1
+    git init -q .
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    mkdir -p .loom/roles .loom/scripts
+    echo "builder role" > .loom/roles/builder.md
+    echo "helper script" > .loom/scripts/helper.sh
+    printf '# top\n\n<!-- BEGIN LOOM ORCHESTRATION -->\nloom\n<!-- END LOOM ORCHESTRATION -->\n' > CLAUDE.md
+)
+FB_OUT=$( cd "$FBTMP" && bash "$VERIFY_SCRIPT" generate 2>&1 )
+assert_contains "$FB_OUT" "falling back to legacy directory walk" "Case 4a: warns about fallback"
+FB_COUNT=$(jq '.file_count' "$FBTMP/.loom/manifest.json" 2>/dev/null || echo 0)
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ "$FB_COUNT" -ge 2 ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: Case 4b: fallback produced a non-empty manifest ($FB_COUNT files)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: Case 4b: fallback manifest too small ($FB_COUNT files)"
+fi
+( cd "$FBTMP" && bash "$VERIFY_SCRIPT" verify --quiet )
+assert_eq "0" "$?" "Case 4c: fallback verify is clean (exit 0)"
+rm -rf "$FBTMP"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo "==============================="
+echo "Tests run:    $TESTS_RUN"
+echo -e "Tests passed: ${GREEN}$TESTS_PASSED${NC}"
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    echo -e "Tests failed: ${RED}$TESTS_FAILED${NC}"
+    exit 1
+fi
+echo "All tests passed."
+exit 0

--- a/defaults/scripts/verify-install.sh
+++ b/defaults/scripts/verify-install.sh
@@ -39,8 +39,24 @@ EXIT_DRIFT=1
 EXIT_BAD_ARGS=2
 EXIT_NO_MANIFEST=3
 EXIT_ENV_ERROR=4
+EXIT_SCHEMA_OUTDATED=5
 
-MANIFEST_VERSION=1
+# Manifest schema version.
+#   v1: whole-file hash of every tracked path; file list derived from a
+#       hard-coded directory walk (captured sibling-installer files).
+#   v2 (issue #3600): file list derived from .loom/install-metadata.json
+#       "installed_files" (Loom's ownership boundary); the top-level CLAUDE.md
+#       entry is hashed over its <!-- BEGIN/END LOOM ORCHESTRATION --> region
+#       only (recorded as "region": "loom-block"), so sibling edits outside
+#       the Loom block no longer report drift.
+# cmd_verify refuses to compare a manifest whose version != MANIFEST_VERSION
+# and instructs the caller to regenerate, rather than reporting false drift.
+MANIFEST_VERSION=2
+
+# Loom section markers in the top-level CLAUDE.md (mirrors
+# loom-daemon/src/init/scaffolding.rs LOOM_SECTION_START / LOOM_SECTION_END).
+LOOM_SECTION_START='<!-- BEGIN LOOM ORCHESTRATION -->'
+LOOM_SECTION_END='<!-- END LOOM ORCHESTRATION -->'
 
 # Find the repository root (works from worktrees and subdirectories)
 find_repo_root() {
@@ -90,28 +106,30 @@ ${BOLD}USAGE:${NC}
 
 ${BOLD}DESCRIPTION:${NC}
     Generates a SHA-256 checksum manifest (.loom/manifest.json) of all
-    tracked Loom installation files. The manifest can then be used to
+    Loom-owned installation files. The manifest can then be used to
     detect post-installation drift (modified or missing files).
 
-${BOLD}TRACKED FILE LOCATIONS:${NC}
-    .loom/roles/*.md, *.json       Role definitions
-    .loom/scripts/*, cli/*         Helper scripts
-    .loom/docs/*                   Documentation
-    .claude/commands/loom/*.md     Slash commands
-    .claude/agents/*.md            Agent definitions
-    .claude/settings.json          Claude settings
-    .github/labels.yml             Label definitions
-    .github/ISSUE_TEMPLATE/*       Issue templates
-    .github/workflows/*.yml        GitHub workflows
-    CLAUDE.md                       Top-level docs
-    .loom/CLAUDE.md, .loom/README.md
-    loom                           CLI wrapper
+${BOLD}TRACKED FILE SET:${NC}
+    The file list is derived from .loom/install-metadata.json
+    "installed_files" (Loom's ownership boundary) intersected with the
+    files actually present on disk. Files a sibling installer added
+    (e.g. .claude/agents/<other-tool>-*.md) are never tracked. When the
+    metadata file is absent (pre-#3450 installs), a legacy directory
+    walk is used instead, with a stderr warning.
 
-${BOLD}NOT TRACKED (runtime/user files):${NC}
+    The top-level CLAUDE.md is hashed over its
+    ${LOOM_SECTION_START} ... ${LOOM_SECTION_END}
+    region only, so sibling edits outside the Loom block do not report
+    drift. All other files are hashed whole.
+
+${BOLD}NOT TRACKED (runtime/user/merge-target files):${NC}
     .loom/config.json              Local terminal config
     .loom/daemon-state.json        Daemon runtime state
+    .loom/manifest.json            This manifest
+    .loom/install-metadata.json    Install ownership record
     .loom/progress/                Shepherd progress
     .loom/worktrees/               Git worktrees
+    .gitignore                     Consumer-merged ignore rules
     package.json                   Project package config
 
 ${BOLD}EXIT CODES:${NC}
@@ -120,6 +138,7 @@ ${BOLD}EXIT CODES:${NC}
     2    Invalid arguments
     3    Manifest not found (verify mode)
     4    Environment error (not a git repo, no SHA command)
+    5    Manifest schema outdated (verify mode) — run generate
 
 ${BOLD}EXAMPLES:${NC}
     # After installation, generate a manifest
@@ -134,35 +153,98 @@ ${BOLD}EXAMPLES:${NC}
 EOF
 }
 
-# Collect all tracked file paths (relative to repo root)
-# Outputs one path per line, sorted
-collect_tracked_files() {
+# Return "loom-block" for the top-level CLAUDE.md (region-scoped hashing),
+# empty string for every other path (whole-file hashing). Only the repo-root
+# CLAUDE.md is a merge target; .loom/CLAUDE.md is fully Loom-owned.
+region_for_path() {
+    if [[ "$1" == "CLAUDE.md" ]]; then
+        echo "loom-block"
+    else
+        echo ""
+    fi
+}
+
+# Runtime / user-mutable / merge-target files that Loom installs (so they
+# appear in install-metadata.json) but must NOT be checksum-tracked: verifying
+# them would report drift on every legitimate consumer edit. Returns 0 (match)
+# for paths to exclude from the tracked set.
+is_untracked_runtime_file() {
+    case "$1" in
+        .loom/config.json) return 0 ;;
+        .loom/daemon-state.json) return 0 ;;
+        .loom/manifest.json) return 0 ;;
+        .loom/install-metadata.json) return 0 ;;
+        .loom/progress/*) return 0 ;;
+        .loom/worktrees/*) return 0 ;;
+        .gitignore) return 0 ;;
+        package.json) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Parse the "installed_files" JSON array from install-metadata.json into
+# newline-delimited target-relative paths. Deliberately jq-free (awk) so
+# `generate` has no hard jq dependency — the awk split pattern is ported from
+# scripts/install/manifest.sh::_emit_loom_ownership_set (Loom-shipped paths
+# never contain commas, so a naive comma split is safe).
+parse_installed_files() {
+    local metadata_path="$1"
+    awk '
+        { buf = buf $0 "\n" }
+        END {
+            idx = index(buf, "\"installed_files\"")
+            if (idx == 0) { exit }
+            rest = substr(buf, idx)
+            lb = index(rest, "[")
+            if (lb == 0) { exit }
+            rest = substr(rest, lb + 1)
+            rb = index(rest, "]")
+            if (rb == 0) { exit }
+            arr = substr(rest, 1, rb - 1)
+            n = split(arr, items, ",")
+            for (i = 1; i <= n; i++) {
+                entry = items[i]
+                sub(/^[[:space:]]+/, "", entry)
+                sub(/[[:space:]]+$/, "", entry)
+                sub(/^"/, "", entry)
+                sub(/"$/, "", entry)
+                if (entry != "") print entry
+            }
+        }
+    ' "$metadata_path"
+}
+
+# Legacy fallback: hard-coded directory walk (pre-#3450 installs, or when
+# install-metadata.json is absent/empty). This is the historical behavior and
+# intentionally still captures .claude/agents/*.md by glob — it is only reached
+# when Loom's ownership manifest is unavailable.
+collect_tracked_files_walk() {
     local root="$1"
     local files=()
 
     # .loom/roles/*.md and *.json
     while IFS= read -r -d '' f; do
-        files+=("${f#$root/}")
+        files+=("${f#"$root"/}")
     done < <(find "$root/.loom/roles" -maxdepth 1 -type f \( -name "*.md" -o -name "*.json" \) -print0 2>/dev/null || true)
 
     # .loom/scripts/* (recursive, all files)
     while IFS= read -r -d '' f; do
-        files+=("${f#$root/}")
+        files+=("${f#"$root"/}")
     done < <(find "$root/.loom/scripts" -type f -print0 2>/dev/null || true)
 
     # .loom/docs/*
     while IFS= read -r -d '' f; do
-        files+=("${f#$root/}")
+        files+=("${f#"$root"/}")
     done < <(find "$root/.loom/docs" -type f -print0 2>/dev/null || true)
 
     # .claude/commands/loom/*.md
     while IFS= read -r -d '' f; do
-        files+=("${f#$root/}")
+        files+=("${f#"$root"/}")
     done < <(find "$root/.claude/commands/loom" -maxdepth 1 -type f -name "*.md" -print0 2>/dev/null || true)
 
     # .claude/agents/*.md
     while IFS= read -r -d '' f; do
-        files+=("${f#$root/}")
+        files+=("${f#"$root"/}")
     done < <(find "$root/.claude/agents" -maxdepth 1 -type f -name "*.md" -print0 2>/dev/null || true)
 
     # .claude/settings.json
@@ -177,7 +259,7 @@ collect_tracked_files() {
 
     # .github/ISSUE_TEMPLATE/*
     while IFS= read -r -d '' f; do
-        files+=("${f#$root/}")
+        files+=("${f#"$root"/}")
     done < <(find "$root/.github/ISSUE_TEMPLATE" -type f -print0 2>/dev/null || true)
 
     # .github/workflows/ - no workflows installed by default
@@ -200,7 +282,83 @@ collect_tracked_files() {
     fi
 
     # Output sorted, one per line
-    printf '%s\n' "${files[@]}" | sort
+    [[ ${#files[@]} -eq 0 ]] && return 0
+    printf '%s\n' "${files[@]}" | sort -u
+}
+
+# Collect all tracked file paths (relative to repo root), one per line, sorted.
+#
+# Primary path (issue #3600): derive the list from .loom/install-metadata.json
+# "installed_files" (Loom's ownership boundary), intersected with files present
+# on disk and minus the runtime/merge-target denylist. This means files a
+# sibling installer added (e.g. Anvil's .claude/agents/anvil-*.md) never enter
+# the manifest. Falls back to the legacy directory walk (with a warning) when
+# the metadata is absent or yields no usable entries.
+collect_tracked_files() {
+    local root="$1"
+    local metadata_path="$root/.loom/install-metadata.json"
+
+    local installed=""
+    if [[ -f "$metadata_path" ]]; then
+        installed=$(parse_installed_files "$metadata_path")
+    fi
+
+    if [[ -n "$installed" ]]; then
+        local files=()
+        local rel
+        while IFS= read -r rel; do
+            [[ -z "$rel" ]] && continue
+            is_untracked_runtime_file "$rel" && continue
+            [[ -f "$root/$rel" ]] || continue
+            files+=("$rel")
+        done <<< "$installed"
+
+        if [[ ${#files[@]} -gt 0 ]]; then
+            printf '%s\n' "${files[@]}" | sort -u
+            return 0
+        fi
+    fi
+
+    # Fallback: metadata missing or empty (pre-#3450 install).
+    echo "Warning: .loom/install-metadata.json missing or has no installed_files;" \
+         "falling back to legacy directory walk (pre-#3450 install?)." \
+         "Sibling-installer files may be captured; re-run install to refresh metadata." >&2
+    collect_tracked_files_walk "$root"
+}
+
+# Emit the hashable bytes for an entry to stdout, honoring region rules.
+# For region "loom-block", emit only the CLAUDE.md Loom marker region
+# (inclusive). For whole-file entries, cat the file verbatim.
+emit_hashable_content() {
+    local full_path="$1"
+    local region="$2"
+    if [[ "$region" == "loom-block" ]]; then
+        sed -n "/${LOOM_SECTION_START}/,/${LOOM_SECTION_END}/p" "$full_path"
+    else
+        cat "$full_path"
+    fi
+}
+
+# Compute "<sha256> <byte-size>" for an entry, honoring the region rule.
+# Whole-file entries hash the raw file bytes (identical to `shasum`); region
+# entries hash the extracted marker block. Both generate and verify call this,
+# so the two sides always agree.
+compute_entry_digest() {
+    local full_path="$1"
+    local region="$2"
+    local sha size
+    if [[ "$region" == "loom-block" ]]; then
+        local block
+        block=$(emit_hashable_content "$full_path" "$region")
+        sha=$(printf '%s' "$block" | $SHA_CMD | awk '{print $1}')
+        size=$(printf '%s' "$block" | wc -c | tr -d '[:space:]')
+    else
+        sha=$(compute_sha256 "$full_path")
+        size=$(wc -c < "$full_path" | tr -d '[:space:]')
+    fi
+    # Trailing newline is required: callers use `read`, which returns non-zero
+    # on EOF-without-newline and would abort under `set -e`.
+    printf '%s %s\n' "$sha" "$size"
 }
 
 # Generate manifest
@@ -268,10 +426,10 @@ cmd_generate() {
                 continue
             fi
 
-            local sha256
-            sha256=$(compute_sha256 "$full_path")
-            local size
-            size=$(wc -c < "$full_path" | tr -d '[:space:]')
+            local region
+            region=$(region_for_path "$rel_path")
+            local sha256 size
+            read -r sha256 size < <(compute_entry_digest "$full_path" "$region")
 
             if [[ "$first" == "true" ]]; then
                 first=false
@@ -285,7 +443,12 @@ cmd_generate() {
 
             printf '    "%s": {\n' "$json_path"
             printf '      "sha256": "%s",\n' "$sha256"
-            printf '      "size": %s\n' "$size"
+            printf '      "size": %s' "$size"
+            if [[ -n "$region" ]]; then
+                printf ',\n      "region": "%s"\n' "$region"
+            else
+                printf '\n'
+            fi
             printf '    }'
         done <<< "$tracked_files"
 
@@ -335,6 +498,22 @@ cmd_verify() {
         exit $EXIT_ENV_ERROR
     fi
 
+    # Schema-version gate (issue #3600). A manifest written by an older
+    # verify-install.sh uses a different file-set / hashing contract (v1:
+    # directory walk + whole-file CLAUDE.md hash). Comparing against it would
+    # report false drift, so refuse and instruct the caller to regenerate.
+    local manifest_schema
+    manifest_schema=$(jq -r '.version // 0' "$manifest_path")
+    if [[ "$manifest_schema" != "$MANIFEST_VERSION" ]]; then
+        if [[ "$output_mode" == "json" ]]; then
+            printf '{"status": "error", "error": "manifest_schema_outdated", "manifest_version": %s, "expected_version": %s}\n' \
+                "${manifest_schema:-0}" "$MANIFEST_VERSION"
+        elif [[ "$output_mode" != "quiet" ]]; then
+            echo -e "${YELLOW}manifest schema outdated (found v${manifest_schema}, expected v${MANIFEST_VERSION}) — run 'verify-install.sh generate'${NC}" >&2
+        fi
+        exit $EXIT_SCHEMA_OUTDATED
+    fi
+
     # Read manifest metadata
     local manifest_generated_at
     manifest_generated_at=$(jq -r '.generated_at // ""' "$manifest_path")
@@ -360,16 +539,25 @@ cmd_verify() {
         expected_sha256=$(jq -r --arg p "$rel_path" '.files[$p].sha256' "$manifest_path")
         local expected_size
         expected_size=$(jq -r --arg p "$rel_path" '.files[$p].size' "$manifest_path")
+        # Per-entry region marker (issue #3600). Absent → whole-file hashing.
+        local region
+        region=$(jq -r --arg p "$rel_path" '.files[$p].region // ""' "$manifest_path")
 
         if [[ ! -f "$full_path" ]]; then
             missing_files+=("$rel_path|$expected_sha256|$expected_size")
             continue
         fi
 
-        local actual_sha256
-        actual_sha256=$(compute_sha256 "$full_path")
-        local actual_size
-        actual_size=$(wc -c < "$full_path" | tr -d '[:space:]')
+        # A region-scoped entry whose Loom marker block is now absent is real
+        # drift (the block was removed), even though the file still exists.
+        if [[ "$region" == "loom-block" ]] \
+            && ! grep -q "$LOOM_SECTION_START" "$full_path" 2>/dev/null; then
+            modified_files+=("$rel_path|$expected_sha256|missing-loom-markers|$expected_size|0")
+            continue
+        fi
+
+        local actual_sha256 actual_size
+        read -r actual_sha256 actual_size < <(compute_entry_digest "$full_path" "$region")
 
         if [[ "$actual_sha256" != "$expected_sha256" ]]; then
             modified_files+=("$rel_path|$expected_sha256|$actual_sha256|$expected_size|$actual_size")
@@ -523,11 +711,21 @@ main() {
             exit $EXIT_OK
             ;;
         "")
-            # Auto mode: verify if manifest exists, generate if not
+            # Auto mode: verify if manifest exists, generate if not.
+            # Self-heal: an outdated-schema manifest is regenerated rather than
+            # verified, giving consumers a hands-free upgrade path (issue #3600).
             local root
             root=$(find_repo_root) || exit $EXIT_ENV_ERROR
             if [[ -f "$root/.loom/manifest.json" ]]; then
-                cmd_verify
+                # Lightweight, jq-free schema read so auto mode stays robust.
+                local auto_schema
+                auto_schema=$(grep -o '"version"[[:space:]]*:[[:space:]]*[0-9]\{1,\}' \
+                    "$root/.loom/manifest.json" | grep -o '[0-9]\{1,\}$' | head -1 || true)
+                if [[ "$auto_schema" != "$MANIFEST_VERSION" ]]; then
+                    cmd_generate
+                else
+                    cmd_verify
+                fi
             else
                 cmd_generate
             fi


### PR DESCRIPTION
Closes #3600 (Part B of #3597).

## Problem

`defaults/scripts/verify-install.sh` built its checksum manifest from a hard-coded directory walk and hashed `CLAUDE.md` whole-file. In a multi-tool consumer repo (Loom + a sibling installer such as Anvil + Repo Skills) that produced false DRIFT:

1. `find .claude/agents -name '*.md'` captured sibling agent shims Loom never shipped (e.g. `anvil-*.md`).
2. A whole-file `CLAUDE.md` hash flagged drift on any sibling edit *outside* Loom's `<!-- BEGIN/END LOOM ORCHESTRATION -->` marker block.

That false drift is what tempted the #3597 reporter to re-run `install.sh --quick` over a dirty tree.

## Changes (all self-contained in `verify-install.sh` + a new test)

- **Ownership-scoped file list**: `collect_tracked_files()` now derives the tracked set from `.loom/install-metadata.json` `installed_files` (Loom's ownership boundary), intersected with files present on disk and minus a runtime/merge-target denylist (`.loom/config.json`, `.gitignore`, `package.json`, `.loom/manifest.json`, ...). Parsing is jq-free (awk, ported from `manifest.sh::_emit_loom_ownership_set`) so `generate` keeps no hard jq dependency. Falls back to the legacy directory walk — with a stderr warning — only when metadata is absent/empty (pre-#3450 installs).
- **Region-scoped CLAUDE.md hashing**: the top-level `CLAUDE.md` entry is hashed over its `<!-- BEGIN LOOM ORCHESTRATION -->` … `<!-- END LOOM ORCHESTRATION -->` region only (recorded as `"region": "loom-block"`; absent field = whole-file). Sibling edits outside the block → `verify` exit 0; edits inside, or removal of the block, are real drift. `.loom/CLAUDE.md` (fully Loom-owned) stays whole-file.
- **Schema bump**: `MANIFEST_VERSION` → 2. `cmd_verify` now reads `.version` first and, on mismatch, prints `manifest schema outdated — run 'verify-install.sh generate'` and exits with a new `EXIT_SCHEMA_OUTDATED=5` instead of reporting false per-file drift (handled in human/`--json`/`--quiet` modes). Auto (no-arg) mode self-heals a stale-schema manifest by regenerating.
- **New regression test** `defaults/scripts/tests/test-verify-install-scope.sh` (16 assertions): sibling agent shim excluded, CLAUDE.md edit outside markers clean / inside markers drift / markers removed drift, v1 manifest → schema-outdated + auto-mode self-heal, and metadata-absent fallback.

## Acceptance criteria

- [x] `generate` derives its file list from `install-metadata.json` `installed_files` (∩ disk), falling back to the walk only when metadata is absent, with a warning.
- [x] `.claude/agents/*` files not shipped by Loom never appear in `.loom/manifest.json`.
- [x] CLAUDE.md drift computed only over the Loom marker region; the #3597 repro yields `verify` exit 0.
- [x] `MANIFEST_VERSION` bumped to 2 with a per-entry region marker; `verify` against a v1 manifest says "manifest schema outdated — run generate" rather than reporting false drift.
- [x] Regression test covering the sibling-CLAUDE.md-edit and sibling-agent-shim cases.

## Testing

- `bash defaults/scripts/tests/test-verify-install-scope.sh` → 16/16 pass
- `bash defaults/scripts/tests/test-gitignore-guard.sh` → 18/18 pass
- `shellcheck --severity=warning` + `bash -n` on both changed scripts → clean
- `scripts/test-installer.sh` → the 2 failures present are pre-existing on the branch base (Test 65 / #3598 `loom-daemon init` config.json merge, a Rust-binary behavior gated on a rebuilt binary); confirmed identical with these changes stashed. This PR adds no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)