### PR TITLE
docs(daemon-reference): name import-from-monitor in pool provisioning + capacity advisory

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -420,6 +420,13 @@ spawn path can actually pick.
 **Provisioning a managed-repo pool.** Bootstrap the shared pool once per machine:
 
 ```bash
+# Preferred on a host running claude-monitor — reads the live credential store
+# (~/.claude-monitor/usage.db -> oauth_credentials, opened mode=ro), so no
+# accounts.env is needed on this machine at all:
+loom-tokens import-from-monitor --shared   # writes ~/.loom/tokens (override LOOM_SHARED_TOKENS_DIR)
+loom-tokens check --ranking                # ranks the effective pool (shared when no per-repo pool)
+
+# Without claude-monitor — materialize from the accounts.env snapshot instead:
 loom-tokens bootstrap --shared      # writes ~/.loom/tokens (override LOOM_SHARED_TOKENS_DIR)
 loom-tokens check --ranking         # ranks the effective pool (shared when no per-repo pool)
 ```
@@ -428,7 +435,16 @@ Every consumer repo the daemon dispatches into then falls back to that one pool 
 no per-repo `loom-tokens bootstrap` required. A repo that *wants* its own isolated
 pool can still `loom-tokens bootstrap` locally; the per-repo pool always wins.
 Selection sources (`~/.claude-monitor/accounts.env`, repo-local `.env`) are
-unchanged — `--shared` only redirects the *destination* of the materialized pool.
+unchanged for `bootstrap` — `--shared` only redirects the *destination* of the
+materialized pool. `import-from-monitor` bypasses `accounts.env` entirely and
+takes claude-monitor as authoritative for pool membership (use `loom-tokens pin`
+to restrict which accounts the selector may pick). If accounts later go
+`blocked` on revoked tokens, `bootstrap --force` cannot recover — the
+`accounts.env` snapshot is itself what went stale — run
+`loom-tokens import-from-monitor --force && loom-tokens check --ranking`
+instead; without `--force` a rolled token is reported as drift and left alone,
+and the command exits `2`. See "Importing live tokens from claude-monitor" in
+the root `CLAUDE.md` for the full behavior.
 
 ## Per-repo status breakdown + per-repo main-health gate (#3930 — phase d)
 
@@ -1220,13 +1236,16 @@ alert, recover — all automatic and non-blocking:
    *token-bound*. On the **state change** into that state it emits an
    add-capacity advisory naming concrete levers — add accounts to
    `~/.claude-monitor/accounts.env` + `loom-tokens bootstrap`, or buy API
-   credits, then `loom-tokens check --ranking` — with the current numbers
-   (queued count, healthy/total accounts, exhausted count, estimated drain time
-   at current capacity). The advisory surfaces on **three** channels: the daemon
-   log (`warn`), the `daemon.capacity.advisory` event-bus topic, and the
-   `capacity` section of `loom-daemon status`. It is **deduplicated** — one
-   advisory on entry, one recovery on exit, never per-tick spam. Advisory only;
-   it never blocks dispatch.
+   credits, then re-probe with `loom-tokens check --ranking` — with the current
+   numbers (queued count, healthy/total accounts, exhausted count, estimated
+   drain time at current capacity). If accounts are `blocked` on revoked tokens,
+   `bootstrap --force` cannot recover — the advisory also names
+   `loom-tokens import-from-monitor --force && loom-tokens check --ranking` as
+   the recovery lever for that case. The advisory surfaces on **three**
+   channels: the daemon log (`warn`), the `daemon.capacity.advisory` event-bus
+   topic, and the `capacity` section of `loom-daemon status`. It is
+   **deduplicated** — one advisory on entry, one recovery on exit, never
+   per-tick spam. Advisory only; it never blocks dispatch.
 3. **Recover.** The finder re-reads the ranking every tick (bounded cadence = the
    tick interval), so as accounts reset to `available` the cap ramps back up and
    the queued `loom:issue` backlog drains automatically — no manual intervention.

--- a/loom-daemon/src/capacity.rs
+++ b/loom-daemon/src/capacity.rs
@@ -20,9 +20,12 @@
 //!    binding constraint *and* work is queued behind it, and
 //!    [`CapacityAdvisory::message`] builds an operator advisory naming the
 //!    concrete levers (add accounts + `loom-tokens bootstrap`, or buy API
