### PR TITLE
fix(merge-pr): proactively degrade --auto when repo has auto-merge disabled (#3820)

### DIFF
--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -1159,7 +1159,7 @@ Use the dedicated merge script (CLAUDE.md "Merging PRs" mandate — never `gh pr
 ./.loom/scripts/merge-pr.sh P --auto
 ```
 
-The script merges via the forge API and cleans up the worktree. `--auto` enables GitHub's server-side auto-merge queue (queues the merge until required checks pass); on PRs that are already in `CLEAN` state, the script transparently falls back to an immediate merge — see #3371.
+The script merges via the forge API and cleans up the worktree. `--auto` enables GitHub's server-side auto-merge queue (queues the merge until required checks pass); on PRs that are already in `CLEAN` state, the script transparently falls back to an immediate merge — see #3371. **On a repo with GitHub auto-merge disabled** (`allow_auto_merge:false`), `merge-pr.sh` now detects the setting up front and degrades `--auto` gracefully to wait-for-checks-then-merge (immediate if already CLEAN) instead of failing (#3820) — so you can pass `--auto` uniformly regardless of the repo's auto-merge setting; no per-repo branching is needed here.
 
 **On successful merge** (script returns 0):
 - If a closing-issue checkpoint is in scope, delete it:
@@ -1550,7 +1550,7 @@ Use the dedicated merge script (CLAUDE.md "Merging PRs" mandate — never `gh pr
 ./.loom/scripts/merge-pr.sh <PR_NUMBER> --auto
 ```
 
-The script merges via the forge API and cleans up the worktree. `--auto` enables GitHub's server-side auto-merge queue (queues the merge until required checks pass); on PRs that are already in `CLEAN` state (fast CI), the script transparently falls back to an immediate merge — see #3371.
+The script merges via the forge API and cleans up the worktree. `--auto` enables GitHub's server-side auto-merge queue (queues the merge until required checks pass); on PRs that are already in `CLEAN` state (fast CI), the script transparently falls back to an immediate merge — see #3371. **On a repo with GitHub auto-merge disabled** (`allow_auto_merge:false`), `merge-pr.sh` now detects the setting up front and degrades `--auto` gracefully to wait-for-checks-then-merge (immediate if already CLEAN) instead of failing (#3820) — so `--auto` is safe to pass uniformly here regardless of the repo's auto-merge setting; no per-repo branching is needed.
 
 **If a previous Merge attempt for this PR died mid-flight without deleting the checkpoint** (rate limit, crash between `merge-pr.sh` success and the delete call), re-verify forge state first: if the PR is already **merged**, just delete the stale checkpoint — do **not** re-run the merge. See "Mid-phase-death recovery" above. (The step 1 stale-checkpoint cleanup is the belt-and-suspenders backstop for this.)
 

--- a/defaults/scripts/lib/forge-helpers.sh
+++ b/defaults/scripts/lib/forge-helpers.sh
@@ -357,6 +357,41 @@ forge_check_auto_delete() {
   fi
 }
 
+# Check whether the repository has GitHub's "Allow auto-merge" setting enabled.
+# Usage: forge_check_auto_merge_allowed NWO [GH_CMD]
+# Returns on stdout: "true", "false", or "unknown".
+#
+# GitHub only: reads the repo-level `allow_auto_merge` flag. When it is false,
+# GitHub rejects the enablePullRequestAutoMerge mutation outright — no PR-level
+# state (CLEAN/UNSTABLE) will ever let it succeed — so callers that want to
+# degrade gracefully (wait-for-checks-then-merge) can detect it up front rather
+# than reacting to the post-mutation error string (#3820).
+#
+# Gitea returns "unknown" (there is no equivalent single repo flag consumed
+# here; Gitea auto-merge goes through loom-auto-merge's own poll-and-merge, which
+# this probe must not perturb). A probe failure (network/auth/unexpected value)
+# also returns "unknown" so callers preserve their existing behavior fail-safe.
+forge_check_auto_merge_allowed() {
+  local nwo="$1"
+  local gh_cmd="${2:-gh}"
+
+  if [[ "$FORGE_TYPE" != "github" ]]; then
+    echo "unknown"
+    return 0
+  fi
+
+  local val
+  val="$("$gh_cmd" api "repos/$nwo" --jq '.allow_auto_merge' 2>/dev/null)" || {
+    echo "unknown"
+    return 0
+  }
+  case "$val" in
+    true)  echo "true" ;;
+    false) echo "false" ;;
+    *)     echo "unknown" ;;
+  esac
+}
+
 # Delete a remote branch.
 # Usage: forge_delete_branch NWO BRANCH_NAME
 # GitHub: DELETE /repos/{nwo}/git/refs/heads/{branch}

