### PR TITLE
fix(daemon): self-verify rebuild→provision so a roll cannot silently ship nothing

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -1970,6 +1970,35 @@ is installed to the machine-level location via
 convention `loom-daemon-start.sh` already resolves through `command -v
 loom-daemon`.
 
+**Self-verifying rebuild → provision (a roll can never silently ship nothing,
+#4053)**: the rebuild → provision path proves it produced what it claims, so a
+successful-looking run can no longer install a stale binary:
+
+- **Built-commit verification (before provisioning).** After `cargo build
+  --release`, the script asserts the freshly-built binary's embedded commit
+  (parsed from `--version`) equals the source `HEAD` it was built from. On
+  mismatch it **fails loudly and does not provision** — a build that succeeds
+  yet bakes in the wrong commit is a build-system defect (historically a
+  `build.rs` `cargo:rerun-if-changed` watch-set bug that missed HEAD movement),
+  not a compile failure, and retrying cannot fix it. **Exit code `4`**,
+  distinguishable from a compile failure (`1`). The underlying `build.rs`
+  watch set is now correct-by-construction via `git rev-parse --git-path`
+  (resolving `HEAD`, the current branch's ref, and `packed-refs`), so it tracks
+  HEAD movement in the main checkout, a **linked worktree** (`.git` is a file —
+  every Builder's environment), a detached HEAD, and a packed-refs repo alike.
+- **Post-provision verification (after provisioning).** The script then asserts
+  the **destination** binary's `--version` is the expected build — for both the
+  `LOOM_DAEMON_BIN` override path and the machine-level
+  `provision_machine_daemon` path. This is the direct answer to "reports success
+  while shipping nothing": the `--version`-equality short-circuit in
+  `provision-daemon.sh` is retained (it is correct once the rebuild is correct)
+  but can no longer produce a silent no-op on a real roll — `provision_machine_daemon`
+  exports the destination it wrote to (`PROVISIONED_DAEMON_BIN`, set even on the
+  short-circuit path) so the caller can verify it. A destination that is not the
+  expected build, or a provisioning step that reports failure, now **exits
+  non-zero** (`5` for a destination mismatch) instead of the pre-#4053 soft
+  warn that left the exit code at `0`.
+
 **Read-only "update available" surface (`loom-daemon --status`)**: separately
 from the update script, `loom-daemon --status` / `--status --json` now prints
 a purely local, read-only self-update line — the same built-commit-vs-source-HEAD

--- a/defaults/scripts/cli/loom-daemon-update.sh
+++ b/defaults/scripts/cli/loom-daemon-update.sh
@@ -53,6 +53,15 @@
 #   0  up to date (no-op) OR rebuild+provision+restart succeeded
 #   1  usage error / not a source checkout / build or provision failure
 #   3  (--check only) update available
+#   4  build verification FAILED: the freshly-built binary's embedded commit
+#      does not match the source HEAD it was built from. This is a BUILD-SYSTEM
+#      defect (a stale baked-in commit — e.g. a build.rs watch-set bug), NOT a
+#      compile failure, and retrying cannot fix it; the script refuses to
+#      provision the mis-stamped binary (#4053).
+#   5  post-provision verification FAILED: the destination binary after a
+#      claimed-successful provision is not the expected build (a silent no-op
+#      roll — "reports success while shipping nothing"). Distinct from both a
+#      compile failure and a provisioning soft-failure (#4053).
 #
 # See also: loom-daemon-start.sh (writes .loom/.daemon.flags), loom-daemon-stop.sh
 # (SIGTERM -> grace -> SIGKILL; in-flight sweeps survive by design — this
@@ -120,6 +129,35 @@ locate_daemon_bin() {
 # "loom-daemon 0.15.0 (commit ab12cd3, built 2026-07-26T12:00:00Z)" -> ab12cd3
 extract_commit() {
     echo "$1" | grep -oE 'commit [0-9a-f]+' | head -n1 | awk '{print $2}'
+}
+
+# verify_destination_binary <dest_path> — assert the provisioned binary at
+# <dest_path> embeds the expected source-HEAD commit (#4053). This is the
+# direct answer to "reports success while shipping nothing": after a provision
+# step returns success, the destination must actually be the freshly-built
+# binary. Exits 5 on mismatch — distinguishable from a compile failure (exit 1)
+# and from a provisioning soft-failure. Skipped only when the source HEAD is
+# unknown (a tarball build with no .git), where there is nothing to compare
+# against. Relies on $SOURCE_COMMIT being resolved (it is, before any build).
+verify_destination_binary() {
+    local dest="$1"
+    if [[ "$SOURCE_COMMIT" == "unknown" ]]; then
+        warn "Source HEAD is unknown (no .git?) — skipping post-provision verification."
+        return 0
+    fi
+    if [[ -z "$dest" || ! -x "$dest" ]]; then
+        err "Post-provision verification FAILED: provisioning reported success but no executable binary was found at the destination ('${dest:-<unknown>}')."
+        exit 5
+    fi
+    local dest_version dest_commit
+    dest_version=$("$dest" --version 2>/dev/null || true)
+    dest_commit=$(extract_commit "$dest_version")
+    if [[ "$dest_commit" != "$SOURCE_COMMIT" ]]; then
+        err "Post-provision verification FAILED: destination binary at $dest embeds commit '${dest_commit:-<none>}' but the expected source HEAD is '$SOURCE_COMMIT'."
+        err "Provisioning reported success yet the destination is NOT the freshly-built binary — a silent no-op roll. This is distinct from a compile failure and from a provisioning soft-failure; refusing to report success."
+        exit 5
+    fi
+    ok "Post-provision verification: destination binary at $dest embeds source HEAD commit ($dest_commit)."
 }
 
 # ---------- args ----------
@@ -301,6 +339,31 @@ if [[ -z "$NEW_BIN" ]]; then
 fi
 ok "Build succeeded: $NEW_BIN"
 
+# ---------- verify the freshly-built binary embeds the expected commit ----------
+# A rebuild can succeed (exit 0) yet bake in a STALE LOOM_DAEMON_GIT_COMMIT — the
+# exact hazard this script exists to close (a build.rs watch-set bug that lets
+# `--version` report the old commit). Provisioning such a binary would "report
+# success while shipping nothing" and, worse, turn any auto-update loop that
+# trusts the baked commit into an infinite rebuild-still-stale retry. So assert
+# the built commit == source HEAD BEFORE provisioning. On mismatch, fail loudly
+# and do NOT provision: this is a build-system defect that retrying cannot fix,
+# distinct from the compile failure handled above (#4053).
+BUILT_VERSION_OUTPUT=$("$NEW_BIN" --version 2>/dev/null || true)
+BUILT_COMMIT=$(extract_commit "$BUILT_VERSION_OUTPUT")
+if [[ "$SOURCE_COMMIT" == "unknown" ]]; then
+    warn "Source HEAD is unknown (no .git?) — skipping built-commit verification (tarball build)."
+elif [[ -z "$BUILT_COMMIT" ]]; then
+    err "Build verification FAILED: the freshly-built binary reports no commit in --version output ('${BUILT_VERSION_OUTPUT:-<empty>}')."
+    err "Refusing to provision a binary that cannot prove what it was built from. This is a build-system defect, not a compile failure."
+    exit 4
+elif [[ "$BUILT_COMMIT" != "$SOURCE_COMMIT" ]]; then
+    err "Build verification FAILED: the freshly-built binary embeds commit '$BUILT_COMMIT' but source HEAD is '$SOURCE_COMMIT'."
+    err "A successful build produced a binary stamped with the WRONG commit (a stale baked-in commit — e.g. a build.rs watch-set bug). Retrying will not fix it; refusing to provision (#4053)."
+    exit 4
+else
+    ok "Build verification: freshly-built binary embeds source HEAD commit ($BUILT_COMMIT)."
+fi
+
 # ---------- provision ----------
 if [[ -n "${LOOM_DAEMON_BIN:-}" ]]; then
     # Explicit operator override — provision directly to that exact path
@@ -313,15 +376,27 @@ if [[ -n "${LOOM_DAEMON_BIN:-}" ]]; then
         err "Failed to provision to LOOM_DAEMON_BIN=$dest"
         exit 1
     fi
+    # This override path has the same "shipped nothing" hazard as the
+    # machine-level path — verify the destination is the freshly-built binary.
+    verify_destination_binary "$dest"
 else
     # shellcheck disable=SC1091
     if [[ -r "$REPO_ROOT/scripts/install/provision-daemon.sh" ]]; then
         source "$REPO_ROOT/scripts/install/provision-daemon.sh"
     fi
     if declare -F provision_machine_daemon >/dev/null 2>&1; then
+        # Hard-fail on provisioning failure: a soft warn here (the pre-#4053
+        # behavior) left the exit code at 0, which is exactly the "reports
+        # success while shipping nothing" defect this issue closes.
         if ! provision_machine_daemon "$NEW_BIN"; then
-            warn "Machine-level provisioning reported an issue (see above); the freshly-built binary is still available at $NEW_BIN"
+            err "Machine-level provisioning FAILED (see above). Refusing to report success; the freshly-built binary is at $NEW_BIN — set LOOM_DAEMON_BIN=$NEW_BIN to use it directly."
+            exit 1
         fi
+        # provision_machine_daemon exports the destination it wrote to (even on
+        # the version-equality short-circuit) — verify that destination is the
+        # expected build so the short-circuit can no longer produce a silent
+        # no-op on a real roll (#4053).
+        verify_destination_binary "${PROVISIONED_DAEMON_BIN:-}"
     else
         warn "scripts/install/provision-daemon.sh not found/sourceable — skipping machine-level provisioning."
         warn "Freshly-built binary: $NEW_BIN (set LOOM_DAEMON_BIN=$NEW_BIN to use it directly)"

--- a/defaults/scripts/tests/test-build-rs-watchset.sh
+++ b/defaults/scripts/tests/test-build-rs-watchset.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# test-build-rs-watchset.sh — Regression test for loom-daemon/build.rs's
+# `cargo:rerun-if-changed` watch set (Issue #4053).
+#
+# The baked LOOM_DAEMON_GIT_COMMIT (surfaced in `loom-daemon --version`) must be
+# re-derived whenever HEAD moves, or a rebuild silently ships a stale commit and
+# any self-update loop that trusts it becomes an infinite retry. The historical
+# watch set (`../.git/HEAD` + `../.git/index`) did NOT track HEAD movement:
+# `.git/HEAD` is a symbolic ref whose content never changes when the branch
+# advances, and the file that actually moves (`.git/refs/heads/<branch>`, or
+# `.git/packed-refs`) was not watched. In a linked worktree neither `../.git/*`
+# path even resolved.
+#
+# Build scripts are awkward to unit-test, so this shell test compiles a tiny
+# scratch crate whose build.rs is a VERBATIM COPY of the real
+# loom-daemon/build.rs (it uses only std, so it is copy-portable) inside a
+# scratch git repo, then advances the branch with a REF-ONLY move
+# (`git commit-tree` + `git update-ref`, touching neither HEAD nor the index)
+# and asserts the embedded commit changed. It exercises:
+#   - the main checkout (the decisive ref-only-move regression: old code would
+#     NOT re-run build.rs here and the commit would stay stale)
+#   - a linked git worktree, where `.git` is a *file* (every Loom Builder's
+#     actual compile environment)
+#   - a detached HEAD (no symbolic ref — must not error)
+#   - a packed-refs repo (loose ref absent — must still bake the right commit)
+#
+# It is a standalone shell test (NOT run by `cargo test`) because it shells out
+# to `cargo build`; it self-skips (exit 0) when `cargo`/`git` are unavailable.
+#
+# Usage:
+#   ./defaults/scripts/tests/test-build-rs-watchset.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# defaults/scripts/tests -> repo root is three levels up.
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+REAL_BUILD_RS="$REPO_ROOT/loom-daemon/build.rs"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_eq() {
+    local expected="$1" actual="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "${GREEN}✓${NC} $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "${RED}✗${NC} $msg"
+        echo -e "  expected: [$expected]"
+        echo -e "  actual:   [$actual]"
+    fi
+}
+
+assert_ne() {
+    local a="$1" b="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$a" != "$b" ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "${GREEN}✓${NC} $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "${RED}✗${NC} $msg"
+        echo -e "  both were: [$a]"
+    fi
+}
+
+# ---------- preflight / self-skip ----------
+if ! command -v cargo >/dev/null 2>&1 || ! command -v git >/dev/null 2>&1; then
+    echo -e "${YELLOW}SKIP:${NC} cargo/git not available — build.rs watch-set test skipped."
+    exit 0
+fi
+if [[ ! -f "$REAL_BUILD_RS" ]]; then
+    echo -e "${YELLOW}SKIP:${NC} $REAL_BUILD_RS not found — build.rs watch-set test skipped."
+    exit 0
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Scaffold a tiny standalone crate whose build.rs is the real one, and whose
+# main prints the baked commit. `[workspace]` makes it standalone so cargo does
+# not try to attach it to any ambient workspace.
+scaffold_crate() {
+    local dir="$1"
+    mkdir -p "$dir/src"
+    cat > "$dir/Cargo.toml" <<'EOF'
+[package]
+name = "wswatch"
+version = "0.0.0"
+edition = "2021"
+
+[workspace]
+EOF
+    cat > "$dir/src/main.rs" <<'EOF'
+fn main() {
+    println!("{}", env!("LOOM_DAEMON_GIT_COMMIT"));
+}
+EOF
+    cp "$REAL_BUILD_RS" "$dir/build.rs"
+}
+
+# Build the crate at $1 and echo the commit its binary reports.
+build_commit() {
+    local dir="$1"
+    ( cd "$dir" && cargo build --release >/dev/null 2>&1 ) || { echo "BUILD_FAILED"; return 1; }
+    "$dir/target/release/wswatch" 2>/dev/null
+}
+
+# Advance the branch checked out at $1 with a REF-ONLY move: reuse the current
+# tree, create a child commit via commit-tree, and point the branch ref at it
+# via update-ref. This touches neither .git/HEAD (symbolic, unchanged) nor the
+# index — so only the resolved ref file (or packed-refs) moves, which is exactly
+# the movement the old watch set failed to track.
+advance_ref_only() {
+    local dir="$1"
+    local branch tree new_commit
+    branch="$(cd "$dir" && git symbolic-ref -q HEAD)" || return 1
+    tree="$(cd "$dir" && git rev-parse "HEAD^{tree}")"
+    new_commit="$(cd "$dir" && git commit-tree "$tree" -p HEAD -m advance)"
+    (cd "$dir" && git update-ref "$branch" "$new_commit")
+}
+
+# The scratch crate is placed in a SUBDIRECTORY (`loom-daemon/`) of the git repo,
+# exactly mirroring the real layout — this is load-bearing for the test's teeth:
+# with the old `../.git/HEAD`+`../.git/index` watch set, `../.git/*` resolves to
+# the real gitdir (a subdir crate), the watched files do NOT change on a ref-only
+# advance, so the old build.rs would NOT re-run and the baked commit would stay
+# stale — failing subtest 1 below. (If the crate were the repo root, `../.git`
+# would point outside the repo, not exist, and mask the bug via cargo's
+# always-rerun-on-missing-path behavior.)
+git_init_commit() {
+    local repo="$1"
+    ( cd "$repo" && git init -q \
+        && git -c user.email=t@t -c user.name=t add -A \
+        && git -c user.email=t@t -c user.name=t commit -q -m init )
+}
+
+# ============================================================
+# 1. Main checkout: a ref-only advance re-bakes the new commit.
+#    (Old watch set leaves the commit stale here — the teeth.)
+# ============================================================
+MAIN="$WORK/main"
+MAIN_CRATE="$MAIN/loom-daemon"
+scaffold_crate "$MAIN_CRATE"
+git_init_commit "$MAIN"
+C1="$(build_commit "$MAIN_CRATE")"
+HEAD1="$(cd "$MAIN_CRATE" && git rev-parse --short HEAD)"
+assert_eq "$HEAD1" "$C1" "main checkout: initial build bakes in current HEAD"
+
+advance_ref_only "$MAIN_CRATE"
+C2="$(build_commit "$MAIN_CRATE")"
+HEAD2="$(cd "$MAIN_CRATE" && git rev-parse --short HEAD)"
+assert_eq "$HEAD2" "$C2" "main checkout: rebuild after ref-only advance bakes in the NEW HEAD"
+assert_ne "$C1" "$C2" "main checkout: baked commit actually CHANGED after ref-only advance"
+
+# ============================================================
+# 2. Linked worktree (`.git` is a FILE): the same ref-only advance
+#    on the worktree's branch re-bakes. This is the Loom Builder's
+#    real compile environment and the case the old watch set could
+#    not resolve at all.
+# ============================================================
+WT="$WORK/wt"
+WT_CRATE="$WT/loom-daemon"
+( cd "$MAIN" && git worktree add -q -b wt-branch "$WT" >/dev/null 2>&1 )
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ -f "$WT/.git" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} worktree fixture: .git is a file (linked worktree)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} worktree fixture: .git is a file (linked worktree)"
+fi
+WC1="$(build_commit "$WT_CRATE")"
+WHEAD1="$(cd "$WT_CRATE" && git rev-parse --short HEAD)"
+assert_eq "$WHEAD1" "$WC1" "linked worktree: initial build bakes in current HEAD"
+
+advance_ref_only "$WT_CRATE"
+WC2="$(build_commit "$WT_CRATE")"
+WHEAD2="$(cd "$WT_CRATE" && git rev-parse --short HEAD)"
+assert_eq "$WHEAD2" "$WC2" "linked worktree: rebuild after ref-only advance bakes in the NEW HEAD"
+assert_ne "$WC1" "$WC2" "linked worktree: baked commit actually CHANGED after ref-only advance"
+
+# ============================================================
+# 3. Detached HEAD: build.rs must not error and must bake the
+#    correct commit (no symbolic ref to resolve).
+# ============================================================
+DET="$WORK/det"
+DET_CRATE="$DET/loom-daemon"
+scaffold_crate "$DET_CRATE"
+( cd "$DET" && git init -q && git -c user.email=t@t -c user.name=t add -A \
+    && git -c user.email=t@t -c user.name=t commit -q -m init \
+    && git -c user.email=t@t -c user.name=t commit -q --allow-empty -m second )
+DET_SHA="$(cd "$DET_CRATE" && git rev-parse --short HEAD)"
+( cd "$DET" && git checkout -q --detach HEAD )
+DC="$(build_commit "$DET_CRATE")"
+assert_eq "$DET_SHA" "$DC" "detached HEAD: build succeeds and bakes the correct commit"
+
+# ============================================================
+# 4. Packed-refs repo (loose ref absent): build.rs must still bake
+#    the correct commit — packed-refs is in the watch set.
+# ============================================================
+PK="$WORK/pk"
+PK_CRATE="$PK/loom-daemon"
+scaffold_crate "$PK_CRATE"
+( cd "$PK" && git init -q && git -c user.email=t@t -c user.name=t add -A \
+    && git -c user.email=t@t -c user.name=t commit -q -m init \
+    && git pack-refs --all )
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ ! -f "$PK/.git/refs/heads/$(cd "$PK" && git symbolic-ref --short HEAD)" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} packed-refs fixture: loose branch ref is absent (packed)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} packed-refs fixture: loose branch ref is absent (packed)"
+fi
+PC="$(build_commit "$PK_CRATE")"
+PHEAD="$(cd "$PK_CRATE" && git rev-parse --short HEAD)"
+assert_eq "$PHEAD" "$PC" "packed-refs: build bakes the correct commit with only packed-refs present"
+
+# ---------- summary ----------
+echo
+echo "Ran $TESTS_RUN tests: $TESTS_PASSED passed, $TESTS_FAILED failed"
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -264,6 +264,19 @@ else
     echo -e "${RED}✗${NC} LOOM_DAEMON_BIN path was provisioned with the freshly-built binary"
 fi
 
