### PR TITLE
feat(daemon): token-capacity backpressure — slow down on token limits, alert to add capacity, recover gracefully (#3902)

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -112,10 +112,16 @@ issue** — the v0.10.0 set is intentionally frozen.
 | `epic.issue.{N}.expand`    | Epic supervisor (#3842)        | `{epic, action, state}` |
 | `epic.issue.{N}.join`      | Epic supervisor (#3842)        | `{epic, action, state}` |
 | `epic.issue.{N}.close`     | Epic supervisor (#3842)        | `{epic, action, state}` |
+| `daemon.capacity.advisory` | Work finder (#3902)            | `{pressured, queued, healthy_accounts, exhausted_accounts, total_accounts, estimated_drain_minutes?, message}` |
 
 The four `epic.issue.{N}.*` topics were authorized by **#3873** (epic #3842
 Phase 4) and are documented in full under [Epic supervisor](#epic-supervisor-3842)
-below. They ride the same in-memory bus as the sweep topics and are tailable via
+below. The `daemon.capacity.advisory` topic was authorized by **#3902** (epic
+#3809): the autonomous work finder publishes it on a token-capacity **pressure
+state change** (entered/left the token-bound state), never every tick, so the
+operator gets one add-capacity advisory on the way in and one recovery on the way
+out. See [Token-capacity backpressure](#token-capacity-backpressure-3902) below.
+They ride the same in-memory bus as the sweep topics and are tailable via
 `subscribe_to_events` / `tail_event_bus`.
 
 In addition, the bus internally emits:
@@ -505,7 +511,7 @@ The concurrency cap is **not** a fixed value resolved once at startup. Every
 tick the finder recomputes
 
 ```
-dynamic_cap = min(token-pool size, disk headroom, configured ceiling)
+dynamic_cap = min(healthy-token count, disk headroom, configured ceiling)
 ```
 
 from three live inputs, so pool/disk/backlog changes are honored without a
@@ -513,7 +519,7 @@ daemon restart:
 
 | Input | Source | Bound it enforces |
 |-------|--------|-------------------|
-| **token-pool size** | count of `*.token` files in `{workspace}/.loom/tokens/` (`tokens::token_pool_size`) | never over-subscribe a rotated OAuth account — one live sweep per usable account |
+| **healthy-token count** | `available` accounts in `{workspace}/.loom/tokens/.ranking` (`capacity::token_axis_limit`), falling back to the `*.token` count (`tokens::token_pool_size`) when no ranking exists | never over-subscribe a rotated OAuth account, and never dispatch to an exhausted/blocked one (#3902) — one live sweep per **healthy** account |
 | **disk headroom** | `floor(free_gb / LOOM_PER_WORKTREE_GB)` on the worktree-root volume (`disk_headroom::disk_headroom_limit`, a Rust port of `disk-headroom.sh` that shells to `df -Pk`) | never provision more worktrees than the scratch volume can hold |
 | **configured ceiling** | `LOOM_WORK_FINDER_MAX_CONCURRENT` (repurposed from Phase A's fixed target into an operator ceiling) | hard operator upper bound regardless of pool/disk headroom |
 
@@ -549,6 +555,48 @@ unparseable value for any of these falls back to its default.
 > cadence remains out of scope (follow-up #3381). So "the daemon does not
 > generate work" below still holds — the finder only closes the gap between an
 > approved issue and its build.
+
+### Token-capacity backpressure (#3902)
+
+At scale, rotation accounts hit their 5h/7d rate limits and go `exhausted`.
+Dispatching to an exhausted account produces startup hangs / mid-build deaths, so
+the finder treats a genuine token limit as a **capacity signal** — slow down,
+alert, recover — all automatic and non-blocking:
+
+1. **Slow down (backpressure).** The token axis of the dynamic cap is the count
+   of **healthy** (`available`) accounts read from `.loom/tokens/.ranking`
+   (`capacity::token_axis_limit`), not the flat `*.token` count. When accounts go
+   exhausted the cap backs off toward the healthy count; when *every* account is
+   exhausted it drops to 0 and the finder **defers** the queue rather than
+   hammering an exhausted account. A single healthy account is the throughput
+   **floor**, never a halt. When no `.ranking` file exists (no probe has run) the
+   axis falls back to the raw pool size — byte-for-byte the pre-#3902 behavior.
+2. **Alert (add capacity).** When the token axis is the *binding* constraint
+   (≤ disk and ≤ ceiling) and work is queued behind it, the finder is
+   *token-bound*. On the **state change** into that state it emits an
+   add-capacity advisory naming concrete levers — add accounts to
+   `~/.claude-monitor/accounts.env` + `loom-tokens bootstrap`, or buy API
+   credits, then `loom-tokens check --ranking` — with the current numbers
+   (queued count, healthy/total accounts, exhausted count, estimated drain time
+   at current capacity). The advisory surfaces on **three** channels: the daemon
+   log (`warn`), the `daemon.capacity.advisory` event-bus topic, and the
+   `capacity` section of `loom-daemon status`. It is **deduplicated** — one
+   advisory on entry, one recovery on exit, never per-tick spam. Advisory only;
+   it never blocks dispatch.
+3. **Recover.** The finder re-reads the ranking every tick (bounded cadence = the
+   tick interval), so as accounts reset to `available` the cap ramps back up and
+   the queued `loom:issue` backlog drains automatically — no manual intervention.
+   A symmetric recovery line/event fires on the way out of the pressured state.
+
+The `estimated_drain_minutes` figure is a coarse `ceil(queued / healthy) ×
+NOMINAL_SWEEP_MINUTES` (30 min nominal) aid, not a precise SLA — the daemon does
+not track live per-sweep durations here. Near-ceiling granularity is limited to
+the `.ranking` discrete status word (`exhausted` is already ≥ 0.95 utilization);
+a finer sub-exhausted (≥ 0.90) bucket would read the richer `loom-tokens check
+--json` utilization and is a tracked follow-up. Even rotation/staggering of
+dispatches across the available account set (so 5h/7d windows reset in a
+staggered pattern) lives in the spawn-time selector (`loom_tools.tokens.select`),
+not the daemon, and is a separate follow-up.
 
 ## Operability — config, start/stop, E2E (Phase D, #3813)
 

--- a/loom-daemon/src/capacity.rs
+++ b/loom-daemon/src/capacity.rs
@@ -1,0 +1,605 @@
+//! Token-capacity backpressure + add-capacity advisory for the autonomous work
+//! finder (Issue #3902, epic #3809).
+//!
+//! The work finder (#3810) drives approved `loom:issue` work to dispatch, and
+//! #3811 bounds its concurrency by `min(token-pool size, disk headroom,
+//! configured max)`. That policy treats the token pool as a flat count of
+//! `*.token` files — but at scale accounts hit their 5h/7d rate limits and go
+//! **exhausted**. Dispatching to an exhausted account produces the startup
+//! hangs / mid-build deaths seen while dogfooding. This module makes the
+//! daemon treat a genuine token limit as a **capacity signal**:
+//!
+//! 1. **Slow down** — [`token_axis_limit`] backs the token axis off from the
+//!    raw pool size toward the count of *healthy* (`available`) accounts, read
+//!    from the rotation ranking file (`.loom/tokens/.ranking`). When every
+//!    account is exhausted the limit drops to 0 and the finder defers (never
+//!    hammers an exhausted account). A single healthy account is the throughput
+//!    floor, never a halt (operator refinement on #3902).
+//! 2. **Alert** — [`assess_pressure`] derives whether the token axis is the
+//!    binding constraint *and* work is queued behind it, and
+//!    [`CapacityAdvisory::message`] builds an operator advisory naming the
+//!    concrete levers (add accounts + `loom-tokens bootstrap`, or buy API
+//!    credits, then `loom-tokens check --ranking`). The advisory surfaces on the
+//!    daemon status view, the event bus (`daemon.capacity.advisory`), and the
+//!    log — deduplicated to fire only on **state change**.
+//! 3. **Recover** — the finder re-reads the ranking every tick (bounded cadence
+//!    = the tick interval), so as accounts reset to `available` the limit ramps
+//!    back up and the backlog drains automatically, with a symmetric recovery
+//!    event/log line.
+//!
+//! # Why the ranking file (not a network probe)
+//!
+//! The daemon never performs the slow per-account rate-limit probe itself — that
+//! is `loom-tokens check`'s job, run out-of-band (cron / `probe-tokens.sh`),
+//! which writes the discrete status into `.loom/tokens/.ranking` (the
+//! format-of-record the spawn-time selector already consumes). Reading that file
+//! keeps this module a fast, non-blocking, filesystem-only read that matches the
+//! footing of [`crate::tokens::token_pool_size`] and
+//! [`crate::disk_headroom::disk_headroom_limit`].
+//!
+//! # Near-ceiling granularity
+//!
+//! The `.ranking` format carries only the discrete status word
+//! (`available` / `exhausted` / `rate_limited` / `blocked`), where `exhausted`
+//! is already assigned by the probe at 7d utilization ≥ 0.95. A finer
+//! "near-ceiling ≥ 0.90 but not yet exhausted" bucket would require the richer
+//! per-account utilization JSON (`loom-tokens check --json`); this module treats
+//! any non-`available` status as unhealthy, which is the actionable signal for
+//! backpressure (do not dispatch to it). Sub-`exhausted` utilization thresholds
+//! are a documented follow-up.
+
+use std::path::Path;
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/// Minimum count of token-bound queued (deferred) issues before the daemon
+/// enters the *pressured* state and fires the add-capacity advisory. One is the
+/// smallest actionable signal (approved work exists that the healthy accounts
+/// cannot take right now); the state-change dedup keeps it from spamming.
+pub const DEFAULT_ADVISORY_MIN_QUEUED: usize = 1;
+
+/// Nominal per-sweep wall-clock minutes used to estimate backlog drain time.
+///
+/// The daemon does not track a live per-sweep duration here, so the drain
+/// estimate is deliberately a coarse "at current healthy capacity" figure:
+/// `ceil(queued / healthy) * NOMINAL_SWEEP_MINUTES`. It is an order-of-magnitude
+/// aid for the operator ("~hours, not ~minutes"), not a precise SLA.
+pub const NOMINAL_SWEEP_MINUTES: u64 = 30;
+
+// ============================================================================
+// Ranking snapshot
+// ============================================================================
+
+/// Health classification of a single rotation account, parsed from the discrete
+/// status word in `.loom/tokens/.ranking`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccountHealth {
+    /// `available` — under the rate-limit ceiling; safe to dispatch to.
+    Available,
+    /// `exhausted` — 7d utilization ≥ 0.95 per the probe; do not dispatch.
+    Exhausted,
+    /// `rate_limited` — a current 429; do not dispatch.
+    RateLimited,
+    /// `blocked` — 401 auth failure or listed in `.bad_tokens`; do not dispatch.
+    Blocked,
+    /// Any other/unrecognized status word — treated as unhealthy (fail safe:
+    /// do not dispatch to an account whose health we cannot confirm).
+    Unknown,
+}
+
+impl AccountHealth {
+    /// Parse a `.ranking` status word. Unrecognized words map to
+    /// [`AccountHealth::Unknown`] (unhealthy) rather than silently counting as
+    /// available.
+    #[must_use]
+    pub fn parse(status: &str) -> Self {
+        match status.trim() {
+            "available" => Self::Available,
+            "exhausted" => Self::Exhausted,
+            "rate_limited" => Self::RateLimited,
+            "blocked" => Self::Blocked,
+            _ => Self::Unknown,
+        }
+    }
+
+    /// True only for [`AccountHealth::Available`] — the sole state safe to
+    /// dispatch a new sweep to.
+    #[must_use]
+    pub fn is_healthy(self) -> bool {
+        matches!(self, Self::Available)
+    }
+}
+
+/// Aggregate account-health counts derived from `.loom/tokens/.ranking`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RankingSnapshot {
+    /// Total accounts listed in the ranking file.
+    pub total: usize,
+    /// Accounts with status `available` — the healthy, dispatchable set.
+    pub available: usize,
+    /// Accounts with status `exhausted`.
+    pub exhausted: usize,
+    /// Accounts with status `rate_limited`.
+    pub rate_limited: usize,
+    /// Accounts with status `blocked`.
+    pub blocked: usize,
+    /// Accounts with an unrecognized status word (counted as unhealthy).
+    pub unknown: usize,
+}
+
+impl RankingSnapshot {
+    /// Number of unhealthy (non-`available`) accounts — exhausted, rate-limited,
+    /// blocked, or unknown.
+    #[must_use]
+    pub fn unhealthy(&self) -> usize {
+        self.total.saturating_sub(self.available)
+    }
+}
+
+/// Parse the rotation ranking file at `{workspace_root}/.loom/tokens/.ranking`.
+///
+/// The file is the pipe-delimited `name|status` format written by
+/// `loom-tokens check --ranking` (one account per line). Returns `None` when the
+/// file is absent, unreadable, or contains no parseable rows — the signal that
+/// no probe data exists, in which case callers fall back to the raw token-pool
+/// size (byte-for-byte the pre-#3902 behavior). Blank lines and malformed rows
+/// (no `|`) are skipped; a row's status is parsed via [`AccountHealth::parse`].
+#[must_use]
+pub fn read_ranking(workspace_root: &Path) -> Option<RankingSnapshot> {
+    let ranking_path = workspace_root.join(".loom").join("tokens").join(".ranking");
+    let contents = std::fs::read_to_string(&ranking_path).ok()?;
+    let mut snap = RankingSnapshot::default();
+    for line in contents.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        // `name|status` — the status is the last pipe-delimited field so a name
+        // containing a stray pipe (there are none in practice) still parses.
+        let Some((_name, status)) = line.rsplit_once('|') else {
+            continue;
+        };
+        snap.total += 1;
+        match AccountHealth::parse(status) {
+            AccountHealth::Available => snap.available += 1,
+            AccountHealth::Exhausted => snap.exhausted += 1,
+            AccountHealth::RateLimited => snap.rate_limited += 1,
+            AccountHealth::Blocked => snap.blocked += 1,
+            AccountHealth::Unknown => snap.unknown += 1,
+        }
+    }
+    if snap.total == 0 {
+        None
+    } else {
+        Some(snap)
+    }
+}
+
+/// The health-adjusted token-axis concurrency limit.
+///
+/// When ranking data exists, this is the count of `available` accounts — the
+/// finder never dispatches beyond the healthy set, so it never targets an
+/// exhausted/blocked account and never over-subscribes. When ranking data is
+/// absent (no probe has run), it falls back to `pool_size` — the pre-#3902
+/// behavior, so a repo that has not wired up `loom-tokens check` sees zero
+/// change.
+#[must_use]
+pub fn token_axis_limit(workspace_root: &Path, pool_size: usize) -> usize {
+    match read_ranking(workspace_root) {
+        Some(snap) => snap.available,
+        None => pool_size,
+    }
+}
+
+// ============================================================================
+// Pressure assessment
+// ============================================================================
+
+/// A point-in-time capacity assessment: whether the token axis is the binding
+/// constraint, how much work is queued behind it, and the derived operator
+/// numbers (healthy/exhausted accounts, estimated drain time).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PressureAssessment {
+    /// True when the token axis is the binding (minimum) constraint on the
+    /// dynamic cap **and** work was deferred this tick — i.e. the queue is held
+    /// back specifically by token capacity (not disk or the operator ceiling).
+    pub token_bound: bool,
+    /// True when [`Self::token_bound`] holds and the queued count meets the
+    /// advisory threshold — the daemon should surface an add-capacity advisory.
+    pub pressured: bool,
+    /// Issues deferred to a future tick because the token-bound cap was reached.
+    pub queued: usize,
+    /// Healthy (`available`) accounts driving current throughput.
+    pub healthy_accounts: usize,
+    /// Unhealthy (exhausted / rate-limited / blocked / unknown) accounts.
+    pub exhausted_accounts: usize,
+    /// Total accounts in the ranking (or the raw pool size when no ranking).
+    pub total_accounts: usize,
+    /// Estimated minutes to drain the queued backlog at current healthy
+    /// capacity, or `None` when no healthy account exists (cannot drain until
+    /// capacity is restored).
+    pub estimated_drain_minutes: Option<u64>,
+}
+
+/// Derive a [`PressureAssessment`] from the tick's live inputs.
+///
+/// - `ranking` — parsed ranking snapshot, or `None` when no probe data exists.
+/// - `pool_size` — raw `*.token` count (the fallback health basis).
+/// - `token_limit` — the health-adjusted token-axis limit
+///   ([`token_axis_limit`]).
+/// - `disk` / `configured_max` — the other two dynamic-cap axes.
+/// - `deferred` — issues the tick deferred for capacity ([`crate`]'s
+///   `TickReport::deferred_capacity`).
+/// - `min_queued` — the advisory threshold ([`DEFAULT_ADVISORY_MIN_QUEUED`]).
+///
+/// `token_bound` requires that the token axis is the (co-)minimum of the three
+/// cap axes: dispatch is held back by tokens, not by a full disk or the operator
+/// ceiling. This keeps the advisory from firing when the real bottleneck is disk
+/// or a deliberately low `maxConcurrent`.
+#[must_use]
+pub fn assess_pressure(
+    ranking: Option<&RankingSnapshot>,
+    pool_size: usize,
+    token_limit: usize,
+    disk: usize,
+    configured_max: usize,
+    deferred: usize,
+    min_queued: usize,
+) -> PressureAssessment {
+    let token_bound = deferred > 0 && token_limit <= disk && token_limit <= configured_max;
+    let pressured = token_bound && deferred >= min_queued;
+
+    let (total_accounts, healthy_accounts, exhausted_accounts) = match ranking {
+        Some(r) => (r.total, r.available, r.unhealthy()),
+        // No ranking: treat the whole pool as healthy (unknown = optimistic
+        // fallback, matching the token_axis_limit fallback).
+        None => (pool_size, pool_size, 0),
+    };
+
+    let estimated_drain_minutes = if healthy_accounts == 0 {
+        None
+    } else {
+        // ceil(queued / healthy) waves, each a nominal sweep duration.
+        let waves = deferred.div_ceil(healthy_accounts);
+        Some(waves as u64 * NOMINAL_SWEEP_MINUTES)
+    };
+
+    PressureAssessment {
+        token_bound,
+        pressured,
+        queued: deferred,
+        healthy_accounts,
+        exhausted_accounts,
+        total_accounts,
+        estimated_drain_minutes,
+    }
+}
+
+// ============================================================================
+// Advisory rendering
+// ============================================================================
+
+/// A rendered add-capacity advisory (or its symmetric recovery counterpart),
+/// carrying the numbers plus a human-readable message that names the concrete
+/// levers. Consumed by the work-finder loop to emit the log line and the
+/// `daemon.capacity.advisory` event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CapacityAdvisory {
+    /// True when entering the pressured state; false on recovery.
+    pub pressured: bool,
+    /// Queued (deferred) issue count at the transition.
+    pub queued: usize,
+    /// Healthy account count at the transition.
+    pub healthy_accounts: usize,
+    /// Unhealthy account count at the transition.
+    pub exhausted_accounts: usize,
+    /// Total account count at the transition.
+    pub total_accounts: usize,
+    /// Estimated drain minutes at the transition (`None` = no healthy capacity).
+    pub estimated_drain_minutes: Option<u64>,
+    /// Operator-facing one-line message.
+    pub message: String,
+}
+
+impl CapacityAdvisory {
+    /// Build the *entered-pressure* advisory from an assessment.
+    #[must_use]
+    pub fn pressure(a: &PressureAssessment) -> Self {
+        let drain = a.estimated_drain_minutes.map_or_else(
+            || "no healthy accounts — stalled until capacity returns".to_string(),
+            format_minutes,
+        );
+        let message = format!(
+            "token capacity: {queued} issue(s) queued; {healthy}/{total} accounts healthy, \
+             {exhausted} exhausted/near-ceiling; est. ~{drain} to drain at current capacity. \
+             Add accounts to ~/.claude-monitor/accounts.env then `loom-tokens bootstrap`, or buy \
+             API credits, then re-probe with `loom-tokens check --ranking`.",
+            queued = a.queued,
+            healthy = a.healthy_accounts,
+            total = a.total_accounts,
+            exhausted = a.exhausted_accounts,
+        );
+        Self {
+            pressured: true,
+            queued: a.queued,
+            healthy_accounts: a.healthy_accounts,
+            exhausted_accounts: a.exhausted_accounts,
+            total_accounts: a.total_accounts,
+            estimated_drain_minutes: a.estimated_drain_minutes,
+            message,
+        }
+    }
+
+    /// Build the *recovered* advisory from an assessment (symmetric with
+    /// [`Self::pressure`]).
+    #[must_use]
+    pub fn recovery(a: &PressureAssessment) -> Self {
+        let message = format!(
+            "token capacity restored: {healthy}/{total} accounts healthy; queued backlog \
+             draining automatically — no action needed.",
+            healthy = a.healthy_accounts,
+            total = a.total_accounts,
+        );
+        Self {
+            pressured: false,
+            queued: a.queued,
+            healthy_accounts: a.healthy_accounts,
+            exhausted_accounts: a.exhausted_accounts,
+            total_accounts: a.total_accounts,
+            estimated_drain_minutes: a.estimated_drain_minutes,
+            message,
+        }
+    }
+}
+
+/// Render a minutes count as a compact `~Xh Ym` / `~Ym` string.
+#[must_use]
+pub fn format_minutes(mins: u64) -> String {
+    if mins >= 60 {
+        let h = mins / 60;
+        let m = mins % 60;
+        if m == 0 {
+            format!("{h}h")
+        } else {
+            format!("{h}h {m}m")
+        }
+    } else {
+        format!("{mins}m")
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+
+    fn write_ranking(workspace: &Path, body: &str) {
+        let dir = workspace.join(".loom").join("tokens");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join(".ranking"), body).unwrap();
+    }
+
+    // ------------------------------------------------------------------
+    // AccountHealth
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn account_health_parse_and_healthy() {
+        assert_eq!(AccountHealth::parse("available"), AccountHealth::Available);
+        assert_eq!(AccountHealth::parse("exhausted"), AccountHealth::Exhausted);
+        assert_eq!(AccountHealth::parse("rate_limited"), AccountHealth::RateLimited);
+        assert_eq!(AccountHealth::parse("blocked"), AccountHealth::Blocked);
+        assert_eq!(AccountHealth::parse("weird"), AccountHealth::Unknown);
+        assert_eq!(AccountHealth::parse(" available "), AccountHealth::Available);
+
+        assert!(AccountHealth::Available.is_healthy());
+        assert!(!AccountHealth::Exhausted.is_healthy());
+        assert!(!AccountHealth::RateLimited.is_healthy());
+        assert!(!AccountHealth::Blocked.is_healthy());
+        assert!(!AccountHealth::Unknown.is_healthy());
+    }
+
+    // ------------------------------------------------------------------
+    // read_ranking
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn read_ranking_missing_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(read_ranking(tmp.path()), None);
+    }
+
+    #[test]
+    fn read_ranking_empty_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_ranking(tmp.path(), "\n  \n");
+        assert_eq!(read_ranking(tmp.path()), None);
+    }
+
+    #[test]
+    fn read_ranking_counts_statuses() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_ranking(
+            tmp.path(),
+            "a|available\nb|available\nc|exhausted\nd|rate_limited\ne|blocked\nf|weird\n",
+        );
+        let snap = read_ranking(tmp.path()).unwrap();
+        assert_eq!(snap.total, 6);
+        assert_eq!(snap.available, 2);
+        assert_eq!(snap.exhausted, 1);
+        assert_eq!(snap.rate_limited, 1);
+        assert_eq!(snap.blocked, 1);
+        assert_eq!(snap.unknown, 1);
+        assert_eq!(snap.unhealthy(), 4);
+    }
+
+    #[test]
+    fn read_ranking_skips_malformed_rows() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_ranking(tmp.path(), "a|available\nno-pipe-here\n\nb|exhausted\n");
+        let snap = read_ranking(tmp.path()).unwrap();
+        assert_eq!(snap.total, 2, "the pipe-less row is skipped");
+        assert_eq!(snap.available, 1);
+        assert_eq!(snap.exhausted, 1);
+    }
+
+    // ------------------------------------------------------------------
+    // token_axis_limit
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn token_axis_limit_uses_available_when_ranking_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_ranking(tmp.path(), "a|available\nb|available\nc|exhausted\n");
+        // 3 token files present, but only 2 available → limit 2.
+        assert_eq!(token_axis_limit(tmp.path(), 3), 2);
+    }
+
+    #[test]
+    fn token_axis_limit_falls_back_to_pool_when_no_ranking() {
+        let tmp = tempfile::tempdir().unwrap();
+        // No ranking file → fall back to raw pool size (pre-#3902 behavior).
+        assert_eq!(token_axis_limit(tmp.path(), 5), 5);
+    }
+
+    #[test]
+    fn token_axis_limit_zero_when_all_exhausted() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_ranking(tmp.path(), "a|exhausted\nb|blocked\n");
+        assert_eq!(token_axis_limit(tmp.path(), 2), 0, "never dispatch to exhausted");
+    }
+
+    // ------------------------------------------------------------------
+    // assess_pressure
+    // ------------------------------------------------------------------
+
+    fn snap(total: usize, available: usize) -> RankingSnapshot {
+        RankingSnapshot {
+            total,
+            available,
+            exhausted: total - available,
+            ..RankingSnapshot::default()
+        }
+    }
+
+    #[test]
+    fn assess_not_token_bound_when_nothing_deferred() {
+        // No deferral ⇒ not token-bound, not pressured, regardless of health.
+        let s = snap(7, 3);
+        let a = assess_pressure(Some(&s), 7, 3, 10, 10, 0, DEFAULT_ADVISORY_MIN_QUEUED);
+        assert!(!a.token_bound);
+        assert!(!a.pressured);
+        assert_eq!(a.healthy_accounts, 3);
+        assert_eq!(a.exhausted_accounts, 4);
+    }
+
+    #[test]
+    fn assess_token_bound_when_token_axis_is_min_and_deferred() {
+        // token_limit 3 < disk 10 and < ceiling 10, with 4 deferred ⇒ token-bound.
+        let s = snap(7, 3);
+        let a = assess_pressure(Some(&s), 7, 3, 10, 10, 4, DEFAULT_ADVISORY_MIN_QUEUED);
+        assert!(a.token_bound);
+        assert!(a.pressured);
+        assert_eq!(a.queued, 4);
+        // ceil(4/3)=2 waves * 30 = 60 min.
+        assert_eq!(a.estimated_drain_minutes, Some(60));
+    }
+
+    #[test]
+    fn assess_not_token_bound_when_disk_is_the_binding_axis() {
+        // disk 2 < token_limit 3 ⇒ the bottleneck is disk, not tokens.
+        let s = snap(7, 3);
+        let a = assess_pressure(Some(&s), 7, 3, 2, 10, 5, DEFAULT_ADVISORY_MIN_QUEUED);
+        assert!(!a.token_bound, "disk binds, so no token advisory");
+        assert!(!a.pressured);
+    }
+
+    #[test]
+    fn assess_not_token_bound_when_ceiling_is_the_binding_axis() {
+        // configured_max 2 < token_limit 3 ⇒ operator ceiling binds, not tokens.
+        let s = snap(7, 3);
+        let a = assess_pressure(Some(&s), 7, 3, 10, 2, 5, DEFAULT_ADVISORY_MIN_QUEUED);
+        assert!(!a.token_bound);
+        assert!(!a.pressured);
+    }
+
+    #[test]
+    fn assess_drain_none_when_no_healthy_accounts() {
+        // All exhausted (token_limit 0), work queued ⇒ token-bound, no drain ETA.
+        let s = snap(4, 0);
+        let a = assess_pressure(Some(&s), 4, 0, 10, 10, 3, DEFAULT_ADVISORY_MIN_QUEUED);
+        assert!(a.token_bound);
+        assert!(a.pressured);
+        assert_eq!(a.healthy_accounts, 0);
+        assert_eq!(a.estimated_drain_minutes, None);
+    }
+
+    #[test]
+    fn assess_no_ranking_treats_pool_as_healthy() {
+        // No ranking ⇒ pool treated as fully healthy; still token-bound if the
+        // pool-sized limit is the min and work is deferred.
+        let a = assess_pressure(None, 2, 2, 10, 10, 3, DEFAULT_ADVISORY_MIN_QUEUED);
+        assert!(a.token_bound);
+        assert_eq!(a.healthy_accounts, 2);
+        assert_eq!(a.exhausted_accounts, 0);
+        assert_eq!(a.total_accounts, 2);
+    }
+
+    #[test]
+    fn assess_threshold_gates_pressured() {
+        // token_bound but below the queued threshold ⇒ not yet pressured.
+        let s = snap(7, 3);
+        let a = assess_pressure(Some(&s), 7, 3, 10, 10, 2, 5);
+        assert!(a.token_bound);
+        assert!(!a.pressured, "2 queued < threshold 5");
+    }
+
+    // ------------------------------------------------------------------
+    // CapacityAdvisory + formatting
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn advisory_pressure_names_the_levers() {
+        let s = snap(7, 1);
+        let a = assess_pressure(Some(&s), 7, 1, 10, 10, 12, DEFAULT_ADVISORY_MIN_QUEUED);
+        let adv = CapacityAdvisory::pressure(&a);
+        assert!(adv.pressured);
+        assert_eq!(adv.queued, 12);
+        assert!(adv.message.contains("loom-tokens bootstrap"));
+        assert!(adv.message.contains("loom-tokens check --ranking"));
+        assert!(adv.message.contains("API credits"));
+        assert!(adv.message.contains("12 issue"));
+    }
+
+    #[test]
+    fn advisory_recovery_is_symmetric() {
+        let s = snap(7, 7);
+        let a = assess_pressure(Some(&s), 7, 7, 10, 10, 0, DEFAULT_ADVISORY_MIN_QUEUED);
+        let adv = CapacityAdvisory::recovery(&a);
+        assert!(!adv.pressured);
+        assert!(adv.message.contains("restored"));
+        assert!(adv.message.contains("7/7"));
+    }
+
+    #[test]
+    fn advisory_pressure_message_handles_zero_healthy() {
+        let s = snap(3, 0);
+        let a = assess_pressure(Some(&s), 3, 0, 10, 10, 5, DEFAULT_ADVISORY_MIN_QUEUED);
+        let adv = CapacityAdvisory::pressure(&a);
+        assert!(adv.message.contains("no healthy accounts"));
+    }
+
+    #[test]
+    fn format_minutes_variants() {
+        assert_eq!(format_minutes(30), "30m");
+        assert_eq!(format_minutes(59), "59m");
+        assert_eq!(format_minutes(60), "1h");
+        assert_eq!(format_minutes(90), "1h 30m");
+        assert_eq!(format_minutes(120), "2h");
+        assert_eq!(format_minutes(0), "0m");
+    }
+}

