### PR TITLE
feat(sweep): experiment-mode model-cost instrumentation to collect the retune evidence (#3725)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ Thumbs.db
 .loom/tokens/
 .loom/accounts.env
 .loom/sweep-checkpoint/
+.loom/stats/
 .loom/spawn-loop.pid
 .loom/spawn-loop-state.json
 .loom/stop-spawn-loop

--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -397,6 +397,8 @@ Every role subagent dispatched by this skill (`loom-curator`, `loom-builder`, `l
 
 **Tier 2.5 — Curator complexity marker (issue #3702, Builder dispatch only)**: between tier 2 and tier 3, at **Builder** dispatch, grep the issue body for the Curator-emitted marker `<!-- loom:complexity=complex -->` (an HTML comment, values `routine` | `complex`; see `curator.md`). When it is present and reads `complex`, bump the Builder's tier-3 (`suggestedModel`) resolution up **exactly one model tier** — `sonnet → opus` — before dispatch. Hard bounds, all enforced here:
 
+> **Experiment-mode suppression (issue #3725).** When `sweep.modelExperiment` resolves to `experiment` (see "Model-cost experiment mode" below), the forced arm **overrides and SUPPRESSES this tier-2.5 bump** for the Builder: the marker is still *read* (same grep), but it is used **only as the stratification key**, never as a `sonnet → opus` bump. This is load-bearing — without it, a `complex`-marked issue on Arm B (sonnet-first) would silently become opus and confound the A/B. The bump behaves exactly as documented here whenever the experiment is `off`/`observe`.
+
 - **One bump maximum, and never to `fable`.** The marker can lift `sonnet → opus` and nothing further; it can never reach the top (`fable`) rung. Fable is reached only via the escalation ladder (objective Judge-rejection evidence) or an explicit operator param, never on a Curator's speculation.
 - **It is not a label** and creates no label — it lives only in the issue body.
 - **Tier-1 and tier-2 pins still win.** The marker sits *strictly between* tiers 2 and 3: an explicit dispatch param (tier 1) or a `roleConfig.model` workspace pin (tier 2) overrides it, exactly as they override tier 3.
@@ -514,6 +516,61 @@ Constraints that keep the exception from becoming an unbounded loop:
 - It is **single-use per PR** — one grace cycle only. A *third* rejection after the grace cycle always blocks, even if it too looks distinct.
 - It applies **only at the default cap** (`max_doctor_cycles == 1`). When an operator has already raised the cap above 1, the exception does **not** compose on top — the configured cap is the entire budget. (Layering a per-rejection grace cycle onto an operator-raised cap would reintroduce the indefinite-thrash risk the cap exists to prevent.)
 - The distinction MUST be stated in the log line. An unlogged grace cycle is a bug.
+
+### Model-cost experiment mode (`sweep.modelExperiment` / `LOOM_MODEL_EXPERIMENT`, issue #3725)
+
+This mode instruments a sweep to produce the balanced A/B evidence #3718 needs to decide the Builder `opus → sonnet` retune. **It is off by default and is byte-for-byte a no-op when unset** — every deterministic instruction below runs only when the mode resolves to `observe` or `experiment`. All the arithmetic (mode resolution, arm assignment, the durable append, the harvest) lives in `./.loom/scripts/sweep-experiment.sh` (a thin stub over `loom_tools.sweep_experiment`); this skill never computes a modulo by hand.
+
+**Tri-state resolution (read once at lifecycle entry, same point as `sweep.escalation`).** Resolve `./.loom/scripts/sweep-experiment.sh resolve-mode` → one of `off` | `observe` | `experiment`. Precedence follows the **string-valued** guard pattern (`guards.rmScope` / `guards.forceScope`), not the boolean one:
+
+- highest: `LOOM_MODEL_EXPERIMENT` env (`off`/`observe`/`experiment`) → then `.loom/config.json` → `sweep.modelExperiment` → default `off`.
+- Unknown/malformed value → treated as `off` with a stderr warning; a bad value **never** aborts the sweep.
+
+The three states:
+
+| Mode | Behavior |
+|------|----------|
+| `off` | No instrumentation. Zero behavior change. No `.loom/stats/` file is created. |
+| `observe` | Passive measurement. No model forcing, no arm. One JSONL record appended per phase (`arm` null). Safe to run anywhere. |
+| `experiment` | Active A/B. Builder is forced to the assigned arm's model; records are tagged with the `arm`. **Canary-only** (see Guardrails). |
+
+**Two arms map onto #3718's inequality.** `resolve-mode` in `experiment` picks a per-issue arm via `./.loom/scripts/sweep-experiment.sh assign-arm --issue N --complexity <routine|complex>` → prints `<arm> <model>`:
+
+- **Arm A = opus-first** — Builder forced to `opus`; the normal escalation ladder still applies on Judge rejection.
+- **Arm B = sonnet-first + escalate** — Builder forced to `sonnet`; on Judge rejection the Doctor escalates via the existing `sweep.escalation` ladder (#3481), exactly as documented in "Model escalation on Judge rejection". Arm B *is* the candidate policy #3718 is evaluating.
+
+**Deterministic, resume-safe, stratified assignment.** The arm is a pure function of the issue number and the #3702 complexity stratum, so a killed-and-resumed sweep re-running the same issue **lands on the same arm**. The complexity marker is read once (the same grep at the tier-2.5 site) and serves two purposes: the **stratification key** (so both arms see a comparable difficulty mix) and — **only when the experiment is off/observe** — the tier-2.5 bump. In `experiment` mode the bump is suppressed (see the "Experiment-mode suppression" note under tier 2.5).
+
+**Forced-arm precedence.** The forced arm slots into the Builder model-resolution chain **above tier 2.5 / tier 3** but **below tier 1 / tier 2 operator pins**: an explicit dispatch param (tier 1) or a `roleConfig.model` workspace pin (tier 2) still wins — a pinned canary is intentionally opted out of the experiment. The forced arm only ever replaces what tier 2.5 / tier 3 would have resolved for the Builder.
+
+**Durable stats store.** Instrumentation appends one JSONL record per role phase invocation to `.loom/stats/sweep-model-stats.jsonl` (gitignored; survives the merge that deletes the transient checkpoint). Immediately after each phase's `sweep-checkpoint.sh write`, also run:
+
+```bash
+./.loom/scripts/sweep-experiment.sh record --mode <mode> --issue N --phase <curator|builder|judge|doctor|merge> \
+  --role <role> --model <resolved-model> --arm <A|B|"" > --attempt <k> --complexity <routine|complex> \
+  --verdict <pass|changes|""> --agent-id <agent-id> --stats-file .loom/stats/sweep-model-stats.jsonl
+```
+
+Each record carries the **HARD deterministic outcome-chain** (`arm`, `model`, `attempt`, `judge_verdict`, `cycle_count`, `complexity`) — which alone answers #3718's inequality (first-attempt Judge-pass rate + mean Doctor cycles × model price) — **plus the `agent-id` join key** for the role invocation (available in the Task-result metadata at dispatch/return time), which the harvest joins against #3726's transcript index to attribute exact cost.
+
+**Token fidelity.** Live per-phase token capture is **not** available at the Task-result boundary; the exact input/output + cache split is recovered at **harvest** time by parsing each role subagent's `agent-<id>.jsonl` `usage` blocks (see below). Each record stamps a `token_fidelity` tag naming the source (`none` | `sweep-aggregate-log` | `transcript`). The deterministic outcome-chain is the load-bearing signal; exact cost just makes it precise.
+
+**Guardrails (load-bearing).** `off` by default; `observe` is safe anywhere. `experiment` is **canary-only**: `resolve-mode` refuses to honor it on a non-canary target and **loudly downgrades to `observe`** unless the operator confirms a canary via `LOOM_MODEL_EXPERIMENT_CANARY=1` (or `sweep.modelExperimentCanary: true`). At lifecycle entry, print the loud banner naming the active mode and — in `experiment` — the arm assigned to the issue:
+
+```bash
+./.loom/scripts/sweep-experiment.sh banner --issue N --complexity <routine|complex>
+```
+
+**Harvest (exact per-role cost).** After a canary run, aggregate the store into the per-arm inequality inputs #3718 consumes — first-attempt Judge-pass rate, mean Doctor cycles, exact cache-aware cost per arm, and the merge-rate quality floor — via the reader alongside `agent-metrics.sh`:
+
+```bash
+./.loom/scripts/agent-metrics.sh --model-experiment --archive-dir "$LOOM_TRANSCRIPT_ARCHIVE"
+# equivalently: ./.loom/scripts/sweep-experiment.sh harvest --archive-dir "$LOOM_TRANSCRIPT_ARCHIVE"
+```
+
+The harvest parses each joined `agent-<id>.jsonl` transcript's `usage` blocks (input/output + `cache_read_input_tokens`/`cache_creation_input_tokens`) and prices them with the same **cache-aware** per-model table as `loom-daemon`'s `resource_usage.rs`. Transcripts are located through #3726's `loom.transcript-index/v1` archive index (`--archive-dir` = `LOOM_TRANSCRIPT_ARCHIVE`); harvest should run periodically (cron) over a multi-day canary so usage is extracted into the compact stats store before `~/.claude/projects` is pruned.
+
+> **Daemon detached-child path (honest finding, verified against on-disk transcripts).** The role-subagent transcripts of a daemon-dispatched `claude -p "/loom:sweep N"` child land under that child's own `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/<cwd-slug>/<child-session-uuid>/subagents/agent-<id>.jsonl` tree — the **durable** location, not the ephemeral `/tmp/.../tasks/` scratch — and each carries the full per-message `usage` (input/output + cache split) and `model`. Confirmed present on disk for real detached-child sessions. So they are archivable/harvestable via the same #3726 periodic sync. What the daemon reaper does **not** yet know is the child's session-uuid, so it cannot trigger a precise single-session archive on exit — the cron periodic sync is the backstop, exactly as for the completion hook (see "Session Transcript Archival").
 
 ### Other constraints
 

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -813,6 +813,72 @@ re-runs copy nothing new. Cron example:
 rsync-to-remote) are an explicit follow-on — v1 is a local filesystem destination
 only.
 
+### Model-Cost Experiment (canary A/B, #3725)
+
+`/loom:sweep` can instrument a run to produce the balanced A/B evidence the
+measurement-gated Builder `opus → sonnet` retune (#3718) needs — you cannot
+generate it by observation alone, since passive collection only ever measures
+whatever the current Builder default is. **Off by default; zero behavior change
+unless you turn it on.** Tri-state `sweep.modelExperiment` /
+`LOOM_MODEL_EXPERIMENT` (env-over-config, string-valued like `guards.rmScope`):
+
+| Mode | Behavior |
+|------|----------|
+| `off` (default) | No instrumentation. No `.loom/stats/` file. Byte-for-byte unchanged. |
+| `observe` | Passive: one JSONL record per phase to `.loom/stats/sweep-model-stats.jsonl`. No model forcing. Safe anywhere. |
+| `experiment` | Active A/B: Builder forced to the per-issue arm's model. **Canary-only.** |
+
+```bash
+# Observe on any sweep (no behavior change, just records the outcome-chain):
+LOOM_MODEL_EXPERIMENT=observe claude -p "/loom:sweep 123" --dangerously-skip-permissions
+
+# Experiment on a canary (must confirm the canary — else it downgrades to observe):
+LOOM_MODEL_EXPERIMENT=experiment LOOM_MODEL_EXPERIMENT_CANARY=1 \
+  claude -p "/loom:sweep 123" --dangerously-skip-permissions
+```
+
+**Two arms** map onto #3718's inequality: **Arm A = opus-first** (Builder→opus),
+**Arm B = sonnet-first + escalate-on-Judge-rejection** (Builder→sonnet, escalating
+via the `sweep.escalation` ladder). Arm assignment is a **deterministic,
+resume-safe** function of the issue number, **stratified by the Curator complexity
+marker** (#3702) so both arms see a comparable difficulty mix — a killed-and-resumed
+sweep re-lands the same arm. In `experiment` mode the tier-2.5 complexity bump is
+**suppressed** (the marker is used only as the stratification key), so a
+`complex`-marked issue on Arm B stays sonnet and the A/B is not confounded.
+
+**Guardrails:** off by default; `observe` safe anywhere; `experiment` refuses to
+run on a non-canary target and loudly downgrades to `observe` unless
+`LOOM_MODEL_EXPERIMENT_CANARY=1` (or `sweep.modelExperimentCanary: true`) confirms
+a canary. A loud startup banner names the active mode and, in `experiment`, the
+arm assigned to each issue. `.loom/stats/` is gitignored.
+
+**Harvesting the evidence:**
+
+```bash
+./.loom/scripts/agent-metrics.sh --model-experiment --archive-dir "$LOOM_TRANSCRIPT_ARCHIVE"
+```
+
+The load-bearing signal is the **deterministic outcome-chain** (arm / model /
+attempt / Judge verdict / Doctor-cycle count / complexity) — that alone answers
+#3718's inequality (first-attempt Judge-pass rate + mean Doctor cycles × model
+price), and it is stamped into the durable store per phase.
+
+**On token fidelity — read this before trusting a cost number.** There is **no
+per-phase real-token split at the Task-result boundary** (the harness does not
+surface per-subagent `usage` when a Task returns). Instead, **exact per-role cost
+is recovered at harvest time** by parsing each role subagent's durable
+`agent-<id>.jsonl` transcript — each Builder / Judge / Doctor invocation is its own
+transcript with full per-message `usage` (input/output + cache read/creation
+split + model), so this is true per-role granularity, not a whole-process
+aggregate. Cost uses the same cache-aware per-model pricing as `loom-daemon`'s
+`resource_usage.rs`. Harvest locates transcripts through the #3726 transcript
+archive's `agent-<id>`-keyed index (`--archive-dir` = `LOOM_TRANSCRIPT_ARCHIVE`),
+joined on the agent-id stamped in each stats record. Over a **multi-day canary**,
+run harvest periodically (cron) so usage is extracted before `~/.claude/projects`
+is pruned — or rely on the #3726 archive as the durable backstop. Each record
+carries a `token_fidelity` tag (`transcript` | `sweep-aggregate-log` | `none`) so
+you know exactly what a cost figure came from.
+
 ### Custom Roles
 
 Create custom roles by adding files to `.loom/roles/`:

--- a/defaults/scripts/agent-metrics.sh
+++ b/defaults/scripts/agent-metrics.sh
@@ -24,5 +24,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Source shared loom-tools helper
 source "$SCRIPT_DIR/lib/loom-tools.sh"
 
+# --model-experiment (or `sweep-experiment`) routes to the sweep model-cost
+# experiment reader (#3725) rather than the activity-db metrics. It aggregates
+# .loom/stats/sweep-model-stats.jsonl into the per-arm inequality inputs #3718
+# needs; keeping it here puts it next to the existing --by-model cost dimension.
+if [[ "${1:-}" == "--model-experiment" || "${1:-}" == "sweep-experiment" ]]; then
+    shift
+    run_loom_tool "sweep-experiment" "sweep_experiment" harvest "$@"
+fi
+
 # Run the command with proper fallback chain
 run_loom_tool "agent-metrics" "agent_metrics" "$@"

--- a/defaults/scripts/sweep-experiment.sh
+++ b/defaults/scripts/sweep-experiment.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# sweep-experiment.sh - Thin stub delegating to loom_tools.sweep_experiment (#3725)
+#
+# The /loom:sweep skill shells out to this for the deterministic parts of the
+# model-cost experiment: tri-state mode resolution, per-issue arm assignment, the
+# startup banner, the durable JSONL append, and the harvest reader. Keeping the
+# arithmetic in Python (not in the LLM-executed markdown) makes arm assignment
+# byte-for-byte deterministic and resume-safe.
+#
+# Usage:
+#   sweep-experiment.sh resolve-mode
+#   sweep-experiment.sh assign-arm --issue N [--complexity complex|routine] [--format json]
+#   sweep-experiment.sh banner --issue N [--complexity ...]
+#   sweep-experiment.sh record --issue N --phase P --role R [--model M --arm A ...]
+#   sweep-experiment.sh harvest [--archive-dir DIR] [--format text|json]
+#
+# The harvest subcommand is ALSO reachable via `agent-metrics.sh --model-experiment`
+# (issue #3725 AC), which forwards here so operators find it next to the existing
+# `--by-model` (#3482) cost dimension.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source shared loom-tools helper
+source "$SCRIPT_DIR/lib/loom-tools.sh"
+
+# Run the command with proper fallback chain
+run_loom_tool "sweep-experiment" "sweep_experiment" "$@"

--- a/defaults/scripts/tests/test-sweep-experiment.sh
+++ b/defaults/scripts/tests/test-sweep-experiment.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# test-sweep-experiment.sh - Unit tests for the sweep model-cost experiment
+# instrumentation (issue #3725).
+#
+# The sweep skill shells out to `sweep-experiment.sh`, a thin stub that execs
+# `python3 -m loom_tools.sweep_experiment`. In the Loom SOURCE tree the stub
+# cannot resolve loom-tools from `defaults/scripts/` (repo-root detection stops
+# at `defaults/.loom`; in a real install the script lives at `.loom/scripts/`),
+# so these tests drive the exact module the stub execs, with PYTHONPATH set the
+# same way `run_loom_tool` sets it. The stub file itself is covered by
+# `bash -n` + `shellcheck` in CI.
+#
+# Usage:
+#   bash defaults/scripts/tests/test-sweep-experiment.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+export PYTHONPATH="$REPO_ROOT/loom-tools/src:${PYTHONPATH:-}"
+
+SE() { python3 -m loom_tools.sweep_experiment "$@"; }
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
+TESTS_RUN=0; TESTS_PASSED=0; TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN+1)); TESTS_PASSED=$((TESTS_PASSED+1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { TESTS_RUN=$((TESTS_RUN+1)); TESTS_FAILED=$((TESTS_FAILED+1)); echo -e "  ${RED}FAIL${NC}: $1"; }
+assert_eq()      { if [[ "$1" == "$2" ]]; then pass "$3"; else fail "$3 (got '$1' want '$2')"; fi; }
+assert_contains(){ if [[ "$1" == *"$2"* ]]; then pass "$3"; else fail "$3 (missing '$2' in: $1)"; fi; }
+assert_file()    { if [[ -f "$1" ]]; then pass "$2"; else fail "$2 (missing: $1)"; fi; }
+
+if ! command -v python3 >/dev/null 2>&1; then echo "ERROR: python3 required" >&2; exit 1; fi
+
+echo "Case 1: tri-state resolution (env-over-config, default off, malformed -> off)"
+assert_eq "$(SE resolve-mode --config /nonexistent 2>/dev/null)" "off" "default is off"
+assert_eq "$(LOOM_MODEL_EXPERIMENT=observe SE resolve-mode --config /nonexistent 2>/dev/null)" "observe" "env observe"
+assert_eq "$(LOOM_MODEL_EXPERIMENT=bogus SE resolve-mode --config /nonexistent 2>/dev/null)" "off" "malformed env -> off"
+echo ""
+
+echo "Case 2: canary guardrail — experiment downgrades to observe on non-canary"
+OUT="$(LOOM_MODEL_EXPERIMENT=experiment SE resolve-mode --config /nonexistent 2>&1)"
+assert_contains "$OUT" "observe" "non-canary experiment downgraded to observe"
+assert_contains "$OUT" "NON-CANARY" "loud warning names the guardrail"
+assert_eq "$(LOOM_MODEL_EXPERIMENT=experiment LOOM_MODEL_EXPERIMENT_CANARY=1 SE resolve-mode --config /nonexistent 2>/dev/null)" "experiment" "canary confirmed -> experiment honored"
+echo ""
+
+echo "Case 3: deterministic + stratified arm assignment"
+A1="$(SE assign-arm --issue 100 --complexity routine)"
+A2="$(SE assign-arm --issue 100 --complexity routine)"
+assert_eq "$A1" "$A2" "same issue+complexity is resume-stable"
+assert_eq "$A1" "A opus" "issue 100 routine -> A opus"
+assert_eq "$(SE assign-arm --issue 100 --complexity complex)" "B sonnet" "issue 100 complex -> opposite arm (stratified)"
+assert_eq "$(SE assign-arm --issue 101 --complexity routine)" "B sonnet" "issue 101 routine -> B sonnet (parity)"
+echo ""
+
+echo "Case 4: startup banner names mode + arm"
+BAN="$(LOOM_MODEL_EXPERIMENT=experiment LOOM_MODEL_EXPERIMENT_CANARY=1 SE banner --issue 100 --complexity complex --config /nonexistent 2>/dev/null)"
+assert_contains "$BAN" "mode=EXPERIMENT" "banner names experiment mode"
+assert_contains "$BAN" "ARM B" "banner names the assigned arm"
+assert_contains "$BAN" "SUPPRESSED" "banner notes tier-2.5 suppression"
+echo ""
+
+echo "Case 5: record append + harvest with transcript join (exact cost)"
+ROOT="$(mktemp -d "${TMPDIR:-/tmp}/se-test.XXXXXX")"
+STATS="$ROOT/stats.jsonl"
+SESS="$ROOT/archive/myrepo/2026-07-22/UUID1"
+mkdir -p "$SESS/UUID1/subagents"
+printf '%s\n' '{"message":{"model":"claude-opus-4-8","usage":{"input_tokens":10,"output_tokens":5,"cache_creation_input_tokens":1000,"cache_read_input_tokens":2000}}}' \
+  > "$SESS/UUID1/subagents/agent-bld1.jsonl"
+cat > "$SESS/index.json" <<EOF
+{"schema":"loom.transcript-index/v1","session_uuid":"UUID1","repo":"myrepo","agents":[{"agent_id":"agent-bld1","role":"loom-builder","transcript":"subagents/agent-bld1.jsonl"}]}
+EOF
+SE record --quiet --stats-file "$STATS" --issue 100 --mode experiment --arm A --model opus --complexity routine --phase builder --role builder --agent-id agent-bld1 --attempt 1
+SE record --quiet --stats-file "$STATS" --issue 100 --mode experiment --arm A --phase judge --role judge --verdict pass --attempt 1
+SE record --quiet --stats-file "$STATS" --issue 100 --mode experiment --arm A --phase merge --role merge
+assert_file "$STATS" "stats JSONL created"
+NLINES="$(wc -l < "$STATS" | tr -d ' ')"
+assert_eq "$NLINES" "3" "three JSONL records appended"
+FMODE="$(stat -f '%Lp' "$STATS" 2>/dev/null || stat -c '%a' "$STATS")"
+assert_eq "$FMODE" "600" "stats file is 0600"
+HARV="$(SE harvest --stats-file "$STATS" --archive-dir "$ROOT/archive" --format json 2>/dev/null)"
+assert_contains "$HARV" '"transcript": 1' "harvest joined 1 transcript (exact cost)"
+assert_contains "$HARV" '"first_attempt_pass_rate": 1.0' "arm A first-attempt pass rate 100%"
+assert_contains "$HARV" '"merge_rate": 1.0' "arm A merge rate 100%"
+# exact cost 0.022275 from the single usage block
+assert_contains "$HARV" '0.022275' "exact cache-aware cost from transcript usage"
+rm -rf "$ROOT"
+echo ""
+
+echo "Case 6: harvest on empty/missing store does not crash"
+OUT="$(SE harvest --stats-file "/nonexistent-$$.jsonl" 2>&1)"; RC=$?
+assert_eq "$RC" "0" "harvest exits 0 on missing store"
+assert_contains "$OUT" "records: 0" "harvest reports zero records"
+echo ""
+
+echo "════════════════════════════════════════════"
+echo "  Total: $TESTS_RUN  Passed: $TESTS_PASSED  Failed: $TESTS_FAILED"
+echo "════════════════════════════════════════════"
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/loom-daemon/tests/sweep_md_doc_lint.rs
+++ b/loom-daemon/tests/sweep_md_doc_lint.rs
@@ -216,3 +216,87 @@ fn sweep_md_asserts_no_fable_judge_invariant() {
          (#3702): `Judge model resolution can never resolve to `fable`...`"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Issue #3725 — model-cost experiment mode. The tri-state setting, the two-arm
+// A/B, the resume-safe stratified assignment, the tier-2.5 suppression, the
+// durable store, the exact-cost harvest, and the canary guardrail are all prose
+// contracts the sweep orchestrator interprets — pin the load-bearing strings so
+// a future edit can't silently drop them.
+// ---------------------------------------------------------------------------
+
+/// #3725: the tri-state experiment setting + env override are documented with
+/// the string-valued guard precedence, and the two arms are named.
+#[test]
+fn sweep_md_documents_model_experiment_mode() {
+    let content = read_sweep_md();
+    let required: &[&str] = &[
+        "### Model-cost experiment mode",
+        "sweep.modelExperiment",
+        "LOOM_MODEL_EXPERIMENT",
+        // Tri-state values.
+        "`off` | `observe` | `experiment`",
+        // Two arms mapping onto #3718's inequality.
+        "Arm A = opus-first",
+        "Arm B = sonnet-first + escalate",
+        // Deterministic, resume-safe, stratified assignment.
+        "Deterministic, resume-safe, stratified assignment",
+        // The durable, gitignored store.
+        ".loom/stats/sweep-model-stats.jsonl",
+        // The agent-id join key into #3726's index.
+        "agent-id` join key",
+        "loom.transcript-index/v1",
+    ];
+    for needle in required {
+        assert!(
+            content.contains(needle),
+            "sweep.md is missing #3725 experiment-mode prose `{needle}` — \
+             update sweep.md or this test if the change is intentional"
+        );
+    }
+}
+
+/// #3725 (hard AC): in `experiment` mode the forced arm SUPPRESSES the tier-2.5
+/// complexity bump so Arm B stays sonnet on `complex`-marked issues.
+#[test]
+fn sweep_md_documents_experiment_tier_2_5_suppression() {
+    let content = read_sweep_md();
+    assert!(
+        content.contains("Experiment-mode suppression (issue #3725)"),
+        "sweep.md must document the tier-2.5 suppression note (#3725 hard AC)"
+    );
+    assert!(
+        content.contains("SUPPRESSES this tier-2.5 bump"),
+        "sweep.md must state the forced arm suppresses the tier-2.5 bump (#3725)"
+    );
+    assert!(
+        content.contains("only as the stratification key"),
+        "sweep.md must state the marker is used only as the stratification key \
+         while an arm is forced (#3725)"
+    );
+}
+
+/// #3725: the canary guardrail and the exact-per-role-cost harvest are pinned.
+#[test]
+fn sweep_md_documents_experiment_guardrail_and_harvest() {
+    let content = read_sweep_md();
+    let required: &[&str] = &[
+        // Canary-only guardrail + explicit opt-in.
+        "canary-only",
+        "LOOM_MODEL_EXPERIMENT_CANARY=1",
+        // Harvest surface.
+        "--model-experiment",
+        // Exact cache-aware cost via transcript usage.
+        "cache-aware",
+        "cache_read_input_tokens",
+        // token_fidelity ladder.
+        "token_fidelity",
+    ];
+    for needle in required {
+        assert!(
+            content.contains(needle),
+            "sweep.md is missing #3725 guardrail/harvest prose `{needle}` — \
+             update sweep.md or this test if the change is intentional"
+        );
+    }
+}

