### PR TITLE
fix(champion): repair vacuous CI gate, broken issue-create, gawk-only awk, stale-PR spam, doc duplication

### DIFF
--- a/defaults/.claude/commands/loom/champion-epic.md
+++ b/defaults/.claude/commands/loom/champion-epic.md
@@ -68,8 +68,13 @@ If all 6 criteria pass:
 1. **Create Phase 1 issues** with `loom:architect` label:
 
 ```bash
-# For each issue in Phase 1
+# For each issue in Phase 1.
+# NOTE: emit the machine-checkable phase marker `<!-- loom:epic:<epic-number>:phase:1 -->`
+# in the body. Phase-completion detection searches for this exact token (see
+# "Detecting Phase Completion"), NOT the natural-language "**Epic**: / **Phase**:"
+# prose — which drifts and is unreliable for GitHub `--search in:body`.
 gh issue create --title "[Epic #<epic>] <Issue Title>" --body "$(cat <<'EOF'
+<!-- loom:epic:<epic-number>:phase:1 -->
 **Epic**: #<epic-number> - <Epic Title>
 **Phase**: 1 of N
 **Phase Goal**: <phase 1 goal from epic>
@@ -146,11 +151,16 @@ When all issues in a phase are closed, Champion creates the next phase's issues.
 EPIC_NUMBER=123
 PHASE=1
 
-# Get all issues with loom:epic-phase that reference this epic and phase
+# Get all issues with loom:epic-phase that reference this epic and phase.
+# Search for the machine-generated marker emitted into each phase-issue body
+# (see Step 3): `<!-- loom:epic:<epic>:phase:<n> -->`. This is an exact,
+# drift-free token — unlike the old natural-language "Epic: #N Phase: N"
+# phrase, which never matched the "**Epic**: #N" / "**Phase**: 1 of N" prose
+# the body template actually emits.
 PHASE_ISSUES=$(gh issue list \
   --label="loom:epic-phase" \
   --state=all \
-  --search="Epic: #$EPIC_NUMBER Phase: $PHASE in:body" \
+  --search="loom:epic:$EPIC_NUMBER:phase:$PHASE in:body" \
   --json number,state \
   --jq '.')
 
@@ -166,7 +176,7 @@ fi
 ### Creating Next Phase Issues
 
 When Phase N completes, create Phase N+1 issues following the same pattern as Step 3 above, but with:
-- Updated phase number
+- Updated phase number — **including the marker**: emit `<!-- loom:epic:<epic-number>:phase:<N+1> -->` in each new body so phase-completion detection can find them
 - Dependencies referencing Phase N completion
 - Updated epic comment showing progress
 

--- a/defaults/.claude/commands/loom/champion-pr-merge.md
+++ b/defaults/.claude/commands/loom/champion-pr-merge.md
@@ -195,24 +195,32 @@ echo "PASS: Recently updated ($HOURS_AGO hours ago)"
 
 **Rationale**: Ensures PR reflects recent state of main branch and hasn't gone stale. In force mode, allows older PRs to merge since aggressive development may queue up PRs faster than they can be merged.
 
+**On failure**: a stale PR is handled by the dedicated stale-PR policy (see "PR Rejection Workflow → Stale PR"), not the transient-failure path — it is commented once (idempotently) and routed out of the queue via `loom:pr` → `loom:changes-requested` so it reaches Doctor rather than being re-commented every cron tick.
+
 ### 6. CI Status Check
 - [ ] If CI checks exist, all checks must be passing
 - [ ] If no CI checks exist, this criterion passes automatically
 
 **Verification command**:
 ```bash
-# Get all CI checks
-CHECKS=$(gh pr checks <number> --json name,conclusion,status 2>&1)
+# Get all CI checks. `gh pr checks --json` exposes `bucket` (the rolled-up
+# pass/fail/pending/skipping/cancel state) and `name` — there is NO `conclusion`
+# or `status` field (those were invalid and made this gate silently vacuous).
+# Capture stdout ONLY: when a PR has no checks, gh prints "no checks reported..."
+# to STDERR and exits non-zero with EMPTY stdout, so an empty result is the
+# robust no-checks signal (do not grep error text).
+CHECKS=$(gh pr checks <number> --json bucket,name 2>/dev/null)
 