--- a/loom-daemon/src/event_bus.rs
+++ b/loom-daemon/src/event_bus.rs
@@ -31,11 +31,15 @@
 //! | `epic.issue.{N}.expand`    | Epic supervisor | `{epic, action, state}` |
 //! | `epic.issue.{N}.join`      | Epic supervisor | `{epic, action, state}` |
 //! | `epic.issue.{N}.close`     | Epic supervisor | `{epic, action, state}` |
+//! | `daemon.capacity.advisory` | Work finder | `{pressured, queued, healthy_accounts, exhausted_accounts, total_accounts, estimated_drain_minutes?, message}` |
 //!
 //! New topics require a follow-up issue — the taxonomy is intentionally
 //! pinned. The four `epic.issue.{N}.*` topics were authorized by **#3873**
 //! (epic #3842 Phase 4) for the epic supervisor's action classes
-//! (decompose / expand / join / close). The bus accepts arbitrary topic
+//! (decompose / expand / join / close). The `daemon.capacity.advisory` topic
+//! was authorized by **#3902** (epic #3809) for the work finder's
+//! token-capacity backpressure advisory (fired on pressure state change). The
+//! bus accepts arbitrary topic
 //! strings (`publish` does not reject unknown topics) so the publisher side
 //! stays open for future extension, but the documented taxonomy is the
 //! contract subscribers should rely on.

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -444,11 +444,29 @@ pub fn build_daemon_status(
     let disk_headroom = crate::disk_headroom::disk_headroom_limit(&workspace_root);
     let wf_config = crate::work_finder::read_work_finder_config(&workspace_root);
     let configured_max = crate::work_finder::resolve_max_concurrent_with_config(&wf_config);
+
+    // Token-capacity backpressure (#3902): back the token axis off from the flat
+    // pool count toward the count of *healthy* accounts read from the rotation
+    // ranking. When no ranking exists, `token_axis_limit` == the raw pool size,
+    // so the dynamic cap is byte-for-byte the pre-#3902 value.
+    let ranking = crate::capacity::read_ranking(&workspace_root);
+    let token_axis_limit = ranking.as_ref().map_or(token_pool_size, |r| r.available);
     let dynamic_cap = crate::work_finder::resolve_dynamic_max_concurrent(
-        token_pool_size,
+        token_axis_limit,
         disk_headroom,
         configured_max,
     );
+    let token_bound = token_axis_limit <= disk_headroom && token_axis_limit <= configured_max;
+    let capacity = crate::types::CapacityReport {
+        ranking_present: ranking.is_some(),
+        total_accounts: ranking.as_ref().map_or(token_pool_size, |r| r.total),
+        healthy_accounts: ranking.as_ref().map_or(token_pool_size, |r| r.available),
+        exhausted_accounts: ranking
+            .as_ref()
+            .map_or(0, crate::capacity::RankingSnapshot::unhealthy),
+        token_axis_limit,
+        token_bound,
+    };
 
     DaemonStatusReport {
         in_flight,
@@ -457,6 +475,7 @@ pub fn build_daemon_status(
         configured_max,
         dynamic_cap,
         main_health_gate_halted: main_health_state.is_halted(),
+        capacity,
     }
 }
 
@@ -1891,8 +1910,16 @@ exit 0
             token_pool_size: 4,
             disk_headroom: 10,
             configured_max: 5,
-            dynamic_cap: 4,
+            dynamic_cap: 3,
             main_health_gate_halted: true,
+            capacity: crate::types::CapacityReport {
+                ranking_present: true,
+                total_accounts: 4,
+                healthy_accounts: 3,
+                exhausted_accounts: 1,
+                token_axis_limit: 3,
+                token_bound: true,
+            },
         };
         let resp = Response::DaemonStatus(report);
         let json = serde_json::to_string(&resp).expect("serialize response");
