### PR TITLE
fix(daemon): singleton guard — refuse to start if a live daemon owns the socket (#3806)

### DIFF
--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -9,12 +9,67 @@ use crate::terminal::TerminalManager;
 use crate::types::{Event, Request, Response};
 use anyhow::Result;
 use chrono::Utc;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use tokio::fs;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
+
+/// Bound on the singleton-guard liveness probe (#3806). Both the connect and
+/// the `Ping`/`Pong` roundtrip are individually capped at this duration so a
+/// hung or unresponsive peer can never stall daemon startup.
+const LIVENESS_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Returns `true` if a live `loom-daemon` is currently listening on
+/// `socket_path` and actively servicing requests.
+///
+/// The probe connects to the socket and performs a `Ping`/`Pong` roundtrip:
+///
+/// - A connect failure (`ECONNREFUSED`, `ENOENT`, `ENOTSOCK`, permission
+///   error, …) means the socket is absent or stale — the file may linger from
+///   a crashed daemon but nothing is listening — so it is safe to remove and
+///   rebind. Returns `false`.
+/// - A successful connect **and** a `Pong` reply confirms a live daemon owns
+///   the socket. Returns `true`; the caller must refuse to start rather than
+///   unlink the path out from under the incumbent.
+///
+/// A connect that succeeds but never yields a `Pong` within
+/// `LIVENESS_PROBE_TIMEOUT` (e.g. an accept loop wedged before it services
+/// requests, or a non-daemon process squatting the path) is treated as "not a
+/// live, responsive daemon" and returns `false` — refusing to ever reclaim
+/// such a socket would be worse than rebinding it.
+async fn socket_has_live_listener(socket_path: &Path) -> bool {
+    let stream = match tokio::time::timeout(
+        LIVENESS_PROBE_TIMEOUT,
+        UnixStream::connect(socket_path),
+    )
+    .await
+    {
+        Ok(Ok(stream)) => stream,
+        // Connect refused/absent, or the connect itself timed out — not a
+        // live listener.
+        _ => return false,
+    };
+
+    let probe = async move {
+        let (reader, mut writer) = stream.into_split();
+        // Reuse the canonical Ping request shape so the probe stays in sync
+        // with the wire protocol.
+        let request_json = serde_json::to_string(&Request::Ping).ok()?;
+        writer.write_all(request_json.as_bytes()).await.ok()?;
+        writer.write_all(b"\n").await.ok()?;
+        writer.flush().await.ok()?;
+
+        let mut lines = BufReader::new(reader).lines();
+        let line = lines.next_line().await.ok()??;
+        let response: Response = serde_json::from_str(&line).ok()?;
+        Some(matches!(response, Response::Pong))
+    };
+
+    matches!(tokio::time::timeout(LIVENESS_PROBE_TIMEOUT, probe).await, Ok(Some(true)))
+}
 
 /// Get the current git branch for a given directory
 /// Returns None if not in a git repository or if the command fails
@@ -65,7 +120,23 @@ impl IpcServer {
     }
 
     pub async fn run(&self) -> Result<()> {
-        // Remove old socket
+        // Singleton guard (#3806): before touching the socket, probe whether a
+        // live daemon is already listening on it. Starting a second daemon used
+        // to unconditionally `remove_file` + rebind, silently orphaning the
+        // incumbent (still running, still holding its children, but with its
+        // socket unlinked). Refuse to start in that case; only a genuinely
+        // stale/absent socket is removed and rebound below.
+        if socket_has_live_listener(&self.socket_path).await {
+            anyhow::bail!(
+                "another loom-daemon is already listening on {} — refusing to start. \
+                 If you intended to replace it, stop the running daemon first \
+                 (e.g. `kill <pid>` or its shutdown path) and retry.",
+                self.socket_path.display()
+            );
+        }
+
+        // Remove old socket (best-effort; only reached when no live listener
+        // answered the probe above, i.e. the file is stale or absent).
         let _ = fs::remove_file(&self.socket_path).await;
 
         let listener = UnixListener::bind(&self.socket_path)?;
@@ -1508,6 +1579,65 @@ exit 0
             }
             other => panic!("Expected SweepStatus, got: {other:?}"),
         }
