### PR TITLE
fix(judge): forbid index-mutating git plumbing against the main checkout (#3637)

### DIFF
--- a/defaults/.claude/commands/loom/judge.md
+++ b/defaults/.claude/commands/loom/judge.md
@@ -363,6 +363,34 @@ This check applies everywhere the judge would run `gh pr checkout`:
 
 This catches merge conflicts early in the evaluation cycle, preventing wasted effort on code that will need to be rebased anyway.
 
+> ### ⛔ NEVER mutate the main checkout's real git index during a merge simulation or inspection
+>
+> **You run in the shared main checkout** — you either reuse the builder's `.loom/worktrees/issue-N` worktree or `gh pr checkout` in place. You do **not** own a disposable git index. Any command that writes the repository's real staging index corrupts the live checkout for every role that touches it next.
+>
+> **NEVER run any of these against the main checkout's real index** to "simulate a merge", preview a tree, or inspect conflicts:
+>
+> - **`git read-tree`** (bare, or `git read-tree <tree>` **without** an isolated `GIT_INDEX_FILE`) — a bare `git read-tree` is equivalent to `git read-tree --empty`: it silently empties the index, turning **every tracked file into a phantom staged deletion**. The working tree and `HEAD` are untouched and **no reflog entry is written**, so the damage is near-invisible until the next `git add -A` commits it.
+> - **`git commit-tree`** piped from a `read-tree`-populated index.
+> - **`git reset`**, **`git rm --cached`**, **`git add`**, or **`git checkout .`** used "just to simulate" a merge or a conflicting state.
+>
+> **Instead, use the index-free approach** (the same one `doctor.md` uses — see `doctor.md`'s merge-conflict check, `git merge-tree origin/main | grep -q "^+<<<<<<<"`):
+>
+> ```bash
+> # Merge preview — writes to the object store, NEVER the working index:
+> git merge-tree --write-tree <base> <branch>
+>
+> # Conflict detection only (older two-arg form):
+> git merge-tree <base> <branch>
+> ```
+>
+> If you genuinely must populate an index (you almost never do), **isolate it** so the real index is never touched:
+>
+> ```bash
+> GIT_INDEX_FILE="$(mktemp)" git read-tree <tree>
+> ```
+>
+> **Why this matters:** bare `read-tree` empties the live index, leaves the working tree and `HEAD` untouched, and writes **no reflog entry**, so recovery is hard and the corruption is easy to miss. Every role that operates in the main checkout (Judge, Champion, Auditor, Guide) is exposed to the same hazard — prefer `git merge-tree --write-tree` for any merge preview and reach for index-mutating plumbing only under an isolated `GIT_INDEX_FILE`.
+
 ### Check Merge State
 
 ```bash

--- a/defaults/hooks/guard-destructive.sh
+++ b/defaults/hooks/guard-destructive.sh
@@ -746,6 +746,33 @@ for pattern in "${ASK_PATTERNS[@]}"; do
 done
 
 # =============================================================================
+# git read-tree WITHOUT an isolating GIT_INDEX_FILE assignment
+#
+# A bare `git read-tree` (no tree-ish, no isolated index) is equivalent to
+# `git read-tree --empty`: it clobbers the repository's REAL staging index,
+# turning every tracked file into a phantom staged deletion. The working tree
+# and HEAD are left untouched and NO reflog entry is written, so the corruption
+# is silent and near-invisible (issue #3637 — a judge ran one against the main
+# checkout during a merge simulation and emptied the live index).
+#
+# This is an ASK (not a deny) because it is generic git hygiene, not a Loom
+# workflow rule, and an isolated form is legitimate. It is kept narrow: the
+# safe, index-free path is `git merge-tree --write-tree <base> <branch>` for a
+# merge preview, or `GIT_INDEX_FILE=$(mktemp) git read-tree <tree>` when a
+# temporary index really is needed. Any command that carries a `GIT_INDEX_FILE=`
+# assignment is treated as isolated and passes through untouched.
+#
+# `git commit-tree` is intentionally NOT guarded here — it writes a commit
+# object from an existing tree and does not mutate the index.
+# =============================================================================
+if echo "$COMMAND_NO_COMMENT" | grep -qE '(^|[;&|(]|[[:space:]])git[[:space:]]+read-tree'; then
+    # Isolated form (GIT_INDEX_FILE=... git read-tree ...) is allowed.
+    if ! echo "$COMMAND_NO_COMMENT" | grep -qE 'GIT_INDEX_FILE='; then
+        ask "Command requires confirmation: $COMMAND (a bare 'git read-tree' empties the real staging index with no reflog trace; use 'git merge-tree --write-tree <base> <branch>' for a merge preview, or isolate with GIT_INDEX_FILE=\$(mktemp))"
+    fi
+fi
+
+# =============================================================================
 # CLOUD CLI ASK patterns — gated by the cloud CLI guard toggle
 #
 # Kept separate from ASK_PATTERNS so cloud-dev repos can opt out

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -459,6 +459,20 @@ assert_ask "Ask for git clean -fd" \
 assert_ask "Ask for git checkout ." \
     "git checkout ."
 
+# --- git read-tree without GIT_INDEX_FILE isolation (#3637) ---
+# A bare `git read-tree` empties the real staging index with no reflog trace.
+assert_ask "Ask for bare git read-tree (#3637)" \
+    "git read-tree"
+
+assert_ask "Ask for git read-tree with a tree-ish but no GIT_INDEX_FILE (#3637)" \
+    "git read-tree HEAD"
+
+assert_ask "Ask for git read-tree -m merge sim without isolation (#3637)" \
+    "git read-tree -m HEAD origin/main"
+
+assert_ask "Ask for git read-tree at the end of a compound command (#3637)" \
+    "git fetch origin && git read-tree origin/main"
+
 assert_ask "Ask for gh pr close" \
     "gh pr close 42"
 
@@ -573,6 +587,21 @@ assert_allow "Allow docker logs (read-only)" \
 
 assert_allow "Allow sky status (read-only)" \
     "sky status"
+
+# --- git read-tree isolated via GIT_INDEX_FILE is allowed (#3637) ---
+assert_allow "Allow GIT_INDEX_FILE-isolated git read-tree (#3637)" \
+    "GIT_INDEX_FILE=\$(mktemp) git read-tree HEAD"
+
+assert_allow "Allow GIT_INDEX_FILE-isolated git read-tree with explicit temp path (#3637)" \
+    "GIT_INDEX_FILE=/tmp/idx.\$\$ git read-tree origin/main"
+
+# --- the safe, index-free merge-preview alternative is never guarded (#3637) ---
+assert_allow "Allow git merge-tree --write-tree (safe merge preview, #3637)" \
+    "git merge-tree --write-tree origin/main feature/my-branch"
+
+# --- git commit-tree does not mutate the index and is not guarded (#3637) ---
+assert_allow "Allow git commit-tree (does not touch the index, #3637)" \
+    "git commit-tree abc123 -m 'msg'"
 
 echo ""
 


### PR DESCRIPTION
Closes #3637

Hardens the judge tooling against silently emptying the main-checkout git index via a bare `git read-tree` during merge simulations. Both parts from the curator's scoped plan are included.

## Part 1 (REQUIRED) — Guidance hardening

Added a prominent, unambiguous subsection to the canonical judge source `defaults/.claude/commands/loom/judge.md` (at the top of the "Rebase Check" section, where merge-state handling begins). It:

- **Prohibits** index-mutating git plumbing against the main checkout's real index during any merge simulation or inspection — names the specific offenders: bare `git read-tree`, `git read-tree <tree>` without `GIT_INDEX_FILE`, `git commit-tree` piped from such, `git reset`, `git rm --cached`, `git add`, `git checkout .`.
- **Prescribes** the index-free safe path: `git merge-tree --write-tree <base> <branch>` (the same approach `doctor.md` already uses for its merge-conflict check — referenced explicitly), or `GIT_INDEX_FILE="$(mktemp)" git read-tree <tree>` isolation when a temporary index is truly needed.
- **States the rationale**: a bare `read-tree` empties the live index, leaves the working tree and `HEAD` untouched, and writes **no reflog entry**, so the corruption is near-invisible; every role in the main checkout (Judge, Champion, Auditor, Guide) is exposed.

Edited the canonical file only. `.loom/roles/judge.md` and `defaults/roles/judge.md` are symlinks that resolve to it (verified via `readlink -f`); the repo-root `.claude/...` copy is gitignored.

## Part 2 (RECOMMENDED) — Guard-hook defense-in-depth

Added an `ask`-tier block to `defaults/hooks/guard-destructive.sh` that catches a bare/unisolated `git read-tree` and **allows** the `GIT_INDEX_FILE=...` isolated form. Chosen as `ask` (not `deny`) because it is generic git hygiene, not a Loom workflow rule. `git commit-tree` is intentionally not guarded — it writes a commit object from an existing tree and does not mutate the index.

Added matching coverage to `tests/hooks/test-guard-destructive.sh`:
- `assert_ask` for bare `git read-tree`, `git read-tree HEAD`, `git read-tree -m HEAD origin/main`, and a compound `... && git read-tree origin/main`.
- `assert_allow` for `GIT_INDEX_FILE=$(mktemp) git read-tree HEAD`, an explicit-temp-path isolated form, `git merge-tree --write-tree ...`, and `git commit-tree ...`.

## Testing

`bash tests/hooks/test-guard-destructive.sh` → **262/263 pass**. All 8 new functional assertions pass. The single failing row is the known load-dependent perf-threshold check (`Average execution time: 248ms (> 200ms threshold)`), which is a timing flake unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)