### PR TITLE
feat(merge-pr): pre-merge merge-ordering guard for stacked children (#3747 v2 item 2)

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -323,10 +323,21 @@ parent branch, the `--base` query returns zero rows on any re-run.
 
 `reconcile-stack.sh` remains available for **manual** invocation — for the
 unsafe/deferred case once the Builder finishes, or for an operator who wants to
-reconcile ahead of a merge (`--dry-run` previews the git surgery). The
-**merge-ordering guard** (never merge a parent whose children haven't
-retargeted) and **rebase-on-parent-amend** remain **out of scope** (deferred
-items of the v2 epic #3747).
+reconcile ahead of a merge (`--dry-run` previews the git surgery).
+
+A **pre-merge merge-ordering guard** shipped as v2 item 2 (#3747): because
+`delete_branch_on_merge:true` deletes `feature/issue-<parent>` synchronously
+during the merge API call — before the post-merge reconcile pass above can run —
+`merge-pr.sh` now runs a guard *before* both merge paths that discovers open
+child PRs (same `gh pr list --base feature/issue-<parent> --state open` query)
+and by default **hard-blocks the merge** (`exit 1`, naming the child PR(s) + the
+`reconcile-stack.sh` unblock command) rather than let the parent merge race the
+branch deletion. It keys purely on "does an open child PR still target this
+branch" (not the child's `loom:building` label). `--allow-stacked-children`
+bypasses it; `--dry-run` reports the would-be block without exiting 1.
+**Rebase-on-parent-amend**, **dependency auto-detection**, **diamonds /
+multi-parent**, and **auto-detach** remain **out of scope** (deferred items of
+the v2 epic #3747).
 
 ## Locks and lifecycle
 

--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -1261,7 +1261,7 @@ If the builder failed (no PR opened), do NOT write a checkpoint — leave the ch
 
 **Mid-builder kill semantics (#3373).** If sweep is killed during the Builder phase, the next invocation will see `CHECKPOINT_PHASE == "curator-done"` (no `builder-done` was written), so the Builder dispatches again from scratch. The worktree from the killed run is preserved by `worktree.sh`'s idempotency — `./.loom/scripts/worktree.sh N` is a no-op if `.loom/worktrees/issue-N` already exists. The builder re-enters the worktree, sees the partial diff, and decides whether to commit / amend / discard. **Sweep itself does not introspect the partial diff** — that's the builder's job.
 
-### Stacked dependency (auto-reconciliation on parent merge) — #3729 (v1), #3747 (v2 item 1)
+### Stacked dependency (auto-reconciliation on parent merge) — #3729 (v1), #3747 (v2 items 1 & 2)
 
 Stacked-PR mode pipelines a genuine dependency: when issue B consumes issue A's output (schema, file, manifest), B is built on `feature/issue-A` so B's lifecycle runs concurrently with A's review instead of serializing behind A's merge. **The dispatch surface is opt-in, daemon-`dispatch_sweep`-only, and linear-chains-only.**
 
@@ -1287,6 +1287,8 @@ The daemon forwards `depends_on` to the child as `--depends-on <parent>`; the ch
 
 The step is **best-effort** — a reconciliation failure never fails the parent merge — and idempotent (once a child's base is retargeted away from the parent branch, the query returns zero rows).
 
+**Pre-merge merge-ordering guard now ships too (v2 item 2, #3747).** Item 1's reconciliation runs *after* the parent has already merged, and the repo setting Loom itself recommends (`delete_branch_on_merge:true`, applied by `setup-repository-settings.sh`) makes GitHub delete `feature/issue-<parent>` **synchronously during the merge API call** — before the post-merge reconcile pass runs, and once the ref is gone `reconcile-stack.sh`'s `git rebase --onto <default> <parent-branch>` can no longer resolve `<parent-branch>`. So item 1 could race and *lose* against the repo's own settings. To close that race, `merge-pr.sh` now runs a **pre-merge guard** (before both the auto-merge and synchronous-merge paths) that discovers open child PRs with the same live-forge query (`gh pr list --base feature/issue-<parent> --state open`) and, by default, **hard-blocks the merge** (`exit 1`, naming the blocking child PR number(s) and the `reconcile-stack.sh` unblock command) rather than letting the parent merge create the race. This is a normal, recoverable failure — Champion's cron retries it next tick, exactly like any other merge-blocking condition. Unlike item 1's post-merge pass, the guard keys **purely on "does an open child PR still target this branch"** — never on the child's `loom:building` label, since a "safe" child is just as exposed to branch deletion as an "unsafe" one. Pass **`--allow-stacked-children`** to `merge-pr.sh` to bypass the guard once you have manually reconciled/verified the children (operator asserts responsibility, mirroring `--worktree-path`); `--dry-run` still runs the guard and reports the would-be block without exiting 1.
+
 `reconcile-stack.sh` remains available for **manual** invocation — for the unsafe/deferred case once the Builder finishes, or to reconcile ahead of a merge (`--dry-run` previews the surgery):
 
 ```bash
@@ -1296,7 +1298,7 @@ The step is **best-effort** — a reconciliation failure never fails the parent 
 #   gh pr edit <child-pr> --base <default-branch>
 ```
 
-**Deferred (v2 epic #3747, not yet implemented):** a **merge-ordering guard** (block merging a parent whose children haven't retargeted) and **rebase-on-parent-amend** (if the parent branch is amended by Doctor after a child branched off it, the child is not auto-rebased — rebase it manually if needed).
+**Deferred (v2 epic #3747, not yet implemented):** **rebase-on-parent-amend** (if the parent branch is amended by Doctor after a child branched off it, the child is not auto-rebased — rebase it manually if needed), **dependency auto-detection**, **diamonds / multi-parent**, and **auto-detach**. (The **merge-ordering guard** shipped as v2 item 2 — see above.)
 
 ### 5. Judge phase (sequential per PR within the wave)
 

--- a/defaults/scripts/merge-pr.sh
+++ b/defaults/scripts/merge-pr.sh
@@ -18,6 +18,11 @@
 #                          commits — Git's own safety check).
 #   --dry-run              Show what would happen without merging
 #   --auto                 Enable auto-merge instead of immediate merge
+#   --allow-stacked-children
+#                          Bypass the pre-merge merge-ordering guard when the
+#                          parent branch (feature/issue-N) still has open
+#                          stacked child PRs targeting it (operator asserts the
+#                          children are already reconciled). See #3747 item 2.
 #
 # By default, the local worktree is cleaned up after a successful merge.
 # Pass --no-cleanup-worktree to skip this (e.g., when other terminals may
@@ -77,6 +82,17 @@ Options:
                          (Git refuses on unmerged commits).
   --dry-run              Show what would happen without merging
   --auto                 Enable auto-merge instead of immediate merge
+  --allow-stacked-children
+                         Bypass the pre-merge merge-ordering guard. That guard
+                         hard-blocks merging a stacked PARENT PR (branch
+                         feature/issue-N) while it still has open stacked CHILD
+                         PRs targeting its branch, because the repo's
+                         delete_branch_on_merge setting would delete the parent
+                         branch synchronously during the merge and leave the
+                         children unable to rebase onto it (see #3747 item 2).
+                         Pass this flag only after you have manually reconciled
+                         (or verified) the children — the operator asserts
+                         responsibility, mirroring --worktree-path.
   -h, --help             Show this help and exit
 
 By default, the local worktree is cleaned up after a successful merge.
@@ -194,6 +210,7 @@ CLEANUP_WORKTREE=true
 DRY_RUN=false
 AUTO_MERGE=false
 WORKTREE_PATH_OVERRIDE=""
+ALLOW_STACKED_CHILDREN=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -211,6 +228,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     --dry-run) DRY_RUN=true; shift ;;
     --auto) AUTO_MERGE=true; shift ;;
+    --allow-stacked-children) ALLOW_STACKED_CHILDREN=true; shift ;;
     -*)  error "Unknown option: $1" ;;
     *)
       if [[ -z "$PR_NUMBER" ]]; then
@@ -223,7 +241,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-[[ -z "$PR_NUMBER" ]] && error "Usage: merge-pr.sh <pr-number> [--no-cleanup-worktree] [--worktree-path <dir>] [--dry-run] [--auto]"
+[[ -z "$PR_NUMBER" ]] && error "Usage: merge-pr.sh <pr-number> [--no-cleanup-worktree] [--worktree-path <dir>] [--dry-run] [--auto] [--allow-stacked-children]"
 [[ "$PR_NUMBER" =~ ^[0-9]+$ ]] || error "PR number must be numeric: $PR_NUMBER"
 
 # Validate --worktree-path early (before any network calls) so bad input
@@ -276,6 +294,89 @@ fi
 if [[ "$PR_STATE" == "closed" ]]; then
   error "PR #$PR_NUMBER is closed (not merged)"
 fi
+
+# ---------------------------------------------------------------------------
+# Pre-merge merge-ordering guard (#3747, stacked-PR v2 item 2).
+#
+# Runs BEFORE both the auto-merge and synchronous-merge paths (that is why it is
+# defined and invoked here, above the "Merging PR" line — not next to item 1's
+# POST-merge _auto_reconcile_stacked_children at the bottom of the merge flow).
+#
+# The race it closes: when a stacked PARENT PR (branch feature/issue-<N>)
+# squash-merges, item 1's post-merge _auto_reconcile_stacked_children rebases any
+# open CHILD PRs off the now-squashed parent branch onto the default branch. That
+# rebase (reconcile-stack.sh's `git rebase --onto <default> <parent-branch>
+# <child-branch>`) needs <parent-branch> to still resolve as a ref. But Loom's own
+# recommended repo setting — delete_branch_on_merge:true, applied by
+# setup-repository-settings.sh — makes GitHub delete feature/issue-<parent>
+# SYNCHRONOUSLY as part of the merge API call itself, before merge-pr.sh even
+# reaches the "merged successfully" log line, let alone the post-merge reconcile
+# step. Once the ref is gone a fresh fetch won't see it and the rebase's <upstream>
+# fails to resolve. Item 1's post-merge pass can therefore race and LOSE against
+# the repo's own settings. This guard refuses to let the parent merge happen at
+# all while that race exists.
+#
+# This is orthogonal to item 1's loom:building safe/unsafe split: a "safe" child
+# is just as exposed to branch deletion as an "unsafe" one, so the guard keys
+# PURELY on "does an open child PR still target this branch", never on the child's
+# label. Discovery reuses item 1's live-forge-query shape (`gh pr list --base
+# <parent> --state open`), NOT the ephemeral daemon registry.
+#
+# Default is a hard block (error, exit 1) — a normal, recoverable failure that
+# Champion's cron retries next tick, exactly like every other merge-blocking
+# condition in this file. --allow-stacked-children bypasses it (operator asserts
+# the children are reconciled). --dry-run still runs the guard and REPORTS the
+# would-be block, but honors the dry-run contract (never exits 1).
+_check_no_open_stacked_children() {
+  # Only GitHub, and only a parent PR on a feature/issue-<N> branch, can have
+  # stacked children — identical guard conditions to
+  # _auto_reconcile_stacked_children. No-op (byte-for-byte unchanged behavior)
+  # otherwise.
+  [[ "$FORGE_TYPE" == "github" ]] || return 0
+  [[ "$PR_BRANCH" =~ ^feature/issue-([0-9]+)$ ]] || return 0
+
+  # Live forge discovery — NEVER the daemon registry. Same call/shape item 1
+  # already makes; plain `gh` (uncached) so we see child PRs as of right now.
+  local children_json count child_list
+  children_json="$(gh pr list --repo "$REPO_NWO" --base "$PR_BRANCH" --state open \
+    --json number,headRefName 2>/dev/null || echo '[]')"
+  [[ -n "$children_json" ]] || return 0
+  count="$(echo "$children_json" | jq 'length' 2>/dev/null || echo 0)"
+  [[ "$count" -gt 0 ]] || return 0
+
+  # Comma-separated "#N" list for the operator-facing message.
+  child_list="$(echo "$children_json" \
+    | jq -r '[.[].number | "#" + tostring] | join(", ")' 2>/dev/null || echo '')"
+
+  # Operator opt-in bypass (mirrors the --worktree-path sentinel-bypass precedent):
+  # the operator asserts responsibility for having reconciled/verified the children.
+  if [[ "$ALLOW_STACKED_CHILDREN" == "true" ]]; then
+    warning "Merge-ordering guard: --allow-stacked-children set; proceeding despite $count open stacked child PR(s) ($child_list) targeting '$PR_BRANCH' (operator asserts they are reconciled)"
+    return 0
+  fi
+
+  local msg
+  msg="Merge blocked: PR #$PR_NUMBER's branch '$PR_BRANCH' still has $count open stacked child PR(s) ($child_list) targeting it.
+
+Merging now would race the repo's delete_branch_on_merge setting: GitHub deletes '$PR_BRANCH' synchronously during the merge, before the child PR(s) can be rebased/retargeted onto the default branch — leaving reconcile-stack.sh's rebase unable to resolve the parent branch ref (#3747 item 2).
+
+Reconcile each child first (from a clean checkout), then re-run this merge:
+  ./.loom/scripts/reconcile-stack.sh <child-pr> $PR_BRANCH
+
+Or, if you have already verified/reconciled them, re-run with --allow-stacked-children to bypass this guard."
+
+  # --dry-run still runs the guard and reports the would-be outcome, but honors
+  # the dry-run contract (dry-run always exits 0). A real run hard-blocks.
+  if [[ "$DRY_RUN" == "true" ]]; then
+    warning "[dry-run] Would BLOCK merge of PR #$PR_NUMBER: $count open stacked child PR(s) ($child_list) still target '$PR_BRANCH'. Re-run with --allow-stacked-children to override, or reconcile the children first."
+    return 0
+  fi
+
+  error "$msg"
+}
+
+# Invoke the guard before either merge path attempts the actual merge API call.
+_check_no_open_stacked_children
 
 info "Merging PR #$PR_NUMBER: $PR_TITLE"
 info "Branch: $PR_BRANCH"

--- a/defaults/scripts/tests/test-merge-pr-merge-ordering-guard.sh
+++ b/defaults/scripts/tests/test-merge-pr-merge-ordering-guard.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+# test-merge-pr-merge-ordering-guard.sh - Unit tests for the PRE-merge
+# merge-ordering guard in merge-pr.sh (#3747, stacked-PR v2 item 2).
+#
+# Before either the auto-merge or synchronous-merge path attempts the actual
+# merge API call, merge-pr.sh now runs a guard that discovers open CHILD PRs
+# still targeting the PARENT branch (feature/issue-<N>) via a LIVE forge query
+# (`gh pr list --base <parent> --state open`, never the daemon registry). If any
+# open child PR exists the guard, by default, HARD-BLOCKS the merge (error, exit
+# 1) — because the repo's delete_branch_on_merge setting would delete the parent
+# branch synchronously during the merge and leave the children unable to rebase
+# onto it. --allow-stacked-children bypasses the guard; --dry-run still runs it
+# and reports the would-be block but never exits 1 (honors the dry-run contract).
+# The guard is a no-op for non-feature/issue-N parent branches and non-GitHub
+# forges, and keys purely on "does an open child PR target this branch" (NOT on
+# the child issue's loom:building label — that split is item 1's concern).
+#
+# Strategy (mirrors test-merge-pr-auto-reconcile.sh): the function under test
+# (_check_no_open_stacked_children) depends only on globals (PR_BRANCH, REPO_NWO,
+# FORGE_TYPE, DRY_RUN, ALLOW_STACKED_CHILDREN) and the `gh` CLI. We extract the
+# function definition from merge-pr.sh and source it, stub `gh` on PATH to serve
+# canned child-PR lists, then assert on the guard's exit code + emitted message.
+# Because the block path calls `error` (which `exit 1`s), the guard is invoked
+# inside a command-substitution subshell so the exit does not tear down the test.
+# Extracting from source (rather than replicating) keeps the test in lockstep
+# with the script.
+#
+# Usage:
+#   ./.loom/scripts/tests/test-merge-pr-merge-ordering-guard.sh
+
+# SC2034: several globals (PR_BRANCH, REPO_NWO, FORGE_TYPE, DRY_RUN,
+# ALLOW_STACKED_CHILDREN) are read only by the function extracted+sourced from
+# merge-pr.sh, which shellcheck cannot see — every such assignment looks
+# "unused" to the linter.
+# shellcheck disable=SC2034
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPERS_DIR="$(cd "$TEST_DIR/.." && pwd)"
+MERGE_PR_SRC="$HELPERS_DIR/merge-pr.sh"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_eq() {
+    local expected="$1" actual="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Expected: '$expected'"
+        echo "    Actual:   '$actual'"
+    fi
+}
+
+assert_contains() {
+    local haystack="$1" needle="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Expected substring: '$needle'"
+        echo "    In: '$haystack'"
+    fi
+}
+
+assert_not_contains() {
+    local haystack="$1" needle="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if ! printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Unexpected substring: '$needle'"
+        echo "    In: '$haystack'"
+    fi
+}
+
+# --- Minimal logging/error shims the extracted function calls ---
+# `error` must exit non-zero to faithfully model the real script's hard block;
+# the guard is always invoked in a subshell (see run_guard) so this exit only
+# tears down that subshell, not the test.
+info()    { echo "INFO: $*"; }
+success() { echo "OK: $*"; }
+warning() { echo "WARN: $*" >&2; }
+error()   { echo "ERROR: $*" >&2; exit 1; }
+
+# --- Extract the function under test from merge-pr.sh and source it ---
+# From `_check_no_open_stacked_children() {` up to (not including) the
+# `# Invoke the guard before` invocation comment. Extracting from source keeps
+# the test in lockstep with the script.
+FUNCS_FILE="$(mktemp)"
+STUB_DIR="$(mktemp -d)"
+trap 'rm -rf "$FUNCS_FILE" "$STUB_DIR" 2>/dev/null || true' EXIT
+awk '
+  /^_check_no_open_stacked_children\(\) \{/ { capture=1 }
+  /^# Invoke the guard before/              { capture=0 }
+  capture { print }
+' "$MERGE_PR_SRC" > "$FUNCS_FILE"
+
+if ! grep -q '_check_no_open_stacked_children()' "$FUNCS_FILE"; then
+    echo -e "${RED}FATAL${NC}: could not extract _check_no_open_stacked_children from $MERGE_PR_SRC" >&2
+    exit 2
+fi
+# shellcheck disable=SC1090
+source "$FUNCS_FILE"
+
+# --- Stub gh on PATH ---
+#   gh pr list --base B ...  -> cat $STUB_DIR/prlist-<sanitized B>.json (or [])
+# The --base value contains a '/' (feature/issue-N), so the stub sanitizes it to
+# '_' before building the fixture filename; the test writes fixtures the same way.
+cat > "$STUB_DIR/gh" <<'STUB'
+#!/usr/bin/env bash
+STUB_DIR_FROM_ENV="${LOOM_TEST_STUB_DIR:?stub gh: LOOM_TEST_STUB_DIR not set}"
+if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  base=""
+  shift 2
+  while [[ $# -gt 0 ]]; do
+    if [[ "$1" == "--base" ]]; then base="$2"; shift 2; continue; fi
+    shift
+  done
+  safe="${base//\//_}"
+  canned="$STUB_DIR_FROM_ENV/prlist-$safe.json"
+  if [[ -f "$canned" ]]; then cat "$canned"; else echo '[]'; fi
+  exit 0
+fi
+echo "stub gh: unhandled args: $*" >&2
+exit 3
+STUB
+chmod +x "$STUB_DIR/gh"
+export LOOM_TEST_STUB_DIR="$STUB_DIR"
+export PATH="$STUB_DIR:$PATH"
+
+# --- Shared globals the function reads (see the file-level SC2034 disable). ---
+PR_NUMBER="999"
+REPO_NWO="owner/repo"
+FORGE_TYPE="github"
+DRY_RUN=false
+ALLOW_STACKED_CHILDREN=false
+
+# Fixture writers (base -> sanitized filename).
+write_prlist() { printf '%s\n' "$2" > "$STUB_DIR/prlist-${1//\//_}.json"; }
+clear_prlist() { rm -f "$STUB_DIR/prlist-${1//\//_}.json"; }
+
+# Run the guard in a subshell (its block path calls `error`, which exit 1's),
+# capturing combined stdout+stderr in LAST_OUT and the exit code in LAST_RC.
+LAST_OUT=""
+LAST_RC=0
+run_guard() {
+    set +e
+    LAST_OUT="$( _check_no_open_stacked_children 2>&1 )"
+    LAST_RC=$?
+    set -e
+}
+
+echo "Testing _check_no_open_stacked_children behavior..."
+
+# T1: no open children -> guard passes (rc 0), no block.
+DRY_RUN=false; ALLOW_STACKED_CHILDREN=false
+PR_BRANCH="feature/issue-100"
+clear_prlist "feature/issue-100"   # stub returns [] with no fixture
+run_guard
+assert_eq "0" "$LAST_RC" "No open children -> guard passes (exit 0)"
+assert_not_contains "$LAST_OUT" "Merge blocked" "No open children -> no block message"
+
+# T2: one open child targeting the parent branch -> hard block (rc 1) with an
+# informative message naming the child PR and the reconcile-stack.sh unblock cmd.
+DRY_RUN=false; ALLOW_STACKED_CHILDREN=false
+PR_BRANCH="feature/issue-100"
+write_prlist "feature/issue-100" '[{"number":501,"headRefName":"feature/issue-201"}]'
+run_guard
+assert_eq "1" "$LAST_RC" "Open child #501 -> merge hard-blocked (exit 1)"
+assert_contains "$LAST_OUT" "Merge blocked" "Open child -> block message emitted"
+assert_contains "$LAST_OUT" "#501" "Block message names the blocking child PR #501"
+assert_contains "$LAST_OUT" "reconcile-stack.sh" "Block message points at the reconcile-stack.sh unblock path"
+assert_contains "$LAST_OUT" "--allow-stacked-children" "Block message mentions the --allow-stacked-children override"
+
+# T3: --allow-stacked-children with an open child present -> merge proceeds
+# (rc 0); a warning is emitted but no hard block.
+DRY_RUN=false; ALLOW_STACKED_CHILDREN=true
+PR_BRANCH="feature/issue-100"
+write_prlist "feature/issue-100" '[{"number":501,"headRefName":"feature/issue-201"}]'
+run_guard
+assert_eq "0" "$LAST_RC" "--allow-stacked-children + open child -> guard proceeds (exit 0)"
+assert_not_contains "$LAST_OUT" "Merge blocked" "--allow-stacked-children -> no hard block"
+assert_contains "$LAST_OUT" "--allow-stacked-children set" "--allow-stacked-children -> override warning emitted"
+ALLOW_STACKED_CHILDREN=false
+
+# T4: non-feature/issue-N parent branch -> guard skipped entirely (rc 0), even
+# though the stub would return an open child for that base.
+DRY_RUN=false; ALLOW_STACKED_CHILDREN=false
+PR_BRANCH="release-1"
+write_prlist "release-1" '[{"number":503,"headRefName":"feature/issue-201"}]'
+run_guard
+assert_eq "0" "$LAST_RC" "Non-feature/issue-N parent 'release-1' -> guard skipped (exit 0)"
+assert_not_contains "$LAST_OUT" "Merge blocked" "Non-feature/issue-N parent -> no block"
+
+# T5: --dry-run with an open child present -> reports the would-be block WITHOUT
+# exiting 1 (dry-run contract preserved), and the reported message still surfaces
+# the would-be block.
+DRY_RUN=true; ALLOW_STACKED_CHILDREN=false
+PR_BRANCH="feature/issue-100"
+write_prlist "feature/issue-100" '[{"number":501,"headRefName":"feature/issue-201"}]'
+run_guard
+assert_eq "0" "$LAST_RC" "--dry-run + open child -> guard does NOT exit 1 (dry-run contract)"
+assert_contains "$LAST_OUT" "[dry-run] Would BLOCK" "--dry-run -> reports the would-be block"
+assert_contains "$LAST_OUT" "#501" "--dry-run block report names the blocking child PR #501"
+DRY_RUN=false
+
+# T6: FORGE_TYPE != github -> no-op (GitHub-only for v2 item 2).
+DRY_RUN=false; ALLOW_STACKED_CHILDREN=false
+FORGE_TYPE="gitea"
+PR_BRANCH="feature/issue-100"
+write_prlist "feature/issue-100" '[{"number":501,"headRefName":"feature/issue-201"}]'
+run_guard
+assert_eq "0" "$LAST_RC" "FORGE_TYPE=gitea -> guard skipped (GitHub-only)"
+assert_not_contains "$LAST_OUT" "Merge blocked" "FORGE_TYPE=gitea -> no block"
+FORGE_TYPE="github"
+
+# T7: multiple open children -> hard block naming each blocking child PR.
+DRY_RUN=false; ALLOW_STACKED_CHILDREN=false
+PR_BRANCH="feature/issue-100"
+write_prlist "feature/issue-100" \
+  '[{"number":501,"headRefName":"feature/issue-201"},{"number":502,"headRefName":"feature/issue-202"}]'
+run_guard
+assert_eq "1" "$LAST_RC" "Multiple open children -> merge hard-blocked (exit 1)"
+assert_contains "$LAST_OUT" "#501" "Multi-child block names child #501"
+assert_contains "$LAST_OUT" "#502" "Multi-child block names child #502"
+
+# --- Source-contains guards (fail if a refactor drops the key behavior) ---
+echo ""
+echo "Testing merge-pr.sh source guards..."
+src="$(cat "$MERGE_PR_SRC")"
+assert_contains "$src" "_check_no_open_stacked_children" \
+  "merge-pr.sh defines and invokes _check_no_open_stacked_children"
+assert_contains "$src" 'gh pr list --repo "$REPO_NWO" --base "$PR_BRANCH" --state open' \
+  "merge-pr.sh discovers children via a live forge query, not the daemon registry"
+assert_contains "$src" "ALLOW_STACKED_CHILDREN" \
+  "merge-pr.sh threads the --allow-stacked-children override into the guard"
+assert_contains "$src" "--allow-stacked-children) ALLOW_STACKED_CHILDREN=true" \
+  "merge-pr.sh parses the --allow-stacked-children flag alongside the other options"
+
+# Assert the guard is invoked BEFORE the auto-merge path (line ordering): the
+# _check_no_open_stacked_children invocation must precede `# Handle auto-merge mode`.
+guard_line="$(grep -n '^_check_no_open_stacked_children$' "$MERGE_PR_SRC" | head -1 | cut -d: -f1)"
+automerge_line="$(grep -n '^# Handle auto-merge mode' "$MERGE_PR_SRC" | head -1 | cut -d: -f1)"
+if [[ -n "$guard_line" && -n "$automerge_line" && "$guard_line" -lt "$automerge_line" ]]; then
+    ordered="yes"
+else
+    ordered="no (guard=$guard_line automerge=$automerge_line)"
+fi
+assert_eq "yes" "$ordered" \
+  "guard is invoked before both merge paths (before '# Handle auto-merge mode')"
+
+# --- Summary ---
+echo ""
+echo "────────────────────────────────"
+echo "Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed"
+
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds a **pre-merge merge-ordering guard** to `defaults/scripts/merge-pr.sh` (stacked-PR v2 **item 2** of epic #3747). It runs **before both** the auto-merge and synchronous-merge paths and, by default, **hard-blocks** merging a stacked parent PR (branch `feature/issue-<N>`) while it still has open stacked child PRs targeting its branch.

### The race this closes

Item 1's post-merge `_auto_reconcile_stacked_children` runs *after* the parent has merged. But the repo setting Loom itself recommends — `delete_branch_on_merge:true`, applied by `setup-repository-settings.sh` — makes GitHub delete `feature/issue-<parent>` **synchronously during the merge API call**, before the post-merge reconcile pass runs. Once the ref is gone, `reconcile-stack.sh`'s `git rebase --onto <default> <parent-branch>` can no longer resolve `<parent-branch>`, so item 1 could race and *lose*. The guard refuses to let the parent merge create that race.

Orthogonal to item 1's `loom:building` safe/unsafe split — a "safe" child is just as exposed to branch deletion — so the guard keys **purely on "does an open child PR still target this branch"**.

## What changed

- **`_check_no_open_stacked_children()`** — scoped to `FORGE_TYPE == github` + `PR_BRANCH` matching `^feature/issue-([0-9]+)$` (no-op otherwise, byte-for-byte unchanged for non-stacked merges). Discovers children via the same live `gh pr list --repo … --base "$PR_BRANCH" --state open` query item 1 uses (never the daemon registry).
- **Default = hard block** (`error`, exit 1) naming the blocking child PR number(s) and the `reconcile-stack.sh` unblock command — a normal, recoverable failure Champion's cron retries next tick, mirroring the existing `PR_MERGEABLE == false` pattern.
- **`--allow-stacked-children`** flag (parsed alongside `--dry-run`/`--auto`/`--worktree-path`, documented in `show_help()` + top comment) bypasses the guard; operator asserts the children are reconciled, mirroring the `--worktree-path` opt-in-bypass precedent.
- **`--dry-run`** still runs the guard and reports the would-be block without breaking the dry-run contract (never exits 1).
- Item 1's post-merge step is untouched.

## Tests

- New `defaults/scripts/tests/test-merge-pr-merge-ordering-guard.sh` (25 assertions), modeled on `test-merge-pr-auto-reconcile.sh` — extracts the guard from source and stubs `gh`. Covers: no-children→proceed, child-exists→block(exit 1) with informative message, `--allow-stacked-children`→proceed, non-`feature/issue-N`→skipped, `--dry-run`→reports-without-exit-1, non-GitHub→no-op, multi-child, and invocation-ordering/source guards.
- All existing merge-pr tests pass (auto-reconcile 20/20, help 15/15, etc.).
- `shellcheck --severity=warning` clean on the modified script and the new test.

## Docs

- `defaults/.claude/commands/loom/sweep.md` — guard documented as shipped; deferred list narrowed to items 3-6.
- `.loom/docs/daemon-reference.md` — corresponding one-line-plus update.

## Out of scope (deferred, epic stays OPEN)

Items 3-6 (rebase-on-amend, dependency auto-detection, diamonds, auto-detach) and the "child hasn't opened a PR yet" case (no forge signal without auto-detection).

Part of #3747