### PR TITLE
refactor(hooks): extract Loom-workflow guards into guard-loom-workflow.sh (#3604)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,10 @@
           {
             "type": "command",
             "command": "bash -c 'ROOT=$(cd \"$(git rev-parse --git-common-dir 2>/dev/null)/..\" 2>/dev/null && pwd) && [ -x \"$ROOT/.loom/hooks/guard-destructive.sh\" ] && exec \"$ROOT/.loom/hooks/guard-destructive.sh\" || exit 0'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'ROOT=$(cd \"$(git rev-parse --git-common-dir 2>/dev/null)/..\" 2>/dev/null && pwd) && [ -x \"$ROOT/.loom/hooks/guard-loom-workflow.sh\" ] && exec \"$ROOT/.loom/hooks/guard-loom-workflow.sh\" || exit 0'"
           }
         ]
       },

--- a/.loom/hooks/guard-destructive.sh
+++ b/.loom/hooks/guard-destructive.sh
@@ -304,32 +304,11 @@ for pattern in "${ASK_PATTERNS[@]}"; do
 done
 
 # =============================================================================
-# LOOM: Prefer merge-pr.sh over gh pr merge
+# NOTE: The two Loom-workflow-specific guards (the 'gh pr merge' → merge-pr.sh
+# redirect, and the 'pip install -e' worktree block keyed on LOOM_WORKTREE_PATH)
+# were extracted into guard-loom-workflow.sh (issue #3604). They are registered
+# as a separate PreToolUse/Bash hook and fire independently of this guard.
 # =============================================================================
-
-if echo "$COMMAND" | grep -qE 'gh\s+pr\s+merge'; then
-    deny "Use ./.loom/scripts/merge-pr.sh <PR_NUMBER> instead of 'gh pr merge'. The script merges via the GitHub API without local checkout, which avoids worktree errors."
-fi
-
-# =============================================================================
-# LOOM: Block pip install -e inside worktrees (issue #2495)
-#
-# Editable pip installs overwrite a global .pth file in site-packages.
-# When multiple builders run in parallel worktrees, each 'pip install -e .'
-# clobbers the .pth to point at its own worktree, causing all other Python
-# processes to import from the wrong source tree.
-#
-# PYTHONPATH is already set by agent-spawn.sh and _build_worktree_env()
-# so editable installs are unnecessary inside worktrees.
-# =============================================================================
-
-WORKTREE_PATH="${LOOM_WORKTREE_PATH:-}"
-if [[ -n "$WORKTREE_PATH" ]]; then
-    if echo "$COMMAND" | grep -qE '(pip|pip3|uv pip)\s+install\s+.*-e\s' || \
-       echo "$COMMAND" | grep -qE '(pip|pip3|uv pip)\s+install\s+.*--editable\s'; then
-        deny "BLOCKED: 'pip install -e' is not allowed inside worktrees. Editable installs overwrite the global .pth file, breaking parallel builders (see issue #2495). PYTHONPATH is already configured for this worktree — imports resolve correctly without editable installs."
-    fi
-fi
 
 # =============================================================================
 # ALLOW - Everything else passes through

