### PR TITLE
fix(hooks): namespaced /loom:<role> detection + bounded session-marker dirs

### DIFF
--- a/.loom/hooks/methodology-inject.sh
+++ b/.loom/hooks/methodology-inject.sh
@@ -180,6 +180,12 @@ if [[ "$INJECT_UNIVERSAL" == "true" ]] && [[ -f "${CONTEXT_DIR}/universal.md" ]]
         SESSION_KEY=$(printf '%s' "$SESSION_ID" | tr -c 'A-Za-z0-9._-' '_')
         SEEN_DIR="${MAIN_ROOT}/.loom/logs/methodology-inject-seen"
         SEEN_MARKER="${SEEN_DIR}/${SESSION_KEY}"
+        # Opportunistic best-effort prune (#3793): every session adds one marker
+        # here and nothing else prunes them, so a busy orchestration repo would
+        # accumulate stale empty files without bound. Drop markers older than 7
+        # days on hook entry. Fail-open — any error (missing dir, permission)
+        # never fails the hook and never changes the dedup decision below.
+        find "$SEEN_DIR" -type f -mtime +7 -delete 2>/dev/null || true
         if [[ -f "$SEEN_MARKER" ]]; then
             INCLUDE_UNIVERSAL=0
         else
@@ -202,17 +208,22 @@ if [[ "$INJECT_ROLE" == "true" ]]; then
 
     # Fallback: detect role from prompt preamble (slash commands)
     if [[ -z "$ROLE" ]]; then
+        # Match both the unnamespaced (/builder) and namespaced (/loom:builder)
+        # forms for every role (#3793). Claude Code 2.1+ requires the namespaced
+        # /loom:<role> form for subdirectory commands (#3345), so an interactive
+        # `/loom:builder 123` must inject builder context too. /loom:sweep has no
+        # unnamespaced counterpart (sweep.md was always namespace-only).
         case "$PROMPT" in
-            /builder*) ROLE="builder" ;;
-            /judge*)   ROLE="judge" ;;
-            /curator*) ROLE="curator" ;;
-            /doctor*)  ROLE="doctor" ;;
-            /architect*) ROLE="architect" ;;
-            /hermit*)  ROLE="hermit" ;;
-            /champion*) ROLE="champion" ;;
-            /guide*)   ROLE="guide" ;;
-            /auditor*) ROLE="auditor" ;;
-            /loom:sweep*) ROLE="sweep" ;;
+            /builder*|/loom:builder*)     ROLE="builder" ;;
+            /judge*|/loom:judge*)         ROLE="judge" ;;
+            /curator*|/loom:curator*)     ROLE="curator" ;;
+            /doctor*|/loom:doctor*)       ROLE="doctor" ;;
+            /architect*|/loom:architect*) ROLE="architect" ;;
+            /hermit*|/loom:hermit*)       ROLE="hermit" ;;
+            /champion*|/loom:champion*)   ROLE="champion" ;;
+            /guide*|/loom:guide*)         ROLE="guide" ;;
+            /auditor*|/loom:auditor*)     ROLE="auditor" ;;
+            /loom:sweep*)                 ROLE="sweep" ;;
         esac
     fi
 

--- a/.loom/hooks/skill-router.sh
+++ b/.loom/hooks/skill-router.sh
@@ -183,6 +183,12 @@ if [[ -n "$SESSION_ID" ]]; then
     SESSION_KEY=$(printf '%s' "$SESSION_ID" | tr -c 'A-Za-z0-9._-' '_')
     SEEN_DIR="${MAIN_ROOT}/.loom/logs/skill-router-seen"
     SEEN_MARKER="${SEEN_DIR}/${SESSION_KEY}"
+    # Opportunistic best-effort prune (#3793): every session adds one marker here
+    # and nothing else prunes them, so a busy orchestration repo would accumulate
+    # stale empty files without bound. Drop markers older than 7 days on hook
+    # entry. Fail-open — any error (missing dir, permission) never fails the hook
+    # and never changes the dedup decision below.
+    find "$SEEN_DIR" -type f -mtime +7 -delete 2>/dev/null || true
     if [[ -f "$SEEN_MARKER" ]]; then
         INCLUDE_TABLE=0
     else

