### PR TITLE
fix(daemon): default loom-daemon-start.sh to FLAGS-OFF (no auto work-finder) (#3911)

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -715,15 +715,23 @@ work-finder / health-gate loops. Two dedicated wrappers manage the raw daemon
 process:
 
 ```bash
-# Bring up autonomous mode (work finder + health gate) as a backgrounded process:
+# Plain start = FLAGS-OFF reliability daemon: BOTH autonomous loops OFF, no
+# auto-dispatch. This is the safe default (#3911), consistent with the
+# ecosystem-wide opt-in / default-off contract (LOOM_WORK_FINDER unset => off,
+# LOOM_MAIN_HEALTH_GATE unset => off, precedence env > config > default):
 ./.loom/scripts/cli/loom-daemon-start.sh
+
+# Opt in to autonomous loops explicitly:
+./.loom/scripts/cli/loom-daemon-start.sh --work-finder   # work finder on
+./.loom/scripts/cli/loom-daemon-start.sh --health-gate   # main-health gate on
+./.loom/scripts/cli/loom-daemon-start.sh --work-finder --health-gate   # both on
 
 # Enable strictly per .loom/config.json → autonomous (no env forcing):
 ./.loom/scripts/cli/loom-daemon-start.sh --from-config
 
-# Selective / foreground variants:
-./.loom/scripts/cli/loom-daemon-start.sh --no-work-finder   # gate only
-./.loom/scripts/cli/loom-daemon-start.sh --no-health-gate   # finder only
+# Explicit-off / foreground variants:
+./.loom/scripts/cli/loom-daemon-start.sh --no-work-finder   # force finder off (explicit; same as default)
+./.loom/scripts/cli/loom-daemon-start.sh --no-health-gate   # force gate off (explicit; same as default)
 ./.loom/scripts/cli/loom-daemon-start.sh --foreground       # run attached, no PID file
 
 # Clean shutdown:
@@ -732,6 +740,13 @@ process:
 ```
 
 `loom-daemon-start.sh`:
+- **defaults FLAGS-OFF (#3911)**: a bare invocation exports `LOOM_WORK_FINDER=0`
+  and `LOOM_MAIN_HEALTH_GATE=0`, so a plain start is a **reliability daemon** that
+  does **not** auto-dispatch sweeps — consistent with the ecosystem-wide opt-in /
+  default-off contract. An already-exported env var always wins; `--work-finder`
+  / `--health-gate` force the respective loop on; `--from-config` leaves both
+  unset so `.loom/config.json → autonomous` drives (precedence env > config >
+  default),
 - locates the `loom-daemon` binary (`LOOM_DAEMON_BIN` → `PATH` → `target/{release,debug}`),
 - runs the **advisory** host-sleep check (`check-host-sleep.sh`, #3350) — never blocks the start,
 - backgrounds the daemon and writes a PID file at `.loom/.daemon.pid` (gitignored),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,10 +342,20 @@ The Rust `loom-daemon` binary is the load-bearing Tier 2 dispatch backend. It is
 Start/stop the **raw daemon process** (distinct from the tmux `loom start|stop` pool) with dedicated wrappers that run the advisory host-sleep check, write a PID file (`.loom/.daemon.pid`), surface the singleton-guard refusal, and shut down cleanly on **SIGTERM** (not just Ctrl-C):
 
 ```bash
-./.loom/scripts/cli/loom-daemon-start.sh              # work finder + health gate, backgrounded
-./.loom/scripts/cli/loom-daemon-start.sh --from-config # enable strictly per .loom/config.json
-./.loom/scripts/cli/loom-daemon-stop.sh               # SIGTERM → grace → SIGKILL
+./.loom/scripts/cli/loom-daemon-start.sh                # FLAGS-OFF reliability daemon (both loops off, backgrounded)
+./.loom/scripts/cli/loom-daemon-start.sh --work-finder  # opt in: autonomous work finder
+./.loom/scripts/cli/loom-daemon-start.sh --health-gate  # opt in: main-health gate
+./.loom/scripts/cli/loom-daemon-start.sh --from-config  # enable strictly per .loom/config.json
+./.loom/scripts/cli/loom-daemon-stop.sh                 # SIGTERM → grace → SIGKILL
 ```
+
+> **Default is FLAGS-OFF (#3911).** A bare `loom-daemon-start.sh` starts a
+> reliability daemon with **both autonomous loops OFF** — it does **not**
+> auto-dispatch sweeps — matching the ecosystem-wide opt-in / default-off
+> contract (`LOOM_WORK_FINDER` unset ⇒ off, `LOOM_MAIN_HEALTH_GATE` unset ⇒ off,
+> precedence env > config > default). Enable autonomy explicitly with
+> `--work-finder` / `--health-gate`, or hand control to committed config with
+> `--from-config`.
 
 A clean stop leaves in-flight `/loom:sweep` children **running** (they survive a daemon restart by design; use `mcp__loom__cancel_sweep` to actively cancel). The full config table, start/stop flags, and a scripted end-to-end acceptance playbook are in [`.loom/docs/daemon-reference.md`](.loom/docs/daemon-reference.md) §Operability and [`docs/autonomous-mode-e2e.md`](docs/autonomous-mode-e2e.md).
 

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -687,11 +687,20 @@ See [`.loom/docs/daemon-reference.md`](.loom/docs/daemon-reference.md) for the w
 Start/stop the **raw daemon process** (distinct from the tmux `.loom/bin/loom start|stop` pool) with dedicated wrappers that run the advisory host-sleep check (#3350), write a PID file (`.loom/.daemon.pid`), surface the singleton-guard refusal (#3806), and shut down cleanly on **SIGTERM** (not just Ctrl-C/SIGINT):
 
 ```bash
-./.loom/scripts/cli/loom-daemon-start.sh               # work finder + health gate, backgrounded
-./.loom/scripts/cli/loom-daemon-start.sh --from-config # enable strictly per .loom/config.json → autonomous
-./.loom/scripts/cli/loom-daemon-start.sh --no-work-finder   # gate only
-./.loom/scripts/cli/loom-daemon-stop.sh                # SIGTERM → grace → SIGKILL (--force for immediate)
+./.loom/scripts/cli/loom-daemon-start.sh                # FLAGS-OFF reliability daemon (both loops off, backgrounded)
+./.loom/scripts/cli/loom-daemon-start.sh --work-finder  # opt in: autonomous work finder
+./.loom/scripts/cli/loom-daemon-start.sh --health-gate  # opt in: main-health gate
+./.loom/scripts/cli/loom-daemon-start.sh --from-config  # enable strictly per .loom/config.json → autonomous
+./.loom/scripts/cli/loom-daemon-stop.sh                 # SIGTERM → grace → SIGKILL (--force for immediate)
 ```
+
+> **Default is FLAGS-OFF (#3911).** A bare `loom-daemon-start.sh` starts a
+> reliability daemon with **both autonomous loops OFF** — it does **not**
+> auto-dispatch sweeps — matching the ecosystem-wide opt-in / default-off
+> contract (`LOOM_WORK_FINDER` unset ⇒ off, `LOOM_MAIN_HEALTH_GATE` unset ⇒ off,
+> precedence env > config > default). Enable autonomy explicitly with
+> `--work-finder` / `--health-gate`, or hand control to committed config with
+> `--from-config`.
 
 **Shutdown decision**: a clean stop leaves in-flight `/loom:sweep` children **running** — they are independent detached processes that survive a daemon restart by design (killing the dispatcher must not kill dispatched work); the registry reconciles them on the next start. Use `mcp__loom__cancel_sweep` against a running daemon to actively cancel a sweep before stopping. The full config table, start/stop flags, and a scripted end-to-end acceptance playbook are in [`.loom/docs/daemon-reference.md`](.loom/docs/daemon-reference.md) §Operability and [`docs/autonomous-mode-e2e.md`](../docs/autonomous-mode-e2e.md).
 

--- a/defaults/scripts/cli/loom-daemon-start.sh
+++ b/defaults/scripts/cli/loom-daemon-start.sh
@@ -12,17 +12,26 @@
 # It:
 #   - locates the loom-daemon binary,
 #   - runs the (advisory, never-blocking) host-sleep check (#3350),
-#   - enables autonomous mode (work finder + health gate) via env by default,
-#     or leaves it to .loom/config.json -> autonomous with --from-config,
+#   - starts a plain reliability daemon with BOTH autonomous loops OFF by
+#     default (matching the ecosystem-wide opt-in / default-off contract:
+#     LOOM_WORK_FINDER unset => off, LOOM_MAIN_HEALTH_GATE unset => off). Opt in
+#     explicitly with --work-finder / --health-gate, or hand control to
+#     .loom/config.json -> autonomous with --from-config (#3911),
 #   - backgrounds the daemon and writes a PID file (.loom/.daemon.pid),
 #   - surfaces the singleton-guard refusal (#3806) legibly instead of leaving a
 #     silently-exited background process.
 #
+# Default is FLAGS-OFF: a bare `loom-daemon-start.sh` does NOT auto-dispatch
+# sweeps. This is a deliberate safe default — enable autonomy explicitly.
+#
 # Usage:
-#   ./.loom/scripts/cli/loom-daemon-start.sh                 Start autonomous mode
+#   ./.loom/scripts/cli/loom-daemon-start.sh                 Reliability daemon (both loops OFF)
+#   ./.loom/scripts/cli/loom-daemon-start.sh --work-finder   Enable the autonomous work finder
+#   ./.loom/scripts/cli/loom-daemon-start.sh --health-gate   Enable the main-health gate
+#   ./.loom/scripts/cli/loom-daemon-start.sh --work-finder --health-gate   Both loops ON
 #   ./.loom/scripts/cli/loom-daemon-start.sh --from-config   Enable per .loom/config.json only
-#   ./.loom/scripts/cli/loom-daemon-start.sh --no-work-finder    Health gate only
-#   ./.loom/scripts/cli/loom-daemon-start.sh --no-health-gate    Work finder only
+#   ./.loom/scripts/cli/loom-daemon-start.sh --no-work-finder    Force work finder OFF (explicit)
+#   ./.loom/scripts/cli/loom-daemon-start.sh --no-health-gate    Force health gate OFF (explicit)
 #   ./.loom/scripts/cli/loom-daemon-start.sh --foreground    Run in the foreground (no PID file)
 #   ./.loom/scripts/cli/loom-daemon-start.sh --help
 #
@@ -48,7 +57,9 @@ warn() { echo -e "${YELLOW}$*${NC}" >&2; }
 ok()   { echo -e "${GREEN}$*${NC}"; }
 
 show_help() {
-    sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+    # Print the leading comment banner (line 2 through the last comment line
+    # before `set -uo pipefail`), stripping the leading "# ".
+    awk 'NR>=2 { if ($0 !~ /^#/) exit; sub(/^# ?/, ""); print }' "$0"
 }
 
 # ---------- repo root ----------
@@ -88,15 +99,20 @@ locate_daemon_bin() {
 }
 
 # ---------- args ----------
+# Default is FLAGS-OFF (#3911): both autonomous loops default OFF, matching the
+# ecosystem-wide opt-in / default-off contract. Opt in with --work-finder /
+# --health-gate, or hand control to config with --from-config.
 FROM_CONFIG=false
 FOREGROUND=false
-WANT_WORK_FINDER=true
-WANT_HEALTH_GATE=true
+WANT_WORK_FINDER=false
+WANT_HEALTH_GATE=false
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --help|-h) show_help; exit 0 ;;
         --from-config) FROM_CONFIG=true; shift ;;
         --foreground|--fg) FOREGROUND=true; shift ;;
+        --work-finder) WANT_WORK_FINDER=true; shift ;;
+        --health-gate) WANT_HEALTH_GATE=true; shift ;;
         --no-work-finder) WANT_WORK_FINDER=false; shift ;;
         --no-health-gate) WANT_HEALTH_GATE=false; shift ;;
         *) err "Unknown option '$1'"; echo "Use --help for usage" >&2; exit 1 ;;