--- a/.loom/hooks/guard-loom-workflow.sh
+++ b/.loom/hooks/guard-loom-workflow.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# guard-loom-workflow.sh - PreToolUse hook for Loom-workflow-specific Bash guards
+#
+# Claude Code PreToolUse hook that intercepts Bash commands before execution.
+# Receives JSON on stdin with tool_input.command and cwd fields.
+#
+# This hook carries ONLY the two Loom-workflow-specific guards that were
+# extracted from guard-destructive.sh (issue #3604):
+#
+#   1. LOOM: Prefer merge-pr.sh over 'gh pr merge'
+#   2. LOOM: Block 'pip install -e' inside worktrees (issue #2495)
+#
+# The generic repository-hygiene guards (catastrophic denies, SQL/cloud toggles,
+# ASK patterns) live in guard-destructive.sh and are being migrated toward Repo
+# Skills (rjwalters/repo#13). This file stays Loom-owned because both guards are
+# specific to the Loom worktree/merge workflow.
+#
+# IMPORTANT: This hook only fires when Claude Code is invoked with:
+#   --dangerously-skip-permissions  ← hooks FIRE (used by Loom agents)
+#
+# It does NOT fire with:
+#   --permission-mode bypassPermissions  ← hooks SKIPPED entirely
+#
+# Output format (Claude Code hooks spec):
+#   { "hookSpecificOutput": { "hookEventName": "PreToolUse", "permissionDecision": "deny|ask", "permissionDecisionReason": "..." } }
+#
+# NOTE: The "hookEventName": "PreToolUse" field is REQUIRED by Claude Code's
+# PreToolUse hook schema. Without it, Claude Code silently discards the
+# decision and the guard becomes inert (see issue #3550).
+#
+# Error handling: This script MUST never exit with a non-zero code or produce
+# invalid output. Any internal error is caught by the trap, logged for
+# diagnostics, and results in an "allow" decision to prevent infinite retry
+# loops in Claude Code.
+
+# Determine log directory relative to this script's location
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null || echo ".")"
+HOOK_ERROR_LOG="${SCRIPT_DIR}/../logs/hook-errors.log"
+
+# Log a diagnostic error message (best-effort, never fails the script)
+log_hook_error() {
+    local msg="$1"
+    # Ensure log directory exists
+    mkdir -p "$(dirname "$HOOK_ERROR_LOG")" 2>/dev/null || true
+    echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] [guard-loom-workflow] $msg" >> "$HOOK_ERROR_LOG" 2>/dev/null || true
+}
+
+# Top-level error trap: on ANY unexpected error, output valid JSON "allow"
+# and log the failure for debugging. This prevents Claude Code from showing
+# "PreToolUse:Bash hook error" which causes infinite retry loops.
+trap 'log_hook_error "Unexpected error on line ${LINENO}: ${BASH_COMMAND:-unknown} (exit=$?)"; exit 0' ERR
+
+# Read stdin safely — if cat or jq fails, the ERR trap fires and we allow
+INPUT=$(cat 2>/dev/null) || INPUT=""
+
+# Verify jq is available before attempting to parse
+if ! command -v jq &>/dev/null; then
+    log_hook_error "jq not found in PATH — allowing command (cannot parse input)"
+    exit 0
+fi
+
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || COMMAND=""
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || CWD=""
+
+# If no command to check, allow
+if [[ -z "$COMMAND" ]]; then
+    exit 0
+fi
+
+# Resolve repo root from cwd (handles worktree paths safely)
+REPO_ROOT=""
+if [[ -n "$CWD" ]] && [[ -d "$CWD" ]]; then
+    REPO_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || true)
+elif [[ -n "$CWD" ]]; then
+    # CWD doesn't exist (e.g., deleted worktree) — log but continue without repo root
+    log_hook_error "cwd does not exist: $CWD — skipping repo root resolution"
+fi
+
+# Helper: output a deny decision and exit
+deny() {
+    local reason="$1"
+    if jq -n --arg reason "$reason" '{
+        hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "deny",
+            permissionDecisionReason: $reason
+        }
+    }' 2>/dev/null; then
+        exit 0
+    fi
+    # jq failed — emit raw JSON as fallback
+    local escaped_reason
+    escaped_reason=$(echo "$reason" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g; s/\n/\\n/g')
+    echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"${escaped_reason}\"}}"
+    exit 0
+}
+
+# Helper: output an ask decision and exit
+ask() {
+    local reason="$1"
+    if jq -n --arg reason "$reason" '{
+        hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "ask",
+            permissionDecisionReason: $reason
+        }
+    }' 2>/dev/null; then
+        exit 0
+    fi
+    # jq failed — emit raw JSON as fallback
+    local escaped_reason
+    escaped_reason=$(echo "$reason" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g; s/\n/\\n/g')
+    echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"${escaped_reason}\"}}"
+    exit 0
+}
+
+# =============================================================================
+# LOOM: Prefer merge-pr.sh over gh pr merge
+# =============================================================================
+
+if echo "$COMMAND" | grep -qE 'gh\s+pr\s+merge'; then
+    # Resolve the merge-pr.sh path for the current repo context. Prefer an
+    # in-repo installed copy (./.loom/scripts/merge-pr.sh); fall back to the
+    # loom-checkout copy under defaults/scripts/ (via $LOOM_HOME) when the repo
+    # runs scripts directly from the checkout rather than an installed copy.
+    MERGE_SCRIPT="./.loom/scripts/merge-pr.sh"
+    if [[ -n "$REPO_ROOT" ]] && [[ ! -x "$REPO_ROOT/.loom/scripts/merge-pr.sh" ]]; then
+        if [[ -n "${LOOM_HOME:-}" ]] && [[ -x "$LOOM_HOME/defaults/scripts/merge-pr.sh" ]]; then
+            MERGE_SCRIPT="$LOOM_HOME/defaults/scripts/merge-pr.sh"
+        elif [[ -x "$REPO_ROOT/defaults/scripts/merge-pr.sh" ]]; then
+            MERGE_SCRIPT="$REPO_ROOT/defaults/scripts/merge-pr.sh"
+        fi
+    fi
+    deny "Use $MERGE_SCRIPT <PR_NUMBER> instead of 'gh pr merge'. The script merges via the GitHub API without local checkout, which avoids worktree errors."
+fi
+
+# =============================================================================
+# LOOM: Block pip install -e inside worktrees (issue #2495)
+#
+# Editable pip installs overwrite a global .pth file in site-packages.
+# When multiple builders run in parallel worktrees, each 'pip install -e .'
+# clobbers the .pth to point at its own worktree, causing all other Python
+# processes to import from the wrong source tree.
+#
+# PYTHONPATH is already set by agent-spawn.sh and _build_worktree_env()
+# so editable installs are unnecessary inside worktrees.
+# =============================================================================
+
+WORKTREE_PATH="${LOOM_WORKTREE_PATH:-}"
+if [[ -n "$WORKTREE_PATH" ]]; then
+    if echo "$COMMAND" | grep -qE '(pip|pip3|uv pip)\s+install\s+.*-e\s' || \
+       echo "$COMMAND" | grep -qE '(pip|pip3|uv pip)\s+install\s+.*--editable\s'; then
+        deny "BLOCKED: 'pip install -e' is not allowed inside worktrees. Editable installs overwrite the global .pth file, breaking parallel builders (see issue #2495). PYTHONPATH is already configured for this worktree — imports resolve correctly without editable installs."
+    fi
+fi
+
+# =============================================================================
+# ALLOW - Everything else passes through
+# =============================================================================
+
+exit 0

--- a/defaults/.claude/settings.json
+++ b/defaults/.claude/settings.json
@@ -7,6 +7,10 @@
           {
             "type": "command",
             "command": "${CLAUDE_PROJECT_DIR}/.loom/hooks/guard-destructive.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.loom/hooks/guard-loom-workflow.sh"
           }
         ]
       }

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -902,7 +902,12 @@ If setup fails, it's usually due to:
 
 ## Custom Guard Hooks
 