--- a/defaults/hooks/methodology-inject.sh
+++ b/defaults/hooks/methodology-inject.sh
@@ -180,6 +180,12 @@ if [[ "$INJECT_UNIVERSAL" == "true" ]] && [[ -f "${CONTEXT_DIR}/universal.md" ]]
         SESSION_KEY=$(printf '%s' "$SESSION_ID" | tr -c 'A-Za-z0-9._-' '_')
         SEEN_DIR="${MAIN_ROOT}/.loom/logs/methodology-inject-seen"
         SEEN_MARKER="${SEEN_DIR}/${SESSION_KEY}"
+        # Opportunistic best-effort prune (#3793): every session adds one marker
+        # here and nothing else prunes them, so a busy orchestration repo would
+        # accumulate stale empty files without bound. Drop markers older than 7
+        # days on hook entry. Fail-open — any error (missing dir, permission)
+        # never fails the hook and never changes the dedup decision below.
+        find "$SEEN_DIR" -type f -mtime +7 -delete 2>/dev/null || true
         if [[ -f "$SEEN_MARKER" ]]; then
             INCLUDE_UNIVERSAL=0
         else
@@ -202,17 +208,22 @@ if [[ "$INJECT_ROLE" == "true" ]]; then
 
     # Fallback: detect role from prompt preamble (slash commands)
     if [[ -z "$ROLE" ]]; then
+        # Match both the unnamespaced (/builder) and namespaced (/loom:builder)
+        # forms for every role (#3793). Claude Code 2.1+ requires the namespaced
+        # /loom:<role> form for subdirectory commands (#3345), so an interactive
+        # `/loom:builder 123` must inject builder context too. /loom:sweep has no
+        # unnamespaced counterpart (sweep.md was always namespace-only).
         case "$PROMPT" in
-            /builder*) ROLE="builder" ;;
-            /judge*)   ROLE="judge" ;;
-            /curator*) ROLE="curator" ;;
-            /doctor*)  ROLE="doctor" ;;
-            /architect*) ROLE="architect" ;;
-            /hermit*)  ROLE="hermit" ;;
-            /champion*) ROLE="champion" ;;
-            /guide*)   ROLE="guide" ;;
-            /auditor*) ROLE="auditor" ;;
-            /loom:sweep*) ROLE="sweep" ;;
+            /builder*|/loom:builder*)     ROLE="builder" ;;
+            /judge*|/loom:judge*)         ROLE="judge" ;;
+            /curator*|/loom:curator*)     ROLE="curator" ;;
+            /doctor*|/loom:doctor*)       ROLE="doctor" ;;
+            /architect*|/loom:architect*) ROLE="architect" ;;
+            /hermit*|/loom:hermit*)       ROLE="hermit" ;;
+            /champion*|/loom:champion*)   ROLE="champion" ;;
+            /guide*|/loom:guide*)         ROLE="guide" ;;
+            /auditor*|/loom:auditor*)     ROLE="auditor" ;;
+            /loom:sweep*)                 ROLE="sweep" ;;
         esac
     fi
 

--- a/defaults/hooks/skill-router.sh
+++ b/defaults/hooks/skill-router.sh
@@ -183,6 +183,12 @@ if [[ -n "$SESSION_ID" ]]; then
     SESSION_KEY=$(printf '%s' "$SESSION_ID" | tr -c 'A-Za-z0-9._-' '_')
     SEEN_DIR="${MAIN_ROOT}/.loom/logs/skill-router-seen"
     SEEN_MARKER="${SEEN_DIR}/${SESSION_KEY}"
+    # Opportunistic best-effort prune (#3793): every session adds one marker here
+    # and nothing else prunes them, so a busy orchestration repo would accumulate
+    # stale empty files without bound. Drop markers older than 7 days on hook
+    # entry. Fail-open — any error (missing dir, permission) never fails the hook
+    # and never changes the dedup decision below.
+    find "$SEEN_DIR" -type f -mtime +7 -delete 2>/dev/null || true
     if [[ -f "$SEEN_MARKER" ]]; then
         INCLUDE_TABLE=0
     else

--- a/defaults/hooks/tests/test-methodology-inject.sh
+++ b/defaults/hooks/tests/test-methodology-inject.sh
@@ -230,6 +230,68 @@ for probe in "the weather is nice today here" "please implement the feature now"
     fi
 done
 
