### PR TITLE
docs: reconcile builder prompt family contradictions and dead rituals

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -111,6 +111,13 @@
   description: Issue is part of an epic phase (references parent epic)
   color: "8B5CF6"  # violet-500 - lighter variant for child issues
 
+# External Contribution Labels
+# Not part of the loom: workflow. Builders MUST skip issues carrying this label
+# (see builder.md "Ignore External Issues") — they need maintainer triage first.
+- name: external
+  description: External contribution requiring manual triage
+  color: "6B7280"  # gray-500 - neutral, non-loom-workflow marker
+
 # Tier Labels (Goal Alignment)
 - name: tier:goal-advancing
   description: Directly implements a milestone deliverable or unblocks goal work

--- a/defaults/.claude/commands/loom/builder-complexity.md
+++ b/defaults/.claude/commands/loom/builder-complexity.md
@@ -33,8 +33,10 @@ gh issue comment 812 --body "This issue is complex (>6 hours). Decomposed into:
 - #YYY: Part 2 (1.5 hours)
 - #ZZZ: Part 3 (2 hours)"
 
-# 3. Close parent issue or remove loom:building
-gh issue close 812  # OR: gh issue edit 812 --remove-label "loom:building"
+# 3. Mark the parent blocked — humans close it once children are filed.
+#    NEVER close a parent issue yourself; the decomposition comment above
+#    is the record, loom:blocked is the terminal state.
+gh issue edit 812 --remove-label "loom:building" --add-label "loom:blocked"
 
 # 4. (Optional) Pick up a sub-issue once a Curator has enhanced it
 #    Sub-issues are born at loom:triage. A separate Curator pass produces
@@ -42,7 +44,7 @@ gh issue close 812  # OR: gh issue edit 812 --remove-label "loom:building"
 #    yourself to a sub-issue you just created -- that would skip both
 #    Curator review and the human-approval gate.
 gh issue edit XXX --add-label "loom:triage"
-# Then exit and let the Curator/Shepherd pipeline pick it up.
+# Then exit and let the Curator/sweep pipeline pick it up.
 ```
 
 **DON'T DO THIS** (abandon without path forward):
@@ -150,7 +152,7 @@ Before decomposing an issue into sub-issues:
    ```
 
 4. **Compare findings to issue requirements**:
-   - **Fully implemented** -> Close issue as already complete with evidence
+   - **Fully implemented** -> Mark `loom:blocked` with an "already implemented" comment citing the evidence (files/lines/tests); a human closes it. Do NOT close the issue yourself and do NOT create duplicate sub-issues.
    - **Partially implemented** -> Create sub-issues only for missing parts
    - **Not implemented** -> Proceed with decomposition as planned
 
@@ -162,7 +164,7 @@ Large issue requiring decomposition
 1. AUDIT: Search codebase for existing implementations
 |
 2. ASSESS:
-   |-- Fully implemented? -> Close issue with evidence
+   |-- Fully implemented? -> Mark loom:blocked with evidence (a human closes it)
    |-- Partially implemented? -> Create sub-issues for gaps only
    +-- Not implemented? -> Proceed with decomposition
 |
@@ -193,7 +195,8 @@ $ find . -name "*_test*" | xargs grep -l constraint
 # Audit shows: All features fully implemented with tests
 
 # Step 4: Decision
-# -> Close issue #341 as already implemented
+# -> Mark issue #341 loom:blocked with an "already implemented" comment citing the
+#    evidence above (a human closes it — builders never close issues)
 # -> Do NOT create sub-issues (would be duplicates)
 # -> Create separate issue for actual gaps: "Add SQLSTATE codes to constraint errors"
 ```
@@ -269,7 +272,7 @@ Before claiming an issue, estimate the work required:
 **If Complex (6-12 hours, clear path)**:
 1. Assess carefully - can you complete it in one focused session?
 2. If YES: Claim and implement (larger PRs are fine if cohesive)
-3. If NO: Break down into 2-4 sub-issues, close parent with explanation
+3. If NO: Break down into 2-4 sub-issues, mark parent `loom:blocked` with an explanation (humans close)
 4. Prefer completing work over creating more issues
 
 **If Intractable (> 12 hours or unclear)**:
@@ -326,10 +329,14 @@ EOF
 )"
 ```
 
