### PR TITLE
fix(daemon): pin explicit non-premium model on autonomous dispatch (#3944)

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -793,6 +793,7 @@ concurrency ceiling 5" and share it with the team:
 ```json
 {
   "autonomous": {
+    "model": "sonnet",
     "workFinder": {
       "enabled": true,
       "intervalSecs": 60,
@@ -823,6 +824,7 @@ exactly like `main_health_gate::read_build_gate_config`.
 
 | Config key | Env override | Default | Notes |
 |------------|--------------|---------|-------|
+| `autonomous.model` | *(per-dispatch `dispatch_sweep` `model` param)* | `sonnet` | Model pinned on **every** daemon-dispatched child (work-finder, epic supervisor, and `dispatch_sweep` when its `model` param is absent). See below (#3944) |
 | `autonomous.workFinder.enabled` | `LOOM_WORK_FINDER` | `false` | Master on/off for the finder loop |
 | `autonomous.workFinder.intervalSecs` | `LOOM_WORK_FINDER_INTERVAL_SECS` | `60` | Zero/invalid → default |
 | `autonomous.workFinder.maxConcurrent` | `LOOM_WORK_FINDER_MAX_CONCURRENT` | `3` | Operator **ceiling**, not a fixed target |
@@ -833,6 +835,30 @@ exactly like `main_health_gate::read_build_gate_config`.
 | `autonomous.watchdog.intervalSecs` | `LOOM_SWEEP_WATCHDOG_INTERVAL_SECS` | `30` | Watchdog probe cadence (shared by all three backstops) |
 | `autonomous.watchdog.reviewStall` | `LOOM_SWEEP_REVIEW_STALL` | `true` | Review-phase stall watchdog on/off (#3910) |
 | `autonomous.watchdog.reviewStallTimeoutSecs` | `LOOM_SWEEP_REVIEW_STALL_TIMEOUT_SECS` | `2700` | Log-silence window before a hung Judge/Doctor sweep is re-dispatched |
+
+**Autonomous dispatch model (`autonomous.model`, #3944).** A daemon-dispatched
+child is a headless `claude -p "/loom:sweep N"` process. Without an explicit
+`--model`, it inherits whatever model the operator last configured in their
+**interactive** CLI — which on the v0.15.0 canary was a premium tier that meters
+premium usage credits and hard-failed every spawn with "out of usage credits". To
+stop an autonomous fleet from ever silently inheriting a premium interactive
+default, the daemon now pins an explicit model on **every** auto-dispatch
+(work-finder sweeps, epic-supervisor role/child dispatches) and on
+`dispatch_sweep` when its `model` param is absent. The resolved model is chosen by
+this precedence, highest first:
+
+1. **`dispatch_sweep` `model` param** — an explicit per-dispatch request always
+   wins (unchanged from #3477).
+2. **`autonomous.model`** in `.loom/config.json` — the per-repo default for all
+   autonomous dispatch.
+3. **Shipped default `sonnet`** — a deliberately **non-premium** tier (fast +
+   cost-appropriate for the bulk of build work). Never a premium tier.
+
+Empty/whitespace values are treated as unset at every tier. The resolved model
+and the tier that supplied it are named in the daemon dispatch log line
+(`… model=<m> (source=param|config|default)`), and the model is forwarded to the
+child via the existing `--model` plumbing (#3705). Set `autonomous.model` to
+`opus` (or any valid model id) to raise the autonomous default per-repo.
 
 **Startup-race mitigation (#3887).** Rapid back-to-back dispatch (the work
 finder draining a backlog in one tick) could wedge some `claude` children at

--- a/loom-daemon/src/epic_supervisor.rs
+++ b/loom-daemon/src/epic_supervisor.rs
@@ -1336,11 +1336,31 @@ pub mod forge {
 
     impl EpicDispatcher for SpawnDispatcher {
         fn dispatch_role(&mut self, epic: u32, shape: &DispatchShape) -> Result<()> {
+            // Autonomous dispatch model (issue #3944): pin an EXPLICIT,
+            // non-premium model so this auto-dispatched role process never
+            // inherits the operator's interactive CLI default. Resolved from the
+            // registry's workspace root (`autonomous.model` config > shipped
+            // default); no per-dispatch override tier here.
+            let repo_root = {
+                let reg = self
+                    .registry
+                    .lock()
+                    .map_err(|e| anyhow!("sweep registry mutex poisoned: {e}"))?;
+                reg.config().workspace_root.clone()
+            };
+            let (model, source) = crate::sweep_registry::resolve_dispatch_model(&repo_root, None);
+            log::info!(
+                "epic_supervisor: dispatching {} for epic #{epic} with model={model} (source={})",
+                shape.role,
+                source.as_str()
+            );
             // Spawn-and-wait: the burst must complete before we return so the
             // supervisor's #3707 guard genuinely serializes it.
             let mut cmd = Command::new(&self.spawn_bin);
             cmd.arg("-p")
                 .arg(&shape.prompt)
+                .arg("--model")
+                .arg(&model)
                 .arg("--dangerously-skip-permissions")
                 .stdin(Stdio::null())
                 .stdout(Stdio::null())
@@ -1366,10 +1386,21 @@ pub mod forge {
                 .registry
                 .lock()
                 .map_err(|e| anyhow!("sweep registry mutex poisoned: {e}"))?;
+            // Autonomous dispatch model (issue #3944): resolve an EXPLICIT
+            // non-premium model (`autonomous.model` config > shipped default) so
+            // the epic child never inherits the operator's interactive CLI
+            // default. No per-dispatch override tier here.
+            let repo_root = reg.config().workspace_root.clone();
+            let (model, source) = crate::sweep_registry::resolve_dispatch_model(&repo_root, None);
+            log::info!(
+                "epic_supervisor: dispatching child #{child} for epic #{_epic} with \
+                 model={model} (source={})",
+                source.as_str()
+            );
             // Idempotency key + the registry's claim lock make a re-dispatch of
             // an already-running child a no-op.
             let key = format!("epic-child-{child}");
-            reg.dispatch(&SweepKind::Issue(child), Some(key), None, None, None)
+            reg.dispatch(&SweepKind::Issue(child), Some(key), Some(&model), None, None)
                 .map(|_| ())
         }
     }

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -1158,10 +1158,24 @@ fn handle_request(
             let target =
                 resolve_registry(sweep_registry, workspace_pool, workspace_root.as_deref());
             let mut sr = target.lock().expect("Sweep registry mutex poisoned");
+            // Model resolution (issue #3944): an explicit `model` param still
+            // wins, but an ABSENT one falls back to `autonomous.model` in
+            // `.loom/config.json` and then the shipped non-premium default —
+            // never the operator's interactive CLI default. This mirrors the
+            // autonomous work-finder / epic-supervisor dispatch paths so every
+            // daemon-dispatched child is pinned to an explicit model.
+            let repo_root = sr.config().workspace_root.clone();
+            let (resolved_model, model_source) =
+                crate::sweep_registry::resolve_dispatch_model(&repo_root, model.as_deref());
+            log::info!(
+                "dispatch_sweep: {:?} with model={resolved_model} (source={})",
+                kind,
+                model_source.as_str()
+            );
             match sr.dispatch(
                 &kind,
                 idempotency_key,
-                model.as_deref(),
+                Some(&resolved_model),
                 effort.as_deref(),
                 depends_on,
             ) {

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -92,6 +92,88 @@ pub const BG_WAIT_CEILING_ENV: &str = "CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS";
 /// "recently exited sweeps should still show up in `list_sweeps`".
 pub const TERMINAL_RETENTION_SECS: i64 = 3600;
 
+/// Issue #3944: the shipped default model for **autonomous / daemon-dispatched**
+/// sweep children when neither an explicit dispatch `model` param nor an
+/// `autonomous.model` config value is present.
+///
+/// This is deliberately a **non-premium tier**. Without it, a daemon-dispatched
+/// child (`claude -p "/loom:sweep N"`) emits **no** `--model` flag and inherits
+/// whatever model the operator last configured interactively — on the v0.15.0
+/// canary that was a premium tier (Fable 5) which meters premium usage credits
+/// and hard-failed every spawn with "out of usage credits". An autonomous fleet
+/// must never silently inherit a premium interactive default, so daemon dispatch
+/// always pins an explicit, cost-appropriate model. `sonnet` is chosen as the
+/// sane default (fast + cheap for the bulk of build work); override per-repo via
+/// `autonomous.model` in `.loom/config.json`, or per-dispatch via the
+/// `dispatch_sweep` `model` param.
+pub const DEFAULT_DISPATCH_MODEL: &str = "sonnet";
+
+/// Issue #3944: which tier of the dispatch-model precedence chain supplied the
+/// resolved model. Surfaced in the daemon dispatch log line so an operator can
+/// tell *why* a child is running a given model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelSource {
+    /// An explicit `dispatch_sweep` `model` param (highest precedence).
+    Param,
+    /// `autonomous.model` in `.loom/config.json`.
+    Config,
+    /// The shipped [`DEFAULT_DISPATCH_MODEL`] fallback (never a premium tier).
+    Default,
+}
+
+impl ModelSource {
+    /// A stable lower-case label for logging (`param` / `config` / `default`).
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ModelSource::Param => "param",
+            ModelSource::Config => "config",
+            ModelSource::Default => "default",
+        }
+    }
+}
+
+/// Read `autonomous.model` from `<repo_root>/.loom/config.json`, soft-failing to
+/// `None` on any error (missing file, malformed JSON, absent `autonomous` /
+/// `model` key, empty/whitespace string). Mirrors the soft-fail contract of the
+/// other `autonomous.*` config readers (`work_finder::read_work_finder_config`,
+/// `main_health_gate::read_autonomous_gate_config`).
+#[must_use]
+pub fn read_autonomous_model(repo_root: &Path) -> Option<String> {
+    let path = repo_root.join(".loom").join("config.json");
+    let contents = std::fs::read_to_string(&path).ok()?;
+    let config: serde_json::Value = serde_json::from_str(&contents).ok()?;
+    config
+        .get("autonomous")?
+        .get("model")?
+        .as_str()
+        .map(str::trim)
+        .filter(|m| !m.is_empty())
+        .map(String::from)
+}
+
+/// Issue #3944: resolve the model a daemon-dispatched child should run with,
+/// per the precedence **explicit dispatch `model` param > `autonomous.model` in
+/// `.loom/config.json` > shipped [`DEFAULT_DISPATCH_MODEL`]**. Empty/whitespace
+/// strings are treated as unset at every tier. Returns the resolved model plus
+/// the [`ModelSource`] that supplied it (for the dispatch log line).
+///
+/// All autonomous dispatch paths (work-finder, epic supervisor) resolve with
+/// `explicit = None` so they never fall through to the CLI-inherited default;
+/// `dispatch_sweep` passes its optional `model` param as `explicit` so an
+/// explicit request still wins, and an absent one still lands on the shipped
+/// default rather than the operator's interactive CLI default.
+#[must_use]
+pub fn resolve_dispatch_model(repo_root: &Path, explicit: Option<&str>) -> (String, ModelSource) {
+    if let Some(m) = explicit.map(str::trim).filter(|m| !m.is_empty()) {
+        return (m.to_string(), ModelSource::Param);
+    }
+    if let Some(m) = read_autonomous_model(repo_root) {
+        return (m, ModelSource::Config);
+    }
+    (DEFAULT_DISPATCH_MODEL.to_string(), ModelSource::Default)
+}
+
 /// Issue #3730: experiment-related env vars forwarded to the detached sweep
 /// child via an EXPLICIT ALLOWLIST (never a blanket env_clear/copy). Byte-exact
 /// names verified against `loom_tools/sweep_experiment.py` (`LOOM_MODEL_EXPERIMENT`,
@@ -3482,6 +3564,93 @@ exit 0
             None,
             "empty model must be recorded as None on the SweepInfo entry"
         );
+    }
+
+    // ========================================================================
+    // Issue #3944 — dispatch-model resolution (precedence + source)
+    // ========================================================================
+
+    /// Write a `.loom/config.json` under `root` with the given JSON body.
+    fn write_config(root: &Path, body: &str) {
+        let loom = root.join(".loom");
+        std::fs::create_dir_all(&loom).unwrap();
+        std::fs::write(loom.join("config.json"), body).unwrap();
+    }
+
+    /// With no `.loom/config.json` and no explicit param, resolution falls back
+    /// to the shipped non-premium default — NOT the CLI-inherited default.
+    #[test]
+    fn resolve_dispatch_model_falls_back_to_shipped_default() {
+        let dir = tempdir().unwrap();
+        let (model, source) = resolve_dispatch_model(dir.path(), None);
+        assert_eq!(model, DEFAULT_DISPATCH_MODEL);
+        assert_eq!(model, "sonnet", "shipped default must be a non-premium tier");
+        assert_eq!(source, ModelSource::Default);
+    }
+
+    /// `autonomous.model` in config wins over the shipped default when no
+    /// explicit param is supplied.
+    #[test]
+    fn resolve_dispatch_model_reads_autonomous_config() {
+        let dir = tempdir().unwrap();
+        write_config(dir.path(), r#"{"autonomous": {"model": "opus"}}"#);
+        let (model, source) = resolve_dispatch_model(dir.path(), None);
+        assert_eq!(model, "opus");
+        assert_eq!(source, ModelSource::Config);
+    }
+
+    /// An explicit dispatch `model` param wins over both config and the default
+    /// (the `dispatch_sweep` highest-precedence tier).
+    #[test]
+    fn resolve_dispatch_model_explicit_param_wins() {
+        let dir = tempdir().unwrap();
+        write_config(dir.path(), r#"{"autonomous": {"model": "opus"}}"#);
+        let (model, source) = resolve_dispatch_model(dir.path(), Some("claude-sonnet-4-6"));
+        assert_eq!(model, "claude-sonnet-4-6");
+        assert_eq!(source, ModelSource::Param);
+    }
+
+    /// Empty/whitespace values are treated as unset at every tier: an empty
+    /// explicit param falls through to config, and an empty config value falls
+    /// through to the shipped default.
+    #[test]
+    fn resolve_dispatch_model_treats_blank_as_unset() {
+        let dir = tempdir().unwrap();
+        // Empty explicit param + populated config → config wins.
+        write_config(dir.path(), r#"{"autonomous": {"model": "opus"}}"#);
+        let (model, source) = resolve_dispatch_model(dir.path(), Some("   "));
+        assert_eq!(model, "opus");
+        assert_eq!(source, ModelSource::Config);
+
+        // Blank config value → shipped default.
+        let dir2 = tempdir().unwrap();
+        write_config(dir2.path(), r#"{"autonomous": {"model": "  "}}"#);
+        let (model2, source2) = resolve_dispatch_model(dir2.path(), None);
+        assert_eq!(model2, DEFAULT_DISPATCH_MODEL);
+        assert_eq!(source2, ModelSource::Default);
+    }
+
+    /// A config with an `autonomous` block but no `model` key soft-falls to the
+    /// shipped default (no panic, no error).
+    #[test]
+    fn resolve_dispatch_model_absent_model_key_uses_default() {
+        let dir = tempdir().unwrap();
+        write_config(dir.path(), r#"{"autonomous": {"workFinder": {"enabled": true}}}"#);
+        assert_eq!(read_autonomous_model(dir.path()), None);
+        let (model, source) = resolve_dispatch_model(dir.path(), None);
+        assert_eq!(model, DEFAULT_DISPATCH_MODEL);
+        assert_eq!(source, ModelSource::Default);
+    }
+
+    /// Malformed JSON soft-fails to `None` (and thus the shipped default) rather
+    /// than propagating an error.
+    #[test]
+    fn resolve_dispatch_model_malformed_config_soft_fails() {
+        let dir = tempdir().unwrap();
+        write_config(dir.path(), "{ this is not valid json");
+        assert_eq!(read_autonomous_model(dir.path()), None);
+        let (model, _) = resolve_dispatch_model(dir.path(), None);
+        assert_eq!(model, DEFAULT_DISPATCH_MODEL);
     }
 
     /// Issue #3716: an `effort` dispatch param threads through to the spawn

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -1094,11 +1094,24 @@ pub mod forge {
                 .registry
                 .lock()
                 .map_err(|e| anyhow!("sweep registry mutex poisoned: {e}"))?;
+            // Autonomous dispatch model (issue #3944): resolve an EXPLICIT model
+            // (`autonomous.model` config > shipped non-premium default) so the
+            // spawned child never silently inherits the operator's interactive
+            // CLI default (which may be a premium tier that burns usage credits).
+            // No dispatch-param tier here — the work finder has no per-issue
+            // override — so `explicit = None`.
+            let repo_root = reg.config().workspace_root.clone();
+            let (model, source) = crate::sweep_registry::resolve_dispatch_model(&repo_root, None);
+            log::info!(
+                "work_finder: dispatching issue #{issue} with model={model} (source={})",
+                source.as_str()
+            );
             // Idempotency key + the registry's claim lock make a re-dispatch of
             // an already-running issue a no-op (`was_new = false`) or a loud
             // lock-collision error.
             let key = format!("workfinder-{issue}");
-            let outcome = reg.dispatch(&SweepKind::Issue(issue), Some(key), None, None, None)?;
+            let outcome =
+                reg.dispatch(&SweepKind::Issue(issue), Some(key), Some(&model), None, None)?;
             Ok(outcome.was_new)
         }
     }


### PR DESCRIPTION
Closes #3944

## Problem

Daemon-dispatched children (`claude -p "/loom:sweep N"`) emitted **no** `--model` flag, so they silently inherited whatever model the operator last configured in their **interactive** CLI. On the v0.15.0 canary that was a premium tier (Fable 5) which meters premium usage credits — every work-finder dispatch died at session start with "You're out of usage credits". An autonomous fleet must never inherit a premium interactive default.

## Fix

Resolve an **explicit** model on every daemon dispatch, with precedence:

1. `dispatch_sweep` `model` param (explicit per-dispatch request — unchanged from #3477)
2. `autonomous.model` in `.loom/config.json`
3. Shipped default **`sonnet`** — a deliberately non-premium tier

Forwarded via the existing `--model` plumbing (#3705). Empty/whitespace values are treated as unset at every tier.

### Shipped default: `sonnet`
Chosen as a fast, cost-appropriate non-premium tier for the bulk of build work. Existing dispatch-model tests and config used `sonnet`/`claude-sonnet-4-6`, so it matches surrounding convention. Override per-repo via `autonomous.model` (e.g. `"opus"`).

## Changes

- `loom-daemon/src/sweep_registry.rs` — new `DEFAULT_DISPATCH_MODEL` const, `ModelSource` enum, `read_autonomous_model()` (soft-fail config reader), `resolve_dispatch_model()`; 6 unit tests for precedence + soft-fail.
- `loom-daemon/src/work_finder.rs` — `RegistryDispatcher::dispatch` resolves (explicit=None) and passes the model; logs `model=<m> (source=…)`.
- `loom-daemon/src/epic_supervisor.rs` — `SpawnDispatcher::dispatch_sweep` AND `dispatch_role` resolve and pin `--model`.
- `loom-daemon/src/ipc.rs` — `DispatchSweep` handler resolves with the param as `explicit`, so an explicit param still wins and an absent one falls back to config/default (not the CLI-inherited default).
- `.loom/docs/daemon-reference.md` — autonomous block documents `autonomous.model` (config example, table row, prose subsection).

## Acceptance criteria

- [x] Work-finder / epic-supervisor auto-dispatches emit an explicit `--model` (config-driven; shipped default `sonnet` is non-premium).
- [x] `dispatch_sweep` explicit `model` still wins; absent config falls back to the shipped default rather than the CLI-inherited default.
- [x] Spawn/dispatch log line names the resolved model AND its source (param / config / default).
- [x] Docs: daemon-reference autonomous block documents `autonomous.model`.

## Testing

- `cargo build` — passes.
- `cargo clippy --lib` — clean.
- `cargo test --lib` — **741 passed, 1 failed**. The single failure (`ipc::tests::test_build_daemon_status_reports_halt_and_in_flight`, asserting `token_pool_size == 0`) is **pre-existing and environmental** — it fails identically on the clean base because this machine has a populated `~/.loom/tokens/` shared pool that the #3938 fallback counts. Unrelated to this change.
- 6 new unit tests (`resolve_dispatch_model_*`) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)