### PR TITLE
fix(tokens): apply exhausted-threshold test on 429 path, not just 2xx

### DIFF
--- a/loom-tools/src/loom_tools/tokens/check.py
+++ b/loom-tools/src/loom_tools/tokens/check.py
@@ -21,8 +21,13 @@ succeeds on plain API keys).
 Status assignment:
 
 * ``available`` — utilizations < 95 percent
-* ``exhausted`` — 7d_utilization >= 0.95
-* ``rate_limited`` — current 429 (transient, distinct from exhausted)
+* ``exhausted`` — 7d_utilization >= 0.95 (checked on **both** the 2xx and
+  429 response paths, issue #3988 — a weekly-exhausted account very often
+  answers the probe with 429 rather than 200, and previously only the 2xx
+  path applied this test, so such accounts were mislabelled
+  ``rate_limited`` and stayed eligible for selection forever)
+* ``rate_limited`` — current 429 with 7d_utilization below the exhausted
+  threshold (a genuine transient rate limit, distinct from exhaustion)
 * ``blocked`` — 401 auth failure or token listed in ``.bad_tokens``
 
 The CLI command writes ``.loom/tokens/.ranking`` atomically when
@@ -287,6 +292,18 @@ def _build_headers(token: str) -> dict[str, str]:
     return base
 
 