-# Handle case where no checks exist
-if echo "$CHECKS" | grep -q "no checks reported"; then
+# Handle case where no checks exist (empty stdout, or an empty JSON array)
+if [ -z "$CHECKS" ] || [ "$(echo "$CHECKS" | jq 'length')" = "0" ]; then
   echo "PASS: No CI checks required"
   exit 0
 fi
 
-# Parse checks
-FAILING_CHECKS=$(echo "$CHECKS" | jq -r '.[] | select(.conclusion != "SUCCESS" and .conclusion != null) | .name')
-PENDING_CHECKS=$(echo "$CHECKS" | jq -r '.[] | select(.status == "IN_PROGRESS" or .status == "QUEUED") | .name')
+# Parse checks by bucket. Buckets: pass, fail, pending, skipping, cancel.
+# `fail`/`cancel` block the merge; `pending` defers; `pass`/`skipping` are OK.
+FAILING_CHECKS=$(echo "$CHECKS" | jq -r '.[] | select(.bucket == "fail" or .bucket == "cancel") | .name')
+PENDING_CHECKS=$(echo "$CHECKS" | jq -r '.[] | select(.bucket == "pending") | .name')
 
 # Check for failing checks
 if [ -n "$FAILING_CHECKS" ]; then
@@ -232,10 +240,10 @@ echo "PASS: All CI checks passing"
 ```
 
 **Edge cases handled**:
-- **No CI checks**: Passes (allows merge)
-- **Pending checks**: Skips (waits for completion)
-- **Failed checks**: Fails (blocks merge)
-- **Mixed state**: Fails if any check is not SUCCESS
+- **No CI checks**: Passes (allows merge) — detected via empty stdout, not error text
+- **Pending checks**: Skips (waits for completion) — `bucket == "pending"`
+- **Failed checks**: Fails (blocks merge) — `bucket == "fail"` or `"cancel"`
+- **Skipped checks**: Passes — `bucket == "skipping"` is not a failure
 
 **Rationale**: Only merge when all automated checks pass or no checks are configured
 
@@ -285,9 +293,9 @@ UPDATED_TS=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$UPDATED_AT" +%s 2>/dev/null || \
 NOW_TS=$(date +%s)
 HOURS_AGO=$(( (NOW_TS - UPDATED_TS) / 3600 ))
 
-# Check CI status
-CHECKS=$(gh pr checks "$PR_NUMBER" --json name,conclusion,status 2>&1)
-if echo "$CHECKS" | grep -q "no checks reported"; then
+# Check CI status (empty stdout = no checks; see criterion #6 above)
+CHECKS=$(gh pr checks "$PR_NUMBER" --json bucket,name 2>/dev/null)
+if [ -z "$CHECKS" ] || [ "$(echo "$CHECKS" | jq 'length')" = "0" ]; then
   CI_STATUS="No CI checks required"
 else
   CI_STATUS="All CI checks passing"
@@ -456,13 +464,20 @@ TODOS_RAW=$(gh pr diff "$PR_NUMBER" 2>/dev/null | awk '
   }
   /^@@/ {
     # Parse hunk header for line number: @@ -old,count +new,count @@
-    match($0, /\+([0-9]+)/, arr)
-    line_num = arr[1]
+    # POSIX awk: 2-arg match() sets RSTART/RLENGTH (the gawk-only 3-arg
+    # match($0, re, arr) form errors on BSD awk / macOS). Capture the "+<n>"
+    # token, then strip the leading "+" with substr().
+    if (match($0, /\+[0-9]+/)) {
+      line_num = substr($0, RSTART + 1, RLENGTH - 1)
+    }
     in_hunk = 1
   }
   in_hunk && /^\+[^+]/ {
     # Added line (not the +++ header)
-    if (/\b(TODO|FIXME|HACK|XXX|FUTURE):/) {
+    # POSIX-portable word boundary: BSD awk (macOS) does NOT support the gawk-only
+    # \b escape, so `/\b(TODO...):/` silently matches nothing there. Anchor on
+    # start-of-string-or-non-word-char instead so this fires on BSD awk too.
+    if ($0 ~ /(^|[^A-Za-z0-9_])(TODO|FIXME|HACK|XXX|FUTURE):/) {
       # Extract the comment text after the pattern
       line = $0
       sub(/^\+/, "", line)
@@ -648,13 +663,17 @@ else
   FORCE_MARKER=""
 fi
 
-# Create the issue
+# Create the issue.
+# NOTE: `gh issue create` does NOT support --json/--jq (only `gh issue view`
+# and `gh issue list` do). On success it prints the new issue's URL to stdout
+# (e.g. https://github.com/<owner>/<repo>/issues/<N>); parse the trailing
+# number from that URL.
 ISSUE_TITLE="${FORCE_MARKER}Follow-on: Work identified in PR #$PR_NUMBER"
-NEW_ISSUE=$(gh issue create \
+NEW_ISSUE_URL=$(gh issue create \
   --title "$ISSUE_TITLE" \
   --body "$ISSUE_BODY" \
-  --label "$ISSUE_LABEL" \
-  --json number --jq '.number')
+  --label "$ISSUE_LABEL")
+NEW_ISSUE=$(echo "$NEW_ISSUE_URL" | grep -oE '[0-9]+$')
 
 if [ -n "$NEW_ISSUE" ]; then
   echo "Created follow-on issue #$NEW_ISSUE with label $ISSUE_LABEL"
@@ -694,7 +713,11 @@ fi
 
 ## PR Rejection Workflow
 
-If ANY safety criterion fails, do NOT merge. Instead, add a comment explaining why:
+If ANY safety criterion fails, do NOT merge. How the failure is handled depends on whether it is **transient** (clears on its own or on the next push — pending CI, conflicts being resolved, `UNKNOWN` mergeability) or **terminal** (the PR has gone stale and cannot clear without a rebase).
+
+### Transient failures — keep `loom:pr`, retry next tick
+
+Add a comment explaining why, and **keep the `loom:pr` label** so the PR is re-evaluated on the next Champion tick once the blocking condition clears:
 
 ```bash
 gh pr comment <number> --body "**Champion: Cannot Auto-Merge**