--- a/defaults/scripts/merge-pr.sh
+++ b/defaults/scripts/merge-pr.sh
@@ -17,7 +17,11 @@
 #                          branch via `git branch -d` (refuses on unmerged
 #                          commits — Git's own safety check).
 #   --dry-run              Show what would happen without merging
-#   --auto                 Enable auto-merge instead of immediate merge
+#   --auto                 Enable auto-merge instead of immediate merge. On a
+#                          repo with GitHub auto-merge disabled
+#                          (allow_auto_merge:false) this degrades gracefully to
+#                          wait-for-checks-then-merge (immediate if CLEAN)
+#                          instead of failing (#3820).
 #   --allow-stacked-children
 #                          Bypass the pre-merge merge-ordering guard when the
 #                          parent branch (feature/issue-N) still has open
@@ -81,7 +85,11 @@ Options:
                          the matching local branch via 'git branch -d'
                          (Git refuses on unmerged commits).
   --dry-run              Show what would happen without merging
-  --auto                 Enable auto-merge instead of immediate merge
+  --auto                 Enable auto-merge instead of immediate merge. When the
+                         repository has GitHub auto-merge disabled
+                         (allow_auto_merge:false), this is detected up front and
+                         degrades gracefully to wait-for-checks-then-merge
+                         (immediate if already CLEAN) rather than failing (#3820).
   --allow-stacked-children
                          Bypass the pre-merge merge-ordering guard. That guard
                          hard-blocks merging a stacked PARENT PR (branch
@@ -136,7 +144,8 @@ Examples:
     Shows what would happen without merging
 
   ./.loom/scripts/merge-pr.sh 123 --auto
-    Enables auto-merge instead of merging immediately
+    Enables auto-merge instead of merging immediately (on a repo with
+    auto-merge disabled, waits for checks then merges synchronously)
 
   ./.loom/scripts/merge-pr.sh 123 --no-cleanup-worktree
     Merges PR but leaves the local worktree in place
@@ -630,6 +639,130 @@ _auto_reconcile_stacked_children() {
   return 0
 }
 
+# ---------------------------------------------------------------------------
+# Repo-level "Allow auto-merge" disabled — proactive wait-then-merge (#3820).
+#
+# When the repository's GitHub "Allow auto-merge" setting is OFF
+# (`gh api repos/{nwo} --jq .allow_auto_merge` == false), the server-side
+# auto-merge queue can NEVER be enabled — enablePullRequestAutoMerge is rejected
+# regardless of PR state. The reactive #3763 fallback catches that post-mutation
+# rejection, but only degrades gracefully when the PR is ALREADY immediately
+# mergeable; when auto-merge is disabled AND the PR is not yet CLEAN (checks
+# still running / .mergeable not yet computed), #3763's mergeability recheck sees
+# `.mergeable != true` and preserves the terminal error, so the PR never merges
+# (the reported failure on a repo with allow_auto_merge:false).
+#
+# This function is entered PROACTIVELY from the repo-setting probe below (so we
+# never attempt the doomed mutation at all) and degrades `--auto` to
+# "wait-for-checks-then-merge, or immediate merge if already CLEAN": it polls the
+# head-SHA check-runs (bounded by LOOM_AUTO_MERGE_TIMEOUT, same knobs as the
+# UNSTABLE fallback) until they settle, then returns 0 so the caller flips to the
+# synchronous-merge path. Unlike the UNSTABLE branch it also handles the
+# already-CLEAN case (nothing failing, nothing pending) by returning 0 for an
+# immediate merge rather than hitting that branch's defensive "unknown gap" error.
+#
+# Contract:
+#   - returns 0  → safe to proceed to the synchronous-merge path (caller flips
+#                  AUTO_MERGE=false). Also returned if the PR merged concurrently
+#                  while waiting (the synchronous path's own race-detection then
+#                  no-ops cleanly).
+#   - calls error() (exit 1) → a required status check failed, or the wait timed
+#                  out. A normal recoverable failure Champion's cron retries.
+# GitHub-only by construction (only invoked when the GitHub-only probe returns
+# "false"). Requires LOOM_AUTO_MERGE_POLL_INTERVAL / LOOM_AUTO_MERGE_TIMEOUT set.
+_wait_for_checks_then_sync_merge() {
+  local head_sha base_ref
+  head_sha="$(echo "$PR_JSON" | jq -r '.head.sha // empty')"
+  base_ref="$(echo "$PR_JSON" | jq -r '.base.ref // empty')"
+
+  # Without the head SHA we cannot reason about checks — proceed to the
+  # synchronous merge, which will itself reject if a required check blocks it.
+  if [[ -z "$head_sha" ]]; then
+    info "PR #$PR_NUMBER: head SHA unavailable; proceeding directly to synchronous merge"
+    return 0
+  fi
+
+  local deadline
+  deadline=$(( $(date +%s) + LOOM_AUTO_MERGE_TIMEOUT ))
+
+  while true; do
+    # A concurrent merger may have completed the PR while we waited.
+    local recheck_json
+    recheck_json="$(forge_get_pr_nocache "$REPO_NWO" "$PR_NUMBER" "$GH" 2>/dev/null || echo '{}')"
+    if [[ "$(echo "$recheck_json" | jq -r '.merged // false')" == "true" ]]; then
+      warning "PR #$PR_NUMBER merged by another process while waiting for checks"
+      return 0
+    fi
+
+    # Fetch the check-runs rollup for the head SHA. Retry once to absorb a blip,
+    # then treat a persistent fetch failure as still-pending (bounded wait),
+    # mirroring the UNSTABLE fallback's #3678 discipline.
+    local fetch_rc=0 runs_raw
+    runs_raw="$(forge_get_check_runs "$REPO_NWO" "$head_sha" 2>/dev/null)" || fetch_rc=$?
+    if [[ "$fetch_rc" -ne 0 ]]; then
+      fetch_rc=0
+      runs_raw="$(forge_get_check_runs "$REPO_NWO" "$head_sha" 2>/dev/null)" || fetch_rc=$?
+    fi
+    if [[ "$fetch_rc" -ne 0 ]]; then
+      if [[ "$(date +%s)" -ge "$deadline" ]]; then
+        error "Timed out after ${LOOM_AUTO_MERGE_TIMEOUT}s waiting for check-runs to become fetchable for PR #$PR_NUMBER (repo has auto-merge disabled). Re-run once the forge API is healthy, or raise LOOM_AUTO_MERGE_TIMEOUT."
+      fi
+      warning "Failed to fetch check-runs for PR #$PR_NUMBER (rc=$fetch_rc); treating as still-pending and continuing to poll"
+      sleep "$LOOM_AUTO_MERGE_POLL_INTERVAL"
+      continue
+    fi
+
+    # Failing (terminal non-success) and pending (not yet completed) check names.
+    local failing pending
+    failing="$(echo "$runs_raw" | \
+      jq -r '[.check_runs[] | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "cancelled" or .conclusion == "action_required") | .name] | unique | .[]' 2>/dev/null || true)"
+    pending="$(echo "$runs_raw" | \
+      jq -r '[.check_runs[] | select(.status != "completed") | .name] | unique | .[]' 2>/dev/null || true)"
+
+    if [[ -n "$failing" ]]; then
+      # A check failed — classify against branch protection. A required failing
+      # check can never merge on this SHA; refuse now. A lookup failure fails
+      # closed (refuse), mirroring the UNSTABLE fallback.
+      local required lookup_rc=0
+      required="$(forge_get_required_status_check_contexts "$REPO_NWO" "$base_ref" "$GH" 2>/dev/null)" || lookup_rc=$?
+      if [[ "$lookup_rc" -ne 0 ]]; then
+        error "Failed to resolve required status checks for $base_ref (rc=$lookup_rc); refusing to merge PR #$PR_NUMBER with failing check(s) while auto-merge is disabled"
+      fi
+      local overlap
+      overlap="$(comm -12 \
+        <(printf '%s\n' "$failing" | sort -u) \
+        <(printf '%s\n' "$required" | sort -u))"
+      if [[ -n "$overlap" ]]; then
+        error "Cannot merge PR #$PR_NUMBER: a required status check has failed ($(printf '%s' "$overlap" | tr '\n' ' ')). Fix the check and re-run the merge."
+      fi
+      if [[ -z "$pending" ]]; then
+        # Only informational (non-required) checks failing and nothing pending →
+        # a synchronous merge is safe (matches the UNSTABLE #3486 fallback).
+        info "PR #$PR_NUMBER: only informational (non-required) check(s) failing; proceeding to synchronous merge"
+        return 0
+      fi
+      # Informational failures but other checks still running — fall through to
+      # the pending wait below.
+    fi
+
+    if [[ -n "$pending" ]]; then
+      if [[ "$(date +%s)" -ge "$deadline" ]]; then
+        local n; n="$(printf '%s\n' "$pending" | wc -l | tr -d ' ')"
+        error "Timed out after ${LOOM_AUTO_MERGE_TIMEOUT}s waiting for ${n} pending check(s) on PR #$PR_NUMBER to complete (repo has auto-merge disabled). Re-run once CI settles, or raise LOOM_AUTO_MERGE_TIMEOUT."
+      fi
+      local n; n="$(printf '%s\n' "$pending" | wc -l | tr -d ' ')"
+      info "PR #$PR_NUMBER: ${n} check(s) still running (repo auto-merge disabled); waiting ${LOOM_AUTO_MERGE_POLL_INTERVAL}s for CI (timeout ${LOOM_AUTO_MERGE_TIMEOUT}s)..."
+      sleep "$LOOM_AUTO_MERGE_POLL_INTERVAL"
+      continue
+    fi
+
+    # Nothing failing (or only informational), nothing pending → effectively
+    # CLEAN. Proceed to the synchronous merge.
+    info "PR #$PR_NUMBER: checks settled (repo auto-merge disabled); proceeding to synchronous merge"
+    return 0
+  done
+}
+
 # Handle auto-merge mode
 #
 # The auto-merge path now mirrors the sync path's resilience patterns:
@@ -643,8 +776,27 @@ _auto_reconcile_stacked_children() {
 #
 # See issue #3279.
 if [[ "$AUTO_MERGE" == "true" ]]; then
+  # Bounded poll window for the UNSTABLE-because-checks-are-still-running case
+  # (#3664). Reuses the same env-var names/semantics as the Gitea auto-merge
+  # poller (loom-tools/src/loom_tools/auto_merge.py) so both forges share
+  # configuration. Defaults match that CLI: 30s interval, 600s ceiling.
+  # (Also consumed by the #3820 auto-merge-disabled wait path below.)
+  LOOM_AUTO_MERGE_POLL_INTERVAL="${LOOM_AUTO_MERGE_POLL_INTERVAL:-30}"
+  LOOM_AUTO_MERGE_TIMEOUT="${LOOM_AUTO_MERGE_TIMEOUT:-600}"
+
+  # Proactive repo-level "Allow auto-merge" probe (#3820). Read the setting once
+  # (GitHub only; Gitea and any probe failure return "unknown", preserving
+  # existing behavior fail-safe). When it is explicitly disabled, the server-side
+  # auto-merge queue can never be enabled, so skip the doomed mutation entirely
+  # and degrade `--auto` to wait-for-checks-then-merge (immediate if CLEAN).
+  REPO_AUTO_MERGE_ALLOWED="$(forge_check_auto_merge_allowed "$REPO_NWO" "$GH" 2>/dev/null || echo unknown)"
+
   if [[ "$DRY_RUN" == "true" ]]; then
-    info "[dry-run] Would enable auto-merge for PR #$PR_NUMBER"
+    if [[ "$REPO_AUTO_MERGE_ALLOWED" == "false" ]]; then
+      info "[dry-run] Repository 'Allow auto-merge' is disabled; would wait for checks then merge PR #$PR_NUMBER synchronously (immediate if already CLEAN)"
+    else
+      info "[dry-run] Would enable auto-merge for PR #$PR_NUMBER"
+    fi
     exit 0
   fi
 
@@ -652,14 +804,22 @@ if [[ "$AUTO_MERGE" == "true" ]]; then
   MERGE_RETRY_DELAY=5
   AUTO_MERGE_OK=false
 
-  # Bounded poll window for the UNSTABLE-because-checks-are-still-running case
-  # (#3664). Reuses the same env-var names/semantics as the Gitea auto-merge
-  # poller (loom-tools/src/loom_tools/auto_merge.py) so both forges share
-  # configuration. Defaults match that CLI: 30s interval, 600s ceiling.
-  LOOM_AUTO_MERGE_POLL_INTERVAL="${LOOM_AUTO_MERGE_POLL_INTERVAL:-30}"
-  LOOM_AUTO_MERGE_TIMEOUT="${LOOM_AUTO_MERGE_TIMEOUT:-600}"
+  # #3820: repo has auto-merge disabled → wait for checks, then fall through to
+  # the synchronous-merge path instead of attempting the enable mutation. The
+  # wait function either returns 0 (proceed) or error()s out terminally. Setting
+  # AUTO_MERGE_OK=true lets the post-loop "after N attempts" guard pass; the loop
+  # itself is short-circuited by the AUTO_MERGE guard on its first iteration.
+  if [[ "$REPO_AUTO_MERGE_ALLOWED" == "false" ]]; then
+    info "PR #$PR_NUMBER: repository 'Allow auto-merge' is disabled; --auto will wait for checks then merge synchronously (immediate if already CLEAN)"
+    _wait_for_checks_then_sync_merge
+    AUTO_MERGE=false
+    AUTO_MERGE_OK=true
+  fi
 
   for MERGE_ATTEMPT in $(seq 1 $MAX_MERGE_RETRIES); do
+    # #3820: when the repo-level probe already converted --auto to a synchronous
+    # merge (AUTO_MERGE flipped false above), do NOT attempt the enable mutation.
+    [[ "$AUTO_MERGE" == "true" ]] || break
     AUTO_MERGE_OUTPUT=""
     # Prefer loom-auto-merge CLI (forge-agnostic, with poll-and-merge for Gitea)
     if command -v loom-auto-merge &>/dev/null; then

--- a/defaults/scripts/tests/test-merge-pr-auto-merge-disabled-fallback.sh
+++ b/defaults/scripts/tests/test-merge-pr-auto-merge-disabled-fallback.sh
@@ -250,6 +250,117 @@ else
     echo -e "  ${RED}FAIL${NC}: #3763 fallback must precede the clean/unstable greps (amd=$_amd_line clean=$_clean_line)"
 fi
 
+# ===========================================================================
+# #3820: PROACTIVE repo-level "Allow auto-merge" probe + wait-then-merge.
+#
+# The reactive #3763 fallback above only degrades gracefully when the PR is
+# ALREADY immediately mergeable. When a repo has auto-merge disabled AND the PR
+# is not yet CLEAN (checks still running / .mergeable not yet computed), #3763
+# preserves the terminal error and the PR never merges. #3820 detects the repo
+# setting up front (gh api repos/{nwo} --jq .allow_auto_merge) and, when
+# disabled, converts --auto into wait-for-checks-then-merge (immediate if CLEAN).
+# ===========================================================================
+FORGE_HELPERS_SRC="$HELPERS_DIR/lib/forge-helpers.sh"
+
+echo ""
+echo "Testing the #3820 forge_check_auto_merge_allowed probe helper..."
+
+# Source the helper library so we can exercise forge_check_auto_merge_allowed
+# directly with a stubbed gh command (no network).
+# shellcheck source=/dev/null
+source "$FORGE_HELPERS_SRC"
+
+# GitHub + setting disabled -> "false".
+FORGE_TYPE="github"
+_stub_gh_false() { echo "false"; }
+assert_eq "false" "$(forge_check_auto_merge_allowed owner/repo _stub_gh_false)" \
+  "#3820: GitHub repo with allow_auto_merge:false -> 'false'"
+
+# GitHub + setting enabled -> "true".
+_stub_gh_true() { echo "true"; }
+assert_eq "true" "$(forge_check_auto_merge_allowed owner/repo _stub_gh_true)" \
+  "#3820: GitHub repo with allow_auto_merge:true -> 'true'"
+
+# GitHub + probe failure (nonzero exit) -> "unknown" (fail-safe).
+_stub_gh_fail() { return 1; }
+assert_eq "unknown" "$(forge_check_auto_merge_allowed owner/repo _stub_gh_fail)" \
+  "#3820: GitHub probe failure -> 'unknown' (preserve existing behavior)"
+
+# GitHub + unexpected value (e.g. null) -> "unknown".
+_stub_gh_null() { echo "null"; }
+assert_eq "unknown" "$(forge_check_auto_merge_allowed owner/repo _stub_gh_null)" \
+  "#3820: GitHub probe returns non-boolean -> 'unknown'"
+
+# Gitea -> "unknown" (probe is GitHub-only; Gitea behavior preserved).
+FORGE_TYPE="gitea"
+assert_eq "unknown" "$(forge_check_auto_merge_allowed owner/repo _stub_gh_true)" \
+  "#3820: Gitea repo -> 'unknown' (probe scoped to GitHub, Gitea unperturbed)"
+# FORGE_TYPE is read by the sourced forge-helpers.sh functions (dynamic use).
+# shellcheck disable=SC2034
+FORGE_TYPE="github"
+
+# --- Assert merge-pr.sh source wires the #3820 proactive path ---
+echo ""
+echo "Testing merge-pr.sh source wiring (#3820)..."
+
+if grep -q 'REPO_AUTO_MERGE_ALLOWED="\$(forge_check_auto_merge_allowed' "$MERGE_PR_SRC"; then
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: merge-pr.sh probes the repo setting via forge_check_auto_merge_allowed"
+else
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: merge-pr.sh missing the #3820 forge_check_auto_merge_allowed probe"
+fi
+
+# The probe result must gate a conversion to the synchronous-merge wait path.
+if grep -q '\[\[ "\$REPO_AUTO_MERGE_ALLOWED" == "false" \]\]' "$MERGE_PR_SRC"; then
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: merge-pr.sh branches on REPO_AUTO_MERGE_ALLOWED == false"
+else
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: merge-pr.sh missing the disabled-repo branch (#3820)"
+fi
+
+if grep -q '_wait_for_checks_then_sync_merge' "$MERGE_PR_SRC"; then
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: merge-pr.sh defines/invokes _wait_for_checks_then_sync_merge (#3820)"
+else
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: merge-pr.sh missing _wait_for_checks_then_sync_merge (#3820)"
+fi
+
+# The retry loop must be short-circuited on its first iteration when the probe
+# already flipped AUTO_MERGE=false — otherwise it would attempt the doomed
+# enablePullRequestAutoMerge mutation.
+if grep -q '\[\[ "\$AUTO_MERGE" == "true" \]\] || break' "$MERGE_PR_SRC"; then
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: retry loop breaks immediately when --auto was converted to synchronous merge"
+else
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: merge-pr.sh missing the AUTO_MERGE loop guard (#3820)"
+fi
+
+# The disabled-repo branch must set AUTO_MERGE_OK=true so the post-loop
+# "after N attempts" guard passes when the loop is short-circuited.
+_amd3820_block="$(awk '/#3820: repo has auto-merge disabled/{f=1} f; /for MERGE_ATTEMPT in/{exit}' "$MERGE_PR_SRC")"
+if echo "$_amd3820_block" | grep -q 'AUTO_MERGE=false' && echo "$_amd3820_block" | grep -q 'AUTO_MERGE_OK=true'; then
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: #3820 branch flips AUTO_MERGE=false / AUTO_MERGE_OK=true"
+else
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: #3820 branch must set AUTO_MERGE=false and AUTO_MERGE_OK=true"
+fi
+
+# The probe helper must be GitHub-scoped (guard on FORGE_TYPE) so Gitea is
+# unperturbed.
+if grep -q 'forge_check_auto_merge_allowed()' "$FORGE_HELPERS_SRC" && \
+   awk '/forge_check_auto_merge_allowed\(\)/{f=1} f && /FORGE_TYPE" != "github"/{print; exit}' "$FORGE_HELPERS_SRC" | grep -q github; then
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: forge_check_auto_merge_allowed is GitHub-scoped (Gitea returns 'unknown')"
+else
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: forge_check_auto_merge_allowed must guard on FORGE_TYPE == github"
+fi
+
 # --- Summary ---
 echo ""
 echo "────────────────────────────────"

--- a/defaults/scripts/tests/test-merge-pr-auto-reconcile.sh
+++ b/defaults/scripts/tests/test-merge-pr-auto-reconcile.sh
@@ -61,7 +61,10 @@ assert_eq() {
 assert_contains() {
     local haystack="$1" needle="$2" msg="$3"
     TESTS_RUN=$((TESTS_RUN + 1))
-    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    # Here-string, not a pipe, so grep -q exiting early on a match cannot
+    # SIGPIPE printf and (under set -o pipefail) flip the pipeline non-zero
+    # despite a match — a size-sensitive flake on large haystacks (#3820).
+    if grep -qF -- "$needle" <<<"$haystack"; then
         TESTS_PASSED=$((TESTS_PASSED + 1))
         echo -e "  ${GREEN}PASS${NC}: $msg"
     else
@@ -75,7 +78,7 @@ assert_contains() {
 assert_not_contains() {
     local haystack="$1" needle="$2" msg="$3"
     TESTS_RUN=$((TESTS_RUN + 1))
-    if ! printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    if ! grep -qF -- "$needle" <<<"$haystack"; then
         TESTS_PASSED=$((TESTS_PASSED + 1))
         echo -e "  ${GREEN}PASS${NC}: $msg"
     else

--- a/defaults/scripts/tests/test-merge-pr-merge-ordering-guard.sh
+++ b/defaults/scripts/tests/test-merge-pr-merge-ordering-guard.sh
@@ -66,7 +66,10 @@ assert_eq() {
 assert_contains() {
     local haystack="$1" needle="$2" msg="$3"
     TESTS_RUN=$((TESTS_RUN + 1))
-    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    # Here-string, not a pipe, so grep -q exiting early on a match cannot
+    # SIGPIPE printf and (under set -o pipefail) flip the pipeline non-zero
+    # despite a match — a size-sensitive flake on large haystacks (#3820).
+    if grep -qF -- "$needle" <<<"$haystack"; then
         TESTS_PASSED=$((TESTS_PASSED + 1))
         echo -e "  ${GREEN}PASS${NC}: $msg"
     else
@@ -80,7 +83,7 @@ assert_contains() {
 assert_not_contains() {
     local haystack="$1" needle="$2" msg="$3"
     TESTS_RUN=$((TESTS_RUN + 1))
-    if ! printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    if ! grep -qF -- "$needle" <<<"$haystack"; then
         TESTS_PASSED=$((TESTS_PASSED + 1))
         echo -e "  ${GREEN}PASS${NC}: $msg"
     else

--- a/defaults/scripts/tests/test-merge-pr-partial-increment.sh
+++ b/defaults/scripts/tests/test-merge-pr-partial-increment.sh
@@ -58,7 +58,10 @@ assert_eq() {
 assert_contains() {
     local haystack="$1" needle="$2" msg="$3"
     TESTS_RUN=$((TESTS_RUN + 1))
-    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    # Here-string, not a pipe, so grep -q exiting early on a match cannot
+    # SIGPIPE printf and (under set -o pipefail) flip the pipeline non-zero
+    # despite a match — a size-sensitive flake on large haystacks (#3820).
+    if grep -qF -- "$needle" <<<"$haystack"; then
         TESTS_PASSED=$((TESTS_PASSED + 1))
         echo -e "  ${GREEN}PASS${NC}: $msg"
     else
@@ -72,7 +75,7 @@ assert_contains() {
 assert_not_contains() {
     local haystack="$1" needle="$2" msg="$3"
     TESTS_RUN=$((TESTS_RUN + 1))
-    if ! printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    if ! grep -qF -- "$needle" <<<"$haystack"; then
         TESTS_PASSED=$((TESTS_PASSED + 1))
         echo -e "  ${GREEN}PASS${NC}: $msg"
     else


### PR DESCRIPTION
## Summary

Fixes #3820. On a repo with GitHub auto-merge disabled repo-wide (`allow_auto_merge:false`), `./.loom/scripts/merge-pr.sh <PR> --auto` failed outright when the PR was not yet CLEAN (checks still running / `.mergeable` not yet computed). The reactive #3763 fallback only degrades gracefully when the PR is *already* immediately mergeable, so it preserved the terminal error and the PR never merged — hit during a `/loom:sweep all` run on rjwalters/once-around.

## Change (primary acceptance criterion 1 — script-side)

`merge-pr.sh --auto` now **detects the repo's `allow_auto_merge` setting once up front** (`gh api repos/{nwo} --jq .allow_auto_merge`, GitHub-scoped) and, when disabled, **degrades gracefully** to wait-for-checks-then-merge (immediate if already CLEAN) instead of attempting the doomed `enablePullRequestAutoMerge` mutation. This protects every caller of `merge-pr.sh`, not just sweep.

- **`forge-helpers.sh`** — new `forge_check_auto_merge_allowed NWO [GH]` helper: returns `true`/`false`/`unknown`. GitHub-only; Gitea and any probe failure (network/auth/unexpected value) return `unknown`, so callers preserve existing behavior fail-safe (Gitea unperturbed; probe failure ⇒ attempt `--auto` as today).
- **`merge-pr.sh`** — proactive probe (cached per invocation in `REPO_AUTO_MERGE_ALLOWED`) + new `_wait_for_checks_then_sync_merge`: a bounded check-runs poll reusing the same `LOOM_AUTO_MERGE_POLL_INTERVAL` / `LOOM_AUTO_MERGE_TIMEOUT` knobs and required-check classification as the UNSTABLE fallback, then falls through to the synchronous squash-merge path. Immediate merge when already CLEAN; terminal error on a failing **required** check or on timeout. The retry loop is short-circuited (`[[ "$AUTO_MERGE" == "true" ]] || break`) so the doomed enable mutation is never attempted. `--auto` docs (header/`--help`/examples) updated.
- **`sweep.md`** (acceptance criterion 3) — documents the degrade-gracefully behavior at **both** merge sites: issue-side Wave Lifecycle step 7 and Mode C step C2. `--auto` is now safe to pass uniformly regardless of the repo's auto-merge setting; no per-repo branching needed.

`.loom/scripts/` is a symlink to `defaults/scripts/`, so the installed copy tracks the `defaults/` edit automatically (matching how #3763 handled the pair).

## Tests

- Extended `test-merge-pr-auto-merge-disabled-fallback.sh` with #3820 coverage: `forge_check_auto_merge_allowed` behavior (GitHub false/true/probe-failure/non-boolean → unknown; Gitea → unknown) plus source-wiring guards for the proactive probe, `_wait_for_checks_then_sync_merge`, the loop short-circuit, and the `AUTO_MERGE`/`AUTO_MERGE_OK` flip. **30/30 pass.**
- Full `test-merge-pr-*` suite green; `bash -n` + `shellcheck -S warning` clean on every touched script.
- Also fixed a **latent SIGPIPE + `pipefail` flake** in three merge-pr test helpers (`printf '%s' "$haystack" | grep -qF`): `grep -q` exits early on a match, `printf` gets SIGPIPE, and `pipefail` flips the pipeline non-zero *despite* the match — a size-sensitive flake the larger `merge-pr.sh` reliably triggered. Switched to a here-string (`grep -qF -- "$needle" <<<"$haystack"`); the three suites now pass deterministically (verified 5× each).

Closes #3820

🤖 Generated with [Claude Code](https://claude.com/claude-code)