### PR TITLE
fix(daemon,tools): decide before pruning dead sweep-journal entries; never-silent staleness skips

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -660,6 +660,88 @@ The reaper (`sweep_registry::spawn_reaper_task`) ticks every 30 seconds
 4. Garbage-collects terminal entries older than the retention window
    (default 1 hour).
 
+## Stale-claim reconciliation & the sweep journal (#3953, fixed #3975)
+
+Two independent surfaces reclaim abandoned `loom:building` claims when the
+sweep that owned them has died, using the same evidence source and the same
+decision rule:
+
+| Surface | Where | When it runs |
+|---------|-------|---------------|
+| Rust startup reconciliation | `claim_reconciliation::forge::reconcile_workspace` (called from `main.rs` at daemon startup, guarded by `LOOM_STALE_CLAIM_RECONCILE`, default on) | Once, on every daemon start, across every `effective_roots()` workspace |
+| Python `loom-recover-orphans` | `loom_tools.orphan_recovery.check_untracked_building` | On demand (operator/cron invocation of `loom-recover-orphans [--recover]`) |
+
+Both read the same machine-level **sweep journal** (`~/.loom/sweeps.json`,
+override `LOOM_SWEEPS_JOURNAL_PATH`, written by `sweep_journal::record_sweep`
+on every `SweepRegistry::dispatch`) and apply the same three-way decision
+rule per `loom:building` issue:
+
+1. **Journal entry with a live recorded PID** → keep (genuinely in-flight).
+2. **Journal entry with a dead recorded PID** → reclaim. This is the
+   strongest possible evidence — a specific PID that provably no longer
+   exists — so both surfaces treat it as authoritative.
+3. **No journal entry at all** → reclaim only once the claim has been stale
+   longer than `LOOM_STALE_BUILDING_HOURS` (default 4h; also drives the
+   Rust-side default `DEFAULT_STALE_BUILDING_HOURS`). Absence of a record
+   might mean a live manual `/loom:sweep` the journal was never told about
+   (a pre-journal claim, or the journal file just doesn't exist on this
+   machine), so a much wider grace window applies than for a claim the
+   journal has proof about.
+
+### The #3975 bug: pruning before deciding
+
+The journal is deliberately self-pruning — `sweep_journal::upsert` (every new
+dispatch) and the Rust reconciliation pass both call `prune_dead` to drop
+dead-PID entries so the file never accumulates an unbounded graveyard
+(mirrors `sweep-run-registry.sh`'s `prune_dead`/`peers`, #3768).
+
+Before #3975, `reconcile_workspace` called `prune_dead` **before** calling
+`plan()`/`decide()` — which deleted the exact dead-PID entry the `DeadPid`
+branch above needs to fire its immediate, unconditional reclaim. With the
+entry gone, every claim silently fell through to branch 3 (no record) and
+its much longer `stale_hours` grace window, even for a sweep that had *just*
+died. Two claims in a downstream workspace (issues #6170/#6173: SIGTERMed
+during a daemon restart) sat un-reclaimed for hours because of this —
+`loom-recover-orphans --recover` found and fixed only a third, unrelated
+claim (#6172) whose label happened to already be older than the stale-hours
+threshold. The fix: `reconcile_workspace` now decides against the raw,
+unpruned journal first; pruning happens only afterward, via the normal
+per-reclaimed-issue `remove_sweep` cleanup (leftover dead entries for
+untouched issues are still pruned lazily by the next `upsert` elsewhere).
+
+The Python side (`gather_liveness_evidence` / `check_untracked_building`)
+never pruned the journal itself — it only reads whatever the file currently
+contains — so it was not directly bugged the same way, but it inherited the
+same *symptom*: by the time an operator ran `loom-recover-orphans` by hand,
+a routine daemon dispatch (or the (now-fixed) Rust startup pass) had often
+already pruned the dead-PID evidence out from under it, leaving only the
+weaker "no record" signal to work with.
+
+### Never-silent staleness-gate skips (#3975)
+
+Separately, `check_untracked_building`'s staleness gate (branch 3 above, and
+the short `label_grace_period` gate that also applies to branch 2) used to
+log its "SKIPPED: #N ..." line **only** under `--verbose`, so a default
+(non-verbose) `loom-recover-orphans` run gave no visible trace that a claim
+had been seen and excluded — indistinguishable from the tool never having
+looked at that issue at all. `OrphanRecoveryResult.watched` now records
+every staleness-gated skip (issue, reason, label age, threshold) regardless
+of `--verbose`, and both `format_result_human` and `--json` output always
+include it. A watched entry is explicitly **not** an orphan — it may still
+be alive — but it is never silently dropped.
+
+### One intentional asymmetry: dead-PID grace period
+
+Rust's `decide()` reclaims a `DeadPid` claim **unconditionally** — no
+staleness check at all (see `decide_dead_pid_overrides_label_age`). Python's
+`check_untracked_building` still applies the short `label_grace_period`
+(default 600s) even to a `journal_pid_dead` reason. This is intentional, not
+a bug to unify: the Rust pass runs once per daemon *start*, a rarer and more
+deliberate event, while the Python tool can be invoked ad hoc (including
+immediately after a claim is made, before its journal entry has even been
+written) — the short grace period is defense-in-depth against a race the
+once-per-restart Rust pass is much less exposed to.
+
 ## Stacked-PR dependency — #3729 (v1), #3747 (v2 item 1)
 
 Stacked-PR mode pipelines a genuine dependency: when issue B consumes issue

--- a/loom-daemon/src/claim_reconciliation.rs
+++ b/loom-daemon/src/claim_reconciliation.rs
@@ -144,7 +144,13 @@ pub fn decide(
 }
 
 /// Plan reconciliation decisions for every `issue` in `issues`, given an
-/// already-loaded (and ideally already-pruned) `journal`. Performs no I/O.
+/// already-loaded `journal`. Performs no I/O.
+///
+/// IMPORTANT (#3975): `journal` must be the **raw, unpruned** journal.
+/// Pruning dead-PID entries before calling this function would erase the
+/// exact evidence the `DeadPid` branch of [`decide`] needs to fire its
+/// unconditional, immediate reclaim -- see [`forge::reconcile_workspace`]
+/// for the caller that got this wrong before #3975.
 #[must_use]
 pub fn plan(
     repo: &str,
@@ -284,13 +290,21 @@ pub mod forge {
                 return (0, 0);
             }
         };
-        let mut journal = sweep_journal::load(&journal_path);
-        let pruned = sweep_journal::prune_dead(&mut journal, crate::sweep_registry::is_pid_alive);
-        if pruned > 0 {
-            if let Err(e) = sweep_journal::save(&journal_path, &journal) {
-                log::warn!("claim_reconciliation: failed to persist pruned journal: {e}");
-            }
-        }
+        // IMPORTANT (#3975): decide FIRST against the raw, unpruned journal.
+        // A prior version pruned dead-PID entries here before calling
+        // `plan()`/`decide()` -- which erased the exact evidence the
+        // `DeadPid` branch needs to fire its *unconditional*, immediate
+        // reclaim. With the entry gone, every claim silently fell through
+        // to the `NoRecordStale` branch and its much longer
+        // `stale_hours` grace period, so a claim whose sweep had *just*
+        // died (recent label, dead PID) was wrongly kept for hours instead
+        // of reclaimed right away. Pruning now happens only *after*
+        // deciding, via the per-reclaimed-issue `remove_sweep` below --
+        // dead entries for issues this pass didn't touch are cleaned up
+        // lazily by the next `record_sweep`/`upsert` elsewhere (which
+        // still prunes the whole journal), so the file never accumulates
+        // an unbounded graveyard.
+        let journal = sweep_journal::load(&journal_path);
 
         let stale_hours = resolve_stale_hours();
         let now = chrono::Utc::now();
@@ -335,6 +349,9 @@ mod tests {
     use super::*;
     use chrono::Duration;
     use serial_test::serial;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+    use tempfile::tempdir;
 
     fn issue(number: u32, updated_at: Option<DateTime<Utc>>) -> BuildingIssue {
         BuildingIssue { number, updated_at }
@@ -492,5 +509,80 @@ mod tests {
         assert!((resolve_stale_hours() - DEFAULT_STALE_BUILDING_HOURS).abs() < f64::EPSILON);
 
         std::env::remove_var(STALE_HOURS_ENV);
+    }
+
+    /// Regression test for #3975: `reconcile_workspace` used to prune dead
+    /// journal entries *before* deciding, which erased the exact evidence the
+    /// `DeadPid` branch needs. A claim with a provably-dead recorded PID must
+    /// be reclaimed immediately by the daemon's own startup pass, even when
+    /// the `loom:building` label is only seconds old (well inside the
+    /// `NoRecordStale` grace window) -- two incidents (#6170/#6173 in a
+    /// downstream workspace) were exactly this: SIGTERMed sweeps left a dead
+    /// PID in the journal, and the pre-decide prune silently downgraded them
+    /// to "no record", so they sat un-reclaimed for hours.
+    #[test]
+    #[serial]
+    fn reconcile_workspace_reclaims_dead_pid_entry_even_when_label_is_fresh() {
+        let dir = tempdir().unwrap();
+        let repo_root = dir.path().join("repo");
+        std::fs::create_dir_all(&repo_root).unwrap();
+        let repo_str = repo_root.display().to_string();
+
+        let journal_path = dir.path().join("sweeps.json");
+        std::env::set_var(sweep_journal::JOURNAL_PATH_ENV, &journal_path);
+
+        // Seed a dead-PID entry (pid 0 is always dead per `is_pid_alive`).
+        let mut journal = SweepJournal::default();
+        journal.entries.push(journal_entry(&repo_str, 99, 0));
+        sweep_journal::save(&journal_path, &journal).unwrap();
+
+        // Fake `gh`: `issue list` reports one loom:building issue labeled
+        // *just now* -- fresh enough that the NoRecordStale (age-based) path
+        // would say Keep. Only the DeadPid evidence should trigger a reclaim.
+        let gh_log = dir.path().join("gh-invocations.log");
+        let fake_gh = dir.path().join("fake-gh.sh");
+        let now = Utc::now().to_rfc3339();
+        let script = format!(
+            r#"#!/usr/bin/env bash
+printf '%s\n' "$*" >> "{log}"
+if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
+  echo '[{{"number":99,"updatedAt":"{now}"}}]'
+  exit 0
+fi
+exit 0
+"#,
+            log = gh_log.display(),
+            now = now,
+        );
+        std::fs::write(&fake_gh, &script).unwrap();
+        #[cfg(unix)]
+        {
+            let mut perms = std::fs::metadata(&fake_gh).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&fake_gh, perms).unwrap();
+        }
+
+        let (checked, reclaimed) = forge::reconcile_workspace(&fake_gh, &repo_root);
+
+        assert_eq!(checked, 1);
+        assert_eq!(
+            reclaimed, 1,
+            "a dead-PID journal entry must be reclaimed immediately regardless of \
+             how fresh the loom:building label is (#3975)"
+        );
+
+        let gh_calls = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert!(
+            gh_calls.contains("issue edit 99 --remove-label loom:building --add-label loom:issue"),
+            "expected reclaim to flip labels for #99; got: {gh_calls:?}"
+        );
+
+        // The reclaimed issue's journal entry is cleaned up as part of
+        // recovery -- confirms cleanup still happens, just after (not
+        // before) the decision that needed the evidence.
+        let after = sweep_journal::load(&journal_path);
+        assert!(sweep_journal::find(&after, &repo_str, 99).is_none());
+
+        std::env::remove_var(sweep_journal::JOURNAL_PATH_ENV);
     }
 }

--- a/loom-tools/src/loom_tools/orphan_recovery.py
+++ b/loom-tools/src/loom_tools/orphan_recovery.py
@@ -176,11 +176,44 @@ class RecoveryEntry:
 
 
 @dataclass
+class WatchedEntry:
+    """A ``loom:building`` issue that was inspected but is not (yet) flagged
+    as orphaned because it hasn't cleared the applicable staleness threshold.
+
+    Recorded by :func:`check_untracked_building` every time the staleness
+    gate skips a candidate -- so an operator running the tool, even *without*
+    ``--verbose``, can see exactly which claims were seen and why they were
+    excluded, instead of the exclusion being silent (issue #3975: two of
+    three genuinely-dead claims were silently skipped with no visible trace
+    in the default, non-verbose output).
+    """
+
+    issue: int
+    title: str | None
+    reason: str  # journal_pid_dead | no_spawn_loop_entry | no_journal_record_stale
+    age_seconds: int | None
+    threshold_seconds: float
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "issue": self.issue,
+            "reason": self.reason,
+            "threshold_seconds": self.threshold_seconds,
+        }
+        if self.title is not None:
+            d["title"] = self.title
+        if self.age_seconds is not None:
+            d["age_seconds"] = self.age_seconds
+        return d
+
+
+@dataclass
 class OrphanRecoveryResult:
     """Result of orphan detection and recovery."""
 
     orphaned: list[OrphanEntry] = field(default_factory=list)
     recovered: list[RecoveryEntry] = field(default_factory=list)
