### PR TITLE
fix(daemon): stop scoped to its launchd label so lifecycle tests can't kill the live daemon

### DIFF
--- a/defaults/scripts/cli/loom-daemon-stop.sh
+++ b/defaults/scripts/cli/loom-daemon-stop.sh
@@ -48,6 +48,11 @@
 # Environment:
 #   LOOM_DAEMON_STOP_GRACE_SECS   Grace window before SIGKILL (default 10)
 #   LOOM_LAUNCHD_LABEL            macOS only: the LaunchAgent label to bootout (default com.rjwalters.loom-daemon)
+#   LOOM_DAEMON_LAUNCHD           macOS only: 0/false/no disables ALL launchd interaction
+#                                 (lookup + bootout), symmetric with loom-daemon-start.sh.
+#                                 A start done with --no-launchd / LOOM_DAEMON_LAUNCHD=0
+#                                 must get a stop that never reads or mutates the
+#                                 machine-global launchd domain (issue #4078).
 #
 # Exit codes:
 #   0  daemon stopped (or was not running)
@@ -107,11 +112,25 @@ GRACE_SECS="${LOOM_DAEMON_STOP_GRACE_SECS:-10}"
 # ---------- launchd plumbing (macOS, #3972) ----------
 IS_DARWIN=false
 [[ "$(uname -s)" == "Darwin" ]] && IS_DARWIN=true
-LAUNCHD_LABEL="${LOOM_LAUNCHD_LABEL:-com.rjwalters.loom-daemon}"
+
+# Honor LOOM_DAEMON_LAUNCHD symmetrically with loom-daemon-start.sh (#4078): a
+# daemon started with --no-launchd / LOOM_DAEMON_LAUNCHD=0 was never a launchd
+# job, so the stop side must NOT reach into the machine-global launchd domain to
+# look it up (which would resolve against — and then SIGTERM — the operator's
+# real production LaunchAgent under the same default label). Before this, the
+# start script gated its whole launchd path on this var but the stop script did
+# not, leaving the guard inert on the stop side.
+USE_LAUNCHD="$IS_DARWIN"
+if [[ "${LOOM_DAEMON_LAUNCHD:-}" =~ ^(0|false|no)$ ]]; then
+    USE_LAUNCHD=false
+fi
+
+DEFAULT_LAUNCHD_LABEL="com.rjwalters.loom-daemon"
+LAUNCHD_LABEL="${LOOM_LAUNCHD_LABEL:-$DEFAULT_LAUNCHD_LABEL}"
 LAUNCHD_SERVICE="gui/$(id -u)/${LAUNCHD_LABEL}"
 
 launchd_job_loaded() {
-    [[ "$IS_DARWIN" == "true" ]] || return 1
+    [[ "$USE_LAUNCHD" == "true" ]] || return 1
     command -v launchctl >/dev/null 2>&1 || return 1
     launchctl print "$LAUNCHD_SERVICE" >/dev/null 2>&1
 }
@@ -144,7 +163,19 @@ if [[ -z "$pid" ]] || ! kill -0 "$pid" 2>/dev/null; then
     fi
 fi
 if [[ -z "$pid" ]] || ! kill -0 "$pid" 2>/dev/null; then
-    if command -v pgrep >/dev/null 2>&1; then
+    # Last-resort process-name match. This tier is LABEL-BLIND: `pgrep -f`
+    # matches ANY loom-daemon on the machine by binary name — including the
+    # operator's production daemon or another repo's daemon — so it can kill a
+    # daemon this invocation was never meant to touch (issue #4078, curator
+    # Correction 3; the incident's actual over-broad kill). Only fall through to
+    # it when the caller did NOT explicitly scope this stop to a specific
+    # launchd label: a non-default LOOM_LAUNCHD_LABEL (a test's scratch label,
+    # or an operator managing a specifically-labeled daemon) means "stop THAT
+    # daemon, not whatever else happens to be named loom-daemon", so a
+    # label-blind kill would violate that scoping and contradict the #4054
+    # label-scoped-stop discipline. With the default label we keep the fallback
+    # as a genuine lost-PID-file recovery path.
+    if [[ "$LAUNCHD_LABEL" == "$DEFAULT_LAUNCHD_LABEL" ]] && command -v pgrep >/dev/null 2>&1; then
         pid=$(pgrep -f '(^|/)loom-daemon$' 2>/dev/null | head -n1 || true)
     fi
 fi

