### PR TITLE
fix(cli): restore daemon control surface — ship loom-status.sh, repoint dead daemon.sh wrappers (#3734)

### DIFF
--- a/.loom/bin/loom
+++ b/.loom/bin/loom
@@ -94,10 +94,7 @@ case "${1:-help}" in
         ;;
     status)
         shift
-        # Use existing loom-status.sh if available
-        if [[ -f "$REPO_ROOT/.loom/scripts/loom-status.sh" ]]; then
-            exec "$REPO_ROOT/.loom/scripts/loom-status.sh" "$@"
-        elif [[ -f "$CLI_DIR/loom-status.sh" ]]; then
+        if [[ -f "$CLI_DIR/loom-status.sh" ]]; then
             exec "$CLI_DIR/loom-status.sh" "$@"
         else
             echo -e "${RED}Error: loom-status.sh not found${NC}" >&2

--- a/defaults/.claude/README.md
+++ b/defaults/.claude/README.md
@@ -169,7 +169,7 @@ The `agents/` directory contains custom subagent definitions for Loom roles. The
 | `loom-guide` | sonnet | Prioritize and triage issues |
 | `loom-auditor` | sonnet | Verify runtime behavior of built software |
 
-> **Note**: the `loom-shepherd` subagent was removed in v0.10.0 along with the `/shepherd` slash command — see [the migration guide](https://github.com/rjwalters/loom/blob/main/docs/migration/v0.10.0-shepherd-deprecation.md). Use `/loom:sweep <issue>` (Tier 1) for the equivalent lifecycle. The `loom-daemon` subagent is preserved and now documents the shell-level daemon surface (`./.loom/scripts/daemon.sh` + tmux + token rotation) rather than the deleted Python brain.
+> **Note**: the `loom-shepherd` subagent was removed in v0.10.0 along with the `/shepherd` slash command — see [the migration guide](https://github.com/rjwalters/loom/blob/main/docs/migration/v0.10.0-shepherd-deprecation.md). Use `/loom:sweep <issue>` (Tier 1) for the equivalent lifecycle. The `loom-daemon` subagent is preserved and now documents the Rust `loom-daemon` binary's MCP dispatch surface (`mcp__loom__dispatch_sweep` / `mcp__loom__list_sweeps` …) plus the background agent-pool CLI (`.loom/bin/loom start|status|stop` + tmux + token rotation) rather than the deleted Python brain.
 
 ### How Subagents Work
 

--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -1435,9 +1435,9 @@ If the user is running an overnight sweep, they should heed the warning before w
 
 ## Daemon Coexistence
 
-> **Stop-gap note (epic #3449, stop-gap #3451)**: `./.loom/scripts/daemon.sh` does not currently exist on `origin/main` (deleted in #3432, rebuild in flight under epic #3449). The PID-file check below is a defensive coexistence guard that fires only if a daemon process is already running — it's a no-op in v0.9.x. The `./.loom/scripts/daemon.sh stop` instruction in the warning text is forward-looking until the rebuild lands.
+> **Note**: the legacy `./.loom/scripts/daemon.sh` was removed in #3432 and is not restored. The historical PID-file daemon (`.loom/daemon-loop.pid`) is not part of the current architecture; the check below is a defensive coexistence guard that fires only if such a process is somehow already running — normally a no-op. The Tier 2 dispatch backend is now the Rust `loom-daemon` binary (observed via `mcp__loom__list_sweeps`); the background agent-pool control surface is `.loom/bin/loom start|status|stop`.
 
-`/sweep` does not require the daemon and does not interact with `.loom/daemon-state.json` for writes. If the daemon is running, `/sweep` and the daemon may both try to claim the same `loom:issue` label.
+`/sweep` does not require the daemon and does not interact with `.loom/daemon-state.json` for writes. If a legacy daemon process is running, `/sweep` and the daemon may both try to claim the same `loom:issue` label.
 
 **Coexistence behavior:** before the first wave, check whether the daemon is running. If it is, warn the user once at the start of the sweep:
 
@@ -1445,8 +1445,8 @@ If the user is running an overnight sweep, they should heed the warning before w
 PID=$(cat .loom/daemon-loop.pid 2>/dev/null)
 if [[ -n "$PID" ]] && kill -0 "$PID" 2>/dev/null; then
   echo "⚠️  Loom daemon is running (PID $PID). /sweep will race with the daemon"
-  echo "   for issues in the loom:issue queue. Consider stopping the daemon first:"
-  echo "       ./.loom/scripts/daemon.sh stop"
+  echo "   for issues in the loom:issue queue. Consider stopping the pool first:"
+  echo "       ./.loom/bin/loom stop"
 fi
 ```
 

--- a/defaults/.loom/CLAUDE.md
+++ b/defaults/.loom/CLAUDE.md
@@ -47,26 +47,39 @@ Use Claude Code terminals with specialized roles for hands-on development coordi
 # Enhances unlabeled issues, marks as loom:ready
 ```
 
-### 2. Daemon Mode
+### 2. Agent Pool (`.loom/bin/loom`)
 
-Run the Loom daemon for fully autonomous system orchestration.
-
-**Setup**:
-```bash
-./.loom/scripts/daemon.sh start   # auto-build enabled (default)
-```
+Spawn and manage a background pool of autonomous agents (tmux sessions) from
+`.loom/config.json`. The canonical control surface is the `.loom/bin/loom` CLI:
 
 ```bash
-/loom           # Activate daemon orchestration (daemon must be started first)
-/loom --merge   # Aggressive autonomous development
+./.loom/bin/loom start    # Spawn the agent pool from .loom/config.json
+./.loom/bin/loom status   # Show running agents (+ configured-but-stopped)
+./.loom/bin/loom stop     # Graceful shutdown of the pool
 ```
 
-**When to use Daemon Mode**:
-- Production-scale development
-- Fully autonomous agent workflows
-- Hands-off orchestration
+**Common commands**:
 
-**Graceful shutdown**: `./.loom/scripts/daemon.sh stop` (or `touch .loom/stop-daemon`)
+| Command | Purpose |
+|---------|---------|
+| `./.loom/bin/loom start` | Start all configured agents (`--only <role>` to filter, `--dry-run` to preview) |
+| `./.loom/bin/loom status` | List running `loom-*` tmux sessions with id / name / role, plus any configured agent that is not running (`--json` for machine-readable output) |
+| `./.loom/bin/loom stop` | Graceful shutdown (`--force` to kill immediately, `<agent>` to stop one) |
+| `./.loom/bin/loom attach <id>` | Attach to a running agent's tmux session |
+| `./.loom/bin/loom logs <id>` | Tail an agent's output |
+| `./.loom/bin/loom help` | Full command list; `./.loom/bin/loom <cmd> --help` for per-command help |
+
+The legacy `./loom.sh` wrapper (and `.loom/scripts/start-daemon.sh` /
+`stop-daemon.sh`) are thin shims that now delegate to these `.loom/bin/loom`
+subcommands, kept only for backwards compatibility.
+
+**When to use the agent pool**:
+- Running several standing role agents (builder / judge / curator …) in the background
+- Hands-off orchestration on a dedicated host
+
+> For single-issue lifecycle orchestration prefer `/loom:sweep <issue>` (Tier 1),
+> and for multi-account autonomous dispatch use the Rust `loom-daemon` binary via
+> `mcp__loom__dispatch_sweep` (Tier 2).
 
 ## Agent Roles
 

--- a/defaults/.loom/bin/loom
+++ b/defaults/.loom/bin/loom
@@ -94,10 +94,7 @@ case "${1:-help}" in
         ;;
     status)
         shift
-        # Use existing loom-status.sh if available
-        if [[ -f "$REPO_ROOT/.loom/scripts/loom-status.sh" ]]; then
-            exec "$REPO_ROOT/.loom/scripts/loom-status.sh" "$@"
-        elif [[ -f "$CLI_DIR/loom-status.sh" ]]; then
+        if [[ -f "$CLI_DIR/loom-status.sh" ]]; then
             exec "$CLI_DIR/loom-status.sh" "$@"
         else
             echo -e "${RED}Error: loom-status.sh not found${NC}" >&2

--- a/defaults/scripts/cli/loom-help.sh
+++ b/defaults/scripts/cli/loom-help.sh
@@ -171,8 +171,8 @@ show_command_help() {
             fi
             ;;
         status)
-            if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/scripts/loom-status.sh" ]]; then
-                exec "$REPO_ROOT/.loom/scripts/loom-status.sh" --help
+            if [[ -n "$CLI_DIR" && -f "$CLI_DIR/loom-status.sh" ]]; then
+                exec "$CLI_DIR/loom-status.sh" --help
             else
                 echo -e "${RED}Error: status command not installed${NC}"
                 exit 1

--- a/defaults/scripts/cli/loom-status.sh
+++ b/defaults/scripts/cli/loom-status.sh
@@ -1,0 +1,300 @@
+#!/usr/bin/env bash
+# loom status - Display agent pool state
+#
+# Usage:
+#   loom status                   Show running agents + configured-but-stopped agents
+#   loom status --json            Machine-readable JSON output
+#   loom status --help            Show help
+#
+# Reports the tmux agent pool spawned by `loom start`:
+#   - Running `loom-*` tmux sessions on the `loom` socket (with pane PID).
+#   - Cross-references each session against .loom/config.json .terminals[]
+#     to report terminal id, name, and role file.
+#   - Flags agents configured in .loom/config.json that are NOT running,
+#     so a crashed / never-started agent is easy to spot.
+#
+# Exits 0 whether or not any agents are running (an empty pool is not an error).
+
+set -euo pipefail
+
+# Find repository root
+find_repo_root() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.loom" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        if [[ -f "$dir/.git" ]]; then
+            local gitdir
+            gitdir=$(sed 's/^gitdir: //' "$dir/.git")
+            local main_repo
+            main_repo=$(dirname "$(dirname "$(dirname "$gitdir")")")
+            if [[ -d "$main_repo/.loom" ]]; then
+                echo "$main_repo"
+                return 0
+            fi
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo ""
+}
+
+REPO_ROOT=$(find_repo_root)
+if [[ -z "$REPO_ROOT" ]]; then
+    echo "Error: Not in a Loom workspace (.loom directory not found)" >&2
+    exit 1
+fi
+
+CONFIG_FILE="$REPO_ROOT/.loom/config.json"
+TMUX_SOCKET="loom"
+
+# ANSI colors
+if [[ -t 1 ]]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    CYAN='\033[0;36m'
+    GRAY='\033[0;90m'
+    BOLD='\033[1m'
+    NC='\033[0m'
+else
+    RED=''
+    GREEN=''
+    YELLOW=''
+    CYAN=''
+    GRAY=''
+    BOLD=''
+    NC=''
+fi
+
+# Show help
+show_help() {
+    cat <<EOF
+${BOLD}loom status - Display agent pool state${NC}
+
+${YELLOW}USAGE:${NC}
+    loom status                   Show running + configured-but-stopped agents
+    loom status --json            Machine-readable JSON output
+    loom status --help            Show this help
+
+${YELLOW}OUTPUT:${NC}
+    Running agents are the ${CYAN}loom-*${NC} tmux sessions on the ${CYAN}loom${NC} socket
+    spawned by 'loom start'. Each is cross-referenced against
+    .loom/config.json .terminals[] to show its id, name, and role file.
+    Agents present in the config but not currently running are listed
+    separately so a crashed or never-started agent is easy to spot.
+
+${YELLOW}EXIT STATUS:${NC}
+    Always 0 when the workspace resolves — an empty pool is not an error.
+
+${YELLOW}RELATED COMMANDS:${NC}
+    loom start       Spawn the agent pool from config
+    loom attach <id> Attach to a running agent's tmux session
+    loom logs <id>   Tail an agent's output
+    loom stop        Graceful shutdown of the agent pool
+EOF
+}
+
+# List running loom-* sessions on the loom socket (one per line, may be empty)
+get_running_sessions() {
+    command -v tmux &>/dev/null || return 0
+    tmux -L "$TMUX_SOCKET" list-sessions -F "#{session_name}" 2>/dev/null \
+        | grep "^loom-" || true
+}
+
+# Pane PID for a session (first pane); empty if unavailable
+session_pid() {
+    local session_name="$1"
+    tmux -L "$TMUX_SOCKET" list-panes -t "$session_name" -F "#{pane_pid}" 2>/dev/null \
+        | head -1 || true
+}
+
+# Read the configured terminals as compact JSON array (or "[]")
+read_terminals() {
+    if [[ -f "$CONFIG_FILE" ]] && command -v jq &>/dev/null; then
+        jq -c '.terminals // []' "$CONFIG_FILE" 2>/dev/null || echo "[]"
+    else
+        echo "[]"
+    fi
+}
+
+# ---- JSON output ---------------------------------------------------------
+emit_json() {
+    if ! command -v jq &>/dev/null; then
+        echo '{"error":"jq not installed"}'
+        return 0
+    fi
+
+    local running
+    running=$(get_running_sessions)
+
+    # Build a JSON array of running sessions with pids
+    local running_json="[]"
+    if [[ -n "$running" ]]; then
+        local rows=""
+        while IFS= read -r session; do
+            [[ -z "$session" ]] && continue
+            local id="${session#loom-}"
+            local pid
+            pid=$(session_pid "$session")
+            rows+=$(jq -nc --arg session "$session" --arg id "$id" --arg pid "$pid" \
+                '{session:$session, id:$id, pid:($pid|select(.!="")|tonumber?)}')
+            rows+=$'\n'
+        done <<< "$running"
+        running_json=$(printf '%s' "$rows" | jq -sc '.')
+    fi
+
+    local terminals
+    terminals=$(read_terminals)
+
+    jq -nc \
+        --argjson running "$running_json" \
+        --argjson terminals "$terminals" \
+        '
+        ($running | map(.id)) as $running_ids
+        | {
+            running: ($terminals | map(
+                . as $t
+                | ($running[] | select(.id == $t.id)) as $r
+                | {
+                    id: $t.id,
+                    name: ($t.name // $t.id),
+                    role: ($t.roleConfig.roleFile // null),
+                    session: $r.session,
+                    pid: $r.pid,
+                    status: "running"
+                  }
+              )),
+            stopped: ($terminals | map(select(.id as $id | ($running_ids | index($id)) | not))
+                | map({
+                    id: .id,
+                    name: (.name // .id),
+                    role: (.roleConfig.roleFile // null),
+                    status: "stopped"
+                  })),
+            unmanaged: ($running | map(select(.id as $rid
+                | ($terminals | map(.id) | index($rid)) | not))
+                | map({session: .session, id: .id, pid: .pid, status: "unmanaged"}))
+          }'
+}
+
+# ---- Human-readable output ----------------------------------------------
+emit_human() {
+    local running running_ids=()
+    running=$(get_running_sessions)
+
+    echo -e "${BOLD}Loom Agent Pool${NC}"
+    echo ""
+    echo -e "  Workspace: ${CYAN}$REPO_ROOT${NC}"
+    if [[ -f "$CONFIG_FILE" ]]; then
+        echo -e "  Config:    ${CYAN}$CONFIG_FILE${NC}"
+    else
+        echo -e "  Config:    ${GRAY}(none — $CONFIG_FILE not found)${NC}"
+    fi
+    echo -e "  Socket:    ${CYAN}tmux -L $TMUX_SOCKET${NC}"
+    echo ""
+
+    if ! command -v tmux &>/dev/null; then
+        echo -e "${YELLOW}tmux is not installed — cannot inspect the agent pool.${NC}"
+        return 0
+    fi
+
+    # Collect running ids
+    if [[ -n "$running" ]]; then
+        while IFS= read -r session; do
+            [[ -z "$session" ]] && continue
+            running_ids+=("${session#loom-}")
+        done <<< "$running"
+    fi
+
+    # Read config terminals for cross-referencing
+    local terminals
+    terminals=$(read_terminals)
+    local terminal_count
+    terminal_count=$(echo "$terminals" | jq 'length' 2>/dev/null || echo 0)
+
+    # Running agents section
+    if [[ ${#running_ids[@]} -eq 0 ]]; then
+        echo -e "${YELLOW}No agents running.${NC}"
+    else
+        echo -e "${GREEN}Running agents (${#running_ids[@]}):${NC}"
+        echo ""
+        local session id name role pid
+        while IFS= read -r session; do
+            [[ -z "$session" ]] && continue
+            id="${session#loom-}"
+            pid=$(session_pid "$session")
+            name=""
+            role=""
+            if [[ "$terminal_count" -gt 0 ]]; then
+                name=$(echo "$terminals" | jq -r --arg id "$id" \
+                    '.[] | select(.id == $id) | (.name // .id)' 2>/dev/null | head -1)
+                role=$(echo "$terminals" | jq -r --arg id "$id" \
+                    '.[] | select(.id == $id) | (.roleConfig.roleFile // "")' 2>/dev/null | head -1)
+            fi
+            if [[ -n "$name" ]]; then
+                echo -e "  ${GREEN}●${NC} ${BOLD}$id${NC} ($name)"
+            else
+                echo -e "  ${GREEN}●${NC} ${BOLD}$id${NC} ${GRAY}(not in config — unmanaged)${NC}"
+            fi
+            echo -e "      session: ${CYAN}$session${NC}   pid: ${CYAN}${pid:-unknown}${NC}"
+            [[ -n "$role" ]] && echo -e "      role:    ${CYAN}$role${NC}"
+        done <<< "$running"
+    fi
+
+    # Configured-but-not-running section
+    if [[ "$terminal_count" -gt 0 ]]; then
+        local stopped
+        stopped=$(echo "$terminals" | jq -r \
+            --argjson running "$(printf '%s\n' "${running_ids[@]:-}" | jq -R . | jq -sc 'map(select(. != ""))')" \
+            '.[] | select(.id as $id | ($running | index($id)) | not)
+                | "\(.id)\t\((.name // .id))\t\((.roleConfig.roleFile // ""))"' 2>/dev/null || true)
+        if [[ -n "$stopped" ]]; then
+            echo ""
+            echo -e "${YELLOW}Configured but not running:${NC}"
+            echo ""
+            while IFS=$'\t' read -r sid sname srole; do
+                [[ -z "$sid" ]] && continue
+                echo -e "  ${GRAY}○${NC} ${BOLD}$sid${NC} ($sname)${srole:+   role: $srole}"
+            done <<< "$stopped"
+        fi
+    fi
+
+    echo ""
+}
+
+# Main
+main() {
+    local json=false
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --help|-h)
+                show_help
+                exit 0
+                ;;
+            --json)
+                json=true
+                shift
+                ;;
+            -*)
+                echo -e "${RED}Error: Unknown option '$1'${NC}" >&2
+                echo "Use 'loom status --help' for usage" >&2
+                exit 1
+                ;;
+            *)
+                echo -e "${RED}Error: Unexpected argument '$1'${NC}" >&2
+                exit 1
+                ;;
+        esac
+    done
+
+    if [[ "$json" == "true" ]]; then
+        emit_json
+    else
+        emit_human
+    fi
+    exit 0
+}
+
+main "$@"

--- a/defaults/scripts/start-daemon.sh
+++ b/defaults/scripts/start-daemon.sh
@@ -1,14 +1,50 @@
 #!/usr/bin/env bash
-# Thin wrapper — delegates to daemon.sh start.
-# Kept for backwards compatibility.
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Thin wrapper — delegates to the Loom CLI (.loom/bin/loom).
+# Kept for backwards compatibility with the legacy ./loom.sh entry point.
+#
+# The historical daemon.sh was removed in #3432; the working agent-pool
+# surface is `.loom/bin/loom start|status|stop` (tmux pool). This wrapper
+# maps the legacy flags onto those subcommands.
 
-# Map legacy flags to daemon.sh subcommands
+# Find the repository root by looking for the .loom directory (handles
+# worktrees and the symlinked defaults/scripts source layout).
+find_repo_root() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.loom" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        if [[ -f "$dir/.git" ]]; then
+            local gitdir
+            gitdir=$(sed 's/^gitdir: //' "$dir/.git")
+            local main_repo
+            main_repo=$(dirname "$(dirname "$(dirname "$gitdir")")")
+            if [[ -d "$main_repo/.loom" ]]; then
+                echo "$main_repo"
+                return 0
+            fi
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo ""
+}
+
+REPO_ROOT=$(find_repo_root)
+LOOM_BIN="$REPO_ROOT/.loom/bin/loom"
+
+if [[ -z "$REPO_ROOT" || ! -x "$LOOM_BIN" ]]; then
+    echo "Error: Loom CLI not found (expected at .loom/bin/loom)" >&2
+    echo "Is Loom installed in this repository?" >&2
+    exit 1
+fi
+
+# Map legacy flags to loom subcommands
 for arg in "$@"; do
     case "$arg" in
-        --status) exec "$SCRIPT_DIR/daemon.sh" status;;
-        --stop)   exec "$SCRIPT_DIR/daemon.sh" stop;;
+        --status) exec "$LOOM_BIN" status;;
+        --stop)   exec "$LOOM_BIN" stop;;
     esac
 done
 
