### PR TITLE
fix(daemon): honor LOOM_DAEMON_LOG override so test daemons don't pollute the operator's daemon.log

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -1330,6 +1330,48 @@ exactly like `main_health_gate::read_build_gate_config`.
 | `autonomous.watchdog.reviewStall` | `LOOM_SWEEP_REVIEW_STALL` | `true` | Review-phase stall watchdog on/off (#3910) |
 | `autonomous.watchdog.reviewStallTimeoutSecs` | `LOOM_SWEEP_REVIEW_STALL_TIMEOUT_SECS` | `2700` | Log-silence window before a hung Judge/Doctor sweep is re-dispatched |
 
+### Daemon log path override (`LOOM_DAEMON_LOG`, #4010)
+
+`setup_logging()` writes every daemon log line to `$HOME/.loom/daemon.log` by
+default — this is the destination for `env_logger`-routed output (see the
+launchd redirect note below), NOT the on-disk `LOOM_SOCKET_PATH` used by IPC.
+Before #4010, this path was hardcoded with no override at all, so **any**
+`loom-daemon` process — including one spawned by an integration test that
+already isolates its IPC socket via `LOOM_SOCKET_PATH` — still wrote into the
+operator's production log, polluting real operator history (worst-case: enough
+test noise to rotate genuine history out of the 10MB × 10-file window).
+
+Two env vars now cover both the log path and the socket path:
+
+| Env var | Purpose | Default |
+|---------|---------|---------|
+| `LOOM_DAEMON_LOG` | Full override of the daemon log file path | `<loom dir>/daemon.log` |
+| `LOOM_SOCKET_PATH` | Full override of the daemon's IPC socket path; also implicitly derives the log path (below) when `LOOM_DAEMON_LOG` is unset | `<loom dir>/loom-daemon.sock` |
+
+Precedence is **env > default only** (no `autonomous.*` config tier) — `resolve_log_path()`
+checks `LOOM_DAEMON_LOG` first, then falls back to `resolve_loom_dir().join("daemon.log")`,
+where `resolve_loom_dir()` is the parent directory of `LOOM_SOCKET_PATH` when
+that env var is set, else `$HOME/.loom`. Practically: setting `LOOM_SOCKET_PATH`
+to a tempdir (as both `loom-daemon/tests/common/mod.rs` and
+`loom-daemon/tests/integration_singleton_guard.rs` already do to isolate IPC)
+isolates the log file for free, with zero test-file edits. A config tier was
+considered and deliberately dropped: `setup_logging()` runs at daemon startup
+*before* workspace/config resolution happens, so wiring config in would require
+restructuring startup order (and `env_logger` cannot be re-targeted after
+`.init()`) for marginal benefit over the env-only surface — file a follow-up if
+a config tier is wanted later.
+
+**The launchd `StandardOutPath`/`StandardErrorPath` redirect is a decoy, not a
+second log.** `defaults/scripts/cli/loom-daemon-start.sh` points both launchd
+redirects at a single file, `$REPO_ROOT/.loom/logs/daemon-start.log`
+(`$START_LOG`), which only ever captures output emitted *before*
+`setup_logging()` installs the `env_logger` pipe target (plus a crash's raw
+stderr, if one occurs before logging is set up). In normal operation this file
+stays **0 bytes** — all real daemon logging goes through `env_logger` straight
+to `daemon.log` (or wherever `LOOM_DAEMON_LOG`/`LOOM_SOCKET_PATH` points it).
+This has repeatedly misled operators into concluding a running daemon was
+silent or dead when they tailed `daemon-start.log` instead of `daemon.log`.
+
 **Autonomous dispatch model (`autonomous.model`, #3944).** A daemon-dispatched
 child is a headless `claude -p "/loom:sweep N"` process. Without an explicit
 `--model`, it inherits whatever model the operator last configured in their

--- a/defaults/CLAUDE.md
+++ b/defaults/CLAUDE.md
@@ -1827,6 +1827,11 @@ gh label sync --file .github/labels.yml
 tail -f ~/.loom/daemon.log
 ```
 
+The log path can be overridden with `LOOM_DAEMON_LOG` (e.g. to isolate a test
+daemon's log from the operator's production history); an unset override falls
+back to `$HOME/.loom/daemon.log` unchanged. See "Daemon log path override" in
+`.loom/docs/daemon-reference.md`.
+
 **Claude Code not found**:
 ```bash
 # Ensure Claude Code CLI is in PATH

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -343,15 +343,10 @@ async fn main() -> Result<()> {
     let (loom_dir, socket_path) = if let Ok(path) = std::env::var("LOOM_SOCKET_PATH") {
         // For testing, use the parent directory of the provided socket path
         let socket_path = std::path::PathBuf::from(path);
-        let loom_dir = socket_path
-            .parent()
-            .ok_or_else(|| anyhow!("Socket path has no parent directory"))?
-            .to_path_buf();
+        let loom_dir = resolve_loom_dir()?;
         (loom_dir, socket_path)
     } else {
-        let loom_dir = dirs::home_dir()
-            .ok_or_else(|| anyhow!("No home directory"))?
-            .join(".loom");
+        let loom_dir = resolve_loom_dir()?;
         fs::create_dir_all(&loom_dir)?;
         let socket_path = loom_dir.join("loom-daemon.sock");
         (loom_dir, socket_path)
@@ -938,10 +933,43 @@ fn check_tmux_installed() -> Result<()> {
         .ok_or_else(|| anyhow!("tmux not installed. Install with: brew install tmux"))
 }
 
-fn setup_logging() -> Result<()> {
-    let log_path = dirs::home_dir()
+/// Resolve the daemon's loom directory: the parent of `LOOM_SOCKET_PATH` when
+/// that env var is set (test isolation), else `$HOME/.loom`. Pure — no side
+/// effects (no directory creation), so it's safe to call from `setup_logging()`
+/// (which runs before `main()`'s own `loom_dir`/`socket_path` resolution block)
+/// as well as from `main()` and `resolve_socket_path()` without duplicating the
+/// branching logic three times over.
+fn resolve_loom_dir() -> Result<PathBuf> {
+    if let Ok(path) = std::env::var("LOOM_SOCKET_PATH") {
+        let socket_path = PathBuf::from(path);
+        let loom_dir = socket_path
+            .parent()
+            .ok_or_else(|| anyhow!("Socket path has no parent directory"))?
+            .to_path_buf();
+        return Ok(loom_dir);
+    }
+    let loom_dir = dirs::home_dir()
         .ok_or_else(|| anyhow!("No home directory"))?
-        .join(".loom/daemon.log");
+        .join(".loom");
+    Ok(loom_dir)
+}
+
+/// Resolve the daemon log file path: `LOOM_DAEMON_LOG` (full override) when
+/// set, else `<loom dir>/daemon.log` derived from [`resolve_loom_dir`]. This
+/// means `LOOM_SOCKET_PATH`-style test isolation covers the log file for free
+/// — a test daemon pointed at a tempdir socket also logs into that tempdir,
+/// never into the operator's `~/.loom/daemon.log` (Issue #4010). Precedence is
+/// env > default only; see #4010 for why a config tier is out of scope here
+/// (`setup_logging()` runs before workspace/config resolution).
+fn resolve_log_path() -> Result<PathBuf> {
+    if let Ok(path) = std::env::var("LOOM_DAEMON_LOG") {
+        return Ok(PathBuf::from(path));
+    }
+    Ok(resolve_loom_dir()?.join("daemon.log"))
+}
+
+fn setup_logging() -> Result<()> {
+    let log_path = resolve_log_path()?;
 
     if let Some(parent) = log_path.parent() {
         fs::create_dir_all(parent)?;
@@ -971,6 +999,85 @@ fn setup_logging() -> Result<()> {
     log::info!("Daemon logging initialized to {}", log_path.display());
 
     Ok(())
+}
+
+#[cfg(test)]
+mod resolve_paths_tests {
+    //! Tests for [`resolve_loom_dir`] and [`resolve_log_path`] (Issue #4010).
+    //!
+    //! `setup_logging()` itself is deliberately NOT unit-tested here: it calls
+    //! `env_logger::Builder::...init()`, which panics if called a second time
+    //! in the same process. Splitting the pure path-resolution logic out into
+    //! these two functions is exactly what makes it testable at all.
+    //!
+    //! Both tests mutate the process-global `LOOM_SOCKET_PATH` / `LOOM_DAEMON_LOG`
+    //! env vars, so they're `#[serial]` (the crate already depends on
+    //! `serial_test` for this exact purpose — see `dispatch_tests` below) to
+    //! avoid racing other env-mutating tests in the same binary.
+    use super::{resolve_log_path, resolve_loom_dir};
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    fn resolve_loom_dir_defaults_to_home_loom() {
+        std::env::remove_var("LOOM_SOCKET_PATH");
+        let expected = dirs::home_dir().expect("home dir").join(".loom");
+        assert_eq!(resolve_loom_dir().expect("resolve"), expected);
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_loom_dir_honors_socket_path_override() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket_path = dir.path().join("loom-daemon.sock");
+        std::env::set_var("LOOM_SOCKET_PATH", &socket_path);
+
+        let resolved = resolve_loom_dir().expect("resolve");
+
+        std::env::remove_var("LOOM_SOCKET_PATH");
+        assert_eq!(resolved, dir.path());
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_log_path_defaults_to_home_loom_daemon_log() {
+        std::env::remove_var("LOOM_SOCKET_PATH");
+        std::env::remove_var("LOOM_DAEMON_LOG");
+        let expected = dirs::home_dir()
+            .expect("home dir")
+            .join(".loom")
+            .join("daemon.log");
+        assert_eq!(resolve_log_path().expect("resolve"), expected);
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_log_path_honors_loom_daemon_log_override() {
+        std::env::remove_var("LOOM_SOCKET_PATH");
+        std::env::set_var("LOOM_DAEMON_LOG", "/tmp/some/d/daemon.log");
+
+        let resolved = resolve_log_path().expect("resolve");
+
+        std::env::remove_var("LOOM_DAEMON_LOG");
+        assert_eq!(resolved, std::path::PathBuf::from("/tmp/some/d/daemon.log"));
+    }
+
+    /// `LOOM_DAEMON_LOG` must win even when `LOOM_SOCKET_PATH` is also set —
+    /// the explicit log override always takes precedence over the derived path.
+    #[test]
+    #[serial]
+    fn resolve_log_path_daemon_log_wins_over_socket_path_derivation() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket_path = dir.path().join("loom-daemon.sock");
+        std::env::set_var("LOOM_SOCKET_PATH", &socket_path);
+        std::env::set_var("LOOM_DAEMON_LOG", "/tmp/explicit/daemon.log");
+
+        let resolved = resolve_log_path().expect("resolve");
+
+        std::env::remove_var("LOOM_SOCKET_PATH");
+        std::env::remove_var("LOOM_DAEMON_LOG");
+        assert_eq!(resolved, std::path::PathBuf::from("/tmp/explicit/daemon.log"));
+    }
 }
 
 /// Handle CLI commands (init, stats, validate modes)
@@ -1193,10 +1300,7 @@ fn resolve_socket_path() -> Result<PathBuf> {
     if let Ok(path) = std::env::var("LOOM_SOCKET_PATH") {
         return Ok(PathBuf::from(path));
     }
-    let loom_dir = dirs::home_dir()
-        .ok_or_else(|| anyhow!("No home directory"))?
-        .join(".loom");
-    Ok(loom_dir.join("loom-daemon.sock"))
+    Ok(resolve_loom_dir()?.join("loom-daemon.sock"))
 }
 
 /// Connect to the running daemon over its Unix socket, send a single


### PR DESCRIPTION
Closes #4010

## Summary

`setup_logging()` hardcoded the daemon log to `$HOME/.loom/daemon.log` with no override, so any `loom-daemon` process — including one spawned by an integration test that already isolates its IPC socket via `LOOM_SOCKET_PATH` — wrote into the operator's production log, polluting real operator history.

## Fix

- Extracted `resolve_loom_dir() -> Result<PathBuf>`: a pure resolver returning the parent of `LOOM_SOCKET_PATH` when set (test isolation), else `$HOME/.loom`. No side effects, unit-testable.
- Added `resolve_log_path() -> Result<PathBuf>`: honors `LOOM_DAEMON_LOG` (full override) first, else derives `<loom dir>/daemon.log` from `resolve_loom_dir()`. Default is byte-for-byte `$HOME/.loom/daemon.log` — no behavior change for operators who don't set the override.
- Wired `resolve_log_path()` into `setup_logging()`. `setup_logging()` runs at `main.rs:336`, *before* `main()`'s own `loom_dir`/`socket_path` resolution block (`:342-343`) — so `resolve_loom_dir()` is self-contained (reads `LOOM_SOCKET_PATH` itself) rather than reusing a not-yet-existing variable. `setup_logging()`'s call site is unchanged relative to `check_tmux_installed()` — no log lines dropped.
- Folded the CLI path's third copy of the same `LOOM_SOCKET_PATH`-else-`$HOME/.loom` branch (`resolve_socket_path()`, ~`main.rs:1189-1200`) into `resolve_loom_dir()` too, removing the duplication.
- Precedence is **env > default only** — no `autonomous.*` config tier, per the curator's analysis on the issue: `setup_logging()` runs before workspace/config resolution, so wiring a config tier in would require restructuring startup order (and `env_logger` can't be re-targeted after `.init()`) for marginal benefit. Filed as a possible follow-up if wanted, not pursued here.
- Kept `create_dir_all` on the log path's parent (so `LOOM_DAEMON_LOG` pointing into a non-existent directory still works) and the existing 10MB × 10-file rotation logic (`rotate_log_file()` in `lib.rs`) completely unchanged.

## Tests

- 5 new `#[cfg(test)]` unit tests (`resolve_paths_tests` module, `#[serial]`-guarded since they mutate process env, following the crate's existing `dispatch_tests` pattern):
  - `resolve_loom_dir` defaults to `$HOME/.loom` with no env set, and to the socket path's parent when `LOOM_SOCKET_PATH` is set.
  - `resolve_log_path` defaults to `$HOME/.loom/daemon.log`, honors `LOOM_DAEMON_LOG`, and confirms `LOOM_DAEMON_LOG` wins over `LOOM_SOCKET_PATH`-derived precedence.
- `setup_logging()` itself is deliberately NOT unit-tested (it calls `env_logger::Builder::...init()`, which panics on a second call in-process) — this is exactly why the pure resolvers were split out.
- `cargo build -p loom-daemon` and `cargo clippy -p loom-daemon --all-targets` both clean.
- `cargo test -p loom-daemon` — all unit tests pass including the 5 new ones; pre-existing `integration_security` flakes (`test_accept_valid_ids`, `test_reject_directory_traversal`, `test_terminal_isolation_between_clients` — different subsets fail on repeated runs) reproduce independent of this change, caused by tmux-session contention from several other worktrees running `cargo test` concurrently on this host during this session — unrelated to `main.rs` logging/path resolution.
- **Regression check (AC3, the acceptance test for this issue)**: manually spawned `./target/debug/loom-daemon` with `LOOM_SOCKET_PATH=/tmp/.../d.sock` (no `LOOM_DAEMON_LOG`) — confirmed a `daemon.log` was created in `/tmp/.../` while `~/.loom/daemon.log`'s size and mtime were byte-for-byte unchanged before/after. Also confirmed `LOOM_DAEMON_LOG` wins over the `LOOM_SOCKET_PATH`-derived path when both are set.
- `cargo fmt -p loom-daemon -- --check` clean.

## Docs

- `.loom/docs/daemon-reference.md`: new "Daemon log path override (`LOOM_DAEMON_LOG`, #4010)" subsection under §Operability, documenting the env var, precedence, and why a config tier is out of scope — plus the launchd `StandardOutPath`/`StandardErrorPath` (`.loom/logs/daemon-start.log`) vs. `daemon.log` distinction (stays 0 bytes in normal operation; all real logging goes through `env_logger`).
- `defaults/CLAUDE.md`: noted the `LOOM_DAEMON_LOG` override next to the existing `tail -f ~/.loom/daemon.log` troubleshooting snippet.

## Scope

Single-concern change: 1 source file (`loom-daemon/src/main.rs`) + 2 doc files, 165 insertions / 14 deletions across 3 files — well under the 400 LOC / 8 file threshold. No rotation-policy changes, no config tier, no launchd plist regeneration/migration, and the unrelated `.loom/.daemon.log` dev-mode log is untouched.