### PR TITLE
fix(champion): delete dead force-mode subsystem; reconcile batch caps to drain-the-queue

### DIFF
--- a/defaults/.claude/agents/loom-champion.md
+++ b/defaults/.claude/agents/loom-champion.md
@@ -20,12 +20,12 @@ Follow the complete role definition in `.loom/roles/champion.md` for:
   5. Updated within 24 hours
   6. CI checks passing
   7. No `loom:manual-merge` label
-- Max 3 merges per iteration
+- Drain the queue — merge every qualifying PR each iteration (no numeric cap; see `champion-pr-merge.md` §"PR Auto-Merge Batch Processing")
 
 **Issue Promotion (Priority 2)**:
 - Find issues with `gh issue list --label="loom:curated" --state=open`
 - Evaluate against 8 quality criteria
 - Promote by adding `loom:issue` label
-- Max 2 promotions per iteration
+- Process the whole queue, bounded only by the tier-based promotion limits in `champion-issue-promo.md` (Tier 1 unlimited / Tier 2 ≤2 per iteration / Tier 3 ≤1, gated at 5 backlog) and the 1-epic-per-iteration limit in `champion-epic.md`
 
 Conservative bias - when in doubt, do NOT act. Always leave detailed audit trail comments.

--- a/defaults/.claude/commands/loom/champion-common.md
+++ b/defaults/.claude/commands/loom/champion-common.md
@@ -8,8 +8,8 @@ This file contains shared utilities, protocols, and information used across all 
 
 After evaluating both queues:
 
-1. Report PRs evaluated and merged (max 3)
-2. Report issues evaluated and promoted (max 2)
+1. Report PRs evaluated and merged
+2. Report issues evaluated and promoted
 3. Report rejections with reasons
 4. List merged PR numbers and promoted issue numbers with links
 
@@ -68,9 +68,9 @@ This role is designed for **autonomous operation** with a recommended interval o
 
 When running autonomously:
 1. Check for `loom:pr` PRs (Priority 1)
-2. Evaluate up to 3 PRs (oldest first), merge safe ones
+2. Drain the queue — evaluate every qualifying PR (oldest first) and merge safe ones until the queue is empty (see `champion-pr-merge.md` §"PR Auto-Merge Batch Processing"; PR merging has no numeric per-iteration cap)
 3. If no PRs, check for `loom:curated` issues (Priority 2)
-4. Evaluate up to 2 issues (oldest first), promote qualifying ones
+4. Evaluate all qualifying issues (oldest first) and promote them, bounded only by the tier-based promotion limits in `champion-issue-promo.md` (Tier 1 unlimited / Tier 2 up to 2 per iteration / Tier 3 up to 1, gated at 5 backlog)
 5. Report results and stop
 
 ### Quality Over Quantity

--- a/defaults/.claude/commands/loom/champion-epic.md
+++ b/defaults/.claude/commands/loom/champion-epic.md
@@ -218,35 +218,6 @@ Epics generate multiple issues, so limit epic approvals to prevent overwhelming 
 
 ---
 
-## Force Mode Epic Behavior
-
-In force mode, epics are evaluated with relaxed criteria:
-- Skip detailed criteria checking
-- Auto-approve if epic has at least 2 phases and clear issue list
-- Create Phase 1 issues immediately
-- Add `[force-mode]` prefix to all comments
-
-```bash
-if [ "$FORCE_MODE" = "true" ]; then
-    # Minimal epic validation
-    BODY=$(gh issue view "$epic" --json body --jq '.body')
-    HAS_PHASES=$(echo "$BODY" | grep -c "### Phase")
-
-    if [ "$HAS_PHASES" -ge 2 ]; then
-        # Auto-approve and create Phase 1 issues
-        create_phase_issues "$epic" 1
-        gh issue comment "$epic" --body "**[force-mode] Epic Auto-Approved**
-
-Phase 1 issues created. Epic will progress automatically.
-
----
-*Automated by Champion role (force mode)*"
-    fi
-fi
-```
-
----
-
 ## Return to Main Champion File
 
 After completing epic evaluation work, return to the main champion.md file for completion reporting.

