### PR TITLE
feat(forge): migrate get_forge_config onto config_resolver, canonicalize worktree root at get_forge()

### DIFF
--- a/loom-tools/src/loom_tools/common/forge.py
+++ b/loom-tools/src/loom_tools/common/forge.py
@@ -25,7 +25,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal, Protocol, Sequence, runtime_checkable
 
-from loom_tools.common.state import read_json_file
+from loom_tools.common.config_resolver import get_path, resolve_effective_config
 
 EntityType = Literal["issue", "pr"]
 
@@ -114,23 +114,30 @@ def _detect_from_host(host: str, forge_config: dict[str, Any] | None = None) -> 
 
 
 def get_forge_config(cwd: Path | None = None) -> dict[str, Any]:
-    """Read the ``forge`` section from ``.loom/config.json``.
+    """Read the ``forge`` section from the resolved effective config.
 
-    Returns an empty dict if the config file is missing or has no
-    ``forge`` key.
+    Resolves via :func:`loom_tools.common.config_resolver.resolve_effective_config`
+    (private/shared defaults -> legacy ``.loom/config.json`` -> tracked
+    ``.loom-project/project.json`` -> ignored ``.loom-local/local.json``,
+    deep-merged in that precedence order). ``cwd`` is passed straight
+    through as the resolver's ``repo_root`` -- today only the legacy tier
+    (``cwd/.loom/config.json``) is ever populated, so this is byte-for-byte
+    behavior-preserving for every existing repo; the new tiers are purely
+    additive.
+
+    Returns an empty dict if no tier has a ``forge`` key, if the merged
+    ``forge`` value is not an object, or if ``cwd`` isn't inside a
+    directory tree with any config file at all. Never raises.
 
     Args:
-        cwd: Working directory to find ``.loom/config.json``. Defaults
-            to the current directory.
+        cwd: Working directory to resolve config from (treated as the
+            repo root). Defaults to the current directory. Note this is
+            *not* canonicalized to the main checkout when ``cwd`` is a
+            git worktree -- see :func:`get_forge` for that.
     """
-    config_dir = (cwd or Path.cwd()) / ".loom"
-    config_file = config_dir / "config.json"
-
-    data = read_json_file(config_file)
-    if not isinstance(data, dict):
-        return {}
-
-    forge = data.get("forge", {})
+    repo_root = cwd or Path.cwd()
+    effective = resolve_effective_config(repo_root)
+    forge = get_path(effective, "forge", {})
     return forge if isinstance(forge, dict) else {}
 
 
@@ -535,8 +542,54 @@ class ForgeClient(Protocol):
 # ---------------------------------------------------------------------------
 
 
+def _canonical_repo_root(cwd: Path | None) -> Path | None:
+    """Resolve the canonical main-checkout root for forge operations.
+
+    Forge credentials (``forge.gitea.url`` / token / detected type) are a
+    per-repo fact, not a per-worktree one -- the same reasoning #3938
+    applied to the ``.loom/tokens/`` pool. This mirrors
+    ``spawn-claude.sh``'s resolution of that pool: run
+    ``git rev-parse --git-common-dir`` (relative to *cwd*, or the
+    process cwd when *cwd* is ``None``), make the result absolute, and
+    take its parent directory. That directory is the canonical repo root
+    whether invoked from the main checkout or a linked worktree.
+
+    Falls back to returning *cwd* unchanged -- never raises, never fails
+    the caller -- when git is unavailable or *cwd* is not inside a git
+    repository at all (e.g. a bare ``tmp_path`` in a test).
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--git-common-dir"],
+            cwd=cwd,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+    except OSError:
+        return cwd
+
+    if result.returncode != 0 or not result.stdout.strip():
+        return cwd
+
+    common_dir = Path(result.stdout.strip())
+    if not common_dir.is_absolute():
+        base = cwd or Path.cwd()
+        common_dir = (base / common_dir).resolve()
+    else:
+        common_dir = common_dir.resolve()
+
+    return common_dir.parent
+
+
 def get_forge(cwd: Path | None = None, *, cached: bool = True) -> ForgeClient:
     """Return a ``ForgeClient`` for the detected forge type.
+
+    Canonicalizes *cwd* to the main-checkout root (see
+    :func:`_canonical_repo_root`) before detecting the forge type or
+    constructing a backend, so forge config/auth always resolves from one
+    place regardless of whether this is called from the main checkout or
+    a linked git worktree (e.g. ``.loom/worktrees/issue-N``).
 
     Uses :func:`detect_forge` to determine which backend to instantiate.
     Imports are lazy to avoid circular dependencies and so that
@@ -549,16 +602,18 @@ def get_forge(cwd: Path | None = None, *, cached: bool = True) -> ForgeClient:
     is undesirable).  Caching can also be disabled globally via the
     ``FORGE_CACHE_DISABLE=1`` environment variable.
     """
