### PR TITLE
feat(tokens): warn when bootstrap disagrees with claude-monitor's live store

### DIFF
--- a/.loom/docs/token-pool.md
+++ b/.loom/docs/token-pool.md
@@ -91,6 +91,14 @@ accounts `blocked`, the daemon's dynamic concurrency cap collapses to
 **`bootstrap --force` does not fix it** — it faithfully rewrites the same revoked
 tokens, because the snapshot itself is what went stale.
 
+**`bootstrap` now detects this condition (#4030).** When `usage.db` is present and
+the tokens `bootstrap` is about to write disagree with the live store (same email,
+different fingerprint), it prints a warning naming the diverging accounts and
+pointing at `import-from-monitor` — so the stale snapshot is caught automatically
+instead of by hand-comparing fingerprints. The check is read-only, warns but never
+auto-switches sources, and is silent when no `usage.db` is present or it is
+unreadable; it prints emails and 8-char fingerprints only, never secret material.
+
 `loom-tokens import-from-monitor` reads the live store directly and is **the
 standard way to populate a new host's pool** (it replaces hand-copying a pool
 between machines):

--- a/loom-tools/src/loom_tools/tokens/bootstrap.py
+++ b/loom-tools/src/loom_tools/tokens/bootstrap.py
@@ -605,6 +605,82 @@ def write_index(
 _HOME_UNSET = object()
 
 
+def _check_monitor_divergence(valid: list[Account]) -> None:
+    """Warn when the merged bootstrap set disagrees with claude-monitor's live store.
+
+    The incident this guards against (#4030): claude-monitor re-authenticated
+    every account, writing fresh tokens to ``usage.db`` but never touching
+    ``accounts.env`` — the static snapshot ``bootstrap`` reads. ``bootstrap
+    --force`` then faithfully rewrote the *revoked* tokens and reported
+    ``written=N`` while the pool was dead; the only diagnosis was hand-comparing
+    sha256 fingerprints between two files. This surfaces that condition
+    automatically and names the remedy.
+
+    Compares what bootstrap is about to write (``valid``) against the live store,
+    joining on lowercased email (matching :func:`merge_accounts` and
+    ``read_monitor_credentials``), and warns on the **intersection** whose
+    fingerprints differ — never auto-switching sources.
+
+    Read-only and non-fatal by contract:
+
+    * **Absent store** (no claude-monitor / no ``usage.db``) — silent. A host
+      without claude-monitor is a fully-supported configuration.
+    * **Unreadable / locked / older-schema store** — silent. The reader
+      normalizes every such failure into :class:`MonitorDbUnavailable`.
+    * **Membership-only difference** (an email present on only one side) —
+      silent. A repo-local account absent from claude-monitor, or a monitor
+      account the pool legitimately pins out, is normal; warning on it would fire
+      on healthy hosts and train operators to ignore the message — the exact
+      failure this check exists to fix.
+
+    No secret material is printed — emails and 8-char fingerprints only,
+    consistent with ``index.json``.
+    """
+    # Deferred import: ``monitor_db`` imports from this module (``Account``,
+    # ``materialize_accounts``, ...), so a top-level import here would create an
+    # import cycle and fail at load time. Keep this import function-local — do
+    # NOT hoist it to the module top (#4030).
+    try:
+        from loom_tools.tokens.monitor_db import (
+            MonitorDbUnavailable,
+            read_monitor_credentials,
+        )
+    except ImportError:
+        return
+
+    try:
+        creds = read_monitor_credentials()
+    except MonitorDbUnavailable:
+        # No store, or an unreadable / locked / older-schema one — degrade to
+        # silence. Detection must never fail an otherwise-successful bootstrap.
+        return
+
+    live_fp = {c.email.strip().lower(): fingerprint(c.token) for c in creds}
+    diverged: list[tuple[str, str, str]] = []
+    for acct in valid:
+        live = live_fp.get(acct.email.strip().lower())
+        if live is None:
+            continue  # membership difference — not a key-divergence signal
+        env_fp = fingerprint(acct.key)
+        if live != env_fp:
+            diverged.append((acct.email, env_fp, live))
+
+    if not diverged:
+        return
+
+    detail = ", ".join(
+        f"{email} (merged fp={merged_fp}, live fp={monitor_fp})"
+        for email, merged_fp, monitor_fp in diverged
+    )
+    log_warning(
+        f"{len(diverged)} account(s) in the merged bootstrap sources disagree "
+        f"with claude-monitor's live store (usage.db): {detail}. The snapshot in "
+        f"accounts.env is stale, not the on-disk tokens — `--force` will NOT fix "
+        f"this, it rewrites the same stale values. Run "
+        f"`loom-tokens import-from-monitor --force` to adopt the live credentials."
+    )
+
+
 def bootstrap_tokens(
     repo_root: Path,
     *,
@@ -791,5 +867,12 @@ def bootstrap_tokens(
         log_success(
             f"Bootstrapped {len(result.written)} token(s) into {tokens_dir}"
         )
+
+    # #4030: detection for the stale-snapshot incident. Runs last so the warning
+    # is the final line the operator sees, and runs under --dry-run too (it is
+    # read-only detection — suppressing it there would hide the divergence from
+    # the exact command used to inspect state). Silent when no claude-monitor
+    # store is present; never fails the bootstrap.
+    _check_monitor_divergence(valid)
 
     return result

--- a/loom-tools/tests/tokens/conftest.py
+++ b/loom-tools/tests/tokens/conftest.py
@@ -12,7 +12,94 @@ to ``bootstrap_tokens``.
 
 from __future__ import annotations
 
+import sqlite3
+from pathlib import Path
+
 import pytest
+
+# --------------------------------------------------------------------------
+# claude-monitor usage.db fixtures (shared by test_monitor_db and
+# test_bootstrap). A minimal stand-in for claude-monitor's SQLite store, kept
+# here so both modules build fake stores through one builder rather than two
+# hand-rolled copies drifting apart.
+# --------------------------------------------------------------------------
+
+_SCHEMA = """
+CREATE TABLE accounts (
+    id TEXT PRIMARY KEY,
+    account_name TEXT,
+    email TEXT,
+    plan TEXT
+);
+CREATE TABLE oauth_credentials (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    account_id TEXT,
+    label TEXT NOT NULL,
+    access_token TEXT,
+    expires_at INTEGER,
+    is_active INTEGER DEFAULT 1
+);
+"""
+
+
+def make_monitor_db(path: Path, rows: list[dict]) -> Path:
+    """Build a usage.db stand-in.
+
+    Each row: ``label``, ``token``; optional ``email`` (creates a joined
+    ``accounts`` row), ``is_active`` (default 1), ``expires_at``.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    conn.executescript(_SCHEMA)
+    for n, row in enumerate(rows, start=1):
+        account_id = None
+        if row.get("email"):
+            account_id = f"acct-{n}"
+            conn.execute(
+                "INSERT INTO accounts (id, email) VALUES (?, ?)",
+                (account_id, row["email"]),
+            )
+        conn.execute(
+            "INSERT INTO oauth_credentials "
+            "(account_id, label, access_token, expires_at, is_active) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (
+                account_id,
+                row["label"],
+                row.get("token"),
+                row.get("expires_at"),
+                row.get("is_active", 1),
+            ),
+        )
+    conn.commit()
+    conn.close()
+    return path
+
+
+@pytest.fixture
+def monitor_db(tmp_path: Path) -> Path:
+    """Two active accounts, one deactivated."""
+    return make_monitor_db(
+        tmp_path / "monitor" / "usage.db",
+        [
+            {
+                "label": "robb@2amlogic.com's Organization",
+                "email": "robb@2amlogic.com",
+                "token": "sk-ant-oat01-fresh-robb",
+            },
+            {
+                "label": "agent-1@2amlogic.com",
+                "email": "agent-1@2amlogic.com",
+                "token": "sk-ant-oat01-fresh-agent1",
+            },
+            {
+                "label": "retired@example.com",
+                "email": "retired@example.com",
+                "token": "sk-ant-oat01-retired",
+                "is_active": 0,
+            },
+        ],
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/loom-tools/tests/tokens/test_bootstrap.py
+++ b/loom-tools/tests/tokens/test_bootstrap.py
@@ -27,6 +27,8 @@ from loom_tools.tokens.bootstrap import (
 )
 from loom_tools.tokens.cli import main as cli_main
 
+from .conftest import make_monitor_db  # shared usage.db builder (#4030)
+
 
 @pytest.fixture
 def mock_repo(tmp_path: pathlib.Path) -> pathlib.Path:
@@ -1240,3 +1242,228 @@ class TestCliMonitorReporting:
         out = capsys.readouterr().out
         assert "claude-monitor" in out
         assert "alice" in out
+
+
+# ---------------------------------------------------------------------------
+# #4030: bootstrap warns when the merged sources disagree with claude-monitor's
+# live store (usage.db). Detection for the stale-snapshot incident — read-only,
+# non-fatal, warn-never-switch.
+# ---------------------------------------------------------------------------
+
+
+def _write_usage_db(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    rows: list[dict],
+) -> pathlib.Path:
+    """Create a claude-monitor ``usage.db`` and point LOOM_CLAUDE_MONITOR_DIR at it.
+
+    The live store lives in the same directory the bootstrap monitor source
+    (``accounts.env``) would; the divergence check reads ``usage.db`` from there.
+    """
+    mon_dir = tmp_path / "claude-monitor-live"
+    mon_dir.mkdir(exist_ok=True)
+    make_monitor_db(mon_dir / "usage.db", rows)
+    monkeypatch.setenv("LOOM_CLAUDE_MONITOR_DIR", str(mon_dir))
+    return mon_dir
+
+
+class TestMonitorDivergenceWarning:
+    """AC #4030: warn on key divergence, stay silent everywhere else."""
+
+    def test_divergence_warns_and_names_remedy(
+        self,
+        mock_repo: pathlib.Path,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # accounts.env snapshot is stale: repo has the revoked key, the live
+        # store has a fresh token for the same email.
+        _write_env(
+            mock_repo, _triple(1, "alice@example.com", "sk-STALE", "alice.token")
+        )
+        _write_usage_db(
+            tmp_path,
+            monkeypatch,
+            [{"label": "alice@example.com", "email": "alice@example.com",
+              "token": "sk-FRESH"}],
+        )
+        bootstrap_tokens(mock_repo)
+        err = capsys.readouterr().err
+        assert "disagree with claude-monitor's live store" in err
+        assert "alice@example.com" in err
+        assert "import-from-monitor" in err
+
+    def test_agreement_is_silent(
+        self,
+        mock_repo: pathlib.Path,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # Same key on both sides -> no divergence.
+        _write_env(
+            mock_repo, _triple(1, "alice@example.com", "sk-SAME", "alice.token")
+        )
+        _write_usage_db(
+            tmp_path,
+            monkeypatch,
+            [{"label": "alice@example.com", "email": "alice@example.com",
+              "token": "sk-SAME"}],
+        )
+        bootstrap_tokens(mock_repo)
+        err = capsys.readouterr().err
+        assert "disagree with claude-monitor" not in err
+
+    def test_store_absent_is_silent(
+        self,
+        mock_repo: pathlib.Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # No usage.db at all (conftest points LOOM_CLAUDE_MONITOR_DIR at a
+        # non-existent dir). A host without claude-monitor is fully supported.
+        _write_env(
+            mock_repo, _triple(1, "alice@example.com", "sk-1", "alice.token")
+        )
+        bootstrap_tokens(mock_repo)
+        err = capsys.readouterr().err
+        assert "disagree with claude-monitor" not in err
+
+    def test_unreadable_store_is_silent(
+        self,
+        mock_repo: pathlib.Path,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # usage.db present but not a valid SQLite file -> degrade to silence,
+        # never fail the bootstrap.
+        mon_dir = tmp_path / "claude-monitor-live"
+        mon_dir.mkdir()
+        (mon_dir / "usage.db").write_bytes(b"not a database")
+        monkeypatch.setenv("LOOM_CLAUDE_MONITOR_DIR", str(mon_dir))
+        _write_env(
+            mock_repo, _triple(1, "alice@example.com", "sk-1", "alice.token")
+        )
+        result = bootstrap_tokens(mock_repo)
+        err = capsys.readouterr().err
+        assert "disagree with claude-monitor" not in err
+        assert result.written == ["alice.token"]
+
+    def test_older_schema_store_is_silent(
+        self,
+        mock_repo: pathlib.Path,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # A valid SQLite DB with no oauth_credentials table (older
+        # claude-monitor) -> silent, bootstrap still succeeds.
+        import sqlite3
+
+        mon_dir = tmp_path / "claude-monitor-live"
+        mon_dir.mkdir()
+        conn = sqlite3.connect(mon_dir / "usage.db")
+        conn.execute("CREATE TABLE unrelated (id INTEGER)")
+        conn.commit()
+        conn.close()
+        monkeypatch.setenv("LOOM_CLAUDE_MONITOR_DIR", str(mon_dir))
+        _write_env(
+            mock_repo, _triple(1, "alice@example.com", "sk-1", "alice.token")
+        )
+        result = bootstrap_tokens(mock_repo)
+        err = capsys.readouterr().err
+        assert "disagree with claude-monitor" not in err
+        assert result.written == ["alice.token"]
+
+    def test_membership_difference_is_silent(
+        self,
+        mock_repo: pathlib.Path,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # Emails present on only one side never warn: a repo-only account
+        # absent from the live store, and a live account the pool omits.
+        _write_env(
+            mock_repo, _triple(1, "repoonly@example.com", "sk-1", "repoonly.token")
+        )
+        _write_usage_db(
+            tmp_path,
+            monkeypatch,
+            [{"label": "liveonly@example.com", "email": "liveonly@example.com",
+              "token": "sk-live"}],
+        )
+        bootstrap_tokens(mock_repo)
+        err = capsys.readouterr().err
+        assert "disagree with claude-monitor" not in err
+
+    def test_no_secret_material_is_printed(
+        self,
+        mock_repo: pathlib.Path,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # The warning carries fingerprints and emails only — never key material.
+        _write_env(
+            mock_repo, _triple(1, "alice@example.com", "sk-STALE", "alice.token")
+        )
+        _write_usage_db(
+            tmp_path,
+            monkeypatch,
+            [{"label": "alice@example.com", "email": "alice@example.com",
+              "token": "sk-FRESH"}],
+        )
+        bootstrap_tokens(mock_repo)
+        err = capsys.readouterr().err
+        assert "sk-STALE" not in err
+        assert "sk-FRESH" not in err
+        assert fingerprint("sk-STALE") in err
+        assert fingerprint("sk-FRESH") in err
+
+    def test_email_case_insensitive_join(
+        self,
+        mock_repo: pathlib.Path,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # accounts.env uses User@x.com, the live store user@x.com -> one account,
+        # so a differing token still surfaces as a divergence (not two accounts).
+        _write_env(
+            mock_repo, _triple(1, "User@example.com", "sk-STALE", "user.token")
+        )
+        _write_usage_db(
+            tmp_path,
+            monkeypatch,
+            [{"label": "user@example.com", "email": "user@example.com",
+              "token": "sk-FRESH"}],
+        )
+        bootstrap_tokens(mock_repo)
+        err = capsys.readouterr().err
+        assert "disagree with claude-monitor" in err
+
+    def test_divergence_still_warns_under_dry_run(
+        self,
+        mock_repo: pathlib.Path,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # The check is read-only detection; --dry-run must not suppress it.
+        _write_env(
+            mock_repo, _triple(1, "alice@example.com", "sk-STALE", "alice.token")
+        )
+        _write_usage_db(
+            tmp_path,
+            monkeypatch,
+            [{"label": "alice@example.com", "email": "alice@example.com",
+              "token": "sk-FRESH"}],
+        )
+        result = bootstrap_tokens(mock_repo, dry_run=True)
+        err = capsys.readouterr().err
+        assert result.dry_run is True
+        assert "disagree with claude-monitor's live store" in err
+        assert "import-from-monitor" in err

--- a/loom-tools/tests/tokens/test_monitor_db.py
+++ b/loom-tools/tests/tokens/test_monitor_db.py
@@ -25,86 +25,11 @@ from loom_tools.tokens.monitor_db import (
     read_monitor_credentials,
 )
 
-# --------------------------------------------------------------------------
-# Fixture helpers — a minimal stand-in for claude-monitor's usage.db
-# --------------------------------------------------------------------------
+from .conftest import make_monitor_db  # relocated shared usage.db builder
 
-_SCHEMA = """
-CREATE TABLE accounts (
-    id TEXT PRIMARY KEY,
-    account_name TEXT,
-    email TEXT,
-    plan TEXT
-);
-CREATE TABLE oauth_credentials (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    account_id TEXT,
-    label TEXT NOT NULL,
-    access_token TEXT,
-    expires_at INTEGER,
-    is_active INTEGER DEFAULT 1
-);
-"""
-
-
-def make_monitor_db(path: Path, rows: list[dict]) -> Path:
-    """Build a usage.db stand-in.
-
-    Each row: ``label``, ``token``; optional ``email`` (creates a joined
-    ``accounts`` row), ``is_active`` (default 1), ``expires_at``.
-    """
-    path.parent.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(path)
-    conn.executescript(_SCHEMA)
-    for n, row in enumerate(rows, start=1):
-        account_id = None
-        if row.get("email"):
-            account_id = f"acct-{n}"
-            conn.execute(
-                "INSERT INTO accounts (id, email) VALUES (?, ?)",
-                (account_id, row["email"]),
-            )
-        conn.execute(
-            "INSERT INTO oauth_credentials "
-            "(account_id, label, access_token, expires_at, is_active) "
-            "VALUES (?, ?, ?, ?, ?)",
-            (
-                account_id,
-                row["label"],
-                row.get("token"),
-                row.get("expires_at"),
-                row.get("is_active", 1),
-            ),
-        )
-    conn.commit()
-    conn.close()
-    return path
-
-
-@pytest.fixture
-def monitor_db(tmp_path: Path) -> Path:
-    """Two active accounts, one deactivated."""
-    return make_monitor_db(
-        tmp_path / "monitor" / "usage.db",
-        [
-            {
-                "label": "robb@2amlogic.com's Organization",
-                "email": "robb@2amlogic.com",
-                "token": "sk-ant-oat01-fresh-robb",
-            },
-            {
-                "label": "agent-1@2amlogic.com",
-                "email": "agent-1@2amlogic.com",
-                "token": "sk-ant-oat01-fresh-agent1",
-            },
-            {
-                "label": "retired@example.com",
-                "email": "retired@example.com",
-                "token": "sk-ant-oat01-retired",
-                "is_active": 0,
-            },
-        ],
-    )
+# The ``monitor_db`` fixture lives in ``conftest.py`` (shared with
+# test_bootstrap); ``make_monitor_db`` is imported above for the tests that
+# build one-off stores inline.
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`loom-tokens bootstrap` rewrites `accounts.env`-derived tokens without ever
consulting claude-monitor's **live** credential store (`~/.claude-monitor/usage.db`).
In the incident that motivated this (#4030), every account was re-authenticated in
claude-monitor — which updated `usage.db` but not the `accounts.env` snapshot — so
`bootstrap --force` faithfully rewrote the revoked tokens, reported `written=N`, and
the pool stayed dead. The only diagnosis was hand-comparing sha256 fingerprints
between two files.

This adds a detection step at the end of `bootstrap_tokens()`: it compares the
merged set it is about to write against the live store and, on divergence, warns
and names `import-from-monitor` as the remedy.

## Changes

- **`loom-tools/src/loom_tools/tokens/bootstrap.py`** — new `_check_monitor_divergence()`
  helper, called last in `bootstrap_tokens()` (after the summary/drift log, so the
  warning is the final line; runs under `--dry-run` too). Compares
  `fingerprint(acct.key)` for the merged `valid` set against `fingerprint(cred.token)`
  from `read_monitor_credentials()`, joining on lowercased email, warning only on the
  intersection whose fingerprints differ. The warning explicitly redirects away from
  the misleading `--force` advice. `read_monitor_credentials` is imported
  **function-locally** to avoid the existing `monitor_db → bootstrap` import cycle.
- **`loom-tools/tests/tokens/conftest.py`** — relocated `make_monitor_db()` and the
  `monitor_db` fixture here so both test modules share one `usage.db` builder.
- **`loom-tools/tests/tokens/test_monitor_db.py`** — import the relocated helpers.
- **`loom-tools/tests/tokens/test_bootstrap.py`** — new `TestMonitorDivergenceWarning`
  class (10 tests).
- **`.loom/docs/token-pool.md`** — note that `bootstrap` now detects the stale-snapshot
  condition. (The "Importing live tokens from claude-monitor" section was moved out of
  `CLAUDE.md` into this doc by the #4014/#4089 split; `CLAUDE.md` now only carries a
  one-line pointer and is budget-checked, so this is the correct structural home. No
  `defaults/` mirror exists for this file — `defaults/docs/` holds only
  `ci-integration.md` — so there is no drift to keep in sync.)

## Design decisions (per issue + curator guidance)

- **Warn, never auto-switch** — `bootstrap`'s contract is "materialize the configured
  sources"; the operator is told, not overridden.
- **Read-only and non-fatal** — a single `except MonitorDbUnavailable` covers absent
  store, unreadable/locked DB, and older schema (the reader normalizes all three).
- **Membership differences stay silent** — an email on only one side is a normal
  configuration (repo-local account, or a monitor account the pool pins out); warning
  on it would train operators to ignore the message.
- **No secrets** — emails and 8-char fingerprints only, consistent with `index.json`.
- **`mode=ro` fix (#4029)** already merged — `read_monitor_credentials()` opens the DB
  `file:…?mode=ro` on `main`, so no dependency remains.

### Out of scope (per curator, deferred to follow-ups)

- The symmetric `loom-tokens check` all-`blocked` hint (a different mechanism — a
  heuristic over probe results, not a source comparison).
- Membership-divergence warnings (monitor holds accounts the merged set omits).

## Acceptance Criteria Verification

- [x] claude-monitor present + live tokens differ → warning names `import-from-monitor`
      (`test_divergence_warns_and_names_remedy`)
- [x] No claude-monitor store present → output unchanged / silent
      (`test_store_absent_is_silent`)
- [x] Unreadable / locked / older-schema store → silent, never fails the bootstrap
      (`test_unreadable_store_is_silent`, `test_older_schema_store_is_silent`)
- [x] No secret material printed — fingerprints + emails only
      (`test_no_secret_material_is_printed`)
- [x] Tests cover agreement (silent), divergence (warns), absent (silent),
      unreadable (silent) — plus membership difference, case-insensitive email join,
      and `--dry-run`.

## Test Plan

- [x] `PYTHONPATH=loom-tools/src python3 -m pytest loom-tools/tests/tokens/ -q` →
      **325 passed** (was 315; +10 new, conftest relocation keeps `test_monitor_db`
      green).
- [x] `ruff check` passes on all changed files.

Closes #4030