### PR TITLE
feat(tokens): retire ~/.loom/accounts.env as the default account source (#3704)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -371,24 +371,27 @@ Each account becomes `.loom/tokens/<file>.token` (mode `0600`). An `index.json` 
 
 `.loom/tokens/` is gitignored. The pool is consumed by external rotation logic (e.g. a `claude-wrapper.sh` that picks the least-used token); only the bootstrap step is provided here.
 
-#### Home-dir master + per-repo override (#3695)
+#### Account sources: claude-monitor-first + per-repo (#3695, #3698, #3704)
 
-Rather than re-declaring the same account triples in every repo's `.env`, declare them **once** in a home-dir master and let each workspace add or override on top of it:
+Rather than re-declaring the same account triples in every repo's `.env`, declare them **once** in the shared claude-monitor master and let each workspace add or override on top of it. Sources are merged by account email in precedence order:
 
 | Source | Default location | Override |
 |--------|------------------|----------|
-| **Home master** | `~/.loom/accounts.env` | `LOOM_ACCOUNTS_ENV` env var (`""` disables the master); `--home-env <path>` / `--no-home` on `bootstrap` |
+| **claude-monitor master** (primary) | `~/.claude-monitor/accounts.env` | `LOOM_CLAUDE_MONITOR_DIR` env var (directory) |
 | **Repo-local** | `<repo>/.loom/accounts.env` if present, else legacy `<repo>/.env` | `--env <path>` on `bootstrap` |
+| **Home master** (opt-in only, #3704) | *no default location* — read **only** when explicitly pointed at | `LOOM_ACCOUNTS_ENV` env var (a path enables it, `""` disables); `--home-env <path>` / `--no-home` on `bootstrap` |
 
-`loom-tokens bootstrap` reads both sources and **merges them by account email** (`ACCOUNT_EMAIL`), with the repo-local source winning:
+**Default resolution is claude-monitor → repo `.env`.** The `~/.loom/accounts.env` home master is **no longer auto-read** (#3704 retired the default location): it is consulted only when an operator opts in via `LOOM_ACCOUNTS_ENV=<path>` (conventionally `~/.loom/accounts.env`) or `--home-env <path>`. This retires the default *location*, not the *capability*.
 
-- An email present **only in the master** is inherited into the pool.
-- An email present **only in the repo** is added.
-- An email present in **both** → the repo entry overrides (e.g. to rotate a key or repoint the token file).
+`loom-tokens bootstrap` reads the available sources and **merges them by account email** (`ACCOUNT_EMAIL`), with the higher-precedence source winning:
 
-To *exclude* a master account from one repo, pin the subset you want with `loom-tokens pin` — the merge only ever adds/overrides, never subtracts. The effective merged set (and where each account came from) is printed by `bootstrap` and `bootstrap --dry-run`. A repo with only a legacy `.env` and no master behaves exactly as before.
+- An email present **only in a lower-precedence source** is inherited into the pool.
+- An email present **only in a higher-precedence source** is added.
+- An email present in **both** → the higher-precedence entry overrides (e.g. to rotate a key or repoint the token file).
 
-> **Secrets**: both `~/.loom/accounts.env` and the repo-local `.loom/accounts.env` hold raw OAuth keys. The repo-local file and `.loom/tokens/` are gitignored (installer- and `loom-daemon init`–managed); keep the home master `0600` and outside any repo. A repo can rely entirely on the home master with no local account file at all.
+To *exclude* an inherited account from one repo, pin the subset you want with `loom-tokens pin` — the merge only ever adds/overrides, never subtracts. The effective merged set (and where each account came from) is printed by `bootstrap` and `bootstrap --dry-run`. A repo with only a legacy `.env` and no other source behaves exactly as before.
+
+> **Secrets**: `~/.claude-monitor/accounts.env`, the opt-in `~/.loom/accounts.env`, and the repo-local `.loom/accounts.env` all hold raw OAuth keys. The repo-local file and `.loom/tokens/` are gitignored (installer- and `loom-daemon init`–managed); keep any home-level master `0600` and outside any repo. A repo can rely entirely on the claude-monitor master with no local account file at all.
 
 #### Account health probe + ranking
 
@@ -479,16 +482,16 @@ For Pro/Max plans, Loom supports rotating between multiple Claude Code OAuth tok
 
 ### Setup
 
-1. Declare account credentials once in the home-dir master `~/.loom/accounts.env` (shared across every workspace, #3695) — or per-repo in `<repo>/.loom/accounts.env` (falls back to legacy `<repo>/.env`):
+1. Declare account credentials in a default source — the shared claude-monitor master `~/.claude-monitor/accounts.env` (primary) or per-repo in `<repo>/.loom/accounts.env` (falls back to legacy `<repo>/.env`). The `~/.loom/accounts.env` home master is **opt-in only** since #3704 (no longer auto-read); point `LOOM_ACCOUNTS_ENV=~/.loom/accounts.env` (or `--home-env <path>`) at it to enable:
    ```env
-   ACCOUNT_EMAIL_1=robb-personal@example.com
+   ACCOUNT_EMAIL_1=account-one@example.com
    ACCOUNT_KEY_1=sk-ant-oat01-...
-   ACCOUNT_TOKEN_FILE_1=robb-personal.token
-   ACCOUNT_EMAIL_2=robb-work@example.com
+   ACCOUNT_TOKEN_FILE_1=account-one.token
+   ACCOUNT_EMAIL_2=account-two@example.com
    ACCOUNT_KEY_2=sk-ant-oat01-...
-   ACCOUNT_TOKEN_FILE_2=robb-work.token
+   ACCOUNT_TOKEN_FILE_2=account-two.token
    ```
-   The home master and repo-local source are **merged by email**, with the repo overriding/adding (see "Home-dir master + per-repo override" above). Keep the master `0600` and outside any repo.
+   The claude-monitor, repo-local, and (opt-in) home sources are **merged by email**, with the higher-precedence source overriding/adding (see "Account sources: claude-monitor-first + per-repo" above). Keep any home-level master `0600` and outside any repo.
 2. Run `loom-tokens bootstrap` to materialize the merged set into per-account `.token` files in `.loom/tokens/` (mode 0600, parent dir 0700). See issues #3234, #3695.
 3. Spawn agents through `.loom/scripts/spawn-claude.sh` instead of invoking `claude` directly. The wrapper selects a token using a 3-tier algorithm (ranking → allowlist → random), exports `CLAUDE_CODE_OAUTH_TOKEN`, then `exec`s `claude` (or pass `--use-wrapper` to layer on top of `claude-wrapper.sh` for retry behavior).
 

--- a/loom-tools/src/loom_tools/tokens/bootstrap.py
+++ b/loom-tools/src/loom_tools/tokens/bootstrap.py
@@ -18,10 +18,11 @@ triples into every repo's ``.env``. In **precedence order, highest first**:
    the email (see :func:`derive_token_filename`). This is a **soft dependency**:
    pure file detection, no import of any claude-monitor package. This is now the
    *primary* home source.
-2. **Home master (#3695)** — ``~/.loom/accounts.env`` (override with the
-   ``LOOM_ACCOUNTS_ENV`` env var; set it to ``""`` to disable the master).
-   Demoted from top default by #3698 to a **still-read fallback** — never
-   removed as a capability.
+2. **Home master (#3695)** — **opt-in only** (#3704). Consulted only when the
+   ``LOOM_ACCOUNTS_ENV`` env var points at a file (conventionally
+   ``~/.loom/accounts.env``); set it to ``""`` to disable, leave it unset and
+   the home master is **not auto-read** (no default location). Retired as a
+   default source by #3704 — the capability survives via the explicit override.
 3. **Repo-local** — ``<repo>/.loom/accounts.env`` if present, else the legacy
    ``<repo>/.env`` (override with ``--env`` / ``env_path``).
 
@@ -76,9 +77,10 @@ INDEX_VERSION = 2
 DIR_MODE = 0o700
 FILE_MODE = 0o600
 
-# Home-dir master accounts file (#3695). Shared across every workspace so the
-# account set is declared once. Override with LOOM_ACCOUNTS_ENV; set that to
-# the empty string to disable the master entirely.
+# Home-dir master accounts file (#3695). The *conventional* opt-in location an
+# operator can point LOOM_ACCOUNTS_ENV at; it is **no longer a default source**
+# (#3704 retired the auto-read). The home master is consulted only when
+# LOOM_ACCOUNTS_ENV is set to a non-empty path (see default_home_accounts_env).
 DEFAULT_HOME_ACCOUNTS_ENV = "~/.loom/accounts.env"
 HOME_ACCOUNTS_ENV_VAR = "LOOM_ACCOUNTS_ENV"
 
@@ -215,22 +217,26 @@ class Account:
 
 
 def default_home_accounts_env() -> Path | None:
-    """Resolve the home-dir master accounts file (#3695).
+    """Resolve the home-dir master accounts file (#3695, retired as default #3704).
 
     Precedence:
         1. ``LOOM_ACCOUNTS_ENV`` env var — an explicit path (``~`` expanded).
            The empty string (or all-whitespace) **disables** the master.
-        2. ``~/.loom/accounts.env`` (the default location).
+        2. Unset — returns ``None``. The home master is **opt-in only**: it is
+           no longer auto-read from a default location (#3704). Point
+           ``LOOM_ACCOUNTS_ENV`` at a file (conventionally
+           ``~/.loom/accounts.env``, :data:`DEFAULT_HOME_ACCOUNTS_ENV`) to
+           enable it.
 
     Returns the resolved :class:`Path` (which may not exist on disk), or
-    ``None`` when the master has been explicitly disabled.
+    ``None`` when the master is disabled or has not been explicitly opted in.
     """
     override = os.environ.get(HOME_ACCOUNTS_ENV_VAR)
     if override is not None:
         if not override.strip():
             return None
         return Path(override).expanduser()
-    return Path(DEFAULT_HOME_ACCOUNTS_ENV).expanduser()
+    return None
 
 
 def default_claude_monitor_accounts_env() -> Path:
@@ -448,8 +454,9 @@ def bootstrap_tokens(
     * the claude-monitor master (``~/.claude-monitor/accounts.env`` when present,
       #3698) — highest precedence, EMAIL+KEY-only entries auto-derive their
       token filename;
-    * the home-dir master (``~/.loom/accounts.env`` by default, #3695) — still
-      read as a fallback, honoring ``LOOM_ACCOUNTS_ENV``;
+    * the home-dir master (#3695) — **opt-in only** (#3704), read only when
+      ``LOOM_ACCOUNTS_ENV`` points at a file (conventionally
+      ``~/.loom/accounts.env``); not auto-read from a default location;
     * the repo-local source (``<repo>/.loom/accounts.env`` if present, else the
       legacy ``<repo>/.env``).
 

--- a/loom-tools/src/loom_tools/tokens/cli.py
+++ b/loom-tools/src/loom_tools/tokens/cli.py
@@ -49,12 +49,14 @@ def _build_parser() -> argparse.ArgumentParser:
     bp = sub.add_parser(
         "bootstrap",
         help=(
-            "Materialize .loom/tokens/ from ACCOUNT_*_N triples, merging three "
-            "sources by email with precedence claude-monitor "
-            "(~/.claude-monitor/accounts.env, primary) > repo-local > home "
-            "master (~/.loom/accounts.env, still-read fallback). "
-            "ACCOUNT_TOKEN_FILE_N is optional: when omitted it is auto-derived "
-            "from ACCOUNT_EMAIL_N (e.g. alice@example.com -> alice-example.token)."
+            "Materialize .loom/tokens/ from ACCOUNT_*_N triples, merging by "
+            "email with precedence claude-monitor "
+            "(~/.claude-monitor/accounts.env, primary) > repo-local. The home "
+            "master (~/.loom/accounts.env) is opt-in only: it is read solely "
+            "when $LOOM_ACCOUNTS_ENV (or --home-env) points at it, never by "
+            "default. ACCOUNT_TOKEN_FILE_N is optional: when omitted it is "
+            "auto-derived from ACCOUNT_EMAIL_N (e.g. alice@example.com -> "
+            "alice-example.token)."
         ),
     )
     bp.add_argument(
@@ -71,10 +73,12 @@ def _build_parser() -> argparse.ArgumentParser:
         type=Path,
         default=None,
         help=(
-            "Path to the home-dir master account source (default: "
-            "$LOOM_ACCOUNTS_ENV or ~/.loom/accounts.env). This is a still-read "
-            "fallback below the claude-monitor master (~/.claude-monitor/"
-            "accounts.env), which is always consulted when present."
+            "Path to the home-dir master account source. Opt-in only: with no "
+            "flag, the home master is read only when $LOOM_ACCOUNTS_ENV points "
+            "at a file (it is not consulted otherwise; there is no default "
+            "location). It sits below the claude-monitor master "
+            "(~/.claude-monitor/accounts.env), which is always consulted when "
+            "present."
         ),
     )
     bp.add_argument(

--- a/loom-tools/tests/tokens/conftest.py
+++ b/loom-tools/tests/tokens/conftest.py
@@ -1,11 +1,13 @@
 """Shared fixtures for the token-pool tests.
 
-The #3695 home-dir master (``~/.loom/accounts.env``, overridable via
-``LOOM_ACCOUNTS_ENV``) is read by ``bootstrap_tokens`` **by default**. Without
-isolation, a developer's or CI runner's real home master would leak into these
-tests. The autouse fixture below disables the master for every test unless a
-test opts back in (by setting ``LOOM_ACCOUNTS_ENV`` to a fixture path or
-passing ``home_env_path=`` explicitly to ``bootstrap_tokens``).
+The #3695 home-dir master is **opt-in only** since #3704: ``bootstrap_tokens``
+reads it solely when ``LOOM_ACCOUNTS_ENV`` points at a file (there is no default
+location). The autouse fixture below still pins ``LOOM_ACCOUNTS_ENV=""`` as
+belt-and-suspenders so a test that ``delenv``s then re-``setenv``s the var can
+never pick up a developer's or CI runner's real home file, and it isolates the
+claude-monitor directory the same way. Tests opt in by setting
+``LOOM_ACCOUNTS_ENV`` to a fixture path or passing ``home_env_path=`` explicitly
+to ``bootstrap_tokens``.
 """
 
 from __future__ import annotations
@@ -18,6 +20,9 @@ def _isolate_home_master(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
     """Isolate host-level state so real files never leak into tests.
 
     * ``LOOM_ACCOUNTS_ENV=""`` disables the #3695 home-dir account master.
+      Since #3704 an unset var already means "not read" (no default location),
+      so this is belt-and-suspenders — it guards tests that ``delenv`` then
+      re-``setenv`` the var.
     * ``LOOM_CLAUDE_MONITOR_DIR`` points the #3697 claude-monitor integration
       at a non-existent tmp path so a developer's or CI runner's real
       ``~/.claude-monitor`` is never consulted. Tests that exercise the

--- a/loom-tools/tests/tokens/test_bootstrap.py
+++ b/loom-tools/tests/tokens/test_bootstrap.py
@@ -429,16 +429,29 @@ def _triple(i: int, email: str, key: str, file: str) -> str:
 
 
 class TestHomeMasterResolution:
-    def test_default_is_home_loom(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_default_unset_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # #3704: the home master is no longer auto-read from a default
+        # location. Unset LOOM_ACCOUNTS_ENV resolves to None (opt-in only).
         monkeypatch.delenv("LOOM_ACCOUNTS_ENV", raising=False)
-        p = default_home_accounts_env()
-        assert p is not None
-        assert p.name == "accounts.env"
-        assert p.parent.name == ".loom"
+        assert default_home_accounts_env() is None
 
     def test_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("LOOM_ACCOUNTS_ENV", "/custom/accts.env")
         assert default_home_accounts_env() == pathlib.Path("/custom/accts.env")
+
+    def test_env_override_can_point_at_home_loom(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Capability retained (#3704): an operator can still opt the ~/.loom
+        # home master back in by pointing LOOM_ACCOUNTS_ENV at it.
+        monkeypatch.setenv("LOOM_ACCOUNTS_ENV", "~/.loom/accounts.env")
+        p = default_home_accounts_env()
+        assert p is not None
+        assert p.name == "accounts.env"
+        assert p.parent.name == ".loom"
+        assert "~" not in str(p)  # ~ was expanded
 
     def test_empty_env_disables(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("LOOM_ACCOUNTS_ENV", "")
@@ -758,6 +771,113 @@ class TestBackwardCompat3697:
         )
         result = bootstrap_tokens(mock_repo)
         assert result.written == ["custom-a.token"]
+
+
+class TestHomeMasterRetired3704:
+    """#3704: the ~/.loom home master is no longer a default source.
+
+    It is read only when ``LOOM_ACCOUNTS_ENV`` (or ``--home-env``) points at
+    it; an unset var no longer auto-reads a default location. The capability is
+    retained (location retired, not the capability), and the repo-``.env``-only
+    path is byte-for-byte backward compatible.
+    """
+
+    def _write_home(self, tmp_path: pathlib.Path, body: str) -> pathlib.Path:
+        home = tmp_path / "home-accounts.env"
+        home.write_text(body, encoding="utf-8")
+        return home
+
+    def test_home_master_not_auto_read_when_unset(
+        self,
+        mock_repo: pathlib.Path,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # A populated home master exists on disk, but with LOOM_ACCOUNTS_ENV
+        # unset (and no claude-monitor) it must NOT be auto-read (#3704).
+        self._write_home(
+            tmp_path, _triple(1, "home@example.com", "sk-home", "home.token")
+        )
+        _write_env(
+            mock_repo, _triple(1, "repo@example.com", "sk-repo", "repo.token")
+        )
+        monkeypatch.delenv("LOOM_ACCOUNTS_ENV", raising=False)
+        result = bootstrap_tokens(mock_repo)
+        assert result.home_env is None
+        assert result.monitor_env is None
+        assert result.written == ["repo.token"]
+        emails = {e["email"] for e in result.effective}
+        assert emails == {"repo@example.com"}
+        assert all(e["source"] == "repo" for e in result.effective)
+
+    def test_same_file_read_when_env_points_at_it(
+        self,
+        mock_repo: pathlib.Path,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Arbiter: the very same home fixture that was ignored above IS read
+        # when LOOM_ACCOUNTS_ENV points at it — capability retained (#3704).
+        home = self._write_home(
+            tmp_path, _triple(1, "home@example.com", "sk-home", "home.token")
+        )
+        _write_env(
+            mock_repo, _triple(1, "repo@example.com", "sk-repo", "repo.token")
+        )
+        monkeypatch.setenv("LOOM_ACCOUNTS_ENV", str(home))
+        result = bootstrap_tokens(mock_repo)
+        assert result.home_env == home
+        assert "home.token" in result.written
+        emails = {e["email"] for e in result.effective}
+        assert emails == {"home@example.com", "repo@example.com"}
+
+    def test_soft_dependency_falls_back_to_repo_not_home(
+        self,
+        mock_repo: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # No claude-monitor file and no LOOM_ACCOUNTS_ENV -> resolution falls
+        # back to the repo .env, NOT to ~/.loom/accounts.env (#3704).
+        _write_env(
+            mock_repo,
+            _triple(1, "a@example.com", "sk-a", "a.token")
+            + _triple(2, "b@example.com", "sk-b", "b.token"),
+        )
+        monkeypatch.delenv("LOOM_ACCOUNTS_ENV", raising=False)
+        result = bootstrap_tokens(mock_repo)
+        assert result.home_env is None
+        assert result.monitor_env is None
+        assert set(result.written) == {"a.token", "b.token"}
+        assert all(e["source"] == "repo" for e in result.effective)
+
+    def test_repo_env_only_backward_compatible(
+        self,
+        mock_repo: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Backward-compat: repo-.env-only setup (no claude-monitor, unset
+        # LOOM_ACCOUNTS_ENV) resolves exactly as today.
+        _write_env(
+            mock_repo, _triple(1, "a@example.com", "sk-1", "custom-a.token")
+        )
+        monkeypatch.delenv("LOOM_ACCOUNTS_ENV", raising=False)
+        result = bootstrap_tokens(mock_repo)
+        assert result.written == ["custom-a.token"]
+        assert result.home_env is None
+        assert (
+            mock_repo / ".loom" / "tokens" / "custom-a.token"
+        ).read_text() == "sk-1"
+
+    def test_all_sources_absent_raises(
+        self,
+        mock_repo: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # No claude-monitor, no repo source, unset LOOM_ACCOUNTS_ENV -> the home
+        # master is not auto-read, so every source is absent -> FileNotFoundError.
+        monkeypatch.delenv("LOOM_ACCOUNTS_ENV", raising=False)
+        with pytest.raises(FileNotFoundError):
+            bootstrap_tokens(mock_repo)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Completes the account-source migration begun in #3698: the `~/.loom/accounts.env` home master is **no longer auto-read** from a default location. Default account resolution is now **claude-monitor (`~/.claude-monitor/accounts.env`) → repo `.env`**.

The change is localized to `default_home_accounts_env()` in `loom-tools/src/loom_tools/tokens/bootstrap.py`: when `LOOM_ACCOUNTS_ENV` is **unset**, it now returns `None` instead of `~/.loom/accounts.env`. The two override branches are unchanged — an explicit `LOOM_ACCOUNTS_ENV=<path>` is still honored, and `LOOM_ACCOUNTS_ENV=""` still disables. Downstream `bootstrap_tokens()` already treats a `None` home file as absent (`home_present = bool(home_file and home_file.is_file())`), so no wiring change was needed.

This retires the default *location*, not the *capability*: an operator can still opt the home master back in via `LOOM_ACCOUNTS_ENV=<path>` or the `--home-env <path>` CLI flag.

## Changes

- **bootstrap.py** — `default_home_accounts_env()` unset branch returns `None`; refreshed module, function, and `bootstrap_tokens` docstrings; `DEFAULT_HOME_ACCOUNTS_ENV` kept as the documented conventional opt-in path (no longer returned as a default).
- **cli.py** — `bootstrap` subcommand help and `--home-env` help reframed as opt-in only.
- **conftest.py** — `LOOM_ACCOUNTS_ENV=""` isolation kept as belt-and-suspenders (guards `delenv`/`setenv` tests); docstrings updated.
- **test_bootstrap.py** — inverted `test_default_is_home_loom` → `test_default_unset_returns_none`; added `test_env_override_can_point_at_home_loom` (capability retained) and `TestHomeMasterRetired3704` covering the arbiter (same fixture not-auto-read vs explicit-read), soft-dependency repo fallback, repo-`.env` backward-compat, and all-sources-absent `FileNotFoundError`.
- **CLAUDE.md** — account-sourcing table and Token Rotation → Setup step reframed claude-monitor-first with the home master as opt-in (no default location); examples genericized to `example.com`.

## Tests

`PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/tokens/ -q` → **230 passed**.

Closes #3704

🤖 Generated with [Claude Code](https://claude.com/claude-code)