@@ -142,9 +158,11 @@ fi
 
 # ---------- autonomous-mode env ----------
 # Precedence: an already-exported env var is always respected. Otherwise the
-# default is to enable both loops (the whole point of starting the daemon),
-# unless --from-config was passed (then leave them unset so .loom/config.json ->
-# autonomous drives) or a --no-* opt-out forces the var to 0.
+# default is FLAGS-OFF (#3911) — a plain start is a reliability daemon with both
+# autonomous loops OFF, matching the ecosystem-wide opt-in / default-off contract
+# (LOOM_WORK_FINDER unset => off, LOOM_MAIN_HEALTH_GATE unset => off). Opt in with
+# --work-finder / --health-gate (force the var to 1), or pass --from-config to
+# leave both unset so .loom/config.json -> autonomous drives.
 export LOOM_WORKSPACE="${LOOM_WORKSPACE:-$REPO_ROOT}"
 
 # ---------- guard-hook autonomy defaults (#3898) ----------
@@ -168,17 +186,24 @@ export LOOM_FORCE_SCOPE="${LOOM_FORCE_SCOPE:-protected}"
 if [[ "$FROM_CONFIG" == "true" ]]; then
     echo -e "${BOLD}Autonomous mode: driven by .loom/config.json -> autonomous (env not forced)${NC}"
 else
