### PR TITLE
feat(daemon): insta-crash quarantine for work-finder dispatch

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -1016,8 +1016,14 @@ for the load-bearing behavior) and, best-effort, flips the forge labels
 (`loom:issue` → `loom:blocked`) with an explanatory comment so the pause is also
 visible to a human. Quarantine is visible per-repo in `loom-daemon status`
 (`quarantined (insta-crash, #3939): #123, #456`) and auto-releases after `ttlSecs`
-(or via `loom:blocked` removal) — a transient breakage (e.g. a re-provisioned
-token pool) recovers without operator action. In `tick_multi`, a quarantined
+— a transient breakage (e.g. a re-provisioned token pool) recovers without
+operator action. To release a quarantine **immediately** (rather than waiting for
+the TTL), run `loom-daemon quarantine clear <issue>`: it clears the daemon's
+in-memory quarantine + insta-crash tally over IPC AND restores `loom:issue` on
+the forge, so the issue re-qualifies on the next tick. **Note:** the in-memory
+quarantine is the load-bearing state — manually flipping `loom:blocked` →
+`loom:issue` on the forge alone does **not** release it (the work finder skips
+the issue until the CLI clear or the TTL fires). In `tick_multi`, a quarantined
 candidate is dropped **before** the global slot-fill pass, so a workspace whose
 only candidates are quarantined never reserves a shared dispatch slot — healthy
 sibling work in other repos gets it instead. Defaults **on**; disable with

