### PR TITLE
fix(guard): anchor ask-tier patterns + redact literal text (#3756)

### DIFF
--- a/defaults/hooks/guard-destructive.sh
+++ b/defaults/hooks/guard-destructive.sh
@@ -691,12 +691,16 @@ parse_force_ops() {
 }
 
 # Redact the quoted VALUES of known text-carrying flags (--body, -m/--message,
-# --title, --notes) so a dangerous-looking phrase quoted INSIDE such a value no
-# longer trips the raw ALWAYS_BLOCK_PATTERNS substring scan. Used ONLY to build
-# COMMAND_NO_LITERAL_TEXT for that one loop (mirrors the COMMAND_NO_COMMENT
-# precedent); every other scan keeps reading the raw command. This kills the
-# #3679 false positive where `gh pr comment --body "…git push --force origin
-# main…"` / `git commit -m "…"` hard-denied even though nothing executes.
+# --title, --notes, --comment) so a dangerous-looking phrase quoted INSIDE such a
+# value no longer trips the raw ALWAYS_BLOCK_PATTERNS substring scan (catastrophic
+# tier) or the ASK_PATTERNS scan (ask tier, #3756). Used ONLY to build the
+# literal-redacted working copies for those two loops (mirrors the
+# COMMAND_NO_COMMENT precedent); every other scan keeps reading the raw command.
+# This kills the #3679 false positive where `gh pr comment --body "…git push
+# --force origin main…"` / `git commit -m "…"` hard-denied even though nothing
+# executes, and (#3756) the analogous ask-tier false ask where an ask-phrase like
+# `gh issue close` quoted inside a `--comment`/`--body` value prompted for
+# confirmation despite no such command actually being run.
 #
 # Safety floor preserved two ways:
 #   - `-c` is deliberately NOT a text-carrying flag, so `bash -c '<payload>'`
@@ -716,7 +720,7 @@ strip_literal_text() {
         SQ = sprintf("%c", 39)   # single quote
         DQ = sprintf("%c", 34)   # double quote
         # boundary + text-carrying flag + optional (ws / = / ws) + quoted span
-        re = "(^|[ \t])(--message|--body|--notes|--title|-m)[ \t]*=?[ \t]*(" \
+        re = "(^|[ \t])(--message|--body|--notes|--title|--comment|-m)[ \t]*=?[ \t]*(" \
              DQ "[^" DQ "]*" DQ "|" SQ "[^" SQ "]*" SQ ")"
     }
     {
@@ -857,16 +861,17 @@ ALWAYS_BLOCK_PATTERNS=(
 )
 
 # Build a literal-text-redacted working copy ONLY for the catastrophic scan
-# below, so a force-push-to-main phrase quoted inside a --body/-m/--title/--notes
-# value no longer false-positives (#3679). The awk only runs when one of those
-# flags is actually present, keeping it off the hot path (mirrors the
-# COMMAND_NO_COMMENT `#`-present guard). `-c` is intentionally excluded so
-# `bash -c '<payload>'` payloads still reach the raw scan; spans carrying `$(` /
-# backtick are left intact so command-substitution smuggling still hard-denies.
+# below, so a force-push-to-main phrase quoted inside a
+# --body/-m/--title/--notes/--comment value no longer false-positives (#3679,
+# --comment added #3756). The awk only runs when one of those flags is actually
+# present, keeping it off the hot path (mirrors the COMMAND_NO_COMMENT
+# `#`-present guard). `-c` is intentionally excluded so `bash -c '<payload>'`
+# payloads still reach the raw scan; spans carrying `$(` / backtick are left
+# intact so command-substitution smuggling still hard-denies.
 COMMAND_NO_LITERAL_TEXT="$COMMAND"
 if [[ "$COMMAND" == *"--body"* || "$COMMAND" == *"--message"* || \
       "$COMMAND" == *"--title"* || "$COMMAND" == *"--notes"* || \
-      "$COMMAND" == *"-m"* ]]; then
+      "$COMMAND" == *"--comment"* || "$COMMAND" == *"-m"* ]]; then
     COMMAND_NO_LITERAL_TEXT=$(strip_literal_text "$COMMAND")
 fi
 
