### PR TITLE
feat(daemon): durable operator watches on issue/PR terminal state (#3971)

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -1036,6 +1036,11 @@ concurrency ceiling 5" and share it with the team:
     "mainHealthGate": {
       "enabled": true
     },
+    "watchMonitor": {
+      "enabled": true,
+      "intervalSecs": 120,
+      "expirySecs": 86400
+    },
     "dispatchStaggerMs": 2000,
     "watchdog": {
       "enabled": true,
@@ -1068,6 +1073,9 @@ exactly like `main_health_gate::read_build_gate_config`.
 | `autonomous.workFinder.quarantine.instaCrashSecs` | `LOOM_WORK_FINDER_QUARANTINE_INSTA_CRASH_SECS` | `60` | Checkpoint-less death within this window of dispatch counts as an insta-crash. Zero/invalid → default |
 | `autonomous.perTokenConcurrency` | `LOOM_PER_TOKEN_CONCURRENCY` | `2` | Concurrent sweeps **per healthy token** in the cap (#3947). Zero/invalid → default; clamped to a floor of 1 |
 | `autonomous.mainHealthGate.enabled` | `LOOM_MAIN_HEALTH_GATE` | `false` | Gate loop on/off |
+| `autonomous.watchMonitor.enabled` | `LOOM_WATCH_MONITOR` | `true` | Durable operator-watch monitor loop (#3971). Default-on; no dispatch side effect, zero forge calls until a watch is registered |
+| `autonomous.watchMonitor.intervalSecs` | `LOOM_WATCH_MONITOR_INTERVAL_SECS` | `120` | Watch poll cadence. Zero/invalid → default |
+| `autonomous.watchMonitor.expirySecs` | `LOOM_WATCH_MONITOR_EXPIRY_SECS` | `86400` | Give-up window for an unresolved watch; `0` disables expiry |
 | `autonomous.dispatchStaggerMs` | `LOOM_SWEEP_DISPATCH_STAGGER_MS` | `2000` | Min gap between consecutive child spawns (#3887). `0` disables |
 | `autonomous.watchdog.enabled` | `LOOM_SWEEP_WATCHDOG` | `true` | Startup watchdog on/off (#3887). Also the master switch for the tick — mid-build-death (#3895) + review-stall (#3910) run in the same task |
 | `autonomous.watchdog.timeoutSecs` | `LOOM_SWEEP_WATCHDOG_TIMEOUT_SECS` | `120` | No-progress window before auto-restart |
@@ -1268,6 +1276,77 @@ the workspace registry each tick and refreshes every registered repo's own
 pool, gated by that repo's own config (an empty registry reduces to the single
 daemon workspace). See `loom-daemon/src/token_ranking_refresh.rs` for the
 implementation.
+
+### Durable operator watches (#3971)
+
+**Problem it fixes.** An operator armed a 4-hour background poll watching two
+items for terminal state, then their Claude Code session crashed and the watch
+died with it — background tasks are children of the session process, so the
+terminal-state report was silently lost. The root cause is harness behaviour,
+but the durable fix belongs on the daemon: it is the long-lived process that
+already outlives any one operator session.
+
+**What it does.** An operator registers a watch on an issue or PR
+(`register_watch` MCP tool, or `loom-daemon watch add`). The watch is persisted
+machine-level to `~/.loom/watches.json` (override `LOOM_WATCHES_PATH`) so it
+survives **both** the registering session's death **and** a daemon restart. A
+default-on monitor loop polls each watch's terminal state on a cadence and, when
+a watch reaches a terminal state or expires, **durably appends** a JSON line to
+`~/.loom/logs/watch-results.log` (override `LOOM_WATCH_RESULTS_LOG`) — a file a
+later session can trivially `tail` — then drops the watch from the active set.
+
+**Terminal states** (forge-observable, read via `gh issue view` / `gh pr view
+--json state,labels`):
+
+| Outcome | Condition |
+|---------|-----------|
+| `closed` | issue/PR state `CLOSED` |
+| `merged` | PR state `MERGED` |
+| `blocked` | still-open item carrying the `loom:blocked` label |
+| `expired` | monitor-generated — no terminal state within the expiry window (bounds the watches file + forge-call budget) |
+
+**Why forge polling, not the event bus.** The in-memory event bus
+(`sweep.issue.{N}.*`, `sweep.global.*`) only knows about sweeps *this daemon
+dispatched*, and the motivating case is explicitly cross-repo (a `vibesql` issue
+watched from the `loom` operator session) which the daemon may never have swept.
+The v0.10.0 event taxonomy is also frozen. So the monitor **polls the forge
+directly**, which works uniformly for any repo — sweep-backed or not — **without
+minting a new event topic**. Address the target cross-repo with either `repo` (a
+forge slug `owner/name`, preferred) or `workspace_root` (the `gh` query runs in
+that repo's working dir — the same addressing pattern as `dispatch_sweep` /
+`list_sweeps`).
+
+**Default-on, like the token-ranking refresh.** It has no dispatch side effect
+and makes **zero** forge calls until an operator registers a watch (an empty
+registry short-circuits the tick to a single file read). Full opt-out knob:
+
+```json
+{
+  "autonomous": {
+    "watchMonitor": { "enabled": true, "intervalSecs": 120, "expirySecs": 86400 }
+  }
+}
+```
+
+| Env var | Config key | Precedence | Default |
+|---------|-----------|------------|---------|
+| `LOOM_WATCH_MONITOR` | `autonomous.watchMonitor.enabled` | env > config > default | `true` (on) |
+| `LOOM_WATCH_MONITOR_INTERVAL_SECS` | `autonomous.watchMonitor.intervalSecs` | env > config > default | `120` (2 min) |
+| `LOOM_WATCH_MONITOR_EXPIRY_SECS` | `autonomous.watchMonitor.expirySecs` | env > config > default | `86400` (24h; `0` disables expiry) |
+
+**Never fatal.** A missing/corrupt watches file degrades to an empty registry; a
+single failing probe (network, `gh` missing, transient forge error) is logged
+and the watch retained for the next tick rather than aborting the whole tick.
+
+**IPC / CLI surface.**
+
+| IPC request | MCP tool | CLI | Purpose |
+|-------------|----------|-----|---------|
+| `RegisterWatch` | `register_watch` | `loom-daemon watch add <N> [--pr] [--repo O/N] [--note …]` | Register a durable watch (idempotent on `(target, kind, number)`) |
+| `ListWatches` | `list_watches` | `loom-daemon watch list [--json]` | List active watches |
+| `RemoveWatch` | `remove_watch` | `loom-daemon watch remove <id>` | Remove a watch by id |
+
+See `loom-daemon/src/watch_registry.rs` for the implementation.
 
 ### Safe start / stop (raw daemon process)
 

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -1376,6 +1376,21 @@ fn handle_request(
 
         Request::ListWorkspaces => handle_list_workspaces(),
 
+        // ====================================================================
+        // Durable Watch Registry Handlers (Issue #3971)
+        // ====================================================================
+        Request::RegisterWatch {
+            kind,
+            number,
+            repo,
+            workspace_root,
+            note,
+        } => handle_register_watch(kind, number, repo, workspace_root, note),
+
+        Request::ListWatches => handle_list_watches(),
+
+        Request::RemoveWatch { id } => handle_remove_watch(&id),
+
         Request::Shutdown => {
             log::info!("Shutdown requested");
             std::process::exit(0);
@@ -1502,6 +1517,86 @@ fn handle_list_workspaces() -> Response {
         Err(e) => Response::Error {
             message: format!("list_workspaces: load failed: {e}"),
         },
+    }
+}
+
+/// Register a durable watch (Issue #3971). Operates on the machine-level watches
+/// file (`~/.loom/watches.json`) directly — like [`handle_register_workspace`],
+/// the daemon's monitor loop re-reads the file each tick (hot-apply), so a watch
+/// added here is picked up without any in-memory registration.
+fn handle_register_watch(
+    kind: crate::watch_registry::WatchKind,
+    number: u32,
+    repo: Option<String>,
+    workspace_root: Option<String>,
+    note: Option<String>,
+) -> Response {
+    use crate::watch_registry::{default_watches_path, load, new_watch, save};
+
+    let path = match default_watches_path() {
+        Ok(p) => p,
+        Err(e) => {
+            return Response::Error {
+                message: format!("register_watch: {e}"),
+            }
+        }
+    };
+    let mut registry = load(&path);
+    let (watch, was_new) = registry.add(new_watch(kind, number, repo, workspace_root, note));
+    if was_new {
+        if let Err(e) = save(&path, &registry) {
+            return Response::Error {
+                message: format!("register_watch: save failed: {e}"),
+            };
+        }
+    }
+    Response::WatchRegistered {
+        watch,
+        already_present: !was_new,
+    }
+}
+
+/// List the currently-registered durable watches (Issue #3971).
+fn handle_list_watches() -> Response {
+    use crate::watch_registry::{default_watches_path, load};
+
+    let path = match default_watches_path() {
+        Ok(p) => p,
+        Err(e) => {
+            return Response::Error {
+                message: format!("list_watches: {e}"),
+            }
+        }
+    };
+    Response::WatchList {
+        watches: load(&path).watches,
+    }
+}
+
+/// Remove a registered durable watch by id (Issue #3971).
+fn handle_remove_watch(id: &str) -> Response {
+    use crate::watch_registry::{default_watches_path, load, save};
+
+    let path = match default_watches_path() {
+        Ok(p) => p,
+        Err(e) => {
+            return Response::Error {
+                message: format!("remove_watch: {e}"),
+            }
+        }
+    };
+    let mut registry = load(&path);
+    let was_present = registry.remove(id);
+    if was_present {
+        if let Err(e) = save(&path, &registry) {
+            return Response::Error {
+                message: format!("remove_watch: save failed: {e}"),
+            };
+        }
+    }
+    Response::WatchRemoved {
+        id: id.to_string(),
+        was_present,
     }
 }
 
@@ -2912,5 +3007,116 @@ exit 0
         }
 
         std::env::remove_var("LOOM_WORKSPACES_PATH");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_watch_registry_ipc_roundtrip() {
+        use crate::watch_registry::WatchKind;
+
+        let (tm, db, sr, bus) = setup_test_context();
+        let dir = tempdir().unwrap();
+        let watches_path = dir.path().join("watches.json");
+        std::env::set_var(crate::watch_registry::WATCHES_PATH_ENV, &watches_path);
+
+        // Empty registry: list returns none.
+        let response = handle_request(Request::ListWatches, &tm, &db, &sr, &bus, &test_pool());
+        match response {
+            Response::WatchList { watches } => assert!(watches.is_empty()),
+            other => panic!("Expected WatchList, got: {other:?}"),
+        }
+
+        // Register a cross-repo issue watch (the motivating #6193 case).
+        let response = handle_request(
+            Request::RegisterWatch {
+                kind: WatchKind::Issue,
+                number: 6193,
+                repo: Some("rjwalters/vibesql".to_string()),
+                workspace_root: None,
+                note: Some("canary".to_string()),
+            },
+            &tm,
+            &db,
+            &sr,
+            &bus,
+            &test_pool(),
+        );
+        let watch_id = match response {
+            Response::WatchRegistered {
+                watch,
+                already_present,
+            } => {
+                assert!(!already_present);
+                assert_eq!(watch.number, 6193);
+                assert_eq!(watch.repo.as_deref(), Some("rjwalters/vibesql"));
+                watch.id
+            }
+            other => panic!("Expected WatchRegistered, got: {other:?}"),
+        };
+
+        // Re-register the same target dedups (already_present = true).
+        let response = handle_request(
+            Request::RegisterWatch {
+                kind: WatchKind::Issue,
+                number: 6193,
+                repo: Some("rjwalters/vibesql".to_string()),
+                workspace_root: None,
+                note: None,
+            },
+            &tm,
+            &db,
+            &sr,
+            &bus,
+            &test_pool(),
+        );
+        match response {
+            Response::WatchRegistered {
+                already_present, ..
+            } => assert!(already_present),
+            other => panic!("Expected WatchRegistered, got: {other:?}"),
+        }
+
+        // List shows exactly one, and it survives being re-loaded from disk
+        // (the whole point — a watch outlives the registering session).
+        let response = handle_request(Request::ListWatches, &tm, &db, &sr, &bus, &test_pool());
+        match response {
+            Response::WatchList { watches } => {
+                assert_eq!(watches.len(), 1);
+                assert_eq!(watches[0].id, watch_id);
+            }
+            other => panic!("Expected WatchList, got: {other:?}"),
+        }
+
+        // Remove by id.
+        let response = handle_request(
+            Request::RemoveWatch {
+                id: watch_id.clone(),
+            },
+            &tm,
+            &db,
+            &sr,
+            &bus,
+            &test_pool(),
+        );
+        match response {
+            Response::WatchRemoved { was_present, .. } => assert!(was_present),
+            other => panic!("Expected WatchRemoved, got: {other:?}"),
+        }
+
+        // Removing again is a no-op success.
+        let response = handle_request(
+            Request::RemoveWatch { id: watch_id },
+            &tm,
+            &db,
+            &sr,
+            &bus,
+            &test_pool(),
+        );
+        match response {
+            Response::WatchRemoved { was_present, .. } => assert!(!was_present),
+            other => panic!("Expected WatchRemoved, got: {other:?}"),
+        }
+
+        std::env::remove_var(crate::watch_registry::WATCHES_PATH_ENV);
     }
 }

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -1531,7 +1531,7 @@ fn handle_register_watch(
     workspace_root: Option<String>,
     note: Option<String>,
 ) -> Response {
-    use crate::watch_registry::{default_watches_path, load, new_watch, save};
+    use crate::watch_registry::{default_watches_path, load, new_watch, save, with_watches_lock};
 
     let path = match default_watches_path() {
         Ok(p) => p,
@@ -1541,18 +1541,26 @@ fn handle_register_watch(
             }
         }
     };
-    let mut registry = load(&path);
-    let (watch, was_new) = registry.add(new_watch(kind, number, repo, workspace_root, note));
-    if was_new {
-        if let Err(e) = save(&path, &registry) {
-            return Response::Error {
-                message: format!("register_watch: save failed: {e}"),
-            };
+    // The load→modify→save runs under the watches-file lock: the background
+    // monitor loop is an independent concurrent writer to the same file, so an
+    // unguarded read-modify-write here could be silently clobbered (Issue #3971
+    // durability guarantee).
+    let outcome = with_watches_lock(&path, || {
+        let mut registry = load(&path);
+        let (watch, was_new) = registry.add(new_watch(kind, number, repo, workspace_root, note));
+        if was_new {
+            save(&path, &registry)?;
         }
-    }
-    Response::WatchRegistered {
-        watch,
-        already_present: !was_new,
+        Ok((watch, was_new))
+    });
+    match outcome {
+        Ok((watch, was_new)) => Response::WatchRegistered {
+            watch,
+            already_present: !was_new,
+        },
+        Err(e) => Response::Error {
+            message: format!("register_watch: save failed: {e}"),
+        },
     }
 }
 
@@ -1575,7 +1583,7 @@ fn handle_list_watches() -> Response {
 
 /// Remove a registered durable watch by id (Issue #3971).
 fn handle_remove_watch(id: &str) -> Response {
-    use crate::watch_registry::{default_watches_path, load, save};
+    use crate::watch_registry::{default_watches_path, load, save, with_watches_lock};
 
     let path = match default_watches_path() {
         Ok(p) => p,
@@ -1585,18 +1593,24 @@ fn handle_remove_watch(id: &str) -> Response {
             }
         }
     };
-    let mut registry = load(&path);
-    let was_present = registry.remove(id);
-    if was_present {
-        if let Err(e) = save(&path, &registry) {
-            return Response::Error {
-                message: format!("remove_watch: save failed: {e}"),
-            };
+    // Guarded by the watches-file lock — same concurrent-writer reasoning as
+    // handle_register_watch (Issue #3971).
+    let outcome = with_watches_lock(&path, || {
+        let mut registry = load(&path);
+        let was_present = registry.remove(id);
+        if was_present {
+            save(&path, &registry)?;
         }
-    }
-    Response::WatchRemoved {
-        id: id.to_string(),
-        was_present,
+        Ok(was_present)
+    });
+    match outcome {
+        Ok(was_present) => Response::WatchRemoved {
+            id: id.to_string(),
+            was_present,
+        },
+        Err(e) => Response::Error {
+            message: format!("remove_watch: save failed: {e}"),
+        },
     }
 }
 

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -36,6 +36,7 @@ pub mod terminal;
 pub mod token_ranking_refresh;
 pub mod tokens;
 pub mod types;
+pub mod watch_registry;
 pub mod work_finder;
 pub mod workspace_pool;
 pub mod workspace_registry;

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -12,6 +12,7 @@ use loom_daemon::sweep_registry::{self, SweepRegistry, SweepRegistryConfig};
 use loom_daemon::terminal::TerminalManager;
 use loom_daemon::token_ranking_refresh;
 use loom_daemon::types::{DaemonStatusReport, Request, Response, SweepKind};
+use loom_daemon::watch_registry;
 use loom_daemon::work_finder;
 use loom_daemon::workspace_pool::WorkspacePool;
 use loom_daemon::{extract_configured_terminal_ids, rotate_log_file};
@@ -157,6 +158,16 @@ enum Commands {
         depends_on: Option<u32>,
     },
 
+    /// Manage durable operator watches on issue/PR terminal state (Issue #3971).
+    /// A watch registered here is persisted to `~/.loom/watches.json` and polled
+    /// by the running daemon, so it survives this shell — and even a daemon
+    /// restart. Terminal resolutions land in `~/.loom/logs/watch-results.log`.
+    /// Connects to the running daemon over its Unix socket.
+    Watch {
+        #[command(subcommand)]
+        action: WatchAction,
+    },
+
     /// Validate role configuration completeness
     Validate {
         /// Workspace directory containing .loom/config.json
@@ -220,6 +231,47 @@ enum WorkspaceAction {
     },
 }
 
+/// Sub-actions for `loom-daemon watch` (Issue #3971).
+#[derive(Subcommand)]
+enum WatchAction {
+    /// Register a durable watch on an issue's or PR's terminal state.
+    Add {
+        /// The issue or PR number to watch.
+        #[arg(value_name = "NUMBER")]
+        number: u32,
+
+        /// Watch a pull request instead of an issue.
+        #[arg(long)]
+        pr: bool,
+
+        /// Forge slug `owner/name` (preferred — works cross-repo for a repo this
+        /// machine may not manage). Omit to resolve from `--workspace-root` or the
+        /// daemon's own cwd.
+        #[arg(long, value_name = "OWNER/NAME")]
+        repo: Option<String>,
+
+        /// Workspace root the `gh` query runs in when `--repo` is absent.
+        #[arg(long, value_name = "PATH")]
+        workspace_root: Option<String>,
+
+        /// Optional note surfaced in the recorded result line.
+        #[arg(long, value_name = "TEXT")]
+        note: Option<String>,
+    },
+    /// List the currently-registered durable watches.
+    List {
+        /// Emit machine-readable JSON instead of the human-readable table.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Remove a registered watch by its id.
+    Remove {
+        /// The watch id (as printed by `watch add` / `watch list`).
+        #[arg(value_name = "ID")]
+        id: String,
+    },
+}
+
 /// Sub-actions for `loom-daemon quarantine`.
 #[derive(Subcommand)]
 enum QuarantineAction {
@@ -262,6 +314,9 @@ async fn main() -> Result<()> {
                 effort,
                 depends_on,
             } => handle_dispatch_command(issue, workspace, model, effort, depends_on).await,
+            // `watch` connects to the running daemon over its Unix socket to
+            // register/list/remove durable watches (Issue #3971).
+            Commands::Watch { action } => handle_watch_command(action).await,
             other => handle_cli_command(other),
         };
     }
@@ -696,6 +751,40 @@ async fn main() -> Result<()> {
             None
         };
 
+    // Durable watch-monitor loop (Issue #3971): the daemon polls the forge for
+    // the terminal state of operator-registered issue/PR watches
+    // (`~/.loom/watches.json`) and appends resolutions to
+    // `~/.loom/logs/watch-results.log`. Because the watch lives in a file the
+    // long-lived daemon owns, an operator's watch survives their Claude Code
+    // session dying — the failure this issue exists to fix. Like the
+    // token-ranking refresh above (and unlike the dispatch-affecting work-finder
+    // / main-health-gate loops) it is **default-ON**: it has no dispatch side
+    // effect and makes ZERO forge calls until an operator registers a watch.
+    // Config surface: `autonomous.watchMonitor.{enabled,intervalSecs,expirySecs}`,
+    // precedence env > config > default (env: `LOOM_WATCH_MONITOR` /
+    // `LOOM_WATCH_MONITOR_INTERVAL_SECS` / `LOOM_WATCH_MONITOR_EXPIRY_SECS`).
+    let watch_monitor_config = watch_registry::read_watch_monitor_config(&sweep_workspace);
+    let _watch_monitor_handle = if watch_registry::resolve_enabled(&watch_monitor_config) {
+        let interval = watch_registry::resolve_interval(&watch_monitor_config);
+        let expiry = watch_registry::resolve_expiry(&watch_monitor_config);
+        log::info!(
+            "watch_monitor: enabled (interval={}s, expiry={}s)",
+            interval.as_secs(),
+            expiry.as_secs()
+        );
+        Some(watch_registry::spawn_watch_monitor_task(
+            watch_registry::GhWatchProbe::new(),
+            interval,
+            expiry,
+        ))
+    } else {
+        log::debug!(
+            "watch_monitor: disabled (set LOOM_WATCH_MONITOR=1 or \
+             autonomous.watchMonitor.enabled=true to opt in)"
+        );
+        None
+    };
+
     // Start IPC server. `workspace_health_states` is threaded in so the
     // `DaemonStatus` request can report each registered repo's own halt state
     // (#3930), and `sweep_workspace` is the `effective_roots` fallback for the
@@ -859,6 +948,11 @@ fn handle_cli_command(command: Commands) -> Result<()> {
             // Routed directly in `main()` (it needs the async runtime for the
             // socket round-trip), never dispatched through this sync handler.
             unreachable!("Dispatch is handled in main() before handle_cli_command")
+        }
+        Commands::Watch { .. } => {
+            // Routed directly in `main()` (it needs the async runtime for the
+            // socket round-trip), never dispatched through this sync handler.
+            unreachable!("Watch is handled in main() before handle_cli_command")
         }
         Commands::Init {
             workspace,
@@ -1136,6 +1230,107 @@ async fn handle_quarantine_command(action: QuarantineAction) -> Result<()> {
             }
         }
     }
+}
+
+/// Handle the `watch` subcommand (Issue #3971). Connects to the running daemon
+/// over its Unix socket and registers/lists/removes durable watches. The watches
+/// are persisted machine-level (`~/.loom/watches.json`), so — like the daemon's
+/// other file-backed state — they survive both this shell and a daemon restart;
+/// the resolution report lands in `~/.loom/logs/watch-results.log`.
+async fn handle_watch_command(action: WatchAction) -> Result<()> {
+    use loom_daemon::watch_registry::WatchKind;
+
+    let socket_path = resolve_socket_path()?;
+    // `json_out` only applies to `list`; captured here so the request build below
+    // does not have to smuggle it back out.
+    let mut json_out = false;
+    let request = match action {
+        WatchAction::Add {
+            number,
+            pr,
+            repo,
+            workspace_root,
+            note,
+        } => Request::RegisterWatch {
+            kind: if pr { WatchKind::Pr } else { WatchKind::Issue },
+            number,
+            repo,
+            workspace_root,
+            note,
+        },
+        WatchAction::List { json } => {
+            json_out = json;
+            Request::ListWatches
+        }
+        WatchAction::Remove { id } => Request::RemoveWatch { id },
+    };
+
+    match query_daemon(&socket_path, &request).await {
+        Ok(Response::WatchRegistered {
+            watch,
+            already_present,
+        }) => {
+            if already_present {
+                println!("Already watching {} (id {}) — no-op.", watch.target_label(), watch.id);
+            } else {
+                println!("Registered watch on {}", watch.target_label());
+                println!("  id:   {}", watch.id);
+                println!("Terminal state will be recorded to {}", watch_results_log_hint());
+            }
+            Ok(())
+        }
+        Ok(Response::WatchList { watches }) => {
+            if json_out {
+                println!("{}", serde_json::to_string_pretty(&watches)?);
+            } else if watches.is_empty() {
+                println!("No durable watches registered.");
+            } else {
+                println!("{} durable watch(es):", watches.len());
+                for w in &watches {
+                    let note = w
+                        .note
+                        .as_deref()
+                        .map(|n| format!(" — {n}"))
+                        .unwrap_or_default();
+                    println!("  {}  {}{}", w.id, w.target_label(), note);
+                }
+                println!();
+                println!("Resolutions are recorded to {}", watch_results_log_hint());
+            }
+            Ok(())
+        }
+        Ok(Response::WatchRemoved { id, was_present }) => {
+            if was_present {
+                println!("Removed watch {id}.");
+            } else {
+                println!("No watch with id {id} — nothing to remove (no-op).");
+            }
+            Ok(())
+        }
+        Ok(Response::Error { message }) => {
+            eprintln!("Daemon error: {message}");
+            std::process::exit(1);
+        }
+        Ok(other) => {
+            eprintln!("Unexpected response from daemon: {other:?}");
+            std::process::exit(1);
+        }
+        Err(e) => {
+            eprintln!("Could not reach loom-daemon at {}: {e}", socket_path.display());
+            eprintln!();
+            eprintln!("Is the daemon running? Start it with:");
+            eprintln!("  ./.loom/scripts/cli/loom-daemon-start.sh");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Best-effort human hint for where watch results are recorded (honors the env
+/// override). Purely cosmetic — never fails.
+fn watch_results_log_hint() -> String {
+    watch_registry::default_results_log_path()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| "~/.loom/logs/watch-results.log".to_string())
 }
 
 /// Connect to the running daemon over its Unix socket, send a single `request`,

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -318,6 +318,41 @@ pub enum Request {
     },
     /// List the managed workspaces in the machine-level registry.
     ListWorkspaces,
+    // ========================================================================
+    // Durable Watch Registry Requests (Issue #3971)
+    // ========================================================================
+    /// Register a durable watch on an issue's or PR's terminal state. The watch
+    /// is persisted to `~/.loom/watches.json` (machine-level) so it survives the
+    /// registering operator session's death AND a daemon restart; the daemon's
+    /// watch-monitor loop polls the forge and, on a terminal state (closed /
+    /// merged / blocked) or expiry, appends a result line to
+    /// `~/.loom/logs/watch-results.log`.
+    ///
+    /// Address the target cross-repo with either `repo` (a forge slug
+    /// `owner/name`, preferred — works for a repo this machine may not manage) or
+    /// `workspace_root` (the `gh` query runs in that repo's working dir, mirroring
+    /// the `workspace_root` param on `DispatchSweep` / `ListSweeps`). Both absent
+    /// ⇒ the daemon's own cwd. Idempotent — re-registering the same
+    /// `(target, kind, number)` returns the existing watch (`already_present:
+    /// true`).
+    RegisterWatch {
+        kind: crate::watch_registry::WatchKind,
+        number: u32,
+        #[serde(default)]
+        repo: Option<String>,
+        #[serde(default)]
+        workspace_root: Option<String>,
+        #[serde(default)]
+        note: Option<String>,
+    },
+    /// List the currently-registered durable watches.
+    ListWatches,
+    /// Remove a registered watch by its id (as returned by `RegisterWatch` /
+    /// `ListWatches`). Removing an unknown id is a no-op success
+    /// (`was_present: false`).
+    RemoveWatch {
+        id: String,
+    },
     Shutdown,
 }
 
@@ -472,6 +507,26 @@ pub enum Response {
     /// Result of a `ListWorkspaces` request.
     WorkspaceList {
         workspaces: Vec<crate::workspace_registry::Workspace>,
+    },
+    // ========================================================================
+    // Durable Watch Registry Responses (Issue #3971)
+    // ========================================================================
+    /// Result of a `RegisterWatch` request. `watch` is the stored spec (the
+    /// pre-existing one on a dedup hit); `already_present` is `true` when a watch
+    /// for the same `(target, kind, number)` was already registered.
+    WatchRegistered {
+        watch: crate::watch_registry::WatchSpec,
+        already_present: bool,
+    },
+    /// Result of a `ListWatches` request.
+    WatchList {
+        watches: Vec<crate::watch_registry::WatchSpec>,
+    },
+    /// Result of a `RemoveWatch` request. `was_present` is `false` when no watch
+    /// with the given id existed (no-op success).
+    WatchRemoved {
+        id: String,
+        was_present: bool,
     },
     /// Legacy error response (deprecated, use `StructuredError` for new code)
     /// Kept for backwards compatibility with existing frontends

--- a/loom-daemon/src/watch_registry.rs
+++ b/loom-daemon/src/watch_registry.rs
@@ -1,0 +1,1165 @@
+//! Durable operator watches on issue/PR terminal state (Issue #3971).
+//!
+//! ## Problem
+//!
+//! At the end of the 2026-07-26 canary session an operator armed a 4-hour
+//! background poll watching two items (`vibesql#6193`, `loom#3964`) for terminal
+//! state. The operator's Claude Code session then crashed, and the watch died
+//! with it — background tasks are children of the session process, so the
+//! terminal-state report was silently lost until the next session reconstructed
+//! it from logs.
+//!
+//! The root cause is harness behaviour (session-scoped background tasks), but the
+//! durable fix belongs on the daemon side: the `loom-daemon` is the long-lived
+//! process that already outlives any one operator session. What was missing was a
+//! way for an operator to register interest that survives their session dying.
+//!
+//! ## Fix
+//!
+//! An operator registers a [`WatchSpec`] against the daemon (over IPC —
+//! `Request::RegisterWatch`, or the `loom-daemon watch add` CLI). The watch is
+//! persisted to a machine-level file (`~/.loom/watches.json`, override via
+//! [`WATCHES_PATH_ENV`]) so it survives **both** the registering session's death
+//! **and** a daemon restart. A background monitor loop
+//! ([`crate::watch_registry` runtime wiring in `main.rs`]) polls each watch's
+//! terminal state on a cadence and, when a watch reaches a terminal state,
+//! **durably appends** a [`WatchResult`] line to `~/.loom/logs/watch-results.log`
+//! (override via [`RESULTS_LOG_PATH_ENV`]) — a file a later session can trivially
+//! `cat`/`tail` — and drops the watch from the active set.
+//!
+//! ## Why forge polling (not the event bus)
+//!
+//! The daemon's in-memory event bus (`sweep.issue.{N}.*`, `sweep.global.*`) only
+//! knows about sweeps **this daemon dispatched**. The motivating case is
+//! explicitly cross-repo — a `vibesql` issue watched from the `loom` operator
+//! session — which the daemon may never have dispatched a sweep for. The v0.10.0
+//! event taxonomy is also frozen (new topics require a follow-up issue). So the
+//! monitor **polls the forge directly** (`gh issue view` / `gh pr view`) for each
+//! watch's terminal state, which works uniformly for any repo — sweep-backed or
+//! not — without minting a new event topic. A watch carries either an explicit
+//! forge slug ([`WatchSpec::repo`]) or a [`WatchSpec::workspace_root`] the `gh`
+//! query runs in (mirroring how [`crate::work_finder::forge::GhWorkSource`]
+//! addresses a specific managed workspace).
+//!
+//! All I/O here is best-effort by design: a missing/empty/corrupt watches file
+//! degrades to an empty registry, and a single failing probe is logged and the
+//! watch retained (retried next tick) rather than aborting the whole tick.
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/// Environment override for the persisted watches file (mirrors
+/// [`crate::sweep_journal::JOURNAL_PATH_ENV`]). Primarily a test seam.
+pub const WATCHES_PATH_ENV: &str = "LOOM_WATCHES_PATH";
+
+/// Environment override for the durable results log file.
+pub const RESULTS_LOG_PATH_ENV: &str = "LOOM_WATCH_RESULTS_LOG";
+
+/// Current on-disk schema version for the watches file.
+pub const WATCHES_VERSION: u32 = 1;
+
+/// Environment variable controlling the watch-monitor loop.
+///
+/// Like [`crate::token_ranking_refresh::TOKEN_RANKING_REFRESH_ENABLE_ENV`] (and
+/// unlike the dispatch-affecting work-finder / main-health-gate loops), this loop
+/// is **default-on**: it only ever *reads* forge state and appends to a
+/// bookkeeping log, has no dispatch side effect, and makes **zero** forge calls
+/// when no watches are registered. Set to `0`/`false`/`no`/`off`
+/// (case-insensitive) to disable; `1`/`true`/`yes`/`on` to force-enable.
+pub const WATCH_MONITOR_ENABLE_ENV: &str = "LOOM_WATCH_MONITOR";
+
+/// Environment override for the monitor cadence (seconds).
+pub const WATCH_MONITOR_INTERVAL_ENV: &str = "LOOM_WATCH_MONITOR_INTERVAL_SECS";
+
+/// Environment override for the watch expiry window (seconds); `0` disables
+/// expiry (watches poll until they resolve).
+pub const WATCH_MONITOR_EXPIRY_ENV: &str = "LOOM_WATCH_MONITOR_EXPIRY_SECS";
+
+/// Default monitor cadence — responsive without being chatty.
+pub const DEFAULT_WATCH_MONITOR_INTERVAL_SECS: u64 = 120;
+
+/// Default expiry window: a watch that has not resolved in 24h is recorded as
+/// [`WatchOutcome::Expired`] and dropped, so `watches.json` and the forge-call
+/// budget stay bounded on a long-lived daemon. `0` disables expiry.
+pub const DEFAULT_WATCH_MONITOR_EXPIRY_SECS: u64 = 86_400;
+
+/// How long to wait for a single `gh` probe before killing it.
+const DEFAULT_PROBE_TIMEOUT: Duration = Duration::from_secs(30);
+
+// ============================================================================
+// Core types
+// ============================================================================
+
+/// Whether a watch targets an issue or a pull request. Governs which `gh`
+/// subcommand the probe uses and which terminal states are observable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WatchKind {
+    Issue,
+    Pr,
+}
+
+impl WatchKind {
+    /// Lower-case label used in ids and human summaries.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Issue => "issue",
+            Self::Pr => "pr",
+        }
+    }
+}
+
+/// The recorded outcome of a resolved watch.
+///
+/// `Closed` / `Merged` / `Blocked` are forge-observable terminal states read by
+/// the probe. `Expired` is monitor-generated — the daemon gave up after the
+/// configured expiry window without observing a terminal state (never a forge
+/// state).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WatchOutcome {
+    /// The issue or PR was closed (issue closed, or PR closed without merge).
+    Closed,
+    /// The PR was merged.
+    Merged,
+    /// The issue/PR carries the `loom:blocked` label (a pending-decision block).
+    Blocked,
+    /// Monitor gave up after the expiry window with no terminal state observed.
+    Expired,
+}
+
+impl WatchOutcome {
+    /// Lower-case label for human summaries.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Closed => "closed",
+            Self::Merged => "merged",
+            Self::Blocked => "blocked",
+            Self::Expired => "expired",
+        }
+    }
+}
+
+/// One registered watch. Persisted verbatim to the watches file.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WatchSpec {
+    /// Stable opaque id assigned at registration (`watch-<kind>-<number>-<rand>`).
+    pub id: String,
+    /// Whether this targets an issue or a PR.
+    pub kind: WatchKind,
+    /// The issue/PR number.
+    pub number: u32,
+    /// Forge slug `owner/name` (preferred — works cross-repo for a repo this
+    /// machine may not manage). `None` ⇒ the probe runs in [`Self::workspace_root`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo: Option<String>,
+    /// Workspace root the `gh` query runs in when [`Self::repo`] is absent
+    /// (mirrors [`crate::work_finder::forge::GhWorkSource::for_root`]). `None` and
+    /// no `repo` ⇒ the daemon's own cwd.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_root: Option<String>,
+    /// Optional operator note surfaced in the result line.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+    /// Registration timestamp (drives expiry).
+    pub registered_at: DateTime<Utc>,
+}
+
+impl WatchSpec {
+    /// Human target label, e.g. `issue #6193 in rjwalters/vibesql`.
+    #[must_use]
+    pub fn target_label(&self) -> String {
+        let where_ = self
+            .repo
+            .clone()
+            .or_else(|| self.workspace_root.clone())
+            .unwrap_or_else(|| "<default workspace>".to_string());
+        format!("{} #{} in {}", self.kind.as_str(), self.number, where_)
+    }
+
+    /// The dedup key: two registrations of the same `(target, kind, number)`
+    /// collapse to one watch. `target` is the forge slug, else the workspace
+    /// root, else the empty string (the daemon's default workspace).
+    fn dedup_key(&self) -> (String, WatchKind, u32) {
+        let target = self
+            .repo
+            .clone()
+            .or_else(|| self.workspace_root.clone())
+            .unwrap_or_default();
+        (target, self.kind, self.number)
+    }
+}
+
+/// A resolved watch, appended as one JSON line to the durable results log.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WatchResult {
+    pub id: String,
+    pub kind: WatchKind,
+    pub number: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_root: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+    pub registered_at: DateTime<Utc>,
+    pub resolved_at: DateTime<Utc>,
+    pub outcome: WatchOutcome,
+    /// Pre-rendered human summary line (also embedded so a plain `tail` of the
+    /// JSONL log is readable without a parser).
+    pub summary: String,
+}
+
+/// The full on-disk watches file: a flat list of active [`WatchSpec`]s.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WatchRegistry {
+    #[serde(default = "default_version")]
+    pub version: u32,
+    #[serde(default)]
+    pub watches: Vec<WatchSpec>,
+}
+
+fn default_version() -> u32 {
+    WATCHES_VERSION
+}
+
+impl Default for WatchRegistry {
+    fn default() -> Self {
+        Self {
+            version: WATCHES_VERSION,
+            watches: Vec::new(),
+        }
+    }
+}
+
+impl WatchRegistry {
+    /// Insert a watch, deduplicating on `(target, kind, number)`. Returns the
+    /// stored watch (the pre-existing one on a dedup hit) and whether it was new.
+    pub fn add(&mut self, spec: WatchSpec) -> (WatchSpec, bool) {
+        let key = spec.dedup_key();
+        if let Some(existing) = self.watches.iter().find(|w| w.dedup_key() == key) {
+            return (existing.clone(), false);
+        }
+        self.watches.push(spec.clone());
+        (spec, true)
+    }
+
+    /// Remove a watch by id. Returns `true` if one was removed.
+    pub fn remove(&mut self, id: &str) -> bool {
+        let before = self.watches.len();
+        self.watches.retain(|w| w.id != id);
+        before != self.watches.len()
+    }
+}
+
+// ============================================================================
+// Persistence (watches.json)
+// ============================================================================
+
+/// Resolve the watches file path: [`WATCHES_PATH_ENV`] override (non-empty), else
+/// `~/.loom/watches.json`.
+pub fn default_watches_path() -> Result<PathBuf> {
+    if let Ok(path) = std::env::var(WATCHES_PATH_ENV) {
+        if !path.is_empty() {
+            return Ok(PathBuf::from(path));
+        }
+    }
+    let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("no home directory"))?;
+    Ok(home.join(".loom").join("watches.json"))
+}
+
+/// Resolve the results log path: [`RESULTS_LOG_PATH_ENV`] override (non-empty),
+/// else `~/.loom/logs/watch-results.log`.
+pub fn default_results_log_path() -> Result<PathBuf> {
+    if let Ok(path) = std::env::var(RESULTS_LOG_PATH_ENV) {
+        if !path.is_empty() {
+            return Ok(PathBuf::from(path));
+        }
+    }
+    let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("no home directory"))?;
+    Ok(home.join(".loom").join("logs").join("watch-results.log"))
+}
+
+/// Load the registry from `path`. Tolerant by design: a missing/empty/corrupt
+/// file yields an empty registry (a garbled watches file must never wedge the
+/// monitor loop), mirroring [`crate::sweep_journal::load`].
+#[must_use]
+pub fn load(path: &Path) -> WatchRegistry {
+    match std::fs::read_to_string(path) {
+        Ok(contents) => {
+            if contents.trim().is_empty() {
+                return WatchRegistry::default();
+            }
+            serde_json::from_str(&contents).unwrap_or_else(|e| {
+                log::warn!(
+                    "watch_registry: corrupt watches file at {} ({e}) — treating as empty",
+                    path.display()
+                );
+                WatchRegistry::default()
+            })
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => WatchRegistry::default(),
+        Err(e) => {
+            log::warn!(
+                "watch_registry: failed to read {} ({e}) — treating as empty",
+                path.display()
+            );
+            WatchRegistry::default()
+        }
+    }
+}
+
+/// Persist the registry to `path` atomically (temp file + rename), creating the
+/// parent directory as needed. Mirrors [`crate::sweep_journal::save`].
+pub fn save(path: &Path, registry: &WatchRegistry) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating watches dir {}", parent.display()))?;
+    }
+    let mut json = serde_json::to_string_pretty(registry)?;
+    json.push('\n');
+    let tmp = path.with_extension(format!("json.tmp.{}", std::process::id()));
+    std::fs::write(&tmp, json.as_bytes())
+        .with_context(|| format!("writing temp watches file {}", tmp.display()))?;
+    std::fs::rename(&tmp, path)
+        .with_context(|| format!("renaming {} -> {}", tmp.display(), path.display()))?;
+    Ok(())
+}
+
+/// Append one [`WatchResult`] as a JSON line to the durable results log at
+/// `path`, creating the parent directory as needed. Append-only so concurrent
+/// results never clobber one another and the file is a permanent record a later
+/// session can read.
+pub fn append_result(path: &Path, result: &WatchResult) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating results-log dir {}", parent.display()))?;
+    }
+    let mut line = serde_json::to_string(result)?;
+    line.push('\n');
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("opening results log {}", path.display()))?;
+    file.write_all(line.as_bytes())
+        .with_context(|| format!("appending to results log {}", path.display()))?;
+    Ok(())
+}
+
+// ============================================================================
+// Probe (forge polling, behind a trait for testability)
+// ============================================================================
+
+/// Reads a watch's current terminal state from the forge. Abstracted behind a
+/// trait so [`tick`] is unit-testable with a scripted fake, mirroring
+/// [`crate::work_finder::WorkSource`] / [`crate::token_ranking_refresh::RankingRefreshRunner`].
+pub trait WatchProbe {
+    /// Probe `spec`'s current state.
+    ///
+    /// - `Ok(Some(outcome))` — a terminal state was observed (`Closed` / `Merged`
+    ///   / `Blocked`; never `Expired` — that is monitor-generated in [`tick`]).
+    /// - `Ok(None)` — still open / non-terminal; keep watching.
+    /// - `Err(_)` — the probe failed (network, `gh` missing, transient forge
+    ///   error). The caller logs it and retains the watch for the next tick.
+    fn probe(&self, spec: &WatchSpec) -> Result<Option<WatchOutcome>>;
+}
+
+/// The concrete [`WatchProbe`]: shells out to `gh issue view` / `gh pr view`.
+pub struct GhWatchProbe {
+    gh_bin: PathBuf,
+    timeout: Duration,
+}
+
+impl GhWatchProbe {
+    /// Construct a probe using `gh` from `PATH`.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            gh_bin: PathBuf::from("gh"),
+            timeout: DEFAULT_PROBE_TIMEOUT,
+        }
+    }
+
+    /// Override the `gh` binary (tests / non-standard installs).
+    #[must_use]
+    pub fn with_gh_bin(mut self, bin: PathBuf) -> Self {
+        self.gh_bin = bin;
+        self
+    }
+
+    /// Build the `gh <issue|pr> view` command for `spec`.
+    fn build_command(&self, spec: &WatchSpec) -> Command {
+        let mut cmd = Command::new(&self.gh_bin);
+        match spec.kind {
+            WatchKind::Issue => {
+                cmd.arg("issue").arg("view").arg(spec.number.to_string());
+                cmd.arg("--json").arg("state,labels");
+            }
+            WatchKind::Pr => {
+                cmd.arg("pr").arg("view").arg(spec.number.to_string());
+                cmd.arg("--json").arg("state,labels");
+            }
+        }
+        if let Some(ref repo) = spec.repo {
+            cmd.arg("--repo").arg(repo);
+        }
+        if let Some(ref root) = spec.workspace_root {
+            cmd.current_dir(root);
+        }
+        cmd.stdin(Stdio::null()).stderr(Stdio::piped());
+        cmd
+    }
+}
+
+impl Default for GhWatchProbe {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Minimal `gh <issue|pr> view --json state,labels` row.
+#[derive(Debug, Deserialize)]
+struct GhView {
+    state: String,
+    #[serde(default)]
+    labels: Vec<GhLabel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhLabel {
+    name: String,
+}
+
+/// Classify a `gh view` JSON payload into a terminal outcome, or `None` when the
+/// item is still open/non-terminal. Pure so it is exhaustively unit-testable
+/// without shelling out. `_kind` is accepted for symmetry / future issue-vs-PR
+/// divergence but does not currently affect classification (both surfaces expose
+/// `state` + `labels`).
+#[must_use]
+pub fn classify_view(_kind: WatchKind, json: &[u8]) -> Option<WatchOutcome> {
+    let view: GhView = serde_json::from_slice(json).ok()?;
+    let blocked = view.labels.iter().any(|l| l.name == "loom:blocked");
+    match view.state.to_ascii_uppercase().as_str() {
+        "MERGED" => Some(WatchOutcome::Merged),
+        "CLOSED" => Some(WatchOutcome::Closed),
+        // Still open: a `loom:blocked` label is a terminal "pending decision"
+        // state the operator asked to be told about. (Only meaningful while
+        // OPEN — a closed item is already reported as Closed above.)
+        _ if blocked => Some(WatchOutcome::Blocked),
+        _ => None,
+    }
+}
+
+impl WatchProbe for GhWatchProbe {
+    fn probe(&self, spec: &WatchSpec) -> Result<Option<WatchOutcome>> {
+        let mut cmd = self.build_command(spec);
+        // Wall-clock timeout via a spawned child + poll loop (no extra deps).
+        let mut child = cmd
+            .stdout(Stdio::piped())
+            .spawn()
+            .with_context(|| format!("failed to invoke {}", self.gh_bin.display()))?;
+        let start = std::time::Instant::now();
+        loop {
+            if let Some(status) = child.try_wait()? {
+                let output = child.wait_with_output()?;
+                if !status.success() {
+                    return Err(anyhow::anyhow!(
+                        "gh view for {} failed: {}",
+                        spec.target_label(),
+                        String::from_utf8_lossy(&output.stderr).trim()
+                    ));
+                }
+                return Ok(classify_view(spec.kind, &output.stdout));
+            }
+            if start.elapsed() >= self.timeout {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(anyhow::anyhow!(
+                    "gh view for {} timed out after {}s",
+                    spec.target_label(),
+                    self.timeout.as_secs()
+                ));
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    }
+}
+
+// ============================================================================
+// Tick (pure logic, testable with a fake probe)
+// ============================================================================
+
+/// Run one monitor pass over `registry`, resolving every watch that has reached
+/// a terminal state (or expired). Returns the resolved [`WatchResult`]s (the
+/// caller appends each to the durable log) and **removes** them from `registry`.
+///
+/// Never panics: a probe error is logged and the watch retained for the next
+/// tick. `now` and `expiry` are injected so expiry is deterministically testable
+/// (`expiry == 0` disables expiry — watches poll until they resolve).
+pub fn tick<P: WatchProbe>(
+    registry: &mut WatchRegistry,
+    probe: &P,
+    now: DateTime<Utc>,
+    expiry: Duration,
+) -> Vec<WatchResult> {
+    let mut resolved: Vec<WatchResult> = Vec::new();
+    let mut resolved_ids: Vec<String> = Vec::new();
+
+    for spec in &registry.watches {
+        // Terminal-state probe first.
+        match probe.probe(spec) {
+            Ok(Some(outcome)) => {
+                resolved.push(make_result(spec, outcome, now));
+                resolved_ids.push(spec.id.clone());
+                continue;
+            }
+            Ok(None) => {}
+            Err(e) => {
+                log::warn!(
+                    "watch_registry: probe for {} failed (retained, retried next tick): {e}",
+                    spec.target_label()
+                );
+                continue;
+            }
+        }
+        // Not terminal — has it expired?
+        if !expiry.is_zero() {
+            let age = now.signed_duration_since(spec.registered_at);
+            if age.num_seconds() >= 0 && (age.num_seconds() as u64) >= expiry.as_secs() {
+                resolved.push(make_result(spec, WatchOutcome::Expired, now));
+                resolved_ids.push(spec.id.clone());
+            }
+        }
+    }
+
+    registry.watches.retain(|w| !resolved_ids.contains(&w.id));
+    resolved
+}
+
+/// Build a [`WatchResult`] with a pre-rendered summary line.
+fn make_result(spec: &WatchSpec, outcome: WatchOutcome, now: DateTime<Utc>) -> WatchResult {
+    let mut summary = format!("{} {}", spec.target_label(), outcome.as_str());
+    if let Some(ref note) = spec.note {
+        summary.push_str(&format!(" — {note}"));
+    }
+    WatchResult {
+        id: spec.id.clone(),
+        kind: spec.kind,
+        number: spec.number,
+        repo: spec.repo.clone(),
+        workspace_root: spec.workspace_root.clone(),
+        note: spec.note.clone(),
+        registered_at: spec.registered_at,
+        resolved_at: now,
+        outcome,
+        summary,
+    }
+}
+
+// ============================================================================
+// Registration helper
+// ============================================================================
+
+/// Build a fresh [`WatchSpec`] with a generated id and `registered_at = now`.
+/// A blank `repo`/`workspace_root`/`note` is normalized to `None`.
+#[must_use]
+pub fn new_watch(
+    kind: WatchKind,
+    number: u32,
+    repo: Option<String>,
+    workspace_root: Option<String>,
+    note: Option<String>,
+) -> WatchSpec {
+    let norm = |s: Option<String>| s.filter(|v| !v.trim().is_empty());
+    let short = uuid::Uuid::new_v4().simple().to_string();
+    let short = &short[..8];
+    WatchSpec {
+        id: format!("watch-{}-{}-{}", kind.as_str(), number, short),
+        kind,
+        number,
+        repo: norm(repo),
+        workspace_root: norm(workspace_root),
+        note: norm(note),
+        registered_at: Utc::now(),
+    }
+}
+
+// ============================================================================
+// Config (.loom/config.json → autonomous.watchMonitor)
+// ============================================================================
+
+/// The subset of `.loom/config.json → autonomous.watchMonitor` this module
+/// consumes. Each field is `Option` so an absent key falls through to the
+/// env-var / built-in default — precedence **env > config > default** for every
+/// knob, matching every other `autonomous.*` surface.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WatchMonitorConfig {
+    /// `autonomous.watchMonitor.enabled` — default **true** (default-on loop).
+    pub enabled: Option<bool>,
+    /// `autonomous.watchMonitor.intervalSecs` — poll cadence.
+    pub interval_secs: Option<u64>,
+    /// `autonomous.watchMonitor.expirySecs` — give-up window (`0` disables).
+    pub expiry_secs: Option<u64>,
+}
+
+/// Read `.loom/config.json → autonomous.watchMonitor`, soft-failing every field
+/// to `None` on any of: missing file, malformed JSON, or a missing
+/// `autonomous`/`watchMonitor` block (mirrors
+/// [`crate::token_ranking_refresh::read_token_ranking_refresh_config`]).
+#[must_use]
+pub fn read_watch_monitor_config(repo_root: &Path) -> WatchMonitorConfig {
+    let config_path = repo_root.join(".loom").join("config.json");
+    let config_str = match std::fs::read_to_string(&config_path) {
+        Ok(s) => s,
+        Err(_) => return WatchMonitorConfig::default(),
+    };
+    let config: serde_json::Value = match serde_json::from_str(&config_str) {
+        Ok(v) => v,
+        Err(e) => {
+            log::warn!("watch_registry: could not parse config at {}: {e}", config_path.display());
+            return WatchMonitorConfig::default();
+        }
+    };
+    let Some(block) = config.get("autonomous").and_then(|a| a.get("watchMonitor")) else {
+        return WatchMonitorConfig::default();
+    };
+    WatchMonitorConfig {
+        enabled: block.get("enabled").and_then(serde_json::Value::as_bool),
+        interval_secs: block
+            .get("intervalSecs")
+            .and_then(serde_json::Value::as_u64)
+            .filter(|&s| s > 0),
+        // expirySecs 0 is a *meaningful* value (disable expiry), so it is NOT
+        // filtered out like intervalSecs.
+        expiry_secs: block.get("expirySecs").and_then(serde_json::Value::as_u64),
+    }
+}
+
+/// Resolve whether the loop is enabled: **env > config > default(true)**.
+#[must_use]
+pub fn resolve_enabled(config: &WatchMonitorConfig) -> bool {
+    if let Ok(v) = std::env::var(WATCH_MONITOR_ENABLE_ENV) {
+        return matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on");
+    }
+    config.enabled.unwrap_or(true)
+}
+
+/// Resolve the poll cadence: **env > config > default**. A zero/unparseable env
+/// value falls through rather than busy-looping.
+#[must_use]
+pub fn resolve_interval(config: &WatchMonitorConfig) -> Duration {
+    std::env::var(WATCH_MONITOR_INTERVAL_ENV)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|&s| s > 0)
+        .or(config.interval_secs)
+        .map_or_else(
+            || Duration::from_secs(DEFAULT_WATCH_MONITOR_INTERVAL_SECS),
+            Duration::from_secs,
+        )
+}
+
+/// Resolve the expiry window: **env > config > default**. `0` (env or config) is
+/// honored as "expiry disabled".
+#[must_use]
+pub fn resolve_expiry(config: &WatchMonitorConfig) -> Duration {
+    let secs = std::env::var(WATCH_MONITOR_EXPIRY_ENV)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .or(config.expiry_secs)
+        .unwrap_or(DEFAULT_WATCH_MONITOR_EXPIRY_SECS);
+    Duration::from_secs(secs)
+}
+
+// ============================================================================
+// Runtime wiring
+// ============================================================================
+
+/// Spawn the watch-monitor loop on the shared daemon runtime. Each tick loads the
+/// persisted registry, runs one [`tick`] with the given `probe`, appends every
+/// resolved [`WatchResult`] to the durable results log, and re-saves the registry
+/// (only when something changed). The probe runs on a blocking thread (it shells
+/// out to `gh`) so it never parks a runtime worker.
+///
+/// A completely empty registry short-circuits to a no-op (no forge calls), so the
+/// default-on loop costs a single file read per tick until an operator registers
+/// a watch.
+pub fn spawn_watch_monitor_task<P>(
+    probe: P,
+    interval: Duration,
+    expiry: Duration,
+) -> tokio::task::JoinHandle<()>
+where
+    P: WatchProbe + Send + Sync + 'static,
+{
+    log::info!(
+        "watch_monitor: starting loop (interval={}s, expiry={}s)",
+        interval.as_secs(),
+        expiry.as_secs()
+    );
+    tokio::spawn(async move {
+        let probe = std::sync::Arc::new(probe);
+        let mut ticker = tokio::time::interval(interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            ticker.tick().await;
+            let probe = probe.clone();
+            let joined = tokio::task::spawn_blocking(move || run_one_tick(&*probe, expiry)).await;
+            if let Err(e) = joined {
+                log::error!("watch_monitor: tick task panicked ({e}); stopping loop");
+                return;
+            }
+        }
+    })
+}
+
+/// Execute a single monitor tick against the default (env-overridable) paths.
+/// Best-effort throughout — an I/O error is logged and the tick returns.
+pub fn run_one_tick<P: WatchProbe>(probe: &P, expiry: Duration) {
+    let watches_path = match default_watches_path() {
+        Ok(p) => p,
+        Err(e) => {
+            log::warn!("watch_monitor: cannot resolve watches path ({e}); skipping tick");
+            return;
+        }
+    };
+    let mut registry = load(&watches_path);
+    if registry.watches.is_empty() {
+        return; // no watches → no forge calls
+    }
+    let resolved = tick(&mut registry, probe, Utc::now(), expiry);
+    if resolved.is_empty() {
+        return; // nothing changed → no writes
+    }
+    if let Ok(log_path) = default_results_log_path() {
+        for result in &resolved {
+            if let Err(e) = append_result(&log_path, result) {
+                log::error!("watch_monitor: failed to append result for {}: {e}", result.summary);
+            } else {
+                log::info!("watch_monitor: {}", result.summary);
+            }
+        }
+    }
+    if let Err(e) = save(&watches_path, &registry) {
+        log::error!("watch_monitor: failed to persist watches after resolution: {e}");
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::sync::Mutex;
+    use tempfile::tempdir;
+
+    fn spec(kind: WatchKind, number: u32, repo: Option<&str>) -> WatchSpec {
+        WatchSpec {
+            id: format!("watch-{}-{number}", kind.as_str()),
+            kind,
+            number,
+            repo: repo.map(String::from),
+            workspace_root: None,
+            note: None,
+            registered_at: Utc::now(),
+        }
+    }
+
+    // ---- classify_view ----
+
+    #[test]
+    fn classify_closed_issue() {
+        let json = br#"{"state":"CLOSED","labels":[]}"#;
+        assert_eq!(classify_view(WatchKind::Issue, json), Some(WatchOutcome::Closed));
+    }
+
+    #[test]
+    fn classify_merged_pr() {
+        let json = br#"{"state":"MERGED","labels":[]}"#;
+        assert_eq!(classify_view(WatchKind::Pr, json), Some(WatchOutcome::Merged));
+    }
+
+    #[test]
+    fn classify_open_is_none() {
+        let json = br#"{"state":"OPEN","labels":[{"name":"loom:building"}]}"#;
+        assert_eq!(classify_view(WatchKind::Issue, json), None);
+    }
+
+    #[test]
+    fn classify_open_but_blocked() {
+        let json = br#"{"state":"OPEN","labels":[{"name":"loom:blocked"}]}"#;
+        assert_eq!(classify_view(WatchKind::Issue, json), Some(WatchOutcome::Blocked));
+    }
+
+    #[test]
+    fn classify_closed_takes_precedence_over_blocked_label() {
+        // A closed item that also carries loom:blocked reports Closed (its real
+        // terminal state), not Blocked.
+        let json = br#"{"state":"CLOSED","labels":[{"name":"loom:blocked"}]}"#;
+        assert_eq!(classify_view(WatchKind::Issue, json), Some(WatchOutcome::Closed));
+    }
+
+    #[test]
+    fn classify_garbage_is_none() {
+        assert_eq!(classify_view(WatchKind::Issue, b"not json"), None);
+    }
+
+    // ---- persistence ----
+
+    #[test]
+    fn load_missing_is_empty() {
+        let dir = tempdir().unwrap();
+        let reg = load(&dir.path().join("watches.json"));
+        assert!(reg.watches.is_empty());
+        assert_eq!(reg.version, WATCHES_VERSION);
+    }
+
+    #[test]
+    fn load_corrupt_is_empty_not_error() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("watches.json");
+        std::fs::write(&path, "{ not json").unwrap();
+        assert!(load(&path).watches.is_empty());
+    }
+
+    #[test]
+    fn save_then_load_round_trips() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nested").join("watches.json");
+        let mut reg = WatchRegistry::default();
+        reg.watches
+            .push(spec(WatchKind::Issue, 6193, Some("rjwalters/vibesql")));
+        save(&path, &reg).unwrap();
+        let back = load(&path);
+        assert_eq!(back.watches.len(), 1);
+        assert_eq!(back.watches[0].number, 6193);
+        assert_eq!(back.watches[0].repo.as_deref(), Some("rjwalters/vibesql"));
+    }
+
+    #[test]
+    fn append_result_is_jsonl() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("logs").join("watch-results.log");
+        let r1 =
+            make_result(&spec(WatchKind::Issue, 1, Some("a/b")), WatchOutcome::Closed, Utc::now());
+        let r2 =
+            make_result(&spec(WatchKind::Pr, 2, Some("a/b")), WatchOutcome::Merged, Utc::now());
+        append_result(&path, &r1).unwrap();
+        append_result(&path, &r2).unwrap();
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = contents.lines().collect();
+        assert_eq!(lines.len(), 2);
+        let parsed: WatchResult = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(parsed.outcome, WatchOutcome::Closed);
+        assert!(lines[1].contains("merged"));
+    }
+
+    // ---- dedup ----
+
+    #[test]
+    fn add_dedups_on_target_kind_number() {
+        let mut reg = WatchRegistry::default();
+        let (_, new1) = reg.add(new_watch(WatchKind::Issue, 42, Some("a/b".into()), None, None));
+        assert!(new1);
+        let (existing, new2) =
+            reg.add(new_watch(WatchKind::Issue, 42, Some("a/b".into()), None, None));
+        assert!(!new2, "same target/kind/number should dedup");
+        assert_eq!(reg.watches.len(), 1);
+        assert_eq!(existing.number, 42);
+        // Different repo is a distinct watch.
+        let (_, new3) = reg.add(new_watch(WatchKind::Issue, 42, Some("c/d".into()), None, None));
+        assert!(new3);
+        assert_eq!(reg.watches.len(), 2);
+        // Different kind is distinct.
+        let (_, new4) = reg.add(new_watch(WatchKind::Pr, 42, Some("a/b".into()), None, None));
+        assert!(new4);
+        assert_eq!(reg.watches.len(), 3);
+    }
+
+    #[test]
+    fn remove_by_id() {
+        let mut reg = WatchRegistry::default();
+        let (s, _) = reg.add(new_watch(WatchKind::Issue, 1, None, None, None));
+        assert!(reg.remove(&s.id));
+        assert!(!reg.remove(&s.id));
+        assert!(reg.watches.is_empty());
+    }
+
+    // ---- tick ----
+
+    /// Fake probe returning scripted outcomes keyed by watch number.
+    struct FakeProbe {
+        by_number: std::collections::HashMap<u32, Result<Option<WatchOutcome>, ()>>,
+        calls: Mutex<Vec<u32>>,
+    }
+    impl WatchProbe for FakeProbe {
+        fn probe(&self, spec: &WatchSpec) -> Result<Option<WatchOutcome>> {
+            self.calls.lock().unwrap().push(spec.number);
+            match self.by_number.get(&spec.number) {
+                Some(Ok(o)) => Ok(*o),
+                Some(Err(())) => Err(anyhow::anyhow!("boom")),
+                None => Ok(None),
+            }
+        }
+    }
+
+    #[test]
+    fn tick_resolves_terminal_and_retains_open() {
+        let mut reg = WatchRegistry::default();
+        reg.add(new_watch(
+            WatchKind::Issue,
+            1,
+            Some("a/b".into()),
+            None,
+            Some("done soon".into()),
+        ));
+        reg.add(new_watch(WatchKind::Issue, 2, Some("a/b".into()), None, None));
+        reg.add(new_watch(WatchKind::Pr, 3, Some("a/b".into()), None, None));
+
+        let mut by_number = std::collections::HashMap::new();
+        by_number.insert(1, Ok(Some(WatchOutcome::Closed)));
+        by_number.insert(2, Ok(None)); // still open
+        by_number.insert(3, Ok(Some(WatchOutcome::Merged)));
+        let probe = FakeProbe {
+            by_number,
+            calls: Mutex::new(Vec::new()),
+        };
+
+        let resolved = tick(&mut reg, &probe, Utc::now(), Duration::from_secs(0));
+        assert_eq!(resolved.len(), 2);
+        // The still-open watch (#2) remains.
+        assert_eq!(reg.watches.len(), 1);
+        assert_eq!(reg.watches[0].number, 2);
+        // Summary embeds the note.
+        let closed = resolved.iter().find(|r| r.number == 1).unwrap();
+        assert_eq!(closed.outcome, WatchOutcome::Closed);
+        assert!(closed.summary.contains("done soon"), "{}", closed.summary);
+    }
+
+    #[test]
+    fn tick_retains_watch_on_probe_error() {
+        let mut reg = WatchRegistry::default();
+        reg.add(new_watch(WatchKind::Issue, 9, Some("a/b".into()), None, None));
+        let mut by_number = std::collections::HashMap::new();
+        by_number.insert(9u32, Err(()));
+        let probe = FakeProbe {
+            by_number,
+            calls: Mutex::new(Vec::new()),
+        };
+        let resolved = tick(&mut reg, &probe, Utc::now(), Duration::from_secs(0));
+        assert!(resolved.is_empty());
+        assert_eq!(reg.watches.len(), 1, "a failing probe retains the watch");
+    }
+
+    #[test]
+    fn tick_expires_stale_watch() {
+        let mut reg = WatchRegistry::default();
+        let mut s = new_watch(WatchKind::Issue, 5, Some("a/b".into()), None, None);
+        s.registered_at = Utc::now() - chrono::Duration::seconds(1000);
+        reg.watches.push(s);
+        let probe = FakeProbe {
+            by_number: std::collections::HashMap::new(), // always Ok(None)
+            calls: Mutex::new(Vec::new()),
+        };
+        // expiry 500s, watch is 1000s old → expired.
+        let resolved = tick(&mut reg, &probe, Utc::now(), Duration::from_secs(500));
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].outcome, WatchOutcome::Expired);
+        assert!(reg.watches.is_empty());
+    }
+
+    #[test]
+    fn tick_expiry_zero_never_expires() {
+        let mut reg = WatchRegistry::default();
+        let mut s = new_watch(WatchKind::Issue, 5, Some("a/b".into()), None, None);
+        s.registered_at = Utc::now() - chrono::Duration::seconds(1_000_000);
+        reg.watches.push(s);
+        let probe = FakeProbe {
+            by_number: std::collections::HashMap::new(),
+            calls: Mutex::new(Vec::new()),
+        };
+        let resolved = tick(&mut reg, &probe, Utc::now(), Duration::from_secs(0));
+        assert!(resolved.is_empty());
+        assert_eq!(reg.watches.len(), 1, "expiry=0 disables expiry");
+    }
+
+    // ---- config precedence ----
+
+    fn write_config(root: &Path, contents: &str) {
+        std::fs::create_dir_all(root.join(".loom")).unwrap();
+        std::fs::write(root.join(".loom").join("config.json"), contents).unwrap();
+    }
+
+    #[test]
+    fn config_missing_is_default() {
+        let dir = tempdir().unwrap();
+        assert_eq!(read_watch_monitor_config(dir.path()), WatchMonitorConfig::default());
+    }
+
+    #[test]
+    fn config_reads_all_fields() {
+        let dir = tempdir().unwrap();
+        write_config(
+            dir.path(),
+            r#"{"autonomous":{"watchMonitor":{"enabled":false,"intervalSecs":60,"expirySecs":0}}}"#,
+        );
+        assert_eq!(
+            read_watch_monitor_config(dir.path()),
+            WatchMonitorConfig {
+                enabled: Some(false),
+                interval_secs: Some(60),
+                expiry_secs: Some(0),
+            }
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_enabled_default_true() {
+        std::env::remove_var(WATCH_MONITOR_ENABLE_ENV);
+        assert!(resolve_enabled(&WatchMonitorConfig::default()));
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_enabled_env_overrides_config() {
+        std::env::set_var(WATCH_MONITOR_ENABLE_ENV, "0");
+        assert!(!resolve_enabled(&WatchMonitorConfig {
+            enabled: Some(true),
+            ..Default::default()
+        }));
+        std::env::set_var(WATCH_MONITOR_ENABLE_ENV, "1");
+        assert!(resolve_enabled(&WatchMonitorConfig {
+            enabled: Some(false),
+            ..Default::default()
+        }));
+        std::env::remove_var(WATCH_MONITOR_ENABLE_ENV);
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_interval_precedence() {
+        std::env::remove_var(WATCH_MONITOR_INTERVAL_ENV);
+        assert_eq!(
+            resolve_interval(&WatchMonitorConfig::default()),
+            Duration::from_secs(DEFAULT_WATCH_MONITOR_INTERVAL_SECS)
+        );
+        assert_eq!(
+            resolve_interval(&WatchMonitorConfig {
+                interval_secs: Some(300),
+                ..Default::default()
+            }),
+            Duration::from_secs(300)
+        );
+        std::env::set_var(WATCH_MONITOR_INTERVAL_ENV, "45");
+        assert_eq!(
+            resolve_interval(&WatchMonitorConfig {
+                interval_secs: Some(300),
+                ..Default::default()
+            }),
+            Duration::from_secs(45)
+        );
+        std::env::remove_var(WATCH_MONITOR_INTERVAL_ENV);
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_expiry_zero_is_honored() {
+        std::env::remove_var(WATCH_MONITOR_EXPIRY_ENV);
+        // Config 0 → disabled (not treated as "unset").
+        assert_eq!(
+            resolve_expiry(&WatchMonitorConfig {
+                expiry_secs: Some(0),
+                ..Default::default()
+            }),
+            Duration::from_secs(0)
+        );
+        // Absent everywhere → default.
+        assert_eq!(
+            resolve_expiry(&WatchMonitorConfig::default()),
+            Duration::from_secs(DEFAULT_WATCH_MONITOR_EXPIRY_SECS)
+        );
+        // Env overrides config.
+        std::env::set_var(WATCH_MONITOR_EXPIRY_ENV, "10");
+        assert_eq!(
+            resolve_expiry(&WatchMonitorConfig {
+                expiry_secs: Some(999),
+                ..Default::default()
+            }),
+            Duration::from_secs(10)
+        );
+        std::env::remove_var(WATCH_MONITOR_EXPIRY_ENV);
+    }
+
+    // ---- run_one_tick integration (env-driven paths) ----
+
+    #[test]
+    #[serial]
+    fn run_one_tick_appends_and_persists() {
+        let dir = tempdir().unwrap();
+        let watches = dir.path().join("watches.json");
+        let results = dir.path().join("watch-results.log");
+        std::env::set_var(WATCHES_PATH_ENV, &watches);
+        std::env::set_var(RESULTS_LOG_PATH_ENV, &results);
+
+        let mut reg = WatchRegistry::default();
+        reg.add(new_watch(WatchKind::Issue, 6193, Some("rjwalters/vibesql".into()), None, None));
+        reg.add(new_watch(WatchKind::Issue, 3964, Some("rjwalters/loom".into()), None, None));
+        save(&watches, &reg).unwrap();
+
+        let mut by_number = std::collections::HashMap::new();
+        by_number.insert(6193u32, Ok(Some(WatchOutcome::Closed)));
+        by_number.insert(3964u32, Ok(None)); // still open
+        let probe = FakeProbe {
+            by_number,
+            calls: Mutex::new(Vec::new()),
+        };
+
+        run_one_tick(&probe, Duration::from_secs(0));
+
+        // One result appended; the still-open watch persists.
+        let log = std::fs::read_to_string(&results).unwrap();
+        assert_eq!(log.lines().count(), 1);
+        assert!(log.contains("6193"));
+        let after = load(&watches);
+        assert_eq!(after.watches.len(), 1);
+        assert_eq!(after.watches[0].number, 3964);
+
+        std::env::remove_var(WATCHES_PATH_ENV);
+        std::env::remove_var(RESULTS_LOG_PATH_ENV);
+    }
+
+    #[test]
+    #[serial]
+    fn run_one_tick_empty_registry_is_noop() {
+        let dir = tempdir().unwrap();
+        let watches = dir.path().join("watches.json");
+        let results = dir.path().join("watch-results.log");
+        std::env::set_var(WATCHES_PATH_ENV, &watches);
+        std::env::set_var(RESULTS_LOG_PATH_ENV, &results);
+
+        // No watches file at all.
+        let probe = FakeProbe {
+            by_number: std::collections::HashMap::new(),
+            calls: Mutex::new(Vec::new()),
+        };
+        run_one_tick(&probe, Duration::from_secs(0));
+        assert!(!results.exists(), "no results log written for an empty registry");
+        assert!(probe.calls.lock().unwrap().is_empty(), "no probe calls for empty registry");
+
+        std::env::remove_var(WATCHES_PATH_ENV);
+        std::env::remove_var(RESULTS_LOG_PATH_ENV);
+    }
+}

--- a/loom-daemon/src/watch_registry.rs
+++ b/loom-daemon/src/watch_registry.rs
@@ -51,7 +51,7 @@ use serde::{Deserialize, Serialize};
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 // ============================================================================
 // Constants
@@ -329,7 +329,16 @@ pub fn save(path: &Path, registry: &WatchRegistry) -> Result<()> {
     }
     let mut json = serde_json::to_string_pretty(registry)?;
     json.push('\n');
-    let tmp = path.with_extension(format!("json.tmp.{}", std::process::id()));
+    // Unique-per-writer temp name: all in-process writers (the monitor task and
+    // every IPC handler task) share `std::process::id()`, so a PID-only suffix
+    // would collide under intra-daemon concurrency and defeat the atomic-rename
+    // guarantee. Appending a fresh uuid makes each writer's temp path unique
+    // (belt-and-suspenders alongside the watches-file lock below).
+    let tmp = path.with_extension(format!(
+        "json.tmp.{}.{}",
+        std::process::id(),
+        uuid::Uuid::new_v4().simple()
+    ));
     std::fs::write(&tmp, json.as_bytes())
         .with_context(|| format!("writing temp watches file {}", tmp.display()))?;
     std::fs::rename(&tmp, path)
@@ -356,6 +365,108 @@ pub fn append_result(path: &Path, result: &WatchResult) -> Result<()> {
     file.write_all(line.as_bytes())
         .with_context(|| format!("appending to results log {}", path.display()))?;
     Ok(())
+}
+
+// ============================================================================
+// Concurrency guard (mkdir-based lock on watches.json)
+// ============================================================================
+//
+// `watches.json` has **two independent concurrent writers** inside one daemon
+// process: the background monitor loop and the IPC `RegisterWatch`/`RemoveWatch`
+// handlers (each IPC connection is its own `tokio::spawn`). Nothing else
+// serializes them, so a naive load→modify→save from each has a lost-update
+// window (a watch registered while the monitor is mid-tick could be silently
+// dropped when the monitor saves). We serialize the whole load→modify→save
+// critical section with a `mkdir`-based lock — POSIX-atomic and macOS-safe
+// (`flock` is deliberately avoided; not available on stock macOS), matching the
+// convention CLAUDE.md documents for `.bad_tokens`/`.allowlist`.
+
+/// How long a writer waits to acquire the watches-file lock before giving up.
+const DEFAULT_LOCK_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// A held lock older than this is presumed abandoned by a crashed writer and is
+/// stolen (an mkdir lock has no OS-level auto-release on process death).
+const STALE_LOCK_AGE: Duration = Duration::from_secs(60);
+
+/// Sibling lock-directory path for a watches file (`<path>.lock`).
+fn lock_dir_for(path: &Path) -> PathBuf {
+    let mut os = path.as_os_str().to_owned();
+    os.push(".lock");
+    PathBuf::from(os)
+}
+
+/// RAII guard holding the mkdir-based watches-file lock; releases (removes the
+/// lock directory) on drop.
+pub struct WatchLock {
+    dir: PathBuf,
+}
+
+impl Drop for WatchLock {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir(&self.dir);
+    }
+}
+
+/// Acquire the mkdir-based lock guarding `watches_path`, retrying until
+/// `timeout`. A lock directory older than [`STALE_LOCK_AGE`] is treated as
+/// abandoned (a writer crashed before releasing) and stolen.
+fn acquire_watch_lock(watches_path: &Path, timeout: Duration) -> Result<WatchLock> {
+    let dir = lock_dir_for(watches_path);
+    if let Some(parent) = dir.parent() {
+        // Best-effort: the save path also creates this, but the lock must exist
+        // first, so ensure the parent is present up front.
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let start = Instant::now();
+    loop {
+        match std::fs::create_dir(&dir) {
+            Ok(()) => return Ok(WatchLock { dir }),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                // Stale-lock breaker: steal a lock whose dir is older than the
+                // presumed-crash window so a crashed writer can't wedge us.
+                if let Ok(meta) = std::fs::metadata(&dir) {
+                    if let Ok(modified) = meta.modified() {
+                        if modified
+                            .elapsed()
+                            .map(|age| age > STALE_LOCK_AGE)
+                            .unwrap_or(false)
+                        {
+                            log::warn!(
+                                "watch_registry: stealing stale lock at {} (older than {}s)",
+                                dir.display(),
+                                STALE_LOCK_AGE.as_secs()
+                            );
+                            let _ = std::fs::remove_dir(&dir);
+                            continue;
+                        }
+                    }
+                }
+                if start.elapsed() >= timeout {
+                    return Err(anyhow::anyhow!(
+                        "timed out after {}s acquiring watches lock at {}",
+                        timeout.as_secs(),
+                        dir.display()
+                    ));
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            Err(e) => {
+                return Err(e).with_context(|| format!("creating lock dir {}", dir.display()))
+            }
+        }
+    }
+}
+
+/// Run `f` while holding the watches-file lock (acquired with the default
+/// timeout), releasing it on return. The critical section MUST be short — never
+/// hold this across a `gh` probe (see [`run_one_tick`], which probes lock-free
+/// and only takes the lock for the fast reload-merge-save).
+pub fn with_watches_lock<T, F>(watches_path: &Path, f: F) -> Result<T>
+where
+    F: FnOnce() -> Result<T>,
+{
+    let _guard = acquire_watch_lock(watches_path, DEFAULT_LOCK_TIMEOUT)?;
+    f()
 }
 
 // ============================================================================
@@ -735,6 +846,10 @@ pub fn run_one_tick<P: WatchProbe>(probe: &P, expiry: Duration) {
             return;
         }
     };
+    // Snapshot lock-free: probing shells out to `gh` (seconds, up to the 30s
+    // timeout per watch), and holding the watches lock across that would block
+    // every IPC register/remove for the whole tick. We probe against a snapshot
+    // and only take the lock for the fast reload-merge-save below.
     let mut registry = load(&watches_path);
     if registry.watches.is_empty() {
         return; // no watches → no forge calls
@@ -743,6 +858,8 @@ pub fn run_one_tick<P: WatchProbe>(probe: &P, expiry: Duration) {
     if resolved.is_empty() {
         return; // nothing changed → no writes
     }
+    // Append to the durable (append-only, O_APPEND) results log first; it is
+    // concurrency-safe on its own and never needs the watches lock.
     if let Ok(log_path) = default_results_log_path() {
         for result in &resolved {
             if let Err(e) = append_result(&log_path, result) {
@@ -752,7 +869,21 @@ pub fn run_one_tick<P: WatchProbe>(probe: &P, expiry: Duration) {
             }
         }
     }
-    if let Err(e) = save(&watches_path, &registry) {
+    // Persist under the lock, but re-load a FRESH copy from disk first and drop
+    // only the ids we actually resolved — never blindly overwrite with our stale
+    // in-memory snapshot. An IPC `RegisterWatch` that landed while we were
+    // probing is merged in (it is present in the fresh load and is not one of
+    // the resolved ids), so a concurrent registration is never lost.
+    let resolved_ids: std::collections::HashSet<&str> =
+        resolved.iter().map(|r| r.id.as_str()).collect();
+    let persist = with_watches_lock(&watches_path, || {
+        let mut fresh = load(&watches_path);
+        fresh
+            .watches
+            .retain(|w| !resolved_ids.contains(w.id.as_str()));
+        save(&watches_path, &fresh)
+    });
+    if let Err(e) = persist {
         log::error!("watch_monitor: failed to persist watches after resolution: {e}");
     }
 }
@@ -1158,6 +1289,65 @@ mod tests {
         run_one_tick(&probe, Duration::from_secs(0));
         assert!(!results.exists(), "no results log written for an empty registry");
         assert!(probe.calls.lock().unwrap().is_empty(), "no probe calls for empty registry");
+
+        std::env::remove_var(WATCHES_PATH_ENV);
+        std::env::remove_var(RESULTS_LOG_PATH_ENV);
+    }
+
+    // ---- concurrency: register-during-resolving-tick (Issue #3971 durability) ----
+
+    /// Regression for the lost-update window the Judge flagged: a
+    /// `RegisterWatch` that lands while the monitor is mid-tick (blocked on a
+    /// slow `gh` probe) must survive the tick's subsequent save. Without the
+    /// reload-merge under the watches-file lock, the monitor would persist its
+    /// stale in-memory snapshot and silently drop the just-registered watch.
+    ///
+    /// The `RegisteringProbe` stands in for the racing IPC handler: while
+    /// probing watch A (which resolves `Closed`), it performs exactly the
+    /// lock→load→add→save that `handle_register_watch` does, registering B. B
+    /// must still be present after the tick completes.
+    #[test]
+    #[serial]
+    fn concurrent_register_during_resolving_tick_is_not_lost() {
+        let dir = tempdir().unwrap();
+        let watches = dir.path().join("watches.json");
+        let results = dir.path().join("watch-results.log");
+        std::env::set_var(WATCHES_PATH_ENV, &watches);
+        std::env::set_var(RESULTS_LOG_PATH_ENV, &results);
+
+        // Registry starts with A (#1), which resolves Closed this tick.
+        let mut reg = WatchRegistry::default();
+        reg.add(new_watch(WatchKind::Issue, 1, Some("a/b".into()), None, None));
+        save(&watches, &reg).unwrap();
+
+        struct RegisteringProbe {
+            watches: PathBuf,
+        }
+        impl WatchProbe for RegisteringProbe {
+            fn probe(&self, _spec: &WatchSpec) -> Result<Option<WatchOutcome>> {
+                // Simulate a concurrent RegisterWatch(B, #2) landing mid-probe,
+                // via the same guarded critical section the IPC handler uses.
+                with_watches_lock(&self.watches, || {
+                    let mut r = load(&self.watches);
+                    r.add(new_watch(WatchKind::Issue, 2, Some("a/b".into()), None, None));
+                    save(&self.watches, &r)
+                })
+                .unwrap();
+                Ok(Some(WatchOutcome::Closed))
+            }
+        }
+
+        run_one_tick(
+            &RegisteringProbe {
+                watches: watches.clone(),
+            },
+            Duration::from_secs(0),
+        );
+
+        // A (#1) resolved and was dropped; B (#2), registered mid-tick, survives.
+        let after = load(&watches);
+        let numbers: Vec<u32> = after.watches.iter().map(|w| w.number).collect();
+        assert_eq!(numbers, vec![2], "watch registered during a resolving tick must not be lost");
 
         std::env::remove_var(WATCHES_PATH_ENV);
         std::env::remove_var(RESULTS_LOG_PATH_ENV);

--- a/mcp-loom/README.md
+++ b/mcp-loom/README.md
@@ -84,6 +84,19 @@ These tools front the Rust `loom-daemon` (Tier 2) over its Unix-socket IPC and b
 | `subscribe_to_events` | Stream topic-filtered events to a subscriber |
 | `tail_event_bus` | Tail the event bus without subscribing to a topic |
 
+### Durable Watches (3 tools)
+
+These tools register durable operator watches on issue/PR terminal state (#3971).
+A watch is persisted machine-level by the long-lived `loom-daemon`, so it survives
+the registering session's death **and** a daemon restart; resolutions are appended
+to `~/.loom/logs/watch-results.log`.
+
+| Tool | Description |
+|------|-------------|
+| `register_watch` | Register a durable watch on an issue/PR (cross-repo via `repo`/`workspace_root`; idempotent) |
+| `list_watches` | List active durable watches |
+| `remove_watch` | Remove a watch by id |
+
 > **If these tools are missing from a live session**, `dist/index.js` is almost
 > certainly a **stale build** predating the sweep tools. See
 > [Rebuilding after source changes](#rebuilding-after-source-changes-reconnect-required).

--- a/mcp-loom/src/tools/sweeps.ts
+++ b/mcp-loom/src/tools/sweeps.ts
@@ -188,6 +188,51 @@ interface EventPublishedResponse {
   };
 }
 
+/**
+ * `WatchKind` mirrors the Rust enum in `loom-daemon/src/watch_registry.rs`
+ * (serde `rename_all = "snake_case"`): `"issue"` or `"pr"`.
+ */
+export type WatchKind = "issue" | "pr";
+
+/**
+ * `WatchSpec` mirrors the Rust struct of the same name (issue #3971): one
+ * durable operator watch on an issue's or PR's terminal state, persisted
+ * machine-level so it survives the registering session's death and a daemon
+ * restart.
+ */
+export interface WatchSpec {
+  id: string;
+  kind: WatchKind;
+  number: number;
+  repo?: string;
+  workspace_root?: string;
+  note?: string;
+  registered_at: string;
+}
+
+interface WatchRegisteredResponse {
+  type: "WatchRegistered";
+  payload: {
+    watch: WatchSpec;
+    already_present: boolean;
+  };
+}
+
+interface WatchListResponse {
+  type: "WatchList";
+  payload: {
+    watches: WatchSpec[];
+  };
+}
+
+interface WatchRemovedResponse {
+  type: "WatchRemoved";
+  payload: {
+    id: string;
+    was_present: boolean;
+  };
+}
+
 type DaemonResponse =
   | DispatchResponse
   | ListResponse
@@ -195,6 +240,9 @@ type DaemonResponse =
   | SweepLogTailResponse
   | SweepCancelledResponse
   | EventPublishedResponse
+  | WatchRegisteredResponse
+  | WatchListResponse
+  | WatchRemovedResponse
   | ErrorResponse
   | StructuredErrorResponse
   | { type: string; payload?: unknown };
@@ -350,6 +398,75 @@ async function listSweeps(args: {
     return { success: false, error: err ?? `Unexpected response: ${response.type}` };
   } catch (error) {
     return { success: false, error: `Error listing sweeps: ${error}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Durable watch registry helpers (Issue #3971)
+// ---------------------------------------------------------------------------
+
+async function registerWatch(args: {
+  kind: WatchKind;
+  number: number;
+  repo?: string;
+  workspace_root?: string;
+  note?: string;
+}): Promise<
+  { success: true; watch: WatchSpec; already_present: boolean } | { success: false; error: string }
+> {
+  try {
+    const response = (await sendDaemonRequest({
+      type: "RegisterWatch",
+      payload: {
+        kind: args.kind,
+        number: args.number,
+        repo: args.repo ?? null,
+        workspace_root: args.workspace_root ?? null,
+        note: args.note ?? null,
+      },
+    })) as DaemonResponse;
+
+    if (response.type === "WatchRegistered") {
+      const payload = (response as WatchRegisteredResponse).payload;
+      return { success: true, watch: payload.watch, already_present: payload.already_present };
+    }
+    const err = extractError(response);
+    return { success: false, error: err ?? `Unexpected response: ${response.type}` };
+  } catch (error) {
+    return { success: false, error: `Error registering watch: ${error}` };
+  }
+}
+
+async function listWatches(): Promise<
+  { success: true; watches: WatchSpec[] } | { success: false; error: string }
+> {
+  try {
+    const response = (await sendDaemonRequest({ type: "ListWatches" })) as DaemonResponse;
+    if (response.type === "WatchList") {
+      return { success: true, watches: (response as WatchListResponse).payload.watches };
+    }
+    const err = extractError(response);
+    return { success: false, error: err ?? `Unexpected response: ${response.type}` };
+  } catch (error) {
+    return { success: false, error: `Error listing watches: ${error}` };
+  }
+}
+
+async function removeWatch(args: {
+  id: string;
+}): Promise<{ success: true; was_present: boolean } | { success: false; error: string }> {
+  try {
+    const response = (await sendDaemonRequest({
+      type: "RemoveWatch",
+      payload: { id: args.id },
+    })) as DaemonResponse;
+    if (response.type === "WatchRemoved") {
+      return { success: true, was_present: (response as WatchRemovedResponse).payload.was_present };
+    }
+    const err = extractError(response);
+    return { success: false, error: err ?? `Unexpected response: ${response.type}` };
+  } catch (error) {
+    return { success: false, error: `Error removing watch: ${error}` };
   }
 }
 
@@ -802,6 +919,73 @@ export const sweepTools: Tool[] = [
             "reached, whichever comes first.",
         },
       },
+    },
+  },
+  {
+    name: "register_watch",
+    description:
+      "Register a DURABLE watch on an issue's or PR's terminal state (issue " +
+      "#3971). Unlike an in-session background poll — which dies when the " +
+      "operator's Claude Code session crashes — this watch is persisted by the " +
+      "long-lived loom-daemon (`~/.loom/watches.json`), so it survives both the " +
+      "registering session AND a daemon restart. The daemon polls the forge and, " +
+      "when the target reaches a terminal state (closed / merged / blocked) or " +
+      "the expiry window elapses, appends a result line to " +
+      "`~/.loom/logs/watch-results.log` — a file a later session can trivially " +
+      "read. Works cross-repo: pass `repo` (a forge slug `owner/name`) to watch " +
+      "an issue in a repo this machine may not even manage. Idempotent — " +
+      "re-registering the same target returns the existing watch.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        number: { type: "number", description: "The issue or PR number to watch." },
+        kind: {
+          type: "string",
+          enum: ["issue", "pr"],
+          description: "Whether `number` is an issue or a pull request. Defaults to `issue`.",
+        },
+        repo: {
+          type: "string",
+          description:
+            "Forge slug `owner/name` (preferred — works cross-repo). Omit to " +
+            "resolve from `workspace_root` or the daemon's own cwd.",
+        },
+        workspace_root: {
+          type: "string",
+          description:
+            "Managed-workspace root the `gh` query runs in when `repo` is " +
+            "absent (mirrors the `workspace_root` param on dispatch_sweep / " +
+            "list_sweeps).",
+        },
+        note: {
+          type: "string",
+          description: "Optional note surfaced in the recorded result line.",
+        },
+      },
+      required: ["number"],
+    },
+  },
+  {
+    name: "list_watches",
+    description:
+      "List the durable watches currently registered with the loom-daemon " +
+      "(issue #3971). Returns a JSON array of WatchSpec records. Resolved " +
+      "watches are removed from this list and recorded in " +
+      "`~/.loom/logs/watch-results.log`.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "remove_watch",
+    description:
+      "Remove a registered durable watch by its id (issue #3971), as printed " +
+      "by `register_watch` / `list_watches`. Removing an unknown id is a no-op " +
+      "success.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: { type: "string", description: "The watch id to remove." },
+      },
+      required: ["id"],
     },
   },
 ];
@@ -1296,6 +1480,97 @@ export async function handleSweepTool(
           text: `=== Tail Event Bus ===\n\n${summary}\n\nFrames:\n${body}`,
         },
       ];
+    }
+
+    case "register_watch": {
+      const number =
+        typeof args?.number === "number" && Number.isInteger(args.number) && args.number > 0
+          ? (args.number as number)
+          : undefined;
+      if (number === undefined) {
+        return [
+          {
+            type: "text",
+            text: "=== Register Watch ===\n\nFailed\n\nError: `number` is required (a positive integer issue/PR number).",
+          },
+        ];
+      }
+      const kind: WatchKind = args?.kind === "pr" ? "pr" : "issue";
+      const repo =
+        typeof args?.repo === "string" && args.repo.length > 0 ? (args.repo as string) : undefined;
+      const note =
+        typeof args?.note === "string" && args.note.length > 0 ? (args.note as string) : undefined;
+
+      const result = await registerWatch({
+        kind,
+        number,
+        repo,
+        workspace_root: extractWorkspaceRoot(args),
+        note,
+      });
+      if (!result.success) {
+        return [{ type: "text", text: `=== Register Watch ===\n\nFailed\n\n${result.error}` }];
+      }
+      const w = result.watch;
+      const where = w.repo ?? w.workspace_root ?? "default workspace";
+      const status = result.already_present ? "Already watching (no-op)" : "Registered";
+      const body = [
+        `Watch ID:   ${w.id}`,
+        `Target:     ${w.kind} #${w.number} in ${where}`,
+        w.note ? `Note:       ${w.note}` : null,
+        "Terminal state will be recorded to ~/.loom/logs/watch-results.log",
+      ]
+        .filter((l): l is string => l !== null)
+        .join("\n");
+      return [{ type: "text", text: `=== Register Watch ===\n\n${status}\n\n${body}` }];
+    }
+
+    case "list_watches": {
+      const result = await listWatches();
+      if (!result.success) {
+        return [{ type: "text", text: `=== List Watches ===\n\nFailed\n\n${result.error}` }];
+      }
+      if (result.watches.length === 0) {
+        return [
+          {
+            type: "text",
+            text: "=== List Watches ===\n\nSuccess\n\nNo durable watches registered.",
+          },
+        ];
+      }
+      const body = result.watches
+        .map((w) => {
+          const where = w.repo ?? w.workspace_root ?? "default workspace";
+          const note = w.note ? ` — ${w.note}` : "";
+          return `* ${w.id}\n  ${w.kind} #${w.number} in ${where}${note}`;
+        })
+        .join("\n");
+      return [
+        {
+          type: "text",
+          text: `=== List Watches ===\n\nSuccess (${result.watches.length})\n\n${body}`,
+        },
+      ];
+    }
+
+    case "remove_watch": {
+      const id = typeof args?.id === "string" && args.id.length > 0 ? (args.id as string) : undefined;
+      if (id === undefined) {
+        return [
+          {
+            type: "text",
+            text: "=== Remove Watch ===\n\nFailed\n\nError: `id` is required.",
+          },
+        ];
+      }
+      const result = await removeWatch({ id });
+      if (!result.success) {
+        return [{ type: "text", text: `=== Remove Watch ===\n\nFailed\n\n${result.error}` }];
+      }
+      const msg = result.was_present
+        ? `Removed watch ${id}.`
+        : `No watch with id ${id} — nothing to remove (no-op).`;
+      return [{ type: "text", text: `=== Remove Watch ===\n\nSuccess\n\n${msg}` }];
     }
 
     default:


### PR DESCRIPTION
## Summary

Operator watches on sweep/issue terminal state died with the operator's Claude Code session (session-scoped background polls are children of the session process), silently losing the terminal-state report until the next session reconstructed it from logs. This adds a **daemon-side persistent watch registry** so an operator's registered interest survives their session dying — and a daemon restart.

## What changed

- **New module `loom-daemon/src/watch_registry.rs`**
  - Watches persisted machine-level to `~/.loom/watches.json` (override `LOOM_WATCHES_PATH`) — survives the registering session **and** a daemon restart.
  - A **default-on monitor loop** polls each watch's terminal state and, on a terminal state (`closed`/`merged`/`blocked`) or expiry, **durably appends** a JSON line to `~/.loom/logs/watch-results.log` (override `LOOM_WATCH_RESULTS_LOG`) — a file a later session can trivially `tail` — then drops the watch.
  - **Forge polling** (`gh issue view` / `gh pr view --json state,labels`) rather than the event bus: works cross-repo for a repo the daemon may never have swept, and mints **no new event topic** (the v0.10.0 taxonomy stays frozen). Address a target cross-repo with `repo` (forge slug `owner/name`) or `workspace_root` — the same addressing pattern as `dispatch_sweep` / `list_sweeps`.
- **IPC**: `RegisterWatch` / `ListWatches` / `RemoveWatch` requests + responses (`types.rs`, handlers in `ipc.rs`).
- **MCP tools**: `register_watch` / `list_watches` / `remove_watch` (`mcp-loom/src/tools/sweeps.ts`).
- **CLI**: `loom-daemon watch add|list|remove` over the daemon socket (analogue of the `dispatch` subcommand).
- **Config**: `autonomous.watchMonitor.{enabled,intervalSecs,expirySecs}` (precedence env > config > default; default-on, zero forge calls until a watch is registered — mirrors the token-ranking refresh loop's rationale).
- **Docs**: new `daemon-reference.md` section + config table rows; mcp-loom README tool table.

## Acceptance criteria

- [x] An operator can register a watch that survives their Claude Code session dying — the watch lives in a file the long-lived daemon owns.
- [x] Terminal state (closed/merged/blocked/expired) is durably recorded in `~/.loom/logs/watch-results.log`, trivially findable by a later session.
- [x] Works cross-repo for daemon-managed workspaces (the #6193 case: a vibesql issue watched from the loom operator session) via `repo` / `workspace_root`.
- [x] No new event-bus topics (frozen taxonomy respected).

## Testing

- 25 new Rust tests: `watch_registry` unit (classify/persist/dedup/tick/expiry/config precedence/`run_one_tick` integration) + an IPC roundtrip (`test_watch_registry_ipc_roundtrip`). Full suite: 896 passed.
- `cargo clippy --all-targets` clean; `mcp-loom` `npm run build` (tsc + esbuild) passes.
- Live end-to-end smoke over a real Unix socket: `watch add` (with dedup) → `list` → `remove` all correct, including the cross-repo `rjwalters/vibesql` case.

Closes #3971

🤖 Generated with [Claude Code](https://claude.com/claude-code)