### PR TITLE
feat(tokens): import live account tokens from claude-monitor's store (#4006)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -459,6 +459,42 @@ To *exclude* an inherited account from one repo, pin the subset you want with `l
 
 > **Secrets**: `~/.claude-monitor/accounts.env`, the opt-in `~/.loom/accounts.env`, and the repo-local `.loom/accounts.env` all hold raw OAuth keys. The repo-local file and `.loom/tokens/` are gitignored (installer- and `loom-daemon init`–managed); keep any home-level master `0600` and outside any repo. A repo can rely entirely on the claude-monitor master with no local account file at all.
 
+#### Importing live tokens from claude-monitor (#4006)
+
+`accounts.env` is a **snapshot** — a file someone wrote by hand at some point. claude-monitor keeps the **live** credentials in its SQLite store (`~/.claude-monitor/usage.db` → `oauth_credentials`) and refreshes them as accounts are re-authenticated. The two drift, and the drift is silent and total:
+
+```text
+401 {"type":"authentication_error","message":"OAuth access token has been revoked."}
+```
+
+When that happens to every account at once, `loom-tokens check` reports all accounts `blocked`, the daemon's dynamic concurrency cap collapses to `min(healthy 0 × per-token N, …) = 0`, and dispatch stops entirely. Crucially **`bootstrap --force` does not fix it** — it faithfully rewrites the same revoked tokens, because the snapshot itself is what went stale.
+
+`loom-tokens import-from-monitor` reads the live store directly and is **the standard way to populate a new host's pool** (it replaces hand-copying a pool between machines):
+
+```bash
+loom-tokens import-from-monitor                  # into <repo>/.loom/tokens
+loom-tokens import-from-monitor --shared         # into the machine-level pool (#3938)
+loom-tokens import-from-monitor --force          # apply ROLLED tokens (see below)
+loom-tokens import-from-monitor --dry-run        # preview
+loom-tokens import-from-monitor --prune          # drop accounts the monitor no longer reports
+```
+
+**`--force` is what applies a token roll.** Every rolled token legitimately differs from what is on disk, so without `--force` each one is reported as drift and left alone — deliberately, so a hand-pinned token is never silently clobbered. The command exits `2` when drift was found and not applied, so a script can detect "pool is still stale". After importing, refresh the ranking so the daemon sees the recovered capacity:
+
+```bash
+loom-tokens import-from-monitor --force && loom-tokens check --ranking
+```
+
+Behavior notes:
+
+- **Read-only** on `usage.db` (opened `mode=ro`) — the store belongs to claude-monitor; Loom never writes or migrates it.
+- Only `is_active = 1` rows are imported; `expires_at` is **not** used as a filter (observed rows carry stale timestamps while still authenticating — health comes from `loom-tokens check`).
+- Token filenames use the same derivation as `bootstrap` (`robb@2amlogic.com` → `robb-2amlogic.token`), so an account keeps one identity across both paths and re-importing overwrites in place.
+- Idempotent: unchanged tokens are left untouched. `index.json` records `source: monitor-db` (distinct from the `monitor` snapshot) and, as always, fingerprints only — never secret material.
+- `--prune` removes only `*.token` files; pool state (`.ranking`, `.bad_tokens`, `.failure_counts`, `.allowlist`) is never touched.
+- The importer takes **claude-monitor as authoritative for pool membership**, so it imports every active account — including any that `accounts.env` omitted. Use `loom-tokens pin` to restrict which accounts the selector may actually pick.
+- Absent claude-monitor, an absent `usage.db`, or an older schema without `oauth_credentials` all exit `1` with a message naming the path tried.
+
 #### Account health probe + ranking
 
 Once bootstrapped, `loom-tokens check` probes each account for current rate-limit headers and (optionally) writes a JSON ranking that the spawn-time selector can consume:
