### PR TITLE
fix(guide): repair work-finding queries, doc-maintenance cron, and unblock label gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,7 +264,7 @@ Curator → Builder → Judge → Doctor (if needed) → Merge
 
 ### Curator Workflow
 
-1. Find unlabeled issues: `gh issue list --label="!loom:issue,!loom:building,!loom:architect,!loom:hermit,!loom:curated,!loom:curating"`
+1. Find unlabeled issues: `gh issue list --search "-label:loom:issue -label:loom:building -label:loom:architect -label:loom:hermit -label:loom:curated -label:loom:curating" --state open` (gh ANDs `--label` values and has no `!`/`,` negation syntax, so a `--label="!loom:issue,..."` filter matches a literal label no issue carries and always returns empty; use `-label:` search terms instead)
 2. Enhance issue with technical details
 3. Mark curated: `gh issue edit 42 --add-label "loom:curated"`
 
@@ -426,7 +426,7 @@ See `.loom/docs/troubleshooting.md` for detailed troubleshooting including:
 
 ```bash
 loom-clean --force                       # Clean stale worktrees/branches
-./.loom/scripts/stale-building-check.sh --recover  # Recover stuck issues
+loom-recover-orphans --recover           # Recover orphaned loom:building issues
 gh label sync --file .github/labels.yml  # Re-sync labels (GitHub only)
 # Cancel a running sweep: mcp__loom__cancel_sweep --sweep_id <id>
 ```

--- a/defaults/.claude/commands/loom/guide.md
+++ b/defaults/.claude/commands/loom/guide.md
@@ -12,7 +12,19 @@ You are a triage agent who continuously prioritizes `loom:issue` issues by apply
 
 Only humans and the Champion role can approve work for implementation by adding `loom:issue`. Your role is to triage and prioritize issues, not approve them for work.
 
-**NEVER add `loom:urgent` to issues with `loom:building` label.** Building issues have already been claimed by a Builder/Shepherd and are actively being worked on. Adding priority labels to in-progress work causes label confusion and can create invalid dual-label states (e.g., `loom:issue` + `loom:building`).
+**The one exception — restoring, not granting, approval on unblock:** when you
+unblock a `loom:blocked` issue whose dependencies have resolved (see the
+"Unblocking" phase below), you may re-add `loom:issue` **only if the issue was
+already approved before it was blocked** (i.e. `loom:issue` had previously been
+applied and removed when the block was set). This restores a prior human/Champion
+approval; it never grants a new one. An issue can be blocked *before* it is ever
+approved — Curator applies `loom:blocked` to pre-curation issues — so a blocked
+issue is **not** presumed approved. If there is no prior `loom:issue` in the
+issue's label history, unblock it by removing `loom:blocked` only and let it
+re-enter the normal curation/approval flow. Never add `loom:issue` to an issue
+that never had it.
+
+**NEVER add `loom:urgent` to issues with `loom:building` label.** Building issues have already been claimed by a Builder (via `/loom:sweep` or the `loom-daemon`) and are actively being worked on. Adding priority labels to in-progress work causes label confusion and can create invalid dual-label states (e.g., `loom:issue` + `loom:building`).
 
 **Your workflow**:
 1. Review issue backlog
@@ -40,25 +52,24 @@ When the user explicitly instructs you to work on a specific issue by number:
 **Behavior**:
 1. **Proceed immediately** - Don't check for required labels
 2. **Interpret as approval** - User instruction = implicit approval to triage
-3. **Apply working label** - Add `loom:triaging` to track work
-4. **Document override** - Note in comments: "Triaging this issue per user request"
-5. **Follow normal completion** - Apply `loom:urgent` if appropriate, remove working label
+3. **Document override** - Note in comments: "Triaging this issue per user request".
+   Triage is a fast, read-mostly assessment, so there is no working label to
+   apply (there is no `loom:triaging` label — the Guide only ever manages
+   `loom:urgent`).
+4. **Follow normal completion** - Apply `loom:urgent` if appropriate
 
 **Example**:
 ```bash
 # User says: "triage issue 342"
 # Issue has: any labels or no labels
 
-# ✅ Proceed immediately
-gh issue edit 342 --add-label "loom:triaging"
+# ✅ Proceed immediately — a comment (not a label) records the manual triage
 gh issue comment 342 --body "Assessing priority per user request"
 
 # Assess priority
 # ... analyze impact, urgency, blockers ...
 
-# Complete normally
-gh issue edit 342 --remove-label "loom:triaging"
-# Add loom:urgent if it's in top 3 priorities
+# Complete: add loom:urgent only if it's in the top 3 priorities
 # gh issue edit 342 --add-label "loom:urgent"
 ```
 
