### PR TITLE
docs(bump): gate CHANGELOG phases on an existing CHANGELOG.md

### DIFF
--- a/defaults/.claude/commands/loom/bump.md
+++ b/defaults/.claude/commands/loom/bump.md
@@ -58,27 +58,13 @@ If **no** version-bearing files are found, stop and tell the operator:
 
 > No version sources detected in this project. Supported shapes are: `package.json`, `Cargo.toml`, `pyproject.toml`, `setup.py`/`setup.cfg`, top-level shell script with `VERSION="X.Y.Z"`, and `CLAUDE.md` / `README.md` with `**Version**: X.Y.Z`. If your project uses a different shape, add one of these conventions first.
 
-## Phase 2: Ensure `CHANGELOG.md` exists with `[Unreleased]`
+## Phase 2: Update `CHANGELOG.md` if present (optional)
 
 Look for `CHANGELOG.md` at the repository root.
 
+- **If absent entirely**: skip this phase — no prompt, no scaffold. `/loom:bump` never creates a `CHANGELOG.md`; that's `/repo:release`'s job (per the no-CHANGELOG positioning above). Proceed straight to Phase 3.
 - **If present and contains `## [Unreleased]`**: continue.
-- **If present but missing `## [Unreleased]`**: ask the operator to add one, or offer to insert it just below the file header.
-- **If absent entirely**: offer to scaffold a minimal Keep-a-Changelog header. Ask first — do not write without confirmation.
-
-Suggested scaffold:
-
-```markdown
-# Changelog
-
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-
-```
+- **If present but missing `## [Unreleased]`**: ask the operator to add one, or offer to insert it just below the file header. (This fixes an existing changelog — it is not scaffolding a new one.)
 
 ## Phase 3: Compute the new version (semver bump)
 
@@ -97,7 +83,9 @@ Show the operator the computed new version and ask for confirmation.
 
 ## Phase 4: Draft the changelog entry
 
-This is a **human-in-the-loop** step. **Never auto-generate the changelog content from commits.** Open `CHANGELOG.md`, find the `## [Unreleased]` section, and:
+**If `CHANGELOG.md` does not exist, skip this phase entirely** — the quick-bump has no changelog step in that case (Phase 2 already skipped for the same reason). Proceed to Phase 5.
+
+Otherwise, this is a **human-in-the-loop** step. **Never auto-generate the changelog content from commits.** Open `CHANGELOG.md`, find the `## [Unreleased]` section, and:
 
 1. If the operator has already written content under `## [Unreleased]`, present it and ask whether to use it as-is or edit.
 2. If the section is empty, ask the operator to dictate the entry. Suggest the categories from Keep a Changelog: `### Added`, `### Changed`, `### Fixed`, `### Removed`, `### Deprecated`, `### Security`.
@@ -365,7 +353,7 @@ Once `scripts/version.sh` exists, invoke it:
 This will:
 1. Update every file in `VERSION_FILES` to the new version.
 2. Refresh `Cargo.lock` (if present).
-3. Stage the changes plus `CHANGELOG.md`.
+3. Stage the changes plus `CHANGELOG.md`, if present.
 4. Create a commit `chore: bump version to X.Y.Z`.
 5. Create an annotated tag `vX.Y.Z`.
 
@@ -394,11 +382,12 @@ git push origin HEAD
 git push origin "v$NEW_VERSION"
 ```
 
-Then create the GitHub Release. Use the just-promoted changelog block as the release notes:
+Then create the GitHub Release. If a `CHANGELOG.md` exists, use the just-promoted changelog block as the release notes; if it does not (the no-changelog quick-bump case), skip the extraction and pass a short operator-supplied note (or `--generate-notes`) instead:
 
 ```bash
-# Extract the most recent ## [X.Y.Z] - DATE block from CHANGELOG.md
-notes=$(awk '/^## \['"$NEW_VERSION"'\]/{flag=1; next} /^## \[/{flag=0} flag' CHANGELOG.md)
+# Extract the most recent ## [X.Y.Z] - DATE block from CHANGELOG.md (only if it exists)
+notes=""
+[ -f "CHANGELOG.md" ] && notes=$(awk '/^## \['"$NEW_VERSION"'\]/{flag=1; next} /^## \[/{flag=0} flag' CHANGELOG.md)
 
 gh release create "v$NEW_VERSION" \
   --title "v$NEW_VERSION" \
@@ -426,6 +415,7 @@ Release v$NEW_VERSION complete
 
 ## Notes and constraints
 
