### PR TITLE
fix(install): post-install guidance points at removed daemon.sh instead of loom-daemon-start.sh (#3923)

### DIFF
--- a/docs/guides/quickstart-tutorial.md
+++ b/docs/guides/quickstart-tutorial.md
@@ -343,14 +343,15 @@ See [defaults/roles/README.md](../../defaults/roles/README.md) for details.
 
 ### Automate Beyond MOM (loom-daemon dispatch, GitHub Actions)
 
-> **Heads up — the Python daemon brain is gone in v0.10.0; the shell-level
-> daemon surface is preserved.** The Python `loom-daemon` brain and the
-> `/loom` / `/loom --merge` slash commands were removed as part of the
-> shepherd/daemon deprecation epic (#3372). However,
-> `./.loom/scripts/daemon.sh` (start/stop/status) survives — it now drives
-> the Rust `loom-daemon` and (optionally) per-role panes in tmux, with
-> multi-account token rotation at the process-spawn boundary. The migration
-> narrative —
+> **Heads up — the Python daemon brain is gone in v0.10.0; the Rust
+> `loom-daemon` is the autonomous surface.** The Python `loom-daemon` brain
+> and the `/loom` / `/loom --merge` slash commands were removed as part of the
+> shepherd/daemon deprecation epic (#3372). The historical
+> `./.loom/scripts/daemon.sh` wrapper was removed in #3432; start/stop the
+> autonomous Rust daemon with `./.loom/scripts/cli/loom-daemon-start.sh` /
+> `loom-daemon-stop.sh`, and drive the tmux agent pool with
+> `./.loom/bin/loom start|status|stop` — both with multi-account token
+> rotation at the process-spawn boundary. The migration narrative —
 > including what each entry point maps to — lives at
 > [`docs/migration/v0.10.0-shepherd-deprecation.md`](../migration/v0.10.0-shepherd-deprecation.md).
 

--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -589,7 +589,8 @@ if [[ -x "$ACTIVE_SESSION_CHECK" ]]; then
       error "Refusing to install: an active Loom session was detected in the target.
 
 To proceed:
-  • Stop the running daemon:   cd '$TARGET_PATH' && ./.loom/scripts/daemon.sh stop
+  • Stop the autonomous daemon: cd '$TARGET_PATH' && ./.loom/scripts/cli/loom-daemon-stop.sh
+  • Stop the tmux agent pool:   cd '$TARGET_PATH' && ./.loom/bin/loom stop
   • Wait for in-flight builders to finish, OR
   • Pass --allow-active-session to override this guard (use with caution).
 
@@ -1975,7 +1976,7 @@ case "$MERGE_STATUS" in
     echo "    Then use /builder, /judge, or other role commands"
     echo ""
     echo "  Daemon Mode (autonomous orchestration):"
-    echo "    cd $TARGET_PATH && ./.loom/scripts/daemon.sh start"
+    echo "    cd $TARGET_PATH && ./.loom/scripts/cli/loom-daemon-start.sh"
     echo "    Then in Claude Code: /loom"
     ;;
   auto)
@@ -1990,7 +1991,7 @@ case "$MERGE_STATUS" in
     echo "    Then use /builder, /judge, or other role commands"
     echo ""
     echo "  Daemon Mode (autonomous orchestration):"
-    echo "    cd $TARGET_PATH && ./.loom/scripts/daemon.sh start"
+    echo "    cd $TARGET_PATH && ./.loom/scripts/cli/loom-daemon-start.sh"
     echo "    Then in Claude Code: /loom"
     ;;
   *)
@@ -2001,7 +2002,7 @@ case "$MERGE_STATUS" in
     echo "       cd $TARGET_PATH && claude"
     echo "       Then use /builder, /judge, or other role commands"
     echo "     Daemon Mode (autonomous orchestration):"
-    echo "       cd $TARGET_PATH && ./.loom/scripts/daemon.sh start"
+    echo "       cd $TARGET_PATH && ./.loom/scripts/cli/loom-daemon-start.sh"
     echo "       Then in Claude Code: /loom"
     ;;
 esac

--- a/scripts/install/create-pr.sh
+++ b/scripts/install/create-pr.sh
@@ -270,7 +270,7 @@ Synced Loom workflow labels via \`.github/labels.yml\`
 
 After merging:
 1. Use \`/builder\`, \`/judge\`, etc. commands in Claude Code
-2. Or run \`./.loom/scripts/daemon.sh start\` to launch the daemon for autonomous orchestration
+2. Or run \`./.loom/scripts/cli/loom-daemon-start.sh\` to launch the daemon for autonomous orchestration
 
 See \`CLAUDE.md\` for complete usage details.
 

--- a/scripts/test-installer.sh
+++ b/scripts/test-installer.sh
@@ -2629,6 +2629,46 @@ fi
 echo ""
 
 # ==========================================================================
+# Test: install-loom.sh guidance points at shipped script paths (#3923)
+#
+# The post-install "Next Steps" and the active-session refusal guidance name
+# script paths the user is told to run. The historical ./.loom/scripts/daemon.sh
+# was removed in #3432; guidance must reference only surfaces that actually ship
+# in defaults/. This smoke check extracts every ./.loom/... path named in the
+# installer's user-facing output and asserts it maps to a real file in defaults/.
+# ==========================================================================
+echo "Test: install-loom.sh guidance names only shipped ./.loom/ script paths"
+GUIDANCE_MISSING=""
+# Pull the ./.loom/... tokens the installer prints in echo/error guidance lines.
+GUIDANCE_PATHS=$(grep -oE '\./\.loom/[A-Za-z0-9._/-]+' "$INSTALL_SCRIPT" \
+  "$LOOM_ROOT/scripts/install/create-pr.sh" | sed 's/^[^:]*://' | sort -u)
+for gp in $GUIDANCE_PATHS; do
+  # Strip the leading ./ and map the installed path back to its defaults/ source:
+  #   .loom/bin/loom       -> defaults/.loom/bin/loom
+  #   .loom/scripts/foo.sh -> defaults/scripts/foo.sh
+  rel="${gp#./}"
+  case "$rel" in
+    .loom/bin/*)     src="$DEFAULTS_DIR/$rel" ;;          # defaults/.loom/bin/loom
+    .loom/scripts/*) src="$DEFAULTS_DIR/${rel#.loom/}" ;; # defaults/scripts/...
+    *)               src="$DEFAULTS_DIR/${rel#.loom/}" ;;
+  esac
+  if [[ ! -e "$src" ]]; then
+    GUIDANCE_MISSING="$GUIDANCE_MISSING\n  $gp -> $src (not shipped)"
+  fi
+done
+# Belt-and-suspenders: the removed daemon.sh must never reappear in guidance.
+if grep -qE '\./\.loom/scripts/daemon\.sh' "$INSTALL_SCRIPT" \
+  "$LOOM_ROOT/scripts/install/create-pr.sh"; then
+  GUIDANCE_MISSING="$GUIDANCE_MISSING\n  ./.loom/scripts/daemon.sh referenced (removed in #3432)"
+fi
+if [[ -z "$GUIDANCE_MISSING" ]]; then
+  pass "all ./.loom/ paths in install guidance exist in defaults/"
+else
+  fail "install guidance references non-shipped paths:$(echo -e "$GUIDANCE_MISSING")"
+fi
+echo ""
+
+# ==========================================================================
 # Summary
 # ==========================================================================
 echo "======================================"


### PR DESCRIPTION
## Summary

The installer's post-install "Next Steps" and active-session refusal guidance told users to run `./.loom/scripts/daemon.sh`, which was **removed in #3432** and is not shipped. A fresh installer following the printed guidance hit "no such file or directory" on the very first command — observed during the v0.14.0 install dogfood into geode-fem and kicad-tools.

## Changes

- **`scripts/install-loom.sh`** — replaced 4 stale `daemon.sh start/stop` references (lines ~592, ~1978, ~1993, ~2004) with shipped surfaces:
  - Autonomous Rust daemon: `.loom/scripts/cli/loom-daemon-start.sh` / `loom-daemon-stop.sh`
  - Tmux agent pool: `.loom/bin/loom stop` (in the active-session refusal guidance)
- **`scripts/install/create-pr.sh`** — fixed the stale `daemon.sh start` reference in the install PR body a fresh installer reads.
- **`docs/guides/quickstart-tutorial.md`** — corrected the "Heads up" note that falsely claimed `daemon.sh` "survives"; now points at `loom-daemon-start.sh` / `loom-daemon-stop.sh` and `.loom/bin/loom`.
- **`scripts/test-installer.sh`** — added a smoke check (already wired into CI via `.github/workflows/ci.yml`) that extracts every `./.loom/` path named in installer guidance and asserts it maps to a real file in shipped `defaults/`, plus a belt-and-suspenders guard against `daemon.sh` reappearing.

Historical `daemon.sh` references in migration docs / ADRs / changelogs that explicitly describe the removal were left intact (they are accurate).

## Test evidence

- `bash -n` passes on all three edited scripts.
- `bash scripts/test-installer.sh`: **138 passed, 0 failed**, including the new `guidance names only shipped ./.loom/ script paths` check.
- Negative test confirmed: reintroducing `daemon.sh start` into `install-loom.sh` makes the new check fail with `./.loom/scripts/daemon.sh referenced (removed in #3432)`.

Closes #3923

🤖 Generated with [Claude Code](https://claude.com/claude-code)