### PR TITLE
feat(guard): add deny/ask decision telemetry log (#3771)

### DIFF
--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -1372,6 +1372,58 @@ LOOM_GUARD_READONLY_FASTPATH=0 git status
 #   .loom/config.json  ->  { "guards": { "readOnlyFastPathExtra": ["jq"] } }
 ```
 
+### Decision Telemetry Log (`guards.decisionLog` / `LOOM_GUARD_DECISION_LOG`)
+
+`guard-destructive.sh` can record every **deny** and **ask** decision to a JSONL decision log (issue #3771), separate from `hook-errors.log`, so guard-hook friction becomes **measurable** — which patterns fire, how often, and whether a precision fix (#3755/#3756/#3757) actually cut the false-positive rate. Without it, "we keep hitting the hooks" is unquantifiable.
+
+The log is **off by default** — enabling it writes a new persistent, cross-session artifact, so like the other opt-in data-collection features (transcript archival #3726, the model-cost experiment #3725) a zero-config install sees no new file and no behaviour change. It is resolved in this order (highest precedence first):
+
+1. **`LOOM_GUARD_DECISION_LOG` env var** — `1`/`true`/`yes`/`on` enables; `0`/`false`/`no`/`off` disables. Overrides the config value.
+2. **`.loom/config.json`** — `guards.decisionLog` (default `false` when absent). Set it to `true` to enable:
+   ```json
+   {
+     "guards": {
+       "decisionLog": true
+     }
+   }
+   ```
+3. **Default** — `false` (no decision log written).
+
+When enabled, each deny/ask appends **one JSON object per line** to `.loom/logs/guard-decisions.log` (`SCRIPT_DIR`-relative, mirroring `hook-errors.log`; override the path with `LOOM_GUARD_DECISION_LOG_FILE`). **Stable schema** (the contract downstream reader tooling in #3772 depends on — field names are load-bearing):
+
+```json
+{"ts":"2026-07-22T23:17:13Z","decision":"deny","pattern":"sql-ddl","tier":"catastrophic","command":"<redacted>"}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `ts` | UTC timestamp (`date -u '+%Y-%m-%dT%H:%M:%SZ'`, same as `hook-errors.log`) |
+| `decision` | `deny` or `ask` |
+| `pattern` | a short, stable rule tag (e.g. `sql-ddl`, `rm-protected-path`, `force-op:protected`, `cloud-cli:<pattern>`) — **not** the full free-text reason |
+| `tier` | `catastrophic` for a deny, `ask` for an ask |
+| `command` | the command string, **redacted** via `strip_literal_text()` so no raw `--body`/`-m`/`--title`/`--notes`/`--comment` secret value is persisted |
+
+**`allow` decisions are never logged** — the #3687 read-only fast path's zero-overhead silent-allow stays silent, and allow-logging would swamp the log with the ~99% common case. Logging is **best-effort / fail-open**: the toggle is resolved lazily (only once a deny/ask is about to fire, so it never touches the fast path's hot path), and a log-write failure (permission denied, disk full, missing dir) never changes the deny/ask decision and never causes the hook to exit non-zero. `.loom/logs/` is gitignored.
+
+Summarize fires by rule (a fuller reader/aggregation CLI is #3772's scope):
+
+```bash
+jq -r '.pattern' .loom/logs/guard-decisions.log | sort | uniq -c | sort -rn
+```
+
+**Examples**:
+
+```bash
+# Enable for a single command (e.g. to capture one session's fires)
+LOOM_GUARD_DECISION_LOG=1 claude -p "/builder" --dangerously-skip-permissions
+
+# Persist for a whole repo
+#   .loom/config.json  ->  { "guards": { "decisionLog": true } }
+
+# Force off for one command even when the repo opts in
+LOOM_GUARD_DECISION_LOG=0 <command>
+```
+
 ### Protecting Read-Only Directories
 
 Many projects have directories that should never be modified by agents (vendor code, generated files, external SDKs, process design kits). Loom provides a template hook for this.

--- a/defaults/hooks/guard-destructive.sh
+++ b/defaults/hooks/guard-destructive.sh
@@ -35,12 +35,85 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null || echo ".")"
 HOOK_ERROR_LOG="${SCRIPT_DIR}/../logs/hook-errors.log"
 
+# Decision telemetry log (issue #3771) — a SEPARATE JSONL file from
+# HOOK_ERROR_LOG. At runtime SCRIPT_DIR is the installed hook's own directory
+# (.loom/hooks/), so this resolves to .loom/logs/guard-decisions.log in a real
+# install. LOOM_GUARD_DECISION_LOG_FILE overrides the path (a test seam; also
+# lets an operator point the log elsewhere). Off by default — see
+# decision_log_enabled() below.
+DECISION_LOG="${LOOM_GUARD_DECISION_LOG_FILE:-${SCRIPT_DIR}/../logs/guard-decisions.log}"
+
 # Log a diagnostic error message (best-effort, never fails the script)
 log_hook_error() {
     local msg="$1"
     # Ensure log directory exists
     mkdir -p "$(dirname "$HOOK_ERROR_LOG")" 2>/dev/null || true
     echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] [guard-destructive] $msg" >> "$HOOK_ERROR_LOG" 2>/dev/null || true
+}
+
+# =============================================================================
+# DECISION TELEMETRY (issue #3771) — one JSONL record per deny/ask decision.
+#
+# Append a machine-readable record to DECISION_LOG each time the guard denies or
+# asks, so false-positive friction becomes measurable (which patterns fire, how
+# often, before/after a precision fix). Deliberately does NOT log `allow`: the
+# #3687 read-only fast path's zero-overhead silent-allow must stay silent, and
+# allow-logging would swamp the log with the ~99% common case.
+#
+# STABLE SCHEMA (the contract #3772's reader/aggregation tooling stacks on — do
+# NOT rename fields without considering that dependency), one JSON object per
+# line:
+#   {"ts":"<UTC>","decision":"deny"|"ask","pattern":"<tag>",
+#    "tier":"catastrophic"|"ask","command":"<redacted>"}
+#     ts       — UTC timestamp, same format as log_hook_error's date -u call.
+#     decision — "deny" or "ask".
+#     pattern  — a short, stable rule tag (NOT the full free-text reason). For
+#                the pattern-array loops it is the matched pattern; the non-loop
+#                sites pass a static tag (e.g. "sql-ddl", "rm-protected-path").
+#     tier     — "catastrophic" for deny, "ask" for ask.
+#     command  — the command string, REDACTED via strip_literal_text() so no raw
+#                --body/-m/--title/--notes/--comment secret value is persisted.
+#
+# Best-effort like log_hook_error: gated by the lazy decision_log_enabled()
+# toggle, and a log-write failure (permission denied, disk full, missing dir)
+# NEVER changes the deny/ask decision and NEVER causes a non-zero exit. Callers
+# invoke it as `log_guard_decision ... || true` so it can never trip the ERR
+# trap.
+#
+# One-liner to summarize fires by pattern (AC — full tooling is #3772):
+#   jq -r '.pattern' .loom/logs/guard-decisions.log | sort | uniq -c | sort -rn
+# =============================================================================
+log_guard_decision() {
+    # Args: <decision> <tier> <pattern-tag>. The command is read from the global
+    # $COMMAND and redacted here. Returns 0 unconditionally.
+    decision_log_enabled || return 0
+    local decision="$1" tier="$2" tag="${3:-$1}"
+    local ts redacted line
+    ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null) || ts=""
+    # Redact quoted --body/-m/--title/--notes/--comment values (same redactor the
+    # pattern-matching tiers use) so no raw secret text is persisted to a log that
+    # aggregates across sessions. Fall back to raw only if redaction produced
+    # nothing (awk unavailable) — impossible in practice since jq is required and
+    # awk is used throughout.
+    redacted=$(strip_literal_text "$COMMAND" 2>/dev/null) || redacted=""
+    [[ -n "$redacted" ]] || redacted="$COMMAND"
+    # Build the JSONL record with jq so all escaping is correct. If jq fails,
+    # skip the write entirely rather than hand-roll a line that might mis-escape.
+    line=$(jq -cn \
+        --arg ts "$ts" \
+        --arg decision "$decision" \
+        --arg pattern "$tag" \
+        --arg tier "$tier" \
+        --arg command "$redacted" \
+        '{ts:$ts, decision:$decision, pattern:$pattern, tier:$tier, command:$command}' \
+        2>/dev/null) || return 0
+    [[ -n "$line" ]] || return 0
+    mkdir -p "$(dirname "$DECISION_LOG")" 2>/dev/null || true
+    # Group the append so a FAILED >> redirection (unwritable/nonexistent dir)
+    # has its bash-level error caught by the group's stderr redirect too — a bare
+    # `>> "$f" 2>/dev/null` does not suppress the redirection-open error itself.
+    { printf '%s\n' "$line" >> "$DECISION_LOG"; } 2>/dev/null || true
+    return 0
 }
 
 # Top-level error trap: on ANY unexpected error, output valid JSON "allow"