-exec "$SCRIPT_DIR/daemon.sh" start "$@"
+exec "$LOOM_BIN" start "$@"

--- a/defaults/scripts/stop-daemon.sh
+++ b/defaults/scripts/stop-daemon.sh
@@ -1,5 +1,41 @@
 #!/usr/bin/env bash
-# Thin wrapper — delegates to daemon.sh stop.
-# Kept for backwards compatibility.
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec "$SCRIPT_DIR/daemon.sh" stop "$@"
+# Thin wrapper — delegates to the Loom CLI (.loom/bin/loom stop).
+# Kept for backwards compatibility with the legacy ./loom.sh entry point.
+#
+# The historical daemon.sh was removed in #3432; `.loom/bin/loom stop`
+# (tmux agent pool graceful shutdown) is the working replacement.
+
+# Find the repository root by looking for the .loom directory (handles
+# worktrees and the symlinked defaults/scripts source layout).
+find_repo_root() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.loom" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        if [[ -f "$dir/.git" ]]; then
+            local gitdir
+            gitdir=$(sed 's/^gitdir: //' "$dir/.git")
+            local main_repo
+            main_repo=$(dirname "$(dirname "$(dirname "$gitdir")")")
+            if [[ -d "$main_repo/.loom" ]]; then
+                echo "$main_repo"
+                return 0
+            fi
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo ""
+}
+
+REPO_ROOT=$(find_repo_root)
+LOOM_BIN="$REPO_ROOT/.loom/bin/loom"
+
+if [[ -z "$REPO_ROOT" || ! -x "$LOOM_BIN" ]]; then
+    echo "Error: Loom CLI not found (expected at .loom/bin/loom)" >&2
+    echo "Is Loom installed in this repository?" >&2
+    exit 1
+fi
+
+exec "$LOOM_BIN" stop "$@"

