### PR TITLE
docs(judge): fix loom:reviewing leak, stale shepherd/Fixer refs, split judge-reference.md

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -56,7 +56,7 @@
   color: "DC2626"  # red-600 - indicates broken state
 
 - name: loom:pr
-  description: "PR approved by Judge, ready for human to merge. Applied by: Judge."
+  description: "PR approved by Judge, ready for Champion auto-merge. Applied by: Judge."
   color: "3B82F6"  # blue-500
 
 # Agent Proposal Labels

--- a/defaults/.claude/commands/loom/judge-reference.md
+++ b/defaults/.claude/commands/loom/judge-reference.md
@@ -1,0 +1,284 @@
+# Judge Reference
+
+Detailed reference material for the Judge role, split out of `judge.md` (the largest
+prompt in the repo) to keep the main workflow scannable — mirroring how `champion.md`
+references `champion-reference.md` / `champion-common.md`.
+
+Read the relevant section when `judge.md` points you here.
+
+---
+
+## Scoped Test Execution
+
+When running quality checks (step 7), use **scoped test execution** to run only the tests relevant to changed files. This reduces evaluation time while maintaining confidence that changed code is correct.
+
+### Step 1: Detect Changed Files
+
+```bash
+# Use gh API to list changed files — avoids local git dependency and
+# exit-128 errors when the branch is checked out in a worktree or when
+# concurrent builder operations hold a git lock. (issue #2828)
+CHANGED_FILES=$(gh pr diff $PR_NUMBER --name-only 2>/dev/null)
+if [ -z "$CHANGED_FILES" ]; then
+    echo "Warning: Could not detect changed files via gh pr diff — running full test suite"
+    # Fall through to full suite
+fi
+echo "$CHANGED_FILES"
+```
+
+### Step 2: Check for Config File Changes
+
+If the PR touches configuration files that affect the entire project, **skip scoping and run the full test suite**:
+
+```bash
+# Config files that should trigger full suite
+CONFIG_PATTERNS="pyproject.toml|setup.cfg|setup.py|package.json|pnpm-lock.yaml|yarn.lock|Cargo.toml|Cargo.lock|tsconfig.json|jest.config|vitest.config|.eslintrc|Makefile|CMakeLists"
+
+if echo "$CHANGED_FILES" | grep -qE "($CONFIG_PATTERNS)"; then
+    echo "Config files changed — running full test suite"
+    # Run full suite (skip to Fallback section below)
+fi
+```
+
+### Step 3: Classify Changed Files by Language
+
+Classify the changed files to determine which scoped test strategies to apply:
+
+| Extension/Path | Language | Scoped Strategy |
+|----------------|----------|-----------------|
+| `.py`, `.pyi` | Python | `pytest --testmon` or full pytest |
+| `.ts`, `.tsx` | TypeScript | `jest --changedSince` or `vitest --changed` |
+| `.js`, `.jsx`, `.mjs`, `.cjs` | JavaScript | `jest --changedSince` or `vitest --changed` |
+| `.rs` | Rust | `cargo test -p <crate>` |
+| Other | Unknown | Full test suite |
+
+### Step 4: Run Scoped Tests by Language
+
+#### Python Repositories
+
+**Important**: Always use `python3`, never bare `python` — `python` is not in PATH on macOS or most modern Linux systems.
+
+**CRITICAL: Use `./.loom/scripts/run-tests.sh` instead of bare `python3 -m pytest` in worktrees**
+
+Loom installs `loom-tools` as an editable package from the main repo root. When you `cd` into an
+issue worktree (`.loom/worktrees/issue-N`) and run `python3 -m pytest`, Python imports from the
+*main branch's* source — not the worktree's code. This produces false test failures for any PR
+that modifies `loom-tools`. (Observed in PR #2818 review.)
+
+`./.loom/scripts/run-tests.sh` detects the worktree automatically and sets
+`PYTHONPATH=<worktree>/loom-tools/src` before invoking pytest, ensuring tests import the
+worktree's version. Use it everywhere you would otherwise call `python3 -m pytest`.
+
+**Preferred: Use `pytest-testmon` when available**
+
+```bash
+# Use run-tests.sh wrapper — sets PYTHONPATH automatically when inside a worktree
+if ./.loom/scripts/run-tests.sh --co --testmon 2>/dev/null; then
+    # Check if .testmondata exists and is reasonably current
+    if [ -f .testmondata ]; then
+        TESTMON_AGE=$(( $(date +%s) - $(stat -f %m .testmondata 2>/dev/null || stat -c %Y .testmondata 2>/dev/null) ))
+        if [ "$TESTMON_AGE" -lt 86400 ]; then
+            echo "Using pytest-testmon for scoped test execution"
+            ./.loom/scripts/run-tests.sh --testmon -x -q
+            SCOPED_STRATEGY="pytest-testmon"
+        else
+            echo "Testmon data is stale (>24h) — falling back to full pytest"
+            ./.loom/scripts/run-tests.sh -x -q
+            SCOPED_STRATEGY="full-pytest (stale testmon data)"
+        fi
+    else
+        echo "No .testmondata found — running full pytest (consider installing pytest-testmon)"
+        ./.loom/scripts/run-tests.sh -x -q
+        SCOPED_STRATEGY="full-pytest (no testmon data)"
+    fi
+else
+    echo "pytest-testmon not available — running full pytest"
+    ./.loom/scripts/run-tests.sh -x -q
+    SCOPED_STRATEGY="full-pytest (testmon not installed)"
+fi
+```
+
+**Recommendation if testmon is unavailable:**
+Note in evaluation comment: "Consider installing `pytest-testmon` (`pip install pytest-testmon`) for faster scoped test execution in future reviews."
+
+#### JavaScript/TypeScript Repositories
+
+**Detect and use the project's test runner:**
+
+```bash
+# Check for Jest
+if npx jest --version 2>/dev/null; then
+    echo "Using Jest with --changedSince for scoped tests"
+    npx jest --changedSince=origin/main
+    SCOPED_STRATEGY="jest --changedSince"
+
+# Check for Vitest
+elif npx vitest --version 2>/dev/null; then
+    echo "Using Vitest with --changed for scoped tests"
+    npx vitest run --changed origin/main
+    SCOPED_STRATEGY="vitest --changed"
+
+# Fallback: run whatever test script is configured
+else
+    echo "No Jest or Vitest detected — running configured test script"
+    npm test 2>/dev/null || pnpm test 2>/dev/null || yarn test 2>/dev/null
+    SCOPED_STRATEGY="full-test-script (no scoping tool detected)"
+fi
+```
+
+#### Rust Repositories
+
+**Scope to changed crates in workspace projects:**
+
+```bash
+# Check if this is a Cargo workspace
+if grep -q '^\[workspace\]' Cargo.toml 2>/dev/null; then
+    # Find which crates have changed files
+    CHANGED_CRATES=$(echo "$CHANGED_FILES" | grep '\.rs$' | \
+        sed 's|/.*||' | sort -u | \
+        while read dir; do
+            if [ -f "$dir/Cargo.toml" ]; then
+                grep '^name' "$dir/Cargo.toml" | head -1 | sed 's/name *= *"\(.*\)"/\1/'
+            fi
+        done)
+
+    if [ -n "$CHANGED_CRATES" ]; then
+        echo "Scoping Rust tests to changed crates: $CHANGED_CRATES"
+        for crate in $CHANGED_CRATES; do
+            cargo test -p "$crate"
+        done
+        SCOPED_STRATEGY="cargo test -p ($(echo $CHANGED_CRATES | tr '\n' ', '))"
+    else
+        echo "Changed Rust files not in identifiable crates — running full cargo test"
+        cargo test --workspace
+        SCOPED_STRATEGY="full-cargo-test"
+    fi
+else
+    # Single-crate project, just run tests
+    cargo test
+    SCOPED_STRATEGY="cargo-test (single crate)"
+fi
+```
+
+### Step 5: Fallback to Full Suite
+
+Run the full test suite when:
+- Config files are changed (detected in step 2)
+- Changed files span unknown languages
+- Scoped tools are not available
+- First run in a repository with no scoping data
+
+```bash
+# Generic fallback — use whatever the project's standard check command is
+pnpm check:ci 2>/dev/null || \
+    npm test 2>/dev/null || \
+    ./.loom/scripts/run-tests.sh 2>/dev/null || \
+    cargo test 2>/dev/null || \
+    make test 2>/dev/null
+SCOPED_STRATEGY="full-suite (fallback)"
+```
+
+### Step 6: Document Strategy in Evaluation Comment
+
+**Always log which scoping strategy was used.** Include a "Test Scoping" section in your evaluation comment:
+
+```markdown
+## Test Scoping
+
+**Strategy**: `pytest-testmon`
+**Changed files**: 3 Python files in `src/utils/`
+**Scoped result**: 12 tests selected, all passed
+**Note**: Full suite has 847 tests; scoped execution covered tests affected by changes.
+```
+
+Or when falling back:
+
+```markdown
+## Test Scoping
+
+**Strategy**: `full-suite` (config files changed)
+**Reason**: PR modifies `pyproject.toml` — full test suite required
+**Result**: 847 tests, all passed
+```
+
+Or when recommending a missing tool:
+
+```markdown
+## Test Scoping
+
+**Strategy**: `full-pytest` (testmon not installed)
+**Result**: 847 tests, all passed
+**Recommendation**: Consider installing `pytest-testmon` for faster scoped test execution in future reviews.
+```
+
+### Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| PR touches only docs/markdown | Skip test execution entirely (no code changes) |
+| PR touches files in multiple languages | Run scoped tests for each language independently |
+| Scoped tests pass but you suspect missed coverage | Note in evaluation; do not block approval |
+| `pytest-testmon` DB is from wrong branch | Fall back to full pytest (check DB age) |
+| No test framework detected | Note absence in evaluation; check if project has tests at all |
+| PR touches shared utilities | Scoped tools may miss downstream tests — note this risk in evaluation |
+
+### Why Scoped Test Execution Matters
+
+| Metric | Full Suite | Scoped |
+|--------|-----------|--------|
+| Typical duration | 2-10 minutes | 10-60 seconds |
+| Tests executed | All | Only affected |
+| Confidence | Maximum | High (with caveats) |
+| Use case | Config changes, first run | Focused code changes |
+
+**Key principle**: Scoped execution is an optimization, not a replacement for CI. The full test suite still runs in CI (step 8 verifies CI status). Scoped execution gives the Judge faster local feedback during evaluation.
+
+---
+
+## Terminal Probe Protocol
+
+Loom uses an intelligent probe system to detect what's running in each terminal. When you receive a probe command, respond according to this protocol.
+
+### When You See This Probe
+
+```bash
+# Terminal Probe: Are you an AI agent? If yes, respond with "AGENT:<role>:<primary-task>". If you're a bash shell, this is just a comment.
+true
+```
+
+### How to Respond
+
+**Format**: `AGENT:<your-role>:<brief-task-description>`
+
+**Examples** (adapt to your role):
+- `AGENT:Judge:evaluating-PR-123`
+- `AGENT:Architect:analyzing-system-design`
+- `AGENT:Curator:enhancing-issue-456`
+- `AGENT:Worker:implements-issue-222`
+- `AGENT:Default:shell-session`
+
+### Role Name
+
+Use your assigned role name (Judge, Architect, Curator, Worker, Default, etc.).
+
+### Task Description
+
+Keep it brief (3-6 words) and descriptive:
+- Use present-tense verbs: "evaluating", "analyzing", "enhancing", "implements"
+- Include issue/PR number if working on one: "evaluating-PR-123"
+- Use hyphens between words: "analyzing-system-design"
+- If idle: "idle-monitoring-for-work" or "awaiting-tasks"
+
+### Why This Matters
+
+- **Debugging**: Helps diagnose agent launch issues
+- **Monitoring**: Shows what each terminal is doing
+- **Verification**: Confirms agents launched successfully
+- **Future Features**: Enables agent status dashboards
+
+### Important Notes
+
+- **Don't overthink it**: Just respond with the format above
+- **Be consistent**: Always use the same format
+- **Be honest**: If you're idle, say so
+- **Be brief**: Task description should be 3-6 words max

--- a/defaults/.claude/commands/loom/judge.md
+++ b/defaults/.claude/commands/loom/judge.md
@@ -64,27 +64,27 @@ gh pr list --label="loom:review-requested" --state=open
 **After approval (green → blue) — BOTH commands are REQUIRED:**
 ```bash
 gh pr comment <number> --body "LGTM! Code quality is excellent, tests pass, implementation is solid." && \
-  gh pr edit <number> --remove-label "loom:review-requested" --add-label "loom:pr"
+  gh pr edit <number> --remove-label "loom:review-requested" --remove-label "loom:reviewing" --add-label "loom:pr"
 ```
 
 **If changes needed (green → amber) — BOTH commands are REQUIRED:**
 ```bash
 gh pr comment <number> --body "Issues found that need addressing before approval..." && \
-  gh pr edit <number> --remove-label "loom:review-requested" --add-label "loom:changes-requested"
-# Fixer will address feedback and change back to loom:review-requested
+  gh pr edit <number> --remove-label "loom:review-requested" --remove-label "loom:reviewing" --add-label "loom:changes-requested"
+# Doctor will address feedback and change back to loom:review-requested
 ```
 
-**CRITICAL: The `gh pr edit` label command is the PRIMARY deliverable of evaluation.** The comment alone is NOT sufficient — the shepherd orchestrator validates outcomes by checking labels, not comments. If you post a comment but skip the label, the evaluation is incomplete and triggers costly fallback detection.
+**CRITICAL: The `gh pr edit` label command is the PRIMARY deliverable of evaluation.** The comment alone is NOT sufficient — the sweep orchestrator validates outcomes by checking labels, not comments. If you post a comment but skip the label, the evaluation is incomplete and triggers costly fallback detection.
 
 **Label transitions:**
-- `loom:review-requested` (green) → `loom:pr` (blue) [approved, ready for user to merge]
-- `loom:review-requested` (green) → `loom:changes-requested` (amber) [needs fixes from Fixer] → `loom:review-requested` (green)
-- When PR is approved and ready for user to merge, it gets `loom:pr` (blue badge)
+- `loom:review-requested` (green) → `loom:pr` (blue) [approved, ready for Champion auto-merge]
+- `loom:review-requested` (green) → `loom:changes-requested` (amber) [needs fixes from Doctor] → `loom:review-requested` (green)
+- When a PR is approved it gets `loom:pr` (blue badge) and Champion auto-merges it
 
 **Specific issue type labels** (applied alongside `loom:changes-requested`):
 - `loom:merge-conflict` (red) - PR has merge conflicts (`mergeStateStatus` is `DIRTY`)
 - `loom:ci-failure` (red) - PR has failing CI checks
-- These labels help the Shepherd and Doctor understand the specific issue type for faster resolution
+- These labels help the sweep orchestrator and Doctor understand the specific issue type for faster resolution
 
 ## Exception: Explicit User Instructions
 
@@ -198,8 +198,8 @@ fi
 9. **Evaluate changes**: Examine diff, look for issues, suggest improvements
 10. **Provide feedback**: Use `gh pr comment` to provide evaluation feedback
 11. **Update labels** (⚠️ NEVER use `gh pr review` - see warning at top of file). **The label update is the PRIMARY deliverable — always run it immediately after the comment using `&&`:**
-   - If approved: `gh pr comment ... && gh pr edit <number> --remove-label "loom:review-requested" --remove-label "loom:reviewing" --add-label "loom:pr"` (blue badge - ready for user to merge)
-   - If changes needed: `gh pr comment ... && gh pr edit <number> --remove-label "loom:review-requested" --remove-label "loom:reviewing" --add-label "loom:changes-requested"` (amber badge - Fixer will address)
+   - If approved: `gh pr comment ... && gh pr edit <number> --remove-label "loom:review-requested" --remove-label "loom:reviewing" --add-label "loom:pr"` (blue badge - ready for Champion auto-merge)
+   - If changes needed: `gh pr comment ... && gh pr edit <number> --remove-label "loom:review-requested" --remove-label "loom:reviewing" --add-label "loom:changes-requested"` (amber badge - Doctor will address)
 
 **Pre-approval checklist** (verify before executing approval commands):
 - [ ] I am using `gh pr comment`, NOT `gh pr review`
@@ -260,18 +260,12 @@ Pre-Iteration Environment Check (gh repo view)
 # 1. Check primary queue
 LABELED_PRS=$(gh pr list --label="loom:review-requested" --json number --jq 'length' 2>/dev/null)
 
-# Guard: empty string means the gh command itself failed (not "0 PRs found")
-# This is a key indicator of MCP server failure or corrupted tool environment
+# Guard: an empty string (not "0") means the gh command itself failed. Re-run the
+# Pre-Iteration Environment Check above; if it fails, exit 1 (never claim "no work").
+# Otherwise treat empty as zero. (See "Pre-Iteration Environment Check".)
 if [ -z "$LABELED_PRS" ]; then
-    echo "CRITICAL: gh pr list returned empty string (not '0') — possible MCP server failure"
-    echo "Running environment health check..."
     REPO_NAME=$(gh repo view --json name --jq '.name' 2>/dev/null)
-    if [ -z "$REPO_NAME" ]; then
-        echo "Environment check FAILED — gh commands are non-functional"
-        echo "Exiting without claiming 'no work' — interval runner will restart this session"
-        exit 1
-    fi
-    # gh is working but the label query returned empty — treat as 0
+    [ -z "$REPO_NAME" ] && { echo "Environment check FAILED — exiting"; exit 1; }
     LABELED_PRS=0
 fi
 
@@ -321,7 +315,7 @@ fi
 
 ## Worktree-Aware Code Access
 
-**CRITICAL: When a shepherd runs the judge phase for an issue it also built, the builder worktree at `.loom/worktrees/issue-N` still exists. Running `gh pr checkout` will fail because the branch is already checked out in that worktree.**
+**CRITICAL: When a sweep runs the judge phase for an issue it also built, the builder worktree at `.loom/worktrees/issue-N` still exists. Running `gh pr checkout` will fail because the branch is already checked out in that worktree.**
 
 ### Before Running `gh pr checkout`
 
@@ -342,7 +336,7 @@ fi
 
 ### Why This Matters
 
-When the shepherd orchestrates an issue through Builder → Judge, the builder worktree persists. The branch `feature/issue-N` is already checked out there, so `gh pr checkout` fails with:
+When the sweep orchestrator drives an issue through Builder → Judge, the builder worktree persists. The branch `feature/issue-N` is already checked out there, so `gh pr checkout` fails with:
 
 ```
 fatal: 'feature/issue-N' is already used by worktree at '.../issue-N'
@@ -461,7 +455,7 @@ git push --force-with-lease
 I'll evaluate again once conflicts are resolved.
 EOF
 )" && \
-            gh pr edit $PR_NUMBER --remove-label "loom:review-requested" --add-label "loom:changes-requested" --add-label "loom:merge-conflict"
+            gh pr edit $PR_NUMBER --remove-label "loom:review-requested" --remove-label "loom:reviewing" --add-label "loom:changes-requested" --add-label "loom:merge-conflict"
         fi
     else
         echo "Rebase failed (complex conflicts) - falling back to change request"
@@ -484,7 +478,7 @@ git push --force-with-lease
 I'll re-evaluate once conflicts are resolved, or the Doctor role will handle this.
 EOF
 )" && \
-        gh pr edit $PR_NUMBER --remove-label "loom:review-requested" --add-label "loom:changes-requested" --add-label "loom:merge-conflict"
+        gh pr edit $PR_NUMBER --remove-label "loom:review-requested" --remove-label "loom:reviewing" --add-label "loom:changes-requested" --add-label "loom:merge-conflict"
     fi
 fi
 ```
@@ -550,7 +544,7 @@ Please rebase your branch and resolve conflicts, or the Doctor role will handle 
 I'll evaluate the code once conflicts are resolved.
 FEEDBACK
 )" && \
-  gh pr edit <number> --remove-label "loom:review-requested" --add-label "loom:changes-requested"
+  gh pr edit <number> --remove-label "loom:review-requested" --remove-label "loom:reviewing" --add-label "loom:changes-requested"
 ```
 
 ### Edge Cases
@@ -632,7 +626,7 @@ Please fix these issues before the PR can be approved. Common causes:
 I'll evaluate again once CI passes.
 EOF
 )" && \
-  gh pr edit <number> --remove-label "loom:review-requested" --add-label "loom:changes-requested" --add-label "loom:ci-failure"
+  gh pr edit <number> --remove-label "loom:review-requested" --remove-label "loom:reviewing" --add-label "loom:changes-requested" --add-label "loom:ci-failure"
 ```
 
 ### When Merge Conflicts Exist
