### PR TITLE
fix(tokens): spread ranked selection across top-N accounts (#3736)

### DIFF
--- a/loom-tools/src/loom_tools/tokens/select.py
+++ b/loom-tools/src/loom_tools/tokens/select.py
@@ -1,8 +1,11 @@
 """Token selection algorithm — 3-tier priority.
 
 Selection order:
-    1. Ranking file (.ranking, <10 min old): pick first non-exhausted
-       account, skipping bad tokens.
+    1. Ranking file (.ranking, <10 min old): pick randomly among the top-N
+       non-exhausted/non-blocked accounts (default N=3, configurable via
+       ``LOOM_TOKEN_SPREAD_TOP_N`` / ``tokens.spreadTopN``; N=1 = greedy
+       first-eligible), skipping bad tokens. Spreading across the top-N
+       avoids concurrent spawners colliding on .ranking[0] (issue #3736).
     2. Allowlist file (.allowlist): random pick from allowed accounts.
     3. Random pick from all .token files.
 
@@ -30,6 +33,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
+from loom_tools.common.config import env_int
 from loom_tools.tokens.bad_tokens import is_bad
 
 # Ranking file is considered fresh for this many seconds.
@@ -37,6 +41,12 @@ _RANKING_FRESH_SECONDS = 600  # 10 min
 
 # Exit code when no token is available (matches sysexits.h EX_CONFIG)
 EX_CONFIG = 78
+
+# Default number of top-ranked eligible accounts to spread spawns across.
+# See issue #3736: picking only .ranking[0] deterministically collides
+# concurrent spawners (e.g. sibling daemons on a shared claude-monitor pool)
+# onto the single least-utilized account, tripping its session limit.
+_DEFAULT_SPREAD_TOP_N = 3
 
 
 class TokenSelectionError(Exception):
@@ -115,16 +125,82 @@ def _read_allowlist(allowlist_file: Path) -> list[str]:
     return out
 
 
+def _resolve_spread_top_n(workspace_path: Path) -> int:
+    """Resolve the top-N spread window for the ranked strategy.
+
+    Precedence (highest first), mirroring the nested-key + env-override
+    precedent in ``common/paths.py`` and ``common/gitea.py``:
+
+        1. ``LOOM_TOKEN_SPREAD_TOP_N`` env var.
+        2. ``.loom/config.json`` -> ``tokens.spreadTopN`` (soft-fail read).
+        3. Default (``_DEFAULT_SPREAD_TOP_N`` = 3).
+
+    Values are clamped to ``>= 1``. ``N == 1`` restores the historical greedy
+    first-eligible behavior exactly (back-compat escape hatch).
+    """
+    # 1. Env var override (highest precedence).
+    if os.environ.get("LOOM_TOKEN_SPREAD_TOP_N") is not None:
+        return max(1, env_int("LOOM_TOKEN_SPREAD_TOP_N", default=_DEFAULT_SPREAD_TOP_N))
+
+    # 2. Config key — .loom/config.json -> tokens.spreadTopN (soft-fail read).
+    config_n = _read_config_spread_top_n(workspace_path)
+    if config_n is not None:
+        return max(1, config_n)
+
+    # 3. Default.
+    return _DEFAULT_SPREAD_TOP_N
+
+
+def _read_config_spread_top_n(workspace_path: Path) -> int | None:
+    """Read ``.loom/config.json`` -> ``tokens.spreadTopN``, soft-failing to ``None``.
+
+    Missing file, parse error, missing key, or a non-int value all resolve to
+    ``None`` (never a hard error), mirroring the soft-fail config reads in
+    ``common/paths.py``.
+    """
+    # Imported lazily to keep this module import-safe (no I/O / heavy deps at
+    # import time — see module docstring).
+    from loom_tools.common.state import read_json_file
+
+    config_path = workspace_path / ".loom" / "config.json"
+    data = read_json_file(config_path, default={})
+    if not isinstance(data, dict):
+        return None
+    tokens_cfg = data.get("tokens")
+    if not isinstance(tokens_cfg, dict):
+        return None
+    value = tokens_cfg.get("spreadTopN")
+    # Reject bool (a subclass of int) and non-int values.
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value
+
+
 def _try_ranking(
     tokens_dir: Path,
     ranking_file: Path,
     workspace_path: Path,
     rng: random.Random,
 ) -> SelectedToken | None:
-    """Strategy 1: read .ranking, return first non-exhausted/non-blocked entry."""
+    """Strategy 1: read .ranking, pick randomly among the top-N eligible entries.
+
+    Historically this returned the *first* non-exhausted/non-blocked entry.
+    Because ``.ranking`` is ordered most-available-first, every concurrent
+    spawner reading a fresh ranking picked the identical account, serializing
+    load onto one account and tripping its session limit (issue #3736).
+
+    We now collect up to the top-N eligible ranked entries (skipping
+    exhausted/blocked/bad/missing/empty tokens, preserving ranking order) and
+    ``rng.choice`` among them, spreading concurrent spawners across the most
+    available accounts while still preferring healthy ones. N is resolved via
+    ``_resolve_spread_top_n``; ``N == 1`` restores the old greedy behavior.
+    """
     age = _file_age_seconds(ranking_file)
     if age is None or age >= _RANKING_FRESH_SECONDS:
         return None
+
+    top_n = _resolve_spread_top_n(workspace_path)
+    eligible: list[SelectedToken] = []
     for name, status in _read_ranking(ranking_file):
         if status in ("exhausted", "blocked"):
             continue
@@ -139,8 +215,15 @@ def _try_ranking(
             continue
         if not key:
             continue
-        return SelectedToken(name=name, file=token_file, key=key, mode="ranked")
-    return None
+        eligible.append(
+            SelectedToken(name=name, file=token_file, key=key, mode="ranked"),
+        )
+        if len(eligible) >= top_n:
+            break
+
+    if not eligible:
+        return None
+    return rng.choice(eligible)
 
 
 def _try_allowlist(

--- a/loom-tools/tests/tokens/test_select.py
+++ b/loom-tools/tests/tokens/test_select.py
@@ -180,11 +180,14 @@ def test_allowlist_with_no_existing_tokens_falls_through_to_random(tmp_path):
 # ---------- ranking tier ----------
 
 
-def test_ranking_picks_first_unblocked(tmp_path):
+def test_ranking_picks_among_top_n_eligible(tmp_path):
+    # Default N=3 spreads across eligible ranked entries (a is exhausted, so
+    # b and c are the top-2 eligible). See issue #3736.
     workspace = _make_workspace(tmp_path, {"a": "ka", "b": "kb", "c": "kc"})
     _write_ranking(workspace, ["a|exhausted", "b|", "c|"])
-    sel = select_token(workspace)
-    assert sel.name == "b"
+    sel = select_token(workspace, rng=random.Random(0))
+    assert sel.name in ("b", "c")
+    assert sel.name != "a"  # never the exhausted account
     assert sel.mode == "ranked"
 
 
@@ -233,6 +236,104 @@ def test_ranking_falls_through_when_all_exhausted(tmp_path):
     # Falls through past tier 1 (all exhausted), past tier 2 (no allowlist),
     # to tier 3 (random).
     assert sel.mode == "random"
+
+
+# ---------- ranking spread (issue #3736) ----------
+
+
+def test_ranking_spreads_across_top_n_with_varying_seeds(tmp_path, monkeypatch):
+    """Varying rng seeds must select different accounts among the top-N.
+
+    This is the anti-collision property: concurrent spawners (each with an
+    independent rng) should NOT deterministically land on .ranking[0].
+    """
+    monkeypatch.delenv("LOOM_TOKEN_SPREAD_TOP_N", raising=False)
+    workspace = _make_workspace(
+        tmp_path, {"a": "ka", "b": "kb", "c": "kc", "d": "kd", "e": "ke"},
+    )
+    # All available; ranking order a,b,c,d,e. Default N=3 => window {a,b,c}.
+    _write_ranking(workspace, ["a|", "b|", "c|", "d|", "e|"])
+    top_n = {"a", "b", "c"}
+    chosen: set[str] = set()
+    for seed in range(50):
+        sel = select_token(workspace, rng=random.Random(seed))
+        assert sel.mode == "ranked"
+        assert sel.name in top_n  # never spills past the top-N window
+        chosen.add(sel.name)
+    # More than one distinct account is selected across seeds (spread), and
+    # entries below the window (d, e) are never chosen.
+    assert len(chosen) > 1
+    assert chosen <= top_n
+
+
+def test_ranking_n1_restores_greedy_first_eligible(tmp_path, monkeypatch):
+    """N=1 (env override) exactly restores the historical greedy behavior."""
+    monkeypatch.setenv("LOOM_TOKEN_SPREAD_TOP_N", "1")
+    workspace = _make_workspace(tmp_path, {"a": "ka", "b": "kb", "c": "kc"})
+    _write_ranking(workspace, ["a|exhausted", "b|", "c|"])
+    # First eligible entry is b — deterministic regardless of seed.
+    for seed in range(25):
+        sel = select_token(workspace, rng=random.Random(seed))
+        assert sel.name == "b"
+        assert sel.mode == "ranked"
+
+
+def test_ranking_spread_config_key(tmp_path, monkeypatch):
+    """.loom/config.json -> tokens.spreadTopN is honored when env is unset."""
+    monkeypatch.delenv("LOOM_TOKEN_SPREAD_TOP_N", raising=False)
+    workspace = _make_workspace(tmp_path, {"a": "ka", "b": "kb", "c": "kc"})
+    _write_ranking(workspace, ["a|", "b|", "c|"])
+    config_path = workspace / ".loom" / "config.json"
+    config_path.write_text(json.dumps({"tokens": {"spreadTopN": 1}}), encoding="utf-8")
+    # spreadTopN=1 => greedy first eligible (a), deterministic across seeds.
+    for seed in range(10):
+        sel = select_token(workspace, rng=random.Random(seed))
+        assert sel.name == "a"
+
+    # env var overrides the config key.
+    monkeypatch.setenv("LOOM_TOKEN_SPREAD_TOP_N", "3")
+    chosen = {
+        select_token(workspace, rng=random.Random(seed)).name for seed in range(50)
+    }
+    assert len(chosen) > 1
+
+
+def test_ranking_spread_skips_interleaved_exhausted_blocked(tmp_path, monkeypatch):
+    """Exhausted/blocked entries interleaved in the ranking are never chosen.
+
+    The top-N window is filled from the *eligible* entries only, preserving
+    ranking order and skipping exhausted/blocked/bad tokens.
+    """
+    monkeypatch.delenv("LOOM_TOKEN_SPREAD_TOP_N", raising=False)
+    workspace = _make_workspace(
+        tmp_path,
+        {"a": "ka", "b": "kb", "c": "kc", "d": "kd", "e": "ke"},
+    )
+    # Interleaved: a exhausted, b ok, c blocked, d ok, e ok.
+    # Eligible order: b, d, e. Default N=3 => window {b, d, e}.
+    _write_ranking(workspace, ["a|exhausted", "b|", "c|blocked", "d|", "e|"])
+    window = {"b", "d", "e"}
+    chosen: set[str] = set()
+    for seed in range(50):
+        sel = select_token(workspace, rng=random.Random(seed))
+        assert sel.mode == "ranked"
+        assert sel.name in window
+        assert sel.name not in ("a", "c")  # never exhausted/blocked
+        chosen.add(sel.name)
+    assert len(chosen) > 1
+
+
+def test_ranking_spread_skips_bad_in_window(tmp_path, monkeypatch):
+    """A bad token is excluded from the top-N window entirely."""
+    monkeypatch.delenv("LOOM_TOKEN_SPREAD_TOP_N", raising=False)
+    workspace = _make_workspace(tmp_path, {"a": "ka", "b": "kb", "c": "kc"})
+    _write_ranking(workspace, ["a|", "b|", "c|"])
+    bad_file = workspace / ".loom" / "tokens" / ".bad_tokens"
+    bad_file.write_text("2026-01-01T00:00:00Z a expired\n", encoding="utf-8")
+    for seed in range(25):
+        sel = select_token(workspace, rng=random.Random(seed))
+        assert sel.name in ("b", "c")
+        assert sel.name != "a"
 
 
 # ---------- CLI ----------


### PR DESCRIPTION
Closes #3736

## Problem
`_try_ranking` (Strategy 1, the common path) returned `.ranking[0]` — the single least-utilized account — deterministically. Since `.ranking` is ordered most-available-first, every concurrent spawner reading a fresh ranking picked the identical account. Two daemons on a shared claude-monitor pool (Loom + lean-genius) both slammed one account to its session limit while other accounts sat idle; all workers died within ~90s.

Strategies 2 (allowlist) and 3 (random) already randomize — only the ranked path was greedy.

## Fix
Collect up to the top-N eligible ranked entries (skipping exhausted/blocked/bad/missing/empty tokens, preserving ranking order) and `rng.choice` among them. This spreads concurrent spawners across the most-available accounts while still preferring healthy ones.

N resolves highest-precedence first (reusing the `env_int` + nested-config precedent from `common/paths.py`/`common/config.py`):
1. `LOOM_TOKEN_SPREAD_TOP_N` env var
2. `.loom/config.json` -> `tokens.spreadTopN` (soft-fail read; bool/non-int rejected)
3. default `3`

`N=1` exactly restores today's greedy first-eligible behavior (back-compat escape hatch). Values clamp to `>= 1`. Exhausted/blocked/bad-token skipping is unchanged.

## Tests
`loom-tools/tests/tokens/test_select.py`:
- `test_ranking_spreads_across_top_n_with_varying_seeds` — varying rng seeds select >1 distinct account, never spilling past the top-N window
- `test_ranking_n1_restores_greedy_first_eligible` — N=1 deterministic across seeds
- `test_ranking_spread_config_key` — `tokens.spreadTopN` honored; env overrides config
- `test_ranking_spread_skips_interleaved_exhausted_blocked` — interleaved exhausted/blocked never chosen; window filled from eligible only
- `test_ranking_spread_skips_bad_in_window` — bad token excluded from window
- updated `test_ranking_picks_among_top_n_eligible` (was `_picks_first_unblocked`)

`PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/tokens/ -v` → 236 passed. `ruff check` clean.

## Out of scope
The sibling lean-genius fix (filed separately), any Rust-daemon duplicate logic, and #3738 (file-disjoint shell wrapper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)