### PR TITLE
perf(guards): read-only fast path for guard-destructive.sh (#3687)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -409,6 +409,34 @@ gh label sync --file .github/labels.yml  # Re-sync labels (GitHub only)
 # Cancel a running sweep: mcp__loom__cancel_sweep --sweep_id <id>
 ```
 
+## Custom Guard Hooks
+
+Loom ships Bash `PreToolUse` guard hooks (`defaults/hooks/guard-destructive.sh`) that block or ask on destructive commands. Several category toggles let a repo opt out of checks that are a category error for it — see `defaults/CLAUDE.md` → "Custom Guard Hooks" for the full catalog (`guards.sqlDdl`, `guards.cloudCli`, `guards.rmScope`, `guards.forceScope`). The read-only fast-path toggle is documented below.
+
+### Read-Only Fast-Path Guard Toggle (`guards.readOnlyFastPath` / `LOOM_GUARD_READONLY_FASTPATH`)
+
+`guard-destructive.sh` fires before **every** Bash tool call. In Bash-dense sessions almost every call is obviously read-only (`git status`, `ls`, `grep`, `aws … describe*`, `gh … list`), yet each otherwise runs the full deny/ask gauntlet (~37 `grep`/`awk`/`sed` forks plus a `git rev-parse`, ~179ms) before allowing. The read-only fast path (issue #3687) short-circuits that case to a **silent** `allow` (exit 0, zero output, no logging) via one bash-builtin structural test (zero forks) plus one lazy `jq` config read, running before the repo-root `git rev-parse` and every deny/ask array.
+
+The fast path is **on by default**, resolved highest-precedence first:
+
+1. **`LOOM_GUARD_READONLY_FASTPATH` env var** — `0`/`false`/`no` disables (full-path checking restored byte-for-byte); `1`/`true`/`yes` forces on. Overrides config.
+2. **`.loom/config.json` → `guards.readOnlyFastPath`** — default `true` when absent; set `false` to disable.
+3. **Default** — `true`.
+
+**Security**: the fast path is a guard bypass by construction, so admission is purely structural. A command is fast-pathed only when it contains **none** of `;` `&` `|` `<` `>` backtick `$(` newline (excludes chaining/piping/redirection/substitution) **and** its first token exactly matches the built-in allowlist: `git status|log|diff|show` (bare, no `git -C …`), `ls`, `grep`, `rg`, `gh <noun> view|list`, `aws <service> describe*|get*|list*`, `aws s3 ls`. Wrappers (`bash -c`, `eval`, `sudo …`, `env …`) are excluded automatically because their first token isn't allowlisted. So `git status && git push --force origin main` takes the full path and is still denied.
+
+**`cat` and `ssh` are deliberately excluded**: `cat` has an existing `.ssh`/`.aws/credentials` ASK carve-out a blanket fast-path would skip, and `ssh` wraps an opaque remote payload the catastrophic scan still covers.
+
+**Optional** `guards.readOnlyFastPathExtra` is an extend-only array of **literal first-word commands** added to the allowlist without hand-editing the installer-managed `.claude/settings.json`:
+
+```json
+{ "guards": { "readOnlyFastPath": true, "readOnlyFastPathExtra": ["jq", "wc"] } }
+```
+
+> **Warning**: each entry is a full-generality bypass for that command word (all arguments) — only add bare, argument-independent read-only utilities, never scripts or anything that could wrap a mutating call.
+
+Disabling the fast path never weakens any deny/ask rule; a missing/malformed `.loom/config.json` falls through to fast-path-ON.
+
 ## MCP Hooks
 
 Loom provides a unified MCP server (`mcp-loom`) for programmatic control. See the mcp-loom package README for full tool documentation.

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -1110,6 +1110,76 @@ LOOM_FORCE_SCOPE=protected git push --force origin feature/x   # allowed
 LOOM_FORCE_SCOPE=all git reset --hard HEAD~1   # ASK
 ```
 
+### Read-Only Fast-Path Guard Toggle (`guards.readOnlyFastPath` / `LOOM_GUARD_READONLY_FASTPATH`)
+
+`guard-destructive.sh` is a `PreToolUse`/`Bash` hook, so it fires before **every** Bash tool call. In Bash-dense sessions (remote ops, benchmark drivers) nearly every call is obviously read-only — `git status`, `ls`, `grep`, `aws … describe*`, `gh … list` — yet each one otherwise runs the full deny/ask gauntlet (~37 `grep`/`awk`/`sed` forks plus a `git rev-parse`, ~179ms measured) before falling through to `allow`.
+
+The read-only fast path (issue #3687) short-circuits that overwhelmingly-common case to a **silent** `allow` (exit 0, zero stdout/stderr, no logging) using a single bash-builtin structural test — zero forks — plus, only when that test passes, one lazy `jq` config read. It runs first, before the `git rev-parse` repo-root resolution and before any deny/ask array.
+
+The fast path is **on by default**. It is resolved in this order (highest precedence first):
+
+1. **`LOOM_GUARD_READONLY_FASTPATH` env var** — `0`/`false`/`no` disables the fast path (every command takes the full deny/ask path, byte-for-byte as before); `1`/`true`/`yes` forces it on. Overrides the config value.
+2. **`.loom/config.json`** — `guards.readOnlyFastPath` (default `true` when absent). Set it to `false` to disable:
+   ```json
+   {
+     "guards": {
+       "readOnlyFastPath": false
+     }
+   }
+   ```
+3. **Default** — `true` (fast path active).
+
+**Security — the fast path is a guard bypass by construction**, so admission is purely **structural** and conservative, never content-sensitive. A command is fast-pathed only when **all** of these hold (otherwise it falls through to the full path unchanged):
+
+- The raw command contains **none** of `;` `&` `|` `<` `>` backtick `$(` or a newline — this excludes all chaining, piping, redirection, and command substitution. So `git status && git push --force origin main`, `git status; rm -rf /`, and `git status $(rm -rf /)` all take the full path and are still denied.
+- The **first token** is an exact allowlist match (never a wrapper — `bash -c`, `sh -c`, `eval`, `xargs`, `env … git status`, `sudo git status` are all excluded because their first token isn't allowlisted):
+
+| First token | Admitted form |
+|-------------|---------------|
+| `git` | `git status` / `git log` / `git diff` / `git show` — **bare** subcommand only (so `git -C /path status` is not admitted) |
+| `ls`, `grep`, `rg` | any arguments |
+| `gh` | `gh <noun> view` / `gh <noun> list` (never `delete`/`close`/`archive`/…) |
+| `aws` | `aws <service> describe*` / `get*` / `list*`, and `aws s3 ls` |
+
+**`cat` and `ssh` are deliberately EXCLUDED** from the built-in list, even though they are read-only in spirit:
+
+- `cat` has a narrow existing `ASK` carve-out (`cat …/.ssh/…`, `cat …/.aws/credentials`); a blanket `cat` fast-path would silently skip it.
+- `ssh <host> '<cmd>'` wraps an **opaque remote command string** that the raw `ALWAYS_BLOCK` catastrophic scan still covers today; fast-pathing any `ssh …` would drop that coverage.
+
+**Optional extend-only escape hatch** — `guards.readOnlyFastPathExtra` is an array of **literal first-word commands** to add to the built-in list without hand-editing the Loom-managed `.claude/settings.json` (which the installer may overwrite). This directly answers "give operators a supported way to scope the matcher":
+
+```json
+{
+  "guards": {
+    "readOnlyFastPath": true,
+    "readOnlyFastPathExtra": ["jq", "wc"]
+  }
+}
+```
+
+> **Warning**: each word added here is a **guard bypass for that command word in full generality** (all arguments). Only add bare, argument-independent read-only utilities — never your own scripts or anything that could wrap a mutating call. Entries are matched as the literal first token only; no subcommand/verb parsing is applied to custom entries.
+
+The config read is best-effort and lazy: it happens only after a command has already passed the structural test, and any missing/empty/malformed `.loom/config.json` falls through to fast-path-ON. Disabling the fast path never weakens any deny/ask rule — it only makes the guard do its full work on every command again.
+
+**Examples**:
+
+```bash
+# Default: read-only commands are near-free and silent
+git status                     # fast-pathed (silent allow)
+aws ec2 describe-instances     # fast-pathed
+gh pr list                     # fast-pathed
+git status && git push --force origin main   # NOT fast-pathed → full path → DENIED
+
+# Disable the fast path for one command (restore full-path checking)
+LOOM_GUARD_READONLY_FASTPATH=0 git status
+
+# Persist the opt-out for a whole repo
+#   .loom/config.json  ->  { "guards": { "readOnlyFastPath": false } }
+
+# Extend the allowlist with a bare read-only utility
+#   .loom/config.json  ->  { "guards": { "readOnlyFastPathExtra": ["jq"] } }
+```
+
 ### Protecting Read-Only Directories
 
 Many projects have directories that should never be modified by agents (vendor code, generated files, external SDKs, process design kits). Loom provides a template hook for this.

--- a/defaults/hooks/guard-destructive.sh
+++ b/defaults/hooks/guard-destructive.sh
@@ -65,6 +65,198 @@ if [[ -z "$COMMAND" ]]; then
     exit 0
 fi
 
+# =============================================================================
+# READ-ONLY FAST PATH (issue #3687) — default ON.
+#
+# guard-destructive.sh is a PreToolUse/Bash hook, so it fires before EVERY Bash
+# tool call. In Bash-dense sessions (remote ops, benchmark drivers) the vast
+# majority of those calls are obviously read-only — `git status`, `ls`, `grep`,
+# `aws … describe*`, `gh … list` — yet each one still runs the full deny/ask
+# gauntlet (~37 grep/awk/sed forks + a git rev-parse, ~179ms measured). This
+# block short-circuits that overwhelmingly-common case to a silent `allow` with
+# a single bash-builtin structural test (zero forks) plus, only when that test
+# passes, one lazy `jq` config read.
+#
+# SECURITY: a fast path is a guard bypass by construction, so admission is
+# purely STRUCTURAL and conservative — never content-sensitive:
+#   1. Reject fast-path eligibility if the raw command contains ANY of
+#      ;  &  |  <  >  backtick  $(  or a newline. This kills chaining, piping,
+#      redirection, and command substitution (so `git status && <force-push>`,
+#      `git status; rm -rf /`, `git status $(rm -rf /)`, `git status > /etc/x`
+#      all fall through to the full path unchanged).
+#   2. Exact first-token (command-word) allowlist — never a wrapper. Because the
+#      allowlist is keyed on the literal first token, wrapper forms (`bash -c`,
+#      `sh -c`, `eval`, `xargs`, `env … git status`, `sudo git status`) are
+#      excluded automatically: their first token isn't allowlisted.
+#   3. Verb/subcommand exactness for multi-word tools, chosen to be provably
+#      disjoint from every existing deny/ask pattern:
+#        git status|log|diff|show  (bare — `git -C /p status` is NOT admitted)
+#        ls  grep  rg
+#        gh <noun> view|list       (never delete/close/archive/…)
+#        aws <service> describe*|get*|list*  and  aws s3 ls   (mirrors the
+#          verb-anchoring already in CLOUD_ASK_PATTERNS: those verbs are never
+#          mutating, so this only skips greps that were going to allow anyway)
+#   cat and ssh are DELIBERATELY EXCLUDED from the built-in list:
+#     - cat has a narrow existing ASK carve-out (cat …/.ssh/, cat …/.aws/
+#       credentials); a blanket cat fast-path would silently skip it.
+#     - ssh wraps an OPAQUE remote command string that the raw ALWAYS_BLOCK scan
+#       still covers today; fast-pathing any `ssh …` would drop that coverage.
+#
+# False NEGATIVES (declining eligibility) are always safe — they just fall
+# through to the correct, slower existing behavior. False POSITIVES are the only
+# danger, so the eligibility test stays maximally conservative.
+#
+# CONFIG-ORDERING CHOICE: this block runs BEFORE REPO_ROOT is resolved (the git
+# rev-parse subprocess below), on purpose — the structural test never needs the
+# repo root. Only the toggle/extra-list config read needs a config file, and it
+# is resolved LAZILY (only after structural admission already passed) by walking
+# up from CWD to the nearest .loom/config.json WITHOUT forking git
+# (fastpath_config_file). So a fast-pathed command pays: 1 bash-builtin test +
+# (only if eligible) 1 stat-walk + 1 jq read — never the git rev-parse, never a
+# deny/ask array, never a log write.
+#
+# Toggle: guards.readOnlyFastPath (default true) / LOOM_GUARD_READONLY_FASTPATH
+# env (0/false/no disables, 1/true/yes forces on; env wins). Optional
+# guards.readOnlyFastPathExtra is an EXTEND-ONLY array of literal first-word
+# commands (each entry is a full-generality bypass for that command word).
+# =============================================================================
+
+# Locate the nearest .loom/config.json by walking up from CWD, fork-free (no
+# git rev-parse). Cached. Best-effort: empty when none is found.
+_FASTPATH_CFG_FILE=""
+_FASTPATH_CFG_FILE_DONE=""
+fastpath_config_file() {
+    if [[ -z "$_FASTPATH_CFG_FILE_DONE" ]]; then
+        _FASTPATH_CFG_FILE_DONE=1
+        local d="$CWD"
+        if [[ -n "$d" && "$d" == /* ]]; then
+            while :; do
+                if [[ -f "$d/.loom/config.json" ]]; then
+                    _FASTPATH_CFG_FILE="$d/.loom/config.json"
+                    break
+                fi
+                [[ "$d" == "/" ]] && break
+                local parent="${d%/*}"
+                [[ -z "$parent" ]] && parent="/"
+                d="$parent"
+            done
+        fi
+    fi
+    printf '%s' "$_FASTPATH_CFG_FILE"
+}
+
+# Resolve the fast-path toggle (config + env), cached. Default true. Only ever
+# called after structural admission has already passed, so the jq read stays off
+# the hot path for commands that don't structurally qualify.
+_FASTPATH_ENABLED_CACHE=""
+fastpath_enabled() {
+    if [[ -z "$_FASTPATH_ENABLED_CACHE" ]]; then
+        local enabled=true cfg
+        cfg=$(fastpath_config_file)
+        if [[ -n "$cfg" ]]; then
+            # Only an explicit `false` disables; a missing key or malformed JSON
+            # (jq non-zero, caught by ||) stays ON — mirrors sql_guard_enabled().
+            enabled=$(jq -r 'if .guards.readOnlyFastPath == false then "false" else "true" end' "$cfg" 2>/dev/null) || enabled=true
+            [[ -n "$enabled" ]] || enabled=true
+        fi
+        # Env override wins over config.
+        case "${LOOM_GUARD_READONLY_FASTPATH:-}" in
+            0|false|no)  enabled=false ;;
+            1|true|yes)  enabled=true ;;
+        esac
+        _FASTPATH_ENABLED_CACHE="$enabled"
+    fi
+    [[ "$_FASTPATH_ENABLED_CACHE" == "true" ]]
+}
+
+# Shared structural pre-check: reject any chaining/piping/redirection/
+# substitution/newline. Pure bash builtins, zero forks.
+fastpath_structural_ok() {
+    case "$1" in
+        *';'*|*'&'*|*'|'*|*'<'*|*'>'*|*'`'*|*'$('*) return 1 ;;
+    esac
+    [[ "$1" == *$'\n'* ]] && return 1
+    return 0
+}
+
+# Built-in allowlist admission — bash-builtin regex/case only, zero forks.
+fastpath_builtin_admits() {
+    local cmd="$1"
+    fastpath_structural_ok "$cmd" || return 1
+    local -a t
+    read -ra t <<< "$cmd"
+    local n=${#t[@]}
+    (( n >= 1 )) || return 1
+    case "${t[0]}" in
+        ls|grep|rg)
+            return 0
+            ;;
+        git)
+            (( n >= 2 )) || return 1
+            case "${t[1]}" in
+                status|log|diff|show) return 0 ;;
+            esac
+            return 1
+            ;;
+        gh)
+            (( n >= 3 )) || return 1
+            case "${t[2]}" in
+                view|list) return 0 ;;
+            esac
+            return 1
+            ;;
+        aws)
+            (( n >= 3 )) || return 1
+            [[ "${t[1]}" == "s3" && "${t[2]}" == "ls" ]] && return 0
+            case "${t[2]}" in
+                describe*|get*|list*) return 0 ;;
+            esac
+            return 1
+            ;;
+    esac
+    return 1
+}
+
+# Optional extend-only escape hatch: guards.readOnlyFastPathExtra is an array of
+# literal first-word commands. Read lazily (only when the built-in list did not
+# admit) and cached. Each entry is a full-generality bypass for that word.
+_FASTPATH_EXTRA_CACHE=""
+_FASTPATH_EXTRA_DONE=""
+fastpath_extra_admits() {
+    local cmd="$1"
+    fastpath_structural_ok "$cmd" || return 1
+    local -a t
+    read -ra t <<< "$cmd"
+    (( ${#t[@]} >= 1 )) || return 1
+    local first="${t[0]}"
+    if [[ -z "$_FASTPATH_EXTRA_DONE" ]]; then
+        _FASTPATH_EXTRA_DONE=1
+        local cfg
+        cfg=$(fastpath_config_file)
+        if [[ -n "$cfg" ]]; then
+            _FASTPATH_EXTRA_CACHE=$(jq -r '(.guards.readOnlyFastPathExtra // []) | .[]' "$cfg" 2>/dev/null) || _FASTPATH_EXTRA_CACHE=""
+        fi
+    fi
+    [[ -n "$_FASTPATH_EXTRA_CACHE" ]] || return 1
+    local w
+    while IFS= read -r w; do
+        [[ -n "$w" && "$first" == "$w" ]] && return 0
+    done <<< "$_FASTPATH_EXTRA_CACHE"
+    return 1
+}
+
+# Fast-path dispatch. The env fast-disable check is first so a fully-disabled
+# feature stays entirely off the hot path (no structural test, no config read).
+_fastpath_env="${LOOM_GUARD_READONLY_FASTPATH:-}"
+if [[ "$_fastpath_env" != "0" && "$_fastpath_env" != "false" && "$_fastpath_env" != "no" ]]; then
+    if fastpath_builtin_admits "$COMMAND"; then
+        # Silent allow: no stdout/stderr, no log_hook_error, before REPO_ROOT.
+        fastpath_enabled && exit 0
+    elif fastpath_extra_admits "$COMMAND"; then
+        fastpath_enabled && exit 0
+    fi
+fi
+
 # Resolve repo root from cwd (handles worktree paths safely)
 REPO_ROOT=""
 if [[ -n "$CWD" ]] && [[ -d "$CWD" ]]; then

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -1413,9 +1413,134 @@ assert_deny "#3679 regression: chained 'force-push to main && echo done' still d
 echo ""
 
 # =========================================================================
+echo -e "${YELLOW}--- Read-only fast path (guards.readOnlyFastPath / LOOM_GUARD_READONLY_FASTPATH, #3687) ---${NC}"
+# =========================================================================
+
+# assert_allow_silent: allow AND zero stdout+stderr bytes. The fast path must
+# emit nothing at all on admission (no decision JSON, no log noise).
+assert_allow_silent() {
+    local description="$1"; local cmd="$2"; local cwd="${3:-$REPO_ROOT}"
+    TOTAL=$((TOTAL + 1))
+    local output; local exit_code=0
+    output=$(run_guard "$cmd" "$cwd") || exit_code=$?
+    if [[ $exit_code -eq 0 && -z "$output" ]]; then
+        PASS=$((PASS + 1)); echo -e "  ${GREEN}PASS${NC}: $description"
+    else
+        FAIL=$((FAIL + 1)); echo -e "  ${RED}FAIL${NC}: $description"
+        echo -e "       Command: $cmd"
+        echo -e "       Expected: allow with EMPTY output (exit 0, 0 bytes)"
+        echo -e "       Exit code: $exit_code  Output bytes: ${#output}"
+        echo -e "       Got: $output"
+    fi
+}
+
+# --- Admission + silence: every built-in allowlisted verb allows with 0 bytes ---
+assert_allow_silent "Fast path: git status admits silently" "git status"
+assert_allow_silent "Fast path: git log admits silently" "git log --oneline -5"
+assert_allow_silent "Fast path: git diff admits silently" "git diff HEAD"
+assert_allow_silent "Fast path: git show admits silently" "git show HEAD"
+assert_allow_silent "Fast path: ls admits silently" "ls -la"
+assert_allow_silent "Fast path: grep admits silently" "grep -n foo bar.txt"
+assert_allow_silent "Fast path: rg admits silently" "rg pattern src/"
+assert_allow_silent "Fast path: gh pr view admits silently" "gh pr view 12"
+assert_allow_silent "Fast path: gh issue list admits silently" "gh issue list --label loom:issue"
+assert_allow_silent "Fast path: aws ec2 describe-instances admits silently" "aws ec2 describe-instances"
+assert_allow_silent "Fast path: aws s3 ls admits silently" "aws s3 ls s3://bucket"
+assert_allow_silent "Fast path: aws lambda get-function admits silently" "aws lambda get-function --function-name f"
+
+# The two "default ON" observable assertions below only apply when the fast path
+# is not force-disabled via the ambient env var. Under a
+# `LOOM_GUARD_READONLY_FASTPATH=0 ./tests/...` full-suite run they are skipped so
+# the pre-existing cases still verify byte-for-byte (issue #3687 test plan #4).
+_FP_AMBIENT_ON=1
+case "${LOOM_GUARD_READONLY_FASTPATH:-}" in 0|false|no) _FP_AMBIENT_ON=0 ;; esac
+
+# --- Observable admission: fast path bypasses the SQL-DDL substring false-
+#     positive for a read-only grep. The DDL literal is assembled from shell
+#     fragments so this file's own source never carries a raw "DROP TABLE"
+#     (mirrors the force-push fragment convention used for the #3679 tests). ---
+_FP_DDL="DR""OP TA""BLE"
+if [[ "$_FP_AMBIENT_ON" == "1" ]]; then
+    assert_allow_silent "Fast path: read-only 'grep <ddl>' bypasses SQL-DDL false-positive (default on)" \
+        "grep '$_FP_DDL' schema.sql"
+fi
+
+# --- Security: compound / substitution / redirection / wrapper / non-bare forms
+#     are NOT eligible and keep their exact pre-existing verdict via the full
+#     path. False positives are the only danger, so these are the core gate. ---
+# && chain carrying a real force-push → ALWAYS_BLOCK still fires (deny).
+assert_deny "Fast path security: 'git status && <force-push main>' still denies" \
+    "git status && $_FP_MAIN"
+# ; chain carrying a real force-push → ALWAYS_BLOCK still fires (deny).
+assert_deny "Fast path security: 'git status ; <force-push main>' still denies" \
+    "git status ; $_FP_MAIN"
+# $(...) substitution: excluded char → full path; the inner catastrophic rm is
+# still caught by the ALWAYS_BLOCK raw scan (deny). The rm root target is
+# assembled from a fragment so this file's source carries no raw "rm -rf /".
+_FP_ROOT="/"
+assert_deny "Fast path security: 'git status \$(rm -rf /)' takes full path and denies" \
+    "git status \$(rm -rf $_FP_ROOT)"
+# Pipe: observable — same read-only grep, but the pipe disqualifies the fast
+# path so the full-path SQL-DDL check fires (deny), proving the excluded-char
+# guard truly routes to the full path rather than admitting.
+assert_deny "Fast path security: 'grep <ddl> | cat' pipe disqualifies fast path (SQL-DDL denies)" \
+    "grep '$_FP_DDL' x.sql | cat"
+# Wrapper: first token is bash (not an allowlist word) → not admitted. Observable
+# via the SQL grep the wrapper carries (full path denies).
+assert_deny "Fast path security: 'bash -c \"grep <ddl>\"' wrapper not admitted (SQL-DDL denies)" \
+    "bash -c \"grep '$_FP_DDL' x.sql\""
+# Non-bare git subcommand form: `git -C /p status` is not admitted; still allows
+# via the existing full path (verdict unchanged, just unoptimized).
+assert_allow "Fast path: 'git -C /tmp status' not fast-pathed, still allowed via full path" \
+    "git -C /tmp status"
+# cat is deliberately excluded: its existing .ssh ASK carve-out must still fire.
+assert_ask "Fast path: 'cat ~/.ssh/id_rsa' still asks (cat excluded from fast path)" \
+    "cat ~/.ssh/id_rsa"
+
+# --- Toggle off restores the full-path verdict byte-for-byte (env + config) ---
+assert_deny_env "Fast path off (env): 'grep <ddl>' takes full path and denies" \
+    "LOOM_GUARD_READONLY_FASTPATH=0" "grep '$_FP_DDL' schema.sql"
+FASTPATH_OFF_REPO=$(make_sql_repo '{"guards":{"readOnlyFastPath":false}}')
+assert_deny "Fast path off (config): 'grep <ddl>' takes full path and denies" \
+    "grep '$_FP_DDL' schema.sql" "$FASTPATH_OFF_REPO"
+# Env override wins over config (mirrors the sqlDdl/cloudCli precedent): env=1
+# forces the fast path ON even when the config disables it.
+assert_allow_env "Fast path: LOOM_GUARD_READONLY_FASTPATH=1 overrides config-off (allow)" \
+    "LOOM_GUARD_READONLY_FASTPATH=1" "grep '$_FP_DDL' schema.sql" "$FASTPATH_OFF_REPO"
+
+# --- Extend-only escape hatch: guards.readOnlyFastPathExtra admits a custom
+#     bare first-word command (full-generality bypass for that word). ---
+FASTPATH_EXTRA_REPO=$(make_sql_repo '{"guards":{"readOnlyFastPathExtra":["psql"]}}')
+# psql is not a built-in allowlist word; the extra list admits it, bypassing the
+# SQL-DDL check (allow). Demonstrates the escape hatch works. Skipped under an
+# ambient LOOM_GUARD_READONLY_FASTPATH=0 run (the env var would disable it).
+if [[ "$_FP_AMBIENT_ON" == "1" ]]; then
+    assert_allow "Fast path extra: 'psql <ddl>' admitted via readOnlyFastPathExtra (bypass)" \
+        "psql -c '$_FP_DDL'" "$FASTPATH_EXTRA_REPO"
+fi
+# A first word NOT in the extra list still takes the full path (SQL-DDL denies),
+# proving the extra list does not leak to arbitrary commands.
+assert_deny "Fast path extra: 'mysql <ddl>' (not listed) still denies via full path" \
+    "mysql -c '$_FP_DDL'" "$FASTPATH_EXTRA_REPO"
+
+# Clean up temp repos created in this section.
+for _fp_dir in "$FASTPATH_OFF_REPO" "$FASTPATH_EXTRA_REPO"; do
+    [[ -n "$_fp_dir" && "$_fp_dir" != "/" && -d "$_fp_dir/.loom" ]] && rm -rf "$_fp_dir"
+done
+
+echo ""
+
+# =========================================================================
 echo -e "${YELLOW}--- Performance check ---${NC}"
 # =========================================================================
 
+# NOTE (#3687): `git status` is now a read-only FAST-PATH command — with the
+# default toggle ON it exits after one bash-builtin structural test + one lazy
+# jq config read, skipping the ~37-fork deny/ask gauntlet and the git rev-parse
+# entirely. This benchmark command should therefore be dramatically cheaper than
+# the historical full-path average (~179ms measured pre-#3687 → ~1 jq read).
+# Export LOOM_GUARD_READONLY_FASTPATH=0 to benchmark the full-path cost instead.
+#
 # The measured average is dominated by 10 sequential guard process spawns
 # (shell + jq/python3 interpreter startup), which is a function of machine
 # load rather than guard-logic complexity. A hard cap therefore flakes under


### PR DESCRIPTION
## Summary

`guard-destructive.sh` is a `PreToolUse`/`Bash` hook, so it fires before **every** Bash tool call. In Bash-dense sessions (remote ops, benchmark drivers) nearly every call is obviously read-only, yet each still ran the full deny/ask gauntlet (~37 `grep`/`awk`/`sed` forks + a `git rev-parse`, ~179ms measured) before falling through to `allow`.

This adds a conservative **read-only fast path** that runs first — immediately after `COMMAND` is parsed, **before** `REPO_ROOT` resolution and every deny/ask array — short-circuiting the overwhelmingly-common case to a **silent** `allow` (exit 0, zero stdout/stderr, no logging).

**Measured: ~20ms/call (fast path) vs ~156ms/call (full path)** on `git status` — a ~7-8x improvement on this machine.

## Design

- **Structural, never content-sensitive** admission (a fast path is a guard bypass by construction). A command is fast-pathed only when it contains **none** of `;` `&` `|` `<` `>` backtick `$(` newline (kills chaining/piping/redirection/substitution) **and** its first token exactly matches the built-in allowlist:
  - `git status|log|diff|show` (bare — `git -C /p status` is not admitted)
  - `ls`, `grep`, `rg`
  - `gh <noun> view|list`
  - `aws <service> describe*|get*|list*`, and `aws s3 ls`
- **Wrappers excluded by construction** — `bash -c`, `sh -c`, `eval`, `xargs`, `env …`, `sudo …` all fail the first-token allowlist.
- **`cat` and `ssh` deliberately excluded** — `cat` has an existing `.ssh`/`.aws/credentials` ASK carve-out a blanket fast-path would skip; `ssh` wraps an opaque remote payload the catastrophic scan still covers.
- **Bash-builtin matching only** (`[[ =~ ]]`/`case`, zero forks) for the structural test; the single `jq` config read happens **only after** structural admission passes.
- **Config-ordering choice**: the fast path runs before `REPO_ROOT`, so the toggle/extra-list config is located by walking up from `CWD` to the nearest `.loom/config.json` **fork-free** (no `git rev-parse`), keeping the hot path cheap. Documented inline.

## Toggle

`guards.readOnlyFastPath` (default `true`) / `LOOM_GUARD_READONLY_FASTPATH` env — mirrors the `sqlDdl`/`cloudCli`/`rmScope`/`forceScope` precedent (env wins, lazy + cached). Optional `guards.readOnlyFastPathExtra` is an extend-only array of literal first-word commands (documented with an explicit bypass warning).

## Tests

- All **310 pre-existing** assertions still pass with the fast path default **ON** (335/335 total).
- **25 new** assertions: per-verb admission + **silence** (0-byte output), security regressions (compound `&&`/`;` force-push still denies, command-substitution denies via full path, pipe-disqualified `grep <ddl> | cat`, `bash -c` wrapper not admitted, `git -C /tmp status` not fast-pathed, `cat ~/.ssh/id_rsa` still asks), env + config toggle-off, env-over-config precedence, and the extra-list knob.
- A `LOOM_GUARD_READONLY_FASTPATH=0` full-suite run stays green (**333/333**; the 2 ambient-default-ON observability tests are skipped), proving the opt-out restores prior behavior byte-for-byte.
- `shellcheck` clean (only the pre-existing info-level `SC2016` on the intentional single-quoted pattern arrays).
- Force-push / SQL-DDL literals in new tests are assembled from shell fragments (session-guard-safe), mirroring the existing #3679 test convention.

## Docs

`defaults/CLAUDE.md` gets a full "Read-Only Fast-Path Guard Toggle" section under Custom Guard Hooks alongside the sibling toggles. The root `CLAUDE.md` has diverged from `defaults/` (no Custom Guard Hooks section — known self-install dogfood drift), so a self-contained section documenting this toggle was added there too.

Closes #3687

🤖 Generated with [Claude Code](https://claude.com/claude-code)
