### PR TITLE
fix(daemon): disable 600s print-mode bg-task ceiling for sweep children (#3943)

### DIFF
--- a/defaults/scripts/spawn-claude.sh
+++ b/defaults/scripts/spawn-claude.sh
@@ -339,19 +339,6 @@ fi
 : "${CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS:=0}"
 export CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS
 
-# --- Print-mode background-task wait ceiling (issue #3943) ---
-# When the daemon spawns a sweep child as a headless `claude -p "/loom:sweep N"`
-# session, the Claude Code harness (print mode) terminates still-running
-# background tasks — the sweep's dispatched Builder/Judge subagents — after a
-# 600s ceiling and exits the session. Any role phase taking >10 minutes is
-# killed mid-build, causing loom:building<->loom:issue label ping-pong. Disable
-# the ceiling (0 = no cap) so long-running phases run to completion. This is
-# harmless for interactive use (no background-task reaping there). Use the
-# `:=` default-assignment idiom so an operator override — e.g. a non-zero
-# ceiling exported in the environment — is preserved.
-: "${CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS:=0}"
-export CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS
-
 # --- Dispatch ---
 if [[ "$USE_WRAPPER" == "true" ]]; then
     _wrapper="${WORKSPACE}/.loom/scripts/claude-wrapper.sh"

--- a/defaults/scripts/spawn-claude.sh
+++ b/defaults/scripts/spawn-claude.sh
@@ -326,6 +326,32 @@ PY
     log_info "spawn-claude: using OAuth account '$_name' (mode=$_mode)"
 fi
 
+# --- Print-mode background-task wait ceiling (issue #3943) ---
+# When the daemon spawns a sweep child as a headless `claude -p "/loom:sweep N"`
+# session, the Claude Code harness (print mode) terminates still-running
+# background tasks — the sweep's dispatched Builder/Judge subagents — after a
+# 600s ceiling and exits the session. Any role phase taking >10 minutes is
+# killed mid-build, causing loom:building<->loom:issue label ping-pong. Disable
+# the ceiling (0 = no cap) so long-running phases run to completion. This is
+# harmless for interactive use (no background-task reaping there). Use the
+# `:=` default-assignment idiom so an operator override — e.g. a non-zero
+# ceiling exported in the environment — is preserved.
+: "${CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS:=0}"
+export CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS
+
+# --- Print-mode background-task wait ceiling (issue #3943) ---
+# When the daemon spawns a sweep child as a headless `claude -p "/loom:sweep N"`
+# session, the Claude Code harness (print mode) terminates still-running
+# background tasks — the sweep's dispatched Builder/Judge subagents — after a
+# 600s ceiling and exits the session. Any role phase taking >10 minutes is
+# killed mid-build, causing loom:building<->loom:issue label ping-pong. Disable
+# the ceiling (0 = no cap) so long-running phases run to completion. This is
+# harmless for interactive use (no background-task reaping there). Use the
+# `:=` default-assignment idiom so an operator override — e.g. a non-zero
+# ceiling exported in the environment — is preserved.
+: "${CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS:=0}"
+export CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS
+
 # --- Dispatch ---
 if [[ "$USE_WRAPPER" == "true" ]]; then
     _wrapper="${WORKSPACE}/.loom/scripts/claude-wrapper.sh"

--- a/defaults/scripts/tests/test-spawn-claude.sh
+++ b/defaults/scripts/tests/test-spawn-claude.sh
@@ -217,6 +217,7 @@ cat > "$STUB_DIR/claude" <<'STUB'
 #!/usr/bin/env bash
 echo "stub-claude got token=${CLAUDE_CODE_OAUTH_TOKEN}"
 echo "stub-claude args=$*"
+echo "stub-claude ceiling=${CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS:-unset}"
 exit 0
 STUB
 chmod +x "$STUB_DIR/claude"
@@ -230,6 +231,20 @@ assert_contains "stub-claude args=-p ping" "$output" \
     "spawn-claude passes args through to claude"
 assert_contains "OAuth account 'alpha'" "$output" \
     "spawn-claude logs the chosen account"
+
+# Test: spawn-claude disables the print-mode background-task wait ceiling
+# (issue #3943) so a daemon-dispatched sweep child's long-running Builder/Judge
+# subagents are not reaped at the 600s ceiling. Default = 0 (no cap).
+assert_contains "stub-claude ceiling=0" "$output" \
+    "spawn-claude exports CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 by default (#3943)"
+
+# Test: an operator-set CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS is PRESERVED
+# (the `:=` default-assignment idiom only fills an unset/empty value).
+output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
+    CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS="120000" \
+    "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
+assert_contains "stub-claude ceiling=120000" "$output" \
+    "spawn-claude preserves an operator-set wait ceiling (#3943)"
 
 # Test: explicit CLAUDE_CODE_OAUTH_TOKEN bypasses selection
 output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -79,6 +79,14 @@ pub const SPAWN_BIN_ENV: &str = "LOOM_SWEEP_SPAWN_BIN";
 /// registry. Falls back to `LOOM_WORKSPACE`, then current dir.
 pub const WORKSPACE_ENV: &str = "LOOM_WORKSPACE";
 
+/// Issue #3943: print-mode background-task wait ceiling (milliseconds). A
+/// daemon-spawned sweep child is a headless `claude -p` session; in print mode
+/// the harness reaps still-running background tasks (the sweep's Builder/Judge
+/// subagents) after a 600s ceiling. `spawn_child` pins this to `0` (no cap) on
+/// the child env so a long role phase runs to completion instead of being
+/// killed mid-build.
+pub const BG_WAIT_CEILING_ENV: &str = "CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS";
+
 /// Retention window after a sweep terminates before it is garbage-collected
 /// from the in-memory map. One hour matches the operator intuition that
 /// "recently exited sweeps should still show up in `list_sweeps`".
@@ -1317,6 +1325,17 @@ impl SweepRegistry {
             // the daemon thinks the workspace is — never inheriting an
             // ambient value that might point elsewhere.
             .env(WORKSPACE_ENV, &self.config.workspace_root)
+            // Issue #3943: the child is a headless `claude -p "/loom:sweep N"`
+            // session. In print mode the Claude Code harness terminates
+            // still-running background tasks — the sweep's dispatched
+            // Builder/Judge subagents — after a 600s ceiling and exits the
+            // session, killing any role phase that runs >10 minutes mid-build
+            // and causing loom:building<->loom:issue label ping-pong. Disable
+            // the ceiling (0 = no cap) explicitly on the child env so a long
+            // Builder/Judge phase runs to completion. `spawn-claude.sh` also
+            // sets this (belt-and-suspenders), but we pin it here too so the
+            // daemon dispatch path does not depend on the wrapper doing it.
+            .env(BG_WAIT_CEILING_ENV, "0")
             // Issue #3730: pin the child's cwd to the resolved workspace root
             // so the child's relative `.loom/config.json` read
             // (loom_tools/sweep_experiment.py) and archive-transcripts.sh's
@@ -3151,6 +3170,7 @@ mod tests {
   printf 'LOOM_TRANSCRIPT_ARCHIVE=%s\n' "${{LOOM_TRANSCRIPT_ARCHIVE:-unset}}"
   printf 'LOOM_SWEEP_CLAIM_OWNED=%s\n' "${{LOOM_SWEEP_CLAIM_OWNED:-unset}}"
   printf 'LOOM_TERMINAL_ID=%s\n' "${{LOOM_TERMINAL_ID:-unset}}"
+  printf 'CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=%s\n' "${{CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS:-unset}}"
 }} >> "{rec}" 2>&1
 exit 0
 "#,
@@ -3371,6 +3391,34 @@ exit 0
         assert!(
             recorded.contains("LOOM_SWEEP_CLAIM_OWNED=4243"),
             "expected claim-ownership marker for issue 4243; got: {recorded}"
+        );
+    }
+
+    /// Issue #3943: `spawn_child` pins
+    /// `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0` on the dispatched child env so
+    /// the print-mode harness does not reap the sweep's long-running
+    /// Builder/Judge background subagents at the 600s ceiling (which caused
+    /// loom:building<->loom:issue label ping-pong). The value is exactly "0"
+    /// (no cap).
+    #[test]
+    #[serial]
+    fn dispatch_disables_print_bg_wait_ceiling() {
+        let dir = tempdir().unwrap();
+        let (mut registry, record_log) = fixture_registry(dir.path());
+
+        let outcome = registry
+            .dispatch(&SweepKind::Issue(4244), None, None, None, None)
+            .expect("dispatch should succeed");
+
+        let needle = format!("LOOM_TERMINAL_ID=daemon-{}", outcome.sweep_id);
+        assert!(
+            wait_for_contents(&record_log, &needle, 10000),
+            "fake spawn-claude.sh did not finish writing within 10s"
+        );
+        let recorded = std::fs::read_to_string(&record_log).unwrap();
+        assert!(
+            recorded.contains("CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0"),
+            "expected print-mode bg-wait ceiling disabled (=0); got: {recorded}"
         );
     }
 


