### PR TITLE
test(daemon): section-local anchor for degrade prose in sweep doc-lint (#3879)

### DIFF
--- a/loom-daemon/tests/sweep_md_doc_lint.rs
+++ b/loom-daemon/tests/sweep_md_doc_lint.rs
@@ -187,15 +187,18 @@ fn sweep_md_documents_effort_rung_grammar_and_fable() {
     }
 
     // PROSE (structural): the Task-tool graceful-degradation half (#3705) must
-    // stay documented, but its wording ("grammar ships either way", "degrades
-    // cleanly to bare sonnet") legitimately gets edited. Anchor on the stable
-    // verb stem `degrade` (matches degrade/degrades/degraded/degradation) so a
-    // reword survives while deleting the whole fallback discussion still fails.
+    // stay documented. Anchor on the section-local fragment `degrades cleanly to
+    // bare` (#3879) rather than a bare `degrade` stem: `degrade` also appears in
+    // unrelated `merge-pr.sh --auto` prose, so a bare-stem anchor would still
+    // pass on incidental matches even if the effort-degradation paragraph were
+    // deleted (violating #3877 AC3). This fragment is unique to that paragraph
+    // while staying prose-tolerant (the surrounding sentence can still be
+    // reworded).
     assert!(
-        content.contains("degrade"),
+        content.contains("degrades cleanly to bare"),
         "sweep.md must document the Task-tool effort graceful-degradation \
-         fallback (#3705) — anchored structurally on the `degrade` stem, not on \
-         an exact sentence"
+         fallback (#3705) — anchored on the section-local fragment `degrades \
+         cleanly to bare`, unique to that paragraph (#3879)"
     );
 }
 


### PR DESCRIPTION
Closes #3879

## Summary

Tightens the graceful-degradation prose anchor in `sweep_md_documents_effort_rung_grammar_and_fable` (`loom-daemon/tests/sweep_md_doc_lint.rs`), a follow-up to #3877.

The assertion anchored on a bare `content.contains("degrade")`. But `degrade` also appears in unrelated `merge-pr.sh --auto` prose in `defaults/.claude/commands/loom/sweep.md` (~lines 1174/1567, "degrades `--auto` gracefully"). If the effort-degradation paragraph (~line 479) were deleted, this assertion would still pass on those incidental matches — a gap against #3877 AC3 ("tests still fail if a section is deleted").

## Change

Anchor on the section-local fragment `degrades cleanly to bare` instead:
- **Unique** to the effort-degradation paragraph (verified: 1 occurrence in `sweep.md`, absent from the ~line-1174/1567 `--auto` prose), so the assertion now fails if that paragraph is removed.
- **Prose-tolerant** — the surrounding sentence can still be reworded without breaking the test, consistent with the de-brittling philosophy of #3877/#3878 (section-local anchors, exact needles only for real contract strings).

## Verification

```
cd loom-daemon && cargo test --test sweep_md_doc_lint
```
Result: `11 passed; 0 failed`.