@@ -563,6 +599,8 @@ For Pro/Max plans, Loom supports rotating between multiple Claude Code OAuth tok
    ```
    The claude-monitor, repo-local, and (opt-in) home sources are **merged by email**, with the higher-precedence source overriding/adding (see "Account sources: claude-monitor-first + per-repo" above). Keep any home-level master `0600` and outside any repo.
 2. Run `loom-tokens bootstrap` to materialize the merged set into per-account `.token` files in `.loom/tokens/` (mode 0600, parent dir 0700). See issues #3234, #3695.
+
+   **If claude-monitor runs on this host, prefer `loom-tokens import-from-monitor`** — it reads claude-monitor's live credential store instead of the `accounts.env` snapshot, so a new host needs no account file of its own and a token roll is picked up automatically (add `--force` to apply rolled tokens). See "Importing live tokens from claude-monitor" above.
 3. Spawn agents through `.loom/scripts/spawn-claude.sh` instead of invoking `claude` directly. The wrapper selects a token using a 3-tier algorithm (ranking → allowlist → random), exports `CLAUDE_CODE_OAUTH_TOKEN`, then `exec`s `claude` (or pass `--use-wrapper` to layer on top of `claude-wrapper.sh` for retry behavior).
 
 ### Selection algorithm (`loom_tools.tokens.select`)

--- a/loom-tools/src/loom_tools/tokens/bootstrap.py
+++ b/loom-tools/src/loom_tools/tokens/bootstrap.py
@@ -434,6 +434,174 @@ class BootstrapResult:
         }
 
 
+@dataclass
+class MaterializeOutcome:
+    """Per-file disposition from :func:`materialize_accounts`."""
+
+    written: list[str]
+    unchanged: list[str]
+    drifted: list[str]
+    # Manifest rows for ``index.json`` (never contains secret material).
+    manifest_accounts: list[dict[str, object]]
+
+
+def materialize_accounts(
+    accounts: list[Account],
+    tokens_dir: Path,
+    *,
+    force: bool = False,
+    dry_run: bool = False,
+) -> MaterializeOutcome:
+    """Write each account's key to ``<tokens_dir>/<file>`` and build manifest rows.
+
+    Extracted from :func:`bootstrap_tokens` so the claude-monitor DB importer
+    (#4006) materializes pools through the *same* writer: identical atomic
+    write-then-rename, identical ``0600``/``0700`` modes, identical
+    fingerprint-based drift detection, identical ``index.json`` rows. A second
+    hand-rolled writer would be free to drift from this one on exactly the
+    security-relevant details.
+
+    Drift (an on-disk token whose fingerprint differs from the source) is
+    reported and **skipped** unless ``force`` — the operator is told to re-run
+    with ``--force`` rather than having a hand-edited token silently clobbered.
+
+    Args:
+        accounts: Effective account set; ``file`` values must already be unique
+            (the caller checks, since it owns the error message).
+        tokens_dir: Destination pool directory (created when not ``dry_run``).
+        force: Overwrite tokens whose fingerprint differs from the source.
+        dry_run: Compute dispositions without writing anything.
+
+    Returns:
+        :class:`MaterializeOutcome` — filenames bucketed by disposition plus
+        the manifest rows to hand to :func:`write_index`.
+    """
+    if not dry_run:
+        tokens_dir.mkdir(parents=True, exist_ok=True)
+        # Tighten directory mode (best-effort; ignore on FS without chmod).
+        try:
+            os.chmod(tokens_dir, DIR_MODE)
+        except OSError:
+            pass
+
+    written: list[str] = []
+    unchanged: list[str] = []
+    drifted: list[str] = []
+    manifest_accounts: list[dict[str, object]] = []
+
+    for acct in accounts:
+        n, email, key, filename = acct.index, acct.email, acct.key, acct.file
+        token_path = tokens_dir / filename
+        new_fp = fingerprint(key)
+
+        existing_fp: str | None = None
+        if token_path.exists():
+            try:
+                existing = token_path.read_text(encoding="utf-8")
+            except OSError as exc:
+                log_warning(f"Could not read {token_path}: {exc}; will rewrite.")
+                existing = None  # type: ignore[assignment]
+            if existing is not None:
+                existing_fp = fingerprint(existing.rstrip("\n"))
+
+        action: str
+        if existing_fp is None:
+            action = "written"
+        elif existing_fp == new_fp:
+            action = "unchanged" if not force else "written"
+        else:
+            action = "drifted"
+
+        if action == "drifted" and not force:
+            log_warning(
+                f"DRIFT: {filename} on disk does not match the account source "
+                f"(disk fp={existing_fp}, source fp={new_fp}); "
+                f"re-run with --force to overwrite."
+            )
+            drifted.append(filename)
+            # Still record current on-disk fingerprint in manifest so
+            # operators can see it.
+            manifest_accounts.append(
+                {
+                    "env_index": n,
+                    "name": _name_from_file(filename),
+                    "email": email,
+                    "file": filename,
+                    "source": acct.source,
+                    "key_fingerprint": existing_fp,
+                    "drift": True,
+                    "env_fingerprint": new_fp,
+                }
+            )
+            continue
+
+        if action == "unchanged":
+            unchanged.append(filename)
+        else:
+            # written (new file or force-overwrite)
+            if not dry_run:
+                # Write atomically: temp file + rename.
+                tmp = token_path.with_suffix(token_path.suffix + ".tmp")
+                tmp.write_text(key, encoding="utf-8")
+                try:
+                    os.chmod(tmp, FILE_MODE)
+                except OSError:
+                    pass
+                os.replace(tmp, token_path)
+                # Re-apply mode in case `replace` reset it on some FS.
+                try:
+                    os.chmod(token_path, FILE_MODE)
+                except OSError:
+                    pass
+            written.append(filename)
+
+        manifest_accounts.append(
+            {
+                "env_index": n,
+                "name": _name_from_file(filename),
+                "email": email,
+                "file": filename,
+                "source": acct.source,
+                "key_fingerprint": new_fp,
+            }
+        )
+
+    return MaterializeOutcome(
+        written=written,
+        unchanged=unchanged,
+        drifted=drifted,
+        manifest_accounts=manifest_accounts,
+    )
+
+
+def write_index(
+    manifest_accounts: list[dict[str, object]],
+    index_path: Path,
+    *,
+    dry_run: bool = False,
+) -> None:
+    """Atomically write the ``index.json`` manifest beside the pool.
+
+    The manifest carries only email / filename / source / 8-char fingerprint —
+    :func:`fingerprint` guarantees no secret material lands here.
+    """
+    manifest = {
+        "version": INDEX_VERSION,
+        "generated_at": _now_iso(),
+        "accounts": manifest_accounts,
+    }
+    if dry_run:
+        return
+    # Confirm dir exists (e.g. dry_run was False but no files written).
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    index_tmp = index_path.with_suffix(index_path.suffix + ".tmp")
+    index_tmp.write_text(
+        json.dumps(manifest, indent=2, sort_keys=False) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(index_tmp, index_path)
+
+
 _HOME_UNSET = object()
 
 
@@ -598,107 +766,14 @@ def bootstrap_tokens(
             raise ValueError(f"duplicate token filename: {acct.file}")
         seen_files[acct.file] = acct
 
-    if not dry_run:
-        tokens_dir.mkdir(parents=True, exist_ok=True)
-        # Tighten directory mode (best-effort; ignore on FS without chmod).
-        try:
-            os.chmod(tokens_dir, DIR_MODE)
-        except OSError:
-            pass
+    outcome = materialize_accounts(
+        valid, tokens_dir, force=force, dry_run=dry_run
+    )
+    result.written.extend(outcome.written)
+    result.unchanged.extend(outcome.unchanged)
+    result.drifted.extend(outcome.drifted)
 
-    manifest_accounts: list[dict[str, object]] = []
-    for acct in valid:
-        n, email, key, filename = acct.index, acct.email, acct.key, acct.file
-        token_path = tokens_dir / filename
-        new_fp = fingerprint(key)
-
-        existing_fp: str | None = None
-        if token_path.exists():
-            try:
-                existing = token_path.read_text(encoding="utf-8")
-            except OSError as exc:
-                log_warning(f"Could not read {token_path}: {exc}; will rewrite.")
-                existing = None  # type: ignore[assignment]
-            if existing is not None:
-                existing_fp = fingerprint(existing.rstrip("\n"))
-
-        action: str
-        if existing_fp is None:
-            action = "written"
-        elif existing_fp == new_fp:
-            action = "unchanged" if not force else "written"
-        else:
-            action = "drifted"
-
-        if action == "drifted" and not force:
-            log_warning(
-                f"DRIFT: {filename} on disk does not match the account source "
-                f"(disk fp={existing_fp}, source fp={new_fp}); "
-                f"re-run with --force to overwrite."
-            )
-            result.drifted.append(filename)
-            # Still record current on-disk fingerprint in manifest so
-            # operators can see it.
-            manifest_accounts.append(
-                {
-                    "env_index": n,
-                    "name": _name_from_file(filename),
-                    "email": email,
-                    "file": filename,
-                    "source": acct.source,
-                    "key_fingerprint": existing_fp,
-                    "drift": True,
-                    "env_fingerprint": new_fp,
-                }
-            )
-            continue
-
-        if action == "unchanged":
-            result.unchanged.append(filename)
-        else:
-            # written (new file or force-overwrite)
-            if not dry_run:
-                # Write atomically: temp file + rename.
-                tmp = token_path.with_suffix(token_path.suffix + ".tmp")
-                tmp.write_text(key, encoding="utf-8")
-                try:
-                    os.chmod(tmp, FILE_MODE)
-                except OSError:
-                    pass
-                os.replace(tmp, token_path)
-                # Re-apply mode in case `replace` reset it on some FS.
-                try:
-                    os.chmod(token_path, FILE_MODE)
-                except OSError:
-                    pass
-            result.written.append(filename)
-
-        manifest_accounts.append(
-            {
-                "env_index": n,
-                "name": _name_from_file(filename),
-                "email": email,
-                "file": filename,
-                "source": acct.source,
-                "key_fingerprint": new_fp,
-            }
-        )
-
-    # Write the manifest.
-    manifest = {
-        "version": INDEX_VERSION,
-        "generated_at": _now_iso(),
-        "accounts": manifest_accounts,
-    }
-    if not dry_run:
-        # Confirm dir exists (e.g. dry_run was False but no files written).
-        tokens_dir.mkdir(parents=True, exist_ok=True)
-        index_tmp = index_path.with_suffix(index_path.suffix + ".tmp")
-        index_tmp.write_text(
-            json.dumps(manifest, indent=2, sort_keys=False) + "\n",
-            encoding="utf-8",
-        )
-        os.replace(index_tmp, index_path)
+    write_index(outcome.manifest_accounts, index_path, dry_run=dry_run)
 
     log_info(
         f"bootstrap: written={len(result.written)} "

--- a/loom-tools/src/loom_tools/tokens/cli.py
+++ b/loom-tools/src/loom_tools/tokens/cli.py
@@ -11,6 +11,9 @@ Subcommands:
   which accounts the spawn-time selector is allowed to pick.
 * ``unblock`` (#3238) — clear ``auth``-reason entries from
   ``.bad_tokens`` so the named accounts become eligible again.
+* ``import-from-monitor`` (#4006) — materialize the pool from
+  claude-monitor's **live** credential store (``usage.db``) rather than the
+  ``accounts.env`` snapshot, which goes stale whenever accounts are rolled.
 
 Additional subcommands (status, ranking sync, etc.) can be added later
 without breaking the top-level surface — the dispatch table mirrors
@@ -32,6 +35,11 @@ from loom_tools.common.repo import find_repo_root
 from loom_tools.tokens import allowlist as allowlist_mod
 from loom_tools.tokens import failure_counts
 from loom_tools.tokens.bootstrap import bootstrap_tokens
+from loom_tools.tokens.monitor_db import (
+    MonitorDbUnavailable,
+    import_from_monitor,
+    monitor_db_path,
+)
 from loom_tools.tokens.paths import resolve_tokens_dir, shared_tokens_dir
 from loom_tools.tokens.check import (
     DEFAULT_PROBE_PROMPT,
@@ -109,6 +117,62 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Report what would change without writing any files.",
     )
     bp.add_argument(
+        "--json",
+        dest="emit_json",
+        action="store_true",
+        help="Emit a JSON summary on stdout (in addition to log lines).",
+    )
+
+    ip = sub.add_parser(
+        "import-from-monitor",
+        help=(
+            "Materialize the pool from claude-monitor's LIVE credential store "
+            "(~/.claude-monitor/usage.db) instead of the accounts.env "
+            "snapshot. Use this after rolling accounts: the snapshot keeps the "
+            "old (now revoked) tokens, so `bootstrap --force` would rewrite "
+            "them unchanged."
+        ),
+    )
+    ip.add_argument(
+        "--shared",
+        action="store_true",
+        help=(
+            "Import into the SHARED machine-level pool at ~/.loom/tokens "
+            "(override with $LOOM_SHARED_TOKENS_DIR) instead of the repo-local "
+            "<repo>/.loom/tokens."
+        ),
+    )
+    ip.add_argument(
+        "--db",
+        type=Path,
+        default=None,
+        help=(
+            "Path to claude-monitor's usage.db (default: <claude-monitor "
+            "dir>/usage.db, honoring $LOOM_CLAUDE_MONITOR_DIR)."
+        ),
+    )
+    ip.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Overwrite on-disk tokens that differ from the store. Required to "
+            "apply rolled tokens, since every rolled token differs by design."
+        ),
+    )
+    ip.add_argument(
+        "--prune",
+        action="store_true",
+        help=(
+            "Delete *.token files for accounts claude-monitor no longer "
+            "reports active (pool state files are never touched)."
+        ),
+    )
+    ip.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would change without writing any files.",
+    )
+    ip.add_argument(
         "--json",
         dest="emit_json",
         action="store_true",
@@ -261,6 +325,8 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "bootstrap":
         return _cmd_bootstrap(args)
+    if args.command == "import-from-monitor":
+        return _cmd_import_from_monitor(args)
     if args.command == "check":
         return _cmd_check(args)
     if args.command == "pin":
@@ -332,6 +398,88 @@ def _cmd_bootstrap(args: argparse.Namespace) -> int:
     if result.drifted and not args.force:
         return 2
     return 0
+
+
+def _cmd_import_from_monitor(args: argparse.Namespace) -> int:
+    """Import the pool from claude-monitor's live credential store (#4006)."""
+    # Destination: the shared machine-level pool, or this repo's pool.
+    if getattr(args, "shared", False):
+        tokens_dir = shared_tokens_dir()
+        if tokens_dir is None:
+            log_error(
+                "--shared requested but the shared pool is disabled "
+                "(LOOM_SHARED_TOKENS_DIR is empty). Unset it or point it at a "
+                "directory.",
+            )
+            return 1
+        log_info(f"Importing into the shared machine-level pool at {tokens_dir}")
+    else:
+        try:
+            repo_root = find_repo_root()
+        except FileNotFoundError as exc:
+            log_error(str(exc))
+            return 1
+        tokens_dir = repo_root / ".loom" / "tokens"
+
+    try:
+        result = import_from_monitor(
+            tokens_dir,
+            db_path=args.db,
+            force=args.force,
+            dry_run=args.dry_run,
+            prune=args.prune,
+        )
+    except MonitorDbUnavailable as exc:
+        log_error(str(exc))
+        return 1
+    except ValueError as exc:
+        log_error(str(exc))
+        return 1
+
+    if args.emit_json:
+        print(json.dumps(result.to_dict(), indent=2))
+    else:
+        _print_monitor_import(result)
+
+    # Unresolved drift without --force is the "rolled tokens not applied" case;
+    # exit non-zero so a script notices the pool is still stale.
+    if result.drifted and not args.force:
+        return 2
+    return 0
+
+
+def _print_monitor_import(result: "object") -> None:
+    """Print the imported account set. Secrets are never shown."""
+    db_path = getattr(result, "db_path", None) or monitor_db_path()
+    effective = getattr(result, "effective", []) or []
+    pruned = getattr(result, "pruned", []) or []
+
+    print(f"claude-monitor store: {db_path}")
+    print(f"Destination pool: {getattr(result, 'tokens_dir', None)}")
+
+    if not effective:
+        print("Active accounts: (none)")
+        return
+
+    written = set(getattr(result, "written", []) or [])
+    unchanged = set(getattr(result, "unchanged", []) or [])
+    drifted = set(getattr(result, "drifted", []) or [])
+
+    print(f"Active accounts ({len(effective)}):")
+    for acct in effective:
+        filename = acct.get("file", "")
+        if filename in written:
+            disposition = "written"
+        elif filename in unchanged:
+            disposition = "unchanged"
+        elif filename in drifted:
+            disposition = "DRIFT (use --force)"
+        else:
+            disposition = "-"
+        print(f"  {acct.get('name', ''):<26} {acct.get('email', ''):<34} {disposition}")
+
+    if pruned:
+        print(f"Pruned ({len(pruned)}): {', '.join(pruned)}")
 
 
 # Human-readable label for each provenance tag from the merge (#3695, #3698).

--- a/loom-tools/src/loom_tools/tokens/monitor_db.py
+++ b/loom-tools/src/loom_tools/tokens/monitor_db.py
@@ -1,0 +1,396 @@
+"""Import **live** account OAuth tokens from claude-monitor's store (#4006).
+
+Loom already treats claude-monitor as its primary account source, but through
+``~/.claude-monitor/accounts.env`` — a **static snapshot** an operator wrote by
+hand at some point in the past. claude-monitor itself keeps the *live*
+credentials in its SQLite store (``usage.db`` → ``oauth_credentials``), and
+refreshes them as accounts are re-authenticated.
+
+Those two surfaces drift, and the drift is silent and total. The incident that
+motivated this module: every account in the pool began returning
+
+    401 {"type":"authentication_error",
+         "message":"OAuth access token has been revoked."}
+
+so the dynamic concurrency cap collapsed to ``min(healthy 0 × …) = 0`` and the
+daemon stopped dispatching entirely. The operator *had* re-authenticated every
+account — but in claude-monitor, which wrote the fresh tokens to ``usage.db``
+and never touched ``accounts.env``. Loom kept reading the stale file, and
+``loom-tokens bootstrap --force`` faithfully rewrote the same revoked tokens,
+because the snapshot itself was what had gone stale. There was no Loom-side
+command to pull from the live store; the standing workaround was hand-copying a
+pool between hosts.
+
+This module closes that gap: it reads the live store directly and materializes
+the pool through the *same* writer ``bootstrap`` uses
+(:func:`bootstrap.materialize_accounts`), so atomic write-then-rename, ``0600``
+file / ``0700`` directory modes, fingerprint drift detection, and the
+``index.json`` manifest are identical by construction rather than by
+convention.
+
+**Read-only, and a soft dependency.** The database is opened
+``file:…?mode=ro`` (never written, never migrated — it belongs to another
+tool) and every failure mode is a clean typed error rather than a crash:
+claude-monitor absent, ``usage.db`` absent, or a schema without
+``oauth_credentials`` (an older claude-monitor). ``LOOM_CLAUDE_MONITOR_DIR``
+relocates the directory, so tests never touch a real ``~/.claude-monitor``.
+
+**Secrets.** ``oauth_credentials.access_token`` is raw secret material. It is
+carried in memory only, written solely to ``0600`` token files, and never
+logged — logs and the manifest carry email, filename, and the 8-char
+fingerprint only.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+from loom_tools.common.logging import log_info, log_warning
+from loom_tools.tokens import monitor
+from loom_tools.tokens.bootstrap import (
+    Account,
+    derive_token_filename,
+    materialize_accounts,
+    write_index,
+)
+
+logger = logging.getLogger(__name__)
+
+# claude-monitor's SQLite store, alongside ranking.json / accounts.env in the
+# directory resolved by ``monitor.claude_monitor_dir()``.
+MONITOR_DB_NAME = "usage.db"
+
+# Provenance tag recorded in index.json for accounts sourced from the live DB.
+# Deliberately distinct from "monitor" (the accounts.env snapshot) so an
+# operator reading the manifest can tell which surface a token came from.
+SOURCE_MONITOR_DB = "monitor-db"
+
+# claude-monitor labels an account either by bare email or as
+# "<email>'s Organization". The bare-email case needs no parsing; this pattern
+# recovers the email from the organization form when the ``accounts`` join
+# yields nothing.
+_ORG_LABEL_RE = re.compile(r"^(?P<email>.+?)'s Organization$")
+
+# Opening the DB should be instant; a bounded timeout means a lock held by
+# claude-monitor surfaces as an error instead of hanging a sweep dispatch.
+_SQLITE_TIMEOUT_SECONDS = 5.0
+
+
+class MonitorDbUnavailable(RuntimeError):
+    """The claude-monitor credential store could not be read.
+
+    Raised when the directory or ``usage.db`` is absent, or the schema has no
+    ``oauth_credentials`` table. Callers surface the message to the operator —
+    it names the path that was tried.
+    """
+
+
+@dataclass(frozen=True)
+class MonitorCredential:
+    """One active credential row resolved to an email."""
+
+    email: str
+    token: str
+    label: str
+
+
+def monitor_db_path(monitor_dir: Path | None = None) -> Path:
+    """Return the path to claude-monitor's ``usage.db``.
+
+    Honors ``LOOM_CLAUDE_MONITOR_DIR`` via :func:`monitor.claude_monitor_dir`.
+    """
+    base = monitor_dir or monitor.claude_monitor_dir()
+    return base / MONITOR_DB_NAME
+
+
+def _email_from_label(label: str) -> str | None:
+    """Recover an email from a credential label, or None if it isn't one.
+
+    claude-monitor uses either the bare email or ``"<email>'s Organization"``.
+    Anything without an ``@`` is a display name we cannot join on.
+    """
+    text = (label or "").strip()
+    if not text:
+        return None
+    m = _ORG_LABEL_RE.match(text)
+    if m:
+        text = m.group("email").strip()
+    return text if "@" in text else None
+
+
+def read_monitor_credentials(
+    db_path: Path | None = None,
+    *,
+    monitor_dir: Path | None = None,
+) -> list[MonitorCredential]:
+    """Read active credentials from claude-monitor's store.
+
+    Only ``is_active = 1`` rows with a non-empty ``access_token`` are returned:
+    claude-monitor deactivates rows for accounts an operator has removed, and
+    importing those would repopulate the pool with accounts they retired.
+
+    ``expires_at`` is deliberately **not** used as a filter. Observed rows carry
+    timestamps months in the past while the token still authenticates
+    (claude-monitor refreshes the value in place without always updating the
+    column), so filtering on it would discard working credentials. Health is
+    established by probing (``loom-tokens check``), which is authoritative.
+
+    When one email has several active rows, the highest ``id`` wins — rows are
+    append-ordered, so that is the most recently stored credential.
+
+    Returns:
+        Credentials ordered by row id, de-duplicated by email.
+
+    Raises:
+        MonitorDbUnavailable: The directory, database file, or
+            ``oauth_credentials`` table is missing.
+    """
+    path = db_path or monitor_db_path(monitor_dir)
+    if not path.is_file():
+        raise MonitorDbUnavailable(
+            f"claude-monitor database not found at {path}. "
+            "Is claude-monitor installed on this host? "
+            "(Set LOOM_CLAUDE_MONITOR_DIR to point elsewhere.)"
+        )
+
+    # Read-only URI: this database belongs to claude-monitor. We never write,
+    # migrate, or take a write lock on it.
+    uri = f"file:{path}?mode=ro"
+    try:
+        conn = sqlite3.connect(uri, uri=True, timeout=_SQLITE_TIMEOUT_SECONDS)
+    except sqlite3.Error as exc:
+        raise MonitorDbUnavailable(f"Could not open {path}: {exc}") from exc
+
+    try:
+        # LEFT JOIN so a credential whose account row is missing still comes
+        # back — its email is then recovered from the label.
+        rows = conn.execute(
+            """
+            SELECT c.id, c.label, c.access_token, a.email
+              FROM oauth_credentials c
+              LEFT JOIN accounts a ON a.id = c.account_id
+             WHERE c.is_active = 1
+             ORDER BY c.id
+            """
+        ).fetchall()
+    except sqlite3.Error as exc:
+        # A missing table (older claude-monitor) lands here as OperationalError.
+        raise MonitorDbUnavailable(
+            f"Could not read oauth_credentials from {path}: {exc}. "
+            "This claude-monitor may predate the credential store."
+        ) from exc
+    finally:
+        conn.close()
+
+    by_email: dict[str, MonitorCredential] = {}
+    for _row_id, label, access_token, joined_email in rows:
+        token = (access_token or "").strip()
+        if not token:
+            logger.debug("monitor-db: row %r has no access_token; skipping", label)
+            continue
+        email = (joined_email or "").strip() or _email_from_label(label or "")
+        if not email:
+            log_warning(
+                f"claude-monitor credential {label!r} has no resolvable email; "
+                "skipping (cannot derive a stable token filename)."
+            )
+            continue
+        # Later rows (higher id) supersede earlier ones for the same email.
+        by_email[email.lower()] = MonitorCredential(
+            email=email, token=token, label=label or email
+        )
+
+    return list(by_email.values())
+
+
+def credentials_to_accounts(creds: list[MonitorCredential]) -> list[Account]:
+    """Convert credentials to :class:`Account`s with derived token filenames.
+
+    Filenames come from :func:`bootstrap.derive_token_filename`, the same
+    derivation ``bootstrap`` uses, so an account keeps one stable identity
+    across both import paths (``robb@2amlogic.com`` → ``robb-2amlogic.token``)
+    and re-importing overwrites in place instead of creating a parallel file.
+    """
+    return [
+        Account(
+            email=c.email,
+            key=c.token,
+            file=derive_token_filename(c.email),
+            source=SOURCE_MONITOR_DB,
+            index=n,
+        )
+        for n, c in enumerate(creds, start=1)
+    ]
+
+
+class MonitorImportResult:
+    """Outcome of a single :func:`import_from_monitor` call."""
+
+    def __init__(self) -> None:
+        self.written: list[str] = []
+        self.unchanged: list[str] = []
+        self.drifted: list[str] = []
+        self.pruned: list[str] = []
+        self.dry_run: bool = False
+        self.tokens_dir: Path | None = None
+        self.index_path: Path | None = None
+        self.db_path: Path | None = None
+        # Each entry: {"email", "name", "file", "source"}.
+        self.effective: list[dict[str, str]] = []
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "written": list(self.written),
+            "unchanged": list(self.unchanged),
+            "drifted": list(self.drifted),
+            "pruned": list(self.pruned),
+            "dry_run": self.dry_run,
+            "tokens_dir": str(self.tokens_dir) if self.tokens_dir else None,
+            "index_path": str(self.index_path) if self.index_path else None,
+            "db_path": str(self.db_path) if self.db_path else None,
+            "effective": [dict(a) for a in self.effective],
+        }
+
+
+def import_from_monitor(
+    tokens_dir: Path,
+    *,
+    db_path: Path | None = None,
+    monitor_dir: Path | None = None,
+    force: bool = False,
+    dry_run: bool = False,
+    prune: bool = False,
+) -> MonitorImportResult:
+    """Materialize ``tokens_dir`` from claude-monitor's live credential store.
+
+    Idempotent: a token whose on-disk fingerprint already matches the store is
+    left untouched and reported ``unchanged``. A token that differs is reported
+    ``drifted`` and skipped unless ``force`` — so a hand-pinned token is never
+    silently replaced. **After an account roll, ``force=True`` is the flag that
+    actually updates the pool**, since every rolled token legitimately differs
+    from what is on disk.
+
+    Args:
+        tokens_dir: Destination pool (per-repo ``<repo>/.loom/tokens`` or the
+            shared machine-level pool — the caller resolves which).
+        db_path: Override the database location (tests).
+        monitor_dir: Override the claude-monitor directory (tests).
+        force: Overwrite tokens that differ from the store.
+        dry_run: Report what would change; write nothing.
+        prune: Delete ``*.token`` files for accounts the store no longer
+            reports active, treating claude-monitor as authoritative for pool
+            membership. Off by default so an import never removes a token an
+            operator provisioned by another route.
+
+    Returns:
+        :class:`MonitorImportResult` summarising the operation.
+
+    Raises:
+        MonitorDbUnavailable: The store could not be read.
+        ValueError: Two accounts derive the same token filename (they would
+            clobber each other on disk).
+    """
+    resolved_db = db_path or monitor_db_path(monitor_dir)
+    creds = read_monitor_credentials(resolved_db)
+
+    result = MonitorImportResult()
+    result.dry_run = dry_run
+    result.tokens_dir = tokens_dir
+    result.index_path = tokens_dir / "index.json"
+    result.db_path = resolved_db
+
+    accounts = credentials_to_accounts(creds)
+    result.effective = [
+        {
+            "email": a.email,
+            "name": a.file[: -len(".token")],
+            "file": a.file,
+            "source": a.source,
+        }
+        for a in accounts
+    ]
+
+    if not accounts:
+        log_warning(
+            f"No active credentials in {resolved_db}; nothing to import. "
+            "Check that claude-monitor has accounts configured."
+        )
+        return result
+
+    # Two distinct emails can derive the same stem (e.g. a.jones@x.com and
+    # ajones@x.com). Fail loudly rather than let one clobber the other.
+    seen: dict[str, Account] = {}
+    for acct in accounts:
+        prior = seen.get(acct.file)
+        if prior is not None:
+            raise ValueError(
+                f"duplicate token filename: {acct.file} maps to both "
+                f"{prior.email!r} and {acct.email!r}"
+            )
+        seen[acct.file] = acct
+
+    outcome = materialize_accounts(
+        accounts, tokens_dir, force=force, dry_run=dry_run
+    )
+    result.written = outcome.written
+    result.unchanged = outcome.unchanged
+    result.drifted = outcome.drifted
+
+    if prune:
+        result.pruned = _prune_stale_tokens(
+            tokens_dir, keep={a.file for a in accounts}, dry_run=dry_run
+        )
+
+    write_index(outcome.manifest_accounts, result.index_path, dry_run=dry_run)
+
+    log_info(
+        f"import-from-monitor: written={len(result.written)} "
+        f"unchanged={len(result.unchanged)} "
+        f"drifted={len(result.drifted)} "
+        f"pruned={len(result.pruned)} "
+        f"(dry_run={dry_run})"
+    )
+    if result.drifted and not force:
+        log_warning(
+            f"{len(result.drifted)} token(s) differ from claude-monitor's store "
+            "and were left as-is; re-run with --force to overwrite. After "
+            "rolling accounts this is expected — --force is what applies the "
+            "new tokens."
+        )
+    return result
+
+
+def _prune_stale_tokens(
+    tokens_dir: Path, *, keep: set[str], dry_run: bool
+) -> list[str]:
+    """Delete ``*.token`` files not in *keep*; return the filenames removed.
+
+    Globbing ``*.token`` deliberately excludes the pool's state files
+    (``.ranking``, ``.bad_tokens``, ``.failure_counts``, ``.allowlist``) and
+    ``index.json``, none of which carry that suffix — pruning never disturbs
+    rotation state.
+    """
+    if not tokens_dir.is_dir():
+        return []
+    pruned: list[str] = []
+    for token_file in sorted(tokens_dir.glob("*.token")):
+        if token_file.name in keep:
+            continue
+        pruned.append(token_file.name)
+        if not dry_run:
+            try:
+                os.remove(token_file)
+            except OSError as exc:
+                log_warning(f"Could not prune {token_file}: {exc}")
+                pruned.pop()
+    if pruned:
+        log_info(
+            f"pruned {len(pruned)} token(s) no longer active in claude-monitor: "
+            + ", ".join(pruned)
+        )
+    return pruned

--- a/loom-tools/tests/tokens/test_monitor_db.py
+++ b/loom-tools/tests/tokens/test_monitor_db.py
@@ -1,0 +1,438 @@
+"""Tests for the claude-monitor live-credential importer (#4006).
+
+The bug these guard against is silent and total: ``accounts.env`` is a snapshot,
+so after an operator rolls every account the pool keeps authenticating with
+revoked tokens and the daemon's concurrency cap collapses to zero. The importer
+must read the *live* store instead, and must actually replace on-disk tokens
+when ``--force`` is given.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import stat
+from pathlib import Path
+
+import pytest
+
+from loom_tools.tokens.cli import main
+from loom_tools.tokens.monitor_db import (
+    MonitorDbUnavailable,
+    credentials_to_accounts,
+    import_from_monitor,
+    monitor_db_path,
+    read_monitor_credentials,
+)
+
+# --------------------------------------------------------------------------
+# Fixture helpers — a minimal stand-in for claude-monitor's usage.db
+# --------------------------------------------------------------------------
+
+_SCHEMA = """
+CREATE TABLE accounts (
+    id TEXT PRIMARY KEY,
+    account_name TEXT,
+    email TEXT,
+    plan TEXT
+);
+CREATE TABLE oauth_credentials (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    account_id TEXT,
+    label TEXT NOT NULL,
+    access_token TEXT,
+    expires_at INTEGER,
+    is_active INTEGER DEFAULT 1
+);
+"""
+
+
+def make_monitor_db(path: Path, rows: list[dict]) -> Path:
+    """Build a usage.db stand-in.
+
+    Each row: ``label``, ``token``; optional ``email`` (creates a joined
+    ``accounts`` row), ``is_active`` (default 1), ``expires_at``.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    conn.executescript(_SCHEMA)
+    for n, row in enumerate(rows, start=1):
+        account_id = None
+        if row.get("email"):
+            account_id = f"acct-{n}"
+            conn.execute(
+                "INSERT INTO accounts (id, email) VALUES (?, ?)",
+                (account_id, row["email"]),
+            )
+        conn.execute(
+            "INSERT INTO oauth_credentials "
+            "(account_id, label, access_token, expires_at, is_active) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (
+                account_id,
+                row["label"],
+                row.get("token"),
+                row.get("expires_at"),
+                row.get("is_active", 1),
+            ),
+        )
+    conn.commit()
+    conn.close()
+    return path
+
+
+@pytest.fixture
+def monitor_db(tmp_path: Path) -> Path:
+    """Two active accounts, one deactivated."""
+    return make_monitor_db(
+        tmp_path / "monitor" / "usage.db",
+        [
+            {
+                "label": "robb@2amlogic.com's Organization",
+                "email": "robb@2amlogic.com",
+                "token": "sk-ant-oat01-fresh-robb",
+            },
+            {
+                "label": "agent-1@2amlogic.com",
+                "email": "agent-1@2amlogic.com",
+                "token": "sk-ant-oat01-fresh-agent1",
+            },
+            {
+                "label": "retired@example.com",
+                "email": "retired@example.com",
+                "token": "sk-ant-oat01-retired",
+                "is_active": 0,
+            },
+        ],
+    )
+
+
+# --------------------------------------------------------------------------
+# read_monitor_credentials
+# --------------------------------------------------------------------------
+
+
+def test_reads_only_active_credentials(monitor_db: Path) -> None:
+    creds = read_monitor_credentials(monitor_db)
+    assert [c.email for c in creds] == [
+        "robb@2amlogic.com",
+        "agent-1@2amlogic.com",
+    ]
+
+
+def test_email_recovered_from_org_label_without_accounts_row(tmp_path: Path) -> None:
+    """A credential with no joined accounts row still resolves via its label."""
+    db = make_monitor_db(
+        tmp_path / "usage.db",
+        [{"label": "solo@example.com's Organization", "token": "tok"}],
+    )
+    creds = read_monitor_credentials(db)
+    assert [c.email for c in creds] == ["solo@example.com"]
+
+
+def test_row_without_resolvable_email_is_skipped(tmp_path: Path) -> None:
+    """A display-name label with no accounts row has no stable filename."""
+    db = make_monitor_db(
+        tmp_path / "usage.db",
+        [
+            {"label": "Claude Code (rwalters)", "token": "tok"},
+            {"label": "ok@example.com", "email": "ok@example.com", "token": "tok2"},
+        ],
+    )
+    creds = read_monitor_credentials(db)
+    assert [c.email for c in creds] == ["ok@example.com"]
+
+
+def test_row_without_token_is_skipped(tmp_path: Path) -> None:
+    db = make_monitor_db(
+        tmp_path / "usage.db",
+        [
+            {"label": "a@example.com", "email": "a@example.com", "token": None},
+            {"label": "b@example.com", "email": "b@example.com", "token": "  "},
+            {"label": "c@example.com", "email": "c@example.com", "token": "tok"},
+        ],
+    )
+    assert [c.email for c in read_monitor_credentials(db)] == ["c@example.com"]
+
+
+def test_duplicate_email_keeps_highest_row_id(tmp_path: Path) -> None:
+    """Rows are append-ordered, so the last active row is the current token."""
+    db = make_monitor_db(
+        tmp_path / "usage.db",
+        [
+            {"label": "dup@example.com", "email": "dup@example.com", "token": "old"},
+            {"label": "dup@example.com", "email": "dup@example.com", "token": "new"},
+        ],
+    )
+    creds = read_monitor_credentials(db)
+    assert len(creds) == 1
+    assert creds[0].token == "new"
+
+
+def test_past_expires_at_does_not_filter(tmp_path: Path) -> None:
+    """Observed rows carry stale expires_at while still authenticating."""
+    db = make_monitor_db(
+        tmp_path / "usage.db",
+        [
+            {
+                "label": "x@example.com",
+                "email": "x@example.com",
+                "token": "tok",
+                "expires_at": 1,  # 1970
+            }
+        ],
+    )
+    assert len(read_monitor_credentials(db)) == 1
+
+
+def test_missing_database_raises(tmp_path: Path) -> None:
+    with pytest.raises(MonitorDbUnavailable, match="not found"):
+        read_monitor_credentials(tmp_path / "nope" / "usage.db")
+
+
+def test_schema_without_credentials_table_raises(tmp_path: Path) -> None:
+    """An older claude-monitor has no oauth_credentials table."""
+    db = tmp_path / "usage.db"
+    conn = sqlite3.connect(db)
+    conn.execute("CREATE TABLE unrelated (id INTEGER)")
+    conn.commit()
+    conn.close()
+    with pytest.raises(MonitorDbUnavailable, match="oauth_credentials"):
+        read_monitor_credentials(db)
+
+
+def test_database_is_not_modified(monitor_db: Path) -> None:
+    """The store belongs to claude-monitor — we only ever read it."""
+    before = monitor_db.read_bytes()
+    read_monitor_credentials(monitor_db)
+    assert monitor_db.read_bytes() == before
+
+
+def test_monitor_db_path_honors_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LOOM_CLAUDE_MONITOR_DIR", "/custom/monitor")
+    assert monitor_db_path() == Path("/custom/monitor/usage.db")
+
+
+# --------------------------------------------------------------------------
+# Filename derivation
+# --------------------------------------------------------------------------
+
+
+def test_filenames_match_bootstrap_derivation(monitor_db: Path) -> None:
+    """Same derivation as bootstrap, so identities don't fork across paths."""
+    accounts = credentials_to_accounts(read_monitor_credentials(monitor_db))
+    assert {a.file for a in accounts} == {
+        "robb-2amlogic.token",
+        "agent1-2amlogic.token",
+    }
+    assert {a.source for a in accounts} == {"monitor-db"}
+
+
+def test_colliding_derived_filenames_raise(tmp_path: Path) -> None:
+    db = make_monitor_db(
+        tmp_path / "usage.db",
+        [
+            {"label": "a.jones@x.com", "email": "a.jones@x.com", "token": "t1"},
+            {"label": "ajones@x.com", "email": "ajones@x.com", "token": "t2"},
+        ],
+    )
+    with pytest.raises(ValueError, match="duplicate token filename"):
+        import_from_monitor(tmp_path / "pool", db_path=db)
+
+
+# --------------------------------------------------------------------------
+# import_from_monitor — materialization
+# --------------------------------------------------------------------------
+
+
+def test_import_writes_tokens_and_manifest(monitor_db: Path, tmp_path: Path) -> None:
+    pool = tmp_path / "pool"
+    result = import_from_monitor(pool, db_path=monitor_db)
+
+    assert sorted(result.written) == ["agent1-2amlogic.token", "robb-2amlogic.token"]
+    assert (pool / "robb-2amlogic.token").read_text() == "sk-ant-oat01-fresh-robb"
+    assert (pool / "agent1-2amlogic.token").read_text() == "sk-ant-oat01-fresh-agent1"
+
+    manifest = json.loads((pool / "index.json").read_text())
+    assert {a["source"] for a in manifest["accounts"]} == {"monitor-db"}
+    assert {a["email"] for a in manifest["accounts"]} == {
+        "robb@2amlogic.com",
+        "agent-1@2amlogic.com",
+    }
+    # The manifest must never carry secret material.
+    blob = json.dumps(manifest)
+    assert "sk-ant-oat01-fresh-robb" not in blob
+    assert "sk-ant-oat01-fresh-agent1" not in blob
+
+
+def test_token_and_directory_modes(monitor_db: Path, tmp_path: Path) -> None:
+    pool = tmp_path / "pool"
+    import_from_monitor(pool, db_path=monitor_db)
+    assert stat.S_IMODE((pool / "robb-2amlogic.token").stat().st_mode) == 0o600
+    assert stat.S_IMODE(pool.stat().st_mode) == 0o700
+
+
+def test_import_is_idempotent(monitor_db: Path, tmp_path: Path) -> None:
+    pool = tmp_path / "pool"
+    import_from_monitor(pool, db_path=monitor_db)
+    second = import_from_monitor(pool, db_path=monitor_db)
+    assert second.written == []
+    assert sorted(second.unchanged) == [
+        "agent1-2amlogic.token",
+        "robb-2amlogic.token",
+    ]
+
+
+def test_dry_run_writes_nothing(monitor_db: Path, tmp_path: Path) -> None:
+    pool = tmp_path / "pool"
+    result = import_from_monitor(pool, db_path=monitor_db, dry_run=True)
+    assert sorted(result.written) == ["agent1-2amlogic.token", "robb-2amlogic.token"]
+    assert not pool.exists()
+
+
+def test_rolled_token_reports_drift_and_is_not_applied(
+    monitor_db: Path, tmp_path: Path
+) -> None:
+    """Without --force a stale pool stays stale — and says so."""
+    pool = tmp_path / "pool"
+    pool.mkdir()
+    (pool / "robb-2amlogic.token").write_text("sk-ant-oat01-REVOKED")
+
+    result = import_from_monitor(pool, db_path=monitor_db)
+
+    assert result.drifted == ["robb-2amlogic.token"]
+    assert (pool / "robb-2amlogic.token").read_text() == "sk-ant-oat01-REVOKED"
+
+
+def test_force_applies_rolled_tokens(monitor_db: Path, tmp_path: Path) -> None:
+    """The core regression: --force replaces revoked tokens with live ones."""
+    pool = tmp_path / "pool"
+    pool.mkdir()
+    (pool / "robb-2amlogic.token").write_text("sk-ant-oat01-REVOKED")
+
+    result = import_from_monitor(pool, db_path=monitor_db, force=True)
+
+    assert result.drifted == []
+    assert (pool / "robb-2amlogic.token").read_text() == "sk-ant-oat01-fresh-robb"
+
+
+def test_no_active_accounts_is_not_an_error(tmp_path: Path) -> None:
+    db = make_monitor_db(
+        tmp_path / "usage.db",
+        [{"label": "x@example.com", "email": "x@example.com", "token": "t",
+          "is_active": 0}],
+    )
+    result = import_from_monitor(tmp_path / "pool", db_path=db)
+    assert result.written == []
+    assert result.effective == []
+
+
+# --------------------------------------------------------------------------
+# Pruning
+# --------------------------------------------------------------------------
+
+
+def test_prune_removes_only_inactive_accounts(
+    monitor_db: Path, tmp_path: Path
+) -> None:
+    pool = tmp_path / "pool"
+    pool.mkdir()
+    (pool / "gone-example.token").write_text("stale")
+
+    result = import_from_monitor(pool, db_path=monitor_db, prune=True)
+
+    assert result.pruned == ["gone-example.token"]
+    assert not (pool / "gone-example.token").exists()
+    assert (pool / "robb-2amlogic.token").exists()
+
+
+def test_prune_is_off_by_default(monitor_db: Path, tmp_path: Path) -> None:
+    pool = tmp_path / "pool"
+    pool.mkdir()
+    (pool / "other-example.token").write_text("provisioned elsewhere")
+
+    result = import_from_monitor(pool, db_path=monitor_db)
+
+    assert result.pruned == []
+    assert (pool / "other-example.token").exists()
+
+
+def test_prune_never_touches_pool_state_files(
+    monitor_db: Path, tmp_path: Path
+) -> None:
+    """Rotation state must survive a prune (#3938: one pool, one truth)."""
+    pool = tmp_path / "pool"
+    pool.mkdir()
+    for name in (".ranking", ".bad_tokens", ".failure_counts", ".allowlist"):
+        (pool / name).write_text("state")
+
+    import_from_monitor(pool, db_path=monitor_db, prune=True)
+
+    for name in (".ranking", ".bad_tokens", ".failure_counts", ".allowlist"):
+        assert (pool / name).read_text() == "state"
+
+
+def test_prune_dry_run_reports_without_deleting(
+    monitor_db: Path, tmp_path: Path
+) -> None:
+    pool = tmp_path / "pool"
+    pool.mkdir()
+    (pool / "gone-example.token").write_text("stale")
+
+    result = import_from_monitor(pool, db_path=monitor_db, prune=True, dry_run=True)
+
+    assert result.pruned == ["gone-example.token"]
+    assert (pool / "gone-example.token").exists()
+
+
+# --------------------------------------------------------------------------
+# CLI surface
+# --------------------------------------------------------------------------
+
+
+def test_cli_imports_into_shared_pool(
+    monitor_db: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    shared = tmp_path / "shared-pool"
+    monkeypatch.setenv("LOOM_SHARED_TOKENS_DIR", str(shared))
+
+    rc = main(["import-from-monitor", "--shared", "--db", str(monitor_db)])
+
+    assert rc == 0
+    assert (shared / "robb-2amlogic.token").read_text() == "sk-ant-oat01-fresh-robb"
+
+
+def test_cli_exits_2_on_unapplied_drift(
+    monitor_db: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Scripts can detect "pool still stale" without parsing logs."""
+    shared = tmp_path / "shared-pool"
+    shared.mkdir()
+    (shared / "robb-2amlogic.token").write_text("sk-ant-oat01-REVOKED")
+    monkeypatch.setenv("LOOM_SHARED_TOKENS_DIR", str(shared))
+
+    rc = main(["import-from-monitor", "--shared", "--db", str(monitor_db)])
+    assert rc == 2
+
+    rc_forced = main(
+        ["import-from-monitor", "--shared", "--force", "--db", str(monitor_db)]
+    )
+    assert rc_forced == 0
+
+
+def test_cli_reports_missing_store(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("LOOM_SHARED_TOKENS_DIR", str(tmp_path / "pool"))
+    rc = main(
+        ["import-from-monitor", "--shared", "--db", str(tmp_path / "absent.db")]
+    )
+    assert rc == 1
+
+
+def test_cli_refuses_shared_when_disabled(
+    monitor_db: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("LOOM_SHARED_TOKENS_DIR", "")
+    rc = main(["import-from-monitor", "--shared", "--db", str(monitor_db)])
+    assert rc == 1


### PR DESCRIPTION
Closes #4006

## Why

`~/.claude-monitor/accounts.env` is a **snapshot**. claude-monitor keeps the **live** credentials in `usage.db` → `oauth_credentials` and refreshes them as accounts are re-authenticated. The two drift, and the drift is silent and total.

This was hit for real on the primary host today. Every account in the pool returned:

```
401 {"type":"authentication_error","message":"OAuth access token has been revoked."}
```

`loom-tokens check` reported all 7 accounts `blocked`, so the daemon's dynamic cap collapsed and dispatch stopped:

```
Dynamic concurrency cap: 0
  = min(healthy 0 × per-token 5 = 0, disk headroom 122, configured max 10)
