### PR TITLE
feat(daemon): reactive main-health backstop — buildGate-on-main + halt-on-red (#3812 Phase C)

### DIFF
--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -23,6 +23,7 @@ pub mod health_monitor;
 pub mod init;
 pub mod ipc;
 pub mod issue_creation_mutex;
+pub mod main_health_gate;
 pub mod metrics_collector;
 pub mod phase_join;
 pub mod role_validation;

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -4,6 +4,7 @@ use loom_daemon::event_bus::EventBus;
 use loom_daemon::health_monitor;
 use loom_daemon::ipc::IpcServer;
 use loom_daemon::issue_creation_mutex::IssueCreationMutex;
+use loom_daemon::main_health_gate;
 use loom_daemon::metrics_collector;
 use loom_daemon::role_validation;
 use loom_daemon::sweep_registry::{self, SweepRegistry, SweepRegistryConfig};
@@ -305,6 +306,12 @@ async fn main() -> Result<()> {
     // interval task on the shared daemon runtime (like the reaper): every call
     // into `dispatch()` returns promptly (fire-and-forget child spawn), so the
     // finder never parks a runtime worker in a long blocking call.
+    // Shared reactive main-health halt flag (Issue #3812 — Phase C of epic
+    // #3809). Always constructed so it can be threaded into the work-finder;
+    // when the gate loop below is disabled nothing ever flips it, so the
+    // work-finder is never halted (zero behavior change with the gate off).
+    let main_health_state = Arc::new(main_health_gate::MainHealthState::new());
+
     let _work_finder_handle = if work_finder::enabled() {
         let source = work_finder::GhWorkSource::new();
         let dispatcher = work_finder::RegistryDispatcher::new(sweep_registry.clone());
@@ -321,9 +328,48 @@ async fn main() -> Result<()> {
             interval,
             sweep_workspace.clone(),
             configured_max,
+            main_health_state.clone(),
         ))
     } else {
         log::debug!("work_finder: disabled (set LOOM_WORK_FINDER=1 to enable)");
+        None
+    };
+
+    // Reactive main-health backstop loop (Issue #3812 — Phase C of epic #3809).
+    // Opt-in via `LOOM_MAIN_HEALTH_GATE` AND a `buildGate` block in
+    // `.loom/config.json`. On a red `main` (a non-zero `buildGate.command`) it
+    // sets `main_health_state` halted, which stops the work-finder above from
+    // dispatching new sweeps until a green run clears it. The gate command runs
+    // on a blocking thread (it may take minutes), so a plain `tokio::spawn`
+    // interval task on the shared runtime is correct (like the reaper).
+    let _main_health_gate_handle = if main_health_gate::enabled() {
+        match main_health_gate::read_build_gate_config(&sweep_workspace) {
+            Some(gate_config) => {
+                let interval = main_health_gate::resolve_interval();
+                log::info!(
+                    "main_health_gate: enabled (interval={}s, command={:?}, timeout={}s)",
+                    interval.as_secs(),
+                    gate_config.command,
+                    gate_config.timeout.as_secs()
+                );
+                let runner =
+                    main_health_gate::CommandGateRunner::new(gate_config, sweep_workspace.clone());
+                Some(main_health_gate::spawn_main_health_gate_task(
+                    runner,
+                    main_health_state.clone(),
+                    interval,
+                ))
+            }
+            None => {
+                log::warn!(
+                    "main_health_gate: LOOM_MAIN_HEALTH_GATE is set but no usable buildGate \
+                     config in .loom/config.json (missing/disabled/empty command) — gate inactive"
+                );
+                None
+            }
+        }
+    } else {
+        log::debug!("main_health_gate: disabled (set LOOM_MAIN_HEALTH_GATE=1 + a buildGate config to enable)");
         None
     };
 

--- a/loom-daemon/src/main_health_gate.rs
+++ b/loom-daemon/src/main_health_gate.rs
@@ -1,0 +1,798 @@
+//! Reactive main-health backstop — `buildGate`-on-`main` + halt-on-red
+//! (Phase C of epic #3809).
+//!
+//! This module is the daemon-native, always-on safety net for **autonomous**
+//! (non-`/loom:sweep`) dispatch. It implements the epic's **git-based reactive
+//! safety** design principle (operator decision 2026-07-23): git already
+//! catches textual conflicts at merge time; this catches the recoverable
+//! *semantic / cross-file* breakage that a clean merge can still introduce —
+//! **reactively**, after the fact, never by dispatch-time collision prevention.
+//!
+//! # What it does
+//!
+//! On a configurable cadence the gate runs the repo's configured
+//! `buildGate.command` (schema shipped in #3749) against `main`. On a **red**
+//! run (non-zero exit or timeout) it sets a shared halt flag; the
+//! [`crate::work_finder`] loop consults that flag and dispatches **zero** new
+//! sweeps while halted (existing in-flight sweeps are never killed — halting
+//! only stops making a red `main` worse). The next **green** run clears the
+//! flag and dispatch resumes on the following work-finder tick.
+//!
+//! # Shape (mirrors [`crate::work_finder`])
+//!
+//! - **Opt-in** via [`MAIN_HEALTH_GATE_ENABLE_ENV`] — unset / false-y keeps it
+//!   OFF, so the daemon's behavior is byte-for-byte unchanged when absent.
+//! - **Config** read from `.loom/config.json` → `buildGate` with the same
+//!   soft-fail pattern as [`crate::worktree_root`]'s `read_config_worktree_root`
+//!   (missing file / missing key / malformed JSON / `enabled: false` all resolve
+//!   to "gate disabled"), matching #3749's opt-in contract.
+//! - **Cadence loop** [`spawn_main_health_gate_task`] runs as a plain
+//!   `tokio::spawn` interval task on the shared daemon runtime, mirroring the
+//!   work-finder. The (potentially minutes-long) gate command is executed on a
+//!   blocking thread via `tokio::task::spawn_blocking` so it never parks a
+//!   runtime worker.
+//!
+//! # Surfacing (scope-limited)
+//!
+//! A red `main` is surfaced by **loud logging** (daemon log): the offending
+//! command, its exit reason, and a tail of its captured output. Auto-revert of
+//! the offending PR (via `merge-pr.sh` / the Auditor cron) is an explicit
+//! non-goal for this issue — halting + surfacing is the hard requirement.
+//! No new event-bus topic is introduced (the six-topic taxonomy is frozen and
+//! has no home for a non-sweep-triggered health event — a follow-up issue would
+//! be required to add one).
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/// Environment variable enabling the main-health gate loop.
+///
+/// The gate is **opt-in** — unset or a false-y value keeps it OFF so the
+/// daemon's behavior is unchanged when the variable is absent. Set to `1` /
+/// `true` / `yes` / `on` (case-insensitive) to enable.
+pub const MAIN_HEALTH_GATE_ENABLE_ENV: &str = "LOOM_MAIN_HEALTH_GATE";
+
+/// Environment variable overriding the gate cadence (seconds).
+pub const MAIN_HEALTH_GATE_INTERVAL_ENV: &str = "LOOM_MAIN_HEALTH_GATE_INTERVAL_SECS";
+
+/// Default gate cadence. Tighter than the work-finder's 60s default — a red
+/// `main` should be caught (and dispatch halted) promptly — while still keeping
+/// build volume low.
+pub const DEFAULT_MAIN_HEALTH_GATE_INTERVAL_SECS: u64 = 30;
+
+/// Default `buildGate.timeoutSeconds` when the config omits it (matches the
+/// #3749 schema example).
+pub const DEFAULT_BUILD_GATE_TIMEOUT_SECS: u64 = 600;
+
+/// Poll granularity while waiting for the gate command to finish.
+const GATE_POLL_INTERVAL: Duration = Duration::from_millis(200);
+
+/// Max bytes of captured gate-command output retained for the red-detail log
+/// line (the *tail* is kept — the failing assertion is usually last).
+const MAX_OUTPUT_TAIL_BYTES: usize = 4096;
+
+// ============================================================================
+// Shared halt state
+// ============================================================================
+
+/// Cheaply-checked halt flag shared between the gate loop (writer) and the
+/// [`crate::work_finder`] loop (reader).
+///
+/// Modeled on [`crate::health_monitor::TmuxHealthState`]'s `Arc<Atomic*>`
+/// idiom: safe under concurrent access from the gate-check thread and the
+/// work-finder tick with no mutex. `halted == true` means "a `buildGate` run
+/// against `main` most recently failed — do not dispatch new work."
+pub struct MainHealthState {
+    /// Whether autonomous dispatch is currently halted due to a red `main`.
+    halted: AtomicBool,
+}
+
+impl MainHealthState {
+    /// A fresh state — **not** halted (dispatch allowed) until a gate run proves
+    /// otherwise. This default means a daemon with the gate *disabled* never
+    /// halts (nothing ever flips the flag), so work-finder behavior is
+    /// unchanged when the gate is off.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            halted: AtomicBool::new(false),
+        }
+    }
+
+    /// Whether autonomous dispatch is currently halted.
+    #[must_use]
+    pub fn is_halted(&self) -> bool {
+        self.halted.load(Ordering::SeqCst)
+    }
+
+    /// Set the halt flag directly (primarily for tests / explicit control).
+    pub fn set_halted(&self, halted: bool) {
+        self.halted.store(halted, Ordering::SeqCst);
+    }
+}
+
+impl Default for MainHealthState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ============================================================================
+// Config
+// ============================================================================
+
+/// The subset of the `.loom/config.json` `buildGate` block this module consumes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BuildGateConfig {
+    /// The command to run against `main` (executed via `sh -c`).
+    pub command: String,
+    /// Timeout for a single gate run.
+    pub timeout: Duration,
+}
+
+/// Read `.loom/config.json` → `buildGate`, soft-failing to `None` (gate
+/// disabled) on any of: missing file, malformed JSON, missing `buildGate` block,
+/// `buildGate.enabled` not `true`, or a missing/empty `buildGate.command`.
+///
+/// Mirrors the soft-fail contract of
+/// [`crate::worktree_root`]'s `read_config_worktree_root` — a repo with no
+/// `buildGate` block (or `enabled: false`) gets zero behavior change.
+#[must_use]
+pub fn read_build_gate_config(repo_root: &Path) -> Option<BuildGateConfig> {
+    let config_path = repo_root.join(".loom").join("config.json");
+
+    let config_str = match std::fs::read_to_string(&config_path) {
+        Ok(s) => s,
+        Err(e) => {
+            log::debug!(
+                "main_health_gate: could not read config at {}: {e}",
+                config_path.display()
+            );
+            return None;
+        }
+    };
+
+    let config: serde_json::Value = match serde_json::from_str(&config_str) {
+        Ok(v) => v,
+        Err(e) => {
+            log::warn!(
+                "main_health_gate: could not parse config at {}: {e}",
+                config_path.display()
+            );
+            return None;
+        }
+    };
+
+    let gate = config.get("buildGate")?;
+
+    // `enabled` must be explicitly true — absent or false ⇒ disabled.
+    if !gate
+        .get("enabled")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+    {
+        log::debug!("main_health_gate: buildGate.enabled is not true — gate disabled");
+        return None;
+    }
+
+    let command = gate
+        .get("command")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("")
+        .trim();
+    if command.is_empty() {
+        log::warn!("main_health_gate: buildGate.enabled is true but buildGate.command is missing/empty — gate disabled");
+        return None;
+    }
+
+    let timeout_secs = gate
+        .get("timeoutSeconds")
+        .and_then(serde_json::Value::as_u64)
+        .filter(|&s| s > 0)
+        .unwrap_or(DEFAULT_BUILD_GATE_TIMEOUT_SECS);
+
+    Some(BuildGateConfig {
+        command: command.to_string(),
+        timeout: Duration::from_secs(timeout_secs),
+    })
+}
+
+// ============================================================================
+// Gate outcome + runner
+// ============================================================================
+
+/// The result of one gate run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GateOutcome {
+    /// `buildGate.command` exited 0 — `main` is healthy.
+    Green,
+    /// `buildGate.command` failed (non-zero exit, timeout, or spawn error).
+    /// `detail` is a human-readable reason + a tail of captured output.
+    Red { detail: String },
+}
+
+impl GateOutcome {
+    /// Convenience constructor for a red outcome.
+    #[must_use]
+    pub fn red(detail: impl Into<String>) -> Self {
+        Self::Red {
+            detail: detail.into(),
+        }
+    }
+
+    /// True when the run was green.
+    #[must_use]
+    pub fn is_green(&self) -> bool {
+        matches!(self, Self::Green)
+    }
+
+    /// The red-detail string, or empty for a green outcome.
+    #[must_use]
+    pub fn detail(&self) -> &str {
+        match self {
+            Self::Green => "",
+            Self::Red { detail } => detail,
+        }
+    }
+}
+
+/// Runs the configured `buildGate` command once and classifies the result.
+///
+/// Abstracted behind a trait so [`spawn_main_health_gate_task`] is testable with
+/// a scripted fake runner, exactly as [`crate::work_finder::WorkSource`] /
+/// [`crate::work_finder::WorkDispatcher`] make `tick` testable.
+pub trait GateRunner {
+    /// Run the gate once and return its classified outcome. Never errors — a
+    /// spawn failure or timeout is itself a [`GateOutcome::Red`].
+    fn run_gate(&mut self) -> GateOutcome;
+}
+
+/// The concrete [`GateRunner`]: shells out to `buildGate.command` (via `sh -c`)
+/// against `main`, honoring `buildGate.timeoutSeconds`.
+///
+/// The command runs in `repo_root` — the daemon's workspace, which is a `main`
+/// checkout. This module is the reactive backstop for autonomous dispatch, so
+/// it verifies `main` as the daemon sees it; it deliberately does not provision
+/// a throwaway worktree (extra complexity for no safety gain in the daemon's own
+/// checkout).
+pub struct CommandGateRunner {
+    config: BuildGateConfig,
+    repo_root: PathBuf,
+}
+
+impl CommandGateRunner {
+    /// Construct a runner for `config`, executing in `repo_root`.
+    #[must_use]
+    pub fn new(config: BuildGateConfig, repo_root: PathBuf) -> Self {
+        Self { config, repo_root }
+    }
+}
+
+impl GateRunner for CommandGateRunner {
+    fn run_gate(&mut self) -> GateOutcome {
+        run_command_with_timeout(&self.config.command, &self.repo_root, self.config.timeout)
+    }
+}
+
+/// Run `command` (via `sh -c`) in `cwd`, killing it if it exceeds `timeout`.
+///
+/// Child stdout+stderr are redirected to a single temp file (not a pipe) so a
+/// chatty build can never dead-lock us on a full pipe buffer while we poll for
+/// completion. The tail of that file is folded into the red-detail string.
+fn run_command_with_timeout(command: &str, cwd: &Path, timeout: Duration) -> GateOutcome {
+    use std::fs::File;
+
+    let log_path =
+        std::env::temp_dir().join(format!("loom-main-health-gate-{}.log", uuid::Uuid::new_v4()));
+    let out_file = match File::create(&log_path) {
+        Ok(f) => f,
+        Err(e) => {
+            return GateOutcome::red(format!(
+                "failed to create gate output file {}: {e}",
+                log_path.display()
+            ));
+        }
+    };
+    let err_file = match out_file.try_clone() {
+        Ok(f) => f,
+        Err(e) => {
+            let _ = std::fs::remove_file(&log_path);
+            return GateOutcome::red(format!("failed to clone gate output file handle: {e}"));
+        }
+    };
+
+    let mut child = match Command::new("sh")
+        .arg("-c")
+        .arg(command)
+        .current_dir(cwd)
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(out_file))
+        .stderr(Stdio::from(err_file))
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            let _ = std::fs::remove_file(&log_path);
+            return GateOutcome::red(format!("failed to spawn gate command '{command}': {e}"));
+        }
+    };
+
+    let start = Instant::now();
+    let outcome = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                if status.success() {
+                    break GateOutcome::Green;
+                }
+                let tail = read_output_tail(&log_path);
+                break GateOutcome::red(format!(
+                    "gate command '{command}' exited with {status}{}",
+                    format_tail(&tail)
+                ));
+            }
+            Ok(None) => {
+                if start.elapsed() >= timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    let tail = read_output_tail(&log_path);
+                    break GateOutcome::red(format!(
+                        "gate command '{command}' timed out after {}s{}",
+                        timeout.as_secs(),
+                        format_tail(&tail)
+                    ));
+                }
+                std::thread::sleep(GATE_POLL_INTERVAL);
+            }
+            Err(e) => {
+                break GateOutcome::red(format!("failed to poll gate command '{command}': {e}"));
+            }
+        }
+    };
+
+    let _ = std::fs::remove_file(&log_path);
+    outcome
+}
+
+/// Read the last [`MAX_OUTPUT_TAIL_BYTES`] of the gate's captured output.
+fn read_output_tail(log_path: &Path) -> String {
+    let bytes = std::fs::read(log_path).unwrap_or_default();
+    let start = bytes.len().saturating_sub(MAX_OUTPUT_TAIL_BYTES);
+    String::from_utf8_lossy(&bytes[start..]).into_owned()
+}
+
+/// Format a captured-output tail for inclusion in a red-detail log line.
+fn format_tail(tail: &str) -> String {
+    let trimmed = tail.trim();
+    if trimmed.is_empty() {
+        String::new()
+    } else {
+        format!("; last output:\n{trimmed}")
+    }
+}
+
+// ============================================================================
+// Halt-state transitions
+// ============================================================================
+
+/// The health-state change a single gate outcome produced — returned so the
+/// loop (and tests) can log/assert on transitions rather than steady state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HealthTransition {
+    /// Green → Red: dispatch was allowed, now halted.
+    EnteredHalt,
+    /// Red → Red: still halted (no change).
+    RemainedHalted,
+    /// Red → Green: was halted, dispatch now resumes.
+    Recovered,
+    /// Green → Green: healthy, no change.
+    RemainedHealthy,
+}
+
+/// Apply a gate `outcome` to the shared `state`, returning the transition.
+///
+/// Atomic `swap` makes the read-modify-write safe against a concurrent
+/// work-finder read (which only ever *loads*). This is the single point that
+/// mutates the halt flag.
+#[must_use]
+pub fn apply_gate_outcome(state: &MainHealthState, outcome: &GateOutcome) -> HealthTransition {
+    match outcome {
+        GateOutcome::Green => {
+            let was_halted = state.halted.swap(false, Ordering::SeqCst);
+            if was_halted {
+                HealthTransition::Recovered
+            } else {
+                HealthTransition::RemainedHealthy
+            }
+        }
+        GateOutcome::Red { .. } => {
+            let was_halted = state.halted.swap(true, Ordering::SeqCst);
+            if was_halted {
+                HealthTransition::RemainedHalted
+            } else {
+                HealthTransition::EnteredHalt
+            }
+        }
+    }
+}
+
+/// Log a health transition at a severity matching its significance.
+fn log_transition(transition: HealthTransition, outcome: &GateOutcome) {
+    match transition {
+        HealthTransition::EnteredHalt => log::error!(
+            "main_health_gate: main is RED — HALTING autonomous dispatch. {}",
+            outcome.detail()
+        ),
+        HealthTransition::RemainedHalted => log::warn!(
+            "main_health_gate: main still RED — dispatch remains halted. {}",
+            outcome.detail()
+        ),
+        HealthTransition::Recovered => log::info!(
+            "main_health_gate: main GREEN again — RESUMING autonomous dispatch on the next work-finder tick"
+        ),
+        HealthTransition::RemainedHealthy => {
+            log::debug!("main_health_gate: main green — dispatch unaffected");
+        }
+    }
+}
+
+// ============================================================================
+// Env-var configuration helpers
+// ============================================================================
+
+/// Whether the main-health gate loop is enabled, per
+/// [`MAIN_HEALTH_GATE_ENABLE_ENV`]. Off by default (opt-in); parsing mirrors
+/// [`crate::work_finder::enabled`].
+#[must_use]
+pub fn enabled() -> bool {
+    std::env::var(MAIN_HEALTH_GATE_ENABLE_ENV).is_ok_and(|v| {
+        matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on")
+    })
+}
+
+/// Resolve the gate cadence from [`MAIN_HEALTH_GATE_INTERVAL_ENV`], falling back
+/// to [`DEFAULT_MAIN_HEALTH_GATE_INTERVAL_SECS`]. A zero or unparseable value
+/// falls back to the default.
+#[must_use]
+pub fn resolve_interval() -> Duration {
+    std::env::var(MAIN_HEALTH_GATE_INTERVAL_ENV)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|&s| s > 0)
+        .map_or_else(
+            || Duration::from_secs(DEFAULT_MAIN_HEALTH_GATE_INTERVAL_SECS),
+            Duration::from_secs,
+        )
+}
+
+// ============================================================================
+// Runtime wiring — the loop runs on the shared daemon runtime
+// ============================================================================
+
+/// Spawn the main-health gate loop on the shared daemon runtime and return its
+/// task handle so the daemon can keep it alive for the process lifetime.
+///
+/// Every `interval` the loop runs one gate command (on a blocking thread via
+/// `spawn_blocking`, since it may take minutes), applies the outcome to the
+/// shared `health_state`, and logs the transition. The work-finder loop reads
+/// `health_state` each of its own ticks and dispatches nothing while halted.
+///
+/// A plain `tokio::spawn` is correct here (unlike the epic supervisor's
+/// dedicated OS thread) because the blocking command runs inside `spawn_blocking`
+/// — the interval task itself never parks a runtime worker.
+pub fn spawn_main_health_gate_task<R>(
+    mut runner: R,
+    health_state: Arc<MainHealthState>,
+    interval: Duration,
+) -> tokio::task::JoinHandle<()>
+where
+    R: GateRunner + Send + 'static,
+{
+    log::info!("main_health_gate: starting loop (interval={}s)", interval.as_secs());
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        // First tick fires immediately; skip it so we don't churn at boot.
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            // Run the (potentially minutes-long) gate command off the runtime.
+            // Move the runner in and back out so it survives across ticks.
+            let joined = tokio::task::spawn_blocking(move || {
+                let outcome = runner.run_gate();
+                (outcome, runner)
+            })
+            .await;
+            let outcome = match joined {
+                Ok((outcome, r)) => {
+                    runner = r;
+                    outcome
+                }
+                Err(e) => {
+                    // The blocking task panicked; we can't recover the runner.
+                    // Clear the halt flag so a panic here never wedges dispatch
+                    // in a permanently-halted state, then stop the loop.
+                    log::error!("main_health_gate: gate run task panicked ({e}); clearing halt and stopping loop");
+                    health_state.set_halted(false);
+                    return;
+                }
+            };
+            let transition = apply_gate_outcome(&health_state, &outcome);
+            log_transition(transition, &outcome);
+        }
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::collections::VecDeque;
+
+    fn write_config(dir: &Path, body: &str) {
+        let loom_dir = dir.join(".loom");
+        std::fs::create_dir_all(&loom_dir).unwrap();
+        std::fs::write(loom_dir.join("config.json"), body).unwrap();
+    }
+
+    // ===================================================================
+    // Config soft-fail
+    // ===================================================================
+
+    #[test]
+    fn test_config_missing_file_is_disabled() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(read_build_gate_config(tmp.path()), None);
+    }
+
+    #[test]
+    fn test_config_malformed_json_is_disabled() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), "{not valid json");
+        assert_eq!(read_build_gate_config(tmp.path()), None);
+    }
+
+    #[test]
+    fn test_config_missing_build_gate_key_is_disabled() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), r#"{"terminals": []}"#);
+        assert_eq!(read_build_gate_config(tmp.path()), None);
+    }
+
+    #[test]
+    fn test_config_enabled_false_is_disabled() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), r#"{"buildGate": {"enabled": false, "command": "true"}}"#);
+        assert_eq!(read_build_gate_config(tmp.path()), None);
+    }
+
+    #[test]
+    fn test_config_enabled_missing_command_is_disabled() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), r#"{"buildGate": {"enabled": true}}"#);
+        assert_eq!(read_build_gate_config(tmp.path()), None);
+    }
+
+    #[test]
+    fn test_config_enabled_empty_command_is_disabled() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), r#"{"buildGate": {"enabled": true, "command": "   "}}"#);
+        assert_eq!(read_build_gate_config(tmp.path()), None);
+    }
+
+    #[test]
+    fn test_config_valid_uses_default_timeout() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(
+            tmp.path(),
+            r#"{"buildGate": {"enabled": true, "command": "bash .loom/scripts/build-gate.sh"}}"#,
+        );
+        let cfg = read_build_gate_config(tmp.path()).unwrap();
+        assert_eq!(cfg.command, "bash .loom/scripts/build-gate.sh");
+        assert_eq!(cfg.timeout, Duration::from_secs(DEFAULT_BUILD_GATE_TIMEOUT_SECS));
+    }
+
+    #[test]
+    fn test_config_valid_honors_timeout_seconds() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(
+            tmp.path(),
+            r#"{"buildGate": {"enabled": true, "command": "true", "timeoutSeconds": 42}}"#,
+        );
+        let cfg = read_build_gate_config(tmp.path()).unwrap();
+        assert_eq!(cfg.timeout, Duration::from_secs(42));
+    }
+
+    #[test]
+    fn test_config_zero_timeout_seconds_falls_back_to_default() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(
+            tmp.path(),
+            r#"{"buildGate": {"enabled": true, "command": "true", "timeoutSeconds": 0}}"#,
+        );
+        let cfg = read_build_gate_config(tmp.path()).unwrap();
+        assert_eq!(cfg.timeout, Duration::from_secs(DEFAULT_BUILD_GATE_TIMEOUT_SECS));
+    }
+
+    // ===================================================================
+    // Halt-state transitions (the reactive core)
+    // ===================================================================
+
+    #[test]
+    fn test_default_state_not_halted() {
+        assert!(!MainHealthState::new().is_halted());
+        assert!(!MainHealthState::default().is_halted());
+    }
+
+    #[test]
+    fn test_green_then_red_enters_halt() {
+        let state = MainHealthState::new();
+        assert_eq!(
+            apply_gate_outcome(&state, &GateOutcome::Green),
+            HealthTransition::RemainedHealthy
+        );
+        assert!(!state.is_halted());
+
+        assert_eq!(
+            apply_gate_outcome(&state, &GateOutcome::red("boom")),
+            HealthTransition::EnteredHalt
+        );
+        assert!(state.is_halted(), "a red run must halt dispatch");
+    }
+
+    #[test]
+    fn test_red_then_red_remains_halted() {
+        let state = MainHealthState::new();
+        assert_eq!(
+            apply_gate_outcome(&state, &GateOutcome::red("boom")),
+            HealthTransition::EnteredHalt
+        );
+        assert_eq!(
+            apply_gate_outcome(&state, &GateOutcome::red("still broken")),
+            HealthTransition::RemainedHalted
+        );
+        assert!(state.is_halted());
+    }
+
+    #[test]
+    fn test_red_then_green_recovers() {
+        let state = MainHealthState::new();
+        let _ = apply_gate_outcome(&state, &GateOutcome::red("boom"));
+        assert!(state.is_halted());
+
+        assert_eq!(apply_gate_outcome(&state, &GateOutcome::Green), HealthTransition::Recovered);
+        assert!(!state.is_halted(), "a green run must clear the halt");
+    }
+
+    #[test]
+    fn test_full_red_then_green_sequence_via_fake_runner() {
+        // A scripted runner: red, red, green — asserting the halt flag tracks
+        // the sequence exactly (halt on first red, stay halted, clear on green).
+        struct FakeGateRunner {
+            outcomes: VecDeque<GateOutcome>,
+        }
+        impl GateRunner for FakeGateRunner {
+            fn run_gate(&mut self) -> GateOutcome {
+                self.outcomes.pop_front().unwrap_or(GateOutcome::Green)
+            }
+        }
+
+        let mut runner = FakeGateRunner {
+            outcomes: VecDeque::from([
+                GateOutcome::red("first failure"),
+                GateOutcome::red("second failure"),
+                GateOutcome::Green,
+            ]),
+        };
+        let state = MainHealthState::new();
+
+        // Tick 1: red ⇒ halted.
+        let t1 = apply_gate_outcome(&state, &runner.run_gate());
+        assert_eq!(t1, HealthTransition::EnteredHalt);
+        assert!(state.is_halted());
+
+        // Tick 2: red ⇒ still halted.
+        let t2 = apply_gate_outcome(&state, &runner.run_gate());
+        assert_eq!(t2, HealthTransition::RemainedHalted);
+        assert!(state.is_halted());
+
+        // Tick 3: green ⇒ recovered, dispatch resumes.
+        let t3 = apply_gate_outcome(&state, &runner.run_gate());
+        assert_eq!(t3, HealthTransition::Recovered);
+        assert!(!state.is_halted());
+    }
+
+    // ===================================================================
+    // Command runner (real subprocess — green + red + timeout)
+    // ===================================================================
+
+    #[test]
+    fn test_command_runner_green_on_zero_exit() {
+        let cfg = BuildGateConfig {
+            command: "exit 0".to_string(),
+            timeout: Duration::from_secs(30),
+        };
+        let mut runner = CommandGateRunner::new(cfg, std::env::temp_dir());
+        assert_eq!(runner.run_gate(), GateOutcome::Green);
+    }
+
+    #[test]
+    fn test_command_runner_red_on_nonzero_exit_captures_output() {
+        let cfg = BuildGateConfig {
+            command: "echo build-failed-marker >&2; exit 1".to_string(),
+            timeout: Duration::from_secs(30),
+        };
+        let mut runner = CommandGateRunner::new(cfg, std::env::temp_dir());
+        let outcome = runner.run_gate();
+        assert!(!outcome.is_green());
+        assert!(
+            outcome.detail().contains("build-failed-marker"),
+            "red detail should include captured output, got: {}",
+            outcome.detail()
+        );
+    }
+
+    #[test]
+    fn test_command_runner_red_on_timeout() {
+        let cfg = BuildGateConfig {
+            command: "sleep 10".to_string(),
+            timeout: Duration::from_secs(1),
+        };
+        let mut runner = CommandGateRunner::new(cfg, std::env::temp_dir());
+        let outcome = runner.run_gate();
+        assert!(!outcome.is_green());
+        assert!(
+            outcome.detail().contains("timed out"),
+            "timeout detail expected, got: {}",
+            outcome.detail()
+        );
+    }
+
+    // ===================================================================
+    // Env-var configuration
+    // ===================================================================
+
+    #[test]
+    #[serial]
+    fn test_enabled_off_by_default() {
+        std::env::remove_var(MAIN_HEALTH_GATE_ENABLE_ENV);
+        assert!(!enabled(), "unset ⇒ disabled (zero behavior change)");
+    }
+
+    #[test]
+    #[serial]
+    fn test_enabled_truthy_and_falsy() {
+        for v in ["1", "true", "yes", "on", "TRUE", "On", " Yes "] {
+            std::env::set_var(MAIN_HEALTH_GATE_ENABLE_ENV, v);
+            assert!(enabled(), "{v:?} should enable");
+        }
+        for v in ["0", "false", "no", "off", "", "maybe"] {
+            std::env::set_var(MAIN_HEALTH_GATE_ENABLE_ENV, v);
+            assert!(!enabled(), "{v:?} should not enable");
+        }
+        std::env::remove_var(MAIN_HEALTH_GATE_ENABLE_ENV);
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_interval_default_and_override() {
+        std::env::remove_var(MAIN_HEALTH_GATE_INTERVAL_ENV);
+        assert_eq!(resolve_interval(), Duration::from_secs(DEFAULT_MAIN_HEALTH_GATE_INTERVAL_SECS));
+
+        std::env::set_var(MAIN_HEALTH_GATE_INTERVAL_ENV, "15");
+        assert_eq!(resolve_interval(), Duration::from_secs(15));
+
+        // Zero and unparseable fall back to the default.
+        std::env::set_var(MAIN_HEALTH_GATE_INTERVAL_ENV, "0");
+        assert_eq!(resolve_interval(), Duration::from_secs(DEFAULT_MAIN_HEALTH_GATE_INTERVAL_SECS));
+        std::env::set_var(MAIN_HEALTH_GATE_INTERVAL_ENV, "garbage");
+        assert_eq!(resolve_interval(), Duration::from_secs(DEFAULT_MAIN_HEALTH_GATE_INTERVAL_SECS));
+        std::env::remove_var(MAIN_HEALTH_GATE_INTERVAL_ENV);
+    }
+}

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -74,11 +74,13 @@
 
 use std::collections::HashSet;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
 
 use crate::disk_headroom::disk_headroom_limit;
