### PR TITLE
fix(merge-pr): route transient check-runs fetch failure into bounded pending-wait (#3678)

### DIFF
--- a/defaults/scripts/merge-pr.sh
+++ b/defaults/scripts/merge-pr.sh
@@ -508,7 +508,40 @@ if [[ "$AUTO_MERGE" == "true" ]]; then
       _UNSTABLE_DEADLINE=$(( $(date +%s) + LOOM_AUTO_MERGE_TIMEOUT ))
 
       while true; do
-        _UNSTABLE_FAILING_RAW="$(forge_get_check_runs "$REPO_NWO" "$_UNSTABLE_HEAD_SHA" 2>/dev/null || echo '{"check_runs":[]}')"
+        # Fetch the check-runs rollup, capturing the helper's own exit status
+        # separately from the JSON payload. A transient fetch failure (network
+        # blip, 5xx, Gitea `return 1`) must NOT be collapsed into the same
+        # `{"check_runs":[]}` shape a legitimately empty rollup produces —
+        # doing so lets a fetch error masquerade as "no failing, no pending"
+        # and, once a pending check has been observed, take the resolved-green
+        # immediate-merge branch on a commit whose real check state is unknown
+        # (#3678). Retry once to absorb a single blip, then route a persistent
+        # failure into the SAME bounded pending-wait path used by branch (b)
+        # below so the LOOM_AUTO_MERGE_TIMEOUT bound still applies.
+        _UNSTABLE_FETCH_RC=0
+        _UNSTABLE_FAILING_RAW="$(forge_get_check_runs "$REPO_NWO" "$_UNSTABLE_HEAD_SHA" 2>/dev/null)" || _UNSTABLE_FETCH_RC=$?
+        if [[ "$_UNSTABLE_FETCH_RC" -ne 0 ]]; then
+          _UNSTABLE_FETCH_RC=0
+          _UNSTABLE_FAILING_RAW="$(forge_get_check_runs "$REPO_NWO" "$_UNSTABLE_HEAD_SHA" 2>/dev/null)" || _UNSTABLE_FETCH_RC=$?
+        fi
+        if [[ "$_UNSTABLE_FETCH_RC" -ne 0 ]]; then
+          # Fetch is failing (twice). Treat as still-pending and keep polling,
+          # reusing the (b) branch's merged-concurrently recheck + deadline
+          # guard so this never bypasses the bounded-wait/timeout semantics.
+          warning "Failed to fetch check-runs for PR #$PR_NUMBER (rc=$_UNSTABLE_FETCH_RC); treating as still-pending and continuing to poll"
+          _UNSTABLE_RECHECK_JSON="$(forge_get_pr_nocache "$REPO_NWO" "$PR_NUMBER" "$GH" 2>/dev/null || echo '{}')"
+          if [[ "$(echo "$_UNSTABLE_RECHECK_JSON" | jq -r '.merged // false')" == "true" ]]; then
+            warning "PR #$PR_NUMBER merged by another process while waiting for checks"
+            AUTO_MERGE_OK=true
+            break
+          fi
+          if [[ "$(date +%s)" -ge "$_UNSTABLE_DEADLINE" ]]; then
+            error "Timed out after ${LOOM_AUTO_MERGE_TIMEOUT}s waiting for check-runs to become fetchable for PR #$PR_NUMBER (last fetch rc=$_UNSTABLE_FETCH_RC). Re-run the merge once the forge API is healthy, or raise LOOM_AUTO_MERGE_TIMEOUT."
+          fi
+          info "PR #$PR_NUMBER is UNSTABLE: check-runs fetch failing (rc=$_UNSTABLE_FETCH_RC); waiting ${LOOM_AUTO_MERGE_POLL_INTERVAL}s for the forge API (timeout ${LOOM_AUTO_MERGE_TIMEOUT}s)..."
+          sleep "$LOOM_AUTO_MERGE_POLL_INTERVAL"
+          continue
+        fi
         # Names of failing check runs (terminal non-success conclusions).
         # Sort + uniq to dedupe re-runs with the same context.
         _UNSTABLE_FAILING="$(echo "$_UNSTABLE_FAILING_RAW" | \
@@ -603,7 +636,7 @@ if [[ "$AUTO_MERGE" == "true" ]]; then
         _UNSTABLE_FAILING _UNSTABLE_PENDING _UNSTABLE_REQUIRED \
         _UNSTABLE_INFORMATIONAL _UNSTABLE_OVERLAP _UNSTABLE_COUNT \
         _UNSTABLE_PENDING_COUNT _UNSTABLE_DEADLINE _UNSTABLE_RECHECK_JSON \
-        _UNSTABLE_LOOKUP_RC _UNSTABLE_OBSERVED_PENDING 2>/dev/null || true
+        _UNSTABLE_LOOKUP_RC _UNSTABLE_FETCH_RC _UNSTABLE_OBSERVED_PENDING 2>/dev/null || true
 
       if [[ "$_UNSTABLE_FALLBACK_TO_MERGE" == "true" ]]; then
         unset _UNSTABLE_FALLBACK_TO_MERGE

--- a/defaults/scripts/tests/test-merge-pr-unstable-fallback.sh
+++ b/defaults/scripts/tests/test-merge-pr-unstable-fallback.sh
@@ -557,6 +557,56 @@ assert_eq "unknown" "$result" "#3664: unknown gap (no failing, no pending, never
 result=$(_unstable_decision "$runs_failed" "Required Build" "false")
 assert_eq "refuse" "$result" "#3486 preserved: failing required check, nothing pending -> refuse"
 
+# --- Test the fetch-failure decision point (#3678) ---
+# The #3678 bug: a transient check-runs fetch failure mid-poll yields empty
+# JSON, which classifies as "no failing, no pending" -> the resolved-green
+# branch -> a premature immediate merge on a commit whose real check state is
+# unknown. The fix captures the fetch exit status separately and, on failure,
+# routes into the bounded pending-wait path BEFORE any empty-runs
+# classification runs. This mirror gates _unstable_decision on fetch success:
+# a failed fetch must always resolve to "wait", never reaching the (a)-(e)
+# empty-runs classification at all.
+echo ""
+echo "Testing UNSTABLE fetch-failure decision point (#3678)..."
+
+_unstable_decision_with_fetch() {
+    local runs="$1" required="$2" observed_pending="$3" fetch_ok="$4"
+    if [[ "$fetch_ok" != "true" ]]; then
+        # A failed fetch never reaches the empty-runs classification; it is
+        # treated as still-pending and re-polled (bounded by the deadline).
+        echo "wait"; return
+    fi
+    _unstable_decision "$runs" "$required" "$observed_pending"
+}
+
+# The exact bug scenario from PR #3669's Judge note: fetch fails AFTER a pending
+# check was observed. Must wait, NOT merge.
+result=$(_unstable_decision_with_fetch "$runs_green" "Required Build" "true" "false")
+assert_eq "wait" "$result" "#3678: fetch fails after observing pending -> wait (NOT premature merge)"
+
+# Fetch fails on the very first poll iteration (never observed pending). Must
+# wait, NOT hit the unknown-gap hard error — a fetch error is not a genuine
+# unknown gap.
+result=$(_unstable_decision_with_fetch "$runs_green" "Required Build" "false" "false")
+assert_eq "wait" "$result" "#3678: fetch fails on first iteration -> wait (NOT unknown-gap hard error)"
+
+# Regression guard: a SUCCESSFUL fetch of a genuinely empty rollup with no
+# observed pending still resolves to the unknown-gap hard error — the fix must
+# not over-widen so real unknown gaps get silently retried forever.
+result=$(_unstable_decision_with_fetch "$runs_green" "Required Build" "false" "true")
+assert_eq "unknown" "$result" "#3678: successful empty fetch, never pending -> unknown-gap preserved"
+
+# Regression guard: a SUCCESSFUL fetch of an empty rollup after observing
+# pending still resolves to merge — the #3664 resolved-green path is unchanged
+# for real (non-error) fetches.
+result=$(_unstable_decision_with_fetch "$runs_green" "Required Build" "true" "true")
+assert_eq "merge" "$result" "#3678: successful empty fetch after pending -> resolved-green merge preserved"
+
+# A failed fetch resolves to wait regardless of what the (ignored) runs payload
+# would otherwise classify as — even a would-be failing-required rollup.
+result=$(_unstable_decision_with_fetch "$runs_failed" "Required Build" "false" "false")
+assert_eq "wait" "$result" "#3678: fetch failure ignores stale/empty payload -> wait (no classification)"
+
 # --- Test the poll-window env-var wiring in merge-pr.sh (#3664) ---
 # The script reuses LOOM_AUTO_MERGE_POLL_INTERVAL / LOOM_AUTO_MERGE_TIMEOUT with
 # the same defaults as loom-auto-merge (30s / 600s). Assert the defaulting
@@ -589,6 +639,25 @@ if grep -q 'LOOM_AUTO_MERGE_TIMEOUT' "$MERGE_PR_SRC" && grep -q 'LOOM_AUTO_MERGE
 else
     TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
     echo -e "  ${RED}FAIL${NC}: merge-pr.sh missing the LOOM_AUTO_MERGE_* poll-window env vars"
+fi
+
+# Assert the merge-pr.sh source captures the check-runs fetch exit status
+# separately (the core of the #3678 fix) rather than collapsing it to empty JSON.
+if grep -q '_UNSTABLE_FETCH_RC' "$MERGE_PR_SRC"; then
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: merge-pr.sh captures the check-runs fetch exit status (_UNSTABLE_FETCH_RC)"
+else
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: merge-pr.sh missing the fetch-exit-status capture (#3678 regression)"
+fi
+# Assert the old exit-status-swallowing collapse is gone: the callsite must no
+# longer OR a failed check-runs fetch into a hardcoded empty-JSON literal.
+if grep -q "forge_get_check_runs .* || echo '{\"check_runs\":\[\]}'" "$MERGE_PR_SRC"; then
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: merge-pr.sh still collapses a failed check-runs fetch to empty JSON (#3678)"
+else
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: merge-pr.sh no longer collapses a failed check-runs fetch to empty JSON"
 fi
 
 # --- Summary ---


### PR DESCRIPTION
## Summary

Fixes the #3678 classification collapse in the `merge-pr.sh` UNSTABLE poll loop. A transient `forge_get_check_runs` fetch failure mid-poll was silently replaced with a hardcoded `{"check_runs":[]}` literal — byte-identical to a genuinely empty rollup — so once a pending check had been observed, the next fetch blip took the resolved-green branch and triggered a **premature immediate merge** on a commit whose real check state was unknown.

## Root cause

`defaults/scripts/merge-pr.sh:511` used `VAR="$(cmd)" || echo '{...}'`, which detects the non-zero exit but throws the signal away and substitutes the empty-JSON literal. Both forge backends already surface the failure as a non-zero exit; the callsite re-suppressed it.

## Fix

- Capture the fetch exit status separately (`_UNSTABLE_FETCH_RC`) instead of collapsing it into empty JSON.
- Retry once to absorb a single blip; on persistent failure, route into the **same bounded pending-wait path** used by the (b) pending branch — reusing its merged-concurrently recheck and `LOOM_AUTO_MERGE_DEADLINE`/`LOOM_AUTO_MERGE_TIMEOUT` bound.
- The resolved-green branch and the unknown-gap hard-error are now reached **only after a successful fetch**.
- A persistent fetch failure that outlives the timeout produces a distinct, honestly-attributed error ("waiting for check-runs to become fetchable") instead of misattributing it as pending-timeout or unknown-gap.
- The (a)/(b)/(c) classification and happy-path behavior are unchanged.

## Tests

Extended `test-merge-pr-unstable-fallback.sh` with a `_unstable_decision_with_fetch` mirror gated on a `fetch_ok` axis:
- fetch fails **after** observing pending -> `wait` (the exact PR #3669 Judge-note bug), NOT `merge`
- fetch fails on the **first** iteration -> `wait`, NOT `unknown`
- successful empty fetch, never pending -> `unknown` (regression guard, no over-widening)
- successful empty fetch after pending -> `merge` (#3664 resolved-green preserved)
- plus source-grep assertions for the new `_UNSTABLE_FETCH_RC` capture and the removed empty-JSON collapse

All merge-pr suites pass (unstable-fallback 58/58, partial-increment 18/18, worktree-awk 11/11, worktree-path 21/21, help 15/15). Shellcheck clean (no new warnings; pre-existing SC2015 at line 812 untouched).

Closes #3678

🤖 Generated with [Claude Code](https://claude.com/claude-code)