### PR TITLE
fix(sweep): Stage -1 pool probe counts merged account sources, not just legacy .env

### DIFF
--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -714,20 +714,23 @@ Both checks are cheap, local, and side-effect-free. The configured-pool count mi
 TOKEN_FILE_COUNT=$(ls .loom/tokens/*.token 2>/dev/null | wc -l | tr -d ' ')
 
 # Repo-local (mirrors bootstrap.py: .loom/accounts.env if present, else legacy .env)
+# NOTE: `grep -c` prints `0` AND exits non-zero on an existing-but-empty file, so a
+# `|| echo 0` fallback would emit a two-line "0\n0" and abort the arithmetic below under
+# bash 3.2. Use `|| true` + `${var:-0}` so an existing-empty source yields exactly `0`.
 if [[ -f .loom/accounts.env ]]; then
-  REPO_KEY_COUNT=$(grep -c '^ACCOUNT_KEY_' .loom/accounts.env 2>/dev/null || echo 0)
+  REPO_KEY_COUNT=$(grep -c '^ACCOUNT_KEY_' .loom/accounts.env 2>/dev/null || true); REPO_KEY_COUNT=${REPO_KEY_COUNT:-0}
 else
-  REPO_KEY_COUNT=$(grep -c '^ACCOUNT_KEY_' .env 2>/dev/null || echo 0)
+  REPO_KEY_COUNT=$(grep -c '^ACCOUNT_KEY_' .env 2>/dev/null || true); REPO_KEY_COUNT=${REPO_KEY_COUNT:-0}
 fi
 
 # claude-monitor master (primary source per CLAUDE.md; LOOM_CLAUDE_MONITOR_DIR override)
 MONITOR_DIR="${LOOM_CLAUDE_MONITOR_DIR:-$HOME/.claude-monitor}"
-MONITOR_KEY_COUNT=$(grep -c '^ACCOUNT_KEY_' "$MONITOR_DIR/accounts.env" 2>/dev/null || echo 0)
+MONITOR_KEY_COUNT=$(grep -c '^ACCOUNT_KEY_' "$MONITOR_DIR/accounts.env" 2>/dev/null || true); MONITOR_KEY_COUNT=${MONITOR_KEY_COUNT:-0}
 
 # Opt-in home master — only consulted when LOOM_ACCOUNTS_ENV is set and non-empty (per #3704)
 HOME_KEY_COUNT=0
 if [[ -n "${LOOM_ACCOUNTS_ENV:-}" ]]; then
-  HOME_KEY_COUNT=$(grep -c '^ACCOUNT_KEY_' "$LOOM_ACCOUNTS_ENV" 2>/dev/null || echo 0)
+  HOME_KEY_COUNT=$(grep -c '^ACCOUNT_KEY_' "$LOOM_ACCOUNTS_ENV" 2>/dev/null || true); HOME_KEY_COUNT=${HOME_KEY_COUNT:-0}
 fi
 
 ENV_KEY_COUNT=$(( REPO_KEY_COUNT + MONITOR_KEY_COUNT + HOME_KEY_COUNT ))

--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -648,7 +648,8 @@ PROBE_DAEMON:
   Ping ~/.loom/loom-daemon.sock with 500ms timeout. Pong → reachable.
 
 PROBE_POOL:
-  Count *.token files in .loom/tokens/ OR ACCOUNT_KEY_* lines in .env. Pool exists if count >= 2.
+  Count *.token files in .loom/tokens/ OR ACCOUNT_KEY_* lines summed across the merged
+  claude-monitor / .loom/accounts.env / legacy .env account sources. Pool exists if count >= 2.
 
 DECIDE:
   if Mode C: use_subagent()
@@ -704,18 +705,43 @@ The `no_such_tool` case covers older Loom installs without Phase A's MCP additio
 
 A pool exists if **either** of these is true (logical OR, both checked):
 
-1. **Materialized pool**: `.loom/tokens/*.token` contains **two or more** files. The bootstrap step (`loom-tokens bootstrap`) writes one `*.token` file per `ACCOUNT_KEY_*` triple in `.env`; a count `>= 2` means at least two distinct accounts are available for rotation.
-2. **Configured pool**: `.env` at the workspace root contains **two or more** `ACCOUNT_KEY_*` lines. This catches the case where the operator has configured multiple accounts but hasn't yet run `loom-tokens bootstrap` — the daemon's spawn-time selector can still pick a token, and the pool will be materialized on demand.
+1. **Materialized pool**: `.loom/tokens/*.token` contains **two or more** files. The bootstrap step (`loom-tokens bootstrap`) writes one `*.token` file per `ACCOUNT_KEY_*` triple in the merged account set; a count `>= 2` means at least two distinct accounts are available for rotation.
+2. **Configured pool**: **two or more** `ACCOUNT_KEY_*` lines are declared across the **merged account sources** — the claude-monitor master (`${LOOM_CLAUDE_MONITOR_DIR:-$HOME/.claude-monitor}/accounts.env`), the repo-local file (`.loom/accounts.env`, falling back to the legacy `.env`), and — **only when `LOOM_ACCOUNTS_ENV` is set** — the opt-in home master at that path. This catches the case where the operator has configured multiple accounts (in the post-#3695/#3704 claude-monitor-first layout, not just the legacy `.env`) but hasn't yet run `loom-tokens bootstrap` — the daemon's spawn-time selector can still pick a token, and the pool will be materialized on demand.
 
-Both checks are cheap, local, and side-effect-free:
+Both checks are cheap, local, and side-effect-free. The configured-pool count mirrors `bootstrap.py`'s source precedence but does **not** dedupe by email — a raw sum of `ACCOUNT_KEY_*` lines is an accepted approximation for this boolean `>= 2` gate (worst case a single account declared in two sources double-counts at the `== 1` vs `== 2` boundary, a false-positive toward daemon use that still requires `PROBE_DAEMON` to also be true):
 
 ```bash
 TOKEN_FILE_COUNT=$(ls .loom/tokens/*.token 2>/dev/null | wc -l | tr -d ' ')
-ENV_KEY_COUNT=$(grep -c '^ACCOUNT_KEY_' .env 2>/dev/null || echo 0)
+
+# Repo-local (mirrors bootstrap.py: .loom/accounts.env if present, else legacy .env)
+if [[ -f .loom/accounts.env ]]; then
+  REPO_KEY_COUNT=$(grep -c '^ACCOUNT_KEY_' .loom/accounts.env 2>/dev/null || echo 0)
+else
+  REPO_KEY_COUNT=$(grep -c '^ACCOUNT_KEY_' .env 2>/dev/null || echo 0)
+fi
+
+# claude-monitor master (primary source per CLAUDE.md; LOOM_CLAUDE_MONITOR_DIR override)
+MONITOR_DIR="${LOOM_CLAUDE_MONITOR_DIR:-$HOME/.claude-monitor}"
+MONITOR_KEY_COUNT=$(grep -c '^ACCOUNT_KEY_' "$MONITOR_DIR/accounts.env" 2>/dev/null || echo 0)
+
+# Opt-in home master — only consulted when LOOM_ACCOUNTS_ENV is set and non-empty (per #3704)
+HOME_KEY_COUNT=0
+if [[ -n "${LOOM_ACCOUNTS_ENV:-}" ]]; then
+  HOME_KEY_COUNT=$(grep -c '^ACCOUNT_KEY_' "$LOOM_ACCOUNTS_ENV" 2>/dev/null || echo 0)
+fi
+
+ENV_KEY_COUNT=$(( REPO_KEY_COUNT + MONITOR_KEY_COUNT + HOME_KEY_COUNT ))
 if (( TOKEN_FILE_COUNT >= 2 )) || (( ENV_KEY_COUNT >= 2 )); then
   PROBE_POOL=true
 else
   PROBE_POOL=false
+fi
+
+# Discoverable signal: accounts configured but not yet bootstrapped. Only fires when
+# the merged sources declare a pool (ENV_KEY_COUNT >= 2) yet .loom/tokens/ has < 2
+# token files — NOT on every subagent fallthrough.
+if (( ENV_KEY_COUNT >= 2 )) && (( TOKEN_FILE_COUNT < 2 )); then
+  echo "Configured account pool detected but not bootstrapped — run 'loom-tokens bootstrap' to materialize .loom/tokens/." >&2
 fi
 ```
 
@@ -817,7 +843,8 @@ These are the AC #3 and AC #4 contracts, written for the operator.
 ```bash
 # Preconditions:
 #   - loom-daemon is running (`pgrep loom-daemon` matches, ~/.loom/loom-daemon.sock exists)
-#   - At least 2 accounts in .env / .loom/tokens/
+#   - At least 2 accounts configured — in .loom/tokens/, or ACCOUNT_KEY_* lines across
+#     the merged claude-monitor / .loom/accounts.env / legacy .env account sources
 
 /loom:sweep 123 456
 
@@ -835,7 +862,8 @@ These are the AC #3 and AC #4 contracts, written for the operator.
 
 ```bash
 # Preconditions:
-#   - Either loom-daemon is not running, OR .env has < 2 ACCOUNT_KEY_* lines.
+#   - Either loom-daemon is not running, OR the merged account sources
+#     (claude-monitor / .loom/accounts.env / legacy .env) have < 2 ACCOUNT_KEY_* lines total.
 
 /loom:sweep 123 456
 


### PR DESCRIPTION
Closes #3789

## Problem

`/loom:sweep` Stage -1's token-pool probe (`PROBE_POOL`) only counted `ACCOUNT_KEY_*` lines in the **legacy** `.env`. Operators on the post-#3695/#3704 claude-monitor-first account layout (`~/.claude-monitor/accounts.env`, `.loom/accounts.env`) who hadn't yet run `loom-tokens bootstrap` got `PROBE_POOL=false`, the Stage -1 strict-AND failed, and every sweep silently fell through to in-process subagent dispatch — losing multi-account daemon parallelism with no signal as to why.

## Change

All edits are confined to the single tracked source `defaults/.claude/commands/loom/sweep.md` (`.claude/commands/loom/sweep.md` is a gitignored installed copy).

- **PROBE_POOL bash probe** now sums `ACCOUNT_KEY_*` lines across all resolvable sources, mirroring `bootstrap.py`'s precedence (no dedup-by-email — a raw sum is an accepted approximation for a boolean `>= 2` gate):
  - Repo-local: `.loom/accounts.env` if present, else legacy `.env`
  - claude-monitor master: `${LOOM_CLAUDE_MONITOR_DIR:-$HOME/.claude-monitor}/accounts.env`
  - Opt-in home master: `$LOOM_ACCOUNTS_ENV` **only** when set and non-empty (per #3704)
- **Discoverable hint**: when accounts are configured (`ENV_KEY_COUNT >= 2`) but not yet bootstrapped (`TOKEN_FILE_COUNT < 2`), the probe prints a stderr line telling the operator to run `loom-tokens bootstrap` — instead of a silent fallthrough. It fires only in that state, not on every subagent fallthrough.
- Updated the decision-tree summary, the detailed `#### PROBE_POOL` section, and the two smoke-test precondition comments to name the merged sources.

## Scope boundaries respected

- No change to `bootstrap.py` / `merge_accounts()`.
- No change to `PROBE_DAEMON`, `DECIDE`, Mode C short-circuit, `--no-daemon`, or `LOOM_SWEEP_CLAIM_OWNED`.
- No change to `loom-daemon/tests/sweep_md_stage_minus_one_doc_lint.rs`.

## Test results

- `cargo test --test sweep_md_stage_minus_one_doc_lint` — **10 passed, 0 failed** (unmodified assertions still hold).
- Manual trace of the updated snippet across five scenarios (all correct):
  | Scenario | Result |
  |----------|--------|
  | claude-monitor only, 2 accounts, no `.env`/tokens | `PROBE_POOL=true` (bug fixed) |
  | legacy `.env` only, 2 accounts | `PROBE_POOL=true` (no regression) |
  | legacy `.env` only, 1 account | `PROBE_POOL=false` (single-token, not a pool) |
  | `LOOM_ACCOUNTS_ENV` unset | home master **not** read (opt-in honored) |
  | `LOOM_ACCOUNTS_ENV` set | home master counted |

Snippet is bash-3.2 portable (`[[ -f ]]`, `${VAR:-default}`, `$(( ))`, no `mapfile`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)