### PR TITLE
feat(hooks): gate universal.md injection to once-per-session (#3758)

### DIFF
--- a/.loom/hooks/methodology-inject.sh
+++ b/.loom/hooks/methodology-inject.sh
@@ -8,7 +8,9 @@
 #
 # Behavior:
 #   1. Check for .loom/context/ directory — exit silently if absent (opt-in)
-#   2. Always inject universal.md if it exists
+#   2. Inject universal.md if it exists, ONCE PER SESSION by default (mirrors
+#      skill-router.sh's #3609 per-session table dedup). The universal_frequency
+#      config knob ("session" default / "always" back-compat) controls this.
 #   3. Inject roles/<LOOM_ROLE>.md if LOOM_ROLE env var is set
 #   4. Inject topics/<name>.md when prompt matches filename or sidecar .pattern file
 #   5. Cap total output at configurable max (default 8000 chars)
@@ -52,6 +54,11 @@ fi
 # Extract prompt
 PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty' 2>/dev/null) || PROMPT=""
 
+# Extract session_id (used for once-per-session universal.md dedup; optional — a
+# missing/empty value degrades gracefully, see the PER-SESSION UNIVERSAL DEDUP
+# block below)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null) || SESSION_ID=""
+
 # If no prompt, nothing to do
 if [[ -z "$PROMPT" ]]; then
     exit 0
@@ -94,6 +101,9 @@ MAX_CONTEXT_CHARS=8000
 INJECT_UNIVERSAL=true
 INJECT_ROLE=true
 INJECT_TOPICS=true
+# Frequency of universal.md injection: "session" (once per session, new default
+# as of #3758) or "always" (every matching prompt, legacy back-compat behavior).
+UNIVERSAL_FREQUENCY=session
 
 # Read config if it exists
 if [[ -f "$CONFIG_FILE" ]] && jq empty "$CONFIG_FILE" 2>/dev/null; then
@@ -108,6 +118,9 @@ if [[ -f "$CONFIG_FILE" ]] && jq empty "$CONFIG_FILE" 2>/dev/null; then
     INJECT_UNIVERSAL=$(jq -r 'if .inject_universal == false then "false" else "true" end' "$CONFIG_FILE" 2>/dev/null) || INJECT_UNIVERSAL=true
     INJECT_ROLE=$(jq -r 'if .inject_role == false then "false" else "true" end' "$CONFIG_FILE" 2>/dev/null) || INJECT_ROLE=true
     INJECT_TOPICS=$(jq -r 'if .inject_topics == false then "false" else "true" end' "$CONFIG_FILE" 2>/dev/null) || INJECT_TOPICS=true
+    # Only "always" opts back into per-prompt injection; anything else (including
+    # a missing key or malformed value) falls through to the "session" default.
+    UNIVERSAL_FREQUENCY=$(jq -r 'if .universal_frequency == "always" then "always" else "session" end' "$CONFIG_FILE" 2>/dev/null) || UNIVERSAL_FREQUENCY=session
 fi
 
 # =============================================================================
@@ -148,9 +161,39 @@ append_context() {
 }
 
 # --- Universal context ---
+# =============================================================================
+# PER-SESSION UNIVERSAL DEDUP (#3758)
+# =============================================================================
+# universal.md is verbatim project-wide context that a session needs at most
+# once. By default (universal_frequency="session") we inject it on the first
+# matching prompt of a session and skip it thereafter, keyed on the session_id
+# present on stdin — exactly mirroring skill-router.sh's #3609 table dedup, but
+# in its own marker namespace (the two hooks are independent opt-ins and must
+# not share state). universal_frequency="always" restores the legacy per-prompt
+# behavior. A missing/empty session_id degrades gracefully: we cannot dedup, so
+# universal.md is included on each matching turn (the legacy behavior).
 if [[ "$INJECT_UNIVERSAL" == "true" ]] && [[ -f "${CONTEXT_DIR}/universal.md" ]]; then
-    UNIVERSAL_CONTENT=$(cat "${CONTEXT_DIR}/universal.md" 2>/dev/null) || UNIVERSAL_CONTENT=""
-    append_context "Project Context" "$UNIVERSAL_CONTENT"
+    INCLUDE_UNIVERSAL=1
+    if [[ "$UNIVERSAL_FREQUENCY" != "always" ]] && [[ -n "$SESSION_ID" ]]; then
+        # Sanitize to filename-safe characters so the marker is a single
+        # predictable file (never a path traversal, never a nested directory).
+        SESSION_KEY=$(printf '%s' "$SESSION_ID" | tr -c 'A-Za-z0-9._-' '_')
+        SEEN_DIR="${MAIN_ROOT}/.loom/logs/methodology-inject-seen"
+        SEEN_MARKER="${SEEN_DIR}/${SESSION_KEY}"
+        if [[ -f "$SEEN_MARKER" ]]; then
+            INCLUDE_UNIVERSAL=0
+        else
+            # Best-effort marker creation; a failure here never fails the hook
+            # and simply means universal.md may be re-injected on a later turn.
+            mkdir -p "$SEEN_DIR" 2>/dev/null || true
+            : > "$SEEN_MARKER" 2>/dev/null || true
+        fi
+    fi
+
+    if [[ "$INCLUDE_UNIVERSAL" -eq 1 ]]; then
+        UNIVERSAL_CONTENT=$(cat "${CONTEXT_DIR}/universal.md" 2>/dev/null) || UNIVERSAL_CONTENT=""
+        append_context "Project Context" "$UNIVERSAL_CONTENT"
+    fi
 fi
 
 # --- Role-specific context ---

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -1381,7 +1381,7 @@ Loom provides an opt-in methodology injection hook that automatically injects pr
    mkdir -p .loom/context/roles .loom/context/topics
    ```
 
-2. Add a universal context file (injected on every prompt):
+2. Add a universal context file (injected once per session by default):
    ```bash
    cat > .loom/context/universal.md << 'EOF'
    # Project Rules
@@ -1398,7 +1398,7 @@ Loom provides an opt-in methodology injection hook that automatically injects pr
 ```
 .loom/context/
 ├── config.json              # Optional configuration
-├── universal.md             # Injected on every prompt
+├── universal.md             # Injected once per session by default
 ├── roles/
 │   ├── builder.md           # Injected when LOOM_ROLE=builder
 │   ├── judge.md             # Injected when LOOM_ROLE=judge
@@ -1410,7 +1410,7 @@ Loom provides an opt-in methodology injection hook that automatically injects pr
     └── ...
 ```
 
-**Universal context** (`universal.md`): Always injected when the context directory exists. Use for project-wide rules and conventions.
+**Universal context** (`universal.md`): Injected when the context directory exists — **once per session by default** (`universal_frequency: "session"`), so the project-wide rules ride along on the first prompt of a session and are deduped on subsequent turns. Set `universal_frequency: "always"` to restore per-prompt injection. Use for project-wide rules and conventions.
 
 **Role context** (`roles/<role>.md`): Injected when the `LOOM_ROLE` environment variable matches the filename, or when a slash command (e.g., `/builder`) is detected in the prompt. Role names are case-insensitive.
 
@@ -1425,6 +1425,7 @@ Create `.loom/context/config.json` to customize behavior:
   "max_context_chars": 8000,
   "enabled": true,
   "inject_universal": true,
+  "universal_frequency": "session",
   "inject_role": true,
   "inject_topics": true
 }
