### PR TITLE
docs(research): evaluate Dynamic Workflows for in-session orchestration (#3739)

### DIFF
--- a/defaults/scripts/experiments/README.md
+++ b/defaults/scripts/experiments/README.md
@@ -1,0 +1,42 @@
+# `defaults/scripts/experiments/`
+
+Off-by-default, isolated experiment artifacts. Nothing here is wired into the
+production Loom path (sweep / judge / doctor / merge). These files exist to be
+picked up deliberately by a human or a future top-level session — never
+auto-loaded, never triggered by a normal sweep.
+
+## Contents
+
+| File | What it is |
+|------|------------|
+| `judge-fanout-workflow.js` | **Design sketch** (issue #3739) of a Claude Code Dynamic Workflow that reviews ONE PR via multi-dimension reviewer fan-out + a typed adversarial verify pass. NOT wired into `sweep.md`/`judge.md`; NOT in a discovered `workflows/` directory, so the CLI does not auto-load it. |
+| `judge-fanout-experiment.sh` | Off-by-default gate/runner. No-op unless `LOOM_JUDGE_FANOUT_EXPERIMENT=1`. When enabled it syntax-checks the sketch and prints top-level-session invocation guidance — it never dispatches a live judge run, applies no labels, merges nothing, and creates no issues. |
+
+Full context, the capability→need mapping, the substrate boundary, and the
+keep/defer/reject verdicts live in
+[`docs/research/dynamic-workflows-evaluation.md`](../../../docs/research/dynamic-workflows-evaluation.md).
+
+## Flag contract
+
+Follows the `LOOM_MODEL_EXPERIMENT` / `sweep.modelExperiment` precedent
+(off by default, loud banner when on):
+
+```bash
+# Disabled (default) — no-op, exits 0:
+./defaults/scripts/experiments/judge-fanout-experiment.sh
+
+# Enabled — banner + syntax check + guidance (still NO live judge run):
+LOOM_JUDGE_FANOUT_EXPERIMENT=1 ./defaults/scripts/experiments/judge-fanout-experiment.sh
+```
+
+## Guardrails (why this is safe to have in the tree)
+
+- **One level deep (#3289):** the workflow makes direct `agent()`/`parallel()`
+  calls and never calls `workflow()` — it adds no second nesting level.
+- **Single-token / in-session:** all agents share the session's one OAuth token.
+  This makes NO claim to multi-account rotation — that is a `loom-daemon` +
+  `spawn-claude.sh` concern on the other side of the substrate boundary.
+- **Read-only:** the workflow returns a verdict object; it merges nothing, applies
+  no `loom:pr` / `loom:changes-requested` transitions, and creates no GitHub issues.
+- **Deferred:** the runnable prototype + measured comparison are a named follow-up,
+  not delivered here. See the evaluation doc → "What is deferred".

--- a/defaults/scripts/experiments/judge-fanout-experiment.sh
+++ b/defaults/scripts/experiments/judge-fanout-experiment.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# judge-fanout-experiment.sh — off-by-default gate/runner for the #3739 design sketch.
+#
+# This is EXPERIMENT TOOLING ONLY. It does not touch the production judge path
+# (defaults/roles/judge.md, defaults/.claude/commands/loom/{judge,sweep}.md), it
+# applies no labels, merges nothing, and creates no GitHub issues.
+#
+# Flag contract (mirrors the LOOM_MODEL_EXPERIMENT / sweep.modelExperiment
+# precedent — off by default, loud banner when on):
+#
+#   (unset) / 0 / false / no / off / ""   -> DISABLED: prints one line, exits 0 (no-op).
+#   1 / true / yes / on                   -> ENABLED:  loud banner, syntax-checks the
+#                                            sketch, prints the top-level-session
+#                                            invocation guidance. Still dispatches
+#                                            NO live judge run (see #3739 deferral).
+#
+# Why it never runs a live judge here: the runnable prototype must be driven from
+# a TOP-LEVEL Claude Code session (so its agent()/parallel() calls are the first
+# nesting level, #3289-safe). A subagent/script context cannot honestly exercise
+# it. See docs/research/dynamic-workflows-evaluation.md → "What is deferred".
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKFLOW_JS="${SCRIPT_DIR}/judge-fanout-workflow.js"
+
+FLAG="${LOOM_JUDGE_FANOUT_EXPERIMENT:-}"
+
+is_enabled() {
+  case "$(printf '%s' "${FLAG}" | tr '[:upper:]' '[:lower:]')" in
+    1 | true | yes | on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+if ! is_enabled; then
+  echo "judge-fanout-experiment: disabled (LOOM_JUDGE_FANOUT_EXPERIMENT unset) — no-op." >&2
+  echo "  Set LOOM_JUDGE_FANOUT_EXPERIMENT=1 to enable the experiment tooling." >&2
+  exit 0
+fi
+
+echo "============================================================================" >&2
+echo "  LOOM JUDGE FAN-OUT EXPERIMENT (#3739) — DESIGN SKETCH, NOT PRODUCTION" >&2
+echo "  This tooling touches NO production judge code, applies NO labels," >&2
+echo "  merges NOTHING, and creates NO issues. Read-only, one level deep (#3289)." >&2
+echo "============================================================================" >&2
+
+if [[ ! -f "${WORKFLOW_JS}" ]]; then
+  echo "judge-fanout-experiment: ERROR — sketch not found at ${WORKFLOW_JS}" >&2
+  exit 1
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "judge-fanout-experiment: node not found — skipping syntax check." >&2
+else
+  # The workflow body legitimately uses top-level await/return, which the Claude
+  # Code workflow VM parses with allowReturnOutsideFunction/allowAwaitOutsideFunction.
+  # To validate it faithfully WITHOUT executing it, wrap the body in an async
+  # function and compile (never run) it via vm.Script.
+  if node -e '
+    const fs = require("fs");
+    const vm = require("vm");
+    const body = fs.readFileSync(process.argv[1], "utf8");
+    // Compile-only: wrapping makes top-level await/return valid; we never run it.
+    new vm.Script("(async () => {\n" + body + "\n})", { filename: process.argv[1] });
+    console.error("judge-fanout-experiment: sketch syntax OK (compiled, not executed).");
+  ' "${WORKFLOW_JS}"; then
+    :
+  else
+    echo "judge-fanout-experiment: ERROR — sketch failed to compile." >&2
+    exit 1
+  fi
+fi
+
+cat >&2 <<'GUIDE'
+
+To run the (deferred) live prototype — from a TOP-LEVEL Claude Code session only:
+  1. Copy judge-fanout-workflow.js into a discovered workflows/ directory
+     (user or project settings), OR invoke it directly with the Workflow tool:
+       Workflow({ scriptPath: "<abs path to judge-fanout-workflow.js>",
+                  args: { pr: <N>, diff: "<unified diff text>" } })
+  2. Do this from a top-level session (NOT a subagent), so the workflow's
+     agent()/parallel() calls are the first nesting level (#3289-safe).
+  3. Compare its verdict/findings against today's single-pass Judge on a fixed
+     3-5 PR corpus (precision / recall / latency / token cost). Record RAW
+     results — do not fabricate numbers.
+
+This script intentionally stops here: it does NOT dispatch a live judge run.
+GUIDE
+
+exit 0

--- a/defaults/scripts/experiments/judge-fanout-workflow.js
+++ b/defaults/scripts/experiments/judge-fanout-workflow.js
@@ -1,0 +1,221 @@
+/**
+ * judge-fanout-workflow.js — DESIGN SKETCH (issue #3739, exploration only)
+ * =========================================================================
+ *
+ * A Claude Code Dynamic Workflow that reviews ONE pull request by fanning out
+ * dimension-scoped reviewers, running a typed adversarial "verify" pass, and
+ * reducing to a single schema-shaped verdict.
+ *
+ * STATUS: DESIGN SKETCH — NOT WIRED INTO PRODUCTION.
+ *   - This file is intentionally placed under defaults/scripts/experiments/,
+ *     which is NOT a discovered `workflows/` directory, so Claude Code will not
+ *     auto-load it. It is inert until a human deliberately copies/points a
+ *     top-level session at it (see defaults/scripts/experiments/README.md).
+ *   - It is NOT referenced by defaults/.claude/commands/loom/sweep.md or
+ *     defaults/roles/judge.md. The production judge path is untouched.
+ *   - The runnable prototype + measured comparison are DEFERRED to a follow-up
+ *     (see docs/research/dynamic-workflows-evaluation.md → "What is deferred").
+ *
+ * SUBSTRATE: in-session, single-token, exactly ONE level deep (#3289).
+ *   - `agent()` calls below are DIRECT — this workflow never calls `workflow()`,
+ *     so it adds no second nesting level. The CLI itself rejects nested
+ *     workflow() calls; we also avoid them by construction.
+ *   - All agents share the session's single OAuth token. This workflow makes NO
+ *     claim to multi-account rotation — that is a loom-daemon + spawn-claude.sh
+ *     concern and lives on the other side of the substrate boundary.
+ *
+ * READ-ONLY / SIDE-EFFECT-FREE by construction:
+ *   - Returns a verdict object. Applies NO labels, merges NOTHING, transitions
+ *     no loom:pr / loom:changes-requested state, creates NO GitHub issues.
+ *   - The caller (a future runnable prototype) decides what, if anything, to do
+ *     with the verdict. During the experiment, the answer is "just record it".
+ *
+ * API: written against Claude Code CLI v2.1.206, whose workflow VM injects the
+ * globals `agent`, `parallel`, `pipeline`, `workflow`, `budget`, `args`,
+ * `console`, `log`, `phase`. There is NO `verify()` primitive; the adversarial
+ * verify pass is an `agent()` call with a schema (confirmed against 2.1.206).
+ *
+ * Expected `args` shape (passed via the Workflow tool's `args`):
+ *   {
+ *     pr: number,             // PR number under review (for labeling only)
+ *     diff: string,           // the unified diff text to review
+ *     dimensions?: string[],  // optional override of the default dimension set
+ *   }
+ *
+ * @workflow-meta (illustrative — the real meta header format is owned by the
+ * CLI's workflow-discovery loader; reproduced here as documentation only):
+ *   name: judge-fanout-experiment
+ *   description: Multi-dimension PR review fan-out + adversarial verify (experiment #3739)
+ *   whenToUse: Experiment only — never on the production sweep/judge path.
+ */
+
+/* eslint-disable no-undef */ // agent/parallel/budget/args are workflow-VM globals.
+
+// --- Configuration ----------------------------------------------------------
+
+const DEFAULT_DIMENSIONS = [
+  "correctness",
+  "security-credential-surface",
+  "test-coverage",
+  "perf-simplification",
+];
+
+// A finding a dimension reviewer emits. `evidenceLine` anchors the claim to the
+// diff so the adversarial pass can check it is actually supported.
+const FINDINGS_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["findings"],
+  properties: {
+    findings: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["severity", "dimension", "claim", "evidenceLine"],
+        properties: {
+          severity: { type: "string", enum: ["blocker", "major", "minor", "nit"] },
+          dimension: { type: "string" },
+          claim: { type: "string" },
+          evidenceLine: {
+            type: "string",
+            description: "The diff hunk header or line the claim rests on.",
+          },
+        },
+      },
+    },
+  },
+};
+
+// The adversarial pass re-emits each finding with a diffSupported verdict.
+const VERIFIED_FINDINGS_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["findings"],
+  properties: {
+    findings: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["severity", "dimension", "claim", "diffSupported", "reason"],
+        properties: {
+          severity: { type: "string", enum: ["blocker", "major", "minor", "nit"] },
+          dimension: { type: "string" },
+          claim: { type: "string" },
+          diffSupported: {
+            type: "boolean",
+            description: "True only if the diff actually contains evidence for the claim.",
+          },
+          reason: { type: "string", description: "Why the claim is / isn't supported." },
+        },
+      },
+    },
+  },
+};
+
+// --- Prompt builders (kept trivial — the real prompts would be fuller) ------
+
+function reviewPrompt(dimension, diff) {
+  return [
+    `You are a code reviewer scoped to exactly ONE dimension: "${dimension}".`,
+    `Review ONLY through that lens. Ignore issues outside your dimension.`,
+    `For every finding, cite the diff hunk header or line it rests on (evidenceLine).`,
+    `Do not invent issues; if the diff is clean for your dimension, return no findings.`,
+    ``,
+    `DIFF:`,
+    diff,
+  ].join("\n");
+}
+
+function verifyPrompt(rawFindings, diff) {
+  return [
+    `You are an ADVERSARIAL verifier. For each finding below, decide whether the`,
+    `DIFF actually supports it (diffSupported=true) or whether it is an unverified`,
+    `nit / hallucination / out-of-scope remark (diffSupported=false). Be strict:`,
+    `a finding is supported ONLY if the cited evidence is really in the diff.`,
+    ``,
+    `FINDINGS:`,
+    JSON.stringify(rawFindings, null, 2),
+    ``,
+    `DIFF:`,
+    diff,
+  ].join("\n");
+}
+
+// --- The workflow body ------------------------------------------------------
+//
+// A top-level `return` is how a workflow script yields its result to the
+// Workflow tool. (Workflow scripts run in a VM where top-level await + return
+// are allowed — see CLI 2.1.206.)
+
+const dimensions = Array.isArray(args?.dimensions) && args.dimensions.length
+  ? args.dimensions
+  : DEFAULT_DIMENSIONS;
+
+// Guard: this sketch is single-PR and single-token. Refuse absurd fan-outs so a
+// mis-call can't blow the shared budget. (budget is a shared HARD ceiling in
+// 2.1.206; agent() throws once it is exhausted anyway — this is belt-and-braces.)
+if (dimensions.length > 8) {
+  throw new Error(
+    `judge-fanout: ${dimensions.length} dimensions requested; cap is 8 (single-PR, single-token experiment).`,
+  );
+}
+
+// 1. FAN OUT — one reviewer per dimension. Direct agent() calls => exactly one
+//    level deep. parallel() is a BARRIER: it awaits all reviewers.
+const rawFindings = (
+  await parallel(
+    dimensions.map((dim) => () =>
+      agent(reviewPrompt(dim, String(args?.diff ?? "")), {
+        label: `review:${dim}`,
+        phase: "review", // explicit phase group avoids racing the global phase()
+        // #3705 note: effort IS recoverable in-session (agent accepts opts.effort);
+        // correctness gets the highest tier, the rest medium.
+        effort: dim === "correctness" ? "high" : "medium",
+        schema: FINDINGS_SCHEMA,
+      }),
+    ),
+  )
+)
+  // agent() returns null if the user skips it or it dies terminally — filter those.
+  .filter(Boolean)
+  .flatMap((r) => (r && Array.isArray(r.findings) ? r.findings : []));
+
+// Short-circuit: nothing to verify.
+if (rawFindings.length === 0) {
+  return {
+    pr: args?.pr ?? null,
+    verdict: "approve",
+    findings: [],
+    dimensionsCovered: dimensions,
+    note: "no findings from any dimension reviewer",
+  };
+}
+
+// 2. ADVERSARIAL VERIFY — an agent() with a schema (NOT a verify() primitive).
+//    Drops findings the diff doesn't actually support.
+const verifyResult = await agent(verifyPrompt(rawFindings, String(args?.diff ?? "")), {
+  label: "adversarial-verify",
+  phase: "verify",
+  effort: "high",
+  schema: VERIFIED_FINDINGS_SCHEMA,
+});
+
+const verified = ((verifyResult && verifyResult.findings) || []).filter(
+  (f) => f && f.diffSupported === true,
+);
+
+// 3. TYPED REDUCE — plain JS. No free-text/label parsing. READ-ONLY: we return a
+//    verdict; we apply nothing to the PR.
+const hasBlocker = verified.some((f) => f.severity === "blocker" || f.severity === "major");
+
+return {
+  pr: args?.pr ?? null,
+  verdict: hasBlocker ? "changes-requested" : "approve",
+  findings: verified,
+  droppedUnverified: rawFindings.length - verified.length,
+  dimensionsCovered: dimensions,
+  // NOTE: the caller decides what to do with this. This workflow merges nothing,
+  // labels nothing, and creates no issues — it is a review-quality experiment.
+};

