### PR TITLE
feat(daemon): work-driven concurrency scaling for the work finder (#3811 Phase B)

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -484,12 +484,42 @@ Each tick:
    `loom:issue → loom:building` label-flip lag) or that defensively carry any
    skip label (`loom:building` / `loom:blocked` / `loom:operator-only`).
 3. Dispatches the remainder through the existing `SweepRegistry::dispatch()`
-   path — up to a **fixed** max-concurrency cap counted against the current live
-   sweep occupancy. `dispatch()` already flips `loom:issue → loom:building`,
-   acquires the per-issue `mkdir`-atomic claim lock, and spawns the
-   rotated-token child, so the finder reimplements none of the race guard. Each
-   dispatch uses a `workfinder-<issue>` idempotency key, making a re-dispatch of
-   an already-running issue a no-op.
+   path — up to a **work-driven dynamic cap** (Phase B, #3811) recomputed every
+   tick and counted against the current live sweep occupancy. `dispatch()`
+   already flips `loom:issue → loom:building`, acquires the per-issue
+   `mkdir`-atomic claim lock, and spawns the rotated-token child, so the finder
+   reimplements none of the race guard. Each dispatch uses a
+   `workfinder-<issue>` idempotency key, making a re-dispatch of an
+   already-running issue a no-op.
+
+### Dynamic concurrency scaling (Phase B, #3811)
+
+The concurrency cap is **not** a fixed value resolved once at startup. Every
+tick the finder recomputes
+
+```
+dynamic_cap = min(token-pool size, disk headroom, configured ceiling)
+```
+
+from three live inputs, so pool/disk/backlog changes are honored without a
+daemon restart:
+
+| Input | Source | Bound it enforces |
+|-------|--------|-------------------|
+| **token-pool size** | count of `*.token` files in `{workspace}/.loom/tokens/` (`tokens::token_pool_size`) | never over-subscribe a rotated OAuth account — one live sweep per usable account |
+| **disk headroom** | `floor(free_gb / LOOM_PER_WORKTREE_GB)` on the worktree-root volume (`disk_headroom::disk_headroom_limit`, a Rust port of `disk-headroom.sh` that shells to `df -Pk`) | never provision more worktrees than the scratch volume can hold |
+| **configured ceiling** | `LOOM_WORK_FINDER_MAX_CONCURRENT` (repurposed from Phase A's fixed target into an operator ceiling) | hard operator upper bound regardless of pool/disk headroom |
+
+The **effective** per-tick concurrency is then `min(dynamic_cap, backlog_depth)`:
+`tick()` iterates the ready `loom:issue` rows and stops at the cap, so
+concurrency **scales up** as the backlog grows and drains to **zero** dispatches
+when the queue is empty (no capacity is pre-reserved and no idle workers are
+spawned). A token pool of 0 (rotation not bootstrapped) yields a cap of 0 —
+the finder dispatches nothing, matching `spawn-claude.sh`'s `EX_CONFIG`
+hard-fail on a missing pool. The `df` probe runs once per tick and is negligible
+on the 60s default interval. Bad-token-aware pool counting (subtracting
+`.bad_tokens` entries) is a tracked follow-up; the first pass counts `*.token`
+files.
 
 The loop is **idempotent** (an issue already in the registry is never
 re-dispatched) and **fail-safe**: a forge-query error aborts only that tick
@@ -500,10 +530,11 @@ new event topics.
 
 Enable it with `LOOM_WORK_FINDER=1` (unset/false-y = OFF). Tunables:
 `LOOM_WORK_FINDER_INTERVAL_SECS` (default 60 — tighter than the epic
-supervisor's 300s so the `loom:issue` backlog drains promptly) and
-`LOOM_WORK_FINDER_MAX_CONCURRENT` (default 3 — the fixed MVP cap; dynamic
-scaling is deferred to Phase B). A zero or unparseable value for either tunable
-falls back to its default.
+supervisor's 300s so the `loom:issue` backlog drains promptly),
+`LOOM_WORK_FINDER_MAX_CONCURRENT` (default 3 — the operator **ceiling** in the
+dynamic policy above, not a fixed target), and `LOOM_PER_WORKTREE_GB` (default 2
+— the per-worktree disk estimate the disk-headroom bound divides by). A zero or
+unparseable value for any of these falls back to its default.
 
 > **Scope note**: the work finder dispatches **already-approved** `loom:issue`
 > items; it does **not** generate new work. Architect/Hermit work-generation

--- a/defaults/scripts/cli/loom-scale.sh
+++ b/defaults/scripts/cli/loom-scale.sh
@@ -1,5 +1,18 @@
 #!/usr/bin/env bash
-# loom scale - Dynamic agent scaling
+# loom scale - Dynamic agent scaling (LEGACY: tmux Manual-Orchestration-Mode)
+#
+# DEPRECATED (#3811): this script scales tmux-session-based agents for the
+# hands-on Manual Orchestration Mode. It is NOT the autonomous daemon's scaling
+# mechanism. The Rust `loom-daemon` work finder now scales concurrent autonomous
+# sweeps automatically, work-driven: min(token-pool size, disk headroom,
+# LOOM_WORK_FINDER_MAX_CONCURRENT), recomputed every tick. To tune autonomous
+# concurrency, set those env vars instead of using this script:
+#   LOOM_WORK_FINDER=1                     Enable the daemon work-finder loop.
+#   LOOM_WORK_FINDER_MAX_CONCURRENT=<N>    Operator ceiling on concurrent sweeps.
+# See .loom/docs/daemon-reference.md -> "Autonomous work finder".
+#
+# The `shepherd` role no longer exists (removed in v0.10.0); use `builder` or
+# another live role name if you drive tmux agents manually.
 #
 # Usage:
 #   loom scale <role> <count>     Scale role to target count
@@ -7,9 +20,9 @@
 #   loom scale --help             Show help
 #
 # Examples:
-#   loom scale shepherd 3         Scale shepherd agents to 3
-#   loom scale shepherd 0         Stop all shepherds
 #   loom scale builder 2          Scale builder agents to 2
+#   loom scale builder 0          Stop all builder agents
+#   loom scale judge 1            Scale judge agents to 1
 
 set -euo pipefail
 
@@ -70,7 +83,17 @@ fi
 # Show help
 show_help() {
     cat <<EOF
-${BOLD}loom scale - Dynamic agent scaling${NC}
+${BOLD}loom scale - Dynamic agent scaling (LEGACY: tmux Manual Orchestration Mode)${NC}
+
+${YELLOW}DEPRECATED (#3811):${NC}
+    This scales tmux-session agents for hands-on Manual Orchestration Mode. It is
+    NOT the autonomous daemon's scaling mechanism. The Rust loom-daemon work
+    finder scales concurrent autonomous sweeps automatically, work-driven:
+    min(token-pool size, disk headroom, LOOM_WORK_FINDER_MAX_CONCURRENT),
+    recomputed every tick. To tune AUTONOMOUS concurrency, set:
+        LOOM_WORK_FINDER=1                    Enable the daemon work-finder loop.
+        LOOM_WORK_FINDER_MAX_CONCURRENT=<N>   Operator ceiling on concurrent sweeps.
+    See .loom/docs/daemon-reference.md -> "Autonomous work finder".
 
 ${YELLOW}USAGE:${NC}
     loom scale <role> <count>     Scale role to target count
@@ -84,13 +107,14 @@ ${YELLOW}OPTIONS:${NC}
     --status          Show current scale for each role
 
 ${YELLOW}EXAMPLES:${NC}
-    loom scale shepherd 3         Scale shepherd agents to 3
-    loom scale shepherd 0         Stop all shepherds
     loom scale builder 2          Scale builder agents to 2
+    loom scale builder 0          Stop all builder agents
+    loom scale judge 1            Scale judge agents to 1
     loom scale --status           Show current agent counts
 
 ${YELLOW}ROLES:${NC}
-    Common roles: shepherd, builder, judge, curator, champion, architect
+    Common roles: builder, judge, curator, champion, architect
+    (the 'shepherd' role was removed in v0.10.0)
 
 ${YELLOW}HOW IT WORKS:${NC}
     Scale up:
@@ -143,7 +167,7 @@ get_max_role_number() {
 
     while read -r session; do
         if [[ -n "$session" ]]; then
-            # Extract number from session name (e.g., loom-shepherd-3 -> 3)
+            # Extract number from session name (e.g., loom-builder-3 -> 3)
             local num
             num=$(echo "$session" | grep -oE '[0-9]+$' || echo "0")
             if [[ "$num" -gt "$max" ]]; then

--- a/loom-daemon/src/disk_headroom.rs
+++ b/loom-daemon/src/disk_headroom.rs
@@ -1,0 +1,252 @@
+//! Disk-headroom math for the autonomous work finder (#3811, Phase B of epic
+//! #3809).
+//!
+//! This is the Rust port of the two `defaults/scripts/lib/disk-headroom.sh`
+//! functions the `/loom:sweep` skill uses to resource-gate its wave size:
+//!
+//! - [`worktree_root_free_gb`] mirrors bash `loom_worktree_root_free_gb`: resolve
+//!   the worktree-root filesystem (via [`crate::worktree_root::worktree_root`],
+//!   the existing Rust-native port of `worktree-root.sh`), walk up to the nearest
+//!   existing ancestor, and shell out to `df -Pk` to read the integer free GB on
+//!   **that** volume (the dedicated scratch volume when `LOOM_WORKTREE_ROOT` /
+//!   `worktree.root` is set — NOT the repo's own drive).
+//! - [`disk_headroom`] mirrors the disk term of bash `loom_wave_size_from_disk`:
+//!   `floor(free_gb / LOOM_PER_WORKTREE_GB)`, the number of worktrees the scratch
+//!   volume can hold at the conservative per-worktree estimate.
+//!
+//! # Why shell out to `df` instead of a `statvfs` crate
+//!
+//! `loom-daemon/Cargo.toml` has no `libc`/`nix`/`sysinfo` dependency, and the
+//! precedent set by [`crate::worktree_root`] (an explicit 1:1 port of a bash lib)
+//! is to keep the Rust and bash implementations trivially comparable. Shelling to
+//! `df -Pk <path>` — the same tool the bash version uses — avoids a new crate
+//! dependency and keeps the two ports byte-for-byte auditable. The pure parsing
+//! and arithmetic ([`parse_df_available_gb`], [`disk_headroom`]) are split out
+//! from the I/O so they stay unit-testable without a real filesystem.
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use crate::worktree_root::worktree_root;
+
+/// Environment variable overriding the conservative per-worktree disk estimate
+/// (GB). Mirrors bash `LOOM_PER_WORKTREE_GB`.
+pub const PER_WORKTREE_GB_ENV: &str = "LOOM_PER_WORKTREE_GB";
+
+/// Default per-worktree disk estimate (GB). Matches the bash default of 2.
+pub const DEFAULT_PER_WORKTREE_GB: u64 = 2;
+
+/// Resolve the per-worktree GB estimate from [`PER_WORKTREE_GB_ENV`], flooring to
+/// a minimum of 1 (a zero or unparseable value would make the disk term diverge).
+/// Mirrors the bash `per` resolution and its `per < 1` guard.
+#[must_use]
+pub fn per_worktree_gb() -> u64 {
+    std::env::var(PER_WORKTREE_GB_ENV)
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|&n| n >= 1)
+        .unwrap_or(DEFAULT_PER_WORKTREE_GB)
+}
+
+/// Parse the integer free GB from `df -Pk` output.
+///
+/// `df -Pk` prints a header row then exactly one single-line data row per
+/// filesystem (the `-P` POSIX format pins one line per fs; `-k` pins 1024-byte
+/// blocks). The 4th whitespace-delimited column of the data row is "Available" in
+/// 1K blocks; this divides down to GB with an integer floor (`/ 1024 / 1024`),
+/// matching the bash `avail_k / 1024 / 1024`.
+///
+/// Returns `None` when the output is malformed (missing data row, non-numeric
+/// Available column) so the caller can floor to 0 free rather than panic.
+#[must_use]
+pub fn parse_df_available_gb(df_output: &str) -> Option<u64> {
+    // Second line is the single data row (`-P` guarantees one line per fs).
+    let data_row = df_output.lines().nth(1)?;
+    // 4th column (0-based index 3) is "Available" in 1K blocks.
+    let avail_k: u64 = data_row.split_whitespace().nth(3)?.parse().ok()?;
+    Some(avail_k / 1024 / 1024)
+}
+
+/// Walk `path` up to the nearest existing ancestor (read-only; never creates a
+/// directory). The worktree-root leaf usually does not exist yet, and `df` errors
+/// on a non-existent path — mirrors the bash `while [[ ... ! -e $probe ]]` loop.
+fn nearest_existing_ancestor(path: &Path) -> &Path {
+    let mut probe = path;
+    while !probe.exists() {
+        match probe.parent() {
+            Some(parent) => probe = parent,
+            None => break,
+        }
+    }
+    probe
+}
+
+/// Echo the integer free space (GB) on the filesystem hosting the resolved
+/// worktree root for `repo_root`. Rust port of bash `loom_worktree_root_free_gb`.
+///
+/// Resolves the worktree root via [`worktree_root`] (override-aware:
+/// `LOOM_WORKTREE_ROOT` / `worktree.root` / default `<repo>/.loom/worktrees`),
+/// walks up to the nearest existing ancestor, and runs `df -Pk` on it. Returns 0
+/// free on any failure (df missing/errored, unparseable output) so the caller
+/// floors to a single worktree rather than crashing — matching the bash
+/// `echo "0"` fallbacks.
+#[must_use]
+pub fn worktree_root_free_gb(repo_root: &Path) -> u64 {
+    let wt_root = worktree_root(repo_root);
+    let probe = nearest_existing_ancestor(&wt_root);
+
+    let output = match Command::new("df")
+        .arg("-Pk")
+        .arg(probe)
+        .stderr(Stdio::null())
+        .output()
+    {
+        Ok(o) if o.status.success() => o,
+        Ok(_) | Err(_) => return 0,
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_df_available_gb(&stdout).unwrap_or(0)
+}
+
+/// The disk-headroom concurrency term: how many worktrees `free_gb` can hold at
+/// `per_gb` GB each. Pure `floor(free_gb / per_gb)`, mirroring the disk term of
+/// bash `loom_wave_size_from_disk` (`free_gb / per`). A `per_gb` of 0 is treated
+/// as 1 to avoid a divide-by-zero (the env resolver already floors it, but this
+/// keeps the pure function total).
+#[must_use]
+pub fn disk_headroom(free_gb: u64, per_gb: u64) -> usize {
+    let per = per_gb.max(1);
+    usize::try_from(free_gb / per).unwrap_or(usize::MAX)
+}
+
+/// Resolve the disk-headroom concurrency bound for `repo_root`: the number of
+/// worktrees the worktree-root scratch volume can hold at the resolved
+/// per-worktree estimate. Combines [`worktree_root_free_gb`] (I/O) with
+/// [`disk_headroom`] (pure math) and [`per_worktree_gb`] (env).
+#[must_use]
+pub fn disk_headroom_limit(repo_root: &Path) -> usize {
+    disk_headroom(worktree_root_free_gb(repo_root), per_worktree_gb())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    // ===================================================================
+    // parse_df_available_gb — df output parsing
+    // ===================================================================
+
+    #[test]
+    fn test_parse_df_macos_shape() {
+        // macOS `df -Pk /` shape: header + one data row. Available (col 4) is
+        // 200 GB worth of 1K blocks (200 * 1024 * 1024).
+        let out = "Filesystem 1024-blocks      Used Available Capacity  Mounted on\n\
+                   /dev/disk3s1 976490576 300000000 209715200      60%    /\n";
+        assert_eq!(parse_df_available_gb(out), Some(200));
+    }
+
+    #[test]
+    fn test_parse_df_linux_shape() {
+        // GNU `df -Pk` shape. Available = 50 GB (50 * 1024 * 1024 = 52428800).
+        let out = "Filesystem     1024-blocks    Used Available Use% Mounted on\n\
+                   /dev/sda1        103081248 47000000  52428800  48% /\n";
+        assert_eq!(parse_df_available_gb(out), Some(50));
+    }
+
+    #[test]
+    fn test_parse_df_floors_partial_gb() {
+        // 1.5 GB of 1K blocks floors to 1.
+        let avail_k = 1024 * 1024 + 512 * 1024;
+        let out = format!("H E A D E R\n/dev/x 999 1 {avail_k} 1% /\n");
+        assert_eq!(parse_df_available_gb(&out), Some(1));
+    }
+
+    #[test]
+    fn test_parse_df_missing_data_row_is_none() {
+        assert_eq!(parse_df_available_gb("only a header line\n"), None);
+        assert_eq!(parse_df_available_gb(""), None);
+    }
+
+    #[test]
+    fn test_parse_df_non_numeric_available_is_none() {
+        let out = "Filesystem 1024-blocks Used Available Capacity Mounted\n\
+                   /dev/x 999 1 not-a-number 1% /\n";
+        assert_eq!(parse_df_available_gb(out), None);
+    }
+
+    // ===================================================================
+    // disk_headroom — pure floor division
+    // ===================================================================
+
+    #[test]
+    fn test_disk_headroom_floors() {
+        assert_eq!(disk_headroom(20, 2), 10);
+        assert_eq!(disk_headroom(21, 2), 10); // floor
+        assert_eq!(disk_headroom(1, 2), 0); // less than one worktree fits
+        assert_eq!(disk_headroom(0, 2), 0);
+    }
+
+    #[test]
+    fn test_disk_headroom_per_gb_zero_treated_as_one() {
+        // Defensive: a 0 per_gb must not divide-by-zero.
+        assert_eq!(disk_headroom(5, 0), 5);
+    }
+
+    // ===================================================================
+    // per_worktree_gb — env resolution
+    // ===================================================================
+
+    #[test]
+    #[serial]
+    fn test_per_worktree_gb_default_and_override() {
+        std::env::remove_var(PER_WORKTREE_GB_ENV);
+        assert_eq!(per_worktree_gb(), DEFAULT_PER_WORKTREE_GB);
+
+        std::env::set_var(PER_WORKTREE_GB_ENV, "5");
+        assert_eq!(per_worktree_gb(), 5);
+
+        // Zero and unparseable fall back to the default (bash floors per >= 1).
+        std::env::set_var(PER_WORKTREE_GB_ENV, "0");
+        assert_eq!(per_worktree_gb(), DEFAULT_PER_WORKTREE_GB);
+        std::env::set_var(PER_WORKTREE_GB_ENV, "garbage");
+        assert_eq!(per_worktree_gb(), DEFAULT_PER_WORKTREE_GB);
+        std::env::remove_var(PER_WORKTREE_GB_ENV);
+    }
+
+    // ===================================================================
+    // nearest_existing_ancestor — read-only ancestor walk
+    // ===================================================================
+
+    #[test]
+    fn test_nearest_existing_ancestor_walks_up() {
+        let tmp = tempfile::tempdir().unwrap();
+        let deep = tmp.path().join("does/not/exist/yet");
+        // Walks up to the tempdir, which exists.
+        assert_eq!(nearest_existing_ancestor(&deep), tmp.path());
+    }
+
+    #[test]
+    fn test_nearest_existing_ancestor_returns_self_when_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(nearest_existing_ancestor(tmp.path()), tmp.path());
+    }
+
+    // ===================================================================
+    // worktree_root_free_gb — smoke test against the real df
+    // ===================================================================
+
+    #[test]
+    fn test_worktree_root_free_gb_returns_a_value() {
+        // Integration smoke: the repo root's volume has some free space, so a
+        // real `df -Pk` should parse to a value. We only assert it doesn't panic
+        // and returns a plausible (non-astronomical) integer — the exact GB is
+        // environment-dependent.
+        let tmp = tempfile::tempdir().unwrap();
+        let free = worktree_root_free_gb(tmp.path());
+        // A modern dev/CI volume has < 1 EB free; this just guards the parse.
+        assert!(free < 1_000_000_000);
+    }
+}

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -11,6 +11,7 @@
 #![allow(clippy::missing_panics_doc)]
 
 pub mod activity;
+pub mod disk_headroom;
 pub mod epic_state;
 pub mod epic_supervisor;
 pub mod errors;
@@ -27,6 +28,7 @@ pub mod phase_join;
 pub mod role_validation;
 pub mod sweep_registry;
 pub mod terminal;
+pub mod tokens;
 pub mod types;
 pub mod work_finder;
 pub mod worktree_root;

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -291,10 +291,15 @@ async fn main() -> Result<()> {
     // Keep the handle alive for the daemon's lifetime; its Drop signals stop.
     let _supervisor_handle = supervisor_handle;
 
-    // Autonomous work-finder loop (Issue #3810 — Phase A of epic #3809). Opt-in
-    // via `LOOM_WORK_FINDER`. Each tick queries the forge for open `loom:issue`
-    // items and dispatches up to a fixed concurrency cap through the same
+    // Autonomous work-finder loop (Issue #3810 — Phase A of epic #3809; dynamic
+    // concurrency scaling added in #3811 — Phase B). Opt-in via
+    // `LOOM_WORK_FINDER`. Each tick queries the forge for open `loom:issue`
+    // items and dispatches up to a **work-driven** cap — recomputed every tick as
+    // `min(token-pool size, disk headroom, configured_max)` — through the same
     // `SweepRegistry::dispatch()` path the IPC `DispatchSweep` request uses.
+    // `LOOM_WORK_FINDER_MAX_CONCURRENT` is repurposed (Phase A → B) from a fixed
+    // target into the operator ceiling; the cap also never exceeds the token-pool
+    // size (no account over-subscription) nor the scratch-volume disk headroom.
     //
     // Unlike the epic supervisor above, this runs as a plain `tokio::spawn`
     // interval task on the shared daemon runtime (like the reaper): every call
@@ -304,16 +309,18 @@ async fn main() -> Result<()> {
         let source = work_finder::GhWorkSource::new();
         let dispatcher = work_finder::RegistryDispatcher::new(sweep_registry.clone());
         let interval = work_finder::resolve_interval();
-        let max_concurrent = work_finder::resolve_max_concurrent();
+        let configured_max = work_finder::resolve_max_concurrent();
         log::info!(
-            "work_finder: enabled (interval={}s, max_concurrent={max_concurrent})",
+            "work_finder: enabled (interval={}s, configured_max={configured_max}, \
+             dynamic cap = min(pool, disk, configured_max))",
             interval.as_secs()
         );
         Some(work_finder::spawn_work_finder_task(
             source,
             dispatcher,
             interval,
-            max_concurrent,
+            sweep_workspace.clone(),
+            configured_max,
         ))
     } else {
         log::debug!("work_finder: disabled (set LOOM_WORK_FINDER=1 to enable)");

--- a/loom-daemon/src/tokens.rs
+++ b/loom-daemon/src/tokens.rs
@@ -1,0 +1,117 @@
+//! Token-pool sizing for the autonomous work finder (#3811, Phase B of epic
+//! #3809).
+//!
+//! The multi-account token pool lives at `{workspace}/.loom/tokens/` — one
+//! `<account>.token` file per rotated Claude OAuth account, materialized by
+//! `loom-tokens bootstrap` (see CLAUDE.md → "Multi-Account Token Pool"). Each
+//! dispatched sweep child consumes exactly one account via `spawn-claude.sh`, so
+//! the **pool size is the hard ceiling on concurrent autonomous sweeps** — a cap
+//! above it would over-subscribe an account (two live sweeps sharing one OAuth
+//! token, defeating the rotation that spreads weekly-limit load).
+//!
+//! [`token_pool_size`] counts the `*.token` files in that directory. The sibling
+//! bookkeeping files the rotation logic writes there — `index.json`, `.ranking`,
+//! `.allowlist`, `.bad_tokens`, `.failure_counts` — are **not** `*.token` files
+//! and so are naturally excluded by the suffix filter.
+//!
+//! # Bad-token-aware counting is a deliberate follow-up
+//!
+//! A fully-accurate *usable* pool size would subtract accounts currently listed
+//! in `.bad_tokens` (auth failures / exhaustion). That entails mirroring
+//! `loom_tools.tokens.bad_tokens`' reason-aware TTL + word-boundary parsing —
+//! meaningful scope the #3811 curator note explicitly permits deferring. This
+//! first pass counts `*.token` files; the spawn path itself already skips
+//! bad-marked tokens and hard-fails (`EX_CONFIG`) when the usable pool is empty,
+//! so an over-count here at most defers one issue to the next tick rather than
+//! over-subscribing (the claim lock + registry dedup still hold). Bad-token-aware
+//! subtraction is tracked as a follow-up.
+
+use std::path::Path;
+
+/// Count the `*.token` files in `{workspace_root}/.loom/tokens/` — the size of
+/// the multi-account rotation pool, and the hard ceiling on concurrent
+/// autonomous sweeps.
+///
+/// Returns 0 when the directory is absent or unreadable (token rotation not
+/// bootstrapped) — the same condition under which `spawn-claude.sh` refuses to
+/// dispatch, so a 0 pool correctly yields a 0 dynamic cap (dispatch nothing that
+/// could not spawn) rather than silently over-subscribing.
+#[must_use]
+pub fn token_pool_size(workspace_root: &Path) -> usize {
+    let tokens_dir = workspace_root.join(".loom").join("tokens");
+    let entries = match std::fs::read_dir(&tokens_dir) {
+        Ok(e) => e,
+        Err(_) => return 0,
+    };
+    entries
+        .filter_map(Result::ok)
+        .filter(|entry| {
+            // Count regular files whose name ends in `.token`. Dotfiles like
+            // `.bad_tokens` / `.ranking` and `index.json` do not match the
+            // `.token` suffix; a directory named `*.token` (there are none in
+            // practice) is excluded by the file-type check.
+            entry.file_type().map(|t| t.is_file()).unwrap_or(false)
+                && entry
+                    .file_name()
+                    .to_str()
+                    .is_some_and(|name| name.ends_with(".token"))
+        })
+        .count()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn write_tokens_dir(workspace: &Path, files: &[&str]) {
+        let dir = workspace.join(".loom").join("tokens");
+        fs::create_dir_all(&dir).unwrap();
+        for f in files {
+            fs::write(dir.join(f), "sk-ant-oat01-fake").unwrap();
+        }
+    }
+
+    #[test]
+    fn test_counts_only_token_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_tokens_dir(
+            tmp.path(),
+            &[
+                "agent-1.token",
+                "agent-2.token",
+                "agent-3.token",
+                // Non-token bookkeeping siblings — must NOT be counted.
+                "index.json",
+                ".ranking",
+                ".allowlist",
+                ".bad_tokens",
+                ".failure_counts",
+            ],
+        );
+        assert_eq!(token_pool_size(tmp.path()), 3);
+    }
+
+    #[test]
+    fn test_missing_dir_is_zero() {
+        let tmp = tempfile::tempdir().unwrap();
+        // No .loom/tokens/ at all — rotation not bootstrapped.
+        assert_eq!(token_pool_size(tmp.path()), 0);
+    }
+
+    #[test]
+    fn test_empty_dir_is_zero() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join(".loom").join("tokens");
+        fs::create_dir_all(&dir).unwrap();
+        assert_eq!(token_pool_size(tmp.path()), 0);
+    }
+
+    #[test]
+    fn test_only_non_token_files_is_zero() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_tokens_dir(tmp.path(), &["index.json", ".bad_tokens"]);
+        assert_eq!(token_pool_size(tmp.path()), 0);
+    }
+}

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -21,9 +21,24 @@
 //!    (`loom:building` / `loom:blocked` / `loom:operator-only`).
 //! 3. For each remaining issue, dispatches through the existing
 //!    [`SweepRegistry::dispatch`](crate::sweep_registry::SweepRegistry::dispatch)
-//!    path — up to a **fixed** max-concurrency cap. `dispatch()` already flips
-//!    `loom:issue → loom:building`, acquires the per-issue `mkdir`-atomic claim
-//!    lock, and spawns the rotated-token child.
+//!    path — up to a **work-driven** max-concurrency cap recomputed every tick
+//!    (Phase B, #3811): `min(token-pool size, disk headroom, configured max)`.
+//!    `dispatch()` already flips `loom:issue → loom:building`, acquires the
+//!    per-issue `mkdir`-atomic claim lock, and spawns the rotated-token child.
+//!
+//! # Concurrency scaling (Phase B, #3811)
+//!
+//! Phase A resolved a single fixed cap once at daemon startup. Phase B replaces
+//! it with a cap **recomputed every tick** by
+//! [`resolve_dynamic_max_concurrent`] from three live inputs — the token-pool
+//! size ([`crate::tokens::token_pool_size`]), the worktree-root disk headroom
+//! ([`crate::disk_headroom::disk_headroom_limit`]), and the operator ceiling
+//! (`LOOM_WORK_FINDER_MAX_CONCURRENT`, repurposed from Phase A's fixed target
+//! into a *ceiling*). The effective per-tick concurrency is then
+//! `min(dynamic_cap, backlog_depth)`: [`tick`] iterates the ready `loom:issue`
+//! rows and stops at the cap, so concurrency scales **up** as the backlog grows
+//! and drains to **zero** dispatches when the queue is empty — all without a
+//! daemon restart, since pool/disk/backlog are read fresh each tick.
 //!
 //! # Idempotency & fail-safe
 //!
@@ -58,9 +73,13 @@
 //! supervisor's OS-thread machinery.
 
 use std::collections::HashSet;
+use std::path::PathBuf;
 use std::time::Duration;
 
 use anyhow::Result;
+
+use crate::disk_headroom::disk_headroom_limit;
+use crate::tokens::token_pool_size;
 
 // ============================================================================
 // Constants
@@ -83,12 +102,19 @@ pub const WORK_FINDER_INTERVAL_ENV: &str = "LOOM_WORK_FINDER_INTERVAL_SECS";
 /// keeping forge query volume low.
 pub const DEFAULT_WORK_FINDER_INTERVAL_SECS: u64 = 60;
 
-/// Environment variable overriding the fixed max-concurrency cap.
+/// Environment variable setting the max-concurrency **ceiling**.
+///
+/// In Phase A this was the fixed concurrency target; Phase B (#3811) repurposes
+/// it as the operator ceiling in the dynamic policy
+/// ([`resolve_dynamic_max_concurrent`]) — the cap never rises above this value
+/// however large the token pool or disk headroom. The name is intentionally
+/// kept (no new env var) so existing operator configuration keeps working.
 pub const WORK_FINDER_MAX_CONCURRENT_ENV: &str = "LOOM_WORK_FINDER_MAX_CONCURRENT";
 
-/// Default fixed max-concurrency cap (MVP). Phase B replaces this with dynamic
-/// scaling; for now the finder never lets the count of live sweeps it started
-/// exceed this.
+/// Default max-concurrency ceiling. The dynamic cap
+/// ([`resolve_dynamic_max_concurrent`]) is bounded by the token-pool size and
+/// disk headroom in addition to this ceiling, so this is an upper bound, not a
+/// fixed target.
 pub const DEFAULT_WORK_FINDER_MAX_CONCURRENT: usize = 3;
 
 /// Labels that disqualify an issue from dispatch even if it still appears in
@@ -303,6 +329,39 @@ pub fn resolve_max_concurrent() -> usize {
         .unwrap_or(DEFAULT_WORK_FINDER_MAX_CONCURRENT)
 }
 
+/// Compute the **work-driven dynamic concurrency cap** (Phase B, #3811):
+/// `min(pool_size, disk_headroom, configured_max)`.
+///
+/// This is the total-concurrency ceiling for the loop, recomputed every tick
+/// from live inputs. It deliberately does **not** fold in the backlog depth:
+/// [`tick`] already bounds the *effective* per-tick concurrency to
+/// `min(this_cap, backlog_depth)` by iterating the ready `loom:issue` rows and
+/// deferring the remainder, and it compares the cap against the current live
+/// sweep occupancy (`in_flight().len()`) — which counts already-dispatched
+/// `loom:building` sweeps that are **not** in the ready backlog. Folding backlog
+/// into the cap here would under-utilize the pool whenever prior-tick sweeps are
+/// still running (a smaller "new work" number would cap total occupancy below
+/// the pool/disk ceiling). Keeping the cap as `min(pool, disk, configured)` and
+/// letting `tick` apply the backlog bound is what makes concurrency scale up
+/// with the backlog and drain to zero when it empties.
+///
+/// The three bounds map directly to the resource each protects:
+/// - `pool_size` — never over-subscribe a rotated OAuth account (one live sweep
+///   per `.loom/tokens/*.token`).
+/// - `disk_headroom` — never provision more worktrees than the scratch volume
+///   can hold at `LOOM_PER_WORKTREE_GB` each.
+/// - `configured_max` — the operator ceiling
+///   (`LOOM_WORK_FINDER_MAX_CONCURRENT`), a hard upper bound regardless of how
+///   much pool/disk headroom exists.
+#[must_use]
+pub fn resolve_dynamic_max_concurrent(
+    pool_size: usize,
+    disk_headroom: usize,
+    configured_max: usize,
+) -> usize {
+    pool_size.min(disk_headroom).min(configured_max)
+}
+
 // ============================================================================
 // Runtime wiring — the loop runs on the shared daemon runtime
 // ============================================================================
@@ -310,23 +369,35 @@ pub fn resolve_max_concurrent() -> usize {
 /// Spawn the work-finder loop on the shared daemon runtime and return its task
 /// handle so the daemon can keep it alive for the process lifetime.
 ///
-/// Every `interval`, the task runs one [`tick`]. Unlike the epic supervisor,
-/// no dedicated OS thread is needed: [`SweepRegistry::dispatch`] returns
-/// promptly (fire-and-forget child spawn), so the finder never parks a runtime
-/// worker in a minutes-long blocking call — the same footing as the reaper
-/// task ([`crate::sweep_registry::spawn_reaper_task`]).
+/// Every `interval`, the task recomputes the **dynamic** concurrency cap
+/// (Phase B, #3811) — `min(token-pool size, disk headroom, configured_max)` via
+/// [`resolve_dynamic_max_concurrent`] — from live inputs read fresh under
+/// `workspace_root`, then runs one [`tick`] with it. The cap is **not** captured
+/// once at startup, so a pool that grows/shrinks (`loom-tokens bootstrap`), a
+/// scratch volume that fills/frees, or a draining backlog are all honored
+/// without a daemon restart. `configured_max` is the operator ceiling
+/// (`LOOM_WORK_FINDER_MAX_CONCURRENT`).
+///
+/// Unlike the epic supervisor, no dedicated OS thread is needed:
+/// [`SweepRegistry::dispatch`] returns promptly (fire-and-forget child spawn),
+/// so the finder never parks a runtime worker in a minutes-long blocking call —
+/// the same footing as the reaper task
+/// ([`crate::sweep_registry::spawn_reaper_task`]). The per-tick disk probe shells
+/// out to `df` briefly, which is negligible on the 60s default interval.
 pub fn spawn_work_finder_task<S, D>(
     mut source: S,
     mut dispatcher: D,
     interval: Duration,
-    max_concurrent: usize,
+    workspace_root: PathBuf,
+    configured_max: usize,
 ) -> tokio::task::JoinHandle<()>
 where
     S: WorkSource + Send + 'static,
     D: WorkDispatcher + Send + 'static,
 {
     log::info!(
-        "work_finder: starting loop (interval={}s, max_concurrent={max_concurrent})",
+        "work_finder: starting loop (interval={}s, configured_max={configured_max}, \
+         dynamic cap = min(pool, disk, configured_max))",
         interval.as_secs()
     );
     tokio::spawn(async move {
@@ -335,12 +406,21 @@ where
         ticker.tick().await;
         loop {
             ticker.tick().await;
+            // Recompute the dynamic cap from live inputs every tick (Phase B).
+            let pool_size = token_pool_size(&workspace_root);
+            let disk = disk_headroom_limit(&workspace_root);
+            let max_concurrent = resolve_dynamic_max_concurrent(pool_size, disk, configured_max);
+            log::debug!(
+                "work_finder: dynamic cap = {max_concurrent} (pool={pool_size}, disk={disk}, \
+                 configured_max={configured_max})"
+            );
             match tick(&mut source, &mut dispatcher, max_concurrent) {
                 Ok(report) => {
                     if report.dispatched > 0 || report.errors > 0 {
                         log::info!(
-                            "work_finder: tick — {} seen, {} dispatched, {} labeled-skip, \
-                             {} in-flight-skip, {} deferred, {} error(s)",
+                            "work_finder: tick — cap {max_concurrent} (pool={pool_size}, \
+                             disk={disk}, ceiling={configured_max}); {} seen, {} dispatched, \
+                             {} labeled-skip, {} in-flight-skip, {} deferred, {} error(s)",
                             report.seen,
                             report.dispatched,
                             report.skipped_labeled,
@@ -788,5 +868,94 @@ mod tests {
         std::env::set_var(WORK_FINDER_MAX_CONCURRENT_ENV, "nope");
         assert_eq!(resolve_max_concurrent(), DEFAULT_WORK_FINDER_MAX_CONCURRENT);
         std::env::remove_var(WORK_FINDER_MAX_CONCURRENT_ENV);
+    }
+
+    // ===================================================================
+    // resolve_dynamic_max_concurrent — Phase B work-driven policy (#3811)
+    // ===================================================================
+
+    #[test]
+    fn test_dynamic_cap_is_min_of_three_inputs() {
+        // Never exceeds any of the three bounds.
+        assert_eq!(resolve_dynamic_max_concurrent(10, 10, 10), 10);
+        assert_eq!(resolve_dynamic_max_concurrent(2, 9, 9), 2, "pool binds");
+        assert_eq!(resolve_dynamic_max_concurrent(9, 3, 9), 3, "disk binds");
+        assert_eq!(resolve_dynamic_max_concurrent(9, 9, 4), 4, "ceiling binds");
+    }
+
+    #[test]
+    fn test_dynamic_cap_pool_size_bound_never_over_subscribes() {
+        // With a large disk headroom and ceiling, the token-pool size is the
+        // hard bound — the cap never exceeds the number of usable accounts.
+        for pool in 0..=5 {
+            assert_eq!(
+                resolve_dynamic_max_concurrent(pool, 100, 100),
+                pool,
+                "cap must equal pool size {pool} when disk/ceiling are larger"
+            );
+        }
+    }
+
+    #[test]
+    fn test_dynamic_cap_disk_headroom_bound() {
+        // A nearly-full scratch volume (disk headroom 1) caps concurrency at 1
+        // even with a big pool and high ceiling.
+        assert_eq!(resolve_dynamic_max_concurrent(8, 1, 8), 1);
+        // A full volume (0 headroom) drops the cap to 0 — dispatch nothing.
+        assert_eq!(resolve_dynamic_max_concurrent(8, 0, 8), 0);
+    }
+
+    #[test]
+    fn test_dynamic_cap_zero_pool_dispatches_nothing() {
+        // No usable tokens ⇒ cap 0 ⇒ a subsequent tick dispatches nothing (the
+        // spawn path would hard-fail EX_CONFIG anyway).
+        let cap = resolve_dynamic_max_concurrent(0, 10, 10);
+        assert_eq!(cap, 0);
+        let mut source = FakeSource::once((1..=3).map(issue).collect());
+        let mut disp = RecordingDispatcher::default();
+        let report = tick(&mut source, &mut disp, cap).unwrap();
+        assert_eq!(report.dispatched, 0);
+        assert_eq!(report.deferred_capacity, 3);
+        assert!(disp.dispatched.is_empty());
+    }
+
+    // ===================================================================
+    // Dynamic cap composed with tick — scale-up / scale-to-zero (#3811)
+    // ===================================================================
+
+    #[test]
+    fn test_scale_up_with_growing_backlog_bounded_by_dynamic_cap() {
+        // Fixed resources: pool=4, disk=10, ceiling=10 ⇒ dynamic cap 4. As the
+        // backlog grows tick-over-tick, effective concurrency scales up but is
+        // bounded by the cap (min(cap, backlog)).
+        let cap = resolve_dynamic_max_concurrent(4, 10, 10);
+        assert_eq!(cap, 4);
+
+        // Backlog 2 (< cap): all 2 dispatch, nothing deferred.
+        let mut source = FakeSource::once((1..=2).map(issue).collect());
+        let mut disp = RecordingDispatcher::default();
+        let report = tick(&mut source, &mut disp, cap).unwrap();
+        assert_eq!(report.dispatched, 2, "backlog 2 < cap 4 ⇒ 2 dispatched");
+        assert_eq!(report.deferred_capacity, 0);
+
+        // Backlog 6 (> cap): scales up to the cap (4), defers the surplus (2).
+        let mut source = FakeSource::once((10..=15).map(issue).collect());
+        let mut disp = RecordingDispatcher::default();
+        let report = tick(&mut source, &mut disp, cap).unwrap();
+        assert_eq!(report.dispatched, 4, "backlog 6 > cap 4 ⇒ scaled up to cap");
+        assert_eq!(report.deferred_capacity, 2);
+    }
+
+    #[test]
+    fn test_scale_to_zero_on_empty_backlog() {
+        // Even with ample resources (cap 5), an empty backlog dispatches nothing
+        // — no capacity is pre-reserved and no idle workers are spawned.
+        let cap = resolve_dynamic_max_concurrent(5, 5, 5);
+        assert_eq!(cap, 5);
+        let mut source = FakeSource::once(vec![]);
+        let mut disp = RecordingDispatcher::default();
+        let report = tick(&mut source, &mut disp, cap).unwrap();
+        assert_eq!(report, TickReport::default(), "empty backlog ⇒ zero activity");
+        assert!(disp.dispatched.is_empty());
     }
 }


### PR DESCRIPTION
Closes #3811

**Part of #3809** (Fully autonomous daemon mode). Builds on Phase A (#3810, the fixed-cap work-finder loop).

## What changed

Replaces Phase A's **fixed** concurrency cap (resolved once at daemon startup and captured into the work-finder task closure) with a **work-driven dynamic cap recomputed every tick**:

```
dynamic_cap = min(token-pool size, disk headroom, configured ceiling)
```

The effective per-tick concurrency stays `min(dynamic_cap, backlog_depth)` — handled by the existing `tick()` loop iterating the ready `loom:issue` rows — so concurrency **scales up** as the backlog grows and drains to **zero** dispatches when the queue empties, all without a daemon restart.

### New modules
- **`loom-daemon/src/disk_headroom.rs`** — Rust port of `defaults/scripts/lib/disk-headroom.sh`'s `loom_worktree_root_free_gb` (shells out to `df -Pk`, reusing the existing `worktree_root::worktree_root()` native port to locate the scratch volume) plus the pure `floor(free_gb / LOOM_PER_WORKTREE_GB)` math. **No new crate dependency** — follows the `worktree_root.rs` porting precedent (no `libc`/`nix`/`sysinfo`), keeping the two implementations trivially comparable.
- **`loom-daemon/src/tokens.rs`** — `token_pool_size()` counts `*.token` files under `{workspace}/.loom/tokens/`; bookkeeping siblings (`index.json`, `.ranking`, `.allowlist`, `.bad_tokens`, `.failure_counts`) are excluded by the suffix filter.

### Modified
- **`work_finder.rs`** — added `resolve_dynamic_max_concurrent(pool, disk, ceiling)`; `spawn_work_finder_task` now recomputes the cap every tick from live inputs (recommendation (a) from the curator note) instead of capturing a single startup `usize`.
- **`main.rs`** — passes `sweep_workspace` + the configured ceiling instead of a pre-resolved cap.
- **`loom-scale.sh`** — retargeted stale `shepherd`/tmux references with a deprecation note pointing at `LOOM_WORK_FINDER` / `LOOM_WORK_FINDER_MAX_CONCURRENT` (lighter deprecate/retarget option, not a functional rewrite).
- **`.loom/docs/daemon-reference.md`** — "Autonomous work finder" section updated for the dynamic policy; dropped the "deferred to Phase B" phrasing.

## Deliberate design decisions (for the Judge)

1. **`LOOM_WORK_FINDER_MAX_CONCURRENT` is repurposed, not renamed** — Phase A's fixed-target env var becomes the operator **ceiling** input. No new env var, per the curator's ADR-friendly recommendation. Not an unrelated rename.
2. **The policy function omits `backlog_depth` from its `min`** (deviating from the issue's *illustrative* code snippet, but matching the refined acceptance criterion which states `min(pool_size, disk_headroom, configured_max)`). `tick()` already bounds effective concurrency to `min(cap, backlog)` and compares the cap against **live sweep occupancy** (`in_flight().len()`, i.e. already-dispatched `loom:building` sweeps not in the ready backlog). Folding backlog into the cap would under-utilize the pool whenever prior-tick sweeps are still running.
3. **Bad-token-aware pool counting deferred** — first pass counts `*.token` files (the curator note explicitly permits this). A 0 pool yields a 0 cap (dispatch nothing), matching `spawn-claude.sh`'s `EX_CONFIG` hard-fail on a missing pool.

## Tests

`cargo test -p loom-daemon`: **546 lib tests pass, 0 failed**. `cargo clippy --all-targets -- -D warnings`: **clean**. `cargo build`: **clean**. `shellcheck loom-scale.sh`: clean.

New coverage: pool-size bound / never-over-subscribe, disk-headroom bound, configured-max ceiling, zero-pool dispatches nothing, scale-up on growing backlog (bounded by cap), scale-to-zero on empty backlog, `df -Pk` parsing (macOS + Linux shapes, GB flooring, malformed rows), `*.token` counting (bookkeeping-sibling exclusion, missing/empty dir).

## Out of scope
Architect/Hermit work-generation cadence (#3381) — this issue only governs *dispatch concurrency* for already-approved `loom:issue` items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)