### PR TITLE
feat(guard): flip guards.rmScope default off→repo (safe-by-default)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+> **Requires a MINOR version bump** — the rm-guard default change below is a behaviour change, not a bug fix.
+
+### Changed
+
+- **BREAKING (behaviour): `guards.rmScope` now defaults to `repo` instead of `off`** — `guard-destructive.sh` runs the repo-scoped `rm` guard by default: an outside-repo recursive `rm` (e.g. `rm -rf /Users/someone/important`) is now **denied** out of the box, while the `/tmp` + Claude-scratchpad ephemeral allowlist and in-repo/worktree paths stay allowed. The catastrophic top-level denies (bare `/tmp`, `/`, `$HOME`) are unchanged. This reverses #3617's "existing installs see zero behaviour change" guarantee as a deliberate, signed-off ADR decision (Option B). Consumers who relied on the old permissive default must opt out with `guards.rmScope: "off"` (synonym: `"permissive"`) in `.loom/config.json` or `LOOM_RM_SCOPE=off`. (#3628)
+
 ## [0.10.10] - 2026-07-18
 
 ### Summary

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -981,24 +981,24 @@ LOOM_GUARD_CLOUD=1 aws ec2 terminate-instances --instance-ids i-1234
 
 ### Repo-Scoped rm Guard (`guards.rmScope` / `LOOM_RM_SCOPE`)
 