+# Happy-path roll must self-verify both the built binary and the destination
+# (#4053): the short-circuit can no longer produce a silent no-op on a real roll.
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -qi 'Build verification' "$W5/update.log" \
+    && grep -qi 'Post-provision verification' "$W5/update.log"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} happy-path roll self-verifies built commit AND destination binary"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} happy-path roll self-verifies built commit AND destination binary"
+    echo "  update.log: $(cat "$W5/update.log" 2>/dev/null)"
+fi
+
 # Clean up the restarted daemon (find it via the PID file this run wrote).
 if [[ -f "$W5/.loom/.daemon.pid" ]]; then
     kill "$(cat "$W5/.loom/.daemon.pid" 2>/dev/null)" 2>/dev/null || true
@@ -400,6 +413,89 @@ mkdir -p "$W9/.loom"
 ( cd "$W9" && PATH="$TEST_PATH" bash "$UPDATE_SCRIPT" --check >/dev/null 2>&1 )
 rc9=$?
 assert_eq "1" "$rc9" "refuses to run when loom-daemon/Cargo.toml is absent"
+
+# ============================================================
+# 10. Build verification: a freshly-built binary whose embedded
+#     commit does NOT match source HEAD (a stale baked-in commit,
+#     e.g. from a build.rs watch-set bug) -> exit 4 and NO provision.
+#     This is the self-verifying rebuild the whole issue is about:
+#     a successful compile that ships the wrong commit is refused,
+#     distinguishably from a compile failure (#4053).
+# ============================================================
+W10="$BASE_WORKDIR/w10"
+new_fixture "$W10"
+INSTALLED10="$W10/installed/loom-daemon"
+mkdir -p "$W10/installed"
+write_fake_daemon "$INSTALLED10" "deadbee" "$W10/old-marker"   # stale installed
+# The freshly-"built" binary reports a WRONG commit (NOT source HEAD): simulates
+# a build.rs watch-set defect that bakes a stale commit into a successful build.
+NEW_FAKE10="$W10/new-fake-daemon"
+write_fake_daemon "$NEW_FAKE10" "badc0de" "$W10/new-marker"
+out10=$( cd "$W10" && PATH="$TEST_PATH" LOOM_DAEMON_BIN="$INSTALLED10" NEW_FAKE_BIN_SRC="$NEW_FAKE10" \
+    bash "$UPDATE_SCRIPT" 2>&1 )
+rc10=$?
+assert_eq "4" "$rc10" "stale baked-in commit (build-system defect) exits 4"
+TESTS_RUN=$((TESTS_RUN + 1))
+if "$INSTALLED10" --version 2>/dev/null | grep -q "deadbee"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} build-commit mismatch does NOT provision (destination left untouched)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} build-commit mismatch does NOT provision (destination left untouched)"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out10" | grep -qi 'Build verification FAILED'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} build-commit mismatch is reported distinguishably from a compile failure"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} build-commit mismatch is reported distinguishably from a compile failure"
+fi
+
+# ============================================================
+# 11. Post-provision verification: a provision step that reports
+#     SUCCESS but leaves the destination stale (the exact "reports
+#     success while shipping nothing" hazard) -> exit 5. Exercises
+#     the provision_machine_daemon branch via a fake provisioner
+#     that returns 0 and points PROVISIONED_DAEMON_BIN at a stale
+#     binary — proving the short-circuit can no longer silently
+#     no-op a real roll, and that the failure is distinguishable
+#     from the pre-existing soft warn (#4053, findings 3 & 4).
+# ============================================================
+W11="$BASE_WORKDIR/w11"
+new_fixture "$W11"
+HEAD11="$(cd "$W11" && git rev-parse --short HEAD)"
+# The freshly-"built" binary reports the CORRECT source HEAD (passes build
+# verification), so the failure below is unambiguously post-provision.
+NEW_FAKE11="$W11/new-fake-daemon"
+write_fake_daemon "$NEW_FAKE11" "$HEAD11" "$W11/new-marker"
+# A STALE destination binary the fake provisioner will dishonestly point at.
+STALE_DEST11="$W11/staledest/loom-daemon"
+mkdir -p "$W11/staledest"
+write_fake_daemon "$STALE_DEST11" "abc0123" "$W11/stale-marker"
+# Fake provision-daemon.sh: reports success but leaves the destination stale.
+mkdir -p "$W11/scripts/install"
+cat > "$W11/scripts/install/provision-daemon.sh" <<EOF
+provision_machine_daemon() {
+    PROVISIONED_DAEMON_BIN="$STALE_DEST11"
+    return 0
+}
+EOF
+# No LOOM_DAEMON_BIN -> the provision_machine_daemon branch. No resolvable
+# installed binary -> UPDATE_NEEDED is true -> the fake cargo "builds" NEW_FAKE11.
+out11=$( cd "$W11" && PATH="$TEST_PATH" NEW_FAKE_BIN_SRC="$NEW_FAKE11" \
+    bash "$UPDATE_SCRIPT" 2>&1 )
+rc11=$?
+assert_eq "5" "$rc11" "provision reports success but ships a stale destination -> exit 5"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out11" | grep -qi 'Post-provision verification FAILED'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} silent no-op roll is caught and reported distinguishably"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} silent no-op roll is caught and reported distinguishably"
+    echo "  output: $out11"
+fi
 
 # ---------- summary ----------
 echo

