### PR TITLE
test(bump): tolerant phase-presence doc-lint (fixes red main #3860/#3861)

### DIFF
--- a/loom-daemon/tests/bump_md_doc_lint.rs
+++ b/loom-daemon/tests/bump_md_doc_lint.rs
@@ -60,15 +60,21 @@ fn bump_md_exists_and_has_title() {
 #[test]
 fn bump_md_documents_all_eight_phases() {
     let content = read_bump_md();
+    // Assert PRESENCE of all eight lifecycle phases by number, not by exact
+    // title. Phase titles are prose that legitimately evolves (e.g. #3856 made
+    // the CHANGELOG phase optional, renaming "Ensure…" to "Update…if present"),
+    // so pinning the full title makes this doc-lint brittle and red-mains main
+    // on legitimate edits (#3860/#3861). The contract is "eight numbered phases
+    // exist as section headers"; that is what we check.
     let required_phase_headers: &[&str] = &[
-        "## Phase 1: Detect version sources",
-        "## Phase 2: Ensure",
-        "## Phase 3: Compute the new version",
-        "## Phase 4: Draft the changelog entry",
-        "## Phase 5: Generate",
-        "## Phase 6: Run the bump",
-        "## Phase 7: Push and",
-        "## Phase 8: Summary",
+        "## Phase 1:",
+        "## Phase 2:",
+        "## Phase 3:",
+        "## Phase 4:",
+        "## Phase 5:",
+        "## Phase 6:",
+        "## Phase 7:",
+        "## Phase 8:",
     ];
     for header in required_phase_headers {
         assert!(


### PR DESCRIPTION
## Summary
Main went red after #3856 (#3795's bump.md fix) renamed Phase 2 from "Ensure CHANGELOG.md exists" to "Update CHANGELOG.md if present (optional)" — the intentional make-CHANGELOG-optional change. The `bump_md_documents_all_eight_phases` doc-lint pinned the exact Phase 2 title and broke.

## Fix
Assert phase **presence by number** (`## Phase N:` for 1–8) instead of exact prose titles. Preserves the "eight lifecycle phases exist" contract while tolerating legitimate title evolution — the brittle-doc-lint class #3837 targets.

Verified: `cargo test --test bump_md_doc_lint` → 8 passed.

Closes #3860
Closes #3861

🤖 Generated with [Claude Code](https://claude.com/claude-code)