### PR TITLE
feat(scripts): resync-installed.sh to refresh .loom/ copies from defaults/ (#3777)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,6 +277,25 @@ Curator → Builder → Judge → Doctor (if needed) → Merge
 
 Manual invocation: `./.loom/scripts/check-host-sleep.sh` (or `--quiet` for stderr-only output).
 
+### Keeping installed `.loom/` copies fresh after a pull (#3770 detect → #3777 resync)
+
+The installed `.loom/hooks/` and `.loom/scripts/` copies the harness actually executes are synced from `defaults/` **at install time**. A `git pull` that merges a hook/script fix updates `defaults/` but **not** the installed copies — so a session can run stale hooks/scripts indefinitely (the incident: a merged `guard-destructive.sh` fix kept prompting until hand-copied).
+
+This is a **detect → fix** pair:
+
+- **Detect (#3770)** — `/loom:sweep` runs `./.loom/scripts/check-main-freshness.sh` at startup. When local `main` is behind `origin/main` it prints a non-blocking warning and flags any installed file that differs from its `defaults/` counterpart. Advisory only; it never pulls, merges, or resets.
+- **Fix (#3777)** — `./.loom/scripts/resync-installed.sh` refreshes the installed `.loom/hooks/*` and `.loom/scripts/*` from `defaults/`. Idempotent (a no-op when in sync), reports per-file `updated`/`created`/`unchanged`/`skipped`, and only ever touches files that exist in `defaults/` (repo-specific hooks with no `defaults/` counterpart are left alone).
+
+The intended flow is **"freshness warning says you're stale → run resync"**:
+
+```bash
+git merge --ff-only origin/main             # bring defaults/ current
+./.loom/scripts/resync-installed.sh --dry-run   # preview what would change
+./.loom/scripts/resync-installed.sh             # apply
+```
+
+`--dry-run` makes no changes and exits `2` when drift is detected (so it doubles as a check). To pin an intentional per-repo customization so resync never overwrites it, list its relative path (e.g. `hooks/guard-destructive.sh`) — one per line — in `.loom/resync-ignore`; matching files are reported `skipped`. A full `loom-daemon init` / installer run already performs the equivalent recursive copy, so a normal reinstall keeps the copies current too.
+
 ## Configuration
 
 ### Workspace Configuration

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -1621,6 +1621,25 @@ If you want to invoke the check manually:
 ./.loom/scripts/check-host-sleep.sh --quiet # stderr warning only, no stdout line
 ```
 
+**Keeping installed `.loom/` copies fresh after a pull (#3770 detect → #3777 resync)**:
+
+The installed `.loom/hooks/` and `.loom/scripts/` copies the harness actually executes are synced from `defaults/` **at install time**. A `git pull` that merges a hook/script fix updates `defaults/` but **not** the installed copies — so a session can run stale hooks/scripts indefinitely until they are re-synced.
+
+This is a **detect → fix** pair:
+
+- **Detect (#3770)** — `check-main-freshness.sh` (run at `/loom:sweep` startup) warns, non-blocking, when local `main` is behind `origin/main` and flags any installed file that differs from its `defaults/` counterpart. It never pulls, merges, or resets.
+- **Fix (#3777)** — `resync-installed.sh` refreshes the installed `.loom/hooks/*` and `.loom/scripts/*` from `defaults/`. Idempotent (no-op when in sync), reports per-file `updated`/`created`/`unchanged`/`skipped`, and only touches files that exist in `defaults/` (repo-specific hooks with no `defaults/` counterpart are left alone).
+
+The intended flow is **"freshness warning says you're stale → run resync"**:
+
+```bash
+git merge --ff-only origin/main                  # bring defaults/ current
+./.loom/scripts/resync-installed.sh --dry-run    # preview (exits 2 when drift found)
+./.loom/scripts/resync-installed.sh              # apply
+```
+
+Pin an intentional per-repo customization by listing its relative path (e.g. `hooks/guard-destructive.sh`), one per line, in `.loom/resync-ignore` — matching files are reported `skipped` and never overwritten. A full `loom-daemon init` / installer run performs the equivalent recursive copy, so a normal reinstall also keeps the copies current.
+
 **Merging PRs from worktrees**:
 
 Use `merge-pr.sh` instead of `gh pr merge` to avoid worktree checkout errors:

--- a/defaults/scripts/check-main-freshness.sh
+++ b/defaults/scripts/check-main-freshness.sh
@@ -153,7 +153,9 @@ warn "${YELLOW}orchestration scripts that silently lack recently-merged logic.${
 warn ""
 warn "${BOLD}Remediation (read-only advisory — this script never pulls for you):${NC}"
 warn "      ${BOLD}git merge --ff-only ${REMOTE_REF}${NC}"
-warn "  then re-sync the installed copies if your install flow does so."
+warn "  then refresh the installed .loom/ copies from defaults/ (#3777):"
+warn "      ${BOLD}./.loom/scripts/resync-installed.sh${NC}"
+warn "  (preview first with ${BOLD}--dry-run${NC}; it only touches files present in defaults/)."
 warn ""
 
 # ---------- stretch goal: best-effort installed-vs-defaults drift note ----------

--- a/defaults/scripts/resync-installed.sh
+++ b/defaults/scripts/resync-installed.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# resync-installed.sh - Refresh installed .loom/ runtime copies from defaults/ (#3777).
+#
+# The installed .loom/hooks/ and .loom/scripts/ trees are copied from the Loom
+# source repo's defaults/ tree at install time. After a `git pull` that merges a
+# fix to those files, the INSTALLED copies the harness actually executes are NOT
+# automatically updated — so a repo can run stale hooks/scripts indefinitely
+# (see #3777: the guard-precision trio #3755/#3756/#3757 merged to main, but the
+# installed guard-destructive.sh kept its pre-fix behavior until hand-copied).
+#
+# This is the REMEDIATION half of the drift problem. #3770
+# (check-main-freshness.sh) DETECTS the drift with a warning; this script FIXES
+# it. The intended flow is: "freshness warning says you're stale -> run resync."
+#
+# It is idempotent (a no-op when already in sync), reports per-file
+# updated/unchanged/skipped, only ever touches files that exist in defaults/
+# (repo-specific hooks with no defaults/ counterpart are left alone), and
+# supports --dry-run.
+#
+# Local-override convention: list a relative path (e.g. `hooks/guard-destructive.sh`
+# or `scripts/foo.sh`) — one per line — in `.loom/resync-ignore` to pin an
+# intentional per-repo customization. Matching files are reported as `skipped`
+# and never overwritten. Blank lines and `#` comments are ignored.
+#
+# Usage:
+#   ./.loom/scripts/resync-installed.sh            # sync; report what changed
+#   ./.loom/scripts/resync-installed.sh --dry-run  # preview only; make no changes
+#   ./.loom/scripts/resync-installed.sh --quiet    # only report updated/skipped
+#   ./.loom/scripts/resync-installed.sh --help     # show usage
+#
+# Exit codes:
+#   0 - Success. Sync applied (or already in sync); or --dry-run found no drift.
+#   1 - Error (not in a git repo, or the defaults/ source could not be located).
+#   2 - --dry-run only: drift detected (one or more files WOULD be updated).
+#       Lets callers (e.g. the #3770 warning) use --dry-run as a cheap check.
+#
+# See also: check-main-freshness.sh (#3770) — the advisory that suggests this.
+
+set -uo pipefail
+
+# ---------- output helpers ----------
+
+if [[ -t 1 ]]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    BLUE='\033[0;34m'
+    BOLD='\033[1m'
+    NC='\033[0m'
+else
+    RED=''
+    GREEN=''
+    YELLOW=''
+    BLUE=''
+    BOLD=''
+    NC=''
+fi
+
+DRY_RUN=0
+QUIET=0
+
+err()  { printf '%b\n' "${RED}ERROR: $*${NC}" >&2; }
+info() { printf '%b\n' "${BLUE}$*${NC}"; }
+note() { [[ "$QUIET" -eq 1 ]] || printf '%b\n' "$*"; }
+
+# ---------- args ----------
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run|-n) DRY_RUN=1 ;;
+        --quiet|-q)   QUIET=1 ;;
+        --help|-h)
+            sed -n '2,37p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            err "Unknown argument: $arg (try --help)"
+            exit 1
+            ;;
+    esac
+done
+
+# ---------- resolve the installed repo root (worktree-safe) ----------
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+    err "Not inside a git repository."
+    exit 1
+fi
+
+# git-common-dir points at the MAIN checkout's .git even from a linked worktree,
+# so installed .loom/ is always resolved against the primary worktree — never a
+# transient issue worktree.
+REPO_ROOT=""
+COMMON_DIR="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+if [[ -n "$COMMON_DIR" ]]; then
+    case "$COMMON_DIR" in
+        */.git) REPO_ROOT="${COMMON_DIR%/.git}" ;;
+    esac
+fi
+if [[ -z "$REPO_ROOT" ]]; then
+    REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+fi
+if [[ -z "$REPO_ROOT" || ! -d "$REPO_ROOT/.loom" ]]; then
+    err "Could not resolve the installed repo root (no .loom/ found)."
+    exit 1
+fi
+
+INSTALLED_HOOKS="$REPO_ROOT/.loom/hooks"
+INSTALLED_SCRIPTS="$REPO_ROOT/.loom/scripts"
+
+# ---------- resolve the defaults/ source tree ----------
+#
+# Mirrors lib/loom-tools.sh find_loom_tools() resolution order:
+#   1. Loom source repo (dogfood): $REPO_ROOT/defaults/
+#   2. Recorded loom-source-path (target repo install)
+#   3. install-metadata.json "loom_source"
+
+DEFAULTS_DIR=""
+resolve_defaults() {
+    if [[ -d "$REPO_ROOT/defaults/hooks" || -d "$REPO_ROOT/defaults/scripts" ]]; then
+        DEFAULTS_DIR="$REPO_ROOT/defaults"
+        return 0
+    fi
+    if [[ -f "$REPO_ROOT/.loom/loom-source-path" ]]; then
+        local src
+        src="$(cat "$REPO_ROOT/.loom/loom-source-path" 2>/dev/null || true)"
+        if [[ -n "$src" && -d "$src/defaults" ]]; then
+            DEFAULTS_DIR="$src/defaults"
+            return 0
+        fi
+    fi
+    if [[ -f "$REPO_ROOT/.loom/install-metadata.json" ]]; then
+        local src
+        src="$(sed -n 's/.*"loom_source" *: *"\(.*\)".*/\1/p' "$REPO_ROOT/.loom/install-metadata.json" 2>/dev/null | head -1)"
+        if [[ -n "$src" && -d "$src/defaults" ]]; then
+            DEFAULTS_DIR="$src/defaults"
+            return 0
+        fi
+    fi
+    return 1
+}
+
+if ! resolve_defaults; then
+    err "Could not locate a defaults/ source tree to sync from."
+    err "Looked in: \$REPO_ROOT/defaults, .loom/loom-source-path, .loom/install-metadata.json."
+    err "Re-run the Loom installer, or set .loom/loom-source-path to the Loom source repo."
+    exit 1
+fi
+
+# ---------- local-override ignore list ----------
+
+IGNORE_FILE="$REPO_ROOT/.loom/resync-ignore"
+is_ignored() {
+    # $1 = relative path like "hooks/foo.sh" or "scripts/bar.sh"
+    [[ -f "$IGNORE_FILE" ]] || return 1
+    local rel="$1" line
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        line="${line%%#*}"                       # strip trailing comment
+        line="${line#"${line%%[![:space:]]*}"}"  # ltrim
+        line="${line%"${line##*[![:space:]]}"}"   # rtrim
+        [[ -z "$line" ]] && continue
+        [[ "$line" == "$rel" ]] && return 0
+    done < "$IGNORE_FILE"
+    return 1
+}
+
+# ---------- counters ----------
+
+N_UPDATED=0
+N_UNCHANGED=0
+N_SKIPPED=0
+
+# ---------- per-file sync ----------
+#
+# sync_one <src_file> <dst_file> <rel_label>
+#   Copies src -> dst when they differ (unless --dry-run), preserving the
+#   installed file's executable bit expectation. Only files that exist in
+#   defaults/ ever reach this function, so repo-specific installed files with no
+#   defaults/ counterpart are never touched.
+sync_one() {
+    local src="$1" dst="$2" rel="$3"
+
+    if is_ignored "$rel"; then
+        note "  ${YELLOW}skipped${NC}   $rel ${YELLOW}(pinned in .loom/resync-ignore)${NC}"
+        N_SKIPPED=$((N_SKIPPED + 1))
+        return 0
+    fi
+
+    if [[ -f "$dst" ]] && cmp -s "$src" "$dst" 2>/dev/null; then
+        note "  ${GREEN}unchanged${NC} $rel"
+        N_UNCHANGED=$((N_UNCHANGED + 1))
+        return 0
+    fi
+
+    # src and dst differ (or dst is missing) — this is an update.
+    N_UPDATED=$((N_UPDATED + 1))
+    local verb_past="updated" verb_pres="update"
+    if [[ ! -f "$dst" ]]; then
+        verb_past="created"
+        verb_pres="create"
+    fi
+
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        printf '%b\n' "  ${BOLD}would ${verb_pres}${NC} $rel"
+        return 0
+    fi
+
+    mkdir -p "$(dirname "$dst")"
+    if cp "$src" "$dst" 2>/dev/null; then
+        # Match the executable bit of the source (defaults/ scripts/hooks are +x).
+        if [[ -x "$src" ]]; then
+            chmod +x "$dst" 2>/dev/null || true
+        fi
+        printf '%b\n' "  ${GREEN}${verb_past}${NC}   $rel"
+    else
+        err "failed to copy $rel"
+        return 1
+    fi
+}
+
+# ---------- walk hooks (top-level *.sh, matching the installer) ----------
+
+if [[ -d "$DEFAULTS_DIR/hooks" && -d "$INSTALLED_HOOKS" ]]; then
+    info "Resyncing .loom/hooks/ from ${DEFAULTS_DIR#"$REPO_ROOT/"}/hooks/ ..."
+    shopt -s nullglob
+    for src in "$DEFAULTS_DIR/hooks/"*.sh; do
+        name="$(basename "$src")"
+        sync_one "$src" "$INSTALLED_HOOKS/$name" "hooks/$name"
+    done
+    shopt -u nullglob
+fi
+
+# ---------- walk scripts (recursive, matching the installer's verify walk) ----------
+
+if [[ -d "$DEFAULTS_DIR/scripts" && -d "$INSTALLED_SCRIPTS" ]]; then
+    info "Resyncing .loom/scripts/ from ${DEFAULTS_DIR#"$REPO_ROOT/"}/scripts/ ..."
+    while IFS= read -r -d '' src; do
+        rel="${src#"$DEFAULTS_DIR/scripts/"}"
+        sync_one "$src" "$INSTALLED_SCRIPTS/$rel" "scripts/$rel"
+    done < <(find "$DEFAULTS_DIR/scripts" -type f -print0 | sort -z)
+fi
+
+# ---------- summary ----------
+
+echo ""
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    if [[ "$N_UPDATED" -gt 0 ]]; then
+        printf '%b\n' "${YELLOW}${BOLD}[resync] DRY RUN: ${N_UPDATED} file(s) would be updated, ${N_UNCHANGED} unchanged, ${N_SKIPPED} skipped.${NC}"
+        printf '%b\n' "${YELLOW}Run without --dry-run to apply.${NC}"
+        exit 2
+    fi
+    printf '%b\n' "${GREEN}[resync] DRY RUN: already in sync (${N_UNCHANGED} unchanged, ${N_SKIPPED} skipped).${NC}"
+    exit 0
+fi
+
+if [[ "$N_UPDATED" -gt 0 ]]; then
+    printf '%b\n' "${GREEN}${BOLD}[resync] ${N_UPDATED} file(s) updated, ${N_UNCHANGED} unchanged, ${N_SKIPPED} skipped.${NC}"
+else
+    printf '%b\n' "${GREEN}[resync] Already in sync (${N_UNCHANGED} unchanged, ${N_SKIPPED} skipped).${NC}"
+fi
+exit 0

--- a/defaults/scripts/tests/test-resync-installed.sh
+++ b/defaults/scripts/tests/test-resync-installed.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# test-resync-installed.sh - Smoke tests for resync-installed.sh (#3777)
+#
+# Constructs throwaway git repos with synthetic defaults/ and installed .loom/
+# trees so it can deterministically exercise the load-bearing cases:
+#   (a) already in sync     -> exit 0, "Already in sync", no writes
+#   (b) drift (differing)   -> file rewritten to match defaults/, exit 0
+#   (c) missing installed   -> file created from defaults/, exit 0
+#   (d) --dry-run + drift    -> exit 2, installed file UNCHANGED
+#   (e) --dry-run + in sync -> exit 0
+#   (f) repo-specific file   -> file present only in .loom/ left untouched
+#   (g) .loom/resync-ignore  -> pinned file reported "skipped", not overwritten
+#   (h) idempotent rerun     -> second run reports all unchanged
+# Plus contract checks:
+#   - --help prints usage, exit 0
+#   - unknown arg exits 1
+#   - not-a-git-repo exits 1
+#
+# Usage:
+#   ./.loom/scripts/tests/test-resync-installed.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPERS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$HELPERS_DIR/resync-installed.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: $1"
+}
+
+fail() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: $1"
+}
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/test-resync.XXXXXX")"
+# shellcheck disable=SC2329  # invoked indirectly via the EXIT trap below
+cleanup() { rm -rf "$WORKDIR" 2>/dev/null || true; }
+trap cleanup EXIT
+
+export GIT_AUTHOR_NAME="test" GIT_AUTHOR_EMAIL="test@example.com"
+export GIT_COMMITTER_NAME="test" GIT_COMMITTER_EMAIL="test@example.com"
+
+# --- fixture builder ---------------------------------------------------------
+# Creates a git repo at $WORKDIR/repo with:
+#   defaults/hooks/guard.sh          (source of truth, "A")
+#   defaults/scripts/foo.sh          (source of truth, "S")
+#   defaults/scripts/lib/bar.sh      (source of truth, "L")
+#   .loom/hooks/guard.sh             (installed, "OLD" -> drift)
+#   .loom/scripts/foo.sh             (installed, "S"   -> in sync)
+#   (.loom/scripts/lib/bar.sh MISSING -> to be created)
+#   .loom/scripts/custom-only.sh     (repo-specific, no defaults/ counterpart)
+make_fixture() {
+    local repo="$WORKDIR/repo"
+    rm -rf "$repo"
+    mkdir -p "$repo/defaults/hooks" "$repo/defaults/scripts/lib" \
+             "$repo/.loom/hooks" "$repo/.loom/scripts/lib"
+    git -C "$repo" init -q
+
+    printf 'A\n' > "$repo/defaults/hooks/guard.sh"
+    printf 'S\n' > "$repo/defaults/scripts/foo.sh"
+    printf 'L\n' > "$repo/defaults/scripts/lib/bar.sh"
+    chmod +x "$repo/defaults/hooks/guard.sh" "$repo/defaults/scripts/foo.sh" \
+             "$repo/defaults/scripts/lib/bar.sh"
+
+    printf 'OLD\n' > "$repo/.loom/hooks/guard.sh"
+    printf 'S\n'   > "$repo/.loom/scripts/foo.sh"
+    printf 'REPO-SPECIFIC\n' > "$repo/.loom/scripts/custom-only.sh"
+
+    echo "$repo"
+}
+
+# --- (a) in-sync / (b) drift / (c) missing: a single apply run --------------
+echo "Test group 1: apply resyncs drift + creates missing, leaves the rest"
+REPO="$(make_fixture)"
+OUT="$(cd "$REPO" && bash "$SCRIPT" 2>&1)"
+RC=$?
+if [[ $RC -eq 0 ]]; then pass "apply exits 0"; else fail "apply exits 0 (got $RC)"; fi
+if [[ "$(cat "$REPO/.loom/hooks/guard.sh")" == "A" ]]; then
+    pass "(b) drifted hooks/guard.sh rewritten to match defaults"
+else
+    fail "(b) drifted hooks/guard.sh not updated"
+fi
+if [[ -f "$REPO/.loom/scripts/lib/bar.sh" && "$(cat "$REPO/.loom/scripts/lib/bar.sh")" == "L" ]]; then
+    pass "(c) missing scripts/lib/bar.sh created from defaults"
+else
+    fail "(c) missing scripts/lib/bar.sh not created"
+fi
+if [[ "$(cat "$REPO/.loom/scripts/custom-only.sh")" == "REPO-SPECIFIC" ]]; then
+    pass "(f) repo-specific custom-only.sh left untouched"
+else
+    fail "(f) repo-specific custom-only.sh was modified/removed"
+fi
+if grep -q "updated" <<<"$OUT" && grep -q "created" <<<"$OUT"; then
+    pass "reports both 'updated' and 'created'"
+else
+    fail "did not report both updated and created"
+fi
+
+# --- (h) idempotent rerun ----------------------------------------------------
+echo "Test group 2: idempotent rerun is a no-op"
+OUT="$(cd "$REPO" && bash "$SCRIPT" 2>&1)"
+RC=$?
+if [[ $RC -eq 0 ]] && grep -q "Already in sync" <<<"$OUT"; then
+    pass "(h) second run reports already in sync, exit 0"
+else
+    fail "(h) second run not a clean no-op (rc=$RC)"
+fi
+
+# --- (d) dry-run + drift: exit 2, no writes ----------------------------------
+echo "Test group 3: --dry-run previews without writing"
+REPO="$(make_fixture)"
+OUT="$(cd "$REPO" && bash "$SCRIPT" --dry-run 2>&1)"
+RC=$?
+if [[ $RC -eq 2 ]]; then
+    pass "(d) --dry-run with drift exits 2"
+else
+    fail "(d) --dry-run with drift exits 2 (got $RC)"
+fi
+if [[ "$(cat "$REPO/.loom/hooks/guard.sh")" == "OLD" ]]; then
+    pass "(d) --dry-run left installed file UNCHANGED"
+else
+    fail "(d) --dry-run modified the installed file"
+fi
+if [[ ! -f "$REPO/.loom/scripts/lib/bar.sh" ]]; then
+    pass "(d) --dry-run did not create the missing file"
+else
+    fail "(d) --dry-run created a file it should only have previewed"
+fi
+
+# --- (e) dry-run + in sync: exit 0 -------------------------------------------
+echo "Test group 4: --dry-run when already in sync exits 0"
+REPO="$(make_fixture)"
+(cd "$REPO" && bash "$SCRIPT" >/dev/null 2>&1)   # apply first
+OUT="$(cd "$REPO" && bash "$SCRIPT" --dry-run 2>&1)"
+RC=$?
+if [[ $RC -eq 0 ]] && grep -q "already in sync" <<<"$OUT"; then
+    pass "(e) --dry-run in sync exits 0"
+else
+    fail "(e) --dry-run in sync exits 0 (rc=$RC)"
+fi
+
+# --- (g) resync-ignore pins a local override ---------------------------------
+echo "Test group 5: .loom/resync-ignore preserves a pinned local override"
+REPO="$(make_fixture)"
+printf 'PINNED-LOCAL\n' > "$REPO/.loom/hooks/guard.sh"
+printf 'hooks/guard.sh  # keep my local tweak\n' > "$REPO/.loom/resync-ignore"
+OUT="$(cd "$REPO" && bash "$SCRIPT" 2>&1)"
+RC=$?
+if [[ $RC -eq 0 ]] && grep -q "skipped" <<<"$OUT"; then
+    pass "(g) pinned file reported as skipped"
+else
+    fail "(g) pinned file not reported skipped (rc=$RC)"
+fi
+if [[ "$(cat "$REPO/.loom/hooks/guard.sh")" == "PINNED-LOCAL" ]]; then
+    pass "(g) pinned file NOT overwritten"
+else
+    fail "(g) pinned file was overwritten despite resync-ignore"
+fi
+
+# --- contract checks ---------------------------------------------------------
+echo "Test group 6: flag/contract checks"
+if bash "$SCRIPT" --help 2>&1 | grep -q "resync-installed.sh"; then
+    pass "--help prints usage"
+else
+    fail "--help did not print usage"
+fi
+if bash "$SCRIPT" --help >/dev/null 2>&1; then pass "--help exits 0"; else fail "--help did not exit 0"; fi
+
+REPO="$(make_fixture)"
+RC=0; (cd "$REPO" && bash "$SCRIPT" --bogus >/dev/null 2>&1) || RC=$?
+if [[ $RC -eq 1 ]]; then pass "unknown arg exits 1"; else fail "unknown arg did not exit 1 (got $RC)"; fi
+
+NON_REPO="$WORKDIR/not-a-repo"
+mkdir -p "$NON_REPO"
+RC=0; (cd "$NON_REPO" && bash "$SCRIPT" >/dev/null 2>&1) || RC=$?
+if [[ $RC -eq 1 ]]; then pass "outside a git repo exits 1"; else fail "outside a git repo did not exit 1 (got $RC)"; fi
+
+# --- summary -----------------------------------------------------------------
+echo ""
+echo "========================================"
+echo "Results: $TESTS_PASSED/$TESTS_RUN passed"
+echo "========================================"
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    echo -e "${RED}$TESTS_FAILED test(s) failed${NC}"
+    exit 1
+fi
+echo -e "${GREEN}All tests passed${NC}"
+exit 0


### PR DESCRIPTION
## Summary

Closes #3777.

The installed `.loom/hooks/` and `.loom/scripts/` copies the harness actually executes are synced from `defaults/` **only at install time**. After a `git pull` that merges a hook/script fix, the installed copies are **not** updated — so a repo can run stale hooks/scripts indefinitely (the guard-precision incident: `guard-destructive.sh` kept prompting until hand-copied). #3770 added drift **detection** (a non-blocking freshness warning); this PR adds the **remediation** half.

## What's in it

- **`defaults/scripts/resync-installed.sh`** — sanctioned resync command. Idempotent refresh of installed `.loom/hooks/*` and `.loom/scripts/*` from `defaults/`:
  - Reports per-file `updated` / `created` / `unchanged` / `skipped`.
  - Only ever touches files that exist in `defaults/` — repo-specific hooks with no `defaults/` counterpart are left alone (consistent with #3770's "files present in both trees" rule).
  - `--dry-run` makes no changes and exits `2` when drift is found, so it doubles as a check; `--quiet`, `--help` supported.
  - Resolves the `defaults/` source via repo root (dogfood) → `.loom/loom-source-path` → `install-metadata.json`, mirroring `lib/loom-tools.sh`. Worktree-safe via `git-common-dir`.
  - **Local-override convention**: list a relative path (e.g. `hooks/guard-destructive.sh`), one per line, in `.loom/resync-ignore` to pin an intentional per-repo customization; matching files are reported `skipped` and never overwritten.
- **`check-main-freshness.sh`** — the #3770 warning now names `resync-installed.sh` as the concrete remediation (with a `--dry-run` nudge).
- **`CLAUDE.md` + `defaults/CLAUDE.md`** — document the "freshness warning says you're stale → run resync" flow alongside the #3770 advisory.
- **`test-resync-installed.sh`** — 16 smoke tests following the `test-check-main-freshness.sh` convention.

## Notes

- A full `loom-daemon init` / installer run already performs the equivalent recursive copy of `defaults/scripts/` → `.loom/scripts/`, so a normal reinstall keeps copies current; this script covers the post-pull-without-reinstall gap, and the #3770 warning suggests it automatically.
- No new GitHub labels; `.loom/scripts`/`.loom/hooks` are untracked runtime copies, so the committed change is entirely under `defaults/`.

## Test results

- `bash defaults/scripts/tests/test-resync-installed.sh` → 16/16 passed
- `bash defaults/scripts/tests/test-check-main-freshness.sh` → 15/15 passed (unaffected by the remediation-text edit)
- `shellcheck` clean on all three shell files

🤖 Generated with [Claude Code](https://claude.com/claude-code)