### PR TITLE
fix(tokens): probe-path .ranking emits pipe format the selector reads (#3709)

### DIFF
--- a/loom-tools/src/loom_tools/tokens/check.py
+++ b/loom-tools/src/loom_tools/tokens/check.py
@@ -32,7 +32,6 @@ partial file is ever visible mid-write).
 
 from __future__ import annotations
 
-import json
 import logging
 import random
 import time
@@ -416,8 +415,25 @@ def build_report(results: Iterable[AccountResult]) -> ProbeReport:
     return ProbeReport(ranked_at=ranked_at, accounts=sorted_results)
 
 
+def format_ranking_lines(report: ProbeReport) -> str:
+    """Serialize a probe report to the selector's ``name|status`` format.
+
+    This is the format ``select.py:_read_ranking`` consumes (pipe-delimited
+    ``name|status``, one account per line, already ordered by
+    :func:`build_report`). A trailing newline is included so the file ends
+    cleanly; an empty report yields an empty string.
+    """
+    lines = [f"{a.name}|{a.status}" for a in report.accounts]
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
 def write_ranking_atomic(report: ProbeReport, ranking_path: Path) -> None:
-    """Write *report* to *ranking_path* atomically.
+    """Write *report* to *ranking_path* atomically in the selector's format.
+
+    Emits the pipe-delimited ``name|status`` format that
+    ``select.py:_read_ranking`` consumes — byte-compatible with the monitor
+    path's ``write_monitor_ranking_atomic`` — so a probe-written ``.ranking``
+    drives tier-1 (ranking-based) selection identically to any other source.
 
     Writes to ``<path>.tmp`` in the same directory (so the rename is on
     the same filesystem and uses ``rename(2)``), then ``Path.replace``s
