### PR TITLE
docs(roles): issues are suggestions — empower curator/builder/judge to close or rescope (#3914)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,6 +191,14 @@ See `.github/labels.yml` for the authoritative `Applied by:` field on every labe
 
 > **Note on label cleanup**: Loom intentionally does **not** remove labels from closed issues or merged PRs (e.g., `loom:pr` remains on merged PRs). Labels on closed/merged items are harmless — all agents filter by open state — and skipping post-close label removal saves gh API calls. Do not implement label cleanup on merge/close (see issue #2838).
 
+### Issues Are Suggestions (Role Autonomy)
+
+Filed issues are the *input queue*, not mandates. In autonomous mode the **Curator, Builder, and Judge** have standing authority to **close** or **rescope** an issue — with a stated rationale — when building it is not the best outcome (obsolete, duplicate/already covered, low value vs. cost, wrong approach, better split/merged). This is what keeps the auto-picked-up backlog healthy rather than "build whatever is filed". Full mechanism + guardrails live in each role prompt's "Issues Are Suggestions — Close or Rescope With Rationale" section (`.loom/roles/curator.md`, `builder.md`, `judge.md`). The rules in brief:
+
+- **Comment the rationale BEFORE closing**, then `gh issue close <N> --reason "not planned"`. A closed issue leaves the queue automatically (the work-finder only polls *open* `loom:issue` items), so it is not re-picked-up.
+- **Rescope** instead of closing when the core is worth keeping: edit the body / split / relabel, and **remove `loom:issue`** if the labels no longer reflect an approved scope (drop back to `loom:triage`/`loom:curated`) so it is not re-dispatched with a stale scope.
+- **Never close an issue that encodes a still-pending human decision** — route it to `loom:blocked` or `loom:operator-only` with a comment instead. Never invent new labels.
+
 ## Git Worktree Workflow
 
 Loom uses git worktrees to isolate agent work.

--- a/defaults/.claude/commands/loom/builder-complexity.md
+++ b/defaults/.claude/commands/loom/builder-complexity.md
@@ -152,7 +152,7 @@ Before decomposing an issue into sub-issues:
    ```
 
 4. **Compare findings to issue requirements**:
-   - **Fully implemented** -> Mark `loom:blocked` with an "already implemented" comment citing the evidence (files/lines/tests); a human closes it. Do NOT close the issue yourself and do NOT create duplicate sub-issues.
+   - **Fully implemented** (verified — you can cite files/lines/tests) -> this is the "Already covered" close case from `builder.md` → "Issues Are Suggestions". Comment the evidence as your rationale, then **close the issue** (`gh issue close <N> --reason "not planned"`); do NOT create duplicate sub-issues. **Under `/loom:sweep` orchestration**, prefer the `.no-changes-needed` marker instead of closing directly so orchestration finalizes the lifecycle (see `builder.md` → "Signaling No Changes Needed"). If the "already implemented" call is **ambiguous** (you cannot fully verify, or it hides a still-pending human decision), do NOT close — route it to `loom:blocked` with a comment per the guardrails.
    - **Partially implemented** -> Create sub-issues only for missing parts
    - **Not implemented** -> Proceed with decomposition as planned
 
@@ -164,7 +164,7 @@ Large issue requiring decomposition
 1. AUDIT: Search codebase for existing implementations
 |
 2. ASSESS:
-   |-- Fully implemented? -> Mark loom:blocked with evidence (a human closes it)
+   |-- Fully implemented (verified)? -> Close with evidence as rationale ("Already covered"); under /loom:sweep use the .no-changes-needed marker. Ambiguous -> loom:blocked with a comment.
    |-- Partially implemented? -> Create sub-issues for gaps only
    +-- Not implemented? -> Proceed with decomposition
 |
@@ -195,8 +195,10 @@ $ find . -name "*_test*" | xargs grep -l constraint
 # Audit shows: All features fully implemented with tests
 
 # Step 4: Decision
-# -> Mark issue #341 loom:blocked with an "already implemented" comment citing the
-#    evidence above (a human closes it — builders never close issues)
+# -> Comment the evidence above as the rationale, then CLOSE issue #341 as
+#    "Already covered" (gh issue close 341 --reason "not planned"). Under
+#    /loom:sweep, write a .no-changes-needed marker instead and let orchestration
+#    finalize. If the "already implemented" call is ambiguous, use loom:blocked + a comment.
 # -> Do NOT create sub-issues (would be duplicates)
 # -> Create separate issue for actual gaps: "Add SQLSTATE codes to constraint errors"
 ```
@@ -329,11 +331,15 @@ EOF
 )"
 ```
 
-**Step 3: Mark Parent Blocked (never close it yourself)**
+**Step 3: Mark Parent Blocked (don't close a decomposition-parent yourself)**
 
 Record the decomposition in a comment, then move the parent to `loom:blocked`. A
-human closes the parent once the children are filed and curated — builders never
-close issues themselves.
+freshly-decomposed **parent** is a tracking issue for its children, so it is **not**
+a close candidate — a human (or Curator, per `curator.md` item 4) closes it once the
+children are filed and curated. This is the decomposition-parent exception, not a
+blanket rule: for a **non-parent** issue you verify is already implemented, close it
+with a rationale per `builder.md` → "Issues Are Suggestions" (or the `.no-changes-needed`
+marker under `/loom:sweep`).
 
 ```bash
 gh issue comment <parent-number> --body "$(cat <<'EOF'

--- a/defaults/.claude/commands/loom/builder.md
+++ b/defaults/.claude/commands/loom/builder.md
@@ -674,14 +674,36 @@ Without a comment, the next attempt starts from scratch with zero context. The c
 - Don't leave a vague comment like "couldn't figure it out" — be specific about what you investigated
 - Don't skip the `loom:blocked` label — the comment is supplemental, not a replacement
 
-### CRITICAL: Never Close Issues
+### Issues Are Suggestions — Close or Rescope With Rationale (Role Autonomy)
 
-You MUST NOT close issues under any circumstances. Issues should only close via PR auto-close (`Closes #N` in the PR body). This includes:
-- DO NOT close issues you believe "don't need changes" — add label `loom:blocked` with a comment explaining why, then exit
-- DO NOT close duplicates — flag them for human review instead
-- DO NOT close issues for any reason — only GitHub's PR auto-close mechanism should close issues
+Treat the issue you claimed as a **suggestion, not a mandate**. The normal, overwhelmingly-common path is still: implement it and let GitHub auto-close it via `Closes #N` in the PR body. But you are **not** obligated to build whatever is filed. When, after investigating, you judge that building it is not the best outcome, you have standing authority to **close** it (with a rationale) or **rescope** it — rather than forcing a low-value or wrong PR.
 
-**Why this matters**: Closing an issue manually destroys a legitimate feature request and bypasses the PR review pipeline. Sweep phase validation will detect this and reopen the issue, but the interruption to sweep orchestration and loss of builder context is already done.
+**When to close directly** (state the rationale in a comment FIRST, then close — no PR needed):
+- **Obsolete** — the condition no longer exists (code/feature already gone; nothing to change).
+- **Already covered** — a merged PR or another issue already delivers it (a genuine "no changes needed").
+- **Low value vs. cost** — an extreme-edge or trivial follow-up whose cost dwarfs its return.
+- **Wrong approach with no salvageable core** — the request bakes in an incorrect approach and there is nothing worth keeping (if there IS a salvageable core, rescope instead).
+
+```bash
+# Rationale comment FIRST (the breadcrumb), then close, then release the claim:
+gh issue comment <number> --body "Closing as not planned: <specific rationale>. <evidence: already delivered by #<n> / condition gone as of <sha> / …>."
+gh issue close <number> --reason "not planned"
+gh issue edit <number> --remove-label "loom:building"
+```
+
+> **Under `/loom:sweep` orchestration**, prefer the `.no-changes-needed` marker (see "Signaling No Changes Needed" below) and let orchestration finalize the lifecycle — a Builder subagent closing the issue out from under the orchestrator can race it. Write the marker with your rationale and exit; the direct `gh issue close` path above is for **manual Builder runs** where you own the whole lifecycle.
+
+**When to rescope** (the core is worth keeping, but not as filed):
+- Correct the scope by editing the body / adding a comment, then implement the corrected scope in your PR.
+- If it is genuinely too large or should be split, decompose it (see Complexity Assessment / `builder-complexity.md`) and relabel so the queue reflects reality — **remove `loom:issue`** if the current labels no longer describe an approved, ready scope, dropping it back to `loom:triage`.
+
+**Guardrails (safety — do NOT skip these):**
+- **Always comment the rationale BEFORE closing.** A silent close destroys context and looks like an escape. `--reason "not planned"` marks it a judgment call, not a fix.
+- **Never close an issue that encodes a still-pending human decision.** If the right call needs a human (policy, a controversial trade-off, security/access, anything you are not authorized to settle), do **not** close — add `loom:blocked` (waiting on a dependency/clarification) or `loom:operator-only` (a human must act) with a comment, then exit. This is the atomic transition described in "CRITICAL: Label Discipline".
+- **"Don't need changes" is now closeable with evidence** — but only when you can point to *why* (already delivered by #N, condition gone). If you are unsure, `loom:blocked` + comment, do not close on a hunch.
+- **Never invent new labels.** Use only the existing label set.
+
+**Composes with the work-finder**: a **closed** issue leaves the queue automatically (the autonomous work-finder only polls *open* `loom:issue` items), so a well-reasoned close is not re-picked-up. A **rescoped** issue must have its labels reset so it is not re-dispatched in a loop with a stale scope.
 
 ## Complexity Assessment
 

--- a/defaults/.claude/commands/loom/builder.md
+++ b/defaults/.claude/commands/loom/builder.md
@@ -691,7 +691,7 @@ gh issue close <number> --reason "not planned"
 gh issue edit <number> --remove-label "loom:building"
 ```
 
-> **Under `/loom:sweep` orchestration**, prefer the `.no-changes-needed` marker (see "Signaling No Changes Needed" below) and let orchestration finalize the lifecycle — a Builder subagent closing the issue out from under the orchestrator can race it. Write the marker with your rationale and exit; the direct `gh issue close` path above is for **manual Builder runs** where you own the whole lifecycle.
+> **Under `/loom:sweep` orchestration**, prefer the `.no-changes-needed` marker (see "Signaling No Changes Needed" above) and let orchestration finalize the lifecycle — a Builder subagent closing the issue out from under the orchestrator can race it. Write the marker with your rationale and exit; the direct `gh issue close` path above is for **manual Builder runs** where you own the whole lifecycle.
 
 **When to rescope** (the core is worth keeping, but not as filed):
 - Correct the scope by editing the body / adding a comment, then implement the corrected scope in your PR.

--- a/defaults/.claude/commands/loom/curator.md
+++ b/defaults/.claude/commands/loom/curator.md
@@ -283,7 +283,7 @@ If, during curation, you determine an issue is too large to be a single Builder 
 1. **Create each sub-issue with `loom:triage` only.** Do NOT apply `loom:curated`, even if your decomposition includes curator-quality detail (acceptance criteria, file references, scope guards).
 2. **Do NOT apply `loom:issue`** — only humans or the Champion role add `loom:issue`. This rule is unchanged for sub-issues (see "NEVER add `loom:issue`" below).
 3. **Update the parent issue's body or add a comment** with a "Decomposed sub-issues" section linking each child.
-4. **Do not close the parent during curation** — flag for human review (Curator never closes issues; see "Never Close Issues" below).
+4. **Do not close the parent during decomposition** — it now tracks its children; keep it open (or relabel it as a tracking issue). Closing here would orphan the sub-issues. (Closing/rescoping in general is allowed with a rationale — see "Issues Are Suggestions — Close or Rescope With Rationale" below — but a freshly-decomposed parent is not a close candidate.)
 5. **Do not self-curate your own sub-issues in the same session.** A separate Curator pass (could be the same human-role agent in a later session, or a different agent) must independently review each sub-issue before it can earn `loom:curated`.
 6. **Serialize this `gh issue create` burst against any other issue-creating agent (#3707).** Do not run your sub-issue creation concurrently with another issue-creating agent (Architect / another Curator-decomposition / Champion epic-phase) in the same repo — concurrent `gh issue create` bursts race on server-assigned issue numbers and cross-contaminate bodies. One filer finishes its full burst before the next starts. See `sweep.md` → "Execution Model → Only Builders parallelize" for the invariant.
 
@@ -385,15 +385,34 @@ Issues about agent behavior or workflow failures need special curation to preven
 - Update issues when requirements change
 - Track technical debt and improvement opportunities
 
-**CRITICAL: Never Close Issues**
+**Issues Are Suggestions — Close or Rescope With Rationale (Role Autonomy)**
 
-You MUST NOT close issues under any circumstances. Your role is to **enhance**, not to close. This includes:
-- ❌ DO NOT close duplicates - flag them for human review instead
-- ❌ DO NOT close "already fixed" issues - add context and let humans decide
-- ❌ DO NOT close stale issues - mark them with appropriate labels
-- ❌ DO NOT close issues for any reason
+Treat a filed issue as a **suggestion, not a mandate**. In autonomous mode the filed backlog is the *input queue*, and your judgment is what keeps it healthy. You have standing authority to **close** or **rescope** an issue — with a stated rationale — when enhancing it toward a build is not the best outcome. You do **not** have to enhance whatever is filed.
 
-**Why this matters**: Closing issues during curation can interrupt shepherd orchestration and require manual intervention. The human observer layer handles issue closure decisions.
+**When to close** (state the rationale in a comment FIRST, then close):
+- **Obsolete** — the underlying condition no longer exists (code deleted, feature removed, superseded by a merged change).
+- **Duplicate / already covered** — a canonical issue or an already-merged PR fully covers it.
+- **Low value vs. cost** — the change costs far more than it returns (e.g. an extreme-edge or low-value follow-up filed by a review).
+- **Wrong approach** — the request bakes in an approach that is clearly incorrect and there is no salvageable core (if there IS a salvageable core, rescope instead).
+
+```bash
+# 1. Rationale comment FIRST (the audit trail), then close as not planned:
+gh issue comment <number> --body "Closing as not planned: <specific rationale>. <evidence: superseded by #<n> / merged in <sha> / covered by #<canonical>>."
+gh issue close <number> --reason "not planned"
+```
+
+**When to rescope** (instead of closing — the core is worth keeping):
+- Edit the body to correct scope / approach, then re-run the normal curation pass.
+- Split an oversized issue into sub-issues (see "Decomposing Oversized Issues" — sub-issues enter at `loom:triage`).
+- Relabel so the queue reflects reality: if the current labels no longer describe an approved, ready scope, **remove `loom:issue`** and drop it back to `loom:triage` (or `loom:curated` after your enhancement pass). This prevents the work-finder from re-dispatching a stale scope.
+
+**Guardrails (safety — do NOT skip these):**
+- **Always comment the rationale BEFORE closing.** A silent close destroys context. `--reason "not planned"` distinguishes a judgment-call close from a fix.
+- **Never close an issue that encodes a still-pending human decision.** If the right call requires a human (a policy choice, a controversial trade-off, a security/access decision, anything you are not authorized to settle), route it instead — add `loom:blocked` (automatable but waiting on a dependency/clarification) or `loom:operator-only` (a human must act) with a comment — do **not** close it.
+- **Never invent new labels.** Use only the existing label set.
+- **Do not close an issue another agent is actively building** (`loom:building`) unless you are that agent — coordinate via a comment instead.
+
+**Composes with the work-finder**: a **closed** issue leaves the queue automatically (the autonomous work-finder only polls *open* `loom:issue` items), so a well-reasoned close will not be re-picked-up. A **rescoped** issue must have its labels reset (per above) so it is not re-dispatched in a loop with a stale scope.
 
 ### Duplicate Detection
 
@@ -413,19 +432,14 @@ fi
 
 **When duplicates are found:**
 
-**IMPORTANT**: Never close issues - flag them for human review instead.
+**IMPORTANT**: A **clear** duplicate may be closed with a rationale (see "Issues Are Suggestions" above); anything **ambiguous** is routed for human review, not closed.
 
-1. **Clearly duplicate**: Flag for human review and block:
+1. **Clearly duplicate** (high confidence the canonical issue fully covers this one): comment the rationale, then close as not planned:
    ```bash
-   gh issue edit <number> --add-label "loom:blocked"
-   gh issue comment <number> --body "⚠️ **Potential Duplicate**
-
-   This appears to be a duplicate of #<canonical>.
-
-   **Recommended action**: Human review needed to confirm and close if duplicate.
-
-   See #<canonical> for the original discussion."
+   gh issue comment <number> --body "Closing as not planned: duplicate of #<canonical>, which fully covers this scope. See #<canonical> for the original discussion."
+   gh issue close <number> --reason "not planned"
    ```
+   If confidence is only *moderate*, treat it as "Unclear" (case 3) and route for review instead of closing.
 
 2. **Related but distinct**: Add cross-reference in enhancement:
    ```bash
@@ -437,19 +451,18 @@ fi
    gh issue comment <number> --body "⚠️ Potential duplicate of #<similar>. Needs human review to determine if distinct."
    ```
 
-4. **Appears already fixed**: Flag for human verification, do NOT close:
+4. **Appears already fixed**: if you can **verify** it is resolved (the referenced PR merged and the condition no longer reproduces), comment the rationale and close as not planned. If you cannot verify, flag for human verification instead of closing:
    ```bash
+   # Verified resolved → close with rationale:
+   gh issue comment <number> --body "Closing as not planned: resolved by PR #<pr_number> (merged <sha>); the condition no longer reproduces."
+   gh issue close <number> --reason "not planned"
+
+   # Cannot verify → flag, do not close:
    gh issue edit <number> --add-label "loom:blocked"
-   gh issue comment <number> --body "⚠️ **May Already Be Fixed**
-
-   This issue may have been addressed by PR #<pr_number> or commit <sha>.
-
-   **Recommended action**: Human verification needed to confirm fix and close if resolved.
-
-   Please test and close if the issue is no longer reproducible."
+   gh issue comment <number> --body "⚠️ **May Already Be Fixed** — possibly addressed by PR #<pr_number> or commit <sha>. Needs verification: please test and close if no longer reproducible."
    ```
 
-**Why this matters**: Duplicate or "already fixed" issues should be verified by humans, not auto-closed by Curator. Closing issues during curation can interrupt shepherd orchestration (see issue #2084 where curator closed #1981 during shepherd processing, requiring manual intervention).
+**Why this matters**: closing on a **clear, stated rationale** keeps the backlog healthy and — because the work-finder only polls *open* issues — removes the item from the queue without a loop. But an **unverified** guess should be flagged, not closed, and never close an issue that is being actively built (`loom:building`) by another agent (see issue #2084 where a curator closed #1981 mid-processing, requiring manual intervention — coordinate via a comment when an issue is in flight).
 
 ### Planning
 - Document multiple implementation approaches

--- a/defaults/.claude/commands/loom/judge.md
+++ b/defaults/.claude/commands/loom/judge.md
@@ -40,6 +40,26 @@ You provide high-quality code evaluations by:
 - Ensuring tests adequately cover new functionality
 - Verifying documentation is clear and complete
 
+## Issues Are Suggestions — Close or Rescope With Rationale (Role Autonomy)
+
+Your review authority extends past the PR to its **underlying issue**: an issue is a **suggestion, not a mandate**, and the review pipeline is where a bad suggestion is most visible. You have standing authority to act on that judgment — with a stated rationale — rather than approving work toward an outcome that should not ship.
+
+**Two situations where this applies:**
+
+1. **Reviewing reveals the issue itself is wrong** — the PR is competent but the *change should not land* because the underlying issue is obsolete, already covered by a merged change, low-value vs. its cost, or built on a wrong approach. Request changes / close the PR **and** address the issue at its root: comment the rationale, then close the issue as not planned (or drop `loom:issue` and relabel back to `loom:triage`/`loom:curated` if it needs rescoping, not killing). Do not silently approve a PR whose only defect is that it should never have been built.
+   ```bash
+   gh issue comment <issue-number> --body "Closing as not planned: <rationale — surfaced during review of #<pr>>. <evidence>."
+   gh issue close <issue-number> --reason "not planned"
+   ```
+
+2. **You are filing a follow-up during review** — when you note an extreme-edge or low-value item, file it as an explicit *suggestion* (normal intake: `loom:triage` → Curator; never self-apply `loom:issue`) and, if it is genuinely trivial, prefer an inline PR comment over a new issue. Downstream Curators/Builders are empowered to close such follow-ups with a rationale — so keep them scoped and honest rather than filing noise the queue must later prune.
+
+**Guardrails (safety — do NOT skip these):**
+- **Always comment the rationale BEFORE closing.** `--reason "not planned"` marks a judgment call, not a fix.
+- **Never close an issue that encodes a still-pending human decision.** If the right call needs a human (policy, a controversial trade-off, security/access), route it — `loom:blocked` or `loom:operator-only` with a comment — do **not** close it.
+- **Never invent new labels.** Use only the existing label set.
+- **A closed issue leaves the queue automatically** (the autonomous work-finder only polls *open* `loom:issue` items); a **rescoped** issue must have `loom:issue` removed so it is not re-dispatched with a stale scope.
+
 ## Argument Handling
 
 Check for an argument passed via the slash command:

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -382,6 +382,14 @@ Agents coordinate work through forge labels (GitHub or Gitea). This enables auto
 - **`loom:blocked`**: Implementation blocked, needs help or clarification
 - **`loom:urgent`**: Critical issue requiring immediate attention
 
+### Issues Are Suggestions (Role Autonomy)
+
+Filed issues are the *input queue*, not mandates. In autonomous mode the **Curator, Builder, and Judge** have standing authority to **close** or **rescope** an issue — with a stated rationale — when building it is not the best outcome (obsolete, duplicate/already covered, low value vs. cost, wrong approach, better split/merged). This is what keeps the auto-picked-up backlog healthy rather than "build whatever is filed". Full mechanism + guardrails live in each role prompt's "Issues Are Suggestions — Close or Rescope With Rationale" section (`.loom/roles/curator.md`, `builder.md`, `judge.md`). The rules in brief:
+
+- **Comment the rationale BEFORE closing**, then `gh issue close <N> --reason "not planned"`. A closed issue leaves the queue automatically (the work-finder only polls *open* `loom:issue` items), so it is not re-picked-up.
+- **Rescope** instead of closing when the core is worth keeping: edit the body / split / relabel, and **remove `loom:issue`** if the labels no longer reflect an approved scope (drop back to `loom:triage`/`loom:curated`) so it is not re-dispatched with a stale scope.
+- **Never close an issue that encodes a still-pending human decision** — route it to `loom:blocked` or `loom:operator-only` with a comment instead. Never invent new labels.
+
 ## Git Worktree Workflow
 
 Loom uses git worktrees to isolate agent work on issues.


### PR DESCRIPTION
## Summary

Encodes the operator principle that **issues are suggestions, not mandates**: in autonomous mode the Curator, Builder, and Judge now have standing authority to **close** or **rescope** an issue (with a stated rationale) when building it is not the best outcome. This reverses the previous blanket "Never Close Issues" policy in the role prompts, replacing it with a bounded, guardrailed autonomy section so the auto-picked-up backlog stays healthy instead of "build whatever is filed."

## Changes

- **`defaults/.claude/commands/loom/curator.md`** (surfaced at `.loom/roles/curator.md` via symlink): replaced "CRITICAL: Never Close Issues" with "Issues Are Suggestions — Close or Rescope With Rationale"; updated the decomposition-parent note and the duplicate-detection / already-fixed handling to permit closing a *clear* duplicate or *verified* fix with a rationale (ambiguous cases still routed for human review).
- **`defaults/.claude/commands/loom/builder.md`**: replaced "CRITICAL: Never Close Issues" with the same autonomy section; bridged it to the existing `.no-changes-needed` marker so a Builder subagent under `/loom:sweep` lets orchestration finalize the lifecycle rather than racing it (direct `gh issue close` is for manual Builder runs).
- **`defaults/.claude/commands/loom/judge.md`**: added the autonomy section covering (1) closing/rescoping the underlying issue when review reveals it should not ship, and (2) filing review follow-ups as closeable *suggestions* (normal `loom:triage` intake; never self-apply `loom:issue`).
- **`CLAUDE.md` + `defaults/CLAUDE.md`**: concise "Issues Are Suggestions (Role Autonomy)" pointer under the label workflow.

## Mechanism + guardrails encoded

- **Close**: rationale comment FIRST, then `gh issue close <N> --reason "not planned"`.
- **Rescope**: edit body / split / relabel; **remove `loom:issue`** if labels no longer reflect an approved scope (drop to `loom:triage`/`loom:curated`).
- **Safety**: never close an issue encoding a still-pending human decision — route to `loom:blocked` / `loom:operator-only` instead; never invent new labels; don't close an issue another agent is actively building.
- **Work-finder composition**: a closed issue leaves the queue automatically (the work-finder only polls *open* `loom:issue` items); a rescoped issue must drop `loom:issue` so it is not re-dispatched in a loop with a stale scope.

## Test plan

Docs/prompts-only change. Verified: no remaining "Never Close Issues" strings in any role prompt; no tests or other command-file copies reference the old policy text; the `.loom/roles/*.md` symlinks resolve to the edited canonical files in `defaults/.claude/commands/loom/`.

Closes #3914