### PR TITLE
test(daemon): de-brittle doc-lint prose assertions, keep contract assertions exact (#3877)

### DIFF
--- a/loom-daemon/tests/bump_md_doc_lint.rs
+++ b/loom-daemon/tests/bump_md_doc_lint.rs
@@ -17,6 +17,26 @@
 //!
 //! Companion tests: `sweep_md_doc_lint.rs` (Phase B, #3453),
 //! `sweep_md_stage_minus_one_doc_lint.rs` (Phase D, #3454).
+//!
+//! ---------------------------------------------------------------------------
+//! Assertion classification (#3877 — prose vs. contract)
+//! ---------------------------------------------------------------------------
+//! Every `contains()` assertion below is tagged PROSE or CONTRACT:
+//!
+//! - **PROSE** — a section title / self-description / wording that legitimately
+//!   gets edited. These assert STRUCTURE/PRESENCE (the H1 prefix, the phase
+//!   NUMBER `## Phase N:`, a single stable self-identifying word) rather than
+//!   exact wording, so a rename that keeps the section does NOT red-main `main`
+//!   — only a deletion does. Precedent: #3856 renamed "Phase 2: Ensure…" →
+//!   "Phase 2: Update…(optional)" → red main → #3863 patch switched to
+//!   `## Phase N:` presence-by-number.
+//! - **CONTRACT** — a stable identifier that MUST NOT drift: the seven
+//!   detection-source shapes (filenames + version-string tokens the runtime
+//!   LLM scans for), the `scripts/version.sh` template function/subcommand
+//!   markers, the Keep-a-Changelog headings + date format, `gh release create`,
+//!   the `npm publish` safety disclaimer, `/repo:release`, the retired
+//!   `/loom:release` negative, and the `.loom-internal.list` path. These stay
+//!   EXACT — their exactness is their value.
 
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
@@ -40,6 +60,10 @@ fn read_bump_md() -> String {
 #[test]
 fn bump_md_exists_and_has_title() {
     let content = read_bump_md();
+    // PROSE (structural prefix): the H1 title text can gain a parenthetical
+    // suffix (it is currently `# Version Bump + Tag (generic)`), so we assert
+    // the stable `# Version Bump + Tag` PREFIX at the top of the file, not the
+    // full title. Fails if the H1 is removed or renamed away from the skill.
     assert!(
         content.starts_with("# Version Bump + Tag"),
         "expected `# Version Bump + Tag` title at top of bump.md — \
@@ -60,8 +84,9 @@ fn bump_md_exists_and_has_title() {
 #[test]
 fn bump_md_documents_all_eight_phases() {
     let content = read_bump_md();
-    // Assert PRESENCE of all eight lifecycle phases by number, not by exact
-    // title. Phase titles are prose that legitimately evolves (e.g. #3856 made
+    // PROSE (structural by number): assert PRESENCE of all eight lifecycle
+    // phases by number, not by exact title. Phase titles are prose that
+    // legitimately evolves (e.g. #3856 made
     // the CHANGELOG phase optional, renaming "Ensure…" to "Update…if present"),
     // so pinning the full title makes this doc-lint brittle and red-mains main
     // on legitimate edits (#3860/#3861). The contract is "eight numbered phases
@@ -91,6 +116,10 @@ fn bump_md_documents_all_eight_phases() {
 #[test]
 fn bump_md_lists_seven_detection_sources() {
     let content = read_bump_md();
+    // CONTRACT (all assertions in this test): each string is a filename or a
+    // version-string token the runtime LLM greps for during detection. If any
+    // disappears the detection contract is broken — these are not editorial
+    // prose. Keep EXACT.
     // AC3: multi-file npm+cargo monorepo shape (Loom-style).
     assert!(
         content.contains("package.json"),
@@ -145,6 +174,9 @@ fn bump_md_lists_seven_detection_sources() {
 #[test]
 fn bump_md_includes_version_sh_template() {
     let content = read_bump_md();
+    // CONTRACT: template markers are function names, variable names, and
+    // subcommand grammar mirrored from Loom's own scripts/version.sh. A rename
+    // means the shipped template drifted — keep EXACT.
     let required_template_markers: &[&str] = &[
         "scripts/version.sh",
         "VERSION_FILES=",
@@ -173,6 +205,9 @@ fn bump_md_includes_version_sh_template() {
 #[test]
 fn bump_md_documents_changelog_handling() {
     let content = read_bump_md();
+    // CONTRACT (all three): `## [Unreleased]` and `YYYY-MM-DD` are exact
+    // Keep-a-Changelog structural tokens; `Keep a Changelog`/`keepachangelog`
+    // names the convention. These are format identifiers, not editable prose.
     assert!(
         content.contains("## [Unreleased]"),
         "bump.md must reference the `## [Unreleased]` Keep-a-Changelog heading (AC7)"
@@ -192,7 +227,11 @@ fn bump_md_documents_changelog_handling() {
 #[test]
 fn bump_md_gates_push_and_release_on_confirmation() {
     let content = read_bump_md();
-    // The Phase 7 header must call itself OPTIONAL.
+    // CONTRACT (structural): `Phase 7` (by number) + `OPTIONAL` is the
+    // confirmation-gate marker; `gh release create` and the `npm publish`
+    // disclaimer are exact command/guardrail tokens. The Phase-7 check asserts
+    // the phase by NUMBER (prose-tolerant) but the OPTIONAL/command/guardrail
+    // tokens are load-bearing contracts — keep EXACT.
     assert!(
         content.contains("Phase 7") && content.contains("OPTIONAL"),
         "bump.md Phase 7 must be marked OPTIONAL — #3468 AC8 requires an \
@@ -218,11 +257,18 @@ fn bump_md_gates_push_and_release_on_confirmation() {
 #[test]
 fn bump_md_distinguishes_itself_from_repo_release() {
     let content = read_bump_md();
+    // CONTRACT: `/repo:release` is an exact skill reference; the negative
+    // `/loom:release` guards against reintroducing the retired skill (#3563).
+    // Keep both EXACT.
     assert!(
         content.contains("/repo:release"),
         "bump.md must reference `/repo:release` so readers know where the full \
          release methodology lives (rjwalters/repo, #3563)"
     );
+    // PROSE (structural presence): `generic` is a single stable self-identifying
+    // word, also anchored by the H1 `(generic)` suffix. A one-word presence
+    // check tolerates surrounding rewording while failing if the skill stops
+    // identifying itself as the generic quick-bump.
     assert!(
         content.contains("generic"),
         "bump.md must describe itself as the generic quick-bump"
@@ -252,6 +298,8 @@ fn bump_md_is_not_in_loom_internal_skip_list() {
         if entry.is_empty() {
             continue;
         }
+        // CONTRACT (negative): the skip-list path is an exact identifier; bump.md
+        // must NOT appear on it (it ships to consumers). Keep EXACT.
         assert_ne!(
             entry, ".claude/commands/loom/bump.md",
             "bump.md must NOT be on defaults/.loom-internal.list — it is the \

--- a/loom-daemon/tests/sweep_md_doc_lint.rs
+++ b/loom-daemon/tests/sweep_md_doc_lint.rs
@@ -10,6 +10,23 @@
 //! - The acceptance criteria for #3453 (AC #3) can be verified
 //!   programmatically.
 //!
+//! ---------------------------------------------------------------------------
+//! Assertion classification (#3877 — prose vs. contract)
+//! ---------------------------------------------------------------------------
+//! Every `contains()` assertion below is tagged PROSE or CONTRACT:
+//!
+//! - **PROSE** — a section title / bold lead-in / wording that legitimately
+//!   gets edited. These assert STRUCTURE/PRESENCE (heading prefix, a stable
+//!   technical token, or a tolerant any-of set of phrasings) rather than exact
+//!   wording, so an editorial reword that keeps the concept does NOT red-main
+//!   `main` — only a deletion does. (Precedent: #3830→#3834, #3856→#3863 both
+//!   red-mained on pinned prose titles.)
+//! - **CONTRACT** — a stable identifier that MUST NOT drift: event topic
+//!   strings, IPC variant names, wire-payload field names, config keys, env
+//!   vars, CLI flags, file paths, schema ids, the complexity marker syntax,
+//!   and the escalation-ladder ordering. These stay EXACT — their exactness is
+//!   the value.
+//!
 //! If the markdown structure intentionally changes (e.g. a follow-up issue
 //! adds a seventh topic), update this test together with the markdown so
 //! the doc-lint stays in sync with the contract.
@@ -21,8 +38,9 @@ use std::path::PathBuf;
 
 const SWEEP_MD_RELATIVE: &str = "../defaults/.claude/commands/loom/sweep.md";
 
-/// All six frozen topic strings from the Phase B taxonomy. The presence
-/// of each in `sweep.md` is part of the acceptance criteria for #3453.
+/// CONTRACT: all six frozen topic strings from the Phase B taxonomy. These are
+/// wire identifiers frozen for v0.10.0 — a rename is a real contract break, not
+/// an editorial edit. Keep EXACT.
 const REQUIRED_TOPICS: &[&str] = &[
     "sweep.issue.{N}.phase",
     "sweep.issue.{N}.blocker",
@@ -47,6 +65,10 @@ fn read_sweep_md() -> String {
 #[test]
 fn sweep_md_has_daemon_event_bus_section() {
     let content = read_sweep_md();
+    // PROSE (structural presence): the section is anchored by its `## ` heading
+    // + stable name prefix `Daemon event bus`; the check tolerates the appended
+    // `(Phase B …)` ref suffix and fails only if the whole section is deleted.
+    // There is no numeric anchor here, so the stable name prefix is the anchor.
     assert!(
         content.contains("## Daemon event bus"),
         "expected `## Daemon event bus` section in sweep.md — the Phase B \
@@ -62,6 +84,7 @@ fn sweep_md_has_daemon_event_bus_section() {
 #[test]
 fn sweep_md_topic_taxonomy_table_lists_six_topics() {
     let content = read_sweep_md();
+    // CONTRACT: frozen topic strings (see REQUIRED_TOPICS). Keep EXACT.
     for topic in REQUIRED_TOPICS {
         assert!(
             content.contains(topic),
@@ -77,6 +100,8 @@ fn sweep_md_topic_taxonomy_table_lists_six_topics() {
 #[test]
 fn sweep_md_documents_publish_event_ipc_contract() {
     let content = read_sweep_md();
+    // CONTRACT: IPC request/variant identifiers are wire-protocol names. Keep
+    // EXACT — a rename here is a real contract break.
     assert!(
         content.contains("Request::PublishEvent"),
         "sweep.md should reference `Request::PublishEvent` — the IPC contract \
@@ -100,9 +125,10 @@ fn sweep_md_documents_publish_event_ipc_contract() {
 fn sweep_md_includes_sample_wire_payloads() {
     let content = read_sweep_md();
 
-    // At least one sample for each topic. We assert that the wire-frame
-    // example contains the topic string AND a JSON `"payload"` key —
-    // together this confirms a sample exists (not just a table entry).
+    // CONTRACT: each sample pins a wire-frame topic string or a Rust event
+    // variant name — both are stable wire identifiers. We deliberately do NOT
+    // pin every payload field (those may evolve); the topic/variant name is the
+    // contract. Keep these EXACT.
     let samples: &[&str] = &[
         r#""topic": "sweep.issue.123.phase""#,
         r#""topic": "sweep.issue.123.blocker""#,
@@ -125,64 +151,86 @@ fn sweep_md_includes_sample_wire_payloads() {
 // refusal fallback, and the no-Fable-Judge invariant.
 //
 // The ladder, precedence chain, `model@effort` grammar, and tier-2.5 marker
-// are PROSE CONTRACTS the sweep orchestrator (an LLM subagent) interprets at
-// dispatch time — there is no parser to unit-test. These string assertions
-// pin the contract so a future edit can't silently drop it.
+// are behavioral contracts the sweep orchestrator (an LLM subagent) interprets
+// at dispatch time — there is no parser to unit-test. Per #3877 these are split
+// into CONTRACT identifiers (grammar tokens, ladders, env vars, flags, markers,
+// class names — pinned EXACT) and PROSE sentences (pinned structurally: a
+// stable technical token or a tolerant any-of phrasing set) so an editorial
+// reword can't red-main main while a deletion still fails.
 // ---------------------------------------------------------------------------
 
-/// #3702: the `model@effort` rung grammar and the `fable` top rung are
-/// documented, with the effort graceful-degradation contract.
-///
-/// #3705: the prose now also documents the effort *passthrough* happy path
-/// (the `claude` CLI / `spawn-claude.sh` `LOOM_EFFORT` → `--effort` surface)
-/// alongside the Task-tool graceful-degradation fallback. Both halves of the
-/// contract are pinned so a future edit can't silently drop either one.
+/// #3702/#3705: the `model@effort` rung grammar, the `fable` top rung, the
+/// effort passthrough happy path, and the Task-tool graceful-degradation
+/// fallback are all documented.
 #[test]
 fn sweep_md_documents_effort_rung_grammar_and_fable() {
     let content = read_sweep_md();
-    let required: &[&str] = &[
-        // Rung grammar: bare alias vs alias@effort.
-        "alias@effort",
-        "sonnet@xhigh",
-        "(model=sonnet, effort=xhigh)",
-        // Effort-before-model escalation ordering.
-        "sonnet → sonnet@xhigh → opus → fable",
-        // Graceful degradation when per-dispatch effort plumbing is absent.
-        "grammar ships either way",
-        // #3705: the effort passthrough happy path (CLI/process/daemon), not
-        // only degradation — effort IS carried where the surface exposes it.
-        "effort IS passed through",
-        "LOOM_EFFORT",
-        // The fable top rung.
-        "fable",
+    // CONTRACT: grammar tokens, the escalation-ladder ordering, the
+    // effort-plumbing identifiers (env var + CLI flag), and the `fable` rung
+    // name. These are stable identifiers the orchestrator + spawn-claude.sh
+    // consume — drift is a real breakage. Keep EXACT.
+    let contract_needles: &[&str] = &[
+        "alias@effort",                         // rung grammar token
+        "sonnet@xhigh",                         // grammar example / example rung
+        "(model=sonnet, effort=xhigh)",         // grammar semantic expansion
+        "sonnet → sonnet@xhigh → opus → fable", // effort-before-model ladder order
+        "LOOM_EFFORT",                          // #3705 passthrough env
+        "--effort",                             // #3705 CLI flag carrying effort
+        "fable",                                // the top rung name
     ];
-    for needle in required {
+    for needle in contract_needles {
         assert!(
             content.contains(needle),
-            "sweep.md is missing #3702 rung-grammar/fable prose `{needle}` — \
-             update sweep.md or this test if the change is intentional"
+            "sweep.md is missing #3702/#3705 rung-grammar/fable contract token \
+             `{needle}` — update sweep.md or this test if the change is intentional"
         );
     }
+
+    // PROSE (structural): the Task-tool graceful-degradation half (#3705) must
+    // stay documented, but its wording ("grammar ships either way", "degrades
+    // cleanly to bare sonnet") legitimately gets edited. Anchor on the stable
+    // verb stem `degrade` (matches degrade/degrades/degraded/degradation) so a
+    // reword survives while deleting the whole fallback discussion still fails.
+    assert!(
+        content.contains("degrade"),
+        "sweep.md must document the Task-tool effort graceful-degradation \
+         fallback (#3705) — anchored structurally on the `degrade` stem, not on \
+         an exact sentence"
+    );
 }
 
 /// #3702: the Curator complexity marker is documented as precedence tier 2.5
-/// with its one-bump/never-fable/never-a-label bounds.
+/// with its one-bump / never-fable bound.
 #[test]
 fn sweep_md_documents_complexity_marker_tier() {
     let content = read_sweep_md();
-    let required: &[&str] = &[
-        "<!-- loom:complexity=complex -->",
-        "Tier 2.5 — Curator complexity marker",
-        "sonnet → opus",
-        "One bump maximum, and never to",
-    ];
-    for needle in required {
-        assert!(
-            content.contains(needle),
-            "sweep.md is missing #3702 complexity-marker prose `{needle}` — \
-             update sweep.md or this test if the change is intentional"
-        );
-    }
+    // CONTRACT: the marker syntax and the `sonnet → opus` one-tier bump are
+    // stable identifiers. Keep EXACT.
+    assert!(
+        content.contains("<!-- loom:complexity=complex -->"),
+        "sweep.md must document the `<!-- loom:complexity=complex -->` marker \
+         syntax (#3702 tier 2.5)"
+    );
+    assert!(
+        content.contains("sonnet → opus"),
+        "sweep.md must document the `sonnet → opus` one-tier bump (#3702 tier 2.5)"
+    );
+    // PROSE (structural): the tier is anchored by its NUMBER (`Tier 2.5`); the
+    // "— Curator complexity marker" title text is prose that can be reworded.
+    assert!(
+        content.contains("Tier 2.5"),
+        "sweep.md must document the complexity marker as precedence `Tier 2.5` \
+         (#3702) — asserted by tier number, not by exact title wording"
+    );
+    // CONTRACT (bound): the never-to-`fable` ceiling is a hard bound; the
+    // backtick-wrapped `fable` makes it identifier-shaped. Pin the tight
+    // `never to `fable`` fragment (not the full "One bump maximum, …" sentence)
+    // so a reword of the lead-in survives while removing the ceiling fails.
+    assert!(
+        content.contains("never to `fable`"),
+        "sweep.md must document the marker's never-to-`fable` ceiling (#3702) — \
+         the marker can lift one tier and never reach the top rung"
+    );
 }
 
 /// #3702: a `MODEL_REFUSAL` at a fable rung drops one rung down WITHOUT
@@ -190,18 +238,29 @@ fn sweep_md_documents_complexity_marker_tier() {
 #[test]
 fn sweep_md_documents_refusal_fallback() {
     let content = read_sweep_md();
+    // CONTRACT: the error class name and the one-rung-down `fable → opus`
+    // fallback are stable identifiers. Keep EXACT.
     assert!(
         content.contains("MODEL_REFUSAL"),
         "sweep.md must reference the `MODEL_REFUSAL` class (#3702 refusal fallback)"
     );
     assert!(
-        content.contains("without consuming a Doctor cycle"),
-        "sweep.md must state the refusal fallback re-dispatches without \
-         consuming a Doctor cycle (#3702)"
-    );
-    assert!(
         content.contains("fable → opus"),
         "sweep.md must document the fable→opus one-rung-down refusal fallback (#3702)"
+    );
+    // PROSE (structural / tolerant): the "does not cost a Doctor cycle" semantic
+    // is wording; accept equivalent phrasings so a reword survives while a
+    // deletion of the no-cost guarantee still fails.
+    let no_cost_phrases: &[&str] = &[
+        "without consuming a Doctor cycle",
+        "without spending a Doctor cycle",
+        "does not consume a Doctor cycle",
+        "not consume a Doctor cycle",
+    ];
+    assert!(
+        no_cost_phrases.iter().any(|p| content.contains(p)),
+        "sweep.md must state the refusal fallback re-dispatches without \
+         consuming a Doctor cycle (#3702) — asserted via a tolerant phrasing set"
     );
 }
 
@@ -210,19 +269,31 @@ fn sweep_md_documents_refusal_fallback() {
 #[test]
 fn sweep_md_asserts_no_fable_judge_invariant() {
     let content = read_sweep_md();
+    // PROSE (structural / tolerant): the no-Fable-Judge invariant is stated in
+    // two places with two phrasings ("Judge model resolution can never resolve
+    // to" and "Judge dispatch never resolves to"). Accept either so a reword of
+    // one survives, while a deletion of BOTH — i.e. the invariant truly gone —
+    // still fails. The `fable` exclusion itself is a hard contract.
+    let invariant_phrases: &[&str] = &[
+        "Judge model resolution can never resolve to",
+        "Judge dispatch never resolves to",
+        "Judge model would ever be `fable`",
+    ];
     assert!(
-        content.contains("Judge model resolution can never resolve to"),
-        "sweep.md must state the no-Fable-Judge hard invariant verbatim \
-         (#3702): `Judge model resolution can never resolve to `fable`...`"
+        invariant_phrases.iter().any(|p| content.contains(p)),
+        "sweep.md must state the no-Fable-Judge hard invariant (#3702): Judge \
+         model resolution can never resolve to `fable` — asserted via a tolerant \
+         phrasing set"
     );
 }
 
 // ---------------------------------------------------------------------------
 // Issue #3725 — model-cost experiment mode. The tri-state setting, the two-arm
 // A/B, the resume-safe stratified assignment, the tier-2.5 suppression, the
-// durable store, the exact-cost harvest, and the canary guardrail are all prose
-// contracts the sweep orchestrator interprets — pin the load-bearing strings so
-// a future edit can't silently drop them.
+// durable store, the exact-cost harvest, and the canary guardrail are behavioral
+// contracts the sweep orchestrator interprets. Per #3877, config keys / env
+// vars / flags / paths / schema ids / field names are pinned EXACT (CONTRACT),
+// while bold lead-ins and wording are pinned structurally (PROSE).
 // ---------------------------------------------------------------------------
 
 /// #3725: the tri-state experiment setting + env override are documented with
@@ -230,30 +301,44 @@ fn sweep_md_asserts_no_fable_judge_invariant() {
 #[test]
 fn sweep_md_documents_model_experiment_mode() {
     let content = read_sweep_md();
-    let required: &[&str] = &[
-        "### Model-cost experiment mode",
-        "sweep.modelExperiment",
-        "LOOM_MODEL_EXPERIMENT",
-        // Tri-state values.
-        "`off` | `observe` | `experiment`",
-        // Two arms mapping onto #3718's inequality.
-        "Arm A = opus-first",
-        "Arm B = sonnet-first + escalate",
-        // Deterministic, resume-safe, stratified assignment.
-        "Deterministic, resume-safe, stratified assignment",
-        // The durable, gitignored store.
-        ".loom/stats/sweep-model-stats.jsonl",
-        // The agent-id join key into #3726's index.
-        "agent-id` join key",
-        "loom.transcript-index/v1",
+    // CONTRACT: config key, env var, the exact tri-state value grammar, the arm
+    // model mappings, the durable-store path, the join key, and the transcript
+    // schema id are all stable identifiers. Keep EXACT.
+    let contract_needles: &[&str] = &[
+        "sweep.modelExperiment",               // config key
+        "LOOM_MODEL_EXPERIMENT",               // env var
+        "`off` | `observe` | `experiment`",    // tri-state value grammar
+        "Arm A = opus-first",                  // arm→model mapping
+        "Arm B = sonnet-first + escalate",     // arm→model mapping
+        ".loom/stats/sweep-model-stats.jsonl", // durable store path
+        "agent-id` join key",                  // harvest join key
+        "loom.transcript-index/v1",            // #3726 transcript schema id
     ];
-    for needle in required {
+    for needle in contract_needles {
         assert!(
             content.contains(needle),
-            "sweep.md is missing #3725 experiment-mode prose `{needle}` — \
-             update sweep.md or this test if the change is intentional"
+            "sweep.md is missing #3725 experiment-mode contract token `{needle}` \
+             — update sweep.md or this test if the change is intentional"
         );
     }
+    // PROSE (structural): the assignment property is documented via a bold
+    // lead-in ("Deterministic, resume-safe, stratified assignment.") that gets
+    // edited. Anchor on the stable technical token `stratified` (matches
+    // "stratified"/"stratification") so a reword survives and a deletion fails.
+    assert!(
+        content.contains("stratified"),
+        "sweep.md must document the deterministic, resume-safe, stratified arm \
+         assignment (#3725) — anchored structurally on `stratified`"
+    );
+
+    // PROSE (structural presence): the subsection heading is anchored by its
+    // `### ` prefix + stable name; the `(sweep.modelExperiment / …)` suffix is
+    // tolerated. Fails only if the whole subsection is deleted.
+    assert!(
+        content.contains("### Model-cost experiment mode"),
+        "sweep.md must retain the `### Model-cost experiment mode` subsection \
+         (#3725) — asserted by heading prefix, tolerating the appended ref suffix"
+    );
 }
 
 /// #3725 (hard AC): in `experiment` mode the forced arm SUPPRESSES the tier-2.5
@@ -261,22 +346,31 @@ fn sweep_md_documents_model_experiment_mode() {
 #[test]
 fn sweep_md_documents_experiment_tier_2_5_suppression() {
     let content = read_sweep_md();
+    // CONTRACT (prefix-tolerant): the suppression note is anchored by its
+    // `Experiment-mode suppression (issue #3725` title + issue ref. The prefix
+    // match (no closing paren) tolerates appended issue refs — e.g. a future
+    // edit turning `(issue #3725)` into `(issue #3725, #NNNN)`. See #3833/#3837
+    // for why exact-paren literals red main on doc edits.
     assert!(
-        // Prefix match (no closing paren) tolerates appended issue refs, e.g.
-        // a future edit turning `(issue #3725)` into `(issue #3725, #NNNN)`.
-        // See #3833/#3837 for why exact-paren literals red main on doc edits.
         content.contains("Experiment-mode suppression (issue #3725"),
         "sweep.md must document the tier-2.5 suppression note (#3725 hard AC; \
          tolerates appended issue refs)"
     );
+    // CONTRACT: the caps `SUPPRESSES` verb and the `tier-2.5` target are the
+    // load-bearing tokens of the suppression semantic. Assert both present
+    // (structural two-token check) rather than the exact "SUPPRESSES this
+    // tier-2.5 bump" phrase whose connective wording can drift.
     assert!(
-        content.contains("SUPPRESSES this tier-2.5 bump"),
-        "sweep.md must state the forced arm suppresses the tier-2.5 bump (#3725)"
+        content.contains("SUPPRESSES") && content.contains("tier-2.5"),
+        "sweep.md must state the forced arm SUPPRESSES the tier-2.5 bump (#3725)"
     );
+    // PROSE (structural): the "marker used only as the stratification key while
+    // an arm is forced" semantic is wording; anchor on the stable noun phrase
+    // `stratification key` (drop the brittle "only as the" lead-in).
     assert!(
-        content.contains("only as the stratification key"),
-        "sweep.md must state the marker is used only as the stratification key \
-         while an arm is forced (#3725)"
+        content.contains("stratification key"),
+        "sweep.md must state the marker is used as the stratification key while \
+         an arm is forced (#3725) — anchored on the `stratification key` phrase"
     );
 }
 
@@ -284,23 +378,23 @@ fn sweep_md_documents_experiment_tier_2_5_suppression() {
 #[test]
 fn sweep_md_documents_experiment_guardrail_and_harvest() {
     let content = read_sweep_md();
-    let required: &[&str] = &[
-        // Canary-only guardrail + explicit opt-in.
-        "canary-only",
-        "LOOM_MODEL_EXPERIMENT_CANARY=1",
-        // Harvest surface.
-        "--model-experiment",
-        // Exact cache-aware cost via transcript usage.
-        "cache-aware",
-        "cache_read_input_tokens",
-        // token_fidelity ladder.
-        "token_fidelity",
+    // CONTRACT: the canary env-var+value, the harvest flag, and the cache
+    // token-usage field names are stable identifiers. `canary-only` and
+    // `cache-aware` are distinctive hyphenated terms naming the guardrail /
+    // costing property. Keep EXACT.
+    let contract_needles: &[&str] = &[
+        "canary-only",                    // guardrail term
+        "LOOM_MODEL_EXPERIMENT_CANARY=1", // canary env var + value
+        "--model-experiment",             // harvest CLI flag
+        "cache-aware",                    // costing property term
+        "cache_read_input_tokens",        // usage-block field name
+        "token_fidelity",                 // record field name
     ];
-    for needle in required {
+    for needle in contract_needles {
         assert!(
             content.contains(needle),
-            "sweep.md is missing #3725 guardrail/harvest prose `{needle}` — \
-             update sweep.md or this test if the change is intentional"
+            "sweep.md is missing #3725 guardrail/harvest contract token \
+             `{needle}` — update sweep.md or this test if the change is intentional"
         );
     }
 }

--- a/loom-daemon/tests/sweep_md_stage_minus_one_doc_lint.rs
+++ b/loom-daemon/tests/sweep_md_stage_minus_one_doc_lint.rs
@@ -24,6 +24,22 @@
 //! - The 500ms timeout for the daemon Ping probe is documented (AC #2
 //!   — the implicit-fallback semantics).
 //!
+//! ---------------------------------------------------------------------------
+//! Assertion classification (#3877 — prose vs. contract)
+//! ---------------------------------------------------------------------------
+//! Every `contains()` assertion below is tagged PROSE or CONTRACT:
+//!
+//! - **PROSE** — a section title / wording that legitimately gets edited.
+//!   These assert STRUCTURE/PRESENCE (heading number, tolerant any-of
+//!   phrasings) rather than exact wording. Two prior red-main incidents
+//!   (#3830→#3834, #3856→#3863) came from pinned prose titles, so a rename
+//!   that keeps the section must NOT fail CI — only a deletion should.
+//! - **CONTRACT** — a stable identifier that MUST NOT drift: the decision-tree
+//!   probe/keyword tokens, the `PROBE_DAEMON AND PROBE_POOL` strict-AND marker,
+//!   the `500ms` timeout, the `mcp__loom__dispatch_sweep` tool name, the
+//!   `--no-daemon` flag, issue-number refs. These stay EXACT — their exactness
+//!   is their value.
+//!
 //! If the markdown structure intentionally changes (e.g. a follow-up
 //! issue revises the decision tree), update this test together with the
 //! markdown so the doc-lint stays in sync with the contract.
@@ -48,15 +64,21 @@ fn read_sweep_md() -> String {
     })
 }
 
-/// AC #1: assert the `## Stage -1: Backend detection` section header
-/// is present.
+/// AC #1: assert the Stage -1 section header is present.
 #[test]
 fn sweep_md_has_stage_minus_one_section() {
     let content = read_sweep_md();
+    // PROSE (structural): the stage is identified by its NUMBER (`-1`), which
+    // is the stable anchor; the "Backend detection …" title text is prose that
+    // can be reworded (cf. #3830→#3834 for a sweep-section rename that
+    // red-mained on a pinned title). Assert `## Stage -1:` — the heading exists
+    // by number — not the full title. A deletion of the stage removes the
+    // heading and still fails this check.
     assert!(
-        content.contains("## Stage -1: Backend detection"),
-        "expected `## Stage -1: Backend detection` section in sweep.md — \
-         the Phase D backend-detection stage is required by #3454 AC #1"
+        content.contains("## Stage -1:"),
+        "expected a `## Stage -1:` section header in sweep.md — the Phase D \
+         backend-detection stage is required by #3454 AC #1 (asserted by stage \
+         number, not by exact title wording)"
     );
 }
 
@@ -67,6 +89,9 @@ fn sweep_md_has_stage_minus_one_section() {
 #[test]
 fn sweep_md_decision_tree_documents_all_probes() {
     let content = read_sweep_md();
+    // CONTRACT: the four decision-tree identifiers are pseudocode tokens the
+    // Stage -1 spec pins verbatim. A rename here is a real spec/markdown drift,
+    // not an editorial edit — keep EXACT.
     let required_identifiers: &[&str] = &["PROBE_MODE", "PROBE_DAEMON", "PROBE_POOL", "DECIDE"];
     for id in required_identifiers {
         assert!(
@@ -86,7 +111,9 @@ fn sweep_md_decision_tree_documents_all_probes() {
 fn sweep_md_documents_strict_and_precedence() {
     let content = read_sweep_md();
 
-    // The literal decision-tree precedence string from the issue body.
+    // CONTRACT: the literal `PROBE_DAEMON AND PROBE_POOL` conjunction is the
+    // strict-AND logic marker. Keep EXACT — this is the negative guard that
+    // fails if the AND is ever relaxed to an OR / auto-start form.
     assert!(
         content.contains("PROBE_DAEMON AND PROBE_POOL"),
         "sweep.md is missing the literal `PROBE_DAEMON AND PROBE_POOL` \
@@ -94,9 +121,10 @@ fn sweep_md_documents_strict_and_precedence() {
          (no implicit auto-start, no `OR` fallback to daemon-without-pool)"
     );
 
-    // The prose explanation that either probe failing → subagent.
-    // Allow any of several equivalent phrasings to survive editorial
-    // changes, but require at least one.
+    // PROSE (structural / tolerant): the plain-English explanation that either
+    // probe failing → subagent is wording that legitimately gets edited. Accept
+    // any of several equivalent phrasings so an editorial reword survives, but
+    // require at least one so a deletion of the explanation still fails.
     let strict_and_phrases: &[&str] = &[
         "Strict AND",
         "strict AND",
@@ -121,6 +149,9 @@ fn sweep_md_documents_strict_and_precedence() {
 #[test]
 fn sweep_md_documents_mode_c_short_circuit() {
     let content = read_sweep_md();
+    // CONTRACT: `if Mode C: use_subagent()` is a literal decision-tree
+    // pseudocode line; the Mode-C-before-probe ordering is the contract. Keep
+    // EXACT.
     assert!(
         content.contains("if Mode C: use_subagent()"),
         "sweep.md is missing the literal `if Mode C: use_subagent()` \
@@ -135,10 +166,10 @@ fn sweep_md_documents_mode_c_short_circuit() {
 fn sweep_md_documents_no_daemon_flag() {
     let content = read_sweep_md();
 
-    // The flag itself must appear at least three times: once in the
-    // optional-flags list, once in the validation rules, and at least
-    // once in the new stage section (and the decision tree). Three is
-    // a lower bound; the real count is higher.
+    // CONTRACT: `--no-daemon` is a stable CLI flag name. The >= 3 occurrence
+    // floor is a structural presence check (optional-flags list + validation
+    // rules + Stage -1 section) that fails if the flag is dropped from any of
+    // its documented sites. Keep the flag name EXACT.
     let occurrences = content.matches("--no-daemon").count();
     assert!(
         occurrences >= 3,
@@ -148,8 +179,10 @@ fn sweep_md_documents_no_daemon_flag() {
          Stage -1 section (lower bound: 3 occurrences)"
     );
 
-    // The decision-tree line must mention --no-daemon as a short-circuit
-    // ahead of the daemon probe.
+    // CONTRACT (tolerant across pseudocode spellings): the decision-tree line
+    // must document `--no-daemon` as a short-circuit ahead of the daemon probe.
+    // The flag + `PROBE_DAEMON skipped` markers are the contract; the exact
+    // `elif` spelling may vary, so accept the documented variants.
     assert!(
         content.contains("elif --no-daemon: use_subagent()")
             || content.contains("elif NO_DAEMON: use_subagent()")
@@ -167,6 +200,8 @@ fn sweep_md_documents_no_daemon_flag() {
 #[test]
 fn sweep_md_documents_500ms_daemon_probe_timeout() {
     let content = read_sweep_md();
+    // CONTRACT: `500ms` is a numeric timeout value — the implicit-fallback
+    // semantic depends on the exact figure. Keep EXACT.
     assert!(
         content.contains("500ms"),
         "sweep.md is missing the `500ms` daemon probe timeout — \
@@ -183,7 +218,9 @@ fn sweep_md_documents_500ms_daemon_probe_timeout() {
 fn sweep_md_documents_smoke_test_recipes() {
     let content = read_sweep_md();
 
-    // Sub-2-second exit expectation (AC #3 documented expectation).
+    // PROSE (structural / tolerant): the sub-2-second exit expectation is
+    // wording; accept the documented spellings so a reword survives while a
+    // deletion of the expectation still fails.
     assert!(
         content.contains("< 2 seconds")
             || content.contains("sub-2-second")
@@ -192,7 +229,10 @@ fn sweep_md_documents_smoke_test_recipes() {
          daemon path — #3454 AC #3 requires this be documented"
     );
 
-    // Daemon-off / single-token fallthrough (AC #4).
+    // CONTRACT + tolerant prose: `PROBE_POOL` is a contract identifier that must
+    // be named in the fallthrough recipe; the single-token phrasing beside it is
+    // wording, so accept the documented variants. Together they fail if the
+    // daemon-off / solo-token recipe is deleted.
     assert!(
         content.contains("PROBE_POOL")
             && (content.contains("single-token")
@@ -210,6 +250,8 @@ fn sweep_md_documents_smoke_test_recipes() {
 #[test]
 fn sweep_md_references_dispatch_sweep_mcp_tool() {
     let content = read_sweep_md();
+    // CONTRACT: `mcp__loom__dispatch_sweep` is the exact MCP tool name (Phase A
+    // wire protocol). Keep EXACT.
     assert!(
         content.contains("mcp__loom__dispatch_sweep"),
         "sweep.md is missing the `mcp__loom__dispatch_sweep` MCP tool \
@@ -228,15 +270,17 @@ fn sweep_md_references_dispatch_sweep_mcp_tool() {
 #[test]
 fn sweep_md_stage_minus_one_wave_size_snippet_is_bash_3_2_portable() {
     let content = read_sweep_md();
+    // CONTRACT: `loom_wave_size_from_disk` is the exact helper name the
+    // regression guard anchors to. Keep EXACT.
     assert!(
         content.contains("loom_wave_size_from_disk"),
         "sweep.md is missing the `loom_wave_size_from_disk` wave-size \
          resolution snippet — #3765 regression guard cannot anchor to it"
     );
-    // Guard against the *invocation* form of the bash-4.0+ array-read
-    // builtins (`mapfile -…` / `readarray -…`). A prose mention of the
-    // word "mapfile" in an explanatory comment is fine — only executable
-    // reintroduction is the regression.
+    // CONTRACT (negative): guard against the *invocation* form of the bash-4.0+
+    // array-read builtins (`mapfile -…` / `readarray -…`). A prose mention of
+    // the word "mapfile" in an explanatory comment is fine — only executable
+    // reintroduction is the regression, so we pin the invocation token exactly.
     for bad in ["mapfile -", "readarray -"] {
         assert!(
             !content.contains(bad),
@@ -255,6 +299,11 @@ fn sweep_md_stage_minus_one_wave_size_snippet_is_bash_3_2_portable() {
 #[test]
 fn sweep_md_limitations_table_records_stage_minus_one_implemented() {
     let content = read_sweep_md();
+    // CONTRACT (prefix-tolerant): the `Implemented (#3454` status + issue ref is
+    // the operator-visible contract; the prefix match (no closing paren)
+    // tolerates appended issue refs (e.g. `(#3454, #3829)`) per #3833/#3837
+    // while still failing if the status flip is reverted. `Daemon backend
+    // detection` is the stable row label.
     assert!(
         content.contains("Daemon backend detection") && content.contains("Implemented (#3454"),
         "sweep.md Limitations table is missing the `Daemon backend \


### PR DESCRIPTION
## Summary

Follow-up to #3837. Audits **all** `contains()` assertions in the three daemon doc-lint tests and classifies each as **PROSE** (converted to a structural/presence check) or **CONTRACT** (kept EXACT). This closes the class of red-main incidents (#3830→#3834, #3856→#3863) that came from pinned prose titles, without loosening the identifiers whose exactness is their value.

Each assertion now carries a one-line PROSE/CONTRACT rationale (or a grouped doc block where assertions are adjacent and share one), plus a file-level classification header in each test file.

## Prose → structural conversions

- **Section/phase titles → assert by number or stable prefix**
  - `## Stage -1: Backend detection` → `## Stage -1:` (stage by number)
  - `Tier 2.5 — Curator complexity marker` → `Tier 2.5` (tier by number)
  - `# Version Bump + Tag` H1 kept as a prefix; `## Phase N:` / `## Daemon event bus` / `### Model-cost experiment mode` kept as prefix-presence (tolerate appended `(…)` suffixes)
- **Wording sentences → stable technical token or tolerant any-of set**
  - `grammar ships either way` / `effort IS passed through` → `degrade` stem + the `--effort` CLI-flag contract
  - `Deterministic, resume-safe, stratified assignment` → `stratified`
  - `only as the stratification key` → `stratification key`
  - `SUPPRESSES this tier-2.5 bump` → two-token `SUPPRESSES` + `tier-2.5`
  - `without consuming a Doctor cycle` and the no-Fable-Judge invariant → tolerant any-of phrasing sets (fail only when every phrasing — i.e. the concept — is deleted)
  - `One bump maximum, and never to` → tight `never to \`fable\`` ceiling fragment

## Contracts kept EXACT

Event topics (`sweep.issue.{N}.phase` …), IPC variants (`Request::PublishEvent`, `SubscribeEvents`), wire-payload topic/variant names, config keys (`sweep.modelExperiment`), env vars (`LOOM_MODEL_EXPERIMENT`, `LOOM_MODEL_EXPERIMENT_CANARY=1`), flags (`--no-daemon`, `--model-experiment`), paths/schema ids (`.loom/stats/sweep-model-stats.jsonl`, `loom.transcript-index/v1`), the `PROBE_*`/`DECIDE` decision-tree tokens, the `PROBE_DAEMON AND PROBE_POOL` strict-AND marker, `500ms`, `mcp__loom__dispatch_sweep`, marker syntax `<!-- loom:complexity=complex -->`, the `sonnet → sonnet@xhigh → opus → fable` ladder ordering, detection-source filenames + version tokens, `scripts/version.sh` template markers, and the `mapfile -`/`readarray -` negative regression guard.

## Classification counts (per file)

| File | Prose (structural) | Contract (exact) |
|------|-------------------:|-----------------:|
| `bump_md_doc_lint.rs` | 3 (H1 prefix, `## Phase N:`, `generic`) | ~20 (detection sources, template markers, changelog format, `gh release create` / `npm publish`, `/repo:release` + `/loom:release` negative, skip-list path) |
| `sweep_md_stage_minus_one_doc_lint.rs` | 4 (`## Stage -1:`, strict-AND any-of, sub-2s any-of, limitations row) | ~11 (`PROBE_*`/`DECIDE`, `PROBE_DAEMON AND PROBE_POOL`, `if Mode C: use_subagent()`, `--no-daemon`, `500ms`, `mcp__loom__dispatch_sweep`, `loom_wave_size_from_disk`, `mapfile`/`readarray` negatives, `Implemented (#3454`) |
| `sweep_md_doc_lint.rs` | 8 (event-bus heading, `degrade`, `Tier 2.5`, never-fable bound, refusal any-of, no-Fable-Judge any-of, `Model-cost` heading, `stratified`/`stratification key`) | ~25 (6 topics, 3 IPC variants, 6 wire samples, grammar tokens + ladder, config keys, env vars, flags, paths, schema id, cache fields) |

## Test results

`cargo test --test bump_md_doc_lint --test sweep_md_doc_lint --test sweep_md_stage_minus_one_doc_lint` — **29 passed, 0 failed** (8 + 11 + 10). `cargo fmt --check` clean; `cargo clippy --tests` clean.

Closes #3877

🤖 Generated with [Claude Code](https://claude.com/claude-code)