@@ -404,6 +477,53 @@ reversible_gh_guard_enabled() {
         _REVERSIBLE_GH_GUARD_CACHE="$enabled"
     fi
     [[ "$_REVERSIBLE_GH_GUARD_CACHE" == "true" ]]
+}
+
+# =============================================================================
+# Decision-telemetry toggle — default OFF (opt-IN; inverse polarity, #3771).
+#
+# The deny/ask decision log (log_guard_decision() near the top of this file) is
+# OFF by default: it writes a new persistent, cross-session artifact of redacted
+# commands, so — mirroring the other opt-in data-collection features in Loom
+# (transcript archival #3726, the model-cost experiment #3725) — a zero-config
+# install sees NO new file and NO behaviour change. An operator enables it to
+# measure guard-hook friction.
+#
+# Same INVERSE polarity as reversible_gh_guard_enabled(): defaults false, the
+# absent-key resolution is false, and only an explicit `true` (config) or a
+# truthy env value enables it.
+#
+# Resolution order (highest precedence first):
+#   1. LOOM_GUARD_DECISION_LOG env var (1/true/yes/on enables; 0/false/no/off
+#      disables). Overrides config.
+#   2. .loom/config.json  ->  guards.decisionLog  (default false when absent).
+#   3. Default: false (no decision log written).
+#
+# Resolved LAZILY and cached in _DECISION_LOG_CACHE, invoked only from inside
+# log_guard_decision() (i.e. only once a deny/ask is about to fire), exactly like
+# the other toggles — so the config read NEVER touches the hot path for the ~99%
+# of commands that neither deny nor ask, and in particular never runs on the
+# #3687 read-only fast path (which exits before any deny/ask). The config read is
+# best-effort: any parse failure falls through to guard-OFF (the default).
+# =============================================================================
+_DECISION_LOG_CACHE=""
+decision_log_enabled() {
+    if [[ -z "$_DECISION_LOG_CACHE" ]]; then
+        local enabled=false
+        if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.loom/config.json" ]]; then
+            # Only an explicit `true` enables; a missing key or malformed JSON
+            # (jq non-zero, caught by ||) stays OFF — inverse of sql_guard_enabled().
+            enabled=$(jq -r 'if .guards.decisionLog == true then "true" else "false" end' "$REPO_ROOT/.loom/config.json" 2>/dev/null) || enabled=false
+            [[ -n "$enabled" ]] || enabled=false
+        fi
+        # Env override wins over config.
+        case "${LOOM_GUARD_DECISION_LOG:-}" in
+            0|false|no|off)   enabled=false ;;
+            1|true|yes|on)    enabled=true ;;
+        esac
+        _DECISION_LOG_CACHE="$enabled"
+    fi
+    [[ "$_DECISION_LOG_CACHE" == "true" ]]
 }
 
 # =============================================================================
