### PR TITLE
fix(mcp): bound sendDaemonRequest so publish_event fails fast instead of hanging ~1800s (#3945)

### DIFF
--- a/mcp-loom/package.json
+++ b/mcp-loom/package.json
@@ -10,6 +10,7 @@
     "build": "tsc --noEmit && rm -rf dist && node esbuild.config.js",
     "build:bundle": "rm -rf dist && node esbuild.config.js",
     "typecheck": "tsc --noEmit",
+    "verify:daemon-timeout": "node scripts/verify-daemon-timeout.mjs",
     "watch": "tsc --watch --noEmit"
   },
   "dependencies": {
@@ -20,5 +21,8 @@
     "@types/node": "^22.18.10",
     "esbuild": "^0.27.3",
     "typescript": "^5.9.3"
+  },
+  "allowScripts": {
+    "esbuild@0.27.3": true
   }
 }

--- a/mcp-loom/scripts/verify-daemon-timeout.mjs
+++ b/mcp-loom/scripts/verify-daemon-timeout.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * Standalone verification for the bounded unary-request timeout (issue #3945).
+ *
+ * mcp-loom has no unit-test runner, so this self-contained script exercises
+ * the REAL `sendDaemonRequest` transport against stub Unix-socket servers:
+ *
+ *   1. Hang case  — server accepts the connection but never responds and never
+ *      closes. Assert the call REJECTS within the bounded timeout (well under
+ *      the 1800s MCP idle timeout that motivated the fix), with the greppable
+ *      "did not respond within" error.
+ *   2. Happy case — server writes a JSON response frame then ends. Assert the
+ *      call RESOLVES quickly and the timer was cleared (no regression to the
+ *      fast path used by dispatch_sweep / list_sweeps / publish_event).
+ *
+ * Run: node scripts/verify-daemon-timeout.mjs   (from the mcp-loom dir)
+ *
+ * No test framework or new runtime deps: it bundles `src/shared/daemon.ts`
+ * with the already-present esbuild devDependency and imports the result.
+ */
+
+import { build } from "esbuild";
+import net from "node:net";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { dirname } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO = join(__dirname, "..");
+
+async function bundleTransport(outDir) {
+  const outfile = join(outDir, "daemon.mjs");
+  await build({
+    entryPoints: [join(REPO, "src/shared/daemon.ts")],
+    bundle: true,
+    format: "esm",
+    platform: "node",
+    outfile,
+    logLevel: "silent",
+  });
+  return import(pathToFileURL(outfile).href);
+}
+
+/** Start a stub server on a temp unix socket. `onConn(socket)` handles it. */
+function startStubServer(sockPath, onConn) {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer(onConn);
+    server.on("error", reject);
+    server.listen(sockPath, () => resolve(server));
+  });
+}
+
+function closeServer(server) {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+let failures = 0;
+function check(name, ok, detail) {
+  if (ok) {
+    console.log(`  ok   ${name}`);
+  } else {
+    failures += 1;
+    console.error(`  FAIL ${name}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+async function main() {
+  const workDir = await mkdtemp(join(tmpdir(), "loom-3945-"));
+  const outDir = await mkdtemp(join(tmpdir(), "loom-3945-out-"));
+
+  // `SOCKET_PATH` in config.ts is a module-load-time constant read from
+  // LOOM_SOCKET_PATH, so it MUST be set before the transport bundle is
+  // imported. Both stub servers reuse this single path (each net server
+  // unlinks the socket file on close, so the second listen is clean).
+  const sockPath = join(workDir, "daemon.sock");
+  process.env.LOOM_SOCKET_PATH = sockPath;
+
+  const { sendDaemonRequest, resolveDaemonIpcTimeoutMs, DEFAULT_DAEMON_IPC_TIMEOUT_MS } =
+    await bundleTransport(outDir);
+
+  console.log("resolveDaemonIpcTimeoutMs / env-override");
+  check(
+    "default is DEFAULT_DAEMON_IPC_TIMEOUT_MS",
+    resolveDaemonIpcTimeoutMs() === DEFAULT_DAEMON_IPC_TIMEOUT_MS,
+    `got ${resolveDaemonIpcTimeoutMs()}`
+  );
+  process.env.LOOM_DAEMON_IPC_TIMEOUT_MS = "1234";
+  check("env override honored", resolveDaemonIpcTimeoutMs() === 1234);
+  process.env.LOOM_DAEMON_IPC_TIMEOUT_MS = "-5";
+  check("invalid env falls back to default", resolveDaemonIpcTimeoutMs() === DEFAULT_DAEMON_IPC_TIMEOUT_MS);
+  delete process.env.LOOM_DAEMON_IPC_TIMEOUT_MS;
+
+  // ---- Case 1: hang (accept, never respond) ----
+  console.log("hang case (accept, never respond)");
+  // Hold the connection open indefinitely; never write, never end.
+  const heldSockets = [];
+  const hangServer = await startStubServer(sockPath, (sock) => heldSockets.push(sock));
+
+  const TIMEOUT = 400;
+  const started = Date.now();
+  let rejectedErr = null;
+  try {
+    await sendDaemonRequest({ type: "PublishEvent", payload: {} }, TIMEOUT);
+  } catch (e) {
+    rejectedErr = e;
+  }
+  const elapsed = Date.now() - started;
+  check("rejected (did not hang)", rejectedErr !== null);
+  check(
+    "rejected within bounded window",
+    elapsed < TIMEOUT + 600,
+    `elapsed=${elapsed}ms`
+  );
+  check(
+    "error names timeout + request type",
+    !!rejectedErr &&
+      /did not respond within \d+ms/.test(rejectedErr.message) &&
+      rejectedErr.message.includes("PublishEvent"),
+    rejectedErr && rejectedErr.message
+  );
+  for (const s of heldSockets) s.destroy();
+  await closeServer(hangServer);
+
+  // ---- Case 2: happy path (respond then end) ----
+  console.log("happy path (respond then end)");
+  const okServer = await startStubServer(sockPath, (sock) => {
+    sock.on("data", () => {
+      sock.write(JSON.stringify({ type: "EventPublished", payload: { topic: "t", receivers: 0 } }));
+      sock.write("\n");
+      sock.end();
+    });
+  });
+
+  const okStart = Date.now();
+  let okResp = null;
+  let okErr = null;
+  try {
+    okResp = await sendDaemonRequest({ type: "PublishEvent", payload: {} }, 2000);
+  } catch (e) {
+    okErr = e;
+  }
+  const okElapsed = Date.now() - okStart;
+  check("resolved without error", okErr === null, okErr && okErr.message);
+  check("resolved with expected payload", !!okResp && okResp.type === "EventPublished");
+  check("resolved fast (timer cleared, no hang)", okElapsed < 1000, `elapsed=${okElapsed}ms`);
+  await closeServer(okServer);
+
+  // Give the process a beat to confirm no lingering timer keeps it alive
+  // (a leaked setTimeout would delay exit by the full timeout window).
+  delete process.env.LOOM_SOCKET_PATH;
+  await rm(workDir, { recursive: true, force: true });
+  await rm(outDir, { recursive: true, force: true });
+
+  if (failures > 0) {
+    console.error(`\n${failures} check(s) failed.`);
+    process.exit(1);
+  }
+  console.log("\nAll checks passed.");
+}
+
+main().catch((e) => {
+  console.error("verification crashed:", e);
+  process.exit(1);
+});

--- a/mcp-loom/src/shared/daemon.ts
+++ b/mcp-loom/src/shared/daemon.ts
@@ -45,19 +45,101 @@ export interface StreamSubscribeResult {
 }
 
 /**
+ * Default bound (ms) for a unary daemon request when neither a per-call
+ * override nor the `LOOM_DAEMON_IPC_TIMEOUT_MS` env override is supplied.
+ *
+ * Kept intentionally small (a couple of seconds) so a fire-and-forget ack
+ * like `publish_event` fails fast instead of hanging until the outer ~1800s
+ * MCP idle timeout aborts the whole tool call (issue #3945). Callers whose
+ * request genuinely takes longer than an immediate ack — `dispatch_sweep`
+ * (spawns a child under the registry mutex) and `cancel_sweep` (blocks for
+ * the SIGTERM→grace→SIGKILL window) — pass an explicit wider `timeoutMs`
+ * rather than raising this global default.
+ */
+export const DEFAULT_DAEMON_IPC_TIMEOUT_MS = 2000;
+
+/**
+ * Resolve the default unary-request timeout (ms).
+ *
+ * Reads the `LOOM_DAEMON_IPC_TIMEOUT_MS` env override — a positive integer
+ * number of milliseconds — and falls back to {@link DEFAULT_DAEMON_IPC_TIMEOUT_MS}
+ * for an absent, non-numeric, zero, or negative value.
+ */
+export function resolveDaemonIpcTimeoutMs(): number {
+  const raw = process.env.LOOM_DAEMON_IPC_TIMEOUT_MS;
+  if (raw !== undefined && raw.trim().length > 0) {
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isInteger(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return DEFAULT_DAEMON_IPC_TIMEOUT_MS;
+}
+
+/**
  * Send a request to the Loom daemon and get the response
  *
  * Uses Unix domain socket to communicate with the running daemon.
  * The daemon expects JSON-encoded requests and returns JSON-encoded responses.
  *
+ * A bounded timeout (issue #3945) guarantees this Promise always settles: if
+ * the daemon accepts the connection but never writes a response frame and
+ * never closes the socket (bridge/protocol skew, a blocked accept loop under
+ * multi-repo load, or a request-variant mismatch), the timer fires and the
+ * Promise rejects with a clear, greppable error instead of hanging until the
+ * outer ~1800s MCP idle timeout. The reject surfaces through each caller's
+ * existing try/catch as a returned `{ success: false, error }`, preserving the
+ * sweep skill's soft-failure path (a dead bus never blocks a sweep).
+ *
  * @param request - The request object to send
+ * @param timeoutMs - Optional per-call timeout override (ms). When omitted,
+ *   falls back to {@link resolveDaemonIpcTimeoutMs} (env override or the small
+ *   default). A non-positive / non-finite value is ignored.
  * @returns The parsed response from the daemon
- * @throws Error if connection fails or response cannot be parsed
+ * @throws Error if connection fails, the response cannot be parsed, or the
+ *   daemon does not respond within the timeout.
  */
-export async function sendDaemonRequest(request: unknown): Promise<unknown> {
+export async function sendDaemonRequest(
+  request: unknown,
+  timeoutMs?: number
+): Promise<unknown> {
+  const effectiveTimeout =
+    typeof timeoutMs === "number" && Number.isFinite(timeoutMs) && timeoutMs > 0
+      ? timeoutMs
+      : resolveDaemonIpcTimeoutMs();
+  const requestType =
+    request && typeof request === "object" && "type" in request
+      ? String((request as { type: unknown }).type)
+      : "unknown";
+
   return new Promise((resolve, reject) => {
     const socket = new Socket();
     let buffer = "";
+    let settled = false;
+    let timer: NodeJS.Timeout | null = null;
+
+    const clearTimer = () => {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    };
+
+    // Guard against double-settle: a late `end`/`error` after a timeout
+    // reject (or vice-versa) must not call resolve/reject twice.
+    const settleResolve = (value: unknown) => {
+      if (settled) return;
+      settled = true;
+      clearTimer();
+      resolve(value);
+    };
+    const settleReject = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      clearTimer();
+      if (!socket.destroyed) socket.destroy();
+      reject(error);
+    };
 
     socket.on("data", (data) => {
       buffer += data.toString();
@@ -66,15 +148,29 @@ export async function sendDaemonRequest(request: unknown): Promise<unknown> {
     socket.on("end", () => {
       try {
         const response = JSON.parse(buffer);
-        resolve(response);
+        settleResolve(response);
       } catch (error) {
-        reject(new Error(`Failed to parse daemon response: ${error}`));
+        settleReject(new Error(`Failed to parse daemon response: ${error}`));
       }
     });
 
     socket.on("error", (error) => {
-      reject(new Error(`Failed to connect to Loom daemon at ${SOCKET_PATH}: ${error.message}`));
+      settleReject(
+        new Error(`Failed to connect to Loom daemon at ${SOCKET_PATH}: ${error.message}`)
+      );
     });
+
+    // Arm the timer up front so it bounds the entire operation — connect,
+    // write, and the wait for the response frame.
+    timer = setTimeout(() => {
+      settleReject(
+        new Error(
+          `Loom daemon did not respond within ${effectiveTimeout}ms at ${SOCKET_PATH} ` +
+            `(request type ${requestType}) — daemon may be unreachable or its MCP/IPC ` +
+            `bridge is not answering`
+        )
+      );
+    }, effectiveTimeout);
 
     socket.connect(SOCKET_PATH, () => {
       socket.write(JSON.stringify(request));

--- a/mcp-loom/src/tools/sweeps.ts
+++ b/mcp-loom/src/tools/sweeps.ts
@@ -20,7 +20,36 @@
  */
 
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
-import { sendDaemonRequest, sendDaemonStreamRequest } from "../shared/daemon.js";
+import {
+  resolveDaemonIpcTimeoutMs,
+  sendDaemonRequest,
+  sendDaemonStreamRequest,
+} from "../shared/daemon.js";
+
+// ============================================================================
+// Per-call IPC timeouts (issue #3945)
+// ============================================================================
+//
+// Most unary calls (publish_event, list_sweeps, get_sweep_status,
+// tail_sweep_log) are immediate acks and use the small default bound in
+// `sendDaemonRequest`. Two calls legitimately take longer than an immediate
+// ack and pass an explicit wider timeout so the bounded-timeout fix does not
+// regress them:
+//
+//   - dispatch_sweep: the daemon spawns the sweep child (token selection +
+//     spawn-claude.sh) while holding the registry mutex before it acks.
+//   - cancel_sweep: the daemon blocks for the SIGTERM -> grace -> SIGKILL
+//     window (grace_secs, default 30) before returning the completed-cancel
+//     ack.
+//
+// Each still resolves to a bounded value — never the ~1800s hang — and honors
+// a higher `LOOM_DAEMON_IPC_TIMEOUT_MS` env override via `Math.max`.
+
+/** Wider bound for `dispatch_sweep`'s spawn-under-mutex ack. */
+const DISPATCH_TIMEOUT_MS = 30_000;
+
+/** Fixed headroom added on top of a cancel's grace window. */
+const CANCEL_TIMEOUT_BUFFER_MS = 30_000;
 
 // ============================================================================
 // Wire types
@@ -283,7 +312,7 @@ async function dispatchSweep(args: {
         // before; a value routes the sweep into that managed repo's registry.
         workspace_root: args.workspace_root ?? null,
       },
-    })) as DaemonResponse;
+    }, Math.max(DISPATCH_TIMEOUT_MS, resolveDaemonIpcTimeoutMs()))) as DaemonResponse;
 
     if (response.type === "SweepDispatched") {
       const payload = (response as DispatchResponse).payload;
@@ -381,10 +410,16 @@ async function cancelSweep(args: {
   | { success: false; error: string }
 > {
   try {
-    const response = (await sendDaemonRequest({
-      type: "CancelSweep",
-      payload: { sweep_id: args.sweep_id, grace_secs: args.grace_secs, workspace_root: args.workspace_root ?? null },
-    })) as DaemonResponse;
+    const response = (await sendDaemonRequest(
+      {
+        type: "CancelSweep",
+        payload: { sweep_id: args.sweep_id, grace_secs: args.grace_secs, workspace_root: args.workspace_root ?? null },
+      },
+      Math.max(
+        args.grace_secs * 1000 + CANCEL_TIMEOUT_BUFFER_MS,
+        resolveDaemonIpcTimeoutMs()
+      )
+    )) as DaemonResponse;
 
     if (response.type === "SweepCancelled") {
       return { success: true, payload: (response as SweepCancelledResponse).payload };


### PR DESCRIPTION
Closes #3945

## Root cause
`mcp-loom/src/shared/daemon.ts` → `sendDaemonRequest` is the unary request/response transport behind `publishEvent`, `dispatchSweep`, `listSweeps`, `getSweepStatus`, `tailSweepLog`, and `cancelSweep`. It created a socket, wrote the request, and resolved **only** on the socket `end` event — with **no timeout**. When the daemon accepted the connection but never wrote a response frame and never closed the socket (bridge/protocol skew, a blocked accept loop under multi-repo canary load, or a request-variant mismatch), the Promise neither resolved nor rejected. The socket sat open until the outer ~1800s MCP idle timeout killed the whole tool call — the reported `publish_event` hang. The sibling `sendDaemonStreamRequest` already had a duration timer; the unary path had none.

## Fix
- Added `DEFAULT_DAEMON_IPC_TIMEOUT_MS = 2000` and `resolveDaemonIpcTimeoutMs()`, which reads a positive-integer `LOOM_DAEMON_IPC_TIMEOUT_MS` env override and falls back to the default. `publish_event` now answers (ack or clean error) in **<2s** (AC1).
- `sendDaemonRequest(request, timeoutMs?)` arms a timer up front that bounds connect + write + response, clears it in the `end`/`error` handlers, and on expiry destroys the socket and rejects with a clear, greppable message naming the socket path, request type, and elapsed timeout: `Loom daemon did not respond within <N>ms at <SOCKET_PATH> (request type <T>) — daemon may be unreachable or its MCP/IPC bridge is not answering` (AC2 — fail fast on skew instead of hanging).
- A `settled` boolean guards against double-settle from a late `end`/`error` after a timeout reject.
- **No regression to the slow-but-legitimate callers:** `dispatch_sweep` spawns the child under the registry mutex before acking, and `cancel_sweep` blocks for the `SIGTERM → grace → SIGKILL` window (verified in `loom-daemon/src/ipc.rs`). Both pass explicit **wider** per-call timeouts via `Math.max(...)` (`dispatch` 30s; `cancel` = grace + 30s headroom) rather than raising the global default — still bounded, never the 1800s hang.

## Soft-failure path preserved (AC3)
The callers in `sweeps.ts` (e.g. `publishEvent`) already wrap the transport in try/catch and return `{ success: false, error }`. A bounded timeout reject therefore surfaces as a clean tool error, not a hang — the sweep skill's fire-and-forget semantics are unchanged, and a dead bus never blocks a sweep. Only the infinite hang was replaced with a bounded reject so the child's soft-failure handling can actually run.

## Verification
mcp-loom has no unit-test runner, so I added a self-contained `mcp-loom/scripts/verify-daemon-timeout.mjs` (`npm run verify:daemon-timeout`) that bundles the **real** transport with the already-present esbuild devDependency (no new deps) and asserts against stub Unix-socket servers:
1. **Hang case** — server accepts but never responds → call rejects within the bounded window with the greppable timeout error.
2. **Happy path** — server writes a JSON frame then ends → call resolves fast with the timer cleared (no regression to `dispatch_sweep`/`list_sweeps`).
3. Env-override parsing (`LOOM_DAEMON_IPC_TIMEOUT_MS`, invalid falls back to default).

Commands run:
- `npm run typecheck` (`tsc --noEmit`) → exit 0
- `npm run build` → exit 0 (rebuilt `dist/index.js`)
- `node scripts/verify-daemon-timeout.mjs` → all 9 checks passed

**Note on `dist/`:** `mcp-loom/dist/` is gitignored in this repo, so the rebuilt esbuild bundle is not committed — operators must run `npm run build` in `mcp-loom/` to ship the fix in the installed bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)