### PR TITLE
feat(sweep): concurrent-/sweep run-state isolation + peer detection (#3768)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ Thumbs.db
 .loom/tokens/
 .loom/accounts.env
 .loom/sweep-checkpoint/
+.loom/sweep-run/
 .loom/stats/
 .loom/CANARY
 .loom/spawn-loop.pid

--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -577,9 +577,61 @@ The harvest parses each joined `agent-<id>.jsonl` transcript's `usage` blocks (i
 
 - **Do NOT write to `.loom/daemon-state.json`.** That file is owned by the standalone daemon. `/sweep` runs independently and must not race with the daemon on shepherd-slot bookkeeping. Reading `daemon-state.json` for situational awareness is fine; writing is not.
 
+## Sweep Run Identity + Peer-`/sweep` Detection (#3768)
+
+Before **any** other stage — including Backend detection (Stage -1), the dry-run gate, and all wave lifecycles — establish a **stable identity for this sweep invocation** and probe for a concurrently-running peer `/sweep`. This runs for **all modes (A, B, and C)** — it is *not* short-circuited by Mode C or `--no-daemon` (those only affect the Stage -1 backend probes below).
+
+This section exists because `/sweep` was originally hardened (#3373 checkpoints, #3648 baseline) assuming a single sweep instance per repo. Two concurrent `/sweep` runs in the same repo (observed live 2026-07-22) collided on shared run-state: they shared the single fixed main-clean baseline path (one clobbered the other's pre-sweep snapshot), and their checkpoints were indistinguishable because `task_id` was `sweep-$$` — the PID of each Bash *subshell*, which varies *within* a single sweep across tool calls, not a stable per-invocation id.
+
+### Step 0a: Generate the stable run id (once, at sweep start)
+
+Run this **exactly once**, before anything else:
+
+```bash
+RUN_ID=$(./.loom/scripts/sweep-run-registry.sh new)
+echo "sweep run id: $RUN_ID"
+```
+
+`sweep-run-registry.sh new` generates a portable (macOS/Linux, no `uuidgen`) run id combining a UTC timestamp + PID + random suffix (e.g. `sweep-20260722T231500Z-84213-a3f9c1`), and registers it under `.loom/sweep-run/<RUN_ID>.json` (gitignored) with a liveness PID (the orchestrator `$PPID`) for peer detection.
+
+**Treat the printed `RUN_ID` as a fixed literal for the entire rest of this sweep.** Thread it — as that literal string — into every `--task-id "$RUN_ID"` checkpoint write and into the main-clean baseline path below. Do **NOT** regenerate it per Bash tool call, and do **NOT** fall back to `sweep-$$` (that is the exact bug this fixes: `$$` is a fresh subshell PID on every tool call). If you ever lose track of the literal mid-sweep, recover it from the registry rather than minting a new one:
+
+```bash
+RUN_ID=$(./.loom/scripts/sweep-run-registry.sh list | awk -v p="$PPID" '$2==p {print $1; exit}')
+```
+
+At sweep completion (or abort), remove this run's registry entry:
+
+```bash
+./.loom/scripts/sweep-run-registry.sh cleanup "$RUN_ID"
+```
+
+This is best-effort cleanup — a dead run's entry is also pruned automatically by any later sweep's peer scan (dead-PID liveness check), so a crash that skips cleanup never leaves a permanent false-positive.
+
+### Step 0b: Peer-`/sweep` detection (loud, NON-BLOCKING)
+
+Immediately after registering, probe for other **live** `/sweep` runs in this repo and warn if any are found — never block, never auto-stop (mirroring the Daemon Coexistence contract):
+
+```bash
+PEERS=$(./.loom/scripts/sweep-run-registry.sh peers "$RUN_ID")
+if [[ -n "$PEERS" ]]; then
+  echo "⚠️  ANOTHER /sweep IS RUNNING IN THIS REPO:" >&2
+  echo "$PEERS" | while read -r rid pid ts; do
+    echo "       run $rid (pid $pid, started $ts)" >&2
+  done
+  echo "   Two concurrent sweeps merge into a moving default branch unaware of" >&2
+  echo "   each other. Per-issue loom:building claims still prevent double-builds," >&2
+  echo "   and each sweep now keys its own main-clean baseline + checkpoints by its" >&2
+  echo "   own RUN_ID, so they will not clobber each other's run-state — but you" >&2
+  echo "   should be aware both are advancing main. Proceeding (non-blocking)." >&2
+fi
+```
+
+The `peers` subcommand only reports runs whose recorded PID is still alive (`kill -0`); it prunes any dead-PID entry as a side effect, so a sweep killed with SIGKILL mid-run does not produce a false-positive warning forever. Empty output → no peer → the single-sweep case, no warning printed (byte-for-byte the prior behaviour). **Do not block, do not auto-stop the peer, do not abort** — the peer sweep is legitimate; this is situational awareness only. See "Coexistence (peer `/sweep` and legacy daemon)" for how this relates to the legacy daemon-PID check.
+
 ## Stage -1: Backend detection (Phase D of #3449)
 
-Before **any** other stage — including the dry-run gate and all wave lifecycles — decide whether to **delegate dispatch to the in-process loom-daemon** or **fall through to the existing in-process subagent dispatch**. This stage is prose for the LLM running this skill; it does not run a separate binary. Implementation is small, side-effect-free probes followed by a single routing decision.
+Before the dry-run gate and all wave lifecycles (but **after** Sweep Run Identity above), decide whether to **delegate dispatch to the in-process loom-daemon** or **fall through to the existing in-process subagent dispatch**. This stage is prose for the LLM running this skill; it does not run a separate binary. Implementation is small, side-effect-free probes followed by a single routing decision.
 
 This stage exists because Phase A of epic #3449 (#3452) shipped `mcp__loom__dispatch_sweep`, an MCP tool that queues a sweep on the daemon's spawn queue and returns immediately. When the daemon is reachable **and** a multi-account token pool is configured, dispatching to the daemon means each sweep runs in its own detached process with its own rotated OAuth token — load is balanced across accounts, and the orchestrator session exits sub-2-second after dispatch. When either precondition is missing, today's Mode A/B/C subagent path is the right choice — it works on a solo token, it doesn't depend on a running daemon, and it is the verified behaviour for the v0.9.x line.
 
@@ -819,7 +871,7 @@ These are the AC #3 and AC #4 contracts, written for the operator.
 - **Does not subscribe to the Phase B event bus.** Subscription is consumed by long-running monitors and the spawn loop, not by this skill. Phase D is dispatch-only.
 - **Does not retry probe failures.** Either probe returns within 500ms (or its natural latency) and is treated as authoritative; no retry, no backoff.
 - **Does not mutate any forge state** during the probes. `mcp__loom__list_sweeps` and the local pool checks are read-only. Even in the daemon path, mutation happens inside the daemon-side child sweep, not in this orchestrator session.
-- **Does not log to `.loom/daemon-state.json` or any daemon-owned state file.** Read-only access is fine for situational awareness; writes are forbidden (same constraint as the existing "Daemon Coexistence" section).
+- **Does not log to `.loom/daemon-state.json` or any daemon-owned state file.** Read-only access is fine for situational awareness; writes are forbidden (same constraint as the legacy-daemon subsection of "Coexistence (peer `/sweep` and legacy daemon)").
 
 ## 0. Dry-run gate (if `--dry-run`)
 
@@ -987,7 +1039,7 @@ Apply exactly one of the three branches below, based on the PR's current label:
   - **Approve** → PR labeled `loom:pr` by Judge. If a closing-issue checkpoint is in scope, write `judge-done`:
     ```bash
     # Append --model <resolved> when you passed a model param to the judge subagent (#3482).
-    ./.loom/scripts/sweep-checkpoint.sh write N judge-done --task-id "sweep-$$" --pr-number P
+    ./.loom/scripts/sweep-checkpoint.sh write N judge-done --task-id "$RUN_ID" --pr-number P
     ```
     Continue to **C2 (Merge)** for this PR.
   - **Request changes** → PR labeled `loom:changes-requested` by Judge. Continue to **C1b (Doctor → Judge)** for this PR (inline Doctor → Judge cycle(s), up to `sweep.max_doctor_cycles`, matching the issue-side cap).
@@ -1004,7 +1056,7 @@ If the PR entered the wave already labeled `loom:changes-requested` (e.g., from 
 - If a closing-issue checkpoint is in scope, write `doctor-done` (with the attempt counter and the model the Doctor actually ran on — escalated or pinned, #3482) **before** the follow-up Judge:
   ```bash
   # <attempt> is the cycle index + 1: 2 for the first Doctor cycle, 3 for the second, etc.
-  ./.loom/scripts/sweep-checkpoint.sh write N doctor-done --task-id "sweep-$$" --pr-number P --attempt <attempt> --model <doctor-model>
+  ./.loom/scripts/sweep-checkpoint.sh write N doctor-done --task-id "$RUN_ID" --pr-number P --attempt <attempt> --model <doctor-model>
   ```
 - Re-dispatch `loom-judge` for the PR (now `loom:review-requested` again).
 - Expected exit states:
@@ -1075,11 +1127,11 @@ See `.claude/commands/loom/shepherd-lifecycle.md` for the canonical phase-by-pha
 **Before dispatching the first wave's builders**, snapshot main's current working-tree state so the per-wave contamination backstop (step 4's `check-main-clean.sh`) can distinguish builder contamination from dirt that predated the sweep:
 
 ```bash
-MAIN_CLEAN_BASELINE=".loom/sweep-checkpoint/main-clean-baseline.txt"
+MAIN_CLEAN_BASELINE=".loom/sweep-checkpoint/main-clean-baseline-${RUN_ID}.txt"
 ./.loom/scripts/check-main-clean.sh --snapshot "$MAIN_CLEAN_BASELINE"
 ```
 
-Capture this **once, before wave 1 — never per-wave**. The baseline must reflect the pre-sweep state so that if an early wave contaminates main and the dirt is not reverted, every later wave's backstop still flags it (a per-wave re-snapshot would silently absorb that contamination into the "pre-existing" set). The baseline path is a gitignored per-sweep-run transient (`.loom/sweep-checkpoint/` is already gitignored); its lifetime is this sweep invocation. If the snapshot step fails for any reason, proceed anyway — step 4's backstop falls back to the whole-status hard-fail when the baseline file is missing (fail-safe, never a silent pass).
+Capture this **once, before wave 1 — never per-wave**. The baseline must reflect the pre-sweep state so that if an early wave contaminates main and the dirt is not reverted, every later wave's backstop still flags it (a per-wave re-snapshot would silently absorb that contamination into the "pre-existing" set). The baseline path is **keyed by this sweep's `RUN_ID`** (`main-clean-baseline-${RUN_ID}.txt`, not a fixed `main-clean-baseline.txt`) so that a **concurrent peer `/sweep` never reads or clobbers this run's baseline** (#3768): before the RUN_ID keying, a second sweep re-snapshotting the shared fixed path mid-run of the first could silently absorb real contamination into the "pre-existing" set. The path is a gitignored per-sweep-run transient (`.loom/sweep-checkpoint/` is already gitignored); its lifetime is this sweep invocation. `check-main-clean.sh` needs no change — it already accepts an arbitrary `--snapshot FILE` / `--baseline FILE` path; only this caller-side path construction is keyed by `RUN_ID`. If the snapshot step fails for any reason, proceed anyway — step 4's backstop falls back to the whole-status hard-fail when the baseline file is missing (fail-safe, never a silent pass).
 
 ### Checkpoint-driven resume (#3373)
 
@@ -1195,7 +1247,7 @@ For each surviving issue `N` in the wave:
 - **On successful completion** (curator ran, or curator-skip-because-already-curated), write the checkpoint:
   ```bash
   # Append --model <resolved> when you passed a model param to the curator subagent (#3482).
-  ./.loom/scripts/sweep-checkpoint.sh write N curator-done --task-id "sweep-$$"
+  ./.loom/scripts/sweep-checkpoint.sh write N curator-done --task-id "$RUN_ID"
   ```
 
 Curator runs sequentially per-issue within wave setup — it is cheap and does not benefit from parallelism here.
@@ -1252,7 +1304,7 @@ If it exits `3`, the main worktree carries **new** uncommitted changes a builder
 **On successful PR creation**, write the `builder-done` checkpoint for that issue (record the PR number):
 ```bash
 # Append --model <resolved> when you passed a model param to the builder subagent (#3482).
-./.loom/scripts/sweep-checkpoint.sh write N builder-done --task-id "sweep-$$" --pr-number <PR>
+./.loom/scripts/sweep-checkpoint.sh write N builder-done --task-id "$RUN_ID" --pr-number <PR>
 ```
 
 If the builder failed (no PR opened), do NOT write a checkpoint — leave the checkpoint at the previous phase (typically `curator-done`) so the next sweep retries the builder from scratch.
@@ -1331,7 +1383,7 @@ post_wave_integration_gate()                    # step 8 — buildGate-against-m
   - **Approve** → PR labeled `loom:pr`. Write the `judge-done` checkpoint for this issue (carrying the PR number), then continue to Merge (step 7) for this PR, then advance to the next PR in the wave.
     ```bash
     # Append --model <resolved> when you passed a model param to the judge subagent (#3482).
-    ./.loom/scripts/sweep-checkpoint.sh write N judge-done --task-id "sweep-$$" --pr-number <PR>
+    ./.loom/scripts/sweep-checkpoint.sh write N judge-done --task-id "$RUN_ID" --pr-number <PR>
     ```
   - **Request changes** → PR labeled `loom:changes-requested`. Continue to Doctor (step 6) **inline for this PR**, then re-judge, then merge or block. Do **not** write a `judge-done` checkpoint here — the PR is not yet approved, and a resume after a kill should re-enter Doctor, not skip Judge.
 
@@ -1348,7 +1400,7 @@ If Judge requests changes on PR `#X` mid-wave, run inline Doctor→Judge cycles 
 - **On successful Doctor completion**, write the `doctor-done` checkpoint for the issue (carrying the PR number, the attempt counter, and the model the Doctor actually ran on — escalated or pinned, #3482) **before** re-invoking Judge:
   ```bash
   # <attempt> is the cycle index + 1: 2 for the first Doctor cycle, 3 for the second, etc.
-  ./.loom/scripts/sweep-checkpoint.sh write N doctor-done --task-id "sweep-$$" --pr-number <PR> --attempt <attempt> --model <doctor-model>
+  ./.loom/scripts/sweep-checkpoint.sh write N doctor-done --task-id "$RUN_ID" --pr-number <PR> --attempt <attempt> --model <doctor-model>
   ```
   This way, if sweep is killed between Doctor and the follow-up Judge, the resume run will see `doctor-done` and re-enter at the Judge phase (step 5), not redo the Doctor work.
 - On completion, re-label the PR from `loom:changes-requested` back to `loom:review-requested` and **re-run the Judge phase** (step 5) for this PR.
@@ -1497,11 +1549,27 @@ This is advisory-only. The script always exits `0` and **must not block** the sw
 
 If the check warns, the operator should refresh local `main` (and re-sync installed copies if their install flow does so) before relying on stacked-dependency or auto-reconcile behavior mid-sweep.
 
-## Daemon Coexistence
+## Coexistence (peer `/sweep` and legacy daemon)
+
+`/sweep` coexists with two **distinct** kinds of other runner, detected by two **separate** mechanisms. Do not conflate them: "another `/sweep` is running" (peer detection, #3768) is not the same as "the legacy daemon is running" (daemon-PID check). Both warnings are **loud but non-blocking** — warn once, never auto-stop, never block.
+
+### Peer `/sweep` detection (#3768)
+
+The primary coexistence case in the current architecture is **another live `/sweep` invocation in the same repo**. This is handled at sweep start by "Sweep Run Identity + Peer-`/sweep` Detection" (Step 0b, above): `sweep-run-registry.sh peers "$RUN_ID"` lists other runs whose registered liveness PID is still alive (pruning dead-PID entries so a SIGKILL'd peer never warns forever), and a loud non-blocking warning fires when any are found.
+
+Two concurrent sweeps are now **run-state isolated**, not just label-isolated:
+
+- **Per-issue `loom:building` claims** (step 1 pre-flight) already prevent two sweeps from building the same issue — if a peer claimed an issue first, this sweep sees `loom:building` and skips. The existing-PR probe (#3359) is the complementary defense when a PR exists but the `loom:building` label was never set / since removed.
+- **Main-clean baseline** is keyed by `RUN_ID` (`main-clean-baseline-${RUN_ID}.txt`), so a peer sweep's `--snapshot` can never clobber this run's pre-sweep baseline (the #3648 contamination backstop stays correct under concurrency).
+- **Checkpoints** carry this run's `RUN_ID` as `task_id`, so a sweep can tell its own `.loom/sweep-checkpoint/issue-<N>.json` writes apart from a peer's.
+
+What remains a shared, un-isolated surface is the **default branch itself**: both sweeps merge into a moving `main`, unaware of each other's in-flight PRs. The peer warning exists so the operator knows that; isolating the merge target is out of scope for #3768 (stacking is #3759's concern).
+
+### Legacy daemon coexistence
 
 > **Note**: the legacy `./.loom/scripts/daemon.sh` was removed in #3432 and is not restored. The historical PID-file daemon (`.loom/daemon-loop.pid`) is not part of the current architecture; the check below is a defensive coexistence guard that fires only if such a process is somehow already running — normally a no-op. The Tier 2 dispatch backend is now the Rust `loom-daemon` binary (observed via `mcp__loom__list_sweeps`); the background agent-pool control surface is `.loom/bin/loom start|status|stop`.
 
-`/sweep` does not require the daemon and does not interact with `.loom/daemon-state.json` for writes. If a legacy daemon process is running, `/sweep` and the daemon may both try to claim the same `loom:issue` label.
+`/sweep` does not require the daemon and does not interact with `.loom/daemon-state.json` for writes. If a legacy daemon process is running, `/sweep` and the daemon may both try to claim the same `loom:issue` label. This is a **different** mechanism from peer-`/sweep` detection above — the daemon is identified by its own `.loom/daemon-loop.pid`, not by the `.loom/sweep-run/` registry.
 
 **Coexistence behavior:** before the first wave, check whether the daemon is running. If it is, warn the user once at the start of the sweep:
 
@@ -1514,9 +1582,7 @@ if [[ -n "$PID" ]] && kill -0 "$PID" 2>/dev/null; then
 fi
 ```
 
-Do not auto-stop the daemon. Do not block on this warning — proceed with the sweep.
-
-Per-issue, the pre-flight check (step 1) already detects `loom:building` and skips, which is the natural defense against races: if the daemon claimed an issue first, `/sweep` will see `loom:building` and skip. The existing-PR probe (#3359) is the complementary defense for the case where a human or prior shepherd opened a PR but the `loom:building` label was never set or has since been removed — sweep will route the existing PR to Judge/Merge rather than spawn a duplicate Builder.
+Do not auto-stop the daemon. Do not block on this warning — proceed with the sweep. The same dead-PID liveness pattern (`kill -0`) is used by peer-`/sweep` detection.
 
 ## Constraints
 
@@ -1545,6 +1611,7 @@ The full `/sweep` design in #3298 includes many features that are intentionally 
 | Checkpoint/resume after kill | **Implemented (#3373)** | Per-issue phase checkpoint at `.loom/sweep-checkpoint/issue-<N>.json`. Sweep reads on entry and skips completed phases. No mid-builder recovery — kill during Builder resumes at builder start, worktree preserved by `worktree.sh` idempotency. Mode C reuses the helper keyed by the PR's closing-issue number (`closingIssuesReferences`); PRs without a `Closes #N` reference run without checkpointing. |
 | PR-set mode (`--prs` flag and PR NL triggers; Judge/Doctor/Merge from current PR label) | **Implemented (#3384)** | Mode C. Skips Curator, Approval gate, Builder. Size-1 waves. `--builders-per-wave` ignored. Reuses issue-keyed checkpoint via `closingIssuesReferences`. |
 | Daemon backend detection (Stage -1) | **Implemented (#3454)** | Strict-AND between daemon reachability and multi-account pool. Mode C and `--no-daemon` short-circuit to subagent. No implicit auto-start. Dispatch-only — Phase D does not subscribe to the event bus. See "Stage -1: Backend detection". |
+| Concurrent-`/sweep` run-state isolation + peer detection | **Implemented (#3768)** | A stable per-sweep-run id (`sweep-run-registry.sh new`) is generated once at sweep start and threaded through all `--task-id` checkpoint writes and the main-clean baseline path (`main-clean-baseline-${RUN_ID}.txt`), so two concurrent sweeps no longer clobber each other's baseline or share an ambiguous `sweep-$$` `task_id`. Stage 0b adds a loud, NON-BLOCKING peer-`/sweep` warning via a dead-PID-pruned run registry (`.loom/sweep-run/`). Merge-target (default-branch) isolation is out of scope — that is #3759's stacking concern. See "Sweep Run Identity + Peer-`/sweep` Detection". |
 | `--max-waves` cap | Deferred | Operator-level brake on long sweeps. |
 | `--paused-merge` / `--no-judge` | Deferred | Merge-mode variants for trusted batches. |
 | `--include-blocked` (unblock pass) | Deferred | Currently `/sweep` skips `loom:blocked` issues outright. |

--- a/defaults/scripts/sweep-checkpoint.sh
+++ b/defaults/scripts/sweep-checkpoint.sh
@@ -13,12 +13,21 @@
 # Checkpoint file format (atomic write via .tmp + mv):
 #   {
 #     "phase": "<curator-done|builder-done|judge-done|doctor-done|merge-done>",
-#     "task_id": "<task identifier, e.g. sweep PID>",
+#     "task_id": "<stable per-sweep-run id>",
 #     "timestamp": "<ISO 8601 UTC>",
 #     "pr_number": <int or null>,
 #     "attempt": <int, optional - omitted when not provided; absent means attempt 1>,
 #     "model": "<string, optional - omitted when not provided; absent means default/unknown>"
 #   }
+#
+# The "task_id" field (#3768) identifies the sweep RUN that wrote the checkpoint.
+# It must be a STABLE per-sweep-run id (generated once at sweep start — see
+# sweep-run-registry.sh), NOT the PID of a Bash subshell. The historical
+# `sweep-$$` default was the wrong mental model: `$$` is re-evaluated per Bash
+# tool call within a single sweep, so it could not distinguish one sweep's
+# checkpoints from a concurrent peer sweep's. Callers (defaults/.claude/commands/
+# loom/sweep.md) now pass a stable `--task-id "$RUN_ID"`; the field is free-form,
+# so legacy checkpoints carrying a `sweep-<pid>` task_id still parse cleanly.
 #
 # The "attempt" field (#3481) is forward-compat bookkeeping for model
 # escalation: attempt 1 is the first Builder pass, attempt 2 is the Doctor
@@ -124,7 +133,11 @@ cmd_write() {
         esac
     done
 
-    [[ -z "$task_id" ]] && task_id="sweep-$$"
+    # Last-resort fallback ONLY: sweep.md always passes a stable --task-id "$RUN_ID"
+    # (see sweep-run-registry.sh). This default exists so a bare/manual write still
+    # produces a parseable checkpoint; `sweep-run-$$` is deliberately labelled a
+    # fallback rather than masquerading as a stable per-run id.
+    [[ -z "$task_id" ]] && task_id="sweep-run-fallback-$$"
     if [[ "$pr_number" != "null" && ! "$pr_number" =~ ^[0-9]+$ ]]; then
         echo "ERROR: --pr-number must be a positive integer or 'null'" >&2
         exit 1

--- a/defaults/scripts/sweep-run-registry.sh
+++ b/defaults/scripts/sweep-run-registry.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+
+# sweep-run-registry.sh - Stable per-sweep-run identity + lightweight peer registry.
+#
+# Purpose (#3768): give a single `/loom:sweep` invocation ONE stable run id that
+# is fixed for the whole sweep, rather than the historical `sweep-$$` — which is
+# the PID of each Bash *subshell* and therefore varies within a single sweep
+# across tool calls. That instability meant:
+#   - concurrent sweeps could not tell their own checkpoints apart from a peer's,
+#   - the main-clean baseline path (a fixed constant) was clobbered when a second
+#     sweep re-snapshotted it mid-run of the first.
+#
+# This helper provides:
+#   - `new`     — generate + register a stable run id once, at sweep start.
+#   - `peers`   — list OTHER live registered sweeps (dead-PID entries are pruned),
+#                 so Stage -1 can print a loud, NON-BLOCKING peer-/sweep warning.
+#   - `cleanup` — remove this run's own entry (and prune dead peers) at sweep end.
+#   - `list`    — dump all registry entries (debug).
+#
+# The run id is portable (macOS/Linux, no `uuidgen`): a compact UTC timestamp, a
+# PID component, and a random suffix, e.g.
+#   sweep-20260722T231500Z-84213-a3f9c1
+# It is a free-form string suitable for a checkpoint `task_id` and for embedding
+# in a filename (charset restricted to [A-Za-z0-9-]).
+#
+# Registry entry (atomic write via .tmp + mv):
+#   .loom/sweep-run/<RUN_ID>.json
+#   {
+#     "run_id": "<RUN_ID>",
+#     "pid": <liveness PID>,
+#     "timestamp": "<ISO 8601 UTC>"
+#   }
+#
+# The "pid" is the LIVENESS handle for peer detection: `peers` treats an entry as
+# a live peer only when `kill -0 <pid>` succeeds, and prunes the entry otherwise —
+# the same pattern as the legacy `.loom/daemon-loop.pid` check. It defaults to the
+# invoking process's parent PID ($PPID, i.e. the long-lived orchestrator/session
+# process that outlives each ephemeral Bash tool call), overridable with `--pid`.
+#
+# Usage:
+#   sweep-run-registry.sh new [--pid P]     # print a fresh RUN_ID, register it
+#   sweep-run-registry.sh peers <RUN_ID>    # print live peers (one per line), prune dead
+#   sweep-run-registry.sh cleanup <RUN_ID>  # remove own entry + prune dead peers
+#   sweep-run-registry.sh list              # print all entries (run_id pid timestamp)
+#
+# `peers` output format (one live peer per line):
+#   <run_id> <pid> <timestamp>
+# Empty output means "no live peer sweeps" — the single-sweep (no-peer) case.
+#
+# Exit codes:
+#   0 - success (including "no peers found")
+#   1 - usage error
+
+set -euo pipefail
+
+usage() {
+    sed -n '3,55p' "$0" | sed 's/^# \{0,1\}//'
+    exit 1
+}
+
+# Resolve repo root (handles invocation from worktree subdirs, mirroring
+# sweep-checkpoint.sh so both helpers agree on where .loom/ lives).
+repo_root() {
+    git rev-parse --show-toplevel 2>/dev/null || pwd
+}
+
+registry_dir() {
+    echo "$(repo_root)/.loom/sweep-run"
+}
+
+ensure_dir() {
+    mkdir -p "$(registry_dir)"
+}
+
+iso_now() {
+    date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+# Extract a string field value from a registry JSON file (no jq dependency).
+json_field() {
+    local file="$1" field="$2"
+    sed -n "s/.*\"${field}\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" "$file" | head -n1
+}
+
+# Extract a numeric field value from a registry JSON file (no jq dependency).
+json_num() {
+    local file="$1" field="$2"
+    sed -n "s/.*\"${field}\"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p" "$file" | head -n1
+}
+
+# Generate a stable, portable, filename-safe run id.
+gen_run_id() {
+    local ts pidpart rand
+    ts=$(date -u +"%Y%m%dT%H%M%SZ")
+    pidpart="$$"
+    # Two 16-bit RANDOM draws → 8 hex chars of entropy (bash builtin, portable).
+    rand=$(printf '%04x%04x' "$((RANDOM))" "$((RANDOM))")
+    echo "sweep-${ts}-${pidpart}-${rand}"
+}
+
+cmd_new() {
+    local pid="${PPID:-$$}"
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --pid)
+                pid="${2:-}"
+                shift 2
+                ;;
+            *)
+                echo "ERROR: unknown flag '$1'" >&2
+                exit 1
+                ;;
+        esac
+    done
+    if [[ -z "$pid" || ! "$pid" =~ ^[0-9]+$ ]]; then
+        echo "ERROR: --pid must be a positive integer (got: '$pid')" >&2
+        exit 1
+    fi
+
+    local run_id target tmp
+    run_id=$(gen_run_id)
+    ensure_dir
+    target="$(registry_dir)/${run_id}.json"
+    tmp="${target}.tmp.$$"
+
+    cat > "$tmp" <<EOF
+{
+  "run_id": "$run_id",
+  "pid": $pid,
+  "timestamp": "$(iso_now)"
+}
+EOF
+    mv "$tmp" "$target"
+
+    # The RUN_ID is the load-bearing output: the caller captures it and threads it
+    # (as a literal) through every subsequent --task-id / baseline path in the sweep.
+    echo "$run_id"
+}
+
+# Prune any entry whose recorded PID is no longer alive. Optionally skip a
+# specific run id (the caller's own, handled separately).
+prune_dead() {
+    local skip="${1:-}"
+    local dir file rid pid
+    dir="$(registry_dir)"
+    [[ -d "$dir" ]] || return 0
+    for file in "$dir"/*.json; do
+        [[ -e "$file" ]] || continue
+        rid=$(json_field "$file" run_id)
+        [[ -n "$skip" && "$rid" == "$skip" ]] && continue
+        pid=$(json_num "$file" pid)
+        if [[ -z "$pid" ]] || ! kill -0 "$pid" 2>/dev/null; then
+            rm -f "$file"
+        fi
+    done
+}
+
+cmd_peers() {
+    local self="${1:-}"
+    if [[ -z "$self" ]]; then
+        echo "ERROR: peers requires a RUN_ID argument" >&2
+        exit 1
+    fi
+    local dir file rid pid ts
+    dir="$(registry_dir)"
+    [[ -d "$dir" ]] || return 0
+    for file in "$dir"/*.json; do
+        [[ -e "$file" ]] || continue
+        rid=$(json_field "$file" run_id)
+        # Skip our own entry.
+        [[ "$rid" == "$self" ]] && continue
+        pid=$(json_num "$file" pid)
+        if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+            ts=$(json_field "$file" timestamp)
+            echo "$rid $pid $ts"
+        else
+            # Dead peer — prune so it never produces a false-positive warning forever.
+            rm -f "$file"
+        fi
+    done
+}
+
+cmd_cleanup() {
+    local self="${1:-}"
+    if [[ -z "$self" ]]; then
+        echo "ERROR: cleanup requires a RUN_ID argument" >&2
+        exit 1
+    fi
+    local target
+    target="$(registry_dir)/${self}.json"
+    rm -f "$target"
+    # Opportunistically prune any dead peers too.
+    prune_dead "$self"
+}
+
+cmd_list() {
+    local dir file rid pid ts
+    dir="$(registry_dir)"
+    [[ -d "$dir" ]] || return 0
+    for file in "$dir"/*.json; do
+        [[ -e "$file" ]] || continue
+        rid=$(json_field "$file" run_id)
+        pid=$(json_num "$file" pid)
+        ts=$(json_field "$file" timestamp)
+        echo "$rid $pid $ts"
+    done
+}
+
+main() {
+    local cmd="${1:-}"
+    shift || true
+    case "$cmd" in
+        new)     cmd_new "$@" ;;
+        peers)   cmd_peers "$@" ;;
+        cleanup) cmd_cleanup "$@" ;;
+        list)    cmd_list "$@" ;;
+        -h|--help|"") usage ;;
+        *) echo "ERROR: unknown command '$cmd'" >&2; usage ;;
+    esac
+}
+
+main "$@"

--- a/defaults/scripts/tests/test-sweep-checkpoint.sh
+++ b/defaults/scripts/tests/test-sweep-checkpoint.sh
@@ -302,6 +302,41 @@ assert "write doctor-done with --attempt 6 (raised cap)" "$CHECKPOINT" write 71 
 out=$("$CHECKPOINT" attempt 71)
 assert_eq "attempt command reads back 6" "6" "$out"
 
+# --- Stable per-sweep-run task_id (#3768) ---
+# sweep.md now threads a stable RUN_ID as --task-id at every call site. The
+# checkpoint round-trips an arbitrary stable id, and the omitted-flag fallback
+# still yields a parseable checkpoint (last-resort only).
+
+# 35. A stable run id passed as --task-id round-trips into the JSON verbatim.
+STABLE_RID="sweep-20260722T231500Z-84213-a3f9c1"
+assert "write with stable RUN_ID task-id" "$CHECKPOINT" write 80 builder-done --task-id "$STABLE_RID" --pr-number 800
+out=$("$CHECKPOINT" read 80)
+if echo "$out" | grep -q "\"task_id\": \"$STABLE_RID\""; then
+    echo "PASS: stable RUN_ID persisted verbatim as task_id"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: stable RUN_ID task_id missing/wrong: $out" >&2
+    FAIL=$((FAIL + 1))
+fi
+
+# 36. Legacy sweep-<pid> task_id still parses cleanly (free-form field, no schema change).
+"$CHECKPOINT" write 81 curator-done --task-id "sweep-12345" >/dev/null
+out=$("$CHECKPOINT" phase 81)
+assert_eq "legacy sweep-<pid> task_id checkpoint still reads phase" "curator-done" "$out"
+
+# 37. Omitted --task-id falls back to a parseable (clearly-labelled fallback) id.
+"$CHECKPOINT" write 82 curator-done >/dev/null
+out=$("$CHECKPOINT" read 82)
+if echo "$out" | grep -Eq '"task_id": "sweep-run-fallback-[0-9]+"'; then
+    echo "PASS: omitted --task-id uses labelled fallback default"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: fallback task_id default unexpected: $out" >&2
+    FAIL=$((FAIL + 1))
+fi
+out=$("$CHECKPOINT" phase 82)
+assert_eq "fallback-default checkpoint still reads phase" "curator-done" "$out"
+
 echo
 echo "Results: $PASS passed, $FAIL failed"
 [[ $FAIL -eq 0 ]] || exit 1

--- a/defaults/scripts/tests/test-sweep-run-registry.sh
+++ b/defaults/scripts/tests/test-sweep-run-registry.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+# test-sweep-run-registry.sh - Smoke tests for the sweep run-identity registry (#3768).
+#
+# Exercises `new` (stable run id generation + registration), `peers` (live-peer
+# listing + dead-PID pruning), `cleanup`, and `list`, plus the concurrency
+# properties the /sweep skill relies on:
+#   - each `new` yields a distinct run id (concurrent sweeps don't collide),
+#   - a run never lists itself as a peer,
+#   - a dead-PID entry is pruned and never warns forever,
+#   - the run id is filename/JSON-safe.
+#
+# Run from anywhere — uses an isolated TMPDIR so it never touches a real
+# workspace's .loom/sweep-run/.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="$SCRIPT_DIR/../sweep-run-registry.sh"
+
+if [[ ! -x "$HELPER" ]]; then
+    echo "FAIL: helper not executable at $HELPER" >&2
+    exit 1
+fi
+
+TMP_REPO="$(mktemp -d)"
+# Spawned long-lived helper PIDs we must reap on exit.
+LIVE_PIDS=()
+cleanup() {
+    local p
+    for p in "${LIVE_PIDS[@]:-}"; do
+        [[ -n "$p" ]] && kill "$p" 2>/dev/null
+    done
+    rm -rf "$TMP_REPO"
+}
+trap cleanup EXIT
+
+cd "$TMP_REPO" || exit 1
+git init -q .
+mkdir -p .loom/scripts
+cp "$HELPER" .loom/scripts/sweep-run-registry.sh
+chmod +x .loom/scripts/sweep-run-registry.sh
+REG="$TMP_REPO/.loom/scripts/sweep-run-registry.sh"
+
+PASS=0
+FAIL=0
+assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $desc (expected '$expected', got '$actual')" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+assert_exit() {
+    local desc="$1" expected="$2"; shift 2
+    "$@" >/dev/null 2>&1
+    local actual=$?
+    if [[ $actual -eq $expected ]]; then
+        echo "PASS: $desc (exit $actual)"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $desc (expected exit $expected, got $actual)" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Spawn a durable background process we control the lifetime of; echo its PID.
+# Redirect the child's stdio to /dev/null so it does not hold the command-
+# substitution pipe open (a backgrounded proc inside $() otherwise blocks until
+# its stdout closes). The array append happens in the PARENT after each call —
+# a $()-subshell append would be lost — so the EXIT trap can reap every child.
+spawn_live() {
+    sleep 300 >/dev/null 2>&1 &
+    echo "$!"
+}
+
+# 1. `new` prints a run id in the documented shape.
+LIVE1=$(spawn_live); LIVE_PIDS+=("$LIVE1")
+RID1=$("$REG" new --pid "$LIVE1")
+if [[ "$RID1" =~ ^sweep-[0-9]{8}T[0-9]{6}Z-[0-9]+-[0-9a-f]{8}$ ]]; then
+    echo "PASS: run id matches expected portable shape ($RID1)"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: run id has unexpected shape: $RID1" >&2
+    FAIL=$((FAIL + 1))
+fi
+
+# 2. run id is filename/JSON-safe (charset [A-Za-z0-9-]).
+if [[ "$RID1" =~ ^[A-Za-z0-9-]+$ ]]; then
+    echo "PASS: run id is filename/JSON-safe"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: run id contains unsafe chars: $RID1" >&2
+    FAIL=$((FAIL + 1))
+fi
+
+# 3. registration wrote a gitignored registry file.
+if [[ -f "$TMP_REPO/.loom/sweep-run/${RID1}.json" ]]; then
+    echo "PASS: registry file created for run 1"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: registry file missing for run 1" >&2
+    FAIL=$((FAIL + 1))
+fi
+
+# 4. Two `new` calls yield distinct run ids (concurrent sweeps don't collide).
+LIVE2=$(spawn_live); LIVE_PIDS+=("$LIVE2")
+RID2=$("$REG" new --pid "$LIVE2")
+if [[ "$RID1" != "$RID2" ]]; then
+    echo "PASS: distinct run ids across two new calls"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: two new calls produced the same run id: $RID1" >&2
+    FAIL=$((FAIL + 1))
+fi
+
+# 5. A run never lists itself as a peer.
+out=$("$REG" peers "$RID1")
+if echo "$out" | grep -q "$RID1"; then
+    echo "FAIL: run listed itself as a peer: $out" >&2
+    FAIL=$((FAIL + 1))
+else
+    echo "PASS: run does not list itself as a peer"
+    PASS=$((PASS + 1))
+fi
+
+# 6. peers of RID1 report RID2 as a live peer (pid + timestamp columns present).
+out=$("$REG" peers "$RID1")
+if echo "$out" | grep -q "^$RID2 $LIVE2 "; then
+    echo "PASS: live peer reported with pid and timestamp"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: expected live peer $RID2 (pid $LIVE2), got: $out" >&2
+    FAIL=$((FAIL + 1))
+fi
+
+# 7. Kill peer 2 → it is no longer a live peer AND its entry is pruned.
+kill "$LIVE2" 2>/dev/null
+wait "$LIVE2" 2>/dev/null
+out=$("$REG" peers "$RID1")
+assert_eq "no live peers after peer killed" "" "$out"
+if [[ -f "$TMP_REPO/.loom/sweep-run/${RID2}.json" ]]; then
+    echo "FAIL: dead peer entry not pruned (would warn forever)" >&2
+    FAIL=$((FAIL + 1))
+else
+    echo "PASS: dead-PID peer entry pruned"
+    PASS=$((PASS + 1))
+fi
+
+# 8. list shows only the surviving run 1.
+out=$("$REG" list)
+if echo "$out" | grep -q "^$RID1 " && ! echo "$out" | grep -q "$RID2"; then
+    echo "PASS: list shows surviving run only"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: list unexpected after prune: $out" >&2
+    FAIL=$((FAIL + 1))
+fi
+
+# 9. cleanup removes the run's own entry.
+"$REG" cleanup "$RID1"
+if [[ -f "$TMP_REPO/.loom/sweep-run/${RID1}.json" ]]; then
+    echo "FAIL: cleanup did not remove own entry" >&2
+    FAIL=$((FAIL + 1))
+else
+    echo "PASS: cleanup removed own entry"
+    PASS=$((PASS + 1))
+fi
+
+# 10. peers on an empty/nonexistent registry is empty, exit 0 (single-sweep case).
+out=$("$REG" peers "sweep-nonexistent")
+assert_eq "peers empty when no registry entries" "" "$out"
+assert_exit "peers exits 0 with no entries" 0 "$REG" peers "sweep-nonexistent"
+
+# 11. peers without a RUN_ID arg is a usage error (exit 1).
+assert_exit "peers requires RUN_ID arg" 1 "$REG" peers
+
+# 12. new rejects a non-numeric --pid.
+assert_exit "new rejects non-numeric --pid" 1 "$REG" new --pid abc
+
+# 13. cleanup of an already-absent entry is a no-op (exit 0).
+assert_exit "cleanup of missing entry exits 0" 0 "$REG" cleanup "$RID1"
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
Closes #3768

**Chain B MIDDLE — STACKED on #3770's branch** (`feature/issue-3770`, PR #3775). Base is intentionally `feature/issue-3770`, NOT `main`, so this builds on #3770's main-freshness advisory without redoing it. `feature/issue-3768` is the Chain B base for #3759.

## Problem

Two concurrent `/loom:sweep` runs (observed live 2026-07-22) collided on shared run-state:
1. **Shared, non-keyed main-clean baseline** — both used the fixed `main-clean-baseline.txt`; sweep #2's re-snapshot clobbered sweep #1's pre-sweep baseline, which can silently absorb real contamination into the `#3648` "pre-existing" set.
2. **`task_id` was `sweep-$$`** — the PID of each Bash *subshell*, re-evaluated per tool call, so a sweep couldn't tell its own checkpoints from a peer's.
3. **No peer-`/sweep` detection** — the coexistence preflight only checked the legacy `.loom/daemon-loop.pid`.

## Scope landed: **Slice A + Slice B** (both, per the Curator's recommended v1)

The two slices share the stable run-id core, so they landed cohesively in one reviewable PR.

### Slice A — isolation
- New `defaults/scripts/sweep-run-registry.sh`: generates a stable, portable (macOS/Linux, no `uuidgen`) per-sweep-run id **once** at sweep start (`sweep-<UTC>-<pid>-<rand>`) and registers it under `.loom/sweep-run/<RUN_ID>.json` with a liveness PID.
- `sweep.md`: new **"Sweep Run Identity + Peer-`/sweep` Detection"** stage (before Stage -1, runs for **all** modes) generates `RUN_ID` and threads it as a literal through all **six** `--task-id` checkpoint writes (replacing `sweep-$$`) and the main-clean baseline path (`main-clean-baseline-${RUN_ID}.txt`).
- `sweep-checkpoint.sh`: corrected the `task_id` header comment (was "e.g. sweep PID" — the wrong mental model) and labelled the omitted-flag default as a last-resort fallback. Field stays free-form — legacy `sweep-<pid>` checkpoints parse cleanly.

### Slice B — detection
- `sweep.md` Stage 0b: **loud but NON-BLOCKING** peer-`/sweep` warning via `sweep-run-registry.sh peers`, which prunes dead-PID entries (same `kill -0` liveness pattern as `.loom/daemon-loop.pid`) so a SIGKILL'd peer never warns forever.
- Renamed/expanded the **"Daemon Coexistence"** section to **"Coexistence (peer `/sweep` and legacy daemon)"**, documenting the two mechanisms as distinct.

`check-main-clean.sh` needs **no** change — it already accepts an arbitrary `--snapshot`/`--baseline FILE` path; only caller-side path construction in `sweep.md` is keyed by `RUN_ID`.

## Out of scope (honest)
- **Merge-target (default-branch) isolation** — two sweeps still merge into a moving `main`. That is #3759's stacking concern, not #3768's detection/isolation concern.

## Tests
- New `defaults/scripts/tests/test-sweep-run-registry.sh` — 15/15 (run id shape/safety, distinct ids across `new`, no-self-peer, live-peer reporting, **dead-PID prune**, cleanup, usage errors).
- Extended `test-sweep-checkpoint.sh` — 62/62 (stable-`RUN_ID` verbatim round-trip, legacy `sweep-<pid>` still parses, labelled fallback default).
- Regression-checked `test-check-main-clean` (17/17), `test-check-main-freshness` (15/15, #3770), `test-sweep-pr-mode` (58/58).
- `shellcheck` clean on all changed scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)