--- a/defaults/scripts/tests/lib/launchd-sandbox.sh
+++ b/defaults/scripts/tests/lib/launchd-sandbox.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# launchd-sandbox.sh — shared test sandbox for the loom-daemon lifecycle tests
+# (issue #4078).
+#
+# Why this exists: the daemon lifecycle tests deliberately execute the REAL
+# loom-daemon-start.sh / loom-daemon-stop.sh (not a mock) so the restart path
+# exercises the actual scripts. But launchd is machine-GLOBAL, and the stop
+# script's PID-resolution ladder can reach outside any per-test sandbox two
+# ways:
+#
+#   1. launchd label lookup — `launchctl print gui/<uid>/com.rjwalters.loom-daemon`
+#      resolves against the operator's REAL production LaunchAgent when the
+#      test does not scope LOOM_LAUNCHD_LABEL, so the stop script adopts and
+#      SIGTERMs the live daemon (issue #4078, curator Correction 2).
+#   2. label-blind pgrep — `pgrep -f '(^|/)loom-daemon$'` matches the production
+#      daemon (or another repo's daemon) by binary NAME alone, so even a scoped
+#      LOOM_LAUNCHD_LABEL does not close the hole (curator Correction 3).
+#
+# This helper closes BOTH axes for a sourcing test, and is deliberately narrow:
+# it stubs only the syscall-level tools (`launchctl`, `pgrep`), NEVER the
+# lifecycle scripts themselves — so the "exercise the actual scripts" intent of
+# the update test's header survives.
+#
+# Usage (source it):
+#   source "$SCRIPT_DIR/lib/launchd-sandbox.sh"
+#   export LOOM_LAUNCHD_LABEL="$(launchd_sandbox_new_label)"
+#   launchd_sandbox_install_stubs "$FAKE_BIN_DIR" "$LOG_DIR"   # optional
+#   decoy_pid="$(launchd_sandbox_spawn_decoy "$WORKDIR")"
+#   ... run the real scripts ...
+#   launchd_sandbox_decoy_alive "$decoy_pid"                    # assert survival
+#   launchd_sandbox_assert_no_production_label "$LOG_DIR/launchctl-invocations.log"
+
+# Print a per-run, guaranteed-nonexistent scratch launchd label. A label built
+# from $$ + $RANDOM cannot collide with the production `com.rjwalters.loom-daemon`
+# label, so `launchctl print` against it always resolves false and the stop
+# script can never observe or mutate a real loaded job under it.
+launchd_sandbox_new_label() {
+    echo "com.example.loom-sandbox-$$-${RANDOM}"
+}
+
+# Install stub `launchctl` and `pgrep` into <bin_dir> (which the caller must
+# place on PATH ahead of the real tools). Both stubs:
+#   - record every invocation to <log_dir>/{launchctl,pgrep}-invocations.log
+#     (one line per call) so a test can assert what was attempted, and
+#   - are STRUCTURALLY UNABLE to touch a real launchd job or process:
+#       * launchctl: `print` always exits 1 (job "not loaded"); everything else
+#         is a harmless no-op exit 0.
+#       * pgrep: always exits 1 with no output (never matches a real process),
+#         so a label-blind `pgrep -f loom-daemon` in the stop script can never
+#         return the production daemon's (or a decoy's) PID.
+#
+# These are belt-and-braces on top of the production-side fixes (stop.sh now
+# honors LOOM_DAEMON_LAUNCHD and scopes its pgrep fallback to the default
+# label): a test that sources this helper cannot reach the real tools even if a
+# future regression re-opens a production path.
+launchd_sandbox_install_stubs() {
+    local bin_dir="$1" log_dir="$2"
+    mkdir -p "$bin_dir" "$log_dir"
+    local launchctl_log="$log_dir/launchctl-invocations.log"
+    local pgrep_log="$log_dir/pgrep-invocations.log"
+    : > "$launchctl_log"
+    : > "$pgrep_log"
+
+    cat > "$bin_dir/launchctl" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >> "$launchctl_log"
+# A scratch-labeled job never exists: 'print' reports not-loaded (exit 1);
+# 'bootout' and everything else are harmless no-ops. NEVER touches a real job.
+case "\${1:-}" in
+  print) exit 1 ;;
+  *)     exit 0 ;;
+esac
+EOF
+    chmod +x "$bin_dir/launchctl"
+
+    cat > "$bin_dir/pgrep" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >> "$pgrep_log"
+# Never match a real process — the whole point is that a label-blind pgrep must
+# not be able to find the production daemon (or a decoy) during a test.
+exit 1
+EOF
+    chmod +x "$bin_dir/pgrep"
+}
+
+# Spawn a decoy process whose argv ends in `/loom-daemon`, so it matches the
+# stop script's label-blind fallback pattern `(^|/)loom-daemon$` exactly like a
+# real production daemon would. Prints the decoy's PID on stdout; the caller
+# must kill it during cleanup.
+#
+# The decoy is a tiny sleeper script literally named `loom-daemon` (not an
+# `exec sleep`, which would rewrite argv to "sleep" and stop matching). It runs
+# under <work_dir>/decoy-bin/loom-daemon.
+launchd_sandbox_spawn_decoy() {
+    local work_dir="$1"
+    local decoy_dir="$work_dir/decoy-bin"
+    mkdir -p "$decoy_dir"
+    cat > "$decoy_dir/loom-daemon" <<'EOF'
+#!/usr/bin/env bash
+# Decoy: keep this process alive with `loom-daemon` in its argv.
+while true; do sleep 1; done
+EOF
+    chmod +x "$decoy_dir/loom-daemon"
+    # Redirect the decoy's stdio to /dev/null so it does not hold open the
+    # stdout pipe of a `$(launchd_sandbox_spawn_decoy ...)` command substitution
+    # (which would block the caller forever waiting on this never-exiting child).
+    "$decoy_dir/loom-daemon" >/dev/null 2>&1 &
+    echo $!
+}
+
+# Return 0 if the decoy PID is still alive, non-zero otherwise.
+launchd_sandbox_decoy_alive() {
+    kill -0 "$1" 2>/dev/null
+}
+
+# Assert that no recorded launchctl invocation named a production label
+# (com.rjwalters.*). Returns 0 (safe) when the log is absent/empty or contains
+# only scratch labels; returns 1 when a production label appears.
+launchd_sandbox_assert_no_production_label() {
+    local launchctl_log="$1"
+    [[ -f "$launchctl_log" ]] || return 0
+    ! grep -q 'com\.rjwalters\.' "$launchctl_log"
+}

