### PR TITLE
fix(sweep): baseline mechanism for check-main-clean.sh to ignore pre-existing dirt

### DIFF
--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -899,6 +899,17 @@ For each wave `W` (partition of the issue list into chunks of up to `--builders-
 
 See `.claude/commands/loom/shepherd-lifecycle.md` for the canonical phase-by-phase reference, label state machine, and recovery procedures. The summary below tells you which skill to invoke at each phase; the lifecycle reference tells you what each phase does in detail.
 
+### 0. Snapshot the main-worktree baseline (once, before wave 1) (#3648)
+
+**Before dispatching the first wave's builders**, snapshot main's current working-tree state so the per-wave contamination backstop (step 4's `check-main-clean.sh`) can distinguish builder contamination from dirt that predated the sweep:
+
+```bash
+MAIN_CLEAN_BASELINE=".loom/sweep-checkpoint/main-clean-baseline.txt"
+./.loom/scripts/check-main-clean.sh --snapshot "$MAIN_CLEAN_BASELINE"
+```
+
+Capture this **once, before wave 1 — never per-wave**. The baseline must reflect the pre-sweep state so that if an early wave contaminates main and the dirt is not reverted, every later wave's backstop still flags it (a per-wave re-snapshot would silently absorb that contamination into the "pre-existing" set). The baseline path is a gitignored per-sweep-run transient (`.loom/sweep-checkpoint/` is already gitignored); its lifetime is this sweep invocation. If the snapshot step fails for any reason, proceed anyway — step 4's backstop falls back to the whole-status hard-fail when the baseline file is missing (fail-safe, never a silent pass).
+
 ### Checkpoint-driven resume (#3373)
 
 Sweep persists a per-issue phase checkpoint after each successful lifecycle phase so that a killed-and-relaunched sweep can pick up where it left off. The checkpoint is the **only** state required to resume — worktree preservation is handled by `worktree.sh`'s idempotency (re-running for an existing worktree is a no-op).
@@ -1026,10 +1037,12 @@ Each builder is responsible for:
 **Backstop: verify the main worktree is clean after the builders return (#3513).** A builder subagent runs without `LOOM_WORKTREE_PATH` injected, so the `guard-worktree-paths.sh` hook does not fire on this path. If a builder used repo-relative paths after a cwd reset, it may have written to the **main** worktree instead of its issue worktree. After the wave's builders return and before advancing any PR to Judge, run:
 
 ```bash
-./.loom/scripts/check-main-clean.sh   # exit 3 ⇒ main is dirty (builder contamination)
+./.loom/scripts/check-main-clean.sh --baseline "$MAIN_CLEAN_BASELINE"   # exit 3 ⇒ NEW main dirt (builder contamination)
 ```
 
-If it exits `3`, the main worktree carries uncommitted changes a builder left behind. Surface this loudly in the wave summary and do not advance the wave to Judge until the contamination is investigated and the stray changes reverted. This is a backstop only — the builder guidance (capture the absolute worktree path once, use absolute paths everywhere) is the primary defense.
+The `--baseline` argument points at the snapshot taken once at step 0 (before wave 1). With it, the check subtracts any dirt that predated the sweep and exits `3` **only** on changes that appeared after the snapshot — so pre-existing working-tree dirt (a regenerated lockfile, an operator scratch edit) no longer false-positives as contamination on every wave (#3648). If the baseline file is missing or unreadable, the check warns and falls back to the whole-status hard-fail (fail-safe).
+
+If it exits `3`, the main worktree carries **new** uncommitted changes a builder left behind. Surface this loudly in the wave summary and do not advance the wave to Judge until the contamination is investigated and the stray changes reverted. This is a backstop only — the builder guidance (capture the absolute worktree path once, use absolute paths everywhere) is the primary defense.
 
 **On successful PR creation**, write the `builder-done` checkpoint for that issue (record the PR number):
 ```bash

--- a/defaults/scripts/check-main-clean.sh
+++ b/defaults/scripts/check-main-clean.sh
@@ -15,14 +15,36 @@
 # from the repo root or from a worktree.
 #
 # Usage:
-#   ./.loom/scripts/check-main-clean.sh            # check main worktree, exit 3 if dirty
-#   ./.loom/scripts/check-main-clean.sh --help     # show usage
+#   ./.loom/scripts/check-main-clean.sh                  # check main worktree, exit 3 if dirty
+#   ./.loom/scripts/check-main-clean.sh --snapshot FILE  # record main's porcelain state to FILE, exit 0
+#   ./.loom/scripts/check-main-clean.sh --baseline FILE  # check main, ignoring dirt recorded in FILE
+#   ./.loom/scripts/check-main-clean.sh --help           # show usage
+#
+# Baseline mechanism (#3648):
+#   The plain (no-arg) check treats ANY uncommitted change on main as builder
+#   contamination. That false-positives when the main worktree carried
+#   pre-existing, unrelated dirt (a regenerated lockfile, a scratch edit) before
+#   the sweep even started. The baseline mechanism lets a caller (e.g. /loom:sweep)
+#   snapshot main's porcelain state ONCE at sweep start, then pass that snapshot
+#   as a --baseline on each post-wave check. Only changes that appeared AFTER the
+#   snapshot (set difference on exact porcelain lines) are treated as
+#   contamination; pre-existing dirt is ignored.
+#
+#     ./.loom/scripts/check-main-clean.sh --snapshot .loom/main-clean-baseline.txt   # once, before wave 1
+#     ./.loom/scripts/check-main-clean.sh --baseline .loom/main-clean-baseline.txt   # after each wave
+#
+#   Fail-safe: if the --baseline FILE is missing or unreadable, the check warns
+#   to stderr and falls back to the plain whole-status behavior (never a silent
+#   pass). With NO --baseline/--snapshot argument, behavior is byte-for-byte
+#   identical to the pre-#3648 whole-status hard-fail — the builder.md /
+#   builder-worktree.md manual call sites depend on that contract.
 #
 # Exit codes:
-#   0 - Main worktree is clean (no uncommitted changes).
+#   0 - Main worktree is clean (or, in --baseline mode, only pre-existing dirt
+#       remains); or a --snapshot completed successfully.
 #   2 - Usage error or could not resolve the main worktree (not a git repo).
 #   3 - Main worktree is DIRTY: uncommitted changes detected (the contamination
-#       this guard exists to catch).
+#       this guard exists to catch). In --baseline mode, only NEW changes count.
 #
 # Notes:
 #   - "Dirty" means `git status --porcelain` on the MAIN worktree returns any
@@ -38,8 +60,13 @@ EXIT_USAGE=2
 EXIT_MAIN_DIRTY=3
 
 usage() {
-    sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+    sed -n '2,54p' "$0" | sed 's/^# \{0,1\}//'
 }
+
+# ---- Argument parsing ----------------------------------------------------
+# Modes: plain (no args, legacy back-compat), snapshot, baseline.
+MODE="plain"
+MODE_FILE=""
 
 case "${1:-}" in
     -h|--help)
