### PR TITLE
docs(loom): repoint stale loom-daemon.sh refs in 3 deprecated command docs

### DIFF
--- a/defaults/.claude/commands/loom/loom-iteration.md
+++ b/defaults/.claude/commands/loom/loom-iteration.md
@@ -4,13 +4,10 @@
 
 ## Execution
 
-Use the `/loom` skill or run directly:
-
-```bash
-./.loom/scripts/loom-daemon.sh {{ARGUMENTS}}
-```
-
-The Python daemon handles iteration logic internally in `loom_tools.daemon.iteration`.
+This skill is superseded. Use `/loom:sweep <issue>` for the single-issue
+lifecycle, or `mcp__loom__dispatch_sweep` against the Rust `loom-daemon` for
+multi-account dispatch. See `.loom/docs/daemon-reference.md` for the current
+daemon surface.
 
 ## Migration
 

--- a/defaults/.claude/commands/loom/loom-parent.md
+++ b/defaults/.claude/commands/loom/loom-parent.md
@@ -4,13 +4,12 @@
 
 ## Execution
 
-Use the `/loom` skill or run directly:
+This skill is superseded. Use `/loom:sweep <issue>` for the single-issue
+lifecycle, or `mcp__loom__dispatch_sweep` against the Rust `loom-daemon` for
+multi-account dispatch. See `.loom/docs/daemon-reference.md` for the current
+daemon surface.
 
-```bash
-./.loom/scripts/loom-daemon.sh {{ARGUMENTS}}
-```
-
-The Python daemon handles all orchestration internally:
+The historical Python daemon handled all orchestration internally:
 - Main event loop
 - Iteration logic
 - Shepherd spawning
@@ -22,6 +21,6 @@ The Python daemon handles all orchestration internally:
 The two-tier LLM architecture (parent/iteration) has been replaced with a deterministic Python implementation:
 
 - **Old**: `/loom` -> `loom-parent.md` -> Task() -> `loom-iteration.md`
-- **New**: `/loom` -> `loom-daemon.sh` -> `loom-daemon` (Python CLI)
+- **New**: `/loom:sweep <issue>` (Tier 1) or `mcp__loom__dispatch_sweep` -> Rust `loom-daemon` (Tier 2)
 
 See `loom-tools/src/loom_tools/daemon/` for the implementation.

--- a/defaults/.claude/commands/loom/loom-reference.md
+++ b/defaults/.claude/commands/loom/loom-reference.md
@@ -4,7 +4,7 @@ This file contains detailed reference documentation for the Loom daemon. It is N
 
 For daemon execution:
 - `loom.md` - Skill that invokes the Python daemon
-- `.loom/scripts/loom-daemon.sh` - Shell wrapper for the daemon
+- `.loom/docs/daemon-reference.md` - Current daemon reference (Rust `loom-daemon` + `mcp__loom__dispatch_sweep`)
 - `loom-tools/src/loom_tools/daemon/` - Python daemon implementation
 
 ## State File Format


### PR DESCRIPTION
Closes #3746

## Summary

Doc-only cleanup. The three DEPRECATED legacy command docs still referenced a `.loom/scripts/loom-daemon.sh` wrapper that no longer exists (removed in the v0.10.0 shepherd/daemon migration). All four stale references are repointed at the real current surfaces:

- `loom-iteration.md` (line 10) — dead `loom-daemon.sh` code block replaced with a one-line "superseded by `/loom:sweep` / `mcp__loom__dispatch_sweep`" pointer.
- `loom-parent.md` (line 10) — same replacement.
- `loom-parent.md` (line 25) — migration-note "New" row repointed from `loom-daemon.sh` -> Python CLI to `/loom:sweep` (Tier 1) / `mcp__loom__dispatch_sweep` -> Rust `loom-daemon` (Tier 2).
- `loom-reference.md` (line 7) — dead wrapper bullet repointed at `.loom/docs/daemon-reference.md`.

## Verification

- `git grep -n 'loom-daemon\.sh' -- 'defaults/.claude/commands/loom/*.md'` -> no matches
- `git grep -n 'loom-daemon\.sh' -- defaults/` -> no matches
- `(DEPRECATED)` headers on `loom-iteration.md` and `loom-parent.md` preserved; no un-deprecation, no functional/script changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)