### PR TITLE
fix(daemon): distinguish pending/disabled/clear main-health-gate states (#4012)

### DIFF
--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -497,6 +497,10 @@ pub fn build_daemon_status(
             // Name the actual failure class (#3974 AC2) rather than letting the
             // renderer assume "dirty tree" for every unevaluated tick.
             health_gate_not_evaluated_reason: health_states.unevaluated_summary(root),
+            // Resolved daemon-side (this process's own env + this root's own
+            // `.loom/config.json`), never the CLI client's environment (#4012).
+            health_gate_enabled: Some(crate::main_health_gate::effective_enabled(root)),
+            health_gate_verdict_at: health_states.last_verdict_at(root),
         });
         in_flight.extend(live);
     }
@@ -577,6 +581,8 @@ pub fn build_daemon_status(
         main_health_gate_halted: health_states.is_halted(fallback_root),
         main_health_gate_not_evaluated: health_states.is_unevaluated(fallback_root),
         main_health_gate_not_evaluated_reason: health_states.unevaluated_summary(fallback_root),
+        main_health_gate_enabled: Some(crate::main_health_gate::effective_enabled(fallback_root)),
+        main_health_gate_verdict_at: health_states.last_verdict_at(fallback_root),
         capacity,
         per_repo,
     }
@@ -2658,6 +2664,8 @@ exit 0
             main_health_gate_halted: true,
             main_health_gate_not_evaluated: false,
             main_health_gate_not_evaluated_reason: None,
+            main_health_gate_enabled: Some(true),
+            main_health_gate_verdict_at: Some(chrono::Utc::now()),
             capacity: crate::types::CapacityReport {
                 ranking_present: true,
                 total_accounts: 4,
@@ -2674,6 +2682,8 @@ exit 0
                 quarantined_issues: vec![101, 202],
                 health_gate_not_evaluated: false,
                 health_gate_not_evaluated_reason: None,
+                health_gate_enabled: Some(true),
+                health_gate_verdict_at: Some(chrono::Utc::now()),
             }],
         };
         let resp = Response::DaemonStatus(report);
@@ -2700,6 +2710,10 @@ exit 0
                 assert_eq!(r.per_repo[0].in_flight_count, 0);
                 assert!(r.per_repo[0].health_gate_halted);
                 assert!(!r.per_repo[0].health_gate_not_evaluated);
+                assert_eq!(r.main_health_gate_enabled, Some(true));
+                assert!(r.main_health_gate_verdict_at.is_some());
+                assert_eq!(r.per_repo[0].health_gate_enabled, Some(true));
+                assert!(r.per_repo[0].health_gate_verdict_at.is_some());
             }
             other => panic!("Expected DaemonStatus, got: {other:?}"),
         }
@@ -2726,6 +2740,17 @@ exit 0
         assert_eq!(report.cpu_headroom, 0);
         assert_eq!(report.logical_cpus, 0);
         assert_eq!(report.loadavg_1m, None);
+        // Absent pre-#4012 fields must default to `None` — NOT `false` — so a
+        // legacy payload from an older, perfectly healthy daemon is read as
+        // "unknown" rather than misreported as "gate disabled" (#4012).
+        assert_eq!(
+            report.main_health_gate_enabled, None,
+            "absent main_health_gate_enabled (#4012) must default to None, not Some(false)"
+        );
+        assert_eq!(
+            report.main_health_gate_verdict_at, None,
+            "absent main_health_gate_verdict_at (#4012) defaults to None (reads as pending)"
+        );
     }
 
     /// `build_daemon_status` reflects the per-repo main-health halt flag and
@@ -2769,6 +2794,37 @@ exit 0
         assert_eq!(report.per_repo[0].root, root);
         assert_eq!(report.per_repo[0].in_flight_count, 0);
         assert!(!report.per_repo[0].health_gate_halted);
+        // No `.loom/config.json` buildGate/autonomous block exists yet, so the
+        // gate is effectively disabled for this root (#4012).
+        assert_eq!(report.main_health_gate_enabled, Some(false));
+        assert_eq!(report.per_repo[0].health_gate_enabled, Some(false));
+        assert_eq!(report.main_health_gate_verdict_at, None);
+        assert_eq!(report.per_repo[0].health_gate_verdict_at, None);
+
+        // #4012: a root the gate loop HAS never evaluated (no verdict yet)
+        // reports the same `Some(false)`/`None` pair while genuinely disabled
+        // -- but once the config turns the gate on, a fresh `MainHealthState`
+        // reports "enabled, pending" (verdict_at still `None`), NOT "clear".
+        // This is the exact ambiguity the issue is about: `pending` and
+        // `disabled` both still allow dispatch, but they must not be
+        // confused with `clear` (verified green).
+        std::env::remove_var(crate::main_health_gate::MAIN_HEALTH_GATE_ENABLE_ENV);
+        std::fs::write(
+            root.join(".loom").join("config.json"),
+            r#"{"autonomous": {"mainHealthGate": {"enabled": true}}, "buildGate": {"enabled": true, "command": "true"}}"#,
+        )
+        .unwrap();
+        let report = build_daemon_status(&pool, &health, &root);
+        assert_eq!(
+            report.main_health_gate_enabled,
+            Some(true),
+            "config now enables the gate for this root"
+        );
+        assert_eq!(
+            report.main_health_gate_verdict_at, None,
+            "no gate run has completed yet -- must report pending, not clear"
+        );
+        assert!(!report.main_health_gate_halted, "pending must still read as dispatch-allowed");
 
         // Dispatch a sweep -> it should show up as in-flight (Running).
         {
@@ -2889,6 +2945,16 @@ exit 0
         assert!(!a.health_gate_halted, "repo A is green");
         assert_eq!(b.in_flight_count, 0, "repo B has no sweeps");
         assert!(b.health_gate_halted, "repo B is red, independently of A");
+        // Neither repo has a `.loom/config.json` buildGate block, so both
+        // resolve as effectively disabled (#4012) — independent of the raw
+        // halt flag test-injected directly on repo B above (`set_halted`
+        // bypasses the gate loop's own disabled soft-fail path, so this
+        // combination only arises in a test; the renderer must still prefer
+        // "halted" over "disabled" when both are true, see `main.rs`).
+        assert_eq!(a.health_gate_enabled, Some(false));
+        assert_eq!(b.health_gate_enabled, Some(false));
+        assert_eq!(a.health_gate_verdict_at, None);
+        assert_eq!(b.health_gate_verdict_at, None);
 
         std::env::remove_var(REGISTRY_PATH_ENV);
     }

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -19,6 +19,7 @@ use loom_daemon::workspace_pool::WorkspacePool;
 use loom_daemon::{extract_configured_terminal_ids, rotate_log_file};
 
 use anyhow::{anyhow, Result};
