### PR TITLE
feat(sweep): non-blocking main-freshness pre-flight advisory (#3770)

### DIFF
--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -1478,6 +1478,23 @@ This is advisory-only. The script always exits `0` and **must not block** the sw
 
 If the user is running an overnight sweep, they should heed the warning before walking away.
 
+## Main Branch Freshness (#3770)
+
+During a long sweep, other PRs can merge to `origin`'s default branch. Because the installed `.loom/scripts/` and `.loom/hooks/` copies are synced from `defaults/` at install time, a local default branch that has drifted behind `origin` means the session may be executing **stale orchestration scripts** that silently lack recently-merged logic. This actually happened (#3770): during a 2026-07-22 sweep, `worktree.sh --base` (#3742) and `merge-pr.sh` auto-reconcile (#3752) were absent from the copies the session was running even though both had merged to `origin/main` — a running sweep had no signal it was behind.
+
+**Before the first wave**, run the main-freshness check and surface its output to the user (same timing and sibling role as the Host Sleep Readiness check above):
+
+```bash
+./.loom/scripts/check-main-freshness.sh
+```
+
+This is advisory-only. The script always exits `0` and **must not block** the sweep — proceed regardless of what it prints. It is strictly **read-only**: it never runs `git pull` / `git merge` / `git reset` and never auto-reconciles. It does a bounded `git fetch` of the default branch (degrading gracefully to the last-known ref when offline), then compares the local default branch against `origin/<default-branch>`:
+
+- **Behind by N commits:** prints a bordered warning to stderr noting that installed `.loom/scripts/` / `.loom/hooks/` copies may be stale, with the remediation `git merge --ff-only origin/<default-branch>`. When it can resolve both trees it also best-effort notes any installed script/hook whose content differs from its `defaults/` counterpart.
+- **Up to date:** prints nothing to stderr; a one-line stdout confirmation (suppressible with `--quiet`, matching `check-host-sleep.sh`).
+
+If the check warns, the operator should refresh local `main` (and re-sync installed copies if their install flow does so) before relying on stacked-dependency or auto-reconcile behavior mid-sweep.
+
 ## Daemon Coexistence
 
 > **Note**: the legacy `./.loom/scripts/daemon.sh` was removed in #3432 and is not restored. The historical PID-file daemon (`.loom/daemon-loop.pid`) is not part of the current architecture; the check below is a defensive coexistence guard that fires only if such a process is somehow already running — normally a no-op. The Tier 2 dispatch backend is now the Rust `loom-daemon` binary (observed via `mcp__loom__list_sweeps`); the background agent-pool control surface is `.loom/bin/loom start|status|stop`.

--- a/defaults/scripts/check-main-freshness.sh
+++ b/defaults/scripts/check-main-freshness.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# check-main-freshness.sh - Warn when local default branch is behind origin.
+#
+# This is a NON-BLOCKING, advisory check. During a long-running /loom:sweep
+# session, other PRs can merge to origin's default branch — and because the
+# installed .loom/scripts/ and .loom/hooks/ copies are synced from defaults/
+# at install time, a local default branch that has drifted behind origin means
+# the session may be executing STALE orchestration scripts that silently lack
+# recently-merged logic (see #3770 for the incident: worktree.sh --base (#3742)
+# and merge-pr.sh auto-reconcile (#3752) were absent from the copies the session
+# was actually running, even though both had merged to origin/main).
+#
+# It is invoked at the start of /loom:sweep, alongside check-host-sleep.sh
+# (#3350). It MUST NOT block — even if git / the network fails, it returns 0 and
+# orchestration proceeds. It NEVER auto-pulls, merges, or resets — read-only.
+#
+# Usage:
+#   ./.loom/scripts/check-main-freshness.sh         # print warning (or nothing) and exit 0
+#   ./.loom/scripts/check-main-freshness.sh --quiet # suppress the stdout one-liner
+#   ./.loom/scripts/check-main-freshness.sh --help  # show usage
+#
+# Exit codes:
+#   0 - Always. This script is advisory; it never blocks Loom.
+#
+# See also: check-host-sleep.sh (#3350) — the sibling pre-flight advisory this
+# script mirrors in structure and contract.
+
+set -uo pipefail  # NOTE: no -e — this script must never exit non-zero
+
+# ---------- source the default-branch helper ----------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null || echo .)"
+# shellcheck source=lib/default-branch.sh
+if [[ -r "$SCRIPT_DIR/lib/default-branch.sh" ]]; then
+    # shellcheck disable=SC1091
+    source "$SCRIPT_DIR/lib/default-branch.sh" 2>/dev/null || true
+fi
+
+# ---------- output helpers ----------
+
+# Colors (only when stderr is a tty)
+if [[ -t 2 ]]; then
+    YELLOW='\033[1;33m'
+    GREEN='\033[1;32m'
+    BOLD='\033[1m'
+    NC='\033[0m'
+else
+    YELLOW=''
+    GREEN=''
+    BOLD=''
+    NC=''
+fi
+
+QUIET=0
+for arg in "$@"; do
+    case "$arg" in
+        --quiet|-q)
+            QUIET=1
+            ;;
+        --help|-h)
+            sed -n '2,27p' "$0" | sed 's/^# //; s/^#//'
+            exit 0
+            ;;
+        *)
+            # Unknown args are ignored — this script must never fail.
+            ;;
+    esac
+done
+
+warn() {
+    # Print a multi-line warning block to stderr. Always returns 0.
+    printf '%b\n' "$*" >&2 || true
+}
+
+info_oneliner() {
+    # Print a single status line to stdout (suppressed by --quiet).
+    if [[ "$QUIET" -eq 0 ]]; then
+        printf '%b\n' "$*" || true
+    fi
+}
+
+# ---------- pre-flight: must be inside a git repo ----------
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+    info_oneliner "${YELLOW}[freshness-check] not inside a git repository; skipping.${NC}"
+    exit 0
+fi
+
+# ---------- resolve default branch ----------
+
+BRANCH=""
+if declare -F loom_default_branch >/dev/null 2>&1; then
+    BRANCH="$(loom_default_branch origin 2>/dev/null || true)"
+fi
+
+if [[ -z "$BRANCH" ]]; then
+    info_oneliner "${YELLOW}[freshness-check] could not determine the default branch; skipping.${NC}"
+    exit 0
+fi
+
+REMOTE_REF="origin/$BRANCH"
+
+# ---------- bounded fetch (degrade gracefully) ----------
+
+# Try to refresh origin's view of the default branch, bounded so a hung network
+# can't stall the sweep. On any failure (offline, auth, rate-limit, no `timeout`
+# binary) we fall back to whatever refs/remotes/origin/<branch> is already known
+# locally — possibly stale, but the check stays cheap and never blocks.
+if command -v timeout >/dev/null 2>&1; then
+    timeout 5 git fetch origin "$BRANCH" --quiet >/dev/null 2>&1 || true
+else
+    # No `timeout` available (e.g. minimal macOS without coreutils). Still try,
+    # but git's own --quiet keeps it unobtrusive; a hung network is a rare edge.
+    git fetch origin "$BRANCH" --quiet >/dev/null 2>&1 || true
+fi
+
+# ---------- verify we have both refs to compare ----------
+
+if ! git show-ref --verify --quiet "refs/heads/$BRANCH" 2>/dev/null; then
+    # No local default branch (e.g. detached checkout of a worktree). Nothing to
+    # compare against — skip silently-ish.
+    info_oneliner "${YELLOW}[freshness-check] no local '${BRANCH}' branch to compare; skipping.${NC}"
+    exit 0
+fi
+
+if ! git show-ref --verify --quiet "refs/remotes/$REMOTE_REF" 2>/dev/null; then
+    info_oneliner "${YELLOW}[freshness-check] no '${REMOTE_REF}' ref known locally; skipping (offline?).${NC}"
+    exit 0
+fi
+
+# ---------- compute how far behind ----------
+
+N="$(git rev-list --count "${BRANCH}..${REMOTE_REF}" 2>/dev/null || echo 0)"
+if ! [[ "$N" =~ ^[0-9]+$ ]]; then
+    N=0
+fi
+
+if [[ "$N" -eq 0 ]]; then
+    info_oneliner "${GREEN}[freshness-check] local ${BRANCH} is up to date with ${REMOTE_REF}.${NC}"
+    exit 0
+fi
+
+# ---------- N > 0: warn (non-blocking) ----------
+
+warn ""
+warn "${YELLOW}${BOLD}========================================================================${NC}"
+warn "${YELLOW}${BOLD}  WARNING: local ${BRANCH} is behind ${REMOTE_REF} (#3770)${NC}"
+warn "${YELLOW}${BOLD}========================================================================${NC}"
+warn "${YELLOW}Local ${BRANCH} is ${N} commit(s) behind ${REMOTE_REF}.${NC}"
+warn "${YELLOW}The installed .loom/scripts/ and .loom/hooks/ copies are synced from${NC}"
+warn "${YELLOW}defaults/ at install time, so this session may be executing STALE${NC}"
+warn "${YELLOW}orchestration scripts that silently lack recently-merged logic.${NC}"
+warn ""
+warn "${BOLD}Remediation (read-only advisory — this script never pulls for you):${NC}"
+warn "      ${BOLD}git merge --ff-only ${REMOTE_REF}${NC}"
+warn "  then re-sync the installed copies if your install flow does so."
+warn ""
+
+# ---------- stretch goal: best-effort installed-vs-defaults drift note ----------
+#
+# When N > 0, additionally flag files present in BOTH .loom/scripts (installed)
+# and defaults/scripts whose content differs. Best-effort: if either tree can't
+# be resolved, skip silently. We only flag content differences for files present
+# in both trees — never "only on one side" (repo-specific hooks like
+# guard-worktree-paths.sh have no defaults/ counterpart and are not drift).
+report_tree_drift() {
+    local installed_dir="$1" defaults_dir="$2" label="$3"
+    [[ -d "$installed_dir" && -d "$defaults_dir" ]] || return 0
+
+    local f name
+    for f in "$installed_dir"/*; do
+        [[ -f "$f" ]] || continue
+        name="$(basename "$f")"
+        if [[ -f "$defaults_dir/$name" ]]; then
+            if ! cmp -s "$f" "$defaults_dir/$name" 2>/dev/null; then
+                warn "${YELLOW}  installed ${label}/${name} differs from defaults/${label}/${name}${NC}"
+            fi
+        fi
+    done
+}
+
+# Resolve the repo root so we can find both trees regardless of cwd. Prefer the
+# common dir (worktree-safe); fall back to toplevel.
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+COMMON_DIR="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+if [[ -n "$COMMON_DIR" ]]; then
+    # git-common-dir points at the main checkout's .git; its parent is the main
+    # worktree root, where installed .loom/ and source defaults/ both live.
+    case "$COMMON_DIR" in
+        */.git) REPO_ROOT="${COMMON_DIR%/.git}" ;;
+    esac
+fi
+
+if [[ -n "$REPO_ROOT" ]]; then
+    drift_found=0
+    if [[ -d "$REPO_ROOT/.loom/scripts" && -d "$REPO_ROOT/defaults/scripts" ]]; then
+        drift_found=1
+    fi
+    if [[ -d "$REPO_ROOT/.loom/hooks" && -d "$REPO_ROOT/defaults/hooks" ]]; then
+        drift_found=1
+    fi
+    if [[ "$drift_found" -eq 1 ]]; then
+        warn "${YELLOW}Installed-copy drift check (files present in both trees):${NC}"
+        report_tree_drift "$REPO_ROOT/.loom/scripts" "$REPO_ROOT/defaults/scripts" "scripts"
+        report_tree_drift "$REPO_ROOT/.loom/hooks" "$REPO_ROOT/defaults/hooks" "hooks"
+        warn ""
+    fi
+fi
+
+warn "${YELLOW}========================================================================${NC}"
+warn ""
+
+info_oneliner "${YELLOW}[freshness-check] WARNING: local ${BRANCH} is ${N} commit(s) behind ${REMOTE_REF}. See stderr for details.${NC}"
+
+# Always succeed — this script is advisory only.
+exit 0

