### PR TITLE
refactor(daemon): migrate 10 mechanical config readers onto config_resolver

### DIFF
--- a/loom-daemon/src/main_health_gate.rs
+++ b/loom-daemon/src/main_health_gate.rs
@@ -573,31 +573,8 @@ pub struct BuildGateConfig {
 /// `buildGate` block (or `enabled: false`) gets zero behavior change.
 #[must_use]
 pub fn read_build_gate_config(repo_root: &Path) -> Option<BuildGateConfig> {
-    let config_path = repo_root.join(".loom").join("config.json");
-
-    let config_str = match std::fs::read_to_string(&config_path) {
-        Ok(s) => s,
-        Err(e) => {
-            log::debug!(
-                "main_health_gate: could not read config at {}: {e}",
-                config_path.display()
-            );
-            return None;
-        }
-    };
-
-    let config: serde_json::Value = match serde_json::from_str(&config_str) {
-        Ok(v) => v,
-        Err(e) => {
-            log::warn!(
-                "main_health_gate: could not parse config at {}: {e}",
-                config_path.display()
-            );
-            return None;
-        }
-    };
-
-    let gate = config.get("buildGate")?;
+    let effective = crate::config_resolver::resolve_effective_config(repo_root);
+    let gate = crate::config_resolver::get_path(&effective, "buildGate")?;
 
     // `enabled` must be explicitly true — absent or false ⇒ disabled.
     if !gate
@@ -2175,33 +2152,8 @@ pub struct AutonomousGateConfig {
 /// change (env-only enablement, exactly like Phase C shipped).
 #[must_use]
 pub fn read_autonomous_gate_config(repo_root: &Path) -> AutonomousGateConfig {
-    let config_path = repo_root.join(".loom").join("config.json");
-
-    let config_str = match std::fs::read_to_string(&config_path) {
-        Ok(s) => s,
-        Err(e) => {
-            log::debug!(
-                "main_health_gate: could not read config at {}: {e}",
-                config_path.display()
-            );
-            return AutonomousGateConfig::default();
-        }
-    };
-
-    let config: serde_json::Value = match serde_json::from_str(&config_str) {
-        Ok(v) => v,
-        Err(e) => {
-            log::warn!(
-                "main_health_gate: could not parse config at {}: {e}",
-                config_path.display()
-            );
-            return AutonomousGateConfig::default();
-        }
-    };
-
-    let Some(gate) = config
-        .get("autonomous")
-        .and_then(|a| a.get("mainHealthGate"))
+    let effective = crate::config_resolver::resolve_effective_config(repo_root);
+    let Some(gate) = crate::config_resolver::get_path(&effective, "autonomous.mainHealthGate")
     else {
         return AutonomousGateConfig::default();
     };
@@ -2524,6 +2476,12 @@ mod tests {
         std::fs::write(loom_dir.join("config.json"), body).unwrap();
     }
 
+    fn write_project_config(dir: &Path, body: &str) {
+        let full = dir.join(crate::config_resolver::PROJECT_CONFIG_REL);
+        std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+        std::fs::write(full, body).unwrap();
+    }
+
     // ===================================================================
     // Config soft-fail
     // ===================================================================
@@ -2601,6 +2559,84 @@ mod tests {
         );
         let cfg = read_build_gate_config(tmp.path()).unwrap();
         assert_eq!(cfg.timeout, Duration::from_secs(DEFAULT_BUILD_GATE_TIMEOUT_SECS));
+    }
+
+    // ===================================================================
+    // config_resolver migration (#4058) — buildGate tier precedence
+    // ===================================================================
+
+    #[test]
+    #[serial(loom_config_env)]
+    fn test_build_gate_project_tier_only_is_honored_like_legacy() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let tmp = tempfile::tempdir().unwrap();
+        write_project_config(tmp.path(), r#"{"buildGate": {"enabled": true, "command": "true"}}"#);
+        let cfg = read_build_gate_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(cfg.unwrap().command, "true");
+    }
+
+    #[test]
+    #[serial(loom_config_env)]
+    fn test_build_gate_project_tier_overrides_legacy_overlap_and_supplies_non_overlap() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(
+            tmp.path(),
+            r#"{"buildGate": {"enabled": true, "command": "legacy-cmd", "timeoutSeconds": 99}}"#,
+        );
+        write_project_config(tmp.path(), r#"{"buildGate": {"command": "project-cmd"}}"#);
+        let cfg = read_build_gate_config(tmp.path()).unwrap();
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        // Overlapping `command` -> project tier wins.
+        assert_eq!(cfg.command, "project-cmd");
+        // Non-overlapping `timeoutSeconds` -> legacy tier still supplies it.
+        assert_eq!(cfg.timeout, Duration::from_secs(99));
+    }
+
+    // ===================================================================
+    // config_resolver migration (#4058) — autonomous.mainHealthGate tier
+    // precedence
+    // ===================================================================
+
+    #[test]
+    #[serial(loom_config_env)]
+    fn test_autonomous_gate_project_tier_only_is_honored_like_legacy() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let tmp = tempfile::tempdir().unwrap();
+        write_project_config(
+            tmp.path(),
+            r#"{"autonomous": {"mainHealthGate": {"enabled": true}}}"#,
+        );
+        let cfg = read_autonomous_gate_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(
+            cfg,
+            AutonomousGateConfig {
+                enabled: Some(true),
+                ci_workflow: None,
+            }
+        );
+    }
+
+    #[test]
+    #[serial(loom_config_env)]
+    fn test_autonomous_gate_local_tier_overrides_legacy_and_project() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), r#"{"autonomous": {"mainHealthGate": {"enabled": false}}}"#);
+        write_project_config(
+            tmp.path(),
+            r#"{"autonomous": {"mainHealthGate": {"enabled": false}}}"#,
+        );
+        let local_full = tmp.path().join(crate::config_resolver::LOCAL_CONFIG_REL);
+        std::fs::create_dir_all(local_full.parent().unwrap()).unwrap();
+        std::fs::write(&local_full, r#"{"autonomous": {"mainHealthGate": {"enabled": true}}}"#)
+            .unwrap();
+
+        let cfg = read_autonomous_gate_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(cfg.enabled, Some(true));
     }
 
     // ===================================================================

--- a/loom-daemon/src/role_runner.rs
+++ b/loom-daemon/src/role_runner.rs
@@ -509,25 +509,8 @@ pub struct RoleRunnerConfig {
 /// [`crate::token_ranking_refresh::read_token_ranking_refresh_config`].
 #[must_use]
 pub fn read_role_runner_config(repo_root: &Path) -> RoleRunnerConfig {
-    let config_path = repo_root.join(".loom").join("config.json");
-
-    let config_str = match std::fs::read_to_string(&config_path) {
-        Ok(s) => s,
-        Err(e) => {
-            log::debug!("role_runner: could not read config at {}: {e}", config_path.display());
-            return RoleRunnerConfig::default();
-        }
-    };
-
-    let config: serde_json::Value = match serde_json::from_str(&config_str) {
-        Ok(v) => v,
-        Err(e) => {
-            log::warn!("role_runner: could not parse config at {}: {e}", config_path.display());
-            return RoleRunnerConfig::default();
-        }
-    };
-
-    let Some(block) = config.get("autonomous").and_then(|a| a.get("roleRunner")) else {
+    let effective = crate::config_resolver::resolve_effective_config(repo_root);
+    let Some(block) = crate::config_resolver::get_path(&effective, "autonomous.roleRunner") else {
         return RoleRunnerConfig::default();
     };
 
@@ -971,6 +954,55 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         write_config(tmp.path(), r#"{"autonomous": {"roleRunner": {"intervalSecs": 0}}}"#);
         assert_eq!(read_role_runner_config(tmp.path()).interval_secs, None);
+    }
+
+    // ===================================================================
+    // config_resolver migration (#4058) — tier precedence
+    // ===================================================================
+
+    fn write_project_config(root: &Path, contents: &str) {
+        let full = root.join(crate::config_resolver::PROJECT_CONFIG_REL);
+        fs::create_dir_all(full.parent().unwrap()).unwrap();
+        fs::write(full, contents).unwrap();
+    }
+
+    #[test]
+    #[serial(loom_config_env)]
+    fn test_config_project_tier_only_is_honored_like_legacy() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let tmp = tempfile::tempdir().unwrap();
+        write_project_config(
+            tmp.path(),
+            r#"{"autonomous": {"roleRunner": {"enabled": true, "roles": ["curator"], "intervalSecs": 60}}}"#,
+        );
+        let cfg = read_role_runner_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(
+            cfg,
+            RoleRunnerConfig {
+                enabled: Some(true),
+                roles: Some(vec!["curator".to_string()]),
+                interval_secs: Some(60),
+            }
+        );
+    }
+
+    #[test]
+    #[serial(loom_config_env)]
+    fn test_config_project_tier_overrides_legacy_overlap_and_supplies_non_overlap() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(
+            tmp.path(),
+            r#"{"autonomous": {"roleRunner": {"enabled": true, "intervalSecs": 120}}}"#,
+        );
+        write_project_config(tmp.path(), r#"{"autonomous": {"roleRunner": {"intervalSecs": 30}}}"#);
+        let cfg = read_role_runner_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        // Overlapping `intervalSecs` -> project tier wins.
+        assert_eq!(cfg.interval_secs, Some(30));
+        // Non-overlapping `enabled` still supplied by legacy tier.
+        assert_eq!(cfg.enabled, Some(true));
     }
 
     // ===================================================================

--- a/loom-daemon/src/sweep_registry.rs
+++ b/loom-daemon/src/sweep_registry.rs
@@ -149,12 +149,8 @@ impl ModelSource {
 /// `main_health_gate::read_autonomous_gate_config`).
 #[must_use]
 pub fn read_autonomous_model(repo_root: &Path) -> Option<String> {
-    let path = repo_root.join(".loom").join("config.json");
-    let contents = std::fs::read_to_string(&path).ok()?;
-    let config: serde_json::Value = serde_json::from_str(&contents).ok()?;
-    config
-        .get("autonomous")?
-        .get("model")?
+    let effective = crate::config_resolver::resolve_effective_config(repo_root);
+    crate::config_resolver::get_path(&effective, "autonomous.model")?
         .as_str()
         .map(str::trim)
         .filter(|m| !m.is_empty())
@@ -3643,15 +3639,8 @@ pub struct StartupRaceConfig {
 /// [`crate::work_finder::read_work_finder_config`].
 #[must_use]
 pub fn read_startup_race_config(repo_root: &Path) -> StartupRaceConfig {
-    let config_path = repo_root.join(".loom").join("config.json");
-    let Ok(config_str) = std::fs::read_to_string(&config_path) else {
-        return StartupRaceConfig::default();
-    };
-    let Ok(config) = serde_json::from_str::<serde_json::Value>(&config_str) else {
-        log::warn!("sweep_registry: could not parse config at {}", config_path.display());
-        return StartupRaceConfig::default();
-    };
-    let Some(auto) = config.get("autonomous") else {
+    let effective = crate::config_resolver::resolve_effective_config(repo_root);
+    let Some(auto) = crate::config_resolver::get_path(&effective, "autonomous") else {
         return StartupRaceConfig::default();
     };
     let watchdog = auto.get("watchdog");
@@ -3787,19 +3776,9 @@ pub struct QuarantineFileConfig {
 /// [`read_startup_race_config`].
 #[must_use]
 pub fn read_quarantine_file_config(repo_root: &Path) -> QuarantineFileConfig {
-    let config_path = repo_root.join(".loom").join("config.json");
-    let Ok(config_str) = std::fs::read_to_string(&config_path) else {
-        return QuarantineFileConfig::default();
-    };
-    let Ok(config) = serde_json::from_str::<serde_json::Value>(&config_str) else {
-        log::warn!("sweep_registry: could not parse config at {}", config_path.display());
-        return QuarantineFileConfig::default();
-    };
-    let block = config
-        .get("autonomous")
-        .and_then(|a| a.get("workFinder"))
-        .and_then(|w| w.get("quarantine"));
-    let Some(q) = block else {
+    let effective = crate::config_resolver::resolve_effective_config(repo_root);
+    let Some(q) = crate::config_resolver::get_path(&effective, "autonomous.workFinder.quarantine")
+    else {
         return QuarantineFileConfig::default();
     };
     QuarantineFileConfig {
@@ -4701,6 +4680,37 @@ exit 0
         assert_eq!(read_autonomous_model(dir.path()), None);
         let (model, _) = resolve_dispatch_model(dir.path(), None);
         assert_eq!(model, DEFAULT_DISPATCH_MODEL);
+    }
+
+    // --- config_resolver migration (#4058) — tier precedence -------------- //
+
+    fn write_project_model_config(dir: &Path, body: &str) {
+        let full = dir.join(crate::config_resolver::PROJECT_CONFIG_REL);
+        std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+        std::fs::write(full, body).unwrap();
+    }
+
+    #[test]
+    #[serial(loom_config_env)]
+    fn read_autonomous_model_project_tier_only_is_honored_like_legacy() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let dir = tempdir().unwrap();
+        write_project_model_config(dir.path(), r#"{"autonomous": {"model": "opus"}}"#);
+        let model = read_autonomous_model(dir.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(model, Some("opus".to_string()));
+    }
+
+    #[test]
+    #[serial(loom_config_env)]
+    fn read_autonomous_model_project_tier_overrides_legacy() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let dir = tempdir().unwrap();
+        write_config(dir.path(), r#"{"autonomous": {"model": "sonnet"}}"#);
+        write_project_model_config(dir.path(), r#"{"autonomous": {"model": "opus"}}"#);
+        let model = read_autonomous_model(dir.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(model, Some("opus".to_string()));
     }
 
     // --- Issue #3982: logical-tier → concrete-ID resolution --------------- //
@@ -5803,6 +5813,34 @@ exit 0
         std::fs::write(loom.join("config.json"), r#"{"autonomous":{"workFinder":{}}}"#).unwrap();
         let file = read_quarantine_file_config(dir.path());
         assert_eq!(file, QuarantineFileConfig::default());
+    }
+
+    /// config_resolver migration (#4058): a value set only at the project
+    /// tier is honored identically to the legacy file.
+    #[test]
+    #[serial(loom_config_env)]
+    fn read_quarantine_file_config_project_tier_only_is_honored_like_legacy() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let dir = tempdir().unwrap();
+        let project = dir.path().join(crate::config_resolver::PROJECT_CONFIG_REL);
+        std::fs::create_dir_all(project.parent().unwrap()).unwrap();
+        std::fs::write(
+            &project,
+            r#"{"autonomous":{"workFinder":{"quarantine":{"enabled":true,"threshold":4,"ttlSecs":900,"instaCrashSecs":45}}}}"#,
+        )
+        .unwrap();
+
+        let file = read_quarantine_file_config(dir.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(
+            file,
+            QuarantineFileConfig {
+                enabled: Some(true),
+                threshold: Some(4),
+                ttl_secs: Some(900),
+                insta_crash_secs: Some(45),
+            }
+        );
     }
 
     /// Issue #3823b: orphaned-claim recovery. A daemon-owned sweep that exits
@@ -7966,6 +8004,98 @@ exit 0\n";
         let tmp = tempdir().unwrap();
         write_cfg(tmp.path(), r#"{"autonomous":{"dispatchStaggerMs":0}}"#);
         assert_eq!(read_startup_race_config(tmp.path()).dispatch_stagger_ms, Some(0));
+    }
+
+    // ===================================================================
+    // config_resolver migration (#4058) — tier precedence
+    // ===================================================================
+
+    fn write_project_cfg(dir: &Path, body: &str) {
+        let full = dir.join(crate::config_resolver::PROJECT_CONFIG_REL);
+        std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+        std::fs::write(full, body).unwrap();
+    }
+
+    fn write_local_cfg(dir: &Path, body: &str) {
+        let full = dir.join(crate::config_resolver::LOCAL_CONFIG_REL);
+        std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+        std::fs::write(full, body).unwrap();
+    }
+
+    #[test]
+    #[serial(loom_config_env)]
+    fn startup_race_config_project_tier_only_is_honored_like_legacy() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let tmp = tempdir().unwrap();
+        write_project_cfg(
+            tmp.path(),
+            r#"{"autonomous":{"dispatchStaggerMs":3000,"watchdog":{"enabled":false,"timeoutSecs":90}}}"#,
+        );
+        let cfg = read_startup_race_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(cfg.dispatch_stagger_ms, Some(3000));
+        assert_eq!(cfg.watchdog_enabled, Some(false));
+        assert_eq!(cfg.watchdog_timeout_secs, Some(90));
+    }
+
+    #[test]
+    #[serial(loom_config_env)]
+    fn startup_race_config_project_tier_overrides_legacy_overlap_and_supplies_non_overlap() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let tmp = tempdir().unwrap();
+        write_cfg(
+            tmp.path(),
+            r#"{"autonomous":{"dispatchStaggerMs":3000,"watchdog":{"timeoutSecs":90}}}"#,
+        );
+        write_project_cfg(tmp.path(), r#"{"autonomous":{"dispatchStaggerMs":750}}"#);
+        let cfg = read_startup_race_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        // Overlapping `dispatchStaggerMs` -> project tier wins.
+        assert_eq!(cfg.dispatch_stagger_ms, Some(750));
+        // Non-overlapping `watchdog.timeoutSecs` still supplied by legacy tier.
+        assert_eq!(cfg.watchdog_timeout_secs, Some(90));
+    }
+
+    #[test]
+    #[serial(loom_config_env)]
+    fn startup_race_config_local_tier_overrides_legacy_and_project() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let tmp = tempdir().unwrap();
+        write_cfg(tmp.path(), r#"{"autonomous":{"dispatchStaggerMs":3000}}"#);
+        write_project_cfg(tmp.path(), r#"{"autonomous":{"dispatchStaggerMs":750}}"#);
+        write_local_cfg(tmp.path(), r#"{"autonomous":{"dispatchStaggerMs":10}}"#);
+        let cfg = read_startup_race_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(cfg.dispatch_stagger_ms, Some(10));
+    }
+
+    /// Regression (#4058): `dispatchStaggerMs: 0` set only at the project
+    /// tier must still be read as `Some(0)` ("disable stagger"), not dropped
+    /// to `None` like a zero `watchdog.timeoutSecs` would be.
+    #[test]
+    #[serial(loom_config_env)]
+    fn startup_race_config_project_tier_dispatch_stagger_zero_is_meaningful() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let tmp = tempdir().unwrap();
+        write_project_cfg(tmp.path(), r#"{"autonomous":{"dispatchStaggerMs":0}}"#);
+        let cfg = read_startup_race_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(cfg.dispatch_stagger_ms, Some(0));
+    }
+
+    /// Explicit `null` at the project tier clears a legacy-tier value —
+    /// documents the `deep_merge` "null clears" semantics (#4058) at this
+    /// migrated site.
+    #[test]
+    #[serial(loom_config_env)]
+    fn startup_race_config_explicit_null_in_project_tier_clears_legacy_value() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let tmp = tempdir().unwrap();
+        write_cfg(tmp.path(), r#"{"autonomous":{"dispatchStaggerMs":3000}}"#);
+        write_project_cfg(tmp.path(), r#"{"autonomous":{"dispatchStaggerMs":null}}"#);
+        let cfg = read_startup_race_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(cfg.dispatch_stagger_ms, None);
     }
 
     #[test]

--- a/loom-daemon/src/token_ranking_refresh.rs
+++ b/loom-daemon/src/token_ranking_refresh.rs
@@ -341,33 +341,9 @@ pub struct TokenRankingRefreshConfig {
 /// cadence).
 #[must_use]
 pub fn read_token_ranking_refresh_config(repo_root: &Path) -> TokenRankingRefreshConfig {
-    let config_path = repo_root.join(".loom").join("config.json");
-
-    let config_str = match std::fs::read_to_string(&config_path) {
-        Ok(s) => s,
-        Err(e) => {
-            log::debug!(
-                "token_ranking_refresh: could not read config at {}: {e}",
-                config_path.display()
-            );
-            return TokenRankingRefreshConfig::default();
-        }
-    };
-
-    let config: serde_json::Value = match serde_json::from_str(&config_str) {
-        Ok(v) => v,
-        Err(e) => {
-            log::warn!(
-                "token_ranking_refresh: could not parse config at {}: {e}",
-                config_path.display()
-            );
-            return TokenRankingRefreshConfig::default();
-        }
-    };
-
-    let Some(block) = config
-        .get("autonomous")
-        .and_then(|a| a.get("tokenRankingRefresh"))
+    let effective = crate::config_resolver::resolve_effective_config(repo_root);
+    let Some(block) =
+        crate::config_resolver::get_path(&effective, "autonomous.tokenRankingRefresh")
     else {
         return TokenRankingRefreshConfig::default();
     };
@@ -748,6 +724,57 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         write_config(tmp.path(), r#"{"autonomous": {"tokenRankingRefresh": {"intervalSecs": 0}}}"#);
         assert_eq!(read_token_ranking_refresh_config(tmp.path()).interval_secs, None);
+    }
+
+    // ===================================================================
+    // config_resolver migration (#4058) — tier precedence
+    // ===================================================================
+
+    fn write_project_config(root: &Path, contents: &str) {
+        let full = root.join(crate::config_resolver::PROJECT_CONFIG_REL);
+        fs::create_dir_all(full.parent().unwrap()).unwrap();
+        fs::write(full, contents).unwrap();
+    }
+
+    #[test]
+    #[serial(loom_config_env)]
+    fn test_config_project_tier_only_is_honored_like_legacy() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let tmp = tempfile::tempdir().unwrap();
+        write_project_config(
+            tmp.path(),
+            r#"{"autonomous": {"tokenRankingRefresh": {"enabled": false, "intervalSecs": 120}}}"#,
+        );
+        let cfg = read_token_ranking_refresh_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(
+            cfg,
+            TokenRankingRefreshConfig {
+                enabled: Some(false),
+                interval_secs: Some(120),
+            }
+        );
+    }
+
+    #[test]
+    #[serial(loom_config_env)]
+    fn test_config_project_tier_overrides_legacy_overlap_and_supplies_non_overlap() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(
+            tmp.path(),
+            r#"{"autonomous": {"tokenRankingRefresh": {"enabled": true, "intervalSecs": 600}}}"#,
+        );
+        write_project_config(
+            tmp.path(),
+            r#"{"autonomous": {"tokenRankingRefresh": {"intervalSecs": 300}}}"#,
+        );
+        let cfg = read_token_ranking_refresh_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        // Overlapping `intervalSecs` -> project tier wins.
+        assert_eq!(cfg.interval_secs, Some(300));
+        // Non-overlapping `enabled` still supplied by legacy tier.
+        assert_eq!(cfg.enabled, Some(true));
     }
 
     // ===================================================================

--- a/loom-daemon/src/watch_registry.rs
+++ b/loom-daemon/src/watch_registry.rs
@@ -731,19 +731,9 @@ pub struct WatchMonitorConfig {
 /// [`crate::token_ranking_refresh::read_token_ranking_refresh_config`]).
 #[must_use]
 pub fn read_watch_monitor_config(repo_root: &Path) -> WatchMonitorConfig {
-    let config_path = repo_root.join(".loom").join("config.json");
-    let config_str = match std::fs::read_to_string(&config_path) {
-        Ok(s) => s,
-        Err(_) => return WatchMonitorConfig::default(),
-    };
-    let config: serde_json::Value = match serde_json::from_str(&config_str) {
-        Ok(v) => v,
-        Err(e) => {
-            log::warn!("watch_registry: could not parse config at {}: {e}", config_path.display());
-            return WatchMonitorConfig::default();
-        }
-    };
-    let Some(block) = config.get("autonomous").and_then(|a| a.get("watchMonitor")) else {
+    let effective = crate::config_resolver::resolve_effective_config(repo_root);
+    let Some(block) = crate::config_resolver::get_path(&effective, "autonomous.watchMonitor")
+    else {
         return WatchMonitorConfig::default();
     };
     WatchMonitorConfig {
@@ -1154,6 +1144,95 @@ mod tests {
                 expiry_secs: Some(0),
             }
         );
+    }
+
+    // ===================================================================
+    // config_resolver migration (#4058) — tier precedence
+    // ===================================================================
+
+    fn write_project_config(root: &Path, contents: &str) {
+        let full = root.join(crate::config_resolver::PROJECT_CONFIG_REL);
+        std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+        std::fs::write(full, contents).unwrap();
+    }
+
+    fn write_local_config(root: &Path, contents: &str) {
+        let full = root.join(crate::config_resolver::LOCAL_CONFIG_REL);
+        std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+        std::fs::write(full, contents).unwrap();
+    }
+
+    #[test]
+    #[serial(loom_config_env)]
+    fn config_project_tier_only_is_honored_like_legacy() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let dir = tempdir().unwrap();
+        write_project_config(
+            dir.path(),
+            r#"{"autonomous":{"watchMonitor":{"enabled":false,"intervalSecs":60,"expirySecs":0}}}"#,
+        );
+        let cfg = read_watch_monitor_config(dir.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(
+            cfg,
+            WatchMonitorConfig {
+                enabled: Some(false),
+                interval_secs: Some(60),
+                expiry_secs: Some(0),
+            }
+        );
+    }
+
+    #[test]
+    #[serial(loom_config_env)]
+    fn config_project_tier_overrides_legacy_overlap_and_supplies_non_overlap() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let dir = tempdir().unwrap();
+        write_config(
+            dir.path(),
+            r#"{"autonomous":{"watchMonitor":{"enabled":true,"intervalSecs":60}}}"#,
+        );
+        write_project_config(dir.path(), r#"{"autonomous":{"watchMonitor":{"intervalSecs":15}}}"#);
+        let cfg = read_watch_monitor_config(dir.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        // Overlapping `intervalSecs` -> project tier wins.
+        assert_eq!(cfg.interval_secs, Some(15));
+        // Non-overlapping `enabled` still supplied by legacy tier.
+        assert_eq!(cfg.enabled, Some(true));
+    }
+
+    #[test]
+    #[serial(loom_config_env)]
+    fn config_local_tier_overrides_legacy_and_project() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let dir = tempdir().unwrap();
+        write_config(dir.path(), r#"{"autonomous":{"watchMonitor":{"intervalSecs":60}}}"#);
+        write_project_config(dir.path(), r#"{"autonomous":{"watchMonitor":{"intervalSecs":30}}}"#);
+        write_local_config(dir.path(), r#"{"autonomous":{"watchMonitor":{"intervalSecs":5}}}"#);
+        let cfg = read_watch_monitor_config(dir.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(cfg.interval_secs, Some(5));
+    }
+
+    /// Regression (#4058): `expirySecs: 0` set only at the project tier must
+    /// still be read as `Some(0)` ("disable expiry"), not dropped to `None`
+    /// like a zero `intervalSecs` would be. `resolve_expiry` itself (which
+    /// turns `Some(0)` into a zero `Duration`) is unmodified by this
+    /// migration and already covered by `resolve_expiry_zero_is_honored`
+    /// above — this test isolates the tier-migrated read path and
+    /// deliberately avoids touching `WATCH_MONITOR_EXPIRY_ENV` (that test
+    /// mutates it under the crate-wide unkeyed `#[serial]` lock, which does
+    /// not mutually exclude against this test's keyed
+    /// `#[serial(loom_config_env)]` lock).
+    #[test]
+    #[serial(loom_config_env)]
+    fn config_project_tier_expiry_secs_zero_is_meaningful() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let dir = tempdir().unwrap();
+        write_project_config(dir.path(), r#"{"autonomous":{"watchMonitor":{"expirySecs":0}}}"#);
+        let cfg = read_watch_monitor_config(dir.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(cfg.expiry_secs, Some(0));
     }
 
     #[test]

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -743,25 +743,8 @@ pub struct WorkFinderConfig {
 /// so it falls through to the built-in default rather than a useless value.
 #[must_use]
 pub fn read_work_finder_config(repo_root: &Path) -> WorkFinderConfig {
-    let config_path = repo_root.join(".loom").join("config.json");
-
-    let config_str = match std::fs::read_to_string(&config_path) {
-        Ok(s) => s,
-        Err(e) => {
-            log::debug!("work_finder: could not read config at {}: {e}", config_path.display());
-            return WorkFinderConfig::default();
-        }
-    };
-
-    let config: serde_json::Value = match serde_json::from_str(&config_str) {
-        Ok(v) => v,
-        Err(e) => {
-            log::warn!("work_finder: could not parse config at {}: {e}", config_path.display());
-            return WorkFinderConfig::default();
-        }
-    };
-
-    let Some(autonomous) = config.get("autonomous") else {
+    let effective = crate::config_resolver::resolve_effective_config(repo_root);
+    let Some(autonomous) = crate::config_resolver::get_path(&effective, "autonomous") else {
         return WorkFinderConfig::default();
     };
 
@@ -2721,6 +2704,70 @@ exit 0
         assert_eq!(cfg.enabled, Some(true));
         assert_eq!(cfg.interval_secs, None);
         assert_eq!(cfg.max_concurrent, None);
+    }
+
+    // ===================================================================
+    // config_resolver migration (#4058) — tier precedence
+    // ===================================================================
+
+    fn write_project_config(dir: &Path, body: &str) {
+        let full = dir.join(crate::config_resolver::PROJECT_CONFIG_REL);
+        std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+        std::fs::write(full, body).unwrap();
+    }
+
+    fn write_local_config(dir: &Path, body: &str) {
+        let full = dir.join(crate::config_resolver::LOCAL_CONFIG_REL);
+        std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+        std::fs::write(full, body).unwrap();
+    }
+
+    #[test]
+    #[serial(loom_config_env)]
+    fn test_config_project_tier_only_is_honored_like_legacy() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let tmp = tempfile::tempdir().unwrap();
+        write_project_config(
+            tmp.path(),
+            r#"{"autonomous": {"perTokenConcurrency": 4, "workFinder": {"enabled": true, "maxConcurrent": 5}}}"#,
+        );
+        let cfg = read_work_finder_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(cfg.enabled, Some(true));
+        assert_eq!(cfg.max_concurrent, Some(5));
+        assert_eq!(cfg.per_token_concurrency, Some(4));
+    }
+
+    #[test]
+    #[serial(loom_config_env)]
+    fn test_config_project_tier_overrides_legacy_overlap_and_supplies_non_overlap() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(
+            tmp.path(),
+            r#"{"autonomous": {"workFinder": {"enabled": true, "maxConcurrent": 5, "intervalSecs": 60}}}"#,
+        );
+        write_project_config(tmp.path(), r#"{"autonomous": {"workFinder": {"maxConcurrent": 9}}}"#);
+        let cfg = read_work_finder_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        // Overlapping `maxConcurrent` -> project tier wins.
+        assert_eq!(cfg.max_concurrent, Some(9));
+        // Non-overlapping keys still supplied by the legacy tier.
+        assert_eq!(cfg.enabled, Some(true));
+        assert_eq!(cfg.interval_secs, Some(60));
+    }
+
+    #[test]
+    #[serial(loom_config_env)]
+    fn test_config_local_tier_overrides_legacy_and_project() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), r#"{"autonomous": {"workFinder": {"maxConcurrent": 5}}}"#);
+        write_project_config(tmp.path(), r#"{"autonomous": {"workFinder": {"maxConcurrent": 9}}}"#);
+        write_local_config(tmp.path(), r#"{"autonomous": {"workFinder": {"maxConcurrent": 2}}}"#);
+        let cfg = read_work_finder_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(cfg.max_concurrent, Some(2));
     }
 
     // ===================================================================

--- a/loom-daemon/src/worktree_root.rs
+++ b/loom-daemon/src/worktree_root.rs
@@ -86,30 +86,15 @@ fn namespaced(override_root: &str, repo_root: &Path) -> PathBuf {
     }
 }
 
-/// Read `.loom/config.json` → `worktree.root`, soft-failing to `None`.
+/// Read `worktree.root` via the config resolver (env > config > default
+/// tiering is layered by the caller; this resolves only the "config"
+/// position), soft-failing to `None`.
 ///
 /// Follows the pattern in `crate::extract_configured_terminal_ids`: missing
 /// file, parse error, or missing key all resolve to `None` (never a hard error).
 fn read_config_worktree_root(repo_root: &Path) -> Option<String> {
-    let config_path = repo_root.join(".loom").join("config.json");
-
-    let config_str = match std::fs::read_to_string(&config_path) {
-        Ok(s) => s,
-        Err(e) => {
-            log::debug!("Could not read config at {}: {e}", config_path.display());
-            return None;
-        }
-    };
-
-    let config: serde_json::Value = match serde_json::from_str(&config_str) {
-        Ok(v) => v,
-        Err(e) => {
-            log::warn!("Could not parse config at {}: {e}", config_path.display());
-            return None;
-        }
-    };
-
-    let root = config.get("worktree")?.get("root")?.as_str()?;
+    let effective = crate::config_resolver::resolve_effective_config(repo_root);
+    let root = crate::config_resolver::get_path(&effective, "worktree.root")?.as_str()?;
     if root.is_empty() {
         return None;
     }
@@ -132,6 +117,7 @@ pub fn is_worktree_path(path: &Path, repo_root: &Path) -> bool {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::sync::Mutex;
 
     // std::env::set_var mutates process-global state; serialize env-touching
@@ -159,6 +145,20 @@ mod tests {
         let loom_dir = dir.join(".loom");
         fs::create_dir_all(&loom_dir).unwrap();
         fs::write(loom_dir.join("config.json"), body).unwrap();
+    }
+
+    fn write_project_config(dir: &Path, body: &str) {
+        let rel = Path::new(crate::config_resolver::PROJECT_CONFIG_REL);
+        let full = dir.join(rel);
+        fs::create_dir_all(full.parent().unwrap()).unwrap();
+        fs::write(full, body).unwrap();
+    }
+
+    fn write_local_config(dir: &Path, body: &str) {
+        let rel = Path::new(crate::config_resolver::LOCAL_CONFIG_REL);
+        let full = dir.join(rel);
+        fs::create_dir_all(full.parent().unwrap()).unwrap();
+        fs::write(full, body).unwrap();
     }
 
     use std::fs;
@@ -339,5 +339,87 @@ mod tests {
             let unrelated = PathBuf::from("/some/other/place/issue-42");
             assert!(!is_worktree_path(&unrelated, &repo_root));
         });
+    }
+
+    // ===== config_resolver migration (#4058) =====
+    //
+    // These tests exercise the config_resolver tiering (project/local tiers)
+    // now that `read_config_worktree_root` goes through
+    // `config_resolver::resolve_effective_config`. Every test that touches
+    // `LOOM_CONFIG_DEFAULTS_FILE` is serialized on the keyed
+    // `loom_config_env` lock (not the crate-wide unkeyed `#[serial]` lock —
+    // see the CI-cost note on issue #4058) and pins the env var to `""` so a
+    // private defaults file on the host can never leak in.
+
+    #[test]
+    #[serial(loom_config_env)]
+    fn project_tier_only_worktree_root_is_honored_like_legacy() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = tmp.path().join("my-repo");
+        fs::create_dir_all(&repo_root).unwrap();
+        write_project_config(&repo_root, r#"{"worktree": {"root": "/Volumes/Project"}}"#);
+
+        let got = with_env(None, || worktree_root(&repo_root));
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+
+        assert_eq!(got, PathBuf::from("/Volumes/Project/my-repo"));
+    }
+
+    #[test]
+    #[serial(loom_config_env)]
+    fn project_tier_overrides_legacy_tier_on_overlap() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = tmp.path().join("my-repo");
+        fs::create_dir_all(&repo_root).unwrap();
+        write_config(
+            &repo_root,
+            r#"{"worktree": {"root": "/Volumes/Legacy"}, "nextAgentNumber": 3}"#,
+        );
+        write_project_config(&repo_root, r#"{"worktree": {"root": "/Volumes/Project"}}"#);
+
+        let got = with_env(None, || worktree_root(&repo_root));
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+
+        // Overlapping key: project tier wins.
+        assert_eq!(got, PathBuf::from("/Volumes/Project/my-repo"));
+    }
+
+    #[test]
+    #[serial(loom_config_env)]
+    fn local_tier_overrides_both_legacy_and_project() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = tmp.path().join("my-repo");
+        fs::create_dir_all(&repo_root).unwrap();
+        write_config(&repo_root, r#"{"worktree": {"root": "/Volumes/Legacy"}}"#);
+        write_project_config(&repo_root, r#"{"worktree": {"root": "/Volumes/Project"}}"#);
+        write_local_config(&repo_root, r#"{"worktree": {"root": "/Volumes/Local"}}"#);
+
+        let got = with_env(None, || worktree_root(&repo_root));
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+
+        assert_eq!(got, PathBuf::from("/Volumes/Local/my-repo"));
+    }
+
+    #[test]
+    #[serial(loom_config_env)]
+    fn explicit_null_in_project_tier_clears_legacy_worktree_root() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = tmp.path().join("my-repo");
+        fs::create_dir_all(&repo_root).unwrap();
+        write_config(&repo_root, r#"{"worktree": {"root": "/Volumes/Legacy"}}"#);
+        // Explicit null at the project tier clears the legacy value —
+        // `deep_merge` matches `jq`'s `*` operator (#4058).
+        write_project_config(&repo_root, r#"{"worktree": {"root": null}}"#);
+
+        let got = with_env(None, || worktree_root(&repo_root));
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+
+        // Cleared key -> falls through to the default, exactly like an
+        // absent key.
+        assert_eq!(got, repo_root.join(".loom").join("worktrees"));
     }
 }


### PR DESCRIPTION
## Summary

Migrates the ten "soft-fail to `None`" Rust `.loom/config.json` readers onto `config_resolver::resolve_effective_config(repo_root)` + `config_resolver::get_path(&cfg, "dotted.key")` (shipped, zero-call-site, in #4039/PR #4051). This is the mechanical cohort of parent #4047 — every site whose semantics are "read a dotted key, apply caller-side env > config > default." Structural/hard-fail readers (`lib.rs::extract_configured_terminal_ids`, `sweep_registry.rs::read_model_aliases`, `role_validation.rs`) are the sibling issue #4059 (already merged) and are untouched here.

Migrated functions:
- `worktree_root.rs::read_config_worktree_root` — `worktree.root`
- `main_health_gate.rs::read_build_gate_config` — `buildGate.*`
- `main_health_gate.rs::read_autonomous_gate_config` — `autonomous.mainHealthGate.*`
- `work_finder.rs::read_work_finder_config` — `autonomous.workFinder.*` + `autonomous.perTokenConcurrency`
- `role_runner.rs::read_role_runner_config` — `autonomous.roleRunner.*`
- `token_ranking_refresh.rs::read_token_ranking_refresh_config` — `autonomous.tokenRankingRefresh.*`
- `watch_registry.rs::read_watch_monitor_config` — `autonomous.watchMonitor.*`
- `sweep_registry.rs::read_autonomous_model` — `autonomous.model`
- `sweep_registry.rs::read_startup_race_config` — `autonomous.dispatchStaggerMs`, `autonomous.watchdog.*`
- `sweep_registry.rs::read_quarantine_file_config` — `autonomous.workFinder.quarantine.*`

Result: `.loom-project/project.json` and `.loom-local/local.json` are now live for every daemon knob these ten sites read — the tiering `config_resolver` introduced in #4039 was previously inert everywhere.

## Two required decisions (per issue AC)

**1. Logging unification (not preserved per-site).** `config_resolver::soft_read_json_object` unconditionally emits `log::warn!("config_resolver: could not parse {path}: {e}")` on malformed JSON at any tier. I deleted the now-dead per-site warn arms (`"main_health_gate: could not parse config at …"`, `"watch_registry: could not parse config at …"`, `"sweep_registry: could not parse config at …"`, etc.) in favor of the unified message. This is deliberate, not a silent regression: the unified message is strictly more informative (it names the specific tier path that failed to parse), and preserving ten near-identical per-site prefixes would have meant either duplicating the resolver's warn call at every site or adding a pre-check purely to keep an old string around. No test in this repo matches on the old per-site prefixes (verified via `git grep` before deleting them).

**2. `read_autonomous_model`'s silence-to-warning change is intentional.** Before this PR it used `.ok()?` and never logged on a malformed `.loom/config.json` (called out explicitly in the issue body as "silent by design"). After migration it goes through `soft_read_json_object`, which does `log::warn!` on parse failure — so a malformed config now produces a log line where it previously produced none. This is accepted as in-scope per the issue body ("recommendation: accept the unified message and delete the dead per-site warn arms... it must be a stated choice, not a silent regression") — confirming it here.

## Preserved semantics (unchanged by this PR)

- **Zero-is-meaningful stays scoped to exactly two keys**: `watchMonitor.expirySecs` and `dispatchStaggerMs` still read as `Some(0)` (disable), everywhere else a `0` still falls through to the built-in default — verified by targeted regression tests at both sites.
- **Default polarity per site is untouched**: `mainHealthGate`/`workFinder` still default off; `tokenRankingRefresh`/`watchMonitor`/sweep watchdog/`workFinder.quarantine` still default on; `buildGate.enabled` still requires an explicit `true`.
- **`buildGate.command` empty/absent still resolves to `None` + warn** (gate off), not a default command — this branch of `read_build_gate_config` is unchanged, only the config-tree acquisition above it moved onto the resolver.
- **The `resolve_*` env-override helpers are untouched** — they still sit above these readers in the existing env > config > default chain; the resolver only replaces the "config" position.

## Test Plan

- `cargo check --all-targets` — clean.
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean (ran `cargo fmt` once to normalize a few long `let-else` lines).
- `cargo test --lib` (full `loom-daemon` suite) — **1057 passed, 0 failed** in the final clean run. (An earlier run showed a single unrelated flake — `terminal::claude_config::tests::test_setup_creates_fallback_state_when_no_home_state`, a pre-existing test that reads the real `dirs::home_dir()`/`~/.claude/` state and isn't `#[serial]`; it passed in isolation and passed on the full re-run. `terminal.rs` is untouched by this PR.)
- Every pre-existing unit test in the seven touched files passes **unmodified** — no existing test assertion changed.
- New tests added at every migrated site (all `#[serial(loom_config_env)]`, all pin `LOOM_CONFIG_DEFAULTS_FILE=""`):
  - Per-site "project tier only, no legacy file" test at all 10 sites.
  - "Legacy + project both present ⇒ project wins overlap, legacy still supplies non-overlapping keys" at 8 of the sites (representative coverage; the same code path is exercised identically at the remaining 2).
  - "Local tier overrides both legacy and project" at `worktree_root.rs`, `main_health_gate.rs::read_autonomous_gate_config`, `work_finder.rs`, `watch_registry.rs`, and `sweep_registry.rs::read_startup_race_config`.
  - Explicit-`null`-clears-higher-tier test at `worktree_root.rs` and `sweep_registry.rs::read_startup_race_config`.
  - Zero-is-meaningful regression at both required sites: `watch_registry.rs::config_project_tier_expiry_secs_zero_is_meaningful` and `sweep_registry.rs::startup_race_config_project_tier_dispatch_stagger_zero_is_meaningful`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| All ten functions use the resolver; no `.join(".loom").join("config.json")` remains in these files | ✅ | Grepped all 7 files; only remaining hits are test-helper `write_config`/`write_cfg` functions that seed the legacy fixture file, plus the explicitly out-of-scope `read_model_aliases` in `sweep_registry.rs` |
| Every existing test passes unmodified | ✅ | `cargo test --lib` full suite green; no existing assertions edited |
| New per-site tier-precedence tests (project overrides legacy, local overrides both, null clears) | ✅ | See Test Plan breakdown above |
| Regression test for the two zero-is-meaningful keys | ✅ | `watch_registry.rs` and `sweep_registry.rs::read_startup_race_config`, both confirming `0` still disables |
| Every new test sets `LOOM_CONFIG_DEFAULTS_FILE=""` and uses keyed `#[serial(loom_config_env)]` | ✅ | Verified via `git grep '#\[serial('` — zero unkeyed `#[serial]` added by this PR |
| PR body records the logging decision and confirms `read_autonomous_model`'s silence change is intentional | ✅ | See "Two required decisions" section above |
| `cargo clippy --all-targets -- -D warnings` clean | ✅ | Ran, zero warnings |

## Deviations from plan

None. This PR builds on a prior in-progress worktree (apparently left mid-run by a previous Builder session before it could commit) — I reviewed the full diff against the issue's acceptance criteria, fast-forward-merged the worktree onto current `origin/main` (clean, docs-only delta, no conflicts), fixed a `cargo fmt` violation the draft introduced, and verified full test/clippy/check results before pushing. No functional changes to the draft were needed.

Closes #4058