@@ -1902,12 +1929,30 @@ exit 0
                 assert_eq!(r.token_pool_size, 4);
                 assert_eq!(r.disk_headroom, 10);
                 assert_eq!(r.configured_max, 5);
-                assert_eq!(r.dynamic_cap, 4);
+                assert_eq!(r.dynamic_cap, 3);
                 assert!(r.main_health_gate_halted);
                 assert!(r.in_flight.is_empty());
+                assert!(r.capacity.ranking_present);
+                assert_eq!(r.capacity.healthy_accounts, 3);
+                assert_eq!(r.capacity.exhausted_accounts, 1);
+                assert_eq!(r.capacity.token_axis_limit, 3);
+                assert!(r.capacity.token_bound);
             }
             other => panic!("Expected DaemonStatus, got: {other:?}"),
         }
+    }
+
+    /// A pre-#3902 `DaemonStatus` JSON payload (no `capacity` field) still
+    /// deserializes — `#[serde(default)]` fills the capacity section.
+    #[test]
+    fn test_daemon_status_backward_compat_missing_capacity() {
+        let legacy = r#"{"in_flight":[],"token_pool_size":2,"disk_headroom":9,"configured_max":3,"dynamic_cap":2,"main_health_gate_halted":false}"#;
+        let report: DaemonStatusReport =
+            serde_json::from_str(legacy).expect("legacy payload deserializes");
+        assert_eq!(report.token_pool_size, 2);
+        assert!(!report.capacity.ranking_present);
+        assert_eq!(report.capacity.healthy_accounts, 0);
+        assert!(!report.capacity.token_bound);
     }
 
     /// `build_daemon_status` reflects the shared main-health halt flag and lists

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -11,6 +11,7 @@
 #![allow(clippy::missing_panics_doc)]
 
 pub mod activity;
