### PR TITLE
feat(daemon): persisted sweep liveness journal for orphaned-claim recovery

### DIFF
--- a/loom-daemon/src/claim_reconciliation.rs
+++ b/loom-daemon/src/claim_reconciliation.rs
@@ -1,0 +1,496 @@
+//! Daemon-startup reconciliation of stale `loom:building` claims across every
+//! managed workspace (Issue #3953, acceptance criterion 3/4).
+//!
+//! The persisted [`crate::sweep_journal`] gives a fresh daemon (post-restart,
+//! post-rate-limit-kill, post-upgrade) an authoritative liveness source that
+//! survives the in-memory [`crate::sweep_registry::SweepRegistry`] being wiped
+//! clean. This module is the consumer that turns that evidence into action at
+//! startup: for every registered workspace, list the open `loom:building`
+//! issues and decide, per issue, whether the claim is still backed by a live
+//! sweep.
+//!
+//! ## Decision rule
+//!
+//! - A journal entry recording a **live** PID ⇒ [`ReconcileAction::Keep`] —
+//!   the claim is genuinely in-flight.
+//! - A journal entry recording a **dead** PID ⇒
+//!   [`ReconcileAction::Reclaim`] — the sweep behind this claim is provably
+//!   gone.
+//! - **No** journal entry at all (the claim predates this journal, or was
+//!   made by a process that never wrote one) ⇒ reclaim only once the label
+//!   has been stale longer than [`resolve_stale_hours`] (`updated_at` age),
+//!   otherwise `Keep`. This mirrors the Python tool's label-age grace period
+//!   philosophy (#3651): absence of evidence is not, by itself, proof of
+//!   orphanhood — only *aged* absence is.
+//! - No age evidence either (an issue whose `updatedAt` is somehow
+//!   unavailable) ⇒ fail safe to `Keep`.
+//!
+//! The pure [`decide`] / [`plan`] functions take no forge/PID dependencies —
+//! they are fully unit-testable. The `gh`/label-flip glue lives in
+//! [`forge::reconcile_workspace`], which mirrors the `WorkSource`/adapter split
+//! established by [`crate::work_finder::forge`] and
+//! [`crate::epic_supervisor::forge`] (those adapters are likewise not
+//! unit-tested directly — they are thin `Command` wrappers around `gh`).
+
+use chrono::{DateTime, Utc};
+
+use crate::sweep_journal::{self, JournalEntry, SweepJournal};
+
+/// Env var to disable the startup reconciliation pass entirely (kill switch,
+/// not a feature gate — this is corrective crash recovery in the same spirit
+/// as the daemon's existing unconditional stale-claim release in
+/// `activity::release_stale_claims` and `SweepRegistry::reconstruct`, so it
+/// defaults to ON). `0`/`false`/`no`/`off` disables; anything else (including
+/// unset) leaves it enabled.
+pub const RECONCILE_ENABLED_ENV: &str = "LOOM_STALE_CLAIM_RECONCILE";
+
+/// Env var overriding the no-record staleness threshold, in hours.
+pub const STALE_HOURS_ENV: &str = "LOOM_STALE_BUILDING_HOURS";
+
+/// Default no-record staleness threshold: a `loom:building` issue with no
+/// journal entry at all must be untouched for this many hours before it is
+/// considered abandoned. Deliberately generous — a claim made by a
+/// pre-journal daemon, or a CLI-driven sweep with no daemon involvement at
+/// all, should get a wide berth before automatic reclaim.
+pub const DEFAULT_STALE_BUILDING_HOURS: f64 = 4.0;
+
+/// Bound on how many `loom:building` issues one reconciliation pass inspects
+/// per workspace (defense in depth against an unexpectedly huge backlog
+/// turning startup into a `gh`-API storm).
+pub const MAX_ISSUES_PER_WORKSPACE: u32 = 100;
+
+/// Resolve whether the startup reconciliation pass is enabled.
+#[must_use]
+pub fn reconciliation_enabled() -> bool {
+    match std::env::var(RECONCILE_ENABLED_ENV) {
+        Ok(v) => !matches!(v.trim().to_ascii_lowercase().as_str(), "0" | "false" | "no" | "off"),
+        Err(_) => true,
+    }
+}
+
+/// Resolve the no-record staleness threshold (hours) from
+/// [`STALE_HOURS_ENV`], falling back to [`DEFAULT_STALE_BUILDING_HOURS`] for
+/// an absent, unparseable, or non-positive value.
+#[must_use]
+pub fn resolve_stale_hours() -> f64 {
+    std::env::var(STALE_HOURS_ENV)
+        .ok()
+        .and_then(|s| s.parse::<f64>().ok())
+        .filter(|v| *v > 0.0)
+        .unwrap_or(DEFAULT_STALE_BUILDING_HOURS)
+}
+
+/// A `loom:building` issue reported by the forge, trimmed to the fields the
+/// reconciliation decision needs.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BuildingIssue {
+    pub number: u32,
+    /// Parsed `updatedAt` timestamp, when available.
+    pub updated_at: Option<DateTime<Utc>>,
+}
+
+/// Why a claim is being reclaimed — carried through to the log line so an
+/// operator reading the daemon log can tell a dead-process reclaim from a
+/// no-record/stale-age reclaim.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ReclaimReason {
+    /// The journal recorded a PID for this issue and it is no longer alive.
+    DeadPid { pid: u32 },
+    /// No journal record exists, and the issue's `loom:building` label has
+    /// been present longer than the staleness threshold.
+    NoRecordStale { age_hours: f64 },
+}
+
+/// The reconciliation decision for one issue.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ReconcileAction {
+    /// No liveness concern — leave the claim alone.
+    Keep,
+    /// Flip `loom:building` back to `loom:issue`.
+    Reclaim(ReclaimReason),
+}
+
+/// Pure decision function — no I/O, fully unit-testable. See the module docs
+/// for the decision rule.
+#[must_use]
+pub fn decide(
+    issue: &BuildingIssue,
+    journal_entry: Option<&JournalEntry>,
+    is_alive: &dyn Fn(u32) -> bool,
+    stale_hours: f64,
+    now: DateTime<Utc>,
+) -> ReconcileAction {
+    if let Some(entry) = journal_entry {
+        return if is_alive(entry.pid) {
+            ReconcileAction::Keep
+        } else {
+            ReconcileAction::Reclaim(ReclaimReason::DeadPid { pid: entry.pid })
+        };
+    }
+
+    match issue.updated_at {
+        Some(updated) => {
+            let age_hours = (now - updated).num_seconds() as f64 / 3600.0;
+            if age_hours >= stale_hours {
+                ReconcileAction::Reclaim(ReclaimReason::NoRecordStale { age_hours })
+            } else {
+                ReconcileAction::Keep
+            }
+        }
+        // No journal evidence AND no age evidence: fail safe, never reclaim
+        // on a total absence of information.
+        None => ReconcileAction::Keep,
+    }
+}
+
+/// Plan reconciliation decisions for every `issue` in `issues`, given an
+/// already-loaded (and ideally already-pruned) `journal`. Performs no I/O.
+#[must_use]
+pub fn plan(
+    repo: &str,
+    issues: &[BuildingIssue],
+    journal: &SweepJournal,
+    is_alive: &dyn Fn(u32) -> bool,
+    stale_hours: f64,
+    now: DateTime<Utc>,
+) -> Vec<(u32, ReconcileAction)> {
+    issues
+        .iter()
+        .map(|issue| {
+            let entry = sweep_journal::find(journal, repo, issue.number);
+            (issue.number, decide(issue, entry, is_alive, stale_hours, now))
+        })
+        .collect()
+}
+
+/// `gh`/label-flip glue. Not unit-tested directly (mirrors
+/// [`crate::work_finder::forge`] / [`crate::epic_supervisor::forge`]) — the
+/// decision logic above is the fully-covered surface; this module is a thin,
+/// best-effort `Command` wrapper.
+pub mod forge {
+    use super::{
+        plan, resolve_stale_hours, BuildingIssue, ReconcileAction, MAX_ISSUES_PER_WORKSPACE,
+    };
+    use crate::sweep_journal;
+    use anyhow::{anyhow, Context, Result};
+    use serde::Deserialize;
+    use std::path::Path;
+    use std::process::{Command, Stdio};
+
+    #[derive(Debug, Deserialize)]
+    struct GhBuildingIssue {
+        number: u32,
+        #[serde(rename = "updatedAt", default)]
+        updated_at: Option<String>,
+    }
+
+    fn list_building_issues(gh_bin: &Path, root: &Path) -> Result<Vec<BuildingIssue>> {
+        let mut cmd = Command::new(gh_bin);
+        cmd.arg("issue")
+            .arg("list")
+            .arg("--label")
+            .arg("loom:building")
+            .arg("--state")
+            .arg("open")
+            .arg("--limit")
+            .arg(MAX_ISSUES_PER_WORKSPACE.to_string())
+            .arg("--json")
+            .arg("number,updatedAt");
+        cmd.current_dir(root);
+        if let Ok(repo) = std::env::var("LOOM_REPO") {
+            cmd.arg("--repo").arg(repo);
+        }
+        cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+        let out = cmd
+            .output()
+            .with_context(|| format!("failed to invoke {}", gh_bin.display()))?;
+        if !out.status.success() {
+            return Err(anyhow!(
+                "gh issue list --label loom:building failed in {}: {}",
+                root.display(),
+                String::from_utf8_lossy(&out.stderr).trim()
+            ));
+        }
+        let rows: Vec<GhBuildingIssue> =
+            serde_json::from_slice(&out.stdout).context("parse gh issue list JSON")?;
+        Ok(rows
+            .into_iter()
+            .map(|r| BuildingIssue {
+                number: r.number,
+                updated_at: r
+                    .updated_at
+                    .as_deref()
+                    .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                    .map(|dt| dt.with_timezone(&chrono::Utc)),
+            })
+            .collect())
+    }
+
+    fn reclaim(gh_bin: &Path, root: &Path, issue: u32) -> Result<()> {
+        let mut cmd = Command::new(gh_bin);
+        cmd.arg("issue")
+            .arg("edit")
+            .arg(issue.to_string())
+            .arg("--remove-label")
+            .arg("loom:building")
+            .arg("--add-label")
+            .arg("loom:issue");
+        cmd.current_dir(root);
+        if let Ok(repo) = std::env::var("LOOM_REPO") {
+            cmd.arg("--repo").arg(repo);
+        }
+        cmd.stdout(Stdio::null()).stderr(Stdio::piped());
+        let out = cmd
+            .output()
+            .with_context(|| format!("failed to invoke {}", gh_bin.display()))?;
+        if !out.status.success() {
+            return Err(anyhow!(
+                "gh issue edit failed for #{issue} in {}: {}",
+                root.display(),
+                String::from_utf8_lossy(&out.stderr).trim()
+            ));
+        }
+        Ok(())
+    }
+
+    /// Reconcile stale `loom:building` claims for one registered workspace
+    /// `root`, using the machine-level journal as the liveness source.
+    /// Best-effort and bounded: any `gh` failure is logged at `warn` and this
+    /// workspace's pass returns `(0, 0)` rather than propagating an error (one
+    /// repo's forge hiccup must never block the daemon's startup, nor the
+    /// other registered workspaces).
+    ///
+    /// Returns `(checked, reclaimed)` — the number of `loom:building` issues
+    /// inspected and the number actually reclaimed, for the caller's summary
+    /// log line.
+    pub fn reconcile_workspace(gh_bin: &Path, root: &Path) -> (usize, usize) {
+        let repo = root.display().to_string();
+
+        let issues = match list_building_issues(gh_bin, root) {
+            Ok(v) => v,
+            Err(e) => {
+                log::warn!("claim_reconciliation: {}: {e}", root.display());
+                return (0, 0);
+            }
+        };
+        if issues.is_empty() {
+            return (0, 0);
+        }
+
+        let journal_path = match sweep_journal::default_journal_path() {
+            Ok(p) => p,
+            Err(e) => {
+                log::warn!("claim_reconciliation: cannot resolve journal path: {e}");
+                return (0, 0);
+            }
+        };
+        let mut journal = sweep_journal::load(&journal_path);
+        let pruned = sweep_journal::prune_dead(&mut journal, crate::sweep_registry::is_pid_alive);
+        if pruned > 0 {
+            if let Err(e) = sweep_journal::save(&journal_path, &journal) {
+                log::warn!("claim_reconciliation: failed to persist pruned journal: {e}");
+            }
+        }
+
+        let stale_hours = resolve_stale_hours();
+        let now = chrono::Utc::now();
+        let decisions =
+            plan(&repo, &issues, &journal, &crate::sweep_registry::is_pid_alive, stale_hours, now);
+        let checked = decisions.len();
+
+        let mut reclaimed = 0usize;
+        for (issue_number, action) in decisions {
+            let ReconcileAction::Reclaim(reason) = action else {
+                continue;
+            };
+            match reclaim(gh_bin, root, issue_number) {
+                Ok(()) => {
+                    reclaimed += 1;
+                    log::info!(
+                        "claim_reconciliation: reclaimed loom:building -> loom:issue for #{issue_number} \
+                         in {} ({:?})",
+                        root.display(),
+                        reason
+                    );
+                    // Best-effort tidy-up: drop the (now stale-or-absent)
+                    // journal entry so the next pass doesn't re-derive it.
+                    let _ = sweep_journal::remove_sweep(&repo, issue_number);
+                }
+                Err(e) => {
+                    log::warn!(
+                        "claim_reconciliation: failed to reclaim #{issue_number} in {}: {e}",
+                        root.display()
+                    );
+                }
+            }
+        }
+
+        (checked, reclaimed)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+    use serial_test::serial;
+
+    fn issue(number: u32, updated_at: Option<DateTime<Utc>>) -> BuildingIssue {
+        BuildingIssue { number, updated_at }
+    }
+
+    fn journal_entry(repo: &str, issue: u32, pid: u32) -> JournalEntry {
+        JournalEntry {
+            repo: repo.to_string(),
+            issue,
+            pid,
+            started_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn decide_keeps_when_journal_entry_pid_alive() {
+        let now = Utc::now();
+        let entry = journal_entry("/repo/a", 42, 111);
+        let action = decide(&issue(42, None), Some(&entry), &|_| true, 4.0, now);
+        assert_eq!(action, ReconcileAction::Keep);
+    }
+
+    #[test]
+    fn decide_reclaims_when_journal_entry_pid_dead() {
+        let now = Utc::now();
+        let entry = journal_entry("/repo/a", 42, 111);
+        let action = decide(&issue(42, None), Some(&entry), &|_| false, 4.0, now);
+        assert_eq!(action, ReconcileAction::Reclaim(ReclaimReason::DeadPid { pid: 111 }));
+    }
+
+    #[test]
+    fn decide_keeps_when_no_record_and_within_grace() {
+        let now = Utc::now();
+        let recent = now - Duration::hours(1);
+        let action = decide(&issue(42, Some(recent)), None, &|_| true, 4.0, now);
+        assert_eq!(action, ReconcileAction::Keep);
+    }
+
+    #[test]
+    fn decide_reclaims_when_no_record_and_past_stale_threshold() {
+        let now = Utc::now();
+        let old = now - Duration::hours(5);
+        let action = decide(&issue(42, Some(old)), None, &|_| true, 4.0, now);
+        match action {
+            ReconcileAction::Reclaim(ReclaimReason::NoRecordStale { age_hours }) => {
+                assert!(age_hours >= 4.0);
+            }
+            other => panic!("expected NoRecordStale reclaim, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decide_keeps_at_exact_boundary_minus_epsilon() {
+        let now = Utc::now();
+        // Just under the threshold: still within grace.
+        let almost = now - Duration::minutes(239); // 3h59m < 4h
+        let action = decide(&issue(42, Some(almost)), None, &|_| true, 4.0, now);
+        assert_eq!(action, ReconcileAction::Keep);
+    }
+
+    #[test]
+    fn decide_keeps_when_no_record_and_no_age_evidence() {
+        let now = Utc::now();
+        let action = decide(&issue(42, None), None, &|_| true, 4.0, now);
+        assert_eq!(action, ReconcileAction::Keep, "fail-safe: no evidence => Keep");
+    }
+
+    #[test]
+    fn decide_dead_pid_overrides_label_age() {
+        // Even a freshly-labeled issue must be reclaimed once its recorded
+        // PID is provably dead — the journal is authoritative when present.
+        let now = Utc::now();
+        let entry = journal_entry("/repo/a", 42, 111);
+        let fresh_issue = issue(42, Some(now - Duration::minutes(1)));
+        let action = decide(&fresh_issue, Some(&entry), &|_| false, 4.0, now);
+        assert_eq!(action, ReconcileAction::Reclaim(ReclaimReason::DeadPid { pid: 111 }));
+    }
+
+    #[test]
+    fn plan_maps_each_issue_to_its_own_journal_entry() {
+        let now = Utc::now();
+        let mut journal = SweepJournal::default();
+        journal.entries.push(journal_entry("/repo/a", 1, 111)); // will be dead
+        journal.entries.push(journal_entry("/repo/a", 2, 222)); // will be alive
+                                                                // #3 has no journal entry and is stale.
+        let issues = vec![
+            issue(1, None),
+            issue(2, None),
+            issue(3, Some(now - Duration::hours(10))),
+        ];
+
+        let decisions = plan("/repo/a", &issues, &journal, &|pid| pid == 222, 4.0, now);
+
+        assert_eq!(decisions.len(), 3);
+        assert_eq!(
+            decisions[0],
+            (1, ReconcileAction::Reclaim(ReclaimReason::DeadPid { pid: 111 }))
+        );
+        assert_eq!(decisions[1], (2, ReconcileAction::Keep));
+        match decisions[2] {
+            (3, ReconcileAction::Reclaim(ReclaimReason::NoRecordStale { .. })) => {}
+            ref other => panic!("expected #3 to be a NoRecordStale reclaim, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn plan_scopes_journal_lookup_by_repo_string() {
+        // Same issue number, different repos — must not cross-contaminate.
+        let now = Utc::now();
+        let mut journal = SweepJournal::default();
+        journal.entries.push(journal_entry("/repo/other", 42, 111));
+
+        let issues = vec![issue(42, Some(now - Duration::hours(10)))];
+        let decisions = plan("/repo/a", &issues, &journal, &|_| true, 4.0, now);
+
+        // No entry under "/repo/a" -> falls through to the age check, which
+        // is stale here, so it reclaims (not "Keep" from the other repo's
+        // live pid).
+        match decisions[0] {
+            (42, ReconcileAction::Reclaim(ReclaimReason::NoRecordStale { .. })) => {}
+            ref other => panic!("expected repo-scoped NoRecordStale reclaim, got {other:?}"),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn reconciliation_enabled_resolves_env_precedence() {
+        std::env::remove_var(RECONCILE_ENABLED_ENV);
+        assert!(reconciliation_enabled(), "defaults to enabled");
+
+        for off in ["0", "false", "no", "off", "OFF", "False"] {
+            std::env::set_var(RECONCILE_ENABLED_ENV, off);
+            assert!(!reconciliation_enabled(), "{off} should disable");
+        }
+
+        std::env::set_var(RECONCILE_ENABLED_ENV, "1");
+        assert!(reconciliation_enabled());
+
+        std::env::remove_var(RECONCILE_ENABLED_ENV);
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_stale_hours_defaults_and_overrides() {
+        std::env::remove_var(STALE_HOURS_ENV);
+        assert!((resolve_stale_hours() - DEFAULT_STALE_BUILDING_HOURS).abs() < f64::EPSILON);
+
+        std::env::set_var(STALE_HOURS_ENV, "2.5");
+        assert!((resolve_stale_hours() - 2.5).abs() < f64::EPSILON);
+
+        // Non-positive / unparseable falls back to the default.
+        std::env::set_var(STALE_HOURS_ENV, "0");
+        assert!((resolve_stale_hours() - DEFAULT_STALE_BUILDING_HOURS).abs() < f64::EPSILON);
+        std::env::set_var(STALE_HOURS_ENV, "garbage");
+        assert!((resolve_stale_hours() - DEFAULT_STALE_BUILDING_HOURS).abs() < f64::EPSILON);
+
+        std::env::remove_var(STALE_HOURS_ENV);
+    }
+}

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -1734,6 +1734,9 @@ exit 0
         let mut config = SweepRegistryConfig::new(dir.path().to_path_buf());
         config.spawn_bin = Some(fake_bin);
         config.skip_label_flip = true;
+        // Confine the #3953 sweep journal to this test's tempdir — never the
+        // real machine-level `~/.loom/sweeps.json`.
+        config.journal_path = Some(dir.path().join("test-sweeps-journal.json"));
         let sr = Arc::new(Mutex::new(SweepRegistry::new(config)));
         (sr, dir, record_log)
     }

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -12,6 +12,7 @@
 
 pub mod activity;
 pub mod capacity;
+pub mod claim_reconciliation;
 pub mod disk_headroom;
 pub mod epic_state;
 pub mod epic_supervisor;
@@ -28,6 +29,7 @@ pub mod main_health_gate;
 pub mod metrics_collector;
 pub mod phase_join;
 pub mod role_validation;
+pub mod sweep_journal;
 pub mod sweep_registry;
 pub mod terminal;
 pub mod tokens;

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -1,4 +1,5 @@
 use loom_daemon::activity::{self, ActivityDb, StatsQueries};
+use loom_daemon::claim_reconciliation;
 use loom_daemon::epic_supervisor;
 use loom_daemon::event_bus::EventBus;
 use loom_daemon::health_monitor;
@@ -391,6 +392,55 @@ async fn main() -> Result<()> {
             if n == 1 { "y" } else { "ies" }
         ),
         Err(e) => log::warn!("sweep_registry: reconstruction failed: {e}"),
+    }
+
+    // Stale-`loom:building`-claim reconciliation across every managed
+    // workspace (Issue #3953). `sweep.reconstruct()` above only recovers
+    // entries this registry itself owns evidence for (locks/checkpoints); it
+    // has nothing to say about a claim left behind by a sweep that died
+    // between the previous daemon's exit and this one's start (rate-limit
+    // kill, print-mode ceiling, an operator upgrade — the daemon-restart
+    // gap where `loom-recover-orphans` used to find *no* authoritative
+    // liveness source at all and refuse to reclaim anything, #3651).
+    //
+    // The machine-level sweep journal (`~/.loom/sweeps.json`, written by
+    // every `dispatch()` — see `sweep_journal`) is that liveness source, and
+    // it survives exactly the restart that wipes this in-memory registry.
+    // This pass is a bounded, logged, best-effort startup sweep over every
+    // `effective_roots()` workspace (empty registry ⇒ just this one). It
+    // never blocks daemon startup — a `gh` hiccup in one repo is logged and
+    // skipped, and the remaining repos are still reconciled.
+    if claim_reconciliation::reconciliation_enabled() {
+        let workspace_registry =
+            loom_daemon::workspace_registry::WorkspaceRegistry::load_default().unwrap_or_default();
+        let roots = workspace_registry.effective_roots(&sweep_workspace);
+        let gh_bin = std::path::PathBuf::from("gh");
+        let mut total_checked = 0usize;
+        let mut total_reclaimed = 0usize;
+        for root in &roots {
+            let (checked, reclaimed) =
+                claim_reconciliation::forge::reconcile_workspace(&gh_bin, root);
+            total_checked += checked;
+            total_reclaimed += reclaimed;
+        }
+        if total_reclaimed > 0 {
+            log::info!(
+                "claim_reconciliation: startup pass checked {total_checked} loom:building \
+                 issue(s) across {} workspace(s), reclaimed {total_reclaimed} stale claim(s) (#3953)",
+                roots.len()
+            );
+        } else {
+            log::debug!(
+                "claim_reconciliation: startup pass checked {total_checked} loom:building \
+                 issue(s) across {} workspace(s), nothing to reclaim",
+                roots.len()
+            );
+        }
+    } else {
+        log::info!(
+            "claim_reconciliation: startup pass disabled ({}=0)",
+            claim_reconciliation::RECONCILE_ENABLED_ENV
+        );
     }
 
     // Startup-race mitigation (Issue #3887): resolve the dispatch stagger + the

--- a/loom-daemon/src/sweep_journal.rs
+++ b/loom-daemon/src/sweep_journal.rs
@@ -1,0 +1,441 @@
+//! Persisted, machine-level sweep liveness journal (Issue #3953).
+//!
+//! ## Problem
+//!
+//! Before this module, the daemon's ONLY liveness record for a dispatched
+//! sweep was the in-memory [`crate::sweep_registry::SweepRegistry`] entry. A
+//! daemon restart — a routine event in the multi-repo autonomous world (rate
+//! limit kills, the print-mode ceiling, an operator upgrade) — wipes that
+//! registry clean. `loom-recover-orphans --recover` (the Python reclaim tool,
+//! `loom_tools.orphan_recovery`) then finds **no authoritative liveness
+//! source** and, per its #3651 fail-safe, refuses to reclaim ANY
+//! `loom:building` claim — even a claim whose sweep process is provably dead.
+//! Stale claims accumulate and an operator ends up hand-flipping labels.
+//!
+//! ## Fix
+//!
+//! This module persists a minimal `{repo, issue, pid, started_at}` record for
+//! every dispatched sweep to a single machine-level file, `~/.loom/sweeps.json`
+//! (override via [`JOURNAL_PATH_ENV`]). Unlike the in-memory registry, this
+//! file **survives a daemon restart** — it is the authoritative liveness
+//! source `loom-recover-orphans` was missing. The dead-PID-pruning pattern
+//! mirrors `defaults/scripts/sweep-run-registry.sh`'s `peers`/`prune_dead`
+//! (Issue #3768): a live PID keeps its entry, a dead PID's entry is dropped
+//! the next time anything reads or writes the journal — so the file never
+//! accumulates a `pid`-graveyard of every sweep that has ever run.
+//!
+//! ## Who writes it
+//!
+//! [`crate::sweep_registry::SweepRegistry::dispatch`] calls [`record_sweep`]
+//! right after a child is spawned (mirrors the fields already tracked on
+//! [`crate::types::SweepInfo`]: `repo`, the issue number from
+//! [`crate::types::SweepKind::Issue`], `pid`, `started_at`). The reaper's
+//! dead-PID paths call [`remove_sweep`] as a best-effort tidy-up (not
+//! load-bearing for correctness — the next `record_sweep` or reconcile pass
+//! prunes it anyway, but it keeps the file small).
+//!
+//! ## Who reads it
+//!
+//! - The Rust startup reconciliation pass ([`crate::claim_reconciliation`])
+//!   consults it directly, in-process.
+//! - `loom_tools.orphan_recovery` (Python) reads the same JSON file as a new
+//!   liveness source, so a *manual* `loom-recover-orphans --recover` run also
+//!   benefits from a fresh daemon's journal.
+//!
+//! All I/O here is best-effort by design: a missing, empty, or corrupt
+//! journal degrades to an empty [`SweepJournal`] rather than propagating an
+//! error that could block a dispatch or a reconciliation pass.
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// Environment override for the journal file location (mirrors
+/// [`crate::workspace_registry::REGISTRY_PATH_ENV`]). Primarily a test seam.
+pub const JOURNAL_PATH_ENV: &str = "LOOM_SWEEPS_JOURNAL_PATH";
+
+/// Current on-disk schema version.
+pub const JOURNAL_VERSION: u32 = 1;
+
+fn default_version() -> u32 {
+    JOURNAL_VERSION
+}
+
+/// One journal record: everything a liveness consumer needs to decide whether
+/// a `(repo, issue)` claim still has a live sweep behind it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct JournalEntry {
+    /// The owning workspace root, formatted identically to
+    /// [`crate::types::SweepInfo::repo`] (`workspace_root.display().to_string()`)
+    /// so journal lookups key on the exact same string dispatch stamps.
+    pub repo: String,
+    /// The GitHub/Gitea issue number this sweep is working.
+    pub issue: u32,
+    /// PID of the detached sweep child process.
+    pub pid: u32,
+    /// Timestamp of the original spawn.
+    pub started_at: DateTime<Utc>,
+}
+
+/// The full on-disk journal: a flat list of [`JournalEntry`] records.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SweepJournal {
+    #[serde(default = "default_version")]
+    pub version: u32,
+    #[serde(default)]
+    pub entries: Vec<JournalEntry>,
+}
+
+impl Default for SweepJournal {
+    fn default() -> Self {
+        Self {
+            version: JOURNAL_VERSION,
+            entries: Vec::new(),
+        }
+    }
+}
+
+/// Resolve the journal file path: [`JOURNAL_PATH_ENV`] override (non-empty),
+/// else `~/.loom/sweeps.json`.
+pub fn default_journal_path() -> Result<PathBuf> {
+    if let Ok(path) = std::env::var(JOURNAL_PATH_ENV) {
+        if !path.is_empty() {
+            return Ok(PathBuf::from(path));
+        }
+    }
+    let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("no home directory"))?;
+    Ok(home.join(".loom").join("sweeps.json"))
+}
+
+/// Load the journal from `path`. Tolerant by design: a missing file yields an
+/// empty journal, and unreadable/corrupt contents log a warning and ALSO
+/// yield an empty journal rather than propagating an error — a garbled
+/// journal must never block a dispatch or a reconciliation pass (mirrors the
+/// fail-safe philosophy of issue #3651: absent/bad liveness data is not proof
+/// of anything, so callers fall back to "no journal evidence" rather than
+/// erroring out).
+#[must_use]
+pub fn load(path: &Path) -> SweepJournal {
+    match std::fs::read_to_string(path) {
+        Ok(contents) => {
+            if contents.trim().is_empty() {
+                return SweepJournal::default();
+            }
+            match serde_json::from_str(&contents) {
+                Ok(journal) => journal,
+                Err(e) => {
+                    log::warn!(
+                        "sweep_journal: corrupt journal at {} ({e}) — treating as empty",
+                        path.display()
+                    );
+                    SweepJournal::default()
+                }
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => SweepJournal::default(),
+        Err(e) => {
+            log::warn!(
+                "sweep_journal: failed to read {} ({e}) — treating as empty",
+                path.display()
+            );
+            SweepJournal::default()
+        }
+    }
+}
+
+/// Persist the journal to `path` atomically (write to a sibling temp file,
+/// then rename) so a concurrent reader never observes a half-written file.
+/// Creates the parent directory if needed.
+pub fn save(path: &Path, journal: &SweepJournal) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating journal dir {}", parent.display()))?;
+    }
+    let mut json = serde_json::to_string_pretty(journal)?;
+    json.push('\n');
+
+    // Temp file in the same directory guarantees the rename is atomic (same
+    // filesystem). Include the PID to avoid collisions between concurrent
+    // writers (mirrors `WorkspaceRegistry::save`).
+    let tmp = path.with_extension(format!("json.tmp.{}", std::process::id()));
+    std::fs::write(&tmp, json.as_bytes())
+        .with_context(|| format!("writing temp journal {}", tmp.display()))?;
+    std::fs::rename(&tmp, path)
+        .with_context(|| format!("renaming {} -> {}", tmp.display(), path.display()))?;
+    Ok(())
+}
+
+/// Prune entries whose `pid` — per `is_alive` — is no longer live. Returns the
+/// number of entries removed.
+///
+/// This is the dead-PID-pruning step mirrored from
+/// `sweep-run-registry.sh`'s `prune_dead` / `peers` (#3768): callers run this
+/// at both write time ([`upsert`]) and read time (the reconciliation pass in
+/// [`crate::claim_reconciliation`]), so a crashed sweep's entry never survives
+/// past the next journal touch.
+pub fn prune_dead(journal: &mut SweepJournal, is_alive: impl Fn(u32) -> bool) -> usize {
+    let before = journal.entries.len();
+    journal.entries.retain(|e| is_alive(e.pid));
+    before - journal.entries.len()
+}
+
+/// Find the entry for `(repo, issue)`, if any.
+#[must_use]
+pub fn find<'a>(journal: &'a SweepJournal, repo: &str, issue: u32) -> Option<&'a JournalEntry> {
+    journal
+        .entries
+        .iter()
+        .find(|e| e.repo == repo && e.issue == issue)
+}
+
+/// Insert or replace the entry keyed by `(repo, issue)`. Prunes dead entries
+/// first so the journal never grows unbounded across a long-lived daemon's
+/// lifetime.
+pub fn upsert(journal: &mut SweepJournal, entry: JournalEntry, is_alive: impl Fn(u32) -> bool) {
+    prune_dead(journal, is_alive);
+    journal
+        .entries
+        .retain(|e| !(e.repo == entry.repo && e.issue == entry.issue));
+    journal.entries.push(entry);
+}
+
+/// Remove the entry for `(repo, issue)` if present. Returns `true` if an
+/// entry was actually removed.
+pub fn remove(journal: &mut SweepJournal, repo: &str, issue: u32) -> bool {
+    let before = journal.entries.len();
+    journal
+        .entries
+        .retain(|e| !(e.repo == repo && e.issue == issue));
+    before != journal.entries.len()
+}
+
+/// High-level convenience: record a freshly-dispatched sweep in the journal
+/// at an explicit `path` (test seam / per-registry override — see
+/// [`crate::sweep_registry::SweepRegistryConfig::journal_path`]). Best-effort
+/// by contract — callers (`SweepRegistry::dispatch`) log a warning on `Err`
+/// but never fail dispatch because of a journal-write hiccup.
+pub fn record_sweep_at(
+    path: &Path,
+    repo: &str,
+    issue: u32,
+    pid: u32,
+    started_at: DateTime<Utc>,
+) -> Result<()> {
+    let mut journal = load(path);
+    upsert(
+        &mut journal,
+        JournalEntry {
+            repo: repo.to_string(),
+            issue,
+            pid,
+            started_at,
+        },
+        crate::sweep_registry::is_pid_alive,
+    );
+    save(path, &journal)
+}
+
+/// Convenience: [`record_sweep_at`] the default (env-overridable) path.
+pub fn record_sweep(repo: &str, issue: u32, pid: u32, started_at: DateTime<Utc>) -> Result<()> {
+    record_sweep_at(&default_journal_path()?, repo, issue, pid, started_at)
+}
+
+/// High-level convenience: remove a sweep's journal entry (e.g. on reap or
+/// cancel) at an explicit `path`. Best-effort; a no-op write is skipped.
+pub fn remove_sweep_at(path: &Path, repo: &str, issue: u32) -> Result<()> {
+    let mut journal = load(path);
+    if remove(&mut journal, repo, issue) {
+        save(path, &journal)?;
+    }
+    Ok(())
+}
+
+/// Convenience: [`remove_sweep_at`] the default (env-overridable) path.
+pub fn remove_sweep(repo: &str, issue: u32) -> Result<()> {
+    remove_sweep_at(&default_journal_path()?, repo, issue)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use tempfile::tempdir;
+
+    fn entry(repo: &str, issue: u32, pid: u32) -> JournalEntry {
+        JournalEntry {
+            repo: repo.to_string(),
+            issue,
+            pid,
+            started_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn load_missing_file_is_empty() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("sweeps.json");
+        let journal = load(&path);
+        assert!(journal.entries.is_empty());
+        assert_eq!(journal.version, JOURNAL_VERSION);
+    }
+
+    #[test]
+    fn load_empty_file_is_empty() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("sweeps.json");
+        std::fs::write(&path, "   \n").unwrap();
+        let journal = load(&path);
+        assert!(journal.entries.is_empty());
+    }
+
+    #[test]
+    fn load_corrupt_file_is_empty_not_error() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("sweeps.json");
+        std::fs::write(&path, "{ not json").unwrap();
+        let journal = load(&path);
+        assert!(journal.entries.is_empty());
+    }
+
+    #[test]
+    fn save_then_load_round_trips() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("sweeps.json");
+        let mut journal = SweepJournal::default();
+        journal.entries.push(entry("/repo/a", 42, 1234));
+
+        save(&path, &journal).unwrap();
+        let loaded = load(&path);
+        assert_eq!(loaded.entries.len(), 1);
+        assert_eq!(loaded.entries[0].repo, "/repo/a");
+        assert_eq!(loaded.entries[0].issue, 42);
+        assert_eq!(loaded.entries[0].pid, 1234);
+    }
+
+    #[test]
+    fn save_creates_parent_dir() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nested").join("sweeps.json");
+        save(&path, &SweepJournal::default()).unwrap();
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn find_returns_matching_entry_only() {
+        let mut journal = SweepJournal::default();
+        journal.entries.push(entry("/repo/a", 1, 100));
+        journal.entries.push(entry("/repo/b", 1, 200));
+        journal.entries.push(entry("/repo/a", 2, 300));
+
+        let found = find(&journal, "/repo/a", 1).unwrap();
+        assert_eq!(found.pid, 100);
+        assert!(find(&journal, "/repo/a", 99).is_none());
+        assert!(find(&journal, "/repo/z", 1).is_none());
+    }
+
+    #[test]
+    fn prune_dead_removes_only_dead_pids() {
+        let mut journal = SweepJournal::default();
+        journal.entries.push(entry("/repo/a", 1, 111)); // alive
+        journal.entries.push(entry("/repo/a", 2, 222)); // dead
+        journal.entries.push(entry("/repo/a", 3, 333)); // alive
+
+        let removed = prune_dead(&mut journal, |pid| pid != 222);
+        assert_eq!(removed, 1);
+        assert_eq!(journal.entries.len(), 2);
+        assert!(find(&journal, "/repo/a", 2).is_none());
+        assert!(find(&journal, "/repo/a", 1).is_some());
+        assert!(find(&journal, "/repo/a", 3).is_some());
+    }
+
+    #[test]
+    fn upsert_replaces_existing_entry_for_same_key() {
+        let mut journal = SweepJournal::default();
+        journal.entries.push(entry("/repo/a", 1, 111));
+
+        upsert(&mut journal, entry("/repo/a", 1, 999), |_| true);
+
+        assert_eq!(journal.entries.len(), 1);
+        assert_eq!(find(&journal, "/repo/a", 1).unwrap().pid, 999);
+    }
+
+    #[test]
+    fn upsert_prunes_dead_entries_before_inserting() {
+        let mut journal = SweepJournal::default();
+        journal.entries.push(entry("/repo/a", 1, 111)); // dead
+        journal.entries.push(entry("/repo/a", 2, 222)); // alive
+
+        upsert(&mut journal, entry("/repo/b", 5, 500), |pid| pid == 222);
+
+        assert_eq!(journal.entries.len(), 2);
+        assert!(find(&journal, "/repo/a", 1).is_none());
+        assert!(find(&journal, "/repo/a", 2).is_some());
+        assert!(find(&journal, "/repo/b", 5).is_some());
+    }
+
+    #[test]
+    fn remove_deletes_matching_entry_and_reports_change() {
+        let mut journal = SweepJournal::default();
+        journal.entries.push(entry("/repo/a", 1, 111));
+        journal.entries.push(entry("/repo/a", 2, 222));
+
+        assert!(remove(&mut journal, "/repo/a", 1));
+        assert_eq!(journal.entries.len(), 1);
+        assert!(find(&journal, "/repo/a", 1).is_none());
+
+        // Idempotent: removing again reports no change.
+        assert!(!remove(&mut journal, "/repo/a", 1));
+    }
+
+    #[test]
+    #[serial]
+    fn default_journal_path_honors_env_override() {
+        let dir = tempdir().unwrap();
+        let custom = dir.path().join("custom-sweeps.json");
+        std::env::set_var(JOURNAL_PATH_ENV, &custom);
+        assert_eq!(default_journal_path().unwrap(), custom);
+        std::env::remove_var(JOURNAL_PATH_ENV);
+    }
+
+    #[test]
+    #[serial]
+    fn record_sweep_then_remove_sweep_round_trip() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("sweeps.json");
+        std::env::set_var(JOURNAL_PATH_ENV, &path);
+
+        record_sweep("/repo/a", 42, std::process::id(), Utc::now()).unwrap();
+        let journal = load(&path);
+        assert_eq!(journal.entries.len(), 1);
+        assert_eq!(journal.entries[0].issue, 42);
+
+        remove_sweep("/repo/a", 42).unwrap();
+        let journal = load(&path);
+        assert!(journal.entries.is_empty());
+
+        std::env::remove_var(JOURNAL_PATH_ENV);
+    }
+
+    #[test]
+    #[serial]
+    fn record_sweep_prunes_dead_peers_via_default_path() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("sweeps.json");
+        std::env::set_var(JOURNAL_PATH_ENV, &path);
+
+        // Seed a dead entry directly (PID 0 is always dead per is_pid_alive).
+        let mut seeded = SweepJournal::default();
+        seeded.entries.push(entry("/repo/a", 1, 0));
+        save(&path, &seeded).unwrap();
+
+        record_sweep("/repo/a", 2, std::process::id(), Utc::now()).unwrap();
+
+        let journal = load(&path);
+        assert_eq!(journal.entries.len(), 1, "dead PID-0 entry should be pruned");
+        assert!(find(&journal, "/repo/a", 2).is_some());
+
+        std::env::remove_var(JOURNAL_PATH_ENV);
+    }
+}

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -42,8 +42,17 @@
 //!   ingesting phantom entries for in-session sweeps it never dispatched
 //!   (#3808). See [`SweepRegistry::reconstruct`].
 //! - Forge labels (`loom:issue` vs `loom:building`).
