### PR TITLE
fix(install): preserve tuned guard hook on quick-install path (Fix A only)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -48,10 +48,19 @@ header() {
   echo -e "${CYAN}$*${NC}"
 }
 
-# Install hooks and CLI wrapper that loom-daemon init doesn't handle
+# Install hooks and CLI wrapper that loom-daemon init doesn't handle.
+#
+# Issue #3625: an existing hook may be a downstream-tuned or forked copy — most
+# notably a customized guard-destructive.sh with a hand-tuned rm allowlist — so
+# it must NOT be silently clobbered on the quick-install/update path. Preserve
+# any existing .loom/hooks/<name> unless an explicit force overwrite is
+# requested (the caller passes "true", e.g. behind --clean). This mirrors the
+# preserve-unless-force behavior already in scripts/install-loom.sh:1099-1116,
+# which the quick path previously diverged from with an unconditional cp.
 install_hooks_and_cli() {
   local loom_root="$1"
   local target="$2"
+  local force="${3:-false}"
 
   # Install hooks
   if [[ -d "$loom_root/defaults/hooks" ]]; then
@@ -59,10 +68,14 @@ install_hooks_and_cli() {
     for hook_file in "$loom_root/defaults/hooks/"*.sh; do
       [[ -f "$hook_file" ]] || continue
       hook_name=$(basename "$hook_file")
-      cp "$hook_file" "$target/.loom/hooks/$hook_name"
-      chmod +x "$target/.loom/hooks/$hook_name"
+      if [[ -f "$target/.loom/hooks/$hook_name" ]] && [[ "$force" != "true" ]]; then
+        warning "Preserving existing hook: $hook_name (use --clean to overwrite)"
+      else
+        cp "$hook_file" "$target/.loom/hooks/$hook_name"
+        chmod +x "$target/.loom/hooks/$hook_name"
+        success "Installed hook: $hook_name"
+      fi
     done
-    success "Installed hooks"
   fi
 
   # Install CLI wrapper
@@ -1002,8 +1015,12 @@ case "$METHOD" in
         error "Installation failed"
     fi
 
-    # Install hooks and CLI wrapper (not handled by loom-daemon init)
-    install_hooks_and_cli "$LOOM_ROOT" "$TARGET_PATH"
+    # Install hooks and CLI wrapper (not handled by loom-daemon init).
+    # Force-overwrite existing hooks only under --clean (a deliberate fresh
+    # install); otherwise preserve a downstream-tuned hook (#3625).
+    _HOOK_FORCE=false
+    [[ "$FORCE_FLAG" == "--clean" ]] && _HOOK_FORCE=true
+    install_hooks_and_cli "$LOOM_ROOT" "$TARGET_PATH" "$_HOOK_FORCE"
     # Emit skill-routes.json, install-metadata.json, loom-source-path (#3502).
     finalize_quick_install "$LOOM_ROOT" "$TARGET_PATH"
     verify_install "$TARGET_PATH"

--- a/tests/install/test-hooks-preserve.sh
+++ b/tests/install/test-hooks-preserve.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Test suite for install.sh::install_hooks_and_cli() hook preservation (#3625).
+#
+# Usage: ./tests/install/test-hooks-preserve.sh
+#
+# Verifies that the quick-install path does NOT silently clobber an existing
+# (possibly downstream-tuned/forked) hook — most importantly a customized
+# guard-destructive.sh with a hand-tuned rm allowlist. Preservation mirrors the
+# skip-unless-force behavior in scripts/install-loom.sh:1099-1116; the previous
+# install.sh implementation did an unconditional cp overwrite.
+#
+# install.sh runs top-level installer logic when sourced, so we extract just the
+# install_hooks_and_cli() function definition and eval it in isolation with stub
+# logging helpers.
+#
+# Exit code 0 = all tests pass, 1 = failures detected.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+INSTALL_SH="$REPO_ROOT/install.sh"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+assert_eq() {
+  local desc="$1"
+  local expected="$2"
+  local actual="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "${RED}FAIL${NC}: $desc"
+    echo "  expected: '$expected'"
+    echo "  actual:   '$actual'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Stub logging helpers so the extracted function has them in scope.
+info()    { :; }
+success() { :; }
+warning() { :; }
+error()   { echo "error: $*" >&2; return 1; }
+
+# Extract the install_hooks_and_cli() function body from install.sh and define
+# it here. awk grabs from the function header to the first closing brace at
+# column 0.
+_FN_SRC="$(awk '/^install_hooks_and_cli\(\) \{/{f=1} f{print} f&&/^}$/{exit}' "$INSTALL_SH")"
+if [[ -z "$_FN_SRC" ]]; then
+  echo -e "${RED}FATAL${NC}: could not extract install_hooks_and_cli() from $INSTALL_SH"
+  exit 1
+fi
+eval "$_FN_SRC"
+
+# Build a fake loom_root whose defaults/hooks ships a canonical guard hook.
+make_loom_root() {
+  local root="$1"
+  mkdir -p "$root/defaults/hooks"
+  printf '%s\n' '#!/usr/bin/env bash' '# CANONICAL guard-destructive.sh' > \
+    "$root/defaults/hooks/guard-destructive.sh"
+}
+
+TUNED_MARKER='# TUNED-FORK: downstream rm allowlist'
+
+# ============================================================================
+# Test 1: existing tuned hook is preserved (no force)
+# ============================================================================
+echo ""
+echo "=== install_hooks_and_cli preserves an existing tuned hook ==="
+
+LOOM_ROOT_DIR="$(mktemp -d)"
+TARGET_DIR="$(mktemp -d)"
+trap 'rm -rf "$LOOM_ROOT_DIR" "$TARGET_DIR"' EXIT
+make_loom_root "$LOOM_ROOT_DIR"
+
+mkdir -p "$TARGET_DIR/.loom/hooks"
+printf '%s\n' '#!/usr/bin/env bash' "$TUNED_MARKER" > \
+  "$TARGET_DIR/.loom/hooks/guard-destructive.sh"
+
+install_hooks_and_cli "$LOOM_ROOT_DIR" "$TARGET_DIR"
+
+assert_eq "tuned hook preserved (default, no force)" \
+  "yes" \
+  "$(grep -qF "$TUNED_MARKER" "$TARGET_DIR/.loom/hooks/guard-destructive.sh" && echo yes || echo no)"
+
+# ============================================================================
+# Test 2: existing tuned hook IS overwritten when force=true
+# ============================================================================
+echo ""
+echo "=== install_hooks_and_cli overwrites when force=true ==="
+
+TARGET_DIR2="$(mktemp -d)"
+mkdir -p "$TARGET_DIR2/.loom/hooks"
+printf '%s\n' '#!/usr/bin/env bash' "$TUNED_MARKER" > \
+  "$TARGET_DIR2/.loom/hooks/guard-destructive.sh"
+
+install_hooks_and_cli "$LOOM_ROOT_DIR" "$TARGET_DIR2" "true"
+
+assert_eq "tuned hook overwritten with force=true" \
+  "no" \
+  "$(grep -qF "$TUNED_MARKER" "$TARGET_DIR2/.loom/hooks/guard-destructive.sh" && echo yes || echo no)"
+assert_eq "canonical hook installed with force=true" \
+  "yes" \
+  "$(grep -qF 'CANONICAL' "$TARGET_DIR2/.loom/hooks/guard-destructive.sh" && echo yes || echo no)"
+rm -rf "$TARGET_DIR2"
+
+# ============================================================================
+# Test 3: fresh target (no existing hook) installs the canonical hook
+# ============================================================================
+echo ""
+echo "=== install_hooks_and_cli installs on a fresh target ==="
+
+TARGET_DIR3="$(mktemp -d)"
+install_hooks_and_cli "$LOOM_ROOT_DIR" "$TARGET_DIR3"
+
+assert_eq "hook installed on fresh target" \
+  "yes" \
+  "$([[ -f "$TARGET_DIR3/.loom/hooks/guard-destructive.sh" ]] && grep -qF 'CANONICAL' "$TARGET_DIR3/.loom/hooks/guard-destructive.sh" && echo yes || echo no)"
+assert_eq "installed hook is executable" \
+  "yes" \
+  "$([[ -x "$TARGET_DIR3/.loom/hooks/guard-destructive.sh" ]] && echo yes || echo no)"
+rm -rf "$TARGET_DIR3"
+
+# ============================================================================
+# Summary
+# ============================================================================
+echo ""
+echo "=========================================="
+echo -e "Results: ${PASS} passed, ${FAIL} failed, ${TOTAL} total"
+echo "=========================================="
+
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #3625

## Scope: Fix A ONLY

This PR implements **Fix A** from issue #3625 and deliberately does **NOT** implement Fix B.

- **Fix A (this PR):** `install.sh` → `install_hooks_and_cli()` previously did an unconditional `cp` overwrite of every hook in `defaults/hooks/`, silently clobbering a downstream-tuned or forked `guard-destructive.sh` (e.g. a hand-tuned rm allowlist) on the quick-install/update path. The sibling installer `scripts/install-loom.sh` (lines 1099-1116) already preserves existing hooks unless `--force`/`--clean`. This ports that skip-unless-force behavior into the quick path.
- **Fix B (NOT in this PR — deferred pending ADR sign-off):** flipping the `guards.rmScope` default from `"off"` to `"repo"` reverses #3617's deliberately-shipped byte-for-byte-OFF compatibility guarantee. That is an ADR-level decision requiring operator sign-off. `defaults/hooks/guard-destructive.sh` is **unchanged** here.

## Change

`install_hooks_and_cli()` now takes an optional third `force` arg (default `false`):

- Existing `.loom/hooks/<name>` is **preserved** (with a visible `warning`) unless `force == "true"`.
- The fresh `--quick` (METHOD 1) call site passes `force=true` only under `--clean` (a deliberate fresh install); otherwise it preserves.
- The `--quick` reinstall call site preserves by default.

This mirrors the established preserve-unless-force convention in `scripts/install-loom.sh`. Blast radius is install-script only; no runtime behavior change.

## Tests

- **New:** `tests/install/test-hooks-preserve.sh` — 5 assertions covering (1) an existing tuned hook is preserved by default, (2) `force=true` overwrites it, (3) fresh-install installs the canonical hook and marks it executable. Passes 5/5.
- **Regression:** `tests/hooks/test-guard-destructive.sh` still passes 247/247, including the "ships OFF" rmScope matrix (which Fix B would have had to rewrite and this PR intentionally leaves intact).