@@ -426,7 +442,7 @@ def write_ranking_atomic(report: ProbeReport, ranking_path: Path) -> None:
     """
     ranking_path.parent.mkdir(parents=True, exist_ok=True)
     tmp = ranking_path.with_suffix(ranking_path.suffix + ".tmp")
-    tmp.write_text(json.dumps(report.to_dict(), indent=2) + "\n")
+    tmp.write_text(format_ranking_lines(report))
     tmp.replace(ranking_path)
 
 

--- a/loom-tools/src/loom_tools/tokens/monitor.py
+++ b/loom-tools/src/loom_tools/tokens/monitor.py
@@ -18,9 +18,9 @@ Two separate surfaces are never mixed (secrets vs usage data):
 **Format-of-record.** The spawn-time selector (``select.py:_read_ranking``)
 parses pipe-delimited ``name|status`` lines. This module emits exactly that
 format so a monitor-sourced ``.ranking`` is consumed by the selector
-identically to any other. (The probe path's ``write_ranking_atomic`` currently
-serializes JSON — a latent producer/consumer discrepancy that predates this
-feature; reconciling the probe path is intentionally out of scope here.)
+identically to any other. The probe path's ``check.write_ranking_atomic``
+emits the same pipe format (reconciled in #3709), so both producers are
+byte-compatible with the selector.
 
 **Ordering policy stays Loom's.** claude-monitor is a thin numbers provider;
 we sort by ``(status_rank, util_7d, util_5h)`` using the existing

--- a/loom-tools/tests/tokens/test_check.py
+++ b/loom-tools/tests/tokens/test_check.py
@@ -300,9 +300,8 @@ class TestRanking:
         target = tmp_path / "tokens" / ".ranking"
         write_ranking_atomic(report, target)
         assert target.exists()
-        data = json.loads(target.read_text())
-        assert data["accounts"][0]["name"] == "a-1"
-        assert data["ranked_at"] == "2026-05-03T00:00:00Z"
+        # Pipe format (name|status) — the format select.py:_read_ranking consumes.
+        assert target.read_text() == "a-1|available\n"
 
     def test_atomic_write_no_partial_file(self, tmp_path: Path):
         # Verify that the temp file is renamed (no stray .tmp left behind on
@@ -321,8 +320,7 @@ class TestRanking:
             accounts=[AccountResult("new", "available")],
         )
         write_ranking_atomic(report, target)
-        data = json.loads(target.read_text())
-        assert data["accounts"][0]["name"] == "new"
+        assert target.read_text() == "new|available\n"
 
 
 # ---------------------------------------------------------------------------
@@ -346,8 +344,13 @@ class TestRunCheck:
         assert names_status["agent-1"] == "available"
         assert names_status["agent-bad"] == "blocked"
 
-        ranking = json.loads((tmp_path / ".ranking").read_text())
-        assert {a["name"] for a in ranking["accounts"]} == {"agent-1", "agent-bad"}
+        # Pipe format (name|status) — parse names back out of the .ranking.
+        ranking_names = {
+            line.split("|", 1)[0]
+            for line in (tmp_path / ".ranking").read_text().splitlines()
+            if line
+        }
+        assert ranking_names == {"agent-1", "agent-bad"}
 
     def test_one_failure_does_not_kill_run(self, tmp_path: Path):
         # Tokens are probed in sorted-name order (a-good, z-bad).
@@ -463,10 +466,11 @@ class TestSourceMonitor:
             run_check(
                 tokens_dir, source="probe", write_ranking=True, stagger=False
             )
-        # It probed (network call made) and wrote JSON, not pipe.
+        # It probed (network call made) and wrote the selector's pipe format.
         assert post.called
-        data = json.loads((tokens_dir / ".ranking").read_text())
-        assert "accounts" in data
+        text = (tokens_dir / ".ranking").read_text()
+        assert "|" in text
+        assert text.startswith("acct-")
 
     def test_monitor_source_writes_pipe_format(self, tmp_path: Path, monkeypatch):
         workspace, tokens_dir, monitor_dir = _setup_pool(tmp_path)
@@ -528,9 +532,10 @@ class TestSourceMonitor:
         ) as post:
             run_check(tokens_dir, source="auto", write_ranking=True, stagger=False)
         assert post.called  # fell back to probing
-        # Probe path writes JSON.
-        data = json.loads((tokens_dir / ".ranking").read_text())
-        assert "accounts" in data
+        # Probe path writes the selector's pipe format.
+        text = (tokens_dir / ".ranking").read_text()
+        assert "|" in text
+        assert text.startswith("acct-")
 
     def test_roundtrip_monitor_output_read_by_selector(
         self, tmp_path: Path, monkeypatch
@@ -553,6 +558,40 @@ class TestSourceMonitor:
             ],
         )
         run_check(tokens_dir, source="monitor", write_ranking=True, stagger=False)
+
+        selected = select_token(workspace)
+        assert selected.mode == "ranked"
+        assert selected.name == "acct-a"
+
+    def test_roundtrip_probe_output_read_by_selector(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """The .ranking emitted by the PROBE path is consumed by select_token.
+
+        Mirrors test_roundtrip_monitor_output_read_by_selector for the probe
+        path (#3709). check.write_ranking_atomic must emit the pipe-delimited
+        name|status format that select.py:_read_ranking parses; if it wrote
+        JSON, tier-1 (ranking-based) selection would be inert and the selector
+        would fall through to allowlist/random.
+        """
+        workspace, tokens_dir, _monitor_dir = _setup_pool(tmp_path)
+
+        # discover_tokens probes in sorted name order (acct-a, then acct-b).
+        # acct-a available (low 7d), acct-b exhausted (high 7d) -> the sorted
+        # ranking lists acct-a first, so the selector must pick acct-a.
+        responses = [
+            _mock_response(200, _good_headers(s7d=0.10)),  # acct-a available
+            _mock_response(200, _good_headers(s7d=0.99)),  # acct-b exhausted
+        ]
+        with patch("requests.post", side_effect=responses):
+            run_check(
+                tokens_dir, source="probe", write_ranking=True, stagger=False
+            )
+
+        # Sanity: the probe wrote the selector's pipe format, not JSON.
+        assert (tokens_dir / ".ranking").read_text() == (
+            "acct-a|available\nacct-b|exhausted\n"
+        )
 
         selected = select_token(workspace)
         assert selected.mode == "ranked"


### PR DESCRIPTION
Closes #3709

## Problem

`check.py::write_ranking_atomic` (the **probe** path of `loom-tokens check --ranking` / `probe-tokens.sh --ranking`) wrote `.loom/tokens/.ranking` as **JSON**, but `select.py::_read_ranking` — the spawn-time selector that consumes `.ranking` — parses **pipe-delimited `name|status`** lines. The formats disagreed, so a probe-written `.ranking` was silently ignored by the selector: tier-1 (ranking-based) selection was **inert** on the probe path, falling through to allowlist/random. #3697 (PR #3699) fixed only the monitor path.

## Fix

Reconcile the **producer** to the format-of-record (pipe `name|status`) that `select.py:_read_ranking` already consumes and `monitor.py::write_monitor_ranking_atomic` already emits. The selector is left untouched — one format, not two.

- `check.py`: `write_ranking_atomic` now emits pipe format via a new `format_ranking_lines(report)` helper (accounts are already ordered by `build_report`). Dropped the now-unused `import json`.
- `monitor.py`: refreshed the stale "probe path serializes JSON" docstring note.
- `test_check.py`: updated the five JSON `.ranking` assertions to the pipe format; added `test_roundtrip_probe_output_read_by_selector` proving `select_token` picks the expected account (`acct-a`, `mode="ranked"`) from a probe-written `.ranking` — mirroring the monitor-path round-trip test.

## Verification

- No regression to the monitor path (unchanged; its round-trip test still green).
- `PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/tokens/ -v` → **231 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)