+//!
+//! One exception (Issue #3953): `dispatch` also writes a minimal
+//! `{repo, issue, pid, started_at}` liveness record to the machine-level
+//! [`crate::sweep_journal`] (`~/.loom/sweeps.json`). This is NOT sweep state
+//! in the sense above — it carries no phase/status/log-path information, only
+//! what `loom-recover-orphans` needs to tell a live claim from a dead one
+//! after a daemon restart wipes this in-memory registry. See
+//! [`crate::claim_reconciliation`] for the startup consumer.
 
 use crate::event_bus::EventBus;
+use crate::sweep_journal;
 use crate::types::{Event, SweepId, SweepInfo, SweepKind, SweepOutcome, SweepState};
 
 use anyhow::{anyhow, Context, Result};
@@ -758,6 +767,12 @@ pub struct SweepRegistryConfig {
     /// When `true`, skip the actual label flip via `gh`. Used by unit tests
     /// that don't have GitHub credentials.
     pub skip_label_flip: bool,
+    /// Override the machine-level sweep journal path (Issue #3953). Defaults
+    /// to [`sweep_journal::default_journal_path`] (`~/.loom/sweeps.json`,
+    /// env-overridable via `LOOM_SWEEPS_JOURNAL_PATH`). Tests set this to a
+    /// tempdir path so `dispatch`/reap never touch the real machine-level
+    /// file.
+    pub journal_path: Option<PathBuf>,
 }
 
 impl SweepRegistryConfig {
@@ -769,7 +784,17 @@ impl SweepRegistryConfig {
             spawn_bin: None,
             gh_bin: None,
             skip_label_flip: false,
+            journal_path: None,
         }
+    }
+
+    /// Resolve the sweep journal path: `journal_path` explicit override, else
+    /// [`sweep_journal::default_journal_path`].
+    pub fn resolve_journal_path(&self) -> Result<PathBuf> {
+        if let Some(ref p) = self.journal_path {
+            return Ok(p.clone());
+        }
+        sweep_journal::default_journal_path()
     }
 
     /// Resolve the spawn binary, preferring (in order):