-**Step 3: Close Parent Issue**
+**Step 3: Mark Parent Blocked (never close it yourself)**
+
+Record the decomposition in a comment, then move the parent to `loom:blocked`. A
+human closes the parent once the children are filed and curated — builders never
+close issues themselves.
 
 ```bash
-gh issue close <parent-number> --comment "$(cat <<'EOF'
+gh issue comment <parent-number> --body "$(cat <<'EOF'
 Decomposed into smaller sub-issues for incremental implementation:
 
 - #<phase1-number>: Phase 1 (1-2 hours)
@@ -339,6 +346,7 @@ Decomposed into smaller sub-issues for incremental implementation:
 Each sub-issue references this parent for full context. Curator will enhance them with implementation details.
 EOF
 )"
+gh issue edit <parent-number> --remove-label "loom:building" --add-label "loom:blocked"
 ```
 
 ### Real-World Example
@@ -361,8 +369,9 @@ gh issue create --title "Integrate activity logging into /builder and /judge"
 gh issue create --title "Add activity querying to /loom heuristic"
 # -> Issue #536 (1-2 hours, depends on #535)
 
-# Close parent
-gh issue close 524 --comment "Decomposed into #534, #535, #536"
+# Mark parent blocked — a human closes it once the children are curated
+gh issue comment 524 --body "Decomposed into #534, #535, #536"
+gh issue edit 524 --remove-label "loom:building" --add-label "loom:blocked"
 ```
 
 **Benefits**:

--- a/defaults/.claude/commands/loom/builder-pr.md
+++ b/defaults/.claude/commands/loom/builder-pr.md
@@ -88,52 +88,6 @@ This review happens BEFORE creating your worktree:
 4. Create worktree
 5. Implement (using patterns learned from review)
 
-## Write PR Body Before Running Tests
-
-**CRITICAL**: Before running the test suite, write your PR description to `.loom/pr-body.md`.
-
-This ensures a high-quality PR description is preserved even if context runs out during testing. The shepherd uses this file when creating the PR automatically.
-
-### Why This Matters
-
-The builder commonly exhausts its context window during test verification. When this happens, the shepherd creates the PR automatically — but it can only generate a boilerplate description unless you've pre-written the body.
-
-### How to Write the PR Body
-
-After implementing your changes (but BEFORE running tests):
-
-```bash
-cat > .loom/pr-body.md << 'EOF'
-## Summary
-[1-2 sentences describing what this PR does and why]
-
-## Changes
-- [Key change 1 - what you changed and why]
-- [Key change 2]
-- [Key change 3]
-
-## Acceptance Criteria Verification
-
-| Criterion | Status | Verification |
-|-----------|--------|--------------|
-| [Criterion from issue] | ✅ | [How you verified it] |
-
-## Test Plan
-- [ ] [Test 1]
-- [ ] [Test 2]
-
-Closes #N
-EOF
-```
-
-Replace `#N` with the actual issue number. Write this BEFORE running `pnpm check:ci` or any test suite. Use `Part of #N` instead of `Closes #N` when this PR is a **partial increment** of a family/epic issue (see "Partial increments" below).
-
-### When to Update It
-
-If you discover additional changes during testing, update `.loom/pr-body.md` to reflect them before committing.
-
----
-
 ## Test Output: Truncate for Token Efficiency
 
 **IMPORTANT**: When running tests, truncate verbose output to conserve tokens in long-running sessions.
