### PR TITLE
feat(tokens): optional claude-monitor ranking consumer + email-derived token files (#3697)

### DIFF
--- a/loom-tools/src/loom_tools/tokens/bootstrap.py
+++ b/loom-tools/src/loom_tools/tokens/bootstrap.py
@@ -69,6 +69,44 @@ FILE_MODE = 0o600
 DEFAULT_HOME_ACCOUNTS_ENV = "~/.loom/accounts.env"
 HOME_ACCOUNTS_ENV_VAR = "LOOM_ACCOUNTS_ENV"
 
+# Characters stripped from an email local-part when deriving a token filename
+# (#3697): dots and hyphens, so ``r.j.walters`` -> ``rjwalters`` and
+# ``agent-1`` -> ``agent1``, matching the established naming convention.
+_LOCAL_PART_STRIP_RE = re.compile(r"[.-]")
+# Any character outside the token-filename safe set is dropped as a final
+# guard so the derived name always passes ``_TOKEN_FILE_RE``.
+_UNSAFE_FILENAME_CHAR_RE = re.compile(r"[^A-Za-z0-9._-]")
+
+
+def derive_token_filename(email: str) -> str:
+    """Derive a safe ``<name>.token`` filename from an account email (#3697).
+
+    Convention (stable so account identities don't churn):
+
+    * strip dots and hyphens from the local-part;
+    * append ``-<first-domain-label>``;
+    * lowercase, then drop any remaining unsafe character.
+
+    Examples::
+
+        robb@2amlogic.com        -> robb-2amlogic.token
+        r.j.walters@gmail.com    -> rjwalters-gmail.token
+        agent-1@2amlogic.com     -> agent1-2amlogic.token
+
+    The result always matches :data:`_TOKEN_FILE_RE`. Two *distinct* emails
+    can still derive the same stem (e.g. ``rjwalters@gmail.com`` and
+    ``r.j.walters@gmail.com``); that true collision is caught by the existing
+    duplicate-filename guard in :func:`bootstrap_tokens`, not silently merged.
+    """
+    local, sep, domain = email.strip().partition("@")
+    local_clean = _LOCAL_PART_STRIP_RE.sub("", local)
+    domain_label = domain.split(".")[0] if sep else ""
+    stem = f"{local_clean}-{domain_label}" if domain_label else local_clean
+    stem = _UNSAFE_FILENAME_CHAR_RE.sub("", stem.lower())
+    if not stem:
+        stem = "account"
+    return f"{stem}.token"
+
 
 # ---------------------------------------------------------------------------
 # .env parsing
@@ -201,6 +239,10 @@ def _assemble_valid_accounts(
     out: list[Account] = []
     for n in sorted(accounts):
         triple = accounts[n]
+        # Auto-derive the token filename from the email when omitted (#3697),
+        # so a claude-monitor-style EMAIL+KEY-only entry bootstraps directly.
+        if not triple.get("file") and triple.get("email"):
+            triple = {**triple, "file": derive_token_filename(triple["email"])}
         missing = [k for k in ("email", "key", "file") if not triple.get(k)]
         if missing:
             log_warning(

--- a/loom-tools/src/loom_tools/tokens/bootstrap.py
+++ b/loom-tools/src/loom_tools/tokens/bootstrap.py
@@ -70,7 +70,7 @@ DEFAULT_HOME_ACCOUNTS_ENV = "~/.loom/accounts.env"
 HOME_ACCOUNTS_ENV_VAR = "LOOM_ACCOUNTS_ENV"
 
 # Characters stripped from an email local-part when deriving a token filename
-# (#3697): dots and hyphens, so ``r.j.walters`` -> ``rjwalters`` and
+# (#3697): dots and hyphens, so ``a.b.jones`` -> ``abjones`` and
 # ``agent-1`` -> ``agent1``, matching the established naming convention.
 _LOCAL_PART_STRIP_RE = re.compile(r"[.-]")
 # Any character outside the token-filename safe set is dropped as a final
@@ -89,13 +89,13 @@ def derive_token_filename(email: str) -> str:
 
     Examples::
 
-        robb@2amlogic.com        -> robb-2amlogic.token
-        r.j.walters@gmail.com    -> rjwalters-gmail.token
-        agent-1@2amlogic.com     -> agent1-2amlogic.token
+        alice@example.com        -> alice-example.token
+        a.b.jones@example.org    -> abjones-example.token
+        agent-1@example.com      -> agent1-example.token
 
     The result always matches :data:`_TOKEN_FILE_RE`. Two *distinct* emails
-    can still derive the same stem (e.g. ``rjwalters@gmail.com`` and
-    ``r.j.walters@gmail.com``); that true collision is caught by the existing
+    can still derive the same stem (e.g. ``ajones@example.com`` and
+    ``a.jones@example.com``); that true collision is caught by the existing
     duplicate-filename guard in :func:`bootstrap_tokens`, not silently merged.
     """
     local, sep, domain = email.strip().partition("@")

--- a/loom-tools/src/loom_tools/tokens/check.py
+++ b/loom-tools/src/loom_tools/tokens/check.py
@@ -435,9 +435,56 @@ def write_ranking_atomic(report: ProbeReport, ranking_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _run_monitor_check(
+    tokens_dir: Path,
+    *,
+    write_ranking: bool,
+) -> ProbeReport | None:
+    """Build a ProbeReport from claude-monitor's ``ranking.json`` (#3697).
+
+    Returns ``None`` when no usable, fresh monitor data is available (the
+    caller then probes under ``auto`` or emits nothing under ``monitor``).
+    When data is available and ``write_ranking`` is set, emits ``.ranking``
+    in the selector's pipe format via the monitor writer (byte-compatible
+    with what ``select.py:_read_ranking`` consumes).
+
+    Imported lazily to avoid an import cycle (``monitor`` imports
+    ``_STATUS_RANK`` from this module).
+    """
+    from loom_tools.tokens import monitor as monitor_mod
+
+    accounts = monitor_mod.build_monitor_accounts(tokens_dir)
+    if accounts is None:
+        return None
+
+    ranked_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    results = [
+        AccountResult(
+            name=a.name,
+            status=a.status or "available",
+            s5h_utilization=a.util_5h,
+            s7d_utilization=a.util_7d,
+        )
+        for a in accounts
+    ]
+    report = ProbeReport(ranked_at=ranked_at, accounts=results)
+
+    if write_ranking:
+        ranking_path = tokens_dir / ".ranking"
+        monitor_mod.write_monitor_ranking_atomic(accounts, ranking_path)
+        logger.info(
+            "wrote monitor-sourced ranking to %s (%d accounts)",
+            ranking_path,
+            len(accounts),
+        )
+
+    return report
+
+
 def run_check(
     tokens_dir: Path,
     *,
+    source: str = "probe",
     write_ranking: bool = False,
     probe_prompt: str = DEFAULT_PROBE_PROMPT,
     model: str = DEFAULT_PROBE_MODEL,
@@ -446,10 +493,39 @@ def run_check(
 ) -> ProbeReport:
     """Probe all accounts and (optionally) write ``.ranking``.
 
+    ``source`` selects where the ranking comes from (#3697):
+
+    * ``"probe"`` (default, unchanged) — live-probe rate-limit headers.
+    * ``"monitor"`` — consume claude-monitor's ``ranking.json`` only; do
+      **not** probe. Yields an empty report when no fresh monitor data is
+      available.
+    * ``"auto"`` — use claude-monitor when a fresh ``ranking.json`` is
+      present, else fall back to probing.
+
+    Under the ``monitor``/``auto`` branch, when ``write_ranking`` is set the
+    monitor-sourced ``.ranking`` is emitted in the selector's pipe format
+    (``name|status``) — the format ``select.py`` actually consumes.
+
     Probes are issued sequentially with 0.5-1.5s jitter between them
     (lean-genius pattern) when *stagger* is true. Tests can pass
     ``stagger=False`` to skip the sleep.
     """
+    if source in ("auto", "monitor"):
+        monitor_report = _run_monitor_check(
+            tokens_dir, write_ranking=write_ranking
+        )
+        if monitor_report is not None:
+            return monitor_report
+        if source == "monitor":
+            # monitor-only: no probe fallback. Return an empty report and
+            # leave any existing .ranking untouched.
+            logger.warning(
+                "check --source monitor: no fresh claude-monitor ranking.json; "
+                "nothing to rank (not probing)."
+            )
+            return build_report([])
+        # source == "auto": fall through to probing.
+
     pairs = discover_tokens(tokens_dir)
     if not pairs:
         logger.warning("no tokens found in %s", tokens_dir)

--- a/loom-tools/src/loom_tools/tokens/cli.py
+++ b/loom-tools/src/loom_tools/tokens/cli.py
@@ -52,7 +52,7 @@ def _build_parser() -> argparse.ArgumentParser:
             "Materialize .loom/tokens/ from ACCOUNT_*_N triples, merging the "
             "home master (~/.loom/accounts.env) with the repo-local source. "
             "ACCOUNT_TOKEN_FILE_N is optional: when omitted it is auto-derived "
-            "from ACCOUNT_EMAIL_N (e.g. robb@2amlogic.com -> robb-2amlogic.token)."
+            "from ACCOUNT_EMAIL_N (e.g. alice@example.com -> alice-example.token)."
         ),
     )
     bp.add_argument(

--- a/loom-tools/src/loom_tools/tokens/cli.py
+++ b/loom-tools/src/loom_tools/tokens/cli.py
@@ -50,7 +50,9 @@ def _build_parser() -> argparse.ArgumentParser:
         "bootstrap",
         help=(
             "Materialize .loom/tokens/ from ACCOUNT_*_N triples, merging the "
-            "home master (~/.loom/accounts.env) with the repo-local source."
+            "home master (~/.loom/accounts.env) with the repo-local source. "
+            "ACCOUNT_TOKEN_FILE_N is optional: when omitted it is auto-derived "
+            "from ACCOUNT_EMAIL_N (e.g. robb@2amlogic.com -> robb-2amlogic.token)."
         ),
     )
     bp.add_argument(
@@ -106,6 +108,18 @@ def _build_parser() -> argparse.ArgumentParser:
         help=(
             "Write .loom/tokens/.ranking atomically (consumed by the spawn "
             "wrapper, #3235)."
+        ),
+    )
+    cp.add_argument(
+        "--source",
+        choices=["auto", "monitor", "probe"],
+        default=None,
+        help=(
+            "Where to source the ranking (#3697): 'auto' (default) uses "
+            "claude-monitor's ~/.claude-monitor/ranking.json when present and "
+            "fresh, else probes; 'monitor' uses claude-monitor only (no "
+            "probe); 'probe' always live-probes (pre-#3697 behavior). "
+            "Overrides $LOOM_RANKING_SOURCE."
         ),
     )
     cp.add_argument(
@@ -319,6 +333,33 @@ def _print_effective_accounts(result: "object") -> None:
         print(f"  {name:<{width}}  {email}  [{label}]")
 
 
+# Environment override for the ranking source (#3697). The --source flag
+# takes precedence; this env is the fallback; 'auto' is the built-in default.
+_RANKING_SOURCE_VAR = "LOOM_RANKING_SOURCE"
+_VALID_RANKING_SOURCES = ("auto", "monitor", "probe")
+
+
+def _resolve_ranking_source(flag_value: str | None) -> str:
+    """Resolve the ranking source: flag > $LOOM_RANKING_SOURCE > 'auto'.
+
+    An invalid env value is ignored (with a warning) and treated as unset so
+    a typo never silently disables ranking.
+    """
+    if flag_value is not None:
+        return flag_value
+    env = os.environ.get(_RANKING_SOURCE_VAR)
+    if env is not None:
+        candidate = env.strip().lower()
+        if candidate in _VALID_RANKING_SOURCES:
+            return candidate
+        if candidate:
+            log_warning(
+                f"Ignoring invalid {_RANKING_SOURCE_VAR}={env!r}; "
+                f"expected one of {', '.join(_VALID_RANKING_SOURCES)}."
+            )
+    return "auto"
+
+
 def _cmd_check(args: argparse.Namespace) -> int:
     """Handle ``loom-tokens check``."""
     # Configure logging on stderr so --json stdout output is clean.
@@ -342,8 +383,11 @@ def _cmd_check(args: argparse.Namespace) -> int:
             return 1
         tokens_dir = repo_root / ".loom" / "tokens"
 
+    source = _resolve_ranking_source(args.source)
+
     report = run_check(
         tokens_dir,
+        source=source,
         write_ranking=args.ranking,
         probe_prompt=args.probe_prompt,
         stagger=not args.no_stagger,

--- a/loom-tools/src/loom_tools/tokens/monitor.py
+++ b/loom-tools/src/loom_tools/tokens/monitor.py
@@ -1,0 +1,311 @@
+"""Optional, auto-detected claude-monitor integration for token selection.
+
+A companion tool, **claude-monitor**, maintains richer per-account
+utilization data (5h/7d, per-model, reset times, freshness) than Loom's own
+rate-limit probe. When present, Loom can consume ``ranking.json`` to produce
+its spawn-time ``.ranking`` file **without** taking a hard dependency: this
+module is pure file detection under ``~/.claude-monitor/``. When the file is
+absent, malformed, stale, or ``schema != 1``, callers fall back to probing so
+behavior collapses to today's path byte-for-byte.
+
+Two separate surfaces are never mixed (secrets vs usage data):
+
+* ``~/.claude-monitor/ranking.json`` — **no secrets** (utilization only);
+  consumed here for smarter selection.
+* ``~/.claude-monitor/accounts.env`` — secrets (0600); consumed by the
+  bootstrap account-sourcing path (separate concern).
+
+**Format-of-record.** The spawn-time selector (``select.py:_read_ranking``)
+parses pipe-delimited ``name|status`` lines. This module emits exactly that
+format so a monitor-sourced ``.ranking`` is consumed by the selector
+identically to any other. (The probe path's ``write_ranking_atomic`` currently
+serializes JSON — a latent producer/consumer discrepancy that predates this
+feature; reconciling the probe path is intentionally out of scope here.)
+
+**Ordering policy stays Loom's.** claude-monitor is a thin numbers provider;
+we sort by ``(status_rank, util_7d, util_5h)`` using the existing
+``check._STATUS_RANK`` vocabulary. The email join to Loom account names goes
+through the ``index.json`` manifest (#3695).
+
+The claude-monitor directory is overridable via ``LOOM_CLAUDE_MONITOR_DIR``
+so tests never touch a real ``~/.claude-monitor``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from loom_tools.tokens.check import _STATUS_RANK
+
+logger = logging.getLogger(__name__)
+
+# Environment override for the claude-monitor directory (tests, custom setups).
+CLAUDE_MONITOR_DIR_VAR = "LOOM_CLAUDE_MONITOR_DIR"
+DEFAULT_CLAUDE_MONITOR_DIR = "~/.claude-monitor"
+
+# Filename of the ranking contract inside the claude-monitor directory.
+RANKING_JSON_NAME = "ranking.json"
+
+# The schema version this consumer understands. Unknown fields are ignored
+# (forward-compatible); an unexpected top-level schema degrades to probe.
+SUPPORTED_SCHEMA = 1
+
+# Freshness window — mirrors ``select._RANKING_FRESH_SECONDS`` (10 min). A
+# ``ranking.json`` older than this is treated as stale and ignored.
+MONITOR_FRESH_SECONDS = 600
+
+
+def claude_monitor_dir() -> Path:
+    """Resolve the claude-monitor directory.
+
+    Precedence:
+        1. ``LOOM_CLAUDE_MONITOR_DIR`` env var (``~`` expanded) — for tests
+           and non-default installs.
+        2. ``~/.claude-monitor`` (the default location).
+    """
+    override = os.environ.get(CLAUDE_MONITOR_DIR_VAR)
+    if override is not None and override.strip():
+        return Path(override).expanduser()
+    return Path(DEFAULT_CLAUDE_MONITOR_DIR).expanduser()
+
+
+def _parse_iso8601(raw: str | None) -> datetime | None:
+    """Parse an ISO-8601 timestamp (accepting a trailing ``Z``) to aware UTC."""
+    if not raw or not isinstance(raw, str):
+        return None
+    text = raw.strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _is_fresh(generated_at: str | None, now: datetime | None) -> bool:
+    """Return True when *generated_at* is within the freshness window.
+
+    A missing/unparseable timestamp is treated as **stale** (fail closed):
+    the whole point of the gate is to avoid trusting an old file, and we
+    cannot establish freshness without a valid timestamp.
+    """
+    dt = _parse_iso8601(generated_at)
+    if dt is None:
+        return False
+    now = now or datetime.now(timezone.utc)
+    age = (now - dt).total_seconds()
+    return 0 <= age < MONITOR_FRESH_SECONDS
+
+
+def load_index_email_map(tokens_dir: Path) -> dict[str, str]:
+    """Return ``{email_lower: account_name}`` from the #3695 ``index.json``.
+
+    Missing/malformed manifest yields an empty map (the caller then finds no
+    joins and degrades to probe under ``auto``).
+    """
+    index_path = tokens_dir / "index.json"
+    try:
+        raw = index_path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    try:
+        data = json.loads(raw)
+    except (ValueError, TypeError):
+        logger.debug("monitor: index.json is not valid JSON: %s", index_path)
+        return {}
+    out: dict[str, str] = {}
+    for entry in data.get("accounts", []) or []:
+        if not isinstance(entry, dict):
+            continue
+        email = entry.get("email")
+        name = entry.get("name")
+        if isinstance(email, str) and isinstance(name, str) and email and name:
+            out[email.strip().lower()] = name
+    return out
+
+
+def _load_ranking_json(monitor_dir: Path) -> dict[str, Any] | None:
+    """Read + validate ``ranking.json``; return the parsed dict or None.
+
+    Returns None (degrade to probe) when the file is absent, unreadable, not
+    valid JSON, not an object, or carries an unsupported ``schema``.
+    """
+    ranking_path = monitor_dir / RANKING_JSON_NAME
+    try:
+        raw = ranking_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        data = json.loads(raw)
+    except (ValueError, TypeError):
+        logger.debug("monitor: %s is not valid JSON", ranking_path)
+        return None
+    if not isinstance(data, dict):
+        logger.debug("monitor: %s is not a JSON object", ranking_path)
+        return None
+    schema = data.get("schema")
+    if schema != SUPPORTED_SCHEMA:
+        logger.debug(
+            "monitor: %s schema=%r unsupported (want %d); ignoring",
+            ranking_path,
+            schema,
+            SUPPORTED_SCHEMA,
+        )
+        return None
+    return data
+
+
+def _coerce_float(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value.strip())
+        except ValueError:
+            return None
+    return None
+
+
+@dataclass(frozen=True)
+class MonitorAccount:
+    """One account resolved from ranking.json, joined to a Loom name."""
+
+    name: str
+    status: str
+    util_7d: float | None
+    util_5h: float | None
+
+
+# Utilization sentinel used when a value is absent so such accounts sort after
+# accounts with a known (lower) utilization within the same status bucket.
+_UTIL_SENTINEL = 2.0
+
+
+def _order_key(acct: MonitorAccount) -> tuple[int, float, float]:
+    """Loom's ordering policy: ``(status_rank, util_7d, util_5h)``."""
+    rank = _STATUS_RANK.get(acct.status, 99)
+    u7 = acct.util_7d if acct.util_7d is not None else _UTIL_SENTINEL
+    u5 = acct.util_5h if acct.util_5h is not None else _UTIL_SENTINEL
+    return (rank, u7, u5)
+
+
+def build_monitor_accounts(
+    tokens_dir: Path,
+    *,
+    monitor_dir: Path | None = None,
+    now: datetime | None = None,
+) -> list[MonitorAccount] | None:
+    """Translate a fresh ``ranking.json`` into ordered :class:`MonitorAccount`s.
+
+    Returns:
+        A list ordered by ``(status_rank, util_7d, util_5h)`` when a usable,
+        fresh ``ranking.json`` exists; otherwise ``None`` (caller degrades to
+        probe under ``auto``, or emits nothing under ``monitor``).
+
+    Join semantics:
+        * Monitor entries are joined to Loom account names **by email** via
+          ``index.json``. An email with no manifest entry is dropped (debug
+          log).
+        * Manifest accounts with no monitor entry are still represented (empty
+          status, no utilization) so the selector continues to see them; they
+          sort last.
+    """
+    monitor_dir = monitor_dir or claude_monitor_dir()
+    data = _load_ranking_json(monitor_dir)
+    if data is None:
+        return None
+    if not _is_fresh(data.get("generated_at"), now):
+        logger.debug(
+            "monitor: ranking.json stale or undated (generated_at=%r); "
+            "falling back",
+            data.get("generated_at"),
+        )
+        return None
+
+    email_to_name = load_index_email_map(tokens_dir)
+    if not email_to_name:
+        logger.debug("monitor: no index.json email map; cannot join")
+        return None
+
+    accounts: list[MonitorAccount] = []
+    matched_names: set[str] = set()
+    for entry in data.get("accounts", []) or []:
+        if not isinstance(entry, dict):
+            continue
+        email = entry.get("email")
+        if not isinstance(email, str) or not email:
+            continue
+        name = email_to_name.get(email.strip().lower())
+        if name is None:
+            logger.debug("monitor: email %r not in index.json; dropping", email)
+            continue
+        status = entry.get("status")
+        if not isinstance(status, str):
+            status = ""
+        util = entry.get("utilization")
+        util_7d = util_5h = None
+        if isinstance(util, dict):
+            util_7d = _coerce_float(util.get("7d"))
+            util_5h = _coerce_float(util.get("5h"))
+        accounts.append(
+            MonitorAccount(
+                name=name,
+                status=status,
+                util_7d=util_7d,
+                util_5h=util_5h,
+            )
+        )
+        matched_names.add(name)
+
+    # Represent manifest accounts that the monitor did not mention so the
+    # selector still sees them (unknown status -> eligible, sorts last).
+    for name in email_to_name.values():
+        if name not in matched_names:
+            accounts.append(
+                MonitorAccount(name=name, status="", util_7d=None, util_5h=None)
+            )
+            matched_names.add(name)
+
+    if not accounts:
+        return None
+
+    accounts.sort(key=_order_key)
+    return accounts
+
+
+def format_ranking_lines(accounts: list[MonitorAccount]) -> str:
+    """Serialize ordered accounts to the selector's ``name|status`` format.
+
+    This is the format ``select.py:_read_ranking`` consumes. A trailing
+    newline is included so the file ends cleanly.
+    """
+    lines = [f"{a.name}|{a.status}" for a in accounts]
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+def write_monitor_ranking_atomic(
+    accounts: list[MonitorAccount], ranking_path: Path
+) -> None:
+    """Write the monitor-sourced ``.ranking`` (pipe format) atomically.
+
+    Write-then-rename in the same directory so readers see either the old or
+    the new file, never a partial. Format-of-record matches
+    ``select.py:_read_ranking`` (pipe-delimited ``name|status``).
+    """
+    ranking_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = ranking_path.with_suffix(ranking_path.suffix + ".tmp")
+    tmp.write_text(format_ranking_lines(accounts), encoding="utf-8")
+    tmp.replace(ranking_path)

--- a/loom-tools/tests/tokens/conftest.py
+++ b/loom-tools/tests/tokens/conftest.py
@@ -14,6 +14,14 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def _isolate_home_master(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Disable the home-dir account master by default (LOOM_ACCOUNTS_ENV="")."""
+def _isolate_home_master(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    """Isolate host-level state so real files never leak into tests.
+
+    * ``LOOM_ACCOUNTS_ENV=""`` disables the #3695 home-dir account master.
+    * ``LOOM_CLAUDE_MONITOR_DIR`` points the #3697 claude-monitor integration
+      at a non-existent tmp path so a developer's or CI runner's real
+      ``~/.claude-monitor`` is never consulted. Tests that exercise the
+      integration override this with their own ``monkeypatch.setenv``.
+    """
     monkeypatch.setenv("LOOM_ACCOUNTS_ENV", "")
+    monkeypatch.setenv("LOOM_CLAUDE_MONITOR_DIR", str(tmp_path / "no-claude-monitor"))

--- a/loom-tools/tests/tokens/test_bootstrap.py
+++ b/loom-tools/tests/tokens/test_bootstrap.py
@@ -648,11 +648,11 @@ class TestDeriveTokenFilename:
 
     def test_convention_examples(self) -> None:
         # Established naming convention (generic example domains).
-        assert derive_token_filename("robb@2amlogic.com") == "robb-2amlogic.token"
+        assert derive_token_filename("alice@example.com") == "alice-example.token"
         assert (
-            derive_token_filename("r.j.walters@gmail.com") == "rjwalters-gmail.token"
+            derive_token_filename("a.b.jones@example.org") == "abjones-example.token"
         )
-        assert derive_token_filename("agent-1@2amlogic.com") == "agent1-2amlogic.token"
+        assert derive_token_filename("agent-1@example.com") == "agent1-example.token"
 
     def test_result_always_passes_safety_regex(self) -> None:
         for email in (
@@ -672,8 +672,8 @@ class TestDeriveTokenFilename:
 
     def test_two_emails_can_collide_to_same_stem(self) -> None:
         # This is intentional: the duplicate-filename guard catches it.
-        assert derive_token_filename("rjwalters@gmail.com") == derive_token_filename(
-            "r.j.walters@gmail.com"
+        assert derive_token_filename("ajones@example.com") == derive_token_filename(
+            "a.jones@example.com"
         )
 
 
@@ -684,17 +684,17 @@ class TestBootstrapAutoDerive:
         # EMAIL + KEY only (claude-monitor-style) -> file derived.
         _write_env(
             mock_repo,
-            "ACCOUNT_EMAIL_1=robb@2amlogic.com\nACCOUNT_KEY_1=sk-1\n",
+            "ACCOUNT_EMAIL_1=alice@example.com\nACCOUNT_KEY_1=sk-1\n",
         )
         result = bootstrap_tokens(mock_repo)
-        assert result.written == ["robb-2amlogic.token"]
+        assert result.written == ["alice-example.token"]
         tokens_dir = mock_repo / ".loom" / "tokens"
-        assert (tokens_dir / "robb-2amlogic.token").read_text() == "sk-1"
+        assert (tokens_dir / "alice-example.token").read_text() == "sk-1"
 
     def test_explicit_file_still_wins(self, mock_repo: pathlib.Path) -> None:
         _write_env(
             mock_repo,
-            "ACCOUNT_EMAIL_1=robb@2amlogic.com\n"
+            "ACCOUNT_EMAIL_1=alice@example.com\n"
             "ACCOUNT_KEY_1=sk-1\n"
             "ACCOUNT_TOKEN_FILE_1=explicit.token\n",
         )
@@ -706,8 +706,8 @@ class TestBootstrapAutoDerive:
         # the existing duplicate-filename guard, not silently merged.
         _write_env(
             mock_repo,
-            "ACCOUNT_EMAIL_1=rjwalters@gmail.com\nACCOUNT_KEY_1=sk-1\n"
-            "ACCOUNT_EMAIL_2=r.j.walters@gmail.com\nACCOUNT_KEY_2=sk-2\n",
+            "ACCOUNT_EMAIL_1=ajones@example.com\nACCOUNT_KEY_1=sk-1\n"
+            "ACCOUNT_EMAIL_2=a.jones@example.com\nACCOUNT_KEY_2=sk-2\n",
         )
         with pytest.raises(ValueError, match="duplicate token filename"):
             bootstrap_tokens(mock_repo)

--- a/loom-tools/tests/tokens/test_bootstrap.py
+++ b/loom-tools/tests/tokens/test_bootstrap.py
@@ -14,9 +14,11 @@ from loom_tools.tokens.bootstrap import (
     INDEX_VERSION,
     Account,
     BootstrapResult,
+    _TOKEN_FILE_RE,
     _strip_value,
     bootstrap_tokens,
     default_home_accounts_env,
+    derive_token_filename,
     fingerprint,
     merge_accounts,
     parse_env_accounts,
@@ -250,20 +252,23 @@ class TestBootstrap:
         assert not tokens_dir.exists() or list(tokens_dir.iterdir()) == []
 
     def test_partial_triple_skipped(self, mock_repo: pathlib.Path) -> None:
+        # A triple missing a non-derivable field (the KEY) is still skipped.
+        # (Missing TOKEN_FILE is now auto-derived from the email, #3697 — see
+        # TestDeriveTokenFilename / test_token_file_auto_derived_from_email.)
         env_body = (
             "ACCOUNT_EMAIL_1=a@b.com\n"
             "ACCOUNT_KEY_1=sk-1\n"
             "ACCOUNT_TOKEN_FILE_1=a.token\n"
-            # _2 is missing TOKEN_FILE
+            # _2 is missing KEY (cannot be derived) -> skipped
             "ACCOUNT_EMAIL_2=c@d.com\n"
-            "ACCOUNT_KEY_2=sk-2\n"
+            "ACCOUNT_TOKEN_FILE_2=c.token\n"
         )
         _write_env(mock_repo, env_body)
         result = bootstrap_tokens(mock_repo)
         assert result.written == ["a.token"]
         # _2 was silently dropped (with a warning).
         tokens_dir = mock_repo / ".loom" / "tokens"
-        assert not (tokens_dir / "c@d.token").exists()
+        assert not (tokens_dir / "c.token").exists()
 
     def test_unsafe_filename_skipped(self, mock_repo: pathlib.Path) -> None:
         env_body = (
@@ -636,3 +641,119 @@ class TestCliMerge:
         assert "Effective accounts" in out
         assert "alice" in out
         assert "home" in out
+
+
+class TestDeriveTokenFilename:
+    """Auto-derive ACCOUNT_TOKEN_FILE_N from email when omitted (#3697)."""
+
+    def test_convention_examples(self) -> None:
+        # Established naming convention (generic example domains).
+        assert derive_token_filename("robb@2amlogic.com") == "robb-2amlogic.token"
+        assert (
+            derive_token_filename("r.j.walters@gmail.com") == "rjwalters-gmail.token"
+        )
+        assert derive_token_filename("agent-1@2amlogic.com") == "agent1-2amlogic.token"
+
+    def test_result_always_passes_safety_regex(self) -> None:
+        for email in (
+            "user@example.com",
+            "a.b.c@sub.example.co.uk",
+            "weird+tag@example.com",
+            "UPPER@Example.COM",
+            "n@d",
+        ):
+            derived = derive_token_filename(email)
+            assert _TOKEN_FILE_RE.match(derived), derived
+            assert "/" not in derived and "\\" not in derived
+
+    def test_no_at_sign_still_safe(self) -> None:
+        derived = derive_token_filename("localonly")
+        assert _TOKEN_FILE_RE.match(derived)
+
+    def test_two_emails_can_collide_to_same_stem(self) -> None:
+        # This is intentional: the duplicate-filename guard catches it.
+        assert derive_token_filename("rjwalters@gmail.com") == derive_token_filename(
+            "r.j.walters@gmail.com"
+        )
+
+
+class TestBootstrapAutoDerive:
+    def test_token_file_auto_derived_from_email(
+        self, mock_repo: pathlib.Path
+    ) -> None:
+        # EMAIL + KEY only (claude-monitor-style) -> file derived.
+        _write_env(
+            mock_repo,
+            "ACCOUNT_EMAIL_1=robb@2amlogic.com\nACCOUNT_KEY_1=sk-1\n",
+        )
+        result = bootstrap_tokens(mock_repo)
+        assert result.written == ["robb-2amlogic.token"]
+        tokens_dir = mock_repo / ".loom" / "tokens"
+        assert (tokens_dir / "robb-2amlogic.token").read_text() == "sk-1"
+
+    def test_explicit_file_still_wins(self, mock_repo: pathlib.Path) -> None:
+        _write_env(
+            mock_repo,
+            "ACCOUNT_EMAIL_1=robb@2amlogic.com\n"
+            "ACCOUNT_KEY_1=sk-1\n"
+            "ACCOUNT_TOKEN_FILE_1=explicit.token\n",
+        )
+        result = bootstrap_tokens(mock_repo)
+        assert result.written == ["explicit.token"]
+
+    def test_derived_collision_aborts(self, mock_repo: pathlib.Path) -> None:
+        # Two distinct emails that sanitize to the same stem must be caught by
+        # the existing duplicate-filename guard, not silently merged.
+        _write_env(
+            mock_repo,
+            "ACCOUNT_EMAIL_1=rjwalters@gmail.com\nACCOUNT_KEY_1=sk-1\n"
+            "ACCOUNT_EMAIL_2=r.j.walters@gmail.com\nACCOUNT_KEY_2=sk-2\n",
+        )
+        with pytest.raises(ValueError, match="duplicate token filename"):
+            bootstrap_tokens(mock_repo)
+
+
+class TestBackwardCompat3697:
+    """Absent claude-monitor, bootstrap behaves exactly as on #3695."""
+
+    def test_loom_accounts_env_still_honored(
+        self, mock_repo: pathlib.Path, tmp_path: pathlib.Path, monkeypatch
+    ) -> None:
+        master = tmp_path / "master-accounts.env"
+        master.write_text(
+            "ACCOUNT_EMAIL_1=home@example.com\n"
+            "ACCOUNT_KEY_1=hk\n"
+            "ACCOUNT_TOKEN_FILE_1=home.token\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("LOOM_ACCOUNTS_ENV", str(master))
+        result = bootstrap_tokens(mock_repo)
+        assert "home.token" in result.written
+        assert result.home_env == master
+
+    def test_empty_loom_accounts_env_disables_master(
+        self, mock_repo: pathlib.Path, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("LOOM_ACCOUNTS_ENV", "")
+        _write_env(
+            mock_repo,
+            "ACCOUNT_EMAIL_1=a@example.com\n"
+            "ACCOUNT_KEY_1=sk-1\n"
+            "ACCOUNT_TOKEN_FILE_1=a.token\n",
+        )
+        result = bootstrap_tokens(mock_repo)
+        assert result.home_env is None
+        assert result.written == ["a.token"]
+
+    def test_existing_full_triple_setup_unchanged(
+        self, mock_repo: pathlib.Path
+    ) -> None:
+        # A config that bootstrapped fine pre-#3697 (full triples) is untouched.
+        _write_env(
+            mock_repo,
+            "ACCOUNT_EMAIL_1=a@example.com\n"
+            "ACCOUNT_KEY_1=sk-1\n"
+            "ACCOUNT_TOKEN_FILE_1=custom-a.token\n",
+        )
+        result = bootstrap_tokens(mock_repo)
+        assert result.written == ["custom-a.token"]

--- a/loom-tools/tests/tokens/test_check.py
+++ b/loom-tools/tests/tokens/test_check.py
@@ -13,6 +13,7 @@ hitting the live API. Covers:
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -34,6 +35,7 @@ from loom_tools.tokens.check import (
     run_check,
     write_ranking_atomic,
 )
+from loom_tools.tokens.select import select_token
 
 
 # ---------------------------------------------------------------------------
@@ -391,3 +393,167 @@ class TestRunCheck:
     def test_empty_pool_returns_empty_report(self, tmp_path: Path):
         report = run_check(tmp_path, write_ranking=False, stagger=False)
         assert report.accounts == []
+
+
+# ---------------------------------------------------------------------------
+# --source (claude-monitor ranking consumer, #3697)
+# ---------------------------------------------------------------------------
+
+
+def _fresh_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _setup_pool(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Create a workspace with .loom/tokens/, index.json and .token files.
+
+    Returns (workspace, tokens_dir, monitor_dir).
+    """
+    workspace = tmp_path / "ws"
+    tokens_dir = workspace / ".loom" / "tokens"
+    tokens_dir.mkdir(parents=True)
+    for name in ("acct-a", "acct-b"):
+        (tokens_dir / f"{name}.token").write_text(
+            f"sk-ant-oat01-{name}", encoding="utf-8"
+        )
+    (tokens_dir / "index.json").write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "accounts": [
+                    {"name": "acct-a", "email": "a@example.com", "file": "acct-a.token"},
+                    {"name": "acct-b", "email": "b@example.com", "file": "acct-b.token"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monitor_dir = tmp_path / "cm"
+    monitor_dir.mkdir(parents=True)
+    return workspace, tokens_dir, monitor_dir
+
+
+def _write_monitor_ranking(monitor_dir: Path, accounts: list[dict], *, generated_at=None):
+    (monitor_dir / "ranking.json").write_text(
+        json.dumps(
+            {
+                "schema": 1,
+                "generated_at": generated_at or _fresh_iso(),
+                "accounts": accounts,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+class TestSourceMonitor:
+    def test_probe_source_never_touches_monitor(self, tmp_path: Path, monkeypatch):
+        """--source probe ignores claude-monitor and probes (unchanged path)."""
+        workspace, tokens_dir, monitor_dir = _setup_pool(tmp_path)
+        monkeypatch.setenv("LOOM_CLAUDE_MONITOR_DIR", str(monitor_dir))
+        _write_monitor_ranking(
+            monitor_dir,
+            [{"email": "a@example.com", "status": "available",
+              "utilization": {"5h": 0.1, "7d": 0.1}}],
+        )
+        with patch(
+            "requests.post",
+            return_value=_mock_response(200, _good_headers(s7d=0.20)),
+        ) as post:
+            run_check(
+                tokens_dir, source="probe", write_ranking=True, stagger=False
+            )
+        # It probed (network call made) and wrote JSON, not pipe.
+        assert post.called
+        data = json.loads((tokens_dir / ".ranking").read_text())
+        assert "accounts" in data
+
+    def test_monitor_source_writes_pipe_format(self, tmp_path: Path, monkeypatch):
+        workspace, tokens_dir, monitor_dir = _setup_pool(tmp_path)
+        monkeypatch.setenv("LOOM_CLAUDE_MONITOR_DIR", str(monitor_dir))
+        _write_monitor_ranking(
+            monitor_dir,
+            [
+                {"email": "b@example.com", "status": "available",
+                 "utilization": {"5h": 0.1, "7d": 0.9}},
+                {"email": "a@example.com", "status": "available",
+                 "utilization": {"5h": 0.1, "7d": 0.1}},
+            ],
+        )
+        with patch("requests.post") as post:
+            run_check(
+                tokens_dir, source="monitor", write_ranking=True, stagger=False
+            )
+        assert not post.called  # monitor path never probes
+        text = (tokens_dir / ".ranking").read_text()
+        # pipe format, ordered by util_7d ascending (a before b)
+        assert text == "acct-a|available\nacct-b|available\n"
+
+    def test_monitor_source_no_data_returns_empty_no_probe(
+        self, tmp_path: Path, monkeypatch
+    ):
+        workspace, tokens_dir, monitor_dir = _setup_pool(tmp_path)
+        monkeypatch.setenv("LOOM_CLAUDE_MONITOR_DIR", str(monitor_dir))
+        # No ranking.json in monitor_dir.
+        with patch("requests.post") as post:
+            report = run_check(
+                tokens_dir, source="monitor", write_ranking=True, stagger=False
+            )
+        assert not post.called
+        assert report.accounts == []
+        # No .ranking written (nothing to rank).
+        assert not (tokens_dir / ".ranking").exists()
+
+    def test_auto_uses_monitor_when_fresh(self, tmp_path: Path, monkeypatch):
+        workspace, tokens_dir, monitor_dir = _setup_pool(tmp_path)
+        monkeypatch.setenv("LOOM_CLAUDE_MONITOR_DIR", str(monitor_dir))
+        _write_monitor_ranking(
+            monitor_dir,
+            [{"email": "a@example.com", "status": "available",
+              "utilization": {"5h": 0.1, "7d": 0.1}}],
+        )
+        with patch("requests.post") as post:
+            run_check(tokens_dir, source="auto", write_ranking=True, stagger=False)
+        assert not post.called
+        text = (tokens_dir / ".ranking").read_text()
+        assert "acct-a|available" in text
+
+    def test_auto_falls_back_to_probe_when_absent(self, tmp_path: Path, monkeypatch):
+        workspace, tokens_dir, monitor_dir = _setup_pool(tmp_path)
+        # Point at an empty monitor dir (no ranking.json).
+        monkeypatch.setenv("LOOM_CLAUDE_MONITOR_DIR", str(monitor_dir))
+        with patch(
+            "requests.post",
+            return_value=_mock_response(200, _good_headers(s7d=0.20)),
+        ) as post:
+            run_check(tokens_dir, source="auto", write_ranking=True, stagger=False)
+        assert post.called  # fell back to probing
+        # Probe path writes JSON.
+        data = json.loads((tokens_dir / ".ranking").read_text())
+        assert "accounts" in data
+
+    def test_roundtrip_monitor_output_read_by_selector(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """The .ranking emitted by the monitor path is consumed by select_token.
+
+        This is the format-of-record proof: select.py:_read_ranking parses
+        pipe-delimited name|status, so the monitor writer must emit that.
+        """
+        workspace, tokens_dir, monitor_dir = _setup_pool(tmp_path)
+        monkeypatch.setenv("LOOM_CLAUDE_MONITOR_DIR", str(monitor_dir))
+        # acct-b exhausted, acct-a available -> selector must pick acct-a.
+        _write_monitor_ranking(
+            monitor_dir,
+            [
+                {"email": "b@example.com", "status": "exhausted",
+                 "utilization": {"5h": 0.99, "7d": 0.99}},
+                {"email": "a@example.com", "status": "available",
+                 "utilization": {"5h": 0.1, "7d": 0.1}},
+            ],
+        )
+        run_check(tokens_dir, source="monitor", write_ranking=True, stagger=False)
+
+        selected = select_token(workspace)
+        assert selected.mode == "ranked"
+        assert selected.name == "acct-a"

--- a/loom-tools/tests/tokens/test_monitor.py
+++ b/loom-tools/tests/tokens/test_monitor.py
@@ -1,0 +1,342 @@
+"""Tests for loom_tools.tokens.monitor (issue #3697).
+
+Covers the claude-monitor ranking consumer in isolation: directory
+resolution, schema validation, freshness gating, the email->name join via
+index.json, ordering policy, unknown-field tolerance, and the pipe-format
+writer that the selector consumes.
+
+The claude-monitor directory is always pointed at a tmp path via
+``LOOM_CLAUDE_MONITOR_DIR`` so no test ever touches a real ~/.claude-monitor.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from loom_tools.tokens.monitor import (
+    MONITOR_FRESH_SECONDS,
+    MonitorAccount,
+    build_monitor_accounts,
+    claude_monitor_dir,
+    format_ranking_lines,
+    load_index_email_map,
+    write_monitor_ranking_atomic,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _fresh_now() -> str:
+    return _iso(datetime.now(timezone.utc))
+
+
+def _write_index(tokens_dir: Path, accounts: list[dict]) -> None:
+    tokens_dir.mkdir(parents=True, exist_ok=True)
+    (tokens_dir / "index.json").write_text(
+        json.dumps({"version": 2, "accounts": accounts}, indent=2),
+        encoding="utf-8",
+    )
+
+
+def _write_ranking(monitor_dir: Path, payload: dict) -> None:
+    monitor_dir.mkdir(parents=True, exist_ok=True)
+    (monitor_dir / "ranking.json").write_text(
+        json.dumps(payload, indent=2), encoding="utf-8"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Directory resolution
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeMonitorDir:
+    def test_env_override(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("LOOM_CLAUDE_MONITOR_DIR", str(tmp_path / "cm"))
+        assert claude_monitor_dir() == tmp_path / "cm"
+
+    def test_default_when_unset(self, monkeypatch) -> None:
+        monkeypatch.delenv("LOOM_CLAUDE_MONITOR_DIR", raising=False)
+        assert claude_monitor_dir() == Path("~/.claude-monitor").expanduser()
+
+    def test_blank_env_falls_back_to_default(self, monkeypatch) -> None:
+        monkeypatch.setenv("LOOM_CLAUDE_MONITOR_DIR", "   ")
+        assert claude_monitor_dir() == Path("~/.claude-monitor").expanduser()
+
+
+# ---------------------------------------------------------------------------
+# index.json email map
+# ---------------------------------------------------------------------------
+
+
+class TestLoadIndexEmailMap:
+    def test_join_is_case_insensitive_on_email(self, tmp_path: Path) -> None:
+        _write_index(
+            tmp_path,
+            [{"name": "u1", "email": "User@Example.com", "file": "u1.token"}],
+        )
+        assert load_index_email_map(tmp_path) == {"user@example.com": "u1"}
+
+    def test_missing_index_is_empty(self, tmp_path: Path) -> None:
+        assert load_index_email_map(tmp_path) == {}
+
+    def test_malformed_index_is_empty(self, tmp_path: Path) -> None:
+        tmp_path.mkdir(parents=True, exist_ok=True)
+        (tmp_path / "index.json").write_text("{not json", encoding="utf-8")
+        assert load_index_email_map(tmp_path) == {}
+
+
+# ---------------------------------------------------------------------------
+# build_monitor_accounts — join + ordering + freshness + schema
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMonitorAccounts:
+    def _setup(self, tmp_path: Path) -> tuple[Path, Path]:
+        tokens_dir = tmp_path / ".loom" / "tokens"
+        monitor_dir = tmp_path / "cm"
+        _write_index(
+            tokens_dir,
+            [
+                {"name": "acct-a", "email": "a@example.com", "file": "acct-a.token"},
+                {"name": "acct-b", "email": "b@example.com", "file": "acct-b.token"},
+            ],
+        )
+        return tokens_dir, monitor_dir
+
+    def test_join_and_order_by_status_then_util(self, tmp_path: Path) -> None:
+        tokens_dir, monitor_dir = self._setup(tmp_path)
+        _write_ranking(
+            monitor_dir,
+            {
+                "schema": 1,
+                "generated_at": _fresh_now(),
+                "accounts": [
+                    {
+                        "email": "b@example.com",
+                        "status": "available",
+                        "utilization": {"5h": 0.10, "7d": 0.80},
+                    },
+                    {
+                        "email": "a@example.com",
+                        "status": "available",
+                        "utilization": {"5h": 0.50, "7d": 0.20},
+                    },
+                ],
+            },
+        )
+        accounts = build_monitor_accounts(tokens_dir, monitor_dir=monitor_dir)
+        assert accounts is not None
+        # Both available -> order by util_7d ascending: a (0.20) before b (0.80).
+        assert [a.name for a in accounts] == ["acct-a", "acct-b"]
+
+    def test_status_rank_beats_utilization(self, tmp_path: Path) -> None:
+        tokens_dir, monitor_dir = self._setup(tmp_path)
+        _write_ranking(
+            monitor_dir,
+            {
+                "schema": 1,
+                "generated_at": _fresh_now(),
+                "accounts": [
+                    {
+                        "email": "a@example.com",
+                        "status": "exhausted",
+                        "utilization": {"5h": 0.01, "7d": 0.01},
+                    },
+                    {
+                        "email": "b@example.com",
+                        "status": "available",
+                        "utilization": {"5h": 0.99, "7d": 0.99},
+                    },
+                ],
+            },
+        )
+        accounts = build_monitor_accounts(tokens_dir, monitor_dir=monitor_dir)
+        assert accounts is not None
+        # available sorts before exhausted regardless of utilization.
+        assert [a.name for a in accounts] == ["acct-b", "acct-a"]
+
+    def test_unmatched_email_dropped(self, tmp_path: Path) -> None:
+        tokens_dir, monitor_dir = self._setup(tmp_path)
+        _write_ranking(
+            monitor_dir,
+            {
+                "schema": 1,
+                "generated_at": _fresh_now(),
+                "accounts": [
+                    {
+                        "email": "a@example.com",
+                        "status": "available",
+                        "utilization": {"5h": 0.1, "7d": 0.1},
+                    },
+                    {
+                        "email": "ghost@example.com",  # not in index.json
+                        "status": "available",
+                        "utilization": {"5h": 0.1, "7d": 0.1},
+                    },
+                ],
+            },
+        )
+        accounts = build_monitor_accounts(tokens_dir, monitor_dir=monitor_dir)
+        assert accounts is not None
+        names = {a.name for a in accounts}
+        # ghost dropped; acct-b (no monitor entry) still represented.
+        assert "acct-a" in names
+        assert "acct-b" in names
+        assert len(accounts) == 2
+
+    def test_unmatched_manifest_account_represented_last(
+        self, tmp_path: Path
+    ) -> None:
+        tokens_dir, monitor_dir = self._setup(tmp_path)
+        _write_ranking(
+            monitor_dir,
+            {
+                "schema": 1,
+                "generated_at": _fresh_now(),
+                "accounts": [
+                    {
+                        "email": "a@example.com",
+                        "status": "available",
+                        "utilization": {"5h": 0.1, "7d": 0.1},
+                    }
+                ],
+            },
+        )
+        accounts = build_monitor_accounts(tokens_dir, monitor_dir=monitor_dir)
+        assert accounts is not None
+        # acct-b has no monitor entry -> empty status, sorts last.
+        assert accounts[0].name == "acct-a"
+        assert accounts[-1].name == "acct-b"
+        assert accounts[-1].status == ""
+
+    def test_stale_returns_none(self, tmp_path: Path) -> None:
+        tokens_dir, monitor_dir = self._setup(tmp_path)
+        old = datetime.now(timezone.utc) - timedelta(
+            seconds=MONITOR_FRESH_SECONDS + 60
+        )
+        _write_ranking(
+            monitor_dir,
+            {
+                "schema": 1,
+                "generated_at": _iso(old),
+                "accounts": [
+                    {"email": "a@example.com", "status": "available"}
+                ],
+            },
+        )
+        assert build_monitor_accounts(tokens_dir, monitor_dir=monitor_dir) is None
+
+    def test_freshness_boundary_just_inside(self, tmp_path: Path) -> None:
+        tokens_dir, monitor_dir = self._setup(tmp_path)
+        gen = datetime.now(timezone.utc) - timedelta(
+            seconds=MONITOR_FRESH_SECONDS - 30
+        )
+        _write_ranking(
+            monitor_dir,
+            {
+                "schema": 1,
+                "generated_at": _iso(gen),
+                "accounts": [
+                    {"email": "a@example.com", "status": "available"}
+                ],
+            },
+        )
+        accounts = build_monitor_accounts(tokens_dir, monitor_dir=monitor_dir)
+        assert accounts is not None
+
+    def test_wrong_schema_returns_none(self, tmp_path: Path) -> None:
+        tokens_dir, monitor_dir = self._setup(tmp_path)
+        _write_ranking(
+            monitor_dir,
+            {
+                "schema": 2,
+                "generated_at": _fresh_now(),
+                "accounts": [{"email": "a@example.com", "status": "available"}],
+            },
+        )
+        assert build_monitor_accounts(tokens_dir, monitor_dir=monitor_dir) is None
+
+    def test_missing_ranking_returns_none(self, tmp_path: Path) -> None:
+        tokens_dir, monitor_dir = self._setup(tmp_path)
+        # monitor_dir has no ranking.json
+        assert build_monitor_accounts(tokens_dir, monitor_dir=monitor_dir) is None
+
+    def test_malformed_ranking_returns_none(self, tmp_path: Path) -> None:
+        tokens_dir, monitor_dir = self._setup(tmp_path)
+        monitor_dir.mkdir(parents=True, exist_ok=True)
+        (monitor_dir / "ranking.json").write_text("{oops", encoding="utf-8")
+        assert build_monitor_accounts(tokens_dir, monitor_dir=monitor_dir) is None
+
+    def test_unknown_fields_ignored(self, tmp_path: Path) -> None:
+        tokens_dir, monitor_dir = self._setup(tmp_path)
+        _write_ranking(
+            monitor_dir,
+            {
+                "schema": 1,
+                "generated_at": _fresh_now(),
+                "future_top_level": {"anything": 1},
+                "accounts": [
+                    {
+                        "email": "a@example.com",
+                        "status": "available",
+                        "utilization": {"5h": 0.1, "7d": 0.2},
+                        "models": {"fable": {"utilization": 0.3}},
+                        "brand_new_field": "ignore me",
+                    }
+                ],
+            },
+        )
+        accounts = build_monitor_accounts(tokens_dir, monitor_dir=monitor_dir)
+        assert accounts is not None
+        assert accounts[0].name == "acct-a"
+        assert accounts[0].util_7d == 0.2
+
+    def test_no_index_returns_none(self, tmp_path: Path) -> None:
+        # No index.json -> cannot join -> None (degrade to probe under auto).
+        monitor_dir = tmp_path / "cm"
+        tokens_dir = tmp_path / ".loom" / "tokens"
+        tokens_dir.mkdir(parents=True)
+        _write_ranking(
+            monitor_dir,
+            {
+                "schema": 1,
+                "generated_at": _fresh_now(),
+                "accounts": [{"email": "a@example.com", "status": "available"}],
+            },
+        )
+        assert build_monitor_accounts(tokens_dir, monitor_dir=monitor_dir) is None
+
+
+# ---------------------------------------------------------------------------
+# pipe-format writer
+# ---------------------------------------------------------------------------
+
+
+class TestWriter:
+    def test_format_lines(self) -> None:
+        accts = [
+            MonitorAccount("a", "available", 0.1, 0.2),
+            MonitorAccount("b", "exhausted", 0.9, 0.9),
+        ]
+        assert format_ranking_lines(accts) == "a|available\nb|exhausted\n"
+
+    def test_empty_writes_empty(self) -> None:
+        assert format_ranking_lines([]) == ""
+
+    def test_atomic_write_no_partial(self, tmp_path: Path) -> None:
+        target = tmp_path / ".ranking"
+        write_monitor_ranking_atomic(
+            [MonitorAccount("a", "available", None, None)], target
+        )
+        assert target.read_text() == "a|available\n"
+        assert not target.with_suffix(target.suffix + ".tmp").exists()


### PR DESCRIPTION
Closes #3697

Adds an **optional, auto-detected claude-monitor integration** for smarter token selection and simpler account sourcing. When claude-monitor is absent, everything collapses to today's path byte-for-byte.

## What's implemented

### Sub-scope A — ranking consumer (complete)
- **New `loom_tools/tokens/monitor.py`**: locates, validates (`schema == 1`), and freshness-gates `~/.claude-monitor/ranking.json` (10-min window mirroring `select._RANKING_FRESH_SECONDS`), joins monitor entries to Loom account names **by email** via the #3695 `index.json` manifest, and orders by `(status_rank, util_7d, util_5h)` using the existing `check._STATUS_RANK` vocabulary. Unknown fields are ignored (forward-compatible).
- **`loom-tokens check --source auto|monitor|probe`** (+ `LOOM_RANKING_SOURCE` env; flag > env > `auto` default):
  - `auto` — use claude-monitor when a fresh `ranking.json` is present, else probe.
  - `monitor` — claude-monitor only, never probes (empty report when no fresh data).
  - `probe` — pre-#3697 behavior, unchanged.
- Join semantics: unmatched emails dropped (debug log); manifest accounts with no monitor entry still represented (sort last) so the selector keeps seeing them.
- Soft dependency: **no import of / hard dep on** claude-monitor — pure file detection. The directory is env-overridable via `LOOM_CLAUDE_MONITOR_DIR` so tests never touch a real `~/.claude-monitor`.

### Sub-scope B — account sourcing (auto-derive half)
- **Auto-derive `ACCOUNT_TOKEN_FILE_N` from `ACCOUNT_EMAIL_N`** when omitted, so a claude-monitor-style `EMAIL`+`KEY`-only entry bootstraps directly. Convention (stable so identities don't churn): strip dots/hyphens from the local-part, append `-<first-domain-label>`, lowercase, drop unsafe chars — e.g. `robb@2amlogic.com -> robb-2amlogic.token`, `r.j.walters@gmail.com -> rjwalters-gmail.token`, `agent-1@2amlogic.com -> agent1-2amlogic.token`. Always passes `_TOKEN_FILE_RE`; the existing duplicate-filename guard still catches true collisions.

## Format-of-record (the curator's load-bearing finding)

`select.py:_read_ranking` parses **pipe-delimited `name|status`**, while `check.py:write_ranking_atomic` (probe path) serializes **JSON** — so the probe-sourced tier-1 ranking is effectively inert against the JSON file today. Per the issue's guidance, the **monitor path emits exactly what the selector consumes** (pipe format), proven by a round-trip test (`test_roundtrip_monitor_output_read_by_selector`): the emitted `.ranking` is read by `select_token`, which picks the expected account. The probe path is left as JSON (its AC says "unchanged") — reconciling the wider discrepancy is **deferred to #3698**, not fixed here.

## Deferred to #3698 (follow-up filed)

Per the issue's scope-discretion clause, the higher-risk half of sub-scope B is deferred to keep the live account-resolution path safe and the diff reviewable:
- Reading `~/.claude-monitor/accounts.env` as a higher-priority account source.
- Changing the default resolution order to claude-monitor-first.
- Retiring the `~/.loom/accounts.env` home-master default.
- Reconciling the probe-path `.ranking` format-of-record (JSON vs pipe).

## Backward compatibility (tested)

- `LOOM_ACCOUNTS_ENV` still honored (path expansion; empty string disables).
- Existing full-triple and home/repo setups still bootstrap unchanged.
- `--no-home` / `--home-env` / `--env` semantics preserved.
- **Absent `~/.claude-monitor/*`, both `check` (auto) and `bootstrap` behave exactly as on current main** — regression tests added; conftest points `LOOM_CLAUDE_MONITOR_DIR` at a non-existent tmp path by default so host state never leaks.

## Tests

`PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/tokens/ -q` -> **207 passed** (was 170; +37 new across `test_monitor.py`, `test_check.py::TestSourceMonitor`, and bootstrap derive/backward-compat classes). New source files lint clean under ruff (2 remaining errors are pre-existing `F541` in `_cmd_unblock`, untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)