-    if [[ "$WANT_WORK_FINDER" == "false" ]]; then
-        export LOOM_WORK_FINDER=0
-    elif [[ -z "${LOOM_WORK_FINDER:-}" ]]; then
-        export LOOM_WORK_FINDER=1
+    # An already-exported env var always wins. Otherwise --work-finder /
+    # --health-gate force the loop ON (=1); the default (flags off) forces it
+    # OFF (=0), so a plain start is a reliability daemon that never auto-dispatches.
+    if [[ "$WANT_WORK_FINDER" == "true" ]]; then
+        export LOOM_WORK_FINDER="${LOOM_WORK_FINDER:-1}"
+    else
+        export LOOM_WORK_FINDER="${LOOM_WORK_FINDER:-0}"
     fi
-    if [[ "$WANT_HEALTH_GATE" == "false" ]]; then
-        export LOOM_MAIN_HEALTH_GATE=0
-    elif [[ -z "${LOOM_MAIN_HEALTH_GATE:-}" ]]; then
-        export LOOM_MAIN_HEALTH_GATE=1
+    if [[ "$WANT_HEALTH_GATE" == "true" ]]; then
+        export LOOM_MAIN_HEALTH_GATE="${LOOM_MAIN_HEALTH_GATE:-1}"
+    else
+        export LOOM_MAIN_HEALTH_GATE="${LOOM_MAIN_HEALTH_GATE:-0}"
     fi
