### PR TITLE
fix(install): provision machine-level loom-daemon binary for consumers (#3922)

### DIFF
--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -710,6 +710,19 @@ Start/stop the **raw daemon process** (distinct from the tmux `.loom/bin/loom st
 > `--work-finder` / `--health-gate`, or hand control to committed config with
 > `--from-config`.
 
+**Daemon binary prerequisite (#3922)**: `loom-daemon-start.sh` needs a runnable
+`loom-daemon` binary. It resolves one via, in order: the `LOOM_DAEMON_BIN` env
+var → `command -v loom-daemon` (PATH) → an in-repo `target/release/loom-daemon`
+build. The Loom installer provisions this for you — it installs the freshly-built
+binary to `~/.local/bin/loom-daemon` (a machine-level, install-once-per-machine
+location shared across every repo Loom is installed into) so `command -v
+loom-daemon` resolves it with **no manual steps**. If the installer warned that
+`~/.local/bin` is not on your `PATH`, add it (`export
+PATH="$HOME/.local/bin:$PATH"` in `~/.zshrc` / `~/.bashrc`) — otherwise point
+`LOOM_DAEMON_BIN` at any built `loom-daemon`. Verify with `command -v loom-daemon
+&& loom-daemon --version`; the provisioned binary version matches your installed
+Loom version.
+
 **Shutdown decision**: a clean stop leaves in-flight `/loom:sweep` children **running** — they are independent detached processes that survive a daemon restart by design (killing the dispatcher must not kill dispatched work); the registry reconciles them on the next start. Use `mcp__loom__cancel_sweep` against a running daemon to actively cancel a sweep before stopping. The full config table, start/stop flags, and a scripted end-to-end acceptance playbook are in [`.loom/docs/daemon-reference.md`](.loom/docs/daemon-reference.md) §Operability and [`docs/autonomous-mode-e2e.md`](../docs/autonomous-mode-e2e.md).
 
 **Issue selection**: by default the daemon is **not a work generator** — it does not autonomously claim items from the `loom:issue` queue; work is operator-driven via `mcp__loom__dispatch_sweep`. (The `/loom:sweep` skill is the typical caller; Stage -1 backend detection picks an issue and dispatches it when both daemon and pool probes succeed.) As of epics #3809 and #3842 that default can be **opted out of** — both autonomous surfaces are default-off:

--- a/install.sh
+++ b/install.sh
@@ -353,6 +353,13 @@ _emit_loom_claude_block() {
 # Determine Loom repository root
 LOOM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Machine-level loom-daemon provisioning helper (#3922). Sourced so the Quick
+# Install path (which runs `loom-daemon init` directly, without delegating to
+# scripts/install-loom.sh) can also drop the built binary on PATH. The Full
+# Install path `exec`s scripts/install-loom.sh, which sources this helper itself.
+# shellcheck source=scripts/install/provision-daemon.sh
+source "$LOOM_ROOT/scripts/install/provision-daemon.sh"
+
 # Show banner
 echo ""
 header "╔═══════════════════════════════════════════════════════════╗"
@@ -822,6 +829,10 @@ elif [[ -d "$TARGET_PATH/.loom" ]]; then
     finalize_quick_install "$LOOM_ROOT" "$TARGET_PATH"
     verify_install "$TARGET_PATH"
 
+    # Provision a machine-level loom-daemon binary (#3922) so the consumer's
+    # loom-daemon-start.sh resolves it via `command -v loom-daemon` post-install.
+    provision_machine_daemon "$LOOM_ROOT/target/release/loom-daemon" || true
+
     # Issue #3545: reconcile the git index after the uninstall→reinstall cycle.
     # The chained uninstall staged the deletion of every prior Loom file (now
     # scoped to Loom-managed paths — see scripts/uninstall-loom.sh), then
@@ -1190,6 +1201,10 @@ case "$METHOD" in
     # Emit skill-routes.json, install-metadata.json, loom-source-path (#3502).
     finalize_quick_install "$LOOM_ROOT" "$TARGET_PATH"
     verify_install "$TARGET_PATH"
+
+    # Provision a machine-level loom-daemon binary (#3922) so the consumer's
+    # loom-daemon-start.sh resolves it via `command -v loom-daemon` post-install.
+    provision_machine_daemon "$LOOM_ROOT/target/release/loom-daemon" || true
 
     echo ""
     success "Quick installation complete!"

--- a/scripts/install-loom.sh
+++ b/scripts/install-loom.sh
@@ -188,6 +188,12 @@ header() {
 # shellcheck source=scripts/install/manifest.sh
 source "$LOOM_ROOT/scripts/install/manifest.sh"
 
+# Source the machine-level loom-daemon provisioning helper (#3922). Kept in its
+# own file so the test suite can exercise it without sourcing the full
+# installer.
+# shellcheck source=scripts/install/provision-daemon.sh
+source "$LOOM_ROOT/scripts/install/provision-daemon.sh"
+
 # Dogfood command-dir linker (issue #3682) — extracted so the test suite can
 # exercise the scoped-symlink logic without running the full installer.
 # shellcheck source=scripts/install/dogfood-commands.sh
@@ -1053,6 +1059,16 @@ success "loom-daemon binary ready"
 # post-hoc when an install regression is reported (issue #3287).
 DAEMON_VERSION=$("$LOOM_ROOT/target/release/loom-daemon" --version 2>/dev/null || echo "(unknown)")
 info "loom-daemon binary: $DAEMON_VERSION"
+
+# Provision a machine-level loom-daemon binary for the consumer (issue #3922).
+# The consumer repo ships loom-daemon-start.sh but no binary; install the
+# freshly-built one to ~/.local/bin (on PATH) so `command -v loom-daemon`
+# resolves it post-install with no manual steps. Best-effort: a soft failure
+# (e.g. ~/.local/bin unwritable) is logged but never aborts the install — the
+# consumer can still point LOOM_DAEMON_BIN at the source build.
+info "Provisioning machine-level loom-daemon binary..."
+provision_machine_daemon "$LOOM_ROOT/target/release/loom-daemon" || \
+  warning "Machine-level loom-daemon not provisioned (see note above); autonomous daemon mode needs LOOM_DAEMON_BIN or a binary on PATH."
 
 # Run loom-daemon init in the worktree
 cd "$TARGET_PATH/$WORKTREE_PATH"

--- a/scripts/install/provision-daemon.sh
+++ b/scripts/install/provision-daemon.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# scripts/install/provision-daemon.sh — machine-level loom-daemon provisioning
+#
+# Issue #3922: a consumer repo ships `.loom/scripts/cli/loom-daemon-start.sh`
+# but NO `loom-daemon` binary. That start script resolves the binary via:
+#   LOOM_DAEMON_BIN env → `command -v loom-daemon` (PATH) →
+#   <repo>/loom-daemon/target/release/loom-daemon → <repo>/target/release/…
+# In a freshly-installed consumer repo NONE of these exist (no Rust source to
+# build, nothing on PATH, LOOM_DAEMON_BIN unset), so autonomous daemon mode —
+# the headline v0.14 feature — cannot start post-install.
+#
+# The v0.14.1 stopgap (toward the full machine-level install epic #3835):
+# install the freshly-built binary to a machine-level location on PATH
+# (~/.local/bin/loom-daemon), install-once per machine, shared across every
+# consumer repo. The consumer side needs NO change — loom-daemon-start.sh
+# already resolves via `command -v loom-daemon`.
+#
+# Source this file with:
+#     source "$LOOM_ROOT/scripts/install/provision-daemon.sh"
+# then call `provision_machine_daemon <src_bin> [dest_dir]`.
+#
+# It is deliberately self-contained (defines its own output helpers) so the
+# test suite can source it without pulling in the full installer.
+
+# Emit a machine-level-provision status line. Prefixed so the installer's
+# output stays scannable; plain text so `source`-ing tests can assert on it.
+_pmd_info()    { echo "  [loom-daemon] $*"; }
+_pmd_ok()      { echo "  [loom-daemon] $*"; }
+_pmd_warn()    { echo "  [loom-daemon] WARNING: $*" >&2; }
+
+# provision_machine_daemon <src_bin> [dest_dir]
+#
+# Installs <src_bin> to <dest_dir>/loom-daemon (default: LOOM_DAEMON_BIN_DIR,
+# else ~/.local/bin). Idempotent + version-aware: a no-op when the destination
+# already holds the same `--version`. Best-effort — never fatal; returns 1 on a
+# soft failure so the caller can note it, but the installer must NOT abort on a
+# non-zero return (a repo can still run the daemon via an explicit
+# LOOM_DAEMON_BIN or an in-repo build).
+provision_machine_daemon() {
+  local src_bin="${1:-}"
+  local dest_dir="${2:-${LOOM_DAEMON_BIN_DIR:-$HOME/.local/bin}}"
+  local dest_bin="$dest_dir/loom-daemon"
+
+  if [[ -z "$src_bin" || ! -x "$src_bin" ]]; then
+    _pmd_warn "built binary not found at '${src_bin:-<unset>}'; skipping machine-level install"
+    return 1
+  fi
+
+  local src_ver dest_ver
+  src_ver=$("$src_bin" --version 2>/dev/null || echo "unknown")
+
+  # Version-aware short-circuit: skip the copy when the destination already
+  # holds the same version (compare `--version` strings).
+  if [[ -x "$dest_bin" ]]; then
+    dest_ver=$("$dest_bin" --version 2>/dev/null || echo "unknown")
+    if [[ "$src_ver" == "$dest_ver" && "$src_ver" != "unknown" ]]; then
+      _pmd_ok "already current at $dest_bin ($dest_ver)"
+      _pmd_check_path "$dest_dir"
+      return 0
+    fi
+  fi
+
+  if ! mkdir -p "$dest_dir" 2>/dev/null; then
+    _pmd_warn "could not create $dest_dir; skipping machine-level install"
+    _pmd_warn "set LOOM_DAEMON_BIN=$src_bin in the consumer env to run the daemon"
+    return 1
+  fi
+
+  # Prefer install(1) for the atomic mode-set; fall back to cp + chmod.
+  if install -m 755 "$src_bin" "$dest_bin" 2>/dev/null || \
+     { cp -f "$src_bin" "$dest_bin" 2>/dev/null && chmod 755 "$dest_bin" 2>/dev/null; }; then
+    _pmd_ok "installed loom-daemon → $dest_bin ($src_ver)"
+  else
+    _pmd_warn "failed to install loom-daemon to $dest_bin"
+    _pmd_warn "set LOOM_DAEMON_BIN=$src_bin in the consumer env to run the daemon"
+    return 1
+  fi
+
+  _pmd_check_path "$dest_dir"
+  return 0
+}
+
+# Warn (one clear line, never fatal) when <dir> is not on PATH, so the operator
+# knows `command -v loom-daemon` will not resolve until they add it.
+_pmd_check_path() {
+  local dir="$1"
+  case ":${PATH:-}:" in
+    *":$dir:"*) return 0 ;;
+    *)
+      _pmd_warn "$dir is not on your PATH — add it so 'loom-daemon' resolves:"
+      _pmd_warn "    export PATH=\"$dir:\$PATH\"   # add to ~/.zshrc or ~/.bashrc"
+      return 0
+      ;;
+  esac
+}

--- a/tests/install/test-provision-daemon.sh
+++ b/tests/install/test-provision-daemon.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Test suite for scripts/install/provision-daemon.sh (issue #3922)
+#
+# Usage: ./tests/install/test-provision-daemon.sh
+#
+# Exercises provision_machine_daemon: machine-level install of the built
+# loom-daemon binary to a PATH location so a consumer repo's
+# loom-daemon-start.sh resolves it via `command -v loom-daemon`. Uses a FAKE
+# loom-daemon binary that prints a settable --version string; no real cargo
+# build or network access needed.
+#
+# Exit code 0 = all tests pass, 1 = failures detected.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# shellcheck source=scripts/install/provision-daemon.sh
+source "$REPO_ROOT/scripts/install/provision-daemon.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "${RED}FAIL${NC}: $desc"
+    echo "  expected: '$expected'"
+    echo "  actual:   '$actual'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo -e "${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "${RED}FAIL${NC}: $desc"
+    echo "  expected to contain: '$needle'"
+    echo "  actual: '$haystack'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# Build a fake loom-daemon binary that prints $1 as its --version.
+make_fake_bin() {
+  local path="$1" ver="$2"
+  cat > "$path" <<EOF
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "--version" ]]; then echo "loom-daemon $ver"; fi
+EOF
+  chmod +x "$path"
+}
+
+# ---------- test 1: fresh install to an empty dest dir ----------
+SRC1="$WORKDIR/src1/loom-daemon"
+mkdir -p "$WORKDIR/src1"
+make_fake_bin "$SRC1" "0.14.1"
+DEST1="$WORKDIR/dest1"
+
+out1=$(LOOM_DAEMON_BIN_DIR="$DEST1" provision_machine_daemon "$SRC1" 2>&1)
+rc1=$?
+assert_eq "fresh install returns 0" "0" "$rc1"
+assert_eq "binary installed at dest" "1" "$( [[ -x "$DEST1/loom-daemon" ]] && echo 1 || echo 0 )"
+assert_eq "installed binary reports src version" "loom-daemon 0.14.1" "$("$DEST1/loom-daemon" --version)"
+assert_contains "fresh-install output names the destination" "$out1" "$DEST1/loom-daemon"
+
+# ---------- test 2: idempotent — same version is a no-op copy ----------
+# Record mtime, run again, assert it did not re-copy (mtime unchanged) and it
+# reports "already current".
+before_mtime=$(stat -f %m "$DEST1/loom-daemon" 2>/dev/null || stat -c %Y "$DEST1/loom-daemon")
+sleep 1
+out2=$(LOOM_DAEMON_BIN_DIR="$DEST1" provision_machine_daemon "$SRC1" 2>&1)
+rc2=$?
+after_mtime=$(stat -f %m "$DEST1/loom-daemon" 2>/dev/null || stat -c %Y "$DEST1/loom-daemon")
+assert_eq "idempotent run returns 0" "0" "$rc2"
+assert_eq "idempotent run does NOT re-copy (mtime unchanged)" "$before_mtime" "$after_mtime"
+assert_contains "idempotent run reports already current" "$out2" "already current"
+
+# ---------- test 3: version drift — different version overwrites ----------
+SRC2="$WORKDIR/src2/loom-daemon"
+mkdir -p "$WORKDIR/src2"
+make_fake_bin "$SRC2" "0.15.0"
+out3=$(LOOM_DAEMON_BIN_DIR="$DEST1" provision_machine_daemon "$SRC2" 2>&1)
+rc3=$?
+assert_eq "version-drift run returns 0" "0" "$rc3"
+assert_eq "dest binary upgraded to new version" "loom-daemon 0.15.0" "$("$DEST1/loom-daemon" --version)"
+assert_contains "version-drift run reports install" "$out3" "installed loom-daemon"
+
+# ---------- test 4: missing/unset source binary is a soft failure ----------
+out4=$(LOOM_DAEMON_BIN_DIR="$WORKDIR/dest4" provision_machine_daemon "$WORKDIR/does-not-exist" 2>&1)
+rc4=$?
+assert_eq "missing source returns 1 (soft failure)" "1" "$rc4"
+assert_contains "missing source warns" "$out4" "not found"
+assert_eq "missing source creates no dest" "0" "$( [[ -e "$WORKDIR/dest4/loom-daemon" ]] && echo 1 || echo 0 )"
+
+# ---------- test 5: PATH warning when dest dir is not on PATH ----------
+SRC5="$WORKDIR/src5/loom-daemon"
+mkdir -p "$WORKDIR/src5"
+make_fake_bin "$SRC5" "0.14.1"
+DEST5="$WORKDIR/dest5"
+# Ensure DEST5 is definitely not on PATH.
+out5=$(PATH="/usr/bin:/bin" LOOM_DAEMON_BIN_DIR="$DEST5" bash -c '
+  source "'"$REPO_ROOT"'/scripts/install/provision-daemon.sh"
+  provision_machine_daemon "'"$SRC5"'"' 2>&1)
+assert_contains "off-PATH dest emits a PATH warning" "$out5" "is not on your PATH"
+
+# ---------- test 6: PATH present → no PATH warning ----------
+SRC6="$WORKDIR/src6/loom-daemon"
+mkdir -p "$WORKDIR/src6"
+make_fake_bin "$SRC6" "0.14.1"
+DEST6="$WORKDIR/dest6"
+mkdir -p "$DEST6"
+out6=$(PATH="$DEST6:/usr/bin:/bin" LOOM_DAEMON_BIN_DIR="$DEST6" bash -c '
+  source "'"$REPO_ROOT"'/scripts/install/provision-daemon.sh"
+  provision_machine_daemon "'"$SRC6"'"' 2>&1)
+TOTAL=$((TOTAL + 1))
+if [[ "$out6" != *"is not on your PATH"* ]]; then
+  echo -e "${GREEN}PASS${NC}: on-PATH dest emits no PATH warning"
+  PASS=$((PASS + 1))
+else
+  echo -e "${RED}FAIL${NC}: on-PATH dest emits no PATH warning"
+  echo "  unexpected warning in: '$out6'"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------- summary ----------
+echo ""
+echo "-----------------------------------------"
+echo "Total: $TOTAL  Passed: $PASS  Failed: $FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Consumer repos install `.loom/scripts/cli/loom-daemon-start.sh` but **no `loom-daemon` binary**. That start script resolves the binary via `LOOM_DAEMON_BIN` → `command -v loom-daemon` (PATH) → an in-repo `target/release/loom-daemon` build — none of which exist in a freshly-installed consumer repo. So autonomous daemon mode (the headline v0.14 feature) cannot start post-install.

Per the operator's decision on the issue, the fix installs the freshly-built binary to a **machine-level location on PATH** (`~/.local/bin/loom-daemon`), install-once per machine, shared across every repo Loom is installed into. The consumer side needs **no change** — `loom-daemon-start.sh` already resolves via `command -v loom-daemon`.

## Changes

- **`scripts/install/provision-daemon.sh`** (new): a self-contained, sourceable `provision_machine_daemon <src_bin> [dest_dir]` helper.
  - Idempotent + version-aware: no-op copy when the destination already holds the same `--version`; overwrites on drift (so the provisioned binary version always matches the installed Loom version — AC 3).
  - Best-effort: a soft failure (e.g. `~/.local/bin` unwritable) warns and returns non-zero but **never aborts the install** — the consumer can still point `LOOM_DAEMON_BIN` at the source build.
  - Warns, non-fatally, with a one-line `export PATH=...` hint when the dest dir is not on `PATH`.
  - Dest dir overridable via `LOOM_DAEMON_BIN_DIR` (defaults to `~/.local/bin`).
- **`scripts/install-loom.sh`**: source the helper and call it after the `cargo build` step (Full Install path).
- **`install.sh`**: source the helper and call it in both Quick Install branches (fresh + method-dispatch). The Full Install path `exec`s `install-loom.sh`, already covered.
- **`defaults/CLAUDE.md`**: document the consumer-side daemon-binary prerequisite + PATH note (AC 4).
- **`tests/install/test-provision-daemon.sh`** (new): 15 assertions covering fresh install, idempotency (mtime-unchanged), version drift, missing source (soft failure), and PATH warning — using a fake `loom-daemon` binary, so no `cargo build` or network is needed.

## Acceptance criteria

1. Install provisions a runnable `loom-daemon` for the consumer — yes, via option (a): machine-level install to `~/.local/bin` on PATH.
2. After a fresh install `loom-daemon-start.sh` finds and starts the daemon with no manual binary steps — yes (`command -v loom-daemon` resolves it).
3. Version match — yes: version-aware overwrite ensures the provisioned binary's `--version` matches the built source.
4. Documented in `defaults/CLAUDE.md` + non-fatal install output.

## Testing

- `tests/install/test-provision-daemon.sh` — 15/15 pass.
- `defaults/scripts/tests/test-loom-daemon-start.sh` — 8/8 pass (no regression).
- `shellcheck` clean on the new scripts; `bash -n` clean on `install.sh` / `install-loom.sh` / `provision-daemon.sh`.

v0.14.1 stopgap toward the full machine-level install (#3835).

Closes #3922

🤖 Generated with [Claude Code](https://claude.com/claude-code)