+# --- Namespaced /loom:<role> detection (#3793) ------------------------------
+# Role commands live at .claude/commands/loom/<role>.md and Claude Code 2.1+
+# requires the namespaced /loom:<role> form for subdirectory commands (#3345).
+# The prompt-preamble fallback must set ROLE for BOTH /builder and /loom:builder.
+# Detection only fires when LOOM_ROLE is UNSET, so run these with LOOM_ROLE
+# explicitly cleared (env -u) so an inherited LOOM_ROLE never masks the fallback.
+setup_context
+printf '# Judge Role\nMARKER_ROLE_JUDGE\n' > "$CONTEXT_DIR/roles/judge.md"
+printf '# Auditor Role\nMARKER_ROLE_AUDITOR\n' > "$CONTEXT_DIR/roles/auditor.md"
+
+run_hook_norole() {
+    local prompt="$1" session="${2:-}"
+    local output exit_code=0
+    output=$(cd "$TMPROOT" && make_input "$prompt" "$session" | env -u LOOM_ROLE "$HOOK" 2>/dev/null) || exit_code=$?
+    if [[ "$exit_code" -ne 0 ]]; then echo "__NONZERO_EXIT__:$exit_code"; return 0; fi
+    if [[ -n "$output" ]] && ! echo "$output" | jq empty 2>/dev/null; then echo "__INVALID_JSON__"; return 0; fi
+    echo "$output"
+}
+
+reset_markers
+outNS1=$(run_hook_norole "/loom:builder 123" "sess-ns-1")
+assert_contains "namespaced /loom:builder -> builder role injected" "$(context_of "$outNS1")" "MARKER_ROLE_BUILDER"
+
+reset_markers
+outNS2=$(run_hook_norole "/loom:judge review this pr" "sess-ns-2")
+assert_contains "namespaced /loom:judge -> judge role injected" "$(context_of "$outNS2")" "MARKER_ROLE_JUDGE"
+
+reset_markers
+outNS3=$(run_hook_norole "/loom:auditor check main branch" "sess-ns-3")
+assert_contains "namespaced /loom:auditor -> auditor role injected" "$(context_of "$outNS3")" "MARKER_ROLE_AUDITOR"
+
+# Regression: the pre-existing unnamespaced forms still resolve unchanged.
+reset_markers
+outUN1=$(run_hook_norole "/builder 123" "sess-un-1")
+assert_contains "unnamespaced /builder -> builder role still injected" "$(context_of "$outUN1")" "MARKER_ROLE_BUILDER"
+
+reset_markers
+outUN2=$(run_hook_norole "/judge review this pr" "sess-un-2")
+assert_contains "unnamespaced /judge -> judge role still injected" "$(context_of "$outUN2")" "MARKER_ROLE_JUDGE"
+
+# --- Session-marker dir pruning (#3793) -------------------------------------
+# Stale markers (>7d) are pruned opportunistically on hook entry; fresh markers
+# survive. The prune runs inside the session-dedup branch (universal.md present,
+# session_id supplied, universal_frequency != always).
+setup_context
+reset_markers
+SEEN_DIR_M="$TMPROOT/.loom/logs/methodology-inject-seen"
+mkdir -p "$SEEN_DIR_M"
+touch -t 202001010000 "$SEEN_DIR_M/stale-old-session"   # ~2020 -> older than 7d
+touch "$SEEN_DIR_M/fresh-session"                        # now -> within 7d
+run_hook "trigger a prune pass here now" "sess-prune-m" >/dev/null
+if [[ ! -e "$SEEN_DIR_M/stale-old-session" ]]; then
+    pass "methodology: stale (>7d) marker pruned on hook entry"
+else
+    fail "methodology: stale (>7d) marker pruned on hook entry"
+fi
+if [[ -e "$SEEN_DIR_M/fresh-session" ]]; then
+    pass "methodology: fresh marker survives prune"
+else
+    fail "methodology: fresh marker survives prune"
+fi
+
 # --- defaults/ vs .loom/ sync -----------------------------------------------
 DEPLOY_HOOK="$REPO_ROOT/.loom/hooks/methodology-inject.sh"
 if [[ -f "$DEPLOY_HOOK" ]] && diff -q "$SRC_HOOK" "$DEPLOY_HOOK" >/dev/null 2>&1; then

--- a/defaults/hooks/tests/test-skill-router.sh
+++ b/defaults/hooks/tests/test-skill-router.sh
@@ -182,6 +182,27 @@ outB=$(run_hook "please implement the new feature")
 ctxB=$(context_of "$outB")
 assert_contains "no session_id -> table included again (graceful)" "$ctxB" "Available Loom agents:"
 
