### PR TITLE
feat(sweep): effort-aware rung grammar, complexity marker, refusal fallback (#3702)

### DIFF
--- a/defaults/.claude/commands/loom/curator.md
+++ b/defaults/.claude/commands/loom/curator.md
@@ -444,6 +444,19 @@ fi
 - Estimate complexity and effort when helpful
 - Break down large features into phased deliverables
 
+### Complexity routing marker (`<!-- loom:complexity=complex -->`, issue #3702)
+
+When your enhancement pass judges an issue to be **genuinely complex** — long-horizon implementation, deep cross-cutting reasoning, or high blast radius (not merely "a bit of work") — you MAY emit a single machine-readable marker into the curated issue body so the sweep orchestrator routes the Builder to a more capable model:
+
+```html
+<!-- loom:complexity=complex -->
+```
+
+- **Format**: an HTML comment (invisible in rendered Markdown, trivially greppable). Values are `routine` | `complex`. Put it in your enhancement section (e.g. near the Problem Statement). **Absent marker ⇒ `routine`** — most issues need no marker.
+- **What it does**: at Builder dispatch the sweep skill reads it as precedence **tier 2.5** (between tiers 2 and 3) and bumps the Builder's role-default model up **exactly one tier** — `sonnet → opus`. See `sweep.md` → "Tier 2.5 — Curator complexity marker".
+- **Hard bounds** (the router's authority is deliberately bounded): **one bump maximum, never to `fable`, and never a label.** Emitting `complex` cannot reach the top (frontier) model — that is reserved for the objective escalation ladder on Judge rejection or an explicit operator param. A `roleConfig.model` pin or explicit dispatch param (tiers 1–2) still overrides the marker.
+- **Use sparingly.** A miscalibrated `complex` only spends one tier of extra cost and the Judge gate still corrects any miss; but marking everything `complex` defeats the cheap-first default. Emit it only when the complexity is real. Do **not** emit `<!-- loom:complexity=routine -->` explicitly — an absent marker already means routine.
+
 ## Where to Add Enhancements
 
 **Use a hybrid approach** based on issue quality:

--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -381,6 +381,16 @@ Every role subagent dispatched by this skill (`loom-curator`, `loom-builder`, `l
 3. **Role default** — `.loom/roles/<role>.json` → `suggestedModel` (ships as an alias: `sonnet`, `opus`, or `haiku`).
 4. **Session default** — if none of the above resolves (or resolves to an empty string), **omit the `model` parameter entirely** so the subagent inherits the parent session's model. Never pass `model: ""`.
 
+**Tier 2.5 — Curator complexity marker (issue #3702, Builder dispatch only)**: between tier 2 and tier 3, at **Builder** dispatch, grep the issue body for the Curator-emitted marker `<!-- loom:complexity=complex -->` (an HTML comment, values `routine` | `complex`; see `curator.md`). When it is present and reads `complex`, bump the Builder's tier-3 (`suggestedModel`) resolution up **exactly one model tier** — `sonnet → opus` — before dispatch. Hard bounds, all enforced here:
+
+- **One bump maximum, and never to `fable`.** The marker can lift `sonnet → opus` and nothing further; it can never reach the top (`fable`) rung. Fable is reached only via the escalation ladder (objective Judge-rejection evidence) or an explicit operator param, never on a Curator's speculation.
+- **It is not a label** and creates no label — it lives only in the issue body.
+- **Tier-1 and tier-2 pins still win.** The marker sits *strictly between* tiers 2 and 3: an explicit dispatch param (tier 1) or a `roleConfig.model` workspace pin (tier 2) overrides it, exactly as they override tier 3.
+- **Absent / `routine` / malformed marker ⇒ no bump** — behaviour is byte-for-byte identical to today's precedence chain. Existing curated issues (which carry no marker) are unaffected.
+- The marker applies **only to the Builder path**. It never influences Curator, Judge, or Doctor resolution.
+
+**No-Fable-Judge hard invariant (issue #3702)**: **Judge model resolution can never resolve to `fable`, regardless of `sweep.escalation` contents or any marker.** The escalation ladder and the tier-2.5 marker apply only to the Curator-marker→Builder path and to the rejection-triggered Doctor — never to Judge. The Judge is the escalation sensor (see #3481); reviewing security-adjacent diffs is precisely Fable's refusal surface, and a refusing Judge would deadlock the control loop. If a resolved Judge model would ever be `fable` (alias or pinned ID), fall back to `opus` for the Judge dispatch and log the substitution.
+
 Rules:
 
 - Aliases (`sonnet`/`opus`/`haiku`) and pinned IDs (`claude-sonnet-4-6`) are both valid at every tier. Shipped role JSONs use aliases; workspaces that need determinism pin exact IDs in `roleConfig.model`.
@@ -419,6 +429,36 @@ Rules:
 4. **Mode C inherits the rule** — C1b runs the identical Doctor phase under the identical cap, so the identical `ladder[1]` rule applies. No separate policy.
 5. **Resume safety**: the escalation decision derives from the `loom:changes-requested` label/phase, **not** from a stored counter — so a sweep killed between Doctor dispatch and the follow-up Judge resumes correctly: re-entry routes back through the Doctor/Judge phases per the checkpoint skip rules, and any re-dispatched rejection-triggered Doctor escalates again. The optional `attempt` field on the sweep checkpoint (`sweep-checkpoint.sh write N doctor-done ... --attempt 2`) is forward-compat bookkeeping for a future cap raise; readers treat an absent field as attempt 1.
 6. **The orchestrator decides, never the wrapper**: escalation is resolved here at Doctor-dispatch time. `claude-wrapper.sh` / `spawn-claude.sh` retries always keep their model (transport failures are not quality signals), and no wrapper change is involved.
+
+### Effort-aware rung grammar, the `fable` rung, and refusal fallback (issue #3702)
+
+This subsection extends the `sweep.escalation` ladder above with an optional richer rung grammar and a top `fable` rung. It is **fully additive and opt-in**: the shipped default ladder stays `["sonnet", "opus"]` with `max_doctor_cycles` `1`, and bare-alias configs parse and behave byte-for-byte as documented above. Nothing here changes default behaviour.
+
+**Rung grammar — `model@effort`.** Each rung in `sweep.escalation` is either:
+
+- a **bare alias** (or pinned ID) — `"opus"` resolves to `(model=opus, no effort override)`, exactly as today; or
+- an **`alias@effort`** form — `"sonnet@xhigh"` resolves to `(model=sonnet, effort=xhigh)`. The part before `@` is the model (alias or pinned ID); the part after `@` is the effort level passed through to the dispatched role.
+
+Escalating the cheaper dimension first (`sonnet → sonnet@xhigh → opus → fable`) retries at ~Sonnet cost before committing to Opus's higher output pricing. A rung with no `@` never carries an effort override, so existing arrays are unaffected.
+
+**Effort graceful degradation.** If per-dispatch effort plumbing (through the Task tool / `claude` CLI) is **not** available in this environment, an `alias@effort` rung **resolves to the bare model** (the `@effort` suffix is dropped) and the orchestrator emits a **loud log line** noting the degradation, e.g. `escalation: effort plumbing unavailable — rung 'sonnet@xhigh' degraded to bare model 'sonnet'`. The grammar ships either way so configs stay stable across environments; when plumbing later lands, the same config activates the effort bump with no edit.
+
+**The `fable` rung.** `fable` (alias, or a pinned frontier-model ID where alias resolution is unavailable at a given tier — do not hard-code a specific ID into shipped defaults) is a valid **top** rung. Because the ladder is consumed as `ladder[min(attempt - 1, len - 1)]` under the Doctor-cycle cap, a `fable` rung placed at index ≥ 3 is only ever reached when `max_doctor_cycles ≥ 3` — i.e. it is **opt-in** and never appears on the shipped default ladder.
+
+**Recommended opt-in deep-ladder recipe** (`.loom/config.json`) — pairs a 4-rung ladder with the cap raise required to reach its deeper rungs (see "Doctor-cycle cap" below):
+
+```json
+{
+  "sweep": {
+    "escalation": ["sonnet", "sonnet@xhigh", "opus", "fable"],
+    "max_doctor_cycles": 3
+  }
+}
+```
+
+**Refusal-aware fallback for the `fable` rung.** Fable-class safety classifiers refuse some legitimate security-adjacent work (guard hooks, OAuth token handling, credential scanning) with `stop_reason: "refusal"` — which `classify_error` (`.loom/scripts/lib/classify-error.sh`) reports as `MODEL_REFUSAL`. On a `MODEL_REFUSAL` at a `fable` rung, the orchestrator **re-dispatches the same attempt one rung down** (`fable → opus`) **without consuming a Doctor cycle**. A refusal is a *routing error*, not a quality signal, so it must not eat the escalation / `max_doctor_cycles` budget: the `attempt` counter is unchanged, and the retried Doctor is still the same cycle `k`. This is distinct from a Judge rejection (which advances the attempt and escalates *up*). Only the `fable` rung has a rung below it to fall to; a `MODEL_REFUSAL` at a non-`fable` rung is handled by the normal error path.
+
+**No-Fable-Judge invariant (restated).** Judge dispatch never resolves to `fable`, regardless of ladder contents — see the invariant under "Model selection for subagent dispatch". The ladder here governs only the rejection-triggered Doctor.
 
 ### Doctor-cycle cap (`sweep.max_doctor_cycles`, issue #3668)
 

--- a/defaults/scripts/lib/classify-error.sh
+++ b/defaults/scripts/lib/classify-error.sh
@@ -9,6 +9,11 @@
 #       CWD_DELETED     — working directory was removed
 #       TOKEN_EXPIRED   — 401 / OAuth token expired (skip this token)
 #       TOKEN_EXHAUSTED — quota/weekly limit hit (rotate)
+#       MODEL_REFUSAL   — model safety classifier refused the turn
+#                         (stop_reason "refusal" on a non-zero-exit run);
+#                         a routing error, not a quality signal — the sweep
+#                         orchestrator drops one ladder rung (e.g. fable→opus)
+#                         WITHOUT consuming a Doctor cycle (see sweep.md).
 #       RECOVERABLE     — transient (rate limit, 5xx, network, etc.)
 #       FATAL           — non-recoverable (currently never returned;
 #                         reserved for future explicit FATAL signals)
@@ -48,6 +53,18 @@ classify_error() {
     # Working directory deleted (worktree cleaned up while CLI ran)
     if echo "$output" | grep -qi "current working directory was deleted"; then
         echo "CWD_DELETED"
+        return
+    fi
+
+    # Model refusal (safety classifier declined the turn) — a `stop_reason`
+    # of "refusal" on a non-zero-exit run. This is a routing error, not a
+    # transport failure or a quality signal: the sweep orchestrator responds
+    # by dropping one ladder rung (e.g. fable→opus) WITHOUT consuming a Doctor
+    # cycle (see sweep.md, "Refusal-aware fallback"). Matched only on a genuine
+    # failure (exit_code != 0) so the exit-code-first #3233 guarantee holds — a
+    # clean exit whose output merely mentions "refusal" stays SUCCESS above.
+    if echo "$output" | grep -qiE '"?stop_reason"?[[:space:]]*[:=][[:space:]]*"?refusal'; then
+        echo "MODEL_REFUSAL"
         return
     fi
 

--- a/defaults/scripts/tests/test-spawn-claude.sh
+++ b/defaults/scripts/tests/test-spawn-claude.sh
@@ -134,6 +134,31 @@ assert_eq "CWD_DELETED" "$result" "cwd deleted -> CWD_DELETED"
 result=$(classify_error "" 2)
 assert_eq "RECOVERABLE" "$result" "unknown exit=2 -> RECOVERABLE"
 
+# --- MODEL_REFUSAL vectors (issue #3702) ---
+# A model safety-classifier refusal (stop_reason "refusal") on a non-zero-exit
+# run classifies as MODEL_REFUSAL — a routing error the sweep orchestrator
+# handles by dropping one ladder rung without consuming a Doctor cycle.
+
+# Vector #19: JSON-shaped stop_reason refusal + exit=1 → MODEL_REFUSAL
+result=$(classify_error '{"type":"message","stop_reason":"refusal"}' 1)
+assert_eq "MODEL_REFUSAL" "$result" 'stop_reason:"refusal" + exit=1 -> MODEL_REFUSAL'
+
+# Vector #20: spaced stop_reason = refusal + exit=1 → MODEL_REFUSAL
+result=$(classify_error "turn ended: stop_reason: refusal (safety)" 1)
+assert_eq "MODEL_REFUSAL" "$result" "spaced stop_reason refusal + exit=1 -> MODEL_REFUSAL"
+
+# Vector #21 (REGRESSION, #3233): clean exit (exit 0) whose output merely
+# contains the word "refusal" is STILL SUCCESS — exit-code-first ordering wins
+# over any substring, including the new refusal match.
+result=$(classify_error '{"stop_reason":"refusal"}' 0)
+assert_eq "SUCCESS" "$result" 'exit=0 with stop_reason:"refusal" is SUCCESS (#3233 exit-code-first)'
+
+# Vector #22: plain word "refusal" without a stop_reason on exit=1 is NOT a
+# refusal classification — the match is anchored to the stop_reason key, so an
+# unrelated failure mentioning the word falls through to the catch-all.
+result=$(classify_error "connection reset; will not retry (refusal to reconnect)" 1)
+assert_eq "RECOVERABLE" "$result" "bare 'refusal' word (no stop_reason) + exit=1 -> RECOVERABLE"
+
 # ============================================================
 # Section 2: spawn-claude.sh dispatch (with stub `claude`)
 # ============================================================

--- a/loom-daemon/tests/sweep_md_doc_lint.rs
+++ b/loom-daemon/tests/sweep_md_doc_lint.rs
@@ -119,3 +119,91 @@ fn sweep_md_includes_sample_wire_payloads() {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// Issue #3702 — model-assignment strategy: rung grammar, complexity marker,
+// refusal fallback, and the no-Fable-Judge invariant.
+//
+// The ladder, precedence chain, `model@effort` grammar, and tier-2.5 marker
+// are PROSE CONTRACTS the sweep orchestrator (an LLM subagent) interprets at
+// dispatch time — there is no parser to unit-test. These string assertions
+// pin the contract so a future edit can't silently drop it.
+// ---------------------------------------------------------------------------
+
+/// #3702: the `model@effort` rung grammar and the `fable` top rung are
+/// documented, with the effort graceful-degradation contract.
+#[test]
+fn sweep_md_documents_effort_rung_grammar_and_fable() {
+    let content = read_sweep_md();
+    let required: &[&str] = &[
+        // Rung grammar: bare alias vs alias@effort.
+        "alias@effort",
+        "sonnet@xhigh",
+        "(model=sonnet, effort=xhigh)",
+        // Effort-before-model escalation ordering.
+        "sonnet → sonnet@xhigh → opus → fable",
+        // Graceful degradation when per-dispatch effort plumbing is absent.
+        "grammar ships either way",
+        // The fable top rung.
+        "fable",
+    ];
+    for needle in required {
+        assert!(
+            content.contains(needle),
+            "sweep.md is missing #3702 rung-grammar/fable prose `{needle}` — \
+             update sweep.md or this test if the change is intentional"
+        );
+    }
+}
+
+/// #3702: the Curator complexity marker is documented as precedence tier 2.5
+/// with its one-bump/never-fable/never-a-label bounds.
+#[test]
+fn sweep_md_documents_complexity_marker_tier() {
+    let content = read_sweep_md();
+    let required: &[&str] = &[
+        "<!-- loom:complexity=complex -->",
+        "Tier 2.5 — Curator complexity marker",
+        "sonnet → opus",
+        "One bump maximum, and never to",
+    ];
+    for needle in required {
+        assert!(
+            content.contains(needle),
+            "sweep.md is missing #3702 complexity-marker prose `{needle}` — \
+             update sweep.md or this test if the change is intentional"
+        );
+    }
+}
+
+/// #3702: a `MODEL_REFUSAL` at a fable rung drops one rung down WITHOUT
+/// consuming a Doctor cycle.
+#[test]
+fn sweep_md_documents_refusal_fallback() {
+    let content = read_sweep_md();
+    assert!(
+        content.contains("MODEL_REFUSAL"),
+        "sweep.md must reference the `MODEL_REFUSAL` class (#3702 refusal fallback)"
+    );
+    assert!(
+        content.contains("without consuming a Doctor cycle"),
+        "sweep.md must state the refusal fallback re-dispatches without \
+         consuming a Doctor cycle (#3702)"
+    );
+    assert!(
+        content.contains("fable → opus"),
+        "sweep.md must document the fable→opus one-rung-down refusal fallback (#3702)"
+    );
+}
+
+/// #3702: the hard invariant that Judge model resolution can never resolve to
+/// `fable`, regardless of ladder contents or any marker.
+#[test]
+fn sweep_md_asserts_no_fable_judge_invariant() {
+    let content = read_sweep_md();
+    assert!(
+        content.contains("Judge model resolution can never resolve to"),
+        "sweep.md must state the no-Fable-Judge hard invariant verbatim \
+         (#3702): `Judge model resolution can never resolve to `fable`...`"
+    );
+}


### PR DESCRIPTION
Closes #3702

## Summary

Implements the **inert, opt-in** model-assignment machinery from the #3702 proposal (Phases 1 + 2). Every change is additive and backward-compatible: a config with no changes behaves byte-for-byte as on current `main`. The new grammar/marker/refusal-class are dormant unless opted in. **No shipped defaults change** — `builder.json`/`judge.json` `suggestedModel`, the default `["sonnet","opus"]` ladder, and `max_doctor_cycles: 1` are untouched.

## Changes

1. **`model@effort` rung grammar** (`sweep.md`, prose contract) — each `sweep.escalation` rung is either a bare alias (unchanged) or `alias@effort` (e.g. `sonnet@xhigh` → `(model=sonnet, effort=xhigh)`). Documents graceful degradation to the bare model, loudly logged, when per-dispatch effort plumbing is unavailable (grammar ships either way).
2. **`fable` top rung** (`sweep.md`) — reachable only with `max_doctor_cycles ≥ 3` via the `ladder[min(attempt-1,len-1)]` consumption rule; never on the shipped default ladder. Includes the recommended opt-in deep-ladder recipe.
3. **`MODEL_REFUSAL` error class** (`classify-error.sh`, the one executable change) — classifies a `stop_reason: "refusal"` on a **non-zero-exit** run. Exit-code-first ordering (#3233) is preserved: a clean exit whose output merely contains "refusal" is still `SUCCESS`. On a `MODEL_REFUSAL` at a `fable` rung the orchestrator re-dispatches the same attempt one rung down (`fable → opus`) **without consuming a Doctor cycle** (documented in `sweep.md`).
4. **Curator complexity marker** — new `<!-- loom:complexity=complex -->` body marker (values `routine`|`complex`, absent ⇒ `routine`). Emit side documented in `curator.md`; consumed by sweep as precedence **tier 2.5** (between tiers 2 and 3) at Builder dispatch, bumping `sonnet → opus`. Bounded: one bump max, never `fable`, never a label; tier-1/tier-2 pins still win.
5. **No-Fable-Judge hard invariant** — `sweep.md` states Judge model resolution can never resolve to `fable` regardless of ladder/marker; pinned by a doc-lint assertion.

## Plumbing note (per issue request)

Per-dispatch **effort** plumbing (a distinct `effort` knob passed through the Task tool / `claude` CLI alongside `--model`) is **not** currently wired in the sweep dispatch path — the existing model plumbing (`spawn-claude.sh`, Task `model` param) carries model only. The grammar therefore ships with the documented graceful-degradation contract: an `alias@effort` rung resolves to the bare model, loudly logged, until effort plumbing lands. The contract ships now so configs stay stable across environments.

## Tests

- `bash defaults/scripts/tests/test-spawn-claude.sh` → **40 passed** (existing 18 classify vectors unchanged + 4 new `MODEL_REFUSAL` vectors incl. the #3233 exit-code-first regression guard).
- `cargo test --test sweep_md_doc_lint` → **8 passed** (existing 4 + 4 new: grammar/fable, marker tier, refusal fallback, no-Fable-Judge invariant).
- Regression (unmodified): `test-sweep-checkpoint.sh` 57/57, `test-sweep-pr-mode.sh` 58/58, `cargo test --test sweep_md_stage_minus_one_doc_lint` 9/9.

## Scope discipline

Edited only `defaults/` + real tracked paths (dogfood symlinks account for the live tree). Out of scope and untouched: any default model/ladder/cap flip (Phase 3 / D5 measure-then-tune), the `builder-complexity.md` defect. Diff grepped clean of personal/employment context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)