### PR TITLE
docs: repoint stale spawn-loop/daemon.sh references to current Tier 2 surface

### DIFF
--- a/defaults/scripts/check-host-sleep.sh
+++ b/defaults/scripts/check-host-sleep.sh
@@ -5,7 +5,7 @@
 # to stderr (and a brief one-liner to stdout) when the host is configured in a
 # way that could let it sleep mid-session, killing in-flight subagents (#3350).
 #
-# It is invoked at the start of /loom:sweep and the spawn loop. It MUST NOT
+# It is invoked at the start of /loom:sweep. It MUST NOT
 # block — even if detection fails, it returns 0 and orchestration proceeds.
 #
 # Usage:

--- a/defaults/scripts/validate-toolchain.sh
+++ b/defaults/scripts/validate-toolchain.sh
@@ -2,12 +2,12 @@
 # validate-toolchain.sh - Validate loom-tools commands are available
 #
 # Validates that essential loom-tools commands are installed and accessible
-# before the spawn loop (Tier 2) enters its main loop. Provides tiered
-# validation with critical vs optional commands.
+# before Tier 2 dispatch (/loom:sweep / loom-daemon) drives worker roles.
+# Provides tiered validation with critical vs optional commands.
 #
 # Exit codes:
 #   0 - All critical commands available (optional warnings may exist)
-#   1 - Critical commands missing (spawn loop cannot start)
+#   1 - Critical commands missing (dispatch cannot start)
 #   2 - Invalid arguments
 #
 # Usage:
@@ -18,7 +18,7 @@
 
 set -euo pipefail
 
-# Critical commands - spawn loop cannot function without these
+# Critical commands - /loom:sweep / loom-daemon dispatch cannot function without these
 CRITICAL_COMMANDS=(
     "loom-cleanup"
     "loom-orphan-recovery"
@@ -306,13 +306,13 @@ output_text() {
         degraded)
             echo -e "${YELLOW}Status: DEGRADED${NC} - Optional commands missing"
             echo ""
-            echo "The spawn loop will continue with degraded functionality."
+            echo "Dispatch will continue with degraded functionality."
             echo "Some features (stuck detection, health monitoring) may not work."
             ;;
         critical)
             echo -e "${RED}Status: CRITICAL${NC} - Essential commands missing"
             echo ""
-            echo "The spawn loop cannot start without these commands."
+            echo "Dispatch cannot start without these commands."
             echo ""
             echo "To install loom-tools, run:"
             echo "  pip install -e ./loom-tools"

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -342,16 +342,18 @@ Every 15 minutes: Review issue backlog, update priorities and organization
 
 ### Setting Up Autonomous Agents (post-v0.10.0)
 
-> **The Python `loom-daemon` brain was removed in v0.10.0; the shell-level
-> daemon surface is preserved.** Historical guidance like "start the
+> **The Python `loom-daemon` brain was removed in v0.10.0 and replaced by
+> the Rust `loom-daemon` binary.** Historical guidance like "start the
 > daemon, it manages roles on a schedule, and spawns shepherds per issue"
 > no longer matches the codebase — the Python brain, the shepherd pool,
 > and the `/shepherd` slash command were all deleted as part of the
-> shepherd/daemon deprecation epic (#3372). However,
-> `./.loom/scripts/daemon.sh` (start/stop/status) survives, re-implemented
-> as a tmux session launcher around the spawn loop + GitHub Actions cron +
-> token-rotated separate Claude Code sessions. For the breaking-change
-> inventory and per-CLI replacement table, see
+> shepherd/daemon deprecation epic (#3372). The Tier 2 surface today is the
+> Rust `loom-daemon` binary, which exposes MCP-level dispatch
+> (`mcp__loom__dispatch_sweep`, `mcp__loom__list_sweeps`,
+> `mcp__loom__cancel_sweep`, plus the event bus) for token-rotated
+> `/loom:sweep` children, alongside GitHub Actions cron for the periodic
+> support roles. For the breaking-change inventory and per-CLI replacement
+> table, see
 > [`docs/migration/v0.10.0-shepherd-deprecation.md`](migration/v0.10.0-shepherd-deprecation.md)
 > and [`.loom/docs/daemon-reference.md`](../.loom/docs/daemon-reference.md).
 


### PR DESCRIPTION
## Summary

Three tracked sources still presented the removed v0.9.x spawn loop (and the nonexistent `daemon.sh`) as current mechanisms. This updates them to describe the current Tier 2 surface — the Rust `loom-daemon` binary (MCP dispatch) + GitHub Actions cron.

## Changes

- **`docs/agents.md`** (blockquote in "Setting Up Autonomous Agents"): rewritten to drop both the "spawn loop" framing and the reference to `./.loom/scripts/daemon.sh` (which no longer exists in the tree). Now describes `loom-daemon` MCP-level dispatch (`mcp__loom__dispatch_sweep` / `list_sweeps` / `cancel_sweep` + event bus) and GitHub Actions cron. Matches the past-tense tone of the surrounding text.
- **`defaults/scripts/validate-toolchain.sh`**: header/usage comments and echo strings (lines ~5, 10, 21, 309, 315) that named "the spawn loop (Tier 2)" as the current gated mechanism now refer to `/loom:sweep` / `loom-daemon` dispatch.
- **`defaults/scripts/check-host-sleep.sh`**: dropped the "and the spawn loop" clause from the invocation comment.

Comment/echo-string only — no behavior change. Only tracked `defaults/scripts/*` sources and `docs/agents.md` were edited; gitignored `.loom/scripts/*` installed copies were left untouched per the curator's scope guard.

## Verification

- `bash -n defaults/scripts/validate-toolchain.sh && bash -n defaults/scripts/check-host-sleep.sh` — syntax OK.
- `grep -rn "spawn loop\|daemon\.sh"` over the three target sites: `docs/agents.md` no longer references `daemon.sh` and its only surviving spawn-loop hit is the pre-existing past-tense removal note; both scripts are clean.

Remaining repo-wide hits live in ADRs, migration guides, and design docs that frame the spawn loop historically (past-tense) — out of scope per the curator's explicit three-site scope guard.

Closes #3652

🤖 Generated with [Claude Code](https://claude.com/claude-code)