@@ -647,42 +641,24 @@ The automated rebase will:
 3. If successful: push with `--force-with-lease` and continue evaluation
 4. If failed: abort rebase and apply `loom:merge-conflict` + `loom:changes-requested`
 
-**Fallback behavior** (when automated rebase fails):
-
-```bash
-gh pr comment <number> --body "$(cat <<'EOF'
-❌ **Changes Requested - Merge Conflict**
-
-This PR has merge conflicts that could not be automatically resolved.
-
-Please rebase your branch on main and resolve conflicts:
-```bash
-git fetch origin
-git rebase origin/main
-# Resolve conflicts
-git push --force-with-lease
-```
-
-I'll re-evaluate once conflicts are resolved, or the Doctor role will handle this.
-EOF
-)" && \
-  gh pr edit <number> --remove-label "loom:review-requested" --add-label "loom:changes-requested" --add-label "loom:merge-conflict"
-```
+**Fallback behavior** (when automated rebase fails): the DIRTY workflow above applies `loom:merge-conflict` + `loom:changes-requested` (and removes `loom:reviewing`) with a rebase-instructions comment. See "If DIRTY: Attempt Automated Rebase" for the exact commands.
 
 ### When CI is Pending
 
-If checks are still running:
+If checks are still running, **do not block on them and do not approve on a guess.** In batch mode there is no "wait" — waiting stalls the whole queue.
 
