### PR TITLE
fix(labels): reconcile root/defaults labels.yml drift + add CI parity check (#3896)

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -2,6 +2,15 @@
 # These labels coordinate the Loom AI agent workflow
 # Sync with: .loom/scripts/sync-labels.sh (from the installed repo root)
 # Or manually: gh label create/edit commands
+#
+# SOURCE OF TRUTH / PARITY CONTRACT (#3896):
+#   .github/labels.yml (this repo's live label registry) and
+#   defaults/.github/labels.yml (the installer template copied into fresh
+#   installs) are kept BYTE-IDENTICAL. A fresh install must ship exactly the
+#   label set Loom itself uses, so there are NO intentional differences between
+#   the two files. Edit ONE file, then mirror the change to the other so they
+#   match exactly. CI enforces parity via defaults/scripts/check-labels-drift.sh
+#   (installer-tests job) — the build fails on any drift.
 
 # Core Workflow States
 - name: loom:triage
@@ -111,13 +120,6 @@
   description: Issue is part of an epic phase (references parent epic)
   color: "8B5CF6"  # violet-500 - lighter variant for child issues
 
-# External Contribution Labels
-# Not part of the loom: workflow. Builders MUST skip issues carrying this label
-# (see builder.md "Ignore External Issues") — they need maintainer triage first.
-- name: external
-  description: External contribution requiring manual triage
-  color: "6B7280"  # gray-500 - neutral, non-loom-workflow marker
-
 # Tier Labels (Goal Alignment)
 - name: tier:goal-advancing
   description: Directly implements a milestone deliverable or unblocks goal work
@@ -132,6 +134,9 @@
   color: "D4C5F9"  # purple - lower priority
 
 # External Contribution Gate
+# Not part of the loom: workflow. Builders MUST skip issues carrying this label
+# (see builder.md "Ignore External Issues") — a non-collaborator submission needs
+# maintainer approval before Curator/Builder process it.
 - name: external
   description: "Submitted by a non-collaborator; requires maintainer approval before Curator/Builder process it. Applied by: humans only."
   color: "E5E7EB"  # gray-200 - external/hold marker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,5 +93,7 @@ jobs:
       - uses: actions/checkout@v7
       - name: Check role prompts reference only real labels (#3786)
         run: bash defaults/scripts/check-phantom-labels.sh
+      - name: Check labels.yml copies are in sync (#3896)
+        run: bash defaults/scripts/check-labels-drift.sh
       - name: Run installer tests
         run: bash scripts/test-installer.sh

--- a/defaults/.github/labels.yml
+++ b/defaults/.github/labels.yml
@@ -2,14 +2,23 @@
 # These labels coordinate the Loom AI agent workflow
 # Sync with: .loom/scripts/sync-labels.sh (from the installed repo root)
 # Or manually: gh label create/edit commands
+#
+# SOURCE OF TRUTH / PARITY CONTRACT (#3896):
+#   .github/labels.yml (this repo's live label registry) and
+#   defaults/.github/labels.yml (the installer template copied into fresh
+#   installs) are kept BYTE-IDENTICAL. A fresh install must ship exactly the
+#   label set Loom itself uses, so there are NO intentional differences between
+#   the two files. Edit ONE file, then mirror the change to the other so they
+#   match exactly. CI enforces parity via defaults/scripts/check-labels-drift.sh
+#   (installer-tests job) — the build fails on any drift.
 
 # Core Workflow States
 - name: loom:triage
-  description: New issue awaiting Curator enhancement
+  description: "New issue awaiting Curator enhancement. Applied by: humans or any agent filing a new issue (intake label)."
   color: "9CA3AF"  # gray-400 - neutral initial state
 
 - name: loom:issue
-  description: Approved for work by human (ready for Builder to claim)
+  description: "Approved for work by human (ready for Builder to claim). Applied by: humans or Champion."
   color: "3B82F6"  # blue-500
 
 # DEPRECATED: loom:in-progress removed (use role-specific labels)
@@ -20,44 +29,64 @@
 
 # Role-Specific Workflow Labels
 - name: loom:building
-  description: Builder is implementing this issue
+  description: "Builder is implementing this issue. Applied by: Builder/Shepherd only (claim label)."
   color: "F59E0B"  # amber-500 - matches other in-progress states
 
 - name: loom:curating
-  description: Curator is enhancing this issue
+  description: "Curator is enhancing this issue. Applied by: Curator only (claim label)."
   color: "F59E0B"  # amber-500 - matches other in-progress states
 
 - name: loom:treating
-  description: Doctor is fixing this bug or addressing PR feedback
+  description: "Doctor is fixing this bug or addressing PR feedback. Applied by: Doctor only (claim label)."
   color: "F59E0B"  # amber-500 - matches other in-progress states
 
 - name: loom:reviewing
-  description: Judge is actively reviewing this PR
+  description: "Judge is actively reviewing this PR. Applied by: Judge only (claim label)."
   color: "F59E0B"  # amber-500 - matches other in-progress states
 
 - name: loom:review-requested
-  description: PR ready for Judge to review
+  description: "PR ready for Judge to review. Applied by: Builder when opening PR."
   color: "10B981"  # emerald-500
 
 - name: loom:changes-requested
-  description: "PR requires changes before re-review (Judge requested modifications)"
+  description: "PR requires changes before re-review (Judge requested modifications). Applied by: Judge."
   color: "F59E0B"  # amber-500 - matches other "action required" labels
 
+- name: loom:merge-conflict
+  description: "PR has merge conflicts requiring resolution"
+  color: "DC2626"  # red-600 - indicates broken state
+
+- name: loom:auto-merge-ok
+  description: Override size limit for auto-merge (applied by Judge or human)
+  color: "10B981"  # emerald-500 - signals safe to proceed
+
+- name: loom:ci-failure
+  description: "PR has failing CI checks"
+  color: "DC2626"  # red-600 - indicates broken state
+
 - name: loom:pr
-  description: PR approved by Judge, ready for Champion auto-merge
+  description: "PR approved by Judge, ready for Champion auto-merge. Applied by: Judge."
   color: "3B82F6"  # blue-500
 
 # Agent Proposal Labels
 - name: loom:architect
-  description: Architect proposal awaiting user approval
+  description: "Architect proposal awaiting user approval. Applied by: Architect only."
   color: "9333EA"  # purple (violet-600)
 
 - name: loom:hermit
-  description: Hermit removal/simplification proposal awaiting user approval
+  description: "Hermit removal/simplification proposal awaiting user approval. Applied by: Hermit only."
   color: "9333EA"  # purple (violet-600)
 
+- name: loom:auditor
+  description: "Bug discovered by Auditor during main branch validation. Applied by: Auditor only."
+  color: "d93f0b"  # red - indicates runtime/build issue
+
+- name: loom:auditor-capability-request
+  description: Auditor capability request for enhanced validation tooling
+  color: "6366F1"  # indigo-500 - indicates meta/tooling request
+
 - name: loom:curated
-  description: "Curator-enriched. Additive marker; coexists with loom:issue (highest-quality state for Builders)"
+  description: "Curator-enriched, awaiting human approval. Additive marker; coexists with loom:issue (highest-quality state for Builders). Applied by: Curator only."
   color: "10B981"  # emerald-500
 
 # Status Labels
@@ -68,6 +97,19 @@
 - name: loom:urgent
   description: Critical/blocking issue requiring immediate attention
   color: "DC2626"  # red-600
+
+- name: loom:abort
+  description: Signal to abort shepherd for this issue (returns to loom:issue)
+  color: "F97316"  # orange-500 - warning/signal color
+
+# loom:operator-only vs loom:blocked: operator-only = a human must act OUTSIDE
+# automation (credentials, infra, hardware) and sweep/shepherd skip it entirely;
+# blocked = waiting on a dependency but otherwise automatable. Keep the
+# description at/under GitHub's 100-char label-description limit so sync-labels.sh
+# can create it (a longer description fails with HTTP 422 and the label never syncs).
+- name: loom:operator-only
+  description: "Requires human action outside automation (credentials, infra, hardware); sweep/shepherd skip"
+  color: "F97316"  # orange-500 - operator-action signal (matches loom:abort)
 
 # Epic Labels
 - name: loom:epic
@@ -92,6 +134,9 @@
   color: "D4C5F9"  # purple - lower priority
 
 # External Contribution Gate
+# Not part of the loom: workflow. Builders MUST skip issues carrying this label
+# (see builder.md "Ignore External Issues") — a non-collaborator submission needs
+# maintainer approval before Curator/Builder process it.
 - name: external
-  description: "Submitted by a non-collaborator; requires maintainer approval before Curator/Builder process it"
+  description: "Submitted by a non-collaborator; requires maintainer approval before Curator/Builder process it. Applied by: humans only."
   color: "E5E7EB"  # gray-200 - external/hold marker

--- a/defaults/scripts/check-labels-drift.sh
+++ b/defaults/scripts/check-labels-drift.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# check-labels-drift.sh - Fail if the two label registries drift apart.
+#
+# Why (#3896): Loom ships the label registry in TWO places —
+#   - <root>/.github/labels.yml          (this repo's live label registry)
+#   - <root>/defaults/.github/labels.yml (the installer template copied into
+#                                         fresh installs)
+# These are supposed to describe the same label set: a fresh install must ship
+# exactly the labels Loom itself uses. But they are two hand-edited files with
+# no automated tie, so they silently drifted — `loom:auditor`,
+# `loom:auditor-capability-request`, `loom:merge-conflict`, `loom:auto-merge-ok`,
+# `loom:ci-failure`, `loom:abort`, `loom:operator-only` were all present in the
+# root copy but missing from the defaults template, and many descriptions had
+# diverged. A fresh install then shipped a label set that differed from the
+# source repo's. This check is the tie that prevents recurrence.
+#
+# Source-of-truth decision (documented in the header of both labels.yml files):
+# the two files are kept BYTE-IDENTICAL. There are NO intentional differences —
+# so the drift check is a plain `diff`. Edit one file, mirror the change to the
+# other. If a future need arises for the template to legitimately differ from the
+# repo copy, that is an explicit design change: update this check (and the parity
+# note in both file headers) in the same PR that introduces the divergence.
+#
+# Usage:
+#   check-labels-drift.sh [ROOT]
+#     ROOT  Repository root containing defaults/ and .github/labels.yml.
+#           Defaults to `git rev-parse --show-toplevel`, then the script's own
+#           repo root. If <ROOT>/defaults does not exist (e.g. an installed
+#           downstream repo with no source tree), the check is a clean no-op.
+#
+# Exit codes: 0 = files identical (or nothing to check); 1 = drift detected
+# (unified diff printed to stderr).
+
+set -euo pipefail
+
+# --- Resolve ROOT -----------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ $# -ge 1 && -n "${1:-}" ]]; then
+  ROOT="$1"
+else
+  if ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)"; then
+    :
+  else
+    # defaults/scripts/ -> defaults/ -> repo root
+    ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+  fi
+fi
+
+ROOT_LABELS="$ROOT/.github/labels.yml"
+DEFAULTS_LABELS="$ROOT/defaults/.github/labels.yml"
+
+# --- Skip when there is nothing to compare ----------------------------------
+if [[ ! -d "$ROOT/defaults" ]]; then
+  # Not a Loom source tree (e.g. an installed repo). Nothing to check.
+  echo "check-labels-drift: no defaults/ under $ROOT — nothing to check (ok)."
+  exit 0
+fi
+
+if [[ ! -f "$ROOT_LABELS" ]]; then
+  echo "check-labels-drift: missing $ROOT_LABELS — cannot compare." >&2
+  exit 1
+fi
+
+if [[ ! -f "$DEFAULTS_LABELS" ]]; then
+  echo "check-labels-drift: missing $DEFAULTS_LABELS — cannot compare." >&2
+  exit 1
+fi
+
+# --- Compare (must be byte-identical) ---------------------------------------
+if diff -u "$ROOT_LABELS" "$DEFAULTS_LABELS" >/dev/null 2>&1; then
+  echo "check-labels-drift: OK — .github/labels.yml and defaults/.github/labels.yml are identical."
+  exit 0
+fi
+
+echo "check-labels-drift: FAIL — the two label registries have drifted:" >&2
+echo "  A: ${ROOT_LABELS#"$ROOT"/}" >&2
+echo "  B: ${DEFAULTS_LABELS#"$ROOT"/}" >&2
+echo "" >&2
+# --label makes the unified-diff header name each side clearly.
+diff -u --label "a/.github/labels.yml" --label "b/defaults/.github/labels.yml" \
+  "$ROOT_LABELS" "$DEFAULTS_LABELS" >&2 || true
+echo "" >&2
+echo "These files must be BYTE-IDENTICAL (see the parity-contract header in each" >&2
+echo "labels.yml). Reconcile them — edit one and mirror the change to the other —" >&2
+echo "then re-run this check." >&2
+exit 1

--- a/defaults/scripts/check-phantom-labels.sh
+++ b/defaults/scripts/check-phantom-labels.sh
@@ -26,10 +26,11 @@
 # `/loom:sweep` command) does not trip the check.
 #
 # Registry: the UNION of label names in `<root>/.github/labels.yml` and
-# `<root>/defaults/.github/labels.yml`. The union is used deliberately — the two
-# files have drifted (the installer template is a subset of the repo copy), and
-# reconciling them is out of scope for #3786; a label defined in either file is
-# real, and a phantom label is absent from BOTH.
+# `<root>/defaults/.github/labels.yml`. A label defined in either file is real,
+# and a phantom label is absent from BOTH. As of #3896 the two files are kept
+# BYTE-IDENTICAL (enforced by defaults/scripts/check-labels-drift.sh), so the
+# union now equals either file on its own; it is retained here defensively so
+# this lint stays correct even if the two copies transiently diverge.
 #
 # Usage:
 #   check-phantom-labels.sh [ROOT]

--- a/scripts/test-installer.sh
+++ b/scripts/test-installer.sh
@@ -2590,6 +2590,45 @@ fi
 echo ""
 
 # ==========================================================================
+# Test: check-labels-drift.sh (root vs defaults labels.yml parity, #3896)
+# ==========================================================================
+echo "Test: check-labels-drift.sh detects drift and passes the in-sync real tree"
+DRIFT_LINT="$DEFAULTS_DIR/scripts/check-labels-drift.sh"
+if [[ ! -x "$DRIFT_LINT" ]]; then
+  fail "check-labels-drift.sh missing or not executable"
+else
+  # (a) The real tree ships the two labels.yml copies byte-identical.
+  if bash "$DRIFT_LINT" "$LOOM_ROOT" >/dev/null 2>&1; then
+    pass "check-labels-drift passes against the real (in-sync) tree"
+  else
+    fail "check-labels-drift flagged the real tree (labels.yml copies should match)"
+  fi
+
+  # (b) A fixture whose defaults/ copy is missing a label must fail.
+  DRIFT_FIX="$(mktemp -d)"
+  mkdir -p "$DRIFT_FIX/.github" "$DRIFT_FIX/defaults/.github"
+  cp "$LOOM_ROOT/.github/labels.yml" "$DRIFT_FIX/.github/labels.yml"
+  grep -v 'loom:auditor-capability-request' "$LOOM_ROOT/.github/labels.yml" \
+    > "$DRIFT_FIX/defaults/.github/labels.yml"
+  DRIFT_OUT="$(bash "$DRIFT_LINT" "$DRIFT_FIX" 2>&1)" && DRIFT_RC=0 || DRIFT_RC=$?
+  if [[ "$DRIFT_RC" -ne 0 ]] && echo "$DRIFT_OUT" | grep -q "drifted"; then
+    pass "check-labels-drift fails (exit $DRIFT_RC) when the copies diverge"
+  else
+    fail "check-labels-drift did not catch the injected drift (rc=$DRIFT_RC)"
+  fi
+
+  # (c) The same fixture with identical copies must pass.
+  cp "$LOOM_ROOT/.github/labels.yml" "$DRIFT_FIX/defaults/.github/labels.yml"
+  if bash "$DRIFT_LINT" "$DRIFT_FIX" >/dev/null 2>&1; then
+    pass "check-labels-drift passes when the two copies are identical"
+  else
+    fail "check-labels-drift false-positived on identical copies"
+  fi
+  rm -rf "$DRIFT_FIX"
+fi
+echo ""
+
+# ==========================================================================
 # Summary
 # ==========================================================================
 echo "======================================"


### PR DESCRIPTION
## Summary

The label registry ships in two places with no automated tie, so they had silently drifted:
- **`.github/labels.yml`** — this repo's live label registry (authoritative)
- **`defaults/.github/labels.yml`** — the installer template copied into fresh installs

The `defaults/` copy was missing seven labels (`loom:auditor`, `loom:auditor-capability-request`, `loom:merge-conflict`, `loom:auto-merge-ok`, `loom:ci-failure`, `loom:abort`, `loom:operator-only`) and many descriptions had diverged. A fresh install therefore shipped a different label set than the source repo. Root also carried a shadowed **duplicate `external`** label (two entries; last-wins meant the first was dead).

## Source-of-truth decision

The two files are kept **byte-identical** — a fresh install must ship exactly the label set Loom itself uses, so there are no intentional differences. This makes the drift check a trivial, unambiguous `diff`. The decision is documented in a shared parity-contract header comment in **both** `labels.yml` files.

## Changes

- **Reconcile** `defaults/.github/labels.yml` to be byte-identical to `.github/labels.yml` (adds the 7 missing labels + aligns all descriptions).
- **Collapse** root's duplicate `external` label into the single winning gate entry, preserving the builder-skip note.
- **Add** `defaults/scripts/check-labels-drift.sh` — a `diff`-based drift check following `check-phantom-labels.sh` conventions (git-toplevel ROOT resolution, clean no-op when `defaults/` is absent, exits 1 with a unified diff on drift).
- **Wire** it into the CI `installer-tests` job next to the phantom-labels check.
- **Test** coverage in `scripts/test-installer.sh`: passes on the in-sync tree, fails on injected drift, passes again when re-synced.
- **Refresh** the now-stale "files have drifted / out of scope" comment in `check-phantom-labels.sh`.

## Verification

- `check-labels-drift.sh` prints OK on the reconciled tree (exit 0) and FAILs with a unified diff on a fixture missing a label (exit 1) — both directions verified locally.
- `shellcheck` clean on the new script; `check-phantom-labels.sh` still passes on the reconciled tree.
- `bash -n` clean on the edited `test-installer.sh`.

## Caveats

- `quickstarts/*/.github/labels.yml` (three sample-app label files) are intentionally **out of scope** — they belong to separate example apps, not the root/defaults pair this issue concerns.

Closes #3896

🤖 Generated with [Claude Code](https://claude.com/claude-code)