### PR TITLE
fix(docs): repoint all remaining broken WORKFLOWS.md links to docs/workflows.md

### DIFF
--- a/.loom/README.md
+++ b/.loom/README.md
@@ -163,5 +163,5 @@ This allows teams to share agent roles and configurations while keeping runtime 
 
 - System roles: [../defaults/roles/](../defaults/roles/)
 - Role creation guide: [../defaults/roles/README.md](../defaults/roles/README.md)
-- Workflow guide: [../WORKFLOWS.md](../WORKFLOWS.md)
+- Workflow guide: [../docs/workflows.md](../docs/workflows.md)
 - Development guide: [../CLAUDE.md](../CLAUDE.md)

--- a/examples/README.md
+++ b/examples/README.md
@@ -106,7 +106,7 @@ Both templates use GitHub labels to coordinate work between agents:
 - `loom:reviewing` (amber) - Under active review
 - `loom:pr` (blue) - PR approved, ready to merge
 
-See [../WORKFLOWS.md](../WORKFLOWS.md) for complete workflow documentation.
+See [../docs/workflows.md](../docs/workflows.md) for complete workflow documentation.
 
 ## Troubleshooting
 
@@ -127,7 +127,7 @@ See [../WORKFLOWS.md](../WORKFLOWS.md) for complete workflow documentation.
 
 ## Next Steps
 
-- Read [../WORKFLOWS.md](../WORKFLOWS.md) for advanced multi-agent patterns
+- Read [../docs/workflows.md](../docs/workflows.md) for advanced multi-agent patterns
 - Explore [../defaults/roles/README.md](../defaults/roles/README.md) to create custom roles
 - Check [../CLAUDE.md](../CLAUDE.md) for development context
 

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -116,7 +116,7 @@ Once you're comfortable with the basics:
 ### Need help?
 
 - Read the [main documentation](../../README.md)
-- Check [WORKFLOWS.md](../../WORKFLOWS.md) for advanced patterns
+- Check [workflow documentation](../../docs/workflows.md) for advanced patterns
 - Open an issue on GitHub
 
 ## Learn More
@@ -125,6 +125,6 @@ This template demonstrates the core Loom workflow. To unlock the full power of A
 
 - **[Full-Stack Template](../full-stack/)** - Complete setup with Architect, Curator, Critic, and more
 - **[Custom Roles](../../defaults/roles/README.md)** - Create specialized agents for your workflow
-- **[Label Workflows](../../WORKFLOWS.md)** - Coordinate complex multi-agent tasks
+- **[Label Workflows](../../docs/workflows.md)** - Coordinate complex multi-agent tasks
 
 Happy coding with Loom! 🧵✨


### PR DESCRIPTION
Follow-up to #3622 / #3614. Those fixed the `../../WORKFLOWS.md` dangling link only in the `CONFIGURATION.md` copies; the same repo-root `WORKFLOWS.md` link (renamed to `docs/workflows.md`) survived in three other files. This sweeps them all:

- `examples/quickstart/README.md` (2 links) → `../../docs/workflows.md`
- `.loom/README.md` (1 link) → `../docs/workflows.md`
- `examples/README.md` (2 links) → `../docs/workflows.md`

Each target verified to resolve from its file's directory, and each edit matches the sibling-link convention already used in that file. Repo-wide grep confirms no `WORKFLOWS.md` links remain outside CHANGELOG history.

Docs-only; no code paths touched.