+- **CHANGELOG work is conditional on an existing `CHANGELOG.md`.** Phases 2 and 4 only run when a `CHANGELOG.md` already exists in the repo; `/loom:bump` never creates one — that's `/repo:release`'s job. When absent, both phases are skipped cleanly (no prompt, no scaffold), keeping the quick-bump quick.
 - **Do not auto-generate CHANGELOG content from commits.** The `## [Unreleased]` content comes from the operator. The skill only *promotes* the existing `[Unreleased]` heading to `[X.Y.Z] - DATE`.
 - **Do not publish to package registries.** Tag + GitHub Release only.
 - **For the full release methodology, defer to `/repo:release`.** That command (from [rjwalters/repo](https://github.com/rjwalters/repo)) owns the CHANGELOG/version-drift gates and GitHub Release flow, and honors `scripts/version.sh`. `/loom:bump` is the lightweight quick-bump counterpart.


### PR DESCRIPTION
## Summary

`defaults/.claude/commands/loom/bump.md` (the `/loom:bump` slash-command definition) contradicted its own positioning. Line 8 advertises it as a lightweight **no-CHANGELOG** quick-bump — CHANGELOG completeness belongs to `/repo:release` — yet Phase 2 offered to **scaffold a brand-new** `CHANGELOG.md` when absent, and Phase 4 mandated drafting/promoting a changelog entry unconditionally. An agent running `/loom:bump` had to guess which instruction wins.

This implements the curator's recommended **Option 1** (conditional skip, never scaffold): gate the CHANGELOG phases on `CHANGELOG.md` already existing so the quick-bump stays quick, deferring CHANGELOG *creation* to `/repo:release`.

## Changes

- **Phase 2** — retitled to "Update `CHANGELOG.md` if present (optional)"; when absent, skip cleanly (no prompt, no scaffold) and proceed to Phase 3. Removed the scaffold offer and its Keep-a-Changelog markdown block. Kept the fix-existing-file branch (present but missing `[Unreleased]`).
- **Phase 4** — added a guard clause skipping the whole phase when `CHANGELOG.md` does not exist; the human-in-the-loop draft/promote flow is unchanged for the present case.
- **Phase 6 summary** (prose) — "Stage the changes plus `CHANGELOG.md`" → "…, if present", matching the already-conditional `do_tag()` template (`[ -f "CHANGELOG.md" ] && git add CHANGELOG.md`, unchanged).
- **Phase 7 release-notes** — guarded the `awk` extraction with `[ -f "CHANGELOG.md" ]` so the no-changelog case doesn't read a nonexistent file; falls back to an operator-supplied note / `--generate-notes`.
- **Notes and constraints** — added a bullet stating CHANGELOG work (Phases 2 & 4) only runs when `CHANGELOG.md` already exists and `/loom:bump` never creates one.

No functional change to the generated `scripts/version.sh` `do_tag()` logic (it was already conditional). Markdown-only change; `.claude/commands/loom/bump.md` is a symlink to the edited `defaults/` file in this repo.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Phase 2 gated on existence, no scaffold when absent | ✅ | Scaffold bullet + markdown block deleted; "If absent → skip, no scaffold" added |
| Phase 4 guard clause skipping the phase when absent | ✅ | "If `CHANGELOG.md` does not exist, skip this phase entirely" added at top of Phase 4 |
| Line 8 positioning accurate for both branches | ✅ | Full-file read-through; both scenarios traced (see Test Plan) |
| Phase 6 prose matches conditional `do_tag()` staging | ✅ | Reworded to "…, if present" |
| No behavior change to generated `do_tag()` logic | ✅ | Lines 295-299 untouched |
| No new labels; no changes to `/repo:release` or other commands | ✅ | Single-file diff |

## Test Plan

Markdown slash-command definition (no executable path). Verified by end-to-end read-through of two scenarios:

1. **No `CHANGELOG.md`**: Phase 1 → Phase 2 (skip) → Phase 3 → Phase 4 (skip) → Phase 5 → Phase 6 (`do_tag` stages CHANGELOG only if present) → Phase 7 (notes extraction guarded) → Phase 8. Line 8's "no-CHANGELOG quick-bump" claim now holds.
2. **Existing `CHANGELOG.md` with `[Unreleased]`**: Phases 2 and 4 behave exactly as before — no regression for the CHANGELOG-owning case (Loom's own repo).

`git diff` scoped to `defaults/.claude/commands/loom/bump.md` only.

Closes #3795