@@ -707,13 +730,43 @@ This PR cannot be automatically merged due to the following:
 - <SPECIFIC_ACTION_1>
 - <SPECIFIC_ACTION_2>
 
-Keeping \`loom:pr\` label. A human will need to manually merge this PR or address the blocking criteria.
+Keeping \`loom:pr\` label. Champion will retry on the next tick once the blocking condition clears.
 
 ---
 *Automated by Champion role*"
 ```
 
-**Do NOT remove the `loom:pr` label** - let the human decide whether to merge or close.
+**Do NOT remove the `loom:pr` label for transient failures** — the next tick retries automatically.
+
+### Stale PR (recency check failed) — comment once, route to Doctor
+
+A stale PR (>24h normal / >72h force mode) will never clear on its own, and under the 10-minute cron a bare "keep the label + comment" loop would re-comment on the same PR **every tick forever**. Instead, **comment once (idempotently)** and **swap `loom:pr` → `loom:changes-requested`** so the PR leaves the auto-merge queue and is picked up by Doctor for a rebase/refresh. This is the single, authoritative stale-PR policy — `champion-reference.md` Edge Case 5 defers to it.
+
+```bash
+PR_NUMBER=<number>
+STALE_MARKER="<!-- champion:stale-pr-notice -->"
+
+# Idempotency guard: only comment + relabel once. If a prior tick already
+# posted the stale notice, do nothing (prevents per-tick comment spam).
+if gh pr view "$PR_NUMBER" --json comments --jq '.comments[].body' | grep -qF "$STALE_MARKER"; then
+  echo "Stale-PR notice already posted for #$PR_NUMBER — skipping"
+else
+  gh pr comment "$PR_NUMBER" --body "$STALE_MARKER
+**Champion: PR Is Stale**
+
+This PR has not been updated within the recency window (24h normal / 72h force mode), so it has been routed out of the auto-merge queue for a rebase/refresh.
+
+**Next steps:**
+- Rebase onto the latest \`main\` and resolve any drift
+- Re-request Judge review to return it to the auto-merge queue
+
+---
+*Automated by Champion role*"
+  # Route to Doctor: leave the auto-merge queue.
+  gh pr edit "$PR_NUMBER" --remove-label "loom:pr" --add-label "loom:changes-requested"
+  echo "Routed stale PR #$PR_NUMBER to Doctor (loom:pr → loom:changes-requested)"
+fi
+```
 
 ---
 

