### PR TITLE
fix(guard): scope ask tier to irreversibility; drop reversible gh ops from defaults (#3757)

### DIFF
--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -1053,7 +1053,7 @@ If setup fails, it's usually due to:
 
 Loom ships with two built-in Bash `PreToolUse` guard hooks, both registered under the `Bash` matcher and firing independently:
 
-- **`guard-destructive.sh`** — the generic repository-hygiene guard: catastrophic denies (`rm -rf /`, force-push to `main`, `gh repo delete`, fork bombs, curl-pipe-to-shell, cloud/SQL destruction), the segment-parsed lifecycle/cloud-CLI checks, and the `guards.sqlDdl` / `guards.cloudCli` / `guards.rmScope` / `guards.forceScope` toggle machinery. Nothing about this guard is Loom-specific; it is slated to move to Repo Skills (companion issue [rjwalters/repo#13](https://github.com/rjwalters/repo/issues/13)), which will own the generic half once it ships. Until then it keeps shipping and working in Loom exactly as before.
+- **`guard-destructive.sh`** — the generic repository-hygiene guard: catastrophic denies (`rm -rf /`, force-push to `main`, `gh repo delete`, fork bombs, curl-pipe-to-shell, cloud/SQL destruction), the segment-parsed lifecycle/cloud-CLI checks, and the `guards.sqlDdl` / `guards.cloudCli` / `guards.reversibleGh` / `guards.rmScope` / `guards.forceScope` toggle machinery. Nothing about this guard is Loom-specific; it is slated to move to Repo Skills (companion issue [rjwalters/repo#13](https://github.com/rjwalters/repo/issues/13)), which will own the generic half once it ships. Until then it keeps shipping and working in Loom exactly as before.
 - **`guard-loom-workflow.sh`** — the thin, Loom-workflow-specific guard (issue #3604): the `gh pr merge` → `merge-pr.sh` redirect and the `pip install -e` worktree block (keyed on `LOOM_WORKTREE_PATH`, issue #2495). These two guards are specific to the Loom worktree/merge workflow and stay Loom-owned.
 
 You can also add project-specific guards to protect read-only directories from accidental edits (see below).
@@ -1126,6 +1126,49 @@ LOOM_GUARD_CLOUD=0 aws ec2 terminate-instances --instance-ids i-1234
 
 # Force the cloud guard on for one command even when the repo opts out
 LOOM_GUARD_CLOUD=1 aws ec2 terminate-instances --instance-ids i-1234
+```
+
+### Reversible-GitHub Ask Opt-In (`guards.reversibleGh` / `LOOM_GUARD_REVERSIBLE_GH`)
+
+`guard-destructive.sh` scopes its ask tier to **irreversibility** (#3757): a guard whose purpose is preventing catastrophic, hard-to-undo mistakes should not add confirmation friction to operations that are trivially reversed. The **reversible** GitHub state changes — `gh pr close` (undo: `gh pr reopen`), `gh issue close` (undo: `gh issue reopen`), and `gh label delete` (undo: recreate, or one `gh label sync` in a repo with `labels.yml`) — therefore **do not prompt by default**. An autonomous agent that closes its own issue/PR as part of a normal lifecycle no longer stalls on a confirmation prompt (or, in a headless run with no approver, blocks entirely).
+
+The genuinely hard-to-reverse operations stay in the ungated ask tier and are **not** affected by this toggle: `gh release delete` (deletes published artifacts/tags), and `git clean -fd` / `git checkout .` / `git restore .` (untracked / uncommitted loss). The full catastrophic deny suite (`rm -rf /`, force-push to `main`, `gh repo delete`, …) is likewise unaffected.
+
+A repo that *wants* the confirmation back on the reversible GitHub ops can **opt in**. Unlike `guards.sqlDdl` / `guards.cloudCli` (which default **on** and are opted **out**), this toggle has **inverse polarity**: it defaults **off** and is opted **in**, because enabling it *adds* friction rather than removing it.
+
+The reversible-GitHub ask is **off by default**. It is resolved in this order (highest precedence first):
+
+1. **`LOOM_GUARD_REVERSIBLE_GH` env var** — `1`/`true`/`yes` enables the ask on `gh pr close` / `gh issue close` / `gh label delete`; `0`/`false`/`no` forces it off. Overrides the config value.
+2. **`.loom/config.json`** — `guards.reversibleGh` (default `false` when absent). Set it to `true` to opt in:
+   ```json
+   {
+     "guards": {
+       "reversibleGh": true
+     }
+   }
+   ```
+3. **Default** — `false` (no ask; the reversible GitHub ops pass through).
+
+The config read is best-effort: a missing, empty, or malformed `.loom/config.json` falls through to guard-**off** (the default) and never causes the hook to exit non-zero. Only the three reversible GitHub ASK patterns are affected — opting in does not touch `gh release delete`, the `git clean`/`checkout`/`restore` asks, or any deny.
+
+**Examples**:
+
+```bash
+# Default (off) — reversible GitHub ops pass through without a prompt:
+gh pr close 42          # allowed (undo: gh pr reopen 42)
+gh issue close 100      # allowed (undo: gh issue reopen 100)
+gh label delete stale   # allowed (undo: recreate the label)
+gh release delete v1.0  # STILL asks (not gated — deletes published artifacts)
+
+# Opt in to the confirmation for a whole repo:
+#   .loom/config.json  ->  { "guards": { "reversibleGh": true } }
+gh issue close 100      # ASK
+
+# Opt in for a single command:
+LOOM_GUARD_REVERSIBLE_GH=1 gh pr close 42       # ASK
+
+# Force off for one command even when the repo opts in:
+LOOM_GUARD_REVERSIBLE_GH=0 gh issue close 100   # allowed
 ```
 
 ### Repo-Scoped rm Guard (`guards.rmScope` / `LOOM_RM_SCOPE`)

--- a/defaults/hooks/guard-destructive.sh
+++ b/defaults/hooks/guard-destructive.sh
@@ -353,6 +353,60 @@ cloud_guard_enabled() {
 }
 
 # =============================================================================
+# Reversible-GitHub ask toggle — default OFF (opt-IN; inverse polarity, #3757).
+#
+# `gh pr close`, `gh issue close`, and `gh label delete` change shared state but
+# are trivially reversible — `gh pr reopen`, `gh issue reopen`, and recreating a
+# label (a repo with labels.yml restores in one `gh label sync`). A guard whose
+# purpose is preventing irreversible loss should not add confirmation friction to
+# these: an autonomous agent that closes its own issue/PR as part of a normal
+# lifecycle would otherwise stall on a prompt (or, headless, block entirely). So
+# they are NO LONGER in the ungated ASK_PATTERNS array; a repo that still wants
+# the confirmation can opt IN here. The genuinely hard-to-reverse ops
+# (`gh release delete` — published artifacts/tags; `git clean -fd` / `git
+# checkout .` / `git restore .` — untracked/uncommitted loss) STAY in the ungated
+# ask tier and are unaffected by this toggle.
+#
+# This is the INVERSE polarity of sql_guard_enabled()/cloud_guard_enabled():
+# those default ON (guard active) and are opted OUT; this one defaults OFF (no
+# ask) and is opted IN — because enabling it ADDS friction rather than removing
+# it. So the default and the absent-key resolution are `false`, not `true`.
+#
+# Resolution order (highest precedence first):
+#   1. LOOM_GUARD_REVERSIBLE_GH env var (1/true/yes enables the ask,
+#      0/false/no forces it off)
+#   2. .loom/config.json  ->  guards.reversibleGh  (default false when absent)
+#   3. Default: false (no ask)
+#
+# Mirrors cloud_guard_enabled()'s lazy/cached shape: cached in
+# _REVERSIBLE_GH_GUARD_CACHE, invoked LAZILY only after a reversible-gh pattern
+# has already matched so the jq config read never touches the hot path for the
+# common (non-matching) case. The config read is best-effort: any parse failure
+# falls through to guard-OFF (the default), never blocking.
+# =============================================================================
+_REVERSIBLE_GH_GUARD_CACHE=""
+reversible_gh_guard_enabled() {
+    if [[ -z "$_REVERSIBLE_GH_GUARD_CACHE" ]]; then
+        local enabled=false
+        if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/config.json" ]]; then
+            # jq // is alternative-on-null, not default-on-missing, so use
+            # if/then/else to treat only an explicit `true` as enabled (a
+            # missing guards.reversibleGh key stays off). On malformed JSON jq
+            # exits non-zero and the `||` fallback restores the guard-OFF default.
+            enabled=$(jq -r 'if .guards.reversibleGh == true then "true" else "false" end' "$REPO_ROOT/.loom/config.json" 2>/dev/null) || enabled=false
+            [[ -n "$enabled" ]] || enabled=false
+        fi
+        # Env override wins over config.
+        case "${LOOM_GUARD_REVERSIBLE_GH:-}" in
+            0|false|no)  enabled=false ;;
+            1|true|yes)  enabled=true ;;
+        esac
+        _REVERSIBLE_GH_GUARD_CACHE="$enabled"
+    fi
+    [[ "$_REVERSIBLE_GH_GUARD_CACHE" == "true" ]]
+}
+
+# =============================================================================
 # rm-scope repo mode toggle — default REPO (safe-by-default; opt out to off).
 #
 # As of issue #3628 (ADR Option B) this guard defaults to `repo` mode: it
@@ -1327,11 +1381,13 @@ ASK_PATTERNS=(
     '(^|[;&|[:space:]])git checkout \.'
     '(^|[;&|[:space:]])git restore \.'
 
-    # GitHub operations that modify shared state
-    '(^|[;&|[:space:]])gh pr close'
-    '(^|[;&|[:space:]])gh issue close'
+    # GitHub operations that are genuinely hard to reverse. `gh release delete`
+    # removes published artifacts/tags — it STAYS an ungated ask. The reversible
+    # GitHub state changes (`gh pr close`, `gh issue close`, `gh label delete`)
+    # were REMOVED from this array (#3757): they are trivially undone (gh pr
+    # reopen / gh issue reopen / recreate the label) and are only asked for when
+    # a repo opts IN via guards.reversibleGh (REVERSIBLE_GH_ASK_PATTERNS below).
     '(^|[;&|[:space:]])gh release delete'
-    '(^|[;&|[:space:]])gh label delete'
 
     # NOTE: cloud CLI (aws) + docker ASK patterns are NOT in this ungated array.
     # They live in CLOUD_ASK_PATTERNS below, gated by cloud_guard_enabled() so
@@ -1362,6 +1418,35 @@ ASK_PATTERNS=(
 for pattern in "${ASK_PATTERNS[@]}"; do
     if echo "$COMMAND_ASK_SCAN" | grep -qE "$pattern"; then
         ask "Command requires confirmation: $COMMAND"
+    fi
+done
+
+# =============================================================================
+# REVERSIBLE-GITHUB ASK patterns — gated by the reversible-gh guard toggle (#3757)
+#
+# Kept OUT of the ungated ASK_PATTERNS array (mirroring the CLOUD_ASK_PATTERNS
+# split) because these GitHub state changes are trivially reversible and should
+# NOT prompt by default — an autonomous agent closing its own issue/PR as part of
+# a normal lifecycle would otherwise stall. reversible_gh_guard_enabled() defaults
+# OFF and is consulted only AFTER a pattern matches, so the config read stays off
+# the hot path for non-matching commands (mirrors the SQL DDL / cloud blocks).
+#
+# These entries are anchored (#3756) and scanned against COMMAND_ASK_SCAN — the
+# comment-stripped, literal-text-redacted ask working copy — exactly as they were
+# while living in ASK_PATTERNS, so #3756's redaction still applies when the toggle
+# is opted IN (an ask-phrase quoted inside a --body/--comment value does not
+# false-ask). `gh release delete` deliberately stays in the ungated ASK_PATTERNS
+# above (hard to reverse) and is NOT gated here.
+# =============================================================================
+REVERSIBLE_GH_ASK_PATTERNS=(
+    '(^|[;&|[:space:]])gh pr close'
+    '(^|[;&|[:space:]])gh issue close'
+    '(^|[;&|[:space:]])gh label delete'
+)
+
+for pattern in "${REVERSIBLE_GH_ASK_PATTERNS[@]}"; do
+    if echo "$COMMAND_ASK_SCAN" | grep -qE "$pattern" && reversible_gh_guard_enabled; then
+        ask "Command requires confirmation: $COMMAND (set guards.reversibleGh:true in .loom/config.json to keep this ask; it is off by default because the op is trivially reversible)"
     fi
 done
 

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -473,11 +473,20 @@ assert_ask "Ask for git read-tree -m merge sim without isolation (#3637)" \
 assert_ask "Ask for git read-tree at the end of a compound command (#3637)" \
     "git fetch origin && git read-tree origin/main"
 
-assert_ask "Ask for gh pr close" \
+# --- #3757: reversible GitHub state changes no longer ask by default ---
+# gh pr close / gh issue close / gh label delete are trivially reversible
+# (gh pr reopen / gh issue reopen / recreate the label), so they are NOT in the
+# ungated ask tier anymore — they only ask when a repo opts IN via
+# guards.reversibleGh (covered in the toggle block below). gh release delete
+# stays a default ask (deletes published artifacts/tags — hard to reverse).
+assert_allow "#3757: gh pr close no longer asks by default (reversible)" \
     "gh pr close 42"
 
-assert_ask "Ask for gh issue close" \
+assert_allow "#3757: gh issue close no longer asks by default (reversible)" \
     "gh issue close 100"
+
+assert_allow "#3757: gh label delete no longer asks by default (reversible)" \
+    "gh label delete needs-triage"
 
 assert_ask "Ask for gh release delete" \
     "gh release delete v1.0"
@@ -508,14 +517,18 @@ assert_allow "#3756: ask-phrase inside a redacted --comment value (no real ask c
 
 # A GENUINE leading ask command still asks even when it carries a --comment whose
 # value also mentions the phrase: the redaction suppresses the redundant second
-# match, but the real leading 'gh issue close' legitimately still asks.
-assert_ask "#3756: genuine leading gh issue close with a --comment still asks" \
-    "gh issue close 5 --comment \"restored the old gh issue close behavior\""
+# match, but the real leading 'gh issue close' legitimately still asks — but only
+# when the reversible-gh ask is opted IN (#3757 moved gh issue close behind
+# guards.reversibleGh, off by default), so this #3756 anchoring case is exercised
+# with the toggle forced on.
+assert_ask_env "#3756/#3757: genuine leading gh issue close with --comment asks when opted in" \
+    "LOOM_GUARD_REVERSIBLE_GH=1" "gh issue close 5 --comment \"restored the old gh issue close behavior\""
 
 # A separator-preceded genuine ask command still asks (the anchor's `[;&|]`
-# alternative covers `&&`-chained commands).
-assert_ask "#3756: chained 'git status && gh issue close' still asks" \
-    "git status && gh issue close 5"
+# alternative covers `&&`-chained commands) — again exercised with the
+# reversible-gh toggle opted in (#3757).
+assert_ask_env "#3756/#3757: chained 'git status && gh issue close' asks when opted in" \
+    "LOOM_GUARD_REVERSIBLE_GH=1" "git status && gh issue close 5"
 
 # aws s3 ls is read-only — verb-narrowed cloud ASK patterns no longer prompt (#3593).
 assert_allow "Allow aws s3 ls (read-only, #3593)" \
@@ -862,6 +875,67 @@ assert_deny_env "Cloud config-off: force-push to main still blocked" \
 # Clean up cloud temp repos.
 for _cloud_dir in "$CLOUD_OFF_REPO" "$CLOUD_ON_REPO" "$CLOUD_ABSENT_REPO" "$CLOUD_BAD_REPO"; do
     [[ -n "$_cloud_dir" && "$_cloud_dir" != "/" && -d "$_cloud_dir/.loom" ]] && rm -rf "$_cloud_dir"
+done
+
+echo ""
+
+# =========================================================================
+echo -e "${YELLOW}--- Reversible-GitHub ask opt-in (guards.reversibleGh / LOOM_GUARD_REVERSIBLE_GH) (#3757) ---${NC}"
+# =========================================================================
+#
+# INVERSE polarity of guards.sqlDdl/cloudCli: default OFF (no ask), opted IN.
+# gh pr close / gh issue close / gh label delete do not ask by default; they ask
+# only when the toggle is enabled. gh release delete is NOT gated by this toggle
+# and always asks. Resolution: LOOM_GUARD_REVERSIBLE_GH env > guards.reversibleGh
+# config > default false. Reuse make_sql_repo (it only writes .loom/config.json).
+REVGH_ON_REPO=$(make_sql_repo '{"guards":{"reversibleGh":true}}')
+REVGH_OFF_REPO=$(make_sql_repo '{"guards":{"reversibleGh":false}}')
+REVGH_ABSENT_REPO=$(make_sql_repo '{"champion":{"auto_merge_max_lines":200}}')
+REVGH_BAD_REPO=$(make_sql_repo '{ not valid json ')
+
+# --- Default OFF: absent key / explicit false / malformed JSON => no ask ---
+assert_allow_env "reversibleGh absent key: gh pr close allowed (default off)" \
+    "" "gh pr close 42" "$REVGH_ABSENT_REPO"
+assert_allow_env "reversibleGh absent key: gh issue close allowed (default off)" \
+    "" "gh issue close 100" "$REVGH_ABSENT_REPO"
+assert_allow_env "reversibleGh absent key: gh label delete allowed (default off)" \
+    "" "gh label delete needs-triage" "$REVGH_ABSENT_REPO"
+assert_allow_env "reversibleGh:false config: gh issue close allowed" \
+    "" "gh issue close 100" "$REVGH_OFF_REPO"
+assert_allow_env "reversibleGh malformed JSON: gh issue close allowed (fails safe to off)" \
+    "" "gh issue close 100" "$REVGH_BAD_REPO"
+
+# --- Config ON: guards.reversibleGh:true opts the ask back in ---
+assert_ask_env "reversibleGh:true config: gh pr close asks" \
+    "" "gh pr close 42" "$REVGH_ON_REPO"
+assert_ask_env "reversibleGh:true config: gh issue close asks" \
+    "" "gh issue close 100" "$REVGH_ON_REPO"
+assert_ask_env "reversibleGh:true config: gh label delete asks" \
+    "" "gh label delete needs-triage" "$REVGH_ON_REPO"
+
+# --- Env override wins over config (mirrors sqlDdl/cloudCli precedent) ---
+assert_ask_env "LOOM_GUARD_REVERSIBLE_GH=1 overrides config-off: gh issue close asks" \
+    "LOOM_GUARD_REVERSIBLE_GH=1" "gh issue close 100" "$REVGH_OFF_REPO"
+assert_allow_env "LOOM_GUARD_REVERSIBLE_GH=0 overrides config-on: gh issue close allowed" \
+    "LOOM_GUARD_REVERSIBLE_GH=0" "gh issue close 100" "$REVGH_ON_REPO"
+
+# --- gh release delete is NOT gated by this toggle: always asks ---
+assert_ask_env "reversibleGh off: gh release delete STILL asks (not gated)" \
+    "" "gh release delete v1.0" "$REVGH_OFF_REPO"
+assert_ask_env "LOOM_GUARD_REVERSIBLE_GH=0: gh release delete STILL asks (not gated)" \
+    "LOOM_GUARD_REVERSIBLE_GH=0" "gh release delete v1.0" "$REVGH_ON_REPO"
+
+# --- Toggle off must NOT weaken unrelated guards ---
+assert_ask_env "reversibleGh off: git clean -fd STILL asks (kept in ungated ask tier)" \
+    "LOOM_GUARD_REVERSIBLE_GH=0" "git clean -fd" "$REVGH_OFF_REPO"
+assert_deny_env "reversibleGh off: rm -rf / still blocked" \
+    "LOOM_GUARD_REVERSIBLE_GH=0" "rm -rf /" "$REVGH_OFF_REPO"
+assert_deny_env "reversibleGh off: force-push to main still blocked" \
+    "LOOM_GUARD_REVERSIBLE_GH=0" "git push --force origin main" "$REVGH_OFF_REPO"
+
+# Clean up reversible-gh temp repos.
+for _revgh_dir in "$REVGH_ON_REPO" "$REVGH_OFF_REPO" "$REVGH_ABSENT_REPO" "$REVGH_BAD_REPO"; do
+    [[ -n "$_revgh_dir" && "$_revgh_dir" != "/" && -d "$_revgh_dir/.loom" ]] && rm -rf "$_revgh_dir"
 done
 
 echo ""


### PR DESCRIPTION
## Summary

Top of the guard-destructive.sh trio (#3755 to #3756 to **#3757**). Stacked on `feature/issue-3756`; contains #3755's qsplit (via main) and #3756's ask-tier anchoring + redaction. This PR changes ONLY ask-tier **membership** by irreversibility — no re-anchoring, no touching `strip_literal_text()`/`COMMAND_NO_LITERAL_TEXT`, no qsplit changes.

The ask tier gated several **reversible** GitHub ops. A guard meant to prevent irreversible loss should not add confirmation friction to ops trivially undone, so those are dropped from the defaults.

## Changes

`defaults/hooks/guard-destructive.sh`:
- Removed `gh pr close` / `gh issue close` / `gh label delete` from the ungated `ASK_PATTERNS` array (they undo via `gh pr reopen` / `gh issue reopen` / recreate).
- Added `reversible_gh_guard_enabled()` gate + a separate `REVERSIBLE_GH_ASK_PATTERNS` array, mirroring `cloud_guard_enabled()` / `CLOUD_ASK_PATTERNS`: lazy + cached, scanned against `COMMAND_ASK_SCAN` so #3756's anchoring + literal-text redaction still apply when opted in.
- **Inverse polarity** toggle (`guards.reversibleGh` / `LOOM_GUARD_REVERSIBLE_GH`): defaults **OFF** (no ask) and is opted **in**, because enabling it *adds* friction (unlike sqlDdl/cloudCli which default on). Resolution: env > config > default false.
- **Kept** in the ungated ask tier (hard to reverse): `gh release delete`, `git clean -fd`, `git checkout .`, `git restore .`.

`tests/hooks/test-guard-destructive.sh`:
- Flipped the `gh pr close` / `gh issue close` default `assert_ask` to `assert_allow`; added a `gh label delete` allow case; kept `gh release delete` asserting ASK.
- Added a full toggle-resolution block (absent/false/malformed to allow; config true to ask; env override wins both ways; `gh release delete` still asks; no weakening of `git clean -fd` / recursive-force root rm / force-push-to-main).
- Re-homed the two #3756 `gh issue close` anchoring cases behind `LOOM_GUARD_REVERSIBLE_GH=1` so anchoring coverage survives under opt-in.

`defaults/CLAUDE.md`: documented `guards.reversibleGh` in the Custom Guard Hooks catalog, matching the existing subsection format (note the inverse default-off polarity).

## Acceptance criteria

- [x] `gh issue close` / `gh pr close` / `gh label delete` no longer prompt by default (moved behind opt-in `guards.reversibleGh`, default off).
- [x] `gh release delete` still asks (unchanged).
- [x] `git clean -fd`, `git checkout .`, `git restore .` still ask (unchanged).
- [x] New opt-in category follows the toggle precedent (env > config > default) and defaults **off**.
- [x] `defaults/CLAUDE.md` Custom Guard Hooks section updated.
- [x] Three default `assert_ask` cases flipped to `assert_allow`; new toggle-on tests confirm `gh release delete` still asks.
- [x] Full suite passes with zero regressions — **370/370**.

## Test

```
bash tests/hooks/test-guard-destructive.sh   # 370/370 pass
```

Closes #3757

🤖 Generated with [Claude Code](https://claude.com/claude-code)
