### PR TITLE
docs: post-v0.11.0 hygiene (stale spawn-loop refs + broken links)

### DIFF
--- a/.loom/docs/troubleshooting.md
+++ b/.loom/docs/troubleshooting.md
@@ -162,7 +162,7 @@ claude -p "/loom:sweep 123" --dangerously-skip-permissions > /tmp/sweep-123.log 
 cat /tmp/sweep-123.log
 ```
 
-**Built-in log file** — when the spawn loop spawns a sweep child, it automatically tees all output to `.loom/logs/sweep-issue-N.log`. If output is invisible in your terminal, check this log file:
+**Built-in log file** — when a sweep child runs, it automatically tees all output to `.loom/logs/sweep-issue-N.log`. If output is invisible in your terminal, check this log file:
 
 ```bash
 cat .loom/logs/sweep-issue-123.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,7 +270,7 @@ Curator → Builder → Judge → Doctor (if needed) → Merge
 
 ### Overnight / long-running orchestration: keep the host awake (#3350)
 
-`/loom:sweep` and the spawn loop automatically run `./.loom/scripts/check-host-sleep.sh` at startup and warn when the host can sleep. This is **advisory only** — Loom never blocks on it. Heed the warning before walking away from a long run.
+`/loom:sweep` automatically runs `./.loom/scripts/check-host-sleep.sh` at startup and warns when the host can sleep. This is **advisory only** — Loom never blocks on it. Heed the warning before walking away from a long run.
 
 - **macOS:** user-idle sleep assertions (Amphetamine, `caffeinate -dimsu`, etc.) do **not** reliably defeat Maintenance Sleep on Apple Silicon. Use `sudo pmset -c sleep 0` for AC-only sleep disable, or flip your sleep manager's "allow system sleep when display is off" toggle to OFF.
 - **systemd Linux:** wrap the session in `systemd-inhibit --what=idle:sleep --who=loom --why=loom -- <cmd>`.
@@ -540,13 +540,13 @@ gh release create vX.Y.Z --title "vX.Y.Z" --notes "Release notes..."
 
 The script updates all 5 version-bearing files (`package.json`, `mcp-loom/package.json`, 2 `Cargo.toml` files (`loom-daemon`, `loom-api`), `CLAUDE.md`) plus `Cargo.lock`. The GitHub Actions release workflow (`.github/workflows/release.yml`) triggers on GitHub Release creation (`release: types: [created]`), NOT on tag push. You must create a GitHub Release via `gh release create` to trigger the build.
 
