### PR TITLE
feat(daemon): stacked-PR mode v1 — --depends-on dispatch param (#3729)

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -136,6 +136,16 @@ Inputs:
   `spawn-claude.sh` argv. When omitted (or empty), NO `--model` flag is
   emitted and the child inherits the session/CLI default. The field is
   `#[serde(default)]` on the wire, so pre-#3477 clients remain compatible.
+- `depends_on` (optional, issue #3729 stacked-PR v1) — a **single** parent
+  issue number this sweep is stacked on. Forwarded to the child as
+  `--depends-on <N>` (mirroring the `--model`/`--effort` append-only,
+  empty-means-unset contract), instructing `/loom:sweep` to branch the child
+  worktree/PR off `feature/issue-<N>` instead of the default branch. When
+  omitted, NO `--depends-on` flag is emitted (byte-for-byte unchanged). A
+  single optional parent (not a list) makes diamonds / multi-parent stacks
+  structurally unrepresentable — see "Stacked-PR dependency (v1)" below. The
+  field is `#[serde(default)]` on the wire, so pre-#3729 clients remain
+  compatible.
 
 ### `list_sweeps` (Phase A)
 
@@ -251,6 +261,45 @@ The reaper (`sweep_registry::spawn_reaper_task`) ticks every 30 seconds
      a global `sweep.global.completed` event.
 4. Garbage-collects terminal entries older than the retention window
    (default 1 hour).
+
+## Stacked-PR dependency (v1) — #3729
+
+Stacked-PR mode pipelines a genuine dependency: when issue B consumes issue
+A's output, B is built on `feature/issue-A` so B's Curator→Builder→Judge runs
+concurrently with A's review instead of serializing behind A's merge. **v1 is
+opt-in, daemon-`dispatch_sweep`-only, and linear-chains-only.**
+
+**Dispatch a chain** — N independent `dispatch_sweep` calls, each naming its
+immediate predecessor via `depends_on` (there is no multi-node planner):
+
+```text
+dispatch_sweep  kind={"Issue": A}                    # parent (independent)
+dispatch_sweep  kind={"Issue": B}  depends_on=A      # child stacked on A
+dispatch_sweep  kind={"Issue": C}  depends_on=B      # A→B→C linear chain
+```
+
+The daemon forwards `depends_on` to the child as `--depends-on <parent>`; the
+child's Builder branches its worktree off `feature/issue-<parent>` (via
+`worktree.sh --base`) and opens its PR with `--base feature/issue-<parent>`.
+`depends_on` is `Option<u32>` — a **single** optional parent — so diamonds /
+multi-parent stacks are structurally unrepresentable (no runtime rejection
+needed). It is recorded on the `SweepInfo` entry for observability.
+
+**Block-the-subtree on parent failure (reaper).** When a parent sweep reaches
+a terminal state and its issue carries `loom:blocked`, the reaper emits
+`sweep.issue.{child}.blocker` on the existing frozen topic (#3453 — no new
+topic) for every live child whose `depends_on` names that parent, so the stuck
+stack surfaces to the operator and the child does not auto-progress. This is
+implemented via `SweepRegistry::children_of` + `block_children_of`. Auto-detach
+(rebasing an orphaned child onto the default branch) is **out of scope for v1**.
+
+**Reconciliation is a manual, scripted step (v1).** Because the repo
+squash-merges, after the parent squash-merges the child branch still carries
+the parent's pre-squash commits. After confirming the parent merged, the
+operator runs `./.loom/scripts/reconcile-stack.sh <child-pr> feature/issue-<parent>`
+(`git rebase --onto <default> <parent-branch> <child-branch>` +
+`--force-with-lease` + `gh pr edit --base <default>`). `merge-pr.sh` is **not**
+modified in v1 — no automatic reconciliation and no merge-ordering guard.
 
 ## Locks and lifecycle
 

--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -120,10 +120,11 @@ Combine flags as needed. Always pass `--state open` explicitly (Mode C operates 
 - **`--dry-run`** — print the planned candidate list (with wave grouping) and EXIT without performing any mutation. Recognized as a bare flag token (no value). May appear anywhere in `$ARGUMENTS`. Default is off. Honoured in **all three** modes — stripped before classification along with other flags. Mode C dry-run prints the PR-set plan (per-PR routing) instead of the issue-set plan.
 - **`--prs`** — switch into Mode C (PR-set mode). Recognized as a bare flag token (no value). May appear anywhere in `$ARGUMENTS`. Default is off. When present, non-flag tokens are interpreted as **PR numbers** (numeric tokens) or as a **PR-list description** (NL tokens). When absent, an NL trigger phrase listed in the Mode C section can still select Mode C. See "Mode C" above for full semantics.
 - **`--no-daemon`** — force in-process subagent dispatch even when the daemon is running with a multi-account token pool. Recognized as a bare flag token (no value). May appear anywhere in `$ARGUMENTS`. Default is off. When present, **Stage -1 (Backend detection) skips the `PROBE_DAEMON` step entirely** and the skill always falls through to the existing Mode A/B/C subagent dispatch path. Honoured in **all three** modes — stripped before classification along with other flags. Use this when you want the predictable single-process behaviour even though daemon dispatch is available (e.g., debugging, demoing the subagent path, or running under a token configuration that you don't want shared with daemon-spawned sweeps). See "Stage -1: Backend detection" below.
+- **`--depends-on <parent>`** — stacked-PR mode (issue #3729, v1). Declares that this sweep's issue is stacked on the single parent issue `<parent>`: the Builder branches its worktree off `feature/issue-<parent>` (not the default branch) and opens its PR with `--base feature/issue-<parent>`, so the child's Curator→Builder→Judge can run **concurrently** with the parent's review. Takes **one value** (a positive integer parent issue number) — this is the sole, authoritative dependency source (no `Depends on #A` body parsing in v1). A single optional parent makes diamonds / multi-parent stacks unrepresentable. Recognized anywhere in `$ARGUMENTS` as `--depends-on N`; strip it (and its value) before classification and store `DEPENDS_ON=N`. Default **unset** — absent the flag, behavior is byte-for-byte unchanged (branches off the default branch as always). Intended for **daemon `dispatch_sweep`-only** use (`mcp__loom__dispatch_sweep` with `depends_on`); the wave lifecycle does **not** auto-detect or auto-create stacks. See "Stacked dependency (v1, manual reconciliation)" below. **Reconciliation after the parent squash-merges is a manual, scripted step** (`./.loom/scripts/reconcile-stack.sh`) — `merge-pr.sh` is not modified in v1.
 
 ### Validation rules
 
-- Recognize `--dry-run`, `--prs`, `--no-daemon`, and `--builders-per-wave N` as flag tokens anywhere in `$ARGUMENTS`, strip them from the candidate list before validation, and store them as flags / parameters (`DRY_RUN=true|false`, `PRS_MODE=true|false`, `NO_DAEMON=true|false`, `BUILDERS_PER_WAVE=N`). When `--builders-per-wave` is **absent**, set the sentinel `BUILDERS_PER_WAVE=auto` (not `1`) — Stage -1 resolves the concrete wave size from the backend + disk headroom. An explicit integer is stored verbatim and overrides auto.
+- Recognize `--dry-run`, `--prs`, `--no-daemon`, `--builders-per-wave N`, and `--depends-on N` as flag tokens anywhere in `$ARGUMENTS`, strip them from the candidate list before validation, and store them as flags / parameters (`DRY_RUN=true|false`, `PRS_MODE=true|false`, `NO_DAEMON=true|false`, `BUILDERS_PER_WAVE=N`, `DEPENDS_ON=N|unset`). When `--builders-per-wave` is **absent**, set the sentinel `BUILDERS_PER_WAVE=auto` (not `1`) — Stage -1 resolves the concrete wave size from the backend + disk headroom. An explicit integer is stored verbatim and overrides auto. `--depends-on N` consumes its following token as the parent issue number (a positive integer); reject a missing/non-numeric value with `Error: --depends-on requires a positive integer parent issue number` and EXIT. When absent, `DEPENDS_ON` is unset (no base override — default-branch behavior).
 - At least one candidate (numeric token or NL description) must be supplied. If `$ARGUMENTS` (after stripping flag tokens) is empty, display:
   ```
   Usage: /sweep <issue-number> [<issue-number> ...] [--builders-per-wave N] [--dry-run] [--no-daemon]
@@ -1229,6 +1230,11 @@ Each builder is responsible for:
 - Pushing the branch and opening a PR labeled `loom:review-requested`.
 - Closing references: `Closes #N` in the PR body.
 
+**Stacked-dependency gated path (`--depends-on`, #3729 v1).** This gate fires **only** when `DEPENDS_ON` is set (from `--depends-on <parent>`); when it is unset the two steps below are byte-for-byte the default behavior. When `DEPENDS_ON=<parent>` is set, the builder for the sweep's issue must:
+  - Create its worktree branched off the parent's branch: `./.loom/scripts/worktree.sh N --base feature/issue-<parent>` (instead of the bare `./.loom/scripts/worktree.sh N`). `worktree.sh` resolves `feature/issue-<parent>` from `origin/feature/issue-<parent>` (or a local branch), so the parent sweep must have created/pushed its branch first; if the base cannot be resolved, `worktree.sh` hard-fails rather than silently branching off the default branch.
+  - Open its PR against the parent branch: `gh pr create --base feature/issue-<parent> --label "loom:review-requested" --body "Closes #N ..."` (instead of the default base). The PR remains stacked on the parent until the operator reconciles it (see "Stacked dependency (v1, manual reconciliation)").
+  This is a single-issue, daemon-`dispatch_sweep`-only path (the daemon forwards `depends_on` as `--depends-on`). The wave lifecycle does not auto-create stacks — only an explicitly `--depends-on`-flagged invocation stacks.
+
 **Await all builders in the wave** before proceeding to Judge. Collect each builder's PR number (or failure marker).
 
 **Backstop: verify the main worktree is clean after the builders return (#3513).** A builder subagent runs without `LOOM_WORKTREE_PATH` injected, so the `guard-worktree-paths.sh` hook does not fire on this path. If a builder used repo-relative paths after a cwd reset, it may have written to the **main** worktree instead of its issue worktree. After the wave's builders return and before advancing any PR to Judge, run:
@@ -1252,6 +1258,36 @@ If the builder failed (no PR opened), do NOT write a checkpoint — leave the ch
 **Per-builder failure isolation.** If builder for issue `#A` fails to open a PR (build error, test failure, unrecoverable conflict, etc.), log it and **continue** with the other builders' PRs in this wave. The failed issue is recorded as `blocked (builder failed)` in the summary. Do NOT abort the wave. Do NOT skip Judge for the other PRs.
 
 **Mid-builder kill semantics (#3373).** If sweep is killed during the Builder phase, the next invocation will see `CHECKPOINT_PHASE == "curator-done"` (no `builder-done` was written), so the Builder dispatches again from scratch. The worktree from the killed run is preserved by `worktree.sh`'s idempotency — `./.loom/scripts/worktree.sh N` is a no-op if `.loom/worktrees/issue-N` already exists. The builder re-enters the worktree, sees the partial diff, and decides whether to commit / amend / discard. **Sweep itself does not introspect the partial diff** — that's the builder's job.
+
+### Stacked dependency (v1, manual reconciliation) — #3729
+
+Stacked-PR mode pipelines a genuine dependency: when issue B consumes issue A's output (schema, file, manifest), B is built on `feature/issue-A` so B's lifecycle runs concurrently with A's review instead of serializing behind A's merge. **v1 is opt-in, daemon-`dispatch_sweep`-only, and linear-chains-only.**
+
+**How to dispatch a chain.** A chain is N independent `dispatch_sweep` calls, each naming its immediate predecessor — there is no multi-node planner:
+
+```text
+# Parent A (independent):
+mcp__loom__dispatch_sweep  kind={"Issue": A}
+# Child B stacked on A:
+mcp__loom__dispatch_sweep  kind={"Issue": B}  depends_on=A
+# Grandchild C stacked on B (A→B→C works because each hop names only its parent):
+mcp__loom__dispatch_sweep  kind={"Issue": C}  depends_on=B
+```
+
+The daemon forwards `depends_on` to the child as `--depends-on <parent>`; the child's Builder branches off `feature/issue-<parent>` and opens its PR with `--base feature/issue-<parent>` (see the gated path in the Builder phase above). A single optional parent makes diamonds / multi-parent stacks **unrepresentable** — there is no rejection logic because the type itself forbids them.
+
+**Block-the-subtree on parent failure (daemon-side, #3729 item 4).** If the parent sweep ends in `loom:blocked` (Doctor-cycle budget exhausted, or an operator cancel), the daemon's reaper does **not** let a child whose `depends_on` names that parent auto-progress: it publishes `sweep.issue.{child}.blocker` on the existing frozen topic (no new topic) so the stuck stack surfaces to the operator. Auto-detach (rebasing an orphaned child onto the default branch) is **not** implemented in v1 — block-the-subtree is the only cascade behavior.
+
+**Reconciliation is a manual, scripted step (v1).** The repo squash-merges, so after the parent squash-merges to the default branch as one commit, the child branch still carries the parent's original pre-squash commits. **After confirming the parent has squash-merged**, the operator runs:
+
+```bash
+./.loom/scripts/reconcile-stack.sh <child-pr> feature/issue-<parent>
+# = git rebase --onto <default-branch> feature/issue-<parent> <child-branch>
+#   git push --force-with-lease
+#   gh pr edit <child-pr> --base <default-branch>
+```
+
+This replays only the child's own commits onto the default branch (stripping the parent's now-squashed commits) and retargets the PR base. `merge-pr.sh` is **not** modified in v1: there is no automatic reconciliation and no merge-ordering guard — the operator is responsible for not merging a parent while an un-reconciled child PR still points at its branch. **Known v1 limitation:** if the parent branch is amended by Doctor after a child branched off it, the child is not auto-rebased — rebase it manually if needed.
 
 ### 5. Judge phase (sequential per PR within the wave)
 

--- a/defaults/scripts/reconcile-stack.sh
+++ b/defaults/scripts/reconcile-stack.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Loom Stacked-PR Reconciliation (issue #3729, stacked-PR v1)
+#
+# Turns the manual git surgery an operator performs after a stacked parent PR
+# squash-merges into one command. This is the v1 manual-but-scripted
+# reconciliation step: merge-pr.sh is intentionally NOT modified in v1, and no
+# automatic merge-ordering guard is added. The operator runs this by hand AFTER
+# confirming the parent branch has squash-merged to the default branch.
+#
+# Usage:
+#   ./.loom/scripts/reconcile-stack.sh <child-pr> <parent-branch> [options]
+#
+# Example (the live #3725-on-#3726 incident, PR #3727):
+#   ./.loom/scripts/reconcile-stack.sh 3727 feature/issue-3726
+#
+# What it does (equivalent to the three-command manual workaround):
+#   git rebase --onto <default-branch> <parent-branch> <child-branch>
+#   git push --force-with-lease
+#   gh pr edit <child-pr> --base <default-branch>
+#
+# The repo squash-merges (setup-repository-settings.sh: squash only), so after
+# the parent squash-merges to the default branch as ONE commit, the child
+# branch still carries the parent's ORIGINAL pre-squash commits. A naive base
+# retarget (child base -> default) then re-shows the parent's entire diff. The
+# `git rebase --onto` replays ONLY the child's own commits onto the default
+# branch, stripping the parent's now-squashed commits, before retargeting.
+#
+# Safety:
+#   - Uses --force-with-lease (NEVER a bare --force) so a concurrent push to the
+#     child branch aborts the rebase rather than clobbering it.
+#   - --dry-run prints every command without executing.
+#   - Refuses to run with a dirty working tree (a rebase would fail confusingly).
+#
+# Options:
+#   --dry-run   Print the commands that would run without executing them.
+#   --help,-h   Show this help.
+#
+# Exit codes:
+#   0 = reconciled (or dry-run printed)
+#   1 = usage / precondition failure
+#   2 = a git/gh step failed (rebase conflict, push rejected, retarget failed)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Colors (skip when not a TTY).
+if [[ -t 2 ]]; then
+    RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+else
+    RED=''; GREEN=''; YELLOW=''; BLUE=''; NC=''
+fi
+err()  { echo -e "${RED}ERROR: $1${NC}" >&2; }
+ok()   { echo -e "${GREEN}✓ $1${NC}" >&2; }
+info() { echo -e "${BLUE}ℹ $1${NC}" >&2; }
+warn() { echo -e "${YELLOW}⚠ $1${NC}" >&2; }
+
+show_help() {
+    sed -n '2,45p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+DRY_RUN=false
+CHILD_PR=""
+PARENT_BRANCH=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run) DRY_RUN=true; shift ;;
+        --help|-h) show_help; exit 0 ;;
+        --*) err "Unknown flag: $1"; exit 1 ;;
+        *)
+            if [[ -z "$CHILD_PR" ]]; then
+                CHILD_PR="$1"
+            elif [[ -z "$PARENT_BRANCH" ]]; then
+                PARENT_BRANCH="$1"
+            else
+                err "Unexpected argument: $1"; exit 1
+            fi
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$CHILD_PR" || -z "$PARENT_BRANCH" ]]; then
+    err "Usage: reconcile-stack.sh <child-pr> <parent-branch> [--dry-run]"
+    echo "  Example: reconcile-stack.sh 3727 feature/issue-3726" >&2
+    exit 1
+fi
+
+if ! [[ "$CHILD_PR" =~ ^[0-9]+$ ]]; then
+    err "Child PR must be numeric (got: '$CHILD_PR')"
+    exit 1
+fi
+
+# Resolve the repo's default branch (the rebase --onto target) offline, honoring
+# a LOOM_DEFAULT_BRANCH override. Same resolver worktree.sh uses.
+DEFAULT_BRANCH="main"
+if [[ -f "$SCRIPT_DIR/lib/default-branch.sh" ]]; then
+    # shellcheck source=lib/default-branch.sh
+    source "$SCRIPT_DIR/lib/default-branch.sh"
+    if resolved="$(loom_default_branch 2>/dev/null)" && [[ -n "$resolved" ]]; then
+        DEFAULT_BRANCH="$resolved"
+    fi
+fi
+
+# Discover the child branch from the PR (GitHub via gh).
+if ! command -v gh >/dev/null 2>&1; then
+    err "gh CLI not found — required to resolve the child PR's head branch and retarget its base."
+    exit 1
+fi
+
+info "Resolving head branch for child PR #$CHILD_PR..."
+CHILD_BRANCH="$(gh pr view "$CHILD_PR" --json headRefName --jq '.headRefName' 2>/dev/null || true)"
+if [[ -z "$CHILD_BRANCH" ]]; then
+    err "Could not resolve the head branch for PR #$CHILD_PR (is the number correct and the PR open?)."
+    exit 1
+fi
+info "Child branch: $CHILD_BRANCH"
+info "Parent branch: $PARENT_BRANCH"
+info "Rebase target (default branch): $DEFAULT_BRANCH"
+
+# Best-effort advisory: has the parent branch squash-merged? If origin still has
+# the parent branch, the operator likely hasn't merged it yet — warn but do not
+# block (the operator asserts they've confirmed the merge).
+git fetch origin "$DEFAULT_BRANCH" 2>/dev/null || true
+if git show-ref --verify --quiet "refs/remotes/origin/$PARENT_BRANCH" 2>/dev/null; then
+    warn "origin/$PARENT_BRANCH still exists — confirm the parent PR has squash-merged before reconciling."
+    warn "(delete-branch-on-merge normally removes it once the parent merges.)"
+fi
+
+# Refuse on a dirty working tree — a rebase would fail confusingly.
+if [[ -n "$(git status --porcelain 2>/dev/null)" ]]; then
+    err "Working tree is dirty. Commit, stash, or discard changes before reconciling."
+    exit 1
+fi
+
+run() {
+    echo -e "${YELLOW}\$ $*${NC}" >&2
+    if [[ "$DRY_RUN" == "true" ]]; then
+        return 0
+    fi
+    "$@"
+}
+
+# 1. Replay ONLY the child's own commits onto the default branch, stripping the
+#    parent's now-squashed pre-merge commits.
+info "Step 1/3: rebase --onto $DEFAULT_BRANCH $PARENT_BRANCH $CHILD_BRANCH"
+if ! run git rebase --onto "$DEFAULT_BRANCH" "$PARENT_BRANCH" "$CHILD_BRANCH"; then
+    err "Rebase failed (likely a conflict). Resolve it, then re-run this script or finish manually:"
+    echo "    git rebase --continue   # after resolving" >&2
+    echo "    git push --force-with-lease" >&2
+    echo "    gh pr edit $CHILD_PR --base $DEFAULT_BRANCH" >&2
+    exit 2
+fi
+
+# 2. Publish the rewritten child branch. --force-with-lease (never bare --force)
+#    so a concurrent push aborts rather than clobbers.
+info "Step 2/3: push --force-with-lease"
+if ! run git push --force-with-lease; then
+    err "Force-with-lease push was rejected (someone else pushed to $CHILD_BRANCH). Fetch, review, and retry."
+    exit 2
+fi
+
+# 3. Retarget the child PR's base to the default branch.
+info "Step 3/3: gh pr edit $CHILD_PR --base $DEFAULT_BRANCH"
+if ! run gh pr edit "$CHILD_PR" --base "$DEFAULT_BRANCH"; then
+    err "Failed to retarget PR #$CHILD_PR base to $DEFAULT_BRANCH. Retarget it manually."
+    exit 2
+fi
+
+if [[ "$DRY_RUN" == "true" ]]; then
+    ok "Dry run complete — no changes made. Re-run without --dry-run to reconcile."
+else
+    ok "Reconciled: PR #$CHILD_PR now stacks only its own commits on $DEFAULT_BRANCH."
+fi

--- a/defaults/scripts/tests/test-worktree-base-override.sh
+++ b/defaults/scripts/tests/test-worktree-base-override.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# test-worktree-base-override.sh — Tests for --base branch override (#3729)
+#
+# Verifies the stacked-PR v1 base-branch override in defaults/scripts/worktree.sh:
+# `worktree.sh N --base feature/issue-<parent>` branches the new worktree off
+# the named parent branch instead of origin/<default>, so a child sweep stacks
+# on its parent. Used by /loom:sweep --depends-on (which the daemon threads from
+# dispatch_sweep's depends_on param).
+#
+# Coverage:
+#   1. Default (no --base): new branch is created from origin/main, unchanged.
+#   2. --base override: the child worktree's branch descends from the parent
+#      branch (contains the parent's unique commit) and NOT from a diverged main.
+#   3. --base with a nonexistent branch: hard-fails (does not silently branch
+#      off main).
+#   4. --base with no value: usage error.
+#
+# Pattern follows test-worktree-root-override.sh: throwaway bare origin + repo
+# in a mktemp dir, copy worktree.sh + lib/, run.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKTREE_SH="$SCRIPTS_DIR/worktree.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1)); echo -e "  ${RED}FAIL${NC}: $1"; }
+
+assert_eq() {
+    if [[ "$1" == "$2" ]]; then pass "$3"; else fail "$3 (expected '$2', got '$1')"; fi
+}
+
+# Build a throwaway repo with an origin/main ref plus a parent feature branch
+# (feature/issue-41) that has one unique commit on top of main. Echoes the
+# working-tree path.
+setup_repo() {
+    local name="${1:-stackrepo}"
+    local tmp
+    tmp=$(mktemp -d /tmp/loom-wtbase.XXXXXX)
+    git init -q -b main "$tmp/origin.git" --bare
+    git init -q -b main "$tmp/$name"
+    (
+        cd "$tmp/$name"
+        git config user.email t@t
+        git config user.name t
+        git commit --allow-empty -q -m init
+        git remote add origin "$tmp/origin.git"
+        git push -q origin main
+        mkdir -p .loom/scripts/lib .loom/hooks
+        cp "$WORKTREE_SH" .loom/scripts/worktree.sh
+        if [[ -d "$SCRIPTS_DIR/lib" ]]; then
+            cp -R "$SCRIPTS_DIR"/lib/* .loom/scripts/lib/ 2>/dev/null || true
+        fi
+        chmod +x .loom/scripts/worktree.sh
+        # Create the parent branch with one unique commit and push it.
+        git checkout -q -b feature/issue-41
+        echo "parent-artifact" > parent-file.txt
+        git add parent-file.txt
+        git commit -q -m "parent: add artifact consumed by child"
+        git push -q origin feature/issue-41
+        # Return main to the checked-out branch so the helper auto-navigates cleanly.
+        git checkout -q main
+    )
+    echo "$tmp/$name"
+}
+
+cleanup_repo() {
+    local repo="$1"
+    [[ -z "$repo" ]] && return 0
+    rm -rf "$(dirname "$repo")"
+}
+
+# --- Test 1: default (no --base) branches off origin/main ---
+echo "Test 1: default (no --base) branches off origin/main"
+REPO=$(setup_repo defrepo)
+(
+    cd "$REPO"
+    ./.loom/scripts/worktree.sh 100 >/tmp/wtbase-def.$$ 2>&1 || { echo "FAILED"; cat /tmp/wtbase-def.$$; }
+)
+# The default worktree must NOT contain the parent's unique file.
+if [[ -f "$REPO/.loom/worktrees/issue-100/parent-file.txt" ]]; then
+    fail "default worktree unexpectedly contains parent artifact (should branch off main)"
+else
+    pass "default worktree branches off main (no parent artifact present)"
+fi
+cleanup_repo "$REPO"
+
+# --- Test 2: --base feature/issue-41 branches off the parent ---
+echo ""
+echo "Test 2: --base feature/issue-41 branches the child off the parent"
+REPO=$(setup_repo baserepo)
+(
+    cd "$REPO"
+    ./.loom/scripts/worktree.sh 42 --base feature/issue-41 >/tmp/wtbase-ovr.$$ 2>&1 || { echo "FAILED"; cat /tmp/wtbase-ovr.$$; }
+)
+# The child worktree must contain the parent's unique file (it descends from it).
+if [[ -f "$REPO/.loom/worktrees/issue-42/parent-file.txt" ]]; then
+    pass "child worktree contains the parent artifact (branched off feature/issue-41)"
+else
+    fail "child worktree missing parent artifact (did not branch off the parent)"
+fi
+# And its branch tip must have the parent commit in its ancestry.
+if git -C "$REPO/.loom/worktrees/issue-42" merge-base --is-ancestor origin/feature/issue-41 HEAD 2>/dev/null; then
+    pass "child branch descends from origin/feature/issue-41"
+else
+    fail "child branch does not descend from the parent branch"
+fi
+cleanup_repo "$REPO"
+
+# --- Test 3: --base with a nonexistent branch hard-fails ---
+echo ""
+echo "Test 3: --base with a nonexistent branch hard-fails (no silent main fallback)"
+REPO=$(setup_repo missrepo)
+rc=0
+(
+    cd "$REPO"
+    ./.loom/scripts/worktree.sh 43 --base feature/issue-9999 >/tmp/wtbase-miss.$$ 2>&1
+) || rc=$?
+assert_eq "$rc" "1" "worktree.sh exits 1 when --base branch cannot be resolved"
+if [[ ! -d "$REPO/.loom/worktrees/issue-43" ]]; then
+    pass "no worktree created for an unresolvable --base"
+else
+    fail "worktree created despite unresolvable --base (silent fallback to main?)"
+fi
+cleanup_repo "$REPO"
+
+# --- Test 4: --base with no value is a usage error ---
+echo ""
+echo "Test 4: --base with no value is a usage error"
+REPO=$(setup_repo novalrepo)
+rc=0
+(
+    cd "$REPO"
+    ./.loom/scripts/worktree.sh 44 --base >/tmp/wtbase-noval.$$ 2>&1
+) || rc=$?
+assert_eq "$rc" "1" "worktree.sh exits 1 when --base has no value"
+cleanup_repo "$REPO"
+
+# --- Summary ---
+echo ""
+echo "Tests run: $TESTS_RUN, Passed: $TESTS_PASSED, Failed: $TESTS_FAILED"
+[[ $TESTS_FAILED -eq 0 ]] || exit 1

--- a/defaults/scripts/worktree.sh
+++ b/defaults/scripts/worktree.sh
@@ -436,6 +436,7 @@ This script helps AI agents safely create and manage git worktrees.
 Usage:
   pnpm worktree <issue-number>                          Create worktree for issue
   pnpm worktree <issue-number> <branch>                 Create worktree with custom branch
+  pnpm worktree <issue-number> --base <branch>          Branch off <branch> (stacked PR, #3729)
   pnpm worktree <issue-number> --sparse <paths...>      Cone-mode sparse checkout
   pnpm worktree <issue-number> --full                   Convert sparse worktree to full
   pnpm worktree --check                                 Check if in a worktree
@@ -451,6 +452,11 @@ Examples:
   pnpm worktree 42 fix-bug
     Creates: .loom/worktrees/issue-42
     Branch: feature/fix-bug
+
+  pnpm worktree 42 --base feature/issue-41
+    Creates: .loom/worktrees/issue-42
+    Branch: feature/issue-42, branched off feature/issue-41 instead of the
+    default branch (stacked-PR mode, #3729). Used by /loom:sweep --depends-on.
 
   pnpm worktree 42 --sparse src/lib defaults/scripts
     Creates a sparse worktree containing only the listed paths plus the
@@ -630,6 +636,11 @@ SPARSE_MODE=false
 FULL_MODE=false
 SPARSE_PATHS=()
 CUSTOM_BRANCH=""
+# Base-branch override (#3729, stacked-PR v1). When set via `--base <branch>`,
+# the new feature branch is created from (and stale worktrees reset to) that
+# branch instead of origin/$DEFAULT_BRANCH. `/loom:sweep --depends-on <parent>`
+# passes `--base feature/issue-<parent>` so the child stacks on the parent.
+BASE_BRANCH=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -645,6 +656,14 @@ while [[ $# -gt 0 ]]; do
         --full)
             FULL_MODE=true
             shift
+            ;;
+        --base)
+            BASE_BRANCH="$2"
+            if [[ -z "$BASE_BRANCH" ]]; then
+                print_error "--base requires a branch name"
+                exit 1
+            fi
+            shift 2
             ;;
         --*)
             print_error "Unknown flag: $1"
@@ -809,6 +828,38 @@ fi
 # Uses fetch-only to avoid conflicts with worktrees that have it checked out
 fetch_latest_main
 
+# ─── Base-branch resolution (#3729, stacked-PR v1) ──────────────────────────
+# By default a new feature branch is created from origin/$DEFAULT_BRANCH. When
+# --base <branch> is passed (e.g. `--base feature/issue-<parent>` from
+# /loom:sweep --depends-on), resolve a ref for that base and use it instead so
+# the child branch stacks on top of the parent's branch. Prefer the pushed
+# origin/<base>, fall back to a local <base>. Hard-fail if neither resolves —
+# an explicit base that can't be found is worse than silently branching off
+# main (which would un-stack the child).
+BASE_REF="origin/$DEFAULT_BRANCH"
+BASE_DISPLAY="$DEFAULT_BRANCH"
+if [[ -n "$BASE_BRANCH" ]]; then
+    git fetch origin "$BASE_BRANCH" 2>/dev/null || true
+    if git show-ref --verify --quiet "refs/remotes/origin/$BASE_BRANCH"; then
+        BASE_REF="origin/$BASE_BRANCH"
+        BASE_DISPLAY="origin/$BASE_BRANCH"
+    elif git show-ref --verify --quiet "refs/heads/$BASE_BRANCH"; then
+        BASE_REF="$BASE_BRANCH"
+        BASE_DISPLAY="$BASE_BRANCH"
+    else
+        if [[ "$JSON_OUTPUT" == "true" ]]; then
+            echo '{"success": false, "error": "base-branch-not-found", "baseBranch": "'"$BASE_BRANCH"'"}' >&3
+        else
+            print_error "Requested --base '$BASE_BRANCH' not found as origin/$BASE_BRANCH or a local branch."
+            echo "  Ensure the parent sweep has created/pushed feature/issue-<parent> before stacking a child on it."
+        fi
+        exit 1
+    fi
+    if [[ "$JSON_OUTPUT" != "true" ]]; then
+        print_info "Stacked worktree base: $BASE_DISPLAY (from --base $BASE_BRANCH)"
+    fi
+fi
+
 # Determine branch name
 if [[ -n "$CUSTOM_BRANCH" ]]; then
     BRANCH_NAME="feature/$CUSTOM_BRANCH"
@@ -882,9 +933,11 @@ if [[ -d "$WORKTREE_PATH" ]]; then
 
     # Check if it's registered with git
     if git worktree list | grep -q "$WORKTREE_PATH"; then
-        # Check if worktree is stale: no commits ahead of main and behind main
-        local_commits_ahead=$(git -C "$WORKTREE_PATH" rev-list --count "origin/$DEFAULT_BRANCH..HEAD" 2>/dev/null) || local_commits_ahead="0"
-        local_commits_behind=$(git -C "$WORKTREE_PATH" rev-list --count "HEAD..origin/$DEFAULT_BRANCH" 2>/dev/null) || local_commits_behind="0"
+        # Check if worktree is stale: no commits ahead of the base and behind it.
+        # For a stacked child (--base), staleness is measured against the parent
+        # branch (BASE_REF), not the default branch (#3729).
+        local_commits_ahead=$(git -C "$WORKTREE_PATH" rev-list --count "$BASE_REF..HEAD" 2>/dev/null) || local_commits_ahead="0"
+        local_commits_behind=$(git -C "$WORKTREE_PATH" rev-list --count "HEAD..$BASE_REF" 2>/dev/null) || local_commits_behind="0"
         local_uncommitted=$(git -C "$WORKTREE_PATH" status --porcelain 2>/dev/null) || local_uncommitted=""
 
         if [[ "$local_commits_ahead" -gt 0 || -n "$local_uncommitted" ]]; then
@@ -907,18 +960,18 @@ if [[ -d "$WORKTREE_PATH" ]]; then
             # Stale worktree: no commits ahead, no uncommitted changes
             # Reset in place instead of removing (avoids CWD corruption)
             if [[ "$JSON_OUTPUT" != "true" ]]; then
-                print_warning "Stale worktree detected (0 commits ahead, $local_commits_behind behind $DEFAULT_BRANCH, no uncommitted changes)"
-                print_info "Resetting worktree in place to origin/$DEFAULT_BRANCH..."
+                print_warning "Stale worktree detected (0 commits ahead, $local_commits_behind behind $BASE_DISPLAY, no uncommitted changes)"
+                print_info "Resetting worktree in place to $BASE_DISPLAY..."
             fi
 
             # Back-fill/refresh the Loom sentinel on both reset outcomes: the
             # worktree remains usable either way, so keep it cleanup-eligible
             # (#3548).
             write_loom_sentinel "$WORKTREE_PATH"
-            if git -C "$WORKTREE_PATH" fetch origin "$DEFAULT_BRANCH" 2>/dev/null && \
-               git -C "$WORKTREE_PATH" reset --hard "origin/$DEFAULT_BRANCH" 2>/dev/null; then
+            if git -C "$WORKTREE_PATH" fetch origin "${BASE_BRANCH:-$DEFAULT_BRANCH}" 2>/dev/null && \
+               git -C "$WORKTREE_PATH" reset --hard "$BASE_REF" 2>/dev/null; then
                 if [[ "$JSON_OUTPUT" != "true" ]]; then
-                    print_success "Stale worktree reset to origin/$DEFAULT_BRANCH"
+                    print_success "Stale worktree reset to $BASE_DISPLAY"
                     echo ""
                     print_info "To use this worktree: cd $WORKTREE_PATH"
                 fi
@@ -953,11 +1006,12 @@ if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
 
     CREATE_ARGS=("$WORKTREE_PATH" "$BRANCH_NAME")
 else
-    # Create new branch from the default branch
+    # Create new branch from the base ref (origin/$DEFAULT_BRANCH by default, or
+    # the --base override for a stacked child — #3729).
     if [[ "$JSON_OUTPUT" != "true" ]]; then
-        print_info "Creating new branch from $DEFAULT_BRANCH"
+        print_info "Creating new branch from $BASE_DISPLAY"
     fi
-    CREATE_ARGS=("$WORKTREE_PATH" "-b" "$BRANCH_NAME" "origin/$DEFAULT_BRANCH")
+    CREATE_ARGS=("$WORKTREE_PATH" "-b" "$BRANCH_NAME" "$BASE_REF")
 fi
 
 # In sparse mode, defer file materialization until after we configure the cone.

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -770,11 +770,18 @@ fn handle_request(
             idempotency_key,
             model,
             effort,
+            depends_on,
         } => {
             let mut sr = sweep_registry
                 .lock()
                 .expect("Sweep registry mutex poisoned");
-            match sr.dispatch(&kind, idempotency_key, model.as_deref(), effort.as_deref()) {
+            match sr.dispatch(
+                &kind,
+                idempotency_key,
+                model.as_deref(),
+                effort.as_deref(),
+                depends_on,
+            ) {
                 Ok(outcome) => Response::SweepDispatched {
                     sweep_id: outcome.sweep_id,
                     pid: outcome.pid,
@@ -1122,6 +1129,7 @@ exit 0
                 idempotency_key: None,
                 model: None,
                 effort: None,
+                depends_on: None,
             },
             &tm,
             &db,
@@ -1166,6 +1174,7 @@ exit 0
                 idempotency_key: None,
                 model: None,
                 effort: None,
+                depends_on: None,
             },
             &tm,
             &db,
@@ -1198,6 +1207,7 @@ exit 0
                 idempotency_key,
                 model,
                 effort,
+                depends_on: _,
             } => {
                 assert!(matches!(kind, SweepKind::Issue(42)));
                 assert!(idempotency_key.is_none());
@@ -1215,6 +1225,7 @@ exit 0
             idempotency_key: Some("key-B".to_string()),
             model: Some("claude-sonnet-4-6".to_string()),
             effort: None,
+            depends_on: None,
         };
         let json = serde_json::to_string(&request).expect("serialize");
         let back: Request = serde_json::from_str(&json).expect("deserialize");
@@ -1224,6 +1235,7 @@ exit 0
                 idempotency_key,
                 model,
                 effort,
+                depends_on: _,
             } => {
                 assert!(matches!(kind, SweepKind::Issue(7)));
                 assert_eq!(idempotency_key.as_deref(), Some("key-B"));
@@ -1241,6 +1253,7 @@ exit 0
             idempotency_key: None,
             model: None,
             effort: None,
+            depends_on: None,
         };
         let json = serde_json::to_string(&request).expect("serialize");
         let back: Request = serde_json::from_str(&json).expect("deserialize");
@@ -1275,6 +1288,7 @@ exit 0
             idempotency_key: Some("key-E".to_string()),
             model: Some("claude-sonnet-4-6".to_string()),
             effort: Some("xhigh".to_string()),
+            depends_on: None,
         };
         let json = serde_json::to_string(&request).expect("serialize");
         let back: Request = serde_json::from_str(&json).expect("deserialize");
@@ -1294,6 +1308,7 @@ exit 0
             idempotency_key: None,
             model: None,
             effort: Some(String::new()),
+            depends_on: None,
         };
         let json = serde_json::to_string(&request).expect("serialize");
         let back: Request = serde_json::from_str(&json).expect("deserialize");
@@ -1302,6 +1317,42 @@ exit 0
             // to None happens spawn-side (registry) exactly like `model`.
             Request::DispatchSweep { effort, .. } => {
                 assert_eq!(effort.as_deref(), Some(""));
+            }
+            other => panic!("Expected DispatchSweep, got: {other:?}"),
+        }
+    }
+
+    // ===== DispatchSweep serde compat for `depends_on` (Issue #3729) =====
+
+    /// A wire payload WITHOUT the `depends_on` field (the pre-#3729 client
+    /// shape) must deserialize with `depends_on == None` — `#[serde(default)]`
+    /// keeps existing clients compatible.
+    #[test]
+    fn test_dispatch_sweep_deserializes_without_depends_on_field() {
+        let json = r#"{"type":"DispatchSweep","payload":{"kind":{"type":"Issue","value":42},"idempotency_key":null,"model":"claude-sonnet-4-6","effort":"xhigh"}}"#;
+        let request: Request = serde_json::from_str(json).expect("pre-#3729 payload must parse");
+        match request {
+            Request::DispatchSweep { depends_on, .. } => {
+                assert!(depends_on.is_none(), "absent depends_on must default to None");
+            }
+            other => panic!("Expected DispatchSweep, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_dispatch_sweep_serde_round_trip_with_depends_on() {
+        let request = Request::DispatchSweep {
+            kind: SweepKind::Issue(3725),
+            idempotency_key: None,
+            model: None,
+            effort: None,
+            depends_on: Some(3726),
+        };
+        let json = serde_json::to_string(&request).expect("serialize");
+        let back: Request = serde_json::from_str(&json).expect("deserialize");
+        match back {
+            Request::DispatchSweep { depends_on, .. } => {
+                assert_eq!(depends_on, Some(3726));
             }
             other => panic!("Expected DispatchSweep, got: {other:?}"),
         }
@@ -1428,6 +1479,7 @@ exit 0
                 idempotency_key: None,
                 model: None,
                 effort: None,
+                depends_on: None,
             },
             &tm,
             &db,

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -303,12 +303,20 @@ impl SweepRegistry {
     /// the argv (immediately after any `--model`). When `None` or empty, no
     /// `--effort` flag is emitted at all — the session default reasoning
     /// effort is preserved end-to-end.
+    ///
+    /// `depends_on` (issue #3729, stacked-PR v1): when `Some(N)`, the spawned
+    /// child receives `--depends-on <N>` appended to the argv (immediately
+    /// after any `--model` / `--effort`), instructing `/loom:sweep` to branch
+    /// its worktree/PR off `feature/issue-<N>`. When `None`, no
+    /// `--depends-on` flag is emitted — byte-for-byte unchanged behavior. A
+    /// single optional parent (not a list) makes diamonds unrepresentable.
     pub fn dispatch(
         &mut self,
         kind: &SweepKind,
         idempotency_key: Option<String>,
         model: Option<&str>,
         effort: Option<&str>,
+        depends_on: Option<u32>,
     ) -> Result<DispatchOutcome> {
         // 1. Idempotency dedup against Running entries.
         if let Some(ref key) = idempotency_key {
@@ -352,7 +360,7 @@ impl SweepRegistry {
         // 5. Compute the log path and spawn the child.
         let log_path = self.compute_log_path(issue_number);
         let (pid, token_name) = self
-            .spawn_child(issue_number, &log_path, &sweep_id, model, effort)
+            .spawn_child(issue_number, &log_path, &sweep_id, model, effort, depends_on)
             .context("failed to spawn sweep child")?;
 
         // 6. Record the entry. The model is carried on the registry entry
@@ -373,6 +381,7 @@ impl SweepRegistry {
             pr_number: None,
             model: model.filter(|m| !m.is_empty()).map(String::from),
             effort: effort.filter(|e| !e.is_empty()).map(String::from),
+            depends_on,
         };
         self.entries.insert(sweep_id.clone(), info);
 
@@ -514,6 +523,92 @@ impl SweepRegistry {
     }
 
     // ------------------------------------------------------------------------
+    // Stacked-PR block-the-subtree (issue #3729, v1 item 4)
+    // ------------------------------------------------------------------------
+
+    /// Return the issue numbers of every still-live (`Running`/`Pending`)
+    /// sweep whose `depends_on` names `parent`. Terminal children are
+    /// excluded — they no longer need blocking. Because `depends_on` is a
+    /// single optional parent, this only ever returns the *direct* children
+    /// of `parent` (a linear chain hop, never a diamond).
+    #[must_use]
+    pub fn children_of(&self, parent: u32) -> Vec<u32> {
+        self.entries
+            .values()
+            .filter(|info| {
+                matches!(info.state, SweepState::Running | SweepState::Pending)
+                    && info.depends_on == Some(parent)
+            })
+            .filter_map(|info| match &info.kind {
+                SweepKind::Issue(n) => Some(*n),
+                SweepKind::PrSet(_) => None,
+            })
+            .collect()
+    }
+
+    /// Block the subtree stacked on `parent` (issue #3729, v1 item 4).
+    ///
+    /// For each direct child of `parent` (see [`Self::children_of`]), emit a
+    /// `sweep.issue.{child}.blocker` event on the existing frozen event-bus
+    /// topic (#3453 — no new topic). This is the safety net that keeps a
+    /// stacked child from auto-progressing (opening/merging its PR) when its
+    /// parent ends in `loom:blocked`. Auto-detach (rebasing an orphaned child
+    /// onto `main`) is explicitly out of v1 scope — block-the-subtree is the
+    /// only cascade behavior.
+    ///
+    /// Returns the child issue numbers that were signalled. Emission is
+    /// best-effort (no subscribers ⇒ debug log only), mirroring the rest of
+    /// the reaper's event handling.
+    pub fn block_children_of(&self, parent: u32, reason: &str) -> Vec<u32> {
+        let children = self.children_of(parent);
+        for child in &children {
+            self.emit_event(Event::SweepBlocker {
+                issue: *child,
+                reason: reason.to_string(),
+                label_added: "loom:blocked".to_string(),
+            });
+        }
+        children
+    }
+
+    /// Best-effort check of whether `issue` currently carries the
+    /// `loom:blocked` label on the forge. Used by the reaper to decide
+    /// whether a terminated parent ended blocked (in which case its stacked
+    /// children must be blocked too) versus completing successfully.
+    ///
+    /// Returns `false` on any error, when label flips are skipped (test
+    /// fixtures), or when `gh` is unavailable — a conservative default that
+    /// never blocks a child on an unverifiable parent state.
+    fn issue_has_blocked_label(&self, issue: u32) -> bool {
+        if self.config.skip_label_flip {
+            return false;
+        }
+        let gh = self
+            .config
+            .gh_bin
+            .clone()
+            .unwrap_or_else(|| PathBuf::from("gh"));
+        let mut cmd = Command::new(&gh);
+        cmd.arg("issue")
+            .arg("view")
+            .arg(issue.to_string())
+            .arg("--json")
+            .arg("labels")
+            .arg("--jq")
+            .arg(r#"[.labels[].name] | index("loom:blocked") != null"#);
+        if let Ok(repo) = std::env::var("LOOM_REPO") {
+            cmd.arg("--repo").arg(repo);
+        }
+        cmd.stderr(Stdio::null());
+        match cmd.output() {
+            Ok(out) if out.status.success() => {
+                String::from_utf8_lossy(&out.stdout).trim() == "true"
+            }
+            _ => false,
+        }
+    }
+
+    // ------------------------------------------------------------------------
     // Spawn
     // ------------------------------------------------------------------------
 
@@ -530,6 +625,7 @@ impl SweepRegistry {
         sweep_id: &str,
         model: Option<&str>,
         effort: Option<&str>,
+        depends_on: Option<u32>,
     ) -> Result<(u32, String)> {
         let spawn_bin = self.config.resolve_spawn_bin()?;
 
@@ -584,6 +680,14 @@ impl SweepRegistry {
             if !e.is_empty() {
                 cmd.arg("--effort").arg(e);
             }
+        }
+        // Stacked-PR dependency (issue #3729, v1): when a parent issue is
+        // declared, append `--depends-on <N>` so `/loom:sweep` branches the
+        // child worktree/PR off `feature/issue-<N>` instead of the default
+        // branch. Absent the param, no flag is emitted (byte-for-byte
+        // unchanged). Mirrors the `--model` / `--effort` append-only contract.
+        if let Some(parent) = depends_on {
+            cmd.arg("--depends-on").arg(parent.to_string());
         }
         cmd.env("LOOM_TERMINAL_ID", format!("daemon-{sweep_id}"))
             // Always pin LOOM_WORKSPACE to the registry's configured root so
@@ -850,6 +954,26 @@ impl SweepRegistry {
                                 outcome: SweepOutcome::Exited,
                             });
                         }
+                        // Block-the-subtree (issue #3729, v1 item 4): if this
+                        // parent ended in `loom:blocked` and stacked children
+                        // still depend on it, signal each child's blocker on
+                        // the existing frozen topic so it does not
+                        // auto-progress. Cheap-guarded: we only consult the
+                        // forge label when direct children actually exist.
+                        let children = self.children_of(issue);
+                        if !children.is_empty() && self.issue_has_blocked_label(issue) {
+                            let reason = format!(
+                                "parent sweep #{issue} ended in loom:blocked; \
+                                 stacked child cannot auto-progress (block-the-subtree, #3729)"
+                            );
+                            for child in children {
+                                events_to_emit.push(Event::SweepBlocker {
+                                    issue: child,
+                                    reason: reason.clone(),
+                                    label_added: "loom:blocked".to_string(),
+                                });
+                            }
+                        }
                     } else {
                         if let Some(info) = self.entries.get_mut(&sweep_id) {
                             info.state = SweepState::Exited {
@@ -979,6 +1103,8 @@ impl SweepRegistry {
                         model: None,
                         // Effort is likewise unrecoverable from the lock (#3716).
                         effort: None,
+                        // depends_on is not recorded in the lock owner (#3729).
+                        depends_on: None,
                     },
                 );
                 admitted += 1;
@@ -1028,8 +1154,9 @@ impl SweepRegistry {
                         state: SweepState::Crashed { at: Utc::now() },
                         latest_phase: phase,
                         pr_number: None,
-                        model: None,  // not recoverable from a checkpoint-only entry
-                        effort: None, // not recoverable from a checkpoint-only entry
+                        model: None,      // not recoverable from a checkpoint-only entry
+                        effort: None,     // not recoverable from a checkpoint-only entry
+                        depends_on: None, // not recoverable from a checkpoint-only entry
                     },
                 );
                 admitted += 1;
@@ -1313,7 +1440,7 @@ exit 0
         let (mut registry, record_log) = fixture_registry(dir.path());
 
         let outcome = registry
-            .dispatch(&SweepKind::Issue(42), None, None, None)
+            .dispatch(&SweepKind::Issue(42), None, None, None, None)
             .expect("dispatch should succeed");
 
         assert!(outcome.was_new);
@@ -1377,7 +1504,7 @@ exit 0
         let (mut registry, record_log) = fixture_registry(dir.path());
 
         let outcome = registry
-            .dispatch(&SweepKind::Issue(43), None, Some("claude-sonnet-4-6"), None)
+            .dispatch(&SweepKind::Issue(43), None, Some("claude-sonnet-4-6"), None, None)
             .expect("dispatch should succeed");
 
         let needle = format!("LOOM_TERMINAL_ID=daemon-{}", outcome.sweep_id);
@@ -1409,7 +1536,7 @@ exit 0
         let (mut registry, record_log) = fixture_registry(dir.path());
 
         let outcome = registry
-            .dispatch(&SweepKind::Issue(44), None, Some(""), None)
+            .dispatch(&SweepKind::Issue(44), None, Some(""), None, None)
             .expect("dispatch should succeed");
 
         let needle = format!("LOOM_TERMINAL_ID=daemon-{}", outcome.sweep_id);
@@ -1439,7 +1566,7 @@ exit 0
         let (mut registry, record_log) = fixture_registry(dir.path());
 
         let outcome = registry
-            .dispatch(&SweepKind::Issue(45), None, None, Some("xhigh"))
+            .dispatch(&SweepKind::Issue(45), None, None, Some("xhigh"), None)
             .expect("dispatch should succeed");
 
         let needle = format!("LOOM_TERMINAL_ID=daemon-{}", outcome.sweep_id);
@@ -1470,7 +1597,7 @@ exit 0
         let (mut registry, record_log) = fixture_registry(dir.path());
 
         let outcome = registry
-            .dispatch(&SweepKind::Issue(46), None, Some("claude-sonnet-4-6"), Some("xhigh"))
+            .dispatch(&SweepKind::Issue(46), None, Some("claude-sonnet-4-6"), Some("xhigh"), None)
             .expect("dispatch should succeed");
 
         let needle = format!("LOOM_TERMINAL_ID=daemon-{}", outcome.sweep_id);
@@ -1497,7 +1624,7 @@ exit 0
         let (mut registry, record_log) = fixture_registry(dir.path());
 
         let outcome = registry
-            .dispatch(&SweepKind::Issue(47), None, None, Some(""))
+            .dispatch(&SweepKind::Issue(47), None, None, Some(""), None)
             .expect("dispatch should succeed");
 
         let needle = format!("LOOM_TERMINAL_ID=daemon-{}", outcome.sweep_id);
@@ -1516,6 +1643,171 @@ exit 0
             None,
             "empty effort must be recorded as None on the SweepInfo entry"
         );
+    }
+
+    /// Issue #3729 (stacked-PR v1): a `depends_on` dispatch param threads
+    /// through to the spawn command as an explicit `--depends-on <N>`
+    /// argument, mirroring `--model` / `--effort`. It is recorded on the
+    /// SweepInfo entry so the reaper can block the subtree on parent failure.
+    #[test]
+    #[serial]
+    fn dispatch_with_depends_on_appends_depends_on_arg() {
+        let dir = tempdir().unwrap();
+        let (mut registry, record_log) = fixture_registry(dir.path());
+
+        let outcome = registry
+            .dispatch(&SweepKind::Issue(50), None, None, None, Some(49))
+            .expect("dispatch should succeed");
+
+        let needle = format!("LOOM_TERMINAL_ID=daemon-{}", outcome.sweep_id);
+        assert!(
+            wait_for_contents(&record_log, &needle, 10000),
+            "fake spawn-claude.sh did not finish writing within 10s"
+        );
+        let recorded = std::fs::read_to_string(&record_log).unwrap();
+        assert!(
+            recorded.contains("argv: -p /loom:sweep 50 --depends-on 49"),
+            "expected --depends-on in argv; got: {recorded}"
+        );
+        assert_eq!(
+            registry.get(&outcome.sweep_id).unwrap().depends_on,
+            Some(49),
+            "dispatch depends_on must be recorded on the SweepInfo entry"
+        );
+    }
+
+    /// Issue #3729: absent `depends_on`, no `--depends-on` flag is emitted —
+    /// byte-for-byte unchanged behavior (opt-in, no default-path regression).
+    #[test]
+    #[serial]
+    fn dispatch_without_depends_on_emits_no_flag() {
+        let dir = tempdir().unwrap();
+        let (mut registry, record_log) = fixture_registry(dir.path());
+
+        let outcome = registry
+            .dispatch(&SweepKind::Issue(51), None, None, None, None)
+            .expect("dispatch should succeed");
+
+        let needle = format!("LOOM_TERMINAL_ID=daemon-{}", outcome.sweep_id);
+        assert!(
+            wait_for_contents(&record_log, &needle, 10000),
+            "fake spawn-claude.sh did not finish writing within 10s"
+        );
+        let recorded = std::fs::read_to_string(&record_log).unwrap();
+        assert!(
+            !recorded.contains("--depends-on"),
+            "depends_on=None must not emit --depends-on; got: {recorded}"
+        );
+        assert_eq!(
+            registry.get(&outcome.sweep_id).unwrap().depends_on,
+            None,
+            "depends_on=None must be recorded as None on the SweepInfo entry"
+        );
+    }
+
+    /// Issue #3729 (v1 item 4, block-the-subtree): `block_children_of` emits a
+    /// `sweep.issue.{child}.blocker` event for every live child whose
+    /// `depends_on` names the given parent — and nothing for unrelated sweeps.
+    #[tokio::test]
+    async fn block_children_of_emits_blocker_for_dependents_only() {
+        use crate::event_bus::EventBus;
+
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+        let bus = Arc::new(EventBus::new());
+        registry.set_event_bus(bus.clone());
+        let mut sub = bus.subscribe::<[&str; 0], &str>([]);
+
+        // Parent #60, a stacked child #61 (depends_on=60), and an unrelated
+        // independent sweep #62 (depends_on=None).
+        for (sid, issue, dep) in [
+            ("sweep-issue-60", 60u32, None),
+            ("sweep-issue-61", 61u32, Some(60u32)),
+            ("sweep-issue-62", 62u32, None),
+        ] {
+            registry.entries.insert(
+                sid.to_string(),
+                SweepInfo {
+                    sweep_id: sid.to_string(),
+                    kind: SweepKind::Issue(issue),
+                    pid: 2_147_483_640,
+                    token_name: "unknown".into(),
+                    log_path: registry.compute_log_path(issue),
+                    idempotency_key: None,
+                    started_at: Utc::now(),
+                    state: SweepState::Running,
+                    latest_phase: None,
+                    pr_number: None,
+                    model: None,
+                    effort: None,
+                    depends_on: dep,
+                },
+            );
+        }
+
+        let blocked = registry.block_children_of(60, "parent #60 blocked");
+        assert_eq!(blocked, vec![61], "only #61 depends on #60");
+
+        // Exactly one blocker event, for issue 61 on its .blocker topic.
+        let ev = sub.recv().await.unwrap();
+        match ev {
+            Event::SweepBlocker {
+                issue, label_added, ..
+            } => {
+                assert_eq!(issue, 61);
+                assert_eq!(label_added, "loom:blocked");
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    /// Issue #3729: `children_of` only returns *live* direct children, and a
+    /// terminal child is excluded (it no longer needs blocking).
+    #[test]
+    #[serial]
+    fn children_of_returns_live_direct_children_only() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+
+        fn mk(issue: u32, dep: Option<u32>, state: SweepState) -> SweepInfo {
+            SweepInfo {
+                sweep_id: format!("s{issue}"),
+                kind: SweepKind::Issue(issue),
+                pid: 2_147_483_640,
+                token_name: "unknown".into(),
+                log_path: PathBuf::from(format!(".loom/logs/sweep-issue-{issue}.log")),
+                idempotency_key: None,
+                started_at: Utc::now(),
+                state,
+                latest_phase: None,
+                pr_number: None,
+                model: None,
+                effort: None,
+                depends_on: dep,
+            }
+        }
+        registry
+            .entries
+            .insert("s70".into(), mk(70, None, SweepState::Running));
+        registry
+            .entries
+            .insert("s71".into(), mk(71, Some(70), SweepState::Running));
+        // Terminal child — excluded.
+        registry.entries.insert(
+            "s72".into(),
+            mk(
+                72,
+                Some(70),
+                SweepState::Exited {
+                    code: None,
+                    at: Utc::now(),
+                },
+            ),
+        );
+
+        let mut kids = registry.children_of(70);
+        kids.sort_unstable();
+        assert_eq!(kids, vec![71], "only the live child #71 is returned");
     }
 
     /// Issue #3730: when the experiment-related env vars are set in the daemon
@@ -1537,7 +1829,7 @@ exit 0
         std::env::set_var("LOOM_TRANSCRIPT_ARCHIVE", "/tmp/loom-archive-3730");
 
         let outcome = registry
-            .dispatch(&SweepKind::Issue(48), None, None, None)
+            .dispatch(&SweepKind::Issue(48), None, None, None, None)
             .expect("dispatch should succeed");
 
         // Clean up the process env immediately so a failure below can't leak
@@ -1589,7 +1881,7 @@ exit 0
         let (mut registry, record_log) = fixture_registry(dir.path());
 
         let outcome = registry
-            .dispatch(&SweepKind::Issue(49), None, None, None)
+            .dispatch(&SweepKind::Issue(49), None, None, None, None)
             .expect("dispatch should succeed");
 
         let needle = format!("LOOM_TERMINAL_ID=daemon-{}", outcome.sweep_id);
@@ -1625,10 +1917,10 @@ exit 0
         let dir = tempdir().unwrap();
         let (mut registry, _record_log) = fixture_registry(dir.path());
 
-        let first = registry.dispatch(&SweepKind::Issue(7), None, None, None);
+        let first = registry.dispatch(&SweepKind::Issue(7), None, None, None, None);
         assert!(first.is_ok());
 
-        let second = registry.dispatch(&SweepKind::Issue(7), None, None, None);
+        let second = registry.dispatch(&SweepKind::Issue(7), None, None, None, None);
         assert!(second.is_err(), "second dispatch for issue #7 should fail (lock collision)");
         let err = second.unwrap_err().to_string();
         assert!(err.contains("lock collision"), "expected lock collision error; got: {err}");
@@ -1641,7 +1933,7 @@ exit 0
         let (mut registry, _record_log) = fixture_registry(dir.path());
 
         let first = registry
-            .dispatch(&SweepKind::Issue(99), Some("key-A".to_string()), None, None)
+            .dispatch(&SweepKind::Issue(99), Some("key-A".to_string()), None, None, None)
             .unwrap();
         assert!(first.was_new);
 
@@ -1649,7 +1941,7 @@ exit 0
         // Issue #99 is the same kind, but we don't need a different issue —
         // the dedup is purely on the idempotency key.
         let second = registry
-            .dispatch(&SweepKind::Issue(99), Some("key-A".to_string()), None, None)
+            .dispatch(&SweepKind::Issue(99), Some("key-A".to_string()), None, None, None)
             .unwrap();
         assert!(!second.was_new);
         assert_eq!(first.sweep_id, second.sweep_id);
@@ -1660,7 +1952,7 @@ exit 0
         let dir = tempdir().unwrap();
         let (mut registry, _record_log) = fixture_registry(dir.path());
 
-        let outcome = registry.dispatch(&SweepKind::PrSet(vec![1, 2, 3]), None, None, None);
+        let outcome = registry.dispatch(&SweepKind::PrSet(vec![1, 2, 3]), None, None, None, None);
         assert!(outcome.is_err());
         assert!(outcome
             .unwrap_err()
@@ -1675,7 +1967,7 @@ exit 0
 
         // Dispatch and then poke an entry into Exited state directly.
         let outcome = registry
-            .dispatch(&SweepKind::Issue(11), None, None, None)
+            .dispatch(&SweepKind::Issue(11), None, None, None, None)
             .unwrap();
         let entry = registry.entries.get_mut(&outcome.sweep_id).unwrap();
         entry.state = SweepState::Exited {
@@ -1732,6 +2024,7 @@ exit 0
                 pr_number: None,
                 model: None,
                 effort: None,
+                depends_on: None,
             },
         );
 
@@ -1803,6 +2096,7 @@ exit 0
                 pr_number: None,
                 model: None,
                 effort: None,
+                depends_on: None,
             },
         );
 
@@ -1856,6 +2150,7 @@ exit 0
                 pr_number: None,
                 model: None,
                 effort: None,
+                depends_on: None,
             },
         );
 
@@ -1891,6 +2186,7 @@ exit 0
                 pr_number: None,
                 model: None,
                 effort: None,
+                depends_on: None,
             },
         );
 
@@ -2052,7 +2348,7 @@ exit 0
         let mut registry = SweepRegistry::new(config);
 
         let outcome = registry
-            .dispatch(&SweepKind::Issue(123), None, None, None)
+            .dispatch(&SweepKind::Issue(123), None, None, None, None)
             .unwrap();
         assert!(outcome.was_new);
 
@@ -2089,6 +2385,7 @@ exit 0
             pr_number: Some(456),
             model: Some("claude-sonnet-4-6".to_string()),
             effort: Some("xhigh".to_string()),
+            depends_on: None,
         };
         let json = serde_json::to_value(vec![info]).unwrap();
         let expected = serde_json::json!([{
@@ -2197,6 +2494,7 @@ exit 0
                 pr_number: None,
                 model: None,
                 effort: None,
+                depends_on: None,
             },
         );
 
@@ -2235,6 +2533,7 @@ exit 0
                 pr_number: None,
                 model: None,
                 effort: None,
+                depends_on: None,
             },
         );
 
@@ -2295,6 +2594,7 @@ exit 0
                 pr_number: None,
                 model: None,
                 effort: None,
+                depends_on: None,
             },
         );
 
@@ -2333,6 +2633,7 @@ exit 0
                 pr_number: None,
                 model: None,
                 effort: None,
+                depends_on: None,
             },
         );
 
@@ -2389,6 +2690,7 @@ exit 0
                 pr_number: None,
                 model: None,
                 effort: None,
+                depends_on: None,
             },
         );
 
@@ -2442,6 +2744,7 @@ exit 0
                 pr_number: None,
                 model: None,
                 effort: None,
+                depends_on: None,
             },
         );
 

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -152,6 +152,17 @@ pub enum Request {
     /// `None` (or absent on the wire — `#[serde(default)]` keeps existing
     /// clients compatible) or empty, NO `--effort` flag is emitted and the
     /// session-default effort is preserved.
+    ///
+    /// `depends_on` (issue #3729, stacked-PR v1) optionally names the single
+    /// parent issue this sweep is stacked on. When `Some(N)`, the daemon
+    /// appends `--depends-on <N>` to the `/loom:sweep` argv (mirroring the
+    /// `--model` / `--effort` append-only, empty-means-unset contract), and
+    /// the spawned child branches its worktree/PR off `feature/issue-<N>`
+    /// instead of the default branch. When `None` (or absent on the wire —
+    /// `#[serde(default)]` keeps existing clients compatible), NO
+    /// `--depends-on` flag is emitted and behavior is byte-for-byte
+    /// unchanged. A single optional parent (not a `Vec`) makes diamonds /
+    /// multi-parent stacks structurally unrepresentable — see #3729 v1 scope.
     DispatchSweep {
         kind: SweepKind,
         idempotency_key: Option<String>,
@@ -159,6 +170,8 @@ pub enum Request {
         model: Option<String>,
         #[serde(default)]
         effort: Option<String>,
+        #[serde(default)]
+        depends_on: Option<u32>,
     },
     /// List tracked sweeps, optionally filtered by state.
     ListSweeps {
@@ -481,6 +494,16 @@ pub struct SweepInfo {
     /// `#[serde(default)]` keeps pre-#3716 wire data and clients compatible.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub effort: Option<String>,
+    /// Single parent issue this sweep is stacked on (issue #3729, stacked-PR
+    /// v1). Mirrors the `depends_on` param of `DispatchSweep`: `Some(N)` when
+    /// the sweep was dispatched with `--depends-on <N>` (so its worktree/PR
+    /// branches off `feature/issue-<N>`), `None` for an independent sweep.
+    /// The reaper uses this to block a stacked child's subtree when its
+    /// parent ends in `loom:blocked` (block-the-subtree, #3729 item 4).
+    /// A single optional parent makes diamonds structurally unrepresentable.
+    /// `#[serde(default)]` keeps pre-#3729 wire data and clients compatible.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub depends_on: Option<u32>,
 }
 
 // ========================================================================

--- a/mcp-loom/src/tools/sweeps.ts
+++ b/mcp-loom/src/tools/sweeps.ts
@@ -83,6 +83,12 @@ export interface SweepInfo {
    * child inherited the session-default effort; render as "default".
    */
   effort?: string;
+  /**
+   * Single parent issue this sweep is stacked on (issue #3729, stacked-PR
+   * v1). Absent/undefined means an independent sweep; when set, the child
+   * branched its worktree/PR off `feature/issue-<depends_on>`.
+   */
+  depends_on?: number;
 }
 
 interface DispatchResponse {
@@ -233,6 +239,7 @@ async function dispatchSweep(args: {
   idempotency_key?: string;
   model?: string;
   effort?: string;
+  depends_on?: number;
 }): Promise<{ success: true; result: DispatchResponse["payload"] } | { success: false; error: string }> {
   try {
     const response = (await sendDaemonRequest({
@@ -248,6 +255,11 @@ async function dispatchSweep(args: {
         // `null` (the default) means the daemon emits NO --effort flag and
         // the spawned child inherits the session-default effort.
         effort: args.effort ?? null,
+        // Issue #3729 (stacked-PR v1): optional single parent issue. `null`
+        // (the default) means the daemon emits NO --depends-on flag and the
+        // child branches off the default branch as usual. When set, the child
+        // branches its worktree/PR off `feature/issue-<depends_on>`.
+        depends_on: args.depends_on ?? null,
       },
     })) as DaemonResponse;
 
@@ -471,6 +483,18 @@ export const sweepTools: Tool[] = [
             "Omit (or pass an empty string) to preserve the session-default " +
             "effort (no --effort flag is emitted at all). Level validation " +
             "is owned by the `claude` CLI, not the daemon.",
+        },
+        depends_on: {
+          type: "number",
+          description:
+            "Optional single parent issue number this sweep is stacked on " +
+            "(issue #3729, stacked-PR v1). When set, the daemon appends " +
+            "`--depends-on <N>` to the `/loom:sweep` argv so the child " +
+            "branches its worktree/PR off `feature/issue-<N>` instead of the " +
+            "default branch, and the reaper blocks the child's subtree if the " +
+            "parent ends in `loom:blocked`. A single optional parent (not a " +
+            "list) makes diamonds / multi-parent stacks unrepresentable. Omit " +
+            "for an independent sweep (no --depends-on flag is emitted).",
         },
       },
       required: ["kind"],
@@ -762,8 +786,23 @@ export async function handleSweepTool(
         typeof args?.effort === "string" && args.effort.length > 0
           ? (args.effort as string)
           : undefined;
+      // Issue #3729 (stacked-PR v1): optional single parent issue. Only a
+      // positive integer is forwarded; anything else is treated as unset so
+      // the daemon never receives a spurious `--depends-on`.
+      const dependsOn =
+        typeof args?.depends_on === "number" &&
+        Number.isInteger(args.depends_on) &&
+        args.depends_on > 0
+          ? (args.depends_on as number)
+          : undefined;
 
-      const result = await dispatchSweep({ kind: normalized, idempotency_key: idempotencyKey, model, effort });
+      const result = await dispatchSweep({
+        kind: normalized,
+        idempotency_key: idempotencyKey,
+        model,
+        effort,
+        depends_on: dependsOn,
+      });
       if (!result.success) {
         return [
           {


### PR DESCRIPTION
## Summary

Implements the **full v1** slice (items 1–6, **not** the v1a fallback) of the stacked-PR-mode Curator enhancement on #3729. `reconcile-stack.sh` is included, so nothing from the curated v1 scope was deferred beyond what the enhancement itself marks OUT of scope.

Stacked-PR mode pipelines a genuine dependency: a child sweep declared with `depends_on=<parent>` branches its worktree/PR off `feature/issue-<parent>`, so the child's Curator→Builder→Judge runs concurrently with the parent's review instead of serializing behind its merge. Opt-in, daemon-`dispatch_sweep`-only, linear-chains-only.

## What landed (full v1)

1. **Operator-declared dependency via dispatch param** — `depends_on: Option<u32>` on the `DispatchSweep` request and `SweepInfo`, threaded through `dispatch() -> spawn_child()` and appended as `--depends-on <N>` following the exact `--model`/`--effort` append-only, empty-means-unset contract. No body-text parsing.
2. **Linear chains only, enforced by the type** — a single `Option<u32>` parent makes diamonds / multi-parent stacks structurally unrepresentable (no runtime rejection code).
3. **Child branches off the parent** — new `worktree.sh --base <branch>` override branches the child (and stale-resets it) off `feature/issue-<parent>` instead of the default branch, hard-failing if the base can't be resolved rather than silently branching off main. `sweep.md` gains `--depends-on` flag parsing/validation + a gated Builder worktree/PR-base code path.
4. **Block-the-subtree on parent failure** — the reaper emits `sweep.issue.{child}.blocker` on the existing frozen topic (no new topic) for live children of a parent that ended in `loom:blocked`, via `SweepRegistry::children_of` + `block_children_of`.
5. **Scripted manual reconciliation** — new standalone `defaults/scripts/reconcile-stack.sh <child-pr> <parent-branch>` implementing the squash-merge `git rebase --onto <default> <parent> <child>` + `--force-with-lease` (never bare `--force`) + `gh pr edit --base` surgery. **`merge-pr.sh` is not modified** (the single biggest cut vs. the full four-phase proposal — automatic reconciliation + the edge-1 merge-ordering guard are deferred to a fast-follow, per the curated scope).
6. **Docs** — `daemon-reference.md` gains a "Stacked-PR dependency (v1)" section + the `depends_on` input; `sweep.md` gains a "Stacked dependency (v1, manual reconciliation)" subsection.

## Explicitly deferred (out of v1 scope per the enhancement)

Diamonds/multi-parent, auto-detection (`Depends on #A` / `Part of #A`), automated reconciliation in `merge-pr.sh` + the merge-ordering guard, rebase-on-parent-amend, operator detach action, cross-repo stacks, and in-session wave-driven stacking. The wave lifecycle is unchanged — only an explicitly `--depends-on`-flagged single-issue (daemon) invocation stacks.

## Tests

- Rust unit tests: `--depends-on` present ⇒ flag in argv; absent ⇒ no flag (mirrors the empty-model test); `block_children_of` emits a blocker for dependents only; `children_of` returns live direct children only; `depends_on` serde compat (absent field defaults to `None`, round-trip). All 410 lib tests + integration/doc-lint suites pass.
- New bash test `test-worktree-base-override.sh` (6 assertions): default branches off main; `--base` branches off the parent; unresolvable base hard-fails; missing value is a usage error.
- `cargo build` + `cargo test` + `cargo fmt --check` + CI-equivalent `cargo clippy -D warnings` green; `mcp-loom` `tsc --noEmit` + bundle build green; `shellcheck --severity=warning` clean on all changed/new scripts.

## Regression safety

Absent `--depends-on` / `depends_on`, behavior is byte-for-byte unchanged: no `--depends-on` flag emitted, worktree branches off the default branch, reaper emits no extra events (the forge label check is skipped in fixtures and only consulted when children exist).

Closes #3729

🤖 Generated with [Claude Code](https://claude.com/claude-code)