--- a/loom.sh
+++ b/loom.sh
@@ -3,31 +3,24 @@
 #
 # Usage:
 #   ./loom.sh               # Start in normal mode
-#   ./loom.sh --start       # Same as above (explicit start)
 #   ./loom.sh --merge       # Force/merge mode (auto-promote + auto-merge)
 #   ./loom.sh --status      # Check if daemon is running
 #   ./loom.sh --stop        # Send graceful shutdown signal
 #   ./loom.sh --help        # Show all options
 #
-# This script is a thin wrapper around .loom/scripts/daemon.sh.
+# This script is a thin wrapper around .loom/scripts/start-daemon.sh.
 # Run it from a terminal OUTSIDE Claude Code so that worker sessions
 # (builder, judge, etc.) are not spawned as Claude Code descendants.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-DAEMON_SH="$SCRIPT_DIR/.loom/scripts/daemon.sh"
+START_DAEMON="$SCRIPT_DIR/.loom/scripts/start-daemon.sh"
 
-if [[ ! -x "$DAEMON_SH" ]]; then
-    echo "Error: Loom daemon script not found at $DAEMON_SH" >&2
+if [[ ! -x "$START_DAEMON" ]]; then
+    echo "Error: Loom daemon script not found at $START_DAEMON" >&2
     echo "Is Loom installed in this repository?" >&2
     exit 1
 fi
 