@@ -229,7 +183,7 @@ During orchestration, incomplete PRs cause:
 - CI failures when criteria are missed
 - Manual intervention mid-workflow
 - Wasted review cycles
-- Shepherd/Judge time spent on fixable issues
+- Sweep/Judge time spent on fixable issues
 
 **Example failure**: Issue #1441 listed 4 shellcheck warnings to fix. Builder fixed 3/4, missed `cli/loom-start.sh:47`, requiring manual fixes after CI failed.
 
@@ -450,7 +404,7 @@ fix: standardize timestamp format to ISO 8601 UTC across log scripts
 feat: add workspace snapshot caching for daemon state
 refactor: rename instant-exit to low-output terminology
 docs: update troubleshooting guide for worktree cleanup
-fix: prevent duplicate label transitions in shepherd phase validator
+fix: prevent duplicate label transitions in sweep phase validation
 ```
 
 ### Issue Title Prefix Mapping
@@ -505,7 +459,7 @@ git diff --stat
 git diff
 
 # Step 2: Describe what the code change does
-git commit -m "fix: validate PR title format in shepherd phase validator"
+git commit -m "fix: validate PR title format in sweep phase validation"
 
 # NOT: git commit -m "feat: implement changes for issue #2678"
 # NOT: git commit -m "fix: address issue #2557"
@@ -513,7 +467,7 @@ git commit -m "fix: validate PR title format in shepherd phase validator"
 
 ### Commit Message Anti-Patterns
 
-These patterns are **WRONG** — the shepherd will reject PRs with titles matching them:
+These patterns are **WRONG** — sweep phase validation will reject PRs with titles matching them:
 
 | Anti-Pattern | Why It's Wrong |
 |-------------|---------------|
@@ -532,7 +486,7 @@ These patterns are **WRONG** — the shepherd will reject PRs with titles matchi
 > family/epic issue (see "Partial increments" below).
 > A closing keyword is required for:
 > 1. GitHub to auto-close the issue when the PR merges
-> 2. **Shepherd orchestration to detect your PR during phase validation**
+> 2. **Sweep orchestration to detect your PR during phase validation**
 >
 > A partial-increment PR intentionally omits the closing keyword so the family/epic issue
 > stays open — it still references the issue with `Part of #N` so the PR is discoverable.

--- a/defaults/.claude/commands/loom/builder-worktree.md
+++ b/defaults/.claude/commands/loom/builder-worktree.md
@@ -339,7 +339,7 @@ done
 ### When to Use Parallel Mode
 
 **Use atomic claiming when:**
-- Multiple Builder agents run simultaneously (Daemon Mode with shepherd pool)
+- Multiple Builder agents run simultaneously (Daemon Mode dispatching parallel sweeps)
 - Risk of two agents picking the same issue
 - Need graceful shutdown capability
 

--- a/defaults/.claude/commands/loom/builder.md
+++ b/defaults/.claude/commands/loom/builder.md
@@ -95,7 +95,7 @@ This role definition is split across multiple files for maintainability:
 
 ## Post-Builder Quality Gate (optional, configured per-repo)
 
-If this repository configures a `buildGate` block in `.loom/config.json`, the shepherd orchestrator runs three deterministic checks **after you exit but before any PR is opened**:
+If this repository configures a `buildGate` block in `.loom/config.json`, the sweep orchestrator runs three deterministic checks **after you exit but before any PR is opened**:
 
 1. At least one commit ahead of `origin/main`.
 2. At least one changed file matches the configured `realChangeGlobs` (or default scratch exclusions).
@@ -210,12 +210,11 @@ PR LIFECYCLE (Builder only creates, Judge/Champion manage):
 
 **Workflow**:
 