-    echo -e "${BOLD}Autonomous mode:${NC} work_finder=${LOOM_WORK_FINDER:-config} main_health_gate=${LOOM_MAIN_HEALTH_GATE:-config}"
+    if [[ "$LOOM_WORK_FINDER" == "0" && "$LOOM_MAIN_HEALTH_GATE" == "0" ]]; then
+        echo -e "${BOLD}Reliability daemon:${NC} work_finder=off main_health_gate=off (both loops OFF; opt in with --work-finder / --health-gate / --from-config)"
+    else
+        echo -e "${BOLD}Autonomous mode:${NC} work_finder=${LOOM_WORK_FINDER} main_health_gate=${LOOM_MAIN_HEALTH_GATE}"
+    fi
 fi
 
 echo "Daemon binary: $DAEMON_BIN"

--- a/defaults/scripts/tests/test-loom-daemon-start.sh
+++ b/defaults/scripts/tests/test-loom-daemon-start.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# test-loom-daemon-start.sh — Tests for loom-daemon-start.sh autonomous-mode
+# env resolution.
+#
+# Focus (#3911): a bare `loom-daemon-start.sh` must default FLAGS-OFF — it must
+# NOT enable the autonomous work finder. Opt-in (--work-finder / --health-gate /
+# --from-config) and explicit-off (--no-work-finder) must still behave.
+#
+# Style matches test-spawn-claude.sh — plain bash, hand-rolled assertions.
+# Bats is NOT used in this repository.
+#
+# Strategy: drive the script in --foreground mode against a FAKE daemon binary
+# that prints the LOOM_WORK_FINDER / LOOM_MAIN_HEALTH_GATE it inherited, then
+# assert on that marker line. --foreground `exec`s the binary, so the exported
+# env is exactly what a real daemon would see.
+#
+# Usage:
+#   ./defaults/scripts/tests/test-loom-daemon-start.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+START_SCRIPT="$(cd "$SCRIPT_DIR/../cli" && pwd)/loom-daemon-start.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_eq() {
+    local expected="$1" actual="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "${GREEN}✓${NC} $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "${RED}✗${NC} $msg"
+        echo -e "  expected: [$expected]"
+        echo -e "  actual:   [$actual]"
+    fi
+}
+
+# ---------- fixture ----------
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+mkdir -p "$WORKDIR/.loom/logs"
+
+FAKE_BIN="$WORKDIR/fake-loom-daemon"
+cat > "$FAKE_BIN" <<'EOF'
+#!/usr/bin/env bash
+# Prints the autonomous-mode env it inherited, then exits cleanly.
+echo "FAKE_DAEMON WF=[${LOOM_WORK_FINDER:-}] HG=[${LOOM_MAIN_HEALTH_GATE:-}]"
+EOF
+chmod +x "$FAKE_BIN"
+
+# ---------- tests ----------
+
+# 1. Plain start = FLAGS-OFF: work finder off, health gate off.
+out=$( ( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE LOOM_DAEMON_BIN="$FAKE_BIN" bash "$START_SCRIPT" --foreground 2>/dev/null ) | grep '^FAKE_DAEMON' )
+assert_eq "FAKE_DAEMON WF=[0] HG=[0]" "$out" "plain start defaults both loops OFF (#3911)"
+
+# 2. --work-finder opts the finder on (gate stays off).
+out=$( ( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE LOOM_DAEMON_BIN="$FAKE_BIN" bash "$START_SCRIPT" --work-finder --foreground 2>/dev/null ) | grep '^FAKE_DAEMON' )
+assert_eq "FAKE_DAEMON WF=[1] HG=[0]" "$out" "--work-finder enables finder only"
+
+# 3. --health-gate opts the gate on (finder stays off).
+out=$( ( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE LOOM_DAEMON_BIN="$FAKE_BIN" bash "$START_SCRIPT" --health-gate --foreground 2>/dev/null ) | grep '^FAKE_DAEMON' )
+assert_eq "FAKE_DAEMON WF=[0] HG=[1]" "$out" "--health-gate enables gate only"
+
+# 4. Both flags → both on.
+out=$( ( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE LOOM_DAEMON_BIN="$FAKE_BIN" bash "$START_SCRIPT" --work-finder --health-gate --foreground 2>/dev/null ) | grep '^FAKE_DAEMON' )
+assert_eq "FAKE_DAEMON WF=[1] HG=[1]" "$out" "--work-finder --health-gate enables both"
+
+# 5. Already-exported env wins over the flags-off default.
+out=$( ( cd "$WORKDIR" && env -u LOOM_MAIN_HEALTH_GATE LOOM_WORK_FINDER=1 LOOM_DAEMON_BIN="$FAKE_BIN" bash "$START_SCRIPT" --foreground 2>/dev/null ) | grep '^FAKE_DAEMON' )
+assert_eq "FAKE_DAEMON WF=[1] HG=[0]" "$out" "exported LOOM_WORK_FINDER=1 wins on plain start"
+
+# 6. --from-config forces neither var (leaves both unset for config to drive).
+out=$( ( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE LOOM_DAEMON_BIN="$FAKE_BIN" bash "$START_SCRIPT" --from-config --foreground 2>/dev/null ) | grep '^FAKE_DAEMON' )
+assert_eq "FAKE_DAEMON WF=[] HG=[]" "$out" "--from-config leaves both env vars unset"
+
+# 7. --no-work-finder forces finder off (explicit; matches default).
+out=$( ( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE LOOM_DAEMON_BIN="$FAKE_BIN" bash "$START_SCRIPT" --no-work-finder --foreground 2>/dev/null ) | grep '^FAKE_DAEMON' )
+assert_eq "FAKE_DAEMON WF=[0] HG=[0]" "$out" "--no-work-finder forces finder off"
+
+# 8. --help mentions the FLAGS-OFF default and the opt-in flags.
+help_out=$(bash "$START_SCRIPT" --help 2>/dev/null)
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$help_out" | grep -qi 'FLAGS-OFF' && echo "$help_out" | grep -q -- '--work-finder'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --help documents the FLAGS-OFF default and --work-finder"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --help documents the FLAGS-OFF default and --work-finder"
+fi
+
+# ---------- summary ----------
+echo
+echo "Ran $TESTS_RUN tests: $TESTS_PASSED passed, $TESTS_FAILED failed"
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/docs/autonomous-mode-e2e.md
+++ b/docs/autonomous-mode-e2e.md
@@ -53,8 +53,9 @@ Add the `autonomous` block to `.loom/config.json` (see
 
 ```bash
 ./.loom/scripts/cli/loom-daemon-start.sh --from-config
-# or force the loops on regardless of config:
-./.loom/scripts/cli/loom-daemon-start.sh
+# or force the loops on regardless of config (a bare start is FLAGS-OFF, #3911,
+# so opt in explicitly — it does NOT enable autonomy on its own):
+./.loom/scripts/cli/loom-daemon-start.sh --work-finder --health-gate
 ```
 
 Confirm the work finder is ticking:


### PR DESCRIPTION
## Summary

`loom-daemon-start.sh` previously defaulted `WANT_WORK_FINDER=true` / `WANT_HEALTH_GATE=true`, so a plain `./loom-daemon-start.sh` exported `LOOM_WORK_FINDER=1` and `LOOM_MAIN_HEALTH_GATE=1` — silently enabling autonomous forge-polling sweep dispatch from what reads like a neutral "start the daemon" command. That inverted the ecosystem-wide **opt-in / default-off** contract every other autonomy surface follows.

This implements option (a) from the issue: make the start-script default **agree** with the env/config default (off).

## Changes

- **Both autonomous loops now default OFF.** A bare start is a *reliability daemon* that does not auto-dispatch. It exports `LOOM_WORK_FINDER=0` / `LOOM_MAIN_HEALTH_GATE=0` (an already-exported env var still always wins, preserving `env > config > default`).
- **New opt-in flags** `--work-finder` / `--health-gate` force the respective loop on. `--from-config` still hands control to `.loom/config.json → autonomous` (leaves both env vars unset). `--no-work-finder` / `--no-health-gate` remain as explicit-off (now matching the default).
- Updated `--help` banner (and made `show_help` range-independent), plus `CLAUDE.md`, `defaults/CLAUDE.md`, `.loom/docs/daemon-reference.md`, and `docs/autonomous-mode-e2e.md` (the E2E playbook now opts in explicitly, since a bare start no longer enables autonomy).
- Added `defaults/scripts/tests/test-loom-daemon-start.sh` (8 assertions: default-off, `--work-finder`/`--health-gate` opt-in, env-wins, `--from-config` leaves env unset, `--no-work-finder`, and `--help` documents the new default).

The installed `.loom/scripts/cli/` copy is not git-tracked (synced from `defaults/` at install time); the canonical `defaults/` source is updated here.

## Test results

`bash defaults/scripts/tests/test-loom-daemon-start.sh` → **8 passed, 0 failed**. `bash -n` and `shellcheck -S warning` both clean.

Closes #3911

🤖 Generated with [Claude Code](https://claude.com/claude-code)