### PR TITLE
fix(daemon): don't hold registry mutex across cancel grace window (#3807)

### DIFF
--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -4,7 +4,7 @@ use crate::event_bus::EventBus;
 use crate::forge_parser::parse_forge_events;
 use crate::git_parser;
 use crate::git_utils;
-use crate::sweep_registry::SweepRegistry;
+use crate::sweep_registry::{BeginCancel, SweepRegistry};
 use crate::terminal::TerminalManager;
 use crate::types::{Event, Request, Response};
 use anyhow::Result;
@@ -204,6 +204,30 @@ async fn handle_client(
             break;
         }
 
+        // CancelSweep is handled here rather than in the synchronous
+        // `handle_request` dispatcher (Issue #3807): its SIGTERM → grace-poll
+        // → SIGKILL escalation must NOT hold the registry mutex across the
+        // (possibly multi-second) grace window, or it would freeze every
+        // other IPC request (ListSweeps / GetSweepStatus / DispatchSweep).
+        // The async handler below re-acquires the lock only for the brief
+        // begin / poll / finish steps and `await`s the sleep unlocked.
+        if let Request::CancelSweep {
+            sweep_id,
+            grace_secs,
+        } = request
+        {
+            let response = cancel_sweep_nonblocking(
+                &sweep_registry,
+                &sweep_id,
+                Duration::from_secs(grace_secs),
+            )
+            .await;
+            let response_json = serde_json::to_string(&response)?;
+            writer.write_all(response_json.as_bytes()).await?;
+            writer.write_all(b"\n").await?;
+            continue;
+        }
+
         let response =
             handle_request(request, &terminal_manager, &activity_db, &sweep_registry, &event_bus);
 
@@ -264,6 +288,98 @@ async fn stream_events(
         }
     }
     Ok(())
+}
+
+/// Cancel a sweep WITHOUT holding the registry mutex across the grace
+/// poll/sleep window (Issue #3807).
+///
+/// The blocking `SweepRegistry::cancel` holds `&mut self` — and therefore the
+/// `Mutex<SweepRegistry>` — for the whole SIGTERM → grace-poll → SIGKILL
+/// escalation, so a `grace_secs = 30` cancel would freeze every other IPC
+/// request (ListSweeps / GetSweepStatus / DispatchSweep) for up to 30s. This
+/// async orchestration instead re-acquires the lock only for three brief,
+/// non-blocking steps:
+///
+/// 1. `begin_cancel` — read pid/kind/liveness + SIGTERM the process group.
+/// 2. `poll_cancel` — one liveness poll (reaps on exit, #3801), once per tick.
+/// 3. `finish_cancel` — SIGKILL decision + reap + terminal transition + events.
+///
+/// The 100ms sleep between polls runs UNLOCKED via `tokio::time::sleep`, so the
+/// registry mutex is free for other clients for the entire grace window. The
+/// synchronous `SweepCancelled` response contract (`sigkill_sent`, `was_running`,
+/// `pid`) is preserved — the caller still gets a completed-cancel ack.
+// Allow expect_used: a poisoned registry mutex means another thread panicked
+// while holding the lock — unrecoverable, so we crash (same policy as
+// `handle_request`).
+#[allow(clippy::expect_used)]
+async fn cancel_sweep_nonblocking(
+    sweep_registry: &Arc<Mutex<SweepRegistry>>,
+    sweep_id: &str,
+    grace: Duration,
+) -> Response {
+    // Step 1: begin (lock-scoped). Read state + SIGTERM, then release.
+    let began = {
+        let mut sr = sweep_registry
+            .lock()
+            .expect("Sweep registry mutex poisoned");
+        sr.begin_cancel(sweep_id)
+    };
+    let (pid, kind, started_at) = match began {
+        Ok(BeginCancel::AlreadyTerminal(outcome)) => {
+            return Response::SweepCancelled {
+                sweep_id: outcome.sweep_id,
+                pid: outcome.pid,
+                sigkill_sent: outcome.sigkill_sent,
+                was_running: outcome.was_running,
+            };
+        }
+        Ok(BeginCancel::Signalled {
+            pid,
+            kind,
+            started_at,
+        }) => (pid, kind, started_at),
+        Err(e) => {
+            return Response::Error {
+                message: format!("cancel_sweep failed: {e}"),
+            };
+        }
+    };
+
+    // Step 2: poll for exit up to the grace window. Each poll takes the lock
+    // only briefly; the sleep between polls is awaited UNLOCKED so concurrent
+    // IPC requests are serviced promptly.
+    let poll_interval = Duration::from_millis(100);
+    let deadline = tokio::time::Instant::now() + grace;
+    let mut exited_within_grace = {
+        let mut sr = sweep_registry
+            .lock()
+            .expect("Sweep registry mutex poisoned");
+        sr.poll_cancel(sweep_id, pid)
+    };
+    while !exited_within_grace && tokio::time::Instant::now() < deadline {
+        tokio::time::sleep(poll_interval).await;
+        exited_within_grace = {
+            let mut sr = sweep_registry
+                .lock()
+                .expect("Sweep registry mutex poisoned");
+            sr.poll_cancel(sweep_id, pid)
+        };
+    }
+
+    // Step 3: finish (lock-scoped). SIGKILL decision + reap + terminal
+    // transition + event emission.
+    let outcome = {
+        let mut sr = sweep_registry
+            .lock()
+            .expect("Sweep registry mutex poisoned");
+        sr.finish_cancel(sweep_id, pid, &kind, started_at, exited_within_grace)
+    };
+    Response::SweepCancelled {
+        sweep_id: outcome.sweep_id,
+        pid: outcome.pid,
+        sigkill_sent: outcome.sigkill_sent,
+        was_running: outcome.was_running,
+    }
 }
 
 // Allow expect_used because mutex poisoning is a panic-level error that indicates