-- **Find work**: `gh issue list --label="loom:issue" --state=open` (sorted oldest-first)
-- **Pick oldest**: Always choose the oldest `loom:issue` issue first (FIFO queue)
+- **Find work**: Use the three-tier priority order in "Finding Work: Priority System" below (urgent → curated → approved-only). FIFO (oldest-first) is only the tiebreak **within** a single tier — not a top-level rule.
 - **Check dependencies**: Verify all task list items are checked before claiming
 - **Claim issue**: `gh issue edit <number> --remove-label "loom:issue" --add-label "loom:building"`
 - **Do the work**: Implement, test, commit, create PR
-- **Mark PR for review**: `gh pr create --label "loom:review-requested"` (MUST use structured body template from PR Creation section below)
+- **Mark PR for review**: `gh pr create --label "loom:review-requested"` (MUST use the structured body template — canonical in builder-pr.md § "Creating the PR")
 - **Complete**: Issue auto-closes when PR merges, or mark `loom:blocked` if stuck
 
 ## Exception: Explicit User Instructions
@@ -252,17 +251,9 @@ gh issue comment 592 --body "Starting work on this issue per user request"
 ./.loom/scripts/worktree.sh 592
 # ... do the work ...
 
-# Complete normally with PR (use full structured body — see PR Creation section)
-gh pr create --title "fix: summary" --label "loom:review-requested" --body "$(cat <<'EOF'
-## Summary
-...
-## Changes
-...
-## Test Plan
-...
-Closes #592
-EOF
-)"
+# Complete normally with a PR — use the canonical structured body template from
+# builder-pr.md § "Creating the PR" (Summary / Changes / Acceptance Criteria /
+# Test Plan + `Closes #592`), with the loom:review-requested label at creation.
 ```
 
 **Why This Matters**:
@@ -357,7 +348,7 @@ git -C "<WORKTREE_ABS>" status        # your changes should appear HERE
 Working directly on main causes:
 - **Workflow violations**: PRs cannot be created from uncommitted changes on main
 - **Lost work**: Changes on main may be overwritten by `git pull`
-- **Pipeline failures**: Shepherd validation fails when no worktree exists
+- **Pipeline failures**: Sweep validation fails when no worktree exists
 - **Coordination issues**: Other agents cannot see or review your work
 - **State corruption**: Issue stuck in `loom:building` with no path forward
 
@@ -379,7 +370,7 @@ Before writing any code, confirm ALL of these:
 These all work from within your worktree:
 - `gh issue view <N>` — no cd needed
 - `gh pr list` — no cd needed
-- `./.loom/scripts/checkpoint.sh write ...` — no cd needed
+- `./.loom/scripts/check-main-clean.sh` — no cd needed
 
 ❌ **WRONG** (causes worktree escape):
 ```bash
@@ -390,85 +381,26 @@ cd {{workspace}} && gh pr list
 ✅ **CORRECT** (stay in worktree):
 ```bash
 gh issue view 123   # Works from worktree
-./.loom/scripts/checkpoint.sh write --stage planning --issue 123
+./.loom/scripts/check-main-clean.sh   # Works from worktree
 ```
 
-**A PreToolUse hook blocks `cd` commands to the main repo from worktrees.**
+## Progress Checkpoints (optional breadcrumb)
 
-## Progress Checkpoints
+Writing per-stage checkpoints is **optional**. The live sweep lifecycle tracks
+phase progress itself via `.loom/scripts/sweep-checkpoint.sh` (which writes
+`.loom/sweep-checkpoint/issue-<N>.json`, keyed by the sweep run) and
+re-dispatches Builder fresh on resume — it does **not** read any worktree-level
+`.loom-checkpoint` file. So skipping checkpoints costs nothing in the live path.
 
