### PR TITLE
test(daemon): tolerate appended issue refs in sweep_md Stage-1 doc-lint (#3833)

### DIFF
--- a/loom-daemon/tests/sweep_md_stage_minus_one_doc_lint.rs
+++ b/loom-daemon/tests/sweep_md_stage_minus_one_doc_lint.rs
@@ -256,9 +256,9 @@ fn sweep_md_stage_minus_one_wave_size_snippet_is_bash_3_2_portable() {
 fn sweep_md_limitations_table_records_stage_minus_one_implemented() {
     let content = read_sweep_md();
     assert!(
-        content.contains("Daemon backend detection") && content.contains("Implemented (#3454)"),
+        content.contains("Daemon backend detection") && content.contains("Implemented (#3454"),
         "sweep.md Limitations table is missing the `Daemon backend \
-         detection | Implemented (#3454)` row — #3454 AC #1 requires \
-         the operator-visible status flip"
+         detection | Implemented (#3454...` row — #3454 AC #1 requires \
+         the operator-visible status flip (tolerates appended issue refs, e.g. #3829)"
     );
 }


### PR DESCRIPTION
Closes #3833

Fixes red `main`: #3830 appended `#3829` to the sweep.md Limitations 'Daemon backend detection' row; the doc-lint regression guard asserted the exact old substring `Implemented (#3454)` (with closing paren), breaking every PR's merge-CI. Relaxes the assertion to the prefix `Implemented (#3454` — still guards that Stage -1 is recorded as implemented, tolerates appended issue refs. sweep.md itself is correct and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)