### PR TITLE
fix(daemon): load daemon as a launchd LaunchAgent on macOS instead of nohup

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -1311,6 +1311,9 @@ process:
   default),
 - locates the `loom-daemon` binary (`LOOM_DAEMON_BIN` → `PATH` → `target/{release,debug}`),
 - runs the **advisory** host-sleep check (`check-host-sleep.sh`, #3350) — never blocks the start,
+- **on macOS, backgrounds the daemon as a `gui/<uid>` LaunchAgent** instead of a
+  plain `nohup … &` (#3972 — see "macOS session-bootstrap hazard" below); on
+  Linux it stays a plain nohup background job,
 - backgrounds the daemon and writes a PID file at `.loom/.daemon.pid` (gitignored),
 - refuses a second start when the PID file points at a live process, and surfaces
   the daemon's own **singleton-guard** refusal (#3806) — if the backgrounded
@@ -1319,7 +1322,8 @@ process:
 
 `loom-daemon-stop.sh` sends **SIGTERM** (not just Ctrl-C/SIGINT — the daemon now
 handles both, #3813), waits `LOOM_DAEMON_STOP_GRACE_SECS` (default 10s), then
-escalates to SIGKILL.
+escalates to SIGKILL. On macOS it additionally `launchctl bootout`s the
+LaunchAgent job definition once the process is confirmed dead (see below).
 
 **Shutdown decision — sweeps survive, they are not drained.** A clean daemon stop
 removes the Unix socket and exits, but **does not cancel in-flight `/loom:sweep`
@@ -1328,6 +1332,85 @@ restart by design — killing the dispatcher must not kill dispatched work — a
 the registry reconciles their state on the next start (`SweepRegistry::reconstruct`
 re-admits live-lock owners). To actively cancel a sweep, use
 `mcp__loom__cancel_sweep` against a running daemon *before* stopping it.
+
+### macOS session-bootstrap hazard (#3972)
+
+**Incident (2026-07-26).** The daemon was started at 21:48 via
+`loom-daemon-start.sh` from inside a Claude Code session. That session crashed
+at 02:49. From the very next work-finder tick (02:50:21), **every** `gh` call
+in the daemon's process tree failed with `tls: failed to verify certificate:
+x509: OSStatus -26276` and `git fetch` failed with `No user exists for uid 501`
+— while the identical commands worked perfectly from any fresh shell. The
+daemon ran blind for ~35 minutes: the work finder saw 0 issues (4 errors/tick),
+the main-health gate went RED on purely environmental failures, and in-flight
+sweep children couldn't reach the forge either.
+
+**Root cause.** The pre-#3972 `loom-daemon-start.sh` detached the process with
+a plain `nohup "$DAEMON_BIN" … &`. `nohup` makes the process immune to
+`SIGHUP`, but it does **not** move the process out of the *launching session's*
+Mach bootstrap namespace — the process stays registered under whichever
+terminal/Claude-Code-session/SSH-connection Mach service happened to spawn it.
+When that session's context is torn down, XPC lookups the daemon (and every
+child it spawns) depend on start failing with no crash and no obvious log
+signal:
+
+- **`trustd`** (certificate verification) — the underlying cause of the `gh`
+  TLS/OSStatus errors, since Go's Darwin certificate verifier round-trips
+  through `trustd` via XPC.
+- **`opendirectoryd`** (`getpwuid`) — the underlying cause of git's
+  "No user exists for uid N", since `git` resolves the current user via
+  `getpwuid()`, which is backed by `opendirectoryd` on macOS.
+
+This is why **"start it from a terminal that might die" is unsafe on macOS**.
+Linux does not have this failure mode — a systemd user session (or a plain
+`nohup` under `init`) does not tie a background process's XPC-equivalent
+identity to the shell that spawned it.
+
+**Fix.** `loom-daemon-start.sh` now generates a `launchd` LaunchAgent plist and
+loads it with `launchctl bootstrap gui/<uid>` instead of `nohup`-backgrounding
+in-process (Darwin only — Linux is unaffected and keeps the plain nohup path).
+This was validated during the incident itself: relaunching the identical
+binary as a launchd agent immediately restored `gh`/`git` — the first tick
+after migration reported `13 seen, 3 dispatched, 0 error(s)`.
+
+- **Plist location & label**: `~/Library/LaunchAgents/com.rjwalters.loom-daemon.plist`
+  (override the label with `LOOM_LAUNCHD_LABEL`). Regenerated and reloaded
+  (`bootout` the old definition, then a fresh `bootstrap` + `kickstart -k`) on
+  **every** start, so a later invocation's flags/env always win over a stale
+  loaded definition.
+- **Environment forwarding**: the plist's `PATH` is the current `PATH` plus a
+  fallback set (`~/.local/bin`, `~/.cargo/bin`, Homebrew, standard bin dirs) so
+  `gh`, `git`, `cargo`, and `python3` resolve even inside launchd's minimal
+  environment. Every already-exported `LOOM_*` / `GH_TOKEN` / `GITEA_TOKEN` /
+  `FORGE_TOKEN` var is forwarded verbatim, so the FLAGS-OFF / `--work-finder` /
+  `--health-gate` / `--from-config` semantics are preserved exactly — the
+  launchd job never sees a wider or narrower autonomy configuration than a
+  plain nohup start would have resolved.
+- **`RunAtLoad=true` / `KeepAlive=false`**: mirrors the hand-written plist that
+  validated this fix during the incident. `RunAtLoad=true` means the daemon
+  also survives a reboot/re-login, not just the death of one particular
+  session — strictly *more* durable than the pre-#3972 nohup contract (which
+  didn't survive a reboot either). `KeepAlive=false` means launchd does **not**
+  auto-respawn a crashed daemon; that responsibility stays with the reaper /
+  operator, unchanged from before. `loom-daemon-stop.sh` `bootout`s the loaded
+  definition after confirming the process is dead, specifically so an explicit
+  stop is honored at the next login too (otherwise `RunAtLoad=true` would
+  silently relaunch it).
+- **Escape hatch**: `--no-launchd` (or `LOOM_DAEMON_LAUNCHD=0`) forces the
+  legacy nohup path even on Darwin — e.g. for a sandboxed/headless macOS runner
+  with no GUI login session where `gui/<uid>` may not resolve.
+- **Inspection without side effects**: `--print-plist` renders the exact plist
+  XML this invocation would install and exits — no `launchctl` call, no file
+  write to `~/Library/LaunchAgents`. Useful for auditing exactly what
+  environment/flags a given invocation would forward.
+- **Linux**: unaffected — `nohup` stays the mechanism, since a systemd user
+  session doesn't tie process identity to the spawning shell the way macOS's
+  Mach bootstrap does. Operators who want equivalent extra hardening on Linux
+  (e.g. surviving a `systemd --user` session teardown in an unusual setup) can
+  optionally wrap the start in `systemd-run --user --scope
+  ./.loom/scripts/cli/loom-daemon-start.sh` — not required for the documented
+  failure mode, since it doesn't reproduce on Linux, but available as a
+  belt-and-suspenders option.
 
 ### Self-update (rebuild + provision + restart, #3968)
 

--- a/defaults/scripts/cli/loom-daemon-start.sh
+++ b/defaults/scripts/cli/loom-daemon-start.sh
@@ -17,6 +17,9 @@
 #     LOOM_WORK_FINDER unset => off, LOOM_MAIN_HEALTH_GATE unset => off). Opt in
 #     explicitly with --work-finder / --health-gate, or hand control to
 #     .loom/config.json -> autonomous with --from-config (#3911),
+#   - on macOS, backgrounds the daemon as a `gui/<uid>` LaunchAgent (#3972) so
+#     it survives the launching session's death instead of a plain `nohup ...
+#     &`; on Linux it stays a plain nohup background job,
 #   - backgrounds the daemon and writes a PID file (.loom/.daemon.pid),
 #   - persists the resolved invocation flags to .loom/.daemon.flags so
 #     `loom-daemon-update.sh` (#3968) can restart with EXACTLY the same
@@ -27,6 +30,18 @@
 # Default is FLAGS-OFF: a bare `loom-daemon-start.sh` does NOT auto-dispatch
 # sweeps. This is a deliberate safe default — enable autonomy explicitly.
 #
+# macOS session-bootstrap hazard (#3972): a plain `nohup "$DAEMON_BIN" &`
+# leaves the process wired into the LAUNCHING SESSION's Mach bootstrap
+# namespace. When that session dies (a Claude Code session crash, a closed
+# terminal, a dropped SSH connection) the daemon and every child it spawns
+# start failing XPC lookups to trustd (cert verification -- `gh` TLS errors)
+# and opendirectoryd (`getpwuid` -- "No user exists for uid N" from `git`),
+# with NO crash and no obvious log signal beyond those downstream errors. This
+# is why "start it from a terminal that might die" is unsafe on macOS. This
+# script defaults to loading the daemon as a `launchd` LaunchAgent on Darwin
+# specifically to avoid that failure mode; see --no-launchd below for the
+# escape hatch and daemon-reference.md Operability for the incident writeup.
+#
 # Usage:
 #   ./.loom/scripts/cli/loom-daemon-start.sh                 Reliability daemon (both loops OFF)
 #   ./.loom/scripts/cli/loom-daemon-start.sh --work-finder   Enable the autonomous work finder
@@ -36,12 +51,16 @@
 #   ./.loom/scripts/cli/loom-daemon-start.sh --no-work-finder    Force work finder OFF (explicit)
 #   ./.loom/scripts/cli/loom-daemon-start.sh --no-health-gate    Force health gate OFF (explicit)
 #   ./.loom/scripts/cli/loom-daemon-start.sh --foreground    Run in the foreground (no PID file)
+#   ./.loom/scripts/cli/loom-daemon-start.sh --no-launchd    macOS only: use legacy nohup instead of a LaunchAgent
+#   ./.loom/scripts/cli/loom-daemon-start.sh --print-plist   Print the LaunchAgent plist that WOULD be installed and exit (no side effects)
 #   ./.loom/scripts/cli/loom-daemon-start.sh --help
 #
 # Environment:
 #   LOOM_DAEMON_BIN     Path to the loom-daemon binary (else auto-detected)
 #   LOOM_SOCKET_PATH    Override the daemon socket (default ~/.loom/loom-daemon.sock)
 #   LOOM_WORK_FINDER / LOOM_MAIN_HEALTH_GATE  Respected when already exported
+#   LOOM_DAEMON_LAUNCHD  macOS only: 0/false/no forces the legacy nohup path (same as --no-launchd)
+#   LOOM_LAUNCHD_LABEL   macOS only: override the LaunchAgent label (default com.rjwalters.loom-daemon)
 #
 # Exit codes:
 #   0  daemon started (or already running)
@@ -101,6 +120,74 @@ locate_daemon_bin() {
     echo ""
 }
 
+# ---------- launchd plist rendering (#3972) ----------
+# Pure string rendering -- safe to call on ANY platform (used by
+# --print-plist for inspection/testing). The actual `launchctl` invocation
+# that consumes this plist is gated to Darwin separately, below.
+xml_escape() {
+    local s="$1"
+    s="${s//&/&amp;}"
+    s="${s//</&lt;}"
+    s="${s//>/&gt;}"
+    printf '%s' "$s"
+}
+
+resolve_launchd_label() {
+    echo "${LOOM_LAUNCHD_LABEL:-com.rjwalters.loom-daemon}"
+}
+
+# render_launchd_plist <label> <daemon_bin> <workdir> <log_path>
+# Prints the LaunchAgent plist XML to stdout. Mirrors the hand-written plist
+# that validated the #3972 fix during the incident
+# (~/Library/LaunchAgents/com.rjwalters.loom-daemon.plist): RunAtLoad=true
+# (the daemon also comes back after a reboot/re-login, not just a session
+# death -- strictly more durable than the pre-#3972 nohup contract, which
+# didn't survive a reboot either) and KeepAlive=false (launchd does not
+# auto-respawn a crashed daemon; that stays the reaper/operator's job, same as
+# before). Lifecycle (first start / explicit stop) is still entirely
+# operator-driven via loom-daemon-start.sh / loom-daemon-stop.sh -- bootout on
+# stop unloads the definition so it does NOT come back at the next login. The
+# PATH is the CURRENT PATH plus a fallback set (~/.local/bin, ~/.cargo/bin,
+# Homebrew, standard bin dirs) so `gh`, `git`, `cargo`, and `python3` resolve
+# inside the LaunchAgent's minimal launchd environment even if the interactive
+# shell's PATH customizations aren't present there. Every already-exported
+# LOOM_* / GH_TOKEN / GITEA_TOKEN / FORGE_TOKEN var is forwarded verbatim so
+# the launchd job sees EXACTLY the autonomy flags and auth this invocation
+# resolved -- never wider, never narrower (#3972 AC: "preserves the current
+# flag semantics").
+render_launchd_plist() {
+    local label="$1" bin="$2" workdir="$3" log_path="$4"
+    local plist_path_value="${PATH}:${HOME}/.local/bin:${HOME}/.cargo/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+    local env_entries=""
+    env_entries+="        <key>PATH</key>\n        <string>$(xml_escape "$plist_path_value")</string>\n"
+    env_entries+="        <key>HOME</key>\n        <string>$(xml_escape "$HOME")</string>\n"
+
+    local line key value
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        key="${line%%=*}"
+        value="${line#*=}"
+        env_entries+="        <key>$(xml_escape "$key")</key>\n        <string>$(xml_escape "$value")</string>\n"
+    done < <(env | grep -E '^(LOOM_[A-Za-z0-9_]*|GH_TOKEN|GITEA_TOKEN|FORGE_TOKEN)=' || true)
+
+    printf '<?xml version="1.0" encoding="UTF-8"?>\n'
+    printf '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n'
+    printf '<plist version="1.0">\n<dict>\n'
+    printf '    <key>Label</key>\n    <string>%s</string>\n' "$(xml_escape "$label")"
+    printf '    <key>ProgramArguments</key>\n    <array>\n        <string>%s</string>\n    </array>\n' "$(xml_escape "$bin")"
+    printf '    <key>WorkingDirectory</key>\n    <string>%s</string>\n' "$(xml_escape "$workdir")"
+    printf '    <key>EnvironmentVariables</key>\n    <dict>\n'
+    printf '%b' "$env_entries"
+    printf '    </dict>\n'
+    printf '    <key>RunAtLoad</key>\n    <true/>\n'
+    printf '    <key>KeepAlive</key>\n    <false/>\n'
+    printf '    <key>ProcessType</key>\n    <string>Background</string>\n'
+    printf '    <key>StandardOutPath</key>\n    <string>%s</string>\n' "$(xml_escape "$log_path")"
+    printf '    <key>StandardErrorPath</key>\n    <string>%s</string>\n' "$(xml_escape "$log_path")"
+    printf '</dict>\n</plist>\n'
+}
+
 # ---------- args ----------
 # Capture the raw invocation args before the parsing loop consumes "$@" — used
 # below to persist exactly what was passed (Issue #3968: `loom-daemon-update.sh`
@@ -115,6 +202,8 @@ FROM_CONFIG=false
 FOREGROUND=false
 WANT_WORK_FINDER=false
 WANT_HEALTH_GATE=false
+NO_LAUNCHD=false
+PRINT_PLIST=false
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --help|-h) show_help; exit 0 ;;
@@ -124,6 +213,8 @@ while [[ $# -gt 0 ]]; do
         --health-gate) WANT_HEALTH_GATE=true; shift ;;
         --no-work-finder) WANT_WORK_FINDER=false; shift ;;
         --no-health-gate) WANT_HEALTH_GATE=false; shift ;;
+        --no-launchd) NO_LAUNCHD=true; shift ;;
+        --print-plist) PRINT_PLIST=true; shift ;;
         *) err "Unknown option '$1'"; echo "Use --help for usage" >&2; exit 1 ;;
     esac
 done
