### PR TITLE
fix(daemon): add sweep-checkpoint/ and locks/ to managed .gitignore patterns

### DIFF
--- a/loom-daemon/src/init/post_init.rs
+++ b/loom-daemon/src/init/post_init.rs
@@ -106,9 +106,11 @@ pub const EPHEMERAL_PATTERNS: &[&str] = &[
     ".loom/mcp-command.json",
     ".loom/activity.db",
     ".loom/claims/",
+    ".loom/locks/",
     ".loom/signals/",
     ".loom/status/",
     ".loom/retry-state/",
+    ".loom/sweep-checkpoint/",
     ".loom/diagnostics/",
     ".loom/guide-docs-state.json",
     ".loom/metrics_state.json",
@@ -309,6 +311,9 @@ mod tests {
         assert!(contents.contains(".loom/activity.db"));
         assert!(contents.contains(".loom/issue-failures.json"));
         assert!(contents.contains(".loom/usage-cache.json"));
+        // Runtime dirs added in #3635 — must appear exactly once
+        assert_eq!(contents.matches(".loom/sweep-checkpoint/").count(), 1);
+        assert_eq!(contents.matches(".loom/locks/").count(), 1);
         assert!(contents.contains("# Loom runtime state"));
 
         // Retired daemon-brain patterns must NOT be emitted (Phase 3.5, #3402)
@@ -360,6 +365,8 @@ mod tests {
         assert_eq!(contents.matches(".loom/spawn-loop-state.json").count(), 1);
         assert_eq!(contents.matches(".loom-in-use").count(), 1);
         assert_eq!(contents.matches(".loom/worktrees/").count(), 1);
+        assert_eq!(contents.matches(".loom/sweep-checkpoint/").count(), 1);
+        assert_eq!(contents.matches(".loom/locks/").count(), 1);
     }
 
     #[test]
@@ -389,9 +396,11 @@ mod tests {
             ".loom/mcp-command.json",
             ".loom/activity.db",
             ".loom/claims/",
+            ".loom/locks/",
             ".loom/signals/",
             ".loom/status/",
             ".loom/retry-state/",
+            ".loom/sweep-checkpoint/",
             ".loom/diagnostics/",
             ".loom/guide-docs-state.json",
             ".loom/metrics_state.json",


### PR DESCRIPTION
## Summary

The Loom-managed `.gitignore` block (`# >>> loom-managed >>>` … `# <<< loom-managed <<<`) is generated from a single source of truth: the `EPHEMERAL_PATTERNS` array in `loom-daemon/src/init/post_init.rs`. Two actively-written runtime dirs were missing:

- `.loom/sweep-checkpoint/` — sweep crash-resume checkpoints (written by `sweep-checkpoint.sh` / `sweep_registry.rs`)
- `.loom/locks/` — sweep registry / worktree locks (written by `sweep_registry.rs` / `worktree.sh`)

Their sibling runtime dirs (`worktrees/`, `claims/`, `signals/`, `status/`, `retry-state/`, `metrics/`, `diagnostics/`, …) were already listed.

## Changes

- Added both patterns to `EPHEMERAL_PATTERNS`, grouped with the other `.loom/*/` runtime-dir entries (`.loom/locks/` after `.loom/claims/`; `.loom/sweep-checkpoint/` after `.loom/retry-state/`).
- Extended the `post_init` unit tests to assert both dirs appear **exactly once** in the fresh-install output, in the idempotent repeated-run output, and in the `covers_all_source_repo_gitignore_patterns` expected list.

`managed_gitignore_block()` / `update_gitignore()` refresh the whole marked span in place, so this propagates to existing installs idempotently with no duplicate lines. No installer sync needed — the bash installer defers Loom patterns to the daemon. This repo's root `.gitignore` already lists both (L69, L73); the doc comment ("Keep in sync with the Loom source repo's `.gitignore`") remains accurate.

## Testing

- `cargo test --lib init::post_init` — 20 passed, 0 failed
- `cargo check` — clean

Closes #3635

🤖 Generated with [Claude Code](https://claude.com/claude-code)