### PR TITLE
feat(experiments): harden Judge fan-out workflow + measurement scaffold (#3748)

### DIFF
--- a/defaults/scripts/experiments/README.md
+++ b/defaults/scripts/experiments/README.md
@@ -9,8 +9,13 @@ auto-loaded, never triggered by a normal sweep.
 
 | File | What it is |
 |------|------------|
-| `judge-fanout-workflow.js` | **Design sketch** (issue #3739) of a Claude Code Dynamic Workflow that reviews ONE PR via multi-dimension reviewer fan-out + a typed adversarial verify pass. NOT wired into `sweep.md`/`judge.md`; NOT in a discovered `workflows/` directory, so the CLI does not auto-load it. |
-| `judge-fanout-experiment.sh` | Off-by-default gate/runner. No-op unless `LOOM_JUDGE_FANOUT_EXPERIMENT=1`. When enabled it syntax-checks the sketch and prints top-level-session invocation guidance — it never dispatches a live judge run, applies no labels, merges nothing, and creates no issues. |
+| `judge-fanout-workflow.js` | A Claude Code Dynamic Workflow that reviews ONE PR via multi-dimension reviewer fan-out + a typed adversarial verify pass. Shipped as a **design sketch** (#3739) and **hardened into a load-bearing artifact** (#3748): real dimension-scoped reviewer prompts (one per `correctness` / `security-credential-surface` / `test-coverage` / `perf-simplification`), a fuller adversarial-verify prompt, and a No-Fable-Judge guard (#3702). NOT wired into `sweep.md`/`judge.md`; NOT in a discovered `workflows/` directory, so the CLI does not auto-load it. |
+| `judge-fanout-experiment.sh` | Off-by-default gate/runner. No-op unless `LOOM_JUDGE_FANOUT_EXPERIMENT=1`. When enabled it syntax-checks the workflow **and the corpus-runner scaffold** and prints top-level-session invocation guidance — it never dispatches a live judge run, applies no labels, merges nothing, and creates no issues. |
+| `judge-fanout-corpus-runner.sh` | **Measurement-harness scaffold** (#3748). Builds per-PR `args` (`{ pr, diff }`) from `gh pr diff` for a 3–5 PR corpus and emits an empty results table. It is READ-ONLY on GitHub and has a clearly-marked **unfilled** hook point where the operator invokes `Workflow({...})` — a builder cannot fill it in (the Workflow tool is top-level-only; #3289). |
+| `judge-fanout-results-template.md` | **Empty** results-table template (#3748). Columns for dimension findings, verified findings, precision, recall, latency, token cost, and the single-pass-Judge baseline. Shipped with no numbers — the operator fills in REAL measured data. |
+
+The **operator runbook** for executing the deferred measurement lives at
+[`docs/research/judge-fanout-measurement-runbook.md`](../../../docs/research/judge-fanout-measurement-runbook.md).
 
 Full context, the capability→need mapping, the substrate boundary, and the
 keep/defer/reject verdicts live in
@@ -38,5 +43,13 @@ LOOM_JUDGE_FANOUT_EXPERIMENT=1 ./defaults/scripts/experiments/judge-fanout-exper
   `spawn-claude.sh` concern on the other side of the substrate boundary.
 - **Read-only:** the workflow returns a verdict object; it merges nothing, applies
   no `loom:pr` / `loom:changes-requested` transitions, and creates no GitHub issues.
-- **Deferred:** the runnable prototype + measured comparison are a named follow-up,
-  not delivered here. See the evaluation doc → "What is deferred".
+- **No-Fable-Judge (#3702):** the fan-out reviewers play the Judge role, so their
+  resolved model must never be `fable`. The workflow's `assertNotFable()` guard
+  rejects an explicit `args.model: "fable"`; run it from an opus/sonnet session so
+  the inherited session default is never fable either.
+- **Deferred measurement:** #3748 hardened the workflow and shipped the
+  measurement scaffold (`judge-fanout-corpus-runner.sh`), the empty results
+  template, and the operator runbook — but **the live measurement itself is still
+  a deferred operator action**. It requires the Workflow tool (top-level-session
+  only, #3289) and produces real precision/recall/latency/cost numbers that are
+  NOT fabricated here. See the runbook and the evaluation doc → "What is deferred".

--- a/defaults/scripts/experiments/judge-fanout-corpus-runner.sh
+++ b/defaults/scripts/experiments/judge-fanout-corpus-runner.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+#
+# judge-fanout-corpus-runner.sh — measurement-harness SCAFFOLD (issue #3748).
+#
+# Purpose: make the DEFERRED Judge fan-out measurement mechanical for an operator
+# running from a TOP-LEVEL Claude Code session. It builds, for each PR in a
+# small corpus, the exact `args` object the Workflow tool needs
+# (`{ pr, diff }`), by shelling out to `gh pr diff`. It then emits an empty
+# results-table row per PR into a Markdown file the operator fills in with real
+# numbers after invoking the workflow.
+#
+# CRITICAL — what this scaffold DOES NOT do (and a builder CANNOT do):
+#   It does NOT invoke `Workflow({ scriptPath, args })`. The Workflow tool is
+#   only exposed to a top-level Claude Code session; a script/subagent context
+#   has no access to it, and driving it from a subagent would add a second
+#   nesting level (#3289). The hook point where the operator invokes the workflow
+#   is a clearly-marked, UNFILLED TODO below (emit_workflow_invocation_stub).
+#   Filling it in is the operator's deferred action — see
+#   docs/research/judge-fanout-measurement-runbook.md.
+#
+# This script is READ-ONLY with respect to GitHub: it only runs `gh pr diff`
+# (and, with --with-outcome auto, `gh pr view`) — it applies no labels, merges
+# nothing, and creates no issues. Its only writes are local artifact files under
+# the chosen output directory.
+#
+# Off-by-default posture: like judge-fanout-experiment.sh this is experiment
+# tooling. It is never wired into the production sweep/judge path.
+#
+# Usage:
+#   judge-fanout-corpus-runner.sh --out DIR PR[:outcome] [PR[:outcome] ...]
+#
+#   PR            a PR number whose diff to fetch (already merged or rejected).
+#   :outcome      optional known ground-truth label for that PR: `merged` or
+#                 `rejected`. If omitted, the cell is left blank for the operator.
+#
+# Options:
+#   --out DIR         output directory for per-PR args + the results table
+#                     (default: ./judge-fanout-corpus-out).
+#   --diff-only       only fetch diffs + build args; skip results-table emission.
+#   --dry-run         print what would be fetched/written; touch nothing.
+#   -h | --help       show this help.
+#
+# Example (operator, top-level session):
+#   ./judge-fanout-corpus-runner.sh --out /tmp/jf 3721:merged 3699:rejected 3688:merged
+#   # -> /tmp/jf/pr-3721.args.json  (…{ "pr": 3721, "diff": "<unified diff>" })
+#   #    /tmp/jf/results.md          (empty table, one row per PR, to be filled)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKFLOW_JS="${SCRIPT_DIR}/judge-fanout-workflow.js"
+TEMPLATE_MD="${SCRIPT_DIR}/judge-fanout-results-template.md"
+
+OUT_DIR="./judge-fanout-corpus-out"
+DIFF_ONLY=0
+DRY_RUN=0
+PR_SPECS=()
+
+usage() { sed -n '2,60p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --out) OUT_DIR="$2"; shift 2 ;;
+    --out=*) OUT_DIR="${1#*=}"; shift ;;
+    --diff-only) DIFF_ONLY=1; shift ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h | --help) usage; exit 0 ;;
+    -*) echo "judge-fanout-corpus-runner: unknown option '$1'" >&2; exit 2 ;;
+    *) PR_SPECS+=("$1"); shift ;;
+  esac
+done
+
+if [[ ${#PR_SPECS[@]} -eq 0 ]]; then
+  echo "judge-fanout-corpus-runner: no PRs given. See --help." >&2
+  exit 2
+fi
+
+if [[ ! -f "${WORKFLOW_JS}" ]]; then
+  echo "judge-fanout-corpus-runner: ERROR — workflow not found at ${WORKFLOW_JS}" >&2
+  exit 1
+fi
+
+# --- helpers ----------------------------------------------------------------
+
+# JSON-escape a string on stdin (no jq dependency for the scaffold's core path;
+# jq is used only when available for the diff, to guarantee valid JSON).
+json_escape() {
+  if command -v jq >/dev/null 2>&1; then
+    jq -Rs .
+  else
+    # Minimal fallback: escape backslash, double-quote, and control chars.
+    python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'
+  fi
+}
+
+# parse "PR[:outcome]" -> sets PR_NUM and PR_OUTCOME globals.
+parse_spec() {
+  local spec="$1"
+  PR_NUM="${spec%%:*}"
+  if [[ "$spec" == *:* ]]; then PR_OUTCOME="${spec#*:}"; else PR_OUTCOME=""; fi
+  if ! [[ "$PR_NUM" =~ ^[0-9]+$ ]]; then
+    echo "judge-fanout-corpus-runner: invalid PR spec '$spec' (need PR[:outcome])" >&2
+    exit 2
+  fi
+  case "$PR_OUTCOME" in
+    "" | merged | rejected) ;;
+    *) echo "judge-fanout-corpus-runner: outcome must be merged|rejected, got '$PR_OUTCOME'" >&2; exit 2 ;;
+  esac
+}
+
+# Build the per-PR args JSON file from `gh pr diff`. Returns the args path.
+build_args_for_pr() {
+  local pr="$1" out="$2"
+  local args_path="${out}/pr-${pr}.args.json"
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "[dry-run] would fetch: gh pr diff ${pr}  ->  ${args_path}" >&2
+    return 0
+  fi
+  local diff_json
+  # gh pr diff is read-only. Capture the unified diff, JSON-escape it, and wrap.
+  diff_json="$(gh pr diff "${pr}" 2>/dev/null | json_escape)"
+  if [[ -z "$diff_json" || "$diff_json" == '""' ]]; then
+    echo "judge-fanout-corpus-runner: WARNING — empty diff for PR ${pr} (skipping args)" >&2
+    return 1
+  fi
+  printf '{\n  "pr": %s,\n  "diff": %s\n}\n' "${pr}" "${diff_json}" > "${args_path}"
+  echo "${args_path}"
+}
+
+# ============================================================================
+# HOOK POINT (UNFILLED — operator's deferred action, requires the Workflow tool)
+# ============================================================================
+# A builder CANNOT fill this in: `Workflow({...})` is a top-level-session tool.
+# From a top-level Claude Code session, the operator replaces this stub with a
+# real invocation, e.g. (pseudocode — the tool is not a shell command):
+#
+#     result = Workflow({
+#       scriptPath: "<abs path to judge-fanout-workflow.js>",
+#       args:       <contents of pr-<N>.args.json>,
+#     })
+#     # then record result.verdict / result.findings / droppedUnverified +
+#     # measured latency + token cost into the results table.
+#
+# See docs/research/judge-fanout-measurement-runbook.md for the full procedure.
+emit_workflow_invocation_stub() {
+  local pr="$1" args_path="$2"
+  cat >&2 <<STUB
+  [PR ${pr}] args ready: ${args_path}
+    TODO(operator): from a TOP-LEVEL session, invoke:
+      Workflow({ scriptPath: "${WORKFLOW_JS}", args: <${args_path}> })
+    then record verdict/findings/latency/token-cost in the results table.
+    (This scaffold intentionally does NOT invoke the Workflow tool — #3289.)
+STUB
+}
+
+# --- main -------------------------------------------------------------------
+
+if [[ "$DRY_RUN" -eq 0 ]]; then
+  mkdir -p "${OUT_DIR}"
+fi
+
+echo "judge-fanout-corpus-runner (#3748 scaffold): ${#PR_SPECS[@]} PR(s), out=${OUT_DIR}" >&2
+echo "  READ-ONLY on GitHub (gh pr diff/view only); no Workflow tool invocation here." >&2
+
+RESULTS_MD="${OUT_DIR}/results.md"
+ROWS=()
+
+for spec in "${PR_SPECS[@]}"; do
+  parse_spec "$spec"
+  args_path="$(build_args_for_pr "${PR_NUM}" "${OUT_DIR}")" || true
+  if [[ "$DRY_RUN" -eq 0 && -n "${args_path:-}" && -f "${args_path}" ]]; then
+    emit_workflow_invocation_stub "${PR_NUM}" "${args_path}"
+  fi
+  # One empty results row per PR. Ground-truth outcome filled if provided; every
+  # measured column is left blank ("") for the operator — NO fabricated numbers.
+  ROWS+=("| ${PR_NUM} | ${PR_OUTCOME:-} |  |  |  |  |  |  |  |")
+done
+
+if [[ "$DIFF_ONLY" -eq 1 ]]; then
+  echo "judge-fanout-corpus-runner: --diff-only set; skipping results table." >&2
+  exit 0
+fi
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "[dry-run] would write results table: ${RESULTS_MD}" >&2
+  printf '%s\n' "${ROWS[@]}" >&2
+  exit 0
+fi
+
+# Emit the results table: header copied from the template if present, else an
+# inline header. Rows are appended EMPTY — the operator fills real numbers in.
+{
+  echo "# Judge fan-out measurement results (issue #3748 harness output)"
+  echo
+  echo "Generated by judge-fanout-corpus-runner.sh. Every measured cell is EMPTY;"
+  echo "fill with REAL numbers after invoking the workflow from a top-level session."
+  echo "See docs/research/judge-fanout-measurement-runbook.md. Do NOT fabricate data."
+  echo
+  echo "| PR # | Known outcome | Dimension findings | Verified findings | Precision (1 - unverified-nit rate) | Recall (dimensions caught) | Fan-out latency (s) | Token cost | Single-pass Judge baseline |"
+  echo "|------|---------------|--------------------|-------------------|-------------------------------------|----------------------------|---------------------|------------|----------------------------|"
+  printf '%s\n' "${ROWS[@]}"
+} > "${RESULTS_MD}"
+
+echo "judge-fanout-corpus-runner: wrote ${#ROWS[@]} empty row(s) -> ${RESULTS_MD}" >&2
+echo "  (template reference: ${TEMPLATE_MD})" >&2
+exit 0

--- a/defaults/scripts/experiments/judge-fanout-experiment.sh
+++ b/defaults/scripts/experiments/judge-fanout-experiment.sh
@@ -24,6 +24,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKFLOW_JS="${SCRIPT_DIR}/judge-fanout-workflow.js"
+CORPUS_RUNNER="${SCRIPT_DIR}/judge-fanout-corpus-runner.sh"
 
 FLAG="${LOOM_JUDGE_FANOUT_EXPERIMENT:-}"
 
@@ -73,18 +74,39 @@ else
   fi
 fi
 
+# Syntax-check the measurement-harness scaffold too (#3748). It is a normal bash
+# script (unlike the workflow VM body), so a plain `bash -n` parse suffices.
+if [[ -f "${CORPUS_RUNNER}" ]]; then
+  if bash -n "${CORPUS_RUNNER}"; then
+    echo "judge-fanout-experiment: corpus-runner scaffold syntax OK (parsed, not executed)." >&2
+  else
+    echo "judge-fanout-experiment: ERROR — corpus-runner scaffold failed to parse." >&2
+    exit 1
+  fi
+fi
+
 cat >&2 <<'GUIDE'
 
-To run the (deferred) live prototype — from a TOP-LEVEL Claude Code session only:
-  1. Copy judge-fanout-workflow.js into a discovered workflows/ directory
+To run the (deferred) live measurement — from a TOP-LEVEL Claude Code session only:
+  1. Build the per-PR args + an empty results table with the harness scaffold:
+       ./judge-fanout-corpus-runner.sh --out /tmp/jf 3721:merged 3699:rejected ...
+     It shells out to `gh pr diff` (read-only) and writes pr-<N>.args.json plus
+     results.md. It does NOT invoke the Workflow tool (that would need a second
+     nesting level, #3289).
+  2. Copy judge-fanout-workflow.js into a discovered workflows/ directory
      (user or project settings), OR invoke it directly with the Workflow tool:
        Workflow({ scriptPath: "<abs path to judge-fanout-workflow.js>",
-                  args: { pr: <N>, diff: "<unified diff text>" } })
-  2. Do this from a top-level session (NOT a subagent), so the workflow's
-     agent()/parallel() calls are the first nesting level (#3289-safe).
-  3. Compare its verdict/findings against today's single-pass Judge on a fixed
-     3-5 PR corpus (precision / recall / latency / token cost). Record RAW
-     results — do not fabricate numbers.
+                  args: <contents of pr-<N>.args.json> })
+     Do this from a top-level session (NOT a subagent), so the workflow's
+     agent()/parallel() calls are the first nesting level (#3289-safe). Never
+     drive it from a `fable` session — the No-Fable-Judge invariant (#3702)
+     applies to the fan-out reviewers.
+  3. Record verdict / findings / droppedUnverified + measured latency + token
+     cost into results.md (template: judge-fanout-results-template.md), and
+     compare against today's single-pass Judge. Record RAW results — do not
+     fabricate numbers.
+
+  Full procedure: docs/research/judge-fanout-measurement-runbook.md
 
 This script intentionally stops here: it does NOT dispatch a live judge run.
 GUIDE

--- a/defaults/scripts/experiments/judge-fanout-results-template.md
+++ b/defaults/scripts/experiments/judge-fanout-results-template.md
@@ -1,0 +1,61 @@
+<!--
+  judge-fanout-results-template.md — EMPTY results template (issue #3748).
+
+  This template is shipped INTENTIONALLY EMPTY. No precision / recall / latency /
+  token-cost numbers have been measured, and none are fabricated (the #3739
+  evaluation and #3748 both forbid inventing data). An operator running the
+  deferred measurement from a TOP-LEVEL Claude Code session fills the rows in
+  with REAL numbers — see docs/research/judge-fanout-measurement-runbook.md.
+
+  Provenance of the numbers, once measured:
+    - Dimension findings   : count of raw findings across all four reviewers
+                             (workflow result: sum before adversarial verify).
+    - Verified findings    : findings the adversarial pass kept
+                             (workflow result: `findings.length`).
+    - Precision            : 1 - (unverified nits / total findings)
+                             = verified / (verified + droppedUnverified).
+    - Recall               : dimensions that produced a *verified* finding,
+                             judged against the PR's known real defects.
+    - Fan-out latency (s)  : wall-clock for the whole Workflow({...}) call.
+    - Token cost           : tokens/$ for the fan-out run (from the session's
+                             transcript usage; see the runbook).
+    - Single-pass baseline : the same PR reviewed by today's single-pass Judge
+                             (defaults/roles/judge.md), for the A/B comparison.
+-->
+
+# Judge fan-out measurement results (issue #3748)
+
+**Status: UNMEASURED.** Fill this in from a top-level session per the runbook.
+Do not fabricate numbers.
+
+## Corpus
+
+3–5 PRs with known ground-truth outcomes (a mix of already-merged and
+already-rejected). Record each PR's number and true outcome before running.
+
+## Results
+
+| PR # | Known outcome | Dimension findings | Verified findings | Precision (1 - unverified-nit rate) | Recall (dimensions caught) | Fan-out latency (s) | Token cost | Single-pass Judge baseline |
+|------|---------------|--------------------|-------------------|-------------------------------------|----------------------------|---------------------|------------|----------------------------|
+|      |               |                    |                   |                                     |                            |                     |            |                            |
+|      |               |                    |                   |                                     |                            |                     |            |                            |
+|      |               |                    |                   |                                     |                            |                     |            |                            |
+
+## Aggregate
+
+| Metric | Fan-out | Single-pass Judge |
+|--------|---------|-------------------|
+| Mean precision |  |  |
+| Mean recall |  |  |
+| Mean latency (s) |  |  |
+| Mean token cost |  |  |
+
+## Keep / kill call
+
+_(Deferred operator action — requires the measured numbers above. Not part of
+the #3748 builder deliverable.)_
+
+- Decision:
+- Rationale (grounded in the measured table, not speculation):
+- If keep: follow-up proposing how the fan-out slots behind the sweep Judge
+  phase behind `LOOM_JUDGE_FANOUT_EXPERIMENT` / a config flag.

--- a/defaults/scripts/experiments/judge-fanout-workflow.js
+++ b/defaults/scripts/experiments/judge-fanout-workflow.js
@@ -1,20 +1,25 @@
 /**
- * judge-fanout-workflow.js — DESIGN SKETCH (issue #3739, exploration only)
+ * judge-fanout-workflow.js — Judge fan-out prototype (issues #3739 → #3748)
  * =========================================================================
  *
  * A Claude Code Dynamic Workflow that reviews ONE pull request by fanning out
  * dimension-scoped reviewers, running a typed adversarial "verify" pass, and
  * reducing to a single schema-shaped verdict.
  *
- * STATUS: DESIGN SKETCH — NOT WIRED INTO PRODUCTION.
- *   - This file is intentionally placed under defaults/scripts/experiments/,
- *     which is NOT a discovered `workflows/` directory, so Claude Code will not
- *     auto-load it. It is inert until a human deliberately copies/points a
- *     top-level session at it (see defaults/scripts/experiments/README.md).
- *   - It is NOT referenced by defaults/.claude/commands/loom/sweep.md or
+ * STATUS: EXPERIMENT ARTIFACT — NOT WIRED INTO PRODUCTION.
+ *   #3739 shipped this as an off-by-default DESIGN SKETCH with trivial prompts.
+ *   #3748 HARDENED it into a load-bearing artifact: real dimension-scoped
+ *   reviewer prompts, a fuller adversarial-verify prompt, and a No-Fable-Judge
+ *   guard — while keeping every invariant below. It remains:
+ *   - Under defaults/scripts/experiments/, which is NOT a discovered `workflows/`
+ *     directory, so Claude Code will not auto-load it. It is inert until a human
+ *     deliberately copies/points a top-level session at it (see README.md +
+ *     docs/research/judge-fanout-measurement-runbook.md).
+ *   - NOT referenced by defaults/.claude/commands/loom/sweep.md or
  *     defaults/roles/judge.md. The production judge path is untouched.
- *   - The runnable prototype + measured comparison are DEFERRED to a follow-up
- *     (see docs/research/dynamic-workflows-evaluation.md → "What is deferred").
+ *   - The measured comparison (precision / recall / latency / token cost vs. the
+ *     single-pass Judge) is still a DEFERRED OPERATOR ACTION — it requires the
+ *     Workflow tool, which only a top-level session has. See the runbook.
  *
  * SUBSTRATE: in-session, single-token, exactly ONE level deep (#3289).
  *   - `agent()` calls below are DIRECT — this workflow never calls `workflow()`,
@@ -27,8 +32,18 @@
  * READ-ONLY / SIDE-EFFECT-FREE by construction:
  *   - Returns a verdict object. Applies NO labels, merges NOTHING, transitions
  *     no loom:pr / loom:changes-requested state, creates NO GitHub issues.
- *   - The caller (a future runnable prototype) decides what, if anything, to do
- *     with the verdict. During the experiment, the answer is "just record it".
+ *   - The caller (the measurement harness) decides what, if anything, to do with
+ *     the verdict. During the experiment, the answer is "just record it".
+ *
+ * NO-FABLE-JUDGE INVARIANT (issue #3702; see
+ * defaults/.claude/commands/loom/sweep.md § "Model selection for subagent
+ * dispatch"): a fan-out reviewer's resolved model must NEVER be `fable`.
+ * Reviewing security-adjacent diffs is precisely Fable's refusal surface, and a
+ * refusing reviewer would poison the verdict. `assertNotFable()` below enforces
+ * this for any model explicitly passed via `args.model` / per-dimension
+ * override. When no model is passed the reviewer inherits the session default,
+ * so the operator MUST NOT drive this workflow from a `fable` session (the
+ * runbook says so explicitly).
  *
  * API: written against Claude Code CLI v2.1.206, whose workflow VM injects the
  * globals `agent`, `parallel`, `pipeline`, `workflow`, `budget`, `args`,
@@ -37,15 +52,17 @@
  *
  * Expected `args` shape (passed via the Workflow tool's `args`):
  *   {
- *     pr: number,             // PR number under review (for labeling only)
- *     diff: string,           // the unified diff text to review
- *     dimensions?: string[],  // optional override of the default dimension set
+ *     pr: number,               // PR number under review (for labeling only)
+ *     diff: string,             // the unified diff text to review
+ *     dimensions?: string[],    // optional override of the default dimension set
+ *     model?: string,           // optional reviewer/verifier model (NEVER "fable")
+ *     dimensionModels?: object,  // optional per-dimension model override map
  *   }
  *
  * @workflow-meta (illustrative — the real meta header format is owned by the
  * CLI's workflow-discovery loader; reproduced here as documentation only):
  *   name: judge-fanout-experiment
- *   description: Multi-dimension PR review fan-out + adversarial verify (experiment #3739)
+ *   description: Multi-dimension PR review fan-out + adversarial verify (experiment #3739/#3748)
  *   whenToUse: Experiment only — never on the production sweep/judge path.
  */
 
@@ -59,6 +76,49 @@ const DEFAULT_DIMENSIONS = [
   "test-coverage",
   "perf-simplification",
 ];
+
+// Per-dimension review guidance. Each reviewer is scoped to EXACTLY one lens so
+// the fan-out actually buys dimension coverage instead of four redundant
+// general reviews. The guidance mirrors the production Judge dimensions
+// (defaults/roles/judge.md) without importing any production code path.
+const DIMENSION_GUIDANCE = {
+  correctness: [
+    "Focus: functional correctness and logic. Does the change do what it claims?",
+    "Look for: off-by-one errors, inverted conditionals, unhandled null/undefined,",
+    "  wrong operator precedence, race conditions, resource leaks, incorrect error",
+    "  handling, edge cases (empty input, boundary values), and regressions in",
+    "  behavior the diff touches.",
+    "Ignore: style, security, test presence, and performance — other reviewers own those.",
+  ],
+  "security-credential-surface": [
+    "Focus: the security and credential surface ONLY.",
+    "Look for: hard-coded secrets/tokens/keys, credentials written to tracked or",
+    "  non-gitignored paths, world-readable secret files (missing 0600/0700),",
+    "  command/SQL/path injection, unsanitized input reaching a shell or eval,",
+    "  overly broad file permissions, secrets logged or echoed, and auth checks",
+    "  that are weakened or bypassed.",
+    "Ignore: general correctness, test coverage, and performance.",
+  ],
+  "test-coverage": [
+    "Focus: test coverage of the change ONLY.",
+    "Look for: new/changed behavior that ships with NO test, tests that assert",
+    "  nothing meaningful, happy-path-only coverage that skips error/edge cases,",
+    "  and deleted or weakened assertions. Note when a bug-fix lacks a regression",
+    "  test that would have caught the bug.",
+    "Ignore: whether the non-test code is itself correct/secure/fast — flag only",
+    "  the ABSENCE or weakness of tests.",
+  ],
+  "perf-simplification": [
+    "Focus: performance and unnecessary complexity ONLY.",
+    "Look for: work that scales with the dataset added to a hot/build path,",
+    "  accidental O(n^2), redundant I/O or subprocess spawns in loops, and code",
+    "  that is more complex than the problem requires (dead branches, needless",
+    "  abstraction, duplicated logic that could be one call).",
+    "Build-time perf is load-bearing, not advisory: downstream deploy scripts",
+    "  hard-cap builds with `timeout`, so per-item build work is a real risk.",
+    "Ignore: correctness bugs, security, and test coverage.",
+  ],
+};
 
 // A finding a dimension reviewer emits. `evidenceLine` anchors the claim to the
 // diff so the adversarial pass can check it is actually supported.
@@ -114,28 +174,75 @@ const VERIFIED_FINDINGS_SCHEMA = {
   },
 };
 
-// --- Prompt builders (kept trivial — the real prompts would be fuller) ------
+// --- No-Fable-Judge guard (#3702) -------------------------------------------
+
+// A fan-out reviewer/verifier resolved model must NEVER be `fable`. This mirrors
+// the production No-Fable-Judge hard invariant: the reviewer here plays the
+// Judge role, and Fable refuses security-adjacent diffs. We only guard models
+// that are EXPLICITLY passed — a null model inherits the session default, which
+// the runbook forbids from being fable.
+function assertNotFable(model, context) {
+  if (model == null || model === "") return;
+  const m = String(model).toLowerCase();
+  // Match the alias `fable` and any pinned ID that carries the fable family name.
+  if (m === "fable" || m.includes("fable")) {
+    throw new Error(
+      `judge-fanout: No-Fable-Judge invariant (#3702) violated — ${context} ` +
+        `model must never be fable (got "${model}"). Use opus/sonnet instead.`,
+    );
+  }
+}
+
+// --- Prompt builders --------------------------------------------------------
 
 function reviewPrompt(dimension, diff) {
+  const guidance = DIMENSION_GUIDANCE[dimension] || [
+    `Review ONLY through the "${dimension}" lens; ignore issues outside it.`,
+  ];
   return [
-    `You are a code reviewer scoped to exactly ONE dimension: "${dimension}".`,
-    `Review ONLY through that lens. Ignore issues outside your dimension.`,
-    `For every finding, cite the diff hunk header or line it rests on (evidenceLine).`,
-    `Do not invent issues; if the diff is clean for your dimension, return no findings.`,
+    `You are a senior code reviewer scoped to EXACTLY ONE dimension: "${dimension}".`,
+    `Review the unified diff below through that single lens and no other.`,
     ``,
-    `DIFF:`,
+    ...guidance,
+    ``,
+    `Rules:`,
+    `  - For EVERY finding, set evidenceLine to the diff hunk header (e.g.`,
+    `    "@@ -10,7 +10,9 @@ ...") or the exact added/removed line the claim rests`,
+    `    on. A finding with no locatable evidence in the diff will be dropped by`,
+    `    the downstream adversarial verifier, so do not guess.`,
+    `  - Do NOT invent issues. If the diff is clean for your dimension, return an`,
+    `    empty findings array. A clean pass is a valid, valuable result.`,
+    `  - Grade severity honestly: blocker (must fix before merge), major`,
+    `    (should fix), minor (worth noting), nit (cosmetic). Do not inflate.`,
+    `  - Stay in scope: a correctness bug is NOT your finding if your dimension is`,
+    `    test-coverage — flag only what your lens owns.`,
+    ``,
+    `Return ONLY the schema-shaped object. DIFF follows:`,
+    ``,
     diff,
   ].join("\n");
 }
 
 function verifyPrompt(rawFindings, diff) {
   return [
-    `You are an ADVERSARIAL verifier. For each finding below, decide whether the`,
-    `DIFF actually supports it (diffSupported=true) or whether it is an unverified`,
-    `nit / hallucination / out-of-scope remark (diffSupported=false). Be strict:`,
-    `a finding is supported ONLY if the cited evidence is really in the diff.`,
+    `You are an ADVERSARIAL verifier auditing findings produced by a panel of`,
+    `single-dimension reviewers. Your job is to protect PRECISION: drop findings`,
+    `the diff does not actually support so the final verdict is not polluted by`,
+    `unverified nits, hallucinations, or out-of-scope remarks.`,
     ``,
-    `FINDINGS:`,
+    `For EACH finding below, decide diffSupported:`,
+    `  - true  ONLY if the cited evidence (evidenceLine / claim) is genuinely`,
+    `          present in the DIFF and the claim is a fair reading of it.`,
+    `  - false if the evidence is not in the diff, the claim overstates what the`,
+    `          diff shows, the issue is pre-existing (not introduced by this`,
+    `          diff), or the finding is speculative / out of the reviewer's`,
+    `          declared dimension.`,
+    `Be strict and skeptical: when in doubt, mark diffSupported=false and explain`,
+    `why in the reason field. Do NOT invent new findings and do NOT upgrade`,
+    `severities — re-emit each finding's original severity/dimension/claim`,
+    `verbatim, adding only diffSupported + reason.`,
+    ``,
+    `FINDINGS (JSON):`,
     JSON.stringify(rawFindings, null, 2),
     ``,
     `DIFF:`,
@@ -153,8 +260,8 @@ const dimensions = Array.isArray(args?.dimensions) && args.dimensions.length
   ? args.dimensions
   : DEFAULT_DIMENSIONS;
 
-// Guard: this sketch is single-PR and single-token. Refuse absurd fan-outs so a
-// mis-call can't blow the shared budget. (budget is a shared HARD ceiling in
+// Guard: this prototype is single-PR and single-token. Refuse absurd fan-outs so
+// a mis-call can't blow the shared budget. (budget is a shared HARD ceiling in
 // 2.1.206; agent() throws once it is exhausted anyway — this is belt-and-braces.)
 if (dimensions.length > 8) {
   throw new Error(
@@ -162,19 +269,43 @@ if (dimensions.length > 8) {
   );
 }
 
+// No-Fable-Judge: validate every explicitly-passed model BEFORE dispatching any
+// agent, so a fable model fails fast instead of poisoning a partial fan-out.
+const reviewerModel = args?.model ?? null;
+assertNotFable(reviewerModel, "fan-out reviewer/verifier");
+const dimensionModels = (args && args.dimensionModels) || {};
+for (const dim of dimensions) {
+  assertNotFable(dimensionModels[dim], `dimension reviewer "${dim}"`);
+}
+
+// Resolve the model for one dimension: per-dimension override → global override →
+// null (inherit session default). Never fable (asserted above).
+function reviewerModelFor(dim) {
+  return dimensionModels[dim] ?? reviewerModel ?? null;
+}
+
+// Build the agent() options for one dimension reviewer, omitting `model` when it
+// resolves to null so the agent inherits the session default cleanly.
+function reviewerOpts(dim) {
+  const opts = {
+    label: `review:${dim}`,
+    phase: "review", // explicit phase group avoids racing the global phase()
+    // #3705 note: effort IS recoverable in-session (agent accepts opts.effort);
+    // correctness gets the highest tier, the rest medium.
+    effort: dim === "correctness" ? "high" : "medium",
+    schema: FINDINGS_SCHEMA,
+  };
+  const m = reviewerModelFor(dim);
+  if (m != null && m !== "") opts.model = m;
+  return opts;
+}
+
 // 1. FAN OUT — one reviewer per dimension. Direct agent() calls => exactly one
 //    level deep. parallel() is a BARRIER: it awaits all reviewers.
 const rawFindings = (
   await parallel(
     dimensions.map((dim) => () =>
-      agent(reviewPrompt(dim, String(args?.diff ?? "")), {
-        label: `review:${dim}`,
-        phase: "review", // explicit phase group avoids racing the global phase()
-        // #3705 note: effort IS recoverable in-session (agent accepts opts.effort);
-        // correctness gets the highest tier, the rest medium.
-        effort: dim === "correctness" ? "high" : "medium",
-        schema: FINDINGS_SCHEMA,
-      }),
+      agent(reviewPrompt(dim, String(args?.diff ?? "")), reviewerOpts(dim)),
     ),
   )
 )
@@ -188,27 +319,38 @@ if (rawFindings.length === 0) {
     pr: args?.pr ?? null,
     verdict: "approve",
     findings: [],
+    droppedUnverified: 0,
     dimensionsCovered: dimensions,
     note: "no findings from any dimension reviewer",
   };
 }
 
 // 2. ADVERSARIAL VERIFY — an agent() with a schema (NOT a verify() primitive).
-//    Drops findings the diff doesn't actually support.
-const verifyResult = await agent(verifyPrompt(rawFindings, String(args?.diff ?? "")), {
+//    Drops findings the diff doesn't actually support. Reuses the global model
+//    override when set (never fable — asserted above).
+const verifyOpts = {
   label: "adversarial-verify",
   phase: "verify",
   effort: "high",
   schema: VERIFIED_FINDINGS_SCHEMA,
-});
+};
+if (reviewerModel != null && reviewerModel !== "") verifyOpts.model = reviewerModel;
+
+const verifyResult = await agent(
+  verifyPrompt(rawFindings, String(args?.diff ?? "")),
+  verifyOpts,
+);
 
 const verified = ((verifyResult && verifyResult.findings) || []).filter(
   (f) => f && f.diffSupported === true,
 );
 
 // 3. TYPED REDUCE — plain JS. No free-text/label parsing. READ-ONLY: we return a
-//    verdict; we apply nothing to the PR.
-const hasBlocker = verified.some((f) => f.severity === "blocker" || f.severity === "major");
+//    verdict; we apply nothing to the PR. A blocker or major finding fails the
+//    review; minor/nit findings are recorded but do not block.
+const hasBlocker = verified.some(
+  (f) => f.severity === "blocker" || f.severity === "major",
+);
 
 return {
   pr: args?.pr ?? null,

--- a/defaults/scripts/tests/test-judge-fanout-experiment.sh
+++ b/defaults/scripts/tests/test-judge-fanout-experiment.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# test-judge-fanout-experiment.sh — tests for the #3739/#3748 Judge fan-out
+# experiment artifacts.
+#
+# Covers everything testable WITHOUT the Workflow tool (which a builder/CI does
+# not have):
+#   1. judge-fanout-workflow.js is syntactically loadable (compile-only via the
+#      same vm.Script wrap-and-never-execute pattern the gate uses), including
+#      the #3748 hardened prompts + No-Fable-Judge guard.
+#   2. judge-fanout-experiment.sh with the flag UNSET is a strict no-op: exit 0,
+#      no dispatch, and it writes no files.
+#   3. judge-fanout-experiment.sh with the flag SET syntax-checks both the
+#      workflow and the corpus-runner scaffold and still runs no live judge.
+#   4. The corpus-runner scaffold's non-Workflow-tool logic (arg validation,
+#      results-table emission) runs and produces the expected shape — without
+#      ever invoking the Workflow tool (a stub `gh` provides the diff).
+#
+# Usage:
+#   bash defaults/scripts/tests/test-judge-fanout-experiment.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+EXP_DIR="$REPO_ROOT/defaults/scripts/experiments"
+GATE="$EXP_DIR/judge-fanout-experiment.sh"
+WORKFLOW_JS="$EXP_DIR/judge-fanout-workflow.js"
+RUNNER="$EXP_DIR/judge-fanout-corpus-runner.sh"
+TEMPLATE="$EXP_DIR/judge-fanout-results-template.md"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
+TESTS_RUN=0; TESTS_PASSED=0; TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN+1)); TESTS_PASSED=$((TESTS_PASSED+1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { TESTS_RUN=$((TESTS_RUN+1)); TESTS_FAILED=$((TESTS_FAILED+1)); echo -e "  ${RED}FAIL${NC}: $1"; }
+assert_eq()       { if [[ "$1" == "$2" ]]; then pass "$3"; else fail "$3 (got '$1' want '$2')"; fi; }
+assert_contains() { if [[ "$1" == *"$2"* ]]; then pass "$3"; else fail "$3 (missing '$2' in: $1)"; fi; }
+assert_file()     { if [[ -f "$1" ]]; then pass "$2"; else fail "$2 (missing: $1)"; fi; }
+assert_no_file()  { if [[ ! -f "$1" ]]; then pass "$2"; else fail "$2 (unexpectedly present: $1)"; fi; }
+
+echo "Preflight: artifacts present"
+assert_file "$GATE" "gate script exists"
+assert_file "$WORKFLOW_JS" "workflow JS exists"
+assert_file "$RUNNER" "corpus-runner scaffold exists"
+assert_file "$TEMPLATE" "results template exists"
+echo ""
+
+echo "Case 1: workflow JS is syntactically loadable (compile-only, never executed)"
+if command -v node >/dev/null 2>&1; then
+  OUT="$(node -e '
+    const fs = require("fs");
+    const vm = require("vm");
+    const body = fs.readFileSync(process.argv[1], "utf8");
+    new vm.Script("(async () => {\n" + body + "\n})", { filename: process.argv[1] });
+    console.log("COMPILE_OK");
+  ' "$WORKFLOW_JS" 2>&1)"
+  RC=$?
+  assert_eq "$RC" "0" "workflow compiles clean"
+  assert_contains "$OUT" "COMPILE_OK" "workflow compile emitted OK marker"
+  # The hardened artifact must carry its guardrails.
+  assert_contains "$(cat "$WORKFLOW_JS")" "assertNotFable" "No-Fable-Judge guard present (#3702)"
+  assert_contains "$(cat "$WORKFLOW_JS")" "security-credential-surface" "dimension-scoped prompt present"
+else
+  echo "  (node not found — skipping compile check)"
+fi
+echo ""
+
+echo "Case 2: flag UNSET is a strict no-op (exit 0, no dispatch, no file writes)"
+SENTINEL_DIR="$(mktemp -d "${TMPDIR:-/tmp}/jf-noop.XXXXXX")"
+# Run the gate with the flag unset, cwd inside an empty sentinel dir so any
+# accidental file write would be detectable.
+OUT="$( cd "$SENTINEL_DIR" && env -u LOOM_JUDGE_FANOUT_EXPERIMENT bash "$GATE" 2>&1 )"; RC=$?
+assert_eq "$RC" "0" "flag-unset gate exits 0"
+assert_contains "$OUT" "disabled" "flag-unset gate reports disabled"
+assert_contains "$OUT" "no-op" "flag-unset gate reports no-op"
+# The disabled path must not run the syntax-check banner or the live-run guidance.
+if [[ "$OUT" == *"EXPERIMENT (#3739)"* ]]; then fail "flag-unset must not print the enabled banner"; else pass "flag-unset prints no enabled banner"; fi
+# No files created in the sentinel dir.
+CREATED="$(find "$SENTINEL_DIR" -mindepth 1 2>/dev/null | wc -l | tr -d ' ')"
+assert_eq "$CREATED" "0" "flag-unset gate writes no files"
+# Explicit off-ish values are also no-ops.
+for v in 0 false no off ""; do
+  RC2=0
+  ( cd "$SENTINEL_DIR" && LOOM_JUDGE_FANOUT_EXPERIMENT="$v" bash "$GATE" >/dev/null 2>&1 ) || RC2=$?
+  assert_eq "$RC2" "0" "flag='$v' is a no-op exit 0"
+done
+rm -rf "$SENTINEL_DIR"
+echo ""
+
+echo "Case 3: flag SET syntax-checks both artifacts and runs no live judge"
+OUT="$( LOOM_JUDGE_FANOUT_EXPERIMENT=1 bash "$GATE" 2>&1 )"; RC=$?
+assert_eq "$RC" "0" "flag-set gate exits 0"
+assert_contains "$OUT" "EXPERIMENT (#3739)" "flag-set gate prints enabled banner"
+if command -v node >/dev/null 2>&1; then
+  assert_contains "$OUT" "syntax OK" "flag-set gate syntax-checks the workflow"
+fi
+assert_contains "$OUT" "corpus-runner scaffold syntax OK" "flag-set gate syntax-checks the scaffold"
+assert_contains "$OUT" "does NOT dispatch a live judge" "flag-set gate confirms no live run"
+echo ""
+
+echo "Case 4: corpus-runner scaffold logic runs + produces expected shape (no Workflow tool)"
+RUN_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/jf-run.XXXXXX")"
+# Stub `gh` so the scaffold's `gh pr diff` returns a fake diff — no network, no
+# real GitHub calls, and definitely no Workflow tool.
+STUB_BIN="$RUN_ROOT/bin"; mkdir -p "$STUB_BIN"
+cat > "$STUB_BIN/gh" <<'STUB'
+#!/usr/bin/env bash
+# minimal gh stub: only `gh pr diff <N>` is exercised.
+if [[ "$1" == "pr" && "$2" == "diff" ]]; then
+  printf '%s\n' "@@ -1,2 +1,3 @@ stub" "+added line for PR $3"
+  exit 0
+fi
+exit 0
+STUB
+chmod +x "$STUB_BIN/gh"
+
+OUT_DIR="$RUN_ROOT/out"
+OUT="$( PATH="$STUB_BIN:$PATH" bash "$RUNNER" --out "$OUT_DIR" 3721:merged 3699:rejected 2>&1 )"; RC=$?
+assert_eq "$RC" "0" "scaffold exits 0"
+assert_file "$OUT_DIR/pr-3721.args.json" "per-PR args built for 3721"
+assert_file "$OUT_DIR/pr-3699.args.json" "per-PR args built for 3699"
+assert_file "$OUT_DIR/results.md" "results table emitted"
+# args JSON has the expected keys and PR number.
+ARGS="$(cat "$OUT_DIR/pr-3721.args.json")"
+assert_contains "$ARGS" '"pr": 3721' "args carries pr number"
+assert_contains "$ARGS" '"diff":' "args carries diff field"
+assert_contains "$ARGS" "added line for PR 3721" "args diff came from gh stub"
+# results table has header + one row per PR, ground-truth outcome filled, measured cells blank.
+TBL="$(cat "$OUT_DIR/results.md")"
+assert_contains "$TBL" "| PR # | Known outcome |" "results table has the expected header"
+assert_contains "$TBL" "| 3721 | merged |" "row for 3721 with known outcome, empty measured cells"
+assert_contains "$TBL" "| 3699 | rejected |" "row for 3699 with known outcome"
+assert_contains "$TBL" "Do NOT fabricate data" "results table warns against fabricated data"
+# The scaffold's Workflow hook point must stay an UNFILLED, documented stub — a
+# builder cannot invoke the Workflow tool (#3289), so it exists only as a marked
+# TODO/example. (bash cannot invoke Workflow at all — any occurrence is textual —
+# so we assert the stub markers are present rather than grep for the call string.)
+RUNNER_SRC="$(cat "$RUNNER")"
+assert_contains "$RUNNER_SRC" "HOOK POINT (UNFILLED" "scaffold marks the hook point UNFILLED"
+assert_contains "$RUNNER_SRC" "emit_workflow_invocation_stub" "scaffold hook point is a stub function"
+assert_contains "$RUNNER_SRC" "does NOT invoke the Workflow tool" "scaffold documents it never invokes the tool"
+
+echo ""
+echo "Case 5: scaffold input validation rejects bad specs"
+RC2=0; ( PATH="$STUB_BIN:$PATH" bash "$RUNNER" --out "$OUT_DIR" notanumber >/dev/null 2>&1 ) || RC2=$?
+if [[ "$RC2" -ne 0 ]]; then pass "non-numeric PR spec rejected"; else fail "non-numeric PR spec should be rejected"; fi
+RC3=0; ( PATH="$STUB_BIN:$PATH" bash "$RUNNER" --out "$OUT_DIR" 3721:bogus >/dev/null 2>&1 ) || RC3=$?
+if [[ "$RC3" -ne 0 ]]; then pass "invalid outcome rejected"; else fail "invalid outcome should be rejected"; fi
+RC4=0; ( PATH="$STUB_BIN:$PATH" bash "$RUNNER" --out "$OUT_DIR" >/dev/null 2>&1 ) || RC4=$?
+if [[ "$RC4" -ne 0 ]]; then pass "no-PR invocation rejected"; else fail "no-PR invocation should be rejected"; fi
+rm -rf "$RUN_ROOT"
+echo ""
+
+echo "════════════════════════════════════════════"
+echo "  Total: $TESTS_RUN  Passed: $TESTS_PASSED  Failed: $TESTS_FAILED"
+echo "════════════════════════════════════════════"
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/docs/research/judge-fanout-measurement-runbook.md
+++ b/docs/research/judge-fanout-measurement-runbook.md
@@ -1,0 +1,141 @@
+# Judge fan-out measurement runbook (issue #3748)
+
+**Audience:** an operator with the Workflow tool — i.e. a person driving a
+**top-level** Claude Code session, not a subagent.
+
+**What this runbook is for:** executing the *deferred* measurement that #3739
+(design sketch) and #3748 (hardened artifact + scaffold) could not perform. A
+`loom-builder` subagent cannot run it, because:
+
+- The Workflow tool (`agent()` / `parallel()` / `workflow()`) is exposed only to
+  a top-level Claude Code session. A subagent dispatched via the Task tool has no
+  access to it.
+- Even if it did, driving the workflow from inside a subagent would add a
+  **second nesting level** (subagent → workflow-agent), which is exactly the
+  #3289 one-level-deep stall the evaluation forbids.
+
+So the builder delivered everything *short of* invoking the Workflow tool: the
+hardened workflow, a measurement-harness scaffold, an empty results template,
+and tests. This runbook is how **you** finish the job.
+
+> **Do not fabricate numbers.** The evaluation doc
+> (`docs/research/dynamic-workflows-evaluation.md`) is explicit that no
+> precision/recall/latency/cost numbers were invented, and #3748 keeps that
+> invariant. If you did not measure it, leave the cell blank.
+
+---
+
+## Artifacts
+
+| File | Role |
+|------|------|
+| `defaults/scripts/experiments/judge-fanout-workflow.js` | The workflow you invoke via the Workflow tool. Fan-out reviewers + adversarial verify + typed reduce. Read-only; returns a verdict. |
+| `defaults/scripts/experiments/judge-fanout-corpus-runner.sh` | Scaffold that builds per-PR `args` from `gh pr diff` and emits an empty results table. Does **not** invoke the Workflow tool. |
+| `defaults/scripts/experiments/judge-fanout-results-template.md` | Empty results table you fill in with real numbers. |
+| `defaults/scripts/experiments/judge-fanout-experiment.sh` | Off-by-default gate. Syntax-checks the two above when `LOOM_JUDGE_FANOUT_EXPERIMENT=1`; never runs a live judge. |
+
+Everything stays **off the production path**: none of this is wired into
+`defaults/roles/judge.md` or the sweep Judge phase, and the flag stays off by
+default.
+
+---
+
+## Step 1 — Select the corpus (3–5 PRs)
+
+Pick 3–5 already-closed PRs with **known ground-truth outcomes** — a mix of:
+
+- **merged** PRs (the fan-out should mostly `approve` these), and
+- **rejected** PRs (the fan-out should catch the real defect and return
+  `changes-requested`).
+
+Prefer PRs whose real defects span the four dimensions
+(`correctness`, `security-credential-surface`, `test-coverage`,
+`perf-simplification`) so recall is actually exercised. Record each PR number and
+its true outcome before running — that is your answer key.
+
+## Step 2 — Build per-PR args + the empty results table
+
+From the repo root (a normal shell is fine for this step — it is read-only on
+GitHub):
+
+```bash
+cd defaults/scripts/experiments
+./judge-fanout-corpus-runner.sh --out /tmp/jf 3721:merged 3699:rejected 3688:merged
+```
+
+This writes, under `/tmp/jf/`:
+
+- `pr-<N>.args.json` — the exact `{ "pr": <N>, "diff": "<unified diff>" }` object
+  the Workflow tool wants, one per PR.
+- `results.md` — an empty results table, one row per PR (every measured cell
+  blank).
+
+`--dry-run` previews without touching anything; `--diff-only` skips the table.
+
+## Step 3 — Invoke the workflow from a top-level session
+
+This is the step only a top-level session can do. For each PR, invoke the
+Workflow tool with the script path and that PR's args:
+
+```
+Workflow({
+  scriptPath: "<abs path>/defaults/scripts/experiments/judge-fanout-workflow.js",
+  args:       <paste the contents of pr-<N>.args.json>,
+})
+```
+
+Alternatively, copy `judge-fanout-workflow.js` into a discovered `workflows/`
+directory (user or project settings) so the CLI auto-loads it, then invoke it by
+name.
+
+**Guardrails to preserve while you run it:**
+
+- **Top-level only, never a subagent** — keeps the workflow's `agent()` /
+  `parallel()` calls at the first nesting level (#3289-safe).
+- **Never from a `fable` session** — the fan-out reviewers play the Judge role,
+  and the No-Fable-Judge invariant (#3702) says a Judge/reviewer model must never
+  be `fable`. The workflow's `assertNotFable()` guard rejects an explicit
+  `args.model: "fable"`, but a `fable` **session default** would still be
+  inherited, so run from an opus/sonnet session. Optionally pass an explicit
+  non-fable `args.model` to pin the reviewers.
+- **Read-only** — the workflow returns a verdict object; it applies no labels,
+  merges nothing, and creates no issues. Do not add side effects.
+
+Capture, per PR: `result.verdict`, `result.findings` (verified),
+`result.droppedUnverified`, plus the wall-clock latency and token cost of the
+call (from the session transcript usage).
+
+## Step 4 — Establish the single-pass baseline
+
+For the same PRs, review each with **today's** single-pass Judge
+(`defaults/roles/judge.md`) and record its verdict, latency, and token cost.
+This is the A/B the whole exercise exists to produce.
+
+## Step 5 — Record real numbers
+
+Fill `results.md` (shape mirrors `judge-fanout-results-template.md`). Column
+provenance:
+
+- **Dimension findings** — raw findings summed across the four reviewers (before
+  verify).
+- **Verified findings** — `result.findings.length` (what the adversarial pass
+  kept).
+- **Precision** — `verified / (verified + droppedUnverified)` = `1 -
+  unverified-nit rate`.
+- **Recall** — dimensions that produced a *verified* finding, scored against the
+  PR's known real defects.
+- **Fan-out latency (s)** — wall-clock of the `Workflow({...})` call.
+- **Token cost** — tokens/$ for the run (transcript usage).
+- **Single-pass Judge baseline** — Step 4's numbers.
+
+## Step 6 — Keep / kill call (still deferred, but now grounded)
+
+With the measured table in hand, make the keep/kill decision the evaluation
+deferred. If **keep**, file a follow-up proposing how the fan-out slots behind
+the sweep Judge phase behind `LOOM_JUDGE_FANOUT_EXPERIMENT` / a config flag
+(still opt-in). If **kill**, record why in `results.md` and leave the production
+Judge path unchanged.
+
+> This step is a **deferred operator action**, explicitly out of scope for the
+> #3748 builder deliverable — it requires the measured numbers, which require the
+> Workflow tool.


### PR DESCRIPTION
## Summary

Implements the **builder-achievable slice** of #3748 — the "keep" surface from the #3739 Dynamic Workflows evaluation (multi-dimension Judge fan-out + adversarial verify). This ships the hardened workflow, a measurement-harness scaffold, an empty results template, tests, and an operator runbook.

**Scope boundary (critical):** A `loom-builder` subagent **cannot** run the live measurement. The Workflow tool (`agent()`/`parallel()`/`workflow()`) is exposed only to a **top-level** Claude Code session; a builder is a Task subagent with no access to it, and driving a workflow from a subagent would add a **second nesting level** (#3289). So this PR delivers everything **short of driving the Workflow tool**, and it fabricates **no** precision/recall/latency/cost numbers.

## What shipped (builder deliverable)

- **`judge-fanout-workflow.js`** — hardened from the #3739 trivial-prompt sketch into a load-bearing artifact:
  - Real dimension-scoped reviewer prompts, one per `DEFAULT_DIMENSIONS` (`correctness`, `security-credential-surface`, `test-coverage`, `perf-simplification`).
  - Fuller adversarial-verify prompt (precision-protecting, strict, no new findings).
  - **No-Fable-Judge guard** (`assertNotFable`, #3702) — validates every explicitly-passed reviewer/verifier model before any dispatch.
  - Strictly one level deep (direct `agent()`/`parallel()`, never `workflow()`), read-only, single-token, creates no issues. Optional `model` / `dimensionModels` overrides.
- **`judge-fanout-corpus-runner.sh`** — measurement-harness scaffold. Builds per-PR `args` (`{pr, diff}`) from `gh pr diff` (read-only on GitHub) and emits an empty results table. The `Workflow({...})` hook point is a clearly-marked **UNFILLED** stub (`emit_workflow_invocation_stub`) — filling it is the operator's deferred action.
- **`judge-fanout-results-template.md`** — empty results template (no invented data).
- **`judge-fanout-experiment.sh`** — extends the enabled-path check to also `bash -n` the scaffold; **flag-off (`LOOM_JUDGE_FANOUT_EXPERIMENT` unset) stays a strict no-op** (exit 0, no dispatch, no file writes).
- **`test-judge-fanout-experiment.sh`** — 40 assertions, all passing: workflow compile-only loadability + guard presence, flag-off strict no-op, flag-on syntax-checks both artifacts with no live run, and the scaffold's non-Workflow-tool logic (arg building via a `gh` stub, results-table shape, input validation).
- **`docs/research/judge-fanout-measurement-runbook.md`** — operator runbook for running the deferred measurement from a top-level session.

## Verification

- `node -e` compile-only (vm.Script) on the workflow JS — OK.
- `bash -n` on all three shell scripts — OK.
- `shellcheck` on all shell scripts — clean.
- `bash defaults/scripts/tests/test-judge-fanout-experiment.sh` — **40/40 pass**.

## Explicitly deferred (NOT part of this builder work — no data fabricated)

- An operator running the harness from a top-level session against a 3–5 PR corpus and recording **real** precision/recall/latency/cost numbers.
- The keep/kill recommendation, which requires those real numbers.

Nothing here is wired into `defaults/roles/judge.md` or the production sweep Judge phase; the flag stays off by default; **zero behavior change to the production path**.

Closes #3748

🤖 Generated with [Claude Code](https://claude.com/claude-code)