@@ -233,7 +324,7 @@ FLAGS_FILE="$REPO_ROOT/.loom/.daemon.flags"
 if [[ "${#ORIGINAL_ARGS[@]}" -gt 0 ]]; then
     for _flag_arg in "${ORIGINAL_ARGS[@]}"; do
         case "$_flag_arg" in
-            --foreground|--fg|--help|-h) continue ;;
+            --foreground|--fg|--help|-h|--no-launchd|--print-plist) continue ;;
             *) echo "$_flag_arg" >> "$FLAGS_FILE" ;;
         esac
     done
@@ -250,8 +341,110 @@ if [[ "$FOREGROUND" == "true" ]]; then
     exec "$DAEMON_BIN"
 fi
 
+# ---------- platform detection (#3972) ----------
+IS_DARWIN=false
+[[ "$(uname -s)" == "Darwin" ]] && IS_DARWIN=true
+
+USE_LAUNCHD=false
+if [[ "$IS_DARWIN" == "true" ]]; then
+    USE_LAUNCHD=true
+    if [[ "${LOOM_DAEMON_LAUNCHD:-}" =~ ^(0|false|no)$ ]]; then
+        USE_LAUNCHD=false
+    fi
+fi
+[[ "$NO_LAUNCHD" == "true" ]] && USE_LAUNCHD=false
+
+# ---------- --print-plist: pure inspection, no side effects ----------
+if [[ "$PRINT_PLIST" == "true" ]]; then
+    render_launchd_plist "$(resolve_launchd_label)" "$DAEMON_BIN" "$REPO_ROOT" "$START_LOG"
+    exit 0
+fi
+
 # ---------- background + PID file ----------
 : > "$START_LOG"