--- a/defaults/scripts/tests/test-check-main-freshness.sh
+++ b/defaults/scripts/tests/test-check-main-freshness.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# test-check-main-freshness.sh - Smoke tests for check-main-freshness.sh (#3770)
+#
+# Unlike test-check-host-sleep.sh (which probes the live host), this harness
+# constructs throwaway local git repos with a synthetic `origin` remote so it can
+# deterministically exercise the three load-bearing cases:
+#   (a) up-to-date  -> exit 0, no stderr warning
+#   (b) behind      -> exit 0, prints the "behind" warning to stderr
+#   (c) fetch fails -> exit 0 (never blocks) even when origin is unreachable
+# Plus the flag/contract checks mirrored from test-check-host-sleep.sh:
+#   - always exits 0
+#   - --quiet suppresses the stdout one-liner
+#   - --help prints usage
+#   - unknown args don't break it
+#
+# Usage:
+#   ./.loom/scripts/tests/test-check-main-freshness.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPERS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$HELPERS_DIR/check-main-freshness.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: $1"
+}
+
+fail() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: $1"
+}
+
+# Scratch area for fixtures — cleaned on exit.
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/test-freshness.XXXXXX")"
+# shellcheck disable=SC2329  # invoked indirectly via the EXIT trap below
+cleanup() { rm -rf "$WORKDIR" 2>/dev/null || true; }
+trap cleanup EXIT
+
+# git needs an identity in a clean CI environment.
+export GIT_AUTHOR_NAME="test" GIT_AUTHOR_EMAIL="test@example.com"
+export GIT_COMMITTER_NAME="test" GIT_COMMITTER_EMAIL="test@example.com"
+# Force the default-branch helper to a known value so detection is deterministic
+# regardless of the host's git init.defaultBranch config.
+export LOOM_DEFAULT_BRANCH="main"
+
+# --- fixture builder ---------------------------------------------------------
+# Creates:
+#   $WORKDIR/origin.git  — a bare "remote"
+#   $WORKDIR/clone       — a working clone with local `main` tracking origin/main
+# The clone's `main` starts at parity with origin/main. Callers then advance
+# origin and/or rewind the clone to create the "behind" case.
+make_fixture() {
+    local origin="$WORKDIR/origin.git"
+    local clone="$WORKDIR/clone"
+    rm -rf "$origin" "$clone"
+
+    git init --quiet --bare "$origin"
+    # Point the bare repo's HEAD at main so `git clone` doesn't warn about a
+    # nonexistent default ref (bare init defaults HEAD to refs/heads/master).
+    git -C "$origin" symbolic-ref HEAD refs/heads/main >/dev/null 2>&1 || true
+
+    # Seed the remote via a throwaway seed clone.
+    local seed="$WORKDIR/seed"
+    rm -rf "$seed"
+    git init --quiet "$seed"
+    git -C "$seed" checkout -q -b main
+    echo "v1" > "$seed/file.txt"
+    git -C "$seed" add file.txt
+    git -C "$seed" commit -q -m "c1"
+    git -C "$seed" remote add origin "$origin"
+    git -C "$seed" push -q origin main
+
+    # The clone under test.
+    git clone -q "$origin" "$clone"
+    git -C "$clone" checkout -q main
+    # Populate refs/remotes/origin/HEAD so loom_default_branch resolves offline
+    # too (belt-and-suspenders; LOOM_DEFAULT_BRANCH already forces it).
+    git -C "$clone" remote set-head origin main >/dev/null 2>&1 || true
+}
+
+# Advance origin/main by one commit (simulating another PR merging mid-sweep).
+advance_origin() {
+    local seed="$WORKDIR/seed"
+    echo "v2-$RANDOM" >> "$seed/file.txt"
+    git -C "$seed" add file.txt
+    git -C "$seed" commit -q -m "c2"
+    git -C "$seed" push -q origin main
+}
+
+# -------- Test 1: script exists and is executable --------
+echo "Test 1: script exists and is executable"
+if [[ -x "$SCRIPT" ]]; then
+    pass "check-main-freshness.sh is executable"
+else
+    fail "check-main-freshness.sh is missing or not executable: $SCRIPT"
+    echo "FAILED: $TESTS_FAILED/$TESTS_RUN"
+    exit 1
+fi
+
+# -------- Test 2: up-to-date -> exit 0, no stderr warning --------
+echo "Test 2: up-to-date case exits 0 with no warning"
+make_fixture
+stderr_out="$(cd "$WORKDIR/clone" && "$SCRIPT" 2>&1 >/dev/null)"
+rc=$?
+if [[ "$rc" -eq 0 ]]; then
+    pass "up-to-date exit code is 0"
+else
+    fail "up-to-date expected exit 0, got $rc"
+fi
+if ! printf '%s' "$stderr_out" | grep -qi "behind"; then
+    pass "up-to-date prints no 'behind' warning"
+else
+    fail "up-to-date unexpectedly warned: $stderr_out"
+fi
+stdout_out="$(cd "$WORKDIR/clone" && "$SCRIPT" 2>/dev/null)"
+if printf '%s' "$stdout_out" | grep -qi "up to date"; then
+    pass "up-to-date prints an up-to-date one-liner"
+else
+    fail "up-to-date missing one-liner. Got: $stdout_out"
+fi
+
+# -------- Test 3: behind -> exit 0 and warns --------
+echo "Test 3: behind case exits 0 and prints the warning"
+make_fixture
+advance_origin   # origin/main now ahead; clone hasn't fetched yet
+stderr_out="$(cd "$WORKDIR/clone" && "$SCRIPT" 2>&1 >/dev/null)"
+rc=$?
+if [[ "$rc" -eq 0 ]]; then
+    pass "behind exit code is 0"
+else
+    fail "behind expected exit 0, got $rc"
+fi
+if printf '%s' "$stderr_out" | grep -qi "behind"; then
+    pass "behind prints the 'behind' warning to stderr"
+else
+    fail "behind did not warn. Got: $stderr_out"
+fi
+if printf '%s' "$stderr_out" | grep -q "3770"; then
+    pass "behind warning references issue #3770"
+else
+    fail "behind warning missing #3770 reference"
+fi
+if printf '%s' "$stderr_out" | grep -q -- "--ff-only"; then
+    pass "behind warning suggests git merge --ff-only remediation"
+else
+    fail "behind warning missing --ff-only remediation"
+fi
+
+# -------- Test 4: fetch failure -> still exit 0 (never blocks) --------
+echo "Test 4: fetch failure still exits 0 (never blocks)"
+make_fixture
+advance_origin
+# Point origin at an unreachable path so `git fetch` fails; the local
+# refs/remotes/origin/main from clone time is still present (stale) as fallback.
+git -C "$WORKDIR/clone" remote set-url origin "/nonexistent/path/repo.git"
+# Run it in the clone dir and capture exit.
+rc=0
+( cd "$WORKDIR/clone" && "$SCRIPT" >/dev/null 2>&1 ) || rc=$?
+if [[ "$rc" -eq 0 ]]; then
+    pass "fetch-failure exit code is 0"
+else
+    fail "fetch-failure expected exit 0, got $rc"
+fi
+
+# -------- Test 5: --quiet suppresses stdout, still exits 0 --------
+echo "Test 5: --quiet suppresses stdout"
+make_fixture
+stdout_quiet="$(cd "$WORKDIR/clone" && "$SCRIPT" --quiet 2>/dev/null)"
+rc=$?
+if [[ "$rc" -eq 0 ]]; then
+    pass "--quiet exit code is 0"
+else
+    fail "--quiet exit expected 0, got $rc"
+fi
+if [[ -z "$stdout_quiet" ]]; then
+    pass "--quiet produces no stdout"
+else
+    fail "--quiet produced stdout: $stdout_quiet"
+fi
+
+# -------- Test 6: --help prints usage and exits 0 --------
+echo "Test 6: --help prints usage and exits 0"
+help_out="$("$SCRIPT" --help 2>&1 || true)"
+rc=$?
+if [[ "$rc" -eq 0 ]]; then
+    pass "--help exit code is 0"
+else
+    fail "--help exit expected 0, got $rc"
+fi
+if printf '%s' "$help_out" | grep -qi "Usage"; then
+    pass "--help mentions Usage"
+else
+    fail "--help did not mention Usage. Got: $help_out"
+fi
+
+# -------- Test 7: unknown args do not break it --------
+echo "Test 7: unknown args do not break the script"
+make_fixture
+rc=0
+( cd "$WORKDIR/clone" && "$SCRIPT" --some-nonsense-flag --another 99 >/dev/null 2>&1 ) || rc=$?
+if [[ "$rc" -eq 0 ]]; then
+    pass "unknown args tolerated; exit 0"
+else
+    fail "unknown args caused non-zero exit ($rc)"
+fi
+
+# -------- Test 8: outside a git repo -> exit 0, skip gracefully --------
+echo "Test 8: outside a git repo exits 0"
+non_git="$WORKDIR/not-a-repo"
+mkdir -p "$non_git"
+rc=0
+( cd "$non_git" && "$SCRIPT" >/dev/null 2>&1 ) || rc=$?
+if [[ "$rc" -eq 0 ]]; then
+    pass "non-git dir exit code is 0"
+else
+    fail "non-git dir expected exit 0, got $rc"
+fi
+
+# -------- Summary --------
+echo ""
+echo "Results: $TESTS_PASSED/$TESTS_RUN passed"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+    echo -e "${RED}FAILED${NC}: $TESTS_FAILED test(s) failed"
+    exit 1
+fi
+echo -e "${GREEN}OK${NC}: all tests passed"
+exit 0