+use crate::main_health_gate::MainHealthState;
 use crate::tokens::token_pool_size;
 
 // ============================================================================
@@ -221,6 +223,10 @@ pub struct TickReport {
     pub deferred_capacity: usize,
     /// Dispatch attempts that returned an error (logged, non-fatal).
     pub errors: usize,
+    /// True when this tick dispatched nothing because the main-health gate
+    /// (Phase C, #3812) had halted dispatch (`main` was red). `seen` still
+    /// reflects the backlog depth; `dispatched` is always 0 in this case.
+    pub halted: bool,
 }
 
 /// Run one work-finder tick: fetch ready issues, filter, and dispatch up to the
@@ -231,6 +237,14 @@ pub struct TickReport {
 /// `occupancy < max_concurrent`, incrementing occupancy per new dispatch so a
 /// single tick never overshoots the cap.
 ///
+/// # Reactive main-health halt (Phase C, #3812)
+///
+/// When `halted` is `true` the main-health gate has observed a red `main`, so
+/// this tick dispatches **zero** new issues (existing in-flight sweeps are never
+/// touched) and returns early with [`TickReport::halted`] set. `seen` still
+/// reflects the backlog so the loop can log "backlog is N but halted." The
+/// caller resumes normally once a green gate run clears the flag.
+///
 /// # Errors
 ///
 /// Propagates a source (`list_ready_issues`) error so the caller can log it and
@@ -240,12 +254,19 @@ pub fn tick(
     source: &mut impl WorkSource,
     dispatcher: &mut impl WorkDispatcher,
     max_concurrent: usize,
+    halted: bool,
 ) -> Result<TickReport> {
     let ready = source.list_ready_issues()?;
     let mut report = TickReport {
         seen: ready.len(),
         ..TickReport::default()
     };
+
+    // Reactive backstop: a red `main` halts all new dispatch this tick.
+    if halted {
+        report.halted = true;
+        return Ok(report);
+    }
 
     let in_flight = dispatcher.in_flight();
     let mut occupancy = in_flight.len();
@@ -390,6 +411,7 @@ pub fn spawn_work_finder_task<S, D>(
     interval: Duration,
     workspace_root: PathBuf,
     configured_max: usize,
+    health_state: Arc<MainHealthState>,
 ) -> tokio::task::JoinHandle<()>
 where
     S: WorkSource + Send + 'static,
@@ -404,18 +426,34 @@ where
         let mut ticker = tokio::time::interval(interval);
         // First tick fires immediately; skip it so we don't churn at boot.
         ticker.tick().await;
+        // Track the halt state across ticks so we log the halt/resume edges
+        // once per halted period, not once per skipped tick.
+        let mut was_halted = false;
         loop {
             ticker.tick().await;
+            // Reactive main-health backstop (Phase C, #3812): skip all dispatch
+            // while the gate reports a red `main`.
+            let halted = health_state.is_halted();
             // Recompute the dynamic cap from live inputs every tick (Phase B).
             let pool_size = token_pool_size(&workspace_root);
             let disk = disk_headroom_limit(&workspace_root);
             let max_concurrent = resolve_dynamic_max_concurrent(pool_size, disk, configured_max);
             log::debug!(
                 "work_finder: dynamic cap = {max_concurrent} (pool={pool_size}, disk={disk}, \
-                 configured_max={configured_max})"
+                 configured_max={configured_max}, halted={halted})"
             );
-            match tick(&mut source, &mut dispatcher, max_concurrent) {
+            match tick(&mut source, &mut dispatcher, max_concurrent, halted) {
                 Ok(report) => {
+                    if report.halted && !was_halted {
+                        log::warn!(
+                            "work_finder: main-health gate halted dispatch — {} ready issue(s) \
+                             held until main is green again",
+                            report.seen
+                        );
+                    } else if !report.halted && was_halted {
+                        log::info!("work_finder: main-health gate cleared — resuming dispatch");
+                    }
+                    was_halted = report.halted;
                     if report.dispatched > 0 || report.errors > 0 {
                         log::info!(
                             "work_finder: tick — cap {max_concurrent} (pool={pool_size}, \
@@ -663,7 +701,7 @@ mod tests {
         // N=5 ready issues, cap K=2 → exactly 2 dispatched this tick, 3 deferred.
         let mut source = FakeSource::once((1..=5).map(issue).collect());
         let mut disp = RecordingDispatcher::default();
-        let report = tick(&mut source, &mut disp, 2).unwrap();
+        let report = tick(&mut source, &mut disp, 2, false).unwrap();
 
         assert_eq!(report.seen, 5);
         assert_eq!(report.dispatched, 2);
@@ -676,7 +714,7 @@ mod tests {
     fn test_tick_all_dispatched_when_under_cap() {
         let mut source = FakeSource::once((1..=3).map(issue).collect());
         let mut disp = RecordingDispatcher::default();
-        let report = tick(&mut source, &mut disp, 10).unwrap();
+        let report = tick(&mut source, &mut disp, 10, false).unwrap();
 
         assert_eq!(report.dispatched, 3);
         assert_eq!(report.deferred_capacity, 0);
@@ -691,7 +729,7 @@ mod tests {
             in_flight: HashSet::from([100, 101]),
             ..Default::default()
         };
-        let report = tick(&mut source, &mut disp, 3).unwrap();
+        let report = tick(&mut source, &mut disp, 3, false).unwrap();
 
         assert_eq!(report.dispatched, 1);
         assert_eq!(report.deferred_capacity, 3);
@@ -707,7 +745,7 @@ mod tests {
             in_flight: HashSet::from([7]),
             ..Default::default()
         };
-        let report = tick(&mut source, &mut disp, 10).unwrap();
+        let report = tick(&mut source, &mut disp, 10, false).unwrap();
 
         assert_eq!(report.skipped_in_flight, 1);
         assert_eq!(report.dispatched, 1);
@@ -724,7 +762,7 @@ mod tests {
             issue(4),
         ]);
         let mut disp = RecordingDispatcher::default();
-        let report = tick(&mut source, &mut disp, 10).unwrap();
+        let report = tick(&mut source, &mut disp, 10, false).unwrap();
 
         assert_eq!(report.skipped_labeled, 3);
         assert_eq!(report.dispatched, 1);
@@ -741,7 +779,7 @@ mod tests {
             ..Default::default()
         };
         // Cap of 2: #1 is a no-op (frees its slot), so #2 AND #3 still dispatch.
-        let report = tick(&mut source, &mut disp, 2).unwrap();
+        let report = tick(&mut source, &mut disp, 2, false).unwrap();
 
         assert_eq!(report.dispatched, 2, "only #2 and #3 are new dispatches");
         assert_eq!(report.skipped_in_flight, 1, "#1 was an idempotency no-op");
@@ -757,7 +795,7 @@ mod tests {
             fail_issues: HashSet::from([2]),
             ..Default::default()
         };
-        let report = tick(&mut source, &mut disp, 10).unwrap();
+        let report = tick(&mut source, &mut disp, 10, false).unwrap();
 
         assert_eq!(report.dispatched, 2);
         assert_eq!(report.errors, 1);
@@ -774,11 +812,11 @@ mod tests {
         let mut source = FakeSource { results };
         let mut disp = RecordingDispatcher::default();
 
-        let first = tick(&mut source, &mut disp, 10);
+        let first = tick(&mut source, &mut disp, 10, false);
         assert!(first.is_err(), "source error propagates out of the tick");
         assert_eq!(disp.dispatched.len(), 0, "no dispatch on the erroring tick");
 
-        let second = tick(&mut source, &mut disp, 10).unwrap();
+        let second = tick(&mut source, &mut disp, 10, false).unwrap();
         assert_eq!(second.dispatched, 2, "the next tick proceeds normally");
         assert_eq!(disp.dispatched, vec![1, 2]);
     }
@@ -787,9 +825,49 @@ mod tests {
     fn test_tick_empty_ready_is_noop() {
         let mut source = FakeSource::once(vec![]);
         let mut disp = RecordingDispatcher::default();
-        let report = tick(&mut source, &mut disp, 10).unwrap();
+        let report = tick(&mut source, &mut disp, 10, false).unwrap();
         assert_eq!(report, TickReport::default());
         assert!(disp.dispatched.is_empty());
+    }
+
+    // ===================================================================
+    // tick — reactive main-health halt (Phase C, #3812)
+    // ===================================================================
+
+    #[test]
+    fn test_tick_halted_dispatches_zero_with_backlog() {
+        // A red `main` (halted=true) dispatches nothing even with ample capacity
+        // and a full backlog; existing in-flight sweeps are untouched.
+        let mut source = FakeSource::once((1..=5).map(issue).collect());
+        let mut disp = RecordingDispatcher {
+            in_flight: HashSet::from([100, 101]),
+            ..Default::default()
+        };
+        let report = tick(&mut source, &mut disp, 10, true).unwrap();
+
+        assert!(report.halted, "report must flag the halt");
+        assert_eq!(report.seen, 5, "backlog is still observed");
+        assert_eq!(report.dispatched, 0, "zero dispatch while halted");
+        assert_eq!(report.deferred_capacity, 0);
+        assert!(disp.dispatched.is_empty(), "no sweeps started while halted");
+    }
+
+    #[test]
+    fn test_tick_resumes_dispatch_once_halt_cleared() {
+        // Same source shape: halted ⇒ zero, then not halted ⇒ dispatches.
+        let mut source = FakeSource::once((1..=3).map(issue).collect());
+        let mut disp = RecordingDispatcher::default();
+        let halted = tick(&mut source, &mut disp, 10, true).unwrap();
+        assert!(halted.halted);
+        assert_eq!(halted.dispatched, 0);
+        assert!(disp.dispatched.is_empty());
+
+        // Next tick with the halt cleared dispatches normally.
+        let mut source = FakeSource::once((1..=3).map(issue).collect());
+        let resumed = tick(&mut source, &mut disp, 10, false).unwrap();
+        assert!(!resumed.halted);
+        assert_eq!(resumed.dispatched, 3);
+        assert_eq!(disp.dispatched, vec![1, 2, 3]);
     }
 
     // ===================================================================
@@ -913,7 +991,7 @@ mod tests {
         assert_eq!(cap, 0);
         let mut source = FakeSource::once((1..=3).map(issue).collect());
         let mut disp = RecordingDispatcher::default();
-        let report = tick(&mut source, &mut disp, cap).unwrap();
+        let report = tick(&mut source, &mut disp, cap, false).unwrap();
         assert_eq!(report.dispatched, 0);
         assert_eq!(report.deferred_capacity, 3);
         assert!(disp.dispatched.is_empty());
@@ -934,14 +1012,14 @@ mod tests {
         // Backlog 2 (< cap): all 2 dispatch, nothing deferred.
         let mut source = FakeSource::once((1..=2).map(issue).collect());
         let mut disp = RecordingDispatcher::default();
-        let report = tick(&mut source, &mut disp, cap).unwrap();
+        let report = tick(&mut source, &mut disp, cap, false).unwrap();
         assert_eq!(report.dispatched, 2, "backlog 2 < cap 4 ⇒ 2 dispatched");
         assert_eq!(report.deferred_capacity, 0);
 
         // Backlog 6 (> cap): scales up to the cap (4), defers the surplus (2).
         let mut source = FakeSource::once((10..=15).map(issue).collect());
         let mut disp = RecordingDispatcher::default();
-        let report = tick(&mut source, &mut disp, cap).unwrap();
+        let report = tick(&mut source, &mut disp, cap, false).unwrap();
         assert_eq!(report.dispatched, 4, "backlog 6 > cap 4 ⇒ scaled up to cap");
         assert_eq!(report.deferred_capacity, 2);
     }
@@ -954,7 +1032,7 @@ mod tests {
         assert_eq!(cap, 5);
         let mut source = FakeSource::once(vec![]);
         let mut disp = RecordingDispatcher::default();
-        let report = tick(&mut source, &mut disp, cap).unwrap();
+        let report = tick(&mut source, &mut disp, cap, false).unwrap();
         assert_eq!(report, TickReport::default(), "empty backlog ⇒ zero activity");
         assert!(disp.dispatched.is_empty());
     }


### PR DESCRIPTION
Closes #3812

## Summary

Phase C of the autonomous-daemon epic (#3809): a **daemon-native, opt-in reactive safety net** for autonomous (non-`/loom:sweep`) dispatch. It implements the epic's git-based reactive-safety principle — git catches textual conflicts at merge time; this catches the recoverable semantic / cross-file breakage a clean merge can still introduce, **reactively**, after the fact. **No dispatch-time overlap detection** (explicit non-goal).

## What it does

On a configurable cadence the new `main_health_gate` loop runs the repo's configured `buildGate.command` against `main`. On a **red** run (non-zero exit or timeout) it sets a shared `Arc<AtomicBool>` halt flag; the work-finder consults that flag and dispatches **zero** new sweeps until a **green** run clears it. Existing in-flight sweeps are never killed — halting only stops making a red `main` worse.

## Changes

- **`loom-daemon/src/main_health_gate.rs` (new)**
  - `read_build_gate_config()` — soft-fail `.loom/config.json` → `buildGate` read (`enabled`/`command`/`timeoutSeconds`), mirroring `worktree_root::read_config_worktree_root`. Missing file / missing key / malformed JSON / `enabled: false` / empty command all resolve to **disabled** (matches #3749's opt-in contract).
  - `MainHealthState` — shared halt flag (`Arc<AtomicBool>`, `health_monitor::TmuxHealthState` idiom).
  - `GateRunner` trait + `CommandGateRunner` — runs `sh -c <command>` with `timeoutSeconds` enforcement. Output is captured to a temp file (not a pipe) so a chatty build can never deadlock on a full pipe buffer; the tail is folded into the red-detail log.
  - `apply_gate_outcome()` — atomic halt/resume transitions (`EnteredHalt`/`RemainedHalted`/`Recovered`/`RemainedHealthy`).
  - `spawn_main_health_gate_task()` — `tokio::spawn` cadence loop; the (minutes-long) command runs via `spawn_blocking` so it never parks a runtime worker. Env-gated by `LOOM_MAIN_HEALTH_GATE` (off by default), cadence via `LOOM_MAIN_HEALTH_GATE_INTERVAL_SECS` (default 30s).
- **`loom-daemon/src/work_finder.rs`** — `tick()` gains a `halted` arg (short-circuits to zero dispatch, still reports `seen`); new `TickReport.halted`; `spawn_work_finder_task()` takes the shared `MainHealthState`, checks it each tick, and logs halt/resume edges once per halted period.
- **`loom-daemon/src/main.rs`** — constructs the shared halt state (always, so the work-finder is threaded even when the gate is off ⇒ never halts), threads it into the work-finder, and spawns the gate loop opt-in.
- **`loom-daemon/src/lib.rs`** — registers `pub mod main_health_gate`.

## Scope decisions / non-goals

- **Surfacing** = loud daemon logging (offending command + exit reason + captured-output tail). **No new event-bus topic** — the six-topic taxonomy is frozen and has no home for a non-sweep-triggered health event.
- **Auto-revert** of the offending PR is a documented non-goal for this issue (halt + surface is the hard requirement).
- **Gate command runs in the daemon's workspace** (`sweep_workspace`, a `main` checkout) rather than provisioning a throwaway worktree — it verifies `main` as the daemon sees it; simpler with no safety loss for the backstop.
- Does **not** touch the `/loom:sweep` skill's in-session `buildGate` checks (`sweep.md`, `builder.md`) — those remain markdown-driven.

## Zero behavior change when off

With `buildGate` unconfigured or `LOOM_MAIN_HEALTH_GATE` unset, the gate loop is never spawned, nothing flips the halt flag, and the work-finder behaves exactly as before.

## Tests

- `cargo test --workspace`: **all pass** (loom-daemon lib 568 passed, incl. 20 new `main_health_gate` tests + 2 new `work_finder` halt tests; all other suites green).
- New `main_health_gate` tests: config soft-fail (missing/malformed/disabled/empty-command/timeout defaults), halt/resume transitions, a scripted `FakeGateRunner` red→red→green sequence, and real-subprocess green / non-zero-red (output captured) / timeout-red.
- New `work_finder` tests: `tick()` dispatches zero while halted (with backlog + in-flight sweeps untouched) and resumes once cleared.
- `cargo clippy` (exact CI invocation) clean; `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)