### PR TITLE
fix(install): make wrapper honor its own --allow-non-main-source / --allow-stale-target suggestion

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,10 +3,14 @@
 # Usage: ./install.sh [OPTIONS] [/path/to/target-repo]
 #
 # Options:
-#   -y, --yes    Non-interactive mode (skip confirmation prompts)
-#   --quick      Quick Install - direct install without GitHub workflow
-#   --full       Full Install - creates issue, worktree, and PR
-#   -h, --help   Show this help message
+#   -y, --yes                  Non-interactive mode (skip confirmation prompts)
+#   --quick                    Quick Install - direct install without GitHub workflow
+#   --full                     Full Install - creates issue, worktree, and PR
+#   --allow-non-main-source    Permit installing from a non-main / detached-HEAD Loom source
+#                              (forwarded to scripts/install-loom.sh)
+#   --allow-stale-target       Permit installing over a target whose Loom is newer/stale
+#                              (forwarded to scripts/install-loom.sh)
+#   -h, --help                 Show this help message
 #
 # Examples:
 #   ./install.sh --quick ~/projects/my-app
@@ -286,6 +290,11 @@ echo ""
 # Parse flags
 NON_INTERACTIVE=false
 INSTALL_TYPE=""
+# Source/target override flags accepted by scripts/install-loom.sh. The top-level
+# wrapper does not act on them (its source guard runs only in the delegated
+# installer), but it must accept and forward them so the flags it suggests
+# actually work. See issue #3650.
+SOURCE_OVERRIDE_FLAGS=()
 while [[ "${1:-}" == -* ]]; do
   case "$1" in
     -y|--yes)
@@ -310,19 +319,30 @@ while [[ "${1:-}" == -* ]]; do
       NON_INTERACTIVE=true  # --full implies non-interactive
       shift
       ;;
+    --allow-non-main-source|--allow-stale-target)
+      # Pass-through: accepted here so the wrapper's own suggestion works, then
+      # forwarded to scripts/install-loom.sh at the Full-Install delegation execs.
+      SOURCE_OVERRIDE_FLAGS+=("$1")
+      shift
+      ;;
     -h|--help)
       echo "Usage: ./install.sh [OPTIONS] [TARGET_PATH]"
       echo ""
       echo "Options:"
-      echo "  -y, --yes    Non-interactive mode (skip confirmation prompts)"
-      echo "  --quick      Quick Install - direct install without GitHub workflow"
-      echo "  --full       Full Install - creates issue, worktree, and PR"
-      echo "  -h, --help   Show this help message"
+      echo "  -y, --yes                  Non-interactive mode (skip confirmation prompts)"
+      echo "  --quick                    Quick Install - direct install without GitHub workflow"
+      echo "  --full                     Full Install - creates issue, worktree, and PR"
+      echo "  --allow-non-main-source    Permit installing from a non-main / detached-HEAD"
+      echo "                             Loom source (forwarded to scripts/install-loom.sh)"
+      echo "  --allow-stale-target       Permit installing over a newer/stale target"
+      echo "                             (forwarded to scripts/install-loom.sh)"
+      echo "  -h, --help                 Show this help message"
       echo ""
       echo "Examples:"
       echo "  ./install.sh --quick ~/projects/my-app"
       echo "  ./install.sh --full /path/to/team-project"
       echo "  ./install.sh -y ~/projects/my-app  # Non-interactive, defaults to quick install"
+      echo "  ./install.sh --yes --allow-non-main-source /path/to/target  # Install from a non-main source"
       exit 0
       ;;
     *)
@@ -885,7 +905,7 @@ elif [[ -d "$TARGET_PATH/.loom" ]]; then
   if [[ "$NON_INTERACTIVE" == true ]]; then
     INSTALL_FLAGS+=(--yes)
   fi
-  exec "$LOOM_ROOT/scripts/install-loom.sh" ${INSTALL_FLAGS[@]+"${INSTALL_FLAGS[@]}"} "$TARGET_PATH"
+  exec "$LOOM_ROOT/scripts/install-loom.sh" ${INSTALL_FLAGS[@]+"${INSTALL_FLAGS[@]}"} ${SOURCE_OVERRIDE_FLAGS[@]+"${SOURCE_OVERRIDE_FLAGS[@]}"} "$TARGET_PATH"
 else
   FORCE_FLAG=""
   SELF_INSTALL=false
@@ -1091,7 +1111,7 @@ case "$METHOD" in
     echo ""
 
     # Run the full installation workflow
-    exec "$LOOM_ROOT/scripts/install-loom.sh" $FORCE_FLAG "$TARGET_PATH"
+    exec "$LOOM_ROOT/scripts/install-loom.sh" $FORCE_FLAG ${SOURCE_OVERRIDE_FLAGS[@]+"${SOURCE_OVERRIDE_FLAGS[@]}"} "$TARGET_PATH"
     ;;
 esac
 

