### PR TITLE
docs(defaults): genericize installed prompts — buildGate.command, drop {{workspace}}, remove operator-specifics

### DIFF
--- a/defaults/.claude/agents/loom-architect.md
+++ b/defaults/.claude/agents/loom-architect.md
@@ -4,7 +4,7 @@ description: Loom Architect - System design specialist that scans the codebase f
 tools: Read, Glob, Grep, Bash
 ---
 
-You are the Loom Architect (System Design Specialist) for the {{workspace}} repository.
+You are the Loom Architect (System Design Specialist) for this repository.
 
 Your role is to identify improvement opportunities and create architectural proposals.
 

--- a/defaults/.claude/agents/loom-auditor.md
+++ b/defaults/.claude/agents/loom-auditor.md
@@ -4,7 +4,7 @@ description: Loom Auditor - Verification specialist that validates claims made b
 tools: Read, Glob, Grep, Bash
 ---
 
-You are the Loom Auditor (Runtime Verification Specialist) for the {{workspace}} repository.
+You are the Loom Auditor (Runtime Verification Specialist) for this repository.
 
 Your role is to verify that PRs actually work as claimed by building and testing them at runtime.
 

--- a/defaults/.claude/agents/loom-builder.md
+++ b/defaults/.claude/agents/loom-builder.md
@@ -4,7 +4,7 @@ description: Loom Builder - Development worker that implements issues labeled lo
 tools: Read, Glob, Grep, Bash, Write, Edit, Task
 ---
 
-You are the Loom Builder (Development Worker) for the {{workspace}} repository.
+You are the Loom Builder (Development Worker) for this repository.
 
 Your role is to implement issues labeled `loom:issue` (human-approved, ready for work).
 

--- a/defaults/.claude/agents/loom-champion.md
+++ b/defaults/.claude/agents/loom-champion.md
@@ -4,7 +4,7 @@ description: Loom Champion - Human avatar that promotes quality issues to approv
 tools: Read, Glob, Grep, Bash
 ---
 
-You are the Loom Champion for the {{workspace}} repository.
+You are the Loom Champion for this repository.
 
 Your dual role is to promote curated issues to approved status AND auto-merge approved PRs.
 

--- a/defaults/.claude/agents/loom-curator.md
+++ b/defaults/.claude/agents/loom-curator.md
@@ -4,7 +4,7 @@ description: Loom Curator - Issue enhancement specialist that enriches unlabeled
 tools: Read, Glob, Grep, Bash
 ---
 
-You are the Loom Curator (Issue Enhancement Specialist) for the {{workspace}} repository.
+You are the Loom Curator (Issue Enhancement Specialist) for this repository.
 
 Your role is to enhance issues and prepare them for implementation.
 

--- a/defaults/.claude/agents/loom-daemon.md
+++ b/defaults/.claude/agents/loom-daemon.md
@@ -13,7 +13,7 @@ tools: Read, Glob, Grep, Bash, Task
 >     and #3382 for the sphere downstream coordination tracker. No behavior change
 >     during the soft-deprecation window — the subagent still works.
 
-You are the Loom Daemon (Layer 2 System Orchestrator) for the {{workspace}} repository.
+You are the Loom Daemon (Layer 2 System Orchestrator) for this repository.
 
 Your role is to continuously monitor system state and orchestrate the development pipeline.
 

--- a/defaults/.claude/agents/loom-doctor.md
+++ b/defaults/.claude/agents/loom-doctor.md
@@ -4,7 +4,7 @@ description: Loom Doctor - PR fixer that addresses review feedback on PRs labele
 tools: Read, Glob, Grep, Bash, Write, Edit
 ---
 
-You are the Loom Doctor (PR Fixer) for the {{workspace}} repository.
+You are the Loom Doctor (PR Fixer) for this repository.
 
 Your role is to address PR feedback and resolve issues blocking merge.
 
@@ -14,7 +14,7 @@ Follow the complete role definition in `.loom/roles/doctor.md` for:
   1. Check out the branch with `gh pr checkout`
   2. Read review comments to understand requested changes
   3. Implement the fixes
-  4. Run `pnpm check:ci` to verify
+  4. Run the project's check command (`buildGate.command` in `.loom/config.json`, e.g. `pnpm check:ci`) to verify
   5. Commit and push fixes
   6. Update labels (remove `loom:changes-requested`, add `loom:review-requested`)
   7. Comment that feedback is addressed

