### PR TITLE
feat(daemon): supervised restart primitive via launchd KeepAlive:SuccessfulExit

### DIFF
--- a/.loom/docs/daemon-reference.md
+++ b/.loom/docs/daemon-reference.md
@@ -1798,6 +1798,17 @@ the registry reconciles their state on the next start (`SweepRegistry::reconstru
 re-admits live-lock owners). To actively cancel a sweep, use
 `mcp__loom__cancel_sweep` against a running daemon *before* stopping it.
 
+**Exit code carries shutdown intent (#4054).** The daemon encodes *why* it is
+shutting down in its exit code, because the launchd `KeepAlive:{SuccessfulExit:true}`
+plist (below) relaunches only on a clean exit `0`: the `RestartDaemon` primitive
+exits `0` (relaunch), SIGTERM exits `143`, SIGINT exits `130`, an explicit IPC
+`Shutdown` exits `143`, and a crash/panic exits non-zero — so only a deliberate
+restart trips a relaunch, and "an operator stop stays stopped" holds without
+depending on `bootout` timing. `loom-daemon-stop.sh` also re-verifies (scoped to
+its launchd label) that no daemon is still alive after the stop and exits non-zero
+if one is, closing the silent-success hole where a failed bootout could leave a
+relaunched daemon dispatching.
+
 ### macOS session-bootstrap hazard (#3972)
 
 **Incident (2026-07-26).** The daemon was started at 21:48 via
@@ -1851,16 +1862,22 @@ after migration reported `13 seen, 3 dispatched, 0 error(s)`.
   `--health-gate` / `--from-config` semantics are preserved exactly — the
   launchd job never sees a wider or narrower autonomy configuration than a
   plain nohup start would have resolved.
-- **`RunAtLoad=true` / `KeepAlive=false`**: mirrors the hand-written plist that
-  validated this fix during the incident. `RunAtLoad=true` means the daemon
-  also survives a reboot/re-login, not just the death of one particular
-  session — strictly *more* durable than the pre-#3972 nohup contract (which
-  didn't survive a reboot either). `KeepAlive=false` means launchd does **not**
-  auto-respawn a crashed daemon; that responsibility stays with the reaper /
-  operator, unchanged from before. `loom-daemon-stop.sh` `bootout`s the loaded
-  definition after confirming the process is dead, specifically so an explicit
-  stop is honored at the next login too (otherwise `RunAtLoad=true` would
-  silently relaunch it).
+- **`RunAtLoad=true` / `KeepAlive={SuccessfulExit:true}`** (#4054): `RunAtLoad=true`
+  means the daemon survives a reboot/re-login, not just the death of one particular
+  session — strictly *more* durable than the pre-#3972 nohup contract (which didn't
+  survive a reboot either). `KeepAlive={SuccessfulExit:true}` (changed from the
+  earlier bare `KeepAlive=false`) is the **supervised restart primitive**: launchd
+  relaunches the job **only** when it exits with status `0`, and leaves it down on
+  any non-zero exit. Because the daemon exits **non-zero** on a crash/panic, on a
+  SIGTERM operator stop (143), and on a SIGINT/Ctrl-C (130), this **preserves** the
+  old no-crash-loop semantics of `KeepAlive=false` — none of those respawn — while
+  making the one deliberate clean-exit path (the `RestartDaemon` request, `loom-daemon
+  restart`) the *only* thing that trips a relaunch. `loom-daemon-stop.sh` still
+  `bootout`s the loaded definition after confirming the process is dead (so an
+  explicit stop is honored at the next login too), but the bootout is now
+  belt-and-braces: the non-zero SIGTERM exit already prevents launchd from relaunching
+  during the stop window. See [Supervised restart primitive](#supervised-restart-primitive-4054)
+  below and `docs/design/supervised-restart-primitive.md`.
 - **Escape hatch**: `--no-launchd` (or `LOOM_DAEMON_LAUNCHD=0`) forces the
   legacy nohup path even on Darwin — e.g. for a sandboxed/headless macOS runner
   with no GUI login session where `gui/<uid>` may not resolve.
@@ -1956,6 +1973,35 @@ changes, verifying `codesign` behavior across the self-update rebuild path,
 deciding whether the identifier needs to be stable across machines) and is
 intentionally left as a follow-up (#4016) rather than bundled into this
 issue's audit + working-set-contract + crash-recovery fix.
+
+### Supervised restart primitive (#4054)
+
+Phase 2 of #4017 (auto-rebuild-and-restart-when-stale). It ships a
+manually-triggerable way for the daemon to **end and reliably come back**, so
+Phase 3 has a *proven* restart path to call. It deliberately ships **no**
+automation — nothing fires it on its own.
+
+```bash
+loom-daemon restart          # send RestartDaemon over the IPC socket
+```
+
+- **Mechanism (macOS):** the plist uses `KeepAlive:{SuccessfulExit:true}` and the
+  daemon exits `0` **only** for a `RestartDaemon` request, so launchd relaunches
+  the job on that one clean exit and leaves it down on every other (SIGTERM 143,
+  SIGINT 130, crash non-zero). The relaunched process re-reads the same plist, so
+  it comes back with **exactly** its start flags/env — never wider. In-flight
+  sweeps survive (they are independent detached processes the daemon never cancels
+  on shutdown). Observable signature: a **new pid**.
+- **Supervision proof:** `loom-daemon-start.sh` bakes `LOOM_DAEMON_SUPERVISOR=launchd`
+  into the plist, and the daemon ends its process for a restart **only** when that
+  var is present. On an unsupervised host (nohup / Linux / `--foreground`) it
+  refuses: `loom-daemon restart` prints the refusal, exits non-zero, and the daemon
+  keeps running — because nothing would bring it back if it exited (#4017's "log
+  loudly, leave the daemon running, do not restart").
+- **Why launchd, not `exec` self-replacement:** the design record — including why
+  the `exec` (Option 2) and detached-helper (Option 3) alternatives were rejected,
+  and the Curator's exit-code-race finding — is in
+  `docs/design/supervised-restart-primitive.md`.
 
 ### Self-update (rebuild + provision + restart, #3968)
 

--- a/defaults/scripts/cli/loom-daemon-start.sh
+++ b/defaults/scripts/cli/loom-daemon-start.sh
@@ -142,12 +142,32 @@ resolve_launchd_label() {
 # (~/Library/LaunchAgents/com.rjwalters.loom-daemon.plist): RunAtLoad=true
 # (the daemon also comes back after a reboot/re-login, not just a session
 # death -- strictly more durable than the pre-#3972 nohup contract, which
-# didn't survive a reboot either) and KeepAlive=false (launchd does not
-# auto-respawn a crashed daemon; that stays the reaper/operator's job, same as
-# before). Lifecycle (first start / explicit stop) is still entirely
-# operator-driven via loom-daemon-start.sh / loom-daemon-stop.sh -- bootout on
-# stop unloads the definition so it does NOT come back at the next login. The
-# PATH is the CURRENT PATH plus a fallback set (~/.local/bin, ~/.cargo/bin,
+# didn't survive a reboot either).
+#
+# KeepAlive is `{ SuccessfulExit: true }` as of the supervised restart primitive
+# (#4054, Phase 2 of #4017): launchd relaunches the job ONLY when it exits with
+# status 0, and leaves it down on any non-zero exit. This is what lets the
+# daemon END and reliably COME BACK on demand -- the `RestartDaemon` IPC request
+# (loom-daemon restart) is the ONLY path that exits 0, so it is the only thing
+# that trips a relaunch. Crucially this PRESERVES the old no-crash-loop semantics
+# of KeepAlive=false: a crashed/panicked daemon, a SIGTERM'd operator stop (exit
+# 143), and a SIGINT/Ctrl-C (exit 130) all exit NON-ZERO, so launchd does NOT
+# respawn them. Making the exit code carry intent (daemon side, #4054) is also
+# what closes the SuccessfulExit/bootout race (Curator Finding 1): an operator
+# stop exits non-zero, so launchd never relaunches it during the stop window --
+# "an operator stop stays stopped" no longer depends on bootout timing. The
+# bootout in loom-daemon-stop.sh is demoted to belt-and-braces (it still unloads
+# the definition so it does not come back at the next login).
+#
+# LOOM_DAEMON_SUPERVISOR=launchd is baked into the plist env so the daemon can
+# PROVE it is supervised before it will exit for a restart. It is hardcoded here
+# (not harvested from the caller's env) so it lands in EVERY rendered plist --
+# and, conversely, is ABSENT from the nohup path (which never renders a plist),
+# so an unsupervised daemon correctly refuses to exit on a restart request
+# (nothing would bring it back). Because it survives in the plist, the relaunched
+# daemon still sees it.
+#
+# The PATH is the CURRENT PATH plus a fallback set (~/.local/bin, ~/.cargo/bin,
 # Homebrew, standard bin dirs) so `gh`, `git`, `cargo`, and `python3` resolve
 # inside the LaunchAgent's minimal launchd environment even if the interactive
 # shell's PATH customizations aren't present there. Every already-exported
@@ -162,12 +182,20 @@ render_launchd_plist() {
     local env_entries=""
     env_entries+="        <key>PATH</key>\n        <string>$(xml_escape "$plist_path_value")</string>\n"
     env_entries+="        <key>HOME</key>\n        <string>$(xml_escape "$HOME")</string>\n"
+    # Mark the daemon as launchd-supervised so its RestartDaemon handler (#4054)
+    # will exit 0 for a supervised relaunch. Hardcoded (not env-harvested) so it
+    # is present in every rendered plist and its relaunch, and never leaks to the
+    # unsupervised nohup path.
+    env_entries+="        <key>LOOM_DAEMON_SUPERVISOR</key>\n        <string>launchd</string>\n"
 
     local line key value
     while IFS= read -r line; do
         [[ -z "$line" ]] && continue
         key="${line%%=*}"
         value="${line#*=}"
+        # Never duplicate the supervisor key hardcoded above (a caller that
+        # exported LOOM_DAEMON_SUPERVISOR must not produce two plist entries).
+        [[ "$key" == "LOOM_DAEMON_SUPERVISOR" ]] && continue
         env_entries+="        <key>$(xml_escape "$key")</key>\n        <string>$(xml_escape "$value")</string>\n"
     done < <(env | grep -E '^(LOOM_[A-Za-z0-9_]*|GH_TOKEN|GITEA_TOKEN|FORGE_TOKEN)=' || true)
 
@@ -181,7 +209,10 @@ render_launchd_plist() {
     printf '%b' "$env_entries"
     printf '    </dict>\n'
     printf '    <key>RunAtLoad</key>\n    <true/>\n'
-    printf '    <key>KeepAlive</key>\n    <false/>\n'
+    # KeepAlive:SuccessfulExit=true (#4054): relaunch ONLY on a clean exit 0 (the
+    # RestartDaemon primitive). A crash/SIGTERM/SIGINT exits non-zero and is NOT
+    # respawned -- preserving the pre-#4054 no-crash-loop semantics of KeepAlive=false.
+    printf '    <key>KeepAlive</key>\n    <dict>\n        <key>SuccessfulExit</key>\n        <true/>\n    </dict>\n'
     printf '    <key>ProcessType</key>\n    <string>Background</string>\n'
     printf '    <key>StandardOutPath</key>\n    <string>%s</string>\n' "$(xml_escape "$log_path")"
     printf '    <key>StandardErrorPath</key>\n    <string>%s</string>\n' "$(xml_escape "$log_path")"

--- a/defaults/scripts/cli/loom-daemon-stop.sh
+++ b/defaults/scripts/cli/loom-daemon-stop.sh
@@ -25,9 +25,20 @@
 # RunAtLoad=true (mirroring the validated incident-fix plist), so leaving the
 # definition loaded would silently relaunch the daemon at the next login/boot
 # even though the operator explicitly stopped it. The pid-kill sequence itself
-# is unchanged (SIGTERM -> grace -> SIGKILL, sent directly to the resolved
-# pid) — launchd does not auto-respawn on a plain exit (KeepAlive=false), so
-# killing the process first is always safe.
+# is unchanged (SIGTERM -> grace -> SIGKILL, sent directly to the resolved pid).
+#
+# Interaction with the supervised restart primitive (#4054): the plist now uses
+# KeepAlive:{SuccessfulExit:true}, so launchd relaunches the daemon on a clean
+# exit 0. But the daemon exits NON-ZERO on SIGTERM (143) and SIGINT (130), so an
+# operator stop is NOT a "successful" exit and launchd does not relaunch it -- the
+# "operator stop stays stopped" guarantee holds WITHOUT depending on bootout
+# timing (Curator Finding 1). SIGKILL (--force) likewise terminates the job by
+# signal, never a clean exit, so it is not respawned either. The bootout below is
+# therefore belt-and-braces (it still unloads the definition so it does not come
+# back at the next login). After the stop this script re-verifies that no daemon
+# for THIS launchd label is still alive and exits non-zero if one is -- closing
+# the inverted-#4011 silent-success hole where a failed bootout could leave a
+# relaunched daemon dispatching while the script reported success.
 #
 # Usage:
 #   ./.loom/scripts/cli/loom-daemon-stop.sh            Graceful stop (SIGTERM -> SIGKILL)
@@ -173,6 +184,25 @@ fi
 # confirmed dead -- RunAtLoad=true on the generated plist means leaving it
 # loaded would silently relaunch the daemon at the next login/boot.
 launchd_bootout_if_loaded
+
+# Post-stop verification (#4054): assert no daemon for THIS launchd label is
+# still alive, rather than trusting that killing the original pid was enough.
+# Under KeepAlive:SuccessfulExit a relaunched daemon carries a DIFFERENT pid than
+# the one we killed, so re-testing the original pid alone would miss it. A
+# still-loaded job with a live pid means the bootout did not stick (the
+# inverted-#4011 silent-success hole) -- fail loudly instead of reporting
+# success. Scoped to this label (not a global `pgrep loom-daemon`) so a test
+# daemon under a non-default LOOM_LAUNCHD_LABEL never false-positives against a
+# separate production daemon, and vice versa.
+if launchd_job_loaded; then
+    relaunched_pid=$(launchd_job_pid)
+    if [[ -n "$relaunched_pid" ]] && kill -0 "$relaunched_pid" 2>/dev/null; then
+        err "loom-daemon is still alive (pid $relaunched_pid) under $LAUNCHD_SERVICE after stop."
+        err "The launchd bootout did not stick — the daemon may still be dispatching."
+        err "Retry the stop, or bootout manually: launchctl bootout $LAUNCHD_SERVICE"
+        exit 1
+    fi
+fi
 
 rm -f "$PID_FILE"
 ok "loom-daemon stopped (pid $pid)."

--- a/defaults/scripts/tests/test-loom-daemon-launchd-plist.sh
+++ b/defaults/scripts/tests/test-loom-daemon-launchd-plist.sh
@@ -104,12 +104,18 @@ fi
 assert_eq "0" "$plist_rc" "--print-plist exits 0"
 assert_eq "$before_count" "$after_count" "--print-plist never writes to ~/Library/LaunchAgents"
 
-# 2. Plain start: RunAtLoad/KeepAlive false, both autonomy loops OFF present
-#    and equal to 0 (FLAGS-OFF default, #3911 semantics preserved), PATH
-#    covers gh/git/cargo/python3 fallback dirs.
+# 2. Plain start: RunAtLoad true, KeepAlive:{SuccessfulExit:true} (#4054 —
+#    relaunch only on a clean exit 0, i.e. the RestartDaemon primitive; a
+#    crash/SIGTERM/SIGINT exits non-zero and is NOT respawned, preserving the
+#    old no-crash-loop semantics), LOOM_DAEMON_SUPERVISOR=launchd baked in, both
+#    autonomy loops OFF present and equal to 0 (FLAGS-OFF default, #3911
+#    semantics preserved), PATH covers gh/git/cargo/python3 fallback dirs.
 assert_contains "$plist_out" "<key>RunAtLoad</key>" "plist declares RunAtLoad"
 assert_contains "$plist_out" $'<key>RunAtLoad</key>\n    <true/>' "RunAtLoad is true (mirrors the validated incident-fix plist; survives reboot/re-login)"
-assert_contains "$plist_out" $'<key>KeepAlive</key>\n    <false/>' "KeepAlive is false (no launchd auto-restart on crash)"
+assert_contains "$plist_out" $'<key>KeepAlive</key>\n    <dict>' "KeepAlive is a dict (SuccessfulExit form, #4054)"
+assert_contains "$plist_out" $'<key>SuccessfulExit</key>\n        <true/>' "KeepAlive.SuccessfulExit is true (relaunch only on the restart primitive's clean exit 0)"
+assert_not_contains "$plist_out" $'<key>KeepAlive</key>\n    <false/>' "KeepAlive is no longer the bare <false/> form"
+assert_contains "$plist_out" $'<key>LOOM_DAEMON_SUPERVISOR</key>\n        <string>launchd</string>' "plist bakes in LOOM_DAEMON_SUPERVISOR=launchd (daemon proves supervision before a restart, #4054)"
 assert_contains "$plist_out" "<key>LOOM_WORK_FINDER</key>" "plain start forwards LOOM_WORK_FINDER"
 assert_contains "$plist_out" $'<key>LOOM_WORK_FINDER</key>\n        <string>0</string>' "plain start: LOOM_WORK_FINDER=0 (FLAGS-OFF default)"
 assert_contains "$plist_out" $'<key>LOOM_MAIN_HEALTH_GATE</key>\n        <string>0</string>' "plain start: LOOM_MAIN_HEALTH_GATE=0 (FLAGS-OFF default)"

--- a/defaults/scripts/tests/test-loom-daemon-stop.sh
+++ b/defaults/scripts/tests/test-loom-daemon-stop.sh
@@ -118,6 +118,63 @@ else
     echo -e "${RED}✗${NC} --help documents the launchd bootout counterpart"
 fi
 
+# 5. The bootout path is unchanged (#4054 must not remove it — it stays as
+#    belt-and-braces alongside the new exit-code-carries-intent contract).
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -q 'launchctl bootout' "$STOP_SCRIPT" && grep -q 'launchd_bootout_if_loaded' "$STOP_SCRIPT"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} bootout path unchanged (launchd_bootout_if_loaded + launchctl bootout still present)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} bootout path unchanged (launchd_bootout_if_loaded + launchctl bootout still present)"
+fi
+
+# 6. Stop must NOT report success while a daemon is still alive (#4054): if the
+#    launchd job for the label remains loaded with a live pid after the stop (a
+#    bootout that did not stick — the inverted-#4011 silent-success hole), the
+#    script exits non-zero. Darwin-only: `launchd_job_loaded` short-circuits on
+#    non-Darwin, so the relaunch-detection branch cannot run there.
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    FAKE_BIN_DIR="$WORKDIR/fakebin"
+    mkdir -p "$FAKE_BIN_DIR"
+    # Fake launchctl: reports the job as loaded and names the "relaunched"
+    # daemon's pid, and treats bootout as a no-op (simulating a bootout that
+    # failed to stop the relaunched instance).
+    cat > "$FAKE_BIN_DIR/launchctl" <<'FAKE'
+#!/usr/bin/env bash
+case "$1" in
+  print)   printf '\tpid = %s\n' "${RELAUNCH_PID:-0}"; exit 0 ;;
+  bootout) exit 0 ;;
+  *)       exit 0 ;;
+esac
+FAKE
+    chmod +x "$FAKE_BIN_DIR/launchctl"
+
+    # Original daemon (killed by the stop) + a separate live "relaunched" daemon.
+    ( sleep 30 & echo $! > "$SLEEP_PID_FILE" )
+    orig_pid=$(cat "$SLEEP_PID_FILE")
+    sleep 30 &
+    relaunch_pid=$!
+
+    stuck_out=$( cd "$WORKDIR" && PATH="$FAKE_BIN_DIR:$PATH" RELAUNCH_PID="$relaunch_pid" \
+        LOOM_LAUNCHD_LABEL="$FAKE_LABEL" LOOM_DAEMON_STOP_GRACE_SECS=2 bash "$STOP_SCRIPT" 2>&1 )
+    stuck_rc=$?
+
+    assert_eq "1" "$stuck_rc" "relaunched-daemon-still-alive: stop exits non-zero (does not report success)"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if echo "$stuck_out" | grep -qi 'still alive'; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "${GREEN}✓${NC} relaunched-daemon-still-alive: reports the live daemon instead of success"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "${RED}✗${NC} relaunched-daemon-still-alive: reports the live daemon instead of success"
+    fi
+
+    kill -9 "$orig_pid" "$relaunch_pid" 2>/dev/null || true
+else
+    echo "  (skipping relaunch-detection test — not Darwin)"
+fi
+
 # ---------- summary ----------
 echo
 echo "Ran $TESTS_RUN tests: $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/docs/design/supervised-restart-primitive.md
+++ b/docs/design/supervised-restart-primitive.md
@@ -1,0 +1,134 @@
+# Supervised restart primitive (Issue #4054, Phase 2 of #4017)
+
+**Status:** implemented
+**Decision record for:** how `loom-daemon` deliberately ends and reliably comes
+back, so #4017 Phase 3 (auto-rebuild-and-restart-when-stale) has a *proven*
+restart primitive to call.
+
+## Problem
+
+#4017 identified the hard part precisely: **a process cannot reliably restart
+itself.** The macOS LaunchAgent that runs `loom-daemon` (`render_launchd_plist`
+in `defaults/scripts/cli/loom-daemon-start.sh`) had `KeepAlive: false`, so there
+was no supervisor that would bring the daemon back after it exited. If the daemon
+spawned `loom-daemon-update.sh` as a child, that helper lives inside the launchd
+job's process tree, and its call to `loom-daemon-stop.sh` → `launchctl bootout`
+tears the tree down — killing the very helper meant to start the replacement. The
+failure mode is *worse than the status quo*: an unattended daemon that takes
+itself down permanently.
+
+## Chosen mechanism: Option 1 — split rebuild from restart, supervised by launchd
+
+The daemon does the safe part (rebuild/provision — #4053) in-process and then only
+needs to **end**. Restart becomes the supervisor's job:
+
+- **Plist:** `KeepAlive: { SuccessfulExit: true }` — launchd relaunches the job
+  **only** when it exits with status `0`, and leaves it down on any non-zero exit.
+- **Trigger:** a new `RestartDaemon` IPC request (`loom-daemon restart`). It is the
+  **only** path that exits the process with status `0`, so it is the only thing
+  that trips a relaunch. It never fires on its own — nothing in the daemon issues
+  it. #4017 Phase 3 will call it after a successful rebuild.
+- **Exit code carries intent** (Curator Finding 1, the load-bearing fix):
+
+  | Shutdown cause                | Exit code | launchd action under `SuccessfulExit: true` |
+  |-------------------------------|-----------|---------------------------------------------|
+  | `RestartDaemon` primitive     | `0`       | relaunch — the desired path                 |
+  | SIGTERM (operator stop)       | `143`     | **no relaunch**                             |
+  | SIGINT (interactive Ctrl-C)   | `130`     | no relaunch                                 |
+  | IPC `Shutdown` request        | `143`     | no relaunch                                 |
+  | crash / panic                 | non-zero  | no relaunch (preserves no-crash-loop)       |
+
+- **Supervision proof:** the daemon only ends its process for a restart when it can
+  prove it is supervised. `loom-daemon-start.sh` bakes
+  `LOOM_DAEMON_SUPERVISOR=launchd` into the plist `EnvironmentVariables` (so it
+  survives a relaunch). On an unsupervised host (nohup / Linux / `--foreground`)
+  the var is absent, and `RestartDaemon` **refuses**: it logs loudly, leaves the
+  daemon running, and returns `DaemonRestart { scheduled: false }`. This is #4017's
+  "log loudly, leave the daemon running, do not restart" for the no-supervisor case.
+
+### Why the exit-code change is the crux (Curator Finding 1)
+
+Before #4054 the daemon exited `0` on **both** SIGINT and SIGTERM. Under
+`SuccessfulExit: true`, an operator stop (`loom-daemon-stop.sh` sends SIGTERM and
+only *then*, after the process is dead, calls `bootout`) would be a **clean exit
+while the job is still loaded** — so launchd would relaunch the daemon in the
+window before the bootout lands. Because `launchd_bootout_if_loaded` swallows all
+errors and the stop script only re-checked the *original* pid, a failed bootout
+would print `loom-daemon stopped` with a relaunched daemon still dispatching — the
+#4011 silent-divergence shape, inverted.
+
+Making the exit code carry intent removes the race entirely: a SIGTERM'd daemon
+exits `143`, which is **not** a successful exit, so launchd never relaunches it
+during an operator stop. "An operator stop stays stopped" now holds **without
+depending on bootout timing**; the bootout is demoted to belt-and-braces (it still
+unloads the definition so the job does not come back at the next login). This also
+preserves the pre-#4054 no-crash-loop semantics of `KeepAlive: false`: a crashed
+or SIGKILL'd daemon terminates non-cleanly and is **not** respawned.
+
+`loom-daemon-stop.sh` additionally re-verifies, **scoped to its launchd label**,
+that no daemon is still alive after the stop and exits non-zero if one is — closing
+the inverted-#4011 silent-success hole. The check is label-scoped (not a global
+`pgrep loom-daemon`) so a test daemon under a non-default `LOOM_LAUNCHD_LABEL`
+never false-positives against a separate production daemon.
+
+## Alternatives rejected
+
+### Option 2 — `exec` self-replacement
+
+After installing the new binary, the daemon `execve()`s it in place: same pid,
+launchd never notices, no plist change. Rejected for this primitive because:
+
+- **It does not prove what this issue asks.** The issue is titled "prove the daemon
+  can end and *reliably come back under launchd*." Option 2 deliberately *sidesteps*
+  launchd — it proves in-place replacement, not that the supervisor brings the
+  daemon back. Phase 2 is exactly the phase that must retire the "can a process
+  restart itself?" unknown by handing the job to a real supervisor.
+- **Concrete hazards (Curator Finding 2).** The singleton guard is **socket-based**
+  (`ipc.rs::socket_has_live_listener`), so an `exec` must `remove_file` the socket
+  before re-exec or the re-exec'd image trips its own guard on the socket it still
+  owns; the listening fd must be `FD_CLOEXEC` so it is not inherited across the
+  exec; and in-flight IPC/registry state must be handled. Each is a sharp edge on
+  the *supervision* path, where the blast radius of a mistake is total unattended
+  autonomy loss.
+- Its genuine upside (same pid ⇒ no plist change ⇒ sidesteps Finding 1) is real but
+  does not outweigh "doesn't actually exercise the supervisor." It remains a
+  reasonable future optimization for a rebuild that wants zero relaunch latency.
+
+### Option 3 — detached helper
+
+A helper process that genuinely escapes the launchd job tree and starts the
+replacement. Rejected: strictly more complex than Option 1, and it requires proving
+the helper survives `bootout` — the exact fragility #4017 flagged. Only worth it if
+1 and 2 both failed; 1 works.
+
+## Non-macOS / unsupervised
+
+The `nohup` path (`loom-daemon-start.sh` when `launchctl` is absent, and Linux)
+has no supervisor. Per #4017 the daemon degrades to "log loudly, leave the daemon
+running, do not restart": `RestartDaemon` returns `DaemonRestart { scheduled:
+false }` and the process keeps running, because exiting with nothing to relaunch it
+would be strictly worse than the status quo.
+
+## Verification
+
+Automated: `cargo test --workspace`; the three `defaults/scripts/tests/
+test-loom-daemon-*.sh` suites (plist pins the new `KeepAlive`/supervisor values;
+stop-path asserts bootout unchanged + the label-scoped still-alive guard); and a
+serde round-trip + supervisor-gating unit test in `loom-daemon/src/ipc.rs`.
+
+Manual (live launchd, against an **isolated** `LOOM_LAUNCHD_LABEL` +
+`LOOM_SOCKET_PATH`, never the production `com.rjwalters.loom-daemon`):
+
+- Restart primitive: daemon exited `0`, launchd relaunched it with a **new pid**,
+  and the relaunched process kept `LOOM_DAEMON_SUPERVISOR=launchd`.
+- Operator stop: SIGTERM → daemon did **not** come back across the relaunch window;
+  job unloaded; stop exited `0`.
+- Crash: `SIGKILL` → **not** respawned (no crash loop).
+- Exit-code contract: SIGTERM → `143`, SIGINT → `130`.
+
+In-flight-sweep survival was **not** exercised live (dispatching a real sweep runs
+an actual, side-effecting Claude session), but it holds by construction: the restart
+is a plain process exit + launchd relaunch, and sweep children are independent
+detached processes the daemon never cancels on shutdown (the documented "survive,
+don't drain" decision). Recommended as a manual follow-up on a canary before Phase 3
+builds on top of it.

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -25,6 +25,97 @@ use tokio::net::{UnixListener, UnixStream};
 /// hung or unresponsive peer can never stall daemon startup.
 const LIVENESS_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
 
+// ============================================================================
+// Shutdown-intent exit codes (Issue #4054 — supervised restart primitive)
+// ============================================================================
+// Under the macOS launchd `KeepAlive: { SuccessfulExit: true }` contract (see
+// `render_launchd_plist` in `loom-daemon-start.sh`), launchd relaunches the job
+// ONLY when it exits with status 0 ("successful"), and leaves it down on any
+// non-zero exit. The daemon therefore encodes *why* it is shutting down in its
+// exit code so exactly one path — the restart primitive — trips a relaunch:
+//
+//   | Cause                         | Exit code       | launchd action    |
+//   |-------------------------------|-----------------|-------------------|
+//   | RestartDaemon (this primitive)| 0  EXIT_RESTART | relaunch (wanted) |
+//   | SIGTERM (operator stop)       | 143 EXIT_SIGTERM| NO relaunch       |
+//   | SIGINT  (interactive Ctrl-C)  | 130 EXIT_SIGINT | NO relaunch       |
+//   | IPC Shutdown request          | 143 EXIT_SHUTDOWN| NO relaunch      |
+//   | crash / panic                 | non-zero        | NO relaunch       |
+//
+// This is Curator Finding 1's remedy: because a SIGTERM'd daemon now exits
+// non-zero, launchd never relaunches it during an operator stop, so "an operator
+// stop stays stopped" holds WITHOUT depending on `bootout` timing (the bootout
+// in `loom-daemon-stop.sh` is demoted to belt-and-braces). It also preserves the
+// pre-existing no-crash-loop semantics: a crashed daemon exits non-zero and is
+// not respawned, exactly as under the old `KeepAlive: false`.
+
+/// Exit code for the supervised restart primitive: the ONLY exit that trips a
+/// launchd `SuccessfulExit` relaunch.
+pub const EXIT_RESTART: i32 = 0;
+/// Exit code for a SIGTERM-driven operator stop (128 + SIGTERM 15). Non-zero so
+/// launchd does not relaunch.
+pub const EXIT_SIGTERM: i32 = 143;
+/// Exit code for an interactive SIGINT / Ctrl-C (128 + SIGINT 2). Non-zero so
+/// launchd does not relaunch.
+pub const EXIT_SIGINT: i32 = 130;
+/// Exit code for an explicit IPC `Shutdown` request. Non-zero — an explicit
+/// shutdown means "stay down", so launchd must not relaunch.
+pub const EXIT_SHUTDOWN: i32 = 143;
+
+/// Detect the daemon's process supervisor from the environment (#4054).
+///
+/// Returns `Some("launchd")` when `LOOM_DAEMON_SUPERVISOR=launchd`
+/// (case-insensitive) is present — a value `loom-daemon-start.sh` bakes into the
+/// launchd plist's `EnvironmentVariables`, so it survives a relaunch. Any other
+/// or absent value ⇒ `None` (the daemon is unsupervised: nohup / Linux /
+/// `--foreground`), and the restart primitive must refuse to end the process
+/// because nothing would bring it back.
+pub fn detect_supervisor() -> Option<String> {
+    match std::env::var("LOOM_DAEMON_SUPERVISOR") {
+        Ok(v) if v.eq_ignore_ascii_case("launchd") => Some("launchd".to_string()),
+        _ => None,
+    }
+}
+
+/// Decide how to answer a `RestartDaemon` request (Issue #4054): the `Response`
+/// to send back, plus whether the daemon should then end its own process (exit
+/// [`EXIT_RESTART`]) for a supervised relaunch.
+///
+/// The daemon ends itself ONLY when [`detect_supervisor`] proves it is
+/// supervised. On an unsupervised host it refuses, stays running, and returns a
+/// `DaemonRestart { scheduled: false, .. }` — degrading to "log loudly, leave
+/// the daemon running, do not restart" per #4017, because exiting with no
+/// supervisor to relaunch it would be strictly worse than the status quo.
+pub fn build_restart_decision() -> (Response, bool) {
+    match detect_supervisor() {
+        Some(sup) => (
+            Response::DaemonRestart {
+                scheduled: true,
+                supervisor: Some(sup.clone()),
+                message: format!(
+                    "restart scheduled: exiting 0 for a {sup}-supervised relaunch. \
+                     In-flight sweeps survive by design; the relaunched daemon re-reads \
+                     the same launchd plist, so it comes back with exactly its start flags."
+                ),
+            },
+            true,
+        ),
+        None => (
+            Response::DaemonRestart {
+                scheduled: false,
+                supervisor: None,
+                message: "refusing to restart: no supervisor detected \
+                    (LOOM_DAEMON_SUPERVISOR unset). This daemon was not started under \
+                    launchd (nohup / Linux / --foreground), so nothing would relaunch it \
+                    if it exited. Leaving it running. Restart it manually with \
+                    loom-daemon-stop.sh && loom-daemon-start.sh."
+                    .to_string(),
+            },
+            false,
+        ),
+    }
+}
+
 /// Returns `true` if a live `loom-daemon` is currently listening on
 /// `socket_path` and actively servicing requests.
 ///
@@ -275,6 +366,31 @@ async fn handle_client(
             let response_json = serde_json::to_string(&response)?;
             writer.write_all(response_json.as_bytes()).await?;
             writer.write_all(b"\n").await?;
+            continue;
+        }
+
+        // RestartDaemon (Issue #4054) is handled here rather than in the
+        // synchronous `handle_request` dispatcher so the supervised path can
+        // reply to the client and FLUSH before ending the process — the
+        // operator / Phase-3 caller gets a clean ack, then the daemon exits 0
+        // for a launchd `KeepAlive:SuccessfulExit` relaunch. On an unsupervised
+        // host it returns `DaemonRestart { scheduled: false }` and keeps running
+        // (do_exit == false). Mirrors the CancelSweep/DaemonStatus interception.
+        if let Request::RestartDaemon = request {
+            let (response, do_exit) = build_restart_decision();
+            let response_json = serde_json::to_string(&response)?;
+            writer.write_all(response_json.as_bytes()).await?;
+            writer.write_all(b"\n").await?;
+            writer.flush().await?;
+            if do_exit {
+                log::warn!(
+                    "RestartDaemon: supervised — exiting {EXIT_RESTART} for a launchd \
+                     KeepAlive:SuccessfulExit relaunch. In-flight sweeps survive by design; \
+                     the relaunched daemon re-reads the same plist (exactly its start flags). \
+                     The stale socket is reclaimed by the relaunched daemon's singleton guard."
+                );
+                std::process::exit(EXIT_RESTART);
+            }
             continue;
         }
 
@@ -1414,8 +1530,20 @@ fn handle_request(
         Request::RemoveWatch { id } => handle_remove_watch(&id),
 
         Request::Shutdown => {
-            log::info!("Shutdown requested");
-            std::process::exit(0);
+            // Exit NON-ZERO (Issue #4054): an explicit shutdown means "stay
+            // down", so under launchd `KeepAlive:SuccessfulExit` this must not
+            // trip a relaunch. Only `RestartDaemon` (handled in `handle_client`)
+            // exits 0. See the EXIT_* constants at the top of this module.
+            log::info!("Shutdown requested (exiting {EXIT_SHUTDOWN}; not a supervised relaunch)");
+            std::process::exit(EXIT_SHUTDOWN);
+        }
+        Request::RestartDaemon => {
+            // Structurally unreachable: `handle_client` intercepts
+            // `RestartDaemon` before dispatching to `handle_request` (it must
+            // reply-then-exit). Answer defensively in case of a future direct
+            // caller — do NOT exit here, only `handle_client` may end the
+            // process for a supervised relaunch.
+            build_restart_decision().0
         }
     }
 }
@@ -2717,6 +2845,122 @@ exit 0
             }
             other => panic!("Expected DaemonStatus, got: {other:?}"),
         }
+    }
+
+    // ===== Supervised restart primitive (Issue #4054) =====
+
+    /// `Request::RestartDaemon` / `Response::DaemonRestart` must survive a serde
+    /// round-trip over the wire (same pattern as the Ping/Pong + DaemonStatus
+    /// round-trips above).
+    #[test]
+    fn test_restart_daemon_request_response_round_trip() {
+        // Request: unit variant, `{"type":"RestartDaemon"}`.
+        let req = Request::RestartDaemon;
+        let json = serde_json::to_string(&req).expect("serialize request");
+        assert_eq!(json, r#"{"type":"RestartDaemon"}"#);
+        let back: Request = serde_json::from_str(&json).expect("deserialize request");
+        assert!(matches!(back, Request::RestartDaemon));
+
+        // Response (supervised / scheduled).
+        let resp = Response::DaemonRestart {
+            scheduled: true,
+            supervisor: Some("launchd".to_string()),
+            message: "restart scheduled".to_string(),
+        };
+        let json = serde_json::to_string(&resp).expect("serialize response");
+        let back: Response = serde_json::from_str(&json).expect("deserialize response");
+        match back {
+            Response::DaemonRestart {
+                scheduled,
+                supervisor,
+                message,
+            } => {
+                assert!(scheduled);
+                assert_eq!(supervisor.as_deref(), Some("launchd"));
+                assert_eq!(message, "restart scheduled");
+            }
+            other => panic!("Expected DaemonRestart, got: {other:?}"),
+        }
+
+        // Response (unsupervised / refused).
+        let resp = Response::DaemonRestart {
+            scheduled: false,
+            supervisor: None,
+            message: "refused".to_string(),
+        };
+        let json = serde_json::to_string(&resp).expect("serialize response");
+        let back: Response = serde_json::from_str(&json).expect("deserialize response");
+        match back {
+            Response::DaemonRestart {
+                scheduled,
+                supervisor,
+                ..
+            } => {
+                assert!(!scheduled);
+                assert!(supervisor.is_none());
+            }
+            other => panic!("Expected DaemonRestart, got: {other:?}"),
+        }
+    }
+
+    /// `build_restart_decision` ends the process (do_exit == true) ONLY when the
+    /// daemon proves it is launchd-supervised via `LOOM_DAEMON_SUPERVISOR`; an
+    /// unsupervised host refuses and stays running. Also pins the shutdown-intent
+    /// exit-code contract (#4054): only the restart primitive exits 0, so under
+    /// launchd `KeepAlive:SuccessfulExit` it is the only path that relaunches.
+    ///
+    /// NOTE: this is the sole test touching `LOOM_DAEMON_SUPERVISOR`, so the
+    /// env-var mutation cannot race another test reading it.
+    #[test]
+    fn test_build_restart_decision_supervisor_gated() {
+        // Exit-code contract: exactly one exit-0 path.
+        assert_eq!(EXIT_RESTART, 0, "restart is the only successful (relaunch) exit");
+        assert_ne!(EXIT_SIGTERM, 0, "SIGTERM stop must be non-zero (no relaunch)");
+        assert_ne!(EXIT_SIGINT, 0, "SIGINT/Ctrl-C must be non-zero (no relaunch)");
+        assert_ne!(EXIT_SHUTDOWN, 0, "explicit Shutdown must be non-zero (no relaunch)");
+
+        // Supervised: scheduled + do_exit.
+        std::env::set_var("LOOM_DAEMON_SUPERVISOR", "launchd");
+        assert_eq!(detect_supervisor().as_deref(), Some("launchd"));
+        let (resp, do_exit) = build_restart_decision();
+        assert!(do_exit, "supervised daemon must end its process for a relaunch");
+        match resp {
+            Response::DaemonRestart {
+                scheduled,
+                supervisor,
+                ..
+            } => {
+                assert!(scheduled);
+                assert_eq!(supervisor.as_deref(), Some("launchd"));
+            }
+            other => panic!("Expected DaemonRestart, got: {other:?}"),
+        }
+
+        // Case-insensitive acceptance.
+        std::env::set_var("LOOM_DAEMON_SUPERVISOR", "LaunchD");
+        assert_eq!(detect_supervisor().as_deref(), Some("launchd"));
+
+        // Unsupervised (var unset): refuse, keep running.
+        std::env::remove_var("LOOM_DAEMON_SUPERVISOR");
+        assert!(detect_supervisor().is_none());
+        let (resp, do_exit) = build_restart_decision();
+        assert!(!do_exit, "unsupervised daemon must NOT exit — nothing would relaunch it");
+        match resp {
+            Response::DaemonRestart {
+                scheduled,
+                supervisor,
+                ..
+            } => {
+                assert!(!scheduled);
+                assert!(supervisor.is_none());
+            }
+            other => panic!("Expected DaemonRestart, got: {other:?}"),
+        }
+
+        // An unrelated value is also unsupervised.
+        std::env::set_var("LOOM_DAEMON_SUPERVISOR", "systemd");
+        assert!(detect_supervisor().is_none());
+        std::env::remove_var("LOOM_DAEMON_SUPERVISOR");
     }
 
     /// A pre-#3902 `DaemonStatus` JSON payload (no `capacity` field, no

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -180,6 +180,16 @@ enum Commands {
         action: WatchAction,
     },
 
+    /// Deliberately restart the running daemon (Issue #4054 — the supervised
+    /// restart primitive). Sends a `RestartDaemon` request over the Unix socket;
+    /// when the daemon is supervised by launchd it exits 0 for a clean
+    /// `KeepAlive:SuccessfulExit` relaunch (a new pid, exactly its start flags,
+    /// in-flight sweeps preserved). On an unsupervised host (nohup / Linux /
+    /// `--foreground`) the daemon refuses and stays running, and this command
+    /// prints the refusal and exits non-zero. This is the primitive #4017 Phase
+    /// 3 will call after a rebuild — it does nothing on its own.
+    Restart,
+
     /// Validate role configuration completeness
     Validate {
         /// Workspace directory containing .loom/config.json
@@ -329,6 +339,9 @@ async fn main() -> Result<()> {
             // `watch` connects to the running daemon over its Unix socket to
             // register/list/remove durable watches (Issue #3971).
             Commands::Watch { action } => handle_watch_command(action).await,
+            // `restart` connects to the running daemon over its Unix socket to
+            // trigger the supervised restart primitive (Issue #4054).
+            Commands::Restart => handle_restart_command().await,
             other => handle_cli_command(other),
         };
     }
@@ -872,8 +885,18 @@ async fn main() -> Result<()> {
             flag.store(true, std::sync::atomic::Ordering::Relaxed);
         }
         let _ = tokio::fs::remove_file(&socket_path_clone).await;
-        log::info!("Socket cleaned up, exiting");
-        std::process::exit(0);
+        // Exit code carries shutdown intent (Issue #4054, Curator Finding 1):
+        // under launchd `KeepAlive:SuccessfulExit` a clean exit(0) triggers a
+        // relaunch, so a signal-driven stop MUST exit non-zero — otherwise an
+        // operator stop would race launchd into relaunching the daemon. Only the
+        // `RestartDaemon` primitive exits 0. SIGTERM => 143, SIGINT => 130.
+        let code = if signal_name == "SIGTERM" {
+            loom_daemon::ipc::EXIT_SIGTERM
+        } else {
+            loom_daemon::ipc::EXIT_SIGINT
+        };
+        log::info!("Socket cleaned up, exiting {code} (operator stop — no supervised relaunch)");
+        std::process::exit(code);
     });
 
     log::info!("Loom daemon starting...");
@@ -1117,6 +1140,11 @@ fn handle_cli_command(command: Commands) -> Result<()> {
             // Routed directly in `main()` (it needs the async runtime for the
             // socket round-trip), never dispatched through this sync handler.
             unreachable!("Watch is handled in main() before handle_cli_command")
+        }
+        Commands::Restart => {
+            // Routed directly in `main()` (it needs the async runtime for the
+            // socket round-trip), never dispatched through this sync handler.
+            unreachable!("Restart is handled in main() before handle_cli_command")
         }
         Commands::Init {
             workspace,
@@ -1389,6 +1417,54 @@ async fn handle_quarantine_command(action: QuarantineAction) -> Result<()> {
                     std::process::exit(1);
                 }
             }
+        }
+    }
+}
+
+/// Handle the `restart` subcommand (Issue #4054 — the supervised restart
+/// primitive). Connects to the running daemon over its Unix socket and sends a
+/// single `RestartDaemon` request.
+///
+/// When the daemon is supervised (launchd) it replies `DaemonRestart {
+/// scheduled: true }` and then exits 0 for a `KeepAlive:SuccessfulExit`
+/// relaunch — we print the ack and exit 0. When it is unsupervised (nohup /
+/// Linux / `--foreground`) it replies `DaemonRestart { scheduled: false }` and
+/// keeps running — we print the refusal and exit non-zero, so an operator or
+/// Phase 3 can detect that no restart happened rather than assuming it did.
+async fn handle_restart_command() -> Result<()> {
+    let socket_path = resolve_socket_path()?;
+    match query_daemon(&socket_path, &Request::RestartDaemon).await {
+        Ok(Response::DaemonRestart {
+            scheduled,
+            supervisor,
+            message,
+        }) => {
+            if scheduled {
+                println!(
+                    "loom-daemon restart scheduled (supervisor: {}).",
+                    supervisor.as_deref().unwrap_or("unknown")
+                );
+                println!("{message}");
+                Ok(())
+            } else {
+                eprintln!("loom-daemon did NOT restart: {message}");
+                std::process::exit(1);
+            }
+        }
+        Ok(Response::Error { message }) => {
+            eprintln!("Daemon error: {message}");
+            std::process::exit(1);
+        }
+        Ok(other) => {
+            eprintln!("Unexpected response from daemon: {other:?}");
+            std::process::exit(1);
+        }
+        Err(e) => {
+            eprintln!("Could not reach loom-daemon at {}: {e}", socket_path.display());
+            eprintln!();
+            eprintln!("Is the daemon running? Start it with:");
+            eprintln!("  ./.loom/scripts/cli/loom-daemon-start.sh");
+            std::process::exit(1);
         }
     }
 }

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -353,6 +353,31 @@ pub enum Request {
     RemoveWatch {
         id: String,
     },
+    // ========================================================================
+    // Supervised restart primitive (Issue #4054 — Phase 2 of #4017)
+    // ========================================================================
+    /// Deliberately restart the daemon by ending the current process so the
+    /// supervisor (macOS launchd) relaunches it — the manually-triggerable
+    /// restart primitive #4017 Phase 3 will call to complete an auto-roll.
+    ///
+    /// This is the ONLY path that exits the process with status `0`. Under the
+    /// launchd `KeepAlive: { SuccessfulExit: true }` contract (see
+    /// `render_launchd_plist` in `loom-daemon-start.sh`), a clean exit-0
+    /// triggers a relaunch, while every operator/signal/crash exit is non-zero
+    /// and does NOT relaunch. The relaunched process re-reads the same plist, so
+    /// it comes back with EXACTLY the flags/env it was started with — never
+    /// wider.
+    ///
+    /// The daemon only ends the process when it can prove it is supervised
+    /// (`LOOM_DAEMON_SUPERVISOR=launchd`, baked into the plist by the start
+    /// script). On an unsupervised host (nohup / Linux / `--foreground`) it
+    /// refuses: it logs loudly, leaves itself running, and returns a
+    /// `DaemonRestart { scheduled: false, .. }` — there is no supervisor that
+    /// would bring it back, and exiting would be strictly worse than the status
+    /// quo (#4017).
+    ///
+    /// It never fires on its own — nothing in the daemon issues this request.
+    RestartDaemon,
     Shutdown,
 }
 
@@ -485,6 +510,19 @@ pub enum Response {
     /// Result of a `DaemonStatus` request — the autonomous-mode operability
     /// snapshot rendered by `loom-daemon status`.
     DaemonStatus(DaemonStatusReport),
+    /// Result of a `RestartDaemon` request (Issue #4054).
+    ///
+    /// `scheduled` is `true` when the daemon is supervised and is about to exit
+    /// `0` for a supervised relaunch (the process ends immediately after this
+    /// frame is flushed). It is `false` when the daemon is NOT supervised and
+    /// therefore refused to exit — the daemon stays running. `supervisor` names
+    /// the detected supervisor (`Some("launchd")`) or `None` when unsupervised,
+    /// and `message` is a human-readable explanation for operator output.
+    DaemonRestart {
+        scheduled: bool,
+        supervisor: Option<String>,
+        message: String,
+    },
     // ========================================================================
     // Workspace Registry Responses (Issue #3926 — phase 1 of #3835)
     // ========================================================================


### PR DESCRIPTION
## Summary

Phase 2 of #4017 — a **manually-triggerable restart primitive** that is proven to make the daemon end and reliably come back under macOS launchd, so Phase 3 (auto-rebuild-and-restart-when-stale) has a safe path to call. It ships **no** automation; nothing fires it on its own.

**Chosen mechanism: Option 1** (split rebuild from restart, supervised by launchd), including the Curator's Finding 1 remedy (exit code carries intent). Option 2 (`exec` self-replacement) and Option 3 (detached helper) are rejected with rationale in `docs/design/supervised-restart-primitive.md` — briefly: Option 1 is the only option that actually exercises the supervisor this issue is about, and it sidesteps Option 2's socket-based-singleton-guard / `FD_CLOEXEC` hazards on the highest-blast-radius path.

## Changes

- **Plist (`loom-daemon-start.sh`)**: `KeepAlive` flips from bare `<false/>` to `{ SuccessfulExit: true }` — launchd relaunches the job **only** on a clean exit `0`. Bakes `LOOM_DAEMON_SUPERVISOR=launchd` into the plist env so the daemon can *prove* it is supervised before it will exit for a restart.
- **`RestartDaemon` IPC request + `loom-daemon restart` CLI** (`types.rs`, `ipc.rs`, `main.rs`): the **only** path that exits `0`, so the only thing that trips a relaunch. Supervised → replies `DaemonRestart { scheduled: true }`, flushes, then exits 0. Unsupervised (nohup/Linux/`--foreground`) → refuses, replies `scheduled: false`, keeps running (#4017's "log loudly, do not restart").
- **Exit code carries intent** (`main.rs` signal handler + `ipc.rs` Shutdown): SIGTERM→143, SIGINT→130, IPC Shutdown→143, crash→non-zero. Only the restart exits 0. This removes the SuccessfulExit/bootout race — an operator stop stays stopped **without depending on bootout timing** — and preserves the old no-crash-loop semantics.
- **`loom-daemon-stop.sh`**: post-stop, re-verifies (**scoped to its launchd label**, never a global `pgrep`) that no daemon is still alive and exits non-zero if one is — closing the inverted-#4011 silent-success hole. Bootout retained as belt-and-braces.
- **Docs**: `docs/design/supervised-restart-primitive.md` (decision record) + daemon-reference.md Self-update/shutdown sections.

## Acceptance Criteria Verification

- [x] Mechanism chosen, implemented, decision recorded with rejected alternatives — `docs/design/supervised-restart-primitive.md`.
- [x] **Restart proven under launchd** (isolated label/socket): daemon exited 0, launchd relaunched with a **new pid**, supervision preserved. Transcript below.
- [x] Operator `loom-daemon-stop.sh` stays stopped — SIGTERM → no relaunch within the window, job unloaded, stop exit 0.
- [x] Crash (SIGKILL) not auto-respawned — no crash loop.
- [x] Restarted daemon runs with exactly its start flags (relaunch re-reads the same plist; never wider).
- [x] "Operator stop stays stopped" holds **without depending on bootout timing** — SIGTERM exits non-zero (143).
- [x] `loom-daemon-stop.sh` exits non-zero if any daemon (for its label) is still alive after it completes.
- [x] Unsupervised (nohup/Linux) → logs loudly, stays running, does not restart.
- [x] The primitive never fires on its own.
- [ ] **In-flight sweeps survive the restart** — not exercised live (see Manual follow-up). Holds by construction: restart is a plain process exit + launchd relaunch; sweep children are independent detached processes the daemon never cancels on shutdown.

## Test Plan

- [x] `cargo test --workspace` — green (1015 + suites, 0 failed).
- [x] `cargo clippy --all-targets` — clean.
- [x] `test-loom-daemon-launchd-plist.sh` — re-pinned to `KeepAlive:{SuccessfulExit:true}` + `LOOM_DAEMON_SUPERVISOR=launchd` (26/26).
- [x] `test-loom-daemon-stop.sh` — bootout-unchanged assertion + Darwin fake-launchctl relaunch-still-alive → non-zero exit (10/10).
- [x] `test-loom-daemon-start.sh` — 10/10.
- [x] serde round-trip + supervisor-gating + exit-code-contract unit tests in `ipc.rs`.

### Live launchd transcript (isolated `LOOM_LAUNCHD_LABEL=com.example.loom-4054-live` + isolated `LOOM_SOCKET_PATH`; production `com.rjwalters.loom-daemon` never touched)

```
[A] START reliability daemon (autonomy OFF): pid 44776
[B] loom-daemon restart -> "restart scheduled (supervisor: launchd)"
    PID before restart: 44776   PID after restart: 45485   (NEW pid) ✓
    relaunched env: LOOM_DAEMON_SUPERVISOR=launchd
[C] loom-daemon-stop.sh -> stop exit 0; came back within 10s: no; job unloaded ✓
[D] SIGKILL pid -> respawned within 10s: no ✓ (no crash loop)
[E] foreground SIGTERM exit 143 ✓ ; foreground SIGINT exit 130 ✓
production com.rjwalters.loom-daemon: not loaded (untouched) ; no stray test procs
```

**Isolation note (per Champion's binding constraint):** every launchd operation ran against a throwaway `com.example.loom-4054-live` label + `/tmp` socket. At test time there was **no** production daemon running and the `com.rjwalters.loom-daemon` job was not loaded (verified before and after). The first accidental start inherited `LOOM_WORK_FINDER=1` from the session env; I caught it before the first 60s work-finder tick (no dispatch occurred) and re-ran with autonomy explicitly OFF (`--no-work-finder --no-health-gate`), so no sweep was ever dispatched.

**Manual follow-up for Judge/human:** the "in-flight sweeps survive a restart" AC was not exercised live because dispatching a real sweep runs an actual, side-effecting Claude session; recommend confirming it on a canary before Phase 3 builds on the primitive.

Closes #4054