+
+if [[ "$USE_LAUNCHD" == "true" ]] && ! command -v launchctl >/dev/null 2>&1; then
+    warn "launchctl not found despite running on Darwin -- falling back to nohup."
+    USE_LAUNCHD=false
+fi
+
+if [[ "$USE_LAUNCHD" == "true" ]]; then
+    # ---------- macOS: launchd LaunchAgent (#3972) ----------
+    # A plain `nohup ... &` stays in the LAUNCHING SESSION's Mach bootstrap
+    # namespace; when that session dies, trustd/opendirectoryd XPC lookups
+    # start failing for the daemon and every child it spawns (gh TLS errors,
+    # "No user exists for uid N" from git) with no crash and no obvious log
+    # signal. Loading as a `gui/<uid>` LaunchAgent keeps the daemon in the
+    # user's durable GUI bootstrap domain instead, independent of whichever
+    # terminal/session launched it. See daemon-reference.md Operability for
+    # the incident writeup. Escape hatch: --no-launchd / LOOM_DAEMON_LAUNCHD=0.
+    LAUNCHD_LABEL=$(resolve_launchd_label)
+    LAUNCHD_UID=$(id -u)
+    LAUNCHD_DOMAIN="gui/${LAUNCHD_UID}"
+    LAUNCHD_SERVICE="${LAUNCHD_DOMAIN}/${LAUNCHD_LABEL}"
+    PLIST_DIR="$HOME/Library/LaunchAgents"
+    PLIST_FILE="$PLIST_DIR/${LAUNCHD_LABEL}.plist"
+    mkdir -p "$PLIST_DIR"
+
+    render_launchd_plist "$LAUNCHD_LABEL" "$DAEMON_BIN" "$REPO_ROOT" "$START_LOG" > "$PLIST_FILE"
+
+    echo "Launchd label:  $LAUNCHD_LABEL"
+    echo "Launchd plist:  $PLIST_FILE"
+
+    # Reload with the freshly-rendered plist every time -- a job left loaded
+    # from a prior invocation (possibly with different flags/env) must not
+    # silently keep running its OLD definition.
+    if launchctl print "$LAUNCHD_SERVICE" >/dev/null 2>&1; then
+        launchctl bootout "$LAUNCHD_SERVICE" >/dev/null 2>&1 || true
+    fi
+
+    BOOTSTRAP_ERR="$START_LOG.bootstrap-err"
+    if ! launchctl bootstrap "$LAUNCHD_DOMAIN" "$PLIST_FILE" 2>"$BOOTSTRAP_ERR"; then
+        err "launchctl bootstrap failed for $LAUNCHD_SERVICE:"
+        cat "$BOOTSTRAP_ERR" >&2 2>/dev/null || true
+        rm -f "$BOOTSTRAP_ERR"
+        exit 1
+    fi
+    rm -f "$BOOTSTRAP_ERR"
+
+    # RunAtLoad=true means bootstrap alone would already start it, but we
+    # kickstart -k explicitly anyway so THIS invocation deterministically wins
+    # (the -k kill-first semantics guarantee a fresh process picking up the
+    # plist we just wrote, rather than racing launchd's own RunAtLoad timing).
+    KICKSTART_ERR="$START_LOG.kickstart-err"
+    if ! launchctl kickstart -k "$LAUNCHD_SERVICE" 2>"$KICKSTART_ERR"; then
+        err "launchctl kickstart failed for $LAUNCHD_SERVICE:"
+        cat "$KICKSTART_ERR" >&2 2>/dev/null || true
+        rm -f "$KICKSTART_ERR"
+        exit 1
+    fi
+    rm -f "$KICKSTART_ERR"
+
+    # Give it a moment to either bind the socket or trip the singleton guard.
+    sleep 2
+
+    daemon_pid=$(launchctl print "$LAUNCHD_SERVICE" 2>/dev/null | awk -F'= ' '/^[[:space:]]*pid = /{gsub(/[^0-9]/, "", $2); print $2; exit}')
+
+    if [[ -z "$daemon_pid" ]] || ! kill -0 "$daemon_pid" 2>/dev/null; then
+        err "loom-daemon did not stay running under launchd ($LAUNCHD_SERVICE)."
+        if [[ -s "$START_LOG" ]]; then
+            echo "----- startup output ($START_LOG) -----" >&2
+            tail -n 20 "$START_LOG" >&2
+            echo "---------------------------------------" >&2
+        fi
+        warn "If another daemon is already listening on the socket, stop it first"
+        warn "(./.loom/scripts/cli/loom-daemon-stop.sh) and retry."
+        exit 1
+    fi
+
+    echo "$daemon_pid" > "$PID_FILE"
+    ok "loom-daemon started under launchd (pid $daemon_pid, label $LAUNCHD_LABEL)."
+    echo "PID file: $PID_FILE"
+    echo "Stop with: ./.loom/scripts/cli/loom-daemon-stop.sh"
+    exit 0
+fi
+
+# ---------- Linux (or --no-launchd): plain nohup background job ----------
 nohup "$DAEMON_BIN" >> "$START_LOG" 2>&1 &
 daemon_pid=$!
 

