### PR TITLE
feat(daemon): migrate 3 structural config readers (terminals[], modelAliases, validate) onto config_resolver (#4059)

### DIFF
--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -82,28 +82,27 @@ pub fn rotate_log_file(log_path: &Path, max_size: u64, max_files: usize) -> anyh
     Ok(())
 }
 
-/// Extract configured terminal IDs from workspace config.json.
+/// Extract configured terminal IDs from workspace config.
 ///
-/// Reads the workspace's `.loom/config.json` and extracts the `id` field from
-/// each terminal entry. Returns None if config file doesn't exist or can't be parsed.
+/// Resolves the workspace's effective config through the tier chain
+/// (`config_resolver::resolve_effective_config`: private/shared defaults →
+/// legacy `.loom/config.json` → `.loom-project/project.json` →
+/// `.loom-local/local.json`) and extracts the `id` field from each terminal
+/// entry. Returns `None` when no tier supplies a non-empty `terminals` array —
+/// the empty-set-⇒-`None` contract is preserved (#4059).
+///
+/// **Diagnostic note (#4059, Finding 3):** the previous direct-read
+/// implementation emitted a function-local `log::warn!` for a malformed
+/// `.loom/config.json`. That warn is not lost: `config_resolver`'s
+/// `soft_read_json_object` still emits a `log::warn!` when a tier's JSON fails
+/// to parse. A malformed config therefore collapses to `{}` at the resolver
+/// layer (so it now reaches the "no terminals" branch here rather than a
+/// dedicated parse-error branch), but the operator still sees a warning — it
+/// just names the resolver tier rather than this call site. This diagnosability
+/// change is accepted deliberately; the observable `None` contract is unchanged
+/// and the existing invalid-JSON test guards the collapsed path.
 pub fn extract_configured_terminal_ids(workspace: &Path) -> Option<HashSet<String>> {
-    let config_path = workspace.join(".loom").join("config.json");
-
-    let config_str = match fs::read_to_string(&config_path) {
-        Ok(s) => s,
-        Err(e) => {
-            log::debug!("Could not read config at {}: {e}", config_path.display());
-            return None;
-        }
-    };
-
-    let config: serde_json::Value = match serde_json::from_str(&config_str) {
-        Ok(v) => v,
-        Err(e) => {
-            log::warn!("Could not parse config at {}: {e}", config_path.display());
-            return None;
-        }
-    };
+    let config = config_resolver::resolve_effective_config(workspace);
 
     let terminals = config.get("terminals")?.as_array()?;
 
@@ -113,11 +112,15 @@ pub fn extract_configured_terminal_ids(workspace: &Path) -> Option<HashSet<Strin
         .collect();
 
     if ids.is_empty() {
-        log::debug!("No terminal IDs found in config");
+        log::debug!("No terminal IDs found in resolved config for {}", workspace.display());
         return None;
     }
 
-    log::info!("Loaded {} configured terminal IDs from {}", ids.len(), config_path.display());
+    log::info!(
+        "Loaded {} configured terminal IDs from resolved config for {}",
+        ids.len(),
+        workspace.display()
+    );
 
     Some(ids)
 }