--- a/defaults/scripts/tests/test-loom-daemon-stop.sh
+++ b/defaults/scripts/tests/test-loom-daemon-stop.sh
@@ -20,6 +20,11 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 STOP_SCRIPT="$(cd "$SCRIPT_DIR/../cli" && pwd)/loom-daemon-stop.sh"
 
+# Shared launchd sandbox (#4078): scratch-label generator, decoy spawner, and
+# stub launchctl/pgrep. Stubs the syscall layer only — never the stop script.
+# shellcheck source=lib/launchd-sandbox.sh
+source "$SCRIPT_DIR/lib/launchd-sandbox.sh"
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m'
@@ -44,10 +49,18 @@ assert_eq() {
 
 # A guaranteed-nonexistent label so `launchctl print` never matches a real
 # loaded job on the host machine, regardless of platform.
-FAKE_LABEL="com.example.loom-daemon-stop-test-$$-$RANDOM"
+FAKE_LABEL="$(launchd_sandbox_new_label)"
 
 WORKDIR="$(mktemp -d)"
-trap 'rm -rf "$WORKDIR"' EXIT
+
+# Suite-level safety guard (#4078): a decoy process whose argv ends in
+# `/loom-daemon` — exactly what the stop script's label-blind `pgrep -f
+# '(^|/)loom-daemon$'` fallback would match. Every stop invocation below pins a
+# scratch LOOM_LAUNCHD_LABEL, so the production narrowing must skip the pgrep
+# tier and leave this decoy alive. If ANY test in this suite regresses into a
+# by-name kill, this decoy dies and the final assertion fails loudly.
+DECOY_PID="$(launchd_sandbox_spawn_decoy "$WORKDIR")"
+trap 'kill "$DECOY_PID" 2>/dev/null; rm -rf "$WORKDIR"' EXIT
 mkdir -p "$WORKDIR/.loom"
 
 # ---------- tests ----------
@@ -175,7 +188,93 @@ else
     echo "  (skipping relaunch-detection test — not Darwin)"
 fi
 
+# 7. Decoy-process test (#4078): the label-blind `pgrep` fallback must NOT be
+#    reachable when the caller scoped the stop to a non-default label. Run the
+#    REAL stop script (real pgrep on PATH, no PID file, scratch label) with a
+#    live decoy whose argv ends in `/loom-daemon`. Pre-fix, stop would `pgrep
+#    -f '(^|/)loom-daemon$'`, match the decoy, and SIGTERM it. Post-fix, the
+#    scratch label routes around the pgrep tier entirely, so the decoy survives
+#    and stop reports "nothing to stop". This is the test that distinguishes a
+#    real fix from an insufficient label-only-on-launchctl one.
+decoy7_pid="$(launchd_sandbox_spawn_decoy "$WORKDIR/decoy7")"
+sleep 0.2
+# Sanity: the decoy really is matchable by the fallback pattern (else the test
+# would pass vacuously). Only meaningful where pgrep exists.
+if command -v pgrep >/dev/null 2>&1; then
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if pgrep -f '(^|/)loom-daemon$' 2>/dev/null | grep -qx "$decoy7_pid"; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "${GREEN}✓${NC} decoy: is matchable by the pgrep fallback pattern (test is not vacuous)"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "${RED}✗${NC} decoy: is matchable by the pgrep fallback pattern (test is not vacuous)"
+    fi
+fi
+decoy_out=$( cd "$WORKDIR" && LOOM_LAUNCHD_LABEL="$FAKE_LABEL" bash "$STOP_SCRIPT" 2>&1 )
+decoy_rc=$?
+assert_eq "0" "$decoy_rc" "decoy: scratch-label stop with no PID file exits 0"
+TESTS_RUN=$((TESTS_RUN + 1))
+if launchd_sandbox_decoy_alive "$decoy7_pid"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} decoy: survives a scratch-label stop (label-blind pgrep tier not taken)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} decoy: survives a scratch-label stop (label-blind pgrep tier not taken)"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$decoy_out" | grep -qi "nothing to stop"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} decoy: reports 'nothing to stop' (does not adopt an unrelated loom-daemon)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} decoy: reports 'nothing to stop' (does not adopt an unrelated loom-daemon)"
+fi
+kill "$decoy7_pid" 2>/dev/null || true
+
+# 8. Symmetry with loom-daemon-start.sh (#4078): LOOM_DAEMON_LAUNCHD=0 must
+#    disable ALL launchd interaction on the stop side too, so no `launchctl` is
+#    ever invoked. Uses the sandbox stub launchctl (records every call); the
+#    recorded log must stay empty. Darwin-only: on non-Darwin launchd is off
+#    regardless, so there is nothing to prove.
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    SYM_BIN="$WORKDIR/sym-bin"
+    SYM_LOG="$WORKDIR/sym-log"
+    launchd_sandbox_install_stubs "$SYM_BIN" "$SYM_LOG"
+    ( cd "$WORKDIR" && PATH="$SYM_BIN:$PATH" LOOM_DAEMON_LAUNCHD=0 \
+        LOOM_LAUNCHD_LABEL="$FAKE_LABEL" bash "$STOP_SCRIPT" >/dev/null 2>&1 )
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ ! -s "$SYM_LOG/launchctl-invocations.log" ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "${GREEN}✓${NC} LOOM_DAEMON_LAUNCHD=0: stop performs no launchctl call at all"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "${RED}✗${NC} LOOM_DAEMON_LAUNCHD=0: stop performs no launchctl call at all"
+        echo "  launchctl invocations: $(cat "$SYM_LOG/launchctl-invocations.log")"
+    fi
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if launchd_sandbox_assert_no_production_label "$SYM_LOG/launchctl-invocations.log"; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "${GREEN}✓${NC} no launchctl invocation named a com.rjwalters.* label"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "${RED}✗${NC} no launchctl invocation named a com.rjwalters.* label"
+    fi
+else
+    echo "  (skipping LOOM_DAEMON_LAUNCHD symmetry test — not Darwin)"
+fi
+
 # ---------- summary ----------