-# --start is the default behavior; strip it before forwarding
-ARGS=()
-for arg in "$@"; do
-    [[ "$arg" == "--start" ]] || ARGS+=("$arg")
-done
-
-exec "$DAEMON_SH" "${ARGS[@]+"${ARGS[@]}"}"
+exec "$START_DAEMON" "$@"


### PR DESCRIPTION
Closes #3734

## Problem

After epic #3449 closed, the documented daemon start/stop/status surface was dead end-to-end on fresh v0.13.0 installs:

- `./.loom/scripts/daemon.sh start|stop` — `No such file or directory` (daemon.sh deleted in #3432, never restored)
- `./loom.sh` → `start-daemon.sh` → `exec daemon.sh` — same failure
- `.loom/bin/loom status` — `Error: loom-status.sh not found` (never shipped)
- `.loom/bin/loom start` worked but was undocumented

## Fix (minimal, focused bug fix)

- **Ship `defaults/scripts/cli/loom-status.sh`** (new, executable): lists running `loom-*` tmux sessions on the `loom` socket with id / name / role / pid, cross-references `.loom/config.json` `.terminals[]`, reports configured-but-stopped agents, supports `--help` and `--json`, exits 0 on an empty pool. Mirrors the `loom-start.sh` / `loom-stop.sh` structural conventions (repo-root discovery, `TMUX_SOCKET="loom"`, ANSI guard, `set -euo pipefail`).
- **Repoint `start-daemon.sh` / `stop-daemon.sh`** at `.loom/bin/loom start|stop` via repo-root discovery (needed because `.loom/scripts` is a symlink to `defaults/scripts`, so `$SCRIPT_DIR/../bin` doesn't resolve). Legacy `--status` / `--stop` flag mapping preserved. Kept as backwards-compat shims.
- **Drop the dead `.loom/scripts/loom-status.sh` fallback** in `.loom/bin/loom` and `loom-help.sh`'s `help status` dispatch; both now resolve `cli/loom-status.sh`.
- **Rewrite the `defaults/.loom/CLAUDE.md` "Daemon Mode" section** to document `.loom/bin/loom start|status|stop` as canonical and drop the broken `daemon.sh` commands.
- **Retire the #3451 stop-gap note** and the `daemon.sh stop` hint in `sweep.md` (#3449 is closed), plus the dead `daemon.sh` reference in `.claude/README.md`.
- **Sync the dogfood copies** (top-level `loom.sh`, `.loom/bin/loom`) that still carried the broken `daemon.sh` reference.

## defaults/ vs installed `.loom/` consistency

- `.loom/scripts` is a **symlink** to `defaults/scripts` in this repo, so the new `cli/loom-status.sh` and the repointed wrappers reach the installed tree automatically.
- `.loom/bin/loom` and `loom.sh` are tracked dogfood copies — updated in-place alongside their `defaults/` templates.
- `.claude/commands/loom/sweep.md` and `.claude/README.md` installed copies are gitignored and pick up the fix on the next `install-loom.sh` sync; only the `defaults/` templates are edited here.

## Verification

- `.loom/bin/loom status` — empty pool prints "No agents running" + configured-but-stopped list, exit 0; with live sessions, lists id/name/role/pid and flags unmanaged sessions; `--json` emits structured `running`/`stopped`/`unmanaged`.
- `.loom/bin/loom help status`, `./loom.sh --status`, `start-daemon.sh --status`, `stop-daemon.sh` all dispatch correctly (no more "not found" / "No such file or directory").
- `git grep -n 'daemon\.sh' -- defaults/` shows only historical/non-actionable mentions remain.
- `shellcheck` clean on the new + changed shell files.
- Automated tests: **N/A — no existing shell test harness for `cli/*.sh`** (checked `defaults/scripts/tests/`); manual verification covers empty pool, running pool, unmanaged sessions, JSON, help, and wrapper dispatch.

## Out of scope (left for #3735)

`loom status` UX redesign (`/lean status`-style), the `loom.sh` external-terminal warning, in-session daemon control, and the unrelated pip `loom_tools.status` state-file staleness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)