### PR TITLE
fix(merge-pr): scope partial-increment reset mutations to REPO_NWO (#3681)

### DIFF
--- a/defaults/scripts/merge-pr.sh
+++ b/defaults/scripts/merge-pr.sh
@@ -336,6 +336,7 @@ _reset_one_partial_issue() {
 
   info "Partial-increment reset: PR #$PR_NUMBER merged as a partial slice of #$issue_num; returning it to the ready queue"
   if gh issue edit "$issue_num" \
+       --repo "$REPO_NWO" \
        --remove-label "loom:building" \
        --add-label "loom:issue" >/dev/null 2>&1; then
     success "Issue #$issue_num: loom:building -> loom:issue (partial increment; issue remains open)"
@@ -353,7 +354,7 @@ This issue is now available for the next increment (a subsequent \`/loom:sweep\`
 
 ---
 *Reset by merge-pr.sh (#3667) at $ts*"
-    gh issue comment "$issue_num" --body "$comment" >/dev/null 2>&1 || \
+    gh issue comment "$issue_num" --repo "$REPO_NWO" --body "$comment" >/dev/null 2>&1 || \
       warning "Could not post partial-increment comment on issue #$issue_num (label swap still applied)"
   else
     warning "Could not reset labels on issue #$issue_num (partial increment) — may need manual 'gh issue edit'"

--- a/defaults/scripts/tests/test-merge-pr-partial-increment.sh
+++ b/defaults/scripts/tests/test-merge-pr-partial-increment.sh
@@ -173,10 +173,10 @@ reset_log
 PR_JSON='{"body":"Implements a slice.\n\nPart of #123"}'
 _reset_partial_increment_labels
 log="$(read_log)"
-assert_contains "$log" "issue edit 123 --remove-label loom:building --add-label loom:issue" \
-  "Part of #123 (open, building) -> swaps loom:building to loom:issue"
-assert_contains "$log" "issue comment 123" \
-  "Part of #123 -> posts an auditable comment"
+assert_contains "$log" "issue edit 123 --repo owner/repo --remove-label loom:building --add-label loom:issue" \
+  "Part of #123 (open, building) -> swaps loom:building to loom:issue (repo-scoped)"
+assert_contains "$log" "issue comment 123 --repo owner/repo" \
+  "Part of #123 -> posts an auditable comment (repo-scoped)"
 
 # T2: Closes #123 -> NOT a partial ref -> no mutation (existing behavior preserved).
 reset_log
@@ -206,17 +206,17 @@ assert_eq "" "$(read_log)" "Part of #888 (not loom:building) -> no-op, idempoten
 reset_log
 PR_JSON='{"body":"Contributes to #456"}'
 _reset_partial_increment_labels
-assert_contains "$(read_log)" "issue edit 456 --remove-label loom:building --add-label loom:issue" \
-  "Contributes to #456 (open, building) -> swaps to loom:issue"
+assert_contains "$(read_log)" "issue edit 456 --repo owner/repo --remove-label loom:building --add-label loom:issue" \
+  "Contributes to #456 (open, building) -> swaps to loom:issue (repo-scoped)"
 
 # T6: case-insensitive keyword + multiple refs -> both swapped.
 reset_log
 PR_JSON='{"body":"part of #123\ncontributes TO #456"}'
 _reset_partial_increment_labels
 log="$(read_log)"
-assert_contains "$log" "issue edit 123 --remove-label loom:building --add-label loom:issue" \
+assert_contains "$log" "issue edit 123 --repo owner/repo --remove-label loom:building --add-label loom:issue" \
   "Case-insensitive 'part of #123' matched"
-assert_contains "$log" "issue edit 456 --remove-label loom:building --add-label loom:issue" \
+assert_contains "$log" "issue edit 456 --repo owner/repo --remove-label loom:building --add-label loom:issue" \
   "Multiple refs: #456 also matched"
 
 # T7: reference target is actually a PR (has .pull_request) -> skip.
@@ -245,7 +245,7 @@ reset_log
 PR_JSON='{"body":"Closes #888\n\nPart of #123"}'
 _reset_partial_increment_labels
 log="$(read_log)"
-assert_contains "$log" "issue edit 123 --remove-label loom:building" \
+assert_contains "$log" "issue edit 123 --repo owner/repo --remove-label loom:building" \
   "Mixed body: Part of #123 is reset"
 assert_not_contains "$log" "issue edit 888" \
   "Mixed body: Closes #888 is NOT touched"
@@ -262,6 +262,8 @@ assert_contains "$src" "--remove-label \"loom:building\"" \
   "merge-pr.sh swaps loom:building"
 assert_contains "$src" "--add-label \"loom:issue\"" \
   "merge-pr.sh restores loom:issue"
+assert_contains "$src" "--repo \"\$REPO_NWO\"" \
+  "merge-pr.sh scopes the partial-increment mutations to REPO_NWO"
 
 # --- Summary ---
 echo ""


### PR DESCRIPTION
## Summary

In `_reset_one_partial_issue()` (`defaults/scripts/merge-pr.sh`), the freshness read uses an explicitly scoped `gh api repos/$REPO_NWO/issues/N`, but the two mutations (`gh issue edit`, `gh issue comment`) relied on `gh` inferring the repo from the CWD. If the script is ever invoked from outside the repo (or a future caller changes CWD), the read and the mutation could target different repos — the read/mutation scope mismatch flagged by the Judge review of #3672.

## Changes

- `gh issue edit` in the partial-increment reset path now passes `--repo "$REPO_NWO"` (placed right after the issue number).
- `gh issue comment` in the same function now passes `--repo "$REPO_NWO"`.
- No behavior change beyond scoping: the label swap (`loom:building` -> `loom:issue`) and the auditable comment are still posted.

## Audit

A full grep of `gh issue` / `gh pr` / `gh api` across `merge-pr.sh` turns up **no other bare `gh issue`/`gh pr` mutation calls** — every other forge interaction goes through `forge_*` wrappers (`forge_get_pr`, `forge_merge_pr`, etc.) that take `REPO_NWO` and carry the repo scope in the `gh api "repos/$nwo/..."` path. The read-only `gh pr` calls in `forge-helpers.sh` are out of scope for this issue and were intentionally not touched.

## Tests

Updated `test-merge-pr-partial-increment.sh` stubbed-`gh` assertions to expect `--repo owner/repo` in the recorded argv, plus a source guard that `merge-pr.sh` scopes the mutations to `REPO_NWO`.

All five merge-pr suites pass:
- partial-increment: 19/19
- unstable-fallback: 58/58
- worktree-awk: 11/11
- worktree-path: 21/21
- help: 15/15

Shellcheck: no new findings (remaining notes are pre-existing info-level, unrelated to this change).

Closes #3681

🤖 Generated with [Claude Code](https://claude.com/claude-code)