### PR TITLE
fix(hooks): skip machine-generated turns; anchor methodology topic fallback (#3608)

### DIFF
--- a/.loom/hooks/methodology-inject.sh
+++ b/.loom/hooks/methodology-inject.sh
@@ -62,6 +62,18 @@ if [[ "$PROMPT" == /self* ]]; then
     exit 0
 fi
 
+# Skip harness-generated task-notification turns. These are not human input —
+# the harness re-runs UserPromptSubmit hooks on every background-task completion,
+# and the relevant context was already injected on the originating human turn.
+# Match against the raw prompt with literal prefix/substring (no regex) so this
+# guard cannot itself false-positive on human text.
+case "$PROMPT" in
+    "[SYSTEM NOTIFICATION"*) exit 0 ;;
+esac
+if [[ "$PROMPT" == *"<task-notification>"* ]]; then
+    exit 0
+fi
+
 # =============================================================================
 # OPT-IN CHECK
 # =============================================================================
@@ -157,8 +169,7 @@ if [[ "$INJECT_ROLE" == "true" ]]; then
             /champion*) ROLE="champion" ;;
             /guide*)   ROLE="guide" ;;
             /auditor*) ROLE="auditor" ;;
-            /shepherd*) ROLE="shepherd" ;;
-            /loom*)    ROLE="loom" ;;
+            /loom:sweep*) ROLE="sweep" ;;
         esac
     fi
 
@@ -196,9 +207,16 @@ if [[ "$INJECT_TOPICS" == "true" ]] && [[ -d "${CONTEXT_DIR}/topics" ]]; then
             PATTERN=$(cat "$PATTERN_FILE" 2>/dev/null) || PATTERN=""
         fi
 
-        # Fall back to using filename as the regex pattern
+        # Fall back to an anchored match on the filename. A bare substring
+        # match (the historical behavior) false-positives on flag-like and
+        # path-segment contexts — e.g. a "release" topic would inject on
+        # "cargo build --release" or "target/release". Require either the
+        # slash-command form (/loom:<topic> or /repo:<topic>) or a
+        # word-boundary token that is NOT preceded by "-" or "/" and NOT
+        # followed by "/". The sidecar .pattern file remains the escape hatch
+        # for topics that need a custom regex.
         if [[ -z "$PATTERN" ]]; then
-            PATTERN="$TOPIC_NAME"
+            PATTERN="/(loom|repo):${TOPIC_NAME}\b|(^|[^-/[:alnum:]])${TOPIC_NAME}([^/[:alnum:]]|$)"
         fi
 
         # Match pattern case-insensitively against prompt

--- a/.loom/hooks/skill-router.sh
+++ b/.loom/hooks/skill-router.sh
@@ -58,6 +58,18 @@ if [[ "$PROMPT" == /self* ]]; then
     exit 0
 fi
 
+# Skip harness-generated task-notification turns. These are not human input —
+# the harness re-runs UserPromptSubmit hooks on every background-task completion,
+# and re-injecting the agent table / re-routing on them is pure noise.
+# Match against the raw prompt with literal prefix/substring (no regex) so this
+# guard cannot itself false-positive on human text.
+case "$PROMPT" in
+    "[SYSTEM NOTIFICATION"*) exit 0 ;;
+esac
+if [[ "$PROMPT" == *"<task-notification>"* ]]; then
+    exit 0
+fi
+
 # =============================================================================
 # ROUTING CONFIG
 # =============================================================================

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -1064,7 +1064,7 @@ Loom provides an opt-in methodology injection hook that automatically injects pr
 
 **Role context** (`roles/<role>.md`): Injected when the `LOOM_ROLE` environment variable matches the filename, or when a slash command (e.g., `/builder`) is detected in the prompt. Role names are case-insensitive.
 
-**Topic context** (`topics/<name>.md`): Injected when the prompt matches a keyword pattern. By default, the filename is used as the regex pattern (e.g., `security.md` matches prompts containing "security"). For custom patterns, create a sidecar `.pattern` file with a regex (e.g., `security.pattern` containing `security|auth|token|credential`).
+**Topic context** (`topics/<name>.md`): Injected when the prompt matches the topic keyword. By default the filename is matched as an **anchored** token — the topic name must appear either as a slash command (`/loom:<name>` or `/repo:<name>`) or as a standalone word that is not part of a flag or path segment. So `security.md` injects on "check the security model" or `/loom:security`, but a "release" topic does **not** inject on `cargo build --release` or `target/release`. For custom matching, create a sidecar `.pattern` file with a regex (e.g., `security.pattern` containing `security|auth|token|credential`); the sidecar overrides the filename fallback entirely.
 
 ### Configuration
 

--- a/defaults/hooks/methodology-inject.sh
+++ b/defaults/hooks/methodology-inject.sh
@@ -62,6 +62,18 @@ if [[ "$PROMPT" == /self* ]]; then
     exit 0
 fi
 