--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -873,7 +873,13 @@ concurrency ceiling 5" and share it with the team:
     "workFinder": {
       "enabled": true,
       "intervalSecs": 60,
-      "maxConcurrent": 5
+      "maxConcurrent": 5,
+      "quarantine": {
+        "enabled": true,
+        "threshold": 3,
+        "ttlSecs": 3600,
+        "instaCrashSecs": 60
+      }
     },
     "mainHealthGate": {
       "enabled": true
@@ -904,6 +910,10 @@ exactly like `main_health_gate::read_build_gate_config`.
 | `autonomous.workFinder.enabled` | `LOOM_WORK_FINDER` | `false` | Master on/off for the finder loop |
 | `autonomous.workFinder.intervalSecs` | `LOOM_WORK_FINDER_INTERVAL_SECS` | `60` | Zero/invalid → default |
 | `autonomous.workFinder.maxConcurrent` | `LOOM_WORK_FINDER_MAX_CONCURRENT` | `3` | Operator **ceiling**, not a fixed target |
+| `autonomous.workFinder.quarantine.enabled` | `LOOM_WORK_FINDER_QUARANTINE` | `true` | Insta-crash quarantine on/off (#3939). A safety backstop — defaults on |
+| `autonomous.workFinder.quarantine.threshold` | `LOOM_WORK_FINDER_QUARANTINE_THRESHOLD` | `3` | Consecutive insta-crashes before an issue is quarantined. Zero/invalid → default |
+| `autonomous.workFinder.quarantine.ttlSecs` | `LOOM_WORK_FINDER_QUARANTINE_TTL_SECS` | `3600` | How long a quarantine entry persists before auto-release. Zero/invalid → default |
+| `autonomous.workFinder.quarantine.instaCrashSecs` | `LOOM_WORK_FINDER_QUARANTINE_INSTA_CRASH_SECS` | `60` | Checkpoint-less death within this window of dispatch counts as an insta-crash. Zero/invalid → default |
 | `autonomous.perTokenConcurrency` | `LOOM_PER_TOKEN_CONCURRENCY` | `2` | Concurrent sweeps **per healthy token** in the cap (#3947). Zero/invalid → default; clamped to a floor of 1 |
 | `autonomous.mainHealthGate.enabled` | `LOOM_MAIN_HEALTH_GATE` | `false` | Gate loop on/off |
 | `autonomous.dispatchStaggerMs` | `LOOM_SWEEP_DISPATCH_STAGGER_MS` | `2000` | Min gap between consecutive child spawns (#3887). `0` disables |
@@ -988,6 +998,30 @@ comes from the separate top-level `buildGate` block (#3749); `autonomous.mainHea
 is purely the on/off surface, so Phase C's already-tested `buildGate` semantics
 are untouched. `LOOM_MAIN_HEALTH_GATE` remains the master override; the config
 key just lets a repo turn the gate on without exporting an env var.
+
+**Insta-crash quarantine (#3939).** The startup watchdog (#3887) and mid-build-death
+watchdog (#3895) both rescue a sweep that made *some* observable progress before
+dying. Neither covers the **insta-crash**: a child that dies within seconds of
+spawn — e.g. a missing token pool or a selector import failure (#3938) — is
+reaped, its `loom:building` claim restored to `loom:issue`, and the issue simply
+re-qualifies on the very next work-finder tick. Left unchecked this occupies a
+global concurrency slot forever and starves healthy candidates in other repos.
+The reaper now counts **consecutive** insta-crashes per issue — a terminal
+transition that wrote no phase checkpoint (never reached real work) and landed
+within `instaCrashSecs` of dispatch. A death *with* a checkpoint, or a clean/slow
+exit, resets the tally, so a genuine one-off failure never accretes toward
+quarantine. After `threshold` consecutive insta-crashes the issue is
+**quarantined**: the work finder skips it in-memory (no forge round-trip needed
+for the load-bearing behavior) and, best-effort, flips the forge labels
+(`loom:issue` → `loom:blocked`) with an explanatory comment so the pause is also
+visible to a human. Quarantine is visible per-repo in `loom-daemon status`
+(`quarantined (insta-crash, #3939): #123, #456`) and auto-releases after `ttlSecs`
+(or via `loom:blocked` removal) — a transient breakage (e.g. a re-provisioned
+token pool) recovers without operator action. In `tick_multi`, a quarantined
+candidate is dropped **before** the global slot-fill pass, so a workspace whose
+only candidates are quarantined never reserves a shared dispatch slot — healthy
+sibling work in other repos gets it instead. Defaults **on**; disable with
+`LOOM_WORK_FINDER_QUARANTINE=0` or `autonomous.workFinder.quarantine.enabled = false`.
 
 ### Prerequisite: a fresh token ranking (#3894)
 

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -473,20 +473,26 @@ pub fn build_daemon_status(
     let mut per_repo: Vec<crate::types::RepoStatus> = Vec::with_capacity(roots.len());
     for root in &roots {
         let registry = workspace_pool.get_or_provision(root);
-        let live: Vec<crate::types::SweepInfo> = {
+        let (live, quarantined_issues): (Vec<crate::types::SweepInfo>, Vec<u32>) = {
             let sr = registry.lock().expect("Sweep registry mutex poisoned");
             // In-flight = sweeps still live (Pending / Running). Terminal sweeps
             // (Exited / Crashed) linger in the registry but are not "in flight".
-            sr.list(None)
+            let live = sr
+                .list(None)
                 .into_iter()
                 .filter(|info| !info.state.is_terminal())
-                .collect()
+                .collect();
+            // Insta-crash quarantine (#3939): surface which issues this repo is
+            // currently refusing to re-dispatch, so a repo with a visible backlog
+            // that is dispatching nothing is explained.
+            (live, sr.quarantined_issues_sorted())
         };
         per_repo.push(crate::types::RepoStatus {
             root: root.clone(),
             priority: workspace_registry.priority_of(root),
             in_flight_count: live.len(),
             health_gate_halted: health_states.is_halted(root),
+            quarantined_issues,
         });
         in_flight.extend(live);
     }
@@ -2383,6 +2389,7 @@ exit 0
                 priority: 100,
                 in_flight_count: 0,
                 health_gate_halted: true,
+                quarantined_issues: vec![101, 202],
             }],
         };
         let resp = Response::DaemonStatus(report);

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -1292,6 +1292,24 @@ fn handle_request(
             }
         }
 
+        Request::ClearQuarantine {
+            issue,
+            workspace_root,
+        } => {
+            // Operator-reachable insta-crash-quarantine release (Issue #3939).
+            // Clears the daemon's in-memory quarantine + insta-crash tally for
+            // `issue` (and restores `loom:issue` on the forge) so the work
+            // finder re-qualifies it immediately instead of waiting for the TTL.
+            let target =
+                resolve_registry(sweep_registry, workspace_pool, workspace_root.as_deref());
+            let mut sr = target.lock().expect("Sweep registry mutex poisoned");
+            let was_quarantined = sr.clear_quarantine(issue);
+            Response::QuarantineCleared {
+                issue,
+                was_quarantined,
+            }
+        }
+
         // ====================================================================
         // Event Bus Handlers (Issue #3453 — Phase B of #3449)
         // ====================================================================
@@ -2217,6 +2235,70 @@ exit 0
             }
             other => panic!("Expected Error, got: {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_handle_request_clear_quarantine_noop() {
+        // Issue #3939/#3960: clearing an issue that is not quarantined is an
+        // idempotent no-op success routed through the full IPC dispatcher.
+        let (tm, db, _, bus) = setup_test_context();
+        let (sr, _dir, _rec) = setup_sweep_registry_in_tempdir();
+        let response = handle_request(
+            Request::ClearQuarantine {
+                issue: 4242,
+                workspace_root: None,
+            },
+            &tm,
+            &db,
+            &sr,
+            &bus,
+            &test_pool(),
+        );
+        match response {
+            Response::QuarantineCleared {
+                issue,
+                was_quarantined,
+            } => {
+                assert_eq!(issue, 4242);
+                assert!(!was_quarantined, "no entry existed -> false");
+            }
+            other => panic!("Expected QuarantineCleared, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_handle_request_clear_quarantine_clears_existing() {
+        // Seed a quarantine directly, then clear it via the IPC dispatcher and
+        // assert the in-memory state was released (was_quarantined: true).
+        let (tm, db, _, bus) = setup_test_context();
+        let (sr, _dir, _rec) = setup_sweep_registry_in_tempdir();
+        {
+            let mut reg = sr.lock().unwrap();
+            reg.seed_quarantine_for_test(808);
+            assert!(reg.is_quarantined(808));
+        }
+        let response = handle_request(
+            Request::ClearQuarantine {
+                issue: 808,
+                workspace_root: None,
+            },
+            &tm,
+            &db,
+            &sr,
+            &bus,
+            &test_pool(),
+        );
+        match response {
+            Response::QuarantineCleared {
+                issue,
+                was_quarantined,
+            } => {
+                assert_eq!(issue, 808);
+                assert!(was_quarantined, "seeded entry existed -> true");
+            }
+            other => panic!("Expected QuarantineCleared, got: {other:?}"),
+        }
+        assert!(!sr.lock().unwrap().is_quarantined(808));
     }
 
     #[test]

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -109,6 +109,15 @@ enum Commands {
         action: WorkspaceAction,
     },
 
+    /// Manage insta-crash quarantines (Issue #3939): the in-memory pauses the
+    /// daemon applies to issues whose sweeps insta-crash repeatedly. Connects to
+    /// the running daemon over its Unix socket, since the quarantine state lives
+    /// in the daemon's memory (not on disk).
+    Quarantine {
+        #[command(subcommand)]
+        action: QuarantineAction,
+    },
+
     /// Validate role configuration completeness
     Validate {
         /// Workspace directory containing .loom/config.json
@@ -172,6 +181,26 @@ enum WorkspaceAction {
     },
 }
 
+/// Sub-actions for `loom-daemon quarantine`.
+#[derive(Subcommand)]
+enum QuarantineAction {
+    /// Clear an issue's insta-crash quarantine (Issue #3939): release the
+    /// daemon's in-memory pause + insta-crash tally so the work finder
+    /// re-qualifies it immediately (instead of waiting for the TTL) and restore
+    /// `loom:issue` on the forge. Idempotent — clearing a non-quarantined issue
+    /// is a no-op success.
+    Clear {
+        /// The issue number whose quarantine to clear.
+        #[arg(value_name = "ISSUE")]
+        issue: u32,
+
+        /// Target managed-workspace root (Issue #3929). Omit to use the daemon's
+        /// default workspace.
+        #[arg(long, value_name = "PATH")]
+        workspace_root: Option<String>,
+    },
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -182,6 +211,9 @@ async fn main() -> Result<()> {
             // `status` connects to the running daemon over its Unix socket, so
             // it needs the async runtime (unlike the other sync subcommands).
             Commands::Status { json } => handle_status_command(json).await,
+            // `quarantine` connects to the running daemon over its Unix socket
+            // (the quarantine state is in-memory), so it needs the async runtime.
+            Commands::Quarantine { action } => handle_quarantine_command(action).await,
             other => handle_cli_command(other),
         };
     }
@@ -684,6 +716,11 @@ fn handle_cli_command(command: Commands) -> Result<()> {
             // socket round-trip), never dispatched through this sync handler.
             unreachable!("Status is handled in main() before handle_cli_command")
         }
+        Commands::Quarantine { .. } => {
+            // Routed directly in `main()` (it needs the async runtime for the
+            // socket round-trip), never dispatched through this sync handler.
+            unreachable!("Quarantine is handled in main() before handle_cli_command")
+        }
         Commands::Init {
             workspace,
             defaults,
@@ -910,6 +947,89 @@ async fn query_daemon_status(socket_path: &Path) -> Result<DaemonStatusReport> {
     tokio::time::timeout(TIMEOUT, roundtrip)
         .await
         .map_err(|_| anyhow!("status round-trip timed out after {}s", TIMEOUT.as_secs()))?
+}
+
+/// Handle the `quarantine` subcommand (Issue #3939). Connects to the running
+/// daemon over its Unix socket and dispatches the requested action. The
+/// quarantine state is in the daemon's memory, so — unlike `workspace` — this
+/// cannot operate on a file when the daemon is down.
+async fn handle_quarantine_command(action: QuarantineAction) -> Result<()> {
+    let socket_path = resolve_socket_path()?;
+    match action {
+        QuarantineAction::Clear {
+            issue,
+            workspace_root,
+        } => {
+            let request = Request::ClearQuarantine {
+                issue,
+                workspace_root,
+            };
+            match query_daemon(&socket_path, &request).await {
+                Ok(Response::QuarantineCleared {
+                    issue,
+                    was_quarantined,
+                }) => {
+                    if was_quarantined {
+                        println!(
+                            "Cleared quarantine for issue #{issue} — it will re-qualify for \
+                             dispatch and `loom:issue` has been restored on the forge."
+                        );
+                    } else {
+                        println!("Issue #{issue} was not quarantined — nothing to clear (no-op).");
+                    }
+                    Ok(())
+                }
+                Ok(Response::Error { message }) => {
+                    eprintln!("Daemon error: {message}");
+                    std::process::exit(1);
+                }
+                Ok(other) => {
+                    eprintln!("Unexpected response from daemon: {other:?}");
+                    std::process::exit(1);
+                }
+                Err(e) => {
+                    eprintln!("Could not reach loom-daemon at {}: {e}", socket_path.display());
+                    eprintln!();
+                    eprintln!("Is the daemon running? Start it with:");
+                    eprintln!("  ./.loom/scripts/cli/loom-daemon-start.sh");
+                    std::process::exit(1);
+                }
+            }
+        }
+    }
+}
+
+/// Connect to the running daemon over its Unix socket, send a single `request`,
+/// and return the parsed `Response`. Both the connect and the round-trip are
+/// individually bounded so an unresponsive/wedged daemon cannot hang the CLI.
+/// Mirrors `query_daemon_status` but for arbitrary single-frame requests.
+async fn query_daemon(socket_path: &Path, request: &Request) -> Result<Response> {
+    const TIMEOUT: Duration = Duration::from_secs(5);
+
+    let stream = tokio::time::timeout(TIMEOUT, UnixStream::connect(socket_path))
+        .await
+        .map_err(|_| anyhow!("connect timed out after {}s", TIMEOUT.as_secs()))?
+        .map_err(|e| anyhow!("connect failed: {e}"))?;
+    let (reader, mut writer) = stream.into_split();
+
+    let request_json = serde_json::to_string(request)?;
+    let roundtrip = async move {
+        writer.write_all(request_json.as_bytes()).await?;
+        writer.write_all(b"\n").await?;
+        writer.flush().await?;
+
+        let mut lines = BufReader::new(reader).lines();
+        let line = lines
+            .next_line()
+            .await?
+            .ok_or_else(|| anyhow!("daemon closed the connection without responding"))?;
+        let response: Response = serde_json::from_str(&line)?;
+        Ok::<Response, anyhow::Error>(response)
+    };
+
+    tokio::time::timeout(TIMEOUT, roundtrip)
+        .await
+        .map_err(|_| anyhow!("round-trip timed out after {}s", TIMEOUT.as_secs()))?
 }
 
 /// Collect per-token usage by shelling out to `loom-tokens check --json`,

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -327,6 +327,19 @@ async fn main() -> Result<()> {
     sweep.set_dispatch_stagger(dispatch_stagger);
     log::info!("sweep_registry: dispatch stagger = {}ms (#3887)", dispatch_stagger.as_millis());
 
+    // Insta-crash quarantine (#3939): resolve env > config > default for the
+    // default workspace so the reaper quarantines a repeatedly-insta-crashing
+    // issue instead of letting the work finder re-dispatch it every tick.
+    let quarantine_config = sweep_registry::resolve_quarantine_config(&sweep_workspace);
+    sweep.set_quarantine_config(quarantine_config);
+    log::info!(
+        "sweep_registry: insta-crash quarantine {} (threshold={}, ttl={}s, insta-crash<{}s) (#3939)",
+        if quarantine_config.enabled { "enabled" } else { "disabled" },
+        quarantine_config.threshold,
+        quarantine_config.ttl.as_secs(),
+        quarantine_config.insta_crash_secs
+    );
+
     let sweep_registry = Arc::new(Mutex::new(sweep));
     let _reaper_handle = sweep_registry::spawn_reaper_task(sweep_registry.clone());
 
@@ -1229,6 +1242,18 @@ fn print_status_human(report: &DaemonStatusReport, token_usage: Option<&serde_js
                 gate,
                 r.root.display()
             );
+            // Insta-crash quarantine (#3939): list the issues this repo is
+            // currently refusing to re-dispatch so a stalled-but-nonempty backlog
+            // is explained. Auto-releases on a TTL (or `loom:blocked` removal).
+            if !r.quarantined_issues.is_empty() {
+                let list = r
+                    .quarantined_issues
+                    .iter()
+                    .map(|n| format!("#{n}"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                println!("        quarantined (insta-crash, #3939): {list}");
+            }
         }
     }
 

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -49,7 +49,7 @@ use crate::types::{Event, SweepId, SweepInfo, SweepKind, SweepOutcome, SweepStat
 use anyhow::{anyhow, Context, Result};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
@@ -317,6 +317,91 @@ pub const DEFAULT_REVIEW_STALL_TIMEOUT_SECS: u64 = 2700;
 /// The dispatch-header marker `spawn_child` writes before each spawn. Reused by
 /// the watchdog's progress probe to anchor its scan to the current dispatch.
 const DISPATCH_HEADER_MARKER: &str = "==== loom-daemon dispatch:";
+
+// ============================================================================
+// Insta-crash quarantine (Issue #3939)
+// ============================================================================
+//
+// The startup watchdog (#3887) and the mid-build-death watchdog (#3895) rescue a
+// *hung* or *mid-build-dead* child. Neither covers the **insta-crash**: a sweep
+// whose child dies within seconds of spawn (e.g. a missing token pool / selector
+// import failure, #3938) is reaped, its `loom:building` claim restored to
+// `loom:issue`, and it simply re-qualifies on the next work-finder poll — so the
+// same broken issue is re-dispatched every tick, occupying a global concurrency
+// slot forever and starving healthy work in other repos.
+//
+// The quarantine backstop closes that gap. The reaper counts *consecutive*
+// insta-crashes per issue — a terminal transition that (a) wrote no phase
+// checkpoint (never reached real work) and (b) happened within
+// [`DEFAULT_QUARANTINE_INSTA_CRASH_SECS`] of dispatch. After
+// [`DEFAULT_QUARANTINE_THRESHOLD`] consecutive insta-crashes the issue is
+// quarantined: the work finder skips it (in-memory, so no forge round-trip is
+// required for the load-bearing behavior) until a TTL
+// ([`DEFAULT_QUARANTINE_TTL_SECS`]) elapses. A terminal outcome that *did* make
+// progress (checkpoint present) or that was a clean/slow exit resets the counter,
+// so a genuine one-off failure never accretes toward quarantine.
+
+/// Env var toggling insta-crash quarantine (Issue #3939). `0`/`false`/`no`/`off`
+/// disables; `1`/`true`/`yes`/`on` forces on. Overrides config. Defaults ON — it
+/// is a safety backstop against a broken workspace starving the shared queue.
+pub const QUARANTINE_ENABLE_ENV: &str = "LOOM_WORK_FINDER_QUARANTINE";
+
+/// Env var overriding the consecutive-insta-crash threshold at which an issue is
+/// quarantined. A zero/invalid value falls through to config/default.
+pub const QUARANTINE_THRESHOLD_ENV: &str = "LOOM_WORK_FINDER_QUARANTINE_THRESHOLD";
+
+/// Env var overriding the quarantine TTL, in seconds. A zero/invalid value falls
+/// through to config/default.
+pub const QUARANTINE_TTL_ENV: &str = "LOOM_WORK_FINDER_QUARANTINE_TTL_SECS";
+
+/// Env var overriding the insta-crash window, in seconds: a checkpoint-less
+/// terminal transition within this wall-clock window of dispatch counts as an
+/// insta-crash. A zero/invalid value falls through to config/default.
+pub const QUARANTINE_INSTA_CRASH_ENV: &str = "LOOM_WORK_FINDER_QUARANTINE_INSTA_CRASH_SECS";
+
+/// Default consecutive-insta-crash threshold before quarantine (#3939).
+pub const DEFAULT_QUARANTINE_THRESHOLD: u32 = 3;
+
+/// Default quarantine TTL: a quarantined issue is auto-released after this window
+/// so a transient breakage (e.g. a token pool that was re-provisioned) recovers
+/// without operator action (#3939).
+pub const DEFAULT_QUARANTINE_TTL_SECS: u64 = 3600;
+
+/// Default insta-crash window (#3939): a checkpoint-less terminal transition
+/// within this many seconds of dispatch counts toward the insta-crash tally. A
+/// real build that reaches even the Curator checkpoint, or a slow death past this
+/// window, is a *different* failure mode (handled by the mid-build watchdog) and
+/// never counts here.
+pub const DEFAULT_QUARANTINE_INSTA_CRASH_SECS: i64 = 60;
+
+/// Resolved insta-crash-quarantine parameters (Issue #3939), set on the registry
+/// at construction so [`SweepRegistry::reap_once`] can enforce them without a
+/// per-tick config read. Defaults mirror the shipped constants (enabled — it is a
+/// safety backstop).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QuarantineConfig {
+    /// Whether insta-crash quarantine is active. When `false` the reaper neither
+    /// counts insta-crashes nor quarantines (byte-for-byte the pre-#3939 path).
+    pub enabled: bool,
+    /// Consecutive insta-crashes before an issue is quarantined.
+    pub threshold: u32,
+    /// How long a quarantine entry persists before auto-release.
+    pub ttl: Duration,
+    /// The insta-crash wall-clock window: a checkpoint-less terminal transition
+    /// within this many seconds of dispatch counts as an insta-crash.
+    pub insta_crash_secs: i64,
+}
+
+impl Default for QuarantineConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            threshold: DEFAULT_QUARANTINE_THRESHOLD,
+            ttl: Duration::from_secs(DEFAULT_QUARANTINE_TTL_SECS),
+            insta_crash_secs: DEFAULT_QUARANTINE_INSTA_CRASH_SECS,
+        }
+    }
+}
 
 /// Compute how long a spawn must wait so that consecutive spawns are separated
 /// by at least `stagger` (Issue #3887). Pure function of the last spawn instant,
@@ -754,6 +839,20 @@ pub struct SweepRegistry {
     /// Issues the review-phase stall watchdog has already logged a give-up for
     /// (Issue #3910), so the loud give-up warning fires once per issue.
     review_stall_gaveup: HashSet<u32>,
+    /// Insta-crash quarantine parameters (Issue #3939). `main.rs` /
+    /// [`crate::workspace_pool::WorkspacePool`] set the resolved env > config >
+    /// default value; the [`QuarantineConfig::default`] is the shipped-on default.
+    quarantine_config: QuarantineConfig,
+    /// Consecutive insta-crash counts per issue (Issue #3939). Incremented by the
+    /// reaper on a checkpoint-less death inside the insta-crash window; reset to
+    /// zero on any terminal outcome that made real progress or exited cleanly.
+    insta_crash_counts: HashMap<u32, u32>,
+    /// Currently-quarantined issues → the instant they were quarantined (Issue
+    /// #3939). The work finder skips these until the entry ages past
+    /// [`QuarantineConfig::ttl`], at which point [`reap_once`](Self::reap_once)
+    /// releases it. Keyed by issue number; since each registry is scoped to one
+    /// workspace root, this is effectively a `(workspace, issue)` key.
+    quarantined: HashMap<u32, DateTime<Utc>>,
 }
 
 impl SweepRegistry {
@@ -776,6 +875,9 @@ impl SweepRegistry {
             midbuild_gaveup: HashSet::new(),
             review_stall_retried: HashSet::new(),
             review_stall_gaveup: HashSet::new(),
+            quarantine_config: QuarantineConfig::default(),
+            insta_crash_counts: HashMap::new(),
+            quarantined: HashMap::new(),
         }
     }
 
@@ -795,6 +897,9 @@ impl SweepRegistry {
             midbuild_gaveup: HashSet::new(),
             review_stall_retried: HashSet::new(),
             review_stall_gaveup: HashSet::new(),
+            quarantine_config: QuarantineConfig::default(),
+            insta_crash_counts: HashMap::new(),
+            quarantined: HashMap::new(),
         }
     }
 
@@ -816,6 +921,58 @@ impl SweepRegistry {
     #[must_use]
     pub fn dispatch_stagger(&self) -> Duration {
         self.dispatch_stagger
+    }
+
+    /// Set the insta-crash quarantine parameters (Issue #3939). `main.rs` and the
+    /// workspace pool call this once at provision time with the resolved
+    /// env > config > default value.
+    pub fn set_quarantine_config(&mut self, config: QuarantineConfig) {
+        self.quarantine_config = config;
+    }
+
+    /// Read-only accessor for the quarantine parameters (Issue #3939).
+    #[must_use]
+    pub fn quarantine_config(&self) -> QuarantineConfig {
+        self.quarantine_config
+    }
+
+    /// The set of issue numbers currently quarantined for insta-crashing (Issue
+    /// #3939). Consumed by the work finder to skip re-dispatch. TTL expiry is
+    /// applied by [`reap_once`](Self::reap_once) (which the work-finder's
+    /// `in_flight()` read path already calls via `reap_liveness`), so this is a
+    /// plain read of the pruned map.
+    #[must_use]
+    pub fn quarantined_issues(&self) -> HashSet<u32> {
+        self.quarantined.keys().copied().collect()
+    }
+
+    /// Sorted view of the currently-quarantined issues (Issue #3939), for the
+    /// `loom-daemon status` per-repo breakdown.
+    #[must_use]
+    pub fn quarantined_issues_sorted(&self) -> Vec<u32> {
+        let mut v: Vec<u32> = self.quarantined.keys().copied().collect();
+        v.sort_unstable();
+        v
+    }
+
+    /// Test/inspection helper: the current consecutive-insta-crash count for an
+    /// issue (Issue #3939). `0` when the issue has no recorded insta-crashes.
+    #[must_use]
+    pub fn insta_crash_count(&self, issue: u32) -> u32 {
+        self.insta_crash_counts.get(&issue).copied().unwrap_or(0)
+    }
+
+    /// Whether `issue` is currently quarantined (Issue #3939).
+    #[must_use]
+    pub fn is_quarantined(&self, issue: u32) -> bool {
+        self.quarantined.contains_key(&issue)
+    }
+
+    /// Manually clear an issue's quarantine + insta-crash tally (Issue #3939),
+    /// the operator-action release path. Returns `true` when an entry existed.
+    pub fn clear_quarantine(&mut self, issue: u32) -> bool {
+        self.insta_crash_counts.remove(&issue);
+        self.quarantined.remove(&issue).is_some()
     }
 
     /// Read-only accessor for the event bus, if any. Exposed so external
@@ -1184,6 +1341,179 @@ impl SweepRegistry {
         cmd.stdout(Stdio::null()).stderr(Stdio::piped());
         let _ = cmd.output()?; // best-effort during reap
         Ok(())
+    }
+
+    // ------------------------------------------------------------------------
+    // Insta-crash quarantine (Issue #3939)
+    // ------------------------------------------------------------------------
+
+    /// Record a terminal sweep outcome against the insta-crash tally (#3939).
+    ///
+    /// `insta_crash` is `true` only when the reaper classified the death as a
+    /// true insta-crash: a checkpoint-less, non-clean exit inside the insta-crash
+    /// window. In that case the per-issue consecutive counter is incremented and,
+    /// on reaching [`QuarantineConfig::threshold`], the issue is quarantined
+    /// (skipped by the work finder until the TTL). Any other outcome — real
+    /// progress (checkpoint present) or a clean/slow exit — resets the counter, so
+    /// only *consecutive* insta-crashes accrue toward quarantine.
+    ///
+    /// A no-op when quarantine is disabled ([`QuarantineConfig::enabled`] is
+    /// `false`), preserving the pre-#3939 behavior byte-for-byte.
+    fn record_terminal_outcome(&mut self, issue: u32, insta_crash: bool) {
+        if !self.quarantine_config.enabled {
+            return;
+        }
+        if !insta_crash {
+            // Progress or a clean/slow exit breaks the consecutive run. Leave any
+            // existing quarantine entry untouched — a quarantined issue is never
+            // dispatched, so it cannot reach here; this only clears the runway for
+            // an issue that has NOT yet been quarantined.
+            self.insta_crash_counts.remove(&issue);
+            return;
+        }
+        let count = self
+            .insta_crash_counts
+            .entry(issue)
+            .and_modify(|c| *c += 1)
+            .or_insert(1);
+        let count = *count;
+        if count >= self.quarantine_config.threshold && !self.quarantined.contains_key(&issue) {
+            self.quarantined.insert(issue, Utc::now());
+            log::warn!(
+                "sweep_registry: issue #{issue} QUARANTINED after {count} consecutive \
+                 insta-crashes (each <{}s with no checkpoint) — pausing re-dispatch for {}s so it \
+                 stops starving the shared queue (#3939). Clear via operator action or wait for \
+                 the TTL.",
+                self.quarantine_config.insta_crash_secs,
+                self.quarantine_config.ttl.as_secs()
+            );
+            self.apply_quarantine_label(issue, count);
+        } else {
+            log::info!(
+                "sweep_registry: issue #{issue} insta-crashed ({count}/{} consecutive, <{}s, no \
+                 checkpoint) (#3939)",
+                self.quarantine_config.threshold,
+                self.quarantine_config.insta_crash_secs
+            );
+        }
+    }
+
+    /// Release any quarantine entries older than the configured TTL (#3939).
+    /// Called at the top of each [`reap_once`](Self::reap_once). Cheap
+    /// early-return when nothing is quarantined. On release the insta-crash tally
+    /// is cleared too, so the issue re-qualifies with a fresh runway, and a
+    /// best-effort forge label restore re-arms `loom:issue`.
+    fn expire_quarantine(&mut self) {
+        if self.quarantined.is_empty() {
+            return;
+        }
+        let ttl_secs = i64::try_from(self.quarantine_config.ttl.as_secs()).unwrap_or(i64::MAX);
+        let now = Utc::now();
+        let expired: Vec<u32> = self
+            .quarantined
+            .iter()
+            .filter(|(_, at)| (now - **at).num_seconds() >= ttl_secs)
+            .map(|(issue, _)| *issue)
+            .collect();
+        for issue in expired {
+            self.quarantined.remove(&issue);
+            self.insta_crash_counts.remove(&issue);
+            log::info!(
+                "sweep_registry: issue #{issue} quarantine expired after {ttl_secs}s — eligible \
+                 for re-dispatch again (#3939)"
+            );
+            self.release_quarantine_label(issue);
+        }
+    }
+
+    /// Best-effort forge mutation on quarantine (#3939): add `loom:blocked`,
+    /// remove `loom:issue`, and post an explanatory comment so the pause is
+    /// visible to a human on the forge — not just in the daemon log. Skipped
+    /// entirely when label flips are disabled (test fixtures / `skip_label_flip`).
+    /// Every step is best-effort: a `gh` failure is logged at debug and never
+    /// affects the load-bearing in-memory quarantine.
+    fn apply_quarantine_label(&self, issue: u32, count: u32) {
+        if self.config.skip_label_flip {
+            return;
+        }
+        let gh = self
+            .config
+            .gh_bin
+            .clone()
+            .unwrap_or_else(|| PathBuf::from("gh"));
+
+        let mut edit = Command::new(&gh);
+        edit.arg("issue")
+            .arg("edit")
+            .arg(issue.to_string())
+            .arg("--add-label")
+            .arg("loom:blocked")
+            .arg("--remove-label")
+            .arg("loom:issue");
+        edit.current_dir(&self.config.workspace_root);
+        if let Ok(repo) = std::env::var("LOOM_REPO") {
+            edit.arg("--repo").arg(repo);
+        }
+        edit.stdout(Stdio::null()).stderr(Stdio::piped());
+        if let Err(e) = edit.output() {
+            log::debug!("sweep_registry: quarantine label edit for #{issue} failed: {e}");
+        }
+
+        let body = format!(
+            "Auto-quarantined by loom-daemon (#3939): this issue's sweep insta-crashed {count} \
+             times in a row — each child died within {}s of dispatch without writing a phase \
+             checkpoint, which almost always means an environment/configuration failure (e.g. a \
+             missing token pool, #3938) rather than a problem with the issue itself. Re-dispatch \
+             is paused so it stops occupying a global concurrency slot and starving other work. \
+             Once the underlying cause is fixed, remove `loom:blocked` and re-add `loom:issue`.",
+            self.quarantine_config.insta_crash_secs
+        );
+        let mut comment = Command::new(&gh);
+        comment
+            .arg("issue")
+            .arg("comment")
+            .arg(issue.to_string())
+            .arg("--body")
+            .arg(body);
+        comment.current_dir(&self.config.workspace_root);
+        if let Ok(repo) = std::env::var("LOOM_REPO") {
+            comment.arg("--repo").arg(repo);
+        }
+        comment.stdout(Stdio::null()).stderr(Stdio::piped());
+        if let Err(e) = comment.output() {
+            log::debug!("sweep_registry: quarantine comment for #{issue} failed: {e}");
+        }
+    }
+
+    /// Best-effort forge mutation on quarantine expiry (#3939): remove
+    /// `loom:blocked` and re-add `loom:issue` so an auto-released issue re-enters
+    /// the work-finder queue. The mirror of [`apply_quarantine_label`]. Skipped
+    /// when label flips are disabled; a `gh` failure is logged at debug only.
+    fn release_quarantine_label(&self, issue: u32) {
+        if self.config.skip_label_flip {
+            return;
+        }
+        let gh = self
+            .config
+            .gh_bin
+            .clone()
+            .unwrap_or_else(|| PathBuf::from("gh"));
+        let mut edit = Command::new(&gh);
+        edit.arg("issue")
+            .arg("edit")
+            .arg(issue.to_string())
+            .arg("--remove-label")
+            .arg("loom:blocked")
+            .arg("--add-label")
+            .arg("loom:issue");
+        edit.current_dir(&self.config.workspace_root);
+        if let Ok(repo) = std::env::var("LOOM_REPO") {
+            edit.arg("--repo").arg(repo);
+        }
+        edit.stdout(Stdio::null()).stderr(Stdio::piped());
+        if let Err(e) = edit.output() {
+            log::debug!("sweep_registry: quarantine-release label edit for #{issue} failed: {e}");
+        }
     }
 
     // ------------------------------------------------------------------------
@@ -1787,6 +2117,11 @@ impl SweepRegistry {
     pub fn reap_once(&mut self) -> usize {
         let mut changes = 0usize;
 
+        // Insta-crash quarantine TTL (#3939): release any issue whose quarantine
+        // has aged past the configured window before this tick's work. Cheap
+        // early-return when nothing is quarantined.
+        self.expire_quarantine();
+
         // Snapshot keys + pids first so we can borrow mutably below.
         // Capture started_at so we can compute durations for Exited events.
         let candidates: Vec<(SweepId, u32, SweepState, SweepKind, chrono::DateTime<Utc>)> = self
@@ -1847,6 +2182,13 @@ impl SweepRegistry {
                                 sweep_id: sweep_id.clone(),
                                 outcome: SweepOutcome::Crashed,
                             });
+                            // Insta-crash quarantine (#3939): a checkpoint exists,
+                            // so this sweep reached real work — the mid-build-death
+                            // watchdog (#3895) owns this failure mode, and it is
+                            // explicitly NOT an insta-crash. Reset the consecutive
+                            // tally so a genuine mid-build death never accretes
+                            // toward quarantine.
+                            self.record_terminal_outcome(issue, false);
                         } else {
                             // Orphaned-claim recovery (issue #3823b): a
                             // daemon-owned sweep that exits cleanly WITHOUT a
@@ -1887,6 +2229,18 @@ impl SweepRegistry {
                                 sweep_id: sweep_id.clone(),
                                 outcome: SweepOutcome::Exited,
                             });
+                            // Insta-crash quarantine (#3939): a checkpoint-less
+                            // death inside the insta-crash window that did NOT
+                            // exit cleanly (exit_code != 0, or an unknown
+                            // signal-death) never reached real work — the #3938
+                            // "missing token pool / import failure" case. Count it
+                            // toward quarantine. A clean exit (code 0 — the
+                            // legitimate self-skip / no-work path) or a slow death
+                            // past the window resets the tally instead.
+                            let insta_crash = duration_sec
+                                < self.quarantine_config.insta_crash_secs
+                                && exit_code != Some(0);
+                            self.record_terminal_outcome(issue, insta_crash);
                         }
                         // Block-the-subtree (issue #3729, v1 item 4): if this
                         // parent ended in `loom:blocked` and stacked children
@@ -3008,6 +3362,112 @@ pub fn resolve_review_stall_timeout(config: &StartupRaceConfig) -> Duration {
         .or(config.review_stall_timeout_secs)
         .unwrap_or(DEFAULT_REVIEW_STALL_TIMEOUT_SECS);
     Duration::from_secs(secs)
+}
+
+// ============================================================================
+// Insta-crash quarantine config resolution (Issue #3939)
+// ============================================================================
+
+/// The subset of `.loom/config.json → autonomous.workFinder.quarantine` this
+/// module consumes (Issue #3939). Each field is `Option` so an absent key falls
+/// through to the env-var / built-in-default resolution — precedence
+/// **env > config > default** for every knob, matching the rest of the module.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct QuarantineFileConfig {
+    /// `autonomous.workFinder.quarantine.enabled` — whether quarantine runs.
+    pub enabled: Option<bool>,
+    /// `autonomous.workFinder.quarantine.threshold` — consecutive insta-crashes
+    /// before quarantine (zero/invalid dropped to `None`).
+    pub threshold: Option<u32>,
+    /// `autonomous.workFinder.quarantine.ttlSecs` — quarantine TTL, in seconds
+    /// (zero/invalid dropped to `None`).
+    pub ttl_secs: Option<u64>,
+    /// `autonomous.workFinder.quarantine.instaCrashSecs` — insta-crash window, in
+    /// seconds (zero/invalid dropped to `None`).
+    pub insta_crash_secs: Option<u64>,
+}
+
+/// Read `.loom/config.json → autonomous.workFinder.quarantine` (Issue #3939),
+/// soft-failing every field to `None` on a missing file, malformed JSON, or an
+/// absent `autonomous` / `workFinder` / `quarantine` block. Mirrors
+/// [`read_startup_race_config`].
+#[must_use]
+pub fn read_quarantine_file_config(repo_root: &Path) -> QuarantineFileConfig {
+    let config_path = repo_root.join(".loom").join("config.json");
+    let Ok(config_str) = std::fs::read_to_string(&config_path) else {
+        return QuarantineFileConfig::default();
+    };
+    let Ok(config) = serde_json::from_str::<serde_json::Value>(&config_str) else {
+        log::warn!("sweep_registry: could not parse config at {}", config_path.display());
+        return QuarantineFileConfig::default();
+    };
+    let block = config
+        .get("autonomous")
+        .and_then(|a| a.get("workFinder"))
+        .and_then(|w| w.get("quarantine"));
+    let Some(q) = block else {
+        return QuarantineFileConfig::default();
+    };
+    QuarantineFileConfig {
+        enabled: q.get("enabled").and_then(serde_json::Value::as_bool),
+        threshold: q
+            .get("threshold")
+            .and_then(serde_json::Value::as_u64)
+            .filter(|&n| n > 0)
+            .and_then(|n| u32::try_from(n).ok()),
+        ttl_secs: q
+            .get("ttlSecs")
+            .and_then(serde_json::Value::as_u64)
+            .filter(|&s| s > 0),
+        insta_crash_secs: q
+            .get("instaCrashSecs")
+            .and_then(serde_json::Value::as_u64)
+            .filter(|&s| s > 0),
+    }
+}
+
+/// Resolve the full [`QuarantineConfig`] for `repo_root` with precedence
+/// **env > config > default** for every knob (Issue #3939). Reads the file
+/// config internally, then layers env overrides on top, then the shipped
+/// defaults. Enabled defaults **on** — it is a safety backstop.
+#[must_use]
+pub fn resolve_quarantine_config(repo_root: &Path) -> QuarantineConfig {
+    let file = read_quarantine_file_config(repo_root);
+
+    let enabled = if let Ok(v) = std::env::var(QUARANTINE_ENABLE_ENV) {
+        matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on")
+    } else {
+        file.enabled.unwrap_or(true)
+    };
+
+    let threshold = std::env::var(QUARANTINE_THRESHOLD_ENV)
+        .ok()
+        .and_then(|v| v.trim().parse::<u32>().ok())
+        .filter(|&n| n > 0)
+        .or(file.threshold)
+        .unwrap_or(DEFAULT_QUARANTINE_THRESHOLD);
+
+    let ttl_secs = std::env::var(QUARANTINE_TTL_ENV)
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|&s| s > 0)
+        .or(file.ttl_secs)
+        .unwrap_or(DEFAULT_QUARANTINE_TTL_SECS);
+
+    let insta_crash_secs = std::env::var(QUARANTINE_INSTA_CRASH_ENV)
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|&s| s > 0)
+        .or(file.insta_crash_secs)
+        .and_then(|s| i64::try_from(s).ok())
+        .unwrap_or(DEFAULT_QUARANTINE_INSTA_CRASH_SECS);
+
+    QuarantineConfig {
+        enabled,
+        threshold,
+        ttl: Duration::from_secs(ttl_secs),
+        insta_crash_secs,
+    }
 }
 
 /// Spawn the watchdog task (Issue #3887 + #3895 + #3910). Every `interval`, it
@@ -4260,6 +4720,269 @@ exit 0
         assert!(changed >= 1);
         let info = registry.get(&sweep_id).unwrap();
         assert!(matches!(info.state, SweepState::Exited { .. }));
+    }
+
+    // ------------------------------------------------------------------------
+    // Insta-crash quarantine (Issue #3939)
+    // ------------------------------------------------------------------------
+
+    /// Insert a fresh `Running` entry for `issue` with a guaranteed-dead PID and
+    /// `started_at` at `now` (so the reaper classifies its death as within the
+    /// insta-crash window). Returns the synthetic sweep_id.
+    fn insert_dead_running(registry: &mut SweepRegistry, issue: u32, seq: u32) -> String {
+        let sweep_id = format!("sweep-issue-{issue}-{seq}");
+        registry.entries.insert(
+            sweep_id.clone(),
+            SweepInfo {
+                sweep_id: sweep_id.clone(),
+                kind: SweepKind::Issue(issue),
+                pid: 2_147_483_640, // ~i32::MAX, almost certainly dead
+                token_name: "unknown".into(),
+                log_path: registry.compute_log_path(issue),
+                idempotency_key: None,
+                started_at: Utc::now(),
+                state: SweepState::Running,
+                latest_phase: None,
+                pr_number: None,
+                model: None,
+                effort: None,
+                depends_on: None,
+                repo: None,
+            },
+        );
+        sweep_id
+    }
+
+    /// AC #1: the consecutive-insta-crash counter increments and, at the
+    /// threshold, quarantines. Exercises `record_terminal_outcome` directly so
+    /// the classification (which depends on a real child's exit code) is not in
+    /// the way of the counter/threshold logic.
+    #[test]
+    fn record_terminal_outcome_counts_then_quarantines_at_threshold() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+        // Default config: threshold 3.
+        assert_eq!(registry.quarantine_config().threshold, 3);
+
+        registry.record_terminal_outcome(7, true);
+        assert_eq!(registry.insta_crash_count(7), 1);
+        assert!(!registry.is_quarantined(7));
+
+        registry.record_terminal_outcome(7, true);
+        assert_eq!(registry.insta_crash_count(7), 2);
+        assert!(!registry.is_quarantined(7));
+
+        registry.record_terminal_outcome(7, true);
+        assert_eq!(registry.insta_crash_count(7), 3);
+        assert!(registry.is_quarantined(7), "3rd consecutive insta-crash quarantines");
+    }
+
+    /// AC #1: a non-insta terminal outcome (real progress / clean exit) resets
+    /// the consecutive tally, so only *consecutive* insta-crashes accrue.
+    #[test]
+    fn record_terminal_outcome_resets_run_on_progress() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+
+        registry.record_terminal_outcome(8, true);
+        registry.record_terminal_outcome(8, true);
+        assert_eq!(registry.insta_crash_count(8), 2);
+
+        // Real progress / clean exit breaks the streak.
+        registry.record_terminal_outcome(8, false);
+        assert_eq!(registry.insta_crash_count(8), 0);
+        assert!(!registry.is_quarantined(8));
+
+        // A subsequent insta-crash starts the count over — one is not enough.
+        registry.record_terminal_outcome(8, true);
+        assert_eq!(registry.insta_crash_count(8), 1);
+        assert!(!registry.is_quarantined(8));
+    }
+
+    /// Disabled quarantine (config `enabled=false`) is a total no-op: no counting,
+    /// no quarantine — byte-for-byte the pre-#3939 path.
+    #[test]
+    fn record_terminal_outcome_noop_when_disabled() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+        registry.set_quarantine_config(QuarantineConfig {
+            enabled: false,
+            ..QuarantineConfig::default()
+        });
+        for _ in 0..5 {
+            registry.record_terminal_outcome(9, true);
+        }
+        assert_eq!(registry.insta_crash_count(9), 0);
+        assert!(!registry.is_quarantined(9));
+    }
+
+    /// AC #1 (end-to-end via the reaper): three consecutive checkpoint-less quick
+    /// deaths — re-dispatched each time — drive the issue into quarantine. The
+    /// dead-PID kill-probe yields no exit code, which the reaper treats as a
+    /// non-clean death inside the insta-crash window (the #3938 case).
+    #[test]
+    fn reaper_quarantines_after_consecutive_insta_crashes() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+
+        for seq in 0..3 {
+            insert_dead_running(&mut registry, 42, seq);
+            registry.reap_once();
+        }
+        assert!(registry.is_quarantined(42), "issue #42 quarantined after 3 insta-crashes");
+        assert!(
+            registry.quarantined_issues().contains(&42),
+            "quarantined set exposes #42 to the work finder"
+        );
+        assert_eq!(registry.quarantined_issues_sorted(), vec![42]);
+    }
+
+    /// AC #1: a death WITH a checkpoint (real work happened) is NOT an
+    /// insta-crash — it is the mid-build-death watchdog's remit (#3895) — so it
+    /// never counts toward quarantine.
+    #[test]
+    fn reaper_checkpoint_death_does_not_count_as_insta_crash() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+
+        let cp_dir = registry.config.checkpoint_dir();
+        std::fs::create_dir_all(&cp_dir).unwrap();
+        std::fs::write(cp_dir.join("issue-43.json"), r#"{"phase":"builder","issue":43}"#).unwrap();
+
+        for seq in 0..5 {
+            insert_dead_running(&mut registry, 43, seq);
+            registry.reap_once();
+        }
+        assert_eq!(registry.insta_crash_count(43), 0, "checkpoint deaths never count");
+        assert!(!registry.is_quarantined(43), "a mid-build death is not quarantined");
+    }
+
+    /// AC #4: a quarantine entry auto-releases once it ages past the TTL, and the
+    /// insta-crash tally is cleared so the issue re-qualifies with a fresh runway.
+    #[test]
+    fn quarantine_expires_after_ttl() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+        registry.set_quarantine_config(QuarantineConfig {
+            ttl: Duration::from_secs(3600),
+            ..QuarantineConfig::default()
+        });
+
+        // Quarantine #44 with a timestamp two hours in the past (past the 1h TTL).
+        registry
+            .quarantined
+            .insert(44, Utc::now() - chrono::Duration::seconds(7200));
+        registry.insta_crash_counts.insert(44, 3);
+        assert!(registry.is_quarantined(44));
+
+        // reap_once runs expire_quarantine at the top of the tick.
+        registry.reap_once();
+        assert!(!registry.is_quarantined(44), "aged-out quarantine is released");
+        assert_eq!(registry.insta_crash_count(44), 0, "tally cleared on release");
+    }
+
+    /// AC #4: a quarantine entry within its TTL is NOT released early.
+    #[test]
+    fn quarantine_within_ttl_is_retained() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+        registry.set_quarantine_config(QuarantineConfig {
+            ttl: Duration::from_secs(3600),
+            ..QuarantineConfig::default()
+        });
+
+        // Quarantined 10s ago — well inside the 1h TTL.
+        registry
+            .quarantined
+            .insert(45, Utc::now() - chrono::Duration::seconds(10));
+        registry.reap_once();
+        assert!(registry.is_quarantined(45), "a fresh quarantine survives the TTL check");
+    }
+
+    /// AC #2/#4: the operator-action release path clears both the quarantine and
+    /// the insta-crash tally.
+    #[test]
+    fn clear_quarantine_releases_entry() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+        registry.quarantined.insert(46, Utc::now());
+        registry.insta_crash_counts.insert(46, 3);
+
+        assert!(registry.clear_quarantine(46), "returns true when an entry existed");
+        assert!(!registry.is_quarantined(46));
+        assert_eq!(registry.insta_crash_count(46), 0);
+        assert!(!registry.clear_quarantine(46), "idempotent: false when nothing to clear");
+    }
+
+    /// Config resolution honors precedence env > config > default (#3939).
+    #[test]
+    #[serial]
+    fn resolve_quarantine_config_env_overrides() {
+        let dir = tempdir().unwrap();
+        // No file, no env → shipped defaults (enabled, threshold 3).
+        let base = resolve_quarantine_config(dir.path());
+        assert!(base.enabled);
+        assert_eq!(base.threshold, DEFAULT_QUARANTINE_THRESHOLD);
+        assert_eq!(base.insta_crash_secs, DEFAULT_QUARANTINE_INSTA_CRASH_SECS);
+
+        std::env::set_var(QUARANTINE_THRESHOLD_ENV, "5");
+        std::env::set_var(QUARANTINE_TTL_ENV, "120");
+        std::env::set_var(QUARANTINE_INSTA_CRASH_ENV, "30");
+        std::env::set_var(QUARANTINE_ENABLE_ENV, "off");
+        let resolved = resolve_quarantine_config(dir.path());
+        std::env::remove_var(QUARANTINE_THRESHOLD_ENV);
+        std::env::remove_var(QUARANTINE_TTL_ENV);
+        std::env::remove_var(QUARANTINE_INSTA_CRASH_ENV);
+        std::env::remove_var(QUARANTINE_ENABLE_ENV);
+
+        assert!(!resolved.enabled, "LOOM_WORK_FINDER_QUARANTINE=off disables");
+        assert_eq!(resolved.threshold, 5);
+        assert_eq!(resolved.ttl, Duration::from_secs(120));
+        assert_eq!(resolved.insta_crash_secs, 30);
+    }
+
+    /// Config-file parsing of `autonomous.workFinder.quarantine` (#3939).
+    #[test]
+    #[serial]
+    fn read_quarantine_file_config_parses_block() {
+        // Ensure env does not shadow the file values for the resolve assertion.
+        std::env::remove_var(QUARANTINE_THRESHOLD_ENV);
+        std::env::remove_var(QUARANTINE_TTL_ENV);
+        std::env::remove_var(QUARANTINE_INSTA_CRASH_ENV);
+        std::env::remove_var(QUARANTINE_ENABLE_ENV);
+
+        let dir = tempdir().unwrap();
+        let loom = dir.path().join(".loom");
+        std::fs::create_dir_all(&loom).unwrap();
+        std::fs::write(
+            loom.join("config.json"),
+            r#"{"autonomous":{"workFinder":{"quarantine":{"enabled":true,"threshold":4,"ttlSecs":900,"instaCrashSecs":45}}}}"#,
+        )
+        .unwrap();
+
+        let file = read_quarantine_file_config(dir.path());
+        assert_eq!(file.enabled, Some(true));
+        assert_eq!(file.threshold, Some(4));
+        assert_eq!(file.ttl_secs, Some(900));
+        assert_eq!(file.insta_crash_secs, Some(45));
+
+        // And the full resolver folds them in (no env set).
+        let resolved = resolve_quarantine_config(dir.path());
+        assert_eq!(resolved.threshold, 4);
+        assert_eq!(resolved.ttl, Duration::from_secs(900));
+        assert_eq!(resolved.insta_crash_secs, 45);
+    }
+
+    /// A missing `quarantine` block yields all-`None` (env/default resolution) —
+    /// zero behavior change for repos that never configure it.
+    #[test]
+    fn read_quarantine_file_config_absent_block_is_none() {
+        let dir = tempdir().unwrap();
+        let loom = dir.path().join(".loom");
+        std::fs::create_dir_all(&loom).unwrap();
+        std::fs::write(loom.join("config.json"), r#"{"autonomous":{"workFinder":{}}}"#).unwrap();
+        let file = read_quarantine_file_config(dir.path());
+        assert_eq!(file, QuarantineFileConfig::default());
     }
 
     /// Issue #3823b: orphaned-claim recovery. A daemon-owned sweep that exits

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -969,10 +969,29 @@ impl SweepRegistry {
     }
 
     /// Manually clear an issue's quarantine + insta-crash tally (Issue #3939),
-    /// the operator-action release path. Returns `true` when an entry existed.
+    /// the operator-action release path (reachable via the `ClearQuarantine` IPC
+    /// request / `loom-daemon quarantine clear <issue>` CLI). Returns `true` when
+    /// an entry existed. When an entry is actually cleared, a best-effort forge
+    /// label restore re-arms `loom:issue` (mirroring [`expire_quarantine`]), so
+    /// the operator command both releases the in-memory pause and re-enters the
+    /// issue into the work-finder queue — the label flip alone never sufficed.
     pub fn clear_quarantine(&mut self, issue: u32) -> bool {
         self.insta_crash_counts.remove(&issue);
-        self.quarantined.remove(&issue).is_some()
+        let was_quarantined = self.quarantined.remove(&issue).is_some();
+        if was_quarantined {
+            self.release_quarantine_label(issue);
+        }
+        was_quarantined
+    }
+
+    /// Test-only helper: seed an in-memory quarantine entry for `issue` so
+    /// cross-module tests (e.g. the IPC dispatcher in `ipc.rs`) can exercise the
+    /// `ClearQuarantine` path without driving the full insta-crash accrual.
+    #[cfg(test)]
+    pub fn seed_quarantine_for_test(&mut self, issue: u32) {
+        self.quarantined.insert(issue, Utc::now());
+        self.insta_crash_counts
+            .insert(issue, self.quarantine_config.threshold);
     }
 
     /// Read-only accessor for the event bus, if any. Exposed so external
@@ -1461,12 +1480,18 @@ impl SweepRegistry {
 
         let body = format!(
             "Auto-quarantined by loom-daemon (#3939): this issue's sweep insta-crashed {count} \
-             times in a row — each child died within {}s of dispatch without writing a phase \
+             times in a row — each child died within {secs}s of dispatch without writing a phase \
              checkpoint, which almost always means an environment/configuration failure (e.g. a \
              missing token pool, #3938) rather than a problem with the issue itself. Re-dispatch \
              is paused so it stops occupying a global concurrency slot and starving other work. \
-             Once the underlying cause is fixed, remove `loom:blocked` and re-add `loom:issue`.",
-            self.quarantine_config.insta_crash_secs
+             Once the underlying cause is fixed, clear the quarantine with `loom-daemon \
+             quarantine clear {issue}` (this releases the in-memory pause AND restores \
+             `loom:issue`), or simply wait for the {ttl}s TTL to auto-release it. Note: manually \
+             flipping `loom:blocked` -> `loom:issue` on the forge does NOT release the daemon's \
+             in-memory quarantine on its own — the work finder skips it until the CLI clear or the \
+             TTL fires.",
+            secs = self.quarantine_config.insta_crash_secs,
+            ttl = self.quarantine_config.ttl.as_secs(),
         );
         let mut comment = Command::new(&gh);
         comment
@@ -4912,6 +4937,73 @@ exit 0
         assert!(!registry.is_quarantined(46));
         assert_eq!(registry.insta_crash_count(46), 0);
         assert!(!registry.clear_quarantine(46), "idempotent: false when nothing to clear");
+    }
+
+    /// The operator-action release path (`clear_quarantine`) must restore
+    /// `loom:issue` on the forge — the whole point of the #3960 fix is that
+    /// clearing the in-memory quarantine ALSO re-arms the label, so the manual
+    /// path is not a dead-end that leaves the issue stuck in `loom:blocked`.
+    #[test]
+    fn clear_quarantine_restores_forge_label() {
+        let dir = tempdir().unwrap();
+        let gh_log = dir.path().join("gh-invocations.log");
+        let fake_gh = dir.path().join("fake-gh.sh");
+        let script = format!(
+            "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"{}\"\nexit 0\n",
+            gh_log.display()
+        );
+        std::fs::write(&fake_gh, &script).unwrap();
+        let mut perms = std::fs::metadata(&fake_gh).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fake_gh, perms).unwrap();
+        if let Ok(f) = std::fs::File::open(&fake_gh) {
+            let _ = f.sync_all();
+        }
+
+        let mut config = SweepRegistryConfig::new(dir.path().to_path_buf());
+        config.gh_bin = Some(fake_gh);
+        config.skip_label_flip = false; // exercise the real restore path
+        let mut registry = SweepRegistry::new(config);
+        registry.quarantined.insert(52, Utc::now());
+        registry.insta_crash_counts.insert(52, 3);
+
+        assert!(registry.clear_quarantine(52));
+        assert!(!registry.is_quarantined(52));
+
+        let gh_calls = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert!(
+            gh_calls.contains("issue edit 52 --remove-label loom:blocked --add-label loom:issue"),
+            "expected clear_quarantine to restore loom:blocked -> loom:issue; got: {gh_calls:?}"
+        );
+    }
+
+    /// A no-op clear (issue not quarantined) must NOT touch the forge — no
+    /// stray label edit for an issue that was never blocked.
+    #[test]
+    fn clear_quarantine_noop_skips_forge_label() {
+        let dir = tempdir().unwrap();
+        let gh_log = dir.path().join("gh-invocations.log");
+        let fake_gh = dir.path().join("fake-gh.sh");
+        let script = format!(
+            "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"{}\"\nexit 0\n",
+            gh_log.display()
+        );
+        std::fs::write(&fake_gh, &script).unwrap();
+        let mut perms = std::fs::metadata(&fake_gh).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fake_gh, perms).unwrap();
+
+        let mut config = SweepRegistryConfig::new(dir.path().to_path_buf());
+        config.gh_bin = Some(fake_gh);
+        config.skip_label_flip = false;
+        let mut registry = SweepRegistry::new(config);
+
+        assert!(!registry.clear_quarantine(999), "no-op when not quarantined");
+        let gh_calls = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert!(
+            gh_calls.is_empty(),
+            "expected no forge call for a no-op clear; got: {gh_calls:?}"
+        );
     }
 
     /// Config resolution honors precedence env > config > default (#3939).

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -265,6 +265,21 @@ pub enum Request {
         #[serde(default)]
         workspace_root: Option<String>,
     },
