### PR TITLE
fix(merge-pr): space-safe worktree porcelain parsing (substr not $2)

### DIFF
--- a/defaults/scripts/merge-pr.sh
+++ b/defaults/scripts/merge-pr.sh
@@ -236,11 +236,15 @@ if [[ -n "$WORKTREE_PATH_OVERRIDE" ]]; then
   fi
   _WT_ABS="$(cd "$WORKTREE_PATH_OVERRIDE" 2>/dev/null && pwd -P)" || \
     error "--worktree-path could not be resolved: $WORKTREE_PATH_OVERRIDE"
-  # Verify the path is actually a worktree of this repo. `git worktree list`
-  # prints absolute paths in column 1; awk on $1 is robust to trailing
-  # metadata columns. We compare against the resolved absolute path.
+  # Verify the path is actually a worktree of this repo. Each porcelain stanza
+  # begins with a literal `worktree ` prefix (9 chars) followed by the
+  # unquoted, unescaped absolute path — which may contain spaces. Parse the
+  # path with substr($0, 10), NOT $2/whitespace-split (which truncates at the
+  # first space). Caveat: a path containing a literal newline would still break
+  # this line-oriented parse; `--porcelain -z` (NUL-delimited) would be needed
+  # for full robustness, but spaces are the realistic failure mode (#3717).
   if ! git -C "$REPO_ROOT" worktree list --porcelain 2>/dev/null | \
-       awk -v p="$_WT_ABS" '/^worktree / { if ($2 == p) { found=1; exit } } END { exit !found }'; then
+       awk -v p="$_WT_ABS" '/^worktree / { if (substr($0, 10) == p) { found=1; exit } } END { exit !found }'; then
     error "--worktree-path is not a registered worktree of this repository: $WORKTREE_PATH_OVERRIDE (resolved: $_WT_ABS)"
   fi
   WORKTREE_PATH_OVERRIDE="$_WT_ABS"
