### PR TITLE
feat(state-machine): executable spec of the Loom label graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,84 @@ For continuous multi-account batches, run the `loom-daemon` (Tier 2) and enqueue
 
 See [WORKFLOWS.md](docs/workflows.md) for complete label documentation.
 
+## Loom State Machine
+
+Loom coordinates its agents entirely through labels. The full label graph — four
+lanes (issue, PR, proposal, epic supervisor), the role that fires each edge, and
+the epic fork-join barriers — is modeled as an **executable specification** in
+[`loom-tools/src/loom_tools/state_machine.py`](loom-tools/src/loom_tools/state_machine.py).
+A CI test (`loom-tools/tests/test_state_machine.py`) validates the graph for
+reachability, dead-ends, label conflation, autonomy gaps, and barrier hygiene,
+and keeps the diagram below in sync with the model.
+
+The five `epic:*` states are **derived** — they all ride the single `loom:epic`
+label and are computed by the daemon-native epic supervisor, so no new labels
+are minted. Edges marked "creates issues" are the ones the #3707 issue-filing
+mutex must serialize.
+
+> Regenerate this diagram with `python -m loom_tools.state_machine --mermaid`.
+
+```mermaid
+stateDiagram-v2
+    state "Issue lane" as lane_issue {
+        s_new : new
+        s_loom_triage : loom:triage
+        s_loom_curating : loom:curating
+        s_loom_curated : loom:curated
+        s_loom_issue : loom:issue
+        s_loom_building : loom:building
+        s_closed : closed
+    }
+    state "PR lane" as lane_pr {
+        s_loom_review_requested : loom:review-requested
+        s_loom_changes_requested : loom:changes-requested
+        s_loom_pr : loom:pr
+        s_merged : merged
+    }
+    state "Proposal lane" as lane_proposal {
+        s_loom_architect : loom:architect
+        s_loom_hermit : loom:hermit
+        s_loom_auditor : loom:auditor
+    }
+    state "Epic supervisor lane (derived — loom:epic)" as lane_epic {
+        s_epic_needs_decomp : epic:needs_decomp
+        s_epic_designed : epic:designed
+        s_epic_active : epic:active
+        s_epic_phase_join : epic:phase_join
+        s_epic_done : epic:done
+    }
+    [*] --> s_new
+    s_new --> s_loom_triage : Human
+    s_loom_triage --> s_loom_curating : Curator
+    s_loom_curating --> s_loom_curated : Curator
+    s_loom_curated --> s_loom_issue : Human
+    s_loom_issue --> s_loom_building : Builder
+    s_loom_building --> s_loom_review_requested : Builder
+    s_loom_building --> s_closed : Champion
+    s_loom_review_requested --> s_loom_pr : Judge
+    s_loom_review_requested --> s_loom_changes_requested : Judge
+    s_loom_changes_requested --> s_loom_review_requested : Doctor
+    s_loom_pr --> s_merged : Champion
+    s_new --> s_loom_architect : Architect · creates issues
+    s_new --> s_loom_hermit : Hermit · creates issues
+    s_new --> s_loom_auditor : Auditor · creates issues
+    s_loom_architect --> s_loom_issue : Champion
+    s_loom_architect --> s_closed : Champion
+    s_loom_hermit --> s_loom_issue : Champion
+    s_loom_hermit --> s_closed : Champion
+    s_loom_auditor --> s_loom_issue : Champion
+    s_loom_auditor --> s_closed : Champion
+    s_new --> s_epic_needs_decomp : Architect
+    s_epic_needs_decomp --> s_epic_designed : Champion · creates issues
+    s_epic_designed --> s_epic_active : Champion
+    s_epic_active --> s_epic_phase_join : Supervisor · barrier: fork-join: current phase complete
+    s_epic_phase_join --> s_epic_active : Supervisor · barrier: advance: dispatch next phase
+    s_epic_phase_join --> s_epic_done : Supervisor · barrier: join: all phases complete
+    s_closed --> [*]
+    s_merged --> [*]
+    s_epic_done --> [*]
+```
+
 ## Features
 
 **Autonomous Orchestration**

--- a/loom-tools/pyproject.toml
+++ b/loom-tools/pyproject.toml
@@ -53,6 +53,7 @@ loom-backlog = "loom_tools.backlog:main"
 loom-forge = "loom_tools.forge_cli:cli_main"
 loom-auto-merge = "loom_tools.auto_merge:main"
 loom-tokens = "loom_tools.tokens.cli:main"