-Loom ships with built-in guard hooks (`guard-destructive.sh` for dangerous Bash commands). You can add project-specific guards to protect read-only directories from accidental edits.
+Loom ships with two built-in Bash `PreToolUse` guard hooks, both registered under the `Bash` matcher and firing independently:
+
+- **`guard-destructive.sh`** — the generic repository-hygiene guard: catastrophic denies (`rm -rf /`, force-push to `main`, `gh repo delete`, fork bombs, curl-pipe-to-shell, cloud/SQL destruction), the segment-parsed lifecycle/cloud-CLI checks, and the `guards.sqlDdl` / `guards.cloudCli` toggle machinery. Nothing about this guard is Loom-specific; it is slated to move to Repo Skills (companion issue [rjwalters/repo#13](https://github.com/rjwalters/repo/issues/13)), which will own the generic half once it ships. Until then it keeps shipping and working in Loom exactly as before.
+- **`guard-loom-workflow.sh`** — the thin, Loom-workflow-specific guard (issue #3604): the `gh pr merge` → `merge-pr.sh` redirect and the `pip install -e` worktree block (keyed on `LOOM_WORKTREE_PATH`, issue #2495). These two guards are specific to the Loom worktree/merge workflow and stay Loom-owned.
+
+You can also add project-specific guards to protect read-only directories from accidental edits (see below).
 
 ### SQL DDL/DML Guard Opt-Out (`guards.sqlDdl` / `LOOM_GUARD_SQL`)
 

--- a/defaults/hooks/guard-destructive.sh
+++ b/defaults/hooks/guard-destructive.sh
@@ -651,49 +651,18 @@ CLOUD_ASK_PATTERNS=(
 
 for pattern in "${CLOUD_ASK_PATTERNS[@]}"; do
     if echo "$COMMAND_NO_COMMENT" | grep -qE "$pattern" && cloud_guard_enabled; then
-        ask "Command requires confirmation: $COMMAND"
+        ask "Command requires confirmation: $COMMAND (set guards.cloudCli:false in .loom/config.json if this repo manages cloud infra as a first-class workflow)"
     fi
 done
 
 # =============================================================================
-# LOOM: Prefer merge-pr.sh over gh pr merge
+# NOTE: The two Loom-workflow-specific guards (the 'gh pr merge' → merge-pr.sh
+# redirect, and the 'pip install -e' worktree block keyed on LOOM_WORKTREE_PATH)
+# were extracted into guard-loom-workflow.sh (issue #3604). They are registered
+# as a separate PreToolUse/Bash hook and fire independently of this guard. This
+# file is the generic repository-hygiene guard, on its way to Repo Skills
+# (rjwalters/repo#13); the Loom-specific pair stays Loom-owned.
 # =============================================================================
-
-if echo "$COMMAND" | grep -qE 'gh\s+pr\s+merge'; then
-    # Resolve the merge-pr.sh path for the current repo context. Prefer an
-    # in-repo installed copy (./.loom/scripts/merge-pr.sh); fall back to the
-    # loom-checkout copy under defaults/scripts/ (via $LOOM_HOME) when the repo
-    # runs scripts directly from the checkout rather than an installed copy.
-    MERGE_SCRIPT="./.loom/scripts/merge-pr.sh"
-    if [[ -n "$REPO_ROOT" ]] && [[ ! -x "$REPO_ROOT/.loom/scripts/merge-pr.sh" ]]; then
-        if [[ -n "${LOOM_HOME:-}" ]] && [[ -x "$LOOM_HOME/defaults/scripts/merge-pr.sh" ]]; then
-            MERGE_SCRIPT="$LOOM_HOME/defaults/scripts/merge-pr.sh"
-        elif [[ -x "$REPO_ROOT/defaults/scripts/merge-pr.sh" ]]; then
-            MERGE_SCRIPT="$REPO_ROOT/defaults/scripts/merge-pr.sh"
-        fi
-    fi
-    deny "Use $MERGE_SCRIPT <PR_NUMBER> instead of 'gh pr merge'. The script merges via the GitHub API without local checkout, which avoids worktree errors."
-fi
-
-# =============================================================================
-# LOOM: Block pip install -e inside worktrees (issue #2495)
-#
-# Editable pip installs overwrite a global .pth file in site-packages.
-# When multiple builders run in parallel worktrees, each 'pip install -e .'
-# clobbers the .pth to point at its own worktree, causing all other Python
-# processes to import from the wrong source tree.
-#
-# PYTHONPATH is already set by agent-spawn.sh and _build_worktree_env()
-# so editable installs are unnecessary inside worktrees.
-# =============================================================================
-
-WORKTREE_PATH="${LOOM_WORKTREE_PATH:-}"
-if [[ -n "$WORKTREE_PATH" ]]; then
-    if echo "$COMMAND" | grep -qE '(pip|pip3|uv pip)\s+install\s+.*-e\s' || \
-       echo "$COMMAND" | grep -qE '(pip|pip3|uv pip)\s+install\s+.*--editable\s'; then
-        deny "BLOCKED: 'pip install -e' is not allowed inside worktrees. Editable installs overwrite the global .pth file, breaking parallel builders (see issue #2495). PYTHONPATH is already configured for this worktree — imports resolve correctly without editable installs."
-    fi
-fi
 
 # =============================================================================
 # ALLOW - Everything else passes through

--- a/defaults/hooks/guard-loom-workflow.sh
+++ b/defaults/hooks/guard-loom-workflow.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# guard-loom-workflow.sh - PreToolUse hook for Loom-workflow-specific Bash guards
+#
+# Claude Code PreToolUse hook that intercepts Bash commands before execution.
+# Receives JSON on stdin with tool_input.command and cwd fields.
+#
+# This hook carries ONLY the two Loom-workflow-specific guards that were
+# extracted from guard-destructive.sh (issue #3604):
+#
+#   1. LOOM: Prefer merge-pr.sh over 'gh pr merge'
+#   2. LOOM: Block 'pip install -e' inside worktrees (issue #2495)
+#
+# The generic repository-hygiene guards (catastrophic denies, SQL/cloud toggles,
+# ASK patterns) live in guard-destructive.sh and are being migrated toward Repo
+# Skills (rjwalters/repo#13). This file stays Loom-owned because both guards are
+# specific to the Loom worktree/merge workflow.
+#
+# IMPORTANT: This hook only fires when Claude Code is invoked with:
+#   --dangerously-skip-permissions  ← hooks FIRE (used by Loom agents)
+#
+# It does NOT fire with:
+#   --permission-mode bypassPermissions  ← hooks SKIPPED entirely
+#
+# Output format (Claude Code hooks spec):
+#   { "hookSpecificOutput": { "hookEventName": "PreToolUse", "permissionDecision": "deny|ask", "permissionDecisionReason": "..." } }
+#
+# NOTE: The "hookEventName": "PreToolUse" field is REQUIRED by Claude Code's
+# PreToolUse hook schema. Without it, Claude Code silently discards the
+# decision and the guard becomes inert (see issue #3550).
+#
+# Error handling: This script MUST never exit with a non-zero code or produce
+# invalid output. Any internal error is caught by the trap, logged for
+# diagnostics, and results in an "allow" decision to prevent infinite retry
+# loops in Claude Code.
+
+# Determine log directory relative to this script's location
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null || echo ".")"
+HOOK_ERROR_LOG="${SCRIPT_DIR}/../logs/hook-errors.log"
+
+# Log a diagnostic error message (best-effort, never fails the script)
+log_hook_error() {
+    local msg="$1"
+    # Ensure log directory exists
+    mkdir -p "$(dirname "$HOOK_ERROR_LOG")" 2>/dev/null || true
+    echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] [guard-loom-workflow] $msg" >> "$HOOK_ERROR_LOG" 2>/dev/null || true
+}
+
+# Top-level error trap: on ANY unexpected error, output valid JSON "allow"
+# and log the failure for debugging. This prevents Claude Code from showing
+# "PreToolUse:Bash hook error" which causes infinite retry loops.
+trap 'log_hook_error "Unexpected error on line ${LINENO}: ${BASH_COMMAND:-unknown} (exit=$?)"; exit 0' ERR
+
+# Read stdin safely — if cat or jq fails, the ERR trap fires and we allow
+INPUT=$(cat 2>/dev/null) || INPUT=""
+
+# Verify jq is available before attempting to parse
+if ! command -v jq &>/dev/null; then
+    log_hook_error "jq not found in PATH — allowing command (cannot parse input)"
+    exit 0
+fi
+
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || COMMAND=""
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || CWD=""
+
+# If no command to check, allow
+if [[ -z "$COMMAND" ]]; then
+    exit 0
+fi
+
+# Resolve repo root from cwd (handles worktree paths safely)
+REPO_ROOT=""
+if [[ -n "$CWD" ]] && [[ -d "$CWD" ]]; then
+    REPO_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || true)
+elif [[ -n "$CWD" ]]; then
+    # CWD doesn't exist (e.g., deleted worktree) — log but continue without repo root
+    log_hook_error "cwd does not exist: $CWD — skipping repo root resolution"
+fi
+
+# Helper: output a deny decision and exit
+deny() {
+    local reason="$1"
+    if jq -n --arg reason "$reason" '{
+        hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "deny",
+            permissionDecisionReason: $reason
+        }
+    }' 2>/dev/null; then
+        exit 0
+    fi
+    # jq failed — emit raw JSON as fallback
+    local escaped_reason
+    escaped_reason=$(echo "$reason" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g; s/\n/\\n/g')
+    echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"${escaped_reason}\"}}"
+    exit 0
+}
+
+# Helper: output an ask decision and exit
+ask() {
+    local reason="$1"
+    if jq -n --arg reason "$reason" '{
+        hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "ask",
+            permissionDecisionReason: $reason
+        }
+    }' 2>/dev/null; then
+        exit 0
+    fi
+    # jq failed — emit raw JSON as fallback
+    local escaped_reason
+    escaped_reason=$(echo "$reason" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g; s/\n/\\n/g')
+    echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"${escaped_reason}\"}}"
+    exit 0
+}
+
+# =============================================================================
+# LOOM: Prefer merge-pr.sh over gh pr merge
+# =============================================================================
+
+if echo "$COMMAND" | grep -qE 'gh\s+pr\s+merge'; then
+    # Resolve the merge-pr.sh path for the current repo context. Prefer an
+    # in-repo installed copy (./.loom/scripts/merge-pr.sh); fall back to the
+    # loom-checkout copy under defaults/scripts/ (via $LOOM_HOME) when the repo
+    # runs scripts directly from the checkout rather than an installed copy.
+    MERGE_SCRIPT="./.loom/scripts/merge-pr.sh"
+    if [[ -n "$REPO_ROOT" ]] && [[ ! -x "$REPO_ROOT/.loom/scripts/merge-pr.sh" ]]; then
+        if [[ -n "${LOOM_HOME:-}" ]] && [[ -x "$LOOM_HOME/defaults/scripts/merge-pr.sh" ]]; then
+            MERGE_SCRIPT="$LOOM_HOME/defaults/scripts/merge-pr.sh"
+        elif [[ -x "$REPO_ROOT/defaults/scripts/merge-pr.sh" ]]; then
+            MERGE_SCRIPT="$REPO_ROOT/defaults/scripts/merge-pr.sh"
+        fi
+    fi
+    deny "Use $MERGE_SCRIPT <PR_NUMBER> instead of 'gh pr merge'. The script merges via the GitHub API without local checkout, which avoids worktree errors."
+fi
+
+# =============================================================================
+# LOOM: Block pip install -e inside worktrees (issue #2495)
+#
+# Editable pip installs overwrite a global .pth file in site-packages.
+# When multiple builders run in parallel worktrees, each 'pip install -e .'
+# clobbers the .pth to point at its own worktree, causing all other Python
+# processes to import from the wrong source tree.
+#
+# PYTHONPATH is already set by agent-spawn.sh and _build_worktree_env()
+# so editable installs are unnecessary inside worktrees.
+# =============================================================================
+
+WORKTREE_PATH="${LOOM_WORKTREE_PATH:-}"
+if [[ -n "$WORKTREE_PATH" ]]; then
+    if echo "$COMMAND" | grep -qE '(pip|pip3|uv pip)\s+install\s+.*-e\s' || \
+       echo "$COMMAND" | grep -qE '(pip|pip3|uv pip)\s+install\s+.*--editable\s'; then
+        deny "BLOCKED: 'pip install -e' is not allowed inside worktrees. Editable installs overwrite the global .pth file, breaking parallel builders (see issue #2495). PYTHONPATH is already configured for this worktree — imports resolve correctly without editable installs."
+    fi
+fi
+
+# =============================================================================
+# ALLOW - Everything else passes through
+# =============================================================================
+
+exit 0

