### PR TITLE
fix(ci): tolerant doc-lint assertion + align .cargo clippy with CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,37 +6,56 @@
 # Set RUSTFLAGS="-D warnings" in CI to enforce this
 
 [target.'cfg(all())']
-# Default clippy lints for all targets
+# Clippy lint config for all targets.
+#
+# IMPORTANT (#3837): this block is kept in *exact sync* with the clippy
+# invocation in `.github/workflows/ci.yml` (the `backend-lint-and-check`
+# job), which runs:
+#
+#   cargo clippy --package loom-daemon --package loom-api -- -D warnings \
+#     -A clippy::cast_precision_loss -A clippy::cast_possible_truncation \
+#     -A clippy::cast_sign_loss -A clippy::too_many_lines -A clippy::panic \
+#     -A clippy::unwrap_used -A clippy::nonminimal_bool \
+#     -A clippy::redundant_closure -A clippy::redundant_closure_for_method_calls \
+#     -A clippy::format_push_string -A clippy::uninlined_format_args
+#
+# Mirroring CI's allow-list here means a bare local `cargo clippy` reproduces
+# CI's pass/fail — no more "is this failure mine or pre-existing?" (#3828).
+#
+# We intentionally do NOT enable `clippy::pedantic`: CI never enforced it, and
+# enabling it locally surfaced a large class of lints CI allows (casts,
+# too_many_lines, redundant closures, uninlined format args, …), reliably
+# red-ing bare local clippy while CI stayed green. `-D clippy::all` (below)
+# minus CI's allow-list is exactly CI's effective clippy lint set.
+#
+# Residual, documented divergence: CI passes `-D warnings`, which also promotes
+# *rustc* warnings (e.g. `dead_code`, `unused_variables`) to hard errors. We
+# keep those at `-W` here so ordinary local `cargo build`/`cargo test` stay
+# dev-friendly (a warning during iteration doesn't abort the build). The clippy
+# *lint selection* — the source of the #3828 confusion — is identical.
 rustflags = [
-    # Deny clippy lints that indicate bugs or poor practices
+    # Deny the default clippy lint set (correctness + suspicious + style +
+    # complexity + perf). CI denies the same set via `-D warnings`.
     "-D", "clippy::all",
-    "-D", "clippy::correctness",
-    "-D", "clippy::suspicious",
-    "-D", "clippy::complexity",
 
-    # Warn on pedantic lints (can be noisy but helpful)
-    "-W", "clippy::pedantic",
+    # CI allow-list — MUST stay identical to .github/workflows/ci.yml.
+    # These lints live inside `clippy::all`/pedantic; CI allows them, so we
+    # allow them too (a later `-A` overrides the earlier `-D clippy::all`).
+    "-A", "clippy::cast_precision_loss",
+    "-A", "clippy::cast_possible_truncation",
+    "-A", "clippy::cast_sign_loss",
+    "-A", "clippy::too_many_lines",
+    "-A", "clippy::panic",
+    "-A", "clippy::unwrap_used",
+    "-A", "clippy::nonminimal_bool",
+    "-A", "clippy::redundant_closure",
+    "-A", "clippy::redundant_closure_for_method_calls",
+    "-A", "clippy::format_push_string",
+    "-A", "clippy::uninlined_format_args",
 
-    # Warn on performance issues
-    "-W", "clippy::perf",
-
-    # Warn on style issues
-    "-W", "clippy::style",
-
-    # Specific lints we want to enforce
-    "-W", "clippy::unwrap_used",
-    "-W", "clippy::expect_used",
-    "-W", "clippy::panic",
-    "-W", "clippy::todo",
-    "-W", "clippy::unimplemented",
-
-    # Warn on dead code (unused functions, variables, etc.)
+    # Warn (not deny) on dead code so it surfaces locally without aborting
+    # iterative builds. CI's `-D warnings` denies it — see the note above.
     "-W", "dead_code",
-
-    # Allow some pedantic lints that are too noisy
-    "-A", "clippy::missing_errors_doc",
-    "-A", "clippy::missing_panics_doc",
-    "-A", "clippy::module_name_repetitions",
 ]
 
 [target.aarch64-apple-darwin]