+    watched: list[WatchedEntry] = field(default_factory=list)
     recover_mode: bool = False
 
     @property
@@ -191,12 +224,18 @@ class OrphanRecoveryResult:
     def total_recovered(self) -> int:
         return len(self.recovered)
 
+    @property
+    def total_watched(self) -> int:
+        return len(self.watched)
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "orphaned": [o.to_dict() for o in self.orphaned],
             "recovered": [r.to_dict() for r in self.recovered],
+            "watched": [w.to_dict() for w in self.watched],
             "total_orphaned": self.total_orphaned,
             "total_recovered": self.total_recovered,
+            "total_watched": self.total_watched,
             "recover_mode": self.recover_mode,
         }
 
@@ -650,6 +689,20 @@ def check_untracked_building(
                         f"applied {label_age}s ago (threshold: "
                         f"{threshold_seconds:.0f}s, reason if stale: {reason})"
                     )
+                # Always record the skip -- issue #3975: this used to be
+                # visible only with --verbose, so an operator running the
+                # default (non-verbose) invocation had no trace that a claim
+                # was seen and excluded. `result.watched` makes every
+                # staleness-gated skip visible in both human and JSON output.
+                result.watched.append(
+                    WatchedEntry(
+                        issue=issue_num,
+                        title=issue_title,
+                        reason=reason,
+                        age_seconds=label_age,
+                        threshold_seconds=threshold_seconds,
+                    )
+                )
                 continue
 
         if verbose:
@@ -1121,6 +1174,24 @@ def format_result_human(result: OrphanRecoveryResult) -> str:
             lines.append("")
             lines.append("Run with --recover to fix these issues")
 
+    # Always surface watched (seen-but-not-yet-stale) claims, even in the
+    # zero-orphan case and without --verbose -- issue #3975: a claim excluded
+    # by the staleness gate must never be silent.
+    if result.watched:
+        lines.append("")
+        lines.append(
+            f"{result.total_watched} claim(s) seen but not yet stale enough to reclaim:"
+        )
+        for w in result.watched:
+            age_str = format_duration(w.age_seconds or 0)
+            threshold_str = format_duration(int(w.threshold_seconds))
+            remaining = max(0, int(w.threshold_seconds) - (w.age_seconds or 0))
+            lines.append(
+                f"  [watched] #{w.issue}: {w.title or 'no title'} -- "
+                f"skipped ({w.reason}): label age {age_str}, "
+                f"threshold {threshold_str}, eligible in {format_duration(remaining)}"
+            )
+
     return "\n".join(lines)
 
 
@@ -1138,6 +1209,13 @@ Exit codes:
 Orphan types:
     untracked_building  - Issue has loom:building but no spawn-loop task
     stale_heartbeat     - Spawn-loop task heartbeat is stale and pid is dead