-By default, `guard-destructive.sh` blocks only **catastrophic** `rm -rf` targets — root (`/`), the user's `$HOME`, and any bare top-level directory (`/tmp`, `/var`, `/etc`, …). Every deeper subpath is allowed, **including subpaths outside the repository** (e.g. `rm -rf /Users/someone/important`). This permissive default is intentional and ships unchanged.
+By default (as of #3628), `guard-destructive.sh` runs in **`repo` mode**: it blocks the **catastrophic** `rm -rf` targets — root (`/`), the user's `$HOME`, and any bare top-level directory (`/tmp`, `/var`, `/etc`, …) — **and** additionally denies any `rm -rf` target that is neither inside the repo/worktree areas nor on a built-in **ephemeral allowlist**. So an outside-repo deep path like `rm -rf /Users/someone/important` is **denied** out of the box. This is the safe-by-default behaviour (ADR Option B); it is a **behaviour change** from the pre-#3628 permissive default.
 
-Repos that want a tighter blast radius can opt in to **`repo` mode**, which additionally denies any `rm -rf` target that is neither inside the repo/worktree areas nor on a built-in **ephemeral allowlist**. The catastrophic top-level deny stays active in both modes, so bare `/tmp` and `/` are always blocked.
+Repos that need the old permissive behaviour — block only catastrophic targets and **allow** every deeper subpath, including subpaths outside the repository — can **opt out** to `off` (a.k.a. `permissive`) mode. The catastrophic top-level deny stays active in both modes, so bare `/tmp` and `/` are always blocked regardless.
 
-The rm-scope guard is **off by default**. It is resolved in this order (highest precedence first):
+The rm-scope guard is **repo (on) by default**. It is resolved in this order (highest precedence first):
 
-1. **`LOOM_RM_SCOPE` env var** — `repo` enables repo mode; `off`/`0`/`no` (or unset) disables it. Overrides the config value.
-2. **`.loom/config.json`** — `guards.rmScope` (default absent = off). Set it to `"repo"` to enable:
+1. **`LOOM_RM_SCOPE` env var** — `repo` forces repo mode; `off`/`0`/`no`/`permissive` forces the permissive opt-out; unset falls through to the config/default. Overrides the config value.
+2. **`.loom/config.json`** — `guards.rmScope`. An explicit `"off"` (or its synonym `"permissive"`) opts out to permissive mode; an absent key, any other value, or malformed JSON resolves to `"repo"` (the safe default):
    ```json
    {
      "guards": {
-       "rmScope": "repo"
+       "rmScope": "off"
      }
    }
    ```
-3. **Default** — off (current permissive behavior, byte-for-byte).
+3. **Default** — repo (safe-by-default, outside-repo deep `rm` denied).
 
-The config read is best-effort: a missing, empty, or malformed `.loom/config.json` falls through to **off** (no behavior change) and never causes the hook to exit non-zero. Enabling repo mode does not weaken any other guard.
+The config read is best-effort: a missing, empty, or malformed `.loom/config.json` falls through to **repo** (the safe default) and never causes the hook to exit non-zero. The permissive opt-out does not weaken any other guard — the catastrophic denies stay active.
 
 **In-scope targets** (allowed under `repo` mode):
 
@@ -1019,16 +1019,19 @@ Plus the Claude scratchpad glob `*/claude-*/*/scratchpad/*`. A **bare** temp roo
 **Examples**:
 
 ```bash
-# Opt in for a whole repo
-#   .loom/config.json  ->  { "guards": { "rmScope": "repo" } }
+# Default (repo mode) — no config needed:
+rm -rf /Users/someone/important   # DENIED (outside repo, safe default)
+rm -rf /tmp/build-cache/x         # allowed (ephemeral allowlist)
+rm -rf ./dist                     # allowed (under repo)
 
-# One-off: strict scope for a single command
-LOOM_RM_SCOPE=repo rm -rf /Users/someone/important   # DENIED (outside repo)
-LOOM_RM_SCOPE=repo rm -rf /tmp/build-cache/x          # allowed (ephemeral)
-LOOM_RM_SCOPE=repo rm -rf ./dist                      # allowed (under repo)
+# Opt out to the old permissive behaviour for a whole repo:
+#   .loom/config.json  ->  { "guards": { "rmScope": "off" } }        # or "permissive"
 
-# Env override wins over config — force OFF even when the repo opts in
-LOOM_RM_SCOPE=off rm -rf /Users/someone/scratch       # allowed (guard disabled)
+# One-off env opt-out — force permissive for a single command:
+LOOM_RM_SCOPE=off rm -rf /Users/someone/scratch       # allowed (permissive)
+
+# Force repo mode for one command even when the repo opts out:
+LOOM_RM_SCOPE=repo rm -rf /Users/someone/important    # DENIED (outside repo)
 ```
 
 ### Protecting Read-Only Directories

--- a/defaults/hooks/guard-destructive.sh
+++ b/defaults/hooks/guard-destructive.sh
@@ -161,45 +161,54 @@ cloud_guard_enabled() {
 }
 
 # =============================================================================
-# rm-scope repo mode toggle — default OFF (opt-in).
+# rm-scope repo mode toggle — default REPO (safe-by-default; opt out to off).
 #
-# By default this guard blocks only catastrophic rm targets (root, $HOME, and
-# bare top-level dirs) and ALLOWS every deeper subpath — including subpaths
-# OUTSIDE the repo (e.g. `rm -rf /Users/someone/important`). That permissive
-# default ships unchanged so existing installs see zero behaviour change.
-#
-# Opt-in `repo` mode (guards.rmScope:"repo" / LOOM_RM_SCOPE=repo) additionally
+# As of issue #3628 (ADR Option B) this guard defaults to `repo` mode: it
 # DENIES any rm target that is neither under the repo / worktree areas nor on a
-# built-in ephemeral allowlist (system temp dirs + the Claude scratchpad). The
-# catastrophic top-level deny stays unconditional in BOTH modes, so bare /tmp
-# and / are still blocked.
+# built-in ephemeral allowlist (system temp dirs + the Claude scratchpad), in
+# addition to the catastrophic top-level deny. A zero-config install therefore
+# gets outside-repo rm protection out of the box (e.g. `rm -rf
+# /Users/someone/important` is DENIED).
+#
+# The legacy permissive behaviour — block only catastrophic rm targets (root,
+# $HOME, bare top-level dirs) and ALLOW every deeper subpath including subpaths
+# OUTSIDE the repo — is now an explicit opt-out: guards.rmScope:"off" (or the
+# synonym "permissive") / LOOM_RM_SCOPE=off. Consumers who relied on the old
+# permissive default must set one of those to restore it.
+#
+# The catastrophic top-level deny stays unconditional in BOTH modes, so bare
+# /tmp and / are still blocked regardless of rmScope.
 #
 # Resolution order (highest precedence first):
-#   1. LOOM_RM_SCOPE env var (repo enables; off/0/no disables). Overrides config.
-#   2. .loom/config.json  ->  guards.rmScope == "repo"  (else off)
-#   3. Default: off (permissive, current behaviour)
+#   1. LOOM_RM_SCOPE env var (repo enables; off/0/no/permissive disables).
+#      Overrides config. Absent → falls through to config/default.
+#   2. .loom/config.json  ->  guards.rmScope: "off"/"permissive" => off;
+#      absent key / any other value / malformed JSON => repo (the new default).
+#   3. Default: repo (safe-by-default, current behaviour after #3628)
 #
 # Mirrors sql_guard_enabled() / cloud_guard_enabled(): cached in
 # _RM_SCOPE_CACHE, invoked LAZILY only after a candidate rm target survives the
 # catastrophic check, so the jq config read never touches the hot path for
 # non-rm commands. The config read is best-effort: any parse failure falls
-# through to OFF (no behaviour change) and never trips the ERR trap.
+# through to REPO (the safe default) and never trips the ERR trap.
 # =============================================================================
 _RM_SCOPE_CACHE=""
 rm_scope_repo_enabled() {
     if [[ -z "$_RM_SCOPE_CACHE" ]]; then
-        local mode=off
+        local mode=repo
         if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/config.json" ]]; then
-            # Only an explicit guards.rmScope == "repo" enables the mode; any
-            # other value, a missing key, or malformed JSON stays OFF (the jq
-            # non-zero exit is caught by the `||` fallback).
-            mode=$(jq -r 'if .guards.rmScope == "repo" then "repo" else "off" end' "$REPO_ROOT/.loom/config.json" 2>/dev/null) || mode=off
-            [[ -n "$mode" ]] || mode=off
+            # Only an explicit guards.rmScope of "off" or "permissive" opts out
+            # to the legacy permissive behaviour; any other value, a missing
+            # key, or malformed JSON resolves to "repo" (the safe default — the
+            # jq non-zero exit on malformed JSON is caught by the `||`
+            # fallback, which also resolves to repo).
+            mode=$(jq -r 'if (.guards.rmScope == "off" or .guards.rmScope == "permissive") then "off" else "repo" end' "$REPO_ROOT/.loom/config.json" 2>/dev/null) || mode=repo
+            [[ -n "$mode" ]] || mode=repo
         fi
         # Env override wins over config.
         case "${LOOM_RM_SCOPE:-}" in
-            repo)         mode=repo ;;
-            off|0|no)     mode=off ;;
+            repo)                  mode=repo ;;
+            off|0|no|permissive)   mode=off ;;
         esac
         _RM_SCOPE_CACHE="$mode"
     fi

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -803,46 +803,70 @@ done
 echo ""
 
 # =========================================================================