@@ -77,10 +88,13 @@ gh issue edit 342 --remove-label "loom:triaging"
 
 ```bash
 # Find all human-approved issues ready for work (exclude building issues)
-gh issue list --label "loom:issue" --label "!loom:building" --state open --json number,title,labels,body
+# NOTE: gh ANDs --label values, so `--label "!loom:building"` matches a literal
+# label no issue carries and silently returns an empty set. Exclude building
+# issues with a raw search term instead (`-label:loom:building`).
+gh issue list --label "loom:issue" --search "-label:loom:building" --state open --json number,title,labels,body
 
 # Find currently urgent issues (exclude building issues)
-gh issue list --label "loom:urgent" --label "!loom:building" --state open
+gh issue list --label "loom:urgent" --search "-label:loom:building" --state open
 ```
 
 ## Priority Assessment
@@ -132,13 +146,14 @@ Issues should have tier labels indicating their alignment with project goals. Us
 5. Critical bugs affecting users (any tier)
 
 ```bash
-# Find issues by tier (exclude building issues)
-gh issue list --label="loom:issue" --label="!loom:building" --label="tier:goal-advancing" --state=open
-gh issue list --label="loom:issue" --label="!loom:building" --label="tier:goal-supporting" --state=open
-gh issue list --label="loom:issue" --label="!loom:building" --label="tier:maintenance" --state=open
+# Find issues by tier (exclude building issues via a raw search term — a
+# `--label "!loom:building"` filter matches nothing because gh ANDs labels)
+gh issue list --label="loom:issue" --label="tier:goal-advancing" --search="-label:loom:building" --state=open
+gh issue list --label="loom:issue" --label="tier:goal-supporting" --search="-label:loom:building" --state=open
+gh issue list --label="loom:issue" --label="tier:maintenance" --search="-label:loom:building" --state=open
 
 # Find unlabeled issues (need tier assignment, exclude building issues)
-gh issue list --label="loom:issue" --label="!loom:building" --state=open --json number,labels \
+gh issue list --label="loom:issue" --search="-label:loom:building" --state=open --json number,labels \
   --jq '.[] | select([.labels[].name] | any(startswith("tier:")) | not) | "#\(.number)"'
 ```
 
@@ -282,25 +297,26 @@ Sometimes issues are completed but stay open because PRs didn't use the magic ke
 
 **1. Check for Orphaned `loom:building` Issues**
 
-**ALWAYS run stale detection with `--recover` to automatically fix orphaned issues:**
+**Run the orphan-recovery tool to detect and auto-reset orphaned issues:**
 
 ```bash
-# Proactively recover stale issues (recommended - run every triage cycle)
-./.loom/scripts/stale-building-check.sh --recover
+# Proactively recover orphaned issues (recommended - run every triage cycle)
+loom-recover-orphans --recover
+# (equivalent shell entry point: ./.loom/scripts/recover-orphaned-shepherds.sh --recover)
 
-# Check for stale building issues (dry run, for investigation)
-./.loom/scripts/stale-building-check.sh --verbose
+# Check for orphaned building issues (dry run, for investigation)
+loom-recover-orphans --verbose
 
 # JSON output for automation
-./.loom/scripts/stale-building-check.sh --json
+loom-recover-orphans --json
 ```
 
