### PR TITLE
feat(tokens): rotate concurrent dispatches one-per-account in rotating order (#3909)

### DIFF
--- a/loom-tools/src/loom_tools/tokens/_locking.py
+++ b/loom-tools/src/loom_tools/tokens/_locking.py
@@ -1,0 +1,78 @@
+"""Shared mkdir-based file lock for the tokens package.
+
+Several token state files (``.bad_tokens``, the rotation cursor) are shared
+across concurrent bash and Python writers. We coordinate with a sibling
+``*.lock`` directory, created via ``mkdir`` (POSIX atomic). ``flock`` is
+intentionally not used because it is unavailable on stock macOS.
+
+This module is import-safe: no I/O occurs at import time.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+# Lock parameters (shared defaults; matched historic bad_tokens values).
+_LOCK_TIMEOUT_SECONDS = 5.0
+_LOCK_POLL_INTERVAL = 0.1
+_STALE_LOCK_THRESHOLD_SECONDS = 30.0
+
+
+class MkdirLock:
+    """Context manager wrapping a directory-as-lock.
+
+    Acquires by creating ``lock_path``. Times out after ``timeout`` seconds.
+    Cleans up stale locks (older than ``stale_threshold`` seconds) before
+    giving up.
+
+    Always releases the lock on ``__exit__`` (via rmdir). If the lock was
+    never acquired (timeout), ``__exit__`` is a no-op.
+    """
+
+    def __init__(
+        self,
+        lock_path: Path,
+        *,
+        timeout: float = _LOCK_TIMEOUT_SECONDS,
+        poll_interval: float = _LOCK_POLL_INTERVAL,
+        stale_threshold: float = _STALE_LOCK_THRESHOLD_SECONDS,
+    ):
+        self._lock_path = lock_path
+        self._timeout = timeout
+        self._poll_interval = poll_interval
+        self._stale_threshold = stale_threshold
+        self._acquired = False
+
+    def __enter__(self) -> "MkdirLock":
+        deadline = time.monotonic() + self._timeout
+        while time.monotonic() < deadline:
+            try:
+                self._lock_path.mkdir(parents=False, exist_ok=False)
+                self._acquired = True
+                return self
+            except FileExistsError:
+                # Stale-lock cleanup
+                try:
+                    age = time.time() - self._lock_path.stat().st_mtime
+                    if age > self._stale_threshold:
+                        try:
+                            self._lock_path.rmdir()
+                        except OSError:
+                            pass
+                except FileNotFoundError:
+                    # Lock vanished between checks; loop and retry mkdir
+                    continue
+                time.sleep(self._poll_interval)
+        raise TimeoutError(
+            f"Could not acquire lock at {self._lock_path} "
+            f"within {self._timeout}s"
+        )
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        if self._acquired:
+            try:
+                self._lock_path.rmdir()
+            except OSError:
+                # Lock already gone — log-friendly silent
+                pass

--- a/loom-tools/src/loom_tools/tokens/bad_tokens.py
+++ b/loom-tools/src/loom_tools/tokens/bad_tokens.py
@@ -6,8 +6,8 @@ calls skip these tokens.
 
 The file is shared across concurrent bash and Python writers. We coordinate
 with a sibling ``.bad_tokens.lock`` directory, created via ``mkdir`` (POSIX
-atomic). ``flock`` is intentionally not used because it is unavailable on
-stock macOS.
+atomic) — see ``loom_tools.tokens._locking.MkdirLock``. ``flock`` is
+intentionally not used because it is unavailable on stock macOS.
 
 File format (one entry per line):
     <ISO8601 UTC timestamp> <token_name> <reason words...>
@@ -19,63 +19,10 @@ collide.
 from __future__ import annotations
 
 import re
-import time
 from datetime import datetime, timezone
 from pathlib import Path
 
-# Lock parameters
-_LOCK_TIMEOUT_SECONDS = 5.0
-_LOCK_POLL_INTERVAL = 0.1
-_STALE_LOCK_THRESHOLD_SECONDS = 30.0
-
-
-class _MkdirLock:
-    """Context manager wrapping a directory-as-lock.
-
-    Acquires by creating ``lock_path``. Times out after _LOCK_TIMEOUT_SECONDS.
-    Cleans up stale locks (older than _STALE_LOCK_THRESHOLD_SECONDS) before
-    giving up.
-
-    Always releases the lock on ``__exit__`` (via rmdir). If the lock was
-    never acquired (timeout), ``__exit__`` is a no-op.
-    """
-
-    def __init__(self, lock_path: Path):
-        self._lock_path = lock_path
-        self._acquired = False
-
-    def __enter__(self) -> "_MkdirLock":
-        deadline = time.monotonic() + _LOCK_TIMEOUT_SECONDS
-        while time.monotonic() < deadline:
-            try:
-                self._lock_path.mkdir(parents=False, exist_ok=False)
-                self._acquired = True
-                return self
-            except FileExistsError:
-                # Stale-lock cleanup
-                try:
-                    age = time.time() - self._lock_path.stat().st_mtime
-                    if age > _STALE_LOCK_THRESHOLD_SECONDS:
-                        try:
-                            self._lock_path.rmdir()
-                        except OSError:
-                            pass
-                except FileNotFoundError:
-                    # Lock vanished between checks; loop and retry mkdir
-                    continue
-                time.sleep(_LOCK_POLL_INTERVAL)
-        raise TimeoutError(
-            f"Could not acquire bad_tokens lock at {self._lock_path} "
-            f"within {_LOCK_TIMEOUT_SECONDS}s"
-        )
-
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
-        if self._acquired:
-            try:
-                self._lock_path.rmdir()
-            except OSError:
-                # Lock already gone — log-friendly silent
-                pass
+from loom_tools.tokens._locking import MkdirLock as _MkdirLock
 
 
 def _bad_tokens_path(tokens_dir: Path) -> Path:

--- a/loom-tools/src/loom_tools/tokens/rotation.py
+++ b/loom-tools/src/loom_tools/tokens/rotation.py
@@ -1,0 +1,108 @@
+"""Rotation cursor for one-per-account distribution of concurrent dispatches.
+
+Issue #3909: the ranked selection tier used to pick the single best-ranked
+(or a random top-N) account, so a burst of N concurrent dispatches stacked all
+N onto one account — exhausting its 5h limit while others sat idle. This module
+provides a persistent, concurrency-safe *rotation cursor* so that consecutive
+selections (whether sequential or concurrent) round-robin across the available
+accounts one-per-account, in rotating order, until they wrap.
+
+Mechanism: a monotonic integer counter is stored in ``.loom/tokens/.rotation_cursor``.
+Each ``next_rotation_index`` call, under a mkdir-based lock (POSIX atomic;
+``flock`` is unavailable on stock macOS — see ``_locking.MkdirLock``):
+
+    1. reads the current counter (initializing it to a *random* offset the
+       first time, so sibling daemons in different repos that share an account
+       pool but not this cursor file start de-correlated rather than all
+       colliding on index 0),
+    2. computes ``counter % modulus`` as the index to return,
+    3. writes ``counter + 1`` back.
+
+Because concurrent callers each acquire the lock and take the next distinct
+counter value, N concurrent selections over M available accounts receive N
+consecutive counter values → ``min(N, M)`` distinct indices, wrapping past M.
+Using a monotonic counter modulo the *current* modulus means the round-robin
+adapts automatically as accounts drop in/out of the available set.
+
+This module is import-safe: no I/O occurs at import time.
+"""
+
+from __future__ import annotations
+
+import random
+from pathlib import Path
+
+from loom_tools.tokens._locking import MkdirLock
+
+# Keep the initial random offset well within a range that never overflows a
+# text int and stays comfortably above any realistic account count so the
+# first modulo is uniformly distributed across accounts.
+_INIT_OFFSET_BOUND = 1 << 30
+
+
+def _cursor_path(tokens_dir: Path) -> Path:
+    return tokens_dir / ".rotation_cursor"
+
+
+def _lock_path(tokens_dir: Path) -> Path:
+    return tokens_dir / ".rotation_cursor.lock"
+
+
+def _read_counter(cursor_file: Path) -> int | None:
+    """Read the stored monotonic counter, or ``None`` if missing/malformed."""
+    try:
+        raw = cursor_file.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    if not raw:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+def next_rotation_index(
+    tokens_dir: Path,
+    modulus: int,
+    rng: random.Random,
+) -> int:
+    """Return the next round-robin index in ``[0, modulus)`` and advance the cursor.
+
+    Args:
+        tokens_dir: The ``.loom/tokens/`` directory holding the cursor file.
+        modulus: Number of available accounts to rotate across (must be >= 1).
+        rng: Random source used only to seed the cursor's initial offset the
+            first time (for cross-repo de-correlation). Subsequent calls are
+            deterministic round-robin regardless of ``rng``.
+
+    The read-compute-write cycle is guarded by a mkdir-based lock so concurrent
+    callers receive distinct consecutive counter values (one-per-account).
+
+    On any lock-timeout or I/O failure this degrades gracefully to a random
+    index rather than raising — selection must never hard-fail on cursor
+    bookkeeping while accounts remain available (preserves the #3907 floor).
+    """
+    if modulus <= 1:
+        # A single (or empty) window has nothing to rotate across.
+        return 0
+
+    cursor_file = _cursor_path(tokens_dir)
+    try:
+        with MkdirLock(_lock_path(tokens_dir)):
+            counter = _read_counter(cursor_file)
+            if counter is None:
+                # First use (or a corrupt cursor): start at a random offset so
+                # sibling spawners that don't share this file don't all begin
+                # at index 0. Subsequent calls advance deterministically.
+                counter = rng.randrange(_INIT_OFFSET_BOUND)
+            index = counter % modulus
+            try:
+                cursor_file.write_text(str(counter + 1), encoding="utf-8")
+            except OSError:
+                # Best-effort persistence; still return a valid index.
+                pass
+            return index
+    except (TimeoutError, OSError):
+        # Never wedge selection on cursor bookkeeping — spread randomly.
+        return rng.randrange(modulus)

--- a/loom-tools/src/loom_tools/tokens/select.py
+++ b/loom-tools/src/loom_tools/tokens/select.py
@@ -1,11 +1,14 @@
 """Token selection algorithm — 3-tier priority.
 
 Selection order:
-    1. Ranking file (.ranking, <10 min old): pick randomly among the top-N
-       non-exhausted/non-blocked accounts (default N=3, configurable via
-       ``LOOM_TOKEN_SPREAD_TOP_N`` / ``tokens.spreadTopN``; N=1 = greedy
-       first-eligible), skipping bad tokens. Spreading across the top-N
-       avoids concurrent spawners colliding on .ranking[0] (issue #3736).
+    1. Ranking file (.ranking, <10 min old): rotate one-per-account across the
+       available (non-exhausted/non-blocked/non-bad) ranked accounts using a
+       persistent rotation cursor, so a burst of N concurrent dispatches spreads
+       across ``min(N, available)`` distinct accounts rather than stacking on the
+       single best-ranked (issue #3909, superseding the earlier random top-N
+       spread of #3736). The rotation window spans *all* available accounts by
+       default; ``LOOM_TOKEN_SPREAD_TOP_N`` / ``tokens.spreadTopN`` optionally
+       caps it to the top-N most-available (N=1 = greedy first-eligible).
     2. Allowlist file (.allowlist): random pick from allowed accounts.
     3. Random pick from all .token files.
 
@@ -45,6 +48,7 @@ from typing import Iterable
 
 from loom_tools.common.config import env_int
 from loom_tools.tokens.bad_tokens import is_bad
+from loom_tools.tokens.rotation import next_rotation_index
 
 # Ranking file is considered fresh for this many seconds.
 _RANKING_FRESH_SECONDS = 600  # 10 min
@@ -52,11 +56,14 @@ _RANKING_FRESH_SECONDS = 600  # 10 min
 # Exit code when no token is available (matches sysexits.h EX_CONFIG)
 EX_CONFIG = 78
 
-# Default number of top-ranked eligible accounts to spread spawns across.
-# See issue #3736: picking only .ranking[0] deterministically collides
-# concurrent spawners (e.g. sibling daemons on a shared claude-monitor pool)
-# onto the single least-utilized account, tripping its session limit.
-_DEFAULT_SPREAD_TOP_N = 3
+# Rotation window cap for the ranked tier. ``None`` (the default) means "rotate
+# across *all* available accounts" — issue #3909: distributing concurrent
+# dispatches one-per-account across every available account (not just a top-N
+# slice) is what lets the pool run at full speed and drain evenly. A positive
+# ``LOOM_TOKEN_SPREAD_TOP_N`` / ``tokens.spreadTopN`` optionally caps the window
+# to the top-N most-available accounts (N=1 = greedy first-eligible, the
+# historical behavior); a value <= 0 also means unbounded.
+_DEFAULT_SPREAD_TOP_N: int | None = None
 
 
 class TokenSelectionError(Exception):
@@ -135,29 +142,32 @@ def _read_allowlist(allowlist_file: Path) -> list[str]:
     return out
 
 
-def _resolve_spread_top_n(workspace_path: Path) -> int:
-    """Resolve the top-N spread window for the ranked strategy.
+def _resolve_spread_top_n(workspace_path: Path) -> int | None:
+    """Resolve the rotation-window cap for the ranked strategy.
 
     Precedence (highest first), mirroring the nested-key + env-override
     precedent in ``common/paths.py`` and ``common/gitea.py``:
 
         1. ``LOOM_TOKEN_SPREAD_TOP_N`` env var.
         2. ``.loom/config.json`` -> ``tokens.spreadTopN`` (soft-fail read).
-        3. Default (``_DEFAULT_SPREAD_TOP_N`` = 3).
+        3. Default (``_DEFAULT_SPREAD_TOP_N`` = ``None`` = unbounded).
 
-    Values are clamped to ``>= 1``. ``N == 1`` restores the historical greedy
-    first-eligible behavior exactly (back-compat escape hatch).
+    Returns the positive cap, or ``None`` meaning "rotate across all available
+    accounts" (issue #3909). A configured value ``<= 0`` also means unbounded.
+    ``N == 1`` restores the historical greedy first-eligible behavior exactly
+    (back-compat escape hatch).
     """
     # 1. Env var override (highest precedence).
     if os.environ.get("LOOM_TOKEN_SPREAD_TOP_N") is not None:
-        return max(1, env_int("LOOM_TOKEN_SPREAD_TOP_N", default=_DEFAULT_SPREAD_TOP_N))
+        n = env_int("LOOM_TOKEN_SPREAD_TOP_N", default=0)
+        return n if n >= 1 else None
 
     # 2. Config key — .loom/config.json -> tokens.spreadTopN (soft-fail read).
     config_n = _read_config_spread_top_n(workspace_path)
     if config_n is not None:
-        return max(1, config_n)
+        return config_n if config_n >= 1 else None
 
-    # 3. Default.
+    # 3. Default (unbounded).
     return _DEFAULT_SPREAD_TOP_N
 
 
@@ -192,24 +202,28 @@ def _try_ranking(
     workspace_path: Path,
     rng: random.Random,
 ) -> SelectedToken | None:
-    """Strategy 1: read .ranking, pick randomly among the top-N eligible entries.
+    """Strategy 1: read .ranking, rotate one-per-account across eligible entries.
 
-    Historically this returned the *first* non-exhausted/non-blocked entry.
-    Because ``.ranking`` is ordered most-available-first, every concurrent
-    spawner reading a fresh ranking picked the identical account, serializing
-    load onto one account and tripping its session limit (issue #3736).
+    Historically this returned the *first* non-exhausted/non-blocked entry, so
+    every concurrent spawner reading a fresh ranking picked the identical
+    account, serializing load onto one account (issue #3736). #3736 mitigated
+    this with a random pick among the top-N; but a burst of N concurrent
+    dispatches still stacked several onto the same account, exhausting its 5h
+    limit while others idled (issue #3909).
 
-    We now collect up to the top-N eligible ranked entries (skipping
-    exhausted/blocked/bad/missing/empty tokens, preserving ranking order) and
-    ``rng.choice`` among them, spreading concurrent spawners across the most
-    available accounts while still preferring healthy ones. N is resolved via
-    ``_resolve_spread_top_n``; ``N == 1`` restores the old greedy behavior.
+    We now collect the eligible ranked entries (skipping exhausted/blocked/bad/
+    missing/empty tokens, preserving most-available-first ranking order) and
+    select via a persistent rotation cursor, so consecutive selections — whether
+    sequential or concurrent — round-robin one-per-account across all available
+    accounts, in rotating order. The window spans every eligible account by
+    default; ``_resolve_spread_top_n`` optionally caps it to the top-N
+    most-available (``N == 1`` restores the greedy first-eligible behavior).
     """
     age = _file_age_seconds(ranking_file)
     if age is None or age >= _RANKING_FRESH_SECONDS:
         return None
 
-    top_n = _resolve_spread_top_n(workspace_path)
+    cap = _resolve_spread_top_n(workspace_path)
     eligible: list[SelectedToken] = []
     for name, status in _read_ranking(ranking_file):
         if status in ("exhausted", "blocked"):
@@ -228,12 +242,13 @@ def _try_ranking(
         eligible.append(
             SelectedToken(name=name, file=token_file, key=key, mode="ranked"),
         )
-        if len(eligible) >= top_n:
+        if cap is not None and len(eligible) >= cap:
             break
 
     if not eligible:
         return None
-    return rng.choice(eligible)
+    index = next_rotation_index(tokens_dir, len(eligible), rng)
+    return eligible[index]
 
 
 def _stale_ranking_exclusions(ranking_file: Path) -> set[str]:

--- a/loom-tools/tests/tokens/test_rotation.py
+++ b/loom-tools/tests/tokens/test_rotation.py
@@ -1,0 +1,106 @@
+"""Tests for loom_tools.tokens.rotation (issue #3909)."""
+
+from __future__ import annotations
+
+import random
+import threading
+from pathlib import Path
+
+from loom_tools.tokens.rotation import (
+    _INIT_OFFSET_BOUND,
+    _cursor_path,
+    next_rotation_index,
+)
+
+
+def _make_tokens_dir(tmp_path: Path) -> Path:
+    d = tmp_path / ".loom" / "tokens"
+    d.mkdir(parents=True)
+    return d
+
+
+def test_modulus_one_returns_zero_and_writes_nothing(tmp_path):
+    d = _make_tokens_dir(tmp_path)
+    for _ in range(5):
+        assert next_rotation_index(d, 1, random.Random(0)) == 0
+    # No cursor file is created when there is nothing to rotate across.
+    assert not _cursor_path(d).exists()
+
+
+def test_modulus_zero_returns_zero(tmp_path):
+    d = _make_tokens_dir(tmp_path)
+    assert next_rotation_index(d, 0, random.Random(0)) == 0
+
+
+def test_first_index_seeded_from_rng(tmp_path):
+    d = _make_tokens_dir(tmp_path)
+    modulus = 4
+    # The first call initializes the cursor from rng.randrange(_INIT_OFFSET_BOUND).
+    expected_offset = random.Random(123).randrange(_INIT_OFFSET_BOUND)
+    idx = next_rotation_index(d, modulus, random.Random(123))
+    assert idx == expected_offset % modulus
+
+
+def test_consecutive_calls_round_robin(tmp_path):
+    d = _make_tokens_dir(tmp_path)
+    modulus = 4
+    first = next_rotation_index(d, modulus, random.Random(7))
+    # Subsequent calls advance by exactly one each, regardless of rng.
+    seq = [first]
+    for _ in range(7):
+        seq.append(next_rotation_index(d, modulus, random.Random(999)))
+    expected = [(first + i) % modulus for i in range(len(seq))]
+    assert seq == expected
+    # One full cycle (modulus calls) covers every index exactly once.
+    assert set(seq[:modulus]) == set(range(modulus))
+
+
+def test_first_offset_varies_across_pools(tmp_path):
+    """Fresh cursors seeded from different rngs de-correlate the first pick."""
+    firsts = set()
+    for seed in range(20):
+        d = _make_tokens_dir(tmp_path / f"pool-{seed}")
+        firsts.add(next_rotation_index(d, 5, random.Random(seed)))
+    # Not always the same starting index (cross-repo de-correlation).
+    assert len(firsts) > 1
+
+
+def test_concurrent_calls_get_distinct_indices(tmp_path):
+    """Threads sharing one cursor receive distinct consecutive indices.
+
+    With modulus >= thread count, every concurrent caller lands on a distinct
+    account (one-per-account) — the core #3909 property under real concurrency.
+    """
+    d = _make_tokens_dir(tmp_path)
+    n_threads = 8
+    modulus = n_threads  # exactly the thread count => all distinct expected
+    results: list[int] = []
+    lock = threading.Lock()
+    barrier = threading.Barrier(n_threads)
+
+    def worker() -> None:
+        barrier.wait()
+        idx = next_rotation_index(d, modulus, random.Random())
+        with lock:
+            results.append(idx)
+
+    threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # All indices distinct and covering the full window: no two threads
+    # collided on the same account.
+    assert sorted(results) == list(range(modulus))
+
+
+def test_corrupt_cursor_reinitializes(tmp_path):
+    d = _make_tokens_dir(tmp_path)
+    _cursor_path(d).write_text("not-an-int", encoding="utf-8")
+    # Malformed cursor must not raise; it re-initializes cleanly.
+    idx = next_rotation_index(d, 3, random.Random(0))
+    assert 0 <= idx < 3
+    # And the next call advances by one from the re-seeded value.
+    idx2 = next_rotation_index(d, 3, random.Random(0))
+    assert idx2 == (idx + 1) % 3

--- a/loom-tools/tests/tokens/test_select.py
+++ b/loom-tools/tests/tokens/test_select.py
@@ -306,32 +306,46 @@ def test_ranking_falls_through_when_all_exhausted(tmp_path):
     assert sel.mode == "random"
 
 
-# ---------- ranking spread (issue #3736) ----------
+# ---------- ranking spread (issue #3736 / rotation #3909) ----------
 
 
-def test_ranking_spreads_across_top_n_with_varying_seeds(tmp_path, monkeypatch):
-    """Varying rng seeds must select different accounts among the top-N.
+def test_ranking_default_rotates_across_all_available(tmp_path, monkeypatch):
+    """Default (unbounded) window rotates one-per-account across ALL available.
 
-    This is the anti-collision property: concurrent spawners (each with an
-    independent rng) should NOT deterministically land on .ranking[0].
+    Issue #3909: the ranked tier no longer caps the spread to a top-N slice by
+    default — consecutive selections round-robin across every available account
+    so the pool drains evenly instead of stacking on the best-ranked few.
     """
     monkeypatch.delenv("LOOM_TOKEN_SPREAD_TOP_N", raising=False)
     workspace = _make_workspace(
         tmp_path, {"a": "ka", "b": "kb", "c": "kc", "d": "kd", "e": "ke"},
     )
-    # All available; ranking order a,b,c,d,e. Default N=3 => window {a,b,c}.
     _write_ranking(workspace, ["a|", "b|", "c|", "d|", "e|"])
-    top_n = {"a", "b", "c"}
-    chosen: set[str] = set()
-    for seed in range(50):
-        sel = select_token(workspace, rng=random.Random(seed))
+    all_accounts = {"a", "b", "c", "d", "e"}
+    chosen: list[str] = []
+    for _ in range(10):
+        sel = select_token(workspace, rng=random.Random(0))
         assert sel.mode == "ranked"
-        assert sel.name in top_n  # never spills past the top-N window
+        chosen.append(sel.name)
+    # Every available account is reached (no top-N slice leaves d/e idle).
+    assert set(chosen) == all_accounts
+
+
+def test_ranking_explicit_cap_limits_window(tmp_path, monkeypatch):
+    """An explicit spreadTopN cap still restricts rotation to the top-N window."""
+    monkeypatch.setenv("LOOM_TOKEN_SPREAD_TOP_N", "3")
+    workspace = _make_workspace(
+        tmp_path, {"a": "ka", "b": "kb", "c": "kc", "d": "kd", "e": "ke"},
+    )
+    _write_ranking(workspace, ["a|", "b|", "c|", "d|", "e|"])
+    window = {"a", "b", "c"}
+    chosen: set[str] = set()
+    for _ in range(20):
+        sel = select_token(workspace, rng=random.Random(0))
+        assert sel.mode == "ranked"
+        assert sel.name in window  # never spills past the top-N window
         chosen.add(sel.name)
-    # More than one distinct account is selected across seeds (spread), and
-    # entries below the window (d, e) are never chosen.
-    assert len(chosen) > 1
-    assert chosen <= top_n
+    assert chosen == window  # rotation reaches every account in the window
 
 
 def test_ranking_n1_restores_greedy_first_eligible(tmp_path, monkeypatch):
@@ -402,6 +416,80 @@ def test_ranking_spread_skips_bad_in_window(tmp_path, monkeypatch):
         sel = select_token(workspace, rng=random.Random(seed))
         assert sel.name in ("b", "c")
         assert sel.name != "a"
+
+
+# ---------- concurrent-dispatch distribution (issue #3909) ----------
+
+
+@pytest.mark.parametrize(
+    ("m_available", "n_dispatches"),
+    [(5, 3), (5, 5), (3, 5), (1, 4)],
+)
+def test_concurrent_dispatch_uses_min_n_m_distinct(
+    tmp_path, monkeypatch, m_available, n_dispatches
+):
+    """N sequential selections over M available accounts use min(N,M) distinct.
+
+    Models a burst of N concurrent dispatches sharing the rotation cursor: they
+    fan out one-per-account across the available pool rather than stacking.
+    """
+    monkeypatch.delenv("LOOM_TOKEN_SPREAD_TOP_N", raising=False)
+    names = [chr(ord("a") + i) for i in range(m_available)]
+    workspace = _make_workspace(tmp_path, {n: f"k{n}" for n in names})
+    _write_ranking(workspace, [f"{n}|" for n in names])
+    chosen = [
+        select_token(workspace, rng=random.Random(0)).name
+        for _ in range(n_dispatches)
+    ]
+    assert len(set(chosen)) == min(n_dispatches, m_available)
+
+
+def test_ranking_rotation_not_always_same_first(tmp_path, monkeypatch):
+    """The first pick rotates across cycles / pools (not always .ranking[0]).
+
+    Fresh pools seeded from different rngs must not all start on the same
+    best-ranked account — the anti-stacking property of #3909.
+    """
+    monkeypatch.delenv("LOOM_TOKEN_SPREAD_TOP_N", raising=False)
+    firsts: set[str] = set()
+    for seed in range(25):
+        ws = _make_workspace(
+            tmp_path / f"pool-{seed}",
+            {"a": "ka", "b": "kb", "c": "kc", "d": "kd"},
+        )
+        _write_ranking(ws, ["a|", "b|", "c|", "d|"])
+        firsts.add(select_token(ws, rng=random.Random(seed)).name)
+    assert len(firsts) > 1
+
+
+def test_ranking_rotation_drains_evenly_over_cycles(tmp_path, monkeypatch):
+    """Over 2 full cycles each available account is used exactly twice."""
+    monkeypatch.delenv("LOOM_TOKEN_SPREAD_TOP_N", raising=False)
+    workspace = _make_workspace(tmp_path, {"a": "ka", "b": "kb", "c": "kc"})
+    _write_ranking(workspace, ["a|", "b|", "c|"])
+    counts: dict[str, int] = {"a": 0, "b": 0, "c": 0}
+    for _ in range(6):  # 2 cycles over 3 accounts
+        counts[select_token(workspace, rng=random.Random(0)).name] += 1
+    assert counts == {"a": 2, "b": 2, "c": 2}
+
+
+def test_ranking_rotation_skips_exhausted_and_never_stalls(tmp_path, monkeypatch):
+    """Rotation only spans available accounts and always returns while >=1 free.
+
+    Preserves #3900 (skip exhausted/blocked) and the #3907 floor (never stall
+    while at least one account has capacity).
+    """
+    monkeypatch.delenv("LOOM_TOKEN_SPREAD_TOP_N", raising=False)
+    workspace = _make_workspace(
+        tmp_path, {"a": "ka", "b": "kb", "c": "kc", "d": "kd"},
+    )
+    # Only b and d are available; a exhausted, c blocked.
+    _write_ranking(workspace, ["a|exhausted", "b|", "c|blocked", "d|"])
+    chosen = [
+        select_token(workspace, rng=random.Random(0)).name for _ in range(8)
+    ]
+    assert set(chosen) == {"b", "d"}  # rotates across exactly the available two
+    assert "a" not in chosen and "c" not in chosen
 
 
 # ---------- CLI ----------


### PR DESCRIPTION
## Summary

Closes #3909.

The ranked token-selection tier picked the single best-ranked account (or, since #3736, a random top-N slice), so a burst of **N concurrent dispatches stacked several onto one account** — observed this session as 5 sweeps piling onto `agent4`, exhausting its 5h limit while other accounts sat idle. This change distributes concurrent dispatches **one-per-account across all available accounts, in rotating order**, so the pool drains evenly (staggered 5h/7d resets).

## What changed

- **New `loom_tools.tokens.rotation`** — a persistent, concurrency-safe rotation cursor:
  - A monotonic counter in `.loom/tokens/.rotation_cursor` (gitignored), guarded by a **mkdir-based lock** (`.rotation_cursor.lock`, POSIX-atomic; `flock` is unavailable on stock macOS, matching the existing `bad_tokens` convention).
  - Each call returns `counter % modulus` and atomically advances the counter, so N concurrent callers take N consecutive values → **`min(N, M)` distinct accounts**, wrapping past M.
  - First use seeds a **random offset** (from the caller's `rng`) so sibling spawners in different repos that share an account pool but not this cursor file start **de-correlated** rather than all colliding on index 0 (preserves the #3736 cross-repo anti-collision intent deterministically).
  - Degrades to a random index on lock-timeout/I-O error — selection never hard-fails on cursor bookkeeping.
- **`select._try_ranking`** now selects via the rotation cursor instead of `rng.choice`. The rotation window spans **all available accounts by default**; `LOOM_TOKEN_SPREAD_TOP_N` / `tokens.spreadTopN` remains an optional cap (`N == 1` = greedy first-eligible, unchanged). Default `_DEFAULT_SPREAD_TOP_N` is now `None` (unbounded).
- **Factored the mkdir lock** into `loom_tools.tokens._locking.MkdirLock`, now shared by `bad_tokens` (re-exported as `bad_tokens._MkdirLock` so `allowlist`/`failure_counts`/`cli` importers are unaffected).

## Acceptance criteria

- [x] Distributes concurrent dispatches one-per-account across available accounts rather than stacking on the best-ranked.
- [x] Ordering rotates each selection cycle (persistent cursor; random first-offset per pool).
- [x] Still skips `exhausted`/`blocked`/bad accounts (#3900) and never stalls while ≥1 account has capacity (#3907 floor).
- [x] Concurrent sweeps use distinct accounts up to the available-account count, then wrap.
- [x] Tests: N selections over M available use `min(N,M)` distinct; rotation observable across cycles; concurrent-thread distinctness.

## Testing

`PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/tokens/ -v` → **256 passed** (14 new: `test_rotation.py` + select-level distribution tests). Verified end-to-end across separate `python3 -m loom_tools.tokens.select` processes: a fresh pool rotated `c → a → b → c` one-per-account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)