### PR TITLE
feat(tokens): claude-monitor-first account sourcing + retire ~/.loom default (#3698)

### DIFF
--- a/loom-tools/src/loom_tools/models/spawn_loop_state.py
+++ b/loom-tools/src/loom_tools/models/spawn_loop_state.py
@@ -9,7 +9,7 @@ The spawn loop writes a minimal state file with the following shape::
           "issue": 42,
           "pid": 12345,
           "started_at": "2026-06-02T16:15:00Z",
-          "token": "robb-personal",
+          "token": "agent-1-personal",
           "output_file": "/path/to/.loom/logs/sweep-issue-42.log"
         },
         ...

--- a/loom-tools/src/loom_tools/tokens/bootstrap.py
+++ b/loom-tools/src/loom_tools/tokens/bootstrap.py
@@ -6,23 +6,35 @@ triples and materializes them as per-account ``.token`` files inside
 fingerprints (truncated to 8 chars) so drift between the source and on-disk
 state can be detected without storing secret material.
 
-**Home-dir master + per-repo override (#3695).** Accounts are read from two
-sources and merged so a set of Claude accounts can be declared **once** and
-shared across every workspace instead of duplicating ``ACCOUNT_*_N`` triples
-into every repo's ``.env``:
+**Additive multi-source merge (#3695, #3698).** Accounts are read from up to
+three sources and merged so a set of Claude accounts can be declared **once**
+and shared across every workspace instead of duplicating ``ACCOUNT_*_N``
+triples into every repo's ``.env``. In **precedence order, highest first**:
 
-1. **Home master** — ``~/.loom/accounts.env`` (override with the
+1. **claude-monitor master (#3698)** — ``~/.claude-monitor/accounts.env`` when
+   present (directory resolved via ``monitor.claude_monitor_dir()``, overridable
+   with ``LOOM_CLAUDE_MONITOR_DIR``). The companion **claude-monitor** tool
+   writes EMAIL+KEY-only entries here; the token filename is auto-derived from
+   the email (see :func:`derive_token_filename`). This is a **soft dependency**:
+   pure file detection, no import of any claude-monitor package. This is now the
+   *primary* home source.
+2. **Home master (#3695)** — ``~/.loom/accounts.env`` (override with the
    ``LOOM_ACCOUNTS_ENV`` env var; set it to ``""`` to disable the master).
-2. **Repo-local** — ``<repo>/.loom/accounts.env`` if present, else the legacy
+   Demoted from top default by #3698 to a **still-read fallback** — never
+   removed as a capability.
+3. **Repo-local** — ``<repo>/.loom/accounts.env`` if present, else the legacy
    ``<repo>/.env`` (override with ``--env`` / ``env_path``).
 
-The two sets are merged **by account email** (``ACCOUNT_EMAIL``): a repo-local
-entry whose email also appears in the master **overrides** it (e.g. to rotate
-a key), and a repo-local entry with a new email **adds** to the pool. Accounts
-present only in the master are inherited. To *exclude* a master account from a
-repo, use the ``.allowlist`` pin (``loom-tokens pin``) — the merge only ever
-adds/overrides, it never subtracts. A repo with only a legacy ``.env`` and no
-master behaves exactly as before this change.
+The sets are merged **by account email** (``ACCOUNT_EMAIL``, case-insensitive)
+with precedence **claude-monitor > repo > home**: an entry whose email appears
+in a higher-precedence source **overrides** the lower one (e.g. to rotate a
+key), and an entry with a new email **adds** to the pool. Accounts present only
+in a lower-precedence source are inherited. To *exclude* an inherited account
+from a repo, use the ``.allowlist`` pin (``loom-tokens pin``) — the merge only
+ever adds/overrides, it never subtracts. **Absent the claude-monitor file,
+resolution is byte-for-byte identical to the #3695 home+repo merge (repo
+overrides home)**, and a repo with only a legacy ``.env`` and no master behaves
+exactly as it did before #3695.
 
 Lean-genius reference: ``scripts/agents/claude-wrapper.sh:46-66``. The
 bootstrap behaviour mirrors that shell snippet (strip surrounding quotes
@@ -48,6 +60,7 @@ from loom_tools.common.logging import (
     log_warning,
 )
 from loom_tools.common.paths import LoomPaths
+from loom_tools.tokens import monitor
 
 # ``ACCOUNT_<FIELD>_<N>=<value>`` — N is 1+ digits, FIELD is one of the
 # triple keys we recognize. Anchored to start of line.
@@ -68,6 +81,13 @@ FILE_MODE = 0o600
 # the empty string to disable the master entirely.
 DEFAULT_HOME_ACCOUNTS_ENV = "~/.loom/accounts.env"
 HOME_ACCOUNTS_ENV_VAR = "LOOM_ACCOUNTS_ENV"
+
+# claude-monitor master accounts file (#3698). The companion claude-monitor tool
+# writes EMAIL+KEY-only entries here; this is the highest-precedence account
+# source. The directory is resolved via ``monitor.claude_monitor_dir()`` so
+# ``LOOM_CLAUDE_MONITOR_DIR`` overrides it and tests never touch a real
+# ``~/.claude-monitor``. Soft dependency: pure file detection, no package import.
+MONITOR_ACCOUNTS_ENV_NAME = "accounts.env"
 
 # Characters stripped from an email local-part when deriving a token filename
 # (#3697): dots and hyphens, so ``a.b.jones`` -> ``abjones`` and
@@ -176,9 +196,15 @@ def parse_env_accounts(env_path: Path) -> dict[int, dict[str, str]]:
 class Account:
     """A single validated account triple with its provenance.
 
-    ``source`` is one of ``"home"`` (only in the master), ``"repo"`` (only in
-    the repo-local source), or ``"repo-override"`` (email present in both; the
-    repo-local entry won).
+    ``source`` is one of:
+
+    * ``"home"`` — only in the ``~/.loom`` home master;
+    * ``"repo"`` — only in the repo-local source;
+    * ``"repo-override"`` — email present in both home and repo; the repo entry
+      won over the home master;
+    * ``"monitor"`` (#3698) — only in the claude-monitor master;
+    * ``"monitor-override"`` (#3698) — email present in claude-monitor and at
+      least one lower-precedence source; the claude-monitor entry won.
     """
 
     email: str
@@ -205,6 +231,19 @@ def default_home_accounts_env() -> Path | None:
             return None
         return Path(override).expanduser()
     return Path(DEFAULT_HOME_ACCOUNTS_ENV).expanduser()
+
+
+def default_claude_monitor_accounts_env() -> Path:
+    """Resolve claude-monitor's master accounts file (#3698).
+
+    Returns ``<claude-monitor-dir>/accounts.env`` where the directory comes from
+    :func:`monitor.claude_monitor_dir` (honoring ``LOOM_CLAUDE_MONITOR_DIR`` so
+    tests never touch a real ``~/.claude-monitor``). The returned path may not
+    exist on disk — the caller checks for presence and degrades silently to the
+    home+repo sources when it is absent. This is a **soft dependency**: only the
+    directory resolver is imported, never any claude-monitor package.
+    """
+    return monitor.claude_monitor_dir() / MONITOR_ACCOUNTS_ENV_NAME
 
 
 def resolve_repo_env(repo_root: Path, env_path: Path | None) -> Path:
@@ -270,23 +309,29 @@ def _assemble_valid_accounts(
 
 
 def merge_accounts(
-    home: list[Account],
-    repo: list[Account],
+    base: list[Account],
+    over: list[Account],
+    *,
+    override_label: str = "repo-override",
 ) -> list[Account]:
-    """Merge repo-local accounts **over** the home master, keyed by email.
+    """Merge the *over* accounts **on top of** the *base* accounts, by email.
 
-    Rules (#3695):
-        * An account whose email appears only in the master is inherited
-          (``source="home"``).
-        * An account whose email appears only in the repo-local source is
-          added (``source="repo"``).
-        * An email present in both: the repo-local entry wins and is tagged
-          ``source="repo-override"`` — it keeps the master's position in the
-          ordering but takes the repo's key/file/index.
+    Rules (#3695, generalized in #3698):
+        * An account whose email appears only in *base* is inherited (keeps its
+          own ``source``).
+        * An account whose email appears only in *over* is added (keeps its own
+          ``source``).
+        * An email present in both: the *over* entry wins and is retagged
+          ``source=override_label`` — it keeps *base*'s position in the ordering
+          but takes *over*'s key/file/index.
 
-    Ordering is deterministic: master accounts first (in master index order),
-    then repo-only additions (in repo index order). Email comparison is
-    case-insensitive so ``User@x.com`` and ``user@x.com`` are the same account.
+    ``override_label`` defaults to ``"repo-override"`` so the #3695 home+repo
+    merge is byte-for-byte unchanged; the #3698 three-source merge passes
+    ``"monitor-override"`` when layering the claude-monitor source on top.
+
+    Ordering is deterministic: *base* accounts first (in *base* order), then
+    *over*-only additions (in *over* order). Email comparison is case-insensitive
+    so ``User@x.com`` and ``user@x.com`` are the same account.
     """
 
     def key(acct: Account) -> str:
@@ -294,13 +339,13 @@ def merge_accounts(
 
     merged: dict[str, Account] = {}
     order: list[str] = []
-    for acct in home:
+    for acct in base:
         k = key(acct)
         if k not in merged:
             order.append(k)
-        merged[k] = acct  # last home entry for a dup email wins (stable)
+        merged[k] = acct  # last base entry for a dup email wins (stable)
 
-    for acct in repo:
+    for acct in over:
         k = key(acct)
         if k in merged:
             # Override in place, preserving position but recording provenance.
@@ -308,7 +353,7 @@ def merge_accounts(
                 email=acct.email,
                 key=acct.key,
                 file=acct.file,
-                source="repo-override",
+                source=override_label,
                 index=acct.index,
             )
         else:
@@ -360,7 +405,8 @@ class BootstrapResult:
         self.dry_run: bool = False
         self.tokens_dir: Path | None = None
         self.index_path: Path | None = None
-        # #3695: where accounts were read from and the effective merged set.
+        # #3695/#3698: where accounts were read from and the effective set.
+        self.monitor_env: Path | None = None
         self.home_env: Path | None = None
         self.repo_env: Path | None = None
         # Each entry: {"email", "name", "file", "source"}.
@@ -375,6 +421,7 @@ class BootstrapResult:
             "dry_run": self.dry_run,
             "tokens_dir": str(self.tokens_dir) if self.tokens_dir else None,
             "index_path": str(self.index_path) if self.index_path else None,
+            "monitor_env": str(self.monitor_env) if self.monitor_env else None,
             "home_env": str(self.home_env) if self.home_env else None,
             "repo_env": str(self.repo_env) if self.repo_env else None,
             "effective": [dict(a) for a in self.effective],
@@ -392,13 +439,22 @@ def bootstrap_tokens(
     force: bool = False,
     dry_run: bool = False,
 ) -> BootstrapResult:
-    """Bootstrap ``.loom/tokens/`` from the merged account sources (#3695).
+    """Bootstrap ``.loom/tokens/`` from the merged account sources (#3695, #3698).
 
-    Reads the home-dir master (``~/.loom/accounts.env`` by default) and the
-    repo-local source (``<repo>/.loom/accounts.env`` if present, else the
-    legacy ``<repo>/.env``), merges them **by account email** with the
-    repo-local source overriding the master, and materializes the effective
-    set into ``.loom/tokens/``.
+    Reads up to three account sources and merges them **by account email** with
+    precedence **claude-monitor > repo > home**, then materializes the effective
+    set into ``.loom/tokens/``:
+
+    * the claude-monitor master (``~/.claude-monitor/accounts.env`` when present,
+      #3698) — highest precedence, EMAIL+KEY-only entries auto-derive their
+      token filename;
+    * the home-dir master (``~/.loom/accounts.env`` by default, #3695) — still
+      read as a fallback, honoring ``LOOM_ACCOUNTS_ENV``;
+    * the repo-local source (``<repo>/.loom/accounts.env`` if present, else the
+      legacy ``<repo>/.env``).
+
+    Absent the claude-monitor file the behavior is byte-for-byte identical to
+    the #3695 home+repo merge (repo overrides home).
 
     Args:
         repo_root: Repository root (must contain ``.loom/``).
@@ -428,31 +484,43 @@ def bootstrap_tokens(
     tokens_dir = paths.loom_dir / "tokens"
     index_path = tokens_dir / "index.json"
 
-    # Resolve the two sources. `home_env_path` uses a sentinel so an explicit
+    # Resolve the sources. `home_env_path` uses a sentinel so an explicit
     # None (disable) is distinguishable from an omitted argument (use default).
     if home_env_path is _HOME_UNSET:
         home_file = default_home_accounts_env()
     else:
         home_file = home_env_path  # type: ignore[assignment]
     repo_file = resolve_repo_env(repo_root, env_path)
+    # claude-monitor master (#3698): highest precedence, soft dependency. The
+    # resolver honors LOOM_CLAUDE_MONITOR_DIR; absent on disk it degrades
+    # silently to the home+repo path (no import, no crash).
+    monitor_file = default_claude_monitor_accounts_env()
 
     result = BootstrapResult()
     result.dry_run = dry_run
     result.tokens_dir = tokens_dir
     result.index_path = index_path
+    result.monitor_env = monitor_file if monitor_file.is_file() else None
     result.home_env = home_file if (home_file and home_file.is_file()) else None
     result.repo_env = repo_file if repo_file.is_file() else None
 
+    monitor_present = monitor_file.is_file()
     home_present = bool(home_file and home_file.is_file())
     repo_present = repo_file.is_file()
-    if not home_present and not repo_present:
+    if not monitor_present and not home_present and not repo_present:
         raise FileNotFoundError(
             "No account source found. Looked for a repo-local source at "
-            f"{repo_file} and a home master at "
-            f"{home_file if home_file else '(disabled)'}. "
+            f"{repo_file}, a home master at "
+            f"{home_file if home_file else '(disabled)'}, and a claude-monitor "
+            f"master at {monitor_file}. "
             "Declare accounts in one of them (see `loom-tokens bootstrap --help`)."
         )
 
+    monitor_accounts: list[Account] = []
+    if monitor_present:
+        monitor_accounts = _assemble_valid_accounts(
+            parse_env_accounts(monitor_file), "monitor"
+        )
     home_accounts: list[Account] = []
     if home_present:
         home_accounts = _assemble_valid_accounts(
@@ -464,7 +532,14 @@ def bootstrap_tokens(
             parse_env_accounts(repo_file), "repo"
         )
 
-    valid = merge_accounts(home_accounts, repo_accounts)
+    # Three-source merge, precedence claude-monitor > repo > home. First layer
+    # repo over home (unchanged #3695 behavior — repo-override), then layer
+    # claude-monitor on top (monitor-override). Absent the monitor source the
+    # second merge is a no-op, so behavior is byte-for-byte identical to #3695.
+    home_repo = merge_accounts(home_accounts, repo_accounts)
+    valid = merge_accounts(
+        home_repo, monitor_accounts, override_label="monitor-override"
+    )
 
     # Record the effective merged set (with provenance) for reporting even
     # when nothing is written — bootstrap --dry-run consumes this.
@@ -480,7 +555,9 @@ def bootstrap_tokens(
 
     if not valid:
         srcs = ", ".join(
-            str(p) for p in (result.home_env, result.repo_env) if p
+            str(p)
+            for p in (result.monitor_env, result.home_env, result.repo_env)
+            if p
         )
         log_warning(
             f"No complete ACCOUNT_*_N triples in {srcs or 'the account source(s)'}; "

--- a/loom-tools/src/loom_tools/tokens/cli.py
+++ b/loom-tools/src/loom_tools/tokens/cli.py
@@ -49,8 +49,10 @@ def _build_parser() -> argparse.ArgumentParser:
     bp = sub.add_parser(
         "bootstrap",
         help=(
-            "Materialize .loom/tokens/ from ACCOUNT_*_N triples, merging the "
-            "home master (~/.loom/accounts.env) with the repo-local source. "
+            "Materialize .loom/tokens/ from ACCOUNT_*_N triples, merging three "
+            "sources by email with precedence claude-monitor "
+            "(~/.claude-monitor/accounts.env, primary) > repo-local > home "
+            "master (~/.loom/accounts.env, still-read fallback). "
             "ACCOUNT_TOKEN_FILE_N is optional: when omitted it is auto-derived "
             "from ACCOUNT_EMAIL_N (e.g. alice@example.com -> alice-example.token)."
         ),
@@ -70,7 +72,9 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help=(
             "Path to the home-dir master account source (default: "
-            "$LOOM_ACCOUNTS_ENV or ~/.loom/accounts.env)."
+            "$LOOM_ACCOUNTS_ENV or ~/.loom/accounts.env). This is a still-read "
+            "fallback below the claude-monitor master (~/.claude-monitor/"
+            "accounts.env), which is always consulted when present."
         ),
     )
     bp.add_argument(
@@ -297,11 +301,13 @@ def _cmd_bootstrap(args: argparse.Namespace) -> int:
     return 0
 
 
-# Human-readable label for each provenance tag from the merge (#3695).
+# Human-readable label for each provenance tag from the merge (#3695, #3698).
 _SOURCE_LABEL = {
     "home": "home",
     "repo": "repo",
     "repo-override": "repo (overrides home)",
+    "monitor": "claude-monitor",
+    "monitor-override": "claude-monitor (overrides repo/home)",
 }
 
 
@@ -313,10 +319,12 @@ def _print_effective_accounts(result: "object") -> None:
     shown — only email, token filename, and source.
     """
     effective = getattr(result, "effective", []) or []
+    monitor_env = getattr(result, "monitor_env", None)
     home_env = getattr(result, "home_env", None)
     repo_env = getattr(result, "repo_env", None)
 
     print("Account sources:")
+    print(f"  claude-monitor: {monitor_env if monitor_env else '(none)'}")
     print(f"  home: {home_env if home_env else '(none)'}")
     print(f"  repo: {repo_env if repo_env else '(none)'}")
 

--- a/loom-tools/tests/tokens/test_bootstrap.py
+++ b/loom-tools/tests/tokens/test_bootstrap.py
@@ -17,6 +17,7 @@ from loom_tools.tokens.bootstrap import (
     _TOKEN_FILE_RE,
     _strip_value,
     bootstrap_tokens,
+    default_claude_monitor_accounts_env,
     default_home_accounts_env,
     derive_token_filename,
     fingerprint,
@@ -757,3 +758,332 @@ class TestBackwardCompat3697:
         )
         result = bootstrap_tokens(mock_repo)
         assert result.written == ["custom-a.token"]
+
+
+# ---------------------------------------------------------------------------
+# #3698: claude-monitor-first account sourcing (additive three-source merge)
+# ---------------------------------------------------------------------------
+
+
+def _pair(i: int, email: str, key: str) -> str:
+    """A claude-monitor-style EMAIL+KEY-only entry (no TOKEN_FILE)."""
+    return f"ACCOUNT_EMAIL_{i}={email}\nACCOUNT_KEY_{i}={key}\n"
+
+
+def _write_monitor(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    body: str,
+) -> pathlib.Path:
+    """Materialize a fixture ``~/.claude-monitor/accounts.env`` and point the
+    ``LOOM_CLAUDE_MONITOR_DIR`` override at it (the autouse conftest fixture
+    otherwise points it at a non-existent path so a real dir never leaks in)."""
+    mon_dir = tmp_path / "claude-monitor-home"
+    mon_dir.mkdir(exist_ok=True)
+    accounts = mon_dir / "accounts.env"
+    accounts.write_text(body, encoding="utf-8")
+    monkeypatch.setenv("LOOM_CLAUDE_MONITOR_DIR", str(mon_dir))
+    return accounts
+
+
+class TestClaudeMonitorResolver:
+    def test_default_dir_honors_env_override(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("LOOM_CLAUDE_MONITOR_DIR", str(tmp_path / "mon"))
+        p = default_claude_monitor_accounts_env()
+        assert p == tmp_path / "mon" / "accounts.env"
+
+    def test_default_dir_is_claude_monitor(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("LOOM_CLAUDE_MONITOR_DIR", raising=False)
+        p = default_claude_monitor_accounts_env()
+        assert p.name == "accounts.env"
+        assert p.parent.name == ".claude-monitor"
+
+
+class TestBackwardCompat3698:
+    """The safety arbiter: nothing that resolves today may break."""
+
+    def test_home_only_still_bootstraps(
+        self, mock_repo: pathlib.Path, tmp_path: pathlib.Path, monkeypatch
+    ) -> None:
+        # ARBITER TEST: only ~/.loom/accounts.env, NO claude-monitor file.
+        # A pure default-swap to claude-monitor would break this; the additive
+        # design must keep it working byte-for-byte.
+        master = tmp_path / "loom-accounts.env"
+        master.write_text(
+            _triple(1, "a@example.com", "hk-a", "alice.token")
+            + _triple(2, "b@example.com", "hk-b", "bob.token"),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("LOOM_ACCOUNTS_ENV", str(master))
+        result = bootstrap_tokens(mock_repo)
+        assert sorted(result.written) == ["alice.token", "bob.token"]
+        assert result.monitor_env is None
+        assert result.home_env == master
+        tokens_dir = mock_repo / ".loom" / "tokens"
+        assert (tokens_dir / "alice.token").read_text() == "hk-a"
+        assert (tokens_dir / "bob.token").read_text() == "hk-b"
+        assert {e["source"] for e in result.effective} == {"home"}
+
+    def test_home_repo_merge_byte_for_byte_without_monitor(
+        self, mock_repo: pathlib.Path, tmp_path: pathlib.Path, monkeypatch
+    ) -> None:
+        # Absent the claude-monitor file, the home+repo merge is unchanged:
+        # repo still overrides home, repo-only adds, home-only inherits.
+        master = tmp_path / "loom-accounts.env"
+        master.write_text(
+            _triple(1, "shared@example.com", "home-key", "shared.token")
+            + _triple(2, "homeonly@example.com", "hk", "homeonly.token"),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("LOOM_ACCOUNTS_ENV", str(master))
+        _write_env(
+            mock_repo,
+            _triple(1, "shared@example.com", "repo-key", "shared.token")
+            + _triple(2, "repoonly@example.com", "rk", "repoonly.token"),
+        )
+        result = bootstrap_tokens(mock_repo)
+        assert result.monitor_env is None
+        tokens_dir = mock_repo / ".loom" / "tokens"
+        # Repo key wins for the shared email (repo-override).
+        assert (tokens_dir / "shared.token").read_text() == "repo-key"
+        assert (tokens_dir / "homeonly.token").read_text() == "hk"
+        assert (tokens_dir / "repoonly.token").read_text() == "rk"
+        sources = {e["email"]: e["source"] for e in result.effective}
+        assert sources == {
+            "shared@example.com": "repo-override",
+            "homeonly@example.com": "home",
+            "repoonly@example.com": "repo",
+        }
+
+    def test_loom_accounts_env_empty_still_disables_master(
+        self, mock_repo: pathlib.Path, monkeypatch
+    ) -> None:
+        # LOOM_ACCOUNTS_ENV="" still disables the home master; the repo source
+        # alone bootstraps (no claude-monitor file present).
+        monkeypatch.setenv("LOOM_ACCOUNTS_ENV", "")
+        _write_env(mock_repo, _triple(1, "a@example.com", "sk-1", "a.token"))
+        result = bootstrap_tokens(mock_repo)
+        assert result.home_env is None
+        assert result.monitor_env is None
+        assert result.written == ["a.token"]
+
+
+class TestClaudeMonitorSourcing:
+    def test_monitor_only_no_dead_end(
+        self, mock_repo: pathlib.Path, tmp_path: pathlib.Path, monkeypatch
+    ) -> None:
+        # Only ~/.claude-monitor/accounts.env populated (EMAIL+KEY only), no
+        # home master, no repo triples -> every account materialized via
+        # auto-derive; no account-resolution dead-end.
+        monkeypatch.setenv("LOOM_ACCOUNTS_ENV", "")  # disable home master
+        mon = _write_monitor(
+            tmp_path,
+            monkeypatch,
+            _pair(1, "alice@example.com", "mk-a")
+            + _pair(2, "a.b.jones@example.org", "mk-j"),
+        )
+        result = bootstrap_tokens(mock_repo)
+        assert result.monitor_env == mon
+        assert result.home_env is None
+        tokens_dir = mock_repo / ".loom" / "tokens"
+        assert (tokens_dir / "alice-example.token").read_text() == "mk-a"
+        assert (tokens_dir / "abjones-example.token").read_text() == "mk-j"
+        assert {e["source"] for e in result.effective} == {"monitor"}
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX modes only")
+    def test_monitor_token_files_mode_0600(
+        self, mock_repo: pathlib.Path, tmp_path: pathlib.Path, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("LOOM_ACCOUNTS_ENV", "")
+        _write_monitor(tmp_path, monkeypatch, _pair(1, "alice@example.com", "mk"))
+        bootstrap_tokens(mock_repo)
+        token_path = mock_repo / ".loom" / "tokens" / "alice-example.token"
+        assert os.stat(token_path).st_mode & 0o777 == 0o600
+
+    def test_monitor_overrides_repo(
+        self, mock_repo: pathlib.Path, tmp_path: pathlib.Path, monkeypatch
+    ) -> None:
+        # Same email in monitor and repo -> monitor key/file wins, provenance
+        # monitor-override; monitor-only adds; repo-only retained.
+        monkeypatch.setenv("LOOM_ACCOUNTS_ENV", "")
+        _write_monitor(
+            tmp_path,
+            monkeypatch,
+            _pair(1, "alice@example.com", "monitor-key")
+            + _pair(2, "monly@example.com", "mk-only"),
+        )
+        _write_env(
+            mock_repo,
+            _triple(1, "alice@example.com", "repo-key", "alice-example.token")
+            + _triple(2, "reponly@example.com", "rk", "reponly.token"),
+        )
+        result = bootstrap_tokens(mock_repo)
+        tokens_dir = mock_repo / ".loom" / "tokens"
+        # Monitor key wins on the shared email.
+        assert (tokens_dir / "alice-example.token").read_text() == "monitor-key"
+        assert (tokens_dir / "monly-example.token").read_text() == "mk-only"
+        assert (tokens_dir / "reponly.token").read_text() == "rk"
+        sources = {e["email"]: e["source"] for e in result.effective}
+        assert sources == {
+            "alice@example.com": "monitor-override",
+            "monly@example.com": "monitor",
+            "reponly@example.com": "repo",
+        }
+
+    def test_monitor_overrides_home(
+        self, mock_repo: pathlib.Path, tmp_path: pathlib.Path, monkeypatch
+    ) -> None:
+        # Precedence is claude-monitor > repo > home. An email in monitor and
+        # home resolves to the monitor key.
+        master = tmp_path / "loom-accounts.env"
+        master.write_text(
+            _triple(1, "alice@example.com", "home-key", "alice-example.token"),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("LOOM_ACCOUNTS_ENV", str(master))
+        _write_monitor(
+            tmp_path, monkeypatch, _pair(1, "alice@example.com", "monitor-key")
+        )
+        result = bootstrap_tokens(mock_repo)
+        tokens_dir = mock_repo / ".loom" / "tokens"
+        assert (tokens_dir / "alice-example.token").read_text() == "monitor-key"
+        assert result.effective[0]["source"] == "monitor-override"
+
+    def test_monitor_no_home_flag_keeps_monitor(
+        self, mock_repo: pathlib.Path, tmp_path: pathlib.Path, monkeypatch
+    ) -> None:
+        # --no-home (home_env_path=None) disables the home master but the
+        # claude-monitor source is independent and still consulted.
+        master = tmp_path / "loom-accounts.env"
+        master.write_text(
+            _triple(1, "homeonly@example.com", "hk", "homeonly.token"),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("LOOM_ACCOUNTS_ENV", str(master))
+        _write_monitor(
+            tmp_path, monkeypatch, _pair(1, "alice@example.com", "mk")
+        )
+        result = bootstrap_tokens(mock_repo, home_env_path=None)
+        assert result.home_env is None
+        assert result.monitor_env is not None
+        assert result.written == ["alice-example.token"]
+
+    def test_missing_monitor_dir_degrades_silently(
+        self, mock_repo: pathlib.Path, monkeypatch
+    ) -> None:
+        # LOOM_CLAUDE_MONITOR_DIR points at a non-existent dir (conftest
+        # default): no crash, no import — falls through to home+repo.
+        _write_env(mock_repo, _triple(1, "a@example.com", "sk-1", "a.token"))
+        result = bootstrap_tokens(mock_repo)
+        assert result.monitor_env is None
+        assert result.written == ["a.token"]
+
+    def test_monitor_index_records_provenance_no_secret(
+        self, mock_repo: pathlib.Path, tmp_path: pathlib.Path, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("LOOM_ACCOUNTS_ENV", "")
+        _write_monitor(
+            tmp_path, monkeypatch, _pair(1, "alice@example.com", "mk-secret")
+        )
+        bootstrap_tokens(mock_repo)
+        idx = json.loads(
+            (mock_repo / ".loom" / "tokens" / "index.json").read_text()
+        )
+        entry = idx["accounts"][0]
+        assert entry["source"] == "monitor"
+        assert entry["email"] == "alice@example.com"
+        # Secret hygiene: only a fingerprint, never the key material.
+        assert "mk-secret" not in json.dumps(idx)
+        assert "key" not in entry
+        assert len(entry["key_fingerprint"]) == 8
+
+
+class TestMonitorIdentityContinuity:
+    """Monitor-derived stems must match existing index.json stems so the
+    .ranking / .bad_tokens history keyed on the account name stays attached."""
+
+    def test_derive_matches_established_stems(self) -> None:
+        # The names the selector keys on are the derived stems; a monitor
+        # account for the same email derives the same name.
+        assert derive_token_filename("alice@example.com") == "alice-example.token"
+        assert (
+            derive_token_filename("a.b.jones@example.org") == "abjones-example.token"
+        )
+        assert derive_token_filename("agent-1@example.com") == "agent1-example.token"
+
+    def test_monitor_stem_matches_prior_index_stem(
+        self, mock_repo: pathlib.Path, tmp_path: pathlib.Path, monkeypatch
+    ) -> None:
+        # Bootstrap once from the repo (auto-derive), record the index stem,
+        # then bootstrap again with the same email sourced from claude-monitor:
+        # the stem (account name) is identical, so history stays attached.
+        monkeypatch.setenv("LOOM_ACCOUNTS_ENV", "")
+        _write_env(mock_repo, _pair(1, "alice@example.com", "repo-key"))
+        bootstrap_tokens(mock_repo)
+        idx_before = json.loads(
+            (mock_repo / ".loom" / "tokens" / "index.json").read_text()
+        )
+        name_before = idx_before["accounts"][0]["name"]
+
+        _write_monitor(
+            tmp_path, monkeypatch, _pair(1, "alice@example.com", "monitor-key")
+        )
+        bootstrap_tokens(mock_repo)
+        idx_after = json.loads(
+            (mock_repo / ".loom" / "tokens" / "index.json").read_text()
+        )
+        name_after = idx_after["accounts"][0]["name"]
+        assert name_after == name_before == "alice-example"
+
+    def test_monitor_repo_overlap_collapses_not_duplicate_abort(
+        self, mock_repo: pathlib.Path, tmp_path: pathlib.Path, monkeypatch
+    ) -> None:
+        # Same email in monitor and repo derives the same filename; the merge
+        # collapses them to one account (override) — it must NOT trip the
+        # duplicate-filename guard.
+        monkeypatch.setenv("LOOM_ACCOUNTS_ENV", "")
+        _write_monitor(
+            tmp_path, monkeypatch, _pair(1, "alice@example.com", "monitor-key")
+        )
+        _write_env(mock_repo, _pair(1, "alice@example.com", "repo-key"))
+        result = bootstrap_tokens(mock_repo)  # must not raise ValueError
+        assert result.written == ["alice-example.token"]
+        tokens_dir = mock_repo / ".loom" / "tokens"
+        assert (tokens_dir / "alice-example.token").read_text() == "monitor-key"
+
+    def test_true_cross_source_collision_still_aborts(
+        self, mock_repo: pathlib.Path, tmp_path: pathlib.Path, monkeypatch
+    ) -> None:
+        # Distinct emails whose derived filenames collide is still a real
+        # clobber and must abort (guard runs on the merged set).
+        monkeypatch.setenv("LOOM_ACCOUNTS_ENV", "")
+        _write_monitor(
+            tmp_path, monkeypatch, _pair(1, "ajones@example.com", "mk")
+        )
+        _write_env(mock_repo, _pair(1, "a.jones@example.com", "rk"))
+        with pytest.raises(ValueError, match="duplicate token filename"):
+            bootstrap_tokens(mock_repo)
+
+
+class TestCliMonitorReporting:
+    def test_effective_report_shows_monitor_provenance(
+        self,
+        mock_repo: pathlib.Path,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("LOOM_ACCOUNTS_ENV", "")
+        _write_monitor(
+            tmp_path, monkeypatch, _pair(1, "alice@example.com", "mk")
+        )
+        monkeypatch.chdir(mock_repo)
+        rc = cli_main(["bootstrap", "--dry-run"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "claude-monitor" in out
+        assert "alice" in out


### PR DESCRIPTION
## Summary

Follow-up to merged #3699. Makes claude-monitor's `~/.claude-monitor/accounts.env` the **primary, highest-precedence** account source in `bootstrap.py`, implemented as an **additive three-source merge** (NOT a pure default-swap) so no currently-resolving setup breaks.

Precedence on email conflict: **claude-monitor > repo > home**.

The `~/.loom/accounts.env` home master is **demoted from top default to a still-read fallback** — the capability is never removed, only the default changed. `LOOM_ACCOUNTS_ENV` stays honored exactly as in #3695.

## What changed

- **`bootstrap.py`**: new `default_claude_monitor_accounts_env()` resolver (reuses `monitor.claude_monitor_dir()`, honoring `LOOM_CLAUDE_MONITOR_DIR`; soft dependency, no claude-monitor package import). Generalized `merge_accounts` with an `override_label` param and applied it twice: `merge(home, repo)` (→ `repo-override`) then `merge(<that>, monitor, "monitor-override")`. Absent the monitor file the second merge is a no-op, so behavior is **byte-for-byte identical** to the #3695 home+repo merge. Added `BootstrapResult.monitor_env`.
- **`cli.py`**: `_SOURCE_LABEL` + `_print_effective_accounts` report the new `monitor` / `monitor-override` provenance; refreshed `bootstrap` and `--home-env` help text.
- **`spawn_loop_state.py`**: doc-only rename of a stale placeholder to a generic one (no behavior change).

## Safety design (the point of this issue)

- claude-monitor entries are EMAIL+KEY only → the #3699 auto-derive materializes token filenames; derived stems match existing `index.json` stems so `.ranking`/`.bad_tokens` history stays attached.
- monitor+repo email overlap is an **override** (collapses to one account), never a duplicate-filename abort; a *true* distinct-email filename collision still aborts.

## Tests

New classes in `test_bootstrap.py` cover: the **arbiter** back-compat test (`~/.loom`-only, no monitor → all accounts resolve), byte-for-byte home+repo merge without monitor, monitor-only (no dead-end) with 0600 modes, monitor > repo and monitor > home precedence, identity continuity, override-not-duplicate-abort, `LOOM_CLAUDE_MONITOR_DIR` override + silent degrade, `--no-home` alongside monitor, secret hygiene, and CLI provenance reporting.

`PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/tokens/ -q` → **224 passed**.

No personal/employment context: `grep -rniE "2amlogic|integratedplasmonics|spheresemi|r\.j\.walters|\brobb\b" loom-tools/` → **zero matches**.

Closes #3698

🤖 Generated with [Claude Code](https://claude.com/claude-code)