--- a/loom-daemon/build.rs
+++ b/loom-daemon/build.rs
@@ -18,14 +18,104 @@
 //! building from a tarball release) or `date` — we never want missing
 //! tooling to break the build. The fallback is loud enough to be obvious
 //! in operator output (e.g., `loom-daemon 0.10.0 (commit unknown)`).
+//!
+//! ## Watch-set correctness (issue #4053)
+//!
+//! The baked commit must be re-derived whenever `HEAD` moves, or `--version`
+//! silently ships a stale commit and any self-update loop that trusts it
+//! (`self_update::check()`, `loom-daemon-update.sh`) becomes an infinite
+//! detect-stale → rebuild → still-stale retry. The naive
+//! `cargo:rerun-if-changed` set — `../.git/HEAD` + `../.git/index` — does NOT
+//! track HEAD movement: `.git/HEAD` is a *symbolic* ref whose content
+//! (`ref: refs/heads/main`) never changes when the branch advances, and the
+//! file that actually moves (`.git/refs/heads/<branch>`, or `.git/packed-refs`
+//! after a `git gc`) was not watched at all. Worse, in a **linked worktree**
+//! (`.git` is a *file*, not a directory — the environment every Loom Builder
+//! compiles in) neither `../.git/HEAD` nor `../.git/index` even resolves, so
+//! the whole watch set evaporated.
+//!
+//! The fix resolves the on-disk files git actually touches via
+//! `git rev-parse --git-path` (which transparently follows the linked-worktree
+//! gitdir indirection and the packed-refs relocation) plus the symbolic-ref
+//! target for the current branch — correct by construction in the main
+//! checkout, a linked worktree, a detached HEAD, and a packed-refs repo alike.
+//! Only paths that actually exist are emitted: cargo re-runs a build script
+//! unconditionally for a `rerun-if-changed` path that does not exist, so
+//! emitting a non-existent path would trade a stale-commit bug for an
+//! every-build recompile.
 