@@ -1434,22 +1435,46 @@ Create `.loom/context/config.json` to customize behavior:
 |-----------|---------|-------------|
 | `max_context_chars` | 8000 | Maximum total characters injected (prevents overwhelming the context window) |
 | `enabled` | true | Set to false to disable injection without removing files |
-| `inject_universal` | true | Whether to inject `universal.md` |
+| `inject_universal` | true | Whether to inject `universal.md` at all (on/off master switch) |
+| `universal_frequency` | `"session"` | How often `universal.md` is injected: `"session"` (once per session — default) or `"always"` (every matching prompt, legacy behavior). Any missing/malformed value falls back to `"session"`. |
 | `inject_role` | true | Whether to inject role-specific context |
 | `inject_topics` | true | Whether to inject topic-matched context |
+
+> **Behavior-change note (#3758)**: `universal_frequency` defaults to `"session"`,
+> a deliberate flip from the historical always-inject behavior. Any repo that
+> already opted into `.loom/context/` **without** setting this key now gets
+> `universal.md` **once per session** instead of on every prompt. This mirrors the
+> precedent set by #3609 for `skill-router.sh` (which likewise dropped per-prompt
+> injection with no back-compat shim). To keep the old every-prompt behavior, set
+> `"universal_frequency": "always"`. The once-per-session dedup uses a session-keyed
+> marker at `.loom/logs/methodology-inject-seen/<sanitized-session-id>` (its own
+> namespace, parallel to `skill-router.sh`'s `skill-router-seen/`); a missing/empty
+> `session_id` on stdin degrades gracefully to per-turn injection. Role and topic
+> injection are unaffected — they still fire on every matching turn.
 
 ### How It Works
 
 The `methodology-inject.sh` hook runs as a `UserPromptSubmit` hook alongside `skill-router.sh`. On each prompt:
 
 1. Checks for `.loom/context/` directory -- exits silently if absent
-2. Reads `universal.md` if present
+2. Reads `universal.md` if present, **once per session** by default (`universal_frequency`) — deduped via a session-keyed marker, exactly like `skill-router.sh`'s #3609 routing-table dedup
 3. Detects the active role via `LOOM_ROLE` env var or prompt slash command
 4. Scans `topics/` files, matching prompt against filename or sidecar `.pattern` regex
 5. Concatenates matching content, capped at `max_context_chars`
 6. Returns the collected context as `additionalContext`
 
 The hook follows the same error-handling patterns as other Loom hooks: it never exits non-zero, logs errors to `.loom/logs/hook-errors.log`, and fails silently on any unexpected error.
+
+### UserPromptSubmit Hooks: Opt-In Triggers and Disabling
+
+Both `UserPromptSubmit` hooks are **opt-in by config presence** and do nothing until you add their config. Each has a one-line off switch:
+
+| Hook | Opt-in trigger | One-line disable |
+|------|----------------|------------------|
+| `methodology-inject.sh` | Presence of the `.loom/context/` directory | Delete/rename `.loom/context/`, or set `"enabled": false` in `.loom/context/config.json`, or remove the hook's entry from the `UserPromptSubmit` array in `.claude/settings.json` |
+| `skill-router.sh` | Presence of `.loom/config/skill-routes.json` | Delete `.loom/config/skill-routes.json`, or remove the hook's entry from the `UserPromptSubmit` array in `.claude/settings.json` |
+
+`skill-router.sh` is already conservative (issue #3609): it emits nothing on non-matching turns, and appends its agent routing table at most once per session (session-keyed dedup, degrading gracefully when `session_id` is missing). `methodology-inject.sh` now mirrors that once-per-session discipline for `universal.md` (see `universal_frequency` above). Neither hook blocks a prompt or exits non-zero; both fail silently on any error.
 
 ### Example Context Files
 

--- a/defaults/hooks/methodology-inject.sh
+++ b/defaults/hooks/methodology-inject.sh
@@ -8,7 +8,9 @@
 #
 # Behavior:
 #   1. Check for .loom/context/ directory — exit silently if absent (opt-in)
-#   2. Always inject universal.md if it exists
+#   2. Inject universal.md if it exists, ONCE PER SESSION by default (mirrors
+#      skill-router.sh's #3609 per-session table dedup). The universal_frequency
+#      config knob ("session" default / "always" back-compat) controls this.
 #   3. Inject roles/<LOOM_ROLE>.md if LOOM_ROLE env var is set
 #   4. Inject topics/<name>.md when prompt matches filename or sidecar .pattern file
 #   5. Cap total output at configurable max (default 8000 chars)
@@ -52,6 +54,11 @@ fi
 # Extract prompt
 PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty' 2>/dev/null) || PROMPT=""
 
+# Extract session_id (used for once-per-session universal.md dedup; optional — a
+# missing/empty value degrades gracefully, see the PER-SESSION UNIVERSAL DEDUP
+# block below)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null) || SESSION_ID=""
+
 # If no prompt, nothing to do
 if [[ -z "$PROMPT" ]]; then
     exit 0
@@ -94,6 +101,9 @@ MAX_CONTEXT_CHARS=8000
 INJECT_UNIVERSAL=true
 INJECT_ROLE=true
 INJECT_TOPICS=true
+# Frequency of universal.md injection: "session" (once per session, new default
+# as of #3758) or "always" (every matching prompt, legacy back-compat behavior).
+UNIVERSAL_FREQUENCY=session
 
 # Read config if it exists
 if [[ -f "$CONFIG_FILE" ]] && jq empty "$CONFIG_FILE" 2>/dev/null; then
@@ -108,6 +118,9 @@ if [[ -f "$CONFIG_FILE" ]] && jq empty "$CONFIG_FILE" 2>/dev/null; then
     INJECT_UNIVERSAL=$(jq -r 'if .inject_universal == false then "false" else "true" end' "$CONFIG_FILE" 2>/dev/null) || INJECT_UNIVERSAL=true
     INJECT_ROLE=$(jq -r 'if .inject_role == false then "false" else "true" end' "$CONFIG_FILE" 2>/dev/null) || INJECT_ROLE=true
     INJECT_TOPICS=$(jq -r 'if .inject_topics == false then "false" else "true" end' "$CONFIG_FILE" 2>/dev/null) || INJECT_TOPICS=true
+    # Only "always" opts back into per-prompt injection; anything else (including
+    # a missing key or malformed value) falls through to the "session" default.
+    UNIVERSAL_FREQUENCY=$(jq -r 'if .universal_frequency == "always" then "always" else "session" end' "$CONFIG_FILE" 2>/dev/null) || UNIVERSAL_FREQUENCY=session
 fi
 
 # =============================================================================
@@ -148,9 +161,39 @@ append_context() {
 }
 
 # --- Universal context ---
+# =============================================================================
+# PER-SESSION UNIVERSAL DEDUP (#3758)
+# =============================================================================
+# universal.md is verbatim project-wide context that a session needs at most
+# once. By default (universal_frequency="session") we inject it on the first
+# matching prompt of a session and skip it thereafter, keyed on the session_id
+# present on stdin — exactly mirroring skill-router.sh's #3609 table dedup, but
+# in its own marker namespace (the two hooks are independent opt-ins and must
+# not share state). universal_frequency="always" restores the legacy per-prompt
+# behavior. A missing/empty session_id degrades gracefully: we cannot dedup, so
+# universal.md is included on each matching turn (the legacy behavior).
 if [[ "$INJECT_UNIVERSAL" == "true" ]] && [[ -f "${CONTEXT_DIR}/universal.md" ]]; then
-    UNIVERSAL_CONTENT=$(cat "${CONTEXT_DIR}/universal.md" 2>/dev/null) || UNIVERSAL_CONTENT=""
-    append_context "Project Context" "$UNIVERSAL_CONTENT"
+    INCLUDE_UNIVERSAL=1
+    if [[ "$UNIVERSAL_FREQUENCY" != "always" ]] && [[ -n "$SESSION_ID" ]]; then
+        # Sanitize to filename-safe characters so the marker is a single
+        # predictable file (never a path traversal, never a nested directory).
+        SESSION_KEY=$(printf '%s' "$SESSION_ID" | tr -c 'A-Za-z0-9._-' '_')
+        SEEN_DIR="${MAIN_ROOT}/.loom/logs/methodology-inject-seen"
+        SEEN_MARKER="${SEEN_DIR}/${SESSION_KEY}"
+        if [[ -f "$SEEN_MARKER" ]]; then
+            INCLUDE_UNIVERSAL=0
+        else
+            # Best-effort marker creation; a failure here never fails the hook
+            # and simply means universal.md may be re-injected on a later turn.
+            mkdir -p "$SEEN_DIR" 2>/dev/null || true
+            : > "$SEEN_MARKER" 2>/dev/null || true
+        fi
+    fi
+
+    if [[ "$INCLUDE_UNIVERSAL" -eq 1 ]]; then
+        UNIVERSAL_CONTENT=$(cat "${CONTEXT_DIR}/universal.md" 2>/dev/null) || UNIVERSAL_CONTENT=""
+        append_context "Project Context" "$UNIVERSAL_CONTENT"
+    fi
 fi
 
 # --- Role-specific context ---

--- a/defaults/hooks/tests/test-methodology-inject.sh
+++ b/defaults/hooks/tests/test-methodology-inject.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# Test suite for defaults/hooks/methodology-inject.sh (issue #3758)
+#
+# Usage: ./defaults/hooks/tests/test-methodology-inject.sh
+#
+# Covers the #3758 rework of the UserPromptSubmit methodology-injection hook:
+#   - opt-in gate: .loom/context/ absent -> silent exit 0, no output
+#   - universal.md is injected ONCE PER SESSION by default (new default),
+#     deduped via the session_id present on stdin (own marker namespace)
+#   - universal_frequency: "always" restores the legacy per-prompt injection
+#   - a missing/empty session_id degrades gracefully (inject every turn)
+#   - role and topic injection are UNCHANGED (still fire every matching turn)
+#   - the hook never exits non-zero and never emits invalid JSON
+#
+# The hook under test is the canonical source at defaults/ (the version-
+# controlled source of truth), copied into an isolated temp git tree so the
+# hook's MAIN_ROOT resolves there (git-common-dir pins MAIN_ROOT to the temp
+# root, and .loom/logs/ markers are written there). Exit 0 = all pass, 1 = fail.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+SRC_HOOK="$REPO_ROOT/defaults/hooks/methodology-inject.sh"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+# Isolated tree so the hook reads OUR context/ and writes OUR session markers.
+# It must be a git repo: the hook resolves MAIN_ROOT via `git rev-parse
+# --git-common-dir`, so an isolated repo root pins MAIN_ROOT to the temp tree.
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+git init -q "$TMPROOT"
+mkdir -p "$TMPROOT/defaults/hooks"
+cp "$SRC_HOOK" "$TMPROOT/defaults/hooks/methodology-inject.sh"
+chmod +x "$TMPROOT/defaults/hooks/methodology-inject.sh"
+HOOK="$TMPROOT/defaults/hooks/methodology-inject.sh"
+
+CONTEXT_DIR="$TMPROOT/.loom/context"
+
+# Build stdin JSON. Second arg (session_id) is optional.
+make_input() {
+    local prompt="$1"
+    local session="${2:-}"
+    if [[ -n "$session" ]]; then
+        jq -n --arg p "$prompt" --arg s "$session" '{prompt: $p, session_id: $s}'
+    else
+        jq -n --arg p "$prompt" '{prompt: $p}'
+    fi
+}
+
+# Run the hook from inside the temp tree so git-common-dir resolves MAIN_ROOT to
+# it. Echoes stdout; asserts exit 0 (never non-zero) and valid JSON.
+# Optional third arg sets LOOM_ROLE for the invocation.
+run_hook() {
+    local prompt="$1"
+    local session="${2:-}"
+    local role="${3:-}"
+    local output exit_code=0
+    if [[ -n "$role" ]]; then
+        output=$(cd "$TMPROOT" && make_input "$prompt" "$session" | LOOM_ROLE="$role" "$HOOK" 2>/dev/null) || exit_code=$?
+    else
+        output=$(cd "$TMPROOT" && make_input "$prompt" "$session" | "$HOOK" 2>/dev/null) || exit_code=$?
+    fi
+    if [[ "$exit_code" -ne 0 ]]; then
+        echo "__NONZERO_EXIT__:$exit_code"
+        return 0
+    fi
+    # Any non-empty output must be valid JSON.
+    if [[ -n "$output" ]] && ! echo "$output" | jq empty 2>/dev/null; then
+        echo "__INVALID_JSON__"
+        return 0
+    fi
+    echo "$output"
+}
+
+# Extract the additionalContext string from hook output ("" if none).
+context_of() {
+    echo "$1" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null || true
+}
+
+pass() { PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1)); printf "${GREEN}PASS${NC} %s\n" "$1"; }
+fail() { FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1)); printf "${RED}FAIL${NC} %s\n" "$1"; }
+
+assert_no_output() {
+    local desc="$1" out="$2"
+    if [[ -z "$out" ]]; then
+        pass "$desc"
+    else
+        fail "$desc (expected empty output, got: $out)"
+    fi
+}
+
+assert_contains() {
+    local desc="$1" haystack="$2" needle="$3"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        pass "$desc"
+    else
+        fail "$desc (expected to contain '$needle', got: $haystack)"
+    fi
+}
+
+assert_not_contains() {
+    local desc="$1" haystack="$2" needle="$3"
+    if [[ "$haystack" != *"$needle"* ]]; then
+        pass "$desc"
+    else
+        fail "$desc (expected NOT to contain '$needle', got: $haystack)"
+    fi
+}
+
+# Reset per-session markers and rebuild the context dir between cases.
+reset_markers() { rm -rf "$TMPROOT/.loom/logs/methodology-inject-seen" 2>/dev/null || true; }
+
+setup_context() {
+    rm -rf "$CONTEXT_DIR"
+    mkdir -p "$CONTEXT_DIR/roles" "$CONTEXT_DIR/topics"
+    printf '# Universal Project Rules\nMARKER_UNIVERSAL\n' > "$CONTEXT_DIR/universal.md"
+    printf '# Builder Role\nMARKER_ROLE_BUILDER\n' > "$CONTEXT_DIR/roles/builder.md"
+    printf '# Security Topic\nMARKER_TOPIC_SECURITY\n' > "$CONTEXT_DIR/topics/security.md"
+}
+
+echo "=== methodology-inject.sh tests (#3758) ==="
+
+# --- Opt-in gate: no .loom/context/ -> silent exit 0 ------------------------
+rm -rf "$CONTEXT_DIR"
+reset_markers
+out=$(run_hook "please do something useful here" "sess-gate")
+assert_no_output "no .loom/context/ -> no additionalContext (opt-in gate)" "$out"
+
+# --- Default (no config.json): universal.md once per session ----------------
+setup_context
+reset_markers
+out1=$(run_hook "just a normal prompt here" "sess-1")
+ctx1=$(context_of "$out1")
+assert_contains "default: first prompt in session -> universal injected" "$ctx1" "MARKER_UNIVERSAL"
+
+out2=$(run_hook "another normal prompt here" "sess-1")
+ctx2=$(context_of "$out2")
+assert_not_contains "default: second prompt same session -> universal deduped" "$ctx2" "MARKER_UNIVERSAL"
+
+# A different session gets its own fresh universal injection.
+out3=$(run_hook "a fresh session prompt here" "sess-2")
+ctx3=$(context_of "$out3")
+assert_contains "default: new session -> universal injected again" "$ctx3" "MARKER_UNIVERSAL"
+
+# --- universal_frequency: "always" restores per-prompt injection ------------
+setup_context
+printf '{ "universal_frequency": "always" }\n' > "$CONTEXT_DIR/config.json"
+reset_markers
+outA=$(run_hook "always mode prompt one here" "sess-always")
+ctxA=$(context_of "$outA")
+assert_contains "always: first prompt -> universal injected" "$ctxA" "MARKER_UNIVERSAL"
+outB=$(run_hook "always mode prompt two here" "sess-always")
+ctxB=$(context_of "$outB")
+assert_contains "always: second prompt same session -> universal STILL injected" "$ctxB" "MARKER_UNIVERSAL"
+rm -f "$CONTEXT_DIR/config.json"
+
+# --- Missing/empty session_id degrades gracefully (inject every turn) -------
+setup_context
+reset_markers
+outN1=$(run_hook "no session id prompt one here")
+ctxN1=$(context_of "$outN1")
+assert_contains "no session_id -> universal injected (turn 1)" "$ctxN1" "MARKER_UNIVERSAL"
+outN2=$(run_hook "no session id prompt two here")
+ctxN2=$(context_of "$outN2")
+assert_contains "no session_id -> universal injected again (graceful degrade)" "$ctxN2" "MARKER_UNIVERSAL"
+
+# --- Role/topic injection UNCHANGED (still fire every matching turn) ---------
+setup_context
+reset_markers
+# Role fires every turn even after universal is deduped for the session.
+outR1=$(run_hook "implement the widget please here" "sess-role" "builder")
+ctxR1=$(context_of "$outR1")
+assert_contains "role: injected on first turn (LOOM_ROLE=builder)" "$ctxR1" "MARKER_ROLE_BUILDER"
+outR2=$(run_hook "implement the gadget please here" "sess-role" "builder")
+ctxR2=$(context_of "$outR2")
+assert_contains "role: STILL injected on second turn (unchanged by #3758)" "$ctxR2" "MARKER_ROLE_BUILDER"
+assert_not_contains "role: universal deduped on second turn but role remains" "$ctxR2" "MARKER_UNIVERSAL"
+
+# Topic fires every turn it matches, independent of universal dedup.
+setup_context
+reset_markers
+outT1=$(run_hook "please review the security model here" "sess-topic")
+ctxT1=$(context_of "$outT1")
+assert_contains "topic: injected on first matching turn" "$ctxT1" "MARKER_TOPIC_SECURITY"
+outT2=$(run_hook "more on the security posture here" "sess-topic")
+ctxT2=$(context_of "$outT2")
+assert_contains "topic: STILL injected on second matching turn (unchanged)" "$ctxT2" "MARKER_TOPIC_SECURITY"
+assert_not_contains "topic: universal deduped on second turn but topic remains" "$ctxT2" "MARKER_UNIVERSAL"
+
+# --- inject_universal:false still fully suppresses universal -----------------
+setup_context
+printf '{ "inject_universal": false }\n' > "$CONTEXT_DIR/config.json"
+reset_markers
+outF=$(run_hook "universal disabled prompt here" "sess-off")
+ctxF=$(context_of "$outF")
+assert_not_contains "inject_universal:false -> universal never injected" "$ctxF" "MARKER_UNIVERSAL"
+rm -f "$CONTEXT_DIR/config.json"
+
+# --- Malformed config.json falls through to session default, no crash -------
+setup_context
+printf '{ this is not valid json ' > "$CONTEXT_DIR/config.json"
+reset_markers
+outM=$(run_hook "malformed config prompt here" "sess-malformed")
+if [[ "$outM" == __NONZERO_EXIT__* || "$outM" == "__INVALID_JSON__" ]]; then
+    fail "malformed config -> hook stays exit 0 + valid JSON"
+else
+    pass "malformed config -> hook stays exit 0 + valid JSON"
+fi
+rm -f "$CONTEXT_DIR/config.json"
+
+# --- Never non-zero / never invalid JSON ------------------------------------
+setup_context
+reset_markers
+for probe in "the weather is nice today here" "please implement the feature now" "review the security model here"; do
+    out=$(run_hook "$probe" "sess-probe")
+    if [[ "$out" == __NONZERO_EXIT__* ]]; then
+        fail "hook exits 0 for: $probe"
+    elif [[ "$out" == "__INVALID_JSON__" ]]; then
+        fail "hook emits valid JSON for: $probe"
+    else
+        pass "hook exit 0 + valid JSON for: $probe"
+    fi
+done
+
+# --- defaults/ vs .loom/ sync -----------------------------------------------
+DEPLOY_HOOK="$REPO_ROOT/.loom/hooks/methodology-inject.sh"
+if [[ -f "$DEPLOY_HOOK" ]] && diff -q "$SRC_HOOK" "$DEPLOY_HOOK" >/dev/null 2>&1; then
+    pass ".loom/ hook byte-identical to defaults/"
+else
+    fail ".loom/ hook byte-identical to defaults/"
+fi
+
+echo "=== $PASS/$TOTAL passed ==="
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #3758