-echo -e "${YELLOW}--- Repo-scoped rm guard (guards.rmScope / LOOM_RM_SCOPE) (#3610) ---${NC}"
+echo -e "${YELLOW}--- Repo-scoped rm guard (guards.rmScope / LOOM_RM_SCOPE) (#3610, #3628) ---${NC}"
 # =========================================================================
 #
-# The guard ships with rmScope OFF: only catastrophic top-level targets deny,
-# every deeper subpath (in- OR out-of-repo) is allowed. Opt-in `repo` mode adds
-# an outside-repo deny with a built-in ephemeral allowlist (system temp dirs +
-# the Claude scratchpad). The 8-case matrix from the issue is asserted in BOTH
-# toggle states, plus worktree-root and env-override cases.
+# As of #3628 (ADR Option B) the guard ships with rmScope REPO by default:
+# catastrophic top-level targets deny in every mode, AND an outside-repo deep
+# path is DENIED unless it is under the repo/worktree areas or on the built-in
+# ephemeral allowlist (system temp dirs + the Claude scratchpad). The legacy
+# permissive behaviour (allow every deeper subpath, including outside-repo) is
+# now an explicit opt-out via guards.rmScope:"off"/"permissive" or
+# LOOM_RM_SCOPE=off. The 8-case matrix from the issue is asserted in BOTH
+# states, plus worktree-root and env-override cases.
 #
 # NB: normalize_abs_path() is LEXICAL (no symlink resolution), so the allowlist
 # lists both /tmp and /private/tmp (and the /var/tmp, /var/folders pairs). These
 # temp-root cases pass in both toggle states — under OFF because a deep subpath
 # is always allowed, under repo because they are on the ephemeral allowlist.
 
-# ---- Matrix in the DEFAULT (off) state: unchanged permissive behaviour. ----
-# rmScope absent → off. Uses the real REPO_ROOT (loom checkout) as cwd.
-assert_allow "rmScope off: rm -f /tmp/x/foo.tsv allowed" \
+# ---- Matrix in the DEFAULT state: repo semantics (safe-by-default, #3628). ----
+# rmScope absent → repo. Uses the real REPO_ROOT (loom checkout) as cwd.
+assert_allow "rmScope default: rm -f /tmp/x/foo.tsv allowed (ephemeral)" \
     "rm -f /tmp/x/foo.tsv" "$REPO_ROOT"
