### PR TITLE
feat(daemon): daemon-native status view (loom-daemon status + IPC DaemonStatus)

### DIFF
--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -4,9 +4,10 @@ use crate::event_bus::EventBus;
 use crate::forge_parser::parse_forge_events;
 use crate::git_parser;
 use crate::git_utils;
+use crate::main_health_gate::MainHealthState;
 use crate::sweep_registry::{BeginCancel, SweepRegistry};
 use crate::terminal::TerminalManager;
-use crate::types::{Event, Request, Response};
+use crate::types::{DaemonStatusReport, Event, Request, Response};
 use anyhow::Result;
 use chrono::Utc;
 use std::path::{Path, PathBuf};
@@ -100,6 +101,10 @@ pub struct IpcServer {
     activity_db: Arc<Mutex<ActivityDb>>,
     sweep_registry: Arc<Mutex<SweepRegistry>>,
     event_bus: Arc<EventBus>,
+    /// Shared reactive main-health halt flag (#3812). Threaded into the IPC
+    /// server so the `DaemonStatus` request (#3891) can report the current
+    /// halt state — the same `Arc` the work-finder and gate loop share.
+    main_health_state: Arc<MainHealthState>,
 }
 
 impl IpcServer {
@@ -109,6 +114,7 @@ impl IpcServer {
         activity_db: Arc<Mutex<ActivityDb>>,
         sweep_registry: Arc<Mutex<SweepRegistry>>,
         event_bus: Arc<EventBus>,
+        main_health_state: Arc<MainHealthState>,
     ) -> Self {
         Self {
             socket_path,
@@ -116,6 +122,7 @@ impl IpcServer {
             activity_db,
             sweep_registry,
             event_bus,
+            main_health_state,
         }
     }
 
@@ -149,8 +156,9 @@ impl IpcServer {
                     let db = self.activity_db.clone();
                     let sr = self.sweep_registry.clone();
                     let bus = self.event_bus.clone();
+                    let health = self.main_health_state.clone();
                     tokio::spawn(async move {
-                        if let Err(e) = handle_client(stream, tm, db, sr, bus).await {
+                        if let Err(e) = handle_client(stream, tm, db, sr, bus, health).await {
                             log::error!("Client error: {e}");
                         }
                     });
@@ -169,6 +177,7 @@ async fn handle_client(
     activity_db: Arc<Mutex<ActivityDb>>,
     sweep_registry: Arc<Mutex<SweepRegistry>>,
     event_bus: Arc<EventBus>,
+    main_health_state: Arc<MainHealthState>,
 ) -> Result<()> {
     let (reader, mut writer) = stream.into_split();
     let mut lines = BufReader::new(reader).lines();
@@ -222,6 +231,21 @@ async fn handle_client(
                 Duration::from_secs(grace_secs),
             )
             .await;
+            let response_json = serde_json::to_string(&response)?;
+            writer.write_all(response_json.as_bytes()).await?;
+            writer.write_all(b"\n").await?;
+            continue;
+        }
+
+        // DaemonStatus (Issue #3891) is handled here rather than in the
+        // synchronous `handle_request` dispatcher because it reads the
+        // `main_health_state` halt flag, which the dispatcher does not receive.
+        // The report is cheap to build (a registry snapshot + a few pure
+        // filesystem reads for the dynamic-cap inputs); per-token usage is left
+        // to the CLI (a slow network probe) so this handler never blocks.
+        if let Request::DaemonStatus = request {
+            let report = build_daemon_status(&sweep_registry, &main_health_state);
+            let response = Response::DaemonStatus(report);
             let response_json = serde_json::to_string(&response)?;
             writer.write_all(response_json.as_bytes()).await?;
             writer.write_all(b"\n").await?;
@@ -379,6 +403,60 @@ async fn cancel_sweep_nonblocking(
         pid: outcome.pid,
         sigkill_sent: outcome.sigkill_sent,
         was_running: outcome.was_running,
+    }
+}
+
+/// Build the autonomous-mode operability snapshot for a `DaemonStatus` request
+/// (Issue #3891 — follow-up to #3813 Phase D).
+///
+/// Combines a live registry snapshot (in-flight = non-terminal sweeps) with the
+/// three dynamic-cap inputs recomputed from the workspace (token-pool size, disk
+/// headroom, configured ceiling) and the shared main-health-gate halt flag. The
+/// `min` of the three inputs is the effective dynamic cap the work finder would
+/// use on its next tick.
+///
+/// Per-token usage is intentionally excluded — probing each account for
+/// rate-limit headers is a slow network call the CLI performs client-side (via
+/// `loom-tokens check --json`), so this handler stays non-blocking.
+// Allow expect_used: a poisoned registry mutex means another thread panicked
+// while holding the lock — unrecoverable, so we crash (same policy as
+// `handle_request`).
+#[allow(clippy::expect_used)]
+pub fn build_daemon_status(
+    sweep_registry: &Arc<Mutex<SweepRegistry>>,
+    main_health_state: &MainHealthState,
+) -> DaemonStatusReport {
+    let (in_flight, workspace_root) = {
+        let sr = sweep_registry
+            .lock()
+            .expect("Sweep registry mutex poisoned");
+        // In-flight = sweeps still live (Pending / Running). Terminal sweeps
+        // (Exited / Crashed) linger in the registry but are not "in flight".
+        let in_flight = sr
+            .list(None)
+            .into_iter()
+            .filter(|info| !info.state.is_terminal())
+            .collect();
+        (in_flight, sr.config().workspace_root.clone())
+    };
+
+    let token_pool_size = crate::tokens::token_pool_size(&workspace_root);
+    let disk_headroom = crate::disk_headroom::disk_headroom_limit(&workspace_root);
+    let wf_config = crate::work_finder::read_work_finder_config(&workspace_root);
+    let configured_max = crate::work_finder::resolve_max_concurrent_with_config(&wf_config);
+    let dynamic_cap = crate::work_finder::resolve_dynamic_max_concurrent(
+        token_pool_size,
+        disk_headroom,
+        configured_max,
+    );
+
+    DaemonStatusReport {
+        in_flight,
+        token_pool_size,
+        disk_headroom,
+        configured_max,
+        dynamic_cap,
+        main_health_gate_halted: main_health_state.is_halted(),
     }
 }
 
@@ -1091,6 +1169,20 @@ fn handle_request(
             }
         }
 
+        Request::DaemonStatus => {
+            // DaemonStatus is intercepted in `handle_client` before it reaches
+            // this dispatcher because it needs the `main_health_state` halt flag
+            // (Issue #3891), which this synchronous dispatcher does not receive.
+            // Reaching this arm means the intercept was removed — fail loud so
+            // the mis-route is visible rather than silently returning a wrong
+            // (halt-unaware) report.
+            Response::Error {
+                message: "internal: DaemonStatus must be handled by build_daemon_status in \
+                          handle_client, not handle_request"
+                    .to_string(),
+            }
+        }
+
         Request::Shutdown => {
             log::info!("Shutdown requested");
             std::process::exit(0);
@@ -1777,6 +1869,96 @@ exit 0
 
         assert!(socket_has_live_listener(&sock).await);
         server.abort();
+    }
+
+    // ===== Autonomous daemon status (Issue #3891) =====
+
+    /// `Request::DaemonStatus` / `Response::DaemonStatus` must survive a serde
+    /// round-trip over the wire (pattern: the existing Ping/Pong probe + the
+    /// dispatch serde round-trips).
+    #[test]
+    fn test_daemon_status_request_response_round_trip() {
+        // Request: unit variant, `{"type":"DaemonStatus"}`.
+        let req = Request::DaemonStatus;
+        let json = serde_json::to_string(&req).expect("serialize request");
+        assert_eq!(json, r#"{"type":"DaemonStatus"}"#);
+        let back: Request = serde_json::from_str(&json).expect("deserialize request");
+        assert!(matches!(back, Request::DaemonStatus));
+
+        // Response: carries the full report.
+        let report = DaemonStatusReport {
+            in_flight: vec![],
+            token_pool_size: 4,
+            disk_headroom: 10,
+            configured_max: 5,
+            dynamic_cap: 4,
+            main_health_gate_halted: true,
+        };
+        let resp = Response::DaemonStatus(report);
+        let json = serde_json::to_string(&resp).expect("serialize response");
+        let back: Response = serde_json::from_str(&json).expect("deserialize response");
+        match back {
+            Response::DaemonStatus(r) => {
+                assert_eq!(r.token_pool_size, 4);
+                assert_eq!(r.disk_headroom, 10);
+                assert_eq!(r.configured_max, 5);
+                assert_eq!(r.dynamic_cap, 4);
+                assert!(r.main_health_gate_halted);
+                assert!(r.in_flight.is_empty());
+            }
+            other => panic!("Expected DaemonStatus, got: {other:?}"),
+        }
+    }
+
+    /// `build_daemon_status` reflects the shared main-health halt flag and lists
+    /// a live dispatched sweep as in-flight.
+    #[test]
+    #[serial_test::serial]
+    fn test_build_daemon_status_reports_halt_and_in_flight() {
+        use crate::main_health_gate::MainHealthState;
+
+        let (sr, _dir, _rec) = setup_sweep_registry_in_tempdir();
+
+        // Fresh state: not halted, no sweeps.
+        let health = MainHealthState::new();
+        let report = build_daemon_status(&sr, &health);
+        assert!(!report.main_health_gate_halted);
+        assert!(report.in_flight.is_empty());
+        // The tempdir has no `.loom/tokens/`, so the pool + dynamic cap are 0.
+        assert_eq!(report.token_pool_size, 0);
+        assert_eq!(report.dynamic_cap, 0);
+
+        // Dispatch a sweep -> it should show up as in-flight (Running).
+        {
+            let mut reg = sr.lock().unwrap();
+            reg.dispatch(&crate::types::SweepKind::Issue(3891), None, None, None, None)
+                .expect("dispatch");
+        }
+        let report = build_daemon_status(&sr, &health);
+        assert_eq!(report.in_flight.len(), 1);
+        assert!(matches!(report.in_flight[0].kind, crate::types::SweepKind::Issue(3891)));
+
+        // Flip the halt flag -> the report tracks it.
+        health.set_halted(true);
+        let report = build_daemon_status(&sr, &health);
+        assert!(report.main_health_gate_halted);
+    }
+
+    /// If `DaemonStatus` ever reaches the synchronous dispatcher (it is meant to
+    /// be intercepted in `handle_client`), it returns a loud Error sentinel.
+    #[test]
+    fn test_handle_request_daemon_status_short_circuits_to_error() {
+        let (tm, db, sr, bus) = setup_test_context();
+        let response = handle_request(Request::DaemonStatus, &tm, &db, &sr, &bus);
+        match response {
+            Response::Error { message } => {
+                assert!(
+                    message.contains("DaemonStatus must be handled by build_daemon_status"),
+                    "expected internal-bug error message; got: {message}"
+                );
+            }
+            other => panic!("Expected Error sentinel, got: {other:?}"),
+        }
     }
 
     #[test]

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -9,6 +9,7 @@ use loom_daemon::metrics_collector;
 use loom_daemon::role_validation;
 use loom_daemon::sweep_registry::{self, SweepRegistry, SweepRegistryConfig};
 use loom_daemon::terminal::TerminalManager;
+use loom_daemon::types::{DaemonStatusReport, Request, Response, SweepKind};
 use loom_daemon::work_finder;
 use loom_daemon::{extract_configured_terminal_ids, rotate_log_file};
 
@@ -16,9 +17,12 @@ use anyhow::{anyhow, Result};
 use clap::{Parser, Subcommand};
 use std::fs;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
 
 /// Loom daemon - terminal multiplexing and workspace orchestration
 #[derive(Parser)]
@@ -84,6 +88,17 @@ enum Commands {
         format: String,
     },
 
+    /// Show the running daemon's autonomous-mode status: in-flight sweeps, the
+    /// three dynamic-cap inputs (token-pool size, disk headroom, configured
+    /// ceiling) plus their `min` cap, the main-health-gate halt state, and
+    /// per-token usage. Connects to the running daemon over its Unix socket
+    /// (Issue #3891 — follow-up to #3813 Phase D).
+    Status {
+        /// Emit machine-readable JSON instead of the human-readable table.
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Validate role configuration completeness
     Validate {
         /// Workspace directory containing .loom/config.json
@@ -110,7 +125,12 @@ async fn main() -> Result<()> {
 
     // Handle CLI commands (init mode)
     if let Some(command) = cli.command {
-        return handle_cli_command(command);
+        return match command {
+            // `status` connects to the running daemon over its Unix socket, so
+            // it needs the async runtime (unlike the other sync subcommands).
+            Commands::Status { json } => handle_status_command(json).await,
+            other => handle_cli_command(other),
+        };
     }
 
     // Setup logging to ~/.loom/daemon.log
@@ -411,8 +431,17 @@ async fn main() -> Result<()> {
         None
     };
 
-    // Start IPC server
-    let server = IpcServer::new(socket_path.clone(), tm, activity_db, sweep_registry, event_bus);
+    // Start IPC server. `main_health_state` is threaded in so the `DaemonStatus`
+    // request (#3891) can report the reactive main-health-gate halt flag — the
+    // same `Arc` the work-finder and gate loop share above.
+    let server = IpcServer::new(
+        socket_path.clone(),
+        tm,
+        activity_db,
+        sweep_registry,
+        event_bus,
+        main_health_state.clone(),
+    );
 
     // Setup signal handler for graceful shutdown. We listen for BOTH SIGINT
     // (Ctrl-C, interactive) and SIGTERM (`kill <pid>`, the default signal a
@@ -546,6 +575,11 @@ fn handle_cli_command(command: Commands) -> Result<()> {
             weekly,
             format,
         } => handle_stats_command(role.as_deref(), issue, weekly, &format),
+        Commands::Status { .. } => {
+            // Routed directly in `main()` (it needs the async runtime for the
+            // socket round-trip), never dispatched through this sync handler.
+            unreachable!("Status is handled in main() before handle_cli_command")
+        }
         Commands::Init {
             workspace,
             defaults,
@@ -719,6 +753,235 @@ fn handle_cli_command(command: Commands) -> Result<()> {
                 }
             }
         }
+    }
+}
+
+/// Resolve the daemon's IPC socket path exactly as the running daemon does in
+/// `main()`: honour `LOOM_SOCKET_PATH` (test override) first, else
+/// `~/.loom/loom-daemon.sock`.
+fn resolve_socket_path() -> Result<PathBuf> {
+    if let Ok(path) = std::env::var("LOOM_SOCKET_PATH") {
+        return Ok(PathBuf::from(path));
+    }
+    let loom_dir = dirs::home_dir()
+        .ok_or_else(|| anyhow!("No home directory"))?
+        .join(".loom");
+    Ok(loom_dir.join("loom-daemon.sock"))
+}
+
+/// Connect to the running daemon over its Unix socket, send a single
+/// `DaemonStatus` request, and return the parsed report (Issue #3891).
+///
+/// Both the connect and the round-trip are individually bounded so an
+/// unresponsive/wedged daemon cannot hang the CLI. Errors when the daemon is
+/// unreachable (socket absent / not listening) or the response is malformed.
+async fn query_daemon_status(socket_path: &Path) -> Result<DaemonStatusReport> {
+    const TIMEOUT: Duration = Duration::from_secs(5);
+
+    let stream = tokio::time::timeout(TIMEOUT, UnixStream::connect(socket_path))
+        .await
+        .map_err(|_| anyhow!("connect timed out after {}s", TIMEOUT.as_secs()))?
+        .map_err(|e| anyhow!("connect failed: {e}"))?;
+    let (reader, mut writer) = stream.into_split();
+
+    let roundtrip = async move {
+        let request_json = serde_json::to_string(&Request::DaemonStatus)?;
+        writer.write_all(request_json.as_bytes()).await?;
+        writer.write_all(b"\n").await?;
+        writer.flush().await?;
+
+        let mut lines = BufReader::new(reader).lines();
+        let line = lines
+            .next_line()
+            .await?
+            .ok_or_else(|| anyhow!("daemon closed the connection without responding"))?;
+        let response: Response = serde_json::from_str(&line)?;
+        match response {
+            Response::DaemonStatus(report) => Ok(report),
+            Response::Error { message } => Err(anyhow!("daemon error: {message}")),
+            other => Err(anyhow!("unexpected response: {other:?}")),
+        }
+    };
+
+    tokio::time::timeout(TIMEOUT, roundtrip)
+        .await
+        .map_err(|_| anyhow!("status round-trip timed out after {}s", TIMEOUT.as_secs()))?
+}
+
+/// Collect per-token usage by shelling out to `loom-tokens check --json`,
+/// mirroring `probe-tokens.sh`: prefer the `loom-tokens` binary on PATH, else
+/// fall back to `python3 -m loom_tools.cli.loom_tokens`. Best-effort — returns
+/// `None` on any failure (binary absent, non-zero exit, unparseable output) so
+/// the status view still renders without the usage table.
+fn collect_token_usage() -> Option<serde_json::Value> {
+    let attempts: [(&str, &[&str]); 2] = [
+        ("loom-tokens", &["check", "--json"]),
+        ("python3", &["-m", "loom_tools.cli.loom_tokens", "check", "--json"]),
+    ];
+    for (bin, args) in attempts {
+        let Ok(output) = Command::new(bin).args(args).output() else {
+            continue;
+        };
+        if !output.status.success() {
+            continue;
+        }
+        if let Ok(value) = serde_json::from_slice::<serde_json::Value>(&output.stdout) {
+            return Some(value);
+        }
+    }
+    None
+}
+
+/// Handle the `status` subcommand — render the running daemon's autonomous-mode
+/// operability snapshot (Issue #3891). Fetches the daemon-native part over IPC
+/// and layers on the client-side per-token usage probe.
+async fn handle_status_command(json: bool) -> Result<()> {
+    let socket_path = resolve_socket_path()?;
+
+    let report = match query_daemon_status(&socket_path).await {
+        Ok(report) => report,
+        Err(e) => {
+            if json {
+                let err = serde_json::json!({
+                    "error": format!(
+                        "could not reach loom-daemon at {}: {e}",
+                        socket_path.display()
+                    ),
+                });
+                println!("{}", serde_json::to_string_pretty(&err)?);
+            } else {
+                eprintln!("Could not reach loom-daemon at {}: {e}", socket_path.display());
+                eprintln!();
+                eprintln!("Is the daemon running? Start it with:");
+                eprintln!("  ./.loom/scripts/cli/loom-daemon-start.sh");
+            }
+            std::process::exit(1);
+        }
+    };
+
+    // Per-token usage is a slow per-account network probe the daemon deliberately
+    // does NOT perform inside the IPC handler; collect it client-side here.
+    let token_usage = collect_token_usage();
+
+    if json {
+        print_status_json(&report, token_usage.as_ref())?;
+    } else {
+        print_status_human(&report, token_usage.as_ref());
+    }
+    Ok(())
+}
+
+/// Emit the combined status (daemon report + per-token usage) as JSON.
+fn print_status_json(
+    report: &DaemonStatusReport,
+    token_usage: Option<&serde_json::Value>,
+) -> Result<()> {
+    let combined = serde_json::json!({
+        "in_flight_count": report.in_flight.len(),
+        "in_flight": report.in_flight,
+        "dynamic_cap": {
+            "token_pool_size": report.token_pool_size,
+            "disk_headroom": report.disk_headroom,
+            "configured_max": report.configured_max,
+            "effective": report.dynamic_cap,
+        },
+        "main_health_gate": {
+            "halted": report.main_health_gate_halted,
+        },
+        "token_usage": token_usage,
+    });
+    println!("{}", serde_json::to_string_pretty(&combined)?);
+    Ok(())
+}
+
+/// Emit the combined status as a human-readable table.
+fn print_status_human(report: &DaemonStatusReport, token_usage: Option<&serde_json::Value>) {
+    println!("\n=== Loom Autonomous Daemon Status ===\n");
+
+    println!("In-flight sweeps: {}", report.in_flight.len());
+    if report.in_flight.is_empty() {
+        println!("  (none)");
+    } else {
+        println!("  {:<30} {:>7} {:>8}  {:<20} PHASE", "SWEEP", "ISSUE", "PID", "TOKEN");
+        println!("  {:-<75}", "");
+        for s in &report.in_flight {
+            let issue = match &s.kind {
+                SweepKind::Issue(n) => format!("#{n}"),
+                SweepKind::PrSet(_) => "prs".to_string(),
+            };
+            let phase = s.latest_phase.as_deref().unwrap_or("-");
+            println!(
+                "  {:<30} {:>7} {:>8}  {:<20} {}",
+                s.sweep_id, issue, s.pid, s.token_name, phase
+            );
+        }
+    }
+
+    println!("\nDynamic concurrency cap: {}", report.dynamic_cap);
+    println!(
+        "  = min(token pool {}, disk headroom {}, configured max {})",
+        report.token_pool_size, report.disk_headroom, report.configured_max
+    );
+
+    let gate = if report.main_health_gate_halted {
+        "HALTED (main is red — new dispatch paused; in-flight sweeps keep running)"
+    } else {
+        "clear (dispatch allowed)"
+    };
+    println!("\nMain-health gate: {gate}");
+
+    println!("\nPer-token usage:");
+    match token_usage {
+        Some(value) => print_token_usage_table(value),
+        None => println!(
+            "  (unavailable — `loom-tokens check --json` failed or the token pool is not bootstrapped)"
+        ),
+    }
+    println!();
+}
+
+/// Render the `loom-tokens check --json` report (`{ "accounts": [ { name,
+/// status, 5h_utilization, 7d_utilization, 7d_reset } ] }`) as a small table.
+/// Falls back to pretty-printed JSON if the shape is unexpected.
+fn print_token_usage_table(value: &serde_json::Value) {
+    let Some(accounts) = value.get("accounts").and_then(serde_json::Value::as_array) else {
+        // Unexpected shape — surface the raw JSON rather than dropping it.
+        if let Ok(pretty) = serde_json::to_string_pretty(value) {
+            for line in pretty.lines() {
+                println!("  {line}");
+            }
+        }
+        return;
+    };
+
+    if accounts.is_empty() {
+        println!("  (no accounts probed)");
+        return;
+    }
+
+    println!("  {:<22} {:<14} {:>8} {:>8}", "ACCOUNT", "STATUS", "5h", "7d");
+    println!("  {:-<54}", "");
+    for acct in accounts {
+        let name = acct
+            .get("name")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("?");
+        let status = acct
+            .get("status")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("?");
+        let fmt_pct = |key: &str| {
+            acct.get(key)
+                .and_then(serde_json::Value::as_f64)
+                .map_or_else(|| "-".to_string(), |u| format!("{:.0}%", u * 100.0))
+        };
+        println!(
+            "  {:<22} {:<14} {:>8} {:>8}",
+            name,
+            status,
+            fmt_pct("5h_utilization"),
+            fmt_pct("7d_utilization")
+        );
     }
 }
 

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -235,6 +235,19 @@ pub enum Request {
         /// arrives in the request.
         grace_secs: u64,
     },
+    // ========================================================================
+    // Autonomous Daemon Status (Issue #3891 — follow-up to #3813 Phase D)
+    // ========================================================================
+    /// Request the daemon's autonomous-mode operability snapshot: the live
+    /// in-flight sweeps, the three dynamic-cap inputs (token-pool size, disk
+    /// headroom, configured ceiling) plus their `min` cap, and the reactive
+    /// main-health-gate halt state.
+    ///
+    /// Per-token usage is deliberately NOT part of this response — probing each
+    /// account for rate-limit headers is a slow network call that would block
+    /// the IPC handler, so the `loom-daemon status` CLI shells out to
+    /// `loom-tokens check --json` client-side (mirroring `probe-tokens.sh`).
+    DaemonStatus,
     Shutdown,
 }
 
@@ -354,6 +367,12 @@ pub enum Response {
         sigkill_sent: bool,
         was_running: bool,
     },
+    // ========================================================================
+    // Autonomous Daemon Status (Issue #3891 — follow-up to #3813 Phase D)
+    // ========================================================================
+    /// Result of a `DaemonStatus` request — the autonomous-mode operability
+    /// snapshot rendered by `loom-daemon status`.
+    DaemonStatus(DaemonStatusReport),
     /// Legacy error response (deprecated, use `StructuredError` for new code)
     /// Kept for backwards compatibility with existing frontends
     Error {
@@ -504,6 +523,46 @@ pub struct SweepInfo {
     /// `#[serde(default)]` keeps pre-#3729 wire data and clients compatible.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub depends_on: Option<u32>,
+}
+
+// ========================================================================
+// Autonomous Daemon Status Types (Issue #3891 — follow-up to #3813 Phase D)
+// ========================================================================
+
+/// The autonomous-mode operability snapshot returned by `Request::DaemonStatus`
+/// and rendered by the `loom-daemon status` CLI subcommand.
+///
+/// This mirrors, at the daemon-native level, what the tmux-pool `loom status`
+/// shows for the terminal pool (#3735 precedent): what work is live and what
+/// the concurrency ceiling currently is. The per-token usage table the CLI also
+/// prints is NOT included here — it is a slow per-account network probe the CLI
+/// collects client-side via `loom-tokens check --json` (mirroring
+/// `probe-tokens.sh`), so the IPC handler stays fast.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DaemonStatusReport {
+    /// Sweeps in a non-terminal state (`Pending` / `Running`) at snapshot time.
+    /// The full `SweepInfo` is carried so the CLI can render issue numbers,
+    /// PIDs, token account, and latest phase without a second round-trip.
+    pub in_flight: Vec<SweepInfo>,
+    /// Dynamic-cap input 1: size of the multi-account token pool
+    /// (`.loom/tokens/*.token`), the hard ceiling on concurrent sweeps
+    /// (never over-subscribe an OAuth account). Via [`crate::tokens::token_pool_size`].
+    pub token_pool_size: usize,
+    /// Dynamic-cap input 2: how many worktrees the scratch volume can hold at
+    /// `LOOM_PER_WORKTREE_GB` each. Via [`crate::disk_headroom::disk_headroom_limit`].
+    pub disk_headroom: usize,
+    /// Dynamic-cap input 3: the configured operator ceiling
+    /// (`autonomous.workFinder.maxConcurrent` / `LOOM_WORK_FINDER_MAX_CONCURRENT`).
+    pub configured_max: usize,
+    /// The effective dynamic concurrency cap — `min` of the three inputs above
+    /// (`resolve_dynamic_max_concurrent`). This is the total-occupancy ceiling
+    /// the work finder recomputes every tick.
+    pub dynamic_cap: usize,
+    /// Whether autonomous dispatch is currently halted by the reactive
+    /// main-health gate (#3812). `true` means a red `main` has paused new
+    /// dispatch (in-flight sweeps keep running); `false` means dispatch is
+    /// allowed. Always `false` when the gate loop is not enabled.
+    pub main_health_gate_halted: bool,
 }
 
 // ========================================================================


### PR DESCRIPTION
Closes #3891

Follow-up to #3813 (Phase D of epic #3809). Implements **Option A** from #3813's Implementation Guidance §2: a daemon-native operability snapshot the operator can read directly, without an MCP client.

## What shipped

**New `loom-daemon status [--json]` subcommand** — connects to the running daemon over its Unix socket (`LOOM_SOCKET_PATH` override else `~/.loom/loom-daemon.sock`), sends a `DaemonStatus` request, and renders the snapshot. Bounded connect + round-trip (5s) so a wedged daemon can't hang the CLI. When the daemon is unreachable it prints a clear "start the daemon" hint and exits 1 (a JSON error object under `--json`).

**New IPC variant** — `Request::DaemonStatus` (unit) / `Response::DaemonStatus(DaemonStatusReport)`. The report carries:
- **In-flight sweeps** — the non-terminal (`Pending`/`Running`) `SweepInfo` entries, so the CLI renders issue numbers, PIDs, token account, and latest phase.
- **The three dynamic-cap inputs** — token-pool size (`tokens::token_pool_size`), disk headroom (`disk_headroom::disk_headroom_limit`), configured ceiling (`work_finder::resolve_max_concurrent_with_config`) — plus their `min` (`resolve_dynamic_max_concurrent`), the effective cap the work finder recomputes each tick.
- **Main-health-gate halt state** — read from the shared `MainHealthState` Arc (#3812), now threaded into `IpcServer`.

**Per-token usage** is collected **client-side** by shelling out to `loom-tokens check --json` (mirroring `probe-tokens.sh`, with the `python3 -m loom_tools.cli.loom_tokens` fallback). Rendered as a small ACCOUNT/STATUS/5h/7d table. It is deliberately kept out of the IPC handler so the slow per-account network probe never blocks the daemon.

`DaemonStatus` is intercepted in `handle_client` (like `CancelSweep`) since it needs `main_health_state`; the synchronous dispatcher keeps a loud `Error` sentinel arm to make any future mis-route visible.

## Deferred

Option B (an "Autonomous Pool" section in `defaults/scripts/cli/loom-status.sh`) was explicitly optional. It touches the distinct tmux-pool status surface with its own resync/doc-lint expectations, so it is left as a follow-up to keep this PR focused. The acceptance criteria are fully met by the subcommand + IPC + `--json` + tests.

## Tests

- `test_daemon_status_request_response_round_trip` — serde round-trip for the request (unit `{"type":"DaemonStatus"}`) and response (full report).
- `test_build_daemon_status_reports_halt_and_in_flight` — dispatches a sweep, asserts it appears in-flight, and that the halt flag tracks `MainHealthState`.
- `test_handle_request_daemon_status_short_circuits_to_error` — the dispatcher mis-route guard.

`cargo test -p loom-daemon`: **609 passed, 0 failed** (all suites green). `cargo build`, `cargo fmt`, and `cargo clippy -p loom-daemon` all clean. Smoke-tested the CLI human/JSON/help + unreachable-daemon paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)