### PR TITLE
feat(loom): opt-in session-transcript archival to a durable location (#3726)

### DIFF
--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -1333,6 +1333,22 @@ Wave annotation makes it easier to triage failures (e.g., "every issue in wave 2
 
 **`rate-limited` vs `blocked` (issue #3683).** These are semantically distinct — reuse the `TOKEN_EXPIRED` / `TOKEN_EXHAUSTED` vocabulary from `.loom/scripts/lib/classify-error.sh` for the reason. `blocked (...)` means the **work itself** failed (build error, doctor cycle exhausted) and a human must fix the actual problem. `rate-limited (...)` means only that a role subagent was killed by an account rate limit mid-phase, so an **extra orchestrator pass** was needed to reach the phase's expected exit state — it says nothing about work quality. A `rate-limited (resumed: <what completed>)` outcome already succeeded (the mid-phase-death recovery finished the missing steps); only a `rate-limited (unresumable: ...)` outcome — where the forge state cannot be recovered without human help — needs attention.
 
+## Session Transcript Archival (completion hook, #3726)
+
+After the entire sweep has settled (issue list exhausted / all PRs processed) and just before printing the Summary Output, run the transcript archiver once so this session's transcript and all its subagent transcripts are captured to durable storage:
+
+```bash
+./.loom/scripts/archive-transcripts.sh
+```
+
+This is **safe to run unconditionally** — the archiver is a **no-op unless archival is opted in** (env `LOOM_TRANSCRIPT_ARCHIVE=<dir>` or `.loom/config.json → loom.transcriptArchive.enabled`). When enabled it copies `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/<cwd-slug>/` (the session's own `<uuid>.jsonl` plus the sibling `<uuid>/subagents/agent-*.jsonl` + `.meta.json` sidecars) into `<dir>/<repo>/<date>/<uuid>/`, emits an `agent-<id>`-keyed `index.json` join key, and is **idempotent** (a re-run copies nothing new).
+
+**Caveat (why the cron backstop still matters):** at this completion point the session's own top-level `<uuid>.jsonl` may still be mid-flush — the final orchestrator messages can lag. The completion hook reliably captures finished subagents; the durable tail is guaranteed only by the cron-friendly periodic sync documented in CLAUDE.md ("Session Transcript Archival"). Run both.
+
+**Guardrails apply** (off by default; destination `0700`/files `0600`; refuses if the destination is inside a git repo but not gitignored; prints a loud banner naming the destination when enabled). See CLAUDE.md → "Session Transcript Archival" for the full contract and the secrets caveat.
+
+> **Daemon detached-child path (v1 refinement, not a blocker).** For sweeps dispatched by the daemon as detached children, the reaper in `loom-daemon/src/sweep_registry.rs` knows the child's PID and issue but **not** its Claude session-uuid, so it cannot yet trigger a precise single-session archive on exit. v1 relies on the **periodic sync** (which copies all recent sessions for the repo regardless of uuid mapping) as the backstop for the detached path; a reaper-triggered auto-invoke keyed on the child's session-uuid is a documented follow-on.
+
 ## Stop Conditions
 
 Stop processing and print the summary when any of these conditions hold:

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -743,6 +743,76 @@ The ladder is configured in `.loom/config.json`:
 }
 ```
 
+### Session Transcript Archival (opt-in, #3726)
+
+Claude Code writes a full JSONL transcript for every session — and a per-subagent
+transcript for every Builder / Judge / Doctor Task — under
+`${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/<cwd-slug>/`. These are the
+ground-truth record of what each agent did and what it cost (per-message `usage`
++ `model`), but they live only on the local box and are subject to Claude Code's
+own pruning. `archive-transcripts.sh` copies them to a durable location so a
+multi-day canary run can be audited / cost-harvested after the fact (serves the
+#3725 per-role cost harvest — the archived index is its `agent-<id>` join key).
+
+**Off by default. Zero behavior change unless you turn it on.** Enable via env or
+config (env-over-config precedence, matching the `guards.rmScope` string pattern):
+
+```bash
+# env wins over config; a path enables, ""/off/0/no/disabled forces off:
+LOOM_TRANSCRIPT_ARCHIVE=/Volumes/scratch/loom-transcripts \
+  ./.loom/scripts/archive-transcripts.sh
+```
+
+```json
+// .loom/config.json — new top-level "loom" block:
+{ "loom": { "transcriptArchive": { "enabled": true, "dir": "/Volumes/scratch/loom-transcripts" } } }
+```
+
+**Layout at destination** — `<dir>/<repo>/<date>/<session-uuid>/`:
+
+```
+<session-uuid>.jsonl                       the session's own transcript
+<session-uuid>/subagents/agent-*.jsonl     per-subagent transcripts
+<session-uuid>/subagents/agent-*.meta.json role+issue sidecars (copied verbatim)
+<session-uuid>/tool-results/…              large tool outputs
+index.json                                 agent-id-keyed join index (schema loom.transcript-index/v1)
+```
+
+The `index.json` is keyed by `agent-<id>` with one row per subagent; **role and
+issue are read from the existing `agent-*.meta.json` sidecars** (not re-derived),
+and the archiver adds only the loom-side context the sidecar lacks (repo, sweep
+issue, model, start/end ts, and `arm`/`attempt` when a model experiment is active).
+
+**Base path is `CLAUDE_CONFIG_DIR`-aware** — the archiver never hard-codes
+`~/.claude`. Per-agent isolated config dirs (`.loom/claude-config/<agent>/`) get a
+fresh `projects/`, so the copier resolves its source through
+`${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects` (mirrors
+`loom_tools.common.claude_config.resolve_projects_dir()`).
+
+**When it runs**: cron-friendly periodic sync (the durability backstop — the
+session's own top-level `<uuid>.jsonl` is still being appended while the session
+runs, so only a periodic + at-exit sync reliably captures the tail), plus a
+completion-time invocation from `/loom:sweep`. Idempotent (size + mtime skip), so
+re-runs copy nothing new. Cron example:
+
+```cron
+*/15 * * * * cd /path/to/repo && ./.loom/scripts/archive-transcripts.sh >> .loom/logs/archive-transcripts.log 2>&1
+```
+
+> **Guardrails — transcripts can contain secrets.** A transcript is full tool I/O
+> and may include `.env` contents or token values that scrolled through a shell.
+> The archiver treats the destination as sensitive, exactly like `.loom/tokens/`
+> and `accounts.env`: created **mode `0700`**, files **`0600`**; if the destination
+> is **inside a git repo it MUST be gitignored** or the archiver **refuses** (it
+> will not copy secret-bearing transcripts into a tracked tree); and it prints a
+> **loud one-line banner naming the destination** whenever archival is enabled.
+> As with the token pool, **you (the operator) own the security of the archive
+> location** — put it outside any repo, or gitignore it.
+
+**Out of scope (v1)**: remote / object-storage backends (`s3://`, `gcs://`,
+rsync-to-remote) are an explicit follow-on — v1 is a local filesystem destination
+only.
+
 ### Custom Roles
 
 Create custom roles by adding files to `.loom/roles/`:

--- a/defaults/scripts/archive-transcripts.sh
+++ b/defaults/scripts/archive-transcripts.sh
@@ -1,0 +1,362 @@
+#!/usr/bin/env bash
+# archive-transcripts.sh - Opt-in, idempotent archival of Claude Code session
+# transcripts (and their per-subagent transcripts + meta sidecars) to a durable
+# local filesystem location.  Issue #3726.
+#
+# WHY: session JSONL transcripts under ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/
+# are the ground-truth record of what every agent did and what it cost, but they
+# live only on the local box and are subject to Claude Code's own pruning.  This
+# copier snapshots them to a long-term location so a multi-day canary run can be
+# audited / cost-harvested after the fact (serves #3725).
+#
+# OPT-IN.  Does nothing unless archival is enabled via env or config:
+#   - env  LOOM_TRANSCRIPT_ARCHIVE=<dir>   (a path enables; ""/off/0/no disables)
+#   - config .loom/config.json ->
+#       { "loom": { "transcriptArchive": { "enabled": true, "dir": "<dir>" } } }
+#   Precedence: env  >  config  >  default(disabled).   (matches guards.rmScope)
+#
+# LAYOUT AT DESTINATION:
+#   <dest>/<repo>/<date>/<session-uuid>/
+#       <session-uuid>.jsonl              the session's own transcript
+#       <session-uuid>/subagents/agent-*.jsonl        per-subagent transcripts
+#       <session-uuid>/subagents/agent-*.meta.json    role+issue sidecars
+#       <session-uuid>/tool-results/...   large tool outputs
+#       index.json                        agent-id-keyed join key (for #3725)
+#
+# GUARDRAILS (load-bearing — transcripts can contain secrets):
+#   - off by default
+#   - destination dir mode 0700, files 0600
+#   - if the destination is inside a git repo it MUST be gitignored, else refuse
+#   - loud startup banner naming the destination when enabled
+#
+# Usage:
+#   ./.loom/scripts/archive-transcripts.sh                 # sync (env/config-gated)
+#   ./.loom/scripts/archive-transcripts.sh --dry-run       # preview, no writes
+#   ./.loom/scripts/archive-transcripts.sh --source-cwd DIR # slug from DIR (default $PWD)
+#   ./.loom/scripts/archive-transcripts.sh --issue N        # tag index with sweep issue
+#   ./.loom/scripts/archive-transcripts.sh --dest DIR       # override destination
+#   ./.loom/scripts/archive-transcripts.sh --all-repo-sessions  # also worktree cwds
+#
+# Cron example (durability backstop every 15 min while a canary runs):
+#   */15 * * * * cd /path/to/repo && ./.loom/scripts/archive-transcripts.sh >> .loom/logs/archive-transcripts.log 2>&1
+#
+# Exit codes:
+#   0 - archival disabled (no-op) OR sync completed (possibly copying nothing new)
+#   1 - a hard error (e.g. destination inside a repo but not gitignored)
+
+set -uo pipefail
+
+# ------------------------------------------------------------------ output ---
+RED='\033[0;31m'; GREEN='\033[0;32m'; BLUE='\033[0;34m'; YELLOW='\033[1;33m'
+CYAN='\033[0;36m'; NC='\033[0m'
+error()   { echo -e "${RED}Error: $*${NC}" >&2; exit 1; }
+info()    { echo -e "${BLUE}$*${NC}"; }
+success() { echo -e "${GREEN}$*${NC}"; }
+warning() { echo -e "${YELLOW}$*${NC}" >&2; }
+header()  { echo -e "${CYAN}$*${NC}"; }
+
+# ---------------------------------------------------------------- defaults ---
+DRY_RUN=false
+SOURCE_CWD="$PWD"
+OPT_DEST=""
+SWEEP_ISSUE=""
+ARM=""
+ATTEMPT=""
+ALL_REPO_SESSIONS=false
+
+# ------------------------------------------------------------------- args ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)           DRY_RUN=true; shift ;;
+    --source-cwd)        SOURCE_CWD="${2:?--source-cwd needs a path}"; shift 2 ;;
+    --dest)              OPT_DEST="${2:?--dest needs a path}"; shift 2 ;;
+    --issue)             SWEEP_ISSUE="${2:?--issue needs a number}"; shift 2 ;;
+    --arm)               ARM="${2:?--arm needs a value}"; shift 2 ;;
+    --attempt)           ATTEMPT="${2:?--attempt needs a value}"; shift 2 ;;
+    --all-repo-sessions) ALL_REPO_SESSIONS=true; shift ;;
+    -h|--help)
+      sed -n '2,50p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) error "Unknown option: $1 (use --help)" ;;
+  esac
+done
+
+lower() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
+
+# slugify a path the way Claude Code names its projects/ subdirs: '/' -> '-'.
+slugify() { printf '%s' "$1" | sed 's#/#-#g'; }
+
+# portable mtime epoch (BSD stat then GNU stat).
+file_mtime_epoch() { stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null || echo 0; }
+file_size()        { stat -f %z "$1" 2>/dev/null || stat -c %s "$1" 2>/dev/null || echo 0; }
+epoch_to_date()    { date -r "$1" +%Y-%m-%d 2>/dev/null || date -d "@$1" +%Y-%m-%d 2>/dev/null || date +%Y-%m-%d; }
+iso_now()          { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+# ---------------------------------------------- resolve enable + destination ---
+# CORRECTION 2: base is CLAUDE_CONFIG_DIR-aware, never hard-coded ~/.claude.
+CLAUDE_BASE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+PROJECTS_DIR="$CLAUDE_BASE/projects"
+
+# Repo root of the thing being archived (best-effort; used for the <repo> label
+# and for the config.json read).  A worktree resolves to the worktree root.
+REPO_ROOT="$(git -C "$SOURCE_CWD" rev-parse --show-toplevel 2>/dev/null || true)"
+REPO_LABEL="$(basename "${REPO_ROOT:-$SOURCE_CWD}")"
+CONFIG_JSON="${REPO_ROOT:+$REPO_ROOT/.loom/config.json}"
+
+CFG_ENABLED=false
+CFG_DIR=""
+if [[ -n "${CONFIG_JSON:-}" && -f "$CONFIG_JSON" ]] && command -v jq >/dev/null 2>&1; then
+  # Best-effort: malformed JSON -> jq fails -> disabled default preserved.
+  CFG_ENABLED="$(jq -r '.loom.transcriptArchive.enabled // false' "$CONFIG_JSON" 2>/dev/null || echo false)"
+  CFG_DIR="$(jq -r '.loom.transcriptArchive.dir // ""' "$CONFIG_JSON" 2>/dev/null || echo "")"
+fi
+
+ENABLED=false
+DEST=""
+if [[ -n "${LOOM_TRANSCRIPT_ARCHIVE+set}" ]]; then
+  # env is present (even if empty) -> env wins over config.
+  case "$(lower "${LOOM_TRANSCRIPT_ARCHIVE}")" in
+    ""|off|0|no|false|disabled) ENABLED=false ;;
+    *) ENABLED=true; DEST="$LOOM_TRANSCRIPT_ARCHIVE" ;;
+  esac
+elif [[ "$CFG_ENABLED" == "true" && -n "$CFG_DIR" ]]; then
+  ENABLED=true; DEST="$CFG_DIR"
+fi
+
+# Explicit --dest always forces on.
+if [[ -n "$OPT_DEST" ]]; then ENABLED=true; DEST="$OPT_DEST"; fi
+
+# Disabled -> silent no-op, zero side effects, zero behaviour change.
+if [[ "$ENABLED" != "true" ]]; then
+  exit 0
+fi
+
+# Enabled but no usable destination -> fail safe to off with a warning.
+DEST="${DEST/#\~/$HOME}"
+if [[ -z "$DEST" ]]; then
+  warning "transcriptArchive enabled but no destination configured — skipping (fail-safe off)."
+  exit 0
+fi
+
+# ------------------------------------------------------------- guardrails ---
+# gitignore-or-refuse: if DEST lives inside a git repo it must be gitignored,
+# else we would leak secret-bearing transcripts into a tracked tree.
+guard_dest_not_tracked() {
+  local dest="$1" probe="$1" top
+  # DEST may not exist yet — walk up to the nearest existing ancestor.
+  while [[ ! -e "$probe" && "$probe" != "/" && -n "$probe" ]]; do
+    probe="$(dirname "$probe")"
+  done
+  top="$(git -C "$probe" rev-parse --show-toplevel 2>/dev/null || true)"
+  [[ -z "$top" ]] && return 0  # not inside any repo -> fine
+  # Probe WITH a trailing slash so git treats DEST as a directory: this matches
+  # directory-only patterns (e.g. `arch/`) even before the dir is created.
+  if git -C "$top" check-ignore -q "${dest%/}/" 2>/dev/null; then
+    return 0  # ignored -> fine
+  fi
+  error "Destination '$dest' is inside git repo '$top' but is NOT gitignored.
+  Transcripts may contain secrets (full tool I/O, scrolled .env/token values).
+  Refusing to copy them into a tracked tree. Add the path to .gitignore, or
+  choose a destination outside the repository."
+}
+guard_dest_not_tracked "$DEST"
+
+# 0700 dirs.
+ensure_dir() { mkdir -p "$1" && chmod 700 "$1"; }
+
+# Loud one-line banner: an operator must always know transcripts are leaving box.
+warning "════════════════════════════════════════════════════════════════════"
+warning "  TRANSCRIPT ARCHIVAL ENABLED — transcripts (which may contain"
+warning "  SECRETS) are being copied off-box to: $DEST"
+warning "  You (operator) own the security of this location. See CLAUDE.md."
+warning "════════════════════════════════════════════════════════════════════"
+
+# --------------------------------------------------------- copy primitives ---
+COPIED=0
+SKIPPED=0
+
+# copy_file <src> <dst>: idempotent (skip when same size and dst not older).
+copy_file() {
+  local src="$1" dst="$2"
+  if [[ -f "$dst" ]]; then
+    local ss ds sm dm
+    ss="$(file_size "$src")"; ds="$(file_size "$dst")"
+    sm="$(file_mtime_epoch "$src")"; dm="$(file_mtime_epoch "$dst")"
+    if [[ "$ss" == "$ds" && "$sm" -le "$dm" ]]; then
+      SKIPPED=$((SKIPPED + 1)); return 0
+    fi
+  fi
+  if [[ "$DRY_RUN" == true ]]; then
+    info "  would copy: ${src#"$PROJECTS_DIR"/} -> ${dst#"$DEST"/}"
+    COPIED=$((COPIED + 1)); return 0
+  fi
+  cp -p "$src" "$dst" && chmod 600 "$dst"
+  COPIED=$((COPIED + 1))
+}
+
+# copy_tree <src_dir> <dst_dir>: mirror every file, 0700 dirs / 0600 files.
+copy_tree() {
+  local src="$1" dst="$2" rel f target
+  [[ -d "$src" ]] || return 0
+  while IFS= read -r f; do
+    rel="${f#"$src"/}"
+    target="$dst/$rel"
+    [[ "$DRY_RUN" == true ]] || ensure_dir "$(dirname "$target")"
+    copy_file "$f" "$target"
+  done < <(find "$src" -type f 2>/dev/null)
+}
+
+# --------------------------------------------------------------- index.json ---
+# CORRECTION 3: role + issue already exist on disk as agent-*.meta.json sidecars.
+# Emit an agent-id-keyed session index adding only the loom-side context the
+# sidecar lacks (repo, sweep issue, model, start/end ts, arm/attempt). Schema is
+# the #3725 join key — keep it agent-id keyed, one row per subagent.
+jsonl_first_ts() { jq -r 'select(.timestamp) | .timestamp' "$1" 2>/dev/null | head -1; }
+jsonl_last_ts()  { jq -r 'select(.timestamp) | .timestamp' "$1" 2>/dev/null | tail -1; }
+jsonl_model()    { jq -r 'select(.message.model) | .message.model' "$1" 2>/dev/null | grep -v '^null$' | head -1; }
+
+write_index() {
+  local sess_dir="$1" uuid="$2" date="$3"
+  command -v jq >/dev/null 2>&1 || { warning "jq not found — skipping index.json for $uuid"; return 0; }
+
+  local subdir="$sess_dir/$uuid/subagents"
+  local agents_json="[]"
+  if [[ -d "$subdir" ]]; then
+    local meta agent_id role desc issue jsonl model start end obj
+    local acc=""
+    while IFS= read -r meta; do
+      [[ -e "$meta" ]] || continue
+      agent_id="$(basename "$meta" .meta.json)"
+      role="$(jq -r '.agentType // ""' "$meta" 2>/dev/null || echo "")"
+      desc="$(jq -r '.description // ""' "$meta" 2>/dev/null || echo "")"
+      issue="$(printf '%s' "$desc" | grep -oE '#?[0-9]+' | head -1 | tr -d '#' || true)"
+      jsonl="$subdir/$agent_id.jsonl"
+      model=""; start=""; end=""
+      if [[ -f "$jsonl" ]]; then
+        model="$(jsonl_model "$jsonl")"
+        start="$(jsonl_first_ts "$jsonl")"
+        end="$(jsonl_last_ts "$jsonl")"
+      fi
+      obj="$(jq -n \
+        --arg id "$agent_id" --arg role "$role" --arg desc "$desc" \
+        --arg issue "$issue" --arg model "$model" \
+        --arg start "$start" --arg end "$end" \
+        --arg arm "$ARM" --arg attempt "$ATTEMPT" \
+        --arg tr "subagents/$agent_id.jsonl" --arg meta "subagents/$agent_id.meta.json" \
+        '{agent_id:$id,
+          role:(($role|select(.!="")) // null),
+          issue:(($issue|select(.!="")|tonumber?) // null),
+          description:(($desc|select(.!="")) // null),
+          model:(($model|select(.!="")) // null),
+          arm:(($arm|select(.!="")) // null),
+          attempt:(($attempt|select(.!="")|tonumber?) // null),
+          start_ts:(($start|select(.!="")) // null),
+          end_ts:(($end|select(.!="")) // null),
+          transcript:$tr, meta:$meta}')"
+      acc="$acc$obj"$'\n'
+    done < <(find "$subdir" -maxdepth 1 -name '*.meta.json' 2>/dev/null | sort)
+    if [[ -n "$acc" ]]; then
+      agents_json="$(printf '%s' "$acc" | jq -s '.')"
+    fi
+  fi
+
+  local index
+  index="$(jq -n \
+    --arg schema "loom.transcript-index/v1" \
+    --arg uuid "$uuid" --arg repo "$REPO_LABEL" \
+    --arg slug "$SLUG" --arg date "$date" \
+    --arg issue "$SWEEP_ISSUE" --arg archived "$(iso_now)" \
+    --arg sess "$uuid.jsonl" \
+    --argjson agents "$agents_json" \
+    '{schema:$schema, session_uuid:$uuid, repo:$repo, source_cwd_slug:$slug,
+      date:$date, sweep_issue:(($issue|select(.!="")|tonumber?) // null),
+      archived_at:$archived, session_transcript:$sess, agents:$agents}')"
+
+  if [[ "$DRY_RUN" == true ]]; then
+    info "  would write index.json for session $uuid ($(printf '%s' "$agents_json" | jq 'length') agent row(s))"
+    return 0
+  fi
+  printf '%s\n' "$index" > "$sess_dir/index.json" && chmod 600 "$sess_dir/index.json"
+}
+
+# --------------------------------------------------------------- main sync ---
+header "════════════════════════════════════════════"
+header "  Loom Transcript Archiver"
+[[ "$DRY_RUN" == true ]] && header "  (DRY RUN)"
+header "════════════════════════════════════════════"
+
+# Claude Code names its projects/ subdir from the *raw* cwd it was launched in
+# (not a symlink-canonicalized path), so slug from SOURCE_CWD — not the
+# git-canonicalized REPO_ROOT — or a symlinked checkout (e.g. /var -> /private/var
+# on macOS) would miss.  REPO_ROOT is used only for the <repo> label + config read.
+SLUG="$(slugify "$SOURCE_CWD")"
+REPO_SLUG="$(slugify "${REPO_ROOT:-$SOURCE_CWD}")"
+
+# Which project dirs to sync.  Primary: the exact cwd slug (the sweep session's
+# own project dir, which also holds all its subagents/).  --all-repo-sessions
+# additionally globs sibling slugs (worktree cwds) sharing the repo prefix.
+declare -a PROJ_DIRS=()
+if [[ -d "$PROJECTS_DIR/$SLUG" ]]; then PROJ_DIRS+=("$PROJECTS_DIR/$SLUG"); fi
+if [[ "$ALL_REPO_SESSIONS" == true ]]; then
+  for d in "$PROJECTS_DIR/$REPO_SLUG"*/; do
+    [[ -d "$d" ]] || continue
+    d="${d%/}"
+    [[ "$d" == "$PROJECTS_DIR/$SLUG" ]] && continue
+    PROJ_DIRS+=("$d")
+  done
+fi
+
+if [[ ${#PROJ_DIRS[@]} -eq 0 ]]; then
+  info "No transcripts found under $PROJECTS_DIR/$SLUG — nothing to archive."
+  exit 0
+fi
+
+info "Source : $PROJECTS_DIR/$SLUG"
+info "Dest   : $DEST/$REPO_LABEL/<date>/<uuid>/"
+echo ""
+
+SESSIONS=0
+for proj in "${PROJ_DIRS[@]}"; do
+  # Union of session uuids: top-level <uuid>.jsonl stems + companion <uuid>/ dirs.
+  uuids="$( { \
+      for f in "$proj"/*.jsonl; do [[ -e "$f" ]] && basename "$f" .jsonl; done; \
+      for d in "$proj"/*/; do [[ -d "$d" ]] && basename "$d"; done; \
+    } 2>/dev/null | sort -u )"
+
+  [[ -z "$uuids" ]] && continue
+
+  while IFS= read -r uuid; do
+    [[ -z "$uuid" ]] && continue
+    local_jsonl="$proj/$uuid.jsonl"
+    local_dir="$proj/$uuid"
+
+    # Date bucket: from the session jsonl mtime, else the companion dir mtime.
+    if [[ -f "$local_jsonl" ]]; then
+      sdate="$(epoch_to_date "$(file_mtime_epoch "$local_jsonl")")"
+    elif [[ -d "$local_dir" ]]; then
+      sdate="$(epoch_to_date "$(file_mtime_epoch "$local_dir")")"
+    else
+      continue
+    fi
+
+    sess_dir="$DEST/$REPO_LABEL/$sdate/$uuid"
+    [[ "$DRY_RUN" == true ]] || ensure_dir "$sess_dir"
+
+    # 1) the session's own transcript (a FILE at the slug top level).
+    [[ -f "$local_jsonl" ]] && copy_file "$local_jsonl" "$sess_dir/$uuid.jsonl"
+    # 2) the sibling <uuid>/ companion dir (subagents/ + meta sidecars + tool-results/).
+    [[ -d "$local_dir" ]] && copy_tree "$local_dir" "$sess_dir/$uuid"
+    # 3) the agent-id-keyed join index.
+    write_index "$sess_dir" "$uuid" "$sdate"
+
+    SESSIONS=$((SESSIONS + 1))
+  done <<< "$uuids"
+done
+
+echo ""
+if [[ "$DRY_RUN" == true ]]; then
+  success "Dry run: $SESSIONS session(s), would copy $COPIED file(s), skip $SKIPPED unchanged."
+else
+  success "Archived $SESSIONS session(s): $COPIED file(s) copied, $SKIPPED unchanged (idempotent skip)."
+fi
+exit 0

--- a/defaults/scripts/tests/test-archive-transcripts.sh
+++ b/defaults/scripts/tests/test-archive-transcripts.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# test-archive-transcripts.sh - Unit tests for defaults/scripts/archive-transcripts.sh
+# (issue #3726 — opt-in session-transcript archival).
+#
+# Strategy: build a throwaway Claude Code projects/ tree under a temp
+# CLAUDE_CONFIG_DIR and a throwaway git repo as the "source cwd", then drive the
+# copier through env/config and assert on the destination layout, file modes, the
+# agent-id-keyed index.json, idempotency, the CLAUDE_CONFIG_DIR-aware base, the
+# gitignore-or-refuse guard, and the disabled-by-default no-op.
+#
+# Usage:
+#   bash defaults/scripts/tests/test-archive-transcripts.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/../archive-transcripts.sh"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
+TESTS_RUN=0; TESTS_PASSED=0; TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN+1)); TESTS_PASSED=$((TESTS_PASSED+1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { TESTS_RUN=$((TESTS_RUN+1)); TESTS_FAILED=$((TESTS_FAILED+1)); echo -e "  ${RED}FAIL${NC}: $1"; }
+
+assert_file()    { if [[ -f "$1" ]]; then pass "$2"; else fail "$2 (missing: $1)"; fi; }
+assert_absent()  { if [[ ! -e "$1" ]]; then pass "$2"; else fail "$2 (exists: $1)"; fi; }
+assert_eq()      { if [[ "$1" == "$2" ]]; then pass "$3"; else fail "$3 (got '$1' want '$2')"; fi; }
+assert_contains(){ if [[ "$1" == *"$2"* ]]; then pass "$3"; else fail "$3 (missing '$2' in: $1)"; fi; }
+
+if [[ ! -f "$SCRIPT" ]]; then echo "ERROR: $SCRIPT not found" >&2; exit 1; fi
+if ! command -v jq >/dev/null 2>&1; then echo "ERROR: jq required for these tests" >&2; exit 1; fi
+
+# Build a fresh fixture: returns via globals REPO, BASE, DEST, SLUG, DATE.
+make_fixture() {
+  ROOT="$(mktemp -d "${TMPDIR:-/tmp}/att-test.XXXXXX")"
+  REPO="$ROOT/myrepo"; mkdir -p "$REPO"
+  git -C "$REPO" init -q; git -C "$REPO" config user.email t@t; git -C "$REPO" config user.name t
+  SLUG="$(printf '%s' "$REPO" | sed 's#/#-#g')"
+  BASE="$ROOT/cfgdir"
+  local proj="$BASE/projects/$SLUG"
+  mkdir -p "$proj/UUID1/subagents" "$proj/UUID1/tool-results"
+  printf '{"timestamp":"2026-07-20T10:00:00Z","message":{"model":"claude-opus-4"}}\n' > "$proj/UUID1.jsonl"
+  printf '{"timestamp":"2026-07-20T10:01:00Z","message":{"model":"claude-sonnet-4"}}\n{"timestamp":"2026-07-20T10:03:00Z"}\n' > "$proj/UUID1/subagents/agent-abc.jsonl"
+  printf '{"agentType":"loom-builder","description":"Build issue #42","spawnDepth":1}\n' > "$proj/UUID1/subagents/agent-abc.meta.json"
+  printf 'big tool output\n' > "$proj/UUID1/tool-results/r1.txt"
+  DEST="$ROOT/archive"
+  DATE="$(date +%Y-%m-%d)"
+}
+
+echo "Case 1: enabled via env — copies session + subagents + sidecars + index"
+make_fixture
+CLAUDE_CONFIG_DIR="$BASE" LOOM_TRANSCRIPT_ARCHIVE="$DEST" \
+  bash "$SCRIPT" --source-cwd "$REPO" --issue 42 >/dev/null 2>&1
+S="$DEST/myrepo/$DATE/UUID1"
+assert_file "$S/UUID1.jsonl"                              "session transcript copied"
+assert_file "$S/UUID1/subagents/agent-abc.jsonl"         "subagent transcript copied"
+assert_file "$S/UUID1/subagents/agent-abc.meta.json"     "meta sidecar copied"
+assert_file "$S/UUID1/tool-results/r1.txt"               "tool-results copied"
+assert_file "$S/index.json"                              "index.json emitted"
+echo ""
+
+echo "Case 2: file/dir modes are 0600/0700"
+DMODE="$(stat -f '%Lp' "$S" 2>/dev/null || stat -c '%a' "$S")"
+FMODE="$(stat -f '%Lp' "$S/UUID1.jsonl" 2>/dev/null || stat -c '%a' "$S/UUID1.jsonl")"
+assert_eq "$DMODE" "700" "session dir is 0700"
+assert_eq "$FMODE" "600" "transcript file is 0600"
+echo ""
+
+echo "Case 3: index.json is agent-id-keyed with role/issue from sidecar"
+ROLE="$(jq -r '.agents[0].role' "$S/index.json")"
+ISSUE="$(jq -r '.agents[0].issue' "$S/index.json")"
+AID="$(jq -r '.agents[0].agent_id' "$S/index.json")"
+MODEL="$(jq -r '.agents[0].model' "$S/index.json")"
+SCHEMA="$(jq -r '.schema' "$S/index.json")"
+SWEEP="$(jq -r '.sweep_issue' "$S/index.json")"
+assert_eq "$AID"    "agent-abc"          "index keyed by agent id"
+assert_eq "$ROLE"   "loom-builder"       "role sourced from meta sidecar"
+assert_eq "$ISSUE"  "42"                 "issue parsed from meta description"
+assert_eq "$MODEL"  "claude-sonnet-4"    "model harvested from subagent jsonl"
+assert_eq "$SCHEMA" "loom.transcript-index/v1" "schema tag present"
+assert_eq "$SWEEP"  "42"                 "sweep issue recorded"
+echo ""
+
+echo "Case 4: idempotent — second run copies nothing new"
+OUT="$(CLAUDE_CONFIG_DIR="$BASE" LOOM_TRANSCRIPT_ARCHIVE="$DEST" \
+  bash "$SCRIPT" --source-cwd "$REPO" 2>&1 | sed 's/\x1b\[[0-9;]*m//g')"
+assert_contains "$OUT" "0 file(s) copied" "second run is a no-op copy"
+rm -rf "$ROOT"
+echo ""
+
+echo "Case 5: disabled by default — no env, no config => no-op, no dest created"
+make_fixture
+CLAUDE_CONFIG_DIR="$BASE" bash "$SCRIPT" --source-cwd "$REPO" >/dev/null 2>&1
+RC=$?
+assert_eq "$RC" "0" "disabled path exits 0"
+assert_absent "$DEST" "disabled path creates no destination"
+rm -rf "$ROOT"
+echo ""
+
+echo "Case 6: CLAUDE_CONFIG_DIR override is honoured (reads overridden projects/)"
+make_fixture
+# Point HOME somewhere with NO projects, prove the copier reads CLAUDE_CONFIG_DIR.
+EMPTY_HOME="$ROOT/emptyhome"; mkdir -p "$EMPTY_HOME/.claude/projects"
+HOME="$EMPTY_HOME" CLAUDE_CONFIG_DIR="$BASE" LOOM_TRANSCRIPT_ARCHIVE="$DEST" \
+  bash "$SCRIPT" --source-cwd "$REPO" >/dev/null 2>&1
+assert_file "$DEST/myrepo/$DATE/UUID1/UUID1.jsonl" "read projects/ from CLAUDE_CONFIG_DIR, not \$HOME/.claude"
+rm -rf "$ROOT"
+echo ""
+
+echo "Case 7: gitignore-or-refuse — dest inside a repo, not ignored => refuse"
+make_fixture
+INREPO="$ROOT/inrepo"; mkdir -p "$INREPO"; git -C "$INREPO" init -q
+OUT="$(CLAUDE_CONFIG_DIR="$BASE" bash "$SCRIPT" --source-cwd "$REPO" --dest "$INREPO/arch" 2>&1 | sed 's/\x1b\[[0-9;]*m//g')"
+RC=$?
+assert_contains "$OUT" "NOT gitignored" "refuses when dest is tracked-tree"
+if [[ "$RC" -ne 0 ]]; then pass "refusal exits non-zero"; else fail "refusal exits non-zero (got $RC)"; fi
+assert_absent "$INREPO/arch/myrepo" "refusal writes no transcripts"
+echo ""
+
+echo "Case 8: gitignore-or-refuse — dest inside a repo BUT ignored => proceeds"
+printf 'arch/\n' > "$INREPO/.gitignore"
+CLAUDE_CONFIG_DIR="$BASE" bash "$SCRIPT" --source-cwd "$REPO" --dest "$INREPO/arch" >/dev/null 2>&1
+assert_file "$INREPO/arch/myrepo/$DATE/UUID1/UUID1.jsonl" "proceeds when dest is gitignored"
+rm -rf "$ROOT"
+echo ""
+
+echo "Case 9: explicit env 'off' disables even if config would enable"
+make_fixture
+mkdir -p "$REPO/.loom"
+printf '{"loom":{"transcriptArchive":{"enabled":true,"dir":"%s"}}}\n' "$DEST" > "$REPO/.loom/config.json"
+CLAUDE_CONFIG_DIR="$BASE" LOOM_TRANSCRIPT_ARCHIVE="off" bash "$SCRIPT" --source-cwd "$REPO" >/dev/null 2>&1
+assert_absent "$DEST" "env=off wins over config-enabled (env-over-config)"
+echo ""
+
+echo "Case 10: config-enabled (no env) archives to config dir"
+CLAUDE_CONFIG_DIR="$BASE" bash "$SCRIPT" --source-cwd "$REPO" >/dev/null 2>&1
+assert_file "$DEST/myrepo/$DATE/UUID1/UUID1.jsonl" "config-driven enablement works"
+rm -rf "$ROOT"
+echo ""
+
+echo "Tests run: $TESTS_RUN, Passed: $TESTS_PASSED, Failed: $TESTS_FAILED"
+[[ $TESTS_FAILED -eq 0 ]]

--- a/loom-tools/src/loom_tools/common/claude_config.py
+++ b/loom-tools/src/loom_tools/common/claude_config.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -20,6 +21,42 @@ from pathlib import Path
 from loom_tools.common.paths import LoomPaths
 
 log = logging.getLogger(__name__)
+
+
+def resolve_claude_base_dir() -> Path:
+    """Resolve the Claude Code base config directory, CLAUDE_CONFIG_DIR-aware.
+
+    Claude Code stores session state (including ``projects/``) under
+    ``$CLAUDE_CONFIG_DIR`` when that variable is set, otherwise under
+    ``~/.claude``.  Per-agent isolation (``setup_agent_config_dir``) sets
+    ``CLAUDE_CONFIG_DIR`` to ``.loom/claude-config/<agent>/``, so any code
+    that needs to *find* an agent's transcripts must honour the override
+    rather than hard-coding ``~/.claude``.
+
+    Returns:
+        The base config directory (``$CLAUDE_CONFIG_DIR`` or ``~/.claude``),
+        with ``~`` expanded.
+    """
+    override = os.environ.get("CLAUDE_CONFIG_DIR")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".claude"
+
+
+def resolve_projects_dir() -> Path:
+    """Resolve the ``projects/`` transcript root, CLAUDE_CONFIG_DIR-aware.
+
+    ``projects`` is a per-agent *mutable* directory (see ``_MUTABLE_DIRS``):
+    an isolated ``CLAUDE_CONFIG_DIR`` gets a fresh ``projects/`` rather than a
+    symlink back to ``~/.claude/projects``.  The transcript-archival tooling
+    (issue #3726) and the #3725 cost harvest both resolve their source through
+    this helper so they never look in the wrong tree.
+
+    Returns:
+        ``<base>/projects`` where ``<base>`` comes from
+        :func:`resolve_claude_base_dir`.
+    """
+    return resolve_claude_base_dir() / "projects"
 
 # Shared config files to symlink from ~/.claude/ (read-only)
 # Note: mcp.json / .mcp.json are intentionally excluded — they are

--- a/loom-tools/tests/test_claude_config.py
+++ b/loom-tools/tests/test_claude_config.py
@@ -18,6 +18,8 @@ from loom_tools.common.claude_config import (
     _resolve_state_file,
     cleanup_agent_config_dir,
     cleanup_all_agent_config_dirs,
+    resolve_claude_base_dir,
+    resolve_projects_dir,
     setup_agent_config_dir,
     validate_agent_config_dir,
 )
@@ -955,3 +957,41 @@ class TestCleanupAllAgentConfigDirs:
         count = cleanup_all_agent_config_dirs(mock_repo)
         assert count == 1
         assert not config_dir.exists()
+
+
+class TestResolveProjectsDir:
+    """Tests for the CLAUDE_CONFIG_DIR-aware base/projects resolvers (#3726)."""
+
+    def test_base_defaults_to_home_claude(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        fake_home = tmp_path / "home"
+        monkeypatch.setattr(pathlib.Path, "home", staticmethod(lambda: fake_home))
+        assert resolve_claude_base_dir() == fake_home / ".claude"
+        assert resolve_projects_dir() == fake_home / ".claude" / "projects"
+
+    def test_base_honours_claude_config_dir_override(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        override = tmp_path / ".loom" / "claude-config" / "builder-1"
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(override))
+        assert resolve_claude_base_dir() == override
+        # HARD AC (#3726 CORRECTION 2): projects/ resolves under the override,
+        # NOT ~/.claude/projects.
+        assert resolve_projects_dir() == override / "projects"
+
+    def test_override_expands_user(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", "~/isolated")
+        assert resolve_claude_base_dir() == pathlib.Path.home() / "isolated"
+
+    def test_empty_override_falls_back_to_home(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # An empty string is falsy — treat as unset.
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", "")
+        fake_home = tmp_path / "home"
+        monkeypatch.setattr(pathlib.Path, "home", staticmethod(lambda: fake_home))
+        assert resolve_claude_base_dir() == fake_home / ".claude"


### PR DESCRIPTION
Closes #3726

## What this does

Adds an **opt-in** mode (off by default, zero behavior change when unset) that copies Claude Code session transcripts — and every per-subagent transcript + `.meta.json` sidecar — to a durable local filesystem location for after-the-fact audit and the #3725 per-role cost harvest.

## Completed (v1)

- **`defaults/scripts/archive-transcripts.sh`** — cron-friendly, idempotent copier modeled on `probe-tokens.sh`.
  - Resolves the source base **`CLAUDE_CONFIG_DIR`-aware** (`${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/<cwd-slug>/`) — never hard-codes `~/.claude` (CORRECTION 2).
  - Captures **both** the top-level `<uuid>.jsonl` file **and** the sibling `<uuid>/` companion dir (`subagents/agent-*.jsonl` + `*.meta.json` + `tool-results/`) into `<dir>/<repo>/<date>/<uuid>/` (CORRECTION 1). Idempotent via size+mtime skip.
  - Emits an **agent-id-keyed `index.json`** (schema `loom.transcript-index/v1`) that **reuses role+issue from the existing `.meta.json` sidecars** (CORRECTION 3) and adds only the loom-side context (repo, sweep issue, model, start/end ts, arm/attempt). This is #3725's join key.
- **Enablement**: `LOOM_TRANSCRIPT_ARCHIVE` env (env-over-config, string-valued like `guards.rmScope`: a path enables, `""`/`off`/`0`/`no`/`disabled` disables) > `.loom/config.json → loom.transcriptArchive.{enabled,dir}` > default(off).
- **Guardrails (hard)**: off by default; dest `0700` / files `0600`; **gitignore-or-refuse** when the dest is inside a git repo (via `rev-parse --show-toplevel` + `check-ignore`); loud startup banner naming the dest; secrets caveat documented with the `.loom/tokens/` posture.
- **`claude_config.py`**: added `resolve_claude_base_dir()` / `resolve_projects_dir()` shared helpers (+ pytest) so #3725 reuses the same base logic.
- **`sweep.md`**: completion-hook invocation (safe to run unconditionally — no-op when disabled) at sweep settle.
- **`defaults/CLAUDE.md`**: new "Session Transcript Archival" section (enabling, `CLAUDE_CONFIG_DIR`-aware base, secrets caveat, out-of-scope remote backends).
- **Tests**: `defaults/scripts/tests/test-archive-transcripts.sh` (23 assertions — copy/modes/index/idempotency/`CLAUDE_CONFIG_DIR` override/gitignore-refuse/gitignore-allow/disabled-no-op/env-over-config) + 4 new pytests in `test_claude_config.py`.

## Deferred (honest scope note)

- **Daemon reaper auto-invoke** (`loom-daemon/src/sweep_registry.rs`): the reaper knows the detached child's PID + issue but **not** its Claude session-uuid, so a precise reaper-triggered single-session archive is **not wired in this PR**. Per the curator's guidance this is a documented refinement, not a v1 blocker — the **cron-friendly periodic sync** (`--all-repo-sessions`) is the backstop for the detached-child path, and both `sweep.md` and CLAUDE.md say so explicitly. No Rust files were touched.
- **Remote / object-storage backends** (`s3://`, `gcs://`, rsync): explicit v1 out-of-scope per the issue; local filesystem only.

## Verification

- `bash -n` + `shellcheck -S warning` clean on both new scripts.
- `bash defaults/scripts/tests/test-archive-transcripts.sh` → 23/23 pass.
- `PYTHONPATH=loom-tools/src pytest loom-tools/tests/test_claude_config.py` → 64/64 pass.
- `cargo test --test sweep_md_doc_lint --test sweep_md_stage_minus_one_doc_lint` → 17/17 pass (doc-lint green after sweep.md edit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)