### PR TITLE
fix(tokens): percent-encode monitor DB path so mode=ro survives '?'/'#'

### DIFF
--- a/loom-tools/src/loom_tools/tokens/cli.py
+++ b/loom-tools/src/loom_tools/tokens/cli.py
@@ -37,6 +37,7 @@ from loom_tools.tokens import failure_counts
 from loom_tools.tokens.bootstrap import bootstrap_tokens
 from loom_tools.tokens.monitor_db import (
     MonitorDbUnavailable,
+    MonitorImportResult,
     import_from_monitor,
     monitor_db_path,
 )
@@ -448,22 +449,22 @@ def _cmd_import_from_monitor(args: argparse.Namespace) -> int:
     return 0
 
 
-def _print_monitor_import(result: "object") -> None:
+def _print_monitor_import(result: MonitorImportResult) -> None:
     """Print the imported account set. Secrets are never shown."""
-    db_path = getattr(result, "db_path", None) or monitor_db_path()
-    effective = getattr(result, "effective", []) or []
-    pruned = getattr(result, "pruned", []) or []
+    db_path = result.db_path or monitor_db_path()
+    effective = result.effective
+    pruned = result.pruned
 
     print(f"claude-monitor store: {db_path}")
-    print(f"Destination pool: {getattr(result, 'tokens_dir', None)}")
+    print(f"Destination pool: {result.tokens_dir}")
 
     if not effective:
         print("Active accounts: (none)")
         return
 
-    written = set(getattr(result, "written", []) or [])
-    unchanged = set(getattr(result, "unchanged", []) or [])
-    drifted = set(getattr(result, "drifted", []) or [])
+    written = set(result.written)
+    unchanged = set(result.unchanged)
+    drifted = set(result.drifted)
 
     print(f"Active accounts ({len(effective)}):")
     for acct in effective:

--- a/loom-tools/src/loom_tools/tokens/monitor_db.py
+++ b/loom-tools/src/loom_tools/tokens/monitor_db.py
@@ -47,6 +47,7 @@ import logging
 import os
 import re
 import sqlite3
+import urllib.parse
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -108,6 +109,26 @@ def monitor_db_path(monitor_dir: Path | None = None) -> Path:
     return base / MONITOR_DB_NAME
 
 
+def _read_only_uri(path: Path) -> str:
+    """Build the ``mode=ro`` SQLite URI for *path*.
+
+    The path is percent-encoded before interpolation. Without this, a ``?`` or
+    ``#`` anywhere in the path terminates the URI early and the ``mode=ro``
+    query parameter is silently dropped — the connection then opens
+    **read-write** against claude-monitor's live database (#4029). ``%`` fares
+    even worse: the unencoded form fails to open a database that is present and
+    readable.
+
+    ``urllib.parse.quote`` (default ``safe='/'``) encodes ``?``, ``#``, ``%``,
+    and spaces while leaving the path separators intact. Unlike
+    :meth:`pathlib.Path.as_uri` it has no absolute-path precondition, so a
+    relative ``LOOM_CLAUDE_MONITOR_DIR`` still yields a usable URI (resolved
+    against the cwd, as the unencoded form was) rather than raising
+    ``ValueError``.
+    """
+    return f"file:{urllib.parse.quote(str(path))}?mode=ro"
+
+
 def _email_from_label(label: str) -> str | None:
     """Recover an email from a credential label, or None if it isn't one.
 
@@ -159,8 +180,9 @@ def read_monitor_credentials(
         )
 
     # Read-only URI: this database belongs to claude-monitor. We never write,
-    # migrate, or take a write lock on it.
-    uri = f"file:{path}?mode=ro"
+    # migrate, or take a write lock on it. The path is percent-encoded so a
+    # '?' or '#' in it cannot silently void the mode=ro guarantee (#4029).
+    uri = _read_only_uri(path)
     try:
         conn = sqlite3.connect(uri, uri=True, timeout=_SQLITE_TIMEOUT_SECONDS)
     except sqlite3.Error as exc:
@@ -179,10 +201,17 @@ def read_monitor_credentials(
             """
         ).fetchall()
     except sqlite3.Error as exc:
-        # A missing table (older claude-monitor) lands here as OperationalError.
+        # A missing oauth_credentials table (older claude-monitor) lands here as
+        # an OperationalError whose message names the missing table — only then
+        # is the "predates the credential store" hint correct. Any other
+        # sqlite3.Error (e.g. a hot WAL missing its -shm sidecar, a corrupt
+        # file) reaches the same branch, and attributing it to a missing table
+        # would send the reader down the wrong path.
+        hint = ""
+        if isinstance(exc, sqlite3.OperationalError) and "no such table" in str(exc):
+            hint = " This claude-monitor may predate the credential store."
         raise MonitorDbUnavailable(
-            f"Could not read oauth_credentials from {path}: {exc}. "
-            "This claude-monitor may predate the credential store."
+            f"Could not read oauth_credentials from {path}: {exc}.{hint}"
         ) from exc
     finally:
         conn.close()