+# --- Session-marker dir pruning (#3793) -------------------------------------
+# Stale markers (>7d) are pruned opportunistically on hook entry; fresh markers
+# survive. The prune runs inside the session-dedup branch (a route matched and
+# session_id is supplied).
+reset_markers
+SEEN_DIR_S="$TMPROOT/.loom/logs/skill-router-seen"
+mkdir -p "$SEEN_DIR_S"
+touch -t 202001010000 "$SEEN_DIR_S/stale-old-session"   # ~2020 -> older than 7d
+touch "$SEEN_DIR_S/fresh-session"                        # now -> within 7d
+run_hook "please implement the new feature" "sess-prune-s" >/dev/null
+if [[ ! -e "$SEEN_DIR_S/stale-old-session" ]]; then
+    pass "skill-router: stale (>7d) marker pruned on hook entry"
+else
+    fail "skill-router: stale (>7d) marker pruned on hook entry"
+fi
+if [[ -e "$SEEN_DIR_S/fresh-session" ]]; then
+    pass "skill-router: fresh marker survives prune"
+else
+    fail "skill-router: fresh marker survives prune"
+fi
+
 # --- Never non-zero / never invalid JSON ------------------------------------
 for probe in "the weather is quite nice today" "please implement the new feature" "review this PR" "/builder x y z"; do
     out=$(run_hook "$probe" "sess-probe")


### PR DESCRIPTION
## Summary

Fixes two small defects in the UserPromptSubmit prompt-injection hooks (from the 2026-07-22 prompt-system audit). Scope is items 1 and 2 of #3793; item 3 (role/topic re-injection dedup) is explicitly out of scope per the issue's acceptance criteria.

### Fix 1 — namespaced `/loom:<role>` role detection

`methodology-inject.sh`'s role-detection `case` matched only the unnamespaced `/builder*` … forms plus `/loom:sweep*`. But role commands live at `.claude/commands/loom/<role>.md`, and Claude Code 2.1+ requires the namespaced `/loom:<role>` form for subdirectory commands (#3345) — so an interactive `/loom:builder 123` got **no** builder methodology context. The case statement now matches **both** `/<role>*` and `/loom:<role>*` for all nine roles (builder, judge, curator, doctor, architect, hermit, champion, guide, auditor). `/loom:sweep*` is unchanged (it never had an unnamespaced counterpart). A repo-wide grep confirms no sibling hook carried the same gap.

### Fix 2 — bounded session-marker directories

`.loom/logs/methodology-inject-seen/` and `.loom/logs/skill-router-seen/` accumulated one empty marker per session with no expiry, and `loom-clean` doesn't know about them. Both hooks now do a **best-effort, fail-open** opportunistic prune on hook entry:

```bash
find "$SEEN_DIR" -type f -mtime +7 -delete 2>/dev/null || true
```

This never changes the dedup semantics (marker presence still means "already injected this session") — only the retention window — and a prune failure never fails the hook.

## Files changed

- `defaults/hooks/methodology-inject.sh` + installed copy `.loom/hooks/methodology-inject.sh` (kept byte-identical, enforced by the suite's sync check)
- `defaults/hooks/skill-router.sh` + installed copy `.loom/hooks/skill-router.sh`
- `defaults/hooks/tests/test-methodology-inject.sh` — added namespaced-role detection (builder/judge/auditor), unnamespaced regression, and marker-prune coverage
- `defaults/hooks/tests/test-skill-router.sh` — added marker-prune coverage

## Testing

```
bash defaults/hooks/tests/test-methodology-inject.sh   # 27/27 passed, exit 0
bash defaults/hooks/tests/test-skill-router.sh          # 28/28 passed, exit 0
```

## Deliberately out of scope

- **Item 3** (role/topic re-injection once-per-session dedup) — filer-marked optional; did not fall out naturally from the case-statement change, left for a follow-up.
- **GH Actions workflow invocations** (`.github/workflows/loom-*.yml` still call `/champion`, `/auditor`, etc. unnamespaced) — the acceptance criteria only require the hook to match both forms, not that workflows change. Matching both forms in the hook makes those invocations resolve fine, so no workflow edit was needed.

Closes #3793