--- a/defaults/.claude/commands/loom/champion-issue-promo.md
+++ b/defaults/.claude/commands/loom/champion-issue-promo.md
@@ -290,49 +290,11 @@ Work through all available curated issues, applying the tier-based rate limits t
 
 Continue evaluating issues until all have been processed or all applicable tier limits are reached. This prevents issues from waiting unnecessarily across multiple 10-minute intervals when they've already met quality criteria.
 
----
+### When NOT to Promote
 
-## Force Mode Issue Promotion
-
-When force mode is active (check `daemon-state.json`), use relaxed criteria:
-
-**Auto-Promote Architect Proposals** that have:
-- A clear title (not vague like "Improve things")
-- At least one acceptance criterion
-- No `loom:blocked` label
-
-**Auto-Promote Hermit Proposals** that have:
-- A specific simplification target (file, module, or pattern)
-- At least one concrete removal action
-- No `loom:blocked` label
-
-**Auto-Promote Auditor Bug Reports** that have:
-- A clear bug description
-- Reproduction steps
-- No `loom:blocked` label
-
-**Auto-Promote Curated Issues** that have:
-- A problem statement
-- At least one acceptance criterion
-- No `loom:blocked` label
-
-**Force mode comment format**:
-```bash
-gh issue comment "$issue" --body "**[force-mode] Champion Auto-Promote**
-
-This proposal has been auto-promoted in force mode. The daemon is configured for aggressive autonomous development.
-
-**Promoted to \`loom:issue\` - Ready for Builder.**
-
----
-*Automated by Champion role (force mode)*"
-```
-
-### When NOT to Auto-Promote (Even in Force Mode)
-
-Even in force mode, do NOT auto-promote if:
+Regardless of quality, do NOT promote an issue if:
 - Issue has `loom:blocked` label
-- Issue has `loom:operator-only` label (requires human action outside automation — credentials, infra rotations, manual deploys, hardware access; sweep/shepherd will skip these in pre-flight, so promoting to `loom:issue` would only stall the queue)
+- Issue has `loom:operator-only` label (requires human action outside automation — credentials, infra rotations, manual deploys, hardware access; sweep will skip these in pre-flight, so promoting to `loom:issue` would only stall the queue)
 - Issue title contains "DISCUSSION" or "RFC" (requires human input)
 - Issue mentions breaking changes without migration plan
 - Issue references external dependencies that need coordination

--- a/defaults/.claude/commands/loom/champion-pr-merge.md
+++ b/defaults/.claude/commands/loom/champion-pr-merge.md
@@ -46,7 +46,6 @@ echo "PASS: Label check"
 - [ ] Total lines changed <= configured limit (additions + deletions)
 - [ ] **Default limit**: 200 lines (configurable via `.loom/config.json` `champion.auto_merge_max_lines`)
 - [ ] **`loom:auto-merge-ok` label**: Size limit is waived (applied by Judge or human to signal large PR is safe)
