### PR TITLE
fix(hooks): gate skill-router table on match + dedup per session (#3609)

### DIFF
--- a/.loom/config/skill-routes.json
+++ b/.loom/config/skill-routes.json
@@ -1,55 +1,50 @@
 {
   "version": 1,
-  "description": "Default skill routing table for Loom agent suggestions. Routes are evaluated top-to-bottom, first match wins. Place specific patterns before general ones.",
+  "description": "Default skill routing table for Loom agent suggestions. Routes are evaluated top-to-bottom, first match wins. Place specific patterns before general ones. Patterns are phrase/word-boundary anchored (issue #3609) so common software vocabulary ('builders', a bare 'issue', a repo path like 'rjwalters/loom') no longer mis-routes — only genuine imperatives do. Agent invocations use the namespaced `/loom:<role>` form required by Claude Code 2.1+ (subdirectory commands at `.claude/commands/loom/<role>.md` resolve via `namespace:command` syntax — see issue #3345).",
   "routes": [
     {
-      "pattern": "shepherd|orchestrate|lifecycle|end.to.end",
-      "agent": "/shepherd",
-      "description": "Full issue lifecycle orchestration"
-    },
-    {
-      "pattern": "architect|design|proposal|system design|rfc",
-      "agent": "/architect",
+      "pattern": "\\barchitect|system design|design (a |an |the )?proposal|\\brfc\\b",
+      "agent": "/loom:architect",
       "description": "System design and architecture"
     },
     {
-      "pattern": "review|\\bPR\\b|pull request|code review",
-      "agent": "/judge",
+      "pattern": "code review|\\bpull request\\b|review (this|the|my|our|that) ",
+      "agent": "/loom:judge",
       "description": "Code review"
     },
     {
-      "pattern": "fix|bug|broken|changes.requested|merge.conflict",
-      "agent": "/doctor",
+      "pattern": "\\bfix\\b|\\bbug\\b|\\bbroken\\b|changes.requested|merge.conflict|address (the )?feedback",
+      "agent": "/loom:doctor",
       "description": "Bug fixes and PR feedback"
     },
     {
-      "pattern": "simplify|refactor|clean.?up|dead.?code|complexity",
-      "agent": "/hermit",
+      "pattern": "\\bsimplify\\b|\\bsimplification\\b|\\brefactor|clean.?up|dead.?code|\\bcomplexity\\b",
+      "agent": "/loom:hermit",
       "description": "Simplification opportunities"
     },
     {
-      "pattern": "build|implement|feature|develop|code",
-      "agent": "/builder",
+      "pattern": "\\bbuild\\b|\\bimplement|\\bfeature\\b|\\bdevelop",
+      "agent": "/loom:builder",
       "description": "Implement features and fixes"
     },
     {
-      "pattern": "curate|triage|issue|enhance|enrich",
-      "agent": "/curator",
+      "pattern": "\\bcurate\\b|\\benrich|\\btriage\\b|file (an |a )?(issue|bug)",
+      "agent": "/loom:curator",
       "description": "Issue enrichment"
     },
     {
-      "pattern": "prioriti[zs]e|backlog|roadmap",
-      "agent": "/guide",
+      "pattern": "prioriti[zs]e|\\bbacklog\\b|\\broadmap\\b",
+      "agent": "/loom:guide",
       "description": "Backlog triage"
     },
     {
-      "pattern": "audit|validate|check.?build",
-      "agent": "/auditor",
+      "pattern": "\\baudit\\b|\\bvalidate\\b|check.?build|verify (the )?build",
+      "agent": "/loom:auditor",
       "description": "Build validation"
     },
     {
-      "pattern": "loom|daemon|auto.?build",
-      "agent": "/loom",
+      "pattern": "loom daemon|\\bdaemon\\b|auto.?build|orchestrat",
+      "agent": "/loom:loom",
       "description": "System daemon orchestration"
     }
   ]

--- a/.loom/hooks/skill-router.sh
+++ b/.loom/hooks/skill-router.sh
@@ -5,9 +5,12 @@
 # Receives JSON on stdin with { "prompt": "...", "session_id": "...", "cwd": "..." }
 #
 # Behavior:
-#   1. Always injects a compact agent routing table as additionalContext
-#   2. Optionally emits an AGENT_ROUTE directive when prompt strongly matches
-#      a domain pattern (first match wins)
+#   1. Emits nothing unless the prompt strongly matches a domain route pattern
+#      (first match wins). Non-matching turns produce NO additionalContext —
+#      the agent table is no longer injected on every prompt (issue #3609).
+#   2. On a match, emits an AGENT_ROUTE directive. A compact agent routing
+#      table is appended at most ONCE per session, deduped via the session_id
+#      present on stdin (a missing session_id degrades to per-match inclusion).
 #
 # Output format (Claude Code hooks spec):
 #   { "hookSpecificOutput": { "hookEventName": "UserPromptSubmit", "additionalContext": "..." } }
@@ -48,6 +51,10 @@ fi
 # Extract prompt
 PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty' 2>/dev/null) || PROMPT=""
 
+# Extract session_id (used for once-per-session table dedup; optional — a
+# missing/empty value degrades gracefully, see the PER-SESSION TABLE DEDUP block)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null) || SESSION_ID=""
+
 # If no prompt, nothing to do
 if [[ -z "$PROMPT" ]]; then
     exit 0
@@ -67,6 +74,26 @@ case "$PROMPT" in
     "[SYSTEM NOTIFICATION"*) exit 0 ;;
 esac
 if [[ "$PROMPT" == *"<task-notification>"* ]]; then
+    exit 0
+fi
+
+# =============================================================================
+# MINIMUM-SIGNAL GATE (#3609)
+# =============================================================================
+# Skip turns that are structurally unlikely to be a routing request:
+#   - prompts that begin with '/' (slash-command turns, e.g. /builder,
+#     /loom:sweep — the user has already chosen a command)
+#   - very short prompts (< 3 words), which carry too little signal to route
+# These skips keep near-zero-signal chatter from producing routing noise.
+if [[ "$PROMPT" == /* ]]; then
+    exit 0
+fi
+
+WORD_COUNT=$(printf '%s' "$PROMPT" | wc -w | tr -d '[:space:]')
+if [[ -z "$WORD_COUNT" ]]; then
+    WORD_COUNT=0
+fi
+if [[ "$WORD_COUNT" -lt 3 ]]; then
     exit 0
 fi
 
@@ -106,18 +133,6 @@ if [[ -z "$ROUTES_JSON" ]] || [[ "$ROUTES_JSON" == "null" ]]; then
 fi
 
 # =============================================================================
-# BUILD AGENT TABLE
-# =============================================================================
-
-# Build compact agent routing table from config
-AGENT_TABLE=$(echo "$ROUTES_JSON" | jq -r '.[] | "\(.agent) — \(.description)"' 2>/dev/null) || AGENT_TABLE=""
-
-if [[ -z "$AGENT_TABLE" ]]; then
-    log_hook_error "Failed to build agent table"
-    exit 0
-fi
-
-# =============================================================================
 # PATTERN MATCHING
 # =============================================================================
 
@@ -145,20 +160,57 @@ for (( i=0; i<ROUTE_COUNT; i++ )); do
     fi
 done
 
-# =============================================================================
-# OUTPUT
-# =============================================================================
-
-# Build the additionalContext string
-CONTEXT="Available Loom agents:
-${AGENT_TABLE}"
-
-if [[ -n "$MATCHED_AGENT" ]]; then
-    CONTEXT="${CONTEXT}
-
-AGENT_ROUTE: ${MATCHED_AGENT} — ${MATCHED_DESC}
-(This is a suggestion based on prompt keywords. Use the Skill tool to invoke if appropriate.)"
+# No route matched: emit nothing at all (issue #3609). The agent table used to
+# ride along on EVERY prompt; now it only accompanies a genuine route match, so
+# non-matching turns are a silent exit — no additionalContext, no token cost.
+if [[ -z "$MATCHED_AGENT" ]]; then
+    exit 0
 fi
+
+# =============================================================================
+# PER-SESSION TABLE DEDUP (#3609)
+# =============================================================================
+# The agent table is verbatim repetition of the roles list already shipped in
+# CLAUDE.md, so a session needs it at most once. We key an "already sent" marker
+# on the session_id already present on stdin. A missing/empty session_id
+# degrades gracefully: we cannot dedup, so the table is included on each match
+# (the pre-#3609 per-turn behavior, but now only on matching turns).
+
+INCLUDE_TABLE=1
+if [[ -n "$SESSION_ID" ]]; then
+    # Sanitize to filename-safe characters so the marker is a single predictable
+    # file (never a path traversal, never a nested directory).
+    SESSION_KEY=$(printf '%s' "$SESSION_ID" | tr -c 'A-Za-z0-9._-' '_')
+    SEEN_DIR="${MAIN_ROOT}/.loom/logs/skill-router-seen"
+    SEEN_MARKER="${SEEN_DIR}/${SESSION_KEY}"
+    if [[ -f "$SEEN_MARKER" ]]; then
+        INCLUDE_TABLE=0
+    else
+        # Best-effort marker creation; a failure here never fails the hook and
+        # simply means the table may be re-sent on a later matching turn.
+        mkdir -p "$SEEN_DIR" 2>/dev/null || true
+        : > "$SEEN_MARKER" 2>/dev/null || true
+    fi
+fi
+
+# =============================================================================
+# BUILD OUTPUT
+# =============================================================================
+
+CONTEXT=""
+if [[ "$INCLUDE_TABLE" -eq 1 ]]; then
+    # Build the compact agent routing table only when we will actually emit it.
+    AGENT_TABLE=$(echo "$ROUTES_JSON" | jq -r '.[] | "\(.agent) — \(.description)"' 2>/dev/null) || AGENT_TABLE=""
+    if [[ -n "$AGENT_TABLE" ]]; then
+        CONTEXT="Available Loom agents:
+${AGENT_TABLE}
+
+"
+    fi
+fi
+
+CONTEXT="${CONTEXT}AGENT_ROUTE: ${MATCHED_AGENT} — ${MATCHED_DESC}
+(This is a suggestion based on prompt keywords. Use the Skill tool to invoke if appropriate.)"
 
 # Output valid JSON
 jq -n --arg context "$CONTEXT" '{

--- a/defaults/config/skill-routes.json
+++ b/defaults/config/skill-routes.json
@@ -1,54 +1,49 @@
 {
   "version": 1,
-  "description": "Default skill routing table for Loom agent suggestions. Routes are evaluated top-to-bottom, first match wins. Place specific patterns before general ones. Agent invocations use the namespaced `/loom:<role>` form required by Claude Code 2.1+ (subdirectory commands at `.claude/commands/loom/<role>.md` resolve via `namespace:command` syntax — see issue #3345).",
+  "description": "Default skill routing table for Loom agent suggestions. Routes are evaluated top-to-bottom, first match wins. Place specific patterns before general ones. Patterns are phrase/word-boundary anchored (issue #3609) so common software vocabulary ('builders', a bare 'issue', a repo path like 'rjwalters/loom') no longer mis-routes — only genuine imperatives do. Agent invocations use the namespaced `/loom:<role>` form required by Claude Code 2.1+ (subdirectory commands at `.claude/commands/loom/<role>.md` resolve via `namespace:command` syntax — see issue #3345).",
   "routes": [
     {
-      "pattern": "shepherd|orchestrate|lifecycle|end.to.end",
-      "agent": "/loom:shepherd",
-      "description": "Full issue lifecycle orchestration"
-    },
-    {
-      "pattern": "architect|design|proposal|system design|rfc",
+      "pattern": "\\barchitect|system design|design (a |an |the )?proposal|\\brfc\\b",
       "agent": "/loom:architect",
       "description": "System design and architecture"
     },
     {
-      "pattern": "review|\\bPR\\b|pull request|code review",
+      "pattern": "code review|\\bpull request\\b|review (this|the|my|our|that) ",
       "agent": "/loom:judge",
       "description": "Code review"
     },
     {
-      "pattern": "fix|bug|broken|changes.requested|merge.conflict",
+      "pattern": "\\bfix\\b|\\bbug\\b|\\bbroken\\b|changes.requested|merge.conflict|address (the )?feedback",
       "agent": "/loom:doctor",
       "description": "Bug fixes and PR feedback"
     },
     {
-      "pattern": "simplify|refactor|clean.?up|dead.?code|complexity",
+      "pattern": "\\bsimplify\\b|\\bsimplification\\b|\\brefactor|clean.?up|dead.?code|\\bcomplexity\\b",
       "agent": "/loom:hermit",
       "description": "Simplification opportunities"
     },
     {
-      "pattern": "build|implement|feature|develop|code",
+      "pattern": "\\bbuild\\b|\\bimplement|\\bfeature\\b|\\bdevelop",
       "agent": "/loom:builder",
       "description": "Implement features and fixes"
     },
     {
-      "pattern": "curate|triage|issue|enhance|enrich",
+      "pattern": "\\bcurate\\b|\\benrich|\\btriage\\b|file (an |a )?(issue|bug)",
       "agent": "/loom:curator",
       "description": "Issue enrichment"
     },
     {
-      "pattern": "prioriti[zs]e|backlog|roadmap",
+      "pattern": "prioriti[zs]e|\\bbacklog\\b|\\broadmap\\b",
       "agent": "/loom:guide",
       "description": "Backlog triage"
     },
     {
-      "pattern": "audit|validate|check.?build",
+      "pattern": "\\baudit\\b|\\bvalidate\\b|check.?build|verify (the )?build",
       "agent": "/loom:auditor",
       "description": "Build validation"
     },
     {
-      "pattern": "loom|daemon|auto.?build",
+      "pattern": "loom daemon|\\bdaemon\\b|auto.?build|orchestrat",
       "agent": "/loom:loom",
       "description": "System daemon orchestration"
     }

--- a/defaults/hooks/skill-router.sh
+++ b/defaults/hooks/skill-router.sh
@@ -5,9 +5,12 @@
 # Receives JSON on stdin with { "prompt": "...", "session_id": "...", "cwd": "..." }
 #
 # Behavior:
-#   1. Always injects a compact agent routing table as additionalContext
-#   2. Optionally emits an AGENT_ROUTE directive when prompt strongly matches
-#      a domain pattern (first match wins)
+#   1. Emits nothing unless the prompt strongly matches a domain route pattern
+#      (first match wins). Non-matching turns produce NO additionalContext —
+#      the agent table is no longer injected on every prompt (issue #3609).
+#   2. On a match, emits an AGENT_ROUTE directive. A compact agent routing
+#      table is appended at most ONCE per session, deduped via the session_id
+#      present on stdin (a missing session_id degrades to per-match inclusion).
 #
 # Output format (Claude Code hooks spec):
 #   { "hookSpecificOutput": { "hookEventName": "UserPromptSubmit", "additionalContext": "..." } }
@@ -48,6 +51,10 @@ fi
 # Extract prompt
 PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty' 2>/dev/null) || PROMPT=""
 
+# Extract session_id (used for once-per-session table dedup; optional — a
+# missing/empty value degrades gracefully, see the PER-SESSION TABLE DEDUP block)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null) || SESSION_ID=""
+
 # If no prompt, nothing to do
 if [[ -z "$PROMPT" ]]; then
     exit 0
@@ -67,6 +74,26 @@ case "$PROMPT" in
     "[SYSTEM NOTIFICATION"*) exit 0 ;;
 esac
 if [[ "$PROMPT" == *"<task-notification>"* ]]; then
+    exit 0
+fi
+
+# =============================================================================
+# MINIMUM-SIGNAL GATE (#3609)
+# =============================================================================
+# Skip turns that are structurally unlikely to be a routing request:
+#   - prompts that begin with '/' (slash-command turns, e.g. /builder,
+#     /loom:sweep — the user has already chosen a command)
+#   - very short prompts (< 3 words), which carry too little signal to route
+# These skips keep near-zero-signal chatter from producing routing noise.
+if [[ "$PROMPT" == /* ]]; then
+    exit 0
+fi
+
+WORD_COUNT=$(printf '%s' "$PROMPT" | wc -w | tr -d '[:space:]')
+if [[ -z "$WORD_COUNT" ]]; then
+    WORD_COUNT=0
+fi
+if [[ "$WORD_COUNT" -lt 3 ]]; then
     exit 0
 fi
 
@@ -106,18 +133,6 @@ if [[ -z "$ROUTES_JSON" ]] || [[ "$ROUTES_JSON" == "null" ]]; then
 fi
 
 # =============================================================================
-# BUILD AGENT TABLE
-# =============================================================================
-
-# Build compact agent routing table from config
-AGENT_TABLE=$(echo "$ROUTES_JSON" | jq -r '.[] | "\(.agent) — \(.description)"' 2>/dev/null) || AGENT_TABLE=""
-
-if [[ -z "$AGENT_TABLE" ]]; then
-    log_hook_error "Failed to build agent table"
-    exit 0
-fi
-
-# =============================================================================
 # PATTERN MATCHING
 # =============================================================================
 
@@ -145,20 +160,57 @@ for (( i=0; i<ROUTE_COUNT; i++ )); do
     fi
 done
 
-# =============================================================================
-# OUTPUT
-# =============================================================================
-
-# Build the additionalContext string
-CONTEXT="Available Loom agents:
-${AGENT_TABLE}"
-
-if [[ -n "$MATCHED_AGENT" ]]; then
-    CONTEXT="${CONTEXT}
-
-AGENT_ROUTE: ${MATCHED_AGENT} — ${MATCHED_DESC}
-(This is a suggestion based on prompt keywords. Use the Skill tool to invoke if appropriate.)"
+# No route matched: emit nothing at all (issue #3609). The agent table used to
+# ride along on EVERY prompt; now it only accompanies a genuine route match, so
+# non-matching turns are a silent exit — no additionalContext, no token cost.
+if [[ -z "$MATCHED_AGENT" ]]; then
+    exit 0
 fi
+
+# =============================================================================
+# PER-SESSION TABLE DEDUP (#3609)
+# =============================================================================
+# The agent table is verbatim repetition of the roles list already shipped in
+# CLAUDE.md, so a session needs it at most once. We key an "already sent" marker
+# on the session_id already present on stdin. A missing/empty session_id
+# degrades gracefully: we cannot dedup, so the table is included on each match
+# (the pre-#3609 per-turn behavior, but now only on matching turns).
+
+INCLUDE_TABLE=1
+if [[ -n "$SESSION_ID" ]]; then
+    # Sanitize to filename-safe characters so the marker is a single predictable
+    # file (never a path traversal, never a nested directory).
+    SESSION_KEY=$(printf '%s' "$SESSION_ID" | tr -c 'A-Za-z0-9._-' '_')
+    SEEN_DIR="${MAIN_ROOT}/.loom/logs/skill-router-seen"
+    SEEN_MARKER="${SEEN_DIR}/${SESSION_KEY}"
+    if [[ -f "$SEEN_MARKER" ]]; then
+        INCLUDE_TABLE=0
+    else
+        # Best-effort marker creation; a failure here never fails the hook and
+        # simply means the table may be re-sent on a later matching turn.
+        mkdir -p "$SEEN_DIR" 2>/dev/null || true
+        : > "$SEEN_MARKER" 2>/dev/null || true
+    fi
+fi
+
+# =============================================================================
+# BUILD OUTPUT
+# =============================================================================
+
+CONTEXT=""
+if [[ "$INCLUDE_TABLE" -eq 1 ]]; then
+    # Build the compact agent routing table only when we will actually emit it.
+    AGENT_TABLE=$(echo "$ROUTES_JSON" | jq -r '.[] | "\(.agent) — \(.description)"' 2>/dev/null) || AGENT_TABLE=""
+    if [[ -n "$AGENT_TABLE" ]]; then
+        CONTEXT="Available Loom agents:
+${AGENT_TABLE}
+
+"
+    fi
+fi
+
+CONTEXT="${CONTEXT}AGENT_ROUTE: ${MATCHED_AGENT} — ${MATCHED_DESC}
+(This is a suggestion based on prompt keywords. Use the Skill tool to invoke if appropriate.)"
 
 # Output valid JSON
 jq -n --arg context "$CONTEXT" '{

--- a/defaults/hooks/tests/test-skill-router.sh
+++ b/defaults/hooks/tests/test-skill-router.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# Test suite for defaults/hooks/skill-router.sh (issue #3609)
+#
+# Usage: ./defaults/hooks/tests/test-skill-router.sh
+#
+# Covers the #3609 rework of the UserPromptSubmit routing hook:
+#   - non-matching / short / slash prompts emit NO additionalContext
+#   - genuine imperative prompts still emit an AGENT_ROUTE suggestion
+#   - the agent table is deduped per session (via session_id), appearing at
+#     most once; a missing session_id degrades gracefully
+#   - the two report example mis-routes ("...builders...", "open an issue
+#     with rjwalters/loom") no longer route
+#   - the hook never exits non-zero and never emits invalid JSON
+#
+# The hook + routing config under test are the canonical sources at
+# defaults/ (the version-controlled source of truth), copied into an isolated
+# temp tree so the hook's MAIN_ROOT resolves there (git-common-dir fails
+# outside a repo, so the BASH_SOURCE fallback locates our temp root).
+# Exit code 0 = all tests pass, 1 = failures detected.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+SRC_HOOK="$REPO_ROOT/defaults/hooks/skill-router.sh"
+SRC_CONFIG="$REPO_ROOT/defaults/config/skill-routes.json"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+# Isolated tree so the hook reads OUR config and writes OUR session markers.
+# It must be a git repo: the hook resolves MAIN_ROOT via `git rev-parse
+# --git-common-dir`, so an isolated repo root pins MAIN_ROOT to the temp tree.
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+git init -q "$TMPROOT"
+mkdir -p "$TMPROOT/defaults/hooks" "$TMPROOT/.loom/config"
+cp "$SRC_HOOK" "$TMPROOT/defaults/hooks/skill-router.sh"
+chmod +x "$TMPROOT/defaults/hooks/skill-router.sh"
+cp "$SRC_CONFIG" "$TMPROOT/.loom/config/skill-routes.json"
+HOOK="$TMPROOT/defaults/hooks/skill-router.sh"
+
+# Build stdin JSON. Second arg (session_id) is optional.
+make_input() {
+    local prompt="$1"
+    local session="${2:-}"
+    if [[ -n "$session" ]]; then
+        jq -n --arg p "$prompt" --arg s "$session" '{prompt: $p, session_id: $s}'
+    else
+        jq -n --arg p "$prompt" '{prompt: $p}'
+    fi
+}
+
+# Run the hook from OUTSIDE any git repo so git-common-dir fails and MAIN_ROOT
+# falls back to the temp tree. Echoes stdout; asserts exit 0 (never non-zero).
+run_hook() {
+    local prompt="$1"
+    local session="${2:-}"
+    local output exit_code=0
+    output=$(cd "$TMPROOT" && make_input "$prompt" "$session" | "$HOOK" 2>/dev/null) || exit_code=$?
+    if [[ "$exit_code" -ne 0 ]]; then
+        echo "__NONZERO_EXIT__:$exit_code"
+        return 0
+    fi
+    # Any non-empty output must be valid JSON.
+    if [[ -n "$output" ]] && ! echo "$output" | jq empty 2>/dev/null; then
+        echo "__INVALID_JSON__"
+        return 0
+    fi
+    echo "$output"
+}
+
+# Extract the additionalContext string from hook output ("" if none).
+context_of() {
+    echo "$1" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null || true
+}
+
+pass() { PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1)); printf "${GREEN}PASS${NC} %s\n" "$1"; }
+fail() { FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1)); printf "${RED}FAIL${NC} %s\n" "$1"; }
+
+assert_no_output() {
+    local desc="$1" out="$2"
+    if [[ -z "$out" ]]; then
+        pass "$desc"
+    else
+        fail "$desc (expected empty output, got: $out)"
+    fi
+}
+
+assert_contains() {
+    local desc="$1" haystack="$2" needle="$3"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        pass "$desc"
+    else
+        fail "$desc (expected to contain '$needle', got: $haystack)"
+    fi
+}
+
+assert_not_contains() {
+    local desc="$1" haystack="$2" needle="$3"
+    if [[ "$haystack" != *"$needle"* ]]; then
+        pass "$desc"
+    else
+        fail "$desc (expected NOT to contain '$needle', got: $haystack)"
+    fi
+}
+
+# Reset any per-session markers between independent cases.
+reset_markers() { rm -rf "$TMPROOT/.loom/logs/skill-router-seen" 2>/dev/null || true; }
+
+echo "=== skill-router.sh tests (#3609) ==="
+
+# --- No-match / short / slash prompts emit nothing --------------------------
+reset_markers
+out=$(run_hook "the weather is quite nice today")
+assert_no_output "non-matching prompt -> no additionalContext" "$out"
+
+out=$(run_hook "/builder go implement the feature now")
+assert_no_output "slash-command prompt -> no additionalContext" "$out"
+
+out=$(run_hook "hi there")
+assert_no_output "short prompt (<3 words) -> no additionalContext" "$out"
+
+out=$(run_hook "help")
+assert_no_output "single-word prompt -> no additionalContext" "$out"
+
+# --- Genuine imperative matches still route ---------------------------------
+reset_markers
+out=$(run_hook "please implement the new feature")
+ctx=$(context_of "$out")
+assert_contains "builder imperative -> AGENT_ROUTE present" "$ctx" "AGENT_ROUTE:"
+assert_contains "builder imperative -> routes to /loom:builder" "$ctx" "/loom:builder"
+
+reset_markers
+out=$(run_hook "review this PR")
+ctx=$(context_of "$out")
+assert_contains "'review this PR' -> routes to /loom:judge" "$ctx" "/loom:judge"
+
+reset_markers
+out=$(run_hook "file an issue for the flaky test")
+ctx=$(context_of "$out")
+assert_contains "'file an issue for X' -> routes to /loom:curator" "$ctx" "/loom:curator"
+
+# --- Report example mis-routes no longer route ------------------------------
+reset_markers
+out=$(run_hook "confirm our builders are still active in the pool")
+ctx=$(context_of "$out")
+assert_no_output "report example 'builders...' -> no route" "$out"
+
+reset_markers
+out=$(run_hook "please open an issue with rjwalters/loom about this")
+assert_no_output "report example 'open an issue with rjwalters/loom' -> no route" "$out"
+
+# --- Per-session dedup of the agent table -----------------------------------
+reset_markers
+out1=$(run_hook "please implement the new feature" "session-abc")
+ctx1=$(context_of "$out1")
+assert_contains "first match in session -> includes agent table" "$ctx1" "Available Loom agents:"
+
+out2=$(run_hook "please refactor this dead code" "session-abc")
+ctx2=$(context_of "$out2")
+assert_contains "second match in session -> AGENT_ROUTE still present" "$ctx2" "AGENT_ROUTE:"
+assert_not_contains "second match in session -> table deduped away" "$ctx2" "Available Loom agents:"
+
+# A different session gets its own fresh table.
+out3=$(run_hook "please implement the new feature" "session-xyz")
+ctx3=$(context_of "$out3")
+assert_contains "new session -> table included again" "$ctx3" "Available Loom agents:"
+
+# --- Missing session_id degrades gracefully (table each match, no crash) ----
+reset_markers
+outA=$(run_hook "please implement the new feature")
+ctxA=$(context_of "$outA")
+assert_contains "no session_id -> AGENT_ROUTE present" "$ctxA" "AGENT_ROUTE:"
+assert_contains "no session_id -> table included (no dedup possible)" "$ctxA" "Available Loom agents:"
+outB=$(run_hook "please implement the new feature")
+ctxB=$(context_of "$outB")
+assert_contains "no session_id -> table included again (graceful)" "$ctxB" "Available Loom agents:"
+
+# --- Never non-zero / never invalid JSON ------------------------------------
+for probe in "the weather is quite nice today" "please implement the new feature" "review this PR" "/builder x y z"; do
+    out=$(run_hook "$probe" "sess-probe")
+    if [[ "$out" == __NONZERO_EXIT__* ]]; then
+        fail "hook exits 0 for: $probe"
+    elif [[ "$out" == "__INVALID_JSON__" ]]; then
+        fail "hook emits valid JSON for: $probe"
+    else
+        pass "hook exit 0 + valid JSON for: $probe"
+    fi
+done
+
+# --- Config hygiene ---------------------------------------------------------
+if jq empty "$SRC_CONFIG" 2>/dev/null; then
+    pass "defaults config is valid JSON"
+else
+    fail "defaults config is valid JSON"
+fi
+
+if grep -q "shepherd" "$SRC_CONFIG"; then
+    fail "dead shepherd route removed from defaults config"
+else
+    pass "dead shepherd route removed from defaults config"
+fi
+
+if grep -Eq '"/(shepherd|architect|judge|doctor|hermit|builder|curator|guide|auditor|loom)"' "$SRC_CONFIG"; then
+    fail "no un-namespaced /<role> agents in defaults config"
+else
+    pass "all agents are namespaced /loom:<role> in defaults config"
+fi
+
+# --- defaults/ vs .loom/ sync (both hook and config) ------------------------
+DEPLOY_HOOK="$REPO_ROOT/.loom/hooks/skill-router.sh"
+DEPLOY_CONFIG="$REPO_ROOT/.loom/config/skill-routes.json"
+if [[ -f "$DEPLOY_HOOK" ]] && diff -q "$SRC_HOOK" "$DEPLOY_HOOK" >/dev/null 2>&1; then
+    pass ".loom/ hook byte-identical to defaults/"
+else
+    fail ".loom/ hook byte-identical to defaults/"
+fi
+if [[ -f "$DEPLOY_CONFIG" ]] && diff -q "$SRC_CONFIG" "$DEPLOY_CONFIG" >/dev/null 2>&1; then
+    pass ".loom/ config byte-identical to defaults/"
+else
+    fail ".loom/ config byte-identical to defaults/"
+fi
+
+echo "=== $PASS/$TOTAL passed ==="
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #3609

## Summary

`skill-router.sh` injected the full agent table on **every** prompt (~120-150 tokens/turn, ~6-7.5k tokens over a ~50-turn session) and matched routes on bare single-word substrings, so "builders" mis-routed to `/loom:builder`, and a bare "issue" / any "loom" mention mis-routed too — near-zero suggestion precision at real token cost.

## Changes

- **Table only on a match.** When no route matches, the hook now emits **no** `additionalContext` and exits silently. The agent table only rides along with a genuine route match.
- **Per-session dedup.** The table is deduped using the `session_id` already present on stdin (marker under `.loom/logs/skill-router-seen/<session_id>`, which is already gitignored). A session receives the table at most once; the `AGENT_ROUTE:` line is still emitted on every match. Missing/empty `session_id` degrades gracefully to per-match inclusion.
- **Minimum-signal gate.** Skip prompts that begin with `/` (slash-command turns) and prompts under 3 words.
- **Tightened patterns** to phrase/word-boundary anchors in `skill-routes.json`. The two report example prompts ("confirm our builders are still active…", "open an issue with rjwalters/loom") no longer route; genuine imperatives ("review this PR", "file an issue for X") still do.
- **Dropped the dead `shepherd` route** (command removed in v0.10.0) and re-synced `.loom/config/skill-routes.json` from `defaults/` (namespaced `/loom:<role>`; the deployed copy had drifted to un-namespaced agents + a dead `/shepherd`).
- **`.loom/hooks/skill-router.sh` kept byte-identical** to `defaults/hooks/skill-router.sh`.

## Scope boundary

The #3608 top-of-file machine-generated-prompt guard (`/self*`, `[SYSTEM NOTIFICATION*`, `<task-notification>`) is unchanged. `methodology-inject.sh` is untouched.

## Test

New `defaults/hooks/tests/test-skill-router.sh` — 26 cases covering match/no-match, short/slash skips, per-session dedup (table once, then deduped; new session refreshed; graceful no-session), the two report mis-routes, the never-non-zero / always-valid-JSON contract, and `defaults/` ↔ `.loom/` sync for both hook and config. All 26 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)