### PR TITLE
docs(sweep): fix naming-row typo comparing /loom:sweep to itself

### DIFF
--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -1755,7 +1755,7 @@ The full `/loom:sweep` design in #3298 includes many features that are intention
 | Intra-wave collision guard (overlapping PRs off a shared base) | **Implemented (#3647)** | Step 7 runs a read-only file-path overlap probe before each in-wave merge; overlapping PRs are updated onto the just-merged `main` and re-Judged (or Doctor→re-Judge on `DIRTY`) before merging, disjoint PRs keep the fast path. Step 8 adds a post-wave `buildGate.command`-against-`main` integration gate — the load-bearing backstop for cross-file semantic coupling (source-vs-test) that path-overlap cannot see; halts the sweep on a red `main`. Symbol/AST-level overlap detection is out of scope. |
 | Spinoff-issue filing for out-of-scope discoveries | Deferred | Build it once we have richer summary output to surface them cleanly. |
 | Daemon `pipeline_state` situational awareness reads | Deferred | Skill only warns when the daemon is running. |
-| Top-level vs namespaced naming (`/loom:sweep` vs `/loom:sweep`) | **Resolved** | Ships as the namespaced `/loom:sweep` (and `/loom:loom` for the daemon operator), matching CLAUDE.md and `help.md`. Originally #3298 open question #1. |
+| Top-level vs namespaced naming (`/sweep` vs `/loom:sweep`) | **Resolved** | Ships as the namespaced `/loom:sweep` (and `/loom:loom` for the daemon operator), matching CLAUDE.md and `help.md`. Originally #3298 open question #1. |
 
 For the full design discussion (including the open questions raised by the curator), see issue #3298.
 


### PR DESCRIPTION
One-line documentation fix, salvaged from an abandoned worktree during a session-reset sweep.

## What

`defaults/.claude/commands/loom/sweep.md`'s deferred-scope table recorded the naming decision as:

> Top-level vs namespaced naming (`/loom:sweep` vs `/loom:sweep`)

— comparing the namespaced form to itself, so the row never states the choice it marks **Resolved**. The rejected alternative was the top-level `/sweep`.

## Why it matters beyond the typo

This row is the evidence cited on #4034 that namespacing is a *deliberate, resolved* decision rather than an accident of install layout — which is what makes the bare `/curator` in `role_runner.rs` and the five `.github/workflows/loom-*.yml` files a consistency bug against an existing decision, not an open design question. A row comparing an option to itself does not support that reading.

Issue #3788 is already closed; this change was sitting uncommitted in its worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)