@@ -836,9 +840,14 @@ fi
 _worktree_branch_for() {
   local target="$1" target_abs
   target_abs="$(cd "$target" 2>/dev/null && pwd -P)" || target_abs="$target"
+  # The `worktree ` path line (prefix = 9 chars) may contain spaces, so parse
+  # it with substr($0, 10) rather than $2 (which truncates at the first space).
+  # The `branch ` line is safe with $2 — git ref names cannot contain spaces.
+  # Caveat: a path with a literal newline would still break this line-oriented
+  # parse; `--porcelain -z` would be needed for full robustness (#3717).
   git -C "$REPO_ROOT" worktree list --porcelain 2>/dev/null | \
     awk -v p="$target_abs" '
-      /^worktree / { wt=$2; br=""; next }
+      /^worktree / { wt=substr($0, 10); br=""; next }
       /^branch /   { br=$2 }
       /^$/         { if (wt == p && br != "" && !found) { sub(/^refs\/heads\//, "", br); print br; found=1; exit } }
       END          { if (wt == p && br != "" && !found) { sub(/^refs\/heads\//, "", br); print br } }
@@ -851,8 +860,11 @@ _worktree_branch_for() {
 # error (e.g. not a git repo). Used by _remove_loom_worktree to hard-refuse
 # removing the primary checkout (#3710).
 _primary_worktree_path() {
+  # Parse the path via substr($0, 10) (strip the literal `worktree ` prefix, 9
+  # chars) so a primary checkout under a space-containing path is not truncated
+  # at the first space. Newline-in-path caveat: see _worktree_branch_for (#3717).
   git -C "$REPO_ROOT" worktree list --porcelain 2>/dev/null | \
-    awk '/^worktree / { print $2; exit }'
+    awk '/^worktree / { print substr($0, 10); exit }'
 }
 
 # Walk porcelain output for a worktree whose branch matches the given branch
@@ -860,9 +872,12 @@ _primary_worktree_path() {
 # bare entries (they have no `branch refs/heads/...` line).
 _find_worktree_by_branch() {
   local want_branch="$1"
+  # `worktree ` path parsed via substr($0, 10) (space-safe); `branch ` via $2
+  # (ref names cannot contain spaces). Newline-in-path caveat: see
+  # _worktree_branch_for (#3717).
   git -C "$REPO_ROOT" worktree list --porcelain 2>/dev/null | \
     awk -v want="refs/heads/${want_branch}" '
-      /^worktree / { wt=$2; br=""; next }
+      /^worktree / { wt=substr($0, 10); br=""; next }
       /^branch /   { br=$2 }
       /^$/         { if (br == want && !found) { print wt; found=1; exit } }
       END          { if (br == want && !found) { print wt } }

--- a/defaults/scripts/tests/test-merge-pr-primary-worktree-guard.sh
+++ b/defaults/scripts/tests/test-merge-pr-primary-worktree-guard.sh
@@ -55,8 +55,8 @@ echo "Test 1: merge-pr.sh source retains the #3710 primary-worktree guard"
 
 assert_grep '_primary_worktree_path\(\) \{' "$MERGE_PR" \
     "merge-pr.sh defines the _primary_worktree_path helper"
-assert_grep "awk '/\^worktree / \{ print \\\$2; exit \}'" "$MERGE_PR" \
-    "_primary_worktree_path takes the FIRST worktree entry (print; exit)"
+assert_grep "awk '/\^worktree / \{ print substr\(\\\$0, 10\); exit \}'" "$MERGE_PR" \
+    "_primary_worktree_path takes the FIRST worktree entry, space-safe (substr; exit)"
 assert_grep 'Refusing to remove the primary/main worktree' "$MERGE_PR" \
     "_remove_loom_worktree refuses when the target resolves to the primary"
 assert_grep 'primary_real="\$\(_primary_worktree_path\)"' "$MERGE_PR" \
@@ -192,6 +192,84 @@ if [[ $sec_rc -eq 0 ]] \
     pass "secondary managed worktree is removed (guard is surgical, not blanket)"
 else
     fail "secondary should be removed; rc=$sec_rc, dir_exists=$([[ -d "$SECONDARY" ]] && echo yes || echo no), out: $sec_out"
+fi
+
+# --- Test 4: space-in-path regression (#3717) ---
+# The porcelain `worktree <path>` line is unquoted/unescaped and may contain
+# spaces. Parsing with $2 (whitespace-split) truncates at the first space; the
+# fix parses via substr($0, 10) (strip the literal `worktree ` prefix). Assert
+# every porcelain-parsing helper resolves the FULL space-containing path, plus
+# the --worktree-path registered-worktree validation snippet.
+echo ""
+echo "Test 4: porcelain parsing preserves worktree paths containing spaces (#3717)"
+
+# Extract _find_worktree_by_branch too (used below); other bodies already eval'd.
+eval "$(extract_fn _find_worktree_by_branch "$MERGE_PR")"
+
+SP_ROOT="$TMP_ROOT/My Repos"     # <-- the space lives here
+SP_PRIMARY="$SP_ROOT/repo"
+mkdir -p "$SP_PRIMARY"
+git -C "$SP_PRIMARY" init -q
+git -C "$SP_PRIMARY" config user.email "test@example.com"
+git -C "$SP_PRIMARY" config user.name "Test"
+echo "hello" > "$SP_PRIMARY/README.md"
+git -C "$SP_PRIMARY" add -A
+git -C "$SP_PRIMARY" commit -q -m "initial"
+
+# A secondary worktree, also under a space-containing path.
+SP_SECONDARY="$SP_ROOT/wt/issue-3717"
+SP_BRANCH="feature/issue-3717"
+git -C "$SP_PRIMARY" worktree add -q -b "$SP_BRANCH" "$SP_SECONDARY" >/dev/null 2>&1
+
+# Resolve canonical (symlink-free) forms to compare against git's output.
+SP_PRIMARY_REAL="$(cd "$SP_PRIMARY" && pwd -P)"
+SP_SECONDARY_REAL="$(cd "$SP_SECONDARY" && pwd -P)"
+
+# Point the eval'd helpers at the space-containing primary.
+# shellcheck disable=SC2034
+REPO_ROOT="$SP_PRIMARY"
+
+# (a) _primary_worktree_path returns the FULL primary path (not truncated at
+#     "My").
+sp_primary="$(_primary_worktree_path)"
+if [[ "$sp_primary" == "$SP_PRIMARY_REAL" ]]; then
+    pass "_primary_worktree_path returns the full space-containing path"
+else
+    fail "_primary_worktree_path truncated: expected '$SP_PRIMARY_REAL', got '$sp_primary'"
+fi
+
+# (b) _find_worktree_by_branch returns the FULL secondary path.
+sp_found="$(_find_worktree_by_branch "$SP_BRANCH")"
+if [[ "$sp_found" == "$SP_SECONDARY_REAL" ]]; then
+    pass "_find_worktree_by_branch returns the full space-containing secondary path"
+else
+    fail "_find_worktree_by_branch truncated: expected '$SP_SECONDARY_REAL', got '$sp_found'"
+fi
+
+# (c) _worktree_branch_for resolves the correct branch short-name from the
+#     full space-containing path.
+sp_branch="$(_worktree_branch_for "$SP_SECONDARY_REAL")"
+if [[ "$sp_branch" == "$SP_BRANCH" ]]; then
+    pass "_worktree_branch_for resolves the branch from a space-containing path"
+else
+    fail "_worktree_branch_for failed on space path: expected '$SP_BRANCH', got '$sp_branch'"
+fi
+
+# (d) The --worktree-path registered-worktree validation snippet (the same awk
+#     used at merge-pr.sh:~242) must accept the full space-containing path.
+if git -C "$SP_PRIMARY" worktree list --porcelain 2>/dev/null | \
+     awk -v p="$SP_SECONDARY_REAL" '/^worktree / { if (substr($0, 10) == p) { found=1; exit } } END { exit !found }'; then
+    pass "--worktree-path validation accepts a registered space-containing worktree"
+else
+    fail "--worktree-path validation rejected a registered space-containing worktree"
+fi
+
+# (e) Negative control: an unregistered space path must still be rejected.
+if git -C "$SP_PRIMARY" worktree list --porcelain 2>/dev/null | \
+     awk -v p="$SP_ROOT/not a worktree" '/^worktree / { if (substr($0, 10) == p) { found=1; exit } } END { exit !found }'; then
+    fail "--worktree-path validation wrongly accepted an unregistered path"
+else
+    pass "--worktree-path validation still rejects an unregistered space-containing path"
 fi
 
 # --- Summary ---


### PR DESCRIPTION
Closes #3717

## Problem

`git worktree list --porcelain` emits the worktree path unquoted and unescaped after a literal `worktree ` prefix, and that path may contain spaces. Four awk blocks in `defaults/scripts/merge-pr.sh` parsed the path with `$2` (whitespace field-split), truncating at the first space. A repo — or a customized `worktree.root` — under a space-containing path (`~/My Repos`, `/Volumes/My Drive`, etc.) then failed `--worktree-path` validation, mis-resolved branches, and printed truncated primary/discovery paths.

## Fix

Parse the path by stripping the literal 9-char `worktree ` prefix (`substr($0, 10)`) in all four spots:
- `--worktree-path` registered-worktree validation
- `_worktree_branch_for`
- `_primary_worktree_path` (added by #3714)
- `_find_worktree_by_branch`

The `branch refs/heads/...` lines keep `$2` — git ref names cannot contain spaces, so no change is needed (and the distinction is documented in-code). A code comment records the residual newline-in-path caveat: line-oriented parsing still breaks on a path containing a literal newline; `--porcelain -z` (NUL-delimited) would be needed for full robustness, but spaces are the realistic failure mode.

## Test

Extends `test-merge-pr-primary-worktree-guard.sh` (which already runs the extracted live function bodies against a real git repo, so it cannot drift) with a **Test 4** that builds a real repo whose primary and secondary worktrees both sit under a space-containing path (`$TMP/My Repos/...`) and asserts:
- `_primary_worktree_path` returns the full path (not truncated at the space)
- `_find_worktree_by_branch <branch>` returns the full secondary path
- `_worktree_branch_for <full-path>` resolves the correct branch short-name
- the `--worktree-path` validation awk accepts the registered space path (plus a negative control that an unregistered path is still rejected)

Also updates the guard's static grep assertion to match the new `substr` form.

## Verification

- `test-merge-pr-primary-worktree-guard.sh` — 14/14 pass
- `test-merge-pr-worktree-awk.sh` — 11/11 pass
- `test-merge-pr-worktree-path.sh` — 21/21 pass
- `bash -n` and `shellcheck -S warning` on `merge-pr.sh` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)