### PR TITLE
feat(daemon): per-token concurrency factor for the dynamic cap (#3947)

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -735,17 +735,45 @@ The concurrency cap is **not** a fixed value resolved once at startup. Every
 tick the finder recomputes
 
 ```
-dynamic_cap = min(healthy-token count, disk headroom, configured ceiling)
+dynamic_cap = min(healthy-token count × per-token concurrency, disk headroom, configured ceiling)
 ```
 
-from three live inputs, so pool/disk/backlog changes are honored without a
-daemon restart:
+from live inputs, so pool/disk/backlog changes are honored without a daemon
+restart:
 
 | Input | Source | Bound it enforces |
 |-------|--------|-------------------|
-| **healthy-token count** | `available` accounts in `{workspace}/.loom/tokens/.ranking` (`capacity::token_axis_limit`), falling back to the `*.token` count (`tokens::token_pool_size`) when no ranking exists | never over-subscribe a rotated OAuth account, and never dispatch to an exhausted/blocked one (#3902) — one live sweep per **healthy** account |
+| **healthy-token count** | `available` accounts in `{workspace}/.loom/tokens/.ranking` (`capacity::token_axis_limit`), falling back to the `*.token` count (`tokens::token_pool_size`) when no ranking exists | the count of accounts safe to dispatch to — never dispatch to an exhausted/blocked one (#3902) |
+| **per-token concurrency** | `LOOM_PER_TOKEN_CONCURRENCY` / `autonomous.perTokenConcurrency`, default **2** (#3947) | how many concurrent sweeps to allow **per healthy account**. A plan limit is a utilization-window token bucket, not a session count, so one healthy account can run several concurrent sessions. Before #3947 the implicit factor was `1` (one sweep per account), which collapsed the whole fleet to cap 1 when 6/7 accounts were at their weekly ceiling even though the single healthy account had ample session-window headroom |
 | **disk headroom** | `floor(free_gb / LOOM_PER_WORKTREE_GB)` on the worktree-root volume (`disk_headroom::disk_headroom_limit`, a Rust port of `disk-headroom.sh` that shells to `df -Pk`) | never provision more worktrees than the scratch volume can hold |
-| **configured ceiling** | `LOOM_WORK_FINDER_MAX_CONCURRENT` (repurposed from Phase A's fixed target into an operator ceiling) | hard operator upper bound regardless of pool/disk headroom |
+| **configured ceiling** | `LOOM_WORK_FINDER_MAX_CONCURRENT` (repurposed from Phase A's fixed target into an operator ceiling) | hard operator upper bound regardless of token/disk headroom |
+
+**Per-token concurrency factor (#3947).** The token axis is `healthy × factor`,
+not `healthy × 1`. The factor is resolved with the standard precedence **env
+(`LOOM_PER_TOKEN_CONCURRENCY`) > config (`autonomous.perTokenConcurrency`) >
+default (2)**; a zero/unparseable value at any layer is ignored, and the cap
+formula additionally clamps the factor to a floor of `1` so a mis-set `0` degrades
+to the pre-#3947 one-sweep-per-account behavior rather than dispatching nothing.
+Bounded **stacking**, not a 1:1 hard limit, is the correct response to a healthy
+account with session-window headroom — the #3909 rotating selection spread still
+fills **distinct** accounts first (via the persistent `.rotation_cursor`), only
+stacking multiple sweeps on one account when concurrency demand exceeds the
+healthy-account count. The `loom-daemon status` view spells the arithmetic out,
+e.g. `= min(healthy 1 × per-token 2 = 2, disk headroom 120, configured max 3)`.
+
+**Session-limit fault handling (#3947).** Stacking can occasionally trip a
+**concurrent-session-limit** fault on a token (the account is healthy but cannot
+start another *simultaneous* session right now). This is a **capacity** signal,
+not quota exhaustion, so `classify-error.sh` classifies it distinctly as
+`SESSION_LIMIT` (checked *before* `TOKEN_EXHAUSTED` so the "session limit" wording
+is not swallowed by the exhaustion regex). `claude-wrapper.sh` responds by
+re-selecting a **different** account and retrying **without** appending the
+current token to `.bad_tokens` — a capacity fault must never poison the healthy
+pool. Re-selection advances the rotation cursor so a healthy sibling is preferred,
+which backs off stacking for the saturated account; a bounded
+`LOOM_MAX_SESSION_LIMIT_RETRIES` (default 10) guards a fully-saturated pool from
+spinning, after which it falls through to normal transient backoff (still without
+marking the token bad).
 
 The **effective** per-tick concurrency is then `min(dynamic_cap, backlog_depth)`:
 `tick()` iterates the ready `loom:issue` rows and stops at the cap, so
@@ -770,8 +798,10 @@ config (`autonomous.workFinder.enabled`, see "Operability" below). Tunables:
 `LOOM_WORK_FINDER_INTERVAL_SECS` (default 60 — tighter than the epic
 supervisor's 300s so the `loom:issue` backlog drains promptly),
 `LOOM_WORK_FINDER_MAX_CONCURRENT` (default 3 — the operator **ceiling** in the
-dynamic policy above, not a fixed target), and `LOOM_PER_WORKTREE_GB` (default 2
-— the per-worktree disk estimate the disk-headroom bound divides by). A zero or
+dynamic policy above, not a fixed target), `LOOM_PER_TOKEN_CONCURRENCY` (default 2
+— the per-healthy-token concurrency factor of the cap, #3947), and
+`LOOM_PER_WORKTREE_GB` (default 2 — the per-worktree disk estimate the
+disk-headroom bound divides by). A zero or
 unparseable value for any of these falls back to its default.
 
 > **Scope note**: the work finder dispatches **already-approved** `loom:issue`
@@ -839,6 +869,7 @@ concurrency ceiling 5" and share it with the team:
 {
   "autonomous": {
     "model": "sonnet",
+    "perTokenConcurrency": 2,
     "workFinder": {
       "enabled": true,
       "intervalSecs": 60,
@@ -873,6 +904,7 @@ exactly like `main_health_gate::read_build_gate_config`.
 | `autonomous.workFinder.enabled` | `LOOM_WORK_FINDER` | `false` | Master on/off for the finder loop |
 | `autonomous.workFinder.intervalSecs` | `LOOM_WORK_FINDER_INTERVAL_SECS` | `60` | Zero/invalid → default |
 | `autonomous.workFinder.maxConcurrent` | `LOOM_WORK_FINDER_MAX_CONCURRENT` | `3` | Operator **ceiling**, not a fixed target |
+| `autonomous.perTokenConcurrency` | `LOOM_PER_TOKEN_CONCURRENCY` | `2` | Concurrent sweeps **per healthy token** in the cap (#3947). Zero/invalid → default; clamped to a floor of 1 |
 | `autonomous.mainHealthGate.enabled` | `LOOM_MAIN_HEALTH_GATE` | `false` | Gate loop on/off |
 | `autonomous.dispatchStaggerMs` | `LOOM_SWEEP_DISPATCH_STAGGER_MS` | `2000` | Min gap between consecutive child spawns (#3887). `0` disables |
 | `autonomous.watchdog.enabled` | `LOOM_SWEEP_WATCHDOG` | `true` | Startup watchdog on/off (#3887). Also the master switch for the tick — mid-build-death (#3895) + review-stall (#3910) run in the same task |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ The Rust `loom-daemon` binary is the Tier 2 dispatch backend. It exposes a Unix-
 
 **By default the daemon is not a work generator** — with no autonomous config it does not poll the forge for `loom:issue` items, does not maintain a `shepherd-N` pool, and does not drive support roles on cron; work arrives only via `mcp__loom__dispatch_sweep` (operator-driven enqueue) and the GitHub Actions cron workflows. As of epics #3809 and #3842 the daemon *can* generate and dispatch its own work when **explicitly opted in** — both surfaces are default-off:
 
-- **Autonomous work finder** (#3810, `LOOM_WORK_FINDER` / `autonomous.workFinder`): polls the forge for open, already-approved `loom:issue` items and auto-dispatches sweeps, with work-driven concurrency bounded by `min(available work, healthy tokens, free disk, maxConcurrent)` (#3811) and a reactive main-health backstop (#3812, `LOOM_MAIN_HEALTH_GATE` / `autonomous.mainHealthGate`) that halts dispatch when `main` goes red. Enable/tune from the `autonomous` block in `.loom/config.json` (precedence **env > config > default**) and manage the raw process with `loom-daemon-start.sh` / `loom-daemon-stop.sh` — see [Autonomous work finder](.loom/docs/daemon-reference.md#autonomous-work-finder-3810) and §Operability, plus "Daemon Configuration (Tier 2)" below.
+- **Autonomous work finder** (#3810, `LOOM_WORK_FINDER` / `autonomous.workFinder`): polls the forge for open, already-approved `loom:issue` items and auto-dispatches sweeps, with work-driven concurrency bounded by `min(available work, healthy tokens × perTokenConcurrency, free disk, maxConcurrent)` (#3811, per-token factor #3947 — default 2, `LOOM_PER_TOKEN_CONCURRENCY` / `autonomous.perTokenConcurrency`) and a reactive main-health backstop (#3812, `LOOM_MAIN_HEALTH_GATE` / `autonomous.mainHealthGate`) that halts dispatch when `main` goes red. Enable/tune from the `autonomous` block in `.loom/config.json` (precedence **env > config > default**) and manage the raw process with `loom-daemon-start.sh` / `loom-daemon-stop.sh` — see [Autonomous work finder](.loom/docs/daemon-reference.md#autonomous-work-finder-3810) and §Operability, plus "Daemon Configuration (Tier 2)" below.
 - **Epic supervisor** (#3842): drives every open `loom:epic` issue through a derived-state fork-join model with a phase-join barrier, serializing child-issue creation behind the #3707 issue-creation mutex on a dedicated off-runtime OS thread — see [Epic supervisor](.loom/docs/daemon-reference.md#epic-supervisor-3842).
 
 For full surface documentation — IPC request/response variants, event-bus internals, registry behaviour, reaper semantics — see [`.loom/docs/daemon-reference.md`](.loom/docs/daemon-reference.md).
@@ -341,6 +341,7 @@ The Rust `loom-daemon` binary is the load-bearing Tier 2 dispatch backend. It is
 ```json
 {
   "autonomous": {
+    "perTokenConcurrency": 2,
     "workFinder": { "enabled": true, "intervalSecs": 60, "maxConcurrent": 5 },
     "mainHealthGate": { "enabled": true }
   }

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -686,6 +686,7 @@ See [`.loom/docs/daemon-reference.md`](.loom/docs/daemon-reference.md) for the w
 ```json
 {
   "autonomous": {
+    "perTokenConcurrency": 2,
     "workFinder": { "enabled": true, "intervalSecs": 60, "maxConcurrent": 5 },
     "mainHealthGate": { "enabled": true }
   }
@@ -727,7 +728,7 @@ Loom version.
 
 **Issue selection**: by default the daemon is **not a work generator** — it does not autonomously claim items from the `loom:issue` queue; work is operator-driven via `mcp__loom__dispatch_sweep`. (The `/loom:sweep` skill is the typical caller; Stage -1 backend detection picks an issue and dispatches it when both daemon and pool probes succeed.) As of epics #3809 and #3842 that default can be **opted out of** — both autonomous surfaces are default-off:
 
-- The autonomous **work finder** (above, `LOOM_WORK_FINDER` / `autonomous.workFinder`), when enabled, *does* poll the forge for open, already-approved `loom:issue` items and dispatch them, with work-driven concurrency bounded by `min(available work, healthy tokens, free disk, maxConcurrent)` (#3811) and a reactive main-health backstop (#3812, `LOOM_MAIN_HEALTH_GATE`) that halts dispatch when `main` goes red. See [Autonomous work finder](.loom/docs/daemon-reference.md#autonomous-work-finder-3810).
+- The autonomous **work finder** (above, `LOOM_WORK_FINDER` / `autonomous.workFinder`), when enabled, *does* poll the forge for open, already-approved `loom:issue` items and dispatch them, with work-driven concurrency bounded by `min(available work, healthy tokens × perTokenConcurrency, free disk, maxConcurrent)` (#3811, per-token factor #3947 — default 2, `LOOM_PER_TOKEN_CONCURRENCY` / `autonomous.perTokenConcurrency`) and a reactive main-health backstop (#3812, `LOOM_MAIN_HEALTH_GATE`) that halts dispatch when `main` goes red. See [Autonomous work finder](.loom/docs/daemon-reference.md#autonomous-work-finder-3810).
 - The **epic supervisor** (#3842), when enabled, drives every open `loom:epic` issue through a derived-state fork-join lifecycle (decompose → expand → phase-join barrier → close), serializing child-issue creation behind the #3707 issue-creation mutex on a dedicated off-runtime OS thread. See [Epic supervisor](.loom/docs/daemon-reference.md#epic-supervisor-3842).
 
 **Multi-repo workspace registry + priority tiers**: the one-per-machine daemon manages a set of repos listed in `~/.loom/workspaces.json`, edited with `loom-daemon workspace add|remove|list` (hot-applied — a running daemon re-reads the file each tick). Each entry carries an optional `priority` integer (**lower = higher priority**, default `100`; a pre-#3946 entry with no `priority` parses as `100`), set via `loom-daemon workspace add <path> --priority N` or `loom-daemon workspace set-priority <path> N` (#3946). The autonomous work-finder and epic supervisor order dispatch across repos by **(workspace priority asc, `loom:urgent` first, issue age asc)** and fill the single shared concurrency budget in that order, so higher-priority tool repos drain before a deep product/canary backlog. Strict priority is intentional (v1) — a permanently-full higher tier starves lower tiers; `loom-daemon status` shows each repo's tier. See [Per-workspace priority tiers](.loom/docs/daemon-reference.md#per-workspace-priority-tiers-3946).

--- a/defaults/scripts/claude-wrapper.sh
+++ b/defaults/scripts/claude-wrapper.sh
@@ -900,6 +900,59 @@ is_account_exhaustion() {
         | grep -qiE "hit your (limit|session limit|weekly limit)|hit\.your\.limit|monthly usage limit|out of extra usage"
 }
 
+# Return 0 if the captured output indicates a concurrent-session-limit fault
+# (#3947): the active account is healthy but cannot start another simultaneous
+# session right now. This is a capacity signal from per-token session stacking,
+# NOT quota exhaustion — the caller re-selects a different account WITHOUT
+# marking the current one bad. Defers to the shared classifier's distinct
+# SESSION_LIMIT category, with an inline regex fallback if the lib wasn't sourced.
+is_account_session_limit() {
+    local output="$1"
+    local exit_code="${2:-1}"
+
+    if declare -F classify_error >/dev/null 2>&1; then
+        [[ "$(classify_error "${output}" "${exit_code}")" == "SESSION_LIMIT" ]]
+        return
+    fi
+    [[ "${exit_code}" -ne 0 ]] && echo "${output}" \
+        | grep -qiE "concurrent (session|sessions|request)|maximum number of concurrent|too many concurrent|simultaneous session|another session is (already )?(active|running)"
+}
+
+# Re-select a DIFFERENT rotation account WITHOUT marking the current one bad
+# (#3947). Used for concurrent-session-limit faults: the account isn't broken,
+# it just can't take another simultaneous session, so we spread to a sibling and
+# retry. Advances the rotation cursor (loom_tools.tokens.select) so a healthy
+# sibling is preferred over re-picking the saturated account. Returns 0 when a
+# new token was exported, 1 when selection yielded nothing.
+reselect_account_no_mark() {
+    local ws pkg
+    ws="$(_resolve_token_workspace)"
+    pkg="$(_resolve_package_path "${ws}")"
+
+    local sel_json _sel_rc
+    set +e
+    sel_json="$(PYTHONPATH="${pkg}${PYTHONPATH:+:$PYTHONPATH}" \
+        "${LOOM_PYTHON}" -m loom_tools.tokens.select --workspace "${ws}" --json 2>/dev/null)"
+    _sel_rc=$?
+    set -e
+    if [[ ${_sel_rc} -ne 0 || -z "${sel_json}" ]]; then
+        return 1
+    fi
+
+    local new_key new_name
+    new_key="$(printf '%s' "${sel_json}" | "${LOOM_PYTHON}" -c 'import json,sys; print(json.load(sys.stdin)["key"])' 2>/dev/null || echo "")"
+    new_name="$(printf '%s' "${sel_json}" | "${LOOM_PYTHON}" -c 'import json,sys; print(json.load(sys.stdin)["name"])' 2>/dev/null || echo "")"
+    if [[ -z "${new_key}" ]]; then
+        return 1
+    fi
+
+    export CLAUDE_CODE_OAUTH_TOKEN="${new_key}"
+    ACTIVE_TOKEN_NAME="${new_name}"
+    export LOOM_TOKEN_NAME="${new_name}"
+    log_info "Re-selected OAuth account → '${new_name}' after concurrent-session limit (token NOT marked bad)"
+    return 0
+}
+
 # Echo a short human phrase describing why the account was considered
 # exhausted (used as the .bad_tokens reason string).
 _exhaustion_phrase() {
@@ -1445,6 +1498,13 @@ run_with_retry() {
     # bad, so re-selection could otherwise keep returning it forever.
     local rotations=0
     local max_rotations="${LOOM_MAX_ACCOUNT_ROTATIONS:-20}"
+    # Concurrent-session-limit bookkeeping (#3947). Distinct from account
+    # rotation: a session-limit fault is a *capacity* signal (the account is
+    # healthy but cannot start another simultaneous session), so we re-select a
+    # DIFFERENT account WITHOUT marking the current one bad and retry. Bounded by
+    # its own cap so a fully-saturated pool doesn't spin forever.
+    local session_limit_retries=0
+    local max_session_limit_retries="${LOOM_MAX_SESSION_LIMIT_RETRIES:-10}"
 
     # Recover CWD if it was deleted before we started
     if ! recover_cwd; then
@@ -1629,6 +1689,31 @@ run_with_retry() {
         fi
 
         log_warn "Claude CLI exited with code ${exit_code}"
+
+        # Concurrent-session-limit fault (#3947) → the active account is healthy
+        # but cannot start another simultaneous session. Re-select a DIFFERENT
+        # account WITHOUT marking this one bad (a capacity fault must not poison
+        # .bad_tokens and shrink the healthy pool) and retry the SAME attempt.
+        # Checked BEFORE is_account_exhaustion so the "session limit" wording is
+        # handled as a capacity signal, not quota exhaustion. Bounded by its own
+        # cap; when exhausted it falls through to the transient-backoff path
+        # (which retries on the next tick without poisoning the token).
+        if is_account_session_limit "${output}" "${exit_code}"; then
+            session_limit_retries=$((session_limit_retries + 1))
+            if [[ "${session_limit_retries}" -le "${max_session_limit_retries}" ]]; then
+                log_warn "Concurrent-session limit hit on '${ACTIVE_TOKEN_NAME:-?}' — backing off stacking for this account and re-selecting (attempt ${attempt}/${MAX_RETRIES} NOT consumed)"
+                if reselect_account_no_mark; then
+                    write_retry_state "running" "${attempt}"
+                    # Brief backoff so a different account's session frees up /
+                    # the cursor spreads load before retrying the same attempt.
+                    sleep "${LOOM_SESSION_LIMIT_BACKOFF:-5}"
+                    continue
+                fi
+                log_warn "Concurrent-session limit hit but re-selection found no alternate account — falling through to transient backoff"
+            else
+                log_warn "Concurrent-session-limit retry cap (${max_session_limit_retries}) reached — falling through to transient backoff (token still NOT marked bad)"
+            fi
+        fi
 
         # Account exhaustion (session / weekly / usage limit) → rotate to a
         # different account and retry WITHOUT consuming a MAX_RETRIES attempt

--- a/defaults/scripts/lib/classify-error.sh
+++ b/defaults/scripts/lib/classify-error.sh
@@ -9,6 +9,16 @@
 #       CWD_DELETED     — working directory was removed
 #       TOKEN_EXPIRED   — 401 / OAuth token expired (skip this token)
 #       TOKEN_EXHAUSTED — quota/weekly limit hit (rotate)
+#       SESSION_LIMIT   — concurrent-session-limit fault (issue #3947): the
+#                         account is NOT out of quota, it just cannot start
+#                         another *simultaneous* session right now (a capacity
+#                         fault from per-token session stacking). Callers must
+#                         re-select a different account and retry WITHOUT
+#                         marking the token bad — poisoning .bad_tokens for a
+#                         transient concurrency limit would wrongly shrink the
+#                         healthy pool. Classified BEFORE TOKEN_EXHAUSTED so the
+#                         "session limit" wording is not swallowed by the
+#                         weekly/usage-limit regex.
 #       MODEL_REFUSAL   — model safety classifier refused the turn
 #                         (stop_reason "refusal" on a non-zero-exit run);
 #                         a routing error, not a quality signal — the sweep
@@ -71,6 +81,19 @@ classify_error() {
     # Token expired (401 auth error) — this specific token is bad
     if echo "$output" | grep -qiE "401[^a-z]*authentication_error|OAuth token has expired|token has expired"; then
         echo "TOKEN_EXPIRED"
+        return
+    fi
+
+    # Concurrent-session-limit fault (issue #3947) — the account is healthy but
+    # cannot start another SIMULTANEOUS session right now. This is a capacity
+    # signal from per-token session stacking, NOT quota exhaustion, so it is
+    # classified distinctly and callers must NOT mark the token bad. Checked
+    # BEFORE TOKEN_EXHAUSTED because "concurrent session limit" contains the
+    # substring "session limit" that the exhaustion regex below also matches;
+    # the concurrency-specific wording ("concurrent", "simultaneous", "already
+    # running") disambiguates a capacity fault from a weekly/usage limit.
+    if echo "$output" | grep -qiE "concurrent (session|sessions|request)|maximum number of concurrent|too many concurrent|simultaneous session|another session is (already )?(active|running)"; then
+        echo "SESSION_LIMIT"
         return
     fi
 

--- a/defaults/scripts/tests/test-spawn-claude.sh
+++ b/defaults/scripts/tests/test-spawn-claude.sh
@@ -194,6 +194,38 @@ assert_eq "SUCCESS" "$result" "exit=0 mentioning 'hit your session limit' is SUC
 result=$(classify_error "The plan was out of extra usage headroom last week." 0)
 assert_eq "SUCCESS" "$result" "exit=0 mentioning 'out of extra usage' is SUCCESS (#3233/#3738)"
 
+# --- SESSION_LIMIT vectors (issue #3947) ---
+# A concurrent-session-limit fault is a capacity signal (per-token stacking), NOT
+# quota exhaustion, so it classifies distinctly as SESSION_LIMIT and callers must
+# NOT mark the token bad. Checked BEFORE TOKEN_EXHAUSTED so the "session limit"
+# substring is not swallowed by the exhaustion regex.
+
+# Vector #30: explicit concurrent session limit → SESSION_LIMIT
+result=$(classify_error "Error: you have reached your concurrent session limit" 1)
+assert_eq "SESSION_LIMIT" "$result" "concurrent session limit -> SESSION_LIMIT (#3947)"
+
+# Vector #31: "maximum number of concurrent sessions" → SESSION_LIMIT
+result=$(classify_error "maximum number of concurrent sessions reached" 1)
+assert_eq "SESSION_LIMIT" "$result" "maximum number of concurrent sessions -> SESSION_LIMIT (#3947)"
+
+# Vector #32: "too many concurrent" → SESSION_LIMIT
+result=$(classify_error "429: too many concurrent requests for this account" 1)
+assert_eq "SESSION_LIMIT" "$result" "too many concurrent -> SESSION_LIMIT (#3947)"
+
+# Vector #33: "another session is already running" → SESSION_LIMIT
+result=$(classify_error "another session is already active for this token" 1)
+assert_eq "SESSION_LIMIT" "$result" "another session already active -> SESSION_LIMIT (#3947)"
+
+# Vector #34 (DISAMBIGUATION): a WEEKLY "session limit" (no concurrency wording)
+# stays TOKEN_EXHAUSTED — the capacity classifier must not steal quota faults.
+result=$(classify_error "You've hit your session limit · resets 4pm" 1)
+assert_eq "TOKEN_EXHAUSTED" "$result" "weekly 'session limit' stays TOKEN_EXHAUSTED (#3947 disambiguation)"
+
+# Vector #35 (REGRESSION, #3233): exit-0 output mentioning concurrent sessions in
+# prose is STILL SUCCESS — exit-code-first ordering wins over the new pattern.
+result=$(classify_error "Note: agents pause on a concurrent session limit." 0)
+assert_eq "SUCCESS" "$result" "exit=0 mentioning 'concurrent session' is SUCCESS (#3233/#3947)"
+
 # ============================================================
 # Section 2: spawn-claude.sh dispatch (with stub `claude`)
 # ============================================================

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -509,6 +509,7 @@ pub fn build_daemon_status(
     let disk_headroom = crate::disk_headroom::disk_headroom_limit(workspace_root);
     let wf_config = crate::work_finder::read_work_finder_config(workspace_root);
     let configured_max = crate::work_finder::resolve_max_concurrent_with_config(&wf_config);
+    let per_token_concurrency = crate::work_finder::resolve_per_token_concurrency(&wf_config);
 
     // Token-capacity backpressure (#3902): back the token axis off from the flat
     // pool count toward the count of *healthy* accounts read from the rotation
@@ -518,10 +519,15 @@ pub fn build_daemon_status(
     let token_axis_limit = ranking.as_ref().map_or(token_pool_size, |r| r.available);
     let dynamic_cap = crate::work_finder::resolve_dynamic_max_concurrent(
         token_axis_limit,
+        per_token_concurrency,
         disk_headroom,
         configured_max,
     );
-    let token_bound = token_axis_limit <= disk_headroom && token_axis_limit <= configured_max;
+    // The token axis of the cap is `healthy × per-token` (#3947), so it is the
+    // binding constraint only when that *product* is the minimum.
+    let token_axis_effective = token_axis_limit.saturating_mul(per_token_concurrency.max(1));
+    let token_bound =
+        token_axis_effective <= disk_headroom && token_axis_effective <= configured_max;
     let capacity = crate::types::CapacityReport {
         ranking_present: ranking.is_some(),
         total_accounts: ranking.as_ref().map_or(token_pool_size, |r| r.total),
@@ -538,6 +544,7 @@ pub fn build_daemon_status(
         token_pool_size,
         disk_headroom,
         configured_max,
+        per_token_concurrency,
         dynamic_cap,
         // Top-level halt preserves its pre-#3930 single-workspace meaning: the
         // daemon's own primary workspace. Per-repo halt is in `per_repo`.
@@ -2360,6 +2367,7 @@ exit 0
             token_pool_size: 4,
             disk_headroom: 10,
             configured_max: 5,
+            per_token_concurrency: 2,
             dynamic_cap: 3,
             main_health_gate_halted: true,
             capacity: crate::types::CapacityReport {

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -459,9 +459,11 @@ async fn main() -> Result<()> {
     let _work_finder_handle = if work_finder::resolve_enabled(&work_finder_config) {
         let interval = work_finder::resolve_interval_with_config(&work_finder_config);
         let configured_max = work_finder::resolve_max_concurrent_with_config(&work_finder_config);
+        let per_token_concurrency = work_finder::resolve_per_token_concurrency(&work_finder_config);
         log::info!(
             "work_finder: enabled (multi-workspace, interval={}s, configured_max={configured_max}, \
-             dynamic cap = min(pool, disk, configured_max), global across workspaces)",
+             per_token_concurrency={per_token_concurrency}, \
+             dynamic cap = min(healthy tokens × per-token, disk, configured_max), global across workspaces)",
             interval.as_secs()
         );
         // Multi-workspace fan-out (#3928): re-reads `effective_roots()` each tick
@@ -472,6 +474,7 @@ async fn main() -> Result<()> {
             sweep_workspace.clone(),
             interval,
             configured_max,
+            per_token_concurrency,
             workspace_health_states.clone(),
             event_bus.clone(),
         ))
@@ -1014,11 +1017,15 @@ fn resolve_capacity(
                 .collect();
             let cap = loom_daemon::capacity::summarize_probe(pairs.iter().copied());
             let token_axis_limit = cap.healthy;
-            let effective_cap = token_axis_limit
+            // The token axis of the cap is `healthy × per-token` (#3947); treat a
+            // pre-#3947 wire `0` as the effective floor of 1.
+            let factor = report.per_token_concurrency.max(1);
+            let token_axis_effective = token_axis_limit.saturating_mul(factor);
+            let effective_cap = token_axis_effective
                 .min(report.disk_headroom)
                 .min(report.configured_max);
-            let token_bound = token_axis_limit <= report.disk_headroom
-                && token_axis_limit <= report.configured_max;
+            let token_bound = token_axis_effective <= report.disk_headroom
+                && token_axis_effective <= report.configured_max;
             return ResolvedCapacity {
                 source: "probe",
                 ranking_present: true,
@@ -1072,6 +1079,8 @@ fn print_status_json(
             "token_pool_size": report.token_pool_size,
             "disk_headroom": report.disk_headroom,
             "configured_max": report.configured_max,
+            "per_token_concurrency": report.per_token_concurrency.max(1),
+            "token_axis_effective": rc.token_axis_limit.saturating_mul(report.per_token_concurrency.max(1)),
             "effective": rc.effective_cap,
         },
         "capacity": {
@@ -1127,10 +1136,15 @@ fn print_status_human(report: &DaemonStatusReport, token_usage: Option<&serde_js
     // input, the Token-capacity summary, and the Per-token table all agree (#3936).
     let rc = resolve_capacity(report, token_usage);
 
+    let factor = report.per_token_concurrency.max(1);
     println!("\nDynamic concurrency cap: {}", rc.effective_cap);
     println!(
-        "  = min(healthy tokens {}, disk headroom {}, configured max {})",
-        rc.token_axis_limit, report.disk_headroom, report.configured_max
+        "  = min(healthy {} × per-token {} = {}, disk headroom {}, configured max {})",
+        rc.token_axis_limit,
+        factor,
+        rc.token_axis_limit.saturating_mul(factor),
+        report.disk_headroom,
+        report.configured_max
     );
 
     // Token-capacity backpressure section (#3902, source-unified in #3936).

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -641,7 +641,17 @@ pub struct DaemonStatusReport {
     /// Dynamic-cap input 3: the configured operator ceiling
     /// (`autonomous.workFinder.maxConcurrent` / `LOOM_WORK_FINDER_MAX_CONCURRENT`).
     pub configured_max: usize,
-    /// The effective dynamic concurrency cap — `min` of the three inputs above
+    /// The per-token concurrency factor (#3947): how many concurrent sweeps the
+    /// dynamic cap allows per *healthy* token. The token axis of the cap is
+    /// `healthy_tokens × per_token_concurrency`, not the old implicit
+    /// `× 1`. Resolved with precedence env (`LOOM_PER_TOKEN_CONCURRENCY`) >
+    /// config (`autonomous.perTokenConcurrency`) > default (2).
+    /// `#[serde(default)]` keeps pre-#3947 wire data / older clients compatible
+    /// (an absent field parses as `0`; the status renderer treats `< 1` as `1`).
+    #[serde(default)]
+    pub per_token_concurrency: usize,
+    /// The effective dynamic concurrency cap —
+    /// `min(token_axis × per_token_concurrency, disk_headroom, configured_max)`
     /// (`resolve_dynamic_max_concurrent`). This is the total-occupancy ceiling
     /// the work finder recomputes every tick.
     pub dynamic_cap: usize,

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -124,6 +124,23 @@ pub const WORK_FINDER_MAX_CONCURRENT_ENV: &str = "LOOM_WORK_FINDER_MAX_CONCURREN
 /// fixed target.
 pub const DEFAULT_WORK_FINDER_MAX_CONCURRENT: usize = 3;
 
+/// Environment variable setting the **per-token concurrency factor** (#3947).
+///
+/// The dynamic cap's token axis is `healthy_tokens × per_token_concurrency`, not
+/// the old implicit `healthy_tokens × 1`. A plan limit is a utilization-window
+/// token bucket (not a session count), so a single healthy account can run
+/// several concurrent sessions; this factor is how many. Precedence is the
+/// standard **env > config (`autonomous.perTokenConcurrency`) > default**. A
+/// zero / unparseable value is ignored (falls through to config/default).
+pub const PER_TOKEN_CONCURRENCY_ENV: &str = "LOOM_PER_TOKEN_CONCURRENCY";
+
+/// Default per-token concurrency factor (#3947). `2` — a conservative amount of
+/// session-window stacking that roughly doubles throughput off a small healthy
+/// set without pushing a single account near its concurrent-session ceiling. The
+/// #3909 rotating spread still fills distinct accounts first, so stacking only
+/// kicks in when concurrency demand exceeds the healthy-account count.
+pub const DEFAULT_PER_TOKEN_CONCURRENCY: usize = 2;
+
 /// Labels that disqualify an issue from dispatch even if it still appears in
 /// the `loom:issue`-filtered listing.
 ///
@@ -636,6 +653,11 @@ pub struct WorkFinderConfig {
     /// `autonomous.workFinder.maxConcurrent` — the operator concurrency ceiling
     /// (a zero/invalid value is dropped to `None`).
     pub max_concurrent: Option<usize>,
+    /// `autonomous.perTokenConcurrency` — how many concurrent sweeps to allow per
+    /// *healthy* token in the dynamic cap (#3947). Note this lives at the
+    /// `autonomous` level (not under `workFinder`), so it is read even when no
+    /// `workFinder` block is present. A zero/invalid value is dropped to `None`.
+    pub per_token_concurrency: Option<usize>,
 }
 
 /// Read `.loom/config.json → autonomous.workFinder`, soft-failing every field
@@ -667,21 +689,36 @@ pub fn read_work_finder_config(repo_root: &Path) -> WorkFinderConfig {
         }
     };
 
-    let Some(wf) = config.get("autonomous").and_then(|a| a.get("workFinder")) else {
+    let Some(autonomous) = config.get("autonomous") else {
         return WorkFinderConfig::default();
     };
 
+    // `perTokenConcurrency` lives at the `autonomous` level (#3947), so it is
+    // read even when the `workFinder` block is absent.
+    let per_token_concurrency = autonomous
+        .get("perTokenConcurrency")
+        .and_then(serde_json::Value::as_u64)
+        .filter(|&n| n > 0)
+        .and_then(|n| usize::try_from(n).ok());
+
+    // The `workFinder` sub-block is optional; each field independently falls
+    // through to `None` (env/default resolution) when absent.
+    let wf = autonomous.get("workFinder");
+
     WorkFinderConfig {
-        enabled: wf.get("enabled").and_then(serde_json::Value::as_bool),
+        enabled: wf
+            .and_then(|w| w.get("enabled"))
+            .and_then(serde_json::Value::as_bool),
         interval_secs: wf
-            .get("intervalSecs")
+            .and_then(|w| w.get("intervalSecs"))
             .and_then(serde_json::Value::as_u64)
             .filter(|&s| s > 0),
         max_concurrent: wf
-            .get("maxConcurrent")
+            .and_then(|w| w.get("maxConcurrent"))
             .and_then(serde_json::Value::as_u64)
             .filter(|&n| n > 0)
             .and_then(|n| usize::try_from(n).ok()),
+        per_token_concurrency,
     }
 }
 
@@ -715,8 +752,31 @@ pub fn resolve_max_concurrent_with_config(config: &WorkFinderConfig) -> usize {
         .unwrap_or(DEFAULT_WORK_FINDER_MAX_CONCURRENT)
 }
 
-/// Compute the **work-driven dynamic concurrency cap** (Phase B, #3811):
-/// `min(pool_size, disk_headroom, configured_max)`.
+/// Env override for the per-token concurrency factor — `None` when unset, zero,
+/// or unparseable (a zero factor would multiply the token axis to nothing).
+fn env_per_token_concurrency() -> Option<usize> {
+    std::env::var(PER_TOKEN_CONCURRENCY_ENV)
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+}
+
+/// Resolve the per-token concurrency factor with precedence **env > config >
+/// default** (#3947). Mirrors [`resolve_max_concurrent_with_config`]: the env
+/// var ([`PER_TOKEN_CONCURRENCY_ENV`]) wins, then
+/// `autonomous.perTokenConcurrency`, then [`DEFAULT_PER_TOKEN_CONCURRENCY`]. A
+/// zero/unparseable value at any layer is treated as absent so it never
+/// collapses the token axis to zero.
+#[must_use]
+pub fn resolve_per_token_concurrency(config: &WorkFinderConfig) -> usize {
+    env_per_token_concurrency()
+        .or(config.per_token_concurrency)
+        .unwrap_or(DEFAULT_PER_TOKEN_CONCURRENCY)
+}
+
+/// Compute the **work-driven dynamic concurrency cap** (Phase B, #3811;
+/// per-token concurrency factor added in #3947):
+/// `min(token_limit × per_token_concurrency, disk_headroom, configured_max)`.
 ///
 /// This is the total-concurrency ceiling for the loop, recomputed every tick
 /// from live inputs. It deliberately does **not** fold in the backlog depth:
@@ -727,25 +787,39 @@ pub fn resolve_max_concurrent_with_config(config: &WorkFinderConfig) -> usize {
 /// `loom:building` sweeps that are **not** in the ready backlog. Folding backlog
 /// into the cap here would under-utilize the pool whenever prior-tick sweeps are
 /// still running (a smaller "new work" number would cap total occupancy below
-/// the pool/disk ceiling). Keeping the cap as `min(pool, disk, configured)` and
-/// letting `tick` apply the backlog bound is what makes concurrency scale up
-/// with the backlog and drain to zero when it empties.
+/// the pool/disk ceiling). Keeping the cap as `min(token×factor, disk,
+/// configured)` and letting `tick` apply the backlog bound is what makes
+/// concurrency scale up with the backlog and drain to zero when it empties.
 ///
-/// The three bounds map directly to the resource each protects:
-/// - `pool_size` — never over-subscribe a rotated OAuth account (one live sweep
-///   per `.loom/tokens/*.token`).
+/// The bounds map directly to the resource each protects:
+/// - `token_limit` — the count of *healthy* accounts (or the raw pool when no
+///   ranking exists). **Multiplied by `per_token_concurrency`** (#3947): a plan
+///   limit is a utilization-window token bucket, not a session count, so one
+///   healthy account can comfortably run several concurrent sessions. Before
+///   #3947 the implicit factor was `1` (one sweep per account), which collapsed
+///   the whole fleet to cap 1 when 6/7 accounts were at their weekly ceiling
+///   even though the single healthy account had ample session-window headroom.
 /// - `disk_headroom` — never provision more worktrees than the scratch volume
 ///   can hold at `LOOM_PER_WORKTREE_GB` each.
 /// - `configured_max` — the operator ceiling
 ///   (`LOOM_WORK_FINDER_MAX_CONCURRENT`), a hard upper bound regardless of how
-///   much pool/disk headroom exists.
+///   much token/disk headroom exists.
+///
+/// `per_token_concurrency` is clamped to a floor of `1` so a mis-set `0`
+/// degrades to the pre-#3947 one-sweep-per-account behavior rather than
+/// dispatching nothing. `token_limit × factor` uses a saturating multiply so a
+/// pathological product can never wrap.
 #[must_use]
 pub fn resolve_dynamic_max_concurrent(
-    pool_size: usize,
+    token_limit: usize,
+    per_token_concurrency: usize,
     disk_headroom: usize,
     configured_max: usize,
 ) -> usize {
-    pool_size.min(disk_headroom).min(configured_max)
+    token_limit
+        .saturating_mul(per_token_concurrency.max(1))
+        .min(disk_headroom)
+        .min(configured_max)
 }
 
 // ============================================================================
@@ -770,12 +844,16 @@ pub fn resolve_dynamic_max_concurrent(
 /// the same footing as the reaper task
 /// ([`crate::sweep_registry::spawn_reaper_task`]). The per-tick disk probe shells
 /// out to `df` briefly, which is negligible on the 60s default interval.
+#[allow(clippy::too_many_arguments)] // dynamic-cap inputs + shared state; the
+                                     // multi-workspace variant ([`spawn_multi_work_finder_task`]) is the production
+                                     // path, this single-workspace form is retained for reference/tests.
 pub fn spawn_work_finder_task<S, D>(
     mut source: S,
     mut dispatcher: D,
     interval: Duration,
     workspace_root: PathBuf,
     configured_max: usize,
+    per_token_concurrency: usize,
     health_state: Arc<MainHealthState>,
     event_bus: Arc<EventBus>,
 ) -> tokio::task::JoinHandle<()>
@@ -785,7 +863,8 @@ where
 {
     log::info!(
         "work_finder: starting loop (interval={}s, configured_max={configured_max}, \
-         dynamic cap = min(healthy tokens, disk, configured_max))",
+         per_token_concurrency={per_token_concurrency}, \
+         dynamic cap = min(healthy tokens × per-token, disk, configured_max))",
         interval.as_secs()
     );
     tokio::spawn(async move {
@@ -815,11 +894,16 @@ where
             let ranking = capacity::read_ranking(&workspace_root);
             let token_limit = ranking.as_ref().map_or(pool_size, |r| r.available);
             let disk = disk_headroom_limit(&workspace_root);
-            let max_concurrent = resolve_dynamic_max_concurrent(token_limit, disk, configured_max);
+            let max_concurrent = resolve_dynamic_max_concurrent(
+                token_limit,
+                per_token_concurrency,
+                disk,
+                configured_max,
+            );
             log::debug!(
                 "work_finder: dynamic cap = {max_concurrent} (pool={pool_size}, \
-                 healthy_tokens={token_limit}, disk={disk}, configured_max={configured_max}, \
-                 halted={halted})"
+                 healthy_tokens={token_limit}, per_token={per_token_concurrency}, disk={disk}, \
+                 configured_max={configured_max}, halted={halted})"
             );
             match tick(&mut source, &mut dispatcher, max_concurrent, halted) {
                 Ok(report) => {
@@ -836,7 +920,8 @@ where
                     if report.dispatched > 0 || report.errors > 0 {
                         log::info!(
                             "work_finder: tick — cap {max_concurrent} (pool={pool_size}, \
-                             healthy={token_limit}, disk={disk}, ceiling={configured_max}); \
+                             healthy={token_limit}, per_token={per_token_concurrency}, disk={disk}, \
+                             ceiling={configured_max}); \
                              {} seen, {} dispatched, {} labeled-skip, {} in-flight-skip, \
                              {} deferred, {} error(s)",
                             report.seen,
@@ -910,12 +995,14 @@ pub fn spawn_multi_work_finder_task(
     fallback_root: PathBuf,
     interval: Duration,
     configured_max: usize,
+    per_token_concurrency: usize,
     health_states: Arc<WorkspaceHealthStates>,
     event_bus: Arc<EventBus>,
 ) -> tokio::task::JoinHandle<()> {
     log::info!(
         "work_finder: starting multi-workspace loop (interval={}s, configured_max={configured_max}, \
-         dynamic cap = min(healthy tokens, disk, configured_max), global across workspaces)",
+         per_token_concurrency={per_token_concurrency}, \
+         dynamic cap = min(healthy tokens × per-token, disk, configured_max), global across workspaces)",
         interval.as_secs()
     );
     tokio::spawn(async move {
@@ -934,7 +1021,12 @@ pub fn spawn_multi_work_finder_task(
             let ranking = capacity::read_ranking(&fallback_root);
             let token_limit = ranking.as_ref().map_or(pool_size, |r| r.available);
             let disk = disk_headroom_limit(&fallback_root);
-            let max_concurrent = resolve_dynamic_max_concurrent(token_limit, disk, configured_max);
+            let max_concurrent = resolve_dynamic_max_concurrent(
+                token_limit,
+                per_token_concurrency,
+                disk,
+                configured_max,
+            );
 
             // Resolve the current set of workspaces fresh each tick so registry
             // edits (add / remove / set-priority) are hot-applied.
@@ -963,8 +1055,9 @@ pub fn spawn_multi_work_finder_task(
 
             log::debug!(
                 "work_finder: dynamic cap = {max_concurrent} (pool={pool_size}, \
-                 healthy_tokens={token_limit}, disk={disk}, configured_max={configured_max}, \
-                 any_halted={any_halted}, workspaces={}, priorities={priorities:?})",
+                 healthy_tokens={token_limit}, per_token={per_token_concurrency}, disk={disk}, \
+                 configured_max={configured_max}, any_halted={any_halted}, workspaces={}, \
+                 priorities={priorities:?})",
                 pairs.len()
             );
 
@@ -985,7 +1078,8 @@ pub fn spawn_multi_work_finder_task(
             if report.dispatched > 0 || report.errors > 0 {
                 log::info!(
                     "work_finder: tick — cap {max_concurrent} (pool={pool_size}, \
-                     healthy={token_limit}, disk={disk}, ceiling={configured_max}); {} workspace(s), \
+                     healthy={token_limit}, per_token={per_token_concurrency}, disk={disk}, \
+                     ceiling={configured_max}); {} workspace(s), \
                      {} seen, {} dispatched, {} labeled-skip, {} in-flight-skip, {} deferred, \
                      {} error(s)",
                     pairs.len(),
@@ -1936,25 +2030,26 @@ mod tests {
     }
 
     // ===================================================================
-    // resolve_dynamic_max_concurrent — Phase B work-driven policy (#3811)
+    // resolve_dynamic_max_concurrent — Phase B work-driven policy (#3811),
+    // per-token concurrency factor (#3947)
     // ===================================================================
 
     #[test]
     fn test_dynamic_cap_is_min_of_three_inputs() {
-        // Never exceeds any of the three bounds.
-        assert_eq!(resolve_dynamic_max_concurrent(10, 10, 10), 10);
-        assert_eq!(resolve_dynamic_max_concurrent(2, 9, 9), 2, "pool binds");
-        assert_eq!(resolve_dynamic_max_concurrent(9, 3, 9), 3, "disk binds");
-        assert_eq!(resolve_dynamic_max_concurrent(9, 9, 4), 4, "ceiling binds");
+        // Never exceeds any of the three bounds (factor 1 = pre-#3947 semantics).
+        assert_eq!(resolve_dynamic_max_concurrent(10, 1, 10, 10), 10);
+        assert_eq!(resolve_dynamic_max_concurrent(2, 1, 9, 9), 2, "token axis binds");
+        assert_eq!(resolve_dynamic_max_concurrent(9, 1, 3, 9), 3, "disk binds");
+        assert_eq!(resolve_dynamic_max_concurrent(9, 1, 9, 4), 4, "ceiling binds");
     }
 
     #[test]
     fn test_dynamic_cap_pool_size_bound_never_over_subscribes() {
-        // With a large disk headroom and ceiling, the token-pool size is the
-        // hard bound — the cap never exceeds the number of usable accounts.
+        // With a large disk headroom and ceiling and factor 1, the token-pool
+        // size is the hard bound — the cap never exceeds the number of accounts.
         for pool in 0..=5 {
             assert_eq!(
-                resolve_dynamic_max_concurrent(pool, 100, 100),
+                resolve_dynamic_max_concurrent(pool, 1, 100, 100),
                 pool,
                 "cap must equal pool size {pool} when disk/ceiling are larger"
             );
@@ -1964,17 +2059,19 @@ mod tests {
     #[test]
     fn test_dynamic_cap_disk_headroom_bound() {
         // A nearly-full scratch volume (disk headroom 1) caps concurrency at 1
-        // even with a big pool and high ceiling.
-        assert_eq!(resolve_dynamic_max_concurrent(8, 1, 8), 1);
+        // even with a big pool, high ceiling, AND a big per-token factor (#3947):
+        // stacking never provisions more worktrees than the disk can hold.
+        assert_eq!(resolve_dynamic_max_concurrent(8, 4, 1, 8), 1);
         // A full volume (0 headroom) drops the cap to 0 — dispatch nothing.
-        assert_eq!(resolve_dynamic_max_concurrent(8, 0, 8), 0);
+        assert_eq!(resolve_dynamic_max_concurrent(8, 4, 0, 8), 0);
     }
 
     #[test]
     fn test_dynamic_cap_zero_pool_dispatches_nothing() {
-        // No usable tokens ⇒ cap 0 ⇒ a subsequent tick dispatches nothing (the
-        // spawn path would hard-fail EX_CONFIG anyway).
-        let cap = resolve_dynamic_max_concurrent(0, 10, 10);
+        // No usable tokens ⇒ cap 0 regardless of the factor (0 × N = 0) ⇒ a
+        // subsequent tick dispatches nothing (the spawn path would hard-fail
+        // EX_CONFIG anyway).
+        let cap = resolve_dynamic_max_concurrent(0, 2, 10, 10);
         assert_eq!(cap, 0);
         let mut source = FakeSource::once((1..=3).map(issue).collect());
         let mut disp = RecordingDispatcher::default();
@@ -1984,16 +2081,52 @@ mod tests {
         assert!(disp.dispatched.is_empty());
     }
 
+    #[test]
+    fn test_dynamic_cap_per_token_factor_multiplies_token_axis() {
+        // #3947 core: the token axis is `healthy × per-token`, not `healthy × 1`.
+        // 3 healthy accounts × factor 2 = 6, bounded only by disk/ceiling.
+        assert_eq!(resolve_dynamic_max_concurrent(3, 2, 100, 100), 6);
+        // 2 healthy × factor 3 = 6.
+        assert_eq!(resolve_dynamic_max_concurrent(2, 3, 100, 100), 6);
+        // The product is still clamped by disk and the operator ceiling.
+        assert_eq!(resolve_dynamic_max_concurrent(3, 2, 4, 100), 4, "disk clamps the product");
+        assert_eq!(resolve_dynamic_max_concurrent(3, 2, 100, 5), 5, "ceiling clamps the product");
+    }
+
+    #[test]
+    fn test_dynamic_cap_one_healthy_account_factor_two_dispatches_two() {
+        // The load-bearing #3947 scenario (6/7 accounts at their weekly ceiling):
+        // ONE healthy account with factor 2 must allow TWO concurrent sweeps —
+        // the pre-#3947 implicit 1:1 cap would have collapsed this to 1.
+        let cap = resolve_dynamic_max_concurrent(1, 2, 120, 3);
+        assert_eq!(cap, 2, "1 healthy × per-token 2 = 2 (disk 120, ceiling 3 don't bind)");
+
+        // And that cap actually dispatches 2 (not 1) against a 2-deep backlog.
+        let mut source = FakeSource::once((1..=2).map(issue).collect());
+        let mut disp = RecordingDispatcher::default();
+        let report = tick(&mut source, &mut disp, cap, false).unwrap();
+        assert_eq!(report.dispatched, 2, "1-healthy/factor-2 dispatches 2 concurrent sweeps");
+        assert_eq!(report.deferred_capacity, 0);
+        assert_eq!(disp.dispatched.len(), 2);
+    }
+
+    #[test]
+    fn test_dynamic_cap_zero_factor_degrades_to_one() {
+        // A mis-set factor 0 must NOT collapse the cap to zero — it degrades to
+        // the pre-#3947 one-sweep-per-account behavior (floor of 1).
+        assert_eq!(resolve_dynamic_max_concurrent(4, 0, 100, 100), 4);
+    }
+
     // ===================================================================
     // Dynamic cap composed with tick — scale-up / scale-to-zero (#3811)
     // ===================================================================
 
     #[test]
     fn test_scale_up_with_growing_backlog_bounded_by_dynamic_cap() {
-        // Fixed resources: pool=4, disk=10, ceiling=10 ⇒ dynamic cap 4. As the
-        // backlog grows tick-over-tick, effective concurrency scales up but is
-        // bounded by the cap (min(cap, backlog)).
-        let cap = resolve_dynamic_max_concurrent(4, 10, 10);
+        // Fixed resources: pool=4, factor=1, disk=10, ceiling=10 ⇒ dynamic cap 4.
+        // As the backlog grows tick-over-tick, effective concurrency scales up
+        // but is bounded by the cap (min(cap, backlog)).
+        let cap = resolve_dynamic_max_concurrent(4, 1, 10, 10);
         assert_eq!(cap, 4);
 
         // Backlog 2 (< cap): all 2 dispatch, nothing deferred.
@@ -2015,7 +2148,7 @@ mod tests {
     fn test_scale_to_zero_on_empty_backlog() {
         // Even with ample resources (cap 5), an empty backlog dispatches nothing
         // — no capacity is pre-reserved and no idle workers are spawned.
-        let cap = resolve_dynamic_max_concurrent(5, 5, 5);
+        let cap = resolve_dynamic_max_concurrent(5, 1, 5, 5);
         assert_eq!(cap, 5);
         let mut source = FakeSource::once(vec![]);
         let mut disp = RecordingDispatcher::default();
@@ -2066,7 +2199,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         write_config(
             tmp.path(),
-            r#"{"autonomous": {"workFinder": {"enabled": true, "intervalSecs": 90, "maxConcurrent": 5}}}"#,
+            r#"{"autonomous": {"perTokenConcurrency": 4, "workFinder": {"enabled": true, "intervalSecs": 90, "maxConcurrent": 5}}}"#,
         );
         assert_eq!(
             read_work_finder_config(tmp.path()),
@@ -2074,8 +2207,30 @@ mod tests {
                 enabled: Some(true),
                 interval_secs: Some(90),
                 max_concurrent: Some(5),
+                per_token_concurrency: Some(4),
             }
         );
+    }
+
+    #[test]
+    fn test_config_per_token_concurrency_read_without_work_finder_block() {
+        // `perTokenConcurrency` lives at the `autonomous` level (#3947), so it is
+        // read even when the `workFinder` sub-block is absent.
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), r#"{"autonomous": {"perTokenConcurrency": 3}}"#);
+        let cfg = read_work_finder_config(tmp.path());
+        assert_eq!(cfg.per_token_concurrency, Some(3));
+        assert_eq!(cfg.enabled, None);
+        assert_eq!(cfg.max_concurrent, None);
+    }
+
+    #[test]
+    fn test_config_zero_per_token_concurrency_drops_to_none() {
+        // A zero factor in config is treated as absent so it falls through to
+        // env/default rather than collapsing the token axis to zero.
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), r#"{"autonomous": {"perTokenConcurrency": 0}}"#);
+        assert_eq!(read_work_finder_config(tmp.path()).per_token_concurrency, None);
     }
 
     #[test]
@@ -2193,6 +2348,37 @@ mod tests {
         std::env::set_var(WORK_FINDER_MAX_CONCURRENT_ENV, "nope");
         assert_eq!(resolve_max_concurrent_with_config(&cfg), 8);
         std::env::remove_var(WORK_FINDER_MAX_CONCURRENT_ENV);
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_per_token_concurrency_precedence() {
+        std::env::remove_var(PER_TOKEN_CONCURRENCY_ENV);
+
+        // Default (2) when neither env nor config set.
+        assert_eq!(
+            resolve_per_token_concurrency(&WorkFinderConfig::default()),
+            DEFAULT_PER_TOKEN_CONCURRENCY
+        );
+        assert_eq!(DEFAULT_PER_TOKEN_CONCURRENCY, 2);
+
+        // Config used when env unset.
+        let cfg = WorkFinderConfig {
+            per_token_concurrency: Some(4),
+            ..Default::default()
+        };
+        assert_eq!(resolve_per_token_concurrency(&cfg), 4);
+
+        // Env overrides config.
+        std::env::set_var(PER_TOKEN_CONCURRENCY_ENV, "3");
+        assert_eq!(resolve_per_token_concurrency(&cfg), 3);
+
+        // A zero/garbage env value is ignored; config still wins over default.
+        std::env::set_var(PER_TOKEN_CONCURRENCY_ENV, "0");
+        assert_eq!(resolve_per_token_concurrency(&cfg), 4);
+        std::env::set_var(PER_TOKEN_CONCURRENCY_ENV, "nope");
+        assert_eq!(resolve_per_token_concurrency(&cfg), 4);
+        std::env::remove_var(PER_TOKEN_CONCURRENCY_ENV);
     }
 
     // ===================================================================


### PR DESCRIPTION
Closes #3947

## Summary

Replaces the implicit **one-sweep-per-account** assumption in the autonomous work-finder dynamic cap with a configurable **per-token concurrency factor**. The cap becomes:

```
dynamic_cap = min(healthy_tokens × perTokenConcurrency, disk_headroom, configured_max)
```

Default factor is **2**. This fixes the v0.15.0 canary constraint where 6/7 accounts at their weekly ceiling collapsed the whole fleet to cap 1, even though the one healthy account could comfortably run several concurrent sessions (plan limits are utilization-window token buckets, not session counts).

## Changes

**Cap formula + config plumbing (Rust)**
- `resolve_dynamic_max_concurrent(token_limit, per_token_concurrency, disk, configured_max)` — multiplies the token axis by the factor (saturating), clamps the factor to a floor of 1 so a mis-set `0` degrades to pre-#3947 behavior rather than dispatching nothing.
- New `LOOM_PER_TOKEN_CONCURRENCY` env + `autonomous.perTokenConcurrency` config (read at the `autonomous` level, so it works even with no `workFinder` block), resolved **env > config > default(2)** — mirrors the existing `maxConcurrent` plumbing exactly.
- Threaded through both the single- and multi-workspace work-finder tasks, `ipc::build_daemon_status`, and `DaemonStatusReport` (new `per_token_concurrency` field, `#[serde(default)]` for wire compat).

**Status view**
- Human view spells the arithmetic out: `= min(healthy 1 × per-token 2 = 2, disk headroom 120, configured max 3)`; JSON adds `per_token_concurrency` + `token_axis_effective`. `token_bound` now tests the *product* against disk/ceiling.

**Selection spread**
- The #3909 rotating spread stays primary (fills distinct healthy accounts first via the persistent `.rotation_cursor`); bounded stacking only kicks in when demand exceeds the healthy-account count. No change needed to the cursor — modulo wrap already stacks.

**Session-limit fault handling**
- `classify-error.sh` adds a distinct `SESSION_LIMIT` category, checked **before** `TOKEN_EXHAUSTED` so the concurrency wording isn't swallowed by the exhaustion regex.
- `claude-wrapper.sh` handles it by re-selecting a **different** account and retrying **without** appending to `.bad_tokens` (a capacity fault must never poison the healthy pool). Re-selection advances the cursor (backs off stacking for the saturated account); bounded by `LOOM_MAX_SESSION_LIMIT_RETRIES` (default 10), then falls through to transient backoff still without marking bad.

**Docs**: daemon-reference capacity section (cap formula, factor table row, session-limit handling), CLAUDE.md autonomous config blocks + inline JSON, config table row.

## Acceptance criteria

- [x] Cap formula uses the factor; default 2; env+config plumbing with standard precedence; `status` explains the arithmetic.
- [x] Rotating spread fills distinct accounts before stacking; unit test for the 1-healthy-account/factor-2 case dispatching 2 (`test_dynamic_cap_one_healthy_account_factor_two_dispatches_two`).
- [x] Session-limit spawn failures classified distinctly, back off stacking for that account only (re-select), never append to `.bad_tokens`.
- [x] Docs: daemon-reference capacity section.

## Tests

- Rust lib: **760 passing**, incl. new `test_dynamic_cap_per_token_factor_multiplies_token_axis`, `test_dynamic_cap_one_healthy_account_factor_two_dispatches_two`, `test_dynamic_cap_zero_factor_degrades_to_one`, `test_resolve_per_token_concurrency_precedence`, `test_config_per_token_concurrency_read_without_work_finder_block`, `test_config_zero_per_token_concurrency_drops_to_none`. `cargo clippy --all-targets` clean.
- `test-spawn-claude.sh`: new SESSION_LIMIT vectors (incl. weekly-"session limit" disambiguation → still TOKEN_EXHAUSTED, and exit-0 prose regression) all pass. (3 pre-existing `--model`/`--effort` failures are unrelated and identical on `main`.)

## Deferred

The operator's 2026-07-25 refinement (utilization-driven saturation controller holding each token near ~90% of its session window via `autonomous.targetUtilization`) is explicitly a **follow-on** to this v1 knob; the schema here (`perTokenConcurrency`) is designed so that controller can subsume it as a floor/ceiling without schema churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)