### PR TITLE
fix(install): worktree-safe git-repo detection (#3649)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -363,8 +363,8 @@ TARGET_PATH="$(cd "$TARGET_PATH" && pwd 2>/dev/null)" || \
 info "Target repository: $TARGET_PATH"
 echo ""
 
-# Check if it's a git repository
-if [[ ! -d "$TARGET_PATH/.git" ]]; then
+# Check if it's a git repository (worktree-safe: a linked worktree's .git is a file)
+if ! git -C "$TARGET_PATH" rev-parse --git-dir >/dev/null 2>&1; then
   warning "$TARGET_PATH is not a git repository."
   echo ""
   echo "Would you like to initialize git and optionally set up GitHub?"

--- a/scripts/install/validate-target.sh
+++ b/scripts/install/validate-target.sh
@@ -38,8 +38,8 @@ TARGET_PATH="$(cd "$TARGET_PATH" && pwd)" || error "Target path does not exist: 
 
 info "Validating target: $TARGET_PATH"
 
-# Check if target is a git repository
-if [[ ! -d "$TARGET_PATH/.git" ]]; then
+# Check if target is a git repository (worktree-safe: a linked worktree's .git is a file)
+if ! git -C "$TARGET_PATH" rev-parse --git-dir >/dev/null 2>&1; then
   error "Target is not a git repository: $TARGET_PATH"
 fi
 success "Git repository detected"

--- a/scripts/uninstall-loom.sh
+++ b/scripts/uninstall-loom.sh
@@ -172,8 +172,8 @@ CURRENT_STEP="Validate Target"
 header "Step 1: Validating Target Repository"
 echo ""
 
-# Check if target is a git repository
-if [[ ! -d "$TARGET_PATH/.git" ]]; then
+# Check if target is a git repository (worktree-safe: a linked worktree's .git is a file)
+if ! git -C "$TARGET_PATH" rev-parse --git-dir >/dev/null 2>&1; then
   error "Target is not a git repository: $TARGET_PATH"
 fi
 success "Git repository detected"

--- a/tests/install/test-git-repo-detection.sh
+++ b/tests/install/test-git-repo-detection.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Test suite for git-repository detection in the installer/uninstaller.
+#
+# Usage: ./tests/install/test-git-repo-detection.sh
+#
+# Regression guard for #3649: a linked git worktree's `.git` is a FILE
+# (a `gitdir:` pointer), so the old `[[ -d "$TARGET_PATH/.git" ]]` idiom
+# misdetected a worktree as a non-repo. The canonical worktree-safe check
+# is `git -C "$dir" rev-parse --git-dir`, which succeeds for both normal
+# repos and linked worktrees. This test exercises that expression directly
+# against three fixtures.
+#
+# Self-contained, no network. Exit code 0 = all tests pass, 1 = failures.
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+assert_eq() {
+  local desc="$1"
+  local expected="$2"
+  local actual="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "${RED}FAIL${NC}: $desc"
+    echo "  expected: '$expected'"
+    echo "  actual:   '$actual'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# The detection expression under test — mirrors the fixed call sites in
+# install.sh, scripts/install/validate-target.sh, scripts/uninstall-loom.sh.
+# Echoes "repo" when the directory is a git repo (or worktree), "notrepo" otherwise.
+detect() {
+  local dir="$1"
+  if git -C "$dir" rev-parse --git-dir >/dev/null 2>&1; then
+    echo "repo"
+  else
+    echo "notrepo"
+  fi
+}
+
+# ----------------------------------------------------------------------------
+# Fixtures
+# ----------------------------------------------------------------------------
+WORK_DIR="$(mktemp -d)"
+cleanup() {
+  # `git worktree add` may leave the linked worktree registered; rm -rf is
+  # sufficient for temp fixtures since the parent repo is also disposable.
+  rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+# Isolate git config so host user settings / hooks don't interfere.
+export GIT_CONFIG_GLOBAL="$WORK_DIR/gitconfig"
+export GIT_CONFIG_SYSTEM=/dev/null
+export HOME="$WORK_DIR"
+git config --global user.email "test@example.com"
+git config --global user.name "Test"
+git config --global init.defaultBranch main
+
+# Fixture 1: a normal git repository.
+NORMAL_REPO="$WORK_DIR/normal-repo"
+mkdir -p "$NORMAL_REPO"
+git -C "$NORMAL_REPO" init -q
+git -C "$NORMAL_REPO" commit -q --allow-empty -m "initial"
+
+# Fixture 2: a linked worktree (its `.git` is a FILE, not a directory).
+LINKED_WORKTREE="$WORK_DIR/linked-worktree"
+git -C "$NORMAL_REPO" worktree add -q -b feature-branch "$LINKED_WORKTREE"
+
+# Fixture 3: an empty, non-repo directory.
+NON_REPO="$WORK_DIR/non-repo"
+mkdir -p "$NON_REPO"
+
+# ----------------------------------------------------------------------------
+# Sanity: confirm the fixture shapes are what we expect.
+# ----------------------------------------------------------------------------
+echo ""
+echo "=== Fixture sanity checks ==="
+
+TOTAL=$((TOTAL + 1))
+if [[ -d "$NORMAL_REPO/.git" ]]; then
+  echo -e "${GREEN}PASS${NC}: normal repo .git is a directory"
+  PASS=$((PASS + 1))
+else
+  echo -e "${RED}FAIL${NC}: normal repo .git is a directory"
+  FAIL=$((FAIL + 1))
+fi
+
+TOTAL=$((TOTAL + 1))
+if [[ -f "$LINKED_WORKTREE/.git" ]]; then
+  echo -e "${GREEN}PASS${NC}: linked worktree .git is a FILE (the regression trigger)"
+  PASS=$((PASS + 1))
+else
+  echo -e "${RED}FAIL${NC}: linked worktree .git is a FILE (the regression trigger)"
+  FAIL=$((FAIL + 1))
+fi
+
+# ----------------------------------------------------------------------------
+# Detection behavior
+# ----------------------------------------------------------------------------
+echo ""
+echo "=== Testing git-repo detection ==="
+
+assert_eq "normal git repo is detected as a repo" \
+  "repo" \
+  "$(detect "$NORMAL_REPO")"
+
+assert_eq "linked worktree is detected as a repo (regression #3649)" \
+  "repo" \
+  "$(detect "$LINKED_WORKTREE")"
+
+assert_eq "empty non-repo dir is correctly flagged as not a repo" \
+  "notrepo" \
+  "$(detect "$NON_REPO")"
+
+# ----------------------------------------------------------------------------
+# Regression guard: the OLD broken idiom would misdetect the worktree.
+# This documents WHY the fix was needed; it asserts the old check was wrong.
+# ----------------------------------------------------------------------------
+echo ""
+echo "=== Regression guard: old idiom would misdetect the worktree ==="
+
+old_detect() {
+  local dir="$1"
+  if [[ -d "$dir/.git" ]]; then echo "repo"; else echo "notrepo"; fi
+}
+
+assert_eq "old '-d .git' idiom misdetects the worktree (documents the bug)" \
+  "notrepo" \
+  "$(old_detect "$LINKED_WORKTREE")"
+
+# ----------------------------------------------------------------------------
+# Summary
+# ----------------------------------------------------------------------------
+echo ""
+echo "=========================================="
+echo -e "Results: ${PASS} passed, ${FAIL} failed, ${TOTAL} total"
+echo "=========================================="
+
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Fixes the `-d "$TARGET_PATH/.git"` idiom that misdetects a linked git worktree as a non-repo. A worktree's `.git` is a FILE (a `gitdir:` pointer), not a directory, so `[[ ! -d ... ]]` is false and the installer/uninstaller wrongly conclude "not a git repository".

## The 3 sites fixed

| # | File | Broken behavior on a worktree |
|---|------|-------------------------------|
| 1 | `install.sh:367` | warned "not a git repository" + offered **destructive `git init`** (primary bug) |
| 2 | `scripts/install/validate-target.sh:42` | hard `error "Target is not a git repository"` (Full Install path) |
| 3 | `scripts/uninstall-loom.sh:176` | hard error, blocking uninstall from a worktree |

Each now uses the canonical worktree-safe check already present in `scripts/install-loom.sh:315/320`:

```sh
if ! git -C "$TARGET_PATH" rev-parse --git-dir >/dev/null 2>&1; then
```

`rev-parse --git-dir` succeeds for both normal repos and linked worktrees, and still fails for genuine non-repos — so the init offer / error path is unchanged for real non-repos.

**Not touched** (per issue scope): `install-loom.sh:315/320` (already correct, regression reference) and `defaults/scripts/*.sh` (already worktree-safe).

## Test

New `tests/install/test-git-repo-detection.sh` (modeled on `test-forge-detect.sh`; self-contained, `set -euo pipefail`, no network). Three `mktemp -d` fixtures:
- normal repo → detected as repo (pass)
- `git worktree add` linked worktree, `.git` is a FILE → detected as repo (the regression, pass)
- empty non-repo dir → correctly flagged as not a repo

Plus a guard asserting the old `-d .git` idiom misdetected the worktree.

```
Results: 6 passed, 0 failed, 6 total
```

Adjacent install tests confirmed green: `test-forge-detect.sh` (19/19), `test-hooks-preserve.sh` (5/5), `test-uninstall-preserve-siblings.sh` (20/20).

Closes #3649

🤖 Generated with [Claude Code](https://claude.com/claude-code)