### PR DESCRIPTION
Closes #3943

## Problem

Daemon-spawned sweep children run as headless `claude -p "/loom:sweep N"` sessions. In print mode the Claude Code harness terminates still-running background tasks — the sweep's dispatched Builder/Judge subagents — after a **600s ceiling** and exits the session. Any role phase taking >10 minutes is killed mid-build, causing `loom:building`↔`loom:issue` label ping-pong and churn.

## Fix

Export `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0` (0 = no cap) into every daemon-spawned sweep child, on **both** spawn paths:

1. **`defaults/scripts/spawn-claude.sh`** — set before `exec claude` using the `: "${CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS:=0}"` default-assignment idiom, so an operator override (e.g. a non-zero ceiling exported in the environment) is **preserved**. Harmless for interactive use.
2. **`loom-daemon/src/sweep_registry.rs`** — `SweepRegistry::spawn_child` pins `.env(BG_WAIT_CEILING_ENV, "0")` explicitly on the child `Command`, matching the existing explicit-env pattern (`LOOM_WORKSPACE`, `LOOM_SWEEP_CLAIM_OWNED`). A new `BG_WAIT_CEILING_ENV` constant is defined next to `WORKSPACE_ENV`. Belt-and-suspenders alongside the wrapper so the daemon dispatch path does not depend on the wrapper doing it.