+pub mod capacity;
 pub mod disk_headroom;
 pub mod epic_state;
 pub mod epic_supervisor;

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -381,6 +381,7 @@ async fn main() -> Result<()> {
             sweep_workspace.clone(),
             configured_max,
             main_health_state.clone(),
+            event_bus.clone(),
         ))
     } else {
         log::debug!("work_finder: disabled (set LOOM_WORK_FINDER=1 to enable)");
@@ -885,6 +886,14 @@ fn print_status_json(
             "configured_max": report.configured_max,
             "effective": report.dynamic_cap,
         },
+        "capacity": {
+            "ranking_present": report.capacity.ranking_present,
+            "total_accounts": report.capacity.total_accounts,
+            "healthy_accounts": report.capacity.healthy_accounts,
+            "exhausted_accounts": report.capacity.exhausted_accounts,
+            "token_axis_limit": report.capacity.token_axis_limit,
+            "token_bound": report.capacity.token_bound,
+        },
         "main_health_gate": {
             "halted": report.main_health_gate_halted,
         },
@@ -919,9 +928,41 @@ fn print_status_human(report: &DaemonStatusReport, token_usage: Option<&serde_js
 
     println!("\nDynamic concurrency cap: {}", report.dynamic_cap);
     println!(
-        "  = min(token pool {}, disk headroom {}, configured max {})",
-        report.token_pool_size, report.disk_headroom, report.configured_max
+        "  = min(healthy tokens {}, disk headroom {}, configured max {})",
+        report.capacity.token_axis_limit, report.disk_headroom, report.configured_max
     );
+
+    // Token-capacity backpressure section (#3902).
+    let cap = &report.capacity;
+    println!("\nToken capacity:");
+    if cap.ranking_present {
+        println!(
+            "  {}/{} accounts healthy, {} exhausted/near-ceiling (from .loom/tokens/.ranking)",
+            cap.healthy_accounts, cap.total_accounts, cap.exhausted_accounts
+        );
+        if cap.token_bound {
+            if cap.healthy_accounts == 0 {
+                println!(
+                    "  token-bound: NO healthy accounts — new dispatch deferred until capacity \
+                     returns. Add accounts (~/.claude-monitor/accounts.env + `loom-tokens \
+                     bootstrap`) or buy API credits, then `loom-tokens check --ranking`."
+                );
+            } else {
+                println!(
+                    "  token-bound: tokens are the binding constraint on throughput. Add accounts \
+                     or API credits to dispatch more concurrently."
+                );
+            }
+        } else {
+            println!("  not token-bound (tokens are not the current bottleneck)");
+        }
+    } else {
+        println!(
+            "  (no ranking — run `loom-tokens check --ranking`; token pool size {} used as the \
+             health basis)",
+            report.token_pool_size
+        );
+    }
 
     let gate = if report.main_health_gate_halted {
         "HALTED (main is red — new dispatch paused; in-flight sweeps keep running)"

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -563,6 +563,38 @@ pub struct DaemonStatusReport {
     /// dispatch (in-flight sweeps keep running); `false` means dispatch is
     /// allowed. Always `false` when the gate loop is not enabled.
     pub main_health_gate_halted: bool,
+    /// Token-capacity backpressure snapshot (#3902): account health derived from
+    /// the rotation ranking (`.loom/tokens/.ranking`) and whether the token axis
+    /// is the binding constraint on the dynamic cap. `#[serde(default)]` keeps
+    /// pre-#3902 wire data / older clients compatible.
+    #[serde(default)]
+    pub capacity: CapacityReport,
+}
+
+/// The token-capacity section of [`DaemonStatusReport`] (#3902).
+///
+/// Derived from the rotation ranking file (`.loom/tokens/.ranking`) — a fast
+/// filesystem read, no network probe. When no ranking exists (`ranking_present`
+/// is `false`) the health counts are zero and `token_axis_limit` equals the raw
+/// token-pool size (byte-for-byte the pre-#3902 dynamic-cap basis).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CapacityReport {
+    /// Whether a ranking file was found and parsed. `false` ⇒ the other fields
+    /// fall back to the raw pool (no probe data).
+    pub ranking_present: bool,
+    /// Total accounts listed in the ranking (or the raw pool size when absent).
+    pub total_accounts: usize,
+    /// Healthy (`available`) accounts — the dispatchable set.
+    pub healthy_accounts: usize,
+    /// Unhealthy (exhausted / rate-limited / blocked) accounts.
+    pub exhausted_accounts: usize,
+    /// The health-adjusted token-axis concurrency limit: `healthy_accounts` when
+    /// a ranking exists, else the raw token-pool size. This is what the work
+    /// finder now feeds into the dynamic cap in place of the flat pool count.
+    pub token_axis_limit: usize,
+    /// Whether the token axis is the binding (minimum) constraint on the dynamic
+    /// cap — i.e. tokens, not disk or the operator ceiling, are the bottleneck.
+    pub token_bound: bool,
 }
 
 // ========================================================================
@@ -625,6 +657,29 @@ pub enum Event {
         /// observability so subscribers see the source state directly.
         state: String,
     },
+    /// `daemon.capacity.advisory` — the autonomous work finder crossed (or
+    /// cleared) a token-capacity pressure threshold. Published by the work-finder
+    /// loop on **state change only** (entered/left the token-bound state), never
+    /// every tick. Authorized by #3902 (epic #3809). Advisory only — it never
+    /// blocks dispatch; it tells the operator when to add accounts / API credits.
+    CapacityAdvisory {
+        /// True when entering the pressured state; false on recovery.
+        pressured: bool,
+        /// Issues queued (deferred) behind the token-bound cap at the transition.
+        queued: usize,
+        /// Healthy (`available`) accounts at the transition.
+        healthy_accounts: usize,
+        /// Unhealthy (exhausted / rate-limited / blocked) accounts.
+        exhausted_accounts: usize,
+        /// Total accounts in the rotation ranking at the transition.
+        total_accounts: usize,
+        /// Estimated minutes to drain the backlog at current healthy capacity;
+        /// omitted when no healthy account exists (cannot drain yet).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        estimated_drain_minutes: Option<u64>,
+        /// Operator-facing advisory message naming the concrete levers.
+        message: String,
+    },
     /// Synthetic event signalling that the subscription fell behind the
     /// publisher. The number of events dropped is reported in `skipped`.
     /// Matches `tokio::sync::broadcast::Receiver::Lagged` semantics.
@@ -652,6 +707,7 @@ impl Event {
     /// | `SweepGlobalDispatch {..}` | `sweep.global.dispatch` |
     /// | `SweepGlobalCompleted {..}` | `sweep.global.completed` |
     /// | `EpicAction {epic, action, ..}` | `epic.issue.{epic}.{action}` |
+    /// | `CapacityAdvisory {..}` | `daemon.capacity.advisory` |
     /// | `TopicLag {..}` | `sweep.system.topic_lag` |
     /// | `Generic {topic, ..}` | the explicit topic string |
     #[must_use]
@@ -666,6 +722,7 @@ impl Event {
             Self::EpicAction { epic, action, .. } => {
                 format!("epic.issue.{epic}.{}", action.as_str())
             }
+            Self::CapacityAdvisory { .. } => "daemon.capacity.advisory".to_string(),
             Self::TopicLag { .. } => "sweep.system.topic_lag".to_string(),
             Self::Generic { topic, .. } => topic.clone(),
         }

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -79,9 +79,12 @@ use std::time::Duration;
 
 use anyhow::Result;
 
+use crate::capacity::{self, CapacityAdvisory};
 use crate::disk_headroom::disk_headroom_limit;
+use crate::event_bus::EventBus;
 use crate::main_health_gate::MainHealthState;
 use crate::tokens::token_pool_size;
+use crate::types::Event;
 
 // ============================================================================
 // Constants
@@ -522,6 +525,7 @@ pub fn spawn_work_finder_task<S, D>(
     workspace_root: PathBuf,
     configured_max: usize,
     health_state: Arc<MainHealthState>,
+    event_bus: Arc<EventBus>,
 ) -> tokio::task::JoinHandle<()>
 where
     S: WorkSource + Send + 'static,
@@ -529,7 +533,7 @@ where
 {
     log::info!(
         "work_finder: starting loop (interval={}s, configured_max={configured_max}, \
-         dynamic cap = min(pool, disk, configured_max))",
+         dynamic cap = min(healthy tokens, disk, configured_max))",
         interval.as_secs()
     );
     tokio::spawn(async move {
@@ -539,18 +543,27 @@ where
         // Track the halt state across ticks so we log the halt/resume edges
         // once per halted period, not once per skipped tick.
         let mut was_halted = false;
+        // Token-capacity pressure state (#3902), tracked across ticks so the
+        // add-capacity advisory / recovery fires only on state change, never
+        // every tick.
+        let mut was_pressured = false;
         loop {
             ticker.tick().await;
             // Reactive main-health backstop (Phase C, #3812): skip all dispatch
             // while the gate reports a red `main`.
             let halted = health_state.is_halted();
-            // Recompute the dynamic cap from live inputs every tick (Phase B).
+            // Recompute the dynamic cap from live inputs every tick (Phase B),
+            // now with token-capacity backpressure (#3902): the token axis is the
+            // count of *healthy* accounts from the ranking, not the flat pool.
             let pool_size = token_pool_size(&workspace_root);
+            let ranking = capacity::read_ranking(&workspace_root);
+            let token_limit = ranking.as_ref().map_or(pool_size, |r| r.available);
             let disk = disk_headroom_limit(&workspace_root);
-            let max_concurrent = resolve_dynamic_max_concurrent(pool_size, disk, configured_max);
+            let max_concurrent = resolve_dynamic_max_concurrent(token_limit, disk, configured_max);
             log::debug!(
-                "work_finder: dynamic cap = {max_concurrent} (pool={pool_size}, disk={disk}, \
-                 configured_max={configured_max}, halted={halted})"
+                "work_finder: dynamic cap = {max_concurrent} (pool={pool_size}, \
+                 healthy_tokens={token_limit}, disk={disk}, configured_max={configured_max}, \
+                 halted={halted})"
             );
             match tick(&mut source, &mut dispatcher, max_concurrent, halted) {
                 Ok(report) => {
@@ -567,8 +580,9 @@ where
                     if report.dispatched > 0 || report.errors > 0 {
                         log::info!(
                             "work_finder: tick — cap {max_concurrent} (pool={pool_size}, \
-                             disk={disk}, ceiling={configured_max}); {} seen, {} dispatched, \
-                             {} labeled-skip, {} in-flight-skip, {} deferred, {} error(s)",
+                             healthy={token_limit}, disk={disk}, ceiling={configured_max}); \
+                             {} seen, {} dispatched, {} labeled-skip, {} in-flight-skip, \
+                             {} deferred, {} error(s)",
                             report.seen,
                             report.dispatched,
                             report.skipped_labeled,
@@ -577,6 +591,22 @@ where
                             report.errors
                         );
                     }
+                    // Token-capacity advisory (#3902) — surface on state change.
+                    // Skip while halted: a red-main halt defers everything, so the
+                    // token axis is not the (relevant) bottleneck this tick.
+                    if !report.halted {
+                        let assessment = capacity::assess_pressure(
+                            ranking.as_ref(),
+                            pool_size,
+                            token_limit,
+                            disk,
+                            configured_max,
+                            report.deferred_capacity,
+                            capacity::DEFAULT_ADVISORY_MIN_QUEUED,
+                        );
+                        was_pressured =
+                            emit_capacity_transition(&event_bus, was_pressured, &assessment);
+                    }
                 }
                 Err(e) => {
                     log::warn!("work_finder: tick failed to list ready issues: {e}");
@@ -584,6 +614,52 @@ where
             }
         }
     })
+}
+
+/// Emit the add-capacity advisory / recovery on a token-pressure **state
+/// change** and return the new pressured state. A no-op (returns `was_pressured`
+/// unchanged) when the state is stable, so the operator sees one advisory on the
+/// way in and one recovery on the way out — never a per-tick stream (#3902).
+///
+/// Each transition is surfaced on all three operator channels required by the
+/// issue: the daemon log, the `daemon.capacity.advisory` event-bus topic, and —
+/// via the recomputed [`crate::types::CapacityReport`] — the daemon status view.
+fn emit_capacity_transition(
+    event_bus: &Arc<EventBus>,
+    was_pressured: bool,
+    assessment: &capacity::PressureAssessment,
+) -> bool {
+    if assessment.pressured && !was_pressured {
+        let advisory = CapacityAdvisory::pressure(assessment);
+        log::warn!("work_finder: {}", advisory.message);
+        publish_capacity_advisory(event_bus, &advisory);
+        true
+    } else if !assessment.pressured && was_pressured {
+        let advisory = CapacityAdvisory::recovery(assessment);
+        log::info!("work_finder: {}", advisory.message);
+        publish_capacity_advisory(event_bus, &advisory);
+        false
+    } else {
+        was_pressured
+    }
+}
+
+/// Publish a [`CapacityAdvisory`] on the `daemon.capacity.advisory` topic.
+/// Fire-and-forget: a `NoSubscribers` result is logged at debug and ignored
+/// (matching the daemon's other publish sites).
+fn publish_capacity_advisory(event_bus: &Arc<EventBus>, advisory: &CapacityAdvisory) {
+    let event = Event::CapacityAdvisory {
+        pressured: advisory.pressured,
+        queued: advisory.queued,
+        healthy_accounts: advisory.healthy_accounts,
+        exhausted_accounts: advisory.exhausted_accounts,
+        total_accounts: advisory.total_accounts,
+        estimated_drain_minutes: advisory.estimated_drain_minutes,
+        message: advisory.message.clone(),
+    };
+    if let Err(e) = event_bus.publish(event) {
+        log::debug!("work_finder: capacity advisory not delivered: {e}");
+    }
 }
 
 // ============================================================================
@@ -1316,5 +1392,138 @@ mod tests {
         std::env::set_var(WORK_FINDER_MAX_CONCURRENT_ENV, "nope");
         assert_eq!(resolve_max_concurrent_with_config(&cfg), 8);
         std::env::remove_var(WORK_FINDER_MAX_CONCURRENT_ENV);
+    }
+
+    // ===================================================================
+    // Token-capacity advisory transitions (#3902)
+    // ===================================================================
+
+    fn pressured_assessment() -> capacity::PressureAssessment {
+        // token_limit 1 < disk 10, ceiling 10; 12 deferred ⇒ token-bound + pressured.
+        let snap = capacity::RankingSnapshot {
+            total: 7,
+            available: 1,
+            exhausted: 6,
+            ..capacity::RankingSnapshot::default()
+        };
+        capacity::assess_pressure(
+            Some(&snap),
+            7,
+            1,
+            10,
+            10,
+            12,
+            capacity::DEFAULT_ADVISORY_MIN_QUEUED,
+        )
+    }
+
+    fn calm_assessment() -> capacity::PressureAssessment {
+        // Nothing deferred ⇒ not pressured (healthy pool).
+        let snap = capacity::RankingSnapshot {
+            total: 7,
+            available: 7,
+            ..capacity::RankingSnapshot::default()
+        };
+        capacity::assess_pressure(
+            Some(&snap),
+            7,
+            7,
+            10,
+            10,
+            0,
+            capacity::DEFAULT_ADVISORY_MIN_QUEUED,
+        )
+    }
+
+    #[test]
+    fn transition_enters_pressure_and_publishes_advisory() {
+        let bus = Arc::new(EventBus::new());
+        let mut sub = bus.subscribe(["daemon.capacity.advisory"]);
+        let a = pressured_assessment();
+        assert!(a.pressured);
+
+        // Not previously pressured ⇒ transition fires, returns true.
+        let now = emit_capacity_transition(&bus, false, &a);
+        assert!(now, "entered pressured state");
+
+        match sub.try_recv().expect("an advisory event was published") {
+            Event::CapacityAdvisory {
+                pressured,
+                queued,
+                healthy_accounts,
+                message,
+                ..
+            } => {
+                assert!(pressured);
+                assert_eq!(queued, 12);
+                assert_eq!(healthy_accounts, 1);
+                assert!(message.contains("loom-tokens bootstrap"));
+            }
+            other => panic!("expected CapacityAdvisory, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn transition_is_deduplicated_while_pressure_persists() {
+        let bus = Arc::new(EventBus::new());
+        let mut sub = bus.subscribe(["daemon.capacity.advisory"]);
+        let a = pressured_assessment();
+
+        // Already pressured ⇒ no new event, state stays true.
+        let now = emit_capacity_transition(&bus, true, &a);
+        assert!(now);
+        assert!(
+            matches!(sub.try_recv(), Err(crate::event_bus::RecvError::Empty)),
+            "no duplicate advisory while pressure persists"
+        );
+    }
+
+    #[test]
+    fn transition_recovers_and_publishes_symmetric_event() {
+        let bus = Arc::new(EventBus::new());
+        let mut sub = bus.subscribe(["daemon.capacity.advisory"]);
+        let calm = calm_assessment();
+
+        // Was pressured, now calm ⇒ recovery event, state returns to false.
+        let now = emit_capacity_transition(&bus, true, &calm);
+        assert!(!now, "left pressured state");
+
+        match sub.try_recv().expect("a recovery event was published") {
+            Event::CapacityAdvisory {
+                pressured, message, ..
+            } => {
+                assert!(!pressured);
+                assert!(message.contains("restored"));
+            }
+            other => panic!("expected CapacityAdvisory recovery, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn transition_stays_calm_when_never_pressured() {
+        let bus = Arc::new(EventBus::new());
+        let mut sub = bus.subscribe(["daemon.capacity.advisory"]);
+        let calm = calm_assessment();
+
+        let now = emit_capacity_transition(&bus, false, &calm);
+        assert!(!now);
+        assert!(
+            matches!(sub.try_recv(), Err(crate::event_bus::RecvError::Empty)),
+            "no event when staying calm"
+        );
+    }
+
+    #[test]
+    fn capacity_advisory_event_topic() {
+        let ev = Event::CapacityAdvisory {
+            pressured: true,
+            queued: 3,
+            healthy_accounts: 1,
+            exhausted_accounts: 6,
+            total_accounts: 7,
+            estimated_drain_minutes: Some(90),
+            message: "x".to_string(),
+        };
+        assert_eq!(ev.topic(), "daemon.capacity.advisory");
     }
 }


### PR DESCRIPTION
Closes #3902

## What & why

When the autonomous work finder runs at scale, rotation accounts hit their 5h/7d rate limits and go `exhausted`. Previously the finder counted a flat `*.token` pool and would keep dispatching onto exhausted accounts (the startup hangs / mid-build deaths seen while dogfooding). This makes the daemon treat a genuine token limit as a **capacity signal** — slow down, alert the operator to add capacity, and recover automatically — all non-blocking.

## Behavior (three phases)

1. **Slow down (backpressure).** The token axis of the dynamic cap is now the count of **healthy** (`available`) accounts read from `.loom/tokens/.ranking` (`capacity::token_axis_limit`), not the flat `*.token` count. The cap backs off toward the healthy count; when *every* account is exhausted it drops to 0 and the finder **defers** the queue (never hammers an exhausted account). A single healthy account is the throughput **floor**, never a halt. With no `.ranking` file (no probe run) it falls back to the raw pool size — byte-for-byte the pre-#3902 behavior.
2. **Alert (add capacity).** When the token axis is the *binding* constraint (≤ disk and ≤ ceiling) and work is queued behind it, the finder is *token-bound*. On the **state change** into that state it emits an add-capacity advisory with the numbers (queued count, healthy/total accounts, exhausted count, estimated drain time) naming concrete levers: add accounts to `~/.claude-monitor/accounts.env` + `loom-tokens bootstrap`, or buy API credits, then `loom-tokens check --ranking`. Surfaced on **three** channels — the daemon log, the new `daemon.capacity.advisory` event-bus topic, and a new `capacity` section of `loom-daemon status` / `DaemonStatus` IPC. **Deduplicated**: one advisory on entry, one recovery on exit, never per-tick. Advisory only — it never blocks dispatch.
3. **Recover.** The ranking is re-read every tick (bounded cadence = tick interval), so as accounts reset to `available` the cap ramps back up and the queued `loom:issue` backlog drains automatically. A symmetric recovery event/log line fires on the way out.

## Key files

- `loom-daemon/src/capacity.rs` (new) — ranking parse + account-health classification, `token_axis_limit`, `assess_pressure` (token-bound / pressured derivation + drain estimate), advisory rendering.
- `loom-daemon/src/work_finder.rs` — the loop now computes the health-adjusted cap and emits advisory/recovery on pressure state change (`emit_capacity_transition` / `publish_capacity_advisory`).
- `loom-daemon/src/types.rs` — new `Event::CapacityAdvisory` variant (`daemon.capacity.advisory` topic) + `CapacityReport` on `DaemonStatusReport` (`#[serde(default)]` for wire back-compat).
- `loom-daemon/src/ipc.rs` — `build_daemon_status` populates the capacity section and uses the health-adjusted cap.
- `loom-daemon/src/main.rs` — passes the event bus to the finder; renders the `capacity` section in `status` (human + JSON).
- `.loom/docs/daemon-reference.md` — event taxonomy row + new "Token-capacity backpressure (#3902)" subsection.

## Design notes / scope

- **Ranking file, not a network probe.** The daemon reads the discrete status the out-of-band `loom-tokens check` probe already writes to `.loom/tokens/.ranking` — a fast filesystem-only read matching the footing of `token_pool_size` / `disk_headroom_limit`. It performs no per-account network probe in the loop.
- **Near-ceiling granularity.** The `.ranking` format carries only the discrete status word (`exhausted` is already ≥ 0.95 utilization). A finer sub-exhausted (≥ 0.90) bucket would read the richer `loom-tokens check --json` utilization — noted as a follow-up.
- **Out of scope (noted, not fixed):** even rotation/staggering of concurrent dispatches across the available account set lives in the spawn-time selector (`loom_tools.tokens.select`), not this Rust daemon, and is a separate follow-up (the operator comment's point 2). The observed session failures were the startup race (fixed by #3892) + stale ranking, not a capacity shortage.

## Test plan

- `cargo build` — clean.
- `cargo test --lib` — **634 passed, 0 failed** (19 new `capacity::` tests, 5 new work_finder transition/event tests, 1 new DaemonStatus back-compat test).
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo fmt` — applied.
- The only full-suite failure is `integration_basic::test_send_input`, a pre-existing tmux-timing flake unrelated to this change (passes in isolation; exercises PTY terminal output, not the finder/capacity/status code).