### PR TITLE
fix(sweep): bash-3.2-portable wave-size capture in Stage -1 snippet (#3765)

### DIFF
--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -696,8 +696,10 @@ else  # use_subagent (no daemon, single-token pool, --no-daemon, or Mode C)
     MECH=subagent; MECHANISM="in-session subagent"
 fi
 # The helper prints two lines: size on line 1, reason token on line 2.
-mapfile -t _WS < <(loom_wave_size_from_disk "$MECH" "$CAND" "$FREE_GB")
-WAVE_SIZE="${_WS[0]}"; REASON="${_WS[1]}"
+# Capture both without `mapfile` (a bash-4.0+ builtin) so this works under
+# macOS's default /bin/bash 3.2: grab stdout once, then split by line.
+_WS_OUT="$(loom_wave_size_from_disk "$MECH" "$CAND" "$FREE_GB")"
+WAVE_SIZE="$(sed -n '1p' <<<"$_WS_OUT")"; REASON="$(sed -n '2p' <<<"$_WS_OUT")"
 ```
 
 `loom_wave_size_from_disk` prints two lines — the clamped size `K = min(target, floor(free_gb / LOOM_PER_WORKTREE_GB), CAND)` with a floor of 1 (never 0, even on a full disk) on line 1, and a machine reason token (`target` / `candidates` / `disk` / `floor`) on line 2. `LOOM_PER_WORKTREE_GB` defaults to a conservative 2 GB and is env-overridable for large-repo operators. The target is **10** for the daemon path; for the subagent path it is the **core-scaled** `clamp(floor((cores-2)/4), 3, 6)` (#3693) — resolved into `LOOM_SUBAGENT_WAVE_CAP` just above via `loom_subagent_target_from_cores` / `loom_detect_cores`, floor 3 on small/shared hosts, ceiling 6 on big ones — and an operator-set `LOOM_SUBAGENT_WAVE_CAP` env value always overrides it.

--- a/loom-daemon/tests/sweep_md_stage_minus_one_doc_lint.rs
+++ b/loom-daemon/tests/sweep_md_stage_minus_one_doc_lint.rs
@@ -218,6 +218,37 @@ fn sweep_md_references_dispatch_sweep_mcp_tool() {
     );
 }
 
+/// Regression (#3765): assert the Stage -1 "Resolve auto wave size"
+/// snippet does NOT use `mapfile`, a bash-4.0+ builtin that is
+/// unavailable in macOS's default `/bin/bash` 3.2. The snippet must
+/// capture `loom_wave_size_from_disk`'s two-line stdout with a
+/// bash-3.2-portable pattern instead. This guards against
+/// reintroduction of any bash-4-only builtin into a documented recipe
+/// operators copy-paste into their default shell.
+#[test]
+fn sweep_md_stage_minus_one_wave_size_snippet_is_bash_3_2_portable() {
+    let content = read_sweep_md();
+    assert!(
+        content.contains("loom_wave_size_from_disk"),
+        "sweep.md is missing the `loom_wave_size_from_disk` wave-size \
+         resolution snippet — #3765 regression guard cannot anchor to it"
+    );
+    // Guard against the *invocation* form of the bash-4.0+ array-read
+    // builtins (`mapfile -…` / `readarray -…`). A prose mention of the
+    // word "mapfile" in an explanatory comment is fine — only executable
+    // reintroduction is the regression.
+    for bad in ["mapfile -", "readarray -"] {
+        assert!(
+            !content.contains(bad),
+            "sweep.md reintroduced `{bad}…` — a bash-4.0+ builtin \
+             unavailable in macOS's default /bin/bash 3.2 (#3765). \
+             Capture the helper's two-line stdout with a bash-3.2- \
+             portable pattern instead (e.g. command substitution + \
+             `sed -n '1p'` / `sed -n '2p'`)."
+        );
+    }
+}
+
 /// AC #1: assert the Limitations table records the Stage -1 row as
 /// Implemented (#3454). This is the operator-visible status flip that
 /// signals Phase D shipped.


### PR DESCRIPTION
## Summary

The Stage -1 "Resolve auto wave size" recipe in `sweep.md` used `mapfile -t`, a **bash-4.0+ builtin** that is unavailable in macOS's default `/bin/bash` 3.2. Operators copy-pasting the documented snippet into their default shell hit `mapfile: command not found`. This is a **doc-only** fix — the underlying shipped helper (`defaults/scripts/lib/disk-headroom.sh`) and its tests already avoid `mapfile`.

## Changes

- **`defaults/.claude/commands/loom/sweep.md`** (Stage -1 "Resolve auto wave size", ~line 699): replaced

  ```bash
  mapfile -t _WS < <(loom_wave_size_from_disk "$MECH" "$CAND" "$FREE_GB")
  WAVE_SIZE="${_WS[0]}"; REASON="${_WS[1]}"
  ```

  with a bash-3.2-portable capture — grab stdout once via command substitution, then split by line:

  ```bash
  _WS_OUT="$(loom_wave_size_from_disk "$MECH" "$CAND" "$FREE_GB")"
  WAVE_SIZE="$(sed -n '1p' <<<"$_WS_OUT")"; REASON="$(sed -n '2p' <<<"$_WS_OUT")"
  ```

  Identical semantics: `WAVE_SIZE` = line 1, `REASON` = line 2.
- **`loom-daemon/tests/sweep_md_stage_minus_one_doc_lint.rs`**: added a regression guard (`sweep_md_stage_minus_one_wave_size_snippet_is_bash_3_2_portable`) asserting the snippet still references `loom_wave_size_from_disk` and contains no `mapfile -` / `readarray -` invocation (a prose mention of the word "mapfile" in an explanatory comment remains allowed).

The top-level `.claude/commands/loom/sweep.md` is a symlink to the canonical `defaults/` file (verified resolving), so the fix propagates automatically.

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Stage -1 snippet no longer uses `mapfile` | Met | `git grep 'mapfile -'` over `defaults/` returns nothing; Rust guard passes |
| Snippet runs under macOS default `/bin/bash` 3.2 | Met | Exercised standalone against `disk-headroom.sh` under `/bin/bash 3.2.57`; no `command not found` |
| Identical semantics (WAVE_SIZE=line1, REASON=line2) | Met | Verified all reason tokens: `target`, `candidates`, `disk`, `floor` populate correctly |
| Shipped helper/tests unchanged (doc-only scope) | Met | Only `sweep.md` + its doc-lint test modified |

## Test Plan

- [x] Standalone snippet run under real `/bin/bash 3.2.57` for each reason token (`target` / `candidates` / `floor` / `disk`) — correct `WAVE_SIZE`/`REASON`, no `mapfile` error.
- [x] `defaults/scripts/tests/test-disk-headroom.sh` — 33/33 pass.
- [x] `cargo test -p loom-daemon --test sweep_md_stage_minus_one_doc_lint` — 10/10 pass (incl. new regression guard).
- [x] Symlink `.claude/commands/loom/sweep.md` resolves to canonical `defaults/` file.

Closes #3765

🤖 Generated with [Claude Code](https://claude.com/claude-code)