@@ -805,8 +925,17 @@ strip_literal_text() {
 }
 
 # Helper: output a deny decision and exit
+#
+# Optional second arg is a short, STABLE rule tag (issue #3771) recorded as the
+# decision log's `pattern` field; it defaults to "deny" (a function-name-derived
+# fallback) so this stays backward-compatible with call sites that don't pass
+# one. Telemetry is emitted BEFORE the JSON decision so a logging hiccup can
+# never suppress the deny, and the `|| true` guarantees it never trips the ERR
+# trap. Deny is always the "catastrophic" tier.
 deny() {
     local reason="$1"
+    local tag="${2:-deny}"
+    log_guard_decision "deny" "catastrophic" "$tag" || true
     if jq -n --arg reason "$reason" '{
         hookSpecificOutput: {
             hookEventName: "PreToolUse",
@@ -824,8 +953,14 @@ deny() {
 }
 
 # Helper: output an ask decision and exit
+#
+# Same optional rule-tag convention as deny() (issue #3771); defaults to "ask".
+# Ask is always the "ask" tier. Telemetry is best-effort and emitted before the
+# JSON decision.
 ask() {
     local reason="$1"
+    local tag="${2:-ask}"
+    log_guard_decision "ask" "ask" "$tag" || true
     if jq -n --arg reason "$reason" '{
         hookSpecificOutput: {
             hookEventName: "PreToolUse",
@@ -931,7 +1066,7 @@ fi
 
 for pattern in "${ALWAYS_BLOCK_PATTERNS[@]}"; do
     if echo "$COMMAND_NO_LITERAL_TEXT" | grep -qiE "$pattern"; then
-        deny "BLOCKED: Command matches dangerous pattern: $pattern"
+        deny "BLOCKED: Command matches dangerous pattern: $pattern" "catastrophic:$pattern"
     fi
 done
 
@@ -1054,7 +1189,7 @@ lifecycle_or_cloud_reason() {
 
 _LIFECYCLE_REASON=$(lifecycle_or_cloud_reason "$COMMAND_NO_COMMENT" | head -1)
 if [[ -n "$_LIFECYCLE_REASON" ]]; then
-    deny "BLOCKED: $_LIFECYCLE_REASON"
+    deny "BLOCKED: $_LIFECYCLE_REASON" "lifecycle-or-cloud-delete"
 fi
 
 # =============================================================================
@@ -1069,7 +1204,7 @@ fi
 SQL_DDL_PATTERN='DROP DATABASE|DROP TABLE|DROP SCHEMA|TRUNCATE TABLE'
 if echo "$COMMAND_NO_COMMENT" | grep -qiE "$SQL_DDL_PATTERN" && sql_guard_enabled; then
     matched=$(echo "$COMMAND_NO_COMMENT" | grep -oiE "$SQL_DDL_PATTERN" | head -1)
-    deny "BLOCKED: Command matches dangerous pattern: ${matched:-SQL DDL statement}"
+    deny "BLOCKED: Command matches dangerous pattern: ${matched:-SQL DDL statement}" "sql-ddl"
 fi
 
 # =============================================================================
@@ -1216,7 +1351,7 @@ if echo "$COMMAND" | grep -qE 'rm[[:space:]]+-[a-zA-Z]*[rf]'; then
             if [[ "$ABS_PATH" == "/" ]] || \
                [[ -n "$HOME" && "$ABS_PATH" == "$HOME" ]] || \
                [[ "$ABS_PATH" =~ ^/[^/]+$ ]]; then
-                deny "BLOCKED: rm on protected system path: $ABS_PATH"
+                deny "BLOCKED: rm on protected system path: $ABS_PATH" "rm-protected-path"
             fi
 
             # Opt-in repo-scoped strict mode (guards.rmScope:"repo" /
@@ -1272,7 +1407,7 @@ if echo "$COMMAND" | grep -qE 'rm[[:space:]]+-[a-zA-Z]*[rf]'; then
                 fi
 
                 if [[ "$IN_SCOPE" == false ]]; then
-                    deny "BLOCKED: rm target outside repo scope (LOOM_RM_SCOPE=repo): $ABS_PATH"
+                    deny "BLOCKED: rm target outside repo scope (LOOM_RM_SCOPE=repo): $ABS_PATH" "rm-scope-outside-repo"
                 fi
             fi
         fi
@@ -1289,7 +1424,7 @@ fi
 # path for non-SQL commands.
 if echo "$COMMAND_NO_COMMENT" | grep -qiE 'DELETE[[:space:]]+FROM[[:space:]]+' && \
    ! echo "$COMMAND_NO_COMMENT" | grep -qiE 'WHERE[[:space:]]+'; then
-    sql_guard_enabled && deny "BLOCKED: DELETE FROM without WHERE clause"
+    sql_guard_enabled && deny "BLOCKED: DELETE FROM without WHERE clause" "sql-delete-no-where"
 fi
 
 # =============================================================================
@@ -1319,7 +1454,7 @@ if [[ "$COMMAND_NO_COMMENT" == *git* ]] && \
         if [[ -n "$_FORCE_OPS" ]]; then
             if [[ "$_FORCE_MODE" == "all" ]]; then
                 # Preserve pre-#3674 behaviour byte-for-byte: any force op asks.
-                ask "Command requires confirmation: $COMMAND"
+                ask "Command requires confirmation: $COMMAND" "force-op:all"
             fi
             # "protected" mode: ask only for protected-branch or ambiguous
             # targets; allow own working branches. resolve_default_branch() plus
@@ -1336,14 +1471,14 @@ if [[ "$COMMAND_NO_COMMENT" == *git* ]] && \
                     if [[ -z "$_fbranch" ]]; then
                         # Detached HEAD / unresolved identity is ambiguous — ask,
                         # never silently allow (fail toward asking).
-                        ask "Command requires confirmation: $COMMAND (force operation on a detached or unresolved branch)"
+                        ask "Command requires confirmation: $COMMAND (force operation on a detached or unresolved branch)" "force-op:detached"
                     fi
                     _ftarget="$_fbranch"
                 fi
                 _fdefault=$(resolve_default_branch "$_fcwd")
                 if [[ "$_ftarget" == "main" || "$_ftarget" == "master" ]] || \
                    { [[ -n "$_fdefault" && "$_ftarget" == "$_fdefault" ]]; }; then
-                    ask "Command requires confirmation: $COMMAND (force operation targets protected branch '$_ftarget')"
+                    ask "Command requires confirmation: $COMMAND (force operation targets protected branch '$_ftarget')" "force-op:protected"
                 fi
             done <<< "$_FORCE_OPS"
             # No protected/ambiguous target matched — fall through to allow.
@@ -1417,7 +1552,7 @@ ASK_PATTERNS=(
 
 for pattern in "${ASK_PATTERNS[@]}"; do
     if echo "$COMMAND_ASK_SCAN" | grep -qE "$pattern"; then
-        ask "Command requires confirmation: $COMMAND"
+        ask "Command requires confirmation: $COMMAND" "ask:$pattern"
     fi
 done
 
@@ -1446,7 +1581,7 @@ REVERSIBLE_GH_ASK_PATTERNS=(
 
 for pattern in "${REVERSIBLE_GH_ASK_PATTERNS[@]}"; do
     if echo "$COMMAND_ASK_SCAN" | grep -qE "$pattern" && reversible_gh_guard_enabled; then
-        ask "Command requires confirmation: $COMMAND (set guards.reversibleGh:true in .loom/config.json to keep this ask; it is off by default because the op is trivially reversible)"
+        ask "Command requires confirmation: $COMMAND (set guards.reversibleGh:true in .loom/config.json to keep this ask; it is off by default because the op is trivially reversible)" "reversible-gh:$pattern"
     fi
 done
 
@@ -1473,7 +1608,7 @@ done
 if echo "$COMMAND_NO_COMMENT" | grep -qE '(^|[;&|(]|[[:space:]])git[[:space:]]+read-tree'; then
     # Isolated form (GIT_INDEX_FILE=... git read-tree ...) is allowed.
     if ! echo "$COMMAND_NO_COMMENT" | grep -qE 'GIT_INDEX_FILE='; then
-        ask "Command requires confirmation: $COMMAND (a bare 'git read-tree' empties the real staging index with no reflog trace; use 'git merge-tree --write-tree <base> <branch>' for a merge preview, or isolate with GIT_INDEX_FILE=\$(mktemp))"
+        ask "Command requires confirmation: $COMMAND (a bare 'git read-tree' empties the real staging index with no reflog trace; use 'git merge-tree --write-tree <base> <branch>' for a merge preview, or isolate with GIT_INDEX_FILE=\$(mktemp))" "git-read-tree"
     fi
 fi
 
@@ -1522,7 +1657,7 @@ CLOUD_ASK_PATTERNS=(
 
 for pattern in "${CLOUD_ASK_PATTERNS[@]}"; do
     if echo "$COMMAND_NO_COMMENT" | grep -qE "$pattern" && cloud_guard_enabled; then
-        ask "Command requires confirmation: $COMMAND (set guards.cloudCli:false in .loom/config.json if this repo manages cloud infra as a first-class workflow)"
+        ask "Command requires confirmation: $COMMAND (set guards.cloudCli:false in .loom/config.json if this repo manages cloud infra as a first-class workflow)" "cloud-cli:$pattern"
     fi
 done
 

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -1694,6 +1694,172 @@ done
 echo ""
 
 # =========================================================================
+echo -e "${YELLOW}--- Decision telemetry log (#3771) ---${NC}"
+# =========================================================================
+#
+# guard-destructive.sh appends one JSONL record per deny/ask decision to a
+# decision log — default .loom/logs/guard-decisions.log (SCRIPT_DIR-relative,
+# so distinct from hook-errors.log in the same dir) — gated by
+# guards.decisionLog / the LOOM_GUARD_DECISION_LOG env (default OFF). `allow`
+# (including the #3687 fast-path silent allow) is never logged. Writes are
+# best-effort / fail-open. The LOOM_GUARD_DECISION_LOG_FILE test seam overrides
+# the write path so these tests inspect records without touching a real install
+# log. The record schema is the STABLE contract #3772 stacks on:
+#   {"ts","decision","pattern","tier","command"}.
+
+DL_DIR="$(mktemp -d)"
+DL_LOG="$DL_DIR/guard-decisions.log"
+
+# dl_assert <description> <status: 0=pass> [detail-on-fail]
+dl_assert() {
+    TOTAL=$((TOTAL + 1))
+    if [[ "$2" -eq 0 ]]; then
+        PASS=$((PASS + 1))
+        echo -e "  ${GREEN}PASS${NC}: $1"
+    else
+        FAIL=$((FAIL + 1))
+        echo -e "  ${RED}FAIL${NC}: $1"
+        [[ -n "${3:-}" ]] && echo -e "       ${3}"
+    fi
+}
+
+# (a) A deny-triggering command writes a JSONL record with decision=deny,
+# tier=catastrophic, and non-empty pattern + command, when the toggle is on.
+rm -f "$DL_LOG"
+make_input "rm -rf /" "$REPO_ROOT" | \
+    env LOOM_GUARD_DECISION_LOG=1 LOOM_GUARD_DECISION_LOG_FILE="$DL_LOG" "$GUARD" >/dev/null 2>&1 || true
+_dl_rec="$(tail -1 "$DL_LOG" 2>/dev/null)"
+if [[ -f "$DL_LOG" ]] && \
+   [[ "$(printf '%s' "$_dl_rec" | jq -r '.decision' 2>/dev/null)" == "deny" ]] && \
+   [[ "$(printf '%s' "$_dl_rec" | jq -r '.tier' 2>/dev/null)" == "catastrophic" ]] && \
+   [[ -n "$(printf '%s' "$_dl_rec" | jq -r '.pattern' 2>/dev/null)" ]] && \
+   [[ -n "$(printf '%s' "$_dl_rec" | jq -r '.command' 2>/dev/null)" ]] && \
+   [[ -n "$(printf '%s' "$_dl_rec" | jq -r '.ts' 2>/dev/null)" ]]; then
+    dl_assert "deny logs a JSONL record (decision=deny, tier=catastrophic, ts/pattern/command present)" 0
+else
+    dl_assert "deny logs a JSONL record (decision=deny, tier=catastrophic, ts/pattern/command present)" 1 "record: ${_dl_rec:-<none>}"
+fi
+
+# (b) An ask-triggering command likewise writes decision=ask, tier=ask.
+rm -f "$DL_LOG"
+make_input "git clean -fd" "$REPO_ROOT" | \
+    env LOOM_GUARD_DECISION_LOG=1 LOOM_GUARD_DECISION_LOG_FILE="$DL_LOG" "$GUARD" >/dev/null 2>&1 || true
+_dl_rec="$(tail -1 "$DL_LOG" 2>/dev/null)"
+if [[ -f "$DL_LOG" ]] && \
+   [[ "$(printf '%s' "$_dl_rec" | jq -r '.decision' 2>/dev/null)" == "ask" ]] && \
+   [[ "$(printf '%s' "$_dl_rec" | jq -r '.tier' 2>/dev/null)" == "ask" ]]; then
+    dl_assert "ask logs a JSONL record (decision=ask, tier=ask)" 0
+else
+    dl_assert "ask logs a JSONL record (decision=ask, tier=ask)" 1 "record: ${_dl_rec:-<none>}"
+fi
+
+# (c) An allow-only command (full-path, non-matching) writes NO record even with
+# the toggle on. `cargo build` is not fast-pathed and matches no deny/ask rule.
+rm -f "$DL_LOG"
+make_input "cargo build --workspace" "$REPO_ROOT" | \
+    env LOOM_GUARD_DECISION_LOG=1 LOOM_GUARD_DECISION_LOG_FILE="$DL_LOG" "$GUARD" >/dev/null 2>&1 || true
+if [[ ! -f "$DL_LOG" ]] || [[ "$(wc -l < "$DL_LOG" 2>/dev/null || echo 0)" -eq 0 ]]; then
+    dl_assert "allow-only command writes NO decision record (toggle on)" 0
+else
+    dl_assert "allow-only command writes NO decision record (toggle on)" 1 "unexpected: $(cat "$DL_LOG")"
+fi
+
+# (d) The #3687 fast-path silent-allow (git status) writes NO record — it exits
+# before any deny/ask, so the decision log is never even touched.
+rm -f "$DL_LOG"
+make_input "git status" "$REPO_ROOT" | \
+    env LOOM_GUARD_DECISION_LOG=1 LOOM_GUARD_DECISION_LOG_FILE="$DL_LOG" "$GUARD" >/dev/null 2>&1 || true
+if [[ ! -f "$DL_LOG" ]]; then
+    dl_assert "fast-path silent-allow (git status) writes NO decision record" 0
+else
+    dl_assert "fast-path silent-allow (git status) writes NO decision record" 1 "unexpected: $(cat "$DL_LOG")"
+fi
+
+# (e) The decision log is a SEPARATE file from hook-errors.log: a clean deny
+# writes to the decision log and does NOT append to the real hook-errors.log.
+_dl_hookerr="$REPO_ROOT/defaults/logs/hook-errors.log"
+_dl_err_before="$( [[ -f "$_dl_hookerr" ]] && wc -l < "$_dl_hookerr" || echo 0 )"
+rm -f "$DL_LOG"
+make_input "rm -rf /" "$REPO_ROOT" | \
+    env LOOM_GUARD_DECISION_LOG=1 LOOM_GUARD_DECISION_LOG_FILE="$DL_LOG" "$GUARD" >/dev/null 2>&1 || true
+_dl_err_after="$( [[ -f "$_dl_hookerr" ]] && wc -l < "$_dl_hookerr" || echo 0 )"
+if [[ -f "$DL_LOG" ]] && [[ "$DL_LOG" != "$_dl_hookerr" ]] && [[ "$_dl_err_before" -eq "$_dl_err_after" ]]; then
+    dl_assert "decision log is separate from hook-errors.log (clean deny does not grow the error log)" 0
+else
+    dl_assert "decision log is separate from hook-errors.log (clean deny does not grow the error log)" 1 "err_before=$_dl_err_before err_after=$_dl_err_after"
+fi
+
+# (f) A secret-bearing -m value that triggers a deny logs a REDACTED command —
+# the secret must not appear anywhere in the log. The force-push-to-main deny
+# fires on the post-&& segment; strip_literal_text() redacts the -m value.
+rm -f "$DL_LOG"
+make_input 'git commit -m "leak sk-ant-SEKRIT-value" && git push --force origin main' "$REPO_ROOT" | \
+    env LOOM_GUARD_DECISION_LOG=1 LOOM_GUARD_DECISION_LOG_FILE="$DL_LOG" "$GUARD" >/dev/null 2>&1 || true
+_dl_cmd="$(tail -1 "$DL_LOG" 2>/dev/null | jq -r '.command' 2>/dev/null)"
+if [[ -f "$DL_LOG" ]] && ! grep -q "SEKRIT" "$DL_LOG" && [[ -n "$_dl_cmd" ]]; then
+    dl_assert "deny with a secret -m value logs a REDACTED command (secret absent)" 0
+else
+    dl_assert "deny with a secret -m value logs a REDACTED command (secret absent)" 1 "logged command: ${_dl_cmd:-<none>}"
+fi
+
+# (g) Toggle OFF (the default) produces no log growth. Use a non-repo cwd so
+# REPO_ROOT is empty and no config can flip it on — the env is unset here.
+_dl_norepo="$(mktemp -d)"
+rm -f "$DL_LOG"
+make_input "rm -rf /" "$_dl_norepo" | \
+    env LOOM_GUARD_DECISION_LOG_FILE="$DL_LOG" "$GUARD" >/dev/null 2>&1 || true
+if [[ ! -f "$DL_LOG" ]]; then
+    dl_assert "toggle default OFF: deny writes NO decision record" 0
+else
+    dl_assert "toggle default OFF: deny writes NO decision record" 1 "unexpected: $(cat "$DL_LOG")"
+fi
+rm -rf "$_dl_norepo"
+
+# (h) Config toggle: guards.decisionLog:true in .loom/config.json enables the log
+# with no env var set (covers the config precedence tier).
+_dl_cfg_repo="$(mktemp -d)"
+git -C "$_dl_cfg_repo" init -q >/dev/null 2>&1
+mkdir -p "$_dl_cfg_repo/.loom"
+printf '%s' '{"guards":{"decisionLog":true}}' > "$_dl_cfg_repo/.loom/config.json"
+rm -f "$DL_LOG"
+make_input "rm -rf /" "$_dl_cfg_repo" | \
+    env LOOM_GUARD_DECISION_LOG_FILE="$DL_LOG" "$GUARD" >/dev/null 2>&1 || true
+if [[ -f "$DL_LOG" ]] && [[ "$(tail -1 "$DL_LOG" | jq -r '.decision' 2>/dev/null)" == "deny" ]]; then
+    dl_assert "config guards.decisionLog:true enables the log (no env)" 0
+else
+    dl_assert "config guards.decisionLog:true enables the log (no env)" 1 "record: $(tail -1 "$DL_LOG" 2>/dev/null)"
+fi
+
+# (i) Env-over-config precedence: LOOM_GUARD_DECISION_LOG=0 overrides config-on.
+rm -f "$DL_LOG"
+make_input "rm -rf /" "$_dl_cfg_repo" | \
+    env LOOM_GUARD_DECISION_LOG=0 LOOM_GUARD_DECISION_LOG_FILE="$DL_LOG" "$GUARD" >/dev/null 2>&1 || true
+if [[ ! -f "$DL_LOG" ]]; then
+    dl_assert "env LOOM_GUARD_DECISION_LOG=0 overrides config-on (no record)" 0
+else
+    dl_assert "env LOOM_GUARD_DECISION_LOG=0 overrides config-on (no record)" 1 "unexpected: $(cat "$DL_LOG")"
+fi
+rm -rf "$_dl_cfg_repo"
+
+# (j) Fail-open: an unwritable decision-log path never changes the deny decision
+# and never causes a non-zero exit (the guard still emits its deny JSON, exit 0).
+_dl_out=""
+_dl_rc=0
+_dl_out="$(make_input "rm -rf /" "$REPO_ROOT" | \
+    env LOOM_GUARD_DECISION_LOG=1 LOOM_GUARD_DECISION_LOG_FILE="/nonexistent-dir-3771/a/b/decisions.log" "$GUARD" 2>/dev/null)" || _dl_rc=$?
+if [[ "$_dl_rc" -eq 0 ]] && \
+   [[ "$(printf '%s' "$_dl_out" | jq -r '.hookSpecificOutput.permissionDecision' 2>/dev/null)" == "deny" ]]; then
+    dl_assert "fail-open: unwritable decision log still denies and exits 0" 0
+else
+    dl_assert "fail-open: unwritable decision log still denies and exits 0" 1 "rc=$_dl_rc out=$_dl_out"
+fi
+
+# Clean up the decision-telemetry temp dir.
+[[ -n "$DL_DIR" && "$DL_DIR" != "/" && -d "$DL_DIR" ]] && rm -rf "$DL_DIR"
+
+echo ""
+
+# =========================================================================
 echo -e "${YELLOW}--- Performance check ---${NC}"
 # =========================================================================
 


### PR DESCRIPTION
## Summary

Makes guard-hook friction **measurable** (issue #3771 — Chain A ROOT). `guard-destructive.sh` now appends one JSONL record per **deny**/**ask** decision to a decision log (`.loom/logs/guard-decisions.log`, `SCRIPT_DIR`-relative) **separate** from `hook-errors.log`, so we can finally quantify which patterns fire, how often, and whether the precision fixes (#3755/#3756/#3757) cut the false-positive rate.

## Toggle default: OFF (documented decision)

The curator left "off or lightweight-default-ON" open. This lands **default OFF** (inverse polarity, mirroring `reversible_gh_guard_enabled()`): enabling writes a new persistent, cross-session artifact of redacted commands, so a zero-config install sees **no new file and no behaviour change** — the same convention as the other opt-in data-collection features (transcript archival #3726, model-cost experiment #3725). Enable via `guards.decisionLog:true` or `LOOM_GUARD_DECISION_LOG=1` (env wins).

## Stable JSONL schema (the contract #3772 stacks on)

```json
{"ts":"2026-07-22T23:17:13Z","decision":"deny","pattern":"sql-ddl","tier":"catastrophic","command":"<redacted>"}
```

`ts` (UTC, same format as `hook-errors.log`) · `decision` (deny/ask) · `pattern` (short stable rule tag, not the free-text reason) · `tier` (catastrophic/ask) · `command` (**redacted** via `strip_literal_text()` — no raw `--body`/`-m`/`--title`/`--notes`/`--comment` secret persisted). **Field names are load-bearing for #3772 — do not rename.**

## Implementation

- New `log_guard_decision()` helper next to `log_hook_error()`, gated by a lazy/cached `decision_log_enabled()` toggle following the exact shape of the existing toggles (config read only fires once a deny/ask is about to occur).
- `deny()`/`ask()` take an optional stable rule-tag 2nd arg (defaults to the function name → backward-compatible); all ~13 call sites now pass a short machine-readable tag. Logging is emitted **before** the JSON decision and wrapped `|| true` so it can never suppress a decision or trip the ERR trap.
- **`allow` is never logged** (including the #3687 fast-path silent allow) — the toggle resolves lazily so the fast path's zero-overhead hot path is byte-for-byte unaffected.
- **Best-effort / fail-open**: a log-write failure never changes the decision or causes a non-zero exit (grouped-redirect so an unwritable path leaks nothing to stderr). `LOOM_GUARD_DECISION_LOG_FILE` overrides the write path (test seam). `.loom/logs/` is already gitignored.

## Tests

10 new cases in `tests/hooks/test-guard-destructive.sh`: deny logs a record (decision/tier/ts/pattern/command); ask logs a record; allow-only **and** fast-path silent-allow log nothing; log is separate from `hook-errors.log`; secret `-m` value logged **redacted**; default-off no growth; config-toggle-on; env-over-config precedence; fail-open still denies + exits 0. **Full suite: 380 passed, 0 failed** (was 370 — zero regressions).

## Summarize fires (fuller reader/aggregation CLI is #3772's scope)

```bash
jq -r '.pattern' .loom/logs/guard-decisions.log | sort | uniq -c | sort -rn
```

## Scope

Touches only the canonical `defaults/hooks/guard-destructive.sh`, its tests, and `defaults/CLAUDE.md`. The `.claude/skills/repo/hooks/` fork and `guard-loom-workflow.sh` are untouched (out of scope per the issue).

**Chain A base for #3772** (which stacks reader/aggregation tooling on this JSONL schema).

Closes #3771

🤖 Generated with [Claude Code](https://claude.com/claude-code)