### PR TITLE
test(hooks): warn-not-fail guard perf check with opt-in strict gate

### DIFF
--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -1194,6 +1194,20 @@ echo ""
 echo -e "${YELLOW}--- Performance check ---${NC}"
 # =========================================================================
 
+# The measured average is dominated by 10 sequential guard process spawns
+# (shell + jq/python3 interpreter startup), which is a function of machine
+# load rather than guard-logic complexity. A hard cap therefore flakes under
+# contention, so by default this row is INFORMATIONAL: it always prints the
+# measured average but never increments FAIL.
+#
+# Env vars:
+#   LOOM_GUARD_PERF_MAX_MS  - threshold in ms for the printed comparison
+#                             (default 200).
+#   LOOM_GUARD_PERF_STRICT  - set to 1/true to restore a hard gate: when the
+#                             average meets/exceeds LOOM_GUARD_PERF_MAX_MS the
+#                             suite fails (FAIL++/exit 1). Intended only for
+#                             runs on a deliberately quiescent machine.
+PERF_MAX_MS="${LOOM_GUARD_PERF_MAX_MS:-200}"
 TOTAL=$((TOTAL + 1))
 START=$(date +%s%N 2>/dev/null || python3 -c "import time; print(int(time.time()*1e9))")
 for i in $(seq 1 10); do
@@ -1203,12 +1217,15 @@ END=$(date +%s%N 2>/dev/null || python3 -c "import time; print(int(time.time()*1
 ELAPSED_MS=$(( (END - START) / 1000000 ))
 AVG_MS=$((ELAPSED_MS / 10))
 
-if [[ $AVG_MS -lt 200 ]]; then
+if [[ $AVG_MS -lt $PERF_MAX_MS ]]; then
     PASS=$((PASS + 1))
-    echo -e "  ${GREEN}PASS${NC}: Average execution time: ${AVG_MS}ms (< 200ms threshold)"
-else
+    echo -e "  ${GREEN}PASS${NC}: Average execution time: ${AVG_MS}ms (< ${PERF_MAX_MS}ms threshold)"
+elif [[ "${LOOM_GUARD_PERF_STRICT:-}" == "1" || "${LOOM_GUARD_PERF_STRICT:-}" == "true" ]]; then
     FAIL=$((FAIL + 1))
-    echo -e "  ${RED}FAIL${NC}: Average execution time: ${AVG_MS}ms (> 200ms threshold)"
+    echo -e "  ${RED}FAIL${NC}: Average execution time: ${AVG_MS}ms (>= ${PERF_MAX_MS}ms threshold, LOOM_GUARD_PERF_STRICT)"
+else
+    PASS=$((PASS + 1))
+    echo -e "  ${YELLOW}INFO${NC}: Average execution time: ${AVG_MS}ms (>= ${PERF_MAX_MS}ms threshold; informational only, set LOOM_GUARD_PERF_STRICT=1 to gate)"
 fi
 
 echo ""


### PR DESCRIPTION
Closes #3653

## Problem

The **Performance check** row in `tests/hooks/test-guard-destructive.sh` timed 10 sequential `$GUARD` process spawns against a hardcoded 200ms cap and incremented `FAIL` (forcing `exit 1`) on exceed. That wall time is dominated by shell + `jq`/`python3` interpreter startup — a function of machine load, not guard-logic complexity — so it flaked under contention (observed 178-248ms across identical runs) and could red the entire functional suite.

## Fix (curator-confirmed approach (b))

- **Informational by default**: always print the measured average; never increment `FAIL` in the default path. A gross perf regression is still visible in the output.
- **Opt-in strict gate**: `LOOM_GUARD_PERF_STRICT=1` (or `true`) restores the hard `FAIL`/`exit 1` behavior.
- **Env-overridable threshold**: `LOOM_GUARD_PERF_MAX_MS` (default 200) replaces the hardcoded 200 for both the printed comparison and the strict gate.
- Both env vars documented in a comment above the block.

Functional assertions (`assert_allow`/`assert_deny`/`*_env`, rmScope, force-push/gh-delete rows) are untouched and still gate the suite.

## Verification

- `bash tests/hooks/test-guard-destructive.sh` → perf row prints `INFO` (239ms > 200), suite exits **0** (263/263 passed).
- `LOOM_GUARD_PERF_STRICT=1 LOOM_GUARD_PERF_MAX_MS=1 bash ...` → perf row `FAIL`, suite exits **1** (opt-in gate trips).
- `LOOM_GUARD_PERF_MAX_MS=1 bash ...` (no strict) → `INFO` only, exits **0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)