### PR TITLE
fix: match Claude model family/pricing by generation-agnostic stem

### DIFF
--- a/loom-daemon/src/activity/resource_usage.rs
+++ b/loom-daemon/src/activity/resource_usage.rs
@@ -46,27 +46,43 @@ pub struct ModelPricing {
 }
 
 impl ModelPricing {
-    /// Get pricing for a given model
+    /// Get pricing for a given model.
+    ///
+    /// Matching is **generation-agnostic**: it keys off the family stem
+    /// (`claude-sonnet-`, `claude-opus-`, `claude-haiku-`, `claude-fable-`)
+    /// rather than a pinned generation number, so a future generation (e.g.
+    /// `claude-sonnet-6`) prices correctly with no code change (#3981). The
+    /// legacy `claude-3-5-sonnet` / `claude-3-opus` / `claude-3-haiku` IDs
+    /// predate the `-<generation>-` naming scheme and are matched explicitly.
+    /// Mirrors `loom_tools.sweep_experiment.model_pricing` in Python — keep
+    /// both in sync.
     pub fn for_model(model: &str) -> Self {
         // Normalize model name for matching
         let model_lower = model.to_lowercase();
 
         // Anthropic models (prices as of Jan 2025)
-        if model_lower.contains("claude-3-5-sonnet") || model_lower.contains("claude-sonnet-4") {
+        if model_lower.contains("claude-3-5-sonnet") || model_lower.contains("claude-sonnet-") {
             Self {
                 input_cost_per_1k: 0.003,
                 output_cost_per_1k: 0.015,
                 cache_read_cost_per_1k: 0.0003,
                 cache_write_cost_per_1k: 0.00375,
             }
-        } else if model_lower.contains("claude-3-opus") || model_lower.contains("claude-opus-4") {
+        } else if model_lower.contains("claude-3-opus")
+            || model_lower.contains("claude-opus-")
+            || model_lower.contains("claude-fable-")
+        {
+            // `claude-fable-*` (the #3702 escalation-ladder rung above Opus)
+            // has no published per-token rate, so it is conservatively priced
+            // at the Opus rate rather than falling through to the cheaper
+            // default and under-reporting cost.
             Self {
                 input_cost_per_1k: 0.015,
                 output_cost_per_1k: 0.075,
                 cache_read_cost_per_1k: 0.0015,
                 cache_write_cost_per_1k: 0.01875,
             }
-        } else if model_lower.contains("claude-3-haiku") {
+        } else if model_lower.contains("claude-3-haiku") || model_lower.contains("claude-haiku-") {
             Self {
                 input_cost_per_1k: 0.00025,
                 output_cost_per_1k: 0.00125,
@@ -352,6 +368,44 @@ mod tests {
         // Total = $0.0108375
         let cost = pricing.calculate_cost(1000, 500, Some(200), Some(50));
         assert!((cost - 0.010_837_5).abs() < 0.0001);
+    }
+
+    // Regression tests for #3981: model-family/pricing matching was
+    // generation-locked to literal `-4` substrings, so gen-5 model IDs
+    // (`claude-sonnet-5`, `claude-opus-5`, `claude-fable-5`) fell through to
+    // the Sonnet-priced default — a 5x cost under-report for Opus 5.
+
+    #[test]
+    fn test_pricing_matches_gen5_sonnet() {
+        let gen5 = ModelPricing::for_model("claude-sonnet-5");
+        let gen4 = ModelPricing::for_model("claude-sonnet-4");
+        assert!((gen5.input_cost_per_1k - gen4.input_cost_per_1k).abs() < f64::EPSILON);
+        assert!((gen5.input_cost_per_1k - 0.003).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_pricing_matches_gen5_opus_not_sonnet() {
+        let opus5 = ModelPricing::for_model("claude-opus-5");
+        // Opus-5 must NOT silently fall through to the Sonnet default.
+        assert!((opus5.input_cost_per_1k - 0.015).abs() < f64::EPSILON);
+        assert!((opus5.output_cost_per_1k - 0.075).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_pricing_matches_gen5_fable() {
+        // `claude-fable-5` has no published rate; it is conservatively priced
+        // at the Opus rate rather than defaulting to (cheaper) Sonnet.
+        let fable5 = ModelPricing::for_model("claude-fable-5");
+        let opus = ModelPricing::for_model("claude-opus-4");
+        assert!((fable5.input_cost_per_1k - opus.input_cost_per_1k).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_pricing_future_generation_still_matches_family_stem() {
+        // A hypothetical future generation must still classify correctly via
+        // the family-stem match, not require a code change.
+        let gen6_opus = ModelPricing::for_model("claude-opus-6");
+        assert!((gen6_opus.input_cost_per_1k - 0.015).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/loom-tools/src/loom_tools/sweep_experiment.py
+++ b/loom-tools/src/loom_tools/sweep_experiment.py
@@ -272,14 +272,24 @@ def arm_model(arm: str) -> str:
 
 
 def _model_family(model: str | None) -> str | None:
-    """Normalize a model alias or pinned ID to its family (mirrors ``model_pricing``)."""
+    """Normalize a model alias or pinned ID to its family (mirrors ``model_pricing``).
+
+    Matching is **generation-agnostic**: it keys off the family stem
+    (``claude-sonnet-``, ``claude-opus-``, ``claude-haiku-``, ``claude-fable-``)
+    rather than a pinned generation number, so a future ``claude-sonnet-6`` (or
+    any other new generation) classifies correctly with no code change (#3981).
+    The legacy ``claude-3-5-sonnet`` / ``claude-3-opus`` / ``claude-3-haiku`` IDs
+    predate the ``-<generation>-`` naming scheme and are matched explicitly.
+    """
     m = (model or "").lower()
-    if "claude-3-5-sonnet" in m or "claude-sonnet-4" in m or m == "sonnet":
+    if m == "sonnet" or "claude-3-5-sonnet" in m or "claude-sonnet-" in m:
         return "sonnet"
-    if "claude-3-opus" in m or "claude-opus-4" in m or m == "opus":
+    if m == "opus" or "claude-3-opus" in m or "claude-opus-" in m:
         return "opus"
-    if "claude-3-haiku" in m or m == "haiku":
+    if m == "haiku" or "claude-3-haiku" in m or "claude-haiku-" in m:
         return "haiku"
+    if m == "fable" or "claude-fable-" in m:
+        return "fable"
     return None
 
 
@@ -393,13 +403,26 @@ def build_record(
 # --------------------------------------------------------------------------- #
 
 # (input, output, cache_read, cache_write) US$ per 1k tokens.
+#
+# Matching is generation-agnostic (see ``_model_family``) — it keys off the
+# family stem so a future generation (e.g. ``claude-sonnet-6``) prices
+# correctly with no code change (#3981). ``claude-fable-5`` has no published
+# per-token rate (it is an escalation-ladder rung above Opus, #3702), so it is
+# conservatively priced at the Opus rate rather than silently falling through
+# to the cheaper Sonnet default and under-reporting cost.
 def model_pricing(model: str | None) -> tuple[float, float, float, float]:
     m = (model or "").lower()
-    if "claude-3-5-sonnet" in m or "claude-sonnet-4" in m or m == "sonnet":
+    if m == "sonnet" or "claude-3-5-sonnet" in m or "claude-sonnet-" in m:
         return (0.003, 0.015, 0.0003, 0.00375)
-    if "claude-3-opus" in m or "claude-opus-4" in m or m == "opus":
+    if (
+        m == "opus"
+        or m == "fable"
+        or "claude-3-opus" in m
+        or "claude-opus-" in m
+        or "claude-fable-" in m
+    ):
         return (0.015, 0.075, 0.0015, 0.01875)
-    if "claude-3-haiku" in m or m == "haiku":
+    if m == "haiku" or "claude-3-haiku" in m or "claude-haiku-" in m:
         return (0.00025, 0.00125, 0.00003, 0.0003)
     # Default to Sonnet pricing as a reasonable middle ground (matches Rust).
     return (0.003, 0.015, 0.0003, 0.00375)

--- a/loom-tools/tests/test_sweep_experiment.py
+++ b/loom-tools/tests/test_sweep_experiment.py
@@ -220,6 +220,63 @@ def test_infer_arm_from_model_unknown_is_none():
 
 
 # --------------------------------------------------------------------------- #
+# Generation-agnostic family/pricing matching (#3981)
+# --------------------------------------------------------------------------- #
+
+
+def test_model_family_matches_gen5_models():
+    # Matching keys off the family stem, not a pinned generation number, so
+    # gen-5 model IDs classify correctly instead of falling through to None.
+    assert se._model_family("claude-sonnet-5") == "sonnet"
+    assert se._model_family("claude-opus-5") == "opus"
+    assert se._model_family("claude-fable-5") == "fable"
+
+
+def test_model_family_matches_future_generation():
+    # A hypothetical future generation must still classify via the family
+    # stem, with no code change required.
+    assert se._model_family("claude-sonnet-6") == "sonnet"
+    assert se._model_family("claude-opus-6") == "opus"
+
+
+def test_model_family_still_matches_legacy_and_aliases():
+    assert se._model_family("claude-3-5-sonnet") == "sonnet"
+    assert se._model_family("claude-3-opus") == "opus"
+    assert se._model_family("claude-3-haiku") == "haiku"
+    assert se._model_family("sonnet") == "sonnet"
+    assert se._model_family("opus") == "opus"
+    assert se._model_family("haiku") == "haiku"
+    assert se._model_family("fable") == "fable"
+
+
+def test_model_family_unknown_is_none():
+    assert se._model_family("gpt-4") is None
+    assert se._model_family(None) is None
+    assert se._model_family("") is None
+
+
+def test_infer_arm_from_model_gen5():
+    # claude-sonnet-5 / claude-opus-5 are the resolved IDs behind the
+    # sonnet/opus aliases as of #3981 and must attribute the same as gen-4.
+    assert se.infer_arm_from_model("claude-opus-5") == "A"
+    assert se.infer_arm_from_model("claude-sonnet-5") == "B"
+
+
+def test_opus5_pricing_is_not_sonnet_pricing():
+    # Regression: claude-opus-5 must not fall through to the Sonnet default
+    # (a 5x cost under-report).
+    assert se.model_pricing("claude-opus-5") == se.model_pricing("claude-opus-4-8")
+    assert se.model_pricing("claude-opus-5") != se.model_pricing("claude-sonnet-5")
+
+
+def test_fable5_pricing_is_not_sonnet_default():
+    # claude-fable-5 has no published rate; it must not silently default to
+    # the cheaper Sonnet pricing either.
+    assert se.model_pricing("claude-fable-5") == se.model_pricing("claude-opus-4-8")
+    assert se.model_pricing("claude-fable-5") != se.model_pricing("claude-sonnet-5")
+
+
+# --------------------------------------------------------------------------- #
 # Pricing + transcript usage
 # --------------------------------------------------------------------------- #
 


### PR DESCRIPTION
## Summary

`_model_family()` / `model_pricing()` (Python, `loom_tools/sweep_experiment.py`) and `ModelPricing::for_model` (Rust, `loom-daemon/src/activity/resource_usage.rs`) matched literal generation-4 substrings (`claude-sonnet-4`, `claude-opus-4`) instead of matching generation-agnostically. Since the CLI's `sonnet`/`opus` aliases now resolve to `claude-sonnet-5` / `claude-opus-5`, `_model_family("claude-sonnet-5")` returned `None` and `claude-opus-5` fell through to the (cheaper) Sonnet pricing default — a 5x cost under-report for Opus-5, and a lost family/arm attribution for Sonnet-5.

## Changes

- `loom-tools/src/loom_tools/sweep_experiment.py`: `_model_family()` and `model_pricing()` now match on the family stem (`claude-sonnet-`, `claude-opus-`, `claude-haiku-`, `claude-fable-`) instead of a pinned generation number, so a future generation (e.g. `claude-sonnet-6`) classifies correctly with no code change. Also added `claude-fable-` classification (the #3702 escalation-ladder rung above Opus), priced conservatively at the Opus rate since it has no published rate of its own.
- `loom-daemon/src/activity/resource_usage.rs`: mirrored the same generation-agnostic stem matching and `fable` pricing in `ModelPricing::for_model`, plus doc comments cross-referencing the Python mirror.
- `loom-tools/tests/test_sweep_experiment.py` and `loom-daemon/src/activity/resource_usage.rs` (`#[cfg(test)] mod tests`): added regression tests for gen-5 family/arm classification, gen-6 forward-compatibility, `fable` classification/pricing, and the opus-5-not-sonnet-pricing check.

## Historical-record re-attribution note

Per the issue-owner's own correction comment on #3981 (2026-07-26): this defect is **latent, not live**. `sweep.modelExperiment` is unset everywhere, `.loom/stats/sweep-model-stats.jsonl` has never been written in any managed repo, and the `resource_usage` / `token_usage` / `agent_metrics` activity-DB tables are all 0 rows. `_model_family()` is only reached from the experiment harvest, which has never run. **There is no history to re-attribute** — no `"?"`-bucketed observe records currently exist that could be recovered by this fix. This PR is a prerequisite that must land before `sweep.modelExperiment` is switched on for the first time.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| Family/pricing matching is generation-agnostic (stem match, not pinned generation) | ✅ | Both `_model_family`/`model_pricing` (Python) and `ModelPricing::for_model` (Rust) now match `claude-sonnet-`, `claude-opus-`, `claude-haiku-` stems; `test_model_family_matches_future_generation` / `test_pricing_future_generation_still_matches_family_stem` assert `claude-sonnet-6`/`claude-opus-6` classify with no code change |
| `claude-fable-5` is classified | ✅ | `_model_family("claude-fable-5") == "fable"`; `test_fable5_pricing_is_not_sonnet_default` / `test_pricing_matches_gen5_fable` |
| Pricing entries exist for gen-5 models; fall-through no longer mis-prices a premium model as Sonnet | ✅ | `test_opus5_pricing_is_not_sonnet_pricing` / `test_pricing_matches_gen5_opus_not_sonnet` assert Opus-5 pricing equals Opus-4 pricing and differs from Sonnet |
| Python and Rust stay mirrors of each other | ✅ | Identical stem-matching logic and `fable`->Opus-rate fallback ported 1:1 in both files; doc comments cross-reference each other |
| Regression tests assert `_model_family("claude-sonnet-5") == "sonnet"`, `_model_family("claude-opus-5") == "opus"`, opus-5 doesn't get Sonnet pricing | ✅ | `test_model_family_matches_gen5_models`, `test_opus5_pricing_is_not_sonnet_pricing` (Python); `test_pricing_matches_gen5_sonnet`, `test_pricing_matches_gen5_opus_not_sonnet` (Rust) |
| Note on historical-record re-attribution | ✅ | See "Historical-record re-attribution note" above — no history exists to recover |

## Test Plan

```bash
PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/test_sweep_experiment.py -v
# 45 passed

cd loom-daemon && cargo test --lib activity::resource_usage
# 17 passed

cd loom-daemon && cargo fmt -- --check && cargo clippy --lib -- -D warnings
# clean
```

Closes #3981