--- a/scripts/test-installer.sh
+++ b/scripts/test-installer.sh
@@ -40,6 +40,7 @@ warn() {
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LOOM_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 INSTALL_SCRIPT="$LOOM_ROOT/scripts/install-loom.sh"
+WRAPPER_SCRIPT="$LOOM_ROOT/install.sh"
 UNINSTALL_SCRIPT="$LOOM_ROOT/scripts/uninstall-loom.sh"
 DEFAULTS_DIR="$LOOM_ROOT/defaults"
 
@@ -1496,6 +1497,75 @@ if echo "$STDERR_45" | grep -q 'install\.sh'; then
   pass "flag-rejection stderr contains 'install.sh' hint text"
 else
   fail "flag-rejection stderr is missing 'install.sh' hint (stderr=$STDERR_45)"
+fi
+echo ""
+
+# ==========================================================================
+# Section 8b: Wrapper Pass-Through Flags (#3650)
+# ==========================================================================
+# The top-level install.sh wrapper previously rejected --allow-non-main-source
+# and --allow-stale-target with "Unknown flag" even though it suggested the
+# former in its own delegated installer, and its delegation execs forwarded
+# only --yes/$FORCE_FLAG. These tests verify the wrapper now accepts and
+# forwards the two source/target override flags that scripts/install-loom.sh
+# already honors.
+echo "--- Section 8b: Wrapper Pass-Through Flags (#3650) ---"
+echo ""
+
+# Test 48: install.sh --allow-non-main-source is NOT rejected as an unknown flag.
+# Trailing --help makes the parser exit 0 after accumulating the pass-through
+# flag, so no real install runs. A rejected flag would error before --help.
+echo "Test 48: install.sh accepts --allow-non-main-source (no 'Unknown flag')"
+OUT_48=$("$WRAPPER_SCRIPT" --allow-non-main-source --help 2>&1 || true)
+if echo "$OUT_48" | grep -q 'Unknown flag'; then
+  fail "install.sh rejected --allow-non-main-source (out=$OUT_48)"
+elif echo "$OUT_48" | grep -q 'Usage:'; then
+  pass "--allow-non-main-source accepted (parser reached --help)"
+else
+  fail "install.sh --allow-non-main-source produced unexpected output (out=$OUT_48)"
+fi
+echo ""
+
+# Test 49: install.sh --allow-stale-target is likewise accepted.
+echo "Test 49: install.sh accepts --allow-stale-target (no 'Unknown flag')"
+OUT_49=$("$WRAPPER_SCRIPT" --allow-stale-target --help 2>&1 || true)
+if echo "$OUT_49" | grep -q 'Unknown flag'; then
+  fail "install.sh rejected --allow-stale-target (out=$OUT_49)"
+elif echo "$OUT_49" | grep -q 'Usage:'; then
+  pass "--allow-stale-target accepted (parser reached --help)"
+else
+  fail "install.sh --allow-stale-target produced unexpected output (out=$OUT_49)"
+fi
+echo ""
+
+# Test 50: a genuinely unknown flag is still rejected by install.sh.
+echo "Test 50: install.sh still rejects a genuinely unknown flag"
+OUT_50=$("$WRAPPER_SCRIPT" --bogus /tmp/fakepath 2>&1 || true)
+if echo "$OUT_50" | grep -q 'Unknown flag: --bogus'; then
+  pass "--bogus rejected with 'Unknown flag: --bogus'"
+else
+  fail "install.sh should reject --bogus with 'Unknown flag' (out=$OUT_50)"
+fi
+echo ""
+
+# Test 51: install.sh --help documents the two pass-through flags.
+echo "Test 51: install.sh --help lists the pass-through flags"
+OUT_51=$("$WRAPPER_SCRIPT" --help 2>&1 || true)
+if echo "$OUT_51" | grep -q -- '--allow-non-main-source' && echo "$OUT_51" | grep -q -- '--allow-stale-target'; then
+  pass "--help documents --allow-non-main-source and --allow-stale-target"
+else
+  fail "install.sh --help is missing pass-through flag documentation (out=$OUT_51)"
+fi
+echo ""
+
+# Test 52: both Full-Install delegation execs forward the pass-through array so
+# the accepted flags actually reach scripts/install-loom.sh.
+echo "Test 52: install.sh forwards SOURCE_OVERRIDE_FLAGS at both delegation execs"
+FORWARD_COUNT=$(grep -c 'install-loom.sh".*SOURCE_OVERRIDE_FLAGS\[@\]' "$WRAPPER_SCRIPT" || true)
+if [[ "$FORWARD_COUNT" -eq 2 ]]; then
+  pass "both delegation execs forward SOURCE_OVERRIDE_FLAGS (count=$FORWARD_COUNT)"
+else
+  fail "expected 2 delegation execs forwarding SOURCE_OVERRIDE_FLAGS, found $FORWARD_COUNT"
 fi
 echo ""
 


### PR DESCRIPTION
## Summary

`install.sh` tells users to pass `--allow-non-main-source` (and its pair `--allow-stale-target`), but its own flag parser rejected them with `Unknown flag`, and the Full-Install delegation execs forwarded only `--yes`/`$FORCE_FLAG` — so the flags were dropped even if the parser had accepted them. The inner `scripts/install-loom.sh` already declares, accepts, and honors both flags; this PR makes the wrapper honor its own advice (curator option i).

## Changes (`install.sh`)

1. **Parser** — added a pass-through case for `--allow-non-main-source` / `--allow-stale-target` that accumulates into a new `SOURCE_OVERRIDE_FLAGS` array (accept-and-collect only; the wrapper's source guard runs only in the delegated installer).
2. **Forwarding** — both Full-Install delegation execs (reinstall→Full and Full) now append `${SOURCE_OVERRIDE_FLAGS[@]+"${SOURCE_OVERRIDE_FLAGS[@]}"}` (empty-safe expansion matching the existing `INSTALL_FLAGS` pattern).
3. **Docs** — `--help` text and the header comment now list both pass-through flags.

`scripts/install-loom.sh` is unchanged (it already accepts and honors the flags).

## Tests (`scripts/test-installer.sh`, Section 8b)

- Test 48/49: wrapper accepts `--allow-non-main-source` / `--allow-stale-target` (no `Unknown flag`; parser reaches `--help`).
- Test 50: a genuinely unknown flag (`--bogus`) is still rejected.
- Test 51: `--help` documents both flags.
- Test 52: both delegation execs forward `SOURCE_OVERRIDE_FLAGS`.

Full suite green: 121 passed, 0 failed.

Closes #3650

🤖 Generated with [Claude Code](https://claude.com/claude-code)