### PR TITLE
fix(install): generalize --quick auto-stash restore beyond .gitignore (#3663)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -276,6 +276,80 @@ reapply_loom_gitignore_patterns() {
   done <<<"$loom_lines"
 }
 
+# Issue #3663: re-apply the current Loom-owned CLAUDE.md marker block after a
+# --quick reinstall stash pop that was performed against a HEAD-reset CLAUDE.md.
+#
+# This generalizes the #3588 .gitignore treatment (HEAD-reset-before-pop, then
+# reapply) to CLAUDE.md, whose Loom content is a marker-delimited block
+# (`<!-- BEGIN LOOM ORCHESTRATION -->` … `<!-- END LOOM ORCHESTRATION -->`)
+# rather than a set of appended lines. The reinstall restores CLAUDE.md to its
+# committed HEAD state before popping so the user's stashed hunk applies cleanly
+# (see the pop block below). That reset reverts the Loom block to its old
+# committed content, so we splice the freshly written block back in here.
+#
+# We rebuild the file as: everything BEFORE the begin marker (from the popped
+# working copy — the user's restored content) + the block (begin…end inclusive)
+# taken from the post-init snapshot (the daemon's authoritative fresh block) +
+# everything AFTER the end marker (again from the popped working copy). Only the
+# delimited Loom region is replaced; every line the user's pop restored outside
+# the markers (e.g. their own `REPO-SKILLS` block) is left byte-for-byte intact.
+# Derived from the snapshot, never hard-coded, mirroring
+# reapply_loom_gitignore_patterns's "trust the daemon's output" property.
+# Idempotent: splicing an already-current block is a no-op. If either file lacks
+# both markers there is no delimited region to reconcile, so the popped file is
+# left as-is.
+reapply_loom_claude_md_block() {
+  local target_path="$1"
+  local postinit_snapshot="$2"
+  local claude_md="$target_path/CLAUDE.md"
+  local begin="<!-- BEGIN LOOM ORCHESTRATION -->"
+  local end="<!-- END LOOM ORCHESTRATION -->"
+
+  [[ -f "$postinit_snapshot" && -f "$claude_md" ]] || return 0
+
+  # Both the snapshot and the popped file must carry the marker block, else
+  # there is no delimited Loom region to splice — leave the popped file alone.
+  grep -qF "$begin" "$postinit_snapshot" && grep -qF "$end" "$postinit_snapshot" || return 0
+  grep -qF "$begin" "$claude_md" && grep -qF "$end" "$claude_md" || return 0
+
+  local tmp
+  tmp="$(mktemp 2>/dev/null || true)"
+  [[ -n "$tmp" ]] || return 0
+
+  # Pass 1 (snapshot): capture the begin…end block into `block`.
+  # Pass 2 (popped file): print user content up to begin, emit the captured
+  # block once, then resume printing user content after end.
+  if awk -v b="$begin" -v e="$end" '
+    FNR==NR {
+      if (index($0, b)) grab=1
+      if (grab) block = block $0 ORS
+      if (index($0, e)) grab=0
+      next
+    }
+    {
+      if (index($0, b)) { printf "%s", block; skip=1 }
+      if (!skip) print
+      if (index($0, e)) skip=0
+    }
+  ' "$postinit_snapshot" "$claude_md" >"$tmp" 2>/dev/null && [[ -s "$tmp" ]]; then
+    cat "$tmp" >"$claude_md" 2>/dev/null || true
+  fi
+  rm -f "$tmp" 2>/dev/null || true
+  return 0
+}
+
+# Issue #3663: emit the Loom marker block (begin…end inclusive) from stdin.
+# Used to decide whether a user's stashed CLAUDE.md edit lands INSIDE the Loom
+# block (in which case a HEAD-reset+reapply would clobber it) or entirely
+# outside it (safe to reset+reapply). Empty output means no block was found.
+_emit_loom_claude_block() {
+  awk '
+    index($0, "<!-- BEGIN LOOM ORCHESTRATION -->") { inblk=1 }
+    inblk { print }
+    index($0, "<!-- END LOOM ORCHESTRATION -->") { inblk=0 }
+  '
+}
+
 # Determine Loom repository root
 LOOM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -813,21 +887,65 @@ elif [[ -d "$TARGET_PATH/.loom" ]]; then
     if [[ "$REINSTALL_STASHED_USER_CHANGES" == "true" ]]; then
       info "Restoring stashed user changes..."
 
