### PR TITLE
fix(mcp): rebuild stale mcp-loom bundle + staleness guard in setup-mcp.sh (#3803)

### DIFF
--- a/.loom/docs/troubleshooting.md
+++ b/.loom/docs/troubleshooting.md
@@ -255,6 +255,32 @@ The pre-v0.10.0 indicators `missing_milestone:worktree_created` and `extended_wo
 
 Multi-issue dispatch is driven by the Rust `loom-daemon` binary via `mcp__loom__dispatch_sweep`. The daemon holds the sweep registry, event bus, and reaper in memory — there is no on-disk orchestration state file to inspect. (The v0.9.x `spawn-loop.sh` and its `.loom/spawn-loop-state.json` state file were removed in v0.11.0.)
 
+### Sweep MCP tools missing (stale dist bundle)
+
+**Symptom**: `mcp__loom__dispatch_sweep`, `mcp__loom__list_sweeps`, `mcp__loom__get_sweep_status`, `mcp__loom__tail_sweep_log`, `mcp__loom__cancel_sweep`, `mcp__loom__publish_event`, `mcp__loom__subscribe_to_events`, or `mcp__loom__tail_event_bus` are **not offered** in a live session — `/loom:sweep`'s Stage -1 daemon probe can't reach them even though `loom-daemon` is running.
+
+**Cause**: the MCP client loads the **built bundle** `mcp-loom/dist/index.js`, never the TypeScript source. `dist/` is gitignored, so a checkout that predates the sweep tools (Phase A #3452 / Phase C #3455) keeps serving an old bundle. The source (`mcp-loom/src/index.ts` → `sweepTools`) is correct; the on-disk artifact is stale (#3803).
+
+**Diagnose**:
+
+```bash
+# 0 means the sweep tools are absent from the built bundle -> stale
+grep -c dispatch_sweep mcp-loom/dist/index.js
+
+# Compare build vs source timestamps
+ls -la mcp-loom/dist/index.js
+find mcp-loom/src -type f -newer mcp-loom/dist/index.js   # any output => dist is stale
+```
+
+**Fix** — rebuild, then **reconnect**:
+
+```bash
+cd mcp-loom && npm install && npm run build
+grep -c dispatch_sweep dist/index.js   # should now be > 0
+```
+
+`scripts/setup-mcp.sh` now auto-rebuilds when `dist/index.js` is missing **or** older than any file under `mcp-loom/src/` (#3803), so `./scripts/setup-mcp.sh` is the safe one-shot path. Rebuilding the bundle does **not** refresh an already-running session — an MCP client caches its tool list at connect time, so you must **restart the Claude Code session** (or respawn the `loom` MCP subprocess) for the new tools to appear. See [`mcp-loom/README.md`](../../mcp-loom/README.md#rebuilding-after-source-changes-reconnect-required) for the full rebuild + reconnect procedure and a raw `tools/list` verification snippet.
+
 ### Inspect running sweeps
 
 ```bash

--- a/mcp-loom/README.md
+++ b/mcp-loom/README.md
@@ -35,9 +35,9 @@ Add to your MCP settings (`.mcp.json` or Claude Desktop config):
 | `LOOM_WORKSPACE` | Path to the Loom workspace | `~/GitHub/loom` |
 | `LOOM_SOCKET_PATH` | Path to daemon socket | `~/.loom/loom-daemon.sock` |
 
-## Available Tools (19 total)
+## Available Tools (27 total)
 
-The MCP server provides 19 essential tools organized by function.
+The MCP server provides 27 tools organized by function.
 
 ### UI/Engine Control (6 tools)
 
@@ -67,6 +67,26 @@ The MCP server provides 19 essential tools organized by function.
 | `stop_autonomous_mode` | Stop autonomous mode |
 | `launch_interval` | Trigger interval prompt manually |
 | `get_agent_metrics` | Get agent performance metrics |
+
+### Sweep Dispatch (8 tools)
+
+These tools front the Rust `loom-daemon` (Tier 2) over its Unix-socket IPC and back
+`/loom:sweep`'s Stage -1 backend detection. They require a running `loom-daemon`.
+
+| Tool | Description |
+|------|-------------|
+| `dispatch_sweep` | Dispatch a `/loom:sweep <N>` for an issue (multi-account token rotation) |
+| `list_sweeps` | Enumerate running sweeps in the daemon registry |
+| `get_sweep_status` | Inspect a running sweep's state |
+| `tail_sweep_log` | Tail a per-sweep log file |
+| `cancel_sweep` | Cancel a running sweep (SIGTERM → grace → SIGKILL) |
+| `publish_event` | Publish a sweep-lifecycle event on the event bus |
+| `subscribe_to_events` | Stream topic-filtered events to a subscriber |
+| `tail_event_bus` | Tail the event bus without subscribing to a topic |
+
+> **If these tools are missing from a live session**, `dist/index.js` is almost
+> certainly a **stale build** predating the sweep tools. See
+> [Rebuilding after source changes](#rebuilding-after-source-changes-reconnect-required).
 
 ## Removed Tools
 
@@ -117,6 +137,47 @@ npm run watch
 npm run build
 ```
 
+## Rebuilding after source changes (reconnect required)
+
+The MCP client (Claude Code, Claude Desktop) loads the **built bundle** at
+`dist/index.js` — never the TypeScript source. Two things follow:
+
+1. **`dist/index.js` can silently drift behind `src/`.** If you add or change a
+   tool in `src/tools/*.ts` but never rebuild, the running server keeps exposing
+   the old tool list. This is exactly how the sweep-dispatch tools went missing
+   from live sessions (#3803): `dist/index.js` was a months-old build predating
+   `src/tools/sweeps.ts`. Always rebuild after touching source:
+
+   ```bash
+   cd mcp-loom && npm run build     # tsc --noEmit && rm -rf dist && node esbuild.config.js
+   ```
+
+   `scripts/setup-mcp.sh` now rebuilds automatically when `dist/index.js` is
+   **missing or older than any file under `src/`**, so `./scripts/setup-mcp.sh`
+   is the safe one-shot path.
+
+2. **Rebuilding on disk does NOT refresh an already-running session.** An MCP
+   client caches the tool list from its stdio-spawned child process **at connect
+   time**. Overwriting `dist/index.js` while a session is live changes nothing
+   until the client reconnects. After rebuilding you must **restart the Claude
+   Code session** (or otherwise respawn the `loom` MCP server subprocess) for the
+   new tools to appear.
+
+**Verify a rebuild picked up a tool** without a full session restart:
+
+```bash
+printf '%s\n%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"1"}}}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
+  | node mcp-loom/dist/index.js 2>/dev/null | grep -o '"dispatch_sweep"'
+```
+
+A non-empty match means the bundle exposes the tool; if a live session still
+can't see it, the session needs to reconnect (point 2).
+
+See also [`.loom/docs/troubleshooting.md`](../.loom/docs/troubleshooting.md) →
+"Sweep MCP tools missing (stale dist bundle)".
+
 ## Architecture
 
 ```
@@ -132,7 +193,8 @@ mcp-loom/
 │   └── tools/
 │       ├── logs.ts        # Log tools (empty - use bash)
 │       ├── ui.ts          # UI/Engine tools
-│       └── terminals.ts   # Terminal management tools
+│       ├── terminals.ts   # Terminal management tools
+│       └── sweeps.ts      # Sweep-dispatch tools (loom-daemon IPC)
 ├── package.json
 └── tsconfig.json
 ```

--- a/scripts/setup-mcp.sh
+++ b/scripts/setup-mcp.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # Generate .mcp.json with current workspace path
-# Builds the unified MCP server if dist/index.js is missing
+# Builds the unified MCP server if dist/index.js is missing OR stale
+# (older than any TypeScript source under mcp-loom/src/). The staleness
+# check prevents the built bundle from silently drifting behind source —
+# e.g. new sweep-dispatch tools added to src/tools/sweeps.ts never showing
+# up in dist/index.js because the artifact merely *exists* (see #3803, same
+# failure shape as the installed-copy drift fixed in #3777).
 
 set -euo pipefail
 
@@ -10,11 +15,25 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 MCP_DIR="$WORKSPACE_ROOT/mcp-loom"
+MCP_SRC="$MCP_DIR/src"
 MCP_ENTRY="$MCP_DIR/dist/index.js"
 
-# Build the unified MCP server if not already built
+# Decide whether the MCP server needs (re)building.
+#   - missing artifact               -> build
+#   - artifact older than any source -> rebuild (stale)
+NEEDS_BUILD=0
+BUILD_REASON=""
 if [[ ! -f "$MCP_ENTRY" ]]; then
-  echo "MCP server not built, building mcp-loom..."
+  NEEDS_BUILD=1
+  BUILD_REASON="MCP server not built"
+elif [[ -d "$MCP_SRC" ]] && [[ -n "$(find "$MCP_SRC" -type f -newer "$MCP_ENTRY" -print -quit 2>/dev/null)" ]]; then
+  # At least one source file is newer than the built bundle.
+  NEEDS_BUILD=1
+  BUILD_REASON="MCP server bundle is stale (src newer than dist)"
+fi
+
+if [[ "$NEEDS_BUILD" -eq 1 ]]; then
+  echo "$BUILD_REASON, building mcp-loom..."
   if command -v node &> /dev/null; then
     (cd "$MCP_DIR" && npm install --silent && npm run build) || {
       echo "Warning: Failed to build mcp-loom. MCP tools will not be available." >&2


### PR DESCRIPTION
Closes #3803

Part of #3809 Phase 0. Disjoint from the Rust daemon-hardening chain — pure TypeScript (`mcp-loom/`) + one bash script. Builds in parallel off `main`, not stacked.

## Root cause: stale build, not a registration gap

`mcp-loom/src/index.ts` **already** composes the sweep tools correctly:

```ts
import { handleSweepTool, sweepTools } from "./tools/sweeps.js";
const allTools = [...logTools, ...uiTools, ...terminalTools, ...sweepTools];
```

The 8 sweep-dispatch tools went missing from live sessions because the **gitignored build artifact** `mcp-loom/dist/index.js` was a Feb-17 bundle predating the sweep tools (`grep -c dispatch_sweep dist/index.js` == 0). `scripts/setup-mcp.sh` only rebuilt when the artifact was **missing**, never when **stale**, so it silently drifted behind source forever — the same failure shape as the installed-copy drift fixed in #3777.

## Changes

- **`scripts/setup-mcp.sh`** (the durable deliverable): add a staleness check — rebuild when any file under `mcp-loom/src/` is newer than `dist/index.js` (via `find -newer`), not just when the file is missing.
- **`mcp-loom/README.md`**: bump tool count 19 → 27, add a **Sweep Dispatch (8 tools)** table, and add a **"Rebuilding after source changes (reconnect required)"** section documenting both the drift risk and that rebuilding does not refresh an already-running session (the MCP client caches its tool list at connect time — the session must reconnect).
- **`.loom/docs/troubleshooting.md`**: add **"Sweep MCP tools missing (stale dist bundle)"** with diagnose + rebuild + reconnect steps, cross-referenced to the README.

## dist is gitignored

`mcp-loom/dist/index.js` is **not** git-tracked (`.gitignore` covers `dist/`), so the rebuilt bundle is a local artifact and is not committed. The `setup-mcp.sh` staleness fix is the durable, portable deliverable that prevents recurrence.

## Verification

- `cd mcp-loom && npm ci && npm run build` → succeeds; `grep -c dispatch_sweep dist/index.js` == 5.
- `tsc --noEmit` clean.
- Raw `tools/list` JSON-RPC against `node dist/index.js`: **27 total tools**, all 8 sweep tools present (`dispatch_sweep, list_sweeps, get_sweep_status, tail_sweep_log, cancel_sweep, publish_event, subscribe_to_events, tail_event_bus`), none missing.
- Staleness logic tested both directions: fresh build → no rebuild; `touch src/tools/sweeps.ts` → rebuild triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)