--- a/defaults/scripts/cli/loom-daemon-stop.sh
+++ b/defaults/scripts/cli/loom-daemon-stop.sh
@@ -18,6 +18,17 @@
 #   the reaper reconciles their state on the next start. To actively cancel a
 #   sweep, use `mcp__loom__cancel_sweep` against a running daemon before stopping.
 #
+# macOS launchd counterpart (#3972): when loom-daemon-start.sh loaded the
+# daemon as a `gui/<uid>` LaunchAgent, this script ALSO unloads the launchd
+# job definition (`launchctl bootout`) after the process is confirmed dead —
+# not just kills the pid. This matters because the generated plist sets
+# RunAtLoad=true (mirroring the validated incident-fix plist), so leaving the
+# definition loaded would silently relaunch the daemon at the next login/boot
+# even though the operator explicitly stopped it. The pid-kill sequence itself
+# is unchanged (SIGTERM -> grace -> SIGKILL, sent directly to the resolved
+# pid) — launchd does not auto-respawn on a plain exit (KeepAlive=false), so
+# killing the process first is always safe.
+#
 # Usage:
 #   ./.loom/scripts/cli/loom-daemon-stop.sh            Graceful stop (SIGTERM -> SIGKILL)
 #   ./.loom/scripts/cli/loom-daemon-stop.sh --force    Skip the grace window (SIGKILL)
@@ -25,6 +36,7 @@
 #
 # Environment:
 #   LOOM_DAEMON_STOP_GRACE_SECS   Grace window before SIGKILL (default 10)
+#   LOOM_LAUNCHD_LABEL            macOS only: the LaunchAgent label to bootout (default com.rjwalters.loom-daemon)
 #
 # Exit codes:
 #   0  daemon stopped (or was not running)