+# Final suite-level decoy guard (#4078): nothing above should have killed the
+# by-name-matchable decoy spawned at suite start.
+TESTS_RUN=$((TESTS_RUN + 1))
+if launchd_sandbox_decoy_alive "$DECOY_PID"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} suite-level decoy loom-daemon survived the whole stop suite"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} suite-level decoy loom-daemon survived the whole stop suite"
+fi
+
 echo
 echo "Ran $TESTS_RUN tests: $TESTS_PASSED passed, $TESTS_FAILED failed"
 [[ "$TESTS_FAILED" -eq 0 ]]

--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -35,6 +35,19 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CLI_DIR="$(cd "$SCRIPT_DIR/../cli" && pwd)"
 UPDATE_SCRIPT="$CLI_DIR/loom-daemon-update.sh"
 
+# Shared launchd sandbox (#4078). Belt-and-braces on top of LOOM_DAEMON_LAUNCHD=0:
+#   - a scratch LOOM_LAUNCHD_LABEL so any launchd lookup that DID fire could not
+#     resolve the operator's real com.rjwalters.loom-daemon job, and
+#   - stub launchctl/pgrep installed onto the test PATH (below), so the real
+#     tools are unreachable even if a future regression re-opens a launchd/pgrep
+#     path in the stop script the restart flow drives.
+# This closes the exact hole that booted out the operator's live daemon: the
+# update suite exercises the REAL start/stop scripts, and launchd is
+# machine-global.
+# shellcheck source=lib/launchd-sandbox.sh
+source "$SCRIPT_DIR/lib/launchd-sandbox.sh"
+export LOOM_LAUNCHD_LABEL="$(launchd_sandbox_new_label)"
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m'
@@ -137,15 +150,40 @@ EOF
 MINIMAL_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
 
 BASE_WORKDIR="$(mktemp -d)"