-assert_allow "rmScope off: rm -rf scratchpad path allowed" \
+assert_allow "rmScope default: rm -rf scratchpad path allowed (ephemeral)" \
     "rm -rf /private/tmp/claude-501/-Users-x/abc/scratchpad/z" "$REPO_ROOT"
-assert_allow "rmScope off: rm -rf \$TMPDIR /var/folders path allowed" \
+assert_allow "rmScope default: rm -rf \$TMPDIR /var/folders path allowed (ephemeral)" \
     "rm -rf /var/folders/ab/cd/T/tmp.123" "$REPO_ROOT"
-assert_deny "rmScope off: rm -rf bare /tmp still denied (top-level rule)" \
+assert_deny "rmScope default: rm -rf bare /tmp still denied (top-level rule)" \
     "rm -rf /tmp" "$REPO_ROOT"
-assert_deny "rmScope off: rm -rf / still denied (catastrophic rule)" \
+assert_deny "rmScope default: rm -rf / still denied (catastrophic rule)" \
     "rm -rf /" "$REPO_ROOT"
-# The key backward-compat row: an outside-repo deep path is ALLOWED when off.
-assert_allow "rmScope off: rm -rf outside-repo path allowed (unchanged)" \
+# The key behaviour-change rows: outside-repo deep paths are now DENIED by default.
+assert_deny "rmScope default: rm -rf outside-repo /opt path denied (NEW default)" \
     "rm -rf /opt/some-vendor/important" "$REPO_ROOT"
-assert_allow "rmScope off: rm -rf under repo root allowed" \
+assert_deny "rmScope default: rm -rf outside-repo /Users path denied (NEW default)" \
+    "rm -rf /Users/someone/important" "$REPO_ROOT"
+assert_allow "rmScope default: rm -rf under repo root allowed" \
     "rm -rf $REPO_ROOT/.loom/tmp/x" "$REPO_ROOT"
-assert_allow "rmScope off: rm -rf external worktree-root path allowed (deep path)" \
-    "rm -rf /Volumes/scratch/wt/foo/issue-5/x" "$REPO_ROOT"
 
-# Explicit guards.rmScope:"off" behaves identically to absent.
+# ---- Explicit opt-out block: guards.rmScope:"off"/"permissive" restores the
+# ---- OLD permissive behaviour (outside-repo deep rm allowed again). ----
 RMSCOPE_OFF_REPO=$(make_sql_repo '{"guards":{"rmScope":"off"}}')
-assert_allow "rmScope config-off: outside-repo path allowed" \
+assert_allow "rmScope config-off: outside-repo path allowed again (opt-out)" \
     "rm -rf /opt/some-vendor/important" "$RMSCOPE_OFF_REPO"
-assert_deny "rmScope config-off: bare /tmp still denied" \
+assert_allow "rmScope config-off: outside-repo /Users path allowed again (opt-out)" \
+    "rm -rf /Users/someone/important" "$RMSCOPE_OFF_REPO"
+assert_deny "rmScope config-off: bare /tmp still denied (catastrophic rule holds)" \
     "rm -rf /tmp" "$RMSCOPE_OFF_REPO"
+assert_deny "rmScope config-off: / still denied (catastrophic rule holds)" \
+    "rm -rf /" "$RMSCOPE_OFF_REPO"
+
+# "permissive" is a recognized synonym for "off".
+RMSCOPE_PERM_REPO=$(make_sql_repo '{"guards":{"rmScope":"permissive"}}')
+assert_allow "rmScope config-permissive: outside-repo path allowed (synonym for off)" \
+    "rm -rf /opt/some-vendor/important" "$RMSCOPE_PERM_REPO"
+assert_deny "rmScope config-permissive: bare /tmp still denied" \
+    "rm -rf /tmp" "$RMSCOPE_PERM_REPO"
+
+# Env opt-out: LOOM_RM_SCOPE=off / permissive restore permissive behaviour even
+# with no config key present (default would otherwise be repo).
+assert_allow_env "rmScope env-off: outside-repo path allowed (env opt-out)" \
+    "LOOM_RM_SCOPE=off" "rm -rf /opt/some-vendor/important" "$REPO_ROOT"
+assert_allow_env "rmScope env-permissive: outside-repo path allowed (env synonym)" \
+    "LOOM_RM_SCOPE=permissive" "rm -rf /opt/some-vendor/important" "$REPO_ROOT"
+assert_deny_env "rmScope env-off: bare /tmp still denied (catastrophic rule holds)" \
+    "LOOM_RM_SCOPE=off" "rm -rf /tmp" "$REPO_ROOT"
 
 # ---- Matrix in the repo (on) state, driven by the env toggle. ----
 assert_allow_env "rmScope repo: rm -f /tmp/x/foo.tsv allowed (ephemeral)" \
