### PR TITLE
fix(daemon): unify status token-capacity summary, cap input, and table on one source (#3936)

### DIFF
--- a/loom-daemon/src/capacity.rs
+++ b/loom-daemon/src/capacity.rs
@@ -177,6 +177,94 @@ pub fn read_ranking(workspace_root: &Path) -> Option<RankingSnapshot> {
     }
 }
 
+// ============================================================================
+// Fresh-probe capacity (issue #3936)
+// ============================================================================
+
+/// Near-ceiling 7d-utilization threshold: an account at or above this fraction
+/// is treated as exhausted/near-ceiling and **never** counted healthy, mirroring
+/// `loom-tokens`' `EXHAUSTED_THRESHOLD` (`check.py`). Kept here so the daemon's
+/// status view applies the *same* threshold the probe uses when it assigns the
+/// discrete status word — closing the #3936 gap where a `99%`-7d account whose
+/// status word said `available` was still counted healthy.
+pub const NEAR_CEILING_THRESHOLD: f64 = 0.95;
+
+/// Decide whether a single probed account is healthy under the unified rule.
+///
+/// An account is healthy **only** when its probe status word is `available`
+/// *and* its 7d utilization is below [`NEAR_CEILING_THRESHOLD`]. The utilization
+/// override is what fixes #3936: a stale or monitor-sourced `available` status
+/// on an account that has actually reached the 7d ceiling (e.g. `99%`) is
+/// treated as unhealthy anyway, so the summary count and the per-token table can
+/// never disagree about it.
+#[must_use]
+pub fn probe_account_healthy(status: &str, util_7d: Option<f64>) -> bool {
+    if let Some(u) = util_7d {
+        if u >= NEAR_CEILING_THRESHOLD {
+            return false;
+        }
+    }
+    status.trim() == "available"
+}
+
+/// The status word to *display* for an account, applying the same near-ceiling
+/// override as [`probe_account_healthy`]. An `available` account at/above the
+/// 7d ceiling renders as `exhausted` so the per-token table never shows a row
+/// that contradicts the healthy count (#3936). Every other status word is
+/// passed through unchanged.
+#[must_use]
+pub fn effective_probe_status(status: &str, util_7d: Option<f64>) -> String {
+    let trimmed = status.trim();
+    if trimmed == "available" {
+        if let Some(u) = util_7d {
+            if u >= NEAR_CEILING_THRESHOLD {
+                return "exhausted".to_string();
+            }
+        }
+    }
+    trimmed.to_string()
+}
+
+/// Aggregate healthy/exhausted counts derived from a fresh `loom-tokens check
+/// --json` probe, applying [`probe_account_healthy`] uniformly.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ProbeCapacity {
+    /// Total accounts in the probe.
+    pub total: usize,
+    /// Accounts healthy under the unified rule (available AND below ceiling).
+    pub healthy: usize,
+    /// Accounts not healthy — `total - healthy`.
+    pub exhausted: usize,
+}
+
+/// Summarize a fresh probe into a [`ProbeCapacity`].
+///
+/// Each item is the account's `(status_word, 7d_utilization)` as read from the
+/// `loom-tokens check --json` accounts array. This is the single source of truth
+/// the status view uses for the capacity summary, the healthy-tokens cap input,
+/// and (via [`effective_probe_status`]) the per-token table — so all three are
+/// computed from the same source and the same threshold and cannot contradict
+/// each other (#3936, acceptance criterion 1).
+#[must_use]
+pub fn summarize_probe<'a, I>(accounts: I) -> ProbeCapacity
+where
+    I: IntoIterator<Item = (&'a str, Option<f64>)>,
+{
+    let mut total = 0usize;
+    let mut healthy = 0usize;
+    for (status, util_7d) in accounts {
+        total += 1;
+        if probe_account_healthy(status, util_7d) {
+            healthy += 1;
+        }
+    }
+    ProbeCapacity {
+        total,
+        healthy,
+        exhausted: total - healthy,
+    }
+}
+
 /// The health-adjusted token-axis concurrency limit.
 ///
 /// When ranking data exists, this is the count of `available` accounts — the
@@ -601,5 +689,110 @@ mod tests {
         assert_eq!(format_minutes(90), "1h 30m");
         assert_eq!(format_minutes(120), "2h");
         assert_eq!(format_minutes(0), "0m");
+    }
+
+    // ------------------------------------------------------------------
+    // Fresh-probe capacity (issue #3936)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn probe_account_healthy_applies_near_ceiling_override() {
+        // A genuinely-available account below the ceiling is healthy.
+        assert!(probe_account_healthy("available", Some(0.10)));
+        assert!(probe_account_healthy("available", Some(0.94)));
+        assert!(probe_account_healthy("available", None));
+        // At/above the 95% near-ceiling threshold it is NEVER healthy, even
+        // though the probe's status word still says `available` (#3936).
+        assert!(!probe_account_healthy("available", Some(0.95)));
+        assert!(!probe_account_healthy("available", Some(0.99)));
+        assert!(!probe_account_healthy("available", Some(1.00)));
+        // Non-`available` status words are never healthy regardless of util.
+        assert!(!probe_account_healthy("exhausted", Some(0.10)));
+        assert!(!probe_account_healthy("rate_limited", Some(0.10)));
+        assert!(!probe_account_healthy("blocked", None));
+        assert!(!probe_account_healthy("error", None));
+        // Whitespace tolerance.
+        assert!(probe_account_healthy(" available ", Some(0.10)));
+    }
+
+    #[test]
+    fn effective_probe_status_corrects_near_ceiling_available() {
+        // The 99%-7d `available` row renders as `exhausted` so the table never
+        // contradicts the healthy count (#3936: agent3-2amlogic at 99%).
+        assert_eq!(effective_probe_status("available", Some(0.99)), "exhausted");
+        assert_eq!(effective_probe_status("available", Some(0.95)), "exhausted");
+        // Below the ceiling it stays `available`.
+        assert_eq!(effective_probe_status("available", Some(0.50)), "available");
+        assert_eq!(effective_probe_status("available", None), "available");
+        // Other status words pass through untouched.
+        assert_eq!(effective_probe_status("exhausted", Some(1.0)), "exhausted");
+        assert_eq!(effective_probe_status("rate_limited", None), "rate_limited");
+        assert_eq!(effective_probe_status("blocked", None), "blocked");
+    }
+
+    #[test]
+    fn summarize_probe_mixed_pool_is_self_consistent() {
+        // A mixed pool: some available-and-low, one near-ceiling `available`
+        // (the #3936 mislabel), some exhausted, one rate_limited. This mirrors
+        // the live incident (2 truly available, 5 not) and asserts the summary
+        // agrees with a table rendered from the SAME source + threshold.
+        let accounts: Vec<(&str, Option<f64>)> = vec![
+            ("available", Some(0.10)),    // healthy
+            ("available", Some(0.42)),    // healthy
+            ("available", Some(0.99)),    // near-ceiling mislabel -> NOT healthy
+            ("exhausted", Some(1.00)),    // not healthy
+            ("exhausted", Some(1.00)),    // not healthy
+            ("exhausted", Some(0.97)),    // not healthy
+            ("rate_limited", Some(0.30)), // not healthy
+        ];
+
+        let cap = summarize_probe(accounts.iter().copied());
+        assert_eq!(cap.total, 7);
+        assert_eq!(cap.healthy, 2, "only the two below-ceiling `available` rows");
+        assert_eq!(cap.exhausted, 5);
+        assert_eq!(cap.healthy + cap.exhausted, cap.total);
+
+        // Table/summary consistency: the number of rows the table renders as an
+        // effective `available` status must equal the summary's healthy count,
+        // and NO row shows `available` while being counted unhealthy (#3936).
+        let table_available = accounts
+            .iter()
+            .filter(|(s, u)| effective_probe_status(s, *u) == "available")
+            .count();
+        assert_eq!(
+            table_available, cap.healthy,
+            "per-token table `available` rows must match the healthy summary count"
+        );
+        for (s, u) in &accounts {
+            let shown = effective_probe_status(s, *u);
+            if shown == "available" {
+                assert!(
+                    probe_account_healthy(s, *u),
+                    "a row shown `available` must be counted healthy"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn summarize_probe_empty_is_zero() {
+        let cap = summarize_probe(std::iter::empty());
+        assert_eq!(cap, ProbeCapacity::default());
+        assert_eq!(cap.total, 0);
+        assert_eq!(cap.healthy, 0);
+        assert_eq!(cap.exhausted, 0);
+    }
+
+    #[test]
+    fn summarize_probe_all_healthy_and_all_exhausted() {
+        let all_ok: Vec<(&str, Option<f64>)> =
+            vec![("available", Some(0.1)), ("available", Some(0.2))];
+        let cap = summarize_probe(all_ok.iter().copied());
+        assert_eq!((cap.total, cap.healthy, cap.exhausted), (2, 2, 0));
+
+        let all_bad: Vec<(&str, Option<f64>)> =
+            vec![("exhausted", Some(1.0)), ("available", Some(0.96))];
+        let cap = summarize_probe(all_bad.iter().copied());
+        assert_eq!((cap.total, cap.healthy, cap.exhausted), (2, 0, 2));
     }
 }

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -943,11 +943,112 @@ async fn handle_status_command(json: bool) -> Result<()> {
     Ok(())
 }
 
+/// The capacity figures the whole status view shares, resolved from a single
+/// source so the summary, the healthy-tokens cap input, and the per-token table
+/// never contradict each other (issue #3936).
+///
+/// Preference order:
+/// 1. **fresh probe** — when a client-side `loom-tokens check --json` succeeded
+///    (the *same* data that renders the per-token table), the health counts are
+///    derived from it via [`loom_daemon::capacity::summarize_probe`], applying
+///    the near-ceiling threshold uniformly. This is the accurate *current*
+///    capacity and matches the table row-for-row.
+/// 2. **daemon ranking** — when no fresh probe is available but the daemon
+///    reported a parsed `.loom/tokens/.ranking`, fall back to its snapshot.
+/// 3. **raw pool** — no probe and no ranking: the pre-#3902 flat pool basis.
+struct ResolvedCapacity {
+    /// Where the figures came from — one of `"probe"`, `"ranking"`, `"pool"`.
+    source: &'static str,
+    /// Whether any account-health data (probe or ranking) was available.
+    ranking_present: bool,
+    total: usize,
+    healthy: usize,
+    exhausted: usize,
+    /// Health-adjusted token axis (healthy accounts, or the raw pool as a
+    /// fallback) — the "healthy tokens" input to the dynamic concurrency cap.
+    token_axis_limit: usize,
+    /// The effective dynamic cap consistent with `token_axis_limit`:
+    /// `min(token_axis_limit, disk_headroom, configured_max)`.
+    effective_cap: usize,
+    /// Whether the token axis is the binding (minimum) constraint.
+    token_bound: bool,
+}
+
+/// Resolve the shared capacity figures for a status render (#3936). Prefers the
+/// fresh client-side probe over the daemon's possibly-stale ranking snapshot so
+/// the summary count, the cap's healthy-tokens input, and the per-token table
+/// all agree.
+fn resolve_capacity(
+    report: &DaemonStatusReport,
+    token_usage: Option<&serde_json::Value>,
+) -> ResolvedCapacity {
+    // Tier 1: fresh probe — the same source as the per-token table.
+    if let Some(usage) = token_usage {
+        if let Some(accounts) = usage.get("accounts").and_then(serde_json::Value::as_array) {
+            let pairs: Vec<(&str, Option<f64>)> = accounts
+                .iter()
+                .map(|a| {
+                    let status = a
+                        .get("status")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("?");
+                    let util_7d = a.get("7d_utilization").and_then(serde_json::Value::as_f64);
+                    (status, util_7d)
+                })
+                .collect();
+            let cap = loom_daemon::capacity::summarize_probe(pairs.iter().copied());
+            let token_axis_limit = cap.healthy;
+            let effective_cap = token_axis_limit
+                .min(report.disk_headroom)
+                .min(report.configured_max);
+            let token_bound = token_axis_limit <= report.disk_headroom
+                && token_axis_limit <= report.configured_max;
+            return ResolvedCapacity {
+                source: "probe",
+                ranking_present: true,
+                total: cap.total,
+                healthy: cap.healthy,
+                exhausted: cap.exhausted,
+                token_axis_limit,
+                effective_cap,
+                token_bound,
+            };
+        }
+    }
+
+    // Tier 2: daemon-reported ranking snapshot.
+    if report.capacity.ranking_present {
+        return ResolvedCapacity {
+            source: "ranking",
+            ranking_present: true,
+            total: report.capacity.total_accounts,
+            healthy: report.capacity.healthy_accounts,
+            exhausted: report.capacity.exhausted_accounts,
+            token_axis_limit: report.capacity.token_axis_limit,
+            effective_cap: report.dynamic_cap,
+            token_bound: report.capacity.token_bound,
+        };
+    }
+
+    // Tier 3: no probe, no ranking — raw pool basis (pre-#3902 behavior).
+    ResolvedCapacity {
+        source: "pool",
+        ranking_present: false,
+        total: report.token_pool_size,
+        healthy: 0,
+        exhausted: 0,
+        token_axis_limit: report.token_pool_size,
+        effective_cap: report.dynamic_cap,
+        token_bound: report.capacity.token_bound,
+    }
+}
+
 /// Emit the combined status (daemon report + per-token usage) as JSON.
 fn print_status_json(
     report: &DaemonStatusReport,
     token_usage: Option<&serde_json::Value>,
 ) -> Result<()> {
+    let rc = resolve_capacity(report, token_usage);
     let combined = serde_json::json!({
         "in_flight_count": report.in_flight.len(),
         "in_flight": report.in_flight,
@@ -955,15 +1056,16 @@ fn print_status_json(
             "token_pool_size": report.token_pool_size,
             "disk_headroom": report.disk_headroom,
             "configured_max": report.configured_max,
-            "effective": report.dynamic_cap,
+            "effective": rc.effective_cap,
         },
         "capacity": {
-            "ranking_present": report.capacity.ranking_present,
-            "total_accounts": report.capacity.total_accounts,
-            "healthy_accounts": report.capacity.healthy_accounts,
-            "exhausted_accounts": report.capacity.exhausted_accounts,
-            "token_axis_limit": report.capacity.token_axis_limit,
-            "token_bound": report.capacity.token_bound,
+            "source": rc.source,
+            "ranking_present": rc.ranking_present,
+            "total_accounts": rc.total,
+            "healthy_accounts": rc.healthy,
+            "exhausted_accounts": rc.exhausted,
+            "token_axis_limit": rc.token_axis_limit,
+            "token_bound": rc.token_bound,
         },
         "main_health_gate": {
             "halted": report.main_health_gate_halted,
@@ -1003,22 +1105,44 @@ fn print_status_human(report: &DaemonStatusReport, token_usage: Option<&serde_js
         }
     }
 
-    println!("\nDynamic concurrency cap: {}", report.dynamic_cap);
+    // Capacity figures resolved from a single source (fresh probe when
+    // available, else the daemon's ranking snapshot) so the cap's healthy-tokens
+    // input, the Token-capacity summary, and the Per-token table all agree (#3936).
+    let rc = resolve_capacity(report, token_usage);
+
+    println!("\nDynamic concurrency cap: {}", rc.effective_cap);
     println!(
         "  = min(healthy tokens {}, disk headroom {}, configured max {})",
-        report.capacity.token_axis_limit, report.disk_headroom, report.configured_max
+        rc.token_axis_limit, report.disk_headroom, report.configured_max
     );
 
-    // Token-capacity backpressure section (#3902).
-    let cap = &report.capacity;
+    // Token-capacity backpressure section (#3902, source-unified in #3936).
     println!("\nToken capacity:");
-    if cap.ranking_present {
+    if rc.ranking_present {
+        let src = if rc.source == "probe" {
+            "live probe: loom-tokens check --json"
+        } else {
+            "from .loom/tokens/.ranking"
+        };
         println!(
-            "  {}/{} accounts healthy, {} exhausted/near-ceiling (from .loom/tokens/.ranking)",
-            cap.healthy_accounts, cap.total_accounts, cap.exhausted_accounts
+            "  {}/{} accounts healthy, {} exhausted/near-ceiling ({src})",
+            rc.healthy, rc.total, rc.exhausted
         );
-        if cap.token_bound {
-            if cap.healthy_accounts == 0 {
+        // When a fresh probe disagrees with the daemon's ranking-based cap, the
+        // ranking is stale — the daemon may still be dispatching against the old
+        // (higher) count. Surface it so the operator re-probes (#3936).
+        if rc.source == "probe"
+            && report.capacity.ranking_present
+            && report.capacity.healthy_accounts != rc.healthy
+        {
+            println!(
+                "  note: daemon dispatch cap still uses a stale .ranking ({} healthy); \
+                 refresh it with `loom-tokens check --ranking`.",
+                report.capacity.healthy_accounts
+            );
+        }
+        if rc.token_bound {
+            if rc.healthy == 0 {
                 println!(
                     "  token-bound: NO healthy accounts — new dispatch deferred until capacity \
                      returns. Add accounts (~/.claude-monitor/accounts.env + `loom-tokens \
@@ -1104,10 +1228,16 @@ fn print_token_usage_table(value: &serde_json::Value) {
             .get("name")
             .and_then(serde_json::Value::as_str)
             .unwrap_or("?");
-        let status = acct
+        let raw_status = acct
             .get("status")
             .and_then(serde_json::Value::as_str)
             .unwrap_or("?");
+        let util_7d = acct
+            .get("7d_utilization")
+            .and_then(serde_json::Value::as_f64);
+        // Apply the same near-ceiling override the summary uses so a 99%-7d
+        // `available` row never renders `available` here (#3936).
+        let status = loom_daemon::capacity::effective_probe_status(raw_status, util_7d);
         let fmt_pct = |key: &str| {
             acct.get(key)
                 .and_then(serde_json::Value::as_f64)


### PR DESCRIPTION
## Summary

`loom-daemon status` printed a self-contradicting token-capacity view: the **Token capacity** summary and the **Dynamic concurrency cap**'s "healthy tokens" input were computed daemon-side from the possibly-stale `.loom/tokens/.ranking` file (`report.capacity`), while the **Per-token usage** table was computed client-side from a fresh `loom-tokens check --json` probe. When the ranking was stale the summary claimed "6/7 accounts healthy, 1 exhausted" while the table below it showed 2 available / 5 exhausted. Separately, the table printed each account's raw `status` word verbatim, so a `7d>=0.95` account mislabeled `available` (e.g. `agent3-2amlogic` at 99%) rendered "available", violating the documented near-ceiling rule.

## Root cause

1. **Two sources.** The summary/cap read `.ranking`; the table ran a fresh probe. They diverge whenever `.ranking` is stale.
2. **Threshold not applied to the table.** The table trusted the probe's status word, so a near-ceiling `available` slipped through.

## Fix

- New pure, unit-tested helpers in `capacity.rs`:
  - `probe_account_healthy(status, util_7d)` — healthy only when `available` AND 7d utilization `< 0.95` (`NEAR_CEILING_THRESHOLD`, mirroring `check.py`'s `EXHAUSTED_THRESHOLD`).
  - `effective_probe_status(status, util_7d)` — corrects a near-ceiling `available` to `exhausted` for display.
  - `summarize_probe(...)` → `ProbeCapacity { total, healthy, exhausted }`.
- `resolve_capacity()` in `main.rs` resolves **one** source (fresh probe → daemon ranking → raw pool) and drives the summary, the healthy-tokens cap input, the recomputed effective cap, and the JSON `capacity` / `dynamic_cap.effective`. Summary, cap input, and table now agree by construction.
- The per-token table renders `effective_probe_status`, so a 99%-7d row never shows `available`.
- When the fresh probe disagrees with the daemon's ranking-based cap, a note flags the stale `.ranking` and suggests `loom-tokens check --ranking` — surfacing the over-subscription risk (#3907 backpressure engaging late).

## Acceptance criteria

1. Summary count, healthy-tokens cap input, and per-token table are computed from the same source + threshold and agree. ✅
2. 95% near-ceiling threshold applied consistently — a 99%-7d account is never counted healthy nor shown `available`. ✅
3. Unit test covering summary/table consistency with a mixed pool. ✅ (`summarize_probe_mixed_pool_is_self_consistent`, plus 4 more)

## Tests

- `cargo test --lib` → **734 passed, 0 failed** (5 new capacity tests).
- `cargo fmt` clean; `cargo clippy --all-targets` clean.

Closes #3936

🤖 Generated with [Claude Code](https://claude.com/claude-code)