### PR TITLE
fix(test): isolate build_daemon_status test from host shared token pool (#3955)

### DIFF
--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -2424,6 +2424,12 @@ exit 0
         let empty_reg = dir.path().join("no-such-workspaces.json");
         std::env::set_var(REGISTRY_PATH_ENV, &empty_reg);
 
+        // Disable the shared machine-level pool fallback (#3940) so the
+        // token-pool assertions see only the tempdir workspace, not the
+        // host's real ~/.loom/tokens (empty value = operator opt-out).
+        let prev_shared = std::env::var("LOOM_SHARED_TOKENS_DIR").ok();
+        std::env::set_var("LOOM_SHARED_TOKENS_DIR", "");
+
         // Seed the pool with the default registry keyed at `root`.
         let pool = Arc::new(WorkspacePool::new(Arc::new(EventBus::new()), test_runtime_handle()));
         pool.seed(root.clone(), sr.clone());
@@ -2460,6 +2466,10 @@ exit 0
         assert!(report.main_health_gate_halted);
         assert!(report.per_repo[0].health_gate_halted);
 
+        match prev_shared {
+            Some(v) => std::env::set_var("LOOM_SHARED_TOKENS_DIR", v),
+            None => std::env::remove_var("LOOM_SHARED_TOKENS_DIR"),
+        }
         std::env::remove_var(REGISTRY_PATH_ENV);
     }
 


### PR DESCRIPTION
Fixes the red main on hosts with a bootstrapped shared machine-level pool.

`test_build_daemon_status_reports_halt_and_in_flight` (#3934) asserts `token_pool_size == 0` for a bare tempdir workspace, but #3940's shared-pool fallback makes `token_pool_size` read `~/.loom/tokens` when the per-repo pool is empty — environment-dependent failure (7 ≠ 0 on the canary host, green on hosts with no shared pool, which is why both PRs passed review individually).

Fix: disable the fallback for the test's duration via the documented empty-value opt-out (`LOOM_SHARED_TOKENS_DIR=""`) with save/restore, mirroring the tokens.rs test pattern. Audited siblings: the other two `token_pool_size` assertions are pure serde tests (no filesystem) and need no isolation.

Validated on the canary host (shared pool present, 7 tokens): `cargo test -p loom-daemon --lib test_build_daemon_status` → 2 passed. Operator fix-forward for red main (the health gate correctly halted loom dispatch, which also blocks the daemon from fixing this itself).

Closes #3955

🤖 Generated with [Claude Code](https://claude.com/claude-code)