### PR TITLE
feat(installer): add --local/--gitignore mode to keep Loom files uncommitted (#3836)

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -362,6 +362,43 @@ Loom automatically updates `.gitignore` with ephemeral patterns:
 - ❌ `.loom/*.log` - Log files
 - ❌ `.loom/*.sock` - Unix socket files
 
+### Local (uncommitted) install mode (`--local`)
+
+By default the installer commits the Loom implementation (`.loom/`,
+`.claude/commands/loom/`, `.claude/agents/loom-*.md`, hooks) into the consumer
+repo. If you would rather use Loom in a repo **without** publishing/duplicating
+that implementation in the repo's history, run the installer in local mode:
+
+```bash
+./scripts/install-loom.sh --local /path/to/your/repo            # print untrack commands
+./scripts/install-loom.sh --local --untrack /path/to/your/repo  # also run them
+```
+
+`--local` (alias `--gitignore`) does **not** run the full copy-into-worktree +
+PR install. Instead it appends a Loom-managed, marker-delimited block to the
+target repo's `.gitignore` (idempotent — re-running refreshes it in place):
+
+```gitignore
+# >>> loom-local install (do not edit) >>>
+# Loom implementation files — installed via 'install-loom.sh --local', not committed to this repo (#3836)
+/.loom/
+/.claude/commands/loom/
+/.claude/agents/loom-*.md
+/.loom-local/
+# <<< loom-local install <<<
+```
+
+Because `.gitignore` alone will not stop tracking files that are already
+committed, local mode also detects any of those paths that git currently tracks
+and prints the exact `git rm -r --cached …` commands to untrack them. Pass
+`--untrack` to run those commands automatically (they stage deletions from the
+index; the files stay on disk — commit to finalize).
+
+> **Note:** local mode intentionally leaves genuinely project-specific config
+> tracked — `.github/labels.yml` is not under any ignored path. `.loom/config.json`
+> lives under the ignored `/.loom/` tree; relocating shared project config under a
+> future `.loom-project/` is left to a follow-up increment.
+
 ## Verifying Your Setup
 
 After installation, verify everything is working correctly:

--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -43,6 +43,8 @@ DOGFOOD_MODE=""  # "" (auto-detect), "true" (forced), "false" (forced off)
 ALLOW_NON_MAIN_SOURCE=false
 ALLOW_STALE_TARGET=false
 SKIP_TARGET_CI=false  # When true, install PR carries `[skip ci]` (issue #3333)
+LOCAL_MODE=false      # --local/--gitignore: keep Loom impl out of repo history (#3836)
+UNTRACK=false         # --untrack: run the git rm --cached commands (#3836)
 TARGET_PATH=""
 
 while [[ $# -gt 0 ]]; do
@@ -83,6 +85,14 @@ while [[ $# -gt 0 ]]; do
       SKIP_TARGET_CI=true
       shift
       ;;
+    --local|--gitignore)
+      LOCAL_MODE=true
+      shift
+      ;;
+    --untrack)
+      UNTRACK=true
+      shift
+      ;;
     -h|--help)
       echo "Usage: $0 [OPTIONS] /path/to/target-repo"
       echo ""
@@ -106,6 +116,16 @@ while [[ $# -gt 0 ]]; do
       echo "                             target repository's CI does not run on the install PR. Use only when"
       echo "                             the target's required-checks rulesets do not depend on CI completing"
       echo "                             (the universal GitHub-native skip directive)."
+      echo "  --local, --gitignore       Local (uncommitted) mode: instead of the full copy-into-worktree +"
+      echo "                             PR install, append a Loom-managed block of the installed"
+      echo "                             implementation paths (.loom/, .claude/commands/loom/,"
+      echo "                             .claude/agents/loom-*.md, .loom-local/) to the target repo's"
+      echo "                             .gitignore (idempotent) so the Loom files are never committed. If any"
+      echo "                             of those paths are already tracked, the exact 'git rm -r --cached'"
+      echo "                             commands to untrack them are printed. Does NOT run loom-daemon init."
+      echo "  --untrack                  With --local: actually run the 'git rm -r --cached' untrack commands"
+      echo "                             (staged as deletions; files stay on disk) instead of just printing"
+      echo "                             them. No effect without --local."
       echo "  -h, --help                 Show this help message"
       echo ""
       echo "Default install PR markers (always on — see .loom/docs/ci-integration.md after install):"
@@ -299,6 +319,85 @@ fi
 
 # Export for sub-scripts
 export NON_INTERACTIVE
+
+# --untrack is meaningless without --local (it modifies which files the local-mode
+# untrack step acts on). Fail loudly rather than silently ignoring it.
+if [[ "$UNTRACK" == "true" ]] && [[ "$LOCAL_MODE" != "true" ]]; then
+  error "--untrack requires --local (it controls the local-mode untrack step)"
+fi
+
+# ============================================================================
+# LOCAL MODE (--local / --gitignore) short-circuit (issue #3836)
+# ============================================================================
+# In local mode we deliberately do NOT run the full copy-into-worktree + PR
+# install. Instead we keep the installed Loom implementation out of the consumer
+# repo's git history:
+#   1. Append a Loom-managed block of the implementation paths to the target's
+#      .gitignore (idempotent — re-running refreshes the block in place).
+#   2. For any of those paths that are already tracked, print the exact
+#      `git rm -r --cached` commands to untrack them (gitignore alone does not
+#      stop tracking already-committed files), or run them when --untrack is set.
+#
+# This is a self-contained operation that runs BEFORE the source-state guard and
+# every heavy dependency/build step: no daemon build, no worktree, no PR. The
+# default committed-install path is completely unchanged unless --local is passed.
+if [[ "$LOCAL_MODE" == "true" ]]; then
+  # shellcheck source=scripts/install/local-mode.sh
+  source "$LOOM_ROOT/scripts/install/local-mode.sh"
+
+  LOCAL_TARGET="$(cd "$TARGET_PATH" 2>/dev/null && pwd)" || \
+    error "Target path does not exist: $TARGET_PATH"
+  if ! git -C "$LOCAL_TARGET" rev-parse --git-dir >/dev/null 2>&1; then
+    error "Target path is not a git repository: $LOCAL_TARGET"
+  fi
+
+  # Resolve to the main worktree root so .gitignore lands at the repo root, not
+  # inside a linked worktree.
+  LOCAL_MAIN_WT=$(git -C "$LOCAL_TARGET" worktree list --porcelain 2>/dev/null | head -4 | grep -m1 '^worktree ' | cut -d' ' -f2- || true)
+  if [[ -n "$LOCAL_MAIN_WT" ]] && [[ "$LOCAL_TARGET" != "$LOCAL_MAIN_WT" ]]; then
+    info "Target is inside a worktree; resolving to main repository root: $LOCAL_MAIN_WT"
+    LOCAL_TARGET="$LOCAL_MAIN_WT"
+  fi
+
+  header "Loom Local Mode (gitignore + untrack)"
+  echo ""
+  info "Target: $LOCAL_TARGET"
+  echo ""
+
+  if loom_local_apply_gitignore "$LOCAL_TARGET"; then
+    success "Wrote Loom-managed local-mode block to .gitignore (idempotent)"
+  else
+    error "Failed to update .gitignore in $LOCAL_TARGET"
+  fi
+  echo ""
+
+  # Collect the implementation paths git still tracks (bash 3.2: no mapfile).
+  LOCAL_TRACKED=()
+  while IFS= read -r _tracked_path; do
+    [[ -n "$_tracked_path" ]] && LOCAL_TRACKED+=("$_tracked_path")
+  done < <(loom_local_tracked_paths "$LOCAL_TARGET")
+
+  if [[ ${#LOCAL_TRACKED[@]} -eq 0 ]]; then
+    success "No installed Loom implementation paths are tracked — nothing to untrack"
+  elif [[ "$UNTRACK" == "true" ]]; then
+    info "Untracking ${#LOCAL_TRACKED[@]} Loom implementation path(s)..."
+    loom_local_run_untrack "$LOCAL_TARGET"
+    success "Untracked Loom implementation paths (staged as deletions — commit to finalize)"
+    info "The files remain on disk; only their git tracking was removed."
+  else
+    warning "These installed Loom implementation paths are still tracked:"
+    printf '    %s\n' "${LOCAL_TRACKED[@]}"
+    echo ""
+    info "Run these commands to untrack them (or re-run with --untrack):"
+    loom_local_untrack_commands "$LOCAL_TARGET" | sed 's/^/    /'
+  fi
+  echo ""
+  success "Local mode complete"
+
+  # Disable the error/cleanup trap and exit cleanly — no worktree was created.
+  trap - EXIT SIGINT SIGTERM
+  exit 0
+fi
 
 # Source-state guard (#3327): before doing any heavy work, verify that the
 # Loom source checkout is on a clean main. Refuse / prompt / continue based

--- a/scripts/install/local-mode.sh
+++ b/scripts/install/local-mode.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# scripts/install/local-mode.sh — Loom "local" (gitignore/untracked) install mode
+# helper (issue #3836).
+#
+# `install-loom.sh --local` (alias `--gitignore`) installs Loom into a consumer
+# repo WITHOUT publishing/duplicating the Loom implementation in that repo's git
+# history. This helper provides the two self-contained primitives that mode needs:
+#
+#   1. loom_local_apply_gitignore <target>
+#        Idempotently write a Loom-managed block of the installed implementation
+#        paths into <target>/.gitignore (marker-delimited, refreshed in place).
+#
+#   2. loom_local_tracked_paths / loom_local_untrack_commands / loom_local_run_untrack
+#        Detect which of those paths git already tracks (gitignore alone does not
+#        stop tracking already-committed files) and either print or run the
+#        `git rm -r --cached` commands to untrack them.
+#
+# The helper is deliberately isolated in its own file (matching manifest.sh,
+# stash-scope.sh, dogfood-commands.sh) so the test suite can exercise it without
+# sourcing the full installer, which has argv-parsing side effects.
+#
+# Source this file with:
+#     source "$LOOM_ROOT/scripts/install/local-mode.sh"
+#
+# Bash 3.2 compatible (stock macOS) — no associative arrays, no mapfile.
+
+# Marker sentinels for the Loom-managed local-mode block. Distinct from the
+# daemon's runtime-state block ("# >>> loom-managed (do not edit) >>>", written
+# by loom-daemon's update_gitignore) so the two blocks never collide: the daemon
+# refreshes its block in place on every init and would otherwise strip these
+# implementation paths back out.
+LOOM_LOCAL_GITIGNORE_BEGIN="# >>> loom-local install (do not edit) >>>"
+LOOM_LOCAL_GITIGNORE_END="# <<< loom-local install <<<"
+LOOM_LOCAL_GITIGNORE_HEADER="# Loom implementation files — installed via 'install-loom.sh --local', not committed to this repo (#3836)"
+
+# The installed Loom implementation paths kept out of version control in local
+# mode. Anchored with a leading '/' so they only match at the repo root.
+#
+# Deliberately excludes genuinely project-specific config that SHOULD stay
+# tracked and shared across a team — notably `.github/labels.yml` (not under any
+# ignored path here). `.loom/config.json` lives under the ignored `/.loom/`
+# tree; moving project-specific config under a future `.loom-project/` is left to
+# a follow-up increment (see the issue's scope notes).
+LOOM_LOCAL_IGNORE_PATTERNS=(
+  "/.loom/"
+  "/.claude/commands/loom/"
+  "/.claude/agents/loom-*.md"
+  "/.loom-local/"
+)
+
+# Concrete pathspecs used to detect + untrack already-committed implementation
+# files. Directories are removed recursively; the agents entry is a git
+# pathspec glob (git expands it, not the shell).
+LOOM_LOCAL_UNTRACK_PATHS=(
+  ".loom"
+  ".claude/commands/loom"
+  ".claude/agents/loom-*.md"
+  ".loom-local"
+)
+
+# Emit the full Loom-managed local-mode block (begin marker, header, patterns,
+# end marker), one line each, with a trailing newline.
+_loom_local_block() {
+  printf '%s\n' "$LOOM_LOCAL_GITIGNORE_BEGIN"
+  printf '%s\n' "$LOOM_LOCAL_GITIGNORE_HEADER"
+  local _p
+  for _p in "${LOOM_LOCAL_IGNORE_PATTERNS[@]}"; do
+    printf '%s\n' "$_p"
+  done
+  printf '%s\n' "$LOOM_LOCAL_GITIGNORE_END"
+}
+
+# Idempotently write the managed block into <target>/.gitignore.
+#   - No .gitignore            → create one containing only the block.
+#   - Block already present    → replace it in place (refresh).
+#   - Block absent, file exists → append, separated by one blank line.
+# Returns non-zero on any filesystem failure.
+loom_local_apply_gitignore() {
+  local target="$1"
+  local gitignore="$target/.gitignore"
+
+  if [[ ! -f "$gitignore" ]]; then
+    _loom_local_block > "$gitignore"
+    return $?
+  fi
+
+  # Strip any existing managed block so the refresh is idempotent.
+  local tmp
+  tmp="$(mktemp)" || return 1
+  awk -v begin="$LOOM_LOCAL_GITIGNORE_BEGIN" -v end="$LOOM_LOCAL_GITIGNORE_END" '
+    $0 == begin { inblock=1; next }
+    inblock && $0 == end { inblock=0; next }
+    inblock { next }
+    { print }
+  ' "$gitignore" > "$tmp" || { rm -f "$tmp"; return 1; }
+
+  # Drop trailing blank lines so we fully control the spacing before the block.
+  local tmp2
+  tmp2="$(mktemp)" || { rm -f "$tmp"; return 1; }
+  awk '
+    { lines[NR] = $0 }
+    END {
+      last = NR
+      while (last > 0 && lines[last] ~ /^[[:space:]]*$/) last--
+      for (i = 1; i <= last; i++) print lines[i]
+    }
+  ' "$tmp" > "$tmp2" || { rm -f "$tmp" "$tmp2"; return 1; }
+  rm -f "$tmp"
+
+  # Separate the block from any preceding content with a single blank line.
+  if [[ -s "$tmp2" ]]; then
+    printf '\n' >> "$tmp2"
+  fi
+  _loom_local_block >> "$tmp2" || { rm -f "$tmp2"; return 1; }
+  mv "$tmp2" "$gitignore"
+}
+
+# Print (one per line) the installed Loom implementation pathspecs that git
+# currently tracks in <target>. Nothing is printed for paths with no tracked
+# files, so an empty result means there is nothing to untrack.
+loom_local_tracked_paths() {
+  local target="$1"
+  local p tracked
+  for p in "${LOOM_LOCAL_UNTRACK_PATHS[@]}"; do
+    # `git ls-files -- <pathspec>` honors glob pathspecs (e.g. loom-*.md).
+    tracked="$(git -C "$target" ls-files -- "$p" 2>/dev/null)"
+    if [[ -n "$tracked" ]]; then
+      printf '%s\n' "$p"
+    fi
+  done
+}
+
+# Print the exact `git rm -r --cached` commands needed to untrack the currently
+# tracked implementation paths. Safe to copy/paste; each pathspec is quoted so
+# the shell does not expand the agents glob before git sees it.
+loom_local_untrack_commands() {
+  local target="$1"
+  local p
+  while IFS= read -r p; do
+    [[ -n "$p" ]] || continue
+    printf "git rm -r --cached -- '%s'\n" "$p"
+  done < <(loom_local_tracked_paths "$target")
+}
+
+# Actually untrack the currently tracked implementation paths in <target>. Files
+# stay on disk; only their index entries are removed (staged as deletions). The
+# caller is responsible for committing.
+loom_local_run_untrack() {
+  local target="$1"
+  local p
+  while IFS= read -r p; do
+    [[ -n "$p" ]] || continue
+    git -C "$target" rm -r --cached --quiet -- "$p"
+  done < <(loom_local_tracked_paths "$target")
+}

--- a/scripts/test-install-local-mode.sh
+++ b/scripts/test-install-local-mode.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+# Test suite for install-loom.sh --local / --gitignore mode (issue #3836).
+#
+# Covers both the sourceable helper (scripts/install/local-mode.sh) in isolation
+# and the installer's --local short-circuit end-to-end. Neither path builds the
+# daemon or touches the network — the short-circuit runs before every heavy step
+# — so this suite runs fast against local temp git repos with no gh auth.
+#
+# Usage: bash scripts/test-install-local-mode.sh
+
+set -uo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+passed=0
+failed=0
+
+pass() { echo -e "${GREEN}✓${NC} $1"; passed=$((passed + 1)); }
+fail() { echo -e "${RED}✗${NC} $1"; failed=$((failed + 1)); }
+warn() { echo -e "${YELLOW}!${NC} $1"; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOOM_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INSTALL_SCRIPT="$LOOM_ROOT/scripts/install-loom.sh"
+HELPER="$LOOM_ROOT/scripts/install/local-mode.sh"
+
+TEST_DIR="$(mktemp -d)"
+cleanup() { [[ -n "${TEST_DIR:-}" && -d "$TEST_DIR" ]] && rm -rf "$TEST_DIR"; }
+trap cleanup EXIT
+
+# Create a fresh git repo that already has Loom implementation files committed
+# (simulating a prior committed install), plus a project-specific labels.yml.
+make_repo() {
+  local repo="$1"
+  mkdir -p "$repo"
+  git -C "$repo" init --quiet
+  git -C "$repo" config user.email "test@example.com"
+  git -C "$repo" config user.name "Test"
+  mkdir -p "$repo/.loom/scripts" \
+           "$repo/.claude/commands/loom" \
+           "$repo/.claude/agents" \
+           "$repo/.github"
+  echo '{}' > "$repo/.loom/config.json"
+  echo 'echo hi' > "$repo/.loom/scripts/worktree.sh"
+  echo 'builder cmd' > "$repo/.claude/commands/loom/builder.md"
+  echo 'builder agent' > "$repo/.claude/agents/loom-builder.md"
+  echo 'not loom' > "$repo/.claude/agents/other.md"
+  echo 'labels' > "$repo/.github/labels.yml"
+  echo 'node_modules/' > "$repo/.gitignore"
+  git -C "$repo" add -A
+  git -C "$repo" commit -q -m "initial with committed loom files"
+}
+
+echo "======================================"
+echo "install-loom.sh --local mode tests"
+echo "======================================"
+echo ""
+
+# ==========================================================================
+# Helper-level tests (source local-mode.sh directly)
+# ==========================================================================
+echo "--- Helper (scripts/install/local-mode.sh) ---"
+
+HREPO="$TEST_DIR/helper-repo"
+make_repo "$HREPO"
+
+(
+  set +e
+  # shellcheck source=scripts/install/local-mode.sh
+  source "$HELPER"
+
+  # 1. apply_gitignore writes the managed block
+  loom_local_apply_gitignore "$HREPO"
+  gi="$HREPO/.gitignore"
+  if grep -qF "$LOOM_LOCAL_GITIGNORE_BEGIN" "$gi" \
+     && grep -qF "$LOOM_LOCAL_GITIGNORE_END" "$gi" \
+     && grep -qF "/.loom/" "$gi" \
+     && grep -qF "/.claude/commands/loom/" "$gi" \
+     && grep -qF "/.claude/agents/loom-*.md" "$gi" \
+     && grep -qF "/.loom-local/" "$gi"; then
+    echo "PASS block-written"
+  else
+    echo "FAIL block-written"
+  fi
+
+  # Pre-existing content preserved
+  grep -qF "node_modules/" "$gi" && echo "PASS preexisting-preserved" || echo "FAIL preexisting-preserved"
+
+  # 2. Idempotency — re-run produces exactly one block, identical file
+  before="$(cat "$gi")"
+  loom_local_apply_gitignore "$HREPO"
+  loom_local_apply_gitignore "$HREPO"
+  after="$(cat "$gi")"
+  begin_count="$(grep -cF "$LOOM_LOCAL_GITIGNORE_BEGIN" "$gi")"
+  if [[ "$before" == "$after" ]] && [[ "$begin_count" -eq 1 ]]; then
+    echo "PASS idempotent"
+  else
+    echo "FAIL idempotent (begin_count=$begin_count)"
+  fi
+
+  # 3. tracked-paths detection finds the committed impl paths (and the glob)
+  tracked="$(loom_local_tracked_paths "$HREPO")"
+  if echo "$tracked" | grep -qxF ".loom" \
+     && echo "$tracked" | grep -qxF ".claude/commands/loom" \
+     && echo "$tracked" | grep -qxF ".claude/agents/loom-*.md"; then
+    echo "PASS tracked-detected"
+  else
+    echo "FAIL tracked-detected [$tracked]"
+  fi
+
+  # 4. untrack-commands prints quoted git rm lines
+  cmds="$(loom_local_untrack_commands "$HREPO")"
+  if echo "$cmds" | grep -qF "git rm -r --cached -- '.loom'" \
+     && echo "$cmds" | grep -qF "git rm -r --cached -- '.claude/agents/loom-*.md'"; then
+    echo "PASS untrack-commands"
+  else
+    echo "FAIL untrack-commands"
+  fi
+
+  # 5. run_untrack actually removes them from the index (files stay on disk)
+  loom_local_run_untrack "$HREPO"
+  still="$(loom_local_tracked_paths "$HREPO")"
+  if [[ -z "$still" ]] \
+     && [[ -f "$HREPO/.loom/config.json" ]] \
+     && [[ -f "$HREPO/.claude/agents/loom-builder.md" ]]; then
+    echo "PASS run-untrack"
+  else
+    echo "FAIL run-untrack [$still]"
+  fi
+
+  # 6. non-loom + project config stay tracked
+  if [[ -n "$(git -C "$HREPO" ls-files -- .github/labels.yml)" ]] \
+     && [[ -n "$(git -C "$HREPO" ls-files -- .claude/agents/other.md)" ]]; then
+    echo "PASS project-config-preserved"
+  else
+    echo "FAIL project-config-preserved"
+  fi
+) > "$TEST_DIR/helper.out" 2>&1
+
+while IFS= read -r line; do
+  case "$line" in
+    PASS*) pass "${line#PASS }" ;;
+    FAIL*) fail "${line#FAIL }" ;;
+  esac
+done < "$TEST_DIR/helper.out"
+echo ""
+
+# ==========================================================================
+# End-to-end: install-loom.sh --local
+# ==========================================================================
+echo "--- install-loom.sh --local (end-to-end) ---"
+
+# 1. --local without --untrack: writes block, prints commands, leaves tracked.
+E1="$TEST_DIR/e2e-print"
+make_repo "$E1"
+OUT1="$(bash "$INSTALL_SCRIPT" --local "$E1" 2>&1)" && rc1=0 || rc1=$?
+if [[ "$rc1" -eq 0 ]]; then pass "--local exits 0"; else fail "--local exits 0 (rc=$rc1)"; fi
+if grep -qF "# >>> loom-local install (do not edit) >>>" "$E1/.gitignore"; then
+  pass "--local wrote gitignore block"
+else
+  fail "--local wrote gitignore block"
+fi
+if echo "$OUT1" | grep -qF "git rm -r --cached -- '.loom'"; then
+  pass "--local printed untrack commands"
+else
+  fail "--local printed untrack commands"
+fi
+if [[ -n "$(git -C "$E1" ls-files -- .loom)" ]]; then
+  pass "--local (no --untrack) leaves files tracked"
+else
+  fail "--local (no --untrack) leaves files tracked"
+fi
+
+# 2. --local --untrack: files no longer tracked afterward (core acceptance).
+E2="$TEST_DIR/e2e-untrack"
+make_repo "$E2"
+bash "$INSTALL_SCRIPT" --local --untrack "$E2" > "$TEST_DIR/e2e2.out" 2>&1 && rc2=0 || rc2=$?
+if [[ "$rc2" -eq 0 ]]; then pass "--local --untrack exits 0"; else fail "--local --untrack exits 0 (rc=$rc2)"; fi
+if [[ -z "$(git -C "$E2" ls-files -- .loom)" ]] \
+   && [[ -z "$(git -C "$E2" ls-files -- .claude/commands/loom)" ]] \
+   && [[ -z "$(git -C "$E2" ls-files -- '.claude/agents/loom-*.md')" ]]; then
+  pass "--local --untrack: Loom impl files not tracked afterward"
+else
+  fail "--local --untrack: Loom impl files not tracked afterward"
+fi
+if [[ -f "$E2/.loom/config.json" ]] && [[ -n "$(git -C "$E2" ls-files -- .github/labels.yml)" ]]; then
+  pass "--local --untrack: files on disk + project config still tracked"
+else
+  fail "--local --untrack: files on disk + project config still tracked"
+fi
+
+# 3. --gitignore alias behaves like --local
+E3="$TEST_DIR/e2e-alias"
+make_repo "$E3"
+bash "$INSTALL_SCRIPT" --gitignore "$E3" > /dev/null 2>&1 || true
+if grep -qF "# >>> loom-local install (do not edit) >>>" "$E3/.gitignore"; then
+  pass "--gitignore alias writes block"
+else
+  fail "--gitignore alias writes block"
+fi
+
+# 4. Idempotency end-to-end: running twice keeps a single block.
+bash "$INSTALL_SCRIPT" --gitignore "$E3" > /dev/null 2>&1 || true
+if [[ "$(grep -cF "# >>> loom-local install (do not edit) >>>" "$E3/.gitignore")" -eq 1 ]]; then
+  pass "--local end-to-end idempotent (single block)"
+else
+  fail "--local end-to-end idempotent (single block)"
+fi
+
+# 5. --untrack without --local is rejected.
+E4="$TEST_DIR/e2e-guard"
+make_repo "$E4"
+if bash "$INSTALL_SCRIPT" --untrack "$E4" > /dev/null 2>&1; then
+  fail "--untrack without --local should error"
+else
+  pass "--untrack without --local errors"
+fi
+
+# 6. --local on a repo with no prior .gitignore creates one with the block.
+E5="$TEST_DIR/e2e-nogitignore"
+mkdir -p "$E5"
+git -C "$E5" init --quiet
+git -C "$E5" config user.email "t@e.com"; git -C "$E5" config user.name "T"
+echo x > "$E5/f"; git -C "$E5" add -A; git -C "$E5" commit -q -m init
+bash "$INSTALL_SCRIPT" --local "$E5" > /dev/null 2>&1 || true
+if [[ -f "$E5/.gitignore" ]] && grep -qF "/.loom/" "$E5/.gitignore"; then
+  pass "--local creates .gitignore when absent"
+else
+  fail "--local creates .gitignore when absent"
+fi
+
+# 7. --local help text is documented.
+HELP_OUT="$(bash "$INSTALL_SCRIPT" --help 2>&1)"
+if printf '%s' "$HELP_OUT" | grep -qF -- "--local"; then
+  pass "--local documented in --help"
+else
+  fail "--local documented in --help"
+fi
+
+echo ""
+echo "======================================"
+echo "Test Summary"
+echo "======================================"
+echo -e "${GREEN}Passed: $passed${NC}"
+echo -e "${RED}Failed: $failed${NC}"
+echo ""
+
+if [ "$failed" -eq 0 ]; then
+  echo -e "${GREEN}All tests passed!${NC}"
+  exit 0
+else
+  echo -e "${RED}Some tests failed.${NC}"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adds a local (uncommitted) install mode so Loom can be installed into a consumer repo **without** publishing/duplicating the Loom implementation in that repo's git history.

`install-loom.sh --local <repo>` (alias `--gitignore`) short-circuits the full copy-into-worktree + PR install and instead:

1. Appends a Loom-managed, marker-delimited block of the installed implementation paths to the target's `.gitignore`, **idempotently** (refreshed in place on re-run):
   ```gitignore
   # >>> loom-local install (do not edit) >>>
   # Loom implementation files — installed via 'install-loom.sh --local', not committed to this repo (#3836)
   /.loom/
   /.claude/commands/loom/
   /.claude/agents/loom-*.md
   /.loom-local/
   # <<< loom-local install <<<
   ```
2. Detects which of those paths git already tracks (gitignore alone will not stop tracking already-committed files) and **prints the exact `git rm -r --cached` commands** to untrack them. `--untrack` runs them instead (staged as deletions; files stay on disk).
3. Leaves genuinely project-specific config tracked — `.github/labels.yml` is not under any ignored path. Relocating `.loom/config.json` under a future `.loom-project/` is documented as a follow-up.

The marker sentinels are deliberately distinct from the daemon's runtime-state block (`# >>> loom-managed (do not edit) >>>`) so the two never collide (the daemon refreshes its block in place and would otherwise strip these paths).

## Design

Core logic lives in a sourceable helper `scripts/install/local-mode.sh` (matching the `manifest.sh` / `stash-scope.sh` / `dogfood-commands.sh` convention) so it is unit-testable without the installer's argv side effects. Bash 3.2 compatible (no `mapfile`/associative arrays).

The short-circuit runs before the source-state guard and every heavy step: **no daemon build, no worktree, no PR, no network**. `--untrack` without `--local` is rejected.

## Acceptance criteria

- [x] `install-loom.sh --local <repo>` writes the gitignore block idempotently and (with `--untrack`) the installed Loom files are not tracked afterward.
- [x] Default committed-install behavior unchanged unless the flag is passed (only new flag branches + a guarded early short-circuit were added; 131 existing installer tests still pass).
- [x] Installer test coverage for the new mode (`scripts/test-install-local-mode.sh`, 19 assertions).
- [x] Pre-existing committed history is untouched (untrack only affects the index).
- [x] Documented in installer `--help` and `docs/guides/getting-started.md`.

## Test evidence

- `scripts/test-install-local-mode.sh` — **19 passed / 0 failed** (helper-level: block write, idempotency, tracked-path detection, untrack command printing, actual untrack, project-config preservation; end-to-end: `--local` print-only, `--local --untrack` untracks, `--gitignore` alias, end-to-end idempotency, `--untrack` guard, no-preexisting-gitignore, `--help` documented).
- `scripts/test-installer.sh` — **131 passed / 0 failed** (no regression to the default path).
- `shellcheck scripts/install/local-mode.sh` clean; new code in `scripts/install-loom.sh` adds no new findings.

Closes #3836

🤖 Generated with [Claude Code](https://claude.com/claude-code)