+
+Watched claims (issue #3975):
+    A loom:building issue the staleness gate skipped (label age below the
+    applicable threshold) is never silently dropped -- it is always listed
+    as a "watched" entry, in both human and --json output, with the reason
+    and the remaining time before it becomes eligible. This is distinct
+    from an orphan: a watched claim MAY still be alive.
 
 Recovery actions:
     reset_issue_label       - Swap loom:building -> loom:issue on issue

--- a/loom-tools/tests/test_orphan_recovery.py
+++ b/loom-tools/tests/test_orphan_recovery.py
@@ -33,6 +33,7 @@ from loom_tools.orphan_recovery import (
     OrphanRecoveryResult,
     _locked_issue_numbers,
     check_untracked_building,
+    format_result_human,
     gather_liveness_evidence,
     run_orphan_recovery,
 )
@@ -613,3 +614,96 @@ def test_journal_repo_matches_exact_and_resolved(tmp_path: pathlib.Path) -> None
     assert orphan_recovery._journal_repo_matches(str(repo), repo) is True
     assert orphan_recovery._journal_repo_matches(str(repo) + "/", repo) is True
     assert orphan_recovery._journal_repo_matches("/some/other/repo", repo) is False
+
+
+# ---------------------------------------------------------------------------
+# Watched entries — issue #3975: a staleness-gated skip must never be silent.
+# ---------------------------------------------------------------------------
+
+
+def test_no_record_stale_gate_skip_is_watched_not_silent(
+    tmp_path: pathlib.Path, _isolated_journal_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Companion to ``test_journal_no_record_within_stale_hours_is_not_recovered``:
+    the exact scenario that used to be invisible without --verbose must now
+    show up in ``result.watched`` (issue #3975)."""
+    repo = _make_repo(tmp_path)
+    _write_journal(_isolated_journal_path, [{"repo": str(repo), "issue": 999, "pid": 1}])
+    monkeypatch.setenv("LOOM_STALE_BUILDING_HOURS", "4")
+    gh = _GhRecorder(allow_edit=False)
+
+    with mock.patch.object(
+        orphan_recovery, "_pid_alive", return_value=True,
+    ), mock.patch.object(
+        orphan_recovery, "gh_issue_list",
+        return_value=[{"number": 42, "title": "no journal entry, not stale enough yet"}],
+    ), mock.patch.object(
+        orphan_recovery, "_get_building_label_age", return_value=3600,  # 1h: > 600s grace, < 4h
+    ), mock.patch.object(
+        orphan_recovery, "has_valid_claim", return_value=False,
+    ), mock.patch.object(orphan_recovery, "gh_run", gh):
+        # verbose=False -- the default, non-verbose invocation that used to
+        # leave this skip completely invisible.
+        result = run_orphan_recovery(repo, recover=True, verbose=False)
+
+    assert result.total_orphaned == 0
+    assert gh.edited_issues == []
+    assert result.total_watched == 1
+    watched = result.watched[0]
+    assert watched.issue == 42
+    assert watched.reason == "no_journal_record_stale"
+    assert watched.age_seconds == 3600
+    assert watched.threshold_seconds == pytest.approx(4 * 3600)
+
+
+def test_label_grace_gate_skip_is_watched_not_silent(tmp_path: pathlib.Path) -> None:
+    """A fresh loom:building label (within the short grace period) with no
+    journal at all -- must also be watched, not silently dropped."""
+    repo = _make_repo(tmp_path)
+    _make_lock(repo, 999)  # unrelated active source
+
+    with mock.patch.object(
+        orphan_recovery, "gh_issue_list",
+        return_value=[{"number": 42, "title": "freshly labeled"}],
+    ), mock.patch.object(
+        orphan_recovery, "_get_building_label_age", return_value=30,  # well under 600s grace
+    ), mock.patch.object(
+        orphan_recovery, "has_valid_claim", return_value=False,
+    ):
+        result = run_orphan_recovery(repo, recover=False, verbose=False)
+
+    assert result.total_orphaned == 0
+    assert result.total_watched == 1
+    watched = result.watched[0]
+    assert watched.issue == 42
+    assert watched.reason == "no_spawn_loop_entry"
+    assert watched.age_seconds == 30
+    assert watched.threshold_seconds == orphan_recovery.DEFAULT_LABEL_GRACE_PERIOD
+
+
+def test_watched_entries_serialize_in_to_dict(tmp_path: pathlib.Path) -> None:
+    result = OrphanRecoveryResult()
+    result.watched.append(
+        orphan_recovery.WatchedEntry(
+            issue=7, title="t", reason="no_spawn_loop_entry",
+            age_seconds=10, threshold_seconds=600.0,
+        )
+    )
+    d = result.to_dict()
+    assert d["total_watched"] == 1
+    assert d["watched"][0]["issue"] == 7
+    assert d["watched"][0]["reason"] == "no_spawn_loop_entry"
+
+
+def test_format_result_human_lists_watched_entries_even_with_zero_orphans() -> None:
+    result = OrphanRecoveryResult()
+    result.watched.append(
+        orphan_recovery.WatchedEntry(
+            issue=42, title="freshly labeled", reason="no_spawn_loop_entry",
+            age_seconds=30, threshold_seconds=600.0,
+        )
+    )
+    text = format_result_human(result)
+    assert "No orphaned tasks found" in text
+    assert "#42" in text
+    assert "no_spawn_loop_entry" in text


### PR DESCRIPTION
## Summary

`loom-recover-orphans --recover` was missing genuinely-dead `loom:building` claims that had a dead recorded PID in the machine-level sweep journal (`~/.loom/sweeps.json`, #3953) but no linked PR. Root cause: `claim_reconciliation::forge::reconcile_workspace` (the daemon's startup reconciliation pass) called `sweep_journal::prune_dead` **before** calling `plan()`/`decide()` -- which erased the exact dead-PID evidence the `DeadPid` branch needs to fire its unconditional, immediate reclaim. With the entry gone, every claim silently fell through to the much longer "no journal record" grace window (default 4h), even for a sweep that had *just* died. In the reported incident, two claims (#6170/#6173, SIGTERMed during a daemon restart) sat un-reclaimed for hours while `loom-recover-orphans --recover` found and fixed only one unrelated stale claim (#6172) whose label happened to already be older than the 4h threshold.

## Changes

- **`loom-daemon/src/claim_reconciliation.rs`**: `reconcile_workspace` now decides against the raw, unpruned journal first. Pruning still happens, but only afterward via the existing per-reclaimed-issue `remove_sweep` cleanup (dead entries for issues this pass didn't touch are pruned lazily by the next `upsert` elsewhere, so the journal file never accumulates an unbounded graveyard). Added a regression test (`reconcile_workspace_reclaims_dead_pid_entry_even_when_label_is_fresh`) using a fake `gh` script that proves a dead-PID entry is reclaimed immediately even when the `loom:building` label is only seconds old.
- **`loom-tools/src/loom_tools/orphan_recovery.py`**: every staleness-gated skip in `check_untracked_building` is now recorded in a new `OrphanRecoveryResult.watched` list (issue, reason, label age, threshold) and always surfaced in both human and `--json` output -- previously this was logged only under `--verbose`, so a default invocation gave zero visible trace that a claim was seen and excluded (acceptance criterion: "never silent").
- **`.loom/docs/daemon-reference.md`**: new section documenting the shared decision rule between the Rust startup pass and the Python tool (they read the same journal and apply the same 3-way rule), the #3975 bug and fix, and the one intentional asymmetry that remains (Rust's `DeadPid` reclaim is unconditional; Python still applies the short `label_grace_period` as defense-in-depth since it can run ad hoc, not just once per daemon start).
- Added/updated Python tests covering both new watched-entry scenarios (short label-grace skip, long no-record-stale skip) plus JSON/human formatting.

## Test plan

- [x] `cargo test --lib claim_reconciliation` (12 tests, including the new regression test) -- all pass
- [x] `cargo test --lib sweep_journal` -- unaffected, all pass
- [x] `cargo fmt -- --check` / `cargo clippy --lib -- -D warnings` -- clean
- [x] `cargo build --bin loom-daemon` -- compiles
- [x] `PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/test_orphan_recovery.py loom-tools/tests/test_recovery_stats.py -q` -- 65 pass
- [x] `ruff check` on changed Python files -- clean (pre-existing `ruff format` drift on both files predates this change, confirmed against `origin/main`)

Closes #3975