-**CRITICAL: Write checkpoints at every stage to enable recovery.** Without checkpoints, the shepherd cannot reliably distinguish "builder made real progress but crashed" from "builder never started meaningful work." While the shepherd can now detect some cases of uncommitted work via log analysis and file counts, checkpoints remain the primary and most reliable signal for recovery. Always write them — skipping checkpoints risks your completed work being retried from scratch instead of recovered.
-
-### Checkpoint Stages
-
-| Stage | When to Write | What It Signals |
-|-------|---------------|-----------------|
-| `planning` | After reading issue, before coding | Issue understood, planning approach |
-| `implementing` | After first meaningful code changes | Code exists, may be useful |
-| `tested` | After running tests | Tests ran (pass or fail noted) |
-| `committed` | After git commit | Changes are safely committed |
-| `pushed` | After git push | Branch is on remote |
-| `pr_created` | After PR creation | PR exists with labels |
-
-### How to Write Checkpoints
-
-Use the checkpoint script from your worktree:
+If you still want to leave a recovery breadcrumb, you may write one from your
+worktree:
 
 ```bash
-# After reading issue and planning approach
-./.loom/scripts/checkpoint.sh write --stage planning --issue <number>
-
-# After making code changes
-./.loom/scripts/checkpoint.sh write --stage implementing --issue <number> --files-changed 5
-
-# After running tests
-./.loom/scripts/checkpoint.sh write --stage tested --issue <number> \
-  --test-result pass --test-command "pnpm check:ci"
-
-# After committing
-./.loom/scripts/checkpoint.sh write --stage committed --issue <number> \
-  --commit-sha "$(git rev-parse HEAD)"
-
-# After pushing
-./.loom/scripts/checkpoint.sh write --stage pushed --issue <number>
-
-# After PR creation
-./.loom/scripts/checkpoint.sh write --stage pr_created --issue <number> \
-  --pr-number <pr-number>
+./.loom/scripts/checkpoint.sh write --stage implementing --issue <number>
 ```
 
-### When to Write Checkpoints
-
-Write a checkpoint **immediately after completing each stage**:
-
-1. **After claiming issue and reading it** → `planning`
-2. **After first meaningful code changes** → `implementing`
-3. **After running tests (pass or fail)** → `tested` with `--test-result`
-4. **After committing** → `committed` with `--commit-sha`
-5. **After pushing** → `pushed`
-6. **After PR creation** → `pr_created` with `--pr-number`
-
-### Why Checkpoints Matter
-
-Without checkpoints, if you fail at any point:
-- Shepherd doesn't know how far you got
-- Recovery always starts from scratch
-- Useful work may be lost or duplicated
-
-With checkpoints:
-- Shepherd knows exactly where you stopped
-- Recovery can skip completed stages
-- Targeted instructions for remaining work
-
-### Checkpoint File Location
-
-Checkpoints are stored in: `.loom-checkpoint` (in your worktree root)
-
-You can read the current checkpoint:
-```bash
-./.loom/scripts/checkpoint.sh read
-./.loom/scripts/checkpoint.sh read --json  # For programmatic use
-```
+The far more reliable form of "recovery insurance" is to **commit real work
+early and often** — a committed change survives any crash, a checkpoint does not.
 
 ## Signaling "No Changes Needed"
 
@@ -480,9 +412,9 @@ echo "Bug is already fixed on main — verified by running the test suite" > .no
 
 The marker file should contain a brief explanation of why no changes are needed.
 
-**IMPORTANT: Do NOT commit the marker file.** Leave it as an untracked file in the worktree. The shepherd checks for the marker file on disk — if you `git add` and commit it, the commit shows as work done and defeats the detection mechanism.
+**IMPORTANT: Do NOT commit the marker file.** Leave it as an untracked file in the worktree. Sweep orchestration checks for the marker file on disk — if you `git add` and commit it, the commit shows as work done and defeats the detection mechanism.
 
-**Why this matters:** Without this marker file, the shepherd cannot distinguish between "builder deliberately decided no changes are needed" and "builder crashed/was killed before doing anything." An empty worktree without the marker is treated as a builder failure, not a deliberate decision.
+**Why this matters:** Without this marker file, sweep orchestration cannot distinguish between "builder deliberately decided no changes are needed" and "builder crashed/was killed before doing anything." An empty worktree without the marker is treated as a builder failure, not a deliberate decision.
 
 **Do NOT create this file if:**
 - You made code changes (even if you later reverted them)