-- [ ] **Force mode**: Size limit is waived
 
 **Verification command**:
 ```bash
@@ -56,37 +55,29 @@ ADDITIONS=$(echo "$PR_DATA" | jq -r '.additions')
 DELETIONS=$(echo "$PR_DATA" | jq -r '.deletions')
 TOTAL=$((ADDITIONS + DELETIONS))
 
-# Check force mode
-FORCE_MODE=$(cat .loom/daemon-state.json 2>/dev/null | jq -r '.force_mode // false')
+# Check for loom:auto-merge-ok label override
+HAS_AUTO_MERGE_OK=$(gh pr view <number> --json labels --jq '[.labels[].name] | any(. == "loom:auto-merge-ok")')
 
-if [ "$FORCE_MODE" = "true" ]; then
-  echo "PASS: Size check waived in force mode ($TOTAL lines)"
+if [ "$HAS_AUTO_MERGE_OK" = "true" ]; then
+  echo "PASS: Size check waived by loom:auto-merge-ok label ($TOTAL lines)"
 else
-  # Check for loom:auto-merge-ok label override
-  HAS_AUTO_MERGE_OK=$(gh pr view <number> --json labels --jq '[.labels[].name] | any(. == "loom:auto-merge-ok")')
+  # Read configurable size limit from .loom/config.json (default: 200)
+  SIZE_LIMIT=$(jq -r '.champion.auto_merge_max_lines // 200' .loom/config.json 2>/dev/null || echo 200)
 
-  if [ "$HAS_AUTO_MERGE_OK" = "true" ]; then
-    echo "PASS: Size check waived by loom:auto-merge-ok label ($TOTAL lines)"
-  else
-    # Read configurable size limit from .loom/config.json (default: 200)
-    SIZE_LIMIT=$(jq -r '.champion.auto_merge_max_lines // 200' .loom/config.json 2>/dev/null || echo 200)
-
-    if [ "$TOTAL" -gt "$SIZE_LIMIT" ]; then
-      echo "FAIL: Too large ($TOTAL lines, limit is $SIZE_LIMIT)"
-      exit 1
-    fi
-    echo "PASS: Size check ($TOTAL lines, limit is $SIZE_LIMIT)"
+  if [ "$TOTAL" -gt "$SIZE_LIMIT" ]; then
+    echo "FAIL: Too large ($TOTAL lines, limit is $SIZE_LIMIT)"
+    exit 1
   fi
+  echo "PASS: Size check ($TOTAL lines, limit is $SIZE_LIMIT)"
 fi
 ```
 
-**Rationale**: Small PRs are easier to revert if problems arise. The size limit is configurable via `.loom/config.json` to allow teams to tune the risk/autonomy tradeoff. The `loom:auto-merge-ok` label provides a per-PR escape hatch for large but safe PRs. In force mode, trust Judge review for all changes.
+**Rationale**: Small PRs are easier to revert if problems arise. The size limit is configurable via `.loom/config.json` to allow teams to tune the risk/autonomy tradeoff. The `loom:auto-merge-ok` label provides a per-PR escape hatch for large but safe PRs.
 
 ### 3. Critical File Exclusion Check
 - [ ] No changes to critical configuration or infrastructure files
-- [ ] **Force mode**: Critical file check is waived (trust Judge review)
 
-**Critical file patterns** (do NOT auto-merge if PR modifies any of these - normal mode only):
+**Critical file patterns** (do NOT auto-merge if PR modifies any of these):
 - `Cargo.toml` - root dependency changes
 - `loom-daemon/Cargo.toml` - daemon dependency changes
 - `loom-api/Cargo.toml` - api dependency changes
@@ -97,41 +88,34 @@ fi
 
 **Verification command**:
 ```bash
-# Check force mode first
-FORCE_MODE=$(cat .loom/daemon-state.json 2>/dev/null | jq -r '.force_mode // false')
+# Get all changed files
+FILES=$(gh pr view <number> --json files --jq -r '.files[].path')
 
-if [ "$FORCE_MODE" = "true" ]; then
-  echo "PASS: Critical file check waived in force mode"
-else
-  # Get all changed files (normal mode)
-  FILES=$(gh pr view <number> --json files --jq -r '.files[].path')
+# Define critical patterns (extend as needed)
+CRITICAL_PATTERNS=(
+  "Cargo.toml"
+  "loom-daemon/Cargo.toml"
+  "loom-api/Cargo.toml"
+  "package.json"
+  ".github/workflows/"
+  ".sql"
+  "migration"
+)
 
-  # Define critical patterns (extend as needed)
-  CRITICAL_PATTERNS=(
-    "Cargo.toml"
-    "loom-daemon/Cargo.toml"
-    "loom-api/Cargo.toml"
-    "package.json"
-    ".github/workflows/"
-    ".sql"
-    "migration"
-  )
-
-  # Check each file against patterns
-  for file in $FILES; do
-    for pattern in "${CRITICAL_PATTERNS[@]}"; do
-      if [[ "$file" == *"$pattern"* ]]; then
-        echo "FAIL: Critical file modified: $file"
-        exit 1
-      fi
-    done
+# Check each file against patterns
+for file in $FILES; do
+  for pattern in "${CRITICAL_PATTERNS[@]}"; do
+    if [[ "$file" == *"$pattern"* ]]; then
+      echo "FAIL: Critical file modified: $file"
+      exit 1
+    fi
   done
+done
 
-  echo "PASS: No critical files modified"
-fi
+echo "PASS: No critical files modified"
 ```
 
