### PR TITLE
docs(builder): guard against pnpm build-approval prompt mutating pnpm-workspace.yaml

### DIFF
--- a/defaults/.claude/commands/loom/builder.md
+++ b/defaults/.claude/commands/loom/builder.md
@@ -54,6 +54,27 @@ git -C "$WORKTREE_ABS" diff --cached --name-only \
   || echo "OK: no Loom runtime markers staged"
 ```
 
+**No unrelated lockfile / workspace-config hunks.** A dependency install can mutate
+files outside your scope. In particular, **pnpm's build-approval prompt persists
+`onlyBuiltDependencies` / `ignoredBuiltDependencies` into `pnpm-workspace.yaml`**
+(older pnpm: into `package.json`) the first time `pnpm install` builds a package with
+an install script — an out-of-scope hunk a careless commit will ship. Defend against it:
+
+- Run installs **non-interactively** so the prompt never mutates config —
+  `CI=true pnpm install` (CI mode skips the build-approval prompt entirely). npm/yarn
+  installs can likewise touch `package-lock.json` / `yarn.lock`.
+- **After any install**, check for stray config/lockfile edits and revert unrelated hunks
+  before staging:
+
+  ```bash
+  git -C "$WORKTREE_ABS" status --short -- pnpm-workspace.yaml pnpm-lock.yaml package.json package-lock.json yarn.lock
+  # revert any hunk your issue did not intentionally change:
+  git -C "$WORKTREE_ABS" checkout -- pnpm-workspace.yaml   # (or the specific file)
+  ```
+
+  A genuinely needed lockfile bump (you added/updated a dependency on purpose) is in
+  scope — keep it; revert only the incidental install-prompt churn.
+
 ### What To Do When You Notice Unrelated Problems
 
 If you discover issues in files you're reading:


### PR DESCRIPTION
## Summary

Builders routinely run `pnpm install` in pnpm repos. pnpm's dependency build-approval prompt persists `onlyBuiltDependencies` / `ignoredBuiltDependencies` into `pnpm-workspace.yaml` (older pnpm: `package.json`) the first time an install builds a package with an install script. That is an out-of-scope hunk a careless builder will ship in its PR — exactly the scope creep the Judge then has to catch (observed on rjwalters/once-around#83).

This is pnpm behavior, not a Loom bug, but the builder guidance is the right place to defend against it.

## Change

Adds a short note to the **Pre-Commit Scope Check** section of `defaults/.claude/commands/loom/builder.md` (the canonical builder role source; `.loom/roles/builder.md` and `defaults/roles/builder.md` are symlinks to it):

- Run installs non-interactively (`CI=true pnpm install`) so the build-approval prompt never mutates config.
- After any install, `git status`-check `pnpm-workspace.yaml` / lockfiles and revert unrelated hunks before staging (keeping a genuinely-needed dependency bump).
- Adds the "no unrelated lockfile / workspace-config hunks" item to the pre-commit self-check.

Flags documented are verified-safe framings (`CI=true` non-interactive install + the git-status check) — no invented flags.

Docs-only change, 21-line addition, no drive-by edits.

Closes #3821

🤖 Generated with [Claude Code](https://claude.com/claude-code)