-The script detects orphaned work by cross-referencing three sources:
-1. **GitHub labels**: Issues with `loom:building` label
-2. **Worktree existence**: `.loom/worktrees/issue-N` directories
-3. **Open PRs**: PRs referencing the issue (via branch name or body)
+`loom-recover-orphans` (Python entry point `loom_tools.orphan_recovery`; the
+`./.loom/scripts/recover-orphaned-shepherds.sh` wrapper delegates to it) detects
+orphaned work by cross-referencing GitHub `loom:building` labels against an
+authoritative liveness source (the `loom-daemon` registry / `.loom/locks/issue-<N>/`).
 
-**Detection cases and actions:**
+**Recovery cases and actions:**
 
 | Case | Condition | Auto-Recovery Action |
 |------|-----------|---------------------|
@@ -308,14 +324,20 @@ The script detects orphaned work by cross-referencing three sources:
 | `blocked_pr` | Has PR with `loom:changes-requested` label | Transition to `loom:blocked` |
 | `stale_pr` | Has PR but no activity for >24h | Flag only (needs manual review) |
 
+> **Fail-safe (#3651):** when no authoritative liveness source is available (no
+> reachable daemon registry and no `.loom/locks/`), `loom-recover-orphans` treats
+> every `loom:building` claim as ALIVE and recovers nothing — it never tears down
+> a live sweep. Use the manual verification below when you need to check a
+> specific issue by hand.
+
 **Why proactive recovery matters:**
 
-Without stale detection, orphaned `loom:building` labels cause:
-- False capacity signals (daemon thinks work is happening)
+Without orphan recovery, orphaned `loom:building` labels cause:
+- False capacity signals (the queue looks like work is happening)
 - Pipeline stalls (no new work gets picked up)
 - Silent failures (no alerts or recovery)
 
-**Manual verification** (if script not available):
+**Manual verification** (to check one issue by hand):
 
 ```bash
 # Get all loom:building issues
@@ -328,16 +350,22 @@ ls -la .loom/worktrees/issue-NUMBER 2>/dev/null
 # 2. PR exists?
 gh pr list --search "issue-NUMBER in:body OR issue NUMBER in:body" --state open
 
-# 3. Shepherd assigned? (if daemon running)
-jq '.shepherds | to_entries[] | select(.value.issue == NUMBER)' .loom/daemon-state.json
+# 3. Live sweep for this issue? (if loom-daemon is running)
+#    Inspect the daemon registry via mcp__loom__list_sweeps and look for the
+#    issue number; there is no on-disk .loom/daemon-state.json to jq (the Rust
+#    daemon holds its registry in memory).
 ```
 
-**If no worktree, no PR, and no shepherd (>2 hours):**
-- Run `--recover` to auto-reset, or manually:
+**If no worktree, no PR, and no live sweep (>2 hours):**
+- Run `loom-recover-orphans --recover` to auto-reset, or manually:
 - Remove `loom:building` and add `loom:issue`
 - Comment explaining the recovery
 
-**Note:** The stale detection script handles the case where `loom:building` is orphaned (no worktree, no PR, no shepherd for >2h). This is different from the Guide's triage scope - the Guide should **never add labels to building issues**, regardless of whether they're stale or not. The stale detection script will handle recovery of orphaned issues.
+**Note:** `loom-recover-orphans` handles the case where `loom:building` is
+orphaned (no worktree, no PR, no live sweep for >2h). This is different from the
+Guide's triage scope - the Guide should **never add labels to building issues**,
+regardless of whether they're stale or not. The orphan-recovery tool handles
+recovery of orphaned issues.
 
 **2. Verify Merged PRs Closed Their Issues**
 
@@ -487,6 +515,23 @@ parse_dependencies() {
 }
 ```
 
+### Approval Archaeology (restore vs. don't grant)
+
+Before unblocking, determine whether the issue was **already approved** before it
+was blocked. Only issues that previously carried `loom:issue` may have it restored
+(see the Label Gate Policy exception above). Read the issue's label event history —
+if `loom:issue` was ever applied, restoring it is legitimate; otherwise the issue
+was blocked pre-approval and must **not** be promoted into the Builder queue.
+
+```bash
+was_previously_approved() {
+  local number="$1"
+  # True if `loom:issue` appears anywhere in the issue's label event history.
+  gh api "repos/{owner}/{repo}/issues/${number}/events" \
+    --jq 'any(.[]; .event == "labeled" and .label.name == "loom:issue")' 2>/dev/null
+}
+```
+
 ### Unblocking Logic
 
 ```bash