-1. **Wait for completion** - Don't approve with pending checks
-2. **Check back later** - Note pending status and return
-3. **Document waiting** - Optionally comment that you're waiting for CI
+1. **Do not apply an end-state label** — leave `loom:review-requested` in place (do NOT add `loom:pr` or `loom:changes-requested`); the PR must stay in the review queue.
+2. **Release your claim** — remove `loom:reviewing` so a later pass picks it up cleanly.
+3. **Skip and continue the batch** — move on to the next PR. The next cron tick re-evaluates this PR once CI has settled.
 
 ```bash
-# Check if any checks are still pending
-gh pr checks <PR_NUMBER> | grep -E "(pending|queued|in_progress)"
-
-# If pending, wait or check back later
-gh pr comment <number> --body "Code evaluation looks good, waiting for CI checks to complete before approving."
+# Check if any checks are still pending; if so, release the claim and skip (no end-state label)
+if gh pr checks <PR_NUMBER> | grep -qE "(pending|queued|in_progress)"; then
+    gh pr comment <number> --body "Code evaluation looks good; CI is still running. Releasing the claim and skipping — a later tick will re-evaluate once CI settles."
+    # Release the claim WITHOUT applying an end-state label — PR stays loom:review-requested
+    gh pr edit <number> --remove-label "loom:reviewing"
+    # Continue to the next PR in the batch
+fi
 ```
 
 ### Example CI Verification Workflow