-//!    credits, then `loom-tokens check --ranking`). The advisory surfaces on the
-//!    daemon status view, the event bus (`daemon.capacity.advisory`), and the
-//!    log — deduplicated to fire only on **state change**.
+//!    credits, then `loom-tokens check --ranking`; when accounts are `blocked`
+//!    on revoked tokens — where `bootstrap --force` cannot recover — the
+//!    advisory instead points at `loom-tokens import-from-monitor --force`).
+//!    The advisory surfaces on the daemon status view, the event bus
+//!    (`daemon.capacity.advisory`), and the log — deduplicated to fire only on
+//!    **state change**.
 //! 3. **Recover** — the finder re-reads the ranking every tick (bounded cadence
 //!    = the tick interval), so as accounts reset to `available` the limit ramps
 //!    back up and the backlog drains automatically, with a symmetric recovery
@@ -415,7 +418,9 @@ impl CapacityAdvisory {
             "token capacity: {queued} issue(s) queued; {healthy}/{total} accounts healthy, \
              {exhausted} exhausted/near-ceiling; est. ~{drain} to drain at current capacity. \
              Add accounts to ~/.claude-monitor/accounts.env then `loom-tokens bootstrap`, or buy \
-             API credits, then re-probe with `loom-tokens check --ranking`.",
+             API credits, then re-probe with `loom-tokens check --ranking`. If accounts are \
+             'blocked' on revoked tokens, 'bootstrap --force' cannot recover — run \
+             'loom-tokens import-from-monitor --force && loom-tokens check --ranking'.",
             queued = a.queued,
             healthy = a.healthy_accounts,
             total = a.total_accounts,
@@ -685,6 +690,7 @@ mod tests {
         assert!(adv.message.contains("loom-tokens check --ranking"));
         assert!(adv.message.contains("API credits"));
         assert!(adv.message.contains("12 issue"));
+        assert!(adv.message.contains("import-from-monitor"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `loom-tokens import-from-monitor --shared` as the preferred first command on a claude-monitor host in the "Provisioning a managed-repo pool" recipe (`.loom/docs/daemon-reference.md`), retaining the existing `loom-tokens bootstrap --shared` recipe for hosts without claude-monitor.
- Names the revoked-token recovery lever (`loom-tokens import-from-monitor --force && loom-tokens check --ranking`) in the daemon's emitted `CapacityAdvisory::pressure` message (`loom-daemon/src/capacity.rs`), since `bootstrap --force` cannot recover a pool that went all-`blocked` on revoked OAuth tokens (the `accounts.env` snapshot is itself what went stale).
- Updates the doc prose describing that advisory (`daemon-reference.md`) and the module doc comment in `capacity.rs` to match the new emitted string exactly.
- States the `--force` requirement explicitly wherever the recovery path is described: `import-from-monitor` reports drift and exits `2` without `--force`.

## Changes

- `.loom/docs/daemon-reference.md`
  - "Provisioning a managed-repo pool" section: adds the `import-from-monitor --shared` variant as the preferred path on a claude-monitor host, plus a note on the `bootstrap --force` revoked-token limitation and the `import-from-monitor --force` recovery lever.
  - Token-capacity backpressure "Alert (add capacity)" bullet: names the same recovery lever, mirroring the updated `capacity.rs` message text.
- `loom-daemon/src/capacity.rs`
  - `CapacityAdvisory::pressure` message: appends a clause naming `loom-tokens import-from-monitor --force && loom-tokens check --ranking` for the revoked-token case.
  - Module doc comment: updated to summarize the same lever.
  - `advisory_pressure_names_the_levers` test: extended with `assert!(adv.message.contains("import-from-monitor"))`; all pre-existing assertions kept passing.

No triggering logic, `assess_pressure`, dedup/state-change semantics, or delivery channels were touched — only human-readable lever text and the docs describing it.

## Acceptance Criteria Verification

- [x] `.loom/docs/daemon-reference.md` "Provisioning a managed-repo pool" presents `loom-tokens import-from-monitor --shared` as the preferred first command on a claude-monitor host, noting it reads the live credential store (`~/.claude-monitor/usage.db -> oauth_credentials`, `mode=ro`) and needs no account file.
- [x] The existing `loom-tokens bootstrap --shared` recipe is retained for hosts without claude-monitor.
- [x] `loom-daemon/src/capacity.rs` `CapacityAdvisory::pressure` message names the revoked-token recovery lever.
- [x] `.loom/docs/daemon-reference.md` advisory lever description updated to match the new emitted string exactly.
- [x] `--force` requirement stated explicitly wherever the recovery path appears (docs and code comment).
- [x] `cargo test -p loom-daemon capacity` passes.
- [x] No new event topics, config keys, or CLI flags introduced.

## Test Plan

- `cd loom-daemon && cargo test capacity` — 35 passed, 0 failed.
- `cargo fmt -- --check` and `cargo clippy -p loom-daemon --lib` — clean.
- Consistency check: `grep -n 'import-from-monitor' .loom/docs/daemon-reference.md loom-daemon/src/capacity.rs CLAUDE.md` — all three agree on the `--force` requirement.

Closes #4021