### PR TITLE
feat(daemon): (repo,issue)-aware sweep visibility + event repo field + pool eviction (#3926 phase c)

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -102,10 +102,10 @@ issue** — the v0.10.0 set is intentionally frozen.
 
 | Topic | Publisher | Payload |
 |-------|-----------|---------|
-| `sweep.issue.{N}.phase`   | Sweep child via `publish_event` | `{phase, pr_number?}` |
-| `sweep.issue.{N}.blocker` | Sweep child                     | `{reason, label_added}` |
-| `sweep.issue.{N}.exited`  | Daemon reaper (or `cancel_sweep`) | `{exit_code, duration_sec}` |
-| `sweep.issue.{N}.crashed` | Daemon reaper                   | `{checkpoint_phase}` |
+| `sweep.issue.{N}.phase`   | Sweep child via `publish_event` | `{phase, pr_number?, repo?}` |
+| `sweep.issue.{N}.blocker` | Sweep child                     | `{reason, label_added, repo?}` |
+| `sweep.issue.{N}.exited`  | Daemon reaper (or `cancel_sweep`) | `{exit_code, duration_sec, repo?}` |
+| `sweep.issue.{N}.crashed` | Daemon reaper                   | `{checkpoint_phase, repo?}` |
 | `sweep.global.dispatch`   | Daemon                          | `{sweep_id, kind}` |
 | `sweep.global.completed`  | Daemon                          | `{sweep_id, outcome}` |
 | `epic.issue.{N}.decompose` | Epic supervisor (#3842)        | `{epic, action, state}` |
@@ -123,6 +123,20 @@ operator gets one add-capacity advisory on the way in and one recovery on the wa
 out. See [Token-capacity backpressure](#token-capacity-backpressure-3902) below.
 They ride the same in-memory bus as the sweep topics and are tailable via
 `subscribe_to_events` / `tail_event_bus`.
+
+The four `sweep.issue.{N}.*` payloads gained an additive **`repo`** field in
+**#3929** (`(repo, issue)`-aware sweep visibility, phase c of #3926). The bus is
+shared across every managed repo, and the topic string is issue-scoped only —
+two managed repos can each dispatch a sweep for issue #42 onto the *identical*
+`sweep.issue.42.phase` topic. `repo` carries the owning registry's
+`workspace_root`, so a multi-repo-aware subscriber can disambiguate them after
+matching the topic. **The topic strings are unchanged** — `repo` lives in the
+payload only, so existing single-repo subscribers that filter on `sweep.issue`
+or `sweep.issue.{N}` route byte-for-byte identically and simply ignore the new
+field. The daemon stamps `repo` centrally when it emits each event; a sweep
+child that already knows its repo (via `publish_event`) may supply it and will
+not be overwritten. `sweep.global.*` events are unchanged — they already carry a
+unique `sweep_id`.
 
 In addition, the bus internally emits:
 
@@ -168,6 +182,12 @@ Inputs:
   structurally unrepresentable — see "Stacked-PR dependency (v1)" below. The
   field is `#[serde(default)]` on the wire, so pre-#3729 clients remain
   compatible.
+- `workspace_root` (optional, issue #3929) — target managed-workspace root.
+  When omitted, the sweep is dispatched into the daemon's **default** workspace
+  (byte-for-byte unchanged). When set to a registered repo root, the daemon
+  resolves that repo's sweep registry via the `WorkspacePool` and dispatches into
+  its working tree — the way to dispatch into a managed repo other than the
+  default when two repos share issue numbers. `#[serde(default)]` on the wire.
 
 ### `list_sweeps` (Phase A)
 
@@ -177,6 +197,19 @@ Terminal entries are garbage-collected ~1h after the transition.
 Inputs:
 - `state_filter` (optional) — one of `Pending`, `Running`, `Exited`,
   `Crashed`.
+- `workspace_root` (optional, issue #3929) — target managed-workspace root.
+  Omit to list the default workspace's sweeps (unchanged). Set to a registered
+  repo root to list the sweeps tracked by that repo's registry — the way to
+  observe sweeps the daemon autonomously dispatched into a non-default managed
+  repo. Each returned `SweepInfo` also carries a `repo` field naming its owner,
+  so a response is self-describing even without filtering. Cross-repo
+  aggregation in a single call is deferred to phase d (#3930). `#[serde(default)]`
+  on the wire.
+
+The same optional `workspace_root` input (default = default workspace, unchanged)
+is accepted by `get_sweep_status`, `tail_sweep_log`, and `cancel_sweep` — so a
+sweep the daemon dispatched into a non-default managed repo can be inspected,
+tailed, and cancelled by naming its repo root (#3929).
 
 ### `publish_event` (Phase B)
 
@@ -261,10 +294,39 @@ The sweep registry (`loom-daemon/src/sweep_registry.rs`) holds a
 - `latest_phase` (optional) — most-recent phase advertised via
   checkpoint.
 - `pr_number` (optional, reserved).
+- `repo` (optional, issue #3929) — the owning managed-workspace root
+  (`config.workspace_root`), stamped at dispatch/reconstruct time so a
+  `list_sweeps` / `get_sweep_status` response disambiguates two managed repos'
+  identically-numbered issues. `#[serde(default, skip_serializing_if = "Option::is_none")]`,
+  so pre-#3929 wire data and clients remain compatible.
 
 The wire shape is pinned by `sweep_info_schema_snapshot` in
 `sweep_registry.rs` — a change to the JSON shape requires deliberate
 test update.
+
+## Per-workspace registry pool (`WorkspacePool`, #3928/#3929)
+
+`loom-daemon/src/workspace_pool.rs` holds **one independent `SweepRegistry` per
+registered repo root**, keyed by `PathBuf`, so every path a registry computes
+(`.loom/locks/issue-<N>`, `.loom/logs/`, `.loom/sweep-checkpoint/`, and the
+spawned child's `current_dir`) is namespaced per repo — two repos each with issue
+#42 never collide. The default workspace's registry is **seeded** into the pool
+(shared with the IPC `dispatch_sweep` path); the autonomous work-finder and epic
+supervisor provision the other managed repos' registries on demand
+(`get_or_provision`). The IPC handler resolves a request's target registry from
+the pool when the request carries an explicit `workspace_root` (#3929), so all
+per-repo registries are observable/addressable via `list_sweeps` /
+`get_sweep_status` / `tail_sweep_log` / `cancel_sweep` / `dispatch_sweep`.
+
+**Eviction on `workspace remove` (#3929)**: `DeregisterWorkspace` (the
+`workspace remove` CLI) calls `WorkspacePool::evict`, which drops the pooled
+registry and **aborts its background reaper task** so it does not leak. The
+**seeded default workspace is guarded** — it is owned by `main` and keeps serving
+default-workspace IPC requests, so evicting it is a no-op. A live sweep child in
+an evicted registry is **not** killed and its lock/log files are untouched; only
+the in-memory tracking + reaper go away, so the sweep finishes normally but its
+terminal state becomes unobservable via IPC after the deregister — an accepted
+consequence of an explicit operator `workspace remove`.
 
 ## Reaper task
 

--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -1805,14 +1805,16 @@ The following six topics are the **entire** event vocabulary for v0.10.0. New to
 
 | Topic | Publisher | Payload (JSON) |
 |-------|-----------|----------------|
-| `sweep.issue.{N}.phase` | Sweep child via `PublishEvent` | `{"phase": "<phase-name>", "pr_number": <int or null>}` |
-| `sweep.issue.{N}.blocker` | Sweep child | `{"reason": "<short-text>", "label_added": "<label>"}` |
-| `sweep.issue.{N}.exited` | Daemon reaper | `{"exit_code": <int or null>, "duration_sec": <int>}` |
-| `sweep.issue.{N}.crashed` | Daemon reaper | `{"checkpoint_phase": "<phase-name or null>"}` |
+| `sweep.issue.{N}.phase` | Sweep child via `PublishEvent` | `{"phase": "<phase-name>", "pr_number": <int or null>, "repo": "<workspace-root>"?}` |
+| `sweep.issue.{N}.blocker` | Sweep child | `{"reason": "<short-text>", "label_added": "<label>", "repo": "<workspace-root>"?}` |
+| `sweep.issue.{N}.exited` | Daemon reaper | `{"exit_code": <int or null>, "duration_sec": <int>, "repo": "<workspace-root>"?}` |
+| `sweep.issue.{N}.crashed` | Daemon reaper | `{"checkpoint_phase": "<phase-name or null>", "repo": "<workspace-root>"?}` |
 | `sweep.global.dispatch` | Daemon | `{"sweep_id": "<id>", "kind": {"type": "Issue", "value": <N>}}` |
 | `sweep.global.completed` | Daemon | `{"sweep_id": "<id>", "outcome": "exited" | "crashed"}` |
 
 `{N}` is the issue number (a positive integer). Phase names match the sweep-checkpoint schema (#3373): `curator`, `builder`, `judge`, `doctor`, `merge`, etc.
+
+**`repo` field (optional, #3929)**: the four `sweep.issue.{N}.*` payloads carry an additive `repo` field naming the owning managed-workspace root, so a subscriber on the shared bus can disambiguate two managed repos that each dispatched a sweep for issue #N (the topic string is issue-scoped only). The **daemon stamps `repo` automatically** on the events it emits (`exited` / `crashed`). For the **child-published** `phase` / `blocker` events, include `repo` in the payload sourced from the `LOOM_WORKSPACE` env var the daemon exports to the sweep child at dispatch (e.g. `{"phase": "builder", "pr_number": 501, "repo": "$LOOM_WORKSPACE"}`). `repo` is optional and backward-compatible — omitting it is byte-for-byte the pre-#3929 behavior, and single-repo subscribers ignore it.
 
 ### How to publish — IPC contract
 

--- a/loom-daemon/src/event_bus.rs
+++ b/loom-daemon/src/event_bus.rs
@@ -350,6 +350,7 @@ mod tests {
             issue,
             phase: phase.to_string(),
             pr_number: None,
+            repo: None,
         }
     }
 
@@ -437,6 +438,7 @@ mod tests {
                 issue,
                 phase,
                 pr_number: _,
+                repo: _,
             } => {
                 assert_eq!(issue, 123);
                 assert_eq!(phase, "builder");
@@ -492,6 +494,7 @@ mod tests {
             issue: 42,
             exit_code: Some(0),
             duration_sec: 12,
+            repo: None,
         });
         let _ = bus.publish_generic("sweep.global.dispatch", json!({"sweep_id": "x"}));
 

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -8,6 +8,7 @@ use crate::main_health_gate::MainHealthState;
 use crate::sweep_registry::{BeginCancel, SweepRegistry};
 use crate::terminal::TerminalManager;
 use crate::types::{DaemonStatusReport, Event, Request, Response};
+use crate::workspace_pool::WorkspacePool;
 use anyhow::Result;
 use chrono::Utc;
 use std::path::{Path, PathBuf};
@@ -105,6 +106,13 @@ pub struct IpcServer {
     /// server so the `DaemonStatus` request (#3891) can report the current
     /// halt state — the same `Arc` the work-finder and gate loop share.
     main_health_state: Arc<MainHealthState>,
+    /// The per-workspace sweep-registry pool (#3929). The default workspace's
+    /// registry is seeded into it, and the autonomous loops provision the other
+    /// managed repos' registries on demand. Threaded into the IPC handler so a
+    /// request carrying an explicit `workspace_root` can observe/address a sweep
+    /// in a managed repo other than the default workspace, and so
+    /// `DeregisterWorkspace` can evict the in-memory entry.
+    workspace_pool: Arc<WorkspacePool>,
 }
 
 impl IpcServer {
@@ -115,6 +123,7 @@ impl IpcServer {
         sweep_registry: Arc<Mutex<SweepRegistry>>,
         event_bus: Arc<EventBus>,
         main_health_state: Arc<MainHealthState>,
+        workspace_pool: Arc<WorkspacePool>,
     ) -> Self {
         Self {
             socket_path,
@@ -123,6 +132,7 @@ impl IpcServer {
             sweep_registry,
             event_bus,
             main_health_state,
+            workspace_pool,
         }
     }
 
@@ -157,8 +167,9 @@ impl IpcServer {
                     let sr = self.sweep_registry.clone();
                     let bus = self.event_bus.clone();
                     let health = self.main_health_state.clone();
+                    let pool = self.workspace_pool.clone();
                     tokio::spawn(async move {
-                        if let Err(e) = handle_client(stream, tm, db, sr, bus, health).await {
+                        if let Err(e) = handle_client(stream, tm, db, sr, bus, health, pool).await {
                             log::error!("Client error: {e}");
                         }
                     });
@@ -178,6 +189,7 @@ async fn handle_client(
     sweep_registry: Arc<Mutex<SweepRegistry>>,
     event_bus: Arc<EventBus>,
     main_health_state: Arc<MainHealthState>,
+    workspace_pool: Arc<WorkspacePool>,
 ) -> Result<()> {
     let (reader, mut writer) = stream.into_split();
     let mut lines = BufReader::new(reader).lines();
@@ -223,14 +235,13 @@ async fn handle_client(
         if let Request::CancelSweep {
             sweep_id,
             grace_secs,
+            workspace_root,
         } = request
         {
-            let response = cancel_sweep_nonblocking(
-                &sweep_registry,
-                &sweep_id,
-                Duration::from_secs(grace_secs),
-            )
-            .await;
+            let target =
+                resolve_registry(&sweep_registry, &workspace_pool, workspace_root.as_deref());
+            let response =
+                cancel_sweep_nonblocking(&target, &sweep_id, Duration::from_secs(grace_secs)).await;
             let response_json = serde_json::to_string(&response)?;
             writer.write_all(response_json.as_bytes()).await?;
             writer.write_all(b"\n").await?;
@@ -252,8 +263,14 @@ async fn handle_client(
             continue;
         }
 
-        let response =
-            handle_request(request, &terminal_manager, &activity_db, &sweep_registry, &event_bus);
+        let response = handle_request(
+            request,
+            &terminal_manager,
+            &activity_db,
+            &sweep_registry,
+            &event_bus,
+            &workspace_pool,
+        );
 
         let response_json = serde_json::to_string(&response)?;
         writer.write_all(response_json.as_bytes()).await?;
@@ -482,6 +499,29 @@ pub fn build_daemon_status(
 // Allow expect_used because mutex poisoning is a panic-level error that indicates
 // a thread panicked while holding the lock. This is not recoverable and should crash.
 // Allow too_many_lines because this is a central request dispatcher that handles all IPC commands.
+/// Resolve which per-repo [`SweepRegistry`] a sweep request targets (Issue
+/// #3929). When `workspace_root` is `Some(non-empty)`, the root is normalized
+/// (canonicalize/absolutize — matching how `WorkspaceRegistry::add` and the
+/// autonomous loops key the pool) and the pool provisions/returns that repo's
+/// registry. When `None`/empty, the daemon's default-workspace registry is
+/// returned, preserving pre-#3929 single-repo behavior byte-for-byte.
+///
+/// A `Some(root)` that equals the seeded default workspace root resolves back to
+/// the same shared default registry (the pool returns the seeded instance).
+fn resolve_registry(
+    default: &Arc<Mutex<SweepRegistry>>,
+    workspace_pool: &Arc<WorkspacePool>,
+    workspace_root: Option<&str>,
+) -> Arc<Mutex<SweepRegistry>> {
+    match workspace_root {
+        Some(root) if !root.trim().is_empty() => {
+            let normalized = crate::workspace_registry::normalize_path(Path::new(root));
+            workspace_pool.get_or_provision(&normalized)
+        }
+        _ => default.clone(),
+    }
+}
+
 #[allow(clippy::expect_used, clippy::too_many_lines)]
 fn handle_request(
     request: Request,
@@ -489,6 +529,7 @@ fn handle_request(
     activity_db: &Arc<Mutex<ActivityDb>>,
     sweep_registry: &Arc<Mutex<SweepRegistry>>,
     event_bus: &Arc<EventBus>,
+    workspace_pool: &Arc<WorkspacePool>,
 ) -> Response {
     match request {
         Request::Ping => Response::Pong,
@@ -1070,10 +1111,11 @@ fn handle_request(
             model,
             effort,
             depends_on,
+            workspace_root,
         } => {
-            let mut sr = sweep_registry
-                .lock()
-                .expect("Sweep registry mutex poisoned");
+            let target =
+                resolve_registry(sweep_registry, workspace_pool, workspace_root.as_deref());
+            let mut sr = target.lock().expect("Sweep registry mutex poisoned");
             match sr.dispatch(
                 &kind,
                 idempotency_key,
@@ -1093,10 +1135,13 @@ fn handle_request(
             }
         }
 
-        Request::ListSweeps { state_filter } => {
-            let mut sr = sweep_registry
-                .lock()
-                .expect("Sweep registry mutex poisoned");
+        Request::ListSweeps {
+            state_filter,
+            workspace_root,
+        } => {
+            let target =
+                resolve_registry(sweep_registry, workspace_pool, workspace_root.as_deref());
+            let mut sr = target.lock().expect("Sweep registry mutex poisoned");
             // Reap-on-read (Issue #3893): reconcile liveness before listing so a
             // sweep whose child has already exited is never reported `Running`
             // just because the 30s reaper timer has not ticked yet.
@@ -1108,10 +1153,13 @@ fn handle_request(
         // ====================================================================
         // Sweep Monitoring Handlers (Issue #3455 — Phase C of #3449)
         // ====================================================================
-        Request::GetSweepStatus { sweep_id } => {
-            let mut sr = sweep_registry
-                .lock()
-                .expect("Sweep registry mutex poisoned");
+        Request::GetSweepStatus {
+            sweep_id,
+            workspace_root,
+        } => {
+            let target =
+                resolve_registry(sweep_registry, workspace_pool, workspace_root.as_deref());
+            let mut sr = target.lock().expect("Sweep registry mutex poisoned");
             // Reap-on-read (Issue #3893): reconcile liveness so a status query
             // reflects a child that has exited rather than a stale `Running`.
             sr.reap_liveness();
@@ -1119,10 +1167,14 @@ fn handle_request(
             Response::SweepStatus { info }
         }
 
-        Request::TailSweepLog { sweep_id, lines } => {
-            let sr = sweep_registry
-                .lock()
-                .expect("Sweep registry mutex poisoned");
+        Request::TailSweepLog {
+            sweep_id,
+            lines,
+            workspace_root,
+        } => {
+            let target =
+                resolve_registry(sweep_registry, workspace_pool, workspace_root.as_deref());
+            let sr = target.lock().expect("Sweep registry mutex poisoned");
             match sr.tail_log(&sweep_id, lines) {
                 Ok((log_path, lines)) => Response::SweepLogTail {
                     sweep_id,
@@ -1138,6 +1190,7 @@ fn handle_request(
         Request::CancelSweep {
             sweep_id,
             grace_secs,
+            workspace_root,
         } => {
             // Production traffic never reaches this arm: `handle_client`
             // intercepts `CancelSweep` and services it via the non-blocking
@@ -1145,9 +1198,9 @@ fn handle_request(
             // window does not hold the registry mutex. This synchronous
             // fallback (holding the lock across the full grace) remains for
             // direct/unit-test callers where lock contention is irrelevant.
-            let mut sr = sweep_registry
-                .lock()
-                .expect("Sweep registry mutex poisoned");
+            let target =
+                resolve_registry(sweep_registry, workspace_pool, workspace_root.as_deref());
+            let mut sr = target.lock().expect("Sweep registry mutex poisoned");
             match sr.cancel(&sweep_id, std::time::Duration::from_secs(grace_secs)) {
                 Ok(outcome) => Response::SweepCancelled {
                     sweep_id: outcome.sweep_id,
@@ -1217,7 +1270,7 @@ fn handle_request(
             config_overrides,
         } => handle_register_workspace(&root, config_overrides),
 
-        Request::DeregisterWorkspace { root } => handle_deregister_workspace(&root),
+        Request::DeregisterWorkspace { root } => handle_deregister_workspace(&root, workspace_pool),
 
         Request::ListWorkspaces => handle_list_workspaces(),
 
@@ -1279,8 +1332,12 @@ fn handle_register_workspace(root: &str, config_overrides: Option<serde_json::Va
 }
 
 /// Load, mutate, and persist the workspace registry for a `DeregisterWorkspace`
-/// request.
-fn handle_deregister_workspace(root: &str) -> Response {
+/// request, then evict the deregistered repo's in-memory sweep registry from the
+/// [`WorkspacePool`] (Issue #3929) so its background reaper stops and it does not
+/// leak. The seeded default workspace is guarded inside [`WorkspacePool::evict`]
+/// (a no-op there), and a live sweep child is never killed — only the in-memory
+/// tracking goes away.
+fn handle_deregister_workspace(root: &str, workspace_pool: &Arc<WorkspacePool>) -> Response {
     use crate::workspace_registry::{default_registry_path, normalize_path, WorkspaceRegistry};
 
     let path = match default_registry_path() {
@@ -1307,6 +1364,16 @@ fn handle_deregister_workspace(root: &str) -> Response {
                 message: format!("deregister_workspace: save failed: {e}"),
             };
         }
+    }
+    // Evict the in-memory pool entry (best-effort, idempotent). The pool keys on
+    // the same normalized root the registry stores, and guards the seeded
+    // default workspace internally.
+    let evicted = workspace_pool.evict(&canonical);
+    if evicted {
+        log::info!(
+            "deregister_workspace: evicted pooled sweep registry for {}",
+            canonical.display()
+        );
     }
     Response::WorkspaceDeregistered {
         root: canonical,
@@ -1352,6 +1419,24 @@ mod tests {
         Arc<EventBus>,
     );
 
+    /// A process-wide leaked runtime handle so [`WorkspacePool`]s can be built in
+    /// synchronous `#[test]` cases (Issue #3929). Reapers spawned onto it during
+    /// provisioning are harmless in tests.
+    fn test_runtime_handle() -> tokio::runtime::Handle {
+        use std::sync::OnceLock;
+        static RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+        RT.get_or_init(|| tokio::runtime::Runtime::new().unwrap())
+            .handle()
+            .clone()
+    }
+
+    /// A [`WorkspacePool`] for `handle_request` tests (Issue #3929). The
+    /// default-workspace (`workspace_root: None`) paths these tests exercise
+    /// never provision, so no task is actually spawned.
+    fn test_pool() -> Arc<WorkspacePool> {
+        Arc::new(WorkspacePool::new(Arc::new(EventBus::new()), test_runtime_handle()))
+    }
+
     fn setup_test_context() -> TestContext {
         let tm = Arc::new(Mutex::new(TerminalManager::new()));
         let dir = tempdir().unwrap();
@@ -1374,7 +1459,7 @@ mod tests {
     #[test]
     fn test_handle_request_ping() {
         let (tm, db, sr, bus) = setup_test_context();
-        let response = handle_request(Request::Ping, &tm, &db, &sr, &bus);
+        let response = handle_request(Request::Ping, &tm, &db, &sr, &bus, &test_pool());
         assert!(matches!(response, Response::Pong));
     }
 
@@ -1385,7 +1470,7 @@ mod tests {
         let (tm, db, sr, bus) = setup_test_context();
         // Set LOOM_NO_RESTORE to prevent tmux restore attempts
         std::env::set_var("LOOM_NO_RESTORE", "1");
-        let response = handle_request(Request::ListTerminals, &tm, &db, &sr, &bus);
+        let response = handle_request(Request::ListTerminals, &tm, &db, &sr, &bus, &test_pool());
         std::env::remove_var("LOOM_NO_RESTORE");
         match response {
             Response::TerminalList { terminals } => {
@@ -1408,6 +1493,7 @@ mod tests {
             &db,
             &sr,
             &bus,
+            &test_pool(),
         );
         match response {
             Response::CurrentCommit { commit } => {
@@ -1431,6 +1517,7 @@ mod tests {
             &db,
             &sr,
             &bus,
+            &test_pool(),
         );
         match response {
             Response::TerminalActivity { entries } => {
@@ -1445,7 +1532,7 @@ mod tests {
     #[test]
     fn test_handle_request_get_all_claims_empty() {
         let (tm, db, sr, bus) = setup_test_context();
-        let response = handle_request(Request::GetAllClaims, &tm, &db, &sr, &bus);
+        let response = handle_request(Request::GetAllClaims, &tm, &db, &sr, &bus, &test_pool());
         match response {
             Response::Claims(claims) => {
                 assert!(claims.is_empty());
@@ -1467,6 +1554,7 @@ mod tests {
             &db,
             &sr,
             &bus,
+            &test_pool(),
         );
         match response {
             Response::ClaimsSummary(summary) => {
@@ -1491,6 +1579,7 @@ mod tests {
             &db,
             &sr,
             &bus,
+            &test_pool(),
         );
         match response {
             Response::GitChangesCaptured {
@@ -1555,14 +1644,144 @@ exit 0
     fn test_handle_request_list_sweeps_empty() {
         let (tm, db, _, bus) = setup_test_context();
         let (sr, _dir, _rec) = setup_sweep_registry_in_tempdir();
-        let response =
-            handle_request(Request::ListSweeps { state_filter: None }, &tm, &db, &sr, &bus);
+        let response = handle_request(
+            Request::ListSweeps {
+                state_filter: None,
+                workspace_root: None,
+            },
+            &tm,
+            &db,
+            &sr,
+            &bus,
+            &test_pool(),
+        );
         match response {
             Response::SweepList { sweeps } => {
                 assert!(sweeps.is_empty());
             }
             other => panic!("Expected SweepList, got: {other:?}"),
         }
+    }
+
+    /// Issue #3929: a request carrying an explicit `workspace_root` routes to
+    /// that repo's registry (via the pool), not the default workspace — and the
+    /// returned `SweepInfo` carries the owning `repo`. Omitting `workspace_root`
+    /// preserves default-workspace-only behavior (regression guard).
+    #[test]
+    #[serial_test::serial]
+    fn test_sweep_requests_route_to_explicit_workspace_root() {
+        let (tm, db, _, bus) = setup_test_context();
+
+        // Default workspace (repo A) and a second managed repo (repo B), each a
+        // fixture registry with a fake spawn bin + skip_label_flip.
+        let (sr_default, dir_a, _rec_a) = setup_sweep_registry_in_tempdir();
+        let (sr_b, dir_b, _rec_b) = setup_sweep_registry_in_tempdir();
+        let root_a = crate::workspace_registry::normalize_path(dir_a.path());
+        let root_b = crate::workspace_registry::normalize_path(dir_b.path());
+
+        // A pool seeded with both registries (mirrors main's seed of the default
+        // workspace, plus repo B provisioned by the autonomous loops).
+        let pool = Arc::new(WorkspacePool::new(Arc::new(EventBus::new()), test_runtime_handle()));
+        pool.seed(root_a, sr_default.clone());
+        pool.seed(root_b.clone(), sr_b.clone());
+
+        // Dispatch issue #42 into repo B explicitly.
+        let dispatched = handle_request(
+            Request::DispatchSweep {
+                kind: SweepKind::Issue(42),
+                idempotency_key: None,
+                model: None,
+                effort: None,
+                depends_on: None,
+                workspace_root: Some(dir_b.path().to_string_lossy().into_owned()),
+            },
+            &tm,
+            &db,
+            &sr_default,
+            &bus,
+            &pool,
+        );
+        let sweep_id = match dispatched {
+            Response::SweepDispatched { sweep_id, .. } => sweep_id,
+            other => panic!("Expected SweepDispatched, got: {other:?}"),
+        };
+
+        // repo B's registry sees the sweep, and its SweepInfo.repo names repo B.
+        let listed_b = handle_request(
+            Request::ListSweeps {
+                state_filter: None,
+                workspace_root: Some(dir_b.path().to_string_lossy().into_owned()),
+            },
+            &tm,
+            &db,
+            &sr_default,
+            &bus,
+            &pool,
+        );
+        match listed_b {
+            Response::SweepList { sweeps } => {
+                assert_eq!(sweeps.len(), 1, "repo B registry should hold the sweep");
+                assert_eq!(
+                    sweeps[0].repo.as_deref(),
+                    Some(dir_b.path().display().to_string().as_str()),
+                    "SweepInfo.repo must name the owning workspace root"
+                );
+            }
+            other => panic!("Expected SweepList, got: {other:?}"),
+        }
+
+        // The default workspace (workspace_root: None) must NOT see repo B's
+        // sweep — this is the identity guarantee (two repos' issue #42 differ).
+        let listed_default = handle_request(
+            Request::ListSweeps {
+                state_filter: None,
+                workspace_root: None,
+            },
+            &tm,
+            &db,
+            &sr_default,
+            &bus,
+            &pool,
+        );
+        match listed_default {
+            Response::SweepList { sweeps } => {
+                assert!(sweeps.is_empty(), "default workspace must not see repo B's sweep");
+            }
+            other => panic!("Expected SweepList, got: {other:?}"),
+        }
+
+        // GetSweepStatus is likewise workspace-scoped: found in repo B, absent
+        // from the default workspace.
+        let status_b = handle_request(
+            Request::GetSweepStatus {
+                sweep_id: sweep_id.clone(),
+                workspace_root: Some(dir_b.path().to_string_lossy().into_owned()),
+            },
+            &tm,
+            &db,
+            &sr_default,
+            &bus,
+            &pool,
+        );
+        assert!(
+            matches!(status_b, Response::SweepStatus { info: Some(_) }),
+            "sweep is observable via repo B's registry"
+        );
+        let status_default = handle_request(
+            Request::GetSweepStatus {
+                sweep_id,
+                workspace_root: None,
+            },
+            &tm,
+            &db,
+            &sr_default,
+            &bus,
+            &pool,
+        );
+        assert!(
+            matches!(status_default, Response::SweepStatus { info: None }),
+            "sweep is NOT observable via the default workspace"
+        );
     }
 
     #[test]
@@ -1578,11 +1797,13 @@ exit 0
                 model: None,
                 effort: None,
                 depends_on: None,
+                workspace_root: None,
             },
             &tm,
             &db,
             &sr,
             &bus,
+            &test_pool(),
         );
         match response {
             Response::SweepDispatched {
@@ -1603,8 +1824,17 @@ exit 0
         // immediately, so reap-on-read (Issue #3893) promptly reconciles the
         // entry to a terminal `Exited` state rather than over-reporting it as
         // `Running` — the entry is still listed, just no longer stale-Running.
-        let response =
-            handle_request(Request::ListSweeps { state_filter: None }, &tm, &db, &sr, &bus);
+        let response = handle_request(
+            Request::ListSweeps {
+                state_filter: None,
+                workspace_root: None,
+            },
+            &tm,
+            &db,
+            &sr,
+            &bus,
+            &test_pool(),
+        );
         match response {
             Response::SweepList { sweeps } => {
                 assert_eq!(sweeps.len(), 1);
@@ -1631,11 +1861,13 @@ exit 0
                 model: None,
                 effort: None,
                 depends_on: None,
+                workspace_root: None,
             },
             &tm,
             &db,
             &sr,
             &bus,
+            &test_pool(),
         );
         match response {
             Response::Error { message } => {
@@ -1664,6 +1896,7 @@ exit 0
                 model,
                 effort,
                 depends_on: _,
+                workspace_root: _,
             } => {
                 assert!(matches!(kind, SweepKind::Issue(42)));
                 assert!(idempotency_key.is_none());
@@ -1682,6 +1915,7 @@ exit 0
             model: Some("claude-sonnet-4-6".to_string()),
             effort: None,
             depends_on: None,
+            workspace_root: None,
         };
         let json = serde_json::to_string(&request).expect("serialize");
         let back: Request = serde_json::from_str(&json).expect("deserialize");
@@ -1692,6 +1926,7 @@ exit 0
                 model,
                 effort,
                 depends_on: _,
+                workspace_root: _,
             } => {
                 assert!(matches!(kind, SweepKind::Issue(7)));
                 assert_eq!(idempotency_key.as_deref(), Some("key-B"));
@@ -1710,6 +1945,7 @@ exit 0
             model: None,
             effort: None,
             depends_on: None,
+            workspace_root: None,
         };
         let json = serde_json::to_string(&request).expect("serialize");
         let back: Request = serde_json::from_str(&json).expect("deserialize");
@@ -1745,6 +1981,7 @@ exit 0
             model: Some("claude-sonnet-4-6".to_string()),
             effort: Some("xhigh".to_string()),
             depends_on: None,
+            workspace_root: None,
         };
         let json = serde_json::to_string(&request).expect("serialize");
         let back: Request = serde_json::from_str(&json).expect("deserialize");
@@ -1765,6 +2002,7 @@ exit 0
             model: None,
             effort: Some(String::new()),
             depends_on: None,
+            workspace_root: None,
         };
         let json = serde_json::to_string(&request).expect("serialize");
         let back: Request = serde_json::from_str(&json).expect("deserialize");
@@ -1803,6 +2041,7 @@ exit 0
             model: None,
             effort: None,
             depends_on: Some(3726),
+            workspace_root: None,
         };
         let json = serde_json::to_string(&request).expect("serialize");
         let back: Request = serde_json::from_str(&json).expect("deserialize");
@@ -1830,6 +2069,7 @@ exit 0
             &db,
             &sr,
             &bus,
+            &test_pool(),
         );
 
         match response {
@@ -1860,11 +2100,13 @@ exit 0
         let response = handle_request(
             Request::GetSweepStatus {
                 sweep_id: "no-such-sweep".to_string(),
+                workspace_root: None,
             },
             &tm,
             &db,
             &sr,
             &bus,
+            &test_pool(),
         );
         match response {
             Response::SweepStatus { info } => assert!(info.is_none()),
@@ -1880,11 +2122,13 @@ exit 0
             Request::TailSweepLog {
                 sweep_id: "no-such-sweep".to_string(),
                 lines: 10,
+                workspace_root: None,
             },
             &tm,
             &db,
             &sr,
             &bus,
+            &test_pool(),
         );
         match response {
             Response::Error { message } => {
@@ -1905,11 +2149,13 @@ exit 0
             Request::CancelSweep {
                 sweep_id: "no-such-sweep".to_string(),
                 grace_secs: 1,
+                workspace_root: None,
             },
             &tm,
             &db,
             &sr,
             &bus,
+            &test_pool(),
         );
         match response {
             Response::Error { message } => {
@@ -1936,11 +2182,13 @@ exit 0
                 model: None,
                 effort: None,
                 depends_on: None,
+                workspace_root: None,
             },
             &tm,
             &db,
             &sr,
             &bus,
+            &test_pool(),
         );
         let sweep_id = match dispatched {
             Response::SweepDispatched { sweep_id, .. } => sweep_id,
@@ -1950,11 +2198,13 @@ exit 0
         let response = handle_request(
             Request::GetSweepStatus {
                 sweep_id: sweep_id.clone(),
+                workspace_root: None,
             },
             &tm,
             &db,
             &sr,
             &bus,
+            &test_pool(),
         );
         match response {
             Response::SweepStatus { info } => {
@@ -2129,7 +2379,7 @@ exit 0
     #[test]
     fn test_handle_request_daemon_status_short_circuits_to_error() {
         let (tm, db, sr, bus) = setup_test_context();
-        let response = handle_request(Request::DaemonStatus, &tm, &db, &sr, &bus);
+        let response = handle_request(Request::DaemonStatus, &tm, &db, &sr, &bus, &test_pool());
         match response {
             Response::Error { message } => {
                 assert!(
@@ -2155,6 +2405,7 @@ exit 0
             &db,
             &sr,
             &bus,
+            &test_pool(),
         );
         match response {
             Response::Error { message } => {
@@ -2185,7 +2436,7 @@ exit 0
         std::env::set_var("LOOM_WORKSPACES_PATH", &registry_path);
 
         // Empty registry: list returns no workspaces.
-        let response = handle_request(Request::ListWorkspaces, &tm, &db, &sr, &bus);
+        let response = handle_request(Request::ListWorkspaces, &tm, &db, &sr, &bus, &test_pool());
         match response {
             Response::WorkspaceList { workspaces } => assert!(workspaces.is_empty()),
             other => panic!("Expected WorkspaceList, got: {other:?}"),
@@ -2201,6 +2452,7 @@ exit 0
             &db,
             &sr,
             &bus,
+            &test_pool(),
         );
         match response {
             Response::WorkspaceRegistered {
@@ -2224,6 +2476,7 @@ exit 0
             &db,
             &sr,
             &bus,
+            &test_pool(),
         );
         match response {
             Response::WorkspaceRegistered {
@@ -2233,7 +2486,7 @@ exit 0
         }
 
         // List now shows exactly one.
-        let response = handle_request(Request::ListWorkspaces, &tm, &db, &sr, &bus);
+        let response = handle_request(Request::ListWorkspaces, &tm, &db, &sr, &bus, &test_pool());
         match response {
             Response::WorkspaceList { workspaces } => {
                 assert_eq!(workspaces.len(), 1);
@@ -2251,6 +2504,7 @@ exit 0
             &db,
             &sr,
             &bus,
+            &test_pool(),
         );
         match response {
             Response::WorkspaceDeregistered { was_present, .. } => assert!(was_present),
@@ -2266,6 +2520,7 @@ exit 0
             &db,
             &sr,
             &bus,
+            &test_pool(),
         );
         match response {
             Response::WorkspaceDeregistered { was_present, .. } => assert!(!was_present),

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -513,6 +513,7 @@ async fn main() -> Result<()> {
         sweep_registry,
         event_bus,
         main_health_state.clone(),
+        workspace_pool.clone(),
     );
 
     // Setup signal handler for graceful shutdown. We listen for BOTH SIGINT

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -903,6 +903,10 @@ impl SweepRegistry {
             model: model.filter(|m| !m.is_empty()).map(String::from),
             effort: effort.filter(|e| !e.is_empty()).map(String::from),
             depends_on,
+            // Stamp the owning workspace root (#3929) so list_sweeps /
+            // get_sweep_status responses disambiguate this repo's issue #N from
+            // another managed repo's identically-numbered issue.
+            repo: Some(self.config.workspace_root.display().to_string()),
         };
         self.entries.insert(sweep_id.clone(), info);
 
@@ -925,7 +929,13 @@ impl SweepRegistry {
 
     /// Internal helper: publish an event on the attached bus (if any).
     /// Best-effort — logs a debug line if no subscribers are listening.
-    fn emit_event(&self, event: Event) {
+    ///
+    /// Sweep-scoped events are stamped with this registry's owning workspace
+    /// root (Issue #3929) so multi-repo subscribers can disambiguate two managed
+    /// repos' issue #N — the topic string is unchanged; `repo` lives in the
+    /// payload only.
+    fn emit_event(&self, mut event: Event) {
+        event.set_repo_if_absent(&self.config.workspace_root.display().to_string());
         if let Some(ref bus) = self.bus {
             let topic = event.topic();
             match bus.publish(event) {
@@ -1120,6 +1130,7 @@ impl SweepRegistry {
                 issue: *child,
                 reason: reason.to_string(),
                 label_added: "loom:blocked".to_string(),
+                repo: None, // stamped by emit_event (#3929)
             });
         }
         children
@@ -1607,6 +1618,7 @@ impl SweepRegistry {
                 issue: *issue,
                 exit_code: None,
                 duration_sec,
+                repo: None, // stamped by emit_event (#3929)
             });
         }
         self.emit_event(Event::SweepGlobalCompleted {
@@ -1715,6 +1727,7 @@ impl SweepRegistry {
                             events_to_emit.push(Event::SweepCrashed {
                                 issue,
                                 checkpoint_phase,
+                                repo: None, // stamped by emit_event (#3929)
                             });
                             events_to_emit.push(Event::SweepGlobalCompleted {
                                 sweep_id: sweep_id.clone(),
@@ -1754,6 +1767,7 @@ impl SweepRegistry {
                                 issue,
                                 exit_code,
                                 duration_sec,
+                                repo: None, // stamped by emit_event (#3929)
                             });
                             events_to_emit.push(Event::SweepGlobalCompleted {
                                 sweep_id: sweep_id.clone(),
@@ -1777,6 +1791,7 @@ impl SweepRegistry {
                                     issue: child,
                                     reason: reason.clone(),
                                     label_added: "loom:blocked".to_string(),
+                                    repo: None, // stamped by emit_event (#3929)
                                 });
                             }
                         }
@@ -2171,6 +2186,7 @@ impl SweepRegistry {
                         self.emit_event(Event::SweepCrashed {
                             issue,
                             checkpoint_phase: None,
+                            repo: None, // stamped by emit_event (#3929)
                         });
                     }
                 }
@@ -2189,6 +2205,7 @@ impl SweepRegistry {
                             self.emit_event(Event::SweepCrashed {
                                 issue,
                                 checkpoint_phase: None,
+                                repo: None, // stamped by emit_event (#3929)
                             });
                         }
                         continue;
@@ -2348,6 +2365,7 @@ impl SweepRegistry {
                         self.emit_event(Event::SweepCrashed {
                             issue,
                             checkpoint_phase: None,
+                            repo: None, // stamped by emit_event (#3929)
                         });
                     }
                 }
@@ -2508,6 +2526,7 @@ impl SweepRegistry {
                 let log_path = self.compute_log_path(issue);
                 let started_at = chrono::DateTime::parse_from_rfc3339(&owner.acquired_at)
                     .map_or_else(|_| Utc::now(), |t| t.with_timezone(&Utc));
+                let repo = Some(self.config.workspace_root.display().to_string());
                 self.entries.insert(
                     owner.sweep_id.clone(),
                     SweepInfo {
@@ -2528,6 +2547,9 @@ impl SweepRegistry {
                         effort: None,
                         // depends_on is not recorded in the lock owner (#3729).
                         depends_on: None,
+                        // Owning workspace root, stamped for multi-repo
+                        // disambiguation (#3929).
+                        repo,
                     },
                 );
                 admitted += 1;
@@ -2577,6 +2599,8 @@ impl SweepRegistry {
                 }
                 let sweep_id = format!("sweep-issue-{issue}-recovered-{}", Utc::now().timestamp());
                 let phase = read_checkpoint_phase(&path);
+                let log_path = self.compute_log_path(issue);
+                let repo = Some(self.config.workspace_root.display().to_string());
                 self.entries.insert(
                     sweep_id.clone(),
                     SweepInfo {
@@ -2584,7 +2608,7 @@ impl SweepRegistry {
                         kind: SweepKind::Issue(issue),
                         pid: 0, // unknown — owner is gone
                         token_name: "unknown".to_string(),
-                        log_path: self.compute_log_path(issue),
+                        log_path,
                         idempotency_key: None,
                         started_at: Utc::now(),
                         state: SweepState::Crashed { at: Utc::now() },
@@ -2593,6 +2617,9 @@ impl SweepRegistry {
                         model: None,      // not recoverable from a checkpoint-only entry
                         effort: None,     // not recoverable from a checkpoint-only entry
                         depends_on: None, // not recoverable from a checkpoint-only entry
+                        // Owning workspace root, stamped for multi-repo
+                        // disambiguation (#3929).
+                        repo,
                     },
                 );
                 admitted += 1;
@@ -3580,6 +3607,7 @@ exit 0
                     model: None,
                     effort: None,
                     depends_on: dep,
+                    repo: None,
                 },
             );
         }
@@ -3623,6 +3651,7 @@ exit 0
                 model: None,
                 effort: None,
                 depends_on: dep,
+                repo: None,
             }
         }
         registry
@@ -3864,6 +3893,7 @@ exit 0
                 model: None,
                 effort: None,
                 depends_on: None,
+                repo: None,
             },
         );
 
@@ -3879,6 +3909,7 @@ exit 0
                 Event::SweepCrashed {
                     issue,
                     checkpoint_phase,
+                    ..
                 } => {
                     assert_eq!(issue, 55);
                     assert_eq!(checkpoint_phase.as_deref(), Some("doctor"));
@@ -3936,6 +3967,7 @@ exit 0
                 model: None,
                 effort: None,
                 depends_on: None,
+                repo: None,
             },
         );
 
@@ -3990,6 +4022,7 @@ exit 0
                 model: None,
                 effort: None,
                 depends_on: None,
+                repo: None,
             },
         );
 
@@ -4045,6 +4078,7 @@ exit 0
                 model: None,
                 effort: None,
                 depends_on: None,
+                repo: None,
             },
         );
 
@@ -4109,6 +4143,7 @@ exit 0
                 model: None,
                 effort: None,
                 depends_on: None,
+                repo: None,
             },
         );
 
@@ -4171,6 +4206,7 @@ exit 0
                 model: None,
                 effort: None,
                 depends_on: None,
+                repo: None,
             },
         );
 
@@ -4232,6 +4268,7 @@ exit 0
                 model: None,
                 effort: None,
                 depends_on: None,
+                repo: None,
             },
         );
 
@@ -4276,6 +4313,7 @@ exit 0
                 model: None,
                 effort: None,
                 depends_on: None,
+                repo: None,
             },
         );
 
@@ -4630,6 +4668,7 @@ exit 0\n";
             model: Some("claude-sonnet-4-6".to_string()),
             effort: Some("xhigh".to_string()),
             depends_on: None,
+            repo: None,
         };
         let json = serde_json::to_value(vec![info]).unwrap();
         let expected = serde_json::json!([{
@@ -4739,6 +4778,7 @@ exit 0\n";
                 model: None,
                 effort: None,
                 depends_on: None,
+                repo: None,
             },
         );
 
@@ -4778,6 +4818,7 @@ exit 0\n";
                 model: None,
                 effort: None,
                 depends_on: None,
+                repo: None,
             },
         );
 
@@ -4839,6 +4880,7 @@ exit 0\n";
                 model: None,
                 effort: None,
                 depends_on: None,
+                repo: None,
             },
         );
 
@@ -4878,6 +4920,7 @@ exit 0\n";
                 model: None,
                 effort: None,
                 depends_on: None,
+                repo: None,
             },
         );
 
@@ -4935,6 +4978,7 @@ exit 0\n";
                 model: None,
                 effort: None,
                 depends_on: None,
+                repo: None,
             },
         );
 
@@ -5011,6 +5055,7 @@ exit 0\n";
                     model: None,
                     effort: None,
                     depends_on: None,
+                    repo: None,
                 },
             );
             reg.entries.insert(
@@ -5029,6 +5074,7 @@ exit 0\n";
                     model: None,
                     effort: None,
                     depends_on: None,
+                    repo: None,
                 },
             );
         }
@@ -5122,6 +5168,7 @@ exit 0\n";
                 model: None,
                 effort: None,
                 depends_on: None,
+                repo: None,
             },
         );
 
@@ -5589,6 +5636,7 @@ exit 0\n";
                 model: None,
                 effort: None,
                 depends_on: None,
+                repo: None,
             },
         );
     }
@@ -5760,6 +5808,7 @@ exit 0\n";
                 model: None,
                 effort: None,
                 depends_on: None,
+                repo: None,
             },
         );
 

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -172,10 +172,25 @@ pub enum Request {
         effort: Option<String>,
         #[serde(default)]
         depends_on: Option<u32>,
+        /// Target managed-workspace root (Issue #3929). When `Some(root)`, the
+        /// daemon resolves the per-repo sweep registry for that root via the
+        /// [`WorkspacePool`](crate::workspace_pool::WorkspacePool) — so a sweep
+        /// can be dispatched into a managed repo other than the daemon's default
+        /// workspace. When `None` (or absent on the wire — `#[serde(default)]`
+        /// keeps existing clients byte-for-byte compatible), the default
+        /// workspace registry is used, exactly as before.
+        #[serde(default)]
+        workspace_root: Option<String>,
     },
     /// List tracked sweeps, optionally filtered by state.
     ListSweeps {
         state_filter: Option<SweepState>,
+        /// Target managed-workspace root (Issue #3929). `Some(root)` lists the
+        /// sweeps tracked by that repo's registry; `None` (or absent) preserves
+        /// the default-workspace-only behavior. Cross-repo aggregation in a
+        /// single call is deferred to phase d (#3930).
+        #[serde(default)]
+        workspace_root: Option<String>,
     },
     // ========================================================================
     // Event Bus Requests (Issue #3453 — Phase B of #3449)
@@ -217,6 +232,11 @@ pub enum Request {
     /// this as `get_sweep_status` in the MCP layer.
     GetSweepStatus {
         sweep_id: SweepId,
+        /// Target managed-workspace root (Issue #3929). `Some(root)` looks the
+        /// sweep up in that repo's registry; `None` (or absent) uses the default
+        /// workspace, exactly as before.
+        #[serde(default)]
+        workspace_root: Option<String>,
     },
     /// Read the last `lines` lines from a sweep's per-sweep log file.
     /// Resolved relative to the registry's workspace root. Used by the
@@ -224,6 +244,11 @@ pub enum Request {
     TailSweepLog {
         sweep_id: SweepId,
         lines: usize,
+        /// Target managed-workspace root (Issue #3929). `Some(root)` resolves the
+        /// log against that repo's registry; `None` (or absent) uses the default
+        /// workspace, exactly as before.
+        #[serde(default)]
+        workspace_root: Option<String>,
     },
     /// Cancel a running sweep: send SIGTERM, wait the grace window, then
     /// SIGKILL if still alive. Transitions the registry entry from
@@ -234,6 +259,11 @@ pub enum Request {
         /// chosen by the MCP layer; the daemon honours whatever value
         /// arrives in the request.
         grace_secs: u64,
+        /// Target managed-workspace root (Issue #3929). `Some(root)` cancels a
+        /// sweep tracked by that repo's registry; `None` (or absent) uses the
+        /// default workspace, exactly as before.
+        #[serde(default)]
+        workspace_root: Option<String>,
     },
     // ========================================================================
     // Autonomous Daemon Status (Issue #3891 — follow-up to #3813 Phase D)
@@ -571,6 +601,15 @@ pub struct SweepInfo {
     /// `#[serde(default)]` keeps pre-#3729 wire data and clients compatible.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub depends_on: Option<u32>,
+    /// The managed-workspace root that owns this sweep (Issue #3929). Populated
+    /// from the owning registry's `config.workspace_root` so a `list_sweeps` /
+    /// `get_sweep_status` response is self-describing: two managed repos can each
+    /// have an issue #42, and this field disambiguates repo A's sweep from repo
+    /// B's. `None` on internally-constructed entries that have not yet been
+    /// stamped; `#[serde(default)]` keeps pre-#3929 wire data and clients
+    /// compatible.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo: Option<String>,
 }
 
 // ========================================================================
@@ -667,12 +706,23 @@ pub enum Event {
         phase: String,
         #[serde(skip_serializing_if = "Option::is_none")]
         pr_number: Option<i32>,
+        /// Owning managed-workspace root (Issue #3929). Stamped by the emitting
+        /// registry from `config.workspace_root` so a subscriber that matches
+        /// the shared `sweep.issue.{N}.phase` topic can disambiguate two managed
+        /// repos' issue #N. Additive/backward-compatible — the topic string is
+        /// unchanged; the field lives in the payload only. `#[serde(default)]`
+        /// keeps pre-#3929 subscribers/wire data compatible.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        repo: Option<String>,
     },
     /// `sweep.issue.{N}.blocker` — sweep child encountered a blocker.
     SweepBlocker {
         issue: u32,
         reason: String,
         label_added: String,
+        /// Owning managed-workspace root (Issue #3929). See [`Self::SweepPhase`].
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        repo: Option<String>,
     },
     /// `sweep.issue.{N}.exited` — reaper detected clean exit.
     SweepExited {
@@ -680,12 +730,18 @@ pub enum Event {
         #[serde(skip_serializing_if = "Option::is_none")]
         exit_code: Option<i32>,
         duration_sec: i64,
+        /// Owning managed-workspace root (Issue #3929). See [`Self::SweepPhase`].
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        repo: Option<String>,
     },
     /// `sweep.issue.{N}.crashed` — reaper detected dead pid + checkpoint.
     SweepCrashed {
         issue: u32,
         #[serde(skip_serializing_if = "Option::is_none")]
         checkpoint_phase: Option<String>,
+        /// Owning managed-workspace root (Issue #3929). See [`Self::SweepPhase`].
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        repo: Option<String>,
     },
     /// `sweep.global.dispatch` — daemon dispatched a new sweep.
     SweepGlobalDispatch { sweep_id: SweepId, kind: SweepKind },
@@ -758,6 +814,12 @@ impl Event {
     /// | `CapacityAdvisory {..}` | `daemon.capacity.advisory` |
     /// | `TopicLag {..}` | `sweep.system.topic_lag` |
     /// | `Generic {topic, ..}` | the explicit topic string |
+    ///
+    /// The four `SweepPhase` / `SweepBlocker` / `SweepExited` / `SweepCrashed`
+    /// variants also carry a `repo` payload field (Issue #3929) so a subscriber
+    /// on the shared `sweep.issue.{N}.*` bus can disambiguate two managed repos'
+    /// issue #N. The topic **strings are unchanged** — `repo` lives in the
+    /// payload only, so existing single-repo subscribers route identically.
     #[must_use]
     pub fn topic(&self) -> String {
         match self {
@@ -773,6 +835,29 @@ impl Event {
             Self::CapacityAdvisory { .. } => "daemon.capacity.advisory".to_string(),
             Self::TopicLag { .. } => "sweep.system.topic_lag".to_string(),
             Self::Generic { topic, .. } => topic.clone(),
+        }
+    }
+
+    /// Stamp the owning managed-workspace `repo` into the sweep-scoped event
+    /// variants (Issue #3929), but only when the field is still absent — a
+    /// caller that already knows the repo (e.g. a `PublishEvent` payload from a
+    /// sweep child running in a specific workspace) is never overwritten.
+    ///
+    /// Non-sweep-scoped variants (`SweepGlobalDispatch` / `SweepGlobalCompleted`
+    /// already carry a unique `sweep_id`; `EpicAction`; `CapacityAdvisory`;
+    /// `TopicLag`; `Generic`) are left untouched. Called centrally from
+    /// `SweepRegistry::emit_event` so every emitted sweep event is stamped with
+    /// its registry's `workspace_root` without touching each construction site.
+    pub fn set_repo_if_absent(&mut self, repo: &str) {
+        let slot = match self {
+            Self::SweepPhase { repo, .. }
+            | Self::SweepBlocker { repo, .. }
+            | Self::SweepExited { repo, .. }
+            | Self::SweepCrashed { repo, .. } => repo,
+            _ => return,
+        };
+        if slot.is_none() {
+            *slot = Some(repo.to_string());
         }
     }
 }
@@ -839,4 +924,144 @@ impl EpicActionClass {
 pub enum SweepOutcome {
     Exited,
     Crashed,
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    // ---- Issue #3929: event `repo` payload field is additive; topic unchanged ----
+
+    #[test]
+    fn sweep_scoped_event_topics_are_unchanged_by_repo_field() {
+        // The topic string format is frozen; adding `repo` to the payload must
+        // not shift any topic segment.
+        let phase = Event::SweepPhase {
+            issue: 42,
+            phase: "builder".to_string(),
+            pr_number: None,
+            repo: Some("/repos/a".to_string()),
+        };
+        assert_eq!(phase.topic(), "sweep.issue.42.phase");
+
+        let blocker = Event::SweepBlocker {
+            issue: 42,
+            reason: "x".to_string(),
+            label_added: "loom:blocked".to_string(),
+            repo: Some("/repos/b".to_string()),
+        };
+        assert_eq!(blocker.topic(), "sweep.issue.42.blocker");
+
+        let exited = Event::SweepExited {
+            issue: 7,
+            exit_code: Some(0),
+            duration_sec: 5,
+            repo: None,
+        };
+        assert_eq!(exited.topic(), "sweep.issue.7.exited");
+
+        let crashed = Event::SweepCrashed {
+            issue: 7,
+            checkpoint_phase: Some("doctor".to_string()),
+            repo: Some("/repos/c".to_string()),
+        };
+        assert_eq!(crashed.topic(), "sweep.issue.7.crashed");
+    }
+
+    #[test]
+    fn event_repo_round_trips_through_serde() {
+        let ev = Event::SweepPhase {
+            issue: 99,
+            phase: "judge".to_string(),
+            pr_number: Some(1234),
+            repo: Some("/repos/alpha".to_string()),
+        };
+        let json = serde_json::to_string(&ev).unwrap();
+        assert!(json.contains("\"repo\":\"/repos/alpha\""));
+        let back: Event = serde_json::from_str(&json).unwrap();
+        match back {
+            Event::SweepPhase { issue, repo, .. } => {
+                assert_eq!(issue, 99);
+                assert_eq!(repo.as_deref(), Some("/repos/alpha"));
+            }
+            other => panic!("expected SweepPhase, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn event_repo_defaults_to_none_for_pre_3929_wire_data() {
+        // A payload emitted before #3929 has no `repo` key; it must still parse,
+        // with `repo` defaulting to None (backward-compatible subscribers).
+        let json = r#"{"type":"SweepPhase","issue":5,"phase":"builder"}"#;
+        let ev: Event = serde_json::from_str(json).unwrap();
+        match ev {
+            Event::SweepPhase {
+                issue,
+                repo,
+                pr_number,
+                ..
+            } => {
+                assert_eq!(issue, 5);
+                assert!(repo.is_none());
+                assert!(pr_number.is_none());
+            }
+            other => panic!("expected SweepPhase, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn set_repo_if_absent_stamps_only_when_empty_and_only_sweep_scoped() {
+        // Stamps when absent.
+        let mut ev = Event::SweepExited {
+            issue: 1,
+            exit_code: None,
+            duration_sec: 0,
+            repo: None,
+        };
+        ev.set_repo_if_absent("/repos/x");
+        match &ev {
+            Event::SweepExited { repo, .. } => assert_eq!(repo.as_deref(), Some("/repos/x")),
+            other => panic!("unexpected {other:?}"),
+        }
+        // Does not overwrite an already-known repo.
+        ev.set_repo_if_absent("/repos/y");
+        match &ev {
+            Event::SweepExited { repo, .. } => assert_eq!(repo.as_deref(), Some("/repos/x")),
+            other => panic!("unexpected {other:?}"),
+        }
+        // Leaves non-sweep-scoped variants untouched (no panic, no field).
+        let mut global = Event::SweepGlobalCompleted {
+            sweep_id: "s1".to_string(),
+            outcome: SweepOutcome::Exited,
+        };
+        global.set_repo_if_absent("/repos/z"); // no-op, must not panic
+        assert_eq!(global.topic(), "sweep.global.completed");
+    }
+
+    // ---- Issue #3929: SweepInfo `repo` field is additive/backward-compatible ----
+
+    #[test]
+    fn sweep_info_repo_round_trips_and_defaults_to_none() {
+        let json = r#"{
+            "sweep_id":"s1",
+            "kind":{"type":"Issue","value":42},
+            "pid":1234,
+            "token_name":"agent-1.token",
+            "log_path":".loom/logs/sweep-issue-42.log",
+            "started_at":"2026-07-24T00:00:00Z",
+            "state":{"state":"Running"}
+        }"#;
+        // Pre-#3929 wire data (no `repo`) parses with repo == None.
+        let info: SweepInfo = serde_json::from_str(json).unwrap();
+        assert!(info.repo.is_none());
+
+        // Round-trip with repo populated.
+        let mut info = info;
+        info.repo = Some("/repos/beta".to_string());
+        let round = serde_json::to_string(&info).unwrap();
+        assert!(round.contains("\"repo\":\"/repos/beta\""));
+        let back: SweepInfo = serde_json::from_str(&round).unwrap();
+        assert_eq!(back.repo.as_deref(), Some("/repos/beta"));
+    }
 }

--- a/loom-daemon/src/workspace_pool.rs
+++ b/loom-daemon/src/workspace_pool.rs
@@ -31,12 +31,16 @@
 //! pool captures a [`tokio::runtime::Handle`] to the shared runtime at
 //! construction and enters it (`Handle::enter`) around the reaper spawn.
 //!
-//! # Scope (phase b)
+//! # Eviction (phase c, #3929)
 //!
-//! Registry **eviction** on `workspace remove` and `(repo, issue)`-keyed
-//! namespacing are explicitly deferred to phase c (#3929). A deregistered
-//! workspace's registry + reaper linger harmlessly (the loops simply stop
-//! iterating it, since they only fan out over the *current* `effective_roots`).
+//! [`WorkspacePool::evict`] removes a provisioned registry when its workspace is
+//! deregistered (`workspace remove` / [`Request::DeregisterWorkspace`]), aborting
+//! its background reaper task so it does not leak for the daemon's lifetime. The
+//! **seeded default workspace** is guarded — its registry + reaper are owned by
+//! `main` and continue serving default-workspace IPC requests, so `evict` is a
+//! no-op for it (identified by `_reaper: None`).
+//!
+//! [`Request::DeregisterWorkspace`]: crate::types::Request::DeregisterWorkspace
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -146,6 +150,51 @@ impl WorkspacePool {
         arc
     }
 
+    /// Evict the provisioned registry for `root`, aborting its background reaper
+    /// task so it does not leak (Issue #3929). Called from the
+    /// [`Request::DeregisterWorkspace`](crate::types::Request::DeregisterWorkspace)
+    /// handler so `workspace remove` also drops the in-memory pool entry.
+    ///
+    /// Returns `true` when an entry was removed, `false` when `root` was not
+    /// pooled **or** was the seeded default workspace (which `main` owns — its
+    /// reaper must never be aborted from this path, since the daemon keeps
+    /// serving default-workspace IPC requests). The default-workspace guard is
+    /// structural: seeded entries carry `_reaper: None`.
+    ///
+    /// A live sweep child in the evicted registry is **not** killed — only the
+    /// in-memory tracking + reaper go away. The child keeps running and its lock
+    /// / log files are untouched; its terminal state simply becomes unobservable
+    /// via IPC after eviction (an accepted consequence of an explicit operator
+    /// `workspace remove`).
+    ///
+    /// Dropping a bare [`tokio::task::JoinHandle`] only *detaches* the task —
+    /// it does **not** cancel it — so we `.abort()` explicitly before dropping.
+    pub fn evict(&self, root: &Path) -> bool {
+        let mut map = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // Guard the seeded default workspace: it has no owned reaper here
+        // (`_reaper: None`) and `main` continues to serve its IPC requests.
+        if map.get(root).is_some_and(|p| p._reaper.is_none()) {
+            log::debug!(
+                "workspace_pool: refusing to evict seeded default workspace {}",
+                root.display()
+            );
+            return false;
+        }
+        match map.remove(root) {
+            Some(pooled) => {
+                if let Some(reaper) = pooled._reaper {
+                    reaper.abort();
+                }
+                log::info!("workspace_pool: evicted sweep registry for {}", root.display());
+                true
+            }
+            None => false,
+        }
+    }
+
     /// Number of registries currently cached (test/observability aid).
     #[must_use]
     pub fn len(&self) -> usize {
@@ -220,5 +269,54 @@ mod tests {
         let pool = pool();
         assert!(pool.is_empty());
         assert_eq!(pool.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn evict_removes_provisioned_root_and_reprovisions_fresh() {
+        let dir = tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let pool = pool();
+
+        let first = pool.get_or_provision(&root);
+        assert_eq!(pool.len(), 1);
+
+        assert!(pool.evict(&root), "evicting a provisioned root returns true");
+        assert_eq!(pool.len(), 0);
+        assert!(pool.is_empty());
+
+        // A subsequent get_or_provision re-provisions a *new* registry instance
+        // (not the evicted Arc).
+        let second = pool.get_or_provision(&root);
+        assert!(!Arc::ptr_eq(&first, &second), "re-provisioned registry is a new instance");
+        assert_eq!(pool.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn evict_absent_root_is_false() {
+        let dir = tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let pool = pool();
+        assert!(!pool.evict(&root), "evicting a never-provisioned root is a no-op false");
+        assert_eq!(pool.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn evict_seeded_default_workspace_is_rejected() {
+        let dir = tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let pool = pool();
+
+        let seeded =
+            Arc::new(Mutex::new(SweepRegistry::new(SweepRegistryConfig::new(root.clone()))));
+        pool.seed(root.clone(), seeded.clone());
+        assert_eq!(pool.len(), 1);
+
+        // The seeded default workspace is owned by `main`; evicting it here must
+        // be a no-op so its reaper/IPC lifecycle is never disturbed.
+        assert!(!pool.evict(&root), "seeded default workspace is not evictable");
+        assert_eq!(pool.len(), 1, "seeded entry survives the evict attempt");
+
+        let got = pool.get_or_provision(&root);
+        assert!(Arc::ptr_eq(&got, &seeded), "seeded instance is still the pooled one");
     }
 }

--- a/mcp-loom/src/tools/sweeps.ts
+++ b/mcp-loom/src/tools/sweeps.ts
@@ -89,6 +89,12 @@ export interface SweepInfo {
    * branched its worktree/PR off `feature/issue-<depends_on>`.
    */
   depends_on?: number;
+  /**
+   * Owning managed-workspace root (issue #3929). Two managed repos can each
+   * have an issue #42; this field disambiguates repo A's sweep from repo B's.
+   * Absent/undefined on pre-#3929 entries.
+   */
+  repo?: string;
 }
 
 interface DispatchResponse {
@@ -184,6 +190,17 @@ function isStateTag(s: string): s is SweepState["state"] {
   return s === "Pending" || s === "Running" || s === "Exited" || s === "Crashed";
 }
 
+/**
+ * Extract an optional `workspace_root` tool argument (issue #3929). Empty
+ * strings are treated as unset so the daemon receives `null` (default
+ * workspace) rather than a spurious empty root.
+ */
+function extractWorkspaceRoot(args?: Record<string, unknown>): string | undefined {
+  return typeof args?.workspace_root === "string" && args.workspace_root.length > 0
+    ? (args.workspace_root as string)
+    : undefined;
+}
+
 function buildStateFilter(stateArg: unknown): SweepState | null {
   if (typeof stateArg !== "string" || stateArg.length === 0) return null;
   if (!isStateTag(stateArg)) {
@@ -240,6 +257,7 @@ async function dispatchSweep(args: {
   model?: string;
   effort?: string;
   depends_on?: number;
+  workspace_root?: string;
 }): Promise<{ success: true; result: DispatchResponse["payload"] } | { success: false; error: string }> {
   try {
     const response = (await sendDaemonRequest({
@@ -260,6 +278,10 @@ async function dispatchSweep(args: {
         // child branches off the default branch as usual. When set, the child
         // branches its worktree/PR off `feature/issue-<depends_on>`.
         depends_on: args.depends_on ?? null,
+        // Issue #3929: optional target managed-workspace root. `null` (the
+        // default) dispatches into the daemon's default workspace, exactly as
+        // before; a value routes the sweep into that managed repo's registry.
+        workspace_root: args.workspace_root ?? null,
       },
     })) as DaemonResponse;
 
@@ -277,12 +299,16 @@ async function dispatchSweep(args: {
 
 async function listSweeps(args: {
   state_filter?: SweepState | null;
+  workspace_root?: string;
 }): Promise<{ success: true; sweeps: SweepInfo[] } | { success: false; error: string }> {
   try {
     const response = (await sendDaemonRequest({
       type: "ListSweeps",
       payload: {
         state_filter: args.state_filter ?? null,
+        // Issue #3929: optional target managed-workspace root. `null` lists the
+        // default workspace's sweeps, exactly as before.
+        workspace_root: args.workspace_root ?? null,
       },
     })) as DaemonResponse;
 
@@ -304,11 +330,12 @@ async function listSweeps(args: {
 
 async function getSweepStatus(args: {
   sweep_id: string;
+  workspace_root?: string;
 }): Promise<{ success: true; info: SweepInfo | null } | { success: false; error: string }> {
   try {
     const response = (await sendDaemonRequest({
       type: "GetSweepStatus",
-      payload: { sweep_id: args.sweep_id },
+      payload: { sweep_id: args.sweep_id, workspace_root: args.workspace_root ?? null },
     })) as DaemonResponse;
 
     if (response.type === "SweepStatus") {
@@ -324,6 +351,7 @@ async function getSweepStatus(args: {
 async function tailSweepLog(args: {
   sweep_id: string;
   lines: number;
+  workspace_root?: string;
 }): Promise<
   | { success: true; payload: SweepLogTailResponse["payload"] }
   | { success: false; error: string }
@@ -331,7 +359,7 @@ async function tailSweepLog(args: {
   try {
     const response = (await sendDaemonRequest({
       type: "TailSweepLog",
-      payload: { sweep_id: args.sweep_id, lines: args.lines },
+      payload: { sweep_id: args.sweep_id, lines: args.lines, workspace_root: args.workspace_root ?? null },
     })) as DaemonResponse;
 
     if (response.type === "SweepLogTail") {
@@ -347,6 +375,7 @@ async function tailSweepLog(args: {
 async function cancelSweep(args: {
   sweep_id: string;
   grace_secs: number;
+  workspace_root?: string;
 }): Promise<
   | { success: true; payload: SweepCancelledResponse["payload"] }
   | { success: false; error: string }
@@ -354,7 +383,7 @@ async function cancelSweep(args: {
   try {
     const response = (await sendDaemonRequest({
       type: "CancelSweep",
-      payload: { sweep_id: args.sweep_id, grace_secs: args.grace_secs },
+      payload: { sweep_id: args.sweep_id, grace_secs: args.grace_secs, workspace_root: args.workspace_root ?? null },
     })) as DaemonResponse;
 
     if (response.type === "SweepCancelled") {
@@ -496,6 +525,16 @@ export const sweepTools: Tool[] = [
             "list) makes diamonds / multi-parent stacks unrepresentable. Omit " +
             "for an independent sweep (no --depends-on flag is emitted).",
         },
+        workspace_root: {
+          type: "string",
+          description:
+            "Optional target managed-workspace root (issue #3929). Omit to " +
+            "dispatch into the daemon's default workspace (unchanged behavior). " +
+            "Provide a registered repo root to dispatch the sweep into that " +
+            "repo's working tree / sweep registry — required to address a " +
+            "managed repo other than the default when two repos share issue " +
+            "numbers.",
+        },
       },
       required: ["kind"],
     },
@@ -517,6 +556,16 @@ export const sweepTools: Tool[] = [
           enum: ["Pending", "Running", "Exited", "Crashed"],
           description:
             "Optional lifecycle state filter. Omit to list all tracked sweeps.",
+        },
+        workspace_root: {
+          type: "string",
+          description:
+            "Optional target managed-workspace root (issue #3929). Omit to " +
+            "list the default workspace's sweeps (unchanged behavior). Provide " +
+            "a registered repo root to list the sweeps tracked by that repo's " +
+            "registry — the way to observe sweeps the daemon autonomously " +
+            "dispatched into a managed repo other than the default. Each " +
+            "returned SweepInfo also carries a `repo` field naming its owner.",
         },
       },
     },
@@ -544,6 +593,14 @@ export const sweepTools: Tool[] = [
             "SweepInfo. Defaults to 10. The bus is in-memory and transient " +
             "— this is a best-effort recent-history sample, not a replay log.",
         },
+        workspace_root: {
+          type: "string",
+          description:
+            "Optional target managed-workspace root (issue #3929). Omit to " +
+            "look the sweep up in the default workspace (unchanged behavior). " +
+            "Provide a registered repo root to resolve the sweep against that " +
+            "repo's registry.",
+        },
       },
       required: ["sweep_id"],
     },
@@ -566,6 +623,14 @@ export const sweepTools: Tool[] = [
         lines: {
           type: "number",
           description: "Number of trailing lines to return. Defaults to 100.",
+        },
+        workspace_root: {
+          type: "string",
+          description:
+            "Optional target managed-workspace root (issue #3929). Omit to " +
+            "resolve the log against the default workspace (unchanged " +
+            "behavior). Provide a registered repo root to resolve it against " +
+            "that repo's registry.",
         },
       },
       required: ["sweep_id"],
@@ -662,6 +727,15 @@ export const sweepTools: Tool[] = [
             "of 0 escalates to SIGKILL immediately after the first poll " +
             "iteration (~100ms).",
         },
+        workspace_root: {
+          type: "string",
+          description:
+            "Optional target managed-workspace root (issue #3929). Omit to " +
+            "cancel a sweep tracked by the default workspace (unchanged " +
+            "behavior). Provide a registered repo root to cancel a sweep " +
+            "tracked by that repo's registry — required to cancel a sweep the " +
+            "daemon autonomously dispatched into a non-default managed repo.",
+        },
       },
       required: ["sweep_id"],
     },
@@ -723,6 +797,9 @@ function formatSweepLine(info: SweepInfo): string {
   if (info.latest_phase) parts.push(`  Phase:      ${info.latest_phase}`);
   if (info.pr_number !== undefined && info.pr_number !== null)
     parts.push(`  PR:         #${info.pr_number}`);
+  // Issue #3929: name the owning managed-workspace root when present so two
+  // repos' identically-numbered issues are distinguishable in the listing.
+  if (info.repo) parts.push(`  Repo:       ${info.repo}`);
   if (info.idempotency_key)
     parts.push(`  Idem. key:  ${info.idempotency_key}`);
   return parts.join("\n");
@@ -802,6 +879,7 @@ export async function handleSweepTool(
         model,
         effort,
         depends_on: dependsOn,
+        workspace_root: extractWorkspaceRoot(args),
       });
       if (!result.success) {
         return [
@@ -836,7 +914,10 @@ export async function handleSweepTool(
       const stateArg = args?.state_filter;
       const stateFilter = stateArg === undefined ? null : buildStateFilter(stateArg);
 
-      const result = await listSweeps({ state_filter: stateFilter });
+      const result = await listSweeps({
+        state_filter: stateFilter,
+        workspace_root: extractWorkspaceRoot(args),
+      });
       if (!result.success) {
         return [
           {
@@ -880,7 +961,10 @@ export async function handleSweepTool(
           ? Math.max(0, Math.floor(recentEventsArg))
           : 10;
 
-      const statusResult = await getSweepStatus({ sweep_id: sweepId });
+      const statusResult = await getSweepStatus({
+        sweep_id: sweepId,
+        workspace_root: extractWorkspaceRoot(args),
+      });
       if (!statusResult.success) {
         return [
           {
@@ -957,7 +1041,11 @@ export async function handleSweepTool(
           ? Math.max(0, Math.floor(linesArg))
           : 100;
 
-      const result = await tailSweepLog({ sweep_id: sweepId, lines });
+      const result = await tailSweepLog({
+        sweep_id: sweepId,
+        lines,
+        workspace_root: extractWorkspaceRoot(args),
+      });
       if (!result.success) {
         return [
           {
@@ -1088,7 +1176,11 @@ export async function handleSweepTool(
           ? Math.floor(graceArg)
           : 30;
 
-      const result = await cancelSweep({ sweep_id: sweepId, grace_secs: graceSecs });
+      const result = await cancelSweep({
+        sweep_id: sweepId,
+        grace_secs: graceSecs,
+        workspace_root: extractWorkspaceRoot(args),
+      });
       if (!result.success) {
         return [
           {


### PR DESCRIPTION
## Summary

Phase c of #3926 (part of #3835). Phase b already namespaced the filesystem paths (locks/logs/checkpoints/dispatch cwd) per repo via `WorkspacePool`. This PR closes the remaining **identity** and **lifecycle** gaps so a sweep dispatched into a non-default managed repo is observable, addressable, and cleanly cleaned up:

1. **IPC/MCP workspace awareness** — the IPC handler only saw the seeded default-workspace registry, so sweeps the autonomous loops dispatched into other repos were invisible to `list_sweeps` / `get_sweep_status` / `tail_sweep_log` / `cancel_sweep` / `dispatch_sweep`. The `WorkspacePool` is now threaded into the handler and each of those requests takes an optional `workspace_root` that resolves the target repo's registry.
2. **Event `repo` field** — the four `sweep.issue.{N}.*` event payloads gained an additive `repo` field so a subscriber on the shared bus can disambiguate two managed repos' issue #N. **Topic strings are unchanged** — `repo` lives in the payload only.
3. **`WorkspacePool::evict()`** — `workspace remove` (`DeregisterWorkspace`) now evicts the deregistered repo's registry and aborts its reaper, guarded against evicting the seeded default workspace.

Backward compatibility: every new field is `#[serde(default)]` / `skip_serializing_if`, so requests without `workspace_root` and pre-#3929 wire data behave byte-for-byte as before; existing single-repo subscribers route identically.

Phase d (#3930: global budget breakdown, per-repo status view, per-repo health gate) is intentionally out of scope.

## Changes

- **`loom-daemon/src/types.rs`** — optional `workspace_root` on `DispatchSweep`/`ListSweeps`/`GetSweepStatus`/`TailSweepLog`/`CancelSweep`; `repo` on `SweepInfo` and on `Event::SweepPhase`/`SweepBlocker`/`SweepExited`/`SweepCrashed`; `Event::set_repo_if_absent`; `topic()` doc note.
- **`loom-daemon/src/ipc.rs`** — `resolve_registry()` helper (normalizes root, resolves via pool or falls back to default); the five sweep handlers + the async cancel path resolve the target registry; `handle_deregister_workspace` evicts the pool entry; `WorkspacePool` threaded through `IpcServer`/`handle_client`/`handle_request`.
- **`loom-daemon/src/sweep_registry.rs`** — stamp `SweepInfo.repo` at dispatch/reconstruct; stamp every emitted sweep event with the registry's `workspace_root` centrally in `emit_event`.
- **`loom-daemon/src/workspace_pool.rs`** — `evict(root) -> bool` (drops entry, `.abort()`s the reaper; no-op for the seeded default); module doc updated.
- **`loom-daemon/src/main.rs`** — pass the pool into `IpcServer::new`.
- **`mcp-loom/src/tools/sweeps.ts`** — optional `workspace_root` param on the five tools; `repo` surfaced in `SweepInfo` + the listing line.
- **docs** — `.loom/docs/daemon-reference.md` and `defaults/.claude/commands/loom/sweep.md` document the `repo` payload field, per-repo `workspace_root` targeting, and pool eviction on `workspace remove` (child-published events source `repo` from the `LOOM_WORKSPACE` env already exported at dispatch).

## Acceptance Criteria Verification

- [x] `list_sweeps` / status distinguish sweeps from different repos with the same issue number — via `workspace_root` routing + `SweepInfo.repo` (new test `test_sweep_requests_route_to_explicit_workspace_root`).
- [x] Registry entries / locks / worktrees / logs namespaced per repo — verified unchanged from phase b (paths derive from `config.workspace_root`).
- [x] Each sweep dispatches into the correct repo's tree — the resolved per-repo registry's `workspace_root` drives `current_dir` (phase b), reachable now via `workspace_root`.
- [x] Backward compatibility — omitting `workspace_root` preserves default-workspace-only behavior (regression asserted in the routing test); all pre-#3929 serde round-trips default cleanly.

## Test Plan

- [x] `cargo test` — 713 lib tests + all integration/doc-lint suites pass.
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `mcp-loom`: `tsc --noEmit` — clean.
- [x] New: `workspace_pool` evict cases (provisioned root removed + re-provisions fresh; absent root false; seeded default rejected).
- [x] New: `ipc` routing — `DispatchSweep`/`ListSweeps`/`GetSweepStatus` with explicit `workspace_root` route to a second fixture repo, not the default; omitting preserves default behavior.
- [x] New: `types` — sweep-scoped event topics unchanged by the `repo` field; `repo` round-trips through serde and defaults to `None` for pre-#3929 payloads; `SweepInfo.repo` round-trips.

Closes #3929