@@ -1234,6 +1259,31 @@ impl SweepRegistry {
         };
         self.entries.insert(sweep_id.clone(), info);
 
+        // 6b. Persist a liveness record to the machine-level sweep journal
+        // (`~/.loom/sweeps.json`, Issue #3953). Unlike the in-memory entry
+        // above, this file survives a daemon restart, giving
+        // `loom-recover-orphans` an authoritative liveness source even when
+        // this registry has just been recreated empty. Best-effort — a
+        // journal-write hiccup must never fail dispatch.
+        match self.config.resolve_journal_path() {
+            Ok(journal_path) => {
+                if let Err(e) = sweep_journal::record_sweep_at(
+                    &journal_path,
+                    &self.config.workspace_root.display().to_string(),
+                    issue_number,
+                    pid,
+                    Utc::now(),
+                ) {
+                    log::warn!(
+                        "sweep_journal: failed to record sweep for issue #{issue_number}: {e}"
+                    );
+                }
+            }
+            Err(e) => log::warn!(
+                "sweep_journal: cannot resolve journal path for issue #{issue_number}: {e}"
+            ),
+        }
+
         // 7. Emit `sweep.global.dispatch` (best-effort — never block
         //    dispatch progress on the bus). If no subscribers are
         //    listening, the bus returns NoSubscribers; log at debug.