-    forge_type = detect_forge(cwd)
+    resolved_cwd = _canonical_repo_root(cwd)
+
+    forge_type = detect_forge(resolved_cwd)
     if forge_type == ForgeType.GITEA:
         from loom_tools.common.gitea import GiteaForge
 
-        inner: ForgeClient = GiteaForge(cwd=cwd)
+        inner: ForgeClient = GiteaForge(cwd=resolved_cwd)
     else:
         # Default: GitHub
         from loom_tools.common.github import GitHubForge
 
-        inner = GitHubForge(cwd=cwd)
+        inner = GitHubForge(cwd=resolved_cwd)
 
     if cached:
         from loom_tools.common.cached_forge import CachedForgeClient

--- a/loom-tools/tests/test_forge.py
+++ b/loom-tools/tests/test_forge.py
@@ -604,6 +604,269 @@ class TestGetForgeConfig:
         result = get_forge_config(tmp_path)
         assert result == {}
 
+    def test_non_dict_forge_value(self, tmp_path: Path) -> None:
+        """A ``forge`` key that isn't an object soft-fails to {}."""
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir()
+        config = {"version": "2", "forge": "not-an-object", "terminals": []}
+        (loom_dir / "config.json").write_text(json.dumps(config))
+        result = get_forge_config(tmp_path)
+        assert result == {}
+
+    def test_no_git_and_no_loom_dir(self, tmp_path: Path) -> None:
+        """A bare directory with neither .git nor .loom/ never raises."""
+        result = get_forge_config(tmp_path)
+        assert result == {}
+
+    def test_project_json_tier_only(self, tmp_path: Path) -> None:
+        """forge config supplied only via .loom-project/project.json (no
+        .loom/config.json at all) is honored -- #4039's new tier is additive."""
+        project_dir = tmp_path / ".loom-project"
+        project_dir.mkdir()
+        config = {
+            "forge": {
+                "type": "gitea",
+                "gitea": {"url": "https://gitea.example.com", "token": "tok"},
+            },
+        }
+        (project_dir / "project.json").write_text(json.dumps(config))
+        result = get_forge_config(tmp_path)
+        assert result == {
+            "type": "gitea",
+            "gitea": {"url": "https://gitea.example.com", "token": "tok"},
+        }
+
+    def test_project_json_overrides_legacy_config(self, tmp_path: Path) -> None:
+        """.loom-project/project.json (tier 3) outranks legacy .loom/config.json
+        (tier 2) -- deep-merge precedence order from resolve_effective_config."""
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir()
+        (loom_dir / "config.json").write_text(json.dumps({
+            "forge": {"type": "gitea", "gitea": {"url": "https://legacy.example.com"}},
+        }))
+
+        project_dir = tmp_path / ".loom-project"
+        project_dir.mkdir()
+        (project_dir / "project.json").write_text(json.dumps({
+            "forge": {"gitea": {"url": "https://project.example.com"}},
+        }))
+
+        result = get_forge_config(tmp_path)
+        # type comes from the legacy tier (not overridden), url from project tier
+        assert result == {
+            "type": "gitea",
+            "gitea": {"url": "https://project.example.com"},
+        }
+
+
+# ---------------------------------------------------------------------------
+# Worktree root resolution (_canonical_repo_root / get_forge canonicalization)
+# ---------------------------------------------------------------------------
+
+
+def _init_git_repo(path: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=test@example.com", "-c", "user.name=Test",
+         "commit", "--allow-empty", "-q", "-m", "init"],
+        cwd=path, check=True,
+    )
+
+
+def _add_worktree(main: Path, wt: Path, branch: str) -> None:
+    subprocess.run(
+        ["git", "worktree", "add", "-q", str(wt), "-b", branch],
+        cwd=main, check=True,
+    )
+
+
+class TestCanonicalRepoRoot:
+    """Tests for _canonical_repo_root -- the worktree root-resolution helper.
+
+    Design decision (#4061): forge credentials are a per-repo fact, not a
+    per-worktree one (same reasoning as #3938 for the .loom/tokens/ pool),
+    so this resolves a worktree cwd back to the canonical main-checkout
+    root via `git rev-parse --git-common-dir`, mirroring
+    `.loom/scripts/spawn-claude.sh`.
+    """
+
+    def test_resolves_worktree_to_main_root(self, tmp_path: Path) -> None:
+        from loom_tools.common.forge import _canonical_repo_root
+
+        main = tmp_path / "main"
+        main.mkdir()
+        _init_git_repo(main)
+
+        wt = tmp_path / "wt"
+        _add_worktree(main, wt, "issue-1")
+
+        assert _canonical_repo_root(wt) == main.resolve()
+
+    def test_main_root_resolves_to_itself(self, tmp_path: Path) -> None:
+        from loom_tools.common.forge import _canonical_repo_root
+
+        main = tmp_path / "main"
+        main.mkdir()
+        _init_git_repo(main)
+
+        assert _canonical_repo_root(main) == main.resolve()
+
+    def test_falls_back_to_cwd_when_not_a_repo(self, tmp_path: Path) -> None:
+        from loom_tools.common.forge import _canonical_repo_root
+
+        assert _canonical_repo_root(tmp_path) == tmp_path
+
+    def test_falls_back_to_cwd_on_os_error(self, tmp_path: Path) -> None:
+        from loom_tools.common.forge import _canonical_repo_root
+
+        with mock.patch(
+            "loom_tools.common.forge.subprocess.run",
+            side_effect=OSError("git not found"),
+        ):
+            assert _canonical_repo_root(tmp_path) is tmp_path
+
+
+class TestGetForgeConfigWorktreeResolution:
+    """Acceptance test: forge config resolves correctly when CWD is a
+    .loom/worktrees/issue-N-style git worktree (#4061)."""
+
+    def test_legacy_config_identical_from_worktree_and_main(
+        self, tmp_path: Path,
+    ) -> None:
+        """.loom/config.json is a tracked file, so it's checked out
+        identically into a fresh worktree -- get_forge_config(cwd) (which
+        does NOT canonicalize) already sees the same content either way."""
+        main = tmp_path / "main"
+        main.mkdir()
+        _init_git_repo(main)
+        loom_dir = main / ".loom"
+        loom_dir.mkdir()
+        config = {
+            "forge": {"type": "gitea", "gitea": {"url": "https://gitea.example.com"}},
+        }
+        (loom_dir / "config.json").write_text(json.dumps(config))
+        subprocess.run(["git", "add", "-A"], cwd=main, check=True)
+        subprocess.run(
+            ["git", "-c", "user.email=test@example.com", "-c", "user.name=Test",
+             "commit", "-q", "-m", "add config"],
+            cwd=main, check=True,
+        )
+
+        wt = tmp_path / "wt"
+        _add_worktree(main, wt, "issue-2")
+
+        assert get_forge_config(main) == get_forge_config(wt) == {
+            "type": "gitea", "gitea": {"url": "https://gitea.example.com"},
+        }
+
+    def test_worktree_local_only_config_needs_canonicalization(
+        self, tmp_path: Path,
+    ) -> None:
+        """The motivating case for the design decision: a host-local
+        .loom-local/local.json exists only at the main root (gitignored in
+        real repos, so it never materializes in a fresh worktree checkout).
+        A naive cwd-relative resolve from inside the worktree sees nothing;
+        resolving via the canonical root (as get_forge() does) sees it."""
+        from loom_tools.common.forge import _canonical_repo_root
+
+        main = tmp_path / "main"
+        main.mkdir()
+        _init_git_repo(main)
+
+        wt = tmp_path / "wt"
+        _add_worktree(main, wt, "issue-3")
+
+        local_dir = main / ".loom-local"
+        local_dir.mkdir()
+        (local_dir / "local.json").write_text(json.dumps({
+            "forge": {"type": "gitea", "gitea": {"url": "https://gitea.example.com", "token": "tok"}},
+        }))
+
+        # Naive cwd-relative resolution from the worktree sees nothing.
+        assert get_forge_config(wt) == {}
+
+        # Canonicalizing first (what get_forge() does) resolves it.
+        canonical = _canonical_repo_root(wt)
+        assert canonical == main.resolve()
+        assert get_forge_config(canonical) == {
+            "type": "gitea", "gitea": {"url": "https://gitea.example.com", "token": "tok"},
+        }
+
+
+# ---------------------------------------------------------------------------
+# get_forge() factory -- worktree canonicalization
+# ---------------------------------------------------------------------------
+
+
+class TestGetForgeCanonicalization:
+    """get_forge() canonicalizes cwd to the main-checkout root before
+    detecting the forge type or constructing a backend (#4061)."""
+
+    def test_detect_forge_receives_canonical_cwd(self, tmp_path: Path) -> None:
+        from loom_tools.common.forge import ForgeType, get_forge
+
+        canonical = tmp_path / "canonical"
+        canonical.mkdir()
+        worktree_cwd = tmp_path / "worktree"
+
+        with (
+            mock.patch(
+                "loom_tools.common.forge._canonical_repo_root",
+                return_value=canonical,
+            ),
+            mock.patch(
+                "loom_tools.common.forge.detect_forge",
+                return_value=ForgeType.GITHUB,
+            ) as mock_detect,
+        ):
+            get_forge(cwd=worktree_cwd, cached=False)
+
+        mock_detect.assert_called_once_with(canonical)
+
+    def test_github_backend_receives_canonical_cwd(self, tmp_path: Path) -> None:
+        from loom_tools.common.forge import ForgeType, get_forge
+
+        canonical = tmp_path / "canonical"
+        canonical.mkdir()
+        worktree_cwd = tmp_path / "worktree"
+
+        with (
+            mock.patch(
+                "loom_tools.common.forge._canonical_repo_root",
+                return_value=canonical,
+            ),
+            mock.patch(
+                "loom_tools.common.forge.detect_forge",
+                return_value=ForgeType.GITHUB,
+            ),
+            mock.patch("loom_tools.common.github.GitHubForge") as mock_cls,
+        ):
+            get_forge(cwd=worktree_cwd, cached=False)
+
+        mock_cls.assert_called_once_with(cwd=canonical)
+
+    def test_gitea_backend_receives_canonical_cwd(self, tmp_path: Path) -> None:
+        from loom_tools.common.forge import ForgeType, get_forge
+
+        canonical = tmp_path / "canonical"
+        canonical.mkdir()
+        worktree_cwd = tmp_path / "worktree"
+
+        with (
+            mock.patch(
+                "loom_tools.common.forge._canonical_repo_root",
+                return_value=canonical,
+            ),
+            mock.patch(
+                "loom_tools.common.forge.detect_forge",
+                return_value=ForgeType.GITEA,
+            ),
+            mock.patch("loom_tools.common.gitea.GiteaForge") as mock_cls,
+        ):
+            get_forge(cwd=worktree_cwd, cached=False)
+
+        mock_cls.assert_called_once_with(cwd=canonical)
+
 
 # ---------------------------------------------------------------------------
 # detect_forge