+
+# Suite-level decoy (#4078): a process whose argv ends in `/loom-daemon`, which
+# the stop script's label-blind `pgrep -f '(^|/)loom-daemon$'` fallback would
+# match. The whole update suite runs under a scratch LOOM_LAUNCHD_LABEL and
+# LOOM_DAEMON_LAUNCHD=0, so no real launchd lookup or by-name kill may fire; if
+# any test regresses into one, this decoy dies and the final assertion fails.
+# Spawned OUTSIDE $BASE_WORKDIR's path so the trap's `pkill -f "$BASE_WORKDIR"`
+# does not sweep it; killed explicitly below.
+DECOY_DIR="$(mktemp -d)"
+cat > "$DECOY_DIR/loom-daemon" <<'EOF'
+#!/usr/bin/env bash
+while true; do sleep 1; done
+EOF
+chmod +x "$DECOY_DIR/loom-daemon"
+# Redirect stdio to /dev/null so the never-exiting decoy cannot hold open a
+# captured stdout pipe of the suite (which would block a caller capturing its
+# output — the same command-substitution gotcha the sandbox spawner avoids).
+"$DECOY_DIR/loom-daemon" >/dev/null 2>&1 &
+DECOY_PID=$!
+
 # Best-effort cleanup of any fake-daemon processes left running (matched by
 # their script path under $BASE_WORKDIR, which appears in `ps`'s command
 # line) — individual tests also kill their own PIDs explicitly, this is a
 # backstop for anything a failed assertion left behind.