@@ -896,10 +920,15 @@ assert_deny "rmScope config-on: outside-repo path denied" \
 assert_allow_env "rmScope: LOOM_RM_SCOPE=off overrides config repo (outside allowed)" \
     "LOOM_RM_SCOPE=off" "rm -rf /opt/some-vendor/important" "$RMSCOPE_ON_REPO"
 
-# ---- Malformed config falls through to OFF (no behaviour change). ----
+# ---- Malformed config falls through to REPO (the safe default, #3628). ----
+# The jq parse failure is caught by the `|| mode=repo` fallback, so a broken
+# config now resolves to repo — outside-repo deep rm is denied, not allowed.
 RMSCOPE_BAD_REPO=$(make_sql_repo '{ this is not valid json ')
-assert_allow "rmScope malformed-config: outside-repo path allowed (falls through to off)" \
+assert_deny "rmScope malformed-config: outside-repo path denied (falls through to repo)" \
     "rm -rf /opt/some-vendor/important" "$RMSCOPE_BAD_REPO"
+# The malformed config must still not trip the ERR trap or weaken other guards.
+assert_deny "rmScope malformed-config: bare /tmp still denied" \
+    "rm -rf /tmp" "$RMSCOPE_BAD_REPO"
 
 # ---- Repo mode must NOT weaken unrelated guards. ----
 assert_deny_env "rmScope repo: force-push to main still blocked" \


### PR DESCRIPTION
## Summary

Implements **ADR Option B** from #3628 (operator-signed-off): flips the `guards.rmScope` default in `defaults/hooks/guard-destructive.sh` from `off` (permissive) to `repo` (repo-scoped, safe-by-default). A zero-config install now **denies** an outside-repo recursive `rm` (e.g. `rm -rf /Users/someone/important`) while keeping the `/tmp` + Claude-scratchpad ephemeral allowlist and in-repo/worktree paths allowed. The catastrophic top-level denies (bare `/tmp`, `/`, `$HOME`) are unchanged in both modes.

This is a deliberate **behaviour change** that reverses #3617's "existing installs see zero behaviour change" guarantee.

## Changes

- **Resolver flip** (`rm_scope_repo_enabled`): default mode is now `repo`. The trinary is explicit and load-bearing:
  - Config `guards.rmScope`: `"off"` / `"permissive"` → permissive (opt-out); **absent key / any other value / malformed JSON → `repo`** (the safe default, via the `|| mode=repo` best-effort fallback that never trips the ERR trap).
  - Env `LOOM_RM_SCOPE`: `repo` → repo; `off`/`0`/`no`/`permissive` → off; absent → falls through to config/default.
  - A *present-but-off* key still means permissive after the flip (not collapsed into the new default).
  - `"permissive"` accepted as a synonym for `"off"` (config and env).
- **Tests** (`tests/hooks/test-guard-destructive.sh`): DEFAULT-state matrix rewritten to assert repo semantics (outside-repo deep `rm` now denied; `/tmp`/scratchpad/`$TMPDIR` allowed; catastrophic rows still deny). New explicit-`off`/`permissive` opt-out block (config + env). Malformed-config now asserts `repo` (deny). All functional assertions pass.
- **Docs** (`defaults/CLAUDE.md`): rm-guard section rewritten to state repo is the default and document `guards.rmScope: "off"` / `LOOM_RM_SCOPE=off` (and `"permissive"`) as the opt-out.
- **CHANGELOG**: behaviour-change entry under `[Unreleased]`, flagged **requires a minor version bump**.

## Testing

- `bash tests/hooks/test-guard-destructive.sh` — 255 functional assertions pass. (The one intermittent perf-threshold failure is pre-existing/environmental — it also fails on unmodified `main` HEAD; a clean run measured 255/255 at 178ms.)
- `bash tests/hooks/test-guard-loom-workflow.sh` — 22/22 pass.
- Manual resolver edge-case checks: absent key → deny outside-repo; `"banana"` → deny; `"off"`/`"permissive"` → allow; `LOOM_RM_SCOPE=off` overrides absent-key default → allow.

## Out of scope

Option C fresh-install seeding, Fix A (#3626), and #3598 config merge-preserve are not touched. No version bump / release cut here — flagged in the CHANGELOG for the operator's `/repo:release`.

Closes #3628

🤖 Generated with [Claude Code](https://claude.com/claude-code)