@@ -41,7 +53,12 @@ err()  { echo -e "${RED}$*${NC}" >&2; }
 warn() { echo -e "${YELLOW}$*${NC}" >&2; }
 ok()   { echo -e "${GREEN}$*${NC}"; }
 
-show_help() { sed -n '2,35p' "$0" | sed 's/^# \{0,1\}//'; }
+show_help() {
+    # Print the leading comment banner (line 2 through the last comment line
+    # before `set -uo pipefail`), stripping the leading "# ". Same pattern as
+    # loom-daemon-start.sh's show_help -- robust to the banner growing.
+    awk 'NR>=2 { if ($0 !~ /^#/) exit; sub(/^# ?/, ""); print }' "$0"
+}
 
 find_repo_root() {
     local dir="$PWD"
@@ -76,13 +93,46 @@ fi
 PID_FILE="$REPO_ROOT/.loom/.daemon.pid"
 GRACE_SECS="${LOOM_DAEMON_STOP_GRACE_SECS:-10}"
 
-# Resolve the target pid: prefer the PID file, else best-effort pgrep.
+# ---------- launchd plumbing (macOS, #3972) ----------
+IS_DARWIN=false
+[[ "$(uname -s)" == "Darwin" ]] && IS_DARWIN=true
+LAUNCHD_LABEL="${LOOM_LAUNCHD_LABEL:-com.rjwalters.loom-daemon}"
+LAUNCHD_SERVICE="gui/$(id -u)/${LAUNCHD_LABEL}"
+
+launchd_job_loaded() {
+    [[ "$IS_DARWIN" == "true" ]] || return 1
+    command -v launchctl >/dev/null 2>&1 || return 1
+    launchctl print "$LAUNCHD_SERVICE" >/dev/null 2>&1
+}
+
+launchd_job_pid() {
+    launchctl print "$LAUNCHD_SERVICE" 2>/dev/null | awk -F'= ' '/^[[:space:]]*pid = /{gsub(/[^0-9]/, "", $2); print $2; exit}'
+}
+
+# Unload the launchd job definition so it does NOT silently relaunch at the
+# next login/boot (the generated plist sets RunAtLoad=true). Idempotent and
+# best-effort -- a job that was never loaded (or already unloaded) is a no-op.
+launchd_bootout_if_loaded() {
+    if launchd_job_loaded; then
+        launchctl bootout "$LAUNCHD_SERVICE" >/dev/null 2>&1 || true
+    fi
+}
+
+# Resolve the target pid: prefer the PID file, else a launchd lookup (Darwin),
+# else best-effort pgrep.
 pid=""
 if [[ -f "$PID_FILE" ]]; then
     pid=$(cat "$PID_FILE" 2>/dev/null || true)
 fi
 if [[ -z "$pid" ]] || ! kill -0 "$pid" 2>/dev/null; then
-    # PID file missing/stale — fall back to a process match (best effort).
+    # PID file missing/stale — try the launchd job (macOS) before falling
+    # back to a process-name match.
+    if launchd_job_loaded; then
+        launchd_pid=$(launchd_job_pid)
+        [[ -n "$launchd_pid" ]] && pid="$launchd_pid"
+    fi
+fi
+if [[ -z "$pid" ]] || ! kill -0 "$pid" 2>/dev/null; then
     if command -v pgrep >/dev/null 2>&1; then
         pid=$(pgrep -f '(^|/)loom-daemon$' 2>/dev/null | head -n1 || true)
     fi
@@ -91,6 +141,7 @@ fi
 if [[ -z "$pid" ]] || ! kill -0 "$pid" 2>/dev/null; then
     warn "No running loom-daemon found (nothing to stop)."
     rm -f "$PID_FILE"
+    launchd_bootout_if_loaded
     exit 0
 fi
 
@@ -117,6 +168,11 @@ if kill -0 "$pid" 2>/dev/null; then
     err "Failed to stop loom-daemon (pid $pid)."
     exit 1
 fi
+
+# Unload the launchd job definition (macOS, #3972) now that the process is
+# confirmed dead -- RunAtLoad=true on the generated plist means leaving it
+# loaded would silently relaunch the daemon at the next login/boot.
+launchd_bootout_if_loaded
 
 rm -f "$PID_FILE"
 ok "loom-daemon stopped (pid $pid)."

--- a/defaults/scripts/tests/test-loom-daemon-launchd-plist.sh
+++ b/defaults/scripts/tests/test-loom-daemon-launchd-plist.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# test-loom-daemon-launchd-plist.sh — Tests for the launchd LaunchAgent plist
+# rendering added by loom-daemon-start.sh / loom-daemon-stop.sh (#3972).
+#
+# Root cause under test: a plain `nohup "$DAEMON_BIN" &` leaves the daemon
+# wired into the LAUNCHING SESSION's Mach bootstrap namespace, so when that
+# session dies, gh/git start failing XPC lookups (trustd/opendirectoryd) for
+# the daemon and every child it spawns. The fix loads the daemon as a
+# `gui/<uid>` LaunchAgent instead.
+#
+# These tests exercise ONLY the plist-rendering path (`--print-plist`), which
+# is pure string generation with NO side effects — it never calls `launchctl`
+# and never touches ~/Library/LaunchAgents. This is deliberate: a test suite
+# must never mutate the real machine's launchd state, on this dev box or any
+# CI runner. Real `launchctl bootstrap`/`kickstart`/`bootout` behavior is not
+# covered here (requires an actual GUI login session) and is validated
+# manually per the daemon-reference.md Operability writeup.
+#
+# Style matches test-loom-daemon-start.sh — plain bash, hand-rolled
+# assertions. Bats is NOT used in this repository.
+#
+# Usage:
+#   ./defaults/scripts/tests/test-loom-daemon-launchd-plist.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+START_SCRIPT="$(cd "$SCRIPT_DIR/../cli" && pwd)/loom-daemon-start.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_contains() {
+    local haystack="$1" needle="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$haystack" == *"$needle"* ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "${GREEN}✓${NC} $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "${RED}✗${NC} $msg"
+        echo "  expected to find: [$needle]"
+    fi
+}
+
+assert_not_contains() {
+    local haystack="$1" needle="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$haystack" != *"$needle"* ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "${GREEN}✓${NC} $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "${RED}✗${NC} $msg"
+        echo "  expected NOT to find: [$needle]"
+    fi
+}
+
+assert_eq() {
+    local expected="$1" actual="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "${GREEN}✓${NC} $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "${RED}✗${NC} $msg"
+        echo "  expected: [$expected]"
+        echo "  actual:   [$actual]"
+    fi
+}
+
+# ---------- fixture ----------
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+mkdir -p "$WORKDIR/.loom/logs"
+
+FAKE_BIN="$WORKDIR/fake-loom-daemon"
+cat > "$FAKE_BIN" <<'EOF'
+#!/usr/bin/env bash
+echo "FAKE_DAEMON"
+EOF
+chmod +x "$FAKE_BIN"
+
+# ---------- tests ----------
+
+# 1. --print-plist is pure inspection: never writes to ~/Library/LaunchAgents
+#    or invokes launchctl, regardless of host platform.
+before_count=0
+if [[ -d "$HOME/Library/LaunchAgents" ]]; then
+    before_count=$(find "$HOME/Library/LaunchAgents" -maxdepth 1 -name 'com.rjwalters.loom-daemon*.plist' 2>/dev/null | wc -l | tr -d ' ')
+fi
+plist_out=$( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE LOOM_DAEMON_BIN="$FAKE_BIN" bash "$START_SCRIPT" --print-plist 2>&1 )
+plist_rc=$?
+after_count=0
+if [[ -d "$HOME/Library/LaunchAgents" ]]; then
+    after_count=$(find "$HOME/Library/LaunchAgents" -maxdepth 1 -name 'com.rjwalters.loom-daemon*.plist' 2>/dev/null | wc -l | tr -d ' ')
+fi
+assert_eq "0" "$plist_rc" "--print-plist exits 0"
+assert_eq "$before_count" "$after_count" "--print-plist never writes to ~/Library/LaunchAgents"
+
+# 2. Plain start: RunAtLoad/KeepAlive false, both autonomy loops OFF present
+#    and equal to 0 (FLAGS-OFF default, #3911 semantics preserved), PATH
+#    covers gh/git/cargo/python3 fallback dirs.
+assert_contains "$plist_out" "<key>RunAtLoad</key>" "plist declares RunAtLoad"
+assert_contains "$plist_out" $'<key>RunAtLoad</key>\n    <true/>' "RunAtLoad is true (mirrors the validated incident-fix plist; survives reboot/re-login)"
+assert_contains "$plist_out" $'<key>KeepAlive</key>\n    <false/>' "KeepAlive is false (no launchd auto-restart on crash)"
+assert_contains "$plist_out" "<key>LOOM_WORK_FINDER</key>" "plain start forwards LOOM_WORK_FINDER"
+assert_contains "$plist_out" $'<key>LOOM_WORK_FINDER</key>\n        <string>0</string>' "plain start: LOOM_WORK_FINDER=0 (FLAGS-OFF default)"
+assert_contains "$plist_out" $'<key>LOOM_MAIN_HEALTH_GATE</key>\n        <string>0</string>' "plain start: LOOM_MAIN_HEALTH_GATE=0 (FLAGS-OFF default)"
+assert_contains "$plist_out" "/.local/bin" "PATH includes ~/.local/bin fallback (loom-daemon's own provisioning dir, #3922)"
+assert_contains "$plist_out" "/.cargo/bin" "PATH includes ~/.cargo/bin fallback (cargo)"
+assert_contains "$plist_out" "/usr/bin" "PATH includes /usr/bin fallback (python3, git)"
+assert_contains "$plist_out" "/opt/homebrew/bin" "PATH includes Homebrew fallback (gh, git)"
+assert_contains "$plist_out" "$FAKE_BIN" "ProgramArguments points at the resolved daemon binary"
+assert_contains "$plist_out" "com.rjwalters.loom-daemon" "default Label is com.rjwalters.loom-daemon"
+
+# 3. --work-finder --print-plist -> LOOM_WORK_FINDER=1, health gate stays 0.
+wf_out=$( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE LOOM_DAEMON_BIN="$FAKE_BIN" bash "$START_SCRIPT" --work-finder --print-plist 2>&1 )
+assert_contains "$wf_out" $'<key>LOOM_WORK_FINDER</key>\n        <string>1</string>' "--work-finder: plist forwards LOOM_WORK_FINDER=1"
+assert_contains "$wf_out" $'<key>LOOM_MAIN_HEALTH_GATE</key>\n        <string>0</string>' "--work-finder: health gate stays 0"
+
+# 4. --from-config --print-plist -> neither autonomy var is forced into the
+#    plist at all (env not forced -- config drives inside the daemon process).
+fc_out=$( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE LOOM_DAEMON_BIN="$FAKE_BIN" bash "$START_SCRIPT" --from-config --print-plist 2>&1 )
+assert_not_contains "$fc_out" "<key>LOOM_WORK_FINDER</key>" "--from-config: LOOM_WORK_FINDER NOT forced into the plist"
+assert_not_contains "$fc_out" "<key>LOOM_MAIN_HEALTH_GATE</key>" "--from-config: LOOM_MAIN_HEALTH_GATE NOT forced into the plist"
+
+# 5. An already-exported LOOM_WORK_FINDER=1 (operator override) is forwarded
+#    verbatim even on a plain (non-flag) invocation.
+exported_out=$( cd "$WORKDIR" && env -u LOOM_MAIN_HEALTH_GATE LOOM_WORK_FINDER=1 LOOM_DAEMON_BIN="$FAKE_BIN" bash "$START_SCRIPT" --print-plist 2>&1 )
+assert_contains "$exported_out" $'<key>LOOM_WORK_FINDER</key>\n        <string>1</string>' "already-exported LOOM_WORK_FINDER=1 wins and is forwarded"
+
+# 6. LOOM_LAUNCHD_LABEL overrides the default label.
+label_out=$( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE LOOM_LAUNCHD_LABEL="com.example.custom" LOOM_DAEMON_BIN="$FAKE_BIN" bash "$START_SCRIPT" --print-plist 2>&1 )
+assert_contains "$label_out" "com.example.custom" "LOOM_LAUNCHD_LABEL overrides the default Label"
+assert_not_contains "$label_out" "<string>com.rjwalters.loom-daemon</string>" "custom label replaces (not appends to) the default"
+
+# 7. --print-plist never persists to .loom/.daemon.flags (it isn't a daemon
+#    autonomy flag; loom-daemon-update.sh must never replay it).
+rm -f "$WORKDIR/.loom/.daemon.flags"
+( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE LOOM_DAEMON_BIN="$FAKE_BIN" bash "$START_SCRIPT" --work-finder --print-plist >/dev/null 2>&1 )
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ ! -f "$WORKDIR/.loom/.daemon.flags" ]] || ! grep -q -- '--print-plist' "$WORKDIR/.loom/.daemon.flags" 2>/dev/null; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --print-plist is excluded from the persisted .daemon.flags file"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --print-plist is excluded from the persisted .daemon.flags file"
+fi
+
+# 8. --help documents --no-launchd and --print-plist.
+help_out=$(bash "$START_SCRIPT" --help 2>/dev/null)
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$help_out" | grep -q -- '--no-launchd' && echo "$help_out" | grep -q -- '--print-plist'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --help documents --no-launchd and --print-plist"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --help documents --no-launchd and --print-plist"
+fi
+
+# ---------- summary ----------
+echo
+echo "Ran $TESTS_RUN tests: $TESTS_PASSED passed, $TESTS_FAILED failed"
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/defaults/scripts/tests/test-loom-daemon-start.sh
+++ b/defaults/scripts/tests/test-loom-daemon-start.sh
@@ -108,13 +108,16 @@ fi
 #    one line and exits immediately, which the start script's own liveness
 #    check would correctly treat as a startup failure — not what this test
 #    is exercising).