-trap 'pkill -f "$BASE_WORKDIR" >/dev/null 2>&1; rm -rf "$BASE_WORKDIR"' EXIT
+trap 'kill "$DECOY_PID" 2>/dev/null; pkill -f "$BASE_WORKDIR" >/dev/null 2>&1; rm -rf "$BASE_WORKDIR" "$DECOY_DIR"' EXIT
 
 FAKE_BIN_DIR="$BASE_WORKDIR/fakebin"
 mkdir -p "$FAKE_BIN_DIR"
 write_fake_cargo "$FAKE_BIN_DIR/cargo"
+# Stub launchctl/pgrep onto the front of every test PATH (FAKE_BIN_DIR is the
+# first entry of TEST_PATH and TEST_PATH_NO_CODESIGN), recording invocations to
+# $SANDBOX_LOG_DIR so the suite can assert no production label was ever named.
+SANDBOX_LOG_DIR="$BASE_WORKDIR/sandbox-log"
+launchd_sandbox_install_stubs "$FAKE_BIN_DIR" "$SANDBOX_LOG_DIR"
 TEST_PATH="$FAKE_BIN_DIR:$MINIMAL_PATH"
 
 # A copy of /usr/bin with every entry EXCEPT `codesign` symlinked in, used by
@@ -646,6 +684,31 @@ else
     TESTS_FAILED=$((TESTS_FAILED + 1))
     echo -e "${RED}✗${NC} codesign absent from PATH: binary is still provisioned"
     echo "  output: $out14"
+fi
+
+# ============================================================
+# 15. Launchd-sandbox guards (#4078): the whole suite exercises the REAL
+#     start/stop scripts, so prove it never reached the operator's live daemon.
+#     (a) The suite-level decoy loom-daemon is still alive — no by-name kill
+#         fired anywhere in the suite.
+#     (b) No recorded launchctl invocation ever named a com.rjwalters.* label.
+# ============================================================
+TESTS_RUN=$((TESTS_RUN + 1))
+if kill -0 "$DECOY_PID" 2>/dev/null; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} suite-level decoy loom-daemon survived the whole update suite"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} suite-level decoy loom-daemon survived the whole update suite"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if launchd_sandbox_assert_no_production_label "$SANDBOX_LOG_DIR/launchctl-invocations.log"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} no launchctl invocation named a com.rjwalters.* label"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} no launchctl invocation named a com.rjwalters.* label"
+    echo "  launchctl invocations: $(cat "$SANDBOX_LOG_DIR/launchctl-invocations.log" 2>/dev/null)"
 fi
 
 # ---------- summary ----------


### PR DESCRIPTION
## Summary

`defaults/scripts/tests/test-loom-daemon-update.sh` and `test-loom-daemon-stop.sh` could adopt and SIGTERM the operator's production `com.rjwalters.loom-daemon` LaunchAgent when run on a host with a live daemon — silently ending autonomy (5 firings on 2026-07-27, per #4078). This closes both escape hatches at the production layer and makes the guarantee structural via a shared test sandbox.

Per the Curator's verification, scoping `LOOM_LAUNCHD_LABEL` alone does **not** close this — the label-blind `pgrep` fallback re-opens it. Both tiers are addressed here.

## Changes

