### PR TITLE
chore(config): enable daemon role runner for curator + champion

### DIFF
--- a/.loom/config.json
+++ b/.loom/config.json
@@ -1,6 +1,12 @@
 {
   "version": "2",
   "offlineMode": false,
+  "autonomous": {
+    "roleRunner": {
+      "enabled": true,
+      "roles": ["curator", "champion"]
+    }
+  },
   "buildGate": {
     "enabled": true,
     "command": "bash .loom/scripts/build-gate.sh",


### PR DESCRIPTION
Enables the daemon-native support-role runner (#4015/#4026) for Curator and Champion on this repo.

## Why

Nothing was running Curator or Champion on this host: the `.github/workflows/loom-*.yml` cron blocks are commented out by default, and the daemon role runner is opt-in (default OFF). The promotion chain `unlabeled → loom:curated → loom:issue` had stalled, so the work finder polled an empty queue while 22 issues sat at triage/unlabeled:

```
12  (unlabeled)
10  loom:triage
 1  loom:blocked,loom:issue   ← the only loom:issue, and it is blocked
```

## Why config rather than LOOM_ROLE_RUNNER

`resolve_enabled()` checks the env var first and it wins **globally**, so setting it would also start role sessions against the other three registered workspaces. `autonomous.roleRunner` is resolved per-workspace on each tick, scoping this to loom — consistent with tool-repos-before-canaries dispatch priority.

## Why only two of five roles

- **Judge** duplicates the per-sweep Judge phase that `sweep_registry` already runs.
- **Auditor** runs a full build/test every 10 min; `build-gate.sh` currently times out at 600s on this host, and it would compete for the CPU term that bounds the dynamic cap.
- **Guide** only reorders priority within `loom:issue`, which is empty.

Curator and Champion are the two that actually unblock dispatch. Easy to widen later.

Verified live — the daemon logs on restart:

```
role_runner: enabled (multi-workspace, 2 role(s): champion, curator)
role_runner: champion interval=600s
role_runner: curator interval=300s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)