### PR TITLE
feat(daemon): autonomous operability — config surface + safe start/stop + E2E playbook (#3813 Phase D)

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -528,7 +528,8 @@ never crashing the daemon. Dispatches surface on the frozen
 `sweep.global.dispatch` topic (emitted inside `dispatch()`); the finder adds no
 new event topics.
 
-Enable it with `LOOM_WORK_FINDER=1` (unset/false-y = OFF). Tunables:
+Enable it with `LOOM_WORK_FINDER=1` (unset/false-y = OFF) **or** from committed
+config (`autonomous.workFinder.enabled`, see "Operability" below). Tunables:
 `LOOM_WORK_FINDER_INTERVAL_SECS` (default 60 — tighter than the epic
 supervisor's 300s so the `loom:issue` backlog drains promptly),
 `LOOM_WORK_FINDER_MAX_CONCURRENT` (default 3 — the operator **ceiling** in the
@@ -541,6 +542,109 @@ unparseable value for any of these falls back to its default.
 > cadence remains out of scope (follow-up #3381). So "the daemon does not
 > generate work" below still holds — the finder only closes the gap between an
 > approved issue and its build.
+
+## Operability — config, start/stop, E2E (Phase D, #3813)
+
+Phases A–C built the autonomous *engine* (work finder, dynamic concurrency,
+main-health gate) as env-var-only surfaces. Phase D (#3813) adds the
+operator-facing layer: a committed config surface, safe start/stop wrappers for
+the raw daemon process, and a documented end-to-end acceptance playbook.
+
+### Config surface (`.loom/config.json → autonomous`)
+
+Autonomous mode can be enabled and tuned entirely from committed config — no env
+vars required — so a repo can declare "this workspace runs autonomous mode with
+concurrency ceiling 5" and share it with the team:
+
+```json
+{
+  "autonomous": {
+    "workFinder": {
+      "enabled": true,
+      "intervalSecs": 60,
+      "maxConcurrent": 5
+    },
+    "mainHealthGate": {
+      "enabled": true
+    }
+  }
+}
+```
+
+**Precedence is `env var > config value > built-in default` for every knob.** An
+operator env var still overrides the committed config for a single run
+(`LOOM_WORK_FINDER=0 loom-daemon` disables the loop even if config enables it).
+An **absent `autonomous` block is byte-for-byte identical to the pre-#3813
+env-only behavior** — the config read soft-fails (missing file / malformed JSON /
+missing block all resolve to "no config value → fall through to env/default"),
+exactly like `main_health_gate::read_build_gate_config`.
+
+| Config key | Env override | Default | Notes |
+|------------|--------------|---------|-------|
+| `autonomous.workFinder.enabled` | `LOOM_WORK_FINDER` | `false` | Master on/off for the finder loop |
+| `autonomous.workFinder.intervalSecs` | `LOOM_WORK_FINDER_INTERVAL_SECS` | `60` | Zero/invalid → default |
+| `autonomous.workFinder.maxConcurrent` | `LOOM_WORK_FINDER_MAX_CONCURRENT` | `3` | Operator **ceiling**, not a fixed target |
+| `autonomous.mainHealthGate.enabled` | `LOOM_MAIN_HEALTH_GATE` | `false` | Gate loop on/off |
+
+The **gate's behavior** (which command runs against `main`, its timeout) still
+comes from the separate top-level `buildGate` block (#3749); `autonomous.mainHealthGate`
+is purely the on/off surface, so Phase C's already-tested `buildGate` semantics
+are untouched. `LOOM_MAIN_HEALTH_GATE` remains the master override; the config
+key just lets a repo turn the gate on without exporting an env var.
+
+### Safe start / stop (raw daemon process)
+
+`.loom/bin/loom start|stop` manage the **tmux Manual-Orchestration-Mode pool** —
+a different process model from the `loom-daemon` binary that hosts the
+work-finder / health-gate loops. Two dedicated wrappers manage the raw daemon
+process:
+
+```bash
+# Bring up autonomous mode (work finder + health gate) as a backgrounded process:
+./.loom/scripts/cli/loom-daemon-start.sh
+
+# Enable strictly per .loom/config.json → autonomous (no env forcing):
+./.loom/scripts/cli/loom-daemon-start.sh --from-config
+
+# Selective / foreground variants:
+./.loom/scripts/cli/loom-daemon-start.sh --no-work-finder   # gate only
+./.loom/scripts/cli/loom-daemon-start.sh --no-health-gate   # finder only
+./.loom/scripts/cli/loom-daemon-start.sh --foreground       # run attached, no PID file
+
+# Clean shutdown:
+./.loom/scripts/cli/loom-daemon-stop.sh            # SIGTERM → grace → SIGKILL
+./.loom/scripts/cli/loom-daemon-stop.sh --force    # immediate SIGKILL
+```
+
+`loom-daemon-start.sh`:
+- locates the `loom-daemon` binary (`LOOM_DAEMON_BIN` → `PATH` → `target/{release,debug}`),
+- runs the **advisory** host-sleep check (`check-host-sleep.sh`, #3350) — never blocks the start,
+- backgrounds the daemon and writes a PID file at `.loom/.daemon.pid` (gitignored),
+- refuses a second start when the PID file points at a live process, and surfaces
+  the daemon's own **singleton-guard** refusal (#3806) — if the backgrounded
+  process exits immediately it prints the startup-log tail instead of leaving a
+  silently-dead process.
+
+`loom-daemon-stop.sh` sends **SIGTERM** (not just Ctrl-C/SIGINT — the daemon now
+handles both, #3813), waits `LOOM_DAEMON_STOP_GRACE_SECS` (default 10s), then
+escalates to SIGKILL.
+
+**Shutdown decision — sweeps survive, they are not drained.** A clean daemon stop
+removes the Unix socket and exits, but **does not cancel in-flight `/loom:sweep`
+children**. Those are independent detached processes that survive a daemon
+restart by design — killing the dispatcher must not kill dispatched work — and
+the registry reconciles their state on the next start (`SweepRegistry::reconstruct`
+re-admits live-lock owners). To actively cancel a sweep, use
+`mcp__loom__cancel_sweep` against a running daemon *before* stopping it.
+
+### End-to-end acceptance playbook
+
+The goal state — "file a `loom:triage` issue, watch it build" with zero operator
+dispatch — is validated by the E2E playbook at
+[`docs/autonomous-mode-e2e.md`](../../docs/autonomous-mode-e2e.md): it walks a
+throwaway issue from `loom:triage` → Curator → `loom:issue` → work-finder
+dispatch → PR → merge, with a scripted label-transition assertion, and confirms
+the operator only ever created the issue.
 
 ## Locks and lifecycle
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,6 +325,27 @@ Configuration stored in `.loom/config.json` (committed to git for team sharing):
 
 The Rust `loom-daemon` binary is the load-bearing Tier 2 dispatch backend. It is a single long-lived process that holds the sweep registry, the event bus, and the reaper task in memory — there is no on-disk state file the operator needs to touch. See [`.loom/docs/daemon-reference.md`](.loom/docs/daemon-reference.md) for the full surface and [`docs/migration/v0.10.0-shepherd-deprecation.md`](docs/migration/v0.10.0-shepherd-deprecation.md) for the migration narrative away from the legacy Python brain.
 
+**Autonomous mode (config + start/stop, #3813)**: the daemon's autonomous work finder (#3810) and reactive main-health gate (#3812) can be enabled and tuned entirely from committed config — an `autonomous` block in `.loom/config.json` — with env vars still overriding for a single run (precedence **env > config > default**; an absent block is byte-for-byte the pre-#3813 env-only behavior):
+
+```json
+{
+  "autonomous": {
+    "workFinder": { "enabled": true, "intervalSecs": 60, "maxConcurrent": 5 },
+    "mainHealthGate": { "enabled": true }
+  }
+}
+```
+
+Start/stop the **raw daemon process** (distinct from the tmux `loom start|stop` pool) with dedicated wrappers that run the advisory host-sleep check, write a PID file (`.loom/.daemon.pid`), surface the singleton-guard refusal, and shut down cleanly on **SIGTERM** (not just Ctrl-C):
+
+```bash
+./.loom/scripts/cli/loom-daemon-start.sh              # work finder + health gate, backgrounded
+./.loom/scripts/cli/loom-daemon-start.sh --from-config # enable strictly per .loom/config.json
+./.loom/scripts/cli/loom-daemon-stop.sh               # SIGTERM → grace → SIGKILL
+```
+
+A clean stop leaves in-flight `/loom:sweep` children **running** (they survive a daemon restart by design; use `mcp__loom__cancel_sweep` to actively cancel). The full config table, start/stop flags, and a scripted end-to-end acceptance playbook are in [`.loom/docs/daemon-reference.md`](.loom/docs/daemon-reference.md) §Operability and [`docs/autonomous-mode-e2e.md`](docs/autonomous-mode-e2e.md).
+
 **Per-sweep logs** live at `.loom/logs/sweep-issue-<N>.log` and are tailable via `mcp__loom__tail_sweep_log`.
 
 **Sweep checkpoints** (`.loom/sweep-checkpoint/issue-<N>.json`, gitignored): when a sweep child crashes mid-flight, the checkpoint records the last completed phase. On the next dispatch the sweep skill resumes from that phase. The exact schema is owned by the sweep skill (#3373).

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -673,7 +673,29 @@ See [`.loom/docs/daemon-reference.md`](.loom/docs/daemon-reference.md) for the w
 | `.loom/logs/sweep-issue-<N>.log` | Per-issue child output (tailable via `mcp__loom__tail_sweep_log`) |
 | `.loom/sweep-checkpoint/issue-<N>.json` | Crash-resume checkpoint (#3373); sweep skill reads it on entry |
 
-**Issue selection** is operator-driven via `mcp__loom__dispatch_sweep` — the daemon does not autonomously claim items from the `loom:issue` queue. (The `/loom:sweep` skill is the typical caller; Stage -1 backend detection picks an issue and dispatches it when both daemon and pool probes succeed.)
+**Autonomous mode (config + start/stop, #3813)**: the daemon's autonomous work finder (#3810) and reactive main-health gate (#3812) can be enabled and tuned entirely from committed config — an `autonomous` block in `.loom/config.json` — with env vars still overriding for a single run (precedence **env > config > default**; an absent block is byte-for-byte the pre-#3813 env-only behavior):
+
+```json
+{
+  "autonomous": {
+    "workFinder": { "enabled": true, "intervalSecs": 60, "maxConcurrent": 5 },
+    "mainHealthGate": { "enabled": true }
+  }
+}
+```
+
+Start/stop the **raw daemon process** (distinct from the tmux `.loom/bin/loom start|stop` pool) with dedicated wrappers that run the advisory host-sleep check (#3350), write a PID file (`.loom/.daemon.pid`), surface the singleton-guard refusal (#3806), and shut down cleanly on **SIGTERM** (not just Ctrl-C/SIGINT):
+
+```bash
+./.loom/scripts/cli/loom-daemon-start.sh               # work finder + health gate, backgrounded
+./.loom/scripts/cli/loom-daemon-start.sh --from-config # enable strictly per .loom/config.json → autonomous
+./.loom/scripts/cli/loom-daemon-start.sh --no-work-finder   # gate only
+./.loom/scripts/cli/loom-daemon-stop.sh                # SIGTERM → grace → SIGKILL (--force for immediate)
+```
+
+**Shutdown decision**: a clean stop leaves in-flight `/loom:sweep` children **running** — they are independent detached processes that survive a daemon restart by design (killing the dispatcher must not kill dispatched work); the registry reconciles them on the next start. Use `mcp__loom__cancel_sweep` against a running daemon to actively cancel a sweep before stopping. The full config table, start/stop flags, and a scripted end-to-end acceptance playbook are in [`.loom/docs/daemon-reference.md`](.loom/docs/daemon-reference.md) §Operability and [`docs/autonomous-mode-e2e.md`](../docs/autonomous-mode-e2e.md).
+
+**Issue selection** is operator-driven via `mcp__loom__dispatch_sweep` — the daemon does not autonomously claim items from the `loom:issue` queue. (The `/loom:sweep` skill is the typical caller; Stage -1 backend detection picks an issue and dispatches it when both daemon and pool probes succeed.) The autonomous work finder (above, opt-in) is the exception: when enabled it *does* claim open `loom:issue` items and dispatch them.
 
 **Sweep checkpoints** (`.loom/sweep-checkpoint/issue-<N>.json`, gitignored) — the per-issue checkpoint format is owned by the sweep skill (#3373). When a sweep child crashes, the next dispatch reads the checkpoint and skips already-completed phases.
 

--- a/defaults/scripts/cli/loom-daemon-start.sh
+++ b/defaults/scripts/cli/loom-daemon-start.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# loom-daemon-start.sh - Safe start wrapper for the RAW loom-daemon process
+# (the autonomous work-finder + main-health-gate host — epic #3809, Phase D
+# #3813).
+#
+# This is NOT the tmux agent pool. `.loom/bin/loom start` (loom-start.sh)
+# manages the Manual-Orchestration-Mode tmux pool; THIS script backgrounds the
+# `loom-daemon` binary itself, which hosts the autonomous forge-polling work
+# finder (#3810) and the reactive main-health gate (#3812). The two process
+# models are independent and can coexist.
+#
+# It:
+#   - locates the loom-daemon binary,
+#   - runs the (advisory, never-blocking) host-sleep check (#3350),
+#   - enables autonomous mode (work finder + health gate) via env by default,
+#     or leaves it to .loom/config.json -> autonomous with --from-config,
+#   - backgrounds the daemon and writes a PID file (.loom/.daemon.pid),
+#   - surfaces the singleton-guard refusal (#3806) legibly instead of leaving a
+#     silently-exited background process.
+#
+# Usage:
+#   ./.loom/scripts/cli/loom-daemon-start.sh                 Start autonomous mode
+#   ./.loom/scripts/cli/loom-daemon-start.sh --from-config   Enable per .loom/config.json only
+#   ./.loom/scripts/cli/loom-daemon-start.sh --no-work-finder    Health gate only
+#   ./.loom/scripts/cli/loom-daemon-start.sh --no-health-gate    Work finder only
+#   ./.loom/scripts/cli/loom-daemon-start.sh --foreground    Run in the foreground (no PID file)
+#   ./.loom/scripts/cli/loom-daemon-start.sh --help
+#
+# Environment:
+#   LOOM_DAEMON_BIN     Path to the loom-daemon binary (else auto-detected)
+#   LOOM_SOCKET_PATH    Override the daemon socket (default ~/.loom/loom-daemon.sock)
+#   LOOM_WORK_FINDER / LOOM_MAIN_HEALTH_GATE  Respected when already exported
+#
+# Exit codes:
+#   0  daemon started (or already running)
+#   1  usage error / binary not found / daemon failed to start
+
+set -uo pipefail
+
+# ---------- output helpers ----------
+if [[ -t 1 ]]; then
+    RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BOLD='\033[1m'; NC='\033[0m'
+else
+    RED=''; GREEN=''; YELLOW=''; BOLD=''; NC=''
+fi
+err()  { echo -e "${RED}$*${NC}" >&2; }
+warn() { echo -e "${YELLOW}$*${NC}" >&2; }
+ok()   { echo -e "${GREEN}$*${NC}"; }
+
+show_help() {
+    sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+# ---------- repo root ----------
+find_repo_root() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.loom" ]]; then echo "$dir"; return 0; fi
+        if [[ -f "$dir/.git" ]]; then
+            local gitdir main_repo
+            gitdir=$(sed 's/^gitdir: //' "$dir/.git")
+            main_repo=$(dirname "$(dirname "$(dirname "$gitdir")")")
+            if [[ -d "$main_repo/.loom" ]]; then echo "$main_repo"; return 0; fi
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo ""
+}
+
+# ---------- locate the daemon binary ----------
+locate_daemon_bin() {
+    local root="$1"
+    if [[ -n "${LOOM_DAEMON_BIN:-}" && -x "${LOOM_DAEMON_BIN}" ]]; then
+        echo "${LOOM_DAEMON_BIN}"; return 0
+    fi
+    if command -v loom-daemon >/dev/null 2>&1; then
+        command -v loom-daemon; return 0
+    fi
+    local candidate
+    for candidate in \
+        "$root/loom-daemon/target/release/loom-daemon" \
+        "$root/loom-daemon/target/debug/loom-daemon" \
+        "$root/target/release/loom-daemon" \
+        "$root/target/debug/loom-daemon"; do
+        if [[ -x "$candidate" ]]; then echo "$candidate"; return 0; fi
+    done
+    echo ""
+}
+
+# ---------- args ----------
+FROM_CONFIG=false
+FOREGROUND=false
+WANT_WORK_FINDER=true
+WANT_HEALTH_GATE=true
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --help|-h) show_help; exit 0 ;;
+        --from-config) FROM_CONFIG=true; shift ;;
+        --foreground|--fg) FOREGROUND=true; shift ;;
+        --no-work-finder) WANT_WORK_FINDER=false; shift ;;
+        --no-health-gate) WANT_HEALTH_GATE=false; shift ;;
+        *) err "Unknown option '$1'"; echo "Use --help for usage" >&2; exit 1 ;;
+    esac
+done
+
+REPO_ROOT=$(find_repo_root)
+if [[ -z "$REPO_ROOT" ]]; then
+    err "Not in a Loom workspace (.loom directory not found)"
+    exit 1
+fi
+
+DAEMON_BIN=$(locate_daemon_bin "$REPO_ROOT")
+if [[ -z "$DAEMON_BIN" ]]; then
+    err "loom-daemon binary not found."
+    echo "Build it (cargo build --release -p loom-daemon) or set LOOM_DAEMON_BIN=/path/to/loom-daemon" >&2
+    exit 1
+fi
+
+PID_FILE="$REPO_ROOT/.loom/.daemon.pid"
+SOCKET_PATH="${LOOM_SOCKET_PATH:-$HOME/.loom/loom-daemon.sock}"
+START_LOG="$REPO_ROOT/.loom/logs/daemon-start.log"
+mkdir -p "$REPO_ROOT/.loom/logs"
+
+# ---------- already-running guard (PID file) ----------
+if [[ -f "$PID_FILE" ]]; then
+    existing_pid=$(cat "$PID_FILE" 2>/dev/null || true)
+    if [[ -n "$existing_pid" ]] && kill -0 "$existing_pid" 2>/dev/null; then
+        warn "loom-daemon already running (pid $existing_pid, per $PID_FILE)."
+        echo "To restart: ./.loom/scripts/cli/loom-daemon-stop.sh && $0" >&2
+        exit 0
+    fi
+    # Stale PID file — clean it up and continue.
+    rm -f "$PID_FILE"
+fi
+
+# ---------- advisory host-sleep check (never blocks — #3350) ----------
+SLEEP_CHECK="$REPO_ROOT/.loom/scripts/check-host-sleep.sh"
+[[ -x "$SLEEP_CHECK" ]] || SLEEP_CHECK="$REPO_ROOT/defaults/scripts/check-host-sleep.sh"
+if [[ -x "$SLEEP_CHECK" ]]; then
+    "$SLEEP_CHECK" || true
+fi
+
+# ---------- autonomous-mode env ----------
+# Precedence: an already-exported env var is always respected. Otherwise the
+# default is to enable both loops (the whole point of starting the daemon),
+# unless --from-config was passed (then leave them unset so .loom/config.json ->
+# autonomous drives) or a --no-* opt-out forces the var to 0.
+export LOOM_WORKSPACE="${LOOM_WORKSPACE:-$REPO_ROOT}"
+
+if [[ "$FROM_CONFIG" == "true" ]]; then
+    echo -e "${BOLD}Autonomous mode: driven by .loom/config.json -> autonomous (env not forced)${NC}"
+else
+    if [[ "$WANT_WORK_FINDER" == "false" ]]; then
+        export LOOM_WORK_FINDER=0
+    elif [[ -z "${LOOM_WORK_FINDER:-}" ]]; then
+        export LOOM_WORK_FINDER=1
+    fi
+    if [[ "$WANT_HEALTH_GATE" == "false" ]]; then
+        export LOOM_MAIN_HEALTH_GATE=0
+    elif [[ -z "${LOOM_MAIN_HEALTH_GATE:-}" ]]; then
+        export LOOM_MAIN_HEALTH_GATE=1
+    fi
+    echo -e "${BOLD}Autonomous mode:${NC} work_finder=${LOOM_WORK_FINDER:-config} main_health_gate=${LOOM_MAIN_HEALTH_GATE:-config}"
+fi
+
+echo "Daemon binary: $DAEMON_BIN"
+echo "Socket:        $SOCKET_PATH"
+echo "Daemon log:    ${HOME}/.loom/daemon.log"
+
+# ---------- foreground mode ----------
+if [[ "$FOREGROUND" == "true" ]]; then
+    echo "Starting loom-daemon in the foreground (Ctrl-C to stop)..."
+    exec "$DAEMON_BIN"
+fi
+
+# ---------- background + PID file ----------
+: > "$START_LOG"
+nohup "$DAEMON_BIN" >> "$START_LOG" 2>&1 &
+daemon_pid=$!
+
+# Give it a moment to either bind the socket or trip the singleton guard.
+sleep 2
+
+if ! kill -0 "$daemon_pid" 2>/dev/null; then
+    err "loom-daemon exited immediately after start (pid $daemon_pid)."
+    if [[ -s "$START_LOG" ]]; then
+        echo "----- startup output ($START_LOG) -----" >&2
+        tail -n 20 "$START_LOG" >&2
+        echo "---------------------------------------" >&2
+    fi
+    warn "If another daemon is already listening on the socket, stop it first"
+    warn "(./.loom/scripts/cli/loom-daemon-stop.sh) and retry."
+    exit 1
+fi
+
+echo "$daemon_pid" > "$PID_FILE"
+ok "loom-daemon started (pid $daemon_pid). PID file: $PID_FILE"
+echo "Stop with: ./.loom/scripts/cli/loom-daemon-stop.sh"
+exit 0

--- a/defaults/scripts/cli/loom-daemon-stop.sh
+++ b/defaults/scripts/cli/loom-daemon-stop.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# loom-daemon-stop.sh - Clean shutdown for the RAW loom-daemon process
+# (autonomous work-finder + main-health-gate host — epic #3809, Phase D #3813).
+#
+# This is NOT the tmux agent pool. `.loom/bin/loom stop` (loom-stop.sh) tears
+# down the Manual-Orchestration-Mode tmux pool; THIS script stops the
+# `loom-daemon` binary started by loom-daemon-start.sh.
+#
+# Shutdown model (drain vs. survive):
+#   The daemon handles BOTH SIGINT (Ctrl-C) and SIGTERM (`kill <pid>`) by
+#   removing its Unix socket and exiting cleanly (#3813). This script sends
+#   SIGTERM, waits a grace window, then escalates to SIGKILL if needed.
+#
+#   In-flight `/loom:sweep` children are NOT cancelled. They are independent
+#   detached processes that survive a daemon restart BY DESIGN — stopping the
+#   dispatcher must not kill dispatched work. This "survive, don't drain"
+#   decision means you can stop+start the daemon without losing running builds;
+#   the reaper reconciles their state on the next start. To actively cancel a
+#   sweep, use `mcp__loom__cancel_sweep` against a running daemon before stopping.
+#
+# Usage:
+#   ./.loom/scripts/cli/loom-daemon-stop.sh            Graceful stop (SIGTERM -> SIGKILL)
+#   ./.loom/scripts/cli/loom-daemon-stop.sh --force    Skip the grace window (SIGKILL)
+#   ./.loom/scripts/cli/loom-daemon-stop.sh --help
+#
+# Environment:
+#   LOOM_DAEMON_STOP_GRACE_SECS   Grace window before SIGKILL (default 10)
+#
+# Exit codes:
+#   0  daemon stopped (or was not running)
+#   1  usage error / failed to stop
+
+set -uo pipefail
+
+if [[ -t 1 ]]; then
+    RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+else
+    RED=''; GREEN=''; YELLOW=''; NC=''
+fi
+err()  { echo -e "${RED}$*${NC}" >&2; }
+warn() { echo -e "${YELLOW}$*${NC}" >&2; }
+ok()   { echo -e "${GREEN}$*${NC}"; }
+
+show_help() { sed -n '2,35p' "$0" | sed 's/^# \{0,1\}//'; }
+
+find_repo_root() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.loom" ]]; then echo "$dir"; return 0; fi
+        if [[ -f "$dir/.git" ]]; then
+            local gitdir main_repo
+            gitdir=$(sed 's/^gitdir: //' "$dir/.git")
+            main_repo=$(dirname "$(dirname "$(dirname "$gitdir")")")
+            if [[ -d "$main_repo/.loom" ]]; then echo "$main_repo"; return 0; fi
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo ""
+}
+
+FORCE=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --help|-h) show_help; exit 0 ;;
+        --force|-f) FORCE=true; shift ;;
+        *) err "Unknown option '$1'"; echo "Use --help for usage" >&2; exit 1 ;;
+    esac
+done
+
+REPO_ROOT=$(find_repo_root)
+if [[ -z "$REPO_ROOT" ]]; then
+    err "Not in a Loom workspace (.loom directory not found)"
+    exit 1
+fi
+
+PID_FILE="$REPO_ROOT/.loom/.daemon.pid"
+GRACE_SECS="${LOOM_DAEMON_STOP_GRACE_SECS:-10}"
+
+# Resolve the target pid: prefer the PID file, else best-effort pgrep.
+pid=""
+if [[ -f "$PID_FILE" ]]; then
+    pid=$(cat "$PID_FILE" 2>/dev/null || true)
+fi
+if [[ -z "$pid" ]] || ! kill -0 "$pid" 2>/dev/null; then
+    # PID file missing/stale — fall back to a process match (best effort).
+    if command -v pgrep >/dev/null 2>&1; then
+        pid=$(pgrep -f '(^|/)loom-daemon$' 2>/dev/null | head -n1 || true)
+    fi
+fi
+
+if [[ -z "$pid" ]] || ! kill -0 "$pid" 2>/dev/null; then
+    warn "No running loom-daemon found (nothing to stop)."
+    rm -f "$PID_FILE"
+    exit 0
+fi
+
+if [[ "$FORCE" == "true" ]]; then
+    warn "Force-killing loom-daemon (pid $pid) with SIGKILL..."
+    kill -KILL "$pid" 2>/dev/null || true
+else
+    echo "Stopping loom-daemon (pid $pid) with SIGTERM (grace ${GRACE_SECS}s)..."
+    kill -TERM "$pid" 2>/dev/null || true
+    # Wait up to the grace window for a clean exit.
+    waited=0
+    while kill -0 "$pid" 2>/dev/null && (( waited < GRACE_SECS )); do
+        sleep 1
+        waited=$((waited + 1))
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+        warn "Daemon did not exit within ${GRACE_SECS}s — escalating to SIGKILL."
+        kill -KILL "$pid" 2>/dev/null || true
+        sleep 1
+    fi
+fi
+
+if kill -0 "$pid" 2>/dev/null; then
+    err "Failed to stop loom-daemon (pid $pid)."
+    exit 1
+fi
+
+rm -f "$PID_FILE"
+ok "loom-daemon stopped (pid $pid)."
+echo "In-flight sweeps (if any) were left running by design; the next start reconciles them."
+exit 0

--- a/docs/autonomous-mode-e2e.md
+++ b/docs/autonomous-mode-e2e.md
@@ -1,0 +1,153 @@
+# Autonomous mode — end-to-end acceptance playbook (#3813)
+
+This playbook demonstrates the headline goal of the autonomous daemon (epic
+#3809): **"focus on creating issues, watch it build."** It walks a single
+throwaway issue from a fresh `loom:triage` filing all the way to a merged PR with
+the operator only ever creating the issue — every intermediate transition
+(`loom:triage` → `loom:curated` → `loom:issue` → `loom:building` → PR →
+merged) is driven by Loom, not by hand.
+
+It is a **repeatable, mostly-scripted** procedure. It cannot be a hermetic CI
+test because it depends on live forge state, real dispatch, and the support-role
+crons — but the label-transition wait in Step 5 is a scripted assertion so the
+"did it actually work" check is not a manual eyeball.
+
+## Prerequisites
+
+- A built `loom-daemon` binary (`cargo build --release -p loom-daemon`), or set
+  `LOOM_DAEMON_BIN`.
+- `gh` authenticated against the target repo (`gh auth status`).
+- A multi-account token pool bootstrapped (`loom-tokens bootstrap`) if you want
+  the daemon dispatch path to rotate accounts; a single token also works.
+- The `buildGate` block configured in `.loom/config.json` if you want the
+  main-health gate active (optional for the loop itself).
+- The support roles reachable: either the GitHub Actions cron workflows enabled
+  (`.github/workflows/loom-*.yml`), or you run Curator / Judge / Champion
+  manually per step (the playbook shows the manual triggers).
+
+## Step 1 — Enable autonomous mode in config
+
+Add the `autonomous` block to `.loom/config.json` (see
+[`.loom/docs/daemon-reference.md`](../.loom/docs/daemon-reference.md) §Operability):
+
+```json
+{
+  "autonomous": {
+    "workFinder": { "enabled": true, "intervalSecs": 60, "maxConcurrent": 3 },
+    "mainHealthGate": { "enabled": true }
+  }
+}
+```
+
+## Step 2 — Start the daemon in autonomous mode
+
+```bash
+./.loom/scripts/cli/loom-daemon-start.sh --from-config
+# or force the loops on regardless of config:
+./.loom/scripts/cli/loom-daemon-start.sh
+```
+
+Confirm the work finder is ticking:
+
+```bash
+grep 'work_finder: enabled' ~/.loom/daemon.log | tail -1
+```
+
+## Step 3 — File a throwaway triage issue (the ONLY operator action)
+
+```bash
+ISSUE=$(gh issue create \
+  --title "E2E canary $(date +%s): no-op doc touch" \
+  --body "Autonomous-mode E2E canary. Curator should enrich; work finder should build. Safe to close." \
+  --label loom:triage \
+  | grep -oE '[0-9]+$')
+echo "Filed canary issue #$ISSUE"
+```
+
+From here on, **do not** run any `gh issue edit` / dispatch commands by hand —
+the whole point is that Loom carries it.
+
+## Step 4 — Let the support roles + work finder run
+
+- **Curator** enriches the issue and marks it `loom:curated`.
+- A human (or Champion in full-autonomy mode) promotes `loom:curated` →
+  `loom:issue`.
+- The **work finder** (daemon) sees the open `loom:issue`, flips it to
+  `loom:building`, and dispatches a `/loom:sweep` child.
+- The sweep runs Builder → Judge → (Doctor) → opens a PR (`loom:review-requested`
+  → `loom:pr`).
+- **Champion** auto-merges the approved PR.
+
+If the crons are not enabled, trigger the roles manually (still zero
+issue-editing by you):
+
+```bash
+claude -p "/curator"  --dangerously-skip-permissions
+claude -p "/champion" --dangerously-skip-permissions   # promotes loom:curated → loom:issue, later auto-merges
+claude -p "/judge"    --dangerously-skip-permissions
+```
+
+## Step 5 — Scripted assertion: wait for the label sequence
+
+Poll the issue until it closes (its PR merged) or a timeout fires. This is the
+load-bearing pass/fail check — it asserts the transitions happened without
+operator dispatch:
+
+```bash
+#!/usr/bin/env bash
+# assert-e2e.sh <issue-number> [timeout-secs]
+set -uo pipefail
+ISSUE="${1:?usage: assert-e2e.sh <issue> [timeout]}"
+TIMEOUT="${2:-3600}"      # default 1h
+INTERVAL=30
+elapsed=0
+declare -A seen
+while (( elapsed < TIMEOUT )); do
+    state=$(gh issue view "$ISSUE" --json state,labels \
+        --jq '{state: .state, labels: [.labels[].name]}')
+    issue_state=$(echo "$state" | jq -r '.state')
+    labels=$(echo "$state" | jq -r '.labels | join(",")')
+    for l in loom:curated loom:issue loom:building; do
+        if [[ ",$labels," == *",$l,"* && -z "${seen[$l]:-}" ]]; then
+            seen[$l]=1
+            echo "[$(date +%T)] reached: $l"
+        fi
+    done
+    if [[ "$issue_state" == "CLOSED" ]]; then
+        echo "PASS: issue #$ISSUE closed (PR merged) after ${elapsed}s"
+        echo "observed transitions: ${!seen[*]}"
+        exit 0
+    fi
+    sleep "$INTERVAL"; elapsed=$((elapsed + INTERVAL))
+done
+echo "FAIL: issue #$ISSUE did not close within ${TIMEOUT}s (labels: $labels)" >&2
+exit 1
+```
+
+```bash
+bash assert-e2e.sh "$ISSUE" 3600
+```
+
+A `PASS` line means the full `loom:triage → merged` chain completed autonomously.
+Record the observed transitions and elapsed time in the PR/run notes.
+
+## Step 6 — Tear down
+
+```bash
+./.loom/scripts/cli/loom-daemon-stop.sh
+# If the canary PR did not auto-merge, close it and the issue:
+gh issue close "$ISSUE" 2>/dev/null || true
+```
+
+Stopping the daemon leaves any still-running sweep child alive by design (see
+daemon-reference §"Shutdown decision"); the next start reconciles it, or cancel
+it explicitly with `mcp__loom__cancel_sweep` before stopping.
+
+## What "green" looks like
+
+| Signal | Where |
+|--------|-------|
+| `work_finder: enabled (...)` | `~/.loom/daemon.log` |
+| `work_finder: tick — ... N dispatched` | `~/.loom/daemon.log` |
+| Issue reaches `loom:building` then closes | `assert-e2e.sh` PASS |
+| Zero operator `gh issue edit` between Step 3 and merge | your shell history |

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -312,11 +312,18 @@ async fn main() -> Result<()> {
     // work-finder is never halted (zero behavior change with the gate off).
     let main_health_state = Arc::new(main_health_gate::MainHealthState::new());
 
-    let _work_finder_handle = if work_finder::enabled() {
+    // Config surface (#3813): `.loom/config.json → autonomous.workFinder` lets a
+    // repo enable/tune the loop from committed config with zero env vars, while
+    // an operator env var still overrides for a single run (precedence env >
+    // config > default). An absent `autonomous` block is byte-for-byte the
+    // env-only behavior shipped in Phases A/B.
+    let work_finder_config = work_finder::read_work_finder_config(&sweep_workspace);
+
+    let _work_finder_handle = if work_finder::resolve_enabled(&work_finder_config) {
         let source = work_finder::GhWorkSource::new();
         let dispatcher = work_finder::RegistryDispatcher::new(sweep_registry.clone());
-        let interval = work_finder::resolve_interval();
-        let configured_max = work_finder::resolve_max_concurrent();
+        let interval = work_finder::resolve_interval_with_config(&work_finder_config);
+        let configured_max = work_finder::resolve_max_concurrent_with_config(&work_finder_config);
         log::info!(
             "work_finder: enabled (interval={}s, configured_max={configured_max}, \
              dynamic cap = min(pool, disk, configured_max))",
@@ -342,7 +349,13 @@ async fn main() -> Result<()> {
     // dispatching new sweeps until a green run clears it. The gate command runs
     // on a blocking thread (it may take minutes), so a plain `tokio::spawn`
     // interval task on the shared runtime is correct (like the reaper).
-    let _main_health_gate_handle = if main_health_gate::enabled() {
+    // Config surface (#3813): `autonomous.mainHealthGate.enabled` can enable the
+    // gate from committed config; `LOOM_MAIN_HEALTH_GATE` remains the master
+    // on/off override (precedence env > config > default). The gate's *behavior*
+    // (command, timeout) still comes from the separate `buildGate` block, so
+    // Phase C's tested semantics are unchanged.
+    let autonomous_gate_config = main_health_gate::read_autonomous_gate_config(&sweep_workspace);
+    let _main_health_gate_handle = if main_health_gate::resolve_enabled(&autonomous_gate_config) {
         match main_health_gate::read_build_gate_config(&sweep_workspace) {
             Some(gate_config) => {
                 let interval = main_health_gate::resolve_interval();
@@ -369,37 +382,82 @@ async fn main() -> Result<()> {
             }
         }
     } else {
-        log::debug!("main_health_gate: disabled (set LOOM_MAIN_HEALTH_GATE=1 + a buildGate config to enable)");
+        log::debug!("main_health_gate: disabled (set LOOM_MAIN_HEALTH_GATE=1 or autonomous.mainHealthGate.enabled=true + a buildGate config to enable)");
         None
     };
 
     // Start IPC server
     let server = IpcServer::new(socket_path.clone(), tm, activity_db, sweep_registry, event_bus);
 
-    // Setup signal handler for graceful shutdown
+    // Setup signal handler for graceful shutdown. We listen for BOTH SIGINT
+    // (Ctrl-C, interactive) and SIGTERM (`kill <pid>`, the default signal a
+    // backgrounded daemon receives from `loom-daemon-stop.sh` — #3813). Either
+    // one removes the socket and exits cleanly so a subsequent start does not
+    // trip the singleton guard on a stale socket.
+    //
+    // In-flight `/loom:sweep` children are NOT cancelled on shutdown — they are
+    // independent detached processes and survive a daemon restart by design
+    // (killing the dispatcher must not kill dispatched work). This is the
+    // documented "survive, don't drain" decision (see daemon-reference.md).
     let socket_path_clone = socket_path.clone();
     tokio::spawn(async move {
-        match tokio::signal::ctrl_c().await {
-            Ok(()) => {
-                log::info!("Received shutdown signal, cleaning up...");
-                // Signal the off-runtime epic supervisor loop to stop.
-                if let Some(flag) = &supervisor_shutdown {
-                    flag.store(true, std::sync::atomic::Ordering::Relaxed);
-                }
-                let _ = tokio::fs::remove_file(&socket_path_clone).await;
-                log::info!("Socket cleaned up, exiting");
-                std::process::exit(0);
-            }
-            Err(err) => {
-                log::error!("Unable to listen for shutdown signal: {err}");
-            }
+        let signal_name = wait_for_shutdown_signal().await;
+        log::info!("Received {signal_name}, cleaning up...");
+        // Signal the off-runtime epic supervisor loop to stop.
+        if let Some(flag) = &supervisor_shutdown {
+            flag.store(true, std::sync::atomic::Ordering::Relaxed);
         }
+        let _ = tokio::fs::remove_file(&socket_path_clone).await;
+        log::info!("Socket cleaned up, exiting");
+        std::process::exit(0);
     });
 
     log::info!("Loom daemon starting...");
     server.run().await?;
 
     Ok(())
+}
+
+/// Await either SIGINT (Ctrl-C) or, on Unix, SIGTERM (`kill <pid>`), returning a
+/// short human-readable name for whichever fired first. On non-Unix platforms
+/// only Ctrl-C is available. Introduced in #3813 so a backgrounded daemon shut
+/// down via `kill` (SIGTERM) cleans up its socket exactly like an interactive
+/// Ctrl-C, rather than being torn down by the default SIGTERM disposition with
+/// the socket left behind.
+async fn wait_for_shutdown_signal() -> &'static str {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        // If a signal stream cannot be installed, fall back to Ctrl-C only
+        // rather than aborting shutdown handling entirely.
+        match signal(SignalKind::terminate()) {
+            Ok(mut sigterm) => {
+                tokio::select! {
+                    r = tokio::signal::ctrl_c() => {
+                        if let Err(err) = r {
+                            log::error!("Unable to listen for Ctrl-C: {err}");
+                        }
+                        "SIGINT (Ctrl-C)"
+                    }
+                    _ = sigterm.recv() => "SIGTERM",
+                }
+            }
+            Err(err) => {
+                log::error!("Unable to install SIGTERM handler ({err}); listening for Ctrl-C only");
+                if let Err(err) = tokio::signal::ctrl_c().await {
+                    log::error!("Unable to listen for Ctrl-C: {err}");
+                }
+                "SIGINT (Ctrl-C)"
+            }
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        if let Err(err) = tokio::signal::ctrl_c().await {
+            log::error!("Unable to listen for Ctrl-C: {err}");
+        }
+        "SIGINT (Ctrl-C)"
+    }
 }
 
 fn check_tmux_installed() -> Result<()> {

--- a/loom-daemon/src/main_health_gate.rs
+++ b/loom-daemon/src/main_health_gate.rs
@@ -448,12 +448,88 @@ fn log_transition(transition: HealthTransition, outcome: &GateOutcome) {
 
 /// Whether the main-health gate loop is enabled, per
 /// [`MAIN_HEALTH_GATE_ENABLE_ENV`]. Off by default (opt-in); parsing mirrors
-/// [`crate::work_finder::enabled`].
+/// [`crate::work_finder::enabled`]. This is the **env-only** primitive; the
+/// config-aware entry point the daemon uses is [`resolve_enabled`] (precedence
+/// env > config > default).
 #[must_use]
 pub fn enabled() -> bool {
     std::env::var(MAIN_HEALTH_GATE_ENABLE_ENV).is_ok_and(|v| {
         matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on")
     })
+}
+
+/// The subset of `.loom/config.json → autonomous.mainHealthGate` this module
+/// consumes. Today it carries only the enablement flag; future tuning knobs
+/// (cadence, timeout) can be added here without touching the call site.
+///
+/// The gate's *behavior* (which command runs against `main`, its timeout) still
+/// comes from the separate `buildGate` block via [`read_build_gate_config`] —
+/// `autonomous.mainHealthGate` is purely the on/off (and future tuning) surface,
+/// so Phase C's already-tested `buildGate` semantics are untouched.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AutonomousGateConfig {
+    /// `autonomous.mainHealthGate.enabled` — whether to run the gate loop.
+    /// `None` when the key is absent (falls through to env / default).
+    pub enabled: Option<bool>,
+}
+
+/// Read `.loom/config.json → autonomous.mainHealthGate`, soft-failing to an
+/// all-`None` config on any of: missing file, malformed JSON, or a missing
+/// `autonomous` / `mainHealthGate` block. Mirrors [`read_build_gate_config`]'s
+/// soft-fail contract — a repo with no `autonomous` block gets zero behavior
+/// change (env-only enablement, exactly like Phase C shipped).
+#[must_use]
+pub fn read_autonomous_gate_config(repo_root: &Path) -> AutonomousGateConfig {
+    let config_path = repo_root.join(".loom").join("config.json");
+
+    let config_str = match std::fs::read_to_string(&config_path) {
+        Ok(s) => s,
+        Err(e) => {
+            log::debug!(
+                "main_health_gate: could not read config at {}: {e}",
+                config_path.display()
+            );
+            return AutonomousGateConfig::default();
+        }
+    };
+
+    let config: serde_json::Value = match serde_json::from_str(&config_str) {
+        Ok(v) => v,
+        Err(e) => {
+            log::warn!(
+                "main_health_gate: could not parse config at {}: {e}",
+                config_path.display()
+            );
+            return AutonomousGateConfig::default();
+        }
+    };
+
+    let Some(gate) = config
+        .get("autonomous")
+        .and_then(|a| a.get("mainHealthGate"))
+    else {
+        return AutonomousGateConfig::default();
+    };
+
+    AutonomousGateConfig {
+        enabled: gate.get("enabled").and_then(serde_json::Value::as_bool),
+    }
+}
+
+/// Resolve whether the gate loop is enabled with precedence **env > config >
+/// default(false)**. When [`MAIN_HEALTH_GATE_ENABLE_ENV`] is *set* (to any
+/// value) it decides (truthy enables, anything else disables); when unset the
+/// config `enabled` flag decides; absent config leaves it off.
+///
+/// Keeping `LOOM_MAIN_HEALTH_GATE` as the master on/off preserves Phase C's
+/// opt-in contract byte-for-byte when no `autonomous` block is present, while
+/// letting a repo enable the gate entirely from committed config.
+#[must_use]
+pub fn resolve_enabled(config: &AutonomousGateConfig) -> bool {
+    if let Ok(v) = std::env::var(MAIN_HEALTH_GATE_ENABLE_ENV) {
+        return matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on");
+    }
+    config.enabled.unwrap_or(false)
 }
 
 /// Resolve the gate cadence from [`MAIN_HEALTH_GATE_INTERVAL_ENV`], falling back
@@ -794,5 +870,76 @@ mod tests {
         std::env::set_var(MAIN_HEALTH_GATE_INTERVAL_ENV, "garbage");
         assert_eq!(resolve_interval(), Duration::from_secs(DEFAULT_MAIN_HEALTH_GATE_INTERVAL_SECS));
         std::env::remove_var(MAIN_HEALTH_GATE_INTERVAL_ENV);
+    }
+
+    // ===================================================================
+    // Autonomous config surface — autonomous.mainHealthGate (#3813)
+    // ===================================================================
+
+    #[test]
+    fn test_autonomous_config_missing_file_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(read_autonomous_gate_config(tmp.path()), AutonomousGateConfig::default());
+    }
+
+    #[test]
+    fn test_autonomous_config_malformed_json_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), "{not valid json");
+        assert_eq!(read_autonomous_gate_config(tmp.path()), AutonomousGateConfig::default());
+    }
+
+    #[test]
+    fn test_autonomous_config_missing_block_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), r#"{"autonomous": {"workFinder": {"enabled": true}}}"#);
+        assert_eq!(read_autonomous_gate_config(tmp.path()), AutonomousGateConfig::default());
+    }
+
+    #[test]
+    fn test_autonomous_config_enabled_true_and_false() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), r#"{"autonomous": {"mainHealthGate": {"enabled": true}}}"#);
+        assert_eq!(
+            read_autonomous_gate_config(tmp.path()),
+            AutonomousGateConfig {
+                enabled: Some(true)
+            }
+        );
+        write_config(tmp.path(), r#"{"autonomous": {"mainHealthGate": {"enabled": false}}}"#);
+        assert_eq!(
+            read_autonomous_gate_config(tmp.path()),
+            AutonomousGateConfig {
+                enabled: Some(false)
+            }
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_enabled_precedence() {
+        std::env::remove_var(MAIN_HEALTH_GATE_ENABLE_ENV);
+
+        // Absent config + unset env ⇒ default off (Phase C opt-in preserved).
+        assert!(!resolve_enabled(&AutonomousGateConfig::default()));
+
+        // Config alone enables/disables when env is unset.
+        assert!(resolve_enabled(&AutonomousGateConfig {
+            enabled: Some(true)
+        }));
+        assert!(!resolve_enabled(&AutonomousGateConfig {
+            enabled: Some(false)
+        }));
+
+        // Env overrides config in both directions (env is the master switch).
+        std::env::set_var(MAIN_HEALTH_GATE_ENABLE_ENV, "1");
+        assert!(resolve_enabled(&AutonomousGateConfig {
+            enabled: Some(false)
+        }));
+        std::env::set_var(MAIN_HEALTH_GATE_ENABLE_ENV, "0");
+        assert!(!resolve_enabled(&AutonomousGateConfig {
+            enabled: Some(true)
+        }));
+        std::env::remove_var(MAIN_HEALTH_GATE_ENABLE_ENV);
     }
 }

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -73,7 +73,7 @@
 //! supervisor's OS-thread machinery.
 
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -317,7 +317,9 @@ pub fn tick(
 /// Whether the work-finder loop is enabled, per [`WORK_FINDER_ENABLE_ENV`].
 ///
 /// Off by default (opt-in) — parsing mirrors
-/// [`crate::epic_supervisor::supervisor_enabled`].
+/// [`crate::epic_supervisor::supervisor_enabled`]. This is the **env-only**
+/// primitive; the config-aware entry point the daemon actually uses is
+/// [`resolve_enabled`] (precedence env > config > default).
 #[must_use]
 pub fn enabled() -> bool {
     std::env::var(WORK_FINDER_ENABLE_ENV).is_ok_and(|v| {
@@ -325,15 +327,30 @@ pub fn enabled() -> bool {
     })
 }
 
+/// Env override for the tick interval — `None` when unset, zero, or
+/// unparseable (a zero-interval busy loop is never useful).
+fn env_interval_secs() -> Option<u64> {
+    std::env::var(WORK_FINDER_INTERVAL_ENV)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|&s| s > 0)
+}
+
+/// Env override for the max-concurrency ceiling — `None` when unset, zero, or
+/// unparseable (a zero cap would dispatch nothing, defeating the loop).
+fn env_max_concurrent() -> Option<usize> {
+    std::env::var(WORK_FINDER_MAX_CONCURRENT_ENV)
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+}
+
 /// Resolve the tick interval from [`WORK_FINDER_INTERVAL_ENV`], falling back to
 /// [`DEFAULT_WORK_FINDER_INTERVAL_SECS`]. A zero or unparseable value falls back
 /// to the default (a zero-interval busy loop is never useful).
 #[must_use]
 pub fn resolve_interval() -> Duration {
-    std::env::var(WORK_FINDER_INTERVAL_ENV)
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .filter(|&s| s > 0)
+    env_interval_secs()
         .map_or_else(|| Duration::from_secs(DEFAULT_WORK_FINDER_INTERVAL_SECS), Duration::from_secs)
 }
 
@@ -343,10 +360,103 @@ pub fn resolve_interval() -> Duration {
 /// back to the default (a zero cap would dispatch nothing, defeating the loop).
 #[must_use]
 pub fn resolve_max_concurrent() -> usize {
-    std::env::var(WORK_FINDER_MAX_CONCURRENT_ENV)
-        .ok()
-        .and_then(|v| v.parse::<usize>().ok())
-        .filter(|&n| n > 0)
+    env_max_concurrent().unwrap_or(DEFAULT_WORK_FINDER_MAX_CONCURRENT)
+}
+
+// ============================================================================
+// Config-file configuration (.loom/config.json → autonomous.workFinder)
+// ============================================================================
+
+/// The subset of `.loom/config.json → autonomous.workFinder` this module
+/// consumes. Each field is `Option` so an absent key falls through to the
+/// env-var / built-in-default resolution — the precedence is **env > config >
+/// default** for every knob.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WorkFinderConfig {
+    /// `autonomous.workFinder.enabled` — whether to run the loop at all.
+    pub enabled: Option<bool>,
+    /// `autonomous.workFinder.intervalSecs` — tick interval in seconds
+    /// (a zero/invalid value is dropped to `None`).
+    pub interval_secs: Option<u64>,
+    /// `autonomous.workFinder.maxConcurrent` — the operator concurrency ceiling
+    /// (a zero/invalid value is dropped to `None`).
+    pub max_concurrent: Option<usize>,
+}
+
+/// Read `.loom/config.json → autonomous.workFinder`, soft-failing every field
+/// to `None` (env/default resolution) on any of: missing file, malformed JSON,
+/// or a missing `autonomous` / `workFinder` block.
+///
+/// Mirrors the soft-fail contract of
+/// [`crate::main_health_gate::read_build_gate_config`] — a repo with no
+/// `autonomous` block gets zero behavior change (env-only, exactly like today).
+/// A zero or non-integer `intervalSecs` / `maxConcurrent` is treated as absent
+/// so it falls through to the built-in default rather than a useless value.
+#[must_use]
+pub fn read_work_finder_config(repo_root: &Path) -> WorkFinderConfig {
+    let config_path = repo_root.join(".loom").join("config.json");
+
+    let config_str = match std::fs::read_to_string(&config_path) {
+        Ok(s) => s,
+        Err(e) => {
+            log::debug!("work_finder: could not read config at {}: {e}", config_path.display());
+            return WorkFinderConfig::default();
+        }
+    };
+
+    let config: serde_json::Value = match serde_json::from_str(&config_str) {
+        Ok(v) => v,
+        Err(e) => {
+            log::warn!("work_finder: could not parse config at {}: {e}", config_path.display());
+            return WorkFinderConfig::default();
+        }
+    };
+
+    let Some(wf) = config.get("autonomous").and_then(|a| a.get("workFinder")) else {
+        return WorkFinderConfig::default();
+    };
+
+    WorkFinderConfig {
+        enabled: wf.get("enabled").and_then(serde_json::Value::as_bool),
+        interval_secs: wf
+            .get("intervalSecs")
+            .and_then(serde_json::Value::as_u64)
+            .filter(|&s| s > 0),
+        max_concurrent: wf
+            .get("maxConcurrent")
+            .and_then(serde_json::Value::as_u64)
+            .filter(|&n| n > 0)
+            .and_then(|n| usize::try_from(n).ok()),
+    }
+}
+
+/// Resolve whether the loop is enabled with precedence **env > config >
+/// default(false)**. When [`WORK_FINDER_ENABLE_ENV`] is *set* (to any value) it
+/// decides (truthy enables, anything else disables); when unset the config
+/// `enabled` flag decides; absent config leaves it off (opt-in, zero behavior
+/// change).
+#[must_use]
+pub fn resolve_enabled(config: &WorkFinderConfig) -> bool {
+    if let Ok(v) = std::env::var(WORK_FINDER_ENABLE_ENV) {
+        return matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on");
+    }
+    config.enabled.unwrap_or(false)
+}
+
+/// Resolve the tick interval with precedence **env > config > default**.
+#[must_use]
+pub fn resolve_interval_with_config(config: &WorkFinderConfig) -> Duration {
+    env_interval_secs()
+        .or(config.interval_secs)
+        .map_or_else(|| Duration::from_secs(DEFAULT_WORK_FINDER_INTERVAL_SECS), Duration::from_secs)
+}
+
+/// Resolve the max-concurrency ceiling with precedence **env > config >
+/// default**.
+#[must_use]
+pub fn resolve_max_concurrent_with_config(config: &WorkFinderConfig) -> usize {
+    env_max_concurrent()
+        .or(config.max_concurrent)
         .unwrap_or(DEFAULT_WORK_FINDER_MAX_CONCURRENT)
 }
 
@@ -1035,5 +1145,176 @@ mod tests {
         let report = tick(&mut source, &mut disp, cap, false).unwrap();
         assert_eq!(report, TickReport::default(), "empty backlog ⇒ zero activity");
         assert!(disp.dispatched.is_empty());
+    }
+
+    // ===================================================================
+    // Config-file surface — read_work_finder_config soft-fail (#3813)
+    // ===================================================================
+
+    fn write_config(dir: &Path, body: &str) {
+        let loom_dir = dir.join(".loom");
+        std::fs::create_dir_all(&loom_dir).unwrap();
+        std::fs::write(loom_dir.join("config.json"), body).unwrap();
+    }
+
+    #[test]
+    fn test_config_missing_file_is_all_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(read_work_finder_config(tmp.path()), WorkFinderConfig::default());
+    }
+
+    #[test]
+    fn test_config_malformed_json_is_all_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), "{not valid json");
+        assert_eq!(read_work_finder_config(tmp.path()), WorkFinderConfig::default());
+    }
+
+    #[test]
+    fn test_config_missing_autonomous_block_is_all_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), r#"{"terminals": []}"#);
+        assert_eq!(read_work_finder_config(tmp.path()), WorkFinderConfig::default());
+    }
+
+    #[test]
+    fn test_config_missing_work_finder_block_is_all_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), r#"{"autonomous": {"mainHealthGate": {"enabled": true}}}"#);
+        assert_eq!(read_work_finder_config(tmp.path()), WorkFinderConfig::default());
+    }
+
+    #[test]
+    fn test_config_full_block_is_parsed() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(
+            tmp.path(),
+            r#"{"autonomous": {"workFinder": {"enabled": true, "intervalSecs": 90, "maxConcurrent": 5}}}"#,
+        );
+        assert_eq!(
+            read_work_finder_config(tmp.path()),
+            WorkFinderConfig {
+                enabled: Some(true),
+                interval_secs: Some(90),
+                max_concurrent: Some(5),
+            }
+        );
+    }
+
+    #[test]
+    fn test_config_enabled_false_is_disabled_flag() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), r#"{"autonomous": {"workFinder": {"enabled": false}}}"#);
+        let cfg = read_work_finder_config(tmp.path());
+        assert_eq!(cfg.enabled, Some(false));
+        assert_eq!(cfg.interval_secs, None);
+        assert_eq!(cfg.max_concurrent, None);
+    }
+
+    #[test]
+    fn test_config_zero_interval_and_max_drop_to_none() {
+        // A zero interval/max in config is treated as absent so it falls through
+        // to the built-in default rather than a useless value.
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(
+            tmp.path(),
+            r#"{"autonomous": {"workFinder": {"enabled": true, "intervalSecs": 0, "maxConcurrent": 0}}}"#,
+        );
+        let cfg = read_work_finder_config(tmp.path());
+        assert_eq!(cfg.enabled, Some(true));
+        assert_eq!(cfg.interval_secs, None);
+        assert_eq!(cfg.max_concurrent, None);
+    }
+
+    // ===================================================================
+    // Config-file surface — resolve_* precedence env > config > default (#3813)
+    // ===================================================================
+
+    #[test]
+    #[serial]
+    fn test_resolve_enabled_precedence() {
+        std::env::remove_var(WORK_FINDER_ENABLE_ENV);
+
+        // Absent config + unset env ⇒ default off (zero behavior change).
+        assert!(!resolve_enabled(&WorkFinderConfig::default()));
+
+        // Config alone enables when env is unset.
+        let on = WorkFinderConfig {
+            enabled: Some(true),
+            ..Default::default()
+        };
+        assert!(resolve_enabled(&on));
+        let off = WorkFinderConfig {
+            enabled: Some(false),
+            ..Default::default()
+        };
+        assert!(!resolve_enabled(&off));
+
+        // Env overrides config in both directions.
+        std::env::set_var(WORK_FINDER_ENABLE_ENV, "1");
+        assert!(resolve_enabled(&off), "env truthy overrides config=false");
+        std::env::set_var(WORK_FINDER_ENABLE_ENV, "0");
+        assert!(!resolve_enabled(&on), "env falsy overrides config=true");
+        std::env::remove_var(WORK_FINDER_ENABLE_ENV);
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_interval_with_config_precedence() {
+        std::env::remove_var(WORK_FINDER_INTERVAL_ENV);
+
+        // Default when neither env nor config set.
+        assert_eq!(
+            resolve_interval_with_config(&WorkFinderConfig::default()),
+            Duration::from_secs(DEFAULT_WORK_FINDER_INTERVAL_SECS)
+        );
+
+        // Config used when env unset.
+        let cfg = WorkFinderConfig {
+            interval_secs: Some(120),
+            ..Default::default()
+        };
+        assert_eq!(resolve_interval_with_config(&cfg), Duration::from_secs(120));
+
+        // Env overrides config.
+        std::env::set_var(WORK_FINDER_INTERVAL_ENV, "45");
+        assert_eq!(resolve_interval_with_config(&cfg), Duration::from_secs(45));
+
+        // A zero/garbage env value is ignored; config still wins over default.
+        std::env::set_var(WORK_FINDER_INTERVAL_ENV, "0");
+        assert_eq!(resolve_interval_with_config(&cfg), Duration::from_secs(120));
+        std::env::set_var(WORK_FINDER_INTERVAL_ENV, "nope");
+        assert_eq!(resolve_interval_with_config(&cfg), Duration::from_secs(120));
+        std::env::remove_var(WORK_FINDER_INTERVAL_ENV);
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_max_concurrent_with_config_precedence() {
+        std::env::remove_var(WORK_FINDER_MAX_CONCURRENT_ENV);
+
+        // Default when neither env nor config set.
+        assert_eq!(
+            resolve_max_concurrent_with_config(&WorkFinderConfig::default()),
+            DEFAULT_WORK_FINDER_MAX_CONCURRENT
+        );
+
+        // Config used when env unset.
+        let cfg = WorkFinderConfig {
+            max_concurrent: Some(8),
+            ..Default::default()
+        };
+        assert_eq!(resolve_max_concurrent_with_config(&cfg), 8);
+
+        // Env overrides config.
+        std::env::set_var(WORK_FINDER_MAX_CONCURRENT_ENV, "2");
+        assert_eq!(resolve_max_concurrent_with_config(&cfg), 2);
+
+        // A zero/garbage env value is ignored; config still wins over default.
+        std::env::set_var(WORK_FINDER_MAX_CONCURRENT_ENV, "0");
+        assert_eq!(resolve_max_concurrent_with_config(&cfg), 8);
+        std::env::set_var(WORK_FINDER_MAX_CONCURRENT_ENV, "nope");
+        assert_eq!(resolve_max_concurrent_with_config(&cfg), 8);
+        std::env::remove_var(WORK_FINDER_MAX_CONCURRENT_ENV);
     }
 }


### PR DESCRIPTION
## Summary

Phase D of epic #3809 — the operator-facing layer on top of the autonomous engine (Phases A–C). Adds a committed config surface, safe start/stop wrappers for the raw daemon process, SIGTERM handling, and a documented+scripted end-to-end acceptance playbook.

## What's implemented

**1. Config surface (`.loom/config.json → autonomous`)**
- `read_work_finder_config()` in `work_finder.rs` and `read_autonomous_gate_config()` in `main_health_gate.rs`, both soft-failing exactly like `read_build_gate_config` (missing file / malformed JSON / missing block → no config value).
- Precedence **env > config > default** for every knob via `resolve_enabled` / `resolve_interval_with_config` / `resolve_max_concurrent_with_config`. An absent `autonomous` block is byte-for-byte the pre-#3813 env-only behavior.
- `LOOM_MAIN_HEALTH_GATE` stays the master override; `autonomous.mainHealthGate` only carries the on/off flag, so Phase C's tested `buildGate` command/timeout semantics are untouched.
- Wired into `main.rs` startup.

```json
{ "autonomous": {
    "workFinder": { "enabled": true, "intervalSecs": 60, "maxConcurrent": 5 },
    "mainHealthGate": { "enabled": true } } }
```

**2. SIGTERM handling** — the shutdown handler now awaits BOTH SIGINT and SIGTERM (`wait_for_shutdown_signal`), so a backgrounded daemon stopped via `kill <pid>` removes its socket cleanly just like Ctrl-C. Verified in a live start/stop smoke test (daemon exited cleanly within the grace window, no SIGKILL needed).

**3. Safe start/stop wrappers** (raw daemon process, distinct from the tmux `loom start|stop` pool):
- `defaults/scripts/cli/loom-daemon-start.sh` — locates the binary, runs the advisory host-sleep check (#3350), backgrounds the daemon, writes `.loom/.daemon.pid`, refuses a live second start, and surfaces the singleton-guard (#3806) refusal / startup-log tail on immediate exit. Flags: `--from-config`, `--no-work-finder`, `--no-health-gate`, `--foreground`.
- `defaults/scripts/cli/loom-daemon-stop.sh` — SIGTERM → grace → SIGKILL (`--force` for immediate).
- **Drain-vs-survive decision documented**: a clean stop leaves in-flight `/loom:sweep` children running (they survive a daemon restart by design; use `mcp__loom__cancel_sweep` to actively cancel).

**4. E2E acceptance** — `docs/autonomous-mode-e2e.md`: a repeatable playbook (`loom:triage` → Curator → `loom:issue` → work-finder dispatch → PR → merge with zero operator dispatch) including a **scripted `assert-e2e.sh` label-transition assertion**, not just a manual checklist.

**5. Docs** — `.loom/docs/daemon-reference.md` §Operability (config table, start/stop, shutdown decision), plus both `CLAUDE.md` and `defaults/CLAUDE.md` daemon-config sections.

## Scope deferred (per issue's decomposition guidance)

The **daemon-native status view** (new IPC `Request::DaemonStatus` variant + `loom-daemon status` CLI subcommand showing in-flight sweeps / pool-disk-ceiling inputs / halt state / per-token usage) is deferred to a tightly-scoped follow-up to keep this PR focused on the load-bearing operability gap (config + start/stop). The E2E playbook is NOT skipped — it ships documented with a scripted assertion. A follow-up issue will be filed for the status view.

## Tests

- New Rust unit tests (following the existing `#[serial]` env-var pattern):
  - `work_finder`: config soft-fail (missing file / malformed JSON / missing `autonomous` / missing `workFinder` / full block / `enabled:false` / zero-drops-to-none) + precedence for enabled/interval/maxConcurrent.
  - `main_health_gate`: config soft-fail + `resolve_enabled` precedence.
- `cargo test -p loom-daemon`: **583 passed, 0 failed**. `cargo clippy --all-targets`: clean.
- `bash -n` on both new scripts; live start → singleton-refusal → stop cycle exercised against an isolated socket.

## Test plan (manual, per issue)

- [x] Start via script with config-only enablement — work finder ticks (`work_finder: enabled` in `~/.loom/daemon.log`).
- [x] Second start refused cleanly (PID-file guard + singleton-guard surfacing).
- [x] Stop cleanly shuts down via SIGTERM (not just SIGINT).
- [x] Host-sleep advisory runs before start.
- [ ] Full live E2E run (requires live forge + crons) — documented playbook + scripted assertion provided.

Part of #3809.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #3813 (deferred status-view scope tracked separately in #3891).