+    /// Manually clear an insta-crash quarantine (Issue #3939) for `issue`,
+    /// the operator-reachable release path (`loom-daemon quarantine clear
+    /// <issue>`). Clears the daemon's in-memory quarantine + insta-crash tally
+    /// so the work finder re-qualifies the issue immediately instead of waiting
+    /// for the TTL, and restores `loom:issue` on the forge. Idempotent — clearing
+    /// an issue that is not quarantined is a no-op success (`was_quarantined:
+    /// false`).
+    ClearQuarantine {
+        issue: u32,
+        /// Target managed-workspace root (Issue #3929). `Some(root)` clears a
+        /// quarantine tracked by that repo's registry; `None` (or absent) uses
+        /// the default workspace, exactly like `CancelSweep`.
+        #[serde(default)]
+        workspace_root: Option<String>,
+    },
     // ========================================================================
     // Autonomous Daemon Status (Issue #3891 — follow-up to #3813 Phase D)
     // ========================================================================
@@ -421,6 +436,13 @@ pub enum Response {
         pid: u32,
         sigkill_sent: bool,
         was_running: bool,
+    },
+    /// Result of a `ClearQuarantine` request (Issue #3939). `was_quarantined`
+    /// is `false` when the issue was not quarantined at the moment of the call
+    /// (idempotent no-op success — the in-memory state was already clear).
+    QuarantineCleared {
+        issue: u32,
+        was_quarantined: bool,
     },
     // ========================================================================
     // Autonomous Daemon Status (Issue #3891 — follow-up to #3813 Phase D)

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -702,6 +702,14 @@ pub struct RepoStatus {
     /// dispatch, never the siblings'. Always `false` for a repo whose gate is
     /// disabled / has no `buildGate` block, or when the gate loop is off.
     pub health_gate_halted: bool,
+    /// Issue numbers currently quarantined for repeated insta-crashing in this
+    /// repo (Issue #3939), sorted ascending. The work finder skips these until
+    /// their TTL elapses (or an operator clears them), so this surfaces *why* a
+    /// repo with a visible backlog is dispatching nothing. Empty in the common
+    /// case. `#[serde(default)]` keeps pre-#3939 wire data / older clients
+    /// compatible (an absent field parses as an empty vec).
+    #[serde(default)]
+    pub quarantined_issues: Vec<u32>,
 }
 
 /// The token-capacity section of [`DaemonStatusReport`] (#3902).

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -305,6 +305,18 @@ pub trait WorkDispatcher {
     /// `Pending`) sweep — the authoritative "already in-flight" view.
     fn in_flight(&self) -> HashSet<u32>;
 
+    /// The set of issue numbers currently **quarantined** for repeated
+    /// insta-crashing (Issue #3939). The finder skips these entirely — they are
+    /// filtered out of the candidate list *before* the concurrency budget is
+    /// filled, so a workspace whose only candidates are quarantined never
+    /// reserves a shared dispatch slot (no cross-repo starvation).
+    ///
+    /// Defaults to empty so a dispatcher that does not model quarantine (e.g. a
+    /// test fake) opts out with zero boilerplate.
+    fn quarantined(&self) -> HashSet<u32> {
+        HashSet::new()
+    }
+
     /// Dispatch a build sweep for `issue`. Returns `true` when a **new** sweep
     /// was started, `false` when the dispatch was an idempotency no-op (a sweep
     /// with the same key was already running).
@@ -334,6 +346,10 @@ pub struct TickReport {
     pub skipped_in_flight: usize,
     /// Issues deferred to a future tick because the concurrency cap was reached.
     pub deferred_capacity: usize,
+    /// Issues skipped because they are quarantined for repeated insta-crashing
+    /// (Issue #3939). Filtered out before the concurrency budget is allocated, so
+    /// a quarantined candidate never consumes a shared dispatch slot.
+    pub skipped_quarantined: usize,
     /// Dispatch attempts that returned an error (logged, non-fatal).
     pub errors: usize,
     /// True when this tick dispatched nothing because the main-health gate
@@ -382,6 +398,7 @@ pub fn tick(
     }
 
     let in_flight = dispatcher.in_flight();
+    let quarantined = dispatcher.quarantined();
     let mut occupancy = in_flight.len();
 
     for item in ready {
@@ -393,6 +410,13 @@ pub fn tick(
         // 2. Authoritative in-flight dedup against the registry.
         if in_flight.contains(&item.number) {
             report.skipped_in_flight += 1;
+            continue;
+        }
+        // 2b. Insta-crash quarantine (#3939): skip a repeatedly-insta-crashing
+        //     issue rather than re-dispatching it every tick. Checked before the
+        //     capacity gate so a quarantined issue never consumes a slot.
+        if quarantined.contains(&item.number) {
+            report.skipped_quarantined += 1;
             continue;
         }
         // 3. Fixed concurrency cap — defer the rest to a future tick.
@@ -492,6 +516,13 @@ pub fn tick_multi<S: WorkSource, D: WorkDispatcher>(
     let in_flights: Vec<HashSet<u32>> = workspaces.iter().map(|(_, d)| d.in_flight()).collect();
     let mut occupancy: usize = in_flights.iter().map(HashSet::len).sum();
 
+    // Snapshot each workspace's quarantined set (#3939) alongside its in-flight
+    // set. Quarantined candidates are dropped in pass 1 *before* the global sort
+    // and slot fill, so a workspace whose only candidates are quarantined never
+    // reserves a shared dispatch slot — its slots go to healthy sibling work.
+    let quarantined_sets: Vec<HashSet<u32>> =
+        workspaces.iter().map(|(_, d)| d.quarantined()).collect();
+
     // Whether any workspace was gated this tick — folds down to the pre-#3930
     // single-flag semantics for a single (empty-registry) workspace.
     let mut any_halted = false;
@@ -536,6 +567,12 @@ pub fn tick_multi<S: WorkSource, D: WorkDispatcher>(
             }
             if in_flight.contains(&item.number) {
                 report.skipped_in_flight += 1;
+                continue;
+            }
+            // Insta-crash quarantine (#3939): drop before the candidate ever
+            // enters the global queue, so it consumes no shared slot.
+            if quarantined_sets[idx].contains(&item.number) {
+                report.skipped_quarantined += 1;
                 continue;
             }
             candidates.push(PriorityCandidate {
@@ -917,17 +954,19 @@ where
                         log::info!("work_finder: main-health gate cleared — resuming dispatch");
                     }
                     was_halted = report.halted;
-                    if report.dispatched > 0 || report.errors > 0 {
+                    if report.dispatched > 0 || report.errors > 0 || report.skipped_quarantined > 0
+                    {
                         log::info!(
                             "work_finder: tick — cap {max_concurrent} (pool={pool_size}, \
                              healthy={token_limit}, per_token={per_token_concurrency}, disk={disk}, \
                              ceiling={configured_max}); \
                              {} seen, {} dispatched, {} labeled-skip, {} in-flight-skip, \
-                             {} deferred, {} error(s)",
+                             {} quarantine-skip, {} deferred, {} error(s)",
                             report.seen,
                             report.dispatched,
                             report.skipped_labeled,
                             report.skipped_in_flight,
+                            report.skipped_quarantined,
                             report.deferred_capacity,
                             report.errors
                         );
@@ -1075,18 +1114,19 @@ pub fn spawn_multi_work_finder_task(
             }
             was_halted = report.halted;
 
-            if report.dispatched > 0 || report.errors > 0 {
+            if report.dispatched > 0 || report.errors > 0 || report.skipped_quarantined > 0 {
                 log::info!(
                     "work_finder: tick — cap {max_concurrent} (pool={pool_size}, \
                      healthy={token_limit}, per_token={per_token_concurrency}, disk={disk}, \
                      ceiling={configured_max}); {} workspace(s), \
-                     {} seen, {} dispatched, {} labeled-skip, {} in-flight-skip, {} deferred, \
-                     {} error(s)",
+                     {} seen, {} dispatched, {} labeled-skip, {} in-flight-skip, \
+                     {} quarantine-skip, {} deferred, {} error(s)",
                     pairs.len(),
                     report.seen,
                     report.dispatched,
                     report.skipped_labeled,
                     report.skipped_in_flight,
+                    report.skipped_quarantined,
                     report.deferred_capacity,
                     report.errors
                 );
@@ -1334,6 +1374,16 @@ pub mod forge {
             set
         }
 
+        fn quarantined(&self) -> HashSet<u32> {
+            match self.registry.lock() {
+                Ok(reg) => reg.quarantined_issues(),
+                Err(poisoned) => {
+                    log::error!("work_finder: sweep registry mutex poisoned ({poisoned:?})");
+                    HashSet::new()
+                }
+            }
+        }
+
         fn dispatch(&mut self, issue: u32) -> Result<bool> {
             let mut reg = self
                 .registry
@@ -1404,11 +1454,16 @@ mod tests {
         noop_issues: HashSet<u32>,
         /// Issue numbers whose dispatch should error.
         fail_issues: HashSet<u32>,
+        /// Issue numbers this dispatcher reports as quarantined (Issue #3939).
+        quarantined: HashSet<u32>,
     }
 
     impl WorkDispatcher for RecordingDispatcher {
         fn in_flight(&self) -> HashSet<u32> {
             self.in_flight.clone()
+        }
+        fn quarantined(&self) -> HashSet<u32> {
+            self.quarantined.clone()
         }
         fn dispatch(&mut self, issue: u32) -> Result<bool> {
             if self.fail_issues.contains(&issue) {
@@ -1498,6 +1553,64 @@ mod tests {
         assert_eq!(report.skipped_labeled, 3);
         assert_eq!(report.dispatched, 1);
         assert_eq!(disp.dispatched, vec![4]);
+    }
+
+    #[test]
+    fn test_tick_skips_quarantined_issue() {
+        // Insta-crash quarantine (#3939): a quarantined issue is skipped — never
+        // dispatched — and counted in `skipped_quarantined`, while its healthy
+        // siblings dispatch normally.
+        let mut source = FakeSource::once(vec![issue(1), issue(2), issue(3)]);
+        let mut disp = RecordingDispatcher {
+            quarantined: HashSet::from([2]),
+            ..Default::default()
+        };
+        let report = tick(&mut source, &mut disp, 10, false).unwrap();
+
+        assert_eq!(report.skipped_quarantined, 1, "#2 is quarantined");
+        assert_eq!(report.dispatched, 2, "#1 and #3 still dispatch");
+        assert_eq!(disp.dispatched, vec![1, 3], "#2 never dispatched");
+    }
+
+    #[test]
+    fn test_tick_quarantined_does_not_consume_capacity_slot() {
+        // The quarantine skip happens BEFORE the capacity gate, so a quarantined
+        // issue never reserves a slot: with cap 1 and #1 quarantined, #2 gets the
+        // slot rather than the tick deferring #2 behind a wasted #1 dispatch.
+        let mut source = FakeSource::once(vec![issue(1), issue(2)]);
+        let mut disp = RecordingDispatcher {
+            quarantined: HashSet::from([1]),
+            ..Default::default()
+        };
+        let report = tick(&mut source, &mut disp, 1, false).unwrap();
+
+        assert_eq!(report.skipped_quarantined, 1);
+        assert_eq!(report.dispatched, 1);
+        assert_eq!(disp.dispatched, vec![2], "the single slot goes to the healthy #2");
+    }
+
+    #[test]
+    fn test_tick_multi_quarantined_workspace_does_not_starve_sibling() {
+        // AC #3 (#3939): workspace A's only candidate is quarantined; workspace B
+        // has a healthy candidate. With a shared cap of 1, B's issue MUST be
+        // dispatched — a quarantined candidate never reserves the shared slot, so
+        // healthy sibling work is not starved.
+        let mut multi = vec![
+            (
+                FakeSource::once(vec![issue(1)]),
+                RecordingDispatcher {
+                    quarantined: HashSet::from([1]),
+                    ..Default::default()
+                },
+            ),
+            (FakeSource::once(vec![issue(10)]), RecordingDispatcher::default()),
+        ];
+        let report = tick_multi(&mut multi, &[], 1, &[false, false]);
+
+        assert_eq!(report.skipped_quarantined, 1, "workspace A's #1 is quarantined");
+        assert_eq!(report.dispatched, 1);
+        assert!(multi[0].1.dispatched.is_empty(), "quarantined workspace dispatches nothing");
+        assert_eq!(multi[1].1.dispatched, vec![10], "healthy sibling gets the shared slot");
     }
 
     #[test]

--- a/loom-daemon/src/workspace_pool.rs
+++ b/loom-daemon/src/workspace_pool.rs
@@ -131,6 +131,10 @@ impl WorkspacePool {
         }
         let startup = sweep_registry::read_startup_race_config(root);
         registry.set_dispatch_stagger(sweep_registry::resolve_dispatch_stagger(&startup));
+        // Insta-crash quarantine (#3939): resolve env > config > default for this
+        // workspace so the reaper quarantines a repeatedly-insta-crashing issue
+        // instead of letting it be re-dispatched every tick.
+        registry.set_quarantine_config(sweep_registry::resolve_quarantine_config(root));
 
         let arc = Arc::new(Mutex::new(registry));
         // Spawn the reaper on the shared daemon runtime regardless of which


### PR DESCRIPTION
## Summary

Adds per-issue insta-crash quarantine to the work finder so a repeatedly-crashing dispatch stops occupying a global concurrency slot every tick and starving healthy work in other managed repos.

- Tracks **consecutive** checkpoint-less deaths within a configurable window (`instaCrashSecs`, default 60s) of dispatch. A death with a checkpoint (real progress made — the mid-build-death watchdog's remit, #3895) or a clean/slow exit resets the tally.
- After `threshold` (default 3) consecutive insta-crashes, the issue is **quarantined**: the work finder skips it in-memory (load-bearing, no forge round-trip required), and best-effort flips `loom:issue` → `loom:blocked` with an explanatory comment.
- Quarantine auto-releases after `ttlSecs` (default 1h), or an operator can release it immediately with `loom-daemon quarantine clear <issue>` (IPC + CLI, added in the #3960 follow-up) — which clears the in-memory quarantine AND restores `loom:issue`. Manually flipping `loom:blocked` -> `loom:issue` on the forge alone does NOT release the in-memory quarantine.
- Visible per-repo in `loom-daemon status` (`quarantined (insta-crash, #3939): #123, #456`).
- `tick_multi` drops quarantined candidates **before** the global slot-fill pass, so a broken workspace's slots go to healthy sibling work in other repos (no cross-repo starvation).
- Fully configurable via `.loom/config.json → autonomous.workFinder.quarantine` (env > config > default precedence, matching every other autonomous knob) — see `.loom/docs/daemon-reference.md`.

Closes #3939

## Test plan
- [x] `cargo test -p loom-daemon --lib` — 774 passed, 0 failed (11 new quarantine tests covering counter/threshold, TTL expiry, disabled no-op, and the `tick_multi` cross-repo-starvation AC)
- [x] `cargo clippy -p loom-daemon --lib --tests --all-targets` — clean
- [x] `cargo fmt -p loom-daemon -- --check` — clean