### PR TITLE
fix(guards): pin protected-mode force-op test to synthetic branch (#3913)

### DIFF
--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -1793,25 +1793,33 @@ assert_deny_env "#3898: force-push to main still HARD-DENIES in protected mode" 
 assert_deny_env "#3898: force-push to master still HARD-DENIES in protected mode" \
     "LOOM_FORCE_SCOPE=protected" "git push -f origin master"
 
-# Own working-branch force ops pass through (no stall) in protected mode. The
-# checked-out branch of REPO_ROOT is a feature branch, not a protected branch.
+# Own working-branch force ops pass through (no stall) in protected mode. Pin to a
+# SYNTHETIC feature-branch fixture repo rather than REPO_ROOT (#3913): a bare
+# `git reset --hard` resolves the *checked-out* branch of the cwd, so using
+# REPO_ROOT made this assertion checkout-branch-sensitive — it spuriously failed
+# when the test was run from a checkout that happened to be on `main`/`master`
+# (where a hard-reset correctly stays protected → ASK). The fixture is always on
+# `feature/work`, making the assertion checkout-independent.
+FS_FEATURE_REPO=$(make_sql_repo '{"guards":{"forceScope":"protected"}}')
+git -C "$FS_FEATURE_REPO" checkout -q -b feature/work 2>/dev/null || \
+    git -C "$FS_FEATURE_REPO" checkout -q -b feature/work
 assert_allow_env "#3898: hard-reset on own working branch is allowed in protected mode" \
-    "LOOM_FORCE_SCOPE=protected" "git reset --hard HEAD~1"
+    "LOOM_FORCE_SCOPE=protected" "git reset --hard HEAD~1" "$FS_FEATURE_REPO"
 
 assert_allow_env "#3898: force-push to a non-protected branch is allowed in protected mode" \
-    "LOOM_FORCE_SCOPE=protected" "git push --force origin feature/some-work"
+    "LOOM_FORCE_SCOPE=protected" "git push --force origin feature/some-work" "$FS_FEATURE_REPO"
 
-# Default (all) mode still ASKS on own-branch force ops (byte-for-byte behaviour).
-TOTAL=$((TOTAL + 1))
-_fs_out=$(run_guard "git reset --hard HEAD~1" "$REPO_ROOT") || true
-if echo "$_fs_out" | jq -e '.hookSpecificOutput.permissionDecision == "ask"' >/dev/null 2>&1; then
-    PASS=$((PASS + 1))
-    echo -e "  ${GREEN}PASS${NC}: #3898: default (all) mode still ASKS on own-branch hard-reset"
-else
-    FAIL=$((FAIL + 1))
-    echo -e "  ${RED}FAIL${NC}: #3898: default (all) mode still ASKS on own-branch hard-reset"
-    echo -e "       Got: $_fs_out"
-fi
+# "all" mode still ASKS on own-branch force ops regardless of branch. Force the
+# mode explicitly via env and pin cwd to the synthetic feature-branch fixture
+# (#3913): the previous form relied on an env-absent `run_guard` against
+# REPO_ROOT, which was doubly environment-sensitive — an ambient LOOM_FORCE_SCOPE
+# (e.g. the `protected` autonomous-daemon default, #3898) overrode the intended
+# "all" resolution, and the outcome then depended on REPO_ROOT's checked-out
+# branch. Forcing LOOM_FORCE_SCOPE=all against a fixture that is always on a
+# feature branch proves the intended property (all-mode asks even on a
+# non-protected branch) independent of ambient env and the runner's checkout.
+assert_ask_env "#3898: all mode still ASKS on own-branch hard-reset (branch-independent)" \
+    "LOOM_FORCE_SCOPE=all" "git reset --hard HEAD~1" "$FS_FEATURE_REPO"
 
 echo ""
 


### PR DESCRIPTION
## Summary

The `#3898` guard assertions for own-branch force ops under `guards.forceScope:"protected"` defaulted their cwd to `REPO_ROOT` (the real loom checkout). A bare `git reset --hard` resolves the **checked-out branch of the cwd**, so the assertion "hard-reset on own working branch allowed in protected mode" was **checkout-branch-sensitive**: it passed from a feature-branch checkout (as CI runs) but spuriously failed when the runner happened to be on `main`/`master` (where a hard-reset correctly stays protected → ASK). The guard behaviour is correct; only the test implicitly assumed the runner was not on a protected branch.

## Change

`tests/hooks/test-guard-destructive.sh` — pin the three own-branch `#3898` assertions to a **synthetic feature-branch fixture repo** (created via `make_sql_repo` + `git checkout -b feature/work`) instead of `REPO_ROOT`:

- `hard-reset on own working branch is allowed in protected mode` → pinned cwd
- `force-push to a non-protected branch is allowed in protected mode` → pinned cwd
- the companion "all mode still ASKS" case — previously a hand-rolled env-absent `run_guard` against `REPO_ROOT` — is converted to `assert_ask_env` with an explicit `LOOM_FORCE_SCOPE=all` and pinned to the same fixture, so it proves the intended property (all-mode asks even on a non-protected branch) independent of both the runner's checkout and any ambient `LOOM_FORCE_SCOPE` (e.g. the `protected` autonomous-daemon default set by `loom-daemon-start.sh`).

**Intent preserved**: own-branch force op allowed under `forceScope:protected`; `main`/`master` force-push still HARD-DENIES via `ALWAYS_BLOCK_PATTERNS` (those assertions are unchanged). No production hook code touched — this is a test-only fix.

## Test evidence

Command: `bash tests/hooks/test-guard-destructive.sh`

| Environment | Result |
|---|---|
| Clean CI-like (`LOOM_FORCE_SCOPE`/`LOOM_GUARD_DECISION_LOG` unset) | **407/407 PASS** (`ALL TESTS PASSED`) |
| The three targeted assertions under clean env | PASS |
| The three targeted assertions under ambient `LOOM_FORCE_SCOPE=protected` | PASS |
| The three targeted assertions under ambient `LOOM_FORCE_SCOPE=all` | PASS |

Before the fix, the `hard-reset on own working branch` assertion failed when run from a checkout on `main` (reproduced on the `main` worktree). After the fix it passes regardless of the runner's branch and regardless of any ambient `LOOM_FORCE_SCOPE`.

## Note (out of scope, potential follow-up)

While diagnosing, I found the broader force-scope and decision-log test sections are also sensitive to an ambient `LOOM_FORCE_SCOPE` / `LOOM_GUARD_DECISION_LOG` (env overrides the per-fixture config those assertions rely on): ~9–13 assertions fail when either var is exported in the process environment, as happens inside an autonomous sweep. CI runs in a clean environment so those pass there. Making the entire suite immune to ambient guard env vars is a larger change than this issue's checkout-branch scope; flagging it as a candidate follow-up rather than expanding scope here.

Closes #3913

🤖 Generated with [Claude Code](https://claude.com/claude-code)