### PR TITLE
docs(models): observe-mode accrual runbook + fix observe→harvest model attribution (#3750)

### DIFF
--- a/docs/model-selection-retune.md
+++ b/docs/model-selection-retune.md
@@ -156,6 +156,113 @@ more is better, and a wider spread of issue difficulty makes `merge_rate` more
 trustworthy. Accumulating this sample is an **out-of-band, over-time activity** — it
 is deliberately **not** a Builder deliverable and must not be fabricated.
 
+### Runbook: accruing the observe-mode sample
+
+The `agent-metrics.sh --by-model` plumbing above reads the **activity DB**. A
+parallel, purpose-built collector — the `/loom:sweep` model-cost experiment
+(#3725/#3728) — writes a durable per-phase **outcome-chain** to
+`.loom/stats/sweep-model-stats.jsonl` (arm / model / attempt / Judge verdict /
+Doctor-cycle count / complexity) and harvests it into exactly the per-arm §2
+inequality inputs. This runbook is the copy-pasteable procedure for accruing that
+sample. See `defaults/CLAUDE.md` § "Model-Cost Experiment (canary A/B, #3725)" for
+the full behavior contract.
+
+> **This runbook is the *tooling*. The multi-day accrual run itself — turning on a
+> mode against real sweeps, waiting for the ≥~30-per-arm floor, harvesting a real
+> sample, and re-evaluating the §2 inequality — is a DEFERRED operator action, not
+> a Builder PR deliverable. Do not fabricate stats rows or a harvest report.**
+
+**Step 1 — choose a collection mode.** Tri-state `sweep.modelExperiment` /
+`LOOM_MODEL_EXPERIMENT` (env-over-config, string-valued like `guards.rmScope`):
+
+| Mode | What it collects | Fills both arms? |
+|------|------------------|------------------|
+| `observe` | Passive per-phase outcome-chain; **no model forcing, `arm=null`**. Safe anywhere. | **Only if the workspace itself already runs a mix of Builder models** (e.g. a `roleConfig.model` pin, or `sonnet` first attempts that escalate to `opus`). A stock `opus`-default workspace in `observe` only ever produces Arm A (opus) rows. |
+| `experiment` | Active A/B: Builder **forced** to the per-issue arm's model, complexity bump suppressed. **Canary-only.** | **Yes — deterministically balances A (opus) and B (sonnet).** This is the reliable way to fill both arms. |
+
+Because `observe` never forces a model, a default `opus` workspace cannot generate
+Arm B (sonnet) rows by observation alone — that is precisely why `experiment`
+(canary) mode exists. Harvest attributes an `observe` issue to an arm from its
+**observed Builder model** (opus⇒A, sonnet⇒B); rows whose Builder ran neither stay
+in the `?` bucket. So `observe` is the safe, always-on collector, but a *balanced*
+two-arm sample in a reasonable window generally needs `experiment` on a canary.
+
+**Step 2 — turn the mode on.** Per-invocation (env wins over config):
+
+```bash
+# Passive observe on any sweep (no behavior change; just records the outcome-chain):
+LOOM_MODEL_EXPERIMENT=observe claude -p "/loom:sweep 123" --dangerously-skip-permissions
+
+# Active A/B on a CANARY (must confirm the canary via an UNCOMMITTED signal, else
+# it loudly downgrades to observe):
+LOOM_MODEL_EXPERIMENT=experiment LOOM_MODEL_EXPERIMENT_CANARY=1 \
+  claude -p "/loom:sweep 123" --dangerously-skip-permissions
+```
+
+Or durably for a multi-day window via committed config (safe: the *mode* may live
+in config; it is inert without the uncommitted canary confirmation):
+
+```json
+// .loom/config.json
+{ "sweep": { "modelExperiment": "observe" } }
+```
+
+The canary confirmation must be **uncommitted** by design (#3731): either the
+`LOOM_MODEL_EXPERIMENT_CANARY=1` env var or the gitignored `.loom/CANARY` sentinel
+file (`touch .loom/CANARY`). The committed `sweep.modelExperimentCanary` flag is no
+longer accepted, and a git-tracked `.loom/CANARY` is refused.
+
+**Step 3 — no daemon-side config is needed.** `LOOM_MODEL_EXPERIMENT`,
+`LOOM_MODEL_EXPERIMENT_CANARY`, and `LOOM_TRANSCRIPT_ARCHIVE` propagate to
+daemon-dispatched detached sweep children (#3732), so a sweep launched via
+`mcp__loom__dispatch_sweep` inherits the mode from the daemon's environment — set
+the env (or the committed `sweep.modelExperiment`) once and every dispatched child
+records.
+
+**Step 4 — harvest periodically.** The harvest reader is reachable through the same
+`agent-metrics.sh` surface as `--by-model`, and directly via `sweep-experiment.sh`:
+
+```bash
+# Per-arm inequality inputs (first-pass rate, Doctor cycles, merge rate, cost):
+./.loom/scripts/agent-metrics.sh --model-experiment --archive-dir "$LOOM_TRANSCRIPT_ARCHIVE"
+# Equivalent direct entry point + JSON for scripted aggregation:
+./.loom/scripts/sweep-experiment.sh harvest --archive-dir "$LOOM_TRANSCRIPT_ARCHIVE" --format json
+```
+
+Passing `--archive-dir` (the #3726 transcript archive) upgrades cost from the
+best-effort sweep-aggregate estimate to **exact** per-role token cost — each
+harvested record carries a `token_fidelity` tag (`transcript` | `sweep-aggregate-log`
+| `none`) naming the source. Over a multi-day run, harvest on a cron so usage is
+extracted before `~/.claude/projects` is pruned (mirrors the `probe-tokens.sh` /
+`archive-transcripts.sh` cron pattern):
+
+```cron
+# Harvest every 30 minutes into a log:
+*/30 * * * * cd /path/to/repo && ./.loom/scripts/agent-metrics.sh --model-experiment \
+  --archive-dir "$LOOM_TRANSCRIPT_ARCHIVE" >> .loom/logs/model-experiment-harvest.log 2>&1
+```
+
+**Step 5 — read `n_issues` against the floor.** The harvest prints one row per arm:
+
+```
+  arm  model    issues  1st-pass  cycles  merge      cost$    $/issue
+  A    opus         31      87%    0.10    97%    ...       ...
+  B    sonnet       33      74%    0.55    96%    ...       ...
+```
+
+The sample is representative enough to evaluate the §2 inequality only when **both**
+arm A and arm B show `issues` (i.e. `n_issues`) ≥ ~30 (the "Minimum representative
+sample" floor above). Until then, `harvest` still runs cleanly — an empty or
+single-arm store reports `records: 0` / one arm and never crashes — but the
+`cost(sonnet_first) < cost(opus_first)` decision stays **unevaluable**, and the
+default remains `opus` (the Hard Rule at the top).
+
+**Step 6 (DEFERRED — operator, not this tooling PR).** Once both arms clear the
+floor, evaluate the §2 inequality against the harvested numbers and record a new
+dated entry in the Status log below — either another "keep opus" decision citing the
+now-non-empty sample, or, if conditions (1) and (2) both hold, open the separate
+gated flip PR per §5.
+
 ---
 
 ## 4. Plumbing verification (result)
@@ -234,6 +341,32 @@ here changes a default** unless it also cites a qualifying sample per Section 3.
   not a Builder code change. `observe` mode is the suggested follow-up mechanism for
   generating the `sonnet` vs `opus` data points a passive `opus`-only default can
   never produce on its own.
+
+- **2026-07-22 (#3750) — runbook + observe→harvest wiring shipped; still no data,
+  accrual DEFERRED.** Delivered the operator tooling to *make* the sample
+  collectable, not the sample itself:
+
+  - Added the "Runbook: accruing the observe-mode sample" procedure to §3 (turn on
+    `observe`/`experiment`, confirm the uncommitted canary, harvest on a cron via
+    `agent-metrics.sh --model-experiment`, read `n_issues` against the ≥~30-per-arm
+    floor).
+  - Fixed a genuine observe→harvest gap: a pure `observe`-mode store (every record
+    `arm=null`) previously collapsed into a single `?` bucket with `model=null`,
+    dropping each row's real Builder model — so the opus-vs-sonnet split was
+    unreadable. Harvest now infers an arm-null issue's arm from its observed Builder
+    model (opus⇒A, sonnet⇒B); explicit `experiment` arms are unchanged
+    (`loom-tools/src/loom_tools/sweep_experiment.py`, covered by new tests in
+    `loom-tools/tests/test_sweep_experiment.py`).
+
+  **Representative sample?** Still **no.** This entry ships tooling only and cites no
+  numbers — no real accrual run was performed and none was fabricated. The §2
+  inequality remains unevaluable until an operator accrues ≥~30 model-attributed
+  first attempts on **both** arms.
+
+  **Decision:** `defaults/roles/builder.json` `suggestedModel` remains `opus`. No
+  default changed. The multi-day accrual + harvest + §2 re-evaluation + any
+  opus→sonnet flip is the **deferred operator action** tracked by #3750, not closed
+  by its Builder PR.
 
 ---
 

--- a/loom-tools/src/loom_tools/sweep_experiment.py
+++ b/loom-tools/src/loom_tools/sweep_experiment.py
@@ -271,6 +271,41 @@ def arm_model(arm: str) -> str:
     return ARM_MODEL.get(arm.upper().strip(), "")
 
 
+def _model_family(model: str | None) -> str | None:
+    """Normalize a model alias or pinned ID to its family (mirrors ``model_pricing``)."""
+    m = (model or "").lower()
+    if "claude-3-5-sonnet" in m or "claude-sonnet-4" in m or m == "sonnet":
+        return "sonnet"
+    if "claude-3-opus" in m or "claude-opus-4" in m or m == "opus":
+        return "opus"
+    if "claude-3-haiku" in m or m == "haiku":
+        return "haiku"
+    return None
+
+
+# Inverse of ``ARM_MODEL`` by model family.
+_MODEL_FAMILY_TO_ARM = {"opus": "A", "sonnet": "B"}
+
+
+def infer_arm_from_model(model: str | None) -> str | None:
+    """Map an observed Builder model to its inequality arm (opus->A, sonnet->B).
+
+    ``observe`` mode records the outcome-chain **without** forcing a model, so its
+    records carry ``arm=null`` (only ``experiment`` mode stamps A/B). Without this
+    inference every observe-mode record collapses into the single ``"?"`` bucket
+    and the harvest drops the per-record ``model`` — so a passive multi-day
+    observe sample could never populate the opus/sonnet split the #3718 inequality
+    needs. Since Arm A is *defined* as opus and Arm B as sonnet (``ARM_MODEL``), an
+    observe issue whose Builder ran opus is opus-first evidence (arm A) and one
+    that ran sonnet is sonnet-first evidence (arm B).
+
+    Returns ``None`` for any model that is not one of the two inequality arms
+    (haiku, an unrecognized ID, or ``None``) so such records stay in ``"?"``
+    rather than being mis-attributed.
+    """
+    return _MODEL_FAMILY_TO_ARM.get(_model_family(model) or "")
+
+
 # --------------------------------------------------------------------------- #
 # Durable stats store (atomic O_APPEND, one JSONL line per phase invocation)
 # --------------------------------------------------------------------------- #
@@ -555,9 +590,42 @@ def harvest(
     (via transcript join where available), merge-rate quality floor, and the
     derived per-issue mean cost that feeds the sonnet-first vs opus-first
     inequality.
+
+    Arm attribution per issue: the explicit ``experiment``-mode arm (A/B) wins
+    when present; otherwise (``observe`` mode records ``arm=null``) the arm is
+    inferred from the issue's observed Builder model (opus->A, sonnet->B) so a
+    passive observe sample is still opus/sonnet-attributed instead of collapsing
+    into a single ``"?"`` bucket. Issues whose Builder model is neither opus nor
+    sonnet (or unknown) stay under ``"?"``.
     """
     records = read_records(stats_file)
     transcript_map = build_transcript_map(archive_dir)
+
+    # Pass 1 — resolve each issue's effective arm. Prefer the explicit experiment
+    # arm (experiment mode stamps A/B on every phase record). Absent it, observe
+    # mode records carry arm=null, so infer the arm from the issue's Builder model
+    # (opus->A, sonnet->B) — otherwise a passive observe sample collapses into a
+    # single "?" bucket and the opus/sonnet split #3718 needs is lost. An issue's
+    # arm is resolved once and applied to all of its phase records so cost is not
+    # scattered across arms (e.g. an Arm B issue's escalated opus Doctor cycle
+    # still counts under B).
+    issue_explicit_arm: dict[int, str] = {}
+    issue_builder_model: dict[int, str | None] = {}
+    for rec in records:
+        issue = rec.get("issue")
+        if issue is None:
+            continue
+        issue = int(issue)
+        arm = rec.get("arm")
+        if arm and issue not in issue_explicit_arm:
+            issue_explicit_arm[issue] = str(arm).upper()
+        if (rec.get("role") or "").lower() == "builder" and issue not in issue_builder_model:
+            issue_builder_model[issue] = rec.get("model")
+
+    def _issue_arm(issue: int) -> str:
+        if issue in issue_explicit_arm:
+            return issue_explicit_arm[issue]
+        return infer_arm_from_model(issue_builder_model.get(issue)) or "?"
 
     # Per-issue outcome roll-up, keyed (arm, issue).
     issues: dict[tuple[str, int], dict[str, Any]] = {}
@@ -566,8 +634,8 @@ def harvest(
     fidelity_counts: dict[str, int] = {"transcript": 0, "sweep-aggregate-log": 0, "none": 0}
 
     for rec in records:
-        arm = rec.get("arm") or "?"
         issue = rec.get("issue")
+        arm = _issue_arm(int(issue)) if issue is not None else (rec.get("arm") or "?")
         phase = (rec.get("phase") or "").lower()
         role = (rec.get("role") or "").lower()
 

--- a/loom-tools/tests/test_sweep_experiment.py
+++ b/loom-tools/tests/test_sweep_experiment.py
@@ -203,6 +203,22 @@ def test_unknown_complexity_normalizes_to_routine():
     assert se.assign_arm(10, "") == se.assign_arm(10, None)
 
 
+def test_infer_arm_from_model_maps_opus_a_sonnet_b():
+    # Aliases and pinned IDs both resolve to the same inequality arm.
+    assert se.infer_arm_from_model("opus") == "A"
+    assert se.infer_arm_from_model("claude-opus-4-8") == "A"
+    assert se.infer_arm_from_model("sonnet") == "B"
+    assert se.infer_arm_from_model("claude-sonnet-4-6") == "B"
+
+
+def test_infer_arm_from_model_unknown_is_none():
+    # Non-inequality models stay unattributed ("?" bucket), never mis-mapped.
+    assert se.infer_arm_from_model("haiku") is None
+    assert se.infer_arm_from_model("gpt-4") is None
+    assert se.infer_arm_from_model(None) is None
+    assert se.infer_arm_from_model("") is None
+
+
 # --------------------------------------------------------------------------- #
 # Pricing + transcript usage
 # --------------------------------------------------------------------------- #
@@ -393,6 +409,100 @@ def test_harvest_aggregation(tmp_path):
     assert b["merge_rate"] == 0.0
     # best-effort cost: 5000/1e3*0.003 + 800/1e3*0.015
     assert b["total_cost_usd"] == pytest.approx(0.027)
+
+
+def test_harvest_observe_mode_attributes_by_model_end_to_end(tmp_path):
+    """End-to-end observe->harvest wiring (#3750).
+
+    A pure ``observe``-mode sample carries ``arm=null`` on every record (only
+    ``experiment`` mode stamps A/B). This exercises the full record -> append ->
+    harvest chain and asserts the harvest still splits the sample into the
+    opus(A) / sonnet(B) inequality buckets from the observed Builder model — the
+    behavior the operator runbook relies on. A synthetic transcript-index fixture
+    confirms the harvest reader consumes it for exact per-arm cost.
+    """
+    archive = _make_archive(tmp_path)  # provides agent-bld1 (opus) transcript
+    stats = tmp_path / "observe-stats.jsonl"
+    sf = str(stats)
+
+    # Issue 300 — observe mode, Builder ran opus (arm intentionally omitted), joins
+    # the transcript fixture for exact cost; first-attempt judge pass; merged.
+    se.append_record(se.build_record(issue=300, phase="builder", role="builder",
+                                     model="opus", mode="observe",
+                                     agent_id="agent-bld1"), sf)
+    se.append_record(se.build_record(issue=300, phase="judge", role="judge",
+                                     mode="observe", attempt=1,
+                                     judge_verdict="pass"), sf)
+    se.append_record(se.build_record(issue=300, phase="merge", role="merge",
+                                     mode="observe"), sf)
+    # Issue 301 — observe mode, Builder ran sonnet; first-attempt judge reject then
+    # one doctor cycle; not merged.
+    se.append_record(se.build_record(issue=301, phase="builder", role="builder",
+                                     model="sonnet", mode="observe"), sf)
+    se.append_record(se.build_record(issue=301, phase="judge", role="judge",
+                                     mode="observe", attempt=1,
+                                     judge_verdict="changes"), sf)
+    se.append_record(se.build_record(issue=301, phase="doctor", role="doctor",
+                                     mode="observe", attempt=2), sf)
+
+    report = se.harvest(sf, str(archive))
+    arms = {a["arm"]: a for a in report["arms"]}
+
+    # Both inequality arms populated purely from observe-mode (arm-null) rows.
+    assert set(arms) == {"A", "B"}
+    assert arms["A"]["model"] == "opus"
+    assert arms["A"]["n_issues"] == 1
+    assert arms["A"]["first_attempt_pass_rate"] == 1.0
+    assert arms["A"]["merge_rate"] == 1.0
+    # Exact cost joined from the transcript fixture (not zero / not "none").
+    assert report["token_fidelity_counts"]["transcript"] == 1
+    assert arms["A"]["total_cost_usd"] > 0.0
+
+    assert arms["B"]["model"] == "sonnet"
+    assert arms["B"]["n_issues"] == 1
+    assert arms["B"]["first_attempt_pass_rate"] == 0.0
+    assert arms["B"]["mean_doctor_cycles"] == 1.0
+    assert arms["B"]["merge_rate"] == 0.0
+
+
+def test_harvest_explicit_arm_beats_model_inference(tmp_path):
+    """Experiment-mode explicit arm wins over the observed model (no regression).
+
+    An issue explicitly assigned Arm B (sonnet-first) whose escalated Doctor cycle
+    ran opus must stay entirely under B — the explicit arm is authoritative and
+    the opus Doctor record must not leak into an inferred Arm A bucket.
+    """
+    stats = tmp_path / "exp-stats.jsonl"
+    sf = str(stats)
+    se.append_record(se.build_record(issue=400, phase="builder", role="builder",
+                                     model="sonnet", mode="experiment", arm="B"), sf)
+    se.append_record(se.build_record(issue=400, phase="judge", role="judge",
+                                     mode="experiment", arm="B", attempt=1,
+                                     judge_verdict="changes"), sf)
+    # Escalated Doctor runs opus but is still Arm B evidence.
+    se.append_record(se.build_record(issue=400, phase="doctor", role="doctor",
+                                     model="opus", mode="experiment", arm="B",
+                                     attempt=2), sf)
+
+    report = se.harvest(sf, None)
+    arms = {a["arm"]: a for a in report["arms"]}
+    assert set(arms) == {"B"}
+    assert arms["B"]["n_issues"] == 1
+    assert arms["B"]["mean_doctor_cycles"] == 1.0
+
+
+def test_harvest_unknown_model_stays_in_question_bucket(tmp_path):
+    """Observe rows whose Builder model isn't opus/sonnet are not mis-attributed."""
+    stats = tmp_path / "haiku-stats.jsonl"
+    sf = str(stats)
+    se.append_record(se.build_record(issue=500, phase="builder", role="builder",
+                                     model="haiku", mode="observe"), sf)
+    se.append_record(se.build_record(issue=500, phase="judge", role="judge",
+                                     mode="observe", attempt=1,
+                                     judge_verdict="pass"), sf)
+    report = se.harvest(sf, None)
+    arms = {a["arm"]: a for a in report["arms"]}
+    assert set(arms) == {"?"}
 
 
 def test_harvest_empty_store_does_not_crash(tmp_path):


### PR DESCRIPTION
Closes #3750

## Scope

This PR delivers the **builder-achievable slice** the Curator rescoped #3750 to: the operator tooling/runbook that makes the `opus→sonnet` retune sample *collectable*, plus a genuine gap fix on the observe→harvest path. The observe/experiment instrumentation, deterministic arm assignment, transcript-cost harvest, and daemon env propagation were already shipped and tested in #3725/#3728/#3730/#3731/#3732 — none of that is reimplemented here.

## What shipped

**1. Operator runbook (`docs/model-selection-retune.md` §3).** New "Runbook: accruing the observe-mode sample" subsection: how to turn on `observe` per-invocation (`LOOM_MODEL_EXPERIMENT=observe`) or durably via `.loom/config.json`; how to confirm the **uncommitted** canary for `experiment` mode; confirmation that `LOOM_MODEL_EXPERIMENT` & friends propagate to daemon-dispatched sweep children (#3732, no daemon-side config needed); the periodic harvest command (`agent-metrics.sh --model-experiment --archive-dir ...`) with a `probe-tokens.sh`-style cron example; and how to read harvest's per-arm `n_issues` against the ≥~30-per-arm floor. The runbook is explicit that `observe` on a stock `opus`-default workspace only fills Arm A — a *balanced* two-arm sample generally needs canary `experiment` mode.

**2. Genuine gap fixed (`loom_tools/sweep_experiment.py`).** Audited the stats-store/harvest path (transcript join, `default`/`?`-bucket handling, empty-store). The transcript join, empty-store, and experiment-mode paths were all correct. But I found one real defect **directly on the observe→harvest path the runbook depends on**: a pure `observe`-mode store (every record `arm=null`, per the sweep skill contract) collapsed **all** records into a single `?` bucket with `model=null`, dropping each row's real Builder model — so the opus-vs-sonnet §2 split was unreadable even though every record carried its model.

Fix: `harvest()` now resolves each issue's arm in a first pass — explicit `experiment` arm wins; absent it, the arm is inferred from the issue's observed Builder model (`opus⇒A`, `sonnet⇒B` via the `ARM_MODEL` inverse). Issues whose Builder ran neither stay in `?`. **Zero behavior change for experiment mode** (explicit arms on every record → identical output; all pre-existing tests green).

Before → after on a pure observe store (issue 700 ran opus, 701 ran sonnet):
```
before:  arm ?  model (null)  issues 2     # opus-vs-sonnet unreadable
after:   arm A  model opus    issues 1
         arm B  model sonnet  issues 1     # §2 inequality inputs populated
```

**3. Tests (`test_sweep_experiment.py`).** End-to-end observe→harvest wiring smoke test with a synthetic transcript-index fixture (confirms an observe record is written and the harvest reader consumes it for exact per-arm cost); explicit-arm-precedence regression guard (Arm B issue with an escalated opus Doctor stays entirely under B); unknown-model `?`-bucket test; and `infer_arm_from_model` unit coverage.

## Verification transcript

End-to-end wiring (operator path, scratch `.loom/stats/`), matching §3/§4 shape:
```
$ .loom/scripts/agent-metrics.sh --model-experiment --stats-file <scratch>
  arm  model    issues  1st-pass  cycles  merge      cost$    $/issue
  A    opus          1      100%    0.00     0%     0.0000     0.0000
  B    sonnet        1      100%    0.00     0%     0.0000     0.0000
  Inequality inputs for #3718 (cost + merge-rate floor): ...
```
Transcript-join path (`--archive-dir` with a synthetic `loom.transcript-index/v1` fixture) resolves exact opus cost `$0.0630` at `token_fidelity=transcript`. Empty store reports `records: 0` / `arms: []` without crashing.

Tests:
```
$ PYTHONPATH=loom-tools/src python3 -m pytest \
    loom-tools/tests/test_sweep_experiment.py loom-tools/tests/test_agent_metrics.py -q
99 passed   # 94 pre-existing + 5 new
```

## Note (source-tree-only, NOT fixed here)

Running the entry point from its **source** copy `defaults/scripts/sweep-experiment.sh` fails to locate loom-tools, because the tracked dogfooding artifact `defaults/.loom/` makes `lib/loom-tools.sh::_find_repo_root` stop at `defaults/`. This is **not** on any operator path — operators run `.loom/scripts/agent-metrics.sh --model-experiment`, which resolves correctly (verified). Fixing `_find_repo_root` touches every loom-tools shell entry point (broad blast radius) and is unrelated to the observe→harvest path, so it is out of scope for this PR — flagging for a possible dedicated follow-up.

## DEFERRED operator action (NOT delivered by this PR)

Per the rescoped AC, the following is explicitly **out of scope** and must not be fabricated:
- Enabling `observe`/canary `experiment` against **real** production sweeps for a multi-day window until harvest reports ≥~30 model-attributed first attempts on **both** Arm A (opus) and Arm B (sonnet) for the Builder role.
- Harvesting the real sample and evaluating the §2 cost + merge-rate-floor inequality.
- Recording a new dated §4 Status-log entry — another "keep opus" citing the non-empty sample, or (if the inequality holds) opening the separate gated flip PR per §5.

No `suggestedModel` default is changed; the Hard Rule at the top of the doc is preserved. No stats rows or harvest numbers were fabricated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)