### PR TITLE
feat(daemon): add forge-side pipeline snapshot to loom-daemon status

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -643,6 +643,43 @@ queues that drain fast. A permanently-full higher tier **will** starve lower tie
 fairness knobs (per-tier slot reservations) and cross-repo dependency awareness are
 explicit follow-ups, deferred until observed to matter.
 
+## Forge-side pipeline snapshot (`status --pipeline`, #3977)
+
+`loom-daemon status` shows the *dispatch*-side picture (in-flight sweeps, the
+dynamic cap, token health, per-repo priority/gate state — see the two sections
+above), but none of that answers "how is the work actually progressing?" —
+that requires forge queries the daemon's IPC handler deliberately does not
+make (the `DaemonStatus` round-trip stays a fast, network-free read). The
+`--pipeline` flag adds a client-side, opt-in forge-side pipeline snapshot per
+managed repo, fetched *after* the IPC round-trip completes:
+
+- **Counts** — for each root in `report.per_repo` (already priority-ordered):
+  open `loom:issue` (queued), open `loom:building` (claimed), open PRs by
+  `loom:review-requested` / `loom:changes-requested` / `loom:pr`, and PRs
+  merged in the last 24h (`gh pr list --state merged --search
+  "merged:>=<24h-ago RFC3339>"`).
+- **Module** — `loom_daemon::pipeline_snapshot`: `PipelineSource` is the forge
+  abstraction (mirrors `work_finder::WorkSource` / `GhWorkSource`),
+  `GhPipelineSource` is the `gh`-backed implementation (six `gh` invocations
+  per repo, `current_dir(root)` so `gh` auto-detects that repo's own remote —
+  same convention as `GhWorkSource::for_root`), and
+  `collect_pipeline_snapshots` fans the per-repo fetch out onto Tokio's
+  blocking-thread pool so N managed repos cost roughly one repo's worth of
+  wall-clock latency.
+- **Resilience** — every count is fetched and allowed to fail independently;
+  a failed metric renders as `?` (`RepoPipelineSnapshot::error` names the
+  first failure) without blocking the other metrics for that repo or any
+  sibling repo's snapshot — the same per-workspace error-isolation rule the
+  work-finder's `tick_multi` already applies to dispatch.
+- **Output** — `loom-daemon status --pipeline` adds a "Forge pipeline" table
+  below the existing "Managed repos" table (same row order); `--json
+  --pipeline` adds a `pipeline` array (`null` when `--pipeline` was not
+  passed, so a consumer can distinguish "not requested" from "requested but
+  empty"). Terminal-friendly and safe to `watch -n 60`.
+- **Why opt-in** — six `gh` calls per managed repo is too slow to bundle into
+  the default view (which is used for frequent, low-latency operator checks);
+  `--pipeline` trades that latency for the queue-depth picture on demand.
+
 ## Reaper task
 
 The reaper (`sweep_registry::spawn_reaper_task`) ticks every 30 seconds

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -29,6 +29,7 @@ pub mod issue_creation_mutex;
 pub mod main_health_gate;
 pub mod metrics_collector;
 pub mod phase_join;
+pub mod pipeline_snapshot;
 pub mod role_validation;
 pub mod self_update;
 pub mod sweep_journal;

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -101,6 +101,16 @@ enum Commands {
         /// Emit machine-readable JSON instead of the human-readable table.
         #[arg(long)]
         json: bool,
+
+        /// Also show the forge-side pipeline snapshot per managed repo (Issue
+        /// #3977): open `loom:issue` (queued), open `loom:building`
+        /// (claimed), open PRs by `loom:review-requested` /
+        /// `loom:changes-requested` / `loom:pr`, and PRs merged in the last
+        /// 24h. Opt-in because it makes several `gh` calls per managed repo
+        /// (client-side, after the fast IPC round-trip) rather than being
+        /// bundled into the default view.
+        #[arg(long)]
+        pipeline: bool,
     },
 
     /// Manage the machine-level workspace registry (`~/.loom/workspaces.json`):
@@ -301,7 +311,7 @@ async fn main() -> Result<()> {
         return match command {
             // `status` connects to the running daemon over its Unix socket, so
             // it needs the async runtime (unlike the other sync subcommands).
-            Commands::Status { json } => handle_status_command(json).await,
+            Commands::Status { json, pipeline } => handle_status_command(json, pipeline).await,
             // `quarantine` connects to the running daemon over its Unix socket
             // (the quarantine state is in-memory), so it needs the async runtime.
             Commands::Quarantine { action } => handle_quarantine_command(action).await,
@@ -1540,7 +1550,14 @@ fn collect_token_usage() -> Option<serde_json::Value> {
 /// Handle the `status` subcommand — render the running daemon's autonomous-mode
 /// operability snapshot (Issue #3891). Fetches the daemon-native part over IPC
 /// and layers on the client-side per-token usage probe.
-async fn handle_status_command(json: bool) -> Result<()> {
+///
+/// `pipeline` opts into the forge-side pipeline snapshot (Issue #3977): per
+/// managed repo, open `loom:issue`/`loom:building` counts, open PR counts by
+/// review-state label, and PRs merged in the last 24h. Like the per-token
+/// usage table, this is collected client-side (several `gh` calls per repo)
+/// rather than inside the IPC handler, and is opt-in specifically because
+/// those extra forge calls are too slow to bundle into the default view.
+async fn handle_status_command(json: bool, pipeline: bool) -> Result<()> {
     let socket_path = resolve_socket_path()?;
 
     let report = match query_daemon_status(&socket_path).await {
@@ -1575,10 +1592,21 @@ async fn handle_status_command(json: bool) -> Result<()> {
     // `.loom/scripts/cli/loom-daemon-update.sh` for the opt-in update flow).
     let update = self_update::check();
 
-    if json {
-        print_status_json(&report, token_usage.as_ref(), &update)?;
+    // Forge-side pipeline snapshot (#3977) — opt-in, fetched in the same
+    // priority order as `report.per_repo` so the rendered table lines up with
+    // the "Managed repos" dispatch table above it.
+    let pipeline_snapshots = if pipeline {
+        let roots: Vec<PathBuf> = report.per_repo.iter().map(|r| r.root.clone()).collect();
+        let source = Arc::new(loom_daemon::pipeline_snapshot::GhPipelineSource::new());
+        Some(loom_daemon::pipeline_snapshot::collect_pipeline_snapshots(source, roots).await)
     } else {
-        print_status_human(&report, token_usage.as_ref(), &update);
+        None
+    };
+
+    if json {
+        print_status_json(&report, token_usage.as_ref(), &update, pipeline_snapshots.as_deref())?;
+    } else {
+        print_status_human(&report, token_usage.as_ref(), &update, pipeline_snapshots.as_deref());
     }
     Ok(())
 }
@@ -1707,6 +1735,7 @@ fn print_status_json(
     report: &DaemonStatusReport,
     token_usage: Option<&serde_json::Value>,
     update: &self_update::SelfUpdateStatus,
+    pipeline: Option<&[loom_daemon::pipeline_snapshot::RepoPipelineSnapshot]>,
 ) -> Result<()> {
     let rc = resolve_capacity(report, token_usage);
     let combined = serde_json::json!({
@@ -1754,6 +1783,19 @@ fn print_status_json(
             "health_gate_not_evaluated": r.health_gate_not_evaluated,
             "health_gate_not_evaluated_reason": r.health_gate_not_evaluated_reason,
         })).collect::<Vec<_>>(),
+        // Forge-side pipeline snapshot (#3977) — present only when `--pipeline`
+        // was passed; `null` otherwise so a consumer can tell "not requested"
+        // apart from "requested but empty".
+        "pipeline": pipeline.map(|snapshots| snapshots.iter().map(|s| serde_json::json!({
+            "root": s.root,
+            "queued": s.queued,
+            "building": s.building,
+            "review_requested": s.review_requested,
+            "changes_requested": s.changes_requested,
+            "approved": s.approved,
+            "merged_24h": s.merged_24h,
+            "error": s.error,
+        })).collect::<Vec<_>>()),
         "token_usage": token_usage,
         // Self-update staleness (#3968) — read-only, local-only comparison of
         // this binary's baked-in commit vs. the source checkout's HEAD.
@@ -1800,6 +1842,7 @@ fn print_status_human(
     report: &DaemonStatusReport,
     token_usage: Option<&serde_json::Value>,
     update: &self_update::SelfUpdateStatus,
+    pipeline: Option<&[loom_daemon::pipeline_snapshot::RepoPipelineSnapshot]>,
 ) {
     println!("\n=== Loom Autonomous Daemon Status ===\n");
 
@@ -1965,6 +2008,38 @@ fn print_status_human(
                     .collect::<Vec<_>>()
                     .join(", ");
                 println!("        quarantined (insta-crash, #3939): {list}");
+            }
+        }
+    }
+
+    // Forge-side pipeline snapshot (#3977) — opt-in via `--pipeline`. Rendered
+    // in the same order as the "Managed repos" table above (both iterate
+    // `report.per_repo`), so the two tables line up row-for-row.
+    if let Some(snapshots) = pipeline {
+        println!("\nForge pipeline (per repo, --pipeline):");
+        if snapshots.is_empty() {
+            println!("  (none)");
+        } else {
+            println!(
+                "  {:>6}  {:>8}  {:>6}  {:>7}  {:>5}  {:>9}  REPO",
+                "QUEUED", "BUILDING", "REVIEW", "CHNG-RQ", "PR", "MERGED24H"
+            );
+            println!("  {:-<75}", "");
+            for s in snapshots {
+                use loom_daemon::pipeline_snapshot::format_count;
+                println!(
+                    "  {:>6}  {:>8}  {:>6}  {:>7}  {:>5}  {:>9}  {}",
+                    format_count(s.queued),
+                    format_count(s.building),
+                    format_count(s.review_requested),
+                    format_count(s.changes_requested),
+                    format_count(s.approved),
+                    format_count(s.merged_24h),
+                    s.root.display()
+                );
+                if let Some(err) = &s.error {
+                    println!("        forge query failed for one or more metrics ({err}) — unreachable fields shown as ?");
+                }
             }
         }
     }

--- a/loom-daemon/src/pipeline_snapshot.rs
+++ b/loom-daemon/src/pipeline_snapshot.rs
@@ -1,0 +1,566 @@
+//! Forge-side pipeline snapshot for `loom-daemon status --pipeline` (Issue
+//! #3977).
+//!
+//! `loom-daemon status` already renders the *dispatch*-side picture (in-flight
+//! sweeps, the dynamic concurrency cap, token health, per-repo priority/gate
+//! state — see [`crate::types::DaemonStatusReport::per_repo`]). None of that
+//! answers "how is the work actually progressing?" — that requires forge
+//! queries the daemon's IPC handler deliberately does *not* make (it stays a
+//! fast, network-free round-trip). This module is the client-side (CLI-only,
+//! opt-in via `--pipeline`) counterpart: for each managed-workspace root it
+//! counts open `loom:issue` (queued), open `loom:building` (claimed), open
+//! PRs by `loom:review-requested` / `loom:changes-requested` / `loom:pr`, and
+//! PRs merged in the last 24h.
+//!
+//! # Resilience
+//!
+//! Every count is independently fetched and independently allowed to fail —
+//! one unreachable repo (network outage, `gh` not authenticated for that
+//! remote, a Gitea-only repo `gh` cannot talk to at all) degrades to `?` for
+//! *that* field only and never sinks the rest of the snapshot. This mirrors
+//! the work-finder's per-workspace error-handling rule (`tick_multi` in
+//! [`crate::work_finder`]): a forge failure aborts only the one workspace's
+//! read for that tick, never the whole multi-repo pass.
+//!
+//! # Parallelism
+//!
+//! [`collect_pipeline_snapshots`] fans the per-repo fetch out onto Tokio's
+//! blocking-thread pool (`gh` is a synchronous subprocess call) so N managed
+//! repos cost roughly one repo's worth of wall-clock latency, not N.
+
+use anyhow::{anyhow, Context, Result};
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+
+/// One managed repo's forge-side pipeline counts.
+///
+/// Every count field is `Option<usize>` — `None` means the underlying forge
+/// query failed for *that* metric (rendered as `?`); a `Some` for one field
+/// and `None` for another on the same repo is expected under partial
+/// degradation (e.g. `gh` rate-limited mid-fetch).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RepoPipelineSnapshot {
+    /// The workspace root this line describes (matches
+    /// [`crate::types::RepoStatus::root`] for the same repo).
+    pub root: PathBuf,
+    /// Open issues labeled `loom:issue` — queued, not yet claimed.
+    pub queued: Option<usize>,
+    /// Open issues labeled `loom:building` — claimed, in progress.
+    pub building: Option<usize>,
+    /// Open PRs labeled `loom:review-requested` — awaiting Judge.
+    pub review_requested: Option<usize>,
+    /// Open PRs labeled `loom:changes-requested` — Doctor's queue.
+    pub changes_requested: Option<usize>,
+    /// Open PRs labeled `loom:pr` — Judge-approved, awaiting Champion merge.
+    pub approved: Option<usize>,
+    /// PRs merged in the last 24h (a throughput signal, not a queue depth).
+    pub merged_24h: Option<usize>,
+    /// The first forge-query failure encountered for this repo, if any. A
+    /// repo can have `Some(error)` and still carry partial `Some(..)` counts
+    /// for the metrics that *did* succeed.
+    pub error: Option<String>,
+}
+
+impl RepoPipelineSnapshot {
+    /// Whether every metric for this repo was fetched successfully.
+    #[must_use]
+    pub fn is_complete(&self) -> bool {
+        self.error.is_none()
+    }
+}
+
+/// Abstraction over the forge read so the fan-out/aggregation logic
+/// ([`collect_pipeline_snapshots`]) is unit-testable without shelling out to
+/// `gh` — mirrors [`crate::work_finder::WorkSource`] /
+/// [`crate::work_finder::forge::GhWorkSource`].
+pub trait PipelineSource {
+    /// Fetch the pipeline snapshot for one managed-workspace root. Never
+    /// panics or propagates an error — any forge failure is captured in
+    /// [`RepoPipelineSnapshot::error`] (and the specific metric left `None`)
+    /// so the caller can render `?` for that repo without losing the rest of
+    /// the batch.
+    fn fetch(&self, root: &Path) -> RepoPipelineSnapshot;
+}
+
+/// Minimal `gh issue/pr list --json number` row — only the count matters, so
+/// the field itself is unused beyond deserializing one row per open item.
+#[derive(Debug, Deserialize)]
+struct NumberRow {
+    #[allow(dead_code)]
+    number: u64,
+}
+
+/// A `gh`-backed [`PipelineSource`]. Runs six `gh` invocations per repo (one
+/// per counted metric) scoped to that repo's own working directory so `gh`
+/// auto-detects the remote — same convention as
+/// [`crate::work_finder::forge::GhWorkSource::for_root`]. `--limit 500` is
+/// generous headroom over the default `gh` page size of 30, which would
+/// otherwise silently undercount a busy repo's queue.
+pub struct GhPipelineSource {
+    gh_bin: PathBuf,
+}
+
+impl GhPipelineSource {
+    /// Construct a source using `gh` from `PATH`.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            gh_bin: PathBuf::from("gh"),
+        }
+    }
+
+    /// Override the `gh` binary path (for tests / non-standard installs).
+    #[must_use]
+    pub fn with_gh_bin(mut self, bin: PathBuf) -> Self {
+        self.gh_bin = bin;
+        self
+    }
+
+    /// Run `gh <args>` with `current_dir(root)` and return the length of the
+    /// returned JSON array — the count for whatever list query `args`
+    /// encodes.
+    fn count(&self, root: &Path, args: &[&str]) -> Result<usize> {
+        let mut cmd = Command::new(&self.gh_bin);
+        cmd.args(args).current_dir(root);
+        let out = cmd
+            .output()
+            .with_context(|| format!("failed to invoke {}", self.gh_bin.display()))?;
+        if !out.status.success() {
+            return Err(anyhow!(
+                "gh {} failed: {}",
+                args.join(" "),
+                String::from_utf8_lossy(&out.stderr).trim()
+            ));
+        }
+        let rows: Vec<NumberRow> =
+            serde_json::from_slice(&out.stdout).context("parse gh JSON output")?;
+        Ok(rows.len())
+    }
+
+    /// The `merged:>=<RFC3339>` search qualifier for "merged in the last 24h",
+    /// computed from `now`. A separate function so tests can pin the clock.
+    fn merged_since_query(now: chrono::DateTime<chrono::Utc>) -> String {
+        let since = now - chrono::Duration::hours(24);
+        format!("merged:>={}", since.format("%Y-%m-%dT%H:%M:%SZ"))
+    }
+}
+
+impl Default for GhPipelineSource {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PipelineSource for GhPipelineSource {
+    fn fetch(&self, root: &Path) -> RepoPipelineSnapshot {
+        let mut snap = RepoPipelineSnapshot {
+            root: root.to_path_buf(),
+            ..Default::default()
+        };
+        let mut first_err: Option<String> = None;
+        let mut record = |result: Result<usize>| -> Option<usize> {
+            match result {
+                Ok(n) => Some(n),
+                Err(e) => {
+                    if first_err.is_none() {
+                        first_err = Some(e.to_string());
+                    }
+                    None
+                }
+            }
+        };
+
+        snap.queued = record(self.count(
+            root,
+            &[
+                "issue",
+                "list",
+                "--state",
+                "open",
+                "--label",
+                "loom:issue",
+                "--json",
+                "number",
+                "--limit",
+                "500",
+            ],
+        ));
+        snap.building = record(self.count(
+            root,
+            &[
+                "issue",
+                "list",
+                "--state",
+                "open",
+                "--label",
+                "loom:building",
+                "--json",
+                "number",
+                "--limit",
+                "500",
+            ],
+        ));
+        snap.review_requested = record(self.count(
+            root,
+            &[
+                "pr",
+                "list",
+                "--state",
+                "open",
+                "--label",
+                "loom:review-requested",
+                "--json",
+                "number",
+                "--limit",
+                "500",
+            ],
+        ));
+        snap.changes_requested = record(self.count(
+            root,
+            &[
+                "pr",
+                "list",
+                "--state",
+                "open",
+                "--label",
+                "loom:changes-requested",
+                "--json",
+                "number",
+                "--limit",
+                "500",
+            ],
+        ));
+        snap.approved = record(self.count(
+            root,
+            &[
+                "pr", "list", "--state", "open", "--label", "loom:pr", "--json", "number",
+                "--limit", "500",
+            ],
+        ));
+
+        let search = Self::merged_since_query(chrono::Utc::now());
+        snap.merged_24h = record(self.count(
+            root,
+            &[
+                "pr", "list", "--state", "merged", "--search", &search, "--json", "number",
+                "--limit", "500",
+            ],
+        ));
+
+        snap.error = first_err;
+        snap
+    }
+}
+
+/// Fetch pipeline snapshots for every root in `roots`, in parallel, preserving
+/// input order in the output (so a caller rendering alongside
+/// `report.per_repo`'s priority order gets a matching row order). Each fetch
+/// runs on Tokio's blocking-thread pool since `gh` is a synchronous subprocess
+/// call; one root's failure (including a panicking/aborted fetch task) never
+/// prevents the others from completing (#3977 AC2).
+pub async fn collect_pipeline_snapshots<S>(
+    source: Arc<S>,
+    roots: Vec<PathBuf>,
+) -> Vec<RepoPipelineSnapshot>
+where
+    S: PipelineSource + Send + Sync + 'static,
+{
+    let handles: Vec<(PathBuf, tokio::task::JoinHandle<RepoPipelineSnapshot>)> = roots
+        .into_iter()
+        .map(|root| {
+            let source = Arc::clone(&source);
+            let root_for_task = root.clone();
+            (root, tokio::task::spawn_blocking(move || source.fetch(&root_for_task)))
+        })
+        .collect();
+
+    let mut out = Vec::with_capacity(handles.len());
+    for (root, handle) in handles {
+        match handle.await {
+            Ok(snap) => out.push(snap),
+            Err(join_err) => out.push(RepoPipelineSnapshot {
+                root,
+                error: Some(format!("pipeline fetch task failed: {join_err}")),
+                ..Default::default()
+            }),
+        }
+    }
+    out
+}
+
+/// Render one count for the human table: `?` for a failed metric, else the
+/// number.
+#[must_use]
+pub fn format_count(count: Option<usize>) -> String {
+    count.map_or_else(|| "?".to_string(), |n| n.to_string())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // ===================================================================
+    // format_count
+    // ===================================================================
+
+    #[test]
+    fn format_count_renders_question_mark_for_none() {
+        assert_eq!(format_count(None), "?");
+    }
+
+    #[test]
+    fn format_count_renders_number_for_some() {
+        assert_eq!(format_count(Some(7)), "7");
+    }
+
+    // ===================================================================
+    // collect_pipeline_snapshots — fan-out/aggregation (no real `gh`)
+    // ===================================================================
+
+    /// A scripted [`PipelineSource`]: returns a canned snapshot per root,
+    /// keyed by the root's own path so a multi-root test can assert
+    /// independent per-repo results.
+    struct FakeSource {
+        by_root: Mutex<std::collections::HashMap<PathBuf, RepoPipelineSnapshot>>,
+    }
+
+    impl FakeSource {
+        fn new(entries: Vec<(PathBuf, RepoPipelineSnapshot)>) -> Self {
+            Self {
+                by_root: Mutex::new(entries.into_iter().collect()),
+            }
+        }
+    }
+
+    impl PipelineSource for FakeSource {
+        fn fetch(&self, root: &Path) -> RepoPipelineSnapshot {
+            self.by_root
+                .lock()
+                .unwrap()
+                .get(root)
+                .cloned()
+                .unwrap_or_else(|| RepoPipelineSnapshot {
+                    root: root.to_path_buf(),
+                    error: Some("no fixture for this root".to_string()),
+                    ..Default::default()
+                })
+        }
+    }
+
+    #[tokio::test]
+    async fn collect_preserves_input_order() {
+        let a = PathBuf::from("/repo/a");
+        let b = PathBuf::from("/repo/b");
+        let c = PathBuf::from("/repo/c");
+        let source = Arc::new(FakeSource::new(vec![
+            (
+                a.clone(),
+                RepoPipelineSnapshot {
+                    root: a.clone(),
+                    queued: Some(1),
+                    ..Default::default()
+                },
+            ),
+            (
+                b.clone(),
+                RepoPipelineSnapshot {
+                    root: b.clone(),
+                    queued: Some(2),
+                    ..Default::default()
+                },
+            ),
+            (
+                c.clone(),
+                RepoPipelineSnapshot {
+                    root: c.clone(),
+                    queued: Some(3),
+                    ..Default::default()
+                },
+            ),
+        ]));
+
+        let out = collect_pipeline_snapshots(source, vec![a.clone(), b.clone(), c.clone()]).await;
+
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].root, a);
+        assert_eq!(out[1].root, b);
+        assert_eq!(out[2].root, c);
+        assert_eq!(out[0].queued, Some(1));
+        assert_eq!(out[1].queued, Some(2));
+        assert_eq!(out[2].queued, Some(3));
+    }
+
+    /// One repo's forge failure must not affect a sibling's snapshot — the
+    /// core #3977 AC2 resilience guarantee, exercised at the aggregation
+    /// layer (`GhPipelineSource` covers the same guarantee at the
+    /// `gh`-invocation layer below).
+    #[tokio::test]
+    async fn collect_isolates_one_repo_failure_from_others() {
+        let healthy = PathBuf::from("/repo/healthy");
+        let unreachable = PathBuf::from("/repo/unreachable");
+        let source = Arc::new(FakeSource::new(vec![
+            (
+                healthy.clone(),
+                RepoPipelineSnapshot {
+                    root: healthy.clone(),
+                    queued: Some(5),
+                    building: Some(2),
+                    ..Default::default()
+                },
+            ),
+            (
+                unreachable.clone(),
+                RepoPipelineSnapshot {
+                    root: unreachable.clone(),
+                    error: Some("network unreachable".to_string()),
+                    ..Default::default()
+                },
+            ),
+        ]));
+
+        let out =
+            collect_pipeline_snapshots(source, vec![healthy.clone(), unreachable.clone()]).await;
+
+        assert!(out[0].is_complete());
+        assert_eq!(out[0].queued, Some(5));
+        assert!(!out[1].is_complete());
+        assert_eq!(out[1].queued, None);
+        assert_eq!(format_count(out[1].queued), "?");
+    }
+
+    #[tokio::test]
+    async fn collect_empty_roots_is_empty() {
+        let source = Arc::new(FakeSource::new(vec![]));
+        let out = collect_pipeline_snapshots(source, vec![]).await;
+        assert!(out.is_empty());
+    }
+
+    // ===================================================================
+    // GhPipelineSource — real fan-out against a fake `gh` binary
+    // ===================================================================
+
+    /// A fake `gh` script that returns a fixed-length JSON array based on
+    /// which label/state substring appears in its argv, mirroring the
+    /// `write_fake_script` fixture pattern used in
+    /// `token_ranking_refresh.rs`'s tests.
+    fn write_fake_gh(dir: &Path, body: &str) -> PathBuf {
+        std::fs::create_dir_all(dir).unwrap();
+        let path = dir.join("fake-gh.sh");
+        std::fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&path).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&path, perms).unwrap();
+        }
+        path
+    }
+
+    #[test]
+    fn gh_pipeline_source_counts_each_metric_independently() {
+        let tmp = tempfile::tempdir().unwrap();
+        let gh = write_fake_gh(
+            tmp.path(),
+            r#"
+case "$*" in
+  *"--label loom:issue "*)
+    echo '[{"number":1},{"number":2},{"number":3}]'
+    ;;
+  *"--label loom:building"*)
+    echo '[{"number":4}]'
+    ;;
+  *"--label loom:review-requested"*)
+    echo '[{"number":5},{"number":6}]'
+    ;;
+  *"--label loom:changes-requested"*)
+    echo '[]'
+    ;;
+  *"--label loom:pr"*)
+    echo '[{"number":7}]'
+    ;;
+  *"--state merged"*)
+    echo '[{"number":8},{"number":9},{"number":10},{"number":11}]'
+    ;;
+  *)
+    echo '[]'
+    ;;
+esac
+"#,
+        );
+
+        let source = GhPipelineSource::new().with_gh_bin(gh);
+        let root = tmp.path();
+        let snap = source.fetch(root);
+
+        assert_eq!(snap.root, root);
+        assert_eq!(snap.queued, Some(3));
+        assert_eq!(snap.building, Some(1));
+        assert_eq!(snap.review_requested, Some(2));
+        assert_eq!(snap.changes_requested, Some(0));
+        assert_eq!(snap.approved, Some(1));
+        assert_eq!(snap.merged_24h, Some(4));
+        assert!(snap.is_complete());
+    }
+
+    #[test]
+    fn gh_pipeline_source_records_error_but_keeps_other_metrics() {
+        let tmp = tempfile::tempdir().unwrap();
+        let gh = write_fake_gh(
+            tmp.path(),
+            r#"
+case "$*" in
+  *"--label loom:issue "*)
+    echo "boom: not authenticated" 1>&2
+    exit 1
+    ;;
+  *"--label loom:building"*)
+    echo '[{"number":1}]'
+    ;;
+  *)
+    echo '[]'
+    ;;
+esac
+"#,
+        );
+
+        let source = GhPipelineSource::new().with_gh_bin(gh);
+        let snap = source.fetch(tmp.path());
+
+        assert_eq!(snap.queued, None);
+        assert_eq!(snap.building, Some(1));
+        assert!(!snap.is_complete());
+        assert!(snap.error.as_deref().unwrap().contains("not authenticated"));
+        // Other metrics that had no dedicated case still resolve (as 0),
+        // proving one failed call didn't abort the rest of the fetch.
+        assert_eq!(snap.merged_24h, Some(0));
+    }
+
+    #[test]
+    fn gh_pipeline_source_missing_binary_is_a_contained_failure() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = GhPipelineSource::new().with_gh_bin(PathBuf::from("/no/such/gh-binary"));
+        let snap = source.fetch(tmp.path());
+
+        assert!(!snap.is_complete());
+        assert_eq!(snap.queued, None);
+        assert_eq!(snap.building, None);
+        assert_eq!(snap.review_requested, None);
+        assert_eq!(snap.changes_requested, None);
+        assert_eq!(snap.approved, None);
+        assert_eq!(snap.merged_24h, None);
+    }
+
+    #[test]
+    fn merged_since_query_formats_rfc3339_24h_window() {
+        let now = chrono::DateTime::parse_from_rfc3339("2026-07-27T12:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let query = GhPipelineSource::merged_since_query(now);
+        assert_eq!(query, "merged:>=2026-07-26T12:00:00Z");
+    }
+}


