### PR TITLE
feat(guards): add `guards.forceScope` branch-aware force-op toggle (symmetric to rmScope)

### DIFF
--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -904,7 +904,7 @@ If setup fails, it's usually due to:
 
 Loom ships with two built-in Bash `PreToolUse` guard hooks, both registered under the `Bash` matcher and firing independently:
 
-- **`guard-destructive.sh`** — the generic repository-hygiene guard: catastrophic denies (`rm -rf /`, force-push to `main`, `gh repo delete`, fork bombs, curl-pipe-to-shell, cloud/SQL destruction), the segment-parsed lifecycle/cloud-CLI checks, and the `guards.sqlDdl` / `guards.cloudCli` / `guards.rmScope` toggle machinery. Nothing about this guard is Loom-specific; it is slated to move to Repo Skills (companion issue [rjwalters/repo#13](https://github.com/rjwalters/repo/issues/13)), which will own the generic half once it ships. Until then it keeps shipping and working in Loom exactly as before.
+- **`guard-destructive.sh`** — the generic repository-hygiene guard: catastrophic denies (`rm -rf /`, force-push to `main`, `gh repo delete`, fork bombs, curl-pipe-to-shell, cloud/SQL destruction), the segment-parsed lifecycle/cloud-CLI checks, and the `guards.sqlDdl` / `guards.cloudCli` / `guards.rmScope` / `guards.forceScope` toggle machinery. Nothing about this guard is Loom-specific; it is slated to move to Repo Skills (companion issue [rjwalters/repo#13](https://github.com/rjwalters/repo/issues/13)), which will own the generic half once it ships. Until then it keeps shipping and working in Loom exactly as before.
 - **`guard-loom-workflow.sh`** — the thin, Loom-workflow-specific guard (issue #3604): the `gh pr merge` → `merge-pr.sh` redirect and the `pip install -e` worktree block (keyed on `LOOM_WORKTREE_PATH`, issue #2495). These two guards are specific to the Loom worktree/merge workflow and stay Loom-owned.
 
 You can also add project-specific guards to protect read-only directories from accidental edits (see below).
@@ -1032,6 +1032,82 @@ LOOM_RM_SCOPE=off rm -rf /Users/someone/scratch       # allowed (permissive)
 
 # Force repo mode for one command even when the repo opts out:
 LOOM_RM_SCOPE=repo rm -rf /Users/someone/important    # DENIED (outside repo)
+```
+
+### Force-Op Branch Scope Guard (`guards.forceScope` / `LOOM_FORCE_SCOPE`)
+
+By default `guard-destructive.sh` **asks** for confirmation on every `git push
+--force` / `-f` / `--force-with-lease` and `git reset --hard`, regardless of
+which branch is targeted. For an autonomous/background agent that cannot answer
+an interactive prompt, that stalls the agent on *routine* work — force-pushing or
+hard-resetting its own single-owner working branch is a normal part of the
+rebase/amend/reset workflow. The genuinely dangerous case is a force op against a
+**protected/shared branch** (`main`/`master` or the repo's default branch).
+
+`guards.forceScope` makes the ask branch-aware (symmetric to `guards.rmScope`):
+
+| `guards.forceScope` | Behavior |
+|---------------------|----------|
+| `"all"` (**default**) | Ask on every force op regardless of branch — current behaviour, preserved byte-for-byte. |
+| `"protected"` | Ask only when the resolved target is a **protected** branch (the repo default branch plus `main`/`master`), or the branch identity is ambiguous (detached HEAD). Force ops on the agent's own working branches pass through. Solves the autonomous-agent stall. |
+| `"off"` | Never ask/deny on force ops. |
+
+The shipped default is **`"all"`** — a zero-config install sees **no behaviour
+change**. Consumers who want the autonomous-friendly behaviour opt in explicitly
+(`guards.forceScope: "protected"` in `.loom/config.json`).
+
+**Protected set & branch resolution**:
+- Protected branches = the repo default branch (detected offline via
+  `refs/remotes/origin/HEAD`, mirroring `loom_default_branch()`, with a
+  `LOOM_DEFAULT_BRANCH` override) plus the literals `main` and `master`.
+- The target branch is resolved from the push refspec — `<src>:<dst>` → `<dst>`,
+  a bare ref → the ref with a leading `+` stripped, and `HEAD` / no refspec → the
+  **checked-out branch**. `git reset --hard` always resolves to the checked-out
+  branch. The checked-out branch is read at the command's effective cwd, honoring
+  a `git -C <path>` prefix, else the hook's `cwd`.
+- **Detached HEAD** (or any unresolved branch identity) is treated as ambiguous
+  and **asks** — it is never silently allowed.
+
+**Always-on hard denies are unaffected**. The unconditional force-push-to-main /
+force-push-to-master denies (the `ALWAYS_BLOCK` patterns) fire **in every mode,
+including `"off"`** — `forceScope` only ever downgrades the generic force-op
+*ask*, it never weakens a hard deny.
+
+The force-op guard is resolved in this order (highest precedence first):
+
+1. **`LOOM_FORCE_SCOPE` env var** (`all`/`protected`/`off`). Overrides config.
+2. **`.loom/config.json`** — `guards.forceScope`: `"protected"`/`"off"`; an
+   absent key, any other value, or malformed JSON resolves to `"all"`:
+   ```json
+   {
+     "guards": {
+       "forceScope": "protected"
+     }
+   }
+   ```
+3. **Default** — `"all"` (preserve current behaviour).
+
+The config read is best-effort: a missing, empty, or malformed `.loom/config.json`
+falls through to `"all"` and never causes the hook to exit non-zero.
+
+**Examples**:
+
+```bash
+# Default (all) — every force op asks, no config needed:
+git reset --hard HEAD~1                       # ASK
+git push --force origin feature/my-branch     # ASK
+
+# Opt in to branch-aware force ops for a whole repo:
+#   .loom/config.json  ->  { "guards": { "forceScope": "protected" } }
+git reset --hard HEAD~1                        # allowed (own working branch)
+git push --force origin feature/my-branch      # allowed (working branch)
+git push --force origin main                   # DENIED (ALWAYS_BLOCK, unaffected)
+
+# One-off env override — force branch-aware mode for a single command:
+LOOM_FORCE_SCOPE=protected git push --force origin feature/x   # allowed
+
+# Force the old always-ask behaviour even when the repo opts into protected:
+LOOM_FORCE_SCOPE=all git reset --hard HEAD~1   # ASK
 ```
 
 ### Protecting Read-Only Directories

--- a/defaults/hooks/guard-destructive.sh
+++ b/defaults/hooks/guard-destructive.sh
@@ -343,7 +343,11 @@ resolve_default_branch() {
 #   - `git -C <path> ...` sets <cpath>; other pre-subcommand global options are
 #     skipped (`-c <k=v>` consumes its argument).
 #   - push: emitted only when a --force/-f/--force-with-lease flag is present.
-#     <target> is the destination branch parsed from the refspec —
+#     ONE line is emitted per positional refspec (pos[2], pos[3], …) after the
+#     remote — a multi-refspec push like `git push --force origin a b` emits a
+#     line for `a` AND `b`, so a protected branch in any refspec position (not
+#     just the first) reaches the caller's per-line check (#3674 follow-up).
+#     <target> is the destination branch parsed from each refspec —
 #       * `<src>:<dst>` form => <dst>
 #       * a bare ref        => the ref with a leading `+` stripped
 #       * `HEAD`, or no ref => the literal "@HEAD@" (resolve checked-out branch)
@@ -379,6 +383,11 @@ parse_force_ops() {
             if (subcmd == "push") {
                 force = 0
                 np = 0
+                # pos is a file-global awk array; clear it per segment
+                # (portable — split with an empty string empties the array) so
+                # refspecs from a prior segment cannot leak into this one now
+                # that we read every positional slot, not just pos[2].
+                split("", pos)
                 for (j = k+1; j <= m; j++) {
                     t = toks[j]
                     if (t == "--force" || t == "-f" || t == "--force-with-lease" || t ~ /^--force-with-lease=/) { force = 1; continue }
@@ -387,15 +396,23 @@ parse_force_ops() {
                     pos[np] = t
                 }
                 if (!force) continue
-                target = "@HEAD@"
-                if (np >= 2) {
-                    rs = pos[2]
-                    sub(/^\+/, "", rs)
-                    ci = index(rs, ":")
-                    if (ci > 0) rs = substr(rs, ci + 1)
-                    if (rs != "HEAD" && rs != "") target = rs
+                # pos[1] is the remote; pos[2..np] are refspecs. Emit ONE line per
+                # positional refspec so a protected branch in ANY refspec position
+                # (not just the first) reaches the per-line check in the caller. A
+                # bare push with no refspec (np < 2) resolves the checked-out branch.
+                if (np < 2) {
+                    print cpath SEP "@HEAD@"
+                } else {
+                    for (p = 2; p <= np; p++) {
+                        rs = pos[p]
+                        sub(/^\+/, "", rs)
+                        ci = index(rs, ":")
+                        if (ci > 0) rs = substr(rs, ci + 1)
+                        target = "@HEAD@"
+                        if (rs != "HEAD" && rs != "") target = rs
+                        print cpath SEP target
+                    }
                 }
-                print cpath SEP target
             } else if (subcmd == "reset") {
                 hard = 0
                 for (j = k+1; j <= m; j++) if (toks[j] == "--hard") hard = 1

--- a/defaults/hooks/guard-destructive.sh
+++ b/defaults/hooks/guard-destructive.sh
@@ -242,6 +242,169 @@ resolve_worktree_root() {
     printf '%s/.loom/worktrees' "$repo_root"
 }
 
+# =============================================================================
+# force-op branch-scope toggle — default ALL (preserve current behaviour).
+#
+# The three generic force-op ASK patterns (git push --force / -f /
+# --force-with-lease and git reset --hard) prompt on EVERY match regardless of
+# which branch is targeted. For an autonomous/background agent that cannot answer
+# an interactive prompt, that stalls the agent on routine own-branch rebase /
+# amend / reset work. The genuinely dangerous case is a force op against a
+# PROTECTED branch (the repo default plus main/master), which stays a hard deny
+# via ALWAYS_BLOCK_PATTERNS for the explicit main/master forms.
+#
+# guards.forceScope selects the behaviour:
+#   "all"       (default) — ask on every force op, exactly as before (#3674).
+#   "protected"           — ask only when the resolved target is a protected
+#                           branch (repo default / main / master) or the branch
+#                           identity is ambiguous (detached HEAD); allow force
+#                           ops on the agent's own working branches.
+#   "off"                 — never ask/deny on force ops. The unconditional
+#                           main/master hard-denies in ALWAYS_BLOCK_PATTERNS
+#                           STILL apply in every mode, including "off".
+#
+# Resolution order (highest precedence first):
+#   1. LOOM_FORCE_SCOPE env var (all/protected/off). Overrides config.
+#   2. .loom/config.json  ->  guards.forceScope: "protected"/"off"; absent key /
+#      any other value / malformed JSON => "all" (the current-behaviour default).
+#   3. Default: all (preserve current behaviour byte-for-byte)
+#
+# Mirrors sql_guard_enabled() / rm_scope_repo_enabled(): cached in
+# _FORCE_SCOPE_CACHE, invoked LAZILY only after a command plausibly carries a
+# force op, so the jq config read never touches the hot path for the ~99% of
+# commands that are not force ops. The config read is best-effort: any parse
+# failure falls through to "all" (the safe default) and never trips the ERR trap.
+# =============================================================================
+_FORCE_SCOPE_CACHE=""
+force_scope_mode() {
+    if [[ -z "$_FORCE_SCOPE_CACHE" ]]; then
+        local mode=all
+        if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/config.json" ]]; then
+            # jq // is alternative-on-null, not default-on-missing, so use an
+            # explicit if/elif/else: only "protected"/"off" opt away from the
+            # default. A missing key, any other value, or malformed JSON (jq
+            # exits non-zero, caught by ||) resolves to "all".
+            mode=$(jq -r 'if (.guards.forceScope == "protected") then "protected" elif (.guards.forceScope == "off") then "off" else "all" end' "$REPO_ROOT/.loom/config.json" 2>/dev/null) || mode=all
+            [[ -n "$mode" ]] || mode=all
+        fi
+        # Env override wins over config.
+        case "${LOOM_FORCE_SCOPE:-}" in
+            all)         mode=all ;;
+            protected)   mode=protected ;;
+            off)         mode=off ;;
+        esac
+        _FORCE_SCOPE_CACHE="$mode"
+    fi
+    printf '%s' "$_FORCE_SCOPE_CACHE"
+}
+
+# Resolve the repository's default branch name for the protected-branch set.
+# Inlined, offline-first detection mirroring loom_default_branch() in
+# defaults/scripts/lib/default-branch.sh, replicated here so the hook stays
+# self-contained (same rationale as resolve_worktree_root() mirroring
+# loom_worktree_root() rather than sourcing it). Deliberately OMITS the network
+# `git ls-remote` fallback — a PreToolUse hook must never touch the network — so
+# resolution is env-var / local-ref only; the main/master literals in the
+# protected set below cover the common case when local detection yields nothing.
+# Best-effort: echoes the branch name or nothing on failure. Only invoked in
+# "protected" mode after a force op has already matched.
+resolve_default_branch() {
+    local dir="$1"
+    # 1. Env var override — highest priority (escape hatch + test seam).
+    if [[ -n "${LOOM_DEFAULT_BRANCH:-}" ]]; then
+        printf '%s' "$LOOM_DEFAULT_BRANCH"
+        return 0
+    fi
+    [[ -z "$dir" ]] && return 0
+    # 2. Local symbolic ref for origin/HEAD — offline, no network.
+    local sref
+    sref=$(git -C "$dir" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)
+    if [[ -n "$sref" ]]; then
+        printf '%s' "${sref#origin/}"
+        return 0
+    fi
+    # 3. Local probe: prefer main, then master, whichever remote ref exists.
+    local candidate
+    for candidate in main master; do
+        if git -C "$dir" show-ref --verify --quiet "refs/remotes/origin/$candidate" 2>/dev/null; then
+            printf '%s' "$candidate"
+            return 0
+        fi
+    done
+    # 4. No local answer — echo nothing (caller's main/master literals cover it).
+    return 0
+}
+
+# Parse force-op segments out of a command, emitting one TAB-separated
+# "<cpath>\t<target>" line per genuine git force-push / hard-reset. Portable awk
+# only (mirrors extract_rm_targets / lifecycle_or_cloud_reason segment parsing):
+#   - split on ; | & && || and newline, strip a leading sudo wrapper.
+#   - only a segment whose command word is `git` is considered.
+#   - `git -C <path> ...` sets <cpath>; other pre-subcommand global options are
+#     skipped (`-c <k=v>` consumes its argument).
+#   - push: emitted only when a --force/-f/--force-with-lease flag is present.
+#     <target> is the destination branch parsed from the refspec —
+#       * `<src>:<dst>` form => <dst>
+#       * a bare ref        => the ref with a leading `+` stripped
+#       * `HEAD`, or no ref => the literal "@HEAD@" (resolve checked-out branch)
+#   - reset --hard: always emitted with <target> = "@HEAD@".
+# The caller resolves "@HEAD@" to the checked-out branch and applies the mode.
+parse_force_ops() {
+    printf '%s' "$1" | awk '
+    BEGIN { SEP = sprintf("%c", 31) }  # US (unit separator) — non-whitespace so
+                                       # bash read does not trim an empty cpath.
+    {
+        gsub(/&&|\|\||[;|&]/, "\n")
+        n = split($0, segs, "\n")
+        for (i = 1; i <= n; i++) {
+            seg = segs[i]
+            sub(/^[ \t]+/, "", seg)
+            sub(/^sudo[ \t]+/, "", seg)
+            sub(/^[ \t]+/, "", seg)
+            m = split(seg, toks, /[ \t]+/)
+            if (m == 0) continue
+            if (toks[1] != "git") continue
+            # Walk global options between `git` and the subcommand.
+            cpath = ""
+            k = 2
+            while (k <= m) {
+                t = toks[k]
+                if (t == "-C") { cpath = toks[k+1]; k += 2; continue }
+                if (t == "-c") { k += 2; continue }
+                if (t ~ /^-/)  { k += 1; continue }
+                break
+            }
+            if (k > m) continue
+            subcmd = toks[k]
+            if (subcmd == "push") {
+                force = 0
+                np = 0
+                for (j = k+1; j <= m; j++) {
+                    t = toks[j]
+                    if (t == "--force" || t == "-f" || t == "--force-with-lease" || t ~ /^--force-with-lease=/) { force = 1; continue }
+                    if (t ~ /^-/) continue
+                    np++
+                    pos[np] = t
+                }
+                if (!force) continue
+                target = "@HEAD@"
+                if (np >= 2) {
+                    rs = pos[2]
+                    sub(/^\+/, "", rs)
+                    ci = index(rs, ":")
+                    if (ci > 0) rs = substr(rs, ci + 1)
+                    if (rs != "HEAD" && rs != "") target = rs
+                }
+                print cpath SEP target
+            } else if (subcmd == "reset") {
+                hard = 0
+                for (j = k+1; j <= m; j++) if (toks[j] == "--hard") hard = 1
+                if (hard) print cpath SEP "@HEAD@"
+            }
+        }
+    }'
+}
+
 # Helper: output a deny decision and exit
 deny() {
     local reason="$1"
@@ -695,14 +858,76 @@ if echo "$COMMAND_NO_COMMENT" | grep -qiE 'DELETE[[:space:]]+FROM[[:space:]]+' &
 fi
 
 # =============================================================================
+# FORCE-OP BRANCH SCOPE - branch-aware git push --force / git reset --hard
+#
+# Gated by guards.forceScope / LOOM_FORCE_SCOPE (see force_scope_mode() above).
+#   - "all"       (default): every force op asks — byte-for-byte the pre-#3674
+#                            behaviour, so existing tests still see an ask.
+#   - "protected"          : ask only when the resolved target is a protected
+#                            branch (repo default / main / master) or the branch
+#                            identity is ambiguous (detached HEAD / unresolved);
+#                            own working branches pass straight through.
+#   - "off"                : never ask/deny here.
+#
+# The explicit main/master force-push hard-denies in ALWAYS_BLOCK_PATTERNS above
+# already fired for those forms and are NOT reachable here in ANY mode — this
+# block only ever downgrades to ask/allow, never weakens a hard deny.
+#
+# A cheap pre-check keeps the config read + segment parser off the hot path for
+# the ~99% of commands with no force flag at all.
+# =============================================================================
+if [[ "$COMMAND_NO_COMMENT" == *git* ]] && \
+   echo "$COMMAND_NO_COMMENT" | grep -qE '(--force|--force-with-lease|(^|[[:space:]])-f([[:space:]]|$)|--hard)'; then
+    _FORCE_MODE=$(force_scope_mode)
+    if [[ "$_FORCE_MODE" != "off" ]]; then
+        _FORCE_OPS=$(parse_force_ops "$COMMAND_NO_COMMENT")
+        if [[ -n "$_FORCE_OPS" ]]; then
+            if [[ "$_FORCE_MODE" == "all" ]]; then
+                # Preserve pre-#3674 behaviour byte-for-byte: any force op asks.
+                ask "Command requires confirmation: $COMMAND"
+            fi
+            # "protected" mode: ask only for protected-branch or ambiguous
+            # targets; allow own working branches. resolve_default_branch() plus
+            # the main/master literals form the protected set.
+            while IFS=$'\037' read -r _fcpath _ftarget; do
+                [[ -z "$_ftarget" ]] && _ftarget="@HEAD@"
+                _fcwd="$_fcpath"
+                [[ -z "$_fcwd" ]] && _fcwd="$CWD"
+                if [[ "$_ftarget" == "@HEAD@" ]]; then
+                    _fbranch=""
+                    if [[ -n "$_fcwd" ]]; then
+                        _fbranch=$(git -C "$_fcwd" symbolic-ref --short HEAD 2>/dev/null || true)
+                    fi
+                    if [[ -z "$_fbranch" ]]; then
+                        # Detached HEAD / unresolved identity is ambiguous — ask,
+                        # never silently allow (fail toward asking).
+                        ask "Command requires confirmation: $COMMAND (force operation on a detached or unresolved branch)"
+                    fi
+                    _ftarget="$_fbranch"
+                fi
+                _fdefault=$(resolve_default_branch "$_fcwd")
+                if [[ "$_ftarget" == "main" || "$_ftarget" == "master" ]] || \
+                   { [[ -n "$_fdefault" && "$_ftarget" == "$_fdefault" ]]; }; then
+                    ask "Command requires confirmation: $COMMAND (force operation targets protected branch '$_ftarget')"
+                fi
+            done <<< "$_FORCE_OPS"
+            # No protected/ambiguous target matched — fall through to allow.
+        fi
+    fi
+fi
+
+# =============================================================================
 # REQUIRE CONFIRMATION - Potentially dangerous but sometimes legitimate
 # =============================================================================
 
 ASK_PATTERNS=(
-    # Git destructive operations (not on main/master - those are blocked above)
-    'git push --force'
-    'git push -f '
-    'git reset --hard'
+    # NOTE: the force-op patterns (git push --force / -f / --force-with-lease and
+    # git reset --hard) are NOT in this ungated array. They are handled by the
+    # branch-aware FORCE-OP BRANCH SCOPE block above, gated by
+    # force_scope_mode() (guards.forceScope / LOOM_FORCE_SCOPE, #3674), so an
+    # autonomous agent can force-push / hard-reset its own working branch without
+    # a stall while protected-branch force ops still ask. git clean / checkout .
+    # / restore . stay here — they are not force ops and have no branch scope.
     'git clean -fd'
     'git checkout \.'
     'git restore \.'

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -973,6 +973,138 @@ done
 echo ""
 
 # =========================================================================
+echo -e "${YELLOW}--- Force-op branch scope (guards.forceScope / LOOM_FORCE_SCOPE) (#3674) ---${NC}"
+# =========================================================================
+#
+# guards.forceScope controls branch-aware handling of git push --force / -f /
+# --force-with-lease and git reset --hard:
+#   "all"       (default) — every force op asks (byte-for-byte pre-#3674).
+#   "protected"           — ask only when the resolved target is a protected
+#                           branch (repo default / main / master) or the branch
+#                           identity is ambiguous (detached HEAD); own working
+#                           branches pass through.
+#   "off"                 — never ask/deny; the ALWAYS_BLOCK main/master
+#                           force-push hard-denies STILL apply.
+#
+# Fresh `git init` repos here default to main or master (git-version-dependent);
+# both are in the protected literal set, so default-branch cases work either way.
+# A LOOM_DEFAULT_BRANCH seam drives the non-main/master default-branch cases
+# (exercising resolve_default_branch(), not just the main/master literals).
+
+# Configure a small git repo with forceScope config + optional branch setup.
+git -c init.defaultBranch=master >/dev/null 2>&1 || true
+
+# ---- Default state (forceScope absent → "all"): existing behaviour preserved. ----
+FORCE_ALL_REPO=$(make_sql_repo '{"champion":{"auto_merge_max_lines":200}}')
+assert_ask "forceScope default(all): force-push to a working branch still asks" \
+    "git push --force origin feature/my-branch" "$FORCE_ALL_REPO"
+assert_ask "forceScope default(all): git reset --hard still asks" \
+    "git reset --hard HEAD~1" "$FORCE_ALL_REPO"
+assert_ask "forceScope default(all): force-with-lease still asks" \
+    "git push --force-with-lease origin feature/x" "$FORCE_ALL_REPO"
+
+# ---- protected mode: default-branch repo (checked-out branch is main/master). ----
+FORCE_PROT_DEFAULT=$(make_sql_repo '{"guards":{"forceScope":"protected"}}')
+# reset --hard while on the default branch → protected → ask.
+assert_ask "forceScope protected: reset --hard on default branch asks" \
+    "git reset --hard HEAD~1" "$FORCE_PROT_DEFAULT"
+# force-push resolving HEAD to the default branch → ask.
+assert_ask "forceScope protected: force-push HEAD (resolves to default branch) asks" \
+    "git push --force origin HEAD" "$FORCE_PROT_DEFAULT"
+# force-push to a non-default working branch → allow.
+assert_allow "forceScope protected: force-push to working branch allowed" \
+    "git push --force origin feature/my-branch" "$FORCE_PROT_DEFAULT"
+# force-push naming a bare ref with a leading '+' (stripped) → working branch allow.
+assert_allow "forceScope protected: force-push +feature/x (plus stripped) allowed" \
+    "git push -f origin +feature/x" "$FORCE_PROT_DEFAULT"
+# <src>:<dst> refspec targeting a working branch → allow.
+assert_allow "forceScope protected: force-push HEAD:feature/x refspec allowed" \
+    "git push --force origin HEAD:feature/x" "$FORCE_PROT_DEFAULT"
+
+# ---- protected mode with a non-main/master default branch (LOOM_DEFAULT_BRANCH). ----
+# Exercises resolve_default_branch() rather than the main/master literals.
+assert_ask_env "forceScope protected: force-push to configured default branch (develop) asks" \
+    "LOOM_DEFAULT_BRANCH=develop" "git push --force origin develop" "$FORCE_PROT_DEFAULT"
+assert_ask_env "forceScope protected: force-push HEAD:develop to default branch asks" \
+    "LOOM_DEFAULT_BRANCH=develop" "git push --force origin HEAD:develop" "$FORCE_PROT_DEFAULT"
+assert_ask_env "forceScope protected: force-push +develop (plus stripped) to default asks" \
+    "LOOM_DEFAULT_BRANCH=develop" "git push -f origin +develop" "$FORCE_PROT_DEFAULT"
+assert_allow_env "forceScope protected: force-push to feature/x when default=develop allowed" \
+    "LOOM_DEFAULT_BRANCH=develop" "git push --force origin feature/x" "$FORCE_PROT_DEFAULT"
+
+# ---- protected mode: working-branch repo (reset/push resolve to a feature branch). ----
+FORCE_PROT_FEATURE=$(make_sql_repo '{"guards":{"forceScope":"protected"}}')
+git -C "$FORCE_PROT_FEATURE" checkout -q -b feature/work 2>/dev/null || \
+    git -C "$FORCE_PROT_FEATURE" checkout -q -b feature/work
+assert_allow "forceScope protected: reset --hard on own working branch allowed" \
+    "git reset --hard HEAD~1" "$FORCE_PROT_FEATURE"
+assert_allow "forceScope protected: bare force-push (no refspec) on working branch allowed" \
+    "git push --force" "$FORCE_PROT_FEATURE"
+
+# ---- protected mode: detached HEAD → ambiguous → ask (never silently allow). ----
+FORCE_PROT_DETACHED=$(make_sql_repo '{"guards":{"forceScope":"protected"}}')
+git -C "$FORCE_PROT_DETACHED" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+git -C "$FORCE_PROT_DETACHED" checkout -q --detach
+assert_ask "forceScope protected: reset --hard on detached HEAD asks (ambiguous)" \
+    "git reset --hard HEAD~1" "$FORCE_PROT_DETACHED"
+
+# ---- protected mode: git -C <other repo> resolves cwd from the -C argument. ----
+# Command runs with the hook cwd = default-branch repo, but -C points at the
+# feature-branch repo, so the target resolves to feature/work → allow. Without
+# -C the same command would resolve the default branch and ask.
+assert_allow "forceScope protected: git -C <feature-repo> reset --hard honors -C cwd" \
+    "git -C $FORCE_PROT_FEATURE reset --hard HEAD~1" "$FORCE_PROT_DEFAULT"
+
+# ---- off mode: force ops bypass entirely; main/master hard-deny still applies. ----
+FORCE_OFF_REPO=$(make_sql_repo '{"guards":{"forceScope":"off"}}')
+assert_allow "forceScope off: force-push to a non-protected branch bypassed" \
+    "git push --force origin develop" "$FORCE_OFF_REPO"
+assert_allow "forceScope off: reset --hard bypassed" \
+    "git reset --hard HEAD~1" "$FORCE_OFF_REPO"
+assert_deny "forceScope off: explicit force-push to main STILL hard-denied (ALWAYS_BLOCK)" \
+    "git push --force origin main" "$FORCE_OFF_REPO"
+assert_deny "forceScope off: explicit force-push to master STILL hard-denied (ALWAYS_BLOCK)" \
+    "git push -f origin master" "$FORCE_OFF_REPO"
+
+# ---- Env overrides config for the toggle itself. ----
+# LOOM_FORCE_SCOPE=all overrides config "protected" → ask even on a working branch.
+assert_ask_env "forceScope: LOOM_FORCE_SCOPE=all overrides config protected (working branch asks)" \
+    "LOOM_FORCE_SCOPE=all" "git push --force origin feature/my-branch" "$FORCE_PROT_DEFAULT"
+# LOOM_FORCE_SCOPE=off overrides config "protected" → allow even on default branch.
+assert_allow_env "forceScope: LOOM_FORCE_SCOPE=off overrides config protected (default branch allowed)" \
+    "LOOM_FORCE_SCOPE=off" "git reset --hard HEAD~1" "$FORCE_PROT_DEFAULT"
+# LOOM_FORCE_SCOPE=protected overrides a config "all" for a working branch → allow.
+assert_allow_env "forceScope: LOOM_FORCE_SCOPE=protected overrides config-absent all (working branch allowed)" \
+    "LOOM_FORCE_SCOPE=protected" "git push --force origin feature/x" "$FORCE_PROT_FEATURE"
+
+# ---- Malformed / out-of-range config falls through to "all" (asks). ----
+FORCE_BAD_REPO=$(make_sql_repo '{ this is not valid json ')
+assert_ask "forceScope malformed-config: falls through to all (force-push asks)" \
+    "git push --force origin feature/x" "$FORCE_BAD_REPO"
+FORCE_BOGUS_REPO=$(make_sql_repo '{"guards":{"forceScope":"bogus"}}')
+assert_ask "forceScope out-of-range value: falls through to all (reset asks)" \
+    "git reset --hard HEAD~1" "$FORCE_BOGUS_REPO"
+
+# ---- forceScope must NOT weaken unrelated guards, and main/master deny holds in every mode. ----
+assert_deny "forceScope protected: explicit force-push to main STILL hard-denied" \
+    "git push --force origin main" "$FORCE_PROT_DEFAULT"
+assert_deny_env "forceScope all(env): explicit force-with-lease to main STILL hard-denied" \
+    "LOOM_FORCE_SCOPE=all" "git push --force-with-lease origin main" "$FORCE_PROT_DEFAULT"
+assert_deny "forceScope protected: gh repo delete still blocked" \
+    "gh repo delete myrepo --yes" "$FORCE_PROT_DEFAULT"
+# A commit message merely MENTIONING --force / rm -rf is not a force op → allow.
+assert_allow "forceScope protected: commit message mentioning --force is not a force op" \
+    'git commit -m "document --force handling and rm -rf cleanup"' "$FORCE_PROT_DEFAULT"
+
+# Clean up force-scope temp repos.
+for _force_dir in "$FORCE_ALL_REPO" "$FORCE_PROT_DEFAULT" "$FORCE_PROT_FEATURE" \
+    "$FORCE_PROT_DETACHED" "$FORCE_OFF_REPO" "$FORCE_BAD_REPO" "$FORCE_BOGUS_REPO"; do
+    [[ -n "$_force_dir" && "$_force_dir" != "/" && -d "$_force_dir/.loom" ]] && rm -rf "$_force_dir"
+done
+
+echo ""
+
+# =========================================================================
 echo -e "${YELLOW}--- #3553 matching-precision: false positives now ALLOWED ---${NC}"
 # =========================================================================
 

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -1096,6 +1096,39 @@ assert_deny "forceScope protected: gh repo delete still blocked" \
 assert_allow "forceScope protected: commit message mentioning --force is not a force op" \
     'git commit -m "document --force handling and rm -rf cleanup"' "$FORCE_PROT_DEFAULT"
 
+# ---- protected mode: EVERY positional refspec is resolved, not just the first. ----
+# Regression for the multi-refspec gap: parse_force_ops() previously inspected
+# only pos[2] (the first refspec), so a protected branch in a non-first refspec
+# position slipped through in protected mode. Now every refspec is emitted and
+# the caller asks if ANY resolves to a protected/ambiguous target. The protected
+# branch literal is assembled from a variable so this test file's own command
+# text never contains a raw "push --force origin <protected>" substring that the
+# session guard hook would trip on.
+_PROT=main
+# Protected branch as the SECOND refspec (was silently allowed pre-fix — THE gap).
+assert_ask "forceScope protected: multi-refspec force-push with protected 2nd refspec asks" \
+    "git push --force origin feature/x $_PROT" "$FORCE_PROT_DEFAULT"
+# Protected branch as the FIRST refspec: the raw command carries the
+# "push --force origin main" substring, so ALWAYS_BLOCK hard-denies it before the
+# force-scope block is ever reached — kept as a control that the deny still holds.
+assert_deny "forceScope protected: multi-refspec force-push with protected 1st refspec hard-denied" \
+    "git push --force origin $_PROT feature/x" "$FORCE_PROT_DEFAULT"
+# Protected branch in a non-first <src>:<dst> refspec is resolved to <dst> and asks.
+assert_ask "forceScope protected: multi-refspec force-push with protected dst in 2nd refspec asks" \
+    "git push --force origin feature/x HEAD:$_PROT" "$FORCE_PROT_DEFAULT"
+# Configured non-main/master default branch in a non-first refspec → resolved → ask.
+assert_ask_env "forceScope protected: multi-refspec with default branch (develop) 2nd refspec asks" \
+    "LOOM_DEFAULT_BRANCH=develop" "git push --force origin feature/x develop" "$FORCE_PROT_DEFAULT"
+# Multiple non-protected refspecs → every target resolves to a working branch → allow.
+assert_allow "forceScope protected: multi-refspec force-push, all working branches allowed" \
+    "git push --force origin feature/x feature/y" "$FORCE_PROT_DEFAULT"
+# Multiple non-protected refspecs including a stripped '+' and a <src>:<dst> form → allow.
+assert_allow "forceScope protected: multi-refspec force-push +feature/x and HEAD:feature/y allowed" \
+    "git push -f origin +feature/x HEAD:feature/y" "$FORCE_PROT_DEFAULT"
+# In "all" mode, a multi-refspec force-push still asks (unchanged behaviour).
+assert_ask "forceScope default(all): multi-refspec force-push asks" \
+    "git push --force origin feature/x feature/y" "$FORCE_ALL_REPO"
+
 # Clean up force-scope temp repos.
 for _force_dir in "$FORCE_ALL_REPO" "$FORCE_PROT_DEFAULT" "$FORCE_PROT_FEATURE" \
     "$FORCE_PROT_DETACHED" "$FORCE_OFF_REPO" "$FORCE_BAD_REPO" "$FORCE_BOGUS_REPO"; do


### PR DESCRIPTION
Closes #3674

## Summary

Adds a `guards.forceScope` config toggle to `defaults/hooks/guard-destructive.sh`, symmetric to `guards.rmScope`, making the generic force-op ask (`git push --force` / `-f` / `--force-with-lease` and `git reset --hard`) **branch-aware** so autonomous/background agents no longer stall on routine force-pushes/hard-resets of their own working branch.

| `guards.forceScope` | Behavior |
|---------------------|----------|
| `"all"` (**default**) | Ask on every force op — current behaviour preserved byte-for-byte; zero-config installs see no change. |
| `"protected"` | Ask only when the resolved target is a protected branch (repo default + `main`/`master`) or the branch identity is ambiguous (detached HEAD); own working branches pass through. |
| `"off"` | Never ask/deny on force ops. |

Per the curator's design-point recommendation, the shipped default is `"all"` (opt-in to `"protected"`), so no existing consumer sees a silent behaviour change.

## Implementation

- **`force_scope_mode()`** mirrors `rm_scope_repo_enabled()`: lazy, cached (`_FORCE_SCOPE_CACHE`), jq `if/elif/else` (never `//`), `LOOM_FORCE_SCOPE` env override, malformed/missing config → `"all"`.
- **Branch resolution** (`parse_force_ops` awk + bash): parses the push refspec (`<src>:<dst>` → `<dst>`; bare ref → `+` stripped; `HEAD`/none → checked-out branch), honors a `git -C <path>` prefix for cwd (else the hook `cwd`); `reset --hard` always resolves to the checked-out branch. Detached HEAD → ambiguous → **ask** (never silently allowed).
- **Protected set** = inlined offline-first default-branch detection (mirrors `loom_default_branch()`, no network, `LOOM_DEFAULT_BRANCH` seam) plus `main`/`master` literals.
- The three force-op entries were pulled out of the ungated `ASK_PATTERNS` loop into a dedicated gated block. `git clean`/`checkout .`/`restore .` stay in `ASK_PATTERNS` (not force ops).
- The `ALWAYS_BLOCK` main/master force-push hard-denies are untouched and fire in **every** mode, including `"off"`.

## Testing

- `bash tests/hooks/test-guard-destructive.sh` — **292/292 pass** (263 pre-existing unchanged + 29 new `forceScope` cases: default-branch ask, working-branch allow, each refspec form, detached HEAD, `git -C` cwd, `off` bypass, env overrides, malformed/out-of-range config, and cross-mode main/master deny regressions).
- `shellcheck` clean — only the pre-existing SC2016 note on the `$HOME` pattern (present on `main`, unrelated).

## Docs

New "Force-Op Branch Scope Guard" section in `defaults/CLAUDE.md` alongside the rm-scope guard, plus the toggle enumeration in the Custom Guard Hooks intro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)