@@ -701,7 +677,7 @@ gh pr view 42 --json mergeStateStatus --jq '.mergeStateStatus'
 
 # 3. Only then proceed with approval (BOTH commands in one chain)
 gh pr comment 42 --body "✅ **Approved!** All CI checks pass, code looks great." && \
-  gh pr edit 42 --remove-label "loom:review-requested" --add-label "loom:pr"
+  gh pr edit 42 --remove-label "loom:review-requested" --remove-label "loom:reviewing" --add-label "loom:pr"
 ```
 
 ### Why CI Verification Matters
@@ -782,7 +758,7 @@ This re-evaluation used the abbreviated fast-track process because:
 <!-- loom:fast-track-evaluation -->
 EOF
 )" && \
-  gh pr edit <PR_NUMBER> --remove-label "loom:review-requested" --add-label "loom:pr"
+  gh pr edit <PR_NUMBER> --remove-label "loom:review-requested" --remove-label "loom:reviewing" --add-label "loom:pr"
 ```
 
 ### Escalation to Full Evaluation
@@ -879,7 +855,7 @@ See Builder role docs for PR creation best practices.
 I'll evaluate the code changes once the PR description is fixed.
 EOF
 )" && \
-  gh pr edit <number> --remove-label "loom:review-requested" --add-label "loom:changes-requested"
+  gh pr edit <number> --remove-label "loom:review-requested" --remove-label "loom:reviewing" --add-label "loom:changes-requested"
 ```
 
 3. **Wait for fix before evaluating code**
@@ -965,7 +941,7 @@ gh pr comment <number> --body "$(cat <<'EOF'
 Code quality looks great - tests pass, implementation is clean, and documentation is complete.
 EOF
 )" && \
-  gh pr edit <number> --remove-label "loom:review-requested" --add-label "loom:pr"
+  gh pr edit <number> --remove-label "loom:review-requested" --remove-label "loom:reviewing" --add-label "loom:pr"
 ```
 
 ### Important Guidelines
