### PR TITLE
fix(build-gate,tests): scope local gate to host-deterministic checks; make tmux/timing tests environment-robust (#3985)

### DIFF
--- a/.loom/docs/build-gate.md
+++ b/.loom/docs/build-gate.md
@@ -122,7 +122,10 @@ The wrapper lives at [`defaults/scripts/build-gate.sh`](../scripts/build-gate.sh
 to it via the `.loom/scripts -> ../defaults/scripts` symlink). It runs three
 stages in order under `set -euo pipefail`, aborting on the first non-zero exit:
 
-1. `cargo test --workspace` — the Rust crates (`loom-daemon`, `loom-api`).
+1. `cargo test --workspace --lib --bins` — the Rust crates' **unit tests**
+   (`loom-daemon`, `loom-api`). The integration test **targets** under
+   `loom-daemon/tests/` are deliberately excluded here — see "Local gate vs.
+   CI" below.
 2. `uv run pytest tests/ -q` in `loom-tools/`, scoped with
    `--ignore=tests/integration` (live-network/credentials e2e) and
    `--ignore=tests/tokens/test_agent_spawn_integration.py` (a slow real-time
@@ -143,6 +146,62 @@ and free of network/npm dependencies. This is a repo-specific,
 self-hosting-only config; `defaults/config.json` (the generic install template)
 ships with no `buildGate` block. See issue
 [#3749](https://github.com/rjwalters/loom/issues/3749).
+
+### Local gate vs. CI: the environment-sensitivity boundary (#3985)
+
+The local gate and GitHub CI run *nearly* the same Rust command, but they
+measure different things, and that difference is deliberate:
+
+| | Command | Measures |
+|---|---------|----------|
+| **CI** (`.github/workflows/ci.yml`) | `cargo test --workspace` (all targets, incl. integration) | **the commit**, in a controlled runner with a guaranteed-live tmux |
+| **Local gate** (`build-gate.sh`) | `cargo test --workspace --lib --bins` (unit tests only) | **the commit**, on whatever host is actively running Loom |
+
+The local gate runs on the machine that is *also running the sweeps* — a busy,
+sometimes headless, sometimes tmux-less host. Any assertion in the gate that
+depends on that host's configuration measures the **host**, not `main`, and so
+can go red for a reason that has nothing to do with the code being gated. That
+is inverted: a gate is supposed to be green when `main` is correct, not green
+only when the host happens to be idle and fully provisioned.
+
+Two concrete failure classes motivated the split (#3985):
+
+- **Dead tmux server.** The `loom-daemon/tests/integration_basic.rs` terminal
+  tests create real tmux sessions and assert they exist. On a host with no
+  reachable tmux server they can only fail. These live in integration test
+  **targets**, which `--lib --bins` excludes — so the gate never runs them,
+  and CI (which always has tmux) still does. As belt-and-suspenders, those
+  tests now **skip cleanly** (via a `require_tmux!()` probe) rather than fail
+  when no tmux is available, so even a full local `cargo test --workspace`
+  stays green on a tmux-less host.
+- **CPU starvation.** A few `sweep_registry` unit tests wait on a fixture child
+  with a wall-clock deadline. Under heavy host load (the gate itself, when it
+  was re-running continuously, cf. #3984) the child could miss a tight 5–10s
+  deadline purely because it was never scheduled. Those bounds are now generous
+  (`FIXTURE_CHILD_WAIT_MS`, 60s), and the whole gate runs under `nice` (below)
+  so it can never starve the very processes it is timing.
+
+**The gate runs at reduced priority.** `build-gate.sh` re-execs itself once
+under `nice -n 19` (the sentinel `LOOM_BUILD_GATE_NICED` prevents a loop) so a
+long `cargo` compile can never starve the sweeps — or the timing-sensitive
+tests — it shares a host with. Tunable via `LOOM_BUILD_GATE_NICENESS`; disable
+with `LOOM_BUILD_GATE_NICE=0`. If `nice` is unavailable the gate proceeds at
+normal priority.
+
+> **Rule of thumb:** if a check's outcome can differ between an idle host and a
+> busy one — or between a host with tmux and one without — it is
+> **environment-sensitive** and belongs in CI (which controls its
+> environment), not in the local post-builder gate. Keep the gate scoped to
+> checks that are deterministic on any host.
+
+**Forge-CI corroboration (deferred).** The curated issue's fourth acceptance
+criterion — when the local gate disagrees with a *green* forge CI result on the
+same evaluated SHA, prefer the forge signal and log the divergence loudly
+rather than halting — is a distinct, larger daemon-side feature (it belongs
+with the RED-classification work in #3974 AC4, not the test/scope hardening
+here). It is intentionally **not** implemented in this change; the scope split
++ test hardening + `nice` above already break the self-reddening loop this
+issue targets. Tracked as follow-up under #3974.
 
 ## Failure semantics
 

--- a/defaults/scripts/build-gate.sh
+++ b/defaults/scripts/build-gate.sh
@@ -5,7 +5,18 @@
 # meaningful. See .loom/docs/build-gate.md.
 #
 # Scope decisions (issue #3749):
-#   - cargo test --workspace covers the Rust crates (loom-daemon, loom-api).
+#   - cargo test covers the Rust crates (loom-daemon, loom-api). As of #3985
+#     the Rust step is scoped to `--lib --bins` (crate unit tests only) and
+#     deliberately EXCLUDES the integration test TARGETS under
+#     loom-daemon/tests/ (integration_basic.rs et al). Those spin up a real
+#     tmux server and are therefore host-dependent — green only where a live
+#     tmux is reachable. The local gate runs on the very host that is actively
+#     running Loom (a busy, sometimes tmux-less machine), so a host-dependent
+#     assertion there measures the host, not `main`. CI (.github/workflows/
+#     ci.yml) controls its environment and still runs the FULL
+#     `cargo test --workspace`, so the integration targets are covered exactly
+#     where their environment is guaranteed. See "Local gate vs. CI" in
+#     .loom/docs/build-gate.md.
 #   - loom-tools pytest runs via `uv run` so the package is importable from
 #     the project venv; scoped to exclude the live-network e2e suite
 #     (tests/integration) and the known slow real-time bypass-poll integration
@@ -17,10 +28,25 @@
 #     unpredictable latency to a gate that also runs once per PR. CI still
 #     gates the mcp-loom build.
 set -euo pipefail
+
+# Run the whole gate at reduced CPU/IO priority (#3985) so it can never starve
+# the sweeps it shares a host with. The gate historically ran the workspace
+# suite at ~100% duty cycle; at nice 0 that saturation starved the timing-
+# sensitive sweeps (and the gate's own timing tests). Re-exec once under `nice`
+# (guarded by a sentinel so we don't loop), best-effort — if `nice` is absent
+# we just proceed at normal priority. Honors LOOM_BUILD_GATE_NICENESS (default
+# 19, the lowest priority) and can be disabled with LOOM_BUILD_GATE_NICE=0.
+if [[ -z "${LOOM_BUILD_GATE_NICED:-}" \
+      && "${LOOM_BUILD_GATE_NICE:-1}" != "0" ]] \
+   && command -v nice >/dev/null 2>&1; then
+  export LOOM_BUILD_GATE_NICED=1
+  exec nice -n "${LOOM_BUILD_GATE_NICENESS:-19}" "$0" "$@"
+fi
+
 cd "$(git rev-parse --show-toplevel)"
 
-echo "[build-gate] cargo test --workspace"
-cargo test --workspace
+echo "[build-gate] cargo test --lib --bins (workspace unit tests; host-dependent integration targets are CI-only, #3985)"
+cargo test --workspace --lib --bins
 
 echo "[build-gate] loom-tools pytest (scoped, excludes network e2e + known slow poll test)"
 (

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -4040,6 +4040,29 @@ exit 0
 
     /// Wait until `path` exists AND contains `needle`. Returns true on
     /// success, false on timeout.
+    /// Generous wall-clock budget for waiting on a fixture child that normally
+    /// completes near-instantly (writes its record file / exits). The build
+    /// gate historically ran the workspace suite at ~100% duty cycle (#3984),
+    /// and under that self-inflicted CPU starvation a fixture child that
+    /// "exits immediately" could still miss a 5–10s deadline purely because it
+    /// was never scheduled — reddening the gate for a host-load reason, not a
+    /// code regression (#3985). A 60s budget is orders of magnitude over the
+    /// real completion time on an idle host, so it never slows a green run,
+    /// but it absorbs even severe scheduler contention. Prefer bumping this
+    /// (or restructuring to await a signal) over tightening it.
+    ///
+    /// NOTE: on macOS, spawning the fixture child execs a *freshly written*
+    /// `spawn-claude.sh`, which Gatekeeper (`syspolicyd`/`amfid`) must assess
+    /// before the first exec — and that assessment can stall for tens of
+    /// seconds when a background AV/backup (Backblaze, XProtect) has the
+    /// security daemons pegged. That is a host condition, not a code fault, so
+    /// the budget is set well above the worst stall observed in the wild
+    /// (#3985). Because every caller *polls* and returns the instant the
+    /// condition is met, a large budget costs nothing on a healthy host — it
+    /// only widens the tolerance before a genuinely stuck child is declared
+    /// failed.
+    const FIXTURE_CHILD_WAIT_MS: u64 = 120_000;
+
     fn wait_for_contents(path: &Path, needle: &str, timeout_ms: u64) -> bool {
         let start = std::time::Instant::now();
         while start.elapsed().as_millis() < u128::from(timeout_ms) {
@@ -4207,9 +4230,11 @@ exit 0
         assert_eq!(entry.pid, outcome.pid);
 
         // The fixture's fake spawn-claude.sh exits immediately, so the pid is
-        // dead almost immediately; wait for the reaper's dead-PID path.
-        let dead = wait_for_condition(10_000, || !is_pid_alive(outcome.pid));
-        assert!(dead, "fixture child did not exit within 10s");
+        // dead almost immediately; wait for the reaper's dead-PID path. The
+        // budget is deliberately generous (#3985) so host CPU starvation — not
+        // a code fault — can never redden this via a missed deadline.
+        let dead = wait_for_condition(FIXTURE_CHILD_WAIT_MS, || !is_pid_alive(outcome.pid));
+        assert!(dead, "fixture child did not exit within the wait budget");
 
         registry.reap_once();
 
@@ -4380,8 +4405,9 @@ exit 0
 
         let needle = format!("LOOM_TERMINAL_ID=daemon-{}", outcome.sweep_id);
         assert!(
-            wait_for_contents(&record_log, &needle, 10000),
-            "fake spawn-claude.sh did not finish writing within 10s"
+            // Generous budget (#3985): a busy host must not turn this red.
+            wait_for_contents(&record_log, &needle, FIXTURE_CHILD_WAIT_MS),
+            "fake spawn-claude.sh did not finish writing within the wait budget"
         );
         let recorded = std::fs::read_to_string(&record_log).unwrap();
         assert!(
@@ -7491,8 +7517,10 @@ exit 0\n";
             elapsed >= Duration::from_millis(400),
             "second dispatch should have waited out the stagger; elapsed={elapsed:?}"
         );
-        // Both fake children ran.
-        assert!(wait_for_contents(&rec, "issue=8002", 5000) || rec.exists());
+        // Both fake children ran. Generous budget (#3985): under host CPU
+        // starvation the children can be slow to be scheduled onto the record
+        // log, so a tight 5s bound made this red for a host-load reason.
+        assert!(wait_for_contents(&rec, "issue=8002", FIXTURE_CHILD_WAIT_MS) || rec.exists());
     }
 
     // --- watchdog_once: bounded auto-restart end-to-end ---

--- a/loom-daemon/tests/common/mod.rs
+++ b/loom-daemon/tests/common/mod.rs
@@ -398,6 +398,38 @@ pub fn tmux_server_running() -> bool {
         .unwrap_or(false)
 }
 
+/// Probe whether tmux is actually *usable* on this host (issue #3985).
+///
+/// Returns `true` only when the `tmux` binary is present AND a server can be
+/// started on the dedicated `-L loom` socket — i.e. a throwaway detached
+/// session can be created and torn down. This is stronger than
+/// [`tmux_server_running`] (which only checks whether a server is *already*
+/// up): the terminal integration tests need to *create* sessions, so what
+/// matters is whether tmux can fork a server at all, not whether one already
+/// exists.
+///
+/// The point is to let host-dependent terminal tests **skip cleanly** on a
+/// machine without a working tmux (no binary, dead server, unwritable
+/// `/tmp/tmux-*` socket dir) instead of reddening the shared build gate. CI —
+/// which controls its environment and always has a working tmux — still
+/// exercises every one of these paths, so coverage is unchanged where it
+/// matters. See `.loom/docs/build-gate.md` (§"Local gate vs. CI").
+#[allow(dead_code)]
+pub fn tmux_available() -> bool {
+    let probe = format!("loom-{}-tmuxprobe", *TEST_PREFIX);
+    // `new-session -d` (detached) with the default shell forks a server on the
+    // loom socket if one isn't already running. Success => tmux is usable.
+    let started = Command::new("tmux")
+        .args(["-L", "loom", "new-session", "-d", "-s", &probe])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if started {
+        kill_tmux_session(&probe);
+    }
+    started
+}
+
 /// Helper: Capture terminal output using tmux capture-pane
 ///
 /// Uses tmux's built-in capture mechanism to read the terminal's pane content.

--- a/loom-daemon/tests/integration_basic.rs
+++ b/loom-daemon/tests/integration_basic.rs
@@ -5,10 +5,32 @@
 mod common;
 
 use common::{
-    capture_terminal_output, cleanup_all_loom_sessions, cleanup_test_sessions, tmux_session_exists,
-    TestClient, TestDaemon,
+    capture_terminal_output, cleanup_all_loom_sessions, cleanup_test_sessions, tmux_available,
+    tmux_session_exists, TestClient, TestDaemon,
 };
 use serial_test::serial;
+
+/// Skip the enclosing test (early `return`) with a loud note when no usable
+/// tmux server is reachable on this host (issue #3985).
+///
+/// These terminal-lifecycle tests *create* tmux sessions, so a host without a
+/// working tmux (dead server, missing binary, unwritable socket dir) can only
+/// ever fail them — for a reason that has nothing to do with the code under
+/// test. Skipping keeps the shared build gate green on a busy dev host while
+/// CI, which always has a live tmux, still exercises the real path. The gate
+/// also excludes integration test targets entirely (see
+/// `.loom/docs/build-gate.md`), so this is belt-and-suspenders.
+macro_rules! require_tmux {
+    () => {
+        if !tmux_available() {
+            eprintln!(
+                "SKIP: no usable tmux server on this host (issue #3985); \
+                 this terminal-lifecycle path is covered by CI"
+            );
+            return;
+        }
+    };
+}
 
 /// Cleanup helper to run before/after tests.
 /// Cleans ALL loom sessions to prevent the daemon from restoring orphan sessions
@@ -119,6 +141,7 @@ async fn test_malformed_json() {
 #[serial]
 async fn test_create_terminal() {
     setup();
+    require_tmux!();
 
     let daemon = TestDaemon::start().await.expect("Failed to start daemon");
     let mut client = TestClient::connect(daemon.socket_path())
@@ -149,6 +172,7 @@ async fn test_create_terminal() {
 #[allow(clippy::panic)]
 async fn test_create_terminal_with_working_dir() {
     setup();
+    require_tmux!();
 
     let daemon = TestDaemon::start().await.expect("Failed to start daemon");
     let mut client = TestClient::connect(daemon.socket_path())
@@ -219,6 +243,7 @@ async fn test_create_terminal_with_working_dir() {
 #[serial]
 async fn test_list_terminals() {
     setup();
+    require_tmux!();
 
     let daemon = TestDaemon::start().await.expect("Failed to start daemon");
     let mut client = TestClient::connect(daemon.socket_path())
@@ -281,6 +306,7 @@ async fn test_list_terminals() {
 #[serial]
 async fn test_destroy_terminal() {
     setup();
+    require_tmux!();
 
     let daemon = TestDaemon::start().await.expect("Failed to start daemon");
     let mut client = TestClient::connect(daemon.socket_path())
@@ -344,6 +370,7 @@ async fn test_destroy_nonexistent_terminal() {
 #[serial]
 async fn test_send_input() {
     setup();
+    require_tmux!();
 
     let daemon = TestDaemon::start().await.expect("Failed to start daemon");
     let mut client = TestClient::connect(daemon.socket_path())
@@ -381,6 +408,7 @@ async fn test_send_input() {
 #[serial]
 async fn test_multiple_clients() {
     setup();
+    require_tmux!();
 
     let daemon = TestDaemon::start().await.expect("Failed to start daemon");
 


### PR DESCRIPTION
Closes #3985

## Problem

The local `buildGate.command` (`.loom/scripts/build-gate.sh`) mirrors CI's `cargo test --workspace`, but CI measures **the commit** in a controlled runner while the local gate measures **the host it runs on** — and that host is the one actively running Loom. Two host-dependent failure classes made the gate red for reasons unrelated to `main`'s correctness, and combined with #3984 (continuous re-run) and #3974 (RED misclassification) into a self-reddening loop.

## Changes

### 1. tmux integration tests (AC1)
- New `tmux_available()` helper in `loom-daemon/tests/common/mod.rs` — probes whether a tmux server can actually be **started** on the `-L loom` socket (stronger than the existing `tmux_server_running()`, which only checks for an already-running server).
- New `require_tmux!()` macro in `integration_basic.rs`, applied to the 6 terminal-lifecycle tests that create tmux sessions. On a host with no usable tmux they now **skip cleanly** (loud `eprintln` + early return) instead of failing.

### 2. Gate scope (AC3)
- `build-gate.sh` Rust step changed from `cargo test --workspace` to `cargo test --workspace --lib --bins`. This runs the crates' unit tests but excludes the integration test **targets** under `loom-daemon/tests/` (which need a live tmux). Those remain covered by CI, which runs the full `cargo test --workspace`.
- Documented the local-gate-vs-CI environment-sensitivity boundary in `.loom/docs/build-gate.md` so the split is intentional.

### 3. Timing-sensitive unit tests (AC2)
- The three flagged `sweep_registry` dispatch tests now share a generous `FIXTURE_CHILD_WAIT_MS` (120s) budget instead of tight 5–10s deadlines. Because the wait helpers poll and return the instant the condition is met, a larger budget is **free on a healthy host** — it only widens tolerance before a genuinely stuck child is declared failed.

### 4. Reduced priority (AC5)
- `build-gate.sh` re-execs itself once under `nice -n 19` (sentinel-guarded against loops) so a long `cargo` compile can never starve the sweeps — or its own timing tests — it shares a host with. Tunable via `LOOM_BUILD_GATE_NICENESS`; disable with `LOOM_BUILD_GATE_NICE=0`.

### Deferred (AC4)
Forge-CI corroboration (prefer a green forge CI result over a local-gate RED on the same SHA) is a distinct, larger daemon-side feature belonging with the RED-classification work in #3974 AC4. It is **not** implemented here; a note in `.loom/docs/build-gate.md` records the deferral.

## Validation

`cargo check --tests` **finished clean (exit 0, no errors/warnings)** — confirming `sweep_registry.rs`, `integration_basic.rs`, and `common/mod.rs` all compile. `bash -n build-gate.sh` passes.

Full test *execution* could not be completed on the build host during this change: the host exhibited exactly the environment pathology this issue describes — macOS Gatekeeper (`syspolicyd`/`amfid`) saturated by a background Backblaze/XProtect scan, stalling every freshly-exec'd fixture child (and even cargo's own link step) well past a minute. That is a host condition, not a code fault; the timing-test changes only widen budgets and cannot break a test that passes in a healthy environment (CI or an unloaded host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)