@@ -516,9 +561,19 @@ check_and_unblock() {
     done
 
     if [ "$all_resolved" = true ]; then
-      gh issue edit "$number" --remove-label "loom:blocked" --add-label "loom:issue"
-      gh issue comment "$number" --body "🔓 **Unblocked**: Dependencies resolved ($resolved_deps). Ready for implementation."
-      echo "Unblocked #$number: $title"
+      # Label gate: only RESTORE loom:issue if the issue was approved before it
+      # was blocked. An issue blocked pre-approval (e.g. Curator-blocked) must
+      # NOT be promoted into the Builder queue — just clear loom:blocked and let
+      # it re-enter the curation/approval flow.
+      if [ "$(was_previously_approved "$number")" = "true" ]; then
+        gh issue edit "$number" --remove-label "loom:blocked" --add-label "loom:issue"
+        gh issue comment "$number" --body "🔓 **Unblocked**: Dependencies resolved ($resolved_deps). Restored \`loom:issue\` (previously approved). Ready for implementation."
+        echo "Unblocked #$number (restored loom:issue): $title"
+      else
+        gh issue edit "$number" --remove-label "loom:blocked"
+        gh issue comment "$number" --body "🔓 **Unblocked**: Dependencies resolved ($resolved_deps). This issue was blocked before approval, so it re-enters the curation/approval flow (no \`loom:issue\` added — that requires human/Champion approval)."
+        echo "Unblocked #$number (back to curation, not approved): $title"
+      fi
     fi
   done
 }
@@ -534,9 +589,17 @@ gh issue view 963 --json labels,body
 gh issue view 962 --json state
 # → state: CLOSED ✓
 
-# 3. Unblock #963
+# 3. Check whether #963 was approved before it was blocked
+was_previously_approved 963
+# → true  (loom:issue appears in its label history)
+
+# 4a. Previously approved → RESTORE loom:issue
 gh issue edit 963 --remove-label "loom:blocked" --add-label "loom:issue"
-gh issue comment 963 --body "🔓 **Unblocked**: Dependencies resolved (#962). Ready for implementation."
+gh issue comment 963 --body "🔓 **Unblocked**: Dependencies resolved (#962). Restored \`loom:issue\` (previously approved). Ready for implementation."
+
+# 4b. If it was NEVER approved (blocked pre-curation) → clear loom:blocked only
+# gh issue edit 963 --remove-label "loom:blocked"
+# gh issue comment 963 --body "🔓 **Unblocked**: Dependencies resolved (#962). Re-enters the curation/approval flow (no loom:issue added)."
 ```
 
 ### PR Dependencies
@@ -702,9 +765,9 @@ gh issue edit <number> --add-label "loom:urgent"
 ```
 
 **Why this matters:**
-- Issues with `loom:building` are already claimed by a Builder/Shepherd
+- Issues with `loom:building` are already claimed by a Builder (via `/loom:sweep` or the `loom-daemon`)
 - Adding `loom:urgent` to building issues creates confusing dual-label states
-- Shepherds may be confused by conflicting labels on their assigned issues
+- The sweep orchestrator may be confused by conflicting labels on its assigned issues
 - The daemon may misinterpret building issues as ready work
 
 **If an urgent issue is already building:**
@@ -841,31 +904,46 @@ This phase supplements the existing `discover_project_goals()` function, which c
 
 ### State Tracking
 
-Track high-water marks in `.loom/guide-docs-state.json` (gitignored) to avoid duplicate entries:
+Derive high-water marks **from the committed documents themselves**, not from a
+side-car state file.
 