## Tests

- **spawn-claude.sh** (`test-spawn-claude.sh`): the stub `claude` now echoes the ceiling; new asserts verify the default (`ceiling=0`) **and** that an operator-set `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=120000` is preserved.
- **Rust** (`sweep_registry.rs`): new `dispatch_disables_print_bg_wait_ceiling` unit test asserts the dispatched child env carries `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0` (the fixture records it).

### Test evidence

```
# Rust
test sweep_registry::tests::dispatch_disables_print_bg_wait_ceiling ... ok
cargo test --lib dispatch → 53 passed; 0 failed

# Shell (test-spawn-claude.sh)
PASS: spawn-claude exports CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 by default (#3943)
PASS: spawn-claude preserves an operator-set wait ceiling (#3943)
```

**Note on pre-existing failures**: `test-spawn-claude.sh` reports 3 failures (`no LOOM_MODEL...emits NO --model`, `model=default log line`, `LOOM_EFFORT env injects --effort`). These reproduce identically on unmodified `main` (they are environmental — LOOM_MODEL/LOOM_EFFORT/editable-install related) and are **not** introduced by this change; this branch adds exactly +2 passing tests (65→67).

## Acceptance criteria

- [x] Env var set on **both** the direct spawn-claude path AND the daemon spawn_child path.
- [x] A test asserts its presence in the spawn env on each path.
- [x] Existing interactive behavior unchanged (operator override preserved; harmless when unset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)