- **`loom-daemon-stop.sh` — honor `LOOM_DAEMON_LAUNCHD` symmetrically with `loom-daemon-start.sh:382`.** `start.sh` gated its whole launchd path on this var; `stop.sh` never referenced it, so the `LOOM_DAEMON_LAUNCHD=0` guard already present at `test-loom-daemon-update.sh:32` was **inert** on the stop side (Curator Correction 1). A `USE_LAUNCHD` gate now disables all launchd lookup + bootout when set to `0/false/no`.
- **`loom-daemon-stop.sh` — narrow the label-blind `pgrep` fallback (Curator Correction 3).** The last-resort `pgrep -f '(^|/)loom-daemon$'` matched any loom-daemon by binary name — including the production daemon and other repos' daemons. It is now skipped whenever the caller scoped a **non-default** `LOOM_LAUNCHD_LABEL`, so a scratch-labeled stop can never fall through to a by-name kill. The default-label lost-PID-file recovery path is preserved. This also closes the cross-repo variant (repo A's stop killing repo B's daemon), aligning with the #4054 label-scoped-stop discipline.
- **New `defaults/scripts/tests/lib/launchd-sandbox.sh`** — shared helper: per-run scratch `LOOM_LAUNCHD_LABEL`, recording stub `launchctl`/`pgrep` (syscall layer only — never the lifecycle scripts), a decoy `loom-daemon` spawner matchable by the fallback pattern, and a `no com.rjwalters.* label` assertion. Sourced from both affected suites.
- **`test-loom-daemon-stop.sh` / `test-loom-daemon-update.sh`** — source the sandbox, run under a scratch label, and add a decoy-process test plus a suite-level decoy-survival guard and a no-production-label assertion.

## Scope decision: pgrep fallback was **narrowed**, not left with a follow-up

I narrowed the production `pgrep` fallback in this PR (the Curator flagged it as builder's judgment). Rationale: with only a scratch label + launchctl stub, the label-blind `pgrep` tier stays reachable and is the exact hole that makes "label-only" fixes insufficient; narrowing it is small, safe (default-label recovery preserved), and fixes the real cross-repo production bug rather than only the test symptom. No follow-up needed.

## Acceptance Criteria Verification

- [x] With a live `com.rjwalters.loom-daemon` loaded, both suites leave it **loaded and running** — verified on the host: PID `96910` identical before/after, still loaded in `launchctl list`.
- [x] The `pgrep` escape is closed, not just `launchctl` — decoy-process test: a live process whose argv ends in `/loom-daemon` (confirmed matchable by the fallback pattern) survives a scratch-label stop.
- [x] `loom-daemon-stop.sh` honors `LOOM_DAEMON_LAUNCHD=0` — symmetry test asserts zero `launchctl` calls; the update test's `:32` guard is now load-bearing.
- [x] Suite fails loudly if any `launchctl` invocation names a `com.rjwalters.*` label — assertion added to both suites.
- [x] Existing coverage preserved — stubs are at the `launchctl`/`pgrep` layer only; the restart path still exercises the real `loom-daemon-start.sh` / `loom-daemon-stop.sh`.
- [x] pgrep fallback disposition stated (narrowed — see above).

## Test Plan

- [x] `test-loom-daemon-stop.sh` — 17/17 pass (incl. decoy + symmetry + no-production-label).
- [x] `test-loom-daemon-update.sh` — 33/33 pass (incl. suite decoy + no-production-label).
- [x] `test-loom-daemon-start.sh` — 10/10 pass (unmodified in intent).
- [x] `test-loom-daemon-launchd-plist.sh` — 26/26 pass (unmodified in intent).
- [x] Manual regression: production `com.rjwalters.loom-daemon` PID `96910` loaded+alive both before and after the full run.
- [x] `shellcheck -S warning` clean on all four changed/new files.
- [x] Linux/no-`launchctl` path unaffected (launchd off there regardless; `command -v pgrep` guard retained).

Closes #4078