### PR TITLE
feat(daemon): per-repo status breakdown + per-repo main-health gate (#3926 phase d)

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -328,6 +328,78 @@ the in-memory tracking + reaper go away, so the sweep finishes normally but its
 terminal state becomes unobservable via IPC after the deregister — an accepted
 consequence of an explicit operator `workspace remove`.
 
+## Per-repo status breakdown + per-repo main-health gate (#3930 — phase d)
+
+Phase d is the final phase of the multi-repo daemon (#3926/#3835). Phases b/c
+already delivered the single global concurrency budget, per-workspace error
+isolation, and `(repo, issue)`-aware IPC/events. Phase d closes the two remaining
+gaps: making `loom-daemon status` see *every* managed repo, and making the
+reactive main-health gate **per-repo** instead of one flag gating all repos.
+
+### Per-repo status breakdown (AC1)
+
+`build_daemon_status` (`ipc.rs`) enumerates
+`WorkspaceRegistry::effective_roots(&fallback_root)` (an **empty** registry ⇒ the
+single daemon workspace, byte-for-byte the pre-#3930 view) and reads each root's
+own registry from the `WorkspacePool` (`get_or_provision`). It returns:
+
+- `DaemonStatusReport.in_flight` — now the **union** of non-terminal sweeps across
+  every registered repo, so a sweep the autonomous loops dispatched into a
+  non-default managed repo is finally visible in `loom-daemon status`.
+- `DaemonStatusReport.per_repo: Vec<RepoStatus>` — one entry per root with `root`,
+  `in_flight_count`, and `health_gate_halted`. Additive + `#[serde(default)]`, so
+  pre-#3930 JSON consumers round-trip unchanged (an absent `per_repo` deserializes
+  to an empty vec).
+
+`loom-daemon status` prints a **Managed repos** section (root, in-flight count,
+gate state); `loom-daemon status --json` adds the `per_repo` array. The
+dynamic-cap inputs (token pool, disk headroom, configured ceiling) remain computed
+once from the daemon's primary workspace — they are *machine-level* resources, so
+they stay a single global figure, not per-repo. `resolve_registry` (the
+per-request `workspace_root` targeting used by `dispatch_sweep` / `list_sweeps` /
+etc.) is unchanged: the cross-repo aggregation is a read-only snapshot for
+`DaemonStatus` only. A merged `list_sweeps` across all repos without an explicit
+`workspace_root` remains a deferred follow-up.
+
+### Per-repo main-health gate (AC2)
+
+The reactive gate was single-repo, single-flag: one `MainHealthState` driven by
+one gate check against the daemon's own workspace, applied uniformly to every
+registered repo's dispatch (a red `main` in one repo halted all repos; a red
+`main` in any *other* registered repo was never even checked). Phase d replaces
+the single flag with `WorkspaceHealthStates` — a `HashMap<PathBuf,
+Arc<MainHealthState>>` keyed by normalized root (mirroring `WorkspacePool`'s
+keying) — and adds `spawn_multi_main_health_gate_task`, which each cycle:
+
+1. Re-reads `effective_roots(&fallback_root)` (hot-applies `workspace add|remove`).
+2. Runs **one gate check per registered root**, resolving that root's own
+   enablement (`autonomous.mainHealthGate.enabled`, env > config > default) and
+   its own `buildGate` block — no new config schema. A root that is
+   disabled / has no `buildGate` block is treated as **always-green** (its halt
+   flag is cleared and no command runs). Gates run **sequentially** per tick, so
+   several minutes-long per-repo builds firing together never contend (each
+   `CommandGateRunner` already isolates its own `origin/main` sync + uuid temp
+   file).
+3. Applies each outcome to that root's own `MainHealthState`.
+
+`work_finder::tick_multi` now takes a `halted: &[bool]` slice parallel to the
+workspaces, so a **red repo skips only its own dispatch loop** (its backlog is
+still counted in `seen` for logging, and its in-flight sweeps still seed the
+shared global occupancy) while sibling repos keep dispatching. The epic supervisor
+likewise attaches each cached per-repo supervisor to that root's own
+`MainHealthState`. `DaemonStatusReport.main_health_gate_halted` keeps its pre-#3930
+meaning (the daemon's own primary workspace); per-repo halt lives in
+`per_repo[].health_gate_halted`.
+
+**Empty-registry equivalence**: with a single workspace exactly one root is ever
+keyed, so both the status view and the gate cadence/halt semantics reduce to the
+pre-#3930 single-workspace behavior byte-for-byte. Enablement is still opt-in
+(`LOOM_MAIN_HEALTH_GATE` / `autonomous.mainHealthGate`, precedence env > config >
+default); the startup master switch reads the daemon's own workspace config, so
+enabling the gate for a genuine multi-repo deployment is done with the machine-
+global `LOOM_MAIN_HEALTH_GATE=1` env var (each repo's own `buildGate` block then
+decides whether it actually gates).
+
 ## Reaper task
 
 The reaper (`sweep_registry::spawn_reaper_task`) ticks every 30 seconds

--- a/loom-daemon/src/epic_supervisor.rs
+++ b/loom-daemon/src/epic_supervisor.rs
@@ -75,7 +75,7 @@ use anyhow::{Context, Result};
 use crate::epic_state::{count_phase_sections, derive_epic_state, EpicState, PhaseChild};
 use crate::event_bus::EventBus;
 use crate::issue_creation_mutex::{IssueCreationMutex, CHAMPION_EPIC_DECOMP};
-use crate::main_health_gate::MainHealthState;
+use crate::main_health_gate::{MainHealthState, WorkspaceHealthStates};
 use crate::phase_join::{barrier_admits, PhaseBoundary};
 use crate::sweep_registry::SweepRegistryConfig;
 use crate::types::{EpicActionClass, Event};
@@ -1008,7 +1008,7 @@ pub fn spawn_multi_supervisor_thread(
     pool: Arc<WorkspacePool>,
     fallback_root: PathBuf,
     event_bus: Arc<EventBus>,
-    health_state: Arc<MainHealthState>,
+    health_states: Arc<WorkspaceHealthStates>,
     interval: Duration,
 ) -> Result<SupervisorHandle> {
     let shutdown = Arc::new(AtomicBool::new(false));
@@ -1073,10 +1073,13 @@ pub fn spawn_multi_supervisor_thread(
                             let registry = pool.get_or_provision(root);
                             let source = forge::GhEpicSource::for_root(root);
                             let dispatcher = forge::SpawnDispatcher::new(spawn_bin, registry);
+                            // Per-repo main-health gate (#3930): each root gets
+                            // its own halt state, so a red `main` in repo A halts
+                            // only A's epic dispatch, never the siblings'.
                             let supervisor =
                                 EpicSupervisor::new(source, dispatcher, IssueCreationMutex::new())
                                     .with_event_bus(event_bus.clone())
-                                    .with_health_gate(health_state.clone());
+                                    .with_health_gate(health_states.get_or_create(root));
                             roots.push(root.clone());
                             supervisors.push(supervisor);
                             log::info!("epic_supervisor: watching workspace {}", root.display());

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -4,11 +4,12 @@ use crate::event_bus::EventBus;
 use crate::forge_parser::parse_forge_events;
 use crate::git_parser;
 use crate::git_utils;
-use crate::main_health_gate::MainHealthState;
+use crate::main_health_gate::WorkspaceHealthStates;
 use crate::sweep_registry::{BeginCancel, SweepRegistry};
 use crate::terminal::TerminalManager;
 use crate::types::{DaemonStatusReport, Event, Request, Response};
 use crate::workspace_pool::WorkspacePool;
+use crate::workspace_registry::WorkspaceRegistry;
 use anyhow::Result;
 use chrono::Utc;
 use std::path::{Path, PathBuf};
@@ -102,10 +103,11 @@ pub struct IpcServer {
     activity_db: Arc<Mutex<ActivityDb>>,
     sweep_registry: Arc<Mutex<SweepRegistry>>,
     event_bus: Arc<EventBus>,
-    /// Shared reactive main-health halt flag (#3812). Threaded into the IPC
-    /// server so the `DaemonStatus` request (#3891) can report the current
-    /// halt state — the same `Arc` the work-finder and gate loop share.
-    main_health_state: Arc<MainHealthState>,
+    /// Per-workspace reactive main-health halt state (#3930, was a single
+    /// `MainHealthState` in #3812). Threaded into the IPC server so the
+    /// `DaemonStatus` request can report each registered repo's own halt state —
+    /// the same `Arc` the multi-workspace work-finder and gate loop share.
+    health_states: Arc<WorkspaceHealthStates>,
     /// The per-workspace sweep-registry pool (#3929). The default workspace's
     /// registry is seeded into it, and the autonomous loops provision the other
     /// managed repos' registries on demand. Threaded into the IPC handler so a
@@ -113,17 +115,24 @@ pub struct IpcServer {
     /// in a managed repo other than the default workspace, and so
     /// `DeregisterWorkspace` can evict the in-memory entry.
     workspace_pool: Arc<WorkspacePool>,
+    /// The daemon's primary workspace root (`sweep_workspace`), used as the
+    /// `effective_roots` fallback when the machine-level workspace registry is
+    /// empty (#3930). In the common single-workspace case this is the only root
+    /// the `DaemonStatus` per-repo breakdown enumerates.
+    fallback_root: PathBuf,
 }
 
 impl IpcServer {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         socket_path: PathBuf,
         terminal_manager: Arc<Mutex<TerminalManager>>,
         activity_db: Arc<Mutex<ActivityDb>>,
         sweep_registry: Arc<Mutex<SweepRegistry>>,
         event_bus: Arc<EventBus>,
-        main_health_state: Arc<MainHealthState>,
+        health_states: Arc<WorkspaceHealthStates>,
         workspace_pool: Arc<WorkspacePool>,
+        fallback_root: PathBuf,
     ) -> Self {
         Self {
             socket_path,
@@ -131,8 +140,9 @@ impl IpcServer {
             activity_db,
             sweep_registry,
             event_bus,
-            main_health_state,
+            health_states,
             workspace_pool,
+            fallback_root,
         }
     }
 
@@ -166,10 +176,13 @@ impl IpcServer {
                     let db = self.activity_db.clone();
                     let sr = self.sweep_registry.clone();
                     let bus = self.event_bus.clone();
-                    let health = self.main_health_state.clone();
+                    let health = self.health_states.clone();
                     let pool = self.workspace_pool.clone();
+                    let fallback = self.fallback_root.clone();
                     tokio::spawn(async move {
-                        if let Err(e) = handle_client(stream, tm, db, sr, bus, health, pool).await {
+                        if let Err(e) =
+                            handle_client(stream, tm, db, sr, bus, health, pool, fallback).await
+                        {
                             log::error!("Client error: {e}");
                         }
                     });
@@ -182,14 +195,16 @@ impl IpcServer {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn handle_client(
     stream: UnixStream,
     terminal_manager: Arc<Mutex<TerminalManager>>,
     activity_db: Arc<Mutex<ActivityDb>>,
     sweep_registry: Arc<Mutex<SweepRegistry>>,
     event_bus: Arc<EventBus>,
-    main_health_state: Arc<MainHealthState>,
+    health_states: Arc<WorkspaceHealthStates>,
     workspace_pool: Arc<WorkspacePool>,
+    fallback_root: PathBuf,
 ) -> Result<()> {
     let (reader, mut writer) = stream.into_split();
     let mut lines = BufReader::new(reader).lines();
@@ -249,13 +264,13 @@ async fn handle_client(
         }
 
         // DaemonStatus (Issue #3891) is handled here rather than in the
-        // synchronous `handle_request` dispatcher because it reads the
-        // `main_health_state` halt flag, which the dispatcher does not receive.
-        // The report is cheap to build (a registry snapshot + a few pure
+        // synchronous `handle_request` dispatcher because it reads the per-repo
+        // `health_states` halt flags, which the dispatcher does not receive.
+        // The report is cheap to build (per-repo registry snapshots + a few pure
         // filesystem reads for the dynamic-cap inputs); per-token usage is left
         // to the CLI (a slow network probe) so this handler never blocks.
         if let Request::DaemonStatus = request {
-            let report = build_daemon_status(&sweep_registry, &main_health_state);
+            let report = build_daemon_status(&workspace_pool, &health_states, &fallback_root);
             let response = Response::DaemonStatus(report);
             let response_json = serde_json::to_string(&response)?;
             writer.write_all(response_json.as_bytes()).await?;
@@ -440,33 +455,57 @@ async fn cancel_sweep_nonblocking(
 // `handle_request`).
 #[allow(clippy::expect_used)]
 pub fn build_daemon_status(
-    sweep_registry: &Arc<Mutex<SweepRegistry>>,
-    main_health_state: &MainHealthState,
+    workspace_pool: &Arc<WorkspacePool>,
+    health_states: &WorkspaceHealthStates,
+    fallback_root: &Path,
 ) -> DaemonStatusReport {
-    let (in_flight, workspace_root) = {
-        let sr = sweep_registry
-            .lock()
-            .expect("Sweep registry mutex poisoned");
-        // In-flight = sweeps still live (Pending / Running). Terminal sweeps
-        // (Exited / Crashed) linger in the registry but are not "in flight".
-        let in_flight = sr
-            .list(None)
-            .into_iter()
-            .filter(|info| !info.state.is_terminal())
-            .collect();
-        (in_flight, sr.config().workspace_root.clone())
-    };
+    // Enumerate every registered managed workspace (Issue #3930). An empty
+    // registry yields `[fallback_root]`, so the common single-workspace case is
+    // byte-for-byte the pre-#3930 behavior (one root — the daemon's own).
+    let roots = WorkspaceRegistry::load_default()
+        .unwrap_or_default()
+        .effective_roots(fallback_root);
 
-    let token_pool_size = crate::tokens::token_pool_size(&workspace_root);
-    let disk_headroom = crate::disk_headroom::disk_headroom_limit(&workspace_root);
-    let wf_config = crate::work_finder::read_work_finder_config(&workspace_root);
+    // Per-repo breakdown + the union of in-flight sweeps across every repo. Each
+    // root reads its own registry from the pool (the fallback/default root
+    // resolves to the seeded default registry, so a single-workspace daemon reads
+    // exactly the same registry it did pre-#3930).
+    let mut in_flight: Vec<crate::types::SweepInfo> = Vec::new();
+    let mut per_repo: Vec<crate::types::RepoStatus> = Vec::with_capacity(roots.len());
+    for root in &roots {
+        let registry = workspace_pool.get_or_provision(root);
+        let live: Vec<crate::types::SweepInfo> = {
+            let sr = registry.lock().expect("Sweep registry mutex poisoned");
+            // In-flight = sweeps still live (Pending / Running). Terminal sweeps
+            // (Exited / Crashed) linger in the registry but are not "in flight".
+            sr.list(None)
+                .into_iter()
+                .filter(|info| !info.state.is_terminal())
+                .collect()
+        };
+        per_repo.push(crate::types::RepoStatus {
+            root: root.clone(),
+            in_flight_count: live.len(),
+            health_gate_halted: health_states.is_halted(root),
+        });
+        in_flight.extend(live);
+    }
+
+    // Dynamic-cap inputs are *machine-level* (one token pool, one scratch
+    // volume), so they are computed once from the daemon's primary workspace —
+    // the same basis as pre-#3930 (which read them from the default registry's
+    // `workspace_root`, i.e. `fallback_root`).
+    let workspace_root = fallback_root;
+    let token_pool_size = crate::tokens::token_pool_size(workspace_root);
+    let disk_headroom = crate::disk_headroom::disk_headroom_limit(workspace_root);
+    let wf_config = crate::work_finder::read_work_finder_config(workspace_root);
     let configured_max = crate::work_finder::resolve_max_concurrent_with_config(&wf_config);
 
     // Token-capacity backpressure (#3902): back the token axis off from the flat
     // pool count toward the count of *healthy* accounts read from the rotation
     // ranking. When no ranking exists, `token_axis_limit` == the raw pool size,
     // so the dynamic cap is byte-for-byte the pre-#3902 value.
-    let ranking = crate::capacity::read_ranking(&workspace_root);
+    let ranking = crate::capacity::read_ranking(workspace_root);
     let token_axis_limit = ranking.as_ref().map_or(token_pool_size, |r| r.available);
     let dynamic_cap = crate::work_finder::resolve_dynamic_max_concurrent(
         token_axis_limit,
@@ -491,8 +530,11 @@ pub fn build_daemon_status(
         disk_headroom,
         configured_max,
         dynamic_cap,
-        main_health_gate_halted: main_health_state.is_halted(),
+        // Top-level halt preserves its pre-#3930 single-workspace meaning: the
+        // daemon's own primary workspace. Per-repo halt is in `per_repo`.
+        main_health_gate_halted: health_states.is_halted(fallback_root),
         capacity,
+        per_repo,
     }
 }
 
@@ -2305,6 +2347,11 @@ exit 0
                 token_axis_limit: 3,
                 token_bound: true,
             },
+            per_repo: vec![crate::types::RepoStatus {
+                root: std::path::PathBuf::from("/repo/a"),
+                in_flight_count: 0,
+                health_gate_halted: true,
+            }],
         };
         let resp = Response::DaemonStatus(report);
         let json = serde_json::to_string(&resp).expect("serialize response");
@@ -2322,13 +2369,17 @@ exit 0
                 assert_eq!(r.capacity.exhausted_accounts, 1);
                 assert_eq!(r.capacity.token_axis_limit, 3);
                 assert!(r.capacity.token_bound);
+                assert_eq!(r.per_repo.len(), 1);
+                assert_eq!(r.per_repo[0].in_flight_count, 0);
+                assert!(r.per_repo[0].health_gate_halted);
             }
             other => panic!("Expected DaemonStatus, got: {other:?}"),
         }
     }
 
-    /// A pre-#3902 `DaemonStatus` JSON payload (no `capacity` field) still
-    /// deserializes — `#[serde(default)]` fills the capacity section.
+    /// A pre-#3902 `DaemonStatus` JSON payload (no `capacity` field, no
+    /// `per_repo` field) still deserializes — `#[serde(default)]` fills the
+    /// capacity section and leaves `per_repo` empty (pre-#3930 compat).
     #[test]
     fn test_daemon_status_backward_compat_missing_capacity() {
         let legacy = r#"{"in_flight":[],"token_pool_size":2,"disk_headroom":9,"configured_max":3,"dynamic_cap":2,"main_health_gate_halted":false}"#;
@@ -2338,25 +2389,44 @@ exit 0
         assert!(!report.capacity.ranking_present);
         assert_eq!(report.capacity.healthy_accounts, 0);
         assert!(!report.capacity.token_bound);
+        assert!(report.per_repo.is_empty(), "absent per_repo defaults to empty");
     }
 
-    /// `build_daemon_status` reflects the shared main-health halt flag and lists
-    /// a live dispatched sweep as in-flight.
+    /// `build_daemon_status` reflects the per-repo main-health halt flag and
+    /// lists a live dispatched sweep as in-flight. Single-workspace case (empty
+    /// registry): exactly one `per_repo` entry for the daemon's own workspace,
+    /// byte-for-byte the pre-#3930 top-level behavior.
     #[test]
     #[serial_test::serial]
     fn test_build_daemon_status_reports_halt_and_in_flight() {
-        use crate::main_health_gate::MainHealthState;
+        use crate::main_health_gate::WorkspaceHealthStates;
+        use crate::workspace_registry::REGISTRY_PATH_ENV;
 
-        let (sr, _dir, _rec) = setup_sweep_registry_in_tempdir();
+        let (sr, dir, _rec) = setup_sweep_registry_in_tempdir();
+        let root = dir.path().to_path_buf();
+
+        // Point the workspace registry at a nonexistent file so effective_roots
+        // falls back to [root] (single-workspace equivalence).
+        let empty_reg = dir.path().join("no-such-workspaces.json");
+        std::env::set_var(REGISTRY_PATH_ENV, &empty_reg);
+
+        // Seed the pool with the default registry keyed at `root`.
+        let pool = Arc::new(WorkspacePool::new(Arc::new(EventBus::new()), test_runtime_handle()));
+        pool.seed(root.clone(), sr.clone());
+        let health = WorkspaceHealthStates::new();
 
         // Fresh state: not halted, no sweeps.
-        let health = MainHealthState::new();
-        let report = build_daemon_status(&sr, &health);
+        let report = build_daemon_status(&pool, &health, &root);
         assert!(!report.main_health_gate_halted);
         assert!(report.in_flight.is_empty());
         // The tempdir has no `.loom/tokens/`, so the pool + dynamic cap are 0.
         assert_eq!(report.token_pool_size, 0);
         assert_eq!(report.dynamic_cap, 0);
+        // Per-repo breakdown: exactly one entry for the single workspace.
+        assert_eq!(report.per_repo.len(), 1);
+        assert_eq!(report.per_repo[0].root, root);
+        assert_eq!(report.per_repo[0].in_flight_count, 0);
+        assert!(!report.per_repo[0].health_gate_halted);
 
         // Dispatch a sweep -> it should show up as in-flight (Running).
         {
@@ -2364,14 +2434,84 @@ exit 0
             reg.dispatch(&crate::types::SweepKind::Issue(3891), None, None, None, None)
                 .expect("dispatch");
         }
-        let report = build_daemon_status(&sr, &health);
+        let report = build_daemon_status(&pool, &health, &root);
         assert_eq!(report.in_flight.len(), 1);
         assert!(matches!(report.in_flight[0].kind, crate::types::SweepKind::Issue(3891)));
+        assert_eq!(report.per_repo[0].in_flight_count, 1);
 
-        // Flip the halt flag -> the report tracks it.
-        health.set_halted(true);
-        let report = build_daemon_status(&sr, &health);
+        // Flip the halt flag for this root -> the report tracks it (top-level and
+        // per-repo).
+        health.set_halted(&root, true);
+        let report = build_daemon_status(&pool, &health, &root);
         assert!(report.main_health_gate_halted);
+        assert!(report.per_repo[0].health_gate_halted);
+
+        std::env::remove_var(REGISTRY_PATH_ENV);
+    }
+
+    /// `build_daemon_status` with two registered workspaces returns one `per_repo`
+    /// entry per root with correct in-flight counts (a sweep dispatched into a
+    /// non-default repo is now visible) and independent per-repo halt state
+    /// (Issue #3930 — a red repo B does not mark repo A halted).
+    #[test]
+    #[serial_test::serial]
+    fn test_build_daemon_status_multi_workspace_per_repo_breakdown() {
+        use crate::main_health_gate::WorkspaceHealthStates;
+        use crate::workspace_registry::{normalize_path, WorkspaceRegistry, REGISTRY_PATH_ENV};
+
+        let (sr_a, dir_a, _rec_a) = setup_sweep_registry_in_tempdir();
+        let (sr_b, dir_b, _rec_b) = setup_sweep_registry_in_tempdir();
+        let root_a = dir_a.path().to_path_buf();
+        let root_b = dir_b.path().to_path_buf();
+
+        // A registry listing BOTH managed repos (roots stored canonicalized).
+        let reg_path = dir_a.path().join("workspaces.json");
+        let mut reg = WorkspaceRegistry::default();
+        reg.add(&root_a, None).unwrap();
+        reg.add(&root_b, None).unwrap();
+        reg.save(&reg_path).unwrap();
+        std::env::set_var(REGISTRY_PATH_ENV, &reg_path);
+
+        // Seed the pool with both registries under their normalized (canonical)
+        // roots — the same key `effective_roots` returns.
+        let canon_a = normalize_path(&root_a);
+        let canon_b = normalize_path(&root_b);
+        let pool = Arc::new(WorkspacePool::new(Arc::new(EventBus::new()), test_runtime_handle()));
+        pool.seed(canon_a.clone(), sr_a.clone());
+        pool.seed(canon_b.clone(), sr_b.clone());
+
+        let health = WorkspaceHealthStates::new();
+        // Repo B is red; repo A green — independently.
+        health.set_halted(&canon_b, true);
+
+        // Dispatch a sweep into repo A only.
+        {
+            let mut reg = sr_a.lock().unwrap();
+            reg.dispatch(&crate::types::SweepKind::Issue(42), None, None, None, None)
+                .expect("dispatch");
+        }
+
+        let report = build_daemon_status(&pool, &health, &root_a);
+        assert_eq!(report.per_repo.len(), 2, "both managed repos are listed");
+        // Union of in-flight across repos = repo A's single sweep.
+        assert_eq!(report.in_flight.len(), 1);
+
+        let a = report
+            .per_repo
+            .iter()
+            .find(|r| r.root == canon_a)
+            .expect("repo A present");
+        let b = report
+            .per_repo
+            .iter()
+            .find(|r| r.root == canon_b)
+            .expect("repo B present");
+        assert_eq!(a.in_flight_count, 1, "repo A has the dispatched sweep");
+        assert!(!a.health_gate_halted, "repo A is green");
+        assert_eq!(b.in_flight_count, 0, "repo B has no sweeps");
+        assert!(b.health_gate_halted, "repo B is red, independently of A");
+
+        std::env::remove_var(REGISTRY_PATH_ENV);
     }
 
     /// If `DaemonStatus` ever reaches the synchronous dispatcher (it is meant to

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -362,7 +362,12 @@ async fn main() -> Result<()> {
     // work-finder — so it can be threaded into both dispatch paths. When the gate
     // loop (below) is disabled nothing ever flips it, so neither the supervisor
     // nor the work-finder is ever halted (zero behavior change with the gate off).
-    let main_health_state = Arc::new(main_health_gate::MainHealthState::new());
+    // Per-repo halt state (#3930): one `MainHealthState` per registered repo,
+    // keyed by normalized root, so a red `main` in one managed repo halts only
+    // that repo's dispatch — never the siblings'. With an empty registry (the
+    // common single-workspace case) exactly one root is keyed, reducing to the
+    // pre-#3930 single-flag behavior byte-for-byte.
+    let workspace_health_states = Arc::new(main_health_gate::WorkspaceHealthStates::new());
 
     // Epic supervisor loop (Issue #3872 — Phase 4 of epic #3842). Opt-in via
     // `LOOM_EPIC_SUPERVISOR`. The loop drives every open `loom:epic` issue
@@ -386,7 +391,7 @@ async fn main() -> Result<()> {
             workspace_pool.clone(),
             sweep_workspace.clone(),
             event_bus.clone(),
-            main_health_state.clone(),
+            workspace_health_states.clone(),
             interval,
         ) {
             Ok(handle) => {
@@ -451,7 +456,7 @@ async fn main() -> Result<()> {
             sweep_workspace.clone(),
             interval,
             configured_max,
-            main_health_state.clone(),
+            workspace_health_states.clone(),
             event_bus.clone(),
         ))
     } else {
@@ -471,49 +476,42 @@ async fn main() -> Result<()> {
     // on/off override (precedence env > config > default). The gate's *behavior*
     // (command, timeout) still comes from the separate `buildGate` block, so
     // Phase C's tested semantics are unchanged.
+    // Multi-workspace fan-out (#3930): the gate loop re-reads `effective_roots()`
+    // each cycle and runs one gate check per registered root, writing into that
+    // root's own `MainHealthState` in `workspace_health_states`. A red repo halts
+    // only its own dispatch. Per-root enablement + `buildGate` config are read
+    // from each repo's own `.loom/config.json` inside the loop, so no single
+    // up-front buildGate resolution is needed. The startup master switch is still
+    // the daemon's own workspace config (env > config), mirroring how the
+    // work-finder / epic-supervisor loops are gated at startup by `sweep_workspace`.
     let autonomous_gate_config = main_health_gate::read_autonomous_gate_config(&sweep_workspace);
     let _main_health_gate_handle = if main_health_gate::resolve_enabled(&autonomous_gate_config) {
-        match main_health_gate::read_build_gate_config(&sweep_workspace) {
-            Some(gate_config) => {
-                let interval = main_health_gate::resolve_interval();
-                log::info!(
-                    "main_health_gate: enabled (interval={}s, command={:?}, timeout={}s)",
-                    interval.as_secs(),
-                    gate_config.command,
-                    gate_config.timeout.as_secs()
-                );
-                let runner =
-                    main_health_gate::CommandGateRunner::new(gate_config, sweep_workspace.clone());
-                Some(main_health_gate::spawn_main_health_gate_task(
-                    runner,
-                    main_health_state.clone(),
-                    interval,
-                ))
-            }
-            None => {
-                log::warn!(
-                    "main_health_gate: LOOM_MAIN_HEALTH_GATE is set but no usable buildGate \
-                     config in .loom/config.json (missing/disabled/empty command) — gate inactive"
-                );
-                None
-            }
-        }
+        let interval = main_health_gate::resolve_interval();
+        log::info!("main_health_gate: enabled (multi-workspace, interval={}s)", interval.as_secs());
+        Some(main_health_gate::spawn_multi_main_health_gate_task(
+            workspace_health_states.clone(),
+            sweep_workspace.clone(),
+            interval,
+        ))
     } else {
         log::debug!("main_health_gate: disabled (set LOOM_MAIN_HEALTH_GATE=1 or autonomous.mainHealthGate.enabled=true + a buildGate config to enable)");
         None
     };
 
-    // Start IPC server. `main_health_state` is threaded in so the `DaemonStatus`
-    // request (#3891) can report the reactive main-health-gate halt flag — the
-    // same `Arc` the work-finder and gate loop share above.
+    // Start IPC server. `workspace_health_states` is threaded in so the
+    // `DaemonStatus` request can report each registered repo's own halt state
+    // (#3930), and `sweep_workspace` is the `effective_roots` fallback for the
+    // per-repo status breakdown — the same values the work-finder and gate loop
+    // share above.
     let server = IpcServer::new(
         socket_path.clone(),
         tm,
         activity_db,
         sweep_registry,
         event_bus,
-        main_health_state.clone(),
+        workspace_health_states.clone(),
         workspace_pool.clone(),
+        sweep_workspace.clone(),
     );
 
     // Setup signal handler for graceful shutdown. We listen for BOTH SIGINT
@@ -970,6 +968,12 @@ fn print_status_json(
         "main_health_gate": {
             "halted": report.main_health_gate_halted,
         },
+        // Per-repo breakdown across every registered managed workspace (#3930).
+        "per_repo": report.per_repo.iter().map(|r| serde_json::json!({
+            "root": r.root,
+            "in_flight_count": r.in_flight_count,
+            "health_gate_halted": r.health_gate_halted,
+        })).collect::<Vec<_>>(),
         "token_usage": token_usage,
     });
     println!("{}", serde_json::to_string_pretty(&combined)?);
@@ -1043,6 +1047,26 @@ fn print_status_human(report: &DaemonStatusReport, token_usage: Option<&serde_js
         "clear (dispatch allowed)"
     };
     println!("\nMain-health gate: {gate}");
+
+    // Per-repo breakdown across every registered managed workspace (#3930). In
+    // the common single-workspace case this is one line for the daemon's own
+    // workspace; with `loom-daemon workspace add <path>` it lists every managed
+    // repo, its in-flight count, and its own gate state.
+    println!("\nManaged repos: {}", report.per_repo.len());
+    if report.per_repo.is_empty() {
+        println!("  (none)");
+    } else {
+        println!("  {:>9}  {:<7}  REPO", "IN-FLIGHT", "GATE");
+        println!("  {:-<60}", "");
+        for r in &report.per_repo {
+            let gate = if r.health_gate_halted {
+                "HALTED"
+            } else {
+                "clear"
+            };
+            println!("  {:>9}  {:<7}  {}", r.in_flight_count, gate, r.root.display());
+        }
+    }
 
     println!("\nPer-token usage:");
     match token_usage {

--- a/loom-daemon/src/main_health_gate.rs
+++ b/loom-daemon/src/main_health_gate.rs
@@ -42,11 +42,14 @@
 //! has no home for a non-sweep-triggered health event — a follow-up issue would
 //! be required to add one).
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+
+use crate::workspace_registry::WorkspaceRegistry;
 
 // ============================================================================
 // Constants
@@ -121,6 +124,87 @@ impl MainHealthState {
 impl Default for MainHealthState {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Per-workspace halt state for the multi-repo main-health gate (Issue #3930 —
+/// phase d of #3835/#3926).
+///
+/// Phase c (#3929) made dispatch `(repo, issue)`-aware; phase d makes the
+/// **reactive main-health gate per-repo** too: each registered repo's `main` is
+/// evaluated independently, and a red repo halts only *its own* dispatch, never
+/// the others. Before this, a single [`MainHealthState`] driven by one gate
+/// check against the daemon's own workspace gated *every* registered repo
+/// uniformly.
+///
+/// This wrapper holds one [`MainHealthState`] per normalized root, mirroring
+/// [`crate::workspace_pool::WorkspacePool`]'s `HashMap<PathBuf, _>` keying. It is
+/// shared (as an `Arc`) between the multi-workspace gate loop (writer), the
+/// multi-workspace work-finder / epic supervisor (readers), and the IPC
+/// `DaemonStatus` per-repo breakdown (reader).
+///
+/// **Empty-registry equivalence**: with a single workspace (the empty-registry
+/// fallback), exactly one root is ever keyed, so this reduces to the single
+/// `MainHealthState` behavior byte-for-byte. A root that has never been gated
+/// (no map entry) reports **not halted** — a repo with no `buildGate` block
+/// simply never gates (soft-fail, unchanged contract).
+#[derive(Default)]
+pub struct WorkspaceHealthStates {
+    inner: Mutex<HashMap<PathBuf, Arc<MainHealthState>>>,
+}
+
+impl WorkspaceHealthStates {
+    /// An empty per-workspace halt map.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Return `root`'s [`MainHealthState`], creating a fresh (not-halted) one on
+    /// first access. The returned `Arc` is shared, so the gate loop (writer) and
+    /// the work-finder / status readers all observe the same flag.
+    pub fn get_or_create(&self, root: &Path) -> Arc<MainHealthState> {
+        let mut map = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        map.entry(root.to_path_buf())
+            .or_insert_with(|| Arc::new(MainHealthState::new()))
+            .clone()
+    }
+
+    /// Whether `root`'s dispatch is currently halted. A never-seen root is
+    /// treated as green (not halted) — no gate has run against it.
+    #[must_use]
+    pub fn is_halted(&self, root: &Path) -> bool {
+        let map = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        map.get(root).is_some_and(|s| s.is_halted())
+    }
+
+    /// Directly set `root`'s halt flag (creating its state if absent). Primarily
+    /// for tests / explicit control, and for the gate loop to clear a
+    /// disabled/absent-`buildGate` repo to green.
+    pub fn set_halted(&self, root: &Path, halted: bool) {
+        self.get_or_create(root).set_halted(halted);
+    }
+
+    /// Snapshot of `(root → halted)` for every root the gate has observed —
+    /// consumed by the daemon-status per-repo breakdown (#3930). Roots never
+    /// gated are absent (a reader treats an absent root as green).
+    #[must_use]
+    pub fn snapshot(&self) -> HashMap<PathBuf, bool> {
+        let map = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        map.iter()
+            .map(|(k, v)| (k.clone(), v.is_halted()))
+            .collect()
     }
 }
 
@@ -820,6 +904,131 @@ where
     })
 }
 
+/// Log a health transition (root-aware variant, #3930) at a severity matching
+/// its significance, naming which repo's `main` the gate evaluated.
+fn log_transition_for_root(root: &Path, transition: HealthTransition, outcome: &GateOutcome) {
+    let r = root.display();
+    match transition {
+        HealthTransition::EnteredHalt => log::error!(
+            "main_health_gate: {r} main is RED — HALTING autonomous dispatch for this repo. {}",
+            outcome.detail()
+        ),
+        HealthTransition::RemainedHalted => log::warn!(
+            "main_health_gate: {r} main still RED — dispatch for this repo remains halted. {}",
+            outcome.detail()
+        ),
+        HealthTransition::Recovered => log::info!(
+            "main_health_gate: {r} main GREEN again — RESUMING dispatch for this repo on the next work-finder tick"
+        ),
+        HealthTransition::RemainedHealthy => {
+            log::debug!("main_health_gate: {r} main green — dispatch unaffected");
+        }
+        HealthTransition::Skipped => log::warn!(
+            "main_health_gate: {r} gate run SKIPPED — {} (halt state unchanged)",
+            outcome.detail()
+        ),
+    }
+}
+
+/// Spawn the **multi-workspace** main-health gate loop (Issue #3930) on the
+/// shared daemon runtime and return its task handle.
+///
+/// This is the multi-repo replacement for [`spawn_main_health_gate_task`]. Every
+/// `interval` it re-reads [`WorkspaceRegistry::effective_roots`] against
+/// `fallback_root` (an **empty** registry ⇒ the single `fallback_root`,
+/// byte-for-byte the pre-#3930 single-workspace behavior) and runs **one gate
+/// check per registered root**, applying each outcome to that root's own
+/// [`MainHealthState`] in `health_states`. A red repo halts only its own
+/// dispatch; sibling repos keep dispatching.
+///
+/// Per-root enablement is resolved from each repo's own `.loom/config.json`
+/// (`autonomous.mainHealthGate.enabled` via [`resolve_enabled`], precedence
+/// env > config > default) plus a usable `buildGate` block
+/// ([`read_build_gate_config`]). A root that is disabled / has no `buildGate`
+/// block is treated as **always-green** — its halt flag is cleared and no gate
+/// command runs for it (soft-fail, unchanged contract). No new config schema is
+/// introduced: the per-root `buildGate` / `autonomous.mainHealthGate` blocks are
+/// exactly the ones phase C already reads.
+///
+/// Gates run **sequentially** per tick (not concurrently) so several minutes-long
+/// per-repo builds firing on the same tick never contend — each
+/// [`CommandGateRunner`] already isolates its own `origin/main` sync and uuid
+/// temp output file, so there is no shared mutable state to leak across repos.
+pub fn spawn_multi_main_health_gate_task(
+    health_states: Arc<WorkspaceHealthStates>,
+    fallback_root: PathBuf,
+    interval: Duration,
+) -> tokio::task::JoinHandle<()> {
+    log::info!(
+        "main_health_gate: starting multi-workspace loop (interval={}s)",
+        interval.as_secs()
+    );
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        // First tick fires immediately; skip it so we don't churn at boot.
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+
+            // Resolve the current workspace set fresh each tick so registry edits
+            // (`workspace add|remove`) are hot-applied without a daemon restart.
+            let roots = WorkspaceRegistry::load_default()
+                .unwrap_or_else(|e| {
+                    log::warn!(
+                        "main_health_gate: could not load workspace registry ({e}); using fallback"
+                    );
+                    WorkspaceRegistry::default()
+                })
+                .effective_roots(&fallback_root);
+
+            for root in roots {
+                // Per-root enablement (env > config > default). The env master
+                // switch, when set, applies to every root uniformly; when unset,
+                // each repo's own config decides.
+                if !resolve_enabled(&read_autonomous_gate_config(&root)) {
+                    // Disabled ⇒ always green for this repo (clear any stale halt).
+                    health_states.set_halted(&root, false);
+                    continue;
+                }
+                let Some(gate_config) = read_build_gate_config(&root) else {
+                    log::debug!(
+                        "main_health_gate: {} enabled but no usable buildGate config — treating as green",
+                        root.display()
+                    );
+                    health_states.set_halted(&root, false);
+                    continue;
+                };
+
+                let state = health_states.get_or_create(&root);
+                let root_for_task = root.clone();
+                // Run the (potentially minutes-long) gate off the runtime.
+                let joined = tokio::task::spawn_blocking(move || {
+                    let mut runner = CommandGateRunner::new(gate_config, root_for_task);
+                    runner.run_gate()
+                })
+                .await;
+                match joined {
+                    Ok(outcome) => {
+                        let transition = apply_gate_outcome(&state, &outcome);
+                        log_transition_for_root(&root, transition, &outcome);
+                    }
+                    Err(e) => {
+                        // The blocking task panicked; clear this repo's halt so a
+                        // panic never wedges it permanently halted, and continue to
+                        // the other repos (one bad gate must not stop the loop).
+                        log::error!(
+                            "main_health_gate: gate run task for {} panicked ({e}); clearing its halt",
+                            root.display()
+                        );
+                        state.set_halted(false);
+                    }
+                }
+            }
+        }
+    })
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -920,6 +1129,57 @@ mod tests {
     fn test_default_state_not_halted() {
         assert!(!MainHealthState::new().is_halted());
         assert!(!MainHealthState::default().is_halted());
+    }
+
+    // ===================================================================
+    // Per-workspace halt state (#3930)
+    // ===================================================================
+
+    #[test]
+    fn test_workspace_health_states_unknown_root_not_halted() {
+        let states = WorkspaceHealthStates::new();
+        assert!(!states.is_halted(Path::new("/repo/never-seen")));
+        assert!(states.snapshot().is_empty());
+    }
+
+    #[test]
+    fn test_workspace_health_states_are_per_root_independent() {
+        // Red repo A must not mark repo B halted (the core AC2 property).
+        let states = WorkspaceHealthStates::new();
+        let a = Path::new("/repo/a");
+        let b = Path::new("/repo/b");
+        states.set_halted(a, true);
+        assert!(states.is_halted(a), "repo A is halted");
+        assert!(!states.is_halted(b), "repo B is unaffected by A's halt");
+
+        // Clearing A does not touch B, and setting B does not touch A.
+        states.set_halted(b, true);
+        states.set_halted(a, false);
+        assert!(!states.is_halted(a));
+        assert!(states.is_halted(b));
+    }
+
+    #[test]
+    fn test_workspace_health_states_get_or_create_shares_arc() {
+        let states = WorkspaceHealthStates::new();
+        let root = Path::new("/repo/a");
+        let s1 = states.get_or_create(root);
+        s1.set_halted(true);
+        // A second get_or_create returns the same shared state (the flag persists).
+        let s2 = states.get_or_create(root);
+        assert!(s2.is_halted());
+        assert!(states.is_halted(root));
+    }
+
+    #[test]
+    fn test_workspace_health_states_snapshot_lists_seen_roots() {
+        let states = WorkspaceHealthStates::new();
+        states.set_halted(Path::new("/repo/a"), true);
+        states.set_halted(Path::new("/repo/b"), false);
+        let snap = states.snapshot();
+        assert_eq!(snap.len(), 2);
+        assert_eq!(snap.get(Path::new("/repo/a")), Some(&true));
+        assert_eq!(snap.get(Path::new("/repo/b")), Some(&false));
     }
 
     #[test]

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -656,6 +656,35 @@ pub struct DaemonStatusReport {
     /// pre-#3902 wire data / older clients compatible.
     #[serde(default)]
     pub capacity: CapacityReport,
+    /// Per-repo breakdown across every registered managed workspace (Issue #3930
+    /// — phase d of #3835/#3926). One entry per [`crate::workspace_registry::WorkspaceRegistry::effective_roots`]
+    /// root: its in-flight sweep count and per-repo main-health-gate halt state.
+    /// The top-level [`Self::in_flight`] is the **union** across these repos, so a
+    /// sweep the autonomous loops dispatched into a non-default repo is now
+    /// visible in `loom-daemon status`. In the common single-workspace case this
+    /// is a single entry for the daemon's own workspace. `#[serde(default)]` keeps
+    /// pre-#3930 wire data / older clients compatible (an empty vec).
+    #[serde(default)]
+    pub per_repo: Vec<RepoStatus>,
+}
+
+/// One registered managed-workspace's status line in [`DaemonStatusReport`]
+/// (Issue #3930). The daemon enumerates every
+/// [`crate::workspace_registry::WorkspaceRegistry::effective_roots`] root for the
+/// per-repo breakdown so sweeps dispatched into any managed repo — not just the
+/// daemon's own default workspace — are observable in `loom-daemon status`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RepoStatus {
+    /// The normalized workspace root this line describes.
+    pub root: PathBuf,
+    /// Count of non-terminal (`Pending` / `Running`) sweeps live in this repo's
+    /// own [`crate::sweep_registry::SweepRegistry`] at snapshot time.
+    pub in_flight_count: usize,
+    /// Whether this repo's dispatch is currently halted by the per-repo reactive
+    /// main-health gate (#3930). A red `main` in this repo halts only this repo's
+    /// dispatch, never the siblings'. Always `false` for a repo whose gate is
+    /// disabled / has no `buildGate` block, or when the gate loop is off.
+    pub health_gate_halted: bool,
 }
 
 /// The token-capacity section of [`DaemonStatusReport`] (#3902).

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -82,7 +82,7 @@ use anyhow::Result;
 use crate::capacity::{self, CapacityAdvisory};
 use crate::disk_headroom::disk_headroom_limit;
 use crate::event_bus::EventBus;
-use crate::main_health_gate::MainHealthState;
+use crate::main_health_gate::{MainHealthState, WorkspaceHealthStates};
 use crate::tokens::token_pool_size;
 use crate::types::Event;
 use crate::workspace_pool::WorkspacePool;
@@ -336,13 +336,26 @@ pub fn tick(
 ///    fallback), this reduces to the same schedule [`tick`] produces, so wiring
 ///    it in for N=1 preserves the pre-#3928 behavior.
 ///
+/// # Per-repo main-health gate (#3930)
+///
+/// `halted` is a slice **parallel to `workspaces`**: `halted[i] == true` means
+/// repo `i`'s `main` is currently red, so its own dispatch loop is skipped this
+/// tick while sibling repos keep dispatching against the shared global budget. A
+/// halted workspace's backlog is still polled and accumulated into
+/// [`TickReport::seen`] (mirroring the pre-#3930 aggregate-log behavior), and its
+/// in-flight sweeps still seed the shared occupancy (they are never touched). A
+/// missing entry (`halted.len() < workspaces.len()`) defaults to *not halted*.
+/// [`TickReport::halted`] is set when **any** workspace was gated this tick — in
+/// the single-workspace (empty-registry) case this reduces to the pre-#3930
+/// single-flag semantics byte-for-byte.
+///
 /// Unlike [`tick`], a source error is **not** propagated (there is no single
 /// caller to retry — the other workspaces must still run); it is folded into the
 /// returned [`TickReport`].
 pub fn tick_multi<S: WorkSource, D: WorkDispatcher>(
     workspaces: &mut [(S, D)],
     max_concurrent: usize,
-    halted: bool,
+    halted: &[bool],
 ) -> TickReport {
     let mut report = TickReport::default();
 
@@ -351,21 +364,9 @@ pub fn tick_multi<S: WorkSource, D: WorkDispatcher>(
     let in_flights: Vec<HashSet<u32>> = workspaces.iter().map(|(_, d)| d.in_flight()).collect();
     let mut occupancy: usize = in_flights.iter().map(HashSet::len).sum();
 
-    // Reactive backstop: a red `main` halts all new dispatch this tick. We still
-    // poll each source so `seen` reflects the combined backlog for logging.
-    if halted {
-        report.halted = true;
-        for (source, _) in workspaces.iter_mut() {
-            match source.list_ready_issues() {
-                Ok(items) => report.seen += items.len(),
-                Err(e) => {
-                    report.errors += 1;
-                    log::warn!("work_finder: (halted) listing ready issues failed: {e}");
-                }
-            }
-        }
-        return report;
-    }
+    // Whether any workspace was gated this tick — folds down to the pre-#3930
+    // single-flag semantics for a single (empty-registry) workspace.
+    let mut any_halted = false;
 
     for (idx, (source, dispatcher)) in workspaces.iter_mut().enumerate() {
         let ready = match source.list_ready_issues() {
@@ -379,6 +380,16 @@ pub fn tick_multi<S: WorkSource, D: WorkDispatcher>(
             }
         };
         report.seen += ready.len();
+
+        // Per-repo main-health gate (#3930): a red repo skips only its own
+        // dispatch loop this tick. `seen` above still reflects its backlog so the
+        // caller can log "backlog is N but halted"; its in-flight sweeps stay in
+        // the global occupancy seed and are never touched.
+        if halted.get(idx).copied().unwrap_or(false) {
+            any_halted = true;
+            continue;
+        }
+
         let in_flight = &in_flights[idx];
 
         for item in ready {
@@ -413,6 +424,7 @@ pub fn tick_multi<S: WorkSource, D: WorkDispatcher>(
         }
     }
 
+    report.halted = any_halted;
     report
 }
 
@@ -761,7 +773,7 @@ pub fn spawn_multi_work_finder_task(
     fallback_root: PathBuf,
     interval: Duration,
     configured_max: usize,
-    health_state: Arc<MainHealthState>,
+    health_states: Arc<WorkspaceHealthStates>,
     event_bus: Arc<EventBus>,
 ) -> tokio::task::JoinHandle<()> {
     log::info!(
@@ -778,7 +790,6 @@ pub fn spawn_multi_work_finder_task(
         let mut was_pressured = false;
         loop {
             ticker.tick().await;
-            let halted = health_state.is_halted();
 
             // Dynamic cap from live *machine-level* inputs (one token pool, one
             // scratch volume) probed from the daemon's primary workspace.
@@ -797,6 +808,11 @@ pub fn spawn_multi_work_finder_task(
                 })
                 .effective_roots(&fallback_root);
 
+            // Per-repo main-health halt (#3930): look up each root's own gate
+            // state, parallel to `pairs`. A red repo halts only its own dispatch.
+            let halted: Vec<bool> = roots.iter().map(|r| health_states.is_halted(r)).collect();
+            let any_halted = halted.iter().any(|&h| h);
+
             let mut pairs: Vec<(GhWorkSource, RegistryDispatcher)> = roots
                 .iter()
                 .map(|root| {
@@ -808,17 +824,18 @@ pub fn spawn_multi_work_finder_task(
             log::debug!(
                 "work_finder: dynamic cap = {max_concurrent} (pool={pool_size}, \
                  healthy_tokens={token_limit}, disk={disk}, configured_max={configured_max}, \
-                 halted={halted}, workspaces={})",
+                 any_halted={any_halted}, workspaces={})",
                 pairs.len()
             );
 
-            let report = tick_multi(&mut pairs, max_concurrent, halted);
+            let report = tick_multi(&mut pairs, max_concurrent, &halted);
 
             if report.halted && !was_halted {
                 log::warn!(
-                    "work_finder: main-health gate halted dispatch — {} ready issue(s) held \
-                     until main is green again",
-                    report.seen
+                    "work_finder: main-health gate halted dispatch for {} of {} repo(s) — \
+                     their ready issues held until their main is green again",
+                    halted.iter().filter(|&&h| h).count(),
+                    halted.len()
                 );
             } else if !report.halted && was_halted {
                 log::info!("work_finder: main-health gate cleared — resuming dispatch");
@@ -1341,7 +1358,7 @@ mod tests {
         // Empty-registry equivalence: one workspace behaves exactly like tick().
         let mut multi =
             vec![(FakeSource::once((1..=3).map(issue).collect()), RecordingDispatcher::default())];
-        let report = tick_multi(&mut multi, 10, false);
+        let report = tick_multi(&mut multi, 10, &[false]);
         assert_eq!(report.seen, 3);
         assert_eq!(report.dispatched, 3);
         assert_eq!(report.deferred_capacity, 0);
@@ -1356,7 +1373,7 @@ mod tests {
             (FakeSource::once(vec![issue(1), issue(2)]), RecordingDispatcher::default()),
             (FakeSource::once(vec![issue(10), issue(11)]), RecordingDispatcher::default()),
         ];
-        let report = tick_multi(&mut multi, 10, false);
+        let report = tick_multi(&mut multi, 10, &[false, false]);
         assert_eq!(report.seen, 4);
         assert_eq!(report.dispatched, 4);
         assert_eq!(multi[0].1.dispatched, vec![1, 2], "workspace 0 dispatches its own issues");
@@ -1372,7 +1389,7 @@ mod tests {
             (FakeSource::once((1..=5).map(issue).collect()), RecordingDispatcher::default()),
             (FakeSource::once((10..=14).map(issue).collect()), RecordingDispatcher::default()),
         ];
-        let report = tick_multi(&mut multi, 3, false);
+        let report = tick_multi(&mut multi, 3, &[false, false]);
         let total: usize = multi.iter().map(|(_, d)| d.dispatched.len()).sum();
         assert_eq!(report.dispatched, 3, "combined dispatch never exceeds the global cap");
         assert_eq!(total, 3, "sum of per-workspace dispatches equals the global cap");
@@ -1399,7 +1416,7 @@ mod tests {
                 },
             ),
         ];
-        let report = tick_multi(&mut multi, 4, false);
+        let report = tick_multi(&mut multi, 4, &[false, false]);
         assert_eq!(report.dispatched, 1, "3 in-flight + cap 4 ⇒ 1 free slot globally");
         assert_eq!(report.deferred_capacity, 3);
         // The single free slot goes to the first workspace's first ready issue.
@@ -1416,7 +1433,7 @@ mod tests {
             (err_source("bad auth for repo B"), RecordingDispatcher::default()),
             (FakeSource::once(vec![issue(30)]), RecordingDispatcher::default()),
         ];
-        let report = tick_multi(&mut multi, 10, false);
+        let report = tick_multi(&mut multi, 10, &[false, false, false]);
         assert_eq!(report.errors, 1, "the failing workspace is counted, not fatal");
         assert_eq!(report.dispatched, 3, "the two healthy workspaces still dispatch");
         assert_eq!(multi[0].1.dispatched, vec![1, 2]);
@@ -1430,7 +1447,7 @@ mod tests {
             (FakeSource::once((1..=3).map(issue).collect()), RecordingDispatcher::default()),
             (FakeSource::once((10..=12).map(issue).collect()), RecordingDispatcher::default()),
         ];
-        let report = tick_multi(&mut multi, 10, true);
+        let report = tick_multi(&mut multi, 10, &[true, true]);
         assert!(report.halted);
         assert_eq!(report.seen, 6, "backlog across both workspaces is still observed");
         assert_eq!(report.dispatched, 0, "zero dispatch while halted");
@@ -1440,8 +1457,89 @@ mod tests {
     #[test]
     fn test_tick_multi_empty_workspace_set_is_noop() {
         let mut multi: Vec<(FakeSource, RecordingDispatcher)> = vec![];
-        let report = tick_multi(&mut multi, 10, false);
+        let report = tick_multi(&mut multi, 10, &[]);
         assert_eq!(report, TickReport::default());
+    }
+
+    #[test]
+    fn test_tick_multi_per_repo_gate_red_repo_halts_only_itself() {
+        // Per-repo main-health gate (#3930): repo A (index 0) is red, repo B
+        // (index 1) is green. A dispatches NOTHING; B still dispatches its full
+        // backlog. A's backlog is still counted in `seen` for logging.
+        let mut multi = vec![
+            (FakeSource::once(vec![issue(1), issue(2)]), RecordingDispatcher::default()),
+            (FakeSource::once(vec![issue(10), issue(11)]), RecordingDispatcher::default()),
+        ];
+        let report = tick_multi(&mut multi, 10, &[true, false]);
+        assert!(report.halted, "report.halted is set when any repo was gated");
+        assert_eq!(report.seen, 4, "both repos' backlogs are observed");
+        assert_eq!(report.dispatched, 2, "only repo B dispatched");
+        assert!(multi[0].1.dispatched.is_empty(), "red repo A dispatched nothing");
+        assert_eq!(multi[1].1.dispatched, vec![10, 11], "green repo B dispatched its backlog");
+    }
+
+    #[test]
+    fn test_tick_multi_per_repo_gate_other_repo_red_does_not_halt_us() {
+        // Mirror image: repo A (index 0) is green, repo B (index 1) is red. A
+        // dispatches; B does not. A red repo never halts a sibling.
+        let mut multi = vec![
+            (FakeSource::once(vec![issue(1), issue(2)]), RecordingDispatcher::default()),
+            (FakeSource::once(vec![issue(10), issue(11)]), RecordingDispatcher::default()),
+        ];
+        let report = tick_multi(&mut multi, 10, &[false, true]);
+        assert!(report.halted, "a gated sibling still sets report.halted");
+        assert_eq!(report.dispatched, 2, "only repo A dispatched");
+        assert_eq!(multi[0].1.dispatched, vec![1, 2], "green repo A dispatched its backlog");
+        assert!(multi[1].1.dispatched.is_empty(), "red repo B dispatched nothing");
+    }
+
+    #[test]
+    fn test_tick_multi_red_repo_in_flight_still_seeds_global_occupancy() {
+        // A red repo's in-flight sweeps are never touched and still count toward
+        // the shared global budget: repo A (red) has 3 in-flight, cap is 3, so the
+        // green repo B gets ZERO free slots this tick even though A itself skips.
+        let mut multi = vec![
+            (
+                FakeSource::once(vec![issue(1)]),
+                RecordingDispatcher {
+                    in_flight: HashSet::from([100, 101, 102]),
+                    ..Default::default()
+                },
+            ),
+            (FakeSource::once(vec![issue(10), issue(11)]), RecordingDispatcher::default()),
+        ];
+        let report = tick_multi(&mut multi, 3, &[true, false]);
+        assert!(report.halted);
+        assert_eq!(report.dispatched, 0, "occupancy already at cap from red repo's in-flight");
+        assert_eq!(report.deferred_capacity, 2, "repo B's 2 ready issues deferred by the budget");
+        assert!(multi.iter().all(|(_, d)| d.dispatched.is_empty()));
+    }
+
+    #[test]
+    fn test_tick_multi_none_halted_is_not_reported_halted() {
+        // No repo gated ⇒ report.halted is false (reduces to pre-#3930 semantics).
+        let mut multi = vec![
+            (FakeSource::once(vec![issue(1)]), RecordingDispatcher::default()),
+            (FakeSource::once(vec![issue(10)]), RecordingDispatcher::default()),
+        ];
+        let report = tick_multi(&mut multi, 10, &[false, false]);
+        assert!(!report.halted);
+        assert_eq!(report.dispatched, 2);
+    }
+
+    #[test]
+    fn test_tick_multi_missing_halt_entry_defaults_not_halted() {
+        // A short `halted` slice (fewer entries than workspaces) treats the
+        // unspecified workspaces as not halted rather than panicking.
+        let mut multi = vec![
+            (FakeSource::once(vec![issue(1)]), RecordingDispatcher::default()),
+            (FakeSource::once(vec![issue(10)]), RecordingDispatcher::default()),
+        ];
+        let report = tick_multi(&mut multi, 10, &[true]);
+        assert!(report.halted);
+        assert_eq!(report.dispatched, 1, "workspace 1 (no halt entry) still dispatches");
+        assert!(multi[0].1.dispatched.is_empty());
+        assert_eq!(multi[1].1.dispatched, vec![10]);
     }
 
     // ===================================================================


### PR DESCRIPTION
## Summary

Final phase (d) of the multi-repo `loom-daemon` (#3926/#3835). Phases b/c already shipped the single global concurrency budget, per-workspace error isolation, and `(repo, issue)`-aware IPC/events; re-curation confirmed only two ACs remained. This PR delivers both.

### AC1 — Per-repo status breakdown
- `build_daemon_status` (`ipc.rs`) now enumerates `WorkspaceRegistry::effective_roots(&fallback_root)` and reads each root's own registry from the `WorkspacePool`, so a sweep the autonomous loops dispatched into a **non-default** managed repo is finally visible in `loom-daemon status`.
- `DaemonStatusReport` gains an additive `#[serde(default)] per_repo: Vec<RepoStatus>` (`root`, `in_flight_count`, `health_gate_halted`). Top-level `in_flight` is now the **union** across repos. `loom-daemon status` prints a **Managed repos** section (human table + `--json` `per_repo` array).
- Dynamic-cap inputs (token pool / disk / ceiling) stay **machine-level** — computed once from the primary workspace. `resolve_registry` per-request `workspace_root` targeting is unchanged (the aggregation is a read-only status snapshot).

### AC2 — Per-repo main-health gate
- New `WorkspaceHealthStates` (`HashMap<PathBuf, Arc<MainHealthState>>`, keyed by normalized root, mirroring `WorkspacePool`) replaces the single shared halt flag.
- New `spawn_multi_main_health_gate_task` runs **one gate check per registered root** each cycle, resolving per-root enablement (`autonomous.mainHealthGate.enabled`, env > config > default) + its own `buildGate` block — no new config schema. A disabled / no-`buildGate` repo is always-green. Gates run sequentially so several minutes-long per-repo builds never contend.
- `work_finder::tick_multi` now takes `halted: &[bool]` parallel to workspaces, so a **red repo skips only its own dispatch** (its backlog still counts in `seen`; its in-flight sweeps still seed the shared global occupancy) while siblings keep dispatching. The epic supervisor attaches each per-repo supervisor to its root's own state.

### Backward compatibility
- **Empty-registry single-workspace behavior is byte-for-byte unchanged** — status view and gate cadence/halt semantics both reduce to the pre-#3930 single-flag behavior when exactly one root is keyed.
- Opt-in preserved: `LOOM_MAIN_HEALTH_GATE` / `autonomous.mainHealthGate`, precedence env > config > default. The startup master switch reads the daemon's own workspace config; a genuine multi-repo deployment enables the gate with the machine-global `LOOM_MAIN_HEALTH_GATE=1`, and each repo's own `buildGate` decides whether it actually gates.
- `DaemonStatusReport` pre-#3930 JSON (no `per_repo`) round-trips (`#[serde(default)]`).

## Tests
- `tick_multi` per-repo gate isolation: red repo A halts only A; a red sibling never halts us; a red repo's in-flight still seeds the global budget; missing halt-slice entry defaults not-halted.
- `build_daemon_status`: single-workspace equivalence (one `per_repo` entry) + 2-workspace breakdown (correct per-repo in-flight counts, independent halt, union `in_flight`).
- `WorkspaceHealthStates` unit tests (per-root independence, shared Arc, snapshot).
- `DaemonStatusReport` round-trip + pre-#3930 backward-compat.
- `cargo test` (723 lib + all integration), `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` all clean.

## Out of scope (documented deferrals, unchanged from phase c)
- Merged cross-repo `list_sweeps` without an explicit `workspace_root` (status snapshot aggregates; per-request IPC stays single-target).
- Machine-level `Workspace.config_overrides` layering.

Closes #3930

🤖 Generated with [Claude Code](https://claude.com/claude-code)