+use chrono::{DateTime, Utc};
 use clap::{Parser, Subcommand};
 use std::fs;
 use std::io::Write;
@@ -1815,6 +1816,13 @@ fn print_status_json(
             "not_evaluated": report.main_health_gate_not_evaluated,
             // Which failure class actually blocked evaluation (#3974 AC2).
             "not_evaluated_reason": report.main_health_gate_not_evaluated_reason,
+            // Whether the gate is actually enabled for this root, and when its
+            // last completed verdict landed (#4012) — the disambiguators
+            // between "disabled", "pending" (enabled, no verdict yet), and
+            // "clear" (verified green), all three of which pre-#4012 rendered
+            // identically as `halted: false, not_evaluated: false`.
+            "enabled": report.main_health_gate_enabled,
+            "verdict_at": report.main_health_gate_verdict_at,
         },
         // Per-repo breakdown across every registered managed workspace (#3930).
         "per_repo": report.per_repo.iter().map(|r| serde_json::json!({
@@ -1824,6 +1832,8 @@ fn print_status_json(
             "health_gate_halted": r.health_gate_halted,
             "health_gate_not_evaluated": r.health_gate_not_evaluated,
             "health_gate_not_evaluated_reason": r.health_gate_not_evaluated_reason,
+            "health_gate_enabled": r.health_gate_enabled,
+            "health_gate_verdict_at": r.health_gate_verdict_at,
         })).collect::<Vec<_>>(),
         // Forge-side pipeline snapshot (#3977) — present only when `--pipeline`
         // was passed; `null` otherwise so a consumer can tell "not requested"
@@ -1851,31 +1861,152 @@ fn print_status_json(
     Ok(())
 }
 
+/// The reportable main-health-gate condition for one workspace root (#4012).
+///
+/// Pre-#4012, `loom-daemon status` derived its summary from just the
+/// `halted`/`not_evaluated` boolean pair — and `(false, false)` meant any of
+/// three genuinely different things: the gate is disabled, the gate is
+/// enabled but has not completed its first evaluation this process
+/// ("pending"), or the gate's last completed run verified `main` green
+/// ("clear"). Two booleans cannot encode three states, so this enum widens
+/// the reporting boundary rather than reusing the same pair for a fourth
+/// meaning. [`classify_gate_verdict`] builds one from the raw wire-report
+/// ingredients; [`format_gate_status`] (long form) and
+/// [`gate_status_short_label`] (13-char table column) both render it, so the
+/// top-level summary and the per-repo table can never disagree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum GateVerdict {
+    /// The gate is not enabled for this root — or is enabled but has no
+    /// usable `buildGate` block, which the gate loop treats identically
+    /// (always-green, never runs). Dispatch is allowed; nothing will ever
+    /// evaluate this root until it is turned on (and configured).
+    Disabled,
+    /// The gate is enabled but has not completed a first evaluation yet this
+    /// daemon process. Dispatch is allowed — this is NOT evidence that `main`
+    /// is healthy, only that nothing has said otherwise yet.
+    Pending,
+    /// The gate's most recent completed run verified `main` green. `since`
+    /// is the wall-clock time of that verdict, when known (#4012 AC4) — a
+    /// `clear` reading with no `since` predates the daemon populating it.
+    Clear { since: Option<DateTime<Utc>> },
+    /// The most recent tick could not produce a verdict at all (dirty tree,
+    /// timeout, missing tool, broken `git`, …) — NOT evidence about `main`
+    /// either way; dispatch is NOT halted by this.
+    NotEvaluated { reason: Option<String> },
+    /// A completed run verified `main` red — dispatch is paused (in-flight
+    /// sweeps keep running). `not_evaluated` records whether a *later* tick
+    /// also failed to produce a verdict (#3950 AC3): the two can co-occur,
+    /// since an unevaluated tick leaves the prior halt untouched.
+    Halted {
+        not_evaluated: bool,
+        reason: Option<String>,
+    },
+}
+
+/// Classify the reportable gate condition from a [`DaemonStatusReport`] /
+/// [`crate::types::RepoStatus`]'s raw fields (#4012).
+///
+/// `enabled` is `Some(false)` only when the daemon positively resolved this
+/// root's gate as off (or effectively off — enabled but no usable
+/// `buildGate` block, via [`main_health_gate::effective_enabled`]); `None`
+/// means an older daemon that never reported the flag at all, which must NOT
+/// be misread as "disabled" (a bare `bool`'s wire default would do exactly
+/// that — see the `Option<bool>` rationale on
+/// [`DaemonStatusReport::main_health_gate_enabled`]). `halted` and
+/// `not_evaluated` take priority over disabled/pending so a genuinely active
+/// halt is never hidden behind either newer state — a case that in practice
+/// only arises from a test poking the raw state directly, since the gate
+/// loop's own disabled path always clears `halted` first.
+fn classify_gate_verdict(
+    enabled: Option<bool>,
+    halted: bool,
+    not_evaluated: bool,
+    reason: Option<&str>,
+    verdict_at: Option<DateTime<Utc>>,
+) -> GateVerdict {
+    if halted {
+        return GateVerdict::Halted {
+            not_evaluated,
+            reason: reason.map(str::to_string),
+        };
+    }
+    if not_evaluated {
+        return GateVerdict::NotEvaluated {
+            reason: reason.map(str::to_string),
+        };
+    }
+    if enabled == Some(false) {
+        return GateVerdict::Disabled;
+    }
+    if verdict_at.is_none() {
+        return GateVerdict::Pending;
+    }
+    GateVerdict::Clear { since: verdict_at }
+}
+
 /// Render the main-health gate summary line for `loom-daemon status`.
 ///