@@ -919,6 +1035,12 @@ fn handle_request(
             sweep_id,
             grace_secs,
         } => {
+            // Production traffic never reaches this arm: `handle_client`
+            // intercepts `CancelSweep` and services it via the non-blocking
+            // async `cancel_sweep_nonblocking` (Issue #3807) so the grace
+            // window does not hold the registry mutex. This synchronous
+            // fallback (holding the lock across the full grace) remains for
+            // direct/unit-test callers where lock contention is irrelevant.
             let mut sr = sweep_registry
                 .lock()
                 .expect("Sweep registry mutex poisoned");

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -41,7 +41,7 @@ use crate::event_bus::EventBus;
 use crate::types::{Event, SweepId, SweepInfo, SweepKind, SweepOutcome, SweepState};
 
 use anyhow::{anyhow, Context, Result};
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 #[cfg(unix)]
@@ -860,7 +860,56 @@ impl SweepRegistry {
     /// against unknown sweep IDs return `Err`. Calls against already-
     /// terminal sweeps return `Ok` with `was_running = false` — cancel
     /// is idempotent so monitor-tool retries don't surface as errors.
+    ///
+    /// This is the **synchronous, self-contained** composition of the
+    /// [`begin_cancel`](Self::begin_cancel) → [`poll_cancel`](Self::poll_cancel)
+    /// → [`finish_cancel`](Self::finish_cancel) split. It holds `&mut self`
+    /// (and therefore, when the registry lives behind a `Mutex`, the lock)
+    /// for the entire grace window, so callers that must not freeze other
+    /// registry access during the poll should orchestrate the three steps
+    /// themselves and release the lock across the sleep (see the non-blocking
+    /// IPC handler for `CancelSweep`, Issue #3807). Kept for direct callers
+    /// and unit tests where lock contention is irrelevant.
     pub fn cancel(&mut self, sweep_id: &str, grace: Duration) -> Result<CancelOutcome> {
+        let (pid, kind, started_at) = match self.begin_cancel(sweep_id)? {
+            BeginCancel::AlreadyTerminal(outcome) => return Ok(outcome),
+            BeginCancel::Signalled {
+                pid,
+                kind,
+                started_at,
+            } => (pid, kind, started_at),
+        };
+
+        // Poll for exit up to the grace window (100ms cadence, matching the
+        // spawn-loop's shutdown-grace polling). Blocking sleep is fine here —
+        // this path holds `&mut self` throughout by design.
+        let poll_interval = Duration::from_millis(100);
+        let deadline = std::time::Instant::now() + grace;
+        let mut exited_within_grace = self.poll_cancel(sweep_id, pid);
+        while !exited_within_grace && std::time::Instant::now() < deadline {
+            std::thread::sleep(poll_interval);
+            exited_within_grace = self.poll_cancel(sweep_id, pid);
+        }
+
+        Ok(self.finish_cancel(sweep_id, pid, &kind, started_at, exited_within_grace))
+    }
+
+    /// First, lock-scoped step of a split cancel (Issue #3807): read the
+    /// target's pid/kind/liveness and, when it is still running, deliver
+    /// SIGTERM to its process GROUP (Issue #3800). Returns quickly — it does
+    /// **no** blocking poll — so the caller can release the registry lock
+    /// before entering the (potentially multi-second) grace window.
+    ///
+    /// SIGTERM (signal 15) is sent to the whole process group via `kill(2)`
+    /// directly rather than spawning `kill(1)` so the path is identical on
+    /// macOS + Linux and doesn't depend on `PATH`. `signal_sweep` falls back
+    /// to single-PID delivery for entries with no retained handle.
+    ///
+    /// - Unknown sweep IDs return `Err`.
+    /// - Already-terminal sweeps return [`BeginCancel::AlreadyTerminal`] with
+    ///   an idempotent `was_running = false` outcome (no signal, no state
+    ///   change) — cancel-from-monitor retries stay idempotent.
+    pub fn begin_cancel(&mut self, sweep_id: &str) -> Result<BeginCancel> {
         let (pid, kind, was_running, started_at) = {
             let info = self
                 .entries
@@ -871,22 +920,14 @@ impl SweepRegistry {
         };
 
         if !was_running {
-            // Already terminal — nothing to signal. Return success so
-            // duplicate cancel-from-monitor requests stay idempotent.
-            return Ok(CancelOutcome {
+            return Ok(BeginCancel::AlreadyTerminal(CancelOutcome {
                 sweep_id: sweep_id.to_string(),
                 pid,
                 sigkill_sent: false,
                 was_running: false,
-            });
+            }));
         }
 
-        // Step 1: SIGTERM (signal 15) to the sweep's process GROUP (Issue
-        // #3800) so the `claude` child AND its tool/MCP subprocess subtree are
-        // reached — not just the tracked leader PID. We send via `kill(2)`
-        // directly rather than spawning `kill(1)` so the path is identical on
-        // macOS + Linux and we don't depend on `PATH`. `signal_sweep` falls
-        // back to single-PID delivery for entries with no retained handle.
         let term_sent = self.signal_sweep(sweep_id, pid, 15);
         if !term_sent {
             log::warn!(
@@ -895,21 +936,39 @@ impl SweepRegistry {
             );
         }
 
-        // Step 2: poll for exit up to the grace window. We poll every
-        // 100ms (matches the spawn-loop's shutdown-grace polling
-        // cadence). The poll loop is a blocking sleep — acceptable for
-        // an IPC handler since cancel is a low-frequency operator action.
-        // `poll_liveness` reaps the child (no zombie, Issue #3801) the moment
-        // it observes the exit via the retained handle's `try_wait()`.
-        let poll_interval = Duration::from_millis(100);
-        let deadline = std::time::Instant::now() + grace;
-        let (mut exited_within_grace, _) = self.poll_liveness(sweep_id, pid);
-        while !exited_within_grace && std::time::Instant::now() < deadline {
-            std::thread::sleep(poll_interval);
-            exited_within_grace = self.poll_liveness(sweep_id, pid).0;
-        }
+        Ok(BeginCancel::Signalled {
+            pid,
+            kind,
+            started_at,
+        })
+    }
 
-        // Step 3: SIGKILL the group if still alive.
+    /// One lock-scoped liveness poll for an in-progress cancel (Issue #3807).
+    /// Returns `true` once the child has exited, reaping it via the retained
+    /// `Child` handle so no `<defunct>` zombie survives (Issue #3801). The
+    /// caller invokes this under a brief lock between *unlocked* sleep
+    /// intervals, so the grace window never holds the registry mutex.
+    pub fn poll_cancel(&mut self, sweep_id: &str, pid: u32) -> bool {
+        self.poll_liveness(sweep_id, pid).0
+    }
+
+    /// Final, lock-scoped step of a split cancel (Issue #3807): SIGKILL the
+    /// process group if the child did not exit within grace, reap the retained
+    /// handle (Issue #3801), transition the entry to `Exited{code: None}`,
+    /// release the per-issue lock, and emit the same lifecycle events a clean
+    /// exit would (`sweep.issue.{N}.exited` + `sweep.global.completed`).
+    ///
+    /// `exited_within_grace` is the terminal result of the caller's poll loop.
+    /// Returns the [`CancelOutcome`] for the (running) sweep.
+    pub fn finish_cancel(
+        &mut self,
+        sweep_id: &str,
+        pid: u32,
+        kind: &SweepKind,
+        started_at: DateTime<Utc>,
+        exited_within_grace: bool,
+    ) -> CancelOutcome {
+        // SIGKILL the group if still alive.
         let sigkill_sent = if exited_within_grace {
             false
         } else {
@@ -920,13 +979,13 @@ impl SweepRegistry {
             true
         };
 
-        // Step 3b: reap the retained handle so the killed leader does not
-        // linger as a `<defunct>` zombie under the daemon PID (Issue #3801).
-        // A no-op when the exit was already reaped in the poll loop above, or
-        // when no handle is retained (reconstructed / test-injected entry).
+        // Reap the retained handle so the killed leader does not linger as a
+        // `<defunct>` zombie under the daemon PID (Issue #3801). A no-op when
+        // the exit was already reaped in the poll loop above, or when no
+        // handle is retained (reconstructed / test-injected entry).
         let _ = self.reap_handle(sweep_id);
 
-        // Step 4: transition state, release lock, emit events.
+        // Transition state, release lock, emit events.
         let now = Utc::now();
         let duration_sec = (now - started_at).num_seconds();
         if let Some(info) = self.entries.get_mut(sweep_id) {
@@ -935,7 +994,7 @@ impl SweepRegistry {
                 at: now,
             };
         }
-        if let SweepKind::Issue(issue) = &kind {
+        if let SweepKind::Issue(issue) = kind {
             let _ = self.release_lock(*issue);
             self.emit_event(Event::SweepExited {
                 issue: *issue,
@@ -948,12 +1007,12 @@ impl SweepRegistry {
             outcome: SweepOutcome::Exited,
         });
 
-        Ok(CancelOutcome {
+        CancelOutcome {
             sweep_id: sweep_id.to_string(),
             pid,
             sigkill_sent,
             was_running: true,
-        })
+        }
     }
 
     /// Read the last `lines` lines from a sweep's log file.
@@ -1301,6 +1360,29 @@ pub struct DispatchOutcome {
     /// `false` when the dispatch was an idempotency hit on an existing
     /// `Running` entry.
     pub was_new: bool,
+}
+
+/// Result of the lock-scoped [`begin_cancel`](SweepRegistry::begin_cancel)
+/// step of a split cancel (Issue #3807).
+///
+/// Splitting `cancel` into begin → poll → finish lets the IPC handler run the
+/// grace poll/sleep window WITHOUT holding the registry mutex, so concurrent
+/// `ListSweeps` / `GetSweepStatus` / `DispatchSweep` for other sweeps are not
+/// blocked for the (potentially multi-second) grace duration.
+#[derive(Debug, Clone)]
+pub enum BeginCancel {
+    /// The sweep was already terminal — nothing was signalled. Carries the
+    /// idempotent [`CancelOutcome`] (`was_running = false`) to return directly.
+    AlreadyTerminal(CancelOutcome),
+    /// SIGTERM has been delivered to the sweep's process group. The caller must
+    /// now poll for exit (unlocked) via
+    /// [`poll_cancel`](SweepRegistry::poll_cancel) and then call
+    /// [`finish_cancel`](SweepRegistry::finish_cancel).
+    Signalled {
+        pid: u32,
+        kind: SweepKind,
+        started_at: DateTime<Utc>,
+    },
 }
 
 /// Result of a `cancel` call (Issue #3455, Phase C).
@@ -2925,6 +3007,139 @@ exit 0
 
         let info = registry.get(&sweep_id).unwrap();
         assert!(matches!(info.state, SweepState::Exited { .. }));
+    }
+
+    /// Issue #3807 core AC: the SIGTERM → grace-poll → SIGKILL escalation must
+    /// NOT hold the registry lock for the full grace window. We drive the split
+    /// `begin_cancel` → `poll_cancel` (unlocked sleeps between polls) →
+    /// `finish_cancel` orchestration on one thread against a real trap-TERM
+    /// child (forced to run the FULL grace before escalating), and assert a
+    /// concurrent `get_status` on a DIFFERENT sweep returns PROMPTLY — well
+    /// under the grace window — rather than blocking for it. With the old
+    /// `cancel(&mut self)` (lock held throughout) the concurrent read would
+    /// block for the entire grace.
+    #[test]
+    fn split_cancel_does_not_hold_lock_across_grace_window() {
+        use std::sync::{Arc, Mutex};
+        use std::thread;
+
+        let dir = tempdir().unwrap();
+        let (registry, _record_log) = fixture_registry(dir.path());
+        let registry = Arc::new(Mutex::new(registry));
+
+        // A real child that traps (ignores) SIGTERM and sleeps, so the cancel
+        // is forced to poll for the full grace before escalating to SIGKILL.
+        let mut child = Command::new("bash")
+            .arg("-c")
+            .arg("trap '' TERM; sleep 30")
+            .spawn()
+            .expect("spawn fixture child");
+        let target_pid = child.id();
+        // Give bash a moment to install the trap before we TERM it.
+        thread::sleep(Duration::from_millis(100));
+
+        let target = "sweep-cancel-target".to_string();
+        let other = "sweep-concurrent-reader".to_string();
+        {
+            let mut reg = registry.lock().unwrap();
+            let target_log = reg.compute_log_path(880);
+            let other_log = reg.compute_log_path(881);
+            reg.entries.insert(
+                target.clone(),
+                SweepInfo {
+                    sweep_id: target.clone(),
+                    kind: SweepKind::Issue(880),
+                    pid: target_pid,
+                    token_name: "unknown".into(),
+                    log_path: target_log,
+                    idempotency_key: None,
+                    started_at: Utc::now(),
+                    state: SweepState::Running,
+                    latest_phase: None,
+                    pr_number: None,
+                    model: None,
+                    effort: None,
+                    depends_on: None,
+                },
+            );
+            reg.entries.insert(
+                other.clone(),
+                SweepInfo {
+                    sweep_id: other.clone(),
+                    kind: SweepKind::Issue(881),
+                    pid: 2_147_483_640, // ~i32::MAX, harmless dead pid
+                    token_name: "unknown".into(),
+                    log_path: other_log,
+                    idempotency_key: None,
+                    started_at: Utc::now(),
+                    state: SweepState::Running,
+                    latest_phase: None,
+                    pr_number: None,
+                    model: None,
+                    effort: None,
+                    depends_on: None,
+                },
+            );
+        }
+
+        // 1s grace: long enough that a lock held throughout would clearly
+        // block the concurrent read for ~1s, short enough to keep the test fast.
+        let grace = Duration::from_millis(1000);
+
+        // Thread A: run the split orchestration (mirrors the IPC handler),
+        // releasing the mutex between the 100ms poll sleeps.
+        let reg_a = Arc::clone(&registry);
+        let target_a = target.clone();
+        let canceller = thread::spawn(move || {
+            let (pid, kind, started_at) =
+                match reg_a.lock().unwrap().begin_cancel(&target_a).unwrap() {
+                    BeginCancel::Signalled {
+                        pid,
+                        kind,
+                        started_at,
+                    } => (pid, kind, started_at),
+                    BeginCancel::AlreadyTerminal(_) => panic!("target should be running"),
+                };
+            let deadline = std::time::Instant::now() + grace;
+            let mut exited = reg_a.lock().unwrap().poll_cancel(&target_a, pid);
+            while !exited && std::time::Instant::now() < deadline {
+                thread::sleep(Duration::from_millis(100));
+                exited = reg_a.lock().unwrap().poll_cancel(&target_a, pid);
+            }
+            reg_a
+                .lock()
+                .unwrap()
+                .finish_cancel(&target_a, pid, &kind, started_at, exited)
+        });
+
+        // Let thread A send SIGTERM and enter the (unlocked) poll loop.
+        thread::sleep(Duration::from_millis(150));
+
+        // Concurrent read on the OTHER sweep: must return well under the grace
+        // window because the poll loop releases the mutex between polls.
+        let start = std::time::Instant::now();
+        let info = registry.lock().unwrap().get_status(&other);
+        let elapsed = start.elapsed();
+        assert!(info.is_some(), "other sweep should still be queryable");
+        assert!(
+            elapsed < Duration::from_millis(400),
+            "concurrent get_status blocked for {elapsed:?} — the registry mutex \
+             was held across the grace window (grace was {grace:?})"
+        );
+
+        let outcome = canceller.join().expect("cancel thread panicked");
+        assert!(outcome.was_running);
+        assert!(
+            outcome.sigkill_sent,
+            "trap-TERM child should have survived SIGTERM and escalated to SIGKILL"
+        );
+
+        // Reap the zombie so the PID leaves the process table.
+        let exit_status = child.wait().expect("wait on cancelled child");
+        assert!(!exit_status.success(), "child should not have exited cleanly after SIGKILL");
+
+        let final_state = registry.lock().unwrap().get(&target).unwrap().state.clone();
+        assert!(matches!(final_state, SweepState::Exited { .. }));
     }
 
     #[test]


### PR DESCRIPTION
Closes #3807

Part of #3809 Phase 0 (3rd in the stacked chain; base = `feature/issue-3805`, which stacks on `feature/issue-3806`).

## Problem
`Request::CancelSweep` (`ipc.rs`) locked the registry `Mutex` and held it across the entire blocking `SweepRegistry::cancel()` — SIGTERM → grace-poll → SIGKILL → reap. For `grace_secs = 30` this froze every other IPC request (`ListSweeps` / `GetSweepStatus` / `DispatchSweep`) for up to 30s.

## Fix (Curator's Option A — begin/finish split)
Split `cancel()` into three lock-scoped steps in `sweep_registry.rs`:

- `begin_cancel` → read pid/kind/liveness + SIGTERM the process **group**.
- `poll_cancel` → one liveness poll (reaps on exit), invoked per tick.
- `finish_cancel` → SIGKILL decision + reap + terminal `Exited` transition + lock release + events.

`handle_client` now intercepts `CancelSweep` and drives these via a new async `cancel_sweep_nonblocking`, awaiting the 100ms poll sleeps **unlocked** (`tokio::time::sleep`) so the registry mutex is free for the entire grace window (addresses the Curator's tokio-worker-blocking note).

## Preserved
- `CancelSweep` response contract (`sigkill_sent`, `was_running`, `pid`, synchronous completion) — unchanged, no MCP/doc coordination needed.
- #3800 process-group kill (`signal_sweep`/`send_group_signal`).
- #3801 reap semantics (`try_wait`/`reap_handle`, no zombie).
- Idempotent already-terminal early-return (`was_running: false`).
- `cancel()` retained as a synchronous composition of the three steps for direct/unit-test callers; all 6 existing cancel-path tests pass unmodified.

## Test
New `split_cancel_does_not_hold_lock_across_grace_window`: inserts a real trap-TERM child, drives the split orchestration on one thread with a 1s grace, and asserts a concurrent `get_status` on a *different* sweep returns in <400ms rather than blocking for the grace window (the core AC). Regression coverage for #3800/#3801 (SIGKILL escalation, process-group kill, reap-no-zombie) unchanged and green.

`cargo test` (all pass) / `cargo build --release` / `cargo fmt --check` clean. `cargo clippy -- -D warnings` clean except the pre-existing `forge_parser.rs:91` uninlined-format-args error already on origin/main (untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)