-## Migration: v0.10.0 shepherd/daemon deprecation (in progress)
+## Migration: v0.10.0 shepherd/daemon deprecation
 
 The orchestration-architecture migration (epic #3372) deleted the shepherd brain (`loom-tools/src/loom_tools/shepherd/`), the Python daemon brain (`loom-tools/src/loom_tools/daemon_v2/`), and the `/shepherd` slash command. The replacement is a two-surface architecture: `/loom:sweep` for in-session subagent dispatch (Tier 1) and the Rust `loom-daemon` binary for multi-account MCP-level dispatch (Tier 2). Epic #3449 rebuilt the daemon surface in phases A–D, all shipped on main. The completed phases:
 
 | Phase | Issue | What shipped | Status |
 |-------|-------|-----------|--------|
-| Phase 1 | #3374 | Minimal multi-account spawn loop (legacy — deprecated in Phase E of #3449) | shipped, deprecated |
+| Phase 1 | #3374 | Minimal multi-account spawn loop (legacy — deprecated in Phase E of #3449) | shipped (deprecated in Phase E, removed in v0.11.0) |
 | Phase 2a | #3375 | GitHub Actions workflows for support roles | shipped (disabled by default) |
 | Phase 2b | #3376 | Soft-deprecation warnings on deprecated entry points | shipped |
 | Phase 3 | #3378 | Deletion of shepherd brain, Python daemon brain, `/shepherd` skill | shipped |

--- a/docs/guides/quickstart-tutorial.md
+++ b/docs/guides/quickstart-tutorial.md
@@ -411,9 +411,9 @@ that move issues and PRs between labels. Either can run on its own.
 
 For the full reference (MCP tool surface, env tunables, opt-in
 checklist, troubleshooting), see the
-[**Daemon Mode**](../../.loom/CLAUDE.md#3-daemon-mode-loom-daemon--mcp-tools)
+[**Daemon Mode**](../../CLAUDE.md#3-daemon-mode-loom-daemon--mcp-tools)
 and
-[**Scheduled Support Roles**](../../.loom/CLAUDE.md#4-scheduled-support-roles-opt-in)
+[**Scheduled Support Roles**](../../CLAUDE.md#4-scheduled-support-roles-opt-in)
 sections of `.loom/CLAUDE.md`, and the full daemon surface at
 [`.loom/docs/daemon-reference.md`](../../.loom/docs/daemon-reference.md).
 

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -493,4 +493,4 @@ When adding new MCP capabilities:
 - [MCP Protocol Specification](https://modelcontextprotocol.io/docs)
 - [Loom README](../../README.md) - Main project documentation
 - [CLAUDE.md](../../CLAUDE.md) - Development context for AI agents
-- [Daemon IPC Protocol](../../loom-daemon/README.md) - Low-level daemon communication
+- [Daemon IPC Protocol](../../.loom/docs/daemon-reference.md) - Low-level daemon communication

--- a/docs/mcp/loom-terminals.md
+++ b/docs/mcp/loom-terminals.md
@@ -683,4 +683,4 @@ Common error types:
 ## See Also
 
 - [MCP Overview](./README.md) - Introduction to Loom MCP servers
-- [Loom Daemon IPC Protocol](../../loom-daemon/README.md) - Low-level IPC details
+- [Loom Daemon IPC Protocol](../../.loom/docs/daemon-reference.md) - Low-level IPC details

--- a/docs/philosophy/agent-archetypes.md
+++ b/docs/philosophy/agent-archetypes.md
@@ -403,6 +403,5 @@ In the end, all archetypes serve a single purpose: to transform the chaos of pos
 ---
 
 **See Also**:
-- [Role File Documentation](../defaults/roles/README.md)
+- [Role File Documentation](../../defaults/roles/README.md)
 - [Workflow Coordination](../workflows.md)
-- [Terminal Configuration](../docs/terminal-configuration.md)

--- a/docs/philosophy/loom-intelligence.md
+++ b/docs/philosophy/loom-intelligence.md
@@ -82,9 +82,9 @@ The previous architecture concentrated intelligence in a Python daemon brain (`d
 
 The emergent architecture distributes intelligence:
 
-- **Fault tolerance**: a crashed sweep child restarts from its checkpoint; the spawn loop re-queues it on the next tick; other sweeps are unaffected
+- **Fault tolerance**: a crashed sweep child restarts from its checkpoint on the next dispatch; other sweeps are unaffected
 - **Transparent state**: all state is visible in the forge — labels, comments, PR status; nothing is hidden in memory
-- **Independent evolution**: worker roles, sweep, spawn loop, and GH Actions workflows can change independently
+- **Independent evolution**: worker roles, sweep, the loom-daemon, and GH Actions workflows can change independently
 - **Horizontal scalability**: parallel sweeps run as separate processes; multi-account token rotation distributes load
 
 ---

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -17,7 +17,7 @@ In Loom, development follows an ancient pattern of archetypal forces working in 
 5. 🔧 **The Fixer heals → claims with `loom:treating``, addresses review feedback (`loom:changes-requested` → `loom:review-requested`)
 6. ⚖️ **The Reviewer** judges → maintains quality through discernment (`loom:pr`)
 
-*Like the Tarot's Major Arcana, each role is essential to the whole. See [Agent Archetypes](docs/philosophy/agent-archetypes.md) for the mystical framework.*
+*Like the Tarot's Major Arcana, each role is essential to the whole. See [Agent Archetypes](philosophy/agent-archetypes.md) for the mystical framework.*
 
 ### Color-coded Workflow
 
@@ -34,7 +34,7 @@ In Loom, development follows an ancient pattern of archetypal forces working in 
   - `loom:blocked` (Blocked, needs help)
   - `loom:urgent` (High priority)
 
-See [scripts/LABEL_WORKFLOW.md](scripts/LABEL_WORKFLOW.md) for detailed label state machine documentation.
+See [.github/labels.yml](../.github/labels.yml) for detailed label state machine documentation.
 
 ## Complete Feature Flow
 
@@ -90,7 +90,7 @@ This issue cannot proceed until all dependencies above are complete.
 - **Worker**: Verifies dependencies before claiming
 - Blocked issues get `loom:blocked` label
 
-See full dependency workflow in [scripts/LABEL_WORKFLOW.md](scripts/LABEL_WORKFLOW.md).
+See full dependency workflow in [.github/labels.yml](../.github/labels.yml).
 
 ## Agent Types Summary
 
@@ -421,10 +421,10 @@ For detailed workflows including:
 - Troubleshooting guides
 - Future enhancements
 
-See [scripts/LABEL_WORKFLOW.md](scripts/LABEL_WORKFLOW.md) for comprehensive documentation.
+See [.github/labels.yml](../.github/labels.yml) for comprehensive documentation.
 
 ---
 
-**For detailed agent workflows and command references, see [scripts/LABEL_WORKFLOW.md](scripts/LABEL_WORKFLOW.md).**
+**For detailed agent workflows and command references, see [.github/labels.yml](../.github/labels.yml).**
 
 Last updated: Issue #332 - Revised label state machine with human approval gate


### PR DESCRIPTION
Post-v0.11.0 documentation hygiene pass surfaced by a `/repo:all` Docs-stage cleanup. All edits are safe, mechanical doc/link corrections — no code or version changes.

## Fix categories

### 1. Stale spawn-loop present-tense references
The spawn loop was **deleted in v0.11.0**, but several docs still described it in the present tense. Corrected:
- `CLAUDE.md` — "keep the host awake" note no longer mentions the spawn loop; verb agreement fixed (`/loom:sweep` runs/warns).
- `CLAUDE.md` — migration section header dropped the stale ` (in progress)` suffix.
- `CLAUDE.md` — Phase 1 (#3374) migration-table status now reads `shipped (deprecated in Phase E, removed in v0.11.0)`, matching `defaults/CLAUDE.md`.
- `.loom/docs/troubleshooting.md` — built-in log-file note rephrased to "when a sweep child runs".
- `docs/philosophy/loom-intelligence.md` — fault-tolerance and independent-evolution bullets no longer reference the spawn loop (checkpoint restart on next dispatch; loom-daemon instead of spawn loop).

### 2. Broken internal links
- `docs/workflows.md` — fixed a wrong `docs/` prefix on the Agent Archetypes link; repointed four dead `scripts/LABEL_WORKFLOW.md` references to the authoritative `.github/labels.yml`.
- `docs/philosophy/agent-archetypes.md` — corrected the Role File Documentation path; removed a dead Terminal Configuration bullet (no valid target).
- `docs/mcp/README.md` and `docs/mcp/loom-terminals.md` — repointed dead `loom-daemon/README.md` links to `.loom/docs/daemon-reference.md`.
- `docs/guides/quickstart-tutorial.md` — repointed two `../../.loom/CLAUDE.md` anchors to the root `CLAUDE.md` (where the content and anchors actually live).

8 files changed, 16 insertions(+), 17 deletions(-).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>