### PR TITLE
docs: split CLAUDE.md operating core from reference and history (#4014)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,16 @@ jobs:
       - name: Verify build output
         run: test -f mcp-loom/dist/index.js
 
+  claude-md-budget:
+    name: CLAUDE.md Line Budget
+    # Cheap structural check; always runs (CLAUDE.md is prepended to every
+    # agent's context, so its size is load-bearing — see #4014).
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Check CLAUDE.md line budget
+        run: bash scripts/check-claude-md-budget.sh
+
   installer-tests:
     name: Installer Integration Tests
     needs: changes

--- a/.loom/docs/token-pool.md
+++ b/.loom/docs/token-pool.md
@@ -1,0 +1,333 @@
+# Multi-Account Token Pool & Rotation
+
+Loom can rotate among multiple Claude OAuth accounts so load spreads across
+accounts and a single weekly limit does not stall the pipeline. This document is
+the full reference for provisioning, importing, health-probing, selecting, and
+operating the token pool. `CLAUDE.md` carries only the operating summary and
+points here.
+
+> **Secrets**: `~/.claude-monitor/accounts.env`, the opt-in `~/.loom/accounts.env`,
+> and the repo-local `.loom/accounts.env` all hold raw OAuth keys. The repo-local
+> file and `.loom/tokens/` are gitignored (installer- and `loom-daemon init`–managed);
+> keep any home-level master `0600` and outside any repo.
+
+## Bootstrapping the pool
+
+For environments that rotate among multiple Claude OAuth accounts, Loom can
+bootstrap a per-account token pool at `.loom/tokens/` from numbered
+`ACCOUNT_EMAIL_N` / `ACCOUNT_KEY_N` / `ACCOUNT_TOKEN_FILE_N` triples:
+
+```env
+ACCOUNT_EMAIL_1=user1@example.com
+ACCOUNT_KEY_1=sk-ant-oat01-...
+ACCOUNT_TOKEN_FILE_1=user1.token
+```
+
+Run `loom-tokens bootstrap` to materialize the pool:
+
+```bash
+loom-tokens bootstrap            # Idempotent — only writes new/missing tokens.
+loom-tokens bootstrap --dry-run  # Preview + print the effective merged account set.
+loom-tokens bootstrap --force    # Overwrite on-disk tokens that have drifted from source.
+loom-tokens bootstrap --shared   # Provision the shared machine-level pool at ~/.loom/tokens
+```
+
+Each account becomes `.loom/tokens/<file>.token` (mode `0600`). An `index.json`
+manifest is written alongside with sha256 fingerprints (8 chars) for drift
+detection plus each account's `source` (home/repo) — **no secret material is
+stored in the manifest**. Numbering gaps are allowed; partial triples are skipped
+with a warning.
+
+`.loom/tokens/` is gitignored. The pool is consumed by external rotation logic
+(e.g. a `claude-wrapper.sh` that picks the least-used token); only the bootstrap
+step is provided here.
+
+## Account sources: claude-monitor-first + per-repo (#3695, #3698, #3704)
+
+Rather than re-declaring the same account triples in every repo's `.env`, declare
+them **once** in the shared claude-monitor master and let each workspace add or
+override on top of it. Sources are merged by account email in precedence order:
+
+| Source | Default location | Override |
+|--------|------------------|----------|
+| **claude-monitor master** (primary) | `~/.claude-monitor/accounts.env` | `LOOM_CLAUDE_MONITOR_DIR` env var (directory) |
+| **Repo-local** | `<repo>/.loom/accounts.env` if present, else legacy `<repo>/.env` | `--env <path>` on `bootstrap` |
+| **Home master** (opt-in only, #3704) | *no default location* — read **only** when explicitly pointed at | `LOOM_ACCOUNTS_ENV` env var (a path enables it, `""` disables); `--home-env <path>` / `--no-home` on `bootstrap` |
+
+**Default resolution is claude-monitor → repo `.env`.** The `~/.loom/accounts.env`
+home master is **no longer auto-read** (#3704 retired the default location): it is
+consulted only when an operator opts in via `LOOM_ACCOUNTS_ENV=<path>`
+(conventionally `~/.loom/accounts.env`) or `--home-env <path>`. This retires the
+default *location*, not the *capability*.
+
+`loom-tokens bootstrap` reads the available sources and **merges them by account
+email** (`ACCOUNT_EMAIL`), with the higher-precedence source winning:
+
+- An email present **only in a lower-precedence source** is inherited into the pool.
+- An email present **only in a higher-precedence source** is added.
+- An email present in **both** → the higher-precedence entry overrides (e.g. to
+  rotate a key or repoint the token file).
+
+To *exclude* an inherited account from one repo, pin the subset you want with
+`loom-tokens pin` — the merge only ever adds/overrides, never subtracts. The
+effective merged set (and where each account came from) is printed by `bootstrap`
+and `bootstrap --dry-run`. A repo with only a legacy `.env` and no other source
+behaves exactly as before.
+
+## Importing live tokens from claude-monitor (#4006)
+
+`accounts.env` is a **snapshot** — a file someone wrote by hand at some point.
+claude-monitor keeps the **live** credentials in its SQLite store
+(`~/.claude-monitor/usage.db` → `oauth_credentials`) and refreshes them as
+accounts are re-authenticated. The two drift, and the drift is silent and total:
+
+```text
+401 {"type":"authentication_error","message":"OAuth access token has been revoked."}
+```
+
+When that happens to every account at once, `loom-tokens check` reports all
+accounts `blocked`, the daemon's dynamic concurrency cap collapses to
+`min(healthy 0 × per-token N, …) = 0`, and dispatch stops entirely. Crucially
+**`bootstrap --force` does not fix it** — it faithfully rewrites the same revoked
+tokens, because the snapshot itself is what went stale.
+
+`loom-tokens import-from-monitor` reads the live store directly and is **the
+standard way to populate a new host's pool** (it replaces hand-copying a pool
+between machines):
+
+```bash
+loom-tokens import-from-monitor                  # into <repo>/.loom/tokens
+loom-tokens import-from-monitor --shared         # into the machine-level pool (#3938)
+loom-tokens import-from-monitor --force          # apply ROLLED tokens (see below)
+loom-tokens import-from-monitor --dry-run        # preview
+loom-tokens import-from-monitor --prune          # drop accounts the monitor no longer reports
+```
+
+**`--force` is what applies a token roll.** Every rolled token legitimately
+differs from what is on disk, so without `--force` each one is reported as drift
+and left alone — deliberately, so a hand-pinned token is never silently clobbered.
+The command exits `2` when drift was found and not applied, so a script can detect
+"pool is still stale". After importing, refresh the ranking so the daemon sees the
+recovered capacity:
+
+```bash
+loom-tokens import-from-monitor --force && loom-tokens check --ranking
+```
+
+Behavior notes:
+
+- **Read-only** on `usage.db` (opened `mode=ro`) — the store belongs to
+  claude-monitor; Loom never writes or migrates it.
+- Only `is_active = 1` rows are imported; `expires_at` is **not** used as a filter
+  (observed rows carry stale timestamps while still authenticating — health comes
+  from `loom-tokens check`).
+- Token filenames use the same derivation as `bootstrap` (`robb@2amlogic.com` →
+  `robb-2amlogic.token`), so an account keeps one identity across both paths and
+  re-importing overwrites in place.
+- Idempotent: unchanged tokens are left untouched. `index.json` records
+  `source: monitor-db` (distinct from the `monitor` snapshot) and, as always,
+  fingerprints only — never secret material.
+- `--prune` removes only `*.token` files; pool state (`.ranking`, `.bad_tokens`,
+  `.failure_counts`, `.allowlist`) is never touched.
+- The importer takes **claude-monitor as authoritative for pool membership**, so
+  it imports every active account — including any that `accounts.env` omitted. Use
+  `loom-tokens pin` to restrict which accounts the selector may actually pick.
+- Absent claude-monitor, an absent `usage.db`, or an older schema without
+  `oauth_credentials` all exit `1` with a message naming the path tried.
+
+## Account health probe + ranking
+
+Once bootstrapped, `loom-tokens check` probes each account for current rate-limit
+headers and (optionally) writes a JSON ranking that the spawn-time selector can
+consume:
+
+```bash
+loom-tokens check                  # Probe + print human table
+loom-tokens check --ranking        # Probe + write .loom/tokens/.ranking atomically
+loom-tokens check --json           # Emit full JSON report to stdout
+./.loom/scripts/probe-tokens.sh    # Cron-friendly wrapper for periodic invocation
+```
+
+The probe sends a minimal `POST /v1/messages` request (1 input, 1 output token)
+and parses rate-limit response headers. The header parser matches by **suffix**
+(`-5h-utilization`, `-7d-utilization`, `-7d-reset`) so future renames of the
+`anthropic-ratelimit-tokens-*` prefix still work; the full header set is logged on
+the first probe of each run.
+
+Status assignment: `available` (utilizations < 95%), `exhausted`
+(`7d_utilization >= 0.95`), `rate_limited` (current 429), `blocked` (401 auth
+failure or token listed in `.bad_tokens`). Probe failures (network, timeout, 5xx)
+are logged and skipped — one bad account does not abort the run.
+
+OAuth tokens shaped `sk-ant-oat01-*` are sent with `Authorization: Bearer` +
+`anthropic-beta: oauth-2025-04-20`; plain API keys use `x-api-key`.
+
+**The running `loom-daemon` self-refreshes `.ranking` (#3969)** — it runs the
+equivalent of `probe-tokens.sh --ranking` on its own periodic loop (default every
+10 minutes, `autonomous.tokenRankingRefresh` / `LOOM_TOKEN_RANKING_REFRESH*`, on
+by default since it is read-only probing with no dispatch side effect), so a
+standing cron for this is no longer required when the daemon is running. See
+[Token-ranking self-refresh](daemon-reference.md#token-ranking-self-refresh-3969)
+for the config knobs.
+
+A cron entry is now only needed as a **fallback for setups that don't run
+`loom-daemon`** (e.g. pure `/loom:sweep` subagent dispatch with no daemon
+process). Cron example (probe every 10 minutes):
+
+```cron
+*/10 * * * * cd /path/to/repo && ./.loom/scripts/probe-tokens.sh --ranking >> .loom/logs/probe-tokens.log 2>&1
+```
+
+## Token rotation setup (per-task spawn)
+
+For Pro/Max plans, Loom supports rotating between multiple Claude Code OAuth
+tokens. This spreads load across accounts and recovers automatically when a single
+token hits its weekly limit.
+
+1. Declare account credentials in a default source — the shared claude-monitor
+   master `~/.claude-monitor/accounts.env` (primary) or per-repo in
+   `<repo>/.loom/accounts.env` (falls back to legacy `<repo>/.env`). The
+   `~/.loom/accounts.env` home master is **opt-in only** since #3704 (no longer
+   auto-read); point `LOOM_ACCOUNTS_ENV=~/.loom/accounts.env` (or `--home-env
+   <path>`) at it to enable:
+   ```env
+   ACCOUNT_EMAIL_1=account-one@example.com
+   ACCOUNT_KEY_1=sk-ant-oat01-...
+   ACCOUNT_TOKEN_FILE_1=account-one.token
+   ACCOUNT_EMAIL_2=account-two@example.com
+   ACCOUNT_KEY_2=sk-ant-oat01-...
+   ACCOUNT_TOKEN_FILE_2=account-two.token
+   ```
+   The claude-monitor, repo-local, and (opt-in) home sources are **merged by
+   email**, with the higher-precedence source overriding/adding. Keep any
+   home-level master `0600` and outside any repo.
+2. Run `loom-tokens bootstrap` to materialize the merged set into per-account
+   `.token` files in `.loom/tokens/` (mode 0600, parent dir 0700). See issues
+   #3234, #3695. **If claude-monitor runs on this host, prefer `loom-tokens
+   import-from-monitor`** — it reads claude-monitor's live credential store instead
+   of the `accounts.env` snapshot, so a new host needs no account file of its own
+   and a token roll is picked up automatically (add `--force` to apply rolled
+   tokens).
+3. Spawn agents through `.loom/scripts/spawn-claude.sh` instead of invoking
+   `claude` directly. The wrapper selects a token using a 3-tier algorithm
+   (ranking → allowlist → random), exports `CLAUDE_CODE_OAUTH_TOKEN`, then `exec`s
+   `claude` (or pass `--use-wrapper` to layer on top of `claude-wrapper.sh` for
+   retry behavior).
+
+## Selection algorithm (`loom_tools.tokens.select`)
+
+Three tiers, falling through to the next when the current tier yields nothing:
+
+1. **Ranking** — `.loom/tokens/.ranking` (pipe-delimited `name|status`, refreshed
+   every <10 min). Picks the first non-`exhausted`/non-`blocked` token.
+2. **Allowlist** — `.loom/tokens/.allowlist` (one name per line). Random pick from
+   allowed accounts.
+3. **Random** — uniform pick from all `*.token` files.
+
+Tokens marked bad in `.loom/tokens/.bad_tokens` are skipped at every tier.
+
+## Bad-token tracking (`loom_tools.tokens.bad_tokens`)
+
+When a token returns `TOKEN_EXPIRED` or `TOKEN_EXHAUSTED`, callers append an entry
+to `.loom/tokens/.bad_tokens`. Writes are guarded with a `mkdir`-based lock
+(POSIX-atomic, macOS-compatible — `flock` is **not** used because it isn't
+available on stock macOS). Reads use word-boundary regex so `agent-1` and
+`agent-10` don't collide.
+
+## Error classification (`.loom/scripts/lib/classify-error.sh`)
+
+The `classify_error <output> <exit_code>` function returns one of `SUCCESS`,
+`TIMEOUT`, `CWD_DELETED`, `TOKEN_EXPIRED`, `TOKEN_EXHAUSTED`, `RECOVERABLE`.
+Critical fix from #3233: exit code is checked **before** output substring
+matching — clean exits (`exit_code == 0`) always return `SUCCESS` regardless of
+stdout content.
+
+## Worktree handling
+
+When invoked from a worktree, `spawn-claude.sh` resolves the canonical repo root
+via `git rev-parse --git-common-dir` and locates `.loom/tokens/` there — never in
+the worktree's path. This avoids each worktree maintaining its own bad-tokens
+list.
+
+## Shared machine-level pool fallback (#3938)
+
+Token selection resolves the effective pool as: the **per-repo** pool
+`<repo>/.loom/tokens/` when it holds `*.token` files, else the **shared
+machine-level pool** `~/.loom/tokens/` (override `LOOM_SHARED_TOKENS_DIR`; set it
+empty to disable the fallback). This lets a consumer repo the daemon dispatches
+into — which has no pool of its own — spawn against the shared pool instead of
+hard-failing with `EX_CONFIG`. Crucially, the pool **state** files (`.bad_tokens`,
+`.failure_counts`, `.ranking`, `.allowlist`) are read/written in whichever pool was
+selected, so state is **never forked per repo** (token-capacity backpressure sees
+one truth). Provision the shared pool once per machine with `loom-tokens bootstrap
+--shared`. See [daemon-reference.md → Token pool provisioning for managed
+repos](daemon-reference.md#token-pool-provisioning-for-managed-repos-3938).
+
+**Package-path fallback for consumer-repo dispatches (#3949)**: `#3938` fixed the
+pool *location*, but token *selection* still shells into `python3 -m
+loom_tools.tokens.select`, and `spawn-claude.sh` locates that Python package via
+(1) `LOOM_PACKAGE_PATH` env, (2) script-relative `../../loom-tools/src`, (3)
+`$WORKSPACE/loom-tools/src`. `loom-daemon`'s `spawn_child` now resolves and
+forwards `LOOM_PACKAGE_PATH` automatically on every dispatch: an ambient override
+on the daemon's own environment always wins, otherwise it derives
+`<loom-checkout>/loom-tools/src` from the source tree the running `loom-daemon`
+binary was compiled from (`CARGO_MANIFEST_DIR`, baked in at build time) when that
+directory still exists and contains `loom_tools/tokens`. A consumer repo with no
+loom checkout and no `LOOM_PACKAGE_PATH` env now selects a token successfully with
+zero manual configuration.
+
+## Hard-fail on missing pool
+
+`spawn-claude.sh` exits `78` (`EX_CONFIG`) with a message instructing the user to
+run `loom-tokens bootstrap` (or `loom-tokens bootstrap --shared` for the
+machine-level pool) when **neither** the per-repo nor the shared pool has usable
+tokens (absent, empty, or all bad). It does **not** silently fall back to
+keychain — that path belongs in `loom-daemon` (#3236), and only when token
+rotation has not been configured at all.
+
+## Operator CLI (`loom-tokens pin/unpin/unblock`)
+
+Operators can restrict the rotation pool to a subset of accounts (an "allowlist")
+and manually un-blacklist accounts marked bad. Auto-recovery prevents pin-induced
+lockouts.
+
+```bash
+loom-tokens pin agent-3 agent-7   # Set allowlist to exactly these
+loom-tokens pin add agent-2       # Append (idempotent)
+loom-tokens pin remove agent-3    # Remove
+loom-tokens pin status            # Show current allowlist
+loom-tokens unpin                 # Delete allowlist (back to full pool)
+
+loom-tokens unblock agent-1       # Remove one entry from .bad_tokens
+loom-tokens unblock --all         # Clear .bad_tokens entirely
+```
+
+**Validation**: `pin` accepts only exact bootstrapped account names —
+substring/fuzzy matches are rejected. The allowlist is sorted, deduplicated, and
+`mkdir`-lock guarded so concurrent operator commands don't drop entries.
+
+**Reason-aware bad-token TTL**: bad-tokens entries with reason `auth` (401) ignore
+`LOOM_TOKENS_BAD_TTL` (default 21600s = 6h) and persist until `loom-tokens
+unblock`. Other reasons expire automatically.
+
+**Auto-unpin** (`failure_counts`): the wrapper tracks consecutive
+`TOKEN_EXHAUSTED` failures per account in `.loom/tokens/.failure_counts` (JSON).
+When **every** account in the allowlist hits the threshold (default 5), the
+wrapper auto-clears `.allowlist` and `.failure_counts` with a loud stderr log
+line. Operators can re-pin afterwards. The threshold is `>= 5`, so a 6th failure
+does not silently exceed; it still triggers (idempotent at-or-above).
+
+Counters are reset on:
+- a successful spawn for that account, or
+- any operator allowlist mutation (`pin`, `unpin`, `add`, `remove`).
+
+**Empty-pool guard**: if the selector finds the allowlist minus `.bad_tokens` is
+empty, `spawn-claude.sh` exits `78` (`EX_CONFIG`) with operator instructions. It
+refuses to silently auto-clear `.bad_tokens` — that masks real auth problems.
+
+## Tests
+
+```bash
+PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/tokens/ -v
+bash .loom/scripts/tests/test-spawn-claude.sh
+```

--- a/.loom/docs/troubleshooting.md
+++ b/.loom/docs/troubleshooting.md
@@ -353,3 +353,61 @@ For now, trigger them manually when the queue is empty:
 claude -p "/architect" --dangerously-skip-permissions
 claude -p "/hermit"    --dangerously-skip-permissions
 ```
+
+## Overnight / long-running orchestration
+
+### Keeping the host awake (#3350)
+
+`/loom:sweep` automatically runs `./.loom/scripts/check-host-sleep.sh` at startup
+and warns when the host can sleep. This is **advisory only** — Loom never blocks
+on it. Heed the warning before walking away from a long run.
+
+- **macOS:** user-idle sleep assertions (Amphetamine, `caffeinate -dimsu`, etc.)
+  do **not** reliably defeat Maintenance Sleep on Apple Silicon. Use `sudo pmset
+  -c sleep 0` for AC-only sleep disable, or flip your sleep manager's "allow
+  system sleep when display is off" toggle to OFF. Restore with `sudo pmset -c
+  sleep 1` afterwards.
+- **systemd Linux:** wrap the session in `systemd-inhibit --what=idle:sleep
+  --who=loom --why=loom -- <cmd>`.
+
+Manual invocation:
+
+```bash
+./.loom/scripts/check-host-sleep.sh         # full warning (or success line)
+./.loom/scripts/check-host-sleep.sh --quiet # stderr warning only, no stdout line
+```
+
+### Keeping installed `.loom/` copies fresh after a pull (#3770 detect → #3777 resync)
+
+The installed `.loom/hooks/` and `.loom/scripts/` copies the harness actually
+executes are synced from `defaults/` **at install time**. A `git pull` that merges
+a hook/script fix updates `defaults/` but **not** the installed copies — so a
+session can run stale hooks/scripts indefinitely (the incident: a merged
+`guard-destructive.sh` fix kept prompting until hand-copied).
+
+This is a **detect → fix** pair:
+
+- **Detect (#3770)** — `/loom:sweep` runs `./.loom/scripts/check-main-freshness.sh`
+  at startup. When local `main` is behind `origin/main` it prints a non-blocking
+  warning and flags any installed file that differs from its `defaults/`
+  counterpart. Advisory only; it never pulls, merges, or resets.
+- **Fix (#3777)** — `./.loom/scripts/resync-installed.sh` refreshes the installed
+  `.loom/hooks/*` and `.loom/scripts/*` from `defaults/`. Idempotent (a no-op when
+  in sync), reports per-file `updated`/`created`/`unchanged`/`skipped`, and only
+  ever touches files that exist in `defaults/` (repo-specific hooks with no
+  `defaults/` counterpart are left alone).
+
+The intended flow is **"freshness warning says you're stale → run resync"**:
+
+```bash
+git merge --ff-only origin/main                 # bring defaults/ current
+./.loom/scripts/resync-installed.sh --dry-run   # preview what would change (exits 2 on drift)
+./.loom/scripts/resync-installed.sh             # apply
+```
+
+`--dry-run` makes no changes and exits `2` when drift is detected (so it doubles
+as a check). To pin an intentional per-repo customization so resync never
+overwrites it, list its relative path (e.g. `hooks/guard-destructive.sh`) — one
+per line — in `.loom/resync-ignore`; matching files are reported `skipped`. A full
+`loom-daemon init` / installer run already performs the equivalent recursive copy,
+so a normal reinstall keeps the copies current too.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,45 +5,26 @@ This repository uses **Loom** for AI-powered development orchestration.
 **Loom Version**: 0.15.0
 **Installation Date**: 2026-04-21
 
+> **This file is the operating core** — only what an agent must know to act
+> correctly *right now*. Reference detail lives in `.loom/docs/*`; completed-migration
+> history in `docs/migration/` + ADRs. **New subsystem detail goes to `.loom/docs/`
+> with a one-line pointer here, not inline** — the CI budget check
+> (`scripts/check-claude-md-budget.sh`) enforces this so every agent's context does
+> not regrow unchecked.
+
 ## What is Loom?
 
-Loom is a CLI + daemon for AI-powered development orchestration. It coordinates AI development workers using git worktrees and a forge (GitHub or Gitea) as the coordination layer. It supports manual coordination (Manual Orchestration Mode), continuous autonomous orchestration via the Rust `loom-daemon` binary (MCP-level dispatch + pub/sub + monitoring), and GitHub Actions cron schedules for periodic support roles.
+Loom is a CLI + daemon for AI-powered development orchestration. It coordinates AI
+development workers using git worktrees and a forge (GitHub or Gitea) as the
+coordination layer, via manual roles, continuous autonomous orchestration (the
+Rust `loom-daemon` binary), and GitHub Actions cron schedules.
 
 **Loom Repository**: https://github.com/rjwalters/loom
 
 ## Orchestration Architecture
 
-Loom decomposes development into three coordination tiers, with the forge (GitHub / Gitea) as the shared state.
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                    Tier 3: Human Observer                       │
-│  - Watches system health, intervenes on blocked work            │
-│  - Overrides Champion on controversial proposals                │
-└─────────────────────────────────────────────────────────────────┘
-                              │ observes/intervenes
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│              Tier 2: loom-daemon + GitHub Actions cron          │
-│  loom-daemon (Rust) — MCP dispatch_sweep, list_sweeps,          │
-│    get_sweep_status, cancel_sweep, event bus (pub/sub)          │
-│  .github/workflows/loom-*.yml — periodic support roles          │
-└─────────────────────────────────────────────────────────────────┘
-                              │ spawns/triggers
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                    Tier 1: /loom:sweep <issue>                  │
-│  Single-issue lifecycle: Curator → Builder → Judge → Doctor →   │
-│  Merge. One detached process per issue. Mode C: PR-set sweeps.  │
-└─────────────────────────────────────────────────────────────────┘
-                              │ dispatches
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                    Worker Roles                                 │
-│  Curator, Builder, Judge, Doctor, etc.                          │
-│  - Execute single tasks (curate issue, build feature, review)   │
-└─────────────────────────────────────────────────────────────────┘
-```
+Loom decomposes development into three coordination tiers, with the forge (GitHub
+/ Gitea) as the shared state.
 
 | Tier | Entry point | Purpose | Mode |
 |------|-------------|---------|------|
@@ -52,98 +33,49 @@ Loom decomposes development into three coordination tiers, with the forge (GitHu
 | Tier 1 | `/loom:sweep <issue>` | Single-issue lifecycle (Curator → Merge) | Per-issue |
 | Tier 0 | `/builder`, `/judge`, etc. | Task execution — single focused work units | Per-task |
 
-**Use `/loom:sweep <issue>`** when you have a specific issue to implement (interactively or from a script). The skill probes for a running `loom-daemon` + multi-account token pool (Stage -1) and delegates dispatch when both are available; otherwise it falls through to in-process subagent dispatch.
-**Use `mcp__loom__dispatch_sweep`** from a Claude Code session to enqueue work directly against the running `loom-daemon` for autonomous multi-account batches.
-**Enable the GitHub Actions cron workflows** under `.github/workflows/loom-*.yml` for periodic Champion / Curator / Judge / Auditor / Guide ticks.
-
 ## Usage Modes
 
 ### 1. Manual Orchestration Mode (MOM)
 
-Use Claude Code terminals with specialized roles for hands-on development:
-
-1. Open Claude Code in this repository
-2. Use slash commands: `/builder`, `/judge`, `/curator`, etc.
-3. Each terminal acts as a specialized agent
+Open Claude Code in this repo and use slash commands (`/builder`, `/judge`,
+`/curator`, …) — each terminal acts as a specialized agent.
 
 ### 2. Single-issue lifecycle: `/loom:sweep <issue>`
 
 Run a complete Curator → Builder → Judge → Doctor → Merge lifecycle on one issue:
 
-```text
-/loom:sweep 123
-```
-
-Or from a script:
-
 ```bash
-claude -p "/loom:sweep 123" --dangerously-skip-permissions
+/loom:sweep 123
+claude -p "/loom:sweep 123" --dangerously-skip-permissions   # from a script
 ```
 
-Sweep also has a **PR-set mode (Mode C, #3384)** that drives Judge / Doctor → Judge / Merge from an existing open-PR set without re-running Curator or Builder:
-
-```text
-/loom:sweep --prs 456 789
-```
-
-Checkpoints (#3373) under `.loom/sweep-checkpoint/issue-<N>.json` survive crashes — restarting `/loom:sweep N` resumes from the last completed phase.
+**PR-set mode (Mode C, #3384)**: `/loom:sweep --prs 456 789` drives Judge / Doctor
+→ Judge / Merge from an existing open-PR set without re-running Curator or Builder.
+Checkpoints (#3373) under `.loom/sweep-checkpoint/issue-<N>.json` survive crashes,
+so restarting `/loom:sweep N` resumes from the last completed phase.
 
 ### 3. Daemon Mode (`loom-daemon` + MCP tools)
 
-The Rust `loom-daemon` binary is the Tier 2 dispatch backend. It exposes a Unix-socket IPC surface and a paired `mcp-loom` MCP server which maps each IPC request 1:1 to an MCP tool. An operator running `/loom:sweep` in a Claude Code session — or any MCP client — interacts with the daemon via:
-
-| MCP tool | Purpose | Phase |
-|----------|---------|-------|
-| `mcp__loom__dispatch_sweep` | Dispatch a sweep for an issue (multi-account token rotation via `spawn-claude.sh`) | A (#3452) |
-| `mcp__loom__list_sweeps` | Enumerate running sweeps in the in-memory registry | A (#3452) |
-| `mcp__loom__publish_event` | Publish a sweep-lifecycle event on the in-memory bus | B (#3453) |
-| `mcp__loom__subscribe_to_events` | Stream topic-filtered events to a subscriber | B (#3453) |
-| `mcp__loom__get_sweep_status` | Inspect a running sweep's state | C (#3455) |
-| `mcp__loom__tail_sweep_log` | Tail the per-sweep log file | C (#3455) |
-| `mcp__loom__cancel_sweep` | Cancel a running sweep (SIGTERM → grace → SIGKILL) | C (#3455) |
-| `mcp__loom__tail_event_bus` | Tail the event bus without subscribing to a topic | C (#3455) |
-
-**Event taxonomy (frozen for v0.10.0)**: `sweep.issue.{N}.phase`, `sweep.issue.{N}.blocker`, `sweep.issue.{N}.exited`, `sweep.issue.{N}.crashed`, `sweep.global.dispatch`, `sweep.global.completed`. New topics require a follow-up issue.
-
-**`/loom:sweep` backend detection (Stage -1, Phase D #3454)**: the skill probes whether the daemon is reachable (a Ping over the IPC socket with a 500ms timeout) AND whether a multi-account token pool exists (`.loom/tokens/` contains ≥ 2 `ACCOUNT_KEY_*` entries). **Strict AND** — either probe failing falls through to in-process subagent dispatch (the existing Mode A/B/C lifecycle). Mode C (`--prs`) always uses subagent dispatch; the daemon does not handle PR-set dispatch in v0.10.0. The `--no-daemon` flag forces subagent dispatch unconditionally.
-
-**By default the daemon is not a work generator** — with no autonomous config it does not poll the forge for `loom:issue` items, does not maintain a `shepherd-N` pool, and does not drive support roles on cron; work arrives only via `mcp__loom__dispatch_sweep` (operator-driven enqueue) and the GitHub Actions cron workflows. As of epics #3809 and #3842 the daemon *can* generate and dispatch its own work when **explicitly opted in** — both surfaces are default-off:
-
-- **Autonomous work finder** (#3810, `LOOM_WORK_FINDER` / `autonomous.workFinder`): polls the forge for open, already-approved `loom:issue` items and auto-dispatches sweeps, with work-driven concurrency bounded by `min(available work, healthy tokens × perTokenConcurrency, free disk, cpu/load headroom, maxConcurrent)` (#3811, per-token factor #3947 — default 2, `LOOM_PER_TOKEN_CONCURRENCY` / `autonomous.perTokenConcurrency`) and a reactive main-health backstop (#3812, `LOOM_MAIN_HEALTH_GATE` / `autonomous.mainHealthGate`) that halts dispatch when `main` goes red. Enable/tune from the `autonomous` block in `.loom/config.json` (precedence **env > config > default**) and manage the raw process with `loom-daemon-start.sh` / `loom-daemon-stop.sh` — see [Autonomous work finder](.loom/docs/daemon-reference.md#autonomous-work-finder-3810) and §Operability, plus "Daemon Configuration (Tier 2)" below.
-- **Epic supervisor** (#3842): drives every open `loom:epic` issue through a derived-state fork-join model with a phase-join barrier, serializing child-issue creation behind the #3707 issue-creation mutex on a dedicated off-runtime OS thread — see [Epic supervisor](.loom/docs/daemon-reference.md#epic-supervisor-3842).
-- **Periodic support-role runner** (#4015, `LOOM_ROLE_RUNNER` / `autonomous.roleRunner`): dispatches the standalone support roles (Champion, Curator, Judge, Auditor, Guide) host-side via `spawn-claude.sh` on their own per-role cadence, drawing from the same rotated, health-ranked token pool sweeps already use — instead of relying solely on the GitHub Actions cron workflows below, which authenticate with a single static `CLAUDE_API_KEY` secret with no rotation. See [Autonomous periodic support-role runner](.loom/docs/daemon-reference.md#autonomous-periodic-support-role-runner-4015).
-
-For full surface documentation — IPC request/response variants, event-bus internals, registry behaviour, reaper semantics — see [`.loom/docs/daemon-reference.md`](.loom/docs/daemon-reference.md).
-
-> **Note**: `/loom:sweep` also supports a **PR-set mode** (Mode C, #3384) via `--prs <pr-number-list>` or NL phrases like "all open `loom:pr`" — drives Judge / Doctor → Judge / Merge from an existing open-PR set without re-running Curator or Builder. Mode C always uses subagent dispatch (see Stage -1 above).
-
-> **Legacy spawn loop (removed)**: `defaults/scripts/spawn-loop.sh` (Phase 1, #3374) was **removed in v0.11.0**. Use `mcp__loom__dispatch_sweep` against `loom-daemon` instead. See [`docs/migration/v0.10.0-shepherd-deprecation.md`](docs/migration/v0.10.0-shepherd-deprecation.md).
+The Rust `loom-daemon` binary is the Tier 2 dispatch backend, driven over MCP:
+`mcp__loom__dispatch_sweep` (dispatch), `list_sweeps` / `get_sweep_status`
+(observe), `subscribe_to_events` (events), `cancel_sweep`. **By default it is not a
+work generator** — work arrives only via `dispatch_sweep` and the cron workflows;
+the autonomous work finder, epic supervisor, and role runner (all opt-in,
+default-off) let it generate its own work when enabled.
 
 ### 4. Scheduled Support Roles
 
-**Preferred path (daemon host, #4015):** when `loom-daemon` is running, enable the daemon-native periodic support-role runner (`LOOM_ROLE_RUNNER` / `autonomous.roleRunner.enabled=true` in `.loom/config.json`) instead of the GitHub Actions cron below — it dispatches Champion/Curator/Judge/Auditor/Guide host-side via `spawn-claude.sh`, drawing from the same rotated, health-ranked token pool sweeps use, so there is no separate `CLAUDE_API_KEY` secret to provision and no static-key exhaustion with no fallback. See [Autonomous periodic support-role runner](.loom/docs/daemon-reference.md#autonomous-periodic-support-role-runner-4015).
+Run the periodic support roles (Champion, Curator, Judge, Auditor, Guide) via the
+daemon-native role runner (`autonomous.roleRunner.enabled=true`, preferred — same
+rotated token pool as sweeps), or via GitHub Actions cron workflows under
+`.github/workflows/loom-*.yml` (disabled by default; opt in with a `CLAUDE_API_KEY`
+secret + uncommented `schedule:` lines — a single static key, no rotation).
 
-**Fallback (no always-on daemon, opt-in):** GitHub Actions workflows under `.github/workflows/loom-*.yml` run the periodic support roles (Champion, Curator, Judge, Auditor, Guide) on cron schedules (#3375). Each workflow checks out the repo, installs the Claude CLI, and runs `claude -p "/<role>" --dangerously-skip-permissions` for one tick of work — no Loom-side state file, no long-running process. This is the degraded mode: a single static `CLAUDE_API_KEY` secret with no rotation and no health-awareness (an exhausted/rate-limited key has no fallback, unlike the daemon path above).
-
-| Workflow | Role | Schedule (commented) |
-|----------|------|----------------------|
-| `loom-champion.yml` | `/champion` | `*/10 * * * *` |
-| `loom-curator.yml`  | `/curator`  | `*/5 * * * *`  |
-| `loom-judge.yml`    | `/judge`    | `*/5 * * * *`  |
-| `loom-auditor.yml`  | `/auditor`  | `*/10 * * * *` |
-| `loom-guide.yml`    | `/guide`    | `*/15 * * * *` |
-
-**Disabled by default.** Every shipped workflow has its `schedule:` block commented out so forks don't burn Actions minutes accidentally. To opt in on a fork:
-
-1. Add a `CLAUDE_API_KEY` repository secret (Settings -> Secrets and variables -> Actions). Workflows run on a single API key — token rotation is for per-task spawns only; scheduled support roles are predictable load that doesn't benefit from rotation.
-2. Uncomment the `schedule:` / `- cron:` lines in each `.github/workflows/loom-*.yml` you want to enable.
-3. Optionally trigger a run via `workflow_dispatch` (the Actions UI's "Run workflow" button) to smoke-test before the next scheduled tick.
-
-Architect and Hermit cadence (work-generation triggers) is intentionally out of scope here — see follow-up #3381 (Phase 2d).
+The full MCP surface, event taxonomy, autonomous config, and role runner are in
+[`.loom/docs/daemon-reference.md`](.loom/docs/daemon-reference.md);
+Architect/Hermit cadence is out of scope (#3381).
 
 ## Agent Roles
-
-### Worker Roles
 
 | Role | File | Purpose | Mode |
 |------|------|---------|------|
@@ -158,15 +90,13 @@ Architect and Hermit cadence (work-generation triggers) is intentionally out of 
 | Driver | `driver.md` | Direct command execution | Manual |
 | Auditor | `auditor.md` | Validate main branch build and runtime | Cron 10min (GH Actions) |
 
-Full role definitions: `.loom/roles/*.md`.
-
-> **Note**: the historical `shepherd.md` (single-issue orchestrator) role file was removed in v0.10.0 along with the `/shepherd` slash command — see [the migration guide](docs/migration/v0.10.0-shepherd-deprecation.md). Its orchestration responsibilities moved to `/loom:sweep` (Tier 1) and the `loom-daemon` + GH Actions cron (Tier 2). The `loom.md` role file is preserved and documents the daemon-mode operator surface: a Claude Code session that observes the running `loom-daemon` via MCP tools (`mcp__loom__list_sweeps`, `mcp__loom__get_sweep_status`, `mcp__loom__subscribe_to_events`) and dispatches new work via `mcp__loom__dispatch_sweep`. The historical Python brain (`loom_tools/daemon_v2/`) is gone; the MCP-level surface is the supported coordination point. The worker-role markdown files above are unchanged.
+Full role definitions: `.loom/roles/*.md`. The `loom.md` role file documents the
+daemon-mode operator surface (observing the running `loom-daemon` via MCP tools).
 
 ## Label-Based Workflow
 
-Agents coordinate through GitHub labels. See `.github/labels.yml` for full definitions.
-
-### Label Flow
+Agents coordinate through labels. See `.github/labels.yml` for full definitions
+(the authoritative `Applied by:` field is on every label).
 
 **Issue Lifecycle**:
 ```
@@ -175,8 +105,6 @@ Agents coordinate through GitHub labels. See `.github/labels.yml` for full defin
                                                           (or Champion
                                                            in --merge mode)
 ```
-
-See `.github/labels.yml` for the authoritative `Applied by:` field on every label.
 
 **PR Lifecycle**:
 ```
@@ -190,58 +118,70 @@ See `.github/labels.yml` for the authoritative `Applied by:` field on every labe
            ↑ Architect/Hermit/Auditor                 ↑ Champion    ↑ Ready for Builder
 ```
 
-**Epic Lifecycle**: `loom:epic` → Champion creates phased `loom:architect` + `loom:epic-phase` issues.
+**Epic Lifecycle**: `loom:epic` → Champion creates phased `loom:architect` +
+`loom:epic-phase` issues.
 
-> **Note on label cleanup**: Loom intentionally does **not** remove labels from closed issues or merged PRs (e.g., `loom:pr` remains on merged PRs). Labels on closed/merged items are harmless — all agents filter by open state — and skipping post-close label removal saves gh API calls. Do not implement label cleanup on merge/close (see issue #2838).
+> **Note on label cleanup**: Loom intentionally does **not** remove labels from
+> closed issues or merged PRs (harmless — all agents filter by open state — and it
+> saves gh API calls). Do not implement label cleanup on merge/close (see #2838).
 
 ### Issues Are Suggestions (Role Autonomy)
 
-Filed issues are the *input queue*, not mandates. In autonomous mode the **Curator, Builder, and Judge** have standing authority to **close** or **rescope** an issue — with a stated rationale — when building it is not the best outcome (obsolete, duplicate/already covered, low value vs. cost, wrong approach, better split/merged). This is what keeps the auto-picked-up backlog healthy rather than "build whatever is filed". Full mechanism + guardrails live in each role prompt's "Issues Are Suggestions — Close or Rescope With Rationale" section (`.loom/roles/curator.md`, `builder.md`, `judge.md`). The rules in brief:
+Filed issues are the *input queue*, not mandates. In autonomous mode the
+**Curator, Builder, and Judge** may **close** or **rescope** an issue — with a
+stated rationale — when building it is not the best outcome (obsolete, duplicate,
+low value, wrong approach, better split/merged). Full guardrails live in each role
+prompt's "Issues Are Suggestions" section (`.loom/roles/curator.md`, `builder.md`,
+`judge.md`). In brief:
 
-- **Comment the rationale BEFORE closing**, then `gh issue close <N> --reason "not planned"`. A closed issue leaves the queue automatically (the work-finder only polls *open* `loom:issue` items), so it is not re-picked-up.
-- **Rescope** instead of closing when the core is worth keeping: edit the body / split / relabel, and **remove `loom:issue`** if the labels no longer reflect an approved scope (drop back to `loom:triage`/`loom:curated`) so it is not re-dispatched with a stale scope.
-- **Never close an issue that encodes a still-pending human decision** — route it to `loom:blocked` or `loom:operator-only` with a comment instead. Never invent new labels.
+- **Comment the rationale BEFORE closing**, then `gh issue close <N> --reason "not
+  planned"`. A closed issue leaves the queue automatically (the work-finder polls
+  only *open* `loom:issue` items).
+- **Rescope** instead of closing when the core is worth keeping: edit/split/relabel,
+  and **remove `loom:issue`** if the labels no longer reflect an approved scope (drop
+  back to `loom:triage`/`loom:curated`) so it is not re-dispatched with a stale scope.
+- **Never close an issue that encodes a still-pending human decision** — route it to
+  `loom:blocked` or `loom:operator-only` with a comment instead. Never invent labels.
 
 ## Git Worktree Workflow
 
-Loom uses git worktrees to isolate agent work.
-
-**Issue Worktrees** (`.loom/worktrees/issue-N`): Issue-specific work for Builder agents.
-
-### Creating Worktrees
+Loom uses git worktrees to isolate agent work. **Issue Worktrees**
+(`.loom/worktrees/issue-N`) hold issue-specific work for Builder agents.
 
 ```bash
-# Claim issue and create worktree
 gh issue edit 42 --remove-label "loom:issue" --add-label "loom:building"
-./.loom/scripts/worktree.sh 42
-cd .loom/worktrees/issue-42
-
-# Work, commit, push, create PR
+./.loom/scripts/worktree.sh 42 && cd .loom/worktrees/issue-42
+# ... work, commit ...
 git push -u origin feature/issue-42
 gh pr create --label "loom:review-requested"
 ```
 
-### Best Practices
+**Rules**:
 
-- Always use `./.loom/scripts/worktree.sh <issue-number>` (it writes a `.loom-managed` sentinel that authorizes cleanup)
-- Never run `git worktree` directly (helper prevents nested worktrees) — to remove one managed worktree on demand, use `./.loom/scripts/worktree.sh remove <issue-number>` (sentinel-honoring, idempotent, deletes the local branch; `loom-clean` remains the bulk path)
-- Loom-managed worktrees (under `.loom/worktrees/` with the `.loom-managed` sentinel) are auto-removed when their PR merges. User-provisioned worktrees at other paths are never removed by Loom — set `LOOM_PRESERVE_WORKTREE=1` to disable cleanup globally for a session.
+- Always use `./.loom/scripts/worktree.sh <issue-number>` (it writes a
+  `.loom-managed` sentinel that authorizes cleanup).
+- **Never run `git worktree` directly** (the helper prevents nested worktrees) — to
+  remove one managed worktree on demand use `./.loom/scripts/worktree.sh remove
+  <issue-number>` (`loom-clean` is the bulk path).
+- Loom-managed worktrees (with the `.loom-managed` sentinel) are auto-removed when
+  their PR merges; user-provisioned worktrees are never removed — set
+  `LOOM_PRESERVE_WORKTREE=1` to disable cleanup for a session.
 
 ### Merging PRs
 
-**Never use `gh pr merge`** -- always use `./.loom/scripts/merge-pr.sh <PR_NUMBER>` instead. The `gh pr merge` command attempts a local checkout which fails when the PR branch is linked to a worktree. The merge script merges via the forge API directly and handles worktree cleanup automatically.
-
-```bash
-./.loom/scripts/merge-pr.sh <PR_NUMBER>         # Standard merge with worktree cleanup
-./.loom/scripts/merge-pr.sh <PR_NUMBER> --auto   # Enable auto-merge instead of immediate merge (queues until checks pass; on CLEAN PRs falls back to immediate merge)
-./.loom/scripts/merge-pr.sh <PR_NUMBER> --dry-run # Preview without merging
-```
+**Never use `gh pr merge`** — always use `./.loom/scripts/merge-pr.sh <PR_NUMBER>`
+instead (`--auto` to queue until checks pass, `--dry-run` to preview). `gh pr
+merge` attempts a local checkout that fails when the PR branch is linked to a
+worktree; the script merges via the forge API directly and handles worktree
+cleanup automatically.
 
 ## Development Workflow
 
 ### Sweep Lifecycle (MANDATORY)
 
-When implementing issues — whether manually, via `/loom:sweep`, or by spawning subagents — **all stages of the lifecycle must be executed in order**. Do not skip stages.
+When implementing issues — whether manually, via `/loom:sweep`, or by spawning
+subagents — **all stages of the lifecycle must be executed in order**. Do not skip
+stages.
 
 ```
 Curator → Builder → Judge → Doctor (if needed) → Merge
@@ -255,9 +195,10 @@ Curator → Builder → Judge → Doctor (if needed) → Merge
 | **Doctor** | Fix issues from judge feedback | Only if judge approves |
 | **Merge** | Champion auto-merges approved PRs | No |
 
-**When spawning subagents to handle an issue**: each subagent must run the full lifecycle, not just the builder phase. If parallelizing multiple issues, each agent must independently execute Curator → Builder → Judge → Doctor → Merge. Simply creating a PR and labeling it `loom:review-requested` is only the Builder stage — the work is not complete until the PR has been reviewed and merged.
-
-**When using `/loom:sweep`**: the skill handles all stages automatically. Prefer `/loom:sweep <issue>` over manual orchestration to avoid accidentally skipping stages.
+**When spawning subagents**: each must run the full lifecycle, not just the builder
+phase — creating a PR labeled `loom:review-requested` is only the Builder stage;
+the work is not complete until reviewed and merged. **`/loom:sweep` handles all
+stages automatically** — prefer it over manual orchestration to avoid skipping any.
 
 ### Builder Workflow
 
@@ -269,489 +210,94 @@ Curator → Builder → Judge → Doctor (if needed) → Merge
 
 ### Judge Workflow
 
-1. Find PR: `gh pr list --label="loom:review-requested"`
-2. Review: `gh pr checkout 123`
-3. Approve: `gh pr comment 123 --body "LGTM! Approved." && gh pr edit 123 --remove-label "loom:review-requested" --add-label "loom:pr"`
-4. Or request changes: `gh pr comment 123 --body "Changes needed: ..." && gh pr edit 123 --remove-label "loom:review-requested" --add-label "loom:changes-requested"`
-
-**Note**: Use `gh pr comment` instead of `gh pr review --approve` — GitHub's API prevents self-review, and Loom agents often create and review the same PR. Labels are the coordination mechanism.
+Find `gh pr list --label="loom:review-requested"`, review, then coordinate via
+**labels** (approve → `loom:pr`; changes → `loom:changes-requested`) plus a `gh pr
+comment`. Use `gh pr comment`, **not** `gh pr review --approve` — GitHub's API
+blocks self-review and Loom agents often create and review the same PR.
 
 ### Curator Workflow
 
-1. Find unlabeled issues: `gh issue list --search "-label:loom:issue -label:loom:building -label:loom:architect -label:loom:hermit -label:loom:curated -label:loom:curating" --state open` (gh ANDs `--label` values and has no `!`/`,` negation syntax, so a `--label="!loom:issue,..."` filter matches a literal label no issue carries and always returns empty; use `-label:` search terms instead)
-2. Enhance issue with technical details
-3. Mark curated: `gh issue edit 42 --add-label "loom:curated"`
+Find unlabeled issues (use `-label:` search terms, **not** `--label` — gh ANDs
+`--label` values with no negation syntax, so a negated `--label` always returns
+empty), enhance with technical detail, then `gh issue edit 42 --add-label
+"loom:curated"`.
 
-### Overnight / long-running orchestration: keep the host awake (#3350)
+### Overnight / long-running orchestration
 
-`/loom:sweep` automatically runs `./.loom/scripts/check-host-sleep.sh` at startup and warns when the host can sleep. This is **advisory only** — Loom never blocks on it. Heed the warning before walking away from a long run.
-
-- **macOS:** user-idle sleep assertions (Amphetamine, `caffeinate -dimsu`, etc.) do **not** reliably defeat Maintenance Sleep on Apple Silicon. Use `sudo pmset -c sleep 0` for AC-only sleep disable, or flip your sleep manager's "allow system sleep when display is off" toggle to OFF.
-- **systemd Linux:** wrap the session in `systemd-inhibit --what=idle:sleep --who=loom --why=loom -- <cmd>`.
-
-Manual invocation: `./.loom/scripts/check-host-sleep.sh` (or `--quiet` for stderr-only output).
-
-### Keeping installed `.loom/` copies fresh after a pull (#3770 detect → #3777 resync)
-
-The installed `.loom/hooks/` and `.loom/scripts/` copies the harness actually executes are synced from `defaults/` **at install time**. A `git pull` that merges a hook/script fix updates `defaults/` but **not** the installed copies — so a session can run stale hooks/scripts indefinitely (the incident: a merged `guard-destructive.sh` fix kept prompting until hand-copied).
-
-This is a **detect → fix** pair:
-
-- **Detect (#3770)** — `/loom:sweep` runs `./.loom/scripts/check-main-freshness.sh` at startup. When local `main` is behind `origin/main` it prints a non-blocking warning and flags any installed file that differs from its `defaults/` counterpart. Advisory only; it never pulls, merges, or resets.
-- **Fix (#3777)** — `./.loom/scripts/resync-installed.sh` refreshes the installed `.loom/hooks/*` and `.loom/scripts/*` from `defaults/`. Idempotent (a no-op when in sync), reports per-file `updated`/`created`/`unchanged`/`skipped`, and only ever touches files that exist in `defaults/` (repo-specific hooks with no `defaults/` counterpart are left alone).
-
-The intended flow is **"freshness warning says you're stale → run resync"**:
-
-```bash
-git merge --ff-only origin/main             # bring defaults/ current
-./.loom/scripts/resync-installed.sh --dry-run   # preview what would change
-./.loom/scripts/resync-installed.sh             # apply
-```
-
-`--dry-run` makes no changes and exits `2` when drift is detected (so it doubles as a check). To pin an intentional per-repo customization so resync never overwrites it, list its relative path (e.g. `hooks/guard-destructive.sh`) — one per line — in `.loom/resync-ignore`; matching files are reported `skipped`. A full `loom-daemon init` / installer run already performs the equivalent recursive copy, so a normal reinstall keeps the copies current too.
+`/loom:sweep` warns (advisory) via `check-host-sleep.sh` when the host can sleep;
+after a `git pull` that updates `defaults/`, `./.loom/scripts/resync-installed.sh`
+refreshes stale installed `.loom/hooks/` + `.loom/scripts/` copies. Details:
+[`.loom/docs/troubleshooting.md` → Overnight / long-running orchestration](.loom/docs/troubleshooting.md).
 
 ## Configuration
 
-### Workspace Configuration
-
-Configuration stored in `.loom/config.json` (committed to git for team sharing):
-
-```json
-{
-  "nextAgentNumber": 3,
-  "terminals": [
-    {
-      "id": "terminal-1",
-      "name": "Builder",
-      "role": "builder",
-      "roleConfig": {
-        "workerType": "claude",
-        "roleFile": "builder.md",
-        "targetInterval": 0,
-        "intervalPrompt": ""
-      }
-    }
-  ]
-}
-```
-
-### Daemon Configuration (Tier 2)
-
-The Rust `loom-daemon` binary is the load-bearing Tier 2 dispatch backend. It is a single long-lived process that holds the sweep registry, the event bus, and the reaper task in memory — there is no on-disk state file the operator needs to touch. See [`.loom/docs/daemon-reference.md`](.loom/docs/daemon-reference.md) for the full surface and [`docs/migration/v0.10.0-shepherd-deprecation.md`](docs/migration/v0.10.0-shepherd-deprecation.md) for the migration narrative away from the legacy Python brain.
-
-**Autonomous mode (config + start/stop, #3813)**: the daemon's autonomous work finder (#3810, `LOOM_WORK_FINDER`) and reactive main-health gate (#3812, `LOOM_MAIN_HEALTH_GATE`) can be enabled and tuned entirely from committed config — an `autonomous` block in `.loom/config.json` — with env vars still overriding for a single run (precedence **env > config > default**; an absent block is byte-for-byte the pre-#3813 env-only behavior):
-
-```json
-{
-  "autonomous": {
-    "perTokenConcurrency": 2,
-    "workFinder": { "enabled": true, "intervalSecs": 60, "maxConcurrent": 5 },
-    "mainHealthGate": { "enabled": true },
-    "roleRunner": { "enabled": true, "roles": ["champion", "curator", "judge", "auditor", "guide"] }
-  }
-}
-```
-
-Start/stop the **raw daemon process** (distinct from the tmux `loom start|stop` pool) with dedicated wrappers that run the advisory host-sleep check, write a PID file (`.loom/.daemon.pid`), surface the singleton-guard refusal, and shut down cleanly on **SIGTERM** (not just Ctrl-C):
-
-```bash
-./.loom/scripts/cli/loom-daemon-start.sh                # FLAGS-OFF reliability daemon (both loops off, backgrounded)
-./.loom/scripts/cli/loom-daemon-start.sh --work-finder  # opt in: autonomous work finder
-./.loom/scripts/cli/loom-daemon-start.sh --health-gate  # opt in: main-health gate
-./.loom/scripts/cli/loom-daemon-start.sh --from-config  # enable strictly per .loom/config.json
-./.loom/scripts/cli/loom-daemon-stop.sh                 # SIGTERM → grace → SIGKILL
-```
-
-> **Default is FLAGS-OFF (#3911).** A bare `loom-daemon-start.sh` starts a
-> reliability daemon with **both autonomous loops OFF** — it does **not**
-> auto-dispatch sweeps — matching the ecosystem-wide opt-in / default-off
-> contract (`LOOM_WORK_FINDER` unset ⇒ off, `LOOM_MAIN_HEALTH_GATE` unset ⇒ off,
-> precedence env > config > default). Enable autonomy explicitly with
-> `--work-finder` / `--health-gate`, or hand control to committed config with
-> `--from-config`.
-
-A clean stop leaves in-flight `/loom:sweep` children **running** (they survive a daemon restart by design; use `mcp__loom__cancel_sweep` to actively cancel). The full config table, start/stop flags, and a scripted end-to-end acceptance playbook are in [`.loom/docs/daemon-reference.md`](.loom/docs/daemon-reference.md) §Operability and [`docs/autonomous-mode-e2e.md`](docs/autonomous-mode-e2e.md).
-
-**Self-update (#3968)**: after merging a daemon fix, `./.loom/scripts/cli/loom-daemon-update.sh` is the single operator command that rebuilds (`cargo build --release`), reprovisions, and restarts — reading the flags `loom-daemon-start.sh` persisted to `.loom/.daemon.flags` at the last start and replaying them **exactly** (never wider than what was already running). Staleness is detected by comparing the commit baked into the resolved binary against the local source tree's `HEAD` (`--check` for a read-only report, `--dry-run` to preview, `--no-restart` to rebuild without touching a running daemon). A daemon that wasn't already running is never started by this script. `loom-daemon --status` also surfaces a read-only "update available" hint from the same comparison — advisory only, no auto-restart. See [Self-update](.loom/docs/daemon-reference.md#self-update-rebuild--provision--restart-3968) for the full detection strategy and provisioning rules.
-
-**Epic supervisor (#3842)**: separately from the work finder, when enabled the daemon runs a [derived-state epic supervisor](.loom/docs/daemon-reference.md#epic-supervisor-3842) that drives every open `loom:epic` issue through a fork-join lifecycle (decompose → expand → phase-join barrier → close), scheduling phase dispatches and serializing all child-issue creation behind the #3707 issue-creation mutex. It runs on a dedicated off-runtime OS thread (not a `tokio::spawn`) precisely because the mutex-guarded issue-creation calls block; see [Epic supervisor](.loom/docs/daemon-reference.md#epic-supervisor-3842) for the transition table and event topics.
-
-**Per-sweep logs** live at `.loom/logs/sweep-issue-<N>.log` and are tailable via `mcp__loom__tail_sweep_log`.
-
-**Sweep checkpoints** (`.loom/sweep-checkpoint/issue-<N>.json`, gitignored): when a sweep child crashes mid-flight, the checkpoint records the last completed phase. On the next dispatch the sweep skill resumes from that phase. The exact schema is owned by the sweep skill (#3373).
-
-**Scheduled support roles** run as separate GitHub Actions cron jobs — see `.github/workflows/loom-*.yml`. They have no persistent state on the Loom side; each tick is a fresh `claude -p "/<role>" --dangerously-skip-permissions` invocation.
-
-> **Legacy spawn-loop state (obsolete)**: the v0.9.x state file `.loom/spawn-loop-state.json` was written by `spawn-loop.sh`, which was **removed in v0.11.0**. Nothing writes it anymore. Operators who need to observe running sweeps should call `mcp__loom__list_sweeps` against the daemon instead.
-
-### Custom Roles
-
-Create custom roles by adding files to `.loom/roles/`:
-
-```bash
-cat > .loom/roles/my-role.md <<EOF
-# My Custom Role
-You are a specialist in {{workspace}}.
-## Your Role
-...
-EOF
-```
-
-### Branch Rulesets
-
-Loom works best with a GitHub ruleset enabled on the default branch. During installation:
-
-```bash
-./scripts/install-loom.sh /path/to/repo  # Interactive, prompts for ruleset
-./scripts/install-loom.sh --yes /path/to/repo  # Non-interactive, skip ruleset
-```
-
-Manual configuration: `./scripts/install/setup-branch-protection.sh /path/to/repo main`
-
-### Repository Settings
-
-Configure merge settings during installation or manually:
-
-```bash
-./scripts/install/setup-repository-settings.sh /path/to/repo
-./scripts/install/setup-repository-settings.sh /path/to/repo --dry-run  # Preview
-```
-
-Settings applied: squash merge only (no merge commits/rebase), delete branches on merge, auto-merge enabled.
-
-### Multi-Account Token Pool
-
-For environments that rotate among multiple Claude OAuth accounts, Loom can bootstrap a per-account token pool at `.loom/tokens/` from numbered `ACCOUNT_EMAIL_N` / `ACCOUNT_KEY_N` / `ACCOUNT_TOKEN_FILE_N` triples:
-
-```env
-ACCOUNT_EMAIL_1=user1@example.com
-ACCOUNT_KEY_1=sk-ant-oat01-...
-ACCOUNT_TOKEN_FILE_1=user1.token
-```
-
-Run `loom-tokens bootstrap` to materialize the pool:
-
-```bash
-loom-tokens bootstrap            # Idempotent — only writes new/missing tokens.
-loom-tokens bootstrap --dry-run  # Preview + print the effective merged account set.
-loom-tokens bootstrap --force    # Overwrite on-disk tokens that have drifted from source.
-```
-
-Each account becomes `.loom/tokens/<file>.token` (mode `0600`). An `index.json` manifest is written alongside with sha256 fingerprints (8 chars) for drift detection plus each account's `source` (home/repo) — **no secret material is stored in the manifest**. Numbering gaps are allowed; partial triples are skipped with a warning.
-
-`.loom/tokens/` is gitignored. The pool is consumed by external rotation logic (e.g. a `claude-wrapper.sh` that picks the least-used token); only the bootstrap step is provided here.
-
-#### Account sources: claude-monitor-first + per-repo (#3695, #3698, #3704)
-
-Rather than re-declaring the same account triples in every repo's `.env`, declare them **once** in the shared claude-monitor master and let each workspace add or override on top of it. Sources are merged by account email in precedence order:
-
-| Source | Default location | Override |
-|--------|------------------|----------|
-| **claude-monitor master** (primary) | `~/.claude-monitor/accounts.env` | `LOOM_CLAUDE_MONITOR_DIR` env var (directory) |
-| **Repo-local** | `<repo>/.loom/accounts.env` if present, else legacy `<repo>/.env` | `--env <path>` on `bootstrap` |
-| **Home master** (opt-in only, #3704) | *no default location* — read **only** when explicitly pointed at | `LOOM_ACCOUNTS_ENV` env var (a path enables it, `""` disables); `--home-env <path>` / `--no-home` on `bootstrap` |
-
-**Default resolution is claude-monitor → repo `.env`.** The `~/.loom/accounts.env` home master is **no longer auto-read** (#3704 retired the default location): it is consulted only when an operator opts in via `LOOM_ACCOUNTS_ENV=<path>` (conventionally `~/.loom/accounts.env`) or `--home-env <path>`. This retires the default *location*, not the *capability*.
-
-`loom-tokens bootstrap` reads the available sources and **merges them by account email** (`ACCOUNT_EMAIL`), with the higher-precedence source winning:
-
-- An email present **only in a lower-precedence source** is inherited into the pool.
-- An email present **only in a higher-precedence source** is added.
-- An email present in **both** → the higher-precedence entry overrides (e.g. to rotate a key or repoint the token file).
-
-To *exclude* an inherited account from one repo, pin the subset you want with `loom-tokens pin` — the merge only ever adds/overrides, never subtracts. The effective merged set (and where each account came from) is printed by `bootstrap` and `bootstrap --dry-run`. A repo with only a legacy `.env` and no other source behaves exactly as before.
-
-> **Secrets**: `~/.claude-monitor/accounts.env`, the opt-in `~/.loom/accounts.env`, and the repo-local `.loom/accounts.env` all hold raw OAuth keys. The repo-local file and `.loom/tokens/` are gitignored (installer- and `loom-daemon init`–managed); keep any home-level master `0600` and outside any repo. A repo can rely entirely on the claude-monitor master with no local account file at all.
-
-#### Importing live tokens from claude-monitor (#4006)
-
-`accounts.env` is a **snapshot** — a file someone wrote by hand at some point. claude-monitor keeps the **live** credentials in its SQLite store (`~/.claude-monitor/usage.db` → `oauth_credentials`) and refreshes them as accounts are re-authenticated. The two drift, and the drift is silent and total:
-
-```text
-401 {"type":"authentication_error","message":"OAuth access token has been revoked."}
-```
-
-When that happens to every account at once, `loom-tokens check` reports all accounts `blocked`, the daemon's dynamic concurrency cap collapses to `min(healthy 0 × per-token N, …) = 0`, and dispatch stops entirely. Crucially **`bootstrap --force` does not fix it** — it faithfully rewrites the same revoked tokens, because the snapshot itself is what went stale.
-
-`loom-tokens import-from-monitor` reads the live store directly and is **the standard way to populate a new host's pool** (it replaces hand-copying a pool between machines):
-
-```bash
-loom-tokens import-from-monitor                  # into <repo>/.loom/tokens
-loom-tokens import-from-monitor --shared         # into the machine-level pool (#3938)
-loom-tokens import-from-monitor --force          # apply ROLLED tokens (see below)
-loom-tokens import-from-monitor --dry-run        # preview
-loom-tokens import-from-monitor --prune          # drop accounts the monitor no longer reports
-```
-
-**`--force` is what applies a token roll.** Every rolled token legitimately differs from what is on disk, so without `--force` each one is reported as drift and left alone — deliberately, so a hand-pinned token is never silently clobbered. The command exits `2` when drift was found and not applied, so a script can detect "pool is still stale". After importing, refresh the ranking so the daemon sees the recovered capacity:
-
-```bash
-loom-tokens import-from-monitor --force && loom-tokens check --ranking
-```
-
-Behavior notes:
-
-- **Read-only** on `usage.db` (opened `mode=ro`) — the store belongs to claude-monitor; Loom never writes or migrates it.
-- Only `is_active = 1` rows are imported; `expires_at` is **not** used as a filter (observed rows carry stale timestamps while still authenticating — health comes from `loom-tokens check`).
-- Token filenames use the same derivation as `bootstrap` (`robb@2amlogic.com` → `robb-2amlogic.token`), so an account keeps one identity across both paths and re-importing overwrites in place.
-- Idempotent: unchanged tokens are left untouched. `index.json` records `source: monitor-db` (distinct from the `monitor` snapshot) and, as always, fingerprints only — never secret material.
-- `--prune` removes only `*.token` files; pool state (`.ranking`, `.bad_tokens`, `.failure_counts`, `.allowlist`) is never touched.
-- The importer takes **claude-monitor as authoritative for pool membership**, so it imports every active account — including any that `accounts.env` omitted. Use `loom-tokens pin` to restrict which accounts the selector may actually pick.
-- Absent claude-monitor, an absent `usage.db`, or an older schema without `oauth_credentials` all exit `1` with a message naming the path tried.
-
-#### Account health probe + ranking
-
-Once bootstrapped, `loom-tokens check` probes each account for current rate-limit headers and (optionally) writes a JSON ranking that the spawn-time selector can consume:
-
-```bash
-loom-tokens check                  # Probe + print human table
-loom-tokens check --ranking        # Probe + write .loom/tokens/.ranking atomically
-loom-tokens check --json           # Emit full JSON report to stdout
-./.loom/scripts/probe-tokens.sh    # Cron-friendly wrapper for periodic invocation
-```
-
-The probe sends a minimal `POST /v1/messages` request (1 input, 1 output token) and parses rate-limit response headers. The header parser matches by **suffix** (`-5h-utilization`, `-7d-utilization`, `-7d-reset`) so future renames of the `anthropic-ratelimit-tokens-*` prefix still work; the full header set is logged on the first probe of each run.
-
-Status assignment: `available` (utilizations < 95%), `exhausted` (`7d_utilization >= 0.95`), `rate_limited` (current 429), `blocked` (401 auth failure or token listed in `.bad_tokens`). Probe failures (network, timeout, 5xx) are logged and skipped — one bad account does not abort the run.
-
-OAuth tokens shaped `sk-ant-oat01-*` are sent with `Authorization: Bearer` + `anthropic-beta: oauth-2025-04-20`; plain API keys use `x-api-key`.
-
-**The running `loom-daemon` self-refreshes `.ranking` (#3969)** — it runs the equivalent of `probe-tokens.sh --ranking` on its own periodic loop (default every 10 minutes, `autonomous.tokenRankingRefresh` / `LOOM_TOKEN_RANKING_REFRESH*`, on by default since it is read-only probing with no dispatch side effect), so a standing cron for this is no longer required when the daemon is running. See [Token-ranking self-refresh](.loom/docs/daemon-reference.md#token-ranking-self-refresh-3969) for the config knobs.
-
-A cron entry is now only needed as a **fallback for setups that don't run `loom-daemon`** (e.g. pure `/loom:sweep` subagent dispatch with no daemon process). Cron example (probe every 10 minutes):
-
-```cron
-*/10 * * * * cd /path/to/repo && ./.loom/scripts/probe-tokens.sh --ranking >> .loom/logs/probe-tokens.log 2>&1
-```
-
-See `.loom/docs/troubleshooting.md` for detailed troubleshooting including:
-- Cleaning up stale worktrees and branches
-- Stuck agent detection and intervention
-- Daemon troubleshooting (registry, event bus, reaper)
-- Common issues and solutions
-
-**Quick fixes**:
-
-```bash
-loom-clean --force                       # Clean stale worktrees/branches
-loom-recover-orphans --recover           # Recover orphaned loom:building issues
-gh label sync --file .github/labels.yml  # Re-sync labels (GitHub only)
-# Cancel a running sweep: mcp__loom__cancel_sweep --sweep_id <id>
-```
-
-## Custom Guard Hooks
-
-Loom ships Bash `PreToolUse` guard hooks (`defaults/hooks/guard-destructive.sh`) that block or ask on destructive commands. Several category toggles let a repo opt out of checks that are a category error for it — see `defaults/CLAUDE.md` → "Custom Guard Hooks" for the full catalog (`guards.sqlDdl`, `guards.cloudCli`, `guards.rmScope`, `guards.forceScope`). The read-only fast-path toggle is documented below.
-
-### Read-Only Fast-Path Guard Toggle (`guards.readOnlyFastPath` / `LOOM_GUARD_READONLY_FASTPATH`)
-
-`guard-destructive.sh` fires before **every** Bash tool call. In Bash-dense sessions almost every call is obviously read-only (`git status`, `ls`, `grep`, `aws … describe*`, `gh … list`), yet each otherwise runs the full deny/ask gauntlet (~37 `grep`/`awk`/`sed` forks plus a `git rev-parse`, ~179ms) before allowing. The read-only fast path (issue #3687) short-circuits that case to a **silent** `allow` (exit 0, zero output, no logging) via one bash-builtin structural test (zero forks) plus one lazy `jq` config read, running before the repo-root `git rev-parse` and every deny/ask array.
-
-The fast path is **on by default**, resolved highest-precedence first:
-
-1. **`LOOM_GUARD_READONLY_FASTPATH` env var** — `0`/`false`/`no` disables (full-path checking restored byte-for-byte); `1`/`true`/`yes` forces on. Overrides config.
-2. **`.loom/config.json` → `guards.readOnlyFastPath`** — default `true` when absent; set `false` to disable.
-3. **Default** — `true`.
-
-**Security**: the fast path is a guard bypass by construction, so admission is purely structural. A command is fast-pathed only when it contains **none** of `;` `&` `|` `<` `>` backtick `$(` newline (excludes chaining/piping/redirection/substitution) **and** its first token exactly matches the built-in allowlist: `git status|log|diff|show` (bare, no `git -C …`), `ls`, `grep`, `rg`, `jq`, `wc`, `head`, `tail`, `test`, `[`, `[[` (any args), `find` (any args **except** a dangerous action-primary — `-delete`/`-exec`/`-execdir`/`-ok`/`-okdir`/`-fls`/`-fprint`/`-fprint0`/`-fprintf` — which routes it to the full path, #3772), `gh <noun> view|list`, `aws <service> describe*|get*|list*`, `aws s3 ls`. Wrappers (`bash -c`, `eval`, `sudo …`, `env …`) are excluded automatically because their first token isn't allowlisted. So `git status && git push --force origin main` takes the full path and is still denied.
-
-**`cat` and `ssh` are deliberately excluded**: `cat` has an existing `.ssh`/`.aws/credentials` ASK carve-out a blanket fast-path would skip, and `ssh` wraps an opaque remote payload the catastrophic scan still covers.
-
-**Optional** `guards.readOnlyFastPathExtra` is an extend-only array of **literal first-word commands** added to the allowlist without hand-editing the installer-managed `.claude/settings.json`:
-
-```json
-{ "guards": { "readOnlyFastPath": true, "readOnlyFastPathExtra": ["psql"] } }
-```
-
-> **Note**: `jq`/`wc` (and `head`/`tail`/`test`/`find`) are part of the built-in default allowlist as of #3772 — `readOnlyFastPathExtra` is now only for a genuinely-custom bare read-only word.
-
-> **Warning**: each entry is a full-generality bypass for that command word (all arguments) — only add bare, argument-independent read-only utilities, never scripts or anything that could wrap a mutating call.
-
-Disabling the fast path never weakens any deny/ask rule; a missing/malformed `.loom/config.json` falls through to fast-path-ON.
-
-## MCP Hooks
-
-Loom provides a unified MCP server (`mcp-loom`) for programmatic control. See the mcp-loom package README for full tool documentation.
-
-**Key tools**: `list_terminals`, `create_terminal`, `send_terminal_input`, `get_agent_metrics`, `trigger_start`, `stop_engine`
-
-**Setup**:
-```bash
-./scripts/setup-mcp.sh  # Generates .mcp.json
-```
-
-**Agent metrics** for self-aware behavior:
-```bash
-./.loom/scripts/agent-metrics.sh --role builder  # Check your effectiveness
-mcp__loom__get_agent_metrics --command summary --period week
-```
-
-## Token Rotation (Multi-Account Claude Code)
-
-For Pro/Max plans, Loom supports rotating between multiple Claude Code OAuth tokens. This spreads load across accounts and recovers automatically when a single token hits its weekly limit.
-
-### Setup
-
-1. Declare account credentials in a default source — the shared claude-monitor master `~/.claude-monitor/accounts.env` (primary) or per-repo in `<repo>/.loom/accounts.env` (falls back to legacy `<repo>/.env`). The `~/.loom/accounts.env` home master is **opt-in only** since #3704 (no longer auto-read); point `LOOM_ACCOUNTS_ENV=~/.loom/accounts.env` (or `--home-env <path>`) at it to enable:
-   ```env
-   ACCOUNT_EMAIL_1=account-one@example.com
-   ACCOUNT_KEY_1=sk-ant-oat01-...
-   ACCOUNT_TOKEN_FILE_1=account-one.token
-   ACCOUNT_EMAIL_2=account-two@example.com
-   ACCOUNT_KEY_2=sk-ant-oat01-...
-   ACCOUNT_TOKEN_FILE_2=account-two.token
-   ```
-   The claude-monitor, repo-local, and (opt-in) home sources are **merged by email**, with the higher-precedence source overriding/adding (see "Account sources: claude-monitor-first + per-repo" above). Keep any home-level master `0600` and outside any repo.
-2. Run `loom-tokens bootstrap` to materialize the merged set into per-account `.token` files in `.loom/tokens/` (mode 0600, parent dir 0700). See issues #3234, #3695.
-
-   **If claude-monitor runs on this host, prefer `loom-tokens import-from-monitor`** — it reads claude-monitor's live credential store instead of the `accounts.env` snapshot, so a new host needs no account file of its own and a token roll is picked up automatically (add `--force` to apply rolled tokens). See "Importing live tokens from claude-monitor" above.
-3. Spawn agents through `.loom/scripts/spawn-claude.sh` instead of invoking `claude` directly. The wrapper selects a token using a 3-tier algorithm (ranking → allowlist → random), exports `CLAUDE_CODE_OAUTH_TOKEN`, then `exec`s `claude` (or pass `--use-wrapper` to layer on top of `claude-wrapper.sh` for retry behavior).
-
-### Selection algorithm (`loom_tools.tokens.select`)
-
-Three tiers, falling through to the next when the current tier yields nothing:
-
-1. **Ranking** — `.loom/tokens/.ranking` (pipe-delimited `name|status`, refreshed every <10 min). Picks the first non-`exhausted`/non-`blocked` token.
-2. **Allowlist** — `.loom/tokens/.allowlist` (one name per line). Random pick from allowed accounts.
-3. **Random** — uniform pick from all `*.token` files.
-
-Tokens marked bad in `.loom/tokens/.bad_tokens` are skipped at every tier.
-
-### Bad-token tracking (`loom_tools.tokens.bad_tokens`)
-
-When a token returns `TOKEN_EXPIRED` or `TOKEN_EXHAUSTED`, callers append an entry to `.loom/tokens/.bad_tokens`. Writes are guarded with a `mkdir`-based lock (POSIX-atomic, macOS-compatible — `flock` is **not** used because it isn't available on stock macOS). Reads use word-boundary regex so `agent-1` and `agent-10` don't collide.
-
-### Error classification (`.loom/scripts/lib/classify-error.sh`)
-
-The `classify_error <output> <exit_code>` function returns one of `SUCCESS`, `TIMEOUT`, `CWD_DELETED`, `TOKEN_EXPIRED`, `TOKEN_EXHAUSTED`, `RECOVERABLE`. Critical fix from #3233: exit code is checked **before** output substring matching — clean exits (`exit_code == 0`) always return `SUCCESS` regardless of stdout content. The previous lean-genius implementation returned `RECOVERABLE` for clean exits whose stdout contained substrings like `500` or `rate limit`.
-
-### Worktree handling
-
-When invoked from a worktree, `spawn-claude.sh` resolves the canonical repo root via `git rev-parse --git-common-dir` and locates `.loom/tokens/` there — never in the worktree's path. This avoids each worktree maintaining its own bad-tokens list.
-
-### Shared machine-level pool fallback (#3938)
-
-Token selection resolves the effective pool as: the **per-repo** pool `<repo>/.loom/tokens/` when it holds `*.token` files, else the **shared machine-level pool** `~/.loom/tokens/` (override `LOOM_SHARED_TOKENS_DIR`; set it empty to disable the fallback). This lets a consumer repo the daemon dispatches into — which has no pool of its own — spawn against the shared pool instead of hard-failing with `EX_CONFIG`. Crucially, the pool **state** files (`.bad_tokens`, `.failure_counts`, `.ranking`, `.allowlist`) are read/written in whichever pool was selected, so state is **never forked per repo** (token-capacity backpressure sees one truth). Provision the shared pool once per machine with `loom-tokens bootstrap --shared` (destination-only; account sources are unchanged). See `.loom/docs/daemon-reference.md` → "Token pool provisioning for managed repos".
-
-**Package-path fallback for consumer-repo dispatches (#3949)**: `#3938` fixed the pool *location*, but token *selection* still shells into `python3 -m loom_tools.tokens.select`, and `spawn-claude.sh` locates that Python package via (1) `LOOM_PACKAGE_PATH` env, (2) script-relative `../../loom-tools/src`, (3) `$WORKSPACE/loom-tools/src` — tiers (2)/(3) only resolve inside an actual loom checkout, so a consumer-repo dispatch used to hard-fail with `ModuleNotFoundError: No module named 'loom_tools'` unless an operator manually exported `LOOM_PACKAGE_PATH` before starting the daemon. `loom-daemon`'s `spawn_child` now resolves and forwards `LOOM_PACKAGE_PATH` automatically on every dispatch: an ambient override on the daemon's own environment always wins, otherwise it derives `<loom-checkout>/loom-tools/src` from the source tree the running `loom-daemon` binary was compiled from (`CARGO_MANIFEST_DIR`, baked in at build time) when that directory still exists and contains `loom_tools/tokens`. A consumer repo with no loom checkout and no `LOOM_PACKAGE_PATH` env now selects a token successfully with zero manual configuration.
-
-### Hard-fail on missing pool
-
-`spawn-claude.sh` exits `78` (`EX_CONFIG`) with a message instructing the user to run `loom-tokens bootstrap` (or `loom-tokens bootstrap --shared` for the machine-level pool) when **neither** the per-repo nor the shared pool has usable tokens (absent, empty, or all bad). It does **not** silently fall back to keychain — that path belongs in `loom-daemon` (#3236), and only when token rotation has not been configured at all.
-
-### Operator CLI (`loom-tokens pin/unpin/unblock`)
-
-Operators can restrict the rotation pool to a subset of accounts (an "allowlist") and manually un-blacklist accounts marked bad. Auto-recovery prevents pin-induced lockouts.
-
-```bash
-loom-tokens pin agent-3 agent-7   # Set allowlist to exactly these
-loom-tokens pin add agent-2       # Append (idempotent)
-loom-tokens pin remove agent-3    # Remove
-loom-tokens pin status            # Show current allowlist
-loom-tokens unpin                 # Delete allowlist (back to full pool)
-
-loom-tokens unblock agent-1       # Remove one entry from .bad_tokens
-loom-tokens unblock --all         # Clear .bad_tokens entirely
-```
-
-**Validation**: `pin` accepts only exact bootstrapped account names — substring/fuzzy matches are rejected. The allowlist is sorted, deduplicated, and `mkdir`-lock guarded so concurrent operator commands don't drop entries.
-
-**Reason-aware bad-token TTL**: bad-tokens entries with reason `auth` (401) ignore `LOOM_TOKENS_BAD_TTL` (default 21600s = 6h) and persist until `loom-tokens unblock`. Other reasons expire automatically.
-
-**Auto-unpin** (`failure_counts`): the wrapper tracks consecutive `TOKEN_EXHAUSTED` failures per account in `.loom/tokens/.failure_counts` (JSON). When **every** account in the allowlist hits the threshold (default 5), the wrapper auto-clears `.allowlist` and `.failure_counts` with a loud stderr log line. Operators can re-pin afterwards. The threshold is `>= 5`, so a 6th failure does not silently exceed; it still triggers (idempotent at-or-above).
-
-Counters are reset on:
-- a successful spawn for that account, or
-- any operator allowlist mutation (`pin`, `unpin`, `add`, `remove`).
-
-**Empty-pool guard**: if the selector finds the allowlist minus `.bad_tokens` is empty, `spawn-claude.sh` exits `78` (`EX_CONFIG`) with operator instructions. It refuses to silently auto-clear `.bad_tokens` — that masks real auth problems (lean-genius failure mode 3).
-
-### Tests
-
-```bash
-PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/tokens/ -v
-bash .loom/scripts/tests/test-spawn-claude.sh
-```
-
-## Forge Authentication
-
-### GitHub
-
-Loom uses the `gh` CLI for all GitHub operations. By default it uses the credential from `gh auth login`, which has access to all repositories. To scope access to a single repository, create a fine-grained PAT and set `export GH_TOKEN=github_pat_xxx` before running Loom.
-
-See `.loom/docs/github-authentication.md` for the detailed setup guide, required token permissions per role, and troubleshooting.
-
-### Gitea
-
-For Gitea repositories, Loom uses the Gitea API with token authentication. Set `GITEA_TOKEN` or `FORGE_TOKEN` environment variable with an API token created at `<your-gitea-instance>/user/settings/applications`. The token needs repository read/write permissions (issues, pull requests, labels).
-
-See `.loom/docs/forge-authentication.md` for the complete authentication guide covering both GitHub and Gitea.
-
-## Releasing
-
-Use `scripts/version.sh` to manage versions across all packages:
-
-```bash
-./scripts/version.sh              # Show current version
-./scripts/version.sh check        # Verify all files are in sync
-./scripts/version.sh bump patch   # Bump patch (minor, major also supported)
-./scripts/version.sh bump patch --tag  # Bump + commit + tag
-./scripts/version.sh set 1.0.0 --tag   # Set explicit version + commit + tag
-```
-
-**Full release flow** — releases are driven by `/repo:release` from
-[rjwalters/repo](https://github.com/rjwalters/repo) (install repo for the
-command). `/repo:release` detects and honors `scripts/version.sh` as its
-first-priority version tool, so the underlying mechanics are unchanged:
-```bash
-./scripts/version.sh bump patch --tag
-git push origin main --tags
-gh release create vX.Y.Z --title "vX.Y.Z" --notes "Release notes..."
-```
-
-The script updates all 5 version-bearing files (`package.json`, `mcp-loom/package.json`, 2 `Cargo.toml` files (`loom-daemon`, `loom-api`), `CLAUDE.md`) plus `Cargo.lock`. The GitHub Actions release workflow (`.github/workflows/release.yml`) triggers on GitHub Release creation (`release: types: [created]`), NOT on tag push. You must create a GitHub Release via `gh release create` to trigger the build.
-
-## Migration: v0.10.0 shepherd/daemon deprecation
-
-The orchestration-architecture migration (epic #3372) deleted the shepherd brain (`loom-tools/src/loom_tools/shepherd/`), the Python daemon brain (`loom-tools/src/loom_tools/daemon_v2/`), and the `/shepherd` slash command. The replacement is a two-surface architecture: `/loom:sweep` for in-session subagent dispatch (Tier 1) and the Rust `loom-daemon` binary for multi-account MCP-level dispatch (Tier 2). Epic #3449 rebuilt the daemon surface in phases A–D, all shipped on main. The completed phases:
-
-| Phase | Issue | What shipped | Status |
-|-------|-------|-----------|--------|
-| Phase 1 | #3374 | Minimal multi-account spawn loop (legacy — deprecated in Phase E of #3449) | shipped (deprecated in Phase E, removed in v0.11.0) |
-| Phase 2a | #3375 | GitHub Actions workflows for support roles | shipped (disabled by default) |
-| Phase 2b | #3376 | Soft-deprecation warnings on deprecated entry points | shipped |
-| Phase 3 | #3378 | Deletion of shepherd brain, Python daemon brain, `/shepherd` skill | shipped |
-| Phase 4 | #3382 | Coordinated downstream sphere-install migration | shipped |
-| #3449 Phase A | #3452 | `loom-daemon`: `dispatch_sweep`, `list_sweeps`, sweep registry, reaper task | shipped |
-| #3449 Phase B | #3453 | `loom-daemon`: event bus (tokio broadcast), 6 frozen topics, `publish_event`, `subscribe_to_events` IPC | shipped |
-| #3449 Phase C | #3455 | MCP tools: `get_sweep_status`, `tail_sweep_log`, `subscribe_to_events`, `publish_event`, `cancel_sweep`, `tail_event_bus`; daemon-reference.md rewrite | shipped |
-| #3449 Phase D | #3454 | `/loom:sweep` Stage -1 backend detection (strict-AND daemon + pool probe) | shipped |
-| #3449 Phase E | #3456 | `spawn-loop.sh` deprecation warning + doc-fiction rewrite | shipped |
-
-**v1.0.0 is intentionally unscheduled.** Loom remains pre-1.0 while the architecture settles.
-
-**Removed entry points** (no longer present in v0.10.0+):
-
-| Removed | Replacement |
-|---------|-------------|
-| `loom-daemon` Python CLI | Rust `loom-daemon` binary + `mcp__loom__dispatch_sweep` (+ GitHub Actions for support roles) |
-| `loom-shepherd` CLI / `/shepherd` slash command | `/loom:sweep <issue>` for the same per-issue lifecycle |
-| `defaults/scripts/spawn-loop.sh` (removed in v0.11.0) | `mcp__loom__dispatch_sweep` against `loom-daemon` |
-
-Full migration narrative and per-CLI replacement table: [`docs/migration/v0.10.0-shepherd-deprecation.md`](docs/migration/v0.10.0-shepherd-deprecation.md).
-
-See also: [ADR-0009](docs/adr/0009-shepherd-deprecation.md) — records the architectural decision to delete the shepherd and daemon Python brains.
+Configuration lives in `.loom/config.json` (committed for team sharing): a
+`terminals` array (per-agent role/model), plus the optional blocks below.
+
+- **Daemon configuration (Tier 2)** — the `autonomous` block, start/stop wrappers,
+  self-update, epic supervisor: [`.loom/docs/daemon-reference.md`](.loom/docs/daemon-reference.md)
+  §Operability (precedence **env > config > default**; daemon defaults FLAGS-OFF).
+- **Post-Builder quality gate (`buildGate`)** — [`.loom/docs/build-gate.md`](.loom/docs/build-gate.md).
+- **Custom roles** — add `.loom/roles/<name>.md` (and optional `<name>.json`).
+- **Branch rulesets & repository settings** — set at install time or via
+  `./scripts/install/setup-branch-protection.sh` / `setup-repository-settings.sh`.
+- **Guard hooks** — Bash `PreToolUse` guards block/ask on destructive commands;
+  category toggles (`guards.sqlDdl`, `cloudCli`, `reversibleGh`, `rmScope`,
+  `forceScope`, `readOnlyFastPath`, `decisionLog`, each with an `LOOM_*` env
+  override) let a repo opt out. Catalog: [`defaults/CLAUDE.md` → "Custom Guard Hooks"](defaults/CLAUDE.md).
+- **MCP hooks** — the unified `mcp-loom` server; run `./scripts/setup-mcp.sh` to
+  generate `.mcp.json`. See the mcp-loom README.
+
+### Multi-Account Token Pool (operating summary)
+
+For Pro/Max plans, Loom rotates among multiple Claude OAuth accounts so one weekly
+limit does not stall the pipeline. Provision `.loom/tokens/` with `loom-tokens
+bootstrap` (or `import-from-monitor --force` on a claude-monitor host) +
+`loom-tokens check --ranking`. Agents spawn through `.loom/scripts/spawn-claude.sh`
+(never `claude` directly), which selects a token (ranking → allowlist → random); a
+missing/exhausted pool exits `78` (`EX_CONFIG`). Full reference:
+[`.loom/docs/token-pool.md`](.loom/docs/token-pool.md).
+
+## Forge Authentication & Releasing
+
+- **GitHub** — Loom uses the `gh` CLI (the `gh auth login` credential; scope to
+  one repo with `export GH_TOKEN=…`). See [`.loom/docs/github-authentication.md`](.loom/docs/github-authentication.md).
+- **Gitea** — set `GITEA_TOKEN` or `FORGE_TOKEN` (repository read/write). See
+  [`.loom/docs/forge-authentication.md`](.loom/docs/forge-authentication.md).
+- **Releasing** — `scripts/version.sh` keeps all 5 version-bearing files in sync
+  (including this `CLAUDE.md`'s `**Loom Version**` line); releases are driven by
+  `/repo:release` from [rjwalters/repo](https://github.com/rjwalters/repo). The
+  release workflow triggers on GitHub Release creation, not tag push.
+
+## Troubleshooting
+
+See [`.loom/docs/troubleshooting.md`](.loom/docs/troubleshooting.md) for stale
+worktrees, stuck agents, daemon registry/event-bus/reaper issues, host-sleep and
+`.loom/` resync procedures, and common fixes. Quick fixes: `loom-clean --force`
+(stale worktrees/branches), `loom-recover-orphans --recover` (orphaned
+`loom:building` issues), `gh label sync --file .github/labels.yml` (re-sync
+labels), `mcp__loom__cancel_sweep --sweep_id <id>` (cancel a running sweep).
+
+## Migration History
+
+The v0.10.0 shepherd/daemon deprecation (epic #3372) deleted the Python shepherd
+and daemon brains and `/shepherd`; epic #3449 rebuilt the daemon surface as the
+Rust `loom-daemon` binary; v0.11.0 removed `spawn-loop.sh` (use
+`mcp__loom__dispatch_sweep`). Complete history — phase table, removed-entry-point
+map, downstream-consumer guidance —
+[`docs/migration/v0.10.0-shepherd-deprecation.md`](docs/migration/v0.10.0-shepherd-deprecation.md),
+[ADR-0009](docs/adr/0009-shepherd-deprecation.md).
 
 ## Resources
 
-- **Main Repository**: https://github.com/rjwalters/loom
-- **Role Definitions**: `.loom/roles/*.md`
-- **Label Definitions**: `.github/labels.yml`
-- **Troubleshooting**: `.loom/docs/troubleshooting.md`
-- **Daemon Reference**: `.loom/docs/daemon-reference.md`
-- **GitHub Authentication**: `.loom/docs/github-authentication.md`
-- **Forge Authentication** (GitHub + Gitea): `.loom/docs/forge-authentication.md`
-- **Scripts**: `.loom/scripts/`
+- **Repository**: https://github.com/rjwalters/loom · **Roles**: `.loom/roles/*.md`
+  · **Labels**: `.github/labels.yml` · **Scripts**: `.loom/scripts/`
+- **Docs**: [daemon-reference](.loom/docs/daemon-reference.md) ·
+  [token-pool](.loom/docs/token-pool.md) ·
+  [troubleshooting](.loom/docs/troubleshooting.md) ·
+  [build-gate](.loom/docs/build-gate.md) ·
+  [forge-auth](.loom/docs/forge-authentication.md) /
+  [github-auth](.loom/docs/github-authentication.md)
 
 ---
 

--- a/scripts/check-claude-md-budget.sh
+++ b/scripts/check-claude-md-budget.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# check-claude-md-budget.sh — fail if CLAUDE.md exceeds its line budget.
+#
+# Why (#4014): CLAUDE.md is prepended to the context of every session, every
+# worker role, and every sweep child — a fixed per-dispatch tax paid thousands of
+# times a day. It grows monotonically because every individual addition is
+# defensible while the aggregate is the problem, and nothing removes anything.
+# This check is the counter-pressure: a new subsystem's inline detail now forces
+# a corresponding removal (move it to `.loom/docs/` and leave a one-line pointer)
+# rather than silently ratcheting the file — and the whole context — larger.
+#
+# The rule this enforces: durable OPERATING instructions live in CLAUDE.md;
+# REFERENCE material lives in `.loom/docs/*` with a pointer; completed-migration
+# HISTORY lives in `docs/migration/` + ADRs. If you are over budget, relocate —
+# do not raise the budget to fit a reference dump.
+#
+# Usage:
+#   check-claude-md-budget.sh [BUDGET]
+#     BUDGET  Max allowed line count (default 320). Override for a one-off check.
+#
+# Exit codes: 0 = within budget; 1 = over budget (overage printed to stderr).
+
+set -euo pipefail
+
+BUDGET="${1:-${CLAUDE_MD_BUDGET:-320}}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)"; then
+  :
+else
+  ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+fi
+
+TARGET="$ROOT/CLAUDE.md"
+
+if [[ ! -f "$TARGET" ]]; then
+  echo "check-claude-md-budget: no CLAUDE.md under $ROOT — nothing to check (ok)."
+  exit 0
+fi
+
+lines="$(wc -l < "$TARGET" | tr -d '[:space:]')"
+
+if [[ "$lines" -gt "$BUDGET" ]]; then
+  over=$((lines - BUDGET))
+  {
+    echo "check-claude-md-budget: FAIL — CLAUDE.md is $lines lines, $over over the $BUDGET-line budget."
+    echo ""
+    echo "CLAUDE.md is prepended to every agent's context on every dispatch, so its"
+    echo "size is a fixed tax paid thousands of times a day. Keep only durable"
+    echo "OPERATING instructions here. To get back under budget:"
+    echo "  - Move REFERENCE detail (config tables, subsystem internals, tool"
+    echo "    catalogs) to .loom/docs/*.md and leave a one-line pointer."
+    echo "  - Retire completed-migration HISTORY to docs/migration/ + ADRs."
+    echo "Do NOT raise the budget to fit a reference dump."
+  } >&2
+  exit 1
+fi
+
+echo "check-claude-md-budget: OK — CLAUDE.md is $lines lines (budget $BUDGET)."
+exit 0


### PR DESCRIPTION
Closes #4014

## Problem

`CLAUDE.md` had grown to **767 lines / ~54KB / ~13.6k tokens**, prepended to the context of every session, every worker role, and every sweep child — a fixed per-dispatch tax that grew monotonically with no counter-pressure. It had drifted from *operating instructions* into a changelog/reference hybrid.

Per the Curator's corrected scope: this is **this repo's own** root `CLAUDE.md`. Both `defaults/CLAUDE.md` and `defaults/.loom/CLAUDE.md` are **out of scope** and untouched, so consumer-install coherence is not a risk this PR manages.

## What moved where

| Old CLAUDE.md content | New location |
|---|---|
| Multi-Account Token Pool + Token Rotation (two duplicated top-level sections, 207 lines / 27% of the file) | **new** [`.loom/docs/token-pool.md`](.loom/docs/token-pool.md) — merged; CLAUDE.md keeps a ~8-line operating summary |
| Host-sleep (#3350) + `.loom/` resync (#3770/#3777) procedures | [`.loom/docs/troubleshooting.md`](.loom/docs/troubleshooting.md) → "Overnight / long-running orchestration"; CLAUDE.md keeps a 3-line pointer |
| Daemon Configuration tables, autonomous block, start/stop wrappers, self-update, epic supervisor | compressed to a pointer at [`.loom/docs/daemon-reference.md`](.loom/docs/daemon-reference.md) (already more complete, 1985 lines) |
| Custom Guard Hooks full catalog | compressed to the toggle names + pointer at `defaults/CLAUDE.md` |
| MCP Hooks tool catalog | compressed to a 2-line pointer |
| Forge Auth + Releasing | compressed to pointers |
| `## Migration: v0.10.0 shepherd/daemon deprecation` phase table + removed-entry-point tables | retired to a 6-line "Migration History" pointer at `docs/migration/v0.10.0-shepherd-deprecation.md` + ADR-0009 |
| ASCII architecture box diagram | dropped (the tier table already says the same) |

## What was kept (load-bearing, non-negotiable)

The mandatory sweep-lifecycle table, the "always use `merge-pr.sh`, never the gh merge subcommand" rule, "never run `git worktree` directly", all three label-flow diagrams, the Agent Roles table, "Issues Are Suggestions", the Builder workflow, and the `**Loom Version**` line / `# Loom Orchestration` H1 / installer footer + repo-skills markers (the version-tool and installer signatures).

## Counter-pressure

- **new** `scripts/check-claude-md-budget.sh` (budget **320** — headroom over the final 313) wired as an always-run `claude-md-budget` job in `.github/workflows/ci.yml` (runs on every `pull_request`). Exits non-zero with a "move it to `.loom/docs/` and leave a pointer" message when over budget.
- An in-file rule at the top of CLAUDE.md: *new subsystem detail goes to `.loom/docs/` with a one-line pointer here, not inline.*

## Result

**767 → 313 lines (59% smaller)**, no load-bearing operating rule lost.

## Verification

- Line budget: `wc -l CLAUDE.md` = 313 (≤ 320, ≥ 200).
- Load-bearing greps all hit: `merge-pr.sh`, `Sweep Lifecycle (MANDATORY)`, `git worktree`, `loom:review-requested`, `Issues Are Suggestions`, `**Loom Version**:`.
- `./scripts/version.sh check` exits 0.
- Budget check both directions: passes on the new file; appending 300 filler lines makes it exit non-zero naming the budget.
- No dead links: every relative link in the rewritten CLAUDE.md (and token-pool.md) resolves.
- `shellcheck scripts/check-claude-md-budget.sh` clean.
- `pytest loom-tools/tests/test_installation_verification.py` → 27 passed (proves the `defaults/` boundary held).
- `cargo test -p loom-daemon scaffolding` passes (H1 + version-line signatures preserved).
- Diff touches no file under `defaults/`.