### PR TITLE
fix(install): make config.json merge idempotent from first install (#3619)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1315,6 +1315,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,6 @@ resolver = "2"
 
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["preserve_order"] }
 tokio = { version = "1.52", features = ["full"] }
 anyhow = "1.0"

--- a/defaults/config.json
+++ b/defaults/config.json
@@ -28,7 +28,11 @@
     "auto_create_issues": false,
     "min_session_duration": 300,
     "upstream_repo": "rjwalters/loom",
-    "categories": ["bug", "enhancement", "documentation"]
+    "categories": [
+      "bug",
+      "enhancement",
+      "documentation"
+    ]
   },
   "terminals": [
     {

--- a/loom-daemon/Cargo.toml
+++ b/loom-daemon/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 tokio = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
+serde_json = { workspace = true, features = ["preserve_order"] }
 anyhow = { workspace = true }
 log = "0.4"
 env_logger = "0.11"

--- a/loom-daemon/src/init/mod.rs
+++ b/loom-daemon/src/init/mod.rs
@@ -272,8 +272,14 @@ fn copy_single_file(
 /// consumer keys such as the documented `worktree.root` override every time the
 /// installer reran. This function instead:
 ///
-/// - **Destination missing** → exact template copy (fresh-install behavior,
-///   recorded as `added`). No consumer file exists to preserve.
+/// - **Destination missing** → the template is parsed and re-emitted through
+///   the same canonical `to_string_pretty` serialize path the merge branch
+///   uses (issue #3619), recorded as `added`. Routing the fresh install through
+///   serialization (rather than a raw `fs::copy` of the hand-formatted
+///   template) makes the on-disk file canonical from the very first install, so
+///   a later reinstall merge re-emits byte-identical output and config.json is
+///   never left dirty. (If the template is not valid JSON, falls back to a raw
+///   copy.)
 /// - **Destination is a valid JSON object** → deep-merge with the shipped
 ///   template as the base and the **existing consumer values winning** on
 ///   conflict; keys new in the template are added, unknown consumer keys at any
@@ -300,15 +306,40 @@ fn merge_config_file(
         return Ok(());
     }
 
-    // Fresh install: no existing consumer file → exact template copy.
+    let template_str = fs::read_to_string(&src)
+        .map_err(|e| format!("Failed to read defaults config.json: {e}"))?;
+
+    // Fresh install: no existing consumer file → write the template through the
+    // SAME canonical serialize path the reinstall merge uses (issue #3619). A
+    // bare `fs::copy` of the hand-formatted template produced bytes that a later
+    // merge's `to_string_pretty` output could never match, leaving config.json
+    // permanently dirty after the first reinstall. Serializing here makes the
+    // on-disk file canonical from the very first install, so any later merge
+    // re-emits byte-identical output. With serde_json's `preserve_order`
+    // feature, template key order is retained (keys are not alphabetized).
     if !dst.exists() {
-        fs::copy(&src, &dst).map_err(|e| format!("Failed to copy config.json: {e}"))?;
+        match serde_json::from_str::<Value>(&template_str) {
+            Ok(template_val) => {
+                let mut serialized = serde_json::to_string_pretty(&template_val)
+                    .map_err(|e| format!("Failed to serialize config.json: {e}"))?;
+                serialized.push('\n');
+                fs::write(&dst, serialized)
+                    .map_err(|e| format!("Failed to write config.json: {e}"))?;
+            }
+            Err(e) => {
+                // Template is invalid JSON — fall back to a raw copy rather than
+                // dropping the install. (The reinstall branch handles this too.)
+                eprintln!(
+                    "Warning: defaults/config.json is not valid JSON ({e}); \
+                     copying it verbatim to .loom/config.json"
+                );
+                fs::copy(&src, &dst).map_err(|e| format!("Failed to copy config.json: {e}"))?;
+            }
+        }
         report.added.push(report_name.to_string());
         return Ok(());
     }
 
-    let template_str = fs::read_to_string(&src)
-        .map_err(|e| format!("Failed to read defaults config.json: {e}"))?;
     let existing_str = fs::read_to_string(&dst)
         .map_err(|e| format!("Failed to read existing config.json: {e}"))?;
 
@@ -1829,6 +1860,69 @@ mod tests {
             report.added.contains(&".loom/config.json".to_string()),
             "fresh config.json should be reported added, got: {:?}",
             report.added
+        );
+    }
+
+    #[test]
+    fn test_config_fresh_install_and_reinstall_are_byte_identical() {
+        // Issue #3619: the fresh-install write path and the reinstall-merge
+        // write path must emit BYTE-IDENTICAL output for the same logical
+        // content. Before the fix, fresh install did a raw `fs::copy` of the
+        // hand-formatted template (semantic key order, inline arrays) while the
+        // reinstall merge re-serialized via `to_string_pretty` (expanded
+        // arrays), so the first reinstall reformatted config.json and left it
+        // permanently dirty. Now both paths serialize, so a fresh install
+        // followed by a reinstall is a byte-for-byte no-op.
+        let temp = TempDir::new().unwrap();
+        // A template exercising the two axes that used to diverge: an inline
+        // array (expanded by to_string_pretty) and multiple keys in a
+        // non-alphabetical semantic order (preserved by `preserve_order`).
+        let template = r#"{
+  "version": "2",
+  "offlineMode": false,
+  "reflection": {
+    "enabled": true,
+    "categories": ["bug", "enhancement", "documentation"]
+  },
+  "terminals": []
+}"#;
+        let (workspace, defaults) = setup_config_merge_repo(&temp, template);
+        let config_path = workspace.join(".loom").join("config.json");
+
+        // Fresh install (no existing .loom/config.json).
+        let first =
+            initialize_workspace(workspace.to_str().unwrap(), defaults.to_str().unwrap(), false)
+                .expect("fresh install");
+        assert!(
+            first.added.contains(&".loom/config.json".to_string()),
+            "fresh install should report config.json as added, got: {:?}",
+            first.added
+        );
+        let after_fresh = fs::read_to_string(&config_path).unwrap();
+
+        // Second run: now the file exists → the merge path runs. Its output
+        // must be byte-identical to the fresh-install output (the crux of
+        // #3619 — a reinstall over a freshly-installed config leaves it clean).
+        initialize_workspace(workspace.to_str().unwrap(), defaults.to_str().unwrap(), false)
+            .expect("reinstall merge");
+        let after_reinstall = fs::read_to_string(&config_path).unwrap();
+
+        assert_eq!(
+            after_fresh, after_reinstall,
+            "fresh-install and reinstall-merge output must be byte-identical (#3619)"
+        );
+
+        // Sanity: the serialized form is canonical (expanded array, trailing
+        // newline, template key order preserved by `preserve_order`).
+        assert!(
+            after_fresh.ends_with("}\n"),
+            "serialized config.json should end with a single trailing newline"
+        );
+        let version_pos = after_fresh.find("\"version\"").unwrap();
+        let offline_pos = after_fresh.find("\"offlineMode\"").unwrap();
+        assert!(
+            version_pos < offline_pos,
+            "preserve_order must retain template key order (version before offlineMode)"
         );
     }
 


### PR DESCRIPTION
Closes #3619

## Problem

`merge_config_file` (`loom-daemon/src/init/mod.rs`) had **two write paths that emitted different byte formats** for identical content:

- **Fresh install**: raw `fs::copy` of the hand-formatted `defaults/config.json` — semantic key order, inline arrays.
- **Reinstall merge**: `serde_json::to_string_pretty`, which (without `preserve_order`) alphabetizes keys and expands arrays one-per-line.

So the first `--quick` reinstall reformatted `config.json` → never byte-equal to HEAD → left permanently `M`. A no-commit double reinstall then genuinely conflicted on `git stash pop` and stranded the caller's `.gitignore` edit (scenario 2 of `scripts/test-install-quick-gitignore-stash.sh`).

## Fix

- Route the **fresh-install branch through the same `to_string_pretty` serialize path** the merge uses, so `config.json` is canonical from the very first install and later merges re-emit byte-identical output. (Invalid-template JSON still falls back to a raw copy.)
- Enable serde_json's **`preserve_order`** feature (workspace `Cargo.toml` + `loom-daemon/Cargo.toml`) so template/insertion key order is retained — consumer keys are **not** alphabetized.
- Normalize `defaults/config.json` to the canonical serialize output (only diff: the `categories` array is now expanded one-element-per-line) so the shipped template and the serialized install agree byte-for-byte.
- New unit test `test_config_fresh_install_and_reinstall_are_byte_identical` asserts fresh-install and reinstall-merge output are byte-equal.

## Consumer impact (one-time reformat)

Consumers who committed a **template-format** `config.json` under the old installer will see a **one-time reformat diff** on their next `--quick` reinstall (the `categories`-style inline arrays expand to one-per-line; key order is unchanged thanks to `preserve_order`). After that first reformat, `config.json` is byte-stable across all subsequent reinstalls. This is expected and harmless.

## Verification

- `cargo build --workspace` and `cargo test --workspace` pass (all init/config merge tests green; no `preserve_order` map-ordering regressions elsewhere).
- New byte-idempotency unit test passes.
- Existing consumer-key preservation tests (`test_config_worktree_root_survives_reinstall`, `test_config_deep_merge_preserves_unknown_keys_and_conflict_resolution`) still pass.
- `scripts/test-install-quick-gitignore-stash.sh` — all 27 checks pass, including **scenario 2** (`.gitignore` byte-stable + zero phantom stashes) and scenarios 1/3. No regression to #3611/#3618 install-stash behavior.

Scope stays inside the #3598 merge machinery; `install.sh` / `stash-scope.sh` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)