### PR TITLE
fix(prompts): use absolute migration-doc URL in deprecated daemon stubs

### DIFF
--- a/defaults/.claude/commands/loom/loom-iteration.md
+++ b/defaults/.claude/commands/loom/loom-iteration.md
@@ -23,4 +23,4 @@ Rust `loom-daemon` binary's MCP surface (`mcp__loom__dispatch_sweep`,
 `mcp__loom__list_sweeps`, `mcp__loom__subscribe_to_events`,
 `mcp__loom__cancel_sweep`, …). The historical Python daemon brain
 (`loom-tools/src/loom_tools/daemon_v2/`) was deleted in Phase 3 (#3378). See
-[`docs/migration/v0.10.0-shepherd-deprecation.md`](../../../docs/migration/v0.10.0-shepherd-deprecation.md).
+[`docs/migration/v0.10.0-shepherd-deprecation.md`](https://github.com/rjwalters/loom/blob/main/docs/migration/v0.10.0-shepherd-deprecation.md).

--- a/defaults/.claude/commands/loom/loom-parent.md
+++ b/defaults/.claude/commands/loom/loom-parent.md
@@ -20,4 +20,4 @@ The two-tier LLM architecture (parent/iteration) has been replaced by the Rust
 
 The historical Python daemon brain (`loom-tools/src/loom_tools/daemon_v2/`) was
 deleted in Phase 3 (#3378). See
-[`docs/migration/v0.10.0-shepherd-deprecation.md`](../../../docs/migration/v0.10.0-shepherd-deprecation.md).
+[`docs/migration/v0.10.0-shepherd-deprecation.md`](https://github.com/rjwalters/loom/blob/main/docs/migration/v0.10.0-shepherd-deprecation.md).


### PR DESCRIPTION
Closes #3886

## Problem

PR #3884 added a migration-doc link to two deprecated daemon stubs, but the relative depth was off by one level, producing a broken link. Both files used:

    [`docs/migration/v0.10.0-shepherd-deprecation.md`](../../../docs/migration/v0.10.0-shepherd-deprecation.md)

The files live at `defaults/.claude/commands/loom/`. Three `../` resolves to `defaults/`, so the link pointed at `defaults/docs/migration/...` which does not exist. The repo-root `docs/migration/` would need four levels.

## Fix

Replaced the broken relative link in both files with the absolute GitHub URL, matching the pattern the same PR already uses in `defaults/.claude/README.md` for this exact doc:

    [`docs/migration/v0.10.0-shepherd-deprecation.md`](https://github.com/rjwalters/loom/blob/main/docs/migration/v0.10.0-shepherd-deprecation.md)

## Rationale

These stubs are installed into downstream target repos where `docs/migration/...` is not present at ANY relative depth, so no relative link works downstream — the absolute URL does.

## Files changed

- `defaults/.claude/commands/loom/loom-parent.md`
- `defaults/.claude/commands/loom/loom-iteration.md`

The installed `.claude/commands/loom/` copies are beyond a symlink and not git-tracked, so no separate fix is needed there; they resync from `defaults/`. `defaults/roles/README.md`'s `../../docs/...` link is correct for its location and was left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)