### PR TITLE
fix(gitignore): lock in .loom-managed regression coverage + builder marker self-check

### DIFF
--- a/defaults/.claude/commands/loom/builder.md
+++ b/defaults/.claude/commands/loom/builder.md
@@ -41,6 +41,19 @@ git diff --stat
 git checkout -- <out-of-scope-file>
 ```
 
+**No Loom runtime markers staged.** `worktree.sh` drops a `.loom-managed` sentinel
+into every issue worktree, and other flows may leave `.loom-in-use` /
+`.loom-checkpoint`. These are gitignored by a correctly-installed repo, but a stale
+or pre-#3838 `.gitignore` may not cover them — so a blanket `git add -A` can sweep
+them into your commit. Before committing, confirm none are staged:
+
+```bash
+git -C "$WORKTREE_ABS" diff --cached --name-only \
+  | grep -E '(^|/)\.loom-managed$|(^|/)\.loom-in-use$|(^|/)\.loom-checkpoint$' \
+  && echo "ERROR: unstage the Loom runtime marker above (git rm --cached <file>)" \
+  || echo "OK: no Loom runtime markers staged"
+```
+
 ### What To Do When You Notice Unrelated Problems
 
 If you discover issues in files you're reading:

--- a/loom-daemon/src/init/post_init.rs
+++ b/loom-daemon/src/init/post_init.rs
@@ -414,6 +414,9 @@ mod tests {
         let expected = [
             ".loom-in-use",
             ".loom-checkpoint",
+            // #3838: the worktree sentinel worktree.sh drops into each issue
+            // worktree must be ignored, else a builder's `git add -A` commits it.
+            ".loom-managed",
             ".loom/.daemon.pid",
             ".loom/.daemon.log",
             ".loom/daemon.sock",


### PR DESCRIPTION
## Summary

Issue #3838 reported that a builder committed the `.loom-managed` worktree sentinel (once-around#87) because the daemon-generated `# >>> loom-managed >>>` gitignore block did not cover it.

Investigation found the root-cause fix already landed in #3826: `.loom-managed` is present in `EPHEMERAL_PATTERNS` (`loom-daemon/src/init/post_init.rs`), in this repo's own `.gitignore`, and in `check-main-clean.sh`'s internal exclusion list. The daemon refreshes the marker-delimited block in place on every `update_gitignore`, so **criteria 1 and 2 are already satisfied on main** — a consumer repo picks up `.loom-managed` on its next installer/daemon-init update.

What was still missing:

1. **No regression lock.** The `covers_all_source_repo_gitignore_patterns` test's `expected` list omitted `.loom-managed`, so removing it from `EPHEMERAL_PATTERNS` would still pass CI and silently re-open the bug. This PR adds `.loom-managed` to that expected list.
2. **Criterion 3 (optional).** Adds a Pre-Commit Scope Check line to `builder.md` telling builders to confirm no Loom runtime markers (`.loom-managed` / `.loom-in-use` / `.loom-checkpoint`) are staged before committing — a defense-in-depth backstop for installs whose `.gitignore` predates #3826.

## Changes

- `loom-daemon/src/init/post_init.rs` — add `.loom-managed` to the `covers_all_source_repo_gitignore_patterns` test's expected patterns.
- `defaults/.claude/commands/loom/builder.md` — Pre-Commit Scope Check now includes a "no Loom runtime markers staged" self-check (canonical source; the root `.claude/` mirror is gitignored in this self-install).

## Testing

- `cargo test --lib init::post_init` — 20 passed, 0 failed.
- `bash scripts/test-install-quick-gitignore-stash.sh` — 46 passed, 0 failed.

## Caveats

- The core fix (criteria 1 & 2) shipped in #3826; this PR hardens it against regression and adds the optional builder guidance. Existing consumer repos installed before #3826 (e.g. once-around) pick up `.loom-managed` on their next `loom-daemon init` / installer run, which rewrites the marker block.

Closes #3838