### PR TITLE
test(daemon): regression coverage + diagnostics for #3967 daemon self-claim marker

### DIFF
--- a/defaults/scripts/spawn-claude.sh
+++ b/defaults/scripts/spawn-claude.sh
@@ -108,6 +108,21 @@ _resolve_workspace() {
 WORKSPACE="$(_resolve_workspace)"
 PYTHON="${LOOM_PYTHON:-python3}"
 
+# --- Daemon self-claim marker visibility (Issue #3823, observability #3967) ---
+# `loom-daemon`'s `SweepRegistry::spawn_child` exports
+# `LOOM_SWEEP_CLAIM_OWNED=<issue>` into a daemon-dispatched child so its
+# `/loom:sweep` pre-flight recognises the daemon's own pre-dispatch
+# `loom:issue -> loom:building` label flip as ITS OWN claim rather than
+# self-skipping the issue as "another worker is in flight" (the #3967
+# incident). Log the marker's presence/value here — unconditionally, on
+# every spawn, whether daemon-dispatched or not — so a future occurrence is
+# diagnosable straight from `.loom/logs/sweep-issue-<N>.log` without needing
+# to reproduce the dispatch: this line, plus the `spawn-claude:` prefix, is
+# already captured by `spawn_child`'s per-sweep log redirection, so any gap
+# between the Rust `Command::env()` call and what this script's own
+# environment actually sees is now directly observable instead of inferred.
+log_info "spawn-claude: LOOM_SWEEP_CLAIM_OWNED=${LOOM_SWEEP_CLAIM_OWNED:-unset}"
+
 # --- Argument parsing ---
 USE_WRAPPER=false
 PASSTHROUGH_ARGS=()

--- a/defaults/scripts/tests/test-spawn-claude.sh
+++ b/defaults/scripts/tests/test-spawn-claude.sh
@@ -278,6 +278,25 @@ output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
 assert_contains "stub-claude ceiling=120000" "$output" \
     "spawn-claude preserves an operator-set wait ceiling (#3943)"
 
+# Test: the daemon self-claim marker's presence/value is always logged (Issue
+# #3967) — with the var unset, an interactive/manual invocation logs "unset".
+# Explicitly unset it first: this test suite may itself be running inside a
+# daemon-dispatched `/loom:sweep` session, which would otherwise leak an
+# ambient `LOOM_SWEEP_CLAIM_OWNED` into the subshell and false-fail this case.
+output=$(env -u LOOM_SWEEP_CLAIM_OWNED LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
+    "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
+assert_contains "spawn-claude: LOOM_SWEEP_CLAIM_OWNED=unset" "$output" \
+    "spawn-claude logs LOOM_SWEEP_CLAIM_OWNED=unset when not daemon-dispatched (#3967)"
+
+# Test: with the var set (simulating a daemon-dispatched child, #3823), the
+# same log line echoes the exact issue number — the diagnostic this issue's
+# acceptance criteria calls for, straight from the per-sweep log.
+output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
+    LOOM_SWEEP_CLAIM_OWNED="3964" \
+    "$SCRIPTS_DIR/spawn-claude.sh" -p "ping" 2>&1 || true)
+assert_contains "spawn-claude: LOOM_SWEEP_CLAIM_OWNED=3964" "$output" \
+    "spawn-claude logs the daemon self-claim marker's value when set (#3967)"
+
 # Test: explicit CLAUDE_CODE_OAUTH_TOKEN bypasses selection
 output=$(LOOM_WORKSPACE="$TEST_WS" PATH="$STUB_DIR:$PATH" \
     CLAUDE_CODE_OAUTH_TOKEN="caller-supplied" \

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -1709,8 +1709,9 @@ mod tests {
     // ===== Sweep registry IPC handlers (Issue #3452) =====
 
     /// Build a SweepRegistry that won't actually launch real children.
-    /// The fixture spawn binary writes its argv to a sibling log and exits
-    /// immediately (same pattern as the sweep_registry unit tests).
+    /// The fixture spawn binary writes its argv AND a handful of env vars
+    /// (notably `LOOM_SWEEP_CLAIM_OWNED`, Issue #3823/#3967) to a sibling log
+    /// and exits immediately (same pattern as the sweep_registry unit tests).
     fn setup_sweep_registry_in_tempdir(
     ) -> (Arc<Mutex<SweepRegistry>>, tempfile::TempDir, std::path::PathBuf) {
         use std::os::unix::fs::PermissionsExt;
@@ -1721,7 +1722,10 @@ mod tests {
         let record_log = dir.path().join("ipc-fake-spawn.log");
         let script = format!(
             r#"#!/usr/bin/env bash
-echo "argv: $*" >> "{rec}"
+{{
+  echo "argv: $*"
+  printf 'LOOM_SWEEP_CLAIM_OWNED=%s\n' "${{LOOM_SWEEP_CLAIM_OWNED:-unset}}"
+}} >> "{rec}"
 exit 0
 "#,
             rec = record_log.display()
@@ -1948,6 +1952,63 @@ exit 0
             }
             other => panic!("Expected SweepList, got: {other:?}"),
         }
+    }
+
+    /// Issue #3967: reproduce the reported daemon-dispatched sweep self-skip at
+    /// the **IPC dispatch-path level** — through `handle_request` itself, not
+    /// `SweepRegistry::dispatch()` called directly (the existing
+    /// `dispatch_exports_claim_ownership_marker` unit test in
+    /// `sweep_registry.rs` covers that narrower scope). `handle_request`'s
+    /// `Request::DispatchSweep` arm is the exact server-side code both the
+    /// `loom-daemon dispatch <issue>` operator CLI (#3952) and the MCP
+    /// `dispatch_sweep` tool round-trip into over the Unix socket — so a
+    /// regression here would have caught the incident regardless of which of
+    /// those two client surfaces initiated the request. Asserts the spawned
+    /// child's env carries `LOOM_SWEEP_CLAIM_OWNED=<issue>` end-to-end.
+    #[test]
+    #[serial_test::serial]
+    fn test_handle_request_dispatch_sweep_exports_claim_ownership_marker() {
+        let (tm, db, _, bus) = setup_test_context();
+        let (sr, _dir, record_log) = setup_sweep_registry_in_tempdir();
+
+        let response = handle_request(
+            Request::DispatchSweep {
+                kind: SweepKind::Issue(3964),
+                idempotency_key: None,
+                model: None,
+                effort: None,
+                depends_on: None,
+                workspace_root: None,
+            },
+            &tm,
+            &db,
+            &sr,
+            &bus,
+            &test_pool(),
+        );
+        assert!(
+            matches!(response, Response::SweepDispatched { .. }),
+            "expected SweepDispatched, got: {response:?}"
+        );
+
+        // The fake spawn-claude.sh exits immediately; give it a brief window
+        // to flush its record log rather than racing the write.
+        let start = std::time::Instant::now();
+        let mut recorded = String::new();
+        while start.elapsed().as_millis() < 5000 {
+            if let Ok(s) = std::fs::read_to_string(&record_log) {
+                if s.contains("LOOM_SWEEP_CLAIM_OWNED=") {
+                    recorded = s;
+                    break;
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+        assert!(
+            recorded.contains("LOOM_SWEEP_CLAIM_OWNED=3964"),
+            "expected the daemon-owned-child self-claim marker to reach the \
+             spawned child via the IPC DispatchSweep handler; got: {recorded:?}"
+        );
     }
 
     #[test]

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -1479,6 +1479,81 @@ mod tests {
     }
 
     // ===================================================================
+    // RegistryDispatcher — production dispatch-path regression (Issue #3967)
+    // ===================================================================
+
+    /// Build a real `SweepRegistry` (not the `RecordingDispatcher` test
+    /// fake) backed by a fixture spawn binary that records its env to a
+    /// sibling log and exits immediately — same pattern used by the
+    /// `sweep_registry.rs` and `ipc.rs` fixtures.
+    fn setup_registry_dispatcher_in_tempdir(
+    ) -> (RegistryDispatcher, tempfile::TempDir, std::path::PathBuf) {
+        use crate::sweep_registry::{SweepRegistry, SweepRegistryConfig};
+        use std::os::unix::fs::PermissionsExt;
+        use std::sync::Mutex;
+
+        let dir = tempfile::tempdir().unwrap();
+        let scripts_dir = dir.path().join(".loom").join("scripts");
+        std::fs::create_dir_all(&scripts_dir).unwrap();
+        let fake_bin = scripts_dir.join("spawn-claude.sh");
+        let record_log = dir.path().join("workfinder-fake-spawn.log");
+        let script = format!(
+            r#"#!/usr/bin/env bash
+printf 'LOOM_SWEEP_CLAIM_OWNED=%s\n' "${{LOOM_SWEEP_CLAIM_OWNED:-unset}}" >> "{rec}"
+exit 0
+"#,
+            rec = record_log.display()
+        );
+        std::fs::write(&fake_bin, script).unwrap();
+        let mut perms = std::fs::metadata(&fake_bin).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fake_bin, perms).unwrap();
+
+        let mut config = SweepRegistryConfig::new(dir.path().to_path_buf());
+        config.spawn_bin = Some(fake_bin);
+        config.skip_label_flip = true;
+        config.journal_path = Some(dir.path().join("test-sweeps-journal.json"));
+        let registry = Arc::new(Mutex::new(SweepRegistry::new(config)));
+        (RegistryDispatcher::new(registry), dir, record_log)
+    }
+
+    /// Issue #3967: the autonomous work finder's real dispatch path
+    /// (`RegistryDispatcher`, the `WorkDispatcher` impl wired into
+    /// production — as opposed to the `RecordingDispatcher` test fake used
+    /// by every `tick`/`tick_multi` test above) must export
+    /// `LOOM_SWEEP_CLAIM_OWNED=<issue>` into the spawned child exactly like
+    /// the IPC `DispatchSweep` path (`ipc.rs`) and the CLI `dispatch`
+    /// subcommand (`main.rs`) do. `RegistryDispatcher::dispatch` forwards to
+    /// `SweepRegistry::dispatch` → `spawn_child`, so this closes the
+    /// dispatch-path-level regression coverage across all three daemon
+    /// dispatch entry points.
+    #[test]
+    #[serial]
+    fn test_registry_dispatcher_exports_claim_ownership_marker() {
+        let (mut dispatcher, _dir, record_log) = setup_registry_dispatcher_in_tempdir();
+
+        let was_new = dispatcher.dispatch(3964).expect("dispatch should succeed");
+        assert!(was_new, "expected a fresh dispatch, not an idempotency no-op");
+
+        let start = std::time::Instant::now();
+        let mut recorded = String::new();
+        while start.elapsed().as_millis() < 5000 {
+            if let Ok(s) = std::fs::read_to_string(&record_log) {
+                if s.contains("LOOM_SWEEP_CLAIM_OWNED=") {
+                    recorded = s;
+                    break;
+                }
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        assert!(
+            recorded.contains("LOOM_SWEEP_CLAIM_OWNED=3964"),
+            "expected the work-finder's production RegistryDispatcher to export \
+             the daemon-owned-child self-claim marker; got: {recorded:?}"
+        );
+    }
+
+    // ===================================================================
     // tick — dispatch scheduling
     // ===================================================================
 


### PR DESCRIPTION
## Summary

Closes #3967.

Reproduces the reported incident — a daemon-dispatched sweep for #3964 self-skipping because `LOOM_SWEEP_CLAIM_OWNED` appeared unset in the child, even though `loom-daemon` had already flipped `loom:issue` -> `loom:building` and (per #3823/#3829) `SweepRegistry::spawn_child` already exports the marker — and adds regression coverage at each of the three dispatch entry points named in the issue, plus a diagnostic log line for future occurrences.

## What was found

**No live propagation bug.** All three dispatch entry points converge on the same underlying mechanism (`SweepRegistry::dispatch` -> `spawn_child`, which already sets `LOOM_SWEEP_CLAIM_OWNED` in the child's `Command::env()`):

- **MCP `dispatch_sweep`** and the **`loom-daemon dispatch <issue>` CLI** (#3952) both send an identical `Request::DispatchSweep` over the daemon's Unix socket, handled by the same `handle_request` match arm in `ipc.rs` (confirmed by reading `main.rs::handle_dispatch_command` / `build_dispatch_request`, which mirrors the MCP tool's field mapping 1:1). The CLI does **not** bypass `spawn_child` — I checked this explicitly per the issue's third suspect.
- **Autonomous work finder** dispatches through `RegistryDispatcher` (the production `WorkDispatcher` impl), which also forwards to `SweepRegistry::dispatch`.

New tests added at the dispatch-path level (broader than the existing `spawn_child`-only unit test) all **pass**, confirming the marker propagates correctly through all three surfaces:

- `loom-daemon/src/ipc.rs` — `test_handle_request_dispatch_sweep_exports_claim_ownership_marker`: drives `handle_request(Request::DispatchSweep{...})` end-to-end (the exact code both the MCP tool and the CLI round-trip into) and asserts the spawned child's env carries `LOOM_SWEEP_CLAIM_OWNED=<issue>`.
- `loom-daemon/src/work_finder.rs` — `test_registry_dispatcher_exports_claim_ownership_marker`: builds a real `SweepRegistry`-backed `RegistryDispatcher` (not the `RecordingDispatcher` test fake used elsewhere in that file) and asserts the same marker propagation through the work-finder's actual production dispatch path.

Given this, the #3967 incident was most likely something environment-specific to that one run (e.g. a stale/pre-#3823 daemon binary running in that repo, or a one-off race) rather than a reproducible code-path bug — so there is no `spawn_child` / `sweep_registry.rs` diff in this PR. The value delivered is closing the regression-coverage gap (so a *future* regression at any of these three entry points is caught) and adding always-on diagnostics so the next occurrence is debuggable straight from the sweep log.

## Diagnostics added (AC #3)

`defaults/scripts/spawn-claude.sh` now unconditionally logs `spawn-claude: LOOM_SWEEP_CLAIM_OWNED=<value|unset>` right after workspace/python resolution, on every spawn (daemon-dispatched or not). This line lands in `.loom/logs/sweep-issue-<N>.log` via `spawn_child`'s existing per-sweep log redirection, so the marker's presence/value is always directly observable rather than inferred — closing the gap between what `spawn_child`'s `Command::env()` call sets and what the child script's environment actually sees.

Two new bash tests in `defaults/scripts/tests/test-spawn-claude.sh` cover both states (unset and set to a specific issue number), with an explicit `env -u LOOM_SWEEP_CLAIM_OWNED` guard on the unset case since the test suite may itself run inside a daemon-dispatched session.

## Test plan

- [x] `cargo test --lib` in `loom-daemon/` — 824 passed, 0 failed (includes the 2 new tests plus the existing `sweep_registry::tests::dispatch_exports_claim_ownership_marker`)
- [x] `cargo build` and `cargo build --release` — both clean
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --lib --tests -- -D warnings` — clean
- [x] `bash defaults/scripts/tests/test-spawn-claude.sh` — 78/78 passed (includes the 2 new #3967 cases)
- [x] `shellcheck` on both touched bash files — clean