+    }
+
+    // ===== Singleton guard liveness probe (Issue #3806) =====
+
+    #[tokio::test]
+    async fn test_socket_has_live_listener_absent_path() {
+        // A path that doesn't exist at all → not live.
+        let dir = tempdir().unwrap();
+        let missing = dir.path().join("nope.sock");
+        assert!(!socket_has_live_listener(&missing).await);
+    }
+
+    #[tokio::test]
+    async fn test_socket_has_live_listener_stale_file() {
+        // A regular file at the socket path (a crashed daemon's leftover) has
+        // nothing listening behind it → not live, safe to remove/rebind.
+        let dir = tempdir().unwrap();
+        let stale = dir.path().join("stale.sock");
+        std::fs::write(&stale, b"").unwrap();
+        assert!(!socket_has_live_listener(&stale).await);
+    }
+
+    #[tokio::test]
+    async fn test_socket_has_live_listener_non_daemon_listener() {
+        // A bound UnixListener that never answers Ping (no accept/respond loop)
+        // must be treated as NOT a live, responsive daemon so startup can still
+        // recover rather than wedging forever.
+        let dir = tempdir().unwrap();
+        let sock = dir.path().join("silent.sock");
+        let _listener = UnixListener::bind(&sock).unwrap();
+        // We never accept()/respond, so the Ping/Pong roundtrip times out.
+        assert!(!socket_has_live_listener(&sock).await);
+    }
+
+    #[tokio::test]
+    async fn test_socket_has_live_listener_true_for_ponging_daemon() {
+        // Stand up a minimal accept loop that answers Ping with Pong, exactly
+        // like the real IPC server, and confirm the probe reports it live.
+        let dir = tempdir().unwrap();
+        let sock = dir.path().join("live.sock");
+        let listener = UnixListener::bind(&sock).unwrap();
+
+        let server = tokio::spawn(async move {
+            if let Ok((stream, _)) = listener.accept().await {
+                let (reader, mut writer) = stream.into_split();
+                let mut lines = BufReader::new(reader).lines();
+                if let Ok(Some(line)) = lines.next_line().await {
+                    if let Ok(Request::Ping) = serde_json::from_str::<Request>(&line) {
+                        let json = serde_json::to_string(&Response::Pong).unwrap();
+                        let _ = writer.write_all(json.as_bytes()).await;
+                        let _ = writer.write_all(b"\n").await;
+                        let _ = writer.flush().await;
+                    }
+                }
+            }
+        });
+
+        assert!(socket_has_live_listener(&sock).await);
+        server.abort();
     }
 
     #[test]

--- a/loom-daemon/tests/integration_singleton_guard.rs
+++ b/loom-daemon/tests/integration_singleton_guard.rs
@@ -1,0 +1,129 @@
+// Integration tests for the daemon singleton guard (Issue #3806).
+//
+// A second daemon started against the same socket must refuse to start rather
+// than unlink the incumbent's socket and silently orphan it. A genuinely stale
+// socket file (crashed daemon leftover) must still be reclaimed normally.
+//
+// expect/unwrap are acceptable here since tests should panic on failure.
+#![allow(clippy::expect_used)]
+#![allow(clippy::unwrap_used)]
+
+mod common;
+
+use common::{cleanup_all_loom_sessions, TestClient, TestDaemon};
+use serial_test::serial;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn setup() {
+    cleanup_all_loom_sessions();
+}
+
+/// Path to the freshly-built daemon binary (matches `TestDaemon::start`).
+fn daemon_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../target/debug/loom-daemon")
+}
+
+/// Spawn a raw `loom-daemon` process pointed at `socket_path`, wait up to
+/// `wait` for it to exit, and return its exit status (or `None` if still
+/// running when the wait elapses). Captures no output beyond piping it away.
+fn spawn_daemon_and_wait(socket_path: &Path, wait: Duration) -> (std::process::Child, bool) {
+    let mut child = Command::new(daemon_bin())
+        .env("LOOM_SOCKET_PATH", socket_path)
+        .env("RUST_LOG", "debug")
+        .env("LOOM_NO_RESTORE", "1")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn second daemon");
+
+    let start = Instant::now();
+    loop {
+        match child.try_wait().expect("try_wait failed") {
+            Some(_status) => return (child, true),
+            None => {
+                if start.elapsed() > wait {
+                    return (child, false);
+                }
+                std::thread::sleep(Duration::from_millis(25));
+            }
+        }
+    }
+}
+
+/// The core singleton-guard scenario: a live daemon owns the socket, a second
+/// daemon on the same socket must refuse (non-zero exit) and NOT orphan the
+/// first — the first stays alive and keeps answering Ping on its socket.
+#[tokio::test]
+#[serial]
+async fn test_second_daemon_refuses_and_first_survives() {
+    setup();
+
+    // Daemon A owns the socket.
+    let daemon_a = TestDaemon::start().await.expect("Failed to start daemon A");
+    let socket_path = daemon_a.socket_path().to_path_buf();
+
+    // Sanity: A answers Ping.
+    {
+        let mut client = TestClient::connect(&socket_path)
+            .await
+            .expect("connect to A");
+        client.ping().await.expect("A ping before second daemon");
+    }
+
+    // Attempt a second daemon on the SAME socket. It should refuse quickly
+    // (the liveness probe is ~500ms) and exit non-zero.
+    let (mut child, exited) = spawn_daemon_and_wait(&socket_path, Duration::from_secs(10));
+    assert!(exited, "second daemon should exit promptly after refusing to start");
+    let status = child.wait().expect("wait on second daemon");
+    assert!(
+        !status.success(),
+        "second daemon must exit non-zero when a live daemon owns the socket; got {status:?}"
+    );
+
+    // The socket must still be there and daemon A must still be answering —
+    // the second daemon must NOT have unlinked/stolen it.
+    assert!(socket_path.exists(), "socket must still exist after the second daemon refused");
+    let mut client = TestClient::connect(&socket_path)
+        .await
+        .expect("connect to A after second daemon refused");
+    client
+        .ping()
+        .await
+        .expect("A must still answer Ping — it was not orphaned");
+}
+
+/// Regression: a stale socket file (a plain file left behind by a crashed
+/// daemon, nothing listening) must still be reclaimed — a fresh daemon starts
+/// normally and binds it.
+#[tokio::test]
+#[serial]
+async fn test_stale_socket_is_reclaimed() {
+    setup();
+
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let socket_path = temp_dir.path().join("daemon.sock");
+    // Simulate a crashed daemon's leftover: a regular file at the socket path.
+    std::fs::write(&socket_path, b"").expect("write stale socket file");
+
+    let (mut child, exited_early) = spawn_daemon_and_wait(&socket_path, Duration::from_secs(2));
+    // It should still be running (successfully bound), not exited.
+    assert!(
+        !exited_early,
+        "daemon should start normally against a stale socket file, not exit early"
+    );
+
+    // Give it a moment and connect — it should be a live daemon now.
+    let mut client = TestClient::connect(&socket_path)
+        .await
+        .expect("connect to daemon that reclaimed a stale socket");
+    client
+        .ping()
+        .await
+        .expect("daemon that reclaimed a stale socket must answer Ping");
+
+    // Teardown.
+    let _ = child.kill();
+    let _ = child.wait();
+}