@@ -749,7 +681,7 @@ You MUST NOT close issues under any circumstances. Issues should only close via 
 - DO NOT close duplicates — flag them for human review instead
 - DO NOT close issues for any reason — only GitHub's PR auto-close mechanism should close issues
 
-**Why this matters**: Closing an issue manually destroys a legitimate feature request and bypasses the PR review pipeline. The phase validator will detect this and reopen the issue, but the interruption to shepherd orchestration and loss of builder context is already done.
+**Why this matters**: Closing an issue manually destroys a legitimate feature request and bypasses the PR review pipeline. Sweep phase validation will detect this and reopen the issue, but the interruption to sweep orchestration and loss of builder context is already done.
 
 ## Complexity Assessment
 
@@ -806,6 +738,7 @@ gh issue list --label="loom:issue" --state=open --json number,title,labels \
 - If an urgent issue appears while working on normal priority, finish your current task first before switching
 - Respect the priority system - urgent issues need immediate attention
 - Always prefer curated issues when available for better context and guidance
+- **FIFO is the tiebreak _within_ a tier, not a top-level rule**: once you have selected the highest non-empty tier above, pick the **oldest** issue among the candidates in that tier. Never let raw oldest-first pull you into a lower-priority tier ahead of a waiting urgent or curated issue.
 
 ## PR Creation
 
@@ -844,68 +777,33 @@ git diff   # Read the actual changes
 
 ### Closing vs Partial Increments (family/epic issues)
 
-Before writing the closing reference, decide whether this PR **fully** resolves the issue or is only a **partial increment** of a larger tracked body of work:
+Decide whether this PR **fully** resolves the issue (`Closes #N`) or is only a
+**partial increment** of a larger tracked body of work that must stay open
+(`Part of #N` / `Contributes to #N`). The full decision rule — when to use the
+non-closing reference, and the requirement to carry the **same** reference in both
+the PR body and the squash commit message — is the canonical guidance in
+**builder-pr.md § "Partial increments (family/epic issues)"**. Do not restate it
+here; follow it there.
 
-- **Full implementation (default)** — this PR resolves the whole issue. Use `Closes #N`.
-- **Partial increment** — this PR lands a coherent but incomplete slice of a larger issue, and tracked work remains after it merges. Use `Part of #N` (or `Contributes to #N`) instead — this references the issue WITHOUT auto-closing it.
+### Creating the PR
 