+def _status_from_utilization(s7d_util: float | None, *, default: str) -> str:
+    """Return ``"exhausted"`` when *s7d_util* clears the threshold, else *default*.
+
+    Shared by both the 2xx and 429 probe-response branches (issue #3988) so
+    the ``EXHAUSTED_THRESHOLD`` test is applied uniformly regardless of which
+    HTTP status the probe happened to receive.
+    """
+    if s7d_util is not None and s7d_util >= EXHAUSTED_THRESHOLD:
+        return "exhausted"
+    return default
+
+
 def probe_account(
     name: str,
     token: str,
@@ -337,11 +354,18 @@ def probe_account(
         return AccountResult(name=name, status="blocked", error="auth_401")
 
     if code == 429:
-        # Even a 429 may include rate-limit headers; capture them.
+        # Even a 429 may include rate-limit headers; capture them. A weekly-
+        # exhausted account frequently answers with 429 (not 200), so the
+        # exhausted-threshold test must apply here too (issue #3988) — else
+        # such accounts are mislabelled "rate_limited" forever and the
+        # selector keeps rotating dispatches into a dead account.
         parsed = parse_rate_limit_headers(resp.headers)
+        status = _status_from_utilization(
+            parsed["7d_utilization"], default="rate_limited"
+        )
         return AccountResult(
             name=name,
-            status="rate_limited",
+            status=status,
             s5h_utilization=parsed["5h_utilization"],
             s7d_utilization=parsed["7d_utilization"],
             s7d_reset=parsed["7d_reset"],
@@ -366,11 +390,7 @@ def probe_account(
 
     parsed = parse_rate_limit_headers(resp.headers)
     s7d_util = parsed["7d_utilization"]
-
-    if s7d_util is not None and s7d_util >= EXHAUSTED_THRESHOLD:
-        status = "exhausted"
-    else:
-        status = "available"
+    status = _status_from_utilization(s7d_util, default="available")
 
     return AccountResult(
         name=name,

--- a/loom-tools/src/loom_tools/tokens/select.py
+++ b/loom-tools/src/loom_tools/tokens/select.py
@@ -231,32 +231,50 @@ def _try_ranking(
     accounts, in rotating order. The window spans every eligible account by
     default; ``_resolve_spread_top_n`` optionally caps it to the top-N
     most-available (``N == 1`` restores the greedy first-eligible behavior).
+
+    Defense in depth (issue #3988): ``rate_limited`` is a weaker signal than
+    ``available`` (a probe that hit 429 without clearing the exhausted
+    threshold, i.e. a genuine transient rate limit *or* a status the
+    classifier hasn't yet promoted). Prefer excluding ``rate_limited``
+    entries entirely while the pool still has at least one non-rate_limited
+    account; only fall back to including them when they are all that is
+    left, so a fully rate-limited pool can still dispatch rather than
+    hard-failing.
     """
     age = _file_age_seconds(ranking_file)
     if age is None or age >= _RANKING_FRESH_SECONDS:
         return None
 
     cap = _resolve_spread_top_n(workspace_path)
-    eligible: list[SelectedToken] = []
-    for name, status in _read_ranking(ranking_file):
-        if status in ("exhausted", "blocked"):
-            continue
-        token_file = tokens_dir / f"{name}.token"
-        if not token_file.is_file():
-            continue
-        if is_bad(workspace_path, name):
-            continue
-        try:
-            key = _read_token_file(token_file)
-        except OSError:
-            continue
-        if not key:
-            continue
-        eligible.append(
-            SelectedToken(name=name, file=token_file, key=key, mode="ranked"),
-        )
-        if cap is not None and len(eligible) >= cap:
-            break
+
+    def _collect(*, skip_rate_limited: bool) -> list[SelectedToken]:
+        out: list[SelectedToken] = []
+        for name, status in _read_ranking(ranking_file):
+            if status in ("exhausted", "blocked"):
+                continue
+            if skip_rate_limited and status == "rate_limited":
+                continue
+            token_file = tokens_dir / f"{name}.token"
+            if not token_file.is_file():
+                continue
+            if is_bad(workspace_path, name):
+                continue
+            try:
+                key = _read_token_file(token_file)
+            except OSError:
+                continue
+            if not key:
+                continue
+            out.append(
+                SelectedToken(name=name, file=token_file, key=key, mode="ranked"),
+            )
+            if cap is not None and len(out) >= cap:
+                break
+        return out
+
+    eligible = _collect(skip_rate_limited=True)
+    if not eligible:
+        eligible = _collect(skip_rate_limited=False)
 
     if not eligible:
         return None
@@ -272,6 +290,10 @@ def _stale_ranking_exclusions(ranking_file: Path) -> set[str]:
     handing out accounts a recent probe already flagged ``exhausted``/``blocked``,
     wedging sweeps at startup. Rather than discard the stale ranking, treat its
     exhausted/blocked entries as an advisory exclusion set for the lower tiers.
+    ``rate_limited`` is included too (issue #3988, same defense-in-depth
+    rationale as ``_try_ranking``) — the caller's existing fail-safe already
+    retries without exclusions if they would empty the pool, so this can only
+    ever prefer a healthier account, never hard-fail one.
 
     Returns an empty set when the ranking is fresh (tier-1 owns that case) or
     missing/unreadable — so callers get exclusions *only* in the stale-but-present
@@ -283,7 +305,7 @@ def _stale_ranking_exclusions(ranking_file: Path) -> set[str]:
     return {
         name
         for name, status in _read_ranking(ranking_file)
-        if status in ("exhausted", "blocked")
+        if status in ("exhausted", "blocked", "rate_limited")
     }
 
 

--- a/loom-tools/tests/tokens/test_check.py
+++ b/loom-tools/tests/tokens/test_check.py
@@ -205,6 +205,40 @@ class TestProbeStatuses:
         # Rate-limit headers still captured even on 429.
         assert r.s7d_utilization == pytest.approx(0.20)
 
+    def test_429_promoted_to_exhausted_when_7d_high(self):
+        """Regression for issue #3988.
+
+        A weekly-exhausted account frequently answers the probe with 429
+        rather than 200 — previously the EXHAUSTED_THRESHOLD test was only
+        applied on the 2xx path, so this response was mislabelled
+        "rate_limited" (and stayed eligible for selection) even though its
+        own headers showed 7d_utilization >= 0.95.
+        """
+        with patch(
+            "requests.post",
+            return_value=_mock_response(429, _good_headers(s7d=0.97)),
+        ):
+            r = probe_account("agent-1", "sk-ant-oat01-x")
+        assert r.status == "exhausted"
+        assert r.s7d_utilization == pytest.approx(0.97)
+
+    def test_429_at_threshold_promoted_to_exhausted(self):
+        with patch(
+            "requests.post",
+            return_value=_mock_response(
+                429, _good_headers(s7d=EXHAUSTED_THRESHOLD)
+            ),
+        ):
+            r = probe_account("agent-1", "sk-ant-oat01-x")
+        assert r.status == "exhausted"
+
+    def test_429_without_utilization_headers_stays_rate_limited(self):
+        """A 429 with no rate-limit headers at all has nothing to promote on."""
+        with patch("requests.post", return_value=_mock_response(429)):
+            r = probe_account("agent-1", "sk-ant-oat01-x")
+        assert r.status == "rate_limited"
+        assert r.s7d_utilization is None
+
     def test_503_error_not_fatal(self):
         with patch("requests.post", return_value=_mock_response(503)):
             r = probe_account("agent-1", "sk-ant-oat01-x")

--- a/loom-tools/tests/tokens/test_select.py
+++ b/loom-tools/tests/tokens/test_select.py
@@ -306,6 +306,65 @@ def test_ranking_falls_through_when_all_exhausted(tmp_path):
     assert sel.mode == "random"
 
 
+# ---------- rate_limited defense-in-depth (issue #3988) ----------
+
+
+def test_ranking_prefers_available_over_rate_limited(tmp_path):
+    """A rate_limited account is skipped while a healthy account exists.
+
+    Regression for issue #3988: rate_limited was previously fully eligible
+    alongside available, so a 429-classified (often genuinely-exhausted-but-
+    misclassified) account competed equally in rotation.
+    """
+    workspace = _make_workspace(tmp_path, {"tired": "kt", "fresh": "kf"})
+    _write_ranking(workspace, ["tired|rate_limited", "fresh|"])
+    for seed in range(30):
+        sel = select_token(workspace, rng=random.Random(seed))
+        assert sel.name == "fresh"
+        assert sel.mode == "ranked"
+
+
+def test_ranking_falls_back_to_rate_limited_when_pool_otherwise_empty(tmp_path):
+    """When every ranked account is rate_limited, still dispatch rather than stall."""
+    workspace = _make_workspace(tmp_path, {"a": "ka", "b": "kb"})
+    _write_ranking(workspace, ["a|rate_limited", "b|rate_limited"])
+    sel = select_token(workspace, rng=random.Random(0))
+    assert sel.name in ("a", "b")
+    assert sel.mode == "ranked"
+
+
+def test_ranking_rate_limited_and_exhausted_mixed_prefers_available(tmp_path):
+    workspace = _make_workspace(
+        tmp_path, {"exhausted-acct": "ke", "rl-acct": "kr", "ok-acct": "ko"},
+    )
+    _write_ranking(
+        workspace,
+        ["exhausted-acct|exhausted", "rl-acct|rate_limited", "ok-acct|"],
+    )
+    for seed in range(20):
+        sel = select_token(workspace, rng=random.Random(seed))
+        assert sel.name == "ok-acct"
+
+
+def test_stale_ranking_excludes_rate_limited_from_random(tmp_path):
+    """Stale-ranking exclusions also treat rate_limited as advisory-excluded."""
+    workspace = _make_workspace(tmp_path, {"tired": "kt", "fresh": "kf"})
+    _write_stale_ranking(workspace, ["tired|rate_limited", "fresh|"], 11 * 60)
+    for seed in range(20):
+        sel = select_token(workspace, rng=random.Random(seed))
+        assert sel.name == "fresh"
+        assert sel.mode == "random"
+
+
+def test_stale_ranking_all_rate_limited_falls_back_rather_than_hard_fail(tmp_path):
+    """A stale ranking where everything is rate_limited must not stall dispatch."""
+    workspace = _make_workspace(tmp_path, {"a": "ka", "b": "kb"})
+    _write_stale_ranking(workspace, ["a|rate_limited", "b|rate_limited"], 30 * 60)
+    sel = select_token(workspace, rng=random.Random(0))
+    assert sel.name in ("a", "b")
+    assert sel.mode == "random"
+
+
 # ---------- ranking spread (issue #3736 / rotation #3909) ----------
 
 


### PR DESCRIPTION
## Summary

Root cause fix for the retry storm described in #3988. Per the issue's follow-up comment, this is a classification bug, not a missing-backoff problem: a weekly-exhausted account frequently answers the health probe with **429**, and `EXHAUSTED_THRESHOLD` (`7d_utilization >= 0.95`) was only ever checked on the **2xx** path (`check.py:370-373`), never the 429 path (`check.py:339-348`). Such accounts were mislabelled `rate_limited` forever, and the selector treats `rate_limited` as fully eligible (`select.py:242`, `select.py:286`) — so the work finder kept rotating dispatches into dead accounts on every poll tick.

## Changes

- **`loom-tools/src/loom_tools/tokens/check.py`**: extracted a shared `_status_from_utilization()` helper and applied it on **both** the 2xx and 429 response branches — a 429 with `7d_utilization >= 0.95` is now classified `exhausted`, not `rate_limited`. Restores the documented CLAUDE.md contract (`exhausted = 7d_utilization >= 0.95`) for the accounts that most need it.
- **`loom-tools/src/loom_tools/tokens/select.py`**: defense in depth suggested in the issue comment — both the ranked tier (`_try_ranking`) and the stale-ranking advisory-exclusion set (`_stale_ranking_exclusions`) now *prefer* excluding `rate_limited` accounts while a healthier (`available`) account exists in the pool, falling back to including them only when the pool would otherwise be empty (the existing exclusion fail-safe in `select_token` already retries without exclusions in that case, so this can only ever prefer a healthier account — never hard-fail).

## Scope note

Per the issue's guidance, this focuses on the root-cause classification hole rather than the broader backoff/quarantine mechanisms in the issue's own acceptance-criteria checklist — those are explicitly described as symptom-side mitigations the classification fix makes largely unnecessary. The insta-crash quarantine (#3939/#3960) and per-issue dispatch accounting are unaffected by this PR; if the classification fix alone doesn't fully resolve the retry-storm symptom in practice, that would be a natural follow-up rather than scope creep here.

## Testing

```
PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/tokens/ -v
```
283 passed, including new regression tests:
- `test_check.py`: `test_429_promoted_to_exhausted_when_7d_high`, `test_429_at_threshold_promoted_to_exhausted`, `test_429_without_utilization_headers_stays_rate_limited`
- `test_select.py`: `test_ranking_prefers_available_over_rate_limited`, `test_ranking_falls_back_to_rate_limited_when_pool_otherwise_empty`, `test_ranking_rate_limited_and_exhausted_mixed_prefers_available`, `test_stale_ranking_excludes_rate_limited_from_random`, `test_stale_ranking_all_rate_limited_falls_back_rather_than_hard_fail`

Closes #3988