--- a/loom-tools/tests/test_gitea.py
+++ b/loom-tools/tests/test_gitea.py
@@ -148,6 +148,93 @@ class TestConstructor:
 
 
 # ===========================================================================
+# Constructor -- real on-disk config resolution (#4061)
+#
+# Every test above (and every other GiteaForge test in this file) patches
+# `loom_tools.common.gitea.get_forge_config` directly, which insulates them
+# from the #4061 migration onto config_resolver -- they would pass whether
+# or not the migration is correct. The tests in this class build a real
+# on-disk config tree and do NOT patch get_forge_config, so they actually
+# exercise resolve_effective_config's tier precedence end-to-end.
+# ===========================================================================
+
+
+class TestConstructorConfigResolutionOnDisk:
+    """GiteaForge construction against a real .loom-project / .loom config tree."""
+
+    def test_project_json_only_supplies_gitea_url(self, tmp_path: Path) -> None:
+        """forge.gitea.url supplied only by .loom-project/project.json
+        (no .loom/config.json at all) is honored end-to-end."""
+        from loom_tools.common.gitea import GiteaForge
+
+        project_dir = tmp_path / ".loom-project"
+        project_dir.mkdir()
+        (project_dir / "project.json").write_text(json.dumps({
+            "forge": {"gitea": {"url": _BASE_URL, "token": _TOKEN}},
+        }))
+
+        forge = GiteaForge(cwd=tmp_path)
+        assert forge._base_url == _BASE_URL
+
+    def test_project_json_overrides_legacy_config_url(self, tmp_path: Path) -> None:
+        """.loom-project/project.json (tier 3) outranks the legacy
+        .loom/config.json (tier 2) for forge.gitea.url."""
+        from loom_tools.common.gitea import GiteaForge
+
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir()
+        (loom_dir / "config.json").write_text(json.dumps({
+            "forge": {"gitea": {"url": "https://legacy.example.com", "token": _TOKEN}},
+        }))
+
+        project_dir = tmp_path / ".loom-project"
+        project_dir.mkdir()
+        (project_dir / "project.json").write_text(json.dumps({
+            "forge": {"gitea": {"url": _BASE_URL}},
+        }))
+
+        forge = GiteaForge(cwd=tmp_path)
+        assert forge._base_url == _BASE_URL
+
+    def test_trailing_slash_stripped_from_project_json_url(self, tmp_path: Path) -> None:
+        from loom_tools.common.gitea import GiteaForge
+
+        project_dir = tmp_path / ".loom-project"
+        project_dir.mkdir()
+        (project_dir / "project.json").write_text(json.dumps({
+            "forge": {"gitea": {"url": _BASE_URL + "/", "token": _TOKEN}},
+        }))
+
+        forge = GiteaForge(cwd=tmp_path)
+        assert forge._base_url == _BASE_URL
+
+    def test_no_config_anywhere_raises_missing_url(self, tmp_path: Path) -> None:
+        """Both ValueErrors keep firing end-to-end (no mocked get_forge_config)."""
+        from loom_tools.common.gitea import GiteaForge
+
+        with (
+            mock.patch.dict(os.environ, {}, clear=True),
+            pytest.raises(ValueError, match="base URL is required"),
+        ):
+            GiteaForge(cwd=tmp_path)
+
+    def test_no_token_anywhere_raises_missing_token(self, tmp_path: Path) -> None:
+        from loom_tools.common.gitea import GiteaForge
+
+        project_dir = tmp_path / ".loom-project"
+        project_dir.mkdir()
+        (project_dir / "project.json").write_text(json.dumps({
+            "forge": {"gitea": {"url": _BASE_URL}},
+        }))
+
+        with (
+            mock.patch.dict(os.environ, {"GITEA_TOKEN": ""}, clear=True),
+            pytest.raises(ValueError, match="API token is required"),
+        ):
+            GiteaForge(cwd=tmp_path)
+
+
+# ===========================================================================
 # Basic Auth mode (issue #3297)
 # ===========================================================================
 


