### PR TITLE
feat(guard): opt-in guards.rmScope=repo rm-scope mode with ephemeral allowlist (#3610)

### DIFF
--- a/.loom/hooks/guard-destructive.sh
+++ b/.loom/hooks/guard-destructive.sh
@@ -20,7 +20,11 @@
 #   - Allow: Everything else (exit 0, no output)
 #
 # Output format (Claude Code hooks spec):
-#   { "hookSpecificOutput": { "permissionDecision": "deny|ask", "permissionDecisionReason": "..." } }
+#   { "hookSpecificOutput": { "hookEventName": "PreToolUse", "permissionDecision": "deny|ask", "permissionDecisionReason": "..." } }
+#
+# NOTE: The "hookEventName": "PreToolUse" field is REQUIRED by Claude Code's
+# PreToolUse hook schema. Without it, Claude Code silently discards the
+# decision and the guard becomes inert (see issue #3550).
 #
 # Error handling: This script MUST never exit with a non-zero code or produce
 # invalid output. Any internal error is caught by the trap, logged for
@@ -70,11 +74,171 @@ elif [[ -n "$CWD" ]]; then
     log_hook_error "cwd does not exist: $CWD — skipping repo root resolution"
 fi
 
+# =============================================================================
+# SQL DDL/DML guard toggle — default ON.
+#
+# The SQL DDL/DML blocks (DROP DATABASE/TABLE/SCHEMA, TRUNCATE TABLE, and
+# DELETE FROM without WHERE) are a category error for repos that are themselves
+# database engines, where those statements are the product's own dev/test
+# vocabulary. Such repos opt out; everyone else keeps the guard on.
+#
+# Resolution order (highest precedence first):
+#   1. LOOM_GUARD_SQL env var (0/false/no disables, 1/true/yes forces on)
+#   2. .loom/config.json  ->  guards.sqlDdl  (default true when absent)
+#   3. Default: true (guard on)
+#
+# The resolution runs LAZILY — sql_guard_enabled() is only invoked once a
+# command has already matched a SQL DDL/DML pattern, so the jq config read never
+# touches the hot path for the ~99% of commands that are not SQL. The result is
+# cached so a command matching multiple SQL patterns pays for at most one read.
+#
+# The config read is best-effort: any parse failure falls through to guard-ON
+# and never trips the ERR trap or produces a non-zero exit.
+# =============================================================================
+_SQL_GUARD_CACHE=""
+sql_guard_enabled() {
+    if [[ -z "$_SQL_GUARD_CACHE" ]]; then
+        local enabled=true
+        if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/config.json" ]]; then
+            # jq // is alternative-on-null, not default-on-missing, so use
+            # if/then/else to treat only an explicit `false` as disabled (a
+            # missing guards.sqlDdl key stays on). On malformed JSON jq exits
+            # non-zero and the `||` fallback restores the guard-ON default.
+            enabled=$(jq -r 'if .guards.sqlDdl == false then "false" else "true" end' "$REPO_ROOT/.loom/config.json" 2>/dev/null) || enabled=true
+            [[ -n "$enabled" ]] || enabled=true
+        fi
+        # Env override wins over config.
+        case "${LOOM_GUARD_SQL:-}" in
+            0|false|no)  enabled=false ;;
+            1|true|yes)  enabled=true ;;
+        esac
+        _SQL_GUARD_CACHE="$enabled"
+    fi
+    [[ "$_SQL_GUARD_CACHE" == "true" ]]
+}
+
+# =============================================================================
+# Cloud CLI guard toggle — default ON.
+#
+# The cloud/docker ASK patterns (mutating aws ec2/lambda/s3/... subcommands and
+# docker rm/rmi/stop/kill/restart) prompt for confirmation on every match. For a
+# repo whose *purpose* is managing cloud infrastructure (launch/stop/terminate
+# dev VMs, build/tear-down containers), that friction is a category error — the
+# mutating calls are the product's own dev/test vocabulary. Such repos opt out;
+# everyone else keeps the guard on. The genuinely catastrophic aws/docker denies
+# in ALWAYS_BLOCK_PATTERNS are NOT gated by this toggle and stay active.
+#
+# Resolution order (highest precedence first):
+#   1. LOOM_GUARD_CLOUD env var (0/false/no disables, 1/true/yes forces on)
+#   2. .loom/config.json  ->  guards.cloudCli  (default true when absent)
+#   3. Default: true (guard on)
+#
+# Mirrors sql_guard_enabled() exactly: cached in _CLOUD_GUARD_CACHE, invoked
+# LAZILY only after a cloud pattern has already matched so the jq config read
+# never touches the hot path for non-cloud commands. The config read is
+# best-effort: any parse failure falls through to guard-ON.
+# =============================================================================
+_CLOUD_GUARD_CACHE=""
+cloud_guard_enabled() {
+    if [[ -z "$_CLOUD_GUARD_CACHE" ]]; then
+        local enabled=true
+        if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/config.json" ]]; then
+            # jq // is alternative-on-null, not default-on-missing, so use
+            # if/then/else to treat only an explicit `false` as disabled (a
+            # missing guards.cloudCli key stays on). On malformed JSON jq exits
+            # non-zero and the `||` fallback restores the guard-ON default.
+            enabled=$(jq -r 'if .guards.cloudCli == false then "false" else "true" end' "$REPO_ROOT/.loom/config.json" 2>/dev/null) || enabled=true
+            [[ -n "$enabled" ]] || enabled=true
+        fi
+        # Env override wins over config.
+        case "${LOOM_GUARD_CLOUD:-}" in
+            0|false|no)  enabled=false ;;
+            1|true|yes)  enabled=true ;;
+        esac
+        _CLOUD_GUARD_CACHE="$enabled"
+    fi
+    [[ "$_CLOUD_GUARD_CACHE" == "true" ]]
+}
+
+# =============================================================================
+# rm-scope repo mode toggle — default OFF (opt-in).
+#
+# By default this guard blocks only catastrophic rm targets (root, $HOME, and
+# bare top-level dirs) and ALLOWS every deeper subpath — including subpaths
+# OUTSIDE the repo (e.g. `rm -rf /Users/someone/important`). That permissive
+# default ships unchanged so existing installs see zero behaviour change.
+#
+# Opt-in `repo` mode (guards.rmScope:"repo" / LOOM_RM_SCOPE=repo) additionally
+# DENIES any rm target that is neither under the repo / worktree areas nor on a
+# built-in ephemeral allowlist (system temp dirs + the Claude scratchpad). The
+# catastrophic top-level deny stays unconditional in BOTH modes, so bare /tmp
+# and / are still blocked.
+#
+# Resolution order (highest precedence first):
+#   1. LOOM_RM_SCOPE env var (repo enables; off/0/no disables). Overrides config.
+#   2. .loom/config.json  ->  guards.rmScope == "repo"  (else off)
+#   3. Default: off (permissive, current behaviour)
+#
+# Mirrors sql_guard_enabled() / cloud_guard_enabled(): cached in
+# _RM_SCOPE_CACHE, invoked LAZILY only after a candidate rm target survives the
+# catastrophic check, so the jq config read never touches the hot path for
+# non-rm commands. The config read is best-effort: any parse failure falls
+# through to OFF (no behaviour change) and never trips the ERR trap.
+# =============================================================================
+_RM_SCOPE_CACHE=""
+rm_scope_repo_enabled() {
+    if [[ -z "$_RM_SCOPE_CACHE" ]]; then
+        local mode=off
+        if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/config.json" ]]; then
+            # Only an explicit guards.rmScope == "repo" enables the mode; any
+            # other value, a missing key, or malformed JSON stays OFF (the jq
+            # non-zero exit is caught by the `||` fallback).
+            mode=$(jq -r 'if .guards.rmScope == "repo" then "repo" else "off" end' "$REPO_ROOT/.loom/config.json" 2>/dev/null) || mode=off
+            [[ -n "$mode" ]] || mode=off
+        fi
+        # Env override wins over config.
+        case "${LOOM_RM_SCOPE:-}" in
+            repo)         mode=repo ;;
+            off|0|no)     mode=off ;;
+        esac
+        _RM_SCOPE_CACHE="$mode"
+    fi
+    [[ "$_RM_SCOPE_CACHE" == "repo" ]]
+}
+
+# Resolve the Loom worktree base dir for repo-scope checks. Mirrors the
+# precedence of loom_worktree_root() in defaults/scripts/lib/worktree-root.sh
+# (env -> config -> default), replicated inline so the hook stays
+# self-contained and best-effort: any failure falls back to the default in-repo
+# path and never fails the hook. Only called in repo mode, once per rm scan.
+resolve_worktree_root() {
+    local repo_root="$1"
+    [[ -z "$repo_root" ]] && return 0
+    # 1. Env override (highest priority); must be absolute.
+    if [[ -n "${LOOM_WORKTREE_ROOT:-}" && "$LOOM_WORKTREE_ROOT" == /* ]]; then
+        printf '%s/%s' "${LOOM_WORKTREE_ROOT%/}" "$(basename "$repo_root")"
+        return 0
+    fi
+    # 2. Config key .loom/config.json -> worktree.root (absolute only).
+    local config_file="$repo_root/.loom/config.json"
+    if [[ -f "$config_file" ]]; then
+        local cfg_root
+        cfg_root=$(jq -r '.worktree.root? // empty' "$config_file" 2>/dev/null) || cfg_root=""
+        if [[ -n "$cfg_root" && "$cfg_root" == /* ]]; then
+            printf '%s/%s' "${cfg_root%/}" "$(basename "$repo_root")"
+            return 0
+        fi
+    fi
+    # 3. Default — in-repo worktrees dir.
+    printf '%s/.loom/worktrees' "$repo_root"
+}
+
 # Helper: output a deny decision and exit
 deny() {
     local reason="$1"
     if jq -n --arg reason "$reason" '{
         hookSpecificOutput: {
+            hookEventName: "PreToolUse",
             permissionDecision: "deny",
             permissionDecisionReason: $reason
         }
@@ -84,7 +248,7 @@ deny() {
     # jq failed — emit raw JSON as fallback
     local escaped_reason
     escaped_reason=$(echo "$reason" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g; s/\n/\\n/g')
-    echo "{\"hookSpecificOutput\":{\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"${escaped_reason}\"}}"
+    echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"${escaped_reason}\"}}"
     exit 0
 }
 
@@ -93,6 +257,7 @@ ask() {
     local reason="$1"
     if jq -n --arg reason "$reason" '{
         hookSpecificOutput: {
+            hookEventName: "PreToolUse",
             permissionDecision: "ask",
             permissionDecisionReason: $reason
         }
@@ -102,7 +267,7 @@ ask() {
     # jq failed — emit raw JSON as fallback
     local escaped_reason
     escaped_reason=$(echo "$reason" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g; s/\n/\\n/g')
-    echo "{\"hookSpecificOutput\":{\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"${escaped_reason}\"}}"
+    echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"${escaped_reason}\"}}"
     exit 0
 }
 
@@ -111,9 +276,14 @@ ask() {
 # =============================================================================
 
 ALWAYS_BLOCK_PATTERNS=(
-    # GitHub destructive operations
-    'gh repo delete'
-    'gh repo archive'
+    # GitHub destructive operations — command-position anchored (start-of-line
+    # or a shell separator must precede the verb) so the phrase inside a flag
+    # value no longer trips. NOTE: the catastrophic scan still runs over the
+    # full raw command, including quoted/heredoc text, so a `gh repo delete`
+    # that a shell would actually execute (leading, sudo-prefixed, or after a
+    # separator) still denies (#3553).
+    '(^|[;&|[:space:]])gh repo delete'
+    '(^|[;&|[:space:]])gh repo archive'
 
     # Force push to main/master (various flag forms)
     'git push --force origin main'
@@ -123,11 +293,16 @@ ALWAYS_BLOCK_PATTERNS=(
     'git push --force-with-lease origin main'
     'git push --force-with-lease origin master'
 
-    # Filesystem destruction
-    'rm -rf /'
-    'rm -rf /\*'
-    'rm -rf ~'
-    'rm -rf \$HOME'
+    # Filesystem destruction — anchored to a *real* root/home target so that a
+    # scoped path like `rm -rf /tmp/x` no longer trips the catastrophic rule,
+    # while root / home obliteration still denies. The left side of `rm` is
+    # deliberately NOT anchored, so a quoted payload such as `bash -c 'rm -rf /'`
+    # (root followed by a closing quote) still matches (#3553). The trailing
+    # class matches anything that is not a path-continuation character (so `/`,
+    # `/ `, `/*`, `/;`, `/'` all count as "root itself" but `/tmp` does not).
+    'rm[[:space:]]+-[a-zA-Z]*[rf][a-zA-Z]*[[:space:]]+/([^[:alnum:]._~/-]|$)'
+    'rm[[:space:]]+-[a-zA-Z]*[rf][a-zA-Z]*[[:space:]]+~([^[:alnum:]._~/-]|$)'
+    'rm[[:space:]]+-[a-zA-Z]*[rf][a-zA-Z]*[[:space:]]+\$HOME([^[:alnum:]._~/-]|$)'
 
     # Fork bombs
     ':\(\)\{ :\|:& \};:'
@@ -138,32 +313,34 @@ ALWAYS_BLOCK_PATTERNS=(
     'wget .* \| .*sh'
     'wget .* -O- \| sh'
 
-    # Cloud infrastructure destruction
+    # Cloud infrastructure destruction. The aws forms below are specific
+    # multi-token phrases, so they stay in this raw substring scan. The az/gcloud
+    # CLIs, by contrast, need command-word anchoring — an unanchored `az.*delete`
+    # matches "h·az·ard … delete" across unrelated prose tokens (#3584) — so they
+    # are handled by the segment-parsed lifecycle/cloud check further below, NOT
+    # here.
+    # NOTE: `aws ec2 terminate` is deliberately NOT in this raw catastrophic
+    # scan. For a repo whose job is standing up and tearing down dev VMs the
+    # teardown path (`terminate-instances`) is a first-class workflow, so it is
+    # downgraded to an ask via the toggle-gated CLOUD_ASK_PATTERNS below (and
+    # fully bypassed when LOOM_GUARD_CLOUD=0 / guards.cloudCli:false). The other
+    # aws forms here stay ungated — they remain a hard safety floor (#3593).
     'aws s3 rm.*--recursive'
     'aws s3 rb'
-    'aws ec2 terminate'
     'aws iam delete'
     'aws cloudformation delete-stack'
-    'gcloud.*delete'
-    'az.*delete'
-    'az group delete'
 
     # Docker mass destruction
     'docker system prune'
 
-    # System reboot/shutdown
-    'reboot'
-    'shutdown'
-    'halt'
-    'poweroff'
-    'init 0'
-    'init 6'
-
-    # Database destruction
-    'DROP DATABASE'
-    'DROP TABLE'
-    'DROP SCHEMA'
-    'TRUNCATE TABLE'
+    # NOTE: system-lifecycle commands (halt/reboot/poweroff/shutdown/init 0/
+    # init 6) are deliberately NOT in this raw substring scan. Even the
+    # whitespace-inclusive boundary anchor they used to carry still fired inside
+    # ordinary prose ("...the box will halt", "...after a reboot event"), and a
+    # pure regex tweak can't separate `sudo halt` from `will halt` (both are
+    # "<word> halt"). They are handled by the segment-parsed check below, which
+    # denies only when a segment's *command word* is exactly the lifecycle word
+    # (#3584).
 )
 
 for pattern in "${ALWAYS_BLOCK_PATTERNS[@]}"; do
@@ -173,18 +350,214 @@ for pattern in "${ALWAYS_BLOCK_PATTERNS[@]}"; do
 done
 
 # =============================================================================
-# rm -rf SCOPE CHECK - Block rm with recursive/force flags outside repo
+# COMMENT-STRIPPED WORKING COPY - used ONLY for the ASK-word and SQL DDL/DML
+# matches below, never for the catastrophic ALWAYS_BLOCK scan.
+#
+# Strips a `#…EOL` shell comment when the `#` is at start-of-line or preceded
+# by whitespace (the common comment shape), so a pattern word that appears only
+# in a trailing comment ("# drop database first", "# git push --force") no
+# longer trips the ASK/DDL gates. This is best-effort: a `#` inside a quoted
+# string that happens to be whitespace-preceded is also stripped, but since the
+# stripped copy is used only for the *narrowing* ASK/DDL matches (never the
+# catastrophic scan) the worst case is a missed ask on quoted data, never a
+# missed catastrophic block. The sed only runs when a `#` is actually present,
+# keeping it off the hot path (#3553).
+# =============================================================================
+if [[ "$COMMAND" == *"#"* ]]; then
+    COMMAND_NO_COMMENT=$(printf '%s\n' "$COMMAND" | sed -E 's/(^|[[:space:]])#.*$//')
+else
+    COMMAND_NO_COMMENT="$COMMAND"
+fi
+
+# =============================================================================
+# SYSTEM-LIFECYCLE + CLOUD-CLI DELETE (segment-parsed, command-word anchored)
+#
+# The system-lifecycle commands (halt/reboot/poweroff/shutdown/init 0/init 6)
+# and the az/gcloud cloud-delete CLIs are far too common as ordinary prose,
+# identifiers, and flag names to scan as unanchored substrings — and even a
+# whitespace-inclusive boundary anchor still fired inside comments and commit
+# messages ("...the box will halt", "...after a reboot event"). A pure regex
+# tweak cannot separate `sudo halt` (a real command) from `will halt` (prose)
+# because both are "<word> halt".
+#
+# So we segment-parse instead, mirroring extract_rm_targets(): split the command
+# on ; | & && || and newline, strip a leading sudo/env wrapper from each segment,
+# and deny only when a segment's *command word* (first token) is exactly a
+# lifecycle word — or is `az`/`gcloud` with a `delete` subcommand token. This
+# distinguishes `sudo halt` (command word = halt) from `will halt` (command word
+# = echo/other) and from `--instance-initiated-shutdown-behavior` (not a command
+# word at all). The scan runs against COMMAND_NO_COMMENT so a lifecycle/cloud
+# word sitting in a trailing comment is already gone. The catastrophic
+# ALWAYS_BLOCK scan above still reads the raw string for the symbolic patterns
+# (rm -rf /, the fork bomb, curl|sh) that are not prose-prone (#3584).
+# =============================================================================
+lifecycle_or_cloud_reason() {
+    # Emit a deny reason (one per line) for every segment whose command word is a
+    # system-lifecycle command or an az/gcloud delete. Portable awk only.
+    printf '%s' "$1" | awk '
+    {
+        gsub(/&&|\|\||[;|&]/, "\n")
+        n = split($0, segs, "\n")
+        for (i = 1; i <= n; i++) {
+            seg = segs[i]
+            sub(/^[ \t]+/, "", seg)
+            sub(/^sudo[ \t]+/, "", seg)
+            # Strip a leading `env` wrapper, then loop-strip the env flags and
+            # NAME=value assignments a shell resolves past before the command
+            # word, so `env FOO=bar halt` resolves to command word `halt` (not
+            # `FOO=bar`) and still denies. `env -i FOO=bar halt` and `env -u
+            # NAME halt` likewise resolve to `halt`. A bare `env halt` (no
+            # assignment) is unaffected — the loop matches nothing and leaves
+            # `halt` as the command word. Portable awk only (no GNU/BSD-specific
+            # escapes), consistent with extract_rm_targets(). (#3586)
+            if (sub(/^env([ \t]+|$)/, "", seg)) {
+                sub(/^[ \t]+/, "", seg)
+                stripped = 1
+                while (stripped) {
+                    stripped = 0
+                    if (sub(/^-u[ \t]+[^ \t]+([ \t]+|$)/, "", seg)) { stripped = 1; continue }
+                    if (sub(/^-i([ \t]+|$)/, "", seg))              { stripped = 1; continue }
+                    if (sub(/^--([ \t]+|$)/, "", seg))              { break }
+                    if (sub(/^[A-Za-z_][A-Za-z0-9_]*=[^ \t]*([ \t]+|$)/, "", seg)) { stripped = 1; continue }
+                }
+            }
+            sub(/^[ \t]+/, "", seg)
+            m = split(seg, toks, /[ \t]+/)
+            if (m == 0) continue
+            cmd = toks[1]
+            if (cmd == "halt" || cmd == "reboot" || cmd == "poweroff" || cmd == "shutdown") {
+                print "system lifecycle command: " cmd
+                continue
+            }
+            if (cmd == "init" && (toks[2] == "0" || toks[2] == "6")) {
+                print "system lifecycle command: init " toks[2]
+                continue
+            }
+            if (cmd == "az" || cmd == "gcloud") {
+                for (j = 2; j <= m; j++) {
+                    if (toks[j] == "delete") {
+                        print "cloud resource deletion: " cmd " delete"
+                        break
+                    }
+                }
+            }
+        }
+    }'
+}
+
+_LIFECYCLE_REASON=$(lifecycle_or_cloud_reason "$COMMAND_NO_COMMENT" | head -1)
+if [[ -n "$_LIFECYCLE_REASON" ]]; then
+    deny "BLOCKED: $_LIFECYCLE_REASON"
+fi
+
+# =============================================================================
+# DATABASE DESTRUCTION - Gated by the SQL DDL/DML guard toggle
+#
+# Kept separate from ALWAYS_BLOCK_PATTERNS so DB-engine repos can opt out
+# (guards.sqlDdl:false / LOOM_GUARD_SQL=0). A single alternation grep matches
+# all four DDL statements in one pass (cheaper than a per-pattern loop), and
+# sql_guard_enabled() is consulted only after a match, so the config read stays
+# off the hot path.
+# =============================================================================
+SQL_DDL_PATTERN='DROP DATABASE|DROP TABLE|DROP SCHEMA|TRUNCATE TABLE'
+if echo "$COMMAND_NO_COMMENT" | grep -qiE "$SQL_DDL_PATTERN" && sql_guard_enabled; then
+    matched=$(echo "$COMMAND_NO_COMMENT" | grep -oiE "$SQL_DDL_PATTERN" | head -1)
+    deny "BLOCKED: Command matches dangerous pattern: ${matched:-SQL DDL statement}"
+fi
+
+# =============================================================================
+# rm -rf SCOPE CHECK - Block rm with recursive/force flags on protected paths
+#
+# Only *actual local* `rm` command words are inspected. `extract_rm_targets`
+# splits the command on ; | & && || and, for each simple-command segment whose
+# command word is `rm` (optionally sudo-prefixed) AND which carries a
+# recursive/force flag, emits the non-flag argument tokens. Consequences (#3553):
+#   - A token from an earlier command in the same line (e.g. the `host-ip.txt`
+#     in `HOST=$(cat host-ip.txt); ssh $HOST rm -rf …`) is never mis-read as an
+#     rm target — only tokens of a real `rm` segment are considered.
+#   - An `rm` inside a remote payload (`ssh host 'rm -rf /home/ubuntu/foo'`) is
+#     NOT treated as a local rm: the wrapper's command word is `ssh`/`scp`, not
+#     `rm`, so no local target is emitted and the local scope check is skipped.
+#     The ALWAYS_BLOCK catastrophic patterns above still scan the whole string,
+#     so a remote or quoted `rm -rf /` still denies.
+#   - Only root, the user's $HOME, and *top-level* directories (/tmp, /var, /etc,
+#     /usr, /home, /opt, /bin, …) are blocked. A scoped subpath such as
+#     `rm -rf /tmp/whatever` or `rm -rf /var/foo` is allowed — the guard stops
+#     obliteration of a whole system/root directory, not cleanup of a subpath.
 # =============================================================================
 
-# Match rm commands with -r or -f flags (in any combination: -rf, -r -f, -fr, etc.)
-if echo "$COMMAND" | grep -qE 'rm\s+(-[a-zA-Z]*[rf][a-zA-Z]*\s+)+' || \
-   echo "$COMMAND" | grep -qE 'rm\s+-[a-zA-Z]*r[a-zA-Z]*\s' || \
-   echo "$COMMAND" | grep -qE 'rm\s+-[a-zA-Z]*f[a-zA-Z]*\s+-[a-zA-Z]*r[a-zA-Z]*\s'; then
+extract_rm_targets() {
+    # Emit one rm-target token per line for every local `rm -r/-f` invocation.
+    # Portable awk only (no GNU/BSD-specific escapes); replaces the shell
+    # separators with newlines, then inspects each simple command.
+    printf '%s' "$1" | awk '
+    {
+        gsub(/&&|\|\||[;|&]/, "\n")
+        n = split($0, segs, "\n")
+        for (i = 1; i <= n; i++) {
+            seg = segs[i]
+            sub(/^[ \t]+/, "", seg)
+            sub(/^sudo[ \t]+/, "", seg)
+            sub(/^[ \t]+/, "", seg)
+            if (seg !~ /^rm([ \t]|$)/) continue
+            m = split(seg, toks, /[ \t]+/)
+            has_rf = 0
+            for (j = 2; j <= m; j++)
+                if (toks[j] ~ /^-/ && toks[j] ~ /[rRfF]/) has_rf = 1
+            if (!has_rf) continue
+            for (j = 2; j <= m; j++) {
+                if (toks[j] == "") continue
+                if (toks[j] ~ /^-/) continue
+                print toks[j]
+            }
+        }
+    }'
+}
 
-    # Extract target paths from the rm command (skip flags)
-    TARGETS=$(echo "$COMMAND" | sed 's/rm\s\+//' | tr ' ' '\n' | grep -v '^-' | head -20)
+normalize_abs_path() {
+    # Lexically normalize an ABSOLUTE path without touching the filesystem:
+    #   - collapse duplicate slashes    (//etc        -> /etc)
+    #   - drop "." segments             (/usr/./      -> /usr)
+    #   - resolve ".." segments         (/tmp/..      -> /,   /tmp/../etc -> /etc)
+    #   - ".." at or above root stays at root (/a/../../../etc -> /etc)
+    #   - strip trailing slash except bare root (/tmp/ -> /tmp)
+    # Pure-bash and portable: `realpath -m` is GNU-only and silently no-ops on
+    # macOS, so this MUST NOT rely on it. Without this normalization any
+    # `..`/`//`/`.` traversal (e.g. `rm -rf /tmp/..` -> `/`) would slip past the
+    # protected-path check below and wrongly ALLOW root/system-dir deletion.
+    local path="$1"
+    local seg
+    local -a parts=() out=()
+    local oldIFS="$IFS"
+    IFS='/'
+    read -r -a parts <<< "$path"
+    IFS="$oldIFS"
+    for seg in "${parts[@]}"; do
+        case "$seg" in
+            ''|'.')
+                : ;;                                    # skip empties (// or leading /) and "."
+            '..')
+                if [[ ${#out[@]} -gt 0 ]]; then
+                    out=("${out[@]:0:$(( ${#out[@]} - 1 ))}")   # pop last segment
+                fi
+                ;;                                       # ".." at/above root: stay at root
+            *)
+                out+=("$seg") ;;
+        esac
+    done
+    if [[ ${#out[@]} -eq 0 ]]; then
+        printf '/'
+    else
+        printf '/%s' "${out[@]}"
+    fi
+}
 
-    for target in $TARGETS; do
+# Cheap pre-check keeps awk off the hot path for the ~99% of commands that have
+# no recursive/force rm at all.
+if echo "$COMMAND" | grep -qE 'rm[[:space:]]+-[a-zA-Z]*[rf]'; then
+    RM_TARGETS=$(extract_rm_targets "$COMMAND" | head -20)
+
+    for target in $RM_TARGETS; do
         # Skip empty targets
         [[ -z "$target" ]] && continue
 
@@ -210,26 +583,90 @@ if echo "$COMMAND" | grep -qE 'rm\s+(-[a-zA-Z]*[rf][a-zA-Z]*\s+)+' || \
                 continue ;;
         esac
 
-        # Resolve path to absolute
+        # Resolve path to absolute (raw — normalization happens next).
         ABS_PATH=""
         if [[ "$target" = /* ]]; then
             ABS_PATH="$target"
         elif [[ -n "$CWD" ]]; then
-            ABS_PATH=$(cd "$CWD" 2>/dev/null && realpath -m "$target" 2>/dev/null || echo "$CWD/$target")
+            ABS_PATH="$CWD/$target"
         fi
 
-        # Block dangerous absolute paths
-        if [[ "$ABS_PATH" == "/" ]] || [[ "$ABS_PATH" == "/home" ]] || \
-           [[ "$ABS_PATH" == "$HOME" ]] || [[ "$ABS_PATH" == "/tmp" ]] || \
-           [[ "$ABS_PATH" == "/usr" ]] || [[ "$ABS_PATH" == "/var" ]] || \
-           [[ "$ABS_PATH" == "/etc" ]] || [[ "$ABS_PATH" == "/opt" ]]; then
-            deny "BLOCKED: rm on protected system path: $ABS_PATH"
+        # Lexically normalize the absolute target BEFORE the protected-path
+        # check. This collapses //, resolves . and .., and strips trailing
+        # slashes, so traversal/normalization tricks cannot smuggle a
+        # root/system-dir deletion past the check below:
+        #   /tmp/..  -> /        //etc     -> /etc
+        #   /usr/./  -> /usr      /a/../../../etc -> /etc
+        # Done in pure shell because `realpath -m` is GNU-only (no-ops on macOS).
+        if [[ "$ABS_PATH" = /* ]]; then
+            ABS_PATH=$(normalize_abs_path "$ABS_PATH")
         fi
 
-        # Block if outside repo root (when we know the repo root)
-        if [[ -n "$REPO_ROOT" ]] && [[ -n "$ABS_PATH" ]]; then
-            if [[ "$ABS_PATH" != "$REPO_ROOT"* ]]; then
-                deny "BLOCKED: rm target outside repository: $ABS_PATH (repo: $REPO_ROOT)"
+        # Block catastrophic targets only: root, the user's home directory, and
+        # any top-level directory (^/<one-segment>$ — covers /tmp, /home, /usr,
+        # /var, /etc, /opt, /bin, /lib, …). Deeper paths are allowed.
+        if [[ -n "$ABS_PATH" ]]; then
+            if [[ "$ABS_PATH" == "/" ]] || \
+               [[ -n "$HOME" && "$ABS_PATH" == "$HOME" ]] || \
+               [[ "$ABS_PATH" =~ ^/[^/]+$ ]]; then
+                deny "BLOCKED: rm on protected system path: $ABS_PATH"
+            fi
+
+            # Opt-in repo-scoped strict mode (guards.rmScope:"repo" /
+            # LOOM_RM_SCOPE=repo). The catastrophic top-level deny above stays
+            # unconditional; here we additionally DENY any target that is
+            # neither under the repo / worktree areas nor on the built-in
+            # ephemeral allowlist. Default OFF preserves the permissive
+            # behaviour byte-for-byte (rm_scope_repo_enabled() returns false).
+            if rm_scope_repo_enabled; then
+                IN_SCOPE=false
+
+                # Repo + worktree areas. Prefix matches carry a trailing slash
+                # (or match the dir itself) so a sibling dir sharing a name
+                # prefix — e.g. "<repo>-sibling" vs "<repo>" — is NOT admitted.
+                if [[ -n "$REPO_ROOT" ]]; then
+                    if [[ "$ABS_PATH" == "$REPO_ROOT" || "$ABS_PATH" == "$REPO_ROOT"/* ]]; then
+                        IN_SCOPE=true
+                    fi
+                    # The default in-repo worktrees dir is always in scope, even
+                    # when an external worktree.root / LOOM_WORKTREE_ROOT is set.
+                    if [[ "$IN_SCOPE" == false ]] && \
+                       { [[ "$ABS_PATH" == "$REPO_ROOT/.loom/worktrees" || "$ABS_PATH" == "$REPO_ROOT/.loom/worktrees"/* ]]; }; then
+                        IN_SCOPE=true
+                    fi
+                    # Configured/overridden worktree root (external volumes).
+                    if [[ "$IN_SCOPE" == false ]]; then
+                        if [[ -z "${_WT_ROOT+x}" ]]; then
+                            _WT_ROOT=$(resolve_worktree_root "$REPO_ROOT")
+                        fi
+                        if [[ -n "$_WT_ROOT" ]] && \
+                           { [[ "$ABS_PATH" == "$_WT_ROOT" || "$ABS_PATH" == "$_WT_ROOT"/* ]]; }; then
+                            IN_SCOPE=true
+                        fi
+                    fi
+                fi
+
+                # Built-in ephemeral allowlist: system temp roots + the Claude
+                # scratchpad. normalize_abs_path() is LEXICAL — it does NOT
+                # resolve symlinks — so on macOS both the symlink form (/tmp,
+                # /var/tmp, /var/folders) AND its /private target must be listed.
+                # A bare temp root (/tmp, /private/tmp, …) is NOT matched here:
+                # those have no trailing component, so the catastrophic
+                # top-level deny above already handled bare /tmp, and a bare
+                # /private/tmp falls through to the out-of-scope deny.
+                if [[ "$IN_SCOPE" == false ]]; then
+                    case "$ABS_PATH" in
+                        /tmp/*|/private/tmp/*|\
+                        /var/tmp/*|/private/var/tmp/*|\
+                        /var/folders/*|/private/var/folders/*|\
+                        */claude-*/*/scratchpad/*)
+                            IN_SCOPE=true ;;
+                    esac
+                fi
+
+                if [[ "$IN_SCOPE" == false ]]; then
+                    deny "BLOCKED: rm target outside repo scope (LOOM_RM_SCOPE=repo): $ABS_PATH"
+                fi
             fi
         fi
     done
@@ -239,9 +676,13 @@ fi
 # DELETE without WHERE - Database safety
 # =============================================================================
 
-if echo "$COMMAND" | grep -qiE 'DELETE\s+FROM\s+' && \
-   ! echo "$COMMAND" | grep -qiE 'WHERE\s+'; then
-    deny "BLOCKED: DELETE FROM without WHERE clause"
+# Gated by the SQL DDL/DML guard toggle. DB-engine repos opt out via
+# guards.sqlDdl:false or LOOM_GUARD_SQL=0. sql_guard_enabled() is consulted only
+# after the DELETE-FROM-without-WHERE match, keeping the config read off the hot
+# path for non-SQL commands.
+if echo "$COMMAND_NO_COMMENT" | grep -qiE 'DELETE[[:space:]]+FROM[[:space:]]+' && \
+   ! echo "$COMMAND_NO_COMMENT" | grep -qiE 'WHERE[[:space:]]+'; then
+    sql_guard_enabled && deny "BLOCKED: DELETE FROM without WHERE clause"
 fi
 
 # =============================================================================
@@ -263,17 +704,9 @@ ASK_PATTERNS=(
     'gh release delete'
     'gh label delete'
 
-    # Cloud CLI operations
-    'aws s3'
-    'aws ec2'
-    'aws lambda'
-
-    # Docker operations
-    'docker rm'
-    'docker rmi'
-    'docker stop'
-    'docker kill'
-    'docker restart'
+    # NOTE: cloud CLI (aws) + docker ASK patterns are NOT in this ungated array.
+    # They live in CLOUD_ASK_PATTERNS below, gated by cloud_guard_enabled() so
+    # cloud-dev repos can opt down (LOOM_GUARD_CLOUD=0 / guards.cloudCli:false).
 
     # Service management
     'systemctl restart'
@@ -298,8 +731,57 @@ ASK_PATTERNS=(
 )
 
 for pattern in "${ASK_PATTERNS[@]}"; do
-    if echo "$COMMAND" | grep -qE "$pattern"; then
+    if echo "$COMMAND_NO_COMMENT" | grep -qE "$pattern"; then
         ask "Command requires confirmation: $COMMAND"
+    fi
+done
+
+# =============================================================================
+# CLOUD CLI ASK patterns — gated by the cloud CLI guard toggle
+#
+# Kept separate from ASK_PATTERNS so cloud-dev repos can opt out
+# (guards.cloudCli:false / LOOM_GUARD_CLOUD=0). cloud_guard_enabled() is
+# consulted only AFTER a cloud pattern matches, so the config read stays off the
+# hot path for non-cloud commands (mirrors the SQL DDL block above).
+#
+# The aws entries are VERB-ANCHORED (case-sensitive ERE against the
+# comment-stripped command): only mutating subcommands match, never read-only
+# describe*/get*/list*/ls. So `aws ec2 describe-instances`, `aws s3 ls`, and
+# `aws lambda list-functions` no longer prompt, while `run-instances`,
+# `create-*`, `terminate-instances`, `stop-instances`, `lambda invoke`,
+# `lambda publish*`, `sns publish`, etc. still ask.
+#
+# The docker entries already name only mutating verbs (rm/rmi/stop/kill/restart)
+# and never match read-only `docker ps`/`docker logs`, so they are unchanged —
+# they only move under this toggle.
+# =============================================================================
+CLOUD_ASK_PATTERNS=(
+    # aws mutating subcommands (verb-anchored). The service list covers the
+    # common infra-mutating namespaces; the verb list is the mutating vocabulary
+    # (never describe*/get*/list*/ls). terminate lands here — an ask, not a deny.
+    # invoke/publish are mutating (lambda invoke runs arbitrary code with side
+    # effects; lambda publish-version / publish-layer-version and sns publish
+    # mutate state) — there is no read-only `aws <svc> invoke|publish`, so they
+    # cannot introduce describe/get/list false-positives. copy (ec2
+    # copy-image/copy-snapshot) and assign (ec2 assign-*-addresses) are likewise
+    # mutating-only. All were caught by the pre-#3593 bare `aws ec2|lambda`
+    # prefixes and must stay asks (#3595).
+    'aws (ec2|lambda|s3api|rds|iam|autoscaling|cloudformation|eks|ecs|elb|elbv2|route53|dynamodb|sns|sqs) (run|create|delete|terminate|stop|start|modify|update|put|reboot|authorize|revoke|attach|detach|associate|disassociate|register|deregister|enable|disable|add|remove|set|import|restore|reset|cancel|scale|invoke|publish|copy|assign)'
+    # aws s3 (high-level) mutating verbs. `ls` is intentionally excluded. `mb`
+    # (make-bucket) is mutating and was caught by the old bare `aws s3` prefix.
+    'aws s3 (rm|rb|cp|mv|sync|mb)'
+
+    # Docker operations (already mutating-verb only; does not match docker ps/logs)
+    'docker rm'
+    'docker rmi'
+    'docker stop'
+    'docker kill'
+    'docker restart'
+)
+
+for pattern in "${CLOUD_ASK_PATTERNS[@]}"; do
+    if echo "$COMMAND_NO_COMMENT" | grep -qE "$pattern" && cloud_guard_enabled; then
+        ask "Command requires confirmation: $COMMAND (set guards.cloudCli:false in .loom/config.json if this repo manages cloud infra as a first-class workflow)"
     fi
 done
 
@@ -307,7 +789,9 @@ done
 # NOTE: The two Loom-workflow-specific guards (the 'gh pr merge' → merge-pr.sh
 # redirect, and the 'pip install -e' worktree block keyed on LOOM_WORKTREE_PATH)
 # were extracted into guard-loom-workflow.sh (issue #3604). They are registered
-# as a separate PreToolUse/Bash hook and fire independently of this guard.
+# as a separate PreToolUse/Bash hook and fire independently of this guard. This
+# file is the generic repository-hygiene guard, on its way to Repo Skills
+# (rjwalters/repo#13); the Loom-specific pair stays Loom-owned.
 # =============================================================================
 
 # =============================================================================

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -904,7 +904,7 @@ If setup fails, it's usually due to:
 
 Loom ships with two built-in Bash `PreToolUse` guard hooks, both registered under the `Bash` matcher and firing independently:
 
-- **`guard-destructive.sh`** — the generic repository-hygiene guard: catastrophic denies (`rm -rf /`, force-push to `main`, `gh repo delete`, fork bombs, curl-pipe-to-shell, cloud/SQL destruction), the segment-parsed lifecycle/cloud-CLI checks, and the `guards.sqlDdl` / `guards.cloudCli` toggle machinery. Nothing about this guard is Loom-specific; it is slated to move to Repo Skills (companion issue [rjwalters/repo#13](https://github.com/rjwalters/repo/issues/13)), which will own the generic half once it ships. Until then it keeps shipping and working in Loom exactly as before.
+- **`guard-destructive.sh`** — the generic repository-hygiene guard: catastrophic denies (`rm -rf /`, force-push to `main`, `gh repo delete`, fork bombs, curl-pipe-to-shell, cloud/SQL destruction), the segment-parsed lifecycle/cloud-CLI checks, and the `guards.sqlDdl` / `guards.cloudCli` / `guards.rmScope` toggle machinery. Nothing about this guard is Loom-specific; it is slated to move to Repo Skills (companion issue [rjwalters/repo#13](https://github.com/rjwalters/repo/issues/13)), which will own the generic half once it ships. Until then it keeps shipping and working in Loom exactly as before.
 - **`guard-loom-workflow.sh`** — the thin, Loom-workflow-specific guard (issue #3604): the `gh pr merge` → `merge-pr.sh` redirect and the `pip install -e` worktree block (keyed on `LOOM_WORKTREE_PATH`, issue #2495). These two guards are specific to the Loom worktree/merge workflow and stay Loom-owned.
 
 You can also add project-specific guards to protect read-only directories from accidental edits (see below).
@@ -977,6 +977,58 @@ LOOM_GUARD_CLOUD=0 aws ec2 terminate-instances --instance-ids i-1234
 
 # Force the cloud guard on for one command even when the repo opts out
 LOOM_GUARD_CLOUD=1 aws ec2 terminate-instances --instance-ids i-1234
+```
+
+### Repo-Scoped rm Guard (`guards.rmScope` / `LOOM_RM_SCOPE`)
+
+By default, `guard-destructive.sh` blocks only **catastrophic** `rm -rf` targets — root (`/`), the user's `$HOME`, and any bare top-level directory (`/tmp`, `/var`, `/etc`, …). Every deeper subpath is allowed, **including subpaths outside the repository** (e.g. `rm -rf /Users/someone/important`). This permissive default is intentional and ships unchanged.
+
+Repos that want a tighter blast radius can opt in to **`repo` mode**, which additionally denies any `rm -rf` target that is neither inside the repo/worktree areas nor on a built-in **ephemeral allowlist**. The catastrophic top-level deny stays active in both modes, so bare `/tmp` and `/` are always blocked.
+
+The rm-scope guard is **off by default**. It is resolved in this order (highest precedence first):
+
+1. **`LOOM_RM_SCOPE` env var** — `repo` enables repo mode; `off`/`0`/`no` (or unset) disables it. Overrides the config value.
+2. **`.loom/config.json`** — `guards.rmScope` (default absent = off). Set it to `"repo"` to enable:
+   ```json
+   {
+     "guards": {
+       "rmScope": "repo"
+     }
+   }
+   ```
+3. **Default** — off (current permissive behavior, byte-for-byte).
+
+The config read is best-effort: a missing, empty, or malformed `.loom/config.json` falls through to **off** (no behavior change) and never causes the hook to exit non-zero. Enabling repo mode does not weaken any other guard.
+
+**In-scope targets** (allowed under `repo` mode):
+
+- Anything under the **repo root** (resolved from the command's `cwd`).
+- Anything under the **worktree root** — resolved with the same precedence as `loom_worktree_root()`: `LOOM_WORKTREE_ROOT` env → `.loom/config.json → worktree.root` → the default `<repo>/.loom/worktrees`. This admits an external scratch volume (e.g. `worktree.root: "/Volumes/scratch/wt"`).
+- The **ephemeral allowlist**: system temp roots and the Claude scratchpad.
+
+**Ephemeral allowlist prefixes**. `normalize_abs_path()` is **lexical only** — it does **not** resolve symlinks — so on macOS each temp root is listed in **both** its symlink form and its `/private` target:
+
+| Symlink form | `/private` target |
+|--------------|-------------------|
+| `/tmp/…` | `/private/tmp/…` |
+| `/var/tmp/…` | `/private/var/tmp/…` |
+| `/var/folders/…` (`$TMPDIR`) | `/private/var/folders/…` |
+
+Plus the Claude scratchpad glob `*/claude-*/*/scratchpad/*`. A **bare** temp root (`/tmp`, `/private/tmp`, …) is never admitted here — bare `/tmp` is already caught by the catastrophic top-level deny, and prefix matches carry a trailing `/` so a name-prefix sibling like `/tmpfoo/x` is **not** admitted by the `/tmp/` entry.
+
+**Examples**:
+
+```bash
+# Opt in for a whole repo
+#   .loom/config.json  ->  { "guards": { "rmScope": "repo" } }
+
+# One-off: strict scope for a single command
+LOOM_RM_SCOPE=repo rm -rf /Users/someone/important   # DENIED (outside repo)
+LOOM_RM_SCOPE=repo rm -rf /tmp/build-cache/x          # allowed (ephemeral)
+LOOM_RM_SCOPE=repo rm -rf ./dist                      # allowed (under repo)
+
+# Env override wins over config — force OFF even when the repo opts in
+LOOM_RM_SCOPE=off rm -rf /Users/someone/scratch       # allowed (guard disabled)
 ```
 
 ### Protecting Read-Only Directories

--- a/defaults/hooks/guard-destructive.sh
+++ b/defaults/hooks/guard-destructive.sh
@@ -160,6 +160,79 @@ cloud_guard_enabled() {
     [[ "$_CLOUD_GUARD_CACHE" == "true" ]]
 }
 
+# =============================================================================
+# rm-scope repo mode toggle — default OFF (opt-in).
+#
+# By default this guard blocks only catastrophic rm targets (root, $HOME, and
+# bare top-level dirs) and ALLOWS every deeper subpath — including subpaths
+# OUTSIDE the repo (e.g. `rm -rf /Users/someone/important`). That permissive
+# default ships unchanged so existing installs see zero behaviour change.
+#
+# Opt-in `repo` mode (guards.rmScope:"repo" / LOOM_RM_SCOPE=repo) additionally
+# DENIES any rm target that is neither under the repo / worktree areas nor on a
+# built-in ephemeral allowlist (system temp dirs + the Claude scratchpad). The
+# catastrophic top-level deny stays unconditional in BOTH modes, so bare /tmp
+# and / are still blocked.
+#
+# Resolution order (highest precedence first):
+#   1. LOOM_RM_SCOPE env var (repo enables; off/0/no disables). Overrides config.
+#   2. .loom/config.json  ->  guards.rmScope == "repo"  (else off)
+#   3. Default: off (permissive, current behaviour)
+#
+# Mirrors sql_guard_enabled() / cloud_guard_enabled(): cached in
+# _RM_SCOPE_CACHE, invoked LAZILY only after a candidate rm target survives the
+# catastrophic check, so the jq config read never touches the hot path for
+# non-rm commands. The config read is best-effort: any parse failure falls
+# through to OFF (no behaviour change) and never trips the ERR trap.
+# =============================================================================
+_RM_SCOPE_CACHE=""
+rm_scope_repo_enabled() {
+    if [[ -z "$_RM_SCOPE_CACHE" ]]; then
+        local mode=off
+        if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/config.json" ]]; then
+            # Only an explicit guards.rmScope == "repo" enables the mode; any
+            # other value, a missing key, or malformed JSON stays OFF (the jq
+            # non-zero exit is caught by the `||` fallback).
+            mode=$(jq -r 'if .guards.rmScope == "repo" then "repo" else "off" end' "$REPO_ROOT/.loom/config.json" 2>/dev/null) || mode=off
+            [[ -n "$mode" ]] || mode=off
+        fi
+        # Env override wins over config.
+        case "${LOOM_RM_SCOPE:-}" in
+            repo)         mode=repo ;;
+            off|0|no)     mode=off ;;
+        esac
+        _RM_SCOPE_CACHE="$mode"
+    fi
+    [[ "$_RM_SCOPE_CACHE" == "repo" ]]
+}
+
+# Resolve the Loom worktree base dir for repo-scope checks. Mirrors the
+# precedence of loom_worktree_root() in defaults/scripts/lib/worktree-root.sh
+# (env -> config -> default), replicated inline so the hook stays
+# self-contained and best-effort: any failure falls back to the default in-repo
+# path and never fails the hook. Only called in repo mode, once per rm scan.
+resolve_worktree_root() {
+    local repo_root="$1"
+    [[ -z "$repo_root" ]] && return 0
+    # 1. Env override (highest priority); must be absolute.
+    if [[ -n "${LOOM_WORKTREE_ROOT:-}" && "$LOOM_WORKTREE_ROOT" == /* ]]; then
+        printf '%s/%s' "${LOOM_WORKTREE_ROOT%/}" "$(basename "$repo_root")"
+        return 0
+    fi
+    # 2. Config key .loom/config.json -> worktree.root (absolute only).
+    local config_file="$repo_root/.loom/config.json"
+    if [[ -f "$config_file" ]]; then
+        local cfg_root
+        cfg_root=$(jq -r '.worktree.root? // empty' "$config_file" 2>/dev/null) || cfg_root=""
+        if [[ -n "$cfg_root" && "$cfg_root" == /* ]]; then
+            printf '%s/%s' "${cfg_root%/}" "$(basename "$repo_root")"
+            return 0
+        fi
+    fi
+    # 3. Default — in-repo worktrees dir.
+    printf '%s/.loom/worktrees' "$repo_root"
+}
+
 # Helper: output a deny decision and exit
 deny() {
     local reason="$1"
@@ -537,6 +610,63 @@ if echo "$COMMAND" | grep -qE 'rm[[:space:]]+-[a-zA-Z]*[rf]'; then
                [[ -n "$HOME" && "$ABS_PATH" == "$HOME" ]] || \
                [[ "$ABS_PATH" =~ ^/[^/]+$ ]]; then
                 deny "BLOCKED: rm on protected system path: $ABS_PATH"
+            fi
+
+            # Opt-in repo-scoped strict mode (guards.rmScope:"repo" /
+            # LOOM_RM_SCOPE=repo). The catastrophic top-level deny above stays
+            # unconditional; here we additionally DENY any target that is
+            # neither under the repo / worktree areas nor on the built-in
+            # ephemeral allowlist. Default OFF preserves the permissive
+            # behaviour byte-for-byte (rm_scope_repo_enabled() returns false).
+            if rm_scope_repo_enabled; then
+                IN_SCOPE=false
+
+                # Repo + worktree areas. Prefix matches carry a trailing slash
+                # (or match the dir itself) so a sibling dir sharing a name
+                # prefix — e.g. "<repo>-sibling" vs "<repo>" — is NOT admitted.
+                if [[ -n "$REPO_ROOT" ]]; then
+                    if [[ "$ABS_PATH" == "$REPO_ROOT" || "$ABS_PATH" == "$REPO_ROOT"/* ]]; then
+                        IN_SCOPE=true
+                    fi
+                    # The default in-repo worktrees dir is always in scope, even
+                    # when an external worktree.root / LOOM_WORKTREE_ROOT is set.
+                    if [[ "$IN_SCOPE" == false ]] && \
+                       { [[ "$ABS_PATH" == "$REPO_ROOT/.loom/worktrees" || "$ABS_PATH" == "$REPO_ROOT/.loom/worktrees"/* ]]; }; then
+                        IN_SCOPE=true
+                    fi
+                    # Configured/overridden worktree root (external volumes).
+                    if [[ "$IN_SCOPE" == false ]]; then
+                        if [[ -z "${_WT_ROOT+x}" ]]; then
+                            _WT_ROOT=$(resolve_worktree_root "$REPO_ROOT")
+                        fi
+                        if [[ -n "$_WT_ROOT" ]] && \
+                           { [[ "$ABS_PATH" == "$_WT_ROOT" || "$ABS_PATH" == "$_WT_ROOT"/* ]]; }; then
+                            IN_SCOPE=true
+                        fi
+                    fi
+                fi
+
+                # Built-in ephemeral allowlist: system temp roots + the Claude
+                # scratchpad. normalize_abs_path() is LEXICAL — it does NOT
+                # resolve symlinks — so on macOS both the symlink form (/tmp,
+                # /var/tmp, /var/folders) AND its /private target must be listed.
+                # A bare temp root (/tmp, /private/tmp, …) is NOT matched here:
+                # those have no trailing component, so the catastrophic
+                # top-level deny above already handled bare /tmp, and a bare
+                # /private/tmp falls through to the out-of-scope deny.
+                if [[ "$IN_SCOPE" == false ]]; then
+                    case "$ABS_PATH" in
+                        /tmp/*|/private/tmp/*|\
+                        /var/tmp/*|/private/var/tmp/*|\
+                        /var/folders/*|/private/var/folders/*|\
+                        */claude-*/*/scratchpad/*)
+                            IN_SCOPE=true ;;
+                    esac
+                fi
+
+                if [[ "$IN_SCOPE" == false ]]; then
+                    deny "BLOCKED: rm target outside repo scope (LOOM_RM_SCOPE=repo): $ABS_PATH"
+                fi
             fi
         fi
     done

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -803,6 +803,118 @@ done
 echo ""
 
 # =========================================================================
+echo -e "${YELLOW}--- Repo-scoped rm guard (guards.rmScope / LOOM_RM_SCOPE) (#3610) ---${NC}"
+# =========================================================================
+#
+# The guard ships with rmScope OFF: only catastrophic top-level targets deny,
+# every deeper subpath (in- OR out-of-repo) is allowed. Opt-in `repo` mode adds
+# an outside-repo deny with a built-in ephemeral allowlist (system temp dirs +
+# the Claude scratchpad). The 8-case matrix from the issue is asserted in BOTH
+# toggle states, plus worktree-root and env-override cases.
+#
+# NB: normalize_abs_path() is LEXICAL (no symlink resolution), so the allowlist
+# lists both /tmp and /private/tmp (and the /var/tmp, /var/folders pairs). These
+# temp-root cases pass in both toggle states — under OFF because a deep subpath
+# is always allowed, under repo because they are on the ephemeral allowlist.
+
+# ---- Matrix in the DEFAULT (off) state: unchanged permissive behaviour. ----
+# rmScope absent → off. Uses the real REPO_ROOT (loom checkout) as cwd.
+assert_allow "rmScope off: rm -f /tmp/x/foo.tsv allowed" \
+    "rm -f /tmp/x/foo.tsv" "$REPO_ROOT"
+assert_allow "rmScope off: rm -rf scratchpad path allowed" \
+    "rm -rf /private/tmp/claude-501/-Users-x/abc/scratchpad/z" "$REPO_ROOT"
+assert_allow "rmScope off: rm -rf \$TMPDIR /var/folders path allowed" \
+    "rm -rf /var/folders/ab/cd/T/tmp.123" "$REPO_ROOT"
+assert_deny "rmScope off: rm -rf bare /tmp still denied (top-level rule)" \
+    "rm -rf /tmp" "$REPO_ROOT"
+assert_deny "rmScope off: rm -rf / still denied (catastrophic rule)" \
+    "rm -rf /" "$REPO_ROOT"
+# The key backward-compat row: an outside-repo deep path is ALLOWED when off.
+assert_allow "rmScope off: rm -rf outside-repo path allowed (unchanged)" \
+    "rm -rf /opt/some-vendor/important" "$REPO_ROOT"
+assert_allow "rmScope off: rm -rf under repo root allowed" \
+    "rm -rf $REPO_ROOT/.loom/tmp/x" "$REPO_ROOT"
+assert_allow "rmScope off: rm -rf external worktree-root path allowed (deep path)" \
+    "rm -rf /Volumes/scratch/wt/foo/issue-5/x" "$REPO_ROOT"
+
+# Explicit guards.rmScope:"off" behaves identically to absent.
+RMSCOPE_OFF_REPO=$(make_sql_repo '{"guards":{"rmScope":"off"}}')
+assert_allow "rmScope config-off: outside-repo path allowed" \
+    "rm -rf /opt/some-vendor/important" "$RMSCOPE_OFF_REPO"
+assert_deny "rmScope config-off: bare /tmp still denied" \
+    "rm -rf /tmp" "$RMSCOPE_OFF_REPO"
+
+# ---- Matrix in the repo (on) state, driven by the env toggle. ----
+assert_allow_env "rmScope repo: rm -f /tmp/x/foo.tsv allowed (ephemeral)" \
+    "LOOM_RM_SCOPE=repo" "rm -f /tmp/x/foo.tsv" "$REPO_ROOT"
+assert_allow_env "rmScope repo: scratchpad path allowed (ephemeral)" \
+    "LOOM_RM_SCOPE=repo" "rm -rf /private/tmp/claude-501/-Users-x/abc/scratchpad/z" "$REPO_ROOT"
+assert_allow_env "rmScope repo: \$TMPDIR /var/folders path allowed (ephemeral)" \
+    "LOOM_RM_SCOPE=repo" "rm -rf /var/folders/ab/cd/T/tmp.123" "$REPO_ROOT"
+assert_deny_env "rmScope repo: bare /tmp denied (top-level rule)" \
+    "LOOM_RM_SCOPE=repo" "rm -rf /tmp" "$REPO_ROOT"
+assert_deny_env "rmScope repo: / denied (catastrophic rule)" \
+    "LOOM_RM_SCOPE=repo" "rm -rf /" "$REPO_ROOT"
+# The new row: an outside-repo deep path is now DENIED under repo mode.
+assert_deny_env "rmScope repo: outside-repo path denied (NEW)" \
+    "LOOM_RM_SCOPE=repo" "rm -rf /opt/some-vendor/important" "$REPO_ROOT"
+assert_deny_env "rmScope repo: outside-repo /Users path denied (NEW)" \
+    "LOOM_RM_SCOPE=repo" "rm -rf /Users/someone/important" "$REPO_ROOT"
+assert_allow_env "rmScope repo: under repo root allowed" \
+    "LOOM_RM_SCOPE=repo" "rm -rf $REPO_ROOT/.loom/tmp/x" "$REPO_ROOT"
+assert_allow_env "rmScope repo: relative subpath under repo allowed" \
+    "LOOM_RM_SCOPE=repo" "rm -rf build-artifacts/tmp/x" "$REPO_ROOT"
+
+# Prefix-boundary precision: /tmpfoo is NOT admitted by the /tmp/ allowlist
+# entry (the trailing slash prevents a name-prefix sibling from slipping in).
+assert_deny_env "rmScope repo: /tmpfoo/x denied (not the /tmp/ allowlist prefix)" \
+    "LOOM_RM_SCOPE=repo" "rm -rf /tmpfoo/x" "$REPO_ROOT"
+
+# ---- Worktree-root cases (configured external volume + env override). ----
+# Configured worktree.root in .loom/config.json admits its subtree. The temp
+# repo's basename namespaces the resolved root (mirrors loom_worktree_root()).
+RMSCOPE_WT_REPO=$(make_sql_repo '{"guards":{"rmScope":"repo"},"worktree":{"root":"/Volumes/scratch/loom-wt"}}')
+RMSCOPE_WT_BN=$(basename "$RMSCOPE_WT_REPO")
+assert_allow "rmScope repo: configured external worktree.root subtree allowed" \
+    "rm -rf /Volumes/scratch/loom-wt/$RMSCOPE_WT_BN/issue-5/foo" "$RMSCOPE_WT_REPO"
+assert_deny "rmScope repo: path outside configured worktree.root still denied" \
+    "rm -rf /Volumes/other/loom-wt/$RMSCOPE_WT_BN/issue-5/foo" "$RMSCOPE_WT_REPO"
+
+# LOOM_WORKTREE_ROOT env override wins over config default. Config enables
+# rmScope; the single env slot carries the worktree-root override.
+RMSCOPE_ENVWT_REPO=$(make_sql_repo '{"guards":{"rmScope":"repo"}}')
+RMSCOPE_ENVWT_BN=$(basename "$RMSCOPE_ENVWT_REPO")
+assert_allow_env "rmScope repo: LOOM_WORKTREE_ROOT env override admits external worktree" \
+    "LOOM_WORKTREE_ROOT=/Volumes/ext/wt" "rm -rf /Volumes/ext/wt/$RMSCOPE_ENVWT_BN/issue-9/x" "$RMSCOPE_ENVWT_REPO"
+
+# ---- Env-overrides-config for the toggle itself. ----
+RMSCOPE_ON_REPO=$(make_sql_repo '{"guards":{"rmScope":"repo"}}')
+# Config repo + no env → outside-repo denied.
+assert_deny "rmScope config-on: outside-repo path denied" \
+    "rm -rf /opt/some-vendor/important" "$RMSCOPE_ON_REPO"
+# LOOM_RM_SCOPE=off overrides config repo → back to permissive (outside allowed).
+assert_allow_env "rmScope: LOOM_RM_SCOPE=off overrides config repo (outside allowed)" \
+    "LOOM_RM_SCOPE=off" "rm -rf /opt/some-vendor/important" "$RMSCOPE_ON_REPO"
+
+# ---- Malformed config falls through to OFF (no behaviour change). ----
+RMSCOPE_BAD_REPO=$(make_sql_repo '{ this is not valid json ')
+assert_allow "rmScope malformed-config: outside-repo path allowed (falls through to off)" \
+    "rm -rf /opt/some-vendor/important" "$RMSCOPE_BAD_REPO"
+
+# ---- Repo mode must NOT weaken unrelated guards. ----
+assert_deny_env "rmScope repo: force-push to main still blocked" \
+    "LOOM_RM_SCOPE=repo" "git push --force origin main" "$REPO_ROOT"
+assert_deny_env "rmScope repo: gh repo delete still blocked" \
+    "LOOM_RM_SCOPE=repo" "gh repo delete myrepo --yes" "$REPO_ROOT"
+
+# Clean up rm-scope temp repos.
+for _rmscope_dir in "$RMSCOPE_OFF_REPO" "$RMSCOPE_WT_REPO" "$RMSCOPE_ENVWT_REPO" "$RMSCOPE_ON_REPO" "$RMSCOPE_BAD_REPO"; do
+    [[ -n "$_rmscope_dir" && "$_rmscope_dir" != "/" && -d "$_rmscope_dir/.loom" ]] && rm -rf "$_rmscope_dir"
+done
+
+echo ""
+
+# =========================================================================
 echo -e "${YELLOW}--- #3553 matching-precision: false positives now ALLOWED ---${NC}"
 # =========================================================================
 


### PR DESCRIPTION
Closes #3610

## Summary

Adds a third opt-in toggle to `guard-destructive.sh` — `guards.rmScope` / `LOOM_RM_SCOPE=repo` — mirroring the existing `sql_guard_enabled()` / `cloud_guard_enabled()` pattern (lazy, cached, env → config → default). **Default OFF preserves current behavior byte-for-byte.**

By default the guard blocks only catastrophic `rm -rf` targets (root, `$HOME`, bare top-level dirs) and allows every deeper subpath — including paths **outside** the repo. When `LOOM_RM_SCOPE=repo` (or `guards.rmScope:"repo"`), an rm target that is neither under the repo/worktree areas nor on a built-in ephemeral allowlist is denied. The catastrophic top-level deny stays unconditional in both modes, so bare `/tmp` and `/` still deny.

## Key design points

- **Lexical-normalization gotcha**: `normalize_abs_path()` does not resolve symlinks, so the ephemeral allowlist lists **both** `/tmp/` and `/private/tmp/` (and the `/var/tmp`, `/var/folders` symlink pairs), plus the scratchpad glob `*/claude-*/*/scratchpad/*`.
- **Worktree areas** resolve via a `resolve_worktree_root()` helper that replicates `loom_worktree_root()`'s `LOOM_WORKTREE_ROOT` env → `worktree.root` config → default `<repo>/.loom/worktrees` precedence inline, keeping the hook self-contained and best-effort (never fails the hook).
- **Prefix precision**: prefix matches carry a trailing `/` so a name-prefix sibling (`/tmpfoo/x`, `<repo>-sibling`) is not admitted.
- Best-effort config read: malformed/missing `.loom/config.json` falls through to OFF; the hook never exits non-zero.

## 8-case matrix (repo mode)

| Target | Decision |
|--------|----------|
| `rm -f /tmp/x/foo.tsv` | ALLOW |
| `rm -rf /private/tmp/…/scratchpad/z` | ALLOW |
| `rm -rf /var/folders/…/T/tmp.123` (`$TMPDIR`) | ALLOW |
| `rm -rf /tmp` (bare) | DENY (top-level) |
| `rm -rf /` | DENY (catastrophic) |
| `rm -rf /Users/someone/important` (outside) | **DENY (new)** |
| `rm -rf <repo>/.loom/tmp/x` | ALLOW |
| `rm -rf /Volumes/.../worktree/foo` (configured root) | ALLOW |

## Files

- `defaults/hooks/guard-destructive.sh` — `rm_scope_repo_enabled()` + `resolve_worktree_root()` helpers and the in-scope/ephemeral-allowlist branch
- `.loom/hooks/guard-destructive.sh` — synced to defaults (was a stale strict variant)
- `tests/hooks/test-guard-destructive.sh` — 28 new assertions: the 8-case matrix in **both** toggle states, worktree-root (config + `LOOM_WORKTREE_ROOT` env override), env-overrides-config, malformed-config, and guard-independence cases
- `defaults/CLAUDE.md` — new **Repo-Scoped rm Guard** section

## Test

`bash tests/hooks/test-guard-destructive.sh` → **247/247 pass** (was 219; +28 new). Performance check 177ms < 200ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)