### PR TITLE
fix(daemon): structured error frame on malformed IPC request (#3805)

### DIFF
--- a/loom-daemon/src/errors.rs
+++ b/loom-daemon/src/errors.rs
@@ -356,6 +356,31 @@ impl DaemonError {
         .with_details(serde_json::json!({ "path": path }))
     }
 
+    // IPC errors
+    /// Creates an "IPC request parse failure" error.
+    ///
+    /// Raised when an incoming line on the IPC socket cannot be deserialized
+    /// into a [`crate::types::Request`] — covers garbage JSON, a missing
+    /// required field, and an unknown `type` tag alike (all three fail at the
+    /// single `serde_json::from_str::<Request>` call). `serde_json::Error`'s
+    /// `Display` already names the offending field/variant (e.g.
+    /// `missing field \`grace_secs\``, `unknown variant \`Nonsense\``), so we
+    /// surface it verbatim in the message.
+    ///
+    /// Marked non-recoverable: retrying the exact same malformed bytes will
+    /// fail identically, so the client must correct the payload rather than
+    /// retry blindly.
+    #[must_use]
+    pub fn ipc_parse_error(raw: &str, source_err: &serde_json::Error) -> Self {
+        Self::new(
+            ErrorDomain::Ipc,
+            ErrorCode::IPC_PROTOCOL_ERROR,
+            format!("failed to parse request: {source_err}"),
+        )
+        .recoverable(false)
+        .with_details(serde_json::json!({ "raw": raw }))
+    }
+
     // Internal errors
     /// Creates a "mutex poisoned" error
     #[must_use]

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -174,7 +174,22 @@ async fn handle_client(
     let mut lines = BufReader::new(reader).lines();
 
     while let Some(line) = lines.next_line().await? {
-        let request: Request = serde_json::from_str(&line)?;
+        // Parse the incoming frame. A malformed payload (garbage JSON, a
+        // missing required field, or an unknown `type` tag) is a per-request
+        // protocol error, NOT a fatal connection error: emit a structured
+        // error frame naming the serde failure and keep the connection usable
+        // for subsequent requests rather than silently dropping the socket.
+        let request: Request = match serde_json::from_str(&line) {
+            Ok(request) => request,
+            Err(parse_err) => {
+                let response =
+                    Response::StructuredError(DaemonError::ipc_parse_error(&line, &parse_err));
+                let response_json = serde_json::to_string(&response)?;
+                writer.write_all(response_json.as_bytes()).await?;
+                writer.write_all(b"\n").await?;
+                continue;
+            }
+        };
         log::debug!("Request: {request:?}");
 
         // SubscribeEvents is the only structurally-different request: it

--- a/loom-daemon/tests/integration_basic.rs
+++ b/loom-daemon/tests/integration_basic.rs
@@ -36,7 +36,15 @@ async fn test_ping_pong() {
     client.ping().await.expect("Second ping failed");
 }
 
-/// Test 1.2: Error handling - malformed JSON
+/// Test 1.2: Error handling - malformed requests (Issue #3805)
+///
+/// A malformed request must be answered with a structured error frame
+/// (`{"type":"StructuredError","payload":{"domain":"ipc","code":"IPC_PROTOCOL_ERROR",...}}`)
+/// rather than silently dropping the connection. The connection must stay
+/// usable for subsequent well-formed requests. All three malformed shapes —
+/// garbage JSON, a missing required field, and an unknown `type` tag — hit
+/// the same `serde_json::from_str::<Request>` failure and must each produce
+/// the structured frame.
 #[tokio::test]
 #[serial]
 async fn test_malformed_json() {
@@ -47,16 +55,63 @@ async fn test_malformed_json() {
         .await
         .expect("Failed to connect");
 
-    // Send malformed JSON (missing required "type" field)
-    let malformed = serde_json::json!({"InvalidRequest": "test"});
-    let result = client.send_request(malformed).await;
+    /// Assert a response is the IPC-protocol structured error frame.
+    fn assert_ipc_protocol_error(response: &serde_json::Value, case: &str) {
+        assert_eq!(
+            response.get("type").and_then(|t| t.as_str()),
+            Some("StructuredError"),
+            "[{case}] expected StructuredError frame, got: {response:?}"
+        );
+        let payload = response
+            .get("payload")
+            .unwrap_or_else(|| panic!("[{case}] StructuredError missing payload: {response:?}"));
+        assert_eq!(
+            payload.get("domain").and_then(|d| d.as_str()),
+            Some("ipc"),
+            "[{case}] expected domain=ipc, got: {payload:?}"
+        );
+        // ErrorCode is a newtype over String, so it serializes as a bare
+        // string (not `{"0": ...}`).
+        assert_eq!(
+            payload.get("code").and_then(|c| c.as_str()),
+            Some("IPC_PROTOCOL_ERROR"),
+            "[{case}] expected code=IPC_PROTOCOL_ERROR, got: {payload:?}"
+        );
+    }
 
-    // Daemon currently closes connection on malformed requests
-    // This is reasonable behavior - malformed requests indicate a protocol error
-    assert!(result.is_err(), "Malformed request should result in error");
+    // Case 1: garbage / unknown-shape JSON (unknown `type` tag). An object
+    // without a valid `type` fails the tagged-enum deserialize.
+    let unknown_type = serde_json::json!({"type": "Nonsense", "payload": {}});
+    let response = client
+        .send_request(unknown_type)
+        .await
+        .expect("unknown-type request must return a frame, not close the connection");
+    assert_ipc_protocol_error(&response, "unknown-type");
 
-    // Since connection is closed, we can't send more requests
-    // This documents current behavior: daemon closes connection on protocol errors
+    // Case 2: missing required field — CancelSweep without `grace_secs`.
+    let missing_field = serde_json::json!({
+        "type": "CancelSweep",
+        "payload": { "sweep_id": "sweep-issue-1-123" }
+    });
+    let response = client
+        .send_request(missing_field)
+        .await
+        .expect("missing-field request must return a frame, not close the connection");
+    assert_ipc_protocol_error(&response, "missing-field");
+
+    // Case 3: structurally invalid JSON (raw garbage, not even an object).
+    let garbage = serde_json::json!("this is not a request object");
+    let response = client
+        .send_request(garbage)
+        .await
+        .expect("garbage request must return a frame, not close the connection");
+    assert_ipc_protocol_error(&response, "garbage");
+
+    // The connection must still be usable after all three malformed requests.
+    client
+        .ping()
+        .await
+        .expect("connection must remain usable after malformed requests");
 }
 
 /// Test 2.1: Create terminal


### PR DESCRIPTION
Closes #3805

Part of #3809 Phase 0 (daemon hardening). **STACKED** — base branch is `feature/issue-3806` (the singleton-guard PR), NOT `main`. Merge #3806 first.

## Problem

A malformed IPC request (garbage JSON, a missing required field, or an unknown `type` tag) all fail at the single bare `?` on `serde_json::from_str::<Request>(&line)` in `handle_client` (`ipc.rs`). That `?` propagated the parse error up through the task's `Result`, which was only logged before the socket was dropped — the client saw an empty EOF, never a diagnostic. This bypassed the `Response::StructuredError` path entirely, since parse failures happen *before* `handle_request` is ever called.

## Fix

- `errors.rs`: new `DaemonError::ipc_parse_error(raw, source_err)` factory using the pre-existing (previously unused) `ErrorDomain::Ipc` / `ErrorCode::IPC_PROTOCOL_ERROR`, marked `recoverable(false)`. `serde_json::Error`'s `Display` already names the offending field/variant, so it's surfaced verbatim.
- `ipc.rs`: replace the bare `?` on the request deserialize with a `match` — on parse failure, write a `StructuredError` frame and `continue` the loop so the connection stays usable. The outer `?` on `lines.next_line()` (a socket I/O error, not a malformed payload) is intentionally left as-is (out of scope).

## Tests

- Rewrote `integration_basic::test_malformed_json` (which asserted the buggy silent-close behavior) to send three malformed shapes — unknown `type`, `CancelSweep` missing `grace_secs`, and a wrong-shape payload — and assert each returns `{"type":"StructuredError","payload":{"domain":"ipc","code":"IPC_PROTOCOL_ERROR",...}}` (ErrorCode is a newtype → serializes as a bare string), then a follow-up `ping()` proving the connection survives.

`cargo test` (all suites), `cargo build --release`, `cargo fmt --check` all pass. `cargo clippy -- -D warnings` is clean on the touched files; the sole remaining clippy error is the pre-existing `forge_parser.rs:91` `uninlined_format_args` already present on the base branch (left untouched per issue scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)