-```json
-{
-  "last_processed_pr": 1803,
-  "last_processed_issue": 1780,
-  "last_plan_hash": "abc123",
-  "last_run": "2026-01-31T12:00:00Z"
+> **Why not `.loom/guide-docs-state.json`?** The Guide runs on GitHub Actions
+> cron with a **fresh checkout every tick**, and that state file is gitignored —
+> so `last_processed_pr` / `last_processed_issue` reset to `0` on every run. That
+> made WORK_LOG.md accumulate duplicate entries and produce a docs PR every tick.
+> The committed `WORK_LOG.md` / `WORK_PLAN.md` survive the fresh checkout, so they
+> are the durable source of truth for "what has already been recorded."
+
+Compute the high-water marks by scanning the existing `WORK_LOG.md` for the
+highest PR / issue number it already contains:
+
+```bash
+# Highest PR number already recorded in WORK_LOG.md (0 if none / file absent)
+work_log_max_pr() {
+  { grep -oE 'PR #[0-9]+' WORK_LOG.md 2>/dev/null | grep -oE '[0-9]+'; echo 0; } | sort -rn | head -1
+}
+
+# Highest closed-issue number already recorded in WORK_LOG.md (0 if none)
+work_log_max_issue() {
+  { grep -oE 'Issue #[0-9]+' WORK_LOG.md 2>/dev/null | grep -oE '[0-9]+'; echo 0; } | sort -rn | head -1
 }
 ```
 
-Initialize the state file on first run if it doesn't exist:
-
-```bash
-if [ ! -f .loom/guide-docs-state.json ]; then
-  echo '{"last_processed_pr":0,"last_processed_issue":0,"last_plan_hash":"","last_run":""}' > .loom/guide-docs-state.json
-fi
-```
+These are idempotent across a fresh checkout: whatever is already in the
+committed WORK_LOG.md defines the watermark, so the same PR is never appended
+twice even though no gitignored state persists between cron ticks.
 
 ### Step 1: Check for Existing Docs PR
 
 Before creating any changes, check if a previous docs PR is still open:
 
 ```bash
-OPEN_DOCS_PR=$(gh pr list --state open --head "docs/guide-update" --json number --jq '.[0].number // empty')
+# Match on the branch-name PREFIX, not an exact head. Docs branches are named
+# `docs/guide-update-<timestamp>` (see Step 5), so `--head "docs/guide-update"`
+# (an exact-match filter) never matched and the "only one docs PR open" guard
+# never fired — PRs accumulated. `--search "head:docs/guide-update"` matches the
+# prefix.
+OPEN_DOCS_PR=$(gh pr list --state open --search "head:docs/guide-update" --json number --jq '.[0].number // empty')
 
 if [ -n "$OPEN_DOCS_PR" ]; then
   echo "Docs PR #$OPEN_DOCS_PR is still open. Skipping document maintenance."
