### PR TITLE
fix(guards): stop false-positiving on force-push strings quoted in flag values (#3679)

### DIFF
--- a/defaults/hooks/guard-destructive.sh
+++ b/defaults/hooks/guard-destructive.sh
@@ -422,6 +422,62 @@ parse_force_ops() {
     }'
 }
 
+# Redact the quoted VALUES of known text-carrying flags (--body, -m/--message,
+# --title, --notes) so a dangerous-looking phrase quoted INSIDE such a value no
+# longer trips the raw ALWAYS_BLOCK_PATTERNS substring scan. Used ONLY to build
+# COMMAND_NO_LITERAL_TEXT for that one loop (mirrors the COMMAND_NO_COMMENT
+# precedent); every other scan keeps reading the raw command. This kills the
+# #3679 false positive where `gh pr comment --body "…git push --force origin
+# main…"` / `git commit -m "…"` hard-denied even though nothing executes.
+#
+# Safety floor preserved two ways:
+#   - `-c` is deliberately NOT a text-carrying flag, so `bash -c '<payload>'`
+#     is never redacted and its payload stays caught by the raw scan.
+#   - a quoted span is redacted ONLY when it carries no command-substitution or
+#     backtick opener (`$(` — which also subsumes the arithmetic `$((` — or a
+#     backtick). So a smuggling attempt like `git commit -m "$(git push --force
+#     origin main)"` is left intact and still hard-denies.
+# Each redacted span is replaced by a SAME-LENGTH placeholder so byte offsets of
+# the surrounding command are unchanged. Best-effort like COMMAND_NO_COMMENT:
+# it does not model backslash-escaped quotes, but since the result feeds only
+# the narrowing (never widening) catastrophic scan, the worst case is a raw
+# substring surviving — never a catastrophic block being skipped incorrectly.
+strip_literal_text() {
+    printf '%s' "$1" | awk '
+    BEGIN {
+        SQ = sprintf("%c", 39)   # single quote
+        DQ = sprintf("%c", 34)   # double quote
+        # boundary + text-carrying flag + optional (ws / = / ws) + quoted span
+        re = "(^|[ \t])(--message|--body|--notes|--title|-m)[ \t]*=?[ \t]*(" \
+             DQ "[^" DQ "]*" DQ "|" SQ "[^" SQ "]*" SQ ")"
+    }
+    {
+        s = $0
+        out = ""
+        while (match(s, re)) {
+            pre     = substr(s, 1, RSTART - 1)
+            matched = substr(s, RSTART, RLENGTH)
+            s       = substr(s, RSTART + RLENGTH)
+            # Locate the opening quote inside the matched span.
+            qpos = 0
+            for (i = 1; i <= length(matched); i++) {
+                c = substr(matched, i, 1)
+                if (c == DQ || c == SQ) { qpos = i; break }
+            }
+            head  = substr(matched, 1, qpos)                              # up to & incl. opening quote
+            qchar = substr(matched, qpos, 1)
+            inner = substr(matched, qpos + 1, length(matched) - qpos - 1) # between the quotes
+            # Redact ONLY provably inert text (no command substitution / backtick).
+            if (index(inner, "$(") == 0 && index(inner, "`") == 0) {
+                gsub(/./, "X", inner)
+            }
+            out = out pre head inner qchar
+        }
+        out = out s
+        printf "%s", out
+    }'
+}
+
 # Helper: output a deny decision and exit
 deny() {
     local reason="$1"
@@ -532,8 +588,22 @@ ALWAYS_BLOCK_PATTERNS=(
     # (#3584).
 )
 
+# Build a literal-text-redacted working copy ONLY for the catastrophic scan
+# below, so a force-push-to-main phrase quoted inside a --body/-m/--title/--notes
+# value no longer false-positives (#3679). The awk only runs when one of those
+# flags is actually present, keeping it off the hot path (mirrors the
+# COMMAND_NO_COMMENT `#`-present guard). `-c` is intentionally excluded so
+# `bash -c '<payload>'` payloads still reach the raw scan; spans carrying `$(` /
+# backtick are left intact so command-substitution smuggling still hard-denies.
+COMMAND_NO_LITERAL_TEXT="$COMMAND"
+if [[ "$COMMAND" == *"--body"* || "$COMMAND" == *"--message"* || \
+      "$COMMAND" == *"--title"* || "$COMMAND" == *"--notes"* || \
+      "$COMMAND" == *"-m"* ]]; then
+    COMMAND_NO_LITERAL_TEXT=$(strip_literal_text "$COMMAND")
+fi
+
 for pattern in "${ALWAYS_BLOCK_PATTERNS[@]}"; do
-    if echo "$COMMAND" | grep -qiE "$pattern"; then
+    if echo "$COMMAND_NO_LITERAL_TEXT" | grep -qiE "$pattern"; then
         deny "BLOCKED: Command matches dangerous pattern: $pattern"
     fi
 done

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -1356,6 +1356,63 @@ assert_deny "Regression: DELETE FROM without WHERE (guard on) still denied" \
 echo ""
 
 # =========================================================================
+echo -e "${YELLOW}--- #3679: force-push literals quoted in flag values no longer DENY ---${NC}"
+# =========================================================================
+#
+# ALWAYS_BLOCK force-push-to-main/master literals are raw, unanchored substring
+# matches over the whole command, so a force-push phrase merely QUOTED inside a
+# text-carrying flag value (`gh pr comment --body "…"`, `git commit -m "…"`,
+# `--title`, `--notes`) false-positived — even though nothing destructive can
+# execute. COMMAND_NO_LITERAL_TEXT redacts those quoted values ONLY for the
+# catastrophic loop, killing the false positive while keeping every genuine
+# force op (direct, `bash -c '…'`, command-substitution smuggling, chained)
+# denied.
+#
+# The protected-branch phrases are assembled from shell fragments so this test
+# file's own source never carries a raw "push --force origin <protected>"
+# literal that this session's guard hook would trip on (mirrors line 1107).
+_PB=main
+_MB=master
+_FP_MAIN="git push --force origin $_PB"       # direct force-push to protected main
+_FP_MASTER="git push --force origin $_MB"     # …to protected master
+_FP_MAIN_F="git push -f origin $_PB"           # short -f form
+
+# ---- false positives now ALLOWED (inert quoted text) ----
+assert_allow "#3679: force-push phrase in a gh pr comment --body (double-quoted) allowed" \
+    "gh pr comment 3676 --body \"example: $_FP_MAIN\""
+assert_allow "#3679: force-push phrase in a gh pr comment --body (single-quoted, master) allowed" \
+    "gh pr comment 3676 --body 'do not run $_FP_MASTER'"
+assert_allow "#3679: force-push phrase in a git commit -m message allowed" \
+    "git commit -m \"revert $_FP_MAIN mistake\""
+assert_allow "#3679: force-push phrase in a gh pr create --title (with a --body too) allowed" \
+    "gh pr create --title \"fix: prevent $_FP_MAIN\" --body \"n/a\""
+assert_allow "#3679: -f short-form phrase quoted in a --notes value allowed" \
+    "gh release create v1 --notes \"changelog: no longer suggest $_FP_MAIN_F\""
+
+# ---- regression guard: genuine force ops STILL denied ----
+assert_deny "#3679 regression: direct force-push to main still denied" \
+    "$_FP_MAIN"
+# bash -c payloads are NOT redacted (`-c` is not a text-carrying flag): the
+# critical no-eval-bypass case, in both single- and double-quote wrapper forms.
+assert_deny "#3679 regression: bash -c 'force-push to main' (single-quoted) still denied" \
+    "bash -c '$_FP_MAIN'"
+assert_deny "#3679 regression: bash -c \"force-push to main\" (double-quoted) still denied" \
+    "bash -c \"$_FP_MAIN\""
+# Command-substitution smuggling inside -m must NOT be redacted (the value
+# carries `$(` so it stays intact and hard-denies): the deliberate bypass named
+# in the acceptance criteria. Assembled with single quotes so $(...) is not
+# expanded while composing the test command.
+assert_deny "#3679 regression: git commit -m \"\$(force-push)\" command-substitution still denied" \
+    'git commit -m "$('"$_FP_MAIN"')"'
+# Chained forms: a real force op after `&&` (no text-flag redaction applies).
+assert_deny "#3679 regression: chained '... && force-push to main' still denied" \
+    "foo && $_FP_MAIN"
+assert_deny "#3679 regression: chained 'force-push to main && echo done' still denied" \
+    "$_FP_MAIN && echo done"
+
+echo ""
+
+# =========================================================================
 echo -e "${YELLOW}--- Performance check ---${NC}"
 # =========================================================================
 


### PR DESCRIPTION
## Summary

`guard-destructive.sh` hard-denied any command whose text merely **quoted** a protected-branch force-push phrase inside a text-carrying flag value — e.g. `gh pr comment --body "example: <force-push to main>"` or `git commit -m "..."`. The six main/master force-push literals in `ALWAYS_BLOCK_PATTERNS` are raw, unanchored substring matches over the whole command, so inert quoted prose tripped them even though nothing destructive executes. This repeatedly blocked Judge/Doctor agents reviewing PRs *about* force-push guarding (the examples in the review comment were unavoidable).

## Fix

- New `strip_literal_text()` awk helper (portable bash/awk, mirrors the existing `parse_force_ops()` style) that redacts the quoted **values** of known text-carrying flags (`--body`, `-m`/`--message`, `--title`, `--notes`) to a same-length placeholder.
- Build `COMMAND_NO_LITERAL_TEXT` from it and use it **only** for the `ALWAYS_BLOCK_PATTERNS` loop (mirrors the `COMMAND_NO_COMMENT` precedent). Every other scan — rm-rf catastrophic, fork bomb, curl-pipe-to-shell, the segment-parsed lifecycle/cloud checks, and `parse_force_ops()` / `guards.forceScope` — keeps reading the raw command, untouched.

### Safety floor preserved
- `-c` is deliberately **not** a text-carrying flag, so `bash -c '<payload>'` is never redacted and stays caught by the raw scan (no eval-style bypass).
- A quoted span is redacted **only** when it carries no command-substitution / backtick opener (a `$(` — which subsumes the arithmetic `$((` — or a backtick), so a command-substitution smuggling attempt inside `-m "..."` is left intact and still hard-denies.
- The awk only runs when a text-carrying flag is present (cheap `[[ ==* ]]` guard), keeping it off the hot path.

`parse_force_ops()` and the `guards.forceScope` ask-tier are not modified.

## Tests

Added 11 regression tests to `tests/hooks/test-guard-destructive.sh` (**299 → 310, all green**):
- 5 "false positive now allowed" cases (`--body` double/single-quoted, `-m`, `--title`, `--notes`).
- 6 "genuine op still denied" cases: direct force-push, `bash -c '...'` (single- and double-quote forms), command-substitution smuggling in `-m`, and both chained (`&&`) forms.

Protected-branch phrases in the test source are assembled from shell fragments (mirroring the existing line-1107 convention) so the file carries no raw literal.

`shellcheck` on the hook: clean, no new findings (the one pre-existing SC2016 info on the `\$HOME` regex literal is unchanged).

Closes #3679