-      # If .gitignore is tracked at HEAD, snapshot the post-init version (which
-      # carries the current Loom patterns) and reset the working copy to HEAD so
-      # the pop's 3-way base lines up with the committed context. Skip this for
-      # repos where .gitignore is untracked/newly created — there is no HEAD
-      # base to restore and the plain pop already applies cleanly.
-      REINSTALL_GITIGNORE_RESET=false
-      REINSTALL_GITIGNORE_POSTINIT=""
-      if git -C "$TARGET_PATH" cat-file -e HEAD:.gitignore 2>/dev/null; then
-        REINSTALL_GITIGNORE_POSTINIT="$(mktemp 2>/dev/null || true)"
-        if [[ -n "$REINSTALL_GITIGNORE_POSTINIT" ]] && \
-           cp "$TARGET_PATH/.gitignore" "$REINSTALL_GITIGNORE_POSTINIT" 2>/dev/null && \
-           git -C "$TARGET_PATH" checkout HEAD -- .gitignore 2>/dev/null; then
-          REINSTALL_GITIGNORE_RESET=true
+      # Issue #3663: generalize the #3588 .gitignore HEAD-reset-then-reapply to
+      # every Loom-owned dirty file that carries a well-defined Loom-vs-user
+      # split — today `.gitignore` (Loom patterns appended at EOF) and
+      # `CLAUDE.md` (a marker-delimited Loom block with user content around it).
+      # For each such path tracked at HEAD, snapshot the post-init on-disk
+      # version (which carries the freshly written Loom content) and reset the
+      # working copy to HEAD so the pop's 3-way base lines up with the committed
+      # context and the user's stashed hunk applies cleanly. After a successful
+      # pop we re-apply only the Loom portion from the snapshot (append for
+      # `.gitignore`, marker-block splice for `CLAUDE.md`), leaving everything
+      # the user's pop restored untouched.
+      #
+      # HEAD-reset is deliberately scoped to files with a reapply strategy. A
+      # fully Loom-owned file (a role `.md`, `config.json`) has no partial
+      # reapply, so resetting it would silently drop the reinstall's update —
+      # those fall through to a plain pop, which surfaces a genuine conflict
+      # (named below) instead of resetting-and-losing. Untracked/newly created
+      # files have no HEAD base to restore to and the plain pop already applies
+      # them cleanly, so they are skipped too.
+      REINSTALL_RESET_PATHS=()
+      REINSTALL_RESET_SNAPSHOTS=()
+      REINSTALL_RESET_STRATEGIES=()
+      for _owned_path in ${REINSTALL_OWNED_DIRTY[@]+"${REINSTALL_OWNED_DIRTY[@]}"}; do
+        _reset_strategy=""
+        case "$_owned_path" in
+          .gitignore) _reset_strategy="gitignore" ;;
+          CLAUDE.md)  _reset_strategy="claude_md" ;;
+          *) continue ;;
+        esac
+        git -C "$TARGET_PATH" cat-file -e "HEAD:$_owned_path" 2>/dev/null || continue
+
+        # Issue #3663: CLAUDE.md's reapply replaces the ENTIRE marker block, so
+        # the reset+reapply path is only safe when (a) HEAD already carries a
+        # Loom block to splice and (b) the user's stashed edits are OUTSIDE that
+        # block. When the user edited INSIDE the block, reset+reapply would
+        # silently clobber their in-block edit — so skip the reset and let the
+        # plain pop's 3-way merge surface a genuine conflict (named below),
+        # keeping the edit in the stash. When HEAD has no block at all, `init`'s
+        # freshly appended block already survives an out-of-block pop unchanged,
+        # so there is nothing to splice. Detect both by comparing the stashed
+        # (user) block region against HEAD's block region.
+        if [[ "$_reset_strategy" == "claude_md" ]]; then
+          _head_block="$(git -C "$TARGET_PATH" show HEAD:CLAUDE.md 2>/dev/null | _emit_loom_claude_block)" || true
+          [[ -n "$_head_block" ]] || continue
+          _stashed_block="$(git -C "$TARGET_PATH" show 'stash@{0}:CLAUDE.md' 2>/dev/null | _emit_loom_claude_block)" || true
+          [[ "$_stashed_block" == "$_head_block" ]] || continue
         fi