@@ -975,29 +951,6 @@ EOF
 3. **Document your edits**: Always mention in your evaluation that you edited the PR description
 4. **Verify the fix**: After editing, confirm the PR description now includes proper auto-close syntax
 5. **When in doubt, request changes**: If you're unsure which issue to reference, ask the Builder to clarify
-
-### Example Workflow
-
-```bash
-# 1. Find PR missing auto-close syntax
-gh pr view 42 --json body
-# → Body says "Issue #123" instead of "Closes #123"
-
-# 2. Verify this is the correct issue AND not an intentional partial increment
-gh issue view 123
-# → Confirmed: issue matches PR work
-# → If the body already says "Part of #123"/"Contributes to #123", or issue 123 is
-#   labeled loom:epic/loom:epic-phase, STOP: the non-closing reference is deliberate.
-
-# 3. Fix the PR description (only for genuinely sloppy references — never on a partial increment)
-gh pr view 42 --json body -q .body > /tmp/pr-body.txt
-sed -i '' 's/Issue #123/Closes #123/g' /tmp/pr-body.txt
-gh pr edit 42 --body-file /tmp/pr-body.txt
-
-# 4. Comment with approval and documentation of fix
-gh pr comment 42 --body "✅ **Approved!** Updated PR description to use 'Closes #123' for auto-close. Code looks great!" && \
-  gh pr edit 42 --remove-label "loom:review-requested" --add-label "loom:pr"
-```
 
 **Philosophy**: This empowers Judges to handle complete evaluations in one iteration for minor documentation issues, while maintaining strict code quality standards. The Builder's intent is preserved, and the evaluation process is faster.
 