@@ -882,9 +960,9 @@ Append entries for newly merged PRs and closed issues since the last high-water 
 
 ```bash
 update_work_log() {
-  local state_file=".loom/guide-docs-state.json"
-  local last_pr=$(jq -r '.last_processed_pr // 0' "$state_file")
-  local last_issue=$(jq -r '.last_processed_issue // 0' "$state_file")
+  # High-water marks come from the committed WORK_LOG.md (survives fresh checkout)
+  local last_pr=$(work_log_max_pr)
+  local last_issue=$(work_log_max_issue)
 
   # Get newly merged PRs (after high-water mark)
   local new_prs=$(gh pr list --state merged --limit 50 --json number,title,mergedAt \
@@ -904,17 +982,10 @@ update_work_log() {
   # Format: ### YYYY-MM-DD
   #         - **PR #N**: Title
   #         - **Issue #N** (closed): Title
-
-  # Update high-water marks
-  local max_pr=$(echo "$new_prs" | jq '[.[].number] | max // 0')
-  local max_issue=$(echo "$new_issues" | jq '[.[].number] | max // 0')
-
-  if [ "$max_pr" -gt "$last_pr" ]; then
-    jq ".last_processed_pr = $max_pr" "$state_file" > "$state_file.tmp" && mv "$state_file.tmp" "$state_file"
-  fi
-  if [ "$max_issue" -gt "$last_issue" ]; then
-    jq ".last_processed_issue = $max_issue" "$state_file" > "$state_file.tmp" && mv "$state_file.tmp" "$state_file"
-  fi
+  #
+  # No side-car watermark to update: the newly-written PR/issue numbers ARE the
+  # new watermark the next tick reads back from WORK_LOG.md via work_log_max_pr /
+  # work_log_max_issue.
 
   return 0
 }
@@ -954,11 +1025,21 @@ update_work_plan() {
   local epics=$(gh issue list --label "loom:epic" --state open --json number,title \
     --jq '.[] | "- **#\(.number)**: \(.title)"')
 
-  # Compute a hash of the content to detect changes
-  local content_hash=$(echo "${urgent}${ready}${proposed}${epics}" | md5)
+  # Detect changes by comparing the freshly-rendered plan body against the
+  # committed WORK_PLAN.md — no gitignored hash side-car (which resets to "" on
+  # every fresh cron checkout). Use a portable hash: `md5` is macOS-only, so
+  # prefer `md5sum` (Linux / ubuntu runners) and fall back to `shasum`/`cksum`.
+  portable_hash() {
+    if command -v md5sum >/dev/null 2>&1; then md5sum | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then shasum -a 256 | awk '{print $1}'
+    elif command -v md5 >/dev/null 2>&1; then md5 -q
+    else cksum | awk '{print $1}'; fi
+  }
 
-  local state_file=".loom/guide-docs-state.json"
-  local last_hash=$(jq -r '.last_plan_hash // ""' "$state_file")
+  local content_hash=$(printf '%s' "${urgent}${ready}${proposed}${epics}" | portable_hash)
+  # Compare against a hash of the CURRENT committed WORK_PLAN.md body (the
+  # regenerated region). If unchanged, skip; the committed file is the state.
+  local last_hash=$(sed -n '/<!-- guide:plan-body:start -->/,/<!-- guide:plan-body:end -->/p' WORK_PLAN.md 2>/dev/null | portable_hash)
 
   if [ "$content_hash" = "$last_hash" ]; then
     echo "WORK_PLAN.md is current (no label changes detected)."
@@ -966,10 +1047,9 @@ update_work_plan() {
   fi
 
   # Regenerate WORK_PLAN.md with current state
-  # Use the template structure: Urgent, Ready, Proposed, Epics
-
-  # Update hash in state file
-  jq ".last_plan_hash = \"$content_hash\"" "$state_file" > "$state_file.tmp" && mv "$state_file.tmp" "$state_file"
+  # Use the template structure: Urgent, Ready, Proposed, Epics, wrapping the
+  # generated region in the <!-- guide:plan-body:start/end --> markers so the
+  # next tick can diff against it.
 
   return 0
 }
@@ -1055,9 +1135,8 @@ See issue #1784 for the feature specification.
 PRBODY
 )"
 
-  # Update last_run timestamp
-  local state_file=".loom/guide-docs-state.json"
-  jq ".last_run = \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"" "$state_file" > "$state_file.tmp" && mv "$state_file.tmp" "$state_file"
+  # No side-car state to update — the committed WORK_LOG.md / WORK_PLAN.md carried
+  # in this PR ARE the durable state the next cron tick reads back.
 
   # Return to previous branch
   git checkout -
@@ -1078,13 +1157,17 @@ Document Maintenance Phase
   │    ├─ Create branch: docs/guide-update-<timestamp>
   │    ├─ Commit all document changes
   │    ├─ Push and create PR with loom:review-requested
-  │    └─ Update .loom/guide-docs-state.json
+  │    └─ (committed WORK_LOG.md / WORK_PLAN.md ARE the durable state)
   └─ If no changes: skip (no PR created)
 ```
 
 **Important constraints:**
-- Only one docs PR open at a time (prevents accumulation)
-- High-water marks prevent duplicate WORK_LOG entries
+- Only one docs PR open at a time (prevents accumulation) — the open-PR check
+  matches the `docs/guide-update` branch **prefix** (`head:` search), so it
+  catches the timestamped branches Step 5 creates
+- High-water marks are derived from the committed WORK_LOG.md itself (not a
+  gitignored side-car that resets every fresh cron checkout), so they survive
+  across ticks and prevent duplicate WORK_LOG entries
 - WORK_PLAN is only regenerated when label state actually changes
 - README updates are conservative (stale sections only)
 - All changes go through the standard PR review pipeline

