### PR TITLE
fix(daemon): reap-on-read so ListSweeps no longer over-reports Running (#3893)

### DIFF
--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -1075,9 +1075,13 @@ fn handle_request(
         }
 
         Request::ListSweeps { state_filter } => {
-            let sr = sweep_registry
+            let mut sr = sweep_registry
                 .lock()
                 .expect("Sweep registry mutex poisoned");
+            // Reap-on-read (Issue #3893): reconcile liveness before listing so a
+            // sweep whose child has already exited is never reported `Running`
+            // just because the 30s reaper timer has not ticked yet.
+            sr.reap_liveness();
             let sweeps = sr.list(state_filter.as_ref());
             Response::SweepList { sweeps }
         }
@@ -1086,9 +1090,12 @@ fn handle_request(
         // Sweep Monitoring Handlers (Issue #3455 — Phase C of #3449)
         // ====================================================================
         Request::GetSweepStatus { sweep_id } => {
-            let sr = sweep_registry
+            let mut sr = sweep_registry
                 .lock()
                 .expect("Sweep registry mutex poisoned");
+            // Reap-on-read (Issue #3893): reconcile liveness so a status query
+            // reflects a child that has exited rather than a stale `Running`.
+            sr.reap_liveness();
             let info = sr.get_status(&sweep_id);
             Response::SweepStatus { info }
         }
@@ -1196,7 +1203,7 @@ mod tests {
     use super::*;
     use crate::activity::ActivityDb;
     use crate::sweep_registry::{SweepRegistry, SweepRegistryConfig};
-    use crate::types::{SweepKind, SweepState};
+    use crate::types::SweepKind;
     use tempfile::tempdir;
 
     type TestContext = (
@@ -1453,13 +1460,21 @@ exit 0
             other => panic!("Expected SweepDispatched, got: {other:?}"),
         }
 
-        // Follow-up ListSweeps should see the new entry.
+        // Follow-up ListSweeps should see the new entry. The fake spawn exits
+        // immediately, so reap-on-read (Issue #3893) promptly reconciles the
+        // entry to a terminal `Exited` state rather than over-reporting it as
+        // `Running` — the entry is still listed, just no longer stale-Running.
         let response =
             handle_request(Request::ListSweeps { state_filter: None }, &tm, &db, &sr, &bus);
         match response {
             Response::SweepList { sweeps } => {
                 assert_eq!(sweeps.len(), 1);
-                assert!(matches!(sweeps[0].state, SweepState::Running));
+                assert!(
+                    sweeps[0].state.is_terminal(),
+                    "reap-on-read should have transitioned the exited fake child \
+                     out of Running (#3893); got {:?}",
+                    sweeps[0].state
+                );
             }
             other => panic!("Expected SweepList, got: {other:?}"),
         }

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -1657,6 +1657,25 @@ impl SweepRegistry {
         changes
     }
 
+    /// Promptly reconcile sweep liveness on a **read path** (Issue #3893).
+    ///
+    /// `ListSweeps` / `GetSweepStatus` / the work-finder occupancy seed call
+    /// this before reading, so a caller never observes a sweep as `Running`
+    /// after its child has already exited. Before #3893 the only path out of
+    /// `Running` was the 30s [`reap_once`](Self::reap_once) timer, so a read
+    /// taken between a child's exit and the next tick over-reported active work
+    /// (the registry accumulated stale `Running` entries across a burst of
+    /// merges). Reap-on-read bounds that staleness window to the read itself.
+    ///
+    /// This performs exactly the same liveness `try_wait` + terminal transition
+    /// (and best-effort event/label side effects) the background timer does; on
+    /// a steady-state read with no newly-exited children it is just one cheap
+    /// `try_wait` per running entry and no side effects. Returns the number of
+    /// entries reaped.
+    pub fn reap_liveness(&mut self) -> usize {
+        self.reap_once()
+    }
+
     // ------------------------------------------------------------------------
     // Startup watchdog (Issue #3887)
     // ------------------------------------------------------------------------
@@ -4579,6 +4598,56 @@ exit 0\n";
         assert!(
             wait_until_dead(pid, 2000),
             "killed child left a <defunct> zombie — reaper did not wait() it"
+        );
+    }
+
+    /// Issue #3893: a read path (`reap_liveness`, wired into `ListSweeps` /
+    /// `GetSweepStatus` / the work-finder occupancy seed) must transition a
+    /// sweep whose child has already exited out of `Running` promptly —
+    /// bounded to seconds — WITHOUT waiting for the 30s reaper timer. This is
+    /// the regression that made `list_sweeps` over-report active work across a
+    /// burst of merges.
+    #[test]
+    #[serial]
+    fn read_path_reaps_exited_child_out_of_running_promptly() {
+        let dir = tempdir().unwrap();
+        let workspace = dir.path();
+
+        // A fake spawn that exits immediately: mirrors a sweep whose lifecycle
+        // has completed (PR merged) and whose process has already exited.
+        let mut registry = lifecycle_registry(workspace, "#!/usr/bin/env bash\nexit 0\n");
+
+        let outcome = registry
+            .dispatch(&SweepKind::Issue(4242), None, None, None, None)
+            .expect("dispatch should succeed");
+        let sweep_id = outcome.sweep_id.clone();
+
+        // Reap-on-read reconciles liveness via the retained handle's
+        // `try_wait()`. Bound the loop to ~2s to prove "prompt" — a healthy
+        // implementation transitions on the first reconcile once the child has
+        // exited (`try_wait` reaps the zombie and yields the exit status).
+        let mut still_running = true;
+        for _ in 0..80 {
+            registry.reap_liveness();
+            let running = registry.list(Some(&SweepState::Running));
+            if !running.iter().any(|i| i.sweep_id == sweep_id) {
+                still_running = false;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        assert!(
+            !still_running,
+            "exited child still reported Running after a read-path reconcile (#3893)"
+        );
+        assert!(
+            matches!(registry.get(&sweep_id).unwrap().state, SweepState::Exited { .. }),
+            "exited child should have transitioned to terminal Exited state"
+        );
+        // And it should no longer count as in-flight for occupancy accounting.
+        assert!(
+            registry.list(Some(&SweepState::Running)).is_empty(),
+            "no sweep should remain Running after the exited child was reaped"
         );
     }
 

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -708,13 +708,17 @@ pub mod forge {
 
     impl WorkDispatcher for RegistryDispatcher {
         fn in_flight(&self) -> HashSet<u32> {
-            let reg = match self.registry.lock() {
+            let mut reg = match self.registry.lock() {
                 Ok(r) => r,
                 Err(poisoned) => {
                     log::error!("work_finder: sweep registry mutex poisoned ({poisoned:?})");
                     return HashSet::new();
                 }
             };
+            // Reap-on-read (Issue #3893): reconcile liveness before seeding
+            // occupancy so a sweep whose child has exited does not over-count
+            // against the concurrency budget and defer legitimate new dispatch.
+            reg.reap_liveness();
             let mut set = HashSet::new();
             for state in [SweepState::Running, SweepState::Pending] {
                 for info in reg.list(Some(&state)) {


### PR DESCRIPTION
## Summary

`mcp__loom__list_sweeps` / the `ListSweeps` IPC repeatedly reported sweeps as `Running` long after their PRs merged and their processes exited. The registry only transitioned exited/merged sweeps out of `Running` on the **30s reaper timer**, so a read taken between a child's exit and the next tick over-reported active work. Across a burst of merges the registry accumulated stale `Running` entries, and any concurrency accounting derived from the live registry (the work-finder occupancy seed / `in_flight()`) could over-count and defer legitimate new dispatch.

## Design

**Reap-on-read.** New `SweepRegistry::reap_liveness()` performs exactly the same `try_wait`-based liveness poll + terminal transition (and best-effort label/event side effects) the background timer does. It is called before every read path:

- `ListSweeps` IPC handler
- `GetSweepStatus` IPC handler
- work-finder occupancy seed (`RegistryDispatcher::in_flight`)

This **bounds the staleness window to the read itself**: a sweep whose child has exited is reaped promptly instead of after up to 30s, so a read never over-reports a genuinely-exited child as `Running`. On a steady-state read with no newly-exited children it is just one cheap `try_wait` per running entry with no side effects. The 30s reaper timer remains as the background GC fallback (it also drops terminal entries past the 1h retention window). `SweepState` already distinguishes terminal states (`Exited` / `Crashed`), so recently-exited sweeps still appear in the list — just no longer as stale `Running`.

No new event topics were introduced (the taxonomy is frozen); this reuses `reap_once`'s existing liveness/transition/event logic.

## Tests

- New `read_path_reaps_exited_child_out_of_running_promptly`: dispatches a fake child that exits immediately, then asserts a read-path reconcile transitions it out of `Running` (to terminal `Exited`) within ~2s — the acceptance-criterion "exited child is no longer reported Running within N seconds."
- Updated `test_handle_request_dispatch_sweep_happy_path`: with reap-on-read, the instantly-exiting fake child is now correctly reported terminal (still listed, `len == 1`), not stale-`Running`.

Full `cargo test` suite passes (610 lib tests + integration suites, 0 failures); `cargo fmt` applied and `cargo clippy --all-targets` is clean.

Complements the startup-hang watchdog (#3892) — both are about the registry/reaper accurately reflecting sweep liveness.

Closes #3893