@@ -894,6 +899,27 @@ if [[ "$COMMAND" == *"#"* ]]; then
     COMMAND_NO_COMMENT=$(printf '%s\n' "$COMMAND" | sed -E 's/(^|[[:space:]])#.*$//')
 else
     COMMAND_NO_COMMENT="$COMMAND"
+fi
+
+# =============================================================================
+# ASK-TIER WORKING COPY (#3756) — comment-stripped AND literal-text redacted.
+#
+# The ASK_PATTERNS loop below needs BOTH narrowings the catastrophic tier's two
+# copies provide separately: COMMAND_NO_COMMENT's `#`-comment stripping AND
+# strip_literal_text()'s quoted-flag-value redaction (the #3679 fix the ask tier
+# never received). Building the ask copy from COMMAND_NO_COMMENT (not raw
+# $COMMAND) preserves the comment-stripping the ask tier already relied on, then
+# redacts --body/-m/--title/--notes/--comment values so an ask-phrase quoted
+# inside such a value (e.g. `gh pr comment --body "…gh issue close…"`) no longer
+# false-asks. The strip only runs when a text-carrying flag is present, keeping
+# it off the hot path. Never feeds the catastrophic scan (that keeps reading the
+# raw command), so this can only NARROW an ask, never miss a hard deny.
+# =============================================================================
+COMMAND_ASK_SCAN="$COMMAND_NO_COMMENT"
+if [[ "$COMMAND_NO_COMMENT" == *"--body"* || "$COMMAND_NO_COMMENT" == *"--message"* || \
+      "$COMMAND_NO_COMMENT" == *"--title"* || "$COMMAND_NO_COMMENT" == *"--notes"* || \
+      "$COMMAND_NO_COMMENT" == *"--comment"* || "$COMMAND_NO_COMMENT" == *"-m"* ]]; then
+    COMMAND_ASK_SCAN=$(strip_literal_text "$COMMAND_NO_COMMENT")
 fi
 
 # =============================================================================
@@ -1283,44 +1309,58 @@ ASK_PATTERNS=(
     # autonomous agent can force-push / hard-reset its own working branch without
     # a stall while protected-branch force ops still ask. git clean / checkout .
     # / restore . stay here — they are not force ops and have no branch scope.
-    'git clean -fd'
-    'git checkout \.'
-    'git restore \.'
+    #
+    # COMMAND-POSITION ANCHORING (#3756): every entry is prefixed with
+    # `(^|[;&|[:space:]])`, mirroring ALWAYS_BLOCK_PATTERNS's `gh repo delete`
+    # anchor (#3553), so the phrase only fires at start-of-command or after a
+    # shell separator — an ask-phrase that merely appears inside another
+    # command's quoted argument (e.g. `jq -n '{cmd:"gh issue close 123"}'`, the
+    # phrase preceded by `"`) no longer false-asks. Entries whose command is a
+    # multi-word phrase (`kubectl rollout restart`, `git checkout \.`) are
+    # anchored at the FIRST token only — the phrase's leading command word — per
+    # the `gh repo delete` precedent. (Like the catastrophic tier, this anchor
+    # cannot distinguish a real separator from a whitespace INSIDE a quoted
+    # string, so a mid-quote prose mention such as `echo "… gh pr close …"` still
+    # matches on its leading space — an accepted limitation shared with the
+    # ALWAYS_BLOCK tier; command-word segment classification is #3757's scope.)
+    '(^|[;&|[:space:]])git clean -fd'
+    '(^|[;&|[:space:]])git checkout \.'
+    '(^|[;&|[:space:]])git restore \.'
 
     # GitHub operations that modify shared state
-    'gh pr close'
-    'gh issue close'
-    'gh release delete'
-    'gh label delete'
+    '(^|[;&|[:space:]])gh pr close'
+    '(^|[;&|[:space:]])gh issue close'
+    '(^|[;&|[:space:]])gh release delete'
+    '(^|[;&|[:space:]])gh label delete'
 
     # NOTE: cloud CLI (aws) + docker ASK patterns are NOT in this ungated array.
     # They live in CLOUD_ASK_PATTERNS below, gated by cloud_guard_enabled() so
     # cloud-dev repos can opt down (LOOM_GUARD_CLOUD=0 / guards.cloudCli:false).
 
     # Service management
-    'systemctl restart'
-    'systemctl stop'
-    'systemctl disable'
+    '(^|[;&|[:space:]])systemctl restart'
+    '(^|[;&|[:space:]])systemctl stop'
+    '(^|[;&|[:space:]])systemctl disable'
 
     # Kubernetes operations
-    'kubectl delete'
-    'kubectl rollout restart'
-    'kubectl drain'
+    '(^|[;&|[:space:]])kubectl delete'
+    '(^|[;&|[:space:]])kubectl rollout restart'
+    '(^|[;&|[:space:]])kubectl drain'
 
     # SkyPilot infrastructure
-    'sky down'
-    'sky stop'
+    '(^|[;&|[:space:]])sky down'
+    '(^|[;&|[:space:]])sky stop'
 
     # Credential exposure
-    'printenv.*SECRET'
-    'printenv.*TOKEN'
-    'printenv.*KEY'
-    'cat.*/\.ssh/'
-    'cat.*/\.aws/credentials'
+    '(^|[;&|[:space:]])printenv.*SECRET'
+    '(^|[;&|[:space:]])printenv.*TOKEN'
+    '(^|[;&|[:space:]])printenv.*KEY'
+    '(^|[;&|[:space:]])cat.*/\.ssh/'
+    '(^|[;&|[:space:]])cat.*/\.aws/credentials'
 )
 
 for pattern in "${ASK_PATTERNS[@]}"; do
