### PR TITLE
feat(worktree): add operator-facing `remove <N>` verb (#3769)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,7 +210,7 @@ gh pr create --label "loom:review-requested"
 ### Best Practices
 
 - Always use `./.loom/scripts/worktree.sh <issue-number>` (it writes a `.loom-managed` sentinel that authorizes cleanup)
-- Never run `git worktree` directly (helper prevents nested worktrees)
+- Never run `git worktree` directly (helper prevents nested worktrees) — to remove one managed worktree on demand, use `./.loom/scripts/worktree.sh remove <issue-number>` (sentinel-honoring, idempotent, deletes the local branch; `loom-clean` remains the bulk path)
 - Loom-managed worktrees (under `.loom/worktrees/` with the `.loom-managed` sentinel) are auto-removed when their PR merges. User-provisioned worktrees at other paths are never removed by Loom — set `LOOM_PRESERVE_WORKTREE=1` to disable cleanup globally for a session.
 
 ### Merging PRs

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -458,12 +458,29 @@ If you need to clean up worktrees:
 # Convert a sparse worktree back to a full checkout
 ./.loom/scripts/worktree.sh 42 --full
 
+# Remove ONE managed worktree on demand (sanctioned single-worktree removal —
+# never call `git worktree remove` directly). Removes .loom/worktrees/issue-42
+# and deletes its local branch (safe `git branch -d`, refuses on unmerged
+# commits). Honors the .loom-managed sentinel (refuses user-provisioned
+# worktrees), is idempotent (clear no-op if absent), and prunes the git
+# worktree registration.
+./.loom/scripts/worktree.sh remove 42
+
+# Same, but keep the local feature branch
+./.loom/scripts/worktree.sh remove 42 --keep-branch
+
 # Check if you're in a worktree
 ./.loom/scripts/worktree.sh --check
 
 # Show help
 ./.loom/scripts/worktree.sh --help
 ```
+
+**Single vs. bulk removal**: `worktree.sh remove <N>` targets exactly one
+issue's managed worktree (e.g. a dead builder's stale checkout). `loom-clean`
+remains the bulk/stale-cleanup path across all closed issues (unchanged). Both
+are safe — you never need `git worktree remove` directly (which corrupts shell
+state when run from inside the worktree, per the warning above).
 
 **Sparse-Mode Notes**:
 - `--sparse` and `--full` are mutually exclusive

--- a/defaults/scripts/tests/test-worktree-remove.sh
+++ b/defaults/scripts/tests/test-worktree-remove.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# test-worktree-remove.sh - Tests for the `worktree.sh remove <N>` verb (#3769)
+#
+# Verifies the operator-facing single-worktree removal verb:
+#   1. Removing a .loom-managed worktree succeeds (dir gone, unregistered,
+#      local branch deleted).
+#   2. Removing a worktree lacking the .loom-managed sentinel is refused
+#      (dir untouched, non-zero exit, clear stderr message).
+#   3. Removing a non-existent issue worktree is an idempotent no-op success.
+#   4. --keep-branch leaves the local branch intact after removal.
+#   5. Running `remove` from a shell whose cwd is inside the target worktree
+#      completes successfully (script cd's out first — no shell corruption).
+#
+# Follows the throwaway-repo harness pattern in test-worktree-sentinel.sh:
+# a bare origin remote + a working repo, with worktree.sh + its lib/ helpers
+# copied into a temp tree, then the script driven directly.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPTS_DIR/../.." && pwd)"
+
+WORKTREE_SH="$SCRIPTS_DIR/worktree.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1)); echo -e "  ${RED}FAIL${NC}: $1"; }
+
+# --- Throwaway repo setup ---------------------------------------------------
+TMP=$(mktemp -d /tmp/loom-remove-test.XXXXXX)
+trap 'rm -rf "$TMP"; cd "$REPO_ROOT" 2>/dev/null || true' EXIT
+
+git init -q -b main "$TMP/origin.git" --bare
+git init -q -b main "$TMP/repo"
+cd "$TMP/repo"
+git config user.email t@t
+git config user.name t
+git commit --allow-empty -q -m init
+git remote add origin "$TMP/origin.git"
+git push -q origin main
+
+mkdir -p .loom/scripts/lib
+cp "$WORKTREE_SH" .loom/scripts/worktree.sh
+if [[ -d "$SCRIPTS_DIR/lib" ]]; then
+    cp -R "$SCRIPTS_DIR"/lib/* .loom/scripts/lib/ 2>/dev/null || true
+fi
+chmod +x .loom/scripts/worktree.sh
+
+REPO="$TMP/repo"
+
+# Helper: create a fresh managed worktree for an issue number.
+make_worktree() {
+    local n="$1"
+    cd "$REPO"
+    ./.loom/scripts/worktree.sh "$n" >/dev/null 2>&1
+}
+
+# --- Test 1: remove a managed worktree succeeds -----------------------------
+echo "Test 1: remove a .loom-managed worktree (dir gone, unregistered, branch deleted)"
+make_worktree 101
+cd "$REPO"
+if ./.loom/scripts/worktree.sh remove 101 >/tmp/rm-out.$$ 2>&1; then
+    if [[ ! -d ".loom/worktrees/issue-101" ]]; then
+        pass "worktree directory removed"
+    else
+        fail "worktree directory still present after remove"
+    fi
+    if ! git worktree list --porcelain | grep -q "issue-101"; then
+        pass "worktree no longer registered with git"
+    else
+        fail "worktree still registered with git"
+    fi
+    if ! git show-ref --verify --quiet "refs/heads/feature/issue-101"; then
+        pass "local branch feature/issue-101 deleted"
+    else
+        fail "local branch feature/issue-101 still exists"
+    fi
+else
+    fail "remove exited non-zero for a managed worktree (see /tmp/rm-out.$$)"
+fi
+
+# --- Test 2: remove a worktree lacking the sentinel is refused --------------
+echo ""
+echo "Test 2: remove refuses a worktree lacking the .loom-managed sentinel"
+make_worktree 102
+cd "$REPO"
+rm -f ".loom/worktrees/issue-102/.loom-managed"
+if ./.loom/scripts/worktree.sh remove 102 >/tmp/rm-out2.$$ 2>&1; then
+    fail "remove succeeded on an unmanaged worktree (should have refused)"
+else
+    pass "remove exited non-zero for an unmanaged worktree"
+fi
+if [[ -d ".loom/worktrees/issue-102" ]]; then
+    pass "unmanaged worktree directory left untouched"
+else
+    fail "unmanaged worktree directory was removed despite missing sentinel"
+fi
+if grep -q "refusing to remove" /tmp/rm-out2.$$ 2>/dev/null; then
+    pass "refusal message mentions 'refusing to remove'"
+else
+    fail "no clear refusal message emitted"
+fi
+
+# --- Test 3: remove a non-existent worktree is an idempotent no-op ----------
+echo ""
+echo "Test 3: remove a non-existent issue worktree is an idempotent no-op success"
+cd "$REPO"
+if ./.loom/scripts/worktree.sh remove 999999 >/tmp/rm-out3.$$ 2>&1; then
+    pass "remove exited 0 for a non-existent worktree"
+else
+    fail "remove exited non-zero for a non-existent worktree (should be no-op success)"
+fi
+if grep -qi "nothing to remove" /tmp/rm-out3.$$ 2>/dev/null; then
+    pass "no-op message emitted ('nothing to remove')"
+else
+    fail "no clear no-op message emitted"
+fi
+
+# --- Test 4: --keep-branch leaves the branch intact -------------------------
+echo ""
+echo "Test 4: --keep-branch removes the worktree but keeps the local branch"
+make_worktree 103
+cd "$REPO"
+if ./.loom/scripts/worktree.sh remove 103 --keep-branch >/tmp/rm-out4.$$ 2>&1; then
+    if [[ ! -d ".loom/worktrees/issue-103" ]]; then
+        pass "worktree directory removed with --keep-branch"
+    else
+        fail "worktree directory still present after remove --keep-branch"
+    fi
+    if git show-ref --verify --quiet "refs/heads/feature/issue-103"; then
+        pass "local branch feature/issue-103 preserved by --keep-branch"
+    else
+        fail "local branch feature/issue-103 was deleted despite --keep-branch"
+    fi
+else
+    fail "remove --keep-branch exited non-zero (see /tmp/rm-out4.$$)"
+fi
+
+# --- Test 5: remove from inside the worktree does not corrupt the shell ------
+echo ""
+echo "Test 5: remove works when cwd is inside the target worktree"
+make_worktree 104
+# Drive the script from inside the worktree in a subshell so this harness's own
+# cwd is not affected.
+if ( cd "$REPO/.loom/worktrees/issue-104" && \
+     "$REPO/.loom/scripts/worktree.sh" remove 104 ) >/tmp/rm-out5.$$ 2>&1; then
+    cd "$REPO"
+    if [[ ! -d ".loom/worktrees/issue-104" ]]; then
+        pass "worktree removed even though cwd was inside it"
+    else
+        fail "worktree still present after in-worktree remove"
+    fi
+    if grep -qi "working directory was inside" /tmp/rm-out5.$$ 2>/dev/null; then
+        pass "emits the CWD-hop advisory when removing from inside"
+    else
+        fail "no CWD-hop advisory emitted for in-worktree removal"
+    fi
+else
+    cd "$REPO"
+    fail "in-worktree remove exited non-zero (see /tmp/rm-out5.$$)"
+fi
+
+# --- Summary ----------------------------------------------------------------
+echo ""
+echo "Tests run: $TESTS_RUN, Passed: $TESTS_PASSED, Failed: $TESTS_FAILED"
+[[ $TESTS_FAILED -eq 0 ]] || exit 1

--- a/defaults/scripts/worktree.sh
+++ b/defaults/scripts/worktree.sh
@@ -8,6 +8,7 @@
 #   pnpm worktree <issue-number> <branch>              # Create worktree with custom branch name
 #   pnpm worktree <issue-number> --sparse <paths...>   # Cone-mode sparse checkout
 #   pnpm worktree <issue-number> --full                # Convert sparse worktree to full
+#   pnpm worktree remove <issue-number> [--keep-branch]# Remove one managed worktree
 #   pnpm worktree --check                              # Check if currently in a worktree
 #   pnpm worktree --json <issue-number>                # Machine-readable output
 #   pnpm worktree --return-to <dir> <issue-number>     # Store return directory
@@ -299,6 +300,198 @@ cleanup_partial_worktree_state() {
 }
 
 # --------------------------------------------------------------------------
+# Operator-facing single-worktree removal (issue #3769)
+# --------------------------------------------------------------------------
+#
+# `worktree.sh remove <N>` (alias `--remove <N>`) is the sanctioned path for an
+# operator to remove exactly one managed worktree on demand — e.g. a dead
+# builder's stale checkout that pushed nothing and needs to be re-created off an
+# updated base. Before this verb existed, the only single-worktree removal was
+# `git worktree remove` directly, which CLAUDE.md forbids because running it
+# while the shell is inside/near the worktree corrupts shell state.
+#
+# The guard order deliberately mirrors merge-pr.sh's private
+# `_remove_loom_worktree()` (defaults/scripts/merge-pr.sh:1129-1199), scoped to
+# the `issue-<N>` path convention only (no --worktree-path override, no
+# discovery fallback — those belong to merge-pr.sh's distinct call-sites):
+#   1. Idempotent no-op if the worktree dir is absent (still prune).
+#   2. Refuse to remove a dir lacking the .loom-managed sentinel (user-owned).
+#   3. Discover the attached branch BEFORE removal (the porcelain entry vanishes
+#      once the worktree is gone).
+#   4. Hop out of the worktree first if our cwd is inside it (CWD-safety).
+#   5. `git worktree remove --force`; warn (don't hard-fail) on failure.
+#   6. `git branch -d` the attached branch (safe delete, refuses on unmerged
+#      commits) unless --keep-branch.
+#   7. `git worktree prune`.
+#
+# `loom-clean` remains the bulk/stale-cleanup path across all closed issues;
+# this verb targets one specific issue's worktree.
+
+# Print the short branch name attached to a worktree path, parsed from
+# `git worktree list --porcelain`. Robust to custom branch names (worktree.sh
+# <N> <custom-branch> allows a non-`feature/issue-<N>` branch). Mirrors
+# merge-pr.sh's _worktree_branch_for(). Prints nothing for a detached/bare
+# worktree or on error.
+_worktree_attached_branch() {
+    local repo_root="$1" target="$2" target_abs
+    target_abs="$(cd "$target" 2>/dev/null && pwd -P)" || target_abs="$target"
+    # The `worktree ` path line (prefix = 9 chars) may contain spaces, so parse
+    # it with substr($0, 10) rather than $2. The `branch ` line is safe with $2
+    # (git ref names cannot contain spaces).
+    git -C "$repo_root" worktree list --porcelain 2>/dev/null | \
+        awk -v p="$target_abs" '
+            /^worktree / { wt=substr($0, 10); br=""; next }
+            /^branch /   { br=$2 }
+            /^$/         { if (wt == p && br != "" && !found) { sub(/^refs\/heads\//, "", br); print br; found=1; exit } }
+            END          { if (wt == p && br != "" && !found) { sub(/^refs\/heads\//, "", br); print br } }
+        '
+}
+
+# remove_worktree_command [--keep-branch] [--json] <issue-number>
+#
+# Invoked from the early arg dispatch below. Returns 0 on success (including the
+# idempotent no-op) and 1 on refusal / usage error / removal failure.
+remove_worktree_command() {
+    local issue_number="" keep_branch=false json=false
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --keep-branch) keep_branch=true; shift ;;
+            --json)        json=true; shift ;;
+            --*)
+                print_error "Unknown flag for remove: $1"
+                echo ""
+                echo "Usage: pnpm worktree remove <issue-number> [--keep-branch] [--json]"
+                return 1
+                ;;
+            *)
+                if [[ -z "$issue_number" ]]; then
+                    issue_number="$1"; shift
+                else
+                    print_error "Unexpected argument: $1"
+                    return 1
+                fi
+                ;;
+        esac
+    done
+
+    if [[ -z "$issue_number" ]]; then
+        print_error "remove requires an issue number"
+        echo ""
+        echo "Usage: pnpm worktree remove <issue-number> [--keep-branch] [--json]"
+        return 1
+    fi
+    if ! [[ "$issue_number" =~ ^[0-9]+$ ]]; then
+        print_error "Issue number must be numeric (got: '$issue_number')"
+        echo ""
+        echo "Usage: pnpm worktree remove <issue-number> [--keep-branch] [--json]"
+        return 1
+    fi
+
+    # In --json mode, human-readable status goes to stderr so stdout carries
+    # only the final JSON document (stdout-purity, mirrors the main script's
+    # fd-3 plumbing). print_error already writes to stderr, safe in both modes.
+    _rm_info()    { if [[ "$json" == true ]]; then echo -e "${BLUE}ℹ $*${NC}" >&2; else print_info "$*"; fi; }
+    _rm_success() { if [[ "$json" == true ]]; then echo -e "${GREEN}✓ $*${NC}" >&2; else print_success "$*"; fi; }
+    _rm_warning() { if [[ "$json" == true ]]; then echo -e "${YELLOW}⚠ $*${NC}" >&2; else print_warning "$*"; fi; }
+    _rm_json() {
+        # $1=success(bool) $2=removed(bool) $3=branchStatus
+        [[ "$json" == true ]] || return 0
+        printf '{"success": %s, "issueNumber": %s, "worktreePath": "%s", "removed": %s, "branch": "%s", "branchStatus": "%s"}\n' \
+            "$1" "$issue_number" "$worktree_path" "$2" "${attached_branch:-}" "$3"
+    }
+
+    # Resolve the repo root even when invoked from inside a worktree: the git
+    # common dir's parent is always the main workspace.
+    local git_common repo_root
+    if ! git_common=$(git rev-parse --git-common-dir 2>/dev/null); then
+        print_error "Not inside a git repository"
+        return 1
+    fi
+    repo_root=$(cd "$(dirname "$git_common")" 2>/dev/null && pwd) || repo_root="$(pwd)"
+
+    local worktree_root_dir worktree_path
+    worktree_root_dir="$(loom_worktree_root "$repo_root")"
+    worktree_path="$worktree_root_dir/issue-$issue_number"
+    local attached_branch=""
+
+    # 1. Idempotent no-op if the worktree dir is absent (still prune any stale
+    #    registration, matching the "prunes git worktree registration" AC).
+    if [[ ! -d "$worktree_path" ]]; then
+        git -C "$repo_root" worktree prune 2>/dev/null || true
+        _rm_info "No worktree found at $worktree_path — nothing to remove"
+        _rm_json true false "absent"
+        return 0
+    fi
+
+    # 2. Sentinel guard: refuse to remove a user-owned / non-managed worktree.
+    if [[ ! -f "$worktree_path/.loom-managed" ]]; then
+        print_error "Worktree at $worktree_path lacks .loom-managed sentinel — refusing to remove (user-owned)"
+        _rm_json false false "untouched"
+        return 1
+    fi
+
+    # 3. Discover the attached branch BEFORE removal (porcelain entry vanishes
+    #    once the worktree is gone).
+    attached_branch="$(_worktree_attached_branch "$repo_root" "$worktree_path")" || attached_branch=""
+
+    # 4. CWD-safety: if our shell is inside the worktree, hop out first.
+    local worktree_real current_dir in_worktree=false
+    worktree_real="$(cd "$worktree_path" 2>/dev/null && pwd -P)" || worktree_real="$worktree_path"
+    current_dir="$(pwd -P 2>/dev/null || pwd)"
+    if [[ "$current_dir" == "$worktree_real"* ]]; then
+        in_worktree=true
+        cd "$repo_root" 2>/dev/null || true
+    fi
+
+    # 5. Remove the worktree.
+    _rm_info "Removing worktree: $worktree_path"
+    local removed=false
+    if git -C "$repo_root" worktree remove "$worktree_path" --force >/dev/null 2>&1; then
+        removed=true
+        _rm_success "Worktree removed"
+        if [[ "$in_worktree" == true ]]; then
+            _rm_warning "Your shell's working directory was inside the removed worktree."
+            _rm_warning "Run this command to fix:  cd $repo_root"
+        fi
+    else
+        _rm_warning "Could not remove worktree at $worktree_path"
+    fi
+
+    # 6. Branch cleanup (unless --keep-branch). Deferred until after removal so
+    #    the worktree's checkout lock on the branch is released first.
+    local branch_status="none"
+    if [[ "$keep_branch" == true ]]; then
+        if [[ -n "$attached_branch" ]]; then
+            _rm_info "Keeping local branch '$attached_branch' (--keep-branch)"
+            branch_status="kept"
+        fi
+    elif [[ "$removed" == true && -n "$attached_branch" ]]; then
+        if ! git -C "$repo_root" show-ref --verify --quiet "refs/heads/$attached_branch"; then
+            _rm_info "Local branch '$attached_branch' does not exist — skipping branch delete"
+            branch_status="absent"
+        elif git -C "$repo_root" branch -d "$attached_branch" >/dev/null 2>&1; then
+            _rm_success "Local branch '$attached_branch' deleted"
+            branch_status="deleted"
+        else
+            _rm_warning "Could not delete local branch '$attached_branch' (may have unmerged commits — use 'git branch -D' if intentional)"
+            branch_status="unmerged"
+        fi
+    fi
+
+    # 7. Prune the git worktree registration.
+    git -C "$repo_root" worktree prune 2>/dev/null || true
+
+    if [[ "$removed" == true ]]; then
+        _rm_json true true "$branch_status"
+        return 0
+    else
+        _rm_json false false "$branch_status"
+        return 1
+    fi
+}
+
+# --------------------------------------------------------------------------
 # Sparse-checkout helpers
 # --------------------------------------------------------------------------
 #
@@ -439,6 +632,7 @@ Usage:
   pnpm worktree <issue-number> --base <branch>          Branch off <branch> (stacked PR, #3729)
   pnpm worktree <issue-number> --sparse <paths...>      Cone-mode sparse checkout
   pnpm worktree <issue-number> --full                   Convert sparse worktree to full
+  pnpm worktree remove <issue-number> [--keep-branch]   Remove one managed worktree
   pnpm worktree --check                                 Check if in a worktree
   pnpm worktree --json <issue-number>                   Machine-readable JSON output
   pnpm worktree --return-to <dir> <issue-number>        Store return directory
@@ -466,6 +660,18 @@ Examples:
   pnpm worktree 42 --full
     Converts an existing sparse worktree back to a full checkout
     (no-op on an already-full worktree).
+
+  pnpm worktree remove 42
+    Removes the managed worktree .loom/worktrees/issue-42 and deletes its local
+    branch (safe delete — refuses on unmerged commits). This is the sanctioned
+    single-worktree removal path so you never need 'git worktree remove'
+    directly. It honors the .loom-managed sentinel (refuses to remove a
+    user-provisioned worktree), is idempotent (clear no-op if absent), and
+    prunes the git worktree registration. Use 'loom-clean' for bulk/stale
+    cleanup across all closed issues.
+
+  pnpm worktree remove 42 --keep-branch
+    Same as above but leaves the local feature branch intact.
 
   pnpm worktree --check
     Shows current worktree status
@@ -566,6 +772,17 @@ fi
 if [[ "$1" == "--check" ]]; then
     get_worktree_info
     exit $?
+fi
+
+# Operator-facing single-worktree removal verb (issue #3769). Dispatched HERE,
+# before the generic numeric-issue-number validation below, so `remove <N>` /
+# `--remove <N>` is not rejected as "Issue number must be numeric". The handler
+# parses its own args (issue number + optional --keep-branch / --json).
+if [[ "$1" == "remove" || "$1" == "--remove" ]]; then
+    shift
+    # Left of && so set -e does not abort on a non-zero return from the handler.
+    remove_worktree_command "$@" && exit 0
+    exit 1
 fi
 
 # Check for --json flag


### PR DESCRIPTION
Closes #3769

## Summary

`worktree.sh` only ever *created* / reconfigured worktrees. Removal of a single managed worktree was internal-only — `merge-pr.sh` on merge, `cleanup_partial_worktree_state()` on crash recovery, `loom-clean` for bulk staleness — so an operator who needed to remove one specific managed worktree (e.g. a rate-limit-killed builder's stale checkout) fell back to `git worktree remove` directly, which CLAUDE.md explicitly forbids.

This adds a sanctioned single-worktree removal verb.

## What changed

- **`defaults/scripts/worktree.sh`**
  - New `remove <N>` verb (alias `--remove <N>`), dispatched **before** the generic numeric-issue-number validation so `remove`/`--remove` isn't rejected as "Issue number must be numeric" (the exact failure from the report).
  - Guard order mirrors `merge-pr.sh`'s private `_remove_loom_worktree()` (scoped to the `issue-<N>` path convention only — no `--worktree-path` override, no discovery fallback):
    1. Idempotent no-op + clear message if the worktree is absent (still runs `git worktree prune`).
    2. Refuses a worktree lacking the `.loom-managed` sentinel (user-owned).
    3. Discovers the attached branch (robust to custom branch names) **before** removal.
    4. `cd`s out of the worktree first if the shell's cwd is inside it (the CWD corruption CLAUDE.md warns about).
    5. `git worktree remove --force`; warns (doesn't hard-fail) on failure.
    6. `git branch -d` (safe delete, refuses on unmerged commits) unless `--keep-branch`.
    7. `git worktree prune`.
  - Optional `--json` emits a single stdout-pure JSON summary (`git` stdout suppressed so it can't pollute the document).
  - `show_help()` + top-of-file usage updated.
- **`defaults/CLAUDE.md`** — documents the verb under "Git Worktree Workflow" → "Worktree Helper Commands", with a single-vs-bulk note (`loom-clean` unchanged).
- **`CLAUDE.md`** (root) — one-line mention alongside "Never run `git worktree` directly".
- **`defaults/scripts/tests/test-worktree-remove.sh`** (new) — throwaway-repo harness modeled on `test-worktree-sentinel.sh`.

## Testing

- New test suite: **12/12 pass** — managed-worktree removal (dir gone, unregistered, branch deleted), sentinel refusal (untouched + non-zero + message), idempotent no-op, `--keep-branch`, and in-worktree CWD-safety.
- Existing `test-worktree-sentinel.sh`: 10/10 still pass.
- `shellcheck defaults/scripts/worktree.sh` — no new warnings (the sole SC2126 is pre-existing on `main`, line 1237, unrelated).
- Manual: `--remove` alias and `--json` stdout purity verified.

## Out of scope (per issue)

Extracting `_remove_loom_worktree()` into a shared lib; a `--worktree-path`/unmanaged-removal escape hatch on this verb; any `loom-clean` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)