+use std::path::Path;
 use std::process::Command;
 
+/// Run `git <args>` and return trimmed stdout on success, else `None`.
+fn git_output(args: &[&str]) -> Option<String> {
+    Command::new("git")
+        .args(args)
+        .output()
+        .ok()
+        .and_then(|out| {
+            if out.status.success() {
+                String::from_utf8(out.stdout)
+                    .ok()
+                    .map(|s| s.trim().to_string())
+            } else {
+                None
+            }
+        })
+        .filter(|s| !s.is_empty())
+}
+
+/// Resolve a git metadata file (e.g. `HEAD`, `packed-refs`, `refs/heads/main`)
+/// to its real on-disk path via `git rev-parse --git-path`. This handles the
+/// linked-worktree indirection (where the per-worktree gitdir lives under the
+/// common `.git/worktrees/<name>/`) and the packed-refs relocation for free.
+fn git_path(spec: &str) -> Option<String> {
+    git_output(&["rev-parse", "--git-path", spec])
+}
+
+/// Emit the `cargo:rerun-if-changed` watch set that correctly tracks HEAD
+/// movement. Best-effort: when `git` is absent or fails (release tarball),
+/// nothing is emitted and the build falls through to the `unknown` commit
+/// fallback below. See the module doc for the full rationale.
+fn emit_git_rerun_paths() {
+    let mut specs: Vec<String> = Vec::new();
+
+    // The always-present metadata files. `HEAD` catches branch switches and a
+    // detached-HEAD move; `index` mirrors the historical watch entry; the
+    // symbolic-ref target and `packed-refs` are the files that actually move
+    // when the checked-out branch advances (loose ref pre-gc, packed-refs
+    // post-gc — watch BOTH, since a `git gc` migrates the ref between them).
+    for spec in ["HEAD", "index", "packed-refs"] {
+        specs.push(spec.to_string());
+    }
+
+    // The resolved ref for the current branch (e.g. `refs/heads/main`). A
+    // detached HEAD has no symbolic ref — skip it there (HEAD itself moves in
+    // that case, and HEAD is already watched above).
+    if let Some(symref) = git_output(&["symbolic-ref", "-q", "HEAD"]) {
+        specs.push(symref);
+    }
+
+    for spec in specs {
+        if let Some(path) = git_path(&spec) {
+            // Only watch paths that exist. cargo re-runs the build script on
+            // EVERY build for a `rerun-if-changed` path that does not exist,
+            // which would defeat incremental compilation. A ref that later
+            // appears (or migrates loose<->packed) is picked up on the next
+            // build-script re-run, which the still-existing sibling paths
+            // (HEAD/index/packed-refs) reliably trigger.
+            if Path::new(&path).exists() {
+                println!("cargo:rerun-if-changed={path}");
+            }
+        }
+    }
+}
+
 fn main() {
-    // Re-run if `git` HEAD moves or the index changes. This is best-effort:
-    // if `.git` is absent (release tarball), we skip and use the fallback.
-    println!("cargo:rerun-if-changed=../.git/HEAD");
-    println!("cargo:rerun-if-changed=../.git/index");
+    // Re-run when HEAD moves (branch advance, checkout, commit) or the index
+    // changes. Resolved correct-by-construction via `git rev-parse --git-path`
+    // so this works in a linked worktree and a packed-refs repo too (#4053).
+    emit_git_rerun_paths();
     // Always re-run when build.rs itself changes.
     println!("cargo:rerun-if-changed=build.rs");
 

--- a/scripts/install/provision-daemon.sh
+++ b/scripts/install/provision-daemon.sh
@@ -28,6 +28,18 @@ _pmd_info()    { echo "  [loom-daemon] $*"; }
 _pmd_ok()      { echo "  [loom-daemon] $*"; }
 _pmd_warn()    { echo "  [loom-daemon] WARNING: $*" >&2; }
 
+# Set by provision_machine_daemon before every successful return so the caller
+# can locate the destination it wrote to WITHOUT re-deriving the
+# LOOM_DAEMON_BIN_DIR default itself (which would duplicate the fallback in two
+# files). This is the "expose enough for the caller to verify" contract from
+# issue #4053: a caller (loom-daemon-update.sh) reads $PROVISIONED_DAEMON_BIN to
+# assert the destination binary is the expected build after provisioning — the
+# direct fix for "provisioning reports success while shipping nothing". It is
+# assigned as a GLOBAL (no `local`) precisely so it survives the function
+# return, and is set even on the version-equality short-circuit path (the very
+# path under suspicion, so it must NOT be the one that leaves it unset).
+PROVISIONED_DAEMON_BIN=""
+
 # provision_machine_daemon <src_bin> [dest_dir]
 #
 # Installs <src_bin> to <dest_dir>/loom-daemon (default: LOOM_DAEMON_BIN_DIR,
@@ -36,10 +48,19 @@ _pmd_warn()    { echo "  [loom-daemon] WARNING: $*" >&2; }
 # soft failure so the caller can note it, but the installer must NOT abort on a
 # non-zero return (a repo can still run the daemon via an explicit
 # LOOM_DAEMON_BIN or an in-repo build).
+#
+# On a successful return (0), sets the global PROVISIONED_DAEMON_BIN to the
+# destination path it resolved (whether it copied or short-circuited), so the
+# caller can verify the destination binary (#4053).
 provision_machine_daemon() {
   local src_bin="${1:-}"
   local dest_dir="${2:-${LOOM_DAEMON_BIN_DIR:-$HOME/.local/bin}}"
   local dest_bin="$dest_dir/loom-daemon"
+  # Publish the resolved destination to the caller up front, so EVERY return
+  # path below (including the short-circuit) communicates where the binary
+  # lives — even the early soft-failure returns (the caller gates on the return
+  # code, so a set-but-unprovisioned value there is harmless).
+  PROVISIONED_DAEMON_BIN="$dest_bin"
 
   if [[ -z "$src_bin" || ! -x "$src_bin" ]]; then
     _pmd_warn "built binary not found at '${src_bin:-<unset>}'; skipping machine-level install"


### PR DESCRIPTION
## Summary

Makes the daemon's rebuild → provision path self-verifying so a successful-looking `loom-daemon-update.sh` run can never install a stale binary — the root cause being a `build.rs` watch set that failed to track HEAD movement, letting a rebuild bake in the *old* commit. This is Phase 1 of #4017 and has standalone value: the manual update path had the same hazard.

Root cause (verified): `build.rs` watched only `../.git/HEAD` + `../.git/index`. `.git/HEAD` is a *symbolic* ref whose content never changes when the branch advances, and the file that actually moves (`.git/refs/heads/<branch>`, or `.git/packed-refs` after `git gc`) was unwatched. In a **linked worktree** (`.git` is a *file* — every Builder's compile environment) neither `../.git/*` path even resolved, so the watch set evaporated entirely.

## Changes

- **`loom-daemon/build.rs`** — resolve the `cargo:rerun-if-changed` watch set correct-by-construction via `git rev-parse --git-path` (HEAD, index, packed-refs, and the current branch's symbolic-ref target). Emits **only paths that exist** — empirically confirmed cargo re-runs the build script on *every* build for a nonexistent `rerun-if-changed` path, so a naive fix would trade a stale-commit bug for an every-build recompile. Preserves the release-tarball (`commit unknown`) fallback and handles detached HEAD (no symbolic ref).
- **`defaults/scripts/cli/loom-daemon-update.sh`** — (1) after `cargo build --release`, assert the freshly-built binary's embedded commit == source HEAD **before** provisioning; on mismatch fail loudly and do **not** provision (**exit 4**, distinct from a compile failure). (2) After provisioning, assert the **destination** binary is the expected build for **both** the `LOOM_DAEMON_BIN` override path and the machine-level `provision_machine_daemon` path (**exit 5** on mismatch). Machine-level provisioning failure now hard-fails instead of the pre-existing soft warn that left exit 0.
- **`scripts/install/provision-daemon.sh`** — export `PROVISIONED_DAEMON_BIN` (set even on the `--version`-equality short-circuit) so the caller can verify the destination. The short-circuit is **retained** (correct once the rebuild is correct).
- **`defaults/scripts/tests/test-build-rs-watchset.sh`** *(new)* — compiles a scratch crate using a verbatim copy of the real `build.rs` in a scratch git repo (crate in a `loom-daemon/` subdir, mirroring reality) and asserts the baked commit re-derives after a **ref-only** advance (`commit-tree` + `update-ref`, touching neither HEAD nor index) across main checkout, linked worktree, detached HEAD, and packed-refs. Verified to **fail against the old build.rs** and pass against the new one.
- **`defaults/scripts/tests/test-loom-daemon-update.sh`** — new cases: built-commit mismatch → exit 4 + no provision; a provision that reports success but ships a stale destination → exit 5; happy-path roll now asserts both verification steps ran.
- **`.loom/docs/daemon-reference.md`** — document the self-verifying rebuild → provision behavior in the Self-update section.

## Acceptance Criteria Verification

- [x] A `cargo build --release` after a HEAD change always bakes the new HEAD — including when only `.git/refs/heads/<branch>` or `.git/packed-refs` moved (regression test, all 10 assertions pass; fails on old build.rs).
- [x] `loom-daemon-update.sh` refuses to provision a binary whose embedded commit ≠ source HEAD, distinguishably from a compile failure (exit 4, "Build verification FAILED").
- [x] `loom-daemon-update.sh` verifies the destination after provisioning and fails if not the expected build (exit 5), covering both the `LOOM_DAEMON_BIN` override and `provision_machine_daemon` branches.
- [x] The `--version`-equality short-circuit in `provision-daemon.sh` is retained and covered by a test proving it no longer produces a silent no-op on a real roll.
- [x] Happy-path behavior unchanged: exit codes `0`/`1`/`3`, flag replay from `.loom/.daemon.flags`, "a daemon that was not running is never started".
- [x] Edge cases handled: no `.git` (tarball), linked worktree (`.git` as file), packed-refs, detached HEAD.

## Test Plan

- [x] `bash defaults/scripts/tests/test-build-rs-watchset.sh` — 10/10 pass; confirmed it fails against the old watch set.
- [x] `bash defaults/scripts/tests/test-loom-daemon-update.sh` — 23/23 pass (includes the new exit-4 / exit-5 cases).
- [x] `cargo build --release` produces a binary whose `--version` reports the current HEAD.
- [x] `cargo test --workspace` — all pass (`test_multiple_clients` timed out once under concurrent-build CPU contention; passes in isolation; unrelated to this change — build.rs only affects the baked-commit env var).

Closes #4053