--- a/loom-tools/src/loom_tools/sweep_experiment.py
+++ b/loom-tools/src/loom_tools/sweep_experiment.py
@@ -1,0 +1,777 @@
+#!/usr/bin/env python3
+"""Model-cost experiment instrumentation for /loom:sweep (issue #3725).
+
+This module is the deterministic, unit-testable core behind the sweep skill's
+``sweep.modelExperiment`` mode. The sweep skill is LLM-executed markdown, so the
+load-bearing arithmetic (tri-state resolution, per-issue arm assignment, the
+durable JSONL append) lives here as a small CLI the skill shells out to — the LLM
+never computes a modulo by hand.
+
+Surface (all subcommands print to stdout; warnings go to stderr):
+
+    resolve-mode                       -> effective mode after the canary guardrail
+    assign-arm --issue N [--complexity]-> deterministic arm + forced model
+    banner --issue N [--complexity]    -> loud startup banner naming mode + arm
+    record ...                         -> append one JSONL outcome-chain record
+    harvest [--archive-dir DIR]        -> per-arm inequality inputs for #3718
+
+Design notes
+------------
+* **Tri-state** ``off`` / ``observe`` / ``experiment`` resolves env-over-config,
+  following the *string-valued* guard precedence (``guards.rmScope`` /
+  ``guards.forceScope``), never the boolean pattern. Unknown value -> ``off`` +
+  warning; a best-effort config read never raises.
+* **Two arms** map onto #3718's inequality: Arm A = Builder->opus (opus-first),
+  Arm B = Builder->sonnet + escalate-on-Judge-rejection (sonnet-first).
+* **Deterministic, resume-safe, stratified** arm assignment is a pure function of
+  the issue number and the #3702 complexity marker, so a killed-and-resumed sweep
+  re-lands the same arm.
+* **Exact per-role cost** is computed at harvest time by parsing each role
+  subagent's ``agent-<id>.jsonl`` ``usage`` blocks (input/output + cache split)
+  with cache-aware pricing (mirrors ``loom-daemon`` ``resource_usage.rs``). The
+  transcripts are located through #3726's ``loom.transcript-index/v1`` archive
+  index, joined on the agent-id stamped in each stats record.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+# --------------------------------------------------------------------------- #
+# Constants
+# --------------------------------------------------------------------------- #
+
+VALID_MODES = ("off", "observe", "experiment")
+_TRUTHY = {"1", "true", "yes", "on"}
+
+# Arm -> forced Builder model. Arm A is opus-first, Arm B is sonnet-first.
+ARM_MODEL = {"A": "opus", "B": "sonnet"}
+
+DEFAULT_STATS_FILE = ".loom/stats/sweep-model-stats.jsonl"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _warn(msg: str) -> None:
+    print(f"[sweep-experiment] WARNING: {msg}", file=sys.stderr)
+
+
+# --------------------------------------------------------------------------- #
+# Config (best-effort — never raises)
+# --------------------------------------------------------------------------- #
+
+
+def load_config(config_path: str | os.PathLike[str] | None) -> dict[str, Any]:
+    """Best-effort read of ``.loom/config.json``; malformed/absent -> ``{}``."""
+    if config_path is None:
+        config_path = ".loom/config.json"
+    try:
+        with open(config_path, encoding="utf-8") as fh:
+            data = json.load(fh)
+        return data if isinstance(data, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+# --------------------------------------------------------------------------- #
+# Tri-state mode resolution + canary guardrail
+# --------------------------------------------------------------------------- #
+
+
+def resolve_raw_mode(
+    env: dict[str, str], config: dict[str, Any]
+) -> tuple[str, list[str]]:
+    """Resolve the tri-state mode env-over-config, before the canary guardrail.
+
+    Returns ``(mode, warnings)``. Unknown/malformed value -> ``off`` + a warning.
+    """
+    warnings: list[str] = []
+
+    raw = env.get("LOOM_MODEL_EXPERIMENT")
+    if raw is not None and raw.strip() != "":
+        val = raw.strip().lower()
+        if val in VALID_MODES:
+            return val, warnings
+        warnings.append(
+            f"LOOM_MODEL_EXPERIMENT={raw!r} is not one of {VALID_MODES}; treating as 'off'"
+        )
+        return "off", warnings
+
+    sweep = config.get("sweep")
+    cfg_val = sweep.get("modelExperiment") if isinstance(sweep, dict) else None
+    if isinstance(cfg_val, str) and cfg_val.strip().lower() in VALID_MODES:
+        return cfg_val.strip().lower(), warnings
+    if cfg_val is not None:
+        warnings.append(
+            f"sweep.modelExperiment={cfg_val!r} is not one of {VALID_MODES}; treating as 'off'"
+        )
+
+    return "off", warnings
+
+
+def canary_confirmed(env: dict[str, str], config: dict[str, Any]) -> bool:
+    """Has the operator explicitly confirmed this target is a canary?
+
+    ``LOOM_MODEL_EXPERIMENT_CANARY`` env (truthy) wins over
+    ``sweep.modelExperimentCanary`` config (bool).
+    """
+    raw = env.get("LOOM_MODEL_EXPERIMENT_CANARY")
+    if raw is not None and raw.strip() != "":
+        return raw.strip().lower() in _TRUTHY
+    sweep = config.get("sweep")
+    if isinstance(sweep, dict):
+        return sweep.get("modelExperimentCanary") is True
+    return False
+
+
+def resolve_effective_mode(
+    env: dict[str, str], config: dict[str, Any]
+) -> tuple[str, list[str]]:
+    """Resolve mode AND apply the canary guardrail.
+
+    ``experiment`` is behavior-changing (it forces Builder models and suppresses
+    the complexity bump), so it is honored only on a confirmed canary. On any
+    other target it is loudly downgraded to ``observe`` (safe anywhere) rather
+    than refused outright — the measurement still accrues, just without the
+    model-forcing behavior change.
+    """
+    mode, warnings = resolve_raw_mode(env, config)
+    if mode == "experiment" and not canary_confirmed(env, config):
+        warnings.append(
+            "experiment mode requested on a NON-CANARY target — downgrading to "
+            "'observe' (no model forcing). Set LOOM_MODEL_EXPERIMENT_CANARY=1 (or "
+            "sweep.modelExperimentCanary=true) to confirm this is a canary."
+        )
+        mode = "observe"
+    return mode, warnings
+
+
+# --------------------------------------------------------------------------- #
+# Deterministic, resume-safe, stratified arm assignment
+# --------------------------------------------------------------------------- #
+
+
+def normalize_complexity(complexity: str | None) -> str:
+    """Normalize the #3702 marker to ``complex`` | ``routine`` (default routine)."""
+    return "complex" if (complexity or "").strip().lower() == "complex" else "routine"
+
+
+def assign_arm(issue_number: int, complexity: str | None = None) -> str:
+    """Deterministically assign ``A`` or ``B`` for an issue.
+
+    Pure function of ``issue_number`` and the complexity stratum, so a resumed
+    sweep re-running the same issue lands on the same arm. The complexity bit
+    offsets the parity split so the ``complex`` and ``routine`` strata each get an
+    independent ~50/50 A/B balance (stratification) rather than correlating.
+    """
+    bit = 1 if normalize_complexity(complexity) == "complex" else 0
+    return "A" if (int(issue_number) + bit) % 2 == 0 else "B"
+
+
+def arm_model(arm: str) -> str:
+    return ARM_MODEL.get(arm.upper().strip(), "")
+
+
+# --------------------------------------------------------------------------- #
+# Durable stats store (atomic O_APPEND, one JSONL line per phase invocation)
+# --------------------------------------------------------------------------- #
+
+
+def _stats_path(stats_file: str | None) -> pathlib.Path:
+    return pathlib.Path(stats_file or DEFAULT_STATS_FILE)
+
+
+def append_record(record: dict[str, Any], stats_file: str | None = None) -> None:
+    """Append one JSONL record atomically.
+
+    POSIX ``O_APPEND`` guarantees per-line atomicity for concurrent detached
+    writers, so no lock is needed for single-line writes.
+    """
+    path = _stats_path(stats_file)
+    parent = path.parent
+    try:
+        parent.mkdir(parents=True, exist_ok=True)
+        # Best-effort: keep the stats dir private (it can carry issue context).
+        try:
+            os.chmod(parent, 0o700)
+        except OSError:
+            pass
+    except OSError:
+        pass
+    line = json.dumps(record, ensure_ascii=False) + "\n"
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+    try:
+        os.write(fd, line.encode("utf-8"))
+    finally:
+        os.close(fd)
+
+
+def build_record(
+    *,
+    issue: int,
+    phase: str,
+    role: str,
+    model: str | None = None,
+    mode: str = "observe",
+    arm: str | None = None,
+    attempt: int = 1,
+    complexity: str | None = None,
+    judge_verdict: str | None = None,
+    cycle_count: int = 0,
+    pr: int | None = None,
+    effort: str | None = None,
+    agent_id: str | None = None,
+    transcript: str | None = None,
+    in_tok: int | None = None,
+    out_tok: int | None = None,
+    token_fidelity: str = "none",
+) -> dict[str, Any]:
+    """Assemble one outcome-chain record.
+
+    The HARD deterministic fields (arm/model/attempt/verdict/cycle_count/
+    complexity) are the load-bearing evidence for #3718. ``agent_id`` is the join
+    key into #3726's transcript index for exact-cost harvest.
+    """
+    return {
+        "ts": _now_iso(),
+        "issue": int(issue),
+        "pr": int(pr) if pr is not None else None,
+        "mode": mode,
+        "phase": phase,
+        "role": role,
+        "model": model,
+        "effort": effort,
+        "arm": (arm.upper() if arm else None),
+        "attempt": int(attempt),
+        "complexity": normalize_complexity(complexity),
+        "judge_verdict": judge_verdict,
+        "cycle_count": int(cycle_count),
+        "agent_id": agent_id,
+        "transcript": transcript,
+        "in_tok": in_tok,
+        "out_tok": out_tok,
+        "token_fidelity": token_fidelity,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Cache-aware pricing (mirrors loom-daemon resource_usage.rs::ModelPricing)
+# --------------------------------------------------------------------------- #
+
+# (input, output, cache_read, cache_write) US$ per 1k tokens.
+def model_pricing(model: str | None) -> tuple[float, float, float, float]:
+    m = (model or "").lower()
+    if "claude-3-5-sonnet" in m or "claude-sonnet-4" in m or m == "sonnet":
+        return (0.003, 0.015, 0.0003, 0.00375)
+    if "claude-3-opus" in m or "claude-opus-4" in m or m == "opus":
+        return (0.015, 0.075, 0.0015, 0.01875)
+    if "claude-3-haiku" in m or m == "haiku":
+        return (0.00025, 0.00125, 0.00003, 0.0003)
+    # Default to Sonnet pricing as a reasonable middle ground (matches Rust).
+    return (0.003, 0.015, 0.0003, 0.00375)
+
+
+def calc_cost(
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_tokens: int,
+    cache_write_tokens: int,
+    model: str | None,
+) -> float:
+    inp, out, cr, cw = model_pricing(model)
+    return (
+        input_tokens / 1000.0 * inp
+        + output_tokens / 1000.0 * out
+        + cache_read_tokens / 1000.0 * cr
+        + cache_write_tokens / 1000.0 * cw
+    )
+
+
+def sum_transcript_usage(path: str | os.PathLike[str]) -> dict[str, Any]:
+    """Sum every ``usage`` block in a subagent transcript.
+
+    Returns exact input/output/cache-read/cache-creation token totals plus the
+    resolved model. Best-effort: unreadable lines are skipped, a missing file
+    yields zeros.
+    """
+    totals = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+    }
+    model: str | None = None
+    blocks = 0
+    try:
+        with open(path, encoding="utf-8") as fh:
+            for raw in fh:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    obj = json.loads(raw)
+                except ValueError:
+                    continue
+                msg = obj.get("message") if isinstance(obj, dict) else None
+                container = msg if isinstance(msg, dict) else obj
+                if not isinstance(container, dict):
+                    continue
+                if model is None:
+                    mv = container.get("model")
+                    if isinstance(mv, str) and mv:
+                        model = mv
+                usage = container.get("usage")
+                if isinstance(usage, dict):
+                    blocks += 1
+                    for key in totals:
+                        val = usage.get(key)
+                        if isinstance(val, (int, float)):
+                            totals[key] += int(val)
+    except OSError:
+        pass
+    cost = calc_cost(
+        totals["input_tokens"],
+        totals["output_tokens"],
+        totals["cache_read_input_tokens"],
+        totals["cache_creation_input_tokens"],
+        model,
+    )
+    return {
+        "model": model,
+        "usage_blocks": blocks,
+        "cost_usd": cost,
+        **totals,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Transcript index join (consumes #3726's loom.transcript-index/v1)
+# --------------------------------------------------------------------------- #
+
+
+def build_transcript_map(archive_dir: str | os.PathLike[str] | None) -> dict[str, str]:
+    """Map ``agent-<id>`` -> absolute transcript path from #3726 archive indexes.
+
+    Walks every ``index.json`` (schema ``loom.transcript-index/v1``) under
+    ``archive_dir`` and resolves each agent's transcript to an absolute path.
+    The index lives at ``<...>/<uuid>/index.json`` and the transcript rel-path is
+    relative to ``<...>/<uuid>/<session_uuid>/``.
+    """
+    mapping: dict[str, str] = {}
+    if not archive_dir:
+        return mapping
+    root = pathlib.Path(archive_dir)
+    if not root.is_dir():
+        return mapping
+    for index_path in root.rglob("index.json"):
+        try:
+            with open(index_path, encoding="utf-8") as fh:
+                data = json.load(fh)
+        except (OSError, ValueError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        if data.get("schema") != "loom.transcript-index/v1":
+            continue
+        sess_dir = index_path.parent
+        uuid = data.get("session_uuid") or ""
+        agents = data.get("agents")
+        if not isinstance(agents, list):
+            continue
+        for agent in agents:
+            if not isinstance(agent, dict):
+                continue
+            agent_id = agent.get("agent_id")
+            tr = agent.get("transcript")
+            if not agent_id or not isinstance(tr, str):
+                continue
+            abs_path = sess_dir / uuid / tr if uuid else sess_dir / tr
+            mapping[agent_id] = str(abs_path)
+    return mapping
+
+
+# --------------------------------------------------------------------------- #
+# Harvest / aggregation
+# --------------------------------------------------------------------------- #
+
+
+def read_records(stats_file: str | None) -> list[dict[str, Any]]:
+    path = _stats_path(stats_file)
+    records: list[dict[str, Any]] = []
+    try:
+        with open(path, encoding="utf-8") as fh:
+            for raw in fh:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    obj = json.loads(raw)
+                except ValueError:
+                    continue
+                if isinstance(obj, dict):
+                    records.append(obj)
+    except OSError:
+        pass
+    return records
+
+
+_PASS_VERDICTS = {"pass", "approve", "approved", "lgtm", "merged", "merge"}
+
+
+def _is_pass(verdict: str | None) -> bool:
+    return (verdict or "").strip().lower() in _PASS_VERDICTS
+
+
+def _record_cost(
+    record: dict[str, Any], transcript_map: dict[str, str]
+) -> tuple[float, str]:
+    """Resolve one record's cost + the actual token-fidelity source used.
+
+    Preference order: exact transcript usage (fidelity ``transcript``) > the
+    record's own best-effort sweep-aggregate tokens (``sweep-aggregate-log``) >
+    nothing (``none``).
+    """
+    agent_id = record.get("agent_id")
+    if agent_id and agent_id in transcript_map:
+        summary = sum_transcript_usage(transcript_map[agent_id])
+        if summary["usage_blocks"] > 0:
+            return summary["cost_usd"], "transcript"
+    in_tok = record.get("in_tok")
+    out_tok = record.get("out_tok")
+    if isinstance(in_tok, (int, float)) or isinstance(out_tok, (int, float)):
+        cost = calc_cost(
+            int(in_tok or 0), int(out_tok or 0), 0, 0, record.get("model")
+        )
+        return cost, "sweep-aggregate-log"
+    return 0.0, "none"
+
+
+def harvest(
+    stats_file: str | None = None,
+    archive_dir: str | os.PathLike[str] | None = None,
+) -> dict[str, Any]:
+    """Aggregate the stats store into per-arm inputs #3718 needs.
+
+    Per arm: first-attempt Judge-pass rate, mean Doctor cycles, exact total cost
+    (via transcript join where available), merge-rate quality floor, and the
+    derived per-issue mean cost that feeds the sonnet-first vs opus-first
+    inequality.
+    """
+    records = read_records(stats_file)
+    transcript_map = build_transcript_map(archive_dir)
+
+    # Per-issue outcome roll-up, keyed (arm, issue).
+    issues: dict[tuple[str, int], dict[str, Any]] = {}
+    # Per-arm cost accumulation across every phase record.
+    arm_cost: dict[str, float] = {}
+    fidelity_counts: dict[str, int] = {"transcript": 0, "sweep-aggregate-log": 0, "none": 0}
+
+    for rec in records:
+        arm = rec.get("arm") or "?"
+        issue = rec.get("issue")
+        phase = (rec.get("phase") or "").lower()
+        role = (rec.get("role") or "").lower()
+
+        cost, fidelity = _record_cost(rec, transcript_map)
+        arm_cost[arm] = arm_cost.get(arm, 0.0) + cost
+        fidelity_counts[fidelity] = fidelity_counts.get(fidelity, 0) + 1
+
+        if issue is None:
+            continue
+        key = (arm, int(issue))
+        state = issues.setdefault(
+            key,
+            {
+                "arm": arm,
+                "issue": int(issue),
+                "complexity": rec.get("complexity") or "routine",
+                "builder_model": None,
+                "first_judge_pass": None,
+                "doctor_cycles": 0,
+                "merged": False,
+            },
+        )
+        if role == "builder" and state["builder_model"] is None:
+            state["builder_model"] = rec.get("model")
+        if phase == "judge" or role == "judge":
+            if int(rec.get("attempt", 1)) == 1 and state["first_judge_pass"] is None:
+                state["first_judge_pass"] = _is_pass(rec.get("judge_verdict"))
+        if phase == "doctor" or role == "doctor":
+            state["doctor_cycles"] += 1
+        if phase == "merge":
+            state["merged"] = True
+
+    # Roll issues up per arm.
+    arms: dict[str, dict[str, Any]] = {}
+    for (arm, _issue), state in issues.items():
+        a = arms.setdefault(
+            arm,
+            {
+                "arm": arm,
+                "model": ARM_MODEL.get(arm, None),
+                "n_issues": 0,
+                "n_judged": 0,
+                "n_first_pass": 0,
+                "doctor_cycles_total": 0,
+                "n_merged": 0,
+            },
+        )
+        a["n_issues"] += 1
+        if state["first_judge_pass"] is not None:
+            a["n_judged"] += 1
+            if state["first_judge_pass"]:
+                a["n_first_pass"] += 1
+        a["doctor_cycles_total"] += state["doctor_cycles"]
+        if state["merged"]:
+            a["n_merged"] += 1
+
+    report_arms = []
+    for arm in sorted(arms):
+        a = arms[arm]
+        n = a["n_issues"]
+        judged = a["n_judged"]
+        total_cost = arm_cost.get(arm, 0.0)
+        report_arms.append(
+            {
+                "arm": arm,
+                "model": a["model"],
+                "n_issues": n,
+                "first_attempt_pass_rate": (a["n_first_pass"] / judged) if judged else None,
+                "mean_doctor_cycles": (a["doctor_cycles_total"] / n) if n else None,
+                "merge_rate": (a["n_merged"] / n) if n else None,
+                "total_cost_usd": round(total_cost, 6),
+                "mean_cost_per_issue_usd": round(total_cost / n, 6) if n else None,
+            }
+        )
+
+    return {
+        "n_records": len(records),
+        "token_fidelity_counts": fidelity_counts,
+        "arms": report_arms,
+    }
+
+
+def format_harvest_text(report: dict[str, Any]) -> str:
+    lines = []
+    lines.append("Sweep model-cost experiment — per-arm harvest (#3725 → #3718)")
+    lines.append(f"  records: {report['n_records']}")
+    fc = report["token_fidelity_counts"]
+    lines.append(
+        "  token fidelity: "
+        f"transcript={fc.get('transcript', 0)} "
+        f"aggregate={fc.get('sweep-aggregate-log', 0)} "
+        f"none={fc.get('none', 0)}"
+    )
+    lines.append("")
+    header = (
+        f"  {'arm':<4} {'model':<8} {'issues':>6} {'1st-pass':>9} "
+        f"{'cycles':>7} {'merge':>6} {'cost$':>10} {'$/issue':>10}"
+    )
+    lines.append(header)
+    lines.append("  " + "-" * (len(header) - 2))
+    for a in report["arms"]:
+        fp = a["first_attempt_pass_rate"]
+        mc = a["mean_doctor_cycles"]
+        mr = a["merge_rate"]
+        cpi = a["mean_cost_per_issue_usd"]
+        fp_s = f"{fp:.0%}" if fp is not None else "-"
+        mc_s = f"{mc:.2f}" if mc is not None else "-"
+        mr_s = f"{mr:.0%}" if mr is not None else "-"
+        cpi_s = f"{cpi:.4f}" if cpi is not None else "-"
+        lines.append(
+            f"  {a['arm']:<4} {str(a['model'] or '-'):<8} {a['n_issues']:>6} "
+            f"{fp_s:>9} {mc_s:>7} {mr_s:>6} "
+            f"{a['total_cost_usd']:>10.4f} {cpi_s:>10}"
+        )
+    # Inequality inputs the retune (#3718) consumes.
+    by_arm = {a["arm"]: a for a in report["arms"]}
+    a_arm = by_arm.get("A")
+    b_arm = by_arm.get("B")
+    if a_arm and b_arm:
+        lines.append("")
+        lines.append("  Inequality inputs for #3718 (cost + merge-rate floor):")
+        lines.append(
+            f"    opus-first  (A): mean ${a_arm['mean_cost_per_issue_usd']} / issue, "
+            f"merge-rate {a_arm['merge_rate']}"
+        )
+        lines.append(
+            f"    sonnet-first(B): mean ${b_arm['mean_cost_per_issue_usd']} / issue, "
+            f"merge-rate {b_arm['merge_rate']}"
+        )
+    return "\n".join(lines)
+
+
+def format_banner(mode: str, issue: int, arm: str | None, model: str | None) -> str:
+    bar = "=" * 72
+    lines = [bar]
+    if mode == "experiment":
+        lines.append(f"  LOOM MODEL EXPERIMENT — mode=EXPERIMENT  issue #{issue}")
+        lines.append(f"  ARM {arm}  ->  Builder model forced to '{model}'")
+        lines.append("  (tier-2.5 complexity bump SUPPRESSED for the forced arm)")
+        lines.append("  CANARY-ONLY. Stats -> .loom/stats/sweep-model-stats.jsonl")
+    elif mode == "observe":
+        lines.append(f"  LOOM MODEL EXPERIMENT — mode=OBSERVE  issue #{issue}")
+        lines.append("  Passive measurement only — no model forcing, no arm.")
+        lines.append("  Stats -> .loom/stats/sweep-model-stats.jsonl")
+    else:
+        lines.append(f"  LOOM MODEL EXPERIMENT — mode=OFF  issue #{issue}")
+        lines.append("  Instrumentation disabled — zero behavior change.")
+    lines.append(bar)
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+
+
+def _cmd_resolve_mode(args: argparse.Namespace) -> int:
+    config = load_config(args.config)
+    mode, warnings = resolve_effective_mode(dict(os.environ), config)
+    for w in warnings:
+        _warn(w)
+    print(mode)
+    return 0
+
+
+def _cmd_assign_arm(args: argparse.Namespace) -> int:
+    arm = assign_arm(args.issue, args.complexity)
+    model = arm_model(arm)
+    if args.format == "json":
+        print(
+            json.dumps(
+                {
+                    "issue": args.issue,
+                    "complexity": normalize_complexity(args.complexity),
+                    "arm": arm,
+                    "model": model,
+                }
+            )
+        )
+    else:
+        print(f"{arm} {model}")
+    return 0
+
+
+def _cmd_banner(args: argparse.Namespace) -> int:
+    config = load_config(args.config)
+    mode, warnings = resolve_effective_mode(dict(os.environ), config)
+    for w in warnings:
+        _warn(w)
+    arm = model = None
+    if mode == "experiment":
+        arm = assign_arm(args.issue, args.complexity)
+        model = arm_model(arm)
+    print(format_banner(mode, args.issue, arm, model))
+    return 0
+
+
+def _cmd_record(args: argparse.Namespace) -> int:
+    record = build_record(
+        issue=args.issue,
+        phase=args.phase,
+        role=args.role,
+        model=args.model,
+        mode=args.mode,
+        arm=args.arm,
+        attempt=args.attempt,
+        complexity=args.complexity,
+        judge_verdict=args.verdict,
+        cycle_count=args.cycle_count,
+        pr=args.pr,
+        effort=args.effort,
+        agent_id=args.agent_id,
+        transcript=args.transcript,
+        in_tok=args.in_tok,
+        out_tok=args.out_tok,
+        token_fidelity=args.token_fidelity,
+    )
+    append_record(record, args.stats_file)
+    if not args.quiet:
+        print(json.dumps(record, ensure_ascii=False))
+    return 0
+
+
+def _cmd_harvest(args: argparse.Namespace) -> int:
+    archive_dir = args.archive_dir or os.environ.get("LOOM_TRANSCRIPT_ARCHIVE")
+    # An env value of ""/off/0/no/disabled is a disable sentinel, not a dir.
+    if archive_dir and archive_dir.strip().lower() in {"", "off", "0", "no", "disabled"}:
+        archive_dir = None
+    report = harvest(args.stats_file, archive_dir)
+    if args.format == "json":
+        print(json.dumps(report, indent=2))
+    else:
+        print(format_harvest_text(report))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="sweep-experiment",
+        description="Model-cost experiment instrumentation for /loom:sweep (#3725).",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_mode = sub.add_parser("resolve-mode", help="Print the effective tri-state mode.")
+    p_mode.add_argument("--config", default=None)
+    p_mode.set_defaults(func=_cmd_resolve_mode)
+
+    p_arm = sub.add_parser("assign-arm", help="Deterministic per-issue arm + model.")
+    p_arm.add_argument("--issue", type=int, required=True)
+    p_arm.add_argument("--complexity", default=None)
+    p_arm.add_argument("--format", choices=("text", "json"), default="text")
+    p_arm.set_defaults(func=_cmd_assign_arm)
+
+    p_ban = sub.add_parser("banner", help="Loud startup banner naming mode + arm.")
+    p_ban.add_argument("--issue", type=int, required=True)
+    p_ban.add_argument("--complexity", default=None)
+    p_ban.add_argument("--config", default=None)
+    p_ban.set_defaults(func=_cmd_banner)
+
+    p_rec = sub.add_parser("record", help="Append one JSONL outcome-chain record.")
+    p_rec.add_argument("--issue", type=int, required=True)
+    p_rec.add_argument("--phase", required=True)
+    p_rec.add_argument("--role", required=True)
+    p_rec.add_argument("--model", default=None)
+    p_rec.add_argument("--mode", default="observe")
+    p_rec.add_argument("--arm", default=None)
+    p_rec.add_argument("--attempt", type=int, default=1)
+    p_rec.add_argument("--complexity", default=None)
+    p_rec.add_argument("--verdict", default=None)
+    p_rec.add_argument("--cycle-count", dest="cycle_count", type=int, default=0)
+    p_rec.add_argument("--pr", type=int, default=None)
+    p_rec.add_argument("--effort", default=None)
+    p_rec.add_argument("--agent-id", dest="agent_id", default=None)
+    p_rec.add_argument("--transcript", default=None)
+    p_rec.add_argument("--in-tok", dest="in_tok", type=int, default=None)
+    p_rec.add_argument("--out-tok", dest="out_tok", type=int, default=None)
+    p_rec.add_argument("--token-fidelity", dest="token_fidelity", default="none")
+    p_rec.add_argument("--stats-file", dest="stats_file", default=None)
+    p_rec.add_argument("--quiet", action="store_true")
+    p_rec.set_defaults(func=_cmd_record)
+
+    p_harv = sub.add_parser("harvest", help="Aggregate the store into #3718 inputs.")
+    p_harv.add_argument("--stats-file", dest="stats_file", default=None)
+    p_harv.add_argument("--archive-dir", dest="archive_dir", default=None)
+    p_harv.add_argument("--format", choices=("text", "json"), default="text")
+    p_harv.set_defaults(func=_cmd_harvest)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/loom-tools/tests/test_sweep_experiment.py
+++ b/loom-tools/tests/test_sweep_experiment.py
@@ -1,0 +1,358 @@
+"""Unit tests for loom_tools.sweep_experiment (issue #3725).
+
+Covers the load-bearing deterministic core:
+- tri-state mode resolution (env-over-config, malformed -> off) + canary guardrail
+- deterministic, resume-safe, stratified arm assignment
+- cache-aware pricing + transcript usage summation
+- transcript-index join (consuming #3726's loom.transcript-index/v1)
+- JSONL append + harvest aggregation into #3718's inequality inputs
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from loom_tools import sweep_experiment as se
+
+
+# --------------------------------------------------------------------------- #
+# Tri-state mode resolution
+# --------------------------------------------------------------------------- #
+
+
+def test_default_mode_is_off():
+    mode, warns = se.resolve_raw_mode({}, {})
+    assert mode == "off"
+    assert warns == []
+
+
+def test_env_over_config():
+    # config says experiment, env says observe -> env wins
+    config = {"sweep": {"modelExperiment": "experiment"}}
+    mode, _ = se.resolve_raw_mode({"LOOM_MODEL_EXPERIMENT": "observe"}, config)
+    assert mode == "observe"
+
+
+def test_config_used_when_env_absent():
+    config = {"sweep": {"modelExperiment": "observe"}}
+    mode, _ = se.resolve_raw_mode({}, config)
+    assert mode == "observe"
+
+
+def test_empty_env_falls_through_to_config():
+    config = {"sweep": {"modelExperiment": "observe"}}
+    mode, _ = se.resolve_raw_mode({"LOOM_MODEL_EXPERIMENT": ""}, config)
+    assert mode == "observe"
+
+
+def test_malformed_env_becomes_off_with_warning():
+    mode, warns = se.resolve_raw_mode({"LOOM_MODEL_EXPERIMENT": "bogus"}, {})
+    assert mode == "off"
+    assert warns and "bogus" in warns[0]
+
+
+def test_malformed_config_becomes_off_with_warning():
+    mode, warns = se.resolve_raw_mode({}, {"sweep": {"modelExperiment": 42}})
+    assert mode == "off"
+    assert warns
+
+
+def test_case_insensitive_values():
+    mode, _ = se.resolve_raw_mode({"LOOM_MODEL_EXPERIMENT": "EXPERIMENT"}, {})
+    assert mode == "experiment"
+
+
+# --------------------------------------------------------------------------- #
+# Canary guardrail
+# --------------------------------------------------------------------------- #
+
+
+def test_experiment_downgrades_to_observe_without_canary():
+    mode, warns = se.resolve_effective_mode(
+        {"LOOM_MODEL_EXPERIMENT": "experiment"}, {}
+    )
+    assert mode == "observe"
+    assert any("NON-CANARY" in w for w in warns)
+
+
+def test_experiment_honored_with_env_canary():
+    mode, _ = se.resolve_effective_mode(
+        {"LOOM_MODEL_EXPERIMENT": "experiment", "LOOM_MODEL_EXPERIMENT_CANARY": "1"},
+        {},
+    )
+    assert mode == "experiment"
+
+
+def test_experiment_honored_with_config_canary():
+    config = {"sweep": {"modelExperimentCanary": True}}
+    mode, _ = se.resolve_effective_mode(
+        {"LOOM_MODEL_EXPERIMENT": "experiment"}, config
+    )
+    assert mode == "experiment"
+
+
+def test_observe_is_safe_anywhere_no_guardrail():
+    mode, warns = se.resolve_effective_mode({"LOOM_MODEL_EXPERIMENT": "observe"}, {})
+    assert mode == "observe"
+    assert warns == []
+
+
+# --------------------------------------------------------------------------- #
+# Arm assignment: determinism, resume-safety, stratification
+# --------------------------------------------------------------------------- #
+
+
+def test_arm_is_deterministic_and_resume_safe():
+    # Same issue + complexity always yields the same arm (resume-safe).
+    for issue in (1, 42, 3725, 999999):
+        for comp in ("complex", "routine", None):
+            assert se.assign_arm(issue, comp) == se.assign_arm(issue, comp)
+
+
+def test_arm_model_mapping():
+    assert se.arm_model("A") == "opus"
+    assert se.arm_model("B") == "sonnet"
+    assert se.arm_model("a") == "opus"
+
+
+def test_arms_are_only_A_or_B():
+    for issue in range(0, 50):
+        assert se.assign_arm(issue, "complex") in ("A", "B")
+        assert se.assign_arm(issue, "routine") in ("A", "B")
+
+
+def test_stratification_balances_within_each_stratum():
+    # Across a contiguous block of issue numbers, each stratum should split
+    # A/B roughly evenly (parity-based) — both arms see a comparable mix.
+    n = 200
+    for comp in ("complex", "routine"):
+        arms = [se.assign_arm(i, comp) for i in range(n)]
+        a_count = arms.count("A")
+        b_count = arms.count("B")
+        assert a_count == b_count == n // 2
+
+
+def test_complexity_offsets_the_parity():
+    # For a fixed issue, complex and routine land on opposite arms (the
+    # stratum offset decorrelates the two strata).
+    for issue in (0, 1, 2, 100, 101, 3725):
+        assert se.assign_arm(issue, "complex") != se.assign_arm(issue, "routine")
+
+
+def test_unknown_complexity_normalizes_to_routine():
+    assert se.assign_arm(10, "weird") == se.assign_arm(10, "routine")
+    assert se.assign_arm(10, "") == se.assign_arm(10, None)
+
+
+# --------------------------------------------------------------------------- #
+# Pricing + transcript usage
+# --------------------------------------------------------------------------- #
+
+
+def test_cache_aware_pricing_opus():
+    # input 30, output 20, cache_read 2000, cache_write 1000 on opus:
+    #  30/1e3*0.015 + 20/1e3*0.075 + 2000/1e3*0.0015 + 1000/1e3*0.01875
+    cost = se.calc_cost(30, 20, 2000, 1000, "claude-opus-4-8")
+    assert cost == pytest.approx(0.00045 + 0.0015 + 0.003 + 0.01875)
+
+
+def test_pricing_alias_and_pinned_agree():
+    assert se.model_pricing("opus") == se.model_pricing("claude-opus-4-8")
+    assert se.model_pricing("sonnet") == se.model_pricing("claude-sonnet-4-6")
+
+
+def test_sum_transcript_usage(tmp_path):
+    tr = tmp_path / "agent-x.jsonl"
+    tr.write_text(
+        json.dumps(
+            {
+                "message": {
+                    "model": "claude-opus-4-8",
+                    "usage": {
+                        "input_tokens": 10,
+                        "output_tokens": 5,
+                        "cache_creation_input_tokens": 1000,
+                        "cache_read_input_tokens": 2000,
+                    },
+                }
+            }
+        )
+        + "\n"
+        + json.dumps(
+            {"message": {"model": "claude-opus-4-8", "usage": {"input_tokens": 20, "output_tokens": 15}}}
+        )
+        + "\n"
+        + "not json, skipped\n"
+    )
+    summary = se.sum_transcript_usage(str(tr))
+    assert summary["input_tokens"] == 30
+    assert summary["output_tokens"] == 20
+    assert summary["cache_creation_input_tokens"] == 1000
+    assert summary["cache_read_input_tokens"] == 2000
+    assert summary["usage_blocks"] == 2
+    assert summary["model"] == "claude-opus-4-8"
+    assert summary["cost_usd"] == pytest.approx(0.0237)
+
+
+def test_sum_transcript_usage_missing_file():
+    summary = se.sum_transcript_usage("/no/such/file.jsonl")
+    assert summary["usage_blocks"] == 0
+    assert summary["cost_usd"] == 0.0
+
+
+# --------------------------------------------------------------------------- #
+# Transcript-index join (#3726 loom.transcript-index/v1)
+# --------------------------------------------------------------------------- #
+
+
+def _make_archive(tmp_path):
+    sess = tmp_path / "archive" / "myrepo" / "2026-07-22" / "UUID1"
+    (sess / "UUID1" / "subagents").mkdir(parents=True)
+    (sess / "UUID1" / "subagents" / "agent-bld1.jsonl").write_text(
+        json.dumps(
+            {
+                "message": {
+                    "model": "claude-opus-4-8",
+                    "usage": {"input_tokens": 10, "output_tokens": 5,
+                              "cache_creation_input_tokens": 1000,
+                              "cache_read_input_tokens": 2000},
+                }
+            }
+        )
+        + "\n"
+    )
+    (sess / "index.json").write_text(
+        json.dumps(
+            {
+                "schema": "loom.transcript-index/v1",
+                "session_uuid": "UUID1",
+                "repo": "myrepo",
+                "agents": [
+                    {"agent_id": "agent-bld1", "role": "loom-builder",
+                     "transcript": "subagents/agent-bld1.jsonl"}
+                ],
+            }
+        )
+    )
+    return tmp_path / "archive"
+
+
+def test_build_transcript_map(tmp_path):
+    archive = _make_archive(tmp_path)
+    mapping = se.build_transcript_map(str(archive))
+    assert "agent-bld1" in mapping
+    assert os.path.isfile(mapping["agent-bld1"])
+    summary = se.sum_transcript_usage(mapping["agent-bld1"])
+    assert summary["input_tokens"] == 10
+
+
+def test_build_transcript_map_ignores_wrong_schema(tmp_path):
+    d = tmp_path / "arch" / "s"
+    d.mkdir(parents=True)
+    (d / "index.json").write_text(json.dumps({"schema": "other", "agents": []}))
+    assert se.build_transcript_map(str(tmp_path / "arch")) == {}
+
+
+def test_build_transcript_map_empty_when_no_dir():
+    assert se.build_transcript_map(None) == {}
+    assert se.build_transcript_map("/no/such/dir") == {}
+
+
+# --------------------------------------------------------------------------- #
+# JSONL append + harvest aggregation
+# --------------------------------------------------------------------------- #
+
+
+def test_append_and_read_records(tmp_path):
+    stats = tmp_path / "stats.jsonl"
+    se.append_record(se.build_record(issue=1, phase="builder", role="builder", arm="A"), str(stats))
+    se.append_record(se.build_record(issue=2, phase="judge", role="judge", arm="B"), str(stats))
+    records = se.read_records(str(stats))
+    assert len(records) == 2
+    assert records[0]["issue"] == 1
+    assert records[1]["arm"] == "B"
+    # File is created 0600.
+    assert oct(os.stat(stats).st_mode)[-3:] == "600"
+
+
+def test_record_stamps_hard_fields():
+    rec = se.build_record(
+        issue=3725, phase="judge", role="judge", model="opus", mode="experiment",
+        arm="a", attempt=2, complexity="complex", judge_verdict="pass",
+        cycle_count=1, agent_id="agent-z",
+    )
+    assert rec["issue"] == 3725
+    assert rec["arm"] == "A"  # uppercased
+    assert rec["attempt"] == 2
+    assert rec["complexity"] == "complex"
+    assert rec["judge_verdict"] == "pass"
+    assert rec["agent_id"] == "agent-z"
+    assert rec["mode"] == "experiment"
+    assert "ts" in rec
+
+
+def test_harvest_aggregation(tmp_path):
+    archive = _make_archive(tmp_path)
+    stats = tmp_path / "stats.jsonl"
+    sf = str(stats)
+    # Arm A: builder(joins transcript) -> judge pass -> merge (first-attempt pass, merged)
+    se.append_record(se.build_record(issue=100, phase="builder", role="builder",
+                                     model="opus", arm="A", agent_id="agent-bld1"), sf)
+    se.append_record(se.build_record(issue=100, phase="judge", role="judge",
+                                     arm="A", attempt=1, judge_verdict="pass"), sf)
+    se.append_record(se.build_record(issue=100, phase="merge", role="merge", arm="A"), sf)
+    # Arm B: builder(best-effort tokens) -> judge changes -> doctor -> judge pass (1 cycle, not merged)
+    se.append_record(se.build_record(issue=101, phase="builder", role="builder",
+                                     model="sonnet", arm="B", in_tok=5000, out_tok=800,
+                                     token_fidelity="sweep-aggregate-log"), sf)
+    se.append_record(se.build_record(issue=101, phase="judge", role="judge",
+                                     arm="B", attempt=1, judge_verdict="changes"), sf)
+    se.append_record(se.build_record(issue=101, phase="doctor", role="doctor",
+                                     arm="B", attempt=2), sf)
+    se.append_record(se.build_record(issue=101, phase="judge", role="judge",
+                                     arm="B", attempt=2, judge_verdict="pass"), sf)
+
+    report = se.harvest(sf, str(archive))
+    assert report["n_records"] == 7
+    assert report["token_fidelity_counts"]["transcript"] == 1
+    assert report["token_fidelity_counts"]["sweep-aggregate-log"] == 1
+
+    arms = {a["arm"]: a for a in report["arms"]}
+    a, b = arms["A"], arms["B"]
+
+    assert a["model"] == "opus"
+    assert a["first_attempt_pass_rate"] == 1.0
+    assert a["mean_doctor_cycles"] == 0.0
+    assert a["merge_rate"] == 1.0
+    # exact from transcript (single usage block):
+    #  10/1e3*0.015 + 5/1e3*0.075 + 2000/1e3*0.0015 + 1000/1e3*0.01875
+    assert a["total_cost_usd"] == pytest.approx(0.022275)
+
+    assert b["model"] == "sonnet"
+    assert b["first_attempt_pass_rate"] == 0.0
+    assert b["mean_doctor_cycles"] == 1.0
+    assert b["merge_rate"] == 0.0
+    # best-effort cost: 5000/1e3*0.003 + 800/1e3*0.015
+    assert b["total_cost_usd"] == pytest.approx(0.027)
+
+
+def test_harvest_empty_store_does_not_crash(tmp_path):
+    report = se.harvest(str(tmp_path / "missing.jsonl"), None)
+    assert report["n_records"] == 0
+    assert report["arms"] == []
+
+
+def test_concurrent_appends_are_line_atomic(tmp_path):
+    # Simulate interleaved detached writers: many small O_APPEND writes must not
+    # corrupt lines. We can't easily fork here, but we can assert every line
+    # round-trips as valid JSON after a burst of appends.
+    stats = tmp_path / "stats.jsonl"
+    for i in range(50):
+        se.append_record(se.build_record(issue=i, phase="builder", role="builder",
+                                         arm="A" if i % 2 else "B"), str(stats))
+    records = se.read_records(str(stats))
+    assert len(records) == 50
+    assert all(isinstance(r["issue"], int) for r in records)


### PR DESCRIPTION
Closes #3725. **Stacked on #3726** (base `feature/issue-3726`); this PR must merge **after** #3726 (and its own stack parent #3727) so the diff stays scoped to only #3725's changes.

## What this ships

Instrumentation that produces the balanced A/B evidence #3718 needs to decide the Builder `opus → sonnet` retune. Passive collection alone can only ever measure the current default arm — this generates both.

- **Tri-state setting** `sweep.modelExperiment` / `LOOM_MODEL_EXPERIMENT` (`off`/`observe`/`experiment`), resolved env-over-config following the **string-valued** guard precedence (`guards.rmScope`/`guards.forceScope`). Unknown/malformed → `off` + warning; **byte-for-byte no-op when unset**.
- **Two arms** map onto #3718's inequality — **A = opus-first**, **B = sonnet-first + escalate** (via the existing `sweep.escalation` ladder). Per-issue arm assignment is a **deterministic, resume-safe** pure function of the issue number, **stratified** by the #3702 complexity marker.
- **(hard AC) experiment mode SUPPRESSES the tier-2.5 complexity bump** — the `sonnet → opus` bump would silently turn Arm B into opus on `complex`-marked issues and confound the A/B. Under a forced arm the marker is *read* only as the stratification key, never as a bump. Tier-1/tier-2 operator pins still win (a pinned canary is opted out).
- **Durable store** `.loom/stats/sweep-model-stats.jsonl` (gitignored; atomic POSIX `O_APPEND`), surviving the merge that deletes the transient checkpoint. Each record carries the HARD deterministic outcome-chain (arm/model/attempt/verdict/cycle-count/complexity) — which alone answers #3718's inequality — plus an `agent-id` join key.
- **Exact per-role cost harvest**: parses each role subagent's `agent-<id>.jsonl` `usage` blocks (input/output + cache-read/creation split) with the same **cache-aware** per-model pricing as `loom-daemon`'s `resource_usage.rs`, joined to outcome records through #3726's `loom.transcript-index/v1` archive index. `token_fidelity` ladder (`transcript` > `sweep-aggregate-log` > `none`).
- **Canary-only guardrail**: `experiment` loudly downgrades to `observe` on a non-canary target unless `LOOM_MODEL_EXPERIMENT_CANARY=1`; a loud startup banner names the mode and the per-issue arm. `observe` is safe anywhere.
- Harvest reachable via `agent-metrics.sh --model-experiment` (next to the existing `--by-model` cost dimension).

## Token-fidelity finding (honest)

There is **no per-phase real-token split at the Task-result boundary** — the harness does not surface per-subagent `usage` when a Task returns. Exact per-role cost is instead recovered at **harvest** time from the durable role-subagent transcripts. I verified on real on-disk transcripts that each role invocation's `agent-<id>.jsonl` carries full per-message `usage` (input/output + cache split) and `model` — true per-role granularity, not the whole-`claude -p`-process aggregate the live daemon path is limited to.

**Daemon detached-child durability (verified, documented in sweep.md):** a daemon-dispatched `claude -p "/loom:sweep N"` child's role-subagent transcripts land under the child's own `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/<slug>/<child-session-uuid>/subagents/agent-<id>.jsonl` — the **durable** tree, not the ephemeral `/tmp/.../tasks/` scratch (those tmp paths are symlinks into the durable transcript). So they are archivable/harvestable via #3726's periodic sync.

**Deferred (not in this PR):** the daemon reaper does not yet know the child's session-uuid, so it cannot trigger a precise single-session archive on child exit — the #3726 cron periodic sync is the durability backstop, exactly as for the completion hook. Retention over a multi-day canary therefore relies on running harvest (or the #3726 archive sync) periodically before `~/.claude/projects` is pruned.

## Tests (all green)

- `PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/test_sweep_experiment.py` — **29 passed** (tri-state resolution, canary guardrail, deterministic/stratified arm assignment, cache-aware pricing, transcript-usage summation, transcript-index join, JSONL append + harvest aggregation).
- `bash defaults/scripts/tests/test-sweep-experiment.sh` — **22 assertions passed**.
- `cargo test --test sweep_md_doc_lint` — **11 passed** (3 new #3725 guards pinning the experiment-mode / tier-2.5-suppression / guardrail+harvest prose).
- `bash -n` + `shellcheck -S warning` clean on both new scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)