-**Rationale**: Changes to these files require careful human review due to high impact. In force mode, trust Judge review for critical file changes.
+**Rationale**: Changes to these files require careful human review due to high impact.
 
 ### 4. Merge Conflict Check
 - [ ] PR is mergeable (no conflicts with base branch)
@@ -158,8 +142,7 @@ echo "PASS: No merge conflicts"
 **Rationale**: Conflicting PRs require human resolution before merging
 
 ### 5. Recency Check
-- [ ] PR updated within last 24 hours (normal mode)
-- [ ] **Force mode**: Extended to 72 hours
+- [ ] PR updated within last 24 hours
 
 **Verification command**:
 ```bash
@@ -176,13 +159,7 @@ NOW_TS=$(date +%s)
 # Calculate hours since update
 HOURS_AGO=$(( (NOW_TS - UPDATED_TS) / 3600 ))
 
-# Check force mode for extended window
-FORCE_MODE=$(cat .loom/daemon-state.json 2>/dev/null | jq -r '.force_mode // false')
-if [ "$FORCE_MODE" = "true" ]; then
-  RECENCY_LIMIT=72
-else
-  RECENCY_LIMIT=24
-fi
+RECENCY_LIMIT=24
 
 # Check if within recency limit
 if [ "$HOURS_AGO" -gt "$RECENCY_LIMIT" ]; then
@@ -193,7 +170,7 @@ fi
 echo "PASS: Recently updated ($HOURS_AGO hours ago)"
 ```
 
-**Rationale**: Ensures PR reflects recent state of main branch and hasn't gone stale. In force mode, allows older PRs to merge since aggressive development may queue up PRs faster than they can be merged.
+**Rationale**: Ensures PR reflects recent state of main branch and hasn't gone stale.
 
 **On failure**: a stale PR is handled by the dedicated stale-PR policy (see "PR Rejection Workflow → Stale PR"), not the transient-failure path — it is commented once (idempotently) and routed out of the queue via `loom:pr` → `loom:changes-requested` so it reaches Doctor rather than being re-commented every cron tick.
 
@@ -447,9 +424,6 @@ ORIGINAL_ISSUE=$2  # The issue this PR closed (may be empty)
 
 echo "Scanning PR #$PR_NUMBER for follow-on work indicators..."
 
-# Check force mode for label selection
-FORCE_MODE=$(cat .loom/daemon-state.json 2>/dev/null | jq -r '.force_mode // false')
-
 # ============================================
 # Stage 1: Extract TODO/FIXME from Diff
 # ============================================
@@ -654,21 +628,15 @@ ISSUE_BODY="${ISSUE_BODY}## Acceptance Criteria
 ---
 *Auto-generated by Champion from PR #$PR_NUMBER*"
 
-# Select label based on force mode
-if [ "$FORCE_MODE" = "true" ]; then
-  ISSUE_LABEL="loom:issue"
-  FORCE_MARKER="[force-mode] "
-else
-  ISSUE_LABEL="loom:curated"
-  FORCE_MARKER=""
-fi
+# Follow-on issues go to the Champion evaluation queue.
+ISSUE_LABEL="loom:curated"
 
 # Create the issue.
 # NOTE: `gh issue create` does NOT support --json/--jq (only `gh issue view`
 # and `gh issue list` do). On success it prints the new issue's URL to stdout
 # (e.g. https://github.com/<owner>/<repo>/issues/<N>); parse the trailing
 # number from that URL.