-/// `halted` means a gate run **completed** and found `main` verified-red — the
-/// only state that pauses dispatch. `not_evaluated` means the most recent tick
-/// could not produce a verdict at all; `reason` (`"<class>: <detail>"`, #3974
-/// AC2) names *why*. Before #3974 this line asserted "workspace tree is dirty"
-/// for every skip, which reported a clean tree as dirty whenever the real cause
-/// was a timeout, a missing build tool, or a broken `git`.
-fn format_gate_status(halted: bool, not_evaluated: bool, reason: Option<&str>) -> String {
-    let cause =
-        reason.map_or_else(|| "cause unrecorded".to_string(), std::string::ToString::to_string);
-    match (halted, not_evaluated) {
-        (true, true) => format!(
-            "HALTED (main verified red — new dispatch paused) + NOT EVALUATED ({cause}) — \
-             the gate cannot currently confirm main is still red, or check for recovery"
-        ),
-        (true, false) => {
-            "HALTED (main verified red — new dispatch paused; in-flight sweeps keep running)"
-                .to_string()
+/// Before #3974 this line asserted "workspace tree is dirty" for every skip,
+/// which reported a clean tree as dirty whenever the real cause was a
+/// timeout, a missing build tool, or a broken `git`; before #4012 `clear` and
+/// "the gate has never run" were the same string.
+fn format_gate_status(verdict: &GateVerdict) -> String {
+    match verdict {
+        GateVerdict::Disabled => "disabled (gate not enabled; dispatch allowed)".to_string(),
+        GateVerdict::Pending => {
+            "pending (no verdict yet this process — dispatch allowed)".to_string()
         }
-        (false, true) => format!(
-            "not evaluated ({cause}) — the gate could not run, which is NOT evidence about \
-             main; dispatch is NOT halted by this"
-        ),
-        (false, false) => "clear (dispatch allowed)".to_string(),
+        GateVerdict::Clear { since } => match since {
+            Some(t) => {
+                format!("clear (dispatch allowed; last verified green at {})", t.to_rfc3339())
+            }
+            None => "clear (dispatch allowed)".to_string(),
+        },
+        GateVerdict::NotEvaluated { reason } => {
+            let cause = reason
+                .clone()
+                .unwrap_or_else(|| "cause unrecorded".to_string());
+            format!(
+                "not evaluated ({cause}) — the gate could not run, which is NOT evidence about \
+                 main; dispatch is NOT halted by this"
+            )
+        }
+        GateVerdict::Halted {
+            not_evaluated,
+            reason,
+        } => {
+            if *not_evaluated {
+                let cause = reason
+                    .clone()
+                    .unwrap_or_else(|| "cause unrecorded".to_string());
+                format!(
+                    "HALTED (main verified red — new dispatch paused) + NOT EVALUATED ({cause}) — \
+                     the gate cannot currently confirm main is still red, or check for recovery"
+                )
+            } else {
+                "HALTED (main verified red — new dispatch paused; in-flight sweeps keep running)"
+                    .to_string()
+            }
+        }
+    }
+}
+
+/// Render `verdict` as a short label for the per-repo table's 13-char `GATE`
+/// column (#4012) — the short-form counterpart to [`format_gate_status`].
+fn gate_status_short_label(verdict: &GateVerdict) -> &'static str {
+    match verdict {
+        GateVerdict::Disabled => "disabled",
+        GateVerdict::Pending => "pending",
+        GateVerdict::Clear { .. } => "clear",
+        GateVerdict::NotEvaluated { .. } => "not-evaluated",
+        GateVerdict::Halted {
+            not_evaluated: true,
+            ..
+        } => "HALTED+UNEVAL",
+        GateVerdict::Halted {
+            not_evaluated: false,
+            ..
+        } => "HALTED",
     }
 }
 
@@ -1998,11 +2129,14 @@ fn print_status_human(
     // cause is reported verbatim from the gate (#3974 AC2) — pre-#3974 this
     // line hard-coded "workspace tree is dirty" for every skip, which
     // misreported timeouts / missing tools / broken `git` as a dirty tree.
-    let gate = format_gate_status(
+    let verdict = classify_gate_verdict(
+        report.main_health_gate_enabled,
         report.main_health_gate_halted,
         report.main_health_gate_not_evaluated,
         report.main_health_gate_not_evaluated_reason.as_deref(),
+        report.main_health_gate_verdict_at,
     );
+    let gate = format_gate_status(&verdict);
     println!("\nMain-health gate: {gate}");
 
     // Per-repo breakdown across every registered managed workspace (#3930). In
@@ -2019,14 +2153,16 @@ fn print_status_human(
         println!("  {:>4}  {:>9}  {:<13}  REPO", "PRIO", "IN-FLIGHT", "GATE");
         println!("  {:-<60}", "");
         for r in &report.per_repo {
-            // Same halted/not-evaluated distinction as the top-level summary
-            // above, condensed for the table column (#3950 AC3).
-            let gate = match (r.health_gate_halted, r.health_gate_not_evaluated) {
-                (true, true) => "HALTED+UNEVAL",
-                (true, false) => "HALTED",
-                (false, true) => "not-evaluated",
-                (false, false) => "clear",
-            };
+            // Same classification as the top-level summary above, condensed
+            // for the table column (#3950 AC3, widened #4012).
+            let verdict = classify_gate_verdict(
+                r.health_gate_enabled,
+                r.health_gate_halted,
+                r.health_gate_not_evaluated,
+                r.health_gate_not_evaluated_reason.as_deref(),
+                r.health_gate_verdict_at,
+            );
+            let gate = gate_status_short_label(&verdict);
             println!(
                 "  {:>4}  {:>9}  {:<13}  {}",
                 r.priority,
@@ -2509,9 +2645,11 @@ mod dispatch_tests {
     //! against a fake daemon, and the bounded-timeout path against a
     //! deliberately-unresponsive socket (the #3945 wedge must never hang).
     use super::{
-        build_dispatch_request, format_gate_status, query_daemon_bounded,
-        resolve_dispatch_ack_timeout, DAEMON_IPC_TIMEOUT_ENV, DISPATCH_ACK_TIMEOUT,
+        build_dispatch_request, classify_gate_verdict, format_gate_status, gate_status_short_label,
+        query_daemon_bounded, resolve_dispatch_ack_timeout, GateVerdict, DAEMON_IPC_TIMEOUT_ENV,
+        DISPATCH_ACK_TIMEOUT,
     };
+    use chrono::{DateTime, Utc};
     use loom_daemon::types::{Request, Response, SweepKind};
     use serial_test::serial;
     use std::time::Duration;
@@ -2797,16 +2935,32 @@ mod dispatch_tests {
     // Main-health gate status line (#3950 AC3 shape, #3974 AC2 cause)
     // ===================================================================
 
+    /// Build a [`GateVerdict`] the same way `print_status_human` /
+    /// `print_status_json` do, so these tests exercise the real classification
+    /// path rather than constructing variants by hand.
+    fn classify(
+        enabled: Option<bool>,
+        halted: bool,
+        not_evaluated: bool,
+        reason: Option<&str>,
+        verdict_at: Option<DateTime<Utc>>,
+    ) -> GateVerdict {
+        classify_gate_verdict(enabled, halted, not_evaluated, reason, verdict_at)
+    }
+
     #[test]
     fn format_gate_status_names_the_actual_not_evaluated_cause() {
         // Pre-#3974 this line asserted "workspace tree is dirty" for EVERY
         // skip, so a `git fetch` failure on a completely clean tree was
         // reported as a dirty tree. The cause is now passed through verbatim.
-        let s = format_gate_status(
+        let v = classify(
+            Some(true),
             false,
             true,
             Some("git-failure: `git -C /repo fetch origin main` failed (exit 128)"),
+            None,
         );
+        let s = format_gate_status(&v);
         assert!(s.contains("git-failure"), "got: {s}");
         assert!(s.contains("exit 128"), "got: {s}");
         assert!(!s.contains("dirty"), "must not assume a dirty tree: {s}");
@@ -2814,28 +2968,151 @@ mod dispatch_tests {
         assert!(s.contains("NOT halted"), "an unevaluated gate does not halt: {s}");
 
         // A dirty tree still reads as a dirty tree — because the gate said so.
-        let s = format_gate_status(false, true, Some("dirty-tree: [ M src/main.rs]"));
+        let v = classify(Some(true), false, true, Some("dirty-tree: [ M src/main.rs]"), None);
+        let s = format_gate_status(&v);
         assert!(s.contains("dirty-tree"), "got: {s}");
         assert!(s.contains("src/main.rs"), "got: {s}");
     }
 
     #[test]
-    fn format_gate_status_covers_all_four_states() {
-        assert_eq!(format_gate_status(false, false, None), "clear (dispatch allowed)");
+    fn format_gate_status_covers_all_halted_and_not_evaluated_states() {
+        let clear = classify(Some(true), false, false, None, Some(Utc::now()));
+        assert!(format_gate_status(&clear).starts_with("clear (dispatch allowed"));
 
-        let halted = format_gate_status(true, false, None);
-        assert!(halted.starts_with("HALTED"), "got: {halted}");
-        assert!(halted.contains("verified red"), "got: {halted}");
+        let halted = classify(Some(true), true, false, None, None);
+        let s = format_gate_status(&halted);
+        assert!(s.starts_with("HALTED"), "got: {s}");
+        assert!(s.contains("verified red"), "got: {s}");
 
         // Both at once: a prior verified-red halt persists while the next tick
         // cannot evaluate.
-        let both = format_gate_status(true, true, Some("timeout: gate command timed out"));
-        assert!(both.contains("HALTED"), "got: {both}");
-        assert!(both.contains("NOT EVALUATED"), "got: {both}");
-        assert!(both.contains("timeout"), "got: {both}");
+        let both = classify(Some(true), true, true, Some("timeout: gate command timed out"), None);
+        let s = format_gate_status(&both);
+        assert!(s.contains("HALTED"), "got: {s}");
+        assert!(s.contains("NOT EVALUATED"), "got: {s}");
+        assert!(s.contains("timeout"), "got: {s}");
 
         // A missing cause degrades gracefully rather than inventing one.
-        let no_cause = format_gate_status(false, true, None);
-        assert!(no_cause.contains("cause unrecorded"), "got: {no_cause}");
+        let no_cause = classify(Some(true), false, true, None, None);
+        let s = format_gate_status(&no_cause);
+        assert!(s.contains("cause unrecorded"), "got: {s}");
+    }
+
+    /// #4012: the core regression this issue fixes — a fresh, enabled gate
+    /// that has never completed an evaluation must render distinctly from a
+    /// verified-green gate, even though both allow dispatch (`halted: false`,
+    /// `not_evaluated: false` in both cases pre-#4012).
+    #[test]
+    fn format_gate_status_distinguishes_pending_from_clear() {
+        let pending = classify(Some(true), false, false, None, None);
+        assert_eq!(pending, GateVerdict::Pending);
+        let s = format_gate_status(&pending);
+        assert!(s.starts_with("pending"), "got: {s}");
+        assert!(s.contains("dispatch allowed"), "got: {s}");
+        assert!(!s.contains("clear"), "must not read as verified-green: {s}");
+
+        let now = Utc::now();
+        let clear = classify(Some(true), false, false, None, Some(now));
+        assert_eq!(clear, GateVerdict::Clear { since: Some(now) });
+        let s = format_gate_status(&clear);
+        assert!(s.starts_with("clear"), "got: {s}");
+        assert!(s.contains(&now.to_rfc3339()), "clear must carry its own recency evidence: {s}");
+        assert_ne!(
+            format_gate_status(&pending),
+            format_gate_status(&clear),
+            "pending and clear must never render identically"
+        );
+    }
+
+    /// #4012 AC2: the gate-disabled case must be distinguishable from both
+    /// `pending` and `clear`.
+    #[test]
+    fn format_gate_status_distinguishes_disabled() {
+        let disabled = classify(Some(false), false, false, None, None);
+        assert_eq!(disabled, GateVerdict::Disabled);
+        let s = format_gate_status(&disabled);
+        assert!(s.starts_with("disabled"), "got: {s}");
+        assert!(s.contains("dispatch allowed"), "got: {s}");
+
+        let pending = classify(Some(true), false, false, None, None);
+        assert_ne!(
+            format_gate_status(&disabled),
+            format_gate_status(&pending),
+            "disabled and pending must never render identically"
+        );
+
+        // A disabled root that (implausibly) still carries a stale verdict
+        // timestamp from before it was turned off still reports `Disabled` —
+        // the enabled flag takes priority over verdict presence.
+        let disabled_with_stale_verdict =
+            classify(Some(false), false, false, None, Some(Utc::now()));
+        assert_eq!(disabled_with_stale_verdict, GateVerdict::Disabled);
+    }
+
+    /// #4012 AC3: `pending` and `disabled` both still allow dispatch —
+    /// observability-only, no new halt path.
+    #[test]
+    fn pending_and_disabled_never_halt() {
+        for verdict in [
+            classify(Some(true), false, false, None, None),
+            classify(Some(false), false, false, None, None),
+        ] {
+            assert!(
+                !matches!(verdict, GateVerdict::Halted { .. }),
+                "{verdict:?} must never be classified as halted"
+            );
+            let s = format_gate_status(&verdict);
+            assert!(s.contains("dispatch allowed"), "got: {s}");
+        }
+    }
+
+    /// An older daemon that never populated `main_health_gate_enabled` (wire
+    /// field absent ⇒ `None`, #4012) must not be misread as "disabled" — that
+    /// is exactly the `bool::default() == false` trap the `Option<bool>` wire
+    /// type exists to avoid.
+    #[test]
+    fn format_gate_status_legacy_none_enabled_is_not_disabled() {
+        let v = classify(None, false, false, None, None);
+        assert_ne!(v, GateVerdict::Disabled);
+        // With no verdict either, it reads as pending (dispatch allowed) —
+        // the conservative reading, never a fabricated "clear".
+        assert_eq!(v, GateVerdict::Pending);
+    }
+
+    /// `halted`/`not_evaluated` always win over disabled/pending, matching the
+    /// gate loop's own soft-fail contract (its disabled path always clears
+    /// `halted` first) — this combination should only ever arise from a test
+    /// poking the raw state directly, and the renderer must still surface it
+    /// as halted rather than silently downgrading to "disabled".
+    #[test]
+    fn format_gate_status_halted_beats_disabled_and_pending() {
+        let v = classify(Some(false), true, false, None, None);
+        assert!(matches!(
+            v,
+            GateVerdict::Halted {
+                not_evaluated: false,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn gate_status_short_label_fits_table_width_and_matches_long_form() {
+        let cases = [
+            classify(Some(false), false, false, None, None),
+            classify(Some(true), false, false, None, None),
+            classify(Some(true), false, false, None, Some(Utc::now())),
+            classify(Some(true), false, true, Some("timeout"), None),
+            classify(Some(true), true, false, None, None),
+            classify(Some(true), true, true, Some("timeout"), None),
+        ];
+        for v in cases {
+            let short = gate_status_short_label(&v);
+            assert!(short.len() <= 13, "{short:?} exceeds the 13-char GATE column");
+        }
+        // The short label and long form must agree on the halted/not distinction.
+        let halted = classify(Some(true), true, false, None, None);
+        assert_eq!(gate_status_short_label(&halted), "HALTED");
+        assert!(format_gate_status(&halted).starts_with("HALTED"));
     }
 }

--- a/loom-daemon/src/main_health_gate.rs
+++ b/loom-daemon/src/main_health_gate.rs
@@ -86,6 +86,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use chrono::{DateTime, Utc};
+
 use crate::workspace_registry::WorkspaceRegistry;
 
 // ============================================================================
@@ -171,6 +173,17 @@ pub struct MainHealthState {
     /// SHA-memoization + indeterminate-run backoff bookkeeping (#3984) — see
     /// [`GateMemo`].
     gate_memo: Mutex<GateMemo>,
+    /// Wall-clock time of the most recent **completed** (Green/Red) gate
+    /// verdict, or `None` before the first one this process (#4012). This is
+    /// the disambiguator between "pending" (gate enabled, no verdict yet —
+    /// the ambiguous pre-#4012 `(false, false)` reading) and "clear"
+    /// (verified green), plus the recency evidence a `clear` reading
+    /// otherwise lacks. Stamped only in [`apply_gate_outcome`]'s Green/Red
+    /// arms — deliberately **not** touched by the #3984 SHA-memo skip path
+    /// ([`run_gate_tick`]'s early return), since a skip proves nothing new
+    /// about `main` and stamping it there would let a stale "last verified"
+    /// silently refresh itself forever.
+    last_verdict_at: Mutex<Option<DateTime<Utc>>>,
 }
 
 /// Bookkeeping for #3984: the SHA of the last **determinate** (Green/Red)
@@ -221,6 +234,7 @@ impl MainHealthState {
             unevaluated: AtomicBool::new(false),
             track: Mutex::new(UnevaluatedTrack::default()),
             gate_memo: Mutex::new(GateMemo::default()),
+            last_verdict_at: Mutex::new(None),
         }
     }
 
@@ -265,6 +279,27 @@ impl MainHealthState {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let (class, reason) = track.detail.as_ref()?;
         Some(format!("{class}: {}", truncate_chars(reason, MAX_STATUS_REASON_CHARS)))
+    }
+
+    /// Wall-clock time of the most recent completed (Green/Red) gate verdict,
+    /// or `None` if none has landed yet this process (#4012). See the field
+    /// doc on [`Self::last_verdict_at`].
+    #[must_use]
+    pub fn last_verdict_at(&self) -> Option<DateTime<Utc>> {
+        *self
+            .last_verdict_at
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// Record `at` as the time of a just-completed (Green/Red) gate verdict.
+    /// Called from [`apply_gate_outcome`] only — never from the SHA-memo skip
+    /// path, which does not represent a completed run.
+    fn record_verdict_at(&self, at: DateTime<Utc>) {
+        *self
+            .last_verdict_at
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(at);
     }
 
     /// Record this tick's evaluated/unevaluated outcome and report whether the
@@ -469,6 +504,20 @@ impl WorkspaceHealthStates {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         map.get(root).and_then(|s| s.unevaluated_summary())
+    }
+
+    /// Wall-clock time of `root`'s most recent completed gate verdict
+    /// (#4012), or `None` when it has never produced one this process (or the
+    /// root has never been seen — deliberately the same "pending" reading as
+    /// a registered-but-not-yet-evaluated root, per the field doc on
+    /// [`MainHealthState::last_verdict_at`]).
+    #[must_use]
+    pub fn last_verdict_at(&self, root: &Path) -> Option<DateTime<Utc>> {
+        let map = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        map.get(root).and_then(|s| s.last_verdict_at())
     }
 
     /// Directly set `root`'s halt flag (creating its state if absent). Primarily
@@ -1988,6 +2037,7 @@ pub enum HealthTransition {
 pub fn apply_gate_outcome(state: &MainHealthState, outcome: &GateOutcome) -> HealthTransition {
     match outcome {
         GateOutcome::Green => {
+            state.record_verdict_at(Utc::now());
             let was_halted = state.halted.swap(false, Ordering::SeqCst);
             if was_halted {
                 HealthTransition::Recovered
@@ -1996,6 +2046,7 @@ pub fn apply_gate_outcome(state: &MainHealthState, outcome: &GateOutcome) -> Hea
             }
         }
         GateOutcome::Red { .. } => {
+            state.record_verdict_at(Utc::now());
             let was_halted = state.halted.swap(true, Ordering::SeqCst);
             if was_halted {
                 HealthTransition::RemainedHalted
@@ -2198,6 +2249,21 @@ pub fn resolve_enabled(config: &AutonomousGateConfig) -> bool {
         return matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on");
     }
     config.enabled.unwrap_or(false)
+}
+
+/// Whether the gate is **effectively** enabled for `repo_root` (#4012): the
+/// [`resolve_enabled`] on/off switch **and** a usable `buildGate` block. A
+/// root can be nominally `autonomous.mainHealthGate.enabled: true` yet never
+/// actually gate anything because `.loom/config.json` has no `buildGate`
+/// block (or an empty command) — [`spawn_multi_main_health_gate_task`]
+/// already treats that as always-green (soft-fail, unchanged contract); this
+/// helper folds the same two checks into one so the `loom-daemon status`
+/// "disabled" reading (#4012 AC2) agrees with what the gate loop actually
+/// does, rather than reporting "enabled" for a root that will never run.
+#[must_use]
+pub fn effective_enabled(repo_root: &Path) -> bool {
+    resolve_enabled(&read_autonomous_gate_config(repo_root))
+        && read_build_gate_config(repo_root).is_some()
 }
 
 /// Resolve the gate cadence from [`MAIN_HEALTH_GATE_INTERVAL_ENV`], falling back
@@ -2545,6 +2611,104 @@ mod tests {
     fn test_default_state_not_halted() {
         assert!(!MainHealthState::new().is_halted());
         assert!(!MainHealthState::default().is_halted());
+    }
+
+    // ===================================================================
+    // Verdict timestamp (#4012) — the pending-vs-clear disambiguator
+    // ===================================================================
+
+    #[test]
+    fn test_fresh_state_has_no_verdict_yet() {
+        // The core #4012 regression: a fresh, never-evaluated state must NOT
+        // be indistinguishable from a verified-green one. `last_verdict_at`
+        // is the new signal a renderer uses to tell them apart.
+        let state = MainHealthState::new();
+        assert_eq!(state.last_verdict_at(), None);
+        assert!(!state.is_halted(), "still not halted -- dispatch allowed either way");
+    }
+
+    #[test]
+    fn test_green_verdict_stamps_last_verdict_at() {
+        let state = MainHealthState::new();
+        let before = Utc::now();
+        let _ = apply_gate_outcome(&state, &GateOutcome::Green);
+        let stamped = state
+            .last_verdict_at()
+            .expect("a completed Green run must stamp a verdict time");
+        assert!(stamped >= before, "stamped time must not be in the past relative to the call");
+    }
+
+    #[test]
+    fn test_red_verdict_also_stamps_last_verdict_at() {
+        // Both determinate outcomes count as "a verdict happened" -- a red
+        // main is still a real answer, just an unwelcome one.
+        let state = MainHealthState::new();
+        let _ = apply_gate_outcome(&state, &GateOutcome::red("boom"));
+        assert!(state.last_verdict_at().is_some());
+    }
+
+    #[test]
+    fn test_unevaluated_outcome_does_not_stamp_last_verdict_at() {
+        // An UNEVALUATED tick produced no verdict at all -- it must not be
+        // mistaken for one by stamping the timestamp.
+        let state = MainHealthState::new();
+        let _ = apply_gate_outcome(
+            &state,
+            &GateOutcome::unevaluated(UnevaluatedClass::Timeout, "timed out"),
+        );
+        assert_eq!(state.last_verdict_at(), None, "an unevaluated tick must not stamp a verdict");
+    }
+
+    #[test]
+    fn test_run_gate_tick_skip_path_does_not_stamp_last_verdict_at() {
+        // The #3984 SHA-memo skip path (unchanged `origin/main`) proves
+        // nothing new -- the Curator's explicit design decision is that only
+        // the real Green/Red run stamps the verdict time, never the skip.
+        let (_origin, clone) = make_origin_and_clone();
+        let marker = tempfile::tempdir().unwrap();
+        let marker_file = marker.path().join("invocations.txt");
+        let cfg = BuildGateConfig {
+            command: format!("echo run >> {}", marker_file.display()),
+            timeout: Duration::from_secs(30),
+            ..Default::default()
+        };
+        let state = MainHealthState::new();
+
+        let first = run_gate_tick(&state, &cfg, clone.path());
+        assert_eq!(first, Some(GateOutcome::Green));
+        // `run_gate_tick` alone does not apply the outcome (the caller does,
+        // via `apply_gate_outcome`) -- so no verdict is stamped by the tick
+        // itself yet.
+        assert_eq!(state.last_verdict_at(), None);
+        let _ = apply_gate_outcome(&state, &first.unwrap());
+        let after_first = state.last_verdict_at();
+        assert!(after_first.is_some(), "the real run's outcome, once applied, stamps a verdict");
+
+        // Second tick: unchanged SHA -> skip. No outcome to apply, so the
+        // verdict time must be untouched.
+        let second = run_gate_tick(&state, &cfg, clone.path());
+        assert_eq!(second, None, "unchanged origin/main must skip the second tick");
+        assert_eq!(
+            state.last_verdict_at(),
+            after_first,
+            "a skipped tick must never refresh the verdict timestamp"
+        );
+    }
+
+    #[test]
+    fn test_workspace_health_states_last_verdict_at_unknown_root_is_none() {
+        let states = WorkspaceHealthStates::new();
+        assert_eq!(states.last_verdict_at(Path::new("/repo/never-seen")), None);
+    }
+
+    #[test]
+    fn test_workspace_health_states_last_verdict_at_delegates_to_root() {
+        let states = WorkspaceHealthStates::new();
+        let root = Path::new("/repo/a");
+        let state = states.get_or_create(root);
+        assert_eq!(states.last_verdict_at(root), None);
+        let _ = apply_gate_outcome(&state, &GateOutcome::Green);
+        assert!(states.last_verdict_at(root).is_some());
     }
 
     // ===================================================================
@@ -4210,6 +4374,84 @@ mod tests {
             enabled: Some(true),
             ..Default::default()
         }));
+        std::env::remove_var(MAIN_HEALTH_GATE_ENABLE_ENV);
+    }
+
+    // ===================================================================
+    // Effective enablement (#4012) — the "disabled" render signal
+    // ===================================================================
+
+    #[test]
+    #[serial]
+    fn test_effective_enabled_false_with_no_config_at_all() {
+        std::env::remove_var(MAIN_HEALTH_GATE_ENABLE_ENV);
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(!effective_enabled(tmp.path()), "no config at all ⇒ disabled");
+    }
+
+    #[test]
+    #[serial]
+    fn test_effective_enabled_false_when_enabled_but_no_usable_build_gate() {
+        // #4012's "edge case" test-plan item: a root that is nominally
+        // enabled but has no usable `buildGate` block (or an empty command)
+        // is treated by the gate loop as always-green and must ALSO report
+        // as effectively disabled here -- not "pending" -- since nothing
+        // will ever evaluate it until `buildGate` is actually configured.
+        std::env::remove_var(MAIN_HEALTH_GATE_ENABLE_ENV);
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), r#"{"autonomous": {"mainHealthGate": {"enabled": true}}}"#);
+        assert!(
+            !effective_enabled(tmp.path()),
+            "enabled=true with no buildGate block must still report disabled"
+        );
+
+        write_config(
+            tmp.path(),
+            r#"{"autonomous": {"mainHealthGate": {"enabled": true}}, "buildGate": {"enabled": true, "command": "   "}}"#,
+        );
+        assert!(
+            !effective_enabled(tmp.path()),
+            "enabled=true with an empty buildGate.command must still report disabled"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_effective_enabled_true_with_both_signals_configured() {
+        std::env::remove_var(MAIN_HEALTH_GATE_ENABLE_ENV);
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(
+            tmp.path(),
+            r#"{"autonomous": {"mainHealthGate": {"enabled": true}}, "buildGate": {"enabled": true, "command": "true"}}"#,
+        );
+        assert!(effective_enabled(tmp.path()));
+    }
+
+    #[test]
+    #[serial]
+    fn test_effective_enabled_false_when_build_gate_present_but_autonomous_disabled() {
+        std::env::remove_var(MAIN_HEALTH_GATE_ENABLE_ENV);
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), r#"{"buildGate": {"enabled": true, "command": "true"}}"#);
+        assert!(
+            !effective_enabled(tmp.path()),
+            "a usable buildGate block alone does not enable the gate -- autonomous.mainHealthGate must opt in too"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_effective_enabled_env_master_switch_overrides_config() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(
+            tmp.path(),
+            r#"{"autonomous": {"mainHealthGate": {"enabled": false}}, "buildGate": {"enabled": true, "command": "true"}}"#,
+        );
+        std::env::set_var(MAIN_HEALTH_GATE_ENABLE_ENV, "1");
+        assert!(
+            effective_enabled(tmp.path()),
+            "the env master switch overrides a config that disables the loop"
+        );
         std::env::remove_var(MAIN_HEALTH_GATE_ENABLE_ENV);
     }
 }

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -762,7 +762,12 @@ pub struct DaemonStatusReport {
     /// Whether autonomous dispatch is currently halted by the reactive
     /// main-health gate (#3812). `true` means a red `main` has paused new
     /// dispatch (in-flight sweeps keep running); `false` means dispatch is
-    /// allowed. Always `false` when the gate loop is not enabled.
+    /// allowed — which covers three distinct conditions the gate loop cannot
+    /// tell apart from this flag alone: the gate is disabled, the gate is
+    /// enabled but has not completed a first evaluation yet ("pending"), or
+    /// the gate's last completed run verified `main` green ("clear"). See
+    /// [`Self::main_health_gate_enabled`] and [`Self::main_health_gate_verdict_at`]
+    /// (#4012) for the fields that disambiguate those three.
     pub main_health_gate_halted: bool,
     /// Whether the gate's most recent tick for this workspace was
     /// `Unevaluated` rather than a completed Green/Red run — "not evaluated",
@@ -783,6 +788,32 @@ pub struct DaemonStatusReport {
     /// `#[serde(default)]` keeps pre-#3974 wire data compatible.
     #[serde(default)]
     pub main_health_gate_not_evaluated_reason: Option<String>,
+    /// Whether the reactive main-health gate is actually enabled for this
+    /// workspace root (#4012) — `resolve_enabled(..)` **and** a usable
+    /// `buildGate` block, so a root that is nominally `enabled: true` but has
+    /// no command configured (the gate loop treats that as always-green,
+    /// `main_health_gate.rs`) also reports `Some(false)` here. `Some(true)` /
+    /// `Some(false)` are resolved daemon-side (reading the daemon's own
+    /// environment and `.loom/config.json`, never the CLI client's); `None`
+    /// only for a pre-#4012 wire payload that never reported this field.
+    /// Deliberately `Option<bool>` rather than `bool`: a legacy payload
+    /// deserializing a missing `bool` field defaults to `false`, which would
+    /// misreport an older, perfectly healthy daemon as "gate disabled" —
+    /// `None` honestly means "unknown, older daemon" instead. `#[serde(default)]`
+    /// keeps pre-#4012 wire data compatible.
+    #[serde(default)]
+    pub main_health_gate_enabled: Option<bool>,
+    /// Wall-clock time of the most recent **completed** (Green/Red) gate
+    /// verdict for this workspace root (#4012), or `None` when no verdict has
+    /// landed yet this daemon process — the disambiguator between "pending"
+    /// (enabled, no verdict yet) and "clear" (verified green), and the
+    /// recency evidence a `clear` reading otherwise lacks. Stamped only on a
+    /// completed run, never on the #3984 SHA-memo skip path (a skip proves
+    /// nothing new). `#[serde(default)]` keeps pre-#4012 wire data compatible
+    /// (an absent field parses as `None`, which reads as "pending" — the
+    /// conservative choice for data an older daemon never populated).
+    #[serde(default)]
+    pub main_health_gate_verdict_at: Option<DateTime<Utc>>,
     /// Token-capacity backpressure snapshot (#3902): account health derived from
     /// the rotation ranking (`.loom/tokens/.ranking`) and whether the token axis
     /// is the binding constraint on the dynamic cap. `#[serde(default)]` keeps
@@ -846,6 +877,18 @@ pub struct RepoStatus {
     /// [`DaemonStatusReport::main_health_gate_not_evaluated_reason`].
     #[serde(default)]
     pub health_gate_not_evaluated_reason: Option<String>,
+    /// Whether this repo's gate is actually enabled (#4012). See
+    /// [`DaemonStatusReport::main_health_gate_enabled`] for the `Option<bool>`
+    /// rationale and the "enabled but no usable `buildGate` block ⇒ `false`"
+    /// rule. `#[serde(default)]` keeps pre-#4012 wire data compatible.
+    #[serde(default)]
+    pub health_gate_enabled: Option<bool>,
+    /// Wall-clock time of this repo's most recent completed gate verdict
+    /// (#4012), or `None` before the first one this process. See
+    /// [`DaemonStatusReport::main_health_gate_verdict_at`]. `#[serde(default)]`
+    /// keeps pre-#4012 wire data compatible.
+    #[serde(default)]
+    pub health_gate_verdict_at: Option<DateTime<Utc>>,
 }
 
 /// The token-capacity section of [`DaemonStatusReport`] (#3902).


### PR DESCRIPTION
## Summary

`loom-daemon status` printed `Main-health gate: clear (dispatch allowed)` for
three genuinely different conditions the pre-existing `halted`/`not_evaluated`
boolean pair could not distinguish:

1. the gate is **disabled** for this root (or enabled with no usable
   `buildGate` block — the gate loop treats that identically),
2. the gate is **enabled** but has not completed its first evaluation yet
   this daemon process ("pending"),
3. the gate's last completed run **verified `main` green** ("clear").

Two booleans can't encode three states, so `(halted=false, not_evaluated=false)`
collapsed all three into the same string — indistinguishable from a genuinely
verified-green `main`. This directly undermines the post-roll verification
loop: a fresh restart reads as "confirmed healthy" when nothing has run yet.

Closes #4012

## Design

Widened the reporting boundary with a `GateVerdict` enum
(`Disabled | Pending | Clear{since} | NotEvaluated{reason} | Halted{..}`)
built by a pure `classify_gate_verdict` function and rendered by both the
long-form summary line and the short 13-char per-repo table column, so the
two renderers can never disagree.

Two new signals feed the classifier, computed **daemon-side** (never the CLI
client's environment):

- **`main_health_gate_enabled: Option<bool>`** (`RepoStatus.health_gate_enabled`
  for per-repo) — via a new `main_health_gate::effective_enabled(repo_root)`
  helper that folds `resolve_enabled(..)` **and** a usable `buildGate` block
  into one check (a root nominally `enabled: true` with no `buildGate`
  command is effectively disabled — the gate loop already treats it as
  always-green). `Option<bool>` rather than `bool` so a legacy wire payload
  that never populated the field deserializes to `None` ("unknown, older
  daemon"), not `Some(false)` — a bare `bool`'s wire default would misreport
  a healthy older daemon as "gate disabled".
- **`main_health_gate_verdict_at: Option<DateTime<Utc>>`** (`RepoStatus.health_gate_verdict_at`
  for per-repo) — the wall-clock time of the most recent **completed**
  (Green/Red) verdict. Stamped only in `apply_gate_outcome`'s Green/Red arms;
  deliberately **not** touched by the `#3984` SHA-memo skip path in
  `run_gate_tick`, since a skip proves nothing new about `main` and stamping
  it there would let a stale "last verified" silently refresh itself
  forever. `None` is exactly the "pending" signal — a fresh process, before
  its first real verdict, can never reach the skip path first (`decide_gate_run`
  always returns `Run` when there's no prior determinate evaluation).

`halted`/`not_evaluated` still take strict priority over disabled/pending in
the classifier, so a genuinely active halt is never hidden behind either
newer state.

## Acceptance criteria

1. ✅ `pending (no verdict yet this process — dispatch allowed)` distinct from `clear (dispatch allowed; last verified green at <rfc3339>)`.
2. ✅ `disabled (gate not enabled; dispatch allowed)` distinct from both.
3. ✅ Dispatch behavior unchanged — pending and disabled both still allow dispatch; no new halt path (`classify_gate_verdict` never returns `Halted` for either).
4. ✅ `clear` carries its own recency evidence via the verdict timestamp, in both the human-readable line and the JSON output (`main_health_gate.verdict_at` / `per_repo[].health_gate_verdict_at`).

## Test plan

- `loom-daemon/src/main_health_gate.rs`: unit tests for `last_verdict_at` (stamped on Green/Red, not on Unevaluated or the SHA-memo skip path) and `effective_enabled` (no config / enabled-but-no-buildGate / both signals / autonomous-disabled-alone / env master switch).
- `loom-daemon/src/ipc.rs`: extended `test_daemon_status_backward_compat_missing_capacity` to assert the new fields default to `None` (not `Some(false)`) from a legacy payload; extended `test_build_daemon_status_reports_halt_and_in_flight` with a case where a fresh, newly-enabled root reports `pending`, not `clear`; extended the multi-workspace test with the disabled/no-verdict assertions; extended the round-trip test.
- `loom-daemon/src/main.rs`: rewrote the `format_gate_status` tests against the new `classify_gate_verdict`/`GateVerdict` API and added dedicated tests for pending-vs-clear, disabled-vs-pending, the "halted beats disabled/pending" priority rule, the legacy-`None`-is-not-disabled case, and the short-label/long-form agreement + 13-char width.
- `cargo build --workspace`, `cargo test --lib` (1012 passed), `cargo test --bin loom-daemon` (16 passed), `cargo clippy --package loom-daemon --package loom-api --all-targets -- -D warnings <ci flags>` (clean), `cargo fmt --check` (clean).

## Notes

Followed the Curator's re-verified design guidance in the issue body,
including stamping the verdict timestamp only at the real Green/Red site
(not the skip path) and computing the enabled signal daemon-side inside
`build_daemon_status` rather than in the CLI renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)