### PR TITLE
chore(config): raise buildGate.timeoutSeconds 600 -> 1200

### DIFF
--- a/.loom/config.json
+++ b/.loom/config.json
@@ -11,7 +11,7 @@
     "enabled": true,
     "command": "bash .loom/scripts/build-gate.sh",
     "realChangeGlobs": ["*.rs", "*.toml", "Cargo.lock", "*.py", "*.sh"],
-    "timeoutSeconds": 600
+    "timeoutSeconds": 1200
   },
   "terminals": [
     {


### PR DESCRIPTION
Raises the build-gate budget so the gate produces a verdict instead of a perpetual `UNEVALUATED [timeout]`.

Measured on the daemon host 2026-07-27:
- Warm run: **500s, all stages green** (138/138 installer tests) against the 600s budget — 83% utilization.
- The daemon's own run on the same commit 15 min earlier: **timed out at 600s**. The runs did not overlap.

The difference is a cold debug recompile. Since #4002 the gate only re-runs when `origin/main`'s SHA changes — i.e. exactly when there is new code to compile — so the cold path is the gate's *normal* condition and the warm 500s case is the one it almost never sees.

Full measurement detail in https://github.com/rjwalters/loom/issues/4020#issuecomment-5094404468. Scoping/serialization work stays tracked in #4020.

Refs #4020