+#    --no-launchd forces the legacy nohup path even on a Darwin test runner —
+#    this test exercises the flags-persistence array guard, not launchd
+#    (#3972), and must never mutate the real machine's LaunchAgents.
 BG_FAKE_BIN="$WORKDIR/fake-loom-daemon-bg"
 cat > "$BG_FAKE_BIN" <<'EOF'
 #!/usr/bin/env bash
 sleep 5
 EOF
 chmod +x "$BG_FAKE_BIN"
-( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE LOOM_DAEMON_BIN="$BG_FAKE_BIN" bash "$START_SCRIPT" >/dev/null 2>&1 )
+( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE LOOM_DAEMON_BIN="$BG_FAKE_BIN" bash "$START_SCRIPT" --no-launchd >/dev/null 2>&1 )
 bg_rc=$?
 assert_eq "0" "$bg_rc" "bare (zero-arg) background start exits 0 (no unbound-variable crash, #3968)"
 TESTS_RUN=$((TESTS_RUN + 1))

--- a/defaults/scripts/tests/test-loom-daemon-stop.sh
+++ b/defaults/scripts/tests/test-loom-daemon-stop.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# test-loom-daemon-stop.sh — Tests for loom-daemon-stop.sh, including the
+# macOS launchd bootout counterpart added by #3972.
+#
+# Every invocation below pins LOOM_LAUNCHD_LABEL to a random, guaranteed-
+# nonexistent label. This is deliberate and load-bearing: it ensures
+# `launchd_job_loaded` always resolves false (no loaded job with that label)
+# so these tests can NEVER observe or mutate the real machine's
+# ~/Library/LaunchAgents/com.rjwalters.loom-daemon.plist, on this dev box or
+# any CI runner.
+#
+# Style matches test-loom-daemon-start.sh — plain bash, hand-rolled
+# assertions. Bats is NOT used in this repository.
+#
+# Usage:
+#   ./defaults/scripts/tests/test-loom-daemon-stop.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STOP_SCRIPT="$(cd "$SCRIPT_DIR/../cli" && pwd)/loom-daemon-stop.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_eq() {
+    local expected="$1" actual="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "${GREEN}✓${NC} $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "${RED}✗${NC} $msg"
+        echo "  expected: [$expected]"
+        echo "  actual:   [$actual]"
+    fi
+}
+
+# A guaranteed-nonexistent label so `launchctl print` never matches a real
+# loaded job on the host machine, regardless of platform.
+FAKE_LABEL="com.example.loom-daemon-stop-test-$$-$RANDOM"
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+mkdir -p "$WORKDIR/.loom"
+
+# ---------- tests ----------
+
+# 1. No PID file, no running process -> "nothing to stop", exits 0.
+out=$( cd "$WORKDIR" && LOOM_LAUNCHD_LABEL="$FAKE_LABEL" bash "$STOP_SCRIPT" 2>&1 )
+rc=$?
+assert_eq "0" "$rc" "no daemon running: exits 0"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out" | grep -qi "nothing to stop"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} no daemon running: reports 'nothing to stop'"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} no daemon running: reports 'nothing to stop'"
+fi
+
+# 2. A live PID-file-tracked process is stopped (SIGTERM path).
+SLEEP_PID_FILE="$WORKDIR/.loom/.daemon.pid"
+( sleep 30 & echo $! > "$SLEEP_PID_FILE" )
+sleep_pid=$(cat "$SLEEP_PID_FILE")
+( cd "$WORKDIR" && LOOM_LAUNCHD_LABEL="$FAKE_LABEL" LOOM_DAEMON_STOP_GRACE_SECS=2 bash "$STOP_SCRIPT" >/dev/null 2>&1 )
+rc2=$?
+assert_eq "0" "$rc2" "live pid: stop exits 0"
+TESTS_RUN=$((TESTS_RUN + 1))
+if ! kill -0 "$sleep_pid" 2>/dev/null; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} live pid: process is actually killed"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} live pid: process is actually killed"
+    kill -9 "$sleep_pid" 2>/dev/null || true
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ ! -f "$SLEEP_PID_FILE" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} live pid: PID file removed after stop"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} live pid: PID file removed after stop"
+fi
+
+# 3. --force skips the grace window (SIGKILL immediately).
+( sleep 30 & echo $! > "$SLEEP_PID_FILE" )
+sleep_pid2=$(cat "$SLEEP_PID_FILE")
+start_ts=$(date +%s)
+( cd "$WORKDIR" && LOOM_LAUNCHD_LABEL="$FAKE_LABEL" bash "$STOP_SCRIPT" --force >/dev/null 2>&1 )
+end_ts=$(date +%s)
+elapsed=$((end_ts - start_ts))
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ "$elapsed" -le 5 ]] && ! kill -0 "$sleep_pid2" 2>/dev/null; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --force kills immediately without waiting the grace window"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --force kills immediately without waiting the grace window (elapsed=${elapsed}s)"
+    kill -9 "$sleep_pid2" 2>/dev/null || true
+fi
+
+# 4. --help documents the launchd bootout counterpart and LOOM_LAUNCHD_LABEL.
+help_out=$(bash "$STOP_SCRIPT" --help 2>/dev/null)
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$help_out" | grep -qi 'launchd' && echo "$help_out" | grep -q 'LOOM_LAUNCHD_LABEL'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --help documents the launchd bootout counterpart"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --help documents the launchd bootout counterpart"
+fi
+
+# ---------- summary ----------
+echo
+echo "Ran $TESTS_RUN tests: $TESTS_PASSED passed, $TESTS_FAILED failed"
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -24,6 +24,13 @@
 
 set -uo pipefail
 
