### PR TITLE
fix(tokens): rotate account + retry on session/usage-limit fault instead of dying (#3738)

### DIFF
--- a/defaults/scripts/claude-wrapper.sh
+++ b/defaults/scripts/claude-wrapper.sh
@@ -73,6 +73,30 @@ TERMINAL_ID="${LOOM_TERMINAL_ID:-}"
 # Note: WORKSPACE may fail if CWD is invalid at startup - recover_cwd handles this
 WORKSPACE="${LOOM_WORKSPACE:-$(pwd 2>/dev/null || echo "$HOME")}"
 
+# Python interpreter + active-account tracking for account rotation (#3738).
+LOOM_PYTHON="${LOOM_PYTHON:-python3}"
+# The account name whose OAuth token is currently exported. spawn-claude.sh
+# exports LOOM_TOKEN_NAME before exec'ing this wrapper; when the wrapper is
+# invoked directly (token pre-set by some other caller) it is derived by
+# content-matching the token against the pool at rotation time.
+ACTIVE_TOKEN_NAME="${LOOM_TOKEN_NAME:-}"
+
+# Directory of this script — used to source the shared error classifier and to
+# locate the loom_tools package for the mark-bad / re-select calls (#3738).
+_WRAPPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source the shared error classifier so the wrapper's account-exhaustion
+# detection stays byte-identical to spawn-claude's classification — the two
+# patterns must NOT drift (issue #3738). Resolved relative to this script so it
+# works from both the installed .loom/scripts copy and the tracked
+# defaults/scripts source. If absent (older install), is_account_exhaustion
+# falls back to an inline regex.
+if [[ -f "${_WRAPPER_DIR}/lib/classify-error.sh" ]]; then
+    # shellcheck source=lib/classify-error.sh
+    # shellcheck disable=SC1091
+    source "${_WRAPPER_DIR}/lib/classify-error.sh"
+fi
+
 # Whether --dangerously-skip-permissions was passed (detected in main())
 SKIP_PERMISSIONS_MODE=false
 
@@ -842,6 +866,167 @@ is_transient_error() {
     return 1
 }
 
+# --- Account rotation on usage/session-limit exhaustion (issue #3738) ---
+#
+# When the active OAuth account hits a session / weekly / usage limit, the
+# right response is NOT to die (the historical behaviour: the RATE_LIMIT_ABORT
+# sentinel was classified fatal, killing the whole worker) and NOT to burn a
+# transient-backoff retry against the same, now-exhausted account. Instead we
+# mark the account exhausted, re-run Loom token selection (which now skips it),
+# and retry on a fresh account WITHOUT consuming a MAX_RETRIES attempt. The
+# pool is finite and each rotation marks one account bad, so this terminates:
+# when selection reports no eligible account we emit a distinct
+# ACCOUNT_POOL_EXHAUSTED sentinel and exit non-zero.
+
+# Return 0 if the captured output indicates the active account is exhausted.
+is_account_exhaustion() {
+    local output="$1"
+    local exit_code="${2:-1}"
+
+    # The output/startup monitors kill the CLI and emit this sentinel on the
+    # interactive usage/plan-limit modal and the 100%-weekly banner. Treat it
+    # as exhaustion regardless of what the classifier makes of the text.
+    if echo "${output}" | grep -q "RATE_LIMIT_ABORT"; then
+        return 0
+    fi
+
+    # Otherwise defer to the shared classifier (widened TOKEN_EXHAUSTED set).
+    # Fall back to an inline regex if the classifier lib was not sourced.
+    if declare -F classify_error >/dev/null 2>&1; then
+        [[ "$(classify_error "${output}" "${exit_code}")" == "TOKEN_EXHAUSTED" ]]
+        return
+    fi
+    [[ "${exit_code}" -ne 0 ]] && echo "${output}" \
+        | grep -qiE "hit your (limit|session limit|weekly limit)|hit\.your\.limit|monthly usage limit|out of extra usage"
+}
+
+# Echo a short human phrase describing why the account was considered
+# exhausted (used as the .bad_tokens reason string).
+_exhaustion_phrase() {
+    local output="$1"
+    if echo "${output}" | grep -q "RATE_LIMIT_ABORT"; then
+        echo "usage/plan limit modal (RATE_LIMIT_ABORT)"
+        return
+    fi
+    local m
+    m="$(echo "${output}" | grep -ioE "hit your (limit|session limit|weekly limit)|monthly usage limit|out of extra usage|used 100% of your weekly limit" | head -1)"
+    echo "${m:-usage limit}"
+}
+
+# Resolve the workspace whose .loom/tokens/ holds the account pool. Mirrors
+# spawn-claude.sh: LOOM_WORKSPACE wins, else the canonical repo root (so a
+# worktree shares the main checkout's token pool), else the wrapper's WORKSPACE.
+_resolve_token_workspace() {
+    if [[ -n "${LOOM_WORKSPACE:-}" ]]; then
+        printf '%s\n' "${LOOM_WORKSPACE}"
+        return
+    fi
+    local gcd
+    if gcd="$(git rev-parse --git-common-dir 2>/dev/null)"; then
+        [[ "${gcd}" = /* ]] || gcd="$(cd "${gcd}" && pwd 2>/dev/null || echo "${gcd}")"
+        printf '%s\n' "$(dirname "${gcd}")"
+        return
+    fi
+    printf '%s\n' "${WORKSPACE}"
+}
+
+# Resolve the loom_tools package source (for the mark_bad / select calls).
+# Script-relative first (repo layout), then $WORKSPACE fallback.
+_resolve_package_path() {
+    local ws="$1"
+    if [[ -n "${LOOM_PACKAGE_PATH:-}" ]]; then
+        printf '%s\n' "${LOOM_PACKAGE_PATH}"
+        return
+    fi
+    local rel
+    rel="$(cd "${_WRAPPER_DIR}/../../loom-tools/src" 2>/dev/null && pwd || echo "")"
+    if [[ -n "${rel}" && -d "${rel}/loom_tools/tokens" ]]; then
+        printf '%s\n' "${rel}"
+        return
+    fi
+    printf '%s\n' "${ws}/loom-tools/src"
+}
+
+# Fallback identification of the active account when LOOM_TOKEN_NAME is unset:
+# content-match the exported token against .loom/tokens/*.token. Deterministic
+# (exact content compare) — deliberately avoids lean-genius's `ls -t | head -1`
+# mtime heuristic, which mispicks the wrong account under concurrent spawns.
+_derive_token_name() {
+    local ws="$1" tok="$2"
+    [[ -n "${tok}" ]] || return 1
+    local tokens_dir="${ws}/.loom/tokens" f content
+    [[ -d "${tokens_dir}" ]] || return 1
+    for f in "${tokens_dir}"/*.token; do
+        [[ -e "${f}" ]] || continue
+        content="$(cat "${f}" 2>/dev/null)"
+        if [[ "${content}" == "${tok}" ]]; then
+            basename "${f}" .token
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Mark the active account exhausted in .loom/tokens/.bad_tokens, then re-run
+# Loom token selection (which now skips it) and re-export
+# CLAUDE_CODE_OAUTH_TOKEN. Reuses the existing Loom primitives
+# (loom_tools.tokens.bad_tokens.mark_bad + loom_tools.tokens.select) rather
+# than reimplementing lean-genius's raw file-glob. Returns 0 on success (a new
+# account is exported), 1 when the pool has no eligible account left.
+rotate_exhausted_account() {
+    local reason="$1"
+    local ws pkg
+    ws="$(_resolve_token_workspace)"
+    pkg="$(_resolve_package_path "${ws}")"
+
+    if [[ -z "${ACTIVE_TOKEN_NAME}" ]]; then
+        ACTIVE_TOKEN_NAME="$(_derive_token_name "${ws}" "${CLAUDE_CODE_OAUTH_TOKEN:-}" || true)"
+    fi
+
+    if [[ -n "${ACTIVE_TOKEN_NAME}" ]]; then
+        local _mb
+        set +e
+        PYTHONPATH="${pkg}${PYTHONPATH:+:$PYTHONPATH}" "${LOOM_PYTHON}" - \
+            "${ws}" "${ACTIVE_TOKEN_NAME}" "exhausted: ${reason}" <<'PY' 2>/dev/null
+import sys
+from loom_tools.tokens.bad_tokens import mark_bad
+mark_bad(sys.argv[1], sys.argv[2], sys.argv[3])
+PY
+        _mb=$?
+        set -e
+        if [[ ${_mb} -eq 0 ]]; then
+            log_info "Marked account '${ACTIVE_TOKEN_NAME}' exhausted in .bad_tokens (${reason})"
+        else
+            log_warn "Could not record '${ACTIVE_TOKEN_NAME}' in .bad_tokens (continuing to re-select)"
+        fi
+    else
+        log_warn "Active account name unknown — cannot mark it bad; re-selecting anyway"
+    fi
+
+    local sel_json _sel_rc
+    set +e
+    sel_json="$(PYTHONPATH="${pkg}${PYTHONPATH:+:$PYTHONPATH}" \
+        "${LOOM_PYTHON}" -m loom_tools.tokens.select --workspace "${ws}" --json 2>/dev/null)"
+    _sel_rc=$?
+    set -e
+    if [[ ${_sel_rc} -ne 0 || -z "${sel_json}" ]]; then
+        return 1
+    fi
+
+    local new_key new_name
+    new_key="$(printf '%s' "${sel_json}" | "${LOOM_PYTHON}" -c 'import json,sys; print(json.load(sys.stdin)["key"])' 2>/dev/null || echo "")"
+    new_name="$(printf '%s' "${sel_json}" | "${LOOM_PYTHON}" -c 'import json,sys; print(json.load(sys.stdin)["name"])' 2>/dev/null || echo "")"
+    if [[ -z "${new_key}" ]]; then
+        return 1
+    fi
+
+    export CLAUDE_CODE_OAUTH_TOKEN="${new_key}"
+    ACTIVE_TOKEN_NAME="${new_name}"
+    export LOOM_TOKEN_NAME="${new_name}"
+    log_info "Rotated OAuth account → '${new_name}' (token tail=…${new_key: -4})"
+    return 0
+}
+
 # Check if error output specifically indicates an MCP/plugin failure.
 # Used to map exhausted-retry exits to exit code 7 so the Python retry
 # layer can recognize MCP failures even when the wrapper's own retries
@@ -1254,6 +1439,12 @@ run_with_retry() {
     local attempt=1
     local exit_code=0
     local output=""
+    # Account-rotation bookkeeping (#3738). Rotations do NOT consume a
+    # MAX_RETRIES attempt; this independent cap is a loop guard for the
+    # pathological case where the active account can't be identified and marked
+    # bad, so re-selection could otherwise keep returning it forever.
+    local rotations=0
+    local max_rotations="${LOOM_MAX_ACCOUNT_ROTATIONS:-20}"
 
     # Recover CWD if it was deleted before we started
     if ! recover_cwd; then
@@ -1438,6 +1629,36 @@ run_with_retry() {
         fi
 
         log_warn "Claude CLI exited with code ${exit_code}"
+
+        # Account exhaustion (session / weekly / usage limit) → rotate to a
+        # different account and retry WITHOUT consuming a MAX_RETRIES attempt
+        # (#3738). Rotation is not transient backoff: charging it against
+        # MAX_RETRIES could burn the whole retry budget before every account
+        # gets a fair shot. Terminates when the pool has no eligible account,
+        # with a distinct ACCOUNT_POOL_EXHAUSTED sentinel (not the generic
+        # "Max retries exceeded" path below).
+        if is_account_exhaustion "${output}" "${exit_code}"; then
+            rotations=$((rotations + 1))
+            if [[ "${rotations}" -gt "${max_rotations}" ]]; then
+                log_error "Account rotation cap (${max_rotations}) exceeded — aborting to avoid a loop"
+                echo "# ACCOUNT_POOL_EXHAUSTED" >&2
+                clear_retry_state
+                return 1
+            fi
+            local _exh_phrase
+            _exh_phrase="$(_exhaustion_phrase "${output}")"
+            log_warn "Account exhaustion detected (${_exh_phrase}) — rotating account (attempt ${attempt}/${MAX_RETRIES} NOT consumed)"
+            if rotate_exhausted_account "${_exh_phrase}"; then
+                write_retry_state "running" "${attempt}"
+                # Retry the SAME attempt number on the fresh account.
+                continue
+            fi
+            log_error "Whole account pool exhausted — every account is marked bad or rate-limited."
+            log_error "Retry after the soonest account reset, or run 'loom-tokens unblock <name>'."
+            echo "# ACCOUNT_POOL_EXHAUSTED" >&2
+            clear_retry_state
+            return 1
+        fi
 
         # Check if this is a transient error worth retrying
         if ! is_transient_error "${output}" "${exit_code}"; then

--- a/defaults/scripts/lib/classify-error.sh
+++ b/defaults/scripts/lib/classify-error.sh
@@ -74,8 +74,15 @@ classify_error() {
         return
     fi
 
-    # Token exhausted (quota used up) — rotate to a different token
-    if echo "$output" | grep -qiE "hit your (limit|weekly limit)|hit.your.limit"; then
+    # Token exhausted (quota / session / weekly / usage limit) — rotate to a
+    # different token. The phrase set is widened (issue #3738) to cover the
+    # multi-word-gap variants the Claude CLI actually emits — "hit your
+    # session limit", "hit your weekly limit", an org's "monthly usage limit",
+    # and "out of extra usage". A naive `hit.your.limit` pattern misses the
+    # "session"/multi-word forms (there is filler between "your" and "limit").
+    # This regex is kept in lockstep with claude-wrapper.sh, which sources this
+    # file rather than duplicating the pattern (issue #3738).
+    if echo "$output" | grep -qiE "hit your (limit|session limit|weekly limit)|hit\.your\.limit|monthly usage limit|out of extra usage"; then
         echo "TOKEN_EXHAUSTED"
         return
     fi

--- a/defaults/scripts/spawn-claude.sh
+++ b/defaults/scripts/spawn-claude.sh
@@ -300,6 +300,12 @@ PY
     fi
 
     export CLAUDE_CODE_OAUTH_TOKEN="$_token"
+    # Export the selected account name so a downstream claude-wrapper.sh knows
+    # which account the exported token belongs to. This is what lets the
+    # wrapper mark exactly the right account bad when it rotates on a
+    # usage/session-limit fault (issue #3738) instead of guessing from file
+    # mtimes. Harmless for the direct-`claude` dispatch path.
+    export LOOM_TOKEN_NAME="$_name"
     log_info "spawn-claude: using OAuth account '$_name' (mode=$_mode)"
 fi
 

--- a/defaults/scripts/tests/test-spawn-claude.sh
+++ b/defaults/scripts/tests/test-spawn-claude.sh
@@ -159,6 +159,41 @@ assert_eq "SUCCESS" "$result" 'exit=0 with stop_reason:"refusal" is SUCCESS (#32
 result=$(classify_error "connection reset; will not retry (refusal to reconnect)" 1)
 assert_eq "RECOVERABLE" "$result" "bare 'refusal' word (no stop_reason) + exit=1 -> RECOVERABLE"
 
+# --- Widened TOKEN_EXHAUSTED vectors (issue #3738) ---
+# The Claude CLI emits several usage/session/weekly/monthly limit phrasings.
+# A naive `hit.your.limit`-style pattern misses the multi-word-gap variants
+# ("hit your SESSION limit", "monthly usage limit", "out of extra usage") —
+# each is verified individually, not just the legacy short form (#10/#11).
+
+# Vector #23: session limit (the exact canary phrase) → TOKEN_EXHAUSTED
+result=$(classify_error "You've hit your session limit · resets 4pm" 1)
+assert_eq "TOKEN_EXHAUSTED" "$result" "hit your session limit -> TOKEN_EXHAUSTED (#3738)"
+
+# Vector #24: full weekly-limit phrasing with reset suffix → TOKEN_EXHAUSTED
+result=$(classify_error "You've hit your weekly limit · resets Monday 9am" 1)
+assert_eq "TOKEN_EXHAUSTED" "$result" "hit your weekly limit (full phrasing) -> TOKEN_EXHAUSTED (#3738)"
+
+# Vector #25: org monthly usage limit → TOKEN_EXHAUSTED
+result=$(classify_error "You've hit your org's monthly usage limit" 1)
+assert_eq "TOKEN_EXHAUSTED" "$result" "monthly usage limit -> TOKEN_EXHAUSTED (#3738)"
+
+# Vector #26: out of extra usage → TOKEN_EXHAUSTED
+result=$(classify_error "You're out of extra usage · resets 4pm" 1)
+assert_eq "TOKEN_EXHAUSTED" "$result" "out of extra usage -> TOKEN_EXHAUSTED (#3738)"
+
+# Vector #27: plain "You've hit your limit" still classifies (legacy short form)
+result=$(classify_error "You've hit your limit" 1)
+assert_eq "TOKEN_EXHAUSTED" "$result" "legacy 'hit your limit' still -> TOKEN_EXHAUSTED (#3738)"
+
+# Vector #28 (REGRESSION, #3233): exit-0 output mentioning a limit phrase in
+# prose is STILL SUCCESS — exit-code-first ordering wins over the new patterns.
+result=$(classify_error "Note: agents pause when they hit your session limit." 0)
+assert_eq "SUCCESS" "$result" "exit=0 mentioning 'hit your session limit' is SUCCESS (#3233/#3738)"
+
+# Vector #29 (REGRESSION): exit-0 with "out of extra usage" in prose → SUCCESS
+result=$(classify_error "The plan was out of extra usage headroom last week." 0)
+assert_eq "SUCCESS" "$result" "exit=0 mentioning 'out of extra usage' is SUCCESS (#3233/#3738)"
+
 # ============================================================
 # Section 2: spawn-claude.sh dispatch (with stub `claude`)
 # ============================================================
@@ -405,6 +440,142 @@ else
     TESTS_FAILED=$((TESTS_FAILED + 1))
     echo -e "  ${RED}FAIL${NC}: empty LOOM_EFFORT emits NO --effort"
     echo "    In: '$output'"
+fi
+
+# ============================================================
+# Section 5: claude-wrapper.sh account rotation on exhaustion (#3738)
+#
+# On a session/usage-limit fault the wrapper must mark the active account bad,
+# re-select a fresh account, and retry WITHOUT consuming a MAX_RETRIES attempt.
+# When the whole pool is exhausted it must emit a distinct sentinel (not the
+# generic "Max retries exceeded" path) and exit non-zero.
+# ============================================================
+
+echo ""
+echo "Testing claude-wrapper.sh account rotation (#3738)..."
+
+WRAPPER="$SCRIPTS_DIR/claude-wrapper.sh"
+PKG_SRC="$(cd "$SCRIPTS_DIR/../../loom-tools/src" 2>/dev/null && pwd || echo "")"
+
+if [[ -z "$PKG_SRC" || ! -d "$PKG_SRC/loom_tools/tokens" ]]; then
+    echo "  (skipping rotation tests — loom_tools package not found)"
+else
+  # --- Fixture: 2-account pool; stub exhausts alpha, succeeds on beta ---
+  ROT_WS="$(mktemp -d)"
+  mkdir -p "$ROT_WS/.loom/tokens"
+  chmod 700 "$ROT_WS/.loom/tokens"
+  printf '%s' "tok-alpha" > "$ROT_WS/.loom/tokens/alpha.token"
+  printf '%s' "tok-beta"  > "$ROT_WS/.loom/tokens/beta.token"
+  chmod 600 "$ROT_WS/.loom/tokens/"*.token
+
+  ROT_STUB="$(mktemp -d)"
+  cat > "$ROT_STUB/claude" <<'STUB'
+#!/usr/bin/env bash
+# Only the real prompt run (contains "-p") drives rotation; any preflight
+# subcommands (auth/mcp/version) succeed quietly.
+case " $* " in
+  *" -p "*) ;;
+  *) exit 0 ;;
+esac
+if [[ "${CLAUDE_CODE_OAUTH_TOKEN}" == "tok-alpha" ]]; then
+    echo "You've hit your session limit · resets 4pm"
+    exit 1
+fi
+echo "stub-claude success on token=${CLAUDE_CODE_OAUTH_TOKEN}"
+exit 0
+STUB
+  chmod +x "$ROT_STUB/claude"
+
+  # Force the first account to alpha (as spawn-claude would). MAX_RETRIES=1:
+  # if rotation consumed a MAX_RETRIES attempt, beta would never be tried.
+  set +e
+  rot_out=$(
+    LOOM_WORKSPACE="$ROT_WS" \
+    LOOM_TOKEN_NAME="alpha" \
+    CLAUDE_CODE_OAUTH_TOKEN="tok-alpha" \
+    LOOM_PACKAGE_PATH="$PKG_SRC" \
+    LOOM_MAX_RETRIES=1 \
+    LOOM_SHEPHERD_TASK_ID="test-rotation" \
+    LOOM_STARTUP_MONITOR_WINDOW=1 \
+    PATH="$ROT_STUB:$PATH" \
+    bash "$WRAPPER" -p "ping" 2>&1
+  )
+  rot_rc=$?
+  set -e
+
+  assert_contains "stub-claude success on token=tok-beta" "$rot_out" \
+      "wrapper rotates from exhausted alpha to beta and succeeds"
+  assert_eq "0" "$rot_rc" \
+      "wrapper exits 0 after rotation (MAX_RETRIES=1 not consumed by rotation)"
+
+  bad_file="$ROT_WS/.loom/tokens/.bad_tokens"
+  TESTS_RUN=$((TESTS_RUN + 1))
+  if [[ -f "$bad_file" ]] && grep -qw "alpha" "$bad_file" && ! grep -qw "beta" "$bad_file"; then
+      TESTS_PASSED=$((TESTS_PASSED + 1))
+      echo -e "  ${GREEN}PASS${NC}: .bad_tokens records exhausted alpha but not beta"
+  else
+      TESTS_FAILED=$((TESTS_FAILED + 1))
+      echo -e "  ${RED}FAIL${NC}: .bad_tokens records exhausted alpha but not beta"
+      echo "    .bad_tokens: $(cat "$bad_file" 2>/dev/null || echo '<missing>')"
+  fi
+
+  # --- Whole-pool exhaustion: both accounts exhaust → ACCOUNT_POOL_EXHAUSTED ---
+  ROT_WS2="$(mktemp -d)"
+  mkdir -p "$ROT_WS2/.loom/tokens"
+  chmod 700 "$ROT_WS2/.loom/tokens"
+  printf '%s' "tok-a" > "$ROT_WS2/.loom/tokens/a.token"
+  printf '%s' "tok-b" > "$ROT_WS2/.loom/tokens/b.token"
+  chmod 600 "$ROT_WS2/.loom/tokens/"*.token
+
+  ROT_STUB2="$(mktemp -d)"
+  cat > "$ROT_STUB2/claude" <<'STUB'
+#!/usr/bin/env bash
+case " $* " in
+  *" -p "*) ;;
+  *) exit 0 ;;
+esac
+echo "You've hit your session limit · resets 4pm"
+exit 1
+STUB
+  chmod +x "$ROT_STUB2/claude"
+
+  set +e
+  rot2_out=$(
+    LOOM_WORKSPACE="$ROT_WS2" \
+    LOOM_TOKEN_NAME="a" \
+    CLAUDE_CODE_OAUTH_TOKEN="tok-a" \
+    LOOM_PACKAGE_PATH="$PKG_SRC" \
+    LOOM_MAX_RETRIES=1 \
+    LOOM_SHEPHERD_TASK_ID="test-rotation" \
+    LOOM_STARTUP_MONITOR_WINDOW=1 \
+    PATH="$ROT_STUB2:$PATH" \
+    bash "$WRAPPER" -p "ping" 2>&1
+  )
+  rot2_rc=$?
+  set -e
+
+  assert_contains "ACCOUNT_POOL_EXHAUSTED" "$rot2_out" \
+      "whole-pool exhaustion emits the ACCOUNT_POOL_EXHAUSTED sentinel"
+  assert_contains "Whole account pool exhausted" "$rot2_out" \
+      "whole-pool exhaustion logs a distinct (non-'Max retries') message"
+  TESTS_RUN=$((TESTS_RUN + 1))
+  if [[ "$rot2_rc" -ne 0 ]]; then
+      TESTS_PASSED=$((TESTS_PASSED + 1))
+      echo -e "  ${GREEN}PASS${NC}: whole-pool exhaustion exits non-zero"
+  else
+      TESTS_FAILED=$((TESTS_FAILED + 1))
+      echo -e "  ${RED}FAIL${NC}: whole-pool exhaustion exits non-zero"
+  fi
+  TESTS_RUN=$((TESTS_RUN + 1))
+  if [[ "$rot2_out" != *"Max retries"* ]]; then
+      TESTS_PASSED=$((TESTS_PASSED + 1))
+      echo -e "  ${GREEN}PASS${NC}: whole-pool exhaustion avoids the generic Max-retries path"
+  else
+      TESTS_FAILED=$((TESTS_FAILED + 1))
+      echo -e "  ${RED}FAIL${NC}: whole-pool exhaustion avoids the generic Max-retries path"
+  fi
+
+  rm -rf "$ROT_WS" "$ROT_STUB" "$ROT_WS2" "$ROT_STUB2"
 fi
 
 # ============================================================


### PR DESCRIPTION
Closes #3738

## Problem

A session/usage-exhaustion fault (`You've hit your session limit · resets 4pm`, the 100%-weekly banner, etc.) was classified **fatal** by `claude-wrapper.sh`: the `RATE_LIMIT_ABORT` sentinel made `is_transient_error` return non-transient, so `run_with_retry` returned immediately and the whole worker died — even when other accounts in the pool still had capacity. The OAuth token was also selected exactly once, outside the retry loop, so no rotation was possible.

## Change

On an account-exhaustion fault the wrapper now (issue #3738):

1. **Marks the active account exhausted** in `.loom/tokens/.bad_tokens` via the existing `loom_tools.tokens.bad_tokens.mark_bad` primitive (not a reimplemented file-glob).
2. **Re-runs Loom token selection** (`loom_tools.tokens.select`), which now skips the just-marked account.
3. **Re-exports `CLAUDE_CODE_OAUTH_TOKEN`** and retries **without consuming a `MAX_RETRIES` attempt** — rotation is not transient backoff; charging it against `MAX_RETRIES` could burn the whole budget before every account gets a fair shot.
4. **Terminates only when selection reports no eligible account**, emitting a distinct `# ACCOUNT_POOL_EXHAUSTED` sentinel + message rather than the generic "Max retries exceeded" path. An independent rotation cap (`LOOM_MAX_ACCOUNT_ROTATIONS`, default 20) guards against a loop if the active account can't be identified.

`select.py` is **not** modified (kept file-disjoint from #3736) — this change only *calls* `select_token`.

### Curator-surfaced gaps also fixed

- **`classify-error.sh` `TOKEN_EXHAUSTED` matcher widened** to the multi-word-gap phrase set (`hit your session limit`, `monthly usage limit`, `out of extra usage`, full `weekly limit`) **and wired in**: `claude-wrapper.sh` now *sources* it rather than duplicating the regex, so the two can't drift. Exit-code-first ordering (#3233) preserved.
- **`spawn-claude.sh` exports `LOOM_TOKEN_NAME`** so the wrapper knows which account to mark bad — with a deterministic content-match fallback for direct invocation (deliberately avoids lean-genius's `ls -t | head -1` mtime heuristic).

## Tests

`defaults/scripts/tests/test-spawn-claude.sh` (65 pass):
- Widened `classify_error` vectors — session / weekly / monthly / extra-usage phrasings, legacy short form, plus exit-0-in-prose regression vectors (#3233).
- Wrapper-level rotation test using a 2-account fixture pool + stub `claude` that exhausts the first account and succeeds on the second: asserts both accounts get tried under `LOOM_MAX_RETRIES=1` (proving non-consumption), `.bad_tokens` records only the exhausted account, and whole-pool exhaustion hits the distinct `ACCOUNT_POOL_EXHAUSTED` sentinel path with a non-zero exit.

`shellcheck --severity=warning` clean on all edited scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)