-    if echo "$COMMAND_NO_COMMENT" | grep -qE "$pattern"; then
+    if echo "$COMMAND_ASK_SCAN" | grep -qE "$pattern"; then
         ask "Command requires confirmation: $COMMAND"
     fi
 done

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -482,6 +482,41 @@ assert_ask "Ask for gh issue close" \
 assert_ask "Ask for gh release delete" \
     "gh release delete v1.0"
 
+# --- #3756: ask-tier command-position anchoring + literal-text redaction ---
+# The ASK_PATTERNS loop used to grep bare, unanchored substrings against a copy
+# that was only comment-stripped (never literal-redacted), so an ask-phrase that
+# merely appeared inside another command's quoted argument or a text-carrying
+# flag value fired a spurious confirmation prompt. Anchoring each entry to a
+# command boundary + reading a comment-stripped AND flag-value-redacted copy
+# fixes the false asks below while every genuine ask still fires.
+
+# Anchoring: the phrase is inside a quoted NON-flag argument, preceded by `"`
+# (not a real command boundary) — no longer asks.
+assert_allow "#3756: ask-phrase inside a quoted jq payload no longer asks" \
+    "jq -n '{cmd:\"gh issue close 123\"}'"
+
+# Redaction: the phrase lives only inside a --body value of an UNRELATED command
+# (command word is 'gh pr comment', not an ask pattern) — no longer asks.
+assert_allow "#3756: ask-phrase inside a redacted --body value (no real ask cmd) no longer asks" \
+    "gh pr comment 5 --body \"notes: gh issue close 123 was a mistake\""
+
+# Redaction extended to --comment (#3756): 'gh issue reopen' is NOT an ask
+# pattern, and the phrase lives only inside its --comment value, preceded by a
+# space (so anchoring alone would still match) — redaction makes it not ask.
+assert_allow "#3756: ask-phrase inside a redacted --comment value (no real ask cmd) no longer asks" \
+    "gh issue reopen 5 --comment \"reverting the gh issue close 123 fix\""
+
+# A GENUINE leading ask command still asks even when it carries a --comment whose
+# value also mentions the phrase: the redaction suppresses the redundant second
+# match, but the real leading 'gh issue close' legitimately still asks.
+assert_ask "#3756: genuine leading gh issue close with a --comment still asks" \
+    "gh issue close 5 --comment \"restored the old gh issue close behavior\""
+
+# A separator-preceded genuine ask command still asks (the anchor's `[;&|]`
+# alternative covers `&&`-chained commands).
+assert_ask "#3756: chained 'git status && gh issue close' still asks" \
+    "git status && gh issue close 5"
+
 # aws s3 ls is read-only — verb-narrowed cloud ASK patterns no longer prompt (#3593).
 assert_allow "Allow aws s3 ls (read-only, #3593)" \
     "aws s3 ls"