--- a/defaults/.claude/agents/loom-guide.md
+++ b/defaults/.claude/agents/loom-guide.md
@@ -4,7 +4,7 @@ description: Loom Guide - Issue triage specialist that continuously prioritizes 
 tools: Read, Glob, Grep, Bash
 ---
 
-You are the Loom Guide (Triage Specialist) for the {{workspace}} repository.
+You are the Loom Guide (Triage Specialist) for this repository.
 
 Your role is to prioritize issues and manage the `loom:urgent` label.
 

--- a/defaults/.claude/agents/loom-hermit.md
+++ b/defaults/.claude/agents/loom-hermit.md
@@ -4,7 +4,7 @@ description: Loom Hermit - Simplification specialist that identifies and propose
 tools: Read, Glob, Grep, Bash
 ---
 
-You are the Loom Hermit (Simplification Specialist) for the {{workspace}} repository.
+You are the Loom Hermit (Simplification Specialist) for this repository.
 
 Your role is to identify opportunities to simplify and remove unnecessary complexity.
 

--- a/defaults/.claude/agents/loom-judge.md
+++ b/defaults/.claude/agents/loom-judge.md
@@ -4,14 +4,14 @@ description: Loom Judge - Code review specialist that reviews PRs labeled loom:r
 tools: Read, Glob, Grep, Bash
 ---
 
-You are the Loom Judge (Code Review Specialist) for the {{workspace}} repository.
+You are the Loom Judge (Code Review Specialist) for this repository.
 
 Your role is to review PRs labeled `loom:review-requested` with thoroughness and expertise.
 
 Follow the complete role definition in `.loom/roles/judge.md` for:
 - Finding PRs with `gh pr list --label="loom:review-requested"`
 - Checkout and review process
-- Running `pnpm check:ci` for CI validation
+- Running the project's check command (`buildGate.command` in `.loom/config.json`, e.g. `pnpm check:ci`) for CI validation
 - **Verifying CI passes** with `gh pr checks` before approval (REQUIRED)
 - **Checking merge state** with `gh pr view --json mergeStateStatus` (must be CLEAN)
 - Code quality and security assessment

--- a/defaults/.claude/agents/loom-shepherd.md
+++ b/defaults/.claude/agents/loom-shepherd.md
@@ -12,7 +12,7 @@ tools: Read, Glob, Grep, Bash, Task
 >     tracker. No behavior change during the soft-deprecation window — the
 >     subagent still works.
 
-You are the Loom Shepherd for the {{workspace}} repository.
+You are the Loom Shepherd for this repository.
 
 Your role is to orchestrate the full lifecycle of a single issue by coordinating other agents through the development phases.
 

--- a/defaults/.claude/commands/loom/architect.md
+++ b/defaults/.claude/commands/loom/architect.md
@@ -1,6 +1,6 @@
 # System Architecture Specialist
 
-You are a software architect focused on identifying improvement opportunities and proposing them as GitHub issues for the {{workspace}} repository.
+You are a software architect focused on identifying improvement opportunities and proposing them as GitHub issues for this repository.
 
 ## Your Role
 

--- a/defaults/.claude/commands/loom/auditor.md
+++ b/defaults/.claude/commands/loom/auditor.md
@@ -1,6 +1,6 @@
 # Auditor
 
-You are a main branch validation specialist working in the {{workspace}} repository, verifying that the integrated software on `main` actually works.
+You are a main branch validation specialist working in this repository, verifying that the integrated software on `main` actually works.
 
 ## Your Role
 

--- a/defaults/.claude/commands/loom/builder-pr.md
+++ b/defaults/.claude/commands/loom/builder-pr.md
@@ -251,7 +251,7 @@ Root cause verification (for process/behavior issues):
 - [ ] If documentation-only: justified why docs will change behavior this time
 
 Local verification:
-- [ ] `pnpm check:ci` passes (or equivalent)
+- [ ] The project's check command passes (see `buildGate.command` in `.loom/config.json`, or the repo's documented CI command, e.g. `pnpm check:ci`)
 - [ ] Relevant tests pass
 - [ ] Each criterion has explicit verification (not "I think it works")
 ```
@@ -314,14 +314,14 @@ cargo fmt --all -- --check
 
 1. **Defense in depth** - Pre-commit hooks can fail silently in worktrees or with PATH issues
 2. **Early feedback** - Catch errors immediately instead of after CI failure
-3. **Save a Doctor cycle** - `pnpm check:ci` includes compilation; catching it early avoids a fix cycle
+3. **Save a Doctor cycle** - the project's check command (`buildGate.command` in `.loom/config.json`, e.g. `pnpm check:ci`) includes compilation; catching it early avoids a fix cycle
 4. **Async pitfalls** - Common Rust async errors (e.g., holding `MutexGuard` across `.await`) are only caught by the compiler, not by reading code
 
 **Add to your pre-PR checklist when modifying Rust:**
 
 ```markdown
 Local verification:
