### PR TITLE
fix(safety): fail-safe orphan recovery when no liveness writer exists (#3651)

### DIFF
--- a/.loom/docs/troubleshooting.md
+++ b/.loom/docs/troubleshooting.md
@@ -224,7 +224,9 @@ When an agent crashes or is cancelled while building, issues can get stuck in `l
 
 ## Stuck Agent Detection
 
-`loom-stuck-detection` (post-v0.10.0) checks for stuck sweep children using the `loom-daemon` sweep registry (`mcp__loom__list_sweeps`) and `.loom/sweep-checkpoint/issue-<N>.json` checkpoint timestamps.
+`loom-stuck-detection` checks for stuck sweep children by reading the per-task heartbeats in `.loom/spawn-loop-state.json::running[].last_heartbeat`.
+
+> **Note (post-v0.11.0):** `spawn-loop.sh` — the only writer of `.loom/spawn-loop-state.json` — was deleted, so this file no longer has a writer. `loom-stuck-detection` therefore currently reports nothing (a safe no-op: it only reports, it never tears down work). Repointing it to the `loom-daemon` sweep registry (`mcp__loom__list_sweeps`) and `.loom/sweep-checkpoint/issue-<N>.json` timestamps is tracked as a follow-up (see `docs/migration/daemon-state-consumers.md`).
 
 ### Check for stuck agents
 

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -1321,11 +1321,15 @@ loom-orphan-recovery --json
 - Adds recovery comments to affected issues
 - Removes stale lock dirs
 
-The daemon's 30-second reaper task usually catches this autonomously; `loom-orphan-recovery` is the manual cross-check.
+> **Fail-safe (#3651):** the untracked-building cross-check requires an authoritative liveness source (a present `.loom/spawn-loop-state.json`, a reachable `loom-daemon` registry, or `.loom/locks/issue-<N>/` locks). When **none** is available — e.g. after `spawn-loop.sh` was removed and no daemon is running — `loom-orphan-recovery` emits **zero** `untracked_building` orphans and recovers nothing. Absent liveness data means "treat every `loom:building` claim as ALIVE", never as orphaned. This prevents tearing down a live sweep that has been building for more than the label-grace window.
+
+The daemon's 30-second reaper task usually catches genuine orphans autonomously; `loom-orphan-recovery` is the manual cross-check.
 
 ### Stuck Agent Detection
 
-`loom-stuck-detection` checks for stuck sweep children by combining the daemon registry (via `mcp__loom__list_sweeps`) with `.loom/sweep-checkpoint/issue-<N>.json` checkpoint timestamps.
+`loom-stuck-detection` checks for stuck sweep children by reading per-task heartbeats in `.loom/spawn-loop-state.json::running[].last_heartbeat`.
+
+> **Note (post-v0.11.0):** `spawn-loop.sh` (the sole writer of `.loom/spawn-loop-state.json`) was deleted, so this file has no writer and `loom-stuck-detection` currently reports nothing — a safe no-op (report-only, never destructive). Repointing it to the `loom-daemon` registry (`mcp__loom__list_sweeps`) plus `.loom/sweep-checkpoint/issue-<N>.json` timestamps is a tracked follow-up (see `docs/migration/daemon-state-consumers.md`).
 
 **Check for stuck agents**:
 ```bash

--- a/docs/migration/daemon-state-consumers.md
+++ b/docs/migration/daemon-state-consumers.md
@@ -35,6 +35,31 @@ The Tauri desktop app the issue speculated about does not exist in this repo. Th
 > (b) is a cross-session log (`issue-failures.json`, `recovery-events.json`) that already lives outside `daemon-state.json` and survives the deletion as-is.
 > If a per-consumer review later decides a minimal-compat shape *is* worth it, that's a follow-up issue per #3377's "Out of Scope" section.
 
+## Post-spawn-loop-deletion fail-safe dispositions (#3651)
+
+`spawn-loop.sh` — the only writer of `.loom/spawn-loop-state.json` — was removed
+in v0.11.0. With no writer the roster is permanently empty, which turned the two
+**destructive** `spawn-loop-state.json` consumers into false-orphan hazards:
+they would flip a live `loom:building` claim back to `loom:issue` (and possibly
+clean its worktree) mid-build. Issue #3651 makes both fail safe and records the
+disposition of every remaining consumer.
+
+| Consumer | Live? | Destructive? | Disposition (#3651) |
+|---|---|---|---|
+| `orphan_recovery.py` (`loom-recover-orphans`, `/loom:sweep all --recover`) | yes | yes | **FIXED.** Liveness repointed to `gather_liveness_evidence()` (present state file ∪ best-effort daemon registry ∪ `.loom/locks/issue-<N>/`). **Fail-safe:** with no authoritative source available, `check_untracked_building` emits **zero** `untracked_building` orphans. Absent evidence ⇒ treat claims as ALIVE. |
+| `clean.py::_revert_stale_building_labels_spawn_loop` (`loom-clean`) | yes | yes | **FIXED.** Same guard: no state file **and** no `.loom/locks/issue-<N>/` locks ⇒ revert nothing. |
+| `daemon_cleanup.py::_run_orphan_recovery` | no (no entry point; superseded by `cleanup.py`) | was yes | **REMOVED.** Dead orphan-recovery call path deleted; use `loom-recover-orphans` (now fail-safe) or `loom-clean`. |
+| `stuck_detection.py` (`loom-stuck-detection`) | yes | no (report only) | **Deferred (safe no-op today).** Still reads `.loom/spawn-loop-state.json::running[].last_heartbeat`; with no writer it reports nothing. Docs (`defaults/CLAUDE.md`, `.loom/docs/troubleshooting.md`) corrected to match code. Repoint to `mcp__loom__list_sweeps` + sweep-checkpoint timestamps is a follow-up. |
+| `status.py` (`loom-status`) | yes | no | **Deferred (safe no-op today).** Renders "spawn loop not present". Repoint is a follow-up. |
+| `health_monitor.py` (`loom-health-monitor`) | yes | no | **Deferred (safe no-op today).** `spawn_loop_present=False`. Repoint is a follow-up. |
+| `daemon_diagnostic.py` (`loom-daemon-diagnostic`) | yes | no | **Deferred (safe no-op today).** Reports daemon not running. Repoint is a follow-up. |
+| `SpawnLoopState` model / `read_spawn_loop_state` / `LoomPaths.spawn_loop_state_file` | infra | no | **Keep** until the last reader is repointed, then retire (follow-up). |
+
+The four deferred reporters are **report-only** — they never tear down work — so
+they do not gate the safety fix. Repointing them (and retiring the
+`SpawnLoopState` model + path) to `mcp__loom__list_sweeps` is the explicit
+follow-up to #3651.
+
 ## Method
 
 Codebase scans (as specified in the issue):

--- a/loom-tools/src/loom_tools/clean.py
+++ b/loom-tools/src/loom_tools/clean.py
@@ -987,7 +987,29 @@ def _revert_stale_building_labels_spawn_loop(
     :mod:`loom_tools.orphan_recovery` performs, scoped down for cleanup.
 
     Returns the number of labels reverted (0 for dry-run skip or no orphans).
+
+    Fail-safe (#3651): the historical writer of
+    ``.loom/spawn-loop-state.json`` (``spawn-loop.sh``) was deleted in v0.11.0.
+    With no writer, ``_active_spawn_loop_issues`` collapses to just the
+    ``.loom/locks/`` set. If there is **no** authoritative liveness source at
+    all — no state file AND no ``.loom/locks/issue-<N>/`` locks — we cannot
+    distinguish a live sweep from an orphan, so we refuse to revert any label.
+    Absent liveness data means treat claims as ALIVE, not orphaned.
     """
+    # SAFETY GATE: refuse to revert when we have no authoritative liveness
+    # evidence. Absent state file AND no per-issue locks would otherwise make
+    # every open loom:building issue look orphaned (see issue #3651).
+    state_present = read_spawn_loop_state(repo_root).present
+    locked_issues = _active_locked_issues(repo_root)
+    if not state_present and not locked_issues:
+        log_warning(
+            "  No authoritative liveness source (no spawn-loop-state.json, no "
+            ".loom/locks/issue-<N>/ locks) — skipping loom:building revert "
+            "(fail-safe: absent liveness data means treat claims as ALIVE, "
+            "not orphaned). See issue #3651."
+        )
+        return 0
+
     active = _active_spawn_loop_issues(repo_root)
     try:
         result = gh_run(

--- a/loom-tools/src/loom_tools/daemon_cleanup.py
+++ b/loom-tools/src/loom_tools/daemon_cleanup.py
@@ -21,7 +21,6 @@ import os
 import pathlib
 import subprocess
 import sys
-import threading
 import time
 from dataclasses import dataclass
 from loom_tools.agent_spawn import TMUX_SOCKET, kill_stuck_session, session_exists
@@ -157,52 +156,11 @@ def _run_loom_clean(
         log_warning("loom-clean execution failed")
 
 
-def _run_orphan_recovery(
-    repo_root: pathlib.Path,
-    *,
-    recover: bool = False,
-    verbose: bool = False,
-    run_background: bool = False,
-) -> None:
-    """Delegate to the Python orphan recovery module.
-
-    When ``run_background=True``, the recovery runs in a daemon thread so the
-    caller returns immediately.  This avoids blocking daemon startup when there
-    are many orphans (each requiring a GitHub API round-trip).  The thread is
-    marked as a daemon thread so it will not prevent process exit if the daemon
-    shuts down before recovery finishes.
-    """
-    def _do_recovery() -> None:
-        try:
-            from loom_tools.orphan_recovery import run_orphan_recovery
-
-            run_orphan_recovery(repo_root, recover=recover, verbose=verbose)
-        except ImportError:
-            # Fall back to the shell script
-            script = repo_root / "scripts" / "recover-orphaned-shepherds.sh"
-            if not script.exists():
-                script = repo_root / ".loom" / "scripts" / "recover-orphaned-shepherds.sh"
-            if script.exists() and os.access(script, os.X_OK):
-                cmd: list[str] = [str(script)]
-                if recover:
-                    cmd.append("--recover")
-                if verbose:
-                    cmd.append("--verbose")
-                try:
-                    subprocess.run(cmd, capture_output=True, timeout=60, cwd=repo_root)
-                except Exception:
-                    log_warning("Orphaned shepherd recovery failed")
-            else:
-                log_warning("Orphan recovery not available")
-        except Exception as exc:
-            log_warning(f"Background orphan recovery failed: {exc}")
-
-    if run_background:
-        thread = threading.Thread(target=_do_recovery, name="orphan-recovery", daemon=True)
-        thread.start()
-        log_info("Orphan recovery started in background (daemon will not wait for it)")
-    else:
-        _do_recovery()
+# NOTE (#3651): ``_run_orphan_recovery`` was removed here. It delegated to
+# ``orphan_recovery.run_orphan_recovery`` from a module that has no console
+# entry point and is superseded by ``cleanup.py`` — dead code, and a latent
+# tear-down hazard after the spawn-loop writer was deleted. Use
+# ``loom-recover-orphans`` (now fail-safe) or ``loom-clean`` instead.
 
 
 # ---------------------------------------------------------------------------
@@ -749,14 +707,12 @@ def handle_daemon_startup(
         log_info("Resetting failure counters (--fresh)...")
         _reset_failure_counters(repo_root, dry_run=dry_run)
 
-    # 3. Orphaned shepherd recovery.
-    log_info("Checking for orphaned shepherds from previous session...")
-    _run_orphan_recovery(
-        repo_root,
-        recover=not dry_run,
-        verbose=True,
-        run_background=not dry_run,
-    )
+    # 3. Orphaned-shepherd recovery was removed in issue #3651. This module has
+    #    no console entry point and is superseded by ``cleanup.py``; its call
+    #    into ``orphan_recovery.run_orphan_recovery`` was dead code and, post
+    #    spawn-loop deletion, a latent tear-down hazard for live sweeps. The
+    #    supported recovery paths are ``loom-recover-orphans`` (fail-safe) and
+    #    ``loom-clean``.
 
     # 4. Archive orphaned task outputs
     if config.archive_logs:

--- a/loom-tools/src/loom_tools/orphan_recovery.py
+++ b/loom-tools/src/loom_tools/orphan_recovery.py
@@ -9,11 +9,31 @@ Detects and recovers orphaned state that occurs when:
 
 This module was ported in Phase 3.1.6 (epic #3372, tracker #3378, issue #3395).
 
-The sources of truth are:
+Liveness sources (issue #3651 — SAFETY-critical fail-safe)
+----------------------------------------------------------
 
-- ``.loom/spawn-loop-state.json::running`` (a flat list of live sweep tasks,
-  written by ``defaults/scripts/spawn-loop.sh`` — see
-  :mod:`loom_tools.models.spawn_loop_state`).
+``defaults/scripts/spawn-loop.sh`` was the historical writer of
+``.loom/spawn-loop-state.json::running`` (the live-sweep roster). It was
+deleted in v0.11.0, so **nothing writes that file anymore**. With no writer,
+the roster is always empty, and a naive cross-check would treat *every* open
+``loom:building`` issue — including live, in-flight sweeps — as an orphan and
+flip it back to ``loom:issue`` (possibly cleaning its worktree) mid-build.
+
+The fix is a **fail-safe** liveness model (:func:`gather_liveness_evidence`):
+
+- Liveness is derived from whatever authoritative sources actually exist:
+  the legacy state file (when present), a reachable ``loom-daemon`` registry
+  (best-effort), and per-issue worktree-lifetime locks under
+  ``.loom/locks/issue-<N>/``.
+- **The invariant: absent/unreadable liveness data ⇒ treat all building
+  issues as ALIVE (emit ZERO ``untracked_building`` orphans).** Absence of a
+  writer is *insufficient evidence* of orphanhood, not proof of it. We fail
+  toward preserving claims. Genuine-orphan cleanup is still handled by
+  ``loom-clean`` (lock-based revert) and the daemon reaper.
+
+The cross-check inputs are:
+
+- The liveness evidence above (roster + daemon + locks).
 - ``gh issue list --label loom:building`` (unchanged).
 
 Stuck-but-running detection lives in :mod:`loom_tools.stuck_detection` (2-min
@@ -45,7 +65,7 @@ from loom_tools.common.logging import log_error, log_info, log_success, log_warn
 from loom_tools.common.repo import find_repo_root
 from loom_tools.common.state import read_spawn_loop_state
 from loom_tools.common.time_utils import elapsed_seconds, format_duration, now_utc
-from loom_tools.models.spawn_loop_state import SpawnLoopState, SpawnLoopTask
+from loom_tools.models.spawn_loop_state import SpawnLoopState
 
 # Default heartbeat stale threshold (5 minutes for orphan recovery).
 # Intentionally higher than stuck_detection's 120s because orphan recovery
@@ -233,22 +253,146 @@ def _get_building_label_age(issue: int) -> int | None:
         return None
 
 
-def check_untracked_building(
+@dataclass
+class LivenessEvidence:
+    """Authoritative evidence of which sweeps are currently alive.
+
+    ``available`` is True when at least one authoritative liveness *source*
+    exists (a present state file, a reachable daemon registry, or one or more
+    ``.loom/locks/issue-<N>/`` locks). When it is False we have **no** evidence
+    either way, and the fail-safe (issue #3651) is to emit zero orphans.
+
+    ``live_issues`` is the union of issue numbers known to be alive across all
+    available sources. ``sources`` records which sources contributed, for
+    logging/observability.
+    """
+
+    available: bool = False
+    live_issues: set[int] = field(default_factory=set)
+    sources: list[str] = field(default_factory=list)
+
+
+def _locked_issue_numbers(repo_root: pathlib.Path) -> set[int]:
+    """Issue numbers with a live ``.loom/locks/issue-<N>/`` worktree lock.
+
+    These lock dirs are the ``mkdir``-atomic claim locks whose lifetime tracks
+    an in-flight worktree/sweep. A present lock is strong evidence the issue is
+    being actively worked. Missing/unreadable locks-dir yields an empty set.
+    """
+    locks_dir = repo_root / ".loom" / "locks"
+    if not locks_dir.is_dir():
+        return set()
+    out: set[int] = set()
+    try:
+        entries = list(locks_dir.iterdir())
+    except OSError:
+        return set()
+    for entry in entries:
+        if not entry.is_dir():
+            continue
+        name = entry.name
+        if not name.startswith("issue-"):
+            # Ignore non-issue locks (e.g. the repo-global ``worktree-add``
+            # lock created transiently by worktree.sh).
+            continue
+        try:
+            out.add(int(name[len("issue-") :]))
+        except ValueError:
+            continue
+    return out
+
+
+def _query_daemon_live_issues(repo_root: pathlib.Path) -> set[int] | None:
+    """Best-effort query of the ``loom-daemon`` sweep registry.
+
+    Returns the set of issue numbers with a live sweep in the daemon registry,
+    or ``None`` when the daemon is not reachable / no Python client is wired up
+    (the common case). The daemon is an **optional** secondary source — it is
+    never hard-required (issue #3651). Returning ``None`` means "daemon is not
+    a source right now", which is distinct from "daemon says nothing is live"
+    (an empty set).
+
+    A future follow-up may implement the IPC/MCP ``list_sweeps`` round-trip
+    here; today there is no Python IPC client, so this is a safe no-op stub.
+    """
+    return None
+
+
+def gather_liveness_evidence(
     spawn_loop_state: SpawnLoopState,
+    repo_root: pathlib.Path | None,
+) -> LivenessEvidence:
+    """Collect authoritative liveness evidence from all available sources.
+
+    Sources, unioned:
+
+    1. ``.loom/spawn-loop-state.json::running`` — legacy roster. Present only
+       when some writer exists (essentially never after v0.11.0).
+    2. ``loom-daemon`` registry via :func:`_query_daemon_live_issues` — optional,
+       best-effort; ``None`` means "not a source".
+    3. ``.loom/locks/issue-<N>/`` — per-issue worktree-lifetime locks.
+
+    ``available`` is True iff at least one of these sources is actually present.
+    When it is False the caller MUST NOT flag any building issue as orphaned.
+    """
+    live: set[int] = set()
+    sources: list[str] = []
+
+    if spawn_loop_state.present:
+        sources.append("spawn-loop-state.json")
+        live |= {task.issue for task in spawn_loop_state.running if task.issue}
+
+    if repo_root is not None:
+        daemon_issues = _query_daemon_live_issues(repo_root)
+        if daemon_issues is not None:
+            sources.append("loom-daemon")
+            live |= daemon_issues
+
+        locked = _locked_issue_numbers(repo_root)
+        if locked:
+            sources.append(".loom/locks")
+            live |= locked
+
+    return LivenessEvidence(
+        available=bool(sources),
+        live_issues=live,
+        sources=sources,
+    )
+
+
+def check_untracked_building(
+    evidence: LivenessEvidence,
     result: OrphanRecoveryResult,
     *,
     repo_root: pathlib.Path | None = None,
     label_grace_period: int = DEFAULT_LABEL_GRACE_PERIOD,
     verbose: bool = False,
 ) -> None:
-    """Find ``loom:building`` issues without an active spawn-loop task.
+    """Find ``loom:building`` issues that no live sweep is tracking.
 
-    Cross-references ``gh issue list --label loom:building`` against the
-    tracked issue set in ``.loom/spawn-loop-state.json::running``.  Issues
-    with a valid file-based claim are skipped (CLI-driven sweeps may hold
-    a claim without a spawn-loop entry).  Issues with a recently-applied
-    ``loom:building`` label are also skipped (label-age grace period).
+    Cross-references ``gh issue list --label loom:building`` against the live
+    issue set in *evidence* (roster + daemon + ``.loom/locks/``).  Issues with a
+    valid file-based claim are skipped (CLI-driven sweeps may hold a claim
+    without a lock).  Issues with a recently-applied ``loom:building`` label are
+    also skipped (label-age grace period).
+
+    **Fail-safe (issue #3651):** if *evidence* reports no authoritative liveness
+    source is available, this emits **zero** orphans — absence of a writer is
+    not proof of orphanhood, and tearing down a live sweep is the worst
+    possible outcome.
     """
+    # SAFETY GATE: with no authoritative liveness source we cannot distinguish
+    # a live sweep from an orphan, so we treat every building issue as ALIVE.
+    if not evidence.available:
+        log_warning(
+            "No authoritative liveness source available (no "
+            "spawn-loop-state.json, no reachable loom-daemon registry, no "
+            ".loom/locks/issue-<N>/ locks) — refusing to flag any loom:building "
+            "issue as orphaned (fail-safe: absent liveness data means treat "
+            "claims as ALIVE, not orphaned). See issue #3651."
+        )
+        return
+
     try:
         building_issues = gh_issue_list(labels=["loom:building"])
     except Exception as exc:
@@ -260,9 +404,7 @@ def check_untracked_building(
             log_info("No loom:building issues found")
         return
 
-    tracked_issues: set[int] = {
-        task.issue for task in spawn_loop_state.running if task.issue
-    }
+    tracked_issues: set[int] = evidence.live_issues
 
     for issue_data in building_issues:
         issue_num = issue_data.get("number", 0)
@@ -273,7 +415,10 @@ def check_untracked_building(
 
         if issue_num in tracked_issues:
             if verbose:
-                log_info(f"  OK: tracked in spawn-loop-state")
+                log_info(
+                    f"  OK: #{issue_num} tracked by live source "
+                    f"({', '.join(evidence.sources)})"
+                )
             continue
 
         # File-based claim check (primary protection, no API call).
@@ -669,17 +814,16 @@ def run_orphan_recovery(
 ) -> OrphanRecoveryResult:
     """Run all orphan detection phases and optionally recover.
 
-    Reads ``.loom/spawn-loop-state.json`` (Phase 1, #3374) and cross-checks
-    against ``gh issue list --label loom:building``.
+    Gathers authoritative liveness evidence (:func:`gather_liveness_evidence`)
+    and cross-checks it against ``gh issue list --label loom:building``. When no
+    liveness source is available the untracked-building check fails safe and
+    emits zero orphans (issue #3651).
 
-    Known invocation paths after Phase 3.1.6 (#3395):
+    Known invocation path:
 
     - CLI: ``./.loom/scripts/recover-orphaned-shepherds.sh [--recover]``
-      (script is a thin stub delegating here).
-    - Pre-Phase-3 daemon callers (``daemon_v2/iteration.py``,
-      ``daemon_cleanup.py``) still call ``run_orphan_recovery`` with the
-      same ``(repo_root, *, recover, verbose)`` signature; they retire as a
-      unit in Phase 3.3.
+      (script is a thin stub delegating here), also reachable from
+      ``/loom:sweep all`` aggressive mode.
 
     Returns an :class:`OrphanRecoveryResult` with all detected orphans and
     any recovery actions taken.
@@ -690,17 +834,27 @@ def run_orphan_recovery(
 
     spawn_loop_state = read_spawn_loop_state(repo_root)
 
-    if not spawn_loop_state.present and verbose:
-        log_info(
-            "No .loom/spawn-loop-state.json found — assuming no "
-            "spawn-loop tasks. Proceeding to forge cross-check only."
-        )
-        # An absent state file means "nothing tracked locally"; the forge
-        # cross-check still runs and may surface untracked-building orphans.
+    # Gather authoritative liveness evidence (roster + daemon + locks). When no
+    # source is available the untracked-building cross-check fails safe and
+    # emits zero orphans — see issue #3651.
+    evidence = gather_liveness_evidence(spawn_loop_state, repo_root)
 
-    # Phase A: cross-check loom:building issues against spawn-loop tasks.
+    if verbose:
+        if evidence.available:
+            log_info(
+                "Liveness sources: "
+                f"{', '.join(evidence.sources)} "
+                f"(live issues: {sorted(evidence.live_issues) or 'none'})"
+            )
+        else:
+            log_info(
+                "No authoritative liveness source found — untracked-building "
+                "cross-check will fail safe (emit zero orphans). See #3651."
+            )
+
+    # Phase A: cross-check loom:building issues against the live issue set.
     check_untracked_building(
-        spawn_loop_state,
+        evidence,
         result,
         repo_root=repo_root,
         label_grace_period=label_grace_period,
@@ -792,9 +946,13 @@ Recovery actions:
     reset_issue_label       - Swap loom:building -> loom:issue on issue
     cleanup_stale_worktree  - Remove stale worktree + branches (0 commits, no changes)
 
-Sources of truth:
-    .loom/spawn-loop-state.json           - Live spawn-loop tasks (Phase 1, #3374)
+Liveness sources (fail-safe, #3651):
+    .loom/spawn-loop-state.json           - Legacy roster (no writer post-v0.11.0)
+    loom-daemon registry                  - Optional, best-effort
+    .loom/locks/issue-<N>/                - Per-issue worktree-lifetime locks
     gh issue list --label loom:building   - Forge label cross-check
+  With NO authoritative liveness source, zero untracked_building orphans
+  are emitted (absent evidence => treat claims as ALIVE, not orphaned).
 
 Environment variables:
     LOOM_HEARTBEAT_STALE_THRESHOLD  Seconds before heartbeat is stale (default: 300)

--- a/loom-tools/tests/test_clean.py
+++ b/loom-tools/tests/test_clean.py
@@ -448,3 +448,84 @@ class TestEvaluateAggressiveCandidateGate:
         )
         assert decision == DECISION_KEEP
         assert reason == "user_owned"
+
+
+# ---------------------------------------------------------------------------
+# _revert_stale_building_labels_spawn_loop — SAFETY fail-safe (#3651)
+# ---------------------------------------------------------------------------
+#
+# Sibling hazard to orphan_recovery: after spawn-loop.sh deletion nothing
+# writes .loom/spawn-loop-state.json, so the "active" set collapsed to just
+# .loom/locks/. With no locks either, EVERY open loom:building issue looked
+# orphaned and got flipped back to loom:issue. The guard: no authoritative
+# liveness source (no state file AND no locks) => revert nothing.
+
+
+class TestRevertStaleBuildingFailSafe:
+    """The no-writer regression for ``loom-clean``'s label-revert path."""
+
+    @staticmethod
+    def _make_repo(tmp_path: pathlib.Path) -> pathlib.Path:
+        (tmp_path / ".loom").mkdir(parents=True, exist_ok=True)
+        return tmp_path
+
+    @staticmethod
+    def _make_lock(repo: pathlib.Path, issue: int) -> None:
+        (repo / ".loom" / "locks" / f"issue-{issue}").mkdir(parents=True, exist_ok=True)
+
+    def test_no_liveness_source_reverts_nothing(self, tmp_path: pathlib.Path) -> None:
+        from loom_tools.clean import _revert_stale_building_labels_spawn_loop
+
+        repo = self._make_repo(tmp_path)  # no state file, no locks
+
+        # gh must not even be consulted — the guard returns before listing.
+        with mock.patch(
+            "loom_tools.clean.gh_run",
+            side_effect=AssertionError("gh_run must not be called (fail-safe)"),
+        ), mock.patch(
+            "loom_tools.clean.subprocess.run",
+            side_effect=AssertionError("no `gh issue edit` allowed"),
+        ):
+            reverted = _revert_stale_building_labels_spawn_loop(repo, dry_run=False)
+
+        assert reverted == 0
+
+    def test_active_lock_present_source_reverts_genuine_orphan(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        from loom_tools.clean import _revert_stale_building_labels_spawn_loop
+
+        repo = self._make_repo(tmp_path)
+        self._make_lock(repo, 999)  # a live sweep -> locks is an active source
+
+        edits: list[list[str]] = []
+
+        def _fake_subprocess_run(args, **kwargs):  # noqa: ANN001 - test stub
+            edits.append(list(args))
+            return _make_completed(returncode=0)
+
+        with mock.patch(
+            "loom_tools.clean.gh_run",
+            return_value=_make_completed(stdout="42\n", returncode=0),
+        ), mock.patch("loom_tools.clean.subprocess.run", _fake_subprocess_run):
+            reverted = _revert_stale_building_labels_spawn_loop(repo, dry_run=False)
+
+        assert reverted == 1
+        assert any(a[:3] == ["gh", "issue", "edit"] and "42" in a for a in edits)
+
+    def test_locked_issue_not_reverted(self, tmp_path: pathlib.Path) -> None:
+        from loom_tools.clean import _revert_stale_building_labels_spawn_loop
+
+        repo = self._make_repo(tmp_path)
+        self._make_lock(repo, 42)  # #42 itself is locked -> alive
+
+        with mock.patch(
+            "loom_tools.clean.gh_run",
+            return_value=_make_completed(stdout="42\n", returncode=0),
+        ), mock.patch(
+            "loom_tools.clean.subprocess.run",
+            side_effect=AssertionError("locked issue must not be reverted"),
+        ):
+            reverted = _revert_stale_building_labels_spawn_loop(repo, dry_run=False)
+
+        assert reverted == 0

--- a/loom-tools/tests/test_orphan_recovery.py
+++ b/loom-tools/tests/test_orphan_recovery.py
@@ -1,0 +1,321 @@
+"""Tests for ``loom_tools.orphan_recovery`` — SAFETY-critical fail-safe (#3651).
+
+The headline property proven here: after ``spawn-loop.sh`` (the only writer of
+``.loom/spawn-loop-state.json``) was deleted in v0.11.0, orphan recovery must
+**never** flip a live ``loom:building`` claim back to ``loom:issue`` (nor clean
+its worktree) just because no roster writer exists. Absent authoritative
+liveness data ⇒ treat every building issue as ALIVE (emit zero orphans).
+
+Test map to acceptance criteria:
+
+- ``test_no_liveness_source_emits_zero_orphans`` — the regression itself: no
+  state file, no daemon, no locks ⇒ a stale, unclaimed building issue is NOT
+  orphaned and NOT recovered.
+- ``test_active_lock_protects_live_building_issue`` — AC (a): an active
+  ``.loom/locks/issue-<N>/`` lock protects the issue even with no state file.
+- ``test_genuinely_dead_claim_is_recoverable`` / ``_via_state_roster`` — AC (b):
+  when an authoritative source IS present but does not list the issue, a
+  genuinely-dead claim is still recovered.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from unittest import mock
+
+from loom_tools import orphan_recovery
+from loom_tools.models.spawn_loop_state import SpawnLoopState, SpawnLoopTask
+from loom_tools.orphan_recovery import (
+    LivenessEvidence,
+    OrphanRecoveryResult,
+    _locked_issue_numbers,
+    check_untracked_building,
+    gather_liveness_evidence,
+    run_orphan_recovery,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_repo(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Create a minimal repo root with a ``.loom`` directory."""
+    (tmp_path / ".loom").mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+def _make_lock(repo_root: pathlib.Path, issue: int) -> None:
+    """Create a ``.loom/locks/issue-<N>/`` worktree-lifetime lock dir."""
+    (repo_root / ".loom" / "locks" / f"issue-{issue}").mkdir(parents=True, exist_ok=True)
+
+
+class _GhRecorder:
+    """Record ``gh_run`` calls and refuse destructive label edits by default.
+
+    A test that expects recovery passes ``allow_edit=True``.
+    """
+
+    def __init__(self, *, allow_edit: bool = False) -> None:
+        self.calls: list[list[str]] = []
+        self.allow_edit = allow_edit
+
+    def __call__(self, args, **kwargs):  # noqa: ANN001 - test stub
+        self.calls.append(list(args))
+        if args[:2] == ["issue", "edit"] and not self.allow_edit:
+            raise AssertionError(
+                f"Unexpected destructive `gh issue edit` call: {args!r}"
+            )
+        return mock.Mock(returncode=0, stdout="", stderr="")
+
+    @property
+    def edited_issues(self) -> list[str]:
+        return [c[2] for c in self.calls if c[:2] == ["issue", "edit"]]
+
+
+# ---------------------------------------------------------------------------
+# gather_liveness_evidence / _locked_issue_numbers unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_locked_issue_numbers_reads_issue_dirs(tmp_path: pathlib.Path) -> None:
+    repo = _make_repo(tmp_path)
+    _make_lock(repo, 42)
+    _make_lock(repo, 7)
+    # Non-issue lock (worktree.sh's repo-global lock) must be ignored.
+    (repo / ".loom" / "locks" / "worktree-add").mkdir(parents=True, exist_ok=True)
+    assert _locked_issue_numbers(repo) == {42, 7}
+
+
+def test_locked_issue_numbers_missing_dir_is_empty(tmp_path: pathlib.Path) -> None:
+    repo = _make_repo(tmp_path)
+    assert _locked_issue_numbers(repo) == set()
+
+
+def test_gather_liveness_unavailable_when_no_sources(tmp_path: pathlib.Path) -> None:
+    repo = _make_repo(tmp_path)
+    evidence = gather_liveness_evidence(SpawnLoopState.absent(), repo)
+    assert evidence.available is False
+    assert evidence.live_issues == set()
+    assert evidence.sources == []
+
+
+def test_gather_liveness_available_from_locks(tmp_path: pathlib.Path) -> None:
+    repo = _make_repo(tmp_path)
+    _make_lock(repo, 42)
+    evidence = gather_liveness_evidence(SpawnLoopState.absent(), repo)
+    assert evidence.available is True
+    assert evidence.live_issues == {42}
+    assert ".loom/locks" in evidence.sources
+
+
+def test_gather_liveness_available_from_present_state(tmp_path: pathlib.Path) -> None:
+    repo = _make_repo(tmp_path)
+    state = SpawnLoopState(running=[SpawnLoopTask(issue=5, pid=123)], present=True)
+    evidence = gather_liveness_evidence(state, repo)
+    assert evidence.available is True
+    assert evidence.live_issues == {5}
+    assert "spawn-loop-state.json" in evidence.sources
+
+
+def test_gather_liveness_present_but_empty_is_available(tmp_path: pathlib.Path) -> None:
+    """A present-but-empty roster IS an authoritative source (says 'none live')."""
+    repo = _make_repo(tmp_path)
+    state = SpawnLoopState(running=[], present=True)
+    evidence = gather_liveness_evidence(state, repo)
+    assert evidence.available is True
+    assert evidence.live_issues == set()
+
+
+# ---------------------------------------------------------------------------
+# check_untracked_building fail-safe
+# ---------------------------------------------------------------------------
+
+
+def test_check_untracked_building_no_source_emits_zero(tmp_path: pathlib.Path) -> None:
+    repo = _make_repo(tmp_path)
+    result = OrphanRecoveryResult()
+    evidence = LivenessEvidence(available=False)
+
+    # gh must never be consulted when we have no liveness evidence.
+    with mock.patch.object(
+        orphan_recovery, "gh_issue_list",
+        side_effect=AssertionError("gh_issue_list must not be called"),
+    ):
+        check_untracked_building(evidence, result, repo_root=repo)
+
+    assert result.total_orphaned == 0
+
+
+# ---------------------------------------------------------------------------
+# run_orphan_recovery — end-to-end safety property
+# ---------------------------------------------------------------------------
+
+
+def test_no_liveness_source_emits_zero_orphans(tmp_path: pathlib.Path) -> None:
+    """THE regression (#3651): no state file, no daemon, no locks.
+
+    A stale, unclaimed ``loom:building`` issue must NOT be orphaned and must NOT
+    be recovered — even under ``--recover``.
+    """
+    repo = _make_repo(tmp_path)  # no spawn-loop-state.json, no claims, no locks
+    gh = _GhRecorder(allow_edit=False)
+
+    with mock.patch.object(
+        orphan_recovery, "gh_issue_list",
+        return_value=[{"number": 42, "title": "live sweep, building > 10 min"}],
+    ), mock.patch.object(
+        orphan_recovery, "_get_building_label_age", return_value=9999,
+    ), mock.patch.object(
+        orphan_recovery, "has_valid_claim", return_value=False,
+    ), mock.patch.object(orphan_recovery, "gh_run", gh):
+        result = run_orphan_recovery(repo, recover=True, verbose=True)
+
+    assert result.total_orphaned == 0, "live building issue must not be orphaned"
+    assert result.total_recovered == 0, "no recovery may occur without evidence"
+    assert gh.edited_issues == [], "no loom:building -> loom:issue flip allowed"
+
+
+def test_active_lock_protects_live_building_issue(tmp_path: pathlib.Path) -> None:
+    """AC (a): an active ``.loom/locks/issue-42/`` lock keeps #42 alive.
+
+    Even with the label older than the grace window and an 'abandoned' claim,
+    the lock is authoritative liveness evidence, so #42 is not orphaned.
+    """
+    repo = _make_repo(tmp_path)
+    _make_lock(repo, 42)  # <-- live sweep marker
+    gh = _GhRecorder(allow_edit=False)
+
+    with mock.patch.object(
+        orphan_recovery, "gh_issue_list",
+        return_value=[{"number": 42, "title": "live sweep with lock"}],
+    ), mock.patch.object(
+        orphan_recovery, "_get_building_label_age", return_value=9999,
+    ), mock.patch.object(
+        orphan_recovery, "has_valid_claim", return_value=False,
+    ), mock.patch.object(orphan_recovery, "gh_run", gh):
+        result = run_orphan_recovery(repo, recover=True, verbose=True)
+
+    assert result.total_orphaned == 0
+    assert result.total_recovered == 0
+    assert gh.edited_issues == []
+
+
+def test_genuinely_dead_claim_is_recoverable(tmp_path: pathlib.Path) -> None:
+    """AC (b): with a live source present that does NOT list #42, #42 recovers.
+
+    A decoy lock for a *different* issue (#999) makes ``.loom/locks`` an
+    authoritative source. #42 has no lock, an old label, and no valid claim, so
+    it is a genuine orphan and IS recovered.
+    """
+    repo = _make_repo(tmp_path)
+    _make_lock(repo, 999)  # some other live sweep — makes locks an active source
+    gh = _GhRecorder(allow_edit=True)
+
+    with mock.patch.object(
+        orphan_recovery, "gh_issue_list",
+        return_value=[{"number": 42, "title": "genuinely orphaned"}],
+    ), mock.patch.object(
+        orphan_recovery, "_get_building_label_age", return_value=9999,
+    ), mock.patch.object(
+        orphan_recovery, "has_valid_claim", return_value=False,
+    ), mock.patch.object(
+        orphan_recovery, "_has_recent_orphan_comment", return_value=False,
+    ), mock.patch.object(orphan_recovery, "gh_run", gh):
+        result = run_orphan_recovery(repo, recover=True, verbose=True)
+
+    assert result.total_orphaned == 1
+    assert result.orphaned[0].issue == 42
+    assert result.orphaned[0].type == "untracked_building"
+    assert "42" in gh.edited_issues, "genuine orphan should be recovered"
+
+
+def test_genuinely_dead_claim_recoverable_via_state_roster(
+    tmp_path: pathlib.Path,
+) -> None:
+    """AC (b) variant: a present-but-empty state roster also enables recovery."""
+    repo = _make_repo(tmp_path)
+    gh = _GhRecorder(allow_edit=True)
+
+    empty_present = SpawnLoopState(running=[], present=True)
+
+    with mock.patch.object(
+        orphan_recovery, "read_spawn_loop_state", return_value=empty_present,
+    ), mock.patch.object(
+        orphan_recovery, "gh_issue_list",
+        return_value=[{"number": 42, "title": "genuinely orphaned"}],
+    ), mock.patch.object(
+        orphan_recovery, "_get_building_label_age", return_value=9999,
+    ), mock.patch.object(
+        orphan_recovery, "has_valid_claim", return_value=False,
+    ), mock.patch.object(
+        orphan_recovery, "_has_recent_orphan_comment", return_value=False,
+    ), mock.patch.object(orphan_recovery, "gh_run", gh):
+        result = run_orphan_recovery(repo, recover=True, verbose=True)
+
+    assert result.total_orphaned == 1
+    assert "42" in gh.edited_issues
+
+
+def test_valid_claim_protects_issue_even_with_source(tmp_path: pathlib.Path) -> None:
+    """Defense-in-depth: a valid file-based claim still protects a building
+    issue when a liveness source is present but does not list it."""
+    repo = _make_repo(tmp_path)
+    _make_lock(repo, 999)  # active source, but not our issue
+    gh = _GhRecorder(allow_edit=False)
+
+    with mock.patch.object(
+        orphan_recovery, "gh_issue_list",
+        return_value=[{"number": 42, "title": "claimed CLI sweep"}],
+    ), mock.patch.object(
+        orphan_recovery, "_get_building_label_age", return_value=9999,
+    ), mock.patch.object(
+        orphan_recovery, "has_valid_claim", return_value=True,  # <-- claim held
+    ), mock.patch.object(orphan_recovery, "gh_run", gh):
+        result = run_orphan_recovery(repo, recover=True, verbose=True)
+
+    assert result.total_orphaned == 0
+    assert gh.edited_issues == []
+
+
+def test_label_grace_protects_issue_even_with_source(tmp_path: pathlib.Path) -> None:
+    """Defense-in-depth: a recently-applied label protects a building issue."""
+    repo = _make_repo(tmp_path)
+    _make_lock(repo, 999)  # active source, but not our issue
+    gh = _GhRecorder(allow_edit=False)
+
+    with mock.patch.object(
+        orphan_recovery, "gh_issue_list",
+        return_value=[{"number": 42, "title": "freshly claimed"}],
+    ), mock.patch.object(
+        orphan_recovery, "_get_building_label_age", return_value=5,  # < grace
+    ), mock.patch.object(
+        orphan_recovery, "has_valid_claim", return_value=False,
+    ), mock.patch.object(orphan_recovery, "gh_run", gh):
+        result = run_orphan_recovery(repo, recover=True, verbose=True)
+
+    assert result.total_orphaned == 0
+    assert gh.edited_issues == []
+
+
+def test_stale_heartbeat_path_unaffected(tmp_path: pathlib.Path) -> None:
+    """The stale-heartbeat orphan path still flags a dead-pid task when a
+    roster is present (independent of the untracked-building fail-safe)."""
+    repo = _make_repo(tmp_path)
+    task = SpawnLoopTask(issue=77, pid=424242, last_heartbeat="2000-01-01T00:00:00Z")
+    state = SpawnLoopState(running=[task], present=True)
+    gh = _GhRecorder(allow_edit=False)
+
+    with mock.patch.object(
+        orphan_recovery, "read_spawn_loop_state", return_value=state,
+    ), mock.patch.object(
+        orphan_recovery, "gh_issue_list", return_value=[],
+    ), mock.patch.object(
+        orphan_recovery, "_pid_alive", return_value=False,
+    ), mock.patch.object(orphan_recovery, "gh_run", gh):
+        result = run_orphan_recovery(repo, recover=False, verbose=True)
+
+    stale = [o for o in result.orphaned if o.type == "stale_heartbeat"]
+    assert len(stale) == 1
+    assert stale[0].issue == 77


### PR DESCRIPTION
Closes #3651

## Problem (SAFETY-critical)

`spawn-loop.sh` — the sole writer of `.loom/spawn-loop-state.json` — was removed in v0.11.0. With no writer, its `running` roster is permanently empty, and `orphan_recovery.check_untracked_building` treated **every** open `loom:building` issue as an orphan candidate, guarded only by ~10-minute time-boxes (`has_valid_claim`'s abandonment threshold + the label-grace window). A live sweep building for more than ~10 minutes satisfied neither guard, so `/loom:sweep all --recover` (and `loom-recover-orphans`) could flip its `loom:building` label back to `loom:issue` and clean its worktree **mid-build**. `clean.py::_revert_stale_building_labels_spawn_loop` had the same false-orphan shape.

## Fix (curator-endorsed fail-safe, bounded scope)

1. **`orphan_recovery.py`** — new `gather_liveness_evidence()` unions the real liveness sources: a present state file, a best-effort daemon-registry stub (`None` when unreachable — never hard-required), and `.loom/locks/issue-<N>/` worktree-lifetime locks. `check_untracked_building` now **emits zero `untracked_building` orphans when no authoritative liveness source is available**. Absent liveness data ⇒ treat every claim as ALIVE, never as orphaned. Existing per-issue claim + label-grace guards are retained as defense-in-depth.
2. **`clean.py`** — same guard on `_revert_stale_building_labels_spawn_loop`: no state file **and** no `.loom/locks/issue-<N>/` locks ⇒ revert nothing.
3. **`daemon_cleanup.py`** — removed the dead `_run_orphan_recovery` call path (module has no console entry point; superseded by `cleanup.py`) plus its now-unused `threading` import.
4. **Docs** — reconciled `loom-stuck-detection` claims in `defaults/CLAUDE.md` and `.loom/docs/troubleshooting.md` with the code (it reads `spawn-loop-state.json`, a safe no-op today); recorded every consumer's disposition in `docs/migration/daemon-state-consumers.md`.

## Out of scope (deferred, per curator)

Repointing the four non-destructive reporters (`status.py`, `health_monitor.py`, `daemon_diagnostic.py`, `stuck_detection.py`) + retiring the `SpawnLoopState` model/path — they are report-only, safe no-ops today.

## How the fail-safe invariant is proven

New `loom-tools/tests/test_orphan_recovery.py` (14 tests) + 3 sibling tests in `test_clean.py`:

- **The regression**: no state file, no daemon, no locks + a stale (`label_age > grace`), unclaimed `loom:building` issue under `--recover` ⇒ `total_orphaned == 0`, `total_recovered == 0`, and **no `gh issue edit`** is ever issued.
- **AC (a)**: an active `.loom/locks/issue-42/` lock keeps #42 alive even with an old label and an "abandoned" claim ⇒ 0 orphans.
- **AC (b)**: with an authoritative source present that does not list the issue (a decoy lock for another issue, or a present-but-empty state roster), a genuinely-dead claim **is** still recovered.
- **AC (c)**: `clean.py` sibling — no state file + no locks ⇒ reverts nothing; a locked issue is never reverted; a genuine orphan is reverted once a source is present.
- Defense-in-depth: valid claim and label-grace still protect issues even when a source is present; the `stale_heartbeat` path is unaffected.

## Test results

`cd loom-tools && PYTHONPATH=src python3 -m pytest -q` ⇒ **4 failed, 1719 passed, 62 skipped**. The 4 failures are pre-existing on base (PYTHONPATH-less subprocess spawns in `test_logging`, `test_agent_spawn`, `test_forge_cli`, `test_installation_verification`) — no new failures introduced (+17 new tests all green). `ruff` clean on all changed files (the two remaining F401s and one F821 are pre-existing on base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)