--- a/defaults/.claude/commands/loom/champion-reference.md
+++ b/defaults/.claude/commands/loom/champion-reference.md
@@ -14,8 +14,11 @@ This section documents how Champion handles non-standard situations during PR au
 
 **Handling**:
 ```bash
-# gh pr checks returns "no checks reported"
-if echo "$CHECKS" | grep -q "no checks reported"; then
+# With no checks, `gh pr checks --json bucket,name` prints "no checks reported..."
+# to STDERR, exits non-zero, and emits EMPTY stdout. Detect via empty stdout
+# (robust) rather than matching error text. CHECKS captured with 2>/dev/null.
+CHECKS=$(gh pr checks "$PR_NUMBER" --json bucket,name 2>/dev/null)
+if [ -z "$CHECKS" ] || [ "$(echo "$CHECKS" | jq 'length')" = "0" ]; then
   echo "PASS: No CI checks required"
   # Continue to merge
 fi
@@ -33,8 +36,8 @@ fi
 
 **Handling**:
 ```bash
-# Check for pending/running checks
-PENDING=$(echo "$CHECKS" | jq -r '.[] | select(.status == "IN_PROGRESS" or .status == "QUEUED") | .name')
+# Check for pending/running checks (bucket == "pending")
+PENDING=$(echo "$CHECKS" | jq -r '.[] | select(.bucket == "pending") | .name')
 if [ -n "$PENDING" ]; then
   echo "SKIP: CI checks still running - will retry next iteration"
   # Skip this PR, try again later
@@ -97,11 +100,11 @@ if [ "$HOURS_AGO" -gt 24 ]; then
 fi
 ```
 
-**Decision**: **Skip and comment** - do not merge stale PRs.
+**Decision**: **Comment once, then route out of the queue** - do not merge stale PRs, and do not re-comment every cron tick.
 
 **Rationale**: Main branch may have evolved significantly. Stale PRs should be rebased or re-reviewed.
 
-**Recommended action**: Remove `loom:pr` label on stale PRs, request rebase from Builder.
+**Action** (single authoritative policy — implemented in `champion-pr-merge.md` → "PR Rejection Workflow → Stale PR"): post the stale notice **once**, guarded by an idempotency marker (`<!-- champion:stale-pr-notice -->`) so the 10-minute cron does not spam the PR, and **swap `loom:pr` → `loom:changes-requested`** to route the PR to Doctor for a rebase/refresh. This removes `loom:pr` (unlike the transient-failure path, which keeps it), because a stale PR cannot clear itself and must leave the auto-merge queue. See `champion-pr-merge.md` for the exact commands.
 
 ---
 
@@ -164,16 +167,17 @@ done
 
 **Handling**:
 ```bash