--- a/defaults/scripts/tests/test-guard-hook-schema.sh
+++ b/defaults/scripts/tests/test-guard-hook-schema.sh
@@ -21,6 +21,7 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEFAULTS_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 GUARD_DESTRUCTIVE="$DEFAULTS_DIR/hooks/guard-destructive.sh"
+GUARD_LOOM_WORKFLOW="$DEFAULTS_DIR/hooks/guard-loom-workflow.sh"
 GUARD_READONLY_TEMPLATE="$DEFAULTS_DIR/hooks/guard-readonly-dirs.sh.template"
 
 RED='\033[0;31m'
@@ -63,6 +64,10 @@ fi
 
 if [[ ! -f "$GUARD_DESTRUCTIVE" ]]; then
     echo "ERROR: $GUARD_DESTRUCTIVE not found" >&2
+    exit 1
+fi
+if [[ ! -f "$GUARD_LOOM_WORKFLOW" ]]; then
+    echo "ERROR: $GUARD_LOOM_WORKFLOW not found" >&2
     exit 1
 fi
 if [[ ! -f "$GUARD_READONLY_TEMPLATE" ]]; then
@@ -110,6 +115,35 @@ if [[ "$FALLBACK_LINES" -eq 2 ]]; then
 else
     TESTS_FAILED=$((TESTS_FAILED + 1))
     echo -e "  ${RED}FAIL${NC}: expected 2 raw fallback echoes with hookEventName, found $FALLBACK_LINES"
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# guard-loom-workflow.sh — functional deny path (gh pr merge redirect)
+# ---------------------------------------------------------------------------
+echo "guard-loom-workflow.sh: deny decision carries hookEventName"
+LW_DENY_INPUT=$(jq -n --arg cmd "gh pr merge 123" --arg cwd "$DEFAULTS_DIR" \
+    '{tool_input: {command: $cmd}, cwd: $cwd}')
+LW_DENY_OUT=$(printf '%s' "$LW_DENY_INPUT" | bash "$GUARD_LOOM_WORKFLOW" 2>/dev/null)
+
+assert_jq_true "$LW_DENY_OUT" '.hookSpecificOutput.hookEventName == "PreToolUse"' \
+    "loom-workflow deny: hookEventName == PreToolUse"
+assert_jq_true "$LW_DENY_OUT" '.hookSpecificOutput.permissionDecision == "deny"' \
+    "loom-workflow deny: permissionDecision == deny"
+echo ""
+
+# ---------------------------------------------------------------------------
+# guard-loom-workflow.sh — raw jq-fallback echo strings carry the field
+# ---------------------------------------------------------------------------
+echo "guard-loom-workflow.sh: raw jq-fallback echoes carry hookEventName"
+LW_FALLBACK_LINES=$(grep -c 'echo "{\\"hookSpecificOutput\\":{\\"hookEventName\\":\\"PreToolUse\\"' "$GUARD_LOOM_WORKFLOW")
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ "$LW_FALLBACK_LINES" -eq 2 ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: both raw fallback echoes (deny + ask) include hookEventName"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: expected 2 raw fallback echoes with hookEventName, found $LW_FALLBACK_LINES"
 fi
 echo ""
 

