### PR TITLE
refactor(prompts): consolidate Terminal Probe Protocol into one canonical file (#3791)

### DIFF
--- a/defaults/.claude/commands/loom/architect.md
+++ b/defaults/.claude/commands/loom/architect.md
@@ -318,12 +318,9 @@ Architect uses context-specific instruction files to keep token usage efficient:
 
 ## Terminal Probe Protocol
 
-When you receive a probe command, respond with: `AGENT:Architect:<brief-task-description>`
+When you receive a probe command, respond with: `AGENT:Architect:<brief-task>` — e.g. `AGENT:Architect:analyzing-system-design`.
 
-Examples:
-- `AGENT:Architect:analyzing-system-design`
-- `AGENT:Architect:creating-proposal-123`
-- `AGENT:Architect:idle-monitoring-for-work`
+**The full probe protocol** (format, per-role examples, task-description conventions, and rationale) **lives in [`probe-protocol.md`](probe-protocol.md).**
 
 ---
 

--- a/defaults/.claude/commands/loom/auditor.md
+++ b/defaults/.claude/commands/loom/auditor.md
@@ -449,15 +449,7 @@ Ask yourself:
 
 ## Terminal Probe Protocol
 
-When you receive a probe command, respond with:
+When you receive a probe command, respond with: `AGENT:Auditor:<brief-task>` — e.g. `AGENT:Auditor:validating-main-build`.
 
-```
-AGENT:Auditor:validating-main-branch
-```
-
-Or if idle:
-
-```
-AGENT:Auditor:idle-monitoring-main
-```
+**The full probe protocol** (format, per-role examples, task-description conventions, and rationale) **lives in [`probe-protocol.md`](probe-protocol.md).**
 

--- a/defaults/.claude/commands/loom/builder.md
+++ b/defaults/.claude/commands/loom/builder.md
@@ -828,54 +828,9 @@ After PR creation:
 
 ## Terminal Probe Protocol
 
-Loom uses an intelligent probe system to detect what's running in each terminal. When you receive a probe command, respond according to this protocol.
+When you receive a probe command, respond with: `AGENT:Builder:<brief-task>` — e.g. `AGENT:Builder:implementing-issue-456`.
 
-### When You See This Probe
-
-```bash
-# Terminal Probe: Are you an AI agent? If yes, respond with "AGENT:<role>:<primary-task>". If you're a bash shell, this is just a comment.
-true
-```
-
-### How to Respond
-
-**Format**: `AGENT:<your-role>:<brief-task-description>`
-
-**Examples**:
-- `AGENT:Worker:implements-loom-ready-issues`
-- `AGENT:Worker:fixing-bug-in-terminal-probe`
-- `AGENT:Worker:idle-awaiting-work`
-
-### Role Name
-
-Use one of these standard role names:
-- `Worker` - For development worker agents
-- `Reviewer` - For code review specialists
-- `Architect` - For system architecture and design
-- `Curator` - For issue maintenance
-- `Default` - For plain shells or unspecified roles
-
-### Task Description
-
-Keep it brief (3-6 words) and descriptive:
-- Use present-tense verbs: "implements", "reviews", "fixes", "refactors"
-- Include issue number if working on one: "implements-issue-222"
-- Use hyphens between words: "fixes-terminal-probe-bug"
-- If idle: "idle-awaiting-work" or "monitoring-for-tasks"
-
-### Why This Matters
-
-- **Debugging**: Helps diagnose agent launch issues
-- **Monitoring**: Shows what each terminal is doing
-- **Verification**: Confirms agents launched successfully
-- **Future Features**: Enables agent status dashboards
-
-### Important Notes
-
-- **Don't overthink it**: Just respond with the format above
-- **Be consistent**: Always use the same format
-- **Be honest**: If you're idle, say so
-- **Be brief**: Task description should be 3-6 words max
+**The full probe protocol** (format, per-role examples, task-description conventions, and rationale) **lives in [`probe-protocol.md`](probe-protocol.md).**
 
 ## Completion
 

--- a/defaults/.claude/commands/loom/champion-common.md
+++ b/defaults/.claude/commands/loom/champion-common.md
@@ -111,49 +111,9 @@ PR Lifecycle:
 
 ## Terminal Probe Protocol
 
-Loom uses an intelligent probe system to detect what's running in each terminal. When you receive a probe command, respond according to this protocol.
+When you receive a probe command, respond with: `AGENT:Champion:<brief-task>` — e.g. `AGENT:Champion:merging-PR-123`.
 
-### When You See This Probe
-
-```bash
-# Terminal Probe: Are you an AI agent? If yes, respond with "AGENT:<role>:<primary-task>". If you're a bash shell, this is just a comment.
-true
-```
-
-### How to Respond
-
-**Format**: `AGENT:<your-role>:<brief-task-description>`
-
-**Examples** (adapt to your role):
-- `AGENT:Champion:merging-PR-123`
-- `AGENT:Champion:promoting-issue-456`
-- `AGENT:Champion:awaiting-work`
-
-### Role Name
-
-Use "Champion" as your role name.
-
-### Task Description
-
-Keep it brief (3-6 words) and descriptive:
-- Use present-tense verbs: "merging", "promoting", "evaluating"
-- Include issue/PR number if working on one: "merging-PR-123"
-- Use hyphens between words: "promoting-issue-456"
-- If idle: "awaiting-work" or "checking-queues"
-
-### Why This Matters
-
-- **Debugging**: Helps diagnose agent launch issues
-- **Monitoring**: Shows what each terminal is doing
-- **Verification**: Confirms agents launched successfully
-- **Future Features**: Enables agent status dashboards
-
-### Important Notes
-
-- **Don't overthink it**: Just respond with the format above
-- **Be consistent**: Always use the same format
-- **Be honest**: If you're idle, say so
-- **Be brief**: Task description should be 3-6 words max
+**The full probe protocol** (format, per-role examples, task-description conventions, and rationale) **lives in [`probe-protocol.md`](probe-protocol.md).**
 
 ---
 

--- a/defaults/.claude/commands/loom/champion.md
+++ b/defaults/.claude/commands/loom/champion.md
@@ -192,14 +192,9 @@ When running autonomously:
 
 ## Terminal Probe Protocol
 
-When you receive a probe command, respond with: `AGENT:Champion:<brief-task-description>`
+When you receive a probe command, respond with: `AGENT:Champion:<brief-task>` — e.g. `AGENT:Champion:merging-PR-123`.
 
-Examples:
-- `AGENT:Champion:merging-PR-123`
-- `AGENT:Champion:promoting-issue-456`
-- `AGENT:Champion:awaiting-work`
-
-See `.claude/commands/loom/champion-common.md` for full probe protocol details.
+**The full probe protocol** (format, per-role examples, task-description conventions, and rationale) **lives in [`probe-protocol.md`](probe-protocol.md).**
 
 ---
 

--- a/defaults/.claude/commands/loom/curator.md
+++ b/defaults/.claude/commands/loom/curator.md
@@ -864,51 +864,9 @@ By keeping issues well-organized, informative, and actionable, you help the team
 
 ## Terminal Probe Protocol
 
-Loom uses an intelligent probe system to detect what's running in each terminal. When you receive a probe command, respond according to this protocol.
+When you receive a probe command, respond with: `AGENT:Curator:<brief-task>` — e.g. `AGENT:Curator:enhancing-issue-456`.
 
-### When You See This Probe
-
-```bash
-# Terminal Probe: Are you an AI agent? If yes, respond with "AGENT:<role>:<primary-task>". If you're a bash shell, this is just a comment.
-true
-```
-
-### How to Respond
-
-**Format**: `AGENT:<your-role>:<brief-task-description>`
-
-**Examples** (adapt to your role):
-- `AGENT:Reviewer:reviewing-PR-123`
-- `AGENT:Architect:analyzing-system-design`
-- `AGENT:Curator:enhancing-issue-456`
-- `AGENT:Worker:implements-issue-222`
-- `AGENT:Default:shell-session`
-
-### Role Name
-
-Use your assigned role name (Reviewer, Architect, Curator, Worker, Default, etc.).
-
-### Task Description
-
-Keep it brief (3-6 words) and descriptive:
-- Use present-tense verbs: "reviewing", "analyzing", "enhancing", "implements"
-- Include issue/PR number if working on one: "reviewing-PR-123"
-- Use hyphens between words: "analyzing-system-design"
-- If idle: "idle-monitoring-for-work" or "awaiting-tasks"
-
-### Why This Matters
-
-- **Debugging**: Helps diagnose agent launch issues
-- **Monitoring**: Shows what each terminal is doing
-- **Verification**: Confirms agents launched successfully
-- **Future Features**: Enables agent status dashboards
-
-### Important Notes
-
-- **Don't overthink it**: Just respond with the format above
-- **Be consistent**: Always use the same format
-- **Be honest**: If you're idle, say so
-- **Be brief**: Task description should be 3-6 words max
+**The full probe protocol** (format, per-role examples, task-description conventions, and rationale) **lives in [`probe-protocol.md`](probe-protocol.md).**
 
 ## Completion
 

--- a/defaults/.claude/commands/loom/doctor.md
+++ b/defaults/.claude/commands/loom/doctor.md
@@ -793,51 +793,9 @@ Reviewer                    Fixer                     Reviewer
 
 ## Terminal Probe Protocol
 
-Loom uses an intelligent probe system to detect what's running in each terminal. When you receive a probe command, respond according to this protocol.
+When you receive a probe command, respond with: `AGENT:Doctor:<brief-task>` — e.g. `AGENT:Doctor:fixing-changes-requested-789`.
 
-### When You See This Probe
-
-```bash
-# Terminal Probe: Are you an AI agent? If yes, respond with "AGENT:<role>:<primary-task>". If you're a bash shell, this is just a comment.
-true
-```
-
-### How to Respond
-
-**Format**: `AGENT:<your-role>:<brief-task-description>`
-
-**Examples** (adapt to your role):
-- `AGENT:Reviewer:reviewing-PR-123`
-- `AGENT:Architect:analyzing-system-design`
-- `AGENT:Curator:enhancing-issue-456`
-- `AGENT:Worker:implements-issue-222`
-- `AGENT:Default:shell-session`
-
-### Role Name
-
-Use your assigned role name (Reviewer, Architect, Curator, Worker, Default, etc.).
-
-### Task Description
-
-Keep it brief (3-6 words) and descriptive:
-- Use present-tense verbs: "reviewing", "analyzing", "enhancing", "implements"
-- Include issue/PR number if working on one: "reviewing-PR-123"
-- Use hyphens between words: "analyzing-system-design"
-- If idle: "idle-monitoring-for-work" or "awaiting-tasks"
-
-### Why This Matters
-
-- **Debugging**: Helps diagnose agent launch issues
-- **Monitoring**: Shows what each terminal is doing
-- **Verification**: Confirms agents launched successfully
-- **Future Features**: Enables agent status dashboards
-
-### Important Notes
-
-- **Don't overthink it**: Just respond with the format above
-- **Be consistent**: Always use the same format
-- **Be honest**: If you're idle, say so
-- **Be brief**: Task description should be 3-6 words max
+**The full probe protocol** (format, per-role examples, task-description conventions, and rationale) **lives in [`probe-protocol.md`](probe-protocol.md).**
 
 ## Pre-existing Failures
 

--- a/defaults/.claude/commands/loom/driver.md
+++ b/defaults/.claude/commands/loom/driver.md
@@ -6,48 +6,6 @@ This is a plain terminal without any specialized role. You can use this for gene
 
 ## Terminal Probe Protocol
 
-Loom uses an intelligent probe system to detect what's running in each terminal. When you receive a probe command, respond according to this protocol.
+When you receive a probe command, respond with: `AGENT:Driver:<brief-task>` — e.g. `AGENT:Driver:idle-awaiting-work`.
 
-### When You See This Probe
-
-```bash
-# Terminal Probe: Are you an AI agent? If yes, respond with "AGENT:<role>:<primary-task>". If you're a bash shell, this is just a comment.
-true
-```
-
-### How to Respond
-
-**Format**: `AGENT:<your-role>:<brief-task-description>`
-
-**Examples** (adapt to your role):
-- `AGENT:Reviewer:reviewing-PR-123`
-- `AGENT:Architect:analyzing-system-design`
-- `AGENT:Curator:enhancing-issue-456`
-- `AGENT:Worker:implements-issue-222`
-- `AGENT:Default:shell-session`
-
-### Role Name
-
-Use your assigned role name (Reviewer, Architect, Curator, Worker, Default, etc.).
-
-### Task Description
-
-Keep it brief (3-6 words) and descriptive:
-- Use present-tense verbs: "reviewing", "analyzing", "enhancing", "implements"
-- Include issue/PR number if working on one: "reviewing-PR-123"
-- Use hyphens between words: "analyzing-system-design"
-- If idle: "idle-monitoring-for-work" or "awaiting-tasks"
-
-### Why This Matters
-
-- **Debugging**: Helps diagnose agent launch issues
-- **Monitoring**: Shows what each terminal is doing
-- **Verification**: Confirms agents launched successfully
-- **Future Features**: Enables agent status dashboards
-
-### Important Notes
-
-- **Don't overthink it**: Just respond with the format above
-- **Be consistent**: Always use the same format
-- **Be honest**: If you're idle, say so
-- **Be brief**: Task description should be 3-6 words max
+**The full probe protocol** (format, per-role examples, task-description conventions, and rationale) **lives in [`probe-protocol.md`](probe-protocol.md).**

--- a/defaults/.claude/commands/loom/guide.md
+++ b/defaults/.claude/commands/loom/guide.md
@@ -844,51 +844,9 @@ By keeping the urgent queue small and well-prioritized, you help Workers focus o
 
 ## Terminal Probe Protocol
 
-Loom uses an intelligent probe system to detect what's running in each terminal. When you receive a probe command, respond according to this protocol.
+When you receive a probe command, respond with: `AGENT:Guide:<brief-task>` — e.g. `AGENT:Guide:triaging-issue-queue`.
 
-### When You See This Probe
-
-```bash
-# Terminal Probe: Are you an AI agent? If yes, respond with "AGENT:<role>:<primary-task>". If you're a bash shell, this is just a comment.
-true
-```
-
-### How to Respond
-
-**Format**: `AGENT:<your-role>:<brief-task-description>`
-
-**Examples** (adapt to your role):
-- `AGENT:Reviewer:reviewing-PR-123`
-- `AGENT:Architect:analyzing-system-design`
-- `AGENT:Curator:enhancing-issue-456`
-- `AGENT:Worker:implements-issue-222`
-- `AGENT:Default:shell-session`
-
-### Role Name
-
-Use your assigned role name (Reviewer, Architect, Curator, Worker, Default, etc.).
-
-### Task Description
-
-Keep it brief (3-6 words) and descriptive:
-- Use present-tense verbs: "reviewing", "analyzing", "enhancing", "implements"
-- Include issue/PR number if working on one: "reviewing-PR-123"
-- Use hyphens between words: "analyzing-system-design"
-- If idle: "idle-monitoring-for-work" or "awaiting-tasks"
-
-### Why This Matters
-
-- **Debugging**: Helps diagnose agent launch issues
-- **Monitoring**: Shows what each terminal is doing
-- **Verification**: Confirms agents launched successfully
-- **Future Features**: Enables agent status dashboards
-
-### Important Notes
-
-- **Don't overthink it**: Just respond with the format above
-- **Be consistent**: Always use the same format
-- **Be honest**: If you're idle, say so
-- **Be brief**: Task description should be 3-6 words max
+**The full probe protocol** (format, per-role examples, task-description conventions, and rationale) **lives in [`probe-protocol.md`](probe-protocol.md).**
 
 ## Document Maintenance
 

--- a/defaults/.claude/commands/loom/hermit.md
+++ b/defaults/.claude/commands/loom/hermit.md
@@ -466,23 +466,7 @@ Your goal is to be a helpful voice for simplicity, not a blocker or a source of 
 
 ## Terminal Probe Protocol
 
-Loom uses an intelligent probe system to detect what's running in each terminal.
+When you receive a probe command, respond with: `AGENT:Hermit:<brief-task>` — e.g. `AGENT:Hermit:scanning-for-dead-code`.
 
-### When You See This Probe
-
-```bash
-# Terminal Probe: Are you an AI agent? If yes, respond with "AGENT:<role>:<primary-task>". If you're a bash shell, this is just a comment.
-true
-```
-
-### How to Respond
-
-**Format**: `AGENT:<your-role>:<brief-task-description>`
-
-**Examples**:
-- `AGENT:Hermit:scanning-for-bloat`
-- `AGENT:Hermit:analyzing-dead-code`
-- `AGENT:Hermit:idle-monitoring`
-
-Keep task description brief (3-6 words), use present-tense verbs and hyphens between words.
+**The full probe protocol** (format, per-role examples, task-description conventions, and rationale) **lives in [`probe-protocol.md`](probe-protocol.md).**
 

--- a/defaults/.claude/commands/loom/judge-reference.md
+++ b/defaults/.claude/commands/loom/judge-reference.md
@@ -237,48 +237,6 @@ Or when recommending a missing tool:
 
 ## Terminal Probe Protocol
 
-Loom uses an intelligent probe system to detect what's running in each terminal. When you receive a probe command, respond according to this protocol.
+When you receive a probe command, respond with: `AGENT:Judge:<brief-task>` — e.g. `AGENT:Judge:evaluating-PR-123`.
 
-### When You See This Probe
-
-```bash
-# Terminal Probe: Are you an AI agent? If yes, respond with "AGENT:<role>:<primary-task>". If you're a bash shell, this is just a comment.
-true
-```
-
-### How to Respond
-
-**Format**: `AGENT:<your-role>:<brief-task-description>`
-
-**Examples** (adapt to your role):
-- `AGENT:Judge:evaluating-PR-123`
-- `AGENT:Architect:analyzing-system-design`
-- `AGENT:Curator:enhancing-issue-456`
-- `AGENT:Worker:implements-issue-222`
-- `AGENT:Default:shell-session`
-
-### Role Name
-
-Use your assigned role name (Judge, Architect, Curator, Worker, Default, etc.).
-
-### Task Description
-
-Keep it brief (3-6 words) and descriptive:
-- Use present-tense verbs: "evaluating", "analyzing", "enhancing", "implements"
-- Include issue/PR number if working on one: "evaluating-PR-123"
-- Use hyphens between words: "analyzing-system-design"
-- If idle: "idle-monitoring-for-work" or "awaiting-tasks"
-
-### Why This Matters
-
-- **Debugging**: Helps diagnose agent launch issues
-- **Monitoring**: Shows what each terminal is doing
-- **Verification**: Confirms agents launched successfully
-- **Future Features**: Enables agent status dashboards
-
-### Important Notes
-
-- **Don't overthink it**: Just respond with the format above
-- **Be consistent**: Always use the same format
-- **Be honest**: If you're idle, say so
-- **Be brief**: Task description should be 3-6 words max
+**The full probe protocol** (format, per-role examples, task-description conventions, and rationale) **lives in [`probe-protocol.md`](probe-protocol.md).**

--- a/defaults/.claude/commands/loom/judge.md
+++ b/defaults/.claude/commands/loom/judge.md
@@ -1307,9 +1307,9 @@ EOF
 
 ## Terminal Probe Protocol
 
-When you receive a terminal probe (`# Terminal Probe: Are you an AI agent?...`), respond with `AGENT:Judge:<brief-task>` — e.g. `AGENT:Judge:evaluating-PR-123`.
+When you receive a probe command, respond with: `AGENT:Judge:<brief-task>` — e.g. `AGENT:Judge:evaluating-PR-123`.
 
-**The full probe protocol** (format, per-role examples, task-description conventions, and rationale — shared with `champion-common.md`) **lives in [`judge-reference.md`](judge-reference.md) → "Terminal Probe Protocol".**
+**The full probe protocol** (format, per-role examples, task-description conventions, and rationale) **lives in [`probe-protocol.md`](probe-protocol.md).**
 
 ## Completion
 

--- a/defaults/.claude/commands/loom/probe-protocol.md
+++ b/defaults/.claude/commands/loom/probe-protocol.md
@@ -1,0 +1,79 @@
+# Terminal Probe Protocol (canonical)
+
+Loom uses an intelligent probe system to detect what's running in each terminal. When you receive a probe command, respond according to this protocol.
+
+This is the single canonical copy of the probe protocol. Every role prompt that
+carries a short "Terminal Probe Protocol" pointer refers here for the full
+format, per-role examples, task-description conventions, and rationale.
+
+## When this protocol applies (interactive terminals only)
+
+**This protocol only matters for Manual Orchestration Mode terminals** —
+human-launched Claude Code sessions tracked in `.loom/config.json`'s `terminals`
+list. Those are the only sessions a terminal probe is ever sent to.
+
+It does **not** apply to:
+
+- **GitHub Actions cron one-shots** (`claude -p "/<role>" --dangerously-skip-permissions`) — no terminal, no probe.
+- **`/loom:sweep` subagent dispatch** and `loom-daemon`-spawned sweeps — no interactive terminal, no probe.
+
+If you are running in either of those non-interactive contexts, no probe will
+ever arrive and there is nothing to do here.
+
+## When you see this probe
+
+```bash
+# Terminal Probe: Are you an AI agent? If yes, respond with "AGENT:<role>:<primary-task>". If you're a bash shell, this is just a comment.
+true
+```
+
+## How to respond
+
+**Format**: `AGENT:<your-role>:<brief-task-description>`
+
+**Examples**:
+- `AGENT:Builder:implementing-issue-456`
+- `AGENT:Judge:evaluating-PR-123`
+- `AGENT:Curator:enhancing-issue-456`
+- `AGENT:Champion:merging-PR-123`
+- `AGENT:Doctor:fixing-changes-requested-789`
+- `AGENT:Guide:triaging-issue-queue`
+- `AGENT:Architect:analyzing-system-design`
+- `AGENT:Hermit:scanning-for-dead-code`
+- `AGENT:Auditor:validating-main-build`
+- `AGENT:Driver:idle-awaiting-work`
+
+## Role name (must be a real Loom role)
+
+Use your **assigned role name**, which must be one of the roles from CLAUDE.md's
+"Agent Roles" table:
+
+`Builder`, `Judge`, `Champion`, `Curator`, `Architect`, `Hermit`, `Doctor`,
+`Guide`, `Driver`, `Auditor`.
+
+**Never invent a role name.** In particular, `Worker`, `Reviewer`, and `Default`
+are **not** Loom roles — they do not appear in `.github/labels.yml`,
+`.loom/config.json`, or CLAUDE.md's role table. Use the real role name for the
+prompt you are running (e.g. the Builder prompt reports `AGENT:Builder:...`).
+
+## Task description
+
+Keep it brief (3-6 words) and descriptive:
+- Use present-tense verbs: "implementing", "evaluating", "enhancing", "fixing".
+- Include the issue/PR number if working on one: "implementing-issue-222", "evaluating-PR-123".
+- Use hyphens between words: "fixing-terminal-probe-bug".
+- If idle: "idle-awaiting-work" or "monitoring-for-tasks".
+
+## Why this matters
+
+- **Debugging**: Helps diagnose agent launch issues.
+- **Monitoring**: Shows what each terminal is doing.
+- **Verification**: Confirms agents launched successfully.
+- **Future Features**: Enables agent status dashboards.
+
+## Important notes
+
+- **Don't overthink it**: Just respond with the format above.
+- **Be consistent**: Always use the same format.
+- **Be honest**: If you're idle, say so.
+- **Be brief**: Task description should be 3-6 words max.


### PR DESCRIPTION
## Summary

The Terminal Probe Protocol (~50-line block specifying how an agent answers "are you alive" terminal probes) was pasted near-verbatim across the role prompt set and had already drifted — `builder.md` prescribed fictitious role names (`Worker`/`Reviewer`/`Default`) that exist in no Loom config. This PR folds all copies into one canonical `defaults/.claude/commands/loom/probe-protocol.md` and replaces each role prompt's copy with a short role-specific pointer, following the `champion.md`/`judge.md` precedent set by #3785.

## Changes

- **New canonical file** `defaults/.claude/commands/loom/probe-protocol.md` — full probe text/format, per-role examples, task-description conventions, a **role-name authority note** (identifiers must be one of the real roles in CLAUDE.md's Agent Roles table), "why this matters", and a single **interactive-terminal-mode gating** paragraph (cron one-shots and `/loom:sweep` subagents never receive a probe).
- **Replaced the full ~50-line block** with a ≤5-line pointer in: `builder.md`, `doctor.md`, `curator.md`, `guide.md`, `driver.md`, `champion-common.md`, `judge-reference.md`. Each pointer now carries the correct `AGENT:<Role>:...` self-example (Builder/Doctor/Curator/Guide/Driver were previously wrong or missing).
- **Repointed** `champion.md` and `judge.md`'s existing one-liners at `probe-protocol.md` directly (were pointing at `champion-common.md`/`judge-reference.md`, which no longer hold the full text) — removes the two-hop reference chain.
- **Converted** the already-short `hermit.md`, `architect.md`, `auditor.md` forms (no drift) to the same pointer for full uniformity — this was optional per the issue; chose conversion so every role funnels to the single source of truth.
- **Role-name vocabulary fix**: dropped `Worker`/`Reviewer`/`Default` entirely. `grep '"Worker"\|"Reviewer"\|AGENT:Worker\|AGENT:Reviewer\|AGENT:Default'` over the prompt set now returns nothing.

## Line-count reduction

12 modified files at **+24 / −351**, plus a new 79-line canonical doc → **~248 net lines removed** (in the issue's 250–300 target range), and a drift-prone duplication class eliminated.

## Scope notes

- `defaults/roles/*.md` symlinks are untouched — they resolve automatically since they point at the edited `defaults/.claude/commands/loom/*.md` files. `probe-protocol.md` gets no `roles/` symlink, matching the existing reference-file precedent (`champion-common.md`, `judge-reference.md`, `architect-reference.md` are likewise not symlinked in `roles/`).
- Installer/test manifests install the whole `commands/loom/` directory (recursive copy / symlink), not an explicit file list, so the new file ships automatically — no manifest change needed.
- `driver.md` (previously almost entirely the block) still reads coherently as a short "Default Shell" prompt.
- Out of scope (left untouched per the issue): `epic.md`, `imagine.md`, and `judge.md`'s separate stale `/clear` instruction.

## Test Plan / Verification

- No markdown/prompt lint harness exists in the repo (`package.json` check scripts are Rust/Python only) — N/A for a prompt-text-only change.
- Verified all 12 role/reference prompts reference `probe-protocol.md` via a same-directory relative link.
- Verified no `Worker`/`Reviewer`/`Default` identifiers remain in any probe-protocol context.
- Verified `defaults/roles/builder.md` symlink still resolves.

Closes #3791