In-flight sweeps: 0
```

The accounts *had* been rolled — in claude-monitor, which wrote fresh tokens to `usage.db` and never touched `accounts.env`. **`bootstrap --force` could not fix it**: it faithfully rewrote the same revoked tokens, because the snapshot itself was what had gone stale. Confirmed by fingerprinting — every key in `accounts.env` was byte-identical to the revoked token on disk, while the DB held different (working) ones.

Until now there was no Loom-side command to pull from the live store; the standing workaround was hand-copying a pool between hosts.

## What

`loom-tokens import-from-monitor` reads the live store directly.

```bash
loom-tokens import-from-monitor                  # into <repo>/.loom/tokens
loom-tokens import-from-monitor --shared         # into the machine-level pool (#3938)
loom-tokens import-from-monitor --force          # apply ROLLED tokens
loom-tokens import-from-monitor --dry-run        # preview
loom-tokens import-from-monitor --prune          # drop accounts no longer reported
```

Design notes worth reviewing:

- **Read-only** on `usage.db` (`mode=ro`, bounded timeout). The store belongs to another tool — never written, never migrated.
- **`expires_at` is deliberately not a filter.** Observed rows carry timestamps months in the past while the token still authenticates, so filtering on it would discard working credentials. Health is established by probing (`loom-tokens check`), which is authoritative.
- **Only `is_active = 1`** — claude-monitor deactivates rows for retired accounts, and importing those would repopulate the pool with accounts the operator removed.
- Emails resolve via the `accounts` join, falling back to parsing the credential label (`"<email>'s Organization"`). A label with no `@` and no joined row is skipped with a warning rather than guessed at.
- Duplicate emails resolve to the **highest row id** (rows are append-ordered, so that's the current credential).
- **`--force` is what applies a roll.** Every rolled token legitimately differs from disk, so without it each is reported as drift and left alone — so a hand-pinned token is never silently clobbered. Unapplied drift exits `2` so a script can detect "pool still stale".
- **`--prune` globs `*.token` only**, so pool state (`.ranking`, `.bad_tokens`, `.failure_counts`, `.allowlist`) is never disturbed. Off by default.
- Filenames use `bootstrap`'s existing derivation, so an account keeps one identity across both paths and re-importing overwrites in place.

### Shared writer, not a second one

Rather than hand-roll a parallel writer, the materialization loop was extracted from `bootstrap_tokens()` into `materialize_accounts()` + `write_index()`, and both paths call it. Atomic write-then-rename, `0600`/`0700` modes, fingerprint drift detection, and the `index.json` schema are therefore identical **by construction** — a second writer would have been free to drift from this one on exactly the security-relevant details.

`index.json` records `source: monitor-db`, distinct from the `monitor` snapshot, so the manifest shows which surface a token came from. As always it carries fingerprints only, never secret material.

## Testing

- **27 new tests** in `loom-tools/tests/tokens/test_monitor_db.py` against a synthetic `usage.db`: active/inactive filtering, both email-resolution paths, unresolvable-label and empty-token skips, duplicate-email precedence, past-`expires_at`, missing DB, older schema without `oauth_credentials`, DB-not-modified, idempotency, dry-run, drift-without-force, force-applies-roll, prune scoping (including state-file safety), file/dir modes, no-secrets-in-manifest, and the CLI surface (shared pool, exit 2 on drift, missing store, `--shared` when disabled).
- **Full suite green: 316 passed** (`loom-tools/tests/tokens/`), including the 92 pre-existing `test_bootstrap.py` tests that pin the refactored writer's behavior.
- **Verified end-to-end against the real store** on the affected host: imported all 8 active accounts, fingerprints matched the live DB tokens, modes were `0600`/`0700`, no secrets in `index.json`, and a second run reported `written=0 unchanged=8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
