### PR TITLE
fix(scaffolding): make committed root-CLAUDE.md pointer self-sufficient (#3612)

### DIFF
--- a/loom-daemon/src/init/scaffolding.rs
+++ b/loom-daemon/src/init/scaffolding.rs
@@ -48,10 +48,15 @@ pub const LOOM_SECTION_END: &str = "<!-- END LOOM ORCHESTRATION -->";
 
 /// The short pointer injected into root CLAUDE.md (between section markers).
 ///
-/// The full Loom guide is written to `.loom/CLAUDE.md` in the target repo.
-/// Claude Code auto-discovers `.loom/CLAUDE.md` when agents work in
-/// `.loom/worktrees/issue-N/` via ancestor directory traversal.
-pub const LOOM_ROOT_POINTER: &str = "This repository uses [Loom](https://github.com/rjwalters/loom) for AI-powered development orchestration. See `.loom/CLAUDE.md` for the full guide (roles, labels, worktrees, configuration).";
+/// This block is committed to the consumer repo, so its authoritative reference
+/// is the always-present Loom repository URL — never the install-generated
+/// `.loom/CLAUDE.md`, which may be gitignored or absent in a fresh clone / CI
+/// checkout (issue #3612). Loom additionally writes a locally-substituted copy
+/// of the full guide to `.loom/CLAUDE.md` at install time; Claude Code
+/// auto-discovers that local copy when agents work in `.loom/worktrees/issue-N/`
+/// via ancestor directory traversal, so the auto-discovery behaviour is
+/// unaffected by this wording.
+pub const LOOM_ROOT_POINTER: &str = "This repository uses [Loom](https://github.com/rjwalters/loom) for AI-powered development orchestration — see the Loom repository for the full guide (roles, labels, worktrees, configuration). When installed, Loom also writes a locally-substituted copy of that guide to `.loom/CLAUDE.md`.";
 
 /// Wrap Loom content in section markers
 pub fn wrap_loom_content(content: &str) -> String {


### PR DESCRIPTION
Closes #3612

## Problem

The LOOM ORCHESTRATION block committed into a consumer repo's root `CLAUDE.md` pointed at `.loom/CLAUDE.md` as "the full guide". That file is an install-only generated artifact — it may be gitignored or simply absent in a fresh clone / CI checkout. When absent, the committed, tool-managed pointer dangles and consumers can't hand-fix it ("edit outside the markers only").

## Fix (Option 1 per curation)

Reword `LOOM_ROOT_POINTER` in `loom-daemon/src/init/scaffolding.rs` so the authoritative reference is the always-present `https://github.com/rjwalters/loom` URL, and `.loom/CLAUDE.md` is described as an optional locally-substituted copy — not a hard "see X for the full guide" dependency. Doc comment updated to record the invariant and the #3612 rationale.

- One-const change; no newly-committed generated file; no reinstall churn.
- Agent auto-discovery of the locally-written `.loom/CLAUDE.md` in `.loom/worktrees/issue-N/` is unchanged (that relies on the post-install file, unaffected by wording).
- All in-file tests assert against the const (`content.contains(LOOM_ROOT_POINTER)`), so they stay green; no golden-string test hardcoded the old text.

## Verification

- `cargo build --workspace` passes.
- `cargo test init::` in loom-daemon: 109 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)