--- a/scripts/test-installer.sh
+++ b/scripts/test-installer.sh
@@ -346,7 +346,7 @@ echo "Test 12b: Hook commands use \${CLAUDE_PROJECT_DIR} prefix"
 SETTINGS_FILE="$INSTALL_REPO/.claude/settings.json"
 if [[ -f "$SETTINGS_FILE" ]] && command -v jq &> /dev/null; then
   HOOK_PREFIX_FAIL=0
-  for hook_name in guard-destructive.sh skill-router.sh methodology-inject.sh; do
+  for hook_name in guard-destructive.sh guard-loom-workflow.sh skill-router.sh methodology-inject.sh; do
     # Collect every command in the settings.json that ends with this hook script.
     matches=$(jq -r --arg name "$hook_name" \
       '[.. | objects | select(.command? != null) | .command | select(endswith($name))][]' \
@@ -453,6 +453,18 @@ if [[ -f "$INSTALL_REPO/.loom/hooks/guard-destructive.sh" ]]; then
   fi
 else
   fail "guard-destructive.sh missing"
+fi
+
+# Test 16b: .loom/hooks/guard-loom-workflow.sh (issue #3604)
+echo "Test 16b: Install creates .loom/hooks/guard-loom-workflow.sh"
+if [[ -f "$INSTALL_REPO/.loom/hooks/guard-loom-workflow.sh" ]]; then
+  if [[ -x "$INSTALL_REPO/.loom/hooks/guard-loom-workflow.sh" ]]; then
+    pass "guard-loom-workflow.sh exists and is executable"
+  else
+    fail "guard-loom-workflow.sh exists but is not executable"
+  fi
+else
+  fail "guard-loom-workflow.sh missing"
 fi
 
 # Test 17: .loom/config.json

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -241,6 +241,31 @@ assert_ask() {
     fi
 }
 
+# Assert the guard asks AND the ask reason matches an extended regex.
+assert_ask_reason_matches() {
+    local description="$1"
+    local cmd="$2"
+    local pattern="$3"
+    local cwd="${4:-$REPO_ROOT}"
+    TOTAL=$((TOTAL + 1))
+
+    local output reason
+    output=$(run_guard "$cmd" "$cwd") || true
+    reason=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
+
+    if echo "$output" | jq -e '.hookSpecificOutput.permissionDecision == "ask"' >/dev/null 2>&1 && \
+       echo "$reason" | grep -qE "$pattern"; then
+        PASS=$((PASS + 1))
+        echo -e "  ${GREEN}PASS${NC}: $description"
+    else
+        FAIL=$((FAIL + 1))
+        echo -e "  ${RED}FAIL${NC}: $description"
+        echo -e "       Command: $cmd"
+        echo -e "       Expected: ask with reason matching /$pattern/"
+        echo -e "       Got: $output"
+    fi
+}
+
 # Assert the guard allows a command (no output, exit 0)
 assert_allow() {
     local description="$1"
@@ -552,43 +577,11 @@ assert_allow "Allow sky status (read-only)" \
 echo ""
 
 # =========================================================================
-echo -e "${YELLOW}--- pip install -e WORKTREE GUARD (issue #2495) ---${NC}"
+# NOTE: The pip-install-e worktree guard and the 'gh pr merge' redirect were
+# extracted into guard-loom-workflow.sh (issue #3604). Their assertions now live
+# in tests/hooks/test-guard-loom-workflow.sh. This suite covers only the generic
+# repository-hygiene guard.
 # =========================================================================
-
-# Should DENY editable installs when LOOM_WORKTREE_PATH is set
-assert_deny_in_worktree "Block pip install -e in worktree" \
-    "pip install -e ."
-
-assert_deny_in_worktree "Block pip install -e ./loom-tools in worktree" \
-    "pip install -e ./loom-tools"
-
-assert_deny_in_worktree "Block pip3 install -e in worktree" \
-    "pip3 install -e ."
-
-assert_deny_in_worktree "Block pip install --editable in worktree" \
-    "pip install --editable ."
-
-assert_deny_in_worktree "Block uv pip install -e in worktree" \
-    "uv pip install -e ./loom-tools"
-
-assert_deny_in_worktree "Block pip install -e with absolute path in worktree" \
-    "pip install -e /Users/dev/project/loom-tools"
-
-# Should ALLOW non-editable pip installs in worktree
-assert_allow_in_worktree "Allow pip install (non-editable) in worktree" \
-    "pip install pytest"
-
-assert_allow_in_worktree "Allow pip install -r requirements.txt in worktree" \
-    "pip install -r requirements.txt"
-
-# Should ALLOW editable installs outside worktrees (no LOOM_WORKTREE_PATH)
-assert_allow "Allow pip install -e outside worktree" \
-    "pip install -e ."
-
-assert_allow "Allow pip install -e ./loom-tools outside worktree" \
-    "pip install -e ./loom-tools"
-
-echo ""
 
 # =========================================================================
 echo -e "${YELLOW}--- SQL DDL/DML opt-out (guards.sqlDdl / LOOM_GUARD_SQL) ---${NC}"
@@ -691,6 +684,10 @@ assert_allow "Cloud: aws lambda list-functions is read-only (allow)" \
     "aws lambda list-functions"
 assert_allow "Cloud: aws ec2 get-console-output is read-only (allow)" \
     "aws ec2 get-console-output --instance-id i-1234"
+
+# --- Discoverability: the cloud ASK reason names the guards.cloudCli opt-out (#3604) ---
+assert_ask_reason_matches "Cloud: ask reason names guards.cloudCli opt-out (#3604)" \
+    "aws ec2 terminate-instances --instance-ids i-1234" "guards\.cloudCli"
 
 # --- Verb-narrowing: mutating aws subcommands still ask (default guard on) ---
 assert_ask "Cloud: aws ec2 run-instances asks" \

--- a/tests/hooks/test-guard-loom-workflow.sh
+++ b/tests/hooks/test-guard-loom-workflow.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+# Test suite for defaults/hooks/guard-loom-workflow.sh
+#
+# Usage: ./tests/hooks/test-guard-loom-workflow.sh
+#
+# Tests the extracted Loom-workflow PreToolUse guard (issue #3604): the
+# 'gh pr merge' -> merge-pr.sh redirect and the 'pip install -e' worktree block.
+# Exit code 0 = all tests pass, 1 = failures detected.
+#
+# The guard under test is the canonical source at defaults/hooks/ (the
+# version-controlled source of truth), NOT the gitignored .loom/hooks/ install
+# artifact — so the suite validates exactly what ships.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+GUARD="$REPO_ROOT/defaults/hooks/guard-loom-workflow.sh"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# Build a JSON input blob for the guard script
+make_input() {
+    local cmd="$1"
+    local cwd="${2:-$REPO_ROOT}"
+    jq -n --arg cmd "$cmd" --arg cwd "$cwd" '{
+        tool_name: "Bash",
+        tool_input: { command: $cmd },
+        cwd: $cwd
+    }'
+}
+
+# Run the guard and capture output + exit code
+run_guard() {
+    local cmd="$1"
+    local cwd="${2:-$REPO_ROOT}"
+    local output
+    local exit_code
+    output=$(make_input "$cmd" "$cwd" | "$GUARD" 2>&1) || exit_code=$?
+    exit_code=${exit_code:-0}
+    echo "$output"
+    return $exit_code
+}
+
+# Run the guard with LOOM_WORKTREE_PATH set (simulates worktree context)
+run_guard_in_worktree() {
+    local cmd="$1"
+    local cwd="${2:-$REPO_ROOT}"
+    local output
+    local exit_code
+    output=$(LOOM_WORKTREE_PATH="$cwd" make_input "$cmd" "$cwd" | LOOM_WORKTREE_PATH="$cwd" "$GUARD" 2>&1) || exit_code=$?
+    exit_code=${exit_code:-0}
+    echo "$output"
+    return $exit_code
+}
+
+# Assert the guard denies a command
+assert_deny() {
+    local description="$1"
+    local cmd="$2"
+    local cwd="${3:-$REPO_ROOT}"
+    TOTAL=$((TOTAL + 1))
+    local output
+    output=$(run_guard "$cmd" "$cwd") || true
+    if echo "$output" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' >/dev/null 2>&1; then
+        PASS=$((PASS + 1))
+        echo -e "  ${GREEN}PASS${NC}: $description"
+    else
+        FAIL=$((FAIL + 1))
+        echo -e "  ${RED}FAIL${NC}: $description"
+        echo -e "       Command: $cmd"
+        echo -e "       Expected: deny"
+        echo -e "       Got: $output"
+    fi
+}
+
+# Assert the guard denies a command AND the reason matches an ERE.
+assert_deny_reason_matches() {
+    local description="$1"
+    local cmd="$2"
+    local pattern="$3"
+    local cwd="${4:-$REPO_ROOT}"
+    TOTAL=$((TOTAL + 1))
+    local output reason
+    output=$(run_guard "$cmd" "$cwd") || true
+    reason=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
+    if echo "$output" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' >/dev/null 2>&1 && \
+       echo "$reason" | grep -qE "$pattern"; then
+        PASS=$((PASS + 1))
+        echo -e "  ${GREEN}PASS${NC}: $description"
+    else
+        FAIL=$((FAIL + 1))
+        echo -e "  ${RED}FAIL${NC}: $description"
+        echo -e "       Command: $cmd"
+        echo -e "       Expected: deny with reason matching /$pattern/"
+        echo -e "       Got: $output"
+    fi
+}
+
+# Assert the guard allows a command (exit 0, no decision)
+assert_allow() {
+    local description="$1"
+    local cmd="$2"
+    local cwd="${3:-$REPO_ROOT}"
+    TOTAL=$((TOTAL + 1))
+    local output
+    local exit_code=0
+    output=$(run_guard "$cmd" "$cwd") || exit_code=$?
+    if [[ $exit_code -eq 0 ]] && \
+       ! echo "$output" | jq -e '.hookSpecificOutput.permissionDecision' >/dev/null 2>&1; then
+        PASS=$((PASS + 1))
+        echo -e "  ${GREEN}PASS${NC}: $description"
+    else
+        FAIL=$((FAIL + 1))
+        echo -e "  ${RED}FAIL${NC}: $description"
+        echo -e "       Command: $cmd"
+        echo -e "       Expected: allow (exit 0, no decision)"
+        echo -e "       Exit code: $exit_code"
+        echo -e "       Got: $output"
+    fi
+}
+
+# Assert the guard denies a command when inside a worktree
+assert_deny_in_worktree() {
+    local description="$1"
+    local cmd="$2"
+    local cwd="${3:-$REPO_ROOT}"
+    TOTAL=$((TOTAL + 1))
+    local output
+    output=$(run_guard_in_worktree "$cmd" "$cwd") || true
+    if echo "$output" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' >/dev/null 2>&1; then
+        PASS=$((PASS + 1))
+        echo -e "  ${GREEN}PASS${NC}: $description"
+    else
+        FAIL=$((FAIL + 1))
+        echo -e "  ${RED}FAIL${NC}: $description"
+        echo -e "       Command: $cmd"
+        echo -e "       Expected: deny"
+        echo -e "       Got: $output"
+    fi
+}
+
+# Assert the guard allows a command when inside a worktree
+assert_allow_in_worktree() {
+    local description="$1"
+    local cmd="$2"
+    local cwd="${3:-$REPO_ROOT}"
+    TOTAL=$((TOTAL + 1))
+    local output
+    local exit_code=0
+    output=$(run_guard_in_worktree "$cmd" "$cwd") || exit_code=$?
+    if [[ $exit_code -eq 0 ]] && \
+       ! echo "$output" | jq -e '.hookSpecificOutput.permissionDecision' >/dev/null 2>&1; then
+        PASS=$((PASS + 1))
+        echo -e "  ${GREEN}PASS${NC}: $description"
+    else
+        FAIL=$((FAIL + 1))
+        echo -e "  ${RED}FAIL${NC}: $description"
+        echo -e "       Command: $cmd"
+        echo -e "       Expected: allow (exit 0, no decision)"
+        echo -e "       Exit code: $exit_code"
+        echo -e "       Got: $output"
+    fi
+}
+
+# =========================================================================
+echo ""
+echo -e "${YELLOW}=== Testing guard-loom-workflow.sh ===${NC}"
+echo ""
+
+# =========================================================================
+echo -e "${YELLOW}--- gh pr merge redirect ---${NC}"
+# =========================================================================
+
+assert_deny "Block gh pr merge" \
+    "gh pr merge 123"
+
+assert_deny "Block gh pr merge --squash" \
+    "gh pr merge 123 --squash"
+
+# The deny message must name merge-pr.sh so the agent learns the correct tool.
+assert_deny_reason_matches "gh pr merge deny reason names merge-pr.sh" \
+    "gh pr merge 123" "merge-pr\.sh"
+
+echo ""
+
+# =========================================================================
+echo -e "${YELLOW}--- pip install -e WORKTREE GUARD (issue #2495) ---${NC}"
+# =========================================================================
+
+# Should DENY editable installs when LOOM_WORKTREE_PATH is set
+assert_deny_in_worktree "Block pip install -e in worktree" \
+    "pip install -e ."
+
+assert_deny_in_worktree "Block pip install -e ./loom-tools in worktree" \
+    "pip install -e ./loom-tools"
+
+assert_deny_in_worktree "Block pip3 install -e in worktree" \
+    "pip3 install -e ."
+
+assert_deny_in_worktree "Block pip install --editable in worktree" \
+    "pip install --editable ."
+
+assert_deny_in_worktree "Block uv pip install -e in worktree" \
+    "uv pip install -e ./loom-tools"
+
+assert_deny_in_worktree "Block pip install -e with absolute path in worktree" \
+    "pip install -e /Users/dev/project/loom-tools"
+
+# The deny message must reference issue #2495.
+TOTAL=$((TOTAL + 1))
+_wt_out=$(run_guard_in_worktree "pip install -e ." "$REPO_ROOT") || true
+if echo "$_wt_out" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null | grep -q "2495"; then
+    PASS=$((PASS + 1))
+    echo -e "  ${GREEN}PASS${NC}: pip install -e deny reason references issue #2495"
+else
+    FAIL=$((FAIL + 1))
+    echo -e "  ${RED}FAIL${NC}: pip install -e deny reason references issue #2495"
+    echo -e "       Got: $_wt_out"
+fi
+
+# Should ALLOW non-editable pip installs in worktree
+assert_allow_in_worktree "Allow pip install (non-editable) in worktree" \
+    "pip install pytest"
+
+assert_allow_in_worktree "Allow pip install -r requirements.txt in worktree" \
+    "pip install -r requirements.txt"
+
+# Should ALLOW editable installs OUTSIDE worktrees (no LOOM_WORKTREE_PATH)
+assert_allow "Allow pip install -e outside worktree" \
+    "pip install -e ."
+
+assert_allow "Allow pip3 install -e ./loom-tools outside worktree" \
+    "pip3 install -e ./loom-tools"
+
+assert_allow "Allow uv pip install -e outside worktree" \
+    "uv pip install -e ."
+
+assert_allow "Allow pip install --editable outside worktree" \
+    "pip install --editable ."
+
+echo ""
+
+# =========================================================================
+echo -e "${YELLOW}--- Unrelated commands pass through (allow) ---${NC}"
+# =========================================================================
+
+assert_allow "Allow git status" \
+    "git status"
+
+assert_allow "Allow gh pr create" \
+    "gh pr create --title 'My PR' --body 'Description'"
+
+assert_allow "Allow gh pr list" \
+    "gh pr list"
+
+# Catastrophic/generic patterns are NOT this hook's job (guard-destructive.sh
+# owns them); this hook must allow them through.
+assert_allow "Allow rm -rf / (not this hook's responsibility)" \
+    "rm -rf /"
+
+echo ""
+
+# =========================================================================
+echo -e "${YELLOW}--- Hook schema contract ---${NC}"
+# =========================================================================
+
+# Deny decisions must carry hookEventName: PreToolUse (#3550).
+TOTAL=$((TOTAL + 1))
+_schema_out=$(run_guard "gh pr merge 123" "$REPO_ROOT") || true
+if echo "$_schema_out" | jq -e '.hookSpecificOutput.hookEventName == "PreToolUse"' >/dev/null 2>&1; then
+    PASS=$((PASS + 1))
+    echo -e "  ${GREEN}PASS${NC}: deny decision carries hookEventName == PreToolUse"
+else
+    FAIL=$((FAIL + 1))
+    echo -e "  ${RED}FAIL${NC}: deny decision carries hookEventName == PreToolUse"
+    echo -e "       Got: $_schema_out"
+fi
+
+# Never exits non-zero, even on empty command input.
+TOTAL=$((TOTAL + 1))
+_empty_exit=0
+echo '{"tool_input":{"command":""},"cwd":"'"$REPO_ROOT"'"}' | "$GUARD" >/dev/null 2>&1 || _empty_exit=$?
+if [[ $_empty_exit -eq 0 ]]; then
+    PASS=$((PASS + 1))
+    echo -e "  ${GREEN}PASS${NC}: empty command exits 0 (allow)"
+else
+    FAIL=$((FAIL + 1))
+    echo -e "  ${RED}FAIL${NC}: empty command exits 0 (allow), got exit $_empty_exit"
+fi
+
+echo ""
+
+# =========================================================================
+# Summary
+# =========================================================================
+
+echo "========================================="
+echo -e "  Total:  $TOTAL"
+echo -e "  ${GREEN}Passed${NC}: $PASS"
+echo -e "  ${RED}Failed${NC}: $FAIL"
+echo "========================================="
+
+if [[ $FAIL -gt 0 ]]; then
+    echo -e "\n${RED}TESTS FAILED${NC}"
+    exit 1
+else
+    echo -e "\n${GREEN}ALL TESTS PASSED${NC}"
+    exit 0
+fi


### PR DESCRIPTION
## Summary

Extracts the two Loom-workflow-specific guards out of the generic `guard-destructive.sh` hook into a new standalone `guard-loom-workflow.sh` (issue #3604, Loom-side only). This is a decomposition, not a deletion — the generic guard keeps shipping and working exactly as before until Repo Skills' copy lands (companion issue rjwalters/repo#13).

The two extracted blocks:
1. the `gh pr merge` -> `merge-pr.sh` redirect (same fallback path-resolution chain)
2. the editable-pip worktree block keyed on `LOOM_WORKTREE_PATH` (issue #2495)

## Changes

- **New `defaults/hooks/guard-loom-workflow.sh`** — standalone PreToolUse hook carrying both moved blocks plus the full hook boilerplate (ERR trap, `log_hook_error`, jq guard, `REPO_ROOT` resolution, `deny`/`ask` helpers with the `hookEventName` raw-JSON fallback).
- **`defaults/hooks/guard-destructive.sh`** — removed the two Loom blocks; everything else unchanged. Also names the `guards.cloudCli` opt-out inline in the `CLOUD_ASK_PATTERNS` ask reason (discoverability).
- **Both settings templates** (`defaults/.claude/settings.json`, `.claude/settings.json`) register the new hook under the same `Bash` PreToolUse matcher pattern each already uses, so both hooks fire independently.
- **Self-install parity** — added `.loom/hooks/guard-loom-workflow.sh`; removed the two blocks from `.loom/hooks/guard-destructive.sh` (narrow, mechanical; unrelated pre-existing drift left alone per the issue).
- **Tests** — new `tests/hooks/test-guard-loom-workflow.sh`; `guard-loom-workflow` schema coverage in `test-guard-hook-schema.sh`; a `guards.cloudCli`-reason assertion plus removal of the relocated pip/merge assertions in `test-guard-destructive.sh`; installed-hook check (Test 16b) + `${CLAUDE_PROJECT_DIR}` prefix coverage in `scripts/test-installer.sh`.
- **`defaults/CLAUDE.md`** — Custom Guard Hooks intro documents the two-hook split and links rjwalters/repo#13.

## Scope

Loom-side only. The Repo Skills companion (rjwalters/repo#13) and the explicitly-deferred follow-ups (installer coexistence detection, full generic-guard removal, `.loom/hooks` drift resync) are out of scope and NOT implemented.

## Test results

- `bash tests/hooks/test-guard-loom-workflow.sh` — PASS (22/22)
- `bash defaults/scripts/tests/test-guard-hook-schema.sh` — PASS (11/11)
- `bash tests/hooks/test-guard-destructive.sh` — 218/219; the one failure is the perf-threshold check (avg ~217ms vs 200ms), a pre-existing host-load flake. Pristine `main`'s guard measures 207ms on the same host while this PR's trimmed guard measures 164ms — the split makes the guard faster, not slower.
- `bash scripts/test-installer.sh` — new Test 12b/16b hook checks PASS. The 2 failures (`worktree.root override dropped by init`, `unknown consumer key dropped by init`) are pre-existing `#3598` config-merge regressions confirmed to fail identically on the pristine `main` workspace; unrelated to guard hooks.
- `bash defaults/scripts/tests/test-worktree-sentinel.sh` — PASS (10/10)
- Manual functional checks (both hooks fire for their triggers; cloud ask names `guards.cloudCli`; catastrophic deny unchanged) — all as expected.

Closes #3604

🤖 Generated with [Claude Code](https://claude.com/claude-code)
