### PR TITLE
fix(merge): reset loom:building on Part-of partial-increment issues (#3667)

### DIFF
--- a/defaults/scripts/merge-pr.sh
+++ b/defaults/scripts/merge-pr.sh
@@ -276,6 +276,118 @@ fi
 info "Merging PR #$PR_NUMBER: $PR_TITLE"
 info "Branch: $PR_BRANCH"
 
+# ---------------------------------------------------------------------------
+# Partial-increment label reset (#3667).
+#
+# A PR that implements only a slice of a family/epic issue references it with a
+# NON-closing keyword — `Part of #N` / `Contributes to #N` (convention in
+# builder-pr.md) — deliberately so the issue survives the merge for further
+# work. GitHub never auto-closes such an issue, and the merge path otherwise
+# leaves `loom:building` orphaned on it: the #2838 "skip label cleanup on close"
+# decision only reasoned about the `Closes #N` auto-close case, where GitHub
+# closes the issue and stale labels on closed items are harmless. Nothing else
+# reclaims the label until a time-gated `/sweep all` stale-claim pass (>=2h),
+# and non-aggressive sweeps hard-skip the still-`loom:building` issue
+# indefinitely (issue #3667).
+#
+# Here — at the deterministic merge choke point — we swap each such still-open,
+# still-`loom:building` referenced issue back to `loom:issue`, mirroring
+# orphan_recovery.py's recover_issue() label-reset semantics (loom:building ->
+# loom:issue, i.e. return to the ready queue). No liveness check is needed: a
+# merge just happened on the PR that necessarily came from whoever held the
+# claim, so the current increment's work is provably done — a deterministic,
+# not heuristic, signal. Closing keywords (`Closes`/`Fixes`/`Resolves`) are NOT
+# matched — GitHub auto-closes those and the #2838 no-cleanup path stays
+# untouched.
+#
+# GitHub-only for v1 (guarded on FORGE_TYPE); merge-pr.sh already branches on
+# forge type elsewhere. Every step is best-effort and must never fail the merge.
+
+# Reset a single referenced issue's labels if — verified fresh at merge time —
+# it is still open and still carries loom:building. Idempotent: a no-op when the
+# issue is already closed, already lacks loom:building (e.g. re-claimed by a
+# second builder), or is actually a PR.
+_reset_one_partial_issue() {
+  local issue_num="$1"
+  local issue_json issue_state issue_labels
+
+  # Fresh (uncached) read so we see the label state AS OF the merge, not as of
+  # PR creation. Plain `gh api` is uncached; use it directly (not $GH, which may
+  # be gh-cached) to avoid a stale cached view masking a fresh re-claim.
+  issue_json="$(gh api "repos/$REPO_NWO/issues/$issue_num" 2>/dev/null || echo '{}')"
+
+  # The GitHub issues endpoint also returns PRs (a PR is an issue with a
+  # .pull_request member). Never mutate a PR that slipped through the regex.
+  if [[ "$(echo "$issue_json" | jq -r 'has("pull_request")')" == "true" ]]; then
+    return 0
+  fi
+
+  issue_state="$(echo "$issue_json" | jq -r '.state // ""')"
+  if [[ "$issue_state" != "open" ]]; then
+    info "Partial-increment reset: issue #$issue_num is not open (state='${issue_state:-unknown}') — skipping"
+    return 0
+  fi
+
+  issue_labels="$(echo "$issue_json" | jq -r '.labels[]?.name' 2>/dev/null || true)"
+  if ! printf '%s\n' "$issue_labels" | grep -qx 'loom:building'; then
+    info "Partial-increment reset: issue #$issue_num is not loom:building — skipping (idempotent)"
+    return 0
+  fi
+
+  info "Partial-increment reset: PR #$PR_NUMBER merged as a partial slice of #$issue_num; returning it to the ready queue"
+  if gh issue edit "$issue_num" \
+       --remove-label "loom:building" \
+       --add-label "loom:issue" >/dev/null 2>&1; then
+    success "Issue #$issue_num: loom:building -> loom:issue (partial increment; issue remains open)"
+    local ts comment
+    ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    comment="## Partial Increment Merged
+
+PR #$PR_NUMBER merged with a non-closing \`Part of\` / \`Contributes to\` reference, so this issue remains **open** for further work.
+
+**Action taken**:
+- Removed \`loom:building\` label
+- Added \`loom:issue\` label to return to the ready queue
+
+This issue is now available for the next increment (a subsequent \`/loom:sweep\` will treat it as ready rather than in-flight).
+
+---
+*Reset by merge-pr.sh (#3667) at $ts*"
+    gh issue comment "$issue_num" --body "$comment" >/dev/null 2>&1 || \
+      warning "Could not post partial-increment comment on issue #$issue_num (label swap still applied)"
+  else
+    warning "Could not reset labels on issue #$issue_num (partial increment) — may need manual 'gh issue edit'"
+  fi
+}
+
+# Parse the merged PR body for non-closing partial-increment references and
+# reset each referenced issue. Best-effort; returns 0 unconditionally.
+_reset_partial_increment_labels() {
+  [[ "$FORGE_TYPE" == "github" ]] || return 0
+
+  local pr_body
+  pr_body="$(echo "$PR_JSON" | jq -r '.body // ""')"
+  [[ -n "$pr_body" ]] || return 0
+
+  # Extract issue numbers referenced with a NON-closing partial-increment
+  # keyword: "Part of #N" / "Contributes to #N" (case-insensitive), deduped.
+  # grep -oiE emits e.g. "Part of #123"; a second grep strips to the number.
+  local refs
+  refs="$(printf '%s\n' "$pr_body" \
+    | grep -oiE '(Part of|Contributes to)[[:space:]]+#[0-9]+' \
+    | grep -oE '[0-9]+' \
+    | sort -u || true)"
+  [[ -n "$refs" ]] || return 0
+
+  local issue_num
+  while IFS= read -r issue_num; do
+    [[ -n "$issue_num" ]] || continue
+    _reset_one_partial_issue "$issue_num"
+  done <<< "$refs"
+
+  return 0
+}
+
 # Handle auto-merge mode
 #
 # The auto-merge path now mirrors the sync path's resilience patterns:
@@ -631,9 +743,23 @@ success "PR #$PR_NUMBER merged successfully"
 
 fi  # end synchronous-merge path (AUTO_MERGE != "true")
 
-# NOTE: Label cleanup on linked issues is intentionally skipped.
+# Partial-increment label reset (#3667). Runs only after a confirmed merge (both
+# the synchronous path above and the auto-merge server-side-completed fall-
+# through reach here; the auto-merge-queued and dry-run paths exit earlier).
+# Best-effort — never fails the merge. See the function definitions above.
+_reset_partial_increment_labels || true
+
+# NOTE: Label cleanup on linked issues is intentionally skipped for the
+# `Closes #N` / `Fixes #N` / `Resolves #N` auto-close case.
 # Labels on closed/merged items are harmless — all agents filter by open state.
 # See: https://github.com/rjwalters/loom/issues/2838
+#
+# EXCEPTION (#3667): non-closing `Part of #N` / `Contributes to #N` partial-
+# increment references leave the referenced issue OPEN after merge, so its
+# `loom:building` label would otherwise be orphaned. The
+# _reset_partial_increment_labels call above handles exactly that case by
+# swapping loom:building -> loom:issue on the still-open referenced issue. The
+# `Closes`-keyword path below is unchanged.
 #
 # NOTE: This script does NOT close linked issues. Issue auto-close is GitHub's
 # responsibility — GitHub's PR parser closes issues referenced via `Closes #N`,

--- a/defaults/scripts/tests/test-merge-pr-partial-increment.sh
+++ b/defaults/scripts/tests/test-merge-pr-partial-increment.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# test-merge-pr-partial-increment.sh - Unit tests for the partial-increment
+# label-reset logic in merge-pr.sh (#3667).
+#
+# A merged PR that references a family/epic issue with a NON-closing keyword
+# (`Part of #N` / `Contributes to #N`) does not auto-close the issue, so its
+# `loom:building` label is left orphaned. merge-pr.sh's
+# _reset_partial_increment_labels swaps that still-open, still-loom:building
+# issue back to `loom:issue` at the merge choke point (mirroring
+# orphan_recovery.py's recover_issue() semantics). Closing keywords
+# (`Closes`/`Fixes`/`Resolves`) are untouched (GitHub auto-closes those).
+#
+# Strategy: the two functions under test (_reset_one_partial_issue and
+# _reset_partial_increment_labels) depend only on globals (PR_JSON, REPO_NWO,
+# PR_NUMBER, FORGE_TYPE) and the `gh` CLI. We extract just those two function
+# definitions from merge-pr.sh and source them, stub `gh` on PATH to serve
+# canned issue JSON and record mutating calls, then assert on the recorded
+# calls. Extracting from source (rather than replicating) keeps the test in
+# lockstep with the script.
+#
+# Usage:
+#   ./.loom/scripts/tests/test-merge-pr-partial-increment.sh
+
+# SC2034: several globals (PR_JSON, REPO_NWO, PR_NUMBER, FORGE_TYPE) are read
+# only by the functions extracted+sourced from merge-pr.sh, which shellcheck
+# cannot see — every such assignment looks "unused" to the linter.
+# shellcheck disable=SC2034
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPERS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+MERGE_PR_SRC="$HELPERS_DIR/merge-pr.sh"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_eq() {
+    local expected="$1" actual="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Expected: '$expected'"
+        echo "    Actual:   '$actual'"
+    fi
+}
+
+assert_contains() {
+    local haystack="$1" needle="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Expected substring: '$needle'"
+        echo "    In: '$haystack'"
+    fi
+}
+
+assert_not_contains() {
+    local haystack="$1" needle="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if ! printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Unexpected substring: '$needle'"
+        echo "    In: '$haystack'"
+    fi
+}
+
+# --- Minimal logging shims the extracted functions call ---
+info()    { echo "INFO: $*"; }
+success() { echo "OK: $*"; }
+warning() { echo "WARN: $*" >&2; }
+
+# --- Extract the two functions under test from merge-pr.sh and source them ---
+# From `_reset_one_partial_issue() {` up to (not including) the
+# `# Handle auto-merge mode` line — this span contains exactly the two function
+# definitions plus intervening comments (harmless when sourced).
+FUNCS_FILE="$(mktemp)"
+trap 'rm -rf "$FUNCS_FILE" "$STUB_DIR" 2>/dev/null || true' EXIT
+awk '
+  /^_reset_one_partial_issue\(\) \{/ { capture=1 }
+  /^# Handle auto-merge mode/        { capture=0 }
+  capture { print }
+' "$MERGE_PR_SRC" > "$FUNCS_FILE"
+
+if ! grep -q '_reset_partial_increment_labels()' "$FUNCS_FILE"; then
+    echo -e "${RED}FATAL${NC}: could not extract functions from $MERGE_PR_SRC" >&2
+    exit 2
+fi
+# shellcheck disable=SC1090
+source "$FUNCS_FILE"
+
+# --- Stub gh on PATH ---
+STUB_DIR="$(mktemp -d)"
+cat > "$STUB_DIR/gh" <<'STUB'
+#!/usr/bin/env bash
+# Stub gh for test-merge-pr-partial-increment.sh.
+#   gh api repos/OWNER/REPO/issues/N   -> cat $STUB_DIR/issue-N.json (or {})
+#   gh issue edit N ...                -> record to $STUB_DIR/gh-calls.log
+#   gh issue comment N ...             -> record to $STUB_DIR/gh-calls.log
+STUB_DIR_FROM_ENV="${LOOM_TEST_STUB_DIR:?stub gh: LOOM_TEST_STUB_DIR not set}"
+LOG="$STUB_DIR_FROM_ENV/gh-calls.log"
+
+if [[ "$1" == "api" ]]; then
+  # Last arg is the api path: repos/owner/repo/issues/N
+  path="${!#}"
+  num="${path##*/}"
+  canned="$STUB_DIR_FROM_ENV/issue-$num.json"
+  if [[ -f "$canned" ]]; then cat "$canned"; else echo '{}'; fi
+  exit 0
+fi
+
+if [[ "$1" == "issue" ]]; then
+  # Record the full argv (issue edit/comment) for assertions.
+  echo "$*" >> "$LOG"
+  exit 0
+fi
+
+echo "stub gh: unhandled args: $*" >&2
+exit 3
+STUB
+chmod +x "$STUB_DIR/gh"
+export LOOM_TEST_STUB_DIR="$STUB_DIR"
+export PATH="$STUB_DIR:$PATH"
+
+# --- Shared globals the functions read (consumed indirectly by the sourced
+# functions; see the file-level SC2034 disable at the top). ---
+REPO_NWO="owner/repo"
+PR_NUMBER="999"
+FORGE_TYPE="github"
+
+# Canned issue fixtures.
+cat > "$STUB_DIR/issue-123.json" <<'EOF'
+{"state":"open","labels":[{"name":"loom:building"},{"name":"loom:epic"}]}
+EOF
+cat > "$STUB_DIR/issue-456.json" <<'EOF'
+{"state":"open","labels":[{"name":"loom:building"}]}
+EOF
+cat > "$STUB_DIR/issue-777.json" <<'EOF'
+{"state":"closed","labels":[{"name":"loom:building"}]}
+EOF
+cat > "$STUB_DIR/issue-888.json" <<'EOF'
+{"state":"open","labels":[{"name":"loom:issue"}]}
+EOF
+cat > "$STUB_DIR/issue-321.json" <<'EOF'
+{"state":"open","pull_request":{"url":"x"},"labels":[{"name":"loom:building"}]}
+EOF
+
+reset_log() { : > "$STUB_DIR/gh-calls.log"; }
+read_log()  { cat "$STUB_DIR/gh-calls.log" 2>/dev/null || true; }
+
+echo "Testing _reset_partial_increment_labels behavior..."
+
+# T1: Part of #123, open + loom:building -> swap to loom:issue + comment.
+reset_log
+PR_JSON='{"body":"Implements a slice.\n\nPart of #123"}'
+_reset_partial_increment_labels
+log="$(read_log)"
+assert_contains "$log" "issue edit 123 --remove-label loom:building --add-label loom:issue" \
+  "Part of #123 (open, building) -> swaps loom:building to loom:issue"
+assert_contains "$log" "issue comment 123" \
+  "Part of #123 -> posts an auditable comment"
+
+# T2: Closes #123 -> NOT a partial ref -> no mutation (existing behavior preserved).
+reset_log
+PR_JSON='{"body":"All done.\n\nCloses #123"}'
+_reset_partial_increment_labels
+assert_eq "" "$(read_log)" "Closes #123 -> no label mutation (auto-close path untouched)"
+
+# T2b: Fixes / Resolves also untouched.
+reset_log
+PR_JSON='{"body":"Fixes #123 and Resolves #456"}'
+_reset_partial_increment_labels
+assert_eq "" "$(read_log)" "Fixes/Resolves -> no label mutation"
+
+# T3: Part of #777 but issue is CLOSED -> no-op.
+reset_log
+PR_JSON='{"body":"Part of #777"}'
+_reset_partial_increment_labels
+assert_eq "" "$(read_log)" "Part of #777 (closed) -> no-op, no mutation"
+
+# T4: Part of #888 but issue lacks loom:building -> no-op (idempotent).
+reset_log
+PR_JSON='{"body":"Part of #888"}'
+_reset_partial_increment_labels
+assert_eq "" "$(read_log)" "Part of #888 (not loom:building) -> no-op, idempotent"
+
+# T5: Contributes to #456 (open, building) -> swap.
+reset_log
+PR_JSON='{"body":"Contributes to #456"}'
+_reset_partial_increment_labels
+assert_contains "$(read_log)" "issue edit 456 --remove-label loom:building --add-label loom:issue" \
+  "Contributes to #456 (open, building) -> swaps to loom:issue"
+
+# T6: case-insensitive keyword + multiple refs -> both swapped.
+reset_log
+PR_JSON='{"body":"part of #123\ncontributes TO #456"}'
+_reset_partial_increment_labels
+log="$(read_log)"
+assert_contains "$log" "issue edit 123 --remove-label loom:building --add-label loom:issue" \
+  "Case-insensitive 'part of #123' matched"
+assert_contains "$log" "issue edit 456 --remove-label loom:building --add-label loom:issue" \
+  "Multiple refs: #456 also matched"
+
+# T7: reference target is actually a PR (has .pull_request) -> skip.
+reset_log
+PR_JSON='{"body":"Part of #321"}'
+_reset_partial_increment_labels
+assert_eq "" "$(read_log)" "Part of #321 (is a PR, has .pull_request) -> skipped"
+
+# T8: FORGE_TYPE != github -> no-op (v1 is GitHub-only).
+reset_log
+FORGE_TYPE="gitea"
+PR_JSON='{"body":"Part of #123"}'
+_reset_partial_increment_labels
+assert_eq "" "$(read_log)" "FORGE_TYPE=gitea -> no-op (GitHub-only v1)"
+FORGE_TYPE="github"
+
+# T9: empty / null body -> no-op.
+reset_log
+PR_JSON='{"body":null}'
+_reset_partial_increment_labels
+assert_eq "" "$(read_log)" "null PR body -> no-op"
+
+# T10: closing keyword AND a partial ref in the same body -> only the partial
+# ref's issue is reset; the Closes issue is left to GitHub auto-close.
+reset_log
+PR_JSON='{"body":"Closes #888\n\nPart of #123"}'
+_reset_partial_increment_labels
+log="$(read_log)"
+assert_contains "$log" "issue edit 123 --remove-label loom:building" \
+  "Mixed body: Part of #123 is reset"
+assert_not_contains "$log" "issue edit 888" \
+  "Mixed body: Closes #888 is NOT touched"
+
+# --- Source-contains guards (fail if a refactor drops the key behavior) ---
+echo ""
+echo "Testing merge-pr.sh source guards..."
+src="$(cat "$MERGE_PR_SRC")"
+assert_contains "$src" "_reset_partial_increment_labels" \
+  "merge-pr.sh defines and calls _reset_partial_increment_labels"
+assert_contains "$src" "(Part of|Contributes to)" \
+  "merge-pr.sh matches the non-closing partial-increment keywords"
+assert_contains "$src" "--remove-label \"loom:building\"" \
+  "merge-pr.sh swaps loom:building"
+assert_contains "$src" "--add-label \"loom:issue\"" \
+  "merge-pr.sh restores loom:issue"
+
+# --- Summary ---
+echo ""
+echo "────────────────────────────────"
+echo "Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed"
+
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Closes #3667.

`Part of #N` / `Contributes to #N` partial-slice PRs orphan the `loom:building` label: GitHub never auto-closes the referenced family/epic issue, and `merge-pr.sh` intentionally skips issue-label cleanup (the #2838 decision only reasoned about the `Closes #N` auto-close case, where stale labels on a *closed* issue are harmless). Merging a non-closing partial PR therefore leaves the issue **open** with `loom:building` stuck on it — nothing reclaims it until a time-gated `/sweep all` stale pass (>=2h), and non-aggressive sweeps hard-skip it indefinitely. A human had to manually strip the label to unblock the next increment.

## Fix

At the deterministic merge choke point in `merge-pr.sh`, after a confirmed merge:

1. Parse the PR body for `Part of #N` / `Contributes to #N` (case-insensitive), deduped.
2. For each referenced issue, verify **fresh at merge time** (uncached `gh api`) that it is still **open** and still carries `loom:building`.
3. If so, swap `loom:building` -> `loom:issue` (back to the ready queue, mirroring `orphan_recovery.py`'s `recover_issue()` semantics) and post a short auditable comment.

No liveness check is needed — a merge just happened on the PR that came from whoever held the claim, so the increment's work is provably done (a deterministic, not heuristic, signal). The swap is **idempotent**: a no-op when the issue is already closed, already lacks `loom:building` (re-claimed by another builder), or is actually a PR (`.pull_request` guard). GitHub-only for v1 (guarded on `FORGE_TYPE`). The `Closes`/`Fixes`/`Resolves` auto-close path (#2838) is untouched.

## Acceptance criteria

- [x] Detects a merged PR whose body carries a non-closing partial-increment ref to a still-open issue.
- [x] Swaps `loom:building` -> `loom:issue` (not merely removes) so the issue re-enters the ready queue.
- [x] Idempotent skip when already closed / not `loom:building` / re-claimed / is a PR.
- [x] `Closes`/`Fixes`/`Resolves` behavior unchanged (additive; #2838 path untouched).
- [x] A subsequent non-aggressive `/loom:sweep <N>` sees `loom:issue`, not a hard-skipped `loom:building`.
- [x] `/sweep all` aggressive stale-claim reclaim unaffected (fallback for PRs that never merge).

## Tests

New `defaults/scripts/tests/test-merge-pr-partial-increment.sh` (18 assertions) — extracts the two functions from `merge-pr.sh` and sources them against a stubbed `gh`, so it stays in lockstep with the script. Covers: the swap+comment, closing-keyword no-op, closed/non-building/PR idempotency, `Contributes to`, case-insensitive + multi-ref, gitea/null-body no-ops, and mixed closing+partial bodies. Plus source-contains guards.

- `test-merge-pr-partial-increment.sh`: 18/18 pass
- `test-merge-pr-help.sh`: 15/15 pass (regression)
- `test-merge-pr-unstable-fallback.sh`: 51/51 pass (regression)
- `test-merge-pr-worktree-path.sh`: 21/21 pass (regression)
- `shellcheck --severity=warning` clean on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)