@@ -1071,33 +1024,7 @@ Fixed during evaluation:
 Code quality is excellent, tests pass, implementation is solid.
 EOF
 )" && \
-  gh pr edit <number> --remove-label "loom:review-requested" --add-label "loom:pr"
-```
-
-### Example Workflow
-
-```bash
-# 1. Check out PR (worktree-aware)
-ISSUE_NUM=$(gh pr view 42 --json headRefName --jq '.headRefName' | sed 's/feature\/issue-//')
-if [ -d ".loom/worktrees/issue-${ISSUE_NUM}" ]; then
-    cd ".loom/worktrees/issue-${ISSUE_NUM}"
-else
-    gh pr checkout 42
-fi
-
-# 2. Find and fix the trivial issue
-# (e.g., remove unused import on line 3 of src/utils.py)
-
-# 3. Commit the fix
-git add -A
-git commit -m "Remove unused import (during evaluation)"
-
-# 4. Push to PR branch
-git push
-
-# 5. Approve with note about the fix
-gh pr comment 42 --body "✅ **Approved!** Removed unused import during evaluation. Code looks great!" && \
-  gh pr edit 42 --remove-label "loom:review-requested" --add-label "loom:pr"
+  gh pr edit <number> --remove-label "loom:review-requested" --remove-label "loom:reviewing" --add-label "loom:pr"
 ```
 
 ### Important Guidelines
@@ -1149,13 +1076,13 @@ This saves significant time and reduces coordination overhead for issues that ta
 
 ### Performance
 
-**Build-time perf is load-bearing, not advisory.** Downstream deploy scripts often hard-cap `pnpm build` / `cargo build` with `timeout` (e.g., `rjwalters/lean-genius`'s `scripts/deploy/sync-and-deploy.sh` line 570 wraps the build in `timeout --kill-after=30 20m pnpm build` — a 20-minute cap). When a PR adds work to the build pipeline that scales with the project's dataset (N items, N subprocesses, N file reads):
+**Build-time perf is load-bearing, not advisory.** Downstream deploy scripts often hard-cap the build (e.g. wrapping `pnpm build` / `cargo build` in a `timeout`), so a build-time regression can fail a production deploy even when the local build passes. When a PR adds work to the build pipeline that scales with the project's dataset (N items, N subprocesses, N file reads):
 
 1. **Estimate the added time against actual N**, not the count the issue body quoted. Re-derive N from `find`, `git ls-files`, or whatever the code iterates over — the issue may have undercounted.
 2. **If the regression is a meaningful fraction of the deploy cap, treat it as blocking, not a non-blocking note.** A regression that consumes ~25% of the budget headroom is already a problem; "we have time today" is not a defense when the dataset grows.
-3. **A passing local build is not a passing deploy.** `pnpm build` on the dev box has no cap; the deploy script does. If the PR adds N-bound work and the project has a documented build-time cap, the regression must be measured before approving.
+3. **A passing local build is not a passing deploy.** A dev-box build has no `timeout`; the deploy script may. If the PR adds N-bound work and the project has a documented build-time cap, the regression must be measured before approving.
 
-The lesson from `rjwalters/lean-genius` PR #20849: a Judge approved with a non-blocking note ("~2435 git log subprocess spawns adds several minutes to build time") — that framing was wrong. The added time pushed total build past the 20-minute cap, killing the production deploy mid-`vite` transform. A "several minutes added" note in a Judge review can translate directly into a failed deploy. When you spot N-bound build-pipeline code, **measure it or block on it** — do not file it as a follow-up.
+When you spot N-bound build-pipeline code, **measure it or block on it** — do not file it as a non-blocking follow-up. A "several minutes added" note in a Judge review can translate directly into a killed production deploy.
 
 ### Test Plan Execution
 
@@ -1215,228 +1142,9 @@ Include a "Test Execution" section in your evaluation comment:
 
 ## Scoped Test Execution
 
-When running quality checks (step 7), use **scoped test execution** to run only the tests relevant to changed files. This reduces evaluation time while maintaining confidence that changed code is correct.
+When running quality checks (step 7), use **scoped test execution** — run only the tests relevant to the changed files — to cut evaluation time while keeping confidence that the changed code is correct.
 
-### Step 1: Detect Changed Files
-
-```bash
-# Use gh API to list changed files — avoids local git dependency and
-# exit-128 errors when the branch is checked out in a worktree or when
-# concurrent builder operations hold a git lock. (issue #2828)
-CHANGED_FILES=$(gh pr diff $PR_NUMBER --name-only 2>/dev/null)
-if [ -z "$CHANGED_FILES" ]; then
-    echo "Warning: Could not detect changed files via gh pr diff — running full test suite"
-    # Fall through to full suite
-fi
-echo "$CHANGED_FILES"
-```
-
-### Step 2: Check for Config File Changes
-
-If the PR touches configuration files that affect the entire project, **skip scoping and run the full test suite**:
-
-```bash
-# Config files that should trigger full suite
-CONFIG_PATTERNS="pyproject.toml|setup.cfg|setup.py|package.json|pnpm-lock.yaml|yarn.lock|Cargo.toml|Cargo.lock|tsconfig.json|jest.config|vitest.config|.eslintrc|Makefile|CMakeLists"
-
-if echo "$CHANGED_FILES" | grep -qE "($CONFIG_PATTERNS)"; then
-    echo "Config files changed — running full test suite"
-    # Run full suite (skip to Fallback section below)
-fi
-```
-
-### Step 3: Classify Changed Files by Language
-
-Classify the changed files to determine which scoped test strategies to apply:
-
-| Extension/Path | Language | Scoped Strategy |
-|----------------|----------|-----------------|
-| `.py`, `.pyi` | Python | `pytest --testmon` or full pytest |
-| `.ts`, `.tsx` | TypeScript | `jest --changedSince` or `vitest --changed` |
-| `.js`, `.jsx`, `.mjs`, `.cjs` | JavaScript | `jest --changedSince` or `vitest --changed` |
-| `.rs` | Rust | `cargo test -p <crate>` |
-| Other | Unknown | Full test suite |
-
-### Step 4: Run Scoped Tests by Language
-
-#### Python Repositories
-
-**Important**: Always use `python3`, never bare `python` — `python` is not in PATH on macOS or most modern Linux systems.
-
-**CRITICAL: Use `./.loom/scripts/run-tests.sh` instead of bare `python3 -m pytest` in worktrees**
-
-Loom installs `loom-tools` as an editable package from the main repo root. When you `cd` into an
-issue worktree (`.loom/worktrees/issue-N`) and run `python3 -m pytest`, Python imports from the
-*main branch's* source — not the worktree's code. This produces false test failures for any PR
-that modifies `loom-tools`. (Observed in PR #2818 review.)
-
-`./.loom/scripts/run-tests.sh` detects the worktree automatically and sets
-`PYTHONPATH=<worktree>/loom-tools/src` before invoking pytest, ensuring tests import the
-worktree's version. Use it everywhere you would otherwise call `python3 -m pytest`.
-
-**Preferred: Use `pytest-testmon` when available**
-
-```bash
-# Use run-tests.sh wrapper — sets PYTHONPATH automatically when inside a worktree
-if ./.loom/scripts/run-tests.sh --co --testmon 2>/dev/null; then
-    # Check if .testmondata exists and is reasonably current
-    if [ -f .testmondata ]; then
-        TESTMON_AGE=$(( $(date +%s) - $(stat -f %m .testmondata 2>/dev/null || stat -c %Y .testmondata 2>/dev/null) ))
-        if [ "$TESTMON_AGE" -lt 86400 ]; then
-            echo "Using pytest-testmon for scoped test execution"
-            ./.loom/scripts/run-tests.sh --testmon -x -q
-            SCOPED_STRATEGY="pytest-testmon"
-        else
-            echo "Testmon data is stale (>24h) — falling back to full pytest"
-            ./.loom/scripts/run-tests.sh -x -q
-            SCOPED_STRATEGY="full-pytest (stale testmon data)"
-        fi
-    else
-        echo "No .testmondata found — running full pytest (consider installing pytest-testmon)"
-        ./.loom/scripts/run-tests.sh -x -q
-        SCOPED_STRATEGY="full-pytest (no testmon data)"
-    fi
-else
-    echo "pytest-testmon not available — running full pytest"
-    ./.loom/scripts/run-tests.sh -x -q
-    SCOPED_STRATEGY="full-pytest (testmon not installed)"
-fi
-```
-
-**Recommendation if testmon is unavailable:**
-Note in evaluation comment: "Consider installing `pytest-testmon` (`pip install pytest-testmon`) for faster scoped test execution in future reviews."
-
-#### JavaScript/TypeScript Repositories
-
-**Detect and use the project's test runner:**
-
-```bash
-# Check for Jest
-if npx jest --version 2>/dev/null; then
-    echo "Using Jest with --changedSince for scoped tests"
-    npx jest --changedSince=origin/main
-    SCOPED_STRATEGY="jest --changedSince"
-
-# Check for Vitest
-elif npx vitest --version 2>/dev/null; then
-    echo "Using Vitest with --changed for scoped tests"
-    npx vitest run --changed origin/main
-    SCOPED_STRATEGY="vitest --changed"
-
-# Fallback: run whatever test script is configured
-else
-    echo "No Jest or Vitest detected — running configured test script"
-    npm test 2>/dev/null || pnpm test 2>/dev/null || yarn test 2>/dev/null
-    SCOPED_STRATEGY="full-test-script (no scoping tool detected)"
-fi
-```
-
-#### Rust Repositories
-
-**Scope to changed crates in workspace projects:**
-
-```bash
-# Check if this is a Cargo workspace
-if grep -q '^\[workspace\]' Cargo.toml 2>/dev/null; then
-    # Find which crates have changed files
-    CHANGED_CRATES=$(echo "$CHANGED_FILES" | grep '\.rs$' | \
-        sed 's|/.*||' | sort -u | \
-        while read dir; do
-            if [ -f "$dir/Cargo.toml" ]; then
-                grep '^name' "$dir/Cargo.toml" | head -1 | sed 's/name *= *"\(.*\)"/\1/'
-            fi
-        done)
-
-    if [ -n "$CHANGED_CRATES" ]; then
-        echo "Scoping Rust tests to changed crates: $CHANGED_CRATES"
-        for crate in $CHANGED_CRATES; do
-            cargo test -p "$crate"
-        done
-        SCOPED_STRATEGY="cargo test -p ($(echo $CHANGED_CRATES | tr '\n' ', '))"
-    else
-        echo "Changed Rust files not in identifiable crates — running full cargo test"
-        cargo test --workspace
-        SCOPED_STRATEGY="full-cargo-test"
-    fi
-else
-    # Single-crate project, just run tests
-    cargo test
-    SCOPED_STRATEGY="cargo-test (single crate)"
-fi
-```
-
-### Step 5: Fallback to Full Suite
-
-Run the full test suite when:
-- Config files are changed (detected in step 2)
-- Changed files span unknown languages
-- Scoped tools are not available
-- First run in a repository with no scoping data
-
-```bash
-# Generic fallback — use whatever the project's standard check command is
-pnpm check:ci 2>/dev/null || \
-    npm test 2>/dev/null || \
-    ./.loom/scripts/run-tests.sh 2>/dev/null || \
-    cargo test 2>/dev/null || \
-    make test 2>/dev/null
-SCOPED_STRATEGY="full-suite (fallback)"
-```
-
-### Step 6: Document Strategy in Evaluation Comment
-
-**Always log which scoping strategy was used.** Include a "Test Scoping" section in your evaluation comment:
-
-```markdown
-## Test Scoping
-
-**Strategy**: `pytest-testmon`
-**Changed files**: 3 Python files in `src/utils/`
-**Scoped result**: 12 tests selected, all passed
-**Note**: Full suite has 847 tests; scoped execution covered tests affected by changes.
-```
-
-Or when falling back:
-
-```markdown
-## Test Scoping
-
-**Strategy**: `full-suite` (config files changed)
-**Reason**: PR modifies `pyproject.toml` — full test suite required
-**Result**: 847 tests, all passed
-```
-
-Or when recommending a missing tool:
-
-```markdown
-## Test Scoping
-
-**Strategy**: `full-pytest` (testmon not installed)
-**Result**: 847 tests, all passed
-**Recommendation**: Consider installing `pytest-testmon` for faster scoped test execution in future reviews.
-```
-
-### Edge Cases
-
-| Scenario | Behavior |
-|----------|----------|
-| PR touches only docs/markdown | Skip test execution entirely (no code changes) |
-| PR touches files in multiple languages | Run scoped tests for each language independently |
-| Scoped tests pass but you suspect missed coverage | Note in evaluation; do not block approval |
-| `pytest-testmon` DB is from wrong branch | Fall back to full pytest (check DB age) |
-| No test framework detected | Note absence in evaluation; check if project has tests at all |
-| PR touches shared utilities | Scoped tools may miss downstream tests — note this risk in evaluation |
-
-### Why Scoped Test Execution Matters
-
-| Metric | Full Suite | Scoped |
-|--------|-----------|--------|
-| Typical duration | 2-10 minutes | 10-60 seconds |
-| Tests executed | All | Only affected |
-| Confidence | Maximum | High (with caveats) |
-| Use case | Config changes, first run | Focused code changes |
-
-**Key principle**: Scoped execution is an optimization, not a replacement for CI. The full test suite still runs in CI (step 8 verifies CI status). Scoped execution gives the Judge faster local feedback during evaluation.
+**The full scoped-test cookbook** (changed-file detection, config-change full-suite trigger, per-language strategies — `pytest-testmon`, `jest --changedSince`, `vitest --changed`, `cargo test -p <crate>` — the full-suite fallback, and the strategy-documentation template) **lives in [`judge-reference.md`](judge-reference.md) → "Scoped Test Execution".** Read and follow it when running step 7.
 
 ## Feedback Style
 
@@ -1500,7 +1208,7 @@ EOF
 
 # Then approve with reference to the issue
 gh pr comment 557 --body "✅ **Approved!** Created #XXX to track documentation update. Code quality is excellent." && \
-  gh pr edit 557 --remove-label "loom:review-requested" --add-label "loom:pr"
+  gh pr edit 557 --remove-label "loom:review-requested" --remove-label "loom:reviewing" --add-label "loom:pr"
 ```
 
 ### Benefits