--- a/docs/research/dynamic-workflows-evaluation.md
+++ b/docs/research/dynamic-workflows-evaluation.md
@@ -1,0 +1,350 @@
+# Evaluating Claude Code Dynamic Workflows for Loom's in-session orchestration
+
+> Status: **exploration deliverable** (issue #3739). This document is an evaluation
+> plus a design sketch. It does **not** rewrite the production sweep/judge path, and it
+> files **no** GitHub issues — recommended follow-ups are *listed* at the end for a
+> human/Curator to file. See "Scope and non-goals".
+
+## TL;DR
+
+- **Feasibility gate: PASS (capability present).** The Dynamic Workflows primitives
+  (`agent()`, `parallel()`, `pipeline()`, nested `workflow()`, a shared `budget`, typed
+  `args`, JSON-Schema-validated agent outputs, journal-based resume) are **shipped in the
+  installed Claude Code CLI, v2.1.206** — confirmed by direct inspection of the CLI binary
+  (see "Feasibility gate"). This is *not* a hypothetical future capability.
+- **But the runnable prototype + measured comparison are DEFERRED** to a follow-up. The
+  reason is not that the primitives are missing — they are present — but that the *only*
+  legitimate way to exercise them here (a top-level Claude Code session invoking the
+  `Workflow` tool) is not available to the Builder harness that produced this document (a
+  `loom-builder` Task subagent, which does not expose the `Workflow` tool and could not
+  drive it without violating the #3289 one-level-deep rule). Honest precision/recall/latency
+  numbers require a top-level session and a fixed PR corpus; fabricating them here would be
+  worse than deferring. **No measurement numbers are invented in this document.**
+- **What ships under #3739:** this evaluation + a **design sketch** of the recommended
+  first prototype (multi-dimension Judge fan-out + adversarial verify), gated behind an
+  off-by-default `LOOM_JUDGE_FANOUT_EXPERIMENT` flag, kept strictly separate from the
+  production judge path. See `defaults/scripts/experiments/`.
+- **The load-bearing conclusion — the substrate boundary:** a Dynamic Workflow is an
+  **in-session, single-token** construct. It can make the *read-heavy, one-level-deep*
+  parts of Loom's orchestration deterministic and testable (review fan-out, triage
+  classification, proposal analysis). It **cannot** replace `loom-daemon` +
+  `spawn-claude.sh`, because multi-account token rotation requires a per-task **process**
+  spawn, and in-process workflow agents inherit the parent session's single OAuth token.
+  **A workflow is not a daemon replacement.**
+
+---
+
+## Scope and non-goals
+
+Per the issue's Curator guardrails, this deliverable is deliberately bounded:
+
+- **Does NOT** modify, fork, or wire anything into the production orchestration
+  (`defaults/.claude/commands/loom/sweep.md`, `defaults/.claude/commands/loom/judge.md`,
+  `defaults/roles/judge.md`). Those were read for reference only.
+- **Does NOT** run `gh issue create` or decompose #3739 into sub-issues. The final
+  acceptance-criteria bullet ("follow-up issues filed for surfaces recommended to proceed")
+  is satisfied by the **listed** recommendations in "Recommended follow-ups (to be filed by
+  a human/Curator)" below — not by autonomous filing (which would itself risk the #3707
+  issue-number race the issue flags as a hazard).
+- **Stays one level deep (#3289)** and read-only with respect to other work's labels/PRs.
+- The prototype is a **review-quality experiment**, never a production judge run: it merges
+  nothing, applies no `loom:pr` / `loom:changes-requested` transitions, and creates no
+  issues.
+
+---
+
+## Feasibility gate
+
+The issue's Curator notes require confirming the primitives actually exist in the
+currently-installed `claude` before designing against them, with two sanctioned outcomes
+(available → full scope; not available → reduced v1 = evaluation + design sketch + explicit
+deferral). The reality found here is a **third, sharper** case, documented honestly below.
+
+### What was checked
+
+Installed CLI: **`claude` v2.1.206** (`/opt/homebrew/Caskroom/claude-code/2.1.206/claude`,
+a single compiled binary). The binary's embedded strings were inspected for the workflow
+runtime and its documented tool surface. The following were **positively confirmed present**
+(quotations are from the binary's own embedded tool documentation and runtime code):
+
+| Primitive | Confirmed signature / behavior (from CLI 2.1.206) |
+|---|---|
+| `agent(prompt, opts?)` | "spawn a subagent. Without schema, returns its final text as a string. With schema (a JSON Schema), the subagent is forced to call a StructuredOutput tool and `agent()` returns the validated object — no parsing needed. Returns `null` if the user skips the agent mid-run or the subagent dies on a terminal API error after retries (filter with `.filter(Boolean)`)." `opts` includes `label`, `phase`, `schema`, `model`, `effort` (`'low'|'medium'|'high'|'xhigh'|'max'`), `isolation: 'worktree'`, `agentType`. |
+| `parallel(thunks)` | "run tasks concurrently. This is a BARRIER: awaits all thunks before returning." A thunk that throws resolves to an error sentinel rather than rejecting the batch. |
+| `pipeline(items, stage1, stage2, …)` | "run each item through all stages independently, NO barrier between stages … Wall-clock = slowest single-item chain, not sum-of-slowest-per-stage." Each stage callback receives `(prevResult, originalItem, index)`. |
+| `workflow(name \| {scriptPath})` | Invokes a named/bundled child workflow — **and enforces one-level nesting itself**: calling `workflow()` from inside a child workflow throws *"workflow() cannot be called from within a child workflow — nesting is limited to one level. Inline the inner script or call its agents directly."* |
+| `budget` | `{total: number\|null, spent(): number, remaining(): number}` — "a HARD ceiling, not advisory: once `spent()` reaches `total`, further `agent()` calls throw." The pool is **shared** across the main loop and all workflows, not per-workflow. |
+| `args` | Typed workflow input, passed verbatim as a real JSON value. |
+| Schema-validated output | Passing `opts.schema` (a JSON Schema) forces a `StructuredOutput` tool call and returns the validated object. |
+| Native resume | Journal-backed: `Workflow({scriptPath, resumeFromRunId: "…"})`; the tool "automatically persists its script to a file under the session directory and returns the path in the tool result." |
+| Discovery | Workflow `.js` files with a meta header (`name`, `description`, `whenToUse`, `phases`) are discovered from `workflows/` directories under user/project settings. |
+
+Two findings that **correct or sharpen the issue's assumptions**:
+
+1. **There is no dedicated `verify()` primitive.** The workflow VM binds exactly four
+   control-flow globals: `agent`, `parallel`, `pipeline`, `workflow`. The "`verify()` /
+   adversarial pass" the issue lists as a first-class primitive is, in the shipped API, a
+   **pattern composed from `agent()` + a schema** (an adversarial reviewer agent that takes
+   the raw findings + the diff and returns a typed, filtered set) — not a built-in. The
+   design sketch reflects this: verify is an `agent()` call, not a `verify()` call.
+2. **`agent()` exposes `effort` directly.** The issue's Risks section assumes the #3705
+   effort-plumbing degradation ("`@effort` rungs stay degraded unless the workflow spawns a
+   process") carries over. It does **not** fully: an in-process `agent()` call accepts
+   `opts.effort` (`'low'…'max'`), so the effort dimension is *recoverable* inside a
+   workflow in a way it is not through the bare Task tool. What a workflow still **cannot**
+   do is multi-account **model/token rotation** — that remains a process-spawn concern (see
+   substrate boundary). So #3705 is *partially mitigated* for the in-session path, not
+   fixed at the substrate level.
+
+### Feasibility outcome for #3739
+
+- **Capability: available.** The primitives are shipped and usable from a top-level Claude
+  Code session in this environment.
+- **Runnable prototype in this PR: deferred — honestly.** The Builder that produced this
+  artifact is a Task subagent. It does not have the `Workflow` tool, and even if it did,
+  invoking it would spawn workflow agents at a *second* nesting level (subagent →
+  workflow-agent), which is exactly the #3289 stall the issue forbids. A truthful
+  measured comparison also needs a fixed corpus of already-merged/rejected PRs run under a
+  top-level session with token accounting — out of a single subagent's reach.
+- **Therefore this PR ships the sanctioned reduced-v1 shape** (evaluation + design sketch +
+  explicit deferral), but for a more precise reason than "primitives absent": *primitives
+  present, harness cannot honestly exercise them one level deeper.* The runnable prototype
+  and its measurement are a named follow-up below.
+
+---
+
+## Capability → need mapping
+
+How each shipped primitive maps to a concrete pain point in Loom's current prose-driven
+orchestration (the "control flow lives in Markdown the model re-executes every run"
+problem):
+
+| Dynamic Workflow capability | Loom need it addresses | Today (prose) | With a workflow |
+|---|---|---|---|
+| `pipeline()` sequential/independent composition | Per-issue lifecycle: curator → approve-gate → builder → judge → doctor-loop → merge | `sweep.md` prose the orchestrator LLM must execute correctly every invocation | Deterministic stage graph; per-item progress without a barrier |
+| `parallel()` fan-out (barrier) | Builder fan-out within a wave; multi-dimension review; multi-domain proposal analysis | Serialized, or "defer parallel to a future issue" | One concurrent barrier'd batch, bounded by the harness concurrency cap |
+| Schema-validated `agent()` output | PR-number extraction; Judge verdict parsing | `sed -n 's/.*pr_number.*'` over checkpoint JSON; verdicts parsed from free-text comments + labels | Typed object, no regex, no free-text parsing |
+| `agent()` + schema as an adversarial "verify" | Drop findings the diff doesn't support (fan-out-then-verify, as the repo's `deep-research` skill already ships) | Single Opus pass emits unverified nits | A second typed agent filters low-support findings |
+| Journal-based resume | Mid-phase-death recovery | Hand-rolled `sweep-checkpoint.sh` phase enum (`.loom/sweep-checkpoint/issue-N.json`) | Native resume — **but** interop with the existing checkpoint schema must be preserved (see Risks) |
+| `budget` (shared hard ceiling) | Cap large fan-outs; bound the doctor→judge loop | Attempt counter the model tracks by hand across kills | `while (budget.remaining() > X)`; provably bounded loop |
+| Ordinary JS arithmetic | Model-precedence chain; escalation ladder `ladder[min(attempt-1, len-1)]`; doctor-cycle cap; routing tables | Arithmetic-in-prose the model must get right every time | Plain, unit-testable code |
+
+The through-line: Loom already hand-rolls a large amount of exactly this orchestration in
+prose (most visibly the ~1600-line `sweep.md`). Every piece of arithmetic or routing that
+lives in Markdown is a surface the model can drift on. Workflows move the *deterministic*
+parts into deterministic code, leaving the model to do what only the model can (read a
+diff, judge a design), which is the right division of labor.
+
+---
+
+## The substrate boundary (the load-bearing conclusion)
+
+This is the single most important output of the evaluation, because it is where the
+enthusiasm has to stop.
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  IN-SESSION, SINGLE-TOKEN  (a Dynamic Workflow fits here)            │
+│  ── read-heavy, one-level-deep fan-out ──                           │
+│                                                                     │
+│   • Multi-dimension Judge review of ONE PR (parallel + verify)      │
+│   • Whole-backlog triage classification (pure-JS router)            │
+│   • Architect/Hermit read-only analysis fan-out (writes serialized) │
+│   • Model-cost experiment record-keeping (typed outputs)            │
+│                                                                     │
+│   Concurrency ceiling = harness cap min(16, cores-2); Loom's        │
+│   subagent wave band is [3,6] (#3693). ONE OAuth token for all.     │
+└─────────────────────────────────────────────────────────────────────┘
+                    ▲  a workflow lives INSIDE one sweep child (Tier 1)
+                    │
+════════════════════╪══════════ SUBSTRATE BOUNDARY ═══════════════════════
+                    │  crossing it requires a PROCESS spawn, not a subagent
+                    ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  DETACHED-PROCESS, MULTI-ACCOUNT  (only loom-daemon fits here)       │
+│  ── account-balanced building, up to ~10 concurrent ──             │
+│                                                                     │
+│   • spawn-claude.sh selects a token, exec's `claude` with           │
+│     CLAUDE_CODE_OAUTH_TOKEN exported → per-child account rotation    │
+│   • loom-daemon: registry, 30s reaper, tokio event bus (6 topics)   │
+│   • Rate-limit recovery by rotating to a fresh account               │
+│                                                                     │
+│   A workflow's in-process agent() inherits the parent's ONE token — │
+│   it CANNOT provide account-balanced concurrency. NOT a replacement.│
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+Why the boundary is hard, not soft:
+
+- **Token rotation is a process-spawn property.** `spawn-claude.sh` picks a token from
+  `.loom/tokens/` and `exec`s `claude` with `CLAUDE_CODE_OAUTH_TOKEN` set. An in-process
+  workflow `agent()` runs in the *same* process and inherits the *same* single token —
+  identically to a Task subagent. So a workflow tops out at the single-token subagent
+  concurrency band (`[3,6]`, #3693), never the daemon's account-balanced ~10.
+- **Two orchestration substrates is a real cost.** `loom-daemon` (Rust: registry, reaper,
+  tokio broadcast bus, 6 frozen topics) is the load-bearing Tier-2 backend. A JS workflow
+  runtime is a *second* dispatch substrate; letting it grow registry/reaper/dispatch logic
+  would duplicate the daemon and risk the "do not write `.loom/daemon-state.json`"
+  coexistence rule. The clean fit is a workflow **inside a single sweep child** (Tier 1),
+  observed by the daemon through the existing checkpoint — never a daemon replacement.
+- **Checkpoint interop is mandatory.** `.loom/sweep-checkpoint/issue-N.json` (#3373) is
+  shared between the sweep skill and the daemon reaper/resume path. A workflow's native
+  journal resume must stay **bidirectionally compatible** with that checkpoint, or the
+  daemon can no longer observe/resume a workflow-driven sweep.
+
+**Rule of thumb for any future adoption:** put a workflow *inside* a sweep child to make
+that child's read-heavy fan-out deterministic; never let a workflow become the thing that
+dispatches sweep children across accounts. That job stays on `loom-daemon` +
+`spawn-claude.sh`.
+
+---
+
+## Keep / defer / reject — the five candidate surfaces
+
+Each verdict is tied to the specific risk(s) that gate it: **nesting** (#3289), **token
+rotation** (single-token substrate), **#3707 filing race**, **checkpoint interop** (#3373),
+**effort degradation** (#3705).
+
+| # | Surface | Verdict | Gating risk(s) | One-paragraph rationale |
+|---|---|---|---|---|
+| 1 | **Judge phase** — multi-dimension review fan-out + adversarial verify (`defaults/roles/judge.md`, `sweep.md` step 5) | **KEEP** (prototype first) | nesting ✔ satisfied; token ✔ single-token-friendly; #3707 n/a (no filing); checkpoint n/a (no sweep-state write); effort ✔ recoverable via `agent(opts.effort)` | The best first target and the one this PR sketches. It is read-only, single-token-friendly, exactly one level deep (dispatch dimension reviewers directly — never a sub-workflow), creates no issues, and produces a clean typed verdict that would feed the doctor-cycle loop without label+comment string parsing. Fan-out across correctness / security-credential-surface / test-coverage / perf-simplification, then a typed adversarial `agent()` that drops findings the diff doesn't support, then a schema-validated reduce to approve/changes-requested. It exercises `parallel()` + schema + the verify pattern with zero exposure to the daemon, the filing race, or checkpoint interop. It **preserves** the No-Fable-Judge invariant and sequential-within-wave merge ordering: only the review of *one* PR is parallelized. |
+| 2 | **Doctor→Judge escalation loop** — bounded rejection loop (`sweep.md` steps 6/C1b, `defaults/roles/doctor.md`) | **DEFER** (after #1 lands) | checkpoint interop (primary); nesting; effort | This is the most arithmetic-heavy prose in the skill — attempt counter across kills, ladder indexing `ladder[min(attempt-1,len-1)]`, the single-use distinct-defect grace cycle, "refusal must not eat the cap". A `budget`-bounded loop with a typed verdict is a genuinely good fit and would make the loop provably bounded and resume-safe. It is deferred, not kept, purely because it **writes sweep state**: the loop's resume must stay bidirectionally compatible with `.loom/sweep-checkpoint/issue-N.json` (#3373), which the daemon reaper also reads. That interop contract has to be designed and tested before this can be trusted, and it should build on the typed-verdict shape proven by #1. Effort rungs are recoverable via `agent(opts.effort)`, but model-tier rotation on escalation still needs care (single-token substrate). |
+| 3 | **Whole-backlog triage** — `/sweep all` routing classifier (`defaults/roles/guide.md`) | **DEFER** (strong, independent) | token rotation (for the *build* legs); #3707 (if it fans out issue-creating classes); nesting | The routing taxonomy (loom:issue→build, loom:curated→promote, uncurated→curate, stale loom:building→reclaim, loom:blocked→probe, loom:epic→fan-out, has-open-PR→judge/merge, loom:operator-only→skip) is already fully deterministic prose — an ideal pure-JS classifier that yields schema-checked routing, a reproducible dry-run plan, and a hard budget, while keeping the mandatory confirmation gate and the loom:operator-only hard exclusion. It is deferred rather than kept because the *classifier* is in-session-safe but the *building* legs it routes to must still cross the substrate boundary to `loom-daemon` for multi-account concurrency, and any class that fans out issue creation (epic fan-out) hits #3707. Right shape: workflow classifies + plans (in-session), daemon builds (multi-account). Sequence it after #1 proves the typed-output ergonomics. |
+| 4 | **Architect / Hermit proposal generation** — fan-out reads, serialize writes (`defaults/roles/architect.md`, `hermit.md`, +#3707) | **DEFER** (blocked on #3707) | #3707 filing race (primary); nesting | A workflow resolves the #3707 tension *structurally*: `parallel()` the read-only analysis agents (architecture, dedup, test-gaps, deps, security, simplification), then a **single serialized** reduce that files via `gh issue create` one at a time behind a filing lock — "fan out reads, serialize writes" becomes an enforced control-flow boundary instead of a documented convention. This is architecturally attractive, but it is deferred because it is *gated on* #3707's resolution: the whole value proposition is disciplining concurrent issue creation, and #3739 itself is explicitly forbidden from filing issues, so this cannot be prototyped end-to-end here. Keep it queued behind #3707 and behind the typed-output patterns from #1. |
+| 5 | **Model-cost A/B experiment (#3725)** — fold arm assignment + per-phase record into the workflow (`defaults/scripts/sweep-experiment.sh`, `sweep-model-stats.jsonl`) | **REJECT** (for now) | checkpoint interop; token fidelity | The #3725 machinery already lives in Python (`sweep_experiment`) precisely so arm assignment is byte-for-byte deterministic and resume-safe, and its cost signal is recovered at harvest time from per-subagent transcripts — a path that a workflow's typed output does **not** improve and might *degrade* (the workflow does not surface per-subagent `usage` at the Task boundary any better than today). Folding arm/record-keeping into a workflow would re-implement working, tested, resume-safe code with no measurable win and new checkpoint-interop surface. Reject unless/until a workflow is *already* driving the sweep for other reasons (#2), at which point the records "fall out of control flow" for free — revisit only then. |
+
+Summary: **1 keep (prototype), 3 defer (sequenced), 1 reject.** Nothing lands in production
+under #3739.
+
+---
+
+## The design sketch (recommended prototype #1)
+
+A runnable version is deferred (see Feasibility gate). The design is captured as an
+**inert, off-by-default** artifact so a future top-level session can pick it up:
+
+- `defaults/scripts/experiments/judge-fanout-workflow.js` — the workflow script itself,
+  written against the confirmed CLI 2.1.206 API (`parallel()` of dimension reviewers →
+  adversarial `agent()`-with-schema verify → typed reduce). It is a **design sketch**: it
+  is not wired into `sweep.md`/`judge.md`, it lives outside any auto-discovered `workflows/`
+  directory, and it is documented as read-only / one-level-deep / creates-no-issues.
+- `defaults/scripts/experiments/judge-fanout-experiment.sh` — an off-by-default gate/runner.
+  Without `LOOM_JUDGE_FANOUT_EXPERIMENT=1` it is a **no-op** that prints how to run the
+  experiment and exits 0 (this is the smoke test: flag off ⇒ nothing happens). With the
+  flag set it syntax-checks the sketch and explains the top-level-session invocation path —
+  it deliberately does **not** attempt to dispatch a live judge run from a subagent context.
+- `defaults/scripts/experiments/README.md` — what these files are, the flag contract, the
+  precedent they follow (`LOOM_MODEL_EXPERIMENT` / `sweep.modelExperiment`, off by default,
+  loud banner), and the explicit deferral.
+
+### Flag contract (follows the `LOOM_MODEL_EXPERIMENT` precedent)
+
+- **Off by default.** No env var, no behavior. Byte-for-byte unchanged production path.
+- `LOOM_JUDGE_FANOUT_EXPERIMENT=1` opts in to the *experiment tooling* only (syntax-check +
+  guidance). It never touches production judge code, never applies labels, never merges.
+- The flag is an in-session experiment switch, exactly like `sweep.modelExperiment`'s
+  `observe`/`experiment` modes are off-by-default and loudly banner'd.
+
+### Sketch shape (pseudocode, mirrors the shipped `.js`)
+
+```js
+// meta: name, description, whenToUse — discovered only if placed under a workflows/ dir.
+// args: { pr: <number>, diff: <string>, dimensions?: [...] }
+const DIMENSIONS = [
+  "correctness", "security-credential-surface", "test-coverage", "perf-simplification",
+];
+
+// 1. FAN OUT — one reviewer per dimension, exactly one level deep (direct agent() calls,
+//    never a nested workflow()). Barrier: parallel() awaits all.
+const rawFindings = await parallel(
+  DIMENSIONS.map((dim) => () =>
+    agent(reviewPrompt(dim, args.diff), {
+      label: `review:${dim}`,
+      phase: "review",
+      effort: dim === "correctness" ? "high" : "medium", // #3705 recoverable in-session
+      schema: FINDINGS_SCHEMA, // typed: [{severity, dimension, claim, evidenceLine}]
+    }),
+  ),
+).then((r) => r.filter(Boolean).flat()); // .filter(Boolean): agent() may return null
+
+// 2. ADVERSARIAL VERIFY — NOT a verify() primitive; an agent() that drops unsupported
+//    findings. Typed in, typed out.
+const verified = await agent(verifyPrompt(rawFindings, args.diff), {
+  label: "adversarial-verify",
+  phase: "verify",
+  effort: "high",
+  schema: VERIFIED_FINDINGS_SCHEMA, // [{...finding, diffSupported: boolean, reason}]
+}).then((v) => (v ?? []).filter((f) => f.diffSupported));
+
+// 3. TYPED REDUCE — plain JS, no free-text/label parsing. Read-only: returns a verdict,
+//    applies NOTHING to the PR.
+return {
+  pr: args.pr,
+  verdict: verified.some((f) => f.severity === "blocker") ? "changes-requested" : "approve",
+  findings: verified,
+  dimensionsCovered: DIMENSIONS,
+}; // caller decides what to do — the workflow itself merges/labels nothing.
+```
+
+Invariants the sketch preserves by construction: **one level deep** (no `workflow()` call
+inside; dimension reviewers are direct `agent()` calls); **read-only** (returns a verdict
+object, performs no label/PR/merge action); **no issue creation**; **single-token-safe**
+(all `agent()` calls share the session token — no rotation claimed).
+
+---
+
+## What is deferred (explicitly)
+
+1. **The runnable prototype.** Place `judge-fanout-workflow.js` under a discovered
+   `workflows/` directory (or invoke via `Workflow({scriptPath})`) from a **top-level**
+   Claude Code session — not a subagent — so its `agent()`/`parallel()` calls are the first
+   nesting level (#3289-safe).
+2. **The measured comparison.** Against a fixed set of 3–5 already-merged/rejected PRs,
+   measure precision (unverified-nit rate), recall (dimensions caught), latency, and token
+   cost versus today's single-pass Judge. Document methodology **and raw results** (not just
+   conclusions). This document intentionally contains **no** such numbers — none have been
+   measured, and none are fabricated.
+
+---
+
+## Recommended follow-ups (to be filed by a human/Curator — NOT filed here)
+
+Listed with enough detail to file later. Filing is a human/Curator decision (autonomous
+filing here would risk the #3707 race the issue itself flags).
+
+1. **Prototype + measure the Judge fan-out workflow (KEEP surface #1).** Promote
+   `judge-fanout-workflow.js` from sketch to runnable behind `LOOM_JUDGE_FANOUT_EXPERIMENT`;
+   run it from a top-level session against a 3–5 PR corpus; record precision/recall/latency/
+   cost vs. the single-pass Judge. Acceptance: a measured table + a keep/kill call. Depends
+   on: nothing (self-contained, read-only). *This is the direct continuation of #3739.*
+2. **Design the checkpoint-interop contract for a workflow-driven Doctor→Judge loop (DEFER
+   surface #2).** Specify how a workflow's journal resume maps onto
+   `.loom/sweep-checkpoint/issue-N.json` (#3373) so the daemon reaper can still observe/
+   resume it. Depends on: #1's typed-verdict shape.
+3. **Prototype the `/sweep all` triage classifier as a pure-JS workflow (DEFER surface
+   #3).** Classifier + dry-run plan in-session; building legs still route to `loom-daemon`.
+   Must keep the confirmation gate and the loom:operator-only exclusion. Depends on: #1;
+   coordinate with #3707 for any epic-fan-out class.
+4. **After #3707 resolves, prototype fan-out-reads/serialize-writes for Architect/Hermit
+   (DEFER surface #4).** The serialized-`gh issue create`-behind-a-lock reduce is the whole
+   point; blocked on #3707. Depends on: #3707.
+5. **(Only if #2 lands) revisit folding the #3725 model-cost record-keeping into the
+   workflow (REJECT-for-now surface #5).** Revisit *only* once a workflow already drives the
+   sweep; otherwise leave the tested Python path alone.
+
+---
+
+## References (read-only)
+
+- `defaults/.claude/commands/loom/sweep.md` — the ~1600-line prose orchestrator (read for
+  the lifecycle, escalation ladder, doctor-cycle cap, checkpoint convention).
+- `defaults/roles/judge.md`, `defaults/.claude/commands/loom/judge.md` — Judge dimensions
+  and the No-Fable-Judge invariant (design reference for surface #1).
+- `CLAUDE.md` → "Model-Cost Experiment" / "Model Selection Strategy" — the
+  `LOOM_MODEL_EXPERIMENT` / `sweep.modelExperiment` off-by-default flag precedent this
+  prototype's flag follows, and the escalation-ladder / doctor-cycle-cap arithmetic that
+  DEFER surface #2 would move into code.
+- `defaults/scripts/sweep-experiment.sh` — the existing Python-backed experiment stub
+  (context for REJECT surface #5).
+- CLI **v2.1.206** binary — source of the confirmed primitive signatures in "Feasibility
+  gate".


### PR DESCRIPTION
Closes #3739

## What this is

An **exploration deliverable** for #3739 — an evaluation of Claude Code's Dynamic
Workflows against Loom's prose-driven orchestration, plus an off-by-default design
sketch of the recommended first prototype. **No production change**: the sweep/judge
path is untouched, and **no GitHub issues were created**.

## Feasibility gate outcome (checked first, per Curator notes)

**Capability: PRESENT.** The Dynamic Workflows primitives — `agent()`, `parallel()`,
`pipeline()`, nested `workflow()`, a shared hard `budget`, typed `args`, JSON-Schema
agent outputs, journal-based resume — are **shipped in the installed CLI, v2.1.206**,
confirmed by direct inspection of the CLI binary. Two findings sharpen the issue's
assumptions and are documented: (1) there is **no dedicated `verify()` primitive** — the
adversarial pass is composed from `agent()` + a schema; (2) `agent()` exposes `effort`
directly, so the #3705 effort degradation is *partially recoverable in-session*.

## Delivered

- `docs/research/dynamic-workflows-evaluation.md` — feasibility gate (with the confirmed
  2.1.206 API surface), capability→need mapping, the **substrate boundary** (in-session
  single-token read-heavy fan-out vs `loom-daemon` + `spawn-claude.sh` multi-account
  building — a workflow is **not** a daemon replacement), and a **keep / defer / reject**
  verdict for all five candidate surfaces, each tied to the specific gating risk (#3289
  nesting, token rotation, #3707 filing race, #3373 checkpoint interop, #3705 effort).
  Verdicts: **1 keep** (Judge fan-out), **3 defer** (Doctor→Judge loop, `/sweep all`
  classifier, Architect/Hermit fan-out), **1 reject** (fold #3725 into a workflow).
- `defaults/scripts/experiments/judge-fanout-workflow.js` — design-sketch workflow written
  against the confirmed API (`parallel()` dimension reviewers → typed adversarial verify →
  typed reduce). Read-only, one level deep, creates no issues, single-token-safe. Not in a
  discovered `workflows/` dir, so the CLI does not auto-load it.
- `defaults/scripts/experiments/judge-fanout-experiment.sh` — off-by-default gate/runner
  (`LOOM_JUDGE_FANOUT_EXPERIMENT`, following the `LOOM_MODEL_EXPERIMENT` precedent).
- `defaults/scripts/experiments/README.md` — flag contract + guardrails.

## Deferred (stated explicitly, no fabricated numbers)

The **runnable prototype** and its **measured comparison** (precision / recall / latency /
token cost vs. today's single-pass Judge) are deferred to a follow-up. Not because the
primitives are missing — they are present — but because the only honest way to exercise
them is a **top-level** Claude Code session invoking the `Workflow` tool. The Builder here
is a `loom-builder` Task subagent, which has no `Workflow` tool and could not drive it
without a second nesting level (#3289). The eval doc lists five follow-ups for a
human/Curator to file (issue filing intentionally left to them, per the #3707 hazard).

## Verification

- `bash -n` clean; `judge-fanout-workflow.js` compiles under `vm.Script` (wrapped for its
  top-level await/return, exactly as the workflow VM parses it).
- Smoke test: flag **off** ⇒ no-op exit 0; flag **on** ⇒ loud banner + syntax OK + guidance,
  dispatches **no** live judge run.
- Confirmed: no GitHub issues created, no labels/PRs of other work touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)