### PR TITLE
docs(models): keep Builder opus — no data yet for retune gate (#3718)

### DIFF
--- a/docs/model-selection-retune.md
+++ b/docs/model-selection-retune.md
@@ -194,6 +194,47 @@ is introduced by this document. If a future gap appears (e.g. a graceful
 "no data yet" message instead of the raw missing-table error), prefer a dedicated
 follow-up issue over expanding the retune scope.
 
+### Status log
+
+Dated re-evaluations of the gate. Each entry records that the measurement plumbing
+was re-run, what it reported, and the resulting flip / no-flip decision. **No entry
+here changes a default** unless it also cites a qualifying sample per Section 3.
+
+- **2026-07-22 (#3718) — keep `opus`, no data yet.** Re-verified the full §3 gating
+  path against `origin/main`. All four by-model commands still surface the documented
+  *no-activity* case, not a defect:
+
+  ```text
+  $ .loom/scripts/agent-metrics.sh effectiveness --by-model
+  [ERROR] Failed to get metrics: no such table: quality_metrics
+  $ .loom/scripts/agent-metrics.sh effectiveness --by-model --role builder
+  [ERROR] Failed to get metrics: no such table: quality_metrics
+  $ .loom/scripts/agent-metrics.sh costs --by-model
+  [ERROR] Failed to get metrics: no such table: prompt_github
+  $ .loom/scripts/agent-metrics.sh effectiveness --by-model --format json
+  [ERROR] Failed to get metrics: no such table: quality_metrics
+  ```
+
+  The #3725/#3728 model-cost experiment harvest entry point
+  (`agent-metrics.sh --model-experiment`) resolves cleanly and reports zero records
+  (exit 0, `records: 0`, empty per-arm table) — the expected empty state, again not a
+  defect. Unit coverage stays green: `pytest loom-tools/tests/test_agent_metrics.py`
+  → 61 passed.
+
+  **Representative sample?** No. The gate requires ≥~30 model-attributed first
+  attempts per model arm for the Builder role (§3, "Minimum representative sample");
+  the DB has zero attributed rows for *any* arm (neither `sonnet` nor `opus`, not even
+  the `default` bucket). The `cost(sonnet_first) < cost(opus_first)` inequality (§2)
+  therefore cannot be evaluated.
+
+  **Decision:** `defaults/roles/builder.json` `suggestedModel` remains `opus`. No
+  default changed, preserving the Hard Rule at the top of this document. Accruing the
+  sample is out-of-band, over-time work (a multi-day `LOOM_MODEL_EXPERIMENT=observe`
+  or canary `experiment` campaign per `defaults/CLAUDE.md` § "Model-Cost Experiment"),
+  not a Builder code change. `observe` mode is the suggested follow-up mechanism for
+  generating the `sonnet` vs `opus` data points a passive `opus`-only default can
+  never produce on its own.
+
 ---
 
 ## 5. The flip is a separate, gated follow-up


### PR DESCRIPTION
Closes #3718

## Summary

Executes the measurement-gated Builder default retune evaluation. The verified outcome is the **no-flip branch**: no representative per-model sample exists, so `defaults/roles/builder.json` `suggestedModel` stays `opus`, preserving the #3706 Hard Rule.

## What I did (and did NOT do)

**Did:**
- Re-ran the full §3 gating procedure from `docs/model-selection-retune.md` against `origin/main` (in the worktree).
- Confirmed the measurement plumbing behaves exactly as documented — no defect found.
- Added a dated **Status log** entry under §4 recording the evaluation + the "keep opus, no data yet" decision so it isn't silently re-litigated.

**Did NOT do (by design, per the issue's invariant):**
- Did **not** change `defaults/roles/builder.json` `suggestedModel` (stays `opus`).
- Did **not** touch the `defaults/CLAUDE.md` "Suggested models by role" table.
- Did **not** enable `LOOM_MODEL_EXPERIMENT` (an operator/multi-day action, out of scope for a Builder PR).

## Plumbing verification (Step 1 — actual output)

```text
$ .loom/scripts/agent-metrics.sh effectiveness --by-model
[ERROR] Failed to get metrics: no such table: quality_metrics
$ .loom/scripts/agent-metrics.sh effectiveness --by-model --role builder
[ERROR] Failed to get metrics: no such table: quality_metrics
$ .loom/scripts/agent-metrics.sh costs --by-model
[ERROR] Failed to get metrics: no such table: prompt_github
$ .loom/scripts/agent-metrics.sh effectiveness --by-model --format json
[ERROR] Failed to get metrics: no such table: quality_metrics
```

These are the documented *no-activity* error shapes (`docs/model-selection-retune.md` §4), not crashes/tracebacks — expected current state, not a defect to fix.

The #3725/#3728 model-cost harvest entry point resolves cleanly:

```text
$ .loom/scripts/agent-metrics.sh --model-experiment
Sweep model-cost experiment — per-arm harvest (#3725 → #3718)
  records: 0
  ...
(exit 0)
```

## Representative sample?

**No.** The gate requires ≥~30 model-attributed first attempts per model arm for the Builder role (§3). The DB has zero attributed rows for any arm (neither `sonnet` nor `opus`, not even the `default` bucket). The §2 `cost(sonnet_first) < cost(opus_first)` inequality therefore cannot be evaluated. Accruing the sample is out-of-band, over-time work (a multi-day `observe`/`experiment` campaign), not a code change — noted as a follow-up in the status-log entry.

## Tests

```text
PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/test_agent_metrics.py -q
61 passed
```

## Files changed

- `docs/model-selection-retune.md` — added dated §4 Status-log entry (only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)