@@ -48,6 +75,24 @@ case "${1:-}" in
         ;;
     "")
         ;;
+    --snapshot)
+        if [[ -z "${2:-}" ]]; then
+            echo "check-main-clean.sh: --snapshot requires a file argument" >&2
+            echo "Run with --help for usage." >&2
+            exit "$EXIT_USAGE"
+        fi
+        MODE="snapshot"
+        MODE_FILE="$2"
+        ;;
+    --baseline)
+        if [[ -z "${2:-}" ]]; then
+            echo "check-main-clean.sh: --baseline requires a file argument" >&2
+            echo "Run with --help for usage." >&2
+            exit "$EXIT_USAGE"
+        fi
+        MODE="baseline"
+        MODE_FILE="$2"
+        ;;
     *)
         echo "check-main-clean.sh: unknown argument: $1" >&2
         echo "Run with --help for usage." >&2
@@ -55,6 +100,7 @@ case "${1:-}" in
         ;;
 esac
 
+# ---- Resolve the main worktree root --------------------------------------
 # Resolve the canonical git common dir, then the main worktree root (its parent).
 # This works from the repo root AND from inside any worktree.
 common_dir=$(git rev-parse --git-common-dir 2>/dev/null || true)
@@ -74,7 +120,47 @@ fi
 
 status=$(git -C "$main_root" status --porcelain 2>/dev/null || true)
 