### PR DESCRIPTION
Closes #3770

## Summary

Adds a read-only, non-blocking Stage -1 pre-flight advisory that warns when the local default branch has drifted behind `origin`, signalling that installed `.loom/scripts/` / `.loom/hooks/` copies (synced from `defaults/`) may be stale — the failure mode from the #3742/#3752 mid-sweep incident where a long sweep silently ran orchestration scripts lacking recently-merged logic.

## Changes

- **`defaults/scripts/check-main-freshness.sh`** (new) — mirrors `check-host-sleep.sh`'s NEVER-FAILS contract (`set -uo pipefail`, no `-e`, always exit 0). Sources `lib/default-branch.sh` (`loom_default_branch`), does a bounded `timeout 5 git fetch` of the default branch (degrades to last-known ref when offline), computes `git rev-list --count <branch>..origin/<branch>`, and on N>0 prints a bordered stderr warning with the `git merge --ff-only origin/<branch>` remediation. Stretch goal implemented: best-effort notes installed scripts/hooks whose content differs from their `defaults/` counterpart (files present in both trees only). Supports `--quiet`/`-q` and `--help`/`-h`. Never pulls/merges/resets.
- **`defaults/.claude/commands/loom/sweep.md`** — new `## Main Branch Freshness (#3770)` section inserted between `## Host Sleep Readiness (#3350)` and `## Daemon Coexistence`, documenting the advisory-only, never-blocks, never-auto-pulls contract and the run-once-before-wave-1 timing.
- **`defaults/scripts/tests/test-check-main-freshness.sh`** (new) — synthetic bare-`origin` fixtures exercising up-to-date, behind, and fetch-failure (never-blocks) cases, plus flag/contract checks. 15/15 pass.

## Testing

- `bash defaults/scripts/tests/test-check-main-freshness.sh` → 15/15 pass
- `shellcheck` clean on both scripts
- Live invocation in-worktree confirms the up-to-date one-liner and exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)