### PR DESCRIPTION
## Summary

`loom-daemon status` already renders the *dispatch*-side picture (in-flight sweeps, dynamic concurrency cap, token health, per-repo priority/gate state), but answering "how is the work actually progressing?" required hand-rolling several `gh` queries per managed repo. This adds an opt-in `--pipeline` flag that shows, per managed repo in priority order:

- Open `loom:issue` count (queued)
- Open `loom:building` count (claimed)
- Open PRs by `loom:review-requested` / `loom:changes-requested` / `loom:pr`
- PRs merged in the last 24h

## Implementation

- New `loom_daemon::pipeline_snapshot` module:
  - `PipelineSource` trait (mirrors `work_finder::WorkSource`/`GhWorkSource`) for testability without shelling out to `gh`.
  - `GhPipelineSource`: six `gh` invocations per repo (one per counted metric), each scoped to that repo's own working directory (`current_dir(root)`) so `gh` auto-detects the remote — same convention as `GhWorkSource::for_root`.
  - Every metric is fetched and allowed to fail **independently** — a failed `gh` call renders `?` for that metric only (`RepoPipelineSnapshot::error` names the first failure), never sinking the rest of that repo's snapshot or any sibling repo's snapshot. Mirrors the work-finder's per-workspace error-isolation rule.
  - `collect_pipeline_snapshots` fans the per-repo fetch out onto Tokio's blocking-thread pool (`spawn_blocking`, since `gh` is a synchronous subprocess call) so N managed repos cost roughly one repo's worth of wall-clock latency, not N — while preserving input order (so the rendered table lines up with the existing "Managed repos" priority-ordered table).