@@ -1563,7 +1271,7 @@ gh pr checkout 42
 # Run checks
 pnpm check:all  # or equivalent for the project
 
-# Request changes (green → amber - Fixer will address)
+# Request changes (green → amber - Doctor will address)
 # IMPORTANT: Chain comment AND label update with && to ensure both execute
 gh pr comment 42 --body "$(cat <<'EOF'
 ❌ **Changes Requested**
@@ -1577,8 +1285,8 @@ Found a few issues that need addressing:
 Please address these and I'll take another look!
 EOF
 )" && \
-  gh pr edit 42 --remove-label "loom:review-requested" --add-label "loom:changes-requested"
-# Note: PR now has loom:changes-requested (amber badge) - Fixer will address and change back to loom:review-requested
+  gh pr edit 42 --remove-label "loom:review-requested" --remove-label "loom:reviewing" --add-label "loom:changes-requested"
+# Note: PR now has loom:changes-requested (amber badge) - Doctor will address and change back to loom:review-requested
 
 # Approve PR (green → blue)
 # IMPORTANT: Chain comment AND label update with && to ensure both execute
@@ -1593,57 +1301,15 @@ gh pr comment 42 --body "$(cat <<'EOF'
 3. Start daemon and observe behavior — ⚠️ Skipped: requires manual observation
 EOF
 )" && \
-  gh pr edit 42 --remove-label "loom:review-requested" --add-label "loom:pr"
-# Note: PR now has loom:pr (blue badge) - ready for user to merge
+  gh pr edit 42 --remove-label "loom:review-requested" --remove-label "loom:reviewing" --add-label "loom:pr"
+# Note: PR now has loom:pr (blue badge) - ready for Champion auto-merge
 ```
 
 ## Terminal Probe Protocol
 
-Loom uses an intelligent probe system to detect what's running in each terminal. When you receive a probe command, respond according to this protocol.
+When you receive a terminal probe (`# Terminal Probe: Are you an AI agent?...`), respond with `AGENT:Judge:<brief-task>` — e.g. `AGENT:Judge:evaluating-PR-123`.
 