-ISSUE_TITLE="${FORCE_MARKER}Follow-on: Work identified in PR #$PR_NUMBER"
+ISSUE_TITLE="Follow-on: Work identified in PR #$PR_NUMBER"
 NEW_ISSUE_URL=$(gh issue create \
   --title "$ISSUE_TITLE" \
   --body "$ISSUE_BODY" \
@@ -705,9 +673,7 @@ fi
 | TODOs with review notes | < 3 TODOs, has notes | Skip (too noisy) |
 | Minimal indicators | < 3 TODOs, no sections | Skip |
 
-**Force Mode Behavior**:
-- Normal mode: Create with `loom:curated` (goes to Champion evaluation queue)
-- Force mode: Create with `loom:issue` (goes directly to Builder queue)
+**Follow-on Issue Labeling**: Follow-on issues are created with `loom:curated` (goes to the Champion evaluation queue).
 
 ---
 
@@ -740,7 +706,7 @@ Keeping \`loom:pr\` label. Champion will retry on the next tick once the blockin
 
 ### Stale PR (recency check failed) — comment once, route to Doctor
 
-A stale PR (>24h normal / >72h force mode) will never clear on its own, and under the 10-minute cron a bare "keep the label + comment" loop would re-comment on the same PR **every tick forever**. Instead, **comment once (idempotently)** and **swap `loom:pr` → `loom:changes-requested`** so the PR leaves the auto-merge queue and is picked up by Doctor for a rebase/refresh. This is the single, authoritative stale-PR policy — `champion-reference.md` Edge Case 5 defers to it.
+A stale PR (>24h) will never clear on its own, and under the 10-minute cron a bare "keep the label + comment" loop would re-comment on the same PR **every tick forever**. Instead, **comment once (idempotently)** and **swap `loom:pr` → `loom:changes-requested`** so the PR leaves the auto-merge queue and is picked up by Doctor for a rebase/refresh. This is the single, authoritative stale-PR policy — `champion-reference.md` Edge Case 5 defers to it.
 
 ```bash
 PR_NUMBER=<number>
@@ -754,7 +720,7 @@ else
   gh pr comment "$PR_NUMBER" --body "$STALE_MARKER
 **Champion: PR Is Stale**
 
-This PR has not been updated within the recency window (24h normal / 72h force mode), so it has been routed out of the auto-merge queue for a rebase/refresh.
+This PR has not been updated within the recency window (24h), so it has been routed out of the auto-merge queue for a rebase/refresh.
 
 **Next steps:**
 - Rebase onto the latest \`main\` and resolve any drift
@@ -805,42 +771,6 @@ This PR met all safety criteria but the merge operation failed. A human will nee
 
 ---
 *Automated by Champion role*"
-```
-
----
-
-## Force Mode PR Merging
-
-**In force mode, Champion relaxes PR auto-merge criteria** for aggressive autonomous development:
-
-| Criterion | Normal Mode | Force Mode |
-|-----------|-------------|------------|
-| Size limit | <= configured limit (default 200, see `champion.auto_merge_max_lines` in `.loom/config.json`; waived by `loom:auto-merge-ok` label) | **No limit** (trust Judge review) |
-| Critical files | Block `Cargo.toml`, `package.json`, etc. | **Allow all** (trust Judge review) |
-| Recency | Updated within 24h | Updated within **72h** |
-| CI status | All checks must pass | All checks must pass (unchanged) |
-| Merge conflicts | Block if conflicting | Block if conflicting (unchanged) |
-| Manual override | Respect `loom:manual-merge` | Respect `loom:manual-merge` (unchanged) |
-
-**Rationale**: In force mode, the Judge has already reviewed the PR. Champion's role is to merge quickly, not to second-guess the review. Essential safety checks (CI, conflicts, manual override) remain.
-
-**Force mode PR merge comment**:
-```bash
-gh pr comment "$PR_NUMBER" --body "$(cat <<EOF
-**[force-mode] Champion Auto-Merge**
-
-This PR has been auto-merged in force mode. Relaxed criteria:
-- Size limit: waived (was $TOTAL_LINES lines)
-- Critical files: waived
-- Trust: Judge review + passing CI
-
-**Merged via squash.** If this was merged in error:
-\`git revert <commit-sha>\`
-
----
-*Automated by Champion role (force mode)*
-EOF
-)"
 ```
 
 ---

--- a/defaults/.claude/commands/loom/champion-reference.md
+++ b/defaults/.claude/commands/loom/champion-reference.md
@@ -279,9 +279,7 @@ gh issue create --title "Follow-on: Work identified in PR #$PR_NUMBER" --label "
 | Standard TODOs | 3+ | Create consolidated |
 | Below threshold | < 3 TODOs, no sections | Skip |
 
-**Force Mode Behavior**:
-- Normal mode: Create with `loom:curated` label (goes to Champion evaluation)
-- Force mode: Create with `loom:issue` label (goes directly to Builder queue)
+**Follow-on Issue Labeling**: Follow-on issues are created with the `loom:curated` label (goes to Champion evaluation).
 
 **Edge Cases Within Follow-on**:
 
@@ -289,7 +287,6 @@ gh issue create --title "Follow-on: Work identified in PR #$PR_NUMBER" --label "
 2. **TODO without colon**: Pattern requires `TODO:` not just `TODO` to avoid false positives
 3. **Multi-line TODOs**: Only first line captured, truncated at 200 chars
 4. **Duplicate follow-on issue exists**: Search before creation, skip if found
-5. **Force mode with no daemon state file**: Fall back to `loom:curated` label
 
 ---
 
@@ -356,9 +353,6 @@ gh pr view <number> --json state,mergeable,statusCheckRollup
 
 # View linked issues (uses GitHub's authoritative parser; `Updates #N` is excluded)
 gh pr view <number> --json closingIssuesReferences --jq '.closingIssuesReferences[].number'
-
-# Check daemon state
-cat .loom/daemon-state.json | jq '.force_mode'
 
 # List blocked issues
 gh issue list --label "loom:blocked" --state open

--- a/defaults/.claude/commands/loom/champion.md
+++ b/defaults/.claude/commands/loom/champion.md
@@ -100,127 +100,6 @@ If no queues have work, report "No work for Champion" and stop.
 
 ---
 
-## Force Mode (Aggressive Autonomous Development)
-
-When the Loom daemon is running with `--merge` flag, Champion operates in **force mode** for aggressive autonomous development. This mode auto-promotes all qualifying proposals without applying the full 8-criterion evaluation.
-
-### Detecting Force Mode
-
-Check for force mode at the start of each iteration:
-
-```bash
-# Check daemon state for force mode
-FORCE_MODE=$(cat .loom/daemon-state.json 2>/dev/null | jq -r '.force_mode // false')
-
-if [ "$FORCE_MODE" = "true" ]; then
-    echo "FORCE MODE ACTIVE - Auto-promoting qualifying proposals"
-fi
-```
-
-### Force Mode Behavior
-
-**When force mode is enabled:**
-
-1. **Auto-Promote Architect Proposals**: Promote all `loom:architect` issues that have:
-   - A clear title (not vague like "Improve things")
-   - At least one acceptance criterion
-   - No `loom:blocked` label
-
-2. **Auto-Promote Hermit Proposals**: Promote all `loom:hermit` issues that have:
-   - A specific simplification target (file, module, or pattern)
-   - At least one concrete removal action
-   - No `loom:blocked` label
-
-3. **Auto-Promote Auditor Bug Reports**: Promote all `loom:auditor` issues that have:
-   - A clear bug description
-   - Reproduction steps
-   - No `loom:blocked` label
-
-4. **Auto-Promote Curated Issues**: Promote all `loom:curated` issues that have:
-   - A problem statement
-   - At least one acceptance criterion
-   - No `loom:blocked` label
-
-5. **Audit Trail**: Add `[force-mode]` prefix to all promotion comments
-
-### Force Mode Promotion Workflow
-
-```bash
-# Check for force mode
-FORCE_MODE=$(cat .loom/daemon-state.json 2>/dev/null | jq -r '.force_mode // false')
-
-if [ "$FORCE_MODE" = "true" ]; then
-    # Auto-promote architect proposals
-    ARCHITECT_ISSUES=$(gh issue list --label="loom:architect" --state=open --json number --jq '.[].number')
-    for issue in $ARCHITECT_ISSUES; do
-        # Minimal validation - just check it's not blocked
-        IS_BLOCKED=$(gh issue view "$issue" --json labels --jq '[.labels[].name] | contains(["loom:blocked"])')
-        if [ "$IS_BLOCKED" = "false" ]; then
-            gh issue edit "$issue" --remove-label "loom:architect" --add-label "loom:issue"
-            gh issue comment "$issue" --body "**[force-mode] Champion Auto-Promote**
-
-This proposal has been auto-promoted in force mode. The daemon is configured for aggressive autonomous development.
-
-**Promoted to \`loom:issue\` - Ready for Builder.**
-
----
-*Automated by Champion role (force mode)*"
-
-            # Track in daemon state
-            jq --arg issue "$issue" --arg type "architect" --arg time "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-                '.force_mode_auto_promotions += [{"issue": ($issue|tonumber), "type": $type, "time": $time}]' \
-                .loom/daemon-state.json > tmp.json && mv tmp.json .loom/daemon-state.json
-        fi
-    done
-
-    # Repeat for hermit, auditor, and curated issues...
-fi
-```
-
-### When NOT to Auto-Promote (Even in Force Mode)
-
-Even in force mode, do NOT auto-promote if:
-
-- Issue has `loom:blocked` label
-- Issue title contains "DISCUSSION" or "RFC" (requires human input)
-- Issue mentions breaking changes without migration plan
-- Issue references external dependencies that need coordination
-
-### Force Mode Safety Guardrails
-
-Force mode still respects these boundaries:
-
-| Guardrail | Behavior |
-|-----------|----------|
-| `loom:blocked` | Never promote blocked issues |
-| Critical file changes | Still flagged in PR review (Judge) |
-| CI failures | PRs still blocked on failing CI |
-| Merge conflicts | Still require Doctor intervention |
-
-### Force Mode PR Merging
-
-**In force mode, Champion also relaxes PR auto-merge criteria** for aggressive autonomous development:
-
-| Criterion | Normal Mode | Force Mode |
-|-----------|-------------|------------|
-| Size limit | <= configured limit (default 200, see `champion.auto_merge_max_lines` in `.loom/config.json`; waived by `loom:auto-merge-ok` label) | **No limit** (trust Judge review) |
-| Critical files | Block `Cargo.toml`, `package.json`, etc. | **Allow all** (trust Judge review) |
-| Recency | Updated within 24h | Updated within **72h** |
-| CI status | All checks must pass | All checks must pass (unchanged) |
-| Merge conflicts | Block if conflicting | Block if conflicting (unchanged) |
-| Manual override | Respect `loom:manual-merge` | Respect `loom:manual-merge` (unchanged) |
-
-**Rationale**: In force mode, the Judge has already reviewed the PR. Champion's role is to merge quickly, not to second-guess the review. Essential safety checks (CI, conflicts, manual override) remain.
-
-### Exiting Force Mode
-
-Force mode can be disabled by:
-1. Stopping daemon and restarting without `--merge`
-2. Manually updating daemon state: `jq '.force_mode = false' .loom/daemon-state.json`
-3. Creating `.loom/stop-force-mode` file (daemon will detect and disable)
-
----
-
 ## Follow-on Issue Creation
 
 After successfully merging a PR (Step 5.5 of the auto-merge workflow), Champion scans for follow-on work indicators and creates consolidated issues to track future work.
@@ -242,10 +121,9 @@ Follow-on issues are only created when meaningful work is identified:
 | Standard TODOs (TODO, FUTURE) | 3+ | Create consolidated issue |
 | Below threshold | < 3 TODOs, no sections | Skip (avoid noise) |
 
-### Force Mode Behavior
+### Follow-on Issue Labeling
 
-- **Normal mode**: Follow-on issues created with `loom:curated` label (returns to Champion for evaluation)
-- **Force mode**: Follow-on issues created with `loom:issue` label (goes directly to Builder queue)
+Follow-on issues are created with the `loom:curated` label (returns to Champion for evaluation).
 
 ### Duplicate Prevention
 


### PR DESCRIPTION
Closes #3782

## Summary

Deletes the permanently-inert Champion **force-mode** subsystem and reconciles the stale **batch-cap** contradiction across the Champion prompt file set. Force mode read `.loom/daemon-state.json::force_mode`, which has had no writer since the Python daemon brain was deleted (epic #3372 / v0.10.0). Every `FORCE_MODE=$(cat .loom/daemon-state.json …)` check reads a missing file and degrades to `"false"`, so the `if [ "$FORCE_MODE" = "true" ]` branch never fires. Per the 2026-07-22 operator decision, force/merge mode is deleted outright (not re-keyed to a config flag) — Champion now has a single, always-auto-merge mode.

## Changes per file

- **`champion.md`** — removed the entire `## Force Mode (Aggressive Autonomous Development)` section (detection, promotion workflow, safety-guardrail table, force-mode PR-merge criteria table, exit instructions) and converted the Follow-on `### Force Mode Behavior` bullet pair to a single `### Follow-on Issue Labeling` statement (`loom:curated`).
- **`champion-pr-merge.md`** — removed the per-criterion `FORCE_MODE` branches in the Size, Critical-File, and Recency checks (dedented the surviving normal-mode logic); removed the follow-on label-selection force branch (`ISSUE_LABEL="loom:curated"` unconditionally, dropped the `[force-mode]` title marker); removed the standalone `## Force Mode PR Merging` section; and stripped `force mode` wording from the stale-PR policy (24h window only).
- **`champion-issue-promo.md`** — removed the `## Force Mode Issue Promotion` section. Its always-on guardrails (`loom:blocked`, `loom:operator-only`, DISCUSSION/RFC, breaking-changes-without-migration, external-dependency coordination) are **preserved** as a new `### When NOT to Promote` block folded into the normal batch-processing flow (per AC #2).
- **`champion-epic.md`** — removed the `## Force Mode Epic Behavior` section (the 1-epic-per-iteration limit is untouched).
- **`champion-reference.md`** — removed the force-mode follow-on bullet pair, edge case 5 `Force mode with no daemon state file`, and the `cat .loom/daemon-state.json | jq '.force_mode'` debugging snippet (deleted, not reworded).
- **`champion-common.md`** — replaced the `max 3` / `max 2` completion-report caps and the `Evaluate up to 3 PRs / up to 2 issues` autonomous-behavior caps with drain-the-queue language pointing at the real throttles.
- **`defaults/.claude/agents/loom-champion.md`** — replaced `Max 3 merges per iteration` / `Max 2 promotions per iteration` with drain-the-queue pointers to `champion-pr-merge.md`, the tier limits in `champion-issue-promo.md`, and the 1-epic limit in `champion-epic.md`.

**Surviving throttles (intended):** the tier-based promotion limits in `champion-issue-promo.md` (Tier 1 unlimited / Tier 2 ≤2 / Tier 3 ≤1, gated at 5 backlog) and the 1-epic-per-iteration limit in `champion-epic.md`. PR merging has no numeric cap.

## Scope

Doc/prompt-file only. No changes to `loom-daemon/` source, `.loom/config.json` schema, `champion.auto_merge_max_lines`, `loom.md` (companion issue), or any `daemon-state.json` producer/consumer. `defaults/roles/champion.md` is a symlink to `defaults/.claude/commands/loom/champion.md` — edited through the canonical path, so it carries the change with no separate diff.

## Verification

- `grep -rn "daemon-state.json\|FORCE_MODE\|force[- _]mode" defaults/.claude/commands/loom/champion*.md defaults/.claude/agents/loom-champion.md` → **no matches**.
- `grep -rn -- "--merge"` and `grep -rni "aggressive autonomous"` across the set → **no matches**.
- Remaining case-insensitive `force` matches are only legitimate git **force-push** edge-case references (Edge Case 3 in `champion-reference.md`).
- Remaining `up to 2` matches are the intended Tier 2 promotion limits.
- No markdown-lint config exists in the repo; verification is grep + read-through per the issue's implementation guidance. Section transitions re-read clean after each deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)