-Use the non-closing reference (`Part of #N`) when ANY of these hold:
-- The issue carries the `loom:epic` label (or `loom:epic-phase`) — a family/epic issue that must stay open until its final increment lands.
-- The issue body explicitly scopes a *family* of work (e.g. "~346 conformance failures across N files") and this PR implements only a subset.
-- Your own scope notes say tracked work remains after this PR — you are decomposing a large issue into slices and this is not the last slice.
-
-**Apply the same reference to BOTH the PR body AND the commit message.** This repository squash-merges, and GitHub harvests closing keywords from the squash commit message as well as the PR body — so a stray `Closes #N` in the commit body will auto-close the family issue even if the PR body says `Part of #N`. Derive the commit message and PR body together (see the diff-review step above) and keep the reference consistent across both.
-
-Only the **final increment** that completes the family should use `Closes #N`. When in doubt on an `loom:epic` issue, prefer `Part of #N` — a human can always close the issue manually, but silently dropping tracked work on an accidental auto-close is far more costly to recover.
-
-**REQUIRED: Use the structured PR body template below.** Do NOT create PRs with just `Closes #N` — the body must include Summary, Changes, and Acceptance Criteria sections.
-
-```bash
-gh pr create \
-  --title "fix: descriptive summary of the change" \
-  --label "loom:review-requested" \
-  --body "$(cat <<'EOF'
-## Summary
-Brief description of what this PR does and why.
-
-## Changes
-- Change 1
-- Change 2
-- Change 3
-
-## Acceptance Criteria Verification
-
-| Criterion | Status | Verification |
-|-----------|--------|--------------|
-| Criterion 1 from issue | ✅ | How you verified it |
-| Criterion 2 from issue | ✅ | How you verified it |
-
-## Test Plan
-How you verified the changes work.
-
-Closes #<issue-number>
-EOF
-)"
-```
-
-> Replace `Closes #<issue-number>` with `Part of #<issue-number>` when this PR is a **partial increment** of a family/epic issue (see "Closing vs Partial Increments" above) — and make the same substitution in your commit message.
-
-**PR title** must use conventional commit format: `fix:`, `feat:`, `refactor:`, `docs:`, `chore:`, etc.
-
-**After creation:**
-- Never touch PR labels after creation
-- For a full implementation, use "Closes #N" syntax (not "Issue #N" or "Addresses #N") for auto-close; for a declared partial increment, use "Part of #N" (see "Closing vs Partial Increments" above)
-- PRs are merged by Champion using `./.loom/scripts/merge-pr.sh` -- never use `gh pr merge`
+The canonical `gh pr create` body template (Summary / Changes / Acceptance
+Criteria Verification / Test Plan + the `Closes #N` reference) lives in
+**builder-pr.md § "Creating the PR"** — use it verbatim. Do NOT create PRs with
+just `Closes #N`; the body must include the structured sections. Add the
+`loom:review-requested` label at creation only, and never touch PR labels
+afterward (canonical rules in **builder-pr.md § "PR Label Rules"**). PRs are
+merged by Champion using `./.loom/scripts/merge-pr.sh` — never use `gh pr merge`.
 
 ## Working Style
 
-- **Start**: `gh issue list --label="loom:issue"` to find work (pick oldest first for fair FIFO queue)
+- **Start**: Find work using the three-tier priority order (see "Finding Work: Priority System") — urgent → curated → approved-only; oldest-first is only the tiebreak **within** a tier, not a top-level rule
 - **Verify before claiming**: Issue MUST have `loom:issue` label (unless explicit user override)
 - **Claim**: Remove `loom:issue`, add `loom:building` - always both labels together
 - **During work**: If you discover out-of-scope needs, PAUSE and create an issue (see builder-complexity.md)
 - Use the TodoWrite tool to plan and track multi-step tasks
 - Run lint, format, and type checks before considering complete
-- **Create PR**: Use the full structured body template (see PR Creation section), add `loom:review-requested` label ONLY at creation
+- **Create PR**: Use the canonical structured body template (builder-pr.md § "Creating the PR"), add `loom:review-requested` label ONLY at creation
 - **After PR creation**: HANDS OFF - never touch PR labels again, move to next issue
 - When blocked: Add comment explaining blocker, mark `loom:blocked`
 - Stay focused on assigned issue - create separate issues for other work
@@ -987,6 +885,6 @@ After successfully creating the PR:
    ```bash
    gh pr view <number> --json labels,number,url
    ```
-2. **Exit the session** - the shepherd will continue the workflow
+2. **Exit the session** - the sweep orchestration will continue the workflow
 
 **Work completion is detected automatically.** When you complete your task (PR created with `loom:review-requested` label, or issue marked as `loom:blocked`), the orchestration layer terminates the session. However, you should explicitly exit after verifying PR creation to avoid unnecessary delays in the pipeline.


### PR DESCRIPTION
## Summary

Resolves six defect classes in the Builder prompt family (`builder.md`, `builder-pr.md`, `builder-worktree.md`, `builder-complexity.md`). Documentation/prompt-consistency fix only — no runtime code changes beyond documenting an already-live label in `.github/labels.yml`. Canonical files live under `defaults/.claude/commands/loom/`; `defaults/roles/builder*.md` are symlinks to them (verified still resolving).

