### PR TITLE
fix(models): resolve the logical `opus` tier to Opus 5 via one indirection point (#3982)

### DIFF
--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -409,6 +409,17 @@ Every role subagent dispatched by this skill (`loom-curator`, `loom-builder`, `l
 3. **Role default** — `.loom/roles/<role>.json` → `suggestedModel` (ships as an alias: `sonnet`, `opus`, or `haiku`).
 4. **Session default** — if none of the above resolves (or resolves to an empty string), **omit the `model` parameter entirely** so the subagent inherits the parent session's model. Never pass `model: ""`.
 
+**Logical-tier resolution before dispatch (issue #3982).** Every rung, tier, and arm in this skill names a *logical tier* by its CLI alias (`sonnet`, `opus`, `fable`) — but the bare `opus` alias still resolves to a **previous-generation** model on the wire (`claude-opus-4-8`), while `sonnet`/`fable` resolve to the current generation. So the shipped ladder `sonnet → sonnet@xhigh → opus → fable` would silently step *down* a generation at the `opus` rung. To fix this **without** scattering a pinned ID across the skill, resolve the chosen model through the single indirection point **immediately before** you pass it to the Task tool's `model` parameter (or to a spawned child's `--model`):
+
+```bash
+RESOLVED_MODEL="$(./.loom/scripts/resolve-model.sh "$LOGICAL_MODEL")"   # e.g. opus -> claude-opus-5
+```
+
+- Apply this to **every** resolved model on the dispatch path: the escalation-ladder rung, the Tier 2.5 `sonnet → opus` bump, the No-Fable-Judge `opus` fallback, the `fable → opus` refusal fallback, and the experiment's Arm A (`assign-arm --resolve` does the same resolution for you — see "Model-cost experiment mode").
+- `resolve-model.sh` maps only the stale logical tiers to concrete IDs (today `opus → claude-opus-5`); it **passes unknown aliases and pinned IDs (`claude-sonnet-4-6`) through unchanged**, and preserves the `@effort` suffix. So resolving is always safe — a tier-1/tier-2 operator pin, a `sonnet` rung, or a `sonnet@xhigh` rung all survive untouched.
+- The mapping is configurable in `.loom/config.json` → `sweep.modelAliases` (an additive tier → ID object), so an operator can repoint a tier — or drop the pin once the CLI's own `opus` alias rolls to gen-5 — with no code change. Absent block ⇒ shipped default.
+- The pinned ladder strings in this document (`sonnet → sonnet@xhigh → opus → fable`, `sonnet → opus`) stay written in **logical aliases** on purpose — the resolution happens at dispatch time, not in this prose.
+
 **Tier 2.5 — Curator complexity marker (issue #3702, Builder dispatch only)**: between tier 2 and tier 3, at **Builder** dispatch, grep the issue body for the Curator-emitted marker `<!-- loom:complexity=complex -->` (an HTML comment, values `routine` | `complex`; see `curator.md`). When it is present and reads `complex`, bump the Builder's tier-3 (`suggestedModel`) resolution up **exactly one model tier** — `sonnet → opus` — before dispatch. Hard bounds, all enforced here:
 
 > **Experiment-mode suppression (issue #3725).** When `sweep.modelExperiment` resolves to `experiment` (see "Model-cost experiment mode" below), the forced arm **overrides and SUPPRESSES this tier-2.5 bump** for the Builder: the marker is still *read* (same grep), but it is used **only as the stratification key**, never as a `sonnet → opus` bump. This is load-bearing — without it, a `complex`-marked issue on Arm B (sonnet-first) would silently become opus and confound the A/B. The bump behaves exactly as documented here whenever the experiment is `off`/`observe`.
@@ -550,7 +561,7 @@ The three states:
 
 **Two arms map onto #3718's inequality.** `resolve-mode` in `experiment` picks a per-issue arm via `./.loom/scripts/sweep-experiment.sh assign-arm --issue N --complexity <routine|complex>` → prints `<arm> <model>`:
 
-- **Arm A = opus-first** — Builder forced to `opus`; the normal escalation ladder still applies on Judge rejection.
+- **Arm A = opus-first** — Builder forced to `opus`; the normal escalation ladder still applies on Judge rejection. Resolve the printed `<model>` through `./.loom/scripts/resolve-model.sh` (or pass `--resolve` to `assign-arm`, which prints the already-resolved ID) before dispatch, so Arm A reaches **Opus 5** (`claude-opus-5`) on the wire rather than the stale gen-4 `opus` alias (issue #3982). Arm B's `sonnet` is unaffected (it passes through unchanged).
 - **Arm B = sonnet-first + escalate** — Builder forced to `sonnet`; on Judge rejection the Doctor escalates via the existing `sweep.escalation` ladder (#3481), exactly as documented in "Model escalation on Judge rejection". Arm B *is* the candidate policy #3718 is evaluating.
 
 **Deterministic, resume-safe, stratified assignment.** The arm is a pure function of the issue number and the #3702 complexity stratum, so a killed-and-resumed sweep re-running the same issue **lands on the same arm**. The complexity marker is read once (the same grep at the tier-2.5 site) and serves two purposes: the **stratification key** (so both arms see a comparable difficulty mix) and — **only when the experiment is off/observe** — the tier-2.5 bump. In `experiment` mode the bump is suppressed (see the "Experiment-mode suppression" note under tier 2.5).
@@ -1146,7 +1157,7 @@ If the PR entered the wave already labeled `loom:changes-requested` (e.g., from 
 - Load and follow the instructions in `.claude/commands/loom/doctor.md` for this PR.
 - Dispatch `loom-doctor` as a **single subagent Task** from this orchestrator session. Do **NOT** invoke `/loom:sweep` or `/doctor` slash-commands as subagents — see "CRITICAL: One level deep".
 - If a previous Doctor attempt for this PR died mid-flight without a fresh `doctor-done` checkpoint (rate limit, crash), re-verify forge state (pushed commit? already re-labeled `loom:review-requested`?) and complete only the missing steps rather than duplicating the pushed fix — see "Mid-phase-death recovery" in the Wave Lifecycle (inherited here, same as the Doctor-cycle cap).
-- **Model escalation (#3481)**: Mode C inherits the issue-side rule unchanged — this Doctor is dispatched because of a `loom:changes-requested` rejection, so resolve its model per "Model escalation on Judge rejection" in the Execution Model: pass `ladder[1]` from `sweep.escalation` (default ladder: `opus`) via the Task tool's `model` parameter, **unless** a tier-1/tier-2 pin applies (pins win) or escalation is disabled (`[]`/`false`).
+- **Model escalation (#3481)**: Mode C inherits the issue-side rule unchanged — this Doctor is dispatched because of a `loom:changes-requested` rejection, so resolve its model per "Model escalation on Judge rejection" in the Execution Model: pass `ladder[1]` from `sweep.escalation` (default ladder: `opus`, resolved through `resolve-model.sh` to `claude-opus-5` — #3982) via the Task tool's `model` parameter, **unless** a tier-1/tier-2 pin applies (pins win) or escalation is disabled (`[]`/`false`).
 - Doctor addresses the judge feedback, commits the fixes, pushes, and re-labels the PR `loom:review-requested`.
 - If a closing-issue checkpoint is in scope, write `doctor-done` (with the attempt counter and the model the Doctor actually ran on — escalated or pinned, #3482) **before** the follow-up Judge:
   ```bash
@@ -1547,7 +1558,7 @@ If Judge requests changes on PR `#X` mid-wave, run inline Doctor→Judge cycles 
 
 - Load and follow the instructions in `.claude/commands/loom/doctor.md` for PR `#X`.
 - **If a previous Doctor attempt for `#X` died mid-flight without writing a fresh `doctor-done` checkpoint** (rate limit, crash — the #3676 shape), re-verify forge state (pushed commit? already re-labeled `loom:review-requested`?) and complete only the missing steps rather than dispatching a fresh Doctor that would duplicate the pushed fix — see "Mid-phase-death recovery" above.
-- **Model escalation (#3481)**: this Doctor is dispatched because of a Judge rejection, so resolve its model per "Model escalation on Judge rejection" in the Execution Model — pass `ladder[min(attempt - 1, len - 1)]` from `sweep.escalation` (cycle 1 → `ladder[1]`, default `opus`) via the Task tool's `model` parameter, **unless** a tier-1/tier-2 pin applies (pins win) or escalation is disabled (`[]`/`false`).
+- **Model escalation (#3481)**: this Doctor is dispatched because of a Judge rejection, so resolve its model per "Model escalation on Judge rejection" in the Execution Model — pass `ladder[min(attempt - 1, len - 1)]` from `sweep.escalation` (cycle 1 → `ladder[1]`, default `opus`, resolved through `resolve-model.sh` to `claude-opus-5` — #3982) via the Task tool's `model` parameter, **unless** a tier-1/tier-2 pin applies (pins win) or escalation is disabled (`[]`/`false`).
 - Doctor addresses the judge's feedback, commits the fixes, and pushes.
 - **On successful Doctor completion**, write the `doctor-done` checkpoint for the issue (carrying the PR number, the attempt counter, and the model the Doctor actually ran on — escalated or pinned, #3482) **before** re-invoking Judge:
   ```bash

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -808,6 +808,23 @@ The ladder is configured in `.loom/config.json`:
 
 **Aliases vs pinned IDs**: shipped role JSONs use aliases so defaults stay sensible across model releases with zero maintenance. The GitHub Actions cron workflows (`.github/workflows/loom-*.yml`) are the exception — they pin exact IDs because scheduled support roles are predictable, cost-sensitive load and a stale pin is visible and cheap to bump in the consuming repo.
 
+> **Logical-tier resolution (`sweep.modelAliases`, issue #3982).** A logical alias
+> is not always current on the wire: the bare `opus` alias still resolves to a
+> **previous-generation** model (`claude-opus-4-8`) while `sonnet`/`fable` resolve
+> to the current generation, which would make the escalation ladder
+> `sonnet → sonnet@xhigh → opus → fable` step *down* a generation at the `opus`
+> rung. So every consumer keeps naming `opus` and a **single indirection point**
+> maps the logical tier to the concrete ID the dispatch should use — the
+> `/loom:sweep` skill via `./.loom/scripts/resolve-model.sh`, `loom_tools` via
+> `model_tiers`, and `loom-daemon` via `resolve_dispatch_model`. The shipped map
+> pins only the stale tier (`opus → claude-opus-5`); `sonnet`/`fable` and pinned
+> IDs pass through unchanged. Repoint or drop a pin per-repo with an additive
+> `.loom/config.json` → `sweep.modelAliases` object (no code change):
+>
+> ```json
+> { "sweep": { "modelAliases": { "opus": "claude-opus-5" } } }
+> ```
+
 **Workspace override example** (`.loom/config.json`):
 
 ```json

--- a/defaults/scripts/resolve-model.sh
+++ b/defaults/scripts/resolve-model.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# resolve-model.sh - Thin stub delegating to loom_tools.model_tiers (#3982)
+#
+# The /loom:sweep skill shells out to this to resolve a *logical* model tier
+# (`opus`, `sonnet`, `sonnet@xhigh`) to the concrete model ID it should dispatch
+# on the wire, BEFORE it passes the model to a subagent Task. This is the single
+# indirection point that fixes the non-monotonic escalation ladder: every rung,
+# the tier-2.5 bump, the Judge/refusal fallbacks, and the experiment's Arm A keep
+# naming the alias `opus`, and exactly one place decides that `opus` means
+# `claude-opus-5` (the CLI's own `opus` alias still resolves to a gen-4 model).
+#
+# The mapping is configurable in `.loom/config.json` -> `sweep.modelAliases`, so
+# an operator can repoint a tier (or drop the pin once the CLI alias rolls to
+# gen-5) with no code change. Unknown aliases and pinned IDs (`claude-sonnet-4-6`)
+# pass through unchanged.
+#
+# Usage:
+#   resolve-model.sh <tier|alias|id>            # prints the resolved model ID
+#   resolve-model.sh <tier> --generation        # prints the resolved generation number
+#   resolve-model.sh <tier> --config <path>     # explicit .loom/config.json path
+#
+# Examples:
+#   resolve-model.sh opus            # -> claude-opus-5
+#   resolve-model.sh sonnet@xhigh    # -> sonnet@xhigh   (passthrough; CLI resolves)
+#   resolve-model.sh claude-sonnet-4-6   # -> claude-sonnet-4-6 (pinned ID, unchanged)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source shared loom-tools helper
+source "$SCRIPT_DIR/lib/loom-tools.sh"
+
+# Run the command with proper fallback chain
+run_loom_tool "resolve-model" "model_tiers" "$@"

--- a/docs/model-selection-retune.md
+++ b/docs/model-selection-retune.md
@@ -368,6 +368,36 @@ here changes a default** unless it also cites a qualifying sample per Section 3.
   opus→sonnet flip is the **deferred operator action** tracked by #3750, not closed
   by its Builder PR.
 
+- **2026-07-27 (#3982) — the `opus` tier now resolves to Opus 5; prior Arm A
+  evidence is NOT comparable to post-change samples.** The logical `opus` rung was
+  resolving to a **previous-generation** model on the wire (`claude-opus-4-8`)
+  while `sonnet`/`fable` resolved to gen-5, so the escalation ladder
+  `sonnet → sonnet@xhigh → opus → fable` was non-monotonic and **Arm A of the
+  #3718 model-cost experiment ("opus-first") was measuring a previous-generation
+  model against a current-generation Arm B**. #3982 introduces a single logical
+  tier → concrete-ID indirection point (`loom_tools/model_tiers.py`,
+  `defaults/scripts/resolve-model.sh`, and `sweep_registry::resolve_dispatch_model`,
+  configurable via `.loom/config.json` → `sweep.modelAliases`) that pins the stale
+  `opus` tier to `claude-opus-5` while leaving `sonnet`/`fable` untouched.
+  `ARM_MODEL` still reads `{"A": "opus", "B": "sonnet"}`; Arm A is now resolved to
+  `claude-opus-5` at dispatch (`assign-arm --resolve`).
+
+  **Consequence for the gate:** any Arm A samples gathered **before 2026-07-27**
+  were run on Opus 4.8 and must **not** be pooled with post-change Arm A samples,
+  which run on Opus 5 — they measure different models. Because #3981 made pricing
+  and family attribution generation-agnostic (both `claude-opus-4-8` and
+  `claude-opus-5` price and attribute as the `opus` family / Arm A), the harvest
+  cannot distinguish the two by arm label alone; the **collection-date cutoff is
+  the discriminator.** Any future §2 re-evaluation must draw its ≥~30 Arm A
+  first-attempts from post-2026-07-27 sweeps only.
+
+  **Representative sample?** No — this entry ships the resolution fix and records
+  the generation change; it cites no numbers and accrues no sample.
+
+  **Decision:** `defaults/roles/builder.json` `suggestedModel` remains `opus` (the
+  alias, now resolving to Opus 5). No default flipped. Arm B and
+  `DEFAULT_DISPATCH_MODEL` (`sonnet`) are unchanged — Sonnet remains the workhorse.
+
 ---
 
 ## 5. The flip is a separate, gated follow-up

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -174,13 +174,96 @@ pub fn read_autonomous_model(repo_root: &Path) -> Option<String> {
 /// default rather than the operator's interactive CLI default.
 #[must_use]
 pub fn resolve_dispatch_model(repo_root: &Path, explicit: Option<&str>) -> (String, ModelSource) {
-    if let Some(m) = explicit.map(str::trim).filter(|m| !m.is_empty()) {
-        return (m.to_string(), ModelSource::Param);
+    let (model, source) = if let Some(m) = explicit.map(str::trim).filter(|m| !m.is_empty()) {
+        (m.to_string(), ModelSource::Param)
+    } else if let Some(m) = read_autonomous_model(repo_root) {
+        (m, ModelSource::Config)
+    } else {
+        (DEFAULT_DISPATCH_MODEL.to_string(), ModelSource::Default)
+    };
+    // Issue #3982: resolve the logical tier/alias to the concrete model ID before
+    // it goes on the wire. This is the daemon's half of the single indirection
+    // point shared with `sweep.md` (via `resolve-model.sh`) and `loom_tools`
+    // (`model_tiers`): every consumer keeps naming `opus`, and exactly one place
+    // decides that `opus` means `claude-opus-5` (the CLI's own `opus` alias still
+    // resolves to a gen-4 model). Applied at ALL tiers so an operator's
+    // `autonomous.model = "opus"` (or an explicit `--model opus`) also reaches
+    // Opus 5; the shipped default `sonnet` is not pinned and passes through.
+    (resolve_model_alias(repo_root, &model), source)
+}
+
+/// Issue #3982: the shipped logical-tier → pinned model-ID default map. Pins ONLY
+/// tiers whose bare CLI alias resolves to a stale generation — today just
+/// `opus → claude-opus-5`. `sonnet`/`fable` are intentionally absent: the CLI
+/// already resolves them to the current generation, so they pass through
+/// unchanged and track future generations with no edit here. Overridable per-repo
+/// via `.loom/config.json` → `sweep.modelAliases`. Kept byte-identical to the
+/// Python default in `loom_tools/model_tiers.py::_DEFAULT_TIER_ALIASES`.
+const DEFAULT_TIER_ALIASES: &[(&str, &str)] = &[("opus", "claude-opus-5")];
+
+/// Read the `sweep.modelAliases` override map from `<repo_root>/.loom/config.json`,
+/// soft-failing to an empty map on any error (missing file, malformed JSON, absent
+/// key, non-object value). Blank keys/values are dropped. Mirrors the soft-fail
+/// contract of [`read_autonomous_model`] and `model_tiers._config_overrides`.
+#[must_use]
+pub fn read_model_aliases(repo_root: &Path) -> BTreeMap<String, String> {
+    let mut out = BTreeMap::new();
+    let path = repo_root.join(".loom").join("config.json");
+    let Ok(contents) = std::fs::read_to_string(&path) else {
+        return out;
+    };
+    let Ok(config) = serde_json::from_str::<serde_json::Value>(&contents) else {
+        return out;
+    };
+    let Some(aliases) = config
+        .get("sweep")
+        .and_then(|s| s.get("modelAliases"))
+        .and_then(serde_json::Value::as_object)
+    else {
+        return out;
+    };
+    for (key, val) in aliases {
+        let key = key.trim().to_lowercase();
+        if key.is_empty() {
+            continue;
+        }
+        if let Some(v) = val.as_str().map(str::trim).filter(|v| !v.is_empty()) {
+            out.insert(key, v.to_string());
+        }
     }
-    if let Some(m) = read_autonomous_model(repo_root) {
-        return (m, ModelSource::Config);
+    out
+}
+
+/// Issue #3982: resolve a logical model tier/alias to the concrete model ID to
+/// dispatch, applying the shipped [`DEFAULT_TIER_ALIASES`] map overlaid with the
+/// per-repo `sweep.modelAliases` override. Preserves any `@effort` suffix
+/// (`opus@xhigh` → `claude-opus-5@xhigh`). Unknown aliases and pinned IDs
+/// (`claude-sonnet-4-6`) pass through unchanged.
+#[must_use]
+pub fn resolve_model_alias(repo_root: &Path, model: &str) -> String {
+    if model.is_empty() {
+        return String::new();
     }
-    (DEFAULT_DISPATCH_MODEL.to_string(), ModelSource::Default)
+    let (base, effort) = match model.split_once('@') {
+        Some((b, e)) => (b, Some(e)),
+        None => (model, None),
+    };
+    let key = base.trim().to_lowercase();
+    let overrides = read_model_aliases(repo_root);
+    let resolved = overrides
+        .get(&key)
+        .map(String::as_str)
+        .or_else(|| {
+            DEFAULT_TIER_ALIASES
+                .iter()
+                .find(|(k, _)| *k == key)
+                .map(|(_, v)| *v)
+        })
+        .unwrap_or(base.trim());
+    match effort {
+        Some(e) => format!("{resolved}@{e}"),
+        None => resolved.to_string(),
+    }
 }
 
 /// Issue #3730: experiment-related env vars forwarded to the detached sweep
@@ -4505,13 +4588,15 @@ exit 0
     }
 
     /// `autonomous.model` in config wins over the shipped default when no
-    /// explicit param is supplied.
+    /// explicit param is supplied. The resolved value is passed through the
+    /// #3982 tier map, so a logical `opus` reaches `claude-opus-5` on the wire
+    /// while the source stays `Config`.
     #[test]
     fn resolve_dispatch_model_reads_autonomous_config() {
         let dir = tempdir().unwrap();
         write_config(dir.path(), r#"{"autonomous": {"model": "opus"}}"#);
         let (model, source) = resolve_dispatch_model(dir.path(), None);
-        assert_eq!(model, "opus");
+        assert_eq!(model, "claude-opus-5");
         assert_eq!(source, ModelSource::Config);
     }
 
@@ -4532,10 +4617,11 @@ exit 0
     #[test]
     fn resolve_dispatch_model_treats_blank_as_unset() {
         let dir = tempdir().unwrap();
-        // Empty explicit param + populated config → config wins.
+        // Empty explicit param + populated config → config wins (and `opus`
+        // resolves through the #3982 tier map to `claude-opus-5`).
         write_config(dir.path(), r#"{"autonomous": {"model": "opus"}}"#);
         let (model, source) = resolve_dispatch_model(dir.path(), Some("   "));
-        assert_eq!(model, "opus");
+        assert_eq!(model, "claude-opus-5");
         assert_eq!(source, ModelSource::Config);
 
         // Blank config value → shipped default.
@@ -4567,6 +4653,105 @@ exit 0
         assert_eq!(read_autonomous_model(dir.path()), None);
         let (model, _) = resolve_dispatch_model(dir.path(), None);
         assert_eq!(model, DEFAULT_DISPATCH_MODEL);
+    }
+
+    // --- Issue #3982: logical-tier → concrete-ID resolution --------------- //
+
+    /// The shipped default map pins the stale `opus` alias to gen-5 while leaving
+    /// current-generation aliases and pinned IDs untouched (passthrough).
+    #[test]
+    fn resolve_model_alias_pins_opus_and_passes_through_rest() {
+        let dir = tempdir().unwrap(); // no config → shipped defaults only
+        assert_eq!(resolve_model_alias(dir.path(), "opus"), "claude-opus-5");
+        // sonnet/fable are NOT pinned — the CLI resolves them to gen-5 already.
+        assert_eq!(resolve_model_alias(dir.path(), "sonnet"), "sonnet");
+        assert_eq!(resolve_model_alias(dir.path(), "fable"), "fable");
+        // A pinned ID is never rewritten.
+        assert_eq!(resolve_model_alias(dir.path(), "claude-sonnet-4-6"), "claude-sonnet-4-6");
+        // An unknown alias passes through unchanged.
+        assert_eq!(resolve_model_alias(dir.path(), "mystery"), "mystery");
+        // Empty stays empty.
+        assert_eq!(resolve_model_alias(dir.path(), ""), "");
+    }
+
+    /// The `model@effort` suffix is preserved across resolution.
+    #[test]
+    fn resolve_model_alias_preserves_effort_suffix() {
+        let dir = tempdir().unwrap();
+        assert_eq!(resolve_model_alias(dir.path(), "opus@xhigh"), "claude-opus-5@xhigh");
+        // Passthrough model keeps its effort too.
+        assert_eq!(resolve_model_alias(dir.path(), "sonnet@xhigh"), "sonnet@xhigh");
+    }
+
+    /// A `sweep.modelAliases` block repoints a tier without a code change, and
+    /// can drop the shipped pin by mapping the alias back to itself.
+    #[test]
+    fn resolve_model_alias_honors_config_override() {
+        // Repoint opus to a hypothetical next generation.
+        let dir = tempdir().unwrap();
+        write_config(dir.path(), r#"{"sweep": {"modelAliases": {"opus": "claude-opus-6"}}}"#);
+        assert_eq!(resolve_model_alias(dir.path(), "opus"), "claude-opus-6");
+
+        // Drop the pin: map opus back to the bare alias (CLI resolves it).
+        let dir2 = tempdir().unwrap();
+        write_config(dir2.path(), r#"{"sweep": {"modelAliases": {"opus": "opus"}}}"#);
+        assert_eq!(resolve_model_alias(dir2.path(), "opus"), "opus");
+
+        // Malformed config soft-falls to the shipped default map.
+        let dir3 = tempdir().unwrap();
+        write_config(dir3.path(), "{ not json");
+        assert_eq!(resolve_model_alias(dir3.path(), "opus"), "claude-opus-5");
+    }
+
+    /// Ladder monotonicity: no rung of the shipped escalation ladder resolves to
+    /// an older generation than the rung below it. This is the regression guard
+    /// for #3982 — before the fix, `opus` resolved to a gen-4 model, one below
+    /// the `sonnet@xhigh` rung beneath it. The generation each bare alias
+    /// resolves to on the wire is the probed table (sonnet/fable → 5, and the
+    /// unfixed `opus` alias → 4); the tier map lifts `opus` to gen-5.
+    #[test]
+    fn resolve_model_alias_ladder_is_monotonic() {
+        let dir = tempdir().unwrap();
+        // Probed alias generations (mirrors model_tiers._ALIAS_GENERATION).
+        fn alias_generation(alias: &str) -> u32 {
+            match alias {
+                "sonnet" | "fable" | "haiku" => 5,
+                "opus" => 4, // the unfixed CLI alias — the bug
+                other => panic!("unexpected bare alias in ladder: {other}"),
+            }
+        }
+        fn generation_of(dir: &Path, rung: &str) -> u32 {
+            let resolved = resolve_model_alias(dir, rung);
+            let base = resolved.split('@').next().unwrap();
+            // Pinned ID `claude-<family>-<gen>[-...]` → parse the generation.
+            if let Some(rest) = base.strip_prefix("claude-") {
+                let mut parts = rest.split('-');
+                let first = parts.next().unwrap_or("");
+                // `claude-opus-5` → family then gen; `claude-3-5-sonnet` → gen first.
+                if let Ok(g) = first.parse::<u32>() {
+                    return g;
+                }
+                if let Some(g) = parts.next().and_then(|p| p.parse::<u32>().ok()) {
+                    return g;
+                }
+            }
+            // A bare alias that passed through unmapped.
+            alias_generation(base)
+        }
+
+        let ladder = ["sonnet", "sonnet@xhigh", "opus", "fable"];
+        let gens: Vec<u32> = ladder
+            .iter()
+            .map(|r| generation_of(dir.path(), r))
+            .collect();
+        for pair in gens.windows(2) {
+            assert!(
+                pair[1] >= pair[0],
+                "escalation ladder is non-monotonic: {ladder:?} resolved to generations {gens:?}"
+            );
+        }
+        // And specifically the previously-broken rung is now gen-5.
+        assert_eq!(generation_of(dir.path(), "opus"), 5);
     }
 
     /// Issue #3716: an `effort` dispatch param threads through to the spawn

--- a/loom-tools/pyproject.toml
+++ b/loom-tools/pyproject.toml
@@ -54,6 +54,7 @@ loom-forge = "loom_tools.forge_cli:cli_main"
 loom-auto-merge = "loom_tools.auto_merge:main"
 loom-tokens = "loom_tools.tokens.cli:main"
 loom-state-machine = "loom_tools.state_machine:main"
+loom-resolve-model = "loom_tools.model_tiers:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/loom-tools/src/loom_tools/model_tiers.py
+++ b/loom-tools/src/loom_tools/model_tiers.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Logical model-tier → concrete model-ID resolution (issue #3982).
+
+The ``/loom:sweep`` escalation ladder, the tier-2.5 complexity bump, the
+No-Fable-Judge fallback, the ``fable`` refusal fallback, the model-cost
+experiment's Arm A, the role-default ``suggestedModel`` fields, and the daemon's
+autonomous dispatch model all name *logical tiers* by their CLI alias —
+``sonnet``, ``opus``, ``fable``. Two of those aliases resolve to the current
+generation on the wire; ``opus`` lags a generation. Probed 2026-07-27::
+
+    opus   → claude-opus-4-8   (generation 4)   ← the lagging rung
+    sonnet → claude-sonnet-5   (generation 5)
+    fable  → claude-fable-5    (generation 5)
+
+That makes the shipped escalation ladder (``sonnet → sonnet@xhigh → opus →
+fable``) **non-monotonic** — the ``sonnet@xhigh → opus`` step steps *down* a
+generation, and Arm A of the #3718 model-cost experiment has been measuring a
+previous-generation model against a current-generation Arm B.
+
+This module is the **single indirection point** that maps a logical tier to the
+concrete model ID it should dispatch on the wire, so every consumer keeps saying
+``opus`` and exactly one place decides what ``opus`` means. The three consumers:
+
+* the ``sweep.md`` skill — via the ``resolve-model.sh`` shell stub (this module's
+  CLI), which it calls to resolve each rung/tier/arm before a subagent dispatch;
+* ``loom_tools`` Python — ``sweep_experiment.resolved_arm_model`` resolves Arm A
+  through here (``ARM_MODEL`` itself stays aliases);
+* the Rust daemon — ``sweep_registry::resolve_dispatch_model`` reads the same
+  ``.loom/config.json`` → ``sweep.modelAliases`` block and applies the same
+  shipped default.
+
+Design rules
+------------
+* **Only stale aliases are pinned.** The shipped default map pins exactly the
+  tiers whose bare CLI alias resolves to an older generation — today just
+  ``opus → claude-opus-5``. ``sonnet``/``fable`` are **not** pinned: the CLI
+  already resolves them to the current generation, so they pass through unchanged
+  and automatically track future generations with no edit here. Drop the ``opus``
+  pin once the CLI's own ``opus`` alias rolls to gen 5.
+* **Configurable.** ``.loom/config.json`` → ``sweep.modelAliases`` (an additive
+  tier → ID object) overrides / extends the default map, so an operator can
+  repoint a tier — or drop a pin (``{"opus": "opus"}`` maps ``opus`` back to the
+  bare alias) — with no code change.
+* **Passthrough is the default.** An input that is not a mapped tier (an unknown
+  alias, or a pinned ID like ``claude-sonnet-4-6``) is returned unchanged, so a
+  workspace that pins an exact ID is never rewritten.
+* **The ``model@effort`` grammar is preserved.** A ``@effort`` suffix
+  (``sonnet@xhigh``) is split off, the model half resolved, and the suffix
+  reattached.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from typing import Any
+
+# --------------------------------------------------------------------------- #
+# Constants
+# --------------------------------------------------------------------------- #
+
+# The generation each bare CLI alias resolves to on the wire TODAY (probed
+# 2026-07-27). This is the guardrail the monotonicity test reads: ``opus`` lags
+# at generation 4, which is the bug #3982 fixes at the resolution layer. Update
+# this table (and drop the matching pin below) when Anthropic repoints an alias.
+_ALIAS_GENERATION: dict[str, int] = {
+    "haiku": 5,
+    "sonnet": 5,
+    "opus": 4,
+    "fable": 5,
+}
+
+# Default logical-tier → pinned model-ID map. Pin ONLY tiers whose bare CLI alias
+# resolves to a stale generation (see ``_ALIAS_GENERATION``). Everything else
+# passes through unchanged. Overridable via ``.loom/config.json`` →
+# ``sweep.modelAliases``.
+_DEFAULT_TIER_ALIASES: dict[str, str] = {
+    "opus": "claude-opus-5",
+}
+
+
+def _warn(msg: str) -> None:
+    print(f"[model-tiers] WARNING: {msg}", file=sys.stderr)
+
+
+# --------------------------------------------------------------------------- #
+# Config (best-effort — never raises)
+# --------------------------------------------------------------------------- #
+
+
+def load_config(config_path: str | os.PathLike[str] | None = None) -> dict[str, Any]:
+    """Best-effort read of ``.loom/config.json``; malformed/absent → ``{}``."""
+    if config_path is None:
+        config_path = ".loom/config.json"
+    try:
+        with open(config_path, encoding="utf-8") as fh:
+            data = json.load(fh)
+        return data if isinstance(data, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def _config_overrides(config: dict[str, Any] | None) -> dict[str, str]:
+    """Extract the ``sweep.modelAliases`` override map (best-effort, tolerant).
+
+    A non-dict ``sweep``/``modelAliases``, non-string keys/values, or blank
+    values are dropped rather than raising — resolution must never block a sweep.
+    """
+    if not isinstance(config, dict):
+        return {}
+    sweep = config.get("sweep")
+    aliases = sweep.get("modelAliases") if isinstance(sweep, dict) else None
+    if not isinstance(aliases, dict):
+        return {}
+    out: dict[str, str] = {}
+    for key, val in aliases.items():
+        if isinstance(key, str) and isinstance(val, str) and val.strip():
+            out[key.strip().lower()] = val.strip()
+    return out
+
+
+def tier_map(config: dict[str, Any] | None = None) -> dict[str, str]:
+    """The effective tier→ID map: shipped defaults overlaid with config overrides."""
+    return {**_DEFAULT_TIER_ALIASES, **_config_overrides(config)}
+
+
+# --------------------------------------------------------------------------- #
+# Resolution
+# --------------------------------------------------------------------------- #
+
+
+def resolve_model(model: str | None, config: dict[str, Any] | None = None) -> str:
+    """Resolve a logical tier / alias / pinned ID to the concrete model ID.
+
+    Preserves any ``@effort`` suffix (``sonnet@xhigh`` → ``sonnet@xhigh``,
+    ``opus@xhigh`` → ``claude-opus-5@xhigh``). Unknown aliases and pinned IDs pass
+    through unchanged. ``None``/empty → ``""``.
+    """
+    if not model:
+        return ""
+    base, sep, effort = model.partition("@")
+    key = base.strip().lower()
+    resolved = tier_map(config).get(key, base.strip())
+    return f"{resolved}{sep}{effort}" if sep else resolved
+
+
+def generation_of(model: str | None, config: dict[str, Any] | None = None) -> int | None:
+    """The model generation a logical tier / ID resolves to on the wire.
+
+    Resolves the input through the tier map first, then extracts the generation
+    from the concrete ID (``claude-opus-5`` → 5, ``claude-sonnet-4-6`` → 4, the
+    legacy ``claude-3-5-sonnet`` → 3). A bare alias that stays unmapped
+    (``sonnet``/``fable``) is looked up in the probed ``_ALIAS_GENERATION`` table.
+    Returns ``None`` for anything unrecognized.
+    """
+    resolved = resolve_model(model, config)
+    base = resolved.partition("@")[0].strip().lower()
+    if not base:
+        return None
+    # Modern IDs: claude-<family>-<gen>[-<minor>]
+    m = re.match(r"^claude-[a-z]+-(\d+)", base)
+    if m:
+        return int(m.group(1))
+    # Legacy IDs: claude-<gen>-...
+    m = re.match(r"^claude-(\d+)-", base)
+    if m:
+        return int(m.group(1))
+    # A bare alias that passed through unmapped.
+    return _ALIAS_GENERATION.get(base)
+
+
+# --------------------------------------------------------------------------- #
+# CLI (the surface `resolve-model.sh` shells out to)
+# --------------------------------------------------------------------------- #
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="loom-resolve-model",
+        description=(
+            "Resolve a logical model tier/alias to the concrete model ID to "
+            "dispatch on the wire (issue #3982). Unknown aliases and pinned IDs "
+            "pass through unchanged."
+        ),
+    )
+    parser.add_argument(
+        "model",
+        help="A logical tier/alias (opus, sonnet, sonnet@xhigh) or a pinned model ID.",
+    )
+    parser.add_argument(
+        "--config",
+        default=None,
+        help="Path to .loom/config.json (default: ./.loom/config.json).",
+    )
+    parser.add_argument(
+        "--generation",
+        action="store_true",
+        help="Print the resolved generation number instead of the model ID.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    config = load_config(args.config)
+    if args.generation:
+        gen = generation_of(args.model, config)
+        print("" if gen is None else gen)
+    else:
+        print(resolve_model(args.model, config))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/loom-tools/src/loom_tools/sweep_experiment.py
+++ b/loom-tools/src/loom_tools/sweep_experiment.py
@@ -44,6 +44,8 @@ import sys
 from datetime import datetime, timezone
 from typing import Any, Callable
 
+from loom_tools import model_tiers
+
 # --------------------------------------------------------------------------- #
 # Constants
 # --------------------------------------------------------------------------- #
@@ -57,6 +59,13 @@ _TRUTHY = {"1", "true", "yes", "on"}
 CANARY_SENTINEL = ".loom/CANARY"
 
 # Arm -> forced Builder model. Arm A is opus-first, Arm B is sonnet-first.
+#
+# These stay **logical aliases** (not pinned IDs): the arm identity is what the
+# harvest, the ``assign-arm`` default output, and ``test-sweep-experiment.sh``
+# key off. The alias is resolved to a concrete model ID through the shared tier
+# map (``model_tiers``, issue #3982) at *dispatch* time — see ``resolved_arm_model``
+# / ``assign-arm --resolve`` — so Arm A reaches Opus 5 rather than the CLI's stale
+# gen-4 ``opus`` alias, WITHOUT changing what this map says.
 ARM_MODEL = {"A": "opus", "B": "sonnet"}
 
 DEFAULT_STATS_FILE = ".loom/stats/sweep-model-stats.jsonl"
@@ -269,6 +278,19 @@ def assign_arm(issue_number: int, complexity: str | None = None) -> str:
 
 def arm_model(arm: str) -> str:
     return ARM_MODEL.get(arm.upper().strip(), "")
+
+
+def resolved_arm_model(arm: str, config: dict[str, Any] | None = None) -> str:
+    """Resolve an arm's logical model alias to the concrete model ID to dispatch.
+
+    ``ARM_MODEL`` stays aliases (Arm A = ``opus``) so the arm identity is stable
+    for reporting and the ``assign-arm`` default output; this resolves that alias
+    through the shared tier map (``model_tiers``, #3982) at *dispatch* time so
+    Arm A reaches Opus 5 (``claude-opus-5``) instead of the CLI's stale gen-4
+    ``opus`` alias. An unmapped arm resolves to ``""``.
+    """
+    alias = arm_model(arm)
+    return model_tiers.resolve_model(alias, config) if alias else ""
 
 
 def _model_family(model: str | None) -> str | None:
@@ -845,7 +867,15 @@ def _cmd_resolve_mode(args: argparse.Namespace) -> int:
 
 def _cmd_assign_arm(args: argparse.Namespace) -> int:
     arm = assign_arm(args.issue, args.complexity)
-    model = arm_model(arm)
+    # Default prints the logical alias (Arm A -> `opus`), which the arm identity
+    # and `test-sweep-experiment.sh` key off. `--resolve` prints the concrete
+    # model ID the tier map resolves that alias to on the wire (#3982), so the
+    # sweep skill can force the Builder to Opus 5 directly instead of passing the
+    # stale bare `opus` alias through.
+    if getattr(args, "resolve", False):
+        model = resolved_arm_model(arm, model_tiers.load_config(args.config))
+    else:
+        model = arm_model(arm)
     if args.format == "json":
         print(
             json.dumps(
@@ -936,6 +966,13 @@ def build_parser() -> argparse.ArgumentParser:
     p_arm.add_argument("--issue", type=int, required=True)
     p_arm.add_argument("--complexity", default=None)
     p_arm.add_argument("--format", choices=("text", "json"), default="text")
+    p_arm.add_argument(
+        "--resolve",
+        action="store_true",
+        help="Print the concrete model ID the arm's alias resolves to on the wire "
+        "(via the #3982 tier map) instead of the bare alias.",
+    )
+    p_arm.add_argument("--config", default=None)
     p_arm.set_defaults(func=_cmd_assign_arm)
 
     p_ban = sub.add_parser("banner", help="Loud startup banner naming mode + arm.")

--- a/loom-tools/tests/test_model_tiers.py
+++ b/loom-tools/tests/test_model_tiers.py
@@ -1,0 +1,190 @@
+"""Unit tests for loom_tools.model_tiers (issue #3982).
+
+The module is the single logical-tier → concrete-model-ID indirection point that
+fixes the non-monotonic escalation ladder: the bare `opus` alias resolves to a
+previous-generation model on the wire, so every consumer keeps naming `opus` and
+exactly one place decides that `opus` means `claude-opus-5`.
+
+Covered:
+- the shipped default map pins only the stale `opus` tier; everything else passes
+  through unchanged (unknown aliases, current-gen aliases, pinned IDs);
+- the `model@effort` suffix is preserved across resolution;
+- `.loom/config.json` → `sweep.modelAliases` overrides / drops a pin with no code
+  change, and malformed config soft-falls to the shipped default;
+- generation extraction (modern IDs, legacy IDs, bare aliases);
+- ladder monotonicity — no rung resolves to an older generation than the rung
+  below it (the regression guard for the reported bug).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from loom_tools import model_tiers as mt
+
+
+# --------------------------------------------------------------------------- #
+# resolve_model
+# --------------------------------------------------------------------------- #
+
+
+def test_pins_only_stale_opus_tier():
+    assert mt.resolve_model("opus") == "claude-opus-5"
+    # sonnet/fable are NOT pinned — the CLI resolves them to the current gen.
+    assert mt.resolve_model("sonnet") == "sonnet"
+    assert mt.resolve_model("fable") == "fable"
+
+
+def test_pinned_id_and_unknown_alias_pass_through():
+    assert mt.resolve_model("claude-sonnet-4-6") == "claude-sonnet-4-6"
+    assert mt.resolve_model("mystery-model") == "mystery-model"
+
+
+@pytest.mark.parametrize("value", [None, "", "  "])
+def test_empty_inputs_resolve_to_empty_string(value):
+    # Whitespace-only input has no tier to resolve; base.strip() → "".
+    assert mt.resolve_model(value) == ""
+
+
+def test_effort_suffix_preserved():
+    assert mt.resolve_model("opus@xhigh") == "claude-opus-5@xhigh"
+    assert mt.resolve_model("sonnet@xhigh") == "sonnet@xhigh"
+    # A malformed/empty effort still round-trips (never raises).
+    assert mt.resolve_model("opus@") == "claude-opus-5@"
+
+
+def test_case_insensitive_alias():
+    assert mt.resolve_model("OPUS") == "claude-opus-5"
+    assert mt.resolve_model("Opus") == "claude-opus-5"
+
+
+# --------------------------------------------------------------------------- #
+# config overrides
+# --------------------------------------------------------------------------- #
+
+
+def test_config_override_repoints_a_tier():
+    cfg = {"sweep": {"modelAliases": {"opus": "claude-opus-6"}}}
+    assert mt.resolve_model("opus", cfg) == "claude-opus-6"
+
+
+def test_config_override_can_add_a_new_tier():
+    cfg = {"sweep": {"modelAliases": {"sonnet": "claude-sonnet-9"}}}
+    assert mt.resolve_model("sonnet", cfg) == "claude-sonnet-9"
+    # opus still uses the shipped default (override is additive).
+    assert mt.resolve_model("opus", cfg) == "claude-opus-5"
+
+
+def test_config_can_drop_the_pin():
+    # Mapping opus back to the bare alias drops the pin (CLI resolves it).
+    cfg = {"sweep": {"modelAliases": {"opus": "opus"}}}
+    assert mt.resolve_model("opus", cfg) == "opus"
+
+
+@pytest.mark.parametrize(
+    "cfg",
+    [
+        None,
+        {},
+        {"sweep": None},
+        {"sweep": {}},
+        {"sweep": {"modelAliases": None}},
+        {"sweep": {"modelAliases": "not-a-dict"}},
+        {"sweep": {"modelAliases": {"opus": ""}}},  # blank value dropped
+        {"sweep": {"modelAliases": {"opus": 5}}},  # non-string value dropped
+        "not-a-dict",
+    ],
+)
+def test_malformed_config_soft_falls_to_shipped_default(cfg):
+    assert mt.resolve_model("opus", cfg) == "claude-opus-5"
+
+
+def test_load_config_missing_and_malformed(tmp_path):
+    assert mt.load_config(tmp_path / "nope.json") == {}
+    bad = tmp_path / "bad.json"
+    bad.write_text("{ not valid json", encoding="utf-8")
+    assert mt.load_config(bad) == {}
+    good = tmp_path / "config.json"
+    good.write_text(json.dumps({"sweep": {"modelAliases": {"opus": "x"}}}), encoding="utf-8")
+    assert mt.load_config(good) == {"sweep": {"modelAliases": {"opus": "x"}}}
+
+
+# --------------------------------------------------------------------------- #
+# generation_of
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "model,expected",
+    [
+        ("opus", 5),  # resolves through the map first
+        ("sonnet", 5),
+        ("fable", 5),
+        ("haiku", 5),
+        ("claude-opus-5", 5),
+        ("claude-sonnet-4-6", 4),
+        ("claude-opus-5@xhigh", 5),
+        ("claude-3-5-sonnet", 3),  # legacy naming
+        ("claude-3-opus", 3),
+        ("mystery", None),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_generation_of(model, expected):
+    assert mt.generation_of(model) == expected
+
+
+def test_generation_of_honors_config_override():
+    cfg = {"sweep": {"modelAliases": {"opus": "claude-opus-6"}}}
+    assert mt.generation_of("opus", cfg) == 6
+
+
+# --------------------------------------------------------------------------- #
+# ladder monotonicity — the regression guard for #3982
+# --------------------------------------------------------------------------- #
+
+
+def test_shipped_ladder_is_monotonic():
+    ladder = ["sonnet", "sonnet@xhigh", "opus", "fable"]
+    gens = [mt.generation_of(rung) for rung in ladder]
+    assert None not in gens, f"a ladder rung has no known generation: {list(zip(ladder, gens))}"
+    for lo, hi in zip(gens, gens[1:]):
+        assert hi >= lo, f"escalation ladder is non-monotonic: {list(zip(ladder, gens))}"
+    # The previously-broken rung is specifically gen-5 now.
+    assert mt.generation_of("opus") == 5
+
+
+def test_probed_alias_table_records_the_bug():
+    # The guardrail table documents the CLI reality the fix compensates for:
+    # `opus` alone still resolves to a gen-4 model, which is why it is pinned.
+    assert mt._ALIAS_GENERATION["opus"] == 4
+    assert mt._ALIAS_GENERATION["sonnet"] == 5
+    assert mt._ALIAS_GENERATION["fable"] == 5
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+
+
+def test_cli_prints_resolved_id(capsys):
+    rc = mt.main(["opus"])
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == "claude-opus-5"
+
+
+def test_cli_generation_flag(capsys):
+    rc = mt.main(["opus", "--generation"])
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == "5"
+
+
+def test_cli_passthrough_and_config(tmp_path, capsys):
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({"sweep": {"modelAliases": {"opus": "claude-opus-6"}}}), encoding="utf-8")
+    rc = mt.main(["opus", "--config", str(cfg)])
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == "claude-opus-6"


### PR DESCRIPTION
Closes #3982

## Problem

The bare `opus` CLI alias still resolves to a **previous-generation** model on the wire (`claude-opus-4-8`), while `sonnet`/`fable` resolve to gen-5. So the shipped escalation ladder `sonnet → sonnet@xhigh → opus → fable` silently stepped **down** a generation at the `opus` rung, and **Arm A of the #3718 model-cost experiment ("opus-first") was measuring a previous-generation model against a current-generation Arm B**.

A naive find/replace of `opus → claude-opus-5` was the wrong fix twice over: it breaks the pinned ladder doc-strings and recreates the same problem one generation later. The rungs are logical tiers; only their *resolution* was wrong.

## Approach — one indirection point, three consumers

Every consumer keeps naming the logical alias `opus`, and exactly one place decides what `opus` means on the wire:

- **`loom-tools/src/loom_tools/model_tiers.py`** *(new)* — the source of truth. Shipped default map pins **only** the stale tier (`opus → claude-opus-5`); `sonnet`/`fable` and pinned IDs (`claude-sonnet-4-6`) pass through unchanged; the `@effort` suffix is preserved. Configurable via `.loom/config.json` → `sweep.modelAliases` (additive; a pin is droppable with `{"opus": "opus"}`).
- **`defaults/scripts/resolve-model.sh`** *(new)* — thin stub the `sweep.md` skill shells out to before each dispatch (mirrors `sweep-experiment.sh`). Lives under `scripts/` so it propagates on the `resync-installed.sh` path, unlike `roles/`.
- **`sweep_registry::resolve_dispatch_model`** — reads the same config block and applies the same shipped default, so the orchestrator child and its subagents agree.

`ARM_MODEL` stays `{"A": "opus", "B": "sonnet"}` and `assign-arm` still prints `A opus`; a new `assign-arm --resolve` / `resolved_arm_model()` resolves Arm A to `claude-opus-5` at dispatch. `DEFAULT_DISPATCH_MODEL` stays `sonnet` — **Sonnet remains the workhorse**. Role JSON `suggestedModel` values stay aliases (resolved at dispatch); the `.loom/roles` symlink is untouched.

## Files changed

| File | Change |
|------|--------|
| `loom-tools/src/loom_tools/model_tiers.py` | **new** — tier→ID map, config override, `resolve_model`/`generation_of`, CLI |
| `defaults/scripts/resolve-model.sh` | **new** — thin stub over `model_tiers` |
| `loom-tools/tests/test_model_tiers.py` | **new** — resolution, override, generation, monotonicity, CLI |
| `loom-tools/src/loom_tools/sweep_experiment.py` | import `model_tiers`; `resolved_arm_model`; `assign-arm --resolve` (default output unchanged) |
| `loom-tools/pyproject.toml` | `loom-resolve-model` entry point |
| `loom-daemon/src/sweep_registry.rs` | `resolve_model_alias` + `read_model_aliases`; `resolve_dispatch_model` resolves through the map; 6 tests (2 updated, 4 new) |
| `defaults/.claude/commands/loom/sweep.md` | dispatch-time resolution instruction (pinned ladder strings unchanged) |
| `defaults/CLAUDE.md` | `sweep.modelAliases` note |
| `docs/model-selection-retune.md` | dated Status-log entry: pre-2026-07-27 Arm A (Opus 4.8) not comparable to post-change (Opus 5) |

## Acceptance criteria

- [x] Single resolution point reachable by the `sweep.md` skill (stub), `loom_tools` Python (`ARM_MODEL`/`resolved_arm_model`), and the Rust daemon (`resolve_dispatch_model`)
- [x] Configurable via `.loom/config.json` → `sweep.modelAliases`; pin droppable
- [x] Ladder monotonicity asserted by tests (Python + Rust)
- [x] `sweep_md_doc_lint.rs` pins at `:176` and `:218` pass **unedited**
- [x] `defaults/scripts/tests/test-sweep-experiment.sh` passes **unedited** (literal `"A opus"`)
- [x] Role `suggestedModel` values stay aliases; `.loom/roles` symlink survives
- [x] Arm A resolves to Opus 5; Arm A definition + `ARM_MODEL` still read `opus`
- [x] `DEFAULT_DISPATCH_MODEL` stays `sonnet`; Arm B unchanged
- [x] Status-log entry recording the Arm A generation change
- [x] Prose mirrors consistent with `sweep.md`

## Tests

- `pytest loom-tools/tests/test_model_tiers.py test_sweep_experiment.py` → **83 passed**
- `bash defaults/scripts/tests/test-sweep-experiment.sh` → **22/22 passed (unedited)**
- `cargo test --test sweep_md_doc_lint` → **11 passed (unedited)**
- `cargo test --lib resolve_dispatch_model resolve_model` + full `sweep_registry` → **129 passed**
- `cargo fmt --check` clean, `cargo clippy --lib` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)