### PR TITLE
fix(tokens): stale .ranking is advisory — skip exhausted accounts in autonomous mode (#3894)

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -616,6 +616,42 @@ is purely the on/off surface, so Phase C's already-tested `buildGate` semantics
 are untouched. `LOOM_MAIN_HEALTH_GATE` remains the master override; the config
 key just lets a repo turn the gate on without exporting an env var.
 
+### Prerequisite: a fresh token ranking (#3894)
+
+**When you run autonomous mode against a multi-account token pool, keep
+`.loom/tokens/.ranking` fresh — a periodic `probe-tokens.sh --ranking` is a
+required part of the setup, not an optional nicety.** The spawn-time selector
+(`loom_tools.tokens.select`) is 3-tier — ranking → allowlist → random — and the
+ranking file is only considered fresh for **10 minutes**. When it is absent or
+stale, tier-1 declines and selection falls to the lower tiers. The work finder
+dispatches in bursts, so a stale ranking means the daemon can steadily hand out
+accounts a recent probe already flagged `exhausted`/`blocked`, whose sweeps then
+wedge at startup (spawn header logged, no worktree, ~0% CPU) — the exact failure
+the startup watchdog (#3887) then has to self-heal, one hang at a time.
+
+Two things now keep this from wedging a burst of issues:
+
+- **Wire the probe on a `<10`-min cadence.** Add a cron entry so the ranking is
+  always fresh under the daemon's dispatch rate:
+
+  ```cron
+  */5 * * * * cd /path/to/repo && ./.loom/scripts/probe-tokens.sh --ranking >> .loom/logs/probe-tokens.log 2>&1
+  ```
+
+  (Use `*/5`, comfortably inside the 10-minute freshness window, rather than the
+  `*/10` boundary case from the single-key example.) One-shot before a run:
+  `loom-tokens check --ranking`.
+
+- **Stale-ranking fail-safe (selector-side, #3894).** Even without a fresh
+  probe, a stale-but-present `.ranking` is no longer discarded. The selector
+  treats its `exhausted`/`blocked` entries as an **advisory exclusion set** for
+  the allowlist and random tiers, so it stops degrading to fully-random
+  selection into known-exhausted accounts. If those exclusions would empty the
+  pool (a stale "everything exhausted" ranking), selection retries ignoring them
+  so a live pool never hard-fails on stale advice. This is a safety net, **not**
+  a replacement for the probe cron — a stale ranking still can't see an account
+  that recovered, so keep it fresh.
+
 ### Safe start / stop (raw daemon process)
 
 `.loom/bin/loom start|stop` manage the **tmux Manual-Orchestration-Mode pool** —

--- a/docs/autonomous-mode-e2e.md
+++ b/docs/autonomous-mode-e2e.md
@@ -19,6 +19,16 @@ crons — but the label-transition wait in Step 5 is a scripted assertion so the
 - `gh` authenticated against the target repo (`gh auth status`).
 - A multi-account token pool bootstrapped (`loom-tokens bootstrap`) if you want
   the daemon dispatch path to rotate accounts; a single token also works.
+- **A fresh token ranking, refreshed on a `<10`-min cadence (#3894).** With a
+  multi-account pool, wire `./.loom/scripts/probe-tokens.sh --ranking` on a cron
+  (e.g. `*/5 * * * *`) — or run `loom-tokens check --ranking` before starting —
+  so `.loom/tokens/.ranking` stays inside its 10-minute freshness window. A
+  stale/absent ranking makes the burst-dispatching work finder repeatedly select
+  exhausted accounts, wedging sweeps at startup. The selector has a stale-ranking
+  fail-safe (it excludes known-exhausted accounts from an aged ranking) but that
+  is a safety net, not a substitute for the probe — see
+  [`.loom/docs/daemon-reference.md`](../.loom/docs/daemon-reference.md)
+  §Operability → "Prerequisite: a fresh token ranking".
 - The `buildGate` block configured in `.loom/config.json` if you want the
   main-health gate active (optional for the loop itself).
 - The support roles reachable: either the GitHub Actions cron workflows enabled

--- a/loom-tools/src/loom_tools/tokens/select.py
+++ b/loom-tools/src/loom_tools/tokens/select.py
@@ -11,6 +11,16 @@ Selection order:
 
 In all tiers, tokens marked bad (via bad_tokens.is_bad) are skipped.
 
+Stale-ranking fail-safe (issue #3894): when ``.ranking`` exists but is older
+than the freshness window, tier-1 declines — but rather than discarding the
+ranking entirely and degrading to *fully-random* selection into accounts a
+recent probe already flagged ``exhausted``/``blocked`` (which wedges sweeps at
+startup), the stale ranking's exhausted/blocked entries are carried forward as
+an **advisory exclusion set** applied to the allowlist and random tiers. If the
+exclusions would empty the pool (e.g. a stale "everything exhausted" ranking),
+selection retries ignoring them so a live pool can never hard-fail on stale
+advice.
+
 This module is import-safe: no I/O occurs at import time. Both the daemon
 (via ``import``) and the bash wrapper (via ``python3 -m``) call
 ``select_token`` from concurrent processes.
@@ -226,18 +236,48 @@ def _try_ranking(
     return rng.choice(eligible)
 
 
+def _stale_ranking_exclusions(ranking_file: Path) -> set[str]:
+    """Advisory exclusion set sourced from a *stale* ``.ranking`` (issue #3894).
+
+    When ``.ranking`` is older than the freshness window, tier-1 (``_try_ranking``)
+    declines and selection would otherwise degrade to fully-random — repeatedly
+    handing out accounts a recent probe already flagged ``exhausted``/``blocked``,
+    wedging sweeps at startup. Rather than discard the stale ranking, treat its
+    exhausted/blocked entries as an advisory exclusion set for the lower tiers.
+
+    Returns an empty set when the ranking is fresh (tier-1 owns that case) or
+    missing/unreadable — so callers get exclusions *only* in the stale-but-present
+    window, and the pre-#3894 behavior is preserved everywhere else.
+    """
+    age = _file_age_seconds(ranking_file)
+    if age is None or age < _RANKING_FRESH_SECONDS:
+        return set()
+    return {
+        name
+        for name, status in _read_ranking(ranking_file)
+        if status in ("exhausted", "blocked")
+    }
+
+
 def _try_allowlist(
     tokens_dir: Path,
     allowlist_file: Path,
     workspace_path: Path,
     rng: random.Random,
+    exclude: frozenset[str] | set[str] = frozenset(),
 ) -> SelectedToken | None:
-    """Strategy 2: random pick from allowlist."""
+    """Strategy 2: random pick from allowlist.
+
+    ``exclude`` is an advisory set of account names to skip (stale-ranking
+    exhausted/blocked entries, issue #3894).
+    """
     if not allowlist_file.is_file():
         return None
     names = _read_allowlist(allowlist_file)
     eligible: list[Path] = []
     for name in names:
+        if name in exclude:
+            continue
         token_file = tokens_dir / f"{name}.token"
         if token_file.is_file() and not is_bad(workspace_path, name):
             eligible.append(token_file)
@@ -264,10 +304,17 @@ def _try_random(
     tokens_dir: Path,
     workspace_path: Path,
     rng: random.Random,
+    exclude: frozenset[str] | set[str] = frozenset(),
 ) -> SelectedToken | None:
-    """Strategy 3: random pick from all tokens."""
+    """Strategy 3: random pick from all tokens.
+
+    ``exclude`` is an advisory set of account names to skip (stale-ranking
+    exhausted/blocked entries, issue #3894).
+    """
     candidates = [
-        p for p in _list_token_files(tokens_dir) if not is_bad(workspace_path, p.stem)
+        p
+        for p in _list_token_files(tokens_dir)
+        if not is_bad(workspace_path, p.stem) and p.stem not in exclude
     ]
     if not candidates:
         return None
@@ -336,13 +383,33 @@ def select_token(
     if selected is not None:
         return selected
 
-    selected = _try_allowlist(tokens_dir, allowlist_file, workspace_path, rng)
+    # Tier-1 declined: .ranking is absent or stale. If a stale ranking exists,
+    # carry its exhausted/blocked entries forward as an advisory exclusion set
+    # so the lower tiers don't degrade to random selection into known-bad
+    # accounts (issue #3894). A fresh/missing ranking yields no exclusions.
+    exclude = _stale_ranking_exclusions(ranking_file)
+
+    selected = _try_allowlist(
+        tokens_dir, allowlist_file, workspace_path, rng, exclude=exclude,
+    )
     if selected is not None:
         return selected
 
-    selected = _try_random(tokens_dir, workspace_path, rng)
+    selected = _try_random(tokens_dir, workspace_path, rng, exclude=exclude)
     if selected is not None:
         return selected
+
+    # Fail-safe: the advisory exclusions emptied the pool (e.g. a stale
+    # "everything exhausted" ranking). Retry ignoring them so a live pool can
+    # never hard-fail on stale advice — better to spawn into a possibly-tired
+    # account than to refuse all work.
+    if exclude:
+        selected = _try_allowlist(tokens_dir, allowlist_file, workspace_path, rng)
+        if selected is not None:
+            return selected
+        selected = _try_random(tokens_dir, workspace_path, rng)
+        if selected is not None:
+            return selected
 
     raise EmptyTokenPoolError(
         f"All {len(all_tokens)} tokens in {tokens_dir} are marked bad or empty. "

--- a/loom-tools/tests/tokens/test_select.py
+++ b/loom-tools/tests/tokens/test_select.py
@@ -219,6 +219,74 @@ def test_stale_ranking_falls_through_to_random(tmp_path):
     assert sel.mode == "random"
 
 
+def _write_stale_ranking(workspace: Path, lines: list[str], age_secs: float) -> None:
+    """Write .ranking and backdate its mtime by *age_secs* seconds."""
+    rfile = workspace / ".loom" / "tokens" / ".ranking"
+    rfile.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    old = time.time() - age_secs
+    os.utime(rfile, (old, old))
+
+
+def test_stale_ranking_excludes_exhausted_from_random(tmp_path):
+    """A stale .ranking still excludes exhausted accounts from the random tier.
+
+    Regression for issue #3894: without this, an absent/stale ranking degraded
+    to fully-random selection and repeatedly handed out the exhausted account,
+    wedging sweeps at startup.
+    """
+    workspace = _make_workspace(tmp_path, {"tired": "kt", "fresh": "kf"})
+    # 11 minutes old — past the freshness window — with `tired` exhausted.
+    _write_stale_ranking(workspace, ["tired|exhausted", "fresh|"], 11 * 60)
+    for seed in range(30):
+        sel = select_token(workspace, rng=random.Random(seed))
+        assert sel.name == "fresh"  # never the exhausted account
+        assert sel.mode == "random"  # tier-1 declined (stale)
+
+
+def test_stale_ranking_excludes_blocked_from_random(tmp_path):
+    workspace = _make_workspace(tmp_path, {"blk": "kb", "ok": "ko"})
+    _write_stale_ranking(workspace, ["blk|blocked", "ok|"], 20 * 60)
+    for seed in range(20):
+        sel = select_token(workspace, rng=random.Random(seed))
+        assert sel.name == "ok"
+        assert sel.mode == "random"
+
+
+def test_stale_ranking_excludes_exhausted_from_allowlist(tmp_path):
+    """Stale-ranking exclusions also apply to the allowlist tier."""
+    workspace = _make_workspace(tmp_path, {"tired": "kt", "fresh": "kf"})
+    _write_allowlist(workspace, ["tired", "fresh"])
+    _write_stale_ranking(workspace, ["tired|exhausted", "fresh|"], 11 * 60)
+    for seed in range(20):
+        sel = select_token(workspace, rng=random.Random(seed))
+        assert sel.name == "fresh"
+        assert sel.mode == "allowlist"
+
+
+def test_stale_ranking_all_exhausted_falls_back_rather_than_hard_fail(tmp_path):
+    """A stale 'everything exhausted' ranking must not hard-fail a live pool.
+
+    The advisory exclusions empty the pool, so selection retries ignoring them
+    — returning a (possibly tired) token rather than raising EmptyTokenPoolError.
+    """
+    workspace = _make_workspace(tmp_path, {"a": "ka", "b": "kb"})
+    _write_stale_ranking(workspace, ["a|exhausted", "b|exhausted"], 30 * 60)
+    sel = select_token(workspace, rng=random.Random(0))
+    assert sel.name in ("a", "b")
+    assert sel.mode == "random"
+
+
+def test_stale_ranking_without_status_still_random_over_all(tmp_path):
+    """A stale ranking with no exhausted/blocked entries excludes nothing."""
+    workspace = _make_workspace(tmp_path, {"a": "ka", "b": "kb"})
+    _write_stale_ranking(workspace, ["a|", "b|"], 11 * 60)
+    chosen = {
+        select_token(workspace, rng=random.Random(seed)).name for seed in range(30)
+    }
+    # No exclusions => both accounts reachable via the random tier.
+    assert chosen == {"a", "b"}
+
+
 def test_ranking_with_comments_and_blank_lines(tmp_path):
     workspace = _make_workspace(tmp_path, {"a": "ka", "b": "kb"})
     _write_ranking(


### PR DESCRIPTION
## Summary

Autonomous daemon mode dispatches in bursts, but the token selector's
`.loom/tokens/.ranking` file is only considered fresh for 10 minutes. When it
went absent or stale, tier-1 (ranking) declined and selection degraded to
**fully-random**, repeatedly handing out accounts a recent probe had already
flagged `exhausted`/`blocked` — whose sweeps then wedged at startup (spawn
header logged, no worktree, ~0% CPU). This required ~6 manual cancel + re-dispatch
cycles in the reported incident.

## Changes

**Selector fail-safe (criterion b)** — `loom_tools/tokens/select.py`:
- When `.ranking` is **stale-but-present**, its `exhausted`/`blocked` entries are
  now carried forward as an **advisory exclusion set** applied to the allowlist
  and random tiers, instead of the ranking being discarded entirely. The selector
  no longer degrades to random selection into known-exhausted accounts.
- Fail-safe: if those exclusions would empty the pool (a stale "everything
  exhausted" ranking), selection **retries ignoring them** so a live pool can
  never hard-fail on stale advice — better to spawn into a tired account than
  refuse all work.
- A **fresh** ranking (tier-1 owns that case) and a **missing** ranking both
  yield no exclusions, so pre-existing behavior is preserved everywhere else.

**Freshness prerequisite documented (criteria a + c)**:
- `.loom/docs/daemon-reference.md` §Operability gains a "Prerequisite: a fresh
  token ranking (#3894)" subsection wiring `probe-tokens.sh --ranking` on a
  `<10`-min cron (`*/5`) as a required part of autonomous-mode setup, plus the
  selector-side fail-safe framed as a safety net (not a replacement for the probe).
- `docs/autonomous-mode-e2e.md` prerequisites list the ranking cron.

## Tests

New tests in `loom-tools/tests/tokens/test_select.py`:
- `test_stale_ranking_excludes_exhausted_from_random`
- `test_stale_ranking_excludes_blocked_from_random`
- `test_stale_ranking_excludes_exhausted_from_allowlist`
- `test_stale_ranking_all_exhausted_falls_back_rather_than_hard_fail`
- `test_stale_ranking_without_status_still_random_over_all`

```
PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/tokens/ -q
241 passed in 2.61s
```

All pre-existing selector tests (including `test_stale_ranking_falls_through_to_random`
and `test_ranking_falls_through_when_all_exhausted`) continue to pass unchanged.

Complements the startup-hang watchdog (#3892), which re-dispatches through the
same selector.

Closes #3894