### PR TITLE
fix(merge-pr): never remove the primary/main worktree (#3710)

### DIFF
--- a/defaults/scripts/merge-pr.sh
+++ b/defaults/scripts/merge-pr.sh
@@ -845,6 +845,16 @@ _worktree_branch_for() {
     '
 }
 
+# Print the absolute path of the PRIMARY (main) worktree — the FIRST `worktree`
+# entry of `git worktree list --porcelain`. Git always lists the main working
+# tree first, so `exit` after the first match is correct. Prints nothing on
+# error (e.g. not a git repo). Used by _remove_loom_worktree to hard-refuse
+# removing the primary checkout (#3710).
+_primary_worktree_path() {
+  git -C "$REPO_ROOT" worktree list --porcelain 2>/dev/null | \
+    awk '/^worktree / { print $2; exit }'
+}
+
 # Walk porcelain output for a worktree whose branch matches the given branch
 # short-name. Prints the worktree absolute path or nothing. Skips detached /
 # bare entries (they have no `branch refs/heads/...` line).
@@ -891,6 +901,29 @@ _remove_loom_worktree() {
     info "No worktree found at $worktree_path"
     return 0
   fi
+  # Resolve to a canonical absolute path once; reused for both the primary-
+  # worktree guard immediately below and the "is our CWD inside it?" check
+  # further down.
+  local worktree_real
+  worktree_real="$(cd "$worktree_path" 2>/dev/null && pwd -P || echo "$worktree_path")"
+  # Hard guard (#3710): NEVER attempt to remove the primary/main worktree — the
+  # FIRST entry of `git worktree list --porcelain` — regardless of a
+  # .loom-managed sentinel, the checked-out branch, --worktree-path, or a
+  # customized worktree.root. This is the single choke point for all three
+  # removal call-sites (default issue/pr path, --worktree-path override, and the
+  # non-standard-path discovery fallback). Without it, a repo whose primary
+  # checkout (a) sits at a non-standard path relative to a customized
+  # worktree.root, (b) carries a .loom-managed sentinel, and (c) has the PR
+  # branch checked out will reach `git worktree remove` on the main working
+  # tree: git fails safe ("Could not remove worktree"), but the attempt is a
+  # logic error and emits a misleading Removing/Could-not-remove pair. Refuse
+  # here, before any sentinel or CWD handling.
+  local primary_real
+  primary_real="$(_primary_worktree_path)"
+  if [[ -n "$primary_real" ]] && [[ "$worktree_real" == "$primary_real" ]]; then
+    warning "Refusing to remove the primary/main worktree at $worktree_real (never removable regardless of .loom-managed sentinel, branch, or worktree.root)"
+    return 0
+  fi
   if [[ "$allow_unmanaged" != "true" ]] && [[ ! -f "$worktree_path/.loom-managed" ]]; then
     warning "Worktree at $worktree_path lacks .loom-managed sentinel — refusing to remove (user-owned)"
     return 0
@@ -906,9 +939,9 @@ _remove_loom_worktree() {
     attached_branch="$(_worktree_branch_for "$worktree_path")"
   fi
   # If our shell is inside the worktree we're removing, hop out first.
-  local current_dir worktree_real in_worktree=false
+  # ($worktree_real was already resolved above for the primary-worktree guard.)
+  local current_dir in_worktree=false
   current_dir="$(pwd -P 2>/dev/null || pwd)"
-  worktree_real="$(cd "$worktree_path" 2>/dev/null && pwd -P || echo "$worktree_path")"
   if [[ "$current_dir" == "$worktree_real"* ]]; then
     in_worktree=true
     cd "$REPO_ROOT"

--- a/defaults/scripts/tests/test-merge-pr-primary-worktree-guard.sh
+++ b/defaults/scripts/tests/test-merge-pr-primary-worktree-guard.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# test-merge-pr-primary-worktree-guard.sh - Regression test for #3710.
+#
+# merge-pr.sh's `_remove_loom_worktree` must NEVER attempt to remove the
+# primary/main worktree (the FIRST entry of `git worktree list --porcelain`),
+# regardless of a .loom-managed sentinel, the checked-out branch, or a
+# customized worktree.root.
+#
+# The bug (Loom 0.12.0, observed in geode-fem): a repo with a customized
+# `worktree.root` has its primary checkout at a "non-standard path" relative to
+# that root. Merging a PR whose branch was checked out in the primary reached
+# the discovery fallback, which found the primary via _find_worktree_by_branch;
+# because the primary carried a .loom-managed sentinel, the code called
+# `_remove_loom_worktree` on the main working tree. Git fails safe there, but
+# the attempt was a logic error and printed a misleading
+# "Removing worktree / Could not remove worktree" pair.
+#
+# Test strategy:
+#   1. Static grep assertions that the live source retains the guard (protects
+#      against a regression that deletes the guard).
+#   2. Behavioral test against a REAL git repo, running the ACTUAL function
+#      bodies extracted from merge-pr.sh (no drift): the primary checkout sits
+#      at a path that is NOT under a customized worktree.root, carries a
+#      .loom-managed sentinel, and has the PR branch checked out. The guard
+#      must refuse to remove it and the checkout must survive.
+#   3. Control: a genuine SECONDARY Loom-managed worktree IS still removed
+#      (the guard is surgical — it only spares the primary).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+MERGE_PR="$SCRIPTS_DIR/merge-pr.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1)); echo -e "  ${RED}FAIL${NC}: $1"; }
+
+assert_grep() {
+    local pattern="$1" file="$2" msg="$3"
+    if grep -qE "$pattern" "$file"; then pass "$msg"; else fail "$msg (pattern: $pattern)"; fi
+}
+
+[[ -f "$MERGE_PR" ]] || { echo "ERROR: $MERGE_PR not found" >&2; exit 1; }
+
+# --- Test 1: source retains the primary-worktree guard ---
+echo "Test 1: merge-pr.sh source retains the #3710 primary-worktree guard"
+
+assert_grep '_primary_worktree_path\(\) \{' "$MERGE_PR" \
+    "merge-pr.sh defines the _primary_worktree_path helper"
+assert_grep "awk '/\^worktree / \{ print \\\$2; exit \}'" "$MERGE_PR" \
+    "_primary_worktree_path takes the FIRST worktree entry (print; exit)"
+assert_grep 'Refusing to remove the primary/main worktree' "$MERGE_PR" \
+    "_remove_loom_worktree refuses when the target resolves to the primary"
+assert_grep 'primary_real="\$\(_primary_worktree_path\)"' "$MERGE_PR" \
+    "_remove_loom_worktree resolves the primary path before any removal"
+
+# --- Extract the ACTUAL function bodies from the live source (no drift) ---
+# Grabs from `name() {` to the first line beginning with `}` (column 0). All
+# four helpers close their brace at column 0 with no intervening column-0 `}`.
+extract_fn() {
+    local name="$1" file="$2"
+    awk -v fn="$name" '
+      $0 ~ "^"fn"\\(\\) \\{" { grab=1 }
+      grab { print }
+      grab && /^}/ { exit }
+    ' "$file"
+}
+
+# Harness: stub the logging helpers and REPO_ROOT, then eval the real bodies.
+info()    { echo "INFO: $*"; }
+warning() { echo "WARN: $*"; }
+success() { echo "OK: $*"; }
+error()   { echo "ERROR: $*" >&2; return 1; }
+
+eval "$(extract_fn _primary_worktree_path "$MERGE_PR")"
+eval "$(extract_fn _worktree_branch_for   "$MERGE_PR")"
+eval "$(extract_fn _maybe_delete_local_branch "$MERGE_PR")"
+eval "$(extract_fn _remove_loom_worktree  "$MERGE_PR")"
+
+# --- Build a real git repo matching the #3710 repro scenario ---
+echo ""
+echo "Test 2: guard refuses to remove the primary/main worktree (real git repo)"
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/loom-merge-primary-guard.XXXXXX")"
+# Resolve symlinks up front so our comparisons match git's canonical paths.
+TMP_ROOT="$(cd "$TMP_ROOT" && pwd -P)"
+cleanup() { rm -rf "$TMP_ROOT" 2>/dev/null || true; }
+trap cleanup EXIT
+
+# Primary checkout at a NON-standard path (just a plain dir — NOT under the
+# customized worktree.root below).
+PRIMARY="$TMP_ROOT/primary-checkout"
+mkdir -p "$PRIMARY"
+git -C "$PRIMARY" init -q
+git -C "$PRIMARY" config user.email "test@example.com"
+git -C "$PRIMARY" config user.name "Test"
+echo "hello" > "$PRIMARY/README.md"
+git -C "$PRIMARY" add -A
+git -C "$PRIMARY" commit -q -m "initial"
+
+# Customized worktree.root pointing somewhere OTHER than the primary's parent,
+# matching the repro (config present but irrelevant to the guard — the guard is
+# config-independent by construction).
+mkdir -p "$PRIMARY/.loom"
+CUSTOM_WT_ROOT="$TMP_ROOT/scratch-wt"
+mkdir -p "$CUSTOM_WT_ROOT"
+cat > "$PRIMARY/.loom/config.json" <<EOF
+{ "worktree": { "root": "$CUSTOM_WT_ROOT" } }
+EOF
+
+# (a) Primary carries a .loom-managed sentinel (the trap that made the old code
+# think it was safe to remove).
+touch "$PRIMARY/.loom-managed"
+
+# (b) The PR branch is checked out IN the primary at merge time.
+PR_BRANCH="paper/conformal-v4-audited"
+git -C "$PRIMARY" checkout -q -b "$PR_BRANCH"
+
+# REPO_ROOT is the primary (as merge-pr.sh resolves it via find_main_repo_root).
+# Consumed by the eval'd _primary_worktree_path / _remove_loom_worktree bodies.
+# shellcheck disable=SC2034
+REPO_ROOT="$PRIMARY"
+
+# Sanity: the primary is the first porcelain entry, and our helper agrees.
+primary_reported="$(_primary_worktree_path)"
+if [[ "$primary_reported" == "$PRIMARY" ]]; then
+    pass "_primary_worktree_path reports the primary checkout ($PRIMARY)"
+else
+    fail "_primary_worktree_path: expected '$PRIMARY', got '$primary_reported'"
+fi
+
+# The actual guard: attempt to remove the primary. Must refuse, and the
+# checkout must survive as a valid git repo.
+set +e
+guard_out="$(_remove_loom_worktree "$PRIMARY" 2>&1)"
+guard_rc=$?
+set -e
+
+if [[ $guard_rc -eq 0 ]] \
+   && [[ "$guard_out" == *"Refusing to remove the primary/main worktree"* ]] \
+   && [[ "$guard_out" != *"Removing worktree"* ]]; then
+    pass "guard refuses the primary and never logs 'Removing worktree'"
+else
+    fail "guard should refuse the primary; rc=$guard_rc, out: $guard_out"
+fi
+
+if [[ -d "$PRIMARY" ]] && git -C "$PRIMARY" rev-parse --git-dir >/dev/null 2>&1; then
+    pass "primary checkout survives (still a valid git repo)"
+else
+    fail "primary checkout was removed or corrupted"
+fi
+
+# Guard must hold even via the --worktree-path explicit-opt-in path
+# (allow_unmanaged=true) — the primary is never removable.
+set +e
+guard_out2="$(_remove_loom_worktree "$PRIMARY" "true" 2>&1)"
+guard_rc2=$?
+set -e
+if [[ $guard_rc2 -eq 0 ]] \
+   && [[ "$guard_out2" == *"Refusing to remove the primary/main worktree"* ]] \
+   && [[ -d "$PRIMARY" ]]; then
+    pass "guard also refuses the primary under allow_unmanaged=true (--worktree-path)"
+else
+    fail "guard should refuse the primary even with allow_unmanaged=true; rc=$guard_rc2, out: $guard_out2"
+fi
+
+# --- Test 3: control — a genuine SECONDARY managed worktree IS removed ---
+echo ""
+echo "Test 3: control — a secondary Loom-managed worktree is still removed"
+
+SECONDARY="$CUSTOM_WT_ROOT/issue-999"
+git -C "$PRIMARY" worktree add -q -b feature/issue-999 "$SECONDARY" >/dev/null 2>&1
+touch "$SECONDARY/.loom-managed"
+
+set +e
+sec_out="$(_remove_loom_worktree "$SECONDARY" 2>&1)"
+sec_rc=$?
+set -e
+
+if [[ $sec_rc -eq 0 ]] \
+   && [[ "$sec_out" == *"Removing worktree"* ]] \
+   && [[ "$sec_out" != *"Refusing to remove the primary"* ]] \
+   && [[ ! -d "$SECONDARY" ]]; then
+    pass "secondary managed worktree is removed (guard is surgical, not blanket)"
+else
+    fail "secondary should be removed; rc=$sec_rc, dir_exists=$([[ -d "$SECONDARY" ]] && echo yes || echo no), out: $sec_out"
+fi
+
+# --- Summary ---
+echo ""
+echo "Tests run: $TESTS_RUN, Passed: $TESTS_PASSED, Failed: $TESTS_FAILED"
+[[ $TESTS_FAILED -eq 0 ]] || exit 1


### PR DESCRIPTION
Closes #3710

## Problem

`merge-pr.sh`'s post-merge worktree cleanup could attempt to remove the **primary/main** working tree when all three of these held:

1. `worktree.root` is customized, so the primary checkout sits at a "non-standard path" relative to that root;
2. the primary root carries a `.loom-managed` sentinel;
3. the PR branch was checked out **in the primary** at merge time.

The Loom-convention path (`$WT_ROOT/pr-N`) didn't exist, so control reached the discovery fallback. `_find_worktree_by_branch "$PR_BRANCH"` returned the primary (the branch was checked out there), and — because the primary had a sentinel — the code ran `git worktree remove` on the main working tree. Git refuses (fails safe), but the attempt was a logic error and printed a misleading `Removing worktree` / `Could not remove worktree` pair.

## Fix

A single hard guard at the recommended choke point `_remove_loom_worktree` (the funnel for all three removal call-sites: default issue/pr path, `--worktree-path` override, and the discovery fallback):

- New `_primary_worktree_path` helper returns the primary path (the **first** entry of `git worktree list --porcelain`; git always lists the main working tree first).
- `_remove_loom_worktree` resolves the target to a canonical absolute path and **refuses** when it equals the primary — regardless of the `.loom-managed` sentinel, checked-out branch, `worktree.root`, or the `allow_unmanaged` (`--worktree-path`) opt-in.

The guard is config-independent by construction; it never touches the merge itself and is a no-op for every normal secondary-worktree removal.

## Test

`defaults/scripts/tests/test-merge-pr-primary-worktree-guard.sh`:

- **Static** grep assertions that the live source retains the guard (drift protection).
- **Behavioral** test that extracts and runs the **actual** function bodies from `merge-pr.sh` against a **real git repo** reproducing the exact repro scenario (customized `worktree.root`, primary at a non-standard path with a sentinel, PR branch checked out in the primary). Asserts the guard refuses (and never logs `Removing worktree`), the primary survives as a valid repo, and the refusal holds even under `allow_unmanaged=true`.
- **Control**: a genuine secondary Loom-managed worktree is still removed — the guard is surgical, not a blanket disable.

## Verification

- New test: 9/9 pass.
- Sibling merge-pr suites unchanged: worktree-awk 11/11, worktree-path 21/21, help 15/15, partial-increment 19/19, unstable-fallback 58/58.
- `bash -n` and `shellcheck -S warning` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)