@@ -1354,6 +1404,27 @@ impl SweepRegistry {
                 .with_context(|| format!("failed to remove lock dir {}", lock.display()))?;
         }
         Ok(())
+    }
+
+    /// Best-effort removal of this registry's sweep-journal entry for
+    /// `issue` (Issue #3953). Never load-bearing — a missed removal is pruned
+    /// the next time anything touches the journal — so failures are logged
+    /// at `debug` and swallowed rather than propagated.
+    fn journal_remove_best_effort(&self, issue: u32) {
+        let journal_path = match self.config.resolve_journal_path() {
+            Ok(p) => p,
+            Err(e) => {
+                log::debug!("sweep_journal: cannot resolve journal path for #{issue}: {e}");
+                return;
+            }
+        };
+        if let Err(e) = sweep_journal::remove_sweep_at(
+            &journal_path,
+            &self.config.workspace_root.display().to_string(),
+            issue,
+        ) {
+            log::debug!("sweep_journal: failed to remove entry for #{issue}: {e}");
+        }
     }
 
     // ------------------------------------------------------------------------
@@ -2141,6 +2212,9 @@ impl SweepRegistry {
         }
         if let SweepKind::Issue(issue) = kind {
             let _ = self.release_lock(*issue);
+            // Best-effort tidy-up of the machine-level liveness journal
+            // (#3953) — this cancelled sweep no longer exists.
+            self.journal_remove_best_effort(*issue);
             // Orphaned-claim recovery on cancel (issue #3827): a cancelled
             // daemon-owned Issue sweep that never opened a PR still holds its
             // pre-dispatch loom:building claim (set at `dispatch()` step 4).
@@ -2254,6 +2328,13 @@ impl SweepRegistry {
                     // Release lock and decide between Exited vs Crashed.
                     if let Some(issue) = issue {
                         let _ = self.release_lock(issue);
+                        // Best-effort tidy-up of the machine-level liveness
+                        // journal (#3953): the reaper just confirmed this
+                        // PID is dead, so drop its entry now rather than
+                        // waiting for the next prune-on-read. Not
+                        // load-bearing — a missed removal is pruned on the
+                        // next journal touch — but keeps the file small.
+                        self.journal_remove_best_effort(issue);
                         let checkpoint = self
                             .config
                             .checkpoint_dir()
@@ -3648,8 +3729,12 @@ pub fn spawn_watchdog_task(
 /// Liveness probe via `kill(pid, 0)`. Returns true when the signal would
 /// be deliverable (i.e. the process exists and is owned by us). PID 0 is
 /// always treated as dead.
+///
+/// `pub(crate)` so [`crate::sweep_journal`] and [`crate::claim_reconciliation`]
+/// can reuse the exact same probe the reaper uses (Issue #3953) rather than
+/// duplicating the `kill(pid, 0)` dance.
 #[cfg(unix)]
-fn is_pid_alive(pid: u32) -> bool {
+pub(crate) fn is_pid_alive(pid: u32) -> bool {
     if pid == 0 {
         return false;
     }
@@ -3663,7 +3748,7 @@ fn is_pid_alive(pid: u32) -> bool {
 }
 
 #[cfg(not(unix))]
-fn is_pid_alive(_pid: u32) -> bool {
+pub(crate) fn is_pid_alive(_pid: u32) -> bool {
     // Non-unix platforms are not supported targets for Loom; assume alive
     // so the test suite can run without a hard panic.
     true
@@ -3829,6 +3914,9 @@ exit 0
         let mut config = SweepRegistryConfig::new(workspace.to_path_buf());
         config.spawn_bin = Some(fake_bin);
         config.skip_label_flip = true;
+        // Confine the #3953 sweep journal to this test's tempdir — never the
+        // real machine-level `~/.loom/sweeps.json`.
+        config.journal_path = Some(workspace.join("test-sweeps-journal.json"));
         (SweepRegistry::new(config), record_log)
     }
 
@@ -3866,6 +3954,7 @@ exit 0
         let mut config = SweepRegistryConfig::new(workspace.to_path_buf());
         config.spawn_bin = Some(fake_bin);
         config.skip_label_flip = true;
+        config.journal_path = Some(workspace.join("test-sweeps-journal.json"));
         SweepRegistry::new(config)
     }
 
@@ -3977,6 +4066,54 @@ exit 0
             recorded.contains("--dangerously-skip-permissions"),
             "expected --dangerously-skip-permissions in argv; got: {recorded}"
         );
+    }
+
+    /// Issue #3953: `dispatch` persists a liveness record to the sweep
+    /// journal (repo/issue/pid/started_at), and the reaper's dead-PID path
+    /// removes it once the child is confirmed dead — end-to-end wiring,
+    /// not just the `sweep_journal` module's own unit tests.
+    #[test]
+    fn dispatch_and_reap_wire_the_sweep_journal() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+        let journal_path = registry.config().journal_path.clone().unwrap();
+
+        let outcome = registry
+            .dispatch(&SweepKind::Issue(4600), None, None, None, None)
+            .expect("dispatch should succeed");
+
+        let journal = crate::sweep_journal::load(&journal_path);
+        let repo = dir.path().display().to_string();
+        let entry = crate::sweep_journal::find(&journal, &repo, 4600)
+            .expect("dispatch should have recorded a journal entry for #4600");
+        assert_eq!(entry.pid, outcome.pid);
+
+        // The fixture's fake spawn-claude.sh exits immediately, so the pid is
+        // dead almost immediately; wait for the reaper's dead-PID path.
+        let dead = wait_for_condition(10_000, || !is_pid_alive(outcome.pid));
+        assert!(dead, "fixture child did not exit within 10s");
+
+        registry.reap_once();
+
+        let journal = crate::sweep_journal::load(&journal_path);
+        assert!(
+            crate::sweep_journal::find(&journal, &repo, 4600).is_none(),
+            "reap_once should have removed the dead sweep's journal entry"
+        );
+    }
+
+    /// Poll until `condition` returns true or `timeout_ms` elapses. Mirrors
+    /// `wait_for_contents` but for an arbitrary predicate (used by the
+    /// journal wiring test above to wait for the fixture child's PID to die).
+    fn wait_for_condition(timeout_ms: u64, mut condition: impl FnMut() -> bool) -> bool {
+        let start = std::time::Instant::now();
+        while start.elapsed().as_millis() < u128::from(timeout_ms) {
+            if condition() {
+                return true;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        false
     }
 
     /// Issue #3824: `spawn_child` unconditionally appends
@@ -5784,6 +5921,7 @@ exit 0
         let mut config = SweepRegistryConfig::new(workspace.to_path_buf());
         config.spawn_bin = Some(fake_bin);
         config.skip_label_flip = true;
+        config.journal_path = Some(workspace.join("test-sweeps-journal.json"));
         let mut registry = SweepRegistry::new(config);
 
         let outcome = registry

--- a/loom-tools/src/loom_tools/orphan_recovery.py
+++ b/loom-tools/src/loom_tools/orphan_recovery.py
@@ -36,6 +36,39 @@ The cross-check inputs are:
 - The liveness evidence above (roster + daemon + locks).
 - ``gh issue list --label loom:building`` (unchanged).
 
+Machine-level sweep journal (issue #3953)
+------------------------------------------
+
+The daemon registry probe above (:func:`_query_daemon_live_issues`) is a
+best-effort stub precisely because the daemon's sweep registry is
+**in-memory** -- a restart (rate-limit kill, the print-mode ceiling, an
+operator upgrade) wipes it clean, and immediately after a restart the
+daemon has *nothing* to say either way. Two canary incidents hit exactly
+this gap: sweeps died, their issues stayed at ``loom:building``, and this
+tool found no authoritative source at all and (correctly, per the fail-safe
+above) refused to touch anything -- an operator had to hand-flip labels.
+
+``loom-daemon``'s ``SweepRegistry::dispatch`` now persists a minimal
+``{repo, issue, pid, started_at}`` record to a machine-level journal at
+``~/.loom/sweeps.json`` (the Rust ``sweep_journal`` module) every time it
+spawns a sweep child. Unlike the in-memory registry, this **file** survives
+a restart, so :func:`gather_liveness_evidence` reads it as a fourth source:
+
+- A journal entry with a **dead** recorded PID is unconditional proof this
+  claim's sweep is gone -- it is NOT added to ``live_issues``, so it falls
+  through to the untracked-building check exactly like a claim the roster
+  says nothing about (subject to the existing label-age grace period).
+- A journal entry with a **live** recorded PID is unconditional proof of
+  life -- added to ``live_issues``, so the claim is always skipped.
+- The **absence** of a journal entry for a `loom:building` issue, when the
+  journal file itself is present (so it IS a contributing source), is
+  treated more conservatively than a dead-PID entry: the journal only
+  covers *daemon-dispatched* sweeps, so "no entry" might mean a live
+  **manual** ``/loom:sweep`` session the daemon was never told about. Such
+  a claim needs to be stale for ``LOOM_STALE_BUILDING_HOURS`` (default 4h,
+  see :func:`_get_stale_building_hours`) -- much longer than the default
+  10-minute label-age grace period -- before it is treated as orphaned.
+
 Stuck-but-running detection lives in :mod:`loom_tools.stuck_detection` (2-min
 heartbeat).  This module's heartbeat threshold is intentionally higher
 (5 minutes by default) because orphan recovery is post-crash cleanup, not
@@ -83,6 +116,21 @@ DEFAULT_LABEL_GRACE_PERIOD = 600
 # If an "## Orphan Recovery" comment was posted within this window,
 # skip posting another to avoid duplicate noise (see issue #2658).
 ORPHAN_COMMENT_DEDUP_SECONDS = 300
+
+# Env var overriding the "no journal record at all" staleness threshold, in
+# HOURS (issue #3953). Only consulted when the sweep journal is itself a
+# contributing evidence source (see `gather_liveness_evidence`) -- a
+# `loom:building` issue with a journal entry uses the (much shorter)
+# `DEFAULT_LABEL_GRACE_PERIOD` instead, since a recorded-dead PID is
+# unconditional proof, whereas "no record" only means the daemon's journal
+# was never told about this claim (it may be a live manual sweep).
+LOOM_STALE_BUILDING_HOURS_ENV = "LOOM_STALE_BUILDING_HOURS"
+DEFAULT_STALE_BUILDING_HOURS = 4.0
+
+# Env var overriding the machine-level sweep journal path (issue #3953).
+# Mirrors `loom_daemon::sweep_journal::JOURNAL_PATH_ENV` (Rust) so both
+# surfaces resolve to the same file by default.
+LOOM_SWEEPS_JOURNAL_PATH_ENV = "LOOM_SWEEPS_JOURNAL_PATH"
 
 
 @dataclass
@@ -175,6 +223,24 @@ def _get_label_grace_period() -> int:
     return DEFAULT_LABEL_GRACE_PERIOD
 
 
+def _get_stale_building_hours() -> float:
+    """Get the no-journal-record staleness threshold (hours) from env or default.
+
+    A non-positive or unparseable override falls back to
+    :data:`DEFAULT_STALE_BUILDING_HOURS` (mirrors
+    ``loom_daemon::claim_reconciliation::resolve_stale_hours`` in Rust).
+    """
+    env_val = os.environ.get(LOOM_STALE_BUILDING_HOURS_ENV)
+    if env_val is not None:
+        try:
+            hours = float(env_val)
+            if hours > 0:
+                return hours
+        except ValueError:
+            pass
+    return DEFAULT_STALE_BUILDING_HOURS
+
+
 def _pid_alive(pid: int) -> bool:
     """Return True if *pid* is a live process.
 
@@ -258,18 +324,29 @@ class LivenessEvidence:
     """Authoritative evidence of which sweeps are currently alive.
 
     ``available`` is True when at least one authoritative liveness *source*
-    exists (a present state file, a reachable daemon registry, or one or more
-    ``.loom/locks/issue-<N>/`` locks). When it is False we have **no** evidence
-    either way, and the fail-safe (issue #3651) is to emit zero orphans.
+    exists (a present state file, a reachable daemon registry, the sweep
+    journal, or one or more ``.loom/locks/issue-<N>/`` locks). When it is
+    False we have **no** evidence either way, and the fail-safe (issue #3651)
+    is to emit zero orphans.
 
     ``live_issues`` is the union of issue numbers known to be alive across all
     available sources. ``sources`` records which sources contributed, for
     logging/observability.
+
+    ``journal_present``/``journal_issues`` (issue #3953) carry extra detail
+    specifically about the machine-level sweep journal: whether the journal
+    file exists at all, and which issue numbers have *any* entry for this repo
+    (dead or alive -- a subset of ``live_issues`` is the alive ones).
+    :func:`check_untracked_building` uses these to pick a stricter staleness
+    threshold for a claim the journal has *never heard of* than for one it can
+    prove is dead.
     """
 
     available: bool = False
     live_issues: set[int] = field(default_factory=set)
     sources: list[str] = field(default_factory=list)
+    journal_present: bool = False
+    journal_issues: set[int] = field(default_factory=set)
 
 
 def _locked_issue_numbers(repo_root: pathlib.Path) -> set[int]:
@@ -318,6 +395,81 @@ def _query_daemon_live_issues(repo_root: pathlib.Path) -> set[int] | None:
     return None
 
 
+@dataclass
+class _JournalEntry:
+    """One entry from the machine-level sweep journal (issue #3953)."""
+
+    repo: str
+    issue: int
+    pid: int
+
+
+def _default_journal_path() -> pathlib.Path:
+    """Resolve the sweep journal path: env override, else ``~/.loom/sweeps.json``.
+
+    Mirrors ``loom_daemon::sweep_journal::default_journal_path`` (Rust) so
+    both surfaces read the exact same file by default.
+    """
+    env_val = os.environ.get(LOOM_SWEEPS_JOURNAL_PATH_ENV)
+    if env_val:
+        return pathlib.Path(env_val)
+    return pathlib.Path.home() / ".loom" / "sweeps.json"
+
+
+def _load_journal_entries(path: pathlib.Path) -> list[_JournalEntry]:
+    """Load and parse the sweep journal. Tolerant: missing/corrupt -> ``[]``.
+
+    Never raises -- a garbled or absent journal must never crash orphan
+    recovery; it degrades to "no journal evidence" (mirrors the Rust-side
+    ``sweep_journal::load``'s tolerant-corrupt-file behavior, issue #3651's
+    fail-safe philosophy applied to this new source).
+    """
+    try:
+        raw = path.read_text()
+    except OSError:
+        return []
+    if not raw.strip():
+        return []
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        log_warning(f"sweep journal at {path} is corrupt (invalid JSON) — treating as empty")
+        return []
+    if not isinstance(data, dict):
+        return []
+    entries: list[_JournalEntry] = []
+    for row in data.get("entries", []) or []:
+        try:
+            entries.append(
+                _JournalEntry(
+                    repo=str(row["repo"]),
+                    issue=int(row["issue"]),
+                    pid=int(row["pid"]),
+                )
+            )
+        except (KeyError, TypeError, ValueError):
+            # Skip a malformed row rather than discarding the whole journal.
+            continue
+    return entries
+
+
+def _journal_repo_matches(entry_repo: str, repo_root: pathlib.Path) -> bool:
+    """Whether a journal entry's ``repo`` string identifies ``repo_root``.
+
+    The daemon stamps ``repo`` as ``workspace_root.display().to_string()``
+    (Rust) — an exact string match is the fast, common-case path (this repo
+    checkout and the daemon's workspace_root agree byte-for-byte). Falls back
+    to a resolved-path comparison so an equivalent-but-differently-formatted
+    path (e.g. a trailing slash) still matches.
+    """
+    if entry_repo == str(repo_root):
+        return True
+    try:
+        return pathlib.Path(entry_repo).resolve() == repo_root.resolve()
+    except OSError:
+        return False
+
+
 def gather_liveness_evidence(
     spawn_loop_state: SpawnLoopState,
     repo_root: pathlib.Path | None,
@@ -331,12 +483,19 @@ def gather_liveness_evidence(
     2. ``loom-daemon`` registry via :func:`_query_daemon_live_issues` — optional,
        best-effort; ``None`` means "not a source".
     3. ``.loom/locks/issue-<N>/`` — per-issue worktree-lifetime locks.
+    4. The machine-level sweep journal (``~/.loom/sweeps.json``, issue #3953)
+       — survives a daemon restart, unlike source 2. A dead recorded PID is
+       proof of death (not added to ``live_issues``); a live recorded PID is
+       proof of life (added). See :attr:`LivenessEvidence.journal_present` /
+       :attr:`LivenessEvidence.journal_issues` for the "no record at all" case.
 
     ``available`` is True iff at least one of these sources is actually present.
     When it is False the caller MUST NOT flag any building issue as orphaned.
     """
     live: set[int] = set()
     sources: list[str] = []
+    journal_present = False
+    journal_issues: set[int] = set()
 
     if spawn_loop_state.present:
         sources.append("spawn-loop-state.json")
@@ -353,10 +512,23 @@ def gather_liveness_evidence(
             sources.append(".loom/locks")
             live |= locked
 
+        journal_path = _default_journal_path()
+        if journal_path.exists():
+            journal_present = True
+            sources.append("sweep-journal")
+            for entry in _load_journal_entries(journal_path):
+                if not _journal_repo_matches(entry.repo, repo_root):
+                    continue
+                journal_issues.add(entry.issue)
+                if _pid_alive(entry.pid):
+                    live.add(entry.issue)
+
     return LivenessEvidence(
         available=bool(sources),
         live_issues=live,
         sources=sources,
+        journal_present=journal_present,
+        journal_issues=journal_issues,
     )
 
 
@@ -371,10 +543,19 @@ def check_untracked_building(
     """Find ``loom:building`` issues that no live sweep is tracking.
 
     Cross-references ``gh issue list --label loom:building`` against the live
-    issue set in *evidence* (roster + daemon + ``.loom/locks/``).  Issues with a
-    valid file-based claim are skipped (CLI-driven sweeps may hold a claim
-    without a lock).  Issues with a recently-applied ``loom:building`` label are
-    also skipped (label-age grace period).
+    issue set in *evidence* (roster + daemon + ``.loom/locks/`` + the sweep
+    journal).  Issues with a valid file-based claim are skipped (CLI-driven
+    sweeps may hold a claim without a lock).
+
+    **Staleness threshold (issue #3953):** a claim with a **dead** sweep-journal
+    entry (the strongest possible evidence — a recorded PID that is provably
+    gone) uses the standard, short *label_grace_period*. A claim with **no**
+    journal entry at all — when the journal is itself a contributing source —
+    uses the much longer ``LOOM_STALE_BUILDING_HOURS`` threshold instead,
+    since "no entry" might mean a live manual ``/loom:sweep`` the daemon was
+    never told about, not a dead one. When the journal is not a source at all
+    (e.g. it has never been written on this machine), every claim falls back
+    to *label_grace_period* — byte-for-byte pre-#3953 behavior.
 
     **Fail-safe (issue #3651):** if *evidence* reports no authoritative liveness
     source is available, this emits **zero** orphans — absence of a writer is
@@ -441,31 +622,47 @@ def check_untracked_building(
                 f"for #{issue_num} (this may cause false positives)"
             )
 
-        # Label-age grace period: skip issues where loom:building was
-        # applied recently.  Protects newly-claimed issues from premature
-        # orphan recovery before claims or heartbeats are established.
-        if label_grace_period > 0:
+        # Select the staleness threshold + reason (#3953): a journal entry for
+        # this issue is unconditional dead-PID proof (it would have been in
+        # `tracked_issues`/skipped above if the recorded PID were alive), so
+        # the standard short grace period applies. No entry at all — only
+        # when the journal is itself a contributing source — requires the
+        # much longer no-record threshold instead (see docstring).
+        has_journal_entry = issue_num in evidence.journal_issues
+        if evidence.journal_present and not has_journal_entry:
+            threshold_seconds = _get_stale_building_hours() * 3600
+            reason = "no_journal_record_stale"
+        else:
+            threshold_seconds = float(label_grace_period)
+            reason = "journal_pid_dead" if has_journal_entry else "no_spawn_loop_entry"
+
+        # Staleness gate: skip issues that haven't been in loom:building long
+        # enough yet under the selected threshold. Protects newly-claimed
+        # issues from premature orphan recovery before claims/heartbeats are
+        # established (short threshold) or before a no-journal-record claim
+        # has had a fair chance to prove itself alive (long threshold).
+        if threshold_seconds > 0:
             label_age = _get_building_label_age(issue_num)
-            if label_age is not None and label_age < label_grace_period:
+            if label_age is not None and label_age < threshold_seconds:
                 if verbose:
                     log_info(
                         f"  SKIPPED: #{issue_num} label loom:building "
-                        f"applied {label_age}s ago (grace period: "
-                        f"{label_grace_period}s)"
+                        f"applied {label_age}s ago (threshold: "
+                        f"{threshold_seconds:.0f}s, reason if stale: {reason})"
                     )
                 continue
 
         if verbose:
             log_warning(
                 f"  ORPHANED: #{issue_num} has loom:building "
-                "but no active spawn-loop task"
+                f"but no active spawn-loop task (reason: {reason})"
             )
         result.orphaned.append(
             OrphanEntry(
                 type="untracked_building",
                 issue=issue_num,
                 title=issue_title,
-                reason="no_spawn_loop_entry",
+                reason=reason,
             )
         )
 
@@ -834,9 +1031,9 @@ def run_orphan_recovery(
 
     spawn_loop_state = read_spawn_loop_state(repo_root)
 
-    # Gather authoritative liveness evidence (roster + daemon + locks). When no
-    # source is available the untracked-building cross-check fails safe and
-    # emits zero orphans — see issue #3651.
+    # Gather authoritative liveness evidence (roster + daemon + locks + the
+    # #3953 sweep journal). When no source is available the untracked-building
+    # cross-check fails safe and emits zero orphans — see issue #3651.
     evidence = gather_liveness_evidence(spawn_loop_state, repo_root)
 
     if verbose:
@@ -950,6 +1147,8 @@ Liveness sources (fail-safe, #3651):
     .loom/spawn-loop-state.json           - Legacy roster (no writer post-v0.11.0)
     loom-daemon registry                  - Optional, best-effort
     .loom/locks/issue-<N>/                - Per-issue worktree-lifetime locks
+    ~/.loom/sweeps.json                   - Machine-level sweep journal (#3953),
+                                             survives a daemon restart
     gh issue list --label loom:building   - Forge label cross-check
   With NO authoritative liveness source, zero untracked_building orphans
   are emitted (absent evidence => treat claims as ALIVE, not orphaned).
@@ -957,6 +1156,10 @@ Liveness sources (fail-safe, #3651):
 Environment variables:
     LOOM_HEARTBEAT_STALE_THRESHOLD  Seconds before heartbeat is stale (default: 300)
     LOOM_LABEL_GRACE_PERIOD         Seconds to skip recently-labeled issues (default: 600)
+    LOOM_STALE_BUILDING_HOURS       Hours before a claim with NO sweep-journal entry
+                                    is treated as orphaned (default: 4.0)
+    LOOM_SWEEPS_JOURNAL_PATH        Override the sweep journal path (default:
+                                    ~/.loom/sweeps.json)
 """,
     )
 

--- a/loom-tools/tests/test_orphan_recovery.py
+++ b/loom-tools/tests/test_orphan_recovery.py
@@ -20,8 +20,11 @@ Test map to acceptance criteria:
 
 from __future__ import annotations
 
+import json
 import pathlib
 from unittest import mock
+
+import pytest
 
 from loom_tools import orphan_recovery
 from loom_tools.models.spawn_loop_state import SpawnLoopState, SpawnLoopTask
@@ -33,6 +36,31 @@ from loom_tools.orphan_recovery import (
     gather_liveness_evidence,
     run_orphan_recovery,
 )
+
+
+@pytest.fixture(autouse=True)
+def _isolated_journal_path(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> pathlib.Path:
+    """Make the #3953 sweep-journal read hermetic for every test in this module.
+
+    ``gather_liveness_evidence`` resolves the journal path via
+    ``_default_journal_path()``, which defaults to the REAL
+    ``~/.loom/sweeps.json`` on the machine running the suite. Without this
+    fixture, a test's outcome (e.g. ``evidence.available``) would depend on
+    whether that file happens to exist on whoever's machine runs the tests.
+
+    Rather than replacing ``_default_journal_path`` itself (which would also
+    defeat a test of its own env-var-override logic), this patches
+    ``pathlib.Path.home()`` to a fresh, per-test fake home directory and
+    clears ``LOOM_SWEEPS_JOURNAL_PATH`` — so ``_default_journal_path()`` runs
+    its REAL resolution logic and lands on a path that is absent by default.
+    Tests that want journal-present behavior write to this same path
+    explicitly via :func:`_write_journal`.
+    """
+    fake_home = tmp_path / "fake-home"
+    fake_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.delenv("LOOM_SWEEPS_JOURNAL_PATH", raising=False)
+    monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+    return fake_home / ".loom" / "sweeps.json"
 
 
 # ---------------------------------------------------------------------------
@@ -49,6 +77,12 @@ def _make_repo(tmp_path: pathlib.Path) -> pathlib.Path:
 def _make_lock(repo_root: pathlib.Path, issue: int) -> None:
     """Create a ``.loom/locks/issue-<N>/`` worktree-lifetime lock dir."""
     (repo_root / ".loom" / "locks" / f"issue-{issue}").mkdir(parents=True, exist_ok=True)
+
+
+def _write_journal(journal_path: pathlib.Path, entries: list[dict]) -> None:
+    """Write a minimal sweep-journal file at ``journal_path``."""
+    journal_path.parent.mkdir(parents=True, exist_ok=True)
+    journal_path.write_text(json.dumps({"version": 1, "entries": entries}))
 
 
 class _GhRecorder:
@@ -319,3 +353,263 @@ def test_stale_heartbeat_path_unaffected(tmp_path: pathlib.Path) -> None:
     stale = [o for o in result.orphaned if o.type == "stale_heartbeat"]
     assert len(stale) == 1
     assert stale[0].issue == 77
+
+
+# ---------------------------------------------------------------------------
+# Machine-level sweep journal (issue #3953)
+# ---------------------------------------------------------------------------
+#
+# The journal gives orphan recovery an authoritative liveness source that
+# SURVIVES a daemon restart (unlike the in-memory registry `_query_daemon_live_
+# issues` merely stubs). These tests cover: (1) `gather_liveness_evidence`
+# reading the journal correctly, and (2) the end-to-end `run_orphan_recovery`
+# staleness-threshold selection it drives in `check_untracked_building`.
+
+
+def test_gather_liveness_journal_absent_file_is_not_a_source(
+    tmp_path: pathlib.Path,
+) -> None:
+    """No journal file at all -> not a source, byte-for-byte pre-#3953 behavior."""
+    repo = _make_repo(tmp_path)
+    evidence = gather_liveness_evidence(SpawnLoopState.absent(), repo)
+    assert evidence.available is False
+    assert evidence.journal_present is False
+    assert evidence.journal_issues == set()
+
+
+def test_gather_liveness_journal_present_dead_pid_is_source_not_live(
+    tmp_path: pathlib.Path, _isolated_journal_path: pathlib.Path,
+) -> None:
+    """A journal entry with a dead PID makes the journal a source, but the
+    issue is NOT added to `live_issues` (it's the strongest orphan evidence,
+    not liveness evidence)."""
+    repo = _make_repo(tmp_path)
+    _write_journal(_isolated_journal_path, [{"repo": str(repo), "issue": 42, "pid": 999999}])
+
+    with mock.patch.object(orphan_recovery, "_pid_alive", return_value=False):
+        evidence = gather_liveness_evidence(SpawnLoopState.absent(), repo)
+
+    assert evidence.available is True
+    assert "sweep-journal" in evidence.sources
+    assert evidence.journal_present is True
+    assert evidence.journal_issues == {42}
+    assert 42 not in evidence.live_issues
+
+
+def test_gather_liveness_journal_present_live_pid_is_live(
+    tmp_path: pathlib.Path, _isolated_journal_path: pathlib.Path,
+) -> None:
+    """A journal entry with a LIVE PID is proof of life: added to `live_issues`."""
+    repo = _make_repo(tmp_path)
+    _write_journal(_isolated_journal_path, [{"repo": str(repo), "issue": 42, "pid": 1}])
+
+    with mock.patch.object(orphan_recovery, "_pid_alive", return_value=True):
+        evidence = gather_liveness_evidence(SpawnLoopState.absent(), repo)
+
+    assert evidence.available is True
+    assert evidence.journal_issues == {42}
+    assert 42 in evidence.live_issues
+
+
+def test_gather_liveness_journal_entry_scoped_to_repo(
+    tmp_path: pathlib.Path, _isolated_journal_path: pathlib.Path,
+) -> None:
+    """An entry for a DIFFERENT repo must not leak into this repo's evidence."""
+    repo = _make_repo(tmp_path)
+    other_repo = tmp_path.parent / "some-other-repo"
+    _write_journal(_isolated_journal_path, [{"repo": str(other_repo), "issue": 42, "pid": 1}])
+
+    with mock.patch.object(orphan_recovery, "_pid_alive", return_value=True):
+        evidence = gather_liveness_evidence(SpawnLoopState.absent(), repo)
+
+    # The journal file exists (this repo's directory), so it IS a source, but
+    # it has no entry scoped to *this* repo.
+    assert evidence.journal_present is True
+    assert evidence.journal_issues == set()
+    assert 42 not in evidence.live_issues
+
+
+def test_gather_liveness_journal_corrupt_file_degrades_to_absent_entries(
+    tmp_path: pathlib.Path, _isolated_journal_path: pathlib.Path,
+) -> None:
+    """A corrupt journal file must not crash -- it degrades to zero entries.
+
+    The file's mere *presence* still marks the journal as a contributing
+    source (mirrors `sweep_journal::load`'s tolerant-corrupt-file behavior on
+    the Rust side): a corrupt journal is not proof of anything, so no entries
+    are read from it, but its presence is not silently ignored either.
+    """
+    repo = _make_repo(tmp_path)
+    _isolated_journal_path.parent.mkdir(parents=True, exist_ok=True)
+    _isolated_journal_path.write_text("{ not json")
+
+    evidence = gather_liveness_evidence(SpawnLoopState.absent(), repo)
+
+    assert evidence.journal_present is True
+    assert evidence.journal_issues == set()
+
+
+def test_journal_dead_pid_claim_is_recoverable(
+    tmp_path: pathlib.Path, _isolated_journal_path: pathlib.Path,
+) -> None:
+    """AC #3953: a claim whose recorded PID is dead IS reclaimable (subject to
+    the standard, short label-age grace period -- not the long no-record one).
+    """
+    repo = _make_repo(tmp_path)
+    _write_journal(_isolated_journal_path, [{"repo": str(repo), "issue": 42, "pid": 999999}])
+    gh = _GhRecorder(allow_edit=True)
+
+    with mock.patch.object(
+        orphan_recovery, "_pid_alive", return_value=False,
+    ), mock.patch.object(
+        orphan_recovery, "gh_issue_list",
+        return_value=[{"number": 42, "title": "dead sweep after daemon restart"}],
+    ), mock.patch.object(
+        orphan_recovery, "_get_building_label_age", return_value=700,  # > grace(600), well under 4h
+    ), mock.patch.object(
+        orphan_recovery, "has_valid_claim", return_value=False,
+    ), mock.patch.object(
+        orphan_recovery, "_has_recent_orphan_comment", return_value=False,
+    ), mock.patch.object(orphan_recovery, "gh_run", gh):
+        result = run_orphan_recovery(repo, recover=True, verbose=True)
+
+    assert result.total_orphaned == 1
+    assert result.orphaned[0].reason == "journal_pid_dead"
+    assert "42" in gh.edited_issues
+
+
+def test_journal_live_pid_claim_still_refuses(
+    tmp_path: pathlib.Path, _isolated_journal_path: pathlib.Path,
+) -> None:
+    """AC #3953: still refuses to reclaim when the record shows a live PID —
+    even with a very old label."""
+    repo = _make_repo(tmp_path)
+    _write_journal(_isolated_journal_path, [{"repo": str(repo), "issue": 42, "pid": 1}])
+    gh = _GhRecorder(allow_edit=False)
+
+    with mock.patch.object(
+        orphan_recovery, "_pid_alive", return_value=True,
+    ), mock.patch.object(
+        orphan_recovery, "gh_issue_list",
+        return_value=[{"number": 42, "title": "long-running live sweep"}],
+    ), mock.patch.object(
+        orphan_recovery, "_get_building_label_age", return_value=99999,
+    ), mock.patch.object(
+        orphan_recovery, "has_valid_claim", return_value=False,
+    ), mock.patch.object(orphan_recovery, "gh_run", gh):
+        result = run_orphan_recovery(repo, recover=True, verbose=True)
+
+    assert result.total_orphaned == 0
+    assert gh.edited_issues == []
+
+
+def test_journal_no_record_within_stale_hours_is_not_recovered(
+    tmp_path: pathlib.Path, _isolated_journal_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No journal entry at all, journal IS a source (has an entry for another
+    issue): must NOT reclaim before LOOM_STALE_BUILDING_HOURS, even though the
+    label is already past the (much shorter) default grace period."""
+    repo = _make_repo(tmp_path)
+    _write_journal(_isolated_journal_path, [{"repo": str(repo), "issue": 999, "pid": 1}])
+    monkeypatch.setenv("LOOM_STALE_BUILDING_HOURS", "4")
+    gh = _GhRecorder(allow_edit=False)
+
+    with mock.patch.object(
+        orphan_recovery, "_pid_alive", return_value=True,
+    ), mock.patch.object(
+        orphan_recovery, "gh_issue_list",
+        return_value=[{"number": 42, "title": "no journal entry, not stale enough yet"}],
+    ), mock.patch.object(
+        orphan_recovery, "_get_building_label_age", return_value=3600,  # 1h: > 600s grace, < 4h
+    ), mock.patch.object(
+        orphan_recovery, "has_valid_claim", return_value=False,
+    ), mock.patch.object(orphan_recovery, "gh_run", gh):
+        result = run_orphan_recovery(repo, recover=True, verbose=True)
+
+    assert result.total_orphaned == 0
+    assert gh.edited_issues == []
+
+
+def test_journal_no_record_past_stale_hours_is_recovered(
+    tmp_path: pathlib.Path, _isolated_journal_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same setup, but past LOOM_STALE_BUILDING_HOURS -> now reclaimable."""
+    repo = _make_repo(tmp_path)
+    _write_journal(_isolated_journal_path, [{"repo": str(repo), "issue": 999, "pid": 1}])
+    monkeypatch.setenv("LOOM_STALE_BUILDING_HOURS", "4")
+    gh = _GhRecorder(allow_edit=True)
+
+    with mock.patch.object(
+        orphan_recovery, "_pid_alive", return_value=True,
+    ), mock.patch.object(
+        orphan_recovery, "gh_issue_list",
+        return_value=[{"number": 42, "title": "no journal entry, now stale"}],
+    ), mock.patch.object(
+        orphan_recovery, "_get_building_label_age", return_value=20000,  # > 4h
+    ), mock.patch.object(
+        orphan_recovery, "has_valid_claim", return_value=False,
+    ), mock.patch.object(
+        orphan_recovery, "_has_recent_orphan_comment", return_value=False,
+    ), mock.patch.object(orphan_recovery, "gh_run", gh):
+        result = run_orphan_recovery(repo, recover=True, verbose=True)
+
+    assert result.total_orphaned == 1
+    assert result.orphaned[0].reason == "no_journal_record_stale"
+    assert "42" in gh.edited_issues
+
+
+def test_journal_absent_falls_back_to_label_grace_period(
+    tmp_path: pathlib.Path,
+) -> None:
+    """No journal file at all (only a lock-based source): unaffected by
+    #3953 -- the standard label_grace_period alone governs, matching
+    pre-#3953 behavior exactly."""
+    repo = _make_repo(tmp_path)
+    _make_lock(repo, 999)  # unrelated active source
+    gh = _GhRecorder(allow_edit=True)
+
+    with mock.patch.object(
+        orphan_recovery, "gh_issue_list",
+        return_value=[{"number": 42, "title": "no journal at all"}],
+    ), mock.patch.object(
+        orphan_recovery, "_get_building_label_age", return_value=700,  # > grace(600s)
+    ), mock.patch.object(
+        orphan_recovery, "has_valid_claim", return_value=False,
+    ), mock.patch.object(
+        orphan_recovery, "_has_recent_orphan_comment", return_value=False,
+    ), mock.patch.object(orphan_recovery, "gh_run", gh):
+        result = run_orphan_recovery(repo, recover=True, verbose=True)
+
+    assert result.total_orphaned == 1
+    assert result.orphaned[0].reason == "no_spawn_loop_entry"
+    assert "42" in gh.edited_issues
+
+
+def test_get_stale_building_hours_default_and_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("LOOM_STALE_BUILDING_HOURS", raising=False)
+    assert orphan_recovery._get_stale_building_hours() == orphan_recovery.DEFAULT_STALE_BUILDING_HOURS
+
+    monkeypatch.setenv("LOOM_STALE_BUILDING_HOURS", "2.5")
+    assert orphan_recovery._get_stale_building_hours() == 2.5
+
+    # Non-positive / unparseable falls back to the default.
+    monkeypatch.setenv("LOOM_STALE_BUILDING_HOURS", "0")
+    assert orphan_recovery._get_stale_building_hours() == orphan_recovery.DEFAULT_STALE_BUILDING_HOURS
+    monkeypatch.setenv("LOOM_STALE_BUILDING_HOURS", "garbage")
+    assert orphan_recovery._get_stale_building_hours() == orphan_recovery.DEFAULT_STALE_BUILDING_HOURS
+
+
+def test_default_journal_path_env_override(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path) -> None:
+    custom = tmp_path / "custom-sweeps.json"
+    monkeypatch.setenv("LOOM_SWEEPS_JOURNAL_PATH", str(custom))
+    assert orphan_recovery._default_journal_path() == custom
+    monkeypatch.delenv("LOOM_SWEEPS_JOURNAL_PATH", raising=False)
+
+
+def test_journal_repo_matches_exact_and_resolved(tmp_path: pathlib.Path) -> None:
+    repo = _make_repo(tmp_path)
+    assert orphan_recovery._journal_repo_matches(str(repo), repo) is True
+    assert orphan_recovery._journal_repo_matches(str(repo) + "/", repo) is True
+    assert orphan_recovery._journal_repo_matches("/some/other/repo", repo) is False


### PR DESCRIPTION
## Summary

Gives `loom-recover-orphans` an authoritative liveness source that **survives a daemon restart** — closing the gap where a restarted daemon's empty in-memory sweep registry left every managed repo's stale `loom:building` claims un-reclaimable (the #3651 fail-safe correctly refuses when *no* liveness source exists at all; this issue was that no source *survived* a restart).

- **Rust: `loom-daemon/src/sweep_journal.rs`** — a persisted, machine-level `{repo, issue, pid, started_at}` journal at `~/.loom/sweeps.json` (override via `LOOM_SWEEPS_JOURNAL_PATH`). `SweepRegistry::dispatch` writes an entry on every successful spawn; the reaper's dead-PID path and `finish_cancel` best-effort-remove it. Dead-PID pruned on every write, mirroring `sweep-run-registry.sh`'s `peers`/`prune_dead` pattern (#3768). `SweepRegistryConfig.journal_path` lets tests confine the journal to a tempdir so the test suite never touches the real `~/.loom/sweeps.json`.
- **Rust: `loom-daemon/src/claim_reconciliation.rs`** — pure decision logic (`decide`/`plan`, fully unit-tested) plus a thin `gh`-shelling `forge::reconcile_workspace` adapter (mirrors the `work_finder::forge` / `epic_supervisor::forge` split — adapters aren't unit-tested directly, matching existing convention). Wired into daemon startup (`main.rs`) as a bounded, logged pass over every `WorkspaceRegistry::effective_roots()` workspace — self-healing stale claims across all managed repos with zero operator intervention. Kill-switch: `LOOM_STALE_CLAIM_RECONCILE=0`.
- **Python: `loom_tools/orphan_recovery.py`** — `gather_liveness_evidence` now reads the same journal as a 4th liveness source:
  - A journal entry with a **dead** PID is unconditional proof of death → reclaimable, subject to the existing (short) label-age grace period.
  - A journal entry with a **live** PID is unconditional proof of life → claim always protected (`--recover` still refuses).
  - **No** journal entry at all, when the journal is a contributing source, uses a new, much longer `LOOM_STALE_BUILDING_HOURS` threshold (default 4h) before treating the claim as orphaned — a "no record" claim might be a live *manual* `/loom:sweep` the daemon was never told about.
  - No journal file at all → byte-for-byte pre-#3953 behavior (untouched).

## Test plan

- [x] `cargo test --lib` in `loom-daemon/` — 822 passed (0 failed), including new `sweep_journal`/`claim_reconciliation` unit tests and a `dispatch_and_reap_wire_the_sweep_journal` integration test.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] Verified test runs never write to the real `~/.loom/sweeps.json` (all dispatch/reap-exercising test fixtures pin `journal_path` to a tempdir).
- [x] `PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/test_orphan_recovery.py` — 27 passed, including 13 new tests covering dead-PID reclaim, live-PID refusal, no-record staleness threshold, repo-scoping, and corrupt-journal tolerance. An autouse fixture patches `pathlib.Path.home()` so no test depends on the real machine's `~/.loom/sweeps.json`.
- [x] `PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests` — 1922 passed, 62 skipped, 2 pre-existing failures unrelated to this change (`test_forge_cli.py::test_version_flag`, `test_logging.py::test_log_output_visible_non_interactively` — both environment/packaging issues, reproduced identically against unmodified files).
- [x] `ruff check` on both changed Python files — clean.

Closes #3953