-### When You See This Probe
-
-```bash
-# Terminal Probe: Are you an AI agent? If yes, respond with "AGENT:<role>:<primary-task>". If you're a bash shell, this is just a comment.
-true
-```
-
-### How to Respond
-
-**Format**: `AGENT:<your-role>:<brief-task-description>`
-
-**Examples** (adapt to your role):
-- `AGENT:Judge:evaluating-PR-123`
-- `AGENT:Architect:analyzing-system-design`
-- `AGENT:Curator:enhancing-issue-456`
-- `AGENT:Worker:implements-issue-222`
-- `AGENT:Default:shell-session`
-
-### Role Name
-
-Use your assigned role name (Judge, Architect, Curator, Worker, Default, etc.).
-
-### Task Description
-
-Keep it brief (3-6 words) and descriptive:
-- Use present-tense verbs: "evaluating", "analyzing", "enhancing", "implements"
-- Include issue/PR number if working on one: "evaluating-PR-123"
-- Use hyphens between words: "analyzing-system-design"
-- If idle: "idle-monitoring-for-work" or "awaiting-tasks"
-
-### Why This Matters
-
-- **Debugging**: Helps diagnose agent launch issues
-- **Monitoring**: Shows what each terminal is doing
-- **Verification**: Confirms agents launched successfully
-- **Future Features**: Enables agent status dashboards
-
-### Important Notes
-
-- **Don't overthink it**: Just respond with the format above
-- **Be consistent**: Always use the same format
-- **Be honest**: If you're idle, say so
-- **Be brief**: Task description should be 3-6 words max
+**The full probe protocol** (format, per-role examples, task-description conventions, and rationale — shared with `champion-common.md`) **lives in [`judge-reference.md`](judge-reference.md) → "Terminal Probe Protocol".**
 
 ## Completion
 
@@ -1667,6 +1333,6 @@ If no work was found (no PRs with `loom:review-requested`), report that and stop
 3. Continue until the queue is empty
 4. Once the queue is empty, execute `/clear` to reset context for the next interval
 
-This batch processing prevents PRs from waiting unnecessarily when multiple are queued. With 5 shepherd slots running in parallel, the judge must drain the queue efficiently rather than processing one PR per interval.
+This batch processing prevents PRs from waiting unnecessarily when multiple are queued. Under the wave-parallel sweep model, several sweeps can land PRs at once, so the judge must drain the queue efficiently rather than processing one PR per interval.
 
 If no work is available at the start of an iteration, execute `/clear` and wait for the next trigger.

--- a/defaults/.github/labels.yml
+++ b/defaults/.github/labels.yml
@@ -44,7 +44,7 @@
   color: "F59E0B"  # amber-500 - matches other "action required" labels
 
 - name: loom:pr
-  description: PR approved by Judge, ready for human to merge
+  description: PR approved by Judge, ready for Champion auto-merge
   color: "3B82F6"  # blue-500
 
 # Agent Proposal Labels


### PR DESCRIPTION
Closes #3785

## Summary

Fixes label-hygiene, stale-role, and approval-gate defects in the largest prompt in the repo (`defaults/.claude/commands/loom/judge.md`, 1,672 lines), and splits ~334 lines of cookbook/duplication out into a new `judge-reference.md` (mirroring the champion split).

## Changes

**1. `loom:reviewing` claim label no longer leaks.** Every terminal label transition — the Label Workflow approval/change-request, all DIRTY-rebase/complex-conflict/CI-failure/missing-Closes fallbacks, and every worked example — now includes `--remove-label "loom:reviewing"`. Verified: all 17 `add-label loom:pr`/`loom:changes-requested` transitions that remove `loom:review-requested` also remove `loom:reviewing`.

**2. Approval gate aligned with reality.** `loom:pr` is now described as "ready for **Champion auto-merge**", not "ready for user to merge", in judge.md and in both canonical `.github/labels.yml` copies (repo + `defaults/`).

**3. Stale role references removed.** `s/shepherd/sweep orchestrator/` and `s/Fixer/Doctor/` throughout; the "5 shepherd slots" batch rationale is replaced with the wave-parallel sweep model. `grep -i "shepherd\|Fixer"` on the final files returns nothing.

**4. Pending-CI batch behavior specified.** Instead of ambiguous "wait / check back later", the Judge now releases `loom:reviewing`, leaves the PR in the review queue with no end-state label, skips it, and relies on the next cron tick.

**5. Dedup + split (judge.md 1,672 → 1,338 lines; judge-reference.md 284 lines):**
- Moved the Scoped Test Execution cookbook and the Terminal Probe Protocol into `judge-reference.md`, leaving short pointers.
- Removed the duplicate DIRTY merge-conflict fallback in the CI section and the two redundant "Example Workflow" restatements.
- Trimmed the duplicated inline MCP environment re-check.
- Generalized the hardcoded `rjwalters/lean-genius` build-timeout postmortem (no other-repo paths/PR numbers in an installable default).

## Notes

- The installed copy at `.claude/commands/loom/judge.md` is **not** git-tracked, so only the `defaults/` copy is changed.
- This is dedup + correction — no unique behavioral guidance was dropped; cookbook content was relocated, not deleted.

## Test Plan
- [x] `grep -i "shepherd\|Fixer"` on judge.md and judge-reference.md → no matches
- [x] No terminal transition removing `loom:review-requested` omits `loom:reviewing`
- [x] No "user to merge" wording remains in judge.md; labels.yml updated
- [x] Section structure verified coherent after moves (pointers in place, reference file self-contained)

🤖 Generated with [Claude Code](https://claude.com/claude-code)