--- a/loom-tools/tests/tokens/test_monitor_db.py
+++ b/loom-tools/tests/tokens/test_monitor_db.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 import pytest
 
+from loom_tools.tokens import monitor_db as monitor_db_mod
 from loom_tools.tokens.cli import main
 from loom_tools.tokens.monitor_db import (
     MonitorDbUnavailable,
@@ -211,6 +212,133 @@ def test_database_is_not_modified(monitor_db: Path) -> None:
 def test_monitor_db_path_honors_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LOOM_CLAUDE_MONITOR_DIR", "/custom/monitor")
     assert monitor_db_path() == Path("/custom/monitor/usage.db")
+
+
+# --------------------------------------------------------------------------
+# Read-only URI construction — #4029
+#
+# A '?' or '#' in the path terminates the URI early and silently drops the
+# mode=ro query parameter, so the connection opens read-WRITE against another
+# tool's live database. The regression is that the pre-fix tests only asserted
+# the open succeeded (which it did, dangerously), not that the handle is
+# genuinely read-only.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dirname", ["q?dir", "h#ash", "pct%20", "sp ace"])
+def test_special_char_path_opens_and_is_read_only(
+    tmp_path: Path, dirname: str
+) -> None:
+    """A path with URI-special characters must still open read-only.
+
+    Asserts both halves the old tests missed: the store opens (so mode=ro is not
+    lost in the ``%`` direction, which fails the open outright), AND a write
+    attempt raises — i.e. mode=ro survived rather than being silently dropped.
+    """
+    db = make_monitor_db(
+        tmp_path / dirname / "usage.db",
+        [{"label": "x@example.com", "email": "x@example.com", "token": "tok"}],
+    )
+
+    # (a) opens via the module and returns the credential
+    creds = read_monitor_credentials(db)
+    assert [c.email for c in creds] == ["x@example.com"]
+
+    # (b) the connection the module builds is genuinely read-only: a write
+    # attempt must raise, proving mode=ro was not silently dropped.
+    conn = sqlite3.connect(monitor_db_mod._read_only_uri(db), uri=True)
+    try:
+        with pytest.raises(sqlite3.OperationalError):
+            conn.execute("CREATE TABLE z (y)")
+    finally:
+        conn.close()
+
+
+def test_relative_monitor_dir_does_not_raise_value_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A relative LOOM_CLAUDE_MONITOR_DIR must not escape as a bare ValueError.
+
+    ``monitor_db_path()`` does not absolutize (``claude_monitor_dir()`` only
+    ``expanduser()``s), so a relative override reaches URI construction. The fix
+    must surface as success or ``MonitorDbUnavailable`` — never ``ValueError``
+    (which ``Path.as_uri()`` would raise on a relative path).
+    """
+    monkeypatch.chdir(tmp_path)
+    make_monitor_db(
+        tmp_path / "rel" / "usage.db",
+        [{"label": "x@example.com", "email": "x@example.com", "token": "tok"}],
+    )
+    monkeypatch.setenv("LOOM_CLAUDE_MONITOR_DIR", "rel")
+
+    creds = read_monitor_credentials()
+    assert [c.email for c in creds] == ["x@example.com"]
+
+
+def test_percent_in_path_opens_where_it_failed_before(tmp_path: Path) -> None:
+    """A '%' in the path was a hard open failure pre-fix; now it opens."""
+    db = make_monitor_db(
+        tmp_path / "pct%dir" / "usage.db",
+        [{"label": "x@example.com", "email": "x@example.com", "token": "tok"}],
+    )
+    assert [c.email for c in read_monitor_credentials(db)] == ["x@example.com"]
+
+
+# --------------------------------------------------------------------------
+# SELECT error hint narrowing — #4029 fold-in item 1
+# --------------------------------------------------------------------------
+
+
+def test_missing_table_keeps_predate_hint(tmp_path: Path) -> None:
+    """A missing oauth_credentials table still earns the "predate" hint."""
+    db = tmp_path / "usage.db"
+    conn = sqlite3.connect(db)
+    conn.execute("CREATE TABLE unrelated (id INTEGER)")
+    conn.commit()
+    conn.close()
+    with pytest.raises(
+        MonitorDbUnavailable, match="predate the credential store"
+    ):
+        read_monitor_credentials(db)
+
+
+def test_non_missing_table_error_omits_predate_hint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-missing-table sqlite3.Error must not claim a missing table.
+
+    Represents the hot-WAL-without-shm family: a real ``OperationalError`` on
+    the SELECT whose cause is not a missing table. The narrowed handler must
+    surface the underlying error without the misleading "predate" hint.
+    """
+    db = make_monitor_db(
+        tmp_path / "usage.db",
+        [{"label": "x@example.com", "email": "x@example.com", "token": "tok"}],
+    )
+
+    real_connect = sqlite3.connect
+
+    class _BoomOnExecute:
+        def __init__(self, inner: sqlite3.Connection) -> None:
+            self._inner = inner
+
+        def execute(self, *args: object, **kwargs: object) -> object:
+            raise sqlite3.OperationalError("database is locked")
+
+        def close(self) -> None:
+            self._inner.close()
+
+    def fake_connect(*args: object, **kwargs: object) -> object:
+        return _BoomOnExecute(real_connect(*args, **kwargs))
+
+    monkeypatch.setattr(monitor_db_mod.sqlite3, "connect", fake_connect)
+
+    with pytest.raises(MonitorDbUnavailable) as excinfo:
+        read_monitor_credentials(db)
+
+    message = str(excinfo.value)
+    assert "database is locked" in message
+    assert "predate the credential store" not in message
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`read_monitor_credentials` built the read-only SQLite URI for claude-monitor's `usage.db` by raw string interpolation — `file:{path}?mode=ro`. Because `path` was never percent-encoded, a `?` or `#` anywhere in it terminated the URI path early and the `mode=ro` query parameter was silently dropped, opening another tool's **live** database read-**write**. A `%` was worse: it failed the open outright against a present, readable database. This voids a documented read-only guarantee, so it is a correctness/safety bug rather than a cosmetic nit.

## Changes

- **`monitor_db.py`** — new `_read_only_uri()` helper percent-encodes the path via `urllib.parse.quote` (default `safe='/'`) before interpolation, so `?`, `#`, `%`, and spaces can no longer void `mode=ro`. `quote` has no absolute-path precondition, so a **relative** `LOOM_CLAUDE_MONITOR_DIR` (which `monitor_db_path()` does not absolutize) still yields a usable URI rather than raising `ValueError` the way `Path.as_uri()` would. Also narrowed the `SELECT` error handler: only a missing-table `OperationalError` now earns the "may predate the credential store" hint; any other `sqlite3.Error` (hot WAL missing its `-shm`, corruption) surfaces its own message without the misleading hint.
- **`cli.py`** — `_print_monitor_import` is annotated with the real `MonitorImportResult` type (added to the import block) and reads fields via plain attribute access instead of defensive `getattr(result, ..., default)`, so a renamed field fails loudly rather than degrading to a default.
- **`test_monitor_db.py`** — regression tests (see below).

Note this also **repairs an outright-broken configuration**: a `%` in the path is a hard open failure today, so the fix is a behavior fix in that direction, not just a hardening.

## Acceptance Criteria Verification

- [x] Monitor DB path is percent-encoded before interpolation into the SQLite URI (`_read_only_uri`).
- [x] Regression test parameterized over `?`, `#`, `%`, and a space asserts the connection both opens **and is genuinely read-only** (a `CREATE TABLE` write attempt raises `sqlite3.OperationalError`) — not merely that the open succeeded.
- [x] The `SELECT` error path no longer asserts a missing-table cause for every `sqlite3.Error` (missing-table keeps the hint; a locked/other error omits it).
- [x] `_print_monitor_import` is annotated with `MonitorImportResult` and reads fields directly.
- [x] A relative `LOOM_CLAUDE_MONITOR_DIR` does not raise a bare `ValueError` (Curator Finding 1).
- [x] A path containing `%` opens successfully, where it fails today (Curator Finding 2).

## Test Plan

- `test_special_char_path_opens_and_is_read_only` — parameterized over `q?dir`, `h#ash`, `pct%20`, `sp ace`; opens via the module and asserts a write raises.
- `test_relative_monitor_dir_does_not_raise_value_error` — relative `LOOM_CLAUDE_MONITOR_DIR` via `monkeypatch.chdir`; succeeds, no `ValueError`.
- `test_percent_in_path_opens_where_it_failed_before` — `%` path now opens.
- `test_missing_table_keeps_predate_hint` / `test_non_missing_table_error_omits_predate_hint` — the narrowed hint.
- Full `loom-tools` tokens suite green: `324 passed`. Ruff clean on all three files.

Closes #4029