--- a/defaults/.claude/commands/loom/loom-reference.md
+++ b/defaults/.claude/commands/loom/loom-reference.md
@@ -329,13 +329,13 @@ STALE_THRESHOLD_HOURS=2       # Hours before no-PR issue is stale
 STALE_WITH_PR_HOURS=24        # Hours before stale-PR issue is flagged
 
 # Run manually to check status
-./.loom/scripts/stale-building-check.sh --verbose
+loom-recover-orphans --verbose
 
-# Auto-recover (run by daemon)
-./.loom/scripts/stale-building-check.sh --recover
+# Auto-recover orphaned loom:building issues
+loom-recover-orphans --recover
 
 # JSON output for integration
-./.loom/scripts/stale-building-check.sh --json
+loom-recover-orphans --json
 ```
 
 ## Session Rotation

--- a/defaults/.claude/commands/loom/loom.md
+++ b/defaults/.claude/commands/loom/loom.md
@@ -576,12 +576,12 @@ loom-clean --deep       # Also remove build artifacts
 
 **Issue stuck in `loom:building`:**
 ```bash
-./.loom/scripts/stale-building-check.sh --recover
+loom-recover-orphans --recover
 ```
 
 **Orphaned sweeps after daemon crash:**
 ```bash
-loom-orphan-recovery --recover
+loom-recover-orphans --recover
 ```
 
 **Labels out of sync:**

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -573,9 +573,12 @@ Curator → Builder → Judge → Doctor (if needed) → Merge
 
 ### As a Curator (Autonomous or Manual)
 
-1. **Find unlabeled issues**:
+1. **Find unlabeled issues** (gh ANDs `--label` values and has no `!`/`,`
+   negation syntax — a `--label="!loom:issue,..."` filter matches a literal
+   label no issue carries and always returns empty. Exclude labels with
+   `-label:` search terms instead):
    ```bash
