### PR TITLE
feat(daemon): expose CPU headroom tunables via autonomous.* config, not env-only

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -1174,9 +1174,29 @@ capacity, unadjusted. Like the token axis's "one healthy account is the floor,
 never a halt" policy (#3902), the CPU term is floored at `1` — a read failure or
 a noisy reading must never by itself wedge the whole dynamic cap to zero; disk
 headroom and the token axis remain the only terms allowed to floor to a genuine
-`0`. Tunable via `LOOM_CPU_UTILIZATION_TARGET` (fraction, default `0.75`) and
-`LOOM_EST_CORES_PER_SWEEP` (cores, default `2.0`) — env-only, mirroring
-`LOOM_PER_WORKTREE_GB`'s config surface (no `.loom/config.json` knob).
+`0`. Tunable with the standard precedence **env (`LOOM_CPU_UTILIZATION_TARGET`
+/ `LOOM_EST_CORES_PER_SWEEP`) > config (`autonomous.cpuUtilizationTarget` /
+`autonomous.estCoresPerSweep`) > default (`0.75` fraction / `2.0` cores)**
+(#4032) — resolved single-root, at startup, from the same
+`WorkFinderConfig`/`read_work_finder_config` that `perTokenConcurrency` uses
+(not per-workspace: the dynamic cap is one global number per tick, computed
+before the workspace registry is even loaded). An out-of-range or
+wrong-JSON-type config value (`cpuUtilizationTarget` outside `(0, 1]`,
+`estCoresPerSweep <= 0`, a string/bool/null where a number is expected) is
+dropped to `None` at the config-read layer, not clamped, so it falls straight
+through to env/default resolution.
+
+**`LOOM_PER_WORKTREE_GB` deliberately stays env-only (#4032 decision).**
+Unlike the CPU knobs, `disk_headroom`'s `LOOM_PER_WORKTREE_GB` was *not*
+migrated to the same `autonomous.*` pattern. It has a second, independent
+Bash-side reader (`defaults/scripts/lib/disk-headroom.sh`, consumed by
+`/loom:sweep` Stage -1 wave sizing) alongside the Rust
+`disk_headroom::per_worktree_gb`. Migrating only the Rust side would create a
+live divergence where the same env var honors `.loom/config.json` on the
+daemon path while silently ignoring it on the sweep path — worse than today's
+consistent env-only behavior. Wiring the Bash `config-resolver.sh` into
+`disk-headroom.sh` too is a separate, larger change; file a follow-up if that
+cost is judged worth paying.
 
 *Calibrating `LOOM_EST_CORES_PER_SWEEP`.* The host-side half of the term
 (consumed cores) is now measured continuously and needs no tuning. The one
@@ -1329,6 +1349,8 @@ concurrency ceiling 5" and share it with the team:
   "autonomous": {
     "model": "sonnet",
     "perTokenConcurrency": 2,
+    "cpuUtilizationTarget": 0.75,
+    "estCoresPerSweep": 2.0,
     "workFinder": {
       "enabled": true,
       "intervalSecs": 60,
@@ -1384,6 +1406,8 @@ exactly like `main_health_gate::read_build_gate_config`.
 | `autonomous.workFinder.quarantine.ttlSecs` | `LOOM_WORK_FINDER_QUARANTINE_TTL_SECS` | `3600` | How long a quarantine entry persists before auto-release. Zero/invalid → default |
 | `autonomous.workFinder.quarantine.instaCrashSecs` | `LOOM_WORK_FINDER_QUARANTINE_INSTA_CRASH_SECS` | `60` | Checkpoint-less death within this window of dispatch counts as an insta-crash. Zero/invalid → default |
 | `autonomous.perTokenConcurrency` | `LOOM_PER_TOKEN_CONCURRENCY` | `2` | Concurrent sweeps **per healthy token** in the cap (#3947). Zero/invalid → default; clamped to a floor of 1 |
+| `autonomous.cpuUtilizationTarget` | `LOOM_CPU_UTILIZATION_TARGET` | `0.75` | Fraction of logical CPUs the CPU headroom term is willing to dedicate to sweep work (#3978, config surface #4032). Outside `(0, 1]` or wrong JSON type → default; single-root, resolved once at startup (not per-workspace) |
+| `autonomous.estCoresPerSweep` | `LOOM_EST_CORES_PER_SWEEP` | `2.0` | Estimated CPU cores one concurrent sweep consumes while building/testing (#3978, config surface #4032). `<= 0` or wrong JSON type → default; integer JSON (`2`) and float JSON (`2.0`) both accepted; single-root, resolved once at startup |
 | `autonomous.mainHealthGate.enabled` | `LOOM_MAIN_HEALTH_GATE` | `false` | Gate loop on/off |
 | `autonomous.mainHealthGate.ciWorkflow` | `LOOM_GATE_CI_WORKFLOW` | *(unset)* | Forge workflow that must itself conclude `success` for forge-CI corroboration to vouch for a commit (#3987). Empty/whitespace → unset. Absent → today's unanimity rule, unchanged. See [Optional named verification workflow](#optional-named-verification-workflow-loom_gate_ci_workflow-3987) |
 | `autonomous.roleRunner.enabled` | `LOOM_ROLE_RUNNER` | `false` | Periodic standalone support-role runner on/off (#4015) |

--- a/docs/measure-est-cores-per-sweep.md
+++ b/docs/measure-est-cores-per-sweep.md
@@ -72,11 +72,24 @@ build concurrency, which is the moment the term exists to guard against.
 
 ### 4. Apply
 
-Set the measured value (env overrides config overrides the `2.0` default):
+Set the measured value with precedence **env > `.loom/config.json` >
+default** (#4032) — pick whichever durability you want:
 
 ```bash
+# Ephemeral (this shell's daemon runs only): env wins over any committed config.
 export LOOM_EST_CORES_PER_SWEEP=<measured>
 # then restart the daemon, or bake it into the daemon's environment
+
+# Durable, shared with the team, and survives loom-daemon-start.sh re-rendering
+# the plist on every start (unlike an env var, which only persists as long as
+# every start exports it):
+```
+```json
+{
+  "autonomous": {
+    "estCoresPerSweep": <measured>
+  }
+}
 ```
 
 Cross-check against `loom-daemon status`, whose `cpu headroom` line now reports
@@ -86,6 +99,9 @@ the measured idle fraction and consumed-core estimate feeding the term.
 
 - **`LOOM_CPU_UTILIZATION_TARGET`** (default `0.75`) is a policy knob — the
   fraction of cores you are *willing* to dedicate to sweeps — not a measurement.
-  Leave headroom for the OS, the daemon, and the build-gate's own `cargo`.
-- Exposing these two knobs via `.loom/config.json` (`autonomous.*`) instead of
-  env-only is tracked separately in #4032.
+  Leave headroom for the OS, the daemon, and the build-gate's own `cargo`. It
+  has the same committed-config counterpart, `autonomous.cpuUtilizationTarget`.
+- Both knobs are resolved **once at daemon startup**, single-root (not
+  per-workspace) — see the `autonomous.*` config surface in
+  [`.loom/docs/daemon-reference.md`](../.loom/docs/daemon-reference.md)
+  (#4032).

--- a/loom-daemon/src/cpu_headroom.rs
+++ b/loom-daemon/src/cpu_headroom.rs
@@ -97,11 +97,33 @@ use std::time::{Duration, Instant};
 use std::process::{Command, Stdio};
 
 // ============================================================================
-// Configuration (env-only, mirrors `LOOM_PER_WORKTREE_GB` in disk_headroom)
+// Configuration (env > config > default — #4032)
 // ============================================================================
+//
+// Both knobs resolve **env > `.loom/config.json` → `autonomous.*` > default**,
+// matching every other autonomous-dispatch knob (`workFinder`,
+// `mainHealthGate`, `perTokenConcurrency`, `tokenRankingRefresh`,
+// `roleRunner`). Resolution is single-root and startup-time — read once from
+// the daemon's primary workspace via [`crate::work_finder::WorkFinderConfig`]
+// and threaded through as plain `f64`s — exactly like
+// [`crate::work_finder::resolve_per_token_concurrency`], not per-workspace
+// (the dynamic cap is one global number per tick; see
+// `crate::work_finder::spawn_multi_work_finder_task`'s module docs).
+//
+// `LOOM_PER_WORKTREE_GB` in [`crate::disk_headroom`] deliberately does **not**
+// get the same treatment here (#4032 decision, recorded rather than
+// implemented): it has a second, independent Bash-side reader
+// (`defaults/scripts/lib/disk-headroom.sh`, consumed by `/loom:sweep` Stage -1
+// wave sizing). Migrating only the Rust side would make the same env var honor
+// `.loom/config.json` on the daemon path while silently ignoring it on the
+// sweep path — a worse, divergent state than today's consistent env-only
+// behavior. Moving both means wiring the Bash `config-resolver.sh` into
+// `disk-headroom.sh` too, which is a separate, larger change. File a follow-up
+// if that cost is judged worth paying.
 
 /// Environment variable overriding the fraction of logical CPUs the dynamic
-/// cap is willing to dedicate to sweep work.
+/// cap is willing to dedicate to sweep work. Wins over
+/// `autonomous.cpuUtilizationTarget`.
 pub const UTILIZATION_TARGET_ENV: &str = "LOOM_CPU_UTILIZATION_TARGET";
 
 /// Default CPU utilization target: 75% of logical cores. Leaves headroom for
@@ -111,37 +133,80 @@ pub const UTILIZATION_TARGET_ENV: &str = "LOOM_CPU_UTILIZATION_TARGET";
 pub const DEFAULT_UTILIZATION_TARGET: f64 = 0.75;
 
 /// Environment variable overriding the estimated CPU cores a single
-/// concurrent sweep consumes while its build/test step is running.
+/// concurrent sweep consumes while its build/test step is running. Wins over
+/// `autonomous.estCoresPerSweep`.
 pub const EST_CORES_PER_SWEEP_ENV: &str = "LOOM_EST_CORES_PER_SWEEP";
 
 /// Default estimated cores per sweep. `cargo build`/`clippy` parallelize
 /// rustc codegen across multiple cores; `2.0` is a conservative estimate for
-/// a Rust-heavy repo like this one (not a hard measurement — tunable via
-/// [`EST_CORES_PER_SWEEP_ENV`] per repo/host).
+/// a Rust-heavy repo like this one (per #4031's measurement, this is now the
+/// calibrated figure for the primary host rather than an un-measured guess —
+/// still tunable per repo/host via [`EST_CORES_PER_SWEEP_ENV`] or
+/// `autonomous.estCoresPerSweep`).
 pub const DEFAULT_EST_CORES_PER_SWEEP: f64 = 2.0;
 
-/// Resolve [`UTILIZATION_TARGET_ENV`], falling back to
-/// [`DEFAULT_UTILIZATION_TARGET`] when unset, unparseable, or outside `(0,
-/// 1]` (a value of `0` would collapse capacity to nothing; a value `> 1`
-/// would claim more than the whole host).
-#[must_use]
-pub fn utilization_target() -> f64 {
+/// Env override for [`UTILIZATION_TARGET_ENV`] — `None` when unset,
+/// unparseable, or outside `(0, 1]` (a value of `0` would collapse capacity to
+/// nothing; a value `> 1` would claim more than the whole host).
+fn env_utilization_target() -> Option<f64> {
     std::env::var(UTILIZATION_TARGET_ENV)
         .ok()
         .and_then(|v| v.trim().parse::<f64>().ok())
         .filter(|f| *f > 0.0 && *f <= 1.0)
-        .unwrap_or(DEFAULT_UTILIZATION_TARGET)
 }
 
-/// Resolve [`EST_CORES_PER_SWEEP_ENV`], falling back to
-/// [`DEFAULT_EST_CORES_PER_SWEEP`] when unset, unparseable, or `<= 0`.
-#[must_use]
-pub fn est_cores_per_sweep() -> f64 {
+/// Env override for [`EST_CORES_PER_SWEEP_ENV`] — `None` when unset,
+/// unparseable, or `<= 0`.
+fn env_est_cores_per_sweep() -> Option<f64> {
     std::env::var(EST_CORES_PER_SWEEP_ENV)
         .ok()
         .and_then(|v| v.trim().parse::<f64>().ok())
         .filter(|f| *f > 0.0)
+}
+
+/// Resolve the CPU utilization target with precedence **env > config >
+/// default**. `config` is the already-range-filtered
+/// `autonomous.cpuUtilizationTarget` value from
+/// [`crate::work_finder::read_work_finder_config`] (`None` when absent,
+/// malformed, or out of `(0, 1]`).
+#[must_use]
+pub fn resolve_utilization_target(config: Option<f64>) -> f64 {
+    env_utilization_target()
+        .or(config)
+        .unwrap_or(DEFAULT_UTILIZATION_TARGET)
+}
+
+/// Resolve the estimated cores-per-sweep with precedence **env > config >
+/// default**. `config` is the already-range-filtered
+/// `autonomous.estCoresPerSweep` value from
+/// [`crate::work_finder::read_work_finder_config`] (`None` when absent,
+/// malformed, or `<= 0`).
+#[must_use]
+pub fn resolve_est_cores_per_sweep(config: Option<f64>) -> f64 {
+    env_est_cores_per_sweep()
+        .or(config)
         .unwrap_or(DEFAULT_EST_CORES_PER_SWEEP)
+}
+
+/// Resolve [`UTILIZATION_TARGET_ENV`] alone, falling back to
+/// [`DEFAULT_UTILIZATION_TARGET`] when unset, unparseable, or outside `(0,
+/// 1]`. Env-only convenience wrapper around [`resolve_utilization_target`]
+/// for callers with no config value in hand (e.g. ad-hoc tooling); production
+/// call sites resolve config too and should call [`resolve_utilization_target`]
+/// directly.
+#[must_use]
+pub fn utilization_target() -> f64 {
+    resolve_utilization_target(None)
+}
+
+/// Resolve [`EST_CORES_PER_SWEEP_ENV`] alone, falling back to
+/// [`DEFAULT_EST_CORES_PER_SWEEP`] when unset, unparseable, or `<= 0`.
+/// Env-only convenience wrapper around [`resolve_est_cores_per_sweep`] for
+/// callers with no config value in hand; production call sites resolve
+/// config too and should call [`resolve_est_cores_per_sweep`] directly.
+#[must_use]
+pub fn est_cores_per_sweep() -> f64 {
+    resolve_est_cores_per_sweep(None)
 }
 
 // ============================================================================
@@ -488,11 +553,21 @@ pub struct CpuHeadroomSnapshot {
 }
 
 /// Build a [`CpuHeadroomSnapshot`] from the memoized idle fraction, a fresh
-/// load-average read, and the env-configured knobs. **Never blocks** — safe on
-/// the tokio runtime and from the synchronous status path. Pre-warm the idle
-/// cache with `spawn_blocking(refresh_cpu_util_cache)` for a fresh measurement.
+/// load-average read, and the resolved knobs. **Never blocks** — safe on the
+/// tokio runtime and from the synchronous status path. Pre-warm the idle
+/// cache with `spawn_blocking(refresh_cpu_util_cache)` for a fresh
+/// measurement.
+///
+/// `utilization_target` / `est_cores_per_sweep` are the already-resolved
+/// (env > config > default, #4032) values — callers get these from
+/// [`resolve_utilization_target`] / [`resolve_est_cores_per_sweep`] fed by
+/// [`crate::work_finder::read_work_finder_config`], resolved once at startup
+/// (or, in `ipc.rs`, freshly per status request against the same config path).
 #[must_use]
-pub fn cpu_headroom_snapshot() -> CpuHeadroomSnapshot {
+pub fn cpu_headroom_snapshot(
+    utilization_target: f64,
+    est_cores_per_sweep: f64,
+) -> CpuHeadroomSnapshot {
     let logical_cpus = logical_cpu_count();
     let idle_fraction = cached_cpu_idle_fraction();
     let loadavg_1m = read_loadavg_1m();
@@ -500,8 +575,8 @@ pub fn cpu_headroom_snapshot() -> CpuHeadroomSnapshot {
         logical_cpus,
         idle_fraction,
         loadavg_1m,
-        utilization_target(),
-        est_cores_per_sweep(),
+        utilization_target,
+        est_cores_per_sweep,
     );
     CpuHeadroomSnapshot {
         logical_cpus,
@@ -514,18 +589,21 @@ pub fn cpu_headroom_snapshot() -> CpuHeadroomSnapshot {
 /// Resolve the CPU headroom term end-to-end from live host inputs, refreshing
 /// the memoized idle-fraction sample first.
 ///
+/// `utilization_target` / `est_cores_per_sweep` are the already-resolved
+/// (env > config > default, #4032) values — see [`cpu_headroom_snapshot`].
+///
 /// **May block** (~1s on macOS via `iostat`; fast, non-sleeping on Linux). The
 /// async work-finder loops call this through `spawn_blocking` so the macOS
 /// sampling window never blocks a tokio runtime worker.
 #[must_use]
-pub fn cpu_headroom_limit() -> usize {
+pub fn cpu_headroom_limit(utilization_target: f64, est_cores_per_sweep: f64) -> usize {
     refresh_cpu_util_cache();
     cpu_headroom(
         logical_cpu_count(),
         cached_cpu_idle_fraction(),
         read_loadavg_1m(),
-        utilization_target(),
-        est_cores_per_sweep(),
+        utilization_target,
+        est_cores_per_sweep,
     )
 }
 
@@ -724,7 +802,7 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // env resolution
+    // env-only resolution (no config value in hand)
     // ------------------------------------------------------------------
 
     #[test]
@@ -766,6 +844,66 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
+    // resolve_utilization_target / resolve_est_cores_per_sweep — env > config
+    // > default precedence (#4032)
+    // ------------------------------------------------------------------
+
+    #[test]
+    #[serial]
+    fn resolve_utilization_target_precedence() {
+        std::env::remove_var(UTILIZATION_TARGET_ENV);
+
+        // Both unset -> built-in default.
+        assert!(
+            (resolve_utilization_target(None) - DEFAULT_UTILIZATION_TARGET).abs() < f64::EPSILON
+        );
+
+        // Config set, env unset -> config wins.
+        assert!((resolve_utilization_target(Some(0.6)) - 0.6).abs() < f64::EPSILON);
+
+        // Env set, config set -> env wins.
+        std::env::set_var(UTILIZATION_TARGET_ENV, "0.5");
+        assert!((resolve_utilization_target(Some(0.6)) - 0.5).abs() < f64::EPSILON);
+
+        // Env set, config unset -> env still wins.
+        assert!((resolve_utilization_target(None) - 0.5).abs() < f64::EPSILON);
+
+        std::env::remove_var(UTILIZATION_TARGET_ENV);
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_est_cores_per_sweep_precedence() {
+        std::env::remove_var(EST_CORES_PER_SWEEP_ENV);
+
+        // Both unset -> built-in default.
+        assert!(
+            (resolve_est_cores_per_sweep(None) - DEFAULT_EST_CORES_PER_SWEEP).abs() < f64::EPSILON
+        );
+
+        // Config set, env unset -> config wins.
+        assert!((resolve_est_cores_per_sweep(Some(4.0)) - 4.0).abs() < f64::EPSILON);
+
+        // Env set, config set -> env wins.
+        std::env::set_var(EST_CORES_PER_SWEEP_ENV, "1.0");
+        assert!((resolve_est_cores_per_sweep(Some(4.0)) - 1.0).abs() < f64::EPSILON);
+
+        // Env set, config unset -> env still wins.
+        assert!((resolve_est_cores_per_sweep(None) - 1.0).abs() < f64::EPSILON);
+
+        std::env::remove_var(EST_CORES_PER_SWEEP_ENV);
+    }
+
+    // Range validation of the config value (`(0, 1]` for utilization target,
+    // `> 0` for cores-per-sweep) is applied at the config-read layer in
+    // `read_work_finder_config` (see `work_finder.rs` tests
+    // `test_config_out_of_range_cpu_utilization_target_drops_to_none` and
+    // `test_config_out_of_range_est_cores_per_sweep_drops_to_none`), not here —
+    // `resolve_utilization_target` / `resolve_est_cores_per_sweep` trust the
+    // `Option<f64>` they are handed is already filtered, exactly like
+    // `resolve_per_token_concurrency` trusts `WorkFinderConfig`.
+
+    // ------------------------------------------------------------------
     // logical_cpu_count — smoke test
     // ------------------------------------------------------------------
 
@@ -784,6 +922,6 @@ mod tests {
     fn cpu_headroom_limit_returns_at_least_one() {
         // Whatever this CI/dev host's load looks like, the policy floor
         // guarantees at least 1.
-        assert!(cpu_headroom_limit() >= 1);
+        assert!(cpu_headroom_limit(DEFAULT_UTILIZATION_TARGET, DEFAULT_EST_CORES_PER_SWEEP) >= 1);
     }
 }

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -528,18 +528,28 @@ pub fn build_daemon_status(
     let workspace_root = fallback_root;
     let token_pool_size = crate::tokens::token_pool_size(workspace_root);
     let disk_headroom = crate::disk_headroom::disk_headroom_limit(workspace_root);
+    // Hoisted above the CPU snapshot (#4032) so the resolved
+    // `cpuUtilizationTarget` / `estCoresPerSweep` knobs can feed it — this read
+    // was already happening six lines below; moving it up is not a new config
+    // read, just a reorder so status and dispatch resolve through the same
+    // env > config > default path (`resolve_cpu_utilization_target` /
+    // `resolve_cpu_est_cores_per_sweep`, single-root, matching
+    // `resolve_per_token_concurrency`).
+    let wf_config = crate::work_finder::read_work_finder_config(workspace_root);
+    let configured_max = crate::work_finder::resolve_max_concurrent_with_config(&wf_config);
+    let per_token_concurrency = crate::work_finder::resolve_per_token_concurrency(&wf_config);
+    let cpu_utilization_target = crate::work_finder::resolve_cpu_utilization_target(&wf_config);
+    let cpu_est_cores_per_sweep = crate::work_finder::resolve_cpu_est_cores_per_sweep(&wf_config);
     // CPU headroom (#3978, measured-idle signal #4031) — a host-level resource
     // (not per-repo). The snapshot reads the memoized idle fraction (never
     // blocks; the caller pre-warms it via `spawn_blocking(refresh_cpu_util_cache)`
     // before invoking `build_daemon_status`) plus a fast fresh loadavg read.
-    let cpu_snapshot = crate::cpu_headroom::cpu_headroom_snapshot();
+    let cpu_snapshot =
+        crate::cpu_headroom::cpu_headroom_snapshot(cpu_utilization_target, cpu_est_cores_per_sweep);
     let logical_cpus = cpu_snapshot.logical_cpus;
     let loadavg_1m = cpu_snapshot.loadavg_1m;
     let cpu_idle_fraction = cpu_snapshot.idle_fraction;
     let cpu_headroom = cpu_snapshot.cpu_headroom;
-    let wf_config = crate::work_finder::read_work_finder_config(workspace_root);
-    let configured_max = crate::work_finder::resolve_max_concurrent_with_config(&wf_config);
-    let per_token_concurrency = crate::work_finder::resolve_per_token_concurrency(&wf_config);
 
     // Token-capacity backpressure (#3902): back the token axis off from the flat
     // pool count toward the count of *healthy* accounts read from the rotation

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -667,9 +667,20 @@ async fn main() -> Result<()> {
         let interval = work_finder::resolve_interval_with_config(&work_finder_config);
         let configured_max = work_finder::resolve_max_concurrent_with_config(&work_finder_config);
         let per_token_concurrency = work_finder::resolve_per_token_concurrency(&work_finder_config);
+        // CPU headroom knobs (#4032): resolved once at startup from the same
+        // `work_finder_config`, precedence env > config > default — matching
+        // `per_token_concurrency` exactly (single-root, startup-time; the
+        // dynamic cap is one global number per tick, computed before the
+        // workspace registry is even loaded, so there is no per-workspace
+        // variant of these knobs).
+        let cpu_utilization_target =
+            work_finder::resolve_cpu_utilization_target(&work_finder_config);
+        let cpu_est_cores_per_sweep =
+            work_finder::resolve_cpu_est_cores_per_sweep(&work_finder_config);
         log::info!(
             "work_finder: enabled (multi-workspace, interval={}s, configured_max={configured_max}, \
-             per_token_concurrency={per_token_concurrency}, \
+             per_token_concurrency={per_token_concurrency}, cpu_utilization_target={cpu_utilization_target}, \
+             cpu_est_cores_per_sweep={cpu_est_cores_per_sweep}, \
              dynamic cap = min(healthy tokens × per-token, disk, cpu, configured_max), \
              global across workspaces)",
             interval.as_secs()
@@ -683,6 +694,8 @@ async fn main() -> Result<()> {
             interval,
             configured_max,
             per_token_concurrency,
+            cpu_utilization_target,
+            cpu_est_cores_per_sweep,
             workspace_health_states.clone(),
             event_bus.clone(),
         ))

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -85,7 +85,9 @@ use std::time::Duration;
 use anyhow::Result;
 
 use crate::capacity::{self, CapacityAdvisory};
-use crate::cpu_headroom::cpu_headroom_limit;
+use crate::cpu_headroom::{
+    cpu_headroom_limit, resolve_est_cores_per_sweep, resolve_utilization_target,
+};
 use crate::disk_headroom::disk_headroom_limit;
 use crate::event_bus::EventBus;
 use crate::main_health_gate::{MainHealthState, WorkspaceHealthStates};
@@ -702,7 +704,7 @@ pub fn resolve_max_concurrent() -> usize {
 /// consumes. Each field is `Option` so an absent key falls through to the
 /// env-var / built-in-default resolution — the precedence is **env > config >
 /// default** for every knob.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct WorkFinderConfig {
     /// `autonomous.workFinder.enabled` — whether to run the loop at all.
     pub enabled: Option<bool>,
@@ -717,6 +719,17 @@ pub struct WorkFinderConfig {
     /// `autonomous` level (not under `workFinder`), so it is read even when no
     /// `workFinder` block is present. A zero/invalid value is dropped to `None`.
     pub per_token_concurrency: Option<usize>,
+    /// `autonomous.cpuUtilizationTarget` — the fraction of logical CPUs the CPU
+    /// headroom term (#3978) is willing to dedicate to sweep work (#4032). Also
+    /// lives at the `autonomous` level, alongside `perTokenConcurrency`. A
+    /// value outside `(0, 1]` (or the wrong JSON type) is dropped to `None`, so
+    /// it falls through to [`crate::cpu_headroom::DEFAULT_UTILIZATION_TARGET`].
+    pub cpu_utilization_target: Option<f64>,
+    /// `autonomous.estCoresPerSweep` — the estimated CPU cores a single
+    /// concurrent sweep consumes while building/testing (#3978, #4032). A
+    /// value `<= 0` (or the wrong JSON type) is dropped to `None`, so it falls
+    /// through to [`crate::cpu_headroom::DEFAULT_EST_CORES_PER_SWEEP`].
+    pub est_cores_per_sweep: Option<f64>,
 }
 
 /// Read `.loom/config.json → autonomous.workFinder`, soft-failing every field
@@ -760,6 +773,21 @@ pub fn read_work_finder_config(repo_root: &Path) -> WorkFinderConfig {
         .filter(|&n| n > 0)
         .and_then(|n| usize::try_from(n).ok());
 
+    // `cpuUtilizationTarget` / `estCoresPerSweep` (#4032) also live at the
+    // `autonomous` level, mirroring `perTokenConcurrency`. `Value::as_f64`
+    // accepts both integer and float JSON (`2` and `2.0`); range filters match
+    // the env-var resolvers in `cpu_headroom.rs` exactly so a config value
+    // that would be rejected there is dropped to `None` here too, rather than
+    // being clamped or silently applied out of range.
+    let cpu_utilization_target = autonomous
+        .get("cpuUtilizationTarget")
+        .and_then(serde_json::Value::as_f64)
+        .filter(|&f| f > 0.0 && f <= 1.0);
+    let est_cores_per_sweep = autonomous
+        .get("estCoresPerSweep")
+        .and_then(serde_json::Value::as_f64)
+        .filter(|&f| f > 0.0);
+
     // The `workFinder` sub-block is optional; each field independently falls
     // through to `None` (env/default resolution) when absent.
     let wf = autonomous.get("workFinder");
@@ -778,6 +806,8 @@ pub fn read_work_finder_config(repo_root: &Path) -> WorkFinderConfig {
             .filter(|&n| n > 0)
             .and_then(|n| usize::try_from(n).ok()),
         per_token_concurrency,
+        cpu_utilization_target,
+        est_cores_per_sweep,
     }
 }
 
@@ -831,6 +861,25 @@ pub fn resolve_per_token_concurrency(config: &WorkFinderConfig) -> usize {
     env_per_token_concurrency()
         .or(config.per_token_concurrency)
         .unwrap_or(DEFAULT_PER_TOKEN_CONCURRENCY)
+}
+
+/// Resolve the CPU headroom term's utilization-target knob with precedence
+/// **env > config > default** (#4032). Thin wrapper over
+/// [`crate::cpu_headroom::resolve_utilization_target`] that reads the config
+/// half from this module's already-parsed [`WorkFinderConfig`], mirroring how
+/// [`resolve_per_token_concurrency`] reads `config.per_token_concurrency`.
+#[must_use]
+pub fn resolve_cpu_utilization_target(config: &WorkFinderConfig) -> f64 {
+    resolve_utilization_target(config.cpu_utilization_target)
+}
+
+/// Resolve the CPU headroom term's est-cores-per-sweep knob with precedence
+/// **env > config > default** (#4032). Thin wrapper over
+/// [`crate::cpu_headroom::resolve_est_cores_per_sweep`]; see
+/// [`resolve_cpu_utilization_target`].
+#[must_use]
+pub fn resolve_cpu_est_cores_per_sweep(config: &WorkFinderConfig) -> f64 {
+    resolve_est_cores_per_sweep(config.est_cores_per_sweep)
 }
 
 /// Compute the **work-driven dynamic concurrency cap** (Phase B, #3811;
@@ -925,6 +974,8 @@ pub fn spawn_work_finder_task<S, D>(
     workspace_root: PathBuf,
     configured_max: usize,
     per_token_concurrency: usize,
+    cpu_utilization_target: f64,
+    cpu_est_cores_per_sweep: f64,
     health_state: Arc<MainHealthState>,
     event_bus: Arc<EventBus>,
 ) -> tokio::task::JoinHandle<()>
@@ -970,9 +1021,14 @@ where
             // memoized idle sample, which sleeps ~1s on macOS (`iostat`), so it
             // is moved off the runtime via `spawn_blocking`; a join error falls
             // back to the policy floor of 1 (soft backoff, never a hard halt).
-            let cpu = tokio::task::spawn_blocking(cpu_headroom_limit)
-                .await
-                .unwrap_or(1);
+            // `cpu_utilization_target` / `cpu_est_cores_per_sweep` are resolved
+            // once at startup (env > config > default, #4032) and captured by
+            // this task, mirroring `per_token_concurrency`.
+            let cpu = tokio::task::spawn_blocking(move || {
+                cpu_headroom_limit(cpu_utilization_target, cpu_est_cores_per_sweep)
+            })
+            .await
+            .unwrap_or(1);
             let max_concurrent = resolve_dynamic_max_concurrent(
                 token_limit,
                 per_token_concurrency,
@@ -1073,12 +1129,17 @@ where
 /// the `(repo, issue)` key that disambiguates them is phase c (#3929). No new
 /// topic shape is introduced here (CLAUDE.md: "New topics require a follow-up
 /// issue").
+#[allow(clippy::too_many_arguments)] // dynamic-cap inputs (#4032 adds two more
+                                     // resolved-once-at-startup f64 knobs, mirroring
+                                     // per_token_concurrency) + shared state.
 pub fn spawn_multi_work_finder_task(
     pool: Arc<WorkspacePool>,
     fallback_root: PathBuf,
     interval: Duration,
     configured_max: usize,
     per_token_concurrency: usize,
+    cpu_utilization_target: f64,
+    cpu_est_cores_per_sweep: f64,
     health_states: Arc<WorkspaceHealthStates>,
     event_bus: Arc<EventBus>,
 ) -> tokio::task::JoinHandle<()> {
@@ -1108,10 +1169,15 @@ pub fn spawn_multi_work_finder_task(
             // machine-level resource, probed once per tick and shared across
             // every workspace. Moved off the runtime via `spawn_blocking` since
             // the macOS `iostat` refresh sleeps ~1s; a join error falls back to
-            // the policy floor of 1.
-            let cpu = tokio::task::spawn_blocking(cpu_headroom_limit)
-                .await
-                .unwrap_or(1);
+            // the policy floor of 1. `cpu_utilization_target` /
+            // `cpu_est_cores_per_sweep` are resolved once at startup (env >
+            // config > default, #4032) and captured by this task, mirroring
+            // `per_token_concurrency`.
+            let cpu = tokio::task::spawn_blocking(move || {
+                cpu_headroom_limit(cpu_utilization_target, cpu_est_cores_per_sweep)
+            })
+            .await
+            .unwrap_or(1);
             let max_concurrent = resolve_dynamic_max_concurrent(
                 token_limit,
                 per_token_concurrency,
@@ -2516,7 +2582,7 @@ exit 0
         let tmp = tempfile::tempdir().unwrap();
         write_config(
             tmp.path(),
-            r#"{"autonomous": {"perTokenConcurrency": 4, "workFinder": {"enabled": true, "intervalSecs": 90, "maxConcurrent": 5}}}"#,
+            r#"{"autonomous": {"perTokenConcurrency": 4, "cpuUtilizationTarget": 0.6, "estCoresPerSweep": 3.5, "workFinder": {"enabled": true, "intervalSecs": 90, "maxConcurrent": 5}}}"#,
         );
         assert_eq!(
             read_work_finder_config(tmp.path()),
@@ -2525,8 +2591,90 @@ exit 0
                 interval_secs: Some(90),
                 max_concurrent: Some(5),
                 per_token_concurrency: Some(4),
+                cpu_utilization_target: Some(0.6),
+                est_cores_per_sweep: Some(3.5),
             }
         );
+    }
+
+    // ===================================================================
+    // cpuUtilizationTarget / estCoresPerSweep config parsing (#4032)
+    // ===================================================================
+
+    #[test]
+    fn test_config_cpu_knobs_read_without_work_finder_block() {
+        // Both knobs live at the `autonomous` level (#4032), so they are read
+        // even when the `workFinder` sub-block is absent — mirroring
+        // `perTokenConcurrency`.
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(
+            tmp.path(),
+            r#"{"autonomous": {"cpuUtilizationTarget": 0.5, "estCoresPerSweep": 1.5}}"#,
+        );
+        let cfg = read_work_finder_config(tmp.path());
+        assert_eq!(cfg.cpu_utilization_target, Some(0.5));
+        assert_eq!(cfg.est_cores_per_sweep, Some(1.5));
+        assert_eq!(cfg.enabled, None);
+    }
+
+    #[test]
+    fn test_config_integer_cpu_knobs_parse_as_f64() {
+        // `Value::as_f64` handles integer JSON as well as float — assert it
+        // (#4032 AC: "estCoresPerSweep": 2 as well as 2.0).
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), r#"{"autonomous": {"estCoresPerSweep": 2}}"#);
+        let cfg = read_work_finder_config(tmp.path());
+        assert_eq!(cfg.est_cores_per_sweep, Some(2.0));
+    }
+
+    #[test]
+    fn test_config_out_of_range_cpu_utilization_target_drops_to_none() {
+        for bad in ["0", "-1", "1.5"] {
+            let tmp = tempfile::tempdir().unwrap();
+            write_config(
+                tmp.path(),
+                &format!(r#"{{"autonomous": {{"cpuUtilizationTarget": {bad}}}}}"#),
+            );
+            assert_eq!(
+                read_work_finder_config(tmp.path()).cpu_utilization_target,
+                None,
+                "cpuUtilizationTarget={bad} must drop to None, not be clamped"
+            );
+        }
+    }
+
+    #[test]
+    fn test_config_out_of_range_est_cores_per_sweep_drops_to_none() {
+        for bad in ["0", "-2"] {
+            let tmp = tempfile::tempdir().unwrap();
+            write_config(
+                tmp.path(),
+                &format!(r#"{{"autonomous": {{"estCoresPerSweep": {bad}}}}}"#),
+            );
+            assert_eq!(
+                read_work_finder_config(tmp.path()).est_cores_per_sweep,
+                None,
+                "estCoresPerSweep={bad} must drop to None, not be clamped"
+            );
+        }
+    }
+
+    #[test]
+    fn test_config_wrong_json_type_cpu_knobs_drop_to_none() {
+        // A string, bool, or null where a number is expected must not panic
+        // and must resolve to None (soft-fail to env/default resolution).
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(
+            tmp.path(),
+            r#"{"autonomous": {"cpuUtilizationTarget": "0.8", "estCoresPerSweep": true}}"#,
+        );
+        let cfg = read_work_finder_config(tmp.path());
+        assert_eq!(cfg.cpu_utilization_target, None);
+        assert_eq!(cfg.est_cores_per_sweep, None);
+
+        let tmp2 = tempfile::tempdir().unwrap();
+        write_config(tmp2.path(), r#"{"autonomous": {"estCoresPerSweep": null}}"#);
+        assert_eq!(read_work_finder_config(tmp2.path()).est_cores_per_sweep, None);
     }
 
     #[test]
@@ -2696,6 +2844,60 @@ exit 0
         std::env::set_var(PER_TOKEN_CONCURRENCY_ENV, "nope");
         assert_eq!(resolve_per_token_concurrency(&cfg), 4);
         std::env::remove_var(PER_TOKEN_CONCURRENCY_ENV);
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_cpu_utilization_target_precedence() {
+        use crate::cpu_headroom::{DEFAULT_UTILIZATION_TARGET, UTILIZATION_TARGET_ENV};
+        std::env::remove_var(UTILIZATION_TARGET_ENV);
+
+        // Default when neither env nor config set.
+        assert!(
+            (resolve_cpu_utilization_target(&WorkFinderConfig::default())
+                - DEFAULT_UTILIZATION_TARGET)
+                .abs()
+                < f64::EPSILON
+        );
+
+        // Config used when env unset.
+        let cfg = WorkFinderConfig {
+            cpu_utilization_target: Some(0.6),
+            ..Default::default()
+        };
+        assert!((resolve_cpu_utilization_target(&cfg) - 0.6).abs() < f64::EPSILON);
+
+        // Env overrides config.
+        std::env::set_var(UTILIZATION_TARGET_ENV, "0.5");
+        assert!((resolve_cpu_utilization_target(&cfg) - 0.5).abs() < f64::EPSILON);
+        std::env::remove_var(UTILIZATION_TARGET_ENV);
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_cpu_est_cores_per_sweep_precedence() {
+        use crate::cpu_headroom::{DEFAULT_EST_CORES_PER_SWEEP, EST_CORES_PER_SWEEP_ENV};
+        std::env::remove_var(EST_CORES_PER_SWEEP_ENV);
+
+        // Default when neither env nor config set.
+        assert!(
+            (resolve_cpu_est_cores_per_sweep(&WorkFinderConfig::default())
+                - DEFAULT_EST_CORES_PER_SWEEP)
+                .abs()
+                < f64::EPSILON
+        );
+
+        // Config used when env unset.
+        let cfg = WorkFinderConfig {
+            est_cores_per_sweep: Some(4.0),
+            ..Default::default()
+        };
+        assert!((resolve_cpu_est_cores_per_sweep(&cfg) - 4.0).abs() < f64::EPSILON);
+
+        // Env overrides config.
+        std::env::set_var(EST_CORES_PER_SWEEP_ENV, "1.0");
+        assert!((resolve_cpu_est_cores_per_sweep(&cfg) - 1.0).abs() < f64::EPSILON);
+        std::env::remove_var(EST_CORES_PER_SWEEP_ENV);
     }
 
     // ===================================================================


### PR DESCRIPTION
## Summary

`utilization_target` and `est_cores_per_sweep` (the two knobs feeding the CPU headroom term, #3978/#4031) were env-var only, out of step with every other autonomous-dispatch knob (`workFinder`, `mainHealthGate`, `perTokenConcurrency`, `tokenRankingRefresh`, `roleRunner`), all of which resolve **env > `.loom/config.json` → `autonomous.*` > default**.

This PR brings the two CPU knobs in line with that pattern:

- `autonomous.cpuUtilizationTarget` / `autonomous.estCoresPerSweep` now resolve **env > config > default**, matching `resolve_per_token_concurrency` exactly.
- Resolution is **single-root and startup-time** (not per-workspace — the dynamic cap is one global number per tick, computed before the workspace registry is even loaded; matches the curated scope of #4032).
- Absent `autonomous` block, absent keys, malformed JSON, wrong JSON type (string/bool/null where a number is expected), and out-of-range values (`cpuUtilizationTarget` outside `(0, 1]`, `estCoresPerSweep <= 0`) all soft-fail to the built-in defaults — not clamped, no panic. Zero behavior change for anyone not opting in.
- Integer JSON (`"estCoresPerSweep": 2`) works, not just float (`2.0`) — `Value::as_f64` handles both.
- `LOOM_CPU_UTILIZATION_TARGET` / `LOOM_EST_CORES_PER_SWEEP` keep working and keep winning over config.
- `loom-daemon --status` (`ipc.rs`) resolves through the same path as dispatch — the existing `read_work_finder_config` call there was hoisted above the CPU snapshot computation (not a new config read, just a reorder).

### `LOOM_PER_WORKTREE_GB` decision (recorded, not implemented) — **defer**

`disk_headroom.rs`'s `LOOM_PER_WORKTREE_GB` is deliberately **not** migrated to the same `autonomous.*` pattern in this PR. It has a second, independent Bash-side reader (`defaults/scripts/lib/disk-headroom.sh`, consumed by `/loom:sweep` Stage -1 wave sizing) alongside the Rust `disk_headroom::per_worktree_gb`. Migrating only the Rust side would make the same env var honor `.loom/config.json` on the daemon path while silently ignoring it on the sweep path — a worse, divergent state than today's consistent env-only behavior. Moving both means wiring the Bash `config-resolver.sh` into `disk-headroom.sh` too, which is a separate, larger change. The decision and rationale are recorded in `cpu_headroom.rs`'s module docs and `.loom/docs/daemon-reference.md`; a follow-up issue can pick it up if that cost is judged worth paying.

## Implementation

- `loom-daemon/src/cpu_headroom.rs`: split `env_utilization_target()` / `env_est_cores_per_sweep()` (env-only) from `resolve_utilization_target(config)` / `resolve_est_cores_per_sweep(config)` (env > config > default). `cpu_headroom_limit()` / `cpu_headroom_snapshot()` now take the two resolved `f64`s as parameters instead of reading env directly.
- `loom-daemon/src/work_finder.rs`: `WorkFinderConfig` gains `cpu_utilization_target: Option<f64>` / `est_cores_per_sweep: Option<f64>`, parsed in `read_work_finder_config` at the `autonomous` level (alongside `perTokenConcurrency`, so read even without a `workFinder` block) with range filters matching the env resolvers. New `resolve_cpu_utilization_target(&WorkFinderConfig)` / `resolve_cpu_est_cores_per_sweep(&WorkFinderConfig)` wrap the `cpu_headroom` resolvers. Both work-finder loops (`spawn_work_finder_task`, `spawn_multi_work_finder_task`) now take the two resolved values as parameters and pass them into the per-tick `spawn_blocking` call to `cpu_headroom_limit`.
- `loom-daemon/src/main.rs`: resolves both knobs once at startup beside `per_token_concurrency` and threads them into `spawn_multi_work_finder_task`.
- `loom-daemon/src/ipc.rs`: hoists the existing `read_work_finder_config` call above the CPU snapshot computation so `loom-daemon status` and dispatch resolve through the same path.
- `.loom/docs/daemon-reference.md`: updated the CPU-headroom section and the `autonomous.*` config table with the two new keys and the disk-deferral rationale.
- `docs/measure-est-cores-per-sweep.md`: updated the "Apply" section to show both the ephemeral env path and the durable config path.

## Test plan

- [x] Unit — config parsing: full block, `autonomous`-only (no `workFinder`), integer JSON, out-of-range, wrong JSON type (string/bool/null) all covered in `work_finder.rs` tests.
- [x] Unit — precedence: env set + config set → env wins; env unset + config set → config wins; both unset → default. Covered in both `cpu_headroom.rs` (`resolve_*_precedence`) and `work_finder.rs` (`test_resolve_cpu_*_precedence`).
- [x] Unit — soft-fail at both layers, not clamped, no panic.
- [x] Regression — existing `read_work_finder_config` / `resolve_dynamic_max_concurrent` tests pass unchanged.
- [x] Env-mutating tests are `#[serial]`.
- [x] `cargo build --workspace --all-targets` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] `cargo test --lib` — 1028 passed, 0 failed.

**Pre-existing failure, unrelated to this change**: `cargo test --workspace` also runs `loom-daemon/tests/integration_basic.rs`, which flakes on `test_create_terminal_with_working_dir` / `test_destroy_terminal` — tmux-session-management integration tests unrelated to `cpu_headroom`/`work_finder`/`ipc`/`main`. Reproduced in isolation (re-running just that test file) with a different one of the two tests failing each run, confirming environmental flakiness rather than a regression from this change.

Closes #4032

🤖 Generated with [Claude Code](https://claude.com/claude-code)