### PR DESCRIPTION
## Summary

Migrates `loom_tools.common.forge.get_forge_config` (the highest-risk of five Python `.loom/config.json` readers scheduled for the config_resolver migration, per parent #4047) onto the shared `config_resolver.resolve_effective_config` layer, and resolves the worktree-root design question that gated this issue.

## Root-resolution decision (stated per the issue's requirement)

**Forge config/auth resolves from the canonical main-checkout root, not the worktree CWD**, matching the precedent #3938 set for `.loom/tokens/` (already documented in this repo's `CLAUDE.md` — "`spawn-claude.sh` resolves the canonical repo root via `git rev-parse --git-common-dir`"). Forge credentials are a per-repo fact, not a per-worktree one.

This is implemented as a new `_canonical_repo_root()` helper in `forge.py` that shells out to `git rev-parse --git-common-dir` (falling back to the given `cwd` unchanged on any failure — never raises), applied **once**, at the single public factory entry point `get_forge(cwd=None)`, before `detect_forge()` runs and before constructing `GiteaForge`/`GitHubForge`. Per the Curator/Champion guidance on this issue:

- `get_forge_config(cwd)` itself is **not** canonicalized — it keeps passing `cwd` straight through as `resolve_effective_config`'s `repo_root`, unchanged from today's `cwd/.loom/config.json` read. This is what keeps it byte-for-byte behavior-preserving on the legacy tier.
- Canonicalization is **not** routed through `common.repo.find_repo_root` — that function raises when no `.loom/` directory is found (violates `get_forge_config`'s never-raise contract) and has a module-level cache that would make a second `cwd` argument silently inert.
- `_canonical_repo_root` failures (git not installed, `cwd` not inside a repo at all) fall back to the original `cwd` — this never turns into a hard failure for callers.

Cross-reference for the sibling Bash-scripts issue (#4062, forge-helpers.sh): **this PR's answer is canonical root via `git rev-parse --git-common-dir`, applied at the forge-client factory, not the config reader** — please mirror this exact rule so both resolvers agree.

## Changes

- `loom-tools/src/loom_tools/common/forge.py`:
  - `get_forge_config(cwd)` now resolves via `config_resolver.resolve_effective_config(repo_root=cwd or Path.cwd())` + `get_path(effective, "forge", {})` instead of a direct `.loom/config.json` open. No direct config file read remains in this module.
  - New `_canonical_repo_root(cwd)` helper (see above).
  - `get_forge(cwd=None, *, cached=True)` now canonicalizes `cwd` via `_canonical_repo_root` before calling `detect_forge()` and before constructing `GiteaForge`/`GitHubForge`.
- `loom-tools/tests/test_forge.py` / `loom-tools/tests/test_gitea.py`: new tests (see Test Plan).

`detect_forge`, `_detect_from_host`, and `GiteaForge.__init__` needed **no code changes** — verified only two production call sites of `get_forge_config` exist (`forge.py:166` inside `detect_forge`, `gitea.py:79` inside `GiteaForge.__init__`); both keep working unchanged because `get_forge_config`'s return contract (a dict, `{}` on any failure) is unchanged.

## Acceptance Criteria Verification

- [x] `get_forge_config` resolves via `resolve_effective_config` + `get_path(cfg, "forge")`; no direct `.loom/config.json` open remains in `common/forge.py`.
- [x] Worktree root-resolution question decided, implemented, documented above.
- [x] Test: forge config resolves correctly when CWD is a `.loom/worktrees/issue-N`-style worktree — `TestGetForgeConfigWorktreeResolution` (real `git worktree add`, no mocks).
- [x] Test: `forge.gitea.url` supplied only by `.loom-project/project.json` is honored by `GiteaForge` — `TestConstructorConfigResolutionOnDisk.test_project_json_only_supplies_gitea_url`, deliberately **not** patching `get_forge_config` (every other `GiteaForge` test in the file does, and would pass regardless of whether this migration is correct).
- [x] Test: both `ValueError` paths in `GiteaForge.__init__` still fire with unchanged messages — existing `test_raises_without_base_url`/`test_raises_without_token` pass unmodified, plus new unmocked equivalents in `TestConstructorConfigResolutionOnDisk`.
- [x] Test: `detect_forge` precedence (`LOOM_FORGE_TYPE` > config `forge.type` > remote-URL autodetect > `github`) — existing `TestDetectForge` suite passes unmodified (regression oracle).
- [x] GitHub-only repos (no `forge` block, this repo included) behave identically to `main` — verified manually below.

## Test Plan

- [x] `PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/ -v` — 2053 passed, 62 skipped, 2 pre-existing failures unrelated to this change (`test_forge_cli.py::TestMainHelp::test_version_flag`, `test_logging.py::test_log_output_visible_non_interactively` — both env/packaging issues that also fail on `main` at HEAD, confirmed before touching any code).
- [x] All four existing `TestGetForgeConfig` cases pass **unmodified** (regression oracle for the legacy tier).
- [x] All existing `test_gitea.py` tests (which patch `get_forge_config` at 6 sites) pass unmodified.
- [x] New: `TestGetForgeConfig` tier-precedence cases — `.loom-project/project.json`-only, and overriding `.loom/config.json`.
- [x] New: `TestCanonicalRepoRoot` — worktree resolves to main root, main resolves to itself, non-repo `cwd` falls back unchanged, `OSError` (git missing) falls back unchanged.
- [x] New: `TestGetForgeConfigWorktreeResolution` — a real `git worktree add`-created worktree; (a) tracked `.loom/config.json` content is identical from both CWDs; (b) a host-local `.loom-local/local.json` present only at the main root (simulating a gitignored file that never materializes in a fresh worktree checkout) is invisible to a naive CWD-relative resolve but visible once canonicalized — the concrete scenario the root-resolution decision protects against.
- [x] New: `TestGetForgeCanonicalization` — `get_forge()` passes the canonicalized cwd to `detect_forge()`, `GitHubForge`, and `GiteaForge`.
- [x] New: `TestConstructorConfigResolutionOnDisk` in `test_gitea.py` — real on-disk `.loom-project/project.json` tree, no `get_forge_config` mock: URL-only via project tier, project tier overriding legacy tier, trailing-slash stripping, both `ValueError`s end-to-end.
- [x] Manual: `python3 -c "from loom_tools.common.forge import detect_forge; print(detect_forge())"` on this (GitHub) repo returns `github` before and after — verified.
- [x] Manual: same command run from inside `.loom/worktrees/issue-4061` — also returns `github`.

Closes #4061