## Changes

- **#1 Issue-closing contradiction** — `builder-complexity.md`: every `gh issue close` instruction (decomposition path *and* the "fully implemented" audit path) now ends in `loom:blocked` + an explanatory comment; humans close. Self-contradiction resolved.
- **#2 Dead checkpoint protocol** — `builder.md`: the 74-line mandatory `.loom-checkpoint` protocol is reduced to a short optional-breadcrumb note; false "the shepherd cannot..." / "Shepherd knows exactly where you stopped" claims removed. Notes the live sweep path checkpoints via `sweep-checkpoint.sh` and never reads `.loom-checkpoint`.
- **#3 Dead pr-body ritual** — `builder-pr.md`: "Write PR Body Before Running Tests" (`.loom/pr-body.md`) section deleted (no live consumer; snippet used a relative path that violated the file's own cwd-reset rule).
- **#4 Conflicting work-selection** — `builder.md`: one canonical three-tier "Finding Work: Priority System"; the two FIFO-only restatements are now pointers, with FIFO documented only as the same-tier tiebreak.
- **#5 Triplicated PR rules** — `builder.md`: the `gh pr create` body template, PR-label rules, and Closes-vs-Part-of guidance are consolidated into one-line pointers to the canonical `builder-pr.md` sections.
- **#6 Misc** — deleted the false cd-blocking-hook sentence; replaced all stale "shepherd" references in `builder*.md` with current sweep/Judge terminology; added the already-live `external` label to `.github/labels.yml` (documents an existing forge label — no `gh label create` run, no new label invented).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| No `gh issue close` / "Close issue"/"Close parent" in builder-complexity.md | ✅ | `grep -n "gh issue close"` → no matches; all terminal states use `loom:blocked` + comment |
| Checkpoint section reduced to short note, false shepherd claims gone | ✅ | Section is now ~15 lines "optional breadcrumb"; shepherd claims removed |
| `.loom/pr-body.md` ritual removed | ✅ | `grep -n "pr-body.md" builder-pr.md` → no matches |
| Exactly one "Finding Work" procedure; others are pointers | ✅ | `grep -c "## Finding Work"` → 1; FIFO restatements now point to it |
| PR template / label rule / Closes-vs-Part-of each in one place (builder-pr.md) | ✅ | No `gh pr create` heredoc template in builder.md; canonical block only in builder-pr.md § "Creating the PR" |
| False cd-blocking-hook sentence removed | ✅ | `grep -n "blocks .cd. commands"` → no matches |
| All shepherd refs in builder*.md updated | ✅ | `grep -in shepherd builder*.md` → no matches |
| labels.yml documents `external` | ✅ | `grep -n "name: external"` → present; color/description match the live label |
| No runtime code files touched | ✅ | `git diff --stat` → only 4 `.md` files + `.github/labels.yml` |
| Four files internally consistent, no new contradictions | ✅ | All builder.md pointers resolve to real headings in builder-pr.md ("Creating the PR", "PR Label Rules", "Partial increments (family/epic issues)"); no dangling cross-refs |

## Test Plan

Ran the issue's grep-based Test Plan — all pass:

- `grep -n "gh issue close" builder-complexity.md` → none
- `grep -in shepherd builder*.md` → none
- `grep -n "pr-body.md" builder-pr.md` → none
- `grep -c "## Finding Work" builder.md` → 1
- No inline `gh pr create ... --body "$(cat <<'EOF'` template block in builder.md; canonical template only in builder-pr.md
- `grep -n "blocks .cd. commands" builder.md` → none
- `.github/labels.yml` has an `external` entry (valid YAML, 27 labels)

Also verified: `defaults/roles/builder*.md` symlinks still resolve; no dangling cross-references to the trimmed checkpoint section or the deleted pr-body section; no doc-lint test covers `builder*.md`.

Closes #3784