### PR TITLE
fix(docs): correct broken WORKFLOWS.md link in CONFIGURATION.md copies

### DIFF
--- a/.github/CONFIGURATION.md
+++ b/.github/CONFIGURATION.md
@@ -68,7 +68,7 @@ The issue template integrates with Loom's label-based workflow coordination:
 | `loom:reviewing` | Judge is actively reviewing | Judge agent |
 | `loom:pr` | Approved for merge | Judge agent |
 
-See [WORKFLOWS.md](../../WORKFLOWS.md) for complete workflow documentation.
+See [WORKFLOWS.md](../docs/workflows.md) for complete workflow documentation.
 
 ## Benefits
 

--- a/defaults/.github/CONFIGURATION.md
+++ b/defaults/.github/CONFIGURATION.md
@@ -68,7 +68,7 @@ The issue template integrates with Loom's label-based workflow coordination:
 | `loom:reviewing` | Judge is actively reviewing | Judge agent |
 | `loom:pr` | Approved for merge | Judge agent |
 
-See [WORKFLOWS.md](../../WORKFLOWS.md) for complete workflow documentation.
+See [WORKFLOWS.md](https://github.com/rjwalters/loom/blob/main/docs/workflows.md) for complete workflow documentation.
 
 ## Benefits
 


### PR DESCRIPTION
Closes #3606

## Problem

Both `CONFIGURATION.md` copies had a `../../WORKFLOWS.md` link (line 71) broken two ways:

1. **Path escaped the repo root.** From `.github/CONFIGURATION.md` (depth 1), `../../` climbs above the repository.
2. **Stale target.** No `WORKFLOWS.md` at root; the doc lives at `docs/workflows.md` (lowercase — case-sensitive on Linux CI / consumer clones).

## Fix

- `.github/CONFIGURATION.md` → repo-relative `../docs/workflows.md` (single `..`, resolves to the tracked `docs/workflows.md`).
- `defaults/.github/CONFIGURATION.md` → absolute `https://github.com/rjwalters/loom/blob/main/docs/workflows.md`, since consumers vendoring the template do not receive the `docs/` tree.

## Verification

- `grep -rn "\.\./\.\./WORKFLOWS.md" .github defaults/.github` returns nothing.
- The Loom-relative link resolves to the existing `docs/workflows.md`.
- Docs-only change; no code/tests/behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)