### PR TITLE
feat(daemon): epic supervisor conformance test + event topics + docs (#3842 Phase 4)

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -101,6 +101,15 @@ issue** — the v0.10.0 set is intentionally frozen.
 | `sweep.issue.{N}.crashed` | Daemon reaper                   | `{checkpoint_phase}` |
 | `sweep.global.dispatch`   | Daemon                          | `{sweep_id, kind}` |
 | `sweep.global.completed`  | Daemon                          | `{sweep_id, outcome}` |
+| `epic.issue.{N}.decompose` | Epic supervisor (#3842)        | `{epic, action, state}` |
+| `epic.issue.{N}.expand`    | Epic supervisor (#3842)        | `{epic, action, state}` |
+| `epic.issue.{N}.join`      | Epic supervisor (#3842)        | `{epic, action, state}` |
+| `epic.issue.{N}.close`     | Epic supervisor (#3842)        | `{epic, action, state}` |
+
+The four `epic.issue.{N}.*` topics were authorized by **#3873** (epic #3842
+Phase 4) and are documented in full under [Epic supervisor](#epic-supervisor-3842)
+below. They ride the same in-memory bus as the sweep topics and are tailable via
+`subscribe_to_events` / `tail_event_bus`.
 
 In addition, the bus internally emits:
 
@@ -348,6 +357,105 @@ issue is still `loom:building` with a comment. Doctor invokes it as a documented
 best-effort step after pushing to a `feature/issue-<N>` branch. **Dependency
 auto-detection**, **diamonds / multi-parent**, and **auto-detach** remain **out
 of scope** (deferred items of the v2 epic #3747).
+
+## Epic supervisor (#3842)
+
+The **epic supervisor** (epic #3842) drives every open `loom:epic` issue
+through a fork-join lifecycle autonomously. It runs as an opt-in loop on a
+**dedicated OS thread** with its own current-thread Tokio runtime (`#3872`) —
+never `tokio::spawn` on the shared daemon runtime — because each transition can
+block on a minutes-long role process (`Command::status()`) while holding the
+#3707 issue-creation mutex. Keeping that blocking call off the shared runtime
+preserves the responsiveness of the event bus, reaper, sweep registry, and IPC
+listener.
+
+Enable it with `LOOM_EPIC_SUPERVISOR=1` (unset/false-y = OFF). Tunables:
+`LOOM_EPIC_SUPERVISOR_INTERVAL_SECS` (default 300) and
+`LOOM_EPIC_INFLIGHT_TTL_SECS` (default 900).
+
+### Derived-state model
+
+Rather than mint new GitHub labels per phase, all five supervisor states ride
+the single `loom:epic` label and are **derived** — computed each tick from two
+already-visible facts: the number of `### Phase` sections in the epic body, and
+the open/closed status of the epic's `loom:epic-phase` children. The five states
+(implemented as `EpicState` in
+[`loom-daemon/src/epic_state.rs`](../../loom-daemon/src/epic_state.rs)) mirror
+the `derived=True` epic lane of the authoritative Python model
+([`loom-tools/src/loom_tools/state_machine.py`](../../loom-tools/src/loom_tools/state_machine.py),
+#3841):
+
+| Derived state | Condition | Enabled transition |
+|---------------|-----------|--------------------|
+| `epic:needs_decomp` | body has `< 2` `### Phase` sections | **decompose** — Architect enriches the body in place (no PR) |
+| `epic:designed` | `≥ 2` phases, no `epic-phase` children yet | **expand** — Champion materializes phase-1 children (under the #3707 mutex) |
+| `epic:active` | a current-phase child is open | per-child `/loom:sweep` dispatch (`BuildChildren`) |
+| `epic:phase_join` | current phase's children all closed, more phases remain | **join** — Champion materializes phase N+1 children (mutex + barrier-gated) |
+| `epic:done` | all phases' children closed, no phases remain | **close** — Champion closes the epic (terminal) |
+
+### Transition table + phase-join barrier
+
+The five intra-lane edges among the derived states — the "epic transition
+table" — are declared explicitly in `epic_state::epic_transition_table()`:
+
+```text
+epic:needs_decomp → epic:designed    (Champion, creates_issues)   [decompose]
+epic:designed     → epic:active      (Champion)                   [expand]
+epic:active       → epic:phase_join  (Supervisor, barrier)        [fork-join]
+epic:phase_join   → epic:active      (Supervisor, barrier)        [join/advance]
+epic:phase_join   → epic:done        (Supervisor, barrier)        [close]
+```
+
+Every edge touching `epic:phase_join` is a **phase-boundary edge** and declares
+a non-empty fork-join barrier
+([`loom-daemon/src/phase_join.rs`](../../loom-daemon/src/phase_join.rs)): the
+barrier holds — degrading the plan to a no-op — until every child of the current
+phase is closed, so phase N+1 (or epic close) never fires while a current-phase
+child is still open.
+
+The lane-*entry* edge `new → epic:needs_decomp` (an Architect filing a
+`loom:epic` proposal) is **not** part of the supervisor's table — the supervisor
+begins its lifecycle at `epic:needs_decomp`.
+
+**Conformance.** The Rust transition table is asserted faithful to the Python
+model by
+[`loom-daemon/tests/epic_conformance.rs`](../../loom-daemon/tests/epic_conformance.rs),
+which **derives** its expectation by invoking
+`python3 -m loom_tools.state_machine --json` and comparing the emitted epic
+sub-graph (states, edges, roles, barriers, `creates_issues`) against the Rust
+table — rather than hardcoding a mirrored copy that would silently drift. The
+test skips gracefully when `python3` is unavailable.
+
+### #3707 issue-creation mutex
+
+The two issue-creating expand bursts (`decompose`'s downstream and both
+`expand`/`join` Champion dispatches that run `gh issue create`) are serialized
+through the global **#3707 issue-creation mutex**
+([`loom-daemon/src/issue_creation_mutex.rs`](../../loom-daemon/src/issue_creation_mutex.rs)).
+The supervisor holds the async guard across the whole (spawn-and-wait) dispatch
+so a burst never interleaves with any other issue-creating burst anywhere in the
+daemon. All epic expands share the single `CHAMPION_EPIC_DECOMP` serialization
+identity.
+
+### Event topics
+
+Each of the four singleton action-class transitions publishes an
+`epic.issue.{N}.{action}` event on the shared event bus when it fires, so the
+supervisor's decisions are tailable via `subscribe_to_events` /
+`tail_event_bus`:
+
+| Topic | Fires from | Payload |
+|-------|-----------|---------|
+| `epic.issue.{N}.decompose` | `epic:needs_decomp` | `{epic, action: "decompose", state: "epic:needs_decomp"}` |
+| `epic.issue.{N}.expand`    | `epic:designed`     | `{epic, action: "expand", state: "epic:designed"}` |
+| `epic.issue.{N}.join`      | `epic:phase_join`   | `{epic, action: "join", state: "epic:phase_join"}` |
+| `epic.issue.{N}.close`     | `epic:done`         | `{epic, action: "close", state: "epic:done"}` |
+
+The `BuildChildren` transition (per-child `/loom:sweep` dispatch) has **no**
+epic-action topic — those dispatches already surface on the frozen
+`sweep.global.dispatch` topic. Subscribe to `epic.issue` to receive every
+epic-supervisor action across all epics, or `epic.issue.{N}` for one epic
+(segment-aligned prefix match, same routing rule as the sweep topics).
 
 ## Locks and lifecycle
 

--- a/loom-daemon/src/epic_state.rs
+++ b/loom-daemon/src/epic_state.rs
@@ -107,6 +107,110 @@ impl std::fmt::Display for EpicState {
     }
 }
 
+/// A directed edge in the epic-supervisor transition table.
+///
+/// This is the **Rust side** of the epic sub-graph — the transitions among the
+/// five derived [`EpicState`]s that the supervisor loop drives. It exists as an
+/// explicit, inspectable artifact (rather than only implicitly inside
+/// `plan_epic_transition`) so it can be documented and, crucially,
+/// **conformance-checked** against the authoritative Python model in
+/// `loom-tools/src/loom_tools/state_machine.py` (epic #3842 Phase 4, #3873).
+///
+/// Only intra-lane edges are modelled — both [`src`](Self::src) and
+/// [`dst`](Self::dst) are `epic:*` derived state ids. The lane-*entry* edge
+/// (`new → epic:needs_decomp`, the Architect filing a `loom:epic` proposal) is
+/// deliberately excluded: it is not a supervisor transition, and the supervisor
+/// begins its lifecycle at [`EpicState::NeedsDecomp`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EpicEdge {
+    /// Source state id (an `epic:*` derived state).
+    pub src: &'static str,
+    /// Destination state id (an `epic:*` derived state).
+    pub dst: &'static str,
+    /// The role that fires the edge, matching the Python model's `Role` value
+    /// (e.g. `"Champion"`, `"Supervisor"`).
+    pub role: &'static str,
+    /// The fork-join barrier description on phase-boundary edges (any edge
+    /// touching `epic:phase_join`), or `""` for non-boundary edges. Matches the
+    /// Python model's `Transition.barrier` string exactly.
+    pub barrier: &'static str,
+    /// Whether firing this edge runs `gh issue create` — the set the #3707
+    /// issue-creation mutex serializes. Matches the Python `creates_issues` flag.
+    pub creates_issues: bool,
+}
+
+/// The epic-supervisor transition table: the five edges among the five derived
+/// [`EpicState`]s.
+///
+/// Faithful to the epic sub-graph of the Python state-machine model (#3841) —
+/// same edges, roles, barriers, and `creates_issues` flags. The conformance
+/// test (`loom-daemon/tests/epic_conformance.rs`) derives its expectation by
+/// parsing the Python model and asserts this table matches it, so drift between
+/// the two representations is caught mechanically rather than by hand.
+///
+/// The edges (matching `plan_epic_transition` + `barrier_admits`):
+///
+/// ```text
+/// epic:needs_decomp → epic:designed    (Champion, creates_issues)   [decompose]
+/// epic:designed     → epic:active      (Champion)                   [expand]
+/// epic:active       → epic:phase_join  (Supervisor, barrier)        [fork-join]
+/// epic:phase_join   → epic:active      (Supervisor, barrier)        [join/advance]
+/// epic:phase_join   → epic:done        (Supervisor, barrier)        [close]
+/// ```
+#[must_use]
+pub fn epic_transition_table() -> [EpicEdge; 5] {
+    [
+        EpicEdge {
+            src: "epic:needs_decomp",
+            dst: "epic:designed",
+            role: "Champion",
+            barrier: "",
+            creates_issues: true,
+        },
+        EpicEdge {
+            src: "epic:designed",
+            dst: "epic:active",
+            role: "Champion",
+            barrier: "",
+            creates_issues: false,
+        },
+        EpicEdge {
+            src: "epic:active",
+            dst: "epic:phase_join",
+            role: "Supervisor",
+            barrier: "fork-join: current phase complete",
+            creates_issues: false,
+        },
+        EpicEdge {
+            src: "epic:phase_join",
+            dst: "epic:active",
+            role: "Supervisor",
+            barrier: "advance: dispatch next phase",
+            creates_issues: false,
+        },
+        EpicEdge {
+            src: "epic:phase_join",
+            dst: "epic:done",
+            role: "Supervisor",
+            barrier: "join: all phases complete",
+            creates_issues: false,
+        },
+    ]
+}
+
+/// All five derived epic state ids, in lifecycle order. Mirrors the `EpicState`
+/// variants and the Python model's `lane == epic` states.
+#[must_use]
+pub fn epic_state_ids() -> [&'static str; 5] {
+    [
+        EpicState::NeedsDecomp.as_state_id(),
+        EpicState::Designed.as_state_id(),
+        EpicState::Active.as_state_id(),
+        EpicState::PhaseJoin.as_state_id(),
+        EpicState::Done.as_state_id(),
+    ]
+}
+
 /// A materialized `loom:epic-phase` child of an epic, reduced to the two facts
 /// the derived-state computation needs: which phase it belongs to, and whether
 /// it is still open.
@@ -368,6 +472,65 @@ details
         assert_eq!(EpicState::Active.as_state_id(), "epic:active");
         assert_eq!(EpicState::PhaseJoin.as_state_id(), "epic:phase_join");
         assert_eq!(EpicState::Done.as_state_id(), "epic:done");
+    }
+
+    // ===== epic transition table (conformance artifact, #3873) =====
+
+    #[test]
+    fn test_epic_state_ids_matches_variants() {
+        assert_eq!(
+            epic_state_ids(),
+            [
+                "epic:needs_decomp",
+                "epic:designed",
+                "epic:active",
+                "epic:phase_join",
+                "epic:done",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_epic_transition_table_shape() {
+        let table = epic_transition_table();
+        assert_eq!(table.len(), 5);
+
+        // Every edge's endpoints are known derived epic states.
+        let ids: std::collections::HashSet<&str> = epic_state_ids().into_iter().collect();
+        for e in &table {
+            assert!(ids.contains(e.src), "unknown src {}", e.src);
+            assert!(ids.contains(e.dst), "unknown dst {}", e.dst);
+        }
+
+        // Exactly one issue-creating edge (needs_decomp → designed).
+        let creators: Vec<_> = table.iter().filter(|e| e.creates_issues).collect();
+        assert_eq!(creators.len(), 1);
+        assert_eq!(creators[0].src, "epic:needs_decomp");
+        assert_eq!(creators[0].dst, "epic:designed");
+
+        // Exactly three phase-boundary (barrier) edges — every edge touching
+        // epic:phase_join declares a non-empty barrier.
+        let boundary: Vec<_> = table
+            .iter()
+            .filter(|e| e.src == "epic:phase_join" || e.dst == "epic:phase_join")
+            .collect();
+        assert_eq!(boundary.len(), 3);
+        for e in boundary {
+            assert!(!e.barrier.is_empty(), "boundary edge {}->{} needs a barrier", e.src, e.dst);
+        }
+
+        // Non-boundary edges carry no barrier.
+        for e in &table {
+            let touches_join = e.src == "epic:phase_join" || e.dst == "epic:phase_join";
+            if !touches_join {
+                assert!(
+                    e.barrier.is_empty(),
+                    "non-boundary edge {}->{} must have no barrier",
+                    e.src,
+                    e.dst
+                );
+            }
+        }
     }
 
     #[test]

--- a/loom-daemon/src/epic_supervisor.rs
+++ b/loom-daemon/src/epic_supervisor.rs
@@ -72,8 +72,10 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result};
 
 use crate::epic_state::{count_phase_sections, derive_epic_state, EpicState, PhaseChild};
+use crate::event_bus::EventBus;
 use crate::issue_creation_mutex::{IssueCreationMutex, CHAMPION_EPIC_DECOMP};
 use crate::phase_join::{barrier_admits, PhaseBoundary};
+use crate::types::{EpicActionClass, Event};
 
 // ============================================================================
 // Constants
@@ -235,6 +237,26 @@ impl EpicTransition {
     #[must_use]
     pub fn is_noop(&self) -> bool {
         matches!(self, EpicTransition::Noop)
+    }
+}
+
+impl TransitionKind {
+    /// The event-bus [`EpicActionClass`] this transition emits when fired, or
+    /// `None` for transitions with no action-class topic.
+    ///
+    /// The four singleton lifecycle transitions each map to one action class
+    /// (decompose / expand / join / close). [`BuildChildren`](Self::BuildChildren)
+    /// and [`Noop`](Self::Noop) have none — per-child sweeps already surface on
+    /// `sweep.global.dispatch`, and a no-op fires nothing.
+    #[must_use]
+    pub fn action_class(self) -> Option<EpicActionClass> {
+        match self {
+            TransitionKind::DesignInPlace => Some(EpicActionClass::Decompose),
+            TransitionKind::ExpandFirstPhase => Some(EpicActionClass::Expand),
+            TransitionKind::AdvancePhase => Some(EpicActionClass::Join),
+            TransitionKind::CloseEpic => Some(EpicActionClass::Close),
+            TransitionKind::BuildChildren | TransitionKind::Noop => None,
+        }
     }
 }
 
@@ -433,6 +455,9 @@ pub struct EpicSupervisor<S: EpicSource, D: EpicDispatcher> {
     /// process lifetime (globally unique across epics).
     dispatched_children: HashSet<u32>,
     inflight_ttl: Duration,
+    /// Optional event bus for publishing epic-action topics (#3873). When
+    /// absent the supervisor runs silently (unit-test / no-observability path).
+    bus: Option<Arc<EventBus>>,
 }
 
 impl<S: EpicSource, D: EpicDispatcher> EpicSupervisor<S, D> {
@@ -447,6 +472,7 @@ impl<S: EpicSource, D: EpicDispatcher> EpicSupervisor<S, D> {
             in_flight: HashMap::new(),
             dispatched_children: HashSet::new(),
             inflight_ttl: resolve_inflight_ttl(),
+            bus: None,
         }
     }
 
@@ -454,6 +480,14 @@ impl<S: EpicSource, D: EpicDispatcher> EpicSupervisor<S, D> {
     #[must_use]
     pub fn with_inflight_ttl(mut self, ttl: Duration) -> Self {
         self.inflight_ttl = ttl;
+        self
+    }
+
+    /// Attach an event bus so fired action-class transitions publish
+    /// `epic.issue.{N}.{action}` events (#3873). Builder-style; returns `self`.
+    #[must_use]
+    pub fn with_event_bus(mut self, bus: Arc<EventBus>) -> Self {
+        self.bus = Some(bus);
         self
     }
 
@@ -597,11 +631,32 @@ impl<S: EpicSource, D: EpicDispatcher> EpicSupervisor<S, D> {
                     },
                 );
                 report.roles_dispatched += 1;
+                self.emit_action(epic, kind);
             }
             Err(e) => {
                 report.errors += 1;
                 log::warn!("epic_supervisor: {} dispatch for epic #{epic} failed: {e}", shape.role);
             }
+        }
+    }
+
+    /// Publish an `epic.issue.{epic}.{action}` event for a just-fired singleton
+    /// transition, when the transition maps to an [`EpicActionClass`] and a bus
+    /// is attached. Best-effort — a missing bus or absent subscribers is not an
+    /// error (mirrors the sweep-registry publish convention).
+    fn emit_action(&self, epic: u32, kind: TransitionKind) {
+        let (Some(bus), Some(action)) = (self.bus.as_ref(), kind.action_class()) else {
+            return;
+        };
+        let event = Event::EpicAction {
+            epic,
+            action,
+            state: action.source_state_id().to_string(),
+        };
+        let topic = event.topic();
+        match bus.publish(event) {
+            Ok(n) => log::debug!("event_bus: published {topic} to {n} subscriber(s)"),
+            Err(_) => log::debug!("event_bus: published {topic} (no subscribers)"),
         }
     }
 
@@ -1337,6 +1392,125 @@ mod tests {
         let (_epic, shape) = &sup.dispatcher.roles[0];
         assert_eq!(shape.role, "Champion");
         assert!(shape.prompt.contains("Close epic"));
+    }
+
+    // ===================================================================
+    // Event-bus action topics (#3873)
+    // ===================================================================
+
+    #[test]
+    fn test_transition_kind_action_class_mapping() {
+        assert_eq!(TransitionKind::DesignInPlace.action_class(), Some(EpicActionClass::Decompose));
+        assert_eq!(TransitionKind::ExpandFirstPhase.action_class(), Some(EpicActionClass::Expand));
+        assert_eq!(TransitionKind::AdvancePhase.action_class(), Some(EpicActionClass::Join));
+        assert_eq!(TransitionKind::CloseEpic.action_class(), Some(EpicActionClass::Close));
+        // BuildChildren is covered by sweep.global.dispatch; Noop fires nothing.
+        assert_eq!(TransitionKind::BuildChildren.action_class(), None);
+        assert_eq!(TransitionKind::Noop.action_class(), None);
+    }
+
+    #[tokio::test]
+    async fn test_tick_publishes_decompose_event() {
+        let bus = Arc::new(EventBus::new());
+        let mut sub = bus.subscribe(["epic.issue"]);
+        let mut sup = supervisor(vec![EpicSnapshot::new(1, "flat body", vec![], vec![])])
+            .with_event_bus(bus.clone());
+
+        let _ = sup.tick().await.unwrap();
+
+        let event = sub.try_recv().expect("a decompose event was published");
+        assert_eq!(event.topic(), "epic.issue.1.decompose");
+        match event {
+            Event::EpicAction {
+                epic,
+                action,
+                state,
+            } => {
+                assert_eq!(epic, 1);
+                assert_eq!(action, EpicActionClass::Decompose);
+                assert_eq!(state, "epic:needs_decomp");
+            }
+            other => panic!("expected EpicAction, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_tick_publishes_expand_and_close_events() {
+        // designed → expand
+        let bus = Arc::new(EventBus::new());
+        let mut sub = bus.subscribe::<[&str; 0], &str>([]);
+        let mut sup = supervisor(vec![EpicSnapshot::new(2, body_with_phases(3), vec![], vec![])])
+            .with_event_bus(bus.clone());
+        let _ = sup.tick().await.unwrap();
+        assert_eq!(sub.try_recv().unwrap().topic(), "epic.issue.2.expand");
+
+        // done → close
+        let bus2 = Arc::new(EventBus::new());
+        let mut sub2 = bus2.subscribe::<[&str; 0], &str>([]);
+        let mut sup2 = supervisor(vec![EpicSnapshot::new(
+            6,
+            body_with_phases(2),
+            vec![closed(1), closed(2)],
+            vec![],
+        )])
+        .with_event_bus(bus2.clone());
+        let _ = sup2.tick().await.unwrap();
+        assert_eq!(sub2.try_recv().unwrap().topic(), "epic.issue.6.close");
+    }
+
+    #[tokio::test]
+    async fn test_tick_publishes_join_event() {
+        let bus = Arc::new(EventBus::new());
+        let mut sub = bus.subscribe(["epic.issue.5.join"]);
+        let mut sup = supervisor(vec![EpicSnapshot::new(
+            5,
+            body_with_phases(3),
+            vec![closed(1)],
+            vec![],
+        )])
+        .with_event_bus(bus.clone());
+
+        let _ = sup.tick().await.unwrap();
+
+        let event = sub.try_recv().expect("a join event was published");
+        assert_eq!(event.topic(), "epic.issue.5.join");
+        match event {
+            Event::EpicAction { action, state, .. } => {
+                assert_eq!(action, EpicActionClass::Join);
+                assert_eq!(state, "epic:phase_join");
+            }
+            other => panic!("expected EpicAction, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_build_children_publishes_no_epic_action_event() {
+        // active → BuildChildren must NOT emit an epic.issue.*.{action} event;
+        // per-child sweeps surface on sweep.global.dispatch instead.
+        let bus = Arc::new(EventBus::new());
+        let mut sub = bus.subscribe(["epic.issue"]);
+        let mut sup = supervisor(vec![EpicSnapshot::new(
+            3,
+            body_with_phases(3),
+            vec![open(1)],
+            vec![301],
+        )])
+        .with_event_bus(bus.clone());
+
+        let report = sup.tick().await.unwrap();
+        assert_eq!(report.sweeps_dispatched, 1);
+        assert!(
+            matches!(sub.try_recv(), Err(crate::event_bus::RecvError::Empty)),
+            "BuildChildren must not publish an epic-action event"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_no_bus_is_silent_and_still_dispatches() {
+        // Without an attached bus the supervisor still dispatches normally.
+        let mut sup = supervisor(vec![EpicSnapshot::new(1, "flat body", vec![], vec![])]);
+        let report = sup.tick().await.unwrap();
+        assert_eq!(report.roles_dispatched, 1);
     }
 
     // ===================================================================

--- a/loom-daemon/src/event_bus.rs
+++ b/loom-daemon/src/event_bus.rs
@@ -27,12 +27,18 @@
 //! | `sweep.issue.{N}.crashed` | Daemon reaper | `{checkpoint_phase}` |
 //! | `sweep.global.dispatch`   | Daemon | `{sweep_id, kind}` |
 //! | `sweep.global.completed`  | Daemon | `{sweep_id, outcome}` |
+//! | `epic.issue.{N}.decompose` | Epic supervisor | `{epic, action, state}` |
+//! | `epic.issue.{N}.expand`    | Epic supervisor | `{epic, action, state}` |
+//! | `epic.issue.{N}.join`      | Epic supervisor | `{epic, action, state}` |
+//! | `epic.issue.{N}.close`     | Epic supervisor | `{epic, action, state}` |
 //!
 //! New topics require a follow-up issue — the taxonomy is intentionally
-//! pinned. The bus accepts arbitrary topic strings (`publish` does not
-//! reject unknown topics) so the publisher side stays open for future
-//! extension, but the documented taxonomy is the contract subscribers
-//! should rely on for v0.10.0.
+//! pinned. The four `epic.issue.{N}.*` topics were authorized by **#3873**
+//! (epic #3842 Phase 4) for the epic supervisor's action classes
+//! (decompose / expand / join / close). The bus accepts arbitrary topic
+//! strings (`publish` does not reject unknown topics) so the publisher side
+//! stays open for future extension, but the documented taxonomy is the
+//! contract subscribers should rely on.
 
 use crate::types::Event;
 

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -260,7 +260,8 @@ async fn main() -> Result<()> {
                 let source = epic_supervisor::forge::GhEpicSource::new();
                 let dispatcher =
                     epic_supervisor::forge::SpawnDispatcher::new(spawn_bin, sweep_registry.clone());
-                let supervisor = EpicSupervisor::new(source, dispatcher, IssueCreationMutex::new());
+                let supervisor = EpicSupervisor::new(source, dispatcher, IssueCreationMutex::new())
+                    .with_event_bus(event_bus.clone());
                 let interval = epic_supervisor::resolve_supervisor_interval();
                 match epic_supervisor::spawn_supervisor_thread(supervisor, interval) {
                     Ok(handle) => {

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -555,6 +555,17 @@ pub enum Event {
         sweep_id: SweepId,
         outcome: SweepOutcome,
     },
+    /// `epic.issue.{N}.{action}` — the epic supervisor (#3842) fired one of its
+    /// four action-class transitions for epic `{N}`. Published by the epic
+    /// supervisor loop; authorized by #3873 (epic #3842 Phase 4).
+    EpicAction {
+        epic: u32,
+        action: EpicActionClass,
+        /// The derived epic state the action fired from (e.g.
+        /// `"epic:needs_decomp"`). Redundant with `action` but carried for
+        /// observability so subscribers see the source state directly.
+        state: String,
+    },
     /// Synthetic event signalling that the subscription fell behind the
     /// publisher. The number of events dropped is reported in `skipped`.
     /// Matches `tokio::sync::broadcast::Receiver::Lagged` semantics.
@@ -581,6 +592,7 @@ impl Event {
     /// | `SweepCrashed {issue, ..}` | `sweep.issue.{issue}.crashed` |
     /// | `SweepGlobalDispatch {..}` | `sweep.global.dispatch` |
     /// | `SweepGlobalCompleted {..}` | `sweep.global.completed` |
+    /// | `EpicAction {epic, action, ..}` | `epic.issue.{epic}.{action}` |
     /// | `TopicLag {..}` | `sweep.system.topic_lag` |
     /// | `Generic {topic, ..}` | the explicit topic string |
     #[must_use]
@@ -592,8 +604,63 @@ impl Event {
             Self::SweepCrashed { issue, .. } => format!("sweep.issue.{issue}.crashed"),
             Self::SweepGlobalDispatch { .. } => "sweep.global.dispatch".to_string(),
             Self::SweepGlobalCompleted { .. } => "sweep.global.completed".to_string(),
+            Self::EpicAction { epic, action, .. } => {
+                format!("epic.issue.{epic}.{}", action.as_str())
+            }
             Self::TopicLag { .. } => "sweep.system.topic_lag".to_string(),
             Self::Generic { topic, .. } => topic.clone(),
+        }
+    }
+}
+
+/// The four action classes the epic supervisor emits on the event bus, one per
+/// singleton lifecycle transition (epic #3842 Phase 4, #3873).
+///
+/// | Variant | Fires from | Supervisor transition |
+/// |---------|-----------|-----------------------|
+/// | [`Decompose`](Self::Decompose) | `epic:needs_decomp` | Architect enriches the epic body with `### Phase` structure |
+/// | [`Expand`](Self::Expand)       | `epic:designed`     | Champion materializes the first phase's children |
+/// | [`Join`](Self::Join)           | `epic:phase_join`   | Champion advances: materializes phase N+1's children (barrier-gated) |
+/// | [`Close`](Self::Close)         | `epic:done`         | Champion closes the completed epic |
+///
+/// The `BuildChildren` transition (per-child `/loom:sweep` dispatch) is **not**
+/// an action class here — those dispatches already surface on the frozen
+/// `sweep.global.dispatch` topic.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum EpicActionClass {
+    /// Decompose an undecomposed epic (`epic:needs_decomp` → `epic:designed`).
+    Decompose,
+    /// Expand the first phase's children (`epic:designed` → `epic:active`).
+    Expand,
+    /// Fork-join advance to the next phase (`epic:phase_join` → `epic:active`).
+    Join,
+    /// Close a completed epic (`epic:done`).
+    Close,
+}
+
+impl EpicActionClass {
+    /// The lower-case topic segment for this action, e.g. `"decompose"`. Used to
+    /// build the `epic.issue.{N}.{action}` topic string.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Decompose => "decompose",
+            Self::Expand => "expand",
+            Self::Join => "join",
+            Self::Close => "close",
+        }
+    }
+
+    /// The derived epic state id this action fires from (e.g.
+    /// `"epic:needs_decomp"` for [`Decompose`](Self::Decompose)).
+    #[must_use]
+    pub fn source_state_id(self) -> &'static str {
+        match self {
+            Self::Decompose => "epic:needs_decomp",
+            Self::Expand => "epic:designed",
+            Self::Join => "epic:phase_join",
+            Self::Close => "epic:done",
         }
     }
 }

--- a/loom-daemon/tests/epic_conformance.rs
+++ b/loom-daemon/tests/epic_conformance.rs
@@ -1,0 +1,238 @@
+//! Conformance test: the Rust epic transition table vs. the authoritative
+//! Python state-machine model (epic #3842 Phase 4, #3873).
+//!
+//! # Why this test derives its expectation (not hardcodes it)
+//!
+//! Per prior Judge feedback (#3867): a conformance test that hardcodes a
+//! mirrored copy of the graph silently drifts and fails to catch the exact
+//! divergence a conformance test exists to catch. So this test **derives** its
+//! expectation by invoking the authoritative Python model
+//! (`loom-tools/src/loom_tools/state_machine.py --json`), parsing the emitted
+//! epic sub-graph (states, edges, barriers), and asserting the Rust
+//! [`loom_daemon::epic_state::epic_transition_table`] conforms to it.
+//!
+//! If the Python model changes an epic edge, a role, a barrier string, or the
+//! `creates_issues` flag, this test fails until the Rust table is brought back
+//! into agreement — real drift is caught mechanically.
+//!
+//! # Gating
+//!
+//! The test shells out to `python3`. On a host without it (or where the model
+//! module can't be imported), the test prints a skip message and returns
+//! rather than failing — but in this repo's normal dev/CI environment
+//! (`python3` present, `loom-tools/src` on disk) it runs and asserts.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+use std::process::Command;
+
+use loom_daemon::epic_state::{epic_state_ids, epic_transition_table, EpicState};
+
+/// Repo root = the loom-daemon crate dir's parent.
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("loom-daemon has a parent dir")
+        .to_path_buf()
+}
+
+/// A minimally-typed view of one Python edge, extracted from the `--json` dump.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DerivedEdge {
+    src: String,
+    dst: String,
+    role: String,
+    barrier: String,
+    creates_issues: bool,
+}
+
+/// Invoke the Python model's JSON exporter and return `(epic_state_ids,
+/// epic_edges, terminal_state_ids)` for the epic sub-graph, or `None` when
+/// `python3` / the model is unavailable (skip path).
+fn derive_python_epic_subgraph() -> Option<(BTreeSet<String>, Vec<DerivedEdge>, BTreeSet<String>)> {
+    let root = repo_root();
+    let pythonpath = root.join("loom-tools").join("src");
+
+    let output = Command::new("python3")
+        .arg("-m")
+        .arg("loom_tools.state_machine")
+        .arg("--json")
+        .env("PYTHONPATH", &pythonpath)
+        .current_dir(&root)
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        eprintln!(
+            "SKIP: `python3 -m loom_tools.state_machine --json` failed \
+             (status {:?}); stderr:\n{}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        return None;
+    }
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
+
+    // Epic-lane states.
+    let mut epic_states: BTreeSet<String> = BTreeSet::new();
+    let mut terminals: BTreeSet<String> = BTreeSet::new();
+    for s in json["states"].as_array()? {
+        if s["lane"].as_str() == Some("epic") {
+            let id = s["id"].as_str()?.to_string();
+            if s["terminal"].as_bool() == Some(true) {
+                terminals.insert(id.clone());
+            }
+            epic_states.insert(id);
+        }
+    }
+
+    // Epic sub-graph edges: BOTH endpoints are epic-lane states. This scopes to
+    // the supervisor's own transitions among the five derived states and
+    // deliberately excludes the lane-entry edge `new → epic:needs_decomp` (src
+    // `new` is not an epic state) — the Rust supervisor begins at needs_decomp.
+    let mut edges: Vec<DerivedEdge> = Vec::new();
+    for t in json["transitions"].as_array()? {
+        let src = t["src"].as_str()?.to_string();
+        let dst = t["dst"].as_str()?.to_string();
+        if epic_states.contains(&src) && epic_states.contains(&dst) {
+            edges.push(DerivedEdge {
+                src,
+                dst,
+                role: t["role"].as_str()?.to_string(),
+                barrier: t["barrier"].as_str().unwrap_or("").to_string(),
+                creates_issues: t["creates_issues"].as_bool().unwrap_or(false),
+            });
+        }
+    }
+
+    Some((epic_states, edges, terminals))
+}
+
+#[test]
+fn rust_epic_states_conform_to_python_model() {
+    let Some((py_states, _edges, py_terminals)) = derive_python_epic_subgraph() else {
+        return; // skip: python3/model unavailable
+    };
+
+    // The five Rust EpicState ids must exactly equal the Python epic-lane states.
+    let rust_states: BTreeSet<String> = epic_state_ids().iter().map(|s| s.to_string()).collect();
+    assert_eq!(
+        rust_states, py_states,
+        "Rust EpicState ids diverge from the Python epic-lane states"
+    );
+    assert_eq!(rust_states.len(), 5, "expected exactly five derived epic states");
+
+    // Terminal conformance: Python's terminal epic state(s) must match Rust's
+    // `is_terminal` (only epic:done).
+    let rust_terminals: BTreeSet<String> = [
+        EpicState::NeedsDecomp,
+        EpicState::Designed,
+        EpicState::Active,
+        EpicState::PhaseJoin,
+        EpicState::Done,
+    ]
+    .into_iter()
+    .filter(|s| s.is_terminal())
+    .map(|s| s.as_state_id().to_string())
+    .collect();
+    assert_eq!(
+        rust_terminals, py_terminals,
+        "Rust terminal epic state(s) diverge from the Python model"
+    );
+    assert_eq!(
+        rust_terminals,
+        BTreeSet::from(["epic:done".to_string()]),
+        "epic:done must be the sole terminal derived state"
+    );
+}
+
+#[test]
+fn rust_epic_edges_conform_to_python_model() {
+    let Some((_states, py_edges, _terminals)) = derive_python_epic_subgraph() else {
+        return; // skip: python3/model unavailable
+    };
+
+    // Key edges by (src, dst) for order-independent comparison.
+    let py_by_key: BTreeMap<(String, String), &DerivedEdge> = py_edges
+        .iter()
+        .map(|e| ((e.src.clone(), e.dst.clone()), e))
+        .collect();
+
+    let rust_edges = epic_transition_table();
+    let rust_by_key: BTreeMap<(String, String), _> = rust_edges
+        .iter()
+        .map(|e| ((e.src.to_string(), e.dst.to_string()), e))
+        .collect();
+
+    // Same set of (src, dst) edges.
+    let py_keys: BTreeSet<_> = py_by_key.keys().cloned().collect();
+    let rust_keys: BTreeSet<_> = rust_by_key.keys().cloned().collect();
+    assert_eq!(
+        rust_keys, py_keys,
+        "Rust epic transition edges (src->dst) diverge from the Python model.\n\
+         Python: {py_keys:?}\nRust:   {rust_keys:?}"
+    );
+
+    // Field-by-field conformance for every edge: role, barrier, creates_issues.
+    for (key, py) in &py_by_key {
+        let rust = rust_by_key.get(key).expect("edge key present in both");
+        assert_eq!(
+            rust.role, py.role,
+            "edge {}->{}: role differs (rust={:?}, python={:?})",
+            key.0, key.1, rust.role, py.role
+        );
+        assert_eq!(
+            rust.barrier, py.barrier,
+            "edge {}->{}: barrier differs (rust={:?}, python={:?})",
+            key.0, key.1, rust.barrier, py.barrier
+        );
+        assert_eq!(
+            rust.creates_issues, py.creates_issues,
+            "edge {}->{}: creates_issues differs (rust={}, python={})",
+            key.0, key.1, rust.creates_issues, py.creates_issues
+        );
+    }
+
+    // Sanity: the epic sub-graph has exactly five intra-lane edges.
+    assert_eq!(rust_edges.len(), 5, "expected five epic transition-table edges");
+}
+
+#[test]
+fn phase_join_barrier_conforms_to_python_model() {
+    let Some((_states, py_edges, _terminals)) = derive_python_epic_subgraph() else {
+        return; // skip: python3/model unavailable
+    };
+
+    // Every Python edge touching epic:phase_join must declare a non-empty
+    // barrier (the barrier-hygiene invariant), and the Rust table must carry the
+    // identical barrier string on the same edge.
+    let rust_edges = epic_transition_table();
+    let mut checked = 0;
+    for py in &py_edges {
+        let touches_join = py.src == "epic:phase_join" || py.dst == "epic:phase_join";
+        if !touches_join {
+            continue;
+        }
+        assert!(
+            !py.barrier.is_empty(),
+            "python phase-boundary edge {}->{} must declare a barrier",
+            py.src,
+            py.dst
+        );
+        let rust = rust_edges
+            .iter()
+            .find(|e| e.src == py.src && e.dst == py.dst)
+            .unwrap_or_else(|| {
+                panic!("rust table missing phase-boundary edge {}->{}", py.src, py.dst)
+            });
+        assert_eq!(
+            rust.barrier, py.barrier,
+            "phase-boundary edge {}->{}: barrier mismatch",
+            py.src, py.dst
+        );
+        checked += 1;
+    }
+    // active→phase_join, phase_join→active, phase_join→done = 3 boundary edges.
+    assert_eq!(checked, 3, "expected three phase-join barrier edges");
+}

--- a/loom-tools/src/loom_tools/state_machine.py
+++ b/loom-tools/src/loom_tools/state_machine.py
@@ -315,6 +315,50 @@ class StateMachine:
 
     # -- rendering ---------------------------------------------------------
 
+    def render_json(self) -> str:
+        """Serialize the full graph (states + transitions) as JSON.
+
+        This is the machine-readable export the Rust loom-daemon conformance
+        test (#3873, epic #3842 Phase 4) parses to derive its expectation of the
+        epic sub-graph — states, edges, and per-edge barriers — rather than
+        hardcoding a mirrored copy that would silently drift from this
+        authoritative model.
+
+        The payload is stable: an object with ``states`` and ``transitions``
+        arrays, each element carrying every model field. Consumers filter to a
+        lane (e.g. ``lane == "epic"``) themselves.
+        """
+        import json
+
+        return json.dumps(
+            {
+                "states": [
+                    {
+                        "id": s.id,
+                        "lane": s.lane.value,
+                        "label": s.label,
+                        "entry": s.entry,
+                        "terminal": s.terminal,
+                        "derived": s.derived,
+                    }
+                    for s in self.states
+                ],
+                "transitions": [
+                    {
+                        "src": t.src,
+                        "dst": t.dst,
+                        "role": t.role.value,
+                        "guard": t.guard,
+                        "creates_issues": t.creates_issues,
+                        "barrier": t.barrier,
+                    }
+                    for t in self.transitions
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+
     def render_mermaid(self) -> str:
         """Render the graph as a Mermaid ``stateDiagram-v2`` grouped by lane."""
         by_id = self.by_id()
@@ -486,9 +530,18 @@ def main(argv: Optional[list[str]] = None) -> int:
         action="store_true",
         help="emit the graph as a Mermaid stateDiagram-v2 grouped by lane",
     )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit the graph (states + transitions) as JSON for conformance checks",
+    )
     args = parser.parse_args(argv)
 
     machine = canonical()
+
+    if args.json:
+        print(machine.render_json())
+        return 0
 
     if args.mermaid:
         print(machine.render_mermaid())

--- a/loom-tools/tests/test_state_machine.py
+++ b/loom-tools/tests/test_state_machine.py
@@ -256,6 +256,47 @@ def test_render_mermaid_is_state_diagram_grouped_by_lane():
     assert "s_merged --> [*]" in out
 
 
+def test_render_json_emits_states_and_transitions():
+    """render_json() emits the full graph with every model field.
+
+    This is the machine-readable export the Rust loom-daemon conformance test
+    (#3873) parses; it must expose states + transitions with their lane, label,
+    role, barrier, and creates_issues fields.
+    """
+    import json
+
+    data = json.loads(canonical().render_json())
+    assert set(data) == {"states", "transitions"}
+
+    # Every state carries the model fields.
+    for s in data["states"]:
+        assert set(s) == {"id", "lane", "label", "entry", "terminal", "derived"}
+
+    # The epic sub-graph: exactly five derived states, all on lane "epic".
+    epic_states = [s for s in data["states"] if s["lane"] == "epic"]
+    assert {s["id"] for s in epic_states} == {
+        "epic:needs_decomp",
+        "epic:designed",
+        "epic:active",
+        "epic:phase_join",
+        "epic:done",
+    }
+    assert all(s["derived"] for s in epic_states)
+    assert [s["id"] for s in epic_states if s["terminal"]] == ["epic:done"]
+
+    # Every transition carries the model fields; phase-boundary edges declare a
+    # non-empty barrier.
+    for t in data["transitions"]:
+        assert set(t) == {"src", "dst", "role", "guard", "creates_issues", "barrier"}
+    boundary = [
+        t
+        for t in data["transitions"]
+        if PHASE_JOIN_STATE in (t["src"], t["dst"])
+    ]
+    assert len(boundary) == 3
+    assert all(t["barrier"] for t in boundary)
+
+
 def _repo_root() -> Path:
     # test file: <root>/loom-tools/tests/test_state_machine.py
     return Path(__file__).resolve().parents[2]


### PR DESCRIPTION
Closes #3873. Final phase (4 of 4) of epic #3842 — the daemon-native epic supervisor is now provably faithful to the Python spec and its actions are observable.

## Deliverables

### (a) Conformance test — Rust transition table vs. Python model
`loom-daemon/tests/epic_conformance.rs` asserts the Rust epic transition table matches the authoritative Python epic sub-graph in `loom-tools/src/loom_tools/state_machine.py`.

Per prior Judge feedback on #3867, the test **derives** its expectation rather than hardcoding a mirror: it invokes a new `python3 -m loom_tools.state_machine --json` exporter, parses the emitted epic sub-graph (the five `lane == epic` derived states and the intra-lane edges), and compares states, edges, roles, barrier strings, and `creates_issues` flags against the Rust `epic_state::epic_transition_table()`. Any drift in the Python model fails the test until the Rust side is realigned. The test skips gracefully (early return + message) when `python3` is unavailable, and runs normally in this repo's dev/CI environment.

Covered: the five derived states (`needs_decomp`, `designed`, `active`, `phase_join`, `done`), their five intra-lane edges, the terminal flag on `epic:done`, and the three phase-join barrier edges.

To give the conformance test a concrete Rust-side artifact, the epic transition table is now declared explicitly in `epic_state.rs` (`EpicEdge` + `epic_transition_table()`) instead of living only implicitly inside `plan_epic_transition`.

### (b) Event-bus topics for the four action classes
New `Event::EpicAction` variant + `EpicActionClass` enum (`types.rs`) publish `epic.issue.{N}.{action}` on the existing in-memory bus when a singleton transition fires:

| Topic | Fires from |
|-------|-----------|
| `epic.issue.{N}.decompose` | `epic:needs_decomp` |
| `epic.issue.{N}.expand` | `epic:designed` |
| `epic.issue.{N}.join` | `epic:phase_join` |
| `epic.issue.{N}.close` | `epic:done` |

The supervisor takes an optional `Arc<EventBus>` (wired in `main.rs`), and publishes best-effort in `dispatch_singleton`. `BuildChildren` (per-child sweeps) deliberately has no epic topic — those already surface on `sweep.global.dispatch`. Tailable via `subscribe_to_events` / `tail_event_bus`; #3873 is the authorizing change for the new topics.

### (c) Documentation
New **Epic supervisor (#3842)** section in `.loom/docs/daemon-reference.md` (the source of truth — there is no `defaults/docs/` copy): derived-state model, explicit transition table, phase-join barrier, the #3707 issue-creation mutex, and the four new event topics. Taxonomy tables in `daemon-reference.md` and `event_bus.rs` module docs updated.

## Tests
- `loom-daemon`: full suite **510 passed / 0 failed**; new epic-supervisor emit tests + conformance tests included. `cargo fmt --check` clean, `cargo clippy --all-targets` clean.
- Python: `loom-tools/tests/test_state_machine.py` **20 passed** (added a `render_json` exporter test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)