--- a/loom-daemon/tests/sweep_md_doc_lint.rs
+++ b/loom-daemon/tests/sweep_md_doc_lint.rs
@@ -262,8 +262,12 @@ fn sweep_md_documents_model_experiment_mode() {
 fn sweep_md_documents_experiment_tier_2_5_suppression() {
     let content = read_sweep_md();
     assert!(
-        content.contains("Experiment-mode suppression (issue #3725)"),
-        "sweep.md must document the tier-2.5 suppression note (#3725 hard AC)"
+        // Prefix match (no closing paren) tolerates appended issue refs, e.g.
+        // a future edit turning `(issue #3725)` into `(issue #3725, #NNNN)`.
+        // See #3833/#3837 for why exact-paren literals red main on doc edits.
+        content.contains("Experiment-mode suppression (issue #3725"),
+        "sweep.md must document the tier-2.5 suppression note (#3725 hard AC; \
+         tolerates appended issue refs)"
     );
     assert!(
         content.contains("SUPPRESSES this tier-2.5 bump"),


### PR DESCRIPTION
Closes #3837

## Problem
Two brittleness sources red-ed `main` and forced every daemon PR this cycle to reason about "is this failure mine or pre-existing?":

1. **Brittle doc-lint**: exact-literal `contains("… (#NNNN)")` assertions with a closing paren break when a legitimate doc edit appends an issue ref (the #3830/#3833 failure mode). Because CI evaluates PRs as a merge with main, one broken doc-lint blocks *every* open PR.
2. **Clippy config divergence**: `.cargo/config.toml` enabled `-W clippy::pedantic` + `-D clippy::all` with no allow-list, while CI's `.github/workflows/ci.yml` allows a specific list (`cast_*`, `too_many_lines`, `nonminimal_bool`, `redundant_closure*`, `format_push_string`, `uninlined_format_args`). Bare local `cargo clippy` hard-errored on lints CI never enforces (#3828).

## Changes
- **Doc-lint tolerance** (`loom-daemon/tests/sweep_md_doc_lint.rs`): relaxed the tier-2.5 suppression guard from the exact literal `Experiment-mode suppression (issue #3725)` to a prefix match (no closing paren), mirroring the #3833 fix. It still asserts the note exists while tolerating appended refs. This was the **only** remaining `contains("… (#NNNN)")` closing-paren needle across all `loom-daemon/tests/*_doc_lint.rs` (the Limitations-table row #3833 fixed was the other); all other needles are stable identifiers/headers or non-load-bearing assertion messages.
- **Clippy alignment** (`.cargo/config.toml`): rewrote the `rustflags` block to mirror CI's allow-list exactly and dropped `clippy::pedantic`, so `-D clippy::all` minus CI's allow-list == CI's effective clippy lint set. A bare local `cargo clippy` now reproduces CI's pass/fail. Documented the one residual divergence: CI's `-D warnings` also promotes rustc warnings (e.g. `dead_code`) to errors; the config keeps those at `-W` for dev-friendly local builds. The clippy *lint selection* (the #3828 source of confusion) is now identical.

## Scope item 3 (optional guard) — already covered
A guard so a doc-only change can't red the Rust CI already exists: `ci.yml` uses `dorny/paths-filter@v4`, and the `backend-lint-and-check` / `backend-tests` jobs run only on `push` to main or when a PR touches `loom-daemon/**`, `loom-api/**`, `Cargo.*`, `rust-toolchain.toml`, or `ci.yml`. Doc-only PRs skip them. No new guard added.

## Verification
- All `*_doc_lint` tests pass.
- Simulated a #3830-style edit (`(issue #3725)` -> `(issue #3725, #9999)`) — the tolerant assertion stays green; reverted before committing.
- `cargo test --workspace` green (all suites, 426 daemon unit tests + integration).
- CI-style clippy invocation **and** bare `cargo clippy --package loom-daemon --package loom-api` both green.
- `cargo fmt --all --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)