### PR TITLE
docs(skills): serialize issue-creating agents; only Builders parallelize (#3707)

### DIFF
--- a/defaults/.claude/commands/loom/architect.md
+++ b/defaults/.claude/commands/loom/architect.md
@@ -167,6 +167,8 @@ When creating a proposal:
 
 **For templates and examples**, read `.claude/commands/loom/architect-patterns.md`.
 
+> **Do not run concurrent Architects — serialize issue creation (#3707).** `gh issue create` returns a server-assigned number with no client-side coordination, so two Architects (or an Architect and a Curator-decomposition / Champion epic-phase run) filing issues at the same time in the same repo **race on issue numbers and cross-contaminate bodies**. Never place an issue-creating agent in a parallel wave; one issue-creating agent must finish its entire `gh issue create` burst before the next starts. See `sweep.md` → "Execution Model → Only Builders parallelize" for the full invariant. Parallel **Builders** (implementing already-filed issues) stay safe — only issue *creation* must be serialized.
+
 ### Duplicate Detection (CRITICAL)
 
 **BEFORE creating any issue, check for potential duplicates:**
@@ -230,7 +232,7 @@ For large features that span multiple phases (4+ issues with dependencies), crea
 **When to create an epic**:
 - Feature requires 4+ distinct implementation issues
 - Work has natural phases with dependencies
-- Multiple shepherds could work in parallel
+- Multiple shepherds could work in parallel — this refers to **Builders implementing already-created phase issues** (safe: each in its own worktree, one PR each), NOT to multiple Architects filing issues concurrently (unsafe — see the serialization note under "Creating Proposals" and `sweep.md` → "Only Builders parallelize", #3707)
 - Implementation order matters
 
 **For epic templates and workflow**, read `.claude/commands/loom/architect-patterns.md`.

--- a/defaults/.claude/commands/loom/champion-epic.md
+++ b/defaults/.claude/commands/loom/champion-epic.md
@@ -63,6 +63,8 @@ Check each of the 6 criteria above. If ANY criterion fails, skip to Step 4 (reje
 
 If all 6 criteria pass:
 
+> **Serialize this phase-issue creation loop against any other issue-creating agent (#3707).** Do not run the `gh issue create` loop below while another issue-creating agent (Architect / Curator-decomposition / another Champion epic-phase run) is filing issues in the same repo — concurrent `gh issue create` bursts race on server-assigned issue numbers and cross-contaminate bodies. One filer must finish its full burst before the next starts. See `sweep.md` → "Execution Model → Only Builders parallelize" for the invariant.
+
 1. **Create Phase 1 issues** with `loom:architect` label:
 
 ```bash

--- a/defaults/.claude/commands/loom/curator.md
+++ b/defaults/.claude/commands/loom/curator.md
@@ -269,6 +269,7 @@ If, during curation, you determine an issue is too large to be a single Builder 
 3. **Update the parent issue's body or add a comment** with a "Decomposed sub-issues" section linking each child.
 4. **Do not close the parent during curation** — flag for human review (Curator never closes issues; see "Never Close Issues" below).
 5. **Do not self-curate your own sub-issues in the same session.** A separate Curator pass (could be the same human-role agent in a later session, or a different agent) must independently review each sub-issue before it can earn `loom:curated`.
+6. **Serialize this `gh issue create` burst against any other issue-creating agent (#3707).** Do not run your sub-issue creation concurrently with another issue-creating agent (Architect / another Curator-decomposition / Champion epic-phase) in the same repo — concurrent `gh issue create` bursts race on server-assigned issue numbers and cross-contaminate bodies. One filer finishes its full burst before the next starts. See `sweep.md` → "Execution Model → Only Builders parallelize" for the invariant.
 
 ### Why this matters
 

--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -362,6 +362,20 @@ The subagent-path target is **soft** — there is no hard upper bound and the wa
 - **Mode A/B (issue-set)**: the candidate list is partitioned into waves of up to `N = --builders-per-wave` issues, where an omitted flag resolves to the Stage -1 auto wave size (see "Resolve auto wave size" — up to 10 on the daemon path, core-scaled within `[3, 6]` on the subagent path, disk-clamped). Issues are picked into waves in order. Within a wave, builders are dispatched in parallel; across waves, processing is sequential. Each wave fully settles (all builders → per-PR Judge → optional Doctor → merge) before the next wave starts.
 - **Mode C (PR-set)**: the candidate list is processed in **size-1 waves** (one PR per wave). `--builders-per-wave` is ignored because there is no Builder phase. Each PR is routed per its current label (Judge / Doctor→Judge / Merge — see "PR-set Wave Lifecycle" below) and fully settles before the next PR is touched. Sequential per-PR processing matches the load-bearing #3289 sequencing rule and parallels the issue-side "per-PR Judge is sequential within a wave" policy.
 
+### CRITICAL: Only Builders parallelize — issue-creating roles must be serialized (issue #3707)
+
+**Waves parallelize Builders only.** The reason a wave can safely fan out `N` agents at once is that each Builder works in an isolated git worktree and produces **exactly one PR at the end** — no shared mutable forge state is touched mid-run, so two concurrent Builders never collide. `/sweep` itself only ever dispatches Builders (plus per-issue Curator/Judge/Doctor, which run **sequentially within a wave**), so today's wave loop is safe by construction.
+
+**Never dispatch two or more issue-creating agents concurrently.** Agents that **create issues** — Architect proposals, Curator oversized-issue decomposition, Champion epic-phase creation — mutate the forge's **shared, server-assigned issue-number space** with no client-side coordination, transaction, or idempotency key. When two such agents run `gh issue create` bursts at the same time they **race on issue numbers and cross-contaminate bodies** (one epic's title paired with another's body), and any recovery/retry loop that PATCHes-by-title amplifies the damage by winning every write race against the other still-active filer. This is not hypothetical: it was observed 2026-07-21 on a 4-wide wave (1 builder + 3 architects) — 2 duplicate issues, 3 with mismatched title/body, and a corrupted roadmap comment, all needing manual reconciliation (#3707).
+
+Concrete rules for anyone extending this skill or hand-driving a wave:
+
+- **Do NOT construct a mixed wave** that places any issue-creating role (Architect / Curator-decomposition / Champion epic-phase) alongside Builders — or alongside another issue-creating agent. That exact `1 builder + 3 architects` shape is the footgun this section forbids.
+- **Serialize issue-creating agents**: one must finish its entire `gh issue create` burst before the next starts. A recovery/retry loop must never run against a still-active concurrent filer.
+- Parallel **Builders** remain safe and are the only role `/sweep` fans out — this is unchanged.
+
+Heavier mitigations (a per-wave issue-filing lock, an epic-scoped idempotency UUID + post-create reconciliation, or a serialized issue-filing sub-phase inside `/sweep`) are **deferred, out-of-scope follow-ups** to this documentation guardrail — build them only if serialization-by-convention proves insufficient in practice (#3707).
+
 ### CRITICAL: One level deep — never spawn `/shepherd` as a subagent
 
 `/sweep` dispatches `loom-builder`, `loom-judge`, and `loom-doctor` subagents **directly from this orchestrator session** in a single tool-call block. This is **one level deep** and is empirically safe for `N` up to at least 3.


### PR DESCRIPTION
Closes #3707

## What

Documents the invariant that **only Builders may be dispatched in parallel**. Each Builder works in an isolated git worktree and produces exactly one PR at the end — no shared mutable forge state mid-run — so concurrent Builders never collide. Agents that **create issues** (Architect proposals, Curator oversized-issue decomposition, Champion epic-phase creation) mutate the forge's shared, server-assigned issue-number space with no client-side coordination, so concurrent `gh issue create` bursts race on issue numbers and cross-contaminate bodies. These roles must be **serialized** — never placed in a parallel or mixed wave.

Motivated by the 2026-07-21 incident: a 4-wide wave (1 builder + 3 architects) produced 2 duplicate issues, 3 with mismatched title/body, and a corrupted roadmap comment.

## Changes (documentation-only)

- **`sweep.md`** — new "CRITICAL: Only Builders parallelize" subsection in the Execution Model, stating the serialization invariant, explicitly forbidding a mixed builder + issue-creating wave, and flagging heavier mitigations as deferred out-of-scope follow-ups.
- **`architect.md`** — "do not run concurrent Architects / serialize issue creation" note near the `gh issue create` guidance; disambiguates the existing "Multiple shepherds could work in parallel" line as referring to Builders on already-filed issues.
- **`curator.md`** — one-line serialization caution in the decomposition section, cross-referencing the sweep.md invariant.
- **`champion-epic.md`** — one-line serialization caution on the phase-1 issue-creation loop, cross-referencing the sweep.md invariant.

All edits are under `defaults/.claude/commands/loom/` (the git-tracked source; `.claude/commands/loom` is a gitignored symlink to it). No script or wave-loop changes.

## Verification

- `sweep_md_doc_lint` (8) + `sweep_md_stage_minus_one_doc_lint` (9) pass — existing string contracts intact.
- Grep confirms the invariant in sweep.md and the cross-referencing caution in all four files.

## Out of scope (deferred follow-ups)

Per the curated issue, heavier mitigations are intentionally **not** implemented: a per-wave issue-filing lock, an epic-scoped idempotency UUID + post-create reconciliation, and a serialized issue-filing sub-phase in `/sweep`. Build only if serialization-by-convention proves insufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)