### PR TITLE
fix(tokens): shared machine-level pool fallback for cross-repo dispatch (#3938)

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -328,6 +328,51 @@ the in-memory tracking + reaper go away, so the sweep finishes normally but its
 terminal state becomes unobservable via IPC after the deregister — an accepted
 consequence of an explicit operator `workspace remove`.
 
+## Token pool provisioning for managed repos (#3938)
+
+The multi-workspace work finder measures the token pool **once per tick from the
+daemon's primary workspace** (`fallback_root`) and uses it as the single global
+concurrency budget — token accounts are a *machine-level* resource, so the cap is
+never replicated per repo. But each dispatched sweep runs `spawn-claude.sh` with
+its `current_dir` set to **its own** repo root, and `spawn-claude.sh` resolves the
+token pool from that repo. A freshly-installed **consumer repo has no
+`.loom/tokens/` of its own** — only the primary workspace was bootstrapped — so
+every cross-repo dispatch used to hard-fail instantly with `EX_CONFIG`
+("Run `loom-tokens bootstrap` …"), burning a dispatch slot per tick on children
+that died in ~2s.
+
+**Fix — a shared machine-level pool with a per-repo fallback.** Token selection
+and *all* pool-state bookkeeping resolve the effective pool directory as:
+
+1. the **per-repo** pool `<repo>/.loom/tokens/` when it holds `*.token` files
+   (unchanged for the primary workspace);
+2. else the **shared** machine-level pool `~/.loom/tokens/` (override
+   `LOOM_SHARED_TOKENS_DIR`; set it empty to disable the fallback);
+3. else the per-repo path (so a truly-unbootstrapped repo still surfaces a clear
+   "run bootstrap" error).
+
+Crucially, the **state files** (`.bad_tokens`, `.failure_counts`, `.ranking`,
+`.allowlist`) are read/written in *whichever pool directory was selected* — so a
+consumer repo dispatching against the shared pool shares one `.bad_tokens` /
+`.ranking` truth with every other repo. Pool state is **never forked per repo**,
+which is what keeps the token-capacity backpressure accounting (#3907/#3930)
+consistent. The Rust `token_pool_size` (the dynamic-cap input) applies the same
+per-repo→shared resolution, so the daemon's concurrency ceiling matches what the
+spawn path can actually pick.
+
+**Provisioning a managed-repo pool.** Bootstrap the shared pool once per machine:
+
+```bash
+loom-tokens bootstrap --shared      # writes ~/.loom/tokens (override LOOM_SHARED_TOKENS_DIR)
+loom-tokens check --ranking         # ranks the effective pool (shared when no per-repo pool)
+```
+
+Every consumer repo the daemon dispatches into then falls back to that one pool —
+no per-repo `loom-tokens bootstrap` required. A repo that *wants* its own isolated
+pool can still `loom-tokens bootstrap` locally; the per-repo pool always wins.
+Selection sources (`~/.claude-monitor/accounts.env`, repo-local `.env`) are
+unchanged — `--shared` only redirects the *destination* of the materialized pool.
+
 ## Per-repo status breakdown + per-repo main-health gate (#3930 — phase d)
 
 Phase d is the final phase of the multi-repo daemon (#3926/#3835). Phases b/c

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -582,9 +582,13 @@ The `classify_error <output> <exit_code>` function returns one of `SUCCESS`, `TI
 
 When invoked from a worktree, `spawn-claude.sh` resolves the canonical repo root via `git rev-parse --git-common-dir` and locates `.loom/tokens/` there — never in the worktree's path. This avoids each worktree maintaining its own bad-tokens list.
 
+### Shared machine-level pool fallback (#3938)
+
+Token selection resolves the effective pool as: the **per-repo** pool `<repo>/.loom/tokens/` when it holds `*.token` files, else the **shared machine-level pool** `~/.loom/tokens/` (override `LOOM_SHARED_TOKENS_DIR`; set it empty to disable the fallback). This lets a consumer repo the daemon dispatches into — which has no pool of its own — spawn against the shared pool instead of hard-failing with `EX_CONFIG`. Crucially, the pool **state** files (`.bad_tokens`, `.failure_counts`, `.ranking`, `.allowlist`) are read/written in whichever pool was selected, so state is **never forked per repo** (token-capacity backpressure sees one truth). Provision the shared pool once per machine with `loom-tokens bootstrap --shared` (destination-only; account sources are unchanged). See `.loom/docs/daemon-reference.md` → "Token pool provisioning for managed repos".
+
 ### Hard-fail on missing pool
 
-`spawn-claude.sh` exits `78` (`EX_CONFIG`) with a message instructing the user to run `loom-tokens bootstrap` when `.loom/tokens/` is absent or all tokens are bad. It does **not** silently fall back to keychain — that path belongs in `loom-daemon` (#3236), and only when token rotation has not been configured at all.
+`spawn-claude.sh` exits `78` (`EX_CONFIG`) with a message instructing the user to run `loom-tokens bootstrap` (or `loom-tokens bootstrap --shared` for the machine-level pool) when **neither** the per-repo nor the shared pool has usable tokens (absent, empty, or all bad). It does **not** silently fall back to keychain — that path belongs in `loom-daemon` (#3236), and only when token rotation has not been configured at all.
 
 ### Operator CLI (`loom-tokens pin/unpin/unblock`)
 

--- a/defaults/scripts/spawn-claude.sh
+++ b/defaults/scripts/spawn-claude.sh
@@ -15,14 +15,28 @@
 # the wrapper.
 #
 # Behavior on missing tokens:
-#   When `.loom/tokens/` is absent, empty, or all tokens are bad, this script
+#   Token selection resolves the effective pool (issue #3938): the per-repo
+#   pool at `<repo>/.loom/tokens/` when it holds `*.token` files, else the
+#   shared machine-level pool at `~/.loom/tokens/` (override
+#   `LOOM_SHARED_TOKENS_DIR`; set it empty to disable the fallback). This lets a
+#   consumer repo the daemon dispatches into — which has no pool of its own —
+#   spawn against the shared pool instead of hard-failing. All pool STATE
+#   (`.bad_tokens`/`.ranking`/`.allowlist`/`.failure_counts`) lives in whichever
+#   pool was selected, so it is never forked per repo.
+#   When NEITHER pool exists/has tokens (or all tokens are bad), this script
 #   exits 78 (EX_CONFIG) with a message instructing the user to run
-#   `loom-tokens bootstrap`. It does NOT silently fall back to keychain.
+#   `loom-tokens bootstrap` (or `loom-tokens bootstrap --shared` for the
+#   machine-level pool). It does NOT silently fall back to keychain.
 #
 # Worktree handling:
 #   When invoked from a git worktree, the script resolves the canonical repo
 #   root via `git rev-parse --git-common-dir` and looks up `.loom/tokens/`
 #   there — never in the worktree's path.
+#
+# Env vars (pool location):
+#   LOOM_SHARED_TOKENS_DIR  Shared machine-level pool location. Non-empty path
+#                           overrides the `~/.loom/tokens` default; an empty
+#                           value disables the shared fallback (per-repo only).
 #
 # Usage:
 #   .loom/scripts/spawn-claude.sh -p "your prompt"
@@ -271,8 +285,11 @@ PY
         log_error "Token selection failed:"
         cat "$_selection_stderr_file" >&2 || true
         rm -f "$_selection_stderr_file"
-        log_error "Run 'loom-tokens bootstrap' to populate .loom/tokens/, or"
-        log_error "use 'loom-tokens unblock <name>' if .bad_tokens is the cause."
+        log_error "Run 'loom-tokens bootstrap' to populate <repo>/.loom/tokens/,"
+        log_error "or 'loom-tokens bootstrap --shared' for the machine-level pool"
+        log_error "(~/.loom/tokens, override LOOM_SHARED_TOKENS_DIR) that consumer"
+        log_error "repos fall back to. Use 'loom-tokens unblock <name>' if"
+        log_error ".bad_tokens is the cause."
         log_error "Spawn-claude refuses to auto-clear .bad_tokens — that's"
         log_error "intentional: an empty pool indicates a real auth problem."
         log_error "Set CLAUDE_CODE_OAUTH_TOKEN explicitly to bypass selection."

--- a/defaults/scripts/tests/test-spawn-claude.sh
+++ b/defaults/scripts/tests/test-spawn-claude.sh
@@ -238,22 +238,56 @@ output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
 assert_contains "stub-claude got token=caller-supplied" "$output" \
     "explicit CLAUDE_CODE_OAUTH_TOKEN is preserved"
 
-# Test: missing tokens dir → exit 78 with helpful message
+# Test: missing tokens dir → exit 78 with helpful message.
+# LOOM_SHARED_TOKENS_DIR="" disables the #3938 shared-pool fallback so this
+# case deterministically hard-fails regardless of the host's ~/.loom/tokens.
 EMPTY_WS="$(mktemp -d)"
-output=$(LOOM_WORKSPACE="$EMPTY_WS" PATH="$STUB_DIR:$PATH" \
+output=$(LOOM_WORKSPACE="$EMPTY_WS" LOOM_SHARED_TOKENS_DIR="" \
+    PATH="$STUB_DIR:$PATH" \
     "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
 exit_code=$?
 assert_contains "loom-tokens bootstrap" "$output" \
     "empty pool error mentions 'loom-tokens bootstrap'"
 rm -rf "$EMPTY_WS"
 
-# Test that spawn-claude.sh exits 78 on missing tokens
+# Test that spawn-claude.sh exits 78 on missing tokens (shared fallback off).
 set +e
-LOOM_WORKSPACE="$(mktemp -d)" PATH="$STUB_DIR:$PATH" \
+LOOM_WORKSPACE="$(mktemp -d)" LOOM_SHARED_TOKENS_DIR="" PATH="$STUB_DIR:$PATH" \
     "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" >/dev/null 2>&1
 exit_code=$?
 set -e
 assert_eq "78" "$exit_code" "missing tokens exits 78 (EX_CONFIG)"
+
+# Test: consumer repo with NO per-repo pool falls back to the shared
+# machine-level pool (issue #3938) instead of hard-failing.
+#
+# Pin LOOM_PACKAGE_PATH at the repo-under-test's loom_tools so the assertion
+# exercises THIS checkout's selector, not any host-level editable install /
+# canary LOOM_PACKAGE_PATH the dev environment may export.
+REPO_PKG="$(cd "$SCRIPTS_DIR/../../loom-tools/src" 2>/dev/null && pwd || echo "")"
+CONSUMER_WS="$(mktemp -d)"
+SHARED_POOL="$(mktemp -d)"
+echo -n "fake-token-shared" > "$SHARED_POOL/shared-acct.token"
+chmod 600 "$SHARED_POOL/shared-acct.token"
+output=$(LOOM_WORKSPACE="$CONSUMER_WS" LOOM_SHARED_TOKENS_DIR="$SHARED_POOL" \
+    LOOM_PACKAGE_PATH="$REPO_PKG" PATH="$STUB_DIR:$PATH" \
+    "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
+assert_contains "stub-claude got token=fake-token-shared" "$output" \
+    "spawn-claude falls back to shared pool for a repo with no pool (#3938)"
+assert_contains "OAuth account 'shared-acct'" "$output" \
+    "spawn-claude logs the shared-pool account (#3938)"
+# State must land in the shared pool, never forked into the consumer repo.
+LOOM_SHARED_TOKENS_DIR="$SHARED_POOL" PYTHONPATH="$REPO_PKG" \
+    python3 -c "
+from loom_tools.tokens.bad_tokens import mark_bad
+mark_bad('$CONSUMER_WS', 'shared-acct', 'test')
+" 2>/dev/null || true
+if [[ -f "$SHARED_POOL/.bad_tokens" && ! -f "$CONSUMER_WS/.loom/tokens/.bad_tokens" ]]; then
+    assert_eq "ok" "ok" "shared-pool .bad_tokens written to shared dir, not consumer repo (#3938)"
+else
+    assert_eq "ok" "fail" "shared-pool .bad_tokens written to shared dir, not consumer repo (#3938)"
+fi
+rm -rf "$CONSUMER_WS" "$SHARED_POOL"
 
 # ============================================================
 # Section 3: model selection (issue #3477, Phase 1)

--- a/loom-daemon/src/tokens.rs
+++ b/loom-daemon/src/tokens.rs
@@ -26,20 +26,38 @@
 //! over-subscribing (the claim lock + registry dedup still hold). Bad-token-aware
 //! subtraction is tracked as a follow-up.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-/// Count the `*.token` files in `{workspace_root}/.loom/tokens/` — the size of
-/// the multi-account rotation pool, and the hard ceiling on concurrent
-/// autonomous sweeps.
+/// Env override for the shared machine-level token pool (issue #3938).
 ///
-/// Returns 0 when the directory is absent or unreadable (token rotation not
-/// bootstrapped) — the same condition under which `spawn-claude.sh` refuses to
-/// dispatch, so a 0 pool correctly yields a 0 dynamic cap (dispatch nothing that
-/// could not spawn) rather than silently over-subscribing.
+/// Mirrors `loom_tools.tokens.paths`: a non-empty value names the shared pool
+/// directory, an explicitly empty value disables the shared fallback, and unset
+/// resolves to `~/.loom/tokens`.
+const SHARED_TOKENS_DIR_ENV: &str = "LOOM_SHARED_TOKENS_DIR";
+
+/// Resolve the shared machine-level pool directory, or `None` when disabled.
+///
+/// Kept in lock-step with the Python resolver (`loom_tools.tokens.paths.
+/// shared_tokens_dir`) so the daemon's concurrency accounting and the
+/// spawn-time selector agree on where the shared pool lives.
 #[must_use]
-pub fn token_pool_size(workspace_root: &Path) -> usize {
-    let tokens_dir = workspace_root.join(".loom").join("tokens");
-    let entries = match std::fs::read_dir(&tokens_dir) {
+fn shared_tokens_dir() -> Option<PathBuf> {
+    match std::env::var(SHARED_TOKENS_DIR_ENV) {
+        Ok(v) => {
+            let trimmed = v.trim();
+            if trimmed.is_empty() {
+                None // explicit opt-out
+            } else {
+                Some(PathBuf::from(trimmed))
+            }
+        }
+        Err(_) => dirs::home_dir().map(|h| h.join(".loom").join("tokens")),
+    }
+}
+
+/// Count the `*.token` files directly under `dir` (no recursion).
+fn count_token_files(dir: &Path) -> usize {
+    let entries = match std::fs::read_dir(dir) {
         Ok(e) => e,
         Err(_) => return 0,
     };
@@ -59,6 +77,44 @@ pub fn token_pool_size(workspace_root: &Path) -> usize {
         .count()
 }
 
+/// Count the `*.token` files in the pool that selection would actually use for
+/// `workspace_root` — the size of the multi-account rotation pool, and the hard
+/// ceiling on concurrent autonomous sweeps.
+///
+/// Resolution mirrors the Python selector (`loom_tools.tokens.paths.
+/// resolve_tokens_dir`, issue #3938): the per-repo pool at
+/// `{workspace_root}/.loom/tokens/` when it holds tokens, else the shared
+/// machine-level pool (`~/.loom/tokens`, override `LOOM_SHARED_TOKENS_DIR`).
+/// Without this fallback the multi-workspace work finder measured 0 tokens for a
+/// consumer repo that had no pool of its own even though a shared pool existed —
+/// the accounting the spawn path then contradicted by succeeding via the shared
+/// pool.
+///
+/// Returns 0 when neither pool is bootstrapped — the same condition under which
+/// `spawn-claude.sh` refuses to dispatch, so a 0 pool correctly yields a 0
+/// dynamic cap (dispatch nothing that could not spawn) rather than silently
+/// over-subscribing.
+#[must_use]
+pub fn token_pool_size(workspace_root: &Path) -> usize {
+    token_pool_size_resolved(workspace_root, shared_tokens_dir().as_deref())
+}
+
+/// Env-free core of [`token_pool_size`]: count the per-repo pool, falling back
+/// to an explicit `shared` pool directory when the per-repo pool is
+/// absent/empty. Split out so it is deterministically testable without touching
+/// process env or the real home directory.
+#[must_use]
+fn token_pool_size_resolved(workspace_root: &Path, shared: Option<&Path>) -> usize {
+    let per_repo = workspace_root.join(".loom").join("tokens");
+    let n = count_token_files(&per_repo);
+    if n > 0 {
+        return n;
+    }
+    // Per-repo pool absent/empty: fall back to the shared machine-level pool so
+    // the concurrency ceiling matches what the spawn path can actually pick.
+    shared.map_or(0, count_token_files)
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -72,6 +128,17 @@ mod tests {
             fs::write(dir.join(f), "sk-ant-oat01-fake").unwrap();
         }
     }
+
+    fn write_flat_pool(dir: &Path, files: &[&str]) {
+        fs::create_dir_all(dir).unwrap();
+        for f in files {
+            fs::write(dir.join(f), "sk-ant-oat01-fake").unwrap();
+        }
+    }
+
+    // The env-free core is exercised directly so tests never touch process env
+    // or the real home directory (issue #3938). We pass `shared = None` to keep
+    // the classic per-repo-only assertions deterministic.
 
     #[test]
     fn test_counts_only_token_files() {
@@ -90,14 +157,14 @@ mod tests {
                 ".failure_counts",
             ],
         );
-        assert_eq!(token_pool_size(tmp.path()), 3);
+        assert_eq!(token_pool_size_resolved(tmp.path(), None), 3);
     }
 
     #[test]
     fn test_missing_dir_is_zero() {
         let tmp = tempfile::tempdir().unwrap();
-        // No .loom/tokens/ at all — rotation not bootstrapped.
-        assert_eq!(token_pool_size(tmp.path()), 0);
+        // No .loom/tokens/ at all — rotation not bootstrapped, no shared pool.
+        assert_eq!(token_pool_size_resolved(tmp.path(), None), 0);
     }
 
     #[test]
@@ -105,13 +172,78 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path().join(".loom").join("tokens");
         fs::create_dir_all(&dir).unwrap();
-        assert_eq!(token_pool_size(tmp.path()), 0);
+        assert_eq!(token_pool_size_resolved(tmp.path(), None), 0);
     }
 
     #[test]
     fn test_only_non_token_files_is_zero() {
         let tmp = tempfile::tempdir().unwrap();
         write_tokens_dir(tmp.path(), &["index.json", ".bad_tokens"]);
-        assert_eq!(token_pool_size(tmp.path()), 0);
+        assert_eq!(token_pool_size_resolved(tmp.path(), None), 0);
     }
+
+    // ---- shared-pool fallback (issue #3938) ---------------------------------
+
+    #[test]
+    fn test_falls_back_to_shared_when_per_repo_absent() {
+        // Consumer repo with NO per-repo pool, but a shared machine-level pool.
+        let repo = tempfile::tempdir().unwrap();
+        let shared = tempfile::tempdir().unwrap();
+        write_flat_pool(shared.path(), &["a.token", "b.token", "index.json"]);
+        assert_eq!(token_pool_size_resolved(repo.path(), Some(shared.path())), 2);
+    }
+
+    #[test]
+    fn test_falls_back_to_shared_when_per_repo_empty() {
+        // Per-repo dir exists but holds no .token files -> shared wins.
+        let repo = tempfile::tempdir().unwrap();
+        fs::create_dir_all(repo.path().join(".loom").join("tokens")).unwrap();
+        let shared = tempfile::tempdir().unwrap();
+        write_flat_pool(shared.path(), &["a.token"]);
+        assert_eq!(token_pool_size_resolved(repo.path(), Some(shared.path())), 1);
+    }
+
+    #[test]
+    fn test_per_repo_pool_wins_over_shared() {
+        // When both exist, the per-repo pool is authoritative (no double count).
+        let repo = tempfile::tempdir().unwrap();
+        write_tokens_dir(repo.path(), &["r1.token", "r2.token", "r3.token"]);
+        let shared = tempfile::tempdir().unwrap();
+        write_flat_pool(shared.path(), &["s1.token"]);
+        assert_eq!(token_pool_size_resolved(repo.path(), Some(shared.path())), 3);
+    }
+
+    #[test]
+    fn test_no_pool_anywhere_is_zero() {
+        let repo = tempfile::tempdir().unwrap();
+        let shared = tempfile::tempdir().unwrap(); // exists but empty
+        assert_eq!(token_pool_size_resolved(repo.path(), Some(shared.path())), 0);
+    }
+
+    #[test]
+    fn test_shared_disabled_is_zero_when_per_repo_absent() {
+        // shared = None models LOOM_SHARED_TOKENS_DIR="" (operator opt-out).
+        let repo = tempfile::tempdir().unwrap();
+        assert_eq!(token_pool_size_resolved(repo.path(), None), 0);
+    }
+
+    #[test]
+    fn test_shared_tokens_dir_env_empty_disables() {
+        // Guard the process-global env mutation behind a serialized section.
+        let _guard = ENV_LOCK.lock().unwrap();
+        let prev = std::env::var(SHARED_TOKENS_DIR_ENV).ok();
+        std::env::set_var(SHARED_TOKENS_DIR_ENV, "");
+        assert!(shared_tokens_dir().is_none());
+        // A non-empty value is honored verbatim.
+        std::env::set_var(SHARED_TOKENS_DIR_ENV, "/tmp/loom-shared-xyz");
+        assert_eq!(shared_tokens_dir(), Some(PathBuf::from("/tmp/loom-shared-xyz")));
+        match prev {
+            Some(v) => std::env::set_var(SHARED_TOKENS_DIR_ENV, v),
+            None => std::env::remove_var(SHARED_TOKENS_DIR_ENV),
+        }
+    }
+
+    // Serialize the single env-touching test so it can't race a parallel test
+    // that reads the same var.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 }

--- a/loom-tools/src/loom_tools/tokens/__init__.py
+++ b/loom-tools/src/loom_tools/tokens/__init__.py
@@ -40,6 +40,10 @@ from loom_tools.tokens.allowlist import (
 )
 from loom_tools.tokens.bad_tokens import cleanup_bad_tokens, is_bad, mark_bad
 from loom_tools.tokens.bootstrap import bootstrap_tokens
+from loom_tools.tokens.paths import (
+    resolve_tokens_dir,
+    shared_tokens_dir,
+)
 from loom_tools.tokens.failure_counts import (
     DEFAULT_THRESHOLD,
     record_failure,
@@ -73,7 +77,9 @@ __all__ = [
     "record_success",
     "remove_from_allowlist",
     "reset_all",
+    "resolve_tokens_dir",
     "select_token",
+    "shared_tokens_dir",
     "threshold_reached",
     "write_allowlist",
 ]

--- a/loom-tools/src/loom_tools/tokens/allowlist.py
+++ b/loom-tools/src/loom_tools/tokens/allowlist.py
@@ -36,6 +36,7 @@ from pathlib import Path
 # Reuse the lock primitive from bad_tokens — same constraints (mkdir-only,
 # no flock on stock macOS) and same workspace.
 from loom_tools.tokens.bad_tokens import _MkdirLock
+from loom_tools.tokens.paths import resolve_tokens_dir
 
 
 class AllowlistError(Exception):
@@ -55,7 +56,10 @@ class UnknownAccountError(AllowlistError):
 
 
 def _tokens_dir(workspace: Path | str) -> Path:
-    return Path(workspace) / ".loom" / "tokens"
+    # Resolve the effective pool dir (per-repo, else shared machine-level pool)
+    # so ``.allowlist`` lives beside the selected ``*.token`` files and is never
+    # forked per repo (issue #3938).
+    return resolve_tokens_dir(workspace)
 
 
 def _allowlist_path(workspace: Path | str) -> Path:

--- a/loom-tools/src/loom_tools/tokens/bad_tokens.py
+++ b/loom-tools/src/loom_tools/tokens/bad_tokens.py
@@ -23,6 +23,17 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from loom_tools.tokens._locking import MkdirLock as _MkdirLock
+from loom_tools.tokens.paths import resolve_tokens_dir
+
+
+def _tokens_dir(workspace_path: Path | str) -> Path:
+    """Resolve the effective pool dir (per-repo, else shared) — issue #3938.
+
+    Routing every bad-token read/write through the shared resolver keeps the
+    ``.bad_tokens`` state file beside the ``*.token`` files that selection
+    actually picks, so it never forks between the per-repo and shared pools.
+    """
+    return resolve_tokens_dir(workspace_path)
 
 
 def _bad_tokens_path(tokens_dir: Path) -> Path:
@@ -58,7 +69,7 @@ def mark_bad(workspace_path: Path | str, token_name: str, reason: str) -> None:
         FileNotFoundError: If ``.loom/tokens/`` does not exist.
     """
     workspace_path = Path(workspace_path)
-    tokens_dir = workspace_path / ".loom" / "tokens"
+    tokens_dir = _tokens_dir(workspace_path)
     if not tokens_dir.is_dir():
         raise FileNotFoundError(f"Tokens dir does not exist: {tokens_dir}")
 
@@ -83,7 +94,7 @@ def is_bad(workspace_path: Path | str, token_name: str) -> bool:
         token_name: Token basename to look up.
     """
     workspace_path = Path(workspace_path)
-    bad_file = _bad_tokens_path(workspace_path / ".loom" / "tokens")
+    bad_file = _bad_tokens_path(_tokens_dir(workspace_path))
     if not bad_file.is_file():
         return False
     try:
@@ -107,7 +118,7 @@ def cleanup_bad_tokens(
         Number of entries retained after pruning.
     """
     workspace_path = Path(workspace_path)
-    tokens_dir = workspace_path / ".loom" / "tokens"
+    tokens_dir = _tokens_dir(workspace_path)
     bad_file = _bad_tokens_path(tokens_dir)
     if not bad_file.is_file():
         return 0

--- a/loom-tools/src/loom_tools/tokens/bootstrap.py
+++ b/loom-tools/src/loom_tools/tokens/bootstrap.py
@@ -444,6 +444,7 @@ def bootstrap_tokens(
     home_env_path: Path | None | object = _HOME_UNSET,
     force: bool = False,
     dry_run: bool = False,
+    tokens_dir: Path | None = None,
 ) -> BootstrapResult:
     """Bootstrap ``.loom/tokens/`` from the merged account sources (#3695, #3698).
 
@@ -476,6 +477,13 @@ def bootstrap_tokens(
             fingerprint matches are left alone.
         dry_run: When ``True``, no files are written; the result lists what
             *would* change (and the effective merged set with provenance).
+        tokens_dir: Optional override for the *destination* pool directory. When
+            ``None`` (default) the pool is written to ``<repo>/.loom/tokens``
+            (unchanged behavior). Pass a directory (e.g. the shared
+            machine-level pool ``~/.loom/tokens``) to materialize a pool shared
+            across every repo the daemon dispatches into (issue #3938). Only the
+            write target changes; account *sources* are resolved exactly as
+            before.
 
     Returns:
         :class:`BootstrapResult` summarising the operation. ``.effective``
@@ -488,7 +496,10 @@ def bootstrap_tokens(
             filename (they would clobber each other on disk).
     """
     paths = LoomPaths(repo_root)
-    tokens_dir = paths.loom_dir / "tokens"
+    # Destination pool dir: the repo-local pool by default, or an explicit
+    # override (e.g. the shared machine-level pool for `--shared`, issue #3938).
+    if tokens_dir is None:
+        tokens_dir = paths.loom_dir / "tokens"
     index_path = tokens_dir / "index.json"
 
     # Resolve the sources. `home_env_path` uses a sentinel so an explicit

--- a/loom-tools/src/loom_tools/tokens/cli.py
+++ b/loom-tools/src/loom_tools/tokens/cli.py
@@ -32,6 +32,7 @@ from loom_tools.common.repo import find_repo_root
 from loom_tools.tokens import allowlist as allowlist_mod
 from loom_tools.tokens import failure_counts
 from loom_tools.tokens.bootstrap import bootstrap_tokens
+from loom_tools.tokens.paths import resolve_tokens_dir, shared_tokens_dir
 from loom_tools.tokens.check import (
     DEFAULT_PROBE_PROMPT,
     format_table,
@@ -85,6 +86,17 @@ def _build_parser() -> argparse.ArgumentParser:
         "--no-home",
         action="store_true",
         help="Ignore the home master; bootstrap from the repo-local source only.",
+    )
+    bp.add_argument(
+        "--shared",
+        action="store_true",
+        help=(
+            "Materialize the SHARED machine-level pool at ~/.loom/tokens "
+            "(override with $LOOM_SHARED_TOKENS_DIR) instead of the repo-local "
+            "<repo>/.loom/tokens. Selection falls back to this pool when a "
+            "consumer repo has no pool of its own (issue #3938), so one "
+            "bootstrap serves every repo the daemon dispatches into."
+        ),
     )
     bp.add_argument(
         "--force",
@@ -278,6 +290,22 @@ def _cmd_bootstrap(args: argparse.Namespace) -> int:
     elif args.home_env is not None:
         home_kwargs["home_env_path"] = args.home_env
 
+    # `--shared` redirects the destination pool to the machine-level location
+    # (issue #3938). Only the write target changes; account sources are
+    # unchanged. Refuse when the operator has disabled the shared pool.
+    shared_kwargs: dict[str, object] = {}
+    if getattr(args, "shared", False):
+        shared_dir = shared_tokens_dir()
+        if shared_dir is None:
+            log_error(
+                "--shared requested but the shared pool is disabled "
+                "(LOOM_SHARED_TOKENS_DIR is empty). Unset it or point it at a "
+                "directory.",
+            )
+            return 1
+        shared_kwargs["tokens_dir"] = shared_dir
+        log_info(f"Bootstrapping the shared machine-level pool at {shared_dir}")
+
     try:
         result = bootstrap_tokens(
             repo_root,
@@ -285,6 +313,7 @@ def _cmd_bootstrap(args: argparse.Namespace) -> int:
             force=args.force,
             dry_run=args.dry_run,
             **home_kwargs,
+            **shared_kwargs,
         )
     except FileNotFoundError as exc:
         log_error(str(exc))
@@ -393,7 +422,10 @@ def _cmd_check(args: argparse.Namespace) -> int:
         except FileNotFoundError as exc:
             log_error(str(exc))
             return 1
-        tokens_dir = repo_root / ".loom" / "tokens"
+        # Rank the pool selection actually uses: per-repo when present, else the
+        # shared machine-level pool (issue #3938), so `.ranking` is written
+        # beside the tokens the spawn wrapper will pick.
+        tokens_dir = resolve_tokens_dir(repo_root)
 
     source = _resolve_ranking_source(args.source)
 
@@ -608,8 +640,11 @@ def _cmd_unblock(args: argparse.Namespace) -> int:
         log_error("`unblock` requires at least one account name.")
         return 1
 
-    bad_file = workspace / ".loom" / "tokens" / ".bad_tokens"
-    lock_path = workspace / ".loom" / "tokens" / ".bad_tokens.lock"
+    # Operate on the effective pool (per-repo, else shared) so unblock clears
+    # the same .bad_tokens selection consults (issue #3938).
+    _tokens_dir = resolve_tokens_dir(workspace)
+    bad_file = _tokens_dir / ".bad_tokens"
+    lock_path = _tokens_dir / ".bad_tokens.lock"
 
     # Reuse the bad_tokens lock to coordinate with concurrent appenders.
     from loom_tools.tokens.bad_tokens import _MkdirLock

--- a/loom-tools/src/loom_tools/tokens/failure_counts.py
+++ b/loom-tools/src/loom_tools/tokens/failure_counts.py
@@ -41,12 +41,16 @@ from pathlib import Path
 
 # Reuse the lock primitive from bad_tokens (mkdir-only, macOS-safe).
 from loom_tools.tokens.bad_tokens import _MkdirLock
+from loom_tools.tokens.paths import resolve_tokens_dir
 
 DEFAULT_THRESHOLD = 5
 
 
 def _tokens_dir(workspace: Path | str) -> Path:
-    return Path(workspace) / ".loom" / "tokens"
+    # Resolve the effective pool dir (per-repo, else shared machine-level pool)
+    # so ``.failure_counts`` lives beside the selected ``*.token`` files and is
+    # never forked per repo (issue #3938).
+    return resolve_tokens_dir(workspace)
 
 
 def _state_path(workspace: Path | str) -> Path:

--- a/loom-tools/src/loom_tools/tokens/paths.py
+++ b/loom-tools/src/loom_tools/tokens/paths.py
@@ -1,0 +1,103 @@
+"""Shared resolution of the effective token-pool directory (issue #3938).
+
+The per-repo pool at ``<repo>/.loom/tokens/`` is the primary location. In the
+one-daemon-many-repos architecture (#3926/#3835), a freshly-installed consumer
+repo has **no** bootstrapped pool — only the daemon's primary workspace does. So
+a cross-repo sweep dispatched by the multi-workspace work finder runs
+``spawn-claude.sh`` with its ``current_dir`` set to the consumer repo, resolves
+that repo's empty ``.loom/tokens/``, and hard-fails with ``EX_CONFIG`` — the
+symptom that motivated this module.
+
+To fix it, token **selection** and **all pool-state bookkeeping** fall back to a
+shared machine-level pool at ``~/.loom/tokens/`` (override with
+``LOOM_SHARED_TOKENS_DIR``) whenever the per-repo pool is absent or empty.
+
+Critically, *every* pool consumer resolves through :func:`resolve_tokens_dir`,
+so the state files (``.bad_tokens``, ``.failure_counts``, ``.ranking``,
+``.allowlist``) are always read/written in the *same* directory the ``*.token``
+files were selected from — pool state is never forked per repo, and the
+token-capacity backpressure accounting (#3907/#3930) sees one truth.
+
+This module is import-safe: no I/O occurs at import time.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+# Env override for the shared machine-level pool location.
+#
+#   * A non-empty value names the shared pool directory (``~`` is expanded).
+#   * An explicitly empty value (``LOOM_SHARED_TOKENS_DIR=``) DISABLES the
+#     shared fallback entirely — selection stays per-repo only.
+#   * Unset -> the default ``~/.loom/tokens``.
+SHARED_TOKENS_DIR_ENV = "LOOM_SHARED_TOKENS_DIR"
+
+
+def per_repo_tokens_dir(workspace: Path | str) -> Path:
+    """Return the canonical per-repo pool dir ``<workspace>/.loom/tokens``."""
+    return Path(workspace) / ".loom" / "tokens"
+
+
+def shared_tokens_dir() -> Path | None:
+    """Return the shared machine-level pool dir, or ``None`` when disabled.
+
+    Resolution precedence (highest first):
+
+        1. ``LOOM_SHARED_TOKENS_DIR`` env var — a non-empty path names the
+           directory (``~`` expanded); an explicitly empty value disables the
+           shared fallback (returns ``None``).
+        2. Default: ``~/.loom/tokens``.
+
+    Returns ``None`` only when the env var is set to an empty string (operator
+    opt-out) or the home directory cannot be resolved.
+    """
+    env = os.environ.get(SHARED_TOKENS_DIR_ENV)
+    if env is not None:
+        stripped = env.strip()
+        if not stripped:
+            return None
+        return Path(stripped).expanduser()
+    try:
+        return Path.home() / ".loom" / "tokens"
+    except (RuntimeError, OSError):
+        # Path.home() can raise when HOME is unset and the password DB lookup
+        # fails — degrade to "no shared pool" rather than crash selection.
+        return None
+
+
+def has_token_files(tokens_dir: Path) -> bool:
+    """Return True iff ``tokens_dir`` exists and holds at least one ``*.token``."""
+    if not tokens_dir.is_dir():
+        return False
+    try:
+        return any(tokens_dir.glob("*.token"))
+    except OSError:
+        return False
+
+
+def resolve_tokens_dir(workspace: Path | str) -> Path:
+    """Resolve the effective pool dir for ``workspace`` (issue #3938).
+
+    Returns:
+        * the **per-repo** pool (``<workspace>/.loom/tokens``) when it holds
+          ``*.token`` files (the common, unchanged case);
+        * otherwise the **shared** machine-level pool when *it* holds token
+          files (the cross-repo fallback);
+        * otherwise the **per-repo** path unchanged — so callers surface a
+          sensible "run ``loom-tokens bootstrap``" error against the repo they
+          were invoked from, exactly as before this module existed.
+
+    Because both selection and every state-file writer resolve through this one
+    function, the ``.bad_tokens`` / ``.failure_counts`` / ``.ranking`` /
+    ``.allowlist`` files always land beside the selected ``*.token`` files —
+    pool state is never split across the per-repo and shared directories.
+    """
+    repo_dir = per_repo_tokens_dir(workspace)
+    if has_token_files(repo_dir):
+        return repo_dir
+    shared = shared_tokens_dir()
+    if shared is not None and has_token_files(shared):
+        return shared
+    return repo_dir

--- a/loom-tools/src/loom_tools/tokens/select.py
+++ b/loom-tools/src/loom_tools/tokens/select.py
@@ -48,6 +48,7 @@ from typing import Iterable
 
 from loom_tools.common.config import env_int
 from loom_tools.tokens.bad_tokens import is_bad
+from loom_tools.tokens.paths import resolve_tokens_dir, shared_tokens_dir
 from loom_tools.tokens.rotation import next_rotation_index
 
 # Ranking file is considered fresh for this many seconds.
@@ -82,6 +83,18 @@ class SelectedToken:
     file: Path  # absolute path to .token file
     key: str  # token contents (whitespace-stripped)
     mode: str  # "ranked" | "allowlist" | "random"
+
+
+def _shared_pool_hint() -> str:
+    """Return a parenthetical naming the shared pool that was also checked.
+
+    Empty when the shared fallback is disabled (``LOOM_SHARED_TOKENS_DIR=``),
+    so the error message stays accurate in both configurations (issue #3938).
+    """
+    shared = shared_tokens_dir()
+    if shared is None:
+        return ""
+    return f" (shared machine-level pool {shared} also checked)"
 
 
 def _read_token_file(token_path: Path) -> str:
@@ -374,18 +387,27 @@ def select_token(
             run ``loom-tokens bootstrap`` — never silently falls back.
     """
     workspace_path = Path(workspace_path)
-    tokens_dir = workspace_path / ".loom" / "tokens"
+    # Resolve the effective pool dir (issue #3938): the per-repo pool when it
+    # holds tokens, else the shared machine-level pool (~/.loom/tokens, override
+    # LOOM_SHARED_TOKENS_DIR), else the per-repo path for a sensible error. All
+    # pool-state files (.bad_tokens/.ranking/.allowlist/.failure_counts) are
+    # keyed off this same resolution, so they never fork per repo.
+    tokens_dir = resolve_tokens_dir(workspace_path)
 
     if not tokens_dir.is_dir():
         raise EmptyTokenPoolError(
-            f"Token directory does not exist: {tokens_dir}. "
-            f"Run `loom-tokens bootstrap` to populate it.",
+            f"Token directory does not exist: {tokens_dir}"
+            f"{_shared_pool_hint()}. "
+            f"Run `loom-tokens bootstrap` to populate it "
+            f"(or `loom-tokens bootstrap --shared` for the machine-level pool).",
         )
 
     all_tokens = _list_token_files(tokens_dir)
     if not all_tokens:
         raise EmptyTokenPoolError(
-            f"No .token files in {tokens_dir}. Run `loom-tokens bootstrap`.",
+            f"No .token files in {tokens_dir}{_shared_pool_hint()}. "
+            f"Run `loom-tokens bootstrap` "
+            f"(or `loom-tokens bootstrap --shared` for the machine-level pool).",
         )
 
     if rng is None:

--- a/loom-tools/tests/tokens/conftest.py
+++ b/loom-tools/tests/tokens/conftest.py
@@ -27,6 +27,12 @@ def _isolate_home_master(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
       at a non-existent tmp path so a developer's or CI runner's real
       ``~/.claude-monitor`` is never consulted. Tests that exercise the
       integration override this with their own ``monkeypatch.setenv``.
+    * ``LOOM_SHARED_TOKENS_DIR`` points the #3938 shared-pool fallback at a
+      non-existent tmp path so a developer's or CI runner's real
+      ``~/.loom/tokens`` never leaks into a test that expects an empty pool.
+      Tests that exercise the shared fallback override this with their own
+      ``monkeypatch.setenv`` pointing at a materialized pool.
     """
     monkeypatch.setenv("LOOM_ACCOUNTS_ENV", "")
     monkeypatch.setenv("LOOM_CLAUDE_MONITOR_DIR", str(tmp_path / "no-claude-monitor"))
+    monkeypatch.setenv("LOOM_SHARED_TOKENS_DIR", str(tmp_path / "no-shared-tokens"))

--- a/loom-tools/tests/tokens/test_bootstrap.py
+++ b/loom-tools/tests/tokens/test_bootstrap.py
@@ -387,6 +387,39 @@ class TestCli:
         rc = cli_main(["bootstrap"])
         assert rc == 1
 
+    def test_bootstrap_shared_writes_machine_level_pool(
+        self,
+        mock_repo: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        """`--shared` materializes the pool in LOOM_SHARED_TOKENS_DIR, not repo."""
+        _make_env(mock_repo, 2)
+        shared = tmp_path / "machine-pool"
+        monkeypatch.setenv("LOOM_SHARED_TOKENS_DIR", str(shared))
+        monkeypatch.chdir(mock_repo)
+
+        rc = cli_main(["bootstrap", "--shared"])
+        assert rc == 0
+        # Tokens land in the shared pool...
+        assert (shared / "user1.token").is_file()
+        assert (shared / "user2.token").is_file()
+        assert (shared / "index.json").is_file()
+        # ...and NOT in the repo-local pool.
+        assert not (mock_repo / ".loom" / "tokens" / "user1.token").exists()
+
+    def test_bootstrap_shared_disabled_returns_1(
+        self,
+        mock_repo: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """`--shared` with the shared pool disabled is a config error."""
+        _make_env(mock_repo, 1)
+        monkeypatch.setenv("LOOM_SHARED_TOKENS_DIR", "")
+        monkeypatch.chdir(mock_repo)
+        rc = cli_main(["bootstrap", "--shared"])
+        assert rc == 1
+
 
 # ---------------------------------------------------------------------------
 # Result struct

--- a/loom-tools/tests/tokens/test_paths.py
+++ b/loom-tools/tests/tokens/test_paths.py
@@ -1,0 +1,118 @@
+"""Tests for loom_tools.tokens.paths — the shared-pool resolver (issue #3938).
+
+The autouse ``_isolate_home_master`` fixture (conftest) pins
+``LOOM_SHARED_TOKENS_DIR`` at a non-existent tmp path, so unless a test opts in
+by pointing it at a materialized pool, the shared fallback is effectively empty.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from loom_tools.tokens.paths import (
+    has_token_files,
+    per_repo_tokens_dir,
+    resolve_tokens_dir,
+    shared_tokens_dir,
+)
+
+
+def _make_pool(dir_path: Path, names: list[str]) -> Path:
+    dir_path.mkdir(parents=True, exist_ok=True)
+    for name in names:
+        (dir_path / f"{name}.token").write_text("sk-ant-oat01-fake", encoding="utf-8")
+    return dir_path
+
+
+# ---------- per_repo_tokens_dir ----------
+
+
+def test_per_repo_tokens_dir_shape(tmp_path):
+    assert per_repo_tokens_dir(tmp_path) == tmp_path / ".loom" / "tokens"
+
+
+# ---------- shared_tokens_dir ----------
+
+
+def test_shared_dir_from_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOOM_SHARED_TOKENS_DIR", str(tmp_path / "pool"))
+    assert shared_tokens_dir() == tmp_path / "pool"
+
+
+def test_shared_dir_empty_env_disables(monkeypatch):
+    monkeypatch.setenv("LOOM_SHARED_TOKENS_DIR", "")
+    assert shared_tokens_dir() is None
+
+
+def test_shared_dir_default_is_home(monkeypatch):
+    monkeypatch.delenv("LOOM_SHARED_TOKENS_DIR", raising=False)
+    assert shared_tokens_dir() == Path.home() / ".loom" / "tokens"
+
+
+def test_shared_dir_expands_tilde(monkeypatch):
+    monkeypatch.setenv("LOOM_SHARED_TOKENS_DIR", "~/custom-pool")
+    assert shared_tokens_dir() == Path.home() / "custom-pool"
+
+
+# ---------- has_token_files ----------
+
+
+def test_has_token_files_true(tmp_path):
+    _make_pool(tmp_path / "p", ["a"])
+    assert has_token_files(tmp_path / "p") is True
+
+
+def test_has_token_files_false_when_missing(tmp_path):
+    assert has_token_files(tmp_path / "nope") is False
+
+
+def test_has_token_files_false_when_only_bookkeeping(tmp_path):
+    d = tmp_path / "p"
+    d.mkdir()
+    (d / ".bad_tokens").write_text("x", encoding="utf-8")
+    (d / "index.json").write_text("{}", encoding="utf-8")
+    assert has_token_files(d) is False
+
+
+# ---------- resolve_tokens_dir ----------
+
+
+def test_resolve_prefers_per_repo(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    per_repo = _make_pool(repo / ".loom" / "tokens", ["r1"])
+    shared = _make_pool(tmp_path / "shared", ["s1"])
+    monkeypatch.setenv("LOOM_SHARED_TOKENS_DIR", str(shared))
+    assert resolve_tokens_dir(repo) == per_repo
+
+
+def test_resolve_falls_back_to_shared_when_per_repo_absent(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    shared = _make_pool(tmp_path / "shared", ["s1", "s2"])
+    monkeypatch.setenv("LOOM_SHARED_TOKENS_DIR", str(shared))
+    assert resolve_tokens_dir(repo) == shared
+
+
+def test_resolve_falls_back_when_per_repo_empty(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    (repo / ".loom" / "tokens").mkdir(parents=True)  # exists but no *.token
+    shared = _make_pool(tmp_path / "shared", ["s1"])
+    monkeypatch.setenv("LOOM_SHARED_TOKENS_DIR", str(shared))
+    assert resolve_tokens_dir(repo) == shared
+
+
+def test_resolve_returns_per_repo_when_nothing_anywhere(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    # Shared points at a non-existent dir (default conftest behavior too).
+    monkeypatch.setenv("LOOM_SHARED_TOKENS_DIR", str(tmp_path / "empty-shared"))
+    assert resolve_tokens_dir(repo) == repo / ".loom" / "tokens"
+
+
+def test_resolve_ignores_shared_when_disabled(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    # A shared pool exists on disk, but the operator disabled the fallback.
+    _make_pool(tmp_path / "shared", ["s1"])
+    monkeypatch.setenv("LOOM_SHARED_TOKENS_DIR", "")
+    assert resolve_tokens_dir(repo) == repo / ".loom" / "tokens"

--- a/loom-tools/tests/tokens/test_select.py
+++ b/loom-tools/tests/tokens/test_select.py
@@ -573,3 +573,68 @@ def test_cli_empty_pool_exits_78(tmp_path):
     )
     assert result.returncode == EX_CONFIG
     assert "loom-tokens bootstrap" in result.stderr
+
+
+# ---------- shared machine-level pool fallback (issue #3938) ----------
+
+
+def _make_shared_pool(tmp_path: Path, accounts: dict[str, str]) -> Path:
+    """Materialize a shared machine-level pool (flat dir, not <repo>/.loom)."""
+    shared = tmp_path / "shared-pool"
+    shared.mkdir(parents=True)
+    for name, key in accounts.items():
+        (shared / f"{name}.token").write_text(key, encoding="utf-8")
+    return shared
+
+
+def test_falls_back_to_shared_pool_when_repo_has_none(tmp_path, monkeypatch):
+    """A consumer repo with no per-repo pool selects from the shared pool."""
+    repo = tmp_path / "consumer"
+    repo.mkdir()
+    shared = _make_shared_pool(tmp_path, {"shared-a": "key-shared-a"})
+    monkeypatch.setenv("LOOM_SHARED_TOKENS_DIR", str(shared))
+
+    sel = select_token(repo)
+    assert sel.name == "shared-a"
+    assert sel.key == "key-shared-a"
+    assert sel.file == shared / "shared-a.token"
+
+
+def test_per_repo_pool_wins_over_shared(tmp_path, monkeypatch):
+    repo = _make_workspace(tmp_path, {"repo-a": "key-repo-a"})
+    shared = _make_shared_pool(tmp_path, {"shared-a": "key-shared-a"})
+    monkeypatch.setenv("LOOM_SHARED_TOKENS_DIR", str(shared))
+
+    sel = select_token(repo)
+    assert sel.name == "repo-a"
+
+
+def test_shared_pool_bad_tokens_written_in_shared_dir(tmp_path, monkeypatch):
+    """State (.bad_tokens) is written in the SELECTED pool dir, never forked."""
+    from loom_tools.tokens.bad_tokens import is_bad, mark_bad
+
+    repo = tmp_path / "consumer"
+    repo.mkdir()
+    shared = _make_shared_pool(tmp_path, {"shared-a": "k-a", "shared-b": "k-b"})
+    monkeypatch.setenv("LOOM_SHARED_TOKENS_DIR", str(shared))
+
+    mark_bad(repo, "shared-a", "expired")
+
+    # Written into the shared pool, NOT into <repo>/.loom/tokens.
+    assert (shared / ".bad_tokens").is_file()
+    assert not (repo / ".loom" / "tokens" / ".bad_tokens").exists()
+    # And selection sees the same truth: shared-a is skipped.
+    assert is_bad(repo, "shared-a") is True
+    sel = select_token(repo)
+    assert sel.name == "shared-b"
+
+
+def test_shared_disabled_still_hard_fails(tmp_path, monkeypatch):
+    """With the shared fallback disabled, a repo-less pool still hard-fails."""
+    repo = tmp_path / "consumer"
+    repo.mkdir()
+    _make_shared_pool(tmp_path, {"shared-a": "k-a"})  # exists but ignored
+    monkeypatch.setenv("LOOM_SHARED_TOKENS_DIR", "")
+
+    with pytest.raises(EmptyTokenPoolError):
+        select_token(repo)


### PR DESCRIPTION
## Summary

Multi-repo daemon-dispatched sweeps died instantly in consumer repos: the multi-workspace work-finder measures the token pool once from the daemon's **primary** workspace, but each dispatched sweep runs `spawn-claude.sh` with `current_dir` set to **its own** repo — which, freshly installed, has no `.loom/tokens/`. Result: every cross-repo dispatch hard-failed with `EX_CONFIG`, burning a dispatch slot per tick.

This implements **Option 1 (preferred)** from the issue: a shared machine-level pool with a per-repo fallback, wired so pool **state is never forked per repo**.

## Design decisions

- **New resolver `loom_tools.tokens.paths.resolve_tokens_dir`**: per-repo pool `<repo>/.loom/tokens/` when it holds `*.token` files, else the shared machine-level pool `~/.loom/tokens/` (override `LOOM_SHARED_TOKENS_DIR`; empty value disables the fallback), else the per-repo path so a truly-unbootstrapped repo still surfaces a clear "run bootstrap" error.
- **State locality (AC2)**: `select`, `bad_tokens`, `failure_counts`, `allowlist`, and `cli` (`check`/`unblock`) all resolve through the one function, so `.bad_tokens` / `.failure_counts` / `.ranking` / `.allowlist` are read/written beside the *selected* `*.token` files. A consumer repo dispatching against the shared pool shares one `.bad_tokens`/`.ranking` truth — token-capacity backpressure (#3907/#3930) sees one truth, never N forked copies.
- **`loom-tokens bootstrap --shared`** materializes the machine-level pool (destination-only; account sources unchanged). Refuses when the shared pool is disabled.
- **Rust `token_pool_size`** applies the same per-repo→shared resolution, so the daemon's dynamic concurrency cap matches what the spawn path can actually pick (kept in lock-step with the Python resolver, incl. the `LOOM_SHARED_TOKENS_DIR` empty-disables semantics).
- **`spawn-claude.sh`** is unchanged in logic — selection is delegated to the Python resolver — so only its header docs + error hints were updated to name the shared pool and `bootstrap --shared`.

The load-bearing fix is the shell/Python fallback; the Rust pre-dispatch accounting change was reasonably scoped and included for consistency (AC2).

## Acceptance criteria

- [x] A sweep dispatched into a consumer repo with no `.loom/tokens/` selects a token successfully via the shared-pool fallback (no silent crash loop).
- [x] Pool health state is not forked per repo — all state files resolve to the selected pool dir.
- [x] Docs: daemon-reference "Token pool provisioning for managed repos" + CLAUDE.md.

## Test evidence

- Python: `275 passed` (`PYTHONPATH=loom-tools/src pytest loom-tools/tests/tokens/`) — incl. new `test_paths.py` (resolver), shared-pool fallback + state-locality in `test_select.py`, `bootstrap --shared` in `test_bootstrap.py`; conftest isolates `LOOM_SHARED_TOKENS_DIR`.
- Rust: `cargo test --lib tokens` → `16 passed` (env-free core + env resolver, per-repo-wins, shared-fallback, disabled-opt-out). `cargo clippy --lib` clean.
- Shell: `bash .loom/scripts/tests/test-spawn-claude.sh` → `68 passed`, incl. a new case proving a pool-less repo falls back to the shared pool and that `.bad_tokens` lands in the shared dir, not the consumer repo.
- `ruff` clean on all changed source files.

Closes #3938

🤖 Generated with [Claude Code](https://claude.com/claude-code)