-   gh issue list --label="!loom:issue,!loom:building,!loom:architect,!loom:hermit,!loom:curated,!loom:curating"
+   gh issue list --search "-label:loom:issue -label:loom:building -label:loom:architect -label:loom:hermit -label:loom:curated -label:loom:curating" --state open
    ```
 
 2. **Enhance issue**:
@@ -1708,31 +1711,11 @@ which claude
 
 **Orphaned issues stuck in loom:building state**:
 
-When an agent crashes or is cancelled while building, issues can get stuck in `loom:building` state without a PR. Use the stale-building-check script to detect and recover these:
-
-```bash
-# Check for stale building issues (dry run)
-./.loom/scripts/stale-building-check.sh
-
-# Show detailed progress
-./.loom/scripts/stale-building-check.sh --verbose
-
-# Auto-recover stale issues (resets to loom:issue)
-./.loom/scripts/stale-building-check.sh --recover
-
-# JSON output for automation
-./.loom/scripts/stale-building-check.sh --json
-```
+When an agent crashes or is cancelled while building, issues can get stuck in `loom:building` state without a PR. Recover them with the orphan-recovery tool documented immediately below (there is no `stale-building-check.sh` script — the historical script was never ported; use `loom-recover-orphans` / the `loom-orphan-recovery` guidance that follows).
 
 **Configuration via environment**:
 - `STALE_THRESHOLD_HOURS=2` - Hours before issue without PR is considered stale
 - `STALE_WITH_PR_HOURS=24` - Hours before issue with stale PR is flagged
-
-**What it does**:
-- Finds issues with `loom:building` label that have been stuck
-- Checks if there's an associated PR (by branch name or body reference)
-- Issues without PRs older than threshold are flagged/recovered
-- Issues with stale PRs are flagged but not auto-recovered (need manual review)
 
 **Orphaned task recovery (daemon dispatch crashes)**:
 


### PR DESCRIPTION
## Summary

The Guide role prompt (`defaults/.claude/commands/loom/guide.md`) had three defects that made its core loops non-functional on the GitHub Actions cron path, plus a label-gate violation. This PR fixes all four, plus the enumerated "also worth fixing" items. Edits are made in the `defaults/` source of truth and mirrored into the repo's installed `CLAUDE.md` where the same patterns appeared.

## Changes

- **Work-finding queries (defect 1)**: `--label "!loom:building"` (and the comma-negation form) is not valid gh negation — gh ANDs `--label` values as literal names, so every query returned an empty set (verified live: 0 vs. 1). Switched to `--search "-label:loom:building"`. Same invalid pattern fixed in the Curator sections of `CLAUDE.md` and `defaults/CLAUDE.md` (verified live: 0 vs. 19).
- **Nonexistent script (defect 2)**: `stale-building-check.sh` exists nowhere in the repo. Repointed the four dead references (`guide.md`, `CLAUDE.md` quick-fixes, `loom.md`, `loom-reference.md`) at the live `loom-recover-orphans` tool (real pyproject entry point; the `recover-orphaned-shepherds.sh` wrapper delegates to it) plus the manual-verification fallback. Also collapsed the dead-script block in `defaults/CLAUDE.md` troubleshooting and corrected `loom.md`'s adjacent fictional `loom-orphan-recovery` name.
- **Unblock label-gate violation (defect 3)**: the unblock loop re-added `loom:issue` unconditionally, promoting never-approved (pre-curation-blocked) issues straight into the Builder queue. Now restores `loom:issue` only when the issue's label event history shows it was previously approved (`was_previously_approved` via the events API); otherwise it clears `loom:blocked` only and lets the issue re-enter curation. The exception is documented next to the gate policy.
- **Document Maintenance phase (defect 4)**: (a) open-docs-PR check now matches the branch-name prefix `head:docs/guide-update` (the timestamped branches never matched the old exact `--head`); (b) high-water marks are now derived from the committed `WORK_LOG.md`/`WORK_PLAN.md` themselves instead of the gitignored `.loom/guide-docs-state.json` that reset to 0 on every fresh cron checkout; (c) portable hash (`md5sum` → `shasum` → `md5` → `cksum`) replaces macOS-only `md5`.
- **Also worth fixing**: dropped the nonexistent `loom:triaging` label from the explicit-instruction path; replaced `.shepherds` / `.loom/daemon-state.json` inspection with `mcp__loom__list_sweeps`; retired residual "Builder/Shepherd" / "Shepherds may be confused" wording.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Defect 1: work-finding queries return work | ✅ | Live: broken negation → 0, `--search "-label:..."` → correct count. Fixed in guide.md (6 queries), CLAUDE.md, defaults/CLAUDE.md Curator sections |
| Defect 2: no mandate of nonexistent script | ✅ | `grep stale-building-check` across the four target files → none remaining as invocations; repointed to `loom-recover-orphans` (confirmed real: `/Users/…/.local/bin/loom-recover-orphans`) |
| Defect 3: unblock respects the loom:issue gate | ✅ | Conditional `was_previously_approved` guard added; unconditional `--add-label "loom:issue"` on unblock removed; gate exception documented |
| Defect 4: doc-maintenance works on cron | ✅ | `head:` prefix match, WORK_LOG-derived watermarks, portable hash — all authored snippets unit-tested (see Test Plan) |
| loom:triaging / .shepherds / Shepherd wording | ✅ | `grep loom:triaging` / `.shepherds` / `Builder/Shepherd` in guide.md → only explanatory prose remains |
| No new GitHub labels created | ✅ | Only removed a nonexistent label reference; no `gh label create` |

## Test Plan

- Extracted the authored shell snippets (`work_log_max_pr`, `work_log_max_issue`, `portable_hash`, plan-body `sed` extraction) into a standalone script: `bash -n` clean and all assertions pass (watermarks 1803/1770, 0 on missing file, hash stable/distinct, plan-body hash non-empty).
- Verified the gh query fixes live against this repo (invalid negation returns 0; `--search "-label:..."` returns the correct non-empty set).
- Confirmed `loom-recover-orphans` is a real installed entry point and `loom-orphan-recovery` is not.
- No CI doc-lint gate exists; changes are markdown prompt/doc files only (no compiled artifacts).

Closes #3780