### PR TITLE
feat(config): config resolution layer over private defaults + .loom-project + .loom-local (Epic #3835 Phase 2)

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -1977,6 +1977,13 @@ what Phase 3 deletes vs preserves".
 - **Phase C** (monitoring + subscription tools): #3455.
 - **Migration guide**:
   [`docs/migration/v0.10.0-shepherd-deprecation.md`](../../docs/migration/v0.10.0-shepherd-deprecation.md).
+- **Config resolution layer** (#4039, Epic #3835 Phase 2): a single resolver
+  over private defaults + tracked `.loom-project/project.json` + ignored
+  `.loom-local/local.json` + legacy `.loom/config.json`, additive-only (no
+  existing call site — including this doc's `.loom/config.json` references
+  above — has been migrated onto it yet; see follow-up #4047). Schema,
+  precedence, and how it composes with `env > config > default`:
+  [`docs/design/config-resolution-tiers.md`](../../docs/design/config-resolution-tiers.md).
 - **Source**:
   - [`loom-daemon/src/types.rs`](../../loom-daemon/src/types.rs) — IPC types.
   - [`loom-daemon/src/sweep_registry.rs`](../../loom-daemon/src/sweep_registry.rs) — registry + reaper.

--- a/defaults/scripts/lib/config-resolver.sh
+++ b/defaults/scripts/lib/config-resolver.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# config-resolver.sh — single resolver over the config tier chain (#4039,
+# Epic #3835 Phase 2).
+#
+# Source this file (do not exec). Defines:
+#
+#   loom_resolve_config <repo_root>
+#       Echoes the merged effective config JSON (compact, one line) for
+#       repo_root, deep-merging the tier chain lowest to highest precedence.
+#
+#   loom_config_get <repo_root> <dotted.path> [default]
+#       Echoes the value at a dotted key path (e.g.
+#       "autonomous.workFinder.enabled") within the resolved effective
+#       config, or `default` (empty string if omitted) when absent.
+#
+# Tier precedence (lowest -> highest; a higher tier overrides a lower one,
+# key-by-key, via a recursive JSON merge — this is exactly jq's `*`
+# operator, so the merge below IS the spec, not an approximation of it):
+#
+#   1. Private/shared defaults — $LOOM_CONFIG_DEFAULTS_FILE, else
+#      ~/.local/share/loom/config/defaults.json. A no-op tier on every host
+#      until Epic #3835 Phase 3 ships (the file doesn't exist yet anywhere).
+#   2. Legacy    <repo_root>/.loom/config.json         — today's status quo.
+#   3. Tracked   <repo_root>/.loom-project/project.json — new in #4039.
+#   4. Ignored   <repo_root>/.loom-local/local.json     — new in #4039.
+#
+# A missing/malformed file at ANY tier soft-fails to `{}` for that tier (it
+# contributes nothing to the merge) — this never aborts the calling script.
+# See docs/design/config-resolution-tiers.md for the full design and the
+# `.loom-project/project.json` schema.
+#
+# Requires `jq`. When jq is unavailable, resolution soft-fails to '{}' (the
+# same "all tiers absent" result callers already treat as fine) rather than
+# erroring the caller.
+#
+# Mirrors loom-daemon/src/config_resolver.rs and
+# loom_tools/common/config_resolver.py key-for-key so a shared fixture tree
+# resolves identically from all three languages (conformance test).
+
+LOOM_CONFIG_LEGACY_REL=".loom/config.json"
+LOOM_CONFIG_PROJECT_REL=".loom-project/project.json"
+LOOM_CONFIG_LOCAL_REL=".loom-local/local.json"
+_LOOM_CONFIG_DEFAULTS_DEFAULT_REL=".local/share/loom/config/defaults.json"
+
+# _loom_config_private_defaults_path -> echoes the resolved private-defaults
+# path honoring $LOOM_CONFIG_DEFAULTS_FILE. Echoes nothing when the env var
+# is explicitly set to empty (tier disabled) or when $HOME is unset. The
+# echoed path may not exist on disk — the caller's soft-read handles that.
+_loom_config_private_defaults_path() {
+    if [[ -n "${LOOM_CONFIG_DEFAULTS_FILE+set}" ]]; then
+        # Explicitly set (possibly empty) -- empty disables the tier.
+        echo -n "$LOOM_CONFIG_DEFAULTS_FILE"
+        return 0
+    fi
+    if [[ -n "${HOME:-}" ]]; then
+        echo "$HOME/$_LOOM_CONFIG_DEFAULTS_DEFAULT_REL"
+    fi
+}
+
+# _loom_config_soft_read <path> -> echoes the file's JSON when it parses as
+# a JSON object; echoes '{}' for a missing path, an unreadable file,
+# malformed JSON, or a non-object top level. Never fails the caller.
+_loom_config_soft_read() {
+    local path="$1"
+    if [[ -z "$path" ]] || [[ ! -f "$path" ]] || ! command -v jq >/dev/null 2>&1; then
+        echo '{}'
+        return 0
+    fi
+    local parsed
+    if ! parsed=$(jq -c 'if type == "object" then . else {} end' "$path" 2>/dev/null); then
+        echo '{}'
+        return 0
+    fi
+    echo "$parsed"
+}
+
+# loom_resolve_config <repo_root>
+#
+# Echoes the merged effective config JSON (compact, one line) by
+# deep-merging the tier chain low -> high precedence.
+loom_resolve_config() {
+    local repo_root="$1"
+
+    if ! command -v jq >/dev/null 2>&1; then
+        echo '{}'
+        return 0
+    fi
+
+    local defaults_path
+    defaults_path=$(_loom_config_private_defaults_path)
+
+    local tier_defaults tier_legacy tier_project tier_local
+    tier_defaults=$(_loom_config_soft_read "$defaults_path")
+    tier_legacy=$(_loom_config_soft_read "$repo_root/$LOOM_CONFIG_LEGACY_REL")
+    tier_project=$(_loom_config_soft_read "$repo_root/$LOOM_CONFIG_PROJECT_REL")
+    tier_local=$(_loom_config_soft_read "$repo_root/$LOOM_CONFIG_LOCAL_REL")
+
+    jq -c -n \
+        --argjson a "$tier_defaults" \
+        --argjson b "$tier_legacy" \
+        --argjson c "$tier_project" \
+        --argjson d "$tier_local" \
+        '$a * $b * $c * $d'
+}
+
+# loom_config_get <repo_root> <dotted.path> [default]
+#
+# Resolve a single value from the effective merged config by dotted key
+# path (e.g. "autonomous.workFinder.enabled"). Echoes `default` (empty
+# string if omitted) when the path is absent, non-scalar, or jq is missing.
+loom_config_get() {
+    local repo_root="$1"
+    local dotted="$2"
+    local default_val="${3:-}"
+
+    if ! command -v jq >/dev/null 2>&1; then
+        echo "$default_val"
+        return 0
+    fi
+
+    local effective
+    effective=$(loom_resolve_config "$repo_root")
+
+    # `try ... catch empty` guards against `dotted` indexing through a
+    # non-object at some segment (e.g. "a.b" where "a" is a scalar) --
+    # getpath() would otherwise raise and jq would exit non-zero, which
+    # (via the `value=$(...)` assignment below) would trip a caller's
+    # `set -e` and abort the whole script. Soft-fail to `default_val`
+    # instead, exactly like a missing path.
+    local value
+    value=$(echo "$effective" | jq -r --arg dotted "$dotted" '
+        ($dotted | split(".")) as $path
+        | try getpath($path) catch null
+        | if . == null then empty else . end
+    ' 2>/dev/null)
+
+    if [[ -z "$value" ]]; then
+        echo "$default_val"
+    else
+        echo "$value"
+    fi
+}

--- a/defaults/scripts/tests/test-config-resolver.sh
+++ b/defaults/scripts/tests/test-config-resolver.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# test-config-resolver.sh — Tests for the config resolution layer (#4039,
+# Epic #3835 Phase 2).
+#
+# Covers defaults/scripts/lib/config-resolver.sh:
+#
+#   1. loom_resolve_config — tier precedence (local > project > legacy >
+#      private defaults), soft-fail on missing/malformed tiers, disjoint-key
+#      union, nested-object merge, and behavior preservation when only the
+#      legacy tier is present (byte-for-byte identical to that file's
+#      content).
+#   2. loom_config_get — dotted-path lookup, default fallback on a missing
+#      path, and soft-fail (not a crash) when the path indexes through a
+#      scalar.
+#
+# Uses a throwaway `mktemp -d` repo_root per test, matching the pattern in
+# test-disk-headroom.sh / test-worktree-root-override.sh.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+CONFIG_RESOLVER_LIB="$SCRIPTS_DIR/lib/config-resolver.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1)); echo -e "  ${RED}FAIL${NC}: $1"; }
+
+assert_eq() {
+    if [[ "$1" == "$2" ]]; then pass "$3"; else fail "$3 (expected '$2', got '$1')"; fi
+}
+
+# shellcheck source=../lib/config-resolver.sh
+source "$CONFIG_RESOLVER_LIB"
+
+# Always disable the private-defaults tier for deterministic test output --
+# it would otherwise read whatever happens to exist at
+# ~/.local/share/loom/config/defaults.json on the CI/dev host.
+export LOOM_CONFIG_DEFAULTS_FILE=""
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "jq not found on PATH -- skipping test-config-resolver.sh"
+    exit 0
+fi
+
+new_repo() {
+    mktemp -d
+}
+
+# --- Test 1: only legacy tier present -> matches legacy content exactly ---
+echo "Test 1: only .loom/config.json present -> byte-for-byte behavior preservation"
+repo=$(new_repo)
+mkdir -p "$repo/.loom"
+echo '{"nextAgentNumber": 3, "autonomous": {"perTokenConcurrency": 2}}' > "$repo/.loom/config.json"
+
+actual=$(loom_resolve_config "$repo")
+expected=$(jq -c -n '{"nextAgentNumber": 3, "autonomous": {"perTokenConcurrency": 2}}')
+assert_eq "$actual" "$expected" "legacy-only repo resolves to exactly the legacy file's content"
+rm -rf "$repo"
+
+# --- Test 2: no files present -> empty object ---
+echo "Test 2: no config files present -> {}"
+repo=$(new_repo)
+assert_eq "$(loom_resolve_config "$repo")" "{}" "no tiers present -> empty object"
+rm -rf "$repo"
+
+# --- Test 3: malformed legacy tier soft-fails without aborting ---
+echo "Test 3: malformed .loom/config.json soft-fails to {} for that tier"
+repo=$(new_repo)
+mkdir -p "$repo/.loom" "$repo/.loom-project"
+echo '{not json' > "$repo/.loom/config.json"
+echo '{"buildGate": {"enabled": true}}' > "$repo/.loom-project/project.json"
+
+actual=$(loom_resolve_config "$repo")
+expected=$(jq -c -n '{"buildGate": {"enabled": true}}')
+assert_eq "$actual" "$expected" "malformed legacy tier contributes nothing; project tier still resolves"
+rm -rf "$repo"
+
+# --- Test 4: precedence -- local overrides project overrides legacy ---
+echo "Test 4: tier precedence (local > project > legacy)"
+repo=$(new_repo)
+mkdir -p "$repo/.loom" "$repo/.loom-project" "$repo/.loom-local"
+echo '{"a": "legacy", "shared": 1}' > "$repo/.loom/config.json"
+echo '{"a": "project", "shared": 2}' > "$repo/.loom-project/project.json"
+echo '{"a": "local"}' > "$repo/.loom-local/local.json"
+
+effective=$(loom_resolve_config "$repo")
+assert_eq "$(echo "$effective" | jq -r '.a')" "local" "key set at all 3 tiers -> local (highest) wins"
+assert_eq "$(echo "$effective" | jq -r '.shared')" "2" "key set at legacy+project -> project wins over legacy"
+rm -rf "$repo"
+
+# --- Test 5: disjoint keys across tiers all present ---
+echo "Test 5: disjoint keys across tiers -> union"
+repo=$(new_repo)
+mkdir -p "$repo/.loom" "$repo/.loom-project" "$repo/.loom-local"
+echo '{"legacyOnly": 1}' > "$repo/.loom/config.json"
+echo '{"projectOnly": 2}' > "$repo/.loom-project/project.json"
+echo '{"localOnly": 3}' > "$repo/.loom-local/local.json"
+
+actual=$(loom_resolve_config "$repo")
+expected=$(jq -c -n '{"legacyOnly": 1, "projectOnly": 2, "localOnly": 3}')
+assert_eq "$actual" "$expected" "disjoint keys across all 3 tiers all present in result"
+rm -rf "$repo"
+
+# --- Test 6: nested object merges across tiers ---
+echo "Test 6: nested object (autonomous block) merges recursively across tiers"
+repo=$(new_repo)
+mkdir -p "$repo/.loom" "$repo/.loom-local"
+echo '{"autonomous": {"workFinder": {"enabled": true}}}' > "$repo/.loom/config.json"
+echo '{"autonomous": {"perTokenConcurrency": 4}}' > "$repo/.loom-local/local.json"
+
+actual=$(loom_resolve_config "$repo")
+expected=$(jq -c -n '{"autonomous": {"workFinder": {"enabled": true}, "perTokenConcurrency": 4}}')
+assert_eq "$actual" "$expected" "nested autonomous block merges recursively, not overwritten wholesale"
+rm -rf "$repo"
+
+# --- Test 7: private defaults tier contributes when present ---
+echo "Test 7: private-defaults tier contributes when pointed at a real file"
+repo=$(new_repo)
+mkdir -p "$repo/.loom"
+defaults_file=$(mktemp)
+echo '{"fromDefaults": true, "shared": "default"}' > "$defaults_file"
+echo '{"shared": "legacy"}' > "$repo/.loom/config.json"
+
+actual=$(LOOM_CONFIG_DEFAULTS_FILE="$defaults_file" loom_resolve_config "$repo")
+assert_eq "$(echo "$actual" | jq -r '.fromDefaults')" "true" "private-defaults key present when no higher tier overrides it"
+assert_eq "$(echo "$actual" | jq -r '.shared')" "legacy" "legacy tier overrides private defaults"
+rm -rf "$repo" "$defaults_file"
+
+# --- Test 8: loom_config_get dotted-path lookup ---
+echo "Test 8: loom_config_get resolves a nested dotted path"
+repo=$(new_repo)
+mkdir -p "$repo/.loom"
+echo '{"autonomous": {"workFinder": {"enabled": true}}}' > "$repo/.loom/config.json"
+
+assert_eq "$(loom_config_get "$repo" "autonomous.workFinder.enabled")" "true" "nested dotted path resolves"
+rm -rf "$repo"
+
+# --- Test 9: loom_config_get default fallback on missing path ---
+echo "Test 9: loom_config_get falls back to default on a missing path"
+repo=$(new_repo)
+assert_eq "$(loom_config_get "$repo" "missing.path" "fallback")" "fallback" "missing path -> default"
+assert_eq "$(loom_config_get "$repo" "missing.path")" "" "missing path, no default -> empty string"
+rm -rf "$repo"
+
+# --- Test 10: loom_config_get soft-fails (not crash) indexing through a scalar ---
+echo "Test 10: loom_config_get soft-fails when a path segment indexes through a scalar"
+repo=$(new_repo)
+mkdir -p "$repo/.loom"
+echo '{"a": 1}' > "$repo/.loom/config.json"
+
+# Must not abort under set -e: run in a subshell that itself has set -e to
+# prove the caller's errexit survives the (invalid) getpath() traversal.
+result=$(
+    set -euo pipefail
+    source "$CONFIG_RESOLVER_LIB"
+    export LOOM_CONFIG_DEFAULTS_FILE=""
+    loom_config_get "$repo" "a.b" "safe-default"
+)
+assert_eq "$result" "safe-default" "indexing through a scalar soft-fails to default under set -e (does not abort)"
+rm -rf "$repo"
+
+# --- Test 11: cross-language conformance fixture (#4039 AC) ---
+# The same fixture tree must resolve identically from Rust, Python, and
+# Bash -- see loom-tools/tests/fixtures/config_resolver/README.md. Rust:
+# loom-daemon/src/config_resolver.rs
+# (test_conformance_fixture_matches_expected_json). Python:
+# loom-tools/tests/test_config_resolver.py (TestConformanceFixture).
+echo "Test 11: cross-language conformance fixture resolves to the shared expected.json"
+REPO_ROOT_FOR_FIXTURE="$(cd "$SCRIPTS_DIR/../.." && pwd)"
+FIXTURE_DIR="$REPO_ROOT_FOR_FIXTURE/loom-tools/tests/fixtures/config_resolver"
+
+if [[ -d "$FIXTURE_DIR" ]]; then
+    actual=$(loom_resolve_config "$FIXTURE_DIR" | jq -S -c .)
+    expected=$(jq -S -c . "$FIXTURE_DIR/expected.json")
+    assert_eq "$actual" "$expected" "Bash resolver matches the cross-language conformance fixture's expected.json"
+else
+    fail "conformance fixture directory not found at $FIXTURE_DIR"
+fi
+
+# --- Summary ---
+echo ""
+echo "────────────────────────────────"
+echo "Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed"
+
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/docs/design/config-resolution-tiers.md
+++ b/docs/design/config-resolution-tiers.md
@@ -1,0 +1,131 @@
+# Config Resolution Tiers (#4039)
+
+**Status:** Resolver shipped, additive only. No existing call site reads through
+it yet (see "Follow-up" below).
+**Tracks:** Epic #3835 ("machine-level Loom install"), Phase 2.
+**Related:** #3836 (Phase 1, installer gitignore/`--local` mode, closed), #3979
+Phase 2 (cloud-host scale-out — blocked on this landing).
+
+## 1. Problem
+
+Epic #3835's target architecture splits the single, per-repo `.loom/config.json`
+into three tiers: private/shared defaults living in the machine-level Loom
+checkout, tracked project config living in the consumer repo, and ignored
+host-local state. Nothing can migrate onto that layout until something can
+*resolve* it — today `.loom/config.json` is read ad hoc at roughly 40 call
+sites across Rust, Python, and Bash, each with its own path derivation and
+soft-fail behavior.
+
+This issue is **the resolver only**. It introduces the schema and one resolver
+per language, with `.loom/config.json` folded into the tier chain as a legacy
+tier so every existing repo (which has only that file) resolves identically to
+today. It does **not** migrate any of the ~40 call sites, create
+`.loom-project/` in any repo, change what the installer writes, or touch
+`.loom-local/` runtime-state relocation — those are follow-ups (see epic phases
+3–6).
+
+## 2. Tier precedence
+
+Four file tiers, listed lowest to highest precedence (a higher tier overrides a
+lower one, key-by-key, via a recursive/deep JSON merge — object values merge
+recursively, any other value type replaces the lower tier's value outright,
+including an explicit `null` written to override a real value):
+
+| # | Tier | Path (repo-root-relative unless noted) | Tracked? | Introduced |
+|---|------|------------------------------------------|----------|------------|
+| 1 | **Private/shared defaults** | `$LOOM_CONFIG_DEFAULTS_FILE`, else `~/.local/share/loom/config/defaults.json` | N/A (machine-level, outside any repo) | Epic #3835 Phase 3 (not yet shipped — this tier is a no-op today; the file does not exist on any host) |
+| 2 | **Legacy config** | `.loom/config.json` | Tracked (today's status quo) | Pre-existing |
+| 3 | **Project config** | `.loom-project/project.json` | Tracked | This issue (schema only; no repo has this file yet) |
+| 4 | **Local config** | `.loom-local/local.json` | Ignored (gitignored) | This issue (schema only; no repo has this file yet) |
+
+A missing file, an unreadable file, or malformed JSON at **any** tier
+soft-fails to "that tier contributes nothing" (an empty object) — it never
+raises, never aborts the daemon/script, and never blocks the other tiers from
+being read. This exactly mirrors the existing soft-fail contract already used
+by `.loom/config.json` readers (e.g.
+`loom-daemon/src/work_finder::read_work_finder_config`,
+`loom-daemon/src/main_health_gate::read_build_gate_config`).
+
+**Composition with `env > config > default` (#3813, the `autonomous` block):**
+env vars remain the highest-precedence override for every individual knob —
+that rule is unchanged. This resolver only replaces what "config" means in that
+chain: instead of "the parsed content of `.loom/config.json`", **"config" is
+now the merged result of tiers 1–4 above.** So the full effective precedence
+for any given knob is:
+
+```
+env var  >  (private defaults ⊕ legacy .loom/config.json ⊕ .loom-project/project.json ⊕ .loom-local/local.json)  >  built-in default
+                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                                     this is "config" — the resolver's output
+```
+
+Because tier 2 alone holds every existing repo's real content and tiers 1, 3,
+4 are empty everywhere until later epic phases ship, a repo with only
+`.loom/config.json` merges to **exactly that file's parsed content** — the
+resolver is byte-for-byte behavior-preserving for the status quo.
+
+## 3. `.loom-project/project.json` schema
+
+The epic names five categories of project-specific, tracked config that belong
+in `.loom-project/project.json` once a repo migrates off `.loom/config.json`
+(Phase 6). Each key below states the tier that **owns** it — i.e., the tier an
+operator is expected to set it in once migrated, even though the resolver will
+happily read it from any tier that has it (that flexibility is what lets a
+partially-migrated repo work correctly).
+
+| Key | Type | Owning tier | Notes |
+|-----|------|-------------|-------|
+| `terminals` | array | Project (`.loom-project/project.json`) | Enabled agents/terminals for the workspace — repo-specific, meant to be shared with the team via git. |
+| `buildGate` | object (`enabled`, `command`, …) | Project | Repo-specific build/verification gate wired into `main_health_gate`. Team-shared, not a host preference. |
+| `guards.*` | object (`readOnlyFastPath`, `sqlDdl`, `cloudCli`, `rmScope`, `forceScope`, …) | Project | Guard-hook category toggles are a property of the repo's risk profile, not the host running the agent. |
+| `labels` / label maps | object | Project | Any future per-repo label-name overrides (label *set* itself stays defined in `.github/labels.yml`; this is for maps/aliases, not label creation). |
+| `autonomous.model` / model overrides | string/object | Project (default) **or** Local (host override) | The *default* model policy for a repo is project-shared; an individual host wanting a different model temporarily (e.g. cost/availability) overrides at `.loom-local/local.json` — local wins per the tier order above. |
+| `autonomous.workFinder`, `autonomous.mainHealthGate`, `autonomous.roleRunner`, `autonomous.perTokenConcurrency` | object/number | Project (default) **or** Local (host override) | Same reasoning as model overrides: the *policy* (should this repo run a work finder at all) is project-shared; the *capacity* tuning for one specific host (e.g. `perTokenConcurrency` sized to that host's account pool) is a natural `.loom-local` override. |
+| `worktree.root` | string | Local (`.loom-local/local.json`) | Inherently host-specific (an external scratch volume path) — never meant to be shared across machines. |
+| `forge.*` (type, gitea url/token) | object | Project (type/url) / Local (token, if not using a repo secret) | `forge.type`/`forge.gitea.url` describe the repo; a raw token belongs host-local, never committed. |
+
+`.loom-local/local.json` has no fixed schema in this issue beyond "same shape
+as `.loom-project/project.json`, host-scoped override" — the epic explicitly
+defers ".loom-local/ runtime-state relocation" to Phase 3+; this issue only
+defines it as a config-merge tier.
+
+## 4. Resolvers (one per language, same precedence)
+
+All three resolvers implement the identical tier list and identical
+deep-merge semantics (recursive merge for objects, override for any other
+value — this is exactly `jq`'s `*` operator, and the Rust/Python
+implementations are written to match it key-for-key):
+
+| Language | Module | Entry points |
+|----------|--------|--------------|
+| Rust | `loom-daemon/src/config_resolver.rs` | `resolve_effective_config(repo_root: &Path) -> serde_json::Value`, `get_path(&Value, "a.b.c") -> Option<&Value>`, `deep_merge`, `private_defaults_path()` |
+| Python | `loom_tools/common/config_resolver.py` | `resolve_effective_config(repo_root: Path) -> dict`, `get_path(config, "a.b.c")`, `deep_merge`, `private_defaults_path()` |
+| Bash | `defaults/scripts/lib/config-resolver.sh` | `loom_resolve_config <repo_root>` (echoes merged JSON), `loom_config_get <repo_root> <dotted.path> [default]` |
+
+A cross-language conformance fixture lives at
+`loom-tools/tests/fixtures/config_resolver/` (a `repo_root`-shaped tree with a
+legacy `.loom/config.json`, a `.loom-project/project.json`, and a
+`.loom-local/local.json`, deliberately overlapping some keys across tiers) and
+is exercised from all three languages:
+
+- Rust: `loom-daemon/src/config_resolver.rs` `mod tests` (`test_conformance_fixture_*`)
+- Python: `loom-tools/tests/test_config_resolver.py` (`TestConformanceFixture`)
+- Bash: `defaults/scripts/tests/test-config-resolver.sh`
+
+Each asserts the same known merged output (or a value drawn from it) so a
+future change to one resolver's merge semantics can't silently diverge from
+the other two.
+
+## 5. Follow-ups (explicitly out of scope here)
+
+- **Call-site migration** — Filed as #4047: swap the ~40 existing
+  `.loom/config.json` ad hoc reads over to these resolvers, one call site (or
+  cohesive group) at a time, so the resolver's non-null behavior is verified in
+  each real reader before the next is touched.
+- **Installer/`.loom-project/` creation** — Epic #3835 Phase 6 (per-consumer-repo
+  migration runbook): actually writing `.loom-project/project.json` /
+  `.loom-local/` into a repo. Nothing in this issue creates those files
+  anywhere.
+- **`.loom-local/` runtime-state relocation** — Epic #3835 Phase 3+.
+- **Deprecating `.loom/config.json`** — not planned; it remains a permanently
+  supported legacy tier per this doc.

--- a/loom-daemon/src/config_resolver.rs
+++ b/loom-daemon/src/config_resolver.rs
@@ -1,0 +1,464 @@
+//! Config resolution layer (#4039, Epic #3835 Phase 2).
+//!
+//! A single resolver over the tier chain: private/shared defaults, the
+//! legacy `.loom/config.json`, tracked `.loom-project/project.json`, and
+//! ignored `.loom-local/local.json`. See
+//! `docs/design/config-resolution-tiers.md` for the full design (schema,
+//! precedence table, and how this composes with the existing **env >
+//! config > default** rule used by e.g. the `autonomous` block).
+//!
+//! **This module is additive only.** No existing call site is migrated onto
+//! it in this PR — every current direct `.loom/config.json` reader (e.g.
+//! [`crate::extract_configured_terminal_ids`],
+//! [`crate::work_finder::read_work_finder_config`],
+//! [`crate::main_health_gate::read_build_gate_config`]) is untouched. A
+//! follow-up issue migrates call sites one at a time.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::{Map, Value};
+
+/// Repo-relative path to the legacy, currently load-bearing config file.
+/// Every existing repo has (at most) this tier populated.
+pub const LEGACY_CONFIG_REL: &str = ".loom/config.json";
+
+/// Repo-relative path to the tracked, project-specific config file
+/// introduced by Epic #3835. Empty (absent) in every repo until a repo
+/// migrates onto the new layout (Phase 6).
+pub const PROJECT_CONFIG_REL: &str = ".loom-project/project.json";
+
+/// Repo-relative path to the ignored, host-local config override file.
+/// Empty (absent) in every repo until Phase 3+.
+pub const LOCAL_CONFIG_REL: &str = ".loom-local/local.json";
+
+/// Env var overriding the private/shared defaults file location. Set to a
+/// non-empty path to point at an alternate file; set to the empty string to
+/// disable this tier entirely (it is already a no-op on any host that
+/// hasn't run the Phase 3 machine-level installer, so disabling it has no
+/// practical effect today — the toggle exists for forward compatibility and
+/// test isolation).
+pub const PRIVATE_DEFAULTS_ENV: &str = "LOOM_CONFIG_DEFAULTS_FILE";
+
+/// Home-relative default location of the private/shared defaults file. Epic
+/// #3835 Phase 3 introduces the machine-level checkout this lives in; until
+/// that phase ships the file simply does not exist on any host, so this
+/// tier resolves to "contributes nothing" everywhere today.
+const DEFAULT_PRIVATE_DEFAULTS_REL: &str = ".local/share/loom/config/defaults.json";
+
+/// Resolve the path to the private/shared defaults file, honoring
+/// [`PRIVATE_DEFAULTS_ENV`]. Returns `None` when the env var is explicitly
+/// set to an empty string (tier disabled) or when no home directory can be
+/// determined.
+#[must_use]
+pub fn private_defaults_path() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var(PRIVATE_DEFAULTS_ENV) {
+        return if p.is_empty() {
+            None
+        } else {
+            Some(PathBuf::from(p))
+        };
+    }
+    dirs::home_dir().map(|h| h.join(DEFAULT_PRIVATE_DEFAULTS_REL))
+}
+
+/// Soft-fail JSON-object read: a missing file, an unreadable file, malformed
+/// JSON, or a non-object top-level value all resolve to an empty object
+/// (`{}`) — that tier simply contributes nothing to the merge. Never a hard
+/// error, mirroring the soft-fail contract already used by
+/// `work_finder::read_work_finder_config` and
+/// `main_health_gate::read_build_gate_config`.
+fn soft_read_json_object(path: &Path) -> Value {
+    let text = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) => {
+            log::debug!("config_resolver: could not read {}: {e}", path.display());
+            return Value::Object(Map::new());
+        }
+    };
+
+    match serde_json::from_str::<Value>(&text) {
+        Ok(v @ Value::Object(_)) => v,
+        Ok(_) => {
+            log::warn!(
+                "config_resolver: top-level of {} is not a JSON object; ignoring this tier",
+                path.display()
+            );
+            Value::Object(Map::new())
+        }
+        Err(e) => {
+            log::warn!("config_resolver: could not parse {}: {e}", path.display());
+            Value::Object(Map::new())
+        }
+    }
+}
+
+/// Deep-merge `overlay` onto `base`, returning the merged value.
+///
+/// Semantics (matching `jq`'s `*` operator exactly, so the Bash resolver can
+/// implement this via `jq -n '$a * $b * $c * $d'` and stay in lockstep):
+/// - When both sides are JSON objects, merge recursively key-by-key.
+/// - Otherwise, `overlay` replaces `base` outright — including when
+///   `overlay` is `null` (an explicit `null` in a higher tier means "clear
+///   this key", not "leave the lower tier's value").
+///
+/// A tier that is entirely absent/malformed is represented as `{}` by
+/// [`soft_read_json_object`] before it ever reaches this function, so an
+/// absent tier is a true no-op merge (it never introduces a spurious
+/// top-level `null`).
+#[must_use]
+pub fn deep_merge(base: &Value, overlay: &Value) -> Value {
+    match (base, overlay) {
+        (Value::Object(base_map), Value::Object(overlay_map)) => {
+            let mut merged = base_map.clone();
+            for (k, v) in overlay_map {
+                let merged_val = match merged.get(k) {
+                    Some(existing) => deep_merge(existing, v),
+                    None => v.clone(),
+                };
+                merged.insert(k.clone(), merged_val);
+            }
+            Value::Object(merged)
+        }
+        _ => overlay.clone(),
+    }
+}
+
+/// Resolve the full effective config tree for `repo_root` by deep-merging,
+/// lowest to highest precedence:
+///
+/// 1. Private/shared defaults ([`private_defaults_path`]) — a no-op tier on
+///    every host until Epic #3835 Phase 3 ships.
+/// 2. Legacy `.loom/config.json` — the sole tier every existing repo has.
+/// 3. Tracked `.loom-project/project.json` — new in #4039; empty until a
+///    repo migrates (Phase 6).
+/// 4. Ignored `.loom-local/local.json` — new in #4039; host-local override.
+///
+/// A missing or malformed file at **any** tier soft-fails to that tier
+/// contributing nothing, and this function never aborts the caller. When
+/// only tier 2 has content — the state of every repo today — the result is
+/// exactly that file's parsed content: byte-for-byte identical to reading
+/// `.loom/config.json` directly, satisfying the #4039 behavior-preservation
+/// requirement.
+#[must_use]
+pub fn resolve_effective_config(repo_root: &Path) -> Value {
+    let mut effective = Value::Object(Map::new());
+
+    if let Some(defaults_path) = private_defaults_path() {
+        effective = deep_merge(&effective, &soft_read_json_object(&defaults_path));
+    }
+
+    effective = deep_merge(&effective, &soft_read_json_object(&repo_root.join(LEGACY_CONFIG_REL)));
+    effective = deep_merge(&effective, &soft_read_json_object(&repo_root.join(PROJECT_CONFIG_REL)));
+    effective = deep_merge(&effective, &soft_read_json_object(&repo_root.join(LOCAL_CONFIG_REL)));
+
+    effective
+}
+
+/// Look up a dotted key path (e.g. `"autonomous.workFinder.enabled"`) in an
+/// already-resolved effective config tree. Returns `None` on any missing
+/// segment or when a non-object value is indexed further.
+///
+/// Callers apply their own env-override / built-in-default fallback on top
+/// of this — exactly as before. This resolver replaces only the "config"
+/// position in the existing **env > config > default** chain; it does not
+/// itself know about any env var.
+#[must_use]
+pub fn get_path<'a>(config: &'a Value, dotted: &str) -> Option<&'a Value> {
+    let mut cur = config;
+    for segment in dotted.split('.') {
+        cur = cur.get(segment)?;
+    }
+    Some(cur)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use serial_test::serial;
+    use tempfile::tempdir;
+
+    fn write(path: &Path, contents: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, contents).unwrap();
+    }
+
+    // ===== deep_merge =====
+
+    #[test]
+    fn test_deep_merge_disjoint_keys_union() {
+        let base = json!({"a": 1});
+        let overlay = json!({"b": 2});
+        assert_eq!(deep_merge(&base, &overlay), json!({"a": 1, "b": 2}));
+    }
+
+    #[test]
+    fn test_deep_merge_nested_objects_merge_recursively() {
+        let base = json!({"a": {"x": 1}});
+        let overlay = json!({"a": {"y": 2}});
+        assert_eq!(deep_merge(&base, &overlay), json!({"a": {"x": 1, "y": 2}}));
+    }
+
+    #[test]
+    fn test_deep_merge_scalar_overlay_replaces_base() {
+        let base = json!({"a": 1});
+        let overlay = json!({"a": 2});
+        assert_eq!(deep_merge(&base, &overlay), json!({"a": 2}));
+    }
+
+    #[test]
+    fn test_deep_merge_explicit_null_overlay_clears_key() {
+        let base = json!({"a": 1});
+        let overlay = json!({"a": null});
+        assert_eq!(deep_merge(&base, &overlay), json!({"a": null}));
+    }
+
+    #[test]
+    fn test_deep_merge_empty_overlay_is_noop() {
+        let base = json!({"a": {"x": 1}, "b": [1, 2]});
+        let overlay = json!({});
+        assert_eq!(deep_merge(&base, &overlay), base);
+    }
+
+    #[test]
+    fn test_deep_merge_array_overlay_replaces_not_concatenates() {
+        let base = json!({"a": [1, 2]});
+        let overlay = json!({"a": [3]});
+        assert_eq!(deep_merge(&base, &overlay), json!({"a": [3]}));
+    }
+
+    // ===== soft_read_json_object =====
+
+    #[test]
+    fn test_soft_read_missing_file_is_empty_object() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nope.json");
+        assert_eq!(soft_read_json_object(&path), json!({}));
+    }
+
+    #[test]
+    fn test_soft_read_malformed_json_is_empty_object() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("bad.json");
+        write(&path, "not valid json");
+        assert_eq!(soft_read_json_object(&path), json!({}));
+    }
+
+    #[test]
+    fn test_soft_read_non_object_top_level_is_empty_object() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("array.json");
+        write(&path, "[1, 2, 3]");
+        assert_eq!(soft_read_json_object(&path), json!({}));
+    }
+
+    #[test]
+    fn test_soft_read_valid_object_passes_through() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("ok.json");
+        write(&path, r#"{"a": 1}"#);
+        assert_eq!(soft_read_json_object(&path), json!({"a": 1}));
+    }
+
+    // ===== private_defaults_path =====
+
+    #[test]
+    #[serial]
+    fn test_private_defaults_path_env_override() {
+        // SAFETY: this test mutates process-global env state. Serialized
+        // via `#[serial]`-free convention already used elsewhere in this
+        // crate's config tests (single-threaded env var section run under
+        // `cargo test` default settings is acceptable here because no other
+        // test in this file touches `LOOM_CONFIG_DEFAULTS_FILE`).
+        std::env::set_var(PRIVATE_DEFAULTS_ENV, "/tmp/custom-defaults.json");
+        let resolved = private_defaults_path();
+        std::env::remove_var(PRIVATE_DEFAULTS_ENV);
+        assert_eq!(resolved, Some(PathBuf::from("/tmp/custom-defaults.json")));
+    }
+
+    #[test]
+    #[serial]
+    fn test_private_defaults_path_empty_env_disables_tier() {
+        std::env::set_var(PRIVATE_DEFAULTS_ENV, "");
+        let resolved = private_defaults_path();
+        std::env::remove_var(PRIVATE_DEFAULTS_ENV);
+        assert_eq!(resolved, None);
+    }
+
+    // ===== resolve_effective_config: behavior preservation =====
+
+    #[test]
+    #[serial]
+    fn test_resolve_only_legacy_tier_present_matches_legacy_content_exactly() {
+        let dir = tempdir().unwrap();
+        // Disable the private-defaults tier for deterministic test output
+        // (it would otherwise read whatever happens to exist at
+        // ~/.local/share/loom/config/defaults.json on the CI/dev host).
+        std::env::set_var(PRIVATE_DEFAULTS_ENV, "");
+
+        write(
+            &dir.path().join(LEGACY_CONFIG_REL),
+            r#"{"nextAgentNumber": 3, "autonomous": {"perTokenConcurrency": 2}}"#,
+        );
+
+        let effective = resolve_effective_config(dir.path());
+        std::env::remove_var(PRIVATE_DEFAULTS_ENV);
+
+        assert_eq!(
+            effective,
+            json!({"nextAgentNumber": 3, "autonomous": {"perTokenConcurrency": 2}})
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_no_files_present_is_empty_object() {
+        let dir = tempdir().unwrap();
+        std::env::set_var(PRIVATE_DEFAULTS_ENV, "");
+        let effective = resolve_effective_config(dir.path());
+        std::env::remove_var(PRIVATE_DEFAULTS_ENV);
+        assert_eq!(effective, json!({}));
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_malformed_legacy_config_soft_fails_never_aborts() {
+        let dir = tempdir().unwrap();
+        std::env::set_var(PRIVATE_DEFAULTS_ENV, "");
+        write(&dir.path().join(LEGACY_CONFIG_REL), "{not json");
+
+        write(&dir.path().join(PROJECT_CONFIG_REL), r#"{"buildGate": {"enabled": true}}"#);
+
+        let effective = resolve_effective_config(dir.path());
+        std::env::remove_var(PRIVATE_DEFAULTS_ENV);
+
+        // Legacy tier contributed nothing (malformed), but the project tier
+        // still resolved fine — one bad tier never blocks the others.
+        assert_eq!(effective, json!({"buildGate": {"enabled": true}}));
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_precedence_local_overrides_project_overrides_legacy() {
+        let dir = tempdir().unwrap();
+        std::env::set_var(PRIVATE_DEFAULTS_ENV, "");
+
+        write(&dir.path().join(LEGACY_CONFIG_REL), r#"{"a": "legacy", "shared": 1}"#);
+        write(&dir.path().join(PROJECT_CONFIG_REL), r#"{"a": "project", "shared": 2}"#);
+        write(&dir.path().join(LOCAL_CONFIG_REL), r#"{"a": "local"}"#);
+
+        let effective = resolve_effective_config(dir.path());
+        std::env::remove_var(PRIVATE_DEFAULTS_ENV);
+
+        // `a` was set at all three tiers -> local (highest) wins.
+        assert_eq!(effective.get("a"), Some(&json!("local")));
+        // `shared` was overridden by project but not local -> project's
+        // value wins over legacy's.
+        assert_eq!(effective.get("shared"), Some(&json!(2)));
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_disjoint_keys_across_tiers_all_present() {
+        let dir = tempdir().unwrap();
+        std::env::set_var(PRIVATE_DEFAULTS_ENV, "");
+
+        write(&dir.path().join(LEGACY_CONFIG_REL), r#"{"legacyOnly": 1}"#);
+        write(&dir.path().join(PROJECT_CONFIG_REL), r#"{"projectOnly": 2}"#);
+        write(&dir.path().join(LOCAL_CONFIG_REL), r#"{"localOnly": 3}"#);
+
+        let effective = resolve_effective_config(dir.path());
+        std::env::remove_var(PRIVATE_DEFAULTS_ENV);
+
+        assert_eq!(effective, json!({"legacyOnly": 1, "projectOnly": 2, "localOnly": 3}));
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_nested_autonomous_block_merges_across_tiers() {
+        let dir = tempdir().unwrap();
+        std::env::set_var(PRIVATE_DEFAULTS_ENV, "");
+
+        write(
+            &dir.path().join(LEGACY_CONFIG_REL),
+            r#"{"autonomous": {"workFinder": {"enabled": true}}}"#,
+        );
+        write(
+            &dir.path().join(LOCAL_CONFIG_REL),
+            r#"{"autonomous": {"perTokenConcurrency": 4}}"#,
+        );
+
+        let effective = resolve_effective_config(dir.path());
+        std::env::remove_var(PRIVATE_DEFAULTS_ENV);
+
+        assert_eq!(
+            effective,
+            json!({"autonomous": {"workFinder": {"enabled": true}, "perTokenConcurrency": 4}})
+        );
+    }
+
+    // ===== get_path =====
+
+    #[test]
+    fn test_get_path_resolves_nested_dotted_key() {
+        let config = json!({"autonomous": {"workFinder": {"enabled": true}}});
+        assert_eq!(get_path(&config, "autonomous.workFinder.enabled"), Some(&json!(true)));
+    }
+
+    #[test]
+    fn test_get_path_missing_segment_returns_none() {
+        let config = json!({"autonomous": {}});
+        assert_eq!(get_path(&config, "autonomous.workFinder.enabled"), None);
+    }
+
+    #[test]
+    fn test_get_path_indexing_through_scalar_returns_none() {
+        let config = json!({"a": 1});
+        assert_eq!(get_path(&config, "a.b"), None);
+    }
+
+    #[test]
+    fn test_get_path_top_level_key() {
+        let config = json!({"nextAgentNumber": 3});
+        assert_eq!(get_path(&config, "nextAgentNumber"), Some(&json!(3)));
+    }
+
+    // ===== Cross-language conformance fixture (#4039 AC) =====
+    //
+    // The same fixture tree (`loom-tools/tests/fixtures/config_resolver/`)
+    // must resolve to the identical effective config from Rust, Python, AND
+    // Bash. See that directory's README.md for what each tier exercises.
+    // Python: `loom-tools/tests/test_config_resolver.py`
+    // (`TestConformanceFixture`). Bash:
+    // `defaults/scripts/tests/test-config-resolver.sh`.
+
+    fn conformance_fixture_dir() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("loom-tools")
+            .join("tests")
+            .join("fixtures")
+            .join("config_resolver")
+    }
+
+    #[test]
+    #[serial]
+    fn test_conformance_fixture_matches_expected_json() {
+        std::env::set_var(PRIVATE_DEFAULTS_ENV, "");
+        let fixture_dir = conformance_fixture_dir();
+
+        let effective = resolve_effective_config(&fixture_dir);
+        std::env::remove_var(PRIVATE_DEFAULTS_ENV);
+
+        let expected_text = std::fs::read_to_string(fixture_dir.join("expected.json"))
+            .expect("conformance fixture expected.json must exist and be readable");
+        let expected: Value = serde_json::from_str(&expected_text)
+            .expect("conformance fixture expected.json must be valid JSON");
+
+        assert_eq!(
+            effective, expected,
+            "Rust resolver diverged from the cross-language conformance fixture's expected.json"
+        );
+    }
+}

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -13,6 +13,7 @@
 pub mod activity;
 pub mod capacity;
 pub mod claim_reconciliation;
+pub mod config_resolver;
 pub mod cpu_headroom;
 pub mod disk_headroom;
 pub mod epic_state;

--- a/loom-tools/src/loom_tools/common/config_resolver.py
+++ b/loom-tools/src/loom_tools/common/config_resolver.py
@@ -1,0 +1,200 @@
+"""Config resolution layer (#4039, Epic #3835 Phase 2).
+
+A single resolver over the tier chain: private/shared defaults, the legacy
+``.loom/config.json``, tracked ``.loom-project/project.json``, and ignored
+``.loom-local/local.json``. See ``docs/design/config-resolution-tiers.md``
+for the full design (schema, precedence table, and how this composes with
+the existing **env > config > default** rule used by e.g. the ``autonomous``
+block).
+
+**This module is additive only.** No existing call site (e.g.
+``loom_tools.common.paths._read_config_worktree_root``) is migrated onto it
+in this PR. A follow-up issue migrates call sites one at a time.
+
+Mirrors ``loom-daemon/src/config_resolver.rs`` and
+``defaults/scripts/lib/config-resolver.sh`` key-for-key so the three
+resolvers agree on one fixture tree (cross-language conformance test).
+
+Example::
+
+    from pathlib import Path
+    from loom_tools.common.config_resolver import (
+        get_path,
+        resolve_effective_config,
+    )
+
+    effective = resolve_effective_config(Path("/path/to/repo"))
+    enabled = get_path(effective, "autonomous.workFinder.enabled")
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+#: Repo-relative path to the legacy, currently load-bearing config file.
+#: Every existing repo has (at most) this tier populated.
+LEGACY_CONFIG_REL = ".loom/config.json"
+
+#: Repo-relative path to the tracked, project-specific config file
+#: introduced by Epic #3835. Empty (absent) in every repo until a repo
+#: migrates onto the new layout (Phase 6).
+PROJECT_CONFIG_REL = ".loom-project/project.json"
+
+#: Repo-relative path to the ignored, host-local config override file.
+#: Empty (absent) in every repo until Phase 3+.
+LOCAL_CONFIG_REL = ".loom-local/local.json"
+
+#: Env var overriding the private/shared defaults file location. Set to a
+#: non-empty path to point at an alternate file; set to the empty string to
+#: disable this tier entirely.
+PRIVATE_DEFAULTS_ENV = "LOOM_CONFIG_DEFAULTS_FILE"
+
+#: Home-relative default location of the private/shared defaults file. Epic
+#: #3835 Phase 3 introduces the machine-level checkout this lives in; until
+#: that phase ships the file simply does not exist on any host, so this
+#: tier resolves to "contributes nothing" everywhere today.
+_DEFAULT_PRIVATE_DEFAULTS_REL = ".local/share/loom/config/defaults.json"
+
+
+def private_defaults_path() -> Path | None:
+    """Resolve the path to the private/shared defaults file.
+
+    Honors :data:`PRIVATE_DEFAULTS_ENV`. Returns ``None`` when the env var
+    is explicitly set to an empty string (tier disabled) or when no home
+    directory can be determined.
+
+    Returns:
+        The resolved path (which may or may not exist on disk), or
+        ``None`` when this tier is disabled.
+    """
+    if PRIVATE_DEFAULTS_ENV in os.environ:
+        override = os.environ[PRIVATE_DEFAULTS_ENV]
+        return Path(override) if override else None
+    try:
+        home = Path.home()
+    except RuntimeError:
+        return None
+    return home / _DEFAULT_PRIVATE_DEFAULTS_REL
+
+
+def _soft_read_json_object(path: Path) -> dict[str, Any]:
+    """Soft-fail JSON-object read.
+
+    A missing file, an unreadable file, malformed JSON, or a non-object
+    top-level value all resolve to an empty dict (``{}``) — that tier
+    simply contributes nothing to the merge. Never a hard error, mirroring
+    the soft-fail contract already used by
+    ``loom_tools.common.paths._read_config_worktree_root``.
+
+    Args:
+        path: Path to the candidate JSON file.
+
+    Returns:
+        The parsed object, or ``{}`` on any failure.
+    """
+    # Imported lazily to avoid a module-level import cycle
+    # (common.state has no dependency on config_resolver, but keeping the
+    # import lazy here matches the existing convention in
+    # common.paths._read_config_worktree_root).
+    from loom_tools.common.state import read_json_file
+
+    data = read_json_file(path, default={})
+    return data if isinstance(data, dict) else {}
+
+
+def deep_merge(base: Any, overlay: Any) -> Any:
+    """Deep-merge ``overlay`` onto ``base``, returning the merged value.
+
+    Semantics (matching ``jq``'s ``*`` operator exactly, so the Bash
+    resolver can implement this via ``jq -n '$a * $b * $c * $d'`` and stay
+    in lockstep):
+
+    - When both sides are dicts, merge recursively key-by-key.
+    - Otherwise, ``overlay`` replaces ``base`` outright — including when
+      ``overlay`` is ``None``/``null`` (an explicit null in a higher tier
+      means "clear this key", not "leave the lower tier's value").
+
+    Args:
+        base: The lower-precedence value.
+        overlay: The higher-precedence value.
+
+    Returns:
+        The merged value. Never mutates ``base`` or ``overlay`` in place.
+    """
+    if isinstance(base, dict) and isinstance(overlay, dict):
+        merged = dict(base)
+        for key, value in overlay.items():
+            if key in merged:
+                merged[key] = deep_merge(merged[key], value)
+            else:
+                merged[key] = value
+        return merged
+    return overlay
+
+
+def resolve_effective_config(repo_root: Path) -> dict[str, Any]:
+    """Resolve the full effective config tree for ``repo_root``.
+
+    Deep-merges, lowest to highest precedence:
+
+    1. Private/shared defaults (:func:`private_defaults_path`) — a no-op
+       tier on every host until Epic #3835 Phase 3 ships.
+    2. Legacy ``.loom/config.json`` — the sole tier every existing repo has.
+    3. Tracked ``.loom-project/project.json`` — new in #4039; empty until a
+       repo migrates (Phase 6).
+    4. Ignored ``.loom-local/local.json`` — new in #4039; host-local
+       override.
+
+    A missing or malformed file at **any** tier soft-fails to that tier
+    contributing nothing, and this function never raises. When only tier 2
+    has content — the state of every repo today — the result is exactly
+    that file's parsed content: byte-for-byte identical to reading
+    ``.loom/config.json`` directly, satisfying the #4039
+    behavior-preservation requirement.
+
+    Args:
+        repo_root: The absolute repository root path.
+
+    Returns:
+        The merged effective config dict.
+    """
+    effective: dict[str, Any] = {}
+
+    defaults_path = private_defaults_path()
+    if defaults_path is not None:
+        effective = deep_merge(effective, _soft_read_json_object(defaults_path))
+
+    effective = deep_merge(effective, _soft_read_json_object(repo_root / LEGACY_CONFIG_REL))
+    effective = deep_merge(effective, _soft_read_json_object(repo_root / PROJECT_CONFIG_REL))
+    effective = deep_merge(effective, _soft_read_json_object(repo_root / LOCAL_CONFIG_REL))
+
+    return effective
+
+
+_MISSING = object()
+
+
+def get_path(config: dict[str, Any], dotted: str, default: Any = None) -> Any:
+    """Look up a dotted key path in an already-resolved effective config tree.
+
+    Args:
+        config: The merged effective config (from
+            :func:`resolve_effective_config`).
+        dotted: A dotted key path, e.g. ``"autonomous.workFinder.enabled"``.
+        default: Value to return when the path is absent or indexes through
+            a non-dict value.
+
+    Returns:
+        The resolved value, or ``default`` when the path can't be
+        resolved.
+    """
+    cur: Any = config
+    for segment in dotted.split("."):
+        if not isinstance(cur, dict):
+            return default
+        cur = cur.get(segment, _MISSING)
+        if cur is _MISSING:
+            return default
+    return cur

--- a/loom-tools/tests/fixtures/config_resolver/.loom-local/local.json
+++ b/loom-tools/tests/fixtures/config_resolver/.loom-local/local.json
@@ -1,0 +1,9 @@
+{
+  "worktree": {
+    "root": "/mnt/scratch"
+  },
+  "overriddenByLocal": "local-value",
+  "autonomous": {
+    "perTokenConcurrency": 4
+  }
+}

--- a/loom-tools/tests/fixtures/config_resolver/.loom-project/project.json
+++ b/loom-tools/tests/fixtures/config_resolver/.loom-project/project.json
@@ -1,0 +1,19 @@
+{
+  "autonomous": {
+    "workFinder": {
+      "maxConcurrent": 5
+    },
+    "mainHealthGate": {
+      "enabled": true
+    }
+  },
+  "guards": {
+    "cloudCli": false
+  },
+  "buildGate": {
+    "enabled": true,
+    "command": "make test"
+  },
+  "projectOnly": "project-value",
+  "overriddenByLocal": "project-value"
+}

--- a/loom-tools/tests/fixtures/config_resolver/.loom/config.json
+++ b/loom-tools/tests/fixtures/config_resolver/.loom/config.json
@@ -1,0 +1,14 @@
+{
+  "nextAgentNumber": 3,
+  "autonomous": {
+    "workFinder": {
+      "enabled": true,
+      "intervalSecs": 60
+    },
+    "perTokenConcurrency": 2
+  },
+  "guards": {
+    "sqlDdl": true
+  },
+  "legacyOnly": "legacy-value"
+}

--- a/loom-tools/tests/fixtures/config_resolver/README.md
+++ b/loom-tools/tests/fixtures/config_resolver/README.md
@@ -1,0 +1,31 @@
+# Config resolver conformance fixture (#4039)
+
+A single `repo_root`-shaped tree used by the cross-language conformance test
+required by #4039's acceptance criteria: "the same fixture tree resolves to
+the same effective config from Rust, Python, and Bash".
+
+Deliberately exercises, in one tree:
+
+- **Disjoint keys** at each tier (`legacyOnly`, `projectOnly`, `worktree.root`)
+- **A key overridden across two tiers** (`overriddenByLocal`: set in
+  `.loom-project/project.json`, overridden in `.loom-local/local.json`)
+- **Nested-object recursive merge** (`autonomous.workFinder` gets fields from
+  both the legacy and project tiers; `guards` gets fields from both legacy
+  and project)
+- **A key set at the lowest and highest tiers with an untouched middle tier**
+  (`autonomous.perTokenConcurrency`: legacy=2, local=4, project doesn't
+  mention it — local should win)
+
+The private/shared-defaults tier is intentionally left out of this fixture
+(every consumer sets `LOOM_CONFIG_DEFAULTS_FILE=""` before resolving it, to
+keep the expected output host-independent) — that tier's soft-fail behavior
+is already covered by each language's own unit tests.
+
+`expected.json` is the canonical merged result all three resolvers must
+produce. Consumers:
+
+- Rust: `loom-daemon/src/config_resolver.rs` (`test_conformance_fixture_*`)
+- Python: `loom-tools/tests/test_config_resolver.py`
+  (`TestConformanceFixture`)
+- Bash: `defaults/scripts/tests/test-config-resolver.sh` (conformance-fixture
+  test case)

--- a/loom-tools/tests/fixtures/config_resolver/expected.json
+++ b/loom-tools/tests/fixtures/config_resolver/expected.json
@@ -1,0 +1,28 @@
+{
+  "nextAgentNumber": 3,
+  "autonomous": {
+    "workFinder": {
+      "enabled": true,
+      "intervalSecs": 60,
+      "maxConcurrent": 5
+    },
+    "perTokenConcurrency": 4,
+    "mainHealthGate": {
+      "enabled": true
+    }
+  },
+  "guards": {
+    "sqlDdl": true,
+    "cloudCli": false
+  },
+  "legacyOnly": "legacy-value",
+  "buildGate": {
+    "enabled": true,
+    "command": "make test"
+  },
+  "projectOnly": "project-value",
+  "overriddenByLocal": "local-value",
+  "worktree": {
+    "root": "/mnt/scratch"
+  }
+}

--- a/loom-tools/tests/test_config_resolver.py
+++ b/loom-tools/tests/test_config_resolver.py
@@ -1,0 +1,210 @@
+"""Tests for the config resolution layer (#4039, Epic #3835 Phase 2)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from loom_tools.common.config_resolver import (
+    LEGACY_CONFIG_REL,
+    LOCAL_CONFIG_REL,
+    PRIVATE_DEFAULTS_ENV,
+    PROJECT_CONFIG_REL,
+    deep_merge,
+    get_path,
+    private_defaults_path,
+    resolve_effective_config,
+)
+
+
+def _write(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data))
+
+
+def _write_raw(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+class TestDeepMerge:
+    def test_disjoint_keys_union(self) -> None:
+        assert deep_merge({"a": 1}, {"b": 2}) == {"a": 1, "b": 2}
+
+    def test_nested_objects_merge_recursively(self) -> None:
+        assert deep_merge({"a": {"x": 1}}, {"a": {"y": 2}}) == {"a": {"x": 1, "y": 2}}
+
+    def test_scalar_overlay_replaces_base(self) -> None:
+        assert deep_merge({"a": 1}, {"a": 2}) == {"a": 2}
+
+    def test_explicit_null_overlay_clears_key(self) -> None:
+        assert deep_merge({"a": 1}, {"a": None}) == {"a": None}
+
+    def test_empty_overlay_is_noop(self) -> None:
+        base = {"a": {"x": 1}, "b": [1, 2]}
+        assert deep_merge(base, {}) == base
+
+    def test_array_overlay_replaces_not_concatenates(self) -> None:
+        assert deep_merge({"a": [1, 2]}, {"a": [3]}) == {"a": [3]}
+
+    def test_does_not_mutate_inputs(self) -> None:
+        base = {"a": {"x": 1}}
+        overlay = {"a": {"y": 2}}
+        result = deep_merge(base, overlay)
+        assert base == {"a": {"x": 1}}
+        assert overlay == {"a": {"y": 2}}
+        assert result == {"a": {"x": 1, "y": 2}}
+
+
+class TestPrivateDefaultsPath:
+    def test_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(PRIVATE_DEFAULTS_ENV, "/tmp/custom-defaults.json")
+        assert private_defaults_path() == Path("/tmp/custom-defaults.json")
+
+    def test_empty_env_disables_tier(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(PRIVATE_DEFAULTS_ENV, "")
+        assert private_defaults_path() is None
+
+    def test_unset_env_derives_from_home(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(PRIVATE_DEFAULTS_ENV, raising=False)
+        resolved = private_defaults_path()
+        assert resolved is not None
+        assert str(resolved).endswith(".local/share/loom/config/defaults.json")
+
+
+class TestResolveEffectiveConfig:
+    def test_only_legacy_tier_present_matches_legacy_content_exactly(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Disable the private-defaults tier for deterministic test output.
+        monkeypatch.setenv(PRIVATE_DEFAULTS_ENV, "")
+        _write(
+            tmp_path / LEGACY_CONFIG_REL,
+            {"nextAgentNumber": 3, "autonomous": {"perTokenConcurrency": 2}},
+        )
+
+        effective = resolve_effective_config(tmp_path)
+
+        assert effective == {"nextAgentNumber": 3, "autonomous": {"perTokenConcurrency": 2}}
+
+    def test_no_files_present_is_empty_dict(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(PRIVATE_DEFAULTS_ENV, "")
+        assert resolve_effective_config(tmp_path) == {}
+
+    def test_malformed_legacy_config_soft_fails_never_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(PRIVATE_DEFAULTS_ENV, "")
+        _write_raw(tmp_path / LEGACY_CONFIG_REL, "{not json")
+        _write(tmp_path / PROJECT_CONFIG_REL, {"buildGate": {"enabled": True}})
+
+        effective = resolve_effective_config(tmp_path)
+
+        # Legacy tier contributed nothing (malformed), but the project tier
+        # still resolved fine -- one bad tier never blocks the others.
+        assert effective == {"buildGate": {"enabled": True}}
+
+    def test_non_object_top_level_soft_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(PRIVATE_DEFAULTS_ENV, "")
+        _write_raw(tmp_path / LEGACY_CONFIG_REL, "[1, 2, 3]")
+
+        assert resolve_effective_config(tmp_path) == {}
+
+    def test_precedence_local_overrides_project_overrides_legacy(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(PRIVATE_DEFAULTS_ENV, "")
+        _write(tmp_path / LEGACY_CONFIG_REL, {"a": "legacy", "shared": 1})
+        _write(tmp_path / PROJECT_CONFIG_REL, {"a": "project", "shared": 2})
+        _write(tmp_path / LOCAL_CONFIG_REL, {"a": "local"})
+
+        effective = resolve_effective_config(tmp_path)
+
+        assert effective["a"] == "local"
+        assert effective["shared"] == 2
+
+    def test_disjoint_keys_across_tiers_all_present(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(PRIVATE_DEFAULTS_ENV, "")
+        _write(tmp_path / LEGACY_CONFIG_REL, {"legacyOnly": 1})
+        _write(tmp_path / PROJECT_CONFIG_REL, {"projectOnly": 2})
+        _write(tmp_path / LOCAL_CONFIG_REL, {"localOnly": 3})
+
+        effective = resolve_effective_config(tmp_path)
+
+        assert effective == {"legacyOnly": 1, "projectOnly": 2, "localOnly": 3}
+
+    def test_nested_autonomous_block_merges_across_tiers(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(PRIVATE_DEFAULTS_ENV, "")
+        _write(tmp_path / LEGACY_CONFIG_REL, {"autonomous": {"workFinder": {"enabled": True}}})
+        _write(tmp_path / LOCAL_CONFIG_REL, {"autonomous": {"perTokenConcurrency": 4}})
+
+        effective = resolve_effective_config(tmp_path)
+
+        assert effective == {
+            "autonomous": {"workFinder": {"enabled": True}, "perTokenConcurrency": 4}
+        }
+
+    def test_private_defaults_tier_contributes_when_present(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        defaults_file = tmp_path / "defaults.json"
+        _write(defaults_file, {"fromDefaults": True, "shared": "default"})
+        monkeypatch.setenv(PRIVATE_DEFAULTS_ENV, str(defaults_file))
+        _write(tmp_path / LEGACY_CONFIG_REL, {"shared": "legacy"})
+
+        effective = resolve_effective_config(tmp_path)
+
+        assert effective["fromDefaults"] is True
+        assert effective["shared"] == "legacy"  # legacy overrides defaults
+
+
+class TestConformanceFixture:
+    """The same fixture tree must resolve identically from Rust, Python,
+    and Bash -- see loom-tools/tests/fixtures/config_resolver/README.md.
+
+    Rust: loom-daemon/src/config_resolver.rs
+    (test_conformance_fixture_matches_expected_json). Bash:
+    defaults/scripts/tests/test-config-resolver.sh.
+    """
+
+    FIXTURE_DIR = Path(__file__).parent / "fixtures" / "config_resolver"
+
+    def test_matches_expected_json(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(PRIVATE_DEFAULTS_ENV, "")
+
+        effective = resolve_effective_config(self.FIXTURE_DIR)
+
+        expected = json.loads((self.FIXTURE_DIR / "expected.json").read_text())
+
+        assert effective == expected, (
+            "Python resolver diverged from the cross-language conformance "
+            "fixture's expected.json"
+        )
+
+
+class TestGetPath:
+    def test_resolves_nested_dotted_key(self) -> None:
+        config = {"autonomous": {"workFinder": {"enabled": True}}}
+        assert get_path(config, "autonomous.workFinder.enabled") is True
+
+    def test_missing_segment_returns_default(self) -> None:
+        config: dict = {"autonomous": {}}
+        assert get_path(config, "autonomous.workFinder.enabled") is None
+        assert get_path(config, "autonomous.workFinder.enabled", default="x") == "x"
+
+    def test_indexing_through_scalar_returns_default(self) -> None:
+        config = {"a": 1}
+        assert get_path(config, "a.b") is None
+
+    def test_top_level_key(self) -> None:
+        assert get_path({"nextAgentNumber": 3}, "nextAgentNumber") == 3


### PR DESCRIPTION
## Summary

Implements Epic #3835 Phase 2 (#4039): a single config resolver per language
(Rust, Python, Bash) over the tier chain private/shared defaults + tracked
`.loom-project/project.json` + ignored `.loom-local/local.json` + legacy
`.loom/config.json`. Additive only, per #4039's scope — no existing call site
(~40 across the codebase) is migrated in this PR. Follow-up filed as #4047.

- **Rust**: `loom-daemon/src/config_resolver.rs` — `resolve_effective_config`,
  `deep_merge`, `get_path`, `private_defaults_path`
- **Python**: `loom_tools/common/config_resolver.py` — same API surface
- **Bash**: `defaults/scripts/lib/config-resolver.sh` — `loom_resolve_config`,
  `loom_config_get`
- **Docs**: `docs/design/config-resolution-tiers.md` — the
  `.loom-project/project.json` schema (with owning tier per key), the tier
  precedence table, and how it composes with the existing **env > config >
  default** rule (env still wins)
- **Cross-language conformance**: `loom-tools/tests/fixtures/config_resolver/`
  is a shared fixture tree; all three resolvers assert against the same
  `expected.json`

All three implement identical deep-merge semantics — equivalent to `jq`'s `*`
operator (recursive merge for objects, override otherwise, including an
explicit `null` clearing a key). A missing/malformed file at any tier
soft-fails to "contributes nothing" and never aborts. A repo with only
`.loom/config.json` (every existing repo today) resolves to **exactly** that
file's parsed content — byte-for-byte behavior preservation, verified by a
dedicated test in each language.

## Test plan

- [x] `cd loom-daemon && cargo test` — 991 passed (0 failed), including 23 new
      `config_resolver` tests
- [x] `cd loom-daemon && cargo clippy --lib --tests -- -D warnings` — clean
- [x] `cd loom-daemon && cargo fmt -- --check` — clean
- [x] `PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/ -q` —
      2005 passed, 23 skipped, 2 pre-existing failures unrelated to this
      change (`test_forge_cli::test_version_flag`,
      `test_logging::test_log_output_visible_non_interactively` — both
      reproduce identically on `main`, environment/packaging issues)
- [x] `ruff check` on the new Python module/tests — clean
- [x] `bash defaults/scripts/tests/test-config-resolver.sh` — 14/14 passed
- [x] `shellcheck` on the new Bash lib + test — clean
- [x] Cross-language conformance: all three resolvers produce the identical
      merged config for `loom-tools/tests/fixtures/config_resolver/`

Closes #4039

🤖 Generated with [Claude Code](https://claude.com/claude-code)