-if [[ -n "$status" ]]; then
+# ---- Snapshot mode: record and exit --------------------------------------
+if [[ "$MODE" == "snapshot" ]]; then
+    # Ensure the parent directory exists so callers can point at .loom/ transients.
+    snap_dir=$(dirname "$MODE_FILE")
+    if [[ -n "$snap_dir" && ! -d "$snap_dir" ]]; then
+        mkdir -p "$snap_dir" 2>/dev/null || true
+    fi
+    if ! printf '%s\n' "$status" > "$MODE_FILE" 2>/dev/null; then
+        echo "check-main-clean.sh: could not write snapshot to '$MODE_FILE'" >&2
+        exit "$EXIT_USAGE"
+    fi
+    echo "check-main-clean.sh: snapshot of main worktree written to $MODE_FILE ($main_root)"
+    exit "$EXIT_OK"
+fi
+
+# ---- Baseline mode: subtract pre-existing dirt ---------------------------
+# Only lines that appear in the current status but NOT in the baseline are
+# treated as new (builder) contamination. A missing/unreadable baseline falls
+# back to the plain whole-status behavior (fail-safe, never a silent pass).
+effective_status="$status"
+ignored=0
+if [[ "$MODE" == "baseline" ]]; then
+    if [[ -r "$MODE_FILE" ]]; then
+        # Set difference: current porcelain lines minus baseline lines.
+        # comm -13 prints lines unique to the second (current) input.
+        effective_status=$(comm -13 \
+            <(sort "$MODE_FILE") \
+            <(printf '%s\n' "$status" | sort) \
+            | sed '/^$/d')
+        pre_existing=$(printf '%s\n' "$status" | sed '/^$/d' | grep -c '' || true)
+        new_count=$(printf '%s\n' "$effective_status" | sed '/^$/d' | grep -c '' || true)
+        ignored=$(( pre_existing - new_count ))
+        if [[ "$ignored" -lt 0 ]]; then ignored=0; fi
+    else
+        echo "WARNING: check-main-clean.sh: baseline file '$MODE_FILE' is missing or unreadable." >&2
+        echo "         Falling back to whole-status check (fail-safe)." >&2
+        effective_status="$status"
+    fi
+fi
+
+if [[ -n "$effective_status" ]]; then
     echo "ERROR: MAIN worktree is dirty (uncommitted changes detected)." >&2
     echo "       Main worktree: $main_root" >&2
     echo "" >&2
@@ -83,12 +169,22 @@ if [[ -n "$status" ]]; then
     echo "       Builders MUST capture the absolute worktree path once and use" >&2
     echo "       absolute paths for every Write/Edit/Bash file operation." >&2
     echo "" >&2
+    if [[ "$ignored" -gt 0 ]]; then
+        echo "       ($ignored pre-existing change(s) ignored via baseline $MODE_FILE)" >&2
+        echo "" >&2
+    fi
     echo "       Offending changes:" >&2
     while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
         echo "         $line" >&2
-    done <<< "$status"
+    done <<< "$effective_status"
     exit "$EXIT_MAIN_DIRTY"
 fi
 
-echo "check-main-clean.sh: main worktree is clean ($main_root)"
+if [[ "$ignored" -gt 0 ]]; then
+    echo "check-main-clean.sh: main worktree carries only pre-existing dirt, no new contamination ($main_root)"
+    echo "check-main-clean.sh: $ignored pre-existing change(s) ignored via baseline $MODE_FILE"
+else
+    echo "check-main-clean.sh: main worktree is clean ($main_root)"
+fi
 exit "$EXIT_OK"

--- a/defaults/scripts/tests/test-check-main-clean.sh
+++ b/defaults/scripts/tests/test-check-main-clean.sh
@@ -14,6 +14,10 @@
 #   - exit 0 from inside a worktree when main is clean
 #   - exit 0 / coherent output for --help
 #   - exit 2 for an unknown argument
+#   - --snapshot FILE records main's porcelain state (#3648)
+#   - --baseline FILE ignores pre-existing dirt but flags genuinely-new changes
+#   - missing baseline file falls back to whole-status hard-fail (fail-safe)
+#   - no-arg invocation remains a byte-for-byte whole-status hard-fail (back-compat)
 #
 # Usage:
 #   ./.loom/scripts/tests/test-check-main-clean.sh
