### PR TITLE
chore(tokens): drop extraneous f-string prefixes in _cmd_unblock (F541)

### DIFF
--- a/loom-tools/src/loom_tools/tokens/cli.py
+++ b/loom-tools/src/loom_tools/tokens/cli.py
@@ -674,8 +674,8 @@ def _cmd_unblock(args: argparse.Namespace) -> int:
             )
         else:
             log_info(
-                f"No matching entries removed (use --all-reasons to drop "
-                f"non-auth entries too).",
+                "No matching entries removed (use --all-reasons to drop "
+                "non-auth entries too).",
             )
     return 0
 


### PR DESCRIPTION
Removes the `f` prefix from two placeholder-free strings in `_cmd_unblock` (ruff `F541`). Pre-existing lint debt surfaced during the #3697 / #3698 Judge reviews. No behavior change; 224 token tests pass; `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)