+# Skip harness-generated task-notification turns. These are not human input —
+# the harness re-runs UserPromptSubmit hooks on every background-task completion,
+# and the relevant context was already injected on the originating human turn.
+# Match against the raw prompt with literal prefix/substring (no regex) so this
+# guard cannot itself false-positive on human text.
+case "$PROMPT" in
+    "[SYSTEM NOTIFICATION"*) exit 0 ;;
+esac
+if [[ "$PROMPT" == *"<task-notification>"* ]]; then
+    exit 0
+fi
+
 # =============================================================================
 # OPT-IN CHECK
 # =============================================================================
@@ -195,9 +207,16 @@ if [[ "$INJECT_TOPICS" == "true" ]] && [[ -d "${CONTEXT_DIR}/topics" ]]; then
             PATTERN=$(cat "$PATTERN_FILE" 2>/dev/null) || PATTERN=""
         fi
 
-        # Fall back to using filename as the regex pattern
+        # Fall back to an anchored match on the filename. A bare substring
+        # match (the historical behavior) false-positives on flag-like and
+        # path-segment contexts — e.g. a "release" topic would inject on
+        # "cargo build --release" or "target/release". Require either the
+        # slash-command form (/loom:<topic> or /repo:<topic>) or a
+        # word-boundary token that is NOT preceded by "-" or "/" and NOT
+        # followed by "/". The sidecar .pattern file remains the escape hatch
+        # for topics that need a custom regex.
         if [[ -z "$PATTERN" ]]; then
-            PATTERN="$TOPIC_NAME"
+            PATTERN="/(loom|repo):${TOPIC_NAME}\b|(^|[^-/[:alnum:]])${TOPIC_NAME}([^/[:alnum:]]|$)"
         fi
 
         # Match pattern case-insensitively against prompt

--- a/defaults/hooks/skill-router.sh
+++ b/defaults/hooks/skill-router.sh
@@ -58,6 +58,18 @@ if [[ "$PROMPT" == /self* ]]; then
     exit 0
 fi
 
+# Skip harness-generated task-notification turns. These are not human input —
+# the harness re-runs UserPromptSubmit hooks on every background-task completion,
+# and re-injecting the agent table / re-routing on them is pure noise.
+# Match against the raw prompt with literal prefix/substring (no regex) so this
+# guard cannot itself false-positive on human text.
+case "$PROMPT" in
+    "[SYSTEM NOTIFICATION"*) exit 0 ;;
+esac
+if [[ "$PROMPT" == *"<task-notification>"* ]]; then
+    exit 0
+fi
+
 # =============================================================================
 # ROUTING CONFIG
 # =============================================================================


### PR DESCRIPTION
Closes #3608

## Summary

UserPromptSubmit hooks (`skill-router.sh`, `methodology-inject.sh`) fired too aggressively on harness-generated prompts and on loose topic-name substrings. This PR addresses the two root causes scoped to #3608.

## Changes

1. **Shared machine-generated-prompt skip guard (both hooks)** — immediately after the existing `/self*` skip, both hooks now exit 0 on harness task-notification turns: prompts starting with `[SYSTEM NOTIFICATION` or containing `<task-notification>`. Matched against the raw `$PROMPT` with literal prefix/substring (no regex), consistent with the existing `/self*` guard, so the guard cannot itself false-positive on human text.

2. **Anchored topic-filename fallback (`methodology-inject.sh`)** — the bare-substring filename fallback caused `cargo build --release` / `target/release` to inject a `release` topic. The fallback pattern is now anchored: it requires the slash-command form (`/loom:<topic>` or `/repo:<topic>`) or a word-boundary token not preceded by `-`/`/` and not followed by `/`. The sidecar `.pattern` escape hatch is unchanged.

3. **`.loom/hooks/` sync** — the dogfooded copies are re-synced from `defaults/`, which also reconciles the pre-existing `/shepherd`//`/loom` role-case drift in the `.loom` methodology-inject copy toward the defaults (`/loom:sweep`) version.

4. **Docs** — `defaults/CLAUDE.md` "Methodology Injection Framework" now describes the anchored fallback behavior.

## Scope coordination with #3609 (READ)

**The only region of `skill-router.sh` touched here is the top-of-file input guard** (right after the `/self*` skip, before the `ROUTING CONFIG` section). The route-table build, pattern-matching loop, dedup, and output sections are **untouched** — those belong to #3609. No changes to `skill-routes.json`. The two PRs edit disjoint regions of `skill-router.sh`.

## Testing (isolated git-repo harness)

- Prompt starting `[SYSTEM NOTIFICATION` → both hooks emit nothing, exit 0.
- Prompt containing `<task-notification>` → both hooks emit nothing, exit 0.
- `cargo build --release` / `see target/release/foo` (topic `release`, no sidecar) → release topic NOT injected.
- `/loom:release`, `/repo:release`, `lets cut a release` → release topic injected.
- Sidecar `release.pattern` still overrides the filename fallback exactly as before.
- Human prompts still inject `universal.md` and the skill-router agent table / AGENT_ROUTE.
- All four hook files pass `bash -n`; every invocation (empty prompt, notification, normal) exits 0.