@@ -232,6 +235,49 @@ mod tests {
         fs::write(loom_dir.join("config.json"), r#"{"terminals": []}"#).unwrap();
 
         let result = extract_configured_terminal_ids(dir.path());
+        assert!(result.is_none());
+    }
+
+    /// #4059: terminals supplied ONLY by the `.loom-project/project.json`
+    /// tier (no legacy `.loom/config.json` at all) are discovered through the
+    /// resolver. The private/shared defaults tier is disabled for hermeticity.
+    #[test]
+    #[serial_test::serial]
+    fn test_extract_terminal_ids_from_project_tier_only() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let dir = tempdir().unwrap();
+        let project_dir = dir.path().join(".loom-project");
+        fs::create_dir_all(&project_dir).unwrap();
+        fs::write(
+            project_dir.join("project.json"),
+            r#"{"terminals": [{"id": "terminal-1"}, {"id": "terminal-2"}]}"#,
+        )
+        .unwrap();
+        // No .loom/config.json exists.
+        assert!(!dir.path().join(".loom").join("config.json").exists());
+
+        let result = extract_configured_terminal_ids(dir.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+
+        let ids = result.expect("terminals from project tier should be discovered");
+        assert_eq!(ids.len(), 2);
+        assert!(ids.contains("terminal-1"));
+        assert!(ids.contains("terminal-2"));
+    }
+
+    /// #4059: an empty `terminals` array in the project tier still yields
+    /// `None`, preserving the empty-set-⇒-`None` contract across tiers.
+    #[test]
+    #[serial_test::serial]
+    fn test_extract_terminal_ids_empty_terminals_project_tier() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let dir = tempdir().unwrap();
+        let project_dir = dir.path().join(".loom-project");
+        fs::create_dir_all(&project_dir).unwrap();
+        fs::write(project_dir.join("project.json"), r#"{"terminals": []}"#).unwrap();
+
+        let result = extract_configured_terminal_ids(dir.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
         assert!(result.is_none());
     }
 

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -2819,7 +2819,8 @@ fn handle_validate_command(
     strict: bool,
     verbose: bool,
 ) -> Result<()> {
-    use role_validation::{format_validation_result, validate_from_file, ValidationMode};
+    use loom_daemon::config_resolver;
+    use role_validation::{format_validation_result, validate_from_config, ValidationMode};
 
     let workspace_path = std::path::Path::new(workspace);
     let absolute_workspace = if workspace_path.is_absolute() {
@@ -2828,13 +2829,62 @@ fn handle_validate_command(
         std::env::current_dir()?.join(workspace_path)
     };
 
-    let config_path = absolute_workspace.join(".loom").join("config.json");
+    // #4059: resolve the effective config through the full tier chain rather
+    // than reading the legacy `.loom/config.json` directly. Under tiering,
+    // "the legacy file is absent" no longer implies "there is no config" — a
+    // repo may configure `terminals` entirely from `.loom-project/project.json`
+    // or `.loom-local/local.json`.
+    let config = config_resolver::resolve_effective_config(&absolute_workspace);
 
-    if !config_path.exists() {
+    // The tiers searched, in precedence order — named in every "not found" error
+    // (Finding 5: both text and json branches).
+    let mut searched_tiers: Vec<String> = Vec::new();
+    if let Some(defaults) = config_resolver::private_defaults_path() {
+        searched_tiers.push(defaults.display().to_string());
+    }
+    searched_tiers.push(
+        absolute_workspace
+            .join(config_resolver::LEGACY_CONFIG_REL)
+            .display()
+            .to_string(),
+    );
+    searched_tiers.push(
+        absolute_workspace
+            .join(config_resolver::PROJECT_CONFIG_REL)
+            .display()
+            .to_string(),
+    );
+    searched_tiers.push(
+        absolute_workspace
+            .join(config_resolver::LOCAL_CONFIG_REL)
+            .display()
+            .to_string(),
+    );
+
+    // Retargeted precondition (#4059) — stated verbatim for #4062 to mirror:
+    //   "A workspace is validatable iff resolve_effective_config(workspace)
+    //    yields a `terminals` array with at least one element; otherwise the
+    //    command exits 1, naming every tier it searched."
+    let has_terminals = config
+        .get("terminals")
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|arr| !arr.is_empty());
+
+    if !has_terminals {
         if format == "json" {
-            println!(r#"{{"error": "Config file not found: {}"}}"#, config_path.display());
+            let err = serde_json::json!({
+                "error": "No Loom config with a non-empty terminals array found in any tier",
+                "searched": searched_tiers,
+            });
+            println!("{}", serde_json::to_string(&err)?);
         } else {
-            eprintln!("Error: Config file not found: {}", config_path.display());
+            eprintln!(
+                "Error: No Loom config with a non-empty `terminals` array found in any tier."
+            );
+            eprintln!("\nSearched (lowest to highest precedence):");
+            for tier in &searched_tiers {
+                eprintln!("  - {tier}");
+            }
             eprintln!("\nMake sure you're in a Loom workspace or specify the path:");
             eprintln!("  loom-daemon validate /path/to/workspace");
         }
@@ -2847,14 +2897,14 @@ fn handle_validate_command(
         ValidationMode::Warn
     };
 
-    let result = validate_from_file(&config_path, mode).map_err(|e| anyhow!("{e}"))?;
+    let result = validate_from_config(&config, mode);
 
     if format == "json" {
         println!("{}", serde_json::to_string_pretty(&result)?);
     } else {
         if verbose {
             println!("\nValidating role configuration...");
-            println!("  Config: {}", config_path.display());
+            println!("  Workspace: {}", absolute_workspace.display());
             println!();
         }
 

--- a/loom-daemon/src/role_validation.rs
+++ b/loom-daemon/src/role_validation.rs
@@ -140,8 +140,21 @@ struct RoleConfig {
 /// Parses the config and extracts role names from terminal configurations.
 /// Role names are derived from roleFile values (e.g., "judge.md" -> "judge").
 pub fn extract_roles_from_config(config_json: &str) -> Result<Vec<String>, String> {
-    let config: LoomConfig =
+    let config: serde_json::Value =
         serde_json::from_str(config_json).map_err(|e| format!("Failed to parse config: {e}"))?;
+    extract_roles_from_value(&config)
+}
+
+/// Extract role names from an already-resolved config `Value` (#4059).
+///
+/// The `Value`-based sibling of [`extract_roles_from_config`]: the validate
+/// command now resolves the effective config through the tier chain
+/// (`config_resolver::resolve_effective_config`) and hands the resulting
+/// `serde_json::Value` here directly, rather than round-tripping through a file
+/// read + string parse.
+pub fn extract_roles_from_value(config: &serde_json::Value) -> Result<Vec<String>, String> {
+    let config: LoomConfig = serde_json::from_value(config.clone())
+        .map_err(|e| format!("Failed to parse config: {e}"))?;
 
     let mut roles = Vec::new();
 
@@ -185,18 +198,47 @@ pub fn validate_role_completeness(config_json: &str, mode: ValidationMode) -> Va
         };
     }
 
-    let configured_roles = match extract_roles_from_config(config_json) {
-        Ok(roles) => roles,
-        Err(e) => {
-            return ValidationResult {
-                valid: false,
-                configured_roles: Vec::new(),
-                warnings: Vec::new(),
-                errors: vec![e],
-            };
-        }
-    };
+    match extract_roles_from_config(config_json) {
+        Ok(roles) => check_role_dependencies(roles),
+        Err(e) => ValidationResult {
+            valid: false,
+            configured_roles: Vec::new(),
+            warnings: Vec::new(),
+            errors: vec![e],
+        },
+    }
+}
 
+/// Validate role completeness from an already-resolved config `Value` (#4059).
+///
+/// The `Value`-based entry point used by `handle_validate_command` after it
+/// resolves the effective config through the tier chain. Behaviorally identical
+/// to [`validate_role_completeness`]; it just skips the file-read + string-parse
+/// round-trip.
+#[must_use]
+pub fn validate_from_config(config: &serde_json::Value, mode: ValidationMode) -> ValidationResult {
+    if mode == ValidationMode::Ignore {
+        return ValidationResult {
+            valid: true,
+            configured_roles: Vec::new(),
+            warnings: Vec::new(),
+            errors: Vec::new(),
+        };
+    }
+
+    match extract_roles_from_value(config) {
+        Ok(roles) => check_role_dependencies(roles),
+        Err(e) => ValidationResult {
+            valid: false,
+            configured_roles: Vec::new(),
+            warnings: Vec::new(),
+            errors: vec![e],
+        },
+    }
+}
+
+/// Shared dependency-satisfaction check over an extracted role set.
+fn check_role_dependencies(configured_roles: Vec<String>) -> ValidationResult {
     let role_set: HashSet<&str> = configured_roles.iter().map(String::as_str).collect();
     let mut warnings = Vec::new();
 
@@ -221,7 +263,10 @@ pub fn validate_role_completeness(config_json: &str, mode: ValidationMode) -> Va
 
 /// Validate role completeness from a config file path
 ///
-/// Convenience function that reads the config file and validates it.
+/// Convenience function that reads the config file and validates it. Retained
+/// as a thin wrapper for backward compatibility (#4059); the production
+/// validate command now resolves through the config tier chain and calls
+/// [`validate_from_config`] instead.
 pub fn validate_from_file(
     config_path: &std::path::Path,
     mode: ValidationMode,
@@ -359,6 +404,62 @@ mod tests {
         assert!(result.valid);
         assert!(result.configured_roles.is_empty());
         assert!(result.warnings.is_empty());
+    }
+
+    /// #4059: `validate_from_config` accepts an already-resolved `Value` and is
+    /// behaviorally identical to the string-based path.
+    #[test]
+    fn test_validate_from_config_value() {
+        let config = serde_json::json!({
+            "terminals": [
+                {"roleConfig": {"roleFile": "judge.md"}},
+                {"roleConfig": {"roleFile": "champion.md"}},
+            ]
+        });
+        let result = validate_from_config(&config, ValidationMode::Warn);
+        assert!(result.valid);
+        // judge and champion both depend on doctor, which is absent.
+        assert!(!result.warnings.is_empty());
+    }
+
+    /// #4059 end-to-end (minus `process::exit`): a repo whose terminals come
+    /// ONLY from `.loom-project/project.json` resolves through the tier chain
+    /// and validates successfully. The private/shared defaults tier is disabled
+    /// for hermeticity.
+    #[test]
+    #[serial_test::serial]
+    fn test_validate_from_project_tier_only() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let dir = tempfile::tempdir().unwrap();
+        let project_dir = dir.path().join(".loom-project");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        std::fs::write(
+            project_dir.join("project.json"),
+            r#"{"terminals": [
+                {"roleConfig": {"roleFile": "judge.md"}},
+                {"roleConfig": {"roleFile": "doctor.md"}}
+            ]}"#,
+        )
+        .unwrap();
+        // No legacy .loom/config.json exists.
+        assert!(!dir.path().join(".loom").join("config.json").exists());
+
+        let config = crate::config_resolver::resolve_effective_config(dir.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+
+        // The precondition the validate command retargets to.
+        let has_terminals = config
+            .get("terminals")
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(|arr| !arr.is_empty());
+        assert!(
+            has_terminals,
+            "terminals from project tier must satisfy the validate precondition"
+        );
+
+        let result = validate_from_config(&config, ValidationMode::Warn);
+        assert!(result.valid);
+        assert_eq!(result.configured_roles, vec!["doctor", "judge"]);
     }
 
     #[test]

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -201,29 +201,42 @@ pub fn resolve_dispatch_model(repo_root: &Path, explicit: Option<&str>) -> (Stri
 /// Python default in `loom_tools/model_tiers.py::_DEFAULT_TIER_ALIASES`.
 const DEFAULT_TIER_ALIASES: &[(&str, &str)] = &[("opus", "claude-opus-5")];
 
-/// Read the `sweep.modelAliases` override map from `<repo_root>/.loom/config.json`,
-/// soft-failing to an empty map on any error (missing file, malformed JSON, absent
-/// key, non-object value). Blank keys/values are dropped. Mirrors the soft-fail
-/// contract of [`read_autonomous_model`] and `model_tiers._config_overrides`.
+/// Read the `sweep.modelAliases` override map for `repo_root`, resolved through
+/// the full config tier chain (`config_resolver::resolve_effective_config`:
+/// private/shared defaults → legacy `.loom/config.json` →
+/// `.loom-project/project.json` → `.loom-local/local.json`). Soft-fails to an
+/// empty map on any error (missing/malformed tiers, absent key, non-object
+/// value). Blank keys/values are dropped. Mirrors the soft-fail contract of
+/// [`read_autonomous_model`] and `model_tiers._config_overrides`.
+///
+/// **Cross-tier merge (#4059):** `deep_merge` merges objects rather than
+/// replacing them, so a `sweep.modelAliases` map split across tiers now *unions*
+/// its keys, with the higher-precedence tier winning on any shared key. This is
+/// deliberate and desirable — a `.loom-project`/`.loom-local` tier can repoint
+/// an individual alias while inheriting the rest from the legacy tier — and is
+/// asserted explicitly by `read_model_aliases_merges_across_tiers`.
+///
+/// **Cross-language divergence (#4059, Finding 2):** blank keys are dropped
+/// here (`key.is_empty()` guard below), but the Python mirror in
+/// `model_tiers._config_overrides` KEEPS blank keys — it only guards blank
+/// *values*. This is a PRE-EXISTING, known-and-harmless divergence: a blank key
+/// can never match a lookup and [`resolve_model_alias`] returns early on an
+/// empty input model. It is intentionally left as-is here (the Python side is
+/// owned by #4060); do NOT normalize Rust to Python's laxer behavior. Both sides
+/// drop blank values.
 #[must_use]
 pub fn read_model_aliases(repo_root: &Path) -> BTreeMap<String, String> {
     let mut out = BTreeMap::new();
-    let path = repo_root.join(".loom").join("config.json");
-    let Ok(contents) = std::fs::read_to_string(&path) else {
-        return out;
-    };
-    let Ok(config) = serde_json::from_str::<serde_json::Value>(&contents) else {
-        return out;
-    };
-    let Some(aliases) = config
-        .get("sweep")
-        .and_then(|s| s.get("modelAliases"))
+    let config = crate::config_resolver::resolve_effective_config(repo_root);
+    let Some(aliases) = crate::config_resolver::get_path(&config, "sweep.modelAliases")
         .and_then(serde_json::Value::as_object)
     else {
         return out;
     };
     for (key, val) in aliases {
         let key = key.trim().to_lowercase();
+        // #4059 Finding 2: blank keys dropped here; Python keeps them. Left as a
+        // known-and-harmless divergence — see the function doc comment above.
         if key.is_empty() {
             continue;
         }
@@ -4749,6 +4762,49 @@ exit 0
         let dir3 = tempdir().unwrap();
         write_config(dir3.path(), "{ not json");
         assert_eq!(resolve_model_alias(dir3.path(), "opus"), "claude-opus-5");
+
+        // #4059 Finding 1: the overlay direction is config-WINS / default-LOSES.
+        // A config that overrides an UNRELATED alias must NOT disturb `opus`,
+        // which still falls back to the shipped `DEFAULT_TIER_ALIASES` default.
+        let dir4 = tempdir().unwrap();
+        write_config(dir4.path(), r#"{"sweep": {"modelAliases": {"sonnet": "claude-sonnet-9"}}}"#);
+        assert_eq!(resolve_model_alias(dir4.path(), "opus"), "claude-opus-5"); // default wins (no override)
+        assert_eq!(resolve_model_alias(dir4.path(), "sonnet"), "claude-sonnet-9");
+        // config wins
+    }
+
+    /// #4059: `sweep.modelAliases` split across the legacy and project tiers is
+    /// MERGED by `config_resolver::deep_merge` (object-merge, not replace). Keys
+    /// union across tiers, and the higher-precedence tier wins on a shared key.
+    /// The private/shared defaults tier is disabled for hermeticity.
+    #[test]
+    #[serial_test::serial]
+    fn read_model_aliases_merges_across_tiers() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let dir = tempdir().unwrap();
+        // Legacy tier supplies `opus` and `sonnet`.
+        write_config(
+            dir.path(),
+            r#"{"sweep": {"modelAliases": {"opus": "legacy-opus", "sonnet": "legacy-sonnet"}}}"#,
+        );
+        // Project tier adds `fable` and overrides `sonnet`.
+        let project_dir = dir.path().join(".loom-project");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        std::fs::write(
+            project_dir.join("project.json"),
+            r#"{"sweep": {"modelAliases": {"sonnet": "project-sonnet", "fable": "project-fable"}}}"#,
+        )
+        .unwrap();
+
+        let aliases = read_model_aliases(dir.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+
+        // Union of keys across both tiers.
+        assert_eq!(aliases.get("opus").map(String::as_str), Some("legacy-opus")); // only in legacy
+        assert_eq!(aliases.get("fable").map(String::as_str), Some("project-fable")); // only in project
+                                                                                     // Higher-precedence (project) tier wins on the shared `sonnet` key.
+        assert_eq!(aliases.get("sonnet").map(String::as_str), Some("project-sonnet"));
+        assert_eq!(aliases.len(), 3);
     }
 
     /// Ladder monotonicity: no rung of the shipped escalation ladder resolves to


### PR DESCRIPTION
Migrates the three structural `.loom/config.json` readers that each needed a real decision (not the mechanical `get_path` swap of sibling #4058) onto `config_resolver::resolve_effective_config`, so `terminals[]`, `sweep.modelAliases`, and the validate precondition all participate in the `.loom-project` / `.loom-local` tier chain (#4039).

Part of epic #3835 / parent #4047. Depends on #4039 (merged as `789669e9`).

## The three sites

1. **`lib.rs` `extract_configured_terminal_ids`** — reads `terminals[]` through the resolver. Empty-set-⇒-`None` contract preserved and tested across tiers.
2. **`sweep_registry.rs` `read_model_aliases`** — reads `sweep.modelAliases` through the resolver, overlaid on `DEFAULT_TIER_ALIASES` (`opus → claude-opus-5`).
3. **`main.rs` `handle_validate_command` + `role_validation.rs`** — the hard-failing site; precondition retargeted, `validate_from_config(&Value, mode)` added.

## Decisions (called out per the issue)

### Finding 3 — malformed-config diagnostic (accepted)
The previous direct read in `extract_configured_terminal_ids` emitted a function-local `log::warn!` for malformed JSON. That warn is **not lost**: `config_resolver::soft_read_json_object` still emits a `log::warn!` on a parse failure. A malformed `.loom/config.json` now soft-fails to `{}` at the resolver and collapses into the "no terminals" branch here rather than a dedicated parse-error branch. **Decision: accept this.** The observable `None` contract is unchanged, the operator still sees a warning (it just names the resolver tier rather than the call site), and the existing invalid-JSON test (`lib.rs`) is retained — it now exercises the collapsed path and guards against silently dropping the case.

### Finding 2 — Rust/Python blank-key divergence (left as a code comment, NOT normalized)
`read_model_aliases` drops blank keys (`key.is_empty()` guard); the Python mirror in `model_tiers._config_overrides` **keeps** blank keys (it only guards blank *values*). Both drop blank values. This pre-existing, known-and-harmless divergence (a blank key can never match a lookup, and `resolve_model_alias` returns early on an empty input model) is **documented in a code comment on `read_model_aliases`, not silently normalized in either direction.** The Python side is owned by #4060.

### Cross-tier merge for `sweep.modelAliases` (intentional)
`deep_merge` merges objects, so `sweep.modelAliases` split across tiers now **unions** its keys with the higher-precedence tier winning per-key (rather than one file being the sole source). This is deliberate and desirable — a `.loom-project` / `.loom-local` tier can repoint an individual alias while inheriting the rest — and is asserted explicitly by the new `read_model_aliases_merges_across_tiers` test.

### Hard-fail precondition rule (stated verbatim for #4062 to mirror)
> **A workspace is validatable iff `resolve_effective_config(workspace)` yields a `terminals` array with at least one element; otherwise the command exits 1, naming every tier it searched.**

This replaces the old "the legacy `.loom/config.json` file exists" check. Under tiering, an absent legacy file no longer implies "no config" — a repo may configure `terminals` entirely from `.loom-project/project.json`.

### Finding 5 — both error branches name the tiers
Both the `text` and `json` branches of the missing-config error now list every tier searched (private/shared defaults → legacy → project → local), in precedence order.

### Finding 4 — signature change is cheap (as predicted)
`validate_from_file` has one production caller; it is retained as a thin backward-compat wrapper. Added `validate_from_config(&serde_json::Value, mode)` + `extract_roles_from_value(&Value)` alongside the existing string-based entry points, with a shared `check_role_dependencies` helper.

## Note on `validate --verbose` output
The verbose header line changed from `  Config: <path>/.loom/config.json` to `  Workspace: <path>` — there is no longer a single config file to name. The substantive output (configured roles, warnings, json result) is byte-identical before/after.

## Testing

- `cargo test` (loom-daemon): all pass (the one flake observed under parallelism — `terminal::claude_config::test_setup_creates_fallback_state_when_no_home_state` — is a pre-existing HOME-env test-ordering race, unrelated to this change; passes in isolation and on rerun).
- `cargo clippy --all-targets -- -D warnings`: clean.
- New tests: terminals-only-in-project-tier discovery; empty terminals array still `None` across tiers; `modelAliases` merge-across-tiers; config-wins overlay direction (Finding 1); `validate_from_config` Value path; project-tier-only validate.
- Manual (`--release`): `validate . --verbose` / `--format json` substantive output unchanged; `validate /tmp/empty-dir` exits 1 naming all four tiers in both text and json branches.
- Cross-language: `./.loom/scripts/resolve-model.sh opus` → `claude-opus-5`, matching Rust `resolve_model_alias`.

## Scope
Only the three structural sites are migrated here. The ten mechanical Rust readers (`work_finder`, `main_health_gate`, `role_runner`, `token_ranking_refresh`, `watch_registry`, `worktree_root`, `ipc`, and the other `sweep_registry` functions) remain sibling #4058's work — expect a possible textual rebase, not a logical conflict (Finding 6).

Closes #4059