### PR DESCRIPTION
Closes #3806

Part of #3809 (Phase 0 daemon-hardening stacked chain — this is the ROOT; #3805 stacks on this branch).

## Problem

`IpcServer::run()` (`loom-daemon/src/ipc.rs`) unconditionally `remove_file`d the socket and rebound at startup. Starting a second `loom-daemon` while one was already running unlinked the incumbent's socket out from under it — leaving the first daemon alive but orphaned (still holding its children, no socket) and the second owning the socket. Two daemons, silently, with split ownership of sweep children. Observed live: PID 74709 (old, orphaned) and 70355 (new) running simultaneously.

## Fix

Add a connect-and-ping liveness probe (`socket_has_live_listener`) that runs **before** `remove_file`:

- Connects to the socket and performs a `Ping`/`Pong` roundtrip, each step bounded by a 500ms timeout.
- **Connect failure / stale file / no Pong** → not a live listener → proceed exactly as before (best-effort `remove_file` + `bind`), preserving crash-recovery behavior for stale sockets.
- **Successful connect + `Pong`** → a live daemon owns the socket → `run()` returns `Err` with an operator-facing message naming the socket path and how to stop the running daemon. `main()`'s existing `server.run().await?` turns that into a non-zero process exit — **no `main.rs` changes required**.

No new dependency — reuses the existing `Ping`/`Pong` wire protocol. Coordinated takeover (killing the incumbent) is intentionally **out of scope** (deferred to sibling issues under the epic).

## Tests

- 4 lib unit tests for the probe: absent path, stale regular file, silent (non-responding) listener, and a live Ping/Pong daemon.
- New `tests/integration_singleton_guard.rs` using the existing `TestDaemon`/`TestClient` harness (temp sockets):
  - `test_second_daemon_refuses_and_first_survives` — daemon A owns the socket; a second daemon on the same socket exits non-zero, does not steal the socket, and daemon A still answers `Ping`.
  - `test_stale_socket_is_reclaimed` — a plain leftover file at the socket path is reclaimed normally (regression guard).

`cargo test` (all 416+ lib + integration tests pass), `cargo build --release`, and `cargo fmt --check` all clean.

**Clippy note:** `cargo clippy --all-targets -- -D warnings` reports a pre-existing set of 16 errors (format-args, expect/panic, too-many-lines, complex-type, etc.) from a newer local toolchain vs the CI-pinned one. Confirmed byte-for-byte identical on `origin/main` (the `ipc.rs` complex-type error is the pre-existing `setup_test_context` helper, shifted line 902→973 only because the new probe fn sits above it). My changed code introduces **zero** new clippy findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)