-      fi
+
+        _reset_snap="$(mktemp 2>/dev/null || true)"
+        [[ -n "$_reset_snap" ]] || continue
+        if cp "$TARGET_PATH/$_owned_path" "$_reset_snap" 2>/dev/null && \
+           git -C "$TARGET_PATH" checkout HEAD -- "$_owned_path" 2>/dev/null; then
+          REINSTALL_RESET_PATHS+=("$_owned_path")
+          REINSTALL_RESET_SNAPSHOTS+=("$_reset_snap")
+          REINSTALL_RESET_STRATEGIES+=("$_reset_strategy")
+        else
+          rm -f "$_reset_snap" 2>/dev/null || true
+        fi
+      done
 
       # Issue #3611: pop with `--index` so a caller's pre-existing staged/
       # unstaged split is reproduced. A plain `git stash pop` re-applies EVERY
@@ -857,25 +975,49 @@ elif [[ -d "$TARGET_PATH/.loom" ]]; then
       fi
 
       if [[ $REINSTALL_POP_STATUS -eq 0 ]]; then
-        # Pop succeeded. When we reset .gitignore to HEAD the user's hunk is now
-        # applied but the current Loom patterns are missing — re-append them.
-        if [[ "$REINSTALL_GITIGNORE_RESET" == "true" ]]; then
-          reapply_loom_gitignore_patterns "$TARGET_PATH" "$REINSTALL_GITIGNORE_POSTINIT"
-        fi
+        # Pop succeeded. Each file we reset to HEAD now carries the user's hunk
+        # but its OLD committed Loom content — re-apply the fresh Loom portion
+        # from that file's post-init snapshot (append for .gitignore, marker-
+        # block splice for CLAUDE.md).
+        _reset_i=0
+        while [[ $_reset_i -lt ${#REINSTALL_RESET_PATHS[@]} ]]; do
+          case "${REINSTALL_RESET_STRATEGIES[$_reset_i]}" in
+            gitignore)
+              reapply_loom_gitignore_patterns "$TARGET_PATH" "${REINSTALL_RESET_SNAPSHOTS[$_reset_i]}"
+              ;;
+            claude_md)
+              reapply_loom_claude_md_block "$TARGET_PATH" "${REINSTALL_RESET_SNAPSHOTS[$_reset_i]}"
+              ;;
+          esac
+          _reset_i=$((_reset_i + 1))
+        done
         success "User changes restored"
       else
-        # Genuine conflict (e.g. the user also edited a Loom-managed file that
-        # `init` rewrote). Roll .gitignore back to the post-init snapshot so the
-        # tree is not left half-reset, then surface the real conflict and a
+        # Genuine conflict (e.g. the user also edited the same lines a Loom-owned
+        # file that `init` rewrote occupies). Roll every reset file back to its
+        # post-init snapshot so the tree is not left half-reset, then surface the
+        # real conflict — naming the specific file(s) that conflicted — and a
         # concrete recovery path. Do NOT abort — the reinstall itself succeeded;
         # only the user-change restore needs manual attention.
-        if [[ "$REINSTALL_GITIGNORE_RESET" == "true" ]]; then
-          cp "$REINSTALL_GITIGNORE_POSTINIT" "$TARGET_PATH/.gitignore" 2>/dev/null || true
+        _reset_i=0
+        while [[ $_reset_i -lt ${#REINSTALL_RESET_PATHS[@]} ]]; do
+          cp "${REINSTALL_RESET_SNAPSHOTS[$_reset_i]}" \
+            "$TARGET_PATH/${REINSTALL_RESET_PATHS[$_reset_i]}" 2>/dev/null || true
+          _reset_i=$((_reset_i + 1))
+        done
+        # Issue #3663: name the file(s) that actually conflicted rather than a
+        # generic "recover by hand". Prefer git's own unmerged set; fall back to
+        # the guarded Loom-owned dirty set when git reports none.
+        REINSTALL_CONFLICT_FILES="$(git -C "$TARGET_PATH" diff --name-only --diff-filter=U 2>/dev/null | paste -sd' ' - 2>/dev/null || true)"
+        if [[ -z "$REINSTALL_CONFLICT_FILES" ]]; then
+          REINSTALL_CONFLICT_FILES="${REINSTALL_OWNED_DIRTY[*]-}"
         fi
         REINSTALL_STASH_REF="$(git -C "$TARGET_PATH" stash list 2>/dev/null | head -1 | cut -d: -f1)"
         [[ -z "$REINSTALL_STASH_REF" ]] && REINSTALL_STASH_REF="stash@{0}"
         warning "Failed to restore stashed user changes automatically"
         echo ""
+        [[ -n "$REINSTALL_CONFLICT_FILES" ]] && \
+          echo "  Conflicting file(s): $REINSTALL_CONFLICT_FILES" && echo ""
         echo "  git stash pop --index reported:"
         printf '%s\n' "$REINSTALL_POP_OUTPUT" | sed 's/^/    /'
         echo ""
@@ -890,7 +1032,11 @@ elif [[ -d "$TARGET_PATH/.loom" ]]; then
         echo "    git stash drop $REINSTALL_STASH_REF                 # once you've reconciled"
       fi
 
-      [[ -n "$REINSTALL_GITIGNORE_POSTINIT" ]] && rm -f "$REINSTALL_GITIGNORE_POSTINIT" 2>/dev/null || true
+      _reset_i=0
+      while [[ $_reset_i -lt ${#REINSTALL_RESET_SNAPSHOTS[@]} ]]; do
+        rm -f "${REINSTALL_RESET_SNAPSHOTS[$_reset_i]}" 2>/dev/null || true
+        _reset_i=$((_reset_i + 1))
+      done
     fi
 
     echo ""

--- a/scripts/test-install-quick-gitignore-stash.sh
+++ b/scripts/test-install-quick-gitignore-stash.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
-# Regression test for issues #3588 and #3611: `install.sh --quick` must not
-# strand or mangle a user's uncommitted changes across the uninstall→reinstall
-# stash/pop + index-reconcile cycle.
+# Regression test for issues #3588, #3611, and #3663: `install.sh --quick` must
+# not strand or mangle a user's uncommitted changes across the uninstall→
+# reinstall stash/pop + index-reconcile cycle.
+#
+# #3663 (Scenarios 11-16): the #3588 HEAD-reset-before-pop + reapply treatment
+# was hardcoded to `.gitignore`. When the update rewrites another Loom-owned
+# file the user has ALSO dirtied — canonically CLAUDE.md, whose Loom content is
+# a marker-delimited block with user content around it — the `stash pop --index`
+# base has moved and the pop conflicts, stranding the change in a stash with a
+# generic "recover by hand" message. The fix generalizes the reset+reapply to
+# CLAUDE.md (block-aware splice) and names the specific conflicting file(s).
 #
 # #3588: The uninstall→init round-trip rewrites .gitignore non-reversibly
 # (uninstall strips Loom patterns mid-block + collapses blanks; init re-appends
@@ -73,6 +81,31 @@ setup_repo() {
   git -C "$w" add -A
   git -C "$w" commit -qm "loom install" >/dev/null 2>&1
 }
+
+# Like setup_repo, but pre-seeds a user-authored CLAUDE.md (content that lives
+# OUTSIDE the Loom marker block) before the first install, so the installed
+# CLAUDE.md is a genuine mixed file: user content + a marker-delimited Loom
+# block. Commits the installed state as the baseline. Used by the #3663
+# scenarios.
+setup_repo_claude_md() {
+  local w="$1"
+  git init -q "$w"
+  git -C "$w" config user.email test@example.com
+  git -C "$w" config user.name "Test User"
+  printf 'node_modules/\n.loom/state.json\n' >"$w/.gitignore"
+  printf '# My Project\n\nUSER SECTION LINE\n' >"$w/CLAUDE.md"
+  echo "hello" >"$w/README.md"
+  git -C "$w" add -A
+  git -C "$w" commit -qm "init"
+  "$INSTALL_SCRIPT" -y --quick "$w" >/dev/null 2>&1
+  git -C "$w" add -A
+  git -C "$w" commit -qm "loom install" >/dev/null 2>&1
+}
+
+# A stable substring that appears INSIDE the generated Loom block (see the
+# scaffolding.rs root-CLAUDE.md content). Editing this line simulates an
+# in-block user edit.
+CLAUDE_INBLOCK_TOKEN="AI-powered development orchestration"
 
 echo "======================================"
 echo "Issue #3588: install.sh --quick .gitignore stash/pop"
@@ -406,6 +439,210 @@ if [[ "$(cat "$R10/.anvil/install-metadata.json")" == "anvil metadata" ]] && \
   pass "sibling non-Loom file contents untouched (#3611)"
 else
   fail "sibling non-Loom file contents mutated by reinstall (#3611)"
+fi
+echo ""
+
+echo "======================================"
+echo "Issue #3663: install.sh --quick CLAUDE.md stash/pop"
+echo "======================================"
+echo ""
+
+# --------------------------------------------------------------------------
+# Scenario 11 (primary #3663 repro): an uncommitted CLAUDE.md edit OUTSIDE the
+# Loom marker block survives the reinstall — no stranded stash, no generic
+# "recover by hand" message — and the Loom block is still present.
+# FAILS against the pre-fix code (CLAUDE.md got none of the .gitignore
+# HEAD-reset treatment, so the pop conflicted and stranded the change).
+# --------------------------------------------------------------------------
+R11="$TEST_DIR/claude-outside-edit"
+setup_repo_claude_md "$R11"
+perl -0pi -e 's/USER SECTION LINE/USER SECTION LINE EDITED/' "$R11/CLAUDE.md"
+R11_OUT="$TEST_DIR/claude-outside-out.txt"
+"$INSTALL_SCRIPT" -y --quick "$R11" >"$R11_OUT" 2>&1
+if grep -qxF "USER SECTION LINE EDITED" "$R11/CLAUDE.md"; then
+  pass "user CLAUDE.md edit (outside block) survives --quick reinstall (#3663)"
+else
+  fail "user CLAUDE.md edit stranded after --quick reinstall (#3663)"
+fi
+if [[ "$(git -C "$R11" stash list | wc -l | tr -d ' ')" == "0" ]]; then
+  pass "stash consumed after CLAUDE.md outside-block edit (#3663)"
+else
+  fail "stash not consumed — CLAUDE.md change left in stash (#3663)"
+fi
+if ! grep -q "recover by hand" "$R11_OUT"; then
+  pass "no generic 'recover by hand' message for outside-block edit (#3663)"
+else
+  fail "generic 'recover by hand' message printed for outside-block edit (#3663)"
+fi
+if grep -qF "<!-- BEGIN LOOM ORCHESTRATION -->" "$R11/CLAUDE.md" && \
+   grep -qF "<!-- END LOOM ORCHESTRATION -->" "$R11/CLAUDE.md"; then
+  pass "Loom marker block present after reinstall (#3663)"
+else
+  fail "Loom marker block missing after reinstall (#3663)"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# Scenario 12 (block refresh): a stale line committed INSIDE the block is
+# refreshed away by the reinstall while an out-of-block user edit is preserved.
+# Proves the reapply splices the daemon's freshly written block (from the
+# post-init snapshot), not the old committed block.
+# --------------------------------------------------------------------------
+R12="$TEST_DIR/claude-block-refresh"
+setup_repo_claude_md "$R12"
+# Inject a stale line just after the BEGIN marker and commit it, so the
+# committed block diverges from what init regenerates.
+perl -0pi -e 's{(<!-- BEGIN LOOM ORCHESTRATION -->\n)}{${1}STALE BLOCK LINE TO BE REMOVED\n}' "$R12/CLAUDE.md"
+git -C "$R12" add -A
+git -C "$R12" commit -qm "stale in-block line" >/dev/null 2>&1
+# User edits OUTSIDE the block (uncommitted).
+perl -0pi -e 's/USER SECTION LINE/USER SECTION LINE EDITED/' "$R12/CLAUDE.md"
+"$INSTALL_SCRIPT" -y --quick "$R12" >/dev/null 2>&1
+if grep -qxF "USER SECTION LINE EDITED" "$R12/CLAUDE.md"; then
+  pass "outside-block edit preserved alongside block refresh (#3663)"
+else
+  fail "outside-block edit lost during block refresh (#3663)"
+fi
+if ! grep -qF "STALE BLOCK LINE TO BE REMOVED" "$R12/CLAUDE.md"; then
+  pass "stale in-block line refreshed away from post-init snapshot (#3663)"
+else
+  fail "stale in-block line survived — block not refreshed from snapshot (#3663)"
+fi
+if [[ "$(grep -cF '<!-- BEGIN LOOM ORCHESTRATION -->' "$R12/CLAUDE.md")" == "1" ]] && \
+   [[ "$(grep -cF '<!-- END LOOM ORCHESTRATION -->' "$R12/CLAUDE.md")" == "1" ]]; then
+  pass "exactly one well-formed marker block after refresh (#3663)"
+else
+  fail "marker block malformed after refresh (#3663)"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# Scenario 13 (staged/unstaged split): stage part of a CLAUDE.md edit and leave
+# part unstaged; the split must survive the reinstall (pop --index property,
+# now that CLAUDE.md participates in the HEAD-reset path). The seeded file has
+# two user lines outside the block; we edit one staged and one unstaged.
+# --------------------------------------------------------------------------
+R13="$TEST_DIR/claude-staged-split"
+git init -q "$R13"
+git -C "$R13" config user.email test@example.com
+git -C "$R13" config user.name "Test User"
+printf 'node_modules/\n' >"$R13/.gitignore"
+printf '# My Project\n\nLINE ALPHA\nLINE BETA\n' >"$R13/CLAUDE.md"
+echo "hello" >"$R13/README.md"
+git -C "$R13" add -A
+git -C "$R13" commit -qm "init"
+"$INSTALL_SCRIPT" -y --quick "$R13" >/dev/null 2>&1
+git -C "$R13" add -A
+git -C "$R13" commit -qm "loom install" >/dev/null 2>&1
+perl -0pi -e 's/LINE ALPHA/LINE ALPHA STAGED/' "$R13/CLAUDE.md"
+git -C "$R13" add CLAUDE.md
+perl -0pi -e 's/LINE BETA/LINE BETA UNSTAGED/' "$R13/CLAUDE.md"
+"$INSTALL_SCRIPT" -y --quick "$R13" >/dev/null 2>&1
+if git -C "$R13" diff --staged CLAUDE.md | grep -qxF "+LINE ALPHA STAGED"; then
+  pass "staged CLAUDE.md hunk restored STILL STAGED (pop --index, #3663)"
+else
+  fail "staged CLAUDE.md hunk came back unstaged/lost (#3663)"
+fi
+if git -C "$R13" diff CLAUDE.md | grep -qxF "+LINE BETA UNSTAGED"; then
+  pass "unstaged CLAUDE.md hunk restored STILL UNSTAGED (#3663)"
+else
+  fail "unstaged CLAUDE.md hunk was spuriously staged/lost (#3663)"
+fi
+if [[ "$(git -C "$R13" stash list | wc -l | tr -d ' ')" == "0" ]]; then
+  pass "stash consumed after CLAUDE.md staged/unstaged split reinstall (#3663)"
+else
+  fail "stash not consumed after CLAUDE.md split reinstall (#3663)"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# Scenario 14 (genuine in-block overlap): the user edits a line INSIDE the Loom
+# block that the reinstall ALSO rewrites (forced via a divergent committed
+# block). The reset+reapply must NOT silently clobber the edit — instead the
+# installer surfaces a clear conflict that NAMES CLAUDE.md, preserves the stash,
+# exits 0, and still prints the completion banner. The in-block edit stays
+# recoverable from the stash.
+# --------------------------------------------------------------------------
+R14="$TEST_DIR/claude-inblock-conflict"
+setup_repo_claude_md "$R14"
+# Commit a stale value on an in-block line so init's regen diverges from HEAD.
+perl -0pi -e "s/\\Q$CLAUDE_INBLOCK_TOKEN\\E/STALE COMMITTED BLOCK VALUE/g" "$R14/CLAUDE.md"
+git -C "$R14" add -A
+git -C "$R14" commit -qm "diverge in-block line" >/dev/null 2>&1
+# User makes an uncommitted edit to that SAME in-block line.
+perl -0pi -e 's/STALE COMMITTED BLOCK VALUE/USER IN-BLOCK EDIT/g' "$R14/CLAUDE.md"
+R14_OUT="$TEST_DIR/claude-inblock-out.txt"
+"$INSTALL_SCRIPT" -y --quick "$R14" >"$R14_OUT" 2>&1
+R14_EXIT=$?
+if [[ $R14_EXIT -eq 0 ]]; then
+  pass "in-block CLAUDE.md conflict: installer exits 0 (does not abort, #3663)"
+else
+  fail "in-block CLAUDE.md conflict: installer exited $R14_EXIT (#3663)"
+fi
+if grep -q "Conflicting file(s):.*CLAUDE.md" "$R14_OUT"; then
+  pass "in-block CLAUDE.md conflict: names CLAUDE.md (not generic, #3663)"
+else
+  fail "in-block CLAUDE.md conflict: did not name the conflicting file (#3663)"
+fi
+if [[ "$(git -C "$R14" stash list | wc -l | tr -d ' ')" != "0" ]]; then
+  pass "in-block CLAUDE.md conflict: stash preserved for recovery (#3663)"
+else
+  fail "in-block CLAUDE.md conflict: stash lost (edit unrecoverable, #3663)"
+fi
+if git -C "$R14" stash show -p 'stash@{0}' 2>/dev/null | grep -qF "USER IN-BLOCK EDIT"; then
+  pass "in-block CLAUDE.md conflict: user edit recoverable from stash (#3663)"
+else
+  fail "in-block CLAUDE.md conflict: user edit missing from stash (#3663)"
+fi
+if grep -q "Quick reinstallation complete" "$R14_OUT"; then
+  pass "in-block CLAUDE.md conflict: completion banner still printed (#3663)"
+else
+  fail "in-block CLAUDE.md conflict: completion banner missing (#3663)"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# Scenario 15 (in-block edit, no divergence): when the reinstall does NOT change
+# the block content (common case), an in-block user edit applies cleanly with no
+# data loss and no stranded stash — the plain-pop 3-way merge succeeds because
+# only one side changed.
+# --------------------------------------------------------------------------
+R15="$TEST_DIR/claude-inblock-clean"
+setup_repo_claude_md "$R15"
+perl -0pi -e "s/\\Q$CLAUDE_INBLOCK_TOKEN\\E/MY HARMLESS IN-BLOCK EDIT/g" "$R15/CLAUDE.md"
+"$INSTALL_SCRIPT" -y --quick "$R15" >/dev/null 2>&1
+if grep -qF "MY HARMLESS IN-BLOCK EDIT" "$R15/CLAUDE.md"; then
+  pass "in-block edit (no divergence) preserved cleanly, no data loss (#3663)"
+else
+  fail "in-block edit (no divergence) lost after reinstall (#3663)"
+fi
+if [[ "$(git -C "$R15" stash list | wc -l | tr -d ' ')" == "0" ]]; then
+  pass "in-block edit (no divergence): stash consumed cleanly (#3663)"
+else
+  fail "in-block edit (no divergence): stash stranded (#3663)"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# Scenario 16 (multiple dirty Loom-owned files): .gitignore AND CLAUDE.md are
+# both dirty (outside-block) in the same reinstall — both must restore cleanly
+# with no stranded stash.
+# --------------------------------------------------------------------------
+R16="$TEST_DIR/claude-and-gitignore"
+setup_repo_claude_md "$R16"
+echo "my-local-dir/" >>"$R16/.gitignore"
+perl -0pi -e 's/USER SECTION LINE/USER SECTION LINE EDITED/' "$R16/CLAUDE.md"
+"$INSTALL_SCRIPT" -y --quick "$R16" >/dev/null 2>&1
+if grep -qxF "my-local-dir/" "$R16/.gitignore" && \
+   grep -qxF "USER SECTION LINE EDITED" "$R16/CLAUDE.md"; then
+  pass "both .gitignore and CLAUDE.md edits restored in one reinstall (#3663)"
+else
+  fail "a simultaneously-dirty Loom-owned file was stranded (#3663)"
+fi
+if [[ "$(git -C "$R16" stash list | wc -l | tr -d ' ')" == "0" ]]; then
+  pass "stash consumed with multiple dirty Loom-owned files (#3663)"
+else
+  fail "stash stranded with multiple dirty Loom-owned files (#3663)"
 fi
 echo ""
 


### PR DESCRIPTION
## Summary

`install.sh --quick` guards uncommitted user changes across the uninstall→reinstall cycle by stashing Loom-owned dirty paths, then restoring with `git stash pop --index`. The #3588 fix that lets this survive a file `init` rewrites in place — HEAD-reset the file before popping so the 3-way base lines up, then reapply the fresh Loom content — was **hardcoded to `.gitignore`**. When the update also rewrote a different Loom-owned file the user had dirtied — canonically `CLAUDE.md` (a marker-delimited Loom block with user content around it) — the pop conflicted, stranded the change in a stash, and printed a generic "recover by hand" message. This is the same defect class as #3588, just not yet generalized.

## What changed

- **`install.sh`**: the `--quick` restore block now iterates the already-computed `REINSTALL_OWNED_DIRTY` set and applies the HEAD-reset-then-reapply treatment to every file with a well-defined Loom-vs-user split — `.gitignore` (Loom patterns appended) and `CLAUDE.md` (marker block).
- New `reapply_loom_claude_md_block()`: a block-aware splice that replaces only the `<!-- BEGIN LOOM ORCHESTRATION -->` … `<!-- END LOOM ORCHESTRATION -->` region with the daemon's freshly-written block from the post-init snapshot, leaving the user's content outside the markers byte-for-byte intact. Derived from the snapshot, never hard-coded (mirrors `reapply_loom_gitignore_patterns`).
- HEAD-reset is scoped to files that have a reapply strategy. A fully Loom-owned file (role `.md`, `config.json`) has no partial reapply, so it falls through to a plain pop rather than resetting-and-losing the update. For `CLAUDE.md`, when the user's stashed edit lands **inside** the block (reapply would clobber it) or HEAD carries no block to splice, the reset is skipped so the plain-pop 3-way merge surfaces a genuine conflict instead of silently losing data.
- The conflict-surfacing branch now **names the specific conflicting file(s)** (`Conflicting file(s): CLAUDE.md`) instead of a generic message.

## Behavior matrix (CLAUDE.md)

| User edit | `init` changes block? | Outcome |
|-----------|----------------------|---------|
| Outside the Loom block | — | Edit preserved, block refreshed, stash consumed, no message |
| Inside the block | No | Applies cleanly (one-sided 3-way), no data loss |
| Inside the block | Yes | Conflict surfaced + named, stash preserved, edit recoverable, installer exits 0 |

Staged/unstaged split is preserved throughout (`pop --index`).

## Tests

Extended the daemon-backed stash regression suite (`scripts/test-install-quick-gitignore-stash.sh`) with six CLAUDE.md scenarios covering all rows above plus multiple-dirty-files. Results:

- `test-install-quick-gitignore-stash.sh`: **46/46** (27 existing #3588/#3611 + 19 new #3663)
- `test-installer.sh` (CI): **121/121**
- `test-install-stash-scope.sh`: **7/7**

Closes #3663

🤖 Generated with [Claude Code](https://claude.com/claude-code)