### PR DESCRIPTION
## Summary

The `ASK_PATTERNS` loop in `guard-destructive.sh` matched **bare, unanchored
substrings** against `COMMAND_NO_COMMENT` — a copy that is only shell-`#`-comment
stripped, **never** literal-text redacted. An ask-phrase (`gh issue close`,
`gh pr close`, `gh release delete`, `systemctl restart`, …) fired a spurious
confirmation prompt merely by appearing inside another command's quoted argument
or a text-carrying flag value, even though nothing dangerous ran.

This ports the two fixes the catastrophic `ALWAYS_BLOCK` tier already has to the
ask tier (issue 2 of 3 in the serialized `#3755`→`#3756`→`#3757` sequence; built
on top of `#3755`'s qsplit fix now on main).

## Changes

**(a) Command-position anchoring (mirrors `#3553`)** — every `ASK_PATTERNS`
entry is prefixed with `(^|[;&|[:space:]])`, anchored at the phrase's **leading
command word** (multi-word phrases like `kubectl rollout restart` / `git
checkout \.` anchor at the first token, per the `gh repo delete` precedent). A
quote-adjacent mention such as `jq -n '{cmd:"gh issue close 123"}'` (phrase
preceded by `"`) no longer false-asks.

**(b) Literal-text redaction (mirrors `#3679`)** — the ask loop now reads a new
comment-stripped **AND** flag-value-redacted copy `COMMAND_ASK_SCAN` (built from
`COMMAND_NO_COMMENT`, so the comment-stripping the ask tier already relied on is
preserved). `strip_literal_text()` and its outer presence guard are extended to
cover `--comment` (previously `--body`/`-m`/`--title`/`--notes` only), so an
ask-phrase quoted inside a `--comment`/`--body` value of an *unrelated* command
no longer false-asks. The `--comment` addition also flows to the catastrophic
tier's `COMMAND_NO_LITERAL_TEXT` (consistent with the existing `--body` handling,
harmless).

## Scope boundary

Limited to ask-tier anchoring + redaction. The `#3755` quote-aware `qsplit`
helper is **untouched**; ask-tier membership / reversibility redesign is `#3757`
(which stacks on this branch). The catastrophic scan still reads the raw
command, so this can only **narrow** an ask, never miss a hard deny.

**Known limitation (shared with the catastrophic tier):** the `[[:space:]]`
anchor cannot distinguish a real separator from whitespace *inside* a quoted
string, so a mid-quote prose mention like `echo "… gh pr close …"` (space before
the phrase) still matches on its leading space. Robustly suppressing that needs
command-word segment classification, which is out of scope for
anchoring+redaction (`#3757` territory). The quote-*adjacent* `jq` case IS fixed.

## Tests

Added a `#3756` regression block in `tests/hooks/test-guard-destructive.sh`:
- ask-phrase in a quoted `jq` payload → ALLOW
- ask-phrase in a redacted `--body` value (no real ask cmd) → ALLOW
- ask-phrase in a redacted `--comment` value (no real ask cmd) → ALLOW
- genuine leading `gh issue close … --comment "…gh issue close…"` → still ASK
  (redaction suppresses the redundant second match; the real leading command
  legitimately still asks)
- chained `git status && gh issue close 5` → still ASK (separator anchor)

Full suite passes: **354/354**. `bash -n` + `shellcheck -S error` clean.

Closes #3756