-# Any non-SUCCESS conclusion fails the check
-FAILING=$(echo "$CHECKS" | jq -r '.[] | select(.conclusion != "SUCCESS" and .conclusion != null) | .name')
+# A "fail" or "cancel" bucket blocks the merge; "pending" defers; "pass" and
+# "skipping" are acceptable. (gh buckets: pass, fail, pending, skipping, cancel.)
+FAILING=$(echo "$CHECKS" | jq -r '.[] | select(.bucket == "fail" or .bucket == "cancel") | .name')
 if [ -n "$FAILING" ]; then
   echo "FAIL: Some checks did not pass"
 fi
 ```
 
-**Decision**: **Fail if any check is not SUCCESS** - conservative approach.
+**Decision**: **Fail on any `fail`/`cancel` bucket; defer on `pending`** - conservative but not falsely blocking.
 
-**Rationale**: "Skipped" or "Neutral" conclusions indicate incomplete validation.
+**Rationale**: A `skipping` bucket (a conditionally-skipped job) is not a failure and does not block auto-merge; only `fail`/`cancel` block and `pending` defers.
 
 ---
 
@@ -297,11 +301,11 @@ gh issue create --title "Follow-on: Work identified in PR #$PR_NUMBER" --label "
 | Pending CI checks | Skip | Defer to next iteration |
 | Force-push after approval | Allow | If criteria still pass |
 | Merge conflicts | Fail | Comment and skip |
-| Stale PR (>24h) | Fail | Comment and skip |
+| Stale PR (>24h) | Route to Doctor | Comment once (idempotent marker), swap `loom:pr` → `loom:changes-requested` |
 | Test-only changes | Allow | Standard criteria apply |
 | Manual-merge override | Skip | Respect human decision |
 | Multiple linked issues | Allow | Verify all closed |
-| Mixed-state CI | Fail | Require all SUCCESS |
+| Mixed-state CI | Fail on `fail`/`cancel` | `pending` defers; `skipping` is OK |
 | Unknown critical file | Miss | Needs pattern update |
 | Exactly at size limit | Allow | Limit is inclusive |
 | API rate limit | Error | Comment and continue |
@@ -312,290 +316,11 @@ gh issue create --title "Follow-on: Work identified in PR #$PR_NUMBER" --label "
 
 ## Complete Auto-Merge Workflow Script
 
-This section provides the full end-to-end implementation integrating all steps.
+**The auto-merge workflow lives in a single source of truth: [`champion-pr-merge.md`](champion-pr-merge.md).**
 
-```bash
-#!/bin/bash
-# Complete Champion PR auto-merge workflow
-# Usage: champion_automerge <pr-number>
+This file previously carried a second, full copy of the end-to-end merge script. That duplicate diverged from `champion-pr-merge.md` over time (it lacked Step 5.5 Follow-on Issue Creation and repeated the same bugs — invalid `gh pr checks --json` fields, etc.), forcing every fix to be applied twice. It has been removed to eliminate the drift (issue #3781).
 
-PR_NUMBER=$1
-
-if [ -z "$PR_NUMBER" ]; then
-  echo "Usage: $0 <pr-number>"
-  exit 1
-fi
-
-echo "========================================="
-echo "Champion Auto-Merge Workflow: PR #$PR_NUMBER"
-echo "========================================="
-echo ""
-
-# ============================================
-# STEP 1: Verify Safety Criteria
-# ============================================
-
-echo "STEP 1/5: Verifying safety criteria..."
-echo ""
-
-# Criterion 1: Label Check
-LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' | tr '\n' ' ')
-if ! echo "$LABELS" | grep -q "loom:pr"; then
-  echo "FAIL: Missing loom:pr label"
-  exit 1
-fi
-if echo "$LABELS" | grep -q "loom:manual-merge"; then
-  echo "SKIP: Has loom:manual-merge label (human override)"
-  exit 1
-fi
-echo "PASS: Label check"
-
-# Criterion 2: Size Check
-FORCE_MODE=$(cat .loom/daemon-state.json 2>/dev/null | jq -r '.force_mode // false')
-PR_DATA=$(gh pr view "$PR_NUMBER" --json additions,deletions)
-ADDITIONS=$(echo "$PR_DATA" | jq -r '.additions')
-DELETIONS=$(echo "$PR_DATA" | jq -r '.deletions')
-TOTAL=$((ADDITIONS + DELETIONS))
-if [ "$FORCE_MODE" != "true" ]; then
-  HAS_AUTO_MERGE_OK=$(gh pr view "$PR_NUMBER" --json labels --jq '[.labels[].name] | any(. == "loom:auto-merge-ok")')
-  if [ "$HAS_AUTO_MERGE_OK" != "true" ]; then
-    SIZE_LIMIT=$(jq -r '.champion.auto_merge_max_lines // 200' .loom/config.json 2>/dev/null || echo 200)
-    if [ "$TOTAL" -gt "$SIZE_LIMIT" ]; then
-      echo "FAIL: Too large ($TOTAL lines, limit is $SIZE_LIMIT)"
-      exit 1
-    fi
-  fi
-fi
-echo "PASS: Size check ($TOTAL lines)"
-
-# Criterion 3: Critical File Exclusion
-if [ "$FORCE_MODE" != "true" ]; then
-  FILES=$(gh pr view "$PR_NUMBER" --json files --jq -r '.files[].path')
-  CRITICAL_PATTERNS=(
-    "Cargo.toml"
-    "loom-daemon/Cargo.toml"
-    "loom-api/Cargo.toml"
-    "package.json"
-    ".github/workflows/"
-    ".sql"
-    "migration"
-  )
-  for file in $FILES; do
-    for pattern in "${CRITICAL_PATTERNS[@]}"; do
-      if [[ "$file" == *"$pattern"* ]]; then
-        echo "FAIL: Critical file modified: $file"
-        exit 1
-      fi
-    done
-  done
-fi
-echo "PASS: No critical files modified"
-
-# Criterion 4: Merge Conflict Check
-MERGEABLE=$(gh pr view "$PR_NUMBER" --json mergeable --jq -r '.mergeable')
-if [ "$MERGEABLE" != "MERGEABLE" ]; then
-  echo "FAIL: Not mergeable (state: $MERGEABLE)"
-  exit 1
-fi
-echo "PASS: No merge conflicts"
-
-# Criterion 5: Recency Check
-UPDATED_AT=$(gh pr view "$PR_NUMBER" --json updatedAt --jq -r '.updatedAt')
-UPDATED_TS=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$UPDATED_AT" +%s 2>/dev/null || \
-             date -d "$UPDATED_AT" +%s 2>/dev/null)
-NOW_TS=$(date +%s)
-HOURS_AGO=$(( (NOW_TS - UPDATED_TS) / 3600 ))
-if [ "$FORCE_MODE" = "true" ]; then
-  RECENCY_LIMIT=72
-else
-  RECENCY_LIMIT=24
-fi
-if [ "$HOURS_AGO" -gt "$RECENCY_LIMIT" ]; then
-  echo "FAIL: Stale PR (updated $HOURS_AGO hours ago)"
-  exit 1
-fi
-echo "PASS: Recently updated ($HOURS_AGO hours ago)"
-
-# Criterion 6: CI Status Check
-CHECKS=$(gh pr checks "$PR_NUMBER" --json name,conclusion,status 2>&1)
-if ! echo "$CHECKS" | grep -q "no checks reported"; then
-  FAILING=$(echo "$CHECKS" | jq -r '.[] | select(.conclusion != "SUCCESS" and .conclusion != null) | .name')
-  PENDING=$(echo "$CHECKS" | jq -r '.[] | select(.status == "IN_PROGRESS" or .status == "QUEUED") | .name')
-  if [ -n "$FAILING" ]; then
-    echo "FAIL: CI checks failing:"
-    echo "$FAILING"
-    exit 1
-  fi
-  if [ -n "$PENDING" ]; then
-    echo "SKIP: CI checks still running:"
-    echo "$PENDING"
-    exit 1
-  fi
-fi
-echo "PASS: All CI checks passing"
-
-echo ""
-echo "All safety criteria passed"
-echo ""
-
-# ============================================
-# STEP 2: Post Pre-Merge Comment
-# ============================================
-
-echo "STEP 2/5: Posting pre-merge comment..."
-echo ""
-
-# Determine CI status text
-if echo "$CHECKS" | grep -q "no checks reported"; then
-  CI_STATUS="No CI checks required"
-else
-  CI_STATUS="All CI checks passing"
-fi
-
-# Post comment
-gh pr comment "$PR_NUMBER" --body "$(cat <<EOF
-**Champion Auto-Merge**
-
-This PR meets all safety criteria for automatic merging:
-
-- Judge approved (\`loom:pr\` label)
-- Size check passed ($TOTAL lines: +$ADDITIONS/-$DELETIONS)
-- No critical files modified
-- No merge conflicts
-- Updated recently ($HOURS_AGO hours ago)
-- $CI_STATUS
-- No manual-merge override
-
-**Proceeding with squash merge...** If this was merged in error, you can revert with:
-\`git revert <commit-sha>\`
-
----
-*Automated by Champion role*
-EOF
-)"
-
-echo "Posted pre-merge comment"
-echo ""
-
-# ============================================
-# STEP 3: Execute Merge
-# ============================================
-
-echo "STEP 3/5: Executing squash merge..."
-echo ""
-
-# Ensure we're on main so .loom/scripts exists (issue #2289)
-git checkout main 2>/dev/null || true
-
-# Use merge-pr.sh for worktree-safe merge via GitHub API
-./.loom/scripts/merge-pr.sh "$PR_NUMBER" --auto || {
-  echo "Merge failed!"
-  exit 1
-}
-echo "Successfully merged PR #$PR_NUMBER"
-echo ""
-
-# ============================================
-# STEP 4: Verify Issue Closure
-# ============================================
-
-echo "STEP 4/5: Verifying linked issue closure..."
-echo ""
-
-# Use GitHub's own parser via closingIssuesReferences (see issue #3267).
-# Correctly excludes `Updates #N` and substring traps like `Discloses #N`.
-source "$(git rev-parse --show-toplevel)/.loom/scripts/lib/forge-helpers.sh"
-forge_detect
-LINKED_ISSUES=$(forge_pr_close_targets "$PR_NUMBER")
-
-if [ -z "$LINKED_ISSUES" ]; then
-  echo "No linked issues found - skipping closure verification"
-else
-  echo "Found linked issues: $LINKED_ISSUES"
-  for issue in $LINKED_ISSUES; do
-    echo "Checking issue #$issue..."
-    ISSUE_STATE=$(gh issue view "$issue" --json state --jq -r '.state' 2>&1)
-    if [ "$ISSUE_STATE" = "CLOSED" ]; then
-      echo "Issue #$issue is closed"
-    else
-      echo "Issue #$issue still open - closing manually..."
-      gh issue close "$issue" --comment "Closed by PR #$PR_NUMBER (auto-merged by Champion)"
-      echo "Manually closed issue #$issue"
-    fi
-  done
-fi
-
-echo ""
-
-# ============================================
-# STEP 5: Unblock Dependent Issues
-# ============================================
-
-echo "STEP 5/5: Checking for dependent issues to unblock..."
-echo ""
-
-for closed_issue in $LINKED_ISSUES; do
-  echo "Checking for issues blocked by #$closed_issue..."
-  BLOCKED_ISSUES=$(gh issue list --label "loom:blocked" --state open --json number,body --jq ".[] | select(.body | test(\"(Blocked by|Depends on|Requires) #$closed_issue\"; \"i\")) | .number")
-
-  if [ -z "$BLOCKED_ISSUES" ]; then
-    echo "  No issues found blocked by #$closed_issue"
-    continue
-  fi
-
-  for blocked in $BLOCKED_ISSUES; do
-    echo "  Checking if #$blocked can be unblocked..."
-    BLOCKED_BODY=$(gh issue view "$blocked" --json body --jq -r '.body')
-    ALL_DEPS=$(echo "$BLOCKED_BODY" | grep -Eo "(Blocked by|Depends on|Requires) #[0-9]+" | grep -Eo "[0-9]+" | sort -u)
-
-    ALL_RESOLVED=true
-    for dep in $ALL_DEPS; do
-      DEP_STATE=$(gh issue view "$dep" --json state --jq -r '.state' 2>/dev/null)
-      if [ "$DEP_STATE" != "CLOSED" ]; then
-        echo "    Still blocked: dependency #$dep is still open"
-        ALL_RESOLVED=false
-        break
-      fi
-    done
-
-    if [ "$ALL_RESOLVED" = true ]; then
-      echo "    All dependencies resolved - unblocking #$blocked"
-      gh issue edit "$blocked" --remove-label "loom:blocked" --add-label "loom:issue"
-      gh issue comment "$blocked" --body "**Unblocked** by merge of PR #$PR_NUMBER (resolved #$closed_issue)
-
-All dependencies are now resolved. This issue is ready for implementation.
-
----
-*Automated by Champion role*"
-      echo "    Unblocked issue #$blocked"
-    fi
-  done
-done
-
-echo ""
-echo "========================================="
-echo "Champion auto-merge complete!"
-echo "========================================="
-echo ""
-echo "Summary:"
-echo "- PR #$PR_NUMBER: Merged successfully"
-echo "- Lines changed: $TOTAL (+$ADDITIONS/-$DELETIONS)"
-echo "- Linked issues: ${LINKED_ISSUES:-none}"
-echo ""
-exit 0
-```
-
-**Usage**:
-
-```bash
-# Auto-merge a single PR
-./champion_automerge.sh 123
-
-# Use in Champion iteration loop
-for pr in $(gh pr list --label="loom:pr" --json number --jq '.[].number' | head -3); do
-  ./champion_automerge.sh "$pr" || echo "Failed to merge PR #$pr, continuing..."
-done
-```
+For the authoritative, end-to-end implementation — the 7 safety criteria, the pre-merge comment, the squash merge via `merge-pr.sh`, linked-issue closure verification, dependent-issue unblocking, and Step 5.5 Follow-on Issue Creation — see **`champion-pr-merge.md`**. The edge cases and decision matrix above remain here as the reference for non-standard situations; they describe *behavior*, and defer to `champion-pr-merge.md` for the *script*.
 
 ---
 


### PR DESCRIPTION
Closes #3781

Repairs five defects in the Champion auto-merge prompts. Per the Curator's source-of-truth note, `.claude/commands/loom` is a symlink to `defaults/.claude/commands/loom`, so **all edits are in `defaults/` only**. `defaults/roles/champion.md` needed no change (it only narratively cross-references Step 5.5, which still exists).

## Fixes

1. **CI safety gate was silently vacuous (HIGH).** `gh pr checks --json name,conclusion,status` is invalid — the JSON surface only exposes `bucket, completedAt, description, event, link, name, startedAt, state, workflow` (verified against `gh pr checks --help`, gh 2.96.0). The invalid fields errored, `jq` then failed on non-JSON, and the gate printed "PASS: All CI checks passing" unconditionally. Now uses `--json bucket,name` and gates on `bucket == "fail"`/`"cancel"` (block), `bucket == "pending"` (defer); `pass`/`skipping` are OK. No-checks is detected via **empty stdout** (gh prints "no checks reported" to stderr + exits non-zero with empty stdout — verified empirically), not error-text matching. Fixed at both call sites in `champion-pr-merge.md` (criterion #6 and the pre-merge-comment block) and in `champion-reference.md`'s edge-case snippets (Edge Cases 1, 2, 9).

2. **Follow-on issue creation always failed.** `gh issue create` has no `--json`/`--jq` flag ("unknown flag"), so Step 5.5 died at the create step every time. Now captures the printed issue URL and parses the trailing number (`grep -oE '[0-9]+$'`).

3. **TODO extraction was gawk-only → silently empty on macOS.** Two constructs in the *same* awk program were BSD-awk-incompatible: the 3-arg `match($0, /\+([0-9]+)/, arr)` (errors "bailing out" on BSD awk) **and** the gawk-only `\b` word boundary in the TODO pattern (silently matches nothing on BSD awk). Fixing only the first would leave defect #3's stated goal ("TODO detection never fires on macOS") unmet, so both are fixed: POSIX `match()`+`substr()` for the hunk header, and `(^|[^A-Za-z0-9_])` for the word boundary. Verified end-to-end on macOS `/usr/bin/awk` (version 20200816): extracts the right lines with correct line numbers and still excludes `MYTODO:`.

4. **Stale-PR (>24h) policy was contradictory and spammy.** `champion-pr-merge.md` said "keep `loom:pr`, comment" (re-comments every 10-min cron tick forever); `champion-reference.md` said the opposite ("remove `loom:pr`, request rebase"). Now a single coherent policy in both files: on a stale PR, **comment once** guarded by an idempotency marker (`<!-- champion:stale-pr-notice -->`), then **swap `loom:pr` → `loom:changes-requested`** so the PR leaves the auto-merge queue and routes to Doctor. The transient-failure path (pending CI, conflicts) still keeps `loom:pr` for the next-tick retry — the two paths are now explicitly distinguished.

5. **Removed the diverging duplicate workflow script.** `champion-reference.md`'s ~285-line "Complete Auto-Merge Workflow Script" re-implemented the same steps as `champion-pr-merge.md`, had already diverged (no Step 5.5, carried the same broken `gh pr checks` call), and forced every fix to be applied twice. **Chosen approach: deletion** (per the issue's stated preference over the larger script-extraction refactor). It's replaced by a pointer to `champion-pr-merge.md` as the single source of truth; the edge cases + decision matrix stay in `champion-reference.md`.

Plus (also in the issue): **champion-epic.md phase-completion search** used `--search="Epic: #$EPIC_NUMBER Phase: $PHASE in:body"`, which never matched the `**Epic**: #N` / `**Phase**: 1 of N` prose the body template emits. Now a machine-checkable marker `<!-- loom:epic:<epic>:phase:<n> -->` is emitted into each phase-issue body and searched for exactly.

## Verification

All snippets validated by executing them (no automated doc-lint covers these markdown files — `shell-lint.yml` only lints `defaults/scripts/**/*.sh`; the Rust doc-lint tests are `sweep.md`/`bump.md`-specific):

- `grep` confirms zero `--json name,conclusion,status`, zero `.conclusion`/`IN_PROGRESS`/`QUEUED`, zero `gh issue create ... --json`, and zero 3-arg `match(...,arr)` remain in `defaults/.claude/commands/loom/`.
- CI-gate jq logic tested across fixtures: no-checks→PASS, all-pass→PASS, one-fail→**FAIL** (was vacuously PASS), pending→SKIP, cancel→FAIL, pass+skipping→PASS.
- awk program run on macOS BSD awk 20200816: exit 0, correct file:line:text extraction, `MYTODO:` excluded.
- URL parse: `https://github.com/rjwalters/loom/issues/3799 | grep -oE '[0-9]+$'` → `3799`.
- Marker consistency: epic emit/search tokens match; stale-PR marker used in both the guard and the comment; only existing labels used (`loom:changes-requested`, no new labels).

No new issues, no new labels. All edits confined to the three in-scope `defaults/` files.