+# Force the legacy nohup path everywhere in this suite (#3972): the restart
+# flow below exercises the REAL loom-daemon-start.sh / loom-daemon-stop.sh
+# (not a mock), and this test must NEVER touch the real machine's
+# ~/Library/LaunchAgents/ -- which may hold an actual production
+# com.rjwalters.loom-daemon LaunchAgent under the exact same default label.
+export LOOM_DAEMON_LAUNCHD=0
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CLI_DIR="$(cd "$SCRIPT_DIR/../cli" && pwd)"
 UPDATE_SCRIPT="$CLI_DIR/loom-daemon-update.sh"


### PR DESCRIPTION
## Summary

Fixes the macOS Mach-bootstrap-namespace hazard identified in the 2026-07-26 incident: `loom-daemon-start.sh` previously detached the daemon with a plain `nohup "$DAEMON_BIN" &`, which keeps the process wired into the *launching session's* Mach bootstrap namespace. When that session (e.g. a Claude Code session) died, XPC lookups to `trustd` (cert verification -> `gh` TLS errors) and `opendirectoryd` (`getpwuid` -> "No user exists for uid N" from `git`) started failing for the daemon and every child it spawned -- with no crash and no obvious log signal. The daemon ran blind for ~35 minutes during the incident.

The validated fix (already hand-applied on the operator's machine as `~/Library/LaunchAgents/com.rjwalters.loom-daemon.plist`) is to load the daemon as a `gui/<uid>` LaunchAgent instead.

## Changes

- `defaults/scripts/cli/loom-daemon-start.sh`:
  - On Darwin, generates a LaunchAgent plist (`~/Library/LaunchAgents/com.rjwalters.loom-daemon.plist` by default, override with `LOOM_LAUNCHD_LABEL`) and loads it via `launchctl bootstrap` + `kickstart -k`, mirroring the hand-written plist that validated the fix during the incident (`RunAtLoad=true`, `KeepAlive=false`).
  - The plist's `PATH` is the current `PATH` plus a fallback set (`~/.local/bin`, `~/.cargo/bin`, Homebrew, standard bin dirs) so `gh`/`git`/`cargo`/`python3` resolve inside launchd's minimal environment.
  - Every already-exported `LOOM_*` / `GH_TOKEN` / `GITEA_TOKEN` / `FORGE_TOKEN` var is forwarded verbatim, so the FLAGS-OFF / `--work-finder` / `--health-gate` / `--from-config` semantics are preserved exactly.
  - New `--no-launchd` / `LOOM_DAEMON_LAUNCHD=0` escape hatch forces the legacy nohup path even on Darwin.
  - New `--print-plist` prints the exact plist XML an invocation would install, with zero side effects (no `launchctl` call, no file write) -- used for test coverage of the plist-rendering logic.
  - Linux is unaffected: unchanged plain `nohup` path.
- `defaults/scripts/cli/loom-daemon-stop.sh`: on macOS, additionally `launchctl bootout`s the LaunchAgent job definition once the process is confirmed dead, so `RunAtLoad=true` doesn't silently relaunch a daemon the operator explicitly stopped at the next login/boot. Falls back to a launchd-sourced pid lookup when the PID file is stale.
- `.loom/docs/daemon-reference.md`: new "macOS session-bootstrap hazard (#3972)" subsection under Operability documenting the incident, root cause, and fix.
- New tests: `test-loom-daemon-launchd-plist.sh` (23 tests, pure `--print-plist` rendering coverage -- FLAGS-OFF default, `--work-finder`, `--from-config` leaves vars unset, label override, PATH fallback dirs, RunAtLoad/KeepAlive, flags-file exclusion), `test-loom-daemon-stop.sh` (7 tests, using a random nonexistent launchd label so the suite never touches a real machine's LaunchAgents).
- Updated `test-loom-daemon-start.sh` / `test-loom-daemon-update.sh`: their existing background-start assertions now force the legacy nohup path (`--no-launchd` / `LOOM_DAEMON_LAUNCHD=0`) since they exercise flag-persistence/rebuild-restart behavior, not launchd itself, and must never mutate a real machine's LaunchAgents.

## Test plan

- [x] `bash defaults/scripts/tests/test-loom-daemon-launchd-plist.sh` -- 23/23 passed
- [x] `bash defaults/scripts/tests/test-loom-daemon-stop.sh` -- 7/7 passed
- [x] `bash defaults/scripts/tests/test-loom-daemon-start.sh` -- 10/10 passed (regression)
- [x] `bash defaults/scripts/tests/test-loom-daemon-update.sh` -- 17/17 passed (regression)
- [x] `shellcheck --severity=warning` clean on all of `defaults/scripts/`
- [x] Verified (md5 before/after) that the whole suite run never mutates the real `~/Library/LaunchAgents/com.rjwalters.loom-daemon.plist` already present on the dev machine from the incident's manual fix
- [ ] Manual end-to-end `launchctl bootstrap`/`kickstart`/`bootout` lifecycle on a real macOS login session (not exercised by the automated suite by design -- requires a GUI login session)

Closes #3972