## Summary

The `methodology-inject.sh` `UserPromptSubmit` hook injected `universal.md` on **every** prompt once a repo opted into `.loom/context/` — the main per-prompt token cost called out in the issue. This gates that injection to **once per session** by default, mirroring `skill-router.sh`'s #3609 session-marker dedup, behind a new `universal_frequency` config knob.

## Changes

- **`defaults/hooks/methodology-inject.sh`** (mirrored byte-identically to `.loom/hooks/`):
  - New `universal_frequency` key in `.loom/context/config.json` — `"session"` (default) or `"always"` (legacy per-prompt). Read the same defensive `jq` way as the other keys; missing/malformed falls back to `"session"` without raising the ERR trap.
  - Session-keyed marker at `.loom/logs/methodology-inject-seen/<sanitized-session-id>` (own namespace, parallel to `skill-router-seen/`), same sanitization + best-effort creation. Missing/empty `session_id` degrades gracefully to per-turn injection.
  - Role (`inject_role`) and topic (`inject_topics`) injection are **unchanged** — still fire every matching turn.
- **`defaults/CLAUDE.md`**: new `universal_frequency` config-table row + behavior-change callout, updated How-It-Works, and a new "UserPromptSubmit Hooks: Opt-In Triggers and Disabling" block documenting **both** hooks' opt-in trigger and one-line disable.
- **`defaults/hooks/tests/test-methodology-inject.sh`** (new, 20 cases, modeled on `test-skill-router.sh`): opt-in gate, once-per-session default, `"always"` back-compat, missing-`session_id` degrade, role/topic-unchanged guards, malformed config, and the never-non-zero / never-invalid-JSON invariant.

## Behavior change (load-bearing)

`universal_frequency` defaults to `"session"` — a deliberate flip from always-inject. A repo already using `.loom/context/` **without** setting this key now gets `universal.md` once per session instead of every prompt. This follows the #3609 precedent (`skill-router.sh` dropped per-prompt injection with no back-compat shim). Set `"universal_frequency": "always"` to restore the old behavior. Documented in `defaults/CLAUDE.md` and above.

## Out of scope

The installer default-wiring bullet (making both hooks opt-in-by-default in a fresh install's `.claude/settings.json`) is explicitly out of scope per the issue's acceptance criteria — a separate, larger installer change. File a follow-up if still wanted.

## Test / verification

- `./defaults/hooks/tests/test-methodology-inject.sh` → **20/20 passed** (default injects once, `always` preserves per-prompt).
- `shellcheck` clean on both the hook and the new test.
- `.loom/hooks/` mirror kept byte-identical (guarded by a sync assertion in the test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)