- Wired into `main.rs`:
  - `loom-daemon status --pipeline` adds a "Forge pipeline" table below the existing "Managed repos" table.
  - `loom-daemon status --json --pipeline` adds a `pipeline` array (`null` when `--pipeline` was not passed, so a consumer can distinguish "not requested" from "requested but empty").
  - Opt-in (not bundled into the default view) because six `gh` calls per managed repo is too slow for the default, frequently-polled status view — matches the existing per-token-usage-table precedent (also client-side, also collected after the fast IPC round-trip).
- Documented in `.loom/docs/daemon-reference.md` (new "Forge-side pipeline snapshot" section).

## Test plan

- [x] `cargo test --lib pipeline_snapshot` — 9 new unit tests (fan-out ordering, per-repo failure isolation, `GhPipelineSource` against a fake `gh` script covering per-metric counts / partial failure / missing binary, RFC3339 merged-window formatting)
- [x] `cargo test --lib` — 932 passed, 0 failed
- [x] `cargo test --bin loom-daemon` — 10 passed (existing `dispatch_tests`), 0 failed
- [x] `cargo clippy --bin loom-daemon --lib -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `loom-daemon status --help` shows the new `--pipeline` flag with its doc string
- [x] `loom-daemon status --pipeline` against an unreachable socket fails gracefully with the existing "Is the daemon running?" message (no panic)

Closes #3977