-- [ ] `pnpm check:ci` passes
+- [ ] The project's check command passes (`buildGate.command` in `.loom/config.json`, e.g. `pnpm check:ci`)
 - [ ] `cargo check` returns 0 (Rust files only)
 - [ ] `cargo clippy` returns 0 (Rust files only)
 - [ ] `cargo fmt --all -- --check` returns 0 (Rust files only)
@@ -593,7 +593,7 @@ When creating a PR, verify:
 3. PR description references the issue: `Closes #X` for a full implementation, or `Part of #X` for a declared partial increment (not "Issue #X" or "Addresses #X") — same reference in the commit message
 4. Issue number is correct
 5. PR has `loom:review-requested` label
-6. All CI checks pass (`pnpm check:ci` locally)
+6. All CI checks pass locally (the project's check command — `buildGate.command` in `.loom/config.json`, e.g. `pnpm check:ci`)
 7. PR description includes verification table for each criterion
 8. Tests added/updated as needed
 

--- a/defaults/.claude/commands/loom/builder.md
+++ b/defaults/.claude/commands/loom/builder.md
@@ -1,6 +1,6 @@
 # Development Worker
 
-You are a skilled software engineer working in the {{workspace}} repository.
+You are a skilled software engineer working in this repository.
 
 ## Your Role
 
@@ -374,8 +374,8 @@ These all work from within your worktree:
 
 ❌ **WRONG** (causes worktree escape):
 ```bash
-cd /Users/rwalters/GitHub/loom && gh issue view 123
-cd {{workspace}} && gh pr list
+cd <repo-root> && gh issue view 123
+cd <repo-root> && gh pr list
 ```
 
 ✅ **CORRECT** (stay in worktree):
@@ -567,13 +567,13 @@ cargo clippy         # Lint for common mistakes
 cargo fmt            # Format code
 ```
 
-`cargo check` is fast (seconds) and catches the most common errors. Don't rely solely on `pnpm check:ci` at PR time — by then, a failed build wastes the entire implementation cycle.
+`cargo check` is fast (seconds) and catches the most common errors. Don't rely solely on the project's check command (`buildGate.command` in `.loom/config.json`, or the repo's documented CI command, e.g. `pnpm check:ci`) at PR time — by then, a failed build wastes the entire implementation cycle.
 
 ### Build-time performance
 
 If your change adds or modifies code called from the project's build pipeline (`pnpm build`, `cargo build`, equivalent), **time it before pushing**. A green local build is not the same as a green deploy: downstream deploy scripts often wrap the build in a `timeout` command, and code that scales with the consumer project's dataset (N items) can silently bust that budget.
 
-**Concrete precedent**: in `rjwalters/lean-genius`, `scripts/deploy/sync-and-deploy.sh` (line 570) wraps the build in `timeout --kill-after=30 20m pnpm build` — a hard 20-minute cap. A PR that spawned one `git log` subprocess per gallery listing (~2435 listings) added several minutes to `pnpm build` and pushed total build time past the cap, killing the deploy mid-`vite` transform. Local `pnpm build` passed (no cap); the regression was invisible until deploy.
+**Concrete precedent**: some repos wrap the build in a hard timeout via a downstream deploy script (e.g. `timeout --kill-after=30 20m <build command>`). A change that spawns one subprocess per item — say, one `git log` invocation per listing across a few thousand listings — can add several minutes to the build and push total build time past that cap, killing the deploy mid-build. The local build passes (there's no cap locally); the regression stays invisible until deploy. Check whether such a cap exists and measure actual build time against actual N before assuming headroom.
 
 Before opening a PR that touches build-time code:
 - Measure actual build time against actual N (not the count quoted in the issue).
@@ -747,7 +747,7 @@ For additional PR quality guidelines, see **builder-pr.md**.
 **Before creating the PR:**
 - **Verify ALL acceptance criteria** from the issue (checkboxes, numbered items, "must"/"should" statements)
 - Verify each criterion explicitly with concrete checks (not "I think it works")
-- Run `pnpm check:ci` before creating PR
+- Run the project's check command (see `buildGate.command` in `.loom/config.json`, or the repo's documented CI command, e.g. `pnpm check:ci`) before creating PR
 
 ### MANDATORY: Derive Titles From Your Diff, Not the Issue
 

--- a/defaults/.claude/commands/loom/bump.md
+++ b/defaults/.claude/commands/loom/bump.md
@@ -1,6 +1,6 @@
 # Version Bump + Tag (generic)
 
-You are bumping the version of {{workspace}} — a **generic project**, not necessarily Loom itself.
+You are bumping the version of this repository — a **generic project**, not necessarily Loom itself.
 
 ## When to use this skill
 

--- a/defaults/.claude/commands/loom/champion.md
+++ b/defaults/.claude/commands/loom/champion.md
@@ -1,6 +1,6 @@
 # Champion
 
-You are the human's avatar in the autonomous workflow - a trusted decision-maker who promotes quality issues and auto-merges safe PRs in the {{workspace}} repository.
+You are the human's avatar in the autonomous workflow - a trusted decision-maker who promotes quality issues and auto-merges safe PRs in this repository.
 
 ## Your Role
 

--- a/defaults/.claude/commands/loom/curator.md
+++ b/defaults/.claude/commands/loom/curator.md
@@ -1,6 +1,6 @@
 # Issue Curator
 
-You are an issue curator who maintains and enhances the quality of GitHub issues in the {{workspace}} repository.
+You are an issue curator who maintains and enhances the quality of GitHub issues in this repository.
 
 ## Your Role
 

--- a/defaults/.claude/commands/loom/doctor.md
+++ b/defaults/.claude/commands/loom/doctor.md
@@ -1,6 +1,6 @@
 # PR Fixer
 
-You are a PR health specialist working in the {{workspace}} repository, addressing review feedback and keeping pull requests polished and ready to merge.
+You are a PR health specialist working in this repository, addressing review feedback and keeping pull requests polished and ready to merge.
 
 ## Your Role
 
@@ -296,7 +296,7 @@ gh pr edit 588 --remove-label "loom:treating" --add-label "loom:review-requested
    - Fix review comments
    - Resolve merge conflicts
    - Update tests or documentation
-8. **Verify ALL checks pass locally**: Run `pnpm check:ci`
+8. **Verify ALL checks pass locally**: Run the project's check command (see `buildGate.command` in `.loom/config.json`, or the repo's documented CI command, e.g. `pnpm check:ci`)
    - Do NOT push until all local checks pass
    - This prevents multiple fix-push-fail cycles
 9. **Commit and push**: Push your fixes to the PR branch
@@ -378,7 +378,7 @@ CI Failures Found:
 **Verify locally before pushing**:
 ```bash
 # Run ALL checks locally
-pnpm check:ci
+pnpm check:ci   # your repo's check command — see buildGate.command in .loom/config.json
 
 # Or run specific checks
 pnpm test              # Frontend tests
@@ -421,7 +421,7 @@ $ gh run view 12345 --log-failed | tail -50
 # ... make all fixes ...
 
 # 5. Verify locally
-$ pnpm check:ci
+$ pnpm check:ci   # your repo's check command — see buildGate.command in .loom/config.json
 # All checks pass!
 
 # 6. Push and verify
@@ -519,7 +519,7 @@ EOF
 ### Quality Checks
 ```bash
 # Always run full CI before pushing
-pnpm check:ci
+pnpm check:ci   # your repo's check command — see buildGate.command in .loom/config.json
 
 # Check specific areas if review mentioned them
 pnpm test              # If review mentioned testing
@@ -591,7 +591,7 @@ gh pr view 42 --comments
 # (edit files, add tests, fix bugs, resolve conflicts)
 
 # Verify everything works
-pnpm check:ci
+pnpm check:ci   # your repo's check command — see buildGate.command in .loom/config.json
 
 # Commit and push
 git add .
@@ -731,7 +731,7 @@ pnpm lint              # Check linting
 pnpm exec tsc --noEmit # Check types
 
 # Verify full CI suite passes
-pnpm check:ci
+pnpm check:ci   # your repo's check command — see buildGate.command in .loom/config.json
 
 # Only push when ALL checks pass
 git push

--- a/defaults/.claude/commands/loom/driver.md
+++ b/defaults/.claude/commands/loom/driver.md
@@ -1,6 +1,6 @@
 # Default Shell
 
-You are working in a standard shell environment in the {{workspace}} repository.
+You are working in a standard shell environment in this repository.
 
 This is a plain terminal without any specialized role. You can use this for general shell commands, exploration, and ad-hoc tasks.
 

--- a/defaults/.claude/commands/loom/help.md
+++ b/defaults/.claude/commands/loom/help.md
@@ -1,6 +1,6 @@
 # Loom Help
 
-You are a read-only help guide for the Loom command surface installed in the {{workspace}} repository. Your job is to orient the user: explain which `/loom:*` commands are available, what each is for, and where to start.
+You are a read-only help guide for the Loom command surface installed in this repository. Your job is to orient the user: explain which `/loom:*` commands are available, what each is for, and where to start.
 
 **Arguments**: `$ARGUMENTS`
 

--- a/defaults/.claude/commands/loom/hermit-patterns.md
+++ b/defaults/.claude/commands/loom/hermit-patterns.md
@@ -508,7 +508,7 @@ rg "^pub struct \w+ \{\}$" --type rust -n
 
 ```bash
 # Frontend: Check for unused npm packages
-cd {{workspace}}
+cd <repo-root>
 npx depcheck
 
 # Backend: Check Cargo.toml vs actual usage
@@ -788,7 +788,7 @@ When running autonomously (every 15 minutes), each Hermit run randomly selects O
 # 5 Hermits running simultaneously at 3:00 PM
 
 # Hermit Terminal 1 (random selection: dead-code)
-cd {{workspace}}
+cd <repo-root>
 rg "export.*function|export.*class" -n
 # Check which exports are never imported
 # -> Found unused function, create issue
@@ -1048,7 +1048,7 @@ Here's what a typical Critic session looks like:
 
 ```bash
 # 1. Check for unused dependencies
-$ cd {{workspace}}
+$ cd <repo-root>
 $ npx depcheck
 
 Unused dependencies:

--- a/defaults/.claude/commands/loom/hermit.md
+++ b/defaults/.claude/commands/loom/hermit.md
@@ -1,6 +1,6 @@
 # Hermit
 
-You are a code simplification specialist working in the {{workspace}} repository, identifying opportunities to remove bloat and reduce unnecessary complexity.
+You are a code simplification specialist working in this repository, identifying opportunities to remove bloat and reduce unnecessary complexity.
 
 ## Reference Files
 

--- a/defaults/.claude/commands/loom/judge.md
+++ b/defaults/.claude/commands/loom/judge.md
@@ -1,6 +1,6 @@
 # Pull Request Judge
 
-You are a thorough and constructive PR evaluator working in the {{workspace}} repository.
+You are a thorough and constructive PR evaluator working in this repository.
 
 ## ⛔ STOP! READ THIS FIRST - GitHub Review API Is BROKEN
 

--- a/defaults/.claude/commands/loom/loom.md
+++ b/defaults/.claude/commands/loom/loom.md
@@ -1,6 +1,6 @@
 # Loom Daemon
 
-You are the Layer 2 Loom Daemon orchestrator in the {{workspace}} repository. The `loom-daemon` is a Rust binary that exposes an MCP-level dispatch + monitoring + pub/sub surface; you coordinate it via MCP tools, not by spawning shell processes directly.
+You are the Layer 2 Loom Daemon orchestrator in this repository. The `loom-daemon` is a Rust binary that exposes an MCP-level dispatch + monitoring + pub/sub surface; you coordinate it via MCP tools, not by spawning shell processes directly.
 
 ## Arguments
 

--- a/defaults/roles/README.md
+++ b/defaults/roles/README.md
@@ -75,7 +75,7 @@ To create a custom role:
 ```markdown
 # My Custom Role
 
-You are a specialist in {{workspace}} repository...
+You are a specialist in this repository...
 
 ## Your Role
 - Primary responsibility
@@ -118,7 +118,12 @@ Worker completion is detected automatically through **phase contracts** - the or
 
 ### Template Variables
 
-- `{{workspace}}` - Replaced with the absolute path to the workspace directory
+Role prompts are written as plain language ("this repository") rather than
+templated paths. Install-time substitution is limited to the `CLAUDE.md`
+placeholders handled by the installer (`{{REPO_OWNER}}`, `{{REPO_NAME}}`,
+`{{LOOM_VERSION}}`, `{{LOOM_COMMIT}}`, `{{INSTALL_DATE}}`); the `.claude/`
+role and agent files are copied verbatim, with no substitution pass. Do not
+add unimplemented placeholders such as `{{workspace}}` to role files.
 
 ## Default vs Workspace Roles
 

--- a/defaults/roles/doctor.json
+++ b/defaults/roles/doctor.json
@@ -3,7 +3,7 @@
   "description": "Addresses review feedback on PRs labeled loom:changes-requested",
   "suggestedModel": "sonnet",
   "defaultInterval": 300000,
-  "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are a PR Fixer. Check for PRs needing attention: (1) Find PRs with changes requested: `gh pr list --label=\"loom:changes-requested\" --state=open`, (2) For each PR, check review comments: `gh pr view <number>`, (3) Check out the PR branch with `gh pr checkout <number>`, address the feedback, run `pnpm check:ci`, commit and push your fixes, then update labels (remove `loom:changes-requested`, add `loom:review-requested`) and comment that feedback is addressed. For complex changes that require substantial refactoring, create an issue with `loom:triage` + `loom:urgent` labels instead.",
+  "defaultIntervalPrompt": "REMINDER: Follow your system prompt - you are a PR Fixer. Check for PRs needing attention: (1) Find PRs with changes requested: `gh pr list --label=\"loom:changes-requested\" --state=open`, (2) For each PR, check review comments: `gh pr view <number>`, (3) Check out the PR branch with `gh pr checkout <number>`, address the feedback, run the project's check command (`buildGate.command` in `.loom/config.json`, e.g. `pnpm check:ci`), commit and push your fixes, then update labels (remove `loom:changes-requested`, add `loom:review-requested`) and comment that feedback is addressed. For complex changes that require substantial refactoring, create an issue with `loom:triage` + `loom:urgent` labels instead.",
   "autonomousRecommended": true,
   "suggestedWorkerType": "claude",
   "gitIdentity": {


### PR DESCRIPTION
## Summary

Genericizes the prompts under `defaults/` so they read correctly when installed into arbitrary (non-pnpm, non-Loom) target repos. Implements **Option B** from the issue (drop the unimplemented `{{workspace}}` placeholder; zero code changes to `loom-daemon/src/`).

### Changes
1. **Hardcoded `pnpm check:ci` → `buildGate.command`.** Every primary "run this" instruction site now references the project's check command (`buildGate.command` in `.loom/config.json`, with `pnpm check:ci` as an example): `builder.md`, `builder-pr.md` (4 sites), `doctor.md` (6 sites), `loom-doctor.md`, `loom-judge.md`, and `doctor.json`'s `defaultIntervalPrompt`. Code-block sites carry the reference inline on the command line.
2. **Lean-genius postmortem genericized** in `builder.md` — the lesson (downstream build-timeout caps, measure actual build time against actual N) is preserved; the `rjwalters/lean-genius` path/line/PR specifics are removed.
3. **Operator path removed** — the `/Users/rwalters/GitHub/loom` example in `builder.md`'s WRONG block is now `<repo-root>`.
4. **`{{workspace}}` dropped** from the 23 primary role-header files (11 `defaults/.claude/agents/loom-*.md` stubs + 12 `defaults/.claude/commands/loom/*.md` role prompts) → "this repository"; illustrative code blocks in `builder.md:378` and `hermit-patterns.md` (3 sites) → `<repo-root>`. `defaults/roles/README.md`'s Template Variables section no longer documents `{{workspace}}` as install-time substituted.

`defaults/roles/{builder,builder-pr,doctor}.md` are symlinks to the canonical `.claude/commands/loom/*.md` files — only the canonical files were edited (git status shows no duplicate diffs).

### Verification (Test Plan)
- `git ls-tree -r HEAD --name-only -- defaults/.claude/agents defaults/.claude/commands/loom | xargs grep -l '{{workspace}}'` → **zero hits**.
- Every remaining `pnpm check:ci` hit in the primary files is inside a phrase referencing `buildGate.command` / "the project's check command" → **confirmed**.
- `grep -n "lean-genius\|/Users/rwalters" defaults/.claude/commands/loom/builder.md` → **zero hits**.
- No `loom-daemon/src/` changes (Option B).

Closes #3792

🤖 Generated with [Claude Code](https://claude.com/claude-code)