### PR TITLE
fix(docs): absolute URL for migration link in vendored .claude/README.md

### DIFF
--- a/defaults/.claude/README.md
+++ b/defaults/.claude/README.md
@@ -169,7 +169,7 @@ The `agents/` directory contains custom subagent definitions for Loom roles. The
 | `loom-guide` | sonnet | Prioritize and triage issues |
 | `loom-auditor` | sonnet | Verify runtime behavior of built software |
 
-> **Note**: the `loom-shepherd` subagent was removed in v0.10.0 along with the `/shepherd` slash command — see [the migration guide](../../docs/migration/v0.10.0-shepherd-deprecation.md). Use `/loom:sweep <issue>` (Tier 1) for the equivalent lifecycle. The `loom-daemon` subagent is preserved and now documents the shell-level daemon surface (`./.loom/scripts/daemon.sh` + tmux + token rotation) rather than the deleted Python brain.
+> **Note**: the `loom-shepherd` subagent was removed in v0.10.0 along with the `/shepherd` slash command — see [the migration guide](https://github.com/rjwalters/loom/blob/main/docs/migration/v0.10.0-shepherd-deprecation.md). Use `/loom:sweep <issue>` (Tier 1) for the equivalent lifecycle. The `loom-daemon` subagent is preserved and now documents the shell-level daemon surface (`./.loom/scripts/daemon.sh` + tmux + token rotation) rather than the deleted Python brain.
 
 ### How Subagents Work
 


### PR DESCRIPTION
## Summary

`defaults/.claude/README.md` is installed verbatim as `.claude/README.md` in every consumer repo (per the `manifest.sh` literal `.claude/* → .claude/*` mapping). Its line-172 link to the migration guide was **root-relative**:

```
../../docs/migration/v0.10.0-shepherd-deprecation.md
```

That path resolves only in the Loom source tree (where the file lives under `defaults/.claude/`). In a consumer repo the installed file lives at `.claude/README.md`, so `../../` escapes the repo root — and `docs/migration/` is never vendored anyway. The link was dead in every consumer, on GitHub and locally.

## Fix

Replace the root-relative link with the absolute GitHub URL, matching the established convention in `defaults/CLAUDE.md`, `defaults/.loom/CLAUDE.md`, and `defaults/.loom-README.md`:

```
https://github.com/rjwalters/loom/blob/main/docs/migration/v0.10.0-shepherd-deprecation.md
```

Single-line edit; no surrounding note text changed.

## Verification

- `grep -rn "](\.\./\.\./docs/migration" defaults/` returns no matches.
- The separate `defaults/.github/CONFIGURATION.md` `../../WORKFLOWS.md` link is explicitly left untouched (tracked separately).

Closes #3605

🤖 Generated with [Claude Code](https://claude.com/claude-code)