@@ -57,7 +61,7 @@ make_repo() {
     git -C "$dir" init -q
     git -C "$dir" config user.email t@t.t
     git -C "$dir" config user.name test
-    printf '.loom/worktrees/\n' > "$dir/.gitignore"
+    printf '.loom/worktrees/\n.loom/sweep-checkpoint/\n' > "$dir/.gitignore"
     git -C "$dir" add .gitignore
     git -C "$dir" commit -q -m init
     echo "$dir"
@@ -132,6 +136,83 @@ if [[ "$RC" -eq 2 ]]; then pass "exit 2 on unknown argument"; else fail "expecte
 
 # Cleanup
 git -C "$REPO" worktree remove --force .loom/worktrees/issue-99 2>/dev/null || true
+rm -rf "$REPO"
+
+# ========================================================================
+# Baseline / snapshot mode (#3648)
+# ========================================================================
+
+# -------- Test 10: --snapshot writes main's porcelain content, exits 0 --------
+echo "Test 10: --snapshot records porcelain state and exits 0"
+REPO=$(make_repo)
+echo "preexisting" > "$REPO/preexisting.txt"    # pre-existing untracked dirt
+# Snapshot lives in a gitignored per-sweep transient dir so it does not itself
+# register as new dirt (mirrors the /loom:sweep wiring, #3648).
+SNAP="$REPO/.loom/sweep-checkpoint/main-clean-baseline.txt"
+( cd "$REPO" && "$SCRIPT" --snapshot "$SNAP" >/dev/null 2>&1 ); RC=$?
+if [[ "$RC" -eq 0 && -f "$SNAP" ]] && grep -q "preexisting.txt" "$SNAP"; then
+    pass "--snapshot writes porcelain content and exits 0"
+else
+    fail "--snapshot: expected 0 + file containing preexisting.txt, got rc=$RC"
+fi
+
+# -------- Test 11: baseline + only pre-existing dirt -> exit 0 --------
+echo "Test 11: baseline ignores pre-existing dirt (exit 0)"
+( cd "$REPO" && "$SCRIPT" --baseline "$SNAP" >/dev/null 2>&1 ); RC=$?
+if [[ "$RC" -eq 0 ]]; then pass "exit 0 when only pre-existing dirt remains"; else fail "expected 0, got $RC"; fi
+
+# -------- Test 12: baseline + one genuinely-new file -> exit 3, reports only new --------
+echo "Test 12: baseline flags a genuinely-new file (exit 3)"
+echo "contamination" > "$REPO/new-contamination.txt"
+out=$( cd "$REPO" && "$SCRIPT" --baseline "$SNAP" 2>&1 ); RC=$?
+if [[ "$RC" -eq 3 ]] \
+   && echo "$out" | grep -q "new-contamination.txt" \
+   && ! echo "$out" | grep -q "preexisting.txt"; then
+    pass "exit 3 flagging only the new path, not pre-existing dirt"
+else
+    fail "expected 3 reporting only new-contamination.txt, got rc=$RC; out=$out"
+fi
+
+# -------- Test 13: baseline + pre-existing persists AND new file appears --------
+echo "Test 13: baseline offending list excludes pre-existing dirt"
+# preexisting.txt and new-contamination.txt both present; only the new one should be flagged.
+out=$( cd "$REPO" && "$SCRIPT" --baseline "$SNAP" 2>&1 ); RC=$?
+offending=$(echo "$out" | sed -n '/Offending changes:/,$p')
+if [[ "$RC" -eq 3 ]] \
+   && echo "$offending" | grep -q "new-contamination.txt" \
+   && ! echo "$offending" | grep -q "preexisting.txt"; then
+    pass "offending list contains only the new path"
+else
+    fail "expected offending list with only new path, got rc=$RC; offending=$offending"
+fi
+rm -f "$REPO/new-contamination.txt"
+
+# -------- Test 14: missing baseline file -> fail-safe whole-status behavior --------
+echo "Test 14: missing baseline file falls back to whole-status (fail-safe)"
+# preexisting.txt is still dirty; with a missing baseline the check must hard-fail.
+out=$( cd "$REPO" && "$SCRIPT" --baseline "$REPO/.loom/does-not-exist.txt" 2>&1 ); RC=$?
+if [[ "$RC" -eq 3 ]] && echo "$out" | grep -qi "missing or unreadable"; then
+    pass "missing baseline warns and hard-fails on pre-existing dirt"
+else
+    fail "expected 3 + fallback warning, got rc=$RC; out=$out"
+fi
+
+# -------- Test 15: back-compat -- no-arg check still hard-fails on any dirt --------
+echo "Test 15: no-arg invocation is byte-for-byte hard-fail (back-compat)"
+# preexisting.txt still present; the legacy no-arg path must exit 3 regardless of any snapshot.
+( cd "$REPO" && "$SCRIPT" >/dev/null 2>&1 ); RC=$?
+if [[ "$RC" -eq 3 ]]; then pass "no-arg exit 3 on pre-existing dirt (unchanged contract)"; else fail "expected 3, got $RC"; fi
+
+# -------- Test 16: --snapshot / --baseline require a file argument (exit 2) --------
+echo "Test 16: --snapshot and --baseline require a file argument"
+"$SCRIPT" --snapshot >/dev/null 2>&1; RC1=$?
+"$SCRIPT" --baseline >/dev/null 2>&1; RC2=$?
+if [[ "$RC1" -eq 2 && "$RC2" -eq 2 ]]; then
+    pass "exit 2 when --snapshot/--baseline missing file arg"
+else
+    fail "expected 2/2, got snapshot=$RC1 baseline=$RC2"
+fi
+
 rm -rf "$REPO"
 
 # -------- Summary --------


### PR DESCRIPTION
Closes #3648

## Problem

`defaults/scripts/check-main-clean.sh` treated ANY non-empty `git status --porcelain` on main as builder contamination (exit 3). `/loom:sweep` runs it as a post-wave backstop after every wave, so a single pre-existing/unrelated dirty file (a regenerated lockfile, an operator scratch edit) re-fired the loud "MAIN worktree is dirty — builder contamination" alarm on every wave → alarm fatigue → a real contamination could be waved through.

## Fix (both halves, curator-confirmed bounded scope)

**`defaults/scripts/check-main-clean.sh`** — two opt-in modes:
- `--snapshot <file>`: write main's current porcelain state to `<file>`, exit 0 (reuses the existing main-root resolution).
- `--baseline <file>`: set-difference (post-wave porcelain MINUS snapshot lines); exit 3 ONLY on NEW lines, exit 0 when only pre-existing dirt remains. Missing/unreadable baseline → fail-safe fallback to whole-status hard-fail (never a silent pass).
- **Back-compat**: no-arg invocation is byte-for-byte identical to prior behavior. The `builder.md` / `builder-worktree.md` manual call sites keep their hard-fail contract untouched (verified: both still call no-arg).

**`defaults/.claude/commands/loom/sweep.md`** — snapshot ONCE before wave 1 (so contamination from any wave is still caught against the original pre-sweep baseline) to a gitignored per-sweep transient (`.loom/sweep-checkpoint/main-clean-baseline.txt`), and pass `--baseline` to the post-wave backstop call.

**`defaults/scripts/tests/test-check-main-clean.sh`** — added cases: `--snapshot` writes porcelain content, baseline ignores pre-existing dirt (exit 0), genuinely-new file flagged (exit 3), offending list excludes pre-existing dirt, missing-baseline fail-safe hard-fail, no-arg back-compat, and missing-file-arg usage errors.

## Testing

`bash defaults/scripts/tests/test-check-main-clean.sh` → **16/16 green** (9 original + 7 new). `bash -n` and `shellcheck` clean on both scripts.

## Acceptance criteria
- [x] `--baseline` does not exit 3 when the only dirt predates the snapshot
- [x] Still exits 3 (reporting only new paths) on genuinely-new builder contamination
- [x] `--snapshot` writes porcelain state and exits 0
- [x] No-baseline invocation byte-for-byte behavior-preserving
- [x] Missing/unreadable baseline fails safe (warn + whole-status)
- [x] `/loom:sweep` snapshots once at sweep start, passes `--baseline` to the backstop; documented in sweep.md
- [x] Test coverage for new paths; all existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)