### PR TITLE
fix(daemon): derive cpu_headroom from measured idle fraction, not load average (#4031)

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -1128,29 +1128,63 @@ daemon restart:
 | **healthy-token count** | `available` accounts in `{workspace}/.loom/tokens/.ranking` (`capacity::token_axis_limit`), falling back to the `*.token` count (`tokens::token_pool_size`) when no ranking exists | the count of accounts safe to dispatch to — never dispatch to an exhausted/blocked one (#3902) |
 | **per-token concurrency** | `LOOM_PER_TOKEN_CONCURRENCY` / `autonomous.perTokenConcurrency`, default **2** (#3947) | how many concurrent sweeps to allow **per healthy account**. A plan limit is a utilization-window token bucket, not a session count, so one healthy account can run several concurrent sessions. Before #3947 the implicit factor was `1` (one sweep per account), which collapsed the whole fleet to cap 1 when 6/7 accounts were at their weekly ceiling even though the single healthy account had ample session-window headroom |
 | **disk headroom** | `floor(free_gb / LOOM_PER_WORKTREE_GB)` on the worktree-root volume (`disk_headroom::disk_headroom_limit`, a Rust port of `disk-headroom.sh` that shells to `df -Pk`) | never provision more worktrees than the scratch volume can hold |
-| **cpu/load headroom** (#3978) | `max(1, floor((logical_cpus × LOOM_CPU_UTILIZATION_TARGET − 1m loadavg) / LOOM_EST_CORES_PER_SWEEP))` (`cpu_headroom::cpu_headroom_limit`) | never start more concurrent sweeps than the host's CPU/load headroom can currently absorb |
+| **cpu headroom** (#3978, measured-idle signal #4031) | `max(1, floor((logical_cpus × LOOM_CPU_UTILIZATION_TARGET − consumed_cores) / LOOM_EST_CORES_PER_SWEEP))`, where `consumed_cores = logical_cpus × (1 − idle_fraction)` from the measured idle fraction (loadavg fallback) (`cpu_headroom::cpu_headroom_limit`) | never start more concurrent sweeps than the host's CPU headroom can currently absorb |
 | **configured ceiling** | `LOOM_WORK_FINDER_MAX_CONCURRENT` (repurposed from Phase A's fixed target into an operator ceiling) | hard operator upper bound regardless of token/disk/cpu headroom |
 
-**CPU/load headroom term (#3978).** The token and disk axes alone let a batch
-of token accounts resetting from `exhausted` to `available` at once raise the
-cap regardless of how many concurrent `cargo build`s were already saturating
-the host — the incident this term fixes: 2–3 concurrent Rust builds in sweep
-worktrees starved `build-gate.sh` of CPU badly enough that it hit its own 600s
-timeout, which the (separately-fixed, #3974) gate misreported as a verified-red
-`main`, halting all dispatch. `cpu_headroom_limit()` combines a **static**
-capacity (`logical_cpus × utilization_target`, default target `0.75` — leaves
-headroom for the OS, the daemon itself, and the gate's own `cargo`
-invocations) with the **current** 1-minute load average (`/proc/loadavg` on
-Linux, `sysctl -n vm.loadavg` on macOS) subtracted from that capacity, divided
-by an estimated per-sweep core cost (`LOOM_EST_CORES_PER_SWEEP`, default
-`2.0`). Like the token axis's "one healthy account is the floor, never a
-halt" policy (#3902), the CPU term is floored at `1` — a load-average read
-failure or a noisy reading must never by itself wedge the whole dynamic cap
-to zero; disk headroom and the token axis remain the only terms allowed to
-floor to a genuine `0`. Tunable via `LOOM_CPU_UTILIZATION_TARGET` (fraction,
-default `0.75`) and `LOOM_EST_CORES_PER_SWEEP` (cores, default `2.0`) —
-env-only, mirroring `LOOM_PER_WORKTREE_GB`'s config surface (no
-`.loom/config.json` knob).
+**CPU headroom term (#3978, measured-idle signal #4031).** The token and disk
+axes alone let a batch of token accounts resetting from `exhausted` to
+`available` at once raise the cap regardless of how many concurrent `cargo
+build`s were already saturating the host — the incident this term fixes: 2–3
+concurrent Rust builds in sweep worktrees starved `build-gate.sh` of CPU badly
+enough that it hit its own 600s timeout, which the (separately-fixed, #3974)
+gate misreported as a verified-red `main`, halting all dispatch.
+`cpu_headroom_limit()` combines a **static** capacity (`logical_cpus ×
+utilization_target`, default target `0.75` — leaves headroom for the OS, the
+daemon itself, and the gate's own `cargo` invocations) with the cores
+**currently consumed**, subtracted from that capacity, divided by an estimated
+per-sweep core cost (`LOOM_EST_CORES_PER_SWEEP`, default `2.0`).
+
+*Consumed cores come from a measured idle fraction, not the load average
+(#4031).* The original #3978 term used the 1-minute load average as a stand-in
+for consumed cores. On macOS that overstated consumption by ~1.5× — an observed
+idle-but-loaded host read `load1m ≈ 6–7` alongside 76–86% CPU idle on 28 cores
+(only ~4–7 cores actually consumed). Load average counts threads in the
+runnable **and** uninterruptible-sleep states, and this daemon's workload is
+dominated by `claude` sessions **blocked on network I/O**, which inflate load
+without consuming a core — pointing the feedback loop the wrong way (more
+concurrent sweeps → more blocked `claude` → higher load → *lower* cap, while
+CPU sat idle). The term now derives `consumed_cores = logical_cpus × (1 −
+idle_fraction)` from a measured idle fraction, **per-platform**:
+
+- **Linux** deltas two reads of the aggregate `cpu` line in `/proc/stat`
+  (`idle + iowait` vs total), memoizing the previous cumulative sample and
+  deltaing **across ticks** — nothing sleeps.
+- **macOS** shells to `iostat -c 2 -w 1 -n 0` and reads the **second** data
+  line (a genuine 1-second delta; the first is cumulative since boot). That
+  1-second wait is moved to `spawn_blocking` at the async call sites and
+  **memoized** behind a ~10s TTL (`CPU_UTIL_MEMO_TTL`) shared with the
+  synchronous `ipc.rs` status path, so a runtime worker is never blocked and a
+  status request + a work-finder tick never each pay the full second.
+
+The signal chain is **fail-open**: `measured idle fraction → 1-minute load
+average → static capacity`. An unreadable idle signal (missing `/proc/stat` or
+`iostat`, unsupported platform, or no delta sampled yet) falls back to the load
+average (#3978's behavior); an unreadable load average falls back to the static
+capacity, unadjusted. Like the token axis's "one healthy account is the floor,
+never a halt" policy (#3902), the CPU term is floored at `1` — a read failure or
+a noisy reading must never by itself wedge the whole dynamic cap to zero; disk
+headroom and the token axis remain the only terms allowed to floor to a genuine
+`0`. Tunable via `LOOM_CPU_UTILIZATION_TARGET` (fraction, default `0.75`) and
+`LOOM_EST_CORES_PER_SWEEP` (cores, default `2.0`) — env-only, mirroring
+`LOOM_PER_WORKTREE_GB`'s config surface (no `.loom/config.json` knob).
+
+*Calibrating `LOOM_EST_CORES_PER_SWEEP`.* The host-side half of the term
+(consumed cores) is now measured continuously and needs no tuning. The one
+remaining constant — how many cores one concurrent sweep consumes during its
+build/test step — is a per-repo/host property. Its default (`2.0`) is **not**
+changed here absent a real multi-sweep measurement; a reproducible recipe lives
+at [`docs/measure-est-cores-per-sweep.md`](../../docs/measure-est-cores-per-sweep.md)
+so an operator can calibrate it on a live fleet without re-opening the code.
 
 **Per-token concurrency factor (#3947).** The token axis is `healthy × factor`,
 not `healthy × 1`. The factor is resolved with the standard precedence **env
@@ -1164,8 +1198,24 @@ fills **distinct** accounts first (via the persistent `.rotation_cursor`), only
 stacking multiple sweeps on one account when concurrency demand exceeds the
 healthy-account count. The `loom-daemon status` view spells the arithmetic out,
 e.g. `= min(healthy 1 × per-token 2 = 2, disk headroom 120, cpu headroom 6,
-configured max 3)`, and a separate line reports the live loadavg/core-count
-detail feeding the cpu headroom term (#3978 AC4).
+configured max 3)`, and a separate line reports the live core-count detail
+feeding the cpu headroom term — naming which signal actually fed it, e.g.
+`cpu headroom: 8 concurrent-sweep slot(s) (28 logical cores, 85% idle measured
+(≈4.2 cores consumed))`, or a `1m loadavg …` / `static capacity only` line when
+falling back (#3978 AC4; measured-idle signal #4031).
+
+**"Currently binding" vs "smallest ceiling" (#4031).** The dynamic cap is the
+*minimum* of several ceilings, but a ceiling only *binds* once in-flight
+occupancy reaches it. Below the cap the limiter is simply how much ready work
+exists, not any resource term — so the status view gates its bottleneck
+diagnosis on real occupancy (`in_flight.len() >= dynamic_cap`, surfaced as the
+`capacity_bound` field, `#[serde(default)]`). With in-flight below the cap it
+prints `not capacity-bound (N in flight, cap M — the limiter is work
+availability, not tokens/disk/CPU)` and **suppresses** the `token-bound:`
+diagnosis line; at or above the cap it names the binding term as before. The
+`= min(…)` breakdown line is untouched — those genuinely are ceilings. The JSON
+status carries the same `capacity_bound` boolean so scripted consumers aren't
+misled at low occupancy either.
 
 **Session-limit fault handling (#3947).** Stacking can occasionally trip a
 **concurrent-session-limit** fault on a token (the account is healthy but cannot

--- a/docs/measure-est-cores-per-sweep.md
+++ b/docs/measure-est-cores-per-sweep.md
@@ -1,0 +1,91 @@
+# Measuring `LOOM_EST_CORES_PER_SWEEP`
+
+`LOOM_EST_CORES_PER_SWEEP` is the one hand-tuned constant left in the daemon's
+CPU-headroom term (`loom-daemon/src/cpu_headroom.rs`). It estimates how many CPU
+cores a **single** concurrent sweep consumes while its build/test step is
+running. The headroom term is:
+
+```
+cpu_headroom = max(1, floor((logical_cpus × LOOM_CPU_UTILIZATION_TARGET − consumed_cores) / LOOM_EST_CORES_PER_SWEEP))
+```
+
+Since #4031 the `consumed_cores` half is **measured continuously at runtime**
+(idle fraction → `logical_cpus × (1 − idle_fraction)`), so only this per-sweep
+divisor remains a guess. Its default is `2.0` (a conservative estimate for a
+Rust-heavy repo where `cargo build`/`clippy` parallelize rustc codegen across a
+few cores). **Do not change the default without a measurement** — replacing one
+guessed constant with a differently-guessed one is not an improvement.
+
+This document is that measurement recipe. It is a per-host / per-repo property,
+so it must be run on a real host running real sweeps — which a single Builder
+worktree cannot provision, hence the recipe rather than a baked-in number.
+
+## Recipe: marginal cores per concurrent sweep
+
+The quantity we want is the **marginal** CPU consumption added by one more
+concurrent sweep — not the whole-host load. Measure it as the slope of consumed
+cores vs. concurrent-sweep count.
+
+### 1. Establish the idle baseline
+
+With **no sweeps running**, sample consumed cores over ~60s:
+
+```bash
+# Linux: idle fraction from /proc/stat delta
+awk '/^cpu /{i=$5+$6; t=0; for(n=2;n<=NF;n++)t+=$n; print i, t}' /proc/stat
+sleep 60
+awk '/^cpu /{i=$5+$6; t=0; for(n=2;n<=NF;n++)t+=$n; print i, t}' /proc/stat
+# consumed_cores = ncpu × (1 − (idle2-idle1)/(total2-total1))
+
+# macOS: second (delta) line of iostat; `id` is idle %
+iostat -c 2 -w 60 -n 0   # take the SECOND data line's `id` column
+# consumed_cores = ncpu × (1 − id/100),  ncpu = sysctl -n hw.logicalcpu
+```
+
+Call this `C0` (cores consumed by the OS + daemon at rest).
+
+### 2. Sample under a known concurrent-sweep count
+
+Drive the daemon to a **fixed** number of concurrent sweeps `N` (e.g. via
+`mcp__loom__dispatch_sweep` for N distinct issues, or set
+`autonomous.workFinder.maxConcurrent = N` with a backlog of ≥ N ready
+`loom:issue` items and let the work finder fill it). Confirm the live count:
+
+```bash
+loom-daemon status --json | jq '.in_flight_count'
+```
+
+Wait until all N sweeps are in their **build/test** phase (the CPU-heavy step —
+this is what the term protects), then sample consumed cores again over ~60s
+using the same commands as step 1. Call this `C_N`.
+
+### 3. Compute the marginal cost
+
+```
+LOOM_EST_CORES_PER_SWEEP ≈ (C_N − C0) / N
+```
+
+Repeat for a couple of values of `N` (e.g. 2 and 4) and confirm the slope is
+roughly linear; use the average. Sampling while sweeps are between build steps
+(idle, waiting on the model) will understate the value — measure during peak
+build concurrency, which is the moment the term exists to guard against.
+
+### 4. Apply
+
+Set the measured value (env overrides config overrides the `2.0` default):
+
+```bash
+export LOOM_EST_CORES_PER_SWEEP=<measured>
+# then restart the daemon, or bake it into the daemon's environment
+```
+
+Cross-check against `loom-daemon status`, whose `cpu headroom` line now reports
+the measured idle fraction and consumed-core estimate feeding the term.
+
+## Notes
+
+- **`LOOM_CPU_UTILIZATION_TARGET`** (default `0.75`) is a policy knob — the
+  fraction of cores you are *willing* to dedicate to sweeps — not a measurement.
+  Leave headroom for the OS, the daemon, and the build-gate's own `cargo`.
+- Exposing these two knobs via `.loom/config.json` (`autonomous.*`) instead of
+  env-only is tracked separately in #4032.

--- a/loom-daemon/src/cpu_headroom.rs
+++ b/loom-daemon/src/cpu_headroom.rs
@@ -19,31 +19,64 @@
 //!    of cores this host is willing to dedicate to sweep work (leaving
 //!    headroom for the OS, the daemon itself, and the build-gate's own
 //!    `cargo` invocations), and
-//! 2. **current load** — the 1-minute load average, subtracted from that
-//!    capacity so a host that is *already* busy (someone else's build, a
-//!    live sweep mid-compile) backs the term off reactively, not just from a
-//!    static core count.
+//! 2. **current CPU consumption** — `logical_cpus × (1 − idle_fraction)`,
+//!    the number of cores actually being *consumed* right now, subtracted
+//!    from that capacity so a host that is already busy (someone else's
+//!    build, a live sweep mid-compile) backs the term off reactively.
 //!
 //! Dividing the resulting headroom by an estimated per-sweep core cost
 //! (`est_cores_per_sweep` — a `cargo build`/`clippy` invocation typically
 //! parallelizes across several cores via rustc codegen units) yields how many
 //! more concurrent sweeps the host can start right now.
 //!
+//! # Why measured idle fraction, not the load average (#4031)
+//!
+//! The original #3978 term used the **1-minute load average** as a stand-in
+//! for consumed cores. On macOS that overstates consumption by ~1.5×: an
+//! observed idle-but-loaded host showed `load1m ≈ 6–7` alongside 76–86% CPU
+//! idle on 28 cores — only ~4–7 cores actually consumed. Load average counts
+//! threads in the runnable **and** uninterruptible-sleep states, and this
+//! daemon's workload is dominated by `claude` sessions **blocked on network
+//! I/O**, which inflate load without consuming a core. That pointed the
+//! feedback loop the wrong way: more concurrent sweeps → more blocked `claude`
+//! processes → higher load average → *lower* concurrency cap, even while the
+//! CPU sat idle. This module now derives `consumed_cores` from a **measured
+//! idle fraction** (actual CPU consumption), per-platform, and keeps the load
+//! average only as a fail-open fallback.
+//!
 //! # Why shell out / read `/proc` instead of a `sysinfo`-style crate
 //!
 //! Matches the precedent set by [`crate::disk_headroom`] (shell out to `df`)
 //! and [`crate::worktree_root`]: no new crate dependency, OS-native data
 //! sources kept small and directly testable via pure parsing functions
-//! ([`parse_proc_loadavg`], [`parse_macos_loadavg`]) split from the I/O.
-//! Logical CPU count uses `std::thread::available_parallelism` (stdlib, no
-//! dependency at all).
+//! ([`parse_proc_loadavg`], [`parse_macos_loadavg`], [`parse_proc_stat_cpu`],
+//! [`parse_iostat_cpu`]) split from the I/O. Logical CPU count uses
+//! `std::thread::available_parallelism` (stdlib, no dependency at all).
+//!
+//! ## Per-platform idle measurement, and the blocking-call hazard
+//!
+//! - **Linux** deltas two reads of the aggregate `cpu` line in `/proc/stat`
+//!   (`idle + iowait` vs total). The previous cumulative sample is memoized in
+//!   a process-global cache and deltaed **across ticks**, so nothing ever
+//!   sleeps.
+//! - **macOS** shells to `iostat -c 2 -w 1 -n 0`: the **second** data line is
+//!   a genuine 1-second delta (the first is cumulative since boot and must not
+//!   be used), `id` is idle %. That 1-second wait would block a tokio runtime
+//!   worker if called inline from a `ticker.tick().await` loop, so the read is
+//!   moved to `spawn_blocking` at the call sites and its result is **memoized**
+//!   behind a short TTL ([`CPU_UTIL_MEMO_TTL`]). The memoized cache is shared
+//!   by the work-finder loops and the synchronous `ipc.rs` status path, so a
+//!   status request and a work-finder tick never each pay the full second.
 //!
 //! # Fail-open, not fail-closed
 //!
-//! A load-average read failure (unsupported platform, missing `sysctl`,
-//! unreadable `/proc/loadavg`) returns `None` and this module falls back to
-//! the **static** capacity term (no load subtracted) rather than treating the
-//! read failure as "host fully loaded". This mirrors
+//! The signal chain is **measured idle fraction → 1-minute load average →
+//! static capacity**, each stage falling forward to the next when its input is
+//! unavailable. An unreadable utilization signal (no `/proc/stat`, missing
+//! `iostat`, unsupported platform, or simply no delta sampled yet) falls back
+//! to the load average (#3978's behavior); an unreadable load average in turn
+//! falls back to the **static** capacity term (no consumption subtracted)
+//! rather than treating the read failure as "host fully loaded". This mirrors
 //! [`crate::capacity::token_axis_limit`]'s policy of falling back to the
 //! optimistic basis (the raw pool) when no ranking data exists — the absence
 //! of a signal is not evidence of unhealthiness. The term itself is floored
@@ -54,9 +87,12 @@
 //! floor to zero (genuine "no room"/"no healthy accounts" signals); CPU is
 //! deliberately a soft backoff, not a hard gate.
 
-// `Command`/`Stdio` back only the macOS `sysctl` read path — cfg-gated so a
-// Linux build (which reads `/proc/loadavg` directly, no subprocess) doesn't
-// warn on an unused import under `-D warnings`.
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+// `Command`/`Stdio` back only the macOS `sysctl` / `iostat` read paths —
+// cfg-gated so a Linux build (which reads `/proc/*` directly, no subprocess)
+// doesn't warn on an unused import under `-D warnings`.
 #[cfg(target_os = "macos")]
 use std::process::{Command, Stdio};
 
@@ -177,44 +213,316 @@ pub fn read_loadavg_1m() -> Option<f64> {
 }
 
 // ============================================================================
+// CPU utilization — measured idle fraction (#4031), OS-specific read, pure parse
+// ============================================================================
+
+/// A cumulative CPU-time sample from Linux `/proc/stat`'s aggregate `cpu`
+/// line. Deltaed against a previous sample to derive the idle fraction over
+/// the interval between two reads (no sleep required — see [`CpuUtilState`]).
+#[cfg(target_os = "linux")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProcStatCpu {
+    /// Idle jiffies (`idle + iowait`) accumulated since boot.
+    pub idle: u64,
+    /// Total jiffies across every state accumulated since boot.
+    pub total: u64,
+}
+
+#[cfg(target_os = "linux")]
+impl ProcStatCpu {
+    /// The idle fraction over the interval `prev → self`, or `None` when the
+    /// total-jiffies delta is zero (two reads too close together / counter
+    /// reset). `saturating_sub` guards a wrapped/reset counter from panicking.
+    #[must_use]
+    pub fn idle_fraction_since(&self, prev: &ProcStatCpu) -> Option<f64> {
+        let total_delta = self.total.saturating_sub(prev.total);
+        if total_delta == 0 {
+            return None;
+        }
+        let idle_delta = self.idle.saturating_sub(prev.idle);
+        Some(idle_delta as f64 / total_delta as f64)
+    }
+}
+
+/// Parse the aggregate `cpu` line from Linux `/proc/stat` contents into a
+/// cumulative [`ProcStatCpu`] sample. The line is
+/// `"cpu  user nice system idle iowait irq softirq steal guest guest_nice"`
+/// (jiffies since boot); idle counts `idle + iowait`, total sums every field.
+/// Returns `None` when no aggregate `cpu ` line is present or it is malformed.
+#[cfg(target_os = "linux")]
+#[must_use]
+pub fn parse_proc_stat_cpu(contents: &str) -> Option<ProcStatCpu> {
+    // The aggregate line is the one whose first token is exactly "cpu" (the
+    // per-core lines are "cpu0", "cpu1", … and must be skipped).
+    let line = contents
+        .lines()
+        .find(|l| l.split_whitespace().next() == Some("cpu"))?;
+    let fields: Vec<u64> = line
+        .split_whitespace()
+        .skip(1)
+        .map(str::parse::<u64>)
+        .collect::<Result<Vec<_>, _>>()
+        .ok()?;
+    // Need at least user..iowait (indices 0..=4) to compute idle+iowait.
+    if fields.len() < 5 {
+        return None;
+    }
+    let idle = fields[3] + fields[4]; // idle + iowait
+    let total: u64 = fields.iter().sum();
+    Some(ProcStatCpu { idle, total })
+}
+
+/// Parse the idle fraction (`0.0..=1.0`) from macOS `iostat -c 2 -w 1 -n 0`
+/// output. Two CPU data lines are emitted: the **first** is cumulative since
+/// boot and must be ignored; the **second** is a genuine 1-second delta. Each
+/// data line's trailing six columns are `us sy id 1m 5m 15m`, so `id` (idle %)
+/// is the fourth-from-last field — a position that holds whether or not disk
+/// columns precede it. Returns `None` on malformed input or fewer than two
+/// data lines.
+#[must_use]
+pub fn parse_iostat_cpu(output: &str) -> Option<f64> {
+    let mut data_lines = output.lines().filter_map(|line| {
+        let tokens: Vec<&str> = line.split_whitespace().collect();
+        if tokens.len() < 6 {
+            return None;
+        }
+        // A data line's last six columns (`us sy id 1m 5m 15m`) are all numeric;
+        // header lines ("us sy id", "cpu    load average") are not.
+        let tail = &tokens[tokens.len() - 6..];
+        if tail.iter().all(|t| t.parse::<f64>().is_ok()) {
+            tokens[tokens.len() - 4].parse::<f64>().ok()
+        } else {
+            None
+        }
+    });
+    // Discard the since-boot cumulative line; use the 1-second delta line.
+    data_lines.next()?;
+    let idle_percent = data_lines.next()?;
+    if (0.0..=100.0).contains(&idle_percent) {
+        Some(idle_percent / 100.0)
+    } else {
+        None
+    }
+}
+
+/// Read the aggregate `/proc/stat` CPU sample on Linux.
+#[cfg(target_os = "linux")]
+#[must_use]
+fn read_proc_stat_cpu() -> Option<ProcStatCpu> {
+    let contents = std::fs::read_to_string("/proc/stat").ok()?;
+    parse_proc_stat_cpu(&contents)
+}
+
+/// Read the current idle fraction on macOS via `iostat -c 2 -w 1 -n 0`.
+///
+/// **Blocks for ~1 second** (the sampling window). Callers on the tokio
+/// runtime MUST route this through `spawn_blocking` + the memoized cache
+/// ([`refresh_cpu_util_cache`]); never call it inline from an async task.
+#[cfg(target_os = "macos")]
+#[must_use]
+fn read_iostat_idle_fraction() -> Option<f64> {
+    let output = Command::new("iostat")
+        .args(["-c", "2", "-w", "1", "-n", "0"])
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    parse_iostat_cpu(&String::from_utf8_lossy(&output.stdout))
+}
+
+// ============================================================================
+// Memoized utilization cache (#4031)
+// ============================================================================
+
+/// TTL for the memoized idle-fraction sample. A read that would sleep (macOS
+/// `iostat`) is taken at most once per this window; within it, both a status
+/// request and a work-finder tick reuse the cached value. Also bounds how
+/// often the Linux cross-tick `/proc/stat` delta is re-sampled.
+pub const CPU_UTIL_MEMO_TTL: Duration = Duration::from_secs(10);
+
+/// Process-global memoized CPU-utilization state.
+struct CpuUtilState {
+    /// Last successfully measured idle fraction (`0.0..=1.0`), or `None` until
+    /// one has been computed (falls back to loadavg meanwhile).
+    idle_fraction: Option<f64>,
+    /// When the cache was last refreshed (success or attempt), for the TTL gate.
+    updated_at: Option<Instant>,
+    /// Linux only: the previous cumulative `/proc/stat` sample, deltaed across
+    /// refreshes to derive `idle_fraction` without ever sleeping.
+    #[cfg(target_os = "linux")]
+    prev: Option<ProcStatCpu>,
+}
+
+impl CpuUtilState {
+    const fn new() -> Self {
+        CpuUtilState {
+            idle_fraction: None,
+            updated_at: None,
+            #[cfg(target_os = "linux")]
+            prev: None,
+        }
+    }
+}
+
+static CPU_UTIL_STATE: Mutex<CpuUtilState> = Mutex::new(CpuUtilState::new());
+
+/// Refresh the memoized idle-fraction sample.
+///
+/// A no-op when a sample is younger than [`CPU_UTIL_MEMO_TTL`] (this is the
+/// memoization that keeps a burst of status requests + work-finder ticks from
+/// each paying the macOS 1-second `iostat`). Otherwise:
+///
+/// - **Linux** reads `/proc/stat` and deltas it against the previous cached
+///   sample (no sleep). The first refresh only seeds the previous sample — the
+///   idle fraction stays `None` (loadavg fallback) until a second refresh has a
+///   delta to compute.
+/// - **macOS** runs `iostat` (~1s wall) and caches the parsed idle fraction.
+///
+/// **Blocks on macOS.** Call from `spawn_blocking`, never inline on the tokio
+/// runtime. Cheap and non-sleeping on Linux, but still routed through
+/// `spawn_blocking` at the async call sites for symmetry.
+pub fn refresh_cpu_util_cache() {
+    let mut st = CPU_UTIL_STATE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if let Some(at) = st.updated_at {
+        if at.elapsed() < CPU_UTIL_MEMO_TTL {
+            return;
+        }
+    }
+    #[cfg(target_os = "linux")]
+    {
+        if let Some(cur) = read_proc_stat_cpu() {
+            if let Some(prev) = st.prev {
+                if let Some(frac) = cur.idle_fraction_since(&prev) {
+                    st.idle_fraction = Some(frac);
+                }
+            }
+            st.prev = Some(cur);
+            st.updated_at = Some(Instant::now());
+        }
+    }
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(frac) = read_iostat_idle_fraction() {
+            st.idle_fraction = Some(frac);
+        }
+        st.updated_at = Some(Instant::now());
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        st.updated_at = Some(Instant::now());
+    }
+}
+
+/// The last memoized idle fraction, or `None` when none has been sampled yet.
+/// Never blocks — a pure cache read, safe on the tokio runtime and from the
+/// synchronous `ipc.rs` status path.
+#[must_use]
+pub fn cached_cpu_idle_fraction() -> Option<f64> {
+    CPU_UTIL_STATE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .idle_fraction
+}
+
+// ============================================================================
 // The pure headroom term
 // ============================================================================
 
-/// Compute the CPU/load headroom concurrency term.
+/// Compute the CPU headroom concurrency term.
 ///
 /// `capacity = ncpu × utilization_target` is the number of cores this host is
-/// willing to dedicate to sweep work. When a current 1-minute load average is
-/// available it is subtracted from that capacity (floored at `0.0` — an
-/// already-saturated host contributes no headroom rather than going
-/// negative); when unavailable, the term falls back to the static capacity
-/// unadjusted (fail-open — see module docs). The resulting headroom divided
-/// by `est_cores_per_sweep` gives how many additional concurrent sweeps the
-/// host can currently absorb, floored to a minimum of `1` so a single noisy
-/// or mis-calibrated CPU reading can never by itself wedge the dynamic cap to
+/// willing to dedicate to sweep work. From it we subtract the cores currently
+/// **consumed**, resolved via the fail-open chain (see module docs):
+///
+/// 1. a measured `idle_fraction` → `consumed = ncpu × (1 − idle_fraction)`
+///    (actual CPU consumption — the #4031 fix), else
+/// 2. the 1-minute `loadavg_1m` as a proxy (#3978's behavior), else
+/// 3. nothing — the static capacity, unadjusted.
+///
+/// The consumption is floored at `0.0` (an already-saturated host contributes
+/// no headroom rather than going negative). The resulting headroom divided by
+/// `est_cores_per_sweep` gives how many additional concurrent sweeps the host
+/// can currently absorb, floored to a minimum of `1` so a single noisy or
+/// mis-calibrated CPU reading can never by itself wedge the dynamic cap to
 /// zero (mirrors the token axis's "never a halt" floor, #3902).
 #[must_use]
 pub fn cpu_headroom(
     ncpu: usize,
+    idle_fraction: Option<f64>,
     loadavg_1m: Option<f64>,
     utilization_target: f64,
     est_cores_per_sweep: f64,
 ) -> usize {
     let capacity = ncpu as f64 * utilization_target;
-    let available = loadavg_1m.map_or(capacity, |load| (capacity - load).max(0.0));
+    // Prefer the measured idle fraction; fall back to load average; else no
+    // consumption term at all (static capacity).
+    let consumed = match idle_fraction {
+        Some(idle) => Some(ncpu as f64 * (1.0 - idle.clamp(0.0, 1.0))),
+        None => loadavg_1m,
+    };
+    let available = consumed.map_or(capacity, |c| (capacity - c).max(0.0));
     let term = (available / est_cores_per_sweep.max(f64::MIN_POSITIVE)).floor();
-    // NaN/negative-infinity can't occur here (both operands are finite and
+    // NaN/negative-infinity can't occur here (all operands are finite and
     // `est_cores_per_sweep` is clamped away from 0), but `max(1.0)` also
     // guards the float→usize cast below against any residual edge case.
     term.max(1.0) as usize
 }
 
-/// Resolve the CPU/load headroom term end-to-end from live host inputs
-/// ([`logical_cpu_count`], [`read_loadavg_1m`]) and env-configured knobs
-/// ([`utilization_target`], [`est_cores_per_sweep`]).
+/// A point-in-time snapshot of the inputs feeding [`cpu_headroom`], for the
+/// status surface (`ipc.rs` / `loom-daemon status`). Reads the memoized idle
+/// fraction (no blocking) plus a fresh, fast load-average read.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CpuHeadroomSnapshot {
+    /// Host logical CPU count.
+    pub logical_cpus: usize,
+    /// Measured idle fraction (`0.0..=1.0`) if one has been sampled, else `None`.
+    pub idle_fraction: Option<f64>,
+    /// Current 1-minute load average if available, else `None`.
+    pub loadavg_1m: Option<f64>,
+    /// The resulting headroom term (concurrent-sweep slots).
+    pub cpu_headroom: usize,
+}
+
+/// Build a [`CpuHeadroomSnapshot`] from the memoized idle fraction, a fresh
+/// load-average read, and the env-configured knobs. **Never blocks** — safe on
+/// the tokio runtime and from the synchronous status path. Pre-warm the idle
+/// cache with `spawn_blocking(refresh_cpu_util_cache)` for a fresh measurement.
+#[must_use]
+pub fn cpu_headroom_snapshot() -> CpuHeadroomSnapshot {
+    let logical_cpus = logical_cpu_count();
+    let idle_fraction = cached_cpu_idle_fraction();
+    let loadavg_1m = read_loadavg_1m();
+    let cpu_headroom = cpu_headroom(
+        logical_cpus,
+        idle_fraction,
+        loadavg_1m,
+        utilization_target(),
+        est_cores_per_sweep(),
+    );
+    CpuHeadroomSnapshot {
+        logical_cpus,
+        idle_fraction,
+        loadavg_1m,
+        cpu_headroom,
+    }
+}
+
+/// Resolve the CPU headroom term end-to-end from live host inputs, refreshing
+/// the memoized idle-fraction sample first.
+///
+/// **May block** (~1s on macOS via `iostat`; fast, non-sleeping on Linux). The
+/// async work-finder loops call this through `spawn_blocking` so the macOS
+/// sampling window never blocks a tokio runtime worker.
 #[must_use]
 pub fn cpu_headroom_limit() -> usize {
+    refresh_cpu_util_cache();
     cpu_headroom(
         logical_cpu_count(),
+        cached_cpu_idle_fraction(),
         read_loadavg_1m(),
         utilization_target(),
         est_cores_per_sweep(),
@@ -261,50 +569,158 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // cpu_headroom — pure math
+    // parse_proc_stat_cpu (Linux)
+    // ------------------------------------------------------------------
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn parse_proc_stat_cpu_sums_total_and_idle_plus_iowait() {
+        // cpu  user nice system idle iowait irq softirq steal guest guest_nice
+        let s = "cpu  100 20 30 700 40 5 5 0 0 0\ncpu0 50 10 15 350 20 2 3 0 0 0\n";
+        let sample = parse_proc_stat_cpu(s).unwrap();
+        assert_eq!(sample.idle, 740, "idle = idle 700 + iowait 40");
+        assert_eq!(sample.total, 100 + 20 + 30 + 700 + 40 + 5 + 5);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn parse_proc_stat_cpu_skips_per_core_lines_and_rejects_malformed() {
+        // A leading per-core line must not be mistaken for the aggregate.
+        let s = "cpu0 1 2 3 4 5\ncpu 10 20 30 40 50\n";
+        assert_eq!(parse_proc_stat_cpu(s).unwrap().idle, 90); // idle 40 + iowait 50
+        assert_eq!(parse_proc_stat_cpu(""), None);
+        assert_eq!(parse_proc_stat_cpu("intr 1 2 3\n"), None, "no aggregate cpu line");
+        assert_eq!(parse_proc_stat_cpu("cpu 1 2\n"), None, "too few fields for idle+iowait");
+        assert_eq!(parse_proc_stat_cpu("cpu a b c d e\n"), None, "non-numeric fields");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn proc_stat_idle_fraction_over_interval() {
+        let prev = ProcStatCpu {
+            idle: 700,
+            total: 1000,
+        };
+        // Over the interval, total advanced 100 jiffies, idle 80 → 80% idle.
+        let cur = ProcStatCpu {
+            idle: 780,
+            total: 1100,
+        };
+        let frac = cur.idle_fraction_since(&prev).unwrap();
+        assert!((frac - 0.80).abs() < 1e-9, "got {frac}");
+        // Zero total delta (or a reset counter) yields None, not a divide-by-zero.
+        assert_eq!(cur.idle_fraction_since(&cur), None);
+    }
+
+    // ------------------------------------------------------------------
+    // parse_iostat_cpu (macOS) — must use the SECOND (delta) data line
     // ------------------------------------------------------------------
 
     #[test]
-    fn cpu_headroom_static_capacity_when_no_load_reading() {
-        // 8 cores, 75% target, no load reading -> capacity 6.0 / 2.0 cores per
-        // sweep = 3.
-        assert_eq!(cpu_headroom(8, None, 0.75, 2.0), 3);
+    fn parse_iostat_cpu_uses_second_delta_line_not_first_since_boot() {
+        // `iostat -c 2 -w 1 -n 0`: header, then a since-boot line (id 83) and a
+        // 1-second delta line (id 50). Using the first line would report 0.83 —
+        // this test FAILS if the parser reads the since-boot line.
+        let out = "      cpu    load average\n \
+                   us sy id   1m   5m   15m\n  \
+                    8  9 83  3.37 4.02 4.64\n \
+                   40 10 50  3.40 4.02 4.64\n";
+        let idle = parse_iostat_cpu(out).unwrap();
+        assert!((idle - 0.50).abs() < 1e-9, "must use the delta line (id 50), got {idle}");
     }
 
     #[test]
-    fn cpu_headroom_subtracts_current_load() {
-        // 8 cores, 75% target -> capacity 6.0. Load 4.0 already in use ->
-        // 2.0 available / 2.0 per sweep = 1.
-        assert_eq!(cpu_headroom(8, Some(4.0), 0.75, 2.0), 1);
+    fn parse_iostat_cpu_tolerates_leading_disk_columns() {
+        // Without `-n 0`, disk columns precede the CPU columns. `id` is still the
+        // fourth-from-last field, so parsing from the right is disk-count-agnostic.
+        let out = "              disk0       cpu    load average\n    \
+                   KB/t  tps  MB/s  us sy id   1m   5m   15m\n   \
+                   13.45 4312 56.62   8  9 83  2.99 4.02 4.66\n   \
+                   45.53  857 38.09   5  2 93  3.07 4.02 4.66\n";
+        let idle = parse_iostat_cpu(out).unwrap();
+        assert!((idle - 0.93).abs() < 1e-9, "got {idle}");
     }
 
     #[test]
-    fn cpu_headroom_floors_at_one_when_load_exceeds_capacity() {
-        // Host already saturated (load 20 on an 8-core/75% = 6.0 capacity
-        // host) -> available would go negative, clamped to 0, but the term
-        // itself floors at 1 (soft backoff, never a hard halt).
-        assert_eq!(cpu_headroom(8, Some(20.0), 0.75, 2.0), 1);
+    fn parse_iostat_cpu_malformed_is_none() {
+        assert_eq!(parse_iostat_cpu(""), None);
+        assert_eq!(
+            parse_iostat_cpu("cpu load average\nus sy id 1m 5m 15m\n"),
+            None,
+            "no data lines"
+        );
+        // Only one data line (no delta line to use).
+        assert_eq!(parse_iostat_cpu("us sy id 1m 5m 15m\n8 9 83 3.0 4.0 4.6\n"), None);
+    }
+
+    // ------------------------------------------------------------------
+    // cpu_headroom — pure math (signature: ncpu, idle, loadavg, target, est)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn cpu_headroom_static_capacity_when_no_signal_at_all() {
+        // 8 cores, 75% target, no idle + no load reading -> capacity 6.0 / 2.0
+        // cores per sweep = 3.
+        assert_eq!(cpu_headroom(8, None, None, 0.75, 2.0), 3);
+    }
+
+    #[test]
+    fn cpu_headroom_subtracts_current_load_when_no_idle_measurement() {
+        // 8 cores, 75% target -> capacity 6.0. No idle measurement; load 4.0 in
+        // use -> 2.0 available / 2.0 per sweep = 1 (the #3978 fallback path).
+        assert_eq!(cpu_headroom(8, None, Some(4.0), 0.75, 2.0), 1);
+    }
+
+    #[test]
+    fn cpu_headroom_prefers_measured_idle_over_loadavg() {
+        // The #4031 core: 28 cores, 75% target -> capacity 21.0. 85% idle means
+        // consumed = 28 × 0.15 = 4.2 cores; loadavg reads an inflated 6.0. The
+        // term must reflect the idle reading (21 - 4.2 = 16.8 / 2.0 = 8), NOT the
+        // load reading (21 - 6.0 = 15.0 / 2.0 = 7).
+        assert_eq!(cpu_headroom(28, Some(0.85), Some(6.0), 0.75, 2.0), 8);
+        // And it must ignore loadavg entirely when idle is present.
+        assert_eq!(
+            cpu_headroom(28, Some(0.85), None, 0.75, 2.0),
+            cpu_headroom(28, Some(0.85), Some(999.0), 0.75, 2.0),
+            "loadavg must not influence the term once a measured idle exists"
+        );
+    }
+
+    #[test]
+    fn cpu_headroom_floors_at_one_under_a_saturated_idle_reading() {
+        // 0% idle on an 8-core/75% host -> consumed 8.0 > capacity 6.0 ->
+        // available clamps to 0, but the term floors at 1 (soft backoff).
+        assert_eq!(cpu_headroom(8, Some(0.0), None, 0.75, 2.0), 1);
+        // Same floor via the loadavg path when load exceeds capacity.
+        assert_eq!(cpu_headroom(8, None, Some(20.0), 0.75, 2.0), 1);
     }
 
     #[test]
     fn cpu_headroom_scales_with_more_cores() {
-        // 32 cores, 75% target, no load -> 24.0 / 2.0 = 12.
-        assert_eq!(cpu_headroom(32, None, 0.75, 2.0), 12);
+        // 32 cores, 75% target, no signal -> 24.0 / 2.0 = 12.
+        assert_eq!(cpu_headroom(32, None, None, 0.75, 2.0), 12);
     }
 
     #[test]
     fn cpu_headroom_never_zero_even_on_a_single_core_host() {
         // 1 core, 75% target -> capacity 0.75, / 2.0 per sweep = 0.375 ->
-        // floors to 0 mathematically, but the `max(1.0)` policy floor kicks
-        // in.
-        assert_eq!(cpu_headroom(1, None, 0.75, 2.0), 1);
+        // floors to 0 mathematically, but the `max(1.0)` policy floor kicks in.
+        assert_eq!(cpu_headroom(1, None, None, 0.75, 2.0), 1);
     }
 
     #[test]
     fn cpu_headroom_est_cores_per_sweep_scales_the_denominator() {
         // 16 cores, 100% target -> capacity 16.0. A heavier 4.0-cores-per-
         // sweep estimate -> 4.
-        assert_eq!(cpu_headroom(16, None, 1.0, 4.0), 4);
+        assert_eq!(cpu_headroom(16, None, None, 1.0, 4.0), 4);
+    }
+
+    #[test]
+    fn cpu_headroom_idle_fraction_is_clamped() {
+        // A nonsense idle fraction > 1 or < 0 can't push consumed negative /
+        // above ncpu enough to break the term (defensive clamp).
+        assert_eq!(cpu_headroom(8, Some(1.5), None, 0.75, 2.0), 3, "idle>1 clamps to full idle");
+        assert_eq!(cpu_headroom(8, Some(-0.5), None, 0.75, 2.0), 1, "idle<0 clamps to fully busy");
     }
 
     // ------------------------------------------------------------------

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -270,6 +270,13 @@ async fn handle_client(
         // filesystem reads for the dynamic-cap inputs); per-token usage is left
         // to the CLI (a slow network probe) so this handler never blocks.
         if let Request::DaemonStatus = request {
+            // Pre-warm the memoized CPU idle-fraction sample off the runtime
+            // (#4031): the macOS `iostat` read sleeps ~1s, so it must never run
+            // inline on a tokio worker. `build_daemon_status` then reads the
+            // freshly-cached value without blocking. A memoized-fresh sample
+            // (within the TTL) makes this a no-op. `spawn_blocking` join errors
+            // are non-fatal — the status falls back to the last cached value.
+            let _ = tokio::task::spawn_blocking(crate::cpu_headroom::refresh_cpu_util_cache).await;
             let report = build_daemon_status(&workspace_pool, &health_states, &fallback_root);
             let response = Response::DaemonStatus(report);
             let response_json = serde_json::to_string(&response)?;
@@ -521,16 +528,15 @@ pub fn build_daemon_status(
     let workspace_root = fallback_root;
     let token_pool_size = crate::tokens::token_pool_size(workspace_root);
     let disk_headroom = crate::disk_headroom::disk_headroom_limit(workspace_root);
-    // CPU/load headroom (#3978) — a host-level resource (not per-repo), read
-    // fresh on every status request just like disk headroom.
-    let logical_cpus = crate::cpu_headroom::logical_cpu_count();
-    let loadavg_1m = crate::cpu_headroom::read_loadavg_1m();
-    let cpu_headroom = crate::cpu_headroom::cpu_headroom(
-        logical_cpus,
-        loadavg_1m,
-        crate::cpu_headroom::utilization_target(),
-        crate::cpu_headroom::est_cores_per_sweep(),
-    );
+    // CPU headroom (#3978, measured-idle signal #4031) — a host-level resource
+    // (not per-repo). The snapshot reads the memoized idle fraction (never
+    // blocks; the caller pre-warms it via `spawn_blocking(refresh_cpu_util_cache)`
+    // before invoking `build_daemon_status`) plus a fast fresh loadavg read.
+    let cpu_snapshot = crate::cpu_headroom::cpu_headroom_snapshot();
+    let logical_cpus = cpu_snapshot.logical_cpus;
+    let loadavg_1m = cpu_snapshot.loadavg_1m;
+    let cpu_idle_fraction = cpu_snapshot.idle_fraction;
+    let cpu_headroom = cpu_snapshot.cpu_headroom;
     let wf_config = crate::work_finder::read_work_finder_config(workspace_root);
     let configured_max = crate::work_finder::resolve_max_concurrent_with_config(&wf_config);
     let per_token_concurrency = crate::work_finder::resolve_per_token_concurrency(&wf_config);
@@ -555,6 +561,11 @@ pub fn build_daemon_status(
     let token_bound = token_axis_effective <= disk_headroom
         && token_axis_effective <= cpu_headroom
         && token_axis_effective <= configured_max;
+    // "Currently binding" vs "smallest ceiling" (#4031): the dynamic cap is the
+    // minimum of several ceilings, but a ceiling only *binds* once in-flight
+    // occupancy reaches it. Below the cap the limiter is work availability, not
+    // any resource term — so gate the token-bound diagnosis on real occupancy.
+    let capacity_bound = in_flight.len() >= dynamic_cap;
     let capacity = crate::types::CapacityReport {
         ranking_present: ranking.is_some(),
         total_accounts: ranking.as_ref().map_or(token_pool_size, |r| r.total),
@@ -573,6 +584,8 @@ pub fn build_daemon_status(
         cpu_headroom,
         logical_cpus,
         loadavg_1m,
+        cpu_idle_fraction,
+        capacity_bound,
         configured_max,
         per_token_concurrency,
         dynamic_cap,
@@ -2658,6 +2671,8 @@ exit 0
             cpu_headroom: 6,
             logical_cpus: 8,
             loadavg_1m: Some(1.25),
+            cpu_idle_fraction: Some(0.90),
+            capacity_bound: false,
             configured_max: 5,
             per_token_concurrency: 2,
             dynamic_cap: 3,
@@ -2696,6 +2711,8 @@ exit 0
                 assert_eq!(r.cpu_headroom, 6);
                 assert_eq!(r.logical_cpus, 8);
                 assert_eq!(r.loadavg_1m, Some(1.25));
+                assert_eq!(r.cpu_idle_fraction, Some(0.90));
+                assert!(!r.capacity_bound);
                 assert_eq!(r.configured_max, 5);
                 assert_eq!(r.dynamic_cap, 3);
                 assert!(r.main_health_gate_halted);
@@ -2751,6 +2768,76 @@ exit 0
             report.main_health_gate_verdict_at, None,
             "absent main_health_gate_verdict_at (#4012) defaults to None (reads as pending)"
         );
+        // Absent pre-#4031 fields default rather than failing to parse: no
+        // measured idle fraction, and "not capacity-bound".
+        assert_eq!(report.cpu_idle_fraction, None);
+        assert!(!report.capacity_bound);
+    }
+
+    /// `build_daemon_status` sets `capacity_bound` only when in-flight occupancy
+    /// has actually reached the dynamic cap (#4031) — the "currently binding" vs
+    /// "smallest ceiling" distinction. With a real token pool (cap > 0) and no
+    /// in-flight sweeps, the cap is a ceiling but is NOT binding.
+    #[test]
+    #[serial_test::serial]
+    fn test_build_daemon_status_capacity_bound_tracks_occupancy() {
+        use crate::main_health_gate::WorkspaceHealthStates;
+        use crate::workspace_registry::REGISTRY_PATH_ENV;
+
+        let (sr, dir, _rec) = setup_sweep_registry_in_tempdir();
+        let root = dir.path().to_path_buf();
+        let empty_reg = dir.path().join("no-such-workspaces.json");
+        std::env::set_var(REGISTRY_PATH_ENV, &empty_reg);
+        let prev_shared = std::env::var("LOOM_SHARED_TOKENS_DIR").ok();
+        std::env::set_var("LOOM_SHARED_TOKENS_DIR", "");
+
+        // Provision a two-token pool so the dynamic cap is > 0 (a real ceiling).
+        let tokens_dir = root.join(".loom").join("tokens");
+        std::fs::create_dir_all(&tokens_dir).unwrap();
+        std::fs::write(tokens_dir.join("acct-a.token"), "sk-ant-oat01-a").unwrap();
+        std::fs::write(tokens_dir.join("acct-b.token"), "sk-ant-oat01-b").unwrap();
+
+        let pool = Arc::new(WorkspacePool::new(Arc::new(EventBus::new()), test_runtime_handle()));
+        pool.seed(root.clone(), sr.clone());
+        let health = WorkspaceHealthStates::new();
+
+        // No sweeps in flight, cap > 0 ⇒ the cap is a ceiling but NOT binding.
+        let report = build_daemon_status(&pool, &health, &root);
+        assert!(report.dynamic_cap > 0, "two tokens should yield a positive cap");
+        assert!(report.in_flight.is_empty());
+        assert!(
+            !report.capacity_bound,
+            "0 in-flight against cap {} must not be capacity-bound",
+            report.dynamic_cap
+        );
+
+        // Fill the cap: dispatch sweeps until in-flight reaches the cap.
+        let cap = report.dynamic_cap;
+        {
+            let mut reg = sr.lock().unwrap();
+            for i in 0..cap {
+                reg.dispatch(
+                    &crate::types::SweepKind::Issue(4031 + i as u32),
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+                .expect("dispatch");
+            }
+        }
+        let report = build_daemon_status(&pool, &health, &root);
+        assert_eq!(report.in_flight.len(), cap);
+        assert!(
+            report.capacity_bound,
+            "{cap} in-flight against cap {cap} must be capacity-bound",
+        );
+
+        if let Some(v) = prev_shared {
+            std::env::set_var("LOOM_SHARED_TOKENS_DIR", v);
+        } else {
+            std::env::remove_var("LOOM_SHARED_TOKENS_DIR");
+        }
     }
 
     /// `build_daemon_status` reflects the per-repo main-health halt flag and

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -1888,15 +1888,23 @@ fn print_status_json(
     let combined = serde_json::json!({
         "in_flight_count": report.in_flight.len(),
         "in_flight": report.in_flight,
+        // "Currently binding" vs "smallest ceiling" (#4031): the cap only binds
+        // once in-flight reaches it. `false` ⇒ the limiter is work availability,
+        // not any resource term, so scripted consumers don't misread the
+        // token/CPU ceiling as a bottleneck at low occupancy.
+        "capacity_bound": report.capacity_bound,
         "dynamic_cap": {
             "token_pool_size": report.token_pool_size,
             "disk_headroom": report.disk_headroom,
-            // CPU/load headroom term (#3978) — see the field docs on
-            // `DaemonStatusReport::cpu_headroom` for the pre-#3978 `0` ⇒
-            // "field absent" wire-compat convention.
+            // CPU headroom term (#3978; measured-idle signal #4031) — see the
+            // field docs on `DaemonStatusReport::cpu_headroom` for the pre-#3978
+            // `0` ⇒ "field absent" wire-compat convention.
             "cpu_headroom": report.cpu_headroom,
             "logical_cpus": report.logical_cpus,
             "loadavg_1m": report.loadavg_1m,
+            // Measured CPU idle fraction (#4031), the signal that replaced
+            // loadavg as the source of consumed cores. `null` until sampled.
+            "cpu_idle_fraction": report.cpu_idle_fraction,
             "configured_max": report.configured_max,
             "per_token_concurrency": report.per_token_concurrency.max(1),
             "token_axis_effective": rc.token_axis_limit.saturating_mul(report.per_token_concurrency.max(1)),
@@ -2159,26 +2167,45 @@ fn print_status_human(
         report.cpu_headroom,
         report.configured_max
     );
-    // CPU/load headroom detail (#3978 AC4: "status shows current
-    // loadavg/CPU headroom next to disk headroom"). `cpu_headroom == 0` with
-    // `logical_cpus == 0` means an older daemon (pre-#3978) never sent these
-    // fields — nothing to show.
+    // CPU headroom detail (#3978 AC4; measured-idle signal #4031). The signal
+    // chain is measured idle → loadavg → static capacity, so the line names
+    // which signal actually fed the term. `logical_cpus == 0` means an older
+    // daemon (pre-#3978) never sent these fields — nothing to show.
     if report.logical_cpus > 0 {
-        match report.loadavg_1m {
-            Some(load) => println!(
-                "  cpu headroom: {} concurrent-sweep slot(s) ({} logical cores, 1m loadavg {load:.2})",
-                report.cpu_headroom, report.logical_cpus
+        let basis = match (report.cpu_idle_fraction, report.loadavg_1m) {
+            // Preferred: measured CPU consumption (#4031). Show consumed cores so
+            // the operator can see the term is tracking real usage, not loadavg.
+            (Some(idle), _) => {
+                let consumed = report.logical_cpus as f64 * (1.0 - idle.clamp(0.0, 1.0));
+                format!(
+                    "{} logical cores, {:.0}% idle measured (≈{:.1} cores consumed)",
+                    report.logical_cpus,
+                    idle * 100.0,
+                    consumed
+                )
+            }
+            // Fallback: 1-minute load average (#3978 behavior) until an idle
+            // sample exists (e.g. the first Linux cross-tick delta not yet taken).
+            (None, Some(load)) => format!(
+                "{} logical cores, 1m loadavg {load:.2} (no idle sample yet — loadavg fallback)",
+                report.logical_cpus
             ),
-            None => println!(
-                "  cpu headroom: {} concurrent-sweep slot(s) ({} logical cores, loadavg \
-                 unavailable on this platform — static capacity only)",
-                report.cpu_headroom, report.logical_cpus
+            // Static capacity only: no CPU signal at all on this platform.
+            (None, None) => format!(
+                "{} logical cores, no CPU signal on this platform — static capacity only",
+                report.logical_cpus
             ),
-        }
+        };
+        println!("  cpu headroom: {} concurrent-sweep slot(s) ({basis})", report.cpu_headroom);
     }
 
     // Token-capacity backpressure section (#3902, source-unified in #3936).
     println!("\nToken capacity:");
+    // "Currently binding" vs "smallest ceiling" (#4031): the dynamic cap is the
+    // minimum of several ceilings, but a ceiling only *binds* once in-flight
+    // occupancy reaches it. Below the cap the limiter is work availability, not
+    // any resource term — so the token-bound diagnosis below is gated on this.
+    let capacity_bound = report.in_flight.len() >= rc.effective_cap;
     if rc.ranking_present {
         let src = if rc.source == "probe" {
             "live probe: loom-tokens check --json"
@@ -2202,7 +2229,18 @@ fn print_status_human(
                 report.capacity.healthy_accounts
             );
         }
-        if rc.token_bound {
+        if !capacity_bound {
+            // In-flight is below the cap: nothing is binding. Naming tokens (or
+            // any resource) as "the bottleneck" here is the #4031 defect — at,
+            // say, 1 in-flight against a cap of 7 the limiter is simply how much
+            // ready work exists. Suppress the token-bound diagnosis.
+            println!(
+                "  not capacity-bound ({} in flight, cap {} — the limiter is work availability, \
+                 not tokens/disk/CPU)",
+                report.in_flight.len(),
+                rc.effective_cap
+            );
+        } else if rc.token_bound {
             if rc.healthy == 0 {
                 println!(
                     "  token-bound: NO healthy accounts — new dispatch deferred until capacity \
@@ -2224,6 +2262,14 @@ fn print_status_human(
              health basis)",
             report.token_pool_size
         );
+        if !capacity_bound {
+            println!(
+                "  not capacity-bound ({} in flight, cap {} — the limiter is work availability, \
+                 not tokens/disk/CPU)",
+                report.in_flight.len(),
+                rc.effective_cap
+            );
+        }
     }
 
     // "Halted" (a completed gate run found main verified-red) and "not

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -741,6 +741,27 @@ pub struct DaemonStatusReport {
     /// pre-#3978 wire data compatible.
     #[serde(default)]
     pub loadavg_1m: Option<f64>,
+    /// The measured CPU idle fraction (`0.0..=1.0`) feeding [`Self::cpu_headroom`]
+    /// (#4031), via [`crate::cpu_headroom::cached_cpu_idle_fraction`]. This is the
+    /// signal that replaced the 1-minute load average as the source of "consumed
+    /// cores" — load average overstated consumption by ~1.5× on macOS because it
+    /// counts network-I/O-blocked `claude` sessions that consume no core. `None`
+    /// when no idle sample has been taken yet (the term then falls back to
+    /// [`Self::loadavg_1m`], then to static capacity — see the
+    /// [`crate::cpu_headroom`] module docs). `#[serde(default)]` keeps pre-#4031
+    /// wire data / older clients compatible.
+    #[serde(default)]
+    pub cpu_idle_fraction: Option<f64>,
+    /// Whether in-flight occupancy has actually reached the dynamic cap
+    /// (`in_flight.len() >= dynamic_cap`) — i.e. the cap is *currently binding*,
+    /// not merely the smallest ceiling (#4031). When `false`, no resource term
+    /// (tokens/disk/CPU) is the limiter — the limiter is **work availability**,
+    /// and the status renderer suppresses the "token-bound" diagnosis rather than
+    /// misreporting a bottleneck at, say, 1 in-flight against a cap of 7.
+    /// `#[serde(default)]` keeps pre-#4031 wire data / older clients compatible
+    /// (an absent field parses as `false` — "not capacity-bound").
+    #[serde(default)]
+    pub capacity_bound: bool,
     /// Dynamic-cap input 4: the configured operator ceiling
     /// (`autonomous.workFinder.maxConcurrent` / `LOOM_WORK_FINDER_MAX_CONCURRENT`).
     pub configured_max: usize,

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -965,8 +965,14 @@ where
             let ranking = capacity::read_ranking(&workspace_root);
             let token_limit = ranking.as_ref().map_or(pool_size, |r| r.available);
             let disk = disk_headroom_limit(&workspace_root);
-            // CPU/load headroom (#3978): the term the pre-#3978 formula lacked.
-            let cpu = cpu_headroom_limit();
+            // CPU headroom (#3978; measured-idle signal #4031): the term the
+            // pre-#3978 formula lacked. `cpu_headroom_limit()` refreshes the
+            // memoized idle sample, which sleeps ~1s on macOS (`iostat`), so it
+            // is moved off the runtime via `spawn_blocking`; a join error falls
+            // back to the policy floor of 1 (soft backoff, never a hard halt).
+            let cpu = tokio::task::spawn_blocking(cpu_headroom_limit)
+                .await
+                .unwrap_or(1);
             let max_concurrent = resolve_dynamic_max_concurrent(
                 token_limit,
                 per_token_concurrency,
@@ -1098,9 +1104,14 @@ pub fn spawn_multi_work_finder_task(
             let ranking = capacity::read_ranking(&fallback_root);
             let token_limit = ranking.as_ref().map_or(pool_size, |r| r.available);
             let disk = disk_headroom_limit(&fallback_root);
-            // CPU/load headroom (#3978) — also a machine-level resource, probed
-            // once per tick and shared across every workspace.
-            let cpu = cpu_headroom_limit();
+            // CPU headroom (#3978; measured-idle signal #4031) — also a
+            // machine-level resource, probed once per tick and shared across
+            // every workspace. Moved off the runtime via `spawn_blocking` since
+            // the macOS `iostat` refresh sleeps ~1s; a join error falls back to
+            // the policy floor of 1.
+            let cpu = tokio::task::spawn_blocking(cpu_headroom_limit)
+                .await
+                .unwrap_or(1);
             let max_concurrent = resolve_dynamic_max_concurrent(
                 token_limit,
                 per_token_concurrency,


### PR DESCRIPTION
Closes #4031

## Problem

The #3978 CPU-headroom term used the **1-minute load average** as a stand-in for consumed cores. Load average counts threads in the runnable **and** uninterruptible-sleep states, and this daemon's workload is dominated by `claude` sessions **blocked on network I/O** — which inflate load without consuming a core. This pointed the dispatch feedback loop the wrong way: more concurrent sweeps → more blocked `claude` → higher load average → *lower* concurrency cap, even while the CPU sat idle.

## What changed

### Primary (signal) fix — `cpu_headroom.rs`
- `cpu_headroom()` now derives `consumed_cores = ncpu × (1 − idle_fraction)` from a **measured idle fraction**, per-platform:
  - **Linux**: cross-tick delta of `/proc/stat`'s aggregate `cpu` line (`idle+iowait` vs total) — the previous cumulative sample is memoized and deltaed across ticks, so **nothing sleeps**.
  - **macOS**: `iostat -c 2 -w 1 -n 0`, using the **second** (1-second-delta) data line, not the since-boot first line.
- **Fail-open chain extended, not replaced**: `measured idle → loadavg (#3978 behavior) → static capacity`. Term stays floored at `1` (#3902/#3978 policy — CPU is a soft backoff, never a hard gate).
- **No tokio-runtime blocking**: the ~1s macOS `iostat` read is moved to `spawn_blocking` at both work-finder call sites and **memoized behind a ~10s TTL** (`CPU_UTIL_MEMO_TTL`) shared with the synchronous `ipc.rs` status path (pre-warmed off-runtime before the status report is built).
- Pure `parse_proc_stat_cpu` / `parse_iostat_cpu` split from I/O, with fixture tests — including a macOS case that **fails if the since-boot first line is used** instead of the delta line.
- `est_cores_per_sweep` default is **unchanged**; a reproducible calibration recipe is committed at `docs/measure-est-cores-per-sweep.md`.

### Secondary (display) fix — same "smallest ceiling vs currently binding" defect
- New `capacity_bound` (`in_flight.len() >= dynamic_cap`) gates the bottleneck diagnosis. Below the cap, `loom-daemon status` prints `not capacity-bound (N in flight, cap M — the limiter is work availability, not tokens/disk/CPU)` and **suppresses** the `token-bound:` line. The `= min(...)` ceiling breakdown is untouched. Same distinction in JSON status.

### Wire compat
- New `DaemonStatusReport` fields (`cpu_idle_fraction: Option<f64>`, `capacity_bound: bool`) are `#[serde(default)]`, matching the existing `cpu_headroom`/`logical_cpus`/`loadavg_1m` convention. `resolve_dynamic_max_concurrent`'s interface is unchanged.

### Docs
- `.loom/docs/daemon-reference.md` §"Dynamic concurrency scaling" formula row + prose updated (was doc fiction after the signal change); added the calibration-recipe pointer and the "currently binding vs smallest ceiling" note.

## Manual verification (this host, 28 logical cores)

Captured `iostat` (delta line) vs `sysctl -n vm.loadavg` at the same moment — a live reproduction of the exact defect:

```
ncpu=28
sysctl -n vm.loadavg:  { 7.24 6.11 5.50 }        # load1m = 7.24
iostat -c 2 -w 1 -n 0:
  us sy id ...
   8  9 83  ...   <- since-boot line (ignored)
   1  2 97  ...   <- 1s delta line: 97% idle
```

- **Load average** claims **7.24** cores in use.
- **Measured idle** (97%) → consumed = 28 × 0.03 ≈ **0.84 cores** actually consumed.

With capacity `28 × 0.75 = 21` and `est_cores_per_sweep = 2.0`:
- **Old (loadavg) term**: `floor((21 − 7.24)/2) = 6` slots — throttling a 97%-idle host to 6.
- **New (measured-idle) term**: `floor((21 − 0.84)/2) = 10` slots.

The ~1.5×+ overstatement (here far worse — a burst of network-blocked `claude` sessions) is gone; the term now tracks the idle reading.

## Tests
- `cargo test --workspace` green (the one transient `test_send_input` failure under the full parallel run is an unrelated terminal-PTY timeout — passes in isolation; untouched by this change).
- New/extended: `parse_proc_stat_cpu`, `parse_iostat_cpu` (incl. the second-line adversarial case), measured-idle vs loadavg-fallback vs static-capacity `cpu_headroom` paths, the `max(1.0)` floor, the `capacity_bound` occupancy test, and serde round-trip + older-shaped-payload backward-compat.
- `resolve_dynamic_max_concurrent` tests pass unchanged.

## Scope note
The scope guard suggested deferring the display half past ~400 LOC / 8 files. I included both: the display fix is small, same-file (`main.rs`/`ipc.rs`), and the bulk of the diff is module docs, the daemon-reference update, and tests (which the guard says not to cut) rather than logic. 6 files touched.

Note: `#4032` (exposing these tunables via `autonomous.*` config) edits the same `cpu_headroom.rs` config block — land it after this to avoid a conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)