### PR TITLE
fix(loom-daemon): clear uninlined_format_args + type_complexity clippy lints (#3828)

### DIFF
--- a/loom-daemon/src/forge_parser.rs
+++ b/loom-daemon/src/forge_parser.rs
@@ -88,7 +88,7 @@ pub fn parse_forge_events(output: &str, forge_host: &str) -> Vec<ParsedForgeEven
     // Matches: https://{forge_host}/owner/repo/pull/456  (GitHub)
     // Matches: https://{forge_host}/owner/repo/pulls/456 (Gitea)
     let escaped_host = regex::escape(forge_host);
-    let url_pattern = format!(r"https://{}/[^/]+/[^/]+/(issues|pulls?)/(\d+)", escaped_host);
+    let url_pattern = format!(r"https://{escaped_host}/[^/]+/[^/]+/(issues|pulls?)/(\d+)");
     if let Ok(url_re) = Regex::new(&url_pattern) {
         for cap in url_re.captures_iter(output) {
             if let (Some(type_match), Some(number_match)) = (cap.get(1), cap.get(2)) {

--- a/loom-daemon/src/init/scaffolding.rs
+++ b/loom-daemon/src/init/scaffolding.rs
@@ -2099,8 +2099,7 @@ WARNING: Never run `lake build` inside Docker - causes memory corruption.
         // hooks key should be removed entirely since nothing remains
         assert!(
             settings.get("hooks").is_none(),
-            "hooks key should be removed when empty, got: {:?}",
-            settings
+            "hooks key should be removed when empty, got: {settings:?}"
         );
     }
 

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -1107,12 +1107,14 @@ mod tests {
     use crate::types::{SweepKind, SweepState};
     use tempfile::tempdir;
 
-    fn setup_test_context() -> (
+    type TestContext = (
         Arc<Mutex<TerminalManager>>,
         Arc<Mutex<ActivityDb>>,
         Arc<Mutex<SweepRegistry>>,
         Arc<EventBus>,
-    ) {
+    );
+
+    fn setup_test_context() -> TestContext {
         let tm = Arc::new(Mutex::new(TerminalManager::new()));
         let dir = tempdir().unwrap();
         let db_path = dir.path().join("test_activity.db");


### PR DESCRIPTION
Closes #3828

Part of #3809 — a targeted, pure clippy lint fix for the `loom-daemon` crate. Zero behavior change, no new `#[allow]` carve-outs.

## Changes (3 sites, all curator-verified)

- **`loom-daemon/src/forge_parser.rs:91`** — inline `escaped_host` into the `format!` string; regex output unchanged.
- **`loom-daemon/src/init/scaffolding.rs`** (test-only) — inline `settings` in the flagged `assert!` format string; drop the trailing positional arg.
- **`loom-daemon/src/ipc.rs`** (test-only) — extract a `type TestContext = (...)` alias for `setup_test_context` to clear `clippy::type_complexity`; no call-site changes (tuple destructuring still works against the alias).

A crate-wide sweep confirms these are the only `uninlined_format_args` / `type_complexity` sites in `loom-daemon`.

## Scope / context

Per the curator's root-cause analysis: CI's actual `backend-lint-and-check` job **already allows** `uninlined_format_args` and does not pass `--all-targets`, so these never failed CI — they only bite a bare `cargo clippy` locally/in a worktree, which picks up the wider `.cargo/config.toml` rustflags. This PR clears that papercut without touching CI config.

The remaining pedantic/restriction lints that a full `--all-targets -- -D warnings` surfaces under the repo rustflags (`expect_used`, `panic`, `too_many_lines`, `items_after_statements`, `duration_suboptimal_units`, `format_collect`) are **out of scope** for this issue and left untouched.

## Verification

- `cargo clippy --package loom-daemon --all-targets -- -D clippy::uninlined_format_args -D clippy::type_complexity` — clean (both in-scope lints, zero hits crate-wide)
- CI-equivalent gate (`cargo clippy --package loom-daemon --package loom-api -- -D warnings -A clippy::...uninlined_format_args...`) — passes
- `cargo test --package loom-daemon` — all pass
- `cargo build --release` — succeeds
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)