+loom-state-machine = "loom_tools.state_machine:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/loom-tools/src/loom_tools/state_machine.py
+++ b/loom-tools/src/loom_tools/state_machine.py
@@ -1,0 +1,503 @@
+"""Executable specification of the Loom label state machine.
+
+Loom coordinates its AI agents entirely through GitHub/Gitea *labels*: an issue
+walks ``loom:triage → loom:curating → loom:curated → loom:issue → loom:building``,
+a PR walks ``loom:review-requested ↔ loom:changes-requested → loom:pr → merged``,
+proposals originate as ``loom:architect|hermit|auditor``, and epics run a
+fork-join supervisor loop. Until now that graph existed **only implicitly**,
+scattered across role prompts (``curator.md``, ``champion-epic.md``,
+``sweep.md``, …). There was no single source of truth and no mechanical way to
+catch a structural regression — an unreachable state, a dead-end, two logical
+states conflated onto one label, or a missing fork-join barrier.
+
+This module is that single source of truth: a pure-stdlib model of the graph
+plus a :func:`StateMachine.validate` pass that returns ``(errors, warnings,
+notes)``. It also renders the graph as a Mermaid ``stateDiagram-v2`` (the
+``--mermaid`` flag / :func:`StateMachine.render_mermaid`) so the README diagram
+can be kept in lockstep with the model by a CI test.
+
+Modeling the graph immediately surfaced a real, live bug: ``epic:needs_decomp``
+was a **dead-end** — an epic with no phase structure had no autonomous
+transition forward, so the whole epic-supervisor sub-graph was unreachable.
+That is exactly why epics did not advance autonomously. The canonical graph
+here includes the *fix* (the Champion decomposition edge
+``epic:needs_decomp → epic:designed``) so it validates clean; the deliberately
+broken variants used in the tests are where the validators fire.
+
+Design notes
+------------
+* **Only existing GitHub labels are used.** The five epic-supervisor states all
+  ride the single ``loom:epic`` label and are marked ``derived=True`` — they are
+  computed by the daemon-native supervisor rather than distinguished by a
+  dedicated label. The label-conflation validator special-cases this: >1 state
+  sharing a label is an ERROR *unless* every such state is ``derived`` (then a
+  NOTE). See issue about not minting new labels for epic phases.
+* **#3707 mutex coverage.** Transitions that call ``gh issue create`` carry
+  ``creates_issues=True``; the validator enumerates them as the set the global
+  issue-filing mutex (#3707) must serialize (Architect/Hermit/Auditor proposal
+  filing + Champion epic decomposition; Curator oversized-issue decomposition is
+  serialized under the same invariant even though it does not change label
+  state).
+
+Run ``python -m loom_tools.state_machine`` to validate, or
+``python -m loom_tools.state_machine --mermaid`` to emit the diagram.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Iterator, Optional
+
+
+# ---------------------------------------------------------------------------
+# Lanes and roles
+# ---------------------------------------------------------------------------
+
+
+class Lane(str, Enum):
+    """The four coordination lanes the graph decomposes into."""
+
+    ISSUE = "issue"
+    PR = "pr"
+    PROPOSAL = "proposal"
+    EPIC = "epic"
+
+
+class Role(str, Enum):
+    """The actor that fires a transition.
+
+    ``daemon_dispatchable`` marks roles the loom-daemon / GitHub Actions cron /
+    ``/loom:sweep`` can drive autonomously. ``HUMAN`` is the sole
+    non-dispatchable role: an edge it fires is an *autonomy gap* (a point where
+    the pipeline stalls waiting on a person), which the validator reports as a
+    WARNING.
+    """
+
+    HUMAN = "Human"
+    CURATOR = "Curator"
+    BUILDER = "Builder"
+    JUDGE = "Judge"
+    DOCTOR = "Doctor"
+    CHAMPION = "Champion"
+    ARCHITECT = "Architect"
+    HERMIT = "Hermit"
+    AUDITOR = "Auditor"
+    SUPERVISOR = "Supervisor"  # daemon-native epic supervisor
+
+    @property
+    def daemon_dispatchable(self) -> bool:
+        return self is not Role.HUMAN
+
+
+# The fork-join barrier state for the epic supervisor loop. Any epic transition
+# entering or leaving this state is a phase-boundary edge and MUST declare a
+# ``barrier`` (see the barrier-hygiene validator).
+PHASE_JOIN_STATE = "epic:phase_join"
+
+
+# ---------------------------------------------------------------------------
+# Model dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class State:
+    """A logical state in the graph.
+
+    Attributes:
+        id: Unique identifier. For label-backed states this equals the label
+            (e.g. ``loom:issue``); for lane-boundary states it is a bare word
+            (``new``, ``closed``, ``merged``); for derived epic states it is an
+            ``epic:*`` pseudo-label.
+        lane: Which coordination lane the state belongs to.
+        label: The backing GitHub label, or ``None`` for states with no label
+            (``new``/``closed``/``merged`` — these represent forge lifecycle,
+            not a Loom label).
+        entry: True if the machine may start in this state.
+        terminal: True if the state has no outgoing transitions (an end state).
+        derived: True if the state is *computed* by the daemon rather than
+            distinguished by a dedicated label (legitimizes label reuse).
+    """
+
+    id: str
+    lane: Lane
+    label: Optional[str] = None
+    entry: bool = False
+    terminal: bool = False
+    derived: bool = False
+
+
+@dataclass(frozen=True)
+class Transition:
+    """A directed, role-fired edge between two states.
+
+    Attributes:
+        src: Source state id.
+        dst: Destination state id.
+        role: The :class:`Role` that fires the edge.
+        guard: Human-readable firing condition.
+        creates_issues: True if firing this edge runs ``gh issue create`` — the
+            set the #3707 global issue-filing mutex must serialize.
+        barrier: Non-empty on epic phase-boundary edges, describing the
+            fork-join condition; empty otherwise.
+    """
+
+    src: str
+    dst: str
+    role: Role
+    guard: str = ""
+    creates_issues: bool = False
+    barrier: str = ""
+
+
+@dataclass
+class ValidationResult:
+    """Outcome of :func:`StateMachine.validate`.
+
+    Unpacks as ``(errors, warnings, notes)`` and exposes :meth:`ok`.
+    """
+
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def ok(self) -> bool:
+        """True when there are no structural ERRORs (warnings/notes are fine)."""
+        return not self.errors
+
+    def __iter__(self) -> Iterator[list[str]]:
+        # Allow: errors, warnings, notes = machine.validate()
+        return iter((self.errors, self.warnings, self.notes))
+
+
+# ---------------------------------------------------------------------------
+# The machine
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StateMachine:
+    """A set of states plus the transitions between them, with a validator."""
+
+    states: list[State]
+    transitions: list[Transition]
+
+    # -- lookups -----------------------------------------------------------
+
+    def state_ids(self) -> set[str]:
+        return {s.id for s in self.states}
+
+    def by_id(self) -> dict[str, State]:
+        return {s.id: s for s in self.states}
+
+    def outgoing(self) -> dict[str, list[Transition]]:
+        """Adjacency map over *known* endpoints only (unknown ids are dropped
+        here so reachability/dead-end checks operate on a well-formed graph;
+        the endpoint validator reports the unknown ids separately)."""
+        ids = self.state_ids()
+        adj: dict[str, list[Transition]] = {sid: [] for sid in ids}
+        for t in self.transitions:
+            if t.src in ids and t.dst in ids:
+                adj[t.src].append(t)
+        return adj
+
+    @staticmethod
+    def is_phase_boundary(t: Transition) -> bool:
+        """True for epic fork-join edges (any edge touching the join state)."""
+        return t.src == PHASE_JOIN_STATE or t.dst == PHASE_JOIN_STATE
+
+    # -- validation --------------------------------------------------------
+
+    def validate(self) -> ValidationResult:
+        """Run every structural check and return the collected findings."""
+        res = ValidationResult()
+        ids = self.state_ids()
+
+        # 1. every transition endpoint is a known state.
+        for t in self.transitions:
+            if t.src not in ids:
+                res.errors.append(
+                    f"transition {t.src}->{t.dst}: unknown source state '{t.src}'"
+                )
+            if t.dst not in ids:
+                res.errors.append(
+                    f"transition {t.src}->{t.dst}: unknown destination state '{t.dst}'"
+                )
+
+        adj = self.outgoing()
+
+        # 2. reachability — every state reachable from an entry state.
+        entries = [s.id for s in self.states if s.entry]
+        if not entries:
+            res.errors.append("no entry state defined (nothing is reachable)")
+        reachable: set[str] = set()
+        stack = list(entries)
+        while stack:
+            cur = stack.pop()
+            if cur in reachable:
+                continue
+            reachable.add(cur)
+            for t in adj.get(cur, []):
+                stack.append(t.dst)
+        for s in self.states:
+            if s.id not in reachable:
+                res.errors.append(
+                    f"state '{s.id}' is unreachable from any entry state"
+                )
+
+        # 3. dead-end / terminal hygiene.
+        for s in self.states:
+            n_out = len(adj.get(s.id, []))
+            if s.terminal and n_out > 0:
+                res.errors.append(
+                    f"terminal state '{s.id}' must have 0 outgoing edges, has {n_out}"
+                )
+            if not s.terminal and n_out == 0:
+                res.errors.append(
+                    f"non-terminal state '{s.id}' is a dead-end (no outgoing edges)"
+                )
+
+        # 4. label conflation — one label backing >1 logical state is an ERROR
+        #    unless every such state is derived (then a NOTE).
+        label_states: dict[str, list[State]] = defaultdict(list)
+        for s in self.states:
+            if s.label is not None:
+                label_states[s.label].append(s)
+        for label, sts in sorted(label_states.items()):
+            if len(sts) <= 1:
+                continue
+            names = ", ".join(s.id for s in sts)
+            if all(s.derived for s in sts):
+                res.notes.append(
+                    f"label '{label}' backs {len(sts)} derived states ({names}); "
+                    "legitimate iff the daemon computes the state"
+                )
+            else:
+                non_derived = ", ".join(s.id for s in sts if not s.derived)
+                res.errors.append(
+                    f"label '{label}' conflates {len(sts)} logical states ({names}); "
+                    f"non-derived offenders: {non_derived}"
+                )
+
+        # 5. autonomy gaps — edges fired by a non-daemon-dispatchable role.
+        for t in self.transitions:
+            if not t.role.daemon_dispatchable:
+                res.warnings.append(
+                    f"autonomy gap: edge {t.src}->{t.dst} is fired by "
+                    f"non-daemon-dispatchable role {t.role.value}"
+                )
+
+        # 6. barrier hygiene — epic phase-boundary edges must declare a barrier.
+        for t in self.transitions:
+            if self.is_phase_boundary(t) and not t.barrier:
+                res.errors.append(
+                    f"epic phase-boundary edge {t.src}->{t.dst} must declare a barrier"
+                )
+
+        # 7. #3707 coverage — enumerate the issue-creating edges the global
+        #    mutex must serialize.
+        creators = [t for t in self.transitions if t.creates_issues]
+        if creators:
+            listed = "; ".join(
+                f"{t.src}->{t.dst} [{t.role.value}]" for t in creators
+            )
+            res.notes.append(
+                f"#3707 issue-filing mutex must serialize {len(creators)} "
+                f"creates_issues edge(s): {listed}"
+            )
+
+        return res
+
+    # -- rendering ---------------------------------------------------------
+
+    def render_mermaid(self) -> str:
+        """Render the graph as a Mermaid ``stateDiagram-v2`` grouped by lane."""
+        by_id = self.by_id()
+
+        def alias(state_id: str) -> str:
+            return "s_" + re.sub(r"[^0-9a-zA-Z]+", "_", state_id).strip("_")
+
+        def display(s: State) -> str:
+            if s.label is not None and not s.derived:
+                return s.label
+            return s.id
+
+        lane_titles = {
+            Lane.ISSUE: "Issue lane",
+            Lane.PR: "PR lane",
+            Lane.PROPOSAL: "Proposal lane",
+            Lane.EPIC: "Epic supervisor lane (derived — loom:epic)",
+        }
+
+        lines: list[str] = ["stateDiagram-v2"]
+
+        # Composite state per lane, states declared inside.
+        for lane in Lane:
+            members = [s for s in self.states if s.lane is lane]
+            if not members:
+                continue
+            lines.append(f'    state "{lane_titles[lane]}" as lane_{lane.value} {{')
+            for s in members:
+                lines.append(f'        {alias(s.id)} : {display(s)}')
+            lines.append("    }")
+
+        # Entry / terminal pseudo-state edges.
+        for s in self.states:
+            if s.entry:
+                lines.append(f"    [*] --> {alias(s.id)}")
+
+        # Transitions (declared after the composites so cross-lane edges work).
+        for t in self.transitions:
+            parts = [t.role.value]
+            if t.barrier:
+                parts.append(f"barrier: {t.barrier}")
+            if t.creates_issues:
+                parts.append("creates issues")
+            label = ": " + " · ".join(parts) if parts else ""
+            lines.append(f"    {alias(t.src)} --> {alias(t.dst)} {label}".rstrip())
+
+        for s in self.states:
+            if s.terminal:
+                lines.append(f"    {alias(s.id)} --> [*]")
+
+        return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# The canonical Loom graph
+# ---------------------------------------------------------------------------
+
+
+def canonical() -> StateMachine:
+    """Build a fresh instance of the canonical (documented, correct) graph.
+
+    A fresh instance every call so callers/tests can mutate copies to
+    construct deliberately-broken variants.
+    """
+    states = [
+        # --- issue lane ---------------------------------------------------
+        State("new", Lane.ISSUE, label=None, entry=True),
+        State("loom:triage", Lane.ISSUE, label="loom:triage"),
+        State("loom:curating", Lane.ISSUE, label="loom:curating"),
+        State("loom:curated", Lane.ISSUE, label="loom:curated"),
+        State("loom:issue", Lane.ISSUE, label="loom:issue"),
+        State("loom:building", Lane.ISSUE, label="loom:building"),
+        State("closed", Lane.ISSUE, label=None, terminal=True),
+        # --- PR lane ------------------------------------------------------
+        State("loom:review-requested", Lane.PR, label="loom:review-requested"),
+        State("loom:changes-requested", Lane.PR, label="loom:changes-requested"),
+        State("loom:pr", Lane.PR, label="loom:pr"),
+        State("merged", Lane.PR, label=None, terminal=True),
+        # --- proposal lane ------------------------------------------------
+        State("loom:architect", Lane.PROPOSAL, label="loom:architect"),
+        State("loom:hermit", Lane.PROPOSAL, label="loom:hermit"),
+        State("loom:auditor", Lane.PROPOSAL, label="loom:auditor"),
+        # --- epic supervisor lane (all derived, all backed by loom:epic) --
+        State("epic:needs_decomp", Lane.EPIC, label="loom:epic", derived=True),
+        State("epic:designed", Lane.EPIC, label="loom:epic", derived=True),
+        State("epic:active", Lane.EPIC, label="loom:epic", derived=True),
+        State("epic:phase_join", Lane.EPIC, label="loom:epic", derived=True),
+        State("epic:done", Lane.EPIC, label="loom:epic", derived=True, terminal=True),
+    ]
+
+    transitions = [
+        # --- issue lane ---------------------------------------------------
+        Transition("new", "loom:triage", Role.HUMAN, "issue filed for triage"),
+        Transition("loom:triage", "loom:curating", Role.CURATOR, "Curator claims"),
+        Transition("loom:curating", "loom:curated", Role.CURATOR, "enrichment complete"),
+        Transition("loom:curated", "loom:issue", Role.HUMAN, "human approval to build"),
+        Transition("loom:issue", "loom:building", Role.BUILDER, "Builder claims"),
+        Transition("loom:building", "loom:review-requested", Role.BUILDER, "Builder opens PR"),
+        Transition("loom:building", "closed", Role.CHAMPION, "linked PR merged (Closes #N)"),
+        # --- PR lane ------------------------------------------------------
+        Transition("loom:review-requested", "loom:pr", Role.JUDGE, "Judge approves"),
+        Transition("loom:review-requested", "loom:changes-requested", Role.JUDGE, "Judge requests changes"),
+        Transition("loom:changes-requested", "loom:review-requested", Role.DOCTOR, "Doctor addresses feedback"),
+        Transition("loom:pr", "merged", Role.CHAMPION, "auto-merge criteria met"),
+        # --- proposal lane (creation edges are #3707-serialized) ----------
+        Transition("new", "loom:architect", Role.ARCHITECT, "Architect files proposal", creates_issues=True),
+        Transition("new", "loom:hermit", Role.HERMIT, "Hermit files simplification proposal", creates_issues=True),
+        Transition("new", "loom:auditor", Role.AUDITOR, "Auditor files runtime bug", creates_issues=True),
+        Transition("loom:architect", "loom:issue", Role.CHAMPION, "Champion approves proposal"),
+        Transition("loom:architect", "closed", Role.CHAMPION, "Champion rejects proposal"),
+        Transition("loom:hermit", "loom:issue", Role.CHAMPION, "Champion approves proposal"),
+        Transition("loom:hermit", "closed", Role.CHAMPION, "Champion rejects proposal"),
+        Transition("loom:auditor", "loom:issue", Role.CHAMPION, "Champion approves proposal"),
+        Transition("loom:auditor", "closed", Role.CHAMPION, "Champion rejects proposal"),
+        # --- epic supervisor lane -----------------------------------------
+        Transition("new", "epic:needs_decomp", Role.ARCHITECT, "epic proposal filed (loom:epic)"),
+        # THE FIX: without this decomposition edge, epic:needs_decomp is a
+        # dead-end and the whole supervisor sub-graph is unreachable.
+        Transition(
+            "epic:needs_decomp", "epic:designed", Role.CHAMPION,
+            "Champion decomposes epic into phase issues", creates_issues=True,
+        ),
+        Transition("epic:designed", "epic:active", Role.CHAMPION, "first phase dispatched"),
+        Transition(
+            "epic:active", "epic:phase_join", Role.SUPERVISOR,
+            "all in-flight phase PRs merged", barrier="fork-join: current phase complete",
+        ),
+        Transition(
+            "epic:phase_join", "epic:active", Role.SUPERVISOR,
+            "phases remain", barrier="advance: dispatch next phase",
+        ),
+        Transition(
+            "epic:phase_join", "epic:done", Role.SUPERVISOR,
+            "no phases remain", barrier="join: all phases complete",
+        ),
+    ]
+
+    return StateMachine(states=states, transitions=transitions)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _format_report(res: ValidationResult) -> str:
+    lines: list[str] = []
+    lines.append(f"errors:   {len(res.errors)}")
+    for e in res.errors:
+        lines.append(f"  ERROR   {e}")
+    lines.append(f"warnings: {len(res.warnings)}")
+    for w in res.warnings:
+        lines.append(f"  WARN    {w}")
+    lines.append(f"notes:    {len(res.notes)}")
+    for n in res.notes:
+        lines.append(f"  NOTE    {n}")
+    lines.append("")
+    lines.append("OK" if res.ok() else "FAILED (structural errors present)")
+    return "\n".join(lines)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="loom-state-machine",
+        description="Executable spec of the Loom label state machine.",
+    )
+    parser.add_argument(
+        "--mermaid",
+        action="store_true",
+        help="emit the graph as a Mermaid stateDiagram-v2 grouped by lane",
+    )
+    args = parser.parse_args(argv)
+
+    machine = canonical()
+
+    if args.mermaid:
+        print(machine.render_mermaid())
+        return 0
+
+    res = machine.validate()
+    print(_format_report(res))
+    return 0 if res.ok() else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/loom-tools/tests/test_state_machine.py
+++ b/loom-tools/tests/test_state_machine.py
@@ -1,0 +1,293 @@
+"""Tests for the executable Loom state-machine spec.
+
+Two responsibilities:
+
+1. The **canonical** graph validates clean (no structural ERRORs).
+2. Each structural validator *fires* on a deliberately-broken variant — a
+   guard is worthless if it never trips.
+
+Also guards the README Mermaid diagram against drift from ``render_mermaid()``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import re
+from pathlib import Path
+
+import pytest
+
+from loom_tools.state_machine import (
+    Lane,
+    PHASE_JOIN_STATE,
+    Role,
+    State,
+    StateMachine,
+    Transition,
+    canonical,
+)
+
+
+# ---------------------------------------------------------------------------
+# Canonical graph
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_validates_clean():
+    """The shipped canonical graph must have zero structural errors."""
+    res = canonical().validate()
+    assert res.ok(), f"canonical graph has errors: {res.errors}"
+    assert res.errors == []
+
+
+def test_validate_unpacks_as_tuple():
+    """validate() unpacks as (errors, warnings, notes)."""
+    errors, warnings, notes = canonical().validate()
+    assert errors == []
+    assert isinstance(warnings, list)
+    assert isinstance(notes, list)
+
+
+def test_canonical_has_four_lanes():
+    machine = canonical()
+    lanes = {s.lane for s in machine.states}
+    assert lanes == {Lane.ISSUE, Lane.PR, Lane.PROPOSAL, Lane.EPIC}
+
+
+def test_epic_states_all_derived_on_loom_epic():
+    """All epic-supervisor states ride the single loom:epic label."""
+    machine = canonical()
+    epic_states = [s for s in machine.states if s.lane is Lane.EPIC]
+    assert epic_states, "expected epic states"
+    for s in epic_states:
+        assert s.label == "loom:epic", s
+        assert s.derived is True, s
+
+
+def test_decomposition_edge_present():
+    """The fix for the epic:needs_decomp dead-end must be in the canonical graph."""
+    machine = canonical()
+    assert any(
+        t.src == "epic:needs_decomp" and t.dst == "epic:designed"
+        for t in machine.transitions
+    ), "canonical graph is missing the Champion decomposition edge"
+
+
+def test_single_entry_state():
+    machine = canonical()
+    entries = [s.id for s in machine.states if s.entry]
+    assert entries == ["new"]
+
+
+# ---------------------------------------------------------------------------
+# Canonical warnings / notes are present (the checks *do* run)
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_reports_autonomy_gaps():
+    """Human-fired edges surface as autonomy-gap warnings."""
+    _, warnings, _ = canonical().validate()
+    assert any("curated->loom:issue" in w or "curated" in w for w in warnings)
+    assert all("autonomy gap" in w for w in warnings)
+
+
+def test_canonical_label_conflation_is_a_note_not_error():
+    """loom:epic reuse across derived states is a NOTE, never an ERROR."""
+    res = canonical().validate()
+    assert any("loom:epic" in n and "derived" in n for n in res.notes)
+    assert not any("conflates" in e for e in res.errors)
+
+
+def test_canonical_enumerates_3707_creates_issues_edges():
+    res = canonical().validate()
+    mutex_notes = [n for n in res.notes if "#3707" in n]
+    assert len(mutex_notes) == 1
+    note = mutex_notes[0]
+    # All four issue-creating edges must be enumerated.
+    for frag in [
+        "new->loom:architect",
+        "new->loom:hermit",
+        "new->loom:auditor",
+        "epic:needs_decomp->epic:designed",
+    ]:
+        assert frag in note, f"missing {frag} in #3707 note"
+
+
+# ---------------------------------------------------------------------------
+# Validator 1: unknown endpoints
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_endpoint_fires():
+    machine = canonical()
+    machine.transitions.append(
+        Transition("loom:building", "nonexistent:state", Role.BUILDER, "bogus")
+    )
+    res = machine.validate()
+    assert not res.ok()
+    assert any("unknown destination state 'nonexistent:state'" in e for e in res.errors)
+
+
+# ---------------------------------------------------------------------------
+# Validator 2 + 3: remove the decomposition edge -> unreachable + dead-end
+# ---------------------------------------------------------------------------
+
+
+def _drop_transition(machine: StateMachine, src: str, dst: str) -> None:
+    machine.transitions = [
+        t for t in machine.transitions if not (t.src == src and t.dst == dst)
+    ]
+
+
+def test_removing_decomposition_edge_fires_deadend_and_unreachable():
+    machine = canonical()
+    _drop_transition(machine, "epic:needs_decomp", "epic:designed")
+    res = machine.validate()
+    assert not res.ok()
+
+    # dead-end: epic:needs_decomp now has no outgoing edge.
+    assert any(
+        "epic:needs_decomp" in e and "dead-end" in e for e in res.errors
+    ), res.errors
+
+    # unreachable: the whole downstream supervisor sub-graph.
+    for dead in ("epic:designed", "epic:active", "epic:phase_join", "epic:done"):
+        assert any(
+            f"'{dead}'" in e and "unreachable" in e for e in res.errors
+        ), f"expected {dead} unreachable; errors={res.errors}"
+
+
+def test_no_entry_state_fires():
+    machine = canonical()
+    machine.states = [
+        dataclasses.replace(s, entry=False) if s.entry else s
+        for s in machine.states
+    ]
+    res = machine.validate()
+    assert not res.ok()
+    assert any("no entry state" in e for e in res.errors)
+
+
+def test_terminal_with_outgoing_edge_fires():
+    machine = canonical()
+    machine.transitions.append(
+        Transition("closed", "loom:issue", Role.HUMAN, "reopen (illegal)")
+    )
+    res = machine.validate()
+    assert not res.ok()
+    assert any("terminal state 'closed'" in e for e in res.errors)
+
+
+# ---------------------------------------------------------------------------
+# Validator 4: label conflation on non-derived states
+# ---------------------------------------------------------------------------
+
+
+def test_label_conflation_on_non_derived_fires():
+    machine = canonical()
+    # Two non-derived states sharing one real label.
+    machine.states.append(State("loom:issue-dup", Lane.ISSUE, label="loom:issue"))
+    machine.transitions.append(
+        Transition("loom:curated", "loom:issue-dup", Role.HUMAN, "dup")
+    )
+    machine.transitions.append(
+        Transition("loom:issue-dup", "loom:building", Role.BUILDER, "dup")
+    )
+    res = machine.validate()
+    assert not res.ok()
+    assert any("conflates" in e and "loom:issue" in e for e in res.errors)
+
+
+# ---------------------------------------------------------------------------
+# Validator 6: barrier hygiene
+# ---------------------------------------------------------------------------
+
+
+def test_dropping_a_barrier_fires_missing_barrier_error():
+    machine = canonical()
+    new_transitions = []
+    dropped = False
+    for t in machine.transitions:
+        if StateMachine.is_phase_boundary(t) and t.barrier and not dropped:
+            new_transitions.append(dataclasses.replace(t, barrier=""))
+            dropped = True
+        else:
+            new_transitions.append(t)
+    assert dropped, "expected at least one phase-boundary edge to strip"
+    machine.transitions = new_transitions
+    res = machine.validate()
+    assert not res.ok()
+    assert any("phase-boundary edge" in e and "must declare a barrier" in e for e in res.errors)
+
+
+def test_every_phase_boundary_edge_has_a_barrier():
+    machine = canonical()
+    boundary = [t for t in machine.transitions if StateMachine.is_phase_boundary(t)]
+    assert boundary, "expected phase-boundary edges around the join state"
+    assert all(t.barrier for t in boundary)
+    # Sanity: the join state is actually present.
+    assert PHASE_JOIN_STATE in machine.state_ids()
+
+
+# ---------------------------------------------------------------------------
+# Validator 5: autonomy gaps fire on a fresh human edge
+# ---------------------------------------------------------------------------
+
+
+def test_autonomy_gap_warning_for_human_role():
+    assert Role.HUMAN.daemon_dispatchable is False
+    for r in Role:
+        if r is not Role.HUMAN:
+            assert r.daemon_dispatchable is True
+
+
+# ---------------------------------------------------------------------------
+# Mermaid rendering + README sync
+# ---------------------------------------------------------------------------
+
+
+def test_render_mermaid_is_state_diagram_grouped_by_lane():
+    out = canonical().render_mermaid()
+    assert out.startswith("stateDiagram-v2")
+    for title in ("Issue lane", "PR lane", "Proposal lane", "Epic supervisor lane"):
+        assert title in out, f"missing lane group {title!r}"
+    # Entry and terminal pseudo-states.
+    assert "[*] --> s_new" in out
+    assert "s_merged --> [*]" in out
+
+
+def _repo_root() -> Path:
+    # test file: <root>/loom-tools/tests/test_state_machine.py
+    return Path(__file__).resolve().parents[2]
+
+
+def _extract_readme_mermaid() -> str | None:
+    readme = _repo_root() / "README.md"
+    if not readme.exists():
+        return None
+    text = readme.read_text(encoding="utf-8")
+    # Find the ```mermaid fenced block inside the "Loom State Machine" section.
+    m = re.search(r"## Loom State Machine.*?```mermaid\n(.*?)```", text, re.DOTALL)
+    if not m:
+        return None
+    return m.group(1).rstrip("\n")
+
+
+def test_readme_mermaid_matches_generated():
+    """The committed README diagram must match render_mermaid() exactly.
+
+    This is the CI guard that keeps the documentation diagram from drifting
+    away from the model. If this fails, regenerate with:
+        python -m loom_tools.state_machine --mermaid
+    and paste the output into the README "Loom State Machine" section.
+    """
+    embedded = _extract_readme_mermaid()
+    assert embedded is not None, (
+        "Could not find a ```mermaid block under a '## Loom State Machine' "
+        "heading in README.md"
+    )
+    generated = canonical().render_mermaid().rstrip("\n")
+    assert embedded == generated, (
+        "README Mermaid diagram is out of sync with render_mermaid().\n"
+        "Regenerate: python -m loom_tools.state_machine --mermaid"
+    )


### PR DESCRIPTION
## Summary

Encodes the Loom label state machine as an **executable specification** in `loom-tools`, renders it as a Mermaid diagram in the README, and guards both with CI tests. Until now the state graph lived only implicitly across role prompts; there was no single source of truth and no mechanical way to catch a structural regression.

Modeling the graph surfaced the real dead-end bug the issue calls out: `epic:needs_decomp` had no autonomous transition forward, making the whole epic-supervisor sub-graph unreachable. The canonical graph here ships with the fix (the Champion decomposition edge `epic:needs_decomp -> epic:designed`) so it validates clean; the deliberately-broken variants live in the tests, where the validators fire.

## Changes

- `loom-tools/src/loom_tools/state_machine.py` — pure-stdlib model: `State`/`Transition` dataclasses, `Lane`/`Role` enums (with `daemon_dispatchable`), the canonical four-lane graph (issue, PR, proposal, epic supervisor), `validate()` returning `(errors, warnings, notes)` with `.ok()`, and `render_mermaid()`.
- The five `epic:*` states are `derived=True`, all backed by the single `loom:epic` label — no new labels minted.
- `--mermaid` flag / `loom-state-machine` console entry point.
- `loom-tools/tests/test_state_machine.py` — 19 tests: canonical graph validates clean, each validator fires on a broken variant, and a README-diagram sync guard.
- README "Loom State Machine" section with the rendered diagram.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `State`/`Transition` dataclasses; four lanes; derived epic states on `loom:epic` | ✅ | `state_machine.py`; `test_epic_states_all_derived_on_loom_epic` |
| Transitions carry `Role`, `guard`, `creates_issues`, `barrier` | ✅ | dataclass fields; canonical graph |
| `validate()` returns `(errors, warnings, notes)` with all 7 checks | ✅ | `test_*` fire each validator on broken variants |
| Label conflation: >1 state per label = ERROR unless all derived (then NOTE) | ✅ | `test_label_conflation_on_non_derived_fires`, `test_canonical_label_conflation_is_a_note_not_error` |
| `--mermaid` emits `stateDiagram-v2` grouped by lane | ✅ | `test_render_mermaid_is_state_diagram_grouped_by_lane` |
| Tests assert `validate().ok()` and each validator fires on a broken variant | ✅ | remove decomposition edge → dead-end + unreachable; drop barrier → missing-barrier |
| README section + committed-diagram sync check | ✅ | `test_readme_mermaid_matches_generated` |
| No new GitHub labels | ✅ | epic states are derived on `loom:epic` |

## Test Plan

- `PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/test_state_machine.py -v` → **19 passed**.
- Full suite: `PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/ -q` → **1869 passed, 62 skipped, 2 failed**. The 2 failures (`test_forge_cli::test_version_flag`, `test_logging::test_log_output_visible_non_interactively`) are pre-existing environmental failures